### PR TITLE
Fix Create PR to allow renamed branches via CreatePrBranchClassifier

### DIFF
--- a/vscode/src/services/CreatePrBranchClassifier.test.ts
+++ b/vscode/src/services/CreatePrBranchClassifier.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockOrphanBranchExists, mockIsAncestor } = vi.hoisted(() => ({
+	mockOrphanBranchExists: vi.fn(),
+	mockIsAncestor: vi.fn(),
+}));
+
+vi.mock("../../../cli/src/core/GitOps.js", async (importActual) => {
+	const actual =
+		await importActual<typeof import("../../../cli/src/core/GitOps.js")>();
+	return {
+		...actual,
+		orphanBranchExists: mockOrphanBranchExists,
+		isAncestor: mockIsAncestor,
+	};
+});
+
+import {
+	type CreatePrBranchDecision,
+	classifyCreatePrBranch,
+	createPrBlockMessage,
+	effectiveBranchFor,
+} from "./CreatePrBranchClassifier.js";
+
+const CWD = "/repo";
+
+describe("classifyCreatePrBranch", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockOrphanBranchExists.mockResolvedValue(false);
+		mockIsAncestor.mockResolvedValue(false);
+	});
+
+	it("no summary branch → ok, scoped to the current branch", async () => {
+		const d = await classifyCreatePrBranch(undefined, "main", "abc", CWD);
+		expect(d).toEqual({ kind: "ok", effectiveBranch: "main" });
+		expect(mockOrphanBranchExists).not.toHaveBeenCalled();
+	});
+
+	it("current branch is the HEAD sentinel → detachedHead", async () => {
+		const d = await classifyCreatePrBranch("feat", "HEAD", "abc", CWD);
+		expect(d).toEqual({ kind: "detachedHead" });
+		expect(mockOrphanBranchExists).not.toHaveBeenCalled();
+	});
+
+	it("summary branch equals current branch → ok, no git probes", async () => {
+		const d = await classifyCreatePrBranch("feat", "feat", "abc", CWD);
+		expect(d).toEqual({ kind: "ok", effectiveBranch: "feat" });
+		expect(mockOrphanBranchExists).not.toHaveBeenCalled();
+		expect(mockIsAncestor).not.toHaveBeenCalled();
+	});
+
+	it("mismatch + old ref still exists → crossBranch", async () => {
+		mockOrphanBranchExists.mockResolvedValue(true);
+		const d = await classifyCreatePrBranch("feat", "other", "abc", CWD);
+		expect(d).toEqual({ kind: "crossBranch", summaryBranch: "feat" });
+		expect(mockOrphanBranchExists).toHaveBeenCalledWith("feat", CWD);
+		// Containment is irrelevant once the old ref exists.
+		expect(mockIsAncestor).not.toHaveBeenCalled();
+	});
+
+	it("mismatch + old ref gone + current contains the commit → okAsCurrent (rename / successor)", async () => {
+		mockOrphanBranchExists.mockResolvedValue(false);
+		mockIsAncestor.mockResolvedValue(true);
+		const d = await classifyCreatePrBranch("old", "new", "abc", CWD);
+		expect(d).toEqual({ kind: "okAsCurrent", effectiveBranch: "new" });
+		expect(mockIsAncestor).toHaveBeenCalledWith("abc", "HEAD", CWD);
+	});
+
+	it("mismatch + old ref gone + current does NOT contain the commit → originalGone (deleted+unrelated, or rename+rebase)", async () => {
+		mockOrphanBranchExists.mockResolvedValue(false);
+		mockIsAncestor.mockResolvedValue(false);
+		const d = await classifyCreatePrBranch("old", "new", "abc", CWD);
+		expect(d).toEqual({ kind: "originalGone", summaryBranch: "old" });
+	});
+
+	it("mismatch + old ref gone + no commit hash → originalGone without probing ancestry", async () => {
+		mockOrphanBranchExists.mockResolvedValue(false);
+		const d = await classifyCreatePrBranch("old", "new", undefined, CWD);
+		expect(d).toEqual({ kind: "originalGone", summaryBranch: "old" });
+		expect(mockIsAncestor).not.toHaveBeenCalled();
+	});
+});
+
+describe("createPrBlockMessage", () => {
+	it("detachedHead → distinct 'cannot determine' message (never 'Checkout HEAD')", () => {
+		const msg = createPrBlockMessage({ kind: "detachedHead" }, "feat");
+		expect(msg).toContain("Cannot determine the current branch");
+		expect(msg).toContain("feat");
+		expect(msg).not.toContain("Checkout HEAD");
+	});
+
+	it("detachedHead with no summary branch → omits the branch clause", () => {
+		const msg = createPrBlockMessage({ kind: "detachedHead" }, undefined);
+		expect(msg).toContain("Cannot determine the current branch");
+		expect(msg).not.toContain("for ");
+	});
+
+	it("crossBranch → asks the user to checkout the summary's branch", () => {
+		const msg = createPrBlockMessage(
+			{ kind: "crossBranch", summaryBranch: "feat" },
+			"feat",
+		);
+		expect(msg).toBe(
+			"This summary is on branch feat. Checkout feat to create its PR.",
+		);
+	});
+
+	it("originalGone → explains the branch is gone and the commit isn't on the current branch", () => {
+		const msg = createPrBlockMessage(
+			{ kind: "originalGone", summaryBranch: "old" },
+			"old",
+		);
+		expect(msg).toContain("no longer exists");
+		expect(msg).toContain("old");
+	});
+
+	it("ok / okAsCurrent → no block message", () => {
+		expect(
+			createPrBlockMessage({ kind: "ok", effectiveBranch: "feat" }, "feat"),
+		).toBeNull();
+		expect(
+			createPrBlockMessage(
+				{ kind: "okAsCurrent", effectiveBranch: "new" },
+				"old",
+			),
+		).toBeNull();
+	});
+});
+
+describe("effectiveBranchFor", () => {
+	it("ok / okAsCurrent → the decision's effective branch", () => {
+		expect(
+			effectiveBranchFor({ kind: "ok", effectiveBranch: "feat" }, "feat"),
+		).toBe("feat");
+		expect(
+			effectiveBranchFor(
+				{ kind: "okAsCurrent", effectiveBranch: "new" },
+				"old",
+			),
+		).toBe("new");
+	});
+
+	it("blocked / cross-branch kinds → fall back to the summary branch", () => {
+		const kinds: CreatePrBranchDecision[] = [
+			{ kind: "detachedHead" },
+			{ kind: "crossBranch", summaryBranch: "feat" },
+			{ kind: "originalGone", summaryBranch: "old" },
+		];
+		for (const d of kinds) {
+			expect(effectiveBranchFor(d, "summary")).toBe("summary");
+		}
+	});
+});

