### PR TITLE
Migrate skills to MCP tools with multi-host registration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,32 @@ Local non-summary state is split across **two** `.jolli/jollimemory/` directorie
 
 Hook installation uses dist-path indirection: hooks call `node "$($HOME/.jolli/jollimemory/resolve-dist-path)/PostCommitHook.js"`, where `resolve-dist-path` reads the `~/.jolli/jollimemory/dist-path` file. CLI vs extension write the same version-tagged dist-path (e.g. `source=cli@1.0.0\n/abs/path/to/dist`), so whichever surface was enabled most recently wins, and version comparisons work across surfaces.
 
+### MCP server registration (multi-host)
+
+`jolli enable` wires the `jolli mcp` stdio server into every detected AI host. Registration is handled by per-host `McpHostRegistrar` implementations under [`cli/src/install/mcp/HostRegistrars.ts`](cli/src/install/mcp/HostRegistrars.ts). Each registrar carries a `scope`: **repo**-scoped hosts (config inside the worktree) are registered per-worktree via `registerRepoMcpHosts`; **global**-scoped hosts (one machine-wide file shared by every repo) are registered once via `registerGlobalMcpHosts`. Uninstall calls `removeRepoMcpHosts` — global entries are deliberately **not** removed, since a single-repo uninstall must not break MCP for other repos still using Jolli. Seven hosts are supported:
+
+| Host | Scope | Config path | Writer |
+|------|-------|-------------|--------|
+| Claude Code | repo | `.mcp.json` in the project root | `registerMcpInClaude` (custom merge — preserves other servers) |
+| Cursor | repo | `.cursor/mcp.json` in the project root | `JsonMcpWriter` |
+| Gemini CLI | global | `~/.gemini/settings.json` | `JsonMcpWriter` |
+| Codex | global | `~/.codex/config.toml` | `CodexTomlWriter` (hand-written TOML — no external TOML lib) |
+| OpenCode | global | `~/.config/opencode/opencode.json` | `JsonMcpWriter` (key `mcp`; entry needs `type:"local"` + combined command array) |
+| GitHub Copilot CLI | global | `~/.copilot/mcp-config.json` | `JsonMcpWriter` |
+| VS Code Copilot Chat | global | `<vscodeUserDataDir>/User/mcp.json` | `JsonMcpWriter` (key `servers`; entry `type:"stdio"`) |
+
+Each non-Claude registrar is gated by its host's existing detector (`isCursorInstalled`, `isCodexInstalled`, …) so registration is skipped for hosts the user hasn't installed. **Claude is the exception**: its `detected` flag mirrors `config.claudeEnabled !== false` (not a filesystem detector) — but MCP registration still runs **regardless of `claudeEnabled`** (it happens before the `claudeEnabled` hook gate in the install loop), because the Claude hook and MCP registration are independent decisions. IntelliJ MCP registration is a follow-up; the IntelliJ plugin registers no MCP today.
+
+### MCP tool set and CLI↔MCP result parity
+
+The `jolli mcp` server exposes four tools: `search`, `recall`, `get_decision_timeline`, `list_branches`. There is no `load_commits` tool.
+
+`recall` (MCP) and `jolli recall --format json` (CLI) both call `resolveRecall()` ([`cli/src/core/RecallResolver.ts`](cli/src/core/RecallResolver.ts)), so they return the identical `type`-tagged union (`recall` | `catalog` | `error`), including catalog fuzzy-match on an unrecognized branch.
+
+`search` (MCP) and `jolli search` (CLI) both call `searchHits()` ([`cli/src/core/SearchHits.ts`](cli/src/core/SearchHits.ts)), Orama BM25. Both return `{ hits }` — single-phase. The CLI `search` command's old two-phase catalog / `--hashes` flow was retired; [`LocalSearchProvider.ts`](cli/src/core/LocalSearchProvider.ts) is kept as an unused `SearchProvider` extension point.
+
+The `jolli-recall` and `jolli-search` skill templates (written by [`SkillInstaller.ts`](cli/src/install/SkillInstaller.ts)) prefer the MCP tools (`mcp__jollimemory__recall` / `mcp__jollimemory__search`) and fall back to the CLI here-doc recipe for hosts without MCP support. `jolli-search` is intentionally lightweight (title / snippet / slug / hash; no decisions or recap) — point users to `jolli-recall` for depth.
+
 ### Site generation lives in a separate plugin package
 
 The `jolli new` / `build` / `dev` / `start` / `convert` / `reverse` / `theme` commands are **not** in this repo. They live in `@jolli.ai/site-cli`, a plugin built and released separately. The host CLI discovers it at runtime through [`PluginLoader`](cli/src/PluginLoader.ts) and [`KnownPlugins.ts`](cli/src/KnownPlugins.ts) (allow-listed by random `jolliPluginId`, never by package name — see the PluginLoader header for the rationale).

--- a/cli/DEVELOPMENT.md
+++ b/cli/DEVELOPMENT.md
@@ -160,7 +160,7 @@ jolli status
 | [SummaryTree.ts](src/core/SummaryTree.ts) | Tree traversal utilities (aggregate stats/turns, collect source nodes, `resolveDiffStats` display helper) |
 | [SummaryMigration.ts](src/core/SummaryMigration.ts) | v1→v3 migration logic for legacy orphan branch data |
 | [GitOperationDetector.ts](src/hooks/GitOperationDetector.ts) | Detects git operation type (commit, amend, squash, rebase, cherry-pick, revert) |
-| [Installer.ts](src/install/Installer.ts) | Installs/removes hooks in Claude Code, Gemini, and git |
+| [Installer.ts](src/install/Installer.ts) | Installs/removes git hooks and MCP server registrations. Git hooks: Claude Code `StopHook`/`SessionStartHook`, Gemini `AfterAgent`, `post-commit`, `prepare-commit-msg`. MCP: `registerAllMcpHosts`/`removeAllMcpHosts` drive per-host `McpHostRegistrar` implementations (Claude `.mcp.json`, Cursor `.cursor/mcp.json`, Gemini `~/.gemini/settings.json`, Codex `~/.codex/config.toml`) gated by per-host detectors. |
 | [references/ReferenceExtractor.ts](src/core/references/ReferenceExtractor.ts) / [references/ReferenceStore.ts](src/core/references/ReferenceStore.ts) | Multi-source external-reference extraction (Linear / Jira / GitHub / Notion) + per-commit reference store. The extractor walks transcripts via per-source envelope parsers (`references/sources/`, `references/bindings/`) for the relevant MCP tool calls and normalises them into an opaque `ReferenceField` bag, so adding a source is a binding entry rather than a schema change. The store persists references to the orphan branch with the same hoist-on-rebase / merge-on-squash semantics as Plans and Notes (see `QueueWorker.runSquashPipeline` for the integration). |
 | [ActiveSessionAggregator.ts](src/core/ActiveSessionAggregator.ts) | Aggregates active sessions across every source (Claude / Codex / Gemini / OpenCode / Cursor / Copilot CLI / Copilot Chat) into a single `ActiveSession[]` snapshot. Powers the VS Code **Conversations** sidebar section; safe to poll because every per-source detector + reader is feature-gated and cheap. |
 | [ConversationOverlayStore.ts](src/core/ConversationOverlayStore.ts) | Persists per-session **transcript edit overlays** — the curated turn list a user produced in the Conversation Details panel. Stored locally per-project; consulted by the summarization pipeline so the LLM sees the user's curated version, not the raw transcript. |
@@ -446,8 +446,8 @@ The server exposes five tools, all pure handlers in [McpTools.ts](src/mcp/McpToo
 
 | Tool | Purpose |
 |------|---------|
-| `search` | Full-text search over the repo's historical decisions and implementations (topics + commits). |
-| `recall` | Recall a branch's development context from **RAW commit summaries** — the same data path as the `jolli-recall` skill, NOT the topic KB. Defaults to the current branch. |
+| `search` | Full-text BM25 search (Orama) over the repo's historical decisions and implementations; returns `{ hits }`. Calls the same `searchHits()` ([SearchHits.ts](src/core/SearchHits.ts)) as `jolli search`, so results are identical. |
+| `recall` | Recall a branch's development context from **RAW commit summaries** — the same data path as the `jolli-recall` skill, NOT the topic KB. Calls the same `resolveRecall()` ([RecallResolver.ts](src/core/RecallResolver.ts)) as `jolli recall --format json`; returns the same `type`-tagged union (`recall` \| `catalog` \| `error`). Defaults to the current branch. |
 | `get_decision_timeline` | Chronological evolution of a topic — its source events ordered oldest-first. |
 | `list_branches` | All branches with JolliMemory records and their topic titles. |
 | `get_pr_description` | Build a GitHub PR title + description from the branch's JolliMemory commit summaries — the same memory-rich body the VS Code extension writes. Use before `gh pr create`. |

--- a/cli/src/Api.test.ts
+++ b/cli/src/Api.test.ts
@@ -4752,6 +4752,80 @@ describe("CLI", () => {
 				await fs.rm(nestedRoot, { recursive: true, force: true });
 			}
 		});
+
+		it("writes the JSON payload to --output instead of stdout (--format json --output)", async () => {
+			// Regression: `--format json` used to short-circuit to stdout BEFORE the
+			// `--output` path could run, so `--format json --output FILE` silently
+			// discarded the file. The JSON payload must now land in the file.
+			vi.mocked(listBranchCatalog).mockReset();
+			vi.mocked(compileTaskContext).mockReset();
+			vi.mocked(listBranchCatalog).mockResolvedValueOnce({
+				type: "catalog",
+				branches: [
+					{
+						branch: "feature/auth",
+						commitCount: 2,
+						period: { start: "2026-03-28", end: "2026-03-29" },
+						commitMessages: ["a"],
+					},
+				],
+			});
+			vi.mocked(compileTaskContext).mockResolvedValueOnce({
+				branch: "feature/auth",
+				period: { start: "2026-03-28", end: "2026-03-29" },
+				commitCount: 2,
+				totalFilesChanged: 5,
+				totalInsertions: 100,
+				totalDeletions: 20,
+				summaries: [],
+				plans: [],
+				notes: [],
+				keyDecisions: [],
+				stats: {
+					topicCount: 1,
+					planCount: 0,
+					noteCount: 0,
+					decisionCount: 0,
+					topicTokens: 50,
+					planTokens: 0,
+					noteTokens: 0,
+					decisionTokens: 0,
+					transcriptTokens: 0,
+					totalTokens: 50,
+				},
+			});
+
+			const os = await import("node:os");
+			const path = await import("node:path");
+			const fs = await import("node:fs/promises");
+			const outputPath = path.join(os.tmpdir(), `jolli-recall-json-${Date.now()}.json`);
+
+			try {
+				await main([
+					"recall",
+					"feature/auth",
+					"--format",
+					"json",
+					"--output",
+					outputPath,
+					"--cwd",
+					"/tmp/test",
+				]);
+
+				const content = await fs.readFile(outputPath, "utf-8");
+				expect(JSON.parse(content).type).toBe("recall");
+
+				const logged = vi
+					.mocked(console.log)
+					.mock.calls.map((c) => String(c[0]))
+					.join("\n");
+				expect(logged).toContain("Recall context (JSON) written to");
+				// And the JSON must NOT also be dumped to stdout when --output is given.
+				expect(logged).not.toContain('"type":"recall"');
+			} finally {
+				await fs.rm(outputPath, { force: true });
+			}
+		});
 	});
 
 	// ── auth commands ────────────────────────────────────────────────────

--- a/cli/src/commands/RecallCommand.ts
+++ b/cli/src/commands/RecallCommand.ts
@@ -17,12 +17,14 @@ import { dirname } from "node:path";
 import { type Command, Option } from "commander";
 import type { BranchCatalog } from "../core/ContextCompiler.js";
 import {
-	buildRecallPayload,
 	compileTaskContext,
 	DEFAULT_TOKEN_BUDGET,
 	listBranchCatalog,
 	renderContextMarkdown,
 } from "../core/ContextCompiler.js";
+import { resolveRecall } from "../core/RecallResolver.js";
+import { createStorage } from "../core/StorageFactory.js";
+import { setActiveStorage } from "../core/SummaryStore.js";
 import { collectAllTopics } from "../core/SummaryTree.js";
 import { setLogDir } from "../Logger.js";
 import type { CommitSummary } from "../Types.js";
