### PR TITLE
Fix amend safety by resolving own-commits base from branch fork point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ Thumbs.db
 .claude/
 .kiro/
 .gemini/
+.cursor/
 .codex/
 .opencode/
 # Claude MCP server config — written per-worktree with an absolute local path

--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -1930,6 +1930,88 @@ describe("JolliMemoryBridge", () => {
 		});
 	});
 
+	// ── getAmendSafety ───────────────────────────────────────────────────
+
+	describe("getAmendSafety()", () => {
+		// Each getAmendSafety() call runs exactly: getHEADHash → refExists
+		// (origin/main) → merge-base → log %ae → config user.email.
+
+		it("reports own work when HEAD diverges from base and the author matches", async () => {
+			// getHEADHash
+			mockExecFileSuccess("head1111\n");
+			// resolveHistoryBaseRef → refExists origin/main
+			mockExecFileSuccess("base9999\n");
+			// merge-base — differs from HEAD
+			mockExecFileSuccess("mergebase7\n");
+			// HEAD author email (different case — must still match)
+			mockExecFileSuccess("Me@Example.com\n");
+			// current git user.email
+			mockExecFileSuccess("me@example.com\n");
+
+			const bridge = makeBridge();
+			const result = await bridge.getAmendSafety("main");
+
+			expect(result).toEqual({
+				hasOwnCommits: true,
+				headAuthoredByCurrentUser: true,
+			});
+		});
+
+		it("flags no own commits when HEAD equals the merge-base", async () => {
+			mockExecFileSuccess("samehash0\n"); // getHEADHash
+			mockExecFileSuccess("base9999\n"); // refExists origin/main
+			mockExecFileSuccess("samehash0\n"); // merge-base === HEAD
+			mockExecFileSuccess("me@example.com\n"); // author
+			mockExecFileSuccess("me@example.com\n"); // user.email
+
+			const bridge = makeBridge();
+			const result = await bridge.getAmendSafety("main");
+
+			expect(result.hasOwnCommits).toBe(false);
+			expect(result.headAuthoredByCurrentUser).toBe(true);
+		});
+
+		it("flags a foreign author when HEAD email differs from user.email", async () => {
+			mockExecFileSuccess("head1111\n"); // getHEADHash
+			mockExecFileSuccess("base9999\n"); // refExists origin/main
+			mockExecFileSuccess("mergebase7\n"); // merge-base
+			mockExecFileSuccess("colleague@example.com\n"); // author
+			mockExecFileSuccess("me@example.com\n"); // user.email
+
+			const bridge = makeBridge();
+			const result = await bridge.getAmendSafety("main");
+
+			expect(result.hasOwnCommits).toBe(true);
+			expect(result.headAuthoredByCurrentUser).toBe(false);
+		});
+
+		it("treats an empty HEAD author email as not the current user", async () => {
+			mockExecFileSuccess("head1111\n"); // getHEADHash
+			mockExecFileSuccess("base9999\n"); // refExists origin/main
+			mockExecFileSuccess("mergebase7\n"); // merge-base
+			mockExecFileSuccess("\n"); // author email empty
+			mockExecFileSuccess("me@example.com\n"); // user.email
+
+			const bridge = makeBridge();
+			const result = await bridge.getAmendSafety("main");
+
+			expect(result.headAuthoredByCurrentUser).toBe(false);
+		});
+
+		it("treats an empty user.email as not the current user", async () => {
+			mockExecFileSuccess("head1111\n"); // getHEADHash
+			mockExecFileSuccess("base9999\n"); // refExists origin/main
+			mockExecFileSuccess("mergebase7\n"); // merge-base
+			mockExecFileSuccess("someone@example.com\n"); // author
+			mockExecFileSuccess("\n"); // user.email empty
+
+			const bridge = makeBridge();
+			const result = await bridge.getAmendSafety("main");
+
+			expect(result.headAuthoredByCurrentUser).toBe(false);
+		});
+	});
+
 	// ── generateSquashMessage ────────────────────────────────────────────
 
 	describe("generateSquashMessage()", () => {

--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -205,9 +205,10 @@ const { lstat, mkdir, rm, unlink, writeFile } = vi.hoisted(() => ({
  * The mock signature must match the callback-based execFile:
  *   execFile(cmd, args, options, callback)
  *
- * Uses an argument-matching approach: each stubbed response is keyed by a
- * matcher that inspects (cmd, args) so the order of concurrent calls
- * (e.g. inside Promise.all) does not matter.
+ * Responses are queued FIFO via `mockImplementationOnce` (see
+ * `mockExecFileSuccess`/`mockExecFileError`): each call consumes the next
+ * stubbed response in order, so a test's mocks must be arranged in the exact
+ * order the code under test invokes git.
  */
 const execFileMock = vi.hoisted(() => {
 	const fn = vi.fn();
@@ -1933,20 +1934,20 @@ describe("JolliMemoryBridge", () => {
 	// ── getAmendSafety ───────────────────────────────────────────────────
 
 	describe("getAmendSafety()", () => {
-		// Each getAmendSafety() call runs exactly: getHEADHash → refExists
-		// (origin/main) → merge-base → log %ae → config user.email.
+		// Call order: getHEADHash → getCurrentBranch → refExists(origin/main) →
+		// merge-base → findBranchCreationPoint (reflog) → [merge-base --is-ancestor
+		// when the creation point differs from the merge-base] → log %ae →
+		// config user.email.
 
-		it("reports own work when HEAD diverges from base and the author matches", async () => {
-			// getHEADHash
-			mockExecFileSuccess("head1111\n");
-			// resolveHistoryBaseRef → refExists origin/main
-			mockExecFileSuccess("base9999\n");
-			// merge-base — differs from HEAD
-			mockExecFileSuccess("mergebase7\n");
-			// HEAD author email (different case — must still match)
-			mockExecFileSuccess("Me@Example.com\n");
-			// current git user.email
-			mockExecFileSuccess("me@example.com\n");
+		it("reports own work when the branch was cut from main and the author matches", async () => {
+			mockExecFileSuccess("head1111\n"); // getHEADHash
+			mockExecFileSuccess("feature/x\n"); // getCurrentBranch
+			mockExecFileSuccess("base9999\n"); // refExists origin/main
+			mockExecFileSuccess("mergebase7\n"); // merge-base — differs from HEAD
+			// reflog: created from main at the merge-base → creationPoint == merge-base
+			mockExecFileSuccess("mergebase7 branch: Created from main\n");
+			mockExecFileSuccess("Me@Example.com\n"); // author (different case — must still match)
+			mockExecFileSuccess("me@example.com\n"); // user.email
 
 			const bridge = makeBridge();
 			const result = await bridge.getAmendSafety("main");
@@ -1957,10 +1958,12 @@ describe("JolliMemoryBridge", () => {
 			});
 		});
 
-		it("flags no own commits when HEAD equals the merge-base", async () => {
+		it("flags no own commits when HEAD equals the mainline merge-base", async () => {
 			mockExecFileSuccess("samehash0\n"); // getHEADHash
+			mockExecFileSuccess("fix/foo\n"); // getCurrentBranch
 			mockExecFileSuccess("base9999\n"); // refExists origin/main
 			mockExecFileSuccess("samehash0\n"); // merge-base === HEAD
+			mockExecFileSuccess("samehash0 branch: Created from main\n"); // reflog → creationPoint == merge-base
 			mockExecFileSuccess("me@example.com\n"); // author
 			mockExecFileSuccess("me@example.com\n"); // user.email
 
@@ -1971,10 +1974,176 @@ describe("JolliMemoryBridge", () => {
 			expect(result.headAuthoredByCurrentUser).toBe(true);
 		});
 
-		it("flags a foreign author when HEAD email differs from user.email", async () => {
+		it("flags no own commits for a fresh branch cut from a non-main base (release fork)", async () => {
+			// hotfix/x cut from release/1.0 at E; HEAD is still E (zero own commits).
+			mockExecFileSuccess("E0000000\n"); // getHEADHash (HEAD = E)
+			mockExecFileSuccess("hotfix/x\n"); // getCurrentBranch
+			mockExecFileSuccess("base9999\n"); // refExists origin/main
+			mockExecFileSuccess("C0000000\n"); // merge-base with main = C
+			mockExecFileSuccess("E0000000 branch: Created from release/1.0\n"); // reflog → creationPoint = E
+			mockExecFileSuccess(""); // is-ancestor E HEAD → exit 0 (still behind HEAD) → keep E
+			mockExecFileSuccess(""); // is-ancestor C E → exit 0 (downstream) → base = E
+			mockExecFileSuccess("me@example.com\n"); // author
+			mockExecFileSuccess("me@example.com\n"); // user.email
+
+			const bridge = makeBridge();
+			const result = await bridge.getAmendSafety("main");
+
+			// base == E == HEAD → no own commits, even though E is ahead of main.
+			expect(result.hasOwnCommits).toBe(false);
+		});
+
+		it("reports own work once the release-fork branch has its own commit", async () => {
+			// hotfix/x cut from release/1.0 at E, now with own commit F on top.
+			mockExecFileSuccess("F0000000\n"); // getHEADHash (HEAD = F)
+			mockExecFileSuccess("hotfix/x\n"); // getCurrentBranch
+			mockExecFileSuccess("base9999\n"); // refExists origin/main
+			mockExecFileSuccess("C0000000\n"); // merge-base with main = C
+			mockExecFileSuccess("E0000000 branch: Created from release/1.0\n"); // reflog → creationPoint = E
+			mockExecFileSuccess(""); // is-ancestor E HEAD → behind HEAD → keep E
+			mockExecFileSuccess(""); // is-ancestor C E → downstream → base = E
+			mockExecFileSuccess("me@example.com\n"); // author
+			mockExecFileSuccess("me@example.com\n"); // user.email
+
+			const bridge = makeBridge();
+			const result = await bridge.getAmendSafety("main");
+
+			// base == E != F → own commit exists → amend allowed.
+			expect(result.hasOwnCommits).toBe(true);
+		});
+
+		it("skips the reflog fork point on detached HEAD and uses the mainline merge-base", async () => {
 			mockExecFileSuccess("head1111\n"); // getHEADHash
+			mockExecFileSuccess("HEAD\n"); // getCurrentBranch → detached
 			mockExecFileSuccess("base9999\n"); // refExists origin/main
 			mockExecFileSuccess("mergebase7\n"); // merge-base
+			// findBranchCreationPoint bails out for "HEAD" → no reflog call,
+			// resolveOwnCommitsBase returns the merge-base directly.
+			mockExecFileSuccess("me@example.com\n"); // author
+			mockExecFileSuccess("me@example.com\n"); // user.email
+
+			const bridge = makeBridge();
+			const result = await bridge.getAmendSafety("main");
+
+			// base == merge-base (mergebase7) != HEAD → own work, no reflog consulted.
+			expect(result.hasOwnCommits).toBe(true);
+		});
+
+		it("falls back to the mainline merge-base when the reflog is unavailable", async () => {
+			mockExecFileSuccess("head1111\n"); // getHEADHash
+			mockExecFileSuccess("feature/x\n"); // getCurrentBranch
+			mockExecFileSuccess("base9999\n"); // refExists origin/main
+			mockExecFileSuccess("mergebase7\n"); // merge-base
+			mockExecFileSuccess("\n"); // reflog empty → creationPoint undefined → use merge-base
+			mockExecFileSuccess("me@example.com\n"); // author
+			mockExecFileSuccess("me@example.com\n"); // user.email
+
+			const bridge = makeBridge();
+			const result = await bridge.getAmendSafety("main");
+
+			// base == merge-base (mergebase7) != HEAD → own work.
+			expect(result.hasOwnCommits).toBe(true);
+		});
+
+		it("keeps the mainline merge-base when the creation point is not downstream of it", async () => {
+			mockExecFileSuccess("head1111\n"); // getHEADHash
+			mockExecFileSuccess("feature/x\n"); // getCurrentBranch
+			mockExecFileSuccess("base9999\n"); // refExists origin/main
+			mockExecFileSuccess("mergebase7\n"); // merge-base
+			mockExecFileSuccess("other000 branch: Created from somewhere\n"); // reflog → creationPoint = other000
+			mockExecFileSuccess(""); // is-ancestor other000 HEAD → behind HEAD (P1 guard passes)
+			mockExecFileError("not downstream"); // is-ancestor mergebase7 other000 → exit 1 → keep merge-base
+			mockExecFileSuccess("me@example.com\n"); // author
+			mockExecFileSuccess("me@example.com\n"); // user.email
+
+			const bridge = makeBridge();
+			const result = await bridge.getAmendSafety("main");
+
+			// base == mergebase7 != HEAD → own work.
+			expect(result.hasOwnCommits).toBe(true);
+		});
+
+		it("rejects a stale creation point that is no longer an ancestor of HEAD (reset onto another branch)", async () => {
+			// feature cut from develop (D1), then `git reset --hard release` → HEAD = R1.
+			// The reflog still says "Created from develop", but D1 is no longer behind HEAD.
+			mockExecFileSuccess("R1111111\n"); // getHEADHash (HEAD = R1, release tip)
+			mockExecFileSuccess("feature\n"); // getCurrentBranch
+			mockExecFileSuccess("base9999\n"); // refExists origin/main
+			mockExecFileSuccess("M1111111\n"); // merge-base with main = M1
+			mockExecFileSuccess("D1111111 branch: Created from develop\n"); // reflog → stale creationPoint = D1
+			mockExecFileError("not an ancestor"); // is-ancestor D1 HEAD → exit 1 → stale → fall back to M1
+			mockExecFileSuccess("me@example.com\n"); // author
+			mockExecFileSuccess("me@example.com\n"); // user.email
+
+			const bridge = makeBridge();
+			const result = await bridge.getAmendSafety("main");
+
+			// The stale D1 is rejected; base falls back to the mainline merge-base M1.
+			const guardCall = execFileMock.mock.calls.find(
+				(c) =>
+					Array.isArray(c[1]) &&
+					c[1][1] === "--is-ancestor" &&
+					c[1][2] === "D1111111" &&
+					c[1][3] === "HEAD",
+			);
+			expect(guardCall).toBeDefined();
+			// Falls back to M1 (≠ HEAD); the downstream check on D1 is never reached.
+			expect(result.hasOwnCommits).toBe(true);
+			const downstreamCall = execFileMock.mock.calls.find(
+				(c) =>
+					Array.isArray(c[1]) &&
+					c[1][1] === "--is-ancestor" &&
+					c[1][3] === "D1111111",
+			);
+			expect(downstreamCall).toBeUndefined();
+		});
+
+		it("ignores a guessed oldest reflog entry when no explicit creation record survives (P2)", async () => {
+			// Single-commit branch whose "Created from" reflog entry has expired;
+			// the oldest surviving entry is the branch's own first commit F1.
+			mockExecFileSuccess("F1111111\n"); // getHEADHash (HEAD = F1)
+			mockExecFileSuccess("feature\n"); // getCurrentBranch
+			mockExecFileSuccess("base9999\n"); // refExists origin/main
+			mockExecFileSuccess("M1111111\n"); // merge-base with main = M1
+			// reflog has entries but NO "branch: Created from" → requireExplicit → undefined.
+			mockExecFileSuccess("F1111111 commit: my first commit\n");
+			mockExecFileSuccess("me@example.com\n"); // author
+			mockExecFileSuccess("me@example.com\n"); // user.email
+
+			const bridge = makeBridge();
+			const result = await bridge.getAmendSafety("main");
+
+			// base degrades to M1 (not the guessed F1), so the lone commit still
+			// counts as own work and amend stays available.
+			expect(result.hasOwnCommits).toBe(true);
+		});
+
+		it("uses the reflog creation point directly when the mainline is unresolvable (master default)", async () => {
+			// master-default repo: origin/main, upstream/main, main all missing.
+			mockExecFileSuccess("E0000000\n"); // getHEADHash (HEAD = E)
+			mockExecFileSuccess("hotfix/x\n"); // getCurrentBranch
+			mockExecFileError("no origin/main"); // refExists origin/main
+			mockExecFileError("no upstream/main"); // refExists upstream/main
+			mockExecFileError("no main"); // refExists main → resolveHistoryBaseRef returns "main"
+			mockExecFileError("no merge base"); // merge-base HEAD main → "" (mergeBaseMain unresolvable)
+			mockExecFileSuccess("E0000000 branch: Created from release/1.0\n"); // reflog → creationPoint = E
+			mockExecFileSuccess(""); // is-ancestor E HEAD → behind HEAD (P1 guard passes)
+			mockExecFileSuccess("me@example.com\n"); // author
+			mockExecFileSuccess("me@example.com\n"); // user.email
+
+			const bridge = makeBridge();
+			const result = await bridge.getAmendSafety("main");
+
+			// mergeBaseMain == "" → use creationPoint E directly; E == HEAD → no own commits.
+			expect(result.hasOwnCommits).toBe(false);
+		});
+
+		it("flags a foreign author when HEAD email differs from user.email", async () => {
+			mockExecFileSuccess("head1111\n"); // getHEADHash
+			mockExecFileSuccess("feature/x\n"); // getCurrentBranch
+			mockExecFileSuccess("base9999\n"); // refExists origin/main
+			mockExecFileSuccess("mergebase7\n"); // merge-base
+			mockExecFileSuccess("mergebase7 branch: Created from main\n"); // reflog → creationPoint == merge-base
 			mockExecFileSuccess("colleague@example.com\n"); // author
 			mockExecFileSuccess("me@example.com\n"); // user.email
 
@@ -1987,8 +2156,10 @@ describe("JolliMemoryBridge", () => {
 
 		it("treats an empty HEAD author email as not the current user", async () => {
 			mockExecFileSuccess("head1111\n"); // getHEADHash
+			mockExecFileSuccess("feature/x\n"); // getCurrentBranch
 			mockExecFileSuccess("base9999\n"); // refExists origin/main
 			mockExecFileSuccess("mergebase7\n"); // merge-base
+			mockExecFileSuccess("mergebase7 branch: Created from main\n"); // reflog
 			mockExecFileSuccess("\n"); // author email empty
 			mockExecFileSuccess("me@example.com\n"); // user.email
 
@@ -2000,8 +2171,10 @@ describe("JolliMemoryBridge", () => {
 
 		it("treats an empty user.email as not the current user", async () => {
 			mockExecFileSuccess("head1111\n"); // getHEADHash
+			mockExecFileSuccess("feature/x\n"); // getCurrentBranch
 			mockExecFileSuccess("base9999\n"); // refExists origin/main
 			mockExecFileSuccess("mergebase7\n"); // merge-base
+			mockExecFileSuccess("mergebase7 branch: Created from main\n"); // reflog
 			mockExecFileSuccess("someone@example.com\n"); // author
 			mockExecFileSuccess("\n"); // user.email empty
 
@@ -2009,6 +2182,72 @@ describe("JolliMemoryBridge", () => {
 			const result = await bridge.getAmendSafety("main");
 
 			expect(result.headAuthoredByCurrentUser).toBe(false);
+		});
+	});
+
+	// ── isHeadSharedWithOtherBranch ──────────────────────────────────────
+
+	describe("isHeadSharedWithOtherBranch()", () => {
+		// Call order: for-each-ref --contains=HEAD → [getCurrentBranch →
+		// @{upstream}] (only when the ref list is non-empty).
+
+		it("returns false when only the current branch and its upstream contain HEAD", async () => {
+			mockExecFileSuccess(
+				"refs/heads/feature\nrefs/remotes/origin/feature\n",
+			); // for-each-ref
+			mockExecFileSuccess("feature\n"); // getCurrentBranch
+			mockExecFileSuccess("origin/feature\n"); // @{upstream}
+
+			const bridge = makeBridge();
+			expect(await bridge.isHeadSharedWithOtherBranch()).toBe(false);
+		});
+
+		it("returns true when another branch contains HEAD", async () => {
+			mockExecFileSuccess(
+				"refs/heads/feature\nrefs/remotes/origin/release/1.0\n",
+			); // for-each-ref
+			mockExecFileSuccess("feature\n"); // getCurrentBranch
+			mockExecFileSuccess("origin/feature\n"); // @{upstream}
+
+			const bridge = makeBridge();
+			expect(await bridge.isHeadSharedWithOtherBranch()).toBe(true);
+		});
+
+		it("returns false when no ref contains HEAD", async () => {
+			mockExecFileSuccess("\n"); // for-each-ref → empty (no branch/upstream lookups)
+
+			const bridge = makeBridge();
+			expect(await bridge.isHeadSharedWithOtherBranch()).toBe(false);
+		});
+
+		it("ignores the current branch when it has no upstream", async () => {
+			mockExecFileSuccess("refs/heads/feature\n"); // for-each-ref → only current branch
+			mockExecFileSuccess("feature\n"); // getCurrentBranch
+			mockExecFileError("no upstream"); // @{upstream} fails → no upstream ref
+
+			const bridge = makeBridge();
+			expect(await bridge.isHeadSharedWithOtherBranch()).toBe(false);
+		});
+
+		it("ignores the current branch's pushed copy even without tracking (push without -u)", async () => {
+			// `git push origin feature` (no -u): origin/feature contains HEAD but
+			// @{upstream} is unset — the origin/<branch> fallback must exclude it.
+			mockExecFileSuccess("refs/heads/feature\nrefs/remotes/origin/feature\n"); // for-each-ref
+			mockExecFileSuccess("feature\n"); // getCurrentBranch
+			mockExecFileError("no upstream"); // @{upstream} fails (no tracking)
+
+			const bridge = makeBridge();
+			expect(await bridge.isHeadSharedWithOtherBranch()).toBe(false);
+		});
+
+		it("treats a detached HEAD reachable from a branch as shared", async () => {
+			mockExecFileSuccess("refs/heads/main\n"); // for-each-ref → main contains HEAD
+			mockExecFileSuccess("HEAD\n"); // getCurrentBranch → detached
+			mockExecFileError("no upstream"); // @{upstream} fails
+
+			const bridge = makeBridge();
+			// No current-branch ref to exclude → main counts as another branch.
+			expect(await bridge.isHeadSharedWithOtherBranch()).toBe(true);
 		});
 	});
 
@@ -3580,6 +3819,8 @@ describe("JolliMemoryBridge", () => {
 			mockExecFileSuccess("headhash123\n");
 			// merge-base
 			mockExecFileSuccess("mergebase456\n");
+			// resolveOwnCommitsBase → findBranchCreationPoint: empty reflog → keep main merge-base
+			mockExecFileSuccess("\n");
 			// git log
 			const logEntry = `commitHash1\x00fix: test change\x00John Doe\x00john@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
 			mockExecFileSuccess(logEntry);
@@ -3655,6 +3896,8 @@ describe("JolliMemoryBridge", () => {
 			mockExecFileSuccess("headhash\n");
 			// merge-base
 			mockExecFileSuccess("mergebase\n");
+			// resolveOwnCommitsBase → findBranchCreationPoint: empty reflog → keep main merge-base
+			mockExecFileSuccess("\n");
 			// git log — empty
 			mockExecFileSuccess("\n");
 
@@ -3665,6 +3908,64 @@ describe("JolliMemoryBridge", () => {
 			expect(result.isMerged).toBe(false);
 		});
 
+		it("excludes the base branch's commits for a fresh branch cut from a non-main base (release fork)", async () => {
+			// hotfix/x cut from release/1.0 at E; HEAD is still E (zero own commits).
+			mockExecFileSuccess("hotfix/x\n"); // getCurrentBranch
+			mockExecFileSuccess("abc\n"); // resolveHistoryBaseRef → origin/main
+			mockExecFileSuccess("E0000000\n"); // getHEADHash (HEAD = E)
+			mockExecFileSuccess("C0000000\n"); // merge-base with main = C (≠ HEAD → not merged)
+			mockExecFileSuccess("E0000000 branch: Created from release/1.0\n"); // reflog → creationPoint = E
+			mockExecFileSuccess(""); // is-ancestor E HEAD → behind HEAD (P1 guard)
+			mockExecFileSuccess(""); // is-ancestor C E → downstream → base = E
+			mockExecFileSuccess("\n"); // git log E..E → empty (nothing of its own)
+
+			const bridge = makeBridge();
+			const result = await bridge.listBranchCommits("main");
+
+			// D and E belong to release/1.0, not to hotfix/x.
+			expect(result.commits).toEqual([]);
+			expect(result.isMerged).toBe(false);
+		});
+
+		it("lists only the branch's own commits past the release fork point, not the base branch's", async () => {
+			// hotfix/x cut from release/1.0 at E, with its own commit F on top.
+			mockExecFileSuccess("hotfix/x\n"); // getCurrentBranch
+			mockExecFileSuccess("abc\n"); // resolveHistoryBaseRef → origin/main
+			mockExecFileSuccess("F0000000\n"); // getHEADHash (HEAD = F)
+			mockExecFileSuccess("C0000000\n"); // merge-base with main = C
+			mockExecFileSuccess("E0000000 branch: Created from release/1.0\n"); // reflog → creationPoint = E
+			mockExecFileSuccess(""); // is-ancestor E HEAD → behind HEAD (P1 guard)
+			mockExecFileSuccess(""); // is-ancestor C E → downstream → base = E
+			const logEntry = `F0000000\x00fix: hotfix work\x00Me\x00me@example.com\x002026-06-20T10:00:00Z\x00\x00\n`;
+			mockExecFileSuccess(logEntry); // git log E..HEAD → only F
+			mockExecFileError("no upstream"); // resolvePushBaseRef @{upstream}
+			mockExecFileError("no origin branch"); // refExists origin/hotfix/x
+			getIndexEntryMap.mockResolvedValue(new Map());
+			getDiffStats.mockResolvedValueOnce({
+				filesChanged: 1,
+				insertions: 2,
+				deletions: 0,
+			});
+			scanTreeHashAliases.mockResolvedValue(false);
+
+			const bridge = makeBridge();
+			const result = await bridge.listBranchCommits("main");
+
+			expect(result.commits).toHaveLength(1);
+			expect(result.commits[0].hash).toBe("F0000000");
+			// The git log range must start at the fork point E, not the main merge-base C.
+			const logCall = execFileMock.mock.calls.find(
+				(c) => Array.isArray(c[1]) && c[1].includes("E0000000..HEAD"),
+			);
+			expect(logCall).toBeDefined();
+			// And it must NOT fall back to the main merge-base C (the old behavior
+			// that would surface release/1.0's D and E).
+			const usedMainBase = execFileMock.mock.calls.some(
+				(c) => Array.isArray(c[1]) && c[1].includes("C0000000..HEAD"),
+			);
+			expect(usedMainBase).toBe(false);
+		});
+
 		it("returns local mainBranch when only the local fallback ref exists", async () => {
 			mockExecFileSuccess("feature/test\n");
 			mockExecFileError("origin missing");
@@ -3672,6 +3973,8 @@ describe("JolliMemoryBridge", () => {
 			mockExecFileSuccess("mainhash\n");
 			mockExecFileSuccess("headhash\n");
 			mockExecFileSuccess("mergebase\n");
+			// resolveOwnCommitsBase → findBranchCreationPoint: empty reflog → keep main merge-base
+			mockExecFileSuccess("\n");
 			const logEntry = `commitHash1\x00feat: local fallback\x00User\x00user@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
 			mockExecFileSuccess(logEntry);
 			mockExecFileError("no upstream");
@@ -3769,6 +4072,8 @@ describe("JolliMemoryBridge", () => {
 			mockExecFileSuccess("headhash123\n");
 			// merge-base
 			mockExecFileSuccess("mergebase456\n");
+			// resolveOwnCommitsBase → findBranchCreationPoint: empty reflog → keep main merge-base
+			mockExecFileSuccess("\n");
 			// git log
 			const logEntry = `commitHash1\x00fix: amend\x00John Doe\x00john@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
 			mockExecFileSuccess(logEntry);
@@ -3853,6 +4158,8 @@ describe("JolliMemoryBridge", () => {
 			mockExecFileSuccess("headhash123\n");
 			// merge-base
 			mockExecFileSuccess("mergebase456\n");
+			// resolveOwnCommitsBase → findBranchCreationPoint: empty reflog → keep main merge-base
+			mockExecFileSuccess("\n");
 			// git log — one commit
 			const logEntry = `commitHash1\x00fix: test\x00John\x00john@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
 			mockExecFileSuccess(logEntry);
@@ -3905,6 +4212,8 @@ describe("JolliMemoryBridge", () => {
 			mockExecFileSuccess("headhash\n");
 			// merge-base
 			mockExecFileSuccess("mergebase\n");
+			// resolveOwnCommitsBase → findBranchCreationPoint: empty reflog → keep main merge-base
+			mockExecFileSuccess("\n");
 			// git log
 			const logEntry = `commitHash1\x00feat: test\x00User\x00user@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
 			mockExecFileSuccess(logEntry);
@@ -3941,6 +4250,8 @@ describe("JolliMemoryBridge", () => {
 			mockExecFileSuccess("headhash\n");
 			// merge-base
 			mockExecFileSuccess("mergebase\n");
+			// resolveOwnCommitsBase → findBranchCreationPoint: empty reflog → keep main merge-base
+			mockExecFileSuccess("\n");
 			// git log
 			const logEntry = `commitHash1\x00feat: new\x00Test User\x00test@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
 			mockExecFileSuccess(logEntry);
@@ -4158,6 +4469,8 @@ describe("JolliMemoryBridge", () => {
 			mockExecFileSuccess("headhash\n");
 			// merge-base
 			mockExecFileSuccess("mergebase\n");
+			// resolveOwnCommitsBase → findBranchCreationPoint: empty reflog → keep main merge-base
+			mockExecFileSuccess("\n");
 			// git log — one commit
 			const logEntry = `commitHash1\x00feat: test\x00User\x00user@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
 			mockExecFileSuccess(logEntry);
@@ -5383,6 +5696,7 @@ describe("JolliMemoryBridge", () => {
 			mockExecFileSuccess("abc\n"); // resolveHistoryBaseRef
 			mockExecFileSuccess("headhash123\n"); // getHEADHash
 			mockExecFileSuccess("mergebase456\n"); // merge-base
+			mockExecFileSuccess("\n"); // resolveOwnCommitsBase → empty reflog → keep main merge-base
 			const logEntry = `commitHash1\x00fix: test change\x00John Doe\x00john@example.com\x002025-03-15T10:00:00Z\x00\x00\n`;
 			mockExecFileSuccess(logEntry); // git log
 			mockExecFileSuccess("origin/feature/test\n"); // upstream rev-parse
@@ -5424,6 +5738,7 @@ describe("JolliMemoryBridge", () => {
 			mockExecFileSuccess("abc\n");
 			mockExecFileSuccess("headhash123\n");
 			mockExecFileSuccess("mergebase456\n");
+			mockExecFileSuccess("\n"); // resolveOwnCommitsBase → empty reflog → keep main merge-base
 			// Two commits in log; only one is in the index, so the other
 			// becomes an unmatched candidate that triggers the scan.
 			const logEntry =

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -978,6 +978,12 @@ export class JolliMemoryBridge {
 				creationPoint: creationPoint.substring(0, 8),
 				author: authorFilter,
 			});
+		} else {
+			// Not merged: measure own commits from the branch's true fork point
+			// rather than the mainline merge-base, so a branch cut from
+			// release/1.0 (etc.) doesn't list that base branch's shared commits
+			// as its own. No-op for branches cut directly from main.
+			mergeBase = await this.resolveOwnCommitsBase(branch, mergeBase);
 		}
 
 		// Build git log command with optional --author filter
@@ -1162,10 +1168,29 @@ export class JolliMemoryBridge {
 	 * Uses git reflog to find the commit where a branch was originally created.
 	 * Returns the hash at creation, or undefined if the reflog has expired or
 	 * is unavailable (e.g. after a fresh clone).
+	 *
+	 * @param opts.requireExplicit when true, return undefined unless an explicit
+	 *   `branch: Created from …` reflog entry is found. Reflog entries expire
+	 *   oldest-first, so once the creation entry is gone the oldest *surviving*
+	 *   entry is often the branch's own first commit — guessing it as the
+	 *   creation point would silently drop that commit from history and
+	 *   mis-judge amend safety. Callers that feed history/amend decisions pass
+	 *   true so they degrade to a safe base instead of trusting a guess. The
+	 *   merged-mode history view (constrained by an `--author` filter) leaves it
+	 *   false to keep its best-effort fallback.
 	 */
 	private async findBranchCreationPoint(
 		branch: string,
+		opts?: { requireExplicit?: boolean },
 	): Promise<string | undefined> {
+		// Detached HEAD has no branch reflog of its own — `reflog show HEAD`
+		// would surface HEAD's whole movement history (oldest entry = the repo's
+		// first commit), which is not a creation point. Bail out rather than
+		// return a misleading hash. (getCurrentBranch() returns "HEAD" when
+		// detached and never an empty string.)
+		if (branch === "HEAD") {
+			return;
+		}
 		const reflog = await tryExecGit(
 			["reflog", "show", branch, "--format=%H %gs"],
 			this.cwd,
@@ -1183,9 +1208,86 @@ export class JolliMemoryBridge {
 			}
 		}
 
-		// Fallback: use the oldest reflog entry
+		// No explicit creation record. Only guess the oldest surviving entry when
+		// the caller tolerates it (see requireExplicit).
+		if (opts?.requireExplicit) {
+			return;
+		}
 		const oldest = lines[lines.length - 1];
 		return oldest.split(" ")[0];
+	}
+
+	/** True when `ancestor` is an ancestor of (or equal to) `descendant`. */
+	private async isAncestor(
+		ancestor: string,
+		descendant: string,
+	): Promise<boolean> {
+		// `merge-base --is-ancestor` exits 0 when true, non-zero (execGit throws)
+		// when false or on a bad ref.
+		return execGit(
+			["merge-base", "--is-ancestor", ancestor, descendant],
+			this.cwd,
+		)
+			.then(() => true)
+			.catch(() => false);
+	}
+
+	/**
+	 * Resolves the base commit that "own commits" on the current branch are
+	 * measured from.
+	 *
+	 * Own commits should be counted from where the branch was actually cut, not
+	 * from the mainline. A branch freshly created from `release/1.0` (or any
+	 * branch downstream of main) starts with its tip equal to that base branch's
+	 * tip — comparing against main would wrongly count the base branch's commits
+	 * (and its shared tip) as this branch's own work, which is exactly what lets
+	 * `getAmendSafety` offer Amend on, and `listBranchCommits` list, a commit
+	 * shared with the base branch.
+	 *
+	 * Prefers the branch's reflog creation point when it sits downstream of (is a
+	 * descendant of) the mainline merge-base — the "cut from release/develop"
+	 * case. Falls back to `mergeBaseMain` when the creation point is unavailable
+	 * (reflog expired → graceful degradation to the previous behavior), equals
+	 * it (cut directly from main), or is not downstream of it. When the mainline
+	 * ref is itself unresolvable (`mergeBaseMain === ""`, e.g. a `master`/`trunk`
+	 * default branch) the creation point is used directly.
+	 *
+	 * @param branch        current branch name, for the reflog lookup
+	 * @param mergeBaseMain already-computed `merge-base HEAD <mainline>` ("" if unresolvable)
+	 */
+	private async resolveOwnCommitsBase(
+		branch: string,
+		mergeBaseMain: string,
+	): Promise<string> {
+		const creationPoint = await this.findBranchCreationPoint(branch, {
+			requireExplicit: true,
+		});
+		if (!creationPoint) {
+			return mergeBaseMain;
+		}
+		// Cut directly from main: mergeBaseMain is an ancestor of HEAD by
+		// construction, so no further checks are needed.
+		if (creationPoint === mergeBaseMain) {
+			return mergeBaseMain;
+		}
+		// The creation point must still be an ancestor of HEAD. After a
+		// `reset --hard` / `rebase --onto` onto a *different* branch, the reflog
+		// creation point is left stale — downstream of main yet no longer behind
+		// HEAD — and `git log <stalePoint>..HEAD` would be meaningless. Fall back
+		// to the mainline merge-base in that case.
+		if (!(await this.isAncestor(creationPoint, "HEAD"))) {
+			return mergeBaseMain;
+		}
+		// Mainline unresolvable (e.g. master/trunk default with no origin):
+		// trust the validated fork point directly.
+		if (mergeBaseMain === "") {
+			return creationPoint;
+		}
+		// Adopt the creation point only when it is downstream of (a descendant
+		// of) the mainline merge-base — the "cut from release/develop" case.
+		return (await this.isAncestor(mergeBaseMain, creationPoint))
+			? creationPoint
+			: mergeBaseMain;
 	}
 
 	/**
@@ -1221,21 +1323,25 @@ export class JolliMemoryBridge {
 	 * summary onto the new hash. The Commit QuickPick uses this to hide the
 	 * Amend actions when unsafe.
 	 *
-	 * `hasOwnCommits` uses the same base ref and `merge-base HEAD <base>` as
-	 * `listBranchCommits`: HEAD equal to the merge-base means the branch has no
-	 * diverging commit to amend. The two differ at one boundary — an empty
-	 * merge-base (no common ancestor, or no resolvable base ref) is counted here
-	 * as own work (amend allowed), since there is no shared commit to clobber;
-	 * the author check below is the real backstop for the "someone else's tip"
-	 * case the gate exists to prevent.
+	 * `hasOwnCommits` is measured from the branch's true fork point (see
+	 * {@link resolveOwnCommitsBase}), not just the mainline merge-base: a branch
+	 * cut from `release/1.0` with no commits of its own has its tip equal to that
+	 * fork point, so `hasOwnCommits` is false and Amend is hidden — even though
+	 * the tip is ahead of main. The author check below is a second guard for the
+	 * "someone else's tip" case.
 	 */
 	async getAmendSafety(mainBranch: string): Promise<AmendSafety> {
 		const headHash = await this.getHEADHash();
+		const branch = await this.getCurrentBranch();
 		const baseRef = await this.resolveHistoryBaseRef(mainBranch);
-		const mergeBase = (
+		const mergeBaseMain = (
 			await tryExecGit(["merge-base", "HEAD", baseRef], this.cwd)
 		).trim();
-		const hasOwnCommits = mergeBase !== headHash;
+		// Measure "own commits" from the branch's true fork point, not from main,
+		// so a branch cut from release/1.0 with no commits of its own is not
+		// treated as owning the base branch's shared tip.
+		const base = await this.resolveOwnCommitsBase(branch, mergeBaseMain);
+		const hasOwnCommits = base !== "" && base !== headHash;
 
 		const headAuthorEmail = (
 			await tryExecGit(["log", "-1", "--pretty=format:%ae"], this.cwd)
@@ -1249,6 +1355,65 @@ export class JolliMemoryBridge {
 			headAuthorEmail.toLowerCase() === currentUserEmail.toLowerCase();
 
 		return { hasOwnCommits, headAuthoredByCurrentUser };
+	}
+
+	/**
+	 * True when HEAD is reachable from a branch other than the current one (and
+	 * its own upstream) — i.e. the tip is also published on / shared with another
+	 * branch, so amending it would rewrite a commit that branch depends on.
+	 *
+	 * This is the safety signal the reflog fork point (see {@link getAmendSafety}
+	 * / {@link resolveOwnCommitsBase}) cannot provide: after a `reset --hard` /
+	 * `rebase --onto` onto another branch, HEAD can be a commit that branch still
+	 * points at while the reflog creation point still looks legitimate (it stays
+	 * an ancestor of HEAD when the other branch descends from it, e.g. gitflow's
+	 * release cut from develop). Used only to gate the Amend actions — the
+	 * history panel keeps the reflog-based range.
+	 *
+	 * Degrades to `false` (no extra block; the fork-point + author gates still
+	 * apply) if the ref scan fails.
+	 */
+	async isHeadSharedWithOtherBranch(): Promise<boolean> {
+		const output = await tryExecGit(
+			[
+				"for-each-ref",
+				"--contains=HEAD",
+				"--format=%(refname)",
+				"refs/heads",
+				"refs/remotes",
+			],
+			this.cwd,
+		);
+		const refs = output
+			.split("\n")
+			.map((r) => r.trim())
+			.filter(Boolean);
+		if (refs.length === 0) {
+			return false;
+		}
+		const branch = await this.getCurrentBranch();
+		const currentHeadRef = branch !== "HEAD" ? `refs/heads/${branch}` : "";
+		const upstream = (
+			await tryExecGit(
+				["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+				this.cwd,
+			)
+		).trim();
+		const currentUpstreamRef = upstream ? `refs/remotes/${upstream}` : "";
+		// Also exclude origin/<branch> directly: `git push origin <branch>` (no
+		// -u) leaves no @{upstream}, yet the same-named remote copy still
+		// contains HEAD. Mirrors resolvePushBaseRef's origin/<branch> fallback so
+		// a pushed-but-untracked branch isn't mistaken for "shared".
+		const currentBranchOriginRef =
+			branch !== "HEAD" ? `refs/remotes/origin/${branch}` : "";
+		// Shared when a containing ref is neither the current branch nor a remote
+		// copy of this same branch (its upstream, or origin/<branch>).
+		return refs.some(
+			(ref) =>
+				ref !== currentHeadRef &&
+				ref !== currentUpstreamRef &&
+				ref !== currentBranchOriginRef,
+		);
 	}
 
 	/**

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -102,6 +102,7 @@ import {
 	removePlan,
 } from "./core/PlanService.js";
 import type {
+	AmendSafety,
 	BranchCommit,
 	BranchCommitsResult,
 	CommitFileInfo,
@@ -1206,6 +1207,48 @@ export class JolliMemoryBridge {
 		);
 		const unpushedHashes = new Set(unpushedOutput.split("\n").filter(Boolean));
 		return !unpushedHashes.has(headHash);
+	}
+
+	/**
+	 * Reports whether amending HEAD is safe — i.e. HEAD is a commit this branch
+	 * created and the current user authored.
+	 *
+	 * `git commit --amend` always rewrites HEAD in place. On a branch freshly
+	 * created from `main` with no commits of its own, HEAD is still the base
+	 * branch's tip (often authored by someone else): amending it rewrites that
+	 * shared commit, keeps its original author (amend preserves author by
+	 * default), and the post-rewrite memory pipeline inherits that commit's
+	 * summary onto the new hash. The Commit QuickPick uses this to hide the
+	 * Amend actions when unsafe.
+	 *
+	 * `hasOwnCommits` uses the same base ref and `merge-base HEAD <base>` as
+	 * `listBranchCommits`: HEAD equal to the merge-base means the branch has no
+	 * diverging commit to amend. The two differ at one boundary — an empty
+	 * merge-base (no common ancestor, or no resolvable base ref) is counted here
+	 * as own work (amend allowed), since there is no shared commit to clobber;
+	 * the author check below is the real backstop for the "someone else's tip"
+	 * case the gate exists to prevent.
+	 */
+	async getAmendSafety(mainBranch: string): Promise<AmendSafety> {
+		const headHash = await this.getHEADHash();
+		const baseRef = await this.resolveHistoryBaseRef(mainBranch);
+		const mergeBase = (
+			await tryExecGit(["merge-base", "HEAD", baseRef], this.cwd)
+		).trim();
+		const hasOwnCommits = mergeBase !== headHash;
+
+		const headAuthorEmail = (
+			await tryExecGit(["log", "-1", "--pretty=format:%ae"], this.cwd)
+		).trim();
+		const currentUserEmail = (
+			await tryExecGit(["config", "user.email"], this.cwd)
+		).trim();
+		const headAuthoredByCurrentUser =
+			headAuthorEmail !== "" &&
+			currentUserEmail !== "" &&
+			headAuthorEmail.toLowerCase() === currentUserEmail.toLowerCase();
+
+		return { hasOwnCommits, headAuthoredByCurrentUser };
 	}
 
 	/**

--- a/vscode/src/Types.ts
+++ b/vscode/src/Types.ts
@@ -65,6 +65,20 @@ export interface BranchCommit {
 	readonly commitType?: string;
 }
 
+/**
+ * Whether amending HEAD is safe, used to gate the Amend actions of the
+ * "Commit Memory" QuickPick. Amend rewrites HEAD in place — on a branch with
+ * no commits of its own, or whose tip was authored by someone else, that
+ * silently rewrites a commit shared with the base branch (keeping the original
+ * author) and inherits its memory onto the new hash.
+ */
+export interface AmendSafety {
+	/** HEAD has commits beyond the merge-base with the base branch (own work on this branch). */
+	readonly hasOwnCommits: boolean;
+	/** HEAD commit's author email matches the current git `user.email`. */
+	readonly headAuthoredByCurrentUser: boolean;
+}
+
 /** Result from listBranchCommits, includes merged-state metadata */
 export interface BranchCommitsResult {
 	/** The commits found on this branch */

--- a/vscode/src/commands/CommitCommand.test.ts
+++ b/vscode/src/commands/CommitCommand.test.ts
@@ -14,6 +14,7 @@ const { info, warn, error, debug } = vi.hoisted(() => ({
 type QuickPickController = {
 	qp: {
 		value: string;
+		title: string;
 		placeholder: string;
 		items: Array<{ label: string }>;
 		selectedItems: Array<{ label: string }>;
@@ -108,11 +109,50 @@ vi.mock("../util/Logger.js", () => ({
 
 import { CommitCommand } from "./CommitCommand.js";
 
+/** Default "amend is safe" availability passed to the QuickPick presenter. */
+const AMEND_ALLOWED = { allowed: true, reason: "" } as const;
+
+/**
+ * Calls the private showCommitQuickPick presenter. Defaults `amend` to allowed
+ * so existing tests exercise the full three-action picker.
+ */
+function showPick(
+	command: CommitCommand,
+	message: string,
+	amend: { allowed: boolean; reason: string } = AMEND_ALLOWED,
+): Promise<{ item: { label: string }; message: string } | undefined> {
+	return (
+		command as unknown as {
+			showCommitQuickPick: (
+				m: string,
+				a: { allowed: boolean; reason: string },
+			) => Promise<{ item: { label: string }; message: string } | undefined>;
+		}
+	).showCommitQuickPick(message, amend);
+}
+
+/** Calls the private executeCommitAction. */
+function runAction(
+	command: CommitCommand,
+	item: { label: string } | undefined,
+	message: string | undefined,
+): Promise<void> {
+	return (
+		command as unknown as {
+			executeCommitAction: (
+				i: { label: string } | undefined,
+				m: string | undefined,
+			) => Promise<void>;
+		}
+	).executeCommitAction(item, message);
+}
+
 function makeDeps() {
 	const bridge = {
 		generateCommitMessage: vi.fn(async () => "feat: generated"),
 		commit: vi.fn().mockResolvedValue(undefined),
 		amendCommit: vi.fn().mockResolvedValue(undefined),
+		amendCommitNoEdit: vi.fn().mockResolvedValue(undefined),
 		saveIndexTree: vi.fn(async () => "tree-sha"),
 		restoreIndexTree: vi.fn().mockResolvedValue(undefined),
 		getStagedFilePaths: vi.fn(async () => []),
@@ -122,6 +162,11 @@ function makeDeps() {
 		getHEADHash: vi.fn(async () => "abcdef1234567890"),
 		getHEADMessage: vi.fn(async () => "Part of PROJ-123: existing"),
 		getStatus: vi.fn(async () => ({ enabled: true })),
+		// Amend is safe by default — own commit, authored by the current user.
+		getAmendSafety: vi.fn(async () => ({
+			hasOwnCommits: true,
+			headAuthoredByCurrentUser: true,
+		})),
 	};
 	const defaultFiles = [
 		{
@@ -161,6 +206,7 @@ function makeDeps() {
 	const commitsStore = {
 		refresh: vi.fn().mockResolvedValue(undefined),
 		getSelectionDebugInfo: vi.fn(() => ({ checkedHashes: [] })),
+		getMainBranch: vi.fn(() => "main"),
 	};
 	const statusStore = {
 		refresh: vi.fn().mockResolvedValue(undefined),
@@ -169,6 +215,17 @@ function makeDeps() {
 		update: vi.fn(),
 	};
 	return { bridge, filesStore, commitsStore, statusStore, statusBar };
+}
+
+function makeCommand(deps: ReturnType<typeof makeDeps>): CommitCommand {
+	return new CommitCommand(
+		deps.bridge as never,
+		deps.filesStore as never,
+		deps.commitsStore as never,
+		deps.statusStore as never,
+		deps.statusBar as never,
+		"/repo",
+	);
 }
 
 describe("CommitCommand", () => {
@@ -189,14 +246,7 @@ describe("CommitCommand", () => {
 	it("stops immediately when the worker lock is held", async () => {
 		isWorkerBlockingBusy.mockResolvedValue(true);
 		const deps = makeDeps();
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
 		await command.execute();
 
@@ -215,14 +265,7 @@ describe("CommitCommand", () => {
 			.mockResolvedValueOnce(false)
 			.mockResolvedValueOnce(true);
 		const deps = makeDeps();
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 		vi.spyOn(command as never, "showCommitQuickPick").mockResolvedValue({
 			item: { label: "$(check) Commit" },
 			message: "feat: generated",
@@ -242,14 +285,7 @@ describe("CommitCommand", () => {
 	it("warns when nothing is selected", async () => {
 		const deps = makeDeps();
 		deps.filesStore.getSelectedFiles.mockReturnValue([]);
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
 		await command.execute();
 
@@ -261,14 +297,7 @@ describe("CommitCommand", () => {
 	it("surfaces commit message generation failures", async () => {
 		const deps = makeDeps();
 		deps.bridge.generateCommitMessage.mockRejectedValue(new Error("api down"));
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
 		await command.execute();
 
@@ -279,22 +308,9 @@ describe("CommitCommand", () => {
 
 	it("shows the quick pick, accepts the first action, and trims the message", async () => {
 		const deps = makeDeps();
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
-		const promise = (
-			command as unknown as {
-				showCommitQuickPick: (
-					message: string,
-				) => Promise<{ item: { label: string }; message: string } | undefined>;
-			}
-		).showCommitQuickPick("  feat: generated  ");
+		const promise = showPick(command, "  feat: generated  ");
 		const controller = queueQuickPick();
 		(controller as NonNullable<typeof controller>).qp.selectedItems = [];
 		controller?.accept?.();
@@ -307,31 +323,64 @@ describe("CommitCommand", () => {
 		expect(controller?.qp.dispose).toHaveBeenCalled();
 	});
 
-	it("returns undefined when the quick pick is dismissed or blank", async () => {
+	it("offers all three actions and the default title when amend is allowed", async () => {
 		const deps = makeDeps();
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
+		const command = makeCommand(deps);
+
+		const promise = showPick(command, "feat: generated");
+		const controller = queueQuickPick();
+		const qp = controller as NonNullable<typeof controller>;
+
+		expect(qp.qp.items).toHaveLength(3);
+		expect(qp.qp.title).toBe(
+			"Edit the commit message, then select an action",
 		);
 
-		const dismissed = (
-			command as unknown as {
-				showCommitQuickPick: (message: string) => Promise<unknown>;
-			}
-		).showCommitQuickPick("feat: generated");
+		qp.accept?.();
+		await promise;
+	});
+
+	it("hides the amend actions and titles the reason when amend is unsafe", async () => {
+		const deps = makeDeps();
+		const command = makeCommand(deps);
+
+		const promise = showPick(command, "feat: generated", {
+			allowed: false,
+			reason: "this branch has no commit of yours to amend",
+		});
+		const controller = queueQuickPick();
+		const qp = controller as NonNullable<typeof controller>;
+
+		// Only Commit remains — Amend actions are removed, not greyed out.
+		expect(qp.qp.items).toHaveLength(1);
+		expect(qp.qp.items[0].label).toContain("Commit");
+		expect(
+			qp.qp.items.some((i) => /Amend/i.test(i.label)),
+		).toBe(false);
+		expect(qp.qp.title).toBe(
+			"Only Commit is available — this branch has no commit of yours to amend",
+		);
+
+		// onDidChangeActive must not overwrite the explanatory title.
+		qp.changeActive?.([qp.qp.items[0]]);
+		expect(qp.qp.title).toBe(
+			"Only Commit is available — this branch has no commit of yours to amend",
+		);
+
+		qp.accept?.();
+		await promise;
+	});
+
+	it("returns undefined when the quick pick is dismissed or blank", async () => {
+		const deps = makeDeps();
+		const command = makeCommand(deps);
+
+		const dismissed = showPick(command, "feat: generated");
 		const dismissedController = queueQuickPick();
 		dismissedController?.hide?.();
 		await expect(dismissed).resolves.toBeUndefined();
 
-		const blank = (
-			command as unknown as {
-				showCommitQuickPick: (message: string) => Promise<unknown>;
-			}
-		).showCommitQuickPick("feat: generated");
+		const blank = showPick(command, "feat: generated");
 		const blankController = queueQuickPick();
 		(blankController as NonNullable<typeof blankController>).qp.value = "   ";
 		blankController?.accept?.();
@@ -341,22 +390,9 @@ describe("CommitCommand", () => {
 	it("amends commits with the new message (no merge) and warns when the original was pushed", async () => {
 		const deps = makeDeps();
 		deps.bridge.isHeadPushed.mockResolvedValue(true);
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
-		const quickPickPromise = (
-			command as unknown as {
-				showCommitQuickPick: (
-					message: string,
-				) => Promise<{ item: { label: string }; message: string } | undefined>;
-			}
-		).showCommitQuickPick("Part of PROJ-123: new change");
+		const quickPickPromise = showPick(command, "Part of PROJ-123: new change");
 		const controller = queueQuickPick();
 		(controller as NonNullable<typeof controller>).qp.selectedItems = [
 			controller?.qp.items[1],
@@ -364,14 +400,7 @@ describe("CommitCommand", () => {
 		controller?.accept?.();
 		const selected = await quickPickPromise;
 
-		await (
-			command as unknown as {
-				executeCommitAction: (
-					item: { label: string },
-					message: string,
-				) => Promise<void>;
-			}
-		).executeCommitAction(selected?.item, selected?.message);
+		await runAction(command, selected?.item, selected?.message);
 
 		// Amend now uses the new message directly without merging with the old one
 		expect(deps.bridge.amendCommit).toHaveBeenCalledWith(
@@ -385,14 +414,7 @@ describe("CommitCommand", () => {
 	it("shows an error when executeCommitAction throws", async () => {
 		const deps = makeDeps();
 		deps.bridge.commit.mockRejectedValue(new Error("git index locked"));
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 		vi.spyOn(command as never, "showCommitQuickPick").mockResolvedValue({
 			item: { label: "$(check) Commit" },
 			message: "feat: generated",
@@ -408,24 +430,11 @@ describe("CommitCommand", () => {
 
 	it("does not resolve twice when onDidHide fires after onDidAccept", async () => {
 		const deps = makeDeps();
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
-		const promise = (
-			command as unknown as {
-				showCommitQuickPick: (
-					message: string,
-				) => Promise<{ item: { label: string }; message: string } | undefined>;
-			}
-		).showCommitQuickPick("feat: test");
+		const promise = showPick(command, "feat: test");
 		const controller = queueQuickPick();
-		// Accept first, then hide — exercises lines 170-171 (accepted=true early return)
+		// Accept first, then hide — exercises the accepted=true early return
 		controller?.accept?.();
 		controller?.hide?.();
 
@@ -439,22 +448,11 @@ describe("CommitCommand", () => {
 
 	it("resolves undefined when QuickPick is dismissed via onDidHide before accept", async () => {
 		const deps = makeDeps();
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
-		const promise = (
-			command as unknown as {
-				showCommitQuickPick: (message: string) => Promise<unknown>;
-			}
-		).showCommitQuickPick("feat: test");
+		const promise = showPick(command, "feat: test");
 		const controller = queueQuickPick();
-		// Simulate hide without prior accept — exercises lines 170-171
+		// Simulate hide without prior accept
 		controller?.hide?.();
 
 		await expect(promise).resolves.toBeUndefined();
@@ -463,14 +461,7 @@ describe("CommitCommand", () => {
 
 	it("returns early when the QuickPick is cancelled during execute()", async () => {
 		const deps = makeDeps();
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 		// Mock showCommitQuickPick to return undefined (user cancelled)
 		vi.spyOn(command as never, "showCommitQuickPick").mockResolvedValue(
 			undefined,
@@ -492,14 +483,7 @@ describe("CommitCommand", () => {
 	it("coerces non-Error thrown from generateCommitMessage to string", async () => {
 		const deps = makeDeps();
 		deps.bridge.generateCommitMessage.mockRejectedValue("plain string error");
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
 		await command.execute();
 
@@ -511,14 +495,7 @@ describe("CommitCommand", () => {
 	it("coerces non-Error thrown from executeCommitAction to string", async () => {
 		const deps = makeDeps();
 		deps.bridge.commit.mockRejectedValue(42);
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 		vi.spyOn(command as never, "showCommitQuickPick").mockResolvedValue({
 			item: { label: "$(check) Commit" },
 			message: "feat: generated",
@@ -534,22 +511,9 @@ describe("CommitCommand", () => {
 	it("amends with new message directly (no merge), no push warning when not pushed", async () => {
 		const deps = makeDeps();
 		deps.bridge.isHeadPushed.mockResolvedValue(false);
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
-		const quickPickPromise = (
-			command as unknown as {
-				showCommitQuickPick: (
-					message: string,
-				) => Promise<{ item: { label: string }; message: string } | undefined>;
-			}
-		).showCommitQuickPick("feat: new");
+		const quickPickPromise = showPick(command, "feat: new");
 		const controller = queueQuickPick();
 		(controller as NonNullable<typeof controller>).qp.selectedItems = [
 			controller?.qp.items[1],
@@ -557,14 +521,7 @@ describe("CommitCommand", () => {
 		controller?.accept?.();
 		const selected = await quickPickPromise;
 
-		await (
-			command as unknown as {
-				executeCommitAction: (
-					item: { label: string },
-					message: string,
-				) => Promise<void>;
-			}
-		).executeCommitAction(selected?.item, selected?.message);
+		await runAction(command, selected?.item, selected?.message);
 
 		expect(deps.bridge.amendCommit).toHaveBeenCalledWith("feat: new");
 		// wasPushed is false, so no push warning
@@ -573,24 +530,10 @@ describe("CommitCommand", () => {
 
 	it("amend no-edit keeps previous message and calls amendCommitNoEdit", async () => {
 		const deps = makeDeps();
-		deps.bridge.amendCommitNoEdit = vi.fn().mockResolvedValue(undefined);
 		deps.bridge.isHeadPushed.mockResolvedValue(false);
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
-		const quickPickPromise = (
-			command as unknown as {
-				showCommitQuickPick: (
-					message: string,
-				) => Promise<{ item: { label: string }; message: string } | undefined>;
-			}
-		).showCommitQuickPick("feat: ignored");
+		const quickPickPromise = showPick(command, "feat: ignored");
 		const controller = queueQuickPick();
 		// Select the third item (Amend, keep message)
 		(controller as NonNullable<typeof controller>).qp.selectedItems = [
@@ -599,14 +542,7 @@ describe("CommitCommand", () => {
 		controller?.accept?.();
 		const selected = await quickPickPromise;
 
-		await (
-			command as unknown as {
-				executeCommitAction: (
-					item: { label: string },
-					message: string,
-				) => Promise<void>;
-			}
-		).executeCommitAction(selected?.item, selected?.message);
+		await runAction(command, selected?.item, selected?.message);
 
 		expect(deps.bridge.amendCommitNoEdit).toHaveBeenCalled();
 		expect(deps.bridge.amendCommit).not.toHaveBeenCalled();
@@ -615,24 +551,10 @@ describe("CommitCommand", () => {
 
 	it("amend no-edit warns when the original was pushed", async () => {
 		const deps = makeDeps();
-		deps.bridge.amendCommitNoEdit = vi.fn().mockResolvedValue(undefined);
 		deps.bridge.isHeadPushed.mockResolvedValue(true);
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
-		const quickPickPromise = (
-			command as unknown as {
-				showCommitQuickPick: (
-					message: string,
-				) => Promise<{ item: { label: string }; message: string } | undefined>;
-			}
-		).showCommitQuickPick("feat: ignored");
+		const quickPickPromise = showPick(command, "feat: ignored");
 		const controller = queueQuickPick();
 		(controller as NonNullable<typeof controller>).qp.selectedItems = [
 			controller?.qp.items[2],
@@ -640,14 +562,7 @@ describe("CommitCommand", () => {
 		controller?.accept?.();
 		const selected = await quickPickPromise;
 
-		await (
-			command as unknown as {
-				executeCommitAction: (
-					item: { label: string },
-					message: string,
-				) => Promise<void>;
-			}
-		).executeCommitAction(selected?.item, selected?.message);
+		await runAction(command, selected?.item, selected?.message);
 
 		expect(deps.bridge.amendCommitNoEdit).toHaveBeenCalled();
 		expect(showInformationMessage).toHaveBeenCalledWith(
@@ -657,23 +572,9 @@ describe("CommitCommand", () => {
 
 	it("amend no-edit resolves even when input is empty", async () => {
 		const deps = makeDeps();
-		deps.bridge.amendCommitNoEdit = vi.fn().mockResolvedValue(undefined);
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
-		const quickPickPromise = (
-			command as unknown as {
-				showCommitQuickPick: (
-					message: string,
-				) => Promise<{ item: { label: string }; message: string } | undefined>;
-			}
-		).showCommitQuickPick("feat: something");
+		const quickPickPromise = showPick(command, "feat: something");
 		const controller = queueQuickPick();
 		// Clear the input and select amend no-edit — should NOT cancel
 		(controller as NonNullable<typeof controller>).qp.value = "";
@@ -692,22 +593,9 @@ describe("CommitCommand", () => {
 		const deps = makeDeps();
 		deps.bridge.isHeadPushed.mockRejectedValue(new Error("fail"));
 		deps.bridge.getHEADHash.mockRejectedValue(new Error("fail"));
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
-		const quickPickPromise = (
-			command as unknown as {
-				showCommitQuickPick: (
-					message: string,
-				) => Promise<{ item: { label: string }; message: string } | undefined>;
-			}
-		).showCommitQuickPick("feat: new");
+		const quickPickPromise = showPick(command, "feat: new");
 		const controller = queueQuickPick();
 		(controller as NonNullable<typeof controller>).qp.selectedItems = [
 			controller?.qp.items[1],
@@ -715,30 +603,120 @@ describe("CommitCommand", () => {
 		controller?.accept?.();
 		const selected = await quickPickPromise;
 
-		await (
-			command as unknown as {
-				executeCommitAction: (
-					item: { label: string },
-					message: string,
-				) => Promise<void>;
-			}
-		).executeCommitAction(selected?.item, selected?.message);
+		await runAction(command, selected?.item, selected?.message);
 
 		// isHeadPushed catch returns false, getHEADHash catch returns ""
 		expect(deps.bridge.amendCommit).toHaveBeenCalledWith("feat: new");
 	});
 
+	// ── Amend gating (getAmendSafety) ────────────────────────────────────────
+
+	it("gates the QuickPick to Commit-only when the branch has no commit of its own", async () => {
+		const deps = makeDeps();
+		deps.bridge.getAmendSafety.mockResolvedValue({
+			hasOwnCommits: false,
+			headAuthoredByCurrentUser: true,
+		});
+		const command = makeCommand(deps);
+		const spy = vi
+			.spyOn(command as never, "showCommitQuickPick")
+			.mockResolvedValue(undefined);
+
+		await command.execute();
+
+		expect(deps.bridge.getAmendSafety).toHaveBeenCalledWith("main");
+		expect(spy).toHaveBeenCalledWith("feat: generated", {
+			allowed: false,
+			reason: "this branch has no commit of yours to amend",
+		});
+	});
+
+	it("gates the QuickPick when the latest commit was authored by someone else", async () => {
+		const deps = makeDeps();
+		deps.bridge.getAmendSafety.mockResolvedValue({
+			hasOwnCommits: true,
+			headAuthoredByCurrentUser: false,
+		});
+		const command = makeCommand(deps);
+		const spy = vi
+			.spyOn(command as never, "showCommitQuickPick")
+			.mockResolvedValue(undefined);
+
+		await command.execute();
+
+		expect(spy).toHaveBeenCalledWith("feat: generated", {
+			allowed: false,
+			reason: "the latest commit was authored by someone else",
+		});
+	});
+
+	it("treats an undeterminable amend safety as unsafe", async () => {
+		const deps = makeDeps();
+		deps.bridge.getAmendSafety.mockRejectedValue(new Error("no HEAD"));
+		const command = makeCommand(deps);
+		const spy = vi
+			.spyOn(command as never, "showCommitQuickPick")
+			.mockResolvedValue(undefined);
+
+		await command.execute();
+
+		expect(spy).toHaveBeenCalledWith("feat: generated", {
+			allowed: false,
+			reason: "this branch has no commit of yours to amend",
+		});
+	});
+
+	it("allows the amend actions when HEAD is the user's own branch commit", async () => {
+		const deps = makeDeps();
+		const command = makeCommand(deps);
+		const spy = vi
+			.spyOn(command as never, "showCommitQuickPick")
+			.mockResolvedValue(undefined);
+
+		await command.execute();
+
+		expect(spy).toHaveBeenCalledWith("feat: generated", {
+			allowed: true,
+			reason: "",
+		});
+	});
+
+	it("blocks amend at execute time when a fresh safety check finds it unamendable", async () => {
+		// Simulates the race / qp.items[0] fallback: the picker yields the real
+		// Amend item, but a fresh safety check finds the commit is not amendable.
+		const deps = makeDeps();
+		deps.bridge.getAmendSafety.mockResolvedValue({
+			hasOwnCommits: false,
+			headAuthoredByCurrentUser: true,
+		});
+		const command = makeCommand(deps);
+
+		const quickPickPromise = showPick(command, "feat: rewrite");
+		const controller = queueQuickPick();
+		(controller as NonNullable<typeof controller>).qp.selectedItems = [
+			controller?.qp.items[1], // real ITEM_AMEND reference
+		];
+		controller?.accept?.();
+		const selected = await quickPickPromise;
+
+		await expect(
+			runAction(command, selected?.item, selected?.message),
+		).rejects.toThrow(
+			"Amend is unavailable — this branch has no commit of yours to amend. Use Commit to create a new commit instead.",
+		);
+		expect(deps.bridge.amendCommit).not.toHaveBeenCalled();
+		expect(deps.bridge.isHeadPushed).not.toHaveBeenCalled();
+		expect(warn).toHaveBeenCalledWith(
+			"commit",
+			"Amend blocked at execute time",
+			{ reason: "this branch has no commit of yours to amend" },
+		);
+	});
+
 	it("handles getHEADHash catch in refreshAll", async () => {
 		const deps = makeDeps();
 		deps.bridge.getHEADHash.mockRejectedValue(new Error("hash fail"));
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 		vi.spyOn(command as never, "showCommitQuickPick").mockResolvedValue({
 			item: { label: "$(check) Commit" },
 			message: "feat: generated",
@@ -753,14 +731,7 @@ describe("CommitCommand", () => {
 
 	it("refreshes files/history/status and updates the status bar after success", async () => {
 		const deps = makeDeps();
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 		vi.spyOn(command as never, "showCommitQuickPick").mockResolvedValue({
 			item: { label: "$(check) Commit" },
 			message: "feat: generated",
@@ -785,14 +756,7 @@ describe("CommitCommand", () => {
 				"Unresolved conflict markers in: bad.ts. Please resolve conflict markers before committing.",
 			),
 		);
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
 		await command.execute();
 
@@ -809,14 +773,7 @@ describe("CommitCommand", () => {
 		deps.bridge.saveIndexTree.mockRejectedValue(
 			new Error("fatal: git-write-tree: error building trees"),
 		);
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
 		await command.execute();
 
@@ -835,14 +792,7 @@ describe("CommitCommand", () => {
 				"Unresolved conflict markers in: x.ts. Please resolve conflict markers before committing.",
 			),
 		);
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
 		await command.execute();
 
@@ -852,14 +802,7 @@ describe("CommitCommand", () => {
 	it("shows error and restores index when stageFiles rejects during index preparation", async () => {
 		const deps = makeDeps();
 		deps.bridge.stageFiles.mockRejectedValue(new Error("cannot stage"));
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
 		await command.execute();
 
@@ -875,14 +818,7 @@ describe("CommitCommand", () => {
 		const deps = makeDeps();
 		// "extra.ts" was staged before commit but is not in selectedPaths (["a.ts"])
 		deps.bridge.getStagedFilePaths.mockResolvedValue(["a.ts", "extra.ts"]);
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 		vi.spyOn(command as never, "showCommitQuickPick").mockResolvedValue({
 			item: { label: "$(check) Commit" },
 			message: "feat: generated",
@@ -918,14 +854,7 @@ describe("CommitCommand", () => {
 			}
 			return Promise.resolve();
 		});
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 		vi.spyOn(command as never, "showCommitQuickPick").mockResolvedValue({
 			item: { label: "$(check) Commit" },
 			message: "feat: generated",
@@ -948,14 +877,7 @@ describe("CommitCommand", () => {
 		deps.bridge.restoreIndexTree.mockRejectedValue(new Error("restore failed"));
 		// Make generateCommitMessage fail so restoreIndex gets called
 		deps.bridge.generateCommitMessage.mockRejectedValue(new Error("api down"));
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
 		await command.execute();
 
@@ -966,34 +888,21 @@ describe("CommitCommand", () => {
 
 	it("updates QuickPick title when onDidChangeActive highlights amend-no-edit", async () => {
 		const deps = makeDeps();
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
-		const promise = (
-			command as unknown as {
-				showCommitQuickPick: (
-					message: string,
-				) => Promise<{ item: { label: string }; message: string } | undefined>;
-			}
-		).showCommitQuickPick("feat: test");
+		const promise = showPick(command, "feat: test");
 		const controller = queueQuickPick();
 		const qp = controller as NonNullable<typeof controller>;
 
 		// Simulate highlighting the "Amend, keep message" item
 		qp.changeActive?.([qp.qp.items[2]]);
-		expect((qp.qp as unknown as { title: string }).title).toBe(
+		expect(qp.qp.title).toBe(
 			"Input will be ignored — reuses last commit message",
 		);
 
 		// Simulate highlighting a non-amend-no-edit item
 		qp.changeActive?.([qp.qp.items[0]]);
-		expect((qp.qp as unknown as { title: string }).title).toBe(
+		expect(qp.qp.title).toBe(
 			"Edit the commit message, then select an action",
 		);
 
@@ -1005,14 +914,7 @@ describe("CommitCommand", () => {
 	it("coerces non-Error thrown from saveIndexTree to string", async () => {
 		const deps = makeDeps();
 		deps.bridge.saveIndexTree.mockRejectedValue("plain string index error");
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
 		await command.execute();
 
@@ -1033,14 +935,7 @@ describe("CommitCommand", () => {
 				worktreeStatus: " ",
 			},
 		]);
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 		vi.spyOn(command as never, "showCommitQuickPick").mockResolvedValue({
 			item: { label: "$(check) Commit" },
 			message: "feat: generated",
@@ -1055,14 +950,7 @@ describe("CommitCommand", () => {
 	it("coerces non-Error thrown from stageFiles during index preparation to string", async () => {
 		const deps = makeDeps();
 		deps.bridge.stageFiles.mockRejectedValue(42);
-		const command = new CommitCommand(
-			deps.bridge as never,
-			deps.filesStore as never,
-			deps.commitsStore as never,
-			deps.statusStore as never,
-			deps.statusBar as never,
-			"/repo",
-		);
+		const command = makeCommand(deps);
 
 		await command.execute();
 

--- a/vscode/src/commands/CommitCommand.test.ts
+++ b/vscode/src/commands/CommitCommand.test.ts
@@ -167,6 +167,8 @@ function makeDeps() {
 			hasOwnCommits: true,
 			headAuthoredByCurrentUser: true,
 		})),
+		// HEAD is not shared with another branch by default.
+		isHeadSharedWithOtherBranch: vi.fn(async () => false),
 	};
 	const defaultFiles = [
 		{
@@ -647,6 +649,25 @@ describe("CommitCommand", () => {
 		expect(spy).toHaveBeenCalledWith("feat: generated", {
 			allowed: false,
 			reason: "the latest commit was authored by someone else",
+		});
+	});
+
+	it("gates the QuickPick when HEAD is shared with another branch (reset/rebase onto a shared tip)", async () => {
+		// hasOwnCommits + own author pass, but the tip is also on another branch —
+		// closes the reflog-fork-point gap (e.g. reset --hard onto release).
+		const deps = makeDeps();
+		deps.bridge.isHeadSharedWithOtherBranch.mockResolvedValue(true);
+		const command = makeCommand(deps);
+		const spy = vi
+			.spyOn(command as never, "showCommitQuickPick")
+			.mockResolvedValue(undefined);
+
+		await command.execute();
+
+		expect(deps.bridge.isHeadSharedWithOtherBranch).toHaveBeenCalled();
+		expect(spy).toHaveBeenCalledWith("feat: generated", {
+			allowed: false,
+			reason: "the latest commit also belongs to another branch",
 		});
 	});
 

--- a/vscode/src/commands/CommitCommand.ts
+++ b/vscode/src/commands/CommitCommand.ts
@@ -270,10 +270,15 @@ export class CommitCommand {
 	/**
 	 * Decides whether the Amend actions may be offered for the current HEAD.
 	 *
-	 * Unsafe when the branch has no commit of its own (HEAD is the base branch's
-	 * tip) or the tip was authored by someone else — amending either rewrites a
-	 * commit shared with the base branch. A failure to determine safety (e.g. an
-	 * empty repo with no HEAD) is treated as unsafe: there is nothing to amend.
+	 * Unsafe when:
+	 * - the branch has no commit of its own (HEAD is the base branch's tip), or
+	 * - the tip was authored by someone else, or
+	 * - the tip is also reachable from another branch (e.g. HEAD was reset/rebased
+	 *   onto a shared branch) — amending any of these rewrites a commit another
+	 *   branch depends on.
+	 *
+	 * A failure to determine safety (e.g. an empty repo with no HEAD) is treated
+	 * as unsafe: there is nothing to amend.
 	 */
 	private async resolveAmendAvailability(): Promise<AmendAvailability> {
 		const safety = await this.bridge
@@ -289,6 +294,18 @@ export class CommitCommand {
 			return {
 				allowed: false,
 				reason: "the latest commit was authored by someone else",
+			};
+		}
+		// The reflog fork point can look legitimate after a reset/rebase onto a
+		// branch that descends from it; a direct "is HEAD shared with another
+		// branch" check closes that gap (the tip is published elsewhere).
+		const headShared = await this.bridge
+			.isHeadSharedWithOtherBranch()
+			.catch(() => false);
+		if (headShared) {
+			return {
+				allowed: false,
+				reason: "the latest commit also belongs to another branch",
 			};
 		}
 		return { allowed: true, reason: "" };

--- a/vscode/src/commands/CommitCommand.ts
+++ b/vscode/src/commands/CommitCommand.ts
@@ -53,6 +53,13 @@ const DEFAULT_TITLE = "Edit the commit message, then select an action";
 const AMEND_NO_EDIT_TITLE =
 	"Input will be ignored — reuses last commit message";
 
+/** Whether the Amend actions may be offered, plus a reason when they may not. */
+interface AmendAvailability {
+	readonly allowed: boolean;
+	/** Empty when allowed; a user-facing clause (no leading capital) when not. */
+	readonly reason: string;
+}
+
 // ─── CommitCommand ────────────────────────────────────────────────────────────
 
 export class CommitCommand {
@@ -162,9 +169,12 @@ export class CommitCommand {
 			return;
 		}
 
-		// Step 4: Show QuickPick at top of screen
-		log.info("commit", "Showing QuickPick");
-		const selected = await this.showCommitQuickPick(generatedMessage);
+		// Step 4: Show QuickPick at top of screen. Gate the Amend actions: on a
+		// branch with no commit of its own (or whose tip is someone else's),
+		// amending would rewrite a commit shared with the base branch.
+		const amend = await this.resolveAmendAvailability();
+		log.info("commit", "Showing QuickPick", { amendAllowed: amend.allowed });
+		const selected = await this.showCommitQuickPick(generatedMessage, amend);
 		if (!selected) {
 			log.info("commit", "QuickPick cancelled by user — restoring index");
 			await this.restoreIndex(originalIndexTree);
@@ -257,15 +267,50 @@ export class CommitCommand {
 		}
 	}
 
+	/**
+	 * Decides whether the Amend actions may be offered for the current HEAD.
+	 *
+	 * Unsafe when the branch has no commit of its own (HEAD is the base branch's
+	 * tip) or the tip was authored by someone else — amending either rewrites a
+	 * commit shared with the base branch. A failure to determine safety (e.g. an
+	 * empty repo with no HEAD) is treated as unsafe: there is nothing to amend.
+	 */
+	private async resolveAmendAvailability(): Promise<AmendAvailability> {
+		const safety = await this.bridge
+			.getAmendSafety(this.commitsStore.getMainBranch())
+			.catch(() => undefined);
+		if (!safety || !safety.hasOwnCommits) {
+			return {
+				allowed: false,
+				reason: "this branch has no commit of yours to amend",
+			};
+		}
+		if (!safety.headAuthoredByCurrentUser) {
+			return {
+				allowed: false,
+				reason: "the latest commit was authored by someone else",
+			};
+		}
+		return { allowed: true, reason: "" };
+	}
+
 	private showCommitQuickPick(
 		generatedMessage: string,
+		amend: AmendAvailability,
 	): Promise<{ item: vscode.QuickPickItem; message: string } | undefined> {
 		return new Promise((resolve) => {
 			const qp = vscode.window.createQuickPick<vscode.QuickPickItem>();
 			qp.value = generatedMessage;
-			qp.title = DEFAULT_TITLE;
+			// Hide the Amend actions entirely when unsafe — VS Code QuickPickItem
+			// has no "disabled" state, so a greyed item would still be selectable.
+			// Surface the reason in the title so the absence isn't mysterious.
+			qp.title = amend.allowed
+				? DEFAULT_TITLE
+				: `Only Commit is available — ${amend.reason}`;
 			qp.placeholder = "Edit the commit message, then select an action";
-			qp.items = [ITEM_COMMIT, ITEM_AMEND, ITEM_AMEND_NO_EDIT];
+			qp.items = amend.allowed
+				? [ITEM_COMMIT, ITEM_AMEND, ITEM_AMEND_NO_EDIT]
+				: [ITEM_COMMIT];
 
 			// Disable filtering so the input text is used as a free-form commit
 			// message, not as a filter query. Without this, the commit message
@@ -277,13 +322,16 @@ export class CommitCommand {
 			qp.matchOnDescription = false;
 			qp.matchOnDetail = false;
 
-			// Update title dynamically when the user highlights a different action
-			qp.onDidChangeActive((active) => {
-				qp.title =
-					active[0] === ITEM_AMEND_NO_EDIT
-						? AMEND_NO_EDIT_TITLE
-						: DEFAULT_TITLE;
-			});
+			// Update title dynamically when the user highlights a different action.
+			// Skip while Amend is hidden so the "Only Commit is available" title stays.
+			if (amend.allowed) {
+				qp.onDidChangeActive((active) => {
+					qp.title =
+						active[0] === ITEM_AMEND_NO_EDIT
+							? AMEND_NO_EDIT_TITLE
+							: DEFAULT_TITLE;
+				});
+			}
 
 			log.debug("quickpick", "Commit QuickPick shown", {
 				value: generatedMessage,
@@ -328,6 +376,20 @@ export class CommitCommand {
 		message: string,
 	): Promise<void> {
 		if (item === ITEM_AMEND || item === ITEM_AMEND_NO_EDIT) {
+			// Defensive re-check: the QuickPick hides Amend when unsafe, but state
+			// can change between opening the picker and accepting (and qp.items[0]
+			// is used as a fallback selection). Refuse to rewrite a commit this
+			// branch did not create — let execute()'s catch restore the index.
+			const amend = await this.resolveAmendAvailability();
+			if (!amend.allowed) {
+				log.warn("commit", "Amend blocked at execute time", {
+					reason: amend.reason,
+				});
+				throw new Error(
+					`Amend is unavailable — ${amend.reason}. Use Commit to create a new commit instead.`,
+				);
+			}
+
 			// Check if HEAD is pushed BEFORE amend (hash changes after amend)
 			const wasPushed = await this.bridge.isHeadPushed().catch(() => false);
 			const headBeforeAmend = await this.bridge.getHEADHash().catch(() => "");


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (2)

1. Gate Amend actions when branch has no own commit or wrong author (`d114719`)
2. Fix amend safety by resolving own-commits base from branch fork point (`1165cd5`)

## Quick recap (2)

### Commit 1 of 2: Gate Amend actions when branch has no own commit or wrong author (`d114719`)

The Commit Memory panel gained a safety gate that prevents a silent data-integrity hazard. On any branch where no local commits exist yet, or where the most recent commit was authored by someone other than the current user, the Amend and Amend-No-Edit actions are now hidden entirely from the panel. Users on such branches see only the standard Commit action along with a plain-language explanation of why amending is unavailable.

The guard operates at two independent layers. The panel checks safety before building the action list, so unsafe options never appear in the first place. A second check runs at the moment the action would execute, catching the narrow window where state could change between opening the panel and confirming a choice — if that check also finds the amend unsafe, the operation is refused and the staged index is restored. Email comparison between the tip commit's author and the current user is handled case-insensitively, and missing or unconfigured email addresses are treated conservatively as a mismatch, keeping the guard effective even in partially configured environments.

### Commit 2 of 2: Fix amend safety by resolving own-commits base from branch fork point (`1165cd5`)

The amend safety check and memories panel now correctly identify which commits on a branch belong to the current developer, even when that branch was created from a release or develop branch rather than directly from the main line. Previously, a freshly created hotfix branch cut from a release branch would show the release branch's commits in its panel and offer the amend action on shared commits it did not own. After this work, that branch shows an empty panel and no amend option until the developer adds at least one commit of their own on top of the fork point. Once their own work exists, the panel and amend action behave exactly as before.

Two additional correctness gaps were closed through code review. When a branch had been hard-reset onto a different line of work, the stored record of where the branch was originally created could still pass validation, causing commits from the other branch to appear as the developer's own. When the oldest reflog entry recording a branch's origin had expired naturally over time, the code would silently promote the branch's own first commit to the role of creation point, making that commit invisible in the history view and incorrectly hiding the amend option on single-commit branches. Both cases are now handled: the creation record is verified to still sit behind the current tip before being trusted, and callers responsible for amend and history decisions now require an explicit creation record rather than accepting a guess.

A third gate was added to the amend safety path to close the remaining gap. Even with a valid fork point, resetting a branch hard onto a release or shared branch could still pass all existing checks if the tip happened to be authored by the same developer. The amend action is now also blocked whenever the current tip is reachable from any other local or remote branch, with the developer's own pushed copy correctly excluded to avoid false positives on branches that have been pushed without a tracking reference configured.

## E2E Test (4)
<details>
<summary><strong>1. [d114719] Amend hidden on a branch with no own commits</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository open in the extension where the current branch was just created from the base branch and has no commits of its own (i.e. the branch tip is still the same as the base branch tip). Make sure at least one file is staged for commit.

**Steps:**
1. Open the Jolli Memory panel in VS Code.
2. Click the "Commit Memory" button to open the commit action picker.
3. Look at the title bar of the picker and count the available action items listed.
4. Check whether any item containing the word "Amend" appears in the list.
5. Read the title shown at the top of the picker.

**Expected Results:**
- Only one action item is shown — the "Commit" option. No "Amend" items appear anywhere in the list.
- The picker title reads something like "Only Commit is available — this branch has no commit of yours to amend" (not the normal "Edit the commit message, then select an action" title).

</blockquote>
</details>
<details>
<summary><strong>2. [d114719] All three actions shown when the branch has your own commit</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository open where the current branch has at least one commit you authored yourself (your git email matches the HEAD commit's author email). Stage at least one file for commit.

**Steps:**
1. Open the Jolli Memory panel in VS Code.
2. Click the "Commit Memory" button to open the commit action picker.
3. Count the action items shown and read the picker title.
4. Verify that both "Amend" options are visible alongside the "Commit" option.

**Expected Results:**
- Three action items are shown: Commit, Amend (with new message), and Amend (keep message).
- The picker title reads "Edit the commit message, then select an action" (the normal default title, not an explanatory restriction message).

</blockquote>
</details>
<details>
<summary><strong>3. [1165cd5] Fresh hotfix branch cut from a release branch shows no amend option</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Git repository with a release branch (e.g. "release/1.0") that is ahead of main. Create a new hotfix branch directly from that release branch without adding any commits of your own — the hotfix branch tip should be identical to the release branch tip.

**Steps:**
1. Open VS Code with the Jolli Memory extension in the repository described above, checked out on the fresh hotfix branch.
2. Open the Jolli Memory panel (e.g. via the activity bar or command palette).
3. Look at the commit list shown in the memories panel for the current branch.
4. Check whether an "Amend" action is offered anywhere in the panel or commit quick-pick menu.
5. Verify the commit list displayed for the hotfix branch.

**Expected Results:**
- The memories panel should show an empty commit list — no commits from the release branch should appear as if they belong to the hotfix branch.
- The "Amend" action should NOT be offered, because the branch has no commits of its own.

</blockquote>
</details>
<details>
<summary><strong>4. [1165cd5] Hotfix branch cut from release branch shows amend option only after adding its own commit</strong></summary>
<br>
<blockquote>

**Preconditions:** Use the same repository as above. After verifying the empty state, add one new commit on the hotfix branch (e.g. make a small file change and commit it).

**Steps:**
1. With the hotfix branch checked out and one new commit added on top of the release branch tip, open the Jolli Memory panel.
2. Look at the commit list shown for the hotfix branch.
3. Check whether the "Amend" action is now available in the panel or commit quick-pick menu.
4. Confirm which commits appear in the list.

**Expected Results:**
- The memories panel should show exactly one commit — the new commit you just made — and nothing from the release branch.
- The "Amend" action should now be offered, because the branch has its own commit.

</blockquote>
</details>

## Topics (4)
<details>
<summary><strong>01 · [d114719] Block amend actions when branch has no own commits or wrong author</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users discovered that on a freshly created branch with no commits of their own, the "Amend" option in the Commit Memory panel would silently rewrite a colleague's commit from the base branch — keeping the original author and inheriting that colleague's memory summary onto the new hash.

**💡 Decisions Behind the Code**

- **Hide vs. grey out the amend actions**: Hiding was chosen over greying out. The VS Code QuickPick API has no native disabled state, so a greyed item would still be keyboard-selectable and require an extra intercept callback to block — effectively a fake disabled state with worse UX. Removing the items entirely is the native, zero-hack approach and leaves no ambiguity for the user.
- **Treat undeterminable safety as unsafe**: When the safety check fails entirely (e.g. an empty repo with no HEAD), the code defaults to blocking amend. The failure mode of silently rewriting someone else's commit is far more harmful than occasionally blocking a legitimate amend in an unusual repo configuration, so the conservative default was chosen.
- **Keep a defensive re-check at execution time**: Even after hiding the amend items in the picker, a second safety check runs immediately before the git amend call. This guards against the narrow race where the picker's fallback selection logic could surface an amend item, and makes the safety guarantee independent of the UI layer.
- **Case-insensitive email comparison**: Author email matching is done case-insensitively. Email addresses are case-insensitive by spec, and a capitalisation mismatch would otherwise produce a false "foreign author" result, blocking a legitimate amend.
- **Empty email treated as mismatch**: Both an empty HEAD author email and an empty configured user email are treated as a mismatch rather than a wildcard. Allowing an empty string to match anything would let the guard pass silently in misconfigured environments, which is the more dangerous failure mode.

**✅ What Was Implemented**

- Added `getAmendSafety()` to `JolliMemoryBridge.ts` and a corresponding `AmendSafety` interface in `Types.ts`. The method checks two conditions: whether HEAD has diverged from the merge-base with the remote tracking branch (indicating the branch has its own commits), and whether the HEAD commit's author email matches the configured git user email. Email comparison is case-insensitive per spec; both an empty HEAD author email and an empty configured user email are treated as a mismatch rather than a wildcard. An empty merge-base is treated as "own work" to avoid blocking legitimate amends in unusual repo configurations, with the author check serving as the real backstop.
- Added `resolveAmendAvailability()` to `CommitCommand.ts`, which calls `getAmendSafety()` and maps the two flags to an `AmendAvailability` result with a user-facing reason string. When unsafe, the two Amend items are removed from the QuickPick entirely and the panel title is replaced with an explanatory message, leaving only the Commit action visible.
- A defensive re-check runs inside `executeCommitAction()` immediately before any amend git call is made. If state changed between the picker opening and the user confirming a selection, the operation is refused with a clear error message and the staged index is restored.
- Updated `CommitCommand.test.ts` with a `makeCommand()` factory and `showPick()` / `runAction()` helpers to reduce boilerplate, plus new test cases covering: branch with no own commits, HEAD authored by someone else, undeterminable safety treated as unsafe, the safe path showing all three actions, and the defensive execute-time block. Added a `getAmendSafety` test suite in `JolliMemoryBridge.test.ts` covering five scenarios: HEAD diverged with matching author (case-insensitive), HEAD equal to merge-base, HEAD authored by a different user, empty HEAD author email, and empty configured user email.

**📋 Future Enhancements**

Optional defense for the CLI path: when the post-rewrite hook detects a cross-author amend (commit rewritten by someone other than the original author), skip inheriting the old memory summary onto the new hash. Discussed as a separate, more cautious follow-up change.

**📁 FILES**
- `vscode/src/JolliMemoryBridge.ts`
- `vscode/src/Types.ts`
- `vscode/src/commands/CommitCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [1165cd5] Block amend when branch tip is reachable from another branch</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the fork-point fix landed, a reviewer reproduced a scenario where resetting a feature branch hard onto a release branch still allowed amending the release tip. The fork-point logic passed all existing safety checks, leaving a gap where a shared, already-published commit could be rewritten.

**💡 Decisions Behind the Code**

- **Amend gate only, not the history panel**: The shared-branch check was added exclusively to the amend safety path. The history panel continues using the reflog-based fork point, which can show a slightly wider range of commits in edge cases. Restricting the panel as well would have required reworking a larger surface area and risked regressions in the merged-branch view, while the amend path is where actual data loss can occur.
- **Exclude the same-named remote copy even without tracking**: When a developer pushes with a plain push command but omits the flag that sets up tracking, the remote copy of the branch contains the current tip but the upstream reference is empty. Without an explicit fallback, this would have incorrectly flagged every untracked-but-pushed branch as shared and hidden the amend option. The fix mirrors the existing push-base resolution logic so both paths treat the same-named remote copy as the developer's own copy.
- **Degrade to permissive on scan failure**: If the ref scan command fails entirely, the method returns false rather than blocking amend. The two existing gates (fork point and author check) still apply, so a scan failure does not silently open up unsafe amends — it only avoids adding a spurious extra block on top of a legitimate failure mode.

**✅ What Was Implemented**

- Added `isHeadSharedWithOtherBranch()` in `vscode/src/JolliMemoryBridge.ts`, which runs a ref scan across all local and remote branches to determine whether the current tip is reachable from any branch other than the current one. The check filters out the current branch, its configured upstream, and the same-named remote copy to avoid false positives when a developer has pushed without setting up tracking.
- Wired the new check as a third gate in `resolveAmendAvailability()` in `vscode/src/commands/CommitCommand.ts`, after the existing "no own commits" and "authored by someone else" checks. A shared tip returns the amend action as unavailable with the reason that the latest commit also belongs to another branch.
- Added six bridge unit tests covering shared and not-shared cases, including the push-without-tracking false-positive regression, and one integration test for the new gate in `CommitCommand`.

**📁 FILES**
- `vscode/src/JolliMemoryBridge.ts`
- `vscode/src/commands/CommitCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [1165cd5] Fix stale fork-point and expired reflog causing wrong own-commit detection</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code review identified two bugs in the logic that determines which commits on a branch belong to the current developer. After resetting a branch onto a different line of work, the stored branch creation point could still pass validation even though it no longer reflected the branch's actual history. Separately, when the oldest reflog entry recording where a branch was created had expired, the code would silently guess the branch's own first commit as the creation point, causing that commit to disappear from the history view and incorrectly hiding the amend option on single-commit branches.

**💡 Decisions Behind the Code**

- **Scoped explicit-only mode to safety-critical callers, not globally**: Removing the oldest-entry fallback everywhere would have changed behavior for the merged-branch history panel and broken an existing test that explicitly asserted the fallback. Introducing a flag lets the amend and history safety path opt into strict mode while the best-effort panel path keeps its existing behavior, avoiding unintended regressions.
- **Ancestor guard as partial mitigation for reset-onto-branch**: The ancestor check prevents the code from using a creation point that is no longer behind HEAD, but it cannot reconstruct the true fork point after a hard reset — the reflog simply does not contain that information. The fallback to the mainline merge-base still shows the reset-onto branch's commits as own work in the history panel. The decision was to add the guard for correctness of the invariant (a base used in a log range must be an ancestor of HEAD) and accept the remaining display inaccuracy as a known limitation, with the shared-branch amend gate closing the dangerous half of the gap.

**✅ What Was Implemented**

- In `resolveOwnCommitsBase()` in `vscode/src/JolliMemoryBridge.ts`, added an ancestor check before trusting the reflog creation point: if the stored creation point is no longer behind the current HEAD (i.e. the branch was reset onto a different line), it is discarded and the mainline merge-base is used as the fallback. The mainline-unresolvable fallback was also reordered to run after this guard rather than before.
- In `findBranchCreationPoint()`, added a `requireExplicit` option. When callers pass this flag, the function returns nothing if no explicit creation reflog entry exists, rather than guessing the oldest surviving entry. `resolveOwnCommitsBase()` now passes this flag, so a branch with a partially expired reflog correctly falls back to the mainline merge-base instead of silently dropping its first commit. The merged-branch history view does not pass the flag and retains its existing best-effort behavior.
- Added two new test cases: one verifying that a stale creation point no longer an ancestor of HEAD is rejected and the downstream check is never reached, and one verifying that a branch whose creation entry has expired still counts its lone commit as own work.

**📁 FILES**
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [1165cd5] Amend safety and history panel now use branch fork point for own-commit detection</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A user reported that the safety check blocking risky amend operations could be bypassed on branches cut from release or develop branches. A fresh hotfix branch created from a release branch had zero commits of its own, yet the tool still offered the amend action and listed the release branch's shared commits as if they belonged to the hotfix branch.

**💡 Decisions Behind the Code**

- **Reflog fork point over a contains-scan approach**: An earlier proposal checked whether the current tip appeared on any other branch, which would have correctly blocked amend on shared tips. The team rejected it for the amend-with-own-commits case: a hotfix branch that already has its own commits on top of a release base would have had its panel emptied and amend hidden — exactly the legitimate workflow the feature is meant to support. The reflog fork-point approach preserves that workflow once the branch has even one commit past the fork.
- **Graceful degradation when reflog is unavailable**: The helper returns the existing mainline merge-base whenever the reflog cannot supply a creation point (expired reflog, shallow clone, etc.). This means the old behavior is the fallback rather than a hard failure, keeping the change safe for edge-case environments while still fixing the common case.
- **Detached HEAD bails out of reflog lookup**: When git reports the current branch as being in a detached state, the reflog for that name would return the repository's entire HEAD movement history, making the oldest entry meaningless as a creation point. Returning early and falling back to the mainline merge-base avoids a subtle correctness bug that would only surface in CI or rebase workflows.

**✅ What Was Implemented**

- Added `resolveOwnCommitsBase()` in `vscode/src/JolliMemoryBridge.ts`, a private helper that determines the true starting point for a branch's own commits. It uses the branch's reflog creation entry and checks whether that creation point sits downstream of the mainline. When the creation point is downstream (the release-fork case), it becomes the base; otherwise the existing mainline merge-base is kept. A detached HEAD guard was also added to `findBranchCreationPoint()` to prevent it from returning a misleading hash in that state.
- Wired `resolveOwnCommitsBase()` into both `getAmendSafety()` and the non-merged path of `listBranchCommits()` in the same file. The amend gate now sets `hasOwnCommits` based on the resolved fork-point base, and the memories panel log range now starts from that same fork point, so a zero-own-commit release-fork branch shows an empty panel and no amend option.
- Updated and extended the test suite in `vscode/src/JolliMemoryBridge.test.ts`: corrected the mock-queue comment, inserted the new reflog mock into every existing non-merged test, and added six new cases covering the release-fork zero-commit scenario, release-fork with own commits, detached HEAD, reflog unavailable, creation point not downstream, and master-default-branch repos.

**📁 FILES**
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 22, 2026 at 10:55 AM*
<!-- jollimemory-summary-end -->