--- a/vscode/src/services/CreatePrBranchClassifier.ts
+++ b/vscode/src/services/CreatePrBranchClassifier.ts
@@ -1,0 +1,125 @@
+import { isAncestor, orphanBranchExists } from "../../../cli/src/core/GitOps.js";
+
+/**
+ * Decision for whether a "Create PR" action may proceed for a given summary,
+ * and which branch the PR should be scoped to.
+ *
+ * Background: a summary records the branch it was created on (`summary.branch`),
+ * captured once at commit time and never refreshed. A `git branch -m` (rename)
+ * or `git branch -D` (delete) makes that stored name stale while the actual work
+ * lives on the current branch. The old equality guard (`summary.branch !==
+ * currentBranch`) could not tell a genuine cross-branch view ("the summary's
+ * branch still exists, you're just looking at it from another branch") apart
+ * from a rename/delete ("the old branch no longer exists; the current branch is
+ * where the work is"), so it blocked the rename case with a dead-end "Checkout
+ * <old> to create its PR" message even though `<old>` was gone.
+ *
+ * The distinguishing signal is whether the summary's branch still exists as a
+ * local ref: `branch -m` / `-D` delete the old ref; `git checkout` elsewhere
+ * does not. When the old ref is gone we additionally require the current branch
+ * to actually contain the summary's commit before attributing the PR to it.
+ */
+export type CreatePrBranchDecision =
+	/** `summary.branch === currentBranch`, or no summary branch context. */
+	| { kind: "ok"; effectiveBranch: string }
+	/** Old ref is gone and the current branch contains the commit (rename / delete-to-successor). */
+	| { kind: "okAsCurrent"; effectiveBranch: string }
+	/** Current branch could not be determined (detached HEAD or git error, normalized to "HEAD"). */
+	| { kind: "detachedHead" }
+	/** `summary.branch !== currentBranch` and the old ref still exists (genuine cross-branch view). */
+	| { kind: "crossBranch"; summaryBranch: string }
+	/** Old ref is gone and the commit is not on the current branch (deleted + unrelated, or rename+rebase). */
+	| { kind: "originalGone"; summaryBranch: string };
+
+/**
+ * Classifies a Create-PR request. Pure given its inputs (delegates only to the
+ * read-only git helpers `orphanBranchExists` + `isAncestor`).
+ *
+ * `currentBranch` must already be normalized by the caller: the literal sentinel
+ * `"HEAD"` signals "could not determine the branch" (detached HEAD or a git
+ * error). `commitHash` is the summary's commit; when absent the rename path
+ * cannot be verified and the request degrades to `originalGone`.
+ */
+export async function classifyCreatePrBranch(
+	summaryBranch: string | undefined,
+	currentBranch: string,
+	commitHash: string | undefined,
+	cwd: string,
+): Promise<CreatePrBranchDecision> {
+	// No summary branch context: fall back to current-branch behavior (allowed).
+	if (!summaryBranch) {
+		return { kind: "ok", effectiveBranch: currentBranch };
+	}
+	// Cannot determine the current branch. Telling the user to checkout a branch
+	// here is wrong — the repo is in a transient bad state, not on a different
+	// branch.
+	if (currentBranch === "HEAD") {
+		return { kind: "detachedHead" };
+	}
+	if (summaryBranch === currentBranch) {
+		return { kind: "ok", effectiveBranch: summaryBranch };
+	}
+	// Mismatch. The old ref still existing means a genuine cross-branch view —
+	// block so we never push the current branch's HEAD onto another branch's PR.
+	// (`orphanBranchExists` is a generic `git rev-parse --verify refs/heads/<b>`
+	// local-ref check despite its name — it is not specific to the orphan branch.)
+	if (await orphanBranchExists(summaryBranch, cwd)) {
+		return { kind: "crossBranch", summaryBranch };
+	}
+	// Old ref is gone (renamed or deleted). Allow only when the current branch
+	// actually contains this summary's commit — that proves the work is on the
+	// branch we'll push. Without it (rename + rebase that rewrote the hash, or a
+	// switch to an unrelated branch) we can't safely attribute the PR.
+	if (commitHash && (await isAncestor(commitHash, "HEAD", cwd))) {
+		return { kind: "okAsCurrent", effectiveBranch: currentBranch };
+	}
+	return { kind: "originalGone", summaryBranch };
+}
+
+/**
+ * The detached-HEAD / git-error warning. Extracted so both guard sites (the
+ * panel's prepare step and the service's submit-time second line) emit the
+ * identical wording without going through the nullable {@link createPrBlockMessage}.
+ */
+export function detachedHeadMessage(summaryBranch: string | undefined): string {
+	return `Cannot determine the current branch (detached HEAD or git error). Resolve the repository state, then retry creating the PR${
+		summaryBranch ? ` for ${summaryBranch}` : ""
+	}.`;
+}
+
+/**
+ * The user-facing warning for a blocking decision, or `null` when the request
+ * may proceed (`ok` / `okAsCurrent`). Shared by both guard sites so the wording
+ * stays identical.
+ */
+export function createPrBlockMessage(
+	decision: CreatePrBranchDecision,
+	summaryBranch: string | undefined,
+): string | null {
+	switch (decision.kind) {
+		case "detachedHead":
+			return detachedHeadMessage(summaryBranch);
+		case "crossBranch":
+			return `This summary is on branch ${decision.summaryBranch}. Checkout ${decision.summaryBranch} to create its PR.`;
+		case "originalGone":
+			return `The branch this summary was created on (${decision.summaryBranch}) no longer exists, and its commit is not on the current branch — there is no branch to create a PR from.`;
+		default:
+			return null;
+	}
+}
+
+/**
+ * The branch a Create/Update PR flow should be scoped to once classified:
+ * `currentBranch` for the rename/successor case, otherwise the summary's own
+ * branch (cross-branch views keep showing the summary's branch; blocked cases
+ * never reach a scoped operation).
+ */
+export function effectiveBranchFor(
+	decision: CreatePrBranchDecision,
+	summaryBranch: string | undefined,
+): string | undefined {
+	if (decision.kind === "ok" || decision.kind === "okAsCurrent") {
+		return decision.effectiveBranch;
+	}
+	return summaryBranch;
+}

