### PR TITLE
Fix: stop filtering transcript history by source enable flags

### DIFF
--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -4305,8 +4305,9 @@ describe("SummaryWebviewPanel", () => {
 				expect(statsMessages).toHaveLength(0);
 			});
 
-			it("excludes sessions from disabled sources in transcript stats", async () => {
-				// Disable claude and codex; only gemini is enabled
+			it("includes sessions from disabled sources in transcript stats (history is not gated by enable flags)", async () => {
+				// Disable claude and codex; only gemini is enabled. Archived history
+				// must still be counted in full — enable flags only gate future capture.
 				mockLoadConfig.mockResolvedValue({
 					claudeEnabled: false,
 					codexEnabled: false,
@@ -4355,18 +4356,23 @@ describe("SummaryWebviewPanel", () => {
 				dispatch({ command: "loadTranscriptStats" });
 				await flushPromises();
 
-				// Claude (s1) and codex (cx1) sessions should be excluded; only gemini (g1) counted
+				// All three sessions counted regardless of disabled claude/codex.
 				expect(postMessage).toHaveBeenCalledWith(
 					expect.objectContaining({
 						command: "transcriptStatsLoaded",
-						totalEntries: 1,
-						sessionCounts: expect.objectContaining({ gemini: 1 }),
+						totalEntries: 4,
+						sessionCounts: expect.objectContaining({
+							claude: 1,
+							codex: 1,
+							gemini: 1,
+						}),
 					}),
 				);
 			});
 
-			it("excludes gemini sessions when geminiEnabled is false", async () => {
-				// Disable gemini while keeping claude and codex enabled
+			it("includes gemini sessions even when geminiEnabled is false", async () => {
+				// Disable gemini while keeping claude and codex enabled — gemini
+				// history is still counted.
 				mockLoadConfig.mockResolvedValue({
 					claudeEnabled: true,
 					codexEnabled: true,
@@ -4407,12 +4413,12 @@ describe("SummaryWebviewPanel", () => {
 				dispatch({ command: "loadTranscriptStats" });
 				await flushPromises();
 
-				// Gemini session (g1) should be excluded; only claude session counted
+				// Both claude and gemini sessions counted despite gemini disabled.
 				expect(postMessage).toHaveBeenCalledWith(
 					expect.objectContaining({
 						command: "transcriptStatsLoaded",
-						totalEntries: 1,
-						sessionCounts: expect.objectContaining({ claude: 1 }),
+						totalEntries: 2,
+						sessionCounts: expect.objectContaining({ claude: 1, gemini: 1 }),
 					}),
 				);
 			});
@@ -4642,8 +4648,10 @@ describe("SummaryWebviewPanel", () => {
 				expect(loadingMessages).toHaveLength(0);
 			});
 
-			it("excludes sessions from disabled sources in loadAllTranscripts", async () => {
-				// Disable claude so claude-sourced sessions are filtered out
+			it("includes sessions from disabled sources in loadAllTranscripts (history is not gated by enable flags)", async () => {
+				// Disable claude — its archived sessions must STILL load, so the
+				// Manage modal shows them and Save All round-trips them. Filtering
+				// here was the visible half of a silent save-time data-loss bug.
 				mockLoadConfig.mockResolvedValue({
 					claudeEnabled: false,
 					codexEnabled: true,
@@ -4707,9 +4715,12 @@ describe("SummaryWebviewPanel", () => {
 				const payload = (loadedCall as Array<unknown>)[0] as {
 					entries: Array<{ source: string }>;
 				};
-				// Only codex entries should be present; claude entries filtered out
-				expect(payload.entries.every((e) => e.source === "codex")).toBe(true);
-				expect(payload.entries).toHaveLength(1);
+				// Both claude (disabled) and codex sessions present — nothing filtered.
+				expect(payload.entries).toHaveLength(2);
+				expect(payload.entries.map((e) => e.source).sort()).toEqual([
+					"claude",
+					"codex",
+				]);
 			});
 
 			it("loads all transcript entries and sends to webview", async () => {
@@ -4946,6 +4957,191 @@ describe("SummaryWebviewPanel", () => {
 				expect(postMessage).toHaveBeenCalledWith({
 					command: "transcriptsSaved",
 				});
+			});
+		});
+
+		// ── BUG 7 regression: history is not gated by enable flags ───────────
+		describe("saveAllTranscripts preserves disabled-source sessions (BUG 7)", () => {
+			type LoadedEntry = {
+				commitHash: string;
+				sessionId: string;
+				source: string;
+				transcriptPath: string;
+				originalIndex: number;
+				role: "human" | "assistant";
+				content: string;
+				timestamp: string;
+			};
+			type WrittenTranscript = {
+				hash: string;
+				data: {
+					sessions: Array<{
+						source: string;
+						entries: Array<{ content: string }>;
+					}>;
+				};
+			};
+
+			function loadedEntries(): Array<LoadedEntry> {
+				const call = postMessage.mock.calls.find(
+					(c) =>
+						(c[0] as { command: string }).command ===
+						"allTranscriptsLoaded",
+				);
+				return (call?.[0] as { entries: Array<LoadedEntry> }).entries;
+			}
+
+			it("round-trips a codex session through load→save even when codexEnabled is false", async () => {
+				mockLoadConfig.mockResolvedValue({
+					claudeEnabled: true,
+					codexEnabled: false,
+				});
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				mockReadTranscriptsForCommits.mockResolvedValue(
+					new Map([
+						[
+							"abc123",
+							{
+								sessions: [
+									{
+										sessionId: "s1",
+										source: "claude" as const,
+										transcriptPath: "/path/claude",
+										entries: [
+											{ role: "human" as const, content: "Claude Q" },
+										],
+									},
+									{
+										sessionId: "cx1",
+										source: "codex" as const,
+										transcriptPath: "/path/codex",
+										entries: [
+											{ role: "human" as const, content: "Codex Q" },
+										],
+									},
+								],
+							},
+						],
+					]),
+				);
+				const summary = makeSummary();
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
+				const dispatch = captureMessageHandler();
+
+				// 1) Load — the webview now receives BOTH claude and codex entries.
+				dispatch({ command: "loadAllTranscripts" });
+				await flushPromises();
+				const loaded = loadedEntries();
+				expect(loaded.map((e) => e.source).sort()).toEqual([
+					"claude",
+					"codex",
+				]);
+
+				// 2) User edits only the claude entry, leaves codex untouched, and
+				//    Save All round-trips the full set the webview holds.
+				const roundTripped = loaded.map((e) =>
+					e.source === "claude" ? { ...e, content: "Claude EDITED" } : e,
+				);
+				mockSaveTranscriptsBatch.mockClear();
+				dispatch({ command: "saveAllTranscripts", entries: roundTripped });
+				await flushPromises();
+
+				expect(mockSaveTranscriptsBatch).toHaveBeenCalledTimes(1);
+				const [writes, deletes] = mockSaveTranscriptsBatch.mock.calls[0] as [
+					Array<WrittenTranscript>,
+					Array<string>,
+				];
+				// abc123 is NOT deleted, and the codex session survives verbatim.
+				expect(deletes).not.toContain("abc123");
+				const write = writes.find((w) => w.hash === "abc123");
+				expect(write?.data.sessions.map((s) => s.source).sort()).toEqual([
+					"claude",
+					"codex",
+				]);
+				const codex = write?.data.sessions.find((s) => s.source === "codex");
+				expect(codex?.entries[0]?.content).toBe("Codex Q");
+			});
+
+			it("does not delete a transcript whose sessions are all from a disabled source", async () => {
+				// abc123 = claude only; def456 = codex only. Codex disabled, user
+				// edits the claude transcript and hits Save All. def456 must NOT be
+				// deleted just because every one of its sessions is codex.
+				mockLoadConfig.mockResolvedValue({
+					claudeEnabled: true,
+					codexEnabled: false,
+				});
+				mockGetTranscriptHashes.mockResolvedValue(
+					new Set(["abc123", "def456"]),
+				);
+				mockReadTranscriptsForCommits.mockResolvedValue(
+					new Map([
+						[
+							"abc123",
+							{
+								sessions: [
+									{
+										sessionId: "s1",
+										source: "claude" as const,
+										transcriptPath: "/path/claude",
+										entries: [
+											{ role: "human" as const, content: "Claude Q" },
+										],
+									},
+								],
+							},
+						],
+						[
+							"def456",
+							{
+								sessions: [
+									{
+										sessionId: "cx1",
+										source: "codex" as const,
+										transcriptPath: "/path/codex",
+										entries: [
+											{ role: "human" as const, content: "Codex Q" },
+										],
+									},
+								],
+							},
+						],
+					]),
+				);
+				const summary = makeSummary({
+					children: [makeSummary({ commitHash: "def456" })],
+				});
+				await SummaryWebviewPanel.show(
+					summary,
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "loadAllTranscripts" });
+				await flushPromises();
+				const roundTripped = loadedEntries().map((e) =>
+					e.source === "claude" ? { ...e, content: "Claude EDITED" } : e,
+				);
+				mockSaveTranscriptsBatch.mockClear();
+				dispatch({ command: "saveAllTranscripts", entries: roundTripped });
+				await flushPromises();
+
+				const [writes, deletes] = mockSaveTranscriptsBatch.mock.calls[0] as [
+					Array<WrittenTranscript>,
+					Array<string>,
+				];
+				expect(deletes).not.toContain("def456");
+				const def = writes.find((w) => w.hash === "def456");
+				expect(def?.data.sessions[0]?.source).toBe("codex");
+				expect(def?.data.sessions[0]?.entries[0]?.content).toBe("Codex Q");
 			});
 		});
 
@@ -8135,7 +8331,7 @@ describe("SummaryWebviewPanel", () => {
 		// ── openCodeEnabled: false ────────────────────────────────────────────────
 
 		describe("loadTranscriptStats: openCodeEnabled false", () => {
-			it("excludes opencode sessions when openCodeEnabled is false", async () => {
+			it("includes opencode sessions even when openCodeEnabled is false", async () => {
 				mockLoadConfig.mockResolvedValue({
 					claudeEnabled: true,
 					codexEnabled: true,
@@ -8180,12 +8376,15 @@ describe("SummaryWebviewPanel", () => {
 				dispatch({ command: "loadTranscriptStats" });
 				await flushPromises();
 
-				// opencode session (oc1) should be excluded; only claude session counted
+				// Both claude and opencode (oc1) counted despite opencode disabled.
 				expect(postMessage).toHaveBeenCalledWith(
 					expect.objectContaining({
 						command: "transcriptStatsLoaded",
-						totalEntries: 1,
-						sessionCounts: expect.objectContaining({ claude: 1 }),
+						totalEntries: 3,
+						sessionCounts: expect.objectContaining({
+							claude: 1,
+							opencode: 1,
+						}),
 					}),
 				);
 			});
@@ -8194,7 +8393,7 @@ describe("SummaryWebviewPanel", () => {
 		// ── cursorEnabled: false ────────────────────────────────────────────────
 
 		describe("loadTranscriptStats: cursorEnabled false", () => {
-			it("excludes cursor sessions when cursorEnabled is false", async () => {
+			it("includes cursor sessions even when cursorEnabled is false", async () => {
 				mockLoadConfig.mockResolvedValue({
 					claudeEnabled: true,
 					codexEnabled: true,
@@ -8240,11 +8439,12 @@ describe("SummaryWebviewPanel", () => {
 				dispatch({ command: "loadTranscriptStats" });
 				await flushPromises();
 
+				// Both claude and cursor (cur1) counted despite cursor disabled.
 				expect(postMessage).toHaveBeenCalledWith(
 					expect.objectContaining({
 						command: "transcriptStatsLoaded",
-						totalEntries: 1,
-						sessionCounts: expect.objectContaining({ claude: 1 }),
+						totalEntries: 3,
+						sessionCounts: expect.objectContaining({ claude: 1, cursor: 1 }),
 					}),
 				);
 			});
@@ -8299,7 +8499,7 @@ describe("SummaryWebviewPanel", () => {
 				);
 			});
 
-			it("excludes copilot sessions when copilotEnabled === false", async () => {
+			it("includes copilot sessions even when copilotEnabled === false", async () => {
 				mockLoadConfig.mockResolvedValue({
 					claudeEnabled: true,
 					copilotEnabled: false,
@@ -8342,12 +8542,12 @@ describe("SummaryWebviewPanel", () => {
 				dispatch({ command: "loadTranscriptStats" });
 				await flushPromises();
 
-				// copilot session (cp1) should be excluded; only claude session counted
+				// Both claude and copilot (cp1) counted despite copilot disabled.
 				expect(postMessage).toHaveBeenCalledWith(
 					expect.objectContaining({
 						command: "transcriptStatsLoaded",
-						totalEntries: 1,
-						sessionCounts: expect.objectContaining({ claude: 1 }),
+						totalEntries: 3,
+						sessionCounts: expect.objectContaining({ claude: 1, copilot: 1 }),
 					}),
 				);
 			});
@@ -8398,7 +8598,7 @@ describe("SummaryWebviewPanel", () => {
 				);
 			});
 
-			it("excludes copilot-chat when copilotEnabled is false", async () => {
+			it("includes copilot-chat even when copilotEnabled is false", async () => {
 				mockLoadConfig.mockResolvedValue({
 					claudeEnabled: true,
 					copilotEnabled: false,
@@ -8441,18 +8641,21 @@ describe("SummaryWebviewPanel", () => {
 				dispatch({ command: "loadTranscriptStats" });
 				await flushPromises();
 
-				// copilot-chat session (cc1) should be excluded; only claude session counted
+				// Both claude and copilot-chat (cc1) counted despite copilot disabled.
 				expect(postMessage).toHaveBeenCalledWith(
 					expect.objectContaining({
 						command: "transcriptStatsLoaded",
-						totalEntries: 1,
-						sessionCounts: expect.objectContaining({ claude: 1 }),
+						totalEntries: 3,
+						sessionCounts: expect.objectContaining({
+							claude: 1,
+							"copilot-chat": 1,
+						}),
 					}),
 				);
 				const lastCall = postMessage.mock.calls[
 					postMessage.mock.calls.length - 1
 				]?.[0] as { sessionCounts?: Record<string, number> } | undefined;
-				expect(lastCall?.sessionCounts).not.toHaveProperty("copilot-chat");
+				expect(lastCall?.sessionCounts).toHaveProperty("copilot-chat", 1);
 			});
 		});
 

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -3416,32 +3416,6 @@ export class SummaryWebviewPanel {
 
 	// ─── Transcript handlers ─────────────────────────────────────────────────
 
-	/** Returns the set of integration source names that are currently enabled in config. */
-	private async getEnabledSources(): Promise<Set<string>> {
-		const config = await loadGlobalConfig();
-		const sources = new Set<string>();
-		if (config.claudeEnabled !== false) {
-			sources.add("claude");
-		}
-		if (config.codexEnabled !== false) {
-			sources.add("codex");
-		}
-		if (config.geminiEnabled !== false) {
-			sources.add("gemini");
-		}
-		if (config.openCodeEnabled !== false) {
-			sources.add("opencode");
-		}
-		if (config.cursorEnabled !== false) {
-			sources.add("cursor");
-		}
-		if (config.copilotEnabled !== false) {
-			sources.add("copilot");
-			sources.add("copilot-chat");
-		}
-		return sources;
-	}
-
 	/** Loads lightweight stats (session/entry counts by source) without sending full content. */
 	private async handleLoadTranscriptStats(): Promise<void> {
 		if (this.transcriptHashSet.size === 0) {
@@ -3456,18 +3430,18 @@ export class SummaryWebviewPanel {
 			: await this.bridge.readTranscriptsForCommits([
 					...this.transcriptHashSet,
 				]);
-		const enabledSources = await this.getEnabledSources();
 
-		// Deduplicate sessions by source:sessionId (same session may appear in multiple commit transcripts)
+		// Stats reflect the transcripts actually archived at commit time. They are
+		// NOT filtered by the current Settings enable flags: those flags govern
+		// whether a source is *captured going forward*, not whether already-archived
+		// history is shown. Filtering here under-counted disabled-source sessions and
+		// — paired with the save path — was the visible half of a silent data-loss bug.
 		const seen = new Set<string>();
 		let totalEntries = 0;
 		const sessionCounts: Record<string, number> = {};
 		for (const [, transcript] of transcriptMap) {
 			for (const session of transcript.sessions) {
 				const source = session.source ?? "claude";
-				if (!enabledSources.has(source)) {
-					continue;
-				}
 				const key = `${source}:${session.sessionId}`;
 				totalEntries += session.entries.length;
 				if (seen.has(key)) {
@@ -3502,8 +3476,13 @@ export class SummaryWebviewPanel {
 					this.foreignStorage,
 				)
 			: await this.bridge.readTranscriptsForCommits(hashesWithTranscripts);
-		const enabledSources = await this.getEnabledSources();
 
+		// Load every archived session regardless of the current Settings enable
+		// flags. Those flags only gate future capture; the transcripts here were
+		// already recorded at commit time. The Manage modal must show — and Save All
+		// must round-trip — all of them, or disabled-source sessions silently vanish
+		// on save (and whole transcripts get deleted when all their sessions are
+		// from a now-disabled source).
 		// Build tagged entries: each entry carries its commit hash, session info, and original index
 		const taggedEntries: Array<{
 			commitHash: string;
@@ -3519,15 +3498,12 @@ export class SummaryWebviewPanel {
 		for (const [commitHash, transcript] of transcriptMap) {
 			for (const session of transcript.sessions) {
 				const source = session.source ?? "claude";
-				if (!enabledSources.has(source)) {
-					continue;
-				}
 				for (let i = 0; i < session.entries.length; i++) {
 					const entry = session.entries[i];
 					taggedEntries.push({
 						commitHash,
 						sessionId: session.sessionId,
-						source: session.source ?? "claude",
+						source,
 						transcriptPath: session.transcriptPath ?? "",
 						originalIndex: i,
 						role: entry.role,


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Conversations recorded by AI sources that a user later disables in Settings are now fully preserved and visible in the commit history panel. Previously, disabling a source caused its past sessions to vanish from the Manage view and be counted as zero in the sidebar; any Save All action after that point would permanently erase those sessions from disk. The fix ensures the history panel always loads and displays every session that was archived at commit time, regardless of what the Settings panel currently shows as enabled. A three-round review process — two independent reviewers followed by an adversarial challenge — confirmed the fix is complete and that no additional defensive code is needed in the save path.

---

## E2E Test (2)
<details>
<summary><strong>1. Disabled AI source conversations still appear in history panel</strong></summary>
<br>
<blockquote>

**Preconditions:** Have at least two AI sources (e.g. Claude and Codex) with recorded conversations in the commit history. Both sources should have past conversations visible before making any changes to Settings.

**Steps:**
1. Open the extension and navigate to the commit history panel to confirm you can see conversations from multiple AI sources (e.g. both Claude and Codex entries are listed).
2. Open Settings and turn OFF one of the AI sources (e.g. disable Codex).
3. Save the Settings change and return to the commit history panel.
4. Check whether the conversations from the now-disabled source (Codex) are still visible in the history list.
5. Open the Manage Transcripts modal (or equivalent panel that shows all recorded conversations).
6. Verify that the disabled source's past conversations are still shown there as well.

**Expected Results:**
- Conversations from the disabled AI source (Codex) remain fully visible in the commit history panel — nothing disappears.
- The Manage Transcripts modal shows entries from all sources, including the one that was just disabled.
- The total conversation count does not drop after disabling a source.

</blockquote>
</details>
<details>
<summary><strong>2. Save All does not delete conversations from a disabled AI source</strong></summary>
<br>
<blockquote>

**Preconditions:** Have at least two AI sources with recorded conversations (e.g. Claude and Codex). Codex should be disabled in Settings before starting.

**Steps:**
1. With Codex disabled in Settings, open the Manage Transcripts modal so all past conversations are loaded.
2. Make a small edit to a Claude conversation entry (e.g. change a word in one message).
3. Click "Save All" to save your changes.
4. Close and reopen the Manage Transcripts modal (or refresh the history panel).
5. Check that the Codex conversations are still present and unchanged.

**Expected Results:**
- After clicking Save All, the Codex conversations are still listed in the history panel and Manage modal.
- The Codex conversation content is exactly as it was before — nothing was altered or removed.
- No data-loss warning or missing-entry state appears.

</blockquote>
</details>

---

## Topic (1)
<details>
<summary><strong>01 · History transcripts no longer filtered by which AI sources are currently enabled</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users discovered that turning off an AI source in Settings caused that source's past conversations to disappear from the commit history panel. Worse, clicking "Save All" after any unrelated edit would permanently delete those hidden conversations from disk, with no way to recover them inside the product.

**💡 Decisions Behind the Code**

- **Remove filtering entirely rather than adding a merge-back safety net**: The original bug report proposed a defensive fix — keep the load-side filter but merge skipped sessions back in before saving. The team chose instead to remove the filter at the source, which is simpler, eliminates the under-counting in the sidebar stats, and matches the correct conceptual model: Settings flags control whether a source is captured going forward, not whether already-archived history is visible. The merge-back approach would have preserved a misleading UI (hidden sessions) while only preventing data loss.
- **Validate that "empty transcript" deletion edge case is not reachable**: An adversarial review raised a concern that a transcript file with no entries could be silently deleted by Save All. Investigation of the write path confirmed two stacked guards prevent this: sessions with zero entries are never added to a transcript, and a transcript with zero sessions is never written to disk or referenced in the commit index. The edge case is structurally unreachable under normal product operation, so no additional guard was added.
- **Reverse existing tests rather than delete them**: Six tests previously asserted that disabled-source sessions were excluded from stats and load results. These were inverted in place — updated expected counts and renamed to describe the correct behavior — rather than deleted. This preserves the test coverage surface and makes the behavioral contract explicit in the test suite.

**✅ What Was Implemented**

- Removed the `getEnabledSources` method and all three call sites from `SummaryWebviewPanel.ts`. The stats-loading path (`handleLoadTranscriptStats`) and the full-content loading path (`handleLoadAllTranscripts`) previously skipped sessions whose source was currently disabled; both now iterate every archived session unconditionally. A clarifying comment was added at each site explaining that enable flags govern future capture only, not historical display.
- Because the save path rebuilds transcripts from whatever the panel loaded, removing the load-side filter was sufficient to fix silent deletion: the webview now holds all sessions and returns them on Save All, so no sessions are dropped and no transcript files are incorrectly queued for deletion.

**📋 Future Enhancements**

The adversarial review identified that a transcript file containing only sessions from a now-disabled source would previously have been silently deleted on Save All. This specific path is confirmed unreachable under normal write behavior, but the finding was noted for potential follow-up as a separate, isolated guard if historical or manually-edited data ever needs to be handled.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 18, 2026 at 4:42 PM · via Anthropic*
<!-- jollimemory-summary-end -->