### PR TITLE
fix(vscode): rebuild CLI dist and install globally before deploy

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -282,7 +282,7 @@
 		"build:watch": "node esbuild.config.mjs --watch",
 		"package": "npm run build && npx @vscode/vsce package --no-dependencies --allow-missing-repository",
 		"install:vsix": "node -e \"const v=require('./package.json').version;const {execSync}=require('child_process');const fs=require('fs');const path=require('path');const isWin=process.platform==='win32';let code;if(isWin){code=path.join(process.env.LOCALAPPDATA||'','Programs','Microsoft VS Code','bin','code.cmd')}else{const candidates=['/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code','/usr/bin/code','/snap/bin/code'];code=candidates.find(p=>fs.existsSync(p))||'code'}execSync((isWin?'\\\"'+code+'\\\"':'\\\"'+code+'\\\"')+' --install-extension jollimemory-vscode-'+v+'.vsix --force',{stdio:'inherit'});\"",
-		"deploy": "npm version patch --no-git-tag-version && npm run build && npm run package && npm run install:vsix",
+		"deploy": "npm --prefix ../cli run build && npm install -g ../cli && npm run build && npm run package && npm run install:vsix",
 		"copy:codicons": "node ./scripts/copy-codicons.mjs"
 	},
 	"dependencies": {


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The deploy script for the VS Code extension now automatically rebuilds the CLI and refreshes the global installation before packaging. Previously, any changes made to the CLI's source code would not take effect after a deploy — the extension's hooks would continue running stale compiled output. With this fix, a single deploy command guarantees that the CLI and the extension are always in sync. The automatic patch-version bump that previously ran on every deploy was also removed, keeping version history clean and intentional.

---

## Topic (1)
<details>
<summary><strong>01 · Deploy script now rebuilds CLI before packaging the extension</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Changes made to the CLI source code were silently ignored when deploying the VS Code extension, because the deploy process only rebuilt the extension bundle and never updated the CLI's compiled output that the extension's hooks actually run.

**💡 Decisions Behind the Code**

- **Rebuild CLI as part of deploy, not separately**: Keeping the CLI build inside the single `deploy` command eliminates the class of silent failures where a developer deploys without remembering to manually rebuild the CLI first. The trade-off is a slightly longer deploy step, but the safety gain outweighs the cost.
- **Remove the automatic version bump from deploy**: The patch-version increment was dropped from the deploy script. Tying a version bump to every local deploy created noise in version history and was unrelated to the core goal of ensuring the CLI is current; versioning is better handled deliberately and separately.

**✅ What Was Implemented**

- `vscode/package.json` `deploy` script was updated to prepend two steps before the existing build-and-package sequence: `npm --prefix ../cli run build` compiles the CLI source into `cli/dist`, and `npm install -g ../cli` re-points the global install to the freshly built output. The previous `npm version patch --no-git-tag-version` step was removed entirely.

**📁 FILES**
- `vscode/package.json`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 23, 2026 at 11:21 AM · via Anthropic*
<!-- jollimemory-summary-end -->