--- a/vscode/src/services/PrCommentService.test.ts
+++ b/vscode/src/services/PrCommentService.test.ts
@@ -1598,6 +1598,9 @@ describe("PrCommentService", () => {
 				if (cmd === "git" && args[0] === "push") {
 					throw new Error("push denied");
 				}
+				if (cmd === "git" && args[0] === "rev-parse") {
+					return { stdout: "branch\n" };
+				}
 				return { stdout: "" };
 			});
 
@@ -1615,6 +1618,9 @@ describe("PrCommentService", () => {
 			setupExecFile((cmd, args) => {
 				if (cmd === "git" && args[0] === "push") {
 					throw "string-only rejection";
+				}
+				if (cmd === "git" && args[0] === "rev-parse") {
+					return { stdout: "branch\n" };
 				}
 				return { stdout: "" };
 			});
@@ -1663,14 +1669,16 @@ describe("PrCommentService", () => {
 			expect(uriParse).toHaveBeenCalledWith(prUrl);
 		});
 
-		// ── Cross-branch guard (Memory Bank) ─────────────────────────────────
+		// ── Submit-time branch guard (TOCTOU second line) ────────────────────
 		//
-		// When the user is viewing a summary on branch X while checked out on
-		// branch Y, `git push -u origin HEAD` would push Y's commits to X's PR
-		// — silently wrong. The service-side guard must reject before any
-		// push/create runs.
+		// The panel decides the effective branch when the form opens and passes
+		// it as `expectedBranch`. `git push -u origin HEAD` pushes whatever is
+		// checked out at submit, so if the user switched branches between
+		// opening and submitting (e.g. away from the summary's branch), the
+		// service must reject before any push/create — never push a different
+		// branch's HEAD onto this PR.
 
-		it("cross-branch: rejects with prCreateBlockedCrossBranch and skips push/create when summaryBranch differs from currentBranch", async () => {
+		it("branch changed since prepare: rejects with prCreateBlockedCrossBranch and skips push/create when expectedBranch differs from currentBranch", async () => {
 			let gitPushCalled = false;
 			let prCreateCalled = false;
 			setupExecFile(
@@ -1743,6 +1751,88 @@ describe("PrCommentService", () => {
 			expect(postMessage).toHaveBeenCalledWith({ command: "prCreating" });
 			expect(postMessage).not.toHaveBeenCalledWith(
 				expect.objectContaining({ command: "prCreateBlockedCrossBranch" }),
+			);
+		});
+
+		it("detached HEAD: blocks with the shared 'cannot determine the current branch' message, not prCreateFailed", async () => {
+			let gitPushCalled = false;
+			setupExecFile(
+				buildRouter({
+					// `git rev-parse --abbrev-ref HEAD` returns the literal "HEAD"
+					// in detached state.
+					"git:rev-parse": () => ({ stdout: "HEAD\n" }),
+					"git:push": () => {
+						gitPushCalled = true;
+						return { stdout: "" };
+					},
+				}),
+			);
+
+			await handleCreatePr("T", "B", CWD, postMessage, "feature/x");
+
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "prCreateBlockedCrossBranch",
+				summaryBranch: "feature/x",
+				currentBranch: "HEAD",
+			});
+			expect(postMessage).not.toHaveBeenCalledWith({ command: "prCreating" });
+			expect(postMessage).not.toHaveBeenCalledWith({
+				command: "prCreateFailed",
+			});
+			expect(gitPushCalled).toBe(false);
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("Cannot determine the current branch"),
+			);
+		});
+
+		it("git error reading the branch: normalized to detached block, not prCreateFailed", async () => {
+			// A hard git failure (.git/index.lock, permission) makes the branch
+			// read throw. getCurrentBranchSafe normalizes it to the "HEAD"
+			// sentinel so it lands on the detached block rather than the outer
+			// catch → prCreateFailed.
+			let gitPushCalled = false;
+			setupExecFile(
+				buildRouter({
+					"git:rev-parse": () => {
+						throw new Error("fatal: unable to read HEAD");
+					},
+					"git:push": () => {
+						gitPushCalled = true;
+						return { stdout: "" };
+					},
+				}),
+			);
+
+			await handleCreatePr("T", "B", CWD, postMessage, "feature/x");
+
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "prCreateBlockedCrossBranch",
+				summaryBranch: "feature/x",
+				currentBranch: "HEAD",
+			});
+			expect(postMessage).not.toHaveBeenCalledWith({
+				command: "prCreateFailed",
+			});
+			expect(gitPushCalled).toBe(false);
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("Cannot determine the current branch"),
+			);
+		});
+
+		it("detached HEAD with no expectedBranch: blocks with an empty summaryBranch field", async () => {
+			setupExecFile(
+				buildRouter({ "git:rev-parse": () => ({ stdout: "HEAD\n" }) }),
+			);
+
+			await handleCreatePr("T", "B", CWD, postMessage);
+
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "prCreateBlockedCrossBranch",
+				summaryBranch: "",
+				currentBranch: "HEAD",
+			});
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("Cannot determine the current branch"),
 			);
 		});
 	});

