### PR TITLE
Redesign IntelliJ sidebar to match the new UX mockup

### DIFF
--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/JolliColors.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/JolliColors.kt
@@ -1,0 +1,17 @@
+package ai.jolli.jollimemory
+
+import com.intellij.ui.JBColor
+
+/**
+ * Brand accent colors for the redesigned sidebar.
+ *
+ * The single Jolli accent (`#6BA5F8`) mirrors the `--jolli-accent` token from the
+ * sidebar redesign mockup. Per the mockup's wiring notes the accent is used for
+ * **accents only** — selected-tab underlines, focus rings, small indicators —
+ * never for body text or large backgrounds, which stay on the platform's
+ * theme-aware `JBColor`/`UIManager` tokens so light/dark/high-contrast keep working.
+ */
+object JolliColors {
+    /** Jolli brand accent (mockup `--jolli-accent #6ba5f8`). Same value in light + dark. */
+    val Accent: JBColor = JBColor(0x6BA5F8, 0x6BA5F8)
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/PinStore.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/PinStore.kt
@@ -1,0 +1,117 @@
+package ai.jolli.jollimemory.core
+
+import ai.jolli.jollimemory.core.JmLogger.JOLLIMEMORY_DIR
+import ai.jolli.jollimemory.core.JmLogger.JOLLI_DIR
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import java.io.File
+import java.time.Instant
+
+/**
+ * PinStore — persists the items the user has PINNED so they survive across
+ * sessions and surface in the redesigned "Pinned" section.
+ *
+ * Each pin is a [PinnedEntry] capturing the item's `kind` (conversations / plans /
+ * notes / references / memories), its `key` (the same key used by
+ * [CommitSelectionStore] — e.g. `conversationKey(source, sessionId)`, a plan slug,
+ * a note id, a reference mapKey, or a commit hash), and a display `title` snapshot
+ * so the Pinned section can render a meaningful row without re-resolving the item.
+ *
+ * Stored under `<projectDir>/.jolli/jollimemory/pins.json`. The directory is
+ * per-project and therefore worktree-scoped (mirrors [CommitSelectionStore]).
+ */
+object PinStore {
+
+	private val log = JmLogger.create("PinStore")
+	private const val PIN_FILE = "pins.json"
+	private const val PIN_VERSION = 1
+	private val gson = Gson()
+
+	data class PinnedEntry(
+		val kind: String,
+		val key: String,
+		val title: String,
+		/** Short tag mirroring the source row's badge — a source name (conversations) or
+		 *  a letter tag (P/N/S/L/GH/J/No for context). Drives the Pinned row's icon. */
+		val badge: String,
+		val pinnedAt: String,
+	)
+
+	private fun pinFile(projectDir: String): File {
+		return File(projectDir, "$JOLLI_DIR/$JOLLIMEMORY_DIR/$PIN_FILE")
+	}
+
+	/** All pins, newest first. */
+	fun readPins(projectDir: String): List<PinnedEntry> {
+		val file = pinFile(projectDir)
+		if (!file.exists()) return emptyList()
+
+		return try {
+			val json = gson.fromJson(file.readText(), JsonObject::class.java) ?: return emptyList()
+			if (json.get("version")?.asInt != PIN_VERSION) {
+				log.warn("readPins version mismatch — ignoring file")
+				return emptyList()
+			}
+			val arr = json.getAsJsonArray("pins") ?: return emptyList()
+			arr.mapNotNull { el ->
+				val o = el as? JsonObject ?: return@mapNotNull null
+				val kind = o.get("kind")?.asString ?: return@mapNotNull null
+				val key = o.get("key")?.asString ?: return@mapNotNull null
+				PinnedEntry(
+					kind = kind,
+					key = key,
+					title = o.get("title")?.asString ?: key,
+					badge = o.get("badge")?.asString ?: "",
+					pinnedAt = o.get("pinnedAt")?.asString ?: "",
+				)
+			}.sortedByDescending { it.pinnedAt }
+		} catch (ex: Exception) {
+			log.warn("readPins failed: %s", ex.message)
+			emptyList()
+		}
+	}
+
+	fun isPinned(projectDir: String, kind: String, key: String): Boolean =
+		readPins(projectDir).any { it.kind == kind && it.key == key }
+
+	/** Pins an item (or refreshes its title/badge/timestamp if already pinned). */
+	fun pin(projectDir: String, kind: String, key: String, title: String, badge: String) {
+		val now = Instant.now().toString()
+		val current = readPins(projectDir).filterNot { it.kind == kind && it.key == key }
+		write(projectDir, current + PinnedEntry(kind, key, title, badge, now))
+	}
+
+	fun unpin(projectDir: String, kind: String, key: String) {
+		val current = readPins(projectDir)
+		val next = current.filterNot { it.kind == kind && it.key == key }
+		if (next.size != current.size) write(projectDir, next)
+	}
+
+	private fun write(projectDir: String, pins: List<PinnedEntry>) {
+		val file = pinFile(projectDir)
+		file.parentFile?.mkdirs()
+
+		val payload = mapOf(
+			"version" to PIN_VERSION,
+			"pins" to pins.map {
+				mapOf(
+					"kind" to it.kind, "key" to it.key, "title" to it.title,
+					"badge" to it.badge, "pinnedAt" to it.pinnedAt,
+				)
+			},
+		)
+
+		val tmp = File(file.parentFile, "${file.name}.tmp-${ProcessHandle.current().pid()}-${System.currentTimeMillis()}")
+		try {
+			tmp.writeText(gson.toJson(payload))
+			if (!tmp.renameTo(file)) {
+				// renameTo can fail on Windows; fall back to overwrite
+				file.writeText(tmp.readText())
+				tmp.delete()
+			}
+		} catch (ex: Exception) {
+			tmp.delete()
+			throw ex
+		}
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActionBarPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActionBarPanel.kt
@@ -1,0 +1,233 @@
+package ai.jolli.jollimemory.toolwindow
+
+import ai.jolli.jollimemory.JolliMemoryIcons
+import ai.jolli.jollimemory.services.JolliMemoryService
+import ai.jolli.jollimemory.services.PrService
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.impl.SimpleDataContext
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.intellij.util.ui.JBUI
+import java.awt.Dimension
+import java.awt.FlowLayout
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
+import java.awt.event.ComponentAdapter
+import java.awt.event.ComponentEvent
+import javax.swing.JButton
+import javax.swing.JPanel
+import javax.swing.SwingUtilities
+
+/**
+ * Fixed bottom action bar for the redesigned "Current Branch" view, mirroring the
+ * mockup's bottom command group: **Commit · Create PR · ⋯ More**.
+ *
+ * Recall layout **V1**: only Commit is a primary button; Create PR is a secondary
+ * button; Recall (and Sync / Refresh) live in the `⋯` overflow menu.
+ *
+ * Existing logic is reused rather than duplicated:
+ * - Commit fires the registered `JolliMemory.CommitAI` action.
+ * - Create PR uses [PrService] (gh availability/auth check → push → `gh pr create`).
+ * - Recall reuses the "Invoke the jolli-recall skill" clipboard prompt.
+ * - Sync calls [JolliMemoryService.requestManualSync].
+ *
+ * On a foreign (read-only) repo/branch selection, Commit and Create PR are hidden
+ * (mirrors the mockup's `hide-foreign`); only Refresh stays useful.
+ */
+class ActionBarPanel(
+	private val project: Project,
+	private val service: JolliMemoryService,
+) : JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(6), JBUI.scale(4))) {
+
+	private val commitBtn: JButton
+	private val prBtn: JButton
+	private val moreBtn: JButton
+
+	private var foreign = false
+	private var compact = false
+
+	init {
+		border = JBUI.Borders.empty(2, 6)
+
+		commitBtn = JButton("Commit", JolliMemoryIcons.Sparkle).apply {
+			toolTipText = "Commit the checked files with an AI-written message and save a memory."
+			addActionListener { invokeRegisteredAction("JolliMemory.CommitAI") }
+		}
+		prBtn = JButton("Create PR", AllIcons.Vcs.Vendors.Github).apply {
+			toolTipText = "Create a pull request for this branch (drafted from its memories)."
+			addActionListener { handleCreatePr() }
+		}
+		moreBtn = JButton(AllIcons.Actions.More).apply {
+			toolTipText = "More actions"
+			addActionListener { showMoreMenu() }
+		}
+
+		add(commitBtn)
+		add(prBtn)
+		add(moreBtn)
+
+		// Collapse button labels to icon-only when the tool window is narrow (~240px),
+		// matching the mockup's responsive action strip.
+		addComponentListener(object : ComponentAdapter() {
+			override fun componentResized(e: ComponentEvent) {
+				val shouldCompact = width in 1 until JBUI.scale(240)
+				if (shouldCompact != compact) {
+					compact = shouldCompact
+					applyCompact()
+				}
+			}
+		})
+	}
+
+	/** Hide Commit / Create PR when viewing a foreign (read-only) repo/branch. */
+	fun setForeign(isForeign: Boolean) {
+		foreign = isForeign
+		commitBtn.isVisible = !isForeign
+		prBtn.isVisible = !isForeign
+		revalidate()
+		repaint()
+	}
+
+	private fun applyCompact() {
+		commitBtn.text = if (compact) "" else "Commit"
+		prBtn.text = if (compact) "" else "Create PR"
+		revalidate()
+		repaint()
+	}
+
+	// ── Commit ────────────────────────────────────────────────────────────────
+
+	private fun invokeRegisteredAction(actionId: String) {
+		val action = ActionManager.getInstance().getAction(actionId) ?: return
+		val ctx = SimpleDataContext.getProjectContext(project)
+		val event = AnActionEvent.createFromAnAction(action, null, "JolliMemoryActionBar", ctx)
+		action.actionPerformed(event)
+	}
+
+	// ── Recall ──────────────────────────────────────────────────────────────
+
+	private fun copyRecallPrompt() {
+		val branch = service.getGitOps()?.getCurrentBranch()
+		if (branch.isNullOrBlank()) {
+			Messages.showWarningDialog(project, "Could not determine the current branch.", "Recall")
+			return
+		}
+		val prompt = "Invoke the \"jolli-recall\" skill with args \"$branch\"."
+		Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(prompt), null)
+		Messages.showInfoMessage(
+			project,
+			"Recall prompt copied — paste it into your AI coding tool.",
+			"Recall",
+		)
+	}
+
+	// ── Sync / Refresh ──────────────────────────────────────────────────────
+
+	private fun syncToMemoryBank() {
+		ApplicationManager.getApplication().executeOnPooledThread {
+			try {
+				service.requestManualSync()
+				SwingUtilities.invokeLater {
+					Messages.showInfoMessage(project, "Sync to Memory Bank requested.", "Jolli Memory")
+				}
+			} catch (ex: Exception) {
+				SwingUtilities.invokeLater {
+					Messages.showErrorDialog(project, "Sync failed: ${ex.message}", "Jolli Memory")
+				}
+			}
+		}
+	}
+
+	private fun refreshAll() {
+		val registry = service.panelRegistry ?: return
+		registry.changesPanel?.refresh()
+		registry.commitsPanel?.refresh()
+		registry.plansPanel?.refresh()
+		registry.activeConversationsPanel?.refresh()
+		service.refreshStatus()
+	}
+
+	// ── ⋯ More menu ─────────────────────────────────────────────────────────
+
+	private fun showMoreMenu() {
+		val menu = javax.swing.JPopupMenu()
+		if (!foreign) {
+			menu.add(javax.swing.JMenuItem("Recall in Claude Code").apply {
+				addActionListener { copyRecallPrompt() }
+			})
+			menu.add(javax.swing.JMenuItem("Copy recall prompt for other tools").apply {
+				addActionListener { copyRecallPrompt() }
+			})
+			menu.addSeparator()
+			menu.add(javax.swing.JMenuItem("Sync to Memory Bank", JolliMemoryIcons.CloudUpload).apply {
+				addActionListener { syncToMemoryBank() }
+			})
+		}
+		menu.add(javax.swing.JMenuItem("Refresh", JolliMemoryIcons.Refresh).apply {
+			addActionListener { refreshAll() }
+		})
+		menu.show(moreBtn, 0, -menu.preferredSize.height)
+	}
+
+	// ── Create PR ─────────────────────────────────────────────────────────────
+
+	private fun handleCreatePr() {
+		val cwd = service.mainRepoRoot ?: project.basePath ?: return
+		ProgressManager.getInstance().run(object : Task.Backgroundable(project, "Jolli Memory: Preparing PR…", true) {
+			override fun run(indicator: ProgressIndicator) {
+				if (!PrService.isGhAvailable(cwd)) {
+					ApplicationManager.getApplication().invokeLater {
+						Messages.showErrorDialog(
+							project,
+							"GitHub CLI (gh) is not installed or not on PATH. Install it from https://cli.github.com to create PRs.",
+							"Create PR",
+						)
+					}
+					return
+				}
+				if (!PrService.isGhAuthenticated(cwd)) {
+					ApplicationManager.getApplication().invokeLater {
+						Messages.showErrorDialog(
+							project,
+							"GitHub CLI is not authenticated. Run `gh auth login` first.",
+							"Create PR",
+						)
+					}
+					return
+				}
+
+				val branch = PrService.getCurrentBranch(cwd) ?: "this branch"
+				val defaultTitle = branch.substringAfterLast('/').replace('-', ' ').replace('_', ' ')
+				val defaultBody = "Drafted from this branch's Jolli memories.\n\n_Review and edit before creating._"
+
+				ApplicationManager.getApplication().invokeLater {
+					val title = Messages.showInputDialog(
+						project, "PR title:", "Create PR", null, defaultTitle, null,
+					) ?: return@invokeLater
+
+					ApplicationManager.getApplication().executeOnPooledThread {
+						try {
+							PrService.pushBranch(cwd)
+							val url = PrService.createPr(title.ifBlank { defaultTitle }, defaultBody, cwd)
+							ApplicationManager.getApplication().invokeLater {
+								Messages.showInfoMessage(project, "Pull request created:\n$url", "Create PR")
+							}
+						} catch (ex: Exception) {
+							ApplicationManager.getApplication().invokeLater {
+								Messages.showErrorDialog(project, "Create PR failed: ${ex.message}", "Create PR")
+							}
+						}
+					}
+				}
+			}
+		})
+	}
+
+	override fun getMaximumSize(): Dimension = Dimension(Int.MAX_VALUE, preferredSize.height)
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActiveConversationsPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActiveConversationsPanel.kt
@@ -111,6 +111,7 @@ class ActiveConversationsPanel(
 					item = item,
 					onRowClicked = ::onRowClicked,
 					onHide = ::onHide,
+					onPin = ::onPin,
 					onSelectionChanged = ::onSelectionChanged,
 				))
 			}