@@ -153,13 +155,31 @@ function renderShortSummary(ctx: {
 }
 
 /**
- * Loads and outputs recalled development context for a branch.
+ * Writes `body` to `outputPath`, creating parent dirs as needed (the `mkdir -p`
+ * ergonomic users expect from a `--output some/nested/path` flag — `writeFile`
+ * itself does not create them, so a fresh repo would otherwise ENOENT).
+ */
+async function writeOutputFile(outputPath: string, body: string): Promise<void> {
+	const parent = dirname(outputPath);
+	if (parent && parent !== ".") {
+		await mkdir(parent, { recursive: true });
+	}
+	await writeFile(outputPath, body, "utf-8");
+}
+
+/**
+ * Loads and outputs recalled development context for a branch (the non-JSON
+ * modes; `--format json` is handled directly in the command action so CLI and
+ * MCP produce byte-identical payloads).
  *
  * Output modes (in priority order):
  * 1. `--output <path>` — writes full markdown to file, prints confirmation line.
- * 2. `--format json` — outputs full JSON (for skill/agent consumption).
- * 3. `--full` — outputs full markdown to stdout.
- * 4. Default — outputs short summary to stdout (terminal-friendly).
+ * 2. `--full` / `--format md` — outputs full markdown to stdout.
+ * 3. Default — outputs short summary to stdout (terminal-friendly).
+ *
+ * Note: `--format json` does NOT reach here — it is intercepted earlier in the
+ * action. When combined with `--output`, the JSON path writes the JSON payload
+ * to the file (see the command action), so `--output` is never silently dropped.
  */
 async function outputRecall(
 	branch: string,
@@ -186,51 +206,28 @@ async function outputRecall(
 	);
 
 	if (ctx.commitCount === 0) {
-		if (options.format === "json") {
-			console.log(
-				JSON.stringify({ type: "error", message: `No Jolli Memory records found for branch "${branch}".` }),
-			);
-		} else {
-			console.log(`No Jolli Memory records found for branch "${branch}".`);
-		}
+		console.log(`No Jolli Memory records found for branch "${branch}".`);
 		return;
 	}
 
 	// Output path 1: --output <file> -> always writes full markdown to file
 	if (options.output) {
 		const markdown = renderContextMarkdown(ctx, options.budget ?? DEFAULT_TOKEN_BUDGET);
-		// Ensure parent dir exists — writeFile itself does not create it, so
-		// `--output some/nested/path.md` on a fresh repo would otherwise ENOENT.
-		// Matches the `mkdir -p`-style ergonomic users expect from --output flags.
-		const parent = dirname(options.output);
-		if (parent && parent !== ".") {
-			await mkdir(parent, { recursive: true });
-		}
-		await writeFile(options.output, markdown, "utf-8");
+		await writeOutputFile(options.output, markdown);
 		console.log(
 			`Context written to ${options.output} (${ctx.stats.totalTokens.toLocaleString()} tokens, ${ctx.commitCount} commit${ctx.commitCount === 1 ? "" : "s"})`,
 		);
 		return;
 	}
 
-	// Output path 2: --format json -> structured RecallPayload for skill/agent
-	// consumption. The skill template's LLM does its own grounded synthesis
-	// from the structured fields; we deliberately do NOT pre-render markdown
-	// here (it would tempt the LLM back into paraphrase mode).
-	if (options.format === "json") {
-		const payload = buildRecallPayload(ctx, options.budget ?? DEFAULT_TOKEN_BUDGET);
-		console.log(JSON.stringify(payload));
-		return;
-	}
-
-	// Output path 3: --full or --format md -> full markdown to stdout
+	// Output path 2: --full or --format md -> full markdown to stdout
 	if (options.full || options.format === "md") {
 		const markdown = renderContextMarkdown(ctx, options.budget ?? DEFAULT_TOKEN_BUDGET);
 		console.log(markdown);
 		return;
 	}
 
-	// Output path 4: default -> short summary for terminal viewing
+	// Output path 3: default -> short summary for terminal viewing
 	console.log(renderShortSummary(ctx));
 }
 
@@ -260,6 +257,14 @@ export function registerRecallCommand(program: Command): void {
 			try {
 				const projectDir = options.cwd;
 				setLogDir(projectDir);
+				// Establish the configured storage backend before any read — same as
+				// the MCP server (McpServer.startMcpServer). resolveRecall and the
+				// text/catalog paths below read through the store APIs without
+				// threading `storage`, so without this they fall through resolveStorage
+				// to the orphan branch. For folder-mode users that diverges from what
+				// the MCP `recall` tool returns, breaking the CLI/MCP parity this
+				// command's JSON mode is built to guarantee.
+				setActiveStorage(await createStorage(projectDir, projectDir));
 
 				// --arg-stdin is mutually exclusive with positional words. The skill
 				// template's here-doc pipeline relies on stdin being the single
@@ -314,6 +319,31 @@ export function registerRecallCommand(program: Command): void {
 					return;
 				}
 
+				// JSON mode: delegate entirely to resolveRecall so CLI and MCP produce
+				// byte-identical output. Non-JSON modes keep their existing text paths.
+				if (options.format === "json") {
+					const result = await resolveRecall(branchOrKeyword, projectDir, {
+						budget: options.budget,
+						depth: options.depth,
+						includeTranscripts: options.includeTranscripts,
+						includePlans: options.plans !== false,
+					});
+					const payload = JSON.stringify(result);
+					// `--output` is honored in JSON mode too: write the SAME payload
+					// that would go to stdout to the file. Previously this branch
+					// short-circuited to stdout before the markdown `--output` path
+					// could run, so `--format json --output FILE` silently dropped
+					// the file. Writing the JSON keeps both flags meaningful.
+					if (options.output) {
+						await writeOutputFile(options.output, payload);
+						console.log(`Recall context (JSON) written to ${options.output}`);
+					} else {
+						console.log(payload);
+					}
+					if (result.type === "error") process.exitCode = 1;
+					return;
+				}
+
 				// Resolve branch: explicit arg, or current git branch
 				let branch = branchOrKeyword as string | undefined;
 				if (!branch) {
@@ -340,38 +370,21 @@ export function registerRecallCommand(program: Command): void {
 						return;
 					}
 
-					// No exact match — return catalog with query for LLM semantic matching
-					if (options.format === "json") {
-						console.log(JSON.stringify({ ...catalog, query: branch }));
-					} else {
-						console.log(renderCatalogText(catalog, branch));
-					}
+					// No exact match — show catalog with query hint for text mode
+					console.log(renderCatalogText(catalog, branch));
 					return;
 				}
 
 				// No branch at all — check current branch in catalog, else return catalog
 				if (catalog.branches.length === 0) {
-					if (options.format === "json") {
-						console.log(
-							JSON.stringify({
-								type: "error",
-								message: "No Jolli Memory records found in this repository.",
-							}),
-						);
-					} else {
-						console.log(
-							'No Jolli Memory records found in this repository.\nRun "jolli enable" to start recording.',
-						);
-					}
+					console.log(
+						'No Jolli Memory records found in this repository.\nRun "jolli enable" to start recording.',
+					);
 					return;
 				}
 
 				// Fallback: return catalog
-				if (options.format === "json") {
-					console.log(JSON.stringify(catalog));
-				} else {
-					console.log(renderCatalogText(catalog));
-				}
+				console.log(renderCatalogText(catalog));
 			} catch (error: unknown) {
 				const message = error instanceof Error ? error.message : String(error);
 				if (options.format === "json") {

--- a/cli/src/commands/SearchCommand.test.ts
+++ b/cli/src/commands/SearchCommand.test.ts
@@ -1,23 +1,23 @@
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { parseHashList, registerSearchCommand } from "./SearchCommand.js";
+import { registerSearchCommand } from "./SearchCommand.js";
 
-vi.mock("../core/SummaryStore.js", async () => {
-	const actual = await vi.importActual<typeof import("../core/SummaryStore.js")>("../core/SummaryStore.js");
-	return {
-		// Re-export the real AmbiguousHashError so `instanceof` checks in
-		// LocalSearchProvider see the same class the tests would throw.
-		AmbiguousHashError: actual.AmbiguousHashError,
-		getCatalogWithLazyBuild: vi.fn(async () => ({ version: 1, entries: [] })),
-		getIndex: vi.fn(async () => null),
-		getSummary: vi.fn(async () => null),
-	};
-});
+// Mock SearchHits so we don't need a real repo/index on disk.
+vi.mock("../core/SearchHits.js", () => ({
+	searchHits: vi.fn(async () => []),
+}));
 
-import { getCatalogWithLazyBuild, getIndex } from "../core/SummaryStore.js";
+// Mock StorageFactory so the command's `createStorage` call is hermetic (does not
+// read the developer's real ~/.jolli config) and returns a stable sentinel that
+// flows through setActiveStorage → getActiveStorage into the searchHits 3rd arg.
+const fakeStorage = { __fake: "storage" } as unknown as import("../core/StorageProvider.js").StorageProvider;
+vi.mock("../core/StorageFactory.js", () => ({
+	createStorage: vi.fn(async () => fakeStorage),
+}));
 
-const mockGetIndex = vi.mocked(getIndex);
-const mockGetCatalog = vi.mocked(getCatalogWithLazyBuild);
+import { searchHits } from "../core/SearchHits.js";
+
+const mockSearchHits = vi.mocked(searchHits);
 
 vi.mock("node:fs/promises", async () => {
 	const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
@@ -29,82 +29,11 @@ vi.mock("node:fs/promises", async () => {
 });
 
 import { mkdir, writeFile } from "node:fs/promises";
-import { getSummary } from "../core/SummaryStore.js";
 
-const mockGetSummary = vi.mocked(getSummary);
 const mockMkdir = vi.mocked(mkdir);
 const mockWriteFile = vi.mocked(writeFile);
 
-// ─── parseHashList ───────────────────────────────────────────────────────────
-
-describe("parseHashList", () => {
-	it("returns null for empty/whitespace", () => {
-		expect(parseHashList(undefined)).toBeNull();
-		expect(parseHashList("")).toBeNull();
-		expect(parseHashList("   ")).toBeNull();
-	});
-
-	it("parses single hex hash", () => {
-		expect(parseHashList("abcd1234abcd1234abcd1234abcd1234abcd1234")).toEqual([
-			"abcd1234abcd1234abcd1234abcd1234abcd1234",
-		]);
-	});
-
-	it("parses comma-separated hashes", () => {
-		expect(
-			parseHashList("abcd1234abcd1234abcd1234abcd1234abcd1234,deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
-		).toEqual(["abcd1234abcd1234abcd1234abcd1234abcd1234", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"]);
-	});
-
-	it("rejects hashes shorter than 8 characters", () => {
-		// Below 8 we don't try to resolve — the catalog never emits anything
-		// shorter, and very short inputs would just produce ambiguous matches.
-		expect(parseHashList("abc")).toBeNull();
-		expect(parseHashList("1234567")).toBeNull();
-	});
-
-	it("accepts 8-char abbreviations (matches the catalog's `hash` field length)", () => {
-		// Once getSummary resolves abbrevs via in-memory index prefix scan
-		// (returning AmbiguousHashError for collisions instead of silently
-		// picking one), the CLI boundary can safely accept either `hit.hash`
-		// (8-char) or `hit.fullHash` (40-char) from the catalog output.
-		expect(parseHashList("abcd1234")).toEqual(["abcd1234"]);
-		expect(parseHashList("abcd1234,deadbeef")).toEqual(["abcd1234", "deadbeef"]);
-		// Mixed lengths in the same call: one 8-char abbrev, one full 40-char SHA.
-		expect(parseHashList("abcd1234,abcd1234abcd1234abcd1234abcd1234abcd1234")).toEqual([
-			"abcd1234",
-			"abcd1234abcd1234abcd1234abcd1234abcd1234",
-		]);
-	});
-
-	it("rejects hashes longer than 40 characters", () => {
-		// 41 hex chars: longer than any real SHA-1 — likely garbage / typo.
-		expect(parseHashList("abcd1234abcd1234abcd1234abcd1234abcd12345")).toBeNull();
-	});
-
-	it("rejects trailing comma", () => {
-		expect(parseHashList("abcd1234abcd1234abcd1234abcd1234abcd1234,")).toBeNull();
-	});
-
-	it("rejects whitespace inside hashes", () => {
-		// Even a 40-char value gets rejected if there's whitespace inside.
-		expect(parseHashList("abcd1234 abcd1234abcd1234abcd1234abcd123")).toBeNull();
-	});
-
-	it("rejects non-hex characters", () => {
-		// "z" is not a valid hex digit.
-		expect(parseHashList("zzz12345abcd1234abcd1234abcd1234abcd1234")).toBeNull();
-		expect(parseHashList("abcd123g")).toBeNull(); // 8 chars, "g" is not hex
-	});
-
-	it("normalizes mixed case to lowercase", () => {
-		expect(parseHashList("AbCd1234abcd1234abcd1234abcd1234abcd1234")).toEqual([
-			"abcd1234abcd1234abcd1234abcd1234abcd1234",
-		]);
-	});
-});
-
-// ─── registerSearchCommand integration ───────────────────────────────────────
+// ─── test harness ────────────────────────────────────────────────────────────
 
 function makeProgram(): Command {
 	const program = new Command();
@@ -133,6 +62,20 @@ async function runCommand(args: string[]): Promise<{ stdout: string; stderr: str
 	return { stdout, stderr };
 }
 
+async function runWithStdin(args: string[], stdinPayload: string): Promise<{ stdout: string; stderr: string }> {
+	const { Readable } = await import("node:stream");
+	const origStdin = process.stdin;
+	const stream = Readable.from([stdinPayload]);
+	Object.defineProperty(process, "stdin", { value: stream, configurable: true });
+	try {
+		return await runCommand(args);
+	} finally {
+		Object.defineProperty(process, "stdin", { value: origStdin, configurable: true });
+	}
+}
+
+// ─── registerSearchCommand ────────────────────────────────────────────────────
+
 describe("registerSearchCommand", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -142,497 +85,204 @@ describe("registerSearchCommand", () => {
 		process.exitCode = undefined;
 	});
 
-	it("default JSON output for an empty repo", async () => {
-		const { stdout } = await runCommand(["auth", "--cwd", "/tmp/jolli-search-test-empty"]);
-		expect(stdout).toContain('"type": "search-catalog"');
+	// ─── {hits} JSON output ───────────────────────────────────────────────────
+
+	it("emits {hits} JSON for a valid query (empty hit list from mock)", async () => {
+		const { stdout } = await runCommand(["auth", "--format", "json", "--cwd", "/tmp/jolli-search-test"]);
+		const parsed = JSON.parse(stdout);
+		expect(parsed).toHaveProperty("hits");
+		expect(Array.isArray(parsed.hits)).toBe(true);
 	});
 
-	it("text format prints human-readable header", async () => {
-		const { stdout } = await runCommand(["auth", "--format", "text", "--cwd", "/tmp/jolli-search-test-empty"]);
-		expect(stdout).toContain("Search catalog");
+	it("passes query and options through to searchHits", async () => {
+		await runCommand(["auth flow", "--limit", "5", "--branch", "main", "--type", "topic", "--cwd", "/tmp/t"]);
+		expect(mockSearchHits).toHaveBeenCalledWith(
+			"/tmp/t",
+			expect.objectContaining({ query: "auth flow", limit: 5, branch: "main", type: "topic" }),
+			fakeStorage,
+		);
 	});
 
-	it("rejects unsafe shell chars in query (deny-list) and sets non-zero exit code", async () => {
-		// `$(date)` violates the query deny-list ($ is blocked because it triggers
-		// shell expansion inside double quotes). Pass as a single positional so
-		// commander doesn't treat any token as a flag.
-		const { stdout } = await runCommand(["foo$(date)", "--cwd", "/tmp/jolli-search-test-empty"]);
-		expect(stdout).toContain('"type":"error"');
-		expect(stdout).toContain("Invalid characters");
-		// Exit code must be set even when --format json (callers shouldn't have to
-		// parse JSON to know there was an error).
+	it("emits populated hits in JSON output", async () => {
+		mockSearchHits.mockResolvedValueOnce([
+			{
+				id: "id1",
+				type: "topic",
+				title: "Auth flow design",
+				snippet: "We chose JWT",
+				branch: "feature/auth",
+				commitDate: "2026-04-01T10:00:00.000Z",
+				slug: "auth-flow-design",
+				hash: "abcd1234",
+				score: 0.9,
+			},
+		]);
+		const { stdout } = await runCommand(["auth", "--cwd", "/tmp/t"]);
+		const parsed = JSON.parse(stdout);
+		expect(parsed.hits).toHaveLength(1);
+		expect(parsed.hits[0].title).toBe("Auth flow design");
+		expect(parsed.hits[0].hash).toBe("abcd1234");
+	});
+
+	// ─── empty query → non-zero exit ─────────────────────────────────────────
+
+	it("rejects empty positional query with non-zero exit", async () => {
+		const { stdout } = await runCommand(["--cwd", "/tmp/t"]);
+		const parsed = JSON.parse(stdout);
+		expect(parsed.type).toBe("error");
+		expect(parsed.message).toContain("query is required");
 		expect(process.exitCode).toBe(1);
 	});
 
+	it("--arg-stdin with empty stdin rejects with non-zero exit", async () => {
+		const { code: _code, ...result } = await (async () => {
+			const r = await runWithStdin(["--arg-stdin", "--cwd", "/tmp/t"], "");
+			return { ...r, code: process.exitCode };
+		})();
+		const parsed = JSON.parse(result.stdout);
+		expect(parsed.type).toBe("error");
+		expect(parsed.message).toContain("query is required");
+		expect(process.exitCode).toBe(1);
+	});
+
+	// ─── isSafeQuery validation (gated on --arg-stdin only) ───────────────────
+
+	it("accepts unsafe shell chars on the direct argv path (MCP parity — no shell, no validation)", async () => {
+		// isSafeQuery only guards the --arg-stdin here-doc bridge: that is the one
+		// path where the query is interpolated into a shell. A direct argv query
+		// never re-enters a shell and flows straight into the in-process index, so
+		// it must accept `$`/backticks exactly like the MCP `search` tool — that is
+		// the documented "CLI fallback === MCP primary" parity.
+		const { stdout } = await runCommand(["foo$(date)", "--cwd", "/tmp/t"]);
+		const parsed = JSON.parse(stdout);
+		expect(parsed).toHaveProperty("hits");
+		expect(mockSearchHits).toHaveBeenCalledWith(
+			"/tmp/t",
+			expect.objectContaining({ query: "foo$(date)" }),
+			fakeStorage,
+		);
+		expect(process.exitCode).toBeUndefined();
+	});
+
 	it("accepts natural-language punctuation in queries", async () => {
-		// `?` `(` `)` `:` `,` `'` `!` were rejected by the old strict pattern but
-		// must pass under the new deny-list. Use a sentence with a question mark.
-		const { stdout } = await runCommand(["why did we choose X over Y?", "--cwd", "/tmp/jolli-search-test-empty"]);
-		expect(stdout).not.toContain('"type":"error"');
-		expect(stdout).toContain('"type": "search-catalog"');
+		const { stdout } = await runCommand(["why did we choose X over Y?", "--cwd", "/tmp/t"]);
+		const parsed = JSON.parse(stdout);
+		expect(parsed).toHaveProperty("hits");
 	});
 
-	it("accepts # and parentheses in queries (ticket lookup, parenthetical)", async () => {
-		const { stdout } = await runCommand(["#789 (token bucket)", "--cwd", "/tmp/jolli-search-test-empty"]);
-		expect(stdout).not.toContain('"type":"error"');
+	it("accepts # and parentheses in queries", async () => {
+		const { stdout } = await runCommand(["#789 (token bucket)", "--cwd", "/tmp/t"]);
+		const parsed = JSON.parse(stdout);
+		expect(parsed).toHaveProperty("hits");
 	});
 
-	it("rejects invalid --hashes", async () => {
-		const { stdout } = await runCommand(["auth", "--hashes", "xyz", "--cwd", "/tmp/jolli-search-test-empty"]);
-		expect(stdout).toContain('"type":"error"');
-	});
+	// ─── text format ──────────────────────────────────────────────────────────
 
-	it("rejects --hashes that don't fit the 8-40 hex pattern (too short / non-hex)", async () => {
-		// Abbreviated SHAs ≥ 8 are now ACCEPTED — `getSummary` resolves them via
-		// in-memory index prefix scan with explicit AmbiguousHashError on collisions,
-		// so the boundary no longer has to enforce "full SHA only". Inputs that
-		// don't look like a hex SHA at all (too short, non-hex chars) still error.
-		const { stdout } = await runCommand([
-			"auth",
-			"--hashes",
-			"abc,defg", // both segments < 8 chars
-			"--cwd",
-			"/tmp/jolli-search-test-empty",
+	it("text format prints one line per hit", async () => {
+		mockSearchHits.mockResolvedValueOnce([
+			{
+				id: "id1",
+				type: "commit",
+				title: "Auth refactor",
+				snippet: "Rewrote auth",
+				branch: "feature/auth",
+				commitDate: "2026-04-01T10:00:00.000Z",
+				slug: "auth-refactor",
+				hash: "deadbeef",
+				score: 0.8,
+			},
 		]);
-		expect(stdout).toContain('"type":"error"');
-		expect(stdout).toContain("8 to 40 characters");
-	});
-
-	it("requires query when --hashes is provided", async () => {
-		const { stdout } = await runCommand([
-			"--hashes",
-			"abcd1234abcd1234abcd1234abcd1234abcd1234",
-			"--cwd",
-			"/tmp/jolli-search-test-empty",
-		]);
-		expect(stdout).toContain('"type":"error"');
-		expect(stdout).toContain("query is required");
-	});
-
-	it("rejects invalid --since instead of silently disabling the filter", async () => {
-		// Regression: earlier `--since=lastweek` parsed to null (treated as no
-		// filter), broadening results instead of erroring. Now buildCatalog
-		// throws, the action's outer try/catch emits a JSON error.
-		const { stdout } = await runCommand(["auth", "--since", "lastweek", "--cwd", "/tmp/jolli-search-test-empty"]);
-		expect(stdout).toContain('"type":"error"');
-		expect(stdout).toContain("Invalid --since");
-	});
-
-	it("Phase 2 path: returns search result for picked hash", async () => {
-		mockGetSummary.mockResolvedValueOnce({
-			version: 4,
-			commitHash: "abcd1234abcd1234abcd1234abcd1234abcd1234",
-			commitMessage: "msg",
-			commitAuthor: "dev",
-			commitDate: "2026-04-01T00:00:00.000Z",
-			branch: "x",
-			generatedAt: "2026-04-01T00:00:00.000Z",
-			recap: "Did auth work",
-			topics: [
-				{
-					title: "Auth",
-					trigger: "T",
-					response: "R",
-					decisions: "auth jwt",
-				},
-			],
-		});
-		const { stdout } = await runCommand([
-			"auth",
-			"--hashes",
-			"abcd1234abcd1234abcd1234abcd1234abcd1234",
-			"--cwd",
-			"/tmp/jolli-search-test-found",
-		]);
-		expect(stdout).toContain('"type": "search"');
-		expect(stdout).toContain("abcd1234abcd1234abcd1234abcd1234abcd1234");
-	});
-
-	it("Phase 2 path: 8-char abbreviated hash flows end-to-end through getSummary's prefix scan", async () => {
-		// Integration coverage for the loosened HASH_LIST_PATTERN: parseHashList
-		// accepts the 8-char abbrev, the CLI passes it to LocalSearchProvider,
-		// which passes it to getSummary, which (in production) resolves it via
-		// the new in-memory prefix scan. Mock returns a summary keyed at the
-		// FULL 40-char SHA — buildHit then renders `hit.hash` as the first 8.
-		const fullHash = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
-		mockGetSummary.mockResolvedValueOnce({
-			version: 4,
-			commitHash: fullHash,
-			commitMessage: "feat: thing",
-			commitAuthor: "dev",
-			commitDate: "2026-04-01T00:00:00.000Z",
-			branch: "feature/thing",
-			generatedAt: "2026-04-01T00:00:00.000Z",
-			recap: "Did the thing",
-			topics: [{ title: "T", trigger: "tr", response: "rs", decisions: "d" }],
-		});
-		const { stdout } = await runCommand([
-			"thing",
-			"--hashes",
-			"deadbeef", // 8-char abbreviation
-			"--cwd",
-			"/tmp/jolli-search-test-abbrev",
-		]);
-		expect(stdout).toContain('"type": "search"');
-		// LocalSearchProvider was called with the abbreviated form (CLI doesn't
-		// expand to full SHA — that's getSummary's job in real use).
-		expect(mockGetSummary).toHaveBeenCalledTimes(1);
-		expect(mockGetSummary.mock.calls[0][0]).toBe("deadbeef");
-		// The result contains the full 40-char SHA (returned by getSummary)
-		// and the 8-char display hash matches the abbreviation.
-		expect(stdout).toContain(fullHash);
-	});
-
-	it("Phase 2 path: dedupes duplicate --hashes input", async () => {
-		// Regression: a copy-pasted list with accidental duplicates shouldn't
-		// double-load the same summary. parseHashList collapses duplicates
-		// into a single entry, so getSummary is only invoked once per unique
-		// hash.
-		mockGetSummary.mockResolvedValue({
-			version: 4,
-			commitHash: "abcd1234abcd1234abcd1234abcd1234abcd1234",
-			commitMessage: "m",
-			commitAuthor: "d",
-			commitDate: "2026-04-01T00:00:00.000Z",
-			branch: "b",
-			generatedAt: "2026-04-01T00:00:00.000Z",
-			topics: [],
-		});
-		await runCommand(["q", "--hashes", "abcd1234,abcd1234,abcd1234", "--cwd", "/tmp/jolli-search-test-dedupe"]);
-		expect(mockGetSummary).toHaveBeenCalledTimes(1);
-	});
-
-	it("--output writes file and prints confirmation", async () => {
-		const { stdout } = await runCommand([
-			"auth",
-			"--output",
-			"/tmp/out.json",
-			"--cwd",
-			"/tmp/jolli-search-test-empty",
-		]);
-		expect(mockWriteFile).toHaveBeenCalled();
-		expect(mockMkdir).toHaveBeenCalled();
-		expect(stdout).toContain("Search output written to");
-	});
-
-	it("Phase 2 text format renders the populated-results path", async () => {
-		mockGetSummary.mockResolvedValueOnce({
-			version: 4,
-			commitHash: "abcd1234abcd1234abcd1234abcd1234abcd1234",
-			commitMessage: "feat: add auth",
-			commitAuthor: "dev",
-			commitDate: "2026-04-01T00:00:00.000Z",
-			branch: "feature/auth",
-			generatedAt: "2026-04-01T00:00:00.000Z",
-			recap: "Auth flow",
-			topics: [
-				{
-					title: "Auth",
-					trigger: "T",
-					response: "R",
-					decisions: "auth picked JWT",
-				},
-			],
-		});
-		const { stdout } = await runCommand([
-			"auth",
-			"--hashes",
-			"abcd1234abcd1234abcd1234abcd1234abcd1234",
-			"--format",
-			"text",
-			"--cwd",
-			"/tmp/jolli-search-test-found",
-		]);
-		expect(stdout).toContain("Search hits");
-		// Text renderer prints `hit.hash` (8-char display abbreviation), not the
-		// 40-char fullHash — see renderResultText in SearchCommand.ts.
-		expect(stdout).toContain("abcd1234 ");
+		const { stdout } = await runCommand(["auth", "--format", "text", "--cwd", "/tmp/t"]);
+		expect(stdout).toContain("deadbeef");
 		expect(stdout).toContain("feature/auth");
+		expect(stdout).toContain("2026-04-01");
+		expect(stdout).toContain("Auth refactor");
 	});
 
-	it("Phase 2 text format renders the empty-results path", async () => {
-		mockGetSummary.mockResolvedValueOnce(null);
-		const { stdout } = await runCommand([
-			"auth",
-			"--hashes",
-			"abcd1234abcd1234abcd1234abcd1234abcd1234",
-			"--format",
-			"text",
-			"--cwd",
-			"/tmp/jolli-search-test-found",
-		]);
-		expect(stdout).toContain("none of the requested hashes resolved");
+	it("text format renders empty-hits path", async () => {
+		// mockSearchHits returns [] by default
+		const { stdout } = await runCommand(["notfound", "--format", "text", "--cwd", "/tmp/t"]);
+		expect(stdout).toContain("(no hits matched the query)");
 	});
 
 	it("text format error path writes to stderr and sets exitCode", async () => {
-		const { stdout, stderr } = await runCommand([
-			"foo$(date)",
-			"--format",
-			"text",
-			"--cwd",
-			"/tmp/jolli-search-test-empty",
-		]);
-		// Text-format error goes to stderr, not stdout; exitCode is set non-zero.
+		// Trigger the text-format emitError path via the --arg-stdin validation
+		// (the one path where unsafe chars are still rejected), since a direct argv
+		// unsafe query is now accepted (MCP parity).
+		const { stdout, stderr } = await runWithStdin(
+			["--arg-stdin", "--format", "text", "--cwd", "/tmp/t"],
+			"$(date)\n",
+		);
 		expect(stdout).toBe("");
 		expect(stderr).toContain("Error:");
-		expect(process.exitCode).not.toBe(0);
+		expect(process.exitCode).toBe(1);
 	});
 
-	it("catches and reports runtime errors from the provider", async () => {
-		mockGetSummary.mockImplementationOnce(async () => {
-			throw new Error("simulated storage failure");
-		});
-		const { stdout } = await runCommand([
-			"auth",
-			"--hashes",
-			"abcd1234abcd1234abcd1234abcd1234abcd1234",
-			"--cwd",
-			"/tmp/jolli-search-test-found",
-		]);
-		expect(stdout).toContain('"type":"error"');
-		expect(stdout).toContain("simulated storage failure");
-	});
+	// ─── --output ─────────────────────────────────────────────────────────────
 
-	it("--output also works for Phase 2", async () => {
-		mockGetSummary.mockResolvedValueOnce({
-			version: 4,
-			commitHash: "abcd1234abcd1234abcd1234abcd1234abcd1234",
-			commitMessage: "msg",
-			commitAuthor: "dev",
-			commitDate: "2026-04-01T00:00:00.000Z",
-			branch: "x",
-			generatedAt: "2026-04-01T00:00:00.000Z",
-			topics: [{ title: "t", trigger: "auth", response: "r", decisions: "d" }],
-		});
-		await runCommand([
-			"auth",
-			"--hashes",
-			"abcd1234abcd1234abcd1234abcd1234abcd1234",
-			"--output",
-			"sub/dir/result.json",
-			"--cwd",
-			"/tmp/jolli-search-test-found",
-		]);
+	it("--output writes file and prints confirmation", async () => {
+		const { stdout } = await runCommand(["auth", "--output", "sub/dir/out.json", "--cwd", "/tmp/t"]);
+		expect(mockMkdir).toHaveBeenCalled();
 		expect(mockWriteFile).toHaveBeenCalled();
+		expect(stdout).toContain("Search output written to");
 	});
 
-	it("--output skips mkdir when path has no parent", async () => {
+	it("--output skips mkdir when path has no parent dir", async () => {
 		mockMkdir.mockClear();
-		await runCommand(["auth", "--output", "result.json", "--cwd", "/tmp/jolli-search-test-empty"]);
+		await runCommand(["auth", "--output", "result.json", "--cwd", "/tmp/t"]);
 		// dirname("result.json") === "." → mkdir is skipped
 		expect(mockMkdir).not.toHaveBeenCalled();
 		expect(mockWriteFile).toHaveBeenCalled();
 	});
 
-	it("default Phase 1 with --since and --limit echoes filter back", async () => {
-		const { stdout } = await runCommand([
-			"auth",
-			"--since",
-			"7d",
-			"--limit",
-			"50",
-			"--budget",
-			"4000",
-			"--cwd",
-			"/tmp/jolli-search-test-empty",
-		]);
-		const result = JSON.parse(stdout);
-		expect(result.filter).toEqual({ since: "7d", limit: 50 });
-	});
+	// ─── runtime errors ───────────────────────────────────────────────────────
 
-	it("Phase 1 text format renders entries WITHOUT decorations (falsy branches)", async () => {
-		mockGetIndex.mockResolvedValueOnce({
-			version: 3,
-			entries: [
-				{
-					commitHash: "minimalcommithash01",
-					parentCommitHash: null,
-					branch: "x",
-					commitMessage: "msg",
-					commitDate: "2026-04-01T10:00:00.000Z",
-					generatedAt: "2026-04-01T10:01:00.000Z",
-				},
-			],
+	it("catches and reports runtime errors from searchHits", async () => {
+		mockSearchHits.mockImplementationOnce(async () => {
+			throw new Error("simulated storage failure");
 		});
-		mockGetCatalog.mockResolvedValueOnce({
-			version: 1,
-			entries: [
-				{
-					commitHash: "minimalcommithash01",
-					// No recap, no ticketId
-					topics: [{ title: "Plain Topic" }], // no category, importance, etc.
-				},
-			],
-		});
-		const { stdout } = await runCommand(["q", "--format", "text", "--cwd", "/tmp/jolli-search-test-minimal"]);
-		expect(stdout).toContain("Plain Topic");
-		// No ticket badge / recap / category / star.
-		expect(stdout).not.toContain("[TKT");
-		expect(stdout).not.toContain("[feature]");
-		expect(stdout).not.toContain("★");
-	});
-
-	it("Phase 1 text format shows '(truncated)' marker when result is capped", async () => {
-		const entries: Array<{
-			commitHash: string;
-			parentCommitHash: null;
-			branch: string;
-			commitMessage: string;
-			commitDate: string;
-			generatedAt: string;
-		}> = [];
-		for (let i = 0; i < 3; i++) {
-			entries.push({
-				commitHash: `cmt${i}aaa00000000000000`.slice(0, 16),
-				parentCommitHash: null,
-				branch: "x",
-				commitMessage: `m${i}`,
-				commitDate: `2026-04-0${i + 1}T10:00:00.000Z`,
-				generatedAt: `2026-04-0${i + 1}T10:01:00.000Z`,
-			});
-		}
-		mockGetIndex.mockResolvedValueOnce({ version: 3, entries });
-		mockGetCatalog.mockResolvedValueOnce({ version: 1, entries: [] });
-		const { stdout } = await runCommand([
-			"q",
-			"--limit",
-			"2",
-			"--format",
-			"text",
-			"--cwd",
-			"/tmp/jolli-search-test-trunc",
-		]);
-		expect(stdout).toContain("(truncated)");
-	});
-
-	it("Phase 1 text format shows '(no commits matched)' on empty catalog", async () => {
-		const { stdout } = await runCommand(["q", "--format", "text", "--cwd", "/tmp/jolli-search-test-none"]);
-		expect(stdout).toContain("(no commits matched the filter)");
-	});
-
-	it("Phase 1 text format renders populated entries with all decorations", async () => {
-		mockGetIndex.mockResolvedValueOnce({
-			version: 3,
-			entries: [
-				{
-					commitHash: "deadbeef00deadbeef00deadbeef00deadbeef00",
-					parentCommitHash: null,
-					branch: "feature/x",
-					commitMessage: "msg",
-					commitDate: "2026-04-01T10:00:00.000Z",
-					generatedAt: "2026-04-01T10:01:00.000Z",
-				},
-			],
-		});
-		mockGetCatalog.mockResolvedValueOnce({
-			version: 1,
-			entries: [
-				{
-					commitHash: "deadbeef00deadbeef00deadbeef00deadbeef00",
-					recap: "Recap line",
-					ticketId: "PROJ-9",
-					topics: [{ title: "Major Topic", category: "feature", importance: "major" }],
-				},
-			],
-		});
-		const { stdout } = await runCommand(["auth", "--format", "text", "--cwd", "/tmp/jolli-search-test-rendered"]);
-		expect(stdout).toContain("Search catalog");
-		expect(stdout).toContain("[PROJ-9]");
-		expect(stdout).toContain("Recap line");
-		expect(stdout).toContain("[feature]");
-		expect(stdout).toContain("★");
+		const { stdout } = await runCommand(["auth", "--cwd", "/tmp/t"]);
+		const parsed = JSON.parse(stdout);
+		expect(parsed.type).toBe("error");
+		expect(parsed.message).toContain("simulated storage failure");
+		expect(process.exitCode).toBe(1);
 	});
 
 	it("non-Error thrown values are stringified safely in the catch path", async () => {
-		mockGetSummary.mockImplementationOnce(async () => {
+		mockSearchHits.mockImplementationOnce(async () => {
 			throw "string error not an Error instance";
 		});
-		const { stdout } = await runCommand([
-			"auth",
-			"--hashes",
-			"abcd1234abcd1234abcd1234abcd1234abcd1234",
-			"--cwd",
-			"/tmp/jolli-search-test-found",
-		]);
-		expect(stdout).toContain('"type":"error"');
-		expect(stdout).toContain("string error");
+		const { stdout } = await runCommand(["auth", "--cwd", "/tmp/t"]);
+		const parsed = JSON.parse(stdout);
+		expect(parsed.type).toBe("error");
+		expect(parsed.message).toContain("string error");
 	});
 
-	// ─── --arg-stdin (here-doc bridge from SKILL.md) ─────────────────────
-	// The skill templates pipe user-supplied query text via a here-doc with an
-	// LLM-generated random delimiter; the CLI reads stdin instead of argv so
-	// shell metacharacters never reach a shell parser. These tests confirm
-	// the wiring: stdin content arrives at the search pipeline verbatim,
-	// mutual exclusion with positional args fires, and the empty-stdin case
-	// degrades to the same behavior as an empty positional query.
+	// ─── --arg-stdin ──────────────────────────────────────────────────────────
 
-	async function runWithStdin(args: string[], stdinPayload: string): Promise<{ stdout: string; stderr: string }> {
-		const { Readable } = await import("node:stream");
-		const origStdin = process.stdin;
-		const stream = Readable.from([stdinPayload]);
-		Object.defineProperty(process, "stdin", { value: stream, configurable: true });
-		try {
-			return await runCommand(args);
-		} finally {
-			Object.defineProperty(process, "stdin", { value: origStdin, configurable: true });
-		}
-	}
-
-	it("--arg-stdin reads the query from stdin verbatim (shell metacharacters preserved)", async () => {
-		// `$(date)` is a shell-injection probe — feeding it on stdin must NOT
-		// trigger the deny-list (the user input never went through the shell).
-		// The CLI rejects it because the query content still violates the
-		// `isSafeQuery` policy, but the value the CLI inspected is the literal
-		// string, not a command output.
-		const { stdout } = await runWithStdin(["--arg-stdin", "--cwd", "/tmp/jolli-search-test-empty"], "$(date)\n");
-		// Query is rejected at the validation layer, but the rejection means
-		// the CLI saw the literal `$(date)` — not the shell-expansion result.
-		expect(stdout).toContain('"type":"error"');
-		expect(stdout).toContain("Invalid characters");
+	it("--arg-stdin reads query from stdin verbatim (shell metacharacters rejected at validation)", async () => {
+		const { stdout } = await runWithStdin(["--arg-stdin", "--cwd", "/tmp/t"], "$(date)\n");
+		const parsed = JSON.parse(stdout);
+		expect(parsed.type).toBe("error");
+		expect(parsed.message).toContain("Invalid characters");
 	});
 
-	it("--arg-stdin accepts a safe natural-language query and runs the catalog phase", async () => {
-		const { stdout } = await runWithStdin(
-			["--arg-stdin", "--cwd", "/tmp/jolli-search-test-empty"],
-			"why did we choose X?\n",
+	it("--arg-stdin with safe query calls searchHits", async () => {
+		const { stdout } = await runWithStdin(["--arg-stdin", "--cwd", "/tmp/t"], "why did we choose X?\n");
+		const parsed = JSON.parse(stdout);
+		expect(parsed).toHaveProperty("hits");
+		expect(mockSearchHits).toHaveBeenCalledWith(
+			"/tmp/t",
+			expect.objectContaining({ query: "why did we choose X?" }),
+			fakeStorage,
 		);
-		expect(stdout).toContain('"type": "search-catalog"');
-		expect(stdout).toContain('"query": "why did we choose X?"');
-	});
-
-	it("--arg-stdin with empty stdin behaves like an empty positional query (catalog only)", async () => {
-		const { stdout } = await runWithStdin(["--arg-stdin", "--cwd", "/tmp/jolli-search-test-empty"], "");
-		expect(stdout).toContain('"type": "search-catalog"');
-	});
-
-	it("--arg-stdin combined with --hashes performs the Phase 2 lookup using stdin as the highlight query", async () => {
-		mockGetSummary.mockResolvedValueOnce({
-			version: 4,
-			commitHash: "abcd1234abcd1234abcd1234abcd1234abcd1234",
-			commitMessage: "msg",
-			commitAuthor: "dev",
-			commitDate: "2026-04-01T00:00:00.000Z",
-			branch: "x",
-			generatedAt: "2026-04-01T00:00:00.000Z",
-			topics: [{ title: "t", trigger: "tr", response: "rs", decisions: "d" }],
-		});
-		const { stdout } = await runWithStdin(
-			[
-				"--arg-stdin",
-				"--hashes",
-				"abcd1234abcd1234abcd1234abcd1234abcd1234",
-				"--cwd",
-				"/tmp/jolli-search-test-found",
-			],
-			"auth\n",
-		);
-		expect(stdout).toContain('"type": "search"');
 	});
 
 	it("rejects --arg-stdin combined with positional words (mutually exclusive)", async () => {
-		const { stdout } = await runCommand(["--arg-stdin", "auth", "--cwd", "/tmp/jolli-search-test-empty"]);
-		expect(stdout).toContain('"type":"error"');
-		expect(stdout).toContain("mutually exclusive");
+		const { stdout } = await runCommand(["--arg-stdin", "auth", "--cwd", "/tmp/t"]);
+		const parsed = JSON.parse(stdout);
+		expect(parsed.type).toBe("error");
+		expect(parsed.message).toContain("mutually exclusive");
 		expect(process.exitCode).toBe(1);
 	});
 });

--- a/cli/src/commands/SearchCommand.ts
+++ b/cli/src/commands/SearchCommand.ts
@@ -1,50 +1,25 @@
 /**
  * SearchCommand — `jolli search` CLI command.
  *
- * Provides the catalog-driven two-phase search invoked by the `/jolli-search`
- * skill template:
- *
- *   Phase 1: `jolli search <query> [--since X] [--limit N] [--budget T]`
- *            → outputs SearchCatalog (root-commit catalog for LLM scanning).
- *
- *   Phase 2: `jolli search <query> --hashes h1,h2,h3`
- *            → outputs SearchResult (full distilled content for picked hashes:
- *              recap + topics with trigger/response/decisions/files/category/
- *              importance + diffStats). Skill template Step 5 documents the
- *              schema and lets the LLM pick the render shape.
- *
- * The CLI is a pure function: no LLM calls, deterministic JSON output for the
- * skill template to parse.
+ * Single-phase BM25 search over distilled commit summaries. Emits `{ hits }`
+ * JSON (or a compact text render) — the same result the MCP `search` tool
+ * returns so the skill's CLI fallback is identical to the primary path.
  */
 
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { type Command, Option } from "commander";
-import { LocalSearchProvider } from "../core/LocalSearchProvider.js";
-import { DEFAULT_CATALOG_LIMIT, DEFAULT_SEARCH_BUDGET, type SearchCatalog, type SearchResult } from "../core/Search.js";
+import { searchHits } from "../core/SearchHits.js";
+import type { SearchHitResult } from "../core/SearchIndex.js";
+import { createStorage } from "../core/StorageFactory.js";
+import { getActiveStorage, setActiveStorage } from "../core/SummaryStore.js";
 import { setLogDir } from "../Logger.js";
 import { isSafeQuery, parsePositiveInt, readStdin, resolveProjectDir } from "./CliUtils.js";
 
-/**
- * Pattern matching a comma-separated list of **8- to 40-char hex SHAs**.
- *
- * Accepts abbreviated SHAs (≥ 8 chars, jolli's catalog `hash` field length) up
- * to full 40-char SHAs. The lower bound mirrors what the catalog emits, so the
- * LLM can echo back either `hit.hash` or `hit.fullHash` and have it resolve.
- *
- * Earlier this was locked to exactly 40 because `getSummary`'s tree-hash
- * fallback could silently mis-resolve cherry-pick / rebase twins that share a
- * tree. Once `getSummary` resolves abbreviated input via in-memory index
- * prefix scan (with explicit `AmbiguousHashError` on collisions), the boundary
- * can safely accept abbreviations again.
- */
-const HASH_LIST_PATTERN = /^[0-9a-f]{8,40}(,[0-9a-f]{8,40})*$/i;
-
 interface SearchOptions {
-	since?: string;
-	hashes?: string;
 	limit?: number;
-	budget?: number;
+	branch?: string;
+	type?: "topic" | "commit";
 	format?: "json" | "text";
 	output?: string;
 	cwd?: string;
@@ -52,85 +27,27 @@ interface SearchOptions {
 }
 
 /**
- * Splits a `--hashes` value into a list of trimmed, lowercased hashes.
+ * Renders a list of SearchHitResult as a compact human-readable text block
+ * (used when `--format text` is passed for terminal-friendly inspection).
  *
- * Deduplicates while preserving first-seen order so a copy-pasted list with
- * accidental duplicates (e.g. `abc1234,abc1234`) doesn't double-load the
- * same summary downstream. The order matters because `LocalSearchProvider.
- * loadHits` returns `results` in input order — the caller may rely on that
- * ordering for rendering.
+ * One line per hit: `hash  branch  date  title`
  */
-export function parseHashList(value: string | undefined): ReadonlyArray<string> | null {
-	if (!value) return null;
-	const trimmed = value.trim();
-	if (trimmed.length === 0) return null;
-	if (!HASH_LIST_PATTERN.test(trimmed)) return null;
-	const seen = new Set<string>();
-	const out: string[] = [];
-	for (const raw of trimmed.split(",")) {
-		const h = raw.trim().toLowerCase();
-		if (h.length === 0 || seen.has(h)) continue;
-		seen.add(h);
-		out.push(h);
+function renderHitsText(hits: SearchHitResult[]): string {
+	if (hits.length === 0) {
+		return "(no hits matched the query)";
 	}
-	return out;
-}
-
-/**
- * Renders a SearchCatalog as a compact human-readable text block (used when
- * `--format text` is passed for terminal-friendly inspection).
- */
-function renderCatalogText(catalog: SearchCatalog): string {
-	const lines: string[] = [];
-	lines.push(`Search catalog for "${catalog.query}"`);
-	lines.push(
-		`  ${catalog.entries.length} of ${catalog.totalCandidates} candidates${catalog.truncated ? " (truncated)" : ""}, ~${catalog.estimatedTokens} tokens`,
-	);
-	lines.push("");
-	for (const entry of catalog.entries) {
-		const ticket = entry.ticketId ? ` [${entry.ticketId}]` : "";
-		lines.push(`  ${entry.hash}  ${entry.branch}${ticket}  ${entry.date}`);
-		if (entry.recap) lines.push(`    ${entry.recap}`);
-		for (const t of entry.topics ?? []) {
-			const cat = t.category ? ` [${t.category}]` : "";
-			const imp = t.importance === "major" ? " ★" : "";
-			lines.push(`    - ${t.title}${cat}${imp}`);
-		}
-	}
-	if (catalog.entries.length === 0) {
-		lines.push("  (no commits matched the filter)");
-	}
-	return lines.join("\n");
-}
-
-/** Renders a SearchResult as compact text (Phase 2 fallback). */
-function renderResultText(result: SearchResult): string {
-	const lines: string[] = [];
-	lines.push(`Search hits for "${result.query}" (${result.results.length} of ${result.hashes.length})`);
-	lines.push("");
-	for (const hit of result.results) {
-		lines.push(`  ${hit.hash}  ${hit.branch}  ${hit.commitDate}`);
-		lines.push(`    ${hit.commitMessage.split("\n")[0]}`);
-		// Compact topic-title preview — one line per topic, no decisions/response
-		// dump (text format is for quick inspection, not deep reading; users who
-		// want full content go through `--format json` to a chat or `jolli view
-		// --commit <hash>`).
-		for (const t of hit.topics) {
-			lines.push(`    • ${t.title}`);
-		}
-	}
-	if (result.results.length === 0) {
-		lines.push("  (none of the requested hashes resolved to summaries)");
-	}
-	return lines.join("\n");
+	return hits
+		.map((h) => {
+			const date = h.commitDate.slice(0, 10);
+			return `${h.hash}  ${h.branch}  ${date}  ${h.title}`;
+		})
+		.join("\n");
 }
 
 /**
  * Writes JSON or text output to stdout (or a file when `--output` is given).
  */
 async function writeOutput(payload: unknown, options: SearchOptions, textFallback: () => string): Promise<void> {
-	// `--format` always carries commander's default ("json"), so `options.format`
-	// is non-undefined in practice. We still narrow with the cast for the type.
 	const fmt = options.format as "json" | "text";
 	const body = fmt === "json" ? JSON.stringify(payload, null, 2) : textFallback();
 
@@ -147,37 +64,43 @@ async function writeOutput(payload: unknown, options: SearchOptions, textFallbac
 	console.log(body);
 }
 
+function emitError(options: SearchOptions, message: string): void {
+	const fmt = options.format as "json" | "text";
+	if (fmt === "json") {
+		console.log(JSON.stringify({ type: "error", message }));
+	} else {
+		console.error(`\n  Error: ${message}\n`);
+	}
+	process.exitCode = 1;
+}
+
 /**
  * Registers the `search` command on the given Commander program.
  */
 export function registerSearchCommand(program: Command): void {
 	program
 		.command("search")
-		.description("Search structured commit memories (Phase 1: catalog; Phase 2: --hashes detail load)")
-		.argument("[words...]", "Query keyword(s). Multi-word queries are matched as a single intent.")
-		.option("--since <date>", "Cutoff date — ISO (YYYY-MM-DD) or relative (7d/2w/1m/3y)")
-		.option("--hashes <list>", "Comma-separated list of commit hashes to load full content for (Phase 2)")
-		.option("--limit <n>", `Catalog entry hard cap (default: ${DEFAULT_CATALOG_LIMIT})`, parsePositiveInt)
-		.option(
-			"--budget <tokens>",
-			`Token budget for catalog output (default: ${DEFAULT_SEARCH_BUDGET})`,
-			parsePositiveInt,
-		)
+		.description("Search structured commit memories (BM25 over distilled summaries)")
+		.argument("[words...]", "Query keyword(s)")
+		.option("--limit <n>", "Max hits (default 20)", parsePositiveInt)
+		.option("--branch <branch>", "Restrict to one branch")
+		.addOption(new Option("--type <kind>", "Restrict result kind").choices(["topic", "commit"]))
 		.addOption(new Option("--format <fmt>", "Output format").choices(["json", "text"]).default("json"))
 		.option("--output <path>", "Write output to file instead of stdout")
-		.option("--arg-stdin", "Read the query argument from stdin instead of argv (used by SKILL.md here-doc bridge)")
+		.option("--arg-stdin", "Read the query from stdin (used by SKILL.md here-doc bridge)")
 		.option("--cwd <dir>", "Project directory (default: git repo root)", resolveProjectDir())
 		.action(async (words: string[], options: SearchOptions) => {
 			try {
-				// `--cwd` carries commander's default (resolveProjectDir() at
-				// register time), so it's always defined when the action runs.
 				const projectDir = options.cwd as string;
 				setLogDir(projectDir);
+				// Establish the configured storage backend before any read — same as
+				// the MCP server (McpServer.startMcpServer). Without this, searchHits
+				// falls through resolveStorage to the orphan branch, so a folder-mode
+				// user's `jolli search` (the skill's CLI fallback) would index a
+				// different store than the MCP `search` tool and break the documented
+				// "CLI fallback === MCP primary" parity.
+				setActiveStorage(await createStorage(projectDir, projectDir));
 
-				// --arg-stdin is mutually exclusive with positional words. The skill
-				// template's here-doc pipeline pushes the query via stdin and CLI
-				// flags via argv; allowing both at once would silently concatenate
-				// or drop one side and undermine the injection-defense contract.
 				if (options.argStdin && words.length > 0) {
 					emitError(
 						options,
@@ -186,19 +109,22 @@ export function registerSearchCommand(program: Command): void {
 					return;
 				}
 
-				let query: string;
-				if (options.argStdin) {
-					query = await readStdin();
-				} else {
-					query = words.length > 0 ? words.join(" ") : "";
+				const query = options.argStdin ? await readStdin() : words.join(" ");
+
+				if (!query || !query.trim()) {
+					emitError(options, "A query is required.");
+					return;
 				}
 
-				// Validate query characters when present (prevents shell injection).
-				// Uses isSafeQuery — a deny-list of characters that escape a double-
-				// quoted bash arg (`\` `` ` `` `$` `"` and control chars). Natural
-				// punctuation (`?`, `#`, `(`, `:`, `,` …) is allowed so queries like
-				// "why did we pick X over Y?" or "#789" are accepted.
-				if (query.length > 0 && !isSafeQuery(query)) {
+				// Injection defense is only meaningful on the here-doc bash bridge
+				// (`--arg-stdin`, used by the skill template): that is the only path
+				// where the query is interpolated into a shell. A direct argv query
+				// — and the MCP `search` tool — never re-enters a shell and flows
+				// solely into the in-process Orama index, so validating those would
+				// reject characters (`$`, `` ` ``, …) the MCP path happily accepts and
+				// break the documented "CLI fallback === MCP primary" parity. Gate the
+				// check on `--arg-stdin` so the two surfaces return identical results.
+				if (options.argStdin && !isSafeQuery(query)) {
 					emitError(
 						options,
 						"Invalid characters in query. Backslash, backtick, dollar sign, double-quote, and control characters are not allowed.",
@@ -206,53 +132,21 @@ export function registerSearchCommand(program: Command): void {
 					return;
 				}
 
-				// --hashes implies Phase 2; require 8-40 char hex SHAs and a query.
-				if (options.hashes !== undefined) {
-					const parsed = parseHashList(options.hashes);
-					if (!parsed || parsed.length === 0) {
-						emitError(
-							options,
-							"Invalid --hashes value. Expected comma-separated hex SHAs of 8 to 40 characters (use `hit.hash` or `hit.fullHash` from the Phase 1 catalog).",
-						);
-						return;
-					}
-					if (query.length === 0) {
-						emitError(options, "A query is required when using --hashes (used for snippet highlighting).");
-						return;
-					}
+				const hits = await searchHits(
+					projectDir,
+					{
+						query,
+						...(options.branch !== undefined && { branch: options.branch }),
+						...(options.type !== undefined && { type: options.type }),
+						...(options.limit !== undefined && { limit: options.limit }),
+					},
+					getActiveStorage(),
+				);
 
-					const provider = new LocalSearchProvider(projectDir);
-					const result = await provider.loadHits({ query, hashes: parsed });
-					await writeOutput(result, options, () => renderResultText(result));
-					return;
-				}
-
-				// Phase 1 — empty query is allowed (returns catalog of recent
-				// commits the LLM can pick from based on the user's natural prompt).
-				const provider = new LocalSearchProvider(projectDir);
-				const catalog = await provider.buildCatalog({
-					query,
-					...(options.since !== undefined && { since: options.since }),
-					...(options.limit !== undefined && { limit: options.limit }),
-					...(options.budget !== undefined && { budget: options.budget }),
-				});
-				await writeOutput(catalog, options, () => renderCatalogText(catalog));
+				await writeOutput({ hits }, options, () => renderHitsText(hits));
 			} catch (error: unknown) {
 				const message = error instanceof Error ? error.message : String(error);
 				emitError(options, message);
 			}
 		});
-}
-
-function emitError(options: SearchOptions, message: string): void {
-	// commander default fills `--format`; cast for the type, no fallback needed.
-	const fmt = options.format as "json" | "text";
-	if (fmt === "json") {
-		console.log(JSON.stringify({ type: "error", message }));
-	} else {
-		console.error(`\n  Error: ${message}\n`);
-	}
-	// Always set a non-zero exit code so CI / shell pipelines can detect the
-	// failure regardless of which output format the caller asked for.
-	process.exitCode = 1;
 }

--- a/cli/src/core/RecallResolver.test.ts
+++ b/cli/src/core/RecallResolver.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BranchCatalog, CompiledContext, RecallPayload } from "./ContextCompiler.js";
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock("./ContextCompiler.js", () => ({
+	listBranchCatalog: vi.fn(),
+	compileTaskContext: vi.fn(),
+	buildRecallPayload: vi.fn(),
+	DEFAULT_TOKEN_BUDGET: 60000,
+}));
+
+vi.mock("../util/Subprocess.js", async () => {
+	const actual = await vi.importActual<typeof import("../util/Subprocess.js")>("../util/Subprocess.js");
+	return {
+		...actual,
+		execFileSyncHidden: vi.fn(() => "feature/seeded"),
+	};
+});
+
+import { execFileSyncHidden } from "../util/Subprocess.js";
+import { buildRecallPayload, compileTaskContext, listBranchCatalog } from "./ContextCompiler.js";
+import { resolveRecall } from "./RecallResolver.js";
+
+const mockListBranchCatalog = vi.mocked(listBranchCatalog);
+const mockCompileTaskContext = vi.mocked(compileTaskContext);
+const mockBuildRecallPayload = vi.mocked(buildRecallPayload);
+const mockExecFileSyncHidden = vi.mocked(execFileSyncHidden);
+
+// ─── Test data helpers ────────────────────────────────────────────────────────
+
+const SEEDED_BRANCH = "feature/seeded";
+const PERIOD = { start: "2026-03-28T10:00:00.000Z", end: "2026-03-28T10:01:00.000Z" };
+
+function makeEmptyCatalog(): BranchCatalog {
+	return { type: "catalog", branches: [] };
+}
+
+function makeSeededCatalog(): BranchCatalog {
+	return {
+		type: "catalog",
+		branches: [{ branch: SEEDED_BRANCH, commitCount: 1, period: PERIOD, commitMessages: ["Add feature X"] }],
+	};
+}
+
+function makeCatalogWithBranch(branch: string): BranchCatalog {
+	return {
+		type: "catalog",
+		branches: [{ branch, commitCount: 1, period: PERIOD, commitMessages: ["Some work"] }],
+	};
+}
+
+const EMPTY_STATS = {
+	topicCount: 0,
+	planCount: 0,
+	noteCount: 0,
+	decisionCount: 0,
+	topicTokens: 0,
+	planTokens: 0,
+	noteTokens: 0,
+	decisionTokens: 0,
+	transcriptTokens: 0,
+	totalTokens: 0,
+};
+
+function makeCompiledContext(commitCount: number): CompiledContext {
+	return {
+		branch: SEEDED_BRANCH,
+		period: PERIOD,
+		commitCount,
+		totalFilesChanged: 0,
+		totalInsertions: 0,
+		totalDeletions: 0,
+		summaries: [],
+		plans: [],
+		notes: [],
+		keyDecisions: [],
+		stats: EMPTY_STATS,
+	};
+}
+
+function makeRecallPayload(): RecallPayload {
+	return {
+		type: "recall",
+		branch: SEEDED_BRANCH,
+		period: PERIOD,
+		commitCount: 1,
+		totalFilesChanged: 0,
+		totalInsertions: 0,
+		totalDeletions: 0,
+		commits: [],
+		plans: [],
+		notes: [],
+		stats: EMPTY_STATS,
+		estimatedTokens: 0,
+	};
+}
+
+// ─── resolveRecall ────────────────────────────────────────────────────────────
+
+describe("resolveRecall", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		// Default: git reports the seeded branch
+		mockExecFileSyncHidden.mockReturnValue(`${SEEDED_BRANCH}\n`);
+		// Default catalog: seeded branch present
+		mockListBranchCatalog.mockResolvedValue(makeSeededCatalog());
+		// Default compileTaskContext: one commit
+		mockCompileTaskContext.mockResolvedValue(makeCompiledContext(1));
+		// Default buildRecallPayload: recall result
+		mockBuildRecallPayload.mockReturnValue(makeRecallPayload());
+	});
+
+	it("returns type:error for invalid characters", async () => {
+		const r = await resolveRecall("bad;rm -rf", "/repo");
+		expect(r.type).toBe("error");
+	});
+
+	it("returns type:recall for an exact branch match", async () => {
+		const r = await resolveRecall(SEEDED_BRANCH, "/repo");
+		expect(r.type).toBe("recall");
+	});
+
+	it("returns type:error when the branch matches but has zero commits recorded", async () => {
+		mockCompileTaskContext.mockResolvedValue(makeCompiledContext(0));
+		const r = await resolveRecall(SEEDED_BRANCH, "/repo");
+		expect(r.type).toBe("error");
+	});
+
+	it("returns type:catalog with query for a non-matching fragment", async () => {
+		const r = await resolveRecall("no-such-frag", "/repo");
+		expect(r.type).toBe("catalog");
+		expect((r as { query?: string }).query).toBe("no-such-frag");
+	});
+
+	it("returns type:error when the repo has no records and no branch is given", async () => {
+		mockListBranchCatalog.mockResolvedValue(makeEmptyCatalog());
+		mockExecFileSyncHidden.mockReturnValue("");
+		const r = await resolveRecall(undefined, "/empty-repo");
+		expect(r.type).toBe("error");
+	});
+
+	it("returns type:catalog when no branch arg is given but the repo has records", async () => {
+		mockListBranchCatalog.mockResolvedValue(makeCatalogWithBranch("main"));
+		// Git returns empty string → branch stays falsy → falls through to catalog return
+		mockExecFileSyncHidden.mockReturnValue("");
+		const r = await resolveRecall(undefined, "/repo");
+		// catalog has branches → should return catalog (not error)
+		expect(r.type).toBe("catalog");
+	});
+
+	it("returns type:catalog when git throws getting current branch but repo has records", async () => {
+		mockListBranchCatalog.mockResolvedValue(makeCatalogWithBranch("main"));
+		mockExecFileSyncHidden.mockImplementation(() => {
+			throw new Error("not a git repo");
+		});
+		const r = await resolveRecall(undefined, "/repo");
+		expect(r.type).toBe("catalog");
+	});
+});

--- a/cli/src/core/RecallResolver.ts
+++ b/cli/src/core/RecallResolver.ts
@@ -1,0 +1,79 @@
+/**
+ * Single source of truth for "what does recall return for this input" — the
+ * type-tagged discriminated union the jolli-recall skill consumes. Both the CLI
+ * `recall --format json` path and the MCP `recall` tool call this, so their
+ * results are byte-identical by construction.
+ */
+import { SAFE_ARGUMENT_PATTERN } from "../commands/CliUtils.js";
+import { execFileSyncHidden } from "../util/Subprocess.js";
+import {
+	type BranchCatalog,
+	buildRecallPayload,
+	compileTaskContext,
+	DEFAULT_TOKEN_BUDGET,
+	listBranchCatalog,
+	type RecallPayload,
+} from "./ContextCompiler.js";
+
+export type RecallResult = RecallPayload | BranchCatalog | { type: "error"; message: string };
+
+export interface ResolveRecallOptions {
+	budget?: number;
+	depth?: number;
+	includeTranscripts?: boolean;
+	includePlans?: boolean;
+}
+
+export async function resolveRecall(
+	branchOrKeyword: string | undefined,
+	projectDir: string,
+	options: ResolveRecallOptions = {},
+): Promise<RecallResult> {
+	if (branchOrKeyword && !SAFE_ARGUMENT_PATTERN.test(branchOrKeyword)) {
+		return {
+			type: "error",
+			message:
+				"Invalid characters in argument. Only letters, numbers, hyphens, underscores, slashes, and dots are allowed.",
+		};
+	}
+
+	let branch = branchOrKeyword;
+	if (!branch) {
+		try {
+			branch = execFileSyncHidden("git", ["branch", "--show-current"], {
+				encoding: "utf-8",
+				cwd: projectDir,
+			}).trim();
+		} catch {
+			branch = undefined;
+		}
+	}
+
+	const catalog = await listBranchCatalog(projectDir);
+
+	if (branch) {
+		const exact = catalog.branches.find((b) => b.branch === branch);
+		if (exact) {
+			const ctx = await compileTaskContext(
+				{
+					branch,
+					depth: options.depth,
+					tokenBudget: options.budget ?? DEFAULT_TOKEN_BUDGET,
+					includeTranscripts: options.includeTranscripts,
+					includePlans: options.includePlans !== false,
+				},
+				projectDir,
+			);
+			if (ctx.commitCount === 0) {
+				return { type: "error", message: `No Jolli Memory records found for branch "${branch}".` };
+			}
+			return buildRecallPayload(ctx, options.budget ?? DEFAULT_TOKEN_BUDGET);
+		}
+		return { ...catalog, query: branch };
+	}
+
+	if (catalog.branches.length === 0) {
+		return { type: "error", message: "No Jolli Memory records found in this repository." };
+	}
+	return catalog;
+}

--- a/cli/src/core/SearchHits.test.ts
+++ b/cli/src/core/SearchHits.test.ts
@@ -1,0 +1,104 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SearchDoc } from "./SearchIndexTypes.js";
+
+vi.mock("./SearchIndexSource.js", () => ({
+	collectSearchDocs: vi.fn(),
+	computeSourceSignature: vi.fn(),
+}));
+
+import { searchHits } from "./SearchHits.js";
+import { SearchIndex } from "./SearchIndex.js";
+import { collectSearchDocs, computeSourceSignature } from "./SearchIndexSource.js";
+
+const docs: SearchDoc[] = [
+	{
+		id: "topic:auth-timeout",
+		type: "topic",
+		title: "Auth Timeout",
+		content: "Auth Timeout\nThe auth session has a 30-minute hard timeout.",
+		decisions: "",
+		branch: ["feature/auth", "main"],
+		category: "summary",
+		commitDate: "2026-01-03T00:00:00Z",
+		slug: "auth-timeout",
+		hash: "",
+	},
+	{
+		id: "commit:abc123",
+		type: "commit",
+		title: "add auth timeout",
+		content: "add auth timeout\nChose a 30-min hard cap.",
+		decisions: "Chose a 30-min hard cap.",
+		branch: ["feature/auth"],
+		category: "commit",
+		commitDate: "2026-01-02T00:00:00Z",
+		slug: "",
+		hash: "abc123",
+	},
+];
+
+const seededTerm = "timeout";
+
+let dir: string;
+beforeEach(async () => {
+	dir = await mkdtemp(join(tmpdir(), "jolli-hits-"));
+	vi.mocked(collectSearchDocs).mockResolvedValue(docs);
+	vi.mocked(computeSourceSignature).mockResolvedValue("sig-v1");
+});
+afterEach(async () => {
+	SearchIndex.clearCache();
+	await rm(dir, { recursive: true, force: true });
+});
+
+describe("searchHits", () => {
+	it("throws on empty query", async () => {
+		await expect(searchHits(dir, { query: "  " })).rejects.toThrow(/query/i);
+	});
+
+	it("throws on empty string query", async () => {
+		await expect(searchHits(dir, { query: "" })).rejects.toThrow(/query/i);
+	});
+
+	it("returns BM25 hits for a seeded term", async () => {
+		const hits = await searchHits(dir, { query: seededTerm });
+		expect(hits.length).toBeGreaterThan(0);
+		expect(hits[0]).toHaveProperty("hash");
+		expect(hits[0]).toHaveProperty("snippet");
+	});
+
+	it("forwards branch filter to the index", async () => {
+		const hits = await searchHits(dir, { query: seededTerm, branch: "main" });
+		// Only topic:auth-timeout has branch "main"
+		expect(hits.map((h) => h.id)).toContain("topic:auth-timeout");
+		expect(hits.map((h) => h.id)).not.toContain("commit:abc123");
+	});
+
+	it("forwards type filter to the index", async () => {
+		const hits = await searchHits(dir, { query: seededTerm, type: "commit" });
+		expect(hits.every((h) => h.type === "commit")).toBe(true);
+	});
+
+	it("forwards limit to the index", async () => {
+		const hits = await searchHits(dir, { query: seededTerm, limit: 1 });
+		expect(hits.length).toBeLessThanOrEqual(1);
+	});
+
+	it("forwards the storage argument to SearchIndex.openCached", async () => {
+		// The storage arg determines where the index dir resolves (kbRoot vs cwd).
+		// We use a distinct temp dir as a fake kbRoot and verify the index is written
+		// there (same contract as the SearchIndex storage-routing test).
+		const { existsSync } = await import("node:fs");
+		const { getJolliMemoryDir } = await import("../Logger.js");
+		const kbDir = await mkdtemp(join(tmpdir(), "jolli-kb-"));
+		try {
+			const storage = { kbRoot: kbDir } as unknown as import("./StorageProvider.js").StorageProvider;
+			await searchHits(dir, { query: seededTerm }, storage);
+			expect(existsSync(join(getJolliMemoryDir(kbDir), "search-index.json"))).toBe(true);
+		} finally {
+			await rm(kbDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/cli/src/core/SearchHits.ts
+++ b/cli/src/core/SearchHits.ts
@@ -1,0 +1,26 @@
+/**
+ * BM25 search hits — the single implementation behind both the MCP `search`
+ * tool and the CLI `search` command, so primary and fallback return identical
+ * results. Wraps the Orama-backed SearchIndex.
+ */
+import { type SearchHitResult, SearchIndex } from "./SearchIndex.js";
+import type { StorageProvider } from "./StorageProvider.js";
+
+export interface SearchHitsArgs {
+	query: string;
+	branch?: string;
+	type?: "topic" | "commit";
+	limit?: number;
+}
+
+export async function searchHits(
+	cwd: string,
+	args: SearchHitsArgs,
+	storage?: StorageProvider,
+): Promise<SearchHitResult[]> {
+	if (!args.query || !args.query.trim()) {
+		throw new Error("`query` is required and must be non-empty");
+	}
+	const index = await SearchIndex.openCached(cwd, storage);
+	return index.search({ query: args.query, branch: args.branch, type: args.type, limit: args.limit });
+}

--- a/cli/src/core/SearchIndex.test.ts
+++ b/cli/src/core/SearchIndex.test.ts
@@ -98,14 +98,25 @@ describe("SearchIndex", () => {
 		expect(res.length).toBeGreaterThan(0);
 	});
 
-	it("filters by exact branch membership (multi-branch topic, space-joined)", async () => {
+	it("filters by exact branch membership (multi-branch topic)", async () => {
 		const idx = await SearchIndex.open(dir);
 		// Only topic:auth-timeout lists "main" among its related branches.
 		const onMain = await idx.search({ query: "timeout", branch: "main" });
 		const ids = onMain.map((r) => r.id);
-		expect(ids).toContain("topic:auth-timeout"); // branch "feature/auth main"
+		expect(ids).toContain("topic:auth-timeout"); // relatedBranches ["feature/auth","main"]
 		expect(ids).not.toContain("commit:abc123"); // branch "feature/auth" only
 		expect(ids).not.toContain("topic:billing-cache"); // branch "feature/billing"
+	});
+
+	it("returns a single valid branch (the first) for a multi-branch topic hit, not a space-joined string", async () => {
+		// Regression: `branch` was `doc.branch.join(" ")`, producing "feature/auth
+		// main" — not a real branch — which the jolli-search skill then fed into
+		// jolli-recall. A hit's `branch` must be one valid branch name.
+		const idx = await SearchIndex.open(dir);
+		const res = await idx.search({ query: "timeout", branch: "main" });
+		const topic = res.find((r) => r.id === "topic:auth-timeout");
+		expect(topic?.branch).toBe("feature/auth"); // first related branch, not "feature/auth main"
+		expect(topic?.branch).not.toContain(" ");
 	});
 
 	it("does not leak across slash branches that share a token", async () => {

--- a/cli/src/core/SearchIndex.ts
+++ b/cli/src/core/SearchIndex.ts
@@ -170,7 +170,12 @@ export class SearchIndex {
 				type: doc.type,
 				title: doc.title,
 				snippet: doc.content.slice(0, 280),
-				branch: doc.branch.join(" "),
+				// Hand back a SINGLE valid branch name. Commit docs always carry
+				// exactly one; topic docs carry their relatedBranches[] — so a
+				// space-join ("feature/auth main") is not a real branch and breaks the
+				// jolli-search skill, which feeds this straight into `jolli-recall`.
+				// Use the first/primary related branch instead.
+				branch: doc.branch[0] ?? "",
 				commitDate: doc.commitDate,
 				slug: doc.slug,
 				hash: doc.hash,

--- a/cli/src/install/Installer.test.ts
+++ b/cli/src/install/Installer.test.ts
@@ -43,17 +43,18 @@ vi.mock("../core/GeminiSessionDetector.js", () => ({
 	isGeminiInstalled: vi.fn().mockResolvedValue(false),
 }));
 
-// Partial mock of McpRegistration: keep the REAL register/remove implementations
-// (they operate on the temp dir's .mcp.json) but wrap them in vi.fn so a single
-// test can force `removeMcpFromClaude` to reject and assert uninstall still
-// proceeds. `clearMocks: true` only clears call history, so the real impl given
-// to vi.fn() survives across tests.
-vi.mock("./McpRegistration.js", async (importOriginal) => {
-	const actual = await importOriginal<typeof import("./McpRegistration.js")>();
+// Partial mock of HostRegistrars: keep the REAL register/remove implementations
+// (they operate on the temp dir's .mcp.json / .cursor/mcp.json) but wrap them
+// in vi.fn so a single test can force `removeRepoMcpHosts` to reject and assert
+// uninstall still proceeds. `clearMocks: true` only clears call history, so the
+// real impl given to vi.fn() survives across tests.
+vi.mock("./mcp/HostRegistrars.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./mcp/HostRegistrars.js")>();
 	return {
 		...actual,
-		registerMcpInClaude: vi.fn(actual.registerMcpInClaude),
-		removeMcpFromClaude: vi.fn(actual.removeMcpFromClaude),
+		registerRepoMcpHosts: vi.fn(actual.registerRepoMcpHosts),
+		registerGlobalMcpHosts: vi.fn(actual.registerGlobalMcpHosts),
+		removeRepoMcpHosts: vi.fn(actual.removeRepoMcpHosts),
 	};
 });
 
@@ -885,6 +886,51 @@ describe("Installer", () => {
 		});
 	});
 
+	describe("multi-host MCP registration", () => {
+		it("registers MCP across detected hosts during enable", async () => {
+			// claude=true (default), cursor=true, gemini=false, codex=false.
+			// cursor writes to <wt>/.cursor/mcp.json (tmpdir-safe).
+			// claude writes to <wt>/.mcp.json (tmpdir-safe).
+			// gemini/codex stay false so no real ~/.gemini or ~/.codex is touched.
+			const { isCursorInstalled } = await import("../core/CursorDetector.js");
+			vi.mocked(isCursorInstalled).mockResolvedValue(true);
+
+			const result = await install(tempDir);
+			expect(result.success).toBe(true);
+
+			// Claude config: <wt>/.mcp.json
+			const claudeMcpPath = join(tempDir, ".mcp.json");
+			const claudeMcp = JSON.parse(await readFile(claudeMcpPath, "utf-8"));
+			expect(claudeMcp.mcpServers).toBeDefined();
+			expect(claudeMcp.mcpServers.jollimemory).toBeDefined();
+
+			// Cursor config: <wt>/.cursor/mcp.json
+			const cursorMcpPath = join(tempDir, ".cursor", "mcp.json");
+			const cursorMcp = JSON.parse(await readFile(cursorMcpPath, "utf-8"));
+			expect(cursorMcp.mcpServers).toBeDefined();
+			expect(cursorMcp.mcpServers.jollimemory).toBeDefined();
+		});
+
+		it("registers non-Claude MCP hosts even when claudeEnabled is false", async () => {
+			// Save config with claudeEnabled=false, then install.
+			await writeFile(join(emptyGlobalDir, "config.json"), JSON.stringify({ claudeEnabled: false }), "utf-8");
+			const { isCursorInstalled } = await import("../core/CursorDetector.js");
+			vi.mocked(isCursorInstalled).mockResolvedValue(true);
+
+			const result = await install(tempDir);
+			expect(result.success).toBe(true);
+
+			// Claude MCP should NOT be written (claude=false in detected)
+			const claudeMcpPath = join(tempDir, ".mcp.json");
+			await expect(stat(claudeMcpPath)).rejects.toThrow();
+
+			// Cursor MCP SHOULD be written despite claudeEnabled=false
+			const cursorMcpPath = join(tempDir, ".cursor", "mcp.json");
+			const cursorMcp = JSON.parse(await readFile(cursorMcpPath, "utf-8"));
+			expect(cursorMcp.mcpServers.jollimemory).toBeDefined();
+		});
+	});
+
 	describe("uninstall", () => {
 		it("should remove Claude hook and all git hooks", async () => {
 			await install(tempDir);
@@ -898,7 +944,7 @@ describe("Installer", () => {
 			expect(settings.hooks).toBeUndefined();
 		});
 
-		it("continues removing git hooks when removeMcpFromClaude throws (e.g. read-only .mcp.json)", async () => {
+		it("continues removing git hooks when removeRepoMcpHosts throws (e.g. read-only .mcp.json)", async () => {
 			await install(tempDir);
 			const postRewritePath = join(tempDir, ".git", "hooks", "post-rewrite");
 			// Sanity: the hook is installed before uninstall.
@@ -908,8 +954,8 @@ describe("Installer", () => {
 			// EPERM / read-only .mcp.json. The install side already treats this as
 			// non-fatal; uninstall must too, or the git hooks leak and post-commit
 			// keeps firing after the user thinks they've uninstalled.
-			const { removeMcpFromClaude } = await import("./McpRegistration.js");
-			vi.mocked(removeMcpFromClaude).mockRejectedValueOnce(new Error("EPERM: read-only .mcp.json"));
+			const { removeRepoMcpHosts } = await import("./mcp/HostRegistrars.js");
+			vi.mocked(removeRepoMcpHosts).mockRejectedValueOnce(new Error("EPERM: read-only .mcp.json"));
 
 			const result = await uninstall(tempDir);
 			expect(result.success).toBe(true);

--- a/cli/src/install/Installer.ts
+++ b/cli/src/install/Installer.ts
@@ -81,7 +81,13 @@ import {
 	removePrepareMsgHook,
 } from "./GitHookInstaller.js";
 import type { HookOpResult } from "./HookSettingsHelper.js";
-import { MCP_GIT_EXCLUDE_PATH, registerMcpInClaude, removeMcpFromClaude } from "./McpRegistration.js";
+import {
+	buildRegistrars,
+	type DetectedHosts,
+	registerGlobalMcpHosts,
+	registerRepoMcpHosts,
+	removeRepoMcpHosts,
+} from "./mcp/HostRegistrars.js";
 import { SKILL_GIT_EXCLUDE_PATHS, updateSkillIfNeeded } from "./SkillInstaller.js";
 
 // ─── Re-exports for backward compatibility ──────────────────────────────────
@@ -180,6 +186,16 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 			};
 		}
 
+		// Run host detectors once before the per-worktree loop so each detector
+		// is called exactly once. Results are reused both inside the loop (for MCP
+		// registration) and after it (for auto-enable config writes / hook installs).
+		const codexDetectedOnce = await isCodexInstalled();
+		const geminiDetectedOnce = await isGeminiInstalled();
+		const cursorDetectedOnce = await isCursorInstalled();
+		const opencodeDetectedOnce = await isOpenCodeInstalled();
+		const copilotDetectedOnce = await isCopilotInstalled();
+		const copilotChatDetectedOnce = await isCopilotChatInstalled();
+
 		// Install .jolli/jollimemory/ state dir (always) and Claude Code hook (if enabled)
 		let claudeResult: HookOpResult = {};
 		for (const wt of worktrees) {
@@ -206,12 +222,41 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 			// We update SKILL.md before the Claude-hook gate below so disabling
 			// Claude doesn't strand the `.agents/` skills target unupdated.
 			await updateSkillIfNeeded(wt, { claudeEnabled: config.claudeEnabled });
+			// Build the set of detected hosts for this worktree iteration.
+			// Claude's detected state mirrors the claudeEnabled config flag so
+			// a user who has disabled Claude still gets non-Claude hosts registered.
+			// Other detectors use the values computed once before the loop.
+			// NOTE: MCP registration is intentionally gated by host DETECTION only,
+			// independent of the per-host *Enabled discovery flags (cursorEnabled,
+			// copilotEnabled, …) — the documented MCP philosophy: "MCP registration
+			// runs regardless of claudeEnabled; the hook and MCP are independent
+			// decisions." So a detected host is wired for MCP even if its session
+			// discovery is disabled. Do not "fix" this into flag-gating.
+			const detected: DetectedHosts = {
+				claude: config.claudeEnabled !== false,
+				codex: codexDetectedOnce,
+				cursor: cursorDetectedOnce,
+				gemini: geminiDetectedOnce,
+				opencode: opencodeDetectedOnce,
+				copilot: copilotDetectedOnce,
+				copilotChat: copilotChatDetectedOnce,
+			};
 			// Keep the user's `git status` clean by adding Jolli-managed paths to
 			// `.git/info/exclude`. Worktree-aware: linked worktrees may have their
-			// own gitdir, so we resolve per-worktree. `.mcp.json` is included
-			// because registerMcpInClaude (below) writes it with a machine-local
-			// absolute path that must never be committed.
-			await updateGitExclude(wt, [...SKILL_GIT_EXCLUDE_PATHS, MCP_GIT_EXCLUDE_PATH]);
+			// own gitdir, so we resolve per-worktree. We compute the union of all
+			// active registrars' gitExcludePaths so each host's config file is
+			// covered (e.g. `.cursor/mcp.json` when Cursor is detected). Global
+			// hosts contribute [] here — their configs live outside the repo.
+			await updateGitExclude(wt, [
+				...SKILL_GIT_EXCLUDE_PATHS,
+				...buildRegistrars(detected).flatMap((r) => r.gitExcludePaths()),
+			]);
+			// Register the MCP server in the detected REPO-scoped hosts (Claude,
+			// Cursor) whose config lives in this worktree. This runs BEFORE the
+			// claudeEnabled gate so Cursor users with Claude disabled still get MCP
+			// registered. Each host is isolated — a failure in one never blocks the
+			// others. Global hosts are registered once after the loop (below).
+			await registerRepoMcpHosts(wt, detected);
 
 			if (config.claudeEnabled === false) continue;
 			const result = await installClaudeHook(wt);
@@ -226,14 +271,21 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 			}
 			// Install SessionStart hook for auto-briefing
 			await installSessionStartHook(wt);
-			// Register the MCP server for AI agents (Claude Code project config).
-			// Non-fatal: a failure here must not block hook installation.
-			try {
-				await registerMcpInClaude(wt);
-			} catch (mcpErr) {
-				log.warn("MCP registration failed in %s (non-fatal): %s", wt, (mcpErr as Error).message);
-			}
 		}
+
+		// Register the MCP server in the detected GLOBAL hosts (Codex, Gemini,
+		// OpenCode, Copilot, Copilot Chat). Their config files are machine-wide and
+		// shared across every repo, so we write them ONCE here rather than rewriting
+		// the same file on each worktree iteration above. Detection-gated only.
+		await registerGlobalMcpHosts({
+			claude: false,
+			cursor: false,
+			codex: codexDetectedOnce,
+			gemini: geminiDetectedOnce,
+			opencode: opencodeDetectedOnce,
+			copilot: copilotDetectedOnce,
+			copilotChat: copilotChatDetectedOnce,
+		});
 
 		// Git hooks are shared across all worktrees — install once
 		const gitResult = await installGitHook(projectDir);
@@ -260,8 +312,7 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 		}
 
 		// Auto-detect Codex CLI and enable session discovery (saved to global config)
-		const codexDetected = await isCodexInstalled();
-		if (codexDetected) {
+		if (codexDetectedOnce) {
 			if (config.codexEnabled === undefined) {
 				await saveConfig({ codexEnabled: true });
 				log.info("Codex CLI detected — enabled Codex session discovery");
@@ -270,8 +321,7 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 
 		// Auto-detect Gemini CLI and install AfterAgent hook in all worktrees (if enabled)
 		let geminiSettingsPath: string | undefined;
-		const geminiDetected = await isGeminiInstalled();
-		if (geminiDetected && config.geminiEnabled !== false) {
+		if (geminiDetectedOnce && config.geminiEnabled !== false) {
 			for (const wt of worktrees) {
 				const geminiResult = await installGeminiHook(wt);
 				// Capture the path from the primary worktree
@@ -286,7 +336,7 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 		}
 
 		// Auto-detect OpenCode and enable session discovery
-		const openCodeDetected = config.openCodeEnabled !== false && (await isOpenCodeInstalled());
+		const openCodeDetected = config.openCodeEnabled !== false && opencodeDetectedOnce;
 		if (openCodeDetected) {
 			if (config.openCodeEnabled === undefined) {
 				await saveConfig({ openCodeEnabled: true });
@@ -295,7 +345,7 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 		}
 
 		// Auto-detect Cursor and enable Composer session discovery
-		const cursorDetected = config.cursorEnabled !== false && (await isCursorInstalled());
+		const cursorDetected = config.cursorEnabled !== false && cursorDetectedOnce;
 		if (cursorDetected) {
 			if (config.cursorEnabled === undefined) {
 				await saveConfig({ cursorEnabled: true });
@@ -306,8 +356,8 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 		// Auto-detect GitHub Copilot in either form (terminal CLI or vscode Chat) and
 		// enable the shared copilotEnabled flag. Both sources share one toggle —
 		// see docs/superpowers/specs/2026-05-06-copilot-chat-support-design.md.
-		const copilotDetected = config.copilotEnabled !== false && (await isCopilotInstalled());
-		const copilotChatDetected = config.copilotEnabled !== false && (await isCopilotChatInstalled());
+		const copilotDetected = config.copilotEnabled !== false && copilotDetectedOnce;
+		const copilotChatDetected = config.copilotEnabled !== false && copilotChatDetectedOnce;
 		if ((copilotDetected || copilotChatDetected) && config.copilotEnabled === undefined) {
 			await saveConfig({ copilotEnabled: true });
 			log.info(
@@ -508,12 +558,18 @@ export async function uninstall(cwd?: string): Promise<InstallResult> {
 			}
 			/* v8 ignore stop */
 			await removeGeminiHook(wt);
-			// Non-fatal, mirroring the install side: a failure here (e.g. EPERM on a
-			// read-only .mcp.json) must not abort the uninstall, or the shared git
-			// hooks below would leak and post-commit would keep firing after the
-			// user believes they've uninstalled.
+			// Remove MCP entries from this repo's REPO-scoped hosts (Claude's
+			// .mcp.json, Cursor's .cursor/mcp.json). Global hosts (Codex/Gemini/
+			// OpenCode/Copilot/Copilot Chat) are intentionally left untouched: their
+			// jollimemory entry is shared by every repo on the machine, so removing
+			// it here would break MCP for other repos still using Jolli. Non-fatal: a
+			// failure in one host (e.g. EPERM on a read-only .mcp.json) must not abort
+			// the uninstall, or the shared git hooks below would leak and post-commit
+			// would keep firing after the user believes they've uninstalled.
+			// removeRepoMcpHosts is internally per-host non-fatal, so no outer
+			// try/catch is needed here, but we keep one for defensive parity.
 			try {
-				await removeMcpFromClaude(wt);
+				await removeRepoMcpHosts(wt);
 			} catch (mcpErr) {
 				log.warn("MCP removal failed in %s (non-fatal): %s", wt, (mcpErr as Error).message);
 			}

--- a/cli/src/install/McpRegistration.test.ts
+++ b/cli/src/install/McpRegistration.test.ts
@@ -75,9 +75,12 @@ describe("mcpServerEntry", () => {
 		expect(mcpServerEntry("win32", runCli, cliJs)).toEqual({ command: "node", args: [cliJs, "mcp"] });
 	});
 
-	it("falls back to run-cli on Windows when the dist Cli.js can't be resolved", () => {
-		// Best effort: nothing better to point at, and re-registration will fix it
-		// once a dist path is known.
+	it("returns the run-cli last resort on Windows when the dist Cli.js can't be resolved", () => {
+		// Last resort only: this run-cli entry is itself NOT launchable on win32
+		// (same ENOENT as the shell wrapper), so it does not avoid breakage — it
+		// defers it. The branch is effectively unreachable on the normal install
+		// path (installDistPath runs, and aborts on failure, before registration),
+		// and re-registration replaces it with `node Cli.js` once a dist is known.
 		expect(mcpServerEntry("win32", runCli, undefined)).toEqual({ command: runCli, args: ["mcp"] });
 	});
 });

--- a/cli/src/install/McpRegistration.ts
+++ b/cli/src/install/McpRegistration.ts
@@ -30,8 +30,16 @@ interface McpServerEntry {
  *   ENOENT (no shebang support, not on PATHEXT). So we spawn `node` (already a
  *   hard requirement for the hooks, hence on PATH) on the resolved `Cli.js`.
  *   This bakes in an absolute path, but `registerMcpInClaude` re-runs on every
- *   install/activate, so a moved dist is re-resolved then. If the dist can't be
- *   resolved yet, fall back to `run-cli` rather than write a broken entry.
+ *   install/activate, so a moved dist is re-resolved then.
+ *
+ *   If the dist can't be resolved yet on Windows there is no launchable command:
+ *   `run-cli` is returned only as a last resort and is itself NOT launchable on
+ *   win32 (same ENOENT) — i.e. it does NOT "avoid a broken entry", it just defers
+ *   the breakage. This branch is effectively unreachable on the normal install
+ *   path: `Installer.install()` writes this source's dist-path entry (and aborts
+ *   on failure) BEFORE any MCP registration runs, so `resolveCliJs` resolves by
+ *   then. If it were ever hit, the host would surface a spawn error (not silent)
+ *   and the next install/activate would re-register with the real `node Cli.js`.
  */
 export function mcpServerEntry(platform: NodeJS.Platform, runCli: string, cliJs: string | undefined): McpServerEntry {
 	if (platform === "win32" && cliJs) return { command: "node", args: [cliJs, "mcp"] };

--- a/cli/src/install/SkillInstaller.test.ts
+++ b/cli/src/install/SkillInstaller.test.ts
@@ -17,7 +17,13 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { SKILL_GIT_EXCLUDE_PATHS, updateSkillIfNeeded, updateSkillsIfNeeded } from "./SkillInstaller.js";
+import {
+	buildRecallSkillTemplate,
+	buildSearchSkillTemplate,
+	SKILL_GIT_EXCLUDE_PATHS,
+	updateSkillIfNeeded,
+	updateSkillsIfNeeded,
+} from "./SkillInstaller.js";
 
 // Vitest reuses vite's `define` config, so `__PKG_VERSION__` is the real
 // package.json version in tests. Use that value when planting legacy SKILL.md
@@ -338,17 +344,9 @@ describe("recall template content", () => {
 	});
 });
 
-// ─── Search-template content pins (carried over from prior versions) ────────
+// ─── Search-template content pins (single-phase lightweight) ─────────────────
 
 describe("search template content", () => {
-	it("instructs the LLM to split the input into query + flags", async () => {
-		await updateSkillsIfNeeded(tempDir);
-		const search = readSearch();
-		expect(search).toMatch(/Parse the user input into query \+ flags/);
-		// Worked-example table shows where flags go on argv (not in the here-doc body).
-		expect(search).toMatch(/--since 2w/);
-	});
-
 	it("includes stale-CLI detection (older install missing the search command)", async () => {
 		await updateSkillsIfNeeded(tempDir);
 		const search = readSearch();
@@ -356,75 +354,52 @@ describe("search template content", () => {
 		expect(search).toMatch(/npm update -g @jolli\.ai\/cli/);
 	});
 
-	it("explains catalog is not pre-filtered by query", async () => {
+	it("documents the lightweight hit schema (type/title/snippet/branch/commitDate/slug/hash)", async () => {
+		// Single-phase hits are lightweight — no fullHash, no decisions star field,
+		// no per-topic fields. Template must document only what the tool returns.
 		await updateSkillsIfNeeded(tempDir);
 		const search = readSearch();
-		expect(search).toMatch(/catalog is NOT pre-filtered by the user's query/);
+		expect(search).toMatch(/`type`/);
+		expect(search).toMatch(/`title`/);
+		expect(search).toMatch(/`snippet`/);
+		expect(search).toMatch(/`branch`/);
+		expect(search).toMatch(/`commitDate`/);
+		expect(search).toMatch(/`slug`/);
+		expect(search).toMatch(/`hash`/);
 	});
 
-	it("forbids programmatic processing (temp files / scoring scripts)", async () => {
+	it("does NOT promise rich SearchHit fields that are absent from lightweight hits", async () => {
+		// The old two-phase template documented fullHash, commitAuthor, diffStats,
+		// recap, trigger/response/decisions per-topic, filesAffected, etc. These
+		// fields are not in a lightweight hit — template must NOT promise them.
 		await updateSkillsIfNeeded(tempDir);
 		const search = readSearch();
-		expect(search).toMatch(/DO NOT\*\* process programmatically/);
-		expect(search).toMatch(/no temp files/);
-		expect(search).toMatch(/jq\/python\/grep/);
-		expect(search).toMatch(/Semantic picking/);
+		expect(search).not.toMatch(/`fullHash`/);
+		expect(search).not.toMatch(/`commitAuthor`/);
+		expect(search).not.toMatch(/`recap\?`/);
+		expect(search).not.toMatch(/`trigger\?`/);
+		expect(search).not.toMatch(/`response\?`/);
+		expect(search).not.toMatch(/decisions ★ \*\*THE STAR FIELD\*\*/);
+		expect(search).not.toMatch(/`filesAffected\?`/);
+		expect(search).not.toMatch(/`diffStats\?`/);
 	});
 
-	it("tells the LLM to retry with bigger budget before bothering the user", async () => {
+	it("does NOT contain two-phase machinery (--hashes, load_commits, catalog scan)", async () => {
 		await updateSkillsIfNeeded(tempDir);
 		const search = readSearch();
-		expect(search).toMatch(/--budget 50000/);
+		expect(search).not.toContain("--hashes");
+		expect(search).not.toContain("load_commits");
+		expect(search).not.toMatch(/catalog is NOT pre-filtered/);
+		expect(search).not.toMatch(/--budget 50000/);
+		expect(search).not.toMatch(/Phase 2/);
 	});
 
-	it("documents every SearchHit identity / provenance field", async () => {
+	it("tells the user to use jolli-recall for full decisions/rationale", async () => {
+		// Single-phase search can't deliver full decisions — template must redirect.
 		await updateSkillsIfNeeded(tempDir);
 		const search = readSearch();
-		expect(search).toMatch(/`hash` —/);
-		expect(search).toMatch(/`fullHash` —/);
-		expect(search).toMatch(/`commitMessage` —/);
-		expect(search).toMatch(/`commitAuthor` —/);
-		expect(search).toMatch(/`commitDate` —/);
-		expect(search).toMatch(/- `branch`/);
-		expect(search).toMatch(/`commitType\?` —/);
-		expect(search).toMatch(/`ticketId\?` —/);
-		expect(search).toMatch(/`diffStats\?` —/);
-		expect(search).toMatch(/`recap\?` —/);
-	});
-
-	it("marks `decisions` as the star field with explicit emphasis", async () => {
-		await updateSkillsIfNeeded(tempDir);
-		const search = readSearch();
-		expect(search).toMatch(/`decisions` ★ \*\*THE STAR FIELD\*\*/);
-		expect(search).toMatch(/why did we choose X/);
-	});
-
-	it("documents every per-topic field", async () => {
-		await updateSkillsIfNeeded(tempDir);
-		const search = readSearch();
-		expect(search).toMatch(/`title` —/);
-		expect(search).toMatch(/`trigger\?` —/);
-		expect(search).toMatch(/`response\?` —/);
-		expect(search).toMatch(/`decisions` ★/);
-		expect(search).toMatch(/`todo\?` —/);
-		expect(search).toMatch(/`filesAffected\?` —/);
-		expect(search).toMatch(/`category\?` —/);
-		expect(search).toMatch(/`importance\?` —/);
-	});
-
-	it("uses correct diffStats field name (filesChanged, not files)", async () => {
-		await updateSkillsIfNeeded(tempDir);
-		const search = readSearch();
-		expect(search).toMatch(/`diffStats\?` — `\{ filesChanged, insertions, deletions \}`/);
-		expect(search).not.toMatch(/`diffStats\?` — `\{ files,/);
-	});
-
-	it("documents plan/note stubs and forbids navigation promises", async () => {
-		await updateSkillsIfNeeded(tempDir);
-		const search = readSearch();
-		expect(search).toMatch(/`plans\?` — `\{ slug, title \}\[\]`/);
-		expect(search).toMatch(/`notes\?` — `\{ id, title \}\[\]`/);
-		expect(search).toMatch(/Do NOT promise the user they can navigate to the plan body/);
+		expect(search).toMatch(/jolli-recall/);
+		expect(search).toMatch(/full decisions\/rationale/);
 	});
 
 	it("lists Lead-with-the-answer principle and forbids preamble openers", async () => {
@@ -432,12 +407,6 @@ describe("search template content", () => {
 		const search = readSearch();
 		expect(search).toMatch(/Lead with the answer/);
 		expect(search).toMatch(/No "Let me analyze\.\.\." or "Found N commits\.\.\." preamble/);
-	});
-
-	it("requires file paths as markdown links", async () => {
-		await updateSkillsIfNeeded(tempDir);
-		const search = readSearch();
-		expect(search).toMatch(/\[cli\/src\/Types\.ts\]\(cli\/src\/Types\.ts\)/);
 	});
 
 	it("forbids snippet dumps and demands complete verbatim clauses", async () => {
@@ -457,14 +426,17 @@ describe("search template content", () => {
 		expect(search).not.toMatch(/Use sparingly \(1-3 quotes per answer\)/);
 	});
 
-	it("forbids exposing machinery", async () => {
+	it("forbids exposing machinery (BM25, score, SearchHit)", async () => {
 		await updateSkillsIfNeeded(tempDir);
 		const search = readSearch();
 		expect(search).toMatch(/Don't expose machinery/);
-		expect(search).toMatch(/"Phase 1"/);
-		expect(search).toMatch(/"Phase 2"/);
-		expect(search).toMatch(/"catalog"/);
+		// New template explicitly bans BM25 and score (lightweight-specific)
+		expect(search).toMatch(/"BM25"/);
 		expect(search).toMatch(/"SearchHit"/);
+		// Old two-phase machinery labels must NOT bleed back in
+		expect(search).not.toMatch(/"Phase 1"/);
+		expect(search).not.toMatch(/"Phase 2"/);
+		expect(search).not.toMatch(/"catalog"/);
 	});
 
 	it("does NOT carry the legacy vscode:// principle", async () => {
@@ -487,11 +459,35 @@ describe("search template content", () => {
 		expect(search).not.toMatch(/Section 1 — Top-line summary/);
 	});
 
-	it("tightens the Step 3 picks limit to 5-10", async () => {
+	it("handles empty hits gracefully (suggest broader keywords)", async () => {
 		await updateSkillsIfNeeded(tempDir);
 		const search = readSearch();
-		expect(search).toMatch(/Pick \*\*5-10\*\*/);
-		expect(search).not.toMatch(/Pick 5-15/);
+		expect(search).toMatch(/broader keywords/);
+		// Must NOT mention BM25 or index internals in the empty-hits path
+		expect(search).toMatch(/Do NOT mention BM25/);
+	});
+});
+
+// ─── MCP-preferred invocation ────────────────────────────────────────────────
+
+describe("recall template MCP-preferred invocation", () => {
+	it("recall template prefers MCP recall and keeps the CLI fallback", () => {
+		const t = buildRecallSkillTemplate();
+		expect(t).toContain("mcp__jollimemory__recall");
+		expect(t).toContain('type:"recall"'); // documents type:recall|catalog|error
+		expect(t).toContain("$HOME/.jolli/jollimemory/run-cli"); // fallback retained
+	});
+});
+
+// ─── Search template MCP-preferred invocation ────────────────────────────────
+
+describe("search template MCP-preferred invocation (lightweight hits)", () => {
+	it("search template uses MCP search (lightweight hits) + CLI fallback", () => {
+		const t = buildSearchSkillTemplate();
+		expect(t).toContain("mcp__jollimemory__search");
+		expect(t).not.toContain("load_commits"); // no two-phase
+		expect(t).not.toContain("--hashes");
+		expect(t).toContain("$HOME/.jolli/jollimemory/run-cli"); // fallback retained
 	});
 });
 

--- a/cli/src/install/SkillInstaller.ts
+++ b/cli/src/install/SkillInstaller.ts
@@ -271,7 +271,7 @@ vector.`;
  * file passes `skills-ref validate` and works on Claude Code, Codex, Cursor,
  * Windsurf, OpenCode, and Gemini without per-host divergence.
  */
-function buildRecallSkillTemplate(): string {
+export function buildRecallSkillTemplate(): string {
 	return `---
 name: jolli-recall
 description: Recall prior development context from Jolli for the current branch. Use when the user wants to recall, remember, or resume prior work on a branch.
@@ -289,10 +289,19 @@ distilled topics (trigger / response / decisions / files), plus any plans
 and notes that the work referenced. Synthesize a grounded answer to the
 user's prompt about that branch.
 
-## Step 1: Run the CLI
+## Step 1: Load the recall result
 
-The user's input \`<user-arg>\` is either a branch name (exact or fragment) or
-empty (in which case the CLI uses the current git branch).
+\`<user-arg>\` is a branch name (exact or fragment) or empty (current branch).
+
+### Preferred: MCP tool
+
+If \`mcp__jollimemory__recall\` is available, call it with \`{ "branch": "<user-arg>" }\`
+(omit \`branch\` when \`<user-arg>\` is empty). It returns a \`type\`-tagged object —
+\`recall\` / \`catalog\` / \`error\` — identical to the CLI fallback below.
+
+### Fallback: CLI here-doc
+
+If no such tool is available, use:
 
 ${heredocInvocation("recall", " --format json")}
 
@@ -300,9 +309,19 @@ If \`~/.jolli/jollimemory/run-cli\` does not exist, tell the user:
 "Jolli not installed. Please install via \`npm install -g @jolli.ai/cli && jolli enable\` or install the Jolli VS Code extension."
 Do not attempt further processing.
 
-## Step 2: Handle the response
+Both the MCP tool and the CLI fallback return the same \`type\`-tagged union.
+Handle the result using Step 2 regardless of which path was used.
 
-The output is JSON with a \`type\` field. Three cases:
+## Step 2: Handle the result by \`type\`
+
+The result (from either the MCP tool or the CLI) is a \`type\`-tagged object:
+
+- \`type:"recall"\` → render Part A + Part B below.
+- \`type:"catalog"\` → semantic-match \`<user-arg>\` against \`branches[].branch\` /
+  \`commitMessages\` / \`topicTitles\`. One match → repeat Step 1 with that branch.
+  Many → list and ask. None → show catalog, ask to clarify.
+- \`type:"error"\` → surface \`message\` verbatim (translated); for "no records",
+  suggest \`jolli enable\`. Never fabricate.
 
 ### type: "recall" — full payload returned
 
@@ -654,15 +673,15 @@ and authenticate with \`gh auth login\`, then retry."
 }
 
 /**
- * Search skill template — describes the two-phase catalog/detail search
+ * Search skill template — describes the single-phase lightweight BM25 search
  * workflow to the host LLM. Byte-identical across every {@link SKILL_TARGETS}
  * entry, same spec-compliant frontmatter as recall.
  *
- * Two-phase pattern: catalog scan → hash-targeted detail load. The chat LLM
- * does all semantic work (matching the user's query against catalog content);
- * the CLI is purely a deterministic data source.
+ * Preferred path: call \`mcp__jollimemory__search\` directly (returns lightweight
+ * \`{ hits }\` — no two-phase catalog/detail load). Fallback: CLI here-doc with
+ * the same \`{ hits }\` envelope.
  */
-function buildSearchSkillTemplate(): string {
+export function buildSearchSkillTemplate(): string {
 	return `---
 name: jolli-search
 description: Search structured commit memories across all branches — decisions, topics, files. Use when the user wants to find prior decisions, related commits, or how a topic was handled before.
@@ -674,9 +693,8 @@ metadata:
 # Jolli Search
 
 Search structured commit memories across every branch in this repo.
-Uses LLM-distilled summaries (decisions, topic titles, recap, filesAffected) —
-not raw markdown — so semantic / cross-language / synonym matching is a fit
-for the chat LLM that runs this skill.
+Lightweight BM25 index returns relevance-ranked hits — no two-phase catalog
+scan required. For full context of a known branch, use jolli-recall instead.
 
 ## When to use
 
@@ -688,40 +706,36 @@ for the chat LLM that runs this skill.
 
 - Need full context of a known branch → run jolli-recall.
 - Looking at the current code → grep / read files directly.
+- Need deep rationale/decisions for a specific branch → run jolli-recall on
+  that branch (search hits are lightweight; full decisions live in recall).
 
-## Step 1: Parse the user input into query + flags
+## Step 1: Parse the query
 
-The user can include flags inline, e.g. \`auth --since 2w\`. Before invoking
-the CLI, split the user's argument into two parts:
+Extract the natural-language query (any language). Optional: \`limit\` (integer,
+default 20). Note: time/budget filters (\`--since\`, \`--budget\`) are not supported
+on the search path — point users at jolli-recall for a full branch when they
+need depth.
 
-1. **Query**: the user's keyword / sentence (everything that is NOT a CLI flag).
-   The query may be in any human language and contain natural punctuation
-   (\`?\`, \`#\`, \`(\`, etc.).
-2. **Flags**: any of \`--since <date>\`, \`--limit <n>\`, \`--budget <tokens>\`,
-   \`--output <path>\`. Pass these through verbatim. Ignore any other token starting
-   with \`--\`.
+## Step 2: Get hits
 
-The query is delivered to the CLI on stdin via a here-doc, and flags go on
-argv as separate tokens. Never put flags inside the here-doc body.
+### Preferred: MCP tool
 
-## Step 2: Run the catalog phase
+If \`mcp__jollimemory__search\` is available, call it with:
 
-${heredocInvocation("search", " <flags> --format json")}
+\`\`\`json
+{ "query": "<query>", "limit": 20 }
+\`\`\`
 
-Replace \`<flags>\` with the parsed flags from Step 1 (e.g. \`--since 2w --limit 30\`)
-or remove the placeholder entirely if there are no flags. Always include
-\`--format json\`.
+Returns \`{ "hits": [ { type, title, snippet, branch, commitDate, slug, hash, score } ] }\`,
+relevance-ranked (BM25). Proceed to Step 3 with these hits.
 
-Worked examples (the part the LLM has to construct):
+### Fallback: CLI here-doc
 
-| User input                                  | Bash you should run                                                                                |
-|---------------------------------------------|----------------------------------------------------------------------------------------------------|
-| \`auth\`                                    | \`run-cli search --arg-stdin --format json <<'JOLLI_ARG_<DELIM>_END' …\`                            |
-| \`auth --since 2w\`                         | \`run-cli search --arg-stdin --since 2w --format json <<'JOLLI_ARG_<DELIM>_END' …\`                 |
-| \`why did we choose X over Y? --since 1m\`  | \`run-cli search --arg-stdin --since 1m --format json <<'JOLLI_ARG_<DELIM>_END' …\`                 |
+If no such tool is available, use:
 
-The \`…\` after \`<<'JOLLI_ARG_<DELIM>_END'\` is the here-doc body containing
-the query, followed on a new line by the closing \`JOLLI_ARG_<DELIM>_END\`.
+${heredocInvocation("search", " --format json")}
+
+The CLI returns the same \`{ hits }\` envelope as the MCP tool.
 
 **Failure handling**:
 - If \`~/.jolli/jollimemory/run-cli\` does not exist: tell the user
@@ -733,141 +747,61 @@ the query, followed on a new line by the closing \`JOLLI_ARG_<DELIM>_END\`.
   \`npm update -g @jolli.ai/cli\` (or update your VS Code extension), then retry."
   Do not attempt further processing.
 
-The output is a JSON object with \`type: "search-catalog"\` containing one entry per
-recent root commit, each with \`branch\`, \`date\`, \`recap\`, \`ticketId\`, and \`topics\`
-(title / decisions / category / importance / filesAffected).
+Both paths produce the same \`{ hits }\` shape. Proceed to Step 3 regardless of
+which path was used.
 
-### What the output fields mean (don't conflate them)
+## Step 3: Render
 
-- \`totalCandidates\`: number of root commits matching the time-window filter
-  (i.e. catalog universe size after \`--since\` / \`--limit\`).
-- \`entries\`: the actual array you'll scan — usually fewer than \`totalCandidates\`
-  because \`--budget\` may have trimmed less-recent ones to fit the token cap.
-- \`truncated: true\` means at least one candidate didn't make it into \`entries\`.
+\`hits\` are lightweight — no full decisions/recap per hit. For each relevant
+hit you have:
 
-**The catalog is NOT pre-filtered by the user's query**. It's a recent-commits
-window — your job in Step 3 is to do the semantic filter. Don't be surprised
-if many entries look unrelated; that's expected.
+- \`type\` — \`"commit"\` or \`"topic"\`
+- \`title\` — one-sentence label
+- \`snippet\` — short excerpt from the matching content
+- \`branch\` — branch the hit belongs to
+- \`commitDate\` — ISO 8601 date
+- \`slug\` — human-readable identifier (for topics)
+- \`hash\` — 8-char short SHA (for commits)
+- \`score\` — BM25 relevance score (internal; do not expose to the user)
 
-## Step 3: Pick relevant commit hashes (semantic, not literal)
-
-**Read each entry's \`title\`, \`recap\`, \`decisions\`, and \`filesAffected\` and judge
-semantic relevance to the user's intent.** The query and the entries may be in
-different human languages. Cross-language and synonym matching is YOUR job here.
-
-- Pick **5-10** commits whose meaning relates to the query. The Phase 2 payload
-  carries full topic content per hit (trigger / response / decisions / files);
-  picking more than 10 risks blowing the chat context budget for ambitious
-  queries.
-- Don't worry if no entry contains the literal query token — that's exactly what
-  semantic picking is for.
-
-**If \`truncated\` is \`true\` and the entries you see don't include obvious matches**,
-silently retry Step 2 once with \`--budget 50000\` to see more of the corpus before
-asking the user to narrow \`--since\`. Only ask the user to narrow time if the
-larger budget still doesn't surface relevant commits.
-
-### Internal constraints
-
-- **DO** read the JSON inline from the previous tool result.
-- **DO NOT** process programmatically — no temp files, no jq/python/grep
-  scoring scripts. Semantic picking by reading is the whole point.
-
-## Step 4: Load full content for the picks
-
-Construct the Phase 2 bash with the same here-doc recipe from Step 2, but add
-\`--hashes <fullHash1,fullHash2,fullHash3>\` to the flags:
-
-\`\`\`bash
-"$HOME/.jolli/jollimemory/run-cli" search --arg-stdin --hashes <fullHash1>,<fullHash2>,<fullHash3> --format json <<'JOLLI_ARG_<DELIM>_END'
-<the query>
-JOLLI_ARG_<DELIM>_END
-\`\`\`
-
-(Generate a new \`<DELIM>\` token for this invocation as in Step 2.)
-
-**Use \`hit.fullHash\` (40-char SHA), NOT \`hit.hash\` (8-char display)**. The
-CLI rejects abbreviated hashes — the 8-char display \`hash\` is for showing in
-your output to the user, but Phase 2 lookup needs the unambiguous full SHA
-(otherwise cherry-pick / rebase chains can resolve to the wrong commit silently).
-
-Output is a \`SearchResult\` with \`results: SearchHit[]\`. See Step 5 for the schema and how to render.
-
-## Step 5: Render to the user
-
-The CLI gave you structured data — full distilled content per commit.
-**Output shape is entirely your call.** Pick whatever serves the user's
-query: prose, table, timeline, side-by-side, mixed. **The principles below
-are the only constraints.**
-
-### A. The data you have (per hit)
-
-Each \`results[i]\` is a \`SearchHit\`:
-
-**Identity / provenance**:
-- \`hash\` — 8-char short SHA (plain text, no link)
-- \`fullHash\` — 40-char full SHA
-- \`commitMessage\` — raw subject (fallback for label; \`recap\` is usually better)
-- \`commitAuthor\` — for "who worked on X" queries
-- \`commitDate\` — ISO 8601
-- \`branch\`
-- \`commitType?\` — \`"commit"\` / \`"amend"\` / \`"squash"\` / \`"rebase-pick"\` / \`"cherry-pick"\` / \`"revert"\`; helps distinguish routine commits from consolidated ones
-- \`ticketId?\` — render as \`[TICKET-1234]\` badge
-
-**Change scale**:
-- \`diffStats?\` — \`{ filesChanged, insertions, deletions }\`
-
-**Narrative**:
-- \`recap?\` — 1-3 paragraphs of plain-English narrative. Highest-quality prose; primary source for "what is X" / "explain X".
-
-**Topics** — \`topics: SearchHitTopic[]\` (★ the meat):
-
-  - \`title\` — one-sentence label
-  - \`trigger?\` — 1-2 sentences, what prompted the work
-  - \`response?\` — implementation summary, may include code; longest field
-  - \`decisions\` ★ **THE STAR FIELD** — design choices + *why*, as markdown bullets. Primary source for "why did we choose X" / "what alternatives" / "rationale". Not in the diff; only here.
-  - \`todo?\` — residual work the LLM flagged (rare)
-  - \`filesAffected?\` — per-topic file list. Render as markdown links: \`[cli/src/Types.ts](cli/src/Types.ts)\`.
-  - \`category?\` — \`feature\` / \`bugfix\` / \`refactor\` / \`tech-debt\` / \`docs\` / \`test\` / \`devops\` / \`ux\`
-  - \`importance?\` — \`major\` / \`minor\`
-
-**Plan / note stubs**:
-- \`plans?\` — \`{ slug, title }[]\` — plan refs this commit declared. Search ships only stubs (no plan body); use the title as a grounding anchor in your narrative ("the decision is consistent with the auth-redesign plan referenced by this commit"). **Do NOT promise the user they can navigate to the plan body from search** — search Phase 2 carries no plan content.
-- \`notes?\` — \`{ id, title }[]\` — same shape and rule as plans.
-
-### B. Universal principles (apply regardless of shape)
+**Universal principles** (apply regardless of shape):
 
 1. **Lead with the answer.** No "Let me analyze..." or "Found N commits..." preamble.
 
-2. **Ground every concrete claim** to a hash and/or file. Use \`(abc1234)\` for hashes and \`[cli/src/Types.ts](cli/src/Types.ts)\` for files.
+2. **Ground every concrete claim** to its \`hash\` (commit hits) or \`slug\` +
+   \`branch\` (topic hits). Use \`(abc12345)\` for hashes.
 
-3. **Synthesize, don't dump — but DO use verbatim quotes from stored data.** Read everything; fold into coherent prose or bullets. Whenever a phrase from \`recap\` or \`decisions\` captures the answer more compactly than your paraphrase, quote it verbatim in **bold** with attribution.
+3. **Synthesize, don't dump — but DO use verbatim quotes from stored data.**
+   Read everything; fold into coherent prose or bullets. Whenever a phrase from
+   \`snippet\` captures the answer more compactly than your paraphrase, quote it
+   verbatim in **bold** with attribution.
 
-   Quote **complete clauses (typically 10-30 words)** — not 2-3 word fragments that depend on your surrounding paraphrase to mean anything. The reader should be able to skim the bold quote alone and understand its claim. Format, embedded in narrative: *the design chose JWT because* **"the stateless model lets us scale horizontally without a shared session store across regions"** *(decisions, abc1234)*.
+   Quote **complete clauses (typically 10-30 words)** — not 2-3 word fragments
+   that depend on your surrounding paraphrase to mean anything. The reader
+   should be able to skim the bold quote alone and understand its claim.
+   Format, embedded in narrative: *the design chose JWT because*
+   **"the stateless model lets us scale horizontally without a shared session store across regions"**
+   *(snippet, abc12345)*.
 
-   **Bold = verbatim from stored data.** Never use bold for general emphasis. Quotes belong inside running prose or bullets that carry their own narrative — never as bare bullets stripped of context. Stringing bare quotes is the wall-of-fragments failure mode.
+   **Bold = verbatim from stored data.** Never use bold for general emphasis.
+   Quotes belong inside running prose or bullets that carry their own narrative
+   — never as bare bullets stripped of context. Stringing bare quotes is the
+   wall-of-fragments failure mode.
 
-4. **Reply in the user's language.** Template is English; user-visible output matches the user.
+4. **Reply in the user's language.** Template is English; user-visible output
+   matches the user.
 
-5. **Don't expose machinery.** No "Phase 1" / "Phase 2" / "catalog" / "SearchCatalog" / "SearchHit" / "JSON field" mentions.
+5. **Don't expose machinery.** No "BM25" / "SearchHit" / "hits array" / "score"
+   mentions. Don't expose \`slug\` or internal field names either.
 
-### C. Output shape
+6. **Output shape is entirely your call.** Prose, compact list, timeline,
+   per-theme sections — pick whatever serves the query. Every concrete claim
+   must be groundable to a hash or branch.
 
-Your call. The only hard rule: every concrete claim must be groundable to a hash or file (principle 2). If the picks share an obvious unifying theme (same \`branch\` / \`ticketId\` / initiative), name it.
+7. **If the user needs the full decisions/rationale behind a hit**, tell them
+   to run jolli-recall on that hit's \`branch\`.
 
-### D. Empty / partial / failed-hash handling
-
-This is the **only** place where it is appropriate to mention search-machinery
-state (catalog size, truncation, hash load failures). Stay silent about it
-when results are healthy.
-
-- If \`results\` is empty: tell the user no usable content was found and suggest
-  broader keywords or a wider \`--since\`. Coverage chatter is appropriate here:
-  *"Scanned N candidates from the last <window>; none matched."*
-- If the catalog was truncated (\`truncated: true\` from Phase 1) **and** the
-  picks feel thin: *"Catalog hit the token budget; rerun with \`--budget 50000\`
-  to widen the search."*
-- If \`failedHashes\` is non-empty: mention which picks couldn't be loaded so the
-  user knows the search isn't complete.
+**Empty hits** → tell the user nothing matched; suggest broader keywords or a
+different phrasing. Do NOT mention BM25 or index internals.
 `;
 }

--- a/cli/src/install/mcp/CodexTomlWriter.test.ts
+++ b/cli/src/install/mcp/CodexTomlWriter.test.ts
@@ -1,0 +1,120 @@
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { removeCodexMcpServer, upsertCodexMcpServer } from "./CodexTomlWriter.js";
+
+const entry = { command: "/h/.jolli/jollimemory/run-cli", args: ["mcp"] };
+
+describe("CodexTomlWriter", () => {
+	it("creates a [mcp_servers.jollimemory] table", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "c-")), "config.toml");
+		await upsertCodexMcpServer(p, entry);
+		const t = await readFile(p, "utf-8");
+		expect(t).toContain("[mcp_servers.jollimemory]");
+		expect(t).toContain('command = "/h/.jolli/jollimemory/run-cli"');
+		expect(t).toContain('args = ["mcp"]');
+	});
+	it("preserves unrelated content and other tables", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "c-")), "config.toml");
+		await writeFile(p, 'model = "o4"\n\n[mcp_servers.other]\ncommand = "x"\n', "utf-8");
+		await upsertCodexMcpServer(p, entry);
+		const t = await readFile(p, "utf-8");
+		expect(t).toContain('model = "o4"');
+		expect(t).toContain("[mcp_servers.other]");
+		expect(t).toContain("[mcp_servers.jollimemory]");
+	});
+	it("replaces an existing jollimemory table idempotently", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "c-")), "config.toml");
+		await upsertCodexMcpServer(p, { command: "old", args: ["mcp"] });
+		await upsertCodexMcpServer(p, entry);
+		const t = await readFile(p, "utf-8");
+		expect(t).not.toContain('command = "old"');
+		expect((t.match(/\[mcp_servers\.jollimemory\]/g) ?? []).length).toBe(1);
+	});
+	it("removeCodexMcpServer drops only the jollimemory table", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "c-")), "config.toml");
+		await writeFile(p, '[mcp_servers.other]\ncommand = "x"\n', "utf-8");
+		await upsertCodexMcpServer(p, entry);
+		await removeCodexMcpServer(p);
+		const t = await readFile(p, "utf-8");
+		expect(t).not.toContain("jollimemory");
+		expect(t).toContain("[mcp_servers.other]");
+	});
+	it("upsertCodexMcpServer skips and warns when file exists but is unreadable (non-ENOENT)", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "c-")), "config.toml");
+		await writeFile(p, 'model = "o4"\n', "utf-8");
+		await chmod(p, 0o000);
+		try {
+			await upsertCodexMcpServer(p, entry);
+			// file should be untouched (chmod 000 means we cannot write either)
+		} finally {
+			await chmod(p, 0o644);
+		}
+		const t = await readFile(p, "utf-8");
+		expect(t).toBe('model = "o4"\n');
+	});
+	it("removeCodexMcpServer is a no-op when file is absent", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "c-")), "config.toml");
+		await expect(removeCodexMcpServer(p)).resolves.toBeUndefined();
+	});
+	it("removeCodexMcpServer is a no-op when jollimemory header is absent", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "c-")), "config.toml");
+		await writeFile(p, 'model = "o4"\n', "utf-8");
+		await removeCodexMcpServer(p);
+		expect(await readFile(p, "utf-8")).toBe('model = "o4"\n');
+	});
+	it("upsertCodexMcpServer works when args is omitted (defaults to [])", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "c-")), "config.toml");
+		await upsertCodexMcpServer(p, { command: "/path/to/cli" });
+		const t = await readFile(p, "utf-8");
+		expect(t).toContain("args = []");
+	});
+	it("removeCodexMcpServer handles block at EOF without trailing header", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "c-")), "config.toml");
+		// jollimemory is the last table in the file (no subsequent '[' header)
+		await writeFile(p, '[mcp_servers.jollimemory]\ncommand = "old"\nargs = ["mcp"]\n', "utf-8");
+		await removeCodexMcpServer(p);
+		const t = await readFile(p, "utf-8");
+		expect(t).not.toContain("jollimemory");
+	});
+	it("preserves intentional blank-line runs elsewhere when replacing the block", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "c-")), "config.toml");
+		// A deliberate triple-newline gap between [a] and [b] must survive an upsert
+		// that replaces the jollimemory block — only the block's own seam is touched.
+		await writeFile(
+			p,
+			'[a]\nx = 1\n\n\n[b]\ny = 2\n\n[mcp_servers.jollimemory]\ncommand = "old"\nargs = ["mcp"]\n',
+			"utf-8",
+		);
+		await upsertCodexMcpServer(p, entry);
+		const t = await readFile(p, "utf-8");
+		expect(t).toContain("x = 1\n\n\n[b]");
+		expect(t).not.toContain('command = "old"');
+		expect((t.match(/\[mcp_servers\.jollimemory\]/g) ?? []).length).toBe(1);
+	});
+	it("does not treat a header string inside a comment as the table (line-anchored)", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "c-")), "config.toml");
+		// The header substring appears mid-line in a comment; removal must be a
+		// no-op (the real table is absent) and must not truncate the file.
+		const original = '# example: [mcp_servers.jollimemory]\nmodel = "o4"\n';
+		await writeFile(p, original, "utf-8");
+		await removeCodexMcpServer(p);
+		expect(await readFile(p, "utf-8")).toBe(original);
+	});
+	it("removeCodexMcpServer strips a jollimemory block followed by another table", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "c-")), "config.toml");
+		// jollimemory is NOT the last table — a subsequent '[' header follows it,
+		// so stripBlock must cut only up to that header (the after !== -1 branch).
+		await writeFile(
+			p,
+			'[mcp_servers.jollimemory]\ncommand = "old"\nargs = ["mcp"]\n\n[mcp_servers.other]\ncommand = "x"\n',
+			"utf-8",
+		);
+		await removeCodexMcpServer(p);
+		const t = await readFile(p, "utf-8");
+		expect(t).not.toContain("jollimemory");
+		expect(t).toContain("[mcp_servers.other]");
+		expect(t).toContain('command = "x"');
+	});
+});

--- a/cli/src/install/mcp/CodexTomlWriter.ts
+++ b/cli/src/install/mcp/CodexTomlWriter.ts
@@ -1,0 +1,109 @@
+/**
+ * Minimal block-level TOML writer for Codex MCP server registration.
+ *
+ * ## Verified config format (observed from real ~/.codex/config.toml on developer machine,
+ *    confirmed against official Codex docs at https://developers.openai.com/codex/mcp)
+ *
+ * Codex CLI global config: ~/.codex/config.toml
+ * MCP servers use table key `mcp_servers` (underscore, NOT `mcpServers` or `mcp-servers`):
+ *
+ *   [mcp_servers.jollimemory]
+ *   command = "/path/to/run-cli"
+ *   args = ["mcp"]
+ *
+ * `args` is a standard TOML string array. `command` is a TOML string (double-quoted).
+ * JSON.stringify produces valid TOML string / string-array values for our inputs
+ * (no backslash paths, no special chars in args).
+ *
+ * ## Block-level merge strategy (no TOML library)
+ *
+ * We treat `[mcp_servers.jollimemory]` as a contiguous text block from its header line
+ * to the next table `[` header (or EOF). Strip-then-append: remove any existing block,
+ * then append the new block after the remaining content.
+ *
+ * The header is matched ONLY at the start of a line (start-of-file or after a
+ * newline), so a header string that merely appears inside a comment or value
+ * (e.g. `# see [mcp_servers.jollimemory]`) is never mistaken for the table.
+ *
+ * All other content is byte-stable: only the seam left behind by removing the
+ * block is normalized to a single blank line — blank-line runs elsewhere in the
+ * file are preserved exactly.
+ *
+ * ## Error-guard pattern (mirrors JsonMcpWriter.ts)
+ * ENOENT -> create fresh file; any other read error -> log.warn + return (file untouched).
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { createLogger } from "../../Logger.js";
+
+const log = createLogger("CodexTomlWriter");
+const HEADER = "[mcp_servers.jollimemory]";
+
+function renderBlock(entry: { command: string; args?: string[] }): string {
+	return `${HEADER}\ncommand = ${JSON.stringify(entry.command)}\nargs = ${JSON.stringify(entry.args ?? [])}\n`;
+}
+
+/**
+ * Index of the `[mcp_servers.jollimemory]` table header, matched only at the
+ * start of a line (offset 0 or immediately after a `\n`). Returns -1 if the
+ * header is absent at line start — a header that only appears inside a comment
+ * or value is intentionally not matched.
+ */
+function findBlockStart(text: string): number {
+	if (text.startsWith(HEADER)) return 0;
+	const idx = text.indexOf(`\n${HEADER}`);
+	return idx === -1 ? -1 : idx + 1;
+}
+
+function stripBlock(text: string): string {
+	const start = findBlockStart(text);
+	if (start === -1) return text;
+	const after = text.indexOf("\n[", start + HEADER.length);
+	const end = after === -1 ? text.length : after + 1;
+	const before = text.slice(0, start);
+	const rest = text.slice(end);
+	// Only normalize the seam between the kept content and what followed the
+	// removed block — collapse the trailing newlines of `before` to a single
+	// blank line. Untouched regions stay byte-for-byte identical.
+	if (before === "" || rest === "") return before + rest;
+	return `${before.replace(/\n+$/, "")}\n\n${rest}`;
+}
+
+/**
+ * Add or refresh the `[mcp_servers.jollimemory]` table in the Codex config at `p`.
+ * All other content is preserved byte-stable. Idempotent: re-running with the same
+ * entry produces exactly one header. Parent directories are created if absent.
+ */
+export async function upsertCodexMcpServer(p: string, entry: { command: string; args?: string[] }): Promise<void> {
+	let text = "";
+	try {
+		text = await readFile(p, "utf-8");
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+			log.warn("Skipping Codex MCP: %s unreadable (%s)", p, String(err));
+			return;
+		}
+	}
+	const base = stripBlock(text).replace(/\s*$/, "");
+	const next = base.length === 0 ? renderBlock(entry) : `${base}\n\n${renderBlock(entry)}`;
+	await mkdir(dirname(p), { recursive: true });
+	await writeFile(p, next, "utf-8");
+	log.info("Registered Codex MCP server in %s", p);
+}
+
+/**
+ * Remove the `[mcp_servers.jollimemory]` table from the Codex config at `p`.
+ * No-op if the file is absent or the table is not present. Other content preserved.
+ */
+export async function removeCodexMcpServer(p: string): Promise<void> {
+	let text: string;
+	try {
+		text = await readFile(p, "utf-8");
+	} catch {
+		return;
+	}
+	if (findBlockStart(text) === -1) return;
+	await writeFile(p, `${stripBlock(text).replace(/\s*$/, "")}\n`, "utf-8");
+	log.info("Removed Codex MCP server from %s", p);
+}

--- a/cli/src/install/mcp/HostRegistrars.test.ts
+++ b/cli/src/install/mcp/HostRegistrars.test.ts
@@ -1,0 +1,395 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getVscodeUserDataDir } from "../../core/VscodeWorkspaceLocator.js";
+import { MCP_GIT_EXCLUDE_PATH } from "../McpRegistration.js";
+import { buildRegistrars, registerRepoMcpHosts, removeRepoMcpHosts } from "./HostRegistrars.js";
+
+const NONE = {
+	claude: false,
+	codex: false,
+	cursor: false,
+	gemini: false,
+	opencode: false,
+	copilot: false,
+	copilotChat: false,
+} as const;
+
+let dir: string;
+beforeEach(async () => {
+	dir = await mkdtemp(join(tmpdir(), "jolli-host-reg-"));
+});
+afterEach(async () => {
+	await rm(dir, { recursive: true, force: true });
+});
+
+describe("buildRegistrars", () => {
+	it("returns claude registrar when detected.claude is true", () => {
+		const registrars = buildRegistrars({ ...NONE, claude: true });
+		expect(registrars.map((r) => r.host)).toEqual(["claude"]);
+	});
+
+	it("omits claude when detected.claude is false", () => {
+		const registrars = buildRegistrars({ ...NONE });
+		expect(registrars).toHaveLength(0);
+	});
+
+	it("claude registrar.register() writes .mcp.json with mcpServers.jollimemory.args === ['mcp']", async () => {
+		const [claude] = buildRegistrars({ ...NONE, claude: true });
+		await claude.register(dir);
+		const json = JSON.parse(await readFile(join(dir, ".mcp.json"), "utf-8"));
+		expect(json.mcpServers.jollimemory.args).toEqual(["mcp"]);
+	});
+
+	it("claude registrar.gitExcludePaths() returns [MCP_GIT_EXCLUDE_PATH]", () => {
+		const [claude] = buildRegistrars({ ...NONE, claude: true });
+		expect(claude.gitExcludePaths()).toEqual([MCP_GIT_EXCLUDE_PATH]);
+	});
+
+	it("claude registrar.remove() is a no-op when file is absent", async () => {
+		const [claude] = buildRegistrars({ ...NONE, claude: true });
+		await expect(claude.remove(dir)).resolves.toBeUndefined();
+	});
+});
+
+describe("registerRepoMcpHosts", () => {
+	it("registers claude (repo-scoped) when detected", async () => {
+		await registerRepoMcpHosts(dir, { ...NONE, claude: true });
+		const json = JSON.parse(await readFile(join(dir, ".mcp.json"), "utf-8"));
+		expect(json.mcpServers.jollimemory.args).toEqual(["mcp"]);
+	});
+
+	it("skips registration when no hosts detected", async () => {
+		await registerRepoMcpHosts(dir, { ...NONE });
+		await expect(readFile(join(dir, ".mcp.json"), "utf-8")).rejects.toThrow();
+	});
+
+	it("does not write global-host configs (codex etc.) — those go through registerGlobalMcpHosts", async () => {
+		// codex is global-scoped; registerRepoMcpHosts must skip it even when detected.
+		await registerRepoMcpHosts(dir, { ...NONE, codex: true });
+		await expect(readFile(join(dir, ".mcp.json"), "utf-8")).rejects.toThrow();
+	});
+
+	it("swallows thrown register error with warn (non-fatal) — unwritable nested path", async () => {
+		// An unwritable nested path causes registerMcpInClaude to throw ENOENT;
+		// registerRepoMcpHosts must catch it and resolve without rethrowing.
+		const unwritable = join(dir, "no-such-dir", "nested");
+		await expect(registerRepoMcpHosts(unwritable, { ...NONE, claude: true })).resolves.toBeUndefined();
+	});
+});
+
+describe("cursor registrar", () => {
+	it("appears in buildRegistrars when detected.cursor is true", () => {
+		const registrars = buildRegistrars({ ...NONE, cursor: true });
+		expect(registrars.map((r) => r.host)).toContain("cursor");
+	});
+
+	it("does not appear when detected.cursor is false", () => {
+		const registrars = buildRegistrars({ ...NONE });
+		expect(registrars.map((r) => r.host)).not.toContain("cursor");
+	});
+
+	it("gitExcludePaths() returns ['/.cursor/mcp.json']", () => {
+		const [cursor] = buildRegistrars({ ...NONE, cursor: true });
+		expect(cursor.gitExcludePaths()).toEqual(["/.cursor/mcp.json"]);
+	});
+
+	it("register() writes <worktree>/.cursor/mcp.json with mcpServers.jollimemory", async () => {
+		const [cursor] = buildRegistrars({ ...NONE, cursor: true });
+		await cursor.register(dir);
+		const json = JSON.parse(await readFile(join(dir, ".cursor", "mcp.json"), "utf-8"));
+		expect(json.mcpServers.jollimemory).toBeDefined();
+		expect(json.mcpServers.jollimemory.args).toEqual(["mcp"]);
+	});
+
+	it("remove() is a no-op when .cursor/mcp.json is absent", async () => {
+		const [cursor] = buildRegistrars({ ...NONE, cursor: true });
+		await expect(cursor.remove(dir)).resolves.toBeUndefined();
+	});
+
+	it("remove() removes only jollimemory from .cursor/mcp.json", async () => {
+		const [cursor] = buildRegistrars({ ...NONE, cursor: true });
+		await cursor.register(dir);
+		await cursor.remove(dir);
+		const json = JSON.parse(await readFile(join(dir, ".cursor", "mcp.json"), "utf-8"));
+		expect(json.mcpServers?.jollimemory).toBeUndefined();
+	});
+});
+
+describe("gemini registrar — structure", () => {
+	it("appears in buildRegistrars when detected.gemini is true", () => {
+		const registrars = buildRegistrars({ ...NONE, gemini: true });
+		expect(registrars.map((r) => r.host)).toContain("gemini");
+	});
+
+	it("does not appear when detected.gemini is false", () => {
+		const registrars = buildRegistrars({ ...NONE });
+		expect(registrars.map((r) => r.host)).not.toContain("gemini");
+	});
+
+	it("gitExcludePaths() returns [] (global config, never committed)", () => {
+		const [gemini] = buildRegistrars({ ...NONE, gemini: true });
+		expect(gemini.gitExcludePaths()).toEqual([]);
+	});
+});
+
+describe("gemini registrar — register/remove target ~/.gemini/settings.json", () => {
+	// Use vi.doMock + resetModules so the mock is scoped to this describe block
+	// and does not affect the cursor tests above, which rely on real file writes.
+	const upsertMock = vi.fn().mockResolvedValue(undefined);
+	const removeMock = vi.fn().mockResolvedValue(undefined);
+	const geminiSettingsPath = join(homedir(), ".gemini", "settings.json");
+
+	beforeEach(() => {
+		vi.resetModules();
+		vi.doMock("./JsonMcpWriter.js", () => ({
+			upsertJsonMcpServer: upsertMock,
+			removeJsonMcpServer: removeMock,
+		}));
+		upsertMock.mockClear();
+		removeMock.mockClear();
+	});
+
+	afterEach(() => {
+		vi.doUnmock("./JsonMcpWriter.js");
+		vi.resetModules();
+	});
+
+	it("register() calls upsertJsonMcpServer with ~/.gemini/settings.json", async () => {
+		const { buildRegistrars: build } = await import("./HostRegistrars.js");
+		const [gemini] = build({ ...NONE, gemini: true });
+		await gemini.register("/some/wt");
+		expect(upsertMock).toHaveBeenCalledOnce();
+		expect(upsertMock.mock.calls[0][0]).toBe(geminiSettingsPath);
+	});
+
+	it("remove() calls removeJsonMcpServer with ~/.gemini/settings.json", async () => {
+		const { buildRegistrars: build } = await import("./HostRegistrars.js");
+		const [gemini] = build({ ...NONE, gemini: true });
+		await gemini.remove("/some/wt");
+		expect(removeMock).toHaveBeenCalledOnce();
+		expect(removeMock.mock.calls[0][0]).toBe(geminiSettingsPath);
+	});
+});
+
+describe("codex registrar — structure", () => {
+	it("appears in buildRegistrars when detected.codex is true", () => {
+		const registrars = buildRegistrars({ ...NONE, codex: true });
+		expect(registrars.map((r) => r.host)).toContain("codex");
+	});
+
+	it("does not appear when detected.codex is false", () => {
+		const registrars = buildRegistrars({ ...NONE });
+		expect(registrars.map((r) => r.host)).not.toContain("codex");
+	});
+
+	it("gitExcludePaths() returns [] (global config, never committed)", () => {
+		const [codex] = buildRegistrars({ ...NONE, codex: true });
+		expect(codex.gitExcludePaths()).toEqual([]);
+	});
+});
+
+describe("codex registrar — register/remove target ~/.codex/config.toml", () => {
+	// Use vi.doMock + resetModules so the mock is scoped to this describe block
+	// and does not affect other tests that rely on real file writes.
+	const upsertMock = vi.fn().mockResolvedValue(undefined);
+	const removeMock = vi.fn().mockResolvedValue(undefined);
+	const codexConfigPath = join(homedir(), ".codex", "config.toml");
+
+	beforeEach(() => {
+		vi.resetModules();
+		vi.doMock("./CodexTomlWriter.js", () => ({
+			upsertCodexMcpServer: upsertMock,
+			removeCodexMcpServer: removeMock,
+		}));
+		upsertMock.mockClear();
+		removeMock.mockClear();
+	});
+
+	afterEach(() => {
+		vi.doUnmock("./CodexTomlWriter.js");
+		vi.resetModules();
+	});
+
+	it("register() calls upsertCodexMcpServer with ~/.codex/config.toml", async () => {
+		const { buildRegistrars: build } = await import("./HostRegistrars.js");
+		const [codex] = build({ ...NONE, codex: true });
+		await codex.register("/some/wt");
+		expect(upsertMock).toHaveBeenCalledOnce();
+		expect(upsertMock.mock.calls[0][0]).toBe(codexConfigPath);
+	});
+
+	it("remove() calls removeCodexMcpServer with ~/.codex/config.toml", async () => {
+		const { buildRegistrars: build } = await import("./HostRegistrars.js");
+		const [codex] = build({ ...NONE, codex: true });
+		await codex.remove("/some/wt");
+		expect(removeMock).toHaveBeenCalledOnce();
+		expect(removeMock.mock.calls[0][0]).toBe(codexConfigPath);
+	});
+});
+
+describe("removeRepoMcpHosts", () => {
+	it("removes claude regardless of detection", async () => {
+		await registerRepoMcpHosts(dir, { ...NONE, claude: true });
+		await removeRepoMcpHosts(dir);
+		const json = JSON.parse(await readFile(join(dir, ".mcp.json"), "utf-8"));
+		expect(json.mcpServers?.jollimemory).toBeUndefined();
+	});
+
+	it("resolves without throwing when dir has no .mcp.json", async () => {
+		await expect(removeRepoMcpHosts(dir)).resolves.toBeUndefined();
+	});
+
+	it("swallows removal error with warn (non-fatal) — spied registrar remove", async () => {
+		// claudeRegistrar is the module-level singleton that buildRegistrars returns.
+		// Temporarily replace its remove method to force a throw, exercise the
+		// catch/warn path in removeRepoMcpHosts, then restore.
+		const [registrar] = buildRegistrars({ ...NONE, claude: true });
+		const originalRemove = registrar.remove;
+		registrar.remove = vi.fn().mockRejectedValue(new Error("simulated removal failure"));
+		try {
+			await expect(removeRepoMcpHosts(dir)).resolves.toBeUndefined();
+		} finally {
+			registrar.remove = originalRemove;
+		}
+	});
+});
+
+describe("opencode/copilot/copilotChat registrars — structure", () => {
+	it("opencode appears when detected.opencode is true, with empty gitExcludePaths", () => {
+		const [r] = buildRegistrars({ ...NONE, opencode: true });
+		expect(r.host).toBe("opencode");
+		expect(r.gitExcludePaths()).toEqual([]);
+	});
+	it("copilot appears when detected.copilot is true", () => {
+		expect(buildRegistrars({ ...NONE, copilot: true }).map((r) => r.host)).toContain("copilot");
+	});
+	it("copilotChat appears when detected.copilotChat is true", () => {
+		expect(buildRegistrars({ ...NONE, copilotChat: true }).map((r) => r.host)).toContain("copilotChat");
+	});
+});
+
+describe("new registrars — register targets & entry shape (mocked writer)", () => {
+	const upsertMock = vi.fn().mockResolvedValue(undefined);
+	const removeMock = vi.fn().mockResolvedValue(undefined);
+	beforeEach(() => {
+		vi.resetModules();
+		vi.doMock("./JsonMcpWriter.js", () => ({ upsertJsonMcpServer: upsertMock, removeJsonMcpServer: removeMock }));
+		upsertMock.mockClear();
+		removeMock.mockClear();
+	});
+	afterEach(() => {
+		vi.doUnmock("./JsonMcpWriter.js");
+		vi.resetModules();
+	});
+
+	it("opencode register() → ~/.config/opencode/opencode.json, key `mcp`, type:local + array command", async () => {
+		const { buildRegistrars: build } = await import("./HostRegistrars.js");
+		const [r] = build({ ...NONE, opencode: true });
+		await r.register("/some/wt");
+		const [path, entry, key] = upsertMock.mock.calls[0];
+		expect(path).toBe(join(homedir(), ".config", "opencode", "opencode.json"));
+		expect(key).toBe("mcp");
+		expect(entry.type).toBe("local");
+		expect(Array.isArray(entry.command)).toBe(true);
+		expect(entry.command.at(-1)).toBe("mcp");
+	});
+
+	it("copilot register() → ~/.copilot/mcp-config.json, default key, {command,args}", async () => {
+		const { buildRegistrars: build } = await import("./HostRegistrars.js");
+		const [r] = build({ ...NONE, copilot: true });
+		await r.register("/some/wt");
+		const [path, entry, key] = upsertMock.mock.calls[0];
+		expect(path).toBe(join(homedir(), ".copilot", "mcp-config.json"));
+		expect(key).toBeUndefined(); // default mcpServers
+		expect(entry.args).toEqual(["mcp"]);
+	});
+
+	it("copilotChat register() → VS Code User/mcp.json, key `servers`, type:stdio", async () => {
+		const { buildRegistrars: build } = await import("./HostRegistrars.js");
+		const [r] = build({ ...NONE, copilotChat: true });
+		await r.register("/some/wt");
+		const [path, entry, key] = upsertMock.mock.calls[0];
+		expect(path).toBe(join(getVscodeUserDataDir("Code"), "User", "mcp.json"));
+		expect(key).toBe("servers");
+		expect(entry.type).toBe("stdio");
+		expect(entry.args).toEqual(["mcp"]);
+	});
+
+	it("opencode/copilotChat remove() pass the right serversKey", async () => {
+		const { buildRegistrars: build } = await import("./HostRegistrars.js");
+		await build({ ...NONE, opencode: true })[0].remove("/some/wt");
+		expect(removeMock.mock.calls[0][1]).toBe("mcp");
+		removeMock.mockClear();
+		await build({ ...NONE, copilotChat: true })[0].remove("/some/wt");
+		expect(removeMock.mock.calls[0][1]).toBe("servers");
+	});
+});
+
+describe("scope filtering — global vs repo", () => {
+	const upsertMock = vi.fn().mockResolvedValue(undefined);
+	const removeMock = vi.fn().mockResolvedValue(undefined);
+	beforeEach(() => {
+		vi.resetModules();
+		vi.doMock("./JsonMcpWriter.js", () => ({ upsertJsonMcpServer: upsertMock, removeJsonMcpServer: removeMock }));
+		upsertMock.mockClear();
+		removeMock.mockClear();
+	});
+	afterEach(() => {
+		vi.doUnmock("./JsonMcpWriter.js");
+		vi.resetModules();
+	});
+
+	it("registerGlobalMcpHosts writes detected global hosts (copilot) and skips repo hosts (cursor)", async () => {
+		const { registerGlobalMcpHosts: regGlobal } = await import("./HostRegistrars.js");
+		await regGlobal({ ...NONE, copilot: true, cursor: true });
+		const paths = upsertMock.mock.calls.map((c) => c[0] as string);
+		expect(paths).toContain(join(homedir(), ".copilot", "mcp-config.json"));
+		expect(paths.every((p) => !p.includes(".cursor"))).toBe(true);
+	});
+
+	it("registerGlobalMcpHosts is a no-op when no global hosts detected", async () => {
+		const { registerGlobalMcpHosts: regGlobal } = await import("./HostRegistrars.js");
+		await regGlobal({ ...NONE, claude: true, cursor: true });
+		expect(upsertMock).not.toHaveBeenCalled();
+	});
+
+	it("removeRepoMcpHosts touches only repo hosts (cursor), never global hosts", async () => {
+		const { removeRepoMcpHosts: rmRepo } = await import("./HostRegistrars.js");
+		await rmRepo("/some/wt");
+		// Only the cursor (.cursor/mcp.json) repo host flows through JsonMcpWriter;
+		// claude uses removeMcpFromClaude directly, and every global host is skipped.
+		expect(removeMock.mock.calls.map((c) => c[0] as string)).toEqual([join("/some/wt", ".cursor", "mcp.json")]);
+	});
+});
+
+describe("jolliEntry — Windows resolves Cli.js and spawns node", () => {
+	const upsertMock = vi.fn().mockResolvedValue(undefined);
+	const originalPlatform = process.platform;
+	beforeEach(() => {
+		vi.resetModules();
+		Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+		vi.doMock("./JsonMcpWriter.js", () => ({ upsertJsonMcpServer: upsertMock, removeJsonMcpServer: vi.fn() }));
+		vi.doMock("../McpRegistration.js", async (importOriginal) => {
+			const actual = await importOriginal<typeof import("../McpRegistration.js")>();
+			return { ...actual, resolveCliJs: () => "/dist/Cli.js" };
+		});
+		upsertMock.mockClear();
+	});
+	afterEach(() => {
+		Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+		vi.doUnmock("./JsonMcpWriter.js");
+		vi.doUnmock("../McpRegistration.js");
+		vi.resetModules();
+	});
+
+	it("non-Claude host entry on win32 is { command: 'node', args: ['<Cli.js>', 'mcp'] }", async () => {
+		const { buildRegistrars: build } = await import("./HostRegistrars.js");
+		const [copilot] = build({ ...NONE, copilot: true });
+		await copilot.register("/wt");
+		const entry = upsertMock.mock.calls[0][1] as { command: string; args: string[] };
+		expect(entry.command).toBe("node");
+		expect(entry.args).toEqual(["/dist/Cli.js", "mcp"]);
+	});
+});

--- a/cli/src/install/mcp/HostRegistrars.ts
+++ b/cli/src/install/mcp/HostRegistrars.ts
@@ -1,0 +1,265 @@
+/**
+ * Per-host MCP registrar abstraction.
+ *
+ * Each AI coding host that supports the Model Context Protocol gets a
+ * `McpHostRegistrar` implementation, tagged with a `scope` ("repo" | "global")
+ * that says where its config file lives. `buildRegistrars` assembles the list of
+ * active registrars based on which hosts were detected in the user's project.
+ * `registerRepoMcpHosts` / `registerGlobalMcpHosts` / `removeRepoMcpHosts`
+ * iterate over the relevant scope with per-host error isolation so a single
+ * failing registration never blocks the others or fails the install.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { getGlobalConfigDir } from "../../core/SessionTracker.js";
+import { getVscodeUserDataDir } from "../../core/VscodeWorkspaceLocator.js";
+import { createLogger } from "../../Logger.js";
+import {
+	MCP_GIT_EXCLUDE_PATH,
+	mcpServerEntry,
+	registerMcpInClaude,
+	removeMcpFromClaude,
+	resolveCliJs,
+} from "../McpRegistration.js";
+import { removeCodexMcpServer, upsertCodexMcpServer } from "./CodexTomlWriter.js";
+import { removeJsonMcpServer, upsertJsonMcpServer } from "./JsonMcpWriter.js";
+
+const log = createLogger("HostRegistrars");
+
+export interface DetectedHosts {
+	claude: boolean;
+	codex: boolean;
+	cursor: boolean;
+	gemini: boolean;
+	opencode: boolean;
+	copilot: boolean;
+	copilotChat: boolean;
+}
+
+export interface McpHostRegistrar {
+	host: string;
+	/**
+	 * Where this host's config lives:
+	 * - `"repo"`: project-scoped file inside the worktree (`.mcp.json`,
+	 *   `.cursor/mcp.json`). Belongs to this repo — safe to remove on uninstall.
+	 * - `"global"`: a single machine-wide file shared by EVERY repo
+	 *   (`~/.codex/config.toml`, `~/.gemini/settings.json`, …). The `jollimemory`
+	 *   entry is repo-agnostic, so a single-repo uninstall must NOT remove it or
+	 *   it breaks MCP for every other repo still using Jolli.
+	 */
+	scope: "repo" | "global";
+	register(wt: string): Promise<void>;
+	remove(wt: string): Promise<void>;
+	gitExcludePaths(): string[];
+}
+
+const claudeRegistrar: McpHostRegistrar = {
+	host: "claude",
+	scope: "repo",
+	register: registerMcpInClaude,
+	remove: removeMcpFromClaude,
+	gitExcludePaths: () => [MCP_GIT_EXCLUDE_PATH],
+};
+
+/**
+ * Build the `{ command, args }` entry for non-Claude MCP hosts.
+ *
+ * Uses the same `run-cli` dispatch script as the Claude registrar so version
+ * bumps are handled transparently. Windows note: `run-cli` is an extension-less
+ * bash script that a host cannot spawn directly (no shebang support, not on
+ * PATHEXT), so on win32 we resolve the winning dist's `Cli.js` and spawn `node`
+ * on it — exactly what `registerMcpInClaude` does. Mirroring it here keeps
+ * Codex/Cursor/Gemini/OpenCode/Copilot working on Windows instead of writing a
+ * command the host can't launch. POSIX spawns the bash shebang directly, so
+ * `cliJs` stays undefined there.
+ */
+function jolliEntry() {
+	const globalDir = getGlobalConfigDir();
+	const cliJs = process.platform === "win32" ? resolveCliJs(globalDir) : undefined;
+	return mcpServerEntry(process.platform, join(globalDir, "run-cli"), cliJs);
+}
+
+/**
+ * Cursor: project-scoped `<worktree>/.cursor/mcp.json`.
+ * Format verified from Cursor app source (parseMcpServersFromFile in workbench.desktop.main.js):
+ * top-level key `mcpServers`, entry shape `{ command, args?, env?, envFile?, cwd? }`.
+ * Contains an absolute machine-local path, so it must not be committed.
+ */
+const cursorRegistrar: McpHostRegistrar = {
+	host: "cursor",
+	scope: "repo",
+	register: (wt) => upsertJsonMcpServer(join(wt, ".cursor", "mcp.json"), { ...jolliEntry() }),
+	remove: (wt) => removeJsonMcpServer(join(wt, ".cursor", "mcp.json")),
+	gitExcludePaths: () => ["/.cursor/mcp.json"],
+};
+
+/**
+ * Gemini CLI: global `~/.gemini/settings.json` (GEMINI_DIR = ".gemini").
+ * Format verified from Gemini CLI 0.38.2 source (SETTINGS_SCHEMA_DEFINITIONS.MCPServerConfig):
+ * top-level key `mcpServers`, entry shape `{ command?, args?, env?, cwd?, url? }`.
+ * Global config — never committed, so gitExcludePaths returns [].
+ */
+const geminiRegistrar: McpHostRegistrar = {
+	host: "gemini",
+	scope: "global",
+	register: () => upsertJsonMcpServer(join(homedir(), ".gemini", "settings.json"), { ...jolliEntry() }),
+	remove: () => removeJsonMcpServer(join(homedir(), ".gemini", "settings.json")),
+	gitExcludePaths: () => [],
+};
+
+/**
+ * Codex CLI: global `~/.codex/config.toml`.
+ * Format verified from official Codex docs (https://developers.openai.com/codex/mcp)
+ * and confirmed against a real ~/.codex/config.toml on developer machine:
+ *   [mcp_servers.jollimemory]
+ *   command = "/path/to/run-cli"
+ *   args = ["mcp"]
+ * Table key is `mcp_servers` (underscore). Global config — never committed, so
+ * gitExcludePaths returns [].
+ */
+const codexRegistrar: McpHostRegistrar = {
+	host: "codex",
+	scope: "global",
+	register: () => upsertCodexMcpServer(join(homedir(), ".codex", "config.toml"), jolliEntry()),
+	remove: () => removeCodexMcpServer(join(homedir(), ".codex", "config.toml")),
+	gitExcludePaths: () => [],
+};
+
+/**
+ * OpenCode: global `~/.config/opencode/opencode.json`.
+ * Format live-verified via `opencode mcp list` (opencode-ai 1.4.1): top-level key
+ * `mcp`; entry REQUIRES `type:"local"` and a single `command` ARRAY (command + args
+ * combined). `mcpServers` key → "Unrecognized key"; split {command,args} → "Invalid
+ * input"; missing `type` → "Invalid input". `enabled` defaults true. Global config —
+ * never committed, so gitExcludePaths returns [].
+ */
+const opencodeRegistrar: McpHostRegistrar = {
+	host: "opencode",
+	scope: "global",
+	register: () => {
+		const base = jolliEntry();
+		const entry = { type: "local", command: [base.command, ...base.args], enabled: true };
+		return upsertJsonMcpServer(join(homedir(), ".config", "opencode", "opencode.json"), entry, "mcp");
+	},
+	remove: () => removeJsonMcpServer(join(homedir(), ".config", "opencode", "opencode.json"), "mcp"),
+	gitExcludePaths: () => [],
+};
+
+/**
+ * GitHub Copilot CLI: user-global `~/.copilot/mcp-config.json`.
+ * Format live-verified via `copilot mcp add`/`get` (copilot CLI): top-level key
+ * `mcpServers`, entry `{ command, args }` (Copilot defaults `type:"local"` when omitted —
+ * live-verified). Same shape as Cursor/Gemini, so the default writer key is reused.
+ * NOTE: Copilot CLI ALSO reads workspace `.mcp.json`, which the Claude registrar already
+ * writes — so the workspace path is covered there; this registrar handles only the
+ * user-global file. Global config — never committed, so gitExcludePaths returns [].
+ */
+const copilotCliRegistrar: McpHostRegistrar = {
+	host: "copilot",
+	scope: "global",
+	register: () => upsertJsonMcpServer(join(homedir(), ".copilot", "mcp-config.json"), { ...jolliEntry() }),
+	remove: () => removeJsonMcpServer(join(homedir(), ".copilot", "mcp-config.json")),
+	gitExcludePaths: () => [],
+};
+
+/**
+ * VS Code Copilot Chat: user-global `<vscodeUserDataDir>/User/mcp.json`.
+ * Format from VS Code app source (workbench.desktop.main.js): top-level key
+ * `servers` (`serversKey ?? "servers"`); stdio entry `{ type:"stdio", command, args }`.
+ * ⚠️ Verified against VS Code app source; not yet confirmed by a live smoke test.
+ * Global config — never committed, so gitExcludePaths returns [].
+ */
+const copilotChatRegistrar: McpHostRegistrar = {
+	host: "copilotChat",
+	scope: "global",
+	register: () => {
+		const base = jolliEntry();
+		const entry = { type: "stdio", command: base.command, args: base.args };
+		return upsertJsonMcpServer(join(getVscodeUserDataDir("Code"), "User", "mcp.json"), entry, "servers");
+	},
+	remove: () => removeJsonMcpServer(join(getVscodeUserDataDir("Code"), "User", "mcp.json"), "servers"),
+	gitExcludePaths: () => [],
+};
+
+/**
+ * Return the ordered list of registrars for the detected set of hosts.
+ */
+export function buildRegistrars(detected: DetectedHosts): McpHostRegistrar[] {
+	const out: McpHostRegistrar[] = [];
+	if (detected.claude) out.push(claudeRegistrar);
+	if (detected.cursor) out.push(cursorRegistrar);
+	if (detected.gemini) out.push(geminiRegistrar);
+	if (detected.codex) out.push(codexRegistrar);
+	if (detected.opencode) out.push(opencodeRegistrar);
+	if (detected.copilot) out.push(copilotCliRegistrar);
+	if (detected.copilotChat) out.push(copilotChatRegistrar);
+	return out;
+}
+
+/** Every host treated as detected — used so removal covers hosts that may have
+ * been registered by a previous install even if not detected right now. */
+const ALL_DETECTED: DetectedHosts = {
+	claude: true,
+	codex: true,
+	cursor: true,
+	gemini: true,
+	opencode: true,
+	copilot: true,
+	copilotChat: true,
+};
+
+/** Run `fn` over `regs` with per-host error isolation — one failure is logged
+ * as a warning but never blocks the rest or fails the install/uninstall. */
+async function forEachIsolated(
+	regs: McpHostRegistrar[],
+	wt: string,
+	verb: string,
+	fn: (r: McpHostRegistrar) => Promise<void>,
+): Promise<void> {
+	for (const r of regs) {
+		try {
+			await fn(r);
+		} catch (err) {
+			log.warn("MCP %s failed for %s in %s (non-fatal): %s", verb, r.host, wt, String(err));
+		}
+	}
+}
+
+/**
+ * Register the MCP server in the detected **repo-scoped** hosts (Claude, Cursor).
+ * Their config files live inside the worktree, so this is called once per
+ * worktree in the install loop.
+ */
+export async function registerRepoMcpHosts(wt: string, detected: DetectedHosts): Promise<void> {
+	const regs = buildRegistrars(detected).filter((r) => r.scope === "repo");
+	await forEachIsolated(regs, wt, "registration", (r) => r.register(wt));
+}
+
+/**
+ * Register the MCP server in the detected **global** hosts (Codex, Gemini,
+ * OpenCode, Copilot, Copilot Chat). Their config files are machine-wide and
+ * shared by every repo, so this is called ONCE per install — not per worktree —
+ * to avoid rewriting the same file N times.
+ */
+export async function registerGlobalMcpHosts(detected: DetectedHosts): Promise<void> {
+	const regs = buildRegistrars(detected).filter((r) => r.scope === "global");
+	// `wt` is ignored by global registrars; pass "" purely to satisfy the signature.
+	await forEachIsolated(regs, "(global)", "registration", (r) => r.register(""));
+}
+
+/**
+ * Remove the JolliMemory MCP entry from the **repo-scoped** hosts (Claude,
+ * Cursor) for this worktree. Runs for ALL known repo hosts regardless of current
+ * detection so an uninstall still cleans up a host that was registered earlier.
+ *
+ * Global hosts are deliberately NOT removed: their `jollimemory` entry is shared
+ * across every repo on the machine, so removing it during a single-repo
+ * uninstall would break MCP for all other repos still using Jolli. A stale
+ * global entry is harmless (idempotently refreshed on the next install) and far
+ * preferable to cross-repo breakage.
+ */
+export async function removeRepoMcpHosts(wt: string): Promise<void> {
+	const regs = buildRegistrars(ALL_DETECTED).filter((r) => r.scope === "repo");
+	await forEachIsolated(regs, wt, "removal", (r) => r.remove(wt));
+}

--- a/cli/src/install/mcp/JsonMcpWriter.test.ts
+++ b/cli/src/install/mcp/JsonMcpWriter.test.ts
@@ -1,0 +1,99 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { removeJsonMcpServer, upsertJsonMcpServer } from "./JsonMcpWriter.js";
+
+const entry = { command: "/h/.jolli/jollimemory/run-cli", args: ["mcp"] };
+
+describe("JsonMcpWriter", () => {
+	it("creates the file with jollimemory under mcpServers", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "j-")), "mcp.json");
+		await upsertJsonMcpServer(p, entry);
+		expect(JSON.parse(await readFile(p, "utf-8")).mcpServers.jollimemory).toEqual(entry);
+	});
+	it("preserves other servers", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "j-")), "mcp.json");
+		await writeFile(p, JSON.stringify({ mcpServers: { other: { command: "x" } } }), "utf-8");
+		await upsertJsonMcpServer(p, entry);
+		const cfg = JSON.parse(await readFile(p, "utf-8"));
+		expect(cfg.mcpServers.other).toEqual({ command: "x" });
+		expect(cfg.mcpServers.jollimemory).toEqual(entry);
+	});
+	it("refuses to overwrite unreadable JSON", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "j-")), "mcp.json");
+		await writeFile(p, "{ not json", "utf-8");
+		await upsertJsonMcpServer(p, entry);
+		expect(await readFile(p, "utf-8")).toBe("{ not json");
+	});
+	it("treats an empty/whitespace-only file as a fresh start (VS Code ships an empty mcp.json)", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "j-")), "mcp.json");
+		await writeFile(p, "   \n", "utf-8"); // empty placeholder, not corruption
+		await upsertJsonMcpServer(p, { type: "stdio", command: "x", args: ["mcp"] }, "servers");
+		const cfg = JSON.parse(await readFile(p, "utf-8"));
+		expect(cfg.servers.jollimemory).toEqual({ type: "stdio", command: "x", args: ["mcp"] });
+	});
+	it("removeJsonMcpServer drops only jollimemory", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "j-")), "mcp.json");
+		await writeFile(p, JSON.stringify({ mcpServers: { jollimemory: entry, other: { command: "x" } } }), "utf-8");
+		await removeJsonMcpServer(p);
+		const cfg = JSON.parse(await readFile(p, "utf-8"));
+		expect(cfg.mcpServers.jollimemory).toBeUndefined();
+		expect(cfg.mcpServers.other).toEqual({ command: "x" });
+	});
+	it("removeJsonMcpServer is a no-op when file is absent", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "j-")), "mcp.json");
+		await expect(removeJsonMcpServer(p)).resolves.toBeUndefined();
+	});
+	it("removeJsonMcpServer is a no-op when jollimemory key is absent", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "j-")), "mcp.json");
+		await writeFile(p, JSON.stringify({ mcpServers: { other: { command: "x" } } }), "utf-8");
+		const before = await readFile(p, "utf-8");
+		await removeJsonMcpServer(p);
+		// File unchanged (early return when key absent)
+		expect(await readFile(p, "utf-8")).toBe(before);
+	});
+	it("upsertJsonMcpServer is idempotent (re-registering updates in place)", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "j-")), "mcp.json");
+		await upsertJsonMcpServer(p, entry);
+		const updated = { command: "/new/run-cli", args: ["mcp"] };
+		await upsertJsonMcpServer(p, updated);
+		const cfg = JSON.parse(await readFile(p, "utf-8"));
+		expect(cfg.mcpServers.jollimemory).toEqual(updated);
+	});
+	it("creates parent dir if it does not exist", async () => {
+		const base = await mkdtemp(join(tmpdir(), "j-"));
+		const p = join(base, "sub", "dir", "mcp.json");
+		await upsertJsonMcpServer(p, entry);
+		expect(JSON.parse(await readFile(p, "utf-8")).mcpServers.jollimemory).toEqual(entry);
+	});
+	it("pretty-prints with 2-space indent and trailing newline", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "j-")), "mcp.json");
+		await upsertJsonMcpServer(p, entry);
+		const raw = await readFile(p, "utf-8");
+		expect(raw).toMatch(/\n$/);
+		expect(raw).toContain("  ");
+	});
+	it("writes under a custom serversKey (mcp) preserving the entry shape", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "j-")), "opencode.json");
+		const customEntry = { type: "local", command: ["node", "/x/Cli.js", "mcp"], enabled: true };
+		await writeFile(p, JSON.stringify({ $schema: "https://opencode.ai/config.json" }), "utf-8");
+		await upsertJsonMcpServer(p, customEntry, "mcp");
+		const cfg = JSON.parse(await readFile(p, "utf-8"));
+		expect(cfg.$schema).toBe("https://opencode.ai/config.json"); // other keys preserved
+		expect(cfg.mcp.jollimemory).toEqual(customEntry);
+		expect(cfg.mcpServers).toBeUndefined(); // default key NOT used
+	});
+	it("removes from a custom serversKey (servers)", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "j-")), "mcp.json");
+		await writeFile(
+			p,
+			JSON.stringify({ servers: { jollimemory: { type: "stdio", command: "x" }, other: { command: "y" } } }),
+			"utf-8",
+		);
+		await removeJsonMcpServer(p, "servers");
+		const cfg = JSON.parse(await readFile(p, "utf-8"));
+		expect(cfg.servers.jollimemory).toBeUndefined();
+		expect(cfg.servers.other).toEqual({ command: "y" });
+	});
+});