--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -19,6 +19,7 @@ import { join } from "node:path";
 import * as vscode from "vscode";
 import { execFileAsyncHidden } from "../../../cli/src/util/Subprocess.js";
 import { MARKER_END, MARKER_START, wrapWithMarkers } from "../../../cli/src/core/PrDescription.js";
+import { detachedHeadMessage } from "./CreatePrBranchClassifier.js";
 import { log } from "../util/Logger.js";
 
 const TAG = "PrSection";
@@ -201,6 +202,23 @@ async function execGit(args: Array<string>, cwd: string): Promise<string> {
 async function getCurrentBranch(cwd: string): Promise<string> {
 	const raw = await execGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
 	return raw.trim();
+}
+
+/**
+ * Like {@link getCurrentBranch} but normalizes every "can't determine the
+ * branch" outcome to the literal sentinel `"HEAD"` — both detached HEAD (where
+ * `rev-parse` itself returns `"HEAD"`) and a hard git error (`.git/index.lock`,
+ * permission failure, not a repo), which would otherwise throw and skip the
+ * cross-branch guard entirely (landing in the outer catch as `prCreateFailed`).
+ * Mirrors `JolliMemoryBridge.getCurrentBranch`'s sentinel so the panel and the
+ * service classify a broken repo state identically.
+ */
+async function getCurrentBranchSafe(cwd: string): Promise<string> {
+	try {
+		return (await getCurrentBranch(cwd)) || "HEAD";
+	} catch {
+		return "HEAD";
+	}
 }
 
 /** Pushes the current branch to origin (no-op if already pushed). */
@@ -577,31 +595,48 @@ export async function handleCheckPrStatus(
 }
 
 /**
- * Creates a new PR for the summary's branch.
+ * Creates a new PR scoped to `expectedBranch` — the effective branch the panel
+ * resolved at prepare time (see `classifyCreatePrBranch`): the summary's own
+ * branch normally, or the current branch when the summary's branch was renamed
+ * away. The physical `git push -u origin HEAD` pushes whatever is checked out,
+ * so this is the submit-time second line of the guard:
  *
- * Routing is by `summaryBranch` (matches Check/Update PR), but the physical
- * `git push -u origin HEAD` requires that branch to be the one currently
- * checked out. So we guard: if `summaryBranch !== currentBranch` (Memory Bank
- * cross-branch view), reject with `prCreateBlockedCrossBranch` and let the
- * webview prompt the user to checkout first. When `summaryBranch` is undefined
- * (no summary context), fall back to current-branch behavior.
+ * - If the current branch can't be determined (detached HEAD / git error,
+ *   normalized to `"HEAD"`), block with the shared detached message rather than
+ *   falling through to `prCreateFailed`.
+ * - If `expectedBranch` no longer equals the live current branch, the user
+ *   switched branches between opening the form and submitting (TOCTOU); block
+ *   so we never push a different branch's HEAD onto this PR. The richer
+ *   cross-branch / original-gone cases are decided earlier at prepare time.
+ *
+ * When `expectedBranch` is undefined (no summary context) we fall back to
+ * current-branch behavior.
  */
 export async function handleCreatePr(
 	title: string,
 	body: string,
 	cwd: string,
 	postMessage: PostMessageFn,
-	summaryBranch?: string,
+	expectedBranch?: string,
 ): Promise<void> {
 	try {
-		const currentBranch = await getCurrentBranch(cwd);
-		if (summaryBranch && summaryBranch !== currentBranch) {
+		const currentBranch = await getCurrentBranchSafe(cwd);
+		if (currentBranch === "HEAD") {
+			vscode.window.showWarningMessage(detachedHeadMessage(expectedBranch));
+			postMessage({
+				command: "prCreateBlockedCrossBranch",
+				summaryBranch: expectedBranch ?? "",
+				currentBranch,
+			});
+			return;
+		}
+		if (expectedBranch && expectedBranch !== currentBranch) {
 			vscode.window.showWarningMessage(
-				`This summary is on branch ${summaryBranch}. Checkout ${summaryBranch} to create its PR.`,
+				`The current branch changed to ${currentBranch} (the form was opened for ${expectedBranch}). Reopen Create PR to continue.`,
 			);
 			postMessage({
 				command: "prCreateBlockedCrossBranch",
-				summaryBranch,
+				summaryBranch: expectedBranch,
 				currentBranch,
 			});
 			return;
@@ -619,7 +654,7 @@ export async function handleCreatePr(
 		log.info(TAG, `PR created: ${prUrl}`);
 
 		// Refresh section to show the new PR
-		await handleCheckPrStatus(cwd, postMessage, summaryBranch);
+		await handleCheckPrStatus(cwd, postMessage, expectedBranch);
 
 		// Toast with "Open PR" action
 		vscode.window

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -406,6 +406,27 @@ vi.mock("./BranchSummaryLoader.js", () => ({
 	loadBranchSummaries: mockLoadBranchSummaries,
 }));
 
+// `CreatePrBranchClassifier` (used by the PR guard) calls these two read-only
+// git helpers. Default: the summary's branch still exists (→ crossBranch when
+// it differs from the current branch, preserving the legacy cross-branch
+// block); rename/successor tests override `mockOrphanBranchExists` → false and
+// `mockIsAncestor` → true. Only the real functions are replaced; the rest of
+// GitOps stays intact.
+const { mockOrphanBranchExists, mockIsAncestor } = vi.hoisted(() => ({
+	mockOrphanBranchExists: vi.fn().mockResolvedValue(true),
+	mockIsAncestor: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../../../cli/src/core/GitOps.js", async (importActual) => {
+	const actual =
+		await importActual<typeof import("../../../cli/src/core/GitOps.js")>();
+	return {
+		...actual,
+		orphanBranchExists: mockOrphanBranchExists,
+		isAncestor: mockIsAncestor,
+	};
+});
+
 const { mockBuildAggregatedPrMarkdown } = vi.hoisted(() => ({
 	mockBuildAggregatedPrMarkdown: vi.fn().mockReturnValue("# Aggregated body"),
 }));
@@ -3685,6 +3706,10 @@ describe("SummaryWebviewPanel", () => {
 					"feature/test",
 					"https://github.com/other/repo.git",
 				);
+				// Foreign summaries belong to a different repo — the local-workspace
+				// branch classifier must NOT run for them.
+				expect(mockOrphanBranchExists).not.toHaveBeenCalled();
+				expect(mockIsAncestor).not.toHaveBeenCalled();
 			});
 
 			it("forwards postMessage callback to the webview panel", async () => {
@@ -3703,9 +3728,14 @@ describe("SummaryWebviewPanel", () => {
 		});
 
 		describe("createPr", () => {
-			it("delegates to handleCreatePr, passing summary.branch", async () => {
+			it("delegates to handleCreatePr, passing the prepare-time effective branch", async () => {
+				// Realistic flow: prepareCreatePr resolves and stashes the effective
+				// branch (here same-branch → "feature/test"), then the form's submit
+				// fires createPr, which forwards that stashed branch as expectedBranch.
 				const dispatch = await setupPanel();
 
+				dispatch({ command: "prepareCreatePr" });
+				await flushPromises();
 				dispatch({ command: "createPr", title: "PR Title", body: "PR Body" });
 				await flushPromises();
 
@@ -3715,6 +3745,35 @@ describe("SummaryWebviewPanel", () => {
 					workspaceRoot,
 					expect.any(Function),
 					"feature/test",
+				);
+			});
+
+			it("renamed branch end-to-end: prepare→submit forwards the CURRENT branch (not the stale summary branch) as expectedBranch", async () => {
+				// Core promise of the fix: after `git branch -m old new`, the value
+				// threaded into handleCreatePr must be the live "feature/new", never
+				// the stale "feature/old". The same-branch delegation test can't catch
+				// a regression to the stale branch because there old === new.
+				mockOrphanBranchExists.mockResolvedValueOnce(false); // old ref gone
+				mockIsAncestor.mockResolvedValueOnce(true); // its commit is on HEAD
+				(
+					stubBridge.getCurrentBranch as ReturnType<typeof vi.fn>
+				).mockResolvedValueOnce("feature/new");
+				const dispatch = await setupPanel({
+					branch: "feature/old",
+					commitHash: "abc123",
+				});
+
+				dispatch({ command: "prepareCreatePr" });
+				await flushPromises();
+				dispatch({ command: "createPr", title: "T", body: "B" });
+				await flushPromises();
+
+				expect(mockHandleCreatePr).toHaveBeenCalledWith(
+					"T",
+					"B",
+					workspaceRoot,
+					expect.any(Function),
+					"feature/new",
 				);
 			});
 
@@ -3997,6 +4056,62 @@ describe("SummaryWebviewPanel", () => {
 					expect.stringContaining("Checkout HEAD"),
 				);
 			});
+
+			it("renamed branch (old ref gone + current carries the commit): allows Create PR, scoped to the current branch", async () => {
+				// `git branch -m old new`: the old ref is gone but its commit is on
+				// the current branch, so the classifier returns okAsCurrent and the
+				// form opens instead of dead-ending on "Checkout old".
+				mockOrphanBranchExists.mockResolvedValueOnce(false);
+				mockIsAncestor.mockResolvedValueOnce(true);
+				(
+					stubBridge.getCurrentBranch as ReturnType<typeof vi.fn>
+				).mockResolvedValueOnce("feature/new");
+				const dispatch = await setupPanel({
+					branch: "feature/old",
+					commitHash: "abc123",
+				});
+
+				dispatch({ command: "prepareCreatePr" });
+				await flushPromises();
+
+				expect(postMessage).not.toHaveBeenCalledWith(
+					expect.objectContaining({ command: "prCreateBlockedCrossBranch" }),
+				);
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({ command: "prShowCreateForm" }),
+				);
+			});
+
+			it("original branch gone + commit not on current branch: blocks with the 'no longer exists' message", async () => {
+				// Deleted branch + switched to an unrelated branch, OR rename+rebase
+				// that rewrote the hash. The commit isn't reachable from HEAD, so we
+				// can't attribute the PR to the current branch.
+				mockOrphanBranchExists.mockResolvedValueOnce(false);
+				mockIsAncestor.mockResolvedValueOnce(false);
+				(
+					stubBridge.getCurrentBranch as ReturnType<typeof vi.fn>
+				).mockResolvedValueOnce("feature/new");
+				const dispatch = await setupPanel({
+					branch: "feature/old",
+					commitHash: "abc123",
+				});
+
+				dispatch({ command: "prepareCreatePr" });
+				await flushPromises();
+
+				expect(postMessage).toHaveBeenCalledWith({
+					command: "prCreateBlockedCrossBranch",
+					summaryBranch: "feature/old",
+					currentBranch: "feature/new",
+				});
+				expect(showWarningMessage).toHaveBeenCalledWith(
+					expect.stringContaining("no longer exists"),
+				);
+				expect(postMessage).not.toHaveBeenCalledWith(
+					expect.objectContaining({ command: "prShowCreateForm" }),
+				);
+				expect(mockLoadBranchSummaries).not.toHaveBeenCalled();
+			});
 		});
 
 		describe("prepareUpdatePr", () => {
@@ -4137,9 +4252,13 @@ describe("SummaryWebviewPanel", () => {
 		});
 
 		describe("updatePr", () => {
-			it("delegates to handleUpdatePr, passing summary.branch", async () => {
+			it("delegates to handleUpdatePr, passing the prepare-time effective branch", async () => {
+				// prepareUpdatePr resolves + stashes the effective branch (same-branch
+				// → "feature/test"); the form's submit then forwards it to handleUpdatePr.
 				const dispatch = await setupPanel();
 
+				dispatch({ command: "prepareUpdatePr" });
+				await flushPromises();
 				dispatch({ command: "updatePr", title: "Updated", body: "Body" });
 				await flushPromises();
 
@@ -4149,6 +4268,33 @@ describe("SummaryWebviewPanel", () => {
 					workspaceRoot,
 					expect.any(Function),
 					"feature/test",
+				);
+			});
+
+			it("renamed branch end-to-end: prepare→submit forwards the CURRENT branch to handleUpdatePr", async () => {
+				// Edit PR is branch-name-routed; after a rename it must target the
+				// renamed-to "feature/new", matching what the status section displays.
+				mockOrphanBranchExists.mockResolvedValueOnce(false);
+				mockIsAncestor.mockResolvedValueOnce(true);
+				(
+					stubBridge.getCurrentBranch as ReturnType<typeof vi.fn>
+				).mockResolvedValueOnce("feature/new");
+				const dispatch = await setupPanel({
+					branch: "feature/old",
+					commitHash: "abc123",
+				});
+
+				dispatch({ command: "prepareUpdatePr" });
+				await flushPromises();
+				dispatch({ command: "updatePr", title: "T", body: "B" });
+				await flushPromises();
+
+				expect(mockHandleUpdatePr).toHaveBeenCalledWith(
+					"T",
+					"B",
+					workspaceRoot,
+					expect.any(Function),
+					"feature/new",
 				);
 			});
 

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -67,6 +67,11 @@ import {
 	pushToJolli,
 } from "../services/JolliPushService.js";
 import {
+	classifyCreatePrBranch,
+	createPrBlockMessage,
+	effectiveBranchFor,
+} from "../services/CreatePrBranchClassifier.js";
+import {
 	handleCheckPrStatus,
 	handleCreatePr,
 	handlePrepareUpdatePr,
@@ -330,6 +335,13 @@ export class SummaryWebviewPanel {
 	private readonly commitHash: string;
 	/** Tracks the currently displayed summary for the Copy Markdown action. */
 	private currentSummary: CommitSummary | undefined;
+	/**
+	 * Effective branch resolved when a Create/Update PR form is opened (prepare
+	 * step). Passed through to the submit handler so the service can detect a
+	 * branch switch between opening and submitting the form (TOCTOU guard) and
+	 * scope the PR to the same branch the body was aggregated for.
+	 */
+	private pendingPrBranch: string | undefined;
 	/** Cached set of commit hashes that have transcript files in the orphan branch (scoped to current tree). */
 	private transcriptHashSet: Set<string> = new Set();
 	/** Cached set of plan slugs whose content contains non-ASCII characters (need translation). */
@@ -778,14 +790,21 @@ export class SummaryWebviewPanel {
 				// foreign repo is local-only (no remoteUrl in its KB config),
 				// pass null and let PrCommentService short-circuit to
 				// `unavailable` rather than silently querying this workspace.
-				handleCheckPrStatus(
-					this.workspaceRoot,
-					(msg) => this.panel.webview.postMessage(msg),
-					this.currentSummary?.branch,
-					this.foreignRepoName ? this.foreignRepoUrl : null,
-				).catch((err: unknown) =>
-					log.error("SummaryPanel", `Check PR status failed: ${err}`),
-				);
+				// `resolveEffectiveBranch` keeps the displayed PR aligned with a
+				// renamed branch (and short-circuits to the summary branch for
+				// foreign panels).
+				this.resolveEffectiveBranch()
+					.then(({ effectiveBranch }) =>
+						handleCheckPrStatus(
+							this.workspaceRoot,
+							(msg) => this.panel.webview.postMessage(msg),
+							effectiveBranch,
+							this.foreignRepoName ? this.foreignRepoUrl : null,
+						),
+					)
+					.catch((err: unknown) =>
+						log.error("SummaryPanel", `Check PR status failed: ${err}`),
+					);
 				break;
 			case "createPr":
 				this.catchAndShow(
@@ -794,7 +813,7 @@ export class SummaryWebviewPanel {
 						message.body,
 						this.workspaceRoot,
 						(msg) => this.panel.webview.postMessage(msg),
-						this.currentSummary?.branch,
+						this.pendingPrBranch,
 					),
 					"Create PR failed",
 				);
@@ -820,7 +839,7 @@ export class SummaryWebviewPanel {
 						this.workspaceRoot,
 						(msg: Record<string, unknown>) =>
 							this.panel.webview.postMessage(msg),
-						this.currentSummary?.branch,
+						this.pendingPrBranch,
 					),
 					"Update PR failed",
 				);
@@ -1416,24 +1435,27 @@ export class SummaryWebviewPanel {
 			return;
 		}
 
-		// Cross-branch guard: Create PR requires being checked out on the
-		// summary's branch (because `git push -u origin HEAD` pushes the current
-		// branch). Block before opening the form to avoid misleading the user.
-		//
-		// `bridge.getCurrentBranch()` returns the literal sentinel "HEAD" when
-		// `git rev-parse --abbrev-ref HEAD` yields nothing — detached HEAD,
-		// `.git/index.lock`, or permission failures. Telling the user to
-		// "checkout <summary.branch>" in that state is wrong (the repo is in
-		// a transient bad state, not on a different branch); they'd checkout
-		// and only then discover the real problem. Use a distinct message.
+		// Cross-branch guard: Create PR requires being checked out on the branch
+		// the PR will be scoped to (because `git push -u origin HEAD` pushes the
+		// current branch). `classifyCreatePrBranch` distinguishes a genuine
+		// cross-branch view (summary's branch still exists → block) from a rename
+		// or delete-to-successor (old ref gone + current branch contains the
+		// commit → allow, scoping to the current branch). Foreign panels never
+		// reach here — `createPr` / `prepareCreatePr` are denied at dispatch, so
+		// only `checkPrStatus` (via `resolveEffectiveBranch`) runs for them.
+		this.pendingPrBranch = summary.branch;
+		let currentBranch: string | undefined;
 		if (summary.branch) {
-			const currentBranch = await this.bridge.getCurrentBranch();
-			if (summary.branch !== currentBranch) {
-				const message =
-					currentBranch === "HEAD"
-						? `Cannot determine the current branch (detached HEAD or git error). Resolve the repository state, then retry creating the PR for ${summary.branch}.`
-						: `This summary is on branch ${summary.branch}. Checkout ${summary.branch} to create its PR.`;
-				vscode.window.showWarningMessage(message);
+			currentBranch = await this.bridge.getCurrentBranch();
+			const decision = await classifyCreatePrBranch(
+				summary.branch,
+				currentBranch,
+				summary.commitHash,
+				this.workspaceRoot,
+			);
+			const blockMessage = createPrBlockMessage(decision, summary.branch);
+			if (blockMessage) {
+				vscode.window.showWarningMessage(blockMessage);
 				postMessage({
 					command: "prCreateBlockedCrossBranch",
 					summaryBranch: summary.branch,
@@ -1441,10 +1463,12 @@ export class SummaryWebviewPanel {
 				});
 				return;
 			}
+			this.pendingPrBranch = effectiveBranchFor(decision, summary.branch);
 		}
 
 		const { summaries, missingCount } = await this.loadBranchSummariesForPr(
-			summary.branch,
+			this.pendingPrBranch,
+			currentBranch,
 		);
 		const markdown = buildPrBodyMarkdown(summary, summaries, missingCount);
 		const title = pickPrTitle(summary, summaries);
@@ -1466,8 +1490,17 @@ export class SummaryWebviewPanel {
 			return;
 		}
 
+		// Edit PR is branch-name-routed (no `git push`), so a renamed branch must
+		// resolve to the same effective branch the status section displays —
+		// otherwise the page shows the new branch's PR while Edit queries/edits
+		// the stale one. `resolveEffectiveBranch` also scopes body aggregation.
+		const { effectiveBranch, currentBranch } =
+			await this.resolveEffectiveBranch();
+		this.pendingPrBranch = effectiveBranch;
+
 		const { summaries, missingCount } = await this.loadBranchSummariesForPr(
-			summary.branch,
+			effectiveBranch,
+			currentBranch,
 		);
 		const markdown = buildPrBodyMarkdown(summary, summaries, missingCount);
 
@@ -1475,8 +1508,40 @@ export class SummaryWebviewPanel {
 			markdown,
 			this.workspaceRoot,
 			postMessage,
-			summary.branch,
+			effectiveBranch,
 		);
+	}
+
+	/**
+	 * The branch a PR status query / body aggregation should be scoped to for
+	 * the currently displayed summary, plus the `currentBranch` it was resolved
+	 * against (so callers can reuse the single `getCurrentBranch` read). The
+	 * effective branch is the summary's own branch except when that branch was
+	 * renamed away and the current branch now carries its commit (`okAsCurrent`),
+	 * in which case it follows the rename to the current branch. Foreign-repo
+	 * panels short-circuit to the summary branch — their branches aren't in this
+	 * workspace's git graph, so the local classifier must not run (and there is
+	 * no meaningful local `currentBranch` for them).
+	 */
+	private async resolveEffectiveBranch(): Promise<{
+		effectiveBranch: string | undefined;
+		currentBranch: string | undefined;
+	}> {
+		const summary = this.currentSummary;
+		if (!summary?.branch || this.foreignRepoName) {
+			return { effectiveBranch: summary?.branch, currentBranch: undefined };
+		}
+		const currentBranch = await this.bridge.getCurrentBranch();
+		const decision = await classifyCreatePrBranch(
+			summary.branch,
+			currentBranch,
+			summary.commitHash,
+			this.workspaceRoot,
+		);
+		return {
+			effectiveBranch: effectiveBranchFor(decision, summary.branch),
+			currentBranch,
+		};
 	}
 
 	// Returns true when worker is busy with a blocking (summary) run: shows the
@@ -1493,39 +1558,41 @@ export class SummaryWebviewPanel {
 		vscode.window.showWarningMessage(
 			"Jolli Memory: AI summary is being generated. Please wait a moment.",
 		);
+		const { effectiveBranch } = await this.resolveEffectiveBranch();
 		await handleCheckPrStatus(
 			this.workspaceRoot,
 			postMessage,
-			this.currentSummary?.branch,
+			effectiveBranch,
+			this.foreignRepoName ? this.foreignRepoUrl : null,
 		);
 		return true;
 	}
 
 	/**
-	 * Loads summaries for PR body aggregation, scoped to the summary's branch.
+	 * Loads summaries for PR body aggregation, scoped to `effectiveBranch`.
 	 *
 	 * Memory Bank lets the user open any historical summary, including ones on
 	 * branches they're not currently checked out on. In that cross-branch case
-	 * aggregating `currentBranch`'s commits into a PR for `summaryBranch` is
+	 * aggregating `currentBranch`'s commits into a PR for the summary's branch is
 	 * misleading — the body would describe commits unrelated to that PR. So we
 	 * force the single-summary fallback by returning an empty array, and
 	 * `buildPrBodyMarkdown` / `pickPrTitle` fall back to the clicked summary.
 	 *
-	 * When `summaryBranch === currentBranch` (or `summaryBranch` is undefined),
-	 * we run the existing HEAD-based `loadBranchSummaries` to get the full
-	 * branch-aggregation behavior.
+	 * When `effectiveBranch === currentBranch` (or `effectiveBranch` is
+	 * undefined) we run the existing HEAD-based `loadBranchSummaries` to get the
+	 * full branch-aggregation behavior. `currentBranch` is supplied by the caller
+	 * (already read for the branch classifier) so a renamed branch resolves to
+	 * the current checkout and a single `getCurrentBranch` read serves both.
 	 */
 	private async loadBranchSummariesForPr(
-		summaryBranch: string | undefined,
+		effectiveBranch: string | undefined,
+		currentBranch: string | undefined,
 	): Promise<{
 		summaries: ReadonlyArray<CommitSummary>;
 		missingCount: number;
 	}> {
-		if (summaryBranch) {
-			const currentBranch = await this.bridge.getCurrentBranch();
-			if (summaryBranch !== currentBranch) {
-				return { summaries: [], missingCount: 0 };
-			}
+		if (effectiveBranch && effectiveBranch !== currentBranch) {
+			return { summaries: [], missingCount: 0 };
 		}
 		const result = await loadBranchSummaries(this.bridge, this.mainBranch);
 		return {


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Users who rename a local branch after the memory tool has already recorded commits on it can now create and edit pull requests normally. Previously, the tool compared the stored branch name against the current branch name and blocked with a message asking the user to check out the old branch — which no longer existed after a rename, leaving them permanently stuck. The fix introduces a smarter check: if the old branch name no longer exists as a local git reference, the tool looks at whether the current branch actually contains the relevant commit. When it does, the PR is scoped to the current branch and the flow proceeds. When it does not — for example after a rebase that rewrote the commit — the tool blocks with a clearer explanation of why.

The fix also closes a subtle gap where switching branches between opening the PR form and clicking submit could cause the tool to push the wrong branch's changes. The branch is now locked in when the form opens, and the submit step verifies the user is still on that same branch before proceeding. Additionally, git errors that prevent the tool from reading the current branch at all — such as a locked index file — now produce the same informative "cannot determine current branch" message in both the panel and the service layer, rather than silently failing with a generic error.

---

## E2E Test (2)
<details>
<summary><strong>1. Create PR works after renaming a local branch</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a local Git repository open in the extension with at least one commit that was recorded by the memory tool on a branch (e.g. "feature/old"). Rename that branch to something new (e.g. "feature/new") using your terminal: `git branch -m feature/old feature/new`. Make sure you are currently checked out on the renamed branch.

**Steps:**
1. Open the extension and navigate to the summary that was recorded on the old branch name (e.g. "feature/old").
2. Click the "Create PR" button on that summary.
3. Wait a moment for the form to load.
4. Check whether a Create PR form appears or whether an error message is shown instead.
5. If the form appears, fill in a title and body, then click the submit button.
6. Verify the result.

**Expected Results:**
- The Create PR form should open successfully — no error message saying "Checkout feature/old to create its PR" should appear, since that branch no longer exists.
- After submitting, a pull request should be created and a success notification should appear, referencing the renamed branch (feature/new), not the old one.

</blockquote>
</details>
<details>
<summary><strong>2. Create PR is still blocked when viewing a summary from a different branch that still exists</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a local Git repository with two branches, e.g. "feature/a" and "main". Record a commit summary while on "feature/a", then switch to "main" without deleting or renaming "feature/a".

**Steps:**
1. While checked out on "main", open the extension and navigate to the summary that was recorded on "feature/a".
2. Click the "Create PR" button on that summary.
3. Wait a moment for the response.
4. Check what message or action appears.

**Expected Results:**
- The Create PR form should NOT open.
- A warning message should appear telling you to check out "feature/a" before creating its PR (something like "This summary is on branch feature/a. Checkout feature/a to create its PR.").
- No pull request should be created.

</blockquote>
</details>

---

## Topic (1)
<details>
<summary><strong>01 · Fix Create PR blocked after renaming a local branch</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A teammate renamed a local branch after commits had already been recorded by the memory tool. Afterwards, clicking "Create PR" on any of those commits showed a dead-end error asking them to check out the old branch name — which no longer existed — making it impossible to create a PR.

**💡 Decisions Behind the Code**

- **Distinguishing rename from genuine cross-branch view**: The key insight is that `git branch -m` and `git branch -D` delete the old local ref, while simply checking out a different branch does not. Checking whether the old branch ref still exists in git is therefore the precise signal that separates "the user renamed their branch" (old ref gone) from "the user is viewing a summary from a different branch" (old ref still present). Using commit ancestry alone would have incorrectly allowed PR creation from branches that merely descended from the same commit.
- **Allowing rename but not rename-plus-rebase**: When a branch is renamed and then rebased, the original commit hash is rewritten and no longer appears in the current branch's history. The classifier blocks this combination with the "original branch gone" message. This is an accepted limitation: the two scenarios (renamed-then-rebased vs. deleted-then-switched-to-unrelated-branch) are indistinguishable from git's perspective without consulting the reflog, and the outcome in both cases — the commit is not reachable from the current branch — means the PR cannot be safely attributed to it. This is a net improvement over the previous behavior, which dead-ended on both cases identically.
- **Not managing pre-rename remote open PRs**: If the remote still has an open PR on the old branch name at the time of rename, the tool takes no action on it. After rename, PR status and creation are scoped entirely to the new branch name. This was chosen for simplicity; the alternative (detecting and warning about orphaned remote open PRs) would require an extra network call on every form open and adds complexity for an edge case users can handle manually.

**✅ What Was Implemented**

- Added `vscode/src/services/CreatePrBranchClassifier.ts`, a new pure classifier module that replaces the old string-equality guard. It calls two read-only git helpers to distinguish five cases: same branch (allow), detached HEAD or git error (block with a clear message), genuine cross-branch view where the old branch still exists (block with the existing "checkout" message), renamed/deleted-to-successor where the old ref is gone but the current branch contains the commit (allow, scoped to the current branch), and original branch gone with the commit unreachable (block with a "no longer exists" message).
- Updated `vscode/src/views/SummaryWebviewPanel.ts` to thread the resolved effective branch through all five touchpoints: initial PR status display, Create PR body aggregation, Update PR prepare and submit, and the worker-busy status refresh. A new `resolveEffectiveBranch()` helper performs a single branch read and classifier call, with a short-circuit for foreign-repo panels whose branches are not in the local git graph. A `pendingPrBranch` field captures the branch resolved at form-open time and passes it to the submit handler, preventing a race where the user switches branches between opening and submitting the form.
- Updated `vscode/src/services/PrCommentService.ts` to add `getCurrentBranchSafe`, which normalizes both detached HEAD and hard git errors (lock file, permissions) to the `"HEAD"` sentinel, ensuring both failure modes reach the shared detached-HEAD message rather than falling through to a generic failure. The submit handler now accepts an `expectedBranch` parameter (the branch resolved at prepare time) and rejects if the live branch has changed since the form was opened.

**📋 Future Enhancements**

Recall, folder storage, and decision timeline still display the old branch name for summaries recorded before a rename. These are independent follow-up items noted in the planning document and not addressed in this commit.

**📁 FILES**
- `vscode/src/services/CreatePrBranchClassifier.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`
- `vscode/src/services/PrCommentService.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 23, 2026 at 7:50 PM · via Anthropic*
<!-- jollimemory-summary-end -->