@@ -157,6 +158,16 @@ class ActiveConversationsPanel(
 		ApplicationManager.getApplication().executeOnPooledThread {
 			HiddenConversationsStore.hideConversation(cwd, item.source, item.sessionId)
 			SwingUtilities.invokeLater { refresh() }
+		}
+	}
+
+	private fun onPin(item: ActiveConversationItem) {
+		val cwd = service.mainRepoRoot ?: project.basePath ?: return
+		val key = CommitSelectionStore.conversationKey(item.source, item.sessionId)
+		val title = item.title.ifBlank { "${item.source.name} conversation" }
+		ApplicationManager.getApplication().executeOnPooledThread {
+			ai.jolli.jollimemory.core.PinStore.pin(cwd, "conversations", key, title, item.source.name)
+			SwingUtilities.invokeLater { service.panelRegistry?.pinnedPanel?.refresh() }
 		}
 	}
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BreadcrumbHeaderPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BreadcrumbHeaderPanel.kt
@@ -1,6 +1,5 @@
 package ai.jolli.jollimemory.toolwindow
 
-import ai.jolli.jollimemory.JolliMemoryIcons
 import ai.jolli.jollimemory.core.KBDataCache
 import ai.jolli.jollimemory.core.KBPathResolver
 import ai.jolli.jollimemory.core.KBRepoDiscoverer
@@ -10,78 +9,51 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.ui.components.JBLabel
 import com.intellij.util.ui.JBUI
 import java.awt.BorderLayout
-import java.awt.Color
 import java.awt.Dimension
-import java.awt.FlowLayout
-import java.awt.event.MouseAdapter
-import java.awt.event.MouseEvent
 import javax.swing.BorderFactory
+import javax.swing.Box
 import javax.swing.BoxLayout
 import javax.swing.DefaultComboBoxModel
 import javax.swing.DefaultListCellRenderer
-import javax.swing.JButton
 import javax.swing.JComboBox
 import javax.swing.JLabel
 import javax.swing.JList
 import javax.swing.JPanel
 import javax.swing.SwingUtilities
