### PR TITLE
Improve IntelliJ plugin parity and fix README formatting

### DIFF
--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/SelectAllConversationsAction.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/SelectAllConversationsAction.kt
@@ -1,0 +1,19 @@
+package ai.jolli.jollimemory.actions
+
+import ai.jolli.jollimemory.services.JolliMemoryService
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+
+/** Toggles selection of all conversations in the Conversations panel. */
+class SelectAllConversationsAction : AnAction() {
+	override fun actionPerformed(e: AnActionEvent) {
+		val project = e.project ?: return
+		val registry = project.getService(JolliMemoryService::class.java).panelRegistry
+		registry?.activeConversationsPanel?.toggleSelectAll()
+	}
+
+	override fun update(e: AnActionEvent) {
+		val status = e.project?.getService(JolliMemoryService::class.java)?.getStatus()
+		e.presentation.isEnabled = status != null && status.enabled
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/CommitSelectionStore.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/CommitSelectionStore.kt
@@ -72,6 +72,28 @@ object CommitSelectionStore {
 		writeExclusions(projectDir, next)
 	}
 
+	fun setAllExcluded(projectDir: String, kind: String, keys: List<String>, excluded: Boolean) {
+		val current = readExclusions(projectDir)
+		val next = mutableMapOf(
+			"conversations" to current.conversations.toMutableSet(),
+			"plans" to current.plans.toMutableSet(),
+			"notes" to current.notes.toMutableSet(),
+			"references" to current.references.toMutableSet(),
+		)
+		val set = next[kind] ?: return
+		if (excluded) {
+			for (k in keys) set.add(k)
+		} else {
+			for (k in keys) set.remove(k)
+		}
+
+		writeExclusions(projectDir, next)
+	}
+
+	fun conversationKey(source: TranscriptSource, sessionId: String): String {
+		return "${source.name}:$sessionId"
+	}
+
 	private fun writeExclusions(projectDir: String, data: Map<String, Set<String>>) {
 		val file = selectionFile(projectDir)
 		file.parentFile?.mkdirs()

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
@@ -179,8 +179,18 @@ object PostCommitHook {
                 allSessions.addAll(CopilotChatSupport.discoverSessions(cwd).sessions)
             }
 
-            val sessions = allSessions
-            log.info("Discovered %d session(s): %s", sessions.size,
+            // Filter out conversations the user excluded via sidebar checkboxes
+            val exclusions = CommitSelectionStore.readExclusions(cwd)
+            val sessions = allSessions.filter { session ->
+                val source = session.source ?: TranscriptSource.claude
+                val key = CommitSelectionStore.conversationKey(source, session.sessionId)
+                val excluded = key in exclusions.conversations
+                if (excluded) log.info("Excluding session %s (user-excluded)", session.sessionId.take(8))
+                !excluded
+            }
+
+            log.info("Discovered %d session(s) (%d excluded): %s",
+                allSessions.size, allSessions.size - sessions.size,
                 sessions.joinToString(", ") { "${it.source ?: "claude"}:${it.sessionId.take(8)}" })
             if (sessions.isEmpty()) {
                 log.info("No active sessions — skipping summarization")
@@ -271,7 +281,6 @@ object PostCommitHook {
 
             // 7b. Assemble reference blocks for prompt injection
             val registry = SessionTracker.loadPlansRegistry(cwd)
-            val exclusions = CommitSelectionStore.readExclusions(cwd)
             val referenceBlocks = PromptRenderer.assembleReferenceBlocks(
                 registry.references ?: emptyMap(),
                 exclusions.references,

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActiveConversationsPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActiveConversationsPanel.kt
@@ -3,6 +3,7 @@ package ai.jolli.jollimemory.toolwindow
 import ai.jolli.jollimemory.core.ActiveConversationItem
 import ai.jolli.jollimemory.core.ActiveConversationsResult
 import ai.jolli.jollimemory.core.ActiveSessionAggregator
+import ai.jolli.jollimemory.core.CommitSelectionStore
 import ai.jolli.jollimemory.core.HiddenConversationsStore
 import ai.jolli.jollimemory.core.TranscriptSource
 import ai.jolli.jollimemory.services.JolliMemoryService
@@ -86,7 +87,13 @@ class ActiveConversationsPanel(
 		} catch (e: Exception) {
 			ActiveConversationsResult(emptyList(), emptyList())
 		}
-		SwingUtilities.invokeLater { updateUI(result) }
+		val exclusions = CommitSelectionStore.readExclusions(cwd)
+		val itemsWithSelection = result.items.map { item ->
+			val key = CommitSelectionStore.conversationKey(item.source, item.sessionId)
+			item.copy(isSelected = key !in exclusions.conversations)
+		}
+		val adjusted = ActiveConversationsResult(itemsWithSelection, result.failedSources)
+		SwingUtilities.invokeLater { updateUI(adjusted) }
 	}
 
 	private fun updateUI(result: ActiveConversationsResult) {
@@ -104,6 +111,7 @@ class ActiveConversationsPanel(
 					item = item,
 					onRowClicked = ::onRowClicked,
 					onHide = ::onHide,
+					onSelectionChanged = ::onSelectionChanged,
 				))
 			}
 		}
@@ -123,6 +131,24 @@ class ActiveConversationsPanel(
 			if (editor is ConversationFileEditor) {
 				editor.onSaved = { refresh() }
 			}
+		}
+	}
+
+	private fun onSelectionChanged(item: ActiveConversationItem, selected: Boolean) {
+		val cwd = service.mainRepoRoot ?: project.basePath ?: return
+		val key = CommitSelectionStore.conversationKey(item.source, item.sessionId)
+		ApplicationManager.getApplication().executeOnPooledThread {
+			CommitSelectionStore.setExcluded(cwd, "conversations", key, !selected)
+		}
+	}
+
+	fun toggleSelectAll() {
+		val anyUnchecked = conversations.any { !it.isSelected }
+		val cwd = service.mainRepoRoot ?: project.basePath ?: return
+		val keys = conversations.map { CommitSelectionStore.conversationKey(it.source, it.sessionId) }
+		ApplicationManager.getApplication().executeOnPooledThread {
+			CommitSelectionStore.setAllExcluded(cwd, "conversations", keys, !anyUnchecked)
+			SwingUtilities.invokeLater { refresh() }
 		}
 	}
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BreadcrumbHeaderPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BreadcrumbHeaderPanel.kt
@@ -15,10 +15,14 @@ import java.awt.Dimension
 import java.awt.FlowLayout
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
+import javax.swing.BorderFactory
 import javax.swing.BoxLayout
 import javax.swing.DefaultComboBoxModel
+import javax.swing.DefaultListCellRenderer
 import javax.swing.JButton
 import javax.swing.JComboBox
+import javax.swing.JLabel
+import javax.swing.JList
 import javax.swing.JPanel
 import javax.swing.SwingUtilities
 import javax.swing.UIManager
@@ -81,6 +85,14 @@ class BreadcrumbHeaderPanel(
 
 	init {
 		border = JBUI.Borders.empty(4, 8)
+
+		// Custom renderers: bold + "(current)" + separator for workspace items
+		repoCombo.renderer = WorkspaceAwareCellRenderer { _, index -> index == 0 && repos.any { it.isCurrentRepo } }
+		branchCombo.renderer = WorkspaceAwareCellRenderer { value, _ ->
+			val selectedRepo = repoCombo.selectedItem as? String
+			val isCurrentRepo = repos.find { it.repoName == selectedRepo }?.isCurrentRepo == true
+			isCurrentRepo && value == currentBranch
+		}
 
 		// Left: repo / branch selectors — BoxLayout so they shrink when the tool window is narrow
 		repoCombo.minimumSize = Dimension(JBUI.scale(30), repoCombo.preferredSize.height)
@@ -301,6 +313,40 @@ class BreadcrumbHeaderPanel(
 			if (isForeign) selectedBranch else null,
 			isForeign,
 		)
+	}
+
+	/**
+	 * Cell renderer that bolds the workspace item, appends a muted "(current)"
+	 * suffix, and draws a 1px separator below it — matching VS Code's breadcrumb
+	 * dropdown styling.
+	 */
+	private inner class WorkspaceAwareCellRenderer(
+		private val isWorkspaceItem: (String, Int) -> Boolean,
+	) : DefaultListCellRenderer() {
+		override fun getListCellRendererComponent(
+			list: JList<*>, value: Any?, index: Int, isSelected: Boolean, cellHasFocus: Boolean,
+		): java.awt.Component {
+			val label = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus) as JLabel
+			val strValue = value as? String ?: return label
+			val isWorkspace = isWorkspaceItem(strValue, index)
+
+			if (isWorkspace) {
+				label.text = "<html><b>$strValue</b> <span style='color:gray'>(current)</span></html>"
+				// Separator line below the workspace item (only in dropdown, not in the collapsed combo)
+				if (index >= 0) {
+					label.border = BorderFactory.createCompoundBorder(
+						BorderFactory.createMatteBorder(0, 0, 1, 0, com.intellij.ui.JBColor.border()),
+						JBUI.Borders.empty(1, 2),
+					)
+				}
+			} else {
+				label.text = strValue
+				if (index >= 0) {
+					label.border = JBUI.Borders.empty(1, 2)
+				}
+			}
+			return label
+		}
 	}
 
 	/** Update the current branch display without full refresh (e.g., on branch switch). */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
@@ -437,20 +437,29 @@ class CommitsPanel(
             filesLoaded = false,
         )
 
-        // Click anywhere on the commit row (except checkbox/eye) toggles expand/collapse
-        val expandClickListener = object : MouseAdapter() {
+        // Chevron click toggles expand/collapse only
+        val chevronClickListener = object : MouseAdapter() {
             override fun mouseClicked(e: MouseEvent) {
                 if (!SwingUtilities.isLeftMouseButton(e)) return
-                if (e.clickCount == 2 && commit.hasSummary) {
+                e.consume()
+                toggleExpand(commit.hash)
+            }
+        }
+        arrowLabel.cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+        arrowLabel.addMouseListener(chevronClickListener)
+
+        // Click anywhere else on the row opens the summary (matching VS Code behavior)
+        val rowClickListener = object : MouseAdapter() {
+            override fun mouseClicked(e: MouseEvent) {
+                if (!SwingUtilities.isLeftMouseButton(e)) return
+                if (commit.hasSummary) {
                     viewSummary(commit.hash)
-                } else if (e.clickCount == 1) {
-                    toggleExpand(commit.hash)
                 }
             }
         }
-        for (child in listOf(arrowLabel, messageLabel, leftPanel, row)) {
+        for (child in listOf(messageLabel, leftPanel, row)) {
             child.cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-            child.addMouseListener(expandClickListener)
+            child.addMouseListener(rowClickListener)
         }
 
         row.maximumSize = Dimension(Int.MAX_VALUE, row.preferredSize.height)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationRowComponent.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationRowComponent.kt
@@ -8,6 +8,7 @@ import com.intellij.util.ui.JBUI
 import java.awt.*
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
+import javax.swing.JCheckBox
 import javax.swing.JLabel
 import javax.swing.JPanel
 
@@ -20,7 +21,15 @@ class ConversationRowComponent(
 	val item: ActiveConversationItem,
 	private val onRowClicked: (ActiveConversationItem) -> Unit,
 	private val onHide: (ActiveConversationItem) -> Unit,
+	private val onSelectionChanged: (ActiveConversationItem, Boolean) -> Unit,
 ) : JPanel(BorderLayout()) {
+
+	private val checkbox = JCheckBox().apply {
+		isSelected = item.isSelected
+		isOpaque = false
+		toolTipText = "Include in next memory"
+		cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+	}
 
 	private val hideLabel = JLabel(AllIcons.Actions.GC).apply {
 		cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
@@ -34,9 +43,14 @@ class ConversationRowComponent(
 		isOpaque = true
 		cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
 
-		// Source badge
+		// Left side: checkbox + source badge
+		val leftPanel = JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(2), 0)).apply {
+			isOpaque = false
+		}
+		leftPanel.add(checkbox)
 		val badge = SourceBadge(item.source)
-		add(badge, BorderLayout.WEST)
+		leftPanel.add(badge)
+		add(leftPanel, BorderLayout.WEST)
 
 		// Title (center, truncates)
 		val titleLabel = JLabel(item.title).apply {
@@ -56,6 +70,11 @@ class ConversationRowComponent(
 		}
 		rightPanel.add(hideLabel)
 		add(rightPanel, BorderLayout.EAST)
+
+		// Checkbox toggle
+		checkbox.addActionListener {
+			onSelectionChanged(item, checkbox.isSelected)
+		}
 
 		// Click handlers
 		hideLabel.addMouseListener(object : MouseAdapter() {
@@ -91,10 +110,10 @@ class ConversationRowComponent(
 		}
 		addMouseListener(hoverListener)
 		addMouseListener(clickListener)
-		// Forward events from all children
-		for (c in listOf(badge, titleLabel, rightPanel, hideLabel)) {
+		// Forward events from all children (checkbox handles its own clicks)
+		for (c in listOf(leftPanel, badge, titleLabel, rightPanel, hideLabel)) {
 			c.addMouseListener(hoverListener)
-			if (c !== hideLabel) c.addMouseListener(clickListener)
+			if (c !== hideLabel && c !== checkbox) c.addMouseListener(clickListener)
 		}
 	}
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
@@ -818,16 +818,6 @@ class SummaryPanel(
         jmLog.info("handleCheckPrStatus: start (cwd='%s')", cwd)
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
-                val commitCount = PrService.getCommitCount(cwd)
-                jmLog.info("handleCheckPrStatus: commitCount=%d", commitCount)
-                if (commitCount > 1) {
-                    jmLog.info("handleCheckPrStatus: status=multipleCommits (count=%d)", commitCount)
-                    ApplicationManager.getApplication().invokeLater {
-                        postToWebview("prStatus", mapOf("status" to "multipleCommits", "count" to commitCount))
-                    }
-                    return@executeOnPooledThread
-                }
-
                 val ghAvailable = PrService.isGhAvailable(cwd)
                 jmLog.info("handleCheckPrStatus: isGhAvailable=%s", ghAvailable)
                 if (!ghAvailable) {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryCssBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryCssBuilder.kt
@@ -1417,7 +1417,6 @@ $rootVars
     border-radius: 10px;
     background: var(--pill-bg);
     color: var(--pill-text);
-    margin-left: auto;
   }
   .private-count { font-weight: 600; }
   .private-drawer .private-body {
@@ -1433,6 +1432,9 @@ $rootVars
     padding-top: 0;
     padding-bottom: 0;
   }
+  .private-body .private-zone { border: none; background: none; padding: 0 14px 12px; margin: 0; }
+  .private-body .private-zone .section-title { display: none; }
+  .private-body .private-zone-watermark { display: none; }
 
   /* ── Reduced motion ── */
   @media (prefers-reduced-motion: reduce) {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilder.kt
@@ -1579,13 +1579,7 @@ ${buildPrMessageScript()}
       prCurrentState = s;
       prHide(prForm);
 
-      if (s === 'multipleCommits') {
-        setPrChip('is-warn', 'Multiple commits');
-        prStatusText.textContent = 'Branch has ' + msg.count + ' commits. Please squash into a single commit before creating or updating a PR.';
-        prShow(prStatusText);
-        prHide(prLinkRow);
-        prHide(prActions);
-      } else if (s === 'unavailable') {
+      if (s === 'unavailable') {
         setPrChip('is-warn', 'Unavailable');
         prStatusText.textContent = 'GitHub CLI (gh) is not installed or not authenticated.';
         prShow(prStatusText);

--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -117,6 +117,11 @@
 
         <!-- Conversations panel actions -->
         <group id="JolliMemory.ConversationsActions" text="JolliMemory Conversations">
+            <action id="JolliMemory.SelectAllConversations"
+                    class="ai.jolli.jollimemory.actions.SelectAllConversationsAction"
+                    text="Select/Deselect All Conversations"
+                    description="Toggle selection of all conversations"
+                    icon="AllIcons.Actions.Selectall"/>
             <action id="JolliMemory.RefreshConversations"
                     class="ai.jolli.jollimemory.actions.RefreshConversationsAction"
                     text="Refresh Conversations"


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The IntelliJ plugin's built-in commit-summary pipeline was previously ignoring the conversation checkboxes users set in the sidebar. Even if a user had explicitly excluded a session before committing, the IntelliJ pipeline would still read that session's transcript and include it in the generated summary. This commit wired the existing exclusion data into the IntelliJ pipeline so it now behaves consistently with the VS Code CLI pipeline. Excluded sessions are filtered out before any transcript content is read, which also preserves the read cursor position so those sessions remain available for future commits rather than being silently consumed.

---

## E2E Test (5)
<details>
<summary><strong>1. Excluded conversations are skipped when generating a commit summary (IntelliJ)</strong></summary>
<br>
<blockquote>

**Preconditions:** Have an IntelliJ project open with JolliMemory installed, at least two active AI conversations visible in the Conversations panel, and a git repository ready to commit to.

**Steps:**
1. Open the JolliMemory sidebar and go to the Conversations panel.
2. Uncheck the checkbox next to one of the conversations to exclude it from the next summary.
3. Make a small change to any file in the project and commit it using IntelliJ's built-in commit dialog.
4. Wait for the post-commit summary to finish generating, then open the JolliMemory Commits panel.
5. Open the generated summary and check which conversations were included.

**Expected Results:**
- The summary should only reference the conversations that had their checkboxes checked.
- The conversation you unchecked should not appear in the generated summary at all.
- The unchecked conversation's read position should not have advanced (it should still show the same unread state as before the commit).

</blockquote>
</details>
<details>
<summary><strong>2. Checking and unchecking individual conversations persists across panel refreshes</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the JolliMemory sidebar open in IntelliJ with at least two active conversations visible.

**Steps:**
1. In the Conversations panel, uncheck the checkbox next to one conversation.
2. Click the Refresh button in the Conversations panel toolbar to reload the list.
3. Check whether the conversation you unchecked is still unchecked after the refresh.
4. Now re-check that same conversation's checkbox.
5. Refresh the panel again and verify the conversation is now checked.

**Expected Results:**
- After the first refresh, the conversation you unchecked should still appear unchecked — the exclusion is remembered.
- After re-checking and refreshing, the conversation should appear checked again.
- All other conversations should retain their previous checked or unchecked state throughout.

</blockquote>
</details>
<details>
<summary><strong>3. Select/Deselect All Conversations toolbar button</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the JolliMemory sidebar open in IntelliJ with at least three active conversations, some checked and some unchecked.

**Steps:**
1. In the Conversations panel toolbar, click the "Select/Deselect All Conversations" button (the select-all icon).
2. Observe the checkboxes next to all conversations in the list.
3. Click the same toolbar button a second time.
4. Observe the checkboxes again.

**Expected Results:**
- After the first click, all conversations should become checked if any were previously unchecked, or all should become unchecked if all were already checked.
- After the second click, the selection state should toggle to the opposite of what it was after the first click.
- No conversations should disappear or change their title — only the checkbox state changes.

</blockquote>
</details>
<details>
<summary><strong>4. Commit row click opens summary; chevron click expands/collapses details</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the JolliMemory Commits panel open in IntelliJ with at least one commit that has a generated summary.

**Steps:**
1. In the Commits panel, click directly on the commit message text of a commit that has a summary.
2. Observe what happens — check whether the summary view opens.
3. Click the arrow/chevron icon on the left side of the same commit row.
4. Observe whether the row expands or collapses its detail section.
5. Click the chevron again to toggle it back.

**Expected Results:**
- Clicking the commit message text should open the full summary view for that commit.
- Clicking the chevron arrow should expand or collapse the commit's detail section without opening the summary view.
- The two actions should be independent — clicking the chevron should never navigate away to the summary.

</blockquote>
</details>
<details>
<summary><strong>5. Repo and branch dropdowns highlight the current workspace item</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the JolliMemory sidebar open in IntelliJ with a project that has at least two repositories or branches available in the breadcrumb dropdowns.

**Steps:**
1. Look at the repository dropdown in the JolliMemory breadcrumb header at the top of the sidebar.
2. Click the repository dropdown to open it.
3. Observe how the currently active repository is displayed compared to the others.
4. Close that dropdown and click the branch dropdown.
5. Observe how the currently active branch is displayed compared to the others.

**Expected Results:**
- In each dropdown, the currently active repository or branch should appear in bold with a "(current)" label next to it.
- A thin separator line should appear below the current item, visually separating it from the rest of the list.
- All other items in the list should appear in normal (non-bold) text with no label.

</blockquote>
</details>

---

## Topics (4)
<details>
<summary><strong>01 · IntelliJ post-commit hook now respects user-excluded conversations</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The IntelliJ plugin has its own built-in pipeline for generating commit summaries, but it was ignoring the checkboxes users set in the sidebar to exclude specific conversations. Every conversation was being included regardless of what the user had selected.

**💡 Decisions Behind the Code**

- **Filter before transcript reads**: Excluded sessions are dropped before any transcript content is consumed, intentionally mirroring the CLI pipeline's approach. This prevents the read cursor from advancing for sessions the user chose to skip, so those sessions remain available on the next commit.
- **Reuse existing store**: `CommitSelectionStore.readExclusions` and `CommitSelectionStore.conversationKey` were already used by the IntelliJ UI layer; wiring the same calls into the pipeline avoids duplicating exclusion-key logic.

**✅ What Was Implemented**

- Added exclusion filtering in `PostCommitHook.runWorker` (PostCommitHook.kt, lines 178–192): reads `commit-selection.json` via `CommitSelectionStore.readExclusions`, builds a conversation key per session, and filters out any session whose key appears in `exclusions.conversations`.
- Filtering runs after session discovery but before transcript reading, so excluded sessions do not advance their read cursors — matching the behavior of the CLI's `QueueWorker`.
- Updated the discovery log line to report both total discovered count and excluded count.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Skills added to check and switch between VS Code and IntelliJ post-commit hooks</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The developer switches between VS Code and IntelliJ regularly and had no easy way to tell which hook was currently active or to swap between them without manually editing the git hook file.

**💡 Decisions Behind the Code**

Both hook runtimes persist on disk after their respective plugin activates and do not get removed when switching editors. Because of this, switching only requires editing the post-commit file rather than reinstalling anything — the skills exploit that fact by commenting/uncommenting sections rather than rewriting the file.

**✅ What Was Implemented**

- Created three Claude skills: one to report which hook sections are present and active, one to activate the VS Code hook, and one to activate the IntelliJ hook.
- Skills use the `# >>> JolliMemory` / `# <<< JolliMemory` section markers already written by each installer to identify and toggle blocks without destroying the other surface's section.

**📋 Future Enhancements**

- The IntelliJ section marker uses an `(intellij)` suffix to distinguish it from the VS Code marker; this convention should be confirmed against what `HookInstaller.install()` actually writes once the IntelliJ installer is updated to emit that marker natively.

**📁 FILES**
- `.claude/commands/check-hook.md`
- `.claude/commands/use-vscode-hook.md`
- `.claude/commands/use-intellij-hook.md`

</blockquote>
</details>
<details>
<summary><strong>03 · IntelliJ post-commit hook now respects user-excluded conversations</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The IntelliJ plugin has its own built-in pipeline for generating commit summaries, but it was ignoring the checkboxes users set in the sidebar to exclude specific conversations. Every conversation was being included regardless of what the user had selected.

**💡 Decisions Behind the Code**

- **Filter before transcript reads**: Excluded sessions are dropped before any transcript content is consumed, intentionally mirroring the CLI pipeline's approach. This prevents the read cursor from advancing for sessions the user chose to skip, so those sessions remain available on the next commit.
- **Reuse existing store**: `CommitSelectionStore.readExclusions` and `CommitSelectionStore.conversationKey` were already used by the IntelliJ UI layer; wiring the same calls into the pipeline avoids duplicating exclusion-key logic.

**✅ What Was Implemented**

- Added exclusion filtering in `PostCommitHook.runWorker` (PostCommitHook.kt, lines 178–192): reads `commit-selection.json` via `CommitSelectionStore.readExclusions`, builds a conversation key per session, and filters out any session whose key appears in `exclusions.conversations`.
- Filtering runs after session discovery but before transcript reading, so excluded sessions do not advance their read cursors — matching the behavior of the CLI's `QueueWorker`.
- Updated the discovery log line to report both total discovered count and excluded count.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt`

</blockquote>
</details>
<details>
<summary><strong>04 · Skills added to check and switch between VS Code and IntelliJ post-commit hooks</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The developer switches between VS Code and IntelliJ regularly and had no easy way to tell which hook was currently active or to swap between them without manually editing the git hook file.

**💡 Decisions Behind the Code**

Both hook runtimes persist on disk after their respective plugin activates and do not get removed when switching editors. Because of this, switching only requires editing the post-commit file rather than reinstalling anything — the skills exploit that fact by commenting/uncommenting sections rather than rewriting the file.

**✅ What Was Implemented**

- Created three Claude skills: one to report which hook sections are present and active, one to activate the VS Code hook, and one to activate the IntelliJ hook.
- Skills use the `# >>> JolliMemory` / `# <<< JolliMemory` section markers already written by each installer to identify and toggle blocks without destroying the other surface's section.

**📋 Future Enhancements**

- The IntelliJ section marker uses an `(intellij)` suffix to distinguish it from the VS Code marker; this convention should be confirmed against what `HookInstaller.install()` actually writes once the IntelliJ installer is updated to emit that marker natively.

**📁 FILES**
- `.claude/commands/check-hook.md`
- `.claude/commands/use-vscode-hook.md`
- `.claude/commands/use-intellij-hook.md`

</blockquote>
</details>

---

*Generated by JolliMemory · June 17, 2026 at 5:01 PM · via Anthropic*
<!-- jollimemory-summary-end -->