### PR TITLE
feat(vscode): sidebar UX redesign — Working Memory + Committed Memories

### DIFF
--- a/cli/src/core/Regenerator.test.ts
+++ b/cli/src/core/Regenerator.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CommitSummary, LlmConfig, StoredTranscript } from "../Types.js";
 import * as GitOps from "./GitOps.js";
-import { regenerateSummary } from "./Regenerator.js";
+import { regenerateSummary, summarizeCommit } from "./Regenerator.js";
 import * as Summarizer from "./Summarizer.js";
 import * as SummaryStore from "./SummaryStore.js";
 import * as TranscriptReader from "./TranscriptReader.js";
@@ -16,6 +16,7 @@ vi.mock("./Summarizer.js", () => ({ generateSummary: vi.fn() }));
 vi.mock("./SummaryStore.js", async () => {
 	const actual = await vi.importActual<typeof import("./SummaryStore.js")>("./SummaryStore.js");
 	return {
+		getSummary: vi.fn(),
 		readTranscriptsForCommits: vi.fn(),
 		readReferenceFromBranch: vi.fn(),
 		readPlanFromBranch: vi.fn(),
@@ -26,7 +27,7 @@ vi.mock("./SummaryStore.js", async () => {
 		normalizeToV4: actual.normalizeToV4,
 	};
 });
-vi.mock("./GitOps.js", () => ({ getDiffContent: vi.fn() }));
+vi.mock("./GitOps.js", () => ({ getDiffContent: vi.fn(), getCommitInfo: vi.fn(), getCurrentBranch: vi.fn() }));
 vi.mock("./TranscriptReader.js", () => ({ buildMultiSessionContext: vi.fn() }));
 
 const config: LlmConfig = { apiKey: "k", model: "haiku" } as LlmConfig;
@@ -1596,5 +1597,58 @@ describe("regenerateSummary", () => {
 			// Only one block, leading with `<linear-issues>`.
 			expect(params.referenceBlocks?.startsWith("<linear-issues>")).toBe(true);
 		});
+	});
+});
+
+describe("summarizeCommit", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(SummaryStore.readTranscriptsForCommits).mockResolvedValue(new Map());
+		vi.mocked(GitOps.getDiffContent).mockResolvedValue("DIFF");
+		vi.mocked(TranscriptReader.buildMultiSessionContext).mockReturnValue("CONV");
+		vi.mocked(SummaryStore.readReferenceFromBranch).mockResolvedValue(null);
+		vi.mocked(SummaryStore.readPlanFromBranch).mockResolvedValue(null);
+		vi.mocked(SummaryStore.readNoteFromBranch).mockResolvedValue(null);
+		vi.mocked(Summarizer.generateSummary).mockResolvedValue(successResult);
+	});
+
+	it("bootstraps a shell from git metadata when no summary exists, then runs the LLM", async () => {
+		vi.mocked(SummaryStore.getSummary).mockResolvedValue(null);
+		vi.mocked(GitOps.getCommitInfo).mockResolvedValue({
+			hash: "deadbeefcafef00d",
+			message: "Add widget",
+			author: "tester",
+			date: "2026-06-01T00:00:00Z",
+		});
+		vi.mocked(GitOps.getCurrentBranch).mockResolvedValue("feature/x");
+
+		const { updated } = await summarizeCommit("deadbeefcafef00d", "/repo", config);
+
+		// Shell carried git metadata straight into the generateSummary call.
+		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
+		expect(params.commitInfo).toEqual({
+			hash: "deadbeefcafef00d",
+			message: "Add widget",
+			author: "tester",
+			date: "2026-06-01T00:00:00Z",
+		});
+		// Result is a real summary with the freshly generated topics + branch.
+		expect(updated.commitHash).toBe("deadbeefcafef00d");
+		expect(updated.branch).toBe("feature/x");
+		expect(updated.topics).toEqual(successResult.topics);
+		expect(updated.summaryError).toBeUndefined();
+	});
+
+	it("delegates to the regenerate path (no git bootstrap) when a summary already exists", async () => {
+		vi.mocked(SummaryStore.getSummary).mockResolvedValue(baseSummary);
+
+		const { updated } = await summarizeCommit(baseSummary.commitHash, "/repo", config);
+
+		// Existing-summary branch never builds a shell from git.
+		expect(GitOps.getCommitInfo).not.toHaveBeenCalled();
+		expect(GitOps.getCurrentBranch).not.toHaveBeenCalled();
+		// Preserves identity + ticket while replacing topics — the regenerate contract.
+		expect(updated.commitHash).toBe(baseSummary.commitHash);
+		expect(updated.topics).toEqual(successResult.topics);
 	});
 });

--- a/cli/src/core/Regenerator.ts
+++ b/cli/src/core/Regenerator.ts
@@ -1,6 +1,6 @@
 import { createLogger } from "../Logger.js";
 import type { CommitSummary, LlmConfig, Reference, ReferenceCommitRef, SourceId } from "../Types.js";
-import { getDiffContent } from "./GitOps.js";
+import { getCommitInfo, getCurrentBranch, getDiffContent } from "./GitOps.js";
 import { escapeForAttr, escapeForText } from "./PromptXmlEscape.js";
 import { truncate } from "./references/ReferenceExtractor.js";
 import { readReferenceMarkdownFromString } from "./references/ReferenceStore.js";
@@ -8,6 +8,7 @@ import { ALL_ADAPTERS } from "./references/sources/index.js";
 import type { StorageProvider } from "./StorageProvider.js";
 import { generateSummary, type SummaryResult } from "./Summarizer.js";
 import {
+	getSummary,
 	normalizeToV4,
 	readNoteFromBranch,
 	readPlanFromBranch,
@@ -158,6 +159,49 @@ export async function regenerateSummary(
 	};
 
 	return { updated, result };
+}
+
+/**
+ * Generate a summary for a commit that has no usable summary yet, OR re-run an
+ * existing one — the two are the same operation. When a summary already exists
+ * (including a failure-marker placeholder) this delegates straight to
+ * `regenerateSummary`. When none exists, it bootstraps a minimal shell
+ * `CommitSummary` from git metadata (`getCommitInfo` + current branch) and feeds
+ * that through the same `regenerateSummary` path, so the from-scratch and re-run
+ * flows share one pipeline rather than duplicating the LLM call + assembly.
+ *
+ * A from-scratch shell carries no archived plans / notes / references (those are
+ * only attached to a summary at first-run commit time), so a never-summarized
+ * commit is summarized from its diff + any stored transcripts alone — the
+ * Summarizer infers topics from the diff when the conversation is empty.
+ *
+ * Returns the `RegenerateResult`; the caller persists via
+ * `storeSummary(result.updated, cwd, true)` exactly as the regenerate path does.
+ */
+export async function summarizeCommit(
+	commitHash: string,
+	cwd: string,
+	config: LlmConfig,
+	storage?: StorageProvider,
+): Promise<RegenerateResult> {
+	const existing = await getSummary(commitHash, cwd, storage);
+	if (existing) {
+		return regenerateSummary(existing, cwd, config, storage);
+	}
+
+	const info = await getCommitInfo(commitHash, cwd);
+	const shell: CommitSummary = {
+		version: 4,
+		commitHash: info.hash,
+		commitMessage: info.message,
+		commitAuthor: info.author,
+		commitDate: info.date,
+		branch: await getCurrentBranch(cwd),
+		generatedAt: new Date().toISOString(),
+		topics: [],
+		recap: "",
+	};
+	return regenerateSummary(shell, cwd, config, storage);
 }
 
 // ─── Prompt-block reconstruction from orphan-branch archives ────────────────

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -3,9 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ─── Hoisted mocks ─────────────────────────────────────────────────────────
 
