### PR TITLE
Fix QueueWorker to use captured branch instead of live branch for summary

### DIFF
--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -633,6 +633,49 @@ describe("QueueWorker", () => {
 		});
 	});
 
+	// Regression: summary.branch used to be read from the live getCurrentBranch
+	// at drain time. That is wrong when HEAD moved between enqueue and drain —
+	// a rapid squash/amend/rebase (rebase transiently checks out the upstream),
+	// or a sibling worktree sitting on another branch. The branch must come from
+	// the queued op (captured inside the git hook at enqueue time), mirroring the
+	// tail-cleanup fix. Otherwise a commit on a feature branch is filed under
+	// whatever branch happened to be live (e.g. "main"), which breaks branch
+	// grouping and the sidebar's `gh pr list --head <branch>` PR-status lookup.
+	describe("runWorker — summary.branch provenance", () => {
+		it("records op.branch on the summary, not the live getCurrentBranch", async () => {
+			const op = makeCommitOp({ branch: "feature/captured" });
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/entry.json" }])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+			setupPipelineMocks();
+			// Simulate HEAD drifting away after enqueue (e.g. rebase checked out main).
+			vi.mocked(getCurrentBranch).mockResolvedValue("main");
+
+			await runWorker("/test/cwd");
+
+			expect(storeSummary).toHaveBeenCalledTimes(1);
+			const savedSummary = vi.mocked(storeSummary).mock.calls[0][0];
+			expect(savedSummary.branch).toBe("feature/captured");
+		});
+
+		it("falls back to live getCurrentBranch when op.branch is absent (pre-0.99.x entries)", async () => {
+			const op = makeCommitOp();
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/entry.json" }])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+			setupPipelineMocks();
+			vi.mocked(getCurrentBranch).mockResolvedValue("feature/live");
+
+			await runWorker("/test/cwd");
+
+			expect(storeSummary).toHaveBeenCalledTimes(1);
+			const savedSummary = vi.mocked(storeSummary).mock.calls[0][0];
+			expect(savedSummary.branch).toBe("feature/live");
+		});
+	});
+
 	describe("runWorker — entity association (multi-source)", () => {
 		it("archives entities into the summary with archivedKey populated (Linear projected to linearIssues)", async () => {
 			const op = makeCommitOp({ commitHash: "abc12345def67890" });

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -1449,7 +1449,14 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 
 	// Step 5: Get git diff and stats (moved before guard to enable diff-only summaries)
 	stepStart = now();
-	const branch = await getCurrentBranch(cwd);
+	// Prefer the branch captured at enqueue time over the live branch. The worker
+	// drains asynchronously, so HEAD may have moved between commit and drain (rapid
+	// squash/amend/rebase, or a sibling worktree on another branch). Reading the
+	// live branch here would file the summary under the wrong branch — the same bug
+	// the tail-cleanup and diff steps already guard against via op.branch/op.commitHash.
+	// Fall back to the live branch only for pre-0.99.x queue entries that predate the
+	// captured field.
+	const branch = op.branch ?? (await getCurrentBranch(cwd));
 	let diff: string;
 	let diffStats: DiffStats;
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer fixed a bug where commit summaries were recording the wrong branch when the worker drained asynchronously. If git operations moved HEAD between the time a commit was queued and when the worker processed it—such as during a rapid squash-amend-rebase sequence or when multiple worktrees were in use—the summary would capture whatever branch was live at drain time rather than the branch where the commit actually lived. This caused the sidebar's PR status lookup to search the wrong branch, making newly created PRs invisible to users. The fix ensures the summary uses the branch captured inside the git hook at enqueue time, matching the protection already in place for other parts of the pipeline. Two regression tests now prevent this class of bug from recurring.

---

## Topic (1)
<details>
<summary><strong>01 · Fix summary branch field to use captured value instead of live branch at drain time</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A PR created via the jolli-pr skill was not appearing in the sidebar's PR status display. The commit was on the feature branch, but the summary had recorded it as being on main, causing the PR lookup to search the wrong branch.

**💡 Decisions Behind the Code**

The branch must be captured at enqueue time rather than read live during drain. Worker drain is asynchronous, and HEAD can move between enqueue and drain due to rapid git operations (squash, amend, rebase) or sibling worktrees on different branches. Reading the live branch would file the summary under whatever branch happened to be checked out at drain time, breaking branch grouping and the sidebar's `gh pr list --head <branch>` PR-status lookup. The codebase already applied this protection to tail-cleanup and diff steps; this fix closes the same gap in summary.branch.

**✅ What Was Implemented**

- Modified `QueueWorker.ts` line 1452 to prefer the branch captured at enqueue time (`op.branch`) over reading the live branch via `getCurrentBranch()`. Falls back to live branch only for pre-0.99.x queue entries that lack the captured field. This mirrors the existing protection in tail-cleanup and diff steps.
- Added two regression tests in `QueueWorker.test.ts` to verify summary.branch is sourced from the queued operation when available, and falls back to live branch when the captured field is absent.
- Repaired the stale summary records for commit `b97475a2` in the orphan branch and index, changing branch from "main" to "feature/mcp-pr-description" to match the actual commit location.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`
- `cli/src/hooks/QueueWorker.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 19, 2026 at 11:17 PM · via Anthropic*
<!-- jollimemory-summary-end -->
