### PR TITLE
Fix LlmClient to stream by default for large tokens or prompts

### DIFF
--- a/cli/src/core/LlmClient.test.ts
+++ b/cli/src/core/LlmClient.test.ts
@@ -5,11 +5,14 @@ import {
 	isLlmCredentialError,
 	LlmCredentialError,
 	NO_LLM_PROVIDER_MESSAGE,
+	NONSTREAM_MAX_OUTPUT_TOKENS,
+	NONSTREAM_MAX_PROMPT_CHARS,
 	PROXY_FETCH_TIMEOUT_MS,
 	resolveLlmCredentialSource,
 	STREAM_IDLE_TIMEOUT_MS,
 	STREAM_MAX_WALL_CLOCK_MS,
 } from "./LlmClient.js";
+import { COMMIT_MSG_DIFF_BUDGET } from "./Summarizer.js";
 
 const { mockCreate, mockStream, mockLogInfo, mockLogWarn, mockLogError } = vi.hoisted(() => ({
 	mockCreate: vi.fn(),
@@ -88,17 +91,20 @@ describe("LlmClient", () => {
 
 	describe("direct mode", () => {
 		it("resolves the prompt template from the action and fills params", async () => {
+			// maxTokens 256 + a tiny prompt keeps this on the non-streaming
+			// `messages.create` carve-out (the default 8192 budget streams now).
 			const result = await callLlm({
 				action: "translate",
 				params: { content: "# Test" },
 				apiKey: "sk-ant-test",
 				model: "claude-sonnet-4-6",
+				maxTokens: 256,
 			});
 
 			expect(mockCreate).toHaveBeenCalledWith(
 				{
 					model: "claude-sonnet-4-6",
-					max_tokens: 8192,
+					max_tokens: 256,
 					temperature: 0,
 					messages: [
 						{
@@ -126,6 +132,7 @@ describe("LlmClient", () => {
 				action: "translate",
 				params: {},
 				apiKey: "sk-ant-test",
+				maxTokens: 256,
 			});
 
 			expect(mockLogWarn).toHaveBeenCalledWith(
@@ -147,6 +154,7 @@ describe("LlmClient", () => {
 			const result = await callLlm({
 				action: "translate",
 				params: { content: "test prompt" },
+				maxTokens: 256,
 			});
 
 			expect(result.text).toBe("response text");
@@ -188,6 +196,7 @@ describe("LlmClient", () => {
 					action: "translate",
 					params: { content: "test" },
 					apiKey: "sk-ant-test",
+					maxTokens: 256,
 				}),
 			).rejects.toThrow("LLM direct request to https://api.anthropic.com failed: 401 token expired");
 		});
@@ -200,6 +209,7 @@ describe("LlmClient", () => {
 					action: "translate",
 					params: { content: "test" },
 					apiKey: "sk-ant-test",
+					maxTokens: 256,
 				}),
 			).rejects.toThrow("LLM direct request to https://api.anthropic.com failed: raw string failure");
 		});
@@ -223,6 +233,7 @@ describe("LlmClient", () => {
 					action: "translate",
 					params: { content: "test" },
 					apiKey: "sk-ant-test",
+					maxTokens: 256,
 				}),
 			).rejects.toThrow("LLM direct request to https://api.anthropic.com failed: fetch failed");
 		});
@@ -237,6 +248,7 @@ describe("LlmClient", () => {
 					action: "translate",
 					params: { content: "test" },
 					apiKey: "sk-ant-test",
+					maxTokens: 256,
 				}),
 			).rejects.toThrow("LLM direct request to https://api.anthropic.com failed: boom");
 		});
@@ -255,6 +267,7 @@ describe("LlmClient", () => {
 					action: "translate",
 					params: { content: "test" },
 					apiKey: "sk-ant-test",
+					maxTokens: 256,
 				}),
 			).rejects.toThrow("LLM direct request to https://api.anthropic.com failed: outer");
 		});
@@ -270,6 +283,7 @@ describe("LlmClient", () => {
 					action: "translate",
 					params: { content: "test" },
 					apiKey: "sk-ant-test",
+					maxTokens: 256,
 				}),
 			).rejects.toThrow("No text content");
 		});
@@ -285,6 +299,7 @@ describe("LlmClient", () => {
 				action: "translate",
 				params: { content: "test" },
 				apiKey: "sk-ant-test",
+				maxTokens: 256,
 			});
 			const call = mockCreate.mock.calls.at(-1);
 			expect(call).toBeDefined();
@@ -293,13 +308,17 @@ describe("LlmClient", () => {
 			expect(requestOptions?.signal).toBeInstanceOf(AbortSignal);
 		});
 