-const { getWorkspaceRoot, resolveCLIPath } = vi.hoisted(() => ({
+const { getWorkspaceRoot, resolveCLIPath, loadGlobalConfig } = vi.hoisted(() => ({
 	getWorkspaceRoot: vi.fn(),
 	resolveCLIPath: vi.fn(),
+	loadGlobalConfig: vi.fn().mockResolvedValue({ apiKey: "test-key", model: "test-model" }),
 }));
 
 const {
@@ -268,6 +269,7 @@ const {
 			.mockResolvedValue({ entries: [], totalCount: 0 }),
 		invalidateEntriesCache: vi.fn(),
 		getCurrentBranch: vi.fn().mockResolvedValue("main"),
+		compileBranchRecall: vi.fn().mockResolvedValue("# Task Context: main\n\nrecall body"),
 		reloadStorage: vi.fn(),
 		reloadReadStorage: vi.fn(),
 		// Bridge wrappers added when storage threading replaced direct
@@ -295,6 +297,22 @@ const {
 		// that don't care about storage threading.
 		createStorageForRepo: vi.fn().mockResolvedValue(null),
 		createReadStorageForCurrentRepo: vi.fn().mockResolvedValue(null),
+		// No-summary "Generate memory" path: viewSummary/viewMemorySummary build a
+		// placeholder via getCommitInfo when getSummary is null, and the
+		// jollimemory.generateMemory command bootstraps via summarizeCommit +
+		// storeSummary. Defaults resolve so the placeholder-open + generate tests
+		// don't need per-test wiring.
+		getCommitInfo: vi.fn().mockResolvedValue({
+			hash: "abc1234567890",
+			message: "feat: add feature",
+			author: "Test User",
+			date: "2026-01-01T00:00:00Z",
+		}),
+		summarizeCommit: vi.fn().mockResolvedValue({
+			updated: { commitHash: "abc1234567890", recap: "generated" },
+			result: {},
+		}),
+		storeSummary: vi.fn().mockResolvedValue(undefined),
 		// Multi-source reference surface — used by the reference commands
 		// (resolveReferenceForCommand resolves a webview mapKey through
 		// listReferences, then routes to the open/ignore handlers). Default:
@@ -406,6 +424,8 @@ const {
 	visibilityCallbacks,
 	openExternal,
 	fsReadFile,
+	createTerminal,
+	getExtension,
 } = vi.hoisted(() => {
 	/** Stores callbacks keyed by tree view ID so tests can trigger checkbox events */
 	const checkboxCallbacks_ = new Map<
@@ -469,6 +489,14 @@ const {
 		// Defaults to rejection = file missing, matching the pre-mock behavior
 		// where the absent `fs` property made readWorkerPhase throw-and-catch.
 		fsReadFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
+		// Default: Claude Code IS installed (the common case). Not-installed
+		// tests override per-call with mockReturnValueOnce(undefined).
+		getExtension: vi.fn().mockReturnValue({ id: "anthropic.claude-code" }),
+		createTerminal: vi.fn(() => ({
+			sendText: vi.fn(),
+			show: vi.fn(),
+			dispose: vi.fn(),
+		})),
 	};
 });
 
@@ -542,6 +570,7 @@ vi.mock("vscode", () => ({
 		})),
 		registerFileDecorationProvider: vi.fn(() => ({ dispose: vi.fn() })),
 		registerUriHandler: vi.fn(() => ({ dispose: vi.fn() })),
+		createTerminal,
 		onDidChangeActiveTextEditor,
 		activeTextEditor: undefined,
 		// Pass-through Progress mock — runs the user's callback so commands that
@@ -573,6 +602,9 @@ vi.mock("vscode", () => ({
 	commands: {
 		executeCommand,
 		registerCommand,
+	},
+	extensions: {
+		getExtension,
 	},
 	env: {
 		clipboard: {
@@ -888,6 +920,7 @@ vi.mock("./util/StatusBarManager.js", () => ({
 vi.mock("./util/WorkspaceUtils.js", () => ({
 	getWorkspaceRoot,
 	resolveCLIPath,
+	loadGlobalConfig,
 }));
 
 vi.mock("./views/SidebarWebviewProvider.js", () => ({
@@ -2284,17 +2317,15 @@ describe("Extension", () => {
 					null,
 					null,
 					null,
+					false, // needsGeneration false — a real summary exists
 				);
 			});
 
-			it("silently returns when no summary is found (no toast, no panel)", async () => {
-				// Product decision: clicking a COMMITS row whose commit has no
-				// summary is a non-event — the row's `codicon-code` glyph (vs
-				// the tinted markdown glyph for memory rows) already conveys
-				// the absence visually, so a follow-up information toast on
-				// every click was redundant noise. The viewMemorySummary path
-				// (next describe) intentionally keeps its toast because hitting
-				// no-summary there indicates a real Memories↔bridge mismatch.
+			it("opens a placeholder panel (needsGeneration) when no summary exists — no toast, no dead-end", async () => {
+				// No-summary is no longer a dead-end: the panel opens on a
+				// git-metadata placeholder with needsGeneration=true so the user
+				// sees a "Generate memory" banner instead of nothing. Still no
+				// toast (the panel IS the feedback).
 				mockBridge.getSummary.mockResolvedValue(null);
 
 				const handler = getRegisteredCommand("jollimemory.viewSummary");
@@ -2303,14 +2334,24 @@ describe("Extension", () => {
 				});
 
 				expect(showInformationMessage).not.toHaveBeenCalled();
-				expect(MockSummaryWebviewPanel.show).not.toHaveBeenCalled();
+				expect(MockSummaryWebviewPanel.show).toHaveBeenCalledWith(
+					expect.objectContaining({ commitHash: "abc1234567890" }),
+					expect.anything(),
+					"/test/workspace",
+					mockBridge,
+					expect.any(String),
+					"commit",
+					null,
+					null,
+					null,
+					true, // needsGeneration
+				);
 			});
 
-			it("accepts a plain hash string instead of CommitItem", async () => {
+			it("accepts a plain hash string instead of CommitItem (placeholder path)", async () => {
 				// Pinned because the sidebar webview dispatches the command
 				// with a bare hash via `branch:openCommit`, not a CommitItem;
-				// regressing the string branch would break every commit-row
-				// click. The no-summary path is silent (see test above).
+				// regressing the string branch would break every commit-row click.
 				mockBridge.getSummary.mockResolvedValue(null);
 
 				const handler = getRegisteredCommand("jollimemory.viewSummary");
@@ -2318,7 +2359,18 @@ describe("Extension", () => {
 
 				expect(mockBridge.getSummary).toHaveBeenCalledWith("abc1234567890");
 				expect(showInformationMessage).not.toHaveBeenCalled();
-				expect(MockSummaryWebviewPanel.show).not.toHaveBeenCalled();
+				expect(MockSummaryWebviewPanel.show).toHaveBeenCalledWith(
+					expect.objectContaining({ commitHash: "abc1234567890" }),
+					expect.anything(),
+					"/test/workspace",
+					mockBridge,
+					expect.any(String),
+					"commit",
+					null,
+					null,
+					null,
+					true,
+				);
 			});
 		});
 
@@ -2497,7 +2549,10 @@ describe("Extension", () => {
 				);
 			});
 
-			it("shows info message when no summary is found in any discovered repo", async () => {
+			it("opens a placeholder panel (needsGeneration) when no summary is found in any repo", async () => {
+				// Not found anywhere → treat as a local commit with no memory yet
+				// and open the placeholder offering Generate, rather than the old
+				// "No summary found" toast dead-end.
 				mockBridge.getSummaryAnyRepoWithSource.mockResolvedValue({
 					summary: null,
 					sourceRepoName: null,
@@ -2506,8 +2561,60 @@ describe("Extension", () => {
 				const handler = getRegisteredCommand("jollimemory.viewMemorySummary");
 				await handler({ entry: { commitHash: "def4567890abc" } });
 
-				expect(showInformationMessage).toHaveBeenCalledWith(
-					"Jolli Memory: No summary found for commit def4567.",
+				expect(showInformationMessage).not.toHaveBeenCalled();
+				expect(MockSummaryWebviewPanel.show).toHaveBeenCalledWith(
+					expect.objectContaining({ commitHash: "def4567890abc" }),
+					expect.anything(),
+					"/test/workspace",
+					mockBridge,
+					expect.any(String),
+					"memory",
+					null,
+					null,
+					null,
+					true, // needsGeneration
+				);
+			});
+		});
+
+		describe("generateMemory command", () => {
+			it("bootstraps via summarizeCommit, persists, refreshes history, then opens the panel", async () => {
+				mockBridge.summarizeCommit.mockResolvedValue({
+					updated: { commitHash: "abc1234567890", recap: "generated" },
+					result: {},
+				});
+
+				const handler = getRegisteredCommand("jollimemory.generateMemory");
+				await handler("abc1234567890");
+
+				expect(mockBridge.summarizeCommit).toHaveBeenCalledWith(
+					"abc1234567890",
+					expect.objectContaining({ apiKey: "test-key" }),
+				);
+				expect(mockBridge.storeSummary).toHaveBeenCalledWith(
+					expect.objectContaining({ commitHash: "abc1234567890" }),
+					true,
+				);
+				expect(executeCommand).toHaveBeenCalledWith("jollimemory.refreshHistory");
+				expect(executeCommand).toHaveBeenCalledWith(
+					"jollimemory.viewSummary",
+					"abc1234567890",
+				);
+			});
+
+			it("resolves the hash from a CommitItem and surfaces failures as an error toast", async () => {
+				mockBridge.summarizeCommit.mockRejectedValueOnce(new Error("LLM down"));
+
+				const handler = getRegisteredCommand("jollimemory.generateMemory");
+				await handler({ commit: { hash: "def4567890abc" } });
+
+				expect(mockBridge.summarizeCommit).toHaveBeenCalledWith(
+					"def4567890abc",
+					expect.anything(),
+				);
+				expect(mockBridge.storeSummary).not.toHaveBeenCalled();
+				expect(showErrorMessage).toHaveBeenCalledWith(
+					expect.stringContaining("Could not generate memory"),
 				);
 			});
 		});
@@ -3408,6 +3515,134 @@ describe("Extension", () => {
 					"No summary found for this commit.",
 				);
 				expect(openExternal).not.toHaveBeenCalled();
+			});
+		});
+
+		// ── branch-level Recall / Create PR (sidebar action bar) ─────────────
+
+		describe("recallBranch command", () => {
+			it("opens Claude Code with the branch recall prompt", async () => {
+				mockBridge.compileBranchRecall.mockResolvedValue("# Task Context: main\n\nbody");
+
+				const handler = getRegisteredCommand("jollimemory.recallBranch");
+				await handler();
+
+				expect(mockBridge.getCurrentBranch).toHaveBeenCalled();
+				expect(mockBridge.compileBranchRecall).toHaveBeenCalledWith("main");
+				expect(openExternal).toHaveBeenCalled();
+			});
+
+			it("shows a friendly notice (no open) when the branch has no memories", async () => {
+				mockBridge.compileBranchRecall.mockResolvedValue("   ");
+
+				const handler = getRegisteredCommand("jollimemory.recallBranch");
+				await handler();
+
+				expect(openExternal).not.toHaveBeenCalled();
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					expect.stringContaining("No memories on this branch"),
+				);
+			});
+
+			it("surfaces a compile failure as an error toast", async () => {
+				mockBridge.compileBranchRecall.mockRejectedValueOnce(new Error("boom"));
+
+				const handler = getRegisteredCommand("jollimemory.recallBranch");
+				await handler();
+
+				expect(openExternal).not.toHaveBeenCalled();
+				expect(showErrorMessage).toHaveBeenCalledWith(
+					expect.stringContaining("Could not build recall context"),
+				);
+			});
+
+			it("copies the prompt (not a dead deep-link) when Claude Code is NOT installed", async () => {
+				getExtension.mockReturnValueOnce(undefined);
+				mockBridge.compileBranchRecall.mockResolvedValue("# Task Context: main\n\nbody");
+				showInformationMessage.mockResolvedValueOnce(undefined); // user dismisses
+
+				const handler = getRegisteredCommand("jollimemory.recallBranch");
+				await handler();
+
+				// Must NOT fire the claude-code deep link that nothing would handle.
+				expect(openExternal).not.toHaveBeenCalled();
+				expect(vscode.env.clipboard.writeText).toHaveBeenCalledWith(
+					expect.stringContaining("Task Context"),
+				);
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					expect.stringContaining("Claude Code isn't installed"),
+					"Install Claude Code",
+				);
+			});
+
+			it("opens the extension page when the user picks Install Claude Code", async () => {
+				getExtension.mockReturnValueOnce(undefined);
+				mockBridge.compileBranchRecall.mockResolvedValue("body text");
+				showInformationMessage.mockResolvedValueOnce("Install Claude Code");
+
+				const handler = getRegisteredCommand("jollimemory.recallBranch");
+				await handler();
+
+				// The only openExternal call is the install deep-link, not the recall one.
+				expect(openExternal).toHaveBeenCalledTimes(1);
+			});
+		});
+
+		describe("copyBranchRecall command", () => {
+			it("copies the branch recall prompt to the clipboard", async () => {
+				mockBridge.compileBranchRecall.mockResolvedValue("# Task Context: main\n\nbody");
+
+				const handler = getRegisteredCommand("jollimemory.copyBranchRecall");
+				await handler();
+
+				expect(vscode.env.clipboard.writeText).toHaveBeenCalledWith(
+					expect.stringContaining("Task Context"),
+				);
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					expect.stringContaining("Recall prompt copied"),
+				);
+			});
+
+			it("shows a notice when there is nothing to recall", async () => {
+				mockBridge.compileBranchRecall.mockResolvedValue("");
+
+				const handler = getRegisteredCommand("jollimemory.copyBranchRecall");
+				await handler();
+
+				expect(vscode.env.clipboard.writeText).not.toHaveBeenCalled();
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					expect.stringContaining("No memories on this branch"),
+				);
+			});
+		});
+
+		describe("createBranchPr command", () => {
+			it("opens the most-recent summarized memory's panel", async () => {
+				mockCommitsStore.getSnapshot.mockReturnValueOnce({
+					commits: [
+						{ hash: "nomemo", hasSummary: false },
+						{ hash: "withmemo", hasSummary: true },
+					],
+				});
+
+				const handler = getRegisteredCommand("jollimemory.createBranchPr");
+				await handler();
+
+				expect(executeCommand).toHaveBeenCalledWith(
+					"jollimemory.viewSummary",
+					"withmemo",
+				);
+			});
+
+			it("shows a notice when no memory exists on the branch yet", async () => {
+				mockCommitsStore.getSnapshot.mockReturnValueOnce({ commits: [] });
+
+				const handler = getRegisteredCommand("jollimemory.createBranchPr");
+				await handler();
+
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					expect.stringContaining("No memories on this branch yet"),
+				);
 			});
 		});
 
@@ -7433,6 +7668,65 @@ describe("Extension", () => {
 			// handleError logs via the shared `log.error`; the test just verifies
 			// the callback didn't throw and an error was logged.
 			expect(error).toHaveBeenCalled();
+		});
+	});
+
+	describe("continueConversation command", () => {
+		it("resumes a Claude session in a terminal", () => {
+			const ctx = makeContext();
+			activate(ctx);
+			createTerminal.mockClear();
+			const handler = commandMap.get("jollimemory.continueConversation");
+			expect(handler).toBeDefined();
+			handler?.("claude", "0fc65422-d25d-41a1-a4f9-b143ffb3addd");
+			expect(createTerminal).toHaveBeenCalledTimes(1);
+			const term = createTerminal.mock.results[0].value as {
+				sendText: ReturnType<typeof vi.fn>;
+				show: ReturnType<typeof vi.fn>;
+			};
+			expect(term.sendText).toHaveBeenCalledWith(
+				"claude --resume 0fc65422-d25d-41a1-a4f9-b143ffb3addd",
+			);
+			expect(term.show).toHaveBeenCalled();
+		});
+
+		it("shows an info message for non-Claude sources (no terminal)", () => {
+			const ctx = makeContext();
+			activate(ctx);
+			createTerminal.mockClear();
+			showInformationMessage.mockClear();
+			commandMap.get("jollimemory.continueConversation")?.(
+				"codex",
+				"0fc65422-d25d-41a1-a4f9-b143ffb3addd",
+			);
+			expect(createTerminal).not.toHaveBeenCalled();
+			expect(showInformationMessage).toHaveBeenCalledWith(
+				expect.stringContaining("Claude Code"),
+			);
+		});
+
+		it("rejects a sessionId with shell metacharacters (injection guard)", () => {
+			const ctx = makeContext();
+			activate(ctx);
+			createTerminal.mockClear();
+			showInformationMessage.mockClear();
+			// Would be a command-injection payload if it reached the shell.
+			commandMap.get("jollimemory.continueConversation")?.(
+				"claude",
+				"$(touch /tmp/pwned)",
+			);
+			expect(createTerminal).not.toHaveBeenCalled();
+			expect(showInformationMessage).toHaveBeenCalled();
+		});
+
+		it("guards an empty sessionId (no terminal, info message)", () => {
+			const ctx = makeContext();
+			activate(ctx);
+			createTerminal.mockClear();
+			showInformationMessage.mockClear();
+			commandMap.get("jollimemory.continueConversation")?.("claude", "");
+			expect(createTerminal).not.toHaveBeenCalled();
+			expect(showInformationMessage).toHaveBeenCalled();
 		});
 	});
 });

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -94,7 +94,7 @@ import { formatShortRelativeDate } from "./util/FormatUtils.js";
 import { isWorkerBusy } from "./util/LockUtils.js";
 import { initLogger, log } from "./util/Logger.js";
 import { StatusBarManager } from "./util/StatusBarManager.js";
-import { getWorkspaceRoot } from "./util/WorkspaceUtils.js";
+import { getWorkspaceRoot, loadGlobalConfig } from "./util/WorkspaceUtils.js";
 import { computeChangesBadge } from "./views/ChangesBadge.js";
 import { NoteEditorWebviewPanel } from "./views/NoteEditorWebviewPanel.js";
 import { SettingsWebviewPanel } from "./views/SettingsWebviewPanel.js";
@@ -207,6 +207,40 @@ function parseSummaryFrontmatter(
 	}
 	if (type !== "commit" || !commitHash) return null;
 	return { commitHash };
+}
+
+/**
+ * Builds a minimal placeholder summary for a commit that has no stored summary
+ * yet, so the detail panel can open in its "Generate memory" state instead of
+ * dead-ending. Pulls real commit metadata (message/author/date) for the title
+ * + header; falls back to the bare hash if the commit can't be read.
+ */
+async function buildPlaceholderSummary(
+	bridge: JolliMemoryBridge,
+	hash: string,
+): Promise<import("../../cli/src/Types.js").CommitSummary> {
+	let message = "";
+	let author = "";
+	let date = "";
+	try {
+		const info = await bridge.getCommitInfo(hash);
+		message = info.message;
+		author = info.author;
+		date = info.date;
+	} catch {
+		// Commit metadata unavailable (shallow clone / gone) — show the hash alone.
+	}
+	return {
+		version: 4,
+		commitHash: hash,
+		commitMessage: message,
+		commitAuthor: author,
+		commitDate: date,
+		branch: "",
+		generatedAt: new Date().toISOString(),
+		topics: [],
+		recap: "",
+	};
 }
 
 /**
@@ -828,6 +862,7 @@ export function activate(context: vscode.ExtensionContext): void {
 			currentRepoName: sidebarRepoName,
 		}),
 		extensionUri: context.extensionUri,
+		loadCommitMemoryDetail: (hash) => bridge.getCommitMemoryDetail(hash),
 		statusProvider: {
 			serialize: () => statusProvider.serialize(),
 			onDidChangeTreeData:
@@ -2539,7 +2574,6 @@ export function activate(context: vscode.ExtensionContext): void {
 			async (item: CommitItem | string) => {
 				const hash = typeof item === "string" ? item : item.commit.hash;
 				const summary = await bridge.getSummary(hash);
-				if (!summary) return;
 				// Local commits also read from the Memory Bank folder layer so
 				// the detail-panel data path is uniform with foreign-repo
 				// panels (and with the user-visible KB tree). Falls back to
@@ -2547,8 +2581,12 @@ export function activate(context: vscode.ExtensionContext): void {
 				// uses bridge-default reads.
 				const readStorageResult =
 					await bridge.createReadStorageForCurrentRepo();
+				// No stored summary → open a placeholder panel in its
+				// "Generate memory" state instead of silently doing nothing.
+				// This is a local commit (workspace orphan branch is writable),
+				// so generating from here is safe.
 				await SummaryWebviewPanel.show(
-					summary,
+					summary ?? (await buildPlaceholderSummary(bridge, hash)),
 					context.extensionUri,
 					workspaceRoot,
 					bridge,
@@ -2557,6 +2595,7 @@ export function activate(context: vscode.ExtensionContext): void {
 					null,
 					null,
 					readStorageResult?.storage ?? null,
+					!summary,
 				);
 			},
 		),
@@ -2569,7 +2608,6 @@ export function activate(context: vscode.ExtensionContext): void {
 			"jollimemory.viewMemorySummary",
 			async (item: MemoryItem | string) => {
 				const hash = typeof item === "string" ? item : item.entry.commitHash;
-				const shortHash = hash.substring(0, 7);
 				// Timeline view aggregates memories across every repo under the
 				// Memory Bank parent (see JolliMemoryBridge.listSummaryEntries),
 				// so a clicked row may belong to a non-current repo whose
@@ -2584,8 +2622,22 @@ export function activate(context: vscode.ExtensionContext): void {
 				const { summary, sourceRepoName, sourceRemoteUrl } =
 					await bridge.getSummaryAnyRepoWithSource(hash);
 				if (!summary) {
-					vscode.window.showInformationMessage(
-						`Jolli Memory: No summary found for commit ${shortHash}.`,
+					// Not found in any repo → treat as a local commit with no
+					// memory yet and open the placeholder panel offering to
+					// generate one, rather than dead-ending on a toast. (A
+					// genuinely foreign commit would have resolved above with a
+					// sourceRepoName, so reaching here means it's local.)
+					await SummaryWebviewPanel.show(
+						await buildPlaceholderSummary(bridge, hash),
+						context.extensionUri,
+						workspaceRoot,
+						bridge,
+						commitsStore.getMainBranch(),
+						"memory",
+						null,
+						null,
+						(await bridge.createReadStorageForCurrentRepo())?.storage ?? null,
+						true,
 					);
 					return;
 				}
@@ -2610,6 +2662,46 @@ export function activate(context: vscode.ExtensionContext): void {
 					sourceRemoteUrl,
 					readStorageResult?.storage ?? null,
 				);
+			},
+		),
+
+		// Generates a memory for a commit that has none yet — the one-click
+		// path from a "Generate memory" row affordance (sidebar) so the user
+		// doesn't have to open the panel first. Bootstraps from the commit hash
+		// via the Bridge, persists, refreshes the history list so the row flips
+		// to a real memory, then opens the panel on the result. Workspace-local
+		// only: generating writes the workspace orphan branch, so this command
+		// is never offered for foreign-repo rows.
+		vscode.commands.registerCommand(
+			"jollimemory.generateMemory",
+			async (item: CommitItem | MemoryItem | string) => {
+				const hash =
+					typeof item === "string"
+						? item
+						: "commit" in item
+							? item.commit.hash
+							: item.entry.commitHash;
+				const config = await loadGlobalConfig();
+				try {
+					await vscode.window.withProgress(
+						{
+							location: vscode.ProgressLocation.Notification,
+							title: "Generating memory…",
+							cancellable: false,
+						},
+						async () => {
+							const result = await bridge.summarizeCommit(hash, config);
+							await bridge.storeSummary(result.updated, true);
+						},
+					);
+				} catch (err) {
+					vscode.window.showErrorMessage(
+						`Jolli Memory: Could not generate memory — ${err instanceof Error ? err.message : String(err)}`,
+					);
+					return;
+				}
+				await vscode.commands.executeCommand("jollimemory.refreshHistory");
+				await vscode.commands.executeCommand("jollimemory.viewSummary", hash);
 			},
 		),
 
@@ -2970,6 +3062,131 @@ export function activate(context: vscode.ExtensionContext): void {
 					`vscode://anthropic.claude-code/open?prompt=${encoded}`,
 				);
 				await vscode.env.openExternal(uri);
+			},
+		),
+
+		// Branch-level Recall (sidebar action bar) — opens Claude Code with the
+		// WHOLE branch's context (every memory + open plans), the same prompt
+		// `jolli recall` emits. Distinct from the per-memory openInClaudeCode
+		// above; right-click on the button copies the prompt instead (handled in
+		// the webview). Empty branch → a friendly no-op notice.
+		vscode.commands.registerCommand("jollimemory.recallBranch", async () => {
+			const branch = await bridge.getCurrentBranch();
+			let prompt: string;
+			try {
+				prompt = await bridge.compileBranchRecall(branch);
+			} catch (err) {
+				vscode.window.showErrorMessage(
+					`Jolli Memory: Could not build recall context — ${err instanceof Error ? err.message : String(err)}`,
+				);
+				return;
+			}
+			if (!prompt || prompt.trim().length === 0) {
+				vscode.window.showInformationMessage(
+					"Jolli Memory: No memories on this branch to recall yet.",
+				);
+				return;
+			}
+			// Recall's deep link is handled by the Claude Code extension. If it
+			// isn't installed, openExternal would hand off a vscode:// URI that
+			// nothing can handle — a dead click for Codex/Cursor/other-tool users.
+			// Detect it and fall back to copying the prompt (the tool-neutral
+			// path), offering a one-click install.
+			if (!vscode.extensions.getExtension("anthropic.claude-code")) {
+				await vscode.env.clipboard.writeText(prompt);
+				const INSTALL = "Install Claude Code";
+				const choice = await vscode.window.showInformationMessage(
+					"Jolli Memory: Claude Code isn't installed — recall prompt copied to your clipboard. Paste it into your AI tool.",
+					INSTALL,
+				);
+				if (choice === INSTALL) {
+					await vscode.env.openExternal(
+						vscode.Uri.parse("vscode:extension/anthropic.claude-code"),
+					);
+				}
+				return;
+			}
+			const uri = vscode.Uri.parse(
+				`vscode://anthropic.claude-code/open?prompt=${encodeURIComponent(prompt)}`,
+			);
+			await vscode.env.openExternal(uri);
+		}),
+
+		// Copy the branch-level recall prompt to the clipboard — the right-click
+		// twin of recallBranch, for pasting into Codex / Cursor / any tool.
+		vscode.commands.registerCommand("jollimemory.copyBranchRecall", async () => {
+			const branch = await bridge.getCurrentBranch();
+			let prompt: string;
+			try {
+				prompt = await bridge.compileBranchRecall(branch);
+			} catch (err) {
+				vscode.window.showErrorMessage(
+					`Jolli Memory: Could not build recall context — ${err instanceof Error ? err.message : String(err)}`,
+				);
+				return;
+			}
+			if (!prompt || prompt.trim().length === 0) {
+				vscode.window.showInformationMessage(
+					"Jolli Memory: No memories on this branch to recall yet.",
+				);
+				return;
+			}
+			await vscode.env.clipboard.writeText(prompt);
+			vscode.window.showInformationMessage(
+				"Recall prompt copied — paste into Codex, Cursor, or any AI tool.",
+			);
+		}),
+
+		// Create PR (sidebar action bar) — v1 opens the most-recent memory's
+		// detail panel, where the existing branch-level Create PR action lives
+		// (the PR flow shows a review form inside that panel before `gh pr
+		// create`, so it can't run fully headless yet — true one-click standalone
+		// is a follow-up). No memory yet → friendly notice.
+		vscode.commands.registerCommand("jollimemory.createBranchPr", async () => {
+			const snap = commitsStore.getSnapshot();
+			const latest = (snap.commits || []).find((c) => c.hasSummary);
+			if (!latest) {
+				vscode.window.showInformationMessage(
+					"Jolli Memory: No memories on this branch yet — commit one before opening a PR.",
+				);
+				return;
+			}
+			await vscode.commands.executeCommand("jollimemory.viewSummary", latest.hash);
+		}),
+
+		// Continue (true resume) for a captured conversation — invoked from the
+		// last-conversation banner's Continue button. Only wired for Claude
+		// sessions: `claude --resume <sessionId>` reopens that exact session.
+		// Other sources have no resume mechanism, so the banner never shows
+		// Continue for them; the guard here is belt-and-suspenders.
+		vscode.commands.registerCommand(
+			"jollimemory.continueConversation",
+			(source: unknown, sessionId: unknown) => {
+				// `sendText` types into a real shell, so an unvalidated sessionId
+				// would be a command-injection sink (JSON.stringify does NOT
+				// neutralize $()/backticks). sessionId crosses the webview trust
+				// boundary (it originates from on-disk session metadata that an
+				// untrusted cloned repo could carry), so hard-restrict it to the
+				// UUID / hex-hash shape Claude session ids actually take —
+				// [0-9a-fA-F-] only — which makes shell metacharacters impossible.
+				if (
+					source !== "claude" ||
+					typeof sessionId !== "string" ||
+					!/^[0-9a-fA-F][0-9a-fA-F-]{7,63}$/.test(sessionId)
+				) {
+					vscode.window.showInformationMessage(
+						"Resume is only available for Claude Code sessions.",
+					);
+					return;
+				}
+				const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+				const terminal = vscode.window.createTerminal({
+					name: "Claude — resume",
+					cwd,
+				});
+				// Safe: sessionId is validated above to contain only [0-9a-fA-F-].
+				terminal.sendText(`claude --resume ${sessionId}`);
+				terminal.show();
 			},
 		),
 

--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -74,8 +74,9 @@ const {
 	};
 });
 
-const { loadGlobalConfig } = vi.hoisted(() => ({
+const { loadGlobalConfig, resolveEnabledSources } = vi.hoisted(() => ({
 	loadGlobalConfig: vi.fn(),
+	resolveEnabledSources: vi.fn(),
 }));
 
 const { generateCommitMessage, generateSquashMessage } = vi.hoisted(() => ({
@@ -257,6 +258,7 @@ vi.mock("../../cli/src/core/MetadataManager.js", () => ({
 
 vi.mock("./util/WorkspaceUtils.js", () => ({
 	loadGlobalConfig,
+	resolveEnabledSources,
 }));
 
 vi.mock("../../cli/src/core/Summarizer.js", () => ({
@@ -455,6 +457,19 @@ describe("JolliMemoryBridge", () => {
 			apiKey: "test-key",
 			model: "claude-3",
 		});
+		// Default: all transcript sources enabled (nothing filtered). Tests that
+		// exercise the enabled-source filter override this per-call.
+		resolveEnabledSources.mockReturnValue(
+			new Set([
+				"claude",
+				"codex",
+				"gemini",
+				"opencode",
+				"cursor",
+				"copilot",
+				"copilot-chat",
+			]),
+		);
 		// SessionTracker.loadConfig is read by StorageFactory.createStorage AND
 		// by listSummaryEntries (for the localFolder lookup). Default to an
 		// empty config so storageMode falls back to "dual-write" and there's no
@@ -3343,6 +3358,105 @@ describe("JolliMemoryBridge", () => {
 		});
 	});
 
+	describe("getCommitMemoryDetail()", () => {
+		it("returns empty groups when the commit has no summary", async () => {
+			getSummary.mockResolvedValue(null);
+			const bridge = makeBridge();
+
+			const detail = await bridge.getCommitMemoryDetail("abc");
+
+			expect(detail).toEqual({ conversations: [], context: [] });
+		});
+
+		it("groups plans/notes/references as context and transcript sessions as conversations", async () => {
+			getSummary.mockResolvedValue({
+				version: 5,
+				commitHash: "abc",
+				transcripts: ["t1"],
+				plans: [{ slug: "p", title: "Plan A" }],
+				notes: [{ id: "n", title: "Note A" }],
+				references: [{ archivedKey: "k", nativeId: "PROJ-1", title: "Ref A" }],
+			});
+			readTranscriptsForCommits.mockResolvedValue(
+				new Map([
+					[
+						"t1",
+						{
+							sessions: [
+								{ sessionId: "s1", source: "claude", entries: [{}, {}] },
+								// no source + empty entries → exercises the ?? fallbacks
+								{ sessionId: "s2", entries: [] },
+							],
+						},
+					],
+				]),
+			);
+			const bridge = makeBridge();
+
+			const detail = await bridge.getCommitMemoryDetail("abc");
+
+			expect(detail.context).toEqual([
+				{ kind: "plan", label: "Plan A" },
+				{ kind: "note", label: "Note A" },
+				{ kind: "reference", label: "Ref A" },
+			]);
+			expect(detail.conversations).toEqual([
+				{ source: "claude", messageCount: 2 },
+				// no source → defaults to "claude" (matches the panel), not "unknown"
+				{ source: "claude", messageCount: 0 },
+			]);
+		});
+
+		it("dedupes a session that appears across multiple commit transcripts", async () => {
+			getSummary.mockResolvedValue({
+				version: 5,
+				commitHash: "abc",
+				transcripts: ["t1", "t2"],
+			});
+			// Same claude session s1 stored in two commit transcripts — the panel
+			// counts it once (source:sessionId key), so the sidebar must too.
+			readTranscriptsForCommits.mockResolvedValue(
+				new Map([
+					["t1", { sessions: [{ sessionId: "s1", source: "claude", entries: [{}, {}, {}] }] }],
+					["t2", { sessions: [{ sessionId: "s1", source: "claude", entries: [{}, {}, {}] }] }],
+				]),
+			);
+			const bridge = makeBridge();
+
+			const detail = await bridge.getCommitMemoryDetail("abc");
+
+			expect(detail.conversations).toEqual([{ source: "claude", messageCount: 3 }]);
+		});
+
+		it("drops sessions whose source is disabled in config", async () => {
+			getSummary.mockResolvedValue({
+				version: 5,
+				commitHash: "abc",
+				transcripts: ["t1"],
+			});
+			resolveEnabledSources.mockReturnValueOnce(new Set(["claude"]));
+			readTranscriptsForCommits.mockResolvedValue(
+				new Map([
+					[
+						"t1",
+						{
+							sessions: [
+								{ sessionId: "s1", source: "claude", entries: [{}] },
+								{ sessionId: "s2", source: "codex", entries: [{}, {}] },
+							],
+						},
+					],
+				]),
+			);
+			const bridge = makeBridge();
+
+			const detail = await bridge.getCommitMemoryDetail("abc");
+
+			// codex disabled → only the claude session survives.
+			expect(detail.conversations).toEqual([{ source: "claude", messageCount: 1 }]);
+		});
+	});
+
 	describe("indexNeedsMigration()", () => {
 		it("forwards the Bridge's storage to SummaryStore.indexNeedsMigration", async () => {
 			indexNeedsMigration.mockResolvedValue(true);
@@ -3499,7 +3613,7 @@ describe("JolliMemoryBridge", () => {
 			// merge-base
 			mockExecFileSuccess("mergebase456\n");
 			// git log
-			const logEntry = `commitHash1\x00fix: test change\x00John Doe\x00john@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
+			const logEntry = `commitHash1\x00treeC1\x00fix: test change\x00John Doe\x00john@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
 			mockExecFileSuccess(logEntry);
 			// resolvePushBaseRef: rev-parse @{upstream}
 			mockExecFileSuccess("origin/feature/test\n");
@@ -3540,6 +3654,52 @@ describe("JolliMemoryBridge", () => {
 			expect(result.commits[0].deletions).toBe(3);
 			expect(result.commits[0].filesChanged).toBe(2);
 			expect(result.commits[0].isPushed).toBe(false);
+			expect(result.commits[0].hasSummary).toBe(true);
+		});
+
+		it("hasSummary is true when the summary is indexed under a different SHA but the tree hash matches (rebase/cherry-pick/amend)", async () => {
+			mockExecFileSuccess("feature/test\n");
+			mockExecFileSuccess("abc\n");
+			mockExecFileSuccess("headhash123\n");
+			mockExecFileSuccess("mergebase456\n");
+			// Commit "rebasedSha" is NOT in the index by hash, but its tree hash
+			// (sharedTree) matches the indexed entry — getSummary would resolve it
+			// via tree hash, so the row must not offer "Generate".
+			mockExecFileSuccess(
+				"rebasedSha\x00sharedTree\x00feat: rebased\x00User\x00user@example.com\x002025-03-15T10:00:00Z\x00\x00\n",
+			);
+			mockExecFileSuccess("origin/feature/test\n");
+			mockExecFileSuccess("def\n");
+			mockExecFileSuccess("\n");
+			getIndexEntryMap.mockResolvedValue(
+				new Map([
+					[
+						"originalSha",
+						{
+							commitHash: "originalSha",
+							parentCommitHash: null,
+							commitType: "commit",
+							commitMessage: "feat: rebased",
+							commitDate: "2025-03-15T10:00:00Z",
+							branch: "feature/test",
+							generatedAt: "2025-03-15T10:00:00Z",
+							topicCount: 1,
+							treeHash: "sharedTree",
+							diffStats: { filesChanged: 1, insertions: 1, deletions: 0 },
+						},
+					],
+				]),
+			);
+			getDiffStats.mockResolvedValueOnce({
+				filesChanged: 1,
+				insertions: 1,
+				deletions: 0,
+			});
+
+			const bridge = makeBridge();
+			const result = await bridge.listBranchCommits("main");
+
+			expect(result.commits[0].hash).toBe("rebasedSha");
 			expect(result.commits[0].hasSummary).toBe(true);
 		});
 
@@ -3590,7 +3750,7 @@ describe("JolliMemoryBridge", () => {
 			mockExecFileSuccess("mainhash\n");
 			mockExecFileSuccess("headhash\n");
 			mockExecFileSuccess("mergebase\n");
-			const logEntry = `commitHash1\x00feat: local fallback\x00User\x00user@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
+			const logEntry = `commitHash1\x00treeC1\x00feat: local fallback\x00User\x00user@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
 			mockExecFileSuccess(logEntry);
 			mockExecFileError("no upstream");
 			mockExecFileError("no origin branch");
@@ -3627,7 +3787,7 @@ describe("JolliMemoryBridge", () => {
 			// getCurrentUserName
 			mockExecFileSuccess("John Doe\n");
 			// git log (with --author filter)
-			const logEntry = `commitHash1\x00fix: merged change\x00John Doe\x00john@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
+			const logEntry = `commitHash1\x00treeC1\x00fix: merged change\x00John Doe\x00john@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
 			mockExecFileSuccess(logEntry);
 
 			getIndexEntryMap.mockResolvedValue(new Map());
@@ -3661,7 +3821,7 @@ describe("JolliMemoryBridge", () => {
 			// getCurrentUserName
 			mockExecFileSuccess("Jane Doe\n");
 			// git log
-			const logEntry = `commitHash2\x00feat: fallback\x00Jane Doe\x00jane@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
+			const logEntry = `commitHash2\x00treeC2\x00feat: fallback\x00Jane Doe\x00jane@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
 			mockExecFileSuccess(logEntry);
 
 			getIndexEntryMap.mockResolvedValue(new Map());
@@ -3688,7 +3848,7 @@ describe("JolliMemoryBridge", () => {
 			// merge-base
 			mockExecFileSuccess("mergebase456\n");
 			// git log
-			const logEntry = `commitHash1\x00fix: amend\x00John Doe\x00john@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
+			const logEntry = `commitHash1\x00treeC1\x00fix: amend\x00John Doe\x00john@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
 			mockExecFileSuccess(logEntry);
 			// resolvePushBaseRef: rev-parse @{upstream}
 			mockExecFileSuccess("origin/feature/test\n");
@@ -3772,7 +3932,7 @@ describe("JolliMemoryBridge", () => {
 			// merge-base
 			mockExecFileSuccess("mergebase456\n");
 			// git log — one commit
-			const logEntry = `commitHash1\x00fix: test\x00John\x00john@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
+			const logEntry = `commitHash1\x00treeC1\x00fix: test\x00John\x00john@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
 			mockExecFileSuccess(logEntry);
 			// resolvePushBaseRef: rev-parse @{upstream}
 			mockExecFileSuccess("origin/feature/test\n");
@@ -3824,7 +3984,7 @@ describe("JolliMemoryBridge", () => {
 			// merge-base
 			mockExecFileSuccess("mergebase\n");
 			// git log
-			const logEntry = `commitHash1\x00feat: test\x00User\x00user@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
+			const logEntry = `commitHash1\x00treeC1\x00feat: test\x00User\x00user@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
 			mockExecFileSuccess(logEntry);
 			// resolvePushBaseRef: rev-parse @{upstream} returns a ref
 			mockExecFileSuccess("origin/main\n");
@@ -3860,7 +4020,7 @@ describe("JolliMemoryBridge", () => {
 			// merge-base
 			mockExecFileSuccess("mergebase\n");
 			// git log
-			const logEntry = `commitHash1\x00feat: new\x00Test User\x00test@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
+			const logEntry = `commitHash1\x00treeC1\x00feat: new\x00Test User\x00test@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
 			mockExecFileSuccess(logEntry);
 			// resolvePushBaseRef: rev-parse @{upstream} — fails
 			mockExecFileError("no upstream");
@@ -4077,7 +4237,7 @@ describe("JolliMemoryBridge", () => {
 			// merge-base
 			mockExecFileSuccess("mergebase\n");
 			// git log — one commit
-			const logEntry = `commitHash1\x00feat: test\x00User\x00user@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
+			const logEntry = `commitHash1\x00treeC1\x00feat: test\x00User\x00user@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
 			mockExecFileSuccess(logEntry);
 			// resolvePushBaseRef: rev-parse @{upstream}
 			mockExecFileSuccess("origin/feature/test\n");
@@ -5301,7 +5461,7 @@ describe("JolliMemoryBridge", () => {
 			mockExecFileSuccess("abc\n"); // resolveHistoryBaseRef
 			mockExecFileSuccess("headhash123\n"); // getHEADHash
 			mockExecFileSuccess("mergebase456\n"); // merge-base
-			const logEntry = `commitHash1\x00fix: test change\x00John Doe\x00john@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
+			const logEntry = `commitHash1\x00treeC1\x00fix: test change\x00John Doe\x00john@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
 			mockExecFileSuccess(logEntry); // git log
 			mockExecFileSuccess("origin/feature/test\n"); // upstream rev-parse
 			mockExecFileSuccess("def\n"); // refExists upstream
@@ -5345,8 +5505,8 @@ describe("JolliMemoryBridge", () => {
 			// Two commits in log; only one is in the index, so the other
 			// becomes an unmatched candidate that triggers the scan.
 			const logEntry =
-				`matched\x00fix\x00A\x00a@x\x002025-03-15T10:00:00Z\x00\x00\n` +
-				`unmatched\x00wip\x00A\x00a@x\x002025-03-15T11:00:00Z\x00\x00\n`;
+				`matched\x00treeMatched\x00fix\x00A\x00a@x\x002025-03-15T10:00:00Z\x00\x00\n` +
+				`unmatched\x00treeUnmatched\x00wip\x00A\x00a@x\x002025-03-15T11:00:00Z\x00\x00\n`;
 			mockExecFileSuccess(logEntry);
 			mockExecFileSuccess("origin/feature/test\n");
 			mockExecFileSuccess("def\n");

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -112,7 +112,10 @@ import type {
 } from "./Types.js";
 import { mergeCommitMessages } from "./util/CommitMessageUtils.js";
 import { log } from "./util/Logger.js";
-import { loadGlobalConfig } from "./util/WorkspaceUtils.js";
+import {
+	loadGlobalConfig,
+	resolveEnabledSources,
+} from "./util/WorkspaceUtils.js";
 
 // ─── Git helpers ────────────────────────────────────────────────────────────
 
@@ -983,7 +986,9 @@ export class JolliMemoryBridge {
 		const logArgs = [
 			"log",
 			`${mergeBase}..HEAD`,
-			"--pretty=format:%H%x00%s%x00%an%x00%ae%x00%aI%x00%x00",
+			// %T (tree hash) rides along so hasSummary can match summaries indexed
+			// under a different SHA (rebase/cherry-pick/amend) without an extra git call.
+			"--pretty=format:%H%x00%T%x00%s%x00%an%x00%ae%x00%aI%x00%x00",
 		];
 		if (authorFilter) {
 			logArgs.push(`--author=${authorFilter}`);
@@ -1024,7 +1029,7 @@ export class JolliMemoryBridge {
 		// Parse all commit hashes first, then batch-read the index (one git show)
 		const parsedEntries = rawEntries
 			.map((entry) => entry.split("\0"))
-			.filter((parts) => parts.length >= 5);
+			.filter((parts) => parts.length >= 6);
 
 		const commitHashes = parsedEntries.map((parts) => parts[0]);
 		// readStorage drives the index lookup; writeStorage stays on the
@@ -1034,10 +1039,21 @@ export class JolliMemoryBridge {
 		const writeStorage = await this.getStorage();
 		const indexEntryMap = await getIndexEntryMap(this.cwd, readStorage);
 
+		// Tree-hash set for cross-SHA matching: a commit whose summary is indexed
+		// under a different SHA (rebase / cherry-pick / amend) still has a memory
+		// if its tree hash matches an index entry — mirroring getSummary's
+		// tree-hash fallback so the row's "Generate" CTA doesn't appear for
+		// memories that already exist. (The background scanTreeHashAliases below
+		// persists these as aliases; this resolves them immediately for display.)
+		const indexTreeHashes = new Set<string>();
+		for (const e of indexEntryMap.values()) {
+			if (e.treeHash) indexTreeHashes.add(e.treeHash);
+		}
+
 		const commits: Array<BranchCommit> = [];
 
 		for (const parts of parsedEntries) {
-			const [hash, message, author, authorEmail, isoDate] = parts;
+			const [hash, treeHash, message, author, authorEmail, isoDate] = parts;
 
 			const entry = indexEntryMap.get(hash);
 			const meta = await resolveCommitMeta(entry, hash, this.cwd);
@@ -1063,7 +1079,9 @@ export class JolliMemoryBridge {
 					: pushBaseRef
 						? !unpushedHashes.has(hash)
 						: false,
-				hasSummary: indexEntryMap.has(hash),
+				hasSummary:
+					indexEntryMap.has(hash) ||
+					(treeHash !== undefined && indexTreeHashes.has(treeHash)),
 				...(meta.commitType && { commitType: meta.commitType }),
 			});
 		}
@@ -2080,6 +2098,29 @@ export class JolliMemoryBridge {
 		return regenerateSummary(summary, this.cwd, config, storage);
 	}
 
+	/**
+	 * Generates a summary for a commit by hash, bootstrapping a shell from git
+	 * metadata when no summary exists yet (or re-running an existing one). Same
+	 * read-storage threading as `regenerateSummary`; the caller persists the
+	 * result via `storeSummary`.
+	 */
+	async summarizeCommit(
+		commitHash: string,
+		config: import("../../cli/src/Types.js").LlmConfig,
+	): Promise<import("../../cli/src/core/Regenerator.js").RegenerateResult> {
+		const storage = await this.getReadStorage();
+		const { summarizeCommit } = await import("../../cli/src/core/Regenerator.js");
+		return summarizeCommit(commitHash, this.cwd, config, storage);
+	}
+
+	/** Reads git commit metadata (hash/message/author/date) for a single commit. */
+	async getCommitInfo(
+		commitHash: string,
+	): Promise<import("../../cli/src/Types.js").CommitInfo> {
+		const { getCommitInfo } = await import("../../cli/src/core/GitOps.js");
+		return getCommitInfo(commitHash, this.cwd);
+	}
+
 	/** Writes plan files (orphan-branch + Memory Bank visible MD). */
 	async storePlans(
 		planFiles: ReadonlyArray<{ slug: string; content: string }>,
@@ -2155,6 +2196,81 @@ export class JolliMemoryBridge {
 	): Promise<Map<string, StoredTranscript>> {
 		const storage = await this.getStorage();
 		return readTranscriptsForCommits(commitHashes, this.cwd, storage);
+	}
+
+	/**
+	 * Lazy detail for a committed memory's inline sidebar expansion: the
+	 * conversations + context (plans / notes / references) attached to the
+	 * commit's summary. Fetched on-demand when a row is expanded (one read per
+	 * commit), NOT eagerly for every row on refresh — see SidebarScriptBuilder's
+	 * commit-detail round-trip. Mirrors the Working Memory card's grouping.
+	 *
+	 * Context comes straight off the summary; conversations require reading the
+	 * stored transcripts (same path the detail panel + Regenerator use). Returns
+	 * empty groups when the commit has no summary yet.
+	 */
+	async getCommitMemoryDetail(hash: string): Promise<{
+		conversations: Array<{ source: string; messageCount: number }>;
+		context: Array<{ kind: "plan" | "note" | "reference"; label: string }>;
+	}> {
+		const summary = await this.getSummary(hash);
+		if (!summary) return { conversations: [], context: [] };
+
+		const context: Array<{
+			kind: "plan" | "note" | "reference";
+			label: string;
+		}> = [
+			...(summary.plans ?? []).map((p) => ({ kind: "plan" as const, label: p.title })),
+			...(summary.notes ?? []).map((n) => ({ kind: "note" as const, label: n.title })),
+			...(summary.references ?? []).map((r) => ({
+				kind: "reference" as const,
+				label: r.title || r.nativeId || r.archivedKey,
+			})),
+		];
+
+		const { getTranscriptIds } = await import(
+			"../../cli/src/core/SummaryTree.js"
+		);
+		const transcriptMap = await this.readTranscriptsForCommits(
+			getTranscriptIds(summary),
+		);
+		// Mirror the Summary panel's transcript-stats logic
+		// (SummaryWebviewPanel.handleLoadTranscriptStats) so the sidebar's
+		// per-conversation list and the panel never disagree: dedupe sessions by
+		// source:sessionId (the same session can appear across multiple commit
+		// transcripts) and drop disabled sources. Source defaults to "claude" to
+		// match the panel.
+		const enabledSources = resolveEnabledSources(await loadGlobalConfig());
+		const seen = new Set<string>();
+		const conversations: Array<{ source: string; messageCount: number }> = [];
+		for (const stored of transcriptMap.values()) {
+			for (const session of stored.sessions) {
+				const source = session.source ?? "claude";
+				if (!enabledSources.has(source)) continue;
+				const key = `${source}:${session.sessionId}`;
+				if (seen.has(key)) continue;
+				seen.add(key);
+				conversations.push({
+					source,
+					messageCount: session.entries?.length ?? 0,
+				});
+			}
+		}
+		return { conversations, context };
+	}
+
+	/**
+	 * Branch-level recall prompt — the same context `jolli recall` emits: every
+	 * memory on the branch + open plans/notes, compiled and rendered to
+	 * markdown. Powers the sidebar's Recall button (open Claude Code with the
+	 * whole branch's context), distinct from the per-memory recall prompt.
+	 */
+	async compileBranchRecall(branch: string): Promise<string> {
+		const { compileTaskContext, renderContextMarkdown } = await import(
+			"../../cli/src/core/ContextCompiler.js"
+		);
+		const ctx = await compileTaskContext({ branch }, this.cwd);
+		return renderContextMarkdown(ctx);
 	}
 
 	/** Returns true if the index needs migration to v3 flat format. */

--- a/vscode/src/providers/HistoryTreeProvider.ts
+++ b/vscode/src/providers/HistoryTreeProvider.ts
@@ -222,6 +222,7 @@ export class HistoryTreeProvider
 			enriched = {
 				...base,
 				hasMemory: !!item.commit.hasSummary,
+				committedAt: item.commit.date,
 				hover: buildHover(item.commit),
 				isSelected: item.checkboxState === vscode.TreeItemCheckboxState.Checked,
 			};

--- a/vscode/src/services/PrCommentService.test.ts
+++ b/vscode/src/services/PrCommentService.test.ts
@@ -286,6 +286,22 @@ describe("PrCommentService", () => {
 			expect(noPrBlock).toContain("createPrBtn");
 			expect(noPrBlock).toContain("'Create PR'");
 		});
+
+		it("does not paint the 'Previously:' history strip under 'noPr' — merged/closed PRs surface only alongside a live PR ('ready')", () => {
+			// A branch with only merged/closed PRs flows into kind:noPr. Painting
+			// the history strip there made a stale merged PR read as "this
+			// memory's PR" on every memory committed to an already-merged branch.
+			// renderPrHistory must run with the real history ONLY in the 'ready'
+			// branch (anchored to a live open PR); the noPr branch clears it.
+			const js = buildPrMessageScript();
+			const noPrIdx = js.indexOf("s === 'noPr'");
+			const readyIdx = js.indexOf("s === 'ready'");
+			const noPrBlock = js.slice(noPrIdx, readyIdx);
+			const readyBlock = js.slice(readyIdx);
+			expect(noPrBlock).not.toContain("renderPrHistory(msg.history)");
+			expect(noPrBlock).toContain("renderPrHistory([])");
+			expect(readyBlock).toContain("renderPrHistory(msg.history)");
+		});
 	});
 
 	// ─── PR history webview rendering: defense-in-depth assertions ──────────

--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -1123,7 +1123,13 @@ export function buildPrMessageScript(): string {
             vscode.postMessage({ command: 'generateE2eTest' });
           });
         }
-        renderPrHistory(msg.history);
+        // When the branch has NO open PR, do not surface its merged/closed
+        // PRs: a stale merged PR painted as a "Previously:" strip read as
+        // "this memory's PR" on every memory committed to an already-merged
+        // branch. History stays only alongside a live open PR (the 'ready'
+        // branch below), which preserves the PR1-merged + PR2-open case the
+        // strip was built for.
+        renderPrHistory([]);
       } else if (s === 'ready') {
         var pr = msg.pr;
         setPrChip('is-ok', '#' + pr.number + ' open');

--- a/vscode/src/util/WorkspaceUtils.test.ts
+++ b/vscode/src/util/WorkspaceUtils.test.ts
@@ -34,6 +34,7 @@ import {
 	getWorkspaceRoot,
 	loadGlobalConfig,
 	resolveCLIPath,
+	resolveEnabledSources,
 } from "./WorkspaceUtils.js";
 
 describe("WorkspaceUtils", () => {
@@ -77,6 +78,39 @@ describe("WorkspaceUtils", () => {
 				"/home/user/.jolli/jollimemory",
 			);
 			expect(config.apiKey).toBe("global-key");
+		});
+	});
+
+	describe("resolveEnabledSources()", () => {
+		it("enables every source by default (opt-out semantics)", () => {
+			expect(resolveEnabledSources({})).toEqual(
+				new Set([
+					"claude",
+					"codex",
+					"gemini",
+					"opencode",
+					"cursor",
+					"copilot",
+					"copilot-chat",
+				]),
+			);
+		});
+
+		it("drops a source only when its flag is explicitly false", () => {
+			const result = resolveEnabledSources({
+				codexEnabled: false,
+				claudeEnabled: true,
+			});
+			expect(result.has("claude")).toBe(true);
+			expect(result.has("codex")).toBe(false);
+		});
+
+		it("gates both copilot tags behind the single copilotEnabled flag", () => {
+			const result = resolveEnabledSources({ copilotEnabled: false });
+			expect(result.has("copilot")).toBe(false);
+			expect(result.has("copilot-chat")).toBe(false);
+			// other sources unaffected
+			expect(result.has("claude")).toBe(true);
 		});
 	});
 });

--- a/vscode/src/util/WorkspaceUtils.ts
+++ b/vscode/src/util/WorkspaceUtils.ts
@@ -43,3 +43,25 @@ export function resolveCLIPath(extensionPath: string): string | null {
 export function loadGlobalConfig(): Promise<JolliMemoryConfig> {
 	return loadConfigFromDir(getGlobalConfigDir());
 }
+
+/**
+ * The transcript sources enabled in config, as a Set of source tags. Each
+ * `<source>Enabled` flag is opt-OUT (a missing/true flag = enabled); only an
+ * explicit `false` disables. Copilot's single flag gates both the CLI and Chat
+ * source tags (they ship together — see CLAUDE.md). Single source of truth for
+ * every "which conversations count" path (the Summary panel's transcript stats
+ * and the sidebar's committed-memory detail) so they never drift apart.
+ */
+export function resolveEnabledSources(config: JolliMemoryConfig): Set<string> {
+	const sources = new Set<string>();
+	if (config.claudeEnabled !== false) sources.add("claude");
+	if (config.codexEnabled !== false) sources.add("codex");
+	if (config.geminiEnabled !== false) sources.add("gemini");
+	if (config.openCodeEnabled !== false) sources.add("opencode");
+	if (config.cursorEnabled !== false) sources.add("cursor");
+	if (config.copilotEnabled !== false) {
+		sources.add("copilot");
+		sources.add("copilot-chat");
+	}
+	return sources;
+}

--- a/vscode/src/views/NextMemoryPreviewPanel.test.ts
+++ b/vscode/src/views/NextMemoryPreviewPanel.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface MockPanel {
+	webview: {
+		html: string;
+		onDidReceiveMessage: ReturnType<typeof vi.fn>;
+		cspSource: string;
+	};
+	onDidDispose: ReturnType<typeof vi.fn>;
+	reveal: ReturnType<typeof vi.fn>;
+	dispose: ReturnType<typeof vi.fn>;
+	disposed: boolean;
+	title: string;
+	__disposeCb?: () => void;
+}
+
+interface MockVsCode {
+	ViewColumn: { Active: number };
+	window: { createWebviewPanel: ReturnType<typeof vi.fn> };
+	commands: { executeCommand: ReturnType<typeof vi.fn> };
+	__panels: MockPanel[];
+	__exec: ReturnType<typeof vi.fn>;
+}
+
+vi.mock("vscode", () => {
+	const panels: MockPanel[] = [];
+	const createWebviewPanel = vi.fn((_type: string, title: string) => {
+		const p: MockPanel = {
+			webview: {
+				html: "",
+				onDidReceiveMessage: vi.fn(),
+				cspSource: "vscode-webview://test",
+			},
+			// Capture the dispose callback so dispose() clears the singleton,
+			// matching the real onDidDispose wiring.
+			onDidDispose: vi.fn((cb: () => void) => {
+				p.__disposeCb = cb;
+			}),
+			reveal: vi.fn(),
+			dispose: vi.fn(() => {
+				p.disposed = true;
+				p.__disposeCb?.();
+			}),
+			disposed: false,
+			title,
+		};
+		panels.push(p);
+		return p;
+	});
+	const executeCommand = vi.fn();
+	return {
+		ViewColumn: { Active: 1 },
+		window: { createWebviewPanel },
+		commands: { executeCommand },
+		__panels: panels,
+		__exec: executeCommand,
+	};
+});
+
+import * as vscode from "vscode";
+import { NextMemoryPreviewPanel, type PreviewExclude } from "./NextMemoryPreviewPanel.js";
+
+const mock = vscode as unknown as MockVsCode;
+
+function captureHandler(): (raw: unknown) => void {
+	const panel = mock.__panels[mock.__panels.length - 1];
+	const h = panel.webview.onDidReceiveMessage.mock.calls[0]?.[0] as
+		| ((raw: unknown) => void)
+		| undefined;
+	if (!h) throw new Error("no handler");
+	return h;
+}
+
+const populated = (onExclude = vi.fn()) => ({
+	files: [{ label: "Foo.ts", relPath: "src/Foo.ts" }],
+	conversations: [
+		{ title: "Redesign", source: "claude", sessionId: "s1" },
+		{ title: "Path fix", source: "codex", sessionId: "s2" },
+	],
+	context: [
+		{ label: "Plan A", contextValue: "plan", id: "plan-a" },
+		{ label: "Note B", contextValue: "note", id: "note-b" },
+		{ label: "JOLLI-1", contextValue: "reference", id: "linear:JOLLI-1" },
+	],
+	onExclude,
+});
+
+afterEach(() => {
+	// Dispose any open panel (clears the singleton) and reset captured panels.
+	for (const p of mock.__panels) {
+		if (!p.disposed) p.dispose();
+	}
+	mock.__panels.length = 0;
+	mock.__exec.mockReset();
+	vi.clearAllMocks();
+});
+
+describe("NextMemoryPreviewPanel", () => {
+	it("renders the detail-parity sections + editable rows", () => {
+		NextMemoryPreviewPanel.show(populated());
+		const html = mock.__panels[0].webview.html;
+		expect(mock.__panels[0].title).toBe("Preview Memory");
+		// Detail-panel parity sections.
+		expect(html).toContain("NOT COMMITTED");
+		expect(html).toContain("Pull Request");
+		expect(html).toContain(">Jolli<");
+		expect(html).toContain("Summary");
+		expect(html).toContain("E2E Test Guide");
+		expect(html).toContain("Private Transcripts");
+		expect(html).toContain("Commit Memory");
+		// Source label + context tag branches.
+		expect(html).toContain("Claude");
+		expect(html).toContain("Codex");
+		// Editable rows carry the toggle ids the host routes on.
+		expect(html).toContain('data-kind="file"');
+		expect(html).toContain('data-relpath="src/Foo.ts"');
+		expect(html).toContain('data-kind="conversation"');
+		expect(html).toContain('data-sessionid="s1"');
+		expect(html).toContain('data-kind="context"');
+		expect(html).toContain('data-contextvalue="reference"');
+	});
+
+	it("shows an empty state and disables Commit when nothing is selected", () => {
+		NextMemoryPreviewPanel.show({
+			files: [],
+			conversations: [],
+			context: [],
+			onExclude: vi.fn(),
+		});
+		const html = mock.__panels[0].webview.html;
+		expect(html).toContain("Nothing selected yet");
+		expect(html).toContain('id="commitBtn" disabled');
+	});
+
+	it("re-opening reveals + refreshes the existing panel (singleton)", () => {
+		NextMemoryPreviewPanel.show(populated());
+		NextMemoryPreviewPanel.show(populated());
+		expect(mock.__panels.length).toBe(1);
+		expect(mock.__panels[0].reveal).toHaveBeenCalled();
+	});
+
+	it("commit runs jollimemory.commitAI, stays open, and shows a confirmation", () => {
+		NextMemoryPreviewPanel.show(populated());
+		const h = captureHandler();
+		h({ type: "commit" });
+		expect(mock.__exec).toHaveBeenCalledWith("jollimemory.commitAI");
+		// Does NOT auto-close; flips to the committed confirmation.
+		expect(mock.__panels[0].disposed).toBe(false);
+		expect(mock.__panels[0].webview.html).toContain("Memory committed");
+		// Close from the confirmation disposes the panel.
+		h({ type: "close" });
+		expect(mock.__panels[0].disposed).toBe(true);
+	});
+
+	it("routes exclude messages to onExclude per kind, carrying selected", () => {
+		const onExclude = vi.fn<(e: PreviewExclude) => void>();
+		NextMemoryPreviewPanel.show(populated(onExclude));
+		const h = captureHandler();
+		h({ type: "exclude", kind: "file", relPath: "src/Foo.ts", selected: false });
+		h({ type: "exclude", kind: "conversation", source: "claude", sessionId: "s1", selected: true });
+		h({ type: "exclude", kind: "context", contextValue: "note", id: "note-b", selected: false });
+		expect(onExclude).toHaveBeenNthCalledWith(1, { kind: "file", relPath: "src/Foo.ts", selected: false });
+		expect(onExclude).toHaveBeenNthCalledWith(2, {
+			kind: "conversation",
+			source: "claude",
+			sessionId: "s1",
+			selected: true,
+		});
+		expect(onExclude).toHaveBeenNthCalledWith(3, {
+			kind: "context",
+			contextValue: "note",
+			id: "note-b",
+			selected: false,
+		});
+	});
+
+	it("ignores malformed / unknown messages", () => {
+		const onExclude = vi.fn();
+		NextMemoryPreviewPanel.show(populated(onExclude));
+		const h = captureHandler();
+		h(null);
+		h({ type: "nope" });
+		h({ type: "exclude", kind: "mystery" });
+		expect(onExclude).not.toHaveBeenCalled();
+		expect(mock.__exec).not.toHaveBeenCalled();
+	});
+});

--- a/vscode/src/views/NextMemoryPreviewPanel.ts
+++ b/vscode/src/views/NextMemoryPreviewPanel.ts
@@ -1,0 +1,316 @@
+/**
+ * NextMemoryPreviewPanel
+ *
+ * Editable pop-out previewing what the next Commit Memory will capture, at
+ * parity with the committed-memory detail panel (meta strip, ship bar, Summary,
+ * E2E, the three grouped sections, Private Transcripts) — but the sections that
+ * only exist after a commit (Summary text, PR, Jolli share, E2E guide) render as
+ * placeholders, and the Conversations / Context / Files rows are editable: an
+ * include checkbox per row routes through the SAME exclusion path the sidebar
+ * checkboxes use (the `onExclude` callback the provider wires to its apply*
+ * deps), so the sidebar's Working Memory card stays in sync. The Commit Memory
+ * button runs the existing jollimemory.commitAI command and closes the panel.
+ *
+ * Singleton: re-opening reveals/refreshes the existing panel with fresh data.
+ */
+
+import { randomBytes } from "node:crypto";
+import * as vscode from "vscode";
+
+export type PreviewExclude =
+	| { readonly kind: "file"; readonly relPath: string; readonly selected: boolean }
+	| { readonly kind: "conversation"; readonly source: string; readonly sessionId: string; readonly selected: boolean }
+	| { readonly kind: "context"; readonly contextValue: string; readonly id: string; readonly selected: boolean };
+
+export interface NextMemoryPreviewData {
+	readonly files: ReadonlyArray<{ readonly label: string; readonly relPath: string }>;
+	readonly conversations: ReadonlyArray<{
+		readonly title: string;
+		readonly source: string;
+		readonly sessionId: string;
+	}>;
+	readonly context: ReadonlyArray<{
+		readonly label: string;
+		readonly contextValue: string;
+		readonly id: string;
+	}>;
+	/** Toggle an item's inclusion — routed by the provider to its apply* deps. */
+	readonly onExclude: (e: PreviewExclude) => void;
+}
+
+function escapeHtml(s: string): string {
+	return s
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
+}
+
+/** Short source label for the conversation badge (mirrors the sidebar). */
+function sourceLabel(source: string): string {
+	switch (source) {
+		case "claude":
+			return "Claude";
+		case "codex":
+			return "Codex";
+		case "cursor":
+			return "Cursor";
+		case "gemini":
+			return "Gemini";
+		case "opencode":
+			return "OpenCode";
+		case "copilot":
+			return "Copilot";
+		case "copilot-chat":
+			return "Copilot Chat";
+		default:
+			return source || "AI";
+	}
+}
+
+/** Single-letter context tag (Plan / Note / reference Link). */
+function contextTag(contextValue: string): string {
+	if (contextValue === "note") return "N";
+	if (contextValue === "reference") return "L";
+	return "P";
+}
+
+export class NextMemoryPreviewPanel {
+	private static current: NextMemoryPreviewPanel | undefined;
+	private readonly panel: vscode.WebviewPanel;
+	private onExclude: (e: PreviewExclude) => void;
+
+	private constructor(data: NextMemoryPreviewData) {
+		this.onExclude = data.onExclude;
+		this.panel = vscode.window.createWebviewPanel(
+			"jollimemory.nextMemoryPreview",
+			"Preview Memory",
+			vscode.ViewColumn.Active,
+			{ enableScripts: true, retainContextWhenHidden: true },
+		);
+		this.panel.webview.html = NextMemoryPreviewPanel.buildHtml(this.panel.webview.cspSource, data);
+		this.panel.webview.onDidReceiveMessage((raw) => this.handleMessage(raw));
+		this.panel.onDidDispose(() => {
+			NextMemoryPreviewPanel.current = undefined;
+		});
+	}
+
+	static show(data: NextMemoryPreviewData): void {
+		if (NextMemoryPreviewPanel.current) {
+			NextMemoryPreviewPanel.current.onExclude = data.onExclude;
+			NextMemoryPreviewPanel.current.panel.webview.html = NextMemoryPreviewPanel.buildHtml(
+				NextMemoryPreviewPanel.current.panel.webview.cspSource,
+				data,
+			);
+			NextMemoryPreviewPanel.current.panel.reveal(vscode.ViewColumn.Active);
+			return;
+		}
+		NextMemoryPreviewPanel.current = new NextMemoryPreviewPanel(data);
+	}
+
+	/** Trust boundary: the webview posts {type:'exclude', ...} or {type:'commit'}. */
+	private handleMessage(raw: unknown): void {
+		if (!raw || typeof raw !== "object") return;
+		const m = raw as Record<string, unknown>;
+		if (m.type === "commit") {
+			void vscode.commands.executeCommand("jollimemory.commitAI");
+			// Don't auto-close — the summary is generated asynchronously by the
+			// queue worker, so flip to a confirmation state instead. (Auto-opening
+			// the generated memory once it's ready is future work.)
+			this.panel.webview.html = NextMemoryPreviewPanel.buildCommittedHtml(this.panel.webview.cspSource);
+			return;
+		}
+		if (m.type === "close") {
+			this.panel.dispose();
+			return;
+		}
+		if (m.type !== "exclude") return;
+		const str = (v: unknown): string => (typeof v === "string" ? v : "");
+		const selected = m.selected === true;
+		if (m.kind === "file") {
+			this.onExclude({ kind: "file", relPath: str(m.relPath), selected });
+		} else if (m.kind === "conversation") {
+			this.onExclude({ kind: "conversation", source: str(m.source), sessionId: str(m.sessionId), selected });
+		} else if (m.kind === "context") {
+			this.onExclude({ kind: "context", contextValue: str(m.contextValue), id: str(m.id), selected });
+		}
+	}
+
+	/** Post-commit confirmation — the panel stays open instead of auto-closing. */
+	private static buildCommittedHtml(cspSource: string): string {
+		const nonce = randomBytes(16).toString("hex");
+		const csp = `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'nonce-${nonce}'; script-src 'nonce-${nonce}';" />`;
+		return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  ${csp}
+  <title>Memory committed</title>
+  <style nonce="${nonce}">
+    body { font-family: var(--vscode-font-family); color: var(--vscode-foreground); padding: 40px 30px; max-width: 620px; }
+    .check { font-size: 30px; color: var(--vscode-testing-iconPassed, #89d185); }
+    h1 { font-size: 18px; font-weight: 650; margin: 12px 0 8px; }
+    p { color: var(--vscode-descriptionForeground); font-size: 13px; line-height: 1.6; margin: 0 0 18px; }
+    .btn { display: inline-flex; align-items: center; gap: 6px; padding: 9px 18px; border: none; border-radius: 7px; cursor: pointer; font-size: 12.5px; font-weight: 600; background: var(--vscode-button-background); color: var(--vscode-button-foreground); }
+    .btn:hover { background: var(--vscode-button-hoverBackground, var(--vscode-button-background)); }
+  </style>
+</head>
+<body>
+  <div class="check">✓</div>
+  <h1>Memory committed</h1>
+  <p>Your commit is in. The AI summary is being written in the background — once it's ready the memory appears under <strong>Committed Memories</strong> in the sidebar, where you can open it.</p>
+  <button class="btn" id="closeBtn">Close</button>
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    document.getElementById('closeBtn').addEventListener('click', function () { vscode.postMessage({ type: 'close' }); });
+  </script>
+</body>
+</html>`;
+	}
+
+	private static buildHtml(cspSource: string, data: NextMemoryPreviewData): string {
+		const nonce = randomBytes(16).toString("hex");
+		const fileCount = data.files.length;
+		const convCount = data.conversations.length;
+		const ctxCount = data.context.length;
+		const empty = fileCount === 0 && convCount === 0 && ctxCount === 0;
+
+		// data-* attributes carry the ids the host needs to route the exclusion.
+		const rowEl = (label: string, lead: string, tail: string, attrs: Record<string, string>): string => {
+			const dataAttrs = Object.entries(attrs)
+				.map(([k, v]) => `data-${k}="${escapeHtml(v)}"`)
+				.join(" ");
+			return `<label class="item"><input type="checkbox" class="inc" checked ${dataAttrs} />${lead}<span class="lbl">${escapeHtml(label) || "(untitled)"}</span><span class="excl-tag">excluded</span>${tail}</label>`;
+		};
+
+		const convRows = data.conversations
+			.map((c) =>
+				rowEl(c.title, `<span class="badge">${escapeHtml(sourceLabel(c.source))}</span>`, "", {
+					kind: "conversation",
+					source: c.source,
+					sessionid: c.sessionId,
+				}),
+			)
+			.join("");
+		const ctxRows = data.context
+			.map((c) =>
+				rowEl(c.label, `<span class="kbtag">${contextTag(c.contextValue)}</span>`, "", {
+					kind: "context",
+					contextvalue: c.contextValue,
+					id: c.id,
+				}),
+			)
+			.join("");
+		const fileRows = data.files
+			.map((f) => rowEl(f.label, "", "", { kind: "file", relpath: f.relPath }))
+			.join("");
+
+		const panel = (title: string, count: string, rows: string): string =>
+			!rows
+				? ""
+				: `<div class="panel"><div class="panel-header"><span class="panel-title">${title}</span><span class="count">${count}</span></div>${rows}</div>`;
+
+		const groups = empty
+			? `<div class="panel"><p class="zero">Nothing selected yet — check files, conversations or context in the sidebar.</p></div>`
+			: `${panel("Conversations", String(convCount), convRows)}${panel("Context", String(ctxCount), ctxRows)}${panel("Files", String(fileCount), fileRows)}`;
+
+		const csp = `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'nonce-${nonce}'; script-src 'nonce-${nonce}';" />`;
+		return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  ${csp}
+  <title>Preview Memory</title>
+  <style nonce="${nonce}">
+    :root { --bd: var(--vscode-widget-border, rgba(128,128,128,0.25)); --muted: var(--vscode-descriptionForeground); }
+    body { font-family: var(--vscode-font-family); color: var(--vscode-foreground); padding: 22px 30px 40px; max-width: 820px; }
+    h1 { font-size: 18px; font-weight: 650; margin: 0 0 8px; }
+    .meta { display: flex; flex-wrap: wrap; align-items: center; gap: 6px 9px; font-size: 11.5px; color: var(--muted); margin-bottom: 8px; }
+    .chip { display: inline-flex; align-items: center; gap: 5px; font-size: 9.5px; font-weight: 650; letter-spacing: 0.02em; padding: 2px 9px; border-radius: 11px; background: var(--vscode-toolbar-hoverBackground, rgba(128,128,128,0.15)); color: var(--muted); }
+    .chip .led { width: 7px; height: 7px; border-radius: 50%; background: var(--muted); }
+    .intro { color: var(--muted); font-size: 12.5px; line-height: 1.5; margin: 0 0 18px; }
+    .ship-bar { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 12px; margin-bottom: 18px; }
+    .ship-card { border: 1px solid var(--bd); border-radius: 11px; padding: 13px 15px; }
+    .ship-head { display: flex; align-items: center; gap: 8px; font-weight: 650; font-size: 12.5px; margin-bottom: 6px; }
+    .ship-head .chip { margin-left: auto; }
+    .ship-sub { font-size: 11.5px; color: var(--muted); line-height: 1.45; }
+    .panel { border: 1px solid var(--bd); border-radius: 12px; padding: 14px 16px; margin-bottom: 16px; }
+    .panel-header { display: flex; align-items: center; gap: 8px; padding-bottom: 8px; margin-bottom: 8px; border-bottom: 1px solid var(--bd); }
+    .panel-title { font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.09em; color: var(--muted); }
+    .panel-header .count { margin-left: auto; font-size: 11px; color: var(--muted); }
+    .recap { font-size: 12.5px; line-height: 1.55; color: var(--muted); }
+    .item { display: flex; align-items: center; gap: 8px; font-size: 13px; padding: 4px 0; cursor: pointer; }
+    .item input { accent-color: var(--vscode-focusBorder); flex-shrink: 0; }
+    .item .lbl { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .item.excluded .lbl { text-decoration: line-through; opacity: 0.55; }
+    .badge { font-size: 10px; border: 1px solid var(--muted); border-radius: 4px; padding: 0 6px; line-height: 16px; flex-shrink: 0; }
+    .kbtag { width: 15px; height: 15px; border-radius: 3px; display: inline-flex; align-items: center; justify-content: center; font-size: 9px; font-weight: 700; color: #fff; background: var(--vscode-charts-blue, #2f7adc); flex-shrink: 0; }
+    .excl-tag { font-size: 9px; font-weight: 700; letter-spacing: 0.05em; color: var(--muted); border: 1px solid var(--bd); border-radius: 4px; padding: 0 5px; flex-shrink: 0; }
+    .item:not(.excluded) .excl-tag { display: none; }
+    .drawer { border: 1px dashed var(--bd); border-radius: 10px; padding: 11px 14px; display: flex; align-items: center; gap: 9px; font-size: 12px; color: var(--muted); margin-bottom: 16px; }
+    .btn { display: inline-flex; align-items: center; justify-content: center; gap: 6px; padding: 9px 18px; border: none; border-radius: 7px; cursor: pointer; font-size: 12.5px; font-weight: 600; background: var(--vscode-button-background); color: var(--vscode-button-foreground); }
+    .btn:hover { background: var(--vscode-button-hoverBackground, var(--vscode-button-background)); }
+    .btn.block { width: 100%; }
+    .btn:disabled { opacity: 0.45; cursor: not-allowed; }
+    .note { color: var(--muted); font-size: 12px; margin-top: 10px; line-height: 1.5; }
+    .zero { color: var(--muted); margin: 0; }
+  </style>
+</head>
+<body>
+  <h1>Preview Memory</h1>
+  <div class="meta">
+    <span class="chip"><span class="led"></span>NOT COMMITTED</span>
+    <span>${fileCount} file${fileCount === 1 ? "" : "s"} · ${convCount} conversation${convCount === 1 ? "" : "s"} · ${ctxCount} context</span>
+  </div>
+  <p class="intro">This is what your next <strong>Commit Memory</strong> will capture — same shape as a committed memory, but editable. Uncheck anything you don't want in this memory.</p>
+
+  <div class="ship-bar">
+    <div class="ship-card">
+      <div class="ship-head"><span>⇧</span><span>Pull Request</span><span class="chip">AFTER COMMIT</span></div>
+      <div class="ship-sub">No PR yet — create one once this memory is committed.</div>
+    </div>
+    <div class="ship-card">
+      <div class="ship-head"><span>⇅</span><span>Jolli</span><span class="chip"><span class="led"></span>LOCAL</span></div>
+      <div class="ship-sub">Not shared. Share to your Jolli Space after commit.</div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="panel-header"><span class="panel-title">Summary</span><span class="count">generated at commit</span></div>
+    <div class="recap">The AI writes the recap and topic decisions from your staged diff and the attached conversations when you commit. This is a placeholder until then.</div>
+  </div>
+
+  <div class="panel">
+    <div class="panel-header"><span class="panel-title">E2E Test Guide</span><span class="count">after commit</span></div>
+    <div class="recap">Reviewer test scenarios are generated from the memory once it exists.</div>
+  </div>
+
+  ${groups}
+
+  <div class="drawer">🔒 Private Transcripts (${convCount}) — full logs of the attached conversations, stored in your repo, never in shared exports.</div>
+
+  <button class="btn block" id="commitBtn"${empty ? " disabled" : ""}>✦ Commit Memory</button>
+  <p class="note">Editable until commit: uncheck here to leave items out of this memory — the same include/exclude state the sidebar's Working Memory card uses.</p>
+
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    document.addEventListener('change', function (e) {
+      const cb = e.target;
+      if (!cb || !cb.classList || !cb.classList.contains('inc')) return;
+      const kind = cb.getAttribute('data-kind');
+      const msg = { type: 'exclude', kind: kind, selected: !!cb.checked };
+      if (kind === 'file') msg.relPath = cb.getAttribute('data-relpath');
+      else if (kind === 'conversation') { msg.source = cb.getAttribute('data-source'); msg.sessionId = cb.getAttribute('data-sessionid'); }
+      else if (kind === 'context') { msg.contextValue = cb.getAttribute('data-contextvalue'); msg.id = cb.getAttribute('data-id'); }
+      vscode.postMessage(msg);
+      const label = cb.closest('.item');
+      if (label) label.classList.toggle('excluded', !cb.checked);
+    });
+    const commitBtn = document.getElementById('commitBtn');
+    if (commitBtn) commitBtn.addEventListener('click', function () { vscode.postMessage({ type: 'commit' }); });
+  </script>
+</body>
+</html>`;
+	}
+}

--- a/vscode/src/views/SidebarCssBuilder.ts
+++ b/vscode/src/views/SidebarCssBuilder.ts
@@ -365,6 +365,17 @@ export function buildSidebarCss(): string {
   .iconbtn--sm .codicon {
     font-size: 12px;
   }
+  /* Passive "Generating…" indicator on a just-committed row whose summary is
+     still being produced asynchronously. Non-interactive (no button) — it
+     flips to a Generate action once the grace window passes. */
+  .mem-generating {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    opacity: 0.7;
+    color: var(--vscode-descriptionForeground, var(--vscode-foreground));
+  }
 
   .tab-content {
     flex: 1;
@@ -546,6 +557,29 @@ export function buildSidebarCss(): string {
   .tree-node[data-indent="6"] { padding-left: 128px; }
   .tree-node[data-indent="7"] { padding-left: 148px; }
   .tree-node[data-indent="8"] { padding-left: 168px; }
+  /* Committed-memory grouped expansion (Conversations / Context / Files) —
+     lazy-loaded on expand; mirrors the Working Memory card's grouping. */
+  .commit-detail-group {
+    font-size: 9px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--vscode-descriptionForeground); padding: 5px 10px 1px 28px;
+  }
+  .commit-detail-row {
+    display: flex; align-items: center; gap: 6px; padding: 2px 10px 2px 28px;
+    font-size: 12px; min-width: 0;
+  }
+  .commit-detail-row .cd-kind {
+    font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
+    color: var(--vscode-descriptionForeground); flex-shrink: 0;
+    border: 1px solid var(--jolli-border); border-radius: 4px; padding: 0 5px; line-height: 15px;
+  }
+  .commit-detail-row .cd-text {
+    min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    color: var(--vscode-foreground);
+  }
+  .commit-detail-loading {
+    padding: 4px 10px 4px 28px; font-size: 11px; font-style: italic;
+    color: var(--vscode-descriptionForeground);
+  }
   /* KB tab folder-mode rows carry data-kind="dir|file" (set by the
      folder renderer) — branch tab rows use data-context instead, so this
      selector cleanly scopes the spacing bump to folder mode. We match
@@ -738,13 +772,15 @@ export function buildSidebarCss(): string {
      specificity (0,4,0) beats the neutral fallback above (0,3,0); a bare
      '.transcript-source-X' rule (0,1,0) is silently overridden and the
      badge stays descriptionForeground-gray. */
-  .tree-node.conversation-row .badge.transcript-source-claude       { color: #a78bfa; border-color: #a78bfa; background: rgba(167,139,250,0.12); }
-  .tree-node.conversation-row .badge.transcript-source-cursor       { color: #2dd4bf; border-color: #2dd4bf; background: rgba(45,212,191,0.12); }
-  .tree-node.conversation-row .badge.transcript-source-codex        { color: #4ade80; border-color: #4ade80; background: rgba(74,222,128,0.12); }
-  .tree-node.conversation-row .badge.transcript-source-gemini       { color: #60a5fa; border-color: #60a5fa; background: rgba(96,165,250,0.12); }
-  .tree-node.conversation-row .badge.transcript-source-opencode     { color: #fb923c; border-color: #fb923c; background: rgba(251,146,60,0.12); }
-  .tree-node.conversation-row .badge.transcript-source-copilot      { color: #94a3b8; border-color: #94a3b8; background: rgba(148,163,184,0.12); }
-  .tree-node.conversation-row .badge.transcript-source-copilot-chat { color: #fbbf24; border-color: #fbbf24; background: rgba(251,191,36,0.12); }
+  /* Per-source badge colours — shared by the CONVERSATIONS rows and the
+     last-conversation banner so both read with the same brand vocabulary. */
+  .tree-node.conversation-row .badge.transcript-source-claude,       .last-convo .badge.transcript-source-claude       { color: #a78bfa; border-color: #a78bfa; background: rgba(167,139,250,0.12); }
+  .tree-node.conversation-row .badge.transcript-source-cursor,       .last-convo .badge.transcript-source-cursor       { color: #2dd4bf; border-color: #2dd4bf; background: rgba(45,212,191,0.12); }
+  .tree-node.conversation-row .badge.transcript-source-codex,        .last-convo .badge.transcript-source-codex        { color: #4ade80; border-color: #4ade80; background: rgba(74,222,128,0.12); }
+  .tree-node.conversation-row .badge.transcript-source-gemini,       .last-convo .badge.transcript-source-gemini       { color: #60a5fa; border-color: #60a5fa; background: rgba(96,165,250,0.12); }
+  .tree-node.conversation-row .badge.transcript-source-opencode,     .last-convo .badge.transcript-source-opencode     { color: #fb923c; border-color: #fb923c; background: rgba(251,146,60,0.12); }
+  .tree-node.conversation-row .badge.transcript-source-copilot,      .last-convo .badge.transcript-source-copilot      { color: #94a3b8; border-color: #94a3b8; background: rgba(148,163,184,0.12); }
+  .tree-node.conversation-row .badge.transcript-source-copilot-chat, .last-convo .badge.transcript-source-copilot-chat { color: #fbbf24; border-color: #fbbf24; background: rgba(251,191,36,0.12); }
 
   /* "Edited" marker — codicon-edit pencil glyph rendered inline after the
      row title. Intentionally a thin icon (no pill / border / fill) so it
@@ -1169,6 +1205,200 @@ export function buildSidebarCss(): string {
     content: "";
     flex: 1;
     border-top: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
+  }
+
+  /* ============================================================
+     SIDEBAR REDESIGN — Phase 1 primitives.
+     Brand accent is layered ON TOP of VS Code theme tokens:
+     accents only (CTA fill, links, chips, focus). Backgrounds and
+     text stay on --vscode-* so user themes are always respected.
+     Backgrounds/borders use editorWidget/widget tokens; high-contrast
+     themes pull borders from --vscode-contrastBorder.
+     ============================================================ */
+  body {
+    --jolli-accent: #6ba5f8;        /* borders, icons, LED dots (non-text, >=3:1) */
+    --jolli-accent-text: #6ba5f8;   /* TEXT-safe accent + CTA fill (AA on dark) */
+    --jolli-on-accent: #0b1f3a;     /* text on the accent CTA */
+    --jolli-surface: var(--vscode-editorWidget-background, rgba(128,128,128,0.06));
+    --jolli-surface-inner: var(--vscode-textBlockQuote-background, rgba(128,128,128,0.10));
+    --jolli-border: var(--vscode-widget-border, var(--vscode-editorWidget-border, rgba(128,128,128,0.25)));
+  }
+  body.vscode-light {
+    --jolli-accent: #3f85f5;
+    --jolli-accent-text: #2563eb;   /* #3f85f5 on white is 3.6:1 — fails AA for text/CTA */
+    --jolli-on-accent: #ffffff;
+  }
+  body.vscode-high-contrast, body.vscode-high-contrast-light {
+    --jolli-border: var(--vscode-contrastBorder, var(--jolli-border));
+  }
+
+  /* ── Last-conversation banner: always above Working Memory ── */
+  /* Borderless full-width section (uniform with Working Memory + Committed
+     Memories) — pinned above the scroll; no card box. */
+  .last-convo {
+    flex-shrink: 0;
+    display: flex; flex-direction: column;
+  }
+  .last-convo .lc-head { display: flex; align-items: center; gap: 6px; }
+  .last-convo .lc-title {
+    font-size: 12px; font-weight: 600; flex: 1; min-width: 0;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .last-convo .lc-sub { font-size: 10.5px; color: var(--vscode-descriptionForeground); margin-top: 2px; }
+  .last-convo .lc-actions { display: flex; gap: 6px; margin-top: 8px; }
+  /* Stacked conversations revealed by "Show more": a hairline separator + spacing
+     between each, so the latest stays visually primary. */
+  .last-convo .lc-item + .lc-item {
+    margin-top: 8px; padding-top: 8px;
+    border-top: 1px solid var(--jolli-border);
+  }
+  .last-convo .lc-more-toggle {
+    margin-top: 8px; padding: 2px 0; background: none; border: none; cursor: pointer;
+    font-size: 11px; color: var(--vscode-textLink-foreground);
+  }
+  .last-convo .lc-more-toggle:hover { text-decoration: underline; }
+  /* Two-button action bar (Recall / Create PR) pinned at the BOTTOM of the
+     sidebar, below the scrolling content. flex-shrink:0 keeps it fixed while
+     the list scrolls; border-top separates it from the content above. */
+  .action-bar-dock {
+    display: flex; gap: 6px; flex-shrink: 0;
+    padding: 8px 10px;
+    border-top: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.2));
+    background: var(--vscode-sideBar-background, var(--vscode-editor-background));
+  }
+  .action-bar-btn {
+    flex: 1; display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+    padding: 7px 10px; border-radius: 6px; cursor: pointer; font-size: 12px; font-weight: 600;
+    background: none; color: var(--vscode-foreground); border: 1px solid var(--jolli-border);
+  }
+  .action-bar-btn:hover {
+    background: var(--vscode-toolbar-hoverBackground, rgba(128,128,128,0.15));
+    border-color: var(--jolli-accent);
+  }
+  .action-bar-btn.primary {
+    background: var(--jolli-accent-text); color: var(--jolli-on-accent); border-color: transparent;
+  }
+  .action-bar-btn.primary:hover { filter: brightness(1.08); background: var(--jolli-accent-text); }
+  .action-bar-btn .codicon { font-size: 14px; }
+  /* Recall split button: main action + ▾ caret menu, joined as one control. */
+  .action-bar-split { flex: 1; display: flex; }
+  .action-bar-split .action-bar-btn { border-top-right-radius: 0; border-bottom-right-radius: 0; }
+  .action-bar-caret {
+    display: inline-flex; align-items: center; justify-content: center;
+    padding: 7px 8px; cursor: pointer; flex-shrink: 0;
+    background: var(--jolli-accent-text); color: var(--jolli-on-accent);
+    border: 1px solid transparent;
+    border-top-right-radius: 6px; border-bottom-right-radius: 6px;
+    /* Darken the caret segment so the split button reads as two parts — the
+       filled Recall action + a distinct ▾ dropdown — instead of one fused
+       button. A solid divider in the on-accent color reinforces the seam. */
+    border-left: 1px solid var(--jolli-on-accent);
+    filter: brightness(0.82);
+  }
+  .action-bar-caret:hover { filter: brightness(1); }
+  .action-bar-caret .codicon { font-size: 14px; }
+  .last-convo .lc-actions button {
+    flex: 1; font-size: 11px; padding: 4px 6px; cursor: pointer;
+    border: 1px solid var(--jolli-border); border-radius: 5px;
+    background: none; color: var(--vscode-foreground);
+  }
+  .last-convo .lc-actions button:hover {
+    background: var(--vscode-toolbar-hoverBackground, rgba(128,128,128,0.15));
+    border-color: var(--jolli-accent);
+  }
+  .last-convo .lc-actions button.primary {
+    background: var(--jolli-accent-text); color: var(--jolli-on-accent); border-color: transparent;
+  }
+
+  /* ── Working Memory card ── */
+  /* Working Memory is a borderless full-width section (uniform with Committed
+     Memories) — no card box; the .section-header bar + .section-body carry the
+     structure. */
+  .wm-card {
+    display: flex; flex-direction: column;
+  }
+  /* Card header — a section-header bar so it reads as a peer of the
+     "Committed Memories" section header below. Negative margins span the card's
+     padding so the bar reaches the card's inner edges; matches .section-header's
+     background / border / type treatment exactly. */
+  /* Working Memory + Conversations reuse the .collapsible-section .section-header
+     bar (twirl + uppercase title) so all three section headers — Conversations,
+     Working Memory, Committed Memories — are uniform. Inside their bordered
+     cards the bar spans the card padding (negative margins) and rounds its top
+     corners; the section-header's own top border is dropped so it doesn't
+     double the card border. */
+  /* The .section-header bar spans edge-to-edge (no card to inset it). The body
+     gets horizontal padding so its content (assembly / CTA / convo rows) insets
+     like the section rows in Committed Memories. */
+  .wm-card > .section-body,
+  .last-convo > .section-body {
+    display: flex; flex-direction: column; gap: 8px; padding: 8px 10px;
+  }
+  .wm-assembly { font-size: 12px; color: var(--vscode-foreground); line-height: 1.55; }
+  .wm-assembly b { color: var(--jolli-accent-text); }
+  .wm-assembly .wm-zero { color: var(--vscode-descriptionForeground); }
+  /* Clickable selection counts → open Review to edit what's attached. */
+  .wm-assembly .wm-pick { cursor: pointer; text-decoration: underline dotted; text-underline-offset: 2px; }
+  .wm-assembly .wm-pick:hover { color: var(--vscode-textLink-foreground); }
+  .wm-cta { display: flex; flex-direction: column; gap: 6px; }
+  .wm-cta .commit-memory-btn { width: 100%; justify-content: center; }
+  .wm-cta .wm-btn-secondary { width: 100%; justify-content: center; }
+  /* Neutralize the wrapper's legacy chrome (it was a right-aligned, padded
+     footer button elsewhere) so inside the card the commit button spans the
+     full card width — matching Preview, which is a direct full-width child. */
+  .wm-cta .commit-memory-action { margin: 0; padding: 0; display: block; }
+  .wm-card .worker-row { display: flex; align-items: center; gap: 6px; font-size: 11px; color: var(--vscode-descriptionForeground); }
+  .wm-card .worker-row .codicon { font-size: 13px; }
+  /* secondary (Review/Preview) buttons: bordered, transparent fill — matches the
+     last-conversation "Show" button's outlined highlight (border + accent on hover). */
+  .wm-btn-secondary {
+    width: 100%; justify-content: center; display: inline-flex; align-items: center; gap: 6px;
+    padding: 7px 12px; font-size: 12px; cursor: pointer; border-radius: 6px;
+    background: none;
+    color: var(--vscode-foreground);
+    border: 1px solid var(--jolli-border);
+  }
+  .wm-btn-secondary:hover {
+    background: var(--vscode-toolbar-hoverBackground, rgba(128,128,128,0.15));
+    border-color: var(--jolli-accent);
+  }
+  .wm-review {
+    display: flex; align-items: center; gap: 6px; width: 100%; text-align: left;
+    background: none; border: none; cursor: pointer; padding: 4px 0 2px;
+    color: var(--vscode-descriptionForeground); font-size: 11px;
+  }
+  .wm-review:hover { color: var(--vscode-textLink-foreground); }
+  .wm-review .twirl { font-size: 9px; transition: transform 0.12s; }
+  .wm-card.reviewing .wm-review .twirl { transform: rotate(90deg); }
+  /* Review body: the three sections render as ONE bounded block fused to the
+     card (tight grouping) rather than three standalone collapsible sections. */
+  .wm-review-body { display: none; margin-top: 6px; border: 1px solid var(--jolli-border); border-radius: 8px; overflow: hidden; }
+  .wm-card.reviewing .wm-review-body { display: block; }
+  .wm-review-body .collapsible-section { border: none; }
+  .wm-review-body .collapsible-section .section-header {
+    background: none; border: none; padding: 6px 10px 2px;
+    font-size: 9px; letter-spacing: 0.06em; text-transform: uppercase;
+    color: var(--vscode-descriptionForeground);
+  }
+  .wm-review-body .collapsible-section .section-header .twirl { display: none; }
+
+  /* Last-conversation banner badge. The base rule is the neutral fallback
+     (unknown source); the per-source rules above (.last-convo .badge.transcript-source-*)
+     win on specificity and tint the badge in the source's brand color, matching
+     the conversation rows. */
+  .last-convo .badge {
+    border: 1px solid var(--vscode-descriptionForeground); border-radius: 4px;
+    padding: 0 6px; font-size: 10px; line-height: 16px; flex-shrink: 0;
+  }
+
+  /* Visible keyboard focus for the redesigned interactive primitives */
+  .wm-review:focus-visible,
+  .last-convo button:focus-visible, .wm-btn-secondary:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder); outline-offset: 1px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .wm-review .twirl { transition: none; }
   }
   `;
 }

--- a/vscode/src/views/SidebarHtmlBuilder.ts
+++ b/vscode/src/views/SidebarHtmlBuilder.ts
@@ -168,6 +168,9 @@ export function buildSidebarHtml(
     </div>
     <div class="dropdown-menu hidden" id="breadcrumb-menu" role="menu"></div>
     <div class="tab-toolbar hidden" id="tab-toolbar"></div>
+    <!-- Last-conversation banner (Branch view only) — populated by the script,
+         shown above the scrolling content. Hidden on KB / Status overlays. -->
+    <div class="last-convo hidden" id="last-convo"></div>
     <div class="tab-content hidden" id="tab-content-kb"><p class="placeholder">Loading...</p></div>
     <div class="tab-content hidden" id="tab-content-branch"><p class="placeholder">Loading...</p></div>
     <div class="tab-content hidden" id="tab-content-status">
@@ -177,6 +180,10 @@ export function buildSidebarHtml(
       </div>
       <div class="status-entries" id="status-entries"><p class="placeholder">Loading...</p></div>
     </div>
+    <!-- Action bar (Branch view only) — pinned at the BOTTOM, below the
+         scrolling content. Populated by renderActionBar(); hidden on KB /
+         Status and in foreign-repo view. -->
+    <div class="action-bar-dock hidden" id="action-bar-dock"></div>
     <div class="context-menu hidden" id="context-menu"></div>
     <div class="hover-card hidden" id="memory-hover" role="tooltip"></div>
     <div class="text-tip hidden" id="text-tip" role="tooltip"></div>

--- a/vscode/src/views/SidebarMessages.ts
+++ b/vscode/src/views/SidebarMessages.ts
@@ -116,6 +116,13 @@ export interface SerializedTreeItem {
 	/** Commits panel only: whether this commit has an associated memory summary. */
 	readonly hasMemory?: boolean;
 	/**
+	 * Commits panel only: ISO 8601 commit date. Distinguishes a recently
+	 * committed memory still being generated asynchronously ("pending") from an
+	 * older commit whose summary never landed ("needs generation"), so the row
+	 * shows a passive "Generating…" indicator vs a Generate action.
+	 */
+	readonly committedAt?: string;
+	/**
 	 * Commits panel only: structured hover-card data, mirroring the Memories
 	 * panel's `MemoryItem.hover` so the webview can drive both rows through
 	 * the same `.hover-card` popover. Absent on file rows.
@@ -448,6 +455,15 @@ export type SidebarOutboundMsg =
 	| { readonly type: "branch:openCommit"; readonly hash: string }
 	| {
 			/**
+			 * Lazy-load a committed memory's attached conversations + context when
+			 * its sidebar row is expanded. Host replies with `commitDetailLoaded`.
+			 * One read per expand — never eager for every row (perf).
+			 */
+			readonly type: "branch:loadCommitDetail";
+			readonly hash: string;
+	  }
+	| {
+			/**
 			 * User clicked a row in the CONVERSATIONS section. Host opens a
 			 * dedicated ConversationDetailsPanel keyed by `sessionId`, reading
 			 * the transcript from `transcriptPath` using the source-specific
@@ -465,6 +481,28 @@ export type SidebarOutboundMsg =
 			 * tab title and the row label never drift.
 			 */
 			readonly title: string;
+	  }
+	| {
+			/**
+			 * Working Memory card "Preview" button — opens the editable pop-out
+			 * (NextMemoryPreviewPanel) for what the next Commit Memory will capture.
+			 * Each item carries the id the host needs to toggle its exclusion via
+			 * the same apply* path the sidebar checkboxes use (files key off the
+			 * RELATIVE path; context off id + contextValue; conversations off
+			 * source + sessionId).
+			 */
+			readonly type: "branch:previewNextMemory";
+			readonly files: ReadonlyArray<{ readonly label: string; readonly relPath: string }>;
+			readonly conversations: ReadonlyArray<{
+				readonly title: string;
+				readonly source: string;
+				readonly sessionId: string;
+			}>;
+			readonly context: ReadonlyArray<{
+				readonly label: string;
+				readonly contextValue: string;
+				readonly id: string;
+			}>;
 	  }
 	| {
 			/**
@@ -543,6 +581,23 @@ export type SidebarOutboundMsg =
 
 export type SidebarInboundMsg =
 	| { readonly type: "init"; readonly state: SidebarState }
+	| {
+			/**
+			 * Response to `branch:loadCommitDetail` — the conversations + context
+			 * attached to a committed memory, for its grouped inline expansion
+			 * (mirrors the Working Memory card's groups).
+			 */
+			readonly type: "commitDetailLoaded";
+			readonly hash: string;
+			readonly conversations: ReadonlyArray<{
+				readonly source: string;
+				readonly messageCount: number;
+			}>;
+			readonly context: ReadonlyArray<{
+				readonly kind: "plan" | "note" | "reference";
+				readonly label: string;
+			}>;
+	  }
 	| { readonly type: "kb:foldersData"; readonly tree: FolderNode }
 	| {
 			/**

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -18,6 +18,81 @@ describe("SidebarScriptBuilder", () => {
 		expect(js).toContain('[data-action="view-graph"]');
 	});
 
+	it("labels the Working Memory card as a uniform collapsible section + clickable selection counts", () => {
+		const js = buildSidebarScript();
+		// Header is the shared section-header bar (uppercased via CSS), and the
+		// card is a collapsible section keyed for the shared toggle handler.
+		expect(js).toContain("Working Memory");
+		expect(js).toContain("'wm-card collapsible-section'");
+		expect(js).toContain("'data-section': 'working-memory'");
+		// Selection counts are clickable and OPEN (not toggle) Review; the
+		// chevron reads as the edit path — addresses "hard to modify what goes in".
+		expect(js).toContain("wm-open-review");
+		expect(js).toContain("Review & adjust");
+	});
+
+	it("lazy commit-detail is reload-safe: reset on load + render-driven fetch", () => {
+		const js = buildSidebarScript();
+		// Persisted 'loading'/stale detail is dropped on load so a row never
+		// stays stuck across reloads.
+		expect(js).toContain("state.commitDetail = {}");
+		// Fetch is render-driven: an expanded row with no cached detail sets
+		// 'loading' synchronously (so repeat renders don't re-request) and
+		// requests it — covering both the click and a reload-restored expand.
+		expect(js).toContain("state.commitDetail[item.id] = 'loading'");
+		expect(js).toContain("type: 'branch:loadCommitDetail', hash: item.id");
+	});
+
+	it("selection counts deep-link to their Review sub-section (data-wm-target + scrollIntoView)", () => {
+		const js = buildSidebarScript();
+		// Each count names its target section and the handler scrolls to it,
+		// even when Review is already open (so it's not a no-op).
+		expect(js).toContain("'data-wm-target'");
+		expect(js).toContain(".wm-review-body .collapsible-section[data-section=");
+		expect(js).toContain("scrollIntoView");
+	});
+
+	it("Recall is a split button — main opens Claude Code, caret menu offers copy-for-other-tools", () => {
+		const js = buildSidebarScript();
+		expect(js).toContain("action-bar-split");
+		expect(js).toContain("'data-action': 'recall-menu'");
+		// The caret menu surfaces both paths so non-Claude users aren't stranded.
+		expect(js).toContain("Open in Claude Code");
+		expect(js).toContain("Copy prompt for other tools");
+		// The menu trigger MUST stop propagation — otherwise the click bubbles to
+		// the document-level "close menu on outside click" handler and hides the
+		// menu on the same click that opened it (the bug that made the caret
+		// appear to "do nothing"). Assert both within the recall-menu block.
+		const menuIdx = js.indexOf("a === 'recall-menu'");
+		expect(menuIdx).toBeGreaterThan(-1);
+		const menuBlock = js.slice(menuIdx, menuIdx + 600);
+		expect(menuBlock).toContain("showContextMenu");
+		expect(menuBlock).toContain("stopPropagation");
+	});
+
+	it("non-native click targets are keyboard-accessible (role=button + Enter/Space activation)", () => {
+		const js = buildSidebarScript();
+		// role + tabindex + aria-expanded on the clickable span / twirl / header.
+		expect(js).toContain("role: 'button'");
+		expect(js).toContain("tabindex: '0'");
+		expect(js).toContain("'aria-expanded'");
+		// keydown maps Enter/Space to a synthetic click for these classes.
+		expect(js).toContain("t.classList.contains('wm-pick')");
+		expect(js).toContain("t.classList.contains('commit-twirl')");
+		expect(js).toContain("t.classList.contains('section-header')");
+	});
+
+	it("emits the no-summary Generate affordance (recency-gated + command dispatch)", () => {
+		const js = buildSidebarScript();
+		// Inline + context-menu Generate both route to the one-click command.
+		expect(js).toContain("jollimemory.generateMemory");
+		// Recent commits show a passive 'Generating…' indicator; only stale
+		// (past the window) no-summary rows get the Generate button.
+		expect(js).toContain("GENERATING_WINDOW_MS");
+		expect(js).toContain("mem-generating");
+		expect(js).toContain("Generate memory");
+	});
+
 	it("output parses as valid JS — backtick / undeclared-symbol smoke test", () => {
 		// Regression for two bug classes that ship-tested but tests-passed:
 		//   1. Backtick trap: SidebarScriptBuilder warns about it in its
@@ -1036,7 +1111,12 @@ describe("SidebarScriptBuilder", () => {
 		it("checks .section-actions [data-action] before .section-header collapse", () => {
 			const js = buildSidebarScript();
 			const sectionActionIdx = js.indexOf(".section-actions [data-action]");
-			const sectionHeaderIdx = js.indexOf(".section-header");
+			// Match the collapse handler specifically (its data-section read), not
+			// the first ".section-header" anywhere — the Conversations banner's own
+			// collapse handler now references ".section-header" earlier in the file.
+			const sectionHeaderIdx = js.indexOf(
+				"header.parentElement.getAttribute('data-section')",
+			);
 			expect(sectionActionIdx).toBeGreaterThan(-1);
 			expect(sectionHeaderIdx).toBeGreaterThan(-1);
 			expect(sectionActionIdx).toBeLessThan(sectionHeaderIdx);
@@ -1431,28 +1511,36 @@ describe("SidebarScriptBuilder", () => {
 		// foreign-readonly mode because the whole Changes section is dropped
 		// above the predicate. Neither items.length nor `collapsed` may gate
 		// the push site.
-		it("pushes the button on the Changes section without gating on items.length or collapsed", () => {
+		it("renders Commit Memory unconditionally in the Working Memory card (not gated by items.length or collapsed)", () => {
 			const js = buildSidebarScript();
-			// Find the push site. Must match `s.id === 'changes'` but NOT
-			// include `!collapsed` (regression — collapsing Changes hid the
-			// group CTA) nor `s.items.length` (regression — empty Changes hid
-			// the discoverability affordance).
-			const renderSectionStart = js.indexOf("function renderSection");
-			expect(renderSectionStart).toBeGreaterThan(-1);
-			const renderSectionEnd = js.indexOf(
+			// Commit Memory now lives in the Working Memory card, which owns the
+			// cross-panel assembly (Conversations + Context + Changes) and the
+			// CTA together. It must be rendered unconditionally there — never
+			// gated on selection count or a collapsed section.
+			const wmStart = js.indexOf("function renderWorkingMemoryCard");
+			expect(wmStart).toBeGreaterThan(-1);
+			const wmEnd = js.indexOf(
 				"function ",
-				renderSectionStart + "function renderSection".length,
+				wmStart + "function renderWorkingMemoryCard".length,
 			);
-			const body = js.slice(renderSectionStart, renderSectionEnd);
-			expect(body).toMatch(
-				/if\s*\(\s*s\.id\s*===\s*'changes'\s*\)\s*\{\s*sectionKids\.push\(renderCommitMemoryButton\(\)\)/,
+			const wmBody = js.slice(wmStart, wmEnd);
+			expect(wmBody).toContain("renderCommitMemoryButton()");
+			expect(wmBody).not.toMatch(
+				/items\.length[\s\S]{0,80}renderCommitMemoryButton/,
 			);
-			// Defense-in-depth: neither old buggy predicate may reappear.
-			expect(body).not.toMatch(
-				/s\.items\.length\s*>\s*0[\s\S]{0,80}renderCommitMemoryButton/,
-			);
-			expect(body).not.toMatch(
+			expect(wmBody).not.toMatch(
 				/!collapsed[\s\S]{0,80}renderCommitMemoryButton/,
+			);
+			// Regression guard: the button must NOT be re-appended inside the
+			// Changes section (its old home) — that would double-render it.
+			const rsStart = js.indexOf("function renderSection");
+			const rsEnd = js.indexOf(
+				"function ",
+				rsStart + "function renderSection".length,
+			);
+			const rsBody = js.slice(rsStart, rsEnd);
+			expect(rsBody).not.toMatch(
+				/s\.id\s*===\s*'changes'[\s\S]{0,80}renderCommitMemoryButton/,
 			);
 		});
 
@@ -1538,7 +1626,28 @@ describe("SidebarScriptBuilder", () => {
 			);
 			const body = js.slice(renderBranchStart, renderBranchEnd);
 			expect(body).toMatch(/const foreign\s*=\s*isViewingForeign\(\)/);
-			expect(body).toMatch(/if\s*\(\s*!foreign\s*\)/);
+			// Foreign mode early-returns with only the Committed Memories list;
+			// the Working Memory card (Conversations + Context + Changes) is
+			// reached only on the non-foreign path below the guard.
+			expect(body).toMatch(/if\s*\(\s*foreign\s*\)/);
+		});
+
+		it("Committed Memories is NOT filtered to commitWithMemory — every branch commit shows (regression: async-summary commits were hidden)", () => {
+			const js = buildSidebarScript();
+			const renderBranchStart = js.indexOf("function renderBranch");
+			const renderBranchEnd = js.indexOf(
+				"function ",
+				renderBranchStart + "function renderBranch".length,
+			);
+			const body = js.slice(renderBranchStart, renderBranchEnd);
+			// The workspace-view commits section feeds straight from branchData.commits.
+			expect(body).toMatch(/items:\s*branchData\.commits/);
+			// And must NOT re-introduce the contextValue==='commitWithMemory' filter,
+			// which hid just-committed memories until their summary generated async.
+			// (Matches an actual .filter(...) call, not the explanatory comment.)
+			expect(body).not.toMatch(
+				/\.filter\([\s\S]*['"]commitWithMemory['"]/,
+			);
 		});
 	});
 

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -98,6 +98,17 @@ export function buildSidebarScript(): string {
     // commit collapsed; we mirror that default but persist user toggles
     // across reloads via vscode.setState.
     commitsExpanded: {},
+    // Lazy per-commit memory detail (hash → { conversations, context } or the
+    // string 'loading'). Reset on load (below) so neither a stuck 'loading'
+    // sentinel nor stale detail survives a reload; re-fetched render-driven
+    // (renderCommitRow requests it whenever an expanded row has no cached
+    // detail) so it's cheap and always fresh.
+    commitDetail: {},
+    // "Conversations" banner: latest shown by default; Show more reveals the
+    // next few recent sessions. Not persisted — the toggle deliberately skips
+    // persist(), so it starts collapsed each load (unlike the persisted keys
+    // above; don't add persist() to the toggle without revisiting this).
+    lcExpanded: false,
     scrollTops: {},
     // Live flag pushed by the host whenever the post-commit Worker is holding
     // the lock. Drives the "AI summary in progress…" indicator on the Branch
@@ -119,6 +130,10 @@ export function buildSidebarScript(): string {
   state.workerBusy = false;
   state.workerPhase = null;
   state.syncPhase = null;
+  // Drop any persisted lazy detail (incl. a 'loading' sentinel from an expand
+  // whose reply never landed before reload). Expanded rows re-request it
+  // render-driven, so this never leaves a row stuck — and avoids stale detail.
+  state.commitDetail = {};
   function persist() { vscode.setState(state); }
 
   // ---- DOM refs ----
@@ -189,6 +204,53 @@ export function buildSidebarScript(): string {
   // calls mountIn(statusEntries, ...) which replaceChildren()s its target;
   // mounting into the panel root would clobber the banner.
   const statusEntries = document.getElementById('status-entries');
+  // Branch-view chrome that lives OUTSIDE tab-content-branch (so it can sit
+  // above the scrolling list): the last-conversation banner. Populated by
+  // renderLastConvo(); hidden on KB/Status.
+  const lastConvoEl = document.getElementById('last-convo');
+  // Conversations banner collapse — it lives outside the scroll container, so
+  // the branch click delegate doesn't catch its section-header; wire it here.
+  if (lastConvoEl) {
+    lastConvoEl.addEventListener('click', function(e) {
+      if (!e.target.closest('.section-header')) return;
+      state.sectionsCollapsed['conversations-banner'] = !state.sectionsCollapsed['conversations-banner'];
+      persist();
+      renderLastConvo();
+    });
+  }
+  // Bottom-pinned action bar (Recall / Create PR), also outside the scroll.
+  // Populated by renderActionBar(); hidden on KB/Status + foreign view.
+  const actionBarDock = document.getElementById('action-bar-dock');
+  if (actionBarDock) {
+    actionBarDock.addEventListener('click', function(e) {
+      const btn = e.target.closest('[data-action]');
+      if (!btn) return;
+      const a = btn.getAttribute('data-action');
+      if (a === 'recall-branch') {
+        vscode.postMessage({ type: 'command', command: 'jollimemory.recallBranch' });
+      } else if (a === 'recall-menu') {
+        const r = btn.getBoundingClientRect();
+        showContextMenu(r.left, r.bottom + 2, [
+          { label: 'Open in Claude Code', command: 'jollimemory.recallBranch' },
+          { label: 'Copy prompt for other tools', command: 'jollimemory.copyBranchRecall' },
+        ]);
+        // Stop the click here: otherwise it bubbles to the document-level
+        // "close menu on outside click" handler, which would hide the menu we
+        // just opened on this very click (same pattern as the section-action
+        // menu triggers).
+        e.stopPropagation();
+      } else if (a === 'create-pr-branch') {
+        vscode.postMessage({ type: 'command', command: 'jollimemory.createBranchPr' });
+      }
+    });
+    // Right-click Recall → copy the prompt (twin of the click, which opens Claude Code).
+    actionBarDock.addEventListener('contextmenu', function(e) {
+      if (e.target.closest('[data-action="recall-branch"]')) {
+        e.preventDefault();
+        vscode.postMessage({ type: 'command', command: 'jollimemory.copyBranchRecall' });
+      }
+    });
+  }
 
   // ---- Plain-text tooltip ----
   // Replaces the native title= tooltip on status rows and toolbar buttons. The
@@ -284,6 +346,12 @@ export function buildSidebarScript(): string {
       elBtn.classList.toggle('active', elBtn.getAttribute('data-tab') === tab);
     });
     Object.keys(tabContents).forEach(function(t) { tabContents[t].classList.toggle('hidden', t !== tab); });
+    // Branch-only chrome: hide when leaving Branch. On Branch, renderBranch()
+    // → renderLastConvo() decides the banner's visibility from the data.
+    if (tab !== 'branch') {
+      if (lastConvoEl) lastConvoEl.classList.add('hidden');
+      if (actionBarDock) actionBarDock.classList.add('hidden');
+    }
     renderToolbar();
     const incoming = tabContents[tab];
     if (incoming) incoming.scrollTop = state.scrollTops[tab] || 0;
@@ -581,6 +649,25 @@ export function buildSidebarScript(): string {
     vscode.postMessage({ type: 'command', command: 'jollimemory.enableJolliMemory' });
   });
 
+  // Keyboard activation for the non-native interactive elements we mark with
+  // role="button" (clickable selection-count spans, commit-row <i> twirls,
+  // section-header divs). Native <button>s handle Enter/Space themselves; these
+  // don't, so map the key to a synthetic .click() that flows through the same
+  // delegated click handlers. Space is included (and its default scroll
+  // suppressed) to match native button semantics.
+  document.addEventListener('keydown', function(e) {
+    if (e.key !== 'Enter' && e.key !== ' ' && e.key !== 'Spacebar') return;
+    const t = e.target;
+    if (t && t.classList && (
+      t.classList.contains('wm-pick') ||
+      t.classList.contains('commit-twirl') ||
+      t.classList.contains('section-header')
+    )) {
+      e.preventDefault();
+      t.click();
+    }
+  });
+
   // Close context menu on outside click.
   document.addEventListener('click', function(e) {
     if (!ctxMenu.contains(e.target)) ctxMenu.classList.add('hidden');
@@ -604,6 +691,17 @@ export function buildSidebarScript(): string {
     // state-bearing entry path uniformly. Idempotent on already-hidden.
     loadingPanel.classList.add('hidden');
     switch (msg.type) {
+      case 'commitDetailLoaded':
+        // Lazy committed-memory detail arrived — cache it and re-render so the
+        // expanded row swaps "Loading…" for the grouped Conversations/Context.
+        state.commitDetail[msg.hash] = {
+          conversations: Array.isArray(msg.conversations) ? msg.conversations : [],
+          context: Array.isArray(msg.context) ? msg.context : [],
+        };
+        // Coalesced: a reload that restores several expanded rows fires a burst
+        // of these — collapse them into one re-render (see scheduleBranchRender).
+        scheduleBranchRender();
+        break;
       case 'init':
         if (typeof msg.state.authenticated === 'boolean') state.authenticated = msg.state.authenticated;
         if (msg.state.degradedReason) {
@@ -2514,60 +2612,304 @@ export function buildSidebarScript(): string {
     return !!state.sectionsCollapsed[section];
   }
 
+  // Review-expander state for the Working Memory card. Client-side only —
+  // resets on reload. (Preview opens a separate pop-out panel, no card state.)
+  let wmReviewing = false;
+
+  // Coalesce branch re-renders: renderBranch() rebuilds the whole view, so a
+  // burst of async replies (e.g. a reload restoring K expanded commit rows
+  // fires K commitDetailLoaded messages) would otherwise trigger K full
+  // rebuilds for one settled state. Collapse them into a single render on the
+  // next animation frame.
+  let branchRenderQueued = false;
+  function scheduleBranchRender() {
+    if (branchRenderQueued) return;
+    branchRenderQueued = true;
+    requestAnimationFrame(function() {
+      branchRenderQueued = false;
+      renderBranch();
+    });
+  }
+
   function renderBranch() {
     hideTextTip();
+    renderLastConvo();
+    renderActionBar();
     const container = tabContents.branch;
-    // Plans & Notes and Changes are workspace-local — they have no meaningful
-    // representation for a foreign repo/branch selection. Drop them entirely
-    // in foreign-readonly mode so the panel reduces to the Memories list.
     const foreign = isViewingForeign();
-    const sections = [];
-    if (!foreign) {
-      // failedSources is the list of TranscriptSource keys whose discoverer
-      // failed (threw or returned r.error) during the most recent aggregator
-      // pass. When non-empty, the section renders a small banner above the
-      // rows so the user understands "list incomplete", not "list truly empty".
-      const failedSources = branchData.conversationsFailedSources || [];
-      const conversationsWarning = failedSources.length > 0
-        ? 'Some sources unavailable (' + failedSources.join(', ') + '). List may be incomplete.'
-        : null;
-      sections.push({ id: 'conversations', title: 'CONVERSATIONS', items: branchData.conversations, emptyText: 'No active AI conversations in the last 2 days.', warning: conversationsWarning });
-      sections.push({ id: 'plans', title: 'Plans & Notes', items: branchData.plans, emptyText: STRINGS.plansEmpty || 'No plans or notes yet.' });
-      sections.push({ id: 'changes', title: 'Changes', items: branchData.changes, emptyText: STRINGS.changesEmpty || 'No changes.' });
-    }
-    // Section id stays 'commits' (back-compat: section-toggle state and CSS
-    // selectors key off it), but the user-facing title is now "Memories"
-    // because every selected row maps to — or will become — a Jolli memory.
-    //
-    // Data source switches with the breadcrumb selection:
-    //  - workspace view → branchData.commits (rich BranchCommit shape pushed
-    //    by host via branch:commitsData; supports checkboxes / squash / push).
-    //  - foreign view   → memoriesState.items filtered by selectedRepoName +
-    //    selectedBranchName, adapted to the display-item shape renderCommitRow
-    //    consumes. Host doesn't refetch commits on selection change (the bridge
-    //    only knows how to git-log workspace HEAD), so we re-derive locally
-    //    from the cross-repo summary index that's already loaded.
-    const commitsItems = foreign ? getForeignCommitItems() : branchData.commits;
-    // Foreign-mode banner — placed at the top of the Memories section body
-    // so the user sees an explicit in-panel signal that they are viewing
-    // another repo (the chrome-only foreign-readonly CSS class is silent on
-    // its own). Wording mirrors IntelliJ CommitsPanel.kt:722 so the two
-    // surfaces stay aligned. Uses sectionBanner (not warning) to keep the
-    // partial-data orange affordance free for the conversations failure case.
-    //
-    // The "(read-only)" suffix only renders when the repo itself is foreign;
-    // browsing another branch in the workspace repo drops the suffix because
-    // those branches are not actually read-only (the user could check them
-    // out). Both foreign-flavors get a "Switch back to current workspace"
-    // affordance so the user is never stranded after a breadcrumb pick.
     const repo = state.selectedRepoName || state.currentRepoName || '';
     const branch = state.selectedBranchName || state.branchName || '';
     const repoForeign = !!state.selectedRepoName && state.selectedRepoName !== state.currentRepoName;
-    const memoriesBanner = foreign && repo && branch
-      ? { text: 'Viewing memories from ' + repo + ' / ' + branch + (repoForeign ? ' (read-only)' : ''), showResetLink: true }
+
+    // Foreign repo/branch is read-only — there is nothing to commit, so the
+    // Working Memory card is dropped and the panel reduces to the Committed
+    // Memories list. Banner wording mirrors IntelliJ CommitsPanel.kt so the
+    // two surfaces stay aligned. "(read-only)" only when the repo itself is
+    // foreign (another branch in the workspace repo is checkout-able).
+    if (foreign) {
+      const memoriesBanner = repo && branch
+        ? { text: 'Viewing memories from ' + repo + ' / ' + branch + (repoForeign ? ' (read-only)' : ''), showResetLink: true }
+        : null;
+      mountIn(container, [renderSection({
+        id: 'commits', title: 'Committed Memories', items: getForeignCommitItems(),
+        emptyText: STRINGS.commitsEmpty || 'No memories yet.', sectionBanner: memoriesBanner,
+      })]);
+      return;
+    }
+
+    // Workspace view: Working Memory card (Conversations + Context + Changes
+    // behind the Review expander, with the live assembly sentence + Commit
+    // Memory) followed by the Committed Memories list.
+    const failedSources = branchData.conversationsFailedSources || [];
+    const conversationsWarning = failedSources.length > 0
+      ? 'Some sources unavailable (' + failedSources.join(', ') + '). List may be incomplete.'
       : null;
-    sections.push({ id: 'commits', title: 'Memories', items: commitsItems, emptyText: STRINGS.commitsEmpty || 'No memories yet.', sectionBanner: memoriesBanner });
-    mountIn(container, sections.map(renderSection));
+    const convSec = { id: 'conversations', title: 'CONVERSATIONS', items: branchData.conversations, emptyText: 'No active AI conversations in the last 2 days.', warning: conversationsWarning };
+    const ctxSec = { id: 'plans', title: 'Context', items: branchData.plans, emptyText: STRINGS.plansEmpty || 'No plans or notes yet.' };
+    const changeSec = { id: 'changes', title: 'Changes', items: branchData.changes, emptyText: STRINGS.changesEmpty || 'No changes.' };
+    // Section id stays 'commits' (back-compat: section-toggle state + CSS
+    // selectors key off it); user-facing title is "Committed Memories".
+    // Every item here is a real branch commit (sourced from the history
+    // provider) — memory-backed and code-only alike. We deliberately do NOT
+    // filter to contextValue==='commitWithMemory': summaries are generated
+    // asynchronously after commit, so filtering would hide a just-made commit
+    // until its summary lands (and code-only commits forever). Memory-backed
+    // rows still get the inline "View Memory" affordance via the per-row
+    // hasMem check. Uncommitted/in-progress work never appears here — it lives
+    // in the Working Memory card above.
+    const commitsSec = { id: 'commits', title: 'Committed Memories', items: branchData.commits || [], emptyText: STRINGS.commitsEmpty || 'No memories yet.' };
+
+    mountIn(container, [
+      renderWorkingMemoryCard(convSec, ctxSec, changeSec),
+      renderSection(commitsSec),
+    ]);
+  }
+
+  // Two-button action bar pinned at the BOTTOM of the sidebar (outside the
+  // scroll, like the last-conversation banner is pinned at the top). Recall
+  // opens Claude Code with the whole branch's context (jolli recall);
+  // right-click copies the prompt. Create PR opens the branch-level PR flow.
+  // Workspace view only — hidden on KB/Status and in foreign-repo view.
+  function renderActionBar() {
+    if (!actionBarDock) return;
+    if (state.activeTab !== 'branch' || isViewingForeign()) {
+      actionBarDock.replaceChildren();
+      actionBarDock.classList.add('hidden');
+      return;
+    }
+    // Split button: the main part opens Claude Code (the common case); the ▾
+    // caret opens a menu with the tool-neutral "copy prompt" path so non-Claude
+    // users (Codex, Cursor) aren't stranded by a click that silently assumes
+    // Claude Code. Both halves are real <button>s, so the whole control is
+    // keyboard-reachable. Right-click still copies, as a power-user shortcut.
+    const recallMain = attachTextTip(
+      el('button', { type: 'button', className: 'action-bar-btn primary', 'data-action': 'recall-branch' }, [
+        el('i', { className: 'codicon codicon-play' }),
+        el('span', { text: 'Recall' }),
+      ]),
+      'Recall this branch’s context — opens Claude Code if installed, otherwise copies the prompt (use ▾ to choose)',
+    );
+    const recallCaret = attachTextTip(
+      el('button', {
+        type: 'button', className: 'action-bar-caret', 'data-action': 'recall-menu',
+        'aria-label': 'Recall options',
+      }, [el('i', { className: 'codicon codicon-chevron-down' })]),
+      'More Recall options — copy the prompt for Codex, Cursor, or any tool',
+    );
+    const recallBtn = el('div', { className: 'action-bar-split' }, [recallMain, recallCaret]);
+    const prBtn = attachTextTip(
+      el('button', { type: 'button', className: 'action-bar-btn', 'data-action': 'create-pr-branch' }, [
+        el('i', { className: 'codicon codicon-git-pull-request' }),
+        el('span', { text: 'Create PR' }),
+      ]),
+      'Draft a pull request from this branch’s memories',
+    );
+    actionBarDock.replaceChildren(recallBtn, prBtn);
+    actionBarDock.classList.remove('hidden');
+  }
+
+  // Working Memory card: assembly sentence (live selection counts) + Commit
+  // Memory + a Review chevron that expands Conversations / Context / Changes.
+  // Those three reuse the existing renderSection, so every row behaviour —
+  // checkboxes, select-all, discard, add-menu — carries over unchanged.
+  function renderWorkingMemoryCard(convSec, ctxSec, changeSec) {
+    const convN = (branchData.conversations || []).filter(function(c) { return !!c.isSelected; }).length;
+    const ctxN = (branchData.plans || []).filter(function(c) { return !!c.isSelected; }).length;
+    const fileN = (branchData.changes || []).filter(function(c) { return !!c.isSelected; }).length;
+
+    // The selection counts are clickable: they open Review focused on the
+    // attached items, so changing what goes into the memory is one obvious tap
+    // from the sentence that states it — not buried behind the chevron alone.
+    // Each count carries the sub-section it names (data-wm-target) so the
+    // click opens Review AND scrolls to those exact items — a real deep-link,
+    // not just "open the whole panel".
+    const pick = (text, target) => el('span', { className: 'wm-pick', 'data-action': 'wm-open-review', 'data-wm-target': target, role: 'button', tabindex: '0', text: text });
+    const assembly = el('div', { className: 'wm-assembly' });
+    if (fileN === 0) {
+      assembly.appendChild(document.createTextNode('No files selected — '));
+      assembly.appendChild(pick('open Review', 'changes'));
+      assembly.appendChild(document.createTextNode(' to choose what to commit.'));
+    } else {
+      assembly.appendChild(document.createTextNode('Commit Memory will commit '));
+      assembly.appendChild(el('span', { className: 'wm-pick', 'data-action': 'wm-open-review', 'data-wm-target': 'changes', role: 'button', tabindex: '0' }, [
+        el('b', { text: String(fileN) }),
+        document.createTextNode(' file' + (fileN > 1 ? 's' : '')),
+      ]));
+      const attach = [];
+      if (convN > 0) attach.push(pick(convN + ' conversation' + (convN > 1 ? 's' : ''), 'conversations'));
+      if (ctxN > 0) attach.push(pick(ctxN + ' context item' + (ctxN > 1 ? 's' : ''), 'plans'));
+      if (attach.length > 0) {
+        assembly.appendChild(document.createTextNode(' and attach '));
+        attach.forEach(function(node, i) {
+          if (i > 0) assembly.appendChild(document.createTextNode(' + '));
+          assembly.appendChild(node);
+        });
+      }
+      assembly.appendChild(document.createTextNode('.'));
+    }
+
+    // CTA: Commit Memory (primary) + Preview, stacked full-width. Preview opens
+    // an editable pop-out (NextMemoryPreviewPanel) of the next memory — its
+    // include/exclude checkboxes route through the same apply* path as the card.
+    const previewBtn = el('button', {
+      type: 'button', className: 'wm-btn-secondary', 'data-action': 'wm-preview-open',
+    }, [el('span', { text: 'Preview Memory' })]);
+    const cta = el('div', { className: 'wm-cta' }, [renderCommitMemoryButton(), previewBtn]);
+
+    const reviewBtn = el('button', {
+      type: 'button', className: 'wm-review', 'data-action': 'wm-review-toggle',
+      'aria-expanded': String(wmReviewing),
+    }, [
+      el('span', { className: 'twirl', text: '▸' }),
+      el('span', { text: 'Review & adjust what’s attached' }),
+    ]);
+    const reviewBody = el('div', { className: 'wm-review-body' }, [
+      renderSection(convSec), renderSection(ctxSec), renderSection(changeSec),
+    ]);
+
+    // Header is the SAME .section-header bar (twirl + uppercase title) as the
+    // Committed Memories section, so all three section headers are uniform. The
+    // card is a .collapsible-section keyed by data-section='working-memory', so
+    // the existing section-toggle click handler + collapse CSS work unchanged.
+    const collapsed = isCollapsed('working-memory');
+    const header = el('div', { className: 'section-header', role: 'button', tabindex: '0', 'aria-expanded': String(!collapsed) }, [
+      el('span', { className: 'twirl', text: '▾' }),
+      el('span', { className: 'section-title', text: 'Working Memory' }),
+    ]);
+
+    const bodyKids = [assembly, cta];
+    // Background AI-summary indicator — shows while the queue worker is mid-run
+    // (state.workerBusy is pushed by the host worker:busy message).
+    if (state.workerBusy) {
+      bodyKids.push(el('div', { className: 'worker-row' }, [
+        el('i', { className: 'codicon codicon-loading codicon-modifier-spin' }),
+        el('span', { text: 'AI summary in progress…' }),
+      ]));
+    }
+    bodyKids.push(reviewBtn, reviewBody);
+
+    return el('div', {
+      className: 'wm-card collapsible-section' + (collapsed ? ' collapsed' : '') + (wmReviewing ? ' reviewing' : ''),
+      'data-section': 'working-memory',
+    }, [header, el('div', { className: 'section-body' }, bodyKids)]);
+  }
+
+  // Last-conversation banner (Branch view, workspace only): the most-recently
+  // updated AI session with "Show" (opens the conversation panel) and, for
+  // Claude sessions only, "Continue" (true resume via the claude CLI).
+  // Non-Claude sources have no resume mechanism, so they get Show only.
+  // Summarize-to-note is future work (no command exists yet).
+  // Builds one conversation block (head + sub + Show/Continue actions). Shared
+  // by the primary (latest) row and the expanded "Show more" rows.
+  function renderConvoItem(c, primary) {
+    const title = c.title || '(untitled)';
+    const ts = Date.parse(c.updatedAt);
+    const rel = Number.isFinite(ts) ? timeAgo(ts) : '';
+    const n = c.messageCount || 0;
+    const sub = n + ' message' + (n === 1 ? '' : 's') + (rel ? ' · ' + rel : '');
+    const actions = [];
+    // Show opens the transcript — only meaningful when there are messages.
+    if (c.messageCount && c.messageCount > 0) {
+      const showBtn = el('button', { type: 'button' }, [el('span', { text: 'Show' })]);
+      showBtn.addEventListener('click', function() {
+        vscode.postMessage({
+          type: 'branch:openConversation',
+          sessionId: c.sessionId,
+          source: c.source,
+          transcriptPath: c.transcriptPath,
+          title: title,
+        });
+      });
+      actions.push(showBtn);
+    }
+    // Continue (true resume) is Claude-only (claude --resume the session).
+    if (c.source === 'claude') {
+      const continueBtn = el('button', { type: 'button', className: 'primary' }, [el('span', { text: 'Continue' })]);
+      continueBtn.addEventListener('click', function() {
+        vscode.postMessage({
+          type: 'command',
+          command: 'jollimemory.continueConversation',
+          args: [c.source, c.sessionId],
+        });
+      });
+      actions.push(continueBtn);
+    }
+    return el('div', { className: 'lc-item' + (primary ? ' lc-primary' : '') }, [
+      el('div', { className: 'lc-head' }, [
+        el('span', { className: 'badge transcript-source-' + c.source, text: providerLabel(c.source) }),
+        el('span', { className: 'lc-title', text: title }),
+      ]),
+      el('div', { className: 'lc-sub', text: sub }),
+      el('div', { className: 'lc-actions' }, actions),
+    ]);
+  }
+
+  // Cap on how many extra recent conversations "Show more" reveals — the full
+  // list lives in the Working Memory Review. Keep the banner a quick resume
+  // surface, not a second list.
+  const LC_MORE_MAX = 4;
+
+  function renderLastConvo() {
+    if (!lastConvoEl) return;
+    const convos = branchData.conversations || [];
+    if (state.activeTab !== 'branch' || isViewingForeign() || convos.length === 0) {
+      lastConvoEl.replaceChildren();
+      lastConvoEl.classList.add('hidden');
+      return;
+    }
+    // Sort most-recent first. Coerce an unparseable updatedAt to -Infinity so a
+    // bad timestamp never sorts ahead of a real one.
+    const parseTs = function(v) { const t = Date.parse(v); return Number.isFinite(t) ? t : -Infinity; };
+    const sorted = convos.slice().sort(function(a, b) { return parseTs(b.updatedAt) - parseTs(a.updatedAt); });
+
+    // Same .section-header bar (twirl + uppercase title) as Working Memory and
+    // Committed Memories — uniform headers. The banner is a .collapsible-section
+    // keyed by 'conversations-banner'; its click handler (attached to
+    // lastConvoEl) toggles collapse via the shared sectionsCollapsed state.
+    const collapsed = isCollapsed('conversations-banner');
+    const header = el('div', { className: 'section-header', role: 'button', tabindex: '0', 'aria-expanded': String(!collapsed) }, [
+      el('span', { className: 'twirl', text: '▾' }),
+      el('span', { className: 'section-title', text: 'Conversations' }),
+    ]);
+    const bodyKids = [renderConvoItem(sorted[0], true)];
+    const more = sorted.slice(1, 1 + LC_MORE_MAX);
+    if (more.length > 0) {
+      if (state.lcExpanded) {
+        more.forEach(function(c) { bodyKids.push(renderConvoItem(c, false)); });
+      }
+      const moreBtn = el('button', { type: 'button', className: 'lc-more-toggle' }, [
+        el('span', { text: state.lcExpanded ? 'Show less' : 'Show more (' + more.length + ')' }),
+      ]);
+      moreBtn.addEventListener('click', function() {
+        state.lcExpanded = !state.lcExpanded;
+        renderLastConvo();
+      });
+      bodyKids.push(moreBtn);
+    }
+    lastConvoEl.replaceChildren(header, el('div', { className: 'section-body' }, bodyKids));
+    lastConvoEl.classList.add('collapsible-section');
+    lastConvoEl.classList.toggle('collapsed', collapsed);
+    lastConvoEl.classList.remove('hidden');
   }
 
   // Adapts BranchMemoryItem → the minimal display-item shape renderCommitRow
@@ -2658,24 +3000,13 @@ export function buildSidebarScript(): string {
       }
       bodyKids.unshift(el('div', { className: 'foreign-banner' }, kids));
     }
-    // Primary CTA mounted as a SIBLING of .section-body so it survives the
-    // Changes section being collapsed. Commit Memory operates on the group
-    // (Plans + Changes + Commits selections together), so hiding it whenever
-    // the user folds Changes makes the cross-panel action unreachable. The
-    // header sparkle iconbtn is too easy to miss, and a labelled button
-    // mirrors the SCM "Commit" pattern users expect. Stays visible when
-    // Changes is empty (sits below the empty-state placeholder, disabled via
-    // renderCommitMemoryButton's selectedCount===0 guard). Foreign-readonly
-    // mode drops the Changes section entirely above, so the s.id==='changes'
-    // predicate already implicitly excludes foreign view — no extra check
-    // needed.
+    // Commit Memory is no longer appended here — it lives in the Working
+    // Memory card (renderWorkingMemoryCard), which owns the cross-panel
+    // assembly (Conversations + Context + Changes) and the CTA together.
     const sectionKids = [
-      el('div', { className: 'section-header' }, headerKids),
+      el('div', { className: 'section-header', role: 'button', tabindex: '0', 'aria-expanded': String(!collapsed) }, headerKids),
       el('div', { className: 'section-body' }, bodyKids),
     ];
-    if (s.id === 'changes') {
-      sectionKids.push(renderCommitMemoryButton());
-    }
     return el('div', {
       className: 'collapsible-section' + (collapsed ? ' collapsed' : ''),
       'data-section': s.id,
@@ -3102,6 +3433,12 @@ export function buildSidebarScript(): string {
     }, kids), item.tooltip || '');
   }
 
+  // Grace window after a commit during which a missing summary is treated as
+  // "still generating" (the post-commit worker holds a 5-min lock; generation
+  // itself is ~20-40s but can queue behind other commits). Past this, a
+  // missing summary is treated as genuinely absent and the row offers Generate.
+  const GENERATING_WINDOW_MS = 10 * 60 * 1000;
+
   function renderCommitRow(item, depth) {
     const hasMem = item.contextValue === 'commitWithMemory';
     // Children are pre-serialized by HistoryTreeProvider when CommitItem
@@ -3118,6 +3455,10 @@ export function buildSidebarScript(): string {
               (expanded ? 'codicon-chevron-down' : 'codicon-chevron-right') +
               ' commit-twirl',
             'data-commit-toggle': item.id,
+            role: 'button',
+            tabindex: '0',
+            'aria-expanded': String(expanded),
+            'aria-label': (expanded ? 'Collapse' : 'Expand') + ' memory detail',
           }),
           expanded ? 'Collapse' : 'Expand',
         )
@@ -3203,7 +3544,37 @@ export function buildSidebarScript(): string {
           );
       kids.push(el('span', { className: 'inline-actions' }, [inlineBtn]));
     } else {
-      kids.push(el('span', { className: 'inline-actions' }));
+      // No stored memory. A just-committed memory is summarized asynchronously
+      // (~20-40s), so within a short window show a passive "Generating…"
+      // indicator rather than an action. Once that window has passed the
+      // summary genuinely didn't land — offer a one-click Generate. Foreign
+      // rows are always memory-backed (never reach here), but guard anyway:
+      // generating writes the workspace orphan branch.
+      const committedMs = item.committedAt ? Date.parse(item.committedAt) : NaN;
+      const isPending = !isNaN(committedMs) && (Date.now() - committedMs) < GENERATING_WINDOW_MS;
+      if (isPending) {
+        kids.push(el('span', { className: 'inline-actions' }, [
+          el('span', { className: 'mem-generating', title: 'Memory is being generated…' }, [
+            el('i', { className: 'codicon codicon-loading codicon-modifier-spin' }),
+            el('span', { text: 'Generating…' }),
+          ]),
+        ]));
+      } else if (!isViewingForeign()) {
+        kids.push(el('span', { className: 'inline-actions' }, [
+          attachTextTip(
+            el('button', {
+              type: 'button',
+              className: 'iconbtn',
+              'data-inline': 'generate',
+              'data-id': item.id,
+              'aria-label': 'Generate memory',
+            }, [el('i', { className: 'codicon codicon-sparkle' })]),
+            'Generate memory',
+          ),
+        ]));
+      } else {
+        kids.push(el('span', { className: 'inline-actions' }));
+      }
     }
     // No title= attribute — hover content is rendered by the custom
     // .hover-card popup (renderHoverCard / showHoverCard) so the legacy
@@ -3216,15 +3587,57 @@ export function buildSidebarScript(): string {
       'data-id': item.id,
     }, kids);
     if (!expanded) return row;
-    // Children share the parent commit's depth (not depth + 1) so the
-    // file-row icon column-aligns with the commit row's leading M↓ /
-    // git-commit icon. The chevron on the commit row already signals the
-    // parent/child relationship, so an extra 20px indent on the file rows
-    // would just visually break the icon column without adding info.
+    // Grouped expansion mirrors the Working Memory card: Conversations +
+    // Context (lazy-loaded from this memory's summary via branch:loadCommitDetail)
+    // then Files. Children share the parent commit's depth so the file-row icon
+    // column-aligns with the commit row's leading glyph.
+    const out = [row];
+    // Lazy + reload-safe: an expanded row with no cached detail (first expand,
+    // OR a reload that cleared the cache) requests it now and shows a spinner.
+    // Setting 'loading' synchronously means repeat renders don't re-request,
+    // and the host always replies (even on error) so this never hangs.
+    let detail = state.commitDetail[item.id];
+    if (detail === undefined) {
+      state.commitDetail[item.id] = 'loading';
+      detail = 'loading';
+      vscode.postMessage({ type: 'branch:loadCommitDetail', hash: item.id });
+    }
+    const groupLabel = (text) => el('div', { className: 'commit-detail-group', text: text });
+    const cap = (s) => { const v = String(s || ''); return v ? v.charAt(0).toUpperCase() + v.slice(1) : 'Unknown'; };
+    if (detail === 'loading') {
+      out.push(el('div', { className: 'commit-detail-loading', text: 'Loading conversations & context…' }));
+    } else {
+      if (detail.conversations && detail.conversations.length) {
+        out.push(groupLabel('Conversations'));
+        detail.conversations.forEach(function(c) {
+          const n = c.messageCount || 0;
+          out.push(el('div', { className: 'commit-detail-row' }, [
+            // Use the shared providerLabel (OpenCode / Copilot Chat) so this
+            // matches the Conversations banner above — cap() is kept only for
+            // the context kinds (plan/note/reference) below.
+            el('span', { className: 'cd-kind', text: providerLabel(c.source) }),
+            el('span', { className: 'cd-text', text: n + ' message' + (n === 1 ? '' : 's') }),
+          ]));
+        });
+      }
+      if (detail.context && detail.context.length) {
+        out.push(groupLabel('Context'));
+        detail.context.forEach(function(x) {
+          out.push(el('div', { className: 'commit-detail-row' }, [
+            el('span', { className: 'cd-kind', text: cap(x.kind) }),
+            el('span', { className: 'cd-text', text: x.label || '' }),
+          ]));
+        });
+      }
+    }
     const fileRows = item.children.map(function(c) {
       return renderCommitFileRow(c, depth);
     });
-    return [row].concat(fileRows);
+    if (fileRows.length) {
+      out.push(groupLabel('Files'));
+      for (let i = 0; i < fileRows.length; i++) out.push(fileRows[i]);
+    }
+    return out;
   }
 
   function renderCommitFileRow(item, depth) {
@@ -3373,8 +3786,53 @@ export function buildSidebarScript(): string {
       e.stopPropagation();
       return;
     }
-    // Bottom-of-section Commit Memory CTA — not gated on .section-actions
-    // because it lives inside .section-body, not the header. Routes to the
+    // Working Memory card: the Review chevron expands the editable attached
+    // Conversations / Context / Changes. State is client-side; re-render.
+    // Clickable selection counts in the assembly sentence — open (not toggle)
+    // Review so the attached items are visible and editable in one tap.
+    const wmOpenReview = e.target.closest('[data-action="wm-open-review"]');
+    if (wmOpenReview) {
+      if (!wmReviewing) {
+        wmReviewing = true;
+        renderBranch();
+      }
+      // Scroll the named sub-section into view even when Review is already
+      // open, so the count behaves like a deep-link to the items it describes
+      // (rather than a no-op once the panel is expanded).
+      const target = wmOpenReview.getAttribute('data-wm-target');
+      if (target) {
+        const sec = document.querySelector('.wm-review-body .collapsible-section[data-section="' + target + '"]');
+        if (sec && sec.scrollIntoView) sec.scrollIntoView({ block: 'nearest' });
+      }
+      e.stopPropagation();
+      return;
+    }
+    const wmReview = e.target.closest('[data-action="wm-review-toggle"]');
+    if (wmReview) {
+      wmReviewing = !wmReviewing;
+      renderBranch();
+      e.stopPropagation();
+      return;
+    }
+    const wmPreview = e.target.closest('[data-action="wm-preview-open"]');
+    if (wmPreview) {
+      // Gather the currently-selected items WITH the ids the pop-out needs to
+      // toggle exclusion. Files key off the relative path (item.description,
+      // mirrored to data-rel-path); context off id + contextValue.
+      const files = (branchData.changes || [])
+        .filter(function(i) { return !!i.isSelected; })
+        .map(function(i) { return { label: String(i.label || ''), relPath: String(i.description || '') }; });
+      const conversations = (branchData.conversations || [])
+        .filter(function(i) { return !!i.isSelected; })
+        .map(function(i) { return { title: String(i.title || '(untitled)'), source: String(i.source || ''), sessionId: String(i.sessionId || '') }; });
+      const context = (branchData.plans || [])
+        .filter(function(i) { return !!i.isSelected; })
+        .map(function(i) { return { label: String(i.label || ''), contextValue: String(i.contextValue || ''), id: String(i.id || '') }; });
+      vscode.postMessage({ type: 'branch:previewNextMemory', files: files, conversations: conversations, context: context });
+      e.stopPropagation();
+      return;
+    }
+    // Commit Memory CTA — lives in the Working Memory card. Routes to the
     // same command as the header sparkle iconbtn.
     const commitMemoryBtn = e.target.closest('.commit-memory-btn[data-action="changes-commit-memory"]');
     if (commitMemoryBtn && !commitMemoryBtn.disabled) {
@@ -3421,6 +3879,9 @@ export function buildSidebarScript(): string {
     if (commitToggle) {
       const hash = commitToggle.getAttribute('data-commit-toggle');
       state.commitsExpanded[hash] = !state.commitsExpanded[hash];
+      // The detail fetch is render-driven (renderCommitRow requests it when an
+      // expanded row has no cached detail), so it fires for both this click and
+      // a reload that restored the expanded state — nothing to request here.
       persist();
       renderBranch();
       e.stopPropagation();
@@ -3502,6 +3963,19 @@ export function buildSidebarScript(): string {
         // the commit hash through the multi-repo summary index so it works
         // for both workspace and foreign hashes.
         vscode.postMessage({ type: 'command', command: 'jollimemory.copyRecallPrompt', args: [id] });
+      }
+      if (action === 'generate') {
+        // One-click generate for a workspace commit whose summary never
+        // landed. The command bootstraps from the hash, persists, refreshes
+        // the list, then opens the panel on the result. Only rendered on
+        // workspace rows, so it never targets a foreign repo's orphan branch.
+        vscode.postMessage({ type: 'command', command: 'jollimemory.generateMemory', args: [id] });
+      }
+      if (action === 'open-reference') {
+        vscode.postMessage({ type: 'branch:openReference', mapKey: id });
+      }
+      if (action === 'ignore-reference') {
+        vscode.postMessage({ type: 'branch:ignoreReference', mapKey: id });
       }
       e.stopPropagation();
       return;
@@ -3728,6 +4202,12 @@ export function buildSidebarScript(): string {
       const items = [];
       if (ctx === 'commitWithMemory') {
         items.push({ label: 'View Memory',      command: 'jollimemory.viewSummary',    args: [id] });
+        items.push({ separator: true });
+      } else if (!isViewingForeign()) {
+        // Workspace commit with no memory yet — offer to generate one.
+        // Skipped in foreign view: generating writes the workspace orphan
+        // branch, which would corrupt the foreign repo's memory identity.
+        items.push({ label: 'Generate memory', command: 'jollimemory.generateMemory', args: [id] });
         items.push({ separator: true });
       }
       items.push({ label: 'Copy Commit Hash', command: 'jollimemory.copyCommitHash', args: [id] });

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -169,6 +169,17 @@ describe("SidebarWebviewProvider", () => {
 		expect(executeCommand).toHaveBeenCalledWith("jollimemory.openSettings");
 	});
 
+	it("rejects `command` outside the jollimemory namespace (no executeCommand)", () => {
+		const view = makeMockView();
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({
+			type: "command",
+			command: "workbench.action.terminal.sendSequence",
+			args: ["rm -rf"],
+		} as unknown as SidebarOutboundMsg);
+		expect(executeCommand).not.toHaveBeenCalled();
+	});
+
 	it("ignores malformed outbound messages without throwing", () => {
 		const view = makeMockView();
 		provider.resolveWebviewView(view as unknown as never);
@@ -3394,6 +3405,86 @@ describe("SidebarWebviewProvider", () => {
 				view.webview.triggerMessage({ type: "refresh", scope: "branch" } as SidebarOutboundMsg),
 			).not.toThrow();
 			expect(discover).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("branch:loadCommitDetail", () => {
+		// The webview sets a persisted 'loading' sentinel on expand, so the host
+		// MUST always reply with commitDetailLoaded — otherwise the row spins
+		// forever (and, because the sentinel is persisted, across reloads). These
+		// pin all three paths: success, rejected load, and unwired dep.
+		function makeProviderWithLoad(
+			load?: (hash: string) => Promise<{
+				conversations: Array<{ source: string; messageCount: number }>;
+				context: Array<{ kind: "plan" | "note" | "reference"; label: string }>;
+			}>,
+		): MockWebviewView {
+			const view = makeMockView();
+			const p = new SidebarWebviewProvider({
+				executeCommand: vi.fn() as never,
+				getInitialState: () => ({
+					enabled: true,
+					authenticated: false,
+					activeTab: "branch",
+					kbMode: "folders",
+					branchName: "main",
+					detached: false,
+				}),
+				extensionUri: mockExtensionUri as unknown as never,
+				loadCommitMemoryDetail: load,
+			});
+			p.resolveWebviewView(view as unknown as never);
+			view.webview.postMessage.mockClear();
+			return view;
+		}
+
+		it("replies commitDetailLoaded with the loaded detail", async () => {
+			const view = makeProviderWithLoad(async () => ({
+				conversations: [{ source: "claude", messageCount: 3 }],
+				context: [{ kind: "plan", label: "Plan A" }],
+			}));
+			view.webview.triggerMessage({
+				type: "branch:loadCommitDetail",
+				hash: "abc",
+			} as SidebarOutboundMsg);
+			await flushReady();
+			expect(view.webview.postMessage).toHaveBeenCalledWith({
+				type: "commitDetailLoaded",
+				hash: "abc",
+				conversations: [{ source: "claude", messageCount: 3 }],
+				context: [{ kind: "plan", label: "Plan A" }],
+			});
+		});
+
+		it("replies with empty arrays when the load REJECTS — no stuck spinner", async () => {
+			const view = makeProviderWithLoad(() =>
+				Promise.reject(new Error("git read failed")),
+			);
+			view.webview.triggerMessage({
+				type: "branch:loadCommitDetail",
+				hash: "def",
+			} as SidebarOutboundMsg);
+			await flushReady();
+			expect(view.webview.postMessage).toHaveBeenCalledWith({
+				type: "commitDetailLoaded",
+				hash: "def",
+				conversations: [],
+				context: [],
+			});
+		});
+
+		it("replies with empty arrays when the dep is unwired — degrade, don't hang", () => {
+			const view = makeProviderWithLoad(undefined);
+			view.webview.triggerMessage({
+				type: "branch:loadCommitDetail",
+				hash: "ghi",
+			} as SidebarOutboundMsg);
+			expect(view.webview.postMessage).toHaveBeenCalledWith({
+				type: "commitDetailLoaded",
+				hash: "ghi",
+				conversations: [],
+				context: [],
+			});
 		});
 	});
 });

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -14,6 +14,7 @@ import { isTranscriptSource } from "../../../cli/src/Types.js";
 import type { ActiveSessionsProvider } from "../services/ActiveSessionsProvider.js";
 import { log } from "../util/Logger.js";
 import { ConversationDetailsPanel } from "./ConversationDetailsPanel.js";
+import { NextMemoryPreviewPanel } from "./NextMemoryPreviewPanel.js";
 import { SIDEBAR_EMPTY_STRINGS } from "./SidebarEmptyMessages.js";
 import { buildSidebarHtml } from "./SidebarHtmlBuilder.js";
 import type {
@@ -35,6 +36,19 @@ export interface SidebarWebviewDeps {
 	getInitialState: () => SidebarState;
 	/** Extension installation root — used to compute webview-resolvable URIs for bundled assets (codicons). */
 	extensionUri: vscode.Uri;
+	/**
+	 * Lazy-fetch a committed memory's attached conversations + context for the
+	 * grouped inline row expansion (mirrors the Working Memory card). Called once
+	 * per row expand — never eagerly for every row. Optional so existing tests
+	 * keep working; absent → the expansion shows files only.
+	 */
+	loadCommitMemoryDetail?: (hash: string) => Promise<{
+		conversations: ReadonlyArray<{ source: string; messageCount: number }>;
+		context: ReadonlyArray<{
+			kind: "plan" | "note" | "reference";
+			label: string;
+		}>;
+	}>;
 	/** Optional in scaffold; required once Phase 2 lands. */
 	statusProvider?: {
 		serialize(): ReadonlyArray<SerializedTreeItem>;
@@ -439,6 +453,16 @@ export class SidebarWebviewProvider
 				void this.handleReady();
 				return;
 			case "command":
+				// Trust boundary: `command` arrives from the webview. Restrict it to
+				// this extension's own command namespace so a compromised/spoofed
+				// webview message can never invoke arbitrary VS Code commands (e.g.
+				// workbench.action.* or another extension's command).
+				if (typeof msg.command !== "string" || !msg.command.startsWith("jollimemory.")) {
+					log.warn("SidebarWebviewProvider", "Rejected command outside jollimemory namespace", {
+						command: String(msg.command),
+					});
+					return;
+				}
 				if (msg.args && msg.args.length > 0) {
 					void this.deps.executeCommand(msg.command, ...msg.args);
 				} else {
@@ -534,6 +558,87 @@ export class SidebarWebviewProvider
 			case "branch:openCommit":
 				void this.deps.executeCommand("jollimemory.viewSummary", msg.hash);
 				return;
+			case "branch:loadCommitDetail": {
+				// Lazy: fetch one commit's attached conversations + context on
+				// expand and push it back. The webview sets a persisted
+				// 'loading' sentinel on expand, so EVERY path here must reply
+				// with commitDetailLoaded — a silent return (unwired dep) or an
+				// unhandled rejection (git/transcript read failure) would leave
+				// that row spinning forever, across reloads. Both fall back to
+				// empty arrays, which the webview renders as files-only.
+				const hash = msg.hash;
+				const load = this.deps.loadCommitMemoryDetail;
+				if (!load) {
+					this.postMessage({ type: "commitDetailLoaded", hash, conversations: [], context: [] });
+					return;
+				}
+				void load(hash)
+					.then((detail) => {
+						this.postMessage({
+							type: "commitDetailLoaded",
+							hash,
+							conversations: detail.conversations,
+							context: detail.context,
+						});
+					})
+					.catch((err: unknown) => {
+						log.warn(
+							"SidebarWebviewProvider",
+							`loadCommitMemoryDetail failed for ${hash}; degrading to files-only`,
+							{ error: err instanceof Error ? err.message : String(err) },
+						);
+						this.postMessage({ type: "commitDetailLoaded", hash, conversations: [], context: [] });
+					});
+				return;
+			}
+			case "branch:previewNextMemory": {
+				// Display data + toggle ids from the webview; coerce defensively
+				// across the trust boundary, then open the editable preview pop-out.
+				const toStr = (v: unknown): string => (typeof v === "string" ? v : "");
+				const get = (o: unknown, k: string): string =>
+					toStr((o as Record<string, unknown> | null)?.[k]);
+				const files = Array.isArray(msg.files)
+					? msg.files.map((f) => ({ label: get(f, "label"), relPath: get(f, "relPath") }))
+					: [];
+				const conversations = Array.isArray(msg.conversations)
+					? msg.conversations.map((c) => ({
+							title: get(c, "title"),
+							source: get(c, "source"),
+							sessionId: get(c, "sessionId"),
+						}))
+					: [];
+				const context = Array.isArray(msg.context)
+					? msg.context.map((c) => ({
+							label: get(c, "label"),
+							contextValue: get(c, "contextValue"),
+							id: get(c, "id"),
+						}))
+					: [];
+				NextMemoryPreviewPanel.show({
+					files,
+					conversations,
+					context,
+					// Route an uncheck/recheck in the pop-out through the SAME apply*
+					// path the sidebar checkboxes use — which also refreshes the
+					// sidebar's Working Memory card, keeping the two surfaces in sync.
+					onExclude: (ex) => {
+						if (ex.kind === "file") {
+							this.deps.applyFileCheckbox?.(ex.relPath, ex.selected);
+						} else if (ex.kind === "conversation") {
+							if (isTranscriptSource(ex.source)) {
+								void this.deps.applyConversationCheckbox?.(ex.source, ex.sessionId, ex.selected);
+							}
+						} else if (ex.contextValue === "note") {
+							void this.deps.applyNoteCheckbox?.(ex.id, ex.selected);
+						} else if (ex.contextValue === "reference") {
+							void this.deps.applyReferenceCheckbox?.(ex.id, ex.selected);
+						} else {
+							void this.deps.applyPlanCheckbox?.(ex.id, ex.selected);
+						}
+					},
+				});
+				return;
+			}
 			case "branch:openConversation":
 				// Same sessionId reveals the existing panel; a different sessionId
 				// disposes the prior panel and opens a fresh one. The source-specific

--- a/vscode/src/views/SummaryErrorBanner.test.ts
+++ b/vscode/src/views/SummaryErrorBanner.test.ts
@@ -28,6 +28,33 @@ describe("buildSummaryErrorBanner", () => {
 		expect(html).toContain('role="status"');
 	});
 
+	it("suppresses the failure banner when summaryError is set but the summary has a recap (transient/partial failure on a complete memory)", () => {
+		const withRecap = {
+			...baseSummary,
+			summaryError: "llm-failed",
+			recap: "A complete recap of the change.",
+		} satisfies CommitSummary;
+		expect(buildSummaryErrorBanner(withRecap)).toBe("");
+	});
+
+	it("suppresses the failure banner when content lives only on a child (squash/amend container)", () => {
+		const container = {
+			...baseSummary,
+			summaryError: "llm-failed",
+			children: [{ ...baseSummary, recap: "Child recap." }],
+		} as CommitSummary;
+		expect(buildSummaryErrorBanner(container)).toBe("");
+	});
+
+	it("still shows the failure banner when summaryError is set and content is empty (the degraded loud-failure state)", () => {
+		const html = buildSummaryErrorBanner({
+			...baseSummary,
+			summaryError: "llm-failed",
+		});
+		expect(html).toContain('class="summary-error-banner"');
+		expect(html).toContain('id="summaryErrorRegenerateBtn"');
+	});
+
 	it("renders banner for legacy summaries with llm.stopReason === 'error'", () => {
 		const legacy: CommitSummary = {
 			...baseSummary,
@@ -72,5 +99,32 @@ describe("buildSummaryErrorBanner", () => {
 		const html = buildSummaryErrorBanner(legacy, { readOnly: true });
 		expect(html).toContain('class="summary-error-banner"');
 		expect(html).not.toContain('id="summaryErrorRegenerateBtn"');
+	});
+
+	it("needsGeneration renders the Generate-memory variant with #generateMemoryBtn", () => {
+		// A never-summarized commit is not a failed one — distinct copy + a
+		// Generate (not Regenerate) button wired to the from-scratch path.
+		const html = buildSummaryErrorBanner(baseSummary, { needsGeneration: true });
+		expect(html).toContain('class="summary-error-banner"');
+		expect(html).toContain('id="generateMemoryBtn"');
+		expect(html).toContain("No memory has been generated");
+		expect(html).not.toContain('id="summaryErrorRegenerateBtn"');
+	});
+
+	it("needsGeneration takes precedence over a healthy summary (no isSummaryError needed)", () => {
+		// The placeholder shell passed on the open-empty path has no summaryError
+		// marker, so the needsGeneration flag must drive the variant on its own.
+		const html = buildSummaryErrorBanner(baseSummary, { needsGeneration: true });
+		expect(html).not.toBe("");
+		expect(html).toContain('id="generateMemoryBtn"');
+	});
+
+	it("needsGeneration + readOnly omits the Generate button (foreign repo)", () => {
+		// Generating writes the workspace orphan branch — never offer it for a
+		// foreign-repo placeholder.
+		const html = buildSummaryErrorBanner(baseSummary, { needsGeneration: true, readOnly: true });
+		expect(html).toContain('class="summary-error-banner"');
+		expect(html).not.toContain('id="generateMemoryBtn"');
+		expect(html).toContain("Open its home repository");
 	});
 });

--- a/vscode/src/views/SummaryErrorBanner.ts
+++ b/vscode/src/views/SummaryErrorBanner.ts
@@ -11,6 +11,14 @@ export interface SummaryErrorBannerOptions {
 	 * be a dead instruction.
 	 */
 	readonly readOnly?: boolean;
+	/**
+	 * True when the panel was opened for a commit that has NO stored summary
+	 * yet (the placeholder-open path). Renders the "Generate memory" variant
+	 * instead of the failure variant — a never-generated commit is not a
+	 * failed one, so the copy explains the empty state and offers to create a
+	 * summary from scratch. Takes precedence over the failure check.
+	 */
+	readonly needsGeneration?: boolean;
 }
 
 /**
@@ -32,11 +40,46 @@ export interface SummaryErrorBannerOptions {
  * button), so promising "Click Regenerate" would be a dead instruction.
  * The banner still renders so the user knows the summary is degraded.
  */
+/**
+ * True when the summary has content worth showing — a non-empty recap or at
+ * least one topic, on this node or (for squash/amend containers) any child.
+ * Used to decide whether a `summaryError` marker should still surface the hard
+ * failure banner: a complete memory shouldn't read as broken just because a
+ * later/secondary LLM attempt failed.
+ */
+function hasUsableContent(summary: CommitSummary): boolean {
+	if ((summary.recap ?? "").trim().length > 0) return true;
+	if ((summary.topics?.length ?? 0) > 0) return true;
+	return (summary.children ?? []).some((child) => hasUsableContent(child));
+}
+
 export function buildSummaryErrorBanner(
 	summary: CommitSummary,
 	options: SummaryErrorBannerOptions = {},
 ): string {
+	if (options.needsGeneration) {
+		if (options.readOnly) {
+			return `<div class="summary-error-banner" role="status">
+  <span class="summary-error-banner-icon" aria-hidden="true">&#x2728;</span>
+  <span class="summary-error-banner-text">No memory has been generated for this commit yet. Open its home repository to generate one.</span>
+</div>`;
+		}
+		return `<div class="summary-error-banner" role="status">
+  <span class="summary-error-banner-icon" aria-hidden="true">&#x2728;</span>
+  <span class="summary-error-banner-text">No memory has been generated for this commit yet — this can happen if summarization was skipped or the AI service was unavailable. Generate one now.</span>
+  <button class="summary-error-banner-action" id="generateMemoryBtn" title="Generate a memory from the diff and any saved AI conversations">&#x2728; Generate memory</button>
+</div>`;
+	}
 	if (!isSummaryError(summary)) return "";
+	// Soften: a transient/partial LLM failure (e.g. a 504 on a secondary call
+	// after the main summarization already produced recap + topics) can leave
+	// `summaryError` set on a summary that actually has usable content. Showing
+	// a hard "generation failed / Regenerate" banner on a complete memory reads
+	// as broken when it isn't. Suppress the banner when content is present —
+	// Regenerate is still available from the panel's action row. The banner
+	// remains for the genuinely-degraded case (summaryError + empty content,
+	// which is the designed loud-failure state the queue worker writes).
+	if (hasUsableContent(summary)) return "";
 	if (options.readOnly) {
 		return `<div class="summary-error-banner" role="status">
   <span class="summary-error-banner-icon" aria-hidden="true">&#x26A0;&#xFE0F;</span>

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -82,6 +82,13 @@ export interface BuildHtmlOptions {
 	 * buttons disappear without knowing why.
 	 */
 	readonly staleRewrittenInto?: string | null;
+	/**
+	 * True when the panel was opened for a commit with no stored summary yet.
+	 * Routes the failure banner into its "Generate memory" variant so the
+	 * empty state offers a from-scratch generate instead of reading as a
+	 * healthy (but blank) summary.
+	 */
+	readonly needsGeneration?: boolean;
 }
 
 /**
@@ -149,7 +156,7 @@ ${csp}
 </head>
 <body>
 <div class="${pageClass}">
-${buildSummaryErrorBanner(summary, { readOnly })}
+${buildSummaryErrorBanner(summary, { readOnly, needsGeneration: opts.needsGeneration })}
 ${staleBannerHtml}
 ${buildHeader(summary, totalFiles, totalInsertions, totalDeletions, !!opts.foreignRepoName)}
 ${buildShipBar(summary)}

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -770,6 +770,26 @@ ${buildPrMessageScript()}
   }
   attachRegenerateSummaryDelegate();
 
+  // Empty-state "Generate memory" button (no stored summary). Distinct from
+  // Regenerate: there are no topics/recap to overwrite, so it skips the
+  // unsaved-edits guard and posts its own message. The host enforces the
+  // in-flight guard (regenerateInProgress) and drives the same
+  // summaryRegenerating / summaryRegenerated lifecycle to swap the result in.
+  function attachGenerateMemoryDelegate() {
+    var page = document.querySelector('.page');
+    if (!page) return;
+    page.addEventListener('click', function(e) {
+      var target = e.target;
+      if (!target || typeof target.closest !== 'function') return;
+      var btn = target.closest('#generateMemoryBtn');
+      if (!btn) return;
+      e.stopPropagation();
+      if (btn.disabled) return;
+      vscode.postMessage({ command: 'generateMemory' });
+    });
+  }
+  attachGenerateMemoryDelegate();
+
   // Toggle the page into / out of regenerating-readonly mode. CSS
   // (.page.regenerating-readonly button:not([data-foreign-safe])) takes
   // care of hiding every action button; the banner explains why. The

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -151,7 +151,11 @@ vi.mock("../../../cli/src/core/SessionTracker.js", () => ({
 	saveConfig: mockSaveConfig,
 }));
 
-vi.mock("../util/WorkspaceUtils.js", () => ({
+vi.mock("../util/WorkspaceUtils.js", async (importOriginal) => ({
+	// Keep the real (pure) resolveEnabledSources so the enabled-source filter
+	// tests exercise the actual flag→source mapping; only loadGlobalConfig is
+	// stubbed to feed those flags.
+	...(await importOriginal<typeof import("../util/WorkspaceUtils.js")>()),
 	loadGlobalConfig: mockLoadConfig,
 }));
 
@@ -170,13 +174,15 @@ vi.mock("../../../cli/src/core/Summarizer.js", () => ({
 	translateToEnglish: mockTranslateToEnglish,
 }));
 
-const { mockRegenerateSummary, mockLoadRegenerateContext } = vi.hoisted(() => ({
+const { mockRegenerateSummary, mockSummarizeCommit, mockLoadRegenerateContext } = vi.hoisted(() => ({
 	mockRegenerateSummary: vi.fn(),
+	mockSummarizeCommit: vi.fn(),
 	mockLoadRegenerateContext: vi.fn(),
 }));
 
 vi.mock("../../../cli/src/core/Regenerator.js", () => ({
 	regenerateSummary: mockRegenerateSummary,
+	summarizeCommit: mockSummarizeCommit,
 }));
 
 vi.mock("../../../cli/src/core/RegenerateContext.js", () => ({
@@ -663,6 +669,9 @@ const stubBridge = {
 	),
 	regenerateSummary: vi.fn((summary: unknown, config: unknown) =>
 		mockRegenerateSummary(summary, workspaceRoot, config),
+	),
+	summarizeCommit: vi.fn((commitHash: unknown, config: unknown) =>
+		mockSummarizeCommit(commitHash, workspaceRoot, config),
 	),
 } as unknown as import("../JolliMemoryBridge.js").JolliMemoryBridge;
 const mainBranch = "main";
@@ -2407,6 +2416,63 @@ describe("SummaryWebviewPanel", () => {
 			});
 		});
 
+		// ── generateMemory (no-summary placeholder path) ────────────────────
+
+		describe("generateMemory", () => {
+			const stubUpdated = () =>
+				makeSummary({ topics: [], recap: "generated", commitMessage: "freshly generated" });
+
+			beforeEach(() => {
+				mockSummarizeCommit.mockReset();
+				withProgress.mockClear();
+				executeCommand.mockClear();
+				mockBuildTopicsSection.mockReturnValue('<div id="topicsSection">t</div>');
+				mockBuildRecapSection.mockReturnValue('<div id="recapSection">r</div>');
+			});
+
+			it("bootstraps via bridge.summarizeCommit, persists, refreshes history, and posts re-render", async () => {
+				mockSummarizeCommit.mockResolvedValue({ updated: stubUpdated(), result: {} as never });
+				const dispatch = await setupPanel();
+
+				dispatch({ command: "generateMemory" });
+				await flushPromises();
+
+				// No "overwrite?" confirm — there is nothing to overwrite.
+				expect(showWarningMessage).not.toHaveBeenCalled();
+				expect(mockStoreSummary).toHaveBeenCalledWith(
+					expect.objectContaining({ recap: "generated" }),
+					workspaceRoot,
+					true,
+				);
+				// Row must flip from "no memory" to a real memory.
+				expect(executeCommand).toHaveBeenCalledWith("jollimemory.refreshHistory");
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({ command: "summaryRegenerated" }),
+				);
+			});
+
+			it("does NOT generate for a foreign-repo panel (would write the wrong orphan branch)", async () => {
+				await SummaryWebviewPanel.show(
+					makeSummary(),
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+					"memory",
+					"other-repo",
+					"https://github.com/other/repo.git",
+					null,
+				);
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "generateMemory" });
+				await flushPromises();
+
+				expect(mockSummarizeCommit).not.toHaveBeenCalled();
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+			});
+		});
+
 		// ── regenerateSummary ───────────────────────────────────────────────
 
 		describe("regenerateSummary", () => {
@@ -2476,15 +2542,19 @@ describe("SummaryWebviewPanel", () => {
 			});
 
 			it("includes a non-empty summaryErrorBannerHtml when regenerate still produces a degraded summary", async () => {
-				// Defensive: if the regenerate result itself somehow carries
-				// summaryError (e.g. user clicks Regenerate while creds are still
-				// broken — though in practice the regenerate path would have
-				// thrown earlier), the post-message should reflect that with a
-				// non-empty banner HTML so the DOM keeps showing it.
+				// Genuinely degraded: the regenerate result carries summaryError AND
+				// no usable content (empty recap + topics) — the banner must show.
+				// (A regenerate that yields content keeps the banner suppressed —
+				// see SummaryErrorBanner's content-aware tests.)
 				mockLoadRegenerateContext.mockResolvedValue(stubCtx());
 				showWarningMessage.mockResolvedValueOnce("Regenerate");
 				mockRegenerateSummary.mockResolvedValue({
-					updated: { ...stubUpdated(), summaryError: "llm-failed" } as never,
+					updated: {
+						...stubUpdated(),
+						summaryError: "llm-failed",
+						recap: "",
+						topics: [],
+					} as never,
 					result: {} as never,
 				});
 				const dispatch = await setupPanel();

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -79,7 +79,10 @@ import {
 } from "../util/GitRemoteUtils.js";
 import { isWorkerBlockingBusy } from "../util/LockUtils.js";
 import { log } from "../util/Logger.js";
-import { loadGlobalConfig } from "../util/WorkspaceUtils.js";
+import {
+	loadGlobalConfig,
+	resolveEnabledSources,
+} from "../util/WorkspaceUtils.js";
 import { BindingChooserWebviewPanel } from "./BindingChooserWebviewPanel.js";
 import { loadBranchSummaries } from "./BranchSummaryLoader.js";
 import { SOURCE_TITLES } from "./SourceLabels.js";
@@ -199,6 +202,7 @@ type WebviewMessage =
 	| { command: "editRecap"; recap: string }
 	| { command: "generateRecap" }
 	| { command: "regenerateSummary" }
+	| { command: "generateMemory" }
 	| { command: "openRewrittenCommit"; hash: string };
 
 /** Entry data sent back from the webview on Save All. */
@@ -445,6 +449,13 @@ export class SummaryWebviewPanel {
 	 */
 	private readonly foreignStorage: StorageProvider | null;
 
+	/**
+	 * True when the panel was opened for a commit with no stored summary yet
+	 * (placeholder-open path). Drives the "Generate memory" banner variant.
+	 * Cleared once a summary is generated and the panel re-renders with it.
+	 */
+	private needsGeneration = false;
+
 	private constructor(
 		extensionUri: vscode.Uri,
 		workspaceRoot: string,
@@ -600,6 +611,15 @@ export class SummaryWebviewPanel {
 				this.catchAndShow(
 					this.handleRegenerateSummary(),
 					"Regenerate failed",
+					{
+						command: "summaryRegenerateError",
+					},
+				);
+				break;
+			case "generateMemory":
+				this.catchAndShow(
+					this.handleGenerateMemory(),
+					"Generate failed",
 					{
 						command: "summaryRegenerateError",
 					},
@@ -1088,6 +1108,7 @@ export class SummaryWebviewPanel {
 		foreignRepoName: string | null = null,
 		foreignRepoUrl: string | null = null,
 		foreignStorage: StorageProvider | null = null,
+		needsGeneration = false,
 	): Promise<void> {
 		if (source === "commit" || source === "kb") {
 			const existing = SummaryWebviewPanel.commitPanels.get(summary.commitHash);
@@ -1101,6 +1122,7 @@ export class SummaryWebviewPanel {
 				// we always run them and then compare the full render-input set
 				// (summary + 3 cache sets) to decide whether re-rendering the
 				// webview HTML is necessary.
+				existing.needsGeneration = needsGeneration;
 				const prevTranscriptHashSet = existing.transcriptHashSet;
 				const prevPlanTranslateSet = existing.planTranslateSet;
 				const prevNoteTranslateSet = existing.noteTranslateSet;
@@ -1152,6 +1174,7 @@ export class SummaryWebviewPanel {
 		} else {
 			SummaryWebviewPanel.commitPanels.set(summary.commitHash, instance);
 		}
+		instance.needsGeneration = needsGeneration;
 		await instance.refreshTranscriptHashes(summary);
 		await instance.refreshPlanTranslateSet(summary);
 		await instance.refreshNoteTranslateSet(summary);
@@ -1187,6 +1210,7 @@ export class SummaryWebviewPanel {
 			nonce,
 			foreignRepoName: this.foreignRepoName,
 			staleRewrittenInto: this.staleRewrittenInto ?? null,
+			needsGeneration: this.needsGeneration,
 		});
 	}
 
@@ -2180,6 +2204,65 @@ export class SummaryWebviewPanel {
 						summaryErrorBannerHtml: buildSummaryErrorBanner(outcome.updated),
 					});
 					vscode.window.showInformationMessage("Summary regenerated.");
+				},
+			);
+		} finally {
+			this.regenerateInProgress = false;
+		}
+	}
+
+	/**
+	 * Generate a summary for a commit that has none yet (the placeholder-open
+	 * path). Shares the regenerate in-flight guard, the regenerating-readonly
+	 * chrome, and the topic/recap swap-in messages, but skips the "overwrite?"
+	 * confirm — there is nothing to overwrite. Bootstraps from the commit hash
+	 * via the Bridge's `summarizeCommit`, persists, clears the
+	 * needs-generation state, then refreshes the history list so the row flips
+	 * from "no memory" to a real memory.
+	 *
+	 * Foreign panels never reach the generate path (their banner omits the
+	 * button), but we hard-guard here too: generating writes the workspace's
+	 * orphan branch, which would corrupt the foreign repo's identity.
+	 */
+	private async handleGenerateMemory(): Promise<void> {
+		if (this.foreignRepoName) return;
+		if (this.regenerateInProgress) return;
+		this.regenerateInProgress = true;
+		try {
+			if (!(await this.ensureCommitNotRewritten("generate memory"))) return;
+			const config = await loadGlobalConfig();
+			this.panel.webview.postMessage({ command: "summaryRegenerating" });
+			await vscode.window.withProgress(
+				{
+					location: vscode.ProgressLocation.Notification,
+					title: "Generating memory…",
+					cancellable: true,
+				},
+				async (_progress, token) => {
+					const cancelled = new Promise<"cancelled">((resolve) => {
+						token.onCancellationRequested(() => resolve("cancelled"));
+					});
+					const work = this.bridge.summarizeCommit(this.commitHash, config);
+					const outcome = await Promise.race([work, cancelled]);
+					if (outcome === "cancelled") {
+						this.panel.webview.postMessage({ command: "summaryRegenerateError" });
+						return;
+					}
+					if (!(await this.ensureCommitNotRewritten("generate memory"))) {
+						this.panel.webview.postMessage({ command: "summaryRegenerateError" });
+						return;
+					}
+					await this.bridge.storeSummary(outcome.updated, true);
+					this.currentSummary = outcome.updated;
+					this.needsGeneration = false;
+					this.panel.webview.postMessage({
+						command: "summaryRegenerated",
+						topicsHtml: buildTopicsSection(outcome.updated),
+						recapHtml: buildRecapSection(outcome.updated.recap),
+						summaryErrorBannerHtml: buildSummaryErrorBanner(outcome.updated),
+					});
+					await vscode.commands.executeCommand("jollimemory.refreshHistory");
+					vscode.window.showInformationMessage("Memory generated.");
 				},
 			);
 		} finally {
@@ -3418,28 +3501,7 @@ export class SummaryWebviewPanel {
 
 	/** Returns the set of integration source names that are currently enabled in config. */
 	private async getEnabledSources(): Promise<Set<string>> {
-		const config = await loadGlobalConfig();
-		const sources = new Set<string>();
-		if (config.claudeEnabled !== false) {
-			sources.add("claude");
-		}
-		if (config.codexEnabled !== false) {
-			sources.add("codex");
-		}
-		if (config.geminiEnabled !== false) {
-			sources.add("gemini");
-		}
-		if (config.openCodeEnabled !== false) {
-			sources.add("opencode");
-		}
-		if (config.cursorEnabled !== false) {
-			sources.add("cursor");
-		}
-		if (config.copilotEnabled !== false) {
-			sources.add("copilot");
-			sources.add("copilot-chat");
-		}
-		return sources;
+		return resolveEnabledSources(await loadGlobalConfig());
 	}
 
 	/** Loads lightweight stats (session/entry counts by source) without sending full content. */


### PR DESCRIPTION
Restructures the VS Code extension's Branch view into three uniform, borderless collapsible sections — **Conversations**, **Working Memory**, and **Committed Memories** — with a bottom action bar (**Recall** + **Create PR**).

### Highlights

- **Recall split button** — the main action opens Claude Code with the branch's full recall context; the ▾ caret menu (and the degraded path when Claude Code isn't installed) copies the prompt for Codex/Cursor/other tools, offering a one-click install. The menu trigger stops event propagation so it isn't closed by the document-level outside-click handler.

- **Lazy, reload-safe committed-memory expansion** — memories expand into grouped *conversations / context / files*, loaded on first expand. A failed or unwired detail load degrades to files-only instead of hanging on a spinner. The expansion's conversation list mirrors the detail panel's stats exactly (dedupe by `source:sessionId`, drop disabled sources) via a shared `resolveEnabledSources` helper, so the two surfaces never disagree.

- **Generate + summary correctness** — un-summarized commits offer a one-click Generate. `hasSummary` now also matches by **tree hash**, so a commit whose summary is indexed under a different SHA (rebase / cherry-pick / amend) no longer falsely offers Generate. The detail panel's failure banner is suppressed when the summary has usable content (recap/topics) — a transient LLM failure no longer makes a complete memory read as broken; the banner still shows for the genuinely-degraded state.

- **Accessibility + polish** — selection counts deep-link into the matching Review sub-section; non-native click targets (counts, twirls, section headers) are keyboard-accessible (`role=button`, `tabindex`, `aria-expanded`, Enter/Space); Preview Memory matches Commit Memory's full width.

- **PR section fix** — a branch's already-merged PR is no longer shown as a memory's live PR; the merged/closed "Previously" strip renders only alongside an open PR.

### Testing

`npm run all` (lint, typecheck, build, ~3,159 vscode tests, 97%+ coverage). The webview's generated JS isn't executed by the suite, so it was also manually exercised (Recall split + dropdown, lazy expansion + reload-safety, source labels, error banner, keyboard activation).