### PR TITLE
Refactor build progress messages to unified "Building knowledge wiki/graph — <repo>" format

### DIFF
--- a/cli/src/core/MultiRepoCompile.test.ts
+++ b/cli/src/core/MultiRepoCompile.test.ts
@@ -66,15 +66,18 @@ describe("compileAllRepos", () => {
 		expect(setActiveStorage).toHaveBeenCalledTimes(4);
 	});
 
-	it("reports per-repo progress with [i/total] prefixes when onProgress is supplied", async () => {
+	it("reports self-contained `<label> — <repo>` phase lines (no [i/total], no separate render line)", async () => {
 		const messages: string[] = [];
 		await compileAllRepos("/mb", { model: "haiku" } as never, { onProgress: (m) => messages.push(m) });
-		// Phase reports are prefixed with the repo's 1-based index and the total.
-		expect(messages).toContain("[1/3] jolli: ingesting sources");
-		expect(messages).toContain("[1/3] jolli: rendering wiki");
-		// boom (3rd) reports ingest before drainIngest throws, but never reaches "rendering wiki".
-		expect(messages).toContain("[3/3] boom: ingesting sources");
-		expect(messages).not.toContain("[3/3] boom: rendering wiki");
+		// wiki is one phase per repo (ingest + render merged); the line names the repo.
+		expect(messages).toContain("Building knowledge wiki — jolli");
+		expect(messages).toContain("Building knowledge graph — jolli");
+		// boom (3rd) reports the wiki phase before drainIngest throws.
+		expect(messages).toContain("Building knowledge wiki — boom");
+		// No legacy counter prefix and no separate "rendering" line.
+		expect(messages.some((m) => /^\[\d+\/\d+\]/.test(m))).toBe(false);
+		expect(messages.some((m) => m.includes("rendering"))).toBe(false);
+		expect(messages.some((m) => m.includes("ingesting sources"))).toBe(false);
 	});
 
 	it("restores the previous active storage override after the sweep (no leak into the host process)", async () => {
@@ -166,7 +169,7 @@ describe("compileAllRepos", () => {
 		expect(res.totalIngested).toBe(2);
 	});
 
-	it("relays graph-build progress under a `graph:` prefix", async () => {
+	it("relays graph-build sub-progress as a parenthesised detail on the graph phase line", async () => {
 		vi.mocked(buildKnowledgeGraph).mockImplementationOnce(async (_cwd, _storage, _config, opts) => {
 			opts?.onProgress?.("distilling topics");
 			return { built: true };
@@ -175,7 +178,7 @@ describe("compileAllRepos", () => {
 		await compileAllRepos("/mb", { compileExcludeFolders: ["jolliai", "boom"] } as never, {
 			onProgress: (m) => messages.push(m),
 		});
-		expect(messages).toContain("[1/1] jolli: graph: distilling topics");
+		expect(messages).toContain("Building knowledge graph — jolli (distilling topics)");
 	});
 
 	it("swallows a graph-build failure without failing the repo (non-fatal)", async () => {

--- a/cli/src/core/MultiRepoCompile.ts
+++ b/cli/src/core/MultiRepoCompile.ts
@@ -34,10 +34,14 @@ export interface CompileAllResult {
 
 export interface CompileAllOptions extends Pick<IngestOptions, "batchSize"> {
 	/**
-	 * Optional one-line progress reporter for UI surfaces (the VS Code "Building
-	 * knowledge wiki…" notification). Messages take the form `[i/total] <repo>:
-	 * <phase>` so the user sees which repo (and how far through the sweep) plus the
-	 * current phase.
+	 * Optional one-line progress reporter for UI surfaces (the VS Code progress
+	 * notification). Each message is a self-contained `<label> — <repo> [(<detail>)]`
+	 * line: the label is one of the two top-level phases ("Building knowledge wiki"
+	 * / "Building knowledge graph"), `<repo>` is the folder being swept, and the
+	 * optional `(<detail>)` is the graph distiller's sub-progress. No `[i/total]`
+	 * counter — it read as a phase index and confused users; the phase label carries
+	 * the meaning. wiki/graph are surfaced as two peers (ingest + render are merged
+	 * into "Building knowledge wiki" — no separate "rendering" line).
 	 */
 	readonly onProgress?: (message: string) => void;
 }
@@ -86,7 +90,6 @@ export async function compileAllRepos(
 	const repos: CompileAllRepoResult[] = [];
 	let totalIngested = 0;
 	let failed = 0;
-	const total = targets.length;
 
 	// We swap the process-global storage override per repo (inner stores fall back
 	// to it). Capture the prior value and restore it in a finally so the override
@@ -99,15 +102,17 @@ export async function compileAllRepos(
 	// into the long-lived VS Code host past this sweep.
 	const previousLogDir = getLogDir();
 	try {
-		for (const [i, t] of targets.entries()) {
-			// `[i/total] <repo>: <phase>` — keeps the UI notification legible about
-			// which repo and phase a long sweep is on.
-			const report = (phase: string) => opts?.onProgress?.(`[${i + 1}/${total}] ${t.folder}: ${phase}`);
+		for (const t of targets) {
+			// Self-contained `<label> — <repo> [(<detail>)]` lines so the notification
+			// reads as two peer phases (wiki / graph) on a named repo, not a counter.
+			const phaseMsg = (label: string, detail?: string) =>
+				opts?.onProgress?.(detail ? `${label} — ${t.folder} (${detail})` : `${label} — ${t.folder}`);
 			try {
 				setLogDir(t.kbRoot);
 				const storage = createFolderStorageAtRoot(t.kbRoot);
 				setActiveStorage(storage);
-				report("ingesting sources");
+				// ingest + render are one user-facing phase: "Building knowledge wiki".
+				phaseMsg("Building knowledge wiki");
 				const { batches, ingested } = await drainIngest(t.kbRoot, config, {
 					batchSize: opts?.batchSize,
 					readStorage: storage,
@@ -119,7 +124,6 @@ export async function compileAllRepos(
 				// "everything not in the index" would delete it (data loss). Orphan pages
 				// from topic consolidation are reclaimed by an explicit `jolli compile
 				// --cwd <repo> --rebuild`, never by the routine sweep.
-				report("rendering wiki");
 				await renderTopicKBWiki(t.kbRoot, storage, writeGuard);
 				// Build the knowledge graph from the freshly-ingested topic KB. Wrapped
 				// non-fatal: a graph build failure or missing LLM key must never fail the
@@ -127,9 +131,9 @@ export async function compileAllRepos(
 				// across it would re-create the commit-blocking stall this fix removes
 				// (the graph is a derived artifact, regenerated on the next sweep).
 				try {
-					report("building knowledge graph");
+					phaseMsg("Building knowledge graph");
 					await buildKnowledgeGraph(t.kbRoot, storage, config, {
-						onProgress: (m) => report(`graph: ${m}`),
+						onProgress: (m) => phaseMsg("Building knowledge graph", m),
 					});
 				} catch (graphErr) {
 					log.warn(

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -2334,7 +2334,7 @@ describe("QueueWorker", () => {
 
 			// The fresh worker holds the lock, proving the previous one is gone, so
 			// the stale marker is cleared at the source — not left to mislabel the
-			// next genuine summary run as "Updating Memory Bank…".
+			// next genuine summary run as "Building knowledge wiki…".
 			expect(realExistsSync(phaseFile)).toBe(false);
 
 			rmSync(tmp, { recursive: true, force: true });
@@ -2398,7 +2398,7 @@ describe("QueueWorker", () => {
 			vi.mocked(createStorage).mockResolvedValue(storageWithWiki(true));
 		});
 
-		it("writes worker-phase=ingest during ingest and removes it after", async () => {
+		it("writes worker-phase=ingest:wiki during ingest, advances to ingest:graph before the graph build, and removes it after", async () => {
 			const tmp = mkdtempSync(join(tmpdir(), "jolli-phase-"));
 			mkdirSync(join(tmp, ".jolli", "jollimemory"), { recursive: true });
 			const phaseFile = join(tmp, ".jolli", "jollimemory", "worker-phase");
@@ -2411,15 +2411,52 @@ describe("QueueWorker", () => {
 			vi.mocked(readFileSync).mockImplementation(realReadFileSync as typeof readFileSync);
 
 			vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-test" } as never);
-			let phaseSeenDuringIngest: string | null = null;
+			const readPhase = () => (existsSync(phaseFile) ? readFileSync(phaseFile, "utf-8") : null);
+			let phaseSeenDuringDrain: string | null = null;
+			let phaseSeenDuringGraph: string | null = null;
 			vi.mocked(drainIngest).mockImplementation(async () => {
-				phaseSeenDuringIngest = existsSync(phaseFile) ? readFileSync(phaseFile, "utf-8") : null;
+				phaseSeenDuringDrain = readPhase();
 				return { batches: 1, ingested: 2, outcome: "OK", topicFailures: [] };
+			});
+			vi.mocked(buildKnowledgeGraph).mockImplementationOnce(async () => {
+				phaseSeenDuringGraph = readPhase();
+				return { built: true };
 			});
 
 			await __test__.runIngestEntry(makeIngestOp("post-merge"), tmp, storageWithWiki(true));
 
-			expect(phaseSeenDuringIngest).toBe("ingest");
+			// The wiki phase covers ingest + render; the marker flips to graph only
+			// right before the (gated) build.
+			expect(phaseSeenDuringDrain).toBe("ingest:wiki");
+			expect(phaseSeenDuringGraph).toBe("ingest:graph");
+			expect(existsSync(phaseFile)).toBe(false);
+
+			rmSync(tmp, { recursive: true, force: true });
+		});
+
+		it("leaves the marker at ingest:wiki (never ingest:graph) when the graph build is skipped", async () => {
+			const tmp = mkdtempSync(join(tmpdir(), "jolli-phase-"));
+			mkdirSync(join(tmp, ".jolli", "jollimemory"), { recursive: true });
+			const phaseFile = join(tmp, ".jolli", "jollimemory", "worker-phase");
+
+			const { existsSync: realExistsSync, readFileSync: realReadFileSync } =
+				await vi.importActual<typeof import("node:fs")>("node:fs");
+			vi.mocked(existsSync).mockImplementation(realExistsSync);
+			vi.mocked(readFileSync).mockImplementation(realReadFileSync as typeof readFileSync);
+
+			vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-test" } as never);
+			// 0 ingested + wiki present → render + graph both skipped, so the phase
+			// never advances past wiki.
+			let phaseSeenDuringDrain: string | null = null;
+			vi.mocked(drainIngest).mockImplementation(async () => {
+				phaseSeenDuringDrain = existsSync(phaseFile) ? readFileSync(phaseFile, "utf-8") : null;
+				return { batches: 1, ingested: 0, outcome: "OK", topicFailures: [] };
+			});
+
+			await __test__.runIngestEntry(makeIngestOp("post-merge"), tmp, storageWithWiki(true));
+
+			expect(phaseSeenDuringDrain).toBe("ingest:wiki");
+			expect(vi.mocked(buildKnowledgeGraph)).not.toHaveBeenCalled();
 			expect(existsSync(phaseFile)).toBe(false);
 
 			rmSync(tmp, { recursive: true, force: true });

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -478,7 +478,7 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 		// was orphaned by a crashed/SIGKILL'd predecessor whose `finally` cleanup
 		// (in processQueueEntry) never ran. Removing it here keeps the file's
 		// lifetime genuinely lock-bound — otherwise it survives indefinitely and
-		// mislabels the next plain summary run as "Updating Memory Bank…".
+		// mislabels the next plain summary run as "Building knowledge wiki…".
 		try {
 			rmSync(join(getJolliMemoryDir(cwd), WORKER_PHASE_FILE), { force: true });
 		} catch (e) {
@@ -647,11 +647,11 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 /**
  * Second line of defense for the worker-phase marker. If the ingest `finally`
  * cleanup failed (e.g. Windows AV briefly holding the file), the marker still
- * reads `ingest` while this same drain processes blocking summary entries —
- * and the extension's Commit/Squash gates would stay open during exactly the
- * runs they must block. Retry the delete here; if the file is still
- * undeletable, overwrite the content so readers see a blocking phase (any
- * value other than `ingest` blocks). The reader-side mtime staleness check is
+ * reads an `ingest:*` sub-phase while this same drain processes blocking summary
+ * entries — and the extension's Commit/Squash gates would stay open during
+ * exactly the runs they must block. Retry the delete here; if the file is still
+ * undeletable, overwrite the content so readers see a blocking phase (any value
+ * not starting with `ingest` blocks). The reader-side mtime staleness check is
  * the final backstop when both attempts fail.
  */
 function clearLeftoverIngestMarker(cwd: string): void {
@@ -671,15 +671,23 @@ function clearLeftoverIngestMarker(cwd: string): void {
 }
 
 /**
+ * Ingest sub-phases written to the `worker-phase` marker. Both keep the
+ * `ingest` prefix so the extension's commit/squash gates (which key off the
+ * prefix) treat them identically — only the cosmetic label differs.
+ */
+type IngestPhase = "ingest:wiki" | "ingest:graph";
+
+/**
  * Runs a topic-KB ingest with the extension's worker-phase marker around it.
  *
  * Called from runWorker's UNLOCKED ingest phase (both entry-level locks already
- * released). The phase marker (`ingest`) is consumed by the extension's
- * worker-busy gates (and the toolbar label): while it reads `ingest` AND is
- * fresh, Commit/Squash stay enabled and the toolbar shows "Updating Memory
- * Bank…". `writeGuard` is threaded down to drainIngest + renderTopicKBWiki so
- * each individual write re-acquires `vault-write.lock` briefly — the reconcile
- * LLM phase between writes holds no lock.
+ * released). The phase marker (`ingest:wiki` / `ingest:graph`) is consumed by
+ * the extension's worker-busy gates (and the toolbar label): while it starts
+ * with `ingest` AND is fresh, Commit/Squash stay enabled and the toolbar shows
+ * the matching "Building knowledge wiki/graph…" label. `writeGuard` is threaded
+ * down to drainIngest + renderTopicKBWiki so each individual write re-acquires
+ * `vault-write.lock` briefly — the reconcile LLM phase between writes holds no
+ * lock.
  */
 async function runIngestEntry(
 	op: IngestOperation,
@@ -689,30 +697,46 @@ async function runIngestEntry(
 ): Promise<void> {
 	log.info("Processing queue entry: type=ingest triggeredBy=%s", op.triggeredBy);
 	// Best-effort marker — a failure only over-blocks (missing marker = blocking
-	// summary phase), never under-blocks.
+	// summary phase), never under-blocks. The marker carries the ingest SUB-PHASE
+	// (`ingest:wiki` while ingesting + rendering the wiki, `ingest:graph` while
+	// building the knowledge graph) so the extension can show the matching label.
+	// Both keep the `ingest` prefix the gates key off — every `ingest:*` value is
+	// commit-exempt, so the prefix preserves the gating semantics unchanged.
 	const phaseFile = join(getJolliMemoryDir(cwd), WORKER_PHASE_FILE);
-	try {
-		writeFileSync(phaseFile, "ingest");
-	} catch (e) {
-		/* v8 ignore next -- best-effort marker; a write failure only over-blocks */
-		log.debug("worker-phase write skipped (non-fatal): %s", errMsg(e));
-	}
+	// Shared by the initial write, the heartbeat, and the graph-phase switch
+	// (threaded into runIngestFromQueue as `setPhase`). The heartbeat MUST write
+	// this variable, not a literal, or it would clobber an already-advanced phase
+	// back to wiki and strand the sidebar on the wrong label.
+	let currentPhase: IngestPhase = "ingest:wiki";
+	const writePhase = (phase: IngestPhase) => {
+		currentPhase = phase;
+		try {
+			writeFileSync(phaseFile, phase);
+		} catch (e) {
+			/* v8 ignore next -- best-effort marker; a write failure only over-blocks */
+			log.debug("worker-phase write skipped (non-fatal): %s", errMsg(e));
+		}
+	};
+	writePhase("ingest:wiki");
 	// Heartbeat: keep the marker's mtime fresh for the whole ingest. Readers
 	// treat a stale marker as blocking (fail-safe), so a long ingest needs this
-	// to stay exempt — and conversely an orphaned `ingest` marker (both the
+	// to stay exempt — and conversely an orphaned `ingest:*` marker (both the
 	// cleanup below and the per-entry guard failed) ages out instead of holding
 	// the gates open during a later summary run.
 	/* v8 ignore start -- timer callback never fires inside fast unit tests */
 	const phaseRefreshTimer = setInterval(() => {
 		try {
-			writeFileSync(phaseFile, "ingest");
+			writeFileSync(phaseFile, currentPhase);
 		} catch {
 			// Next tick retries; reader-side staleness covers persistent failure.
 		}
 	}, WORKER_LOCK_REFRESH_INTERVAL_MS);
 	/* v8 ignore stop */
 	try {
-		await runIngestFromQueue(op, cwd, storage, writeGuard);
+		// `setPhase` lets runIngestFromQueue advance the marker to `ingest:graph`
+		// right before the (in-function) graph build — the marker owner lives here
+		// but the graph phase boundary lives there.
+		await runIngestFromQueue(op, cwd, storage, writeGuard, (phase) => writePhase(phase));
 	} finally {
 		clearInterval(phaseRefreshTimer);
 		try {
@@ -815,6 +839,10 @@ async function runIngestFromQueue(
 	cwd: string,
 	storage: StorageProvider,
 	writeGuard: (fn: () => Promise<void>) => Promise<void> = (fn) => fn(),
+	// Advances the worker-phase marker (the marker owner lives in runIngestEntry).
+	// Required — the sole caller always threads it — so there is no dead default
+	// branch to leave uncovered.
+	setPhase: (phase: IngestPhase) => void,
 ): Promise<void> {
 	const { drainIngest } = await import("../core/IngestPipeline.js");
 	const { renderTopicKBWiki } = await import("../core/TopicWikiRenderer.js");
@@ -834,6 +862,11 @@ async function runIngestFromQueue(
 	const wikiMissing = storage.isTopicWikiPresent ? !storage.isTopicWikiPresent() : false;
 	if (result.ingested > 0 || wikiMissing) {
 		await renderTopicKBWiki(cwd, storage, writeGuard);
+		// Advance the marker to the graph sub-phase right before the build so the
+		// sidebar swaps to "Building knowledge graph…". Still commit-exempt (same
+		// `ingest` prefix). Only reached when there was wiki work, so on a no-source
+		// commit the marker stays `ingest:wiki` and `ingest:graph` never shows.
+		setPhase("ingest:graph");
 		// Refresh the knowledge graph alongside the wiki, on the same gate. Cheap
 		// now that it's diff-based: a no-op build (nothing changed) costs 0 LLM
 		// calls, and a typical change costs ~one call per changed topic. Isolated +

--- a/vscode/src/CompileCommand.ts
+++ b/vscode/src/CompileCommand.ts
@@ -59,7 +59,10 @@ export function registerCompileCommand(opts: CompileCommandOpts): vscode.Disposa
 			const result = await vscode.window.withProgress(
 				{
 					location: vscode.ProgressLocation.Notification,
-					title: "Jolli Memory: Building knowledge wiki…",
+					// Title is fixed for the notification's lifetime (VS Code API), so it
+					// stays a neutral prefix; the wiki/graph phase + repo + detail all ride
+					// in progress.report({ message }) so both phases appear as peers.
+					title: "Jolli Memory",
 					cancellable: false,
 				},
 				async (progress) =>

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -5047,9 +5047,9 @@ describe("Extension", () => {
 		// The workerBusy context key gates the commitAI / squash commands'
 		// `enablement`. The ingest phase (Memory Bank wiki update) must NOT
 		// block them — only summary runs do — so when the worker-phase marker
-		// reads "ingest" the context flips to false even while the lock is held,
-		// and flips back when the marker is deleted (lock still held).
-		it("exempts the ingest phase from the workerBusy context key", async () => {
+		// reads an `ingest:*` sub-phase the context flips to false even while the
+		// lock is held, and flips back when the marker is deleted (lock still held).
+		it("exempts an ingest sub-phase from the workerBusy context key and forwards the full phase", async () => {
 			// Watcher indices: 0=sessions, 1=head, 2=orphan-ref, 3=lock, 4=phase.
 			const lockWatcher = createFileSystemWatcher.mock.results[3]?.value;
 			const phaseWatcher = createFileSystemWatcher.mock.results[4]?.value;
@@ -5068,11 +5068,29 @@ describe("Extension", () => {
 			onLockCreate?.();
 			executeCommand.mockClear();
 
-			fsReadFile.mockResolvedValueOnce(Buffer.from("ingest"));
+			fsReadFile.mockResolvedValueOnce(Buffer.from("ingest:wiki"));
 			onPhaseCreate?.();
 
 			await vi.waitFor(() => {
-				expect(mockStatusStore.setWorkerPhase).toHaveBeenCalledWith("ingest");
+				// The full sub-phase value is forwarded (not collapsed to "ingest"),
+				// so the sidebar can pick the wiki vs graph label.
+				expect(mockStatusStore.setWorkerPhase).toHaveBeenCalledWith("ingest:wiki");
+				expect(executeCommand).toHaveBeenCalledWith(
+					"setContext",
+					"jollimemory.workerBusy",
+					false,
+				);
+			});
+
+			// Phase advances to the graph build — still commit-exempt (ingest prefix),
+			// and the graph value is forwarded verbatim.
+			executeCommand.mockClear();
+			mockStatusStore.setWorkerPhase.mockClear();
+			fsReadFile.mockResolvedValueOnce(Buffer.from("ingest:graph"));
+			onPhaseCreate?.();
+
+			await vi.waitFor(() => {
+				expect(mockStatusStore.setWorkerPhase).toHaveBeenCalledWith("ingest:graph");
 				expect(executeCommand).toHaveBeenCalledWith(
 					"setContext",
 					"jollimemory.workerBusy",

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -86,7 +86,7 @@ import { CommitsStore } from "./stores/CommitsStore.js";
 import { FilesStore } from "./stores/FilesStore.js";
 import { MemoriesStore } from "./stores/MemoriesStore.js";
 import { PlansStore } from "./stores/PlansStore.js";
-import { StatusStore } from "./stores/StatusStore.js";
+import { StatusStore, type WorkerPhase } from "./stores/StatusStore.js";
 import { registerCompileCommand } from "./CompileCommand.js";
 import { openKnowledgeGraph } from "./views/KnowledgeGraphPanel.js";
 import { activateSync } from "./sync/VsCodeSyncBootstrap.js";
@@ -1526,9 +1526,10 @@ export function activate(context: vscode.ExtensionContext): void {
 	void isWorkerBusy(workspaceRoot).then(setWorkerBusy);
 
 	// ── Worker phase file watcher ───────────────────────────────────────
-	// The worker writes `.jolli/jollimemory/worker-phase` (content "ingest")
-	// while running a topic-KB ingest, so the Branch toolbar can show
-	// "Updating Memory Bank…" instead of "AI summary in progress…". The phase
+	// The worker writes `.jolli/jollimemory/worker-phase` (content
+	// "ingest:wiki" / "ingest:graph") while running a topic-KB ingest, so the
+	// Branch toolbar can show "Building knowledge wiki/graph…" instead of
+	// "AI summary in progress…". The phase
 	// is purely cosmetic; its busy-bound lifetime (StatusStore clears it on
 	// workerBusy=false) means a stale marker left by a crashed worker can't
 	// outlive the lock. Separate from the lock watcher because a phase-file
@@ -1555,8 +1556,18 @@ export function activate(context: vscode.ExtensionContext): void {
 				return;
 			}
 			const content = Buffer.from(bytes).toString("utf-8").trim();
-			workerPhaseIsIngest = content === "ingest";
-			statusStore.setWorkerPhase(workerPhaseIsIngest ? "ingest" : null);
+			// Prefix match: every `ingest:*` sub-phase (wiki / graph) plus the legacy
+			// bare `ingest` is commit-exempt — only the prefix decides the gate. Map
+			// the raw marker to a known WorkerPhase rather than casting: `ingest:graph`
+			// keeps the graph label, everything else ingest-prefixed (incl. legacy
+			// bare `ingest`) collapses to the wiki label; non-ingest clears to null.
+			workerPhaseIsIngest = content.startsWith("ingest");
+			const phase: WorkerPhase = !workerPhaseIsIngest
+				? null
+				: content === "ingest:graph"
+					? "ingest:graph"
+					: "ingest:wiki";
+			statusStore.setWorkerPhase(phase);
 		} catch {
 			if (epoch !== workerPhaseEpoch) {
 				return;

--- a/vscode/src/stores/StatusStore.test.ts
+++ b/vscode/src/stores/StatusStore.test.ts
@@ -175,6 +175,15 @@ describe("StatusStore", () => {
 		expect(store.getSnapshot().changeReason).toBe("workerPhase");
 	});
 
+	it("setWorkerPhase carries the ingest sub-phases verbatim (wiki / graph)", () => {
+		const store = new StatusStore({ getStatus: vi.fn() } as never);
+		store.setWorkerBusy(true);
+		store.setWorkerPhase("ingest:wiki");
+		expect(store.getSnapshot().workerPhase).toBe("ingest:wiki");
+		store.setWorkerPhase("ingest:graph");
+		expect(store.getSnapshot().workerPhase).toBe("ingest:graph");
+	});
+
 	it("setWorkerPhase is a no-op when unchanged", () => {
 		const store = new StatusStore({ getStatus: vi.fn() } as never);
 		let emits = 0;
@@ -200,7 +209,7 @@ describe("StatusStore", () => {
 		// isWorkerBusy().then(setWorkerBusy) resolves false. Because workerBusy
 		// starts false, setWorkerBusy(false) would hit the equality early-return
 		// and skip the phase clear — leaving a stale phase that mislabels the
-		// next genuine summary run as "Updating Memory Bank…". The busy-bound
+		// next genuine summary run as "Building knowledge wiki…". The busy-bound
 		// invariant must hold here too.
 		const store = new StatusStore({ getStatus: vi.fn() } as never);
 		store.setWorkerPhase("ingest"); // stale marker read while workerBusy is still false

--- a/vscode/src/stores/StatusStore.ts
+++ b/vscode/src/stores/StatusStore.ts
@@ -55,12 +55,21 @@ export interface SyncPhaseState {
 	readonly severity: "info" | "error";
 }
 
+/**
+ * Post-commit worker phase surfaced to the sidebar. The QueueWorker writes the
+ * ingest sub-phase (`ingest:wiki` / `ingest:graph`); `"ingest"` is the legacy
+ * bare value, still accepted as a wiki-equivalent fallback. All non-null values
+ * keep the `ingest` prefix, which the commit/squash gates key off. `null` is the
+ * default (blocking) summary phase.
+ */
+export type WorkerPhase = "ingest" | "ingest:wiki" | "ingest:graph" | null;
+
 export interface StatusSnapshot extends Snapshot<StatusChangeReason> {
 	readonly status: StatusInfo | null;
 	readonly config: JolliMemoryConfig | null;
 	readonly derived: StatusDerived;
 	readonly workerBusy: boolean;
-	readonly workerPhase: "ingest" | null;
+	readonly workerPhase: WorkerPhase;
 	readonly syncPhase: SyncPhaseState | null;
 	readonly extensionOutdated: boolean;
 	readonly migrating: boolean;
@@ -90,7 +99,7 @@ export class StatusStore extends BaseStore<StatusChangeReason, StatusSnapshot> {
 	private status: StatusInfo | null = null;
 	private config: JolliMemoryConfig | null = null;
 	private workerBusy = false;
-	private workerPhase: "ingest" | null = null;
+	private workerPhase: WorkerPhase = null;
 	private syncPhase: SyncPhaseState | null = null;
 	private extensionOutdated = false;
 	private migrating = false;
@@ -131,7 +140,7 @@ export class StatusStore extends BaseStore<StatusChangeReason, StatusSnapshot> {
 		// be cleared even when `workerBusy` is already false. Otherwise the equality
 		// early-return below would skip the clear, and a stale 'ingest' marker read
 		// at activation — before `isWorkerBusy()` resolves false — would survive into
-		// the next genuine summary run and mislabel it "Updating Memory Bank…".
+		// the next genuine summary run and mislabel it "Building knowledge wiki…".
 		const staleClear = !busy && this.workerPhase !== null;
 		if (this.workerBusy === busy && !staleClear) {
 			return;
@@ -144,12 +153,12 @@ export class StatusStore extends BaseStore<StatusChangeReason, StatusSnapshot> {
 	}
 
 	/**
-	 * Push (or clear) the post-commit worker's phase. Only `"ingest"` is
-	 * surfaced today; any other phase is represented as `null` (default
-	 * "AI summary in progress…" label). Equality-checked so a redundant call
-	 * is a no-op.
+	 * Push (or clear) the post-commit worker's phase. Non-null values are the
+	 * `ingest:*` sub-phases (wiki / graph), each selecting a distinct sidebar
+	 * label; `null` is the default "AI summary in progress…" phase. Equality-
+	 * checked so a redundant call is a no-op.
 	 */
-	setWorkerPhase(phase: "ingest" | null): void {
+	setWorkerPhase(phase: WorkerPhase): void {
 		if (this.workerPhase === phase) {
 			return;
 		}

--- a/vscode/src/util/LockUtils.test.ts
+++ b/vscode/src/util/LockUtils.test.ts
@@ -76,6 +76,14 @@ describe("isWorkerBlockingBusy", () => {
 		);
 	});
 
+	it("returns false for the ingest:wiki / ingest:graph sub-phases (prefix match)", async () => {
+		readFile.mockResolvedValue("ingest:wiki");
+		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(false);
+
+		readFile.mockResolvedValue("ingest:graph");
+		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(false);
+	});
+
 	it("trims whitespace around the phase marker content", async () => {
 		readFile.mockResolvedValue("ingest\n");
 

--- a/vscode/src/util/LockUtils.ts
+++ b/vscode/src/util/LockUtils.ts
@@ -79,7 +79,11 @@ async function isFreshIngestPhase(cwd: string): Promise<boolean> {
 	const phasePath = join(cwd, ".jolli", "jollimemory", "worker-phase");
 	try {
 		const content = await readFile(phasePath, "utf-8");
-		if (content.trim() !== "ingest") {
+		// Prefix match: the worker writes `ingest:wiki` / `ingest:graph` (and, for
+		// older workers, bare `ingest`). Every `ingest*` value is commit-exempt;
+		// only a non-ingest phase (e.g. `summary`) blocks. An equality check here
+		// would wrongly block commits during the new sub-phases.
+		if (!content.trim().startsWith("ingest")) {
 			return false;
 		}
 		const phaseStat = await stat(phasePath);

--- a/vscode/src/views/SidebarMessages.ts
+++ b/vscode/src/views/SidebarMessages.ts
@@ -10,6 +10,7 @@
 
 import type { ActiveConversationItem } from "../../../cli/src/core/ActiveSessionAggregator.js";
 import type { ReferenceField, SourceId, TranscriptSource } from "../../../cli/src/Types.js";
+import type { WorkerPhase } from "../stores/StatusStore.js";
 
 export type SidebarTab = "kb" | "branch" | "status";
 export type KbMode = "folders" | "memories";
@@ -631,14 +632,14 @@ export type SidebarInboundMsg =
 	| {
 			/**
 			 * Worker-phase indicator for the Branch-tab toolbar. Selects a
-			 * distinct label for specific worker phases — currently only
-			 * `"ingest"` (topic-KB ingest), which renders "Updating Memory
-			 * Bank…" instead of the default "AI summary in progress…". `null`
-			 * falls back to the default label. Lifetime is bound to
-			 * `worker:busy` on the reader side.
+			 * distinct label per ingest sub-phase: `"ingest:wiki"` → "Building
+			 * knowledge wiki…", `"ingest:graph"` → "Building knowledge graph…"
+			 * (the legacy bare `"ingest"` falls back to the wiki label). `null`
+			 * falls back to the default "AI summary in progress…". Lifetime is
+			 * bound to `worker:busy` on the reader side.
 			 */
 			readonly type: "worker:phase";
-			readonly phase: "ingest" | null;
+			readonly phase: WorkerPhase;
 	  }
 	| {
 			/**

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -1014,9 +1014,10 @@ describe("SidebarScriptBuilder", () => {
 		it("exempts the ingest phase from disabling commit actions", () => {
 			const js = buildSidebarScript();
 			// isWorkerBlocking is the single busy predicate for commit actions:
-			// busy in any phase except ingest.
+			// busy in any phase except an `ingest*` sub-phase (prefix match so
+			// ingest:wiki / ingest:graph both stay exempt).
 			expect(js).toContain(
-				"return state.workerBusy && state.workerPhase !== 'ingest';",
+				"return state.workerBusy && !(state.workerPhase && state.workerPhase.indexOf('ingest') === 0);",
 			);
 			// Both commit entry points go through it: the Commit-AI icon button
 			// (asserted above) and the labelled Commit Memory button.
@@ -2199,15 +2200,30 @@ describe("SidebarScriptBuilder", () => {
 		});
 	});
 
-	it("selects the Updating Memory Bank label for the ingest phase", () => {
+	it("selects the wiki / graph labels per ingest sub-phase (graph checked first, wiki for the rest)", () => {
 		const js = buildSidebarScript();
-		expect(js).toContain("Updating Memory Bank…");
-		expect(js).toContain("state.workerPhase === 'ingest'");
+		expect(js).toContain("Building knowledge wiki…");
+		expect(js).toContain("Building knowledge graph…");
+		// graph is the more specific prefix and must be tested before the wiki
+		// fallback, else 'ingest:graph' would match the wiki branch.
+		expect(js).toContain("state.workerPhase.indexOf('ingest:graph') === 0");
+		expect(js).toContain("state.workerPhase.indexOf('ingest') === 0");
+		// The retired single-value label must be gone.
+		expect(js).not.toContain("Updating Memory Bank…");
 	});
 
 	it("keeps the default AI summary label for non-ingest busy state", () => {
 		const js = buildSidebarScript();
 		expect(js).toContain("AI summary in progress…");
+	});
+
+	it("worker:phase keeps any ingest* sub-phase verbatim and clears anything else", () => {
+		const js = buildSidebarScript();
+		const handlerStart = js.indexOf("case 'worker:phase'");
+		const handlerEnd = js.indexOf("case ", handlerStart + 1);
+		const body = js.slice(handlerStart, handlerEnd);
+		// Prefix-gated pass-through: ingest:wiki / ingest:graph survive, summary → null.
+		expect(body).toContain("(msg.phase && msg.phase.indexOf('ingest') === 0) ? msg.phase : null");
 	});
 
 	it("handles the worker:phase message channel", () => {

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -104,9 +104,10 @@ export function buildSidebarScript(): string {
     // toolbar. Not persisted — start from false on every load and let the next
     // worker:busy or status push correct it.
     workerBusy: false,
-    // Live phase of the running worker (currently only 'ingest'), pushed on the
-    // worker:phase channel. Selects "Updating Memory Bank..." over the default
-    // summary label. Not persisted -- host re-pushes on reload.
+    // Live phase of the running worker ('ingest:wiki' / 'ingest:graph', or the
+    // legacy bare 'ingest'), pushed on the worker:phase channel. Selects the
+    // matching "Building knowledge wiki/graph…" label over the default summary
+    // label. Not persisted -- host re-pushes on reload.
     workerPhase: null,
     // Live sync-phase indicator pushed by the host as the sync engine
     // advances through phases (downloading / merging / uploading) or ends
@@ -426,10 +427,15 @@ export function buildSidebarScript(): string {
       // toolbar — it's about moving memories to/from the Personal Space, not
       // about the working-tree branch.
       const items = [];
+      // Ingest sub-phase → matching label. 'ingest:graph' is the more specific
+      // case (check first); 'ingest:wiki' and the legacy bare 'ingest' both map to
+      // the wiki label; anything else (summary phase) shows the default.
       const indicator = state.workerBusy
-        ? (state.workerPhase === 'ingest'
-            ? { label: 'Updating Memory Bank…', severity: 'info' }
-            : { label: 'AI summary in progress…', severity: 'info' })
+        ? (state.workerPhase && state.workerPhase.indexOf('ingest:graph') === 0
+            ? { label: 'Building knowledge graph…', severity: 'info' }
+            : (state.workerPhase && state.workerPhase.indexOf('ingest') === 0
+                ? { label: 'Building knowledge wiki…', severity: 'info' }
+                : { label: 'AI summary in progress…', severity: 'info' }))
         : null;
       items.push(buildToolbarIndicator(indicator));
       items.push(iconButton('refresh', 'Refresh', 'refresh'));
@@ -706,12 +712,13 @@ export function buildSidebarScript(): string {
       }
       case 'worker:phase': {
         // Per-phase label for the post-commit Worker. Independent of
-        // worker:busy; only 'ingest' is surfaced today, anything else clears to
-        // the default summary label. Only the Branch tab reacts. renderBranch
-        // runs too because the commit buttons' disabled state depends on the
-        // phase (ingest is exempt from blocking — see isWorkerBlocking), not
-        // just on worker:busy.
-        const nextPhase = (msg.phase === 'ingest') ? 'ingest' : null;
+        // worker:busy; any 'ingest'-prefixed sub-phase ('ingest', 'ingest:wiki',
+        // 'ingest:graph') is kept verbatim so renderToolbar can pick the matching
+        // wiki/graph label, anything else clears to the default summary label.
+        // Only the Branch tab reacts. renderBranch runs too because the commit
+        // buttons' disabled state depends on the phase (ingest is exempt from
+        // blocking — see isWorkerBlocking), not just on worker:busy.
+        const nextPhase = (msg.phase && msg.phase.indexOf('ingest') === 0) ? msg.phase : null;
         if (state.workerPhase === nextPhase) break;
         state.workerPhase = nextPhase;
         if (state.activeTab === 'branch') {
@@ -2683,11 +2690,12 @@ export function buildSidebarScript(): string {
   }
 
   function isWorkerBlocking() {
-    // Busy with a phase that must disable commit actions. The ingest phase
-    // (Memory Bank wiki update, ~80s+) is exempt: it never touches the commit
-    // pipeline, so commits landed during it are simply queued for the next
-    // worker. Mirrors isWorkerBlockingBusy in util/LockUtils.ts.
-    return state.workerBusy && state.workerPhase !== 'ingest';
+    // Busy with a phase that must disable commit actions. The ingest family
+    // (Memory Bank wiki update + graph build, ~80s+) is exempt: it never touches
+    // the commit pipeline, so commits landed during it are simply queued for the
+    // next worker. Prefix match so every 'ingest:*' sub-phase stays exempt.
+    // Mirrors isWorkerBlockingBusy in util/LockUtils.ts.
+    return state.workerBusy && !(state.workerPhase && state.workerPhase.indexOf('ingest') === 0);
   }
 
   function renderCommitMemoryButton() {

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -13,6 +13,7 @@ import type { TranscriptSource } from "../../../cli/src/Types.js";
 import { isTranscriptSource } from "../../../cli/src/Types.js";
 import type { ActiveSessionsProvider } from "../services/ActiveSessionsProvider.js";
 import { flushExtensionTelemetry } from "../TelemetryActivation.js";
+import type { WorkerPhase } from "../stores/StatusStore.js";
 import { log } from "../util/Logger.js";
 import { ConversationDetailsPanel } from "./ConversationDetailsPanel.js";
 import { SIDEBAR_EMPTY_STRINGS } from "./SidebarEmptyMessages.js";
@@ -60,11 +61,11 @@ export interface SidebarWebviewDeps {
 		} | null;
 		/**
 		 * Returns the current post-commit worker phase from StatusStore. Pushed
-		 * to the webview as `worker:phase` so the Branch tab toolbar can show
-		 * "Updating Memory Bank…" during a topic-KB ingest. Optional so existing
-		 * tests that only stub `getWorkerBusy` keep compiling.
+		 * to the webview as `worker:phase` so the Branch tab toolbar can show the
+		 * matching "Building knowledge wiki/graph…" label during a topic-KB ingest.
+		 * Optional so existing tests that only stub `getWorkerBusy` keep compiling.
 		 */
-		getWorkerPhase?: () => "ingest" | null;
+		getWorkerPhase?: () => WorkerPhase;
 	};
 	kbFolders?: {
 		listChildren(relPath: string): Promise<FolderNode>;


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The background knowledge-base update process now surfaces two distinct progress phases to users: "Building knowledge wiki" and "Building knowledge graph", each labeled with the name of the repository being processed. Previously, the progress notification used a numbered counter format that was easy to misread as a step index, and the sidebar toolbar showed a different, outdated label entirely. Both surfaces now use consistent wording and update in real time as the worker moves from the wiki phase into the graph phase.

To make the phase transition work correctly, the implementation introduced a shared phase variable that both the progress marker and the heartbeat timer read from. The heartbeat previously wrote a fixed value on every tick, which would have silently reset an already-advanced "graph" marker back to "wiki" mid-run. Threading an explicit callback from the outer function into the inner graph-build function keeps the phase state owned in one place while allowing the boundary to be crossed cleanly. All commit-gate checks were updated from exact-value comparisons to prefix matching, preserving the existing rule that knowledge-base update work never blocks a user from committing — and making the gate forward-compatible with any future sub-phases added under the same prefix.

---

## E2E Test (2)
<details>
<summary><strong>1. Progress notification shows &quot;Building knowledge wiki — &lt;repo&gt;&quot; and &quot;Building knowledge graph — &lt;repo&gt;&quot; as separate phases</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the Jolli Memory VS Code extension installed and connected to at least one repository. Make a small code change and commit it so the background knowledge-base update is triggered.

**Steps:**
1. Open VS Code with a repository that has Jolli Memory active.
2. Make a small change to any file and commit it to trigger a background knowledge update.
3. Watch the notification popup that appears in the bottom-right corner of VS Code.
4. Check the text shown in the notification as the update runs through its phases.
5. Wait for the update to complete and confirm the notification disappears.

**Expected Results:**
- The notification title should read "Jolli Memory" (not "Jolli Memory: Building knowledge wiki…").
- The notification message area should first show something like "Building knowledge wiki — [your-repo-name]".
- The message should then change to "Building knowledge graph — [your-repo-name]" as the second phase begins.
- No message should contain a numbered counter like "[1/3]" or words like "ingesting sources" or "rendering".
- After the update finishes, the notification should close on its own.

</blockquote>
</details>
<details>
<summary><strong>2. Sidebar toolbar label updates to match the current build phase (wiki vs. graph)</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the Jolli Memory VS Code extension installed and connected to at least one repository. Make a small code change and commit it so the background knowledge-base update is triggered.

**Steps:**
1. Open VS Code and locate the Jolli Memory sidebar panel (usually in the Activity Bar on the left).
2. Make a small change to any file and commit it to trigger a background knowledge update.
3. Watch the toolbar label inside the Jolli Memory sidebar as the update progresses.
4. Observe the label during the first phase of the update, then again during the second phase.

**Expected Results:**
- During the first phase the sidebar toolbar should display a label containing "Building knowledge wiki" along with the repository name.
- During the second phase the label should change to show "Building knowledge graph" along with the repository name.
- The label should never show the old text "Updating Memory Bank…" at any point.
- Once the update finishes, the toolbar should return to its normal idle state.

</blockquote>
</details>

---

## Topics (2)
<details>
<summary><strong>01 · Unified build progress messages to wiki and graph phase labels</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Progress notifications shown during background knowledge-base updates used inconsistent, outdated wording. The sidebar toolbar showed "Updating Memory Bank…" while the notification popup showed a different format with a numbered counter prefix, making it hard for users to understand which repository was being processed and what phase the work was in.

**💡 Decisions Behind the Code**

- **Sub-phases over a single marker value**: Keeping a single `"ingest"` marker would have required a separate side-channel to communicate which label to show, and the heartbeat would still have needed to know the current phase. Introducing `"ingest:wiki"` and `"ingest:graph"` as sub-phases lets the marker itself carry the label information while preserving the existing commit-gate semantics through a prefix match — every `ingest:*` value remains commit-exempt with no change to the gating logic.
- **Prefix matching instead of equality for gate checks**: Changing all consumer-side checks from `=== "ingest"` to `startsWith("ingest")` means future sub-phases can be added without touching every gate. An equality check would have silently blocked commits during `ingest:graph` because the new value would not match the old literal, which is exactly the regression the heartbeat-clobber fix was designed to prevent.
- **`setPhase` callback threading rather than module-level state**: The phase marker's owner (`runIngestEntry`) and the graph build boundary (`runIngestFromQueue`) are in different function scopes. Passing a callback rather than promoting the variable to module scope keeps the state lifetime strictly tied to a single ingest run and makes the dependency explicit — a module-level variable would survive across runs and could produce stale reads in tests or rapid successive invocations.

**✅ What Was Implemented**

- `cli/src/core/MultiRepoCompile.ts` was refactored to replace the `[i/total] <repo>: <phase>` progress message format with self-contained `Building knowledge wiki — <repo>` and `Building knowledge graph — <repo> (<detail>)` lines. The `total` variable and the separate "rendering wiki" and "ingesting sources" phase strings were removed; wiki ingest and render are now surfaced as a single peer phase alongside graph.
- `cli/src/hooks/QueueWorker.ts` introduced a shared `currentPhase` variable of a new `IngestPhase` type (`"ingest:wiki"` / `"ingest:graph"`), written by a `writePhase` helper that is also used by the heartbeat timer. A `setPhase` callback is threaded from `runIngestEntry` into `runIngestFromQueue` so the marker advances to `ingest:graph` immediately before the knowledge-graph build, without the heartbeat clobbering the advanced value back to the wiki sub-phase.
- `vscode/src/views/SidebarScriptBuilder.ts`, `SidebarMessages.ts`, `SidebarWebviewProvider.ts`, `Extension.ts`, `stores/StatusStore.ts`, and `util/LockUtils.ts` were updated together: the `WorkerPhase` union type was widened to include `"ingest:wiki"` and `"ingest:graph"`, all equality checks against the literal `"ingest"` were replaced with prefix (`startsWith` / `indexOf`) checks, the toolbar label logic was split into a graph-first / wiki-fallback branch, and `CompileCommand.ts` title was changed to the neutral `"Jolli Memory"` prefix so both wiki and graph phases can appear as peers in the notification message area.

**📁 FILES**
- `cli/src/core/MultiRepoCompile.ts`
- `cli/src/hooks/QueueWorker.ts`
- `vscode/src/views/SidebarScriptBuilder.ts`
- `vscode/src/stores/StatusStore.ts`
- `vscode/src/util/LockUtils.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Three-agent adversarial review caught and fixed dead code and type safety gaps</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After implementing the progress message changes, the developer ran three independent automated review passes to catch problems that a single reviewer might miss, then challenged each finding before deciding whether to act on it.

**💡 Decisions Behind the Code**

- **Adversarial cross-examination before acting on findings**: Each of the three agents' findings was independently verified against the actual code before any fix was applied. This caught that the `setPhase` default was genuinely dead (not just theoretically unused) and that the type cast was safe at runtime but structurally unsound — distinguishing real problems from theoretical ones avoided unnecessary churn.

**✅ What Was Implemented**

- The `setPhase` parameter in `runIngestFromQueue` originally had a no-op default value (`() => {}`). Review confirmed the function has exactly one call site and always receives the argument, making the default a permanently unreachable branch that suppressed a coverage gap. The default was removed, making the parameter required.
- `Extension.ts` originally used a type cast (`content as WorkerPhase`) to convert the raw file content to the phase type. Review flagged this as unsound — a future marker value not in the union would silently pass through. It was replaced with an explicit mapping that handles `"ingest:graph"` specifically and collapses everything else ingest-prefixed to `"ingest:wiki"`.
- Stale comments referencing the old "Updating Memory Bank…" wording were found in `QueueWorker.ts`, `Extension.ts`, and `StatusStore.ts` and updated to match the new label text.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`
- `vscode/src/Extension.ts`
- `vscode/src/stores/StatusStore.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 25, 2026 at 3:28 PM · via Anthropic*
<!-- jollimemory-summary-end -->