-		it("logs model, maxTokens, promptChars and elapsedMs on failure so timeout-vs-size is diagnosable", async () => {
-			// The pre-fix failure log only carried action/baseUrl/message/cause —
-			// when a large squash/regenerate prompt hit the wall-clock timeout the
-			// log gave no way to tell HOW big the prompt was or HOW long it ran
-			// before aborting. These fields make "Request was aborted." actionable
-			// in debug.log without re-running the failing call.
-			mockCreate.mockRejectedValueOnce(new Error("Request was aborted."));
+		it("logs model, maxTokens, promptChars, elapsedMs plus errorName/httpStatus/requestId so timeout-vs-size-vs-server is diagnosable", async () => {
+			// A large call streams; when it aborts on the wall-clock/idle timeout the
+			// catch must log enough to tell "prompt too big for the budget" from a
+			// wedged connection from a server-side rejection — without re-running.
+			// An abort that fired on an in-flight request has NO httpStatus and NO
+			// requestId (the response never came), the wedge/slow fingerprint.
+			mockStream.mockReturnValueOnce({
+				finalMessage: vi.fn().mockRejectedValue(new Error("Request was aborted.")),
+				on: vi.fn(),
+				abort: vi.fn(),
+			});
 
 			await expect(
 				callLlm({
@@ -312,15 +331,79 @@ describe("LlmClient", () => {
 			).rejects.toThrow("LLM direct request to https://api.anthropic.com failed: Request was aborted.");
 
 			expect(mockLogError).toHaveBeenCalledWith(
-				expect.stringMatching(/model=%s.*maxTokens=%d.*promptChars=%d.*elapsedMs=%d/),
+				expect.stringMatching(
+					/maxTokens=%d.*promptChars=%d.*elapsedMs=%d.*errorName=%s.*httpStatus=%s.*requestId=%s/,
+				),
 				"translate", // action
 				expect.any(String), // resolved model id
 				8192, // maxTokens
 				expect.any(Number), // promptChars
 				expect.any(Number), // elapsedMs
 				"https://api.anthropic.com", // baseUrl
+				"Error", // errorName (the rejected Error's name)
+				"(none)", // httpStatus — an in-flight abort carries no HTTP status
+				"(none)", // requestId — the request never reached the server
 				"Request was aborted.", // message
 				expect.any(String), // cause
+			);
+		});
+
+		it("surfaces httpStatus and request_id when a server-side error carries them", async () => {
+			// A rate-limit (429) / overloaded (529) / 5xx error from Anthropic carries
+			// an HTTP status and a request id; surfacing them separates "the API
+			// rejected us" from "the connection never produced a response".
+			const apiErr = Object.assign(new Error("429 rate limited"), { status: 429, request_id: "req_abc123" });
+			mockCreate.mockRejectedValueOnce(apiErr);
+
+			await expect(
+				callLlm({ action: "translate", params: { content: "x" }, apiKey: "sk-ant-test", maxTokens: 256 }),
+			).rejects.toThrow("429 rate limited");
+
+			expect(mockLogError).toHaveBeenCalledWith(
+				expect.stringMatching(/errorName=%s.*httpStatus=%s.*requestId=%s/),
+				"translate",
+				expect.any(String),
+				256,
+				expect.any(Number),
+				expect.any(Number),
+				"https://api.anthropic.com",
+				"Error",
+				"429",
+				"req_abc123",
+				"429 rate limited",
+				expect.any(String),
+			);
+		});
+
+		it("surfaces status + requestID (camelCase fallback) on the STREAMING path too", async () => {
+			// Server-side errors (429/529/5xx) most often hit the large STREAMING
+			// calls (reconcile/summarize), where `finalMessage()` rejects. The shared
+			// catch must surface status + the id there too, reading the camelCase
+			// `requestID` fallback when `request_id` is absent. maxTokens 8192 streams.
+			const apiErr = Object.assign(new Error("500 server error"), { status: 500, requestID: "req_xyz789" });
+			mockStream.mockReturnValueOnce({
+				finalMessage: vi.fn().mockRejectedValue(apiErr),
+				on: vi.fn(),
+				abort: vi.fn(),
+			});
+
+			await expect(
+				callLlm({ action: "translate", params: { content: "x" }, apiKey: "sk-ant-test", maxTokens: 8192 }),
+			).rejects.toThrow("500 server error");
+
+			expect(mockLogError).toHaveBeenCalledWith(
+				expect.stringMatching(/httpStatus=%s.*requestId=%s/),
+				"translate",
+				expect.any(String),
+				8192,
+				expect.any(Number),
+				expect.any(Number),
+				"https://api.anthropic.com",
+				"Error",
+				"500",
+				"req_xyz789",
+				"500 server error",
+				expect.any(String),
 			);
 		});
 
@@ -344,36 +427,175 @@ describe("LlmClient", () => {
 			expect(result.outputTokens).toBe(32_000);
 		});
 
-		it("uses non-streaming when maxTokens is at or below the threshold", async () => {
-			// Per-branch compile / summarize / translate all use the default
-			// 8192 budget — keep them on the simple non-streaming path so this
-			// change is a no-op for the vast majority of callers.
+		it("uses non-streaming only when the call is small on BOTH axes", async () => {
+			// Tiny output cap AND tiny prompt → the simple non-streaming path.
 			await callLlm({
 				action: "translate",
 				params: { content: "x" },
 				apiKey: "sk-ant-test",
 				model: "claude-sonnet-4-6",
-				maxTokens: 16_384,
+				maxTokens: 256,
 			});
 
 			expect(mockCreate).toHaveBeenCalledTimes(1);
 			expect(mockStream).not.toHaveBeenCalled();
 		});
 
-		it("uses streaming when forceStreaming is set, even below the token threshold", async () => {
-			// The ingest route call sets forceStreaming explicitly instead of padding
-			// maxTokens above the threshold to coerce the streaming path.
+		it("streams when the output cap is large even if the prompt is tiny", async () => {
 			await callLlm({
 				action: "translate",
 				params: { content: "x" },
 				apiKey: "sk-ant-test",
 				model: "claude-sonnet-4-6",
 				maxTokens: 8192,
+			});
+
+			expect(mockStream).toHaveBeenCalledTimes(1);
+			expect(mockCreate).not.toHaveBeenCalled();
+		});
+
+		it("streams when the prompt is large even if the output cap is tiny (commit-message with a huge diff)", async () => {
+			// The motivating case: a small-output action carrying a large input must
+			// NOT be pinned to the fixed-budget non-streaming path. The filled
+			// template is already > NONSTREAM_MAX_PROMPT_CHARS from `content` alone.
+			await callLlm({
+				action: "translate",
+				params: { content: "x".repeat(NONSTREAM_MAX_PROMPT_CHARS + 1) },
+				apiKey: "sk-ant-test",
+				model: "claude-sonnet-4-6",
+				maxTokens: 256,
+			});
+
+			expect(mockStream).toHaveBeenCalledTimes(1);
+			expect(mockCreate).not.toHaveBeenCalled();
+		});
+
+		it("treats the output-cap boundary correctly: ≤ limit stays non-streaming, +1 streams", async () => {
+			await callLlm({
+				action: "translate",
+				params: { content: "x" },
+				apiKey: "sk-ant-test",
+				maxTokens: NONSTREAM_MAX_OUTPUT_TOKENS,
+			});
+			expect(mockCreate).toHaveBeenCalledTimes(1);
+			expect(mockStream).not.toHaveBeenCalled();
+
+			mockCreate.mockClear();
+			await callLlm({
+				action: "translate",
+				params: { content: "x" },
+				apiKey: "sk-ant-test",
+				maxTokens: NONSTREAM_MAX_OUTPUT_TOKENS + 1,
+			});
+			expect(mockStream).toHaveBeenCalledTimes(1);
+			expect(mockCreate).not.toHaveBeenCalled();
+		});
+
+		it("treats the prompt-char boundary correctly: prompt == limit stays non-streaming, +1 streams", async () => {
+			// The decision compares prompt.length (the FILLED template), not the raw
+			// param. Measure the template overhead with a probe call, then size
+			// `content` to land the prompt exactly on NONSTREAM_MAX_PROMPT_CHARS — with
+			// a tiny maxTokens so only the input axis decides. This pins the `<=` on
+			// the input side (a `<` slip or wrong constant breaks one assertion).
+			const probe = "PROBE";
+			await callLlm({ action: "translate", params: { content: probe }, apiKey: "sk-ant-test", maxTokens: 256 });
+			const probeBody = mockCreate.mock.calls.at(-1)?.[0] as { messages: { content: string }[] };
+			const overhead = probeBody.messages[0].content.length - probe.length;
+
+			mockCreate.mockClear();
+			mockStream.mockClear();
+			await callLlm({
+				action: "translate",
+				params: { content: "x".repeat(NONSTREAM_MAX_PROMPT_CHARS - overhead) },
+				apiKey: "sk-ant-test",
+				maxTokens: 256,
+			});
+			expect(mockCreate).toHaveBeenCalledTimes(1);
+			expect(mockStream).not.toHaveBeenCalled();
+			// Confirm we actually landed on the boundary, not merely under it.
+			const atLimitBody = mockCreate.mock.calls.at(-1)?.[0] as { messages: { content: string }[] };
+			expect(atLimitBody.messages[0].content.length).toBe(NONSTREAM_MAX_PROMPT_CHARS);
+
+			mockCreate.mockClear();
+			await callLlm({
+				action: "translate",
+				params: { content: "x".repeat(NONSTREAM_MAX_PROMPT_CHARS - overhead + 1) },
+				apiKey: "sk-ant-test",
+				maxTokens: 256,
+			});
+			expect(mockStream).toHaveBeenCalledTimes(1);
+			expect(mockCreate).not.toHaveBeenCalled();
+		});
+
+		it("uses streaming when forceStreaming is set, even for an otherwise-trivial call", async () => {
+			// forceStreaming's only remaining job is to force the streaming path on a
+			// call that WOULD be trivial (small output AND small prompt). Use exactly
+			// such a call (maxTokens 256 + tiny prompt) so this test actually guards
+			// the `forceStreaming === true ||` branch — dropping that branch would
+			// route this to messages.create and fail the assertion.
+			await callLlm({
+				action: "translate",
+				params: { content: "x" },
+				apiKey: "sk-ant-test",
+				model: "claude-sonnet-4-6",
+				maxTokens: 256,
 				forceStreaming: true,
 			});
 
 			expect(mockStream).toHaveBeenCalledTimes(1);
 			expect(mockCreate).not.toHaveBeenCalled();
+		});
+
+		it("logs the streaming path decision (observability) with the reason on every direct call", async () => {
+			// A successful call otherwise records nothing about the chosen path;
+			// this info log lets debug.log confirm streaming-vs-non-streaming (and
+			// why) without forcing a failure. Verify the decision + reason per case.
+
+			// trivial → non-streaming
+			await callLlm({ action: "translate", params: { content: "x" }, apiKey: "sk-ant-test", maxTokens: 256 });
+			expect(mockLogInfo).toHaveBeenCalledWith(
+				expect.stringContaining("Direct path: action=%s streaming=%s reason=%s"),
+				"translate",
+				false,
+				"trivial(small output+prompt)",
+				256,
+				expect.any(Number),
+				NONSTREAM_MAX_OUTPUT_TOKENS,
+				NONSTREAM_MAX_PROMPT_CHARS,
+			);
+
+			// large output only → streaming
+			mockLogInfo.mockClear();
+			await callLlm({ action: "translate", params: { content: "x" }, apiKey: "sk-ant-test", maxTokens: 8192 });
+			expect(mockLogInfo).toHaveBeenCalledWith(
+				expect.stringContaining("streaming=%s reason=%s"),
+				"translate",
+				true,
+				"large output",
+				8192,
+				expect.any(Number),
+				NONSTREAM_MAX_OUTPUT_TOKENS,
+				NONSTREAM_MAX_PROMPT_CHARS,
+			);
+
+			// large output AND large prompt → streaming (covers the combined reason)
+			mockLogInfo.mockClear();
+			await callLlm({
+				action: "translate",
+				params: { content: "x".repeat(NONSTREAM_MAX_PROMPT_CHARS + 1) },
+				apiKey: "sk-ant-test",
+				maxTokens: 8192,
+			});
+			expect(mockLogInfo).toHaveBeenCalledWith(
+				expect.stringContaining("reason=%s"),
+				"translate",
+				true,
+				"large output+prompt",
+				8192,
+				expect.any(Number),
+				NONSTREAM_MAX_OUTPUT_TOKENS,
+				NONSTREAM_MAX_PROMPT_CHARS,
+			);
 		});
 
 		it("aborts a streaming call when no stream events arrive within the idle window", async () => {
@@ -763,6 +985,21 @@ describe("LlmClient", () => {
 					jolliApiKey: "sk-jol-test.secret",
 				}),
 			).rejects.toBe(transport);
+
+			// Diagnostic parity with the direct path: the proxy catch logs
+			// elapsedMs + bodyChars + errorName so a wall-clock-timeout abort (≈180s,
+			// name AbortError) is distinguishable from a transport failure that fails
+			// faster with a populated cause.
+			expect(mockLogError).toHaveBeenCalledWith(
+				expect.stringMatching(/elapsedMs=%d.*bodyChars=%d.*errorName=%s/),
+				"commit-message",
+				expect.stringContaining("/api/push/llm/complete"),
+				expect.any(Number),
+				expect.any(Number),
+				"TypeError",
+				"fetch failed",
+				expect.any(String),
+			);
 		});
 
 		it("rethrows when fetch rejects with a non-Error value", async () => {
@@ -1028,6 +1265,25 @@ describe("LlmClient", () => {
 			// proxy fetch wraps — gets the same budget.
 			expect(DIRECT_FETCH_TIMEOUT_MS).toBe(180_000);
 			expect(PROXY_FETCH_TIMEOUT_MS).toBe(180_000);
+		});
+	});
+
+	describe("streaming carve-out thresholds", () => {
+		it("pins the non-streaming carve-out limits (a change here flips which calls stream)", () => {
+			// The direct path streams unless a call is small on BOTH axes. These
+			// values gate that decision; a regression here silently re-routes a
+			// whole class of calls onto the fixed-budget non-streaming path.
+			expect(NONSTREAM_MAX_OUTPUT_TOKENS).toBe(512);
+			expect(NONSTREAM_MAX_PROMPT_CHARS).toBe(16_000);
+		});
+
+		it("keeps the commit-message diff budget under the non-streaming prompt limit (cross-module headroom)", () => {
+			// commit-message truncates its diff to COMMIT_MSG_DIFF_BUDGET specifically
+			// so the assembled prompt (diff + template + fileList) stays under
+			// NONSTREAM_MAX_PROMPT_CHARS and keeps the fast non-streaming path. These
+			// two constants live in different modules; bumping the budget past the
+			// limit would silently re-route every commit-message onto streaming.
+			expect(COMMIT_MSG_DIFF_BUDGET).toBeLessThan(NONSTREAM_MAX_PROMPT_CHARS);
 		});
 	});
 });

--- a/cli/src/core/LlmClient.ts
+++ b/cli/src/core/LlmClient.ts
@@ -70,9 +70,12 @@ const LLM_PROXY_PATH = "/api/push/llm/complete";
  * End-to-end timeout for proxy LLM calls (covers connect + headers + body).
  * The backend invokes Anthropic non-streaming inside this request, so 180s is
  * generous for a full LLM round-trip while bounding how long a stuck request
- * can hold the QueueWorker file lock. Moved in lockstep with
- * `DIRECT_FETCH_TIMEOUT_MS` so both paths share one wall-clock budget.
- * Exported so a regression test can pin the value.
+ * can hold the QueueWorker file lock. Historically moved in lockstep with
+ * `DIRECT_FETCH_TIMEOUT_MS`, but that rationale no longer holds: the direct
+ * path now streams by default and its non-streaming budget governs only
+ * trivially-small calls, whereas this proxy budget governs ALL proxy calls
+ * (which have no streaming escape). They happen to share 180s today but should
+ * be evaluated independently. Exported so a regression test can pin the value.
  */
 export const PROXY_FETCH_TIMEOUT_MS = 180_000;
 
@@ -94,15 +97,29 @@ export const PROXY_FETCH_TIMEOUT_MS = 180_000;
 export const DIRECT_FETCH_TIMEOUT_MS = 180_000;
 
 /**
- * `max_tokens` above which a direct Anthropic call switches from non-streaming
- * `messages.create` to `messages.stream` (see the call site for the SDK's
- * "Streaming is strongly recommended" guard). Exported because callers tune
- * `maxTokens` *relative to this value* to force one path or the other — most
- * notably the ingest route call (`ROUTE_MAX_TOKENS`), which sits just above it
- * on purpose. Keeping it a shared constant means changing the threshold can't
- * silently flip a caller onto the other path's timeout behaviour.
+ * The direct path **streams by default**. A call takes the simple non-streaming
+ * `messages.create` path only when it is "trivially small" — small on BOTH
+ * axes: output cap ≤ {@link NONSTREAM_MAX_OUTPUT_TOKENS} AND prompt length ≤
+ * {@link NONSTREAM_MAX_PROMPT_CHARS}. Everything else streams.
+ *
+ * Why default to streaming: a non-streaming request has no liveness signal, so
+ * a single fixed wall-clock deadline ({@link DIRECT_FETCH_TIMEOUT_MS}) cannot
+ * tell "healthy but slow" from "wedged socket" — it either kills legitimately
+ * slow large calls or waits the full budget on a dead one. The streaming path's
+ * inactivity watchdog ({@link STREAM_IDLE_TIMEOUT_MS}) governs by liveness
+ * instead: a healthy-but-slow call (big prompt and/or big output) keeps the
+ * `ping` events flowing and completes, while a wedged socket trips the watchdog
+ * and fails fast. So any call that might run long belongs on the streaming path.
+ *
+ * Why BOTH axes: a small-output action can still carry a large input — most
+ * notably `commit-message`, whose `max_tokens` is tiny (256) but whose staged
+ * diff can be huge. Gating only on output would wrongly keep such a call on the
+ * fixed-budget non-streaming path. `finalMessage()` returns the same
+ * `Anthropic.Message` shape `messages.create` returns, so downstream code is
+ * unchanged either way. Exported so a regression test can pin the values.
  */
-export const STREAMING_THRESHOLD_TOKENS = 16_384;
+export const NONSTREAM_MAX_OUTPUT_TOKENS = 512;
+export const NONSTREAM_MAX_PROMPT_CHARS = 16_000;
 
 /**
  * Inactivity budget for the streaming direct path. Streaming is selected for
@@ -211,13 +228,12 @@ export interface LlmCallOptions extends LlmCredentials {
 	/** Max output tokens (direct mode only, default 8192) */
 	readonly maxTokens?: number;
 	/**
-	 * Force the direct path onto `messages.stream` regardless of `maxTokens`.
-	 * Use when a call may run long enough to trip the SDK's non-streaming "10
-	 * minute" refusal even below {@link STREAMING_THRESHOLD_TOKENS} (e.g. the
-	 * ingest route call). Replaces the old trick of padding `maxTokens` just
-	 * above the threshold to coerce the streaming path — an explicit flag can't
-	 * be silently undone by retuning the threshold or the token count. No effect
-	 * in proxy mode.
+	 * Force the direct path onto `messages.stream` regardless of size. Rarely
+	 * needed now that the direct path streams by default for anything but a
+	 * trivially-small call (see {@link NONSTREAM_MAX_OUTPUT_TOKENS}), but kept as
+	 * an explicit override for callers that want to guarantee the streaming path
+	 * even for a small call (e.g. the ingest route call). An explicit flag can't
+	 * be silently undone by retuning the size thresholds. No effect in proxy mode.
 	 */
 	readonly forceStreaming?: boolean;
 	/** Optional prompt revision to pin (proxy mode only) */
@@ -335,17 +351,40 @@ async function callDirect(
 	const client = getOrCreateClient(apiKey);
 	const startTime = Date.now();
 
-	// Anthropic SDK refuses non-streaming `messages.create` when the request's
-	// estimated duration exceeds 10 minutes (sees `max_tokens` and the model's
-	// output speed and errors out with "Streaming is strongly recommended").
-	// Empirically the threshold lands around `max_tokens > ~20k` for the
-	// current generation; cross it via `messages.stream` instead so any caller
-	// (the merge path raised this to 64k) keeps working without a per-call
-	// switch. `finalMessage()` resolves to the same `Anthropic.Message` shape
-	// `messages.create` returns, so the downstream code is unchanged.
-	// `forceStreaming` lets a caller pick streaming explicitly even below the
-	// token threshold (the ingest route call) instead of padding maxTokens.
-	const useStreaming = options.forceStreaming === true || maxTokens > STREAMING_THRESHOLD_TOKENS;
+	// Stream by default; only a "trivially small" call — small on BOTH the output
+	// cap AND the prompt size — takes the simple non-streaming `messages.create`
+	// path. See NONSTREAM_MAX_OUTPUT_TOKENS / NONSTREAM_MAX_PROMPT_CHARS for the
+	// rationale (liveness watchdog beats a fixed wall-clock for anything that may
+	// run long, and a tiny-output action like commit-message can still carry a
+	// huge diff). `forceStreaming` still forces streaming. The SDK's non-streaming
+	// "10-minute" refusal is moot: any call large enough to approach it streams.
+	const isTrivialCall = maxTokens <= NONSTREAM_MAX_OUTPUT_TOKENS && prompt.length <= NONSTREAM_MAX_PROMPT_CHARS;
+	const useStreaming = options.forceStreaming === true || !isTrivialCall;
+
+	// Observability: a successful direct call otherwise logs nothing about which
+	// path it took, so streaming-vs-non-streaming can't be confirmed from
+	// debug.log without forcing a failure. Emit the decision + the inputs behind
+	// it at info level (debug level is not persisted to debug.log).
+	const streamReason =
+		options.forceStreaming === true
+			? "forceStreaming"
+			: !useStreaming
+				? "trivial(small output+prompt)"
+				: maxTokens > NONSTREAM_MAX_OUTPUT_TOKENS && prompt.length > NONSTREAM_MAX_PROMPT_CHARS
+					? "large output+prompt"
+					: maxTokens > NONSTREAM_MAX_OUTPUT_TOKENS
+						? "large output"
+						: "large prompt";
+	log.info(
+		"Direct path: action=%s streaming=%s reason=%s maxTokens=%d promptChars=%d (non-stream needs maxTokens<=%d AND promptChars<=%d)",
+		options.action,
+		useStreaming,
+		streamReason,
+		maxTokens,
+		prompt.length,
+		NONSTREAM_MAX_OUTPUT_TOKENS,
+		NONSTREAM_MAX_PROMPT_CHARS,
+	);
 
 	let response: Anthropic.Message;
 	try {
@@ -410,14 +449,31 @@ async function callDirect(
 		// ran before aborting, so "prompt too big for the 180s budget" is
 		// distinguishable from a genuinely wedged connection without re-running.
 		const elapsedMs = Date.now() - startTime;
+		// errorName / httpStatus / requestId separate the failure modes that share
+		// the "Request was aborted. cause=(none)" fingerprint. A wedged/slow call
+		// killed by our AbortSignal surfaces as an abort with NO httpStatus and NO
+		// requestId (the response never came). A server-side failure (rate limit
+		// 429, overloaded 529, 5xx) carries an httpStatus, and any request that
+		// actually reached Anthropic carries a requestId — so "the API rejected us"
+		// is distinguishable from "the connection never produced a response".
+		const errorName = err instanceof Error ? err.name : "(non-error)";
+		const httpStatus = (err as { status?: number })?.status;
+		// `||` (not `??`) so an empty-string id falls through to the camelCase
+		// fallback and then to "(none)" rather than logging a blank field. The
+		// current SDK sets `request_id` (snake_case) from the `request-id` header;
+		// `requestID` is a defensive fallback for other/older error shapes.
+		const requestId = (err as { request_id?: string })?.request_id || (err as { requestID?: string })?.requestID;
 		log.error(
-			"Direct LLM call failed: action=%s model=%s maxTokens=%d promptChars=%d elapsedMs=%d baseUrl=%s error=%s cause=%s",
+			"Direct LLM call failed: action=%s model=%s maxTokens=%d promptChars=%d elapsedMs=%d baseUrl=%s errorName=%s httpStatus=%s requestId=%s error=%s cause=%s",
 			options.action,
 			model,
 			maxTokens,
 			prompt.length,
 			elapsedMs,
 			baseUrl,
+			errorName,
+			httpStatus === undefined ? "(none)" : String(httpStatus),
+			requestId || "(none)",
 			message,
 			cause,
 		);
@@ -503,9 +559,25 @@ async function callProxy(
 		// Transport-layer failure (DNS, TLS handshake, connect, reset, timeout).
 		// undici wraps the real reason in `cause` — without surfacing it the log
 		// is just "fetch failed" and the operator has no way to diagnose.
+		// elapsedMs / bodyChars / errorName bring the proxy path to diagnostic
+		// parity with the direct path: elapsedMs ≈ PROXY_FETCH_TIMEOUT_MS plus an
+		// AbortError name marks a wall-clock-timeout abort (the backend stalled or
+		// the connection wedged), versus a transport error that fails faster with
+		// a populated cause; bodyChars is the proxy-side analog of promptChars.
+		const elapsedMs = Date.now() - startTime;
 		const message = err instanceof Error ? err.message : String(err);
 		const cause = err instanceof Error ? formatCause((err as { cause?: unknown }).cause) : "(non-error)";
-		log.error("Proxy LLM fetch failed: action=%s url=%s error=%s cause=%s", options.action, url, message, cause);
+		const errorName = err instanceof Error ? err.name : "(non-error)";
+		log.error(
+			"Proxy LLM fetch failed: action=%s url=%s elapsedMs=%d bodyChars=%d errorName=%s error=%s cause=%s",
+			options.action,
+			url,
+			elapsedMs,
+			body.length,
+			errorName,
+			message,
+			cause,
+		);
 		throw err;
 	}
 	const elapsed = Date.now() - startTime;

--- a/cli/src/core/Summarizer.test.ts
+++ b/cli/src/core/Summarizer.test.ts
@@ -12,6 +12,7 @@ vi.spyOn(console, "error").mockImplementation(() => {});
 
 import type { CommitInfo, CommitMessageParams, DiffStats } from "../Types.js";
 import {
+	COMMIT_MSG_DIFF_BUDGET,
 	extractTicketIdFromMessage,
 	formatSourceCommitsForSquash,
 	generateCommitMessage,
@@ -1277,6 +1278,45 @@ ${delimited({
 					params: expect.objectContaining({
 						stagedDiff: "(empty diff -- no staged changes)",
 					}),
+				}),
+			);
+		});
+
+		it("truncates a staged diff that exceeds COMMIT_MSG_DIFF_BUDGET and marks it", async () => {
+			// A one-line message doesn't need the whole diff; an oversized diff would
+			// also push the call off the fast non-streaming path. The head is kept,
+			// the full file list rides along separately, and a marker records the cut.
+			mockCallLlm.mockResolvedValueOnce(summaryLlmResult("Refactor the storage layer"));
+			// Distinctive head/tail sentinels so the cut point is actually verified:
+			// the head must survive, the tail (past the budget) must be dropped.
+			const head = "HEAD_KEEP_";
+			const tail = "_TAIL_DROP";
+			const hugeDiff = head + "x".repeat(COMMIT_MSG_DIFF_BUDGET) + tail;
+
+			await generateCommitMessage({ ...mockCommitMessageParams, stagedDiff: hugeDiff });
+
+			const sent = mockCallLlm.mock.calls.at(-1)?.[0] as LlmCallOptions;
+			const [keptHead, marker] = sent.params.stagedDiff.split("\n--- diff truncated");
+			// Exactly the budget's worth of head is kept — not more, not less.
+			expect(keptHead.length).toBe(COMMIT_MSG_DIFF_BUDGET);
+			expect(keptHead.startsWith(head)).toBe(true);
+			// Everything past the budget (incl. the tail sentinel) is dropped.
+			expect(sent.params.stagedDiff).not.toContain(tail);
+			// Marker cites the ORIGINAL total length.
+			expect(marker).toContain(`(${hugeDiff.length} chars total)`);
+			// File list is unaffected — it's the highest-signal input for a one-liner.
+			expect(sent.params.fileList).toBe("src/Foo.ts");
+		});
+
+		it("leaves a diff at exactly COMMIT_MSG_DIFF_BUDGET untouched (boundary)", async () => {
+			mockCallLlm.mockResolvedValueOnce(summaryLlmResult("Tidy imports"));
+			const exactDiff = "y".repeat(COMMIT_MSG_DIFF_BUDGET);
+
+			await generateCommitMessage({ ...mockCommitMessageParams, stagedDiff: exactDiff });
+
+			expect(mockCallLlm).toHaveBeenCalledWith(
+				expect.objectContaining({
+					params: expect.objectContaining({ stagedDiff: exactDiff }),
 				}),
 			);
 		});

--- a/cli/src/core/Summarizer.ts
+++ b/cli/src/core/Summarizer.ts
@@ -61,6 +61,18 @@ export function resolveModelId(aliasOrId: string | undefined): string {
 const DEFAULT_MAX_TOKENS = 8192;
 
 /**
+ * Character budget for the staged diff fed to the `commit-message` call. The
+ * output is a single line, so the full diff is wasteful: it costs tokens and
+ * latency, and a large diff would push the call off the fast non-streaming path
+ * (see LlmClient's NONSTREAM_MAX_PROMPT_CHARS). We keep only the head of the
+ * diff — the complete file list is sent separately as `fileList`, which is the
+ * highest-signal input for a one-line message — and append a truncation marker.
+ * Sized below NONSTREAM_MAX_PROMPT_CHARS so the call stays in the fast lane even
+ * after the template and file list are added. Exported so a test can pin it.
+ */
+export const COMMIT_MSG_DIFF_BUDGET = 12_000;
+
+/**
  * Result from generateSummary -- fields to be spread onto a CommitSummary.
  * Replaces the deprecated SummaryRecord as the return type.
  */
@@ -669,10 +681,18 @@ export async function generateCommitMessage(params: CommitMessageParams): Promis
 
 	const { config } = params;
 	const fileList = params.stagedFiles.join(", ") || "(none)";
+	// A one-line commit message doesn't need the whole diff — cap it to the head
+	// within COMMIT_MSG_DIFF_BUDGET (fileList carries the full file list) so the
+	// call stays cheap and on the fast non-streaming path even for huge commits.
+	const rawDiff = params.stagedDiff || "(empty diff -- no staged changes)";
+	const stagedDiff =
+		rawDiff.length > COMMIT_MSG_DIFF_BUDGET
+			? `${rawDiff.slice(0, COMMIT_MSG_DIFF_BUDGET)}\n--- diff truncated (${rawDiff.length} chars total); full file list provided separately, head of diff shown above ---`
+			: rawDiff;
 	const llmResult = await callLlm({
 		action: "commit-message",
 		params: {
-			stagedDiff: params.stagedDiff || "(empty diff -- no staged changes)",
+			stagedDiff,
 			branch: params.branch,
 			fileList,
 		},


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

AI summary features that previously froze for several minutes before failing with an unhelpful error will now fail faster or complete successfully. The root cause was that every AI call, regardless of how large the input was, traveled through a fixed-timeout non-streaming channel with no way to detect whether the connection was alive. The fix makes streaming the default for any call where either the expected output or the input text is large enough to run long; only requests that are small on both dimensions continue to use the simpler non-streaming path.

Alongside the routing fix, the action that generates a one-line commit message now caps how much diff content it sends to the AI. For large staged changes, only the beginning of the diff is included, and the full list of changed files is always sent separately. The list of files is the most useful signal for a short summary, so the cap removes the risk of an oversized request without meaningfully reducing the quality of the generated message.

Developers can now verify streaming behavior on any live call directly from the application log. Every AI call writes a log entry naming the exact reason the streaming or non-streaming path was chosen — whether the request was too large in output tokens, too large in prompt text, both, or explicitly forced — along with the raw numbers and the thresholds they were compared against. Confirming that the fix is working on a given call now requires only a log search, with no need to simulate failures or instrument a test environment.

---

## Topics (3)
<details>
<summary><strong>01 · Observability logging added for every AI streaming path decision</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After fixing the AI client to stream by default for large requests, there was no way to confirm from the application log whether a given call actually took the streaming path or the non-streaming path. A successful call left no trace of which route was chosen, making the fix unverifiable without deliberately causing a failure.

**💡 Decisions Behind the Code**

- **Info level over debug level**: The application log file only persists `info`-and-above entries; `debug` entries are discarded. Emitting at `debug` level would have produced no visible output in the log, defeating the entire purpose of the change. Using `info` level ensures the decision appears on every call without requiring a failure to be manufactured.
- **Five named reason strings over a boolean flag**: A plain true/false streaming flag would confirm the outcome but not explain it. Naming the specific axis that triggered streaming (`large output`, `large prompt`, or both) lets a developer reading the log immediately understand whether the token limit, the prompt size, or an explicit override drove the decision, without needing to cross-reference thresholds in the source code.

**✅ What Was Implemented**

- `cli/src/core/LlmClient.ts`: added an `info`-level log statement immediately after the streaming decision is made in `callDirect`. The log emits the action name, the boolean streaming decision, a human-readable `streamReason` (one of five values: `forceStreaming`, `trivial(small output+prompt)`, `large output`, `large prompt`, `large output+prompt`), the token limit, the prompt character count, and the two threshold constants used to make the decision.
- `cli/src/core/LlmClient.test.ts`: added a new test covering all three newly reachable `streamReason` branches (`trivial`, `large output`, `large output+prompt`), verifying the exact log arguments for each. The existing suite already covered `forceStreaming` and `large prompt`, bringing the new branches to full coverage alongside the existing 63 passing tests.

**📁 FILES**
- `cli/src/core/LlmClient.ts`
- `cli/src/core/LlmClient.test.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · AI calls now stream by default unless both input and output are provably small</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Two users reported that AI summary features were freezing for up to three minutes before failing with a cryptic error. Investigation revealed that all calls were routed through a fixed 180-second non-streaming channel regardless of input size, leaving no way to distinguish a slow-but-healthy request from a completely stuck connection.

**💡 Decisions Behind the Code**

- **Default to streaming rather than computing a duration budget**: The team considered estimating total call duration from input size, output cap, and a per-model decode-speed table, but rejected it as fragile and hard to maintain. The streaming path's inactivity watchdog already solves the core problem by detecting liveness rather than predicting duration, so the right move was to make streaming the default and carve out only calls that are provably tiny on both axes.
- **Both axes must be small, not just one**: The original threshold only checked the output cap, which meant a call generating a short response from a huge input — the motivating failure case — was still routed to the fixed-budget non-streaming path. Requiring both the output cap and the prompt to be small closes that gap. The specific values were chosen so that the most common fast calls (short commit messages, small translations) stay on the non-streaming path while anything that could plausibly run long is moved to streaming.
- **Do not lower the 180-second non-streaming timeout**: Lowering the timeout to 120 seconds was discussed but deferred. After the routing change, the non-streaming path only handles trivially small calls that complete in seconds, so the timeout value matters less. The proxy path still carries all proxy calls with no streaming escape, so lowering its timeout would risk killing healthy large proxy calls — a problem the proxy-side streaming work must solve first.

**✅ What Was Implemented**

- `LlmClient.ts` replaced the single output-token threshold with a two-axis rule: a call takes the non-streaming path only when both the output cap is at or below 512 tokens AND the prompt is at or below 16,000 characters. Everything else streams. The old `STREAMING_THRESHOLD_TOKENS` constant was deleted and replaced with two exported constants `NONSTREAM_MAX_OUTPUT_TOKENS` and `NONSTREAM_MAX_PROMPT_CHARS`. The comment on the proxy timeout constant was updated to note that the two timeouts no longer share the same rationale and should be evaluated independently.
- The direct-path error catch block was enriched with three new diagnostic fields logged on every failure: the error class name, the HTTP status code (when the server returned one), and the Anthropic request ID (when the request reached the server). The proxy catch block was brought to parity with elapsed time, body size, and error class name, making it possible to distinguish a wedged connection from a server-side rejection without re-running the failing call.

**📋 Future Enhancements**

- End-to-end streaming support for the proxy (Jolli backend) path requires backend cooperation and is a separate workstream; the proxy path remains non-streaming and retains its 180-second timeout.
- The inactivity watchdog's 120-second first-event window is slightly tighter than the non-streaming 180-second budget; under extreme server load a healthy streaming call could be killed. A separate first-connection timeout could address this.

**📁 FILES**
- `cli/src/core/LlmClient.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Commit message generation now caps oversized diffs before sending to AI</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The action that generates a one-line commit message had no limit on how much diff content it would send to the AI model. A large staged change could produce a prompt big enough to push the call off the fast non-streaming path or cause a timeout, even though a one-line message needs only a fraction of that content.

**💡 Decisions Behind the Code**

- **Truncate at the shared generation function, not at each call site**: Placing the cap where all callers converge ensures it applies regardless of which editor or CLI path triggered the commit message request, with no risk of a call site being missed.
- **Exclude the file list from truncation**: The list of changed files is the most useful signal for writing a one-line summary. The diff head provides supporting context, but truncating the diff while always sending the full file list preserves the highest-value input even for very large commits.

**✅ What Was Implemented**

`Summarizer.ts` gained a new exported constant `COMMIT_MSG_DIFF_BUDGET` (12,000 characters) and truncation logic inside `generateCommitMessage`. When the staged diff exceeds the budget, only the head of the diff is kept and a marker is appended recording the original total length. The complete file list is always sent in full as a separate parameter, preserving the highest-signal input for a one-line message.

**📁 FILES**
- `cli/src/core/Summarizer.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 24, 2026 at 5:06 PM · via Anthropic*
<!-- jollimemory-summary-end -->