--- a/cli/src/install/mcp/JsonMcpWriter.ts
+++ b/cli/src/install/mcp/JsonMcpWriter.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared idempotent writer for parameterized JSON config files.
+ * Writes the `jollimemory` MCP server entry under a configurable top-level key.
+ *
+ * ## Verified config formats (observed from real installed app source code)
+ *
+ * ### Cursor & Gemini CLI (key `mcpServers`)
+ * Source: /Applications/Cursor.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js
+ * (Cursor) and /opt/homebrew/Cellar/gemini-cli/0.38.2/libexec/.../chunk-7DZN7VCC.js (Gemini).
+ *   ```json
+ *   { "mcpServers": { "<name>": { "command": "<path>", "args": ["..."] } } }
+ *   ```
+ *   Entry shape: `{ command: string, args?: string[], env?, envFile?, cwd?, enabledTools?, url?, timeout?, trust? }`.
+ *
+ * ### OpenCode (key `mcp`)
+ * Top-level key: `mcp` (object, server-name → entry).
+ * Entry shape: `{ type: "local" | "stdio", command: string | string[], enabled?: boolean, ... }`.
+ *
+ * ### VS Code Copilot Chat (key `servers`)
+ * Top-level key: `servers` (object, server-name → entry).
+ * Entry shape: varies by implementation.
+ *
+ * ## Error-guard pattern (mirrors McpRegistration.ts)
+ * ENOENT → create fresh; any other read/parse error → log.warn + return without writing
+ * (preserves the user's file even if it is mid-edit or corrupted).
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { createLogger } from "../../Logger.js";
+
+const log = createLogger("JsonMcpWriter");
+const SERVER_KEY = "jollimemory";
+const DEFAULT_KEY = "mcpServers";
+
+type ServerEntry = Record<string, unknown>;
+type JsonConfig = Record<string, unknown>;
+
+/**
+ * Add or refresh the `jollimemory` entry in `configPath`'s servers object (keyed by `serversKey`).
+ * Idempotent: re-running with the same entry is a no-op in effect (overwrites
+ * with identical content). Other servers in the file are always preserved.
+ * Parent directories are created if they do not exist.
+ *
+ * @param configPath path to the JSON config file
+ * @param entry server entry (shape depends on the target config format)
+ * @param serversKey top-level key for the servers object (defaults to "mcpServers")
+ */
+export async function upsertJsonMcpServer(
+	configPath: string,
+	entry: ServerEntry,
+	serversKey: string = DEFAULT_KEY,
+): Promise<void> {
+	let config: JsonConfig;
+	try {
+		const raw = await readFile(configPath, "utf-8");
+		// An empty / whitespace-only file is a fresh-start placeholder, NOT corruption:
+		// VS Code ships an empty `User/mcp.json` by default, so JSON.parse("") would
+		// otherwise throw and wrongly trip the unreadable-guard below, skipping registration.
+		// An empty file has no servers to preserve, so starting from {} is safe.
+		config = raw.trim() === "" ? {} : (JSON.parse(raw) as JsonConfig);
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+			// File exists with NON-EMPTY content that is unreadable or not valid JSON
+			// (mid-edit, trailing comma, partial write, EACCES). Resetting to {} would
+			// silently drop the user's other MCP servers — so refuse to write and leave
+			// the file untouched. Re-registration on the next install/activate recovers
+			// once the file is valid.
+			log.warn("Skipping MCP registration: %s unreadable/invalid (%s)", configPath, String(err));
+			return;
+		}
+		config = {}; // no file yet — fine to create a fresh one
+	}
+	const servers = (config[serversKey] as Record<string, ServerEntry> | undefined) ?? {};
+	servers[SERVER_KEY] = entry;
+	await mkdir(dirname(configPath), { recursive: true });
+	await writeFile(configPath, `${JSON.stringify({ ...config, [serversKey]: servers }, null, 2)}\n`, "utf-8");
+	log.info("Registered MCP server in %s", configPath);
+}
+
+/**
+ * Remove the `jollimemory` entry from `configPath`'s servers object (keyed by `serversKey`).
+ * No-op if the file is absent, unreadable, or the entry is already gone.
+ * Other servers are always preserved.
+ *
+ * @param configPath path to the JSON config file
+ * @param serversKey top-level key for the servers object (defaults to "mcpServers")
+ */
+export async function removeJsonMcpServer(configPath: string, serversKey: string = DEFAULT_KEY): Promise<void> {
+	let config: JsonConfig;
+	try {
+		config = JSON.parse(await readFile(configPath, "utf-8")) as JsonConfig;
+	} catch {
+		return; // absent or unreadable → nothing to remove
+	}
+	const servers = config[serversKey] as Record<string, ServerEntry> | undefined;
+	if (!servers?.[SERVER_KEY]) return;
+	delete servers[SERVER_KEY];
+	await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+	log.info("Removed MCP server from %s", configPath);
+}

