### PR TITLE
Part of #226: Replace findBranchCreationPoint with resolveMergedHistory to skip branches with no own commits

### DIFF
--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -3996,7 +3996,7 @@ describe("JolliMemoryBridge", () => {
 			expect(result.commits[0].deletions).toBe(0);
 		});
 
-		it("uses findBranchCreationPoint 'Created from' entry when branch is merged", async () => {
+		it("uses resolveMergedHistory 'Created from' entry as the base when branch is merged", async () => {
 			// getCurrentBranch
 			mockExecFileSuccess("feature/merged\n");
 			// resolveHistoryBaseRef: refExists for origin/main
@@ -4005,7 +4005,7 @@ describe("JolliMemoryBridge", () => {
 			mockExecFileSuccess("mergebase456\n");
 			// merge-base — equals HEAD, triggers merged mode
 			mockExecFileSuccess("mergebase456\n");
-			// findBranchCreationPoint: reflog show
+			// resolveMergedHistory: reflog has own commits + explicit "Created from"
 			mockExecFileSuccess(
 				"ccc333 commit: third commit\nbbb222 commit: second commit\naaa111 branch: Created from main\n",
 			);
@@ -4030,7 +4030,7 @@ describe("JolliMemoryBridge", () => {
 			expect(result.commits[0].hash).toBe("commitHash1");
 		});
 
-		it("uses findBranchCreationPoint oldest entry fallback when no 'Created from'", async () => {
+		it("uses resolveMergedHistory oldest-entry base fallback when reflog has no 'Created from'", async () => {
 			// getCurrentBranch
 			mockExecFileSuccess("feature/merged\n");
 			// resolveHistoryBaseRef: refExists for origin/main
@@ -4039,7 +4039,7 @@ describe("JolliMemoryBridge", () => {
 			mockExecFileSuccess("mergebase456\n");
 			// merge-base
 			mockExecFileSuccess("mergebase456\n");
-			// findBranchCreationPoint: reflog without "Created from"
+			// resolveMergedHistory: own commits but no "Created from" → base = oldest entry
 			mockExecFileSuccess(
 				"ccc333 commit: third\nbbb222 commit: second\naaa111 commit: first\n",
 			);
@@ -4061,6 +4061,45 @@ describe("JolliMemoryBridge", () => {
 
 			expect(result.isMerged).toBe(true);
 			expect(result.commits).toHaveLength(1);
+			// Base must be the oldest reflog entry (aaa111), not a guessed merge-base.
+			const logCall = execFileMock.mock.calls.find(
+				(c) => Array.isArray(c[1]) && c[1].includes("aaa111..HEAD"),
+			);
+			expect(logCall).toBeDefined();
+		});
+
+		it("treats an amend-only merged branch as having own work (the 'amend when no commit' case)", async () => {
+			// A branch whose only own work is an amended commit: the reflog op is
+			// `commit (amend):`, never a plain `commit:`. hasOwnCommit must still be
+			// true (the `\b` after "commit" matches the "(amend)" variant), so the
+			// merged history is listed rather than emptied.
+			mockExecFileSuccess("feature/amended\n"); // getCurrentBranch
+			mockExecFileSuccess("abc\n"); // resolveHistoryBaseRef → origin/main
+			mockExecFileSuccess("mergebase456\n"); // getHEADHash
+			mockExecFileSuccess("mergebase456\n"); // merge-base == HEAD → merged mode
+			// resolveMergedHistory: amend + initial ops, explicit "Created from"
+			mockExecFileSuccess(
+				"ddd444 commit (amend): reworded\n" +
+					"ccc333 commit (initial): first\n" +
+					"aaa111 branch: Created from main\n",
+			);
+			mockExecFileSuccess("Amy Mender\n"); // getCurrentUserName
+			const logEntry = `commitHash9\x00fix: amended change\x00Amy Mender\x00amy@example.com\x002026-06-23T10:00:00Z\x00\x00\n`;
+			mockExecFileSuccess(logEntry); // git log --author
+
+			getIndexEntryMap.mockResolvedValue(new Map());
+			getDiffStats.mockResolvedValueOnce({
+				filesChanged: 1,
+				insertions: 3,
+				deletions: 1,
+			});
+
+			const bridge = makeBridge();
+			const result = await bridge.listBranchCommits("main");
+
+			expect(result.isMerged).toBe(true);
+			expect(result.commits).toHaveLength(1);
+			expect(result.commits[0].hash).toBe("commitHash9");
 		});
 
 		it("includes commitType when summary has non-'commit' type (e.g. amend, squash)", async () => {
@@ -4118,8 +4157,11 @@ describe("JolliMemoryBridge", () => {
 			mockExecFileSuccess("mergebase456\n");
 			// merge-base
 			mockExecFileSuccess("mergebase456\n");
-			// findBranchCreationPoint: valid reflog
-			mockExecFileSuccess("aaa111 branch: Created from main\n");
+			// resolveMergedHistory: reflog has an own commit → has own work, so it
+			// proceeds to getCurrentUserName (rather than short-circuiting empty).
+			mockExecFileSuccess(
+				"bbb222 commit: own work\naaa111 branch: Created from main\n",
+			);
 			// getCurrentUserName — returns empty string (git config not set)
 			mockExecFileError("no user.name set");
 
@@ -4130,7 +4172,7 @@ describe("JolliMemoryBridge", () => {
 			expect(result.isMerged).toBe(false);
 		});
 
-		it("returns empty when findBranchCreationPoint gets empty reflog (merged branch)", async () => {
+		it("returns empty when resolveMergedHistory gets empty reflog (merged branch)", async () => {
 			// getCurrentBranch
 			mockExecFileSuccess("feature/merged\n");
 			// resolveHistoryBaseRef: refExists for origin/main
@@ -4139,8 +4181,48 @@ describe("JolliMemoryBridge", () => {
 			mockExecFileSuccess("mergebase456\n");
 			// merge-base
 			mockExecFileSuccess("mergebase456\n");
-			// findBranchCreationPoint: empty reflog
+			// resolveMergedHistory: empty reflog → undefined → empty panel
 			mockExecFileError("no reflog");
+
+			const bridge = makeBridge();
+			const result = await bridge.listBranchCommits("main");
+
+			expect(result.commits).toEqual([]);
+			expect(result.isMerged).toBe(false);
+		});
+
+		it("returns empty for a merged branch that never committed its own work (created-from-main + rebase sync)", async () => {
+			// The #226 regression case: branch created from main, then `git rebase
+			// main` after one of *your own* commits had merged into main. HEAD is now
+			// main's tip (fully contained in main), the branch has zero own commits,
+			// yet the rebased-in commit is authored by you. It must NOT be listed —
+			// it belongs to main, not to this branch.
+			// X0000000 / M0000000 are opaque sentinels (the test only cares that the
+			// reflog has no `commit` op, not their hex-ness).
+			mockExecFileSuccess("fix/synced-to-main\n"); // getCurrentBranch
+			mockExecFileSuccess("abc\n"); // resolveHistoryBaseRef → origin/main
+			mockExecFileSuccess("X0000000\n"); // getHEADHash (HEAD = X = origin/main tip)
+			mockExecFileSuccess("X0000000\n"); // merge-base == HEAD → merged mode
+			// resolveMergedHistory: reflog has only creation + rebase, no `commit:` op.
+			mockExecFileSuccess(
+				"X0000000 rebase (finish): refs/heads/fix/synced-to-main onto X0000000\n" +
+					"M0000000 branch: Created from main\n",
+			);
+
+			const bridge = makeBridge();
+			const result = await bridge.listBranchCommits("main");
+
+			// No own commits → empty panel, and never reaches getCurrentUserName/log.
+			expect(result.commits).toEqual([]);
+			expect(result.isMerged).toBe(false);
+		});
+
+		it("returns empty for a merged detached HEAD (no branch reflog)", async () => {
+			mockExecFileSuccess("HEAD\n"); // getCurrentBranch → detached
+			mockExecFileSuccess("abc\n"); // resolveHistoryBaseRef → origin/main
+			mockExecFileSuccess("deadbeef\n"); // getHEADHash
+			mockExecFileSuccess("deadbeef\n"); // merge-base == HEAD → merged mode
+			// resolveMergedHistory bails out for "HEAD" before any reflog read.
 
 			const bridge = makeBridge();
 			const result = await bridge.listBranchCommits("main");

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -960,9 +960,22 @@ export class JolliMemoryBridge {
 		let authorFilter: string | undefined;
 
 		if (mergeBase === headHash) {
-			// Branch is fully merged into main — attempt merged mode
-			const creationPoint = await this.findBranchCreationPoint(branch);
-			if (!creationPoint) {
+			// Branch is fully merged into main — attempt merged mode.
+			const merged = await this.resolveMergedHistory(branch);
+			if (!merged) {
+				return emptyResult;
+			}
+
+			// A branch whose HEAD is fully contained in main but that never
+			// committed anything of its own (only "Created from main" + a
+			// rebase/reset onto main, i.e. a routine `git rebase main` sync) must
+			// show an empty panel: those commits belong to main, not to this
+			// branch. Without this guard, a sync that pulls in your *own*
+			// already-merged commit re-lists that commit here, because it passes
+			// the `--author` filter below. Git's ancestry can't tell this apart
+			// from a branch whose own work was merged (both have HEAD ⊆ main) —
+			// only the reflog records which branch actually authored the commits.
+			if (!merged.hasOwnCommit) {
 				return emptyResult;
 			}
 
@@ -971,11 +984,11 @@ export class JolliMemoryBridge {
 				return emptyResult;
 			}
 
-			mergeBase = creationPoint;
+			mergeBase = merged.base;
 			isMerged = true;
 			log.info("bridge", "Merged mode activated", {
 				branch,
-				creationPoint: creationPoint.substring(0, 8),
+				creationPoint: merged.base.substring(0, 8),
 				author: authorFilter,
 			});
 		} else {
@@ -1215,6 +1228,80 @@ export class JolliMemoryBridge {
 		}
 		const oldest = lines[lines.length - 1];
 		return oldest.split(" ")[0];
+	}
+
+	/**
+	 * Reads the branch reflog once and resolves what the merged-mode history view
+	 * needs: the log-range base (where the branch was created), and whether the
+	 * branch ever committed anything of its own.
+	 *
+	 * `hasOwnCommit` is the key signal. When a branch's HEAD is fully contained in
+	 * `main`, two very different situations look identical to git's ancestry:
+	 *
+	 *  1. the branch's *own* commits were merged into main (show them, read-only);
+	 *  2. the branch never committed anything — it was created from main and then
+	 *     `git rebase main`'d (a routine sync), so its HEAD is just main's tip.
+	 *
+	 * Only the reflog distinguishes them: case 1 has a `commit` op, case 2 has
+	 * only `branch: Created …` + `rebase`/`reset` ops. Telling them apart matters
+	 * because in case 2 a sync that replays your *own* already-merged commit would
+	 * otherwise re-surface it in the panel (it passes the merged-mode `--author`
+	 * filter), even though that commit belongs to main, not to this branch.
+	 *
+	 * `hasOwnCommit` keys on a `commit` reflog op specifically — not `merge` or
+	 * `cherry-pick`. For a fully-merged branch those land in main via the branch's
+	 * own `commit` ops (or the PR merge), so a branch whose only trace is a local
+	 * merge/cherry-pick of work already in main is correctly the empty case. Two
+	 * residual limitations are accepted (both rare, and the `--author` + fork-point
+	 * range bounds the blast radius): a branch that committed and then
+	 * `reset --hard` away its own work still reads as "has own commit" (the
+	 * historical `commit` op survives in the reflog); and a fully-expired reflog
+	 * degrades to the empty panel below.
+	 *
+	 * Returns `undefined` (→ caller shows an empty panel) for detached HEAD or when
+	 * the reflog is unavailable/expired — the same graceful-degradation boundary
+	 * `findBranchCreationPoint` uses.
+	 */
+	private async resolveMergedHistory(
+		branch: string,
+	): Promise<{ base: string; hasOwnCommit: boolean } | undefined> {
+		// Detached HEAD has no branch reflog of its own (see findBranchCreationPoint).
+		if (branch === "HEAD") {
+			return;
+		}
+		const reflog = await tryExecGit(
+			["reflog", "show", branch, "--format=%H %gs"],
+			this.cwd,
+		);
+		if (!reflog.trim()) {
+			return;
+		}
+
+		const lines = reflog.split("\n").filter(Boolean);
+
+		// Base: the explicit "branch: Created from …" entry if present (scan from
+		// oldest), else the oldest surviving entry — same best-effort fallback the
+		// non-strict findBranchCreationPoint uses for the merged-mode view.
+		let base: string | undefined;
+		for (let i = lines.length - 1; i >= 0; i--) {
+			if (lines[i].includes("branch: Created from")) {
+				base = lines[i].split(" ")[0];
+				break;
+			}
+		}
+		if (!base) {
+			base = lines[lines.length - 1].split(" ")[0];
+		}
+
+		// Own commit = a `commit` reflog op ("commit:", "commit (amend):",
+		// "commit (initial):"). A branch showing only creation + rebase/reset/
+		// checkout never authored anything itself. The subject follows the leading
+		// "<hash> " from the --format above.
+		const hasOwnCommit = lines.some((line) =>
+			/^[0-9a-f]+ commit\b/.test(line),
+		);
+
+		return { base, hasOwnCommit };
 	}
 
 	/** True when `ancestor` is an ancestor of (or equal to) `descendant`. */


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The branch history panel now correctly handles branches that were created from main and later synced back to main's tip via rebase. Previously, a developer's own commit that had already merged into main could reappear in the panel after a routine sync, making it look like unfinished branch work. The panel now stays empty for those branches, showing only commits that were genuinely authored on the branch itself.

The fix works by inspecting the branch's reflog for evidence of actual commit activity. Branches that show only creation and rebase entries — with no commit operations of their own — are treated as having no original work, and the panel returns nothing. Amend-only branches are handled correctly: amended commits still count as own work and continue to appear as expected.

---

## Topic (1)
<details>
<summary><strong>01 · Detect branches with no own commits to avoid re-listing merged work</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A branch created from main and then synced via rebase would sometimes show commits in the history panel that actually belonged to main, not to the branch itself. This happened when a developer's own previously-merged commit was replayed onto the branch during the sync, causing it to pass the author filter and appear as branch work.

**💡 Decisions Behind the Code**

- **Reflog as the source of truth for branch authorship**: Git's ancestry graph cannot distinguish a branch whose own commits were merged into main from a branch that was merely rebased onto main's tip — both result in HEAD being fully contained in main. The reflog is the only record that shows whether the branch itself ever ran a `commit` operation. Using the reflog for this check means the detection is accurate for the common case without requiring any additional git queries beyond what the merged-mode path already needed.
- **Keying on the `commit` reflog op rather than commit count**: Checking for a `commit` op in the reflog (rather than counting commits in the log range) avoids a chicken-and-egg problem: the log range base is what we are trying to determine, so we cannot use the range to decide whether to proceed. The reflog op approach also correctly handles amend-only branches, where `commit (amend):` and `commit (initial):` both match the `commit\b` pattern, ensuring amended work is not incorrectly treated as absent.
- **Accepted residual limitations**: A branch that committed work and then hard-reset it away still reads as having own commits, and a fully expired reflog degrades to an empty panel. Both edge cases were accepted as low-frequency and bounded in blast radius by the existing author filter and fork-point range, matching the graceful-degradation contract already established by the method being replaced.

**✅ What Was Implemented**

- Replaced `findBranchCreationPoint` with a new `resolveMergedHistory` method in `JolliMemoryBridge.ts`. The new method reads the branch reflog once and returns both the log-range base (where the branch was created) and a `hasOwnCommit` boolean. The boolean is true only when the reflog contains a `commit` operation (including amend and initial variants), distinguishing branches that authored work from those that only have creation and rebase/reset entries.
- Added a guard in the merged-mode path of `listBranchCommits` that returns an empty panel when `hasOwnCommit` is false. This prevents a post-rebase sync branch — whose HEAD is fully contained in main but whose commits were never authored on that branch — from surfacing those commits in the panel.
- Extended the test suite in `JolliMemoryBridge.test.ts` with four new cases: amend-only branches (must show as having own work), synced-to-main branches with no commit ops (must return empty), detached HEAD in merged mode (must return empty), and a regression guard for the oldest-entry fallback path verifying the correct range base is used.

**📁 FILES**
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 23, 2026 at 5:37 PM · via Anthropic*
<!-- jollimemory-summary-end -->