### PR TITLE
Fix duplicate Jolli plan push and improve link deduplication

### DIFF
--- a/vscode/src/services/JolliPushService.test.ts
+++ b/vscode/src/services/JolliPushService.test.ts
@@ -690,7 +690,7 @@ describe("pushToJolli", () => {
 			DEFAULT_PAYLOAD,
 		).catch((e: unknown) => e);
 		expect(err).not.toBeInstanceOf(BindingRequiredError);
-		expect((err as Error).message).toBe("precondition_failed");
+		expect((err as Error).message).toBe("precondition_failed (HTTP 412)");
 	});
 
 	it("throws BindingAlreadyExistsError on 409 with binding_already_exists", async () => {
@@ -749,7 +749,7 @@ describe("pushToJolli", () => {
 			DEFAULT_PAYLOAD,
 		).catch((e: unknown) => e);
 		expect(err).not.toBeInstanceOf(BindingAlreadyExistsError);
-		expect((err as Error).message).toBe("conflict");
+		expect((err as Error).message).toBe("conflict (HTTP 409)");
 	});
 
 	it("handles statusCode being undefined (defaults to 0)", async () => {

--- a/vscode/src/services/JolliPushService.ts
+++ b/vscode/src/services/JolliPushService.ts
@@ -232,7 +232,10 @@ export function pushToJolli(
 								),
 							);
 						} else {
-							reject(new Error(json.error ?? `HTTP ${status}`));
+							const detail = [json.error, json.message]
+								.filter(Boolean)
+								.join(" — ");
+							reject(new Error(`${detail || "request failed"} (HTTP ${status})`));
 						}
 					} catch {
 						reject(

--- a/vscode/src/util/PlanGrouping.test.ts
+++ b/vscode/src/util/PlanGrouping.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { PlanReference } from "../../../cli/src/Types.js";
+import { annotatePlans, latestPlanPerName, planBaseKey } from "./PlanGrouping.js";
+
+function makePlan(overrides?: Partial<PlanReference>): PlanReference {
+	return {
+		slug: "test-plan",
+		title: "Test Plan",
+		addedAt: "2026-01-15T10:00:00Z",
+		updatedAt: "2026-01-15T10:05:00Z",
+		...overrides,
+	};
+}
+
+describe("PlanGrouping", () => {
+	describe("planBaseKey", () => {
+		it("strips an 8-hex archived commit-hash suffix", () => {
+			expect(planBaseKey("refactor-auth-1a2b3c4d")).toBe("refactor-auth");
+		});
+
+		it("leaves a base slug ending in real words alone", () => {
+			expect(planBaseKey("refactor-auth")).toBe("refactor-auth");
+			// 7 or 9 hex chars (not exactly 8) are not a hash suffix.
+			expect(planBaseKey("plan-1a2b3c4")).toBe("plan-1a2b3c4");
+			expect(planBaseKey("plan-1a2b3c4d5")).toBe("plan-1a2b3c4d5");
+			// A trailing word that is not hex is untouched.
+			expect(planBaseKey("plan-feature")).toBe("plan-feature");
+		});
+	});
+
+	describe("annotatePlans", () => {
+		it("orders newest-first and flags exactly one Latest per multi-snapshot group", () => {
+			const a = makePlan({ slug: "p-1111aaaa", updatedAt: "2026-01-10T00:00:00Z" });
+			const b = makePlan({ slug: "p-2222bbbb", updatedAt: "2026-01-12T00:00:00Z" });
+			const result = annotatePlans([a, b]);
+			expect(result.map((r) => r.plan.slug)).toEqual(["p-2222bbbb", "p-1111aaaa"]);
+			expect(result[0]).toMatchObject({ isLatest: true, isSuperseded: false });
+			expect(result[1]).toMatchObject({ isLatest: false, isSuperseded: true });
+		});
+
+		it("flags no Latest for a singleton group", () => {
+			const result = annotatePlans([makePlan({ slug: "solo-1111aaaa" })]);
+			expect(result[0]).toMatchObject({ isLatest: false, isSuperseded: false });
+		});
+
+		it("keeps distinct-named plans independent", () => {
+			const x = makePlan({ slug: "alpha-1111aaaa", updatedAt: "2026-01-10T00:00:00Z" });
+			const y = makePlan({ slug: "beta-2222bbbb", updatedAt: "2026-01-12T00:00:00Z" });
+			const result = annotatePlans([x, y]);
+			expect(result.every((r) => !r.isLatest && !r.isSuperseded)).toBe(true);
+		});
+
+		it("breaks updatedAt ties deterministically by slug", () => {
+			const same = "2026-01-10T00:00:00Z";
+			const a = makePlan({ slug: "p-bbbbbbbb", updatedAt: same });
+			const b = makePlan({ slug: "p-aaaaaaaa", updatedAt: same });
+			// Input order reversed between the two runs — output must be identical.
+			const r1 = annotatePlans([a, b]).map((r) => r.plan.slug);
+			const r2 = annotatePlans([b, a]).map((r) => r.plan.slug);
+			expect(r1).toEqual(r2);
+			expect(r1).toEqual(["p-aaaaaaaa", "p-bbbbbbbb"]);
+		});
+
+		it("keeps identical entries (same slug + updatedAt) stable", () => {
+			const p = makePlan({ slug: "dup-1111aaaa", updatedAt: "2026-01-10T00:00:00Z" });
+			const result = annotatePlans([p, { ...p }]);
+			// Same base key twice → a duplicate group; second occurrence superseded.
+			expect(result.map((r) => r.plan.slug)).toEqual(["dup-1111aaaa", "dup-1111aaaa"]);
+			expect(result[0]).toMatchObject({ isLatest: true, isSuperseded: false });
+			expect(result[1]).toMatchObject({ isLatest: false, isSuperseded: true });
+		});
+	});
+
+	describe("latestPlanPerName", () => {
+		it("returns one plan per base name — the latest", () => {
+			const a = makePlan({ slug: "p-1111aaaa", updatedAt: "2026-01-10T00:00:00Z" });
+			const b = makePlan({ slug: "p-2222bbbb", updatedAt: "2026-01-12T00:00:00Z" });
+			const c = makePlan({ slug: "other-3333cccc", updatedAt: "2026-01-09T00:00:00Z" });
+			const result = latestPlanPerName([a, b, c]);
+			expect(result.map((p) => p.slug)).toEqual(["p-2222bbbb", "other-3333cccc"]);
+		});
+
+		it("returns the input unchanged when all names are distinct", () => {
+			const result = latestPlanPerName([makePlan({ slug: "only-1111aaaa" })]);
+			expect(result.map((p) => p.slug)).toEqual(["only-1111aaaa"]);
+		});
+
+		it("inherits a pushed sibling's docId onto the latest snapshot so the push updates, not duplicates", () => {
+			const older = makePlan({
+				slug: "p-1111aaaa",
+				updatedAt: "2026-01-10T00:00:00Z",
+				jolliPlanDocId: 42,
+				jolliPlanDocUrl: "https://jolli.ai/articles?doc=42",
+			});
+			const latest = makePlan({ slug: "p-2222bbbb", updatedAt: "2026-01-12T00:00:00Z" });
+			const result = latestPlanPerName([older, latest]);
+			expect(result).toHaveLength(1);
+			expect(result[0].slug).toBe("p-2222bbbb");
+			expect(result[0].jolliPlanDocId).toBe(42);
+			expect(result[0].jolliPlanDocUrl).toBe("https://jolli.ai/articles?doc=42");
+		});
+
+		it("keeps the latest snapshot's own docId when it already has one", () => {
+			const older = makePlan({ slug: "p-1111aaaa", updatedAt: "2026-01-10T00:00:00Z", jolliPlanDocId: 42 });
+			const latest = makePlan({ slug: "p-2222bbbb", updatedAt: "2026-01-12T00:00:00Z", jolliPlanDocId: 99 });
+			const result = latestPlanPerName([older, latest]);
+			expect(result[0].jolliPlanDocId).toBe(99);
+		});
+	});
+});

--- a/vscode/src/util/PlanGrouping.ts
+++ b/vscode/src/util/PlanGrouping.ts
@@ -1,0 +1,113 @@
+/**
+ * Grouping helpers for plans that share a logical name across commit snapshots.
+ *
+ * A plan committed to a commit is archived under a slug that embeds the commit
+ * hash (`<base-slug>-<shortHash>`, shortHash = commitHash.substring(0,8) — see
+ * QueueWorker.associatePlansWithCommit). Squash consolidation hoists every
+ * source commit's plans into the consolidated commit, so the same logical plan
+ * appears once per source commit — same title, different slug. These helpers
+ * collapse those snapshots by base name and pick the latest, and are the single
+ * source of truth shared by the detail-panel display (annotatePlans) and the
+ * push-to-Jolli path (latestPlanPerName) so the two never drift.
+ */
+
+import type { PlanReference } from "../../../cli/src/Types.js";
+
+/** A plan plus its standing among its same-named siblings. */
+export interface AnnotatedPlan {
+	readonly plan: PlanReference;
+	/** True only when this plan is the newest of a group with more than one snapshot. */
+	readonly isLatest: boolean;
+	/** True when this plan belongs to a multi-snapshot group but is NOT the latest. */
+	readonly isSuperseded: boolean;
+}
+
+/**
+ * Strips a trailing archived commit-hash suffix (`-<8 hex>`) to get the base
+ * name. Committed snapshots (`refactor-auth-a1b2c3d4`) and an uncommitted base
+ * (`refactor-auth`) collapse to the same key.
+ */
+export function planBaseKey(slug: string): string {
+	return slug.replace(/-[0-9a-f]{8}$/, "");
+}
+
+/**
+ * Compares two plans newest-first by `updatedAt`, tiebroken by `slug` so the
+ * order is deterministic across the standalone re-renders the panel performs.
+ */
+function byUpdatedAtDesc(a: PlanReference, b: PlanReference): number {
+	if (a.updatedAt !== b.updatedAt) {
+		return a.updatedAt < b.updatedAt ? 1 : -1;
+	}
+	return a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0;
+}
+
+/**
+ * Sorts plans newest-first and flags the latest snapshot of each same-named
+ * group. `isLatest` is set only when the group has more than one snapshot, so a
+ * lone plan never gets a "Latest" badge.
+ */
+export function annotatePlans(plans: ReadonlyArray<PlanReference>): ReadonlyArray<AnnotatedPlan> {
+	const sorted = [...plans].sort(byUpdatedAtDesc);
+	const seenOnce = new Set<string>();
+	const duplicatedKeys = new Set<string>();
+	for (const p of sorted) {
+		const key = planBaseKey(p.slug);
+		if (seenOnce.has(key)) {
+			duplicatedKeys.add(key);
+		}
+		seenOnce.add(key);
+	}
+	const latestSeen = new Set<string>();
+	return sorted.map((plan) => {
+		const key = planBaseKey(plan.slug);
+		const isFirstOfGroup = !latestSeen.has(key);
+		latestSeen.add(key);
+		const hasSiblings = duplicatedKeys.has(key);
+		const isLatest = isFirstOfGroup && hasSiblings;
+		const isSuperseded = !isFirstOfGroup && hasSiblings;
+		return { plan, isLatest, isSuperseded };
+	});
+}
+
+/**
+ * Returns exactly one plan per base name — the latest snapshot — preserving the
+ * newest-first order. Used to avoid pushing duplicate same-named documents to
+ * Jolli.
+ *
+ * Same-named plans share an identical server push identity (same title, branch,
+ * relativePath, commit — the slug is NOT sent), so `jolliPlanDocId` is the only
+ * thing that tells the server to UPDATE rather than CREATE. When a previously
+ * pushed older snapshot carries the docId but the latest snapshot does not, the
+ * latest inherits that docId/url so the push updates the existing article
+ * instead of creating a duplicate (which the server rejects → push failure).
+ */
+export function latestPlanPerName(plans: ReadonlyArray<PlanReference>): ReadonlyArray<PlanReference> {
+	const sorted = [...plans].sort(byUpdatedAtDesc);
+	// Newest already-pushed docId/url per base name (first hit wins = newest).
+	const pushedDoc = new Map<string, { docId: number; url: string | undefined }>();
+	for (const plan of sorted) {
+		const key = planBaseKey(plan.slug);
+		if (plan.jolliPlanDocId !== undefined && !pushedDoc.has(key)) {
+			pushedDoc.set(key, { docId: plan.jolliPlanDocId, url: plan.jolliPlanDocUrl });
+		}
+	}
+	const seen = new Set<string>();
+	const result: PlanReference[] = [];
+	for (const plan of sorted) {
+		const key = planBaseKey(plan.slug);
+		if (seen.has(key)) {
+			continue;
+		}
+		seen.add(key);
+		if (plan.jolliPlanDocId === undefined) {
+			const inherited = pushedDoc.get(key);
+			if (inherited) {
+				result.push({ ...plan, jolliPlanDocId: inherited.docId, jolliPlanDocUrl: inherited.url });
+				continue;
+			}
+		}
+		result.push(plan);
+	}
+	return result;
+}

--- a/vscode/src/views/SummaryCssBuilder.ts
+++ b/vscode/src/views/SummaryCssBuilder.ts
@@ -246,6 +246,27 @@ export function buildCss(): string {
     color: var(--vscode-descriptionForeground);
     padding-left: 2px;
   }
+  /* Per-snapshot disambiguation: relative date + "Latest" badge let the user
+     tell which of several same-named plans (one per pre-squash commit) is the
+     newest; superseded snapshots are dimmed. */
+  .plan-date {
+    font-size: 0.8em;
+    color: var(--vscode-descriptionForeground);
+    white-space: nowrap;
+  }
+  .plan-latest-badge {
+    font-size: 0.72em;
+    font-weight: 600;
+    line-height: 1;
+    margin-left: 8px;
+    padding: 2px 6px;
+    border-radius: 8px;
+    color: var(--vscode-badge-foreground);
+    background: var(--vscode-badge-background);
+    white-space: nowrap;
+  }
+  .plan-item.plan-older { opacity: 0.6; }
+  .plan-jolli-link { font-size: 0.85em; }
   .plan-remove-btn:hover { color: var(--vscode-errorForeground, #f44); }
   .plan-translate-btn.translating,
   .note-translate-btn.translating {

--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -1680,6 +1680,74 @@ describe("buildAllConversationsSection — Regenerate button", () => {
 			expect(html).toContain('id="plansAndNotesSection"');
 		});
 
+		it("marks only the newest of same-named plan snapshots as Latest and renders it first", () => {
+			const older = makePlan({
+				slug: "refactor-auth-1111aaaa",
+				title: "Refactor auth",
+				updatedAt: "2026-01-10T10:00:00Z",
+			});
+			const newer = makePlan({
+				slug: "refactor-auth-2222bbbb",
+				title: "Refactor auth",
+				updatedAt: "2026-01-12T10:00:00Z",
+			});
+			const html = buildPlansAndNotesSection(
+				[older, newer],
+				undefined,
+				[],
+			);
+			// Exactly one Latest badge.
+			expect(html.match(/plan-latest-badge/g)).toHaveLength(1);
+			// The badge sits on the newer snapshot, and the newer item is rendered first.
+			const newerIdx = html.indexOf('id="plan-refactor-auth-2222bbbb"');
+			const olderIdx = html.indexOf('id="plan-refactor-auth-1111aaaa"');
+			expect(newerIdx).toBeGreaterThanOrEqual(0);
+			expect(newerIdx).toBeLessThan(olderIdx);
+			// The superseded (older) snapshot is dimmed.
+			expect(html).toContain('class="plan-item plan-older" id="plan-refactor-auth-1111aaaa"');
+			// Every plan item carries a relative date.
+			expect(html.match(/plan-date/g)).toHaveLength(2);
+		});
+
+		it("does not render a Latest badge for a single (non-duplicated) plan", () => {
+			const html = buildPlansAndNotesSection([makePlan()], undefined, []);
+			expect(html).not.toContain("plan-latest-badge");
+			expect(html).toContain("plan-date");
+		});
+
+		it("renders an inline Jolli link only for a plan with jolliPlanDocUrl", () => {
+			const pushed = makePlan({
+				slug: "pushed-plan",
+				jolliPlanDocUrl: "https://jolli.ai/articles?doc=42",
+			});
+			const unpushed = makePlan({ slug: "unpushed-plan" });
+			const html = buildPlansAndNotesSection([pushed, unpushed], undefined, []);
+			expect(html).toContain(
+				'class="jolli-link plan-jolli-link" href="https://jolli.ai/articles?doc=42"',
+			);
+			// Only one inline link — the unpushed plan has none.
+			expect(html.match(/plan-jolli-link/g)).toHaveLength(1);
+		});
+
+		it("shows the inline Jolli link only on the latest of same-named snapshots", () => {
+			const url = "https://jolli.ai/very/articles?doc=2570";
+			const latest = makePlan({
+				slug: "dup-2222bbbb",
+				title: "Dup",
+				updatedAt: "2026-01-12T00:00:00Z",
+				jolliPlanDocUrl: url,
+			});
+			const older = makePlan({
+				slug: "dup-1111aaaa",
+				title: "Dup",
+				updatedAt: "2026-01-10T00:00:00Z",
+				jolliPlanDocUrl: url,
+			});
+			const html = buildPlansAndNotesSection([older, latest], undefined, []);
+			// Both snapshots share one Jolli doc, so only the latest links out.
+			expect(html.match(/plan-jolli-link/g)).toHaveLength(1);
+		});
+
 		it("buildJolliRow is exported: returns '' without a url, renders #jolliRow with one", () => {
 			expect(buildJolliRow(undefined, "msg", undefined, undefined)).toBe("");
 			const withUrl = buildJolliRow(
@@ -1689,6 +1757,20 @@ describe("buildAllConversationsSection — Regenerate button", () => {
 				undefined,
 			);
 			expect(withUrl).toContain('id="jolliRow"');
+		});
+
+		it("buildJolliRow lists a shared plan doc URL only once", () => {
+			const url = "https://jolli.ai/very/articles?doc=2570";
+			const p1 = makePlan({ slug: "dup-2222bbbb", title: "Dup", jolliPlanDocUrl: url });
+			const p2 = makePlan({ slug: "dup-1111aaaa", title: "Dup", jolliPlanDocUrl: url });
+			const html = buildJolliRow(
+				"https://jolli.ai/very/articles?doc=2571",
+				"msg",
+				[p1, p2],
+				undefined,
+			);
+			// Two snapshots, one doc — the Plans & Notes block lists it once.
+			expect(html.match(/jolli-plan-item/g)).toHaveLength(1);
 		});
 
 		it("buildAllConversationsSection wraps both branches in #allConversationsSection", () => {

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -22,6 +22,7 @@ import type {
 	TopicCategory,
 } from "../../../cli/src/Types.js";
 import { buildPrSectionHtml } from "../services/PrCommentService.js";
+import { annotatePlans } from "../util/PlanGrouping.js";
 import { SOURCE_TITLES } from "./SourceLabels.js";
 import { buildCss } from "./SummaryCssBuilder.js";
 import { buildScript } from "./SummaryScriptBuilder.js";
@@ -229,16 +230,30 @@ export function buildJolliRow(
 		: "View on Jolli";
 	const publishedPlans = (plans ?? []).filter((p) => p.jolliPlanDocUrl);
 	const publishedNotes = (notes ?? []).filter((n) => n.jolliNoteDocUrl);
-	const allItems = [
-		...publishedPlans.map((p) => {
-			const planUrl = p.jolliPlanDocUrl as string;
-			return `<div class="jolli-plan-item"><a class="jolli-link" href="${escHtml(planUrl)}" title="${escHtml(p.title)}">${escHtml(planUrl)}</a></div>`;
-		}),
-		...publishedNotes.map((n) => {
-			const noteUrl = n.jolliNoteDocUrl as string;
-			return `<div class="jolli-plan-item"><a class="jolli-link" href="${escHtml(noteUrl)}" title="${escHtml(n.title)}">${escHtml(noteUrl)}</a></div>`;
-		}),
-	];
+	// Same-named plan snapshots collapse to one Jolli doc, so several can carry
+	// the same URL — dedupe by URL so the ship card lists each doc once.
+	const seenUrls = new Set<string>();
+	const allItems: string[] = [];
+	for (const p of publishedPlans) {
+		const planUrl = p.jolliPlanDocUrl as string;
+		if (seenUrls.has(planUrl)) {
+			continue;
+		}
+		seenUrls.add(planUrl);
+		allItems.push(
+			`<div class="jolli-plan-item"><a class="jolli-link" href="${escHtml(planUrl)}" title="${escHtml(p.title)}">${escHtml(planUrl)}</a></div>`,
+		);
+	}
+	for (const n of publishedNotes) {
+		const noteUrl = n.jolliNoteDocUrl as string;
+		if (seenUrls.has(noteUrl)) {
+			continue;
+		}
+		seenUrls.add(noteUrl);
+		allItems.push(
+			`<div class="jolli-plan-item"><a class="jolli-link" href="${escHtml(noteUrl)}" title="${escHtml(n.title)}">${escHtml(noteUrl)}</a></div>`,
+		);
+	}
 	const plansAndNotesHtml =
 		allItems.length > 0
 			? `<div class="jolli-plans-block"><span class="jolli-plans-label">Plans &amp; Notes</span>${allItems.join("")}</div>`
@@ -642,23 +657,33 @@ export function buildPlansAndNotesSection(
 	const referenceList = references ?? [];
 	const totalCount = planList.length + noteList.length + referenceList.length;
 
-	const planItems = planList
-		.map((p) => {
+	const planItems = annotatePlans(planList)
+		.map(({ plan: p, isLatest, isSuperseded }) => {
 			const key = p.slug;
 			const showTranslate = planTranslateSet?.has(key) ?? false;
 			const translateBtn = showTranslate
 				? `<button class="topic-action-btn plan-translate-btn" title="Translate to English" data-plan-slug="${key}" data-action="translatePlan">&#x1F310;</button>`
 				: "";
+			const latestBadge = isLatest ? `<span class="plan-latest-badge">Latest</span>` : "";
+			const dateBadge = `<span class="plan-date">${escHtml(timeAgo(p.updatedAt))}</span>`;
+			// Same-named snapshots collapse to one Jolli doc, so only the latest
+			// links out — a superseded older version would point to the same doc
+			// (now holding the latest content), which reads as confusing.
+			const jolliLink =
+				p.jolliPlanDocUrl && !isSuperseded
+					? ` &middot; <a class="jolli-link plan-jolli-link" href="${escHtml(p.jolliPlanDocUrl)}" title="View plan on Jolli">&#x1F517; View on Jolli</a>`
+					: "";
+			const itemClass = isSuperseded ? "plan-item plan-older" : "plan-item";
 			return `
-  <div class="plan-item" id="plan-${key}">
+  <div class="${itemClass}" id="plan-${key}">
     <div class="plan-header">
-      <a class="plan-title plan-title-link" href="#" title="Click to preview" data-action="previewPlan" data-plan-slug="${key}" data-plan-title="${escAttr(p.title)}">${escHtml(p.title)}</a>
+      <a class="plan-title plan-title-link" href="#" title="Click to preview" data-action="previewPlan" data-plan-slug="${key}" data-plan-title="${escAttr(p.title)}">${escHtml(p.title)}</a>${latestBadge}
       <span class="plan-header-actions">
-        ${translateBtn}<button class="topic-action-btn plan-edit-btn" title="Edit Plan" data-plan-slug="${key}" data-action="loadPlanContent">&#x270E;</button>
+        ${dateBadge}${translateBtn}<button class="topic-action-btn plan-edit-btn" title="Edit Plan" data-plan-slug="${key}" data-action="loadPlanContent">&#x270E;</button>
         <button class="topic-action-btn plan-remove-btn" title="Remove Plan" data-plan-slug="${key}" data-plan-title="${escAttr(p.title)}" data-action="removePlan">&#x1F5D1;</button>
       </span>
     </div>
-    <div class="plan-meta">${escHtml(key)}.md</div>
+    <div class="plan-meta">${escHtml(key)}.md${jolliLink}</div>
     <div class="plan-edit-area">
       <textarea class="plan-edit-textarea" data-plan-slug="${key}" rows="20"></textarea>
       <div class="plan-edit-actions">

--- a/vscode/src/views/SummaryWebviewPanel.handlePush.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.handlePush.test.ts
@@ -525,6 +525,101 @@ describe("SummaryWebviewPanel handlePush", () => {
 			);
 			expect(localResultCalls).toHaveLength(0);
 		});
+
+		it("uploads only the latest snapshot when same-named plans accumulate after squash", async () => {
+			mockLoadConfig.mockResolvedValue({
+				apiKey: "test",
+				jolliApiKey: "jk_valid",
+			});
+			mockParseJolliApiKey.mockReturnValue({ u: "https://my.jolli.app" });
+			mockReadPlanFromBranch.mockResolvedValue("# Refactor auth\n\nbody");
+			mockPushToJolli.mockResolvedValue({ docId: 7 });
+			const dispatch = await setupPanel({
+				plans: [
+					{
+						slug: "refactor-auth-1111aaaa",
+						title: "Refactor auth",
+						addedAt: "2026-01-10T00:00:00Z",
+						updatedAt: "2026-01-10T00:00:00Z",
+					},
+					{
+						slug: "refactor-auth-2222bbbb",
+						title: "Refactor auth",
+						addedAt: "2026-01-12T00:00:00Z",
+						updatedAt: "2026-01-12T00:00:00Z",
+					},
+				],
+			});
+
+			dispatch({ command: "push" });
+			await flushPromises();
+
+			// Exactly one plan-type upload — the two same-named snapshots collapse
+			// to the latest, instead of creating a duplicate document per commit.
+			const planCalls = mockPushToJolli.mock.calls.filter(
+				(c: Array<unknown>) =>
+					(c[2] as { docType?: string }).docType === "plan",
+			);
+			expect(planCalls).toHaveLength(1);
+			// The single upload reads the latest snapshot's content (push reads
+			// with the 2-arg signature; the translate-set refresh uses 3 args).
+			expect(mockReadPlanFromBranch).toHaveBeenCalledWith(
+				"refactor-auth-2222bbbb",
+				workspaceRoot,
+			);
+			// The pushed summary markdown is built from the deduped plans, so the
+			// article's Plans & Notes list doesn't repeat the superseded snapshot.
+			const mdSummary = mockBuildMarkdown.mock.calls.at(-1)?.[0] as {
+				plans: Array<{ slug: string }>;
+			};
+			expect(mdSummary.plans).toHaveLength(1);
+			expect(mdSummary.plans[0].slug).toBe("refactor-auth-2222bbbb");
+		});
+
+		it("does not abort the push when a single plan fails — pushes the summary and warns", async () => {
+			mockLoadConfig.mockResolvedValue({
+				apiKey: "test",
+				jolliApiKey: "jk_valid",
+			});
+			mockParseJolliApiKey.mockReturnValue({ u: "https://my.jolli.app" });
+			mockReadPlanFromBranch.mockResolvedValue("# Plan body\n\nbody");
+			// Plan upload 500s (server already has the doc); summary upload succeeds.
+			mockPushToJolli.mockImplementation(
+				(_base: unknown, _key: unknown, payload: { docType?: string }) =>
+					payload.docType === "plan"
+						? Promise.reject(new Error("Push failed (HTTP 500)"))
+						: Promise.resolve({ docId: 55 }),
+			);
+			const dispatch = await setupPanel({
+				plans: [
+					{
+						slug: "stuck-plan-1111aaaa",
+						title: "Stuck plan",
+						addedAt: "2026-01-10T00:00:00Z",
+						updatedAt: "2026-01-10T00:00:00Z",
+					},
+				],
+			});
+
+			dispatch({ command: "push" });
+			await flushPromises();
+
+			// The summary still uploaded despite the plan failure.
+			const summaryCalls = mockPushToJolli.mock.calls.filter(
+				(c: Array<unknown>) =>
+					(c[2] as { docType?: string }).docType === "summary",
+			);
+			expect(summaryCalls).toHaveLength(1);
+			// The user gets a MODAL warning (not a missable toast) naming the
+			// failed attachment in its detail.
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("attachment(s) failed"),
+				expect.objectContaining({
+					modal: true,
+					detail: expect.stringContaining('plan "Stuck plan"'),
+				}),
+			);
+		});
 	});
 	// ── Test 8: result message edge cases ────────────────────────────────────
 

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -78,6 +78,7 @@ import {
 } from "../util/GitRemoteUtils.js";
 import { isWorkerBlockingBusy } from "../util/LockUtils.js";
 import { log } from "../util/Logger.js";
+import { latestPlanPerName } from "../util/PlanGrouping.js";
 import { loadGlobalConfig } from "../util/WorkspaceUtils.js";
 import { BindingChooserWebviewPanel } from "./BindingChooserWebviewPanel.js";
 import { loadBranchSummaries } from "./BranchSummaryLoader.js";
@@ -208,6 +209,14 @@ interface TranscriptEntryUpdate {
 	readonly role: "human" | "assistant";
 	readonly content: string;
 	readonly timestamp?: string;
+}
+
+/** A plan/note that could not be pushed — surfaced to the user, not thrown. */
+interface PushAttachmentFailure {
+	/** Human-readable identifier, e.g. `plan "Fix P1/P2 review findings"`. */
+	readonly label: string;
+	/** Error message (includes the HTTP status from JolliPushService). */
+	readonly message: string;
 }
 
 /** Source of the panel — determines which static slot it occupies. */
@@ -1626,31 +1635,41 @@ export class SummaryWebviewPanel {
 		const repoUrl = await getCanonicalRepoUrl(this.workspaceRoot);
 
 		try {
-			// Step 1: Upload associated plans and notes
-			const planUrls = await this.pushPlans(
-				summary,
-				resolvedBaseUrl,
-				baseUrl,
-				jolliApiKey,
-				repoUrl,
-			);
-			const noteUrls = await this.pushNotes(
-				summary,
-				resolvedBaseUrl,
-				baseUrl,
-				jolliApiKey,
-				repoUrl,
-			);
+			// Step 1: Upload associated plans and notes. Per-attachment failures
+			// are collected (not thrown) so one bad plan/note doesn't abort the
+			// whole push — the summary and the remaining attachments still go up.
+			const { results: planUrls, failures: planFailures } =
+				await this.pushPlans(
+					summary,
+					resolvedBaseUrl,
+					baseUrl,
+					jolliApiKey,
+					repoUrl,
+				);
+			const { results: noteUrls, failures: noteFailures } =
+				await this.pushNotes(
+					summary,
+					resolvedBaseUrl,
+					baseUrl,
+					jolliApiKey,
+					repoUrl,
+				);
+			const attachmentFailures = [...planFailures, ...noteFailures];
 
 			// Step 2: Update plan/note URLs in summary before building markdown
-			// (so the Plans & Notes section in markdown includes the published URLs)
-			const plansWithUrls = applyPlanUrls(summary.plans, planUrls);
+			// (so the Plans & Notes section in markdown includes the published
+			// URLs). Dedupe same-named plan snapshots here too: only the latest
+			// was uploaded, so the pushed article's Plans & Notes list must not
+			// repeat the superseded duplicates. The locally-stored summary below
+			// still keeps every snapshot for the detail view.
+			const dedupedPlans = latestPlanPerName(summary.plans ?? []);
+			const plansWithUrls = applyPlanUrls(dedupedPlans, planUrls) ?? dedupedPlans;
 			const notesWithUrls = summary.notes
 				? applyNoteUrls(summary.notes, noteUrls)
 				: summary.notes;
 			const summaryForMarkdown: CommitSummary = {
 				...summary,
-				...(plansWithUrls !== summary.plans && { plans: plansWithUrls }),
+				plans: plansWithUrls,
 				...(notesWithUrls !== summary.notes && { notes: notesWithUrls }),
 			};
 			const markdown = buildMarkdown(summaryForMarkdown);
@@ -1694,9 +1713,24 @@ export class SummaryWebviewPanel {
 				attachments > 0
 					? ` (with ${attachments} attachment${attachments > 1 ? "s" : ""})`
 					: "";
-			vscode.window.showInformationMessage(
-				`${verb} on Jolli Space${attachMsg}.`,
-			);
+			if (attachmentFailures.length > 0) {
+				// Modal (not a transient toast): a partial failure must be as
+				// visible as the old fail-fast error — the panel otherwise
+				// re-renders to "Synced" and the failure would go unnoticed.
+				vscode.window.showWarningMessage(
+					`${verb} the memory on Jolli Space${attachMsg}, but ${attachmentFailures.length} attachment(s) failed to push.`,
+					{
+						modal: true,
+						detail: attachmentFailures
+							.map((f) => `• ${f.label}: ${f.message}`)
+							.join("\n"),
+					},
+				);
+			} else {
+				vscode.window.showInformationMessage(
+					`${verb} on Jolli Space${attachMsg}.`,
+				);
+			}
 
 			// Clean up orphaned memory articles, then persist which ones were actually deleted
 			const cleanedSummary = await cleanupOrphanedDocs(
@@ -1752,17 +1786,29 @@ export class SummaryWebviewPanel {
 		}
 	}
 
-	/** Uploads associated plans to Jolli and returns their published URLs. */
+	/**
+	 * Uploads associated plans to Jolli and returns their published URLs plus
+	 * any per-plan failures. A single plan's failure (e.g. a server 500 because
+	 * the document already exists) is collected and reported, NOT thrown, so it
+	 * doesn't abort the rest of the memory push. The fatal binding/plugin errors
+	 * still propagate — the outer handler drives the binding chooser off them.
+	 */
 	private async pushPlans(
 		summary: CommitSummary,
 		resolvedBaseUrl: string,
 		baseUrl: string,
 		apiKey: string,
 		repoUrl: string,
-	): Promise<
-		Array<{ slug: string; title: string; url: string; docId: number }>
-	> {
-		const allPlans = summary.plans ?? [];
+	): Promise<{
+		results: Array<{ slug: string; title: string; url: string; docId: number }>;
+		failures: PushAttachmentFailure[];
+	}> {
+		const failures: PushAttachmentFailure[] = [];
+		// Same-named plans accumulate one snapshot per source commit after a
+		// squash (slug embeds the commit hash). Upload only the latest snapshot
+		// per name so Jolli gets one document per plan, not a duplicate per
+		// commit. latestPlanPerName is shared with the detail-panel display.
+		const allPlans = latestPlanPerName(summary.plans ?? []);
 		log.info(
 			"SummaryPanel",
 			`Push to Jolli: found ${allPlans.length} plan(s) to upload`,
@@ -1789,16 +1835,33 @@ export class SummaryWebviewPanel {
 				`Uploading plan ${plan.slug} (${planContent.length} chars)`,
 			);
 
-			const planResult = await pushToJolli(resolvedBaseUrl, apiKey, {
-				title: buildPlanPushTitle(summary, plan.title),
-				content: planContent,
-				commitHash: summary.commitHash,
-				docType: "plan",
-				branch: summary.branch,
-				...(plan.jolliPlanDocId && { docId: plan.jolliPlanDocId }),
-				repoUrl,
-				relativePath: buildBranchRelativePath(summary.branch),
-			});
+			let planResult: Awaited<ReturnType<typeof pushToJolli>>;
+			try {
+				planResult = await pushToJolli(resolvedBaseUrl, apiKey, {
+					title: buildPlanPushTitle(summary, plan.title),
+					content: planContent,
+					commitHash: summary.commitHash,
+					docType: "plan",
+					branch: summary.branch,
+					...(plan.jolliPlanDocId && { docId: plan.jolliPlanDocId }),
+					repoUrl,
+					relativePath: buildBranchRelativePath(summary.branch),
+				});
+			} catch (err) {
+				if (
+					err instanceof BindingRequiredError ||
+					err instanceof PluginOutdatedError
+				) {
+					throw err;
+				}
+				const msg = err instanceof Error ? err.message : String(err);
+				log.error(
+					"SummaryPanel",
+					`Plan ${plan.slug} push FAILED (docId=${plan.jolliPlanDocId ?? "none"}, title="${buildPlanPushTitle(summary, plan.title)}"): ${msg}`,
+				);
+				failures.push({ label: `plan "${plan.title}"`, message: msg });
+				continue;
+			}
 			const planUrl = `${baseUrl}/articles?doc=${planResult.docId}`;
 			log.info(
 				"SummaryPanel",
@@ -1811,17 +1874,24 @@ export class SummaryWebviewPanel {
 				docId: planResult.docId,
 			});
 		}
-		return results;
+		return { results, failures };
 	}
 
-	/** Uploads associated notes to Jolli and returns their published URLs. */
+	/**
+	 * Uploads associated notes to Jolli. Like {@link pushPlans}, a single note's
+	 * failure is collected and reported rather than aborting the whole push.
+	 */
 	private async pushNotes(
 		summary: CommitSummary,
 		resolvedBaseUrl: string,
 		baseUrl: string,
 		apiKey: string,
 		repoUrl: string,
-	): Promise<Array<{ id: string; title: string; url: string; docId: number }>> {
+	): Promise<{
+		results: Array<{ id: string; title: string; url: string; docId: number }>;
+		failures: PushAttachmentFailure[];
+	}> {
+		const failures: PushAttachmentFailure[] = [];
 		const allNotes = summary.notes ?? [];
 		log.info(
 			"SummaryPanel",
@@ -1859,16 +1929,33 @@ export class SummaryWebviewPanel {
 					continue;
 				}
 			}
-			const noteResult = await pushToJolli(resolvedBaseUrl, apiKey, {
-				title: buildNotePushTitle(summary, note.title),
-				content: noteContent,
-				commitHash: summary.commitHash,
-				docType: "note",
-				branch: summary.branch,
-				...(note.jolliNoteDocId && { docId: note.jolliNoteDocId }),
-				repoUrl,
-				relativePath: buildBranchRelativePath(summary.branch),
-			});
+			let noteResult: Awaited<ReturnType<typeof pushToJolli>>;
+			try {
+				noteResult = await pushToJolli(resolvedBaseUrl, apiKey, {
+					title: buildNotePushTitle(summary, note.title),
+					content: noteContent,
+					commitHash: summary.commitHash,
+					docType: "note",
+					branch: summary.branch,
+					...(note.jolliNoteDocId && { docId: note.jolliNoteDocId }),
+					repoUrl,
+					relativePath: buildBranchRelativePath(summary.branch),
+				});
+			} catch (err) {
+				if (
+					err instanceof BindingRequiredError ||
+					err instanceof PluginOutdatedError
+				) {
+					throw err;
+				}
+				const msg = err instanceof Error ? err.message : String(err);
+				log.error(
+					"SummaryPanel",
+					`Note ${note.id} push FAILED (docId=${note.jolliNoteDocId ?? "none"}, title="${buildNotePushTitle(summary, note.title)}"): ${msg}`,
+				);
+				failures.push({ label: `note "${note.title}"`, message: msg });
+				continue;
+			}
 			const noteUrl = `${baseUrl}/articles?doc=${noteResult.docId}`;
 			results.push({
 				id: note.id,
@@ -1877,7 +1964,7 @@ export class SummaryWebviewPanel {
 				docId: noteResult.docId,
 			});
 		}
-		return results;
+		return { results, failures };
 	}
 
 	/** Handles editing a memory at the given global index. */


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Plans & Notes

- Plan: Disambiguate same-named plans (display + push) + show Jolli link in Commit Memory

## Quick recap

Two related push bugs were fixed in this batch of changes. The first addressed duplicate plan uploads after squash merges: the same logical plan accumulated one snapshot per source commit, and pushing would attempt to create a separate Jolli article for each. A new set of grouping helpers now collapses same-named snapshots to the latest before uploading, and inherits any previously-assigned document ID from an older sibling onto the newest snapshot so the server updates the existing article rather than creating a new one. The detail panel also gained visual disambiguation — superseded snapshots are dimmed, the newest carries a "Latest" badge, and every plan shows a relative timestamp.

The second fix addressed how partial push failures were communicated. When one attachment failed but the rest of the push succeeded, the panel re-rendered to "Synced" and only a transient, auto-dismissing notification appeared — easy to miss. Partial failures now raise a modal dialog that must be explicitly dismissed, listing each failed attachment and its error. The push itself still completes as much as possible: a single failing plan no longer blocks the summary article or the remaining attachments from going up.

---

## E2E Test (3)
<details>
<summary><strong>1. Duplicate plan snapshots collapse to one upload after squash merge</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit in the Jolli panel that contains two plans with the same name but different snapshot identifiers (this happens naturally after a squash merge — the same plan appears once per source commit). Make sure a valid Jolli API key is configured.

**Steps:**
1. Open the Jolli summary panel for the squash-merged commit.
2. Scroll to the Plans & Notes section and confirm you can see two entries with the same plan name (they will have slightly different identifiers in the filename shown below each title).
3. Check that the newer of the two entries shows a "Latest" badge next to its title, and the older entry appears dimmed.
4. Click the Push (or Sync) button to upload to Jolli.
5. Wait for the push to complete, then open your Jolli Space in a browser.
6. Check the Plans & Notes list in the published article.

**Expected Results:**
- In the panel, only the newer snapshot has a "Latest" badge; the older one is visibly dimmed (lower opacity).
- After pushing, only one plan document appears in the Jolli Space — not two separate entries for the same plan name.
- The published article's Plans & Notes section lists the plan once, not twice.

</blockquote>
</details>
<details>
<summary><strong>2. Superseded plan snapshots show relative date and are visually dimmed</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit summary with at least two plans that share the same name (same-named snapshots from a squash merge).

**Steps:**
1. Open the Jolli summary panel for the relevant commit.
2. Scroll to the Plans & Notes section.
3. Look at the plan entries that share a name.
4. Check the visual appearance of each entry and the information shown next to the action buttons.

**Expected Results:**
- Each plan entry displays a relative date (e.g. "3 days ago") near the action buttons.
- The newest snapshot of a duplicated name shows a "Latest" badge next to the plan title.
- The older snapshot(s) of the same name appear dimmed/faded compared to the newest one.
- A plan that has no same-named siblings shows neither a "Latest" badge nor any dimming.

</blockquote>
</details>
<details>
<summary><strong>3. Partial push failure shows a modal warning instead of a silent toast</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a commit summary with at least one plan attached. Arrange for the plan upload to fail — for example, by temporarily using an invalid or expired Jolli API key, or by having the server reject the specific plan document.

**Steps:**
1. Open the Jolli summary panel for a commit that has one or more plans.
2. Click the Push (or Sync) button.
3. Wait for the push to finish.
4. Observe any notifications or dialogs that appear.

**Expected Results:**
- A modal warning dialog appears (it blocks the screen and requires you to dismiss it — it does not auto-disappear).
- The dialog message mentions that one or more attachments failed.
- The detail text inside the dialog names the specific plan (e.g. "plan "My Plan Name"") and includes an error description with an HTTP status code (e.g. "HTTP 500").
- The overall summary still uploads successfully — the push is not fully aborted by the single plan failure.
- After dismissing the dialog, the panel reflects that the summary was synced even though the plan attachment failed.

</blockquote>
</details>

---

## Topics (2)
<details>
<summary><strong>01 · Prevent duplicate plan uploads when multiple snapshots share the same name</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After a squash merge, the same logical plan appeared multiple times in the summary — once per source commit — each with a slightly different identifier. Pushing to Jolli would attempt to create a separate document for each snapshot, causing duplicate articles or server errors.

**💡 Decisions Behind the Code**

- **Shared grouping logic, not two separate implementations**: The same `planBaseKey` / `annotatePlans` / `latestPlanPerName` helpers are used by both the detail-panel display and the push path. Keeping them in one place ensures the two never drift — if the display shows N plans and the push uploads a different N, users would see confusing mismatches between what the panel shows and what lands on Jolli.
- **Inherit the older snapshot's document ID onto the latest**: When an older snapshot was already pushed (it carries a Jolli document ID) but the newest snapshot was not, the latest inherits that ID before being uploaded. This makes the server treat the upload as an update to the existing article rather than a new creation. The alternative — always creating a new document — would produce duplicate articles and the server would eventually reject the push with a conflict error.
- **Show superseded snapshots in the panel rather than hiding them**: Older snapshots are dimmed and labelled rather than removed from the detail view. This preserves the full history for the user while making it visually clear which version is current. Hiding them entirely would silently discard information the user may want to inspect or remove.

**✅ What Was Implemented**

- Created `vscode/src/util/PlanGrouping.ts` with three exported helpers: `planBaseKey` (strips the 8-hex commit-hash suffix from a plan slug), `annotatePlans` (sorts plans newest-first and flags the latest snapshot of each same-named group), and `latestPlanPerName` (returns one plan per base name — the latest — and inherits any previously-pushed document ID from an older sibling so the push updates rather than creates). Full unit coverage added in `PlanGrouping.test.ts`.
- In `SummaryWebviewPanel.ts`, `pushPlans` now calls `latestPlanPerName` before iterating, so only one upload is issued per logical plan name. The markdown built for the Jolli article also uses the deduplicated list, keeping the Plans & Notes section clean.
- In `SummaryHtmlBuilder.ts`, `buildPlansAndNotesSection` now calls `annotatePlans` to sort and annotate the list; superseded snapshots are rendered dimmed with a `plan-older` CSS class, the newest of a multi-snapshot group gets a "Latest" badge, and every item shows a relative date. `buildJolliRow` deduplicates plan/note URLs so the ship card never lists the same Jolli document twice.

**📁 FILES**
- `vscode/src/util/PlanGrouping.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`
- `vscode/src/views/SummaryHtmlBuilder.ts`
- `vscode/src/views/SummaryCssBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Make partial push failures visible with a modal warning instead of a silent toast</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the push was made resilient (individual attachment failures no longer abort the whole operation), a partial failure still caused the panel to show "Synced" in green. The only signal was a transient toast notification that auto-dismissed — easy to miss, and far less prominent than the hard error the old fail-fast approach produced.

**💡 Decisions Behind the Code**

- **Modal dialog over transient toast for partial failures**: A partial failure leaves the panel in a "Synced" state, so a dismissable toast is too easy to overlook. A modal dialog matches the prominence of the old fail-fast error and forces acknowledgement. The trade-off is a slightly more disruptive UX on partial failure, but that disruption is intentional — the user needs to know something didn't land.
- **Collect failures rather than abort on first error**: Stopping at the first failed attachment would leave the summary article unpushed if a plan fails early. Collecting failures and continuing means the memory article always goes up as long as the main push succeeds, and the user gets a complete picture of what failed rather than having to retry and discover the next failure.

**✅ What Was Implemented**

- In `SummaryWebviewPanel.ts`, `pushPlans` and `pushNotes` now catch per-attachment errors internally, collect them into a `PushAttachmentFailure` list, and return both the successful results and the failures. Fatal binding/plugin errors are still re-thrown so the binding chooser flow is unaffected.
- When any attachment failures are collected after the push completes, `vscode.window.showWarningMessage` is called with `{ modal: true }` and a `detail` string listing each failed item and its error message. Full success continues to use the quiet info toast.
- In `JolliPushService.ts`, the HTTP error message now includes both `json.error` and `json.message` joined with an em-dash, plus the HTTP status code in parentheses (e.g. `precondition_failed (HTTP 412)`), giving the modal's detail line enough context to be actionable.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.ts`
- `vscode/src/services/JolliPushService.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 23, 2026 at 5:04 PM · via Anthropic*
<!-- jollimemory-summary-end -->