--- a/cli/src/mcp/McpTools.test.ts
+++ b/cli/src/mcp/McpTools.test.ts
@@ -7,18 +7,19 @@ vi.mock("../core/ContextCompiler.js", () => ({
 	compileTaskContext: vi.fn(),
 	buildRecallPayload: vi.fn(),
 	listBranchCatalog: vi.fn(),
+	DEFAULT_TOKEN_BUDGET: 80000,
 }));
 vi.mock("../core/TopicPageStore.js", () => ({ readTopicPage: vi.fn() }));
-vi.mock("../core/GitOps.js", () => ({ getCurrentBranch: vi.fn() }));
 vi.mock("../core/SummaryStore.js", () => ({ getActiveStorage: vi.fn() }));
 vi.mock("../core/PrDescription.js", () => ({ buildPrDescription: vi.fn() }));
+vi.mock("../util/Subprocess.js", () => ({ execFileSyncHidden: vi.fn() }));
 
 import { buildRecallPayload, compileTaskContext, listBranchCatalog } from "../core/ContextCompiler.js";
-import { getCurrentBranch } from "../core/GitOps.js";
 import { buildPrDescription } from "../core/PrDescription.js";
 import { SearchIndex } from "../core/SearchIndex.js";
 import { getActiveStorage } from "../core/SummaryStore.js";
 import { readTopicPage } from "../core/TopicPageStore.js";
