### PR TITLE
Fix Ingest block commit

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jolli.ai/cli",
-	"version": "0.99.3",
+	"version": "0.99.4",
 	"description": "AI development process auto-documentation tool - generates structured commit summaries from Claude Code, Codex, Gemini, OpenCode, Cursor, and Copilot sessions",
 	"main": "./dist/Api.js",
 	"types": "./dist/Api.d.ts",

--- a/cli/src/Api.test.ts
+++ b/cli/src/Api.test.ts
@@ -422,6 +422,37 @@ describe("CLI", () => {
 			exitSpy.mockRestore();
 		});
 
+		it("hides a command via the `hidden` fallback field when `_hidden` is absent (forward-compat)", async () => {
+			// isHiddenCommand probes BOTH `_hidden` (commander v13) and `hidden`, so a
+			// future commander that renames the internal can't silently un-hide a
+			// command. Simulate that future: drop `_hidden` and set `hidden` — the
+			// `?? internal.hidden` fallback operand must still hide it.
+			vi.mocked(loadPlugins).mockImplementationOnce(async (program) => {
+				const c = program.command("plugin-fallback-hidden").description("hidden via fallback field");
+				const internal = c as unknown as { _hidden?: boolean; hidden?: boolean };
+				delete internal._hidden;
+				internal.hidden = true;
+				program.command("plugin-visible-after-fallback").description("visible plugin cmd");
+				return { loaded: new Set<string>(), diagnostics: [] };
+			});
+
+			const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+				throw new Error("process.exit");
+			}) as never);
+			try {
+				await main(["--help"]);
+			} catch {
+				// Commander calls process.exit after --help
+			}
+			const helpOutput = vi
+				.mocked(process.stdout.write)
+				.mock.calls.map((c) => String(c[0]))
+				.join("");
+			expect(helpOutput).toContain("plugin-visible-after-fallback");
+			expect(helpOutput).not.toContain("plugin-fallback-hidden");
+			exitSpy.mockRestore();
+		});
+
 		it("classifies every builtin/stub command into Memory, Site, or Space (no 'Other commands:' fall-through)", async () => {
 			// Invariant: every builtin/stub command name must appear in
 			// MEMORY_COMMAND_NAMES, SITE_COMMAND_NAMES, SPACE_COMMAND_NAMES, or

--- a/cli/src/PluginLoader.test.ts
+++ b/cli/src/PluginLoader.test.ts
@@ -15,11 +15,19 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as HelpGroups from "./commands/HelpGroups.js";
 import { getHelpGroup } from "./commands/HelpGroups.js";
 import type { KnownPlugin } from "./KnownPlugins.js";
 import { KNOWN_PLUGINS } from "./KnownPlugins.js";
 import { setSilentConsole } from "./Logger.js";
-import { findNodeModulesRoot, getNpmRootGlobal, inspectPlugins, loadPlugins } from "./PluginLoader.js";
+import {
+	compareDirentNames,
+	findNodeModulesRoot,
+	getNpmRootGlobal,
+	inspectPlugins,
+	loadPlugins,
+	registerMissingStubs,
+} from "./PluginLoader.js";
 import { symlinksSupported } from "./testUtils/symlinkSupport.js";
 
 // The npm-link / symlink-layout case needs a real symlink, which requires
@@ -1405,6 +1413,286 @@ describe("loadPlugins", () => {
 		expect(cmd).toBeDefined();
 		expect(cmd && getHelpGroup(cmd)).toBe(known.helpGroup);
 	});
+
+	it("does not re-tag pre-existing commands when a known plugin declares a help group", async () => {
+		// L818 false branch: only commands the plugin *adds* during register() get
+		// tagged. A command already on `program` before register (here a builtin
+		// `preexisting`) must be left untouched — `commandsBefore.has(c)` is true so
+		// the tagging loop skips it.
+		const known = KNOWN_PLUGINS.find((p) => p.helpGroup);
+		if (!known) throw new Error("expected a known plugin with a helpGroup");
+		const root = await writeFixture(tempDir, {
+			peerVersion: "^0.100.0",
+			pluginId: known.id,
+			pluginSource:
+				"export const register = (ctx) => { ctx.program.command('plugin-grouped').action(() => {}); };",
+		});
+		const program = new Command();
+		program.command("preexisting").action(() => {});
+		await loadPlugins(program, "0.100.0", {
+			rootsOverride: [root],
+			allowlistOverride: [known.id],
+			scopesOverride: [FIXTURE_SCOPE],
+		});
+		const pre = program.commands.find((c) => c.name() === "preexisting");
+		const added = program.commands.find((c) => c.name() === "plugin-grouped");
+		expect(pre && getHelpGroup(pre)).toBeUndefined();
+		expect(added && getHelpGroup(added)).toBe(known.helpGroup);
+	});
+
+	it("recovers when an unexpected error escapes the per-site handlers (outer catch)", async () => {
+		// L838 outer safety net: a throw outside the inner import/register try
+		// blocks (here from the help-group tagging step) must still be caught so
+		// loadPlugins keeps iterating and the CLI keeps running.
+		const known = KNOWN_PLUGINS.find((p) => p.helpGroup);
+		if (!known) throw new Error("expected a known plugin with a helpGroup");
+		const root = await writeFixture(tempDir, {
+			peerVersion: "^0.100.0",
+			pluginId: known.id,
+			pluginSource:
+				"export const register = (ctx) => { ctx.program.command('plugin-late-throw').action(() => {}); };",
+		});
+		const spy = vi.spyOn(HelpGroups, "setHelpGroup").mockImplementation(() => {
+			throw new Error("setHelpGroup boom");
+		});
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const program = new Command();
+			const { loaded } = await loadPlugins(program, "0.100.0", {
+				rootsOverride: [root],
+				allowlistOverride: [known.id],
+				scopesOverride: [FIXTURE_SCOPE],
+			});
+			// The unexpected throw lands in the outer catch → not loaded, no crash.
+			expect(loaded.has(known.id)).toBe(false);
+			const calls = warnSpy.mock.calls.map((c) => String(c[0])).join("\n");
+			expect(calls).toContain("unexpected loader error");
+		} finally {
+			spy.mockRestore();
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("tolerates a plugin command registered with an empty leading token", async () => {
+		// L948 false branch: `.command(" <arg>")` yields an empty base name after
+		// the leading-whitespace split, so the conflict short-circuit and the
+		// occupiedNames bookkeeping are both skipped. The loader must not crash and
+		// must still register the plugin's other, well-named command.
+		const root = await writeFixture(tempDir, {
+			pluginSource: `export const register = (ctx) => {
+				ctx.program.command(' <arg>');
+				ctx.program.command('plugin-after-empty').action(() => {});
+			};`,
+		});
+		const program = new Command();
+		await loadPlugins(program, "0.100.0", {
+			rootsOverride: [root],
+			allowlistOverride: [FIXTURE_ID],
+			scopesOverride: [FIXTURE_SCOPE],
+		});
+		expect(program.commands.find((c) => c.name() === "plugin-after-empty")).toBeDefined();
+	});
+
+	it("registers an addCommand payload whose aliases extend the occupied namespace", async () => {
+		// L981/L963-false: a non-conflicting addCommand payload carrying an alias
+		// flows through to Commander and its alias is added to occupiedNames, so a
+		// later plugin command reusing that alias-name is blocked.
+		const root = await writeFixture(tempDir, {
+			pluginSource: `export const register = (ctx) => {
+				const Cmd = ctx.program.constructor;
+				const c = new Cmd('plugin-add-aliased');
+				c.alias('fresh-add-alias');
+				ctx.program.addCommand(c);
+				ctx.program.command('fresh-add-alias').action(() => {});
+				ctx.program.command('plugin-after-add-alias').action(() => {});
+			};`,
+		});
+		const program = new Command();
+		await loadPlugins(program, "0.100.0", {
+			rootsOverride: [root],
+			allowlistOverride: [FIXTURE_ID],
+			scopesOverride: [FIXTURE_SCOPE],
+		});
+		const names = program.commands.map((c) => c.name());
+		expect(names).toContain("plugin-add-aliased");
+		// The later `.command('fresh-add-alias')` collides with the alias just
+		// claimed via addCommand, so it is dropped.
+		expect(names).not.toContain("fresh-add-alias");
+		expect(names).toContain("plugin-after-add-alias");
+	});
+
+	it("tolerates an addCommand payload whose aliases is not a function", async () => {
+		// L969 false branch: the patched addCommand guards `cmd.aliases` with a
+		// `typeof ... === "function"` check before calling it. When it is not a
+		// function (an unusual subclass / fixture), the alias list falls back to
+		// `[]` instead of throwing inside the loader's own conflict pre-check.
+		// Commander itself still rejects the malformed command downstream, so the
+		// register() aborts there — but the earlier command stays (partial
+		// registration) and the loader never crashes.
+		const root = await writeFixture(tempDir, {
+			pluginSource: `export const register = (ctx) => {
+				const Cmd = ctx.program.constructor;
+				ctx.program.command('plugin-before-weird').action(() => {});
+				const weird = new Cmd('plugin-weird-aliases');
+				weird.aliases = 'not-a-function';
+				ctx.program.addCommand(weird);
+				ctx.program.command('plugin-after-weird').action(() => {});
+			};`,
+		});
+		const program = new Command();
+		const { loaded } = await loadPlugins(program, "0.100.0", {
+			rootsOverride: [root],
+			allowlistOverride: [FIXTURE_ID],
+			scopesOverride: [FIXTURE_SCOPE],
+		});
+		const names = program.commands.map((c) => c.name());
+		// The command registered before the malformed addCommand survives.
+		expect(names).toContain("plugin-before-weird");
+		// Commander rejected the malformed payload, aborting the rest of register().
+		expect(loaded.has(FIXTURE_ID)).toBe(false);
+		expect(names).not.toContain("plugin-after-weird");
+	});
+
+	it("restores own-property command/addCommand after register() (does not delete them)", async () => {
+		// L989/L994 true branches: when `program.command` / `program.addCommand`
+		// were own-properties before patching (e.g. a prior layer shadowed the
+		// prototype), restore must re-assign the originals rather than `delete`
+		// them — otherwise the outer layer's overrides would be lost.
+		const program = new Command();
+		const origCommand = program.command.bind(program);
+		const origAddCommand = program.addCommand.bind(program);
+		const internal = program as unknown as {
+			command: typeof program.command;
+			addCommand: typeof program.addCommand;
+		};
+		// Make both own-properties so `hadOwnCommand` / `hadOwnAddCommand` are true.
+		internal.command = origCommand as typeof program.command;
+		internal.addCommand = origAddCommand as typeof program.addCommand;
+		const root = await writeFixture(tempDir, {
+			pluginSource:
+				"export const register = (ctx) => { ctx.program.command('plugin-own-prop').action(() => {}); };",
+		});
+		await loadPlugins(program, "0.100.0", {
+			rootsOverride: [root],
+			allowlistOverride: [FIXTURE_ID],
+			scopesOverride: [FIXTURE_SCOPE],
+		});
+		// The own-properties survive and point back at the originals.
+		expect(Object.getOwnPropertyDescriptor(program, "command")?.value).toBe(origCommand);
+		expect(Object.getOwnPropertyDescriptor(program, "addCommand")?.value).toBe(origAddCommand);
+		expect(program.commands.find((c) => c.name() === "plugin-own-prop")).toBeDefined();
+	});
+
+	it("logs symlink forensics only when the link resolves outside the walked roots", async () => {
+		// L655 false branch: a symlink whose realpath stays inside a walked root is
+		// the benign workspace case — no out-of-roots breadcrumb is emitted. The
+		// existing symlink test covers the outside-roots (true) branch.
+		const realPkgRoot = join(tempDir, "node_modules", FIXTURE_SCOPE, "real-plugin");
+		await mkdir(join(realPkgRoot, "dist"), { recursive: true });
+		await writeFile(
+			join(realPkgRoot, "package.json"),
+			JSON.stringify({
+				name: `${FIXTURE_SCOPE}/real-plugin`,
+				version: "0.1.0",
+				type: "module",
+				main: "./dist/Plugin.js",
+				jolliPluginId: FIXTURE_ID,
+			}),
+			"utf-8",
+		);
+		await writeFile(
+			join(realPkgRoot, "dist", "Plugin.js"),
+			"export const register = (ctx) => { ctx.program.command('plugin-inside-symlink').action(() => {}); };",
+			"utf-8",
+		);
+		const nodeModules = join(tempDir, "node_modules");
+		// Symlink under the SAME node_modules root, pointing at the sibling package
+		// that also lives inside that root — so realpath is within the walked root.
+		await symlink(realPkgRoot, join(nodeModules, FIXTURE_SCOPE, "a-link"), "dir");
+
+		// macOS resolves `/var/folders/...` (from mkdtemp) to `/private/var/...`
+		// when `realpath` follows the symlink. Pass the realpath-resolved root so
+		// the loader's `insideAnyRoot` check sees the resolved target as inside it
+		// (otherwise the comparison would spuriously land on the outside-roots
+		// branch the existing symlink test already covers).
+		const realNodeModules = await realpath(nodeModules);
+		const program = new Command();
+		await loadPlugins(program, "0.100.0", {
+			rootsOverride: [realNodeModules],
+			allowlistOverride: [FIXTURE_ID],
+			scopesOverride: [FIXTURE_SCOPE],
+		});
+		// `a-link` sorts before `real-plugin`, so the symlink wins the same-ID race;
+		// either way the command registers and the loader did not crash.
+		expect(program.commands.find((c) => c.name() === "plugin-inside-symlink")).toBeDefined();
+	});
+
+	it("picks the lexicographically first across more than two same-ID packages", async () => {
+		// Behavioral check that the byte-order sort makes "first match wins"
+		// deterministic regardless of readdir order: `a-plugin` beats `m-plugin`
+		// and `z-plugin`. (The comparator branches themselves are covered
+		// deterministically by the compareDirentNames unit tests below.)
+		const root = await writeFixture(tempDir, {
+			name: `${FIXTURE_SCOPE}/m-plugin`,
+			pluginSource: "export const register = (ctx) => { ctx.program.command('plugin-m').action(() => {}); };",
+		});
+		for (const short of ["a-plugin", "z-plugin"]) {
+			const dir = join(root, FIXTURE_SCOPE, short);
+			await mkdir(join(dir, "dist"), { recursive: true });
+			await writeFile(
+				join(dir, "package.json"),
+				JSON.stringify({
+					name: `${FIXTURE_SCOPE}/${short}`,
+					version: "0.1.0",
+					type: "module",
+					main: "./dist/Plugin.js",
+					jolliPluginId: FIXTURE_ID,
+				}),
+				"utf-8",
+			);
+			await writeFile(
+				join(dir, "dist", "Plugin.js"),
+				`export const register = (ctx) => { ctx.program.command('plugin-${short}').action(() => {}); };`,
+				"utf-8",
+			);
+		}
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const program = new Command();
+			await loadPlugins(program, "0.100.0", {
+				rootsOverride: [root],
+				allowlistOverride: [FIXTURE_ID],
+				scopesOverride: [FIXTURE_SCOPE],
+			});
+			const names = program.commands.map((c) => c.name());
+			expect(names).toContain("plugin-a-plugin");
+			expect(names).not.toContain("plugin-m");
+			expect(names).not.toContain("plugin-z-plugin");
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("uses the default global-root resolver when getGlobalRoot is not injected", async () => {
+		// L466 + the default `() => getNpmRootGlobal()` arrow: with no rootsOverride
+		// and no getGlobalRoot, resolveRoots falls back to the real npm-root
+		// resolver. Running from a clean cwd means no fixture matches, so nothing
+		// loads — we only need the default resolver path to execute.
+		const cleanCwd = await mkdtemp(join(tmpdir(), "clean-cwd-default-global-"));
+		const origCwd = process.cwd();
+		process.chdir(cleanCwd);
+		try {
+			const program = new Command();
+			await loadPlugins(program, "0.100.0", {
+				allowlistOverride: [FIXTURE_ID],
+				scopesOverride: [FIXTURE_SCOPE],
+			});
+			expect(program.commands.find((c) => c.name() === "should-not-load")).toBeUndefined();
+		} finally {
+			process.chdir(origCwd);
+			await rm(cleanCwd, { recursive: true, force: true });
+		}
+	});
 });
 
 describe("getNpmRootGlobal", () => {
@@ -1491,6 +1779,26 @@ describe("getNpmRootGlobal", () => {
 		// Still returns the runtime path even if cache write fails
 		expect(result).toBe("/runtime/path");
 	});
+
+	it("defaults the runNpm resolver without spawning npm on a fresh cache hit", async () => {
+		// Omitting `runNpm` exercises the `opts?.runNpm ?? runNpmRootGlobal`
+		// default branch. A fresh cache hit returns before the resolver is ever
+		// invoked, so the real `npm root -g` subprocess is never spawned.
+		const cacheFile = join(tempDir, "cache");
+		await writeFile(cacheFile, "/cached/no-subprocess", "utf-8");
+		const result = await getNpmRootGlobal({ cacheFile, ttlMs: 60 * 60 * 1000 });
+		expect(result).toBe("/cached/no-subprocess");
+	});
+
+	it("defaults the cache file path when none is supplied", async () => {
+		// Omitting `cacheFile` exercises the `opts?.cacheFile ?? getNpmRootCacheFile()`
+		// default branch (and getNpmRootCacheFile itself). `runNpm` is stubbed to
+		// return null so no real subprocess runs and nothing is written to the real
+		// global-root cache. The result may be a real cached path (if one exists and
+		// is fresh) or null — either is acceptable; we only assert the type contract.
+		const result = await getNpmRootGlobal({ runNpm: async () => null, ttlMs: 1 });
+		expect(result === null || typeof result === "string").toBe(true);
+	});
 });
 
 describe("inspectPlugins", () => {
@@ -1559,6 +1867,32 @@ describe("inspectPlugins", () => {
 			installedVersion: "0.4.2",
 			peerRange: ">=2.0.0",
 		});
+	});
+
+	it("omits installedVersion when the package.json version is not a string", async () => {
+		// L322 false branch: JSON.parse can hand back a non-string `version`
+		// (number, array, …). diagnoseFound must report `installedVersion` as
+		// undefined rather than coercing it.
+		const pkgDir = join(tempDir, "node_modules", FIXTURE_SCOPE, "example-plugin");
+		await mkdir(pkgDir, { recursive: true });
+		await writeFile(
+			join(pkgDir, "package.json"),
+			JSON.stringify({
+				name: FIXTURE_NAME,
+				version: 123,
+				type: "module",
+				main: "./dist/Plugin.js",
+				jolliPluginId: FIXTURE_ID,
+			}),
+			"utf-8",
+		);
+		const diagnostics = await inspectPlugins("1.0.0", {
+			rootsOverride: [join(tempDir, "node_modules")],
+			scopesOverride: [FIXTURE_SCOPE],
+			knownPluginsOverride: KNOWN,
+		});
+		expect(diagnostics[0]).toMatchObject({ state: "ok" });
+		expect(diagnostics[0].installedVersion).toBeUndefined();
 	});
 
 	it("treats a plugin with no peerDependencies as ok", async () => {
@@ -1651,6 +1985,55 @@ describe("loadPlugins diagnostics", () => {
 	});
 });
 
+describe("registerMissingStubs", () => {
+	beforeEach(() => {
+		delete process.env.JOLLI_NO_PLUGIN_WARNINGS;
+	});
+
+	afterEach(() => {
+		delete process.env.JOLLI_NO_PLUGIN_WARNINGS;
+	});
+
+	it("registers stubs for known plugins not in the loaded set", () => {
+		// L222 false branch + L224: an empty loaded set means every known plugin
+		// with a registerStub gets its stub installed, so its commands appear in
+		// `--help`.
+		const program = new Command();
+		registerMissingStubs(program, new Set());
+		// Every known plugin that declares a stub contributes at least one command.
+		const withStub = KNOWN_PLUGINS.filter((p) => p.registerStub);
+		expect(withStub.length).toBeGreaterThan(0);
+		expect(program.commands.length).toBeGreaterThan(0);
+	});
+
+	it("skips known plugins already present in the loaded set", () => {
+		// L222 true branch: a plugin whose ID is in the loaded set is loaded for
+		// real, so its stub must not be installed.
+		const program = new Command();
+		const allLoaded = new Set(KNOWN_PLUGINS.map((p) => p.id));
+		registerMissingStubs(program, allLoaded);
+		expect(program.commands).toHaveLength(0);
+	});
+
+	it("does not tear down the host when a stub registration throws", () => {
+		// L228 catch: a throwing stub must be caught and warned, not propagated.
+		// Forcing `program.command` to throw makes every stub's registration throw.
+		const program = new Command();
+		const internal = program as unknown as { command: () => Command };
+		internal.command = () => {
+			throw new Error("stub command boom");
+		};
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			expect(() => registerMissingStubs(program, new Set())).not.toThrow();
+			const calls = warnSpy.mock.calls.map((c) => String(c[0])).join("\n");
+			expect(calls).toContain("stub registration failed");
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+});
+
 describe("findNodeModulesRoot", () => {
 	// Pure walk used by the self-install discovery root (JOLLI-1694). Inputs use
 	// forward slashes, which both `path.posix` (CI runners) and `path.win32`
@@ -1679,5 +2062,31 @@ describe("findNodeModulesRoot", () => {
 
 	it("returns null at the filesystem root", () => {
 		expect(findNodeModulesRoot("/")).toBeNull();
+	});
+
+	it("returns null for a rootless relative path with no node_modules", () => {
+		// A relative input has an empty `parse().root`, so the `dir !== fsRoot`
+		// loop guard never trips. The walk relies on `dirname` non-progress
+		// (`dirname(".") === "."`) to terminate — exercising that break branch.
+		expect(findNodeModulesRoot("a/b/c")).toBeNull();
+	});
+});
+
+describe("compareDirentNames", () => {
+	// Deterministic byte-order comparator that drives the "first match wins"
+	// sort in discoverPlugins. Tested directly so both ordering branches are
+	// exercised without depending on the filesystem's (nondeterministic)
+	// readdir order.
+
+	it("returns -1 when the first name sorts before the second", () => {
+		expect(compareDirentNames("a-plugin", "z-plugin")).toBe(-1);
+	});
+
+	it("returns 1 when the first name sorts after the second", () => {
+		expect(compareDirentNames("z-plugin", "a-plugin")).toBe(1);
+	});
+
+	it("orders an array lexicographically by byte value", () => {
+		expect(["z", "a", "m"].sort(compareDirentNames)).toEqual(["a", "m", "z"]);
 	});
 });

--- a/cli/src/PluginLoader.ts
+++ b/cli/src/PluginLoader.ts
@@ -46,7 +46,7 @@ import type { PluginContext, PluginRegister } from "./Api.js";
 import { setHelpGroup } from "./commands/HelpGroups.js";
 import { getGlobalConfigDir } from "./core/SessionTracker.js";
 import { KNOWN_PLUGINS, type KnownPlugin } from "./KnownPlugins.js";
-import { createLogger } from "./Logger.js";
+import { createLogger, errMsg } from "./Logger.js";
 import { runNpmCommand } from "./util/Subprocess.js";
 
 const log = createLogger("PluginLoader");
@@ -225,7 +225,7 @@ export function registerMissingStubs(program: Command, loadedPluginIds: Readonly
 		} catch (err) {
 			// A throwing stub should never tear down the host — same
 			// non-fatal contract as a throwing plugin `register()`.
-			warn(`${known.packageName} stub registration failed: ${errMessage(err)}`);
+			warn(`${known.packageName} stub registration failed: ${errMsg(err)}`);
 		}
 	}
 }
@@ -413,7 +413,12 @@ async function resolveRoots(opts?: LoadPluginsOptions): Promise<ReadonlyArray<st
 			if (existsSync(join(dir, ".git"))) return dir;
 			if (dir === fsRoot) return null;
 			const parent = dirname(dir);
+			// Defensive: `cwd` is always absolute, so `dirname` stabilizes exactly at
+			// `fsRoot` and the `dir === fsRoot` check above always fires first — this
+			// guard against `dirname` non-progress is never reached in production.
+			/* v8 ignore start -- unreachable: dirname stabilizes at fsRoot for absolute cwd */
 			if (parent === dir) return null;
+			/* v8 ignore stop */
 			dir = parent;
 		}
 	};
@@ -432,7 +437,12 @@ async function resolveRoots(opts?: LoadPluginsOptions): Promise<ReadonlyArray<st
 		}
 		if (dir === boundary) break;
 		const parent = dirname(dir);
+		// Defensive: for an absolute `cwd`, `dirname` stabilizes at `fsRoot`, which
+		// is outside any `boundary` (so `isWithinBoundary` exits the loop first) or
+		// equals `boundary` (caught above) — the non-progress guard is never reached.
+		/* v8 ignore start -- unreachable: walk exits via boundary/isWithinBoundary for absolute cwd */
 		if (parent === dir) break;
+		/* v8 ignore stop */
 		dir = parent;
 	}
 
@@ -510,6 +520,25 @@ function defaultSelfInstallRoot(): string | null {
 /* v8 ignore stop */
 
 /**
+ * Byte-order comparator for two scope-directory entry names, used to make the
+ * "first match wins" rule deterministic across filesystems (`readdir`'s native
+ * order is inode-allocation on ext4, undefined on APFS, and varies per FS).
+ *
+ * Plain `<`/`>` is a byte-order comparison (not locale-sensitive), so the
+ * winner is the same regardless of the runner's `LC_COLLATE` —
+ * `localeCompare` without a fixed locale would otherwise reorder names
+ * containing case or punctuation between machines.
+ *
+ * `readdir` never returns two entries with the same name in one directory, so a
+ * strict `<` split is a correct total order here; the equal case can't fire and
+ * is not represented. Exported so the order invariant is unit-testable without
+ * depending on the filesystem's `readdir` ordering.
+ */
+export function compareDirentNames(a: string, b: string): number {
+	return a < b ? -1 : 1;
+}
+
+/**
  * Walk the given roots, scan each known scope directory, and return the first
  * matching package directory per allow-listed plugin ID.
  *
@@ -562,11 +591,8 @@ async function discoverPlugins(
 
 			// Sort for deterministic "first match wins". Without this, two packages
 			// declaring the same ID would race on the underlying filesystem order.
-			// Plain `<`/`>` is a byte-order comparison (not locale-sensitive), so
-			// the winner is the same regardless of the runner's `LC_COLLATE` —
-			// `localeCompare(b.name)` without a fixed locale would otherwise
-			// reorder names containing case or punctuation between machines.
-			entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+			// See {@link compareDirentNames} for the byte-order rationale.
+			entries.sort((a, b) => compareDirentNames(a.name, b.name));
 
 			// Per-scope+root dedupe. Used to detect two packages claiming the same
 			// ID at the same depth (the unstable-migration case the comment above
@@ -615,11 +641,7 @@ async function discoverPlugins(
 					// Compromise: leave a debug breadcrumb (only surfaced with
 					// debug logging on) recording the path + parse error, matching
 					// the symlink-forensics `log.debug` pattern below. Then skip.
-					log.debug(
-						`skipping ${scope}/${entry.name}: unreadable/invalid package.json (${
-							err instanceof Error ? err.message : String(err)
-						})`,
-					);
+					log.debug(`skipping ${scope}/${entry.name}: unreadable/invalid package.json (${errMsg(err)})`);
 					continue;
 				}
 
@@ -662,7 +684,7 @@ async function discoverPlugins(
 						// debug breadcrumb — same rationale as `runNpmRootGlobal`.
 						/* v8 ignore start */
 						log.debug(
-							`plugin symlink ${scope}/${entry.name} realpath failed (${errMessage(err)}) — loading without audit trail`,
+							`plugin symlink ${scope}/${entry.name} realpath failed (${errMsg(err)}) — loading without audit trail`,
 						);
 						/* v8 ignore stop */
 					}
@@ -757,7 +779,7 @@ async function loadOnePlugin(program: Command, cliVersion: string, plugin: Found
 		try {
 			mod = await import(pathToFileURL(entryAbs).href);
 		} catch (err) {
-			warn(`${name} failed to load: ${errMessage(err)}`);
+			warn(`${name} failed to load: ${errMsg(err)}`);
 			return false;
 		}
 
@@ -796,7 +818,7 @@ async function loadOnePlugin(program: Command, cliVersion: string, plugin: Found
 		try {
 			await mod.register(ctx);
 		} catch (err) {
-			warn(`${name} register() threw: ${errMessage(err)}`);
+			warn(`${name} register() threw: ${errMsg(err)}`);
 			return false;
 		} finally {
 			restoreCommand();
@@ -825,19 +847,9 @@ async function loadOnePlugin(program: Command, cliVersion: string, plugin: Found
 		// (e.g. malformed JSON yielding pkg.main as an array, a buggy fs
 		// implementation throwing on existsSync) lands here so loadPlugins
 		// keeps iterating and the CLI keeps running.
-		warn(`${name} unexpected loader error: ${errMessage(err)}`);
+		warn(`${name} unexpected loader error: ${errMsg(err)}`);
 		return false;
 	}
-}
-
-/**
- * Stringify an unknown thrown value for diagnostic warnings. Plugins are
- * untrusted code — `throw "boom"` and `throw null` would otherwise render as
- * `(err as Error).message === undefined`, losing the only signal the operator
- * has for tracking down a misbehaving plugin.
- */
-function errMessage(err: unknown): string {
-	return err instanceof Error ? err.message : String(err);
 }
 
 /**

--- a/cli/src/commands/CompileCommand.test.ts
+++ b/cli/src/commands/CompileCommand.test.ts
@@ -49,14 +49,22 @@ vi.mock("../Logger.js", () => ({
 vi.mock("../sync/SyncBootstrap.js", () => ({
 	deriveMemoryBankRoot: vi.fn((localFolder: string | undefined) => localFolder ?? "/mb"),
 }));
-vi.mock("../sync/VaultWriteLock.js", () => ({
-	DEFAULT_VAULT_WRITE_WAIT_MS: 60_000,
-	// Default: lock free → run the body and surface its value.
-	withVaultWriteLock: vi.fn(async (_root: string, _mode: unknown, body: () => Promise<unknown>) => ({
-		ran: true,
-		value: await body(),
-	})),
-}));
+vi.mock("../sync/VaultWriteLock.js", async (importOriginal) => {
+	// Keep the real `VaultWriteBusyError` so the production `instanceof` check
+	// (busy → clean exit vs real error → propagate) is exercised faithfully; only
+	// the lock acquisition itself is stubbed.
+	const actual = await importOriginal<typeof import("../sync/VaultWriteLock.js")>();
+	return {
+		...actual,
+		DEFAULT_VAULT_WRITE_WAIT_MS: 60_000,
+		// Default: lock free → run the body and surface its value.
+		withVaultWriteLock: vi.fn(async (_root: string, _mode: unknown, body: () => Promise<unknown>) => ({
+			ran: true,
+			value: await body(),
+		})),
+	};
+});
+vi.mock("../hooks/QueueWorker.js", () => ({ launchWorker: vi.fn() }));
 
 import { drainIngest } from "../core/IngestPipeline.js";
 import { appendCredentialMissingRun } from "../core/IngestRunStore.js";
@@ -130,14 +138,6 @@ describe("registerCompileCommand", () => {
 		expect(stdout).toContain("jolli");
 	});
 
-	it("sweep skipped (another compile running): prints skip note, no per-repo output", async () => {
-		mockCompileAllRepos.mockResolvedValue({ repos: [], totalIngested: 0, failed: 0, skipped: true });
-		const { stdout } = await runCompile([]);
-		expect(stdout).toContain("Another compile is already running");
-		expect(stdout).not.toContain("Done:");
-		expect(process.exitCode).not.toBe(1);
-	});
-
 	it("sweep with no localFolder: error + exitCode=1", async () => {
 		mockLoadConfig.mockResolvedValue({ apiKey: "test" } as never);
 		const { stderr } = await runCompile([]);
@@ -171,19 +171,91 @@ describe("registerCompileCommand", () => {
 		expect(stdout).toContain("3 source(s)");
 	});
 
-	it("--cwd: runs the drain under the canonical vault-write lock (wait mode)", async () => {
+	it("--cwd: drains with a per-write writeGuard (lock released during the LLM phase, not held across the whole drain)", async () => {
 		await runCompile(["--cwd", "/repo"]);
-		expect(withVaultWriteLock).toHaveBeenCalledWith("/mb", { wait: 60_000 }, expect.any(Function));
+		// The key contract: drainIngest gets a writeGuard so its reconcile LLM phase
+		// runs UNLOCKED and only re-acquires the lock per write — a concurrent
+		// commit-summary worker can interleave and generate its memory promptly.
+		expect(mockDrainIngest).toHaveBeenCalledWith(
+			"/repo",
+			expect.anything(),
+			expect.objectContaining({ triggeredBy: "manual", writeGuard: expect.any(Function) }),
+		);
+		// And that guard acquires the canonical vault lock in wait-mode with the
+		// pending-worker wakeup hook (4th arg).
+		expect(withVaultWriteLock).toHaveBeenCalledWith("/mb", { wait: 60_000 }, expect.any(Function), {
+			launch: expect.any(Function),
+		});
 	});
 
-	it("--cwd: another vault writer busy → error, exitCode=1, no drain/render", async () => {
-		// Lock held by a worker/sync → body never runs.
+	it("--cwd: a per-write guard that can't acquire the lock (ran:false) surfaces as a non-fatal warn, compile still completes", async () => {
+		// The single writeGuard call on a non-rebuild compile is the search-index
+		// warm-up; a busy lock makes withVaultWriteLock report ran:false, so the
+		// guard throws "could not acquire vault-write.lock". That throw is the
+		// disposable-cache catch's concern — it must NOT fail the compile.
 		vi.mocked(withVaultWriteLock).mockResolvedValueOnce({ ran: false });
-		const { stderr } = await runCompile(["--cwd", "/repo"]);
-		expect(stderr).toContain("another vault writer");
+		const { stdout } = await runCompile(["--cwd", "/repo"]);
+		expect(stdout).toContain("Done:");
+		expect(process.exitCode).not.toBe(1);
+	});
+
+	it("--cwd: a non-Error thrown from the guarded search-index warm-up is stringified, still non-fatal", async () => {
+		// The search-index warm-up is wrapped in a disposable-cache catch that
+		// stringifies a non-Error throw (`String(idxErr)`). A throw from the guard
+		// body propagates as-is, so a non-Error value exercises that branch.
+		vi.mocked(withVaultWriteLock).mockImplementationOnce(async () => {
+			throw "orama exploded (string, not Error)";
+		});
+		const { stdout } = await runCompile(["--cwd", "/repo"]);
+		expect(stdout).toContain("Done:");
+		expect(process.exitCode).not.toBe(1);
+	});
+
+	it("--cwd --rebuild: store reset can't acquire the lock → clean 'busy' exit (exitCode=1), drain skipped, no uncaught throw", async () => {
+		// On --rebuild the FIRST writeGuard call is the store reset (processed-set +
+		// index). A busy lock makes withVaultWriteLock report ran:false, so the guard
+		// throws VaultWriteBusyError. The reset is a real prerequisite — without it
+		// the drain runs against the OLD index and is silently NOT a rebuild — so this
+		// must surface as a clean retry-later exit, not an uncaught stack trace.
+		vi.mocked(withVaultWriteLock).mockResolvedValueOnce({ ran: false });
+		const { stderr } = await runCompile(["--cwd", "/repo", "--rebuild"]);
+		expect(stderr).toMatch(/busy/i);
 		expect(process.exitCode).toBe(1);
 		expect(mockDrainIngest).not.toHaveBeenCalled();
-		expect(mockRenderTopicKBWiki).not.toHaveBeenCalled();
+	});
+
+	it("--cwd --rebuild: a non-lock error during store reset propagates (not swallowed as 'busy')", async () => {
+		// A real write failure (disk, corruption) is NOT a VaultWriteBusyError, so the
+		// busy-exit catch must rethrow it rather than masquerade it as lock contention.
+		mockSaveTopicIndex.mockRejectedValueOnce(new Error("disk full"));
+		await expect(runCompile(["--cwd", "/repo", "--rebuild"])).rejects.toThrow("disk full");
+	});
+
+	it("--cwd: render lock contention is non-fatal — the ingest already persisted, command still reports Done", async () => {
+		// drainIngest swallows its own lock contention (sources held / pending), so by
+		// the time the derived Markdown re-render runs the data is already on the orphan
+		// branch. A busy lock on render must NOT fail the whole command (matches the
+		// QueueWorker unlocked-ingest catch + the search-index disposable-cache catch).
+		mockRenderTopicKBWiki.mockImplementationOnce(
+			async (_cwd: string, _storage: unknown, guard?: (fn: () => Promise<void>) => Promise<void>) => {
+				await guard?.(async () => {});
+			},
+		);
+		vi.mocked(withVaultWriteLock).mockResolvedValueOnce({ ran: false }); // render's per-write guard
+		const { stdout } = await runCompile(["--cwd", "/repo"]);
+		expect(stdout).toContain("Done:");
+		expect(process.exitCode).not.toBe(1);
+	});
+
+	it("--cwd --rebuild: a purge that can't acquire the lock is non-fatal — orphan pages are reclaimed on the next rebuild", async () => {
+		// On --rebuild the guard call order is reset → (drain, no guard) → purge →
+		// (render, no guard) → search-index. Make only the purge call busy.
+		vi.mocked(withVaultWriteLock)
+			.mockResolvedValueOnce({ ran: true, value: undefined }) // store reset
+			.mockResolvedValueOnce({ ran: false }); // purge
+		const { stdout } = await runCompile(["--cwd", "/repo", "--rebuild"]);
+		expect(stdout).toContain("Done:");
+		expect(process.exitCode).not.toBe(1);
 	});
 
 	it("--cwd --rebuild resets stores before drain", async () => {
@@ -243,21 +315,29 @@ describe("registerCompileCommand", () => {
 		expect(vi.mocked(appendCredentialMissingRun)).toHaveBeenCalledWith("/repo", "manual");
 	});
 
-	it("--cwd: passes the index's stable slugs to the topic-page purge", async () => {
-		// The slug-mapping callback in the `purgeTopicPagesExcept(index.topics.map(...))`
-		// call only executes when the index is non-empty. The default mock returns an
-		// empty `topics` array, leaving that arrow uncovered; a populated index exercises
-		// it and pins the convergence contract (keep exactly the indexed slugs).
+	it("--cwd --rebuild: purges to the index's stable slugs (purge runs ONLY on rebuild)", async () => {
+		// Purge is gated to --rebuild: a routine compile must not purge (a concurrent
+		// ingest could have added a page not yet in our index snapshot — deleting it
+		// would be data loss). The slug-mapping callback only runs on a non-empty index.
 		vi.mocked(readTopicIndex).mockResolvedValueOnce({
 			schemaVersion: 1,
 			topics: [{ stableSlug: "auth-flow" }, { stableSlug: "storage-layer" }],
 		} as never);
-		await runCompile(["--cwd", "/repo"]);
+		await runCompile(["--cwd", "/repo", "--rebuild"]);
 		expect(vi.mocked(purgeTopicPagesExcept)).toHaveBeenCalledWith(
 			["auth-flow", "storage-layer"],
 			"/repo",
 			expect.anything(),
 		);
+	});
+
+	it("--cwd (no rebuild): does NOT purge (avoids deleting a page a concurrent ingest just added)", async () => {
+		vi.mocked(readTopicIndex).mockResolvedValueOnce({
+			schemaVersion: 1,
+			topics: [{ stableSlug: "auth-flow" }],
+		} as never);
+		await runCompile(["--cwd", "/repo"]);
+		expect(vi.mocked(purgeTopicPagesExcept)).not.toHaveBeenCalled();
 	});
 
 	it("--cwd: prints the outcome code and held topics in the summary", async () => {
@@ -270,6 +350,10 @@ describe("registerCompileCommand", () => {
 		const { stdout } = await runCompile(["--cwd", "/repo"]);
 		expect(stdout).toContain("[OK]");
 		expect(stdout).toContain("held (RECONCILE_TRUNCATED)");
-		expect(mockDrainIngest).toHaveBeenCalledWith("/repo", expect.anything(), { triggeredBy: "manual" });
+		expect(mockDrainIngest).toHaveBeenCalledWith(
+			"/repo",
+			expect.anything(),
+			expect.objectContaining({ triggeredBy: "manual" }),
+		);
 	});
 });

--- a/cli/src/commands/CompileCommand.ts
+++ b/cli/src/commands/CompileCommand.ts
@@ -24,7 +24,7 @@ import { renderTopicKBWiki } from "../core/TopicWikiRenderer.js";
 import { buildKnowledgeGraph } from "../graph/GraphBuilder.js";
 import { createLogger, setLogDir } from "../Logger.js";
 import { deriveMemoryBankRoot } from "../sync/SyncBootstrap.js";
-import { DEFAULT_VAULT_WRITE_WAIT_MS, withVaultWriteLock } from "../sync/VaultWriteLock.js";
+import { DEFAULT_VAULT_WRITE_WAIT_MS, VaultWriteBusyError, withVaultWriteLock } from "../sync/VaultWriteLock.js";
 
 const log = createLogger("CompileCommand");
 
@@ -47,71 +47,133 @@ async function compileSingleRepo(cwd: string, rebuild: boolean): Promise<void> {
 	const previousStorage = getActiveStorage();
 	setActiveStorage(storage);
 	try {
-		// Serialise on the same `vault-write.lock` the background QueueWorker holds for
-		// its ingest drain. Without it, a manual compile racing a post-commit worker
-		// lost-updates `topics/index.json` and the `drainIngest → readTopicIndex →
-		// purgeTopicPagesExcept` window can delete a topic page the worker just wrote.
-		// Wait mode (not fail-fast): the user explicitly asked to compile, so yield to
-		// a busy worker/sync rather than skip outright.
+		// Per-write `vault-write.lock` instead of one lock held across the whole drain:
+		// the long reconcile LLM phase runs UNLOCKED and only each persistence call
+		// re-acquires the lock briefly, so a concurrent commit-summary worker can grab
+		// the lock between our writes and generate its summary promptly (commit memory
+		// is high-priority; "build wiki" can proceed slowly). This mirrors the
+		// QueueWorker unlocked-ingest phase. Data safety is preserved by drainIngest's
+		// own guarded-write phase: topic pages re-read + compare before write (no
+		// clobber), the index + processed-set are RMW under the same guard (no
+		// lost-update). The releaseHook wakes any worker that still timed out waiting
+		// on us (defense-in-depth — see VaultWriteLock).
 		const vaultRoot = deriveMemoryBankRoot(config.localFolder);
-		const result = await withVaultWriteLock(vaultRoot, { wait: DEFAULT_VAULT_WRITE_WAIT_MS }, async () => {
-			if (rebuild) {
-				// Reset the watermark + index only. An empty index makes route treat every
-				// topic as new, so reconcile gets current=null (clean rebuild).
-				console.log("\n  Rebuilding knowledge base from scratch...");
-				await saveProcessedSet(emptyProcessedSet(), cwd);
-				await saveTopicIndex(emptyTopicIndex(), cwd);
-			} else {
-				console.log("\n  Ingesting pending sources into the knowledge base...");
-			}
+		// `launchWorker` is imported lazily so this command's module load (at CLI
+		// startup, via registerCompileCommand) doesn't eagerly pull QueueWorker's
+		// transcript-reader/detector graph in. A busy miss throws VaultWriteBusyError
+		// (caught for the rebuild prerequisite below).
+		const { launchWorker } = await import("../hooks/QueueWorker.js");
+		const writeGuard = async (fn: () => Promise<void>): Promise<void> => {
+			const r = await withVaultWriteLock(vaultRoot, { wait: DEFAULT_VAULT_WRITE_WAIT_MS }, fn, {
+				launch: launchWorker,
+			});
+			if (!r.ran) throw new VaultWriteBusyError();
+		};
 
-			const drainResult = await drainIngest(cwd, config, { triggeredBy: "manual" });
-			// Converge the canonical layer to the index: drop topic pages no longer
-			// referenced (e.g. left behind when --rebuild replays into fewer topics).
-			const index = await readTopicIndex(cwd, storage);
-			await purgeTopicPagesExcept(
-				index.topics.map((t) => t.stableSlug),
-				cwd,
-				storage,
-			);
-			await renderTopicKBWiki(cwd, storage);
-			// Build the knowledge graph from the freshly-ingested topic KB. Wrapped
-			// non-fatal: a graph build failure or missing LLM key must never fail the
-			// compile. Statically imported — the graph module pulls no optional/native
-			// deps, so eager load is safe (unlike the SearchIndex warm-up below).
+		if (rebuild) {
+			// Reset the watermark + index only. An empty index makes route treat every
+			// topic as new, so reconcile gets current=null (clean rebuild).
+			//
+			// This reset is a PREREQUISITE, not a derived view: if it can't take the
+			// lock the index stays populated and the drain below runs as a no-op
+			// incremental — a silent non-rebuild. So a busy lock here exits cleanly with
+			// the same "try again shortly" message the whole-lock predecessor printed,
+			// rather than letting the guard's throw bubble out as an uncaught stack
+			// trace. A real (non-lock) write error still propagates. The QueueWorker
+			// ingest path logs-and-continues instead because its drain is best-effort
+			// background work; a user-invoked compile owes the user a clear exit code.
+			console.log("\n  Rebuilding knowledge base from scratch...");
 			try {
-				await buildKnowledgeGraph(cwd, storage, config);
-			} catch (graphErr) {
-				log.warn(
-					"Knowledge graph build failed (non-fatal): %s",
-					graphErr instanceof Error ? graphErr.message : String(graphErr),
-				);
+				await writeGuard(async () => {
+					await saveProcessedSet(emptyProcessedSet(), cwd);
+					await saveTopicIndex(emptyTopicIndex(), cwd);
+				});
+			} catch (e) {
+				if (e instanceof VaultWriteBusyError) {
+					console.error(
+						"\n  Error: another vault writer (a background worker or sync) is busy — try again shortly.\n",
+					);
+					process.exitCode = 1;
+					return;
+				}
+				throw e;
 			}
-			// Keep the local search index warm so the next query (MCP server / `jolli
-			// search`) rarely pays a lazy rebuild. Disposable cache: a failure here must
-			// never fail the compile. SearchIndex (→ @orama/*) is lazy-imported INSIDE
-			// this try so a load failure is contained (mirrors compileAllRepos).
-			try {
-				const { SearchIndex } = await import("../core/SearchIndex.js");
-				await SearchIndex.rebuild(cwd, storage);
-			} catch (idxErr) {
-				log.warn(
-					"Search index update failed (non-fatal): %s",
-					idxErr instanceof Error ? idxErr.message : String(idxErr),
-				);
-			}
-			return drainResult;
-		});
-
-		if (!result.ran) {
-			console.error(
-				"\n  Error: another vault writer (a background worker or sync) is busy — try again shortly.\n",
-			);
-			process.exitCode = 1;
-			return;
+		} else {
+			console.log("\n  Ingesting pending sources into the knowledge base...");
 		}
 
-		const { batches, ingested, outcome, topicFailures } = result.value;
+		const drainResult = await drainIngest(cwd, config, { triggeredBy: "manual", writeGuard });
+		// Converge the canonical layer to the index: drop topic pages no longer
+		// referenced. ONLY on --rebuild (which replays into a possibly smaller topic
+		// set). A routine compile must NOT purge: with the lock released between writes
+		// a concurrent ingest can add a page that is not yet in our index snapshot, and
+		// purging "everything not in the index" would delete it — data loss. Orphans
+		// from topic consolidation are reclaimed on the next --rebuild instead. The
+		// rebuild path is an explicit single-repo reset, so the read+purge under one
+		// writeGuard is sufficient there.
+		// Purge + Markdown re-render are DERIVED-layer regeneration over data the
+		// drain already persisted to the orphan branch / canonical JSON. A busy lock
+		// (or any other failure) here is non-fatal: the memories are safe, only the
+		// regenerated views lag until the next drain. Failing the whole command on a
+		// derived-layer hiccup is what made a successful ingest report as a failure.
+		// Mirrors the QueueWorker unlocked-ingest catch and the search-index
+		// disposable-cache catch below. Orphan pages a skipped purge leaves behind are
+		// reclaimed on the next explicit --rebuild.
+		if (rebuild) {
+			try {
+				await writeGuard(async () => {
+					const index = await readTopicIndex(cwd, storage);
+					await purgeTopicPagesExcept(
+						index.topics.map((t) => t.stableSlug),
+						cwd,
+						storage,
+					);
+				});
+			} catch (purgeErr) {
+				log.warn(
+					"Topic-page purge skipped (non-fatal): %s",
+					purgeErr instanceof Error ? purgeErr.message : String(purgeErr),
+				);
+			}
+		}
+		try {
+			await renderTopicKBWiki(cwd, storage, writeGuard);
+		} catch (renderErr) {
+			log.warn(
+				"Wiki re-render skipped (non-fatal): %s",
+				renderErr instanceof Error ? renderErr.message : String(renderErr),
+			);
+		}
+		// Build the knowledge graph from the freshly-ingested topic KB. Wrapped
+		// non-fatal: a graph build failure or missing LLM key must never fail the
+		// compile. Run UNGUARDED — it is LLM-bearing, so holding vault-write.lock
+		// across it would re-create the commit-blocking stall this fix removes (the
+		// graph is a derived artifact, regenerated on the next compile).
+		try {
+			await buildKnowledgeGraph(cwd, storage, config);
+		} catch (graphErr) {
+			log.warn(
+				"Knowledge graph build failed (non-fatal): %s",
+				graphErr instanceof Error ? graphErr.message : String(graphErr),
+			);
+		}
+		// Keep the local search index warm so the next query (MCP server / `jolli
+		// search`) rarely pays a lazy rebuild. Disposable cache: a failure here must
+		// never fail the compile. SearchIndex (→ @orama/*) is lazy-imported INSIDE
+		// this try so a load failure is contained (mirrors compileAllRepos).
+		try {
+			const { SearchIndex } = await import("../core/SearchIndex.js");
+			await writeGuard(async () => {
+				await SearchIndex.rebuild(cwd, storage);
+			});
+		} catch (idxErr) {
+			log.warn(
+				"Search index update failed (non-fatal): %s",
+				idxErr instanceof Error ? idxErr.message : String(idxErr),
+			);
+		}
+
+		const { batches, ingested, outcome, topicFailures } = drainResult;
 		let summary = `\n  Done: ${ingested} source(s) folded in ${batches} batch(es). Wiki rebuilt. [${outcome}]`;
 		if (topicFailures.length > 0) {
 			summary += `\n  ${topicFailures.length} topic(s) held: ${topicFailures.map((f) => `${f.slug} (${f.code})`).join(", ")}`;
@@ -137,10 +199,6 @@ async function compileSweep(): Promise<void> {
 	}
 	console.log("\n  Ingesting pending sources across all Memory Bank repos...");
 	const result = await compileAllRepos(config.localFolder, config);
-	if (result.skipped) {
-		console.log("\n  Another compile is already running for this Memory Bank folder — skipped.\n");
-		return;
-	}
 	for (const r of result.repos) {
 		console.log(r.error ? `    ✗ ${r.folder}: ${r.error}` : `    ✓ ${r.folder}: ${r.ingested} source(s)`);
 	}

--- a/cli/src/core/ConversationOverlayStore.test.ts
+++ b/cli/src/core/ConversationOverlayStore.test.ts
@@ -8,6 +8,7 @@ import {
 	applyOverlay,
 	applyOverlaysToSessions,
 	type ConversationOverlay,
+	hasOverlayChanges,
 	loadOverlay,
 	mergeOverlay,
 	type OverlayableSession,
@@ -37,6 +38,46 @@ describe("ConversationOverlayStore", () => {
 			"utf8",
 		);
 	}
+
+	describe("hasOverlayChanges", () => {
+		const base = {
+			version: 2 as const,
+			source: "claude" as const,
+			sessionId: "s",
+			updatedAt: "2026-05-17T00:00:00Z",
+		};
+
+		it("returns false for a null overlay", () => {
+			expect(hasOverlayChanges(null)).toBe(false);
+		});
+
+		it("returns false for an undefined overlay", () => {
+			expect(hasOverlayChanges(undefined)).toBe(false);
+		});
+
+		it("returns true when deletes is non-empty", () => {
+			const overlay: ConversationOverlay = {
+				...base,
+				deletes: [{ role: "human", content: "x" }],
+				edits: [],
+			};
+			expect(hasOverlayChanges(overlay)).toBe(true);
+		});
+
+		it("returns true when edits is non-empty while deletes is empty", () => {
+			const overlay: ConversationOverlay = {
+				...base,
+				deletes: [],
+				edits: [{ role: "assistant", content: "y", newContent: "z" }],
+			};
+			expect(hasOverlayChanges(overlay)).toBe(true);
+		});
+
+		it("returns false when both deletes and edits are empty", () => {
+			const overlay: ConversationOverlay = { ...base, deletes: [], edits: [] };
+			expect(hasOverlayChanges(overlay)).toBe(false);
+		});
+	});
 
 	describe("overlayPath", () => {
 		it("returns <projectDir>/.jolli/jollimemory/conversation-edits/<source>--<sessionId>.json", () => {
@@ -886,6 +927,27 @@ describe("ConversationOverlayStore", () => {
 
 			await pruneConsumedOverlayRules([session], projectDir);
 
+			expect(existsSync(overlayFile())).toBe(false);
+		});
+
+		it("defaults source to 'claude' when the session shape omits it", async () => {
+			// Overlay is saved under the 'claude' source; the session below has
+			// no `source` field, so pruneOneSession must fall back to "claude"
+			// (line 347 `s.source ?? "claude"`) to locate and prune it.
+			await saveOverlay(
+				{ projectDir, source: "claude", sessionId: sid },
+				{ deletes: [{ role: "human", content: "drop", timestamp: "t1" }], edits: [] },
+			);
+			expect(existsSync(overlayFile())).toBe(true);
+
+			const session: OverlayableSession = {
+				sessionId: sid,
+				// no source field — must default to "claude"
+				entries: [{ role: "human", content: "drop", timestamp: "t1" }],
+			};
+			await pruneConsumedOverlayRules([session], projectDir);
+
+			// All rules consumed → file unlinked, proving the fallback found it.
 			expect(existsSync(overlayFile())).toBe(false);
 		});
 

--- a/cli/src/core/ConversationOverlayStore.unlinkfail.test.ts
+++ b/cli/src/core/ConversationOverlayStore.unlinkfail.test.ts
@@ -126,4 +126,33 @@ describe("pruneConsumedOverlayRules unlink-failure", () => {
 		// Confirm unlink was actually called so the branch was exercised.
 		expect(realFsPromises.unlink).toHaveBeenCalled();
 	});
+
+	it("swallows an ENOENT unlink error silently (inner catch does not re-throw)", async () => {
+		// Mirror of the non-ENOENT case above, but the unlink fails with ENOENT
+		// — e.g. a concurrent prune already removed the now-empty overlay file.
+		// The inner catch's `if (!isEnoent(err)) throw err;` must NOT re-throw
+		// (exercises the false branch at line 361); the call resolves cleanly.
+		const sessionId = "prune-unlink-enoent";
+		const rule = { role: "human" as const, content: "ask-enoent", timestamp: "tp2" };
+		await saveOverlay({ projectDir, source: "claude", sessionId }, { deletes: [rule], edits: [] });
+
+		const overlayDir = join(projectDir, ".jolli", "jollimemory", "conversation-edits");
+		const overlayFile = join(overlayDir, "claude--prune-unlink-enoent.json");
+		expect(existsSync(overlayFile)).toBe(true);
+
+		// Reject with an ENOENT-shaped error so isEnoent(err) === true.
+		const enoent = Object.assign(new Error("ENOENT: no such file"), { code: "ENOENT" });
+		vi.mocked(realFsPromises.unlink).mockRejectedValueOnce(enoent);
+
+		const session: OverlayableSession = {
+			sessionId,
+			source: "claude",
+			entries: [{ role: "human", content: "ask-enoent", timestamp: "tp2" }],
+		};
+
+		// Resolves cleanly — the ENOENT is swallowed by the inner catch, never
+		// reaching the outer warn-log path.
+		await expect(pruneConsumedOverlayRules([session], projectDir)).resolves.toBeUndefined();
+		expect(realFsPromises.unlink).toHaveBeenCalled();
+	});
 });

--- a/cli/src/core/DualWriteStorage.test.ts
+++ b/cli/src/core/DualWriteStorage.test.ts
@@ -67,6 +67,49 @@ describe("DualWriteStorage", () => {
 		rmrf(tempDir);
 	});
 
+	it("exposes the shadow's kbRoot via the kbRoot getter", () => {
+		const primary = new InMemoryStorage();
+		const shadow = {
+			readFile: vi.fn(),
+			writeFiles: vi.fn(),
+			listFiles: vi.fn(),
+			exists: vi.fn().mockResolvedValue(true),
+			ensure: vi.fn(),
+			kbRoot: "/some/kb/root",
+		} as unknown as StorageProvider;
+
+		const dual = new DualWriteStorage(primary, shadow);
+		// The disposable search index lives in the folder (shadow) layer.
+		expect(dual.kbRoot).toBe("/some/kb/root");
+	});
+
+	describe("isTopicWikiPresent branch coverage", () => {
+		const stub = (over: Partial<StorageProvider> = {}) =>
+			({
+				readFile: vi.fn(),
+				writeFiles: vi.fn(),
+				listFiles: vi.fn(),
+				exists: vi.fn().mockResolvedValue(true),
+				ensure: vi.fn(),
+				...over,
+			}) as unknown as StorageProvider;
+
+		it("returns false when the shadow does not implement isTopicWikiPresent", () => {
+			const dual = new DualWriteStorage(stub(), stub());
+			expect(dual.isTopicWikiPresent()).toBe(false);
+		});
+
+		it("returns true when the shadow reports the wiki present", () => {
+			const dual = new DualWriteStorage(stub(), stub({ isTopicWikiPresent: vi.fn().mockReturnValue(true) }));
+			expect(dual.isTopicWikiPresent()).toBe(true);
+		});
+
+		it("returns false when the shadow reports the wiki absent", () => {
+			const dual = new DualWriteStorage(stub(), stub({ isTopicWikiPresent: vi.fn().mockReturnValue(false) }));
+			expect(dual.isTopicWikiPresent()).toBe(false);
+		});
+	});
+
 	it("reads from primary", async () => {
 		const primary = new InMemoryStorage();
 		const shadowRoot = join(tempDir, "shadow");

--- a/cli/src/core/IngestErrors.ts
+++ b/cli/src/core/IngestErrors.ts
@@ -18,6 +18,22 @@ export const INGEST_CODES = {
 	RECONCILE_CALL_FAILED: "RECONCILE_CALL_FAILED",
 	NO_SOURCE_CONTENT: "NO_SOURCE_CONTENT",
 	ITERATION_GUARD: "ITERATION_GUARD",
+	// The topic page changed under us between the lock-free reconcile read and the
+	// guarded write (a sync pull or concurrent drain rewrote `topics/<slug>.json`),
+	// OR the guarded write could not acquire the write lock in budget (a
+	// `VaultWriteBusyError`). Either way the reconciled body was built from stale
+	// input — or the lock was simply busy — so the sources are held for a retry on
+	// the next drain rather than clobbering the newer content. This is a BENIGN,
+	// self-resolving condition.
+	PAGE_WRITE_CONFLICT: "PAGE_WRITE_CONFLICT",
+	// The guarded page+index write itself FAILED for a reason other than lock
+	// contention or a concurrent rewrite — a real I/O error (disk full, permission,
+	// JSON serialisation, git plumbing). Distinct from PAGE_WRITE_CONFLICT so a
+	// genuine fault is not silently mislabeled as benign contention and retried
+	// forever: it surfaces in telemetry and the `jolli compile` summary as an error,
+	// not a conflict. The source is still held (the batch continues), but the
+	// failure is visible.
+	PAGE_WRITE_ERROR: "PAGE_WRITE_ERROR",
 } as const;
 
 export type IngestCode = (typeof INGEST_CODES)[keyof typeof INGEST_CODES];

--- a/cli/src/core/IngestPipeline.test.ts
+++ b/cli/src/core/IngestPipeline.test.ts
@@ -28,6 +28,7 @@ vi.mock("./IngestRunStore.js", () => ({ appendIngestRun: vi.fn() }));
 // dummy provider is never actually read.
 vi.mock("./ReadStorageResolver.js", () => ({ createReadStorage: vi.fn(async () => ({})) }));
 
+import { VaultWriteBusyError } from "../sync/VaultWriteLock.js";
 import { drainIngest, ingestPendingBatch } from "./IngestPipeline.js";
 import { appendIngestRun } from "./IngestRunStore.js";
 import { callLlm } from "./LlmClient.js";
@@ -52,6 +53,15 @@ const reconcileOut = (slug: string) =>
 	`===TOPIC===\n---TITLE---\nT\n---STABLESLUG---\n${slug}\n---SUMMARY---\nsum\n---CONTENT---\nbody\n`;
 const s = (id: string, ts: string): SourceRef => ({ type: "summary", id, timestamp: ts });
 const sb = (id: string, ts: string, branch: string): SourceRef => ({ type: "summary", id, timestamp: ts, branch });
+const pg = (slug: string, lastUpdatedAt: string, content = "body"): TopicPage => ({
+	schemaVersion: 1,
+	stableSlug: slug,
+	title: "T",
+	content,
+	relatedBranches: [],
+	sourceRefs: [],
+	lastUpdatedAt,
+});
 
 describe("ingestPendingBatch", () => {
 	beforeEach(() => {
@@ -135,6 +145,188 @@ describe("ingestPendingBatch", () => {
 		expect(r.touchedSlugs).toEqual(["auth"]);
 		expect(vi.mocked(saveTopicPage)).toHaveBeenCalledTimes(1);
 		expect(vi.mocked(saveProcessedSet)).toHaveBeenCalledTimes(1);
+	});
+
+	it("runs every LLM call before the first guarded write (LLM phase is lock-free)", async () => {
+		// The write guard is where the QueueWorker hangs the per-write vault-write.lock.
+		// To keep the long reconcile phase off the lock, ALL callLlm calls (route +
+		// reconcile) must complete before the first guarded write runs.
+		vi.mocked(listPendingSources).mockResolvedValue([s("c0", "2026-01-01T00:00:00Z")]);
+		vi.mocked(callLlm)
+			.mockResolvedValueOnce(
+				llmText(
+					"route",
+					JSON.stringify({
+						updates: [],
+						newTopics: [{ stableSlug: "auth", title: "Auth", sourceIndexes: [0] }],
+					}),
+				),
+			)
+			.mockResolvedValueOnce(llmText("reconcile", reconcileOut("auth")));
+		let llmCallsAtFirstGuardedWrite = -1;
+		const writeGuard = vi.fn(async (fn: () => Promise<void>): Promise<void> => {
+			if (llmCallsAtFirstGuardedWrite === -1) llmCallsAtFirstGuardedWrite = vi.mocked(callLlm).mock.calls.length;
+			await fn();
+		});
+		await ingestPendingBatch("/tmp/x", cfg, { writeGuard });
+		expect(writeGuard).toHaveBeenCalled(); // persistence is routed through the guard
+		expect(llmCallsAtFirstGuardedWrite).toBe(2); // route + reconcile both done first
+		expect(vi.mocked(saveTopicPage)).toHaveBeenCalled();
+		expect(vi.mocked(saveProcessedSet)).toHaveBeenCalled();
+	});
+
+	it("re-reads the topic index inside the guard so a concurrent index change is not clobbered (RMW)", async () => {
+		// With the LLM phase lock-free, sync can advance the index between route-read
+		// and apply-write. The apply must merge onto a FRESH index read (inside the
+		// guard), not overwrite from the stale route-time snapshot.
+		vi.mocked(listPendingSources).mockResolvedValue([s("c0", "2026-01-01T00:00:00Z")]);
+		vi.mocked(callLlm)
+			.mockResolvedValueOnce(
+				llmText(
+					"route",
+					JSON.stringify({
+						updates: [],
+						newTopics: [{ stableSlug: "auth", title: "Auth", sourceIndexes: [0] }],
+					}),
+				),
+			)
+			.mockResolvedValueOnce(llmText("reconcile", reconcileOut("auth")));
+		vi.mocked(readTopicIndex)
+			.mockResolvedValueOnce({ schemaVersion: 1, topics: [] }) // route-time read: empty
+			.mockResolvedValueOnce({
+				schemaVersion: 1,
+				topics: [
+					{
+						stableSlug: "other",
+						title: "Other",
+						summary: "s",
+						relatedBranches: [],
+						sourceRefs: [],
+						lastUpdatedAt: "2026-01-01T00:00:00Z",
+					},
+				],
+			}); // apply-time fresh read: a concurrent writer added "other"
+		await ingestPendingBatch("/tmp/x", cfg, { writeGuard: (fn) => fn() });
+		const savedIndex = vi.mocked(saveTopicIndex).mock.calls[0]?.[0];
+		const slugs = savedIndex?.topics.map((t) => t.stableSlug) ?? [];
+		expect(slugs).toContain("other"); // concurrent topic preserved (not clobbered)
+		expect(slugs).toContain("auth"); // our new topic still applied
+	});
+
+	it("holds the source when the page was CREATED concurrently during the lock-free LLM phase", async () => {
+		// New topic: reconcile's `before` snapshot is null. If a concurrent writer
+		// landed the page during the lock-free LLM phase, the guarded re-read finds it
+		// non-null — we must HOLD the source (PAGE_WRITE_CONFLICT), not clobber it.
+		vi.mocked(listPendingSources).mockResolvedValue([s("c0", "2026-01-01T00:00:00Z")]);
+		vi.mocked(callLlm)
+			.mockResolvedValueOnce(
+				llmText(
+					"route",
+					JSON.stringify({
+						updates: [],
+						newTopics: [{ stableSlug: "auth", title: "Auth", sourceIndexes: [0] }],
+					}),
+				),
+			)
+			.mockResolvedValueOnce(llmText("reconcile", reconcileOut("auth")));
+		// New topic → reconcile does NOT read the page; the single read is the guard's.
+		vi.mocked(readTopicPage).mockResolvedValueOnce(pg("auth", "2026-02-02T00:00:00Z"));
+		const r = await ingestPendingBatch("/tmp/x", cfg);
+		expect(vi.mocked(saveTopicPage)).not.toHaveBeenCalled();
+		expect(vi.mocked(saveProcessedSet)).not.toHaveBeenCalled();
+		expect(r.ingested).toBe(0);
+		expect(r.touchedSlugs).toEqual([]);
+		expect(r.topicFailures).toEqual([{ slug: "auth", code: "PAGE_WRITE_CONFLICT" }]);
+	});
+
+	it("holds the source when an EXISTING page changed under us during the LLM phase", async () => {
+		vi.mocked(listPendingSources).mockResolvedValue([s("c0", "2026-01-01T00:00:00Z")]);
+		vi.mocked(callLlm)
+			.mockResolvedValueOnce(
+				llmText(
+					"route",
+					JSON.stringify({ updates: [{ stableSlug: "auth", sourceIndexes: [0] }], newTopics: [] }),
+				),
+			)
+			.mockResolvedValueOnce(llmText("reconcile", reconcileOut("auth")));
+		// reconcile-time read (the `before` snapshot) vs the guard-time re-read differ:
+		// a sync pull bumped lastUpdatedAt while the LLM phase ran lock-free.
+		vi.mocked(readTopicPage)
+			.mockResolvedValueOnce(pg("auth", "2026-01-01T00:00:00Z"))
+			.mockResolvedValueOnce(pg("auth", "2026-09-09T00:00:00Z"));
+		const r = await ingestPendingBatch("/tmp/x", cfg);
+		expect(vi.mocked(saveTopicPage)).not.toHaveBeenCalled();
+		expect(r.ingested).toBe(0);
+		expect(r.topicFailures).toEqual([{ slug: "auth", code: "PAGE_WRITE_CONFLICT" }]);
+	});
+
+	it("holds the source as PAGE_WRITE_CONFLICT when the per-write guard reports the lock busy", async () => {
+		// A VaultWriteBusyError (vault-write.lock not acquired in budget) is benign
+		// contention: hold this page, don't abort the batch or mark the source done.
+		vi.mocked(listPendingSources).mockResolvedValue([s("c0", "2026-01-01T00:00:00Z")]);
+		vi.mocked(callLlm)
+			.mockResolvedValueOnce(
+				llmText(
+					"route",
+					JSON.stringify({
+						updates: [],
+						newTopics: [{ stableSlug: "auth", title: "Auth", sourceIndexes: [0] }],
+					}),
+				),
+			)
+			.mockResolvedValueOnce(llmText("reconcile", reconcileOut("auth")));
+		const writeGuard = vi.fn(async (): Promise<void> => {
+			throw new VaultWriteBusyError();
+		});
+		const r = await ingestPendingBatch("/tmp/x", cfg, { writeGuard });
+		expect(vi.mocked(saveTopicPage)).not.toHaveBeenCalled();
+		expect(vi.mocked(saveProcessedSet)).not.toHaveBeenCalled();
+		expect(r.ingested).toBe(0);
+		expect(r.topicFailures).toEqual([{ slug: "auth", code: "PAGE_WRITE_CONFLICT" }]);
+	});
+
+	it("surfaces a real page-write failure as PAGE_WRITE_ERROR, not a benign conflict", async () => {
+		// A non-busy throw from inside the guarded section (disk / JSON / git plumbing
+		// fault) must NOT be masked as PAGE_WRITE_CONFLICT — otherwise a genuine fault
+		// is silently held and retried forever with no error surfaced. The source is
+		// still held (batch continues), but the failure is reported as an error code.
+		vi.mocked(listPendingSources).mockResolvedValue([s("c0", "2026-01-01T00:00:00Z")]);
+		vi.mocked(callLlm)
+			.mockResolvedValueOnce(
+				llmText(
+					"route",
+					JSON.stringify({
+						updates: [],
+						newTopics: [{ stableSlug: "auth", title: "Auth", sourceIndexes: [0] }],
+					}),
+				),
+			)
+			.mockResolvedValueOnce(llmText("reconcile", reconcileOut("auth")));
+		// Guard runs the body; the body's saveTopicPage throws a real I/O error.
+		vi.mocked(saveTopicPage).mockRejectedValueOnce(new Error("ENOSPC: no space left on device"));
+		const r = await ingestPendingBatch("/tmp/x", cfg, { writeGuard: (fn) => fn() });
+		expect(r.ingested).toBe(0);
+		expect(r.topicFailures).toEqual([{ slug: "auth", code: "PAGE_WRITE_ERROR" }]);
+	});
+
+	it("writes the page when the on-disk version is unchanged since reconcile read it", async () => {
+		// The common case under the per-write guard: nothing changed between the
+		// reconcile read and the guarded write, so the write proceeds normally.
+		vi.mocked(listPendingSources).mockResolvedValue([s("c0", "2026-01-01T00:00:00Z")]);
+		vi.mocked(callLlm)
+			.mockResolvedValueOnce(
+				llmText(
+					"route",
+					JSON.stringify({ updates: [{ stableSlug: "auth", sourceIndexes: [0] }], newTopics: [] }),
+				),
+			)
+			.mockResolvedValueOnce(llmText("reconcile", reconcileOut("auth")));
+		vi.mocked(readTopicPage).mockResolvedValue(pg("auth", "2026-01-01T00:00:00Z"));
+		const r = await ingestPendingBatch("/tmp/x", cfg);
+		expect(vi.mocked(saveTopicPage)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(saveProcessedSet)).toHaveBeenCalledTimes(1);
+		expect(r.ingested).toBe(1);
+		expect(r.touchedSlugs).toEqual(["auth"]);
 	});
 
 	it("threads the injected readStorage into processed-set / topic-index / topic-page reads", async () => {
@@ -268,6 +460,42 @@ describe("ingestPendingBatch", () => {
 		expect(r.topicFailures).toEqual([{ slug: "t", code: "RECONCILE_TRUNCATED" }]);
 		expect(r.reconcileCalls).toBe(1);
 		expect(vi.mocked(saveProcessedSet)).not.toHaveBeenCalled();
+	});
+
+	it("persists the page+index but treats a failed processed-set write as non-fatal (sources stay pending)", async () => {
+		// The page+index write share one guarded section, so they land atomically.
+		// If the LATER processed-set guard then can't acquire the lock, that is
+		// hold-and-continue: the batch must NOT throw — the page+index stay written
+		// and the source is simply not marked done, so the next drain retries it via
+		// the (now-indexed) UPDATE path. This is what keeps a missed processed-set
+		// write from stranding a source the way a missed index write would.
+		vi.mocked(listPendingSources).mockResolvedValue([s("c0", "2026-01-01T00:00:00Z")]);
+		vi.mocked(callLlm)
+			.mockResolvedValueOnce(
+				llmText(
+					"route",
+					JSON.stringify({
+						updates: [],
+						newTopics: [{ stableSlug: "auth", title: "Auth", sourceIndexes: [0] }],
+					}),
+				),
+			)
+			.mockResolvedValueOnce(llmText("reconcile", reconcileOut("auth")));
+		// First guard call (page + index) runs; the second (processed-set) throws.
+		let calls = 0;
+		const writeGuard = vi.fn(async (fn: () => Promise<void>): Promise<void> => {
+			calls++;
+			if (calls >= 2) throw new Error("lock budget exceeded");
+			await fn();
+		});
+		const r = await ingestPendingBatch("/tmp/x", cfg, { writeGuard });
+		expect(vi.mocked(saveTopicPage)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(saveTopicIndex)).toHaveBeenCalledTimes(1);
+		// Processed-set write was attempted (2nd guard call) but threw → swallowed.
+		expect(vi.mocked(saveProcessedSet)).not.toHaveBeenCalled();
+		// The page wrote cleanly (not a PAGE_WRITE_CONFLICT) and the batch did not throw.
+		expect(r.topicFailures).toEqual([]);
+		expect(r.touchedSlugs).toEqual(["auth"]);
 	});
 
 	it("reports RECONCILE_PARSE_FAILED when the block is unparseable", async () => {
@@ -518,9 +746,12 @@ describe("drainIngest", () => {
 		expect(r.ingested).toBe(2);
 	});
 
-	it("trips the adaptive iteration guard when the pipeline never drains", async () => {
-		// 2 pending, batchSize 1 -> guard = ceil(2/1)+2 = 4. Every reconcile fails, so
-		// nothing is marked and `done` is always false -> the guard must stop the loop.
+	it("stops after the first no-progress batch instead of re-running the LLM", async () => {
+		// 2 pending, batchSize 1. Every reconcile is truncated, so nothing is marked
+		// and the batch makes ZERO progress. Re-running route+reconcile against the
+		// identical pending slice would just re-bill tokens, so the drain must STOP
+		// after one batch (1 route + 1 reconcile = 2 LLM calls) rather than loop to
+		// the iteration guard (which would be 8 calls).
 		vi.mocked(listPendingSources).mockResolvedValue([
 			s("c0", "2026-01-01T00:00:00Z"),
 			s("c1", "2026-01-02T00:00:00Z"),
@@ -544,8 +775,34 @@ describe("drainIngest", () => {
 					},
 		);
 		const r = await drainIngest("/tmp/x", cfg, { batchSize: 1 });
-		expect(r.batches).toBe(4);
+		expect(r.batches).toBe(1);
 		expect(r.ingested).toBe(0);
+		expect(r.outcome).toBe("RECONCILE_TRUNCATED");
+		expect(vi.mocked(callLlm).mock.calls.length).toBe(2); // not 8 — no wasted re-runs
+	});
+
+	it("trips the adaptive iteration guard when batches make progress but pending never shrinks", async () => {
+		// Backstop for the pathological case the no-progress short-circuit can't catch:
+		// each batch DOES mark a source (ingested>0) yet listPendingSources keeps
+		// returning the same 2 entries, so `done` is never true. guard = ceil(2/1)+2 = 4.
+		vi.mocked(listPendingSources).mockResolvedValue([
+			s("c0", "2026-01-01T00:00:00Z"),
+			s("c1", "2026-01-02T00:00:00Z"),
+		]);
+		vi.mocked(callLlm).mockImplementation(async (o) =>
+			o.action === "route"
+				? llmText(
+						"route",
+						JSON.stringify({
+							updates: [],
+							newTopics: [{ stableSlug: "t", title: "T", sourceIndexes: [0] }],
+						}),
+					)
+				: llmText("reconcile", reconcileOut("t")),
+		);
+		const r = await drainIngest("/tmp/x", cfg, { batchSize: 1 });
+		expect(r.batches).toBe(4);
+		expect(r.outcome).toBe("ITERATION_GUARD");
 	});
 
 	it("records one OK run with aggregated counts", async () => {

--- a/cli/src/core/IngestPipeline.ts
+++ b/cli/src/core/IngestPipeline.ts
@@ -5,7 +5,8 @@
  * drainIngest loops to empty. Canonical layer only; visible render is sub-project 3.
  */
 
-import { createLogger } from "../Logger.js";
+import { createLogger, errMsg } from "../Logger.js";
+import { VaultWriteBusyError } from "../sync/VaultWriteLock.js";
 import type { IngestOperation, LlmConfig } from "../Types.js";
 import { mapWithConcurrency } from "./Concurrency.js";
 import { INGEST_CODES, type IngestCode } from "./IngestErrors.js";
@@ -46,6 +47,17 @@ export interface IngestOptions {
 	readonly readStorage?: StorageProvider;
 	/** Tags the telemetry record written by drainIngest. Defaults to "manual". */
 	readonly triggeredBy?: IngestOperation["triggeredBy"];
+	/**
+	 * Wraps each persistence call (topic-page / index / processed-set write) so the
+	 * caller can serialise it under a lock and release between writes. The LLM
+	 * route + reconcile phase runs OUTSIDE this guard. ALL production callers — the
+	 * `jolli compile` paths (`compileSingleRepo` / `compileAllRepos`) AND the
+	 * QueueWorker post-commit path — pass a guard that acquires `vault-write.lock`
+	 * PER WRITE (releasing between writes) so a long ingest never blocks
+	 * commit-summary generation, throwing `VaultWriteBusyError` on a busy miss (see
+	 * `cli/src/sync/VaultWriteLock.ts`). Defaults to identity for unit tests only.
+	 */
+	readonly writeGuard?: (fn: () => Promise<void>) => Promise<void>;
 }
 
 export interface IngestResult {
@@ -108,7 +120,16 @@ export async function ingestPendingBatch(cwd: string, config: LlmConfig, opts?: 
 
 	// -- Reconcile: parallel LLM phase (pure) -> serial apply phase (writes) ---
 	type ReconcileOutcome =
-		| { kind: "ok"; slug: string; page: TopicPage; indexEntry: TopicIndexEntry }
+		// `before` is the page snapshot read pre-LLM (null for a new topic); the guarded
+		// write compares it against a fresh read to detect a concurrent rewrite (RMW).
+		| {
+				kind: "ok";
+				slug: string;
+				page: TopicPage;
+				indexEntry: TopicIndexEntry;
+				before: TopicPage | null;
+				refs: readonly SourceRef[];
+		  }
 		| { kind: "failed"; slug: string; refs: SourceRef[]; code: IngestCode };
 
 	const assignments = [...plan.assignments];
@@ -177,7 +198,7 @@ export async function ingestPendingBatch(cwd: string, config: LlmConfig, opts?: 
 				sourceRefs,
 				lastUpdatedAt: nowIso,
 			};
-			return { kind: "ok", slug, page, indexEntry };
+			return { kind: "ok", slug, page, indexEntry, before: current, refs: assignment.refs };
 		},
 		// A task that throws (the reconcile LLM call failed — network/abort/transport/
 		// unexpected) degrades to a held CALL failure rather than aborting the whole
@@ -190,11 +211,16 @@ export async function ingestPendingBatch(cwd: string, config: LlmConfig, opts?: 
 		},
 	);
 
-	// -- Serial apply phase (side effects; orphan-branch writes never race) ----
+	// -- Classify outcomes (pure, lock-free) -----------------------------------
 	const failedRefs = new Set<SourceRef>();
-	const touchedSlugs: string[] = [];
+	const okOutcomes: Array<{
+		slug: string;
+		page: TopicPage;
+		indexEntry: TopicIndexEntry;
+		before: TopicPage | null;
+		refs: readonly SourceRef[];
+	}> = [];
 	const topicFailures: { slug: string; code: IngestCode }[] = [];
-	const nextIndex: TopicIndex = { schemaVersion: 1, topics: [...index.topics] };
 	let reconcileCalls = 0;
 	for (const outcome of outcomes) {
 		// `ok` always issued a reconcile LLM call; a `failed` issued one unless it
@@ -203,24 +229,97 @@ export async function ingestPendingBatch(cwd: string, config: LlmConfig, opts?: 
 		const issuedCall = outcome.kind === "ok" || outcome.code !== INGEST_CODES.NO_SOURCE_CONTENT;
 		if (issuedCall) reconcileCalls++;
 		if (outcome.kind === "ok") {
-			await saveTopicPage(outcome.page, cwd);
-			upsertIndexEntry(nextIndex, outcome.indexEntry);
-			touchedSlugs.push(outcome.slug);
+			okOutcomes.push({
+				slug: outcome.slug,
+				page: outcome.page,
+				indexEntry: outcome.indexEntry,
+				before: outcome.before,
+				refs: outcome.refs,
+			});
 		} else {
 			for (const ref of outcome.refs) failedRefs.add(ref);
 			topicFailures.push({ slug: outcome.slug, code: outcome.code });
 		}
 	}
+	// -- Guarded write phase ---------------------------------------------------
+	// `writeGuard` is the seam where every production caller (QueueWorker AND the
+	// `jolli compile` paths) hangs the per-write `vault-write.lock` (acquire →
+	// write → release) so a long ingest never holds the lock across the reconcile
+	// LLM phase and never blocks commit-summary generation. Default is identity for
+	// unit tests only.
+	//
+	// Optimistic concurrency: between the lock-free reconcile read and this guarded
+	// write a sync pull (or a concurrent drain) may have rewritten the page. We
+	// re-read it INSIDE the guard and compare to the `before` snapshot reconcile
+	// used; on divergence the reconciled body is stale, so we HOLD the source (skip
+	// the write) instead of clobbering the newer content. A writeGuard throw (lock
+	// not acquired in budget) is treated identically — hold this page, keep going.
+	// Both land as PAGE_WRITE_CONFLICT and feed `failedRefs`.
+	//
+	// Each page is persisted ATOMICALLY with its index entry, inside ONE guarded
+	// section. A separate index write (an independent later lock acquisition) could
+	// fail to acquire the lock AFTER the page persisted, orphaning the page — on
+	// disk but absent from the index — which the next drain re-routes as a brand-new
+	// topic, whose guarded re-read then finds the orphan page and holds the source
+	// forever (recoverable only by `--rebuild`). The index is re-read FRESH inside
+	// the guard (RMW) so a concurrent index change is merged, not clobbered. The
+	// processed-set is written last (also a fresh-read RMW) once every targeted page
+	// has persisted.
+	const writeGuard = opts?.writeGuard ?? ((fn: () => Promise<void>) => fn());
+	const written: typeof okOutcomes = [];
+	for (const o of okOutcomes) {
+		let held = false;
+		// Default to the benign conflict code; a real (non-busy) write fault below
+		// overrides it with PAGE_WRITE_ERROR so it isn't masked as contention.
+		let heldCode: IngestCode = INGEST_CODES.PAGE_WRITE_CONFLICT;
+		try {
+			await writeGuard(async () => {
+				const live = await readTopicPage(o.slug, cwd, readStorage);
+				if (!samePage(live, o.before)) {
+					log.warn(
+						"Topic %s changed under us during the lock-free LLM phase -- holding sources, not clobbering",
+						o.slug,
+					);
+					held = true;
+					return;
+				}
+				await saveTopicPage(o.page, cwd);
+				// Same guarded section as the page write: a page never lands without
+				// its index entry. RMW onto a fresh index read so a concurrent index
+				// change (sync pull / another drain) is preserved, not clobbered.
+				const freshIndex = await readTopicIndex(cwd, readStorage);
+				const mergedIndex: TopicIndex = { schemaVersion: 1, topics: [...freshIndex.topics] };
+				upsertIndexEntry(mergedIndex, o.indexEntry);
+				await saveTopicIndex(mergedIndex, cwd);
+			});
+		} catch (e) {
+			held = true;
+			if (e instanceof VaultWriteBusyError) {
+				// Lock busy in budget — benign, retried next drain (PAGE_WRITE_CONFLICT).
+				log.warn("Topic %s page write could not acquire vault-write.lock in budget -- holding sources", o.slug);
+			} else {
+				// A real I/O / serialisation / plumbing fault, NOT lock contention. Hold
+				// the source so the batch continues, but surface it as an ERROR (not a
+				// benign conflict) so it isn't silently retried forever and unflagged.
+				heldCode = INGEST_CODES.PAGE_WRITE_ERROR;
+				log.error("Topic %s page write FAILED (not lock contention) -- holding sources: %s", o.slug, errMsg(e));
+			}
+		}
+		if (held) {
+			for (const ref of o.refs) failedRefs.add(ref);
+			topicFailures.push({ slug: o.slug, code: heldCode });
+		} else {
+			written.push(o);
+		}
+	}
+	const touchedSlugs = written.map((o) => o.slug);
 
-	// Only persist the index when at least one page changed.
-	if (touchedSlugs.length > 0) await saveTopicIndex(nextIndex, cwd);
-
-	// -- Mark: a source is processed iff every topic it targeted succeeded -----
-	// A failed page adds ALL its assigned refs to `failedRefs`, so a source that
-	// targeted any failed page is held back; a source routed nowhere is simply done.
+	// -- Mark set: a source is processed iff every topic it targeted succeeded -
+	// A failed (or held) page adds ALL its assigned refs to `failedRefs`, so a source
+	// that targeted any such page is held back; a source routed nowhere is simply done.
+	// Computed AFTER the page writes so page-write conflicts are reflected here too.
 	const routedRefs = new Set<SourceRef>();
 	for (const [, assignment] of plan.assignments) for (const ref of assignment.refs) routedRefs.add(ref);
-
 	const succeeded: SourceRef[] = [];
 	for (const ref of batch) {
 		if (failedRefs.has(ref)) continue;
@@ -229,7 +328,27 @@ export async function ingestPendingBatch(cwd: string, config: LlmConfig, opts?: 
 		}
 		succeeded.push(ref); // either fully routed-and-reconciled, or routed nowhere (un-filed) -- both are "done"
 	}
-	if (succeeded.length > 0) await saveProcessedSet(addProcessed(processed, succeeded), cwd);
+
+	// Processed-set: its own guarded RMW, AFTER every page+index write. A guard
+	// failure here is hold-and-continue (NOT a batch abort): the sources stay
+	// pending and are retried next drain. Because each page was written atomically
+	// with its index entry above, that retry takes the UPDATE path (topic already
+	// indexed), the unchanged re-read passes, and the write self-heals — so a missed
+	// processed-set write never strands a source the way a missed index write would.
+	if (succeeded.length > 0) {
+		try {
+			await writeGuard(async () => {
+				const fresh = await readProcessedSet(cwd, readStorage);
+				await saveProcessedSet(addProcessed(fresh, succeeded), cwd);
+			});
+		} catch (e) {
+			log.error(
+				"Processed-set write could not acquire the write lock -- %d source(s) stay pending for the next drain: %s",
+				succeeded.length,
+				(e as Error).message,
+			);
+		}
+	}
 
 	return {
 		ingested: succeeded.length,
@@ -280,6 +399,23 @@ export async function drainIngest(
 			break;
 		}
 		if (r.done) break;
+		// No forward progress this batch: every targeted page was held (sustained
+		// vault-write.lock contention, a real write fault, or a deterministic
+		// reconcile failure). `ingested === 0` means no source was marked processed,
+		// so the next batch would re-route the IDENTICAL pending slice — re-billing
+		// the route + reconcile LLM phase for zero gain. Stop and let the next
+		// trigger (post-commit re-enqueue / successor worker / user re-run) retry.
+		// The iteration guard below remains a backstop for the pathological case
+		// where each batch DOES make progress yet never drains.
+		if (r.ingested === 0) {
+			outcome = r.topicFailures[0]?.code ?? INGEST_CODES.PAGE_WRITE_CONFLICT;
+			log.warn(
+				"drainIngest made no progress this batch (%d source(s) held, outcome=%s) -- stopping; next trigger retries",
+				r.pendingCount,
+				outcome,
+			);
+			break;
+		}
 	}
 	if (batches >= maxIterations) {
 		log.error("drainIngest hit iteration guard (%d) -- pipeline not draining, stopping", maxIterations);
@@ -305,6 +441,24 @@ export async function drainIngest(
 function formatIndexForRoute(index: TopicIndex): string {
 	if (index.topics.length === 0) return "(none yet)";
 	return index.topics.map((t) => `- ${t.stableSlug} -- ${t.title}: ${t.summary}`).join("\n");
+}
+
+/**
+ * Optimistic-concurrency check for the guarded page write: did the on-disk page
+ * change since reconcile read it? `lastUpdatedAt` is bumped on every reconcile so
+ * it alone flags a concurrent writer; `content` is compared too as a belt-and-braces
+ * guard. Both `null`/absent (a new topic still absent) counts as unchanged. A
+ * new topic that now exists, or an existing page whose body or timestamp moved,
+ * counts as changed. Under the identity writeGuard (unit tests only) nothing can
+ * change between read and write, so this is always `true` there; under the real
+ * per-write guard every production caller now passes, a concurrent commit-summary
+ * worker or sync pull CAN move the page, so this legitimately returns `false`.
+ */
+function samePage(a: TopicPage | null | undefined, b: TopicPage | null | undefined): boolean {
+	const aAbsent = a == null;
+	const bAbsent = b == null;
+	if (aAbsent || bAbsent) return aAbsent && bAbsent;
+	return a.lastUpdatedAt === b.lastUpdatedAt && a.content === b.content;
 }
 
 function upsertIndexEntry(index: TopicIndex, entry: TopicIndexEntry): void {

--- a/cli/src/core/MultiRepoCompile.test.ts
+++ b/cli/src/core/MultiRepoCompile.test.ts
@@ -5,12 +5,22 @@ vi.mock("../sync/SyncBootstrap.js", () => ({
 	deriveMemoryBankRoot: vi.fn((localFolder: string) => localFolder),
 }));
 vi.mock("../sync/VaultWriteLock.js", () => ({
+	DEFAULT_VAULT_WRITE_WAIT_MS: 60_000,
+	// Stand-in for the real typed busy signal the guard throws on a busy miss; the
+	// default message matches the real class so the substring assertion holds.
+	VaultWriteBusyError: class VaultWriteBusyError extends Error {
+		constructor(message = "could not acquire vault-write.lock within budget") {
+			super(message);
+			this.name = "VaultWriteBusyError";
+		}
+	},
 	// Default: lock free → run the body and surface its value.
 	withVaultWriteLock: vi.fn(async (_root: string, _mode: unknown, body: () => Promise<unknown>) => ({
 		ran: true,
 		value: await body(),
 	})),
 }));
+vi.mock("../hooks/QueueWorker.js", () => ({ launchWorker: vi.fn() }));
 vi.mock("./IngestPipeline.js", () => ({
 	drainIngest: vi.fn(async (cwd: string) => {
 		if (cwd.endsWith("boom")) throw new Error("kaboom");
@@ -18,7 +28,6 @@ vi.mock("./IngestPipeline.js", () => ({
 	}),
 }));
 vi.mock("./TopicWikiRenderer.js", () => ({ renderTopicKBWiki: vi.fn(async () => {}) }));
-vi.mock("./TopicIndexStore.js", () => ({ readTopicIndex: vi.fn(async () => ({ schemaVersion: 1, topics: [] })) }));
 vi.mock("./TopicPageStore.js", () => ({ purgeTopicPagesExcept: vi.fn(async () => []) }));
 vi.mock("./StorageFactory.js", () => ({ createFolderStorageAtRoot: vi.fn((kbRoot: string) => ({ kbRoot })) }));
 vi.mock("./SummaryStore.js", () => ({ setActiveStorage: vi.fn(), getActiveStorage: vi.fn(() => undefined) }));
@@ -43,7 +52,6 @@ import { discoverRepos } from "./MemoryBankRepoDiscovery.js";
 import { compileAllRepos } from "./MultiRepoCompile.js";
 import { SearchIndex } from "./SearchIndex.js";
 import { getActiveStorage, setActiveStorage } from "./SummaryStore.js";
-import { readTopicIndex } from "./TopicIndexStore.js";
 import { purgeTopicPagesExcept } from "./TopicPageStore.js";
 
 describe("compileAllRepos", () => {
@@ -92,30 +100,35 @@ describe("compileAllRepos", () => {
 		);
 	});
 
-	it("passes discovered topic slugs through when purging stale topic pages", async () => {
-		vi.mocked(readTopicIndex).mockResolvedValueOnce({
-			schemaVersion: 1,
-			topics: [{ stableSlug: "auth" }, { stableSlug: "storage" }],
-			// biome-ignore lint/suspicious/noExplicitAny: minimal topic-index stub
-		} as any);
-		const res = await compileAllRepos("/mb", { compileExcludeFolders: ["jolliai", "boom"] } as never);
-		expect(res.repos.map((r) => r.folder)).toEqual(["jolli"]);
-		expect(purgeTopicPagesExcept).toHaveBeenCalledWith(["auth", "storage"], "/mb/jolli", { kbRoot: "/mb/jolli" });
+	it("drains each repo with a per-write writeGuard that acquires vault-write.lock in wait mode (lock released during the LLM phase)", async () => {
+		await compileAllRepos("/mb", { compileExcludeFolders: ["jolliai", "boom"] } as never);
+		// drainIngest receives a writeGuard — the seam that re-acquires the lock per
+		// write so the reconcile LLM phase runs UNLOCKED and a concurrent commit-summary
+		// worker can interleave. NOT one lock held across the whole sweep.
+		const opts = vi.mocked(drainIngest).mock.calls[0][2];
+		expect(opts?.writeGuard).toBeTypeOf("function");
+		// Invoking the guard acquires the canonical vault lock (wait-mode, keyed off the
+		// vault root) with the pending-worker wakeup hook.
+		await opts?.writeGuard?.(async () => {});
+		expect(withVaultWriteLock).toHaveBeenCalledWith("/mb", { wait: 60_000 }, expect.any(Function), {
+			launch: expect.any(Function),
+		});
 	});
 
-	it("runs the sweep under the canonical vault-write lock (fail-fast, keyed off the vault root)", async () => {
-		await compileAllRepos("/mb", { model: "haiku" } as never);
-		expect(withVaultWriteLock).toHaveBeenCalledWith("/mb", "fail-fast", expect.any(Function));
-	});
-
-	it("skips the sweep (no discovery) when another vault writer holds the lock", async () => {
-		// Lock busy → body never runs → ran:false.
+	it("the per-write guard rejects with VaultWriteBusyError when an individual write can't acquire the lock", async () => {
+		await compileAllRepos("/mb", { compileExcludeFolders: ["jolliai", "boom"] } as never);
+		const guard = vi.mocked(drainIngest).mock.calls[0][2]?.writeGuard;
+		// Lock busy on this one write → withVaultWriteLock reports ran:false → the
+		// guard surfaces it as a TYPED VaultWriteBusyError (not a bare Error) so
+		// drainIngest's page-write catch holds the page as a benign conflict instead
+		// of mislabeling it a real write fault.
 		vi.mocked(withVaultWriteLock).mockResolvedValueOnce({ ran: false });
-		const res = await compileAllRepos("/mb", { model: "haiku" } as never);
-		expect(res.skipped).toBe(true);
-		expect(res.repos).toEqual([]);
-		expect(res.totalIngested).toBe(0);
-		expect(discoverRepos).not.toHaveBeenCalled();
+		await expect(guard?.(async () => {})).rejects.toThrow("could not acquire vault-write.lock");
+	});
+
+	it("does NOT purge topic pages during a routine sweep (would delete a page a concurrent ingest just added — data loss)", async () => {
+		await compileAllRepos("/mb", { compileExcludeFolders: ["jolliai", "boom"] } as never);
+		expect(purgeTopicPagesExcept).not.toHaveBeenCalled();
 	});
 
 	it("stringifies non-Error throws in the per-repo error field", async () => {

--- a/cli/src/core/MultiRepoCompile.ts
+++ b/cli/src/core/MultiRepoCompile.ts
@@ -8,14 +8,12 @@
 import { buildKnowledgeGraph } from "../graph/GraphBuilder.js";
 import { createLogger } from "../Logger.js";
 import { deriveMemoryBankRoot } from "../sync/SyncBootstrap.js";
-import { withVaultWriteLock } from "../sync/VaultWriteLock.js";
+import { DEFAULT_VAULT_WRITE_WAIT_MS, VaultWriteBusyError, withVaultWriteLock } from "../sync/VaultWriteLock.js";
 import type { JolliMemoryConfig } from "../Types.js";
 import { drainIngest, type IngestOptions } from "./IngestPipeline.js";
 import { discoverRepos } from "./MemoryBankRepoDiscovery.js";
 import { createFolderStorageAtRoot } from "./StorageFactory.js";
 import { getActiveStorage, setActiveStorage } from "./SummaryStore.js";
-import { readTopicIndex } from "./TopicIndexStore.js";
-import { purgeTopicPagesExcept } from "./TopicPageStore.js";
 import { renderTopicKBWiki } from "./TopicWikiRenderer.js";
 
 const log = createLogger("MultiRepoCompile");
@@ -32,8 +30,6 @@ export interface CompileAllResult {
 	readonly repos: CompileAllRepoResult[];
 	readonly totalIngested: number;
 	readonly failed: number;
-	/** Set when the sweep was skipped because another compile already holds the lock. */
-	readonly skipped?: boolean;
 }
 
 export interface CompileAllOptions extends Pick<IngestOptions, "batchSize"> {
@@ -50,105 +46,127 @@ export async function compileAllRepos(
 	config: JolliMemoryConfig,
 	opts?: CompileAllOptions,
 ): Promise<CompileAllResult> {
-	// This sweep writes each repo's canonical JSON and regenerates its `_wiki/` in
-	// place. Serialise on the SAME `vault-write.lock` the QueueWorker and SyncEngine
-	// hold (keyed off the vault root), so a sweep can't interleave on-disk writes
-	// with a background worker ingest, a sync round, or a second sweep over the same
-	// Memory Bank folder. NOTE: the risk is on-disk file contention, NOT in-memory
-	// "global pollution" — `setActiveStorage` is per-process. The lock is PID-aware
-	// (reclaims a crashed holder) and heartbeated by `withVaultWriteLock`, so a long
-	// LLM-bearing drain can't be reaped mid-sweep.
+	// This sweep writes each repo's canonical JSON and regenerates its `_wiki/`. Rather
+	// than hold `vault-write.lock` across the whole (multi-minute, LLM-bearing) drain —
+	// which starved commit-summary workers that timed out waiting and left their queue
+	// entries orphaned — it acquires the lock PER WRITE via `writeGuard` and runs the
+	// reconcile LLM phase UNLOCKED. A concurrent commit-summary worker can then grab the
+	// lock between our writes and generate its summary promptly ("build wiki" is
+	// low-priority and may proceed slowly). Data safety is preserved by drainIngest's
+	// guarded-write phase: topic pages re-read + compare before write (no clobber), the
+	// index + processed-set are RMW under the same guard (no lost-update). The
+	// releaseHook wakes any worker that still timed out waiting on a write (defense in
+	// depth — see VaultWriteLock). The lock is keyed off the vault root (shared by all
+	// repos under this Memory Bank folder), matching QueueWorker / SyncEngine.
+	//
+	// Dropping the whole-sweep lock means two sweeps over the same folder can now
+	// overlap; that is safe (the same optimistic-concurrency / RMW guards apply), just
+	// potentially redundant LLM work — so the sweep no longer reports a "skipped"
+	// outcome (there is no longer a whole-sweep lock to contend for).
 	const vaultRoot = deriveMemoryBankRoot(localFolder);
-	const result = await withVaultWriteLock(vaultRoot, "fail-fast", async () => {
-		const targets = await discoverRepos(localFolder, config.compileExcludeFolders ?? []);
-		const repos: CompileAllRepoResult[] = [];
-		let totalIngested = 0;
-		let failed = 0;
-		const total = targets.length;
+	// `launchWorker` is imported lazily (not at module top) so importing
+	// MultiRepoCompile — which the VS Code "Build wiki" path does dynamically —
+	// doesn't eagerly pull QueueWorker's transcript-reader/detector graph into the
+	// compile path. A busy miss throws VaultWriteBusyError (a TYPED busy signal,
+	// shared verbatim with the other per-write guards) so `drainIngest` can tell
+	// transient contention apart from a real write fault. NOTE: this PER-WRITE guard
+	// REPLACES the former whole-sweep `fail-fast` lock — the long, LLM-bearing drain
+	// must NOT hold the vault lock or it re-starves the commit-summary workers this
+	// fix unblocks. Two overlapping sweeps are safe (optimistic-concurrency / RMW).
+	const { launchWorker } = await import("../hooks/QueueWorker.js");
+	const writeGuard = async (fn: () => Promise<void>): Promise<void> => {
+		const r = await withVaultWriteLock(vaultRoot, { wait: DEFAULT_VAULT_WRITE_WAIT_MS }, fn, {
+			launch: launchWorker,
+		});
+		if (!r.ran) throw new VaultWriteBusyError();
+	};
 
-		// We swap the process-global storage override per repo (inner stores fall back
-		// to it). Capture the prior value and restore it in a finally so the override
-		// never leaks past this sweep into a long-lived host process (VS Code), where
-		// it would silently point later reads/writes at the last-compiled repo.
-		const previousStorage = getActiveStorage();
-		try {
-			for (const [i, t] of targets.entries()) {
-				// `[i/total] <repo>: <phase>` — keeps the UI notification legible about
-				// which repo and phase a long sweep is on.
-				const report = (phase: string) => opts?.onProgress?.(`[${i + 1}/${total}] ${t.folder}: ${phase}`);
+	const targets = await discoverRepos(localFolder, config.compileExcludeFolders ?? []);
+	const repos: CompileAllRepoResult[] = [];
+	let totalIngested = 0;
+	let failed = 0;
+	const total = targets.length;
+
+	// We swap the process-global storage override per repo (inner stores fall back
+	// to it). Capture the prior value and restore it in a finally so the override
+	// never leaks past this sweep into a long-lived host process (VS Code), where
+	// it would silently point later reads/writes at the last-compiled repo.
+	const previousStorage = getActiveStorage();
+	try {
+		for (const [i, t] of targets.entries()) {
+			// `[i/total] <repo>: <phase>` — keeps the UI notification legible about
+			// which repo and phase a long sweep is on.
+			const report = (phase: string) => opts?.onProgress?.(`[${i + 1}/${total}] ${t.folder}: ${phase}`);
+			try {
+				const storage = createFolderStorageAtRoot(t.kbRoot);
+				setActiveStorage(storage);
+				report("ingesting sources");
+				const { batches, ingested } = await drainIngest(t.kbRoot, config, {
+					batchSize: opts?.batchSize,
+					readStorage: storage,
+					triggeredBy: "manual",
+					writeGuard,
+				});
+				// NO purge here: with the lock released between writes a concurrent ingest
+				// can add a topic page not yet in our index snapshot, and purging
+				// "everything not in the index" would delete it (data loss). Orphan pages
+				// from topic consolidation are reclaimed by an explicit `jolli compile
+				// --cwd <repo> --rebuild`, never by the routine sweep.
+				report("rendering wiki");
+				await renderTopicKBWiki(t.kbRoot, storage, writeGuard);
+				// Build the knowledge graph from the freshly-ingested topic KB. Wrapped
+				// non-fatal: a graph build failure or missing LLM key must never fail the
+				// compile. Run UNGUARDED — it is LLM-bearing, so holding vault-write.lock
+				// across it would re-create the commit-blocking stall this fix removes
+				// (the graph is a derived artifact, regenerated on the next sweep).
 				try {
-					const storage = createFolderStorageAtRoot(t.kbRoot);
-					setActiveStorage(storage);
-					report("ingesting sources");
-					const { batches, ingested } = await drainIngest(t.kbRoot, config, {
-						batchSize: opts?.batchSize,
-						readStorage: storage,
-						triggeredBy: "manual",
+					report("building knowledge graph");
+					await buildKnowledgeGraph(t.kbRoot, storage, config, {
+						onProgress: (m) => report(`graph: ${m}`),
 					});
-					const index = await readTopicIndex(t.kbRoot, storage);
-					await purgeTopicPagesExcept(
-						index.topics.map((topic) => topic.stableSlug),
-						t.kbRoot,
-						storage,
+				} catch (graphErr) {
+					log.warn(
+						"Knowledge graph build failed for %s (non-fatal): %s",
+						t.folder,
+						graphErr instanceof Error ? graphErr.message : String(graphErr),
 					);
-					report("rendering wiki");
-					await renderTopicKBWiki(t.kbRoot, storage);
-					// Build the knowledge graph from the freshly-ingested topic KB. Wrapped
-					// non-fatal: a graph build failure or missing LLM key must never fail the
-					// compile. Statically imported — unlike the SearchIndex warm-up below, the
-					// graph module pulls no optional/native deps, so eager load is safe.
-					try {
-						await buildKnowledgeGraph(t.kbRoot, storage, config, {
-							onProgress: (m) => report(`graph: ${m}`),
-						});
-					} catch (graphErr) {
-						log.warn(
-							"Knowledge graph build failed for %s (non-fatal): %s",
-							t.folder,
-							graphErr instanceof Error ? graphErr.message : String(graphErr),
-						);
-					}
-					// Keep the local search index warm so query-time rebuilds are rare.
-					// Disposable cache: a failure here must never fail the compile.
-					// SearchIndex (→ @orama/*) is lazy-imported INSIDE this try so a
-					// load failure is contained the same way the node:sqlite readers
-					// are — a missing/incompatible orama degrades to "index not warmed",
-					// it never crashes module load or the whole sweep.
-					try {
-						const { SearchIndex } = await import("./SearchIndex.js");
-						await SearchIndex.rebuild(t.kbRoot, storage);
-					} catch (idxErr) {
-						log.warn(
-							"Search index update failed for %s (non-fatal): %s",
-							t.folder,
-							idxErr instanceof Error ? idxErr.message : String(idxErr),
-						);
-					}
-					totalIngested += ingested;
-					repos.push({ folder: t.folder, repoIdentity: t.repoIdentity, ingested, batches });
-					log.info("Compiled %s: %d source(s) in %d batch(es)", t.folder, ingested, batches);
-				} catch (err) {
-					failed++;
-					const message = err instanceof Error ? err.message : String(err);
-					repos.push({
-						folder: t.folder,
-						repoIdentity: t.repoIdentity,
-						ingested: 0,
-						batches: 0,
-						error: message,
-					});
-					log.error("Compile failed for %s: %s", t.folder, message);
 				}
+				// Keep the local search index warm so query-time rebuilds are rare.
+				// Disposable cache: a failure here must never fail the compile.
+				// SearchIndex (→ @orama/*) is lazy-imported INSIDE this try so a
+				// load failure is contained the same way the node:sqlite readers
+				// are — a missing/incompatible orama degrades to "index not warmed",
+				// it never crashes module load or the whole sweep.
+				try {
+					const { SearchIndex } = await import("./SearchIndex.js");
+					await writeGuard(async () => {
+						await SearchIndex.rebuild(t.kbRoot, storage);
+					});
+				} catch (idxErr) {
+					log.warn(
+						"Search index update failed for %s (non-fatal): %s",
+						t.folder,
+						idxErr instanceof Error ? idxErr.message : String(idxErr),
+					);
+				}
+				totalIngested += ingested;
+				repos.push({ folder: t.folder, repoIdentity: t.repoIdentity, ingested, batches });
+				log.info("Compiled %s: %d source(s) in %d batch(es)", t.folder, ingested, batches);
+			} catch (err) {
+				failed++;
+				const message = err instanceof Error ? err.message : String(err);
+				repos.push({
+					folder: t.folder,
+					repoIdentity: t.repoIdentity,
+					ingested: 0,
+					batches: 0,
+					error: message,
+				});
+				log.error("Compile failed for %s: %s", t.folder, message);
 			}
-			return { repos, totalIngested, failed };
-		} finally {
-			setActiveStorage(previousStorage);
 		}
-	});
-
-	if (!result.ran) {
-		log.warn("Another vault writer is busy for %s — skipping this sweep", localFolder);
-		return { repos: [], totalIngested: 0, failed: 0, skipped: true };
+		return { repos, totalIngested, failed };
+	} finally {
+		setActiveStorage(previousStorage);
 	}
-	return result.value;
 }

--- a/cli/src/core/TopicWikiRenderer.test.ts
+++ b/cli/src/core/TopicWikiRenderer.test.ts
@@ -42,6 +42,27 @@ describe("renderTopicKBWiki", () => {
 		expect(call0[0].map((p) => (p as { stableSlug: string }).stableSlug)).toEqual(["auth", "storage"]);
 	});
 
+	it("routes the storage.renderTopicWiki write through the provided writeGuard", async () => {
+		// The visible-wiki render is one bulk write; the QueueWorker wraps it in the
+		// per-vault lock so it can't land mid-sync. The guard must wrap the actual
+		// renderTopicWiki call, and the reads (index/pages) must precede it.
+		vi.mocked(readTopicIndex).mockResolvedValue({ schemaVersion: 1, topics: [idxEntry("auth")] });
+		vi.mocked(readTopicPage).mockImplementation(async (slug) => page(slug));
+		const order: string[] = [];
+		const renderTopicWiki = vi.fn(async () => {
+			order.push("render");
+		});
+		const writeGuard = vi.fn(async (fn: () => Promise<void>): Promise<void> => {
+			order.push("guard-enter");
+			await fn();
+			order.push("guard-exit");
+		});
+		await renderTopicKBWiki("/tmp/x", { renderTopicWiki } as unknown as StorageProvider, writeGuard);
+		expect(writeGuard).toHaveBeenCalledTimes(1);
+		expect(renderTopicWiki).toHaveBeenCalledTimes(1);
+		expect(order).toEqual(["guard-enter", "render", "guard-exit"]);
+	});
+
 	it("skips index entries whose page file is missing", async () => {
 		vi.mocked(readTopicIndex).mockResolvedValue({ schemaVersion: 1, topics: [idxEntry("auth"), idxEntry("gone")] });
 		vi.mocked(readTopicPage).mockImplementation(async (slug) => (slug === "gone" ? null : page(slug)));

--- a/cli/src/core/TopicWikiRenderer.ts
+++ b/cli/src/core/TopicWikiRenderer.ts
@@ -17,16 +17,31 @@ const log = createLogger("TopicWikiRenderer");
  * index (NOT a directory scan), so orphaned `topics/<slug>.json` files left by
  * a slug change or `--rebuild` are excluded. No-op on orphan-only storage.
  */
-export async function renderTopicKBWiki(cwd: string, storage: StorageProvider): Promise<void> {
+export async function renderTopicKBWiki(
+	cwd: string,
+	storage: StorageProvider,
+	writeGuard: (fn: () => Promise<void>) => Promise<void> = (fn) => fn(),
+): Promise<void> {
 	if (!storage.renderTopicWiki) {
 		log.debug("Active storage has no renderTopicWiki — skipping visible wiki render");
 		return;
 	}
-	const index = await readTopicIndex(cwd, storage);
-	const pages: TopicPage[] = [];
-	for (const entry of index.topics) {
-		const page = await readTopicPage(entry.stableSlug, cwd, storage);
-		if (page) pages.push(page);
-	}
-	await storage.renderTopicWiki(pages);
+	// The index/page reads AND the bulk render run INSIDE the guard so they form one
+	// atomic snapshot-then-render under the per-vault lock. Reading the snapshot
+	// lock-free would re-open a TOCTOU: a concurrent ingest/compile could update the
+	// canonical JSON between the read and the render, and since `renderTopicWiki`
+	// wipes `_wiki/` and rewrites it wholesale from the snapshot, this pass would
+	// republish a stale wiki (dropping a page the concurrent writer just added).
+	// Defaults to identity — the `jolli compile` paths already hold the lock for
+	// their whole drain.
+	const render = storage.renderTopicWiki.bind(storage);
+	await writeGuard(async () => {
+		const index = await readTopicIndex(cwd, storage);
+		const pages: TopicPage[] = [];
+		for (const entry of index.topics) {
+			const page = await readTopicPage(entry.stableSlug, cwd, storage);
+			if (page) pages.push(page);
+		}
+		await render(pages);
+	});
 }

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -73,21 +73,35 @@ vi.mock("../core/Locks.js", () => ({
 // drain-queue test path stays focused on per-entry behaviour. A separate
 // QueueWorker.vaultLock test file exercises the lock acquisition / release
 // contract directly.
-vi.mock("../sync/VaultWriteLock.js", () => ({
-	acquireVaultWriteLock: vi.fn().mockResolvedValue({
-		release: vi.fn().mockResolvedValue(undefined),
-		refresh: vi.fn().mockResolvedValue(undefined),
-	}),
-	DEFAULT_VAULT_WRITE_WAIT_MS: 60_000,
-	isVaultWriteLockHeld: vi.fn(),
-}));
+vi.mock("../sync/VaultWriteLock.js", async (importOriginal) => {
+	// Keep the real `VaultWriteBusyError` so the unlocked-ingest guard's typed busy
+	// signal is the genuine class; only the lock acquisition is stubbed.
+	const actual = await importOriginal<typeof import("../sync/VaultWriteLock.js")>();
+	return {
+		...actual,
+		acquireVaultWriteLock: vi.fn().mockResolvedValue({
+			release: vi.fn().mockResolvedValue(undefined),
+			refresh: vi.fn().mockResolvedValue(undefined),
+		}),
+		// Used by the unlocked-ingest writeGuard. Passthrough: run the body, report ran.
+		withVaultWriteLock: vi.fn(async (_root: string, _mode: unknown, body: () => Promise<unknown>) => ({
+			ran: true,
+			value: await body(),
+		})),
+		DEFAULT_VAULT_WRITE_WAIT_MS: 60_000,
+		isVaultWriteLockHeld: vi.fn(),
+	};
+});
 
 // PendingWorkers cross-repo wakeup helpers. Mocked so tests can verify
 // QueueWorker records its cwd on lock acquisition failure (L295/309-314)
-// and skips itself when consuming on release (L425).
+// and delegates the on-release wakeup to `wakePendingWorkers`. The real
+// drain+launch+skip-self loop is exercised directly in PendingWorkers.test.ts;
+// here we only assert QueueWorker calls the helper with its own cwd as selfCwd.
 vi.mock("../sync/PendingWorkers.js", () => ({
 	recordPendingWorker: vi.fn().mockResolvedValue(undefined),
 	consumePendingWorkers: vi.fn().mockResolvedValue([]),
+	wakePendingWorkers: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../sync/SyncBootstrap.js", () => ({
@@ -375,7 +389,7 @@ import { generateSummary } from "../core/Summarizer.js";
 import { storeSummary } from "../core/SummaryStore.js";
 import { renderTopicKBWiki } from "../core/TopicWikiRenderer.js";
 import { buildMultiSessionContext, readTranscript } from "../core/TranscriptReader.js";
-import { consumePendingWorkers, recordPendingWorker } from "../sync/PendingWorkers.js";
+import { recordPendingWorker, wakePendingWorkers } from "../sync/PendingWorkers.js";
 import { acquireVaultWriteLock } from "../sync/VaultWriteLock.js";
 import type { CommitGitOperation, IngestOperation } from "../Types.js";
 import { __test__, buildWorkerStartupBanner, launchWorker, runWorker } from "./QueueWorker.js";
@@ -485,13 +499,14 @@ describe("QueueWorker", () => {
 	});
 
 	describe("runWorker — vault-write.lock failure path", () => {
-		it("records pendingWorker and returns early when vault lock acquisition fails", async () => {
-			// Pins QueueWorker.ts L295 (vaultLock === null branch) and
-			// L309-314 (recordPendingWorker call + early return). When the
-			// vault-write.lock is held by another writer, the worker must
-			// record its cwd so the next release re-spawns it, then exit
-			// without touching the queue.
-			vi.mocked(acquireVaultWriteLock).mockResolvedValueOnce(null);
+		it("records pendingWorker and returns early when vault lock stays busy through the retry", async () => {
+			// Pins the vaultLock === null branch: recordPendingWorker call +
+			// post-record fail-fast retry + early return. When the
+			// vault-write.lock is held by another writer that is STILL holding
+			// it on the retry, the worker must record its cwd so the next
+			// release re-spawns it, then exit without touching the queue.
+			// Both the wait-mode acquire and the fail-fast retry miss.
+			vi.mocked(acquireVaultWriteLock).mockResolvedValueOnce(null).mockResolvedValueOnce(null);
 
 			await runWorker("/test/cwd-locked");
 
@@ -499,30 +514,52 @@ describe("QueueWorker", () => {
 			// release can wake us up.
 			expect(recordPendingWorker).toHaveBeenCalledTimes(1);
 			expect(recordPendingWorker).toHaveBeenCalledWith(expect.any(String), "/test/cwd-locked");
+			// Two acquisition attempts: the wait-mode acquire, then the
+			// post-record fail-fast retry (the lost-wakeup guard).
+			expect(acquireVaultWriteLock).toHaveBeenCalledTimes(2);
 			// And we MUST NOT have done any queue work.
 			expect(dequeueAllGitOperations).not.toHaveBeenCalled();
 			expect(acquireWorkerLock).not.toHaveBeenCalled();
 		});
 
-		it("consumePendingWorkers wakes other pending cwds but skips self on release", async () => {
-			// Pins the `pendingCwd !== cwd` guard on QueueWorker.ts L425 —
-			// when our own cwd is recorded as pending (e.g. we raced with
-			// ourselves), we must not infinitely re-spawn. Other cwds get
-			// `launchWorker` invoked.
-			vi.mocked(consumePendingWorkers).mockResolvedValueOnce(["/test/cwd", "/other/cwd"]);
+		it("proceeds when the holder releases during the pending-record gap (lost-wakeup guard)", async () => {
+			// Pins the lost-wakeup guard: the wait-mode acquire times out, we
+			// record our pending entry, and the holder happens to release in
+			// the gap between our timeout and the record landing. Its
+			// consumePendingWorkers may have run against an empty registry and
+			// will never re-spawn us — so the post-record fail-fast retry must
+			// grab the now-free lock and PROCEED to drain the queue rather than
+			// stranding the entry until this repo's next commit.
+			vi.mocked(acquireVaultWriteLock)
+				.mockResolvedValueOnce(null) // wait-mode acquire times out
+				.mockResolvedValueOnce({
+					release: vi.fn().mockResolvedValue(undefined),
+					refresh: vi.fn().mockResolvedValue(undefined),
+				}); // fail-fast retry succeeds — holder released in the gap
+
+			await runWorker("/test/cwd-retry");
+
+			// Intent was recorded before the retry (so any concurrent releaser
+			// would also see it), but this run grabbed the lock itself.
+			expect(recordPendingWorker).toHaveBeenCalledTimes(1);
+			expect(acquireVaultWriteLock).toHaveBeenCalledTimes(2);
+			// Crucially: we proceeded past the vault lock and did real work
+			// instead of returning early.
+			expect(acquireWorkerLock).toHaveBeenCalled();
+		});
+
+		it("delegates the on-release wakeup to wakePendingWorkers with its own cwd as selfCwd", async () => {
+			// QueueWorker no longer hand-rolls the drain+launch+skip-self loop;
+			// it delegates to the shared `wakePendingWorkers`, passing its own cwd
+			// as `selfCwd` so the helper won't re-spawn this very worker (which
+			// already chain-spawns for itself at the end of the drain). The actual
+			// skip-self + launch behaviour is exercised against the REAL helper in
+			// PendingWorkers.test.ts — here we only pin the delegation contract.
 			vi.mocked(dequeueAllGitOperations).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
-			// launchWorker refuses to spawn when the worker bundle is missing;
-			// satisfy its existence probe (and only that one) so the wake-up
-			// spawn for /other/cwd goes through.
-			vi.mocked(existsSync).mockImplementation((path) => String(path).endsWith("QueueWorker.js"));
 
 			await runWorker("/test/cwd");
 
-			expect(consumePendingWorkers).toHaveBeenCalledTimes(1);
-			// `launchWorker` is `v8 ignore`d (calls `spawn`), so we verify the
-			// observable side: `spawn` was invoked exactly once (for /other/cwd,
-			// not /test/cwd).
-			expect(vi.mocked(spawn)).toHaveBeenCalledTimes(1);
+			expect(wakePendingWorkers).toHaveBeenCalledWith(expect.any(String), expect.any(Function), "/test/cwd");
 		});
 	});
 
@@ -2333,7 +2370,7 @@ describe("QueueWorker", () => {
 				return { batches: 1, ingested: 2, outcome: "OK", topicFailures: [] };
 			});
 
-			await __test__.processQueueEntry(makeIngestOp("post-merge"), tmp, storageWithWiki(true), false);
+			await __test__.runIngestEntry(makeIngestOp("post-merge"), tmp, storageWithWiki(true));
 
 			expect(phaseSeenDuringIngest).toBe("ingest");
 			expect(existsSync(phaseFile)).toBe(false);
@@ -2353,7 +2390,7 @@ describe("QueueWorker", () => {
 			vi.mocked(drainIngest).mockRejectedValue(new Error("boom"));
 
 			await expect(
-				__test__.processQueueEntry(makeIngestOp("post-merge"), tmp, storageWithWiki(true), false),
+				__test__.runIngestEntry(makeIngestOp("post-merge"), tmp, storageWithWiki(true)),
 			).rejects.toThrow("boom");
 
 			expect(existsSync(phaseFile)).toBe(false);
@@ -2374,6 +2411,84 @@ describe("QueueWorker", () => {
 
 			expect(vi.mocked(drainIngest)).toHaveBeenCalledOnce();
 			expect(vi.mocked(renderTopicKBWiki)).toHaveBeenCalledOnce();
+		});
+
+		it("releases the entry-level vault-write.lock before running the ingest LLM phase", async () => {
+			// A dequeued ingest op must NOT be processed under the worker's entry-level
+			// vault-write.lock: the long reconcile phase would otherwise block every
+			// later commit-summary worker. The entry lock is released first; ingest's
+			// own per-write guard re-acquires it briefly per page.
+			vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-test" } as never);
+			const order: string[] = [];
+			const release = vi.fn(async () => {
+				order.push("release");
+			});
+			vi.mocked(acquireVaultWriteLock).mockResolvedValue({
+				release,
+				refresh: vi.fn().mockResolvedValue(undefined),
+			});
+			vi.mocked(drainIngest).mockImplementation(async () => {
+				order.push("drainIngest");
+				return { batches: 1, ingested: 1, outcome: "OK", topicFailures: [] };
+			});
+
+			const op = makeIngestOp("post-merge");
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/ingest.json" }])
+				.mockResolvedValueOnce([]);
+
+			await runWorker("/test/cwd");
+
+			expect(order).toEqual(["release", "drainIngest"]);
+		});
+
+		it("holds worker.lock THROUGH the ingest LLM phase, releasing it only after the drain", async () => {
+			// Direction-A guarantee: vault-write.lock is dropped before ingest (so
+			// cross-repo summary workers proceed) but the per-repo worker.lock stays
+			// held across the whole ingest. That serialises same-repo workers, so no
+			// concurrent summary run can clear the `ingest` worker-phase marker and no
+			// second ingest can race this one. Hence: drainIngest runs BEFORE
+			// releaseWorkerLock, while vault release happens BEFORE drainIngest.
+			vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-test" } as never);
+			const order: string[] = [];
+			vi.mocked(acquireVaultWriteLock).mockResolvedValue({
+				release: vi.fn(async () => {
+					order.push("vault-release");
+				}),
+				refresh: vi.fn().mockResolvedValue(undefined),
+			});
+			vi.mocked(releaseWorkerLock).mockImplementation(async () => {
+				order.push("worker-release");
+			});
+			vi.mocked(drainIngest).mockImplementation(async () => {
+				order.push("drainIngest");
+				return { batches: 1, ingested: 1, outcome: "OK", topicFailures: [] };
+			});
+
+			const op = makeIngestOp("post-merge");
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/ingest.json" }])
+				.mockResolvedValueOnce([]);
+
+			await runWorker("/test/cwd");
+
+			expect(order).toEqual(["vault-release", "drainIngest", "worker-release"]);
+		});
+
+		it("passes a per-write guard to drainIngest and renderTopicKBWiki so ingest writes self-lock", async () => {
+			vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-test" } as never);
+			vi.mocked(drainIngest).mockResolvedValue({ batches: 1, ingested: 2, outcome: "OK", topicFailures: [] });
+
+			const op = makeIngestOp("post-merge");
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/ingest.json" }])
+				.mockResolvedValueOnce([]);
+
+			await runWorker("/test/cwd");
+
+			const drainOpts = vi.mocked(drainIngest).mock.calls[0]?.[2];
+			expect(typeof drainOpts?.writeGuard).toBe("function");
+			expect(typeof vi.mocked(renderTopicKBWiki).mock.calls[0]?.[2]).toBe("function");
 		});
 
 		it("skips drainIngest when no API key is configured", async () => {

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -99,9 +99,14 @@ import type { SessionTranscript } from "../core/TranscriptReader.js";
 import { buildMultiSessionContext, readTranscript } from "../core/TranscriptReader.js";
 import { deriveSourceTag } from "../install/DistPathResolver.js";
 import { createLogger, errMsg, getJolliMemoryDir, setLogDir, setLogLevel } from "../Logger.js";
-import { consumePendingWorkers, recordPendingWorker } from "../sync/PendingWorkers.js";
+import { recordPendingWorker, wakePendingWorkers } from "../sync/PendingWorkers.js";
 import { deriveMemoryBankRoot } from "../sync/SyncBootstrap.js";
-import { acquireVaultWriteLock, DEFAULT_VAULT_WRITE_WAIT_MS } from "../sync/VaultWriteLock.js";
+import {
+	acquireVaultWriteLock,
+	DEFAULT_VAULT_WRITE_WAIT_MS,
+	VaultWriteBusyError,
+	withVaultWriteLock,
+} from "../sync/VaultWriteLock.js";
 import {
 	type CommitGitOperation,
 	type CommitInfo,
@@ -332,7 +337,7 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 	// sync-allowlist-staging.md (Option (a) — wait-mode, not registry).
 	const vaultLockConfig = await loadConfig();
 	const memoryBankRoot = deriveMemoryBankRoot(vaultLockConfig.localFolder);
-	const vaultLock = await acquireVaultWriteLock(memoryBankRoot, {
+	let vaultLock = await acquireVaultWriteLock(memoryBankRoot, {
 		wait: DEFAULT_VAULT_WRITE_WAIT_MS,
 	});
 	if (vaultLock === null) {
@@ -350,11 +355,32 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 		// the majority — also get the cross-repo wakeup. Passing raw
 		// `vaultLockConfig.localFolder` would no-op when it's undefined.
 		await recordPendingWorker(memoryBankRoot, cwd);
-		log.warn(
-			"Could not acquire vault-write.lock within %d ms; another writer is busy. Exiting — recorded pending-worker entry so the next lock release re-spawns us.",
-			DEFAULT_VAULT_WRITE_WAIT_MS,
+
+		// Lost-wakeup guard. The registry hand-off above has a TOCTOU window:
+		// the holder can release AND drain the registry in the gap between our
+		// wait expiring and `recordPendingWorker` landing. Its
+		// `consumePendingWorkers` then sees an empty registry and never
+		// re-spawns us — and with no further commit/sync round in this repo
+		// our queue entry is orphaned forever (the exact failure that left an
+		// amended commit's summary stranded under its pre-amend hash). So
+		// after recording intent, attempt one fail-fast acquire: if the lock
+		// freed during the gap we grab it here and PROCEED; if it's still held
+		// the current holder will observe our now-recorded entry on its next
+		// release. Either path closes the orphan-entry gap. Recording BEFORE
+		// this retry is what makes it airtight — a concurrent releaser always
+		// sees our entry, so the worst case is a benign duplicate spawn that
+		// loses the worker.lock race and exits.
+		vaultLock = await acquireVaultWriteLock(memoryBankRoot, "fail-fast");
+		if (vaultLock === null) {
+			log.warn(
+				"Could not acquire vault-write.lock within %d ms; another writer is busy. Exiting — recorded pending-worker entry so the next lock release re-spawns us.",
+				DEFAULT_VAULT_WRITE_WAIT_MS,
+			);
+			return;
+		}
+		log.info(
+			"Acquired vault-write.lock on the post-timeout fail-fast retry — the holder released during the pending-record gap; proceeding instead of stranding the queue entry.",
 		);
-		return;
 	}
 
 	// Periodically bump vault-write.lock's mtime so a long-running LLM call
@@ -367,11 +393,58 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 	}, WORKER_LOCK_REFRESH_INTERVAL_MS);
 	/* v8 ignore stop */
 
+	// vault-write.lock is released BEFORE the unlocked-ingest phase, but worker.lock
+	// is held THROUGH it (see that phase below). Releasing the vault-wide lock lets
+	// cross-repo commit-summary workers proceed; holding the per-repo worker.lock
+	// keeps the ingest's worker-phase marker and topic-page writes uncontested
+	// within this repo — no same-repo summary worker (which would clear the marker)
+	// and no second ingest can race. `releaseVault` is idempotent: called explicitly
+	// before ingest and again in the outer finally as the error-path backstop.
+	let vaultReleased = false;
+	const releaseVault = async (): Promise<void> => {
+		if (vaultReleased) return;
+		vaultReleased = true;
+		clearInterval(vaultRefreshTimer);
+		await vaultLock.release();
+	};
+	// Cross-repo wakeup (P2): wake any worker that timed out waiting for
+	// vault-write.lock while WE held it (it recorded its cwd in the per-vault
+	// registry). Draining the registry makes this safe to call more than once; we
+	// call it right after releasing the lock so waiters don't idle through our
+	// ingest, and again in the outer finally to cover the early-return paths.
+	// `cwd` is passed as `selfCwd` so we don't re-launch ourselves — the worker
+	// already chain-spawns for its own cwd at the end of the drain. The shared
+	// `wakePendingWorkers` (also used by the compile paths via withVaultWriteLock)
+	// is the single implementation of the drain+launch loop.
+	const wakeWaiters = async (): Promise<void> => {
+		await wakePendingWorkers(memoryBankRoot, launchWorker, cwd);
+	};
+
+	// A dequeued ingest entry only flips this flag inside the locked drain; its long
+	// reconcile LLM phase runs in the unlocked-ingest phase below (worker.lock held,
+	// vault-write.lock released) so it never holds the vault-wide lock.
+	let storage: StorageProvider | null = null;
+	let ingestRequested = false;
+	let ingestTriggeredBy: IngestOperation["triggeredBy"] = "post-commit";
+	// worker.lock (per-repo) is released only AFTER the unlocked-ingest phase, so its
+	// mtime-refresh timer must outlive ingest too — otherwise the stale-lock reclaimer
+	// could hand the lock to a second worker mid-ingest. `releaseWorker` is idempotent
+	// (explicit release before the chain-spawn check, backstop in the outer finally).
+	let workerRefreshTimer: ReturnType<typeof setInterval> | undefined;
+	let workerLockReleased = true;
+	const releaseWorker = async (): Promise<void> => {
+		if (workerLockReleased) return;
+		workerLockReleased = true;
+		if (workerRefreshTimer) clearInterval(workerRefreshTimer);
+		await releaseWorkerLock(cwd);
+		log.info("=== Queue worker finished ===");
+	};
+
 	try {
 		// Create storage provider based on config (orphan/dual-write/folder).
 		// Now safe — we hold `vault-write.lock` so no concurrent writer can race
 		// on `resolveKBPath`'s side effects.
-		const storage = await createStorage(cwd, cwd);
+		storage = await createStorage(cwd, cwd);
 		setActiveStorage(storage);
 
 		// Acquire worker.lock — the per-source-repo lock that serialises two
@@ -385,6 +458,7 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 			log.warn("Could not acquire worker lock, another worker may be running. Exiting.");
 			return;
 		}
+		workerLockReleased = false;
 
 		// Clear a stale `worker-phase` marker at the source. Holding worker.lock
 		// proves no other worker for this repo is alive, so any leftover phase file
@@ -403,7 +477,7 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 		// Periodically bump the worker.lock mtime — same rationale as
 		// vault-write.lock above.
 		/* v8 ignore start -- setInterval's lambda only fires on a real timer tick; unit tests finish in milliseconds and never observe the callback. */
-		const refreshTimer = setInterval(() => {
+		workerRefreshTimer = setInterval(() => {
 			void refreshWorkerLockMtime(cwd);
 		}, WORKER_LOCK_REFRESH_INTERVAL_MS);
 		/* v8 ignore stop */
@@ -426,9 +500,21 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 					// stop inside the inner loop so the outer while condition can re-check and
 					// exit cleanly. The subsequent chain-spawn (line below) picks up leftovers.
 					if (processedCount >= MAX_ENTRIES_PER_RUN) break;
+					// Divert ingest out of the locked drain: record the request and consume
+					// the trigger entry. The reconcile runs in the unlocked-ingest phase
+					// after both entry-level locks are released, so its minutes-long LLM
+					// phase never holds vault-write.lock. Deleting here (we hold worker.lock)
+					// avoids an infinite re-dequeue; losing the trigger on a crash is benign
+					// — the next commit re-triggers and unprocessed sources stay pending.
+					if (isIngestOperation(op)) {
+						ingestRequested = true;
+						ingestTriggeredBy = op.triggeredBy;
+						await deleteQueueEntry(filePath);
+						continue;
+					}
 					try {
 						await processQueueEntry(op, cwd, storage, force);
-						if (!isIngestOperation(op)) committedThisRun = true;
+						committedThisRun = true;
 					} catch (error: unknown) {
 						// Queue entries are deleted regardless of success or failure (fire-and-forget).
 						// Retry is intentionally not implemented: pipeline steps (transcript cursor
@@ -437,10 +523,11 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 						// TODO: Support re-summarize for specific commits (e.g., after LLM quota
 						// replenishment). Requires persisting transcripts to the orphan branch BEFORE
 						// the LLM call so re-summarize can read them back without cursor dependency.
+						// Ingest is diverted before this try, so `op` here is always commit-typed.
 						log.error(
 							"Failed to process queue entry type=%s ref=%s: %s",
 							op.type,
-							isIngestOperation(op) ? "ingest" : (op as CommitGitOperation).commitHash.substring(0, 8),
+							(op as CommitGitOperation).commitHash.substring(0, 8),
 							(error as Error).message,
 						);
 					}
@@ -465,14 +552,56 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 			/* v8 ignore start -- catch block only reached if dequeueAllGitOperations throws unexpectedly */
 		} catch (error: unknown) {
 			log.error("Worker failed: %s", (error as Error).message);
-		} finally {
-			/* v8 ignore stop */
-			clearInterval(refreshTimer);
-			await releaseWorkerLock(cwd);
-			log.info("=== Queue worker finished ===");
+		}
+		/* v8 ignore stop */
+
+		// Release vault-write.lock BEFORE the (potentially minutes-long) ingest:
+		// cross-repo commit-summary workers only need the vault-wide lock, which we
+		// no longer hold. worker.lock stays held so no same-repo worker races us.
+		await releaseVault();
+
+		// ── Unlocked-ingest phase (vault-write.lock released; worker.lock held) ───
+		// The reconcile LLM phase runs with NO vault-write.lock; only each individual
+		// write re-acquires it briefly via `writeGuard` (per topic page, plus the
+		// index / processed-set / wiki render), so a slow ingest never blocks the
+		// cross-repo commit-summary workers that wait on the same lock. Holding
+		// worker.lock throughout is what keeps it safe within THIS repo: no same-repo
+		// summary worker can run startup cleanup or processQueueEntry (and thus clear
+		// the `ingest` worker-phase marker) mid-run, and no second ingest can race
+		// this one. `storage` is null only if createStorage threw before the drain.
+		if (ingestRequested && storage !== null) {
+			// Wake cross-repo waiters now (vault-write.lock is free) so they don't idle
+			// through our ingest. Each per-write guard below ALSO wakes on its release
+			// (via the releaseHook), so a worker that times out and registers DURING the
+			// ingest is woken at the next per-write release rather than waiting for the
+			// whole drain — matching the compile paths. The outer-finally wake is the
+			// final backstop.
+			await wakeWaiters();
+			const writeGuard = async (fn: () => Promise<void>): Promise<void> => {
+				const r = await withVaultWriteLock(memoryBankRoot, { wait: DEFAULT_VAULT_WRITE_WAIT_MS }, fn, {
+					launch: launchWorker,
+					selfCwd: cwd,
+				});
+				// Typed busy signal (shared verbatim with the compile guards) so
+				// drainIngest's page-write catch can tell contention from a real fault.
+				if (!r.ran) throw new VaultWriteBusyError();
+			};
+			try {
+				const ingestOp: IngestOperation = {
+					type: "ingest",
+					triggeredBy: ingestTriggeredBy,
+					createdAt: new Date().toISOString(),
+				};
+				await runIngestEntry(ingestOp, cwd, storage, writeGuard);
+			} catch (e) {
+				log.error("Unlocked ingest phase failed (non-fatal): %s", errMsg(e));
+			}
 		}
 
-		// Chain spawn: if new entries appeared while we were processing, spawn another Worker
+		// Release worker.lock, THEN chain-spawn: a same-repo successor (commits that
+		// arrived while we held the lock through ingest, plus the post-commit ingest
+		// trigger enqueued above) can acquire worker.lock immediately on its spawn.
+		await releaseWorker();
 		const remaining = await dequeueAllGitOperations(cwd);
 		/* v8 ignore start -- chain spawn only occurs when new entries arrive during worker processing */
 		if (remaining.length > 0) {
@@ -481,27 +610,12 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 		}
 		/* v8 ignore stop */
 	} finally {
-		// Outer finally — vault-write.lock release. Runs AFTER worker.lock
-		// release and AFTER the chain-spawn check, so a chain-spawned successor
-		// can re-acquire vault-write.lock immediately on its own spawn.
-		clearInterval(vaultRefreshTimer);
-		await vaultLock.release();
-		// Cross-repo wakeup (P2). Any worker that timed out waiting for
-		// vault-write.lock while WE held it recorded its cwd; spawn a
-		// successor for each so the queue entry isn't stranded until that
-		// repo's next post-commit hook. Idempotent: `launchWorker` against
-		// an empty queue is a cheap no-op.
-		try {
-			const pending = await consumePendingWorkers(memoryBankRoot);
-			for (const pendingCwd of pending) {
-				if (pendingCwd !== cwd) {
-					log.info("Waking pending worker for cwd=%s", pendingCwd);
-					launchWorker(pendingCwd);
-				}
-			}
-		} catch (e) {
-			log.warn("consumePendingWorkers on release failed (non-fatal): %s", (e as Error).message);
-		}
+		// Backstops (idempotent): cover the early-return and mid-run-throw paths
+		// where the explicit releases above didn't run. worker.lock is released
+		// first (so a successor can grab it), then the vault-wide lock.
+		await releaseWorker();
+		await releaseVault();
+		await wakeWaiters();
 	}
 }
 
@@ -532,7 +646,67 @@ function clearLeftoverIngestMarker(cwd: string): void {
 }
 
 /**
- * Processes a single queue entry based on its type.
+ * Runs a topic-KB ingest with the extension's worker-phase marker around it.
+ *
+ * Called from runWorker's UNLOCKED ingest phase (both entry-level locks already
+ * released). The phase marker (`ingest`) is consumed by the extension's
+ * worker-busy gates (and the toolbar label): while it reads `ingest` AND is
+ * fresh, Commit/Squash stay enabled and the toolbar shows "Updating Memory
+ * Bank…". `writeGuard` is threaded down to drainIngest + renderTopicKBWiki so
+ * each individual write re-acquires `vault-write.lock` briefly — the reconcile
+ * LLM phase between writes holds no lock.
+ */
+async function runIngestEntry(
+	op: IngestOperation,
+	cwd: string,
+	storage: StorageProvider,
+	writeGuard: (fn: () => Promise<void>) => Promise<void> = (fn) => fn(),
+): Promise<void> {
+	log.info("Processing queue entry: type=ingest triggeredBy=%s", op.triggeredBy);
+	// Best-effort marker — a failure only over-blocks (missing marker = blocking
+	// summary phase), never under-blocks.
+	const phaseFile = join(getJolliMemoryDir(cwd), WORKER_PHASE_FILE);
+	try {
+		writeFileSync(phaseFile, "ingest");
+	} catch (e) {
+		/* v8 ignore next -- best-effort marker; a write failure only over-blocks */
+		log.debug("worker-phase write skipped (non-fatal): %s", errMsg(e));
+	}
+	// Heartbeat: keep the marker's mtime fresh for the whole ingest. Readers
+	// treat a stale marker as blocking (fail-safe), so a long ingest needs this
+	// to stay exempt — and conversely an orphaned `ingest` marker (both the
+	// cleanup below and the per-entry guard failed) ages out instead of holding
+	// the gates open during a later summary run.
+	/* v8 ignore start -- timer callback never fires inside fast unit tests */
+	const phaseRefreshTimer = setInterval(() => {
+		try {
+			writeFileSync(phaseFile, "ingest");
+		} catch {
+			// Next tick retries; reader-side staleness covers persistent failure.
+		}
+	}, WORKER_LOCK_REFRESH_INTERVAL_MS);
+	/* v8 ignore stop */
+	try {
+		await runIngestFromQueue(op, cwd, storage, writeGuard);
+	} finally {
+		clearInterval(phaseRefreshTimer);
+		try {
+			rmSync(phaseFile, { force: true });
+		} catch (e) {
+			/* v8 ignore start -- needs an OS-level rm failure (e.g. Windows AV briefly holding the file) */
+			// A surviving `ingest` marker would keep the extension's gates open while
+			// a later summary run is in flight. Two backstops cover it:
+			// clearLeftoverIngestMarker before each commit-typed entry, and the
+			// reader-side mtime staleness check.
+			log.warn("worker-phase cleanup failed — relying on per-entry guard + staleness: %s", errMsg(e));
+			/* v8 ignore stop */
+		}
+	}
+}
+
+/**
+ * Processes a single commit-typed queue entry. Ingest entries are diverted to
+ * the unlocked-ingest phase by runWorker and never reach here.
  * Called by runWorker() for each entry in the queue.
  */
 async function processQueueEntry(
@@ -541,57 +715,6 @@ async function processQueueEntry(
 	storage: StorageProvider,
 	force: boolean,
 ): Promise<void> {
-	// SP3 — topic-KB ingest. Drains all pending sources and renders the wiki.
-	// No commit-hash or branch field; dispatch and return before commit-only code.
-	if (isIngestOperation(op)) {
-		log.info("Processing queue entry: type=ingest triggeredBy=%s", op.triggeredBy);
-		// Phase marker consumed by the extension's worker-busy gates (and the
-		// toolbar label): while it reads `ingest` AND is fresh, Commit/Squash
-		// stay enabled and the toolbar shows "Updating Memory Bank…". The write
-		// is best-effort — a failure only over-blocks (missing marker = blocking
-		// summary phase), never under-blocks.
-		const phaseFile = join(getJolliMemoryDir(cwd), WORKER_PHASE_FILE);
-		try {
-			writeFileSync(phaseFile, "ingest");
-		} catch (e) {
-			/* v8 ignore next -- best-effort marker; a write failure only over-blocks */
-			log.debug("worker-phase write skipped (non-fatal): %s", errMsg(e));
-		}
-		// Heartbeat: keep the marker's mtime fresh for the whole ingest. Readers
-		// treat a stale marker as blocking (fail-safe), so a long ingest needs
-		// this to stay exempt — and conversely an orphaned `ingest` marker (both
-		// the cleanup below and the per-entry guard failed) ages out instead of
-		// holding the gates open during a later summary run.
-		/* v8 ignore start -- timer callback never fires inside fast unit tests */
-		const phaseRefreshTimer = setInterval(() => {
-			try {
-				writeFileSync(phaseFile, "ingest");
-			} catch {
-				// Next tick retries; reader-side staleness covers persistent failure.
-			}
-		}, WORKER_LOCK_REFRESH_INTERVAL_MS);
-		/* v8 ignore stop */
-		try {
-			await runIngestFromQueue(op, cwd, storage);
-		} finally {
-			clearInterval(phaseRefreshTimer);
-			try {
-				rmSync(phaseFile, { force: true });
-			} catch (e) {
-				/* v8 ignore start -- needs an OS-level rm failure (e.g. Windows AV briefly holding the file) */
-				// A surviving `ingest` marker would keep the extension's gates open
-				// while this same drain moves on to blocking summary entries. Two
-				// backstops cover it: clearLeftoverIngestMarker before each
-				// commit-typed entry, and the reader-side mtime staleness check.
-				log.warn("worker-phase cleanup failed — relying on per-entry guard + staleness: %s", errMsg(e));
-				/* v8 ignore stop */
-			}
-		}
-		return;
-	}
-
-	// At this point the only remaining operation is commit-typed (the GitOperation
-	// union is CommitGitOperation | IngestOperation, and ingest returned above).
 	// A summary run must present a blocking phase to the extension's gates, so
 	// clear any `ingest` marker a failed cleanup left behind before starting.
 	clearLeftoverIngestMarker(cwd);
@@ -662,7 +785,12 @@ function now(): number {
  * visible `_wiki/` layer. No branch field — the topic KB is repo-wide.
  * Credential-missing is a silent skip (no API key → skip).
  */
-async function runIngestFromQueue(op: IngestOperation, cwd: string, storage: StorageProvider): Promise<void> {
+async function runIngestFromQueue(
+	op: IngestOperation,
+	cwd: string,
+	storage: StorageProvider,
+	writeGuard: (fn: () => Promise<void>) => Promise<void> = (fn) => fn(),
+): Promise<void> {
 	const { drainIngest } = await import("../core/IngestPipeline.js");
 	const { renderTopicKBWiki } = await import("../core/TopicWikiRenderer.js");
 	const { appendCredentialMissingRun } = await import("../core/IngestRunStore.js");
@@ -672,7 +800,7 @@ async function runIngestFromQueue(op: IngestOperation, cwd: string, storage: Sto
 		await appendCredentialMissingRun(cwd, op.triggeredBy);
 		return;
 	}
-	const result = await drainIngest(cwd, config, { triggeredBy: op.triggeredBy });
+	const result = await drainIngest(cwd, config, { triggeredBy: op.triggeredBy, writeGuard });
 	log.info("Ingest drained: %d batches, %d sources (%s)", result.batches, result.ingested, op.triggeredBy);
 	// Re-render when new sources landed, OR when the visible wiki is gone (the user
 	// deleted `_wiki/`): without the second clause a deleted wiki would never come
@@ -680,7 +808,7 @@ async function runIngestFromQueue(op: IngestOperation, cwd: string, storage: Sto
 	// (ingested === 0 every commit), leaving `jolli compile` as the only recovery.
 	const wikiMissing = storage.isTopicWikiPresent ? !storage.isTopicWikiPresent() : false;
 	if (result.ingested > 0 || wikiMissing) {
-		await renderTopicKBWiki(cwd, storage);
+		await renderTopicKBWiki(cwd, storage, writeGuard);
 	}
 }
 
@@ -2789,6 +2917,7 @@ export const __test__ = {
 	loadSessionTranscripts,
 	buildStoredTranscript,
 	processQueueEntry,
+	runIngestEntry,
 	reassociateMetadata,
 };
 

--- a/cli/src/sync/PendingWorkers.test.ts
+++ b/cli/src/sync/PendingWorkers.test.ts
@@ -23,7 +23,12 @@ vi.mock("node:os", async () => {
 	return { ...actual, homedir: () => mockHomeDir.value };
 });
 
-import { consumePendingWorkers, getPendingWorkersDir, recordPendingWorker } from "./PendingWorkers.js";
+import {
+	consumePendingWorkers,
+	getPendingWorkersDir,
+	recordPendingWorker,
+	wakePendingWorkers,
+} from "./PendingWorkers.js";
 
 let tempDir: string;
 
@@ -169,5 +174,68 @@ describe("consumePendingWorkers", () => {
 		await recordPendingWorker(memoryBankRoot, "/cwd-2");
 		const cwds = await consumePendingWorkers(memoryBankRoot);
 		expect(cwds).toEqual(["/cwd-2"]);
+	});
+});
+
+describe("wakePendingWorkers", () => {
+	it("drains the registry and launches a worker for each recorded cwd", async () => {
+		const memoryBankRoot = join(tempDir, "vault");
+		await recordPendingWorker(memoryBankRoot, "/repo-a");
+		await recordPendingWorker(memoryBankRoot, "/repo-b");
+		const launched: string[] = [];
+
+		await wakePendingWorkers(memoryBankRoot, (cwd) => launched.push(cwd));
+
+		expect(launched.sort()).toEqual(["/repo-a", "/repo-b"]);
+		// Drained — a second wake launches nothing.
+		const again: string[] = [];
+		await wakePendingWorkers(memoryBankRoot, (cwd) => again.push(cwd));
+		expect(again).toEqual([]);
+	});
+
+	it("skips the holder's own cwd when selfCwd is supplied", async () => {
+		const memoryBankRoot = join(tempDir, "vault");
+		await recordPendingWorker(memoryBankRoot, "/repo-self");
+		await recordPendingWorker(memoryBankRoot, "/repo-other");
+		const launched: string[] = [];
+
+		await wakePendingWorkers(memoryBankRoot, (cwd) => launched.push(cwd), "/repo-self");
+
+		expect(launched).toEqual(["/repo-other"]);
+	});
+
+	it("is a no-op when the registry is empty", async () => {
+		const memoryBankRoot = join(tempDir, "vault");
+		const launched: string[] = [];
+		await wakePendingWorkers(memoryBankRoot, (cwd) => launched.push(cwd));
+		expect(launched).toEqual([]);
+	});
+
+	it("swallows a launch() throw (best-effort — one bad spawn must not abort the rest)", async () => {
+		const memoryBankRoot = join(tempDir, "vault");
+		await recordPendingWorker(memoryBankRoot, "/repo-a");
+		// launch throws — wakePendingWorkers must not propagate it.
+		await expect(
+			wakePendingWorkers(memoryBankRoot, () => {
+				throw new Error("spawn failed");
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	it("isolates a launch() throw per cwd — a later repo is still launched", async () => {
+		// The registry is DRAINED before launching, so a throw that aborted the loop
+		// would silently drop every later (already-consumed) repo. Each launch must
+		// be isolated so one bad spawn never strands the others.
+		const memoryBankRoot = join(tempDir, "vault");
+		await recordPendingWorker(memoryBankRoot, "/repo-throws");
+		await recordPendingWorker(memoryBankRoot, "/repo-ok");
+		const launched: string[] = [];
+
+		await wakePendingWorkers(memoryBankRoot, (cwd) => {
+			if (cwd === "/repo-throws") throw new Error("spawn failed");
+			launched.push(cwd);
+		});
+
+		expect(launched).toEqual(["/repo-ok"]);
 	});
 });

--- a/cli/src/sync/PendingWorkers.ts
+++ b/cli/src/sync/PendingWorkers.ts
@@ -149,3 +149,52 @@ export async function consumePendingWorkers(memoryBankRoot: string): Promise<Rea
 	}
 	return cwds;
 }
+
+/**
+ * Drain the pending-worker registry for `memoryBankRoot` and `launch` a worker
+ * for every recorded cwd (skipping `selfCwd` when supplied). The single place
+ * a `vault-write.lock` releaser turns "someone timed out waiting on me" into a
+ * re-spawn.
+ *
+ * `launch` is injected rather than imported so this stays in the sync layer
+ * (the spawn helper, `launchWorker`, lives in `hooks/QueueWorker.ts` and varies
+ * by host — CLI vs VS Code bundle). `selfCwd` exists for the QueueWorker case:
+ * a worker draining its OWN queue already does a chain-spawn for its cwd at the
+ * end of `runWorker`, so re-launching itself here would be a redundant spawn
+ * that loses the worker.lock race. Holders that are NOT queue workers (the
+ * compile/ingest paths) pass no `selfCwd` so a pending worker for the same repo
+ * still gets woken.
+ *
+ * Best-effort: a drain/launch failure is logged and swallowed. The worst
+ * outcome is a worker that isn't auto-woken — its queue entry stays on disk for
+ * the repo's next post-commit hook.
+ */
+export async function wakePendingWorkers(
+	memoryBankRoot: string,
+	launch: (cwd: string) => void,
+	selfCwd?: string,
+): Promise<void> {
+	// `consumePendingWorkers` DRAINS the registry (reads + deletes) before
+	// returning, so the entries are already gone once we start launching. A launch
+	// failure must therefore be isolated PER cwd — letting one throw abort the loop
+	// would silently drop every later (already-consumed) repo, re-opening the
+	// orphaned-queue-entry gap this whole mechanism closes.
+	let pending: ReadonlyArray<string>;
+	try {
+		pending = await consumePendingWorkers(memoryBankRoot);
+		/* v8 ignore start -- consumePendingWorkers is contractually non-throwing (readdir/read/unlink failures are caught internally); this guard only exists so a future contract change can't make wakePendingWorkers throw out of a finally block */
+	} catch (e) {
+		log.warn("wakePendingWorkers: draining the pending registry failed (non-fatal): %s", (e as Error).message);
+		return;
+	}
+	/* v8 ignore stop */
+	for (const cwd of pending) {
+		if (selfCwd !== undefined && cwd === selfCwd) continue;
+		try {
+			log.info("Waking pending worker for cwd=%s", cwd);
+			launch(cwd);
+		} catch (e) {
+			log.warn("wakePendingWorkers: launch failed for cwd=%s (non-fatal): %s", cwd, (e as Error).message);
+		}
+	}
+}

--- a/cli/src/sync/VaultWriteLock.test.ts
+++ b/cli/src/sync/VaultWriteLock.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LOCK_TIMEOUT_MS } from "../core/LockPrimitives.js";
+import { consumePendingWorkers, recordPendingWorker } from "./PendingWorkers.js";
 import { getVaultWriteLockPath } from "./VaultLockPath.js";
 import { acquireVaultWriteLock, isVaultWriteLockHeld, withVaultWriteLock } from "./VaultWriteLock.js";
 
@@ -189,6 +190,85 @@ describe("acquireVaultWriteLock", () => {
 				}),
 			).rejects.toThrow("body failed");
 			expect(await isVaultWriteLockHeld(vault)).toBe(false);
+		});
+	});
+
+	describe("withVaultWriteLock pending-worker wakeup on release", () => {
+		// Regression contract: a long compile/ingest holder serialised on
+		// vault-write.lock can starve a post-commit QueueWorker that times out
+		// waiting and records itself in the pending registry. Before this fix the
+		// compile's release did NOT drain the registry — only QueueWorker and
+		// SyncBootstrap did — so the timed-out worker's queue entry was orphaned
+		// until the repo's next commit/sync (the "amended commit's summary never
+		// generated" symptom). withVaultWriteLock must wake pending workers on
+		// release so EVERY holder closes the gap, not just the two that
+		// re-implemented the drain by hand.
+
+		it("wakes (and drains) pending workers recorded for this vault on release", async () => {
+			const waiterCwd = "/repo/blocked-waiter";
+			await recordPendingWorker(vault, waiterCwd);
+			const launched: string[] = [];
+
+			const result = await withVaultWriteLock(vault, "fail-fast", async () => "ok", {
+				launch: (cwd) => launched.push(cwd),
+			});
+
+			expect(result).toEqual({ ran: true, value: "ok" });
+			expect(launched).toEqual([waiterCwd]);
+			// Registry drained so the next release doesn't double-spawn.
+			expect(await consumePendingWorkers(vault)).toEqual([]);
+		});
+
+		it("wakes pending workers even when the body throws", async () => {
+			const waiterCwd = "/repo/blocked-waiter";
+			await recordPendingWorker(vault, waiterCwd);
+			const launched: string[] = [];
+
+			await expect(
+				withVaultWriteLock(
+					vault,
+					"fail-fast",
+					async () => {
+						throw new Error("body failed");
+					},
+					{ launch: (cwd) => launched.push(cwd) },
+				),
+			).rejects.toThrow("body failed");
+
+			expect(launched).toEqual([waiterCwd]);
+		});
+
+		it("does NOT wake or drain when the lock was not acquired (ran:false)", async () => {
+			const waiterCwd = "/repo/blocked-waiter";
+			await recordPendingWorker(vault, waiterCwd);
+			const launched: string[] = [];
+			const blocker = await acquireVaultWriteLock(vault, "fail-fast");
+
+			const result = await withVaultWriteLock(vault, "fail-fast", async () => "ok", {
+				launch: (cwd) => launched.push(cwd),
+			});
+
+			expect(result).toEqual({ ran: false });
+			// We never held the lock, so we are not the releaser — leave the
+			// registry for whoever actually releases.
+			expect(launched).toEqual([]);
+			expect(await consumePendingWorkers(vault)).toEqual([waiterCwd]);
+			await blocker?.release();
+		});
+
+		it("skips the holder's own cwd when selfCwd is supplied", async () => {
+			const ownCwd = "/repo/self";
+			const otherCwd = "/repo/other";
+			await recordPendingWorker(vault, ownCwd);
+			await recordPendingWorker(vault, otherCwd);
+			const launched: string[] = [];
+
+			await withVaultWriteLock(vault, "fail-fast", async () => undefined, {
+				launch: (cwd) => launched.push(cwd),
+				selfCwd: ownCwd,
+			});
+
+			expect(launched).toEqual([otherCwd]);
 		});
 	});
 

--- a/cli/src/sync/VaultWriteLock.ts
+++ b/cli/src/sync/VaultWriteLock.ts
@@ -91,6 +91,7 @@ import {
 	tryAcquireOnce,
 } from "../core/LockPrimitives.js";
 import { createLogger } from "../Logger.js";
+import { wakePendingWorkers } from "./PendingWorkers.js";
 import { getVaultWriteLockPath } from "./VaultLockPath.js";
 
 const log = createLogger("Sync:VaultWriteLock");
@@ -115,6 +116,25 @@ export const DEFAULT_PULL_LOCK_WAIT_MS = 10_000;
 
 /** Poll interval while waiting for the lock. */
 export const DEFAULT_VAULT_WRITE_POLL_MS = 100;
+
+/**
+ * Thrown by a `writeGuard` wrapper when its `withVaultWriteLock` call returns
+ * `{ ran: false }` — i.e. a concurrent vault writer (background QueueWorker,
+ * sync, or another compile) held `vault-write.lock` for the whole wait budget.
+ *
+ * A distinct type (rather than a bare `Error`) lets callers tell a transient,
+ * user-actionable "busy — try again shortly" state apart from a real write
+ * failure (disk, corruption) and react differently. The `jolli compile` CLI
+ * uses this to turn a busy lock on its *prerequisite* writes into a clean
+ * retry-later exit instead of an uncaught stack trace, while a genuine write
+ * error still propagates.
+ */
+export class VaultWriteBusyError extends Error {
+	constructor(message = "could not acquire vault-write.lock within budget") {
+		super(message);
+		this.name = "VaultWriteBusyError";
+	}
+}
 
 /**
  * `acquireVaultWriteLock` mode discriminator.
@@ -198,6 +218,27 @@ export async function acquireVaultWriteLock(
 export const VAULT_WRITE_LOCK_REFRESH_INTERVAL_MS = 60_000;
 
 /**
+ * Optional pending-worker wakeup wired into `withVaultWriteLock`'s release.
+ *
+ * Production holders MUST pass this so a QueueWorker that timed out waiting on
+ * the lock (and recorded itself in the per-vault pending registry) gets
+ * re-spawned the moment this holder releases. Omitting it re-opens the
+ * orphaned-queue-entry bug — the symptom that a long compile/ingest leaves an
+ * amended commit's summary stranded because nothing drains the registry on the
+ * compile's release. The drain is keyed off the SAME `vaultRoot` the lock is,
+ * so no extra path needs threading.
+ *
+ *   - `launch` — injected `launchWorker` (lives in `hooks/QueueWorker.ts`,
+ *     varies by host) so this sync-layer helper need not import it.
+ *   - `selfCwd` — skip waking this cwd (QueueWorker passes its own cwd because
+ *     it chain-spawns for itself separately; compile holders omit it).
+ */
+export interface VaultWriteLockReleaseHook {
+	readonly launch: (cwd: string) => void;
+	readonly selfCwd?: string;
+}
+
+/**
  * Acquire `vault-write.lock`, run `body` while holding it (heartbeating the
  * mtime so the stale-reclaimer can't steal it during a long drain), then
  * release — on success, throw, OR early return. The compile paths
@@ -208,11 +249,18 @@ export const VAULT_WRITE_LOCK_REFRESH_INTERVAL_MS = 60_000;
  * Returns `{ ran: true, value }` when the lock was acquired and the body ran,
  * or `{ ran: false }` when the lock was busy (fail-fast miss / wait timeout).
  * Re-throws whatever `body` throws after releasing the lock.
+ *
+ * When `releaseHook` is supplied, pending workers that timed out waiting for
+ * this lock are woken on release (success, throw, AND early-return paths — but
+ * NOT the `ran:false` path, since we never held the lock there and are not the
+ * releaser). This is what makes `withVaultWriteLock` close the cross-holder
+ * wakeup gap instead of each caller re-implementing the drain.
  */
 export async function withVaultWriteLock<T>(
 	vaultRoot: string,
 	mode: VaultWriteLockMode,
 	body: () => Promise<T>,
+	releaseHook?: VaultWriteLockReleaseHook,
 ): Promise<{ ran: true; value: T } | { ran: false }> {
 	const handle = await acquireVaultWriteLock(vaultRoot, mode);
 	if (handle === null) return { ran: false };
@@ -230,6 +278,11 @@ export async function withVaultWriteLock<T>(
 	} finally {
 		clearInterval(refreshTimer);
 		await handle.release();
+		// Wake AFTER release so a re-spawned worker can immediately acquire the
+		// freed lock rather than racing us through another timeout.
+		if (releaseHook !== undefined) {
+			await wakePendingWorkers(vaultRoot, releaseHook.launch, releaseHook.selfCwd);
+		}
 	}
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 		},
 		"cli": {
 			"name": "@jolli.ai/cli",
-			"version": "0.99.3",
+			"version": "0.99.4",
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "jollimemory-vscode",
 	"displayName": "Jolli Memory",
 	"description": "VS Code sidebar for Jolli Memory — AI-powered commit summaries and smart git operations",
-	"version": "0.99.3",
+	"version": "0.99.4",
 	"publisher": "jolli",
 	"license": "Apache-2.0",
 	"icon": "assets/icon.png",

--- a/vscode/src/CompileCommand.test.ts
+++ b/vscode/src/CompileCommand.test.ts
@@ -133,17 +133,6 @@ describe("registerCompileCommand", () => {
 		expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("5 source(s) across 2 repo(s)"));
 	});
 
-	it("shows a skipped notice (not a 0-source success) when the sweep was lock-contended", async () => {
-		mockLoadConfig.mockResolvedValue({ apiKey: "sk-test", localFolder: "/mb" });
-		mockCompileAllRepos.mockResolvedValue({ repos: [], totalIngested: 0, failed: 0, skipped: true });
-		registerCompileCommand(makeOpts());
-
-		await registeredHandlers.get("jollimemory.compileNow")?.();
-
-		expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("already running"));
-		expect(showInformationMessage).not.toHaveBeenCalledWith(expect.stringContaining("0 source(s)"));
-	});
-
 	it("surfaces failed count in the success toast", async () => {
 		mockLoadConfig.mockResolvedValue({ apiKey: "sk-test", localFolder: "/mb" });
 		mockCompileAllRepos.mockResolvedValue({

--- a/vscode/src/CompileCommand.ts
+++ b/vscode/src/CompileCommand.ts
@@ -67,18 +67,10 @@ export function registerCompileCommand(opts: CompileCommandOpts): vscode.Disposa
 						onProgress: (message) => progress.report({ message }),
 					}),
 			);
-			if (result.skipped) {
-				// Lock contended: a background worker / sync / another compile holds the
-				// vault-write lock. Nothing ran — don't report a "0 source(s)" success.
-				await vscode.window.showInformationMessage(
-					"Another knowledge wiki build is already running for this Memory Bank folder — skipped.",
-				);
-			} else {
-				const failedNote = result.failed ? ` (${result.failed} failed)` : "";
-				await vscode.window.showInformationMessage(
-					`Knowledge wiki updated: ${result.totalIngested} source(s) across ${result.repos.length} repo(s)${failedNote}.`,
-				);
-			}
+			const failedNote = result.failed ? ` (${result.failed} failed)` : "";
+			await vscode.window.showInformationMessage(
+				`Knowledge wiki updated: ${result.totalIngested} source(s) across ${result.repos.length} repo(s)${failedNote}.`,
+			);
 		} catch (err) {
 			await vscode.window.showErrorMessage(
 				`Knowledge wiki build failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -1571,6 +1571,30 @@ describe("SidebarScriptBuilder", () => {
 			expect(window).toContain("'branch:openCommit'");
 		});
 
+		it("workspace commitWithMemory row click also posts kb:openMemory (not the silent commit slot)", () => {
+			// Regression: a workspace memory whose summary lives under a
+			// pre-amend hash (commit was amended) had its branch-tab row become
+			// unclickable — branch:openCommit → viewSummary → single-hash
+			// getSummary missed and silently returned. commitWithMemory rows
+			// must route to kb:openMemory regardless of foreign vs workspace so
+			// the cross-hash/cross-repo lookup (alias-resolving + "No summary
+			// found" feedback) runs instead of the silent commit-slot lookup.
+			const js = buildSidebarScript();
+			const ctxBlockIdx = js.indexOf(
+				"ctx === 'commit' || ctx === 'commitWithMemory'",
+			);
+			expect(ctxBlockIdx).toBeGreaterThan(-1);
+			const window = js.slice(ctxBlockIdx, ctxBlockIdx + 1200);
+			// The dispatch predicate must trigger kb:openMemory for
+			// commitWithMemory rows OR foreign mode — i.e. not gated on
+			// isViewingForeign() alone (which left workspace memory rows on the
+			// silent path).
+			expect(window).toMatch(/ctx === 'commitWithMemory' \|\| isViewingForeign\(\)/);
+			expect(window).toContain("'kb:openMemory'");
+			// Plain commit rows still keep the commit slot.
+			expect(window).toContain("'branch:openCommit'");
+		});
+
 		it("inline viewSummary button routes through viewMemorySummary in foreign mode", () => {
 			const js = buildSidebarScript();
 			// Find the inline-action `viewSummary` branch inside the Branch tab

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -3547,10 +3547,18 @@ export function buildSidebarScript(): string {
         });
       }
       if (ctx === 'commit' || ctx === 'commitWithMemory') {
-        // Foreign rows are cross-repo memories — reuse kb:openMemory
-        // (→ viewMemorySummary, cross-repo) so the Memory slot opens
-        // instead of the Commit slot's single-repo lookup silently missing.
-        if (isViewingForeign()) {
+        // Memory rows route through kb:openMemory (→ viewMemorySummary →
+        // cross-repo getSummaryAnyRepoWithSource): a lookup that resolves
+        // amend/rebase hash aliases AND surfaces "No summary found" feedback
+        // on a true miss. The Commit slot's branch:openCommit → viewSummary
+        // is single-repo, single-hash, and SILENTLY returns on a miss — so a
+        // memory stored under a pre-amend hash (the exact stranded-amend case)
+        // or in a foreign repo made the click a dead no-op. Applies to every
+        // commitWithMemory row (workspace or foreign) plus all foreign rows.
+        // Plain unsummarized workspace commit rows keep branch:openCommit
+        // (Commit slot; intentionally silent — the code glyph already signals
+        // "no memory").
+        if (ctx === 'commitWithMemory' || isViewingForeign()) {
           vscode.postMessage({ type: 'kb:openMemory', commitHash: id });
         } else {
           vscode.postMessage({ type: 'branch:openCommit', hash: id });


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

This batch of commits fixes a critical data-loss scenario where commit summaries and ingest sources would become permanently orphaned during long-running operations. The root cause was a priority-inversion lock pattern: ingest backfills and compile jobs held the vault write lock across their entire multi-minute reconciliation phase, blocking concurrent post-commit workers from acquiring it. When those workers timed out, they recorded themselves as pending but the lock holders never woke them on release, leaving their queue entries stranded forever.

The fix decouples expensive LLM work from the vault write lock. Ingest and compile operations now release the lock between write operations, allowing commit-summary workers to grab it and generate summaries while reconciliation runs unlocked in the background. A shared wakeup helper ensures every lock holder automatically drains and re-spawns pending workers on release, closing the orphan-entry window. Data safety is preserved through a two-tier lock hierarchy: the vault-wide lock is released early to unblock cross-repo workers, but a per-repo lock is held throughout ingest to serialize same-repo workers and prevent marker conflicts. Topic pages are protected by conflict detection—when a page is rewritten by a concurrent sync pull during the lock-free reconciliation phase, the ingest source is held for retry rather than clobbering the newer content with a stale reconciled body. Index and processed-set writes remain read-modify-write inside the guard, so concurrent updates from sync operations are merged rather than lost.

Memory rows in the branch tab are now routable when the underlying commit has been amended: they dispatch through the cross-repo lookup path that resolves hash aliases and provides user feedback on lookup failures, fixing the case where an amended commit's summary became inaccessible. The compile command now handles lock contention gracefully, printing a clear "try again shortly" message and exiting with code 1 instead of crashing with an uncaught exception. The ingest pipeline now distinguishes genuine I/O failures (disk errors, JSON serialization faults, git plumbing breakage) from transient lock contention, surfacing real faults as errors in telemetry and user-facing summaries instead of silently retrying them forever. The drain loop stops immediately when a batch makes zero forward progress, avoiding wasteful re-runs of the route and reconcile LLM phases against the same pending sources. The test suite was expanded with 34 new cases covering guard failures, lock timeouts, and edge cases in error handling, reaching 100% coverage on seven core files.

---

## E2E Test (7)
<details>
<summary><strong>1. Memory row click behavior after commit amendment</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with a commit that has been amended (the commit hash changed), and a memory summary was generated under the original commit hash.

**Steps:**
1. Open the branch tab and locate the memory row for the amended commit
2. Click on the memory row
3. Observe the response

**Expected Results:**
- The memory summary should open and display correctly
- If no summary exists for the current commit hash, a "No summary found" message should appear instead of silently failing
- The click should work reliably even though the underlying commit hash changed

</blockquote>
</details>
<details>
<summary><strong>2. Commit summary generation during long compile operations</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository ready to compile, and a pending commit that needs a summary generated.

**Steps:**
1. Start a "Build Knowledge Wiki" compile operation
2. While the compile is running, make a new commit to the repository
3. Wait for the compile to finish
4. Check the commit summary for the new commit

**Expected Results:**
- The commit summary should be generated and visible within a reasonable time (not stuck waiting 16+ minutes)
- The compile should complete successfully without being blocked by the summary generation
- The summary should appear even though it was triggered during a long-running compile

</blockquote>
</details>
<details>
<summary><strong>3. Ingest reconciliation completes without blocking other repositories</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a multi-repository setup with at least two repositories. One repository should have pending ingest entries that will take time to process (LLM reconciliation phase).

**Steps:**
1. Trigger an ingest operation on the first repository that will run reconciliation
2. While the ingest is processing, attempt to generate a commit summary in a different repository
3. Wait for both operations to complete

**Expected Results:**
- The commit summary in the second repository should complete promptly (within normal time, not waiting 16+ minutes)
- The ingest operation in the first repository should complete successfully
- Both operations should not block each other

</blockquote>
</details>
<details>
<summary><strong>4. Ingest recovery when topic page diverges during reconciliation</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with pending ingest entries and an existing topic page that will be reconciled.

**Steps:**
1. Start an ingest operation that will reconcile a topic
2. While the ingest reconciliation is running (before the write phase), manually edit the topic page in the vault
3. Wait for the ingest to complete
4. Check the topic page content and the ingest status

**Expected Results:**
- The topic page should retain the manual edit (not be overwritten with stale reconciled content)
- The ingest source should be marked as pending for retry on the next drain (not lost or orphaned)
- No data loss should occur; the manual edit and the ingest should both be recoverable

</blockquote>
</details>
<details>
<summary><strong>5. Ingest page and index writes persist atomically</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with pending ingest entries that will create or update topic pages.

**Steps:**
1. Trigger an ingest operation that will write new topic pages and update the index
2. While the ingest is writing (simulate a crash or force-quit the process mid-write)
3. Restart the application and trigger another ingest drain
4. Check the topic pages and index for consistency

**Expected Results:**
- Topic pages and their index entries should be in sync (no orphaned pages that are not indexed)
- If a page write succeeded but the index write failed, the next drain should detect and retry the source (not strand it indefinitely)
- No manual rebuild should be required to recover from a partial write

</blockquote>
</details>
<details>
<summary><strong>6. Same-repository ingest and summary workers do not interfere</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with both pending ingest entries and a pending commit summary to generate.

**Steps:**
1. Trigger an ingest operation on the repository
2. While the ingest reconciliation is running, attempt to generate a commit summary for the same repository
3. Wait for both operations to complete
4. Check the ingest status and the summary result

**Expected Results:**
- The ingest should complete without the summary worker clearing its phase marker mid-operation
- The summary should not be generated while ingest is still running (they should serialize)
- Both operations should succeed without conflicts or data loss

</blockquote>
</details>
<details>
<summary><strong>7. Pending worker wake-up after vault lock release</strong></summary>
<br>
<blockquote>

**Preconditions:** Have multiple repositories in the queue, with one repository's worker timing out while waiting for the vault lock.

**Steps:**
1. Trigger operations on multiple repositories that will compete for the vault lock
2. Allow one worker to time out waiting for the lock
3. Wait for the lock holder to release the lock
4. Check if the timed-out worker is re-spawned and processes its queue

**Expected Results:**
- The timed-out worker should be re-spawned and resume processing its queue entries
- Queue entries should not be orphaned or lost due to the timeout
- The worker should complete its work without requiring a manual restart or new commit

</blockquote>
</details>

---

## Topics (17)
<details>
<summary><strong>01 · Decouple ingest and compile LLM work from vault write lock to unblock concurrent workers</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Long-running ingest backfills and compile operations held the vault write lock across their entire reconciliation phase, blocking concurrent commit-summary workers from acquiring it. When those workers timed out, they became orphaned with no mechanism to retry, leaving commit summaries permanently ungenerated.

**💡 Decisions Behind the Code**

- **Lock scope narrowed to writes only, not computation**: The vault write lock was originally held across the entire ingest and compile drains, including minutes of LLM calls that are pure functions with zero side effects. Moving the lock to wrap only the sub-second per-page writes and index/processed-set/wiki renders eliminates the priority inversion without requiring queue or lock splitting. The reconciliation phase now holds no lock, so commit-summary workers can acquire and release the lock between any two ingest or compile writes.
- **Per-page lock granularity over per-batch**: Releasing and re-acquiring the lock per topic page (rather than per batch of 50 sources) maximizes interleaving opportunities for commit-summary workers. Each page write is its own atomic read-modify-write, so per-page locking is safe and requires no additional coordination. Batch size becomes irrelevant to lock contention—a 199-source backfill's LLM phase no longer blocks anything.
- **Shared wakeup helper over per-caller re-implementation**: The pending-worker drain logic was only implemented in QueueWorker and SyncBootstrap; compile paths never called it. Rather than duplicate the logic in compile, a shared `wakePendingWorkers` function in the sync layer is injected into `withVaultWriteLock` so every holder automatically wakes pending workers on release. This closes the gap once and prevents future holders from forgetting.

**✅ What Was Implemented**

- Restructured ingest and compile operations to release the vault write lock between write operations instead of holding it across the entire reconciliation phase. The expensive LLM work (route, reconcile, and compile calls) now executes without the lock, allowing concurrent commit-summary workers to acquire and release it between any two writes.
- Introduced a per-write `writeGuard` parameter that wraps each persistence call (topic page, index, processed-set, wiki render). The reconciliation phase runs entirely outside the guard, then each write re-acquires the lock briefly for its atomic read-modify-write operation.
- Extracted a shared `wakePendingWorkers` helper in the sync layer that drains the pending-worker registry and re-spawns workers that timed out waiting. Wired this into `withVaultWriteLock` as an optional `releaseHook` parameter so every lock holder (ingest, compile, sync bootstrap) automatically wakes pending workers on release.
- Added comprehensive test coverage verifying that all LLM calls complete before the first guarded write, that per-write releases wake pending workers immediately, and that dequeued ingest entries release the entry-level vault-write lock before the ingest LLM phase runs.

**📁 FILES**
- `cli/src/core/IngestPipeline.ts`
- `cli/src/hooks/QueueWorker.ts`
- `cli/src/commands/CompileCommand.ts`
- `cli/src/sync/VaultWriteLock.ts`
- `cli/src/sync/PendingWorkers.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Serialize same-repo ingest and summary workers to prevent marker conflicts</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Moving the ingest reconciliation phase outside all locks to unblock cross-repo commit-summary workers inadvertently allowed same-repo workers to run concurrently, causing a summary worker to clear the ingest phase marker while ingest was still running and incorrectly permitting commits during an active summary operation.

**💡 Decisions Behind the Code**

- **Per-repo vs vault-wide lock granularity**: Holding worker.lock (per-repo) through ingest while releasing vault-write.lock (vault-wide) achieves both goals: cross-repo summary workers proceed immediately, and same-repo workers remain serialized so the ingest marker cannot be cleared mid-run. This is a more precise lock hierarchy than the all-or-nothing approach of releasing both locks before ingest.
- **Idempotent release helpers**: The vault and worker releases are called both explicitly (before ingest and before chain-spawn) and as backstops in the outer finally block. Making them idempotent ensures early-return and error paths are covered without double-releasing or leaving locks held.

**✅ What Was Implemented**

- Restructured the lock lifecycle in QueueWorker so that vault-write.lock is released before the ingest phase (allowing cross-repo workers to proceed), but worker.lock (per-repo) is held throughout the entire ingest reconciliation and write phases. This serializes same-repo workers while unblocking cross-repo ones.
- Added idempotent `releaseVault` and `releaseWorker` helpers to manage the two-phase release, with a `wakePendingWorkers` call between them to unblock any cross-repo workers that timed out waiting for the vault lock.
- Moved the unlocked-ingest phase inside the try-finally block so it runs after vault-write.lock is released but before worker.lock is released. The worker.lock refresh timer now spans the entire ingest phase to prevent the stale-lock reclaimer from handing the lock to a second worker mid-ingest.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Atomic page-plus-index writes and processed-set hold-and-continue in ingest pipeline</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The ingest pipeline was splitting page writes and index writes into separate lock acquisitions, creating a window where a page could persist to disk but fail to be indexed. On the next drain, such orphaned pages would be re-routed as new topics, detected as conflicts, and held indefinitely—stranding sources and requiring a full rebuild to recover.

**💡 Decisions Behind the Code**

- **Atomic page+index over separate writes**: A page without an index entry is invisible and triggers re-routing as a new topic on retry, creating a permanent hold loop. Atomicity under one lock acquisition prevents this failure mode entirely. The cost is slightly longer lock hold time, but ingest already holds the lock for LLM calls, so per-write acquisition was the new bottleneck—moving index writes into the same guard does not extend the critical path.
- **Hold-and-continue for processed-set over abort**: The processed-set is a pure optimization (marking sources as done to skip re-routing). If its write fails, the sources simply stay pending and retry next drain via the faster UPDATE path (topic already indexed). Aborting the batch would be wasteful—pages are already written and indexed. Holding allows the batch to complete and the next drain to self-heal.
- **Fresh index read inside guard over pre-read snapshot**: Reading the index outside the guard and rendering from a snapshot opens a TOCTOU window where concurrent writes update the canonical index between the read and the render. Pulling the read inside the guard ensures the snapshot is current at render time and concurrent changes are merged, not clobbered.

**✅ What Was Implemented**

- Folded page and index writes into a single guarded section so they persist atomically. The index is now re-read fresh inside the guard (read-modify-write) to merge concurrent changes rather than clobbering them, eliminating the orphan window entirely.
- Changed processed-set writes to use hold-and-continue: if the lock cannot be acquired, the write is skipped with a warning, sources remain pending, and the next drain retries via the UPDATE path (topic already indexed), allowing the write to self-heal without stranding sources.
- Removed the intermediate `refsBySlug` map and moved source refs directly into ok-outcomes, eliminating an unreachable fallback branch and simplifying the data flow.

**📁 FILES**
- `cli/src/core/IngestPipeline.ts`
- `cli/src/core/TopicWikiRenderer.ts`
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Detect and hold sources when topic pages diverge during lock-free reconciliation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The ingest reconciliation phase runs without vault-write.lock to avoid blocking other repos. During this minutes-long LLM phase, a concurrent sync pull or another drain could rewrite a topic page, and the old code would clobber that newer content with a reconciled page built from stale input, losing user edits.

**💡 Decisions Behind the Code**

- **Hold vs merge for page conflicts**: Topic pages are LLM reconciliation outputs (not mechanically mergeable like index entries or set appends), so a conflict cannot be resolved by merging. Holding the source for retry is safer than clobbering newer content or aborting the entire batch. The source will be re-routed and re-reconciled on the next drain, at which point the page state will be fresh.
- **Conflict detection scope**: Only the page body is checked for divergence (via `lastUpdatedAt` and `content`), not the index or processed-set. The index and processed-set are re-read fresh inside the guard (read-modify-write), so they are protected from concurrent writes. This asymmetry is intentional: pages require conflict detection because they are reconciled from stale input; index and processed-set are simple appends that can be merged.

**✅ What Was Implemented**

- Modified IngestPipeline to carry a `before` snapshot (the page state read before the LLM phase) through the reconcile outcome. The guarded write phase now re-reads each page inside the lock and compares it to the `before` snapshot using a new `samePage` helper that checks both `lastUpdatedAt` and `content`.
- When a page has diverged (concurrent rewrite detected), the source is held for retry on the next drain instead of writing the stale reconciled body, recorded as a `PAGE_WRITE_CONFLICT` failure code. A writeGuard throw (lock acquisition timeout) is treated identically—the source is held, not lost.
- The index and processed-set writes remain read-modify-write inside the guard, so concurrent changes to those records are merged rather than clobbered. Page writes are now per-page guarded calls, and the index/processed-set writes happen after all page writes so they only reflect pages that actually persisted.

**📁 FILES**
- `cli/src/core/IngestPipeline.ts`
- `cli/src/core/IngestErrors.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Distinguish lock contention from real write faults in ingest pipeline</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The ingest pipeline's page-write error handler was catching all exceptions (disk errors, JSON serialization failures, git plumbing faults) and treating them identically to lock-acquisition timeouts, masking genuine I/O failures as benign contention and retrying them silently forever.

**💡 Decisions Behind the Code**

- **Typed busy signal over bare exceptions**: Using a dedicated `VaultWriteBusyError` class instead of a generic `Error` allows the catch block to distinguish transient lock contention (which should be retried) from permanent faults (which should be surfaced). This prevents silent data loss and makes genuine failures visible in telemetry and user-facing summaries.
- **Separate error code for real faults**: Creating `PAGE_WRITE_ERROR` as a distinct outcome code ensures that real I/O failures are never mislabeled as benign conflicts. The source is still held so the batch continues, but the failure is logged at error level and reported in the compile summary, making it discoverable by operators.

**✅ What Was Implemented**

- Added a new `PAGE_WRITE_ERROR` code to IngestErrors.ts to distinguish real write faults from lock contention. The page-write catch block in IngestPipeline.ts now checks whether the exception is a `VaultWriteBusyError` (benign, retried as `PAGE_WRITE_CONFLICT`) or a real fault (surfaced as `PAGE_WRITE_ERROR` with error-level logging).
- Unified the three per-write guard implementations (CompileCommand.ts, MultiRepoCompile.ts, QueueWorker.ts) to all throw `VaultWriteBusyError` on lock-acquisition failure, replacing inconsistent bare `Error` throws. This allows the ingest catch block to reliably distinguish the two failure modes via `instanceof` checks.
- Updated IngestPipeline.ts docstrings to clarify that all production callers now use per-write guards (not whole-drain locks), and added two new test cases: one verifying that `VaultWriteBusyError` is held as a benign conflict, and another confirming that real I/O faults surface as `PAGE_WRITE_ERROR`.

**📁 FILES**
- `cli/src/core/IngestErrors.ts`
- `cli/src/core/IngestPipeline.ts`
- `cli/src/commands/CompileCommand.ts`
- `cli/src/core/MultiRepoCompile.ts`
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Close lost-wakeup race in queue worker pending-worker registry</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a queue worker times out acquiring the vault write lock and records itself as pending, the lock holder can release and drain the pending-worker registry in the gap between the timeout and the record landing on disk. The holder's wakeup then sees an empty registry and never re-spawns the worker, leaving queue entries orphaned forever with no further commit to trigger a retry.

**💡 Decisions Behind the Code**

The pending-worker entry is recorded BEFORE attempting the fail-fast retry rather than after. This ordering is critical: if the record happens after the retry, a concurrent releaser could drain the registry between the retry and the record, recreating the orphan window. Recording first ensures any releaser sees the entry regardless of timing, making the worst case a benign duplicate spawn that loses the worker-lock race and exits cleanly.

**✅ What Was Implemented**

- Added a fail-fast retry after recording the pending-worker entry in QueueWorker. If the lock freed during the record gap, the retry acquires it immediately and proceeds to drain the queue instead of returning early. If the lock is still held, the current holder will observe the now-recorded entry on its next release, closing the orphan-entry window.
- Recording intent before the retry ensures any concurrent releaser always sees the entry. Updated the vault-lock-failure test in QueueWorker.test.ts to verify both acquisition attempts (wait-mode and fail-fast retry) and added a new test case covering the lost-wakeup guard scenario where the holder releases during the pending-record gap.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`
- `cli/src/hooks/QueueWorker.test.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Per-cwd launch error isolation in pending worker wake-up</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The pending worker registry was drained (read and deleted) before launching workers, but all launches were wrapped in a single try-catch. If the first spawn threw, the loop would abort and every remaining (already-consumed) repo would be silently dropped, re-opening the orphaned-queue-entry gap the mechanism was designed to close.

**💡 Decisions Behind the Code**

The registry is consumed before launching, so error isolation must happen per-cwd, not at the outer level. A single outer try-catch would silently drop already-consumed entries on the first failure. Per-cwd isolation is the only way to preserve the invariant that every pending repo gets a launch attempt.

**✅ What Was Implemented**

- Moved the try-catch inside the launch loop in PendingWorkers so each cwd's spawn is isolated. A throw from one launch no longer stops the loop; later repos are still launched.
- Added a regression test verifying that a failed launch for one repo does not prevent subsequent repos from being launched.

**📁 FILES**
- `cli/src/sync/PendingWorkers.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Route workspace memory rows through cross-repo lookup to fix stranded-amend click failures</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Memory rows in the branch tab became unclickable when the underlying commit was amended and the summary remained stored under the pre-amend hash. The branch tab lists the current HEAD hash, but the single-hash lookup in the commit slot silently missed and returned with no feedback.

**💡 Decisions Behind the Code**

Memory rows must use the same robust lookup path regardless of whether they are workspace or foreign, because both can have summaries stored under different hashes (amends, rebases, cross-branch picks). The commit slot's single-hash lookup is intentionally silent for unsummarized commits (the code glyph already signals "no memory"), but memory rows need feedback when a lookup fails so users know whether to regenerate or investigate. Consolidating both memory-row types on the cross-repo path eliminates the asymmetry and ensures consistent UX.

**✅ What Was Implemented**

- Changed the routing in SidebarScriptBuilder so that `commitWithMemory` rows (workspace or foreign) dispatch `kb:openMemory` instead of `branch:openCommit`. This routes through the cross-repo lookup path (`viewMemorySummary` → `getSummaryAnyRepoWithSource`) which resolves amend/rebase hash aliases and surfaces "No summary found" feedback on a true miss, instead of the silent single-hash path.
- Added a test in SidebarScriptBuilder.test.ts pinning the new routing behavior for workspace memory rows and verifying that plain unsummarized commit rows still use the commit slot.

**📁 FILES**
- `vscode/src/views/SidebarScriptBuilder.ts`
- `vscode/src/views/SidebarScriptBuilder.test.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Compile command handles lock contention gracefully with retry message</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The compile command was throwing uncaught exceptions when a background worker held the vault write lock, instead of printing a user-friendly "try again shortly" message and exiting cleanly. This broke the user experience when multiple processes competed for the lock.

**💡 Decisions Behind the Code**

- **Layered failure semantics**: The store reset is a prerequisite write—without it, the drain becomes a silent no-op incremental instead of a true rebuild. A busy lock here must exit cleanly so the user knows to retry, not crash with a stack trace. Purge and render are derived views over already-persisted data, so their failures are non-fatal and should not fail the whole command. This distinction prevents successful ingests from being reported as failures.
- **Reusing the real error class in tests**: The mock for `withVaultWriteLock` was updated to import and preserve the real `VaultWriteBusyError` class while stubbing only the lock acquisition itself. This ensures the production `instanceof` check is exercised faithfully in tests, catching any future refactors that break the error type contract.

**✅ What Was Implemented**

- Added a new `VaultWriteBusyError` sentinel class to VaultWriteLock that distinguishes transient lock contention from real write failures (disk, corruption). This lets callers react differently to the two failure modes.
- Restructured `compileSingleRepo` in CompileCommand to catch `VaultWriteBusyError` on the prerequisite store reset (rebuild mode) and exit cleanly with exit code 1 and a user-friendly message, while still propagating genuine write errors.
- Wrapped the purge and Markdown re-render steps (derived-layer regeneration) in try-catch blocks that log warnings and continue on any failure, since the data is already persisted to the orphan branch. This mirrors the non-fatal error handling in QueueWorker and search-index caching.

**📁 FILES**
- `cli/src/sync/VaultWriteLock.ts`
- `cli/src/commands/CompileCommand.ts`
- `cli/src/core/MultiRepoCompile.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · Skip purge in routine compile to avoid racing with concurrent ingest</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The compile command was purging topic pages not in the compile's index snapshot. When the vault write lock was released between writes to allow concurrent ingest, a concurrent ingest could add a page not yet in the compile's snapshot—purging would delete it and lose data.

**💡 Decisions Behind the Code**

Purging "everything not in the index" races with concurrent ingest that adds pages. Rather than add complex locking around purge, routine compiles simply skip it (orphans are rare and reclaimed on rebuild). This trades off immediate cleanup for guaranteed data safety and simpler code.

**✅ What Was Implemented**

- Gated the topic-page purge operation to rebuild-only mode. Routine compiles no longer purge orphan pages, since the lock is released between writes and a concurrent ingest could add a page not yet in the compile's index snapshot—purging would delete it and lose data. Orphan pages are reclaimed on explicit `--rebuild` instead.

**📁 FILES**
- `cli/src/core/MultiRepoCompile.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · Stop drain loop on zero progress to avoid wasted LLM re-runs</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When all pages in a batch were held (due to lock contention, write faults, or reconciliation failures), the drain loop would immediately re-run the entire route and reconcile LLM phases against the identical pending slice, re-billing tokens for zero forward progress.

**💡 Decisions Behind the Code**

When a batch makes zero forward progress, the cost of re-running route and reconcile LLM phases against the same pending sources far outweighs the benefit of an immediate retry. Stopping the drain and letting the next trigger (which may resolve the underlying contention or fault) retry is cheaper and simpler than burning tokens on guaranteed-identical LLM outputs. The iteration guard remains as a backstop for the rare case where each batch does mark a source yet the pending queue never shrinks.

**✅ What Was Implemented**

- Added a zero-progress check in drainIngest (IngestPipeline.ts) that breaks the loop when `ingested === 0`, preventing redundant LLM calls. The next trigger (post-commit re-enqueue, successor worker, or user re-run) will retry the batch.
- Rewrote the iteration-guard test to split it into two cases: one verifying the new no-progress short-circuit (1 batch, 2 LLM calls), and a second backstop test confirming the iteration guard still catches pathological cases where each batch makes progress yet pending never shrinks (4 batches, 8 LLM calls).

**📁 FILES**
- `cli/src/core/IngestPipeline.ts`
- `cli/src/core/IngestPipeline.test.ts`

</blockquote>
</details>
<details>
<summary><strong>12 · Lazy-load QueueWorker in compile paths to avoid eager module graph</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Importing `launchWorker` statically at the top of CompileCommand.ts and MultiRepoCompile.ts pulled QueueWorker's entire transcript-reader and detector graph (Copilot, Cursor, Gemini, OpenCode, etc.) into the compile module load path, violating the codebase convention that heavy optional modules are lazy-imported.

**💡 Decisions Behind the Code**

Lazy importing defers the cost of loading QueueWorker's transcript-reader graph until it is actually needed (during a write operation), rather than paying that cost at CLI startup when the compile command is registered. This keeps the compile path lightweight and aligns with the established pattern in the codebase for optional heavy modules.

**✅ What Was Implemented**

- Changed CompileCommand.ts and MultiRepoCompile.ts to import `launchWorker` lazily inside the writeGuard factory using `await import("../hooks/QueueWorker.js")`, deferring the QueueWorker graph load until a write actually needs to wake pending workers.
- Added explanatory comments in both files documenting why the lazy import is necessary and clarifying that the guard throws `VaultWriteBusyError` (the typed busy signal shared with other guards).

**📁 FILES**
- `cli/src/commands/CompileCommand.ts`
- `cli/src/core/MultiRepoCompile.ts`

</blockquote>
</details>
<details>
<summary><strong>13 · Per-write release hook in ingest to wake cross-repo pending workers</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The ingest phase was using per-write lock acquisitions but not passing a release hook, so pending workers from other repos would not be woken until the entire ingest completed. This partially defeated the goal of letting cross-repo work proceed while ingest runs.

**💡 Decisions Behind the Code**

The compile paths already pass a release hook to wake pending workers on each lock release. Ingest should follow the same pattern for consistency and to avoid idle time for cross-repo workers. The cost is negligible—the hook is already implemented and tested in the compile paths.

**✅ What Was Implemented**

- Added the `releaseHook` parameter (with `launch` and `selfCwd`) to the per-write `withVaultWriteLock` call in QueueWorker, matching the pattern used in compile paths. Now each per-write release wakes pending workers immediately rather than waiting for the outer-finally.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>14 · Deduplicate error-message stringification helper</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

PluginLoader.ts had a local `errMessage` function that was byte-identical to the shared `errMsg` exported from Logger.ts, creating two independent implementations of the same utility.

**💡 Decisions Behind the Code**

Using a single shared helper prevents divergence and reduces maintenance burden. The shared `errMsg` is already imported in the file, so the change is a straightforward substitution.

**✅ What Was Implemented**

- Removed the local `errMessage` function from PluginLoader.ts and replaced all six call sites with the shared `errMsg` import from Logger.ts.

**📁 FILES**
- `cli/src/PluginLoader.ts`

</blockquote>
</details>
<details>
<summary><strong>15 · Update docstrings to reflect per-write guard architecture</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Multiple docstrings in IngestPipeline.ts still claimed that the compile path holds the vault-write lock across the entire drain and uses an identity guard, which was no longer true after the per-write guard refactor.

**💡 Decisions Behind the Code**

Accurate docstrings prevent future maintainers from making incorrect assumptions about the concurrency model. The per-write guard architecture is a load-bearing design choice, and the documentation must reflect the actual behavior.

**✅ What Was Implemented**

- Updated the IngestOptions docstring to clarify that all production callers (compile paths and QueueWorker) now use per-write guards that acquire and release the lock between writes, not whole-drain locks.
- Updated the guarded-write phase comment block to remove the claim that compile holds the lock for its whole drain.
- Updated the `samePage` function docstring to note that under the real per-write guard, concurrent commits or sync pulls can legitimately move the page between read and write, so the function can return false in production (not just in tests).

**📁 FILES**
- `cli/src/core/IngestPipeline.ts`

</blockquote>
</details>
<details>
<summary><strong>16 · Update test mocks to provide real VaultWriteBusyError class</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Test mocks for VaultWriteLock.js were stubbing out the entire module, including the `VaultWriteBusyError` class, which prevented tests from verifying that the ingest pipeline correctly distinguishes busy errors from real faults via `instanceof` checks.

**💡 Decisions Behind the Code**

Preserving the real `VaultWriteBusyError` class in test mocks allows tests to verify the actual exception type that production code throws and catches, rather than testing against a mock that would never match the real behavior. This catches regressions where the guard might accidentally throw a different exception type.

**✅ What Was Implemented**

- Updated MultiRepoCompile.test.ts to provide a stand-in `VaultWriteBusyError` class in the mock with the correct message, so the guard's busy-path test can verify the typed exception is thrown.
- Updated QueueWorker.test.ts to use `importOriginal` to preserve the real `VaultWriteBusyError` class while stubbing only the lock-acquisition functions, ensuring the unlocked-ingest guard's typed busy signal is the genuine class.
- Updated the MultiRepoCompile test assertion to clarify that the guard rejects with a typed `VaultWriteBusyError`, not a bare `Error`.

**📁 FILES**
- `cli/src/core/MultiRepoCompile.test.ts`
- `cli/src/hooks/QueueWorker.test.ts`

</blockquote>
</details>
<details>
<summary><strong>17 · Coverage improvements for ingest, compile, and plugin-loading paths</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Seven core files had uncovered branches and statements, leaving gaps in the test suite that could hide regressions in error handling, edge cases, and fallback logic.

**💡 Decisions Behind the Code**

- **Test over ignore for reachable branches**: Every branch that can be reached in production gets a test. Only branches that are provably unreachable (e.g., dirname non-progress for absolute paths, which stabilizes at the filesystem root) are marked with v8-ignore, and only with a comment explaining why they cannot fire.
- **Pure function extraction for determinism**: Sorting behavior depends on filesystem readdir order, which is nondeterministic. Extracting `compareDirentNames` as a pure function lets tests verify the sort order directly without relying on filesystem behavior.

**✅ What Was Implemented**

- Added 34 new test cases across IngestPipeline, CompileCommand, MultiRepoCompile, TopicWikiRenderer, Api, PluginLoader, ConversationOverlayStore, and DualWriteStorage, covering guard failures, lock timeouts, unlink errors, symlink edge cases, and command-hiding fallbacks.
- Extracted `compareDirentNames` as a testable pure function in PluginLoader to verify deterministic sorting without depending on filesystem readdir order.
- Added defensive v8-ignore markers for unreachable branches in PluginLoader (dirname non-progress guards for absolute paths) and PendingWorkers (drain-failure catch that is contractually non-throwing).

**📁 FILES**
- `cli/src/core/IngestPipeline.ts`
- `cli/src/commands/CompileCommand.ts`
- `cli/src/core/MultiRepoCompile.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 17, 2026 at 11:52 PM · via Anthropic*
<!-- jollimemory-summary-end -->