-import javax.swing.UIManager
 
 /**
- * Breadcrumb header above the accordion: Repo / Branch selectors + icon buttons.
+ * Breadcrumb header below the view switch: Repo / Branch selectors.
  *
- * When the user selects a foreign repo or branch, [onSelectionChanged] fires
- * so the factory can toggle foreign mode on the panels.
+ * Two modes (set by the factory in response to the [ViewSwitchPanel]):
+ * - [Mode.BRANCH] — Current Branch view: shows `repo / branch` selectors.
+ * - [Mode.REPO_FILTER] — Memory Bank / Knowledge views: shows a single
+ *   "Showing: <repo>" filter (branch part hidden).
+ *
+ * The Memory Bank toggle and the Agents / Settings / Status icons that used to
+ * live here moved to the view switch and the tool window title bar respectively;
+ * this row is now just the repo/branch selectors. Selecting a foreign repo/branch
+ * fires [onSelectionChanged] so the factory can toggle read-only mode.
  */
 class BreadcrumbHeaderPanel(
 	private val service: JolliMemoryService,
 	private val onSelectionChanged: (repo: String?, branch: String?, isForeign: Boolean) -> Unit,
-	private val onShowAccordion: () -> Unit,
-	private val onShowKB: () -> Unit,
-	private val onShowStatus: () -> Unit,
-	private val onSettingsClicked: () -> Unit,
 ) : JPanel(BorderLayout()) {
+
+	enum class Mode { BRANCH, REPO_FILTER }
 
 	private val repoCombo = JComboBox<String>()
 	private val branchCombo = JComboBox<String>()
+	private val showingLabel = JBLabel("Showing:")
+	private val slashLabel = JBLabel("/")
+	private val branchIcon = JBLabel(AllIcons.Vcs.Branch)
+
+	private var mode = Mode.BRANCH
 
 	private var currentRepoName: String? = null
 	private var currentBranch: String? = null
 	private var repos: List<KBRepoDiscoverer.DiscoveredRepo> = emptyList()
 
 	private var suppressEvents = false
-
-	private var kbActive = false
-	private var statusActive = false
-
-	private val memoryBankBtn: JButton
-	private val statusBtn: JButton
-
-	private val toggleBg: Color
-		get() = UIManager.getColor("ActionButton.pressedBackground")
-			?: JBUI.CurrentTheme.ActionButton.pressedBackground()
-
-	private val hoverBg: Color
-		get() = UIManager.getColor("ActionButton.hoverBackground")
-			?: JBUI.CurrentTheme.ActionButton.hoverBackground()
-
-	/** Adds hover highlight to a breadcrumb icon button, respecting active toggle state. */
-	private fun installHover(btn: JButton, isActive: () -> Boolean) {
-		btn.addMouseListener(object : MouseAdapter() {
-			override fun mouseEntered(e: MouseEvent) {
-				if (!isActive()) {
-					btn.background = hoverBg
-					btn.isContentAreaFilled = true
-				}
-			}
-			override fun mouseExited(e: MouseEvent) {
-				if (!isActive()) {
-					btn.background = UIManager.getColor("Panel.background") ?: background
-					btn.isContentAreaFilled = false
-				}
-			}
-		})
-	}
 
 	init {
 		border = JBUI.Borders.empty(4, 8)
@@ -97,75 +69,22 @@ class BreadcrumbHeaderPanel(
 		// Left: repo / branch selectors — BoxLayout so they shrink when the tool window is narrow
 		repoCombo.minimumSize = Dimension(JBUI.scale(30), repoCombo.preferredSize.height)
 		branchCombo.minimumSize = Dimension(JBUI.scale(30), branchCombo.preferredSize.height)
+		showingLabel.isVisible = false
 		val selectorPanel = JPanel().apply {
 			layout = BoxLayout(this, BoxLayout.X_AXIS)
+			add(showingLabel)
+			add(Box.createHorizontalStrut(JBUI.scale(4)))
 			add(JBLabel(AllIcons.Nodes.Module))
-			add(javax.swing.Box.createHorizontalStrut(JBUI.scale(4)))
+			add(Box.createHorizontalStrut(JBUI.scale(4)))
 			add(repoCombo)
-			add(javax.swing.Box.createHorizontalStrut(JBUI.scale(4)))
-			add(JBLabel("/"))
-			add(javax.swing.Box.createHorizontalStrut(JBUI.scale(4)))
-			add(JBLabel(AllIcons.Vcs.Branch))
-			add(javax.swing.Box.createHorizontalStrut(JBUI.scale(4)))
+			add(Box.createHorizontalStrut(JBUI.scale(4)))
+			add(slashLabel)
+			add(Box.createHorizontalStrut(JBUI.scale(4)))
+			add(branchIcon)
+			add(Box.createHorizontalStrut(JBUI.scale(4)))
 			add(branchCombo)
 		}
 		add(selectorPanel, BorderLayout.CENTER)
-
-		// Right: icon buttons (tightly grouped, BoxLayout for vertical alignment with combos)
-		val buttonsPanel = JPanel().apply {
-			layout = BoxLayout(this, BoxLayout.X_AXIS)
-		}
-
-		val btnSize = Dimension(JBUI.scale(22), JBUI.scale(22))
-
-		memoryBankBtn = JButton(JolliMemoryIcons.Book).apply {
-			toolTipText = "Memory Bank"
-			isBorderPainted = false
-			isFocusPainted = false
-			isContentAreaFilled = false
-			isOpaque = true
-			margin = JBUI.emptyInsets()
-			preferredSize = btnSize
-			maximumSize = btnSize
-			minimumSize = btnSize
-			background = parent?.background ?: UIManager.getColor("Panel.background")
-			addActionListener { toggleKB() }
-		}
-		val settingsBtn = JButton(AllIcons.General.GearPlain).apply {
-			toolTipText = "Settings"
-			isBorderPainted = false
-			isFocusPainted = false
-			isContentAreaFilled = false
-			isOpaque = true
-			margin = JBUI.emptyInsets()
-			background = parent?.background ?: UIManager.getColor("Panel.background")
-			preferredSize = btnSize
-			maximumSize = btnSize
-			minimumSize = btnSize
-			addActionListener { onSettingsClicked() }
-		}
-		statusBtn = JButton(JolliMemoryIcons.CircleGreen).apply {
-			toolTipText = "Toggle Status"
-			isBorderPainted = false
-			isFocusPainted = false
-			isContentAreaFilled = false
-			isOpaque = true
-			margin = JBUI.emptyInsets()
-			preferredSize = btnSize
-			maximumSize = btnSize
-			minimumSize = btnSize
-			background = parent?.background ?: UIManager.getColor("Panel.background")
-			addActionListener { toggleStatus() }
-		}
-		buttonsPanel.add(memoryBankBtn)
-		buttonsPanel.add(settingsBtn)
-		buttonsPanel.add(statusBtn)
-		add(buttonsPanel, BorderLayout.EAST)
-
-		// Hover highlights for icon buttons
-		installHover(memoryBankBtn) { kbActive }
-		installHover(settingsBtn) { false }
-		installHover(statusBtn) { statusActive }
 
 		// Selection listeners
 		repoCombo.addActionListener {
@@ -178,58 +97,17 @@ class BreadcrumbHeaderPanel(
 		}
 	}
 
-	private fun toggleKB() {
-		if (kbActive) {
-			// KB is showing → switch back to accordion
-			kbActive = false
-			onShowAccordion()
-		} else {
-			// Show KB; deactivate status so the views stay mutually exclusive
-			kbActive = true
-			statusActive = false
-			onShowKB()
-		}
-		updateButtonHighlights()
-	}
-
-	private fun toggleStatus() {
-		if (statusActive) {
-			// Status card is showing → switch back to accordion
-			statusActive = false
-			onShowAccordion()
-		} else {
-			// Show status full-card; deactivate KB to stay mutually exclusive
-			statusActive = true
-			kbActive = false
-			onShowStatus()
-		}
-		updateButtonHighlights()
-	}
-
-	/**
-	 * External control — used by the factory to force the status card on/off in
-	 * response to service state (e.g., auto-show when Jolli Memory is disabled,
-	 * auto-hide when the user enables it from the status panel itself).
-	 */
-	fun setStatusActive(active: Boolean) {
-		if (statusActive == active) return
-		statusActive = active
-		if (active) {
-			kbActive = false
-			onShowStatus()
-		} else {
-			onShowAccordion()
-		}
-		updateButtonHighlights()
-	}
-
-	private fun updateButtonHighlights() {
-		val defaultBg = UIManager.getColor("Panel.background") ?: background
-		memoryBankBtn.isContentAreaFilled = kbActive
-		memoryBankBtn.background = if (kbActive) toggleBg else defaultBg
-
-		statusBtn.isContentAreaFilled = statusActive
-		statusBtn.background = if (statusActive) toggleBg else defaultBg
+	/** Switches between branch selectors and the repo-filter ("Showing:") display. */
+	fun setMode(newMode: Mode) {
+		if (mode == newMode) return
+		mode = newMode
+		val branchVisible = newMode == Mode.BRANCH
+		slashLabel.isVisible = branchVisible
+		branchIcon.isVisible = branchVisible
+		branchCombo.isVisible = branchVisible
+		showingLabel.isVisible = !branchVisible
+		revalidate()
+		repaint()
 	}
 
 	/** Populate combos. Call from a background thread after KB data is loaded. */
@@ -299,14 +177,6 @@ class BreadcrumbHeaderPanel(
 		val selectedBranch = branchCombo.selectedItem as? String ?: return
 		val isCurrentRepo = repos.find { it.repoName == selectedRepo }?.isCurrentRepo == true
 		val isForeign = !isCurrentRepo || selectedBranch != currentBranch
-
-		// Changing repo/branch always returns to accordion view
-		if (kbActive || statusActive) {
-			kbActive = false
-			statusActive = false
-			onShowAccordion()
-			updateButtonHighlights()
-		}
 
 		onSelectionChanged(
 			if (isForeign) selectedRepo else null,

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationRowComponent.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationRowComponent.kt
@@ -1,5 +1,6 @@
 package ai.jolli.jollimemory.toolwindow
 
+import ai.jolli.jollimemory.JolliMemoryIcons
 import ai.jolli.jollimemory.core.ActiveConversationItem
 import ai.jolli.jollimemory.core.TranscriptSource
 import com.intellij.icons.AllIcons
@@ -21,6 +22,7 @@ class ConversationRowComponent(
 	val item: ActiveConversationItem,
 	private val onRowClicked: (ActiveConversationItem) -> Unit,
 	private val onHide: (ActiveConversationItem) -> Unit,
+	private val onPin: (ActiveConversationItem) -> Unit,
 	private val onSelectionChanged: (ActiveConversationItem, Boolean) -> Unit,
 ) : JPanel(BorderLayout()) {
 
@@ -31,11 +33,31 @@ class ConversationRowComponent(
 		cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
 	}
 
-	private val hideLabel = JLabel(AllIcons.Actions.GC).apply {
+	private val pinLabel = JLabel(AllIcons.Nodes.Favorite).apply {
 		cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-		toolTipText = "Hide conversation"
+		toolTipText = "Pin"
 		isVisible = false
-		border = JBUI.Borders.emptyRight(4)
+		border = JBUI.Borders.empty(0, 3)
+	}
+
+	private val hideLabel = JLabel(JolliMemoryIcons.Trash).apply {
+		cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+		toolTipText = "Delete"
+		isVisible = false
+		border = JBUI.Borders.empty(0, 3)
+	}
+
+	private val countLabel = JLabel(if (item.messageCount > 0) "${item.messageCount}" else "").apply {
+		foreground = JBColor.GRAY
+		font = font.deriveFont(font.size2D - 1f)
+	}
+
+	/** Toggles the right side between the message count and the hover actions. */
+	private fun setHovered(hovered: Boolean) {
+		background = if (hovered) JBColor(Color(0, 0, 0, 20), Color(255, 255, 255, 20)) else null
+		countLabel.isVisible = !hovered
+		pinLabel.isVisible = hovered
+		hideLabel.isVisible = hovered
 	}
 
 	init {
@@ -58,16 +80,12 @@ class ConversationRowComponent(
 		}
 		add(titleLabel, BorderLayout.CENTER)
 
-		// Right side: message count + hide button
-		val rightPanel = JPanel(FlowLayout(FlowLayout.RIGHT, JBUI.scale(4), 0)).apply {
+		// Right side: message count (default) swaps to Pin · Delete on hover (matches Context).
+		val rightPanel = JPanel(FlowLayout(FlowLayout.RIGHT, 0, 0)).apply {
 			isOpaque = false
 		}
-		if (item.messageCount > 0) {
-			rightPanel.add(JLabel("${item.messageCount}").apply {
-				foreground = JBColor.GRAY
-				font = font.deriveFont(font.size2D - 1f)
-			})
-		}
+		rightPanel.add(countLabel)
+		rightPanel.add(pinLabel)
 		rightPanel.add(hideLabel)
 		add(rightPanel, BorderLayout.EAST)
 
@@ -77,6 +95,12 @@ class ConversationRowComponent(
 		}
 
 		// Click handlers
+		pinLabel.addMouseListener(object : MouseAdapter() {
+			override fun mouseClicked(e: MouseEvent) {
+				e.consume()
+				onPin(item)
+			}
+		})
 		hideLabel.addMouseListener(object : MouseAdapter() {
 			override fun mouseClicked(e: MouseEvent) {
 				e.consume()
@@ -86,20 +110,19 @@ class ConversationRowComponent(
 
 		val hoverListener = object : MouseAdapter() {
 			override fun mouseEntered(e: MouseEvent) {
-				background = JBColor(Color(0, 0, 0, 20), Color(255, 255, 255, 20))
-				hideLabel.isVisible = true
+				setHovered(true)
 			}
 
 			override fun mouseExited(e: MouseEvent) {
-				// Only hide if mouse actually left the row bounds
+				// Only un-hover if the mouse actually left the row bounds (not when
+				// moving onto a child component within the row).
 				val p = e.point
 				val src = e.source as Component
 				val screenPoint = src.locationOnScreen.apply { translate(p.x, p.y) }
 				val rowLoc = this@ConversationRowComponent.locationOnScreen
 				val rowBounds = Rectangle(rowLoc.x, rowLoc.y, width, height)
 				if (!rowBounds.contains(screenPoint)) {
-					background = null
-					hideLabel.isVisible = false
+					setHovered(false)
 				}
 			}
 		}
@@ -111,9 +134,9 @@ class ConversationRowComponent(
 		addMouseListener(hoverListener)
 		addMouseListener(clickListener)
 		// Forward events from all children (checkbox handles its own clicks)
-		for (c in listOf(leftPanel, badge, titleLabel, rightPanel, hideLabel)) {
+		for (c in listOf(leftPanel, badge, titleLabel, rightPanel, countLabel, pinLabel, hideLabel)) {
 			c.addMouseListener(hoverListener)
-			if (c !== hideLabel && c !== checkbox) c.addMouseListener(clickListener)
+			if (c !== hideLabel && c !== pinLabel && c !== checkbox) c.addMouseListener(clickListener)
 		}
 	}
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CurrentMemoryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CurrentMemoryPanel.kt
@@ -1,0 +1,108 @@
+package ai.jolli.jollimemory.toolwindow
+
+import ai.jolli.jollimemory.JolliMemoryIcons
+import ai.jolli.jollimemory.core.SessionTracker
+import ai.jolli.jollimemory.services.JolliMemoryService
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.Disposable
+import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import java.awt.Component
+import javax.swing.Box
+import javax.swing.BoxLayout
+import javax.swing.JPanel
+import javax.swing.SwingUtilities
+
+/**
+ * "Current Memory" card — the draft the next commit will save (the mockup's
+ * `sec-ship` / `.ship-panel`, internally "ship").
+ *
+ * Content (top → bottom):
+ * - **Consequence line** — "Commit Memory will commit N changed file(s)…".
+ * - **AI-summary status row** — busy ("Summarizing…") or failed (warning + hint),
+ *   sourced from [JolliMemoryService] status / `lastError` and the worker lock.
+ * - The three input sub-sections in order: **Conversations → Context → Files**
+ *   (passed in as [CollapsiblePanel]s so their toolbars and row logic are reused
+ *   verbatim). The Commit action itself lives in the bottom [ActionBarPanel].
+ */
+class CurrentMemoryPanel(
+	private val service: JolliMemoryService,
+	private val conversationsSection: CollapsiblePanel,
+	private val contextSection: CollapsiblePanel,
+	private val filesSection: CollapsiblePanel,
+) : JPanel(BorderLayout()), Disposable {
+
+	private val consequenceLabel = JBLabel().apply {
+		border = JBUI.Borders.empty(2, 6)
+	}
+	private val statusLabel = JBLabel().apply {
+		border = JBUI.Borders.empty(2, 6)
+	}
+	private val sectionsContainer = JPanel().apply {
+		layout = BoxLayout(this, BoxLayout.Y_AXIS)
+		isOpaque = false
+	}
+
+	private val statusListener: () -> Unit = {
+		SwingUtilities.invokeLater { updateHeader() }
+	}
+
+	init {
+		val header = JPanel().apply {
+			layout = BoxLayout(this, BoxLayout.Y_AXIS)
+			isOpaque = false
+			border = JBUI.Borders.empty(2, 0)
+			consequenceLabel.alignmentX = Component.LEFT_ALIGNMENT
+			statusLabel.alignmentX = Component.LEFT_ALIGNMENT
+			add(consequenceLabel)
+			add(statusLabel)
+		}
+		add(header, BorderLayout.NORTH)
+
+		// Conversations → Context → Files (the inputs that will be saved).
+		sectionsContainer.add(conversationsSection)
+		sectionsContainer.add(Box.createVerticalStrut(JBUI.scale(2)))
+		sectionsContainer.add(contextSection)
+		sectionsContainer.add(Box.createVerticalStrut(JBUI.scale(2)))
+		sectionsContainer.add(filesSection)
+		add(sectionsContainer, BorderLayout.CENTER)
+
+		updateHeader()
+		service.addStatusListener(statusListener)
+	}
+
+	/** Refreshes the consequence + status lines from the current service state. */
+	fun updateHeader() {
+		val files = service.panelRegistry?.changesPanel?.getFiles()?.size
+			?: service.getChangedFiles().size
+		consequenceLabel.text = if (files > 0) {
+			"Commit Memory will commit $files changed file(s) with an AI-written message."
+		} else {
+			"No changes staged — nothing will be committed yet."
+		}
+
+		val cwd = service.mainRepoRoot
+		val busy = cwd != null && SessionTracker.isWorkerBusy(cwd)
+		val error = service.lastError
+		when {
+			busy -> {
+				statusLabel.icon = AllIcons.Process.Step_1
+				statusLabel.text = "Summarizing the last commit…"
+				statusLabel.isVisible = true
+			}
+			error != null -> {
+				statusLabel.icon = JolliMemoryIcons.Warning
+				statusLabel.text = "Summary failed — open Status for details."
+				statusLabel.isVisible = true
+			}
+			else -> {
+				statusLabel.isVisible = false
+			}
+		}
+	}
+
+	override fun dispose() {
+		service.removeStatusListener(statusListener)
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
@@ -7,6 +7,8 @@ import ai.jolli.jollimemory.core.SessionTracker
 import ai.jolli.jollimemory.services.JolliApiClient
 import ai.jolli.jollimemory.services.JolliAuthService
 import ai.jolli.jollimemory.services.JolliMemoryService
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.DumbAware
@@ -149,12 +151,27 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
             }
         }
 
-        // Create the panels (Memories + Commits are merged into CommitsPanel)
+        // Create the panels
         val statusPanel = StatusPanel(project, service)
         val conversationsPanel = ActiveConversationsPanel(project, service)
         val plansPanel = PlansPanel(project, service)
         val changesPanel = ChangesPanel(project, service)
         val commitsPanel = CommitsPanel(project, service)
+        val pinnedPanel = PinnedPanel(project, service)
+
+        // ── Review-Memory sub-sections (folded inside Current Memory) ──
+        // Conversations / Changes / Context keep their existing action toolbars and
+        // row logic; they are no longer top-level sections (minimal-density redesign).
+        val conversationsCollapsible = CollapsiblePanel(
+            "Conversations", "JolliMemory.ConversationsActions", conversationsPanel,
+        )
+        val contextCollapsible = CollapsiblePanel("Context", "JolliMemory.PlansActions", plansPanel)
+        val filesCollapsible = CollapsiblePanel("Files", "JolliMemory.ChangesActions", changesPanel)
+
+        // Inputs folded into Current Memory, in order: Conversations → Context → Files.
+        val currentMemoryPanel = CurrentMemoryPanel(
+            service, conversationsCollapsible, contextCollapsible, filesCollapsible,
+        )
 
         // Register panels for action lookup
         val registry = PanelRegistry().apply {
@@ -163,53 +180,41 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
             this.plansPanel = plansPanel
             this.changesPanel = changesPanel
             this.commitsPanel = commitsPanel
+            this.pinnedPanel = pinnedPanel
+            this.currentMemoryPanel = currentMemoryPanel
         }
         service.panelRegistry = registry
 
-        // Build collapsible sections (uppercase titles)
-        // CommitsPanel is titled "MEMORIES" — it shows commits in workspace mode
-        // and foreign memories in read-only mode (matching VS Code's unified section).
-        // STATUS is no longer a collapsible — it takes the full content area as
-        // a dedicated card when the breadcrumb status button is toggled on,
-        // matching VS Code's full-pane status view.
-        val conversationsCollapsible = CollapsiblePanel(
-            "CONVERSATIONS", "JolliMemory.ConversationsActions", conversationsPanel,
+        // ── Top-level accordion: Pinned → Current Memory → Committed Memories ──
+        // (the redesign's three collapsible panels). CommitsPanel still shows
+        // workspace commits, or foreign memories in read-only mode.
+        val pinnedCollapsible = CollapsiblePanel("Pinned", "JolliMemory.PinnedActions", pinnedPanel)
+        val currentMemoryCollapsible = CollapsiblePanel(
+            "Current Memory", "JolliMemory.CurrentMemoryActions", currentMemoryPanel,
         )
-        val plansCollapsible = CollapsiblePanel("PLANS & NOTES", "JolliMemory.PlansActions", plansPanel)
-        val changesCollapsible = CollapsiblePanel("CHANGES", "JolliMemory.ChangesActions", changesPanel)
         val memoriesCollapsible = CollapsiblePanel(
-            "MEMORIES", "JolliMemory.CommitsActions", commitsPanel,
+            "Committed Memories", "JolliMemory.CommitsActions", commitsPanel,
         )
 
-        // Use an accordion layout so collapsed panels shrink to header-only height
-        // and expanded panels share the remaining vertical space proportionally.
-        // Resize dividers between panels allow users to drag and adjust panel heights.
+        // Accordion layout so collapsed panels shrink to header-only height and
+        // expanded panels share remaining space; dividers allow manual resize.
         val accordionPanel = JPanel(AccordionLayout()).apply {
-            add(conversationsCollapsible)
+            add(pinnedCollapsible)
             add(ResizeDivider())
-            add(plansCollapsible)
-            add(ResizeDivider())
-            add(changesCollapsible)
+            add(currentMemoryCollapsible)
             add(ResizeDivider())
             add(memoriesCollapsible)
         }
 
-        // Add gear menu toggle actions to the tool window title bar,
-        // allowing users to show/hide individual panels — like VS Code's "..." menu.
+        // Gear menu: show/hide the three top-level panels.
         val gearActions = DefaultActionGroup().apply {
-            add(TogglePanelAction(conversationsCollapsible))
+            add(TogglePanelAction(pinnedCollapsible))
+            add(TogglePanelAction(currentMemoryCollapsible))
             add(TogglePanelAction(memoriesCollapsible))
-            add(TogglePanelAction(plansCollapsible))
-            add(TogglePanelAction(changesCollapsible))
         }
         toolWindow.setAdditionalGearActions(gearActions)
 
-        // Title bar actions — always visible regardless of which panels are open.
-        toolWindow.setTitleActions(listOf(
-            CloudSyncAction(),
-        ))
-
-        // ── Content area: CardLayout swaps accordion / KB explorer / status full-pane ──
+        // ── Content cards: current accordion / KB / Knowledge / status full-pane ──
         val contentCardLayout = CardLayout()
         val contentCards = JPanel(contentCardLayout)
         contentCards.add(accordionPanel, CARD_ACCORDION)
@@ -217,44 +222,104 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         val kbPanel = KBExplorerPanel(project, service)
         contentCards.add(kbPanel, CARD_KB)
 
-        // StatusPanel lives directly as a card so the breadcrumb status button can
-        // swap it in to occupy the full content area (matches VS Code's behavior).
+        val knowledgePanel = buildKnowledgePlaceholder()
+        contentCards.add(knowledgePanel, CARD_KNOWLEDGE)
+
+        // StatusPanel lives directly as a card so the status button can swap it in
+        // to occupy the full content area (matches VS Code's full-pane status view).
         contentCards.add(statusPanel, CARD_STATUS)
 
-        // Breadcrumb header: repo/branch selectors + icon buttons (always visible)
+        // Fixed bottom action bar (Current Branch view only): Commit · Create PR · ⋯ More
+        val actionBar = ActionBarPanel(project, service)
+
+        // Status full-pane controller: shows the STATUS card over the accordion.
+        // Driven by the title-bar Status toggle and auto-shown when Jolli is disabled.
+        var statusShown = false
+        fun setStatusShown(shown: Boolean) {
+            statusShown = shown
+            contentCardLayout.show(contentCards, if (shown) CARD_STATUS else CARD_ACCORDION)
+        }
+
+        // ── Title-bar actions: Agents · Settings · Status · Cloud sync ──
+        // These live in the tool window header (the "Jolli Memory" title bar),
+        // matching the mockup's view-title icon group.
+        val agentsAction = object : AnAction(
+            "Agent Access", "Agent access — what your AI tools can reach", AllIcons.Nodes.Plugin,
+        ), DumbAware {
+            override fun actionPerformed(e: com.intellij.openapi.actionSystem.AnActionEvent) {
+                com.intellij.openapi.ui.Messages.showInfoMessage(
+                    project, "Agent access settings are coming soon.", "Agent Access",
+                )
+            }
+        }
+        val settingsAction = object : AnAction(
+            "Settings", "Open Jolli Memory settings", AllIcons.General.GearPlain,
+        ), DumbAware {
+            override fun actionPerformed(e: com.intellij.openapi.actionSystem.AnActionEvent) {
+                SettingsDialog(project, service).show()
+            }
+        }
+        val statusAction = object : com.intellij.openapi.actionSystem.ToggleAction(
+            "Status", "Toggle the Jolli Memory status panel", JolliMemoryIcons.Pulse,
+        ), DumbAware {
+            override fun isSelected(e: com.intellij.openapi.actionSystem.AnActionEvent): Boolean = statusShown
+            override fun setSelected(e: com.intellij.openapi.actionSystem.AnActionEvent, state: Boolean) {
+                setStatusShown(state)
+            }
+        }
+        toolWindow.setTitleActions(listOf(agentsAction, settingsAction, statusAction, CloudSyncAction()))
+
+        // Breadcrumb header: repo/branch selectors (icon buttons now live in the title bar)
         val breadcrumb = BreadcrumbHeaderPanel(
             service = service,
             onSelectionChanged = { repo, branch, isForeign ->
                 if (isForeign && repo != null && branch != null) {
-                    plansCollapsible.isVisible = false
-                    changesCollapsible.isVisible = false
+                    currentMemoryCollapsible.isVisible = false
+                    actionBar.setForeign(true)
                     commitsPanel.setForeignMode(repo, branch)
                 } else {
-                    plansCollapsible.isVisible = plansCollapsible.isPanelVisible()
-                    changesCollapsible.isVisible = changesCollapsible.isPanelVisible()
+                    currentMemoryCollapsible.isVisible = currentMemoryCollapsible.isPanelVisible()
+                    actionBar.setForeign(false)
                     commitsPanel.clearForeignMode()
                 }
             },
-            onShowAccordion = {
-                contentCardLayout.show(contentCards, CARD_ACCORDION)
-            },
-            onShowKB = {
-                contentCardLayout.show(contentCards, CARD_KB)
-            },
-            onShowStatus = {
-                contentCardLayout.show(contentCards, CARD_STATUS)
-            },
-            onSettingsClicked = {
-                SettingsDialog(project, service).show()
-            },
         )
 
+        // View switch (Current Branch / Memory Bank / Knowledge) above the breadcrumb.
+        val viewSwitch = ViewSwitchPanel { view ->
+            // Switching views replaces the status card with a real view card.
+            statusShown = false
+            when (view) {
+                ViewSwitchPanel.View.CURRENT -> {
+                    contentCardLayout.show(contentCards, CARD_ACCORDION)
+                    breadcrumb.setMode(BreadcrumbHeaderPanel.Mode.BRANCH)
+                    actionBar.isVisible = true
+                }
+                ViewSwitchPanel.View.BANK -> {
+                    contentCardLayout.show(contentCards, CARD_KB)
+                    breadcrumb.setMode(BreadcrumbHeaderPanel.Mode.REPO_FILTER)
+                    actionBar.isVisible = false
+                    ApplicationManager.getApplication().executeOnPooledThread { kbPanel.load() }
+                }
+                ViewSwitchPanel.View.KNOWLEDGE -> {
+                    contentCardLayout.show(contentCards, CARD_KNOWLEDGE)
+                    breadcrumb.setMode(BreadcrumbHeaderPanel.Mode.REPO_FILTER)
+                    actionBar.isVisible = false
+                }
+            }
+        }
+
         // Auto-switch to the STATUS card when Jolli Memory is disabled (preserves
-        // the install/setup discoverability the accordion's auto-show provided),
-        // and auto-return to accordion once it becomes enabled.
+        // the install/setup discoverability), and auto-return once it's enabled.
+        // When enabled, only dismiss the status card if it was being shown — don't
+        // disturb the Memory Bank / Knowledge views.
         fun syncStatusCard() {
             val enabled = service.getStatus()?.enabled == true
-            breadcrumb.setStatusActive(!enabled)
+            if (!enabled) {
+                setStatusShown(true)
+            } else if (statusShown) {
+                setStatusShown(false)
+            }
         }
         syncStatusCard()
         val statusSyncListener: () -> Unit = { SwingUtilities.invokeLater { syncStatusCard() } }
@@ -263,12 +328,20 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
             service.removeStatusListener(statusSyncListener)
         }
 
-        // Refresh breadcrumb data on background thread
-        ApplicationManager.getApplication().executeOnPooledThread { breadcrumb.refresh() }
+        // Refresh breadcrumb + pinned data on background thread
+        ApplicationManager.getApplication().executeOnPooledThread {
+            breadcrumb.refresh()
+            pinnedPanel.refresh()
+        }
 
+        val northWrapper = JPanel(BorderLayout()).apply {
+            add(viewSwitch, BorderLayout.NORTH)
+            add(breadcrumb, BorderLayout.SOUTH)
+        }
         val mainPanel = JPanel(BorderLayout()).apply {
-            add(breadcrumb, BorderLayout.NORTH)
+            add(northWrapper, BorderLayout.NORTH)
             add(contentCards, BorderLayout.CENTER)
+            add(actionBar, BorderLayout.SOUTH)
         }
 
         // ── Onboarding / Main card layout ──────────────────────
@@ -343,6 +416,9 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
                 Disposer.register(parentDisposable, plansPanel)
                 Disposer.register(parentDisposable, changesPanel)
                 Disposer.register(parentDisposable, commitsPanel)
+                Disposer.register(parentDisposable, conversationsPanel)
+                Disposer.register(parentDisposable, pinnedPanel)
+                Disposer.register(parentDisposable, currentMemoryPanel)
                 Disposer.register(parentDisposable, kbPanel)
             })
         }
@@ -379,11 +455,28 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         return project.basePath != null
     }
 
+    /**
+     * Placeholder card for the Knowledge view. The wiki + graph rendering is a
+     * follow-up; this keeps the third view-switch tab navigable and discoverable.
+     */
+    private fun buildKnowledgePlaceholder(): JPanel {
+        return JPanel(BorderLayout()).apply {
+            border = JBUI.Borders.empty(16)
+            val message = JBLabel(
+                "<html><b>Knowledge</b><br/><br/>" +
+                    "Your memories, compiled into a browsable wiki + decision graph.<br/>" +
+                    "Coming soon.</html>",
+            )
+            add(message, BorderLayout.NORTH)
+        }
+    }
+
     companion object {
         private const val CARD_ONBOARDING = "onboarding"
         private const val CARD_MAIN = "main"
         private const val CARD_ACCORDION = "accordion"
         private const val CARD_KB = "kb"
+        private const val CARD_KNOWLEDGE = "knowledge"
         private const val CARD_STATUS = "status"
     }
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PanelRegistry.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PanelRegistry.kt
@@ -16,4 +16,6 @@ class PanelRegistry {
 	var changesPanel: ChangesPanel? = null
 	var commitsPanel: CommitsPanel? = null
 	var activeConversationsPanel: ActiveConversationsPanel? = null
+	var pinnedPanel: PinnedPanel? = null
+	var currentMemoryPanel: CurrentMemoryPanel? = null
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt
@@ -1,0 +1,252 @@
+package ai.jolli.jollimemory.toolwindow
+
+import ai.jolli.jollimemory.core.ActiveSessionAggregator
+import ai.jolli.jollimemory.core.CommitSelectionStore
+import ai.jolli.jollimemory.core.PinStore
+import ai.jolli.jollimemory.core.SessionTracker
+import ai.jolli.jollimemory.services.JolliMemoryService
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.ui.JBColor
+import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import java.awt.Color
+import java.awt.Component
+import java.awt.Cursor
+import java.awt.Dimension
+import java.awt.FlowLayout
+import java.awt.Font
+import java.awt.Graphics
+import java.awt.Graphics2D
+import java.awt.RenderingHints
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import java.io.File
+import javax.swing.BoxLayout
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.SwingConstants
+import javax.swing.SwingUtilities
+
+/**
+ * "Pinned" section — items the user pinned (via the pin hover action in the
+ * Context / Conversations rows) so they survive across sessions. Backed by
+ * [PinStore] under `<projectDir>/.jolli/jollimemory/pins.json` (worktree-scoped).
+ *
+ * Each row mirrors its source row: the same badge (source name for conversations,
+ * letter tag for context) + the title, with an unpin (×) on hover. Clicking a row
+ * opens the underlying content (transcript / plan / note / reference / memory).
+ */
+class PinnedPanel(
+	private val project: Project,
+	private val service: JolliMemoryService,
+) : JPanel(BorderLayout()), Disposable {
+
+	private val rowsPanel = JPanel().apply {
+		layout = BoxLayout(this, BoxLayout.Y_AXIS)
+		border = JBUI.Borders.empty(2, 4)
+	}
+	private val emptyLabel = JBLabel("Nothing pinned.").apply {
+		foreground = JBColor.GRAY
+		border = JBUI.Borders.empty(6, 8)
+	}
+
+	init {
+		add(rowsPanel, BorderLayout.NORTH)
+		renderEmpty()
+	}
+
+	private fun cwd(): String? = service.mainRepoRoot ?: project.basePath
+
+	fun refresh() {
+		val dir = cwd() ?: return
+		ApplicationManager.getApplication().executeOnPooledThread {
+			val pins = PinStore.readPins(dir)
+			SwingUtilities.invokeLater { render(pins) }
+		}
+	}
+
+	private fun renderEmpty() {
+		rowsPanel.removeAll()
+		rowsPanel.add(emptyLabel)
+		rowsPanel.revalidate()
+		rowsPanel.repaint()
+	}
+
+	private fun render(pins: List<PinStore.PinnedEntry>) {
+		rowsPanel.removeAll()
+		if (pins.isEmpty()) {
+			rowsPanel.add(emptyLabel)
+		} else {
+			pins.forEach { rowsPanel.add(pinRow(it)) }
+		}
+		rowsPanel.revalidate()
+		rowsPanel.repaint()
+	}
+
+	private fun pinRow(entry: PinStore.PinnedEntry): JPanel {
+		val row = JPanel(BorderLayout()).apply {
+			border = JBUI.Borders.empty(2, 4)
+			maximumSize = Dimension(Int.MAX_VALUE, JBUI.scale(26))
+			alignmentX = Component.LEFT_ALIGNMENT
+			isOpaque = false
+			cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+		}
+
+		val left = JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(4), 0)).apply { isOpaque = false }
+		left.add(BadgePill(entry.badge, badgeColor(entry)))
+		val title = JBLabel(entry.title).apply { minimumSize = Dimension(0, 0) }
+		left.add(title)
+		row.add(left, BorderLayout.CENTER)
+
+		val unpin = JBLabel(AllIcons.Actions.Close).apply {
+			toolTipText = "Unpin"
+			cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+			isVisible = false
+			border = JBUI.Borders.empty(0, 3)
+			addMouseListener(object : MouseAdapter() {
+				override fun mouseClicked(e: MouseEvent) {
+					e.consume()
+					val dir = cwd() ?: return
+					ApplicationManager.getApplication().executeOnPooledThread {
+						PinStore.unpin(dir, entry.kind, entry.key)
+						refresh()
+					}
+				}
+			})
+		}
+		val east = JPanel(FlowLayout(FlowLayout.RIGHT, 0, 0)).apply {
+			isOpaque = false
+			add(unpin)
+		}
+		row.add(east, BorderLayout.EAST)
+
+		val hover = object : MouseAdapter() {
+			override fun mouseEntered(e: MouseEvent) { unpin.isVisible = true }
+			override fun mouseExited(e: MouseEvent) {
+				val p = e.point
+				val src = e.source as Component
+				val screen = src.locationOnScreen.apply { translate(p.x, p.y) }
+				val loc = row.locationOnScreen
+				if (!java.awt.Rectangle(loc.x, loc.y, row.width, row.height).contains(screen)) {
+					unpin.isVisible = false
+				}
+			}
+		}
+		val click = object : MouseAdapter() {
+			override fun mouseClicked(e: MouseEvent) { openPinned(entry) }
+		}
+		for (c in listOf(row, left, title)) {
+			c.addMouseListener(hover)
+			c.addMouseListener(click)
+		}
+		unpin.addMouseListener(hover)
+		return row
+	}
+
+	private fun badgeColor(entry: PinStore.PinnedEntry): Color = when (entry.kind) {
+		"conversations" -> SOURCE_COLORS[entry.badge.lowercase()] ?: JBColor.GRAY
+		else -> TAG_COLORS[entry.badge] ?: JBColor.GRAY
+	}
+
+	// ── Open content on click ───────────────────────────────────────────────
+
+	private fun openPinned(entry: PinStore.PinnedEntry) {
+		val cwd = cwd() ?: return
+		when (entry.kind) {
+			"conversations" -> openConversation(entry.key, cwd)
+			"plans" -> openPath(SessionTracker.loadPlansRegistry(cwd).plans[entry.key]?.sourcePath)
+			"notes" -> openPath((SessionTracker.loadPlansRegistry(cwd).notes ?: emptyMap())[entry.key]?.sourcePath)
+			"references" -> openPath((SessionTracker.loadPlansRegistry(cwd).references ?: emptyMap())[entry.key]?.sourcePath)
+			"memories" -> openMemory(entry.key)
+		}
+	}
+
+	private fun openPath(path: String?) {
+		if (path.isNullOrBlank()) return
+		val vf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(File(path)) ?: return
+		FileEditorManager.getInstance(project).openFile(vf, true)
+	}
+
+	private fun openConversation(key: String, cwd: String) {
+		ApplicationManager.getApplication().executeOnPooledThread {
+			val item = try {
+				ActiveSessionAggregator.listActiveConversationsWithDiagnostics(cwd).items.firstOrNull {
+					CommitSelectionStore.conversationKey(it.source, it.sessionId) == key
+				}
+			} catch (_: Exception) { null }
+			SwingUtilities.invokeLater {
+				if (item != null) {
+					FileEditorManager.getInstance(project).openFile(ConversationVirtualFile(item, cwd), true)
+				}
+			}
+		}
+	}
+
+	private fun openMemory(hash: String) {
+		ApplicationManager.getApplication().executeOnPooledThread {
+			val summary = service.getSummary(hash)
+			SwingUtilities.invokeLater {
+				if (summary != null) {
+					FileEditorManager.getInstance(project).openFile(SummaryVirtualFile(summary, readOnly = true), true)
+				}
+			}
+		}
+	}
+
+	override fun dispose() {}
+
+	/** Small rounded pill mirroring the source row's badge (letter tag or source name). */
+	private class BadgePill(text: String, private val color: Color) : JLabel(text, SwingConstants.CENTER) {
+		init {
+			foreground = Color.WHITE
+			font = JBUI.Fonts.label(9f).deriveFont(Font.BOLD)
+			isOpaque = false
+			border = JBUI.Borders.empty(1, 6)
+		}
+
+		override fun getPreferredSize(): Dimension {
+			val base = super.getPreferredSize()
+			return Dimension(base.width.coerceAtLeast(JBUI.scale(18)), JBUI.scale(16))
+		}
+
+		override fun paintComponent(g: Graphics) {
+			val g2 = g.create() as Graphics2D
+			try {
+				g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+				g2.color = color
+				val arc = JBUI.scale(8)
+				g2.fillRoundRect(0, 0, width, height, arc, arc)
+			} finally {
+				g2.dispose()
+			}
+			super.paintComponent(g)
+		}
+	}
+
+	private companion object {
+		// Mirrors ConversationRowComponent.SourceBadge colors.
+		val SOURCE_COLORS = mapOf(
+			"claude" to JBColor(Color(217, 119, 6), Color(217, 119, 6)),
+			"gemini" to JBColor(Color(5, 150, 105), Color(5, 150, 105)),
+			"codex" to JBColor(Color(124, 58, 237), Color(124, 58, 237)),
+			"opencode" to JBColor(Color(37, 99, 235), Color(37, 99, 235)),
+			"cursor" to JBColor(Color(220, 38, 38), Color(220, 38, 38)),
+		)
+		// Mirrors PlansPanel tag colors (P/N/S/L/GH/J/No).
+		val TAG_COLORS = mapOf(
+			"P" to JBColor(0x4C82F7, 0x4C82F7),
+			"N" to JBColor(0x3FA45B, 0x3FA45B),
+			"S" to JBColor(0xC9851E, 0xD18616),
+			"L" to JBColor(0x7A6FF0, 0x8A7FF5),
+			"GH" to JBColor(0x6E7681, 0x8B949E),
+			"J" to JBColor(0x2A78C8, 0x3B82D6),
+			"No" to JBColor(0x6B6B6B, 0x9B9B9B),
+		)
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PlansPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PlansPanel.kt
@@ -5,17 +5,20 @@ import ai.jolli.jollimemory.core.NoteEntry
 import ai.jolli.jollimemory.core.NoteFormat
 import ai.jolli.jollimemory.core.PlanEntry
 import ai.jolli.jollimemory.core.CommitSelectionStore
+import ai.jolli.jollimemory.core.PinStore
 import ai.jolli.jollimemory.core.SessionTracker
 import ai.jolli.jollimemory.core.references.ReferenceEntry
 import ai.jolli.jollimemory.core.references.ReferenceStore
 import ai.jolli.jollimemory.core.references.SourceId
 import ai.jolli.jollimemory.services.JolliMemoryService
+import com.intellij.icons.AllIcons
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBList
 import com.intellij.ui.components.JBScrollPane
@@ -26,6 +29,11 @@ import java.awt.Component
 import java.awt.Cursor
 import java.awt.Desktop
 import java.awt.Dimension
+import java.awt.FlowLayout
+import java.awt.Font
+import java.awt.Graphics
+import java.awt.Graphics2D
+import java.awt.RenderingHints
 import java.awt.event.KeyEvent
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
@@ -99,83 +107,97 @@ class PlansPanel(
     private companion object {
         const val HOVER_SHOW_DELAY_MS = 1000
         const val HOVER_HIDE_GRACE_MS = 200
+
+        // Context type-tag accent colors (mockup `kb-tag` parity).
+        val TAG_PLAN = JBColor(0x4C82F7, 0x4C82F7)
+        val TAG_NOTE = JBColor(0x3FA45B, 0x3FA45B)
+        val TAG_SNIPPET = JBColor(0xC9851E, 0xD18616)
+        val TAG_LINEAR = JBColor(0x7A6FF0, 0x8A7FF5)
+        val TAG_GITHUB = JBColor(0x6E7681, 0x8B949E)
+        val TAG_JIRA = JBColor(0x2A78C8, 0x3B82D6)
+        val TAG_NOTION = JBColor(0x6B6B6B, 0x9B9B9B)
     }
     private val emptyLabel = JBLabel("No plans or notes yet.", SwingConstants.CENTER)
     private var excludedReferences: Set<String> = emptySet()
+    private var excludedPlans: Set<String> = emptySet()
+    private var excludedNotes: Set<String> = emptySet()
+
+    /** Row index whose hover actions (pin/edit/delete) are currently shown. */
+    private var actionHoverIndex: Int = -1
+
     private val statusListener: () -> Unit = { SwingUtilities.invokeLater { refresh() } }
 
     init {
         border = JBUI.Borders.empty(8)
 
-        // Single click on trash icon to remove; double-click elsewhere to open in editor
+        // Row interaction. Left→right zones: [checkbox] [tag] [title] … [pin][edit][delete].
+        // The pin/edit/delete actions render only on the hovered row.
         itemList.addMouseListener(object : MouseAdapter() {
             override fun mouseClicked(e: MouseEvent) {
                 val index = itemList.locationToIndex(e.point)
                 if (index < 0) return
                 val cellBounds = itemList.getCellBounds(index, index) ?: return
-
-                // Check if click landed on checkbox zone (left edge, references only)
                 val item = listModel.getElementAt(index)
-                if (item is ListItem.ReferenceItem && e.clickCount == 1) {
-                    val checkboxWidth = cellRenderer.getCheckboxWidth()
-                    if (e.x - cellBounds.x < checkboxWidth) {
-                        toggleReferenceExclusion(item.mapKey)
-                        return
-                    }
-                }
 
-                // Check if click landed on the trash icon (right edge of the row)
-                val trashWidth = cellRenderer.getTrashIconWidth()
-                val trashStart = cellBounds.x + cellBounds.width - trashWidth
-                if (e.x >= trashStart && e.clickCount == 1) {
-                    itemList.selectedIndex = index
-                    removeSelectedItem()
+                // Checkbox zone (left edge) — toggles include/exclude for any kind.
+                if (e.clickCount == 1 && e.x - cellBounds.x < cellRenderer.getCheckboxWidth()) {
+                    toggleExclusion(item)
                     return
                 }
 
-                if (e.clickCount == 2) {
-                    val selected = itemList.selectedValue ?: return
-                    when (selected) {
-                        is ListItem.PlanItem -> openPlan(selected.plan)
-                        is ListItem.NoteItem -> openNote(selected.note)
-                        is ListItem.ReferenceItem -> openReference(selected.ref)
+                // Action zone (right edge): pin | edit | delete (left→right).
+                val offsetFromRight = (cellBounds.x + cellBounds.width) - e.x
+                if (e.clickCount == 1 && offsetFromRight in 0..cellRenderer.getActionsWidth()) {
+                    val slot = cellRenderer.getActionSlotWidth()
+                    when {
+                        offsetFromRight <= slot -> { itemList.selectedIndex = index; removeSelectedItem() } // delete
+                        offsetFromRight <= slot * 2 -> openItem(item) // edit
+                        else -> pinItem(item) // pin
                     }
+                    return
                 }
+
+                if (e.clickCount == 2) openItem(item)
             }
         })
 
-        // Show hand cursor when hovering over the trash icon zone + trigger hover popup
+        // Hover: reveal the action icons on the hovered row + hand cursor over click zones.
         itemList.addMouseMotionListener(object : MouseAdapter() {
             override fun mouseMoved(e: MouseEvent) {
                 val index = itemList.locationToIndex(e.point)
-                if (index >= 0) {
-                    val cellBounds = itemList.getCellBounds(index, index)
-                    if (cellBounds != null && cellBounds.contains(e.point)) {
-                        // Cursor: hand over trash icon
-                        val renderer = itemList.cellRenderer as? PlansAndNotesCellRenderer
-                        val trashWidth = renderer?.getTrashIconWidth() ?: 30
-                        val trashStart = cellBounds.x + cellBounds.width - trashWidth
-                        if (e.x >= trashStart) {
-                            itemList.cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-                        } else {
-                            itemList.cursor = Cursor.getDefaultCursor()
-                        }
-
-                        // Hover popup: schedule show if moved to a new cell
-                        if (index != hoverIndex || hoverPopup?.isVisible != true) {
-                            scheduleShowHoverPopup(index)
-                        }
-                        return
+                val cellBounds = if (index >= 0) itemList.getCellBounds(index, index) else null
+                if (cellBounds != null && cellBounds.contains(e.point)) {
+                    if (index != actionHoverIndex) {
+                        val old = actionHoverIndex
+                        actionHoverIndex = index
+                        repaintRow(old)
+                        repaintRow(index)
                     }
+                    val offsetFromRight = (cellBounds.x + cellBounds.width) - e.x
+                    val overActions = offsetFromRight in 0..cellRenderer.getActionsWidth()
+                    val overCheckbox = e.x - cellBounds.x < cellRenderer.getCheckboxWidth()
+                    itemList.cursor = if (overActions || overCheckbox) {
+                        Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+                    } else {
+                        Cursor.getDefaultCursor()
+                    }
+                    if (index != hoverIndex || hoverPopup?.isVisible != true) {
+                        scheduleShowHoverPopup(index)
+                    }
+                    return
                 }
                 itemList.cursor = Cursor.getDefaultCursor()
+                clearActionHover()
                 scheduleHoverDismiss()
             }
         })
 
-        // Dismiss hover popup when mouse leaves the list
+        // Dismiss hover popup + action icons when mouse leaves the list
         itemList.addMouseListener(object : MouseAdapter() {
-            override fun mouseExited(e: MouseEvent) { scheduleHoverDismiss() }
+            override fun mouseExited(e: MouseEvent) {
+                clearActionHover()
+                scheduleHoverDismiss()
+            }
         })
 
         // Right-click context menu with "Remove" option
@@ -323,14 +345,85 @@ class PlansPanel(
         }
     }
 
-    private fun toggleReferenceExclusion(mapKey: String) {
-        val currentlyExcluded = mapKey in excludedReferences
+    /** (kind, key) used by CommitSelectionStore / PinStore for a given list item. */
+    private fun kindKeyOf(item: ListItem): Pair<String, String> = when (item) {
+        is ListItem.PlanItem -> "plans" to item.plan.slug
+        is ListItem.NoteItem -> "notes" to item.note.id
+        is ListItem.ReferenceItem -> "references" to item.mapKey
+    }
+
+    private fun isExcluded(item: ListItem): Boolean {
+        val (kind, key) = kindKeyOf(item)
+        return when (kind) {
+            "plans" -> key in excludedPlans
+            "notes" -> key in excludedNotes
+            else -> key in excludedReferences
+        }
+    }
+
+    /** Toggles include/exclude for any item kind (checkbox click). */
+    private fun toggleExclusion(item: ListItem) {
+        val (kind, key) = kindKeyOf(item)
+        val nowExcluded = !isExcluded(item)
         val cwd = service.mainRepoRoot ?: project.basePath ?: return
         ApplicationManager.getApplication().executeOnPooledThread {
-            CommitSelectionStore.setExcluded(cwd, "references", mapKey, !currentlyExcluded)
-            // Re-read exclusions and repaint
-            excludedReferences = CommitSelectionStore.readExclusions(cwd).references
+            CommitSelectionStore.setExcluded(cwd, kind, key, nowExcluded)
+            val ex = CommitSelectionStore.readExclusions(cwd)
+            excludedReferences = ex.references
+            excludedPlans = ex.plans
+            excludedNotes = ex.notes
             SwingUtilities.invokeLater { itemList.repaint() }
+        }
+    }
+
+    /** Pins an item so it appears in the Pinned section (pin hover action). */
+    private fun pinItem(item: ListItem) {
+        val (kind, key) = kindKeyOf(item)
+        val title = when (item) {
+            is ListItem.PlanItem -> item.plan.title.ifBlank { item.plan.slug }
+            is ListItem.NoteItem -> item.note.title
+            is ListItem.ReferenceItem -> when (item.ref.source) {
+                SourceId.notion -> item.ref.title
+                else -> "${item.ref.nativeId} — ${item.ref.title}"
+            }
+        }
+        // Same letter tag the Context row shows, so the Pinned row mirrors the icon.
+        val badge = when (item) {
+            is ListItem.PlanItem -> "P"
+            is ListItem.NoteItem -> if (item.note.format == NoteFormat.snippet) "S" else "N"
+            is ListItem.ReferenceItem -> when (item.ref.source) {
+                SourceId.linear -> "L"
+                SourceId.github -> "GH"
+                SourceId.jira -> "J"
+                SourceId.notion -> "No"
+            }
+        }
+        val cwd = service.mainRepoRoot ?: project.basePath ?: return
+        ApplicationManager.getApplication().executeOnPooledThread {
+            PinStore.pin(cwd, kind, key, title, badge)
+            SwingUtilities.invokeLater { service.panelRegistry?.pinnedPanel?.refresh() }
+        }
+    }
+
+    /** Opens an item in its editor / detail view (edit hover action, double-click). */
+    private fun openItem(item: ListItem) {
+        when (item) {
+            is ListItem.PlanItem -> openPlan(item.plan)
+            is ListItem.NoteItem -> openNote(item.note)
+            is ListItem.ReferenceItem -> openReference(item.ref)
+        }
+    }
+
+    private fun repaintRow(index: Int) {
+        if (index < 0) return
+        itemList.getCellBounds(index, index)?.let { itemList.repaint(it) }
+    }
+
+    private fun clearActionHover() {
+        if (actionHoverIndex != -1) {
+            val old = actionHoverIndex
+            actionHoverIndex = -1
+            repaintRow(old)
         }
     }
 
@@ -365,7 +458,10 @@ class PlansPanel(
             val currentBranch = gitOps?.getCurrentBranch()
             val registry = SessionTracker.loadPlansRegistry(cwd)
 
-            excludedReferences = CommitSelectionStore.readExclusions(cwd).references
+            val ex = CommitSelectionStore.readExclusions(cwd)
+            excludedReferences = ex.references
+            excludedPlans = ex.plans
+            excludedNotes = ex.notes
 
             val planItems = filterPlans(registry.plans, gitOps, currentBranch)
                 .map { ListItem.PlanItem(it) }
@@ -709,196 +805,136 @@ class PlansPanel(
      * - Note (committed): lock (green) icon
      */
     private inner class PlansAndNotesCellRenderer : ListCellRenderer<ListItem> {
-        private val panel = JPanel(BorderLayout()).apply { border = JBUI.Borders.empty(4, 8) }
+        private val panel = JPanel(BorderLayout()).apply { border = JBUI.Borders.empty(3, 8) }
         private val checkBox = JCheckBox().apply { isOpaque = false }
-        private val iconLabel = JLabel()
+        private val tagLabel = TagLabel()
         private val titleLabel = JLabel()
-        private val metaLabel = JLabel()
-        private val ageLabel = JLabel().apply {
-            foreground = Color.GRAY
-            border = JBUI.Borders.emptyLeft(4)
-        }
-        private val trashLabel = JLabel(JolliMemoryIcons.Trash).apply {
-            toolTipText = "Remove"
-            border = JBUI.Borders.emptyLeft(6)
-            cursor = java.awt.Cursor.getPredefinedCursor(java.awt.Cursor.HAND_CURSOR)
-        }
+        private val pinLabel = actionIcon(AllIcons.Nodes.Favorite, "Pin")
+        private val editLabel = actionIcon(AllIcons.Actions.Edit, "Edit")
+        private val trashLabel = actionIcon(JolliMemoryIcons.Trash, "Delete")
 
-        /** Returns the width of the trash icon click zone (icon 16px + left border 6px + panel right padding 8px). */
-        fun getTrashIconWidth(): Int = 30
+        /** Checkbox click zone (checkbox ~20px + left padding 8px). */
+        fun getCheckboxWidth(): Int = JBUI.scale(28)
 
-        /** Returns the width of the checkbox click zone (checkbox ~20px + left padding 8px). */
-        fun getCheckboxWidth(): Int = 28
+        /** Width of one hover-action slot (icon + gap). */
+        fun getActionSlotWidth(): Int = JBUI.scale(24)
+
+        /** Total width of the pin/edit/delete action strip on the right. */
+        fun getActionsWidth(): Int = getActionSlotWidth() * 3
+
+        private fun actionIcon(icon: javax.swing.Icon, tip: String): JLabel = JLabel(icon).apply {
+            toolTipText = tip
+            border = JBUI.Borders.empty(0, 3)
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+        }
 
         override fun getListCellRendererComponent(
             list: JList<out ListItem>, value: ListItem, index: Int,
             isSelected: Boolean, cellHasFocus: Boolean,
         ): Component {
-            val isRef = value is ListItem.ReferenceItem
-            when (value) {
-                is ListItem.PlanItem -> renderPlan(value.plan, list, isSelected)
-                is ListItem.NoteItem -> renderNote(value.note, list, isSelected)
-                is ListItem.ReferenceItem -> renderReference(value.ref, list, isSelected, value.mapKey)
-            }
+            // Column layout (mockup parity): [checkbox] [type tag] [title] …hover[pin][edit][delete]
+            val (letter, color) = tagFor(value)
+            checkBox.isSelected = !isExcluded(value)
+            tagLabel.setBadge(letter, color)
+            titleLabel.text = titleFor(value)
+            titleLabel.font = list.font
+            titleLabel.foreground = if (isSelected) list.selectionForeground else list.foreground
 
             panel.removeAll()
 
-            // References get a checkbox on the left; plans/notes do not
-            if (isRef) {
-                val leftPanel = JPanel(BorderLayout()).apply {
+            val left = JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(2), 0)).apply {
+                isOpaque = false
+                add(checkBox)
+                add(tagLabel)
+            }
+            panel.add(left, BorderLayout.WEST)
+            // Min size 0 so BorderLayout.CENTER can shrink the title and it ellipsizes ("…").
+            titleLabel.minimumSize = Dimension(0, 0)
+            panel.add(titleLabel, BorderLayout.CENTER)
+
+            // Action icons appear only on the hovered row, anchored to the right edge.
+            if (index == actionHoverIndex) {
+                val actions = JPanel(FlowLayout(FlowLayout.RIGHT, 0, 0)).apply {
                     isOpaque = false
-                    add(checkBox, BorderLayout.WEST)
-                    add(iconLabel, BorderLayout.CENTER)
+                    add(pinLabel)
+                    add(editLabel)
+                    add(trashLabel)
                 }
-                panel.add(leftPanel, BorderLayout.WEST)
-            } else {
-                panel.add(iconLabel, BorderLayout.WEST)
+                panel.add(actions, BorderLayout.EAST)
             }
 
-            val center = JPanel(BorderLayout()).apply {
-                isOpaque = false
-                add(titleLabel, BorderLayout.WEST)
-                add(metaLabel, BorderLayout.CENTER)
-            }
-            panel.add(center, BorderLayout.CENTER)
-
-            ageLabel.text = formatAge(value.lastModified)
-            ageLabel.font = list.font
-
-            val rightPanel = JPanel(BorderLayout()).apply {
-                isOpaque = false
-                add(ageLabel, BorderLayout.CENTER)
-                add(trashLabel, BorderLayout.EAST)
-            }
-            panel.add(rightPanel, BorderLayout.EAST)
             panel.background = if (isSelected) list.selectionBackground else list.background
 
+            // Pin the cell to the list's visible width so a long title truncates with "…"
+            // instead of widening the cell and pushing the hover icons past the window edge.
+            panel.preferredSize = null
+            val listWidth = list.width
+            if (listWidth > 0) {
+                panel.preferredSize = Dimension(listWidth, panel.preferredSize.height)
+            }
             return panel
         }
 
-        private fun renderPlan(plan: PlanEntry, list: JList<*>, isSelected: Boolean) {
-            iconLabel.icon = if (plan.commitHash != null) JolliMemoryIcons.Lock else JolliMemoryIcons.FileText
-
-            // Match VS Code: "shortHash · title" for committed, plain title for uncommitted
-            val displayTitle = if (plan.commitHash != null) {
-                "${plan.commitHash.take(8)} \u00b7 ${plan.title.ifBlank { plan.slug }}"
-            } else {
-                plan.title.ifBlank { plan.slug }
+        /** Single/double-letter type tag + accent color (mockup `kb-tag` parity). */
+        private fun tagFor(item: ListItem): Pair<String, Color> = when (item) {
+            is ListItem.PlanItem -> "P" to TAG_PLAN
+            is ListItem.NoteItem ->
+                if (item.note.format == NoteFormat.snippet) "S" to TAG_SNIPPET else "N" to TAG_NOTE
+            is ListItem.ReferenceItem -> when (item.ref.source) {
+                SourceId.linear -> "L" to TAG_LINEAR
+                SourceId.github -> "GH" to TAG_GITHUB
+                SourceId.jira -> "J" to TAG_JIRA
+                SourceId.notion -> "No" to TAG_NOTION
             }
-            titleLabel.text = displayTitle
-            titleLabel.font = list.font
-            titleLabel.foreground = if (isSelected) list.selectionForeground else list.foreground
-
-            val editStr = "${plan.editCount} edit${if (plan.editCount != 1) "s" else ""}"
-            metaLabel.text = " $editStr"
-            metaLabel.font = list.font
-            metaLabel.foreground = Color.GRAY
-
         }
 
-        private fun renderNote(note: NoteEntry, list: JList<*>, isSelected: Boolean) {
-            // Match VS Code: lock for committed, comment for snippet, note for markdown
-            iconLabel.icon = when {
-                note.commitHash != null -> JolliMemoryIcons.Lock
-                note.format == NoteFormat.snippet -> JolliMemoryIcons.Comment
-                else -> JolliMemoryIcons.Note
+        private fun titleFor(item: ListItem): String = when (item) {
+            is ListItem.PlanItem -> {
+                val t = item.plan.title.ifBlank { item.plan.slug }
+                if (item.plan.commitHash != null) "${item.plan.commitHash.take(8)} · $t" else t
             }
-
-            // Match VS Code: "shortHash · title" for committed, plain title for uncommitted
-            val displayTitle = if (note.commitHash != null) {
-                "${note.commitHash.take(8)} \u00b7 ${note.title}"
-            } else {
-                note.title
-            }
-            titleLabel.text = displayTitle
-            titleLabel.font = list.font
-            titleLabel.foreground = if (isSelected) list.selectionForeground else list.foreground
-
-            val formatStr = if (note.format == NoteFormat.snippet) "snippet" else "markdown"
-            metaLabel.text = " $formatStr"
-            metaLabel.font = list.font
-            metaLabel.foreground = Color.GRAY
-
-        }
-
-        private fun renderReference(ref: ReferenceEntry, list: JList<*>, isSelected: Boolean, mapKey: String) {
-            // Checked = included (not excluded)
-            checkBox.isSelected = mapKey !in excludedReferences
-            // Match VS Code: issues icon for linear/jira/github, file-text for notion
-            iconLabel.icon = when (ref.source) {
-                SourceId.notion -> JolliMemoryIcons.FileText
-                else -> JolliMemoryIcons.Issues
-            }
-
-            // Match VS Code: "NATIVE_ID — Title" for linear/jira/github, just title for notion
-            val displayTitle = when (ref.source) {
-                SourceId.notion -> ref.title
-                else -> "${ref.nativeId} \u2014 ${ref.title}"
-            }
-            titleLabel.text = displayTitle
-            titleLabel.font = list.font
-            titleLabel.foreground = if (isSelected) list.selectionForeground else list.foreground
-
-            metaLabel.text = " ${ref.source.name}"
-            metaLabel.font = list.font
-            metaLabel.foreground = Color.GRAY
-
-        }
-
-        /** Builds a rich HTML tooltip showing reference fields (status, priority, labels) from the markdown file. */
-        fun buildReferenceTooltip(ref: ReferenceEntry): String {
-            val sourceLabel = when (ref.source) {
-                SourceId.linear -> "Linear"
-                SourceId.jira -> "Jira"
-                SourceId.github -> "GitHub"
-                SourceId.notion -> "Notion"
-            }
-
-            val sb = StringBuilder("<html><div style='padding:2px 4px'>")
-            sb.append("<p><b>${escapeHtml(ref.nativeId)} \u2014 ${escapeHtml(ref.title)}</b></p>")
-
-            // Parse fields from the backing markdown file
-            if (ref.sourcePath != null) {
-                val parsed = ReferenceStore.readReferenceMarkdown(ref.sourcePath)
-                if (parsed?.fields != null) {
-                    sb.append("<table cellpadding='1' cellspacing='0'>")
-                    for (f in parsed.fields) {
-                        sb.append("<tr><td style='color:gray'>${escapeHtml(f.label)}</td><td style='padding-left:8px'>${escapeHtml(f.value)}</td></tr>")
-                    }
-                    sb.append("</table>")
+            is ListItem.NoteItem ->
+                if (item.note.commitHash != null) {
+                    "${item.note.commitHash.take(8)} · ${item.note.title}"
+                } else {
+                    item.note.title
                 }
+            is ListItem.ReferenceItem -> when (item.ref.source) {
+                SourceId.notion -> item.ref.title
+                else -> "${item.ref.nativeId} — ${item.ref.title}"
             }
+        }
+    }
 
-            sb.append("<p style='color:gray'>${escapeHtml(sourceLabel)}</p>")
-            sb.append("</div></html>")
-            return sb.toString()
+    /** A small rounded badge painting a 1–2 letter context-type tag (mockup `kb-tag`). */
+    private inner class TagLabel : JLabel("", SwingConstants.CENTER) {
+        private var badgeColor: Color = JBColor.GRAY
+
+        init {
+            isOpaque = false
+            foreground = Color.WHITE
+            font = JBUI.Fonts.label(9f).deriveFont(Font.BOLD)
         }
 
-        private fun escapeHtml(s: String): String =
-            s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        fun setBadge(text: String, color: Color) {
+            this.text = text
+            this.badgeColor = color
+        }
 
-        private fun formatAge(isoDate: String): String {
-            val millis = try {
-                java.time.Instant.parse(isoDate).toEpochMilli()
-            } catch (_: Exception) { return "" }
-            val diff = System.currentTimeMillis() - millis
-            if (diff < 0) return "just now"
-            val seconds = diff / 1000
-            val minutes = seconds / 60
-            val hours = minutes / 60
-            val days = hours / 24
-            val weeks = days / 7
-            val months = days / 30
-            val years = days / 365
-            return when {
-                seconds < 60 -> "just now"
-                minutes < 60 -> "${minutes}m ago"
-                hours < 24 -> "${hours}h ago"
-                days < 7 -> "${days}d ago"
-                weeks < 5 -> "${weeks}w ago"
-                months < 12 -> "${months}mo ago"
-                else -> "${years}y ago"
+        override fun getPreferredSize(): Dimension =
+            Dimension(JBUI.scale(if (text.length > 1) 24 else 18), JBUI.scale(16))
+
+        override fun paintComponent(g: Graphics) {
+            val g2 = g.create() as Graphics2D
+            try {
+                g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+                g2.color = badgeColor
+                val arc = JBUI.scale(6)
+                g2.fillRoundRect(0, 0, width - 1, height - 1, arc, arc)
+            } finally {
+                g2.dispose()
             }
+            super.paintComponent(g)
         }
     }
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ViewSwitchPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ViewSwitchPanel.kt
@@ -1,0 +1,131 @@
+package ai.jolli.jollimemory.toolwindow
+
+import ai.jolli.jollimemory.JolliColors
+import com.intellij.util.ui.JBUI
+import java.awt.Color
+import java.awt.Cursor
+import java.awt.Dimension
+import java.awt.FlowLayout
+import java.awt.Font
+import java.awt.Graphics
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.SwingConstants
+import javax.swing.UIManager
+
+/**
+ * Persistent three-segment view switch shown at the very top of the sidebar
+ * content, mirroring the redesign mockup's `.view-switch`:
+ *
+ *   Current Branch  |  Memory Bank  |  Knowledge
+ *
+ * The active segment is emphasized (bold) and underlined with the Jolli accent;
+ * inactive segments use the muted description foreground and highlight on hover.
+ * Selecting a segment fires [onViewSelected]; the factory swaps content cards and
+ * adjusts the breadcrumb / bottom action bar in response.
+ */
+class ViewSwitchPanel(
+	private val onViewSelected: (View) -> Unit,
+) : JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(2), 0)) {
+
+	enum class View { CURRENT, BANK, KNOWLEDGE }
+
+	private val tabs = linkedMapOf(
+		View.CURRENT to "Current Branch",
+		View.BANK to "Memory Bank",
+		View.KNOWLEDGE to "Knowledge",
+	)
+
+	private val labels = mutableMapOf<View, TabLabel>()
+	private var selected: View = View.CURRENT
+
+	init {
+		border = JBUI.Borders.empty(2, 6)
+		isOpaque = false
+		for ((view, text) in tabs) {
+			val label = TabLabel(text, view)
+			labels[view] = label
+			add(label)
+		}
+		updateStyles()
+	}
+
+	/** Programmatically select a view without firing [onViewSelected]. */
+	fun setSelected(view: View) {
+		if (selected == view) return
+		selected = view
+		updateStyles()
+	}
+
+	fun getSelected(): View = selected
+
+	private fun select(view: View) {
+		if (selected == view) return
+		selected = view
+		updateStyles()
+		onViewSelected(view)
+	}
+
+	private fun updateStyles() {
+		for ((view, label) in labels) {
+			label.active = view == selected
+			label.repaint()
+		}
+	}
+
+	private val mutedFg: Color
+		get() = UIManager.getColor("Label.disabledForeground")
+			?: UIManager.getColor("Component.infoForeground")
+			?: JBUI.CurrentTheme.Label.disabledForeground()
+
+	private val activeFg: Color
+		get() = UIManager.getColor("Label.foreground") ?: foreground
+
+	private val hoverBg: Color
+		get() = UIManager.getColor("ActionButton.hoverBackground")
+			?: JBUI.CurrentTheme.ActionButton.hoverBackground()
+
+	/** A single clickable tab that paints its own accent underline when active. */
+	private inner class TabLabel(text: String, val view: View) : JLabel(text, SwingConstants.CENTER) {
+		var active: Boolean = false
+		private var hovered: Boolean = false
+
+		init {
+			cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+			border = JBUI.Borders.empty(4, 8, 6, 8)
+			isOpaque = false
+			addMouseListener(object : MouseAdapter() {
+				override fun mouseClicked(e: MouseEvent) = select(view)
+				override fun mouseEntered(e: MouseEvent) { hovered = true; repaint() }
+				override fun mouseExited(e: MouseEvent) { hovered = false; repaint() }
+			})
+		}
+
+		override fun getPreferredSize(): Dimension {
+			// Reserve width for the bold variant so the layout doesn't jump on selection.
+			val boldMetrics = getFontMetrics(font.deriveFont(Font.BOLD))
+			val w = boldMetrics.stringWidth(text) + JBUI.scale(16)
+			val h = super.getPreferredSize().height
+			return Dimension(w, h)
+		}
+
+		override fun paintComponent(g: Graphics) {
+			font = if (active) font.deriveFont(Font.BOLD) else font.deriveFont(Font.PLAIN)
+			foreground = if (active) activeFg else mutedFg
+
+			if (hovered && !active) {
+				g.color = hoverBg
+				g.fillRoundRect(0, 0, width, height, JBUI.scale(6), JBUI.scale(6))
+			}
+			super.paintComponent(g)
+
+			if (active) {
+				g.color = JolliColors.Accent
+				val thickness = JBUI.scale(2)
+				g.fillRect(JBUI.scale(6), height - thickness, width - JBUI.scale(12), thickness)
+			}
+		}
+	}
+}

--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -148,6 +148,12 @@
                     icon="AllIcons.Actions.Refresh"/>
         </group>
 
+        <!-- Pinned panel actions (redesign: top-level "Pinned" section) -->
+        <group id="JolliMemory.PinnedActions" text="JolliMemory Pinned"/>
+
+        <!-- Current Memory panel actions (redesign: top-level "Current Memory" section) -->
+        <group id="JolliMemory.CurrentMemoryActions" text="JolliMemory Current Memory"/>
+
         <!-- Standalone action (not in a panel toolbar) -->
         <action id="JolliMemory.ViewSummary"
                 class="ai.jolli.jollimemory.actions.ViewSummaryAction"

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/PinStoreTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/PinStoreTest.kt
@@ -1,0 +1,82 @@
+package ai.jolli.jollimemory.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class PinStoreTest {
+
+	@TempDir
+	lateinit var tempDir: File
+
+	private val cwd get() = tempDir.absolutePath
+
+	@BeforeEach
+	fun setUp() {
+		File(tempDir, ".jolli/jollimemory").mkdirs()
+	}
+
+	@Nested
+	inner class Read {
+		@Test
+		fun `returns empty when no file exists`() {
+			PinStore.readPins(cwd) shouldBe emptyList()
+		}
+
+		@Test
+		fun `returns empty for corrupt JSON`() {
+			File(JmLogger.getJolliMemoryDir(cwd), "pins.json").apply {
+				parentFile.mkdirs()
+				writeText("not json")
+			}
+			PinStore.readPins(cwd) shouldBe emptyList()
+		}
+	}
+
+	@Nested
+	inner class PinAndQuery {
+		@Test
+		fun `pin and isPinned round-trip across kinds`() {
+			PinStore.pin(cwd, "memories", "abc12345def", "Redesign sidebar", "M")
+			PinStore.pin(cwd, "conversations", "claude:s1", "Sidebar UX redesign", "claude")
+
+			PinStore.isPinned(cwd, "memories", "abc12345def") shouldBe true
+			PinStore.isPinned(cwd, "conversations", "claude:s1") shouldBe true
+			PinStore.isPinned(cwd, "memories", "other") shouldBe false
+			PinStore.isPinned(cwd, "notes", "claude:s1") shouldBe false
+		}
+
+		@Test
+		fun `pin stores the display title and badge`() {
+			PinStore.pin(cwd, "plans", "plan-1", "My plan title", "P")
+			val pins = PinStore.readPins(cwd)
+			pins.size shouldBe 1
+			pins[0].kind shouldBe "plans"
+			pins[0].key shouldBe "plan-1"
+			pins[0].title shouldBe "My plan title"
+			pins[0].badge shouldBe "P"
+		}
+
+		@Test
+		fun `pinning the same key twice does not duplicate`() {
+			PinStore.pin(cwd, "plans", "plan-1", "First title", "P")
+			PinStore.pin(cwd, "plans", "plan-1", "Updated title", "P")
+			val pins = PinStore.readPins(cwd)
+			pins.size shouldBe 1
+			pins[0].title shouldBe "Updated title"
+		}
+
+		@Test
+		fun `unpin removes the entry`() {
+			PinStore.pin(cwd, "references", "github:1", "Issue 1", "GH")
+			PinStore.isPinned(cwd, "references", "github:1") shouldBe true
+
+			PinStore.unpin(cwd, "references", "github:1")
+			PinStore.isPinned(cwd, "references", "github:1") shouldBe false
+			PinStore.readPins(cwd) shouldBe emptyList()
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Brings the **IntelliJ** plugin's Jolli Memory tool window in line with the new sidebar redesign mockup. The IntelliJ sidebar is native Kotlin/Swing (right-anchored), so this translates the mockup's design/interaction into Swing components, using `AllIcons`/`JolliMemoryIcons` and `JBColor`/`UIManager` tokens (light/dark/high-contrast safe).

## What changed

- **3-tab view switch** (Current Branch / Memory Bank / Knowledge) above the breadcrumb. Memory Bank reuses the existing KB explorer; Knowledge is a placeholder for the forthcoming wiki/graph.
- **Title-bar icons** — Agents / Settings / Status moved into the tool window title bar (`setTitleActions`); the breadcrumb row is now just repo / branch.
- **Three collapsible panels** for Current Branch: **Pinned → Current Memory → Committed Memories**. Conversations, Context and Files fold into the Current Memory card (minimal-density default).
- **Fixed bottom action bar** — Commit · Create PR · ⋯ More, using the **V1** recall layout (recall lives in the More menu alongside Sync / Refresh).
- **Context rows** reworked to mockup parity: checkbox (all kinds), single/double-letter type tag (P / N / S / L / GH / J / No), title, and hover **Pin / Edit / Delete** anchored to the right edge with title ellipsis + full-content hover popup.
- **Conversation rows** gain hover **Pin / Delete**.
- **PinStore + Pinned panel** — pinning a conversation or context item surfaces it (with its original source/type badge) in the Pinned section; clicking a pinned row opens the underlying content (transcript / plan / note / reference / memory); unpin on hover. Backed by `<projectDir>/.jolli/jollimemory/pins.json` (worktree-scoped, mirrors `CommitSelectionStore`).

## Testing

- `./gradlew build` (compile + full test suite) passes.
- New `PinStoreTest` covers pin/unpin, dedupe, title+badge persistence.
- Verified interactively via `./gradlew runIde`.

## Notes / deferred

- Per-item token costs are omitted — the service only exposes summary-level token totals, not per-item.
- Recall copies the `jolli-recall` prompt to the clipboard (IntelliJ can't launch the AI tool directly), matching existing behavior.
- Knowledge wiki/graph rendering, the agents-access overlay, and share/auth overlays are intentionally left as follow-ups.
- Scope is IntelliJ-only; no `cli/` or `vscode/` files are touched.