### PR TITLE
Add incremental knowledge-graph update with fingerprint diffing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ Thumbs.db
 .claude/
 .kiro/
 .gemini/
+.agents/
 .cursor/
 .codex/
 .opencode/

--- a/cli/src/Logger.ts
+++ b/cli/src/Logger.ts
@@ -59,6 +59,16 @@ export function setLogDir(cwd: string): void {
 }
 
 /**
+ * Returns the current global log directory cwd (or undefined when unset). Lets a
+ * caller that re-points the log dir per work item — e.g. the multi-repo compile
+ * sweep — capture the prior value and restore it afterward, so the override never
+ * leaks into a long-lived host (VS Code) past the operation that set it.
+ */
+export function getLogDir(): string | undefined {
+	return _logDirCwd;
+}
+
+/**
  * Resets the global log directory (for testing only).
  */
 export function resetLogDir(): void {

--- a/cli/src/core/MultiRepoCompile.ts
+++ b/cli/src/core/MultiRepoCompile.ts
@@ -6,7 +6,7 @@
  */
 
 import { buildKnowledgeGraph } from "../graph/GraphBuilder.js";
-import { createLogger } from "../Logger.js";
+import { createLogger, getLogDir, resetLogDir, setLogDir } from "../Logger.js";
 import { deriveMemoryBankRoot } from "../sync/SyncBootstrap.js";
 import { DEFAULT_VAULT_WRITE_WAIT_MS, VaultWriteBusyError, withVaultWriteLock } from "../sync/VaultWriteLock.js";
 import type { JolliMemoryConfig } from "../Types.js";
@@ -35,8 +35,9 @@ export interface CompileAllResult {
 export interface CompileAllOptions extends Pick<IngestOptions, "batchSize"> {
 	/**
 	 * Optional one-line progress reporter for UI surfaces (the VS Code "Building
-	 * knowledge wiki…" notification). Messages are prefixed with `[i/total] <repo>`
-	 * so the user sees which repo and phase the sweep is on.
+	 * knowledge wiki…" notification). Messages take the form `[i/total] <repo>:
+	 * <phase>` so the user sees which repo (and how far through the sweep) plus the
+	 * current phase.
 	 */
 	readonly onProgress?: (message: string) => void;
 }
@@ -92,12 +93,18 @@ export async function compileAllRepos(
 	// never leaks past this sweep into a long-lived host process (VS Code), where
 	// it would silently point later reads/writes at the last-compiled repo.
 	const previousStorage = getActiveStorage();
+	// Capture the global log dir too: we re-point it per repo (below) so each repo's
+	// ingest/graph logs land in its OWN <kbRoot>/.jolli/jollimemory/debug.log instead
+	// of the host process's cwd. Restored in the finally so the override never leaks
+	// into the long-lived VS Code host past this sweep.
+	const previousLogDir = getLogDir();
 	try {
 		for (const [i, t] of targets.entries()) {
 			// `[i/total] <repo>: <phase>` — keeps the UI notification legible about
 			// which repo and phase a long sweep is on.
 			const report = (phase: string) => opts?.onProgress?.(`[${i + 1}/${total}] ${t.folder}: ${phase}`);
 			try {
+				setLogDir(t.kbRoot);
 				const storage = createFolderStorageAtRoot(t.kbRoot);
 				setActiveStorage(storage);
 				report("ingesting sources");
@@ -168,5 +175,7 @@ export async function compileAllRepos(
 		return { repos, totalIngested, failed };
 	} finally {
 		setActiveStorage(previousStorage);
+		if (previousLogDir === undefined) resetLogDir();
+		else setLogDir(previousLogDir);
 	}
 }

--- a/cli/src/core/PromptTemplates.test.ts
+++ b/cli/src/core/PromptTemplates.test.ts
@@ -39,6 +39,7 @@ describe("PromptTemplates", () => {
 			"route",
 			"reconcile",
 			"graph-categories",
+			"graph-categories-delta",
 			"graph-units",
 			"graph-edges",
 		]);

--- a/cli/src/core/PromptTemplates.ts
+++ b/cli/src/core/PromptTemplates.ts
@@ -802,6 +802,24 @@ Output ONLY a JSON object -- no prose, no markdown fences:
 {"edges":[{"from":"<unit id>","to":"<unit id>","type":"extends|caused-by|supersedes|contradicts|related-to","confidence":<0.5-1.0>,"evidence":"<one sentence>"}]}
 Use [] when there are no edges.`;
 
+const GRAPH_CATEGORIES_DELTA = `You are incrementally updating a software project's knowledge wiki graph. The category set already exists; only a few topics changed or were added. Place ONLY those topics, reusing existing categories wherever possible.
+
+## Existing categories
+{{existingCategories}}
+
+## Changed / new topics
+{{topics}}
+
+## Task
+- Assign EACH listed topic to a category via categoryId. STRONGLY prefer an existing category id from the list above. Only invent a new category when no existing one fits.
+- When you invent a new category: give it a stable kebab-case id, a shortTitle (<= 5 words), and a one-sentence summary. Its shortTitle MUST NOT duplicate any existing category's label.
+- For each topic, write a shortTitle (<= 5 words) and a one-sentence summary. Keep the original slug and title unchanged.
+
+## Output
+Output ONLY a JSON object -- no prose, no markdown fences:
+{"newCategories":[{"id":"<kebab-id>","shortTitle":"<<=5 words>","summary":"<one sentence>"}],"topics":[{"slug":"<unchanged>","title":"<unchanged>","shortTitle":"<<=5 words>","summary":"<one sentence>","categoryId":"<existing or new id>"}]}
+Include EVERY listed topic exactly once. Put only categories you newly invented in newCategories (never repeat an existing one). Use [] for empty arrays.`;
+
 // -- Exported map -------------------------------------------------------------
 
 /**
@@ -851,7 +869,15 @@ export const TEMPLATES: ReadonlyMap<string, PromptTemplate> = new Map<string, Pr
 	["translate", { action: "translate", version: 2, template: TRANSLATE }],
 	["route", { action: "route", version: 1, template: ROUTE }],
 	["reconcile", { action: "reconcile", version: 1, template: RECONCILE }],
+	// NOTE: the four graph-* templates feed the knowledge-graph distiller. If you
+	// change the OUTPUT SHAPE of any of them (a new/renamed field, a changed kind
+	// or edge-type enum, a changed unit-id format) you MUST also bump
+	// GRAPH_SCHEMA_VERSION in cli/src/graph/GraphSchema.ts — graph.json embeds
+	// these shapes verbatim and the incremental baseline reuses prior output only
+	// when schemaVersion matches. Pure wording/few-shot tweaks need only this
+	// template's own version bump, not the schema version.
 	["graph-categories", { action: "graph-categories", version: 1, template: GRAPH_CATEGORIES }],
+	["graph-categories-delta", { action: "graph-categories-delta", version: 1, template: GRAPH_CATEGORIES_DELTA }],
 	["graph-units", { action: "graph-units", version: 1, template: GRAPH_UNITS }],
 	["graph-edges", { action: "graph-edges", version: 1, template: GRAPH_EDGES }],
 ]);

--- a/cli/src/graph/GraphArtifactStore.test.ts
+++ b/cli/src/graph/GraphArtifactStore.test.ts
@@ -1,9 +1,9 @@
 import { existsSync } from "node:fs";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { writeGraphArtifacts } from "./GraphArtifactStore.js";
+import { graphJsonPath, readGraph, writeGraphArtifacts } from "./GraphArtifactStore.js";
 import { assembleGraph, type DistilledGraph } from "./GraphSchema.js";
 
 function tinyDistill(): DistilledGraph {
@@ -31,31 +31,58 @@ afterEach(async () => {
 	await Promise.all(dirs.splice(0).map((d) => rm(d, { recursive: true, force: true })));
 });
 
-describe("writeGraphArtifacts", () => {
-	it("writes graph.json + distill.json under the hidden .jolli/graph layer", async () => {
-		const root = await mkdtemp(join(tmpdir(), "jolli-graph-"));
-		dirs.push(root);
-		const distill = tinyDistill();
-		const graph = assembleGraph(distill, new Map(), ISO);
+async function freshDir(): Promise<string> {
+	const root = await mkdtemp(join(tmpdir(), "jolli-graph-"));
+	dirs.push(root);
+	return root;
+}
 
-		const result = await writeGraphArtifacts(root, graph, distill);
+describe("writeGraphArtifacts", () => {
+	it("writes graph.json (the only artifact) under the hidden .jolli/graph layer", async () => {
+		const root = await freshDir();
+		const graph = assembleGraph(tinyDistill(), new Map(), ISO, { t1: "fp" });
+
+		const result = await writeGraphArtifacts(root, graph);
 
 		const graphJson = JSON.parse(await readFile(join(root, ".jolli", "graph", "graph.json"), "utf8"));
 		expect(graphJson.stats.topics).toBe(1);
-		const distillJson = JSON.parse(await readFile(join(root, ".jolli", "graph", "distill.json"), "utf8"));
-		expect(distillJson.units).toHaveLength(1);
+		expect(graphJson.topicFingerprints).toEqual({ t1: "fp" });
 		expect(result.graphJsonPath).toBe(join(root, ".jolli", "graph", "graph.json"));
+		// distill.json is no longer written — graph.json is the sole artifact + baseline.
+		expect(existsSync(join(root, ".jolli", "graph", "distill.json"))).toBe(false);
 	});
 
 	it("writes atomically, leaving no .tmp sibling behind", async () => {
-		const root = await mkdtemp(join(tmpdir(), "jolli-graph-"));
-		dirs.push(root);
-		const distill = tinyDistill();
-		await writeGraphArtifacts(root, assembleGraph(distill, new Map(), ISO), distill);
+		const root = await freshDir();
+		await writeGraphArtifacts(root, assembleGraph(tinyDistill(), new Map(), ISO));
 
 		// atomicWriteFile renames tmp → final, so no half-written sibling lingers.
-		const graphDir = join(root, ".jolli", "graph");
-		expect(existsSync(join(graphDir, "graph.json.tmp"))).toBe(false);
-		expect(existsSync(join(graphDir, "distill.json.tmp"))).toBe(false);
+		expect(existsSync(join(root, ".jolli", "graph", "graph.json.tmp"))).toBe(false);
+	});
+});
+
+describe("readGraph", () => {
+	it("round-trips a written graph", async () => {
+		const root = await freshDir();
+		const written = assembleGraph(tinyDistill(), new Map(), ISO, { t1: "fp" });
+		await writeGraphArtifacts(root, written);
+
+		const got = await readGraph(root);
+		expect(got?.schemaVersion).toBe(2);
+		expect(got?.topicFingerprints).toEqual({ t1: "fp" });
+		expect(got?.units).toHaveLength(1);
+	});
+
+	it("returns null when no graph.json exists (missing → full rebuild)", async () => {
+		const root = await freshDir();
+		expect(await readGraph(root)).toBeNull();
+	});
+
+	it("returns null when graph.json is unparseable (corrupt → full rebuild)", async () => {
+		const root = await freshDir();
+		// Write a valid graph first so the .jolli/graph dir exists, then corrupt it.
+		await writeGraphArtifacts(root, assembleGraph(tinyDistill(), new Map(), ISO));
+		await writeFile(graphJsonPath(root), "{ not valid json", "utf8");
+		expect(await readGraph(root)).toBeNull();
 	});
 });

--- a/cli/src/graph/GraphArtifactStore.ts
+++ b/cli/src/graph/GraphArtifactStore.ts
@@ -1,43 +1,74 @@
 /**
- * GraphArtifactStore — writes the knowledge-graph data to a repo's Memory Bank
- * folder, in the hidden canonical layer:
+ * GraphArtifactStore — reads/writes the knowledge-graph data in a repo's Memory
+ * Bank folder, in the hidden canonical layer:
  *
- *   <kbRoot>/.jolli/graph/graph.json    final merged graph (the data the viz renders)
- *   <kbRoot>/.jolli/graph/distill.json  raw LLM-distilled layer (kept for future incremental)
+ *   <kbRoot>/.jolli/graph/graph.json    the merged graph the viz renders, AND the
+ *                                       incremental baseline (carries topicFingerprints)
  *
  * Folder-local and regenerable (like the disposable search index), written with
  * `fs` directly — NOT dual-written to the orphan branch. Only DATA is written
  * here: the viz runtime (JS/CSS) is referenced externally by the VS Code webview
  * (loaded from `assets/graph/` via `asWebviewUri`), which inlines just this
  * graph.json. There is no self-contained HTML artifact.
+ *
+ * Single file by design: graph.json is a superset of the old `distill.json` (the
+ * raw distilled layer is the `{categories,topics,units,edges}` subset, restored
+ * via `toDistilled`). Keeping one file means one write — no cross-file torn-write
+ * where a new graph.json pairs with a stale distill.json baseline. (A single
+ * file can still tear on the Windows EPERM fallback in `atomicWriteFile`, but a
+ * parse failure on read degrades to a full rebuild → self-heals; the orphan
+ * branch is always the system of record, so no data is lost.)
  */
 
-import { mkdir } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { atomicWriteFile } from "../core/AtomicWrite.js";
-import type { DistilledGraph, KnowledgeGraph } from "./GraphSchema.js";
+import { createLogger } from "../Logger.js";
+import type { KnowledgeGraph } from "./GraphSchema.js";
 
+const log = createLogger("GraphArtifactStore");
 const GRAPH_DIR = [".jolli", "graph"];
 
 export interface WriteGraphResult {
 	readonly graphJsonPath: string;
 }
 
+/** Absolute path to a repo's graph.json under `rootDir` (the per-repo kbRoot). */
+export function graphJsonPath(rootDir: string): string {
+	return join(rootDir, ...GRAPH_DIR, "graph.json");
+}
+
 /**
- * Writes `graph.json` (the final merged graph) and `distill.json` (the raw
- * distilled layer) under `rootDir` (the per-repo Memory Bank folder, i.e. kbRoot).
+ * Writes `graph.json` (the merged graph + incremental baseline) under `rootDir`
+ * (the per-repo Memory Bank folder, i.e. kbRoot). Atomic (tmp + rename) so a read
+ * during compile, or a crash mid-write, never leaves a truncated graph.json that
+ * breaks the webview/export.
  */
-export async function writeGraphArtifacts(
-	rootDir: string,
-	graph: KnowledgeGraph,
-	distill: DistilledGraph,
-): Promise<WriteGraphResult> {
+export async function writeGraphArtifacts(rootDir: string, graph: KnowledgeGraph): Promise<WriteGraphResult> {
 	const graphDir = join(rootDir, ...GRAPH_DIR);
 	await mkdir(graphDir, { recursive: true });
-	const graphJsonPath = join(graphDir, "graph.json");
-	// Atomic (tmp + rename) so a read during compile, or a crash mid-write, never
-	// leaves a truncated graph.json/distill.json that breaks the webview/export.
-	await atomicWriteFile(graphJsonPath, JSON.stringify(graph, null, "\t"));
-	await atomicWriteFile(join(graphDir, "distill.json"), JSON.stringify(distill, null, "\t"));
-	return { graphJsonPath };
+	const path = graphJsonPath(rootDir);
+	await atomicWriteFile(path, JSON.stringify(graph, null, "\t"));
+	return { graphJsonPath: path };
+}
+
+/**
+ * Reads a repo's prior `graph.json` for use as the incremental baseline. Returns
+ * the parsed object (an `unknown`-shaped `KnowledgeGraph`; the caller runs
+ * `toDistilled` to field-validate it) or `null` when the file is missing or
+ * unparseable — both cases degrade to a full rebuild. Never throws.
+ */
+export async function readGraph(rootDir: string): Promise<KnowledgeGraph | null> {
+	let raw: string;
+	try {
+		raw = await readFile(graphJsonPath(rootDir), "utf8");
+	} catch {
+		return null; // missing (ENOENT) or unreadable — full rebuild
+	}
+	try {
+		return JSON.parse(raw) as KnowledgeGraph;
+	} catch {
+		log.warn("Prior graph.json failed to parse -- treating as no baseline (full rebuild)");
+		return null;
+	}
 }

--- a/cli/src/graph/GraphBuilder.test.ts
+++ b/cli/src/graph/GraphBuilder.test.ts
@@ -1,18 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { StorageProvider } from "../core/StorageProvider.js";
 
-const { readTopicIndex, readTopicPage, distillGraph, writeGraphArtifacts } = vi.hoisted(() => ({
-	readTopicIndex: vi.fn(),
-	readTopicPage: vi.fn(),
-	distillGraph: vi.fn(),
-	writeGraphArtifacts: vi.fn(),
-}));
+const { readTopicIndex, readTopicPage, distillGraph, distillGraphIncremental, writeGraphArtifacts, readGraph } =
+	vi.hoisted(() => ({
+		readTopicIndex: vi.fn(),
+		readTopicPage: vi.fn(),
+		distillGraph: vi.fn(),
+		distillGraphIncremental: vi.fn(),
+		writeGraphArtifacts: vi.fn(),
+		readGraph: vi.fn(),
+	}));
 vi.mock("../core/TopicIndexStore.js", () => ({ readTopicIndex }));
 vi.mock("../core/TopicPageStore.js", () => ({ readTopicPage }));
-vi.mock("./GraphDistiller.js", () => ({ distillGraph }));
-vi.mock("./GraphArtifactStore.js", () => ({ writeGraphArtifacts }));
+vi.mock("./GraphDistiller.js", () => ({ distillGraph, distillGraphIncremental }));
+vi.mock("./GraphArtifactStore.js", () => ({ writeGraphArtifacts, readGraph }));
 
-import { buildKnowledgeGraph } from "./GraphBuilder.js";
+import { buildKnowledgeGraph, topicFingerprint, topicMetaFingerprint } from "./GraphBuilder.js";
 
 const ISO = "2026-06-15T00:00:00.000Z";
 const CONFIG = { apiKey: "k" };
@@ -36,9 +39,19 @@ const validDistill = {
 };
 
 beforeEach(() => {
-	for (const m of [readTopicIndex, readTopicPage, distillGraph, writeGraphArtifacts]) m.mockReset();
+	for (const m of [
+		readTopicIndex,
+		readTopicPage,
+		distillGraph,
+		distillGraphIncremental,
+		writeGraphArtifacts,
+		readGraph,
+	])
+		m.mockReset();
 	distillGraph.mockResolvedValue(validDistill);
+	distillGraphIncremental.mockResolvedValue(validDistill);
 	writeGraphArtifacts.mockResolvedValue({ graphJsonPath: "/kb/.jolli/graph/graph.json" });
+	readGraph.mockResolvedValue(null); // default: no baseline → full path
 });
 
 describe("buildKnowledgeGraph", () => {
@@ -49,12 +62,13 @@ describe("buildKnowledgeGraph", () => {
 		expect(readTopicIndex).not.toHaveBeenCalled();
 	});
 
-	it("skips when the topic index is empty", async () => {
+	it("skips when the topic index is empty and there is no prior graph", async () => {
 		readTopicIndex.mockResolvedValue({ schemaVersion: 1, topics: [] });
 		const r = await buildKnowledgeGraph("/cwd", folderStorage, CONFIG);
 		expect(r.built).toBe(false);
 		expect(r.reason).toBe("no topics");
 		expect(distillGraph).not.toHaveBeenCalled();
+		expect(writeGraphArtifacts).not.toHaveBeenCalled();
 	});
 
 	it("forwards onProgress to the distiller and reports the write step", async () => {
@@ -205,6 +219,204 @@ describe("buildKnowledgeGraph", () => {
 		expect(t1.sourceCommits).toEqual([{ hash: "cafebabe", message: "" }]);
 	});
 
+	it("derives overview from the first non-heading paragraph (skips a leading markdown heading)", async () => {
+		readTopicIndex.mockResolvedValue({
+			schemaVersion: 1,
+			topics: [{ stableSlug: "t1", title: "T1", summary: "s", lastUpdatedAt: "x" }],
+		});
+		readTopicPage.mockResolvedValue({
+			schemaVersion: 1,
+			stableSlug: "t1",
+			title: "T1",
+			content: "# Heading line\n\nreal first paragraph",
+			lastUpdatedAt: "x",
+		});
+		await buildKnowledgeGraph("/cwd", folderStorage, CONFIG, { nowIso: ISO });
+		const [, graphArg] = writeGraphArtifacts.mock.calls[0];
+		expect(graphArg.topics.find((t: { slug: string }) => t.slug === "t1").overview).toBe("real first paragraph");
+	});
+
+	// --- incremental path ---------------------------------------------------
+
+	const ONE_TOPIC_INDEX = {
+		schemaVersion: 1,
+		topics: [{ stableSlug: "t1", title: "Topic1", summary: "s1", lastUpdatedAt: "x" }],
+	};
+
+	/** A minimal, field-valid prior graph.json (the incremental baseline). */
+	function baselineGraph(
+		topicFingerprints: Record<string, string>,
+		topicMetaFingerprints: Record<string, string> = {},
+	) {
+		return {
+			schemaVersion: 2,
+			generatedAt: "x",
+			source: "x",
+			topicFingerprints,
+			topicMetaFingerprints,
+			stats: {},
+			categories: [],
+			topics: [],
+			units: [],
+			edges: [],
+		};
+	}
+
+	// Use the real fingerprint fns (not hand-copied formulas) so the skip / reassemble
+	// tests cannot silently go green if the separator/algorithm ever changes.
+	const fpOf = topicFingerprint;
+	const metaOf = (sourceBranches: string[], sourceCommits: { hash: string; message: string }[]) =>
+		topicMetaFingerprint({ sourceBranches, sourceCommits, overview: "", fullBody: "" });
+
+	/** A field-valid baseline that actually carries a distilled t1 topic + unit, so a
+	 *  no-LLM reassemble (metadata drift) and an empty-on-delete have something to act on. */
+	function richBaseline(topicFingerprints: Record<string, string>, topicMetaFingerprints: Record<string, string>) {
+		return {
+			...baselineGraph(topicFingerprints, topicMetaFingerprints),
+			categories: [{ id: "c", shortTitle: "C", summary: "c" }],
+			topics: [{ slug: "t1", shortTitle: "T1", summary: "s", title: "Topic1", categoryId: "c" }],
+			units: [
+				{
+					id: "t1::u1",
+					topicSlug: "t1",
+					kind: "decision",
+					shortTitle: "U1",
+					summary: "s",
+					anchors: { files: [], commits: [] },
+				},
+			],
+			edges: [],
+		};
+	}
+
+	it("takes the incremental path when a valid baseline exists with changed topics", async () => {
+		readTopicIndex.mockResolvedValue(ONE_TOPIC_INDEX);
+		readTopicPage.mockResolvedValue(null);
+		readGraph.mockResolvedValue(baselineGraph({})); // empty baseline → t1 is "added"
+
+		const r = await buildKnowledgeGraph("/cwd", folderStorage, CONFIG, { nowIso: ISO });
+
+		expect(r.built).toBe(true);
+		expect(r.mode).toBe("incremental");
+		expect(distillGraphIncremental).toHaveBeenCalled();
+		expect(distillGraph).not.toHaveBeenCalled();
+	});
+
+	it("skips entirely (no LLM, no write) when both content and metadata fingerprints are unchanged", async () => {
+		readTopicIndex.mockResolvedValue(ONE_TOPIC_INDEX);
+		readTopicPage.mockResolvedValue(null); // content = "", no branches/commits
+		// Baseline matches BOTH the content fingerprint and the (empty) metadata one.
+		readGraph.mockResolvedValue(baselineGraph({ t1: fpOf("Topic1", "s1", "") }, { t1: metaOf([], []) }));
+
+		const r = await buildKnowledgeGraph("/cwd", folderStorage, CONFIG, { nowIso: ISO });
+
+		expect(r.built).toBe(false);
+		expect(r.reason).toBe("no changes");
+		expect(distillGraph).not.toHaveBeenCalled();
+		expect(distillGraphIncremental).not.toHaveBeenCalled();
+		expect(writeGraphArtifacts).not.toHaveBeenCalled();
+	});
+
+	it("reassembles without LLM when content is unchanged but source metadata drifted", async () => {
+		readTopicIndex.mockResolvedValue(ONE_TOPIC_INDEX);
+		// Page present with a NEW commit ref, but the content (→ content fingerprint) is
+		// unchanged from the baseline. Only the join metadata moved.
+		readTopicPage.mockResolvedValue({
+			schemaVersion: 1,
+			stableSlug: "t1",
+			title: "Topic1",
+			content: "",
+			relatedBranches: [],
+			sourceRefs: [{ type: "summary", id: "abcdef120000", timestamp: "x" }],
+			lastUpdatedAt: "x",
+		});
+		// Baseline: same content fingerprint, but EMPTY (different) metadata fingerprint.
+		readGraph.mockResolvedValue(richBaseline({ t1: fpOf("Topic1", "s1", "") }, { t1: metaOf([], []) }));
+
+		const r = await buildKnowledgeGraph("/cwd", folderStorage, CONFIG, { nowIso: ISO });
+
+		expect(r.built).toBe(true);
+		expect(r.mode).toBe("incremental");
+		// No LLM ran (neither distiller), but graph.json WAS rewritten with fresh metadata.
+		expect(distillGraph).not.toHaveBeenCalled();
+		expect(distillGraphIncremental).not.toHaveBeenCalled();
+		expect(writeGraphArtifacts).toHaveBeenCalled();
+		const [, graphArg] = writeGraphArtifacts.mock.calls[0];
+		const t1 = graphArg.topics.find((t: { slug: string }) => t.slug === "t1");
+		expect(t1.sourceCommits).toEqual([{ hash: "abcdef12", message: "" }]); // refreshed
+		expect(t1.commitCount).toBe(1);
+	});
+
+	it("reassembles without LLM when the baseline metadata map has a different key set", async () => {
+		readTopicIndex.mockResolvedValue(ONE_TOPIC_INDEX);
+		readTopicPage.mockResolvedValue(null); // content unchanged
+		// Content fingerprint matches, but the baseline meta map carries an extra stale
+		// key — a size mismatch that must still trigger a refresh (never a false skip).
+		readGraph.mockResolvedValue(
+			richBaseline({ t1: fpOf("Topic1", "s1", "") }, { t1: metaOf([], []), tGhost: metaOf([], []) }),
+		);
+
+		const r = await buildKnowledgeGraph("/cwd", folderStorage, CONFIG, { nowIso: ISO });
+
+		expect(r.built).toBe(true);
+		expect(r.mode).toBe("incremental");
+		expect(distillGraph).not.toHaveBeenCalled();
+		expect(distillGraphIncremental).not.toHaveBeenCalled();
+		expect(writeGraphArtifacts).toHaveBeenCalled();
+	});
+
+	it("reassembles without LLM when the baseline has no metadata fingerprints (older write heals once)", async () => {
+		readTopicIndex.mockResolvedValue(ONE_TOPIC_INDEX);
+		readTopicPage.mockResolvedValue(null);
+		// schemaVersion matches, content fingerprint matches, but topicMetaFingerprints is
+		// absent (corrupt primitive) → treated as drifted → one reassemble heals it.
+		readGraph.mockResolvedValue({
+			...richBaseline({ t1: fpOf("Topic1", "s1", "") }, {}),
+			topicMetaFingerprints: "corrupt",
+		});
+
+		const r = await buildKnowledgeGraph("/cwd", folderStorage, CONFIG, { nowIso: ISO });
+
+		expect(r.built).toBe(true);
+		expect(r.mode).toBe("incremental");
+		expect(writeGraphArtifacts).toHaveBeenCalled();
+	});
+
+	it("rebuilds fully when the baseline schemaVersion does not match", async () => {
+		readTopicIndex.mockResolvedValue(ONE_TOPIC_INDEX);
+		readTopicPage.mockResolvedValue(null);
+		readGraph.mockResolvedValue({ ...baselineGraph({}), schemaVersion: 1 }); // stale schema
+
+		const r = await buildKnowledgeGraph("/cwd", folderStorage, CONFIG, { nowIso: ISO });
+		expect(r.mode).toBe("full");
+		expect(distillGraph).toHaveBeenCalled();
+		expect(distillGraphIncremental).not.toHaveBeenCalled();
+	});
+
+	it("rebuilds fully (one-time heal) when the baseline topicFingerprints are malformed", async () => {
+		readTopicIndex.mockResolvedValue(ONE_TOPIC_INDEX);
+		readTopicPage.mockResolvedValue(null);
+		// schemaVersion matches but topicFingerprints is a corrupt primitive → not a
+		// usable baseline → full (never throws in diffTopics).
+		readGraph.mockResolvedValue({ ...baselineGraph({}), topicFingerprints: "corrupt" });
+
+		const r = await buildKnowledgeGraph("/cwd", folderStorage, CONFIG, { nowIso: ISO });
+		expect(r.mode).toBe("full");
+		expect(distillGraph).toHaveBeenCalled();
+		expect(distillGraphIncremental).not.toHaveBeenCalled();
+	});
+
+	it("rebuilds fully when the baseline is structurally incompatible (toDistilled → null)", async () => {
+		readTopicIndex.mockResolvedValue(ONE_TOPIC_INDEX);
+		readTopicPage.mockResolvedValue(null);
+		// schemaVersion matches but a unit is missing required fields → toDistilled null.
+		readGraph.mockResolvedValue({ ...baselineGraph({}), units: [{ id: "x" }] });
+
+		const r = await buildKnowledgeGraph("/cwd", folderStorage, CONFIG, { nowIso: ISO });
+		expect(r.mode).toBe("full");
+		expect(distillGraph).toHaveBeenCalled();
+	});
+
 	it("falls back to index metadata when a topic page is missing", async () => {
 		readTopicIndex.mockResolvedValue({
 			schemaVersion: 1,
@@ -232,5 +444,23 @@ describe("buildKnowledgeGraph", () => {
 		const t1 = graphArg.topics.find((t: { slug: string }) => t.slug === "t1");
 		expect(t1.sourceBranches).toEqual(["release/1.x"]);
 		expect(t1.sourceCommits).toEqual([{ hash: "deadbeef", message: "" }]);
+	});
+
+	it("writes an empty graph (no LLM) when the last topic is deleted, clearing the stale graph", async () => {
+		readTopicIndex.mockResolvedValue({ schemaVersion: 1, topics: [] }); // all topics gone
+		readGraph.mockResolvedValue(richBaseline({ t1: fpOf("Topic1", "s1", "") }, { t1: metaOf([], []) }));
+
+		const r = await buildKnowledgeGraph("/cwd", folderStorage, CONFIG, { nowIso: ISO });
+
+		expect(r.built).toBe(true);
+		expect(r.mode).toBe("incremental");
+		expect(r).toMatchObject({ topics: 0, units: 0, edges: 0 });
+		// No LLM, but the stale graph IS overwritten with an empty one (no phantom topics).
+		expect(distillGraph).not.toHaveBeenCalled();
+		expect(distillGraphIncremental).not.toHaveBeenCalled();
+		const [, graphArg] = writeGraphArtifacts.mock.calls[0];
+		expect(graphArg.topics).toEqual([]);
+		expect(graphArg.units).toEqual([]);
+		expect(graphArg.categories).toEqual([]);
 	});
 });

--- a/cli/src/graph/GraphBuilder.ts
+++ b/cli/src/graph/GraphBuilder.ts
@@ -12,15 +12,31 @@
  * here degrades to "no graph this run" and never fails the compile.
  */
 
+import { createHash } from "node:crypto";
+import { createFolderStorageAtRoot } from "../core/StorageFactory.js";
 import type { StorageProvider } from "../core/StorageProvider.js";
 import { readTopicIndex } from "../core/TopicIndexStore.js";
 import type { SourceRef } from "../core/TopicKBTypes.js";
 import { readTopicPage } from "../core/TopicPageStore.js";
 import { createLogger } from "../Logger.js";
 import type { LlmConfig } from "../Types.js";
-import { writeGraphArtifacts } from "./GraphArtifactStore.js";
-import { type DistillTopicInput, distillGraph, type GraphProgressReporter } from "./GraphDistiller.js";
-import { assembleGraph, type SourceCommitRef, type TopicSourceMeta } from "./GraphSchema.js";
+import { readGraph, writeGraphArtifacts } from "./GraphArtifactStore.js";
+import {
+	type DistillTopicInput,
+	distillGraph,
+	distillGraphIncremental,
+	type GraphProgressReporter,
+} from "./GraphDistiller.js";
+import {
+	assembleGraph,
+	type DistilledGraph,
+	diffTopics,
+	GRAPH_SCHEMA_VERSION,
+	isFingerprintMap,
+	type SourceCommitRef,
+	type TopicSourceMeta,
+	toDistilled,
+} from "./GraphSchema.js";
 
 const log = createLogger("GraphBuilder");
 
@@ -34,10 +50,44 @@ export interface BuildGraphOptions {
 export interface BuildGraphResult {
 	readonly built: boolean;
 	readonly reason?: string;
+	/** Which path produced the graph (absent when nothing was built). */
+	readonly mode?: "full" | "incremental";
 	readonly topics?: number;
 	readonly units?: number;
 	readonly edges?: number;
 	readonly graphJsonPath?: string;
+}
+
+/**
+ * Per-topic content fingerprint for incremental dirty detection. Hashes the
+ * EXACT inputs the distiller consumes — `title`/`summary` from the index entry,
+ * `content` from the page — so a "should recompute" change is never missed. The
+ * NUL separators keep field boundaries unambiguous.
+ */
+export function topicFingerprint(title: string, summary: string, content: string): string {
+	return createHash("sha256").update(`${title}\u0000${summary}\u0000${content}`).digest("hex");
+}
+
+/**
+ * Per-topic fingerprint of the JOIN metadata graph.json carries but the content
+ * fingerprint excludes: `sourceBranches` + `sourceCommits` hashes. These are NOT
+ * LLM inputs, so they can change while {@link topicFingerprint} stays put — and
+ * the rolled-up `commitCount` is derived from them. When the content diff is a
+ * no-op but this changes, GraphBuilder does a NO-LLM reassemble instead of
+ * skipping, so the on-disk metadata never goes stale. (`overview` / `fullBody`
+ * are derived from `content`, already covered by the content fingerprint.)
+ */
+export function topicMetaFingerprint(meta: TopicSourceMeta): string {
+	const branches = meta.sourceBranches.join(",");
+	const commits = meta.sourceCommits.map((c) => c.hash).join(",");
+	return createHash("sha256").update(`${branches}\u0000${commits}`).digest("hex");
+}
+
+/** Shallow equality of two fingerprint maps (same keys, same values). */
+function sameFingerprints(a: Record<string, string>, b: Record<string, string>): boolean {
+	const keys = Object.keys(a);
+	if (keys.length !== Object.keys(b).length) return false;
+	return keys.every((k) => a[k] === b[k]);
 }
 
 /** Distinct commit refs (summary-type sources) for a topic, in first-seen order. */
@@ -80,38 +130,158 @@ export async function buildKnowledgeGraph(
 		return { built: false, reason: "orphan-only storage (no folder layer)" };
 	}
 
-	const index = await readTopicIndex(cwd, storage);
+	const kbRoot = storage.kbRoot ?? cwd;
+	const now = opts?.nowIso ?? new Date().toISOString();
+	const startedAt = performance.now();
+
+	// Read topic inputs from the FOLDER (canonical JSON under <kbRoot>/.jolli), never
+	// through the passed storage. In dual-write mode the passed storage reads the
+	// orphan branch — but graph.json (the incremental baseline) lives in and is derived
+	// from the folder, and the manual sweep already reads the folder. If the two trigger
+	// paths read different sources, their topic summaries drift and each recomputes the
+	// other's fingerprints as "dirty", re-distilling in a loop. Pinning every build to
+	// the folder keeps the baseline self-consistent (and matches the direction of
+	// retiring the orphan branch). The folder is always populated here: dual-write
+	// mirrors to it during the ingest that precedes this build, and the folder-layer
+	// gate above guarantees a folder exists.
+	const reader = createFolderStorageAtRoot(kbRoot);
+
+	const index = await readTopicIndex(cwd, reader);
+
+	// Incremental decision: reuse the prior graph.json as the baseline only when
+	// its schemaVersion matches, its topicFingerprints are a usable string map,
+	// AND it field-validates (toDistilled → null on a structural mismatch, e.g. a
+	// units-shape change shipped without a version bump). Any of these failing
+	// means there is no usable baseline → one-time full distillation that heals it
+	// (distinct from a recoverable incremental failure, which keeps the old graph).
+	// Read BEFORE the empty-index gate: an empty index over a non-empty baseline is
+	// "the last topic was just deleted", not "nothing was ever built".
+	const prevGraph = await readGraph(kbRoot);
+	const prevDistill: DistilledGraph | null =
+		prevGraph && prevGraph.schemaVersion === GRAPH_SCHEMA_VERSION && isFingerprintMap(prevGraph.topicFingerprints)
+			? toDistilled(prevGraph)
+			: null;
+
 	if (index.topics.length === 0) {
+		// All topics deleted → the deletion case, taken to zero topics. Overwrite the
+		// stale graph.json with an empty (referentially-trivial) graph so the viz stops
+		// showing phantom topics — NO LLM. A bare skip here would leave the last good
+		// graph on disk forever. Nothing-ever-built (no usable baseline, or a baseline
+		// that is already empty) still skips.
+		if (prevDistill && prevDistill.topics.length > 0) {
+			log.info("All topics deleted (was %d) -- writing empty knowledge graph", prevDistill.topics.length);
+			const empty = assembleGraph({ categories: [], topics: [], units: [], edges: [] }, new Map(), now, {}, {});
+			opts?.onProgress?.("writing graph.json");
+			const { graphJsonPath } = await writeGraphArtifacts(kbRoot, empty);
+			return { built: true, mode: "incremental", topics: 0, units: 0, edges: 0, graphJsonPath };
+		}
 		log.debug("No topics in the index -- skipping knowledge graph build");
 		return { built: false, reason: "no topics" };
 	}
 
 	const topicsInput: DistillTopicInput[] = [];
 	const sources = new Map<string, TopicSourceMeta>();
+	const fingerprints: Record<string, string> = {};
+	const metaFingerprints: Record<string, string> = {};
 	for (const entry of index.topics) {
-		const page = await readTopicPage(entry.stableSlug, cwd, storage);
+		const page = await readTopicPage(entry.stableSlug, cwd, reader);
 		const content = page?.content ?? "";
 		topicsInput.push({ slug: entry.stableSlug, title: entry.title, summary: entry.summary, content });
-		sources.set(entry.stableSlug, {
+		fingerprints[entry.stableSlug] = topicFingerprint(entry.title, entry.summary, content);
+		const meta: TopicSourceMeta = {
 			sourceBranches: page?.relatedBranches ?? entry.relatedBranches ?? [],
 			sourceCommits: commitRefs(page?.sourceRefs ?? entry.sourceRefs ?? []),
 			overview: firstParagraph(content),
 			fullBody: content,
-		});
+		};
+		sources.set(entry.stableSlug, meta);
+		metaFingerprints[entry.stableSlug] = topicMetaFingerprint(meta);
 	}
 
-	const kbRoot = storage.kbRoot ?? cwd;
-	log.info("Building knowledge graph for %s: %d topic(s)", kbRoot, index.topics.length);
-	const startedAt = performance.now();
+	let distill: DistilledGraph;
+	let mode: "full" | "incremental";
+	if (prevDistill) {
+		const diff = diffTopics(prevGraph?.topicFingerprints ?? {}, fingerprints);
+		if (diff.dirty.length === 0 && diff.added.length === 0 && diff.deleted.length === 0) {
+			// Content unchanged for every topic. But the join metadata (sourceBranches /
+			// sourceCommits → commitCount) is NOT in the content fingerprint, so it can
+			// drift on its own (a new commit folded into a topic whose summary regenerated
+			// identically, a branch rename). If it ALSO matches → true no-op, skip. If it
+			// drifted → NO-LLM reassemble: reuse the distilled layer verbatim, re-join the
+			// fresh metadata so the on-disk source/commitCount fields never go stale. A
+			// missing/corrupt baseline meta map (older write, hand-edit) counts as drifted
+			// → one reassemble heals it.
+			const prevMeta = isFingerprintMap(prevGraph?.topicMetaFingerprints)
+				? prevGraph.topicMetaFingerprints
+				: null;
+			if (prevMeta && sameFingerprints(prevMeta, metaFingerprints)) {
+				log.info("Knowledge graph unchanged (%d topics) -- skipping rebuild", index.topics.length);
+				return { built: false, reason: "no changes", topics: index.topics.length };
+			}
+			log.info("Knowledge graph content unchanged but source metadata drifted -- reassembling (no LLM)");
+			mode = "incremental";
+			distill = prevDistill;
+			const graph = assembleGraph(distill, sources, now, fingerprints, metaFingerprints);
+			opts?.onProgress?.("writing graph.json");
+			const { graphJsonPath } = await writeGraphArtifacts(kbRoot, graph);
+			log.info(
+				"Knowledge graph built (incremental, no LLM): %d categories, %d topics, %d units, %d edges in %dms -> %s",
+				graph.stats.categories,
+				graph.stats.topics,
+				graph.stats.units,
+				graph.stats.edges,
+				Math.round(performance.now() - startedAt),
+				graphJsonPath,
+			);
+			return {
+				built: true,
+				mode,
+				topics: graph.stats.topics,
+				units: graph.stats.units,
+				edges: graph.stats.edges,
+				graphJsonPath,
+			};
+		}
+		log.info(
+			"Building knowledge graph incrementally for %s: %d dirty, %d new, %d deleted, %d clean",
+			kbRoot,
+			diff.dirty.length,
+			diff.added.length,
+			diff.deleted.length,
+			diff.clean.length,
+		);
+		mode = "incremental";
+		// DECISION: an incremental failure (delta/edges LLM error, or an
+		// assembleGraph validation throw below) is NOT caught here to fall back to
+		// a full rebuild. It bubbles to CompileCommand's non-fatal try/catch →
+		// "no graph this round, keep the last good graph.json, retry next commit".
+		// Why no auto-full fallback:
+		//   - Full re-runs every LLM call (N+2) — exactly what incremental avoids;
+		//     one transient hiccup shouldn't trigger a 44-call rebuild.
+		//   - On a transient LLM error, full hits the same LLM and likely fails too,
+		//     burning double the tokens.
+		//   - An assembleGraph validation throw can only mean a merge bug (the
+		//     incremental path is built to always emit a referentially-sound graph).
+		//     Auto-full would mask that bug AND pay "incremental + full" every build;
+		//     keeping the old graph is cheap, safe, and surfaces the bug.
+		// "No usable baseline" (handled above via the schemaVersion / isFingerprintMap
+		// / toDistilled gate → full) is a DIFFERENT case: there's no starting point to
+		// build from, so a one-time full is correct — that is not a fallback.
+		distill = await distillGraphIncremental({ topics: topicsInput }, prevDistill, diff, config, opts?.onProgress);
+	} else {
+		log.info("Building knowledge graph for %s: %d topic(s) (full)", kbRoot, index.topics.length);
+		mode = "full";
+		distill = await distillGraph({ topics: topicsInput }, config, opts?.onProgress);
+	}
 
-	const distill = await distillGraph({ topics: topicsInput }, config, opts?.onProgress);
-	const graph = assembleGraph(distill, sources, opts?.nowIso ?? new Date().toISOString());
+	const graph = assembleGraph(distill, sources, now, fingerprints, metaFingerprints);
 
 	opts?.onProgress?.("writing graph.json");
-	const { graphJsonPath } = await writeGraphArtifacts(kbRoot, graph, distill);
+	const { graphJsonPath } = await writeGraphArtifacts(kbRoot, graph);
 
 	log.info(
-		"Knowledge graph built: %d categories, %d topics, %d units, %d edges in %dms -> %s",
+		"Knowledge graph built (%s): %d categories, %d topics, %d units, %d edges in %dms -> %s",
+		mode,
 		graph.stats.categories,
 		graph.stats.topics,
 		graph.stats.units,
@@ -121,6 +291,7 @@ export async function buildKnowledgeGraph(
 	);
 	return {
 		built: true,
+		mode,
 		topics: graph.stats.topics,
 		units: graph.stats.units,
 		edges: graph.stats.edges,

--- a/cli/src/graph/GraphDistiller.test.ts
+++ b/cli/src/graph/GraphDistiller.test.ts
@@ -4,7 +4,8 @@ const { callLlm } = vi.hoisted(() => ({ callLlm: vi.fn() }));
 vi.mock("../core/LlmClient.js", () => ({ callLlm }));
 vi.mock("../core/Summarizer.js", () => ({ resolveModelId: (m?: string) => m ?? "model" }));
 
-import { type DistillInput, distillGraph } from "./GraphDistiller.js";
+import { type DistillInput, distillGraph, distillGraphIncremental } from "./GraphDistiller.js";
+import type { DistilledGraph, TopicDiff } from "./GraphSchema.js";
 
 const CONFIG = { apiKey: "k", model: "haiku" };
 
@@ -360,5 +361,343 @@ describe("distillGraph", () => {
 		expect(g.categories.some((c) => c.id === "uncategorized")).toBe(true);
 		expect(g.units).toEqual([]);
 		expect(g.edges).toEqual([]);
+	});
+});
+
+describe("distillGraphIncremental", () => {
+	function baseline(): DistilledGraph {
+		return {
+			categories: [{ id: "c1", shortTitle: "C1", summary: "s" }],
+			topics: [
+				{ slug: "t1", shortTitle: "T1", summary: "s", title: "Topic1", categoryId: "c1" },
+				{ slug: "t2", shortTitle: "T2old", summary: "old", title: "Topic2", categoryId: "c1" },
+			],
+			units: [
+				{
+					id: "t1::u1",
+					topicSlug: "t1",
+					kind: "decision",
+					shortTitle: "U1",
+					summary: "s",
+					anchors: { files: [], commits: [] },
+				},
+				{
+					id: "t2::uOld",
+					topicSlug: "t2",
+					kind: "fix",
+					shortTitle: "old",
+					summary: "s",
+					anchors: { files: [], commits: [] },
+				},
+			],
+			edges: [{ from: "t1::u1", to: "t2::uOld", type: "related-to", confidence: 0.7, evidence: "old" }],
+		};
+	}
+
+	it("reuses clean units, re-distills changed topics, re-categorizes, and recomputes edges in full", async () => {
+		callLlm.mockImplementation(async (opts: { action: string; params: Record<string, string> }) => {
+			if (opts.action === "graph-categories-delta")
+				return {
+					text: JSON.stringify({
+						newCategories: [],
+						topics: [
+							{ slug: "t2", title: "Topic2", shortTitle: "T2new", summary: "new", categoryId: "c1" },
+							{ slug: "t3", title: "Topic3", shortTitle: "T3", summary: "s", categoryId: "c1" },
+						],
+					}),
+				};
+			if (opts.action === "graph-units")
+				return {
+					text: JSON.stringify({ units: [{ id: "u", kind: "decision", shortTitle: "U", summary: "s" }] }),
+				};
+			if (opts.action === "graph-edges")
+				return {
+					text: JSON.stringify({
+						edges: [{ from: "t1::u1", to: "t2::u", type: "extends", confidence: 0.9, evidence: "fresh" }],
+					}),
+					stopReason: null,
+				};
+			throw new Error(`unexpected ${opts.action}`);
+		});
+
+		const input: DistillInput = {
+			topics: [
+				{ slug: "t1", title: "Topic1", summary: "s", content: "c1" }, // clean
+				{ slug: "t2", title: "Topic2", summary: "new", content: "c2" }, // dirty
+				{ slug: "t3", title: "Topic3", summary: "s", content: "c3" }, // new
+			],
+		};
+		const diff: TopicDiff = { clean: ["t1"], dirty: ["t2"], added: ["t3"], deleted: [] };
+		const g = await distillGraphIncremental(input, baseline(), diff, CONFIG);
+
+		// t1's unit reused verbatim; t2's old unit gone; t2/t3 re-distilled.
+		expect(g.units.map((u) => u.id).sort()).toEqual(["t1::u1", "t2::u", "t3::u"]);
+		expect(g.units).not.toContainEqual(expect.objectContaining({ id: "t2::uOld" }));
+		// units NOT called for the clean topic.
+		expect(callLlm).not.toHaveBeenCalledWith(
+			expect.objectContaining({ params: expect.objectContaining({ topicTitle: "Topic1" }) }),
+		);
+		// dirty topic got the delta's refreshed shortTitle; categories merged.
+		expect(g.topics.find((t) => t.slug === "t2")?.shortTitle).toBe("T2new");
+		expect(g.topics.map((t) => t.slug).sort()).toEqual(["t1", "t2", "t3"]);
+		// edges recomputed in full (old edge discarded, fresh one kept).
+		expect(g.edges).toEqual([{ from: "t1::u1", to: "t2::u", type: "extends", confidence: 0.9, evidence: "fresh" }]);
+	});
+
+	it("admits a genuinely-new delta category while dropping empty / duplicate / existing-id proposals", async () => {
+		callLlm.mockImplementation(async (opts: { action: string }) => {
+			if (opts.action === "graph-categories-delta")
+				return {
+					text: JSON.stringify({
+						newCategories: [
+							{ id: "", shortTitle: "blank", summary: "x" }, // empty id → dropped
+							{ id: "storage", shortTitle: "Storage", summary: "x" }, // genuinely new → kept
+							{ id: "storage", shortTitle: "Dup", summary: "x" }, // duplicate id → dropped
+							{ id: "c1", shortTitle: "Collide", summary: "x" }, // collides with existing → dropped
+						],
+						topics: [
+							{ slug: "t3", title: "Topic3", shortTitle: "T3", summary: "s", categoryId: "storage" },
+						],
+					}),
+				};
+			if (opts.action === "graph-units")
+				return {
+					text: JSON.stringify({ units: [{ id: "u", kind: "decision", shortTitle: "U", summary: "s" }] }),
+				};
+			return { text: '{"edges":[]}', stopReason: null };
+		});
+		const input: DistillInput = {
+			topics: [
+				{ slug: "t1", title: "Topic1", summary: "s", content: "c1" },
+				{ slug: "t2", title: "Topic2", summary: "old", content: "c2" },
+				{ slug: "t3", title: "Topic3", summary: "s", content: "c3" },
+			],
+		};
+		const diff: TopicDiff = { clean: ["t1", "t2"], dirty: [], added: ["t3"], deleted: [] };
+		const g = await distillGraphIncremental(input, baseline(), diff, CONFIG);
+		expect(g.categories.map((c) => c.id).sort()).toEqual(["c1", "storage"]);
+		expect(g.topics.find((t) => t.slug === "t3")?.categoryId).toBe("storage");
+	});
+
+	it("sanitizes the categories-delta: empty-existing, blank fallbacks, hallucinated slug, invalid categoryId", async () => {
+		callLlm.mockImplementation(async (opts: { action: string }) => {
+			if (opts.action === "graph-categories-delta")
+				return {
+					text: JSON.stringify({
+						newCategories: [{ id: "new1", shortTitle: "  ", summary: "x" }], // blank label → id fallback
+						topics: [
+							// blank shortTitle/summary → fall back to title/summary; bad categoryId → uncategorized.
+							{ slug: "t1", title: "Topic1", shortTitle: "", summary: "", categoryId: "unknown" },
+							{ slug: "ghost", title: "G", shortTitle: "G", summary: "s", categoryId: "new1" }, // dropped
+						],
+					}),
+				};
+			if (opts.action === "graph-units")
+				return {
+					text: JSON.stringify({ units: [{ id: "u", kind: "decision", shortTitle: "U", summary: "s" }] }),
+				};
+			return { text: '{"edges":[]}', stopReason: null };
+		});
+		const emptyBaseline: DistilledGraph = { categories: [], topics: [], units: [], edges: [] };
+		const input: DistillInput = { topics: [{ slug: "t1", title: "Topic1", summary: "sum1", content: "c" }] };
+		const diff: TopicDiff = { clean: [], dirty: [], added: ["t1"], deleted: [] };
+		const g = await distillGraphIncremental(input, emptyBaseline, diff, CONFIG);
+
+		expect(g.categories.find((c) => c.id === "new1")?.shortTitle).toBe("new1"); // blank → id
+		const t1 = g.topics.find((t) => t.slug === "t1");
+		expect(t1?.categoryId).toBe("uncategorized"); // unknown categoryId → uncategorized
+		expect(t1?.shortTitle).toBe("Topic1"); // blank → src.title
+		expect(t1?.summary).toBe("sum1"); // blank → src.summary
+		expect(g.topics.find((t) => t.slug === "ghost")).toBeUndefined(); // hallucinated dropped
+	});
+
+	it("throws on an unparseable categories-delta (incremental fails closed, keeping the prior graph)", async () => {
+		callLlm.mockImplementation(async (opts: { action: string }) => {
+			if (opts.action === "graph-categories-delta") return { text: "garbage not json" };
+			if (opts.action === "graph-units") return { text: '{"units":[]}' };
+			return { text: '{"edges":[]}', stopReason: null };
+		});
+		const input: DistillInput = { topics: [{ slug: "t1", title: "Topic1", summary: "s", content: "c" }] };
+		const diff: TopicDiff = { clean: [], dirty: [], added: ["t1"], deleted: [] };
+		// Unparseable delta → throw (not a silent dump of the changed topic into
+		// uncategorized over a still-good baseline). The outer non-fatal catch keeps
+		// the last good graph. Contrast the full path, which tolerates this (no
+		// baseline to protect).
+		await expect(
+			distillGraphIncremental(input, { categories: [], topics: [], units: [], edges: [] }, diff, CONFIG),
+		).rejects.toThrow(/graph-categories-delta returned a malformed response/);
+	});
+
+	it("throws when the categories-delta is valid JSON but missing the topics array (incremental fails closed)", async () => {
+		callLlm.mockImplementation(async (opts: { action: string }) => {
+			if (opts.action === "graph-categories-delta") return { text: "{}" }; // parses, but no arrays
+			if (opts.action === "graph-units") return { text: '{"units":[]}' };
+			return { text: '{"edges":[]}', stopReason: null };
+		});
+		const input: DistillInput = { topics: [{ slug: "t1", title: "Topic1", summary: "s", content: "c" }] };
+		const diff: TopicDiff = { clean: [], dirty: [], added: ["t1"], deleted: [] };
+		// `{}` would otherwise dump t1 into uncategorized over a still-good baseline — strict
+		// requires the contracted arrays, not merely parseable JSON.
+		await expect(
+			distillGraphIncremental(input, { categories: [], topics: [], units: [], edges: [] }, diff, CONFIG),
+		).rejects.toThrow(/graph-categories-delta returned a malformed response/);
+	});
+
+	it("runs no LLM on a pure deletion: filters deleted units and dangling edges", async () => {
+		const input: DistillInput = { topics: [{ slug: "t1", title: "Topic1", summary: "s", content: "c1" }] };
+		const diff: TopicDiff = { clean: ["t1"], dirty: [], added: [], deleted: ["t2"] };
+		const g = await distillGraphIncremental(input, baseline(), diff, CONFIG);
+
+		expect(callLlm).not.toHaveBeenCalled();
+		expect(g.units.map((u) => u.id)).toEqual(["t1::u1"]); // t2's unit dropped
+		expect(g.edges).toEqual([]); // the t1→t2 edge dangled and was filtered
+		expect(g.topics.map((t) => t.slug)).toEqual(["t1"]);
+		expect(g.categories.map((c) => c.id)).toEqual(["c1"]);
+	});
+
+	it("backfills a changed topic the delta dropped (a valid-but-incomplete delta is tolerated)", async () => {
+		callLlm.mockImplementation(async (opts: { action: string; params: Record<string, string> }) => {
+			if (opts.action === "graph-categories-delta")
+				return { text: JSON.stringify({ newCategories: [], topics: [] }) }; // valid JSON, just dropped t2
+			if (opts.action === "graph-units")
+				return {
+					text: JSON.stringify({ units: [{ id: "u", kind: "decision", shortTitle: "U", summary: "s" }] }),
+				};
+			if (opts.action === "graph-edges") return { text: '{"edges":[]}', stopReason: null };
+			throw new Error(`unexpected ${opts.action}`);
+		});
+		const input: DistillInput = { topics: [{ slug: "t2", title: "Topic2", summary: "new", content: "c2" }] };
+		const diff: TopicDiff = { clean: [], dirty: ["t2"], added: [], deleted: ["t1"] };
+		const g = await distillGraphIncremental(input, baseline(), diff, CONFIG, () => {});
+
+		// A VALID delta that merely omitted t2 is not a failure — the merge backfills it
+		// into uncategorized, and its units were still re-distilled successfully.
+		expect(g.topics.find((t) => t.slug === "t2")?.categoryId).toBe("uncategorized");
+		expect(g.units.map((u) => u.id)).toEqual(["t2::u"]);
+	});
+
+	it("throws when a changed topic's unit call fails (incremental fails closed)", async () => {
+		callLlm.mockImplementation(async (opts: { action: string }) => {
+			if (opts.action === "graph-units") throw new Error("boom"); // a thrown LLM error must propagate
+			return { text: JSON.stringify({ newCategories: [], topics: [] }) };
+		});
+		const input: DistillInput = { topics: [{ slug: "t2", title: "Topic2", summary: "new", content: "c2" }] };
+		const diff: TopicDiff = { clean: [], dirty: ["t2"], added: [], deleted: ["t1"] };
+		// A dirty topic's failed unit re-distillation must abort the round (NOT emit a
+		// unit-less topic over a baseline that had units). The full path swallows this;
+		// the incremental path must not.
+		await expect(distillGraphIncremental(input, baseline(), diff, CONFIG, () => {})).rejects.toThrow("boom");
+	});
+
+	it("throws when a changed topic's units return unparseable JSON (incremental fails closed)", async () => {
+		callLlm.mockImplementation(async (opts: { action: string }) => {
+			if (opts.action === "graph-units") return { text: "not json at all" };
+			return { text: JSON.stringify({ newCategories: [], topics: [] }) };
+		});
+		const input: DistillInput = { topics: [{ slug: "t2", title: "Topic2", summary: "new", content: "c2" }] };
+		const diff: TopicDiff = { clean: [], dirty: ["t2"], added: [], deleted: ["t1"] };
+		await expect(distillGraphIncremental(input, baseline(), diff, CONFIG)).rejects.toThrow(
+			/graph-units returned no units array/,
+		);
+	});
+
+	it("throws when a changed topic's units are valid JSON but missing the units array (incremental)", async () => {
+		callLlm.mockImplementation(async (opts: { action: string }) => {
+			if (opts.action === "graph-units") return { text: "{}" }; // parses, but no units array
+			return { text: JSON.stringify({ newCategories: [], topics: [] }) };
+		});
+		const input: DistillInput = { topics: [{ slug: "t2", title: "Topic2", summary: "new", content: "c2" }] };
+		const diff: TopicDiff = { clean: [], dirty: ["t2"], added: [], deleted: ["t1"] };
+		await expect(distillGraphIncremental(input, baseline(), diff, CONFIG)).rejects.toThrow(
+			/graph-units returned no units array/,
+		);
+	});
+
+	it("throws when graph-edges returns unparseable JSON (incremental fails closed)", async () => {
+		callLlm.mockImplementation(async (opts: { action: string }) => {
+			if (opts.action === "graph-categories-delta")
+				return {
+					text: JSON.stringify({
+						newCategories: [],
+						topics: [{ slug: "t2", title: "Topic2", shortTitle: "T2", summary: "s", categoryId: "c1" }],
+					}),
+				};
+			if (opts.action === "graph-units")
+				return {
+					text: JSON.stringify({ units: [{ id: "u", kind: "decision", shortTitle: "U", summary: "s" }] }),
+				};
+			if (opts.action === "graph-edges") return { text: "not json at all", stopReason: null };
+			throw new Error(`unexpected ${opts.action}`);
+		});
+		// Two final units (t1 reused + t2 fresh) → the edge call fires; its unparseable
+		// output would otherwise wipe the whole edge layer, so it must throw instead.
+		const input: DistillInput = {
+			topics: [
+				{ slug: "t1", title: "Topic1", summary: "s", content: "c1" },
+				{ slug: "t2", title: "Topic2", summary: "new", content: "c2" },
+			],
+		};
+		const diff: TopicDiff = { clean: ["t1"], dirty: ["t2"], added: [], deleted: [] };
+		await expect(distillGraphIncremental(input, baseline(), diff, CONFIG)).rejects.toThrow(
+			/graph-edges returned no edges array/,
+		);
+	});
+
+	it("surfaces truncation in the thrown error when graph-edges is cut off at max_tokens (incremental)", async () => {
+		callLlm.mockImplementation(async (opts: { action: string }) => {
+			if (opts.action === "graph-categories-delta")
+				return {
+					text: JSON.stringify({
+						newCategories: [],
+						topics: [{ slug: "t2", title: "Topic2", shortTitle: "T2", summary: "s", categoryId: "c1" }],
+					}),
+				};
+			if (opts.action === "graph-units")
+				return {
+					text: JSON.stringify({ units: [{ id: "u", kind: "decision", shortTitle: "U", summary: "s" }] }),
+				};
+			// Cut-off JSON that won't parse, flagged as a max_tokens truncation.
+			if (opts.action === "graph-edges") return { text: '{"edges":[{"from":"t1', stopReason: "max_tokens" };
+			throw new Error(`unexpected ${opts.action}`);
+		});
+		const input: DistillInput = {
+			topics: [
+				{ slug: "t1", title: "Topic1", summary: "s", content: "c1" },
+				{ slug: "t2", title: "Topic2", summary: "new", content: "c2" },
+			],
+		};
+		const diff: TopicDiff = { clean: ["t1"], dirty: ["t2"], added: [], deleted: [] };
+		// fail-closed AND the reason (truncation) is named so a stuck graph is diagnosable.
+		await expect(distillGraphIncremental(input, baseline(), diff, CONFIG)).rejects.toThrow(
+			/graph-edges returned no edges array \(response truncated at max_tokens\)/,
+		);
+	});
+
+	it("throws when graph-edges is valid JSON but missing the edges array (incremental fails closed)", async () => {
+		callLlm.mockImplementation(async (opts: { action: string }) => {
+			if (opts.action === "graph-categories-delta")
+				return {
+					text: JSON.stringify({
+						newCategories: [],
+						topics: [{ slug: "t2", title: "Topic2", shortTitle: "T2", summary: "s", categoryId: "c1" }],
+					}),
+				};
+			if (opts.action === "graph-units")
+				return {
+					text: JSON.stringify({ units: [{ id: "u", kind: "decision", shortTitle: "U", summary: "s" }] }),
+				};
+			if (opts.action === "graph-edges") return { text: "{}", stopReason: null }; // parses, no edges array
+			throw new Error(`unexpected ${opts.action}`);
+		});
+		const input: DistillInput = {
+			topics: [
+				{ slug: "t1", title: "Topic1", summary: "s", content: "c1" },
+				{ slug: "t2", title: "Topic2", summary: "new", content: "c2" },
+			],
+		};
+		const diff: TopicDiff = { clean: ["t1"], dirty: ["t2"], added: [], deleted: [] };
+		await expect(distillGraphIncremental(input, baseline(), diff, CONFIG)).rejects.toThrow(
+			/graph-edges returned no edges array/,
+		);
 	});
 });

--- a/cli/src/graph/GraphDistiller.ts
+++ b/cli/src/graph/GraphDistiller.ts
@@ -18,6 +18,7 @@ import { resolveModelId } from "../core/Summarizer.js";
 import { createLogger } from "../Logger.js";
 import type { LlmConfig } from "../Types.js";
 import {
+	type CategoriesDelta,
 	type DistilledCategory,
 	type DistilledGraph,
 	type DistilledTopic,
@@ -25,6 +26,9 @@ import {
 	EDGE_TYPES,
 	type EdgeType,
 	type GraphEdge,
+	mergeCategoryLayer,
+	type TopicDiff,
+	UNCATEGORIZED_CATEGORY_ID,
 	UNIT_KINDS,
 	type UnitKind,
 } from "./GraphSchema.js";
@@ -35,7 +39,6 @@ const CATEGORIES_MAX_TOKENS = 16_384;
 const UNITS_MAX_TOKENS = 4_096;
 const EDGES_MAX_TOKENS = 32_000;
 const UNITS_CONCURRENCY = 4;
-const UNCATEGORIZED_ID = "uncategorized";
 
 /**
  * Reports a one-line, human-readable progress message for UI surfaces (the VS
@@ -173,7 +176,7 @@ async function distillCategories(
 		const slug = asString(t.slug);
 		const src = inputBySlug.get(slug);
 		if (!src) continue; // hallucinated slug
-		const categoryId = categoryIds.has(asString(t.categoryId)) ? asString(t.categoryId) : UNCATEGORIZED_ID;
+		const categoryId = categoryIds.has(asString(t.categoryId)) ? asString(t.categoryId) : UNCATEGORIZED_CATEGORY_ID;
 		llmTopics.set(slug, {
 			slug,
 			title: asString(t.title, src.title),
@@ -192,27 +195,44 @@ async function distillCategories(
 		const t = llmTopics.get(src.slug);
 		if (t) {
 			topics.push(t);
-			if (t.categoryId === UNCATEGORIZED_ID) needsUncategorized = true;
+			if (t.categoryId === UNCATEGORIZED_CATEGORY_ID) needsUncategorized = true;
 		} else {
 			topics.push({
 				slug: src.slug,
 				title: src.title,
 				shortTitle: src.title.slice(0, 80),
 				summary: src.summary,
-				categoryId: UNCATEGORIZED_ID,
+				categoryId: UNCATEGORIZED_CATEGORY_ID,
 			});
 			needsUncategorized = true;
 		}
 	}
-	if (needsUncategorized && !categoryIds.has(UNCATEGORIZED_ID)) {
-		categories.push({ id: UNCATEGORIZED_ID, shortTitle: "Uncategorized", summary: "Topics not yet grouped." });
+	if (needsUncategorized && !categoryIds.has(UNCATEGORIZED_CATEGORY_ID)) {
+		categories.push({
+			id: UNCATEGORIZED_CATEGORY_ID,
+			shortTitle: "Uncategorized",
+			summary: "Topics not yet grouped.",
+		});
 	}
 
 	return { categories, topics };
 }
 
-/** Phase 2: units for one topic. Returns globally-namespaced units; never throws. */
-async function distillUnitsForTopic(topic: DistillTopicInput, config: LlmConfig): Promise<DistilledUnit[]> {
+/**
+ * Phase 2: units for one topic. Returns globally-namespaced units.
+ *
+ * `strict` (incremental path) turns an UNPARSEABLE response into a throw so the
+ * caller fails the round and keeps the prior good graph — a dirty topic's units
+ * must never be silently overwritten with nothing. On the full path `strict` is
+ * off: a parse failure degrades to no units for that topic (there is no prior
+ * graph to protect). A response that parses to `{units:[]}` (a topic the LLM
+ * legitimately found no units in) is NOT a failure and never throws.
+ */
+async function distillUnitsForTopic(
+	topic: DistillTopicInput,
+	config: LlmConfig,
+	opts?: { readonly strict?: boolean },
+): Promise<DistilledUnit[]> {
 	const result = await callLlm({
 		action: "graph-units",
 		params: { topicTitle: topic.title, content: topic.content || "(empty)" },
@@ -223,6 +243,13 @@ async function distillUnitsForTopic(topic: DistillTopicInput, config: LlmConfig)
 		aiProvider: config.aiProvider,
 	});
 	const parsed = parseJsonObject<UnitsResponse>(result.text);
+	// Strict (incremental): require an actual `units` ARRAY, not merely parseable JSON.
+	// `{}` / `{"foo":1}` parse fine but would degrade to zero units and overwrite a
+	// dirty topic's baseline units — so a missing/non-array field fails the round too.
+	// `{"units":[]}` (array present, empty) is a legitimate "no units" and does not throw.
+	if (opts?.strict && !Array.isArray(parsed?.units)) {
+		throw new Error(`graph-units returned no units array for topic ${topic.slug}`);
+	}
 	const units: DistilledUnit[] = [];
 	const seenLocal = new Set<string>();
 	for (const u of parsed?.units ?? []) {
@@ -249,8 +276,21 @@ async function distillUnitsForTopic(topic: DistillTopicInput, config: LlmConfig)
 	return units;
 }
 
-/** Phase 3: typed edges across all units. Filters to valid endpoints/types; never throws. */
-async function distillEdges(units: ReadonlyArray<DistilledUnit>, config: LlmConfig): Promise<GraphEdge[]> {
+/**
+ * Phase 3: typed edges across all units. Filters to valid endpoints/types.
+ *
+ * `strict` (incremental path) turns an UNPARSEABLE response into a throw: because
+ * the incremental path recomputes edges in full every run, silently degrading to
+ * `[]` would overwrite the prior graph's entire edge layer with nothing. On the
+ * full path `strict` is off and a parse failure degrades to no edges. A response
+ * that parses to `{edges:[]}` is a legitimate "no edges found", not a failure, and
+ * never throws (nor does `< 2` units, which skips the call).
+ */
+async function distillEdges(
+	units: ReadonlyArray<DistilledUnit>,
+	config: LlmConfig,
+	opts?: { readonly strict?: boolean },
+): Promise<GraphEdge[]> {
 	if (units.length < 2) return [];
 	const unitsBlock = units.map((u) => `- ${u.id} [${u.topicSlug}] ${u.shortTitle}: ${u.summary}`).join("\n");
 	const result = await callLlm({
@@ -263,10 +303,33 @@ async function distillEdges(units: ReadonlyArray<DistilledUnit>, config: LlmConf
 		jolliApiKey: config.jolliApiKey,
 		aiProvider: config.aiProvider,
 	});
-	if (result.stopReason === "max_tokens") {
+	const truncated = result.stopReason === "max_tokens";
+	const parsed = parseJsonObject<EdgesResponse>(result.text);
+	// Strict (incremental): require an actual `edges` ARRAY. `{}` parses but would wipe
+	// the whole edge layer (edges are recomputed in full each incremental run), so a
+	// missing/non-array field fails the round. `{"edges":[]}` ("no edges") is fine.
+	if (opts?.strict && !Array.isArray(parsed?.edges)) {
+		// Truncation is the usual cause of an unparseable strict response: a graph with
+		// enough units blows EDGES_MAX_TOKENS, the cut-off JSON won't parse, and the
+		// fail-closed throw keeps the prior graph. Unlike the full path (which degrades
+		// to the edges that DID parse), the incremental path abandons the whole round —
+		// so a repo whose edge set stays above the limit gets stuck on its old graph
+		// indefinitely. Log that explicitly: otherwise "graph never updates" gives no
+		// clue why (raise EDGES_MAX_TOKENS or split the graph if this repeats).
+		if (truncated) {
+			log.warn(
+				"graph-edges truncated (max_tokens) and unparseable in strict mode -- abandoning incremental round, keeping prior graph",
+			);
+		}
+		throw new Error(
+			truncated
+				? "graph-edges returned no edges array (response truncated at max_tokens)"
+				: "graph-edges returned no edges array",
+		);
+	}
+	if (truncated) {
 		log.warn("graph-edges truncated (max_tokens) -- keeping the edges that parsed");
 	}
-	const parsed = parseJsonObject<EdgesResponse>(result.text);
 	const unitIds = new Set(units.map((u) => u.id));
 	const seen = new Set<string>();
 	const edges: GraphEdge[] = [];
@@ -342,6 +405,164 @@ export async function distillGraph(
 		units.length,
 		Math.round(performance.now() - t2),
 	);
+
+	return { categories, topics, units, edges };
+}
+
+interface DeltaCategoriesResponse {
+	newCategories?: RawCategory[];
+	topics?: RawTopic[];
+}
+
+/**
+ * Incremental Phase 1: place ONLY the changed topics, reusing existing
+ * categories. Returns the LLM's genuinely-new categories + each changed topic's
+ * (re)assignment. Sanitizing mirrors {@link distillCategories} (drop empty/dup
+ * ids, blank-label fallback); a proposed id that already exists is dropped (the
+ * merge keeps the existing category). Hallucinated / not-in-changed-set slugs are
+ * omitted — the caller's {@link mergeCategoryLayer} backfills any changed topic
+ * the LLM dropped (a valid-but-incomplete response is tolerated this way).
+ *
+ * An UNPARSEABLE response, by contrast, throws: this is the incremental path, so
+ * a failed delta must fail the round and keep the prior good graph rather than
+ * dumping every changed topic into `uncategorized` over a still-good baseline.
+ * (A raw LLM-call error already throws — `callLlm` is awaited here.)
+ */
+async function distillCategoriesDelta(
+	existingCategories: ReadonlyArray<DistilledCategory>,
+	changedTopics: ReadonlyArray<DistillTopicInput>,
+	config: LlmConfig,
+): Promise<CategoriesDelta> {
+	const existingBlock =
+		existingCategories.map((c) => `- ${c.id} -- ${c.shortTitle}: ${c.summary}`).join("\n") || "(none)";
+	const topicsBlock = changedTopics.map((t) => `- ${t.slug} -- ${t.title}: ${t.summary}`).join("\n") || "(none)";
+	const result = await callLlm({
+		action: "graph-categories-delta",
+		params: { existingCategories: existingBlock, topics: topicsBlock },
+		model: resolveModelId(config.model),
+		maxTokens: CATEGORIES_MAX_TOKENS,
+		forceStreaming: true,
+		apiKey: config.apiKey,
+		jolliApiKey: config.jolliApiKey,
+		aiProvider: config.aiProvider,
+	});
+	const parsed = parseJsonObject<DeltaCategoriesResponse>(result.text);
+	// Incremental fails closed: require BOTH arrays the prompt contracts for
+	// (`{newCategories:[],topics:[]}`). Unparseable JSON, `{}`, or a non-array field
+	// would otherwise dump every changed topic into `uncategorized` over a still-good
+	// baseline. Empty arrays are a legitimate response (handled by the backfill merge).
+	if (!Array.isArray(parsed?.topics) || !Array.isArray(parsed?.newCategories)) {
+		throw new Error("graph-categories-delta returned a malformed response (missing newCategories/topics array)");
+	}
+
+	const existingIds = new Set(existingCategories.map((c) => c.id));
+	const seen = new Set<string>();
+	const newCategories: DistilledCategory[] = [];
+	for (const c of parsed?.newCategories ?? []) {
+		const id = asString(c.id);
+		if (id.length === 0 || seen.has(id) || existingIds.has(id)) continue;
+		seen.add(id);
+		newCategories.push({ id, shortTitle: asNonBlank(c.shortTitle, id), summary: asString(c.summary) });
+	}
+
+	const changedBySlug = new Map(changedTopics.map((t) => [t.slug, t]));
+	const validIds = new Set([...existingIds, ...seen]);
+	const topics: DistilledTopic[] = [];
+	for (const t of parsed?.topics ?? []) {
+		const slug = asString(t.slug);
+		const src = changedBySlug.get(slug);
+		if (!src) continue; // hallucinated / not in the changed set
+		const categoryId = validIds.has(asString(t.categoryId)) ? asString(t.categoryId) : UNCATEGORIZED_CATEGORY_ID;
+		topics.push({
+			slug,
+			title: asString(t.title, src.title),
+			shortTitle: asNonBlank(t.shortTitle, src.title).slice(0, 80),
+			summary: asNonBlank(t.summary, src.summary),
+			categoryId,
+		});
+	}
+	return { newCategories, topics };
+}
+
+/**
+ * Incremental distillation. Reuses clean topics' units verbatim from the
+ * baseline, re-distills only dirty/new topics, re-categorizes the changed topics
+ * via the delta call (clean topics keep their baseline assignment → stable
+ * layout), and — when any topic changed — recomputes edges in full over the final
+ * unit set (full edges sidesteps unit-id instability and edge merge entirely).
+ *
+ * A pure-deletion change (dirty ∪ new empty) runs NO LLM: it filters out the
+ * deleted topics' units and drops any edge whose endpoint disappeared.
+ *
+ * `prev` is the field-validated baseline (from `toDistilled`); `diff` is the
+ * topic partition. Returns a complete `DistilledGraph` for `assembleGraph`.
+ */
+export async function distillGraphIncremental(
+	input: DistillInput,
+	prev: DistilledGraph,
+	diff: TopicDiff,
+	config: LlmConfig,
+	onProgress?: GraphProgressReporter,
+): Promise<DistilledGraph> {
+	const changedSlugs = new Set([...diff.dirty, ...diff.added]);
+	const cleanSlugs = new Set(diff.clean);
+	const currentSlugs = new Set(input.topics.map((t) => t.slug));
+	// `diffTopics` derives dirty/added from the SAME current-topic set as `input`,
+	// so changedSlugs ⊆ currentSlugs and `changedTopics.length > 0 ⇔ changedSlugs.size > 0`.
+	// We branch every phase on `changedTopics.length` for one consistent predicate.
+	const changedTopics = input.topics.filter((t) => changedSlugs.has(t.slug));
+
+	// --- units --- reuse clean topics' units (WHITE-LIST by the current clean set,
+	// never a "not-dirty" black-list — that would drag deleted topics' units back).
+	const reusedUnits = prev.units.filter((u) => cleanSlugs.has(u.topicSlug));
+	let newUnits: DistilledUnit[] = [];
+	if (changedTopics.length > 0) {
+		let done = 0;
+		const report = (): void => onProgress?.(`extracting units ${done}/${changedTopics.length}`);
+		report();
+		// Fail closed: NO onError swallow + `strict: true`. A dirty/new topic's unit
+		// re-distillation that throws (LLM error) or returns unparseable JSON must
+		// abort the round so `buildKnowledgeGraph`'s non-fatal catch keeps the prior
+		// good graph. Swallowing to `[]` would emit a topic with zero units over a
+		// baseline that had them — data loss, not degradation. (The full path
+		// deliberately tolerates this: it has no prior graph to protect.)
+		const perTopic = await mapWithConcurrency(changedTopics, UNITS_CONCURRENCY, async (topic) => {
+			const r = await distillUnitsForTopic(topic, config, { strict: true });
+			done++;
+			report();
+			return r;
+		});
+		newUnits = perTopic.flat();
+	}
+	const units = [...reusedUnits, ...newUnits];
+
+	// --- categories ---
+	let categories: DistilledCategory[];
+	let topics: DistilledTopic[];
+	if (changedTopics.length > 0) {
+		onProgress?.(`categorizing ${changedTopics.length} changed topic(s)`);
+		const delta = await distillCategoriesDelta(prev.categories, changedTopics, config);
+		const merged = mergeCategoryLayer(prev.categories, prev.topics, delta, input.topics, changedSlugs);
+		categories = merged.categories;
+		topics = merged.topics;
+	} else {
+		// Pure deletion: keep baseline categories/topics minus the deleted topics.
+		// assembleGraph prunes any category left empty by the deletion.
+		categories = [...prev.categories];
+		topics = prev.topics.filter((t) => currentSlugs.has(t.slug));
+	}
+
+	// --- edges ---
+	let edges: GraphEdge[];
+	if (changedTopics.length > 0) {
+		onProgress?.(`linking edges across ${units.length} unit(s)`);
+		edges = await distillEdges(units, config, { strict: true });
+	} else {
+		// Pure deletion: removing units can only invalidate edges, never create
+		// them. Drop any edge whose endpoint no longer exists; no LLM.
+		const unitIds = new Set(units.map((u) => u.id));
+		edges = prev.edges.filter((e) => unitIds.has(e.from) && unitIds.has(e.to));
+	}
 
 	return { categories, topics, units, edges };
 }

--- a/cli/src/graph/GraphSchema.test.ts
+++ b/cli/src/graph/GraphSchema.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { assembleGraph, type DistilledGraph, type TopicSourceMeta, validateDistilledGraph } from "./GraphSchema.js";
+import {
+	assembleGraph,
+	type CategoriesDelta,
+	type DistilledCategory,
+	type DistilledGraph,
+	type DistilledTopic,
+	diffTopics,
+	isFingerprintMap,
+	mergeCategoryLayer,
+	type TopicSourceMeta,
+	toDistilled,
+	UNCATEGORIZED_CATEGORY_ID,
+	validateDistilledGraph,
+} from "./GraphSchema.js";
 
 function validGraph(): DistilledGraph {
 	return {
@@ -114,7 +127,7 @@ describe("assembleGraph", () => {
 		const graph = assembleGraph(validGraph(), sources, "2026-06-15T00:00:00.000Z");
 
 		expect(graph.generatedAt).toBe("2026-06-15T00:00:00.000Z");
-		expect(graph.schemaVersion).toBe(1);
+		expect(graph.schemaVersion).toBe(2);
 
 		const t1 = graph.topics.find((t) => t.slug === "t1");
 		expect(t1?.sourceBranches).toEqual(["main", "feature/x"]);
@@ -184,5 +197,260 @@ describe("assembleGraph", () => {
 		const g = validGraph();
 		g.edges.push({ from: "ghost", to: "t1::u1", type: "extends", confidence: 0.6, evidence: "x" });
 		expect(() => assembleGraph(g, sources, "2026-06-15T00:00:00.000Z")).toThrow(/validation failed/);
+	});
+
+	it("embeds the passed topicFingerprints / topicMetaFingerprints (and defaults both to {})", () => {
+		const withFp = assembleGraph(
+			validGraph(),
+			sources,
+			"2026-06-15T00:00:00.000Z",
+			{ t1: "a", t2: "b" },
+			{ t1: "m" },
+		);
+		expect(withFp.topicFingerprints).toEqual({ t1: "a", t2: "b" });
+		expect(withFp.topicMetaFingerprints).toEqual({ t1: "m" });
+		const withoutFp = assembleGraph(validGraph(), sources, "2026-06-15T00:00:00.000Z");
+		expect(withoutFp.topicFingerprints).toEqual({});
+		expect(withoutFp.topicMetaFingerprints).toEqual({});
+	});
+
+	it("prunes a category that ends up with zero topics", () => {
+		const distill = validGraph();
+		// Add an extra category no topic references → must be pruned by assembleGraph.
+		distill.categories.push({ id: "orphan-cat", shortTitle: "Orphan", summary: "Nobody here." });
+		const graph = assembleGraph(distill, sources, "2026-06-15T00:00:00.000Z");
+		expect(graph.categories.map((c) => c.id).sort()).toEqual(["cat-a", "cat-b"]);
+		expect(graph.stats.categories).toBe(2);
+	});
+});
+
+describe("isFingerprintMap", () => {
+	it("accepts a plain string→string object (incl. empty)", () => {
+		expect(isFingerprintMap({})).toBe(true);
+		expect(isFingerprintMap({ a: "h1", b: "h2" })).toBe(true);
+	});
+
+	it("rejects null, arrays, primitives, and non-string values", () => {
+		expect(isFingerprintMap(null)).toBe(false);
+		expect(isFingerprintMap(undefined)).toBe(false);
+		expect(isFingerprintMap(["h"])).toBe(false);
+		expect(isFingerprintMap("hash")).toBe(false);
+		expect(isFingerprintMap(5)).toBe(false);
+		expect(isFingerprintMap({ a: 123 })).toBe(false);
+	});
+});
+
+describe("diffTopics", () => {
+	it("partitions into clean / dirty / added / deleted", () => {
+		const prev = { keep: "h1", change: "h2", gone: "h3" };
+		const cur = { keep: "h1", change: "h2-NEW", fresh: "h4" };
+		expect(diffTopics(prev, cur)).toEqual({
+			clean: ["keep"],
+			dirty: ["change"],
+			added: ["fresh"],
+			deleted: ["gone"],
+		});
+	});
+
+	it("is all-empty when nothing changed", () => {
+		const fp = { a: "1", b: "2" };
+		expect(diffTopics(fp, { ...fp })).toEqual({ clean: ["a", "b"], dirty: [], added: [], deleted: [] });
+	});
+});
+
+describe("toDistilled", () => {
+	function priorGraph(): unknown {
+		// A real emitted KnowledgeGraph (the incremental baseline shape).
+		return assembleGraph(validGraph(), new Map(), "2026-06-15T00:00:00.000Z", { t1: "a", t2: "b" });
+	}
+
+	it("strips derived fields and restores the DistilledGraph subset", () => {
+		const restored = toDistilled(priorGraph());
+		expect(restored).not.toBeNull();
+		// Derived fields gone from categories/topics; units/edges verbatim.
+		const cat = restored?.categories[0] as unknown as Record<string, unknown>;
+		expect(Object.keys(cat).sort()).toEqual(["id", "shortTitle", "summary"]);
+		const topic = restored?.topics[0] as unknown as Record<string, unknown>;
+		expect(Object.keys(topic).sort()).toEqual(["categoryId", "shortTitle", "slug", "summary", "title"]);
+		expect(restored?.units).toHaveLength(3);
+		expect(restored?.edges).toHaveLength(2);
+		// anchors arrays are copied (not the same reference).
+		expect(restored?.units[0].anchors.files).toEqual([]);
+	});
+
+	it("returns null for a non-object / missing top-level arrays", () => {
+		expect(toDistilled(null)).toBeNull();
+		expect(toDistilled("nope")).toBeNull();
+		expect(toDistilled({ categories: [], topics: [], units: [] })).toBeNull(); // edges missing
+		expect(toDistilled({ categories: {}, topics: [], units: [], edges: [] })).toBeNull(); // categories non-array
+	});
+
+	it("returns null on a structurally-incompatible category / topic", () => {
+		const g = priorGraph() as Record<string, unknown>;
+		expect(toDistilled({ ...g, categories: [{ id: "c" /* missing shortTitle/summary */ }] })).toBeNull();
+		expect(toDistilled({ ...g, topics: [{ slug: "t", shortTitle: "T", summary: "s", title: "T" }] })).toBeNull();
+	});
+
+	it("returns null on a unit missing a field, a bad kind, or bad anchors", () => {
+		const g = priorGraph() as Record<string, unknown>;
+		const baseUnit = { id: "x::u", topicSlug: "x", kind: "decision", shortTitle: "U", summary: "s" };
+		expect(toDistilled({ ...g, units: [{ ...baseUnit /* no anchors */ }] })).toBeNull();
+		expect(
+			toDistilled({ ...g, units: [{ ...baseUnit, kind: "bogus", anchors: { files: [], commits: [] } }] }),
+		).toBeNull();
+		expect(toDistilled({ ...g, units: [{ ...baseUnit, anchors: { files: "no", commits: [] } }] })).toBeNull();
+		expect(toDistilled({ ...g, units: [{ ...baseUnit, anchors: null }] })).toBeNull();
+		expect(
+			toDistilled({ ...g, units: [{ ...baseUnit, summary: 5, anchors: { files: [], commits: [] } }] }),
+		).toBeNull();
+	});
+
+	it("returns null on a structurally-incompatible edge", () => {
+		const g = priorGraph() as Record<string, unknown>;
+		expect(toDistilled({ ...g, edges: [{ from: "a", to: "b", type: "extends", confidence: 0.9 }] })).toBeNull();
+		expect(
+			toDistilled({ ...g, edges: [{ from: "a", to: "b", type: "nope", confidence: 0.9, evidence: "e" }] }),
+		).toBeNull();
+	});
+
+	it("returns null when an array element is a non-object (null / primitive)", () => {
+		const g = priorGraph() as Record<string, unknown>;
+		expect(toDistilled({ ...g, categories: [null] })).toBeNull();
+		expect(toDistilled({ ...g, topics: ["nope"] })).toBeNull();
+		expect(toDistilled({ ...g, units: [42] })).toBeNull();
+		expect(toDistilled({ ...g, edges: [null] })).toBeNull();
+	});
+});
+
+describe("mergeCategoryLayer", () => {
+	const prevCategories: DistilledCategory[] = [
+		{ id: "build", shortTitle: "Build Tooling", summary: "build stuff" },
+		{ id: "auth", shortTitle: "Auth", summary: "auth stuff" },
+	];
+	const prevTopics: DistilledTopic[] = [
+		{ slug: "t-clean", shortTitle: "Clean", summary: "clean s", title: "Clean Topic", categoryId: "build" },
+		{ slug: "t-dirty", shortTitle: "OldDirty", summary: "old s", title: "Dirty Topic", categoryId: "auth" },
+	];
+	const current = [
+		{ slug: "t-clean", title: "Clean Topic", summary: "clean s" },
+		{ slug: "t-dirty", title: "Dirty Topic", summary: "new s" },
+		{ slug: "t-new", title: "New Topic", summary: "fresh s" },
+	];
+
+	it("keeps clean topics, applies delta to changed, reuses existing category on id collision", () => {
+		const delta: CategoriesDelta = {
+			// id collides with existing "auth" → dropped, existing wins.
+			newCategories: [{ id: "auth", shortTitle: "Auth v2", summary: "x" }],
+			topics: [
+				{ slug: "t-dirty", title: "Dirty Topic", shortTitle: "NewDirty", summary: "new s", categoryId: "auth" },
+				{ slug: "t-new", title: "New Topic", shortTitle: "New", summary: "fresh s", categoryId: "build" },
+			],
+		};
+		const { categories, topics } = mergeCategoryLayer(
+			prevCategories,
+			prevTopics,
+			delta,
+			current,
+			new Set(["t-dirty", "t-new"]),
+		);
+		// No new category added (collision); existing metadata kept.
+		expect(categories.map((c) => c.id).sort()).toEqual(["auth", "build"]);
+		expect(categories.find((c) => c.id === "auth")?.shortTitle).toBe("Auth");
+		// Clean topic kept verbatim; dirty got delta's shortTitle.
+		expect(topics.find((t) => t.slug === "t-clean")?.shortTitle).toBe("Clean");
+		expect(topics.find((t) => t.slug === "t-dirty")?.shortTitle).toBe("NewDirty");
+		expect(topics.find((t) => t.slug === "t-new")?.categoryId).toBe("build");
+	});
+
+	it("folds a new category whose shortTitle duplicates an existing one into that existing id", () => {
+		const delta: CategoriesDelta = {
+			// New id but shortTitle "build tooling" (case-insensitive) duplicates "build".
+			newCategories: [{ id: "tooling", shortTitle: "build tooling", summary: "x" }],
+			topics: [
+				{ slug: "t-new", title: "New Topic", shortTitle: "New", summary: "fresh s", categoryId: "tooling" },
+			],
+		};
+		const { categories, topics } = mergeCategoryLayer(
+			prevCategories,
+			prevTopics,
+			delta,
+			current,
+			new Set(["t-new"]),
+		);
+		// "tooling" folded away; topic remapped to "build".
+		expect(categories.map((c) => c.id).sort()).toEqual(["auth", "build"]);
+		expect(topics.find((t) => t.slug === "t-new")?.categoryId).toBe("build");
+	});
+
+	it("adds a genuinely-new category", () => {
+		const delta: CategoriesDelta = {
+			newCategories: [{ id: "storage", shortTitle: "Storage", summary: "x" }],
+			topics: [
+				{ slug: "t-new", title: "New Topic", shortTitle: "New", summary: "fresh s", categoryId: "storage" },
+			],
+		};
+		const { categories } = mergeCategoryLayer(prevCategories, prevTopics, delta, current, new Set(["t-new"]));
+		expect(categories.map((c) => c.id)).toContain("storage");
+	});
+
+	it("falls a changed topic missing from the delta into uncategorized (and adds the category)", () => {
+		const delta: CategoriesDelta = { newCategories: [], topics: [] }; // delta dropped t-new
+		const onlyNew = [{ slug: "t-new", title: "New Topic", summary: "fresh s" }];
+		const { categories, topics } = mergeCategoryLayer([], [], delta, onlyNew, new Set(["t-new"]));
+		expect(topics[0].categoryId).toBe(UNCATEGORIZED_CATEGORY_ID);
+		expect(categories.map((c) => c.id)).toContain(UNCATEGORIZED_CATEGORY_ID);
+	});
+
+	it("reassigns a topic pointing at an unknown category to uncategorized", () => {
+		const delta: CategoriesDelta = {
+			newCategories: [],
+			topics: [{ slug: "t-new", title: "New Topic", shortTitle: "N", summary: "s", categoryId: "ghost" }],
+		};
+		const onlyNew = [{ slug: "t-new", title: "New Topic", summary: "fresh s" }];
+		const { topics } = mergeCategoryLayer(prevCategories, prevTopics, delta, onlyNew, new Set(["t-new"]));
+		expect(topics[0].categoryId).toBe(UNCATEGORIZED_CATEGORY_ID);
+	});
+
+	it("indexes only the first of two baseline categories sharing a shortTitle", () => {
+		// Two distinct ids, same label: the shortTitle index keeps the first; a delta
+		// new category with that label folds into the first id.
+		const prev: DistilledCategory[] = [
+			{ id: "a1", shortTitle: "Same", summary: "1" },
+			{ id: "a2", shortTitle: "Same", summary: "2" },
+		];
+		const prevT: DistilledTopic[] = [{ slug: "k", shortTitle: "K", summary: "s", title: "K", categoryId: "a2" }];
+		const delta: CategoriesDelta = {
+			newCategories: [{ id: "a3", shortTitle: "same", summary: "3" }],
+			topics: [{ slug: "n", title: "N", shortTitle: "N", summary: "s", categoryId: "a3" }],
+		};
+		const { categories, topics } = mergeCategoryLayer(
+			prev,
+			prevT,
+			delta,
+			[
+				{ slug: "k", title: "K", summary: "s" },
+				{ slug: "n", title: "N", summary: "s" },
+			],
+			new Set(["n"]),
+		);
+		// "a3" folds into the first-indexed "a1".
+		expect(categories.map((c) => c.id).sort()).toEqual(["a1", "a2"]);
+		expect(topics.find((t) => t.slug === "n")?.categoryId).toBe("a1");
+	});
+
+	it("keep-firsts a duplicated baseline category id", () => {
+		const dupPrev: DistilledCategory[] = [
+			{ id: "x", shortTitle: "First", summary: "1" },
+			{ id: "x", shortTitle: "Second", summary: "2" },
+		];
+		const { categories } = mergeCategoryLayer(
+			dupPrev,
+			[{ slug: "t", shortTitle: "T", summary: "s", title: "T", categoryId: "x" }],
+			{ newCategories: [], topics: [] },
+			[{ slug: "t", title: "T", summary: "s" }],
+			new Set(),
+		);
+		expect(categories.filter((c) => c.id === "x")).toHaveLength(1);
+		expect(categories.find((c) => c.id === "x")?.shortTitle).toBe("First");
 	});
 });

--- a/cli/src/graph/GraphSchema.ts
+++ b/cli/src/graph/GraphSchema.ts
@@ -19,8 +19,32 @@ export type EdgeType = (typeof EDGE_TYPES)[number];
 export const UNIT_KINDS = ["decision", "mechanism", "fix"] as const;
 export type UnitKind = (typeof UNIT_KINDS)[number];
 
-/** Schema version stamped onto the emitted graph; bump on a breaking shape change. */
-export const GRAPH_SCHEMA_VERSION = 1;
+/**
+ * Schema version stamped onto the emitted graph; bump on a breaking shape change.
+ *
+ * Because `units` / `edges` / `categories` / `topics` are embedded in graph.json
+ * verbatim, ANY change to their output SHAPE (a new field, a changed `kind` /
+ * edge-type enum, a changed unit-id format) IS a breaking shape change here and
+ * MUST bump this constant. Incremental update (GraphBuilder) reuses the prior
+ * graph.json as its baseline only when the stored `schemaVersion` matches this
+ * value. Bumping is the PRIMARY (and only complete) guard against reusing a
+ * structurally-incompatible baseline — in particular it is the ONLY thing that
+ * catches a NEWLY-ADDED field (see `toDistilled`: a field-set check cannot detect
+ * a field it doesn't yet know about). `toDistilled`'s check is a secondary net
+ * for removed/retyped fields and corruption, not a substitute for this bump.
+ * Bumped 1→2 when incremental dirty detection added `topicFingerprints` AND
+ * `topicMetaFingerprints` to `KnowledgeGraph`. Both top-level fields landed
+ * together in the same (unreleased) v2, so adding the second one did not need a
+ * further bump. Consumers (webview / export) read only
+ * `categories`/`topics`/`units`/`edges`, so these baseline-only fields are inert
+ * to them. A FUTURE change to either field's shape, or any new top-level field,
+ * is a breaking shape change and must bump this constant again.
+ */
+export const GRAPH_SCHEMA_VERSION = 2;
+
+/** Category id for topics not grouped into any real category. Shared by the full
+ * distiller (backfill) and the incremental merge so both bucket the same way. */
+export const UNCATEGORIZED_CATEGORY_ID = "uncategorized";
 
 // -- LLM-distilled layer (what GraphDistiller emits) --------------------------
 
@@ -121,6 +145,23 @@ export interface KnowledgeGraph {
 	readonly schemaVersion: number;
 	readonly generatedAt: string;
 	readonly source: string;
+	/**
+	 * Per-topic content fingerprint, keyed by `stableSlug`. The incremental
+	 * baseline: GraphBuilder diffs the previous graph.json's fingerprints against
+	 * the freshly-computed ones to find dirty/new/deleted topics. Empty `{}` on a
+	 * full build that had no fingerprint input (e.g. legacy callers / tests).
+	 */
+	readonly topicFingerprints: Record<string, string>;
+	/**
+	 * Per-topic fingerprint of the JOIN metadata that the content fingerprint
+	 * deliberately excludes — `sourceBranches` + `sourceCommits` (→ `commitCount`).
+	 * Keyed by `stableSlug`. These fields live in graph.json but are NOT LLM inputs,
+	 * so they can drift while `topicFingerprints` stays put (a new commit folded into
+	 * a topic whose summary regenerated identically, a branch rename). GraphBuilder
+	 * compares this on a content-no-op to decide between a true skip and a NO-LLM
+	 * reassemble that refreshes the stale metadata. Empty `{}` when unavailable.
+	 */
+	readonly topicMetaFingerprints: Record<string, string>;
 	readonly stats: GraphStats;
 	readonly categories: GraphCategory[];
 	readonly topics: GraphTopic[];
@@ -183,6 +224,8 @@ export function assembleGraph(
 	distill: DistilledGraph,
 	sources: ReadonlyMap<string, TopicSourceMeta>,
 	generatedAt: string,
+	topicFingerprints: Record<string, string> = {},
+	topicMetaFingerprints: Record<string, string> = {},
 ): KnowledgeGraph {
 	const errors = validateDistilledGraph(distill);
 	if (errors.length > 0) {
@@ -211,15 +254,24 @@ export function assembleGraph(
 		t.commitCount = t.sourceCommits.length;
 	}
 
-	const categories: GraphCategory[] = distill.categories.map((c) => {
-		const catTopics = topics.filter((t) => t.categoryId === c.id);
-		return {
-			...c,
-			topicCount: catTopics.length,
-			unitCount: catTopics.reduce((a, t) => a + t.unitCount, 0),
-			commitCount: catTopics.reduce((a, t) => a + t.commitCount, 0),
-		};
-	});
+	// Mechanical empty-category prune: drop any category no topic references
+	// (topicCount === 0). Post-validation every topic's categoryId resolves to a
+	// real category, so a zero-topic category is unreferenced and safe to remove —
+	// this is what keeps the incremental "categories only grow" merge from leaving
+	// an empty `uncategorized` (or any) card behind after a topic is deleted or
+	// re-categorized out of it. Harmless on the full path (the distiller rarely
+	// emits an unused category, but if it does, it goes too).
+	const categories: GraphCategory[] = distill.categories
+		.map((c) => {
+			const catTopics = topics.filter((t) => t.categoryId === c.id);
+			return {
+				...c,
+				topicCount: catTopics.length,
+				unitCount: catTopics.reduce((a, t) => a + t.unitCount, 0),
+				commitCount: catTopics.reduce((a, t) => a + t.commitCount, 0),
+			};
+		})
+		.filter((c) => c.topicCount > 0);
 
 	// Edge rollups (for stats / the panel header; the view recomputes its own
 	// aggregates at render time from expansion state).
@@ -255,10 +307,263 @@ export function assembleGraph(
 		schemaVersion: GRAPH_SCHEMA_VERSION,
 		generatedAt,
 		source: "topic KB distillation (LLM categories/topics/units/edges + computed joins)",
+		topicFingerprints,
+		topicMetaFingerprints,
 		stats,
 		categories,
 		topics,
 		units: distill.units,
 		edges: distill.edges,
 	};
+}
+
+// -- Incremental baseline: diff + restore -------------------------------------
+
+/** The four buckets an incremental build partitions the current topics into. */
+export interface TopicDiff {
+	/** Existing topics whose fingerprint changed. */
+	readonly dirty: string[];
+	/** Topics present now but absent from the baseline. */
+	readonly added: string[];
+	/** Topics in the baseline but absent now. */
+	readonly deleted: string[];
+	/** Existing topics whose fingerprint is unchanged (reusable verbatim). */
+	readonly clean: string[];
+}
+
+/**
+ * Partitions topics by comparing the baseline fingerprint map (from the prior
+ * graph.json) against the freshly-computed one. Pure: no I/O, no LLM. Keys are
+ * `stableSlug`, values are the content fingerprint.
+ */
+export function diffTopics(prev: Record<string, string>, cur: Record<string, string>): TopicDiff {
+	const dirty: string[] = [];
+	const added: string[] = [];
+	const clean: string[] = [];
+	for (const [slug, fp] of Object.entries(cur)) {
+		if (!(slug in prev)) added.push(slug);
+		else if (prev[slug] !== fp) dirty.push(slug);
+		else clean.push(slug);
+	}
+	const deleted = Object.keys(prev).filter((slug) => !(slug in cur));
+	return { dirty, added, deleted, clean };
+}
+
+function isStringArray(v: unknown): boolean {
+	return Array.isArray(v) && v.every((x) => typeof x === "string");
+}
+
+function validCategory(c: unknown): boolean {
+	if (typeof c !== "object" || c === null) return false;
+	const r = c as Record<string, unknown>;
+	return typeof r.id === "string" && typeof r.shortTitle === "string" && typeof r.summary === "string";
+}
+
+function validTopic(t: unknown): boolean {
+	if (typeof t !== "object" || t === null) return false;
+	const r = t as Record<string, unknown>;
+	return (
+		typeof r.slug === "string" &&
+		typeof r.shortTitle === "string" &&
+		typeof r.summary === "string" &&
+		typeof r.title === "string" &&
+		typeof r.categoryId === "string"
+	);
+}
+
+function validUnit(u: unknown): boolean {
+	if (typeof u !== "object" || u === null) return false;
+	const r = u as Record<string, unknown>;
+	if (
+		typeof r.id !== "string" ||
+		typeof r.topicSlug !== "string" ||
+		typeof r.shortTitle !== "string" ||
+		typeof r.summary !== "string"
+	) {
+		return false;
+	}
+	if (!UNIT_KINDS.includes(r.kind as UnitKind)) return false;
+	if (typeof r.anchors !== "object" || r.anchors === null) return false;
+	const a = r.anchors as Record<string, unknown>;
+	return isStringArray(a.files) && isStringArray(a.commits);
+}
+
+function validEdge(e: unknown): boolean {
+	if (typeof e !== "object" || e === null) return false;
+	const r = e as Record<string, unknown>;
+	return (
+		typeof r.from === "string" &&
+		typeof r.to === "string" &&
+		EDGE_TYPES.includes(r.type as EdgeType) &&
+		typeof r.confidence === "number" &&
+		typeof r.evidence === "string"
+	);
+}
+
+/**
+ * Restores a prior `KnowledgeGraph` (parsed graph.json) to the `DistilledGraph`
+ * subset used as the incremental baseline: strips the derived join/rollup fields
+ * from categories/topics, keeps `units`/`edges` verbatim.
+ *
+ * Runs a FIELD-SET check on every entity — NOT just referential integrity (which
+ * {@link validateDistilledGraph} covers). If any reused entity is missing a
+ * required field or has the wrong type, the baseline is structurally
+ * incompatible and this returns `null` so the caller degrades to a safe full
+ * rebuild. Also returns `null` when the top-level arrays are absent or non-array.
+ *
+ * SCOPE — this catches a CURRENTLY-REQUIRED field that is missing or mistyped in
+ * the baseline (a removed/renamed field, a changed `kind`/edge-type enum, a
+ * changed id format, or corruption). It CANNOT catch a baseline that predates a
+ * NEWLY-ADDED field: a validator only checks fields it knows about, so an old
+ * unit lacking a brand-new field still passes, and the explicit field-pick below
+ * simply omits the new field (degraded display for reused entities until the next
+ * full rebuild — never a crash). Guarding "added field" drift is the job of
+ * {@link GRAPH_SCHEMA_VERSION}: bumping it on any output-shape change makes the
+ * baseline version-mismatch → full rebuild before `toDistilled` is even reached.
+ */
+export function toDistilled(graph: unknown): DistilledGraph | null {
+	if (typeof graph !== "object" || graph === null) return null;
+	const g = graph as Record<string, unknown>;
+	const { categories, topics, units, edges } = g;
+	if (!Array.isArray(categories) || !Array.isArray(topics) || !Array.isArray(units) || !Array.isArray(edges)) {
+		return null;
+	}
+	if (!categories.every(validCategory) || !topics.every(validTopic)) return null;
+	if (!units.every(validUnit) || !edges.every(validEdge)) return null;
+
+	const cats = categories as DistilledCategory[];
+	const tops = topics as (DistilledTopic & Record<string, unknown>)[];
+	const us = units as DistilledUnit[];
+	const es = edges as GraphEdge[];
+	return {
+		categories: cats.map((c) => ({ id: c.id, shortTitle: c.shortTitle, summary: c.summary })),
+		topics: tops.map((t) => ({
+			slug: t.slug,
+			shortTitle: t.shortTitle,
+			summary: t.summary,
+			title: t.title,
+			categoryId: t.categoryId,
+		})),
+		units: us.map((u) => ({
+			id: u.id,
+			topicSlug: u.topicSlug,
+			kind: u.kind,
+			shortTitle: u.shortTitle,
+			summary: u.summary,
+			anchors: { files: [...u.anchors.files], commits: [...u.anchors.commits] },
+		})),
+		edges: es.map((e) => ({
+			from: e.from,
+			to: e.to,
+			type: e.type,
+			confidence: e.confidence,
+			evidence: e.evidence,
+		})),
+	};
+}
+
+/**
+ * Validates the prior graph.json's `topicFingerprints` baseline: a plain object
+ * whose every value is a string. A malformed value (null, array, primitive, or
+ * non-string entries — only reachable via hand-corruption or a future bug) means
+ * the baseline can't be diffed, so the caller treats it like any other unusable
+ * baseline (schema mismatch / `toDistilled` null) → one-time full rebuild that
+ * heals it, rather than throwing in `diffTopics` (`"x" in 5` throws) and getting
+ * stuck "no graph" every build. This is NOT a fallback from a recoverable
+ * incremental hiccup (those keep the old graph) — it's "no usable starting point".
+ */
+export function isFingerprintMap(v: unknown): v is Record<string, string> {
+	if (typeof v !== "object" || v === null || Array.isArray(v)) return false;
+	return Object.values(v).every((x) => typeof x === "string");
+}
+
+// -- Incremental categories merge --------------------------------------------
+
+/** What the `graph-categories-delta` LLM call yields: newly-invented categories
+ * plus the changed topics' (re)assignments. */
+export interface CategoriesDelta {
+	readonly newCategories: DistilledCategory[];
+	readonly topics: DistilledTopic[];
+}
+
+/** Minimal current-topic shape the merge needs (slug/title/summary, in order). */
+export interface MergeTopicInput {
+	readonly slug: string;
+	readonly title: string;
+	readonly summary: string;
+}
+
+/**
+ * Merges the incremental categories layer (pure, no LLM): keeps the prior
+ * category list as authoritative, folds in only genuinely-new delta categories,
+ * and rebuilds the topic→category assignment.
+ *
+ * - **clean** topics keep their baseline categoryId / shortTitle / summary →
+ *   stable category ids → stable layout.
+ * - **changed** topics (dirty ∪ new) take the delta's assignment.
+ * - **id collision**: a delta category whose id already exists is dropped (the
+ *   existing category wins; its topic just resolves to the kept one).
+ * - **shortTitle collision**: a delta category whose normalized label matches an
+ *   existing one is folded into that existing id (avoids two cards with the same
+ *   label, since the viz keys cards by id — a delta-path-only hazard).
+ * - **uncategorized invariant**: any topic whose categoryId doesn't resolve falls
+ *   into `uncategorized`, which is added to the list iff used. (Empty categories
+ *   are pruned later by {@link assembleGraph}.)
+ *
+ * Topics absent from both delta and baseline get a minimal fallback so a topic is
+ * never silently dropped. `title` always comes from the current input (the LLM is
+ * told to keep it unchanged, but the input is authoritative).
+ */
+export function mergeCategoryLayer(
+	prevCategories: ReadonlyArray<DistilledCategory>,
+	prevTopics: ReadonlyArray<DistilledTopic>,
+	delta: CategoriesDelta,
+	currentTopics: ReadonlyArray<MergeTopicInput>,
+	changedSlugs: ReadonlySet<string>,
+): { categories: DistilledCategory[]; topics: DistilledTopic[] } {
+	const norm = (s: string): string => s.trim().toLowerCase();
+
+	const catById = new Map<string, DistilledCategory>();
+	const idByShortTitle = new Map<string, string>();
+	for (const c of prevCategories) {
+		if (catById.has(c.id)) continue; // keep-first on a duplicated baseline id
+		catById.set(c.id, c);
+		if (!idByShortTitle.has(norm(c.shortTitle))) idByShortTitle.set(norm(c.shortTitle), c.id);
+	}
+
+	// remap: a delta category id folded into an existing one (by shortTitle) → kept id.
+	const remap = new Map<string, string>();
+	for (const c of delta.newCategories) {
+		if (catById.has(c.id)) continue; // id already exists → reuse existing (keep its metadata)
+		const existingByTitle = idByShortTitle.get(norm(c.shortTitle));
+		if (existingByTitle) {
+			remap.set(c.id, existingByTitle);
+			continue;
+		}
+		catById.set(c.id, c);
+		idByShortTitle.set(norm(c.shortTitle), c.id);
+	}
+
+	const deltaBySlug = new Map(delta.topics.map((t) => [t.slug, t]));
+	const prevBySlug = new Map(prevTopics.map((t) => [t.slug, t]));
+	const topics: DistilledTopic[] = [];
+	let needUncategorized = false;
+	for (const ct of currentTopics) {
+		const src = changedSlugs.has(ct.slug) ? deltaBySlug.get(ct.slug) : prevBySlug.get(ct.slug);
+		let categoryId = src ? (remap.get(src.categoryId) ?? src.categoryId) : UNCATEGORIZED_CATEGORY_ID;
+		const shortTitle = src ? src.shortTitle : ct.title.slice(0, 80);
+		const summary = src ? src.summary : ct.summary;
+		if (!catById.has(categoryId)) categoryId = UNCATEGORIZED_CATEGORY_ID;
+		if (categoryId === UNCATEGORIZED_CATEGORY_ID) needUncategorized = true;
+		topics.push({ slug: ct.slug, title: ct.title, shortTitle, summary, categoryId });
+	}
+	if (needUncategorized && !catById.has(UNCATEGORIZED_CATEGORY_ID)) {
+		catById.set(UNCATEGORIZED_CATEGORY_ID, {
+			id: UNCATEGORIZED_CATEGORY_ID,
+			shortTitle: "Uncategorized",
+			summary: "Topics not yet grouped.",
+		});
+	}
+
+	return { categories: [...catById.values()], topics };
 }

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -334,6 +334,9 @@ vi.mock("../core/IngestPipeline.js", () => ({
 vi.mock("../core/TopicWikiRenderer.js", () => ({
 	renderTopicKBWiki: vi.fn(async () => {}),
 }));
+vi.mock("../graph/GraphBuilder.js", () => ({
+	buildKnowledgeGraph: vi.fn(async () => ({ built: false })),
+}));
 
 vi.mock("../core/IngestRunStore.js", () => ({
 	appendCredentialMissingRun: vi.fn(async () => {}),
@@ -389,6 +392,7 @@ import { generateSummary } from "../core/Summarizer.js";
 import { storeSummary } from "../core/SummaryStore.js";
 import { renderTopicKBWiki } from "../core/TopicWikiRenderer.js";
 import { buildMultiSessionContext, readTranscript } from "../core/TranscriptReader.js";
+import { buildKnowledgeGraph } from "../graph/GraphBuilder.js";
 import { recordPendingWorker, wakePendingWorkers } from "../sync/PendingWorkers.js";
 import { acquireVaultWriteLock } from "../sync/VaultWriteLock.js";
 import type { CommitGitOperation, IngestOperation } from "../Types.js";
@@ -2454,6 +2458,31 @@ describe("QueueWorker", () => {
 
 			expect(vi.mocked(drainIngest)).toHaveBeenCalledOnce();
 			expect(vi.mocked(renderTopicKBWiki)).toHaveBeenCalledOnce();
+			// The knowledge graph is refreshed right after the wiki, on the same gate.
+			expect(vi.mocked(buildKnowledgeGraph)).toHaveBeenCalledOnce();
+		});
+
+		it("isolates a knowledge-graph build failure (non-fatal: wiki/ingest still succeed)", async () => {
+			vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-test" } as never);
+			vi.mocked(drainIngest).mockResolvedValue({ batches: 1, ingested: 2, outcome: "OK", topicFailures: [] });
+			vi.mocked(buildKnowledgeGraph).mockRejectedValueOnce(new Error("graph boom"));
+
+			const op = makeIngestOp("post-merge");
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/ingest.json" }])
+				.mockResolvedValueOnce([]);
+
+			// Must not throw despite the graph build rejecting.
+			await expect(runWorker("/test/cwd")).resolves.not.toThrow();
+			expect(vi.mocked(renderTopicKBWiki)).toHaveBeenCalledOnce();
+			expect(vi.mocked(buildKnowledgeGraph)).toHaveBeenCalledOnce();
+			// The INNER graph try/catch handled it — proven by the graph-specific WARN
+			// firing while the OUTER ingest-phase catch's ERROR does NOT. Without the
+			// inner catch the throw would bubble to that outer catch and this would
+			// flip, so these two assertions are what make the inner isolation
+			// load-bearing rather than redundant with the outer handler.
+			expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("Knowledge graph build failed"));
+			expect(console.error).not.toHaveBeenCalledWith(expect.stringContaining("Unlocked ingest phase failed"));
 		});
 
 		it("releases the entry-level vault-write.lock before running the ingest LLM phase", async () => {
@@ -2566,6 +2595,8 @@ describe("QueueWorker", () => {
 
 			expect(vi.mocked(drainIngest)).toHaveBeenCalledOnce();
 			expect(vi.mocked(renderTopicKBWiki)).not.toHaveBeenCalled();
+			// Graph is gated identically — no wiki render, no graph build.
+			expect(vi.mocked(buildKnowledgeGraph)).not.toHaveBeenCalled();
 		});
 
 		it("re-renders the wiki when ingested=0 but the visible wiki was deleted", async () => {

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -97,6 +97,7 @@ import { generateTranscriptId } from "../core/TranscriptId.js";
 import { getParserForSource } from "../core/TranscriptParser.js";
 import type { SessionTranscript } from "../core/TranscriptReader.js";
 import { buildMultiSessionContext, readTranscript } from "../core/TranscriptReader.js";
+import { buildKnowledgeGraph } from "../graph/GraphBuilder.js";
 import { deriveSourceTag } from "../install/DistPathResolver.js";
 import { createLogger, errMsg, getJolliMemoryDir, setLogDir, setLogLevel } from "../Logger.js";
 import { recordPendingWorker, wakePendingWorkers } from "../sync/PendingWorkers.js";
@@ -809,6 +810,17 @@ async function runIngestFromQueue(
 	const wikiMissing = storage.isTopicWikiPresent ? !storage.isTopicWikiPresent() : false;
 	if (result.ingested > 0 || wikiMissing) {
 		await renderTopicKBWiki(cwd, storage, writeGuard);
+		// Refresh the knowledge graph alongside the wiki, on the same gate. Cheap
+		// now that it's diff-based: a no-op build (nothing changed) costs 0 LLM
+		// calls, and a typical change costs ~one call per changed topic. Isolated +
+		// non-fatal: a graph failure must never break ingest/wiki/commit — it just
+		// leaves the prior graph.json untouched. An incremental failure keeps the
+		// old graph and never auto-falls-back to a full rebuild (see buildKnowledgeGraph).
+		try {
+			await buildKnowledgeGraph(cwd, storage, config);
+		} catch (err) {
+			log.warn("Knowledge graph build failed (non-fatal): %s", (err as Error).message);
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The knowledge graph now rebuilds incrementally on each commit. Previously, every build re-ran the full set of AI calls regardless of how much had changed; now the system computes a content fingerprint for each topic and compares it against the fingerprints stored in the previous graph output. Topics whose content is unchanged have their extracted knowledge reused verbatim, and only added or modified topics are re-processed. When nothing has changed at all, the build exits immediately without calling any external service or writing any files.

The incremental path was hardened against bad AI responses. Previously, an unparseable or structurally incomplete response would silently produce a degraded graph and write it over the last known-good version. The incremental path now treats any such response as a failure and leaves the prior graph untouched, while the first-time full build retains its original tolerant behavior for cases where there is no prior graph to protect.

Two additional correctness gaps were closed. Fields in the graph output that describe source branches and commit history are not inputs to the AI, so they could drift without triggering a rebuild; a new metadata fingerprint now tracks these fields independently, and when only metadata has moved the graph is reassembled with fresh metadata and no AI calls. Separately, removing all topics from the project previously left the old graph file on disk indefinitely; the build now detects this case and writes an empty graph, clearing the phantom topics immediately.

---

## E2E Test (2)
<details>
<summary><strong>1. Knowledge graph updates only changed topics, not the whole graph</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository connected to Jolli with at least two topics already in the knowledge graph (so one can be changed while the other stays the same).

**Steps:**
1. Open the Jolli knowledge graph panel and note the current topics, their categories, and the connections between them.
2. Edit the content of exactly one topic (for example, change its summary or body text) and save the file.
3. Trigger a compile or sync run and wait for it to complete.
4. Open the knowledge graph panel again and inspect the updated topic and the unchanged topic.

**Expected Results:**
- The topic you edited shows updated information (refreshed summary or short title reflecting your change).
- The topic you did not edit remains exactly as it was — same category assignment, same short title, same connections.
- The compile run completes faster than a full rebuild would (only one topic was re-processed, not all of them).

</blockquote>
</details>
<details>
<summary><strong>2. Full rebuild runs automatically when the graph baseline is missing or outdated</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository connected to Jolli. Either delete the hidden graph file manually or use a fresh repository that has never had a graph built.

**Steps:**
1. Ensure there is no existing knowledge graph for the repository (use a fresh repo, or clear the graph by removing the stored graph data).
2. Trigger a compile or sync run and wait for it to complete.
3. Open the knowledge graph panel and review the result.

**Expected Results:**
- The compile run completes successfully and produces a full knowledge graph.
- All topics appear in the graph with categories, summaries, and connections.
- No error is shown about a missing baseline — the tool handles the absence gracefully and builds from scratch.

</blockquote>
</details>

---

## Topics (7)
<details>
<summary><strong>01 · Incremental graph update fails safely instead of silently overwriting good data</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When the incremental knowledge graph update encountered a bad response from the AI — unparseable text or a response missing required fields — it silently treated the failure as an empty result and wrote a degraded graph to disk, overwriting the last known-good version.

**💡 Decisions Behind the Code**

- **Strict mode as a switch, not a rewrite**: Rather than changing the shared distillation helpers to always throw, a `strict` boolean option was added so the incremental and full-build paths can share the same functions with different failure semantics. The full-build path has no prior graph to protect and has always tolerated partial results; changing its behavior would be a separate trade-off with different consequences. Keeping the two paths diverge only at the error-handling boundary minimized the blast radius of the change.
- **Array presence required, not just parseability**: The strict check was extended beyond JSON parseability to require that the parsed object contain the expected array field. A response of `{}` parses successfully but degrades to zero units or zero edges just as badly as unparseable text. The prompt contract already guarantees both arrays will be present (using empty arrays for the nothing-found case), so requiring them in strict mode is consistent with the contract and closes the gap without over-constraining legitimate empty responses.
- **Tolerating valid-but-incomplete deltas**: A categories-delta response that parses correctly and contains both required arrays but simply omits a changed topic is still handled by the existing backfill merge that places the omitted topic into the uncategorized bucket. The distinction drawn is between a structurally malformed response (failure, throw) and a structurally valid response that is merely incomplete (tolerated, backfilled).

**✅ What Was Implemented**

- `GraphDistiller.ts` gained a `strict` mode for the units and edges distillation functions. When called from the incremental path, an unparseable response or a response that parses to a valid object but is missing the required array field now throws an error rather than silently degrading to an empty list. The categories-delta function, which is incremental-only, was similarly hardened to throw on any malformed response. The full-build path passes no `strict` flag and retains its original tolerant behavior.
- The error-swallowing callback from the concurrent units fan-out on the incremental path was removed. Previously, a thrown LLM error during a dirty topic's unit re-distillation was caught, logged, and converted to an empty unit list; now the error propagates up so the outer non-fatal catch in the compile command keeps the prior graph on disk intact.
- `GraphDistiller.test.ts` was updated: two tests that had cemented the old tolerant behavior were rewritten to assert that errors are thrown, and seven new tests were added covering unparseable JSON, structurally valid but array-less responses, thrown LLM errors, and the distinction between a legitimately incomplete-but-valid delta (still tolerated via backfill) and a genuinely malformed one (now throws).

**📁 FILES**
- `cli/src/graph/GraphDistiller.ts`
- `cli/src/graph/GraphDistiller.test.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Incremental knowledge graph updates using fingerprint-based topic diffing</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Rebuilding the entire knowledge graph on every commit was expensive — it triggered dozens of LLM calls even when only one topic changed. The team needed a way to reuse unchanged work and skip the rebuild entirely when nothing had changed.

**💡 Decisions Behind the Code**

- **Incremental failures keep the old graph rather than falling back to a full rebuild**: an incremental LLM error or validation failure bubbles up to the non-fatal outer handler, leaving the previous graph intact. Auto-fallback to full was rejected on three grounds: it re-runs every LLM call (negating the incremental benefit), a transient LLM error would likely fail the full run too at double the cost, and a validation failure can only mean a merge bug — silently covering it with a full rebuild would mask the bug and impose permanent double cost on every subsequent build. This was confirmed correct after an adversarial review challenged it.
- **Edges are always recomputed in full rather than incrementally merged**: the unit IDs that edges reference are regenerated by the LLM on every topic re-distillation and are not stable across runs, making partial edge reuse unreliable. Full edge recomputation sidesteps unit-ID instability, eliminates complex merge-and-dedup logic, and the existing global temperature-zero setting already suppresses non-determinism for unchanged inputs.
- **A corrupted fingerprint baseline triggers a one-time full rebuild rather than a permanent no-graph state**: a corrupted fingerprint map is treated the same as a missing or version-mismatched baseline — there is no usable starting point, so a full rebuild heals it. This is distinct from a recoverable incremental failure, which keeps the old graph.

**✅ What Was Implemented**

- `GraphSchema.ts` gained the core incremental primitives: `diffTopics` partitions topics into clean/dirty/added/deleted by comparing SHA-256 content fingerprints; `toDistilled` restores a prior graph output to its raw distilled form while running a field-set validity check on every entity; `mergeCategoryLayer` performs the sticky category merge (reusing existing category IDs, folding shortTitle duplicates, backfilling uncategorized); `isFingerprintMap` guards against a corrupted fingerprint baseline; and `assembleGraph` was updated to accept and embed `topicFingerprints` and to prune zero-topic categories mechanically.
- `GraphDistiller.ts` received `distillGraphIncremental`, which reuses clean topics' units verbatim, re-distills only dirty/new topics in parallel, calls the new `graph-categories-delta` prompt for changed topics only (keeping clean topics' category assignments stable), and always recomputes edges in full over the final unit set. A pure-deletion path runs zero LLM calls.
- `GraphBuilder.ts` orchestrates the decision: it reads the prior `graph.json` via `readGraph`, checks schema version and fingerprint map validity, calls `toDistilled` for structural compatibility, then routes to full or incremental distillation. A no-change path skips all LLM calls and all disk writes entirely.
- Two correctness issues found during adversarial review were fixed: a literal NUL byte in the fingerprint separator was replaced with a Unicode escape (producing the same hash at runtime but keeping the source file text-readable), and the fingerprint type guard was added to handle the edge case where a hand-corrupted or future-bug-produced non-object value in the baseline would throw rather than degrade gracefully.

**📋 Future Enhancements**

- Edge locality (recomputing only edges touching changed topics) was deferred as a future optimization once edge volume becomes a bottleneck.
- The `graph-overrides.json` user-edit overlay (allowing users to delete units or edges without losing edits on rebuild) was explicitly deferred; the current design does not support it.

**📁 FILES**
- `cli/src/graph/GraphSchema.ts`
- `cli/src/graph/GraphDistiller.ts`
- `cli/src/graph/GraphBuilder.ts`
- `cli/src/graph/GraphArtifactStore.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Source metadata staleness fixed with a dedicated metadata fingerprint</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The no-op skip logic only compared content fingerprints, so changes to a topic's source branches or commit history — fields that appear in the graph output but are not fed to the AI — would never trigger a rebuild. The graph could show stale commit counts and branch lists indefinitely even as the underlying data changed.

**💡 Decisions Behind the Code**

- **Separate fingerprint, not merged into content fingerprint**: Folding source branches and commit hashes into the existing content fingerprint would cause a pure metadata change to mark the topic as dirty and trigger a full AI re-distillation of its units. That would be expensive and semantically wrong — the content did not change. A separate metadata fingerprint allows the two concerns to be checked independently, with metadata drift taking the cheaper no-LLM reassemble path.
- **No-LLM reassemble reuses the distilled layer verbatim**: When only metadata drifted, the builder skips all AI calls and passes the prior distilled categories, topics, units, and edges directly to the assembly step alongside the freshly computed join metadata. This keeps the reassemble path fast and side-effect-free with respect to AI costs, while still producing a correctly dated and correctly sourced graph output on disk.

**✅ What Was Implemented**

- `GraphSchema.ts` added a `topicMetaFingerprints` field to the `KnowledgeGraph` type and to the `assembleGraph` function. This field stores a per-topic hash of the join metadata (source branches and commit hashes) that the content fingerprint deliberately excludes. The schema version comment was updated to clarify that both fingerprint fields landed together in the same unreleased v2.
- `GraphBuilder.ts` introduced a `topicMetaFingerprint` export function and a `sameFingerprints` helper. The main build orchestration now computes metadata fingerprints alongside content fingerprints for every topic. When content fingerprints are all unchanged but the metadata fingerprints differ (or the baseline has no metadata fingerprints at all), the builder performs a no-LLM reassemble: it reuses the existing distilled layer verbatim and re-joins the fresh metadata before writing to disk. A baseline with a missing or corrupt metadata map is treated as drifted, triggering one healing reassemble.
- `GraphBuilder.test.ts` was updated: the existing skip test was given a matching metadata fingerprint so it still exercises the true no-op path, and four new tests were added covering metadata drift, key-set mismatch, and the legacy-baseline healing case.

**📁 FILES**
- `cli/src/graph/GraphBuilder.ts`
- `cli/src/graph/GraphSchema.ts`
- `cli/src/graph/GraphBuilder.test.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Deleting the last topic now clears the graph instead of leaving stale data</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When all topics were removed, the build skipped entirely because the topic index was empty, leaving the previous graph file on disk. The graph would continue showing topics that no longer existed until a new topic was added and a full rebuild ran.

**💡 Decisions Behind the Code**

The plan document contained a contradiction: one section said to skip when the index has no topics, while the behavior matrix said a pure-deletion case should produce a filtered reassemble. Resolving in favor of the behavior matrix was the right product call — a graph showing phantom topics that were deleted is a correctness bug, not an acceptable degraded state. The no-LLM path makes the fix cheap: no AI calls are needed to write an empty graph, so the only cost is a single disk write.

**✅ What Was Implemented**

`GraphBuilder.ts` moved the baseline graph read to before the empty-index gate. When the index is empty but the prior graph contains topics, the builder now writes an empty graph (zero categories, topics, units, edges) with no AI calls, overwriting the stale file. The skip-entirely path is preserved only when there is no usable prior graph or the prior graph was already empty. A corresponding test was added to `GraphBuilder.test.ts` asserting that the written graph has empty arrays and that no AI distillation ran.

**📁 FILES**
- `cli/src/graph/GraphBuilder.ts`
- `cli/src/graph/GraphBuilder.test.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · New delta categorization prompt for incremental topic placement</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The existing category prompt assigns all topics at once and produces a fresh category list each run, which would cause category IDs to shift and destabilize the graph layout on every incremental build. A separate prompt was needed that accepts the existing categories as a constraint and only places the changed topics.

**💡 Decisions Behind the Code**

Keeping clean topics' category assignments from the baseline (rather than re-running the full categorization prompt) was chosen specifically to preserve layout stability: the graph visualization keys node positions to category IDs, so reassigning a clean topic to a differently-named category would move its card on screen even though its content had not changed. The delta prompt enforces this by only receiving the changed topics, making it structurally impossible to accidentally reassign a clean topic.

**✅ What Was Implemented**

`graph-categories-delta` was added to `PromptTemplates.ts`. It receives the existing category list and the changed/new topics, instructs the model to reuse existing category IDs wherever possible, and only invents a new category when nothing fits. A comment block was added above all four graph prompt registrations explaining that output-shape changes require a schema version bump.

**📁 FILES**
- `cli/src/core/PromptTemplates.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Schema version bumped and distill.json artifact removed</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Adding the fingerprint baseline to the graph output changed the shape of the output file, requiring a version bump. The separate distill file had no readers and was originally kept only as a placeholder for future incremental work that is now implemented differently.

**💡 Decisions Behind the Code**

Removing `distill.json` was safe because no code anywhere read it at runtime — it existed solely as a reserved slot for future incremental work. Consolidating to a single file also eliminates the window where a crash between the two sequential atomic writes could leave a new graph paired with a stale distill baseline, a subtle consistency hazard that the single-file design makes structurally impossible.

**✅ What Was Implemented**

- `GRAPH_SCHEMA_VERSION` was incremented from 1 to 2 in `GraphSchema.ts`, with an expanded comment explaining that this constant is the primary guard against reusing a structurally-incompatible baseline and must be bumped on any output-shape change to the embedded units, edges, categories, or topics.
- `writeGraphArtifacts` in `GraphArtifactStore.ts` was simplified to write only `graph.json`; the `distill` parameter and the `distill.json` atomic write were removed. A new `readGraph` function and `graphJsonPath` helper were added to support the incremental baseline read path.

**📁 FILES**
- `cli/src/graph/GraphArtifactStore.ts`
- `cli/src/graph/GraphSchema.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Branch rebased onto latest main after remote updates</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The feature branch had fallen behind the main branch by eleven commits and needed to be brought up to date before further review.

**💡 Decisions Behind the Code**

Rebasing rather than merging keeps the branch history linear and avoids a merge commit that would complicate the eventual pull request review. The lock file conflict was resolved in favor of the remote version because the local change was version-number noise with no functional significance.

**✅ What Was Implemented**

The branch was rebased onto the latest remote main. A lock file conflict from dependency version bumps on main was resolved by accepting the incoming version. Uncommitted changes to a progress message comment were stashed before the rebase and restored cleanly afterward.

**📁 FILES**
- `cli/src/core/MultiRepoCompile.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 22, 2026 at 2:09 PM · via Anthropic*
<!-- jollimemory-summary-end -->

---

## Reviewer notes (manual)

**New post-commit LLM call.** This branch wires `buildKnowledgeGraph` into the post-commit ingest path (`QueueWorker.runIngestFromQueue`): on every commit where new sources landed (or the visible wiki is missing), the graph now refreshes alongside the wiki. This is a new steady-state behavior — previously the graph was only (re)built by an explicit compile/sync. It is safe by construction: the call runs in the detached, non-blocking queue worker, is diff-based (a no-op build costs **0** LLM calls; a typical change costs ~one call per changed topic), and is wrapped in an isolated non-fatal `try/catch` so a graph failure can never break ingest, wiki, or the commit itself. Worth calling out only because "relevant commit → possible extra LLM call" is now the default.
