### PR TITLE
Add mcp__claude_ai_Linear__ prefix support to Claude binding and LinearAdapter

### DIFF
--- a/cli/src/core/CodexDiscovery.ts
+++ b/cli/src/core/CodexDiscovery.ts
@@ -73,6 +73,7 @@ async function runOnce(cwd: string): Promise<void> {
 
 		await migrateDiscoveryCursors(cwd);
 		const sessions = await discoverCodexSessions(cwd);
+		let advanced = 0;
 		for (const session of sessions) {
 			// Per-session try/catch: one bad transcript (read error, parse failure)
 			// must not abort the rest of the batch or block cursor advances.
@@ -115,10 +116,16 @@ async function runOnce(cwd: string): Promise<void> {
 						},
 						cwd,
 					);
+					advanced++;
 				}
 			} catch (err) {
 				log.warn("Codex discovery failed for %s: %s", session.sessionId, (err as Error).message);
 			}
+		}
+		// Summary line so the otherwise-silent 60s tick is observable in debug.log.
+		// Logged only when there are sessions to scan (no noise on idle ticks).
+		if (sessions.length > 0) {
+			log.info("Codex discovery pass: %d session(s) scanned, %d advanced", sessions.length, advanced);
 		}
 	} catch (err) {
 		// Top-level guard: loadConfig / discoverCodexSessions / migrate can throw.

--- a/cli/src/core/references/CodexEnvelopeParser.test.ts
+++ b/cli/src/core/references/CodexEnvelopeParser.test.ts
@@ -26,9 +26,23 @@ function fnCall(namespace: string, name: string, callId: string, args = "{}"): s
 /** function_call_output row. `inner` is the business object; `wrap` controls
  *  whether it's the `[{type:text,text}]` double-string form (Linear/Notion) or a
  *  bare object (GitHub/Jira). `prefix` toggles the `Wall time:` human prefix. */
-function fnOutput(callId: string, inner: unknown, opts: { wrap: "array" | "bare"; prefix: boolean }): string {
+function fnOutput(
+	callId: string,
+	inner: unknown,
+	opts: { wrap: "array" | "bare" | "envelope"; prefix: boolean },
+): string {
 	const innerJson =
-		opts.wrap === "array" ? JSON.stringify([{ type: "text", text: JSON.stringify(inner) }]) : JSON.stringify(inner);
+		opts.wrap === "array"
+			? JSON.stringify([{ type: "text", text: JSON.stringify(inner) }])
+			: opts.wrap === "envelope"
+				? // Newer codex_apps connectors emit the full MCP CallToolResult object.
+					JSON.stringify({
+						meta: null,
+						content: [{ type: "text", text: JSON.stringify(inner) }],
+						structuredContent: null,
+						isError: false,
+					})
+				: JSON.stringify(inner);
 	const output = opts.prefix ? `Wall time: 1.20s\nOutput:\n${innerJson}` : innerJson;
 	return jsonl({
 		type: "response_item",
@@ -139,6 +153,22 @@ describe("CodexEnvelopeParser.parse", () => {
 		expect(results.map((r) => r.adapter.id).sort()).toEqual(["github", "jira", "linear", "notion"]);
 		const jira = results.find((r) => r.adapter.id === "jira");
 		expect(jira?.toolName).toContain("mcp__claude_ai_Atlassian__");
+	});
+
+	it("unwraps the object-envelope function_call_output ({content:[{text}]}) — newer Linear _get_issue connector", () => {
+		// Regression: the OpenAI-curated Linear connector returns the full MCP
+		// CallToolResult object (not the bare [{text}] array). The issue JSON lives
+		// in content[0].text and must be unwrapped, or the adapter sees the envelope
+		// and extracts nothing.
+		const lines = [
+			fnCall("mcp__codex_apps__linear", "_get_issue", "c_gi"),
+			fnOutput("c_gi", LINEAR, { wrap: "envelope", prefix: true }),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {}, ALL_ADAPTERS);
+		expect(results.map((r) => r.adapter.id)).toEqual(["linear"]);
+		// Payload is the UNWRAPPED issue (id present), not the envelope object.
+		expect((results[0].payload as { id?: string }).id).toBe("JOLLI-1657");
+		expect(results[0].toolName).toBe("mcp__linear__get_issue");
 	});
 
 	it("skips a non-JSON / no-prefix output (execution error) without throwing", () => {
@@ -258,10 +288,10 @@ describe("CodexEnvelopeParser.parse — defensive branches", () => {
 			fnCall("mcp__codex_apps__linear", "_fetch", "c1"),
 			raw({ type: "function_call_output", call_id: "c1", output: "Wall time: 1s but no marker {not json}" }),
 			fnCall("mcp__codex_apps__linear", "_fetch", "c2"),
-			// array form whose first element is not a {type:text} block → unwrapTextArray returns the array as-is → adapter rejects
+			// array form whose first element is not a {type:text} block → unwrapTextEnvelope returns the array as-is → adapter rejects
 			raw({ type: "function_call_output", call_id: "c2", output: JSON.stringify([{ notText: 1 }]) }),
 			fnCall("mcp__codex_apps__linear", "_fetch", "c3"),
-			// array form whose text is not valid JSON → unwrapTextArray returns the array as-is
+			// array form whose text is not valid JSON → unwrapTextEnvelope returns the array as-is
 			raw({
 				type: "function_call_output",
 				call_id: "c3",

--- a/cli/src/core/references/CodexEnvelopeParser.ts
+++ b/cli/src/core/references/CodexEnvelopeParser.ts
@@ -319,9 +319,9 @@ export const codexEnvelopeParser: TranscriptEnvelopeParser = new CodexEnvelopePa
 
 /**
  * function_call_output → business object. Strips the human-readable
- * `Wall time: …\nOutput:\n` prefix when present, parses, and unwraps the
- * `[{type:"text",text:<JSON>}]` double-string form (Linear/Notion) to its inner
- * object. Returns null on any non-JSON / malformed output (e.g. exec errors).
+ * `Wall time: …\nOutput:\n` prefix when present, parses, and unwraps the MCP
+ * text-block envelope to its inner object. Returns null on any non-JSON /
+ * malformed output (e.g. exec errors).
  */
 function parseFunctionCallOutput(output: string): unknown {
 	let text = output;
@@ -333,7 +333,7 @@ function parseFunctionCallOutput(output: string): unknown {
 	}
 	const parsed = tryParse(text);
 	if (parsed === null) return null;
-	return unwrapTextArray(parsed);
+	return unwrapTextEnvelope(parsed);
 }
 
 /** Parse the `command` field from a shell `function_call`'s JSON-string `arguments`. */
@@ -364,15 +364,24 @@ function tryParse(s: string): unknown {
 }
 
 /**
- * If `value` is the `[{type:"text",text:"<JSON>"}]` form, parse the first text
- * block's JSON and return it; otherwise return `value` unchanged.
+ * Unwrap the MCP text-block envelope to its inner JSON. Handles both observed
+ * `function_call_output` shapes:
+ *   - bare array   `[{type:"text",text:"<JSON>"}]`               (older Linear/Notion)
+ *   - object env.  `{content:[{type:"text",text:"<JSON>"}], …}`  (newer codex_apps
+ *     connectors — the full MCP CallToolResult; the payload is `content[0].text`,
+ *     sibling fields `structuredContent`/`isError`/`meta` are ignored)
+ * Anything else (already-unwrapped object, non-text first block, non-JSON inner
+ * text) is returned unchanged.
  */
-function unwrapTextArray(value: unknown): unknown {
-	if (!Array.isArray(value)) return value;
-	const first = value[0];
-	if (isObject(first) && first.type === "text" && typeof first.text === "string") {
-		const inner = tryParse(first.text);
-		return inner === null ? value : inner;
+function unwrapTextEnvelope(value: unknown): unknown {
+	const block = Array.isArray(value)
+		? value[0]
+		: isObject(value) && Array.isArray(value.content)
+			? value.content[0]
+			: undefined;
+	if (isObject(block) && block.type === "text" && typeof block.text === "string") {
+		const inner = tryParse(block.text);
+		if (inner !== null) return inner;
 	}
 	return value;
 }

--- a/cli/src/core/references/bindings/claude/index.test.ts
+++ b/cli/src/core/references/bindings/claude/index.test.ts
@@ -7,6 +7,8 @@ describe("Claude producer binding", () => {
 			expect(claudeBindingForToolName("mcp__github__issue_read")?.sourceId).toBe("github");
 			expect(claudeBindingForToolName("mcp__claude_ai_Atlassian__getJiraIssue")?.sourceId).toBe("jira");
 			expect(claudeBindingForToolName("mcp__linear__get_issue")?.sourceId).toBe("linear");
+			// Both Linear MCP prefixes resolve to the linear source.
+			expect(claudeBindingForToolName("mcp__claude_ai_Linear__get_issue")?.sourceId).toBe("linear");
 			expect(claudeBindingForToolName("mcp__claude_ai_Notion__notion-fetch")?.sourceId).toBe("notion");
 		});
 
@@ -16,6 +18,9 @@ describe("Claude producer binding", () => {
 				"jira",
 			);
 			expect(claudeBindingForToolName("mcp__linear__list_issues")?.sourceId).toBe("linear");
+			// The official Linear connector counts read AND write tools (no accept scope).
+			expect(claudeBindingForToolName("mcp__claude_ai_Linear__list_issues")?.sourceId).toBe("linear");
+			expect(claudeBindingForToolName("mcp__claude_ai_Linear__save_issue")?.sourceId).toBe("linear");
 		});
 
 		it("returns null for an unrecognised tool name", () => {
@@ -47,11 +52,12 @@ describe("Claude producer binding", () => {
 	});
 
 	describe("CLAUDE_TOOL_PREFIXES", () => {
-		it("lists the four vendor prefixes for the envelope pre-filter", () => {
+		it("lists every vendor prefix for the envelope pre-filter (both Linear prefixes included)", () => {
 			expect(CLAUDE_TOOL_PREFIXES).toEqual([
 				"mcp__github__",
 				"mcp__claude_ai_Atlassian__",
 				"mcp__linear__",
+				"mcp__claude_ai_Linear__",
 				"mcp__claude_ai_Notion__",
 			]);
 		});

--- a/cli/src/core/references/bindings/claude/index.ts
+++ b/cli/src/core/references/bindings/claude/index.ts
@@ -48,9 +48,19 @@ interface Rule {
 const RULES: readonly Rule[] = [
 	{ prefix: "mcp__github__", sourceId: "github" },
 	{ prefix: "mcp__claude_ai_Atlassian__", sourceId: "jira" },
+	// Linear ships under two MCP prefixes: `mcp__linear__` (the standalone Linear
+	// MCP server) and `mcp__claude_ai_Linear__` (Claude's official connector). Both
+	// emit the same issue shape — id / title / url / status (string) / priority
+	// ({name} or string) / labels (string[]) — read directly by LinearAdapter, so
+	// no `accept` scope and identity normalize: read AND write tools both count, and
+	// LinearAdapter.extractRef rejects any payload that isn't a real issue.
 	{ prefix: "mcp__linear__", sourceId: "linear" },
+	{ prefix: "mcp__claude_ai_Linear__", sourceId: "linear" },
 	// Notion: prefix matches all notion tools; only `notion-fetch` is in business
-	// scope (search/update/write deliberately excluded).
+	// scope. Unlike Linear, Notion's create/update/search outputs are each a
+	// DIFFERENT shape from fetch (no top-level `metadata.type`/`title`; update
+	// returns only a page_id), so they can't be extracted without per-tool reshaping
+	// — deliberately left out of scope.
 	{ prefix: "mcp__claude_ai_Notion__", sourceId: "notion", accept: (name) => name.endsWith("notion-fetch") },
 ];
 

--- a/cli/src/core/references/bindings/codex/CodexLinearBinding.ts
+++ b/cli/src/core/references/bindings/codex/CodexLinearBinding.ts
@@ -1,11 +1,19 @@
 /**
  * CodexLinearBinding — Linear `codex_apps` connector binding.
  *
- * Single-entity `_fetch` only (no search shape observed yet). The payload needs
- * no reshaping: the ticket id is already in `id` (e.g. `JOLLI-1657`) and the URL
- * is `linear.app/…`, both read directly by the Linear adapter. When a Linear
- * search/list shape is observed, add its tool name + a collection key + (if
- * needed) a URL backfill here, mirroring CodexGitHubBinding.
+ * Recognizes the read tools that return issue-shaped payloads. `_fetch` /
+ * `linear_fetch` are the original standalone-MCP names; `_get_issue` /
+ * `_list_issues` / `_search` (and their dotted `linear.*` invocation forms) are
+ * what the OpenAI-curated Codex Linear connector emits — verified live for
+ * `_get_issue` / `linear.get_issue` (payload is a normal Linear issue object: the
+ * ticket id is in `id` (e.g. `ABC-123`) and the URL is `linear.app/…`, read
+ * directly by the Linear adapter; no reshaping → identity normalize). List/search
+ * are added on the same recognition but their payload shape is NOT yet verified
+ * live; the expectation is that entries wrap under a key in
+ * `LinearAdapter.wrapperKeys` (`issues` / `results`) so the driver unwraps them and
+ * `extractRef` validates each — if that guess is wrong they simply yield nothing
+ * (never crash). Write tools (e.g. `_create_attachment`, `_delete_comment`) are
+ * intentionally absent: they don't return an issue, so they'd be dropped anyway.
  */
 
 import type { CodexBinding } from "./CodexBinding.js";
@@ -13,8 +21,8 @@ import type { CodexBinding } from "./CodexBinding.js";
 export const linearCodexBinding: CodexBinding = {
 	id: "linear",
 	namespaceSuffix: "linear",
-	functionCallNames: new Set(["_fetch"]),
-	invocationTools: new Set(["linear_fetch"]),
+	functionCallNames: new Set(["_fetch", "_get_issue", "_list_issues", "_search"]),
+	invocationTools: new Set(["linear_fetch", "linear.get_issue", "linear.list_issues", "linear.search"]),
 	canonicalToolName: "mcp__linear__get_issue",
 	normalize: (business) => business,
 };

--- a/cli/src/core/references/bindings/codex/index.test.ts
+++ b/cli/src/core/references/bindings/codex/index.test.ts
@@ -10,6 +10,12 @@ describe("Codex producer binding registry", () => {
 			expect(codexBindingFromInvocationTool("atlassian rovo_getjiraissue")?.id).toBe("jira");
 		});
 
+		it("maps the OpenAI-curated Linear connector's dotted read invocations", () => {
+			expect(codexBindingFromInvocationTool("linear.get_issue")?.id).toBe("linear");
+			expect(codexBindingFromInvocationTool("linear.list_issues")?.id).toBe("linear");
+			expect(codexBindingFromInvocationTool("linear.search")?.id).toBe("linear");
+		});
+
 		it("maps github_search_issues to github (search-then-resolve path)", () => {
 			expect(codexBindingFromInvocationTool("github_search_issues")?.id).toBe("github");
 		});
@@ -30,6 +36,12 @@ describe("Codex producer binding registry", () => {
 			expect(codexBindingFromFunctionCall("mcp__codex_apps__github", "_fetch_issue")?.id).toBe("github");
 			expect(codexBindingFromFunctionCall("mcp__codex_apps__github", "_search_issues")?.id).toBe("github");
 			expect(codexBindingFromFunctionCall("mcp__codex_apps__atlassian_rovo", "_getjiraissue")?.id).toBe("jira");
+		});
+
+		it("maps the OpenAI-curated Linear connector's read tools (_get_issue/_list_issues/_search)", () => {
+			expect(codexBindingFromFunctionCall("mcp__codex_apps__linear", "_get_issue")?.id).toBe("linear");
+			expect(codexBindingFromFunctionCall("mcp__codex_apps__linear", "_list_issues")?.id).toBe("linear");
+			expect(codexBindingFromFunctionCall("mcp__codex_apps__linear", "_search")?.id).toBe("linear");
 		});
 
 		it("returns null when the source does not expose that tool name", () => {

--- a/cli/src/core/references/sources/LinearAdapter.test.ts
+++ b/cli/src/core/references/sources/LinearAdapter.test.ts
@@ -44,6 +44,30 @@ describe("LinearAdapter", () => {
 		expect(fieldVal(ref, "priority")).toBe("Urgent");
 	});
 
+	it("extracts the official Claude Linear connector shape (status string, priority {value,name}, labels[])", () => {
+		// Verified live against mcp__claude_ai_Linear__get_issue (JOLLI-1804): the
+		// official connector and the standalone mcp__linear__ server emit the same
+		// fields, so identity normalize + this adapter handle both unchanged.
+		const ref = LinearAdapter.extractRef(
+			{
+				id: "JOLLI-1804",
+				title: "Incremental knowledge-graph updates",
+				url: "https://linear.app/jolliai/issue/JOLLI-1804/incremental-knowledge-graph-updates",
+				status: "In Progress",
+				priority: { value: 0, name: "No priority" },
+				labels: ["JolliMemory"],
+				description: "Replace the full graph rebuild with incremental updates.",
+			},
+			"mcp__claude_ai_Linear__get_issue",
+			ts,
+		);
+		expect(ref).toMatchObject({ mapKey: "linear:JOLLI-1804", source: "linear", nativeId: "JOLLI-1804" });
+		expect(fieldVal(ref, "status")).toBe("In Progress");
+		expect(fieldVal(ref, "priority")).toBe("No priority");
+		expect(fieldVal(ref, "labels")).toBe("JolliMemory");
+		expect(ref?.toolName).toBe("mcp__claude_ai_Linear__get_issue");
+	});
+
 	it("filters non-string labels", () => {
 		const ref = LinearAdapter.extractRef(
 			{ id: "PROJ-1", title: "x", url: "https://x.example", labels: ["good", 42, ""] },


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (2)

1. Add mcp__claude_ai_Linear__ prefix support to Claude binding and LinearAdapter (`54cf00b`)
2. Fix Linear auto-discovery for OpenAI-curated connector tools and envelope format (`399c50f`)

## Quick recap (2)

### Commit 1 of 2: Add mcp__claude_ai_Linear__ prefix support to Claude binding and LinearAdapter (`54cf00b`)

A long-standing gap in the automatic reference discovery system was closed: tools called through the officially connected Linear integration now produce entries in Plans and Notes, matching the behavior that already worked for the standalone Linear server. The fix was confirmed safe through live API testing that verified both connection types return identically shaped data, and through a parallel investigation of Notion's tools that found their outputs too structurally varied to extend the same treatment.

### Commit 2 of 2: Fix Linear auto-discovery for OpenAI-curated connector tools and envelope format (`399c50f`)

Two bugs were fixed that together caused Linear issues fetched through Codex to never appear in the Plans & Notes sidebar. The first fix extended the Codex Linear binding to recognize the tool names used by the newer OpenAI-curated connector — the original binding only knew a single legacy name, so every call from the updated connector was silently ignored. The second fix, uncovered by a three-agent review and independently verified against live transcript data, addressed a deeper problem: even after the tool names were recognized, the response payload was still discarded. The newer connector wraps its response in a full envelope object rather than a plain array, and the unwrapping logic only handled the array form. The fix extended that logic to handle both shapes in a single unified function, so all connectors benefit automatically. A regression test was added that directly reproduces the failure scenario and confirms the unwrapped issue data reaches the adapter correctly.

## E2E Test (1)
<details>
<summary><strong>1. [54cf00b] Linear issue created via official connector appears in Plans and Notes</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the official Claude Linear integration connected (not the standalone Linear MCP server). Have at least one Linear issue that was created or fetched through that official connector during a Claude conversation.

**Steps:**
1. Open the app and start or open a Claude conversation where you have previously used the official Linear integration to create or look up a Linear issue.
2. In that conversation, ask Claude to fetch or create a Linear issue using the connected Linear tool (for example, "Get the details for issue PROJ-123" or "Create a new Linear issue called Test issue").
3. Wait for Claude to respond with the issue details.
4. Open the Plans and Notes sidebar (look for the sidebar panel on the side of the screen).
5. Check whether the Linear issue now appears as a reference card in the Plans and Notes sidebar.
6. Click the reference card and verify it shows the correct issue title, status, and priority.

**Expected Results:**
- The Linear issue should appear as a reference card in the Plans and Notes sidebar after Claude fetches or creates it.
- The card should display the correct issue title, status (for example "In Progress"), and priority (for example "No priority" or "Urgent").
- This should work whether the issue was fetched with a read tool (like "get issue") or created with a write tool (like "save issue" or "create issue").

</blockquote>
</details>

## Topics (4)
<details>
<summary><strong>01 · [54cf00b] Linear official connector tools now automatically appear in Plans and Notes</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After creating a Linear issue using the officially connected Linear integration, the issue never appeared in the Plans and Notes sidebar. The developer investigated and found that the automatic reference discovery system only recognized one of the two possible Linear connection types, missing the one actually in use.

**💡 Decisions Behind the Code**

- **Both Linear server types recognized, not just one**: The standalone Linear MCP server and the official Claude connector were verified live to emit identical issue shapes, so a single adapter handles both with no reshaping. Restricting to one prefix would have silently dropped references depending on which connection type a user had active, with no error or warning to diagnose it.
- **Read and write tools both count for Linear, unlike Notion**: For Notion, only the fetch tool was kept in scope after live testing revealed that create, update, and search each return a structurally different payload — update returns only a page identifier with no title or URL, making it impossible to form a reference at all. For Linear, every tool returns the same issue shape, so the adapter's own validation acts as the gatekeeper and no accept filter is needed.

**✅ What Was Implemented**

- Added the official Claude Linear connector prefix (`mcp__claude_ai_Linear__`) as a recognized source in `cli/src/core/references/bindings/claude/index.ts`, alongside the existing standalone server prefix. No accept-scope filter was added, meaning both read and write tool calls are eligible — the adapter's own shape validation rejects anything that isn't a real issue object. A comment was added explaining why Notion was deliberately left more restrictive (its create/update/search outputs each have a different shape that cannot be extracted without per-tool reshaping).
- Added a test fixture in `cli/src/core/references/sources/LinearAdapter.test.ts` using the exact payload shape returned by a live call to the official connector (string status, priority as an object with value and name, string-array labels), confirming the existing adapter handles both server types without any normalization step.
- Updated `cli/src/core/references/bindings/claude/index.test.ts` to assert five recognized prefixes instead of four, and added explicit cases for the official connector's read and write tool names.

**📁 FILES**
- `cli/src/core/references/bindings/claude/index.ts`
- `cli/src/core/references/sources/LinearAdapter.test.ts`
- `cli/src/core/references/bindings/claude/index.test.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [399c50f] Fix silent failure when Codex Linear connector returns object-wrapped payloads</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the initial Codex Linear binding fix was implemented, a three-agent review revealed that the fix recognized the right tool calls but still extracted nothing. The newer Linear connector wraps its response in a full envelope object rather than a plain array, and the existing unwrapping logic only handled the array form — so the issue data was silently discarded every time.

**💡 Decisions Behind the Code**

- **Adversarial verification before trusting the review finding**: The agent review flagged the envelope mismatch as a high-severity issue, but the team verified it independently against the actual parser source and a live transcript payload before acting on it. This prevented a false fix and confirmed the root cause was real — the array-only branch in the unwrap function genuinely could not reach the nested content.
- **Unified unwrap function rather than a separate code path**: Rather than adding a separate branch elsewhere in the pipeline for the object-envelope case, the unwrap function itself was extended to handle both shapes. This keeps the extraction logic in one place and means all connectors — present and future — benefit from the broader handling without changes to the calling code.
- **Leaving list and search tool shapes unverified but safe**: The `_list_issues` and `_search` tool names were added to the recognized set alongside `_get_issue`, but no live payload sample existed for them. The decision was to include them with a documented caveat: if the shape guess is wrong, those calls simply yield no references rather than crashing, so the risk of being wrong is bounded.

**✅ What Was Implemented**

- `unwrapTextEnvelope` in `CodexEnvelopeParser.ts` replaced the old `unwrapTextArray` function. The new implementation handles both the legacy bare-array form (`[{type:"text",text:"<JSON>"}]`) and the newer object-envelope form (`{content:[{type:"text",text:"<JSON>"}],…}`) that the OpenAI-curated Linear connector emits. The sibling fields (`structuredContent`, `isError`, `meta`) are ignored; only `content[0].text` is extracted.
- A regression test was added to `CodexEnvelopeParser.test.ts` using a new `"envelope"` wrap mode in the `fnOutput` helper. The test asserts that the unwrapped issue payload (not the envelope object) reaches the adapter, directly covering the failure scenario the review uncovered.

**📁 FILES**
- `cli/src/core/references/CodexEnvelopeParser.ts`
- `cli/src/core/references/bindings/codex/CodexLinearBinding.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [399c50f] Extend Codex Linear binding to recognize newer connector tool names</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Codex Linear binding only recognized a single legacy tool name from an older connector version. When the user fetched a Linear issue through Codex, the sidebar showed nothing — the tool call was not matched by the binding and was silently dropped.

**💡 Decisions Behind the Code**

- **Read-only tools only, write tools deliberately excluded**: Only tools that return issue-shaped data were added. Write tools like comment creation or attachment upload do not return a recognizable issue object, so the adapter's validation would reject them anyway — including them in the binding would add noise with no benefit.
- **Full read coverage (get, list, search) rather than just the single-fetch tool**: The team chose to recognize all three read tool variants at once rather than the minimal single-tool fix. The rationale was that list and search calls are common in real workflows, and the adapter's per-entry validation provides a natural safety net if any of those shapes turn out to be unexpected.

**✅ What Was Implemented**

- `CodexLinearBinding.ts` was updated to recognize three additional function-call names (`_get_issue`, `_list_issues`, `_search`) and their dotted invocation equivalents (`linear.get_issue`, `linear.list_issues`, `linear.search`), alongside the original `_fetch` / `linear_fetch` names. The canonical tool name and identity normalize remain unchanged.
- New binding lookup tests were added to `bindings/codex/index.test.ts` covering all three new function-call names and all three new invocation tool names, verifying they resolve to the linear adapter.

**📁 FILES**
- `cli/src/core/references/bindings/codex/CodexLinearBinding.ts`
- `cli/src/core/references/bindings/codex/index.test.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [399c50f] Add observable logging to the otherwise-silent background discovery pass</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The user noticed that the background scan that runs every minute left no trace in the debug log, making it impossible to tell whether it was running at all or simply finding nothing.

**💡 Decisions Behind the Code**

Logging only when sessions are present was a deliberate noise-reduction choice. An idle system with no active conversations would otherwise produce a log line every minute with zero counts, which would make the log harder to scan for meaningful signal. The trade-off is that a completely idle system remains silent, but that is the expected and desirable behavior.

**✅ What Was Implemented**

`CodexDiscovery.ts` now emits a single info-level log line after each pass that has sessions to scan, reporting how many sessions were examined and how many advanced their cursor position. The log is suppressed on idle ticks where no sessions are found, avoiding noise.

**📁 FILES**
- `cli/src/core/CodexDiscovery.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 22, 2026 at 5:31 PM*
<!-- jollimemory-summary-end -->