+import { execFileSyncHidden } from "../util/Subprocess.js";
 import { runDecisionTimeline, runGetPrDescription, runListBranches, runRecall, runSearch } from "./McpTools.js";
 
 describe("runSearch", () => {
@@ -49,19 +50,48 @@ describe("runSearch", () => {
 
 describe("runRecall", () => {
 	it("defaults to the current branch when none given", async () => {
-		vi.mocked(getCurrentBranch).mockResolvedValue("feature/auth");
-		vi.mocked(compileTaskContext).mockResolvedValue({ branch: "feature/auth" } as never);
+		vi.mocked(execFileSyncHidden).mockReturnValue("feature/auth\n");
+		vi.mocked(listBranchCatalog).mockResolvedValue({
+			type: "catalog",
+			branches: [{ branch: "feature/auth", commitCount: 1, period: { start: "2026-01-01", end: "2026-01-01" } }],
+		} as never);
+		vi.mocked(compileTaskContext).mockResolvedValue({ branch: "feature/auth", commitCount: 1 } as never);
 		vi.mocked(buildRecallPayload).mockReturnValue({ type: "recall", branch: "feature/auth" } as never);
 		const out = await runRecall("/repo", {});
-		expect(compileTaskContext).toHaveBeenCalledWith({ branch: "feature/auth" }, "/repo");
-		expect(out.branch).toBe("feature/auth");
+		expect(out.type).toBe("recall");
+		if (out.type === "recall") expect(out.branch).toBe("feature/auth");
 	});
 
 	it("uses the explicit branch when provided", async () => {
-		vi.mocked(compileTaskContext).mockResolvedValue({ branch: "main" } as never);
+		vi.mocked(listBranchCatalog).mockResolvedValue({
+			type: "catalog",
+			branches: [{ branch: "main", commitCount: 1, period: { start: "2026-01-01", end: "2026-01-01" } }],
+		} as never);
+		vi.mocked(compileTaskContext).mockResolvedValue({ branch: "main", commitCount: 1 } as never);
 		vi.mocked(buildRecallPayload).mockReturnValue({ type: "recall", branch: "main" } as never);
 		await runRecall("/repo", { branch: "main" });
-		expect(compileTaskContext).toHaveBeenCalledWith({ branch: "main" }, "/repo");
+		expect(compileTaskContext).toHaveBeenCalledWith(expect.objectContaining({ branch: "main" }), "/repo");
+	});
+
+	it("returns type:catalog for a non-matching branch fragment", async () => {
+		vi.mocked(listBranchCatalog).mockResolvedValue({
+			type: "catalog",
+			branches: [{ branch: "main", commitCount: 1, period: { start: "2026-01-01", end: "2026-01-01" } }],
+		} as never);
+		const r = await runRecall("/repo", { branch: "no-such-frag" });
+		expect(r.type).toBe("catalog");
+	});
+
+	it("returns type:recall for an exact branch", async () => {
+		const seededBranch = "feature/seeded";
+		vi.mocked(listBranchCatalog).mockResolvedValue({
+			type: "catalog",
+			branches: [{ branch: seededBranch, commitCount: 2, period: { start: "2026-01-01", end: "2026-01-02" } }],
+		} as never);
+		vi.mocked(compileTaskContext).mockResolvedValue({ branch: seededBranch, commitCount: 2 } as never);
+		vi.mocked(buildRecallPayload).mockReturnValue({ type: "recall", branch: seededBranch } as never);
+		const r = await runRecall("/repo", { branch: seededBranch });
+		expect(r.type).toBe("recall");
 	});
 });
 

--- a/cli/src/mcp/McpTools.ts
+++ b/cli/src/mcp/McpTools.ts
@@ -5,12 +5,12 @@
  * adapts these into SDK tool responses.
  */
 
-import type { BranchCatalog, RecallPayload } from "../core/ContextCompiler.js";
-import { buildRecallPayload, compileTaskContext, listBranchCatalog } from "../core/ContextCompiler.js";
-import { getCurrentBranch } from "../core/GitOps.js";
+import type { BranchCatalog } from "../core/ContextCompiler.js";
+import { listBranchCatalog } from "../core/ContextCompiler.js";
 import { buildPrDescription, type PrDescriptionResult } from "../core/PrDescription.js";
+import { type RecallResult, resolveRecall } from "../core/RecallResolver.js";
+import { searchHits } from "../core/SearchHits.js";
 import type { SearchHitResult } from "../core/SearchIndex.js";
-import { SearchIndex } from "../core/SearchIndex.js";
 import { compareSourceRefs } from "../core/SourceTimeline.js";
 import { getActiveStorage } from "../core/SummaryStore.js";
 import { readTopicPage } from "../core/TopicPageStore.js";
@@ -23,28 +23,11 @@ export interface SearchArgs {
 }
 
 export async function runSearch(cwd: string, args: SearchArgs): Promise<{ hits: SearchHitResult[] }> {
-	if (!args.query || !args.query.trim()) {
-		throw new Error("`query` is required and must be non-empty");
-	}
-	// Pass the active storage so the index dir resolves to the SAME location the
-	// compile warm-up wrote to — `<kbRoot>/.jolli/jollimemory/` in folder/dual-write
-	// mode, the checkout's `.jolli/jollimemory/` in orphan-only. Without it,
-	// resolveIndexDir falls back to cwd and a folder-mode server never sees the
-	// warm index (see SearchIndex.resolveIndexDir).
-	const index = await SearchIndex.openCached(cwd, getActiveStorage());
-	const hits = await index.search({
-		query: args.query,
-		branch: args.branch,
-		type: args.type,
-		limit: args.limit,
-	});
-	return { hits };
+	return { hits: await searchHits(cwd, args, getActiveStorage()) };
 }
 
-export async function runRecall(cwd: string, args: { branch?: string }): Promise<RecallPayload> {
-	const branch = args.branch ?? (await getCurrentBranch(cwd));
-	const ctx = await compileTaskContext({ branch }, cwd);
-	return buildRecallPayload(ctx);
+export async function runRecall(cwd: string, args: { branch?: string }): Promise<RecallResult> {
+	return resolveRecall(args.branch, cwd);
 }
 
 export interface TimelineEntry {

--- a/cli/src/sync/BootstrapMerge.test.ts
+++ b/cli/src/sync/BootstrapMerge.test.ts
@@ -26,6 +26,16 @@ const itIfSymlinks = symlinksSupported ? it : it.skip;
 process.env.GIT_CONFIG_GLOBAL = "/dev/null";
 process.env.GIT_CONFIG_SYSTEM = "/dev/null";
 process.env.GIT_TERMINAL_PROMPT = "0";
+// `GIT_CONFIG_GLOBAL=/dev/null` neutralizes ~/.gitconfig but NOT the XDG default
+// excludes file (~/.config/git/ignore) — its path is a git built-in, not read
+// from config. A developer entry there (e.g. `.jolli/`, which `jolli impact
+// init` adds) would make `git add .` silently skip every seeded `.jolli/...`
+// fixture, so origin never receives them and the bootstrap conflict cases
+// resolve local-wins instead of remote-wins. Force core.excludesFile empty for
+// every git invocation this suite spawns.
+process.env.GIT_CONFIG_COUNT = "1";
+process.env.GIT_CONFIG_KEY_0 = "core.excludesFile";
+process.env.GIT_CONFIG_VALUE_0 = "/dev/null";
 
 // Every test spawns several real `git` subprocesses; under parallel suite load
 // + `--coverage` the global 15s testTimeout / 10s hookTimeout flake. 30s gives

--- a/cli/test/sync-acceptance/_helpers.ts
+++ b/cli/test/sync-acceptance/_helpers.ts
@@ -98,6 +98,15 @@ const SAFE_GIT_OPTS: readonly string[] = [
 	"init.defaultBranch=main",
 	"-c",
 	"core.hooksPath=/dev/null",
+	// Neutralize the host's XDG global ignore (`~/.config/git/ignore`). On dev
+	// machines `jolli impact init` adds `.jolli/` there, which `git config
+	// --get core.excludesFile` won't reveal (git reads the XDG path implicitly)
+	// yet silently makes `git add .` skip any `.jolli/...` path — so seeding an
+	// aggregate like `test-repo/.jolli/manifest.json` stages nothing and the
+	// commit dies with "nothing to commit". CI lacks the global ignore, so this
+	// only bites locally; pinning excludesFile keeps the tests hermetic.
+	"-c",
+	"core.excludesFile=/dev/null",
 ];
 
 export async function setupAcceptance(): Promise<AcceptanceWorld> {

--- a/docs/superpowers/plans/2026-06-20-skills-use-mcp-tools.md
+++ b/docs/superpowers/plans/2026-06-20-skills-use-mcp-tools.md
@@ -1,0 +1,1134 @@
+# Skills Use MCP Tools — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move `jolli-recall` and `jolli-search` skills onto the JolliMemory MCP tools, with each skill's MCP tool and CLI fallback returning byte-identical results (one shared implementation per skill), and register the MCP server across non-Claude hosts.
+
+**Architecture:** Three components in one plan. (1) Extract one shared implementation per skill — `resolveRecall()` (the `type`-tagged recall union) and `searchHits()` (BM25 hits) — and route both the CLI command and the MCP tool through it; rewrite the CLI `search` command to single-phase BM25. (2) Both SKILL.md templates become MCP-preferred with the existing here-doc as fallback. (3) `McpRegistration` is generalized into a per-host registrar list so Codex/Cursor/Gemini also get the MCP server.
+
+**Tech Stack:** TypeScript (ESM, Node 22.5+), Vitest, Commander, `@modelcontextprotocol/sdk`, Orama, Biome. No new runtime dependencies.
+
+## Global Constraints
+
+- **DCO sign-off on every commit** — `git commit -s`.
+- **No `Co-Authored-By: Claude …` / no `🤖 Generated with …`** in commits or PRs.
+- **`npm run all` must pass before commit** (clean → build → lint → test).
+- **CLI coverage floor:** ≥ 97% statements / 96% branches / 97% functions / 97% lines.
+- **`toForwardSlash` for `\`→`/`** — never inline `replace(/\\/g,"/")`.
+- **Biome:** tabs, 4-wide, 120 col. `noExplicitAny: error`, `noUnusedImports/Variables: error`. Warnings fail.
+- **Coverage-ignore:** only `/* v8 ignore start … stop */` blocks; single-line `ignore next` does NOT work.
+- **No new npm dependencies** — Codex TOML uses a hand-written minimal emitter.
+- **Worktree-aware:** registration runs per-worktree in the existing Installer loop.
+
+## Resolved design points
+
+- **recall:** MCP `recall` must equal CLI `recall --format json` — the
+  `type:"recall"|"catalog"|"error"` union incl. catalog fuzzy match. Shared via
+  `resolveRecall()`. Both `RecallPayload` and `BranchCatalog` already carry a
+  `type` discriminant (`ContextCompiler.ts:135/179`).
+- **search:** lightweight BM25 only; **no `load_commits`, no two-phase.** MCP and
+  CLI fallback share `searchHits()`. The CLI `search` command is rewritten to
+  single-phase BM25. Two-phase `LocalSearchProvider.buildCatalog`/`loadHits` has
+  no consumer besides `SearchCommand` (verified) — retired from the command,
+  kept as the `SearchProvider` extension point.
+- **TOML lib:** none available → Codex uses a hand-written block-level merge.
+
+## File structure
+
+- `cli/src/core/RecallResolver.ts` (new) — `resolveRecall()` + `RecallResult`.
+- `cli/src/core/SearchHits.ts` (new) — `searchHits()` + `SearchHitsArgs`.
+- `cli/src/commands/RecallCommand.ts` (modify) — JSON path delegates to `resolveRecall`.
+- `cli/src/commands/SearchCommand.ts` (modify) — rewrite to single-phase BM25 `{hits}`.
+- `cli/src/mcp/McpTools.ts` (modify) — `runRecall`→`resolveRecall`; `runSearch`→`searchHits`.
+- `cli/src/install/SkillInstaller.ts` (modify) — rewrite both template builders.
+- `cli/src/install/McpRegistration.ts` (modify) — keep Claude writer; export `mcpServerEntry`.
+- `cli/src/install/mcp/HostRegistrars.ts` (new) — registrar list + register/remove all.
+- `cli/src/install/mcp/JsonMcpWriter.ts` (new) — shared `mcpServers` JSON merge.
+- `cli/src/install/mcp/CodexTomlWriter.ts` (new) — minimal TOML merge.
+- `cli/src/install/Installer.ts` (modify) — call `registerAllMcpHosts`; thread git-exclude.
+- Test files mirror each.
+
+---
+
+## Phase 1 — unify CLI ↔ MCP results
+
+### Task 1: Shared `resolveRecall`
+
+**Files:**
+- Create: `cli/src/core/RecallResolver.ts`
+- Test: `cli/src/core/RecallResolver.test.ts`
+
+**Interfaces:**
+- Consumes: `compileTaskContext`, `buildRecallPayload`, `listBranchCatalog`, `DEFAULT_TOKEN_BUDGET` (ContextCompiler); `getCurrentBranch` (GitOps); `SAFE_ARGUMENT_PATTERN` (CliUtils).
+- Produces:
+  ```ts
+  export type RecallResult = RecallPayload | BranchCatalog | { type: "error"; message: string };
+  export async function resolveRecall(
+  	branchOrKeyword: string | undefined,
+  	projectDir: string,
+  	options?: { budget?: number; depth?: number; includeTranscripts?: boolean; includePlans?: boolean },
+  ): Promise<RecallResult>;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// cli/src/core/RecallResolver.test.ts
+import { describe, expect, it } from "vitest";
+import { resolveRecall } from "./RecallResolver.js";
+// Reuse the repo-seeding helper the existing ContextCompiler/RecallCommand tests use.
+
+describe("resolveRecall", () => {
+	it("returns type:error for invalid characters", async () => {
+		const r = await resolveRecall("bad;rm -rf", repoDir);
+		expect(r.type).toBe("error");
+	});
+	it("returns type:recall for an exact branch match", async () => {
+		const r = await resolveRecall(seededBranch, repoDir);
+		expect(r.type).toBe("recall");
+	});
+	it("returns type:catalog with query for a non-matching fragment", async () => {
+		const r = await resolveRecall("no-such-frag", repoDir);
+		expect(r.type).toBe("catalog");
+		expect((r as { query?: string }).query).toBe("no-such-frag");
+	});
+	it("returns type:error when the repo has no records and no branch is given", async () => {
+		const r = await resolveRecall(undefined, emptyRepoDir);
+		expect(r.type).toBe("error");
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/RecallResolver.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement `RecallResolver.ts`**
+
+Lift the dispatch from `RecallCommand.ts:259-385` (the action body's JSON branches). Concretely:
+
+```ts
+// cli/src/core/RecallResolver.ts
+/**
+ * Single source of truth for "what does recall return for this input" — the
+ * type-tagged discriminated union the jolli-recall skill consumes. Both the CLI
+ * `recall --format json` path and the MCP `recall` tool call this, so their
+ * results are byte-identical by construction.
+ */
+import { execFileSync } from "node:child_process";
+import {
+	type BranchCatalog,
+	buildRecallPayload,
+	compileTaskContext,
+	DEFAULT_TOKEN_BUDGET,
+	listBranchCatalog,
+	type RecallPayload,
+} from "./ContextCompiler.js";
+import { SAFE_ARGUMENT_PATTERN } from "../commands/CliUtils.js";
+import { execFileSyncHidden } from "../util/Subprocess.js";
+
+export type RecallResult = RecallPayload | BranchCatalog | { type: "error"; message: string };
+
+export interface ResolveRecallOptions {
+	budget?: number;
+	depth?: number;
+	includeTranscripts?: boolean;
+	includePlans?: boolean;
+}
+
+export async function resolveRecall(
+	branchOrKeyword: string | undefined,
+	projectDir: string,
+	options: ResolveRecallOptions = {},
+): Promise<RecallResult> {
+	if (branchOrKeyword && !SAFE_ARGUMENT_PATTERN.test(branchOrKeyword)) {
+		return {
+			type: "error",
+			message:
+				"Invalid characters in argument. Only letters, numbers, hyphens, underscores, slashes, and dots are allowed.",
+		};
+	}
+
+	let branch = branchOrKeyword;
+	if (!branch) {
+		try {
+			branch = execFileSyncHidden("git", ["branch", "--show-current"], {
+				encoding: "utf-8",
+				cwd: projectDir,
+			}).trim();
+		} catch {
+			branch = undefined;
+		}
+	}
+
+	const catalog = await listBranchCatalog(projectDir);
+
+	if (branch) {
+		const exact = catalog.branches.find((b) => b.branch === branch);
+		if (exact) {
+			const ctx = await compileTaskContext(
+				{
+					branch,
+					depth: options.depth,
+					tokenBudget: options.budget ?? DEFAULT_TOKEN_BUDGET,
+					includeTranscripts: options.includeTranscripts,
+					includePlans: options.includePlans !== false,
+				},
+				projectDir,
+			);
+			if (ctx.commitCount === 0) {
+				return { type: "error", message: `No Jolli Memory records found for branch "${branch}".` };
+			}
+			return buildRecallPayload(ctx, options.budget ?? DEFAULT_TOKEN_BUDGET);
+		}
+		return { ...catalog, query: branch };
+	}
+
+	if (catalog.branches.length === 0) {
+		return { type: "error", message: "No Jolli Memory records found in this repository." };
+	}
+	return catalog;
+}
+```
+
+(Drop the unused `execFileSync` import — use only `execFileSyncHidden`. Verify `SAFE_ARGUMENT_PATTERN` is exported from CliUtils; it is used in RecallCommand.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/RecallResolver.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/core/RecallResolver.ts cli/src/core/RecallResolver.test.ts
+git commit -s -m "feat(core): extract resolveRecall as shared recall result implementation"
+```
+
+---
+
+### Task 2: Route RecallCommand JSON path + MCP runRecall through `resolveRecall`
+
+**Files:**
+- Modify: `cli/src/commands/RecallCommand.ts` (JSON path → `resolveRecall`)
+- Modify: `cli/src/mcp/McpTools.ts` (`runRecall` → `resolveRecall`)
+- Test: `cli/src/mcp/McpTools.test.ts`, `cli/src/commands/RecallCommand.test.ts` (extend/verify)
+
+**Interfaces:**
+- Consumes: `resolveRecall`.
+- Produces: `runRecall(cwd, args: { branch?: string }): Promise<RecallResult>` (return type widens from `RecallPayload` to `RecallResult`).
+
+- [ ] **Step 1: Write the failing test (MCP recall now yields the union)**
+
+```ts
+// in cli/src/mcp/McpTools.test.ts
+it("runRecall returns type:catalog for a non-matching branch fragment", async () => {
+	const r = await runRecall(repoDir, { branch: "no-such-frag" });
+	expect(r.type).toBe("catalog");
+});
+it("runRecall returns type:recall for an exact branch", async () => {
+	const r = await runRecall(repoDir, { branch: seededBranch });
+	expect(r.type).toBe("recall");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/mcp/McpTools.test.ts -t runRecall`
+Expected: FAIL — current `runRecall` returns a bare payload (no catalog branch), `r.type` is always `"recall"` or it throws.
+
+- [ ] **Step 3: Rewire both callers**
+
+In `McpTools.ts`, replace `runRecall`:
+
+```ts
+import { resolveRecall, type RecallResult } from "../core/RecallResolver.js";
+
+export async function runRecall(cwd: string, args: { branch?: string }): Promise<RecallResult> {
+	return resolveRecall(args.branch, cwd);
+}
+```
+
+(Remove the now-unused `compileTaskContext`/`buildRecallPayload`/`getCurrentBranch` imports if `runRecall` was their only user in this file — check `runListBranches`/others first.)
+
+In `RecallCommand.ts`, replace the `--format json` dispatch in the action (the exact-match / no-match / empty / error JSON branches) with:
+
+```ts
+if (options.format === "json") {
+	const result = await resolveRecall(branchOrKeyword, projectDir, {
+		budget: options.budget,
+		depth: options.depth,
+		includeTranscripts: options.includeTranscripts,
+		includePlans: options.plans !== false,
+	});
+	console.log(JSON.stringify(result));
+	if (result.type === "error") process.exitCode = 1;
+	return;
+}
+```
+
+Keep the non-JSON (text/`--full`/`--output`/`--catalog`) modes exactly as they are. Remove inline JSON-branch code now duplicated by `resolveRecall`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm run test -w @jolli.ai/cli -- src/mcp/McpTools.test.ts src/commands/RecallCommand.test.ts`
+Expected: PASS (existing RecallCommand JSON assertions still hold — same output).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/commands/RecallCommand.ts cli/src/mcp/McpTools.ts cli/src/mcp/McpTools.test.ts
+git commit -s -m "feat: recall CLI json path and MCP tool share resolveRecall (identical results)"
+```
+
+---
+
+### Task 3: Shared `searchHits` + MCP runSearch delegation
+
+**Files:**
+- Create: `cli/src/core/SearchHits.ts`
+- Modify: `cli/src/mcp/McpTools.ts` (`runSearch` → `searchHits`)
+- Test: `cli/src/core/SearchHits.test.ts`
+
+**Interfaces:**
+- Consumes: `SearchIndex`, `SearchHitResult` (SearchIndex.js).
+- Produces:
+  ```ts
+  export interface SearchHitsArgs { query: string; branch?: string; type?: "topic" | "commit"; limit?: number; }
+  export async function searchHits(cwd: string, args: SearchHitsArgs, storage?: StorageProvider): Promise<SearchHitResult[]>;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// cli/src/core/SearchHits.test.ts
+import { describe, expect, it } from "vitest";
+import { searchHits } from "./SearchHits.js";
+
+describe("searchHits", () => {
+	it("throws on empty query", async () => {
+		await expect(searchHits(repoDir, { query: "  " })).rejects.toThrow(/query/i);
+	});
+	it("returns BM25 hits for a seeded term", async () => {
+		const hits = await searchHits(repoDir, { query: seededTerm });
+		expect(hits.length).toBeGreaterThan(0);
+		expect(hits[0]).toHaveProperty("hash");
+		expect(hits[0]).toHaveProperty("snippet");
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/SearchHits.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement `SearchHits.ts` (move the runSearch core)**
+
+```ts
+// cli/src/core/SearchHits.ts
+/**
+ * BM25 search hits — the single implementation behind both the MCP `search`
+ * tool and the CLI `search` command, so primary and fallback return identical
+ * results. Wraps the Orama-backed SearchIndex.
+ */
+import { SearchIndex, type SearchHitResult } from "./SearchIndex.js";
+import type { StorageProvider } from "./StorageProvider.js";
+
+export interface SearchHitsArgs {
+	query: string;
+	branch?: string;
+	type?: "topic" | "commit";
+	limit?: number;
+}
+
+export async function searchHits(
+	cwd: string,
+	args: SearchHitsArgs,
+	storage?: StorageProvider,
+): Promise<SearchHitResult[]> {
+	if (!args.query || !args.query.trim()) {
+		throw new Error("`query` is required and must be non-empty");
+	}
+	const index = await SearchIndex.openCached(cwd, storage);
+	return index.search({ query: args.query, branch: args.branch, type: args.type, limit: args.limit });
+}
+```
+
+In `McpTools.ts`, replace `runSearch`'s body:
+
+```ts
+import { searchHits } from "../core/SearchHits.js";
+
+export async function runSearch(cwd: string, args: SearchArgs): Promise<{ hits: SearchHitResult[] }> {
+	return { hits: await searchHits(cwd, args, getActiveStorage()) };
+}
+```
+
+(Keep `SearchArgs`/`SearchHitResult` types; drop the now-unused direct `SearchIndex` import in McpTools if `searchHits` is the only user there.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/SearchHits.test.ts src/mcp/McpTools.test.ts -t runSearch`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/core/SearchHits.ts cli/src/mcp/McpTools.ts cli/src/core/SearchHits.test.ts
+git commit -s -m "feat(core): extract searchHits; MCP search delegates to it"
+```
+
+---
+
+### Task 4: Rewrite CLI `search` command to single-phase BM25
+
+**Files:**
+- Modify: `cli/src/commands/SearchCommand.ts` (rewrite)
+- Test: `cli/src/commands/SearchCommand.test.ts` (rewrite the two-phase cases)
+
+**Interfaces:**
+- Consumes: `searchHits`.
+- Produces: `jolli search [query] --arg-stdin --limit <n> --branch <b> --type <topic|commit> --format <json|text>` → `{ hits }` JSON.
+
+- [ ] **Step 1: VERIFY no external consumer of the two-phase API**
+
+Run: `grep -rn "parseHashList\|buildCatalog\|loadHits\|HASH_LIST_PATTERN" cli/src vscode/src | grep -v "\.test\." | grep -v "LocalSearchProvider\|SearchProvider\|RemoteSearchProvider"`
+Expected: only `SearchCommand.ts` (and the provider classes). If anything else appears, STOP and reassess — the rewrite would break it.
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+// rewrite cli/src/commands/SearchCommand.test.ts core cases
+it("emits {hits} JSON for a query", async () => {
+	const out = await runSearchCli(["seeded-term", "--format", "json", "--cwd", repoDir]);
+	const parsed = JSON.parse(out);
+	expect(parsed).toHaveProperty("hits");
+	expect(Array.isArray(parsed.hits)).toBe(true);
+});
+it("rejects an empty query with a non-zero exit", async () => {
+	const { code } = await runSearchCliRaw(["--arg-stdin", "--format", "json", "--cwd", repoDir], "");
+	expect(code).not.toBe(0);
+});
+```
+
+(Use the same CLI-invocation harness the existing SearchCommand tests use; delete the catalog/`--hashes` two-phase test cases.)
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/commands/SearchCommand.test.ts`
+Expected: FAIL — current command emits a catalog, not `{hits}`.
+
+- [ ] **Step 4: Rewrite `SearchCommand.ts`**
+
+Replace the command registration with single-phase BM25. Remove `--since`,
+`--budget`, `--hashes`, `parseHashList`, `HASH_LIST_PATTERN`, `renderResultText`,
+`renderCatalogText`, and the `LocalSearchProvider` import. New action:
+
+```ts
+import { searchHits } from "../core/SearchHits.js";
+// keep: isSafeQuery, parsePositiveInt, readStdin, resolveProjectDir, setLogDir
+
+program
+	.command("search")
+	.description("Search structured commit memories (BM25 over distilled summaries)")
+	.argument("[words...]", "Query keyword(s)")
+	.option("--limit <n>", "Max hits (default 20)", parsePositiveInt)
+	.option("--branch <branch>", "Restrict to one branch")
+	.addOption(new Option("--type <kind>", "Restrict result kind").choices(["topic", "commit"]))
+	.addOption(new Option("--format <fmt>", "Output format").choices(["json", "text"]).default("json"))
+	.option("--output <path>", "Write output to file instead of stdout")
+	.option("--arg-stdin", "Read the query from stdin (used by SKILL.md here-doc bridge)")
+	.option("--cwd <dir>", "Project directory (default: git repo root)", resolveProjectDir())
+	.action(async (words, options) => {
+		try {
+			const projectDir = options.cwd as string;
+			setLogDir(projectDir);
+			if (options.argStdin && words.length > 0) { emitError(options, "--arg-stdin and positional [words...] are mutually exclusive."); return; }
+			const query = options.argStdin ? await readStdin() : words.join(" ");
+			if (!query || !query.trim()) { emitError(options, "A query is required."); return; }
+			if (!isSafeQuery(query)) { emitError(options, "Invalid characters in query."); return; }
+			const hits = await searchHits(projectDir, {
+				query,
+				...(options.branch && { branch: options.branch }),
+				...(options.type && { type: options.type }),
+				...(options.limit !== undefined && { limit: options.limit }),
+			});
+			await writeOutput({ hits }, options, () => renderHitsText(hits));
+		} catch (error) {
+			emitError(options, error instanceof Error ? error.message : String(error));
+		}
+	});
+```
+
+Add a compact `renderHitsText(hits)` (one line per hit: `hash/slug  branch  date  title`). Keep `writeOutput`/`emitError` (adjust `emitError`'s type set to `json|text`).
+
+- [ ] **Step 5: Run tests**
+
+Run: `npm run test -w @jolli.ai/cli -- src/commands/SearchCommand.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/commands/SearchCommand.ts cli/src/commands/SearchCommand.test.ts
+git commit -s -m "feat(cli): rewrite search command to single-phase BM25 {hits} (matches MCP)"
+```
+
+---
+
+## Phase 2 — skill template rewrite
+
+### Task 5: jolli-recall → MCP-preferred (CLI fallback, shared union)
+
+**Files:**
+- Modify: `cli/src/install/SkillInstaller.ts` (`buildRecallSkillTemplate`; add `export`)
+- Test: `cli/src/install/SkillInstaller.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { buildRecallSkillTemplate } from "./SkillInstaller.js";
+it("recall template prefers MCP recall and keeps the CLI fallback", () => {
+	const t = buildRecallSkillTemplate();
+	expect(t).toContain("mcp__jollimemory__recall");
+	expect(t).toContain('type'); // documents type:recall|catalog|error
+	expect(t).toContain("$HOME/.jolli/jollimemory/run-cli"); // fallback retained
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/SkillInstaller.test.ts -t "recall template prefers"`
+Expected: FAIL.
+
+- [ ] **Step 3: Edit `buildRecallSkillTemplate`**
+
+`export` both builders. Replace `## Step 1: Run the CLI` with a two-path Step 1, keeping ALL Step-2 rendering (Part A/B, principles, etc.) and adding catalog handling:
+
+````md
+## Step 1: Load the recall result
+
+\`<user-arg>\` is a branch name (exact or fragment) or empty (current branch).
+
+### Preferred: MCP tool
+If \`mcp__jollimemory__recall\` is available, call it with \`{ "branch": "<user-arg>" }\`
+(omit \`branch\` when \`<user-arg>\` is empty). It returns a \`type\`-tagged object —
+\`recall\` / \`catalog\` / \`error\` — identical to the CLI fallback below.
+
+### Fallback: CLI here-doc
+If no such tool, use:
+
+<heredocInvocation("recall", " --format json"), verbatim>
+
+If \`~/.jolli/jollimemory/run-cli\` does not exist: "Jolli not installed. Please
+install via \`npm install -g @jolli.ai/cli && jolli enable\` or the VS Code extension."
+
+## Step 2: Handle the result by \`type\`
+- \`type:"recall"\` → render Part A + Part B below.
+- \`type:"catalog"\` → semantic-match \`<user-arg>\` against \`branches[].branch\` /
+  \`commitMessages\` / \`topicTitles\`. One match → repeat Step 1 with that branch.
+  Many → list and ask. None → show catalog, ask to clarify.
+- \`type:"error"\` → surface \`message\` verbatim (translated); for "no records",
+  suggest \`jolli enable\`. Never fabricate.
+````
+
+(Keep the rest of the existing template — Part A/B, universal principles, plan/note stubs, empty/partial — unchanged.) Interpolate the existing `heredocInvocation("recall", " --format json")` into the fallback block (DRY).
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/SkillInstaller.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/install/SkillInstaller.ts cli/src/install/SkillInstaller.test.ts
+git commit -s -m "feat(skills): jolli-recall prefers MCP recall tool, shared CLI fallback"
+```
+
+---
+
+### Task 6: jolli-search → MCP-preferred single-phase (CLI fallback)
+
+**Files:**
+- Modify: `cli/src/install/SkillInstaller.ts` (`buildSearchSkillTemplate`)
+- Test: `cli/src/install/SkillInstaller.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { buildSearchSkillTemplate } from "./SkillInstaller.js";
+it("search template uses MCP search (lightweight hits) + CLI fallback", () => {
+	const t = buildSearchSkillTemplate();
+	expect(t).toContain("mcp__jollimemory__search");
+	expect(t).not.toContain("load_commits"); // no two-phase
+	expect(t).not.toContain("--hashes");
+	expect(t).toContain("$HOME/.jolli/jollimemory/run-cli"); // fallback retained
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/SkillInstaller.test.ts -t "search template uses MCP"`
+Expected: FAIL.
+
+- [ ] **Step 3: Rewrite `buildSearchSkillTemplate`**
+
+Keep frontmatter + "When to use"/"When NOT to use". Replace Steps 1–5 with a single-phase lightweight flow:
+
+````md
+## Step 1: Parse the query
+Extract the natural-language query (any language). Optional: \`limit\`. Note:
+time/budget filters are not supported on the search path — point users at
+jolli-recall for a full branch when they need depth.
+
+## Step 2: Get hits
+### Preferred: MCP tool
+If \`mcp__jollimemory__search\` is available, call it with \`{ "query": "<query>", "limit": 20 }\`.
+Returns \`{ "hits": [ { type, title, snippet, branch, commitDate, slug, hash, score } ] }\`,
+relevance-ranked (BM25).
+
+### Fallback: CLI here-doc
+If no such tool:
+
+<heredocInvocation("search", " --format json"), verbatim>  →  returns the same \`{ hits }\`.
+
+Failure handling: missing \`run-cli\` → "Jolli not installed…"; \`unknown command 'search'\`
+→ "Your installed Jolli CLI is older than this skill — run \`npm update -g @jolli.ai/cli\`."
+
+## Step 3: Render
+\`hits\` are lightweight (no full decisions/recap). For each relevant hit you have
+\`type\` (commit/topic), \`title\`, \`snippet\`, \`branch\`, \`commitDate\`, \`slug\`, \`hash\`.
+
+Principles: lead with the answer; ground each item to its \`hash\` (commit) or
+\`slug\`/\`branch\` (topic); reply in the user's language; don't expose machinery
+(no "BM25"/"SearchHit"/"hits array"). Render a relevance-ordered answer (prose or
+a compact list). If the user needs the full decisions/rationale behind a hit,
+tell them to run jolli-recall on that hit's \`branch\`.
+
+Empty \`hits\` → tell the user nothing matched; suggest broader keywords.
+````
+
+Interpolate `heredocInvocation("search", " --format json")` into the fallback block.
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/SkillInstaller.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/install/SkillInstaller.ts cli/src/install/SkillInstaller.test.ts
+git commit -s -m "feat(skills): jolli-search uses MCP BM25 search (lightweight), shared CLI fallback"
+```
+
+---
+
+## Phase 3 — multi-host MCP registration
+
+> **integrating-external-systems applies to every host writer.** Each host
+> task's Step 1 verifies the real config location/schema before implementation.
+> Omit a host if unverifiable — the skill CLI fallback covers it.
+
+### Task 7: Registrar abstraction (Claude refactored in)
+
+**Files:**
+- Create: `cli/src/install/mcp/HostRegistrars.ts`
+- Test: `cli/src/install/mcp/HostRegistrars.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  interface DetectedHosts { claude: boolean; codex: boolean; cursor: boolean; gemini: boolean; }
+  interface McpHostRegistrar { host: string; register(wt: string): Promise<void>; remove(wt: string): Promise<void>; gitExcludePaths(): string[]; }
+  function buildRegistrars(detected: DetectedHosts): McpHostRegistrar[];
+  function registerAllMcpHosts(wt: string, detected: DetectedHosts): Promise<void>;
+  function removeAllMcpHosts(wt: string): Promise<void>;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// cli/src/install/mcp/HostRegistrars.test.ts
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildRegistrars } from "./HostRegistrars.js";
+
+describe("buildRegistrars", () => {
+	it("claude registrar writes .mcp.json", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "mcp-"));
+		const claude = buildRegistrars({ claude: true, codex: false, cursor: false, gemini: false }).find((r) => r.host === "claude");
+		await claude!.register(dir);
+		expect(JSON.parse(await readFile(join(dir, ".mcp.json"), "utf-8")).mcpServers.jollimemory.args).toEqual(["mcp"]);
+	});
+	it("omits undetected hosts", () => {
+		expect(buildRegistrars({ claude: true, codex: false, cursor: false, gemini: false }).map((r) => r.host)).toEqual(["claude"]);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/mcp/HostRegistrars.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement `HostRegistrars.ts` (Claude only for now)**
+
+```ts
+// cli/src/install/mcp/HostRegistrars.ts
+import { createLogger } from "../../Logger.js";
+import { MCP_GIT_EXCLUDE_PATH, registerMcpInClaude, removeMcpFromClaude } from "../McpRegistration.js";
+
+const log = createLogger("HostRegistrars");
+
+export interface DetectedHosts { claude: boolean; codex: boolean; cursor: boolean; gemini: boolean; }
+export interface McpHostRegistrar {
+	host: string;
+	register(wt: string): Promise<void>;
+	remove(wt: string): Promise<void>;
+	gitExcludePaths(): string[];
+}
+
+const claudeRegistrar: McpHostRegistrar = {
+	host: "claude",
+	register: registerMcpInClaude,
+	remove: removeMcpFromClaude,
+	gitExcludePaths: () => [MCP_GIT_EXCLUDE_PATH],
+};
+
+export function buildRegistrars(detected: DetectedHosts): McpHostRegistrar[] {
+	const out: McpHostRegistrar[] = [];
+	if (detected.claude) out.push(claudeRegistrar);
+	// cursor / gemini / codex appended in Tasks 8-9
+	return out;
+}
+
+export async function registerAllMcpHosts(wt: string, detected: DetectedHosts): Promise<void> {
+	for (const r of buildRegistrars(detected)) {
+		try { await r.register(wt); }
+		catch (err) { log.warn("MCP registration failed for %s in %s (non-fatal): %s", r.host, wt, String(err)); }
+	}
+}
+
+export async function removeAllMcpHosts(wt: string): Promise<void> {
+	for (const r of buildRegistrars({ claude: true, codex: true, cursor: true, gemini: true })) {
+		try { await r.remove(wt); }
+		catch (err) { log.warn("MCP removal failed for %s in %s (non-fatal): %s", r.host, wt, String(err)); }
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/mcp/HostRegistrars.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/install/mcp/HostRegistrars.ts cli/src/install/mcp/HostRegistrars.test.ts
+git commit -s -m "refactor(install): registrar abstraction over MCP host config writers"
+```
+
+---
+
+### Task 8: JSON `mcpServers` writer for Cursor + Gemini
+
+**Files:**
+- Create: `cli/src/install/mcp/JsonMcpWriter.ts`
+- Modify: `cli/src/install/mcp/HostRegistrars.ts` (+ cursor, gemini)
+- Test: `cli/src/install/mcp/JsonMcpWriter.test.ts`, extend `HostRegistrars.test.ts`
+
+- [ ] **Step 1: VERIFY (integrating-external-systems)**
+
+Confirm via official docs: Cursor project `<wt>/.cursor/mcp.json` key `mcpServers`;
+Gemini global `~/.gemini/settings.json` key `mcpServers`. Record findings in the
+file header. If a schema differs, do not reuse this writer for that host.
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+// cli/src/install/mcp/JsonMcpWriter.test.ts
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { removeJsonMcpServer, upsertJsonMcpServer } from "./JsonMcpWriter.js";
+const entry = { command: "/h/.jolli/jollimemory/run-cli", args: ["mcp"] };
+
+describe("JsonMcpWriter", () => {
+	it("creates the file with jollimemory under mcpServers", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "j-")), "mcp.json");
+		await upsertJsonMcpServer(p, entry);
+		expect(JSON.parse(await readFile(p, "utf-8")).mcpServers.jollimemory).toEqual(entry);
+	});
+	it("preserves other servers", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "j-")), "mcp.json");
+		await writeFile(p, JSON.stringify({ mcpServers: { other: { command: "x" } } }), "utf-8");
+		await upsertJsonMcpServer(p, entry);
+		const cfg = JSON.parse(await readFile(p, "utf-8"));
+		expect(cfg.mcpServers.other).toEqual({ command: "x" });
+		expect(cfg.mcpServers.jollimemory).toEqual(entry);
+	});
+	it("refuses to overwrite unreadable JSON", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "j-")), "mcp.json");
+		await writeFile(p, "{ not json", "utf-8");
+		await upsertJsonMcpServer(p, entry);
+		expect(await readFile(p, "utf-8")).toBe("{ not json");
+	});
+	it("removeJsonMcpServer drops only jollimemory", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "j-")), "mcp.json");
+		await writeFile(p, JSON.stringify({ mcpServers: { jollimemory: entry, other: { command: "x" } } }), "utf-8");
+		await removeJsonMcpServer(p);
+		const cfg = JSON.parse(await readFile(p, "utf-8"));
+		expect(cfg.mcpServers.jollimemory).toBeUndefined();
+		expect(cfg.mcpServers.other).toEqual({ command: "x" });
+	});
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/mcp/JsonMcpWriter.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 4: Implement `JsonMcpWriter.ts`** (idempotent merge, preserve-others, refuse-on-unreadable — same guard as `McpRegistration.ts`)
+
+```ts
+// cli/src/install/mcp/JsonMcpWriter.ts
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { createLogger } from "../../Logger.js";
+const log = createLogger("JsonMcpWriter");
+const SERVER_KEY = "jollimemory";
+interface ServerEntry { command: string; args?: string[]; }
+interface JsonConfig { mcpServers?: Record<string, ServerEntry>; [k: string]: unknown; }
+
+export async function upsertJsonMcpServer(configPath: string, entry: ServerEntry): Promise<void> {
+	let config: JsonConfig;
+	try { config = JSON.parse(await readFile(configPath, "utf-8")) as JsonConfig; }
+	catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+			log.warn("Skipping MCP registration: %s unreadable/invalid (%s)", configPath, String(err));
+			return;
+		}
+		config = {};
+	}
+	const servers = config.mcpServers ?? {};
+	servers[SERVER_KEY] = entry;
+	await mkdir(dirname(configPath), { recursive: true });
+	await writeFile(configPath, `${JSON.stringify({ ...config, mcpServers: servers }, null, 2)}\n`, "utf-8");
+	log.info("Registered MCP server in %s", configPath);
+}
+
+export async function removeJsonMcpServer(configPath: string): Promise<void> {
+	let config: JsonConfig;
+	try { config = JSON.parse(await readFile(configPath, "utf-8")) as JsonConfig; } catch { return; }
+	if (!config.mcpServers?.[SERVER_KEY]) return;
+	delete config.mcpServers[SERVER_KEY];
+	await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+	log.info("Removed MCP server from %s", configPath);
+}
+```
+
+- [ ] **Step 5: Add cursor + gemini registrars**
+
+```ts
+// in HostRegistrars.ts
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { getGlobalConfigDir } from "../../core/SessionTracker.js";
+import { mcpServerEntry } from "../McpRegistration.js";
+import { removeJsonMcpServer, upsertJsonMcpServer } from "./JsonMcpWriter.js";
+
+function jolliEntry() {
+	// POSIX: run-cli bash script honored on direct spawn. Windows for non-Claude
+	// hosts: VERIFY each host can spawn the extension-less bash script; if not,
+	// reuse resolveCliJs() like the Claude registrar. (Verification gate.)
+	return mcpServerEntry(process.platform, join(getGlobalConfigDir(), "run-cli"), undefined);
+}
+
+const cursorRegistrar: McpHostRegistrar = {
+	host: "cursor",
+	register: (wt) => upsertJsonMcpServer(join(wt, ".cursor", "mcp.json"), jolliEntry()),
+	remove: (wt) => removeJsonMcpServer(join(wt, ".cursor", "mcp.json")),
+	gitExcludePaths: () => ["/.cursor/mcp.json"],
+};
+const geminiRegistrar: McpHostRegistrar = {
+	host: "gemini",
+	register: () => upsertJsonMcpServer(join(homedir(), ".gemini", "settings.json"), jolliEntry()),
+	remove: () => removeJsonMcpServer(join(homedir(), ".gemini", "settings.json")),
+	gitExcludePaths: () => [],
+};
+```
+
+Append `if (detected.cursor) out.push(cursorRegistrar);` and `if (detected.gemini) out.push(geminiRegistrar);` to `buildRegistrars`. Add `HostRegistrars.test.ts` cases asserting they appear when detected and write to the expected paths.
+
+- [ ] **Step 6: Run tests**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/mcp/`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cli/src/install/mcp/JsonMcpWriter.ts cli/src/install/mcp/JsonMcpWriter.test.ts cli/src/install/mcp/HostRegistrars.ts cli/src/install/mcp/HostRegistrars.test.ts
+git commit -s -m "feat(install): MCP registration for Cursor and Gemini (shared JSON writer)"
+```
+
+---
+
+### Task 9: Codex TOML writer
+
+**Files:**
+- Create: `cli/src/install/mcp/CodexTomlWriter.ts`
+- Modify: `cli/src/install/mcp/HostRegistrars.ts` (+ codex)
+- Test: `cli/src/install/mcp/CodexTomlWriter.test.ts`, extend `HostRegistrars.test.ts`
+
+- [ ] **Step 1: VERIFY Codex config** — global `~/.codex/config.toml`, table
+  `[mcp_servers.jollimemory]`, `command`/`args`. Confirm exact key + array syntax;
+  record in file header. If unverifiable, omit codex registrar.
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+// cli/src/install/mcp/CodexTomlWriter.test.ts
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { removeCodexMcpServer, upsertCodexMcpServer } from "./CodexTomlWriter.js";
+const entry = { command: "/h/.jolli/jollimemory/run-cli", args: ["mcp"] };
+
+describe("CodexTomlWriter", () => {
+	it("creates a [mcp_servers.jollimemory] table", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "c-")), "config.toml");
+		await upsertCodexMcpServer(p, entry);
+		const t = await readFile(p, "utf-8");
+		expect(t).toContain("[mcp_servers.jollimemory]");
+		expect(t).toContain('command = "/h/.jolli/jollimemory/run-cli"');
+		expect(t).toContain('args = ["mcp"]');
+	});
+	it("preserves unrelated content and other tables", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "c-")), "config.toml");
+		await writeFile(p, 'model = "o4"\n\n[mcp_servers.other]\ncommand = "x"\n', "utf-8");
+		await upsertCodexMcpServer(p, entry);
+		const t = await readFile(p, "utf-8");
+		expect(t).toContain('model = "o4"');
+		expect(t).toContain("[mcp_servers.other]");
+		expect(t).toContain("[mcp_servers.jollimemory]");
+	});
+	it("replaces an existing jollimemory table idempotently", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "c-")), "config.toml");
+		await upsertCodexMcpServer(p, { command: "old", args: ["mcp"] });
+		await upsertCodexMcpServer(p, entry);
+		const t = await readFile(p, "utf-8");
+		expect(t).not.toContain('command = "old"');
+		expect((t.match(/\[mcp_servers\.jollimemory\]/g) ?? []).length).toBe(1);
+	});
+	it("removeCodexMcpServer drops only the jollimemory table", async () => {
+		const p = join(await mkdtemp(join(tmpdir(), "c-")), "config.toml");
+		await writeFile(p, '[mcp_servers.other]\ncommand = "x"\n', "utf-8");
+		await upsertCodexMcpServer(p, entry);
+		await removeCodexMcpServer(p);
+		const t = await readFile(p, "utf-8");
+		expect(t).not.toContain("jollimemory");
+		expect(t).toContain("[mcp_servers.other]");
+	});
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/mcp/CodexTomlWriter.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 4: Implement block-level TOML merge** (no TOML lib; only touches our table)
+
+```ts
+// cli/src/install/mcp/CodexTomlWriter.ts
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { createLogger } from "../../Logger.js";
+const log = createLogger("CodexTomlWriter");
+const HEADER = "[mcp_servers.jollimemory]";
+
+function renderBlock(entry: { command: string; args?: string[] }): string {
+	return `${HEADER}\ncommand = ${JSON.stringify(entry.command)}\nargs = ${JSON.stringify(entry.args ?? [])}\n`;
+}
+function stripBlock(text: string): string {
+	const start = text.indexOf(HEADER);
+	if (start === -1) return text;
+	const after = text.indexOf("\n[", start + HEADER.length);
+	const end = after === -1 ? text.length : after + 1;
+	return (text.slice(0, start) + text.slice(end)).replace(/\n{3,}/g, "\n\n");
+}
+export async function upsertCodexMcpServer(p: string, entry: { command: string; args?: string[] }): Promise<void> {
+	let text = "";
+	try { text = await readFile(p, "utf-8"); }
+	catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ENOENT") { log.warn("Skipping Codex MCP: %s unreadable (%s)", p, String(err)); return; }
+	}
+	const base = stripBlock(text).replace(/\s*$/, "");
+	const next = base.length === 0 ? renderBlock(entry) : `${base}\n\n${renderBlock(entry)}`;
+	await mkdir(dirname(p), { recursive: true });
+	await writeFile(p, next, "utf-8");
+	log.info("Registered Codex MCP server in %s", p);
+}
+export async function removeCodexMcpServer(p: string): Promise<void> {
+	let text: string;
+	try { text = await readFile(p, "utf-8"); } catch { return; }
+	if (!text.includes(HEADER)) return;
+	await writeFile(p, `${stripBlock(text).replace(/\s*$/, "")}\n`, "utf-8");
+	log.info("Removed Codex MCP server from %s", p);
+}
+```
+
+- [ ] **Step 5: Add codex registrar**
+
+```ts
+// in HostRegistrars.ts
+import { removeCodexMcpServer, upsertCodexMcpServer } from "./CodexTomlWriter.js";
+const codexRegistrar: McpHostRegistrar = {
+	host: "codex",
+	register: () => upsertCodexMcpServer(join(homedir(), ".codex", "config.toml"), jolliEntry()),
+	remove: () => removeCodexMcpServer(join(homedir(), ".codex", "config.toml")),
+	gitExcludePaths: () => [],
+};
+```
+
+Append `if (detected.codex) out.push(codexRegistrar);`. Add `HostRegistrars.test.ts` case for codex.
+
+- [ ] **Step 6: Run tests**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/mcp/`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cli/src/install/mcp/CodexTomlWriter.ts cli/src/install/mcp/CodexTomlWriter.test.ts cli/src/install/mcp/HostRegistrars.ts cli/src/install/mcp/HostRegistrars.test.ts
+git commit -s -m "feat(install): MCP registration for Codex (minimal TOML writer)"
+```
+
+---
+
+### Task 10: Wire registrars into the Installer
+
+**Files:**
+- Modify: `cli/src/install/Installer.ts`
+- Test: `cli/src/install/Installer.test.ts`
+
+- [ ] **Step 1: Locate detection + disable path**
+
+Run: `grep -n "registerMcpInClaude\|isCodexInstalled\|CodexDetector\|CursorDetector\|GeminiSessionDetector\|removeMcpFromClaude\|MCP_GIT_EXCLUDE_PATH" cli/src/install/Installer.ts`
+Confirm the per-worktree loop and the disable/uninstall path. Check the existing detector helper names (e.g. `isCodexInstalled`).
+
+- [ ] **Step 2: Write the failing test**
+
+Use the existing Installer test harness (temp repo). If it cannot safely write to real `~/.codex`/`~/.gemini`, add an injectable host-config root param to the registration call (default `homedir()`) so tests pass a temp dir. Assert: `.mcp.json` (claude) present after enable, and the multi-host wiring runs without throwing when other hosts are absent.
+
+```ts
+it("registers MCP across detected hosts during enable", async () => {
+	// follow existing Installer.test.ts setup; assert .mcp.json present and no throw
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/Installer.test.ts -t "registers MCP across detected hosts"`
+Expected: FAIL.
+
+- [ ] **Step 4: Replace the Claude-only call**
+
+Replace the `try { await registerMcpInClaude(wt); } catch …` block with:
+
+```ts
+const detected = {
+	claude: config.claudeEnabled !== false,
+	codex: await isCodexInstalled(),
+	cursor: await isCursorInstalled(),
+	gemini: await isGeminiInstalled(),
+};
+await registerAllMcpHosts(wt, detected);
+```
+
+Thread git-exclude: replace the single `MCP_GIT_EXCLUDE_PATH` in `updateGitExclude(wt, […])` with the union of active registrars' `gitExcludePaths()` (e.g. `buildRegistrars(detected).flatMap((r) => r.gitExcludePaths())`). In the disable/uninstall path, call `await removeAllMcpHosts(wt)`.
+
+(Use the actual detector function names confirmed in Step 1; if a detector is async-only or named differently, adapt. If a host has no detector, default it to `false`.)
+
+- [ ] **Step 5: Run tests + full gate**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/Installer.test.ts`
+Then: `npm run all`
+Expected: PASS; coverage ≥ thresholds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/install/Installer.ts cli/src/install/Installer.test.ts
+git commit -s -m "feat(install): register MCP server across all detected hosts"
+```
+
+---
+
+### Task 11: End-to-end verification + docs
+
+**Files:**
+- Modify: `CLAUDE.md` (MCP section), `cli/DEVELOPMENT.md` (if it lists MCP tools).
+
+- [ ] **Step 1: Build + smoke-test MCP**
+
+```bash
+cd cli && npm run build
+```
+In a repo with records, start `node dist/Cli.js mcp` via an MCP client; confirm
+`recall` returns the `type`-tagged union (try a non-matching branch → `catalog`)
+and `search` returns `{hits}`.
+
+- [ ] **Step 2: Verify a non-Claude host config (one host)**
+
+After `jolli enable` in a scratch repo with Cursor detected, confirm
+`.cursor/mcp.json` has the `jollimemory` entry and `git status` is clean.
+
+- [ ] **Step 3: Update CLAUDE.md**
+
+Note: MCP now registers across Claude (`.mcp.json`) + Cursor + Gemini + Codex;
+skills prefer MCP `recall`/`search` and fall back to the CLI here-doc; MCP
+`recall` and `search` share `resolveRecall`/`searchHits` with the CLI so results
+are identical; IntelliJ MCP registration is a follow-up.
+
+- [ ] **Step 4: Final gate + commit**
+
+```bash
+npm run all
+git add CLAUDE.md cli/DEVELOPMENT.md
+git commit -s -m "docs: multi-host MCP registration; recall/search MCP↔CLI parity"
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- Component 1 (unify results) → Tasks 1-4 (`resolveRecall`, rewire recall, `searchHits`, rewrite CLI search). ✓
+- Component 2 (multi-host) → Tasks 7-10. ✓
+- Component 3 (skill rewrite, MCP-preferred + fallback) → Tasks 5-6. ✓
+- Decision 1 (recall identical) → shared `resolveRecall`, Tasks 1-2. ✓
+- Decision 2 (search lightweight, fallback same impl) → shared `searchHits`, Tasks 3-4. ✓
+- Decision 4 (fallback retained) → Tasks 5-6 keep `heredocInvocation`. ✓
+- "Intentionally unchanged" `LocalSearchProvider` → Task 4 Step 1 verifies no other consumer; kept. ✓
+
+**Placeholder scan:** Code steps show full content. Task 10 Step 2 defers the exact Installer-test assertion to the existing harness shape (with the injectable-home seam) — flagged, not vague. Detector function names (`isCodexInstalled` etc.) are confirmed in Task 10 Step 1 before use.
+
+**Type consistency:** `RecallResult` identical in Tasks 1/2 and `runRecall` return. `SearchHitsArgs`/`searchHits` identical Tasks 3/4 and `runSearch`. `McpHostRegistrar`/`DetectedHosts` identical Tasks 7/8/9/10. `jolliEntry()`/`mcpServerEntry` reused.
+
+**Known soft spots (resolve during execution):**
+- Task 8/9 `jolliEntry()` uses `run-cli` for all hosts; verify Windows direct-spawn per non-Claude host or reuse `resolveCliJs` like Claude.
+- Task 10 may need a small injectable-home refactor in `Installer.ts`.
+- Confirm `SAFE_ARGUMENT_PATTERN` and the detector helpers are exported where Task 1/10 import them.

--- a/docs/superpowers/plans/2026-06-21-mcp-registration-opencode-copilot.md
+++ b/docs/superpowers/plans/2026-06-21-mcp-registration-opencode-copilot.md
@@ -1,0 +1,437 @@
+# MCP Registration for OpenCode / Copilot CLI / Copilot Chat — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-register the `jollimemory` MCP server into three additional AI *agents* — OpenCode, GitHub Copilot CLI, and VS Code Copilot Chat — during `jolli enable`, alongside the existing Claude/Cursor/Gemini/Codex registrars.
+
+**Architecture:** Extend the existing per-host `McpHostRegistrar` model in [HostRegistrars.ts](../../../cli/src/install/mcp/HostRegistrars.ts). Three of the four JSON hosts can share one writer once `JsonMcpWriter` is parameterized by top-level key + entry shape; the registrars only differ in config path and entry transform. Detection reuses the existing `is*Installed` detectors, run once in `Installer.ts` and folded into the `DetectedHosts` struct. MCP registration runs independently of any `*Enabled` config flag (same rule the existing four hosts follow).
+
+**Tech Stack:** TypeScript (ESM, Node 22.5+), Vitest + coverage, Biome (tabs, 120 col).
+
+## Observed Reality
+
+Verified on a real machine (2026-06-21), not from documentation. See per-host notes:
+
+| Agent | Config file (verified path) | Top-level key | Entry shape (verified) | Writer |
+|-------|------|---------|------|------|
+| **Copilot CLI** | global `~/.copilot/mcp-config.json` | `mcpServers` | `{ command, args }` — `type` optional, defaults `local` (live-verified `copilot mcp get` accepts no-`type`) | reuse parameterized `JsonMcpWriter` (default key) |
+| **OpenCode** | global `~/.config/opencode/opencode.json` | `mcp` | `{ type:"local"(**required**), command:["node",…args](**required array**), enabled? }` — `mcpServers` key → "Unrecognized key"; split `{command,args}` → "Invalid input"; missing `type` → "Invalid input". All live-verified via `opencode mcp list`. | `JsonMcpWriter` with `serversKey:"mcp"` + array-command entry |
+| **Copilot Chat** (VS Code) | global `<vscodeUserDataDir>/User/mcp.json` | `servers` (source: `serversKey ?? "servers"`) | `{ type:"stdio", command, args, env?, cwd? }` (source: `type:"stdio",command:t,args:n,…`) | `JsonMcpWriter` with `serversKey:"servers"` + stdio entry |
+
+**Scope decision (settled 2026-06-21):** Register at the scope whose config file jolli can cleanly **own** — not a blanket project-vs-global preference. Claude (`.mcp.json`) and Cursor (`.cursor/mcp.json`) have dedicated, jolli-ownable, gitexcludable **project** files, so they stay project-scoped. Gemini/Codex (existing) and the three new agents have no such file — their per-project config is a user-authored shared file (OpenCode `opencode.json`) or doesn't exist — so they register **globally**, matching the Gemini/Codex precedent. Adding a user-scope/global option for Claude (`~/.claude.json` top-level `mcpServers`, `claude mcp add --scope user`) or Cursor (`~/.cursor/mcp.json`) was explicitly **declined**: it would surface `jollimemory` in every project (breaking per-repo opt-in) and, for Claude, merge into the high-risk shared `~/.claude.json` blob rather than a dedicated file. OpenCode therefore stays **global** in this plan despite supporting a project config.
+
+**Verification gaps carried into this plan:**
+- Copilot Chat schema is from **reading the installed VS Code `workbench.desktop.main.js` source**, NOT a live smoke test (this machine's `User/mcp.json` is a 0-byte empty file; populating it needs the VS Code GUI). **Task 6 includes a mandatory live smoke-test gate** before this registrar is considered done.
+- Copilot CLI *workspace* config is `.mcp.json` — the **same file** Claude's registrar already writes (`copilot mcp list` in this worktree already shows `jollimemory` as a Workspace server). This plan therefore writes Copilot only to its **user-global** file; the workspace path is already covered when Claude is detected.
+
+## Global Constraints
+
+- **DCO sign-off on every commit** — `git commit -s`. No `Co-Authored-By: Claude` / `🤖 Generated` trailers.
+- **`npm run all` must pass before commit** (clean → build → lint → test). Run it once at the end, not per-task.
+- **CLI coverage floor:** 97% statements / 96% branches / 97% functions / 97% lines under `cli/src/`.
+- **Biome:** tabs, 4-wide, 120 col. `noExplicitAny: error`, `noUnusedImports/Variables: error`.
+- **Path normalization:** use `toForwardSlash` for `\`→`/`; never inline `.replace(/\\/g,"/")`. (Not expected to arise here — config paths are built with `join`.)
+- **No literal NUL, no per-task commit+test.** Write tests + impl per task; defer `npm run all` + commit to the end (per repo convention).
+
+## File Structure
+
+- **Modify** [cli/src/install/mcp/JsonMcpWriter.ts](../../../cli/src/install/mcp/JsonMcpWriter.ts) — add optional `serversKey` param (default `"mcpServers"`) and broaden the entry type so any JSON-shaped entry can be written. Single writer now serves Cursor, Gemini, Copilot CLI, OpenCode, Copilot Chat.
+- **Modify** [cli/src/install/mcp/HostRegistrars.ts](../../../cli/src/install/mcp/HostRegistrars.ts) — expand `DetectedHosts`, add `opencodeRegistrar` / `copilotCliRegistrar` / `copilotChatRegistrar`, wire them into `buildRegistrars` and the `removeAllMcpHosts` all-true set.
+- **Modify** [cli/src/install/Installer.ts](../../../cli/src/install/Installer.ts) — run the three detectors once, fold into the `detected` struct.
+- **Modify** test files: `JsonMcpWriter.test.ts`, `HostRegistrars.test.ts` (the latter's existing `buildRegistrars({...})` calls must gain the three new fields — TypeScript will flag every site).
+
+**No new files.** Each new host is a small registrar object reusing the parameterized JSON writer; a bespoke writer (like `CodexTomlWriter`) is not needed because all three are JSON.
+
+---
+
+### Task 1: Parameterize `JsonMcpWriter` by top-level key + entry shape
+
+**Files:**
+- Modify: `cli/src/install/mcp/JsonMcpWriter.ts`
+- Test: `cli/src/install/mcp/JsonMcpWriter.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces:
+  - `upsertJsonMcpServer(configPath: string, entry: Record<string, unknown>, serversKey?: string): Promise<void>` — `serversKey` defaults to `"mcpServers"`.
+  - `removeJsonMcpServer(configPath: string, serversKey?: string): Promise<void>` — `serversKey` defaults to `"mcpServers"`.
+
+- [ ] **Step 1: Write the failing test** — append to `JsonMcpWriter.test.ts` inside the `describe("JsonMcpWriter", …)` block:
+
+```typescript
+it("writes under a custom serversKey (mcp) preserving the entry shape", async () => {
+	const p = join(tmp, "opencode.json");
+	const entry = { type: "local", command: ["node", "/x/Cli.js", "mcp"], enabled: true };
+	await writeFile(p, JSON.stringify({ $schema: "https://opencode.ai/config.json" }), "utf-8");
+	await upsertJsonMcpServer(p, entry, "mcp");
+	const cfg = JSON.parse(await readFile(p, "utf-8"));
+	expect(cfg.$schema).toBe("https://opencode.ai/config.json"); // other keys preserved
+	expect(cfg.mcp.jollimemory).toEqual(entry);
+	expect(cfg.mcpServers).toBeUndefined(); // default key NOT used
+});
+
+it("removes from a custom serversKey (servers)", async () => {
+	const p = join(tmp, "mcp.json");
+	await writeFile(p, JSON.stringify({ servers: { jollimemory: { type: "stdio", command: "x" }, other: { command: "y" } } }), "utf-8");
+	await removeJsonMcpServer(p, "servers");
+	const cfg = JSON.parse(await readFile(p, "utf-8"));
+	expect(cfg.servers.jollimemory).toBeUndefined();
+	expect(cfg.servers.other).toEqual({ command: "y" });
+});
+```
+
+(Reuse whatever `tmp` / `entry` setup the existing tests already declare at the top of the file; if `tmp` is named differently there, match it.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/mcp/JsonMcpWriter.test.ts -t "custom serversKey"`
+Expected: FAIL — `upsertJsonMcpServer` currently ignores a 3rd arg and writes under `mcpServers`.
+
+- [ ] **Step 3: Implement** — replace the type declarations and both functions in `JsonMcpWriter.ts`. Broaden the entry type and thread `serversKey` through:
+
+```typescript
+const SERVER_KEY = "jollimemory";
+const DEFAULT_KEY = "mcpServers";
+
+type ServerEntry = Record<string, unknown>;
+type JsonConfig = Record<string, unknown>;
+
+export async function upsertJsonMcpServer(
+	configPath: string,
+	entry: ServerEntry,
+	serversKey: string = DEFAULT_KEY,
+): Promise<void> {
+	let config: JsonConfig;
+	try {
+		config = JSON.parse(await readFile(configPath, "utf-8")) as JsonConfig;
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+			log.warn("Skipping MCP registration: %s unreadable/invalid (%s)", configPath, String(err));
+			return;
+		}
+		config = {};
+	}
+	const servers = (config[serversKey] as Record<string, ServerEntry> | undefined) ?? {};
+	servers[SERVER_KEY] = entry;
+	await mkdir(dirname(configPath), { recursive: true });
+	await writeFile(configPath, `${JSON.stringify({ ...config, [serversKey]: servers }, null, 2)}\n`, "utf-8");
+	log.info("Registered MCP server in %s", configPath);
+}
+
+export async function removeJsonMcpServer(configPath: string, serversKey: string = DEFAULT_KEY): Promise<void> {
+	let config: JsonConfig;
+	try {
+		config = JSON.parse(await readFile(configPath, "utf-8")) as JsonConfig;
+	} catch {
+		return;
+	}
+	const servers = config[serversKey] as Record<string, ServerEntry> | undefined;
+	if (!servers?.[SERVER_KEY]) return;
+	delete servers[SERVER_KEY];
+	await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+	log.info("Removed MCP server from %s", configPath);
+}
+```
+
+Also update the file's top docstring: note the writer is now key-parameterized and lists the verified keys (`mcpServers` for Cursor/Gemini/Copilot-CLI, `mcp` for OpenCode, `servers` for Copilot Chat).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/mcp/JsonMcpWriter.test.ts`
+Expected: PASS — including the pre-existing `mcpServers` tests (default key unchanged).
+
+---
+
+### Task 2: Expand `DetectedHosts` and add the three registrars
+
+**Files:**
+- Modify: `cli/src/install/mcp/HostRegistrars.ts`
+- Test: `cli/src/install/mcp/HostRegistrars.test.ts`
+
+**Interfaces:**
+- Consumes: `upsertJsonMcpServer(path, entry, serversKey?)`, `removeJsonMcpServer(path, serversKey?)` from Task 1; `getVscodeUserDataDir(flavor, home?)` from `../../core/VscodeWorkspaceLocator.js`.
+- Produces: `DetectedHosts` gains `opencode: boolean`, `copilot: boolean`, `copilotChat: boolean`. `buildRegistrars` emits `opencode` / `copilot` / `copilotChat` hosts when their flag is set.
+
+- [ ] **Step 1: Write the failing tests** — append to `HostRegistrars.test.ts`.
+
+All three new hosts are **global** (paths resolved from `homedir()` inside the registrar, NOT from the `wt` argument). So the seam to assert against is the **`vi.doMock("./JsonMcpWriter.js")` pattern the existing gemini describe-block uses** (HostRegistrars.test.ts:122–159) — mock the writer, call `register()`, assert it was called with the expected path + entry + `serversKey`. Do **not** write real files under a temp dir for these — the `wt` arg is ignored.
+
+First add a top-of-file helper so the 7-field literals stay readable:
+
+```typescript
+const NONE = { claude: false, codex: false, cursor: false, gemini: false, opencode: false, copilot: false, copilotChat: false } as const;
+```
+
+Structure tests (host presence + gitExclude) use the plain `buildRegistrars`:
+
+```typescript
+describe("opencode/copilot/copilotChat registrars — structure", () => {
+	it("opencode appears when detected.opencode is true, with empty gitExcludePaths", () => {
+		const [r] = buildRegistrars({ ...NONE, opencode: true });
+		expect(r.host).toBe("opencode");
+		expect(r.gitExcludePaths()).toEqual([]);
+	});
+	it("copilot appears when detected.copilot is true", () => {
+		expect(buildRegistrars({ ...NONE, copilot: true }).map((r) => r.host)).toContain("copilot");
+	});
+	it("copilotChat appears when detected.copilotChat is true", () => {
+		expect(buildRegistrars({ ...NONE, copilotChat: true }).map((r) => r.host)).toContain("copilotChat");
+	});
+});
+```
+
+Target/shape tests reuse the existing gemini `vi.doMock` seam (mirror the `beforeEach`/`afterEach` doMock/unmock from lines 123–142; `upsertMock`/`removeMock`/`build` are the same locals):
+
+```typescript
+describe("new registrars — register targets & entry shape (mocked writer)", () => {
+	const upsertMock = vi.fn().mockResolvedValue(undefined);
+	const removeMock = vi.fn().mockResolvedValue(undefined);
+	beforeEach(() => {
+		vi.resetModules();
+		vi.doMock("./JsonMcpWriter.js", () => ({ upsertJsonMcpServer: upsertMock, removeJsonMcpServer: removeMock }));
+		upsertMock.mockClear();
+		removeMock.mockClear();
+	});
+	afterEach(() => { vi.doUnmock("./JsonMcpWriter.js"); vi.resetModules(); });
+
+	it("opencode register() → ~/.config/opencode/opencode.json, key `mcp`, type:local + array command", async () => {
+		const { buildRegistrars: build } = await import("./HostRegistrars.js");
+		const [r] = build({ ...NONE, opencode: true });
+		await r.register("/some/wt");
+		const [path, entry, key] = upsertMock.mock.calls[0];
+		expect(path).toBe(join(homedir(), ".config", "opencode", "opencode.json"));
+		expect(key).toBe("mcp");
+		expect(entry.type).toBe("local");
+		expect(Array.isArray(entry.command)).toBe(true);
+		expect(entry.command.at(-1)).toBe("mcp");
+	});
+
+	it("copilot register() → ~/.copilot/mcp-config.json, default key, {command,args}", async () => {
+		const { buildRegistrars: build } = await import("./HostRegistrars.js");
+		const [r] = build({ ...NONE, copilot: true });
+		await r.register("/some/wt");
+		const [path, entry, key] = upsertMock.mock.calls[0];
+		expect(path).toBe(join(homedir(), ".copilot", "mcp-config.json"));
+		expect(key).toBeUndefined(); // default mcpServers
+		expect(entry.args).toEqual(["mcp"]);
+	});
+
+	it("copilotChat register() → VS Code User/mcp.json, key `servers`, type:stdio", async () => {
+		const { buildRegistrars: build } = await import("./HostRegistrars.js");
+		const [r] = build({ ...NONE, copilotChat: true });
+		await r.register("/some/wt");
+		const [path, entry, key] = upsertMock.mock.calls[0];
+		expect(path).toBe(join(getVscodeUserDataDir("Code"), "User", "mcp.json"));
+		expect(key).toBe("servers");
+		expect(entry.type).toBe("stdio");
+		expect(entry.args).toEqual(["mcp"]);
+	});
+
+	it("opencode/copilotChat remove() pass the right serversKey", async () => {
+		const { buildRegistrars: build } = await import("./HostRegistrars.js");
+		await build({ ...NONE, opencode: true })[0].remove("/some/wt");
+		expect(removeMock.mock.calls[0][1]).toBe("mcp");
+		removeMock.mockClear();
+		await build({ ...NONE, copilotChat: true })[0].remove("/some/wt");
+		expect(removeMock.mock.calls[0][1]).toBe("servers");
+	});
+});
+```
+
+Add `import { getVscodeUserDataDir } from "../../core/VscodeWorkspaceLocator.js";` to the test imports.
+
+Also update the existing `buildRegistrars({...})` / `registerAllMcpHosts(...)` call sites in this file (claude/cursor/gemini/codex/registerAllMcpHosts tests) to include the three new `false` fields, or refactor them onto the `{ ...NONE, … }` spread. TypeScript flags each one.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/mcp/HostRegistrars.test.ts`
+Expected: FAIL/compile-error — `DetectedHosts` has no `opencode`/`copilot`/`copilotChat`; registrars don't exist.
+
+- [ ] **Step 3: Implement** in `HostRegistrars.ts`.
+
+Expand the interface:
+
+```typescript
+export interface DetectedHosts {
+	claude: boolean;
+	codex: boolean;
+	cursor: boolean;
+	gemini: boolean;
+	opencode: boolean;
+	copilot: boolean;
+	copilotChat: boolean;
+}
+```
+
+Add the import:
+
+```typescript
+import { getVscodeUserDataDir } from "../../core/VscodeWorkspaceLocator.js";
+```
+
+Add the three registrars (place after `codexRegistrar`). `jolliEntry()` already returns `{ command, args }`; derive the other shapes from it:
+
+```typescript
+/**
+ * OpenCode: global `~/.config/opencode/opencode.json`.
+ * Format live-verified via `opencode mcp list` (opencode-ai 1.4.1): top-level key
+ * `mcp`; entry REQUIRES `type:"local"` and a single `command` ARRAY (command + args
+ * combined). `mcpServers` key → "Unrecognized key"; split {command,args} → "Invalid
+ * input"; missing `type` → "Invalid input". `enabled` defaults true. Global config —
+ * never committed, so gitExcludePaths returns [].
+ */
+const opencodeRegistrar: McpHostRegistrar = {
+	host: "opencode",
+	register: () => {
+		const base = jolliEntry();
+		const entry = { type: "local", command: [base.command, ...base.args], enabled: true };
+		return upsertJsonMcpServer(join(homedir(), ".config", "opencode", "opencode.json"), entry, "mcp");
+	},
+	remove: () => removeJsonMcpServer(join(homedir(), ".config", "opencode", "opencode.json"), "mcp"),
+	gitExcludePaths: () => [],
+};
+
+/**
+ * GitHub Copilot CLI: user-global `~/.copilot/mcp-config.json`.
+ * Format live-verified via `copilot mcp add`/`get` (copilot CLI): top-level key
+ * `mcpServers`, entry `{ command, args }` (Copilot defaults `type:"local"` when omitted —
+ * live-verified). Same shape as Cursor/Gemini, so the default writer key is reused.
+ * NOTE: Copilot CLI ALSO reads workspace `.mcp.json`, which the Claude registrar already
+ * writes — so the workspace path is covered there; this registrar handles only the
+ * user-global file. Global config — never committed, so gitExcludePaths returns [].
+ */
+const copilotCliRegistrar: McpHostRegistrar = {
+	host: "copilot",
+	register: () => upsertJsonMcpServer(join(homedir(), ".copilot", "mcp-config.json"), jolliEntry()),
+	remove: () => removeJsonMcpServer(join(homedir(), ".copilot", "mcp-config.json")),
+	gitExcludePaths: () => [],
+};
+
+/**
+ * VS Code Copilot Chat: user-global `<vscodeUserDataDir>/User/mcp.json`.
+ * Format from VS Code app source (workbench.desktop.main.js): top-level key
+ * `servers` (`serversKey ?? "servers"`); stdio entry `{ type:"stdio", command, args }`.
+ * ⚠️ Source-verified only — see plan Task 6 for the mandatory live smoke test.
+ * Global config — never committed, so gitExcludePaths returns [].
+ */
+const copilotChatRegistrar: McpHostRegistrar = {
+	host: "copilotChat",
+	register: () => {
+		const base = jolliEntry();
+		const entry = { type: "stdio", command: base.command, args: base.args };
+		return upsertJsonMcpServer(join(getVscodeUserDataDir("Code"), "User", "mcp.json"), entry, "servers");
+	},
+	remove: () => removeJsonMcpServer(join(getVscodeUserDataDir("Code"), "User", "mcp.json"), "servers"),
+	gitExcludePaths: () => [],
+};
+```
+
+Wire into `buildRegistrars`:
+
+```typescript
+export function buildRegistrars(detected: DetectedHosts): McpHostRegistrar[] {
+	const out: McpHostRegistrar[] = [];
+	if (detected.claude) out.push(claudeRegistrar);
+	if (detected.cursor) out.push(cursorRegistrar);
+	if (detected.gemini) out.push(geminiRegistrar);
+	if (detected.codex) out.push(codexRegistrar);
+	if (detected.opencode) out.push(opencodeRegistrar);
+	if (detected.copilot) out.push(copilotCliRegistrar);
+	if (detected.copilotChat) out.push(copilotChatRegistrar);
+	return out;
+}
+```
+
+Update the `removeAllMcpHosts` all-true set:
+
+```typescript
+for (const r of buildRegistrars({
+	claude: true, codex: true, cursor: true, gemini: true,
+	opencode: true, copilot: true, copilotChat: true,
+})) {
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/mcp/HostRegistrars.test.ts`
+Expected: PASS.
+
+---
+
+### Task 3: Wire the three detectors into `Installer.ts`
+
+**Files:**
+- Modify: `cli/src/install/Installer.ts` (detector block ~line 186; `detected` struct ~line 220; the `removeAllMcpHosts` caller — confirm via grep)
+- Test: covered by the existing Installer integration tests (run after wiring).
+
+**Interfaces:**
+- Consumes: `isOpenCodeInstalled()` (`../core/OpenCodeSessionDiscoverer.js`, already imported ~line 32), `isCopilotInstalled()` (`../core/CopilotDetector.js`, imported ~line 25), `isCopilotChatInstalled()` (`../core/CopilotChatDetector.js`, imported ~line 22). All three imports already exist in this file.
+- Produces: `detected` now carries all seven hosts.
+
+- [ ] **Step 1: Add the detector calls** next to the existing once-before-loop block (after line 188):
+
+```typescript
+const opencodeDetectedOnce = await isOpenCodeInstalled();
+const copilotDetectedOnce = await isCopilotInstalled();
+const copilotChatDetectedOnce = await isCopilotChatInstalled();
+```
+
+- [ ] **Step 2: Extend the `detected` struct** (~line 220). MCP registration runs regardless of `*Enabled` — these are pure detector results, mirroring codex/cursor/gemini:
+
+```typescript
+const detected = {
+	claude: config.claudeEnabled !== false,
+	codex: codexDetectedOnce,
+	cursor: cursorDetectedOnce,
+	gemini: geminiDetectedOnce,
+	opencode: opencodeDetectedOnce,
+	copilot: copilotDetectedOnce,
+	copilotChat: copilotChatDetectedOnce,
+};
+```
+
+- [ ] **Step 3: Build to confirm type-completeness**
+
+Run: `npm run typecheck:cli`
+Expected: PASS — every `DetectedHosts` literal in non-test code now has all seven fields. If any other `buildRegistrars(...)` / `registerAllMcpHosts(...)` call sites exist with a 4-field literal, the compiler flags them; fix each to include the three new fields.
+
+---
+
+### Task 4: Live smoke-test gate for Copilot Chat (manual verification)
+
+This is the verification the discovery phase could not perform (empty `User/mcp.json`; needs the VS Code GUI). It is a **gate**, not code — but it must pass before the feature ships, because the Copilot Chat schema is source-verified only.
+
+- [ ] **Step 1: Generate real reference data.** In VS Code, run Command Palette → **MCP: Add Server** → add any stdio server (e.g. command `echo`). Then read the file:
+
+Run: `cat "$HOME/Library/Application Support/Code/User/mcp.json"` (macOS path; use `getVscodeUserDataDir` equivalent on other OSes)
+Expected: a JSON object whose top-level key is `servers` and whose entry has `"type": "stdio"`, `"command"`, `"args"`. Confirm there is **no** `inputs`-style wrapper around the server entry (if there is, the registrar's entry shape must adapt — update Task 2's `copilotChatRegistrar` accordingly and re-run its test).
+
+- [ ] **Step 2: Confirm jolli's written entry is accepted.** With the registrar wired (Tasks 2–3), run `jolli enable` (or the dev equivalent) on a machine with VS Code installed, then open VS Code and verify the `jollimemory` MCP server appears and connects in the Copilot Chat MCP server list.
+Expected: `jollimemory` listed and reachable. If VS Code rejects the entry, capture the exact error and reconcile the schema before shipping.
+
+- [ ] **Step 3: Record the result** in the PR description under an "Observed Reality — Copilot Chat" note (verified live vs. still source-only). If a real VS Code install is unavailable at implementation time, **say so explicitly** in the PR and mark the Copilot Chat registrar as source-verified-only — do not silently claim live verification.
+
+---
+
+### Final: build, lint, test, commit
+
+- [ ] **Step 1: Full gate**
+
+Run: `npm run all`
+Expected: clean → build → lint → test all PASS; CLI coverage ≥ 97/96/97/97. If the three tiny registrars dip branch coverage, add the missing `remove()` / `gitExcludePaths()` assertions in `HostRegistrars.test.ts` (mirror the existing cursor/gemini coverage).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add cli/src/install/mcp/JsonMcpWriter.ts cli/src/install/mcp/JsonMcpWriter.test.ts \
+        cli/src/install/mcp/HostRegistrars.ts cli/src/install/mcp/HostRegistrars.test.ts \
+        cli/src/install/Installer.ts \
+        docs/superpowers/plans/2026-06-21-mcp-registration-opencode-copilot.md
+git commit -s -m "Register jollimemory MCP server in OpenCode, Copilot CLI, and Copilot Chat"
+```
+
+## Self-Review
+
+- **Spec coverage:** Copilot CLI → Task 2 (`copilotCliRegistrar`) + Task 3 wiring; OpenCode → Task 1 (key param) + Task 2 (`opencodeRegistrar`) + Task 3; Copilot Chat → Task 1 + Task 2 (`copilotChatRegistrar`) + Task 3 + Task 4 live gate. Writer parameterization → Task 1. Detection → Task 3. ✓
+- **Type consistency:** `DetectedHosts` 7 fields defined in Task 2, consumed in Task 3; `upsertJsonMcpServer(path, entry, serversKey?)` signature defined in Task 1, called with `"mcp"`/`"servers"`/default in Task 2. `getVscodeUserDataDir("Code", home?)` matches the real signature. ✓
+- **Known follow-on:** IntelliJ registers no MCP today (CLAUDE.md) — out of scope here, unchanged. Copilot CLI/Chat sharing one `copilotEnabled` flag does not affect MCP (registration ignores enable flags), so no flag-split is needed. ✓

--- a/docs/superpowers/specs/2026-06-20-skills-use-mcp-tools-design.md
+++ b/docs/superpowers/specs/2026-06-20-skills-use-mcp-tools-design.md
@@ -1,0 +1,270 @@
+# Skills use MCP tools — design
+
+**Date:** 2026-06-20 (revised same day)
+**Branch:** `change-skill-use-mcp`
+**Status:** Draft — pending user review
+
+## Goal
+
+Move the `jolli-recall` and `jolli-search` skill templates off the
+shell-injection-defended CLI here-doc bridge and onto the structured
+JolliMemory MCP tools (`mcp__jollimemory__recall`, `mcp__jollimemory__search`),
+and register the MCP server for non-Claude hosts. MCP tool calls carry no shell
+surface, so the per-invocation hex-delimiter here-doc recipe is eliminated on
+the primary path; it remains as a fallback for hosts without the MCP server.
+
+The defining principle of this design: **the MCP tool and the CLI fallback for a
+skill must return byte-identical results.** This is guaranteed structurally by
+extracting one shared implementation per skill that BOTH the CLI command and the
+MCP tool call — not by keeping two parallel code paths in sync by hand.
+
+## Confirmed decisions (current — supersedes earlier draft)
+
+1. **recall — unify results.** `mcp__jollimemory__recall` must produce the same
+   result as the CLI `recall --format json` the skill fallback calls today: the
+   `type`-tagged discriminated union (`recall` / `catalog` / `error`) **including
+   the catalog fuzzy-match fallback**. Achieved by extracting a shared
+   `resolveRecall()` that both the CLI `recall` command and the MCP `runRecall`
+   tool call. (User: "recall 兑底也抽出共享实现，MCP 和兑底都使用它.")
+2. **search — use the current MCP BM25 search, lightweight.** `mcp__jollimemory__search`
+   stays a single Orama BM25 query returning lightweight
+   `{ hits: [{ id, type, title, snippet, branch, commitDate, slug, hash, score }] }`
+   — **no full content, no two-phase, no `load_commits` tool.** The CLI fallback
+   is changed to produce the **same** lightweight `{ hits }` via the **same**
+   shared `searchHits()` implementation (BM25), so primary and fallback match.
+   (User: "skill search 用当前 MCP search 实现… 兑底改成和 MCP search 同样的实现.")
+3. **Host scope.** Register the MCP server for non-Claude hosts too
+   (Codex / Cursor / Gemini, optionally Windsurf / OpenCode), gated on each
+   host's existing detector.
+4. **Fallback retained for both skills.** MCP-preferred with CLI here-doc
+   fallback, so cross-platform hosts keep working before/without MCP registration.
+
+### Reversals from the earlier draft (now void)
+
+- ~~Add a `load_commits` MCP tool~~ — dropped (decision 2). Search is lightweight.
+- ~~Extract `parseHashList` for `load_commits`~~ — dropped (no `--hashes` path).
+- ~~Keep the rich two-phase SearchHit rendering~~ — dropped; lightweight render.
+
+## Background facts (verified in code)
+
+- **One byte-identical SKILL.md** is written to both `.claude/skills/<name>/`
+  and `.agents/skills/<name>/` ([SkillInstaller.ts](../../../cli/src/install/SkillInstaller.ts)).
+- **MCP is registered only in Claude's `.mcp.json`** today
+  ([McpRegistration.ts](../../../cli/src/install/McpRegistration.ts),
+  [Installer.ts:232](../../../cli/src/install/Installer.ts#L232)). VS Code reuses
+  the bundled CLI Installer; **IntelliJ registers no MCP at all.**
+- **CLI `recall --format json`** emits a discriminated union:
+  `RecallPayload` (`type:"recall"`, [ContextCompiler.ts:135](../../../cli/src/core/ContextCompiler.ts#L135)),
+  `BranchCatalog` (`type:"catalog"`, [ContextCompiler.ts:179](../../../cli/src/core/ContextCompiler.ts#L179), with optional `query`),
+  or `{type:"error", message}`. The dispatch (resolve branch → load catalog →
+  exact match → fuzzy fallback → empty/error) lives inline in
+  [RecallCommand.ts:259-385](../../../cli/src/commands/RecallCommand.ts#L259).
+- **MCP `runRecall`** ([McpTools.ts:43](../../../cli/src/mcp/McpTools.ts#L43))
+  currently returns a bare `RecallPayload` only — no catalog fuzzy match, no
+  error/empty envelope. **This is the gap decision 1 closes.**
+- **MCP `runSearch`** ([McpTools.ts:24](../../../cli/src/mcp/McpTools.ts#L24)) is
+  `SearchIndex.openCached(...).search(...)` (Orama BM25) → `{ hits }`.
+- **CLI two-phase `search`** (`LocalSearchProvider.buildCatalog`/`loadHits`,
+  [SearchCommand.ts](../../../cli/src/commands/SearchCommand.ts)) — **its only
+  consumer is the current jolli-search skill.** Verified: no VS Code / core
+  module calls `buildCatalog`/`loadHits` outside `SearchCommand` (and the
+  `SearchProvider` interface + `RemoteSearchProvider` stub). So the CLI `search`
+  command can be switched to BM25 single-phase without breaking other consumers.
+- **Three independent "search" paths exist — do not conflate them.** (1) The VS
+  Code / IntelliJ **Memory Bank timeline view** search is
+  `JolliMemoryBridge.listSummaryEntries(count, offset, filter)` — an in-process
+  case-insensitive substring filter over `commitMessage`/`branch`/`repoName`
+  ([JolliMemoryBridge.ts:1485](../../../vscode/src/JolliMemoryBridge.ts#L1485)).
+  It touches none of the search backends below. (2) CLI two-phase catalog
+  (`SearchCommand`→`LocalSearchProvider`) — old skill only, being retired here.
+  (3) BM25 `SearchIndex` — the MCP `search` tool. This work touches only (2) and
+  (3); the timeline view (1) is unaffected.
+
+## Component 1 — unify CLI ↔ MCP results
+
+### 1a. Shared `resolveRecall`
+
+Create `cli/src/core/RecallResolver.ts` exporting:
+
+```ts
+export type RecallResult = RecallPayload | BranchCatalog | { type: "error"; message: string };
+
+/**
+ * The single source of truth for "what does recall return for this input".
+ * Mirrors the existing RecallCommand JSON dispatch exactly. Used by the CLI
+ * `recall --format json` path AND the MCP `recall` tool, so both are identical.
+ */
+export async function resolveRecall(
+	branchOrKeyword: string | undefined,
+	projectDir: string,
+	options?: { budget?: number; depth?: number; includeTranscripts?: boolean; includePlans?: boolean },
+): Promise<RecallResult>;
+```
+
+Logic (lifted verbatim from RecallCommand's action):
+1. Validate `branchOrKeyword` with `SAFE_ARGUMENT_PATTERN`; invalid → `{type:"error", …}`.
+2. Resolve branch: explicit arg, else current git branch (`getCurrentBranch`).
+3. Load `listBranchCatalog(projectDir)`.
+4. If branch + exact catalog match → `compileTaskContext` → `commitCount===0`
+   ? `{type:"error", message:"No Jolli Memory records found for branch …"}`
+   : `buildRecallPayload(ctx, budget)`.
+5. If branch + no exact match → `{...catalog, query: branch}` (`type:"catalog"`).
+6. No branch + empty catalog → `{type:"error", message:"No … records in this repository."}`.
+7. No branch + non-empty catalog → `catalog` (`type:"catalog"`).
+
+Then:
+- **RecallCommand** `--format json` path calls `resolveRecall` and
+  `console.log(JSON.stringify(result))`. (The `--full`/`--output`/default text
+  modes stay in the command — they are human-facing renders, not the JSON
+  contract.) The catalog text fallback (`renderCatalogText`) for non-JSON modes
+  stays in the command.
+- **MCP `runRecall`** becomes `return resolveRecall(args.branch, cwd)`. The
+  server still wraps a thrown error as `{error}`+`isError`, but `resolveRecall`
+  returns `{type:"error"}` for the *expected* empty/no-match cases (matching the
+  CLI), reserving throws for genuinely unexpected failures.
+
+### 1b. Shared `searchHits` + CLI search → BM25
+
+Create `cli/src/core/SearchHits.ts` exporting:
+
+```ts
+export interface SearchHitsArgs { query: string; branch?: string; type?: "topic" | "commit"; limit?: number; }
+/** BM25 hits — the single implementation behind MCP `search` and CLI `search`. */
+export async function searchHits(cwd: string, args: SearchHitsArgs, storage?: StorageProvider): Promise<SearchHitResult[]>;
+```
+
+Body = the current `runSearch` core (`SearchIndex.openCached(cwd, storage).search({query,branch,type,limit})`), including its non-empty-query guard and `limit` sanitization.
+
+Then:
+- **MCP `runSearch`** becomes `return { hits: await searchHits(cwd, args, getActiveStorage()) }`.
+- **CLI `search` command** is rewritten to single-phase BM25: parse query
+  (+ `--limit`, `--branch`, `--type`, `--arg-stdin`, `--format`, `--output`,
+  `--cwd`), call `searchHits`, emit `{ hits }` JSON (or a compact text render).
+  **Remove** the two-phase flags/logic (`--hashes`, `--since`, `--budget`,
+  `buildCatalog`/`loadHits`, `parseHashList`, `HASH_LIST_PATTERN`,
+  `renderResultText`). The skill's CLI fallback calls this and gets the same
+  `{ hits }` as MCP.
+
+### Intentionally unchanged (now unused by the skill, retained on purpose)
+
+- `LocalSearchProvider` (`buildCatalog`/`loadHits`), the `SearchProvider`
+  interface, `RemoteSearchProvider`, and the `SearchCatalog`/`SearchHit`/
+  `SearchResult` types in `Search.ts`. They lose their only live consumer
+  (the old `search` command) but are kept as the designed pluggable-provider
+  extension point and remain independently tested. Removing them is a separate
+  cleanup, out of scope here. (Listed explicitly so the omission is a decision.)
+
+## Component 2 — multi-host MCP registration
+
+Unchanged from the earlier draft. Generalize `McpRegistration` into a per-host
+registrar list; each registrar idempotent, preserves other servers, reuses the
+dist-path-indirected `run-cli mcp` entry from `mcpServerEntry`, gated on the
+host's existing detector. **integrating-external-systems applies** — verify each
+host's real config location/schema before writing its registrar; omit a host if
+unverifiable (the skill CLI fallback covers it).
+
+| Host | Location (hypothesis — verify) | Shape | Scope |
+|------|-------------------------------|-------|-------|
+| Claude (done) | `<wt>/.mcp.json` | `mcpServers` | project |
+| Cursor | `<wt>/.cursor/mcp.json` | `mcpServers` | project |
+| Gemini | `~/.gemini/settings.json` | `mcpServers` | global |
+| Codex | `~/.codex/config.toml` | `[mcp_servers.jollimemory]` TOML | global |
+| Windsurf / OpenCode | verify | verify | deferred behind verification |
+
+- **No TOML lib available** (verified: `@iarna/toml`/`smol-toml` absent, none in
+  any `package.json`; repo avoids new deps) → Codex uses a hand-written
+  block-level TOML merge that only ever touches our own table.
+- Cursor/Gemini/Windsurf share the `mcpServers` JSON shape → one shared JSON
+  writer, multiple locations.
+- Project-local config files get a `.git/info/exclude` entry; global configs
+  don't. `jolli disable`/uninstall must remove every host's entry.
+- **IntelliJ MCP registration: out of scope** (it registers no MCP today).
+
+## Component 3 — rewrite skill templates
+
+Both templates ([SkillInstaller.ts](../../../cli/src/install/SkillInstaller.ts))
+become MCP-preferred with the existing `heredocInvocation` recipe reused verbatim
+as the fallback (DRY — the security recipe is not duplicated).
+
+### jolli-recall
+
+Because MCP `recall` now returns the same `type`-tagged union as the CLI, the
+MCP path and the fallback path share identical Step-2 handling. New Step 1:
+
+- **Preferred:** if `mcp__jollimemory__recall` exists, call it with `{ branch }`
+  (omit for current branch). It returns the discriminated union directly.
+- **Fallback:** the existing `recall --format json` here-doc.
+- **Step 2 (shared):** handle `type:"recall"` (render Part A fact opener + Part B
+  synthesis — unchanged), `type:"catalog"` (semantic-match the user's input
+  against `branches`/`commitMessages`/`topicTitles`; one match → re-call recall
+  with that branch; many → ask; none → show catalog), `type:"error"` (surface
+  verbatim). All existing rendering guidance is retained.
+
+### jolli-search
+
+Single-phase, lightweight. New body:
+
+- **Step 1:** parse query (+ optional `limit`; note `--since`/`--budget` are not
+  supported on either path now).
+- **Step 2 — get hits:**
+  - **Preferred:** if `mcp__jollimemory__search` exists, call it with
+    `{ query, limit }` → `{ hits }`.
+  - **Fallback:** `jolli search --arg-stdin --format json` here-doc → `{ hits }`
+    (same shape, same BM25 implementation).
+- **Step 3 — render:** each hit has `type` (`topic`/`commit`), `title`,
+  `snippet`, `branch`, `commitDate`, `slug`, `hash`, `score`. Render a relevance-
+  ordered answer grounded by `hash` (commit) / `slug` (topic) and `branch`.
+  Universal principles (lead with the answer; ground every claim to hash/file;
+  reply in the user's language; don't expose machinery) are retained. The old
+  Step-5 SearchHit schema (decisions/recap/full topics) is **removed** — those
+  fields are not in a lightweight hit; the template must not promise them. If the
+  user needs deeper content, point them at `jolli-recall` for the relevant branch.
+
+## Data flow
+
+```
+recall:  input → [MCP recall | CLI recall here-doc] → resolveRecall()
+         → {type:recall|catalog|error} → LLM (catalog?→re-call; recall?→synthesize)
+
+search:  query → [MCP search | CLI search here-doc] → searchHits()
+         → {hits[]} → LLM renders ranked list grounded by hash/slug/branch
+```
+
+## Error handling
+
+- `resolveRecall` returns `{type:"error"}` for expected empty/no-match/invalid;
+  genuine failures throw → MCP `{error}`+`isError`, CLI non-zero exit. Templates
+  surface error text verbatim, never fabricate.
+- MCP tool absent → CLI here-doc fallback.
+- Per-host registration failure → non-fatal `log.warn`; hooks still install.
+- Unreadable host config → refuse to write (preserve), `log.warn`, retry next install.
+
+## Testing & coverage
+
+CLI ≥ 97%/96%. New/changed code needing tests:
+- `resolveRecall` — all 7 branches (exact/fuzzy/empty/no-branch/invalid/error).
+- `runRecall` returns the same union (delegates to `resolveRecall`).
+- `searchHits` — empty-query guard, limit sanitization, hits passthrough.
+- Rewritten `SearchCommand` — `{hits}` JSON output, `--limit`/`--branch`/`--type`,
+  removed-flag behavior; update existing two-phase tests (they will be deleted/
+  rewritten — verify no other test imports `parseHashList` from SearchCommand).
+- Per-host MCP registrars (JSON writer, Codex TOML writer, registrar list,
+  Installer wiring) — idempotent / preserve-others / unreadable-guard / remove.
+- SkillInstaller template assertions (MCP tool refs + fallback recipe present).
+- `npm run all` green; DCO sign-off; no Claude co-author trailer.
+
+## Out of scope
+
+- IntelliJ MCP registration (Kotlin).
+- Removing `LocalSearchProvider` / `SearchProvider` / catalog types (separate cleanup).
+- Any change to MCP search ranking/semantics (BM25 used as-is).
+
+## Verification gates before implementation
+
+1. Per-host config format/location verified (integrating-external-systems) before
+   that host's registrar is written; omit if unverifiable.
+2. Confirm no test outside `SearchCommand.test.ts` imports `parseHashList` /
+   two-phase types before deleting them.
+3. Confirm `LocalSearchProvider` has no live consumer besides `SearchCommand`
+   after the rewrite (re-grep) — keep it, but verify the "intentionally unchanged"
+   claim holds.


### PR DESCRIPTION
## Summary

Move the `jolli-recall` and `jolli-search` skills onto the JolliMemory MCP tools, and register the MCP server across non-Claude hosts. The skills now prefer the structured MCP tools and fall back to the existing CLI here-doc recipe only when the MCP server is unavailable.

The defining guarantee: **each skill's MCP tool and its CLI fallback return byte-identical results**, achieved structurally by extracting one shared implementation per skill that both the CLI command and the MCP tool call — not by keeping two parallel paths in sync.

## Changes

**Unify CLI ↔ MCP results**
- `resolveRecall()` (`cli/src/core/RecallResolver.ts`) — the MCP `recall` tool and `recall --format json` both call it, returning the identical `type:"recall"|"catalog"|"error"` union (including catalog fuzzy-match).
- `searchHits()` (`cli/src/core/SearchHits.ts`, Orama BM25) — the MCP `search` tool and the CLI `search` command both call it. The CLI `search` command is rewritten to single-phase `{ hits }`; the old two-phase catalog/`--hashes` flow is retired (`LocalSearchProvider` is kept as the unused `SearchProvider` extension point — verified no other consumer).

**Skill templates** (`cli/src/install/SkillInstaller.ts`)
- Both templates are MCP-preferred with the existing `heredocInvocation` here-doc reused verbatim as fallback.
- `jolli-search` is now single-phase lightweight (title/snippet/slug/hash); it points users to `jolli-recall` for full decisions/rationale rather than promising rich content it no longer has.

**Multi-host MCP registration**
- Per-host registrar abstraction (`cli/src/install/mcp/HostRegistrars.ts`) with writers for Claude (`.mcp.json`), Cursor (`.cursor/mcp.json`), Gemini (`~/.gemini/settings.json` — `JsonMcpWriter`), and Codex (`~/.codex/config.toml` — `CodexTomlWriter`, hand-written TOML, no new dependency).
- Wired into the Installer (`registerAllMcpHosts`/`removeAllMcpHosts`), gated by the existing per-host detectors, and runs **regardless of `claudeEnabled`** so a Cursor/Gemini/Codex user with Claude disabled still gets MCP registered.
- Config formats verified against real sources (Cursor app source, gemini-cli bundle, official Codex docs + a real `~/.codex/config.toml`).

## Intentionally unchanged / out of scope
- No `load_commits` tool (an earlier design idea, dropped): search is lightweight by design.
- `LocalSearchProvider` / `SearchProvider` / catalog types retained as the extension point.
- IntelliJ MCP registration — follow-up (it registers no MCP today).
- Windows `command` for non-Claude registrars uses the `run-cli` bash entry (not directly spawnable on Windows yet) — documented, covered by the CLI here-doc fallback.

## Testing
`npm run all` passes (clean → build → lint → test); the only failures are the pre-existing `safe.bareRepository=explicit` environment flake in `BootstrapMerge`/`GitClient`, unrelated to this change. New CLI code meets the 97%/96% coverage floor.
