### PR TITLE
Add dual edge layers, symmetric edge dedup, and unit-focus camera

### DIFF
--- a/cli/src/graph/GraphSchema.test.ts
+++ b/cli/src/graph/GraphSchema.test.ts
@@ -6,8 +6,12 @@ import {
 	type DistilledGraph,
 	type DistilledTopic,
 	diffTopics,
+	dropSubsumedRelatedTo,
+	type GraphEdge,
 	isFingerprintMap,
 	mergeCategoryLayer,
+	normalizeSymmetricEdges,
+	SYMMETRIC_EDGE_TYPES,
 	type TopicSourceMeta,
 	toDistilled,
 	UNCATEGORIZED_CATEGORY_ID,
@@ -106,6 +110,128 @@ describe("validateDistilledGraph", () => {
 	});
 });
 
+describe("normalizeSymmetricEdges", () => {
+	const e = (from: string, to: string, type: GraphEdge["type"], confidence: number, evidence = ""): GraphEdge => ({
+		from,
+		to,
+		type,
+		confidence,
+		evidence,
+	});
+
+	it("collapses a reversed symmetric pair to one edge, keeping the higher-confidence side", () => {
+		const out = normalizeSymmetricEdges([
+			e("a", "b", "related-to", 0.6, "lo"),
+			e("b", "a", "related-to", 0.9, "hi"),
+		]);
+		expect(out).toHaveLength(1);
+		expect(out[0]).toMatchObject({ from: "b", to: "a", confidence: 0.9, evidence: "hi" });
+	});
+
+	it("keeps the first occurrence on a confidence tie", () => {
+		const out = normalizeSymmetricEdges([
+			e("a", "b", "related-to", 0.8, "first"),
+			e("b", "a", "related-to", 0.8, "second"),
+		]);
+		expect(out).toHaveLength(1);
+		expect(out[0].evidence).toBe("first");
+	});
+
+	it("dedups every symmetric type but never directed ones", () => {
+		expect([...SYMMETRIC_EDGE_TYPES].sort()).toEqual(["contradicts", "related-to"]);
+		const out = normalizeSymmetricEdges([
+			e("a", "b", "contradicts", 0.5),
+			e("b", "a", "contradicts", 0.7),
+			// Directed: A→B and B→A are genuinely distinct facts — both survive.
+			e("a", "b", "extends", 0.9),
+			e("b", "a", "extends", 0.9),
+		]);
+		expect(out.filter((x) => x.type === "contradicts")).toHaveLength(1);
+		expect(out.filter((x) => x.type === "extends")).toHaveLength(2);
+	});
+
+	it("preserves the original order of kept edges", () => {
+		const out = normalizeSymmetricEdges([
+			e("a", "b", "extends", 0.9),
+			e("c", "d", "related-to", 0.6),
+			e("d", "c", "related-to", 0.4),
+			e("e", "f", "supersedes", 0.8),
+		]);
+		expect(out.map((x) => `${x.from}->${x.to}:${x.type}`)).toEqual([
+			"a->b:extends",
+			"c->d:related-to",
+			"e->f:supersedes",
+		]);
+	});
+
+	it("keeps distinct symmetric pairs separate (different endpoints, same type)", () => {
+		const out = normalizeSymmetricEdges([e("a", "b", "related-to", 0.6), e("a", "c", "related-to", 0.6)]);
+		expect(out).toHaveLength(2);
+	});
+
+	it("keeps a reversed twin of a DIFFERENT symmetric type (type is part of the key)", () => {
+		const out = normalizeSymmetricEdges([e("a", "b", "related-to", 0.7), e("b", "a", "contradicts", 0.7)]);
+		expect(out).toHaveLength(2);
+	});
+
+	it("collapses three-plus duplicates of one pair to the single max-confidence edge", () => {
+		const out = normalizeSymmetricEdges([
+			e("a", "b", "related-to", 0.5, "first"),
+			e("b", "a", "related-to", 0.9, "max"),
+			e("a", "b", "related-to", 0.7, "third"),
+		]);
+		expect(out).toHaveLength(1);
+		expect(out[0].evidence).toBe("max");
+	});
+
+	it("returns an empty list unchanged", () => {
+		expect(normalizeSymmetricEdges([])).toEqual([]);
+	});
+});
+
+describe("dropSubsumedRelatedTo", () => {
+	const e = (from: string, to: string, type: GraphEdge["type"], confidence = 0.7): GraphEdge => ({
+		from,
+		to,
+		type,
+		confidence,
+		evidence: "",
+	});
+
+	it("drops a related-to when a directed edge links the same pair (either orientation)", () => {
+		const out = dropSubsumedRelatedTo([
+			e("a", "b", "related-to", 0.9), // generic, even at higher confidence
+			e("b", "a", "extends", 0.5), // specific, reversed orientation — still subsumes
+		]);
+		expect(out).toHaveLength(1);
+		expect(out[0].type).toBe("extends");
+	});
+
+	it("drops related-to subsumed by any specific type (contradicts included)", () => {
+		const out = dropSubsumedRelatedTo([e("a", "b", "related-to"), e("a", "b", "contradicts")]);
+		expect(out.map((x) => x.type)).toEqual(["contradicts"]);
+	});
+
+	it("keeps a related-to with no competing specific edge on its pair", () => {
+		const out = dropSubsumedRelatedTo([
+			e("a", "b", "related-to"),
+			e("c", "d", "extends"), // different pair — does not subsume a-b
+		]);
+		expect(out).toHaveLength(2);
+	});
+
+	it("keeps two genuinely-distinct specific edges on one pair (only related-to is ever dropped)", () => {
+		const out = dropSubsumedRelatedTo([e("a", "b", "extends"), e("a", "b", "caused-by")]);
+		expect(out).toHaveLength(2);
+	});
+
+	it("is order-preserving and a no-op on the empty list", () => {
+		expect(dropSubsumedRelatedTo([])).toEqual([]);
+		const edges = [e("a", "b", "extends"), e("c", "d", "related-to"), e("e", "f", "supersedes")];
+		expect(dropSubsumedRelatedTo(edges).map((x) => `${x.from}${x.to}`)).toEqual(["ab", "cd", "ef"]);
+	});
+});
+
 describe("assembleGraph", () => {
 	const sources = new Map<string, TopicSourceMeta>([
 		[
@@ -191,6 +317,33 @@ describe("assembleGraph", () => {
 		expect(graph.stats.crossCategoryEdges).toBe(0);
 		// t3 has no units — the `?? 0` rollup path.
 		expect(graph.topics.find((t) => t.slug === "t3")?.unitCount).toBe(0);
+	});
+
+	it("collapses a reversed symmetric edge pair before stats + emit", () => {
+		const g = validGraph();
+		// Reversed twins on a pair that has NO competing specific edge (u2↔u3), so the
+		// symmetric collapse is isolated from the related-to subsumption rule.
+		g.edges.push({ from: "t1::u2", to: "t2::u3", type: "related-to", confidence: 0.6, evidence: "fwd" });
+		g.edges.push({ from: "t2::u3", to: "t1::u2", type: "related-to", confidence: 0.9, evidence: "rev" });
+		const graph = assembleGraph(g, sources, "2026-06-15T00:00:00.000Z");
+		// 2 original directed + 1 collapsed symmetric = 3 (not 4).
+		expect(graph.stats.edges).toBe(3);
+		expect(graph.edges).toHaveLength(3);
+		const rel = graph.edges.filter((x) => x.type === "related-to");
+		expect(rel).toHaveLength(1);
+		expect(rel[0].evidence).toBe("rev"); // higher-confidence side won
+	});
+
+	it("drops a related-to subsumed by an existing extends on the same pair (the screenshot case)", () => {
+		const g = validGraph(); // already has t1::u1 --extends--> t1::u2
+		// Distiller also emitted a generic related-to for the same pair (reversed) at
+		// higher confidence — it must be dropped in favor of the specific extends.
+		g.edges.push({ from: "t1::u2", to: "t1::u1", type: "related-to", confidence: 0.95, evidence: "generic" });
+		const graph = assembleGraph(g, sources, "2026-06-15T00:00:00.000Z");
+		// extends (t1) + caused-by (cross) survive; the related-to is subsumed.
+		expect(graph.stats.edges).toBe(2);
+		expect(graph.edges.some((x) => x.type === "related-to")).toBe(false);
+		expect(graph.edges.filter((x) => x.type === "extends")).toHaveLength(1);
 	});
 
 	it("throws on a graph that fails validation", () => {

--- a/cli/src/graph/GraphSchema.ts
+++ b/cli/src/graph/GraphSchema.ts
@@ -15,6 +15,17 @@
 export const EDGE_TYPES = ["extends", "caused-by", "supersedes", "contradicts", "related-to"] as const;
 export type EdgeType = (typeof EDGE_TYPES)[number];
 
+/**
+ * The relationships that are SYMMETRIC (undirected): `A relates-to B` is the same
+ * fact as `B relates-to A`. The distiller sometimes emits both directions for one
+ * such relationship, which would otherwise render as two arrowed lines (and list
+ * the peer twice in the panel) for a single undirected link. {@link
+ * normalizeSymmetricEdges} collapses each pair to one edge at assembly time so
+ * graph.json never carries the duplicate. The remaining types
+ * (`extends`/`caused-by`/`supersedes`) are directed and pass through untouched.
+ */
+export const SYMMETRIC_EDGE_TYPES: ReadonlySet<EdgeType> = new Set<EdgeType>(["related-to", "contradicts"]);
+
 /** The kinds a knowledge unit can take. */
 export const UNIT_KINDS = ["decision", "mechanism", "fix"] as const;
 export type UnitKind = (typeof UNIT_KINDS)[number];
@@ -209,6 +220,62 @@ export function validateDistilledGraph(graph: DistilledGraph): string[] {
 	return errors;
 }
 
+/**
+ * Collapses symmetric edges (see {@link SYMMETRIC_EDGE_TYPES}) to a single edge
+ * per unordered endpoint pair, keeping the higher-confidence side (ties keep the
+ * first occurrence). Directed edges pass through untouched and in place.
+ *
+ * Pure; preserves the original order of every edge it keeps. This is the
+ * SOURCE-OF-TRUTH dedup: it runs inside {@link assembleGraph}, so every emitted
+ * graph.json — full, incremental, and the no-LLM reassemble — is already clean.
+ * The viz runtime (`assets/js/data.js`) carries a thin mirror of this logic only
+ * to clean up graph.json files written before this normalization existed; once a
+ * repo rebuilds its graph, the runtime dedup is a no-op.
+ */
+export function normalizeSymmetricEdges(edges: ReadonlyArray<GraphEdge>): GraphEdge[] {
+	const pairKey = (e: GraphEdge): string => {
+		const [a, b] = e.from < e.to ? [e.from, e.to] : [e.to, e.from];
+		return `${a}|${b}|${e.type}`;
+	};
+	// Pass 1: pick the winning edge object for each symmetric endpoint pair.
+	const winner = new Map<string, GraphEdge>();
+	for (const e of edges) {
+		if (!SYMMETRIC_EDGE_TYPES.has(e.type)) continue;
+		const k = pairKey(e);
+		const prev = winner.get(k);
+		if (!prev || e.confidence > prev.confidence) winner.set(k, e);
+	}
+	// Pass 2: emit in original order, dropping the non-winning symmetric duplicates.
+	return edges.filter((e) => !SYMMETRIC_EDGE_TYPES.has(e.type) || winner.get(pairKey(e)) === e);
+}
+
+/**
+ * Drops `related-to` edges that are SUBSUMED by a more specific edge between the
+ * same unordered unit pair. `related-to` is the generic "these two are connected"
+ * relationship; every other type (`extends`/`caused-by`/`supersedes`/
+ * `contradicts`) is a more specific claim that already implies relatedness. When
+ * the distiller emits both a `related-to` and, say, an `extends` for one pair,
+ * they describe the SAME fact at two precisions — rendering both draws two
+ * redundant lines (and lists the peer twice). Keep only the specific edge.
+ *
+ * Pure; order-preserving. Match is on the UNORDERED pair (relatedness is
+ * symmetric, so a directed `A extends B` subsumes `related-to` in either
+ * orientation). Confidence is irrelevant: a generic edge carries no information a
+ * specific one between the same pair doesn't already. Two genuinely-distinct
+ * specific edges on one pair (e.g. `extends` + `caused-by`) are BOTH kept — only
+ * the generic `related-to` is ever dropped. Runs after {@link
+ * normalizeSymmetricEdges} inside {@link assembleGraph}; mirrored defensively in
+ * the viz runtime (`assets/js/data.js`) for pre-normalization graph.json.
+ */
+export function dropSubsumedRelatedTo(edges: ReadonlyArray<GraphEdge>): GraphEdge[] {
+	const unorderedKey = (e: GraphEdge): string => (e.from < e.to ? `${e.from}|${e.to}` : `${e.to}|${e.from}`);
+	const specificPairs = new Set<string>();
+	for (const e of edges) {
+		if (e.type !== "related-to") specificPairs.add(unorderedKey(e));
+	}
+	return edges.filter((e) => e.type !== "related-to" || !specificPairs.has(unorderedKey(e)));
+}
+
 // -- Assembly -----------------------------------------------------------------
 
 /**
@@ -227,7 +294,17 @@ export function assembleGraph(
 	topicFingerprints: Record<string, string> = {},
 	topicMetaFingerprints: Record<string, string> = {},
 ): KnowledgeGraph {
-	const errors = validateDistilledGraph(distill);
+	// Normalize edges BEFORE validation, stats, and emit so graph.json never
+	// carries the distiller's redundant duplicates:
+	//   1. collapse symmetric edges to one undirected link per pair (also kills the
+	//      reversed-pair dupe that validateDistilledGraph's `from|to|type` key
+	//      cannot see);
+	//   2. drop a generic `related-to` whenever a more specific typed edge already
+	//      links the same pair (the specific edge subsumes it).
+	// Directed/specific edges are otherwise untouched.
+	const edges = dropSubsumedRelatedTo(normalizeSymmetricEdges(distill.edges));
+
+	const errors = validateDistilledGraph({ ...distill, edges });
 	if (errors.length > 0) {
 		throw new Error(`knowledge graph validation failed (${errors.length}): ${errors.join("; ")}`);
 	}
@@ -280,7 +357,7 @@ export function assembleGraph(
 	let intraTopicEdges = 0;
 	let crossTopicEdges = 0;
 	let crossCategoryEdges = 0;
-	for (const e of distill.edges) {
+	for (const e of edges) {
 		const ta = unitToTopic.get(e.from);
 		const tb = unitToTopic.get(e.to);
 		if (ta === tb) {
@@ -297,7 +374,7 @@ export function assembleGraph(
 		categories: categories.length,
 		topics: topics.length,
 		units: distill.units.length,
-		edges: distill.edges.length,
+		edges: edges.length,
 		intraTopicEdges,
 		crossTopicEdges,
 		crossCategoryEdges,
@@ -313,7 +390,7 @@ export function assembleGraph(
 		categories,
 		topics,
 		units: distill.units,
-		edges: distill.edges,
+		edges,
 	};
 }
 

--- a/cli/src/graph/assets/index.html
+++ b/cli/src/graph/assets/index.html
@@ -12,7 +12,7 @@
       <div class="brand"><span class="brand-name">Jolli</span><span class="brand-sub">GRAPH</span></div>
       <nav class="breadcrumb" id="breadcrumb"></nav>
       <div class="topbar-spacer"></div>
-      <input type="search" class="searchbox" id="searchbox" placeholder="Search topics & decisions…" autocomplete="off" />
+      <input type="search" class="searchbox" id="searchbox" placeholder="Search topics & units…" autocomplete="off" />
     </header>
 
     <div class="layout">
@@ -20,8 +20,13 @@
         <!-- board-wrap is the pan/zoom canvas: cards and the SVG edge layer
              transform together, so edge geometry stays valid at any zoom -->
         <div class="board-wrap" id="board-wrap">
-          <svg class="edge-layer" id="edge-layer"></svg>
+          <!-- Two edge layers straddling the board: the back layer (cross-topic
+               / cross-category edges) sits behind the board so opaque topic
+               boxes occlude it; the front layer (intra-topic edges) sits above
+               the board so it stays visible over those boxes. -->
+          <svg class="edge-layer edge-layer-back" id="edge-layer-back"></svg>
           <div class="board" id="board"></div>
+          <svg class="edge-layer edge-layer-front" id="edge-layer"></svg>
         </div>
         <div class="zoom-controls">
           <button type="button" id="zoom-out" title="Zoom out">−</button>

--- a/cli/src/graph/assets/js/camera.js
+++ b/cli/src/graph/assets/js/camera.js
@@ -11,6 +11,12 @@
   const MIN_SCALE = 0.2;
   const MAX_SCALE = 2.5;
   const FIT_MARGIN = 70;
+  // Readability standard for a clicked unit: below this scale its text is too
+  // small, so focusUnit zooms IN to it. At/above it the zoom is left untouched
+  // (a click never zooms out). See focusUnit's rules.
+  const READABLE_SCALE = 0.8;
+  // Viewport padding (px) used when deciding "fully visible" / computing pans.
+  const FOCUS_PAD = 16;
 
   let pz = null;
   let main = null;
@@ -146,7 +152,95 @@
     centerOn(cx, cy, target, true);
   }
 
+  // Focus a clicked UNIT, following the unit-focus rules:
+  //   1. Readability — only ever zoom IN, up to READABLE_SCALE; never zoom out.
+  //      (At/above the standard the zoom is left exactly as-is.)
+  //   2. Anchor — zoom around the unit's OWN center, so that center stays on the
+  //      same screen pixel; no recentering pan when the unit stays fully visible.
+  //   3. Pan only when the unit would not be fully visible, and then by the
+  //      minimal amount that brings it in (translate only — scale is never lowered).
+  //   4. Within the slack that still keeps the unit fully visible, bias the pan to
+  //      reveal as many related units as fit; fit the whole unit+related group when
+  //      it can, else keep the unit visible and lean toward the group. Never zoom
+  //      out to fit related units — the unit's readability wins.
+  // relatedEls: the unit's neighbor card elements (may be empty or contain nulls).
+  function focusUnit(el, relatedEls, opts) {
+    if (!pz || !el) return;
+    if (!ready) { pendingOp = () => focusUnit(el, relatedEls, opts); return; }
+    if (!canvas.offsetWidth || !canvas.offsetHeight) return; // not laid out yet → avoid /0
+    const animate = !opts || opts.animate !== false;
+
+    const c = canvas.getBoundingClientRect();
+    const m = main.getBoundingClientRect();
+    const sv = c.width / canvas.offsetWidth;       // current visual scale (robust mid-transition)
+    const ox = canvas.offsetLeft, oy = canvas.offsetTop;
+
+    // Rule 1: raise the scale to the readable standard only if it is below it.
+    const s = clamp(Math.max(sv, READABLE_SCALE), MIN_SCALE, MAX_SCALE);
+
+    // Canvas-local (pre-transform) geometry of an element, from its screen rect.
+    const toLocal = (rect) => ({
+      cx: (rect.left + rect.width / 2 - c.left) / sv,
+      cy: (rect.top + rect.height / 2 - c.top) / sv,
+      w: rect.width / sv,
+      h: rect.height / sv,
+    });
+    const u = toLocal(el.getBoundingClientRect());
+
+    // Rule 2: anchor the unit center at its current main-local screen position, so
+    // the zoom pivots there. A local point p then maps to ax + s*(p - u.center).
+    const r = el.getBoundingClientRect();
+    const ax = (r.left + r.width / 2) - m.left;
+    const ay = (r.top + r.height / 2) - m.top;
+    const box = (g) => ({
+      x0: ax + s * ((g.cx - g.w / 2) - u.cx),
+      x1: ax + s * ((g.cx + g.w / 2) - u.cx),
+      y0: ay + s * ((g.cy - g.h / 2) - u.cy),
+      y1: ay + s * ((g.cy + g.h / 2) - u.cy),
+    });
+    const ub = box(u);
+
+    // Group bbox = unit ∪ related, in the same anchored main-local space.
+    let gx0 = ub.x0, gx1 = ub.x1, gy0 = ub.y0, gy1 = ub.y1;
+    for (const re of relatedEls || []) {
+      if (!re || !re.offsetWidth) continue;
+      const rb = box(toLocal(re.getBoundingClientRect()));
+      gx0 = Math.min(gx0, rb.x0); gx1 = Math.max(gx1, rb.x1);
+      gy0 = Math.min(gy0, rb.y0); gy1 = Math.max(gy1, rb.y1);
+    }
+
+    // Rules 3+4: minimal per-axis pan (screen px) keeping the unit fully visible
+    // and revealing the group as far as that allows.
+    const dx = solveAxis(FOCUS_PAD, main.clientWidth - FOCUS_PAD, ub.x0, ub.x1, gx0, gx1);
+    const dy = solveAxis(FOCUS_PAD, main.clientHeight - FOCUS_PAD, ub.y0, ub.y1, gy0, gy1);
+
+    // Compose anchored translate + the chosen screen-space pan (÷s → local units).
+    const txAnchor = (ax - ox) / s - u.cx;
+    const tyAnchor = (ay - oy) / s - u.cy;
+    pz.zoom(s, { animate });
+    pz.pan(txAnchor + dx / s, tyAnchor + dy / s, { animate });
+  }
+
+  // Minimal screen-space shift along one axis. Hard constraint: keep the unit
+  // [uA,uB] fully inside [viewMin,viewMax]. Within that freedom, bring the group
+  // [gA,gB] (unit ∪ related) in too — fully when it fits, else lean to its center.
+  // Returns the delta closest to 0 (the smallest pan) satisfying the constraints.
+  function solveAxis(viewMin, viewMax, uA, uB, gA, gB) {
+    const viewLen = viewMax - viewMin;
+    // Unit alone overflows the viewport → can't fully fit; center it (no slack).
+    if (uB - uA > viewLen) return (viewMin + viewMax) / 2 - (uA + uB) / 2;
+    const fMin = viewMin - uA, fMax = viewMax - uB; // feasible Δ keeping the unit in
+    if (gB - gA <= viewLen) {
+      // Group fits → minimal Δ to bring the whole group in (unit ⊆ group, so this
+      // keeps the unit in too). 0 when everything is already visible.
+      return clamp(0, Math.max(fMin, viewMin - gA), Math.min(fMax, viewMax - gB));
+    }
+    // Group too spread to fit at this scale → keep the unit fully visible and lean
+    // toward the group's center as far as the unit's slack allows (no zoom-out).
+    return clamp((viewMin + viewMax) / 2 - (gA + gB) / 2, fMin, fMax);
+  }
+
   function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)); }
 
-  window.WikiCamera = { init, scale, fit, focusOn };
+  window.WikiCamera = { init, scale, fit, focusOn, focusUnit };
 })();

--- a/cli/src/graph/assets/js/data.js
+++ b/cli/src/graph/assets/js/data.js
@@ -22,6 +22,43 @@
       graph = await res.json();
     }
 
+    // `related-to` / `contradicts` are SYMMETRIC relationships. The extractor
+    // sometimes emits both directions (A→B and B→A) for one relationship, which
+    // would otherwise draw two arrowed lines (and list two "related units") for
+    // what is really a single undirected link. Collapse each symmetric pair to
+    // one edge, keeping the higher-confidence side.
+    //
+    // Source-of-truth dedup now lives in GraphSchema.normalizeSymmetricEdges
+    // (assembleGraph), so freshly-built graph.json is already clean. This block
+    // is a defensive mirror that keeps graph.json files written BEFORE that
+    // normalization (not yet rebuilt) from rendering the duplicate; on clean
+    // data it is a no-op. Keep the two in lockstep.
+    const SYMMETRIC = new Set(["related-to", "contradicts"]);
+    const symKey = (e) => (e.from < e.to ? e.from + "|" + e.to : e.to + "|" + e.from) + "|" + e.type;
+    const bestSym = new Map();
+    for (const e of graph.edges) {
+      if (!SYMMETRIC.has(e.type)) continue;
+      const k = symKey(e);
+      const prev = bestSym.get(k);
+      // Strict `>` keeps the first occurrence on a tie — byte-identical to
+      // GraphSchema.normalizeSymmetricEdges (confidence is always a number in any
+      // graph.json that passed assembly validation, so no `|| 0` guard is needed).
+      if (!prev || e.confidence > prev.confidence) bestSym.set(k, e);
+    }
+    graph.edges = graph.edges.filter((e) => !SYMMETRIC.has(e.type) || bestSym.get(symKey(e)) === e);
+
+    // Drop a generic `related-to` when a more specific typed edge already links the
+    // same unordered pair: the specific edge (extends/caused-by/supersedes/
+    // contradicts) subsumes "these two are connected", so keeping both just draws
+    // two redundant lines. Mirrors GraphSchema.dropSubsumedRelatedTo; keep in
+    // lockstep. No-op on freshly-built (already-normalized) graph.json.
+    const pairKey = (e) => (e.from < e.to ? e.from + "|" + e.to : e.to + "|" + e.from);
+    const specificPairs = new Set();
+    for (const e of graph.edges) {
+      if (e.type !== "related-to") specificPairs.add(pairKey(e));
+    }
+    graph.edges = graph.edges.filter((e) => e.type !== "related-to" || !specificPairs.has(pairKey(e)));
+
     const categoriesById = new Map();
     graph.categories.forEach((t, i) => {
       t.color = CATEGORY_PALETTE[i % CATEGORY_PALETTE.length];
@@ -79,6 +116,8 @@
       adj,
       categoryAgg: [...categoryAgg.values()],
       categoryOfUnit: (unitId) => unitCategory(unitsById.get(unitId)),
+      // Relationship types with no direction — drawn as a single line, no arrow.
+      symmetricTypes: SYMMETRIC,
     };
     return window.WikiData;
   }

--- a/cli/src/graph/assets/js/drag.js
+++ b/cli/src/graph/assets/js/drag.js
@@ -21,8 +21,8 @@
       if (e.button !== 0) return;
       if (opts.handle && !(e.target.closest && e.target.closest(opts.handle))) return;
       // Never start a drag from an interactive control inside the card
-      // (jump arrows, the "details" link, or the collapse title zone).
-      if (e.target.closest("[data-open-category],[data-open-topic],.p-jump,.c-jump,.t-open,.tg-toggle")) return;
+      // (jump arrows, or the title/caret zone that selects the topic / collapses it).
+      if (e.target.closest("[data-open-category],.p-jump,.c-jump,.tg-toggle")) return;
 
       const scale = window.WikiCamera ? window.WikiCamera.scale() : 1;
       const startX = e.clientX, startY = e.clientY;

--- a/cli/src/graph/assets/js/edges.js
+++ b/cli/src/graph/assets/js/edges.js
@@ -26,20 +26,36 @@
 
   const svgNS = "http://www.w3.org/2000/svg";
 
+  // The board is straddled by two SVG layers — "edge-layer" (front, intra-topic
+  // edges, painted above the board) and "edge-layer-back" (cross-topic /
+  // cross-category edges, painted behind the board so opaque boxes occlude
+  // them). Helpers that touch "the edges" operate on both.
+  function layerEls() {
+    return ["edge-layer", "edge-layer-back"]
+      .map((id) => document.getElementById(id))
+      .filter(Boolean);
+  }
+
+  // Reset both layers and return { front, back } so callers can route each edge
+  // to the right one. `back` falls back to `front` if the back layer is absent.
   function clear() {
-    const layer = document.getElementById("edge-layer");
-    while (layer.firstChild) layer.removeChild(layer.firstChild);
+    let front = null, back = null;
+    for (const layer of layerEls()) {
+      while (layer.firstChild) layer.removeChild(layer.firstChild);
+      syncSize(layer);
+      // Arrowheads are drawn manually into this group, kept as the LAST child
+      // of the layer so dashes from other edges can never overlay a triangle
+      // (SVG has no z-index — document order is paint order).
+      const arrows = document.createElementNS(svgNS, "g");
+      arrows.setAttribute("class", "edge-arrows");
+      layer.appendChild(arrows);
+      if (layer.id === "edge-layer-back") back = layer;
+      else front = layer;
+    }
     // Anchor nubs live on the cards themselves (so they move with card hover
     // transforms) — clear them along with the edges they belong to
     document.querySelectorAll(".card-nub").forEach((n) => n.remove());
-    syncSize(layer);
-    // Arrowheads are drawn manually into this group, kept as the LAST child
-    // of the layer so dashes from other edges can never overlay a triangle
-    // (SVG has no z-index — document order is paint order).
-    const arrows = document.createElementNS(svgNS, "g");
-    arrows.setAttribute("class", "edge-arrows");
-    layer.appendChild(arrows);
-    return layer;
+    return { front, back: back || front };
   }
 
   // Attach a semicircle nub to the inside of a card's top/bottom border.
@@ -253,14 +269,18 @@
     return g;
   }
 
-  function dimAllExcept(layer, predicate) {
-    // [data-edge-key] covers both the edge groups and their arrowheads
-    layer.querySelectorAll("[data-edge-key]").forEach((g) => {
-      g.classList.toggle("edge-dim", !predicate(g.dataset.edgeKey));
-    });
+  function dimAllExcept(predicate) {
+    for (const layer of layerEls()) {
+      // [data-edge-key] covers both the edge groups and their arrowheads
+      layer.querySelectorAll("[data-edge-key]").forEach((g) => {
+        g.classList.toggle("edge-dim", !predicate(g.dataset.edgeKey));
+      });
+    }
   }
-  function undim(layer) {
-    layer.querySelectorAll("g.edge-dim").forEach((g) => g.classList.remove("edge-dim"));
+  function undim() {
+    for (const layer of layerEls()) {
+      layer.querySelectorAll("g.edge-dim").forEach((g) => g.classList.remove("edge-dim"));
+    }
   }
 
   window.WikiEdges = { clear, draw, dimAllExcept, undim, EDGE_COLORS };

--- a/cli/src/graph/assets/js/main.js
+++ b/cli/src/graph/assets/js/main.js
@@ -90,11 +90,14 @@
   }
 
   function wireCanvasClear() {
-    // Clicking empty canvas releases the locked selection. Interactive
-    // elements are excluded; the camera's capture-phase handler already
+    // Clicking the empty board (outside every card) releases the locked selection,
+    // so the panel falls back to the current category's summary — the third
+    // category-page detail level (unit / topic / category). The whole topic card
+    // is excluded (its own handler selects the topic), as are units, portals,
+    // category cards, and controls. The camera's capture-phase handler already
     // suppresses the click that follows a drag-pan.
     document.getElementById("main").addEventListener("click", (e) => {
-      if (e.target.closest(".unit-card, .topic-head, .portal, .category-card, .zoom-controls, .edge-hit, .topic-group.collapsed")) return;
+      if (e.target.closest(".unit-card, .topic-group, .portal, .category-card, .zoom-controls, .edge-hit")) return;
       const S = window.WikiState;
       if (S.get().selected) S.set({ selected: null });
     });
@@ -149,7 +152,14 @@
         document.querySelectorAll(".selected").forEach((el) => el.classList.remove("selected"));
         if (s.selected && s.selected.kind === "unit") {
           const el = document.querySelector(`[data-unit="${s.selected.id}"]`);
-          if (el) { el.classList.add("selected"); window.WikiCamera.focusOn(el); }
+          // Unit-focus rules (readability zoom + minimal pan); same path as a
+          // navigation that lands on a unit (see views.settleCamera).
+          if (el) { el.classList.add("selected"); window.WikiViews.focusSelectedUnit(s.selected.id); }
+        } else if (s.selected && s.selected.kind === "topic") {
+          // A topic card whose detail is showing in the panel — highlight it
+          // (reached by click OR by Back into a topic within the same category).
+          const el = document.querySelector(`[data-topic="${s.selected.id}"]`);
+          if (el) el.classList.add("selected");
         } else if (s.selected && s.selected.kind === "category") {
           // A category card (overview) or portal (level 2) selected for inspection
           const el = document.querySelector(

--- a/cli/src/graph/assets/js/panel.js
+++ b/cli/src/graph/assets/js/panel.js
@@ -19,10 +19,12 @@
   }
 
   function relItemHtml(edge, dir, peerUnit, topicOfPeer) {
-    const arrow = dir === "out" ? "→" : "←";
+    // Symmetric relationships are undirected, so they carry no direction arrow.
+    const sym = window.WikiData.symmetricTypes.has(edge.type);
+    const arrow = sym ? "" : (dir === "out" ? "→ " : "← ");
     return `<div class="rel-item" data-goto-unit="${esc(peerUnit.id)}" data-edge-key="${esc(edge.from + ">" + edge.to)}">` +
       `<div class="rel-head">` +
-      `<span class="rel-type ${esc(edge.type)}">${arrow} ${esc(edge.type)}</span>` +
+      `<span class="rel-type ${esc(edge.type)}">${arrow}${esc(edge.type)}</span>` +
       confPill(edge.confidence) +
       `<span class="rel-title">${esc(peerUnit.shortTitle)}</span>` +
       `</div>` +
@@ -36,13 +38,16 @@
     const g = D.graph;
     let html = "";
     html += `<h2>Jolli Graph</h2>`;
-    html += `<div class="p-meta">Distilled from the team wiki · regenerated on every merge</div>`;
+    html += `<div class="p-meta">Distilled from your local knowledge base · regenerated on every merge</div>`;
     html += `<h6>Project stats</h6><div class="stat-rows">`;
     html += row("Categories", g.stats.categories);
-    html += row("Knowledge topics", g.stats.topics);
-    html += row("Knowledge units", g.stats.units);
-    html += row("Typed links", g.stats.edges);
-    html += row("Cross-category links", g.stats.crossCategoryEdges);
+    html += row("Topics", g.stats.topics);
+    html += row("Units", g.stats.units);
+    // Typed links by scope (the three buckets sum to the total): both endpoints in
+    // one topic; across topics but inside one category; across categories.
+    html += row("Links within a topic", g.stats.intraTopicEdges);
+    html += row("Links within a category", g.stats.crossTopicEdges - g.stats.crossCategoryEdges);
+    html += row("Links across categories", g.stats.crossCategoryEdges);
     html += `</div>`;
     html += `<h6>How to read this</h6>`;
     html += `<p class="summary">Each big card is a <strong>category</strong>. Click one to see its knowledge topics and the units inside. Lines with numbers show how many links connect two categories — click a line to list them.</p>`;
@@ -97,6 +102,12 @@
     html += `<div class="p-meta">${esc(t.title)}</div>`;
     html += `<p class="summary">${esc(t.summary)}</p>`;
 
+    // Full wiki page opens in-panel (kind: "wiki"); Back returns to this topic.
+    // Sits right under the description, mirroring the "Open category" button.
+    if (t.fullBody) {
+      html += `<button type="button" class="wiki-open" data-open-wiki="${esc(slug)}">📖 Open full wiki page</button>`;
+    }
+
     // Distilled units as quick links into the board.
     if (units.length) {
       html += `<h6>Units in this topic — ${units.length}</h6>`;
@@ -108,12 +119,6 @@
       }
     }
 
-    // Full wiki page opens in-panel (kind: "wiki"); Back returns to this topic.
-    if (t.fullBody) {
-      html += `<h6>Source wiki page</h6>`;
-      html += `<button type="button" class="wiki-open" data-open-wiki="${esc(slug)}">` +
-        `📖 Open full wiki page</button>`;
-    }
     return html;
   }
 
@@ -143,9 +148,11 @@
     html += `<div class="p-meta">${agg.edges.length} cross-category link${agg.edges.length === 1 ? "" : "s"}</div>`;
     for (const e of agg.edges) {
       const fu = D.unitsById.get(e.from), tu = D.unitsById.get(e.to);
+      // Symmetric relationships are undirected → a non-directional connector.
+      const conn = window.WikiData.symmetricTypes.has(e.type) ? "↔" : "→";
       html += `<div class="rel-item" data-goto-unit="${esc(e.from)}">` +
         `<div class="rel-head"><span class="rel-type ${esc(e.type)}">${esc(e.type)}</span>${confPill(e.confidence)}</div>` +
-        `<div class="rel-title" style="margin-bottom:3px">${esc(fu.shortTitle)} → ${esc(tu.shortTitle)}</div>` +
+        `<div class="rel-title" style="margin-bottom:3px">${esc(fu.shortTitle)} ${conn} ${esc(tu.shortTitle)}</div>` +
         `<div class="rel-evidence">${esc(e.evidence)}</div></div>`;
     }
     return html;
@@ -172,6 +179,9 @@
     // Reading mode widens the panel for the long-form wiki page.
     const panelEl = document.getElementById("panel");
     if (panelEl) panelEl.classList.toggle("reading", !!(sel && sel.kind === "wiki"));
+    // Opening the full wiki page: jump to the top so reading starts at the
+    // beginning, not wherever the previous panel content was scrolled.
+    if (panelEl && sel && sel.kind === "wiki") panelEl.scrollTop = 0;
 
     const back = document.getElementById("panel-back");
     if (back) back.addEventListener("click", () => S.goBack());
@@ -190,7 +200,7 @@
         const key = el.dataset.edgeKey;
         if (!key) return;
         el.classList.add("spotlight");
-        window.WikiEdges.dimAllExcept(document.getElementById("edge-layer"), (k) => k === key);
+        window.WikiEdges.dimAllExcept((k) => k === key);
       });
       el.addEventListener("mouseleave", () => {
         el.classList.remove("spotlight");

--- a/cli/src/graph/assets/js/views.js
+++ b/cli/src/graph/assets/js/views.js
@@ -60,12 +60,17 @@
       window.WikiDrag.enable(el, drawOverviewEdges);
     });
 
-    // ELK layout first, then the aggregated category-pair edges
+    // ELK layout first, then the aggregated category-pair edges. The trailing
+    // .then always runs (catch resolves) so edges are (re)drawn and the camera
+    // settles even if ELK rejects — otherwise render()'s upfront edge-clear would
+    // leave the overview blank with no edges and no camera fit.
     requestAnimationFrame(() => {
-      layoutOverview(board).then(() => {
-        drawOverviewEdges();
-        settleCamera();
-      });
+      layoutOverview(board)
+        .catch((err) => { console.error("[wiki] layoutOverview failed", err); })
+        .then(() => {
+          drawOverviewEdges();
+          settleCamera();
+        });
     });
   }
 
@@ -73,13 +78,15 @@
   function drawOverviewEdges() {
     const D = window.WikiData;
     const board = document.getElementById("board");
-    const layer = window.WikiEdges.clear();
+    // Category cards are opaque, so the aggregated overview edges go on the back
+    // layer (behind the board) — same "tucked behind the cards" look as before.
+    const { back } = window.WikiEdges.clear();
     for (const agg of D.categoryAgg) {
       const elA = board.querySelector(`[data-category="${agg.a}"]`);
       const elB = board.querySelector(`[data-category="${agg.b}"]`);
       if (!elA || !elB) continue;
       const key = "agg:" + agg.a + "|" + agg.b;
-      window.WikiEdges.draw(layer, {
+      window.WikiEdges.draw(back, {
         fromEl: elA, toEl: elB,
         type: dominantType(agg.edges),
         width: Math.min(3.5, 1 + agg.edges.length * 0.35),
@@ -89,9 +96,8 @@
         key,
         onClick: () => window.WikiState.set({ selected: { kind: "category-pair", id: agg.a + "|" + agg.b } }),
         onHover: (on) => {
-          const layerEl = document.getElementById("edge-layer");
-          if (on) window.WikiEdges.dimAllExcept(layerEl, (k) => k === key);
-          else window.WikiEdges.undim(layerEl);
+          if (on) window.WikiEdges.dimAllExcept((k) => k === key);
+          else window.WikiEdges.undim();
         },
       });
     }
@@ -171,18 +177,25 @@
       const sel = S.get().selected;
       return sel && sel.kind === "unit" ? sel.id : null;
     })();
+    const selectedTopicSlug = (() => {
+      const sel = S.get().selected;
+      return sel && sel.kind === "topic" ? sel.id : null;
+    })();
 
-    let html = '<div class="category-detail masonry">';
+    // Expose the current category's color as --tcolor so selected topic/unit cards
+    // highlight in this category's color (mirrors how an overview category card
+    // highlights in its own color). Portals re-set their own --tcolor inline.
+    let html = `<div class="category-detail masonry" style="--tcolor:${category.color}">`;
     for (const t of topics) {
       const units = D.unitsByTopic.get(t.slug) || [];
       // All topics start expanded; only an explicit click on the title bar
       // collapses one (and that survives navigation via collapsedTopics).
       const isCollapsed = collapsed.has(t.slug);
-      html += `<section class="topic-group ${isCollapsed ? "collapsed" : ""}" data-topic="${esc(t.slug)}" title="Drag to move this group">`;
-      html += `<div class="topic-head" data-toggle="${esc(t.slug)}">`;
+      const isSelected = t.slug === selectedTopicSlug;
+      html += `<section class="topic-group ${isCollapsed ? "collapsed" : ""}${isSelected ? " selected" : ""}" data-topic="${esc(t.slug)}" title="Drag to move this group">`;
+      html += `<div class="topic-head">`;
       html += `<span class="tg-toggle"><span class="caret">▼</span><h4>${esc(t.shortTitle)}</h4></span>`;
       html += `<span class="t-sub">${units.length} units · ${t.commitCount} commits</span>`;
-      html += `<span class="t-open" data-open-topic="${esc(t.slug)}">details →</span>`;
       html += `</div>`;
       html += `<div class="collapsed-hint">${units.length} unit${units.length === 1 ? "" : "s"} hidden — click to expand</div>`;
       html += `<div class="unit-grid">`;
@@ -226,26 +239,29 @@
       drawCategoryEdges(categoryId);
       refreshSpotlight();
     }
-    board.querySelectorAll("[data-toggle]").forEach((el) => {
-      el.addEventListener("click", (ev) => {
-        // Collapse only when the title/caret zone is clicked; the rest of the
-        // header bar is the drag handle, and "details" opens the panel.
-        if (!ev.target.closest(".tg-toggle")) return;
-        toggleGroup(el.closest(".topic-group"), el.dataset.toggle);
-      });
-    });
-    // A collapsed group's whole body ("N units hidden — click to expand")
-    // expands it; the header keeps its own toggle.
+    // Topic card click model (one of the three category-page detail levels):
+    //   - the TITLE ZONE (caret + title, .tg-toggle) collapses / expands the group;
+    //   - clicking a COLLAPSED card's body expands it (its units are hidden);
+    //   - clicking an EXPANDED card anywhere else (subtitle, padding, gaps) selects
+    //     the TOPIC, opening its detail in the side panel (replaces the old
+    //     "details →" button);
+    //   - clicking a UNIT card selects that unit instead (its own handler below);
+    //     this handler bails on unit-card clicks so the two never collide.
+    // Clicking the empty board (outside every card) selects the category — handled
+    // by wireCanvasClear (clears the selection → the panel falls back to the
+    // current category's summary).
     board.querySelectorAll(".topic-group").forEach((sec) => {
+      const slug = sec.dataset.topic;
+      // Caret AND title both collapse — they read as one control, so clicking the
+      // title must behave like clicking the caret.
+      const toggle = sec.querySelector(".tg-toggle");
+      if (toggle) {
+        toggle.addEventListener("click", (ev) => { ev.stopPropagation(); toggleGroup(sec, slug); });
+      }
       sec.addEventListener("click", (ev) => {
-        if (!sec.classList.contains("collapsed")) return;
-        if (ev.target.closest(".topic-head")) return;
-        toggleGroup(sec, sec.dataset.topic);
-      });
-    });
-    board.querySelectorAll("[data-open-topic]").forEach((el) => {
-      el.addEventListener("click", () => {
-        S.set({ selected: { kind: "topic", id: el.dataset.openTopic } });
+        if (ev.target.closest(".unit-card") || ev.target.closest(".tg-toggle")) return;
+        if (sec.classList.contains("collapsed")) { toggleGroup(sec, slug); return; }
+        S.set({ selected: { kind: "topic", id: slug } });
       });
     });
     const redraw = () => { drawCategoryEdges(categoryId); refreshSpotlight(); };
@@ -531,13 +547,54 @@
   // fit the whole level into the viewport.
   function settleCamera() {
     const s = window.WikiState.get();
-    let el = null;
-    if (s.selected) {
-      if (s.selected.kind === "unit") el = document.querySelector(`[data-unit="${s.selected.id}"]`);
-      else if (s.selected.kind === "topic") el = document.querySelector(`[data-topic="${s.selected.id}"]`);
-    }
+    // A selected unit uses the unit-focus rules (readability zoom anchored on the
+    // unit's center, minimal pan biased toward its related units).
+    if (s.selected && s.selected.kind === "unit" && focusSelectedUnit(s.selected.id)) return;
+    // Topics keep the prior behavior; nothing selected → fit the whole level.
+    const el = s.selected && s.selected.kind === "topic"
+      ? document.querySelector(`[data-topic="${s.selected.id}"]`)
+      : null;
     if (el) window.WikiCamera.focusOn(el, { scale: 1 });
     else window.WikiCamera.fit({ animate: true });
+  }
+
+  // Apply the unit-focus camera rules to one unit. Shared by settleCamera (after a
+  // navigation re-render) and main.js's selection-only path (clicking a unit while
+  // already on its board), so a click gets identical behavior either way. Returns
+  // false when the unit has no rendered card (e.g. it lives behind a portal).
+  function focusSelectedUnit(unitId) {
+    let el = document.querySelector(`[data-unit="${unitId}"]`);
+    if (!el) return false;
+    // A unit inside a COLLAPSED group has a card that's still in the DOM but
+    // visibility:hidden (non-zero rect) — focusing it would zoom to an invisible
+    // spot. Focus the visible collapsed box instead, so the camera lands on where
+    // the unit lives.
+    const collapsed = el.closest(".topic-group.collapsed");
+    if (collapsed) el = collapsed;
+    window.WikiCamera.focusUnit(el, relatedUnitEls(unitId));
+    return true;
+  }
+
+  // Rendered neighbor cards of a unit, for the focus group bbox. Peers in another
+  // category (shown only via a portal) or otherwise absent resolve to no card and
+  // are simply skipped — the camera math tolerates an empty/partial list. A peer
+  // hidden in a collapsed group resolves to its visible box. Deduped: parallel
+  // edges to the same peer must not count its box twice.
+  function relatedUnitEls(unitId) {
+    const D = window.WikiData;
+    const els = [];
+    const seen = new Set();
+    for (const r of D.adj.get(unitId) || []) {
+      if (seen.has(r.peer)) continue;
+      seen.add(r.peer);
+      let el = document.querySelector(`[data-unit="${r.peer}"]`);
+      if (el) {
+        const collapsed = el.closest(".topic-group.collapsed");
+        if (collapsed) el = collapsed;
+        els.push(el);
+      }
+    }
+    return els;
   }
 
   function computePortals(categoryId) {
@@ -575,7 +632,7 @@
 
   function drawCategoryEdges(categoryId) {
     const D = window.WikiData;
-    const layer = window.WikiEdges.clear();
+    const { front, back } = window.WikiEdges.clear();
     const drawn = new Set(); // dedupe promoted pairs
 
     for (const e of D.edges) {
@@ -593,18 +650,28 @@
       drawn.add(pairKey);
 
       const isPortalEdge = fromEl.hasAttribute("data-portal") || toEl.hasAttribute("data-portal");
-      window.WikiEdges.draw(layer, {
+      // Layer routing: any edge with at least one visible unit-card endpoint
+      // rides the front layer (z-index 3, above the board), so it stays visible
+      // where it enters a box to reach its unit. Edges between two promoted
+      // headers / portals (no unit endpoint) stay on the back layer (z-index 1),
+      // occluded by the opaque boxes. (Front edges ride above ALL boxes — there
+      // is no per-edge occlusion, so a front edge may thread over an unrelated
+      // box it merely passes; that tradeoff was chosen over fragile masking.)
+      const anyUnit = !!(fromEl.dataset.unit || toEl.dataset.unit);
+      const targetLayer = anyUnit ? front : back;
+      window.WikiEdges.draw(targetLayer, {
         fromEl, toEl,
         type: e.type,
         width: 1 + (e.confidence - 0.6) * 4,        // 0.6→1.0, 0.9→2.2
         opacity: isPortalEdge ? 0.45 : 0.3 + (e.confidence - 0.6) * 1.6,
         dashed: isPortalEdge,
+        // Symmetric relationships have no direction → no arrowhead.
+        arrow: !D.symmetricTypes.has(e.type),
         label: e.type,
         key: e.from + ">" + e.to,
         onClick: () => window.WikiState.set({ selected: { kind: "unit", id: e.from } }),
         onHover: (on) => {
-          const l = document.getElementById("edge-layer");
-          if (on) window.WikiEdges.dimAllExcept(l, (k) => k === e.from + ">" + e.to);
+          if (on) window.WikiEdges.dimAllExcept((k) => k === e.from + ">" + e.to);
           else refreshSpotlight();
         },
       });
@@ -617,16 +684,15 @@
 
   // Dim everything not adjacent to unitId; null restores the neutral state.
   function dimToUnit(unitId) {
-    const layer = document.getElementById("edge-layer");
     const D = window.WikiData;
     if (!unitId) {
-      window.WikiEdges.undim(layer);
+      window.WikiEdges.undim();
       document.querySelectorAll(".unit-card.dimmed").forEach((el) => el.classList.remove("dimmed"));
       return;
     }
     const neighbors = new Set([unitId]);
     for (const r of D.adj.get(unitId) || []) neighbors.add(r.peer);
-    window.WikiEdges.dimAllExcept(layer, (k) => {
+    window.WikiEdges.dimAllExcept((k) => {
       const [f, t] = k.split(">");
       return f === unitId || t === unitId;
     });
@@ -644,17 +710,23 @@
   // everything else dims, until the selection is cleared (canvas click / Esc)
   // or moves to another card.
   function applySpotlight(unitId) {
-    const layer = document.getElementById("edge-layer");
-    layer.querySelectorAll("g.edge-flow").forEach((g) => g.classList.remove("edge-flow"));
-    // Lift the edge layer above the cards while focused, so highlighted edges
-    // can't be hidden behind unrelated topic boxes that sit between endpoints.
-    layer.classList.toggle("spotlight", !!unitId);
+    const layers = ["edge-layer", "edge-layer-back"]
+      .map((id) => document.getElementById(id)).filter(Boolean);
+    for (const layer of layers) {
+      layer.querySelectorAll("g.edge-flow").forEach((g) => g.classList.remove("edge-flow"));
+      // Lift the back layer above the boxes while focused (front already sits
+      // above them), so a highlighted cross edge can't be hidden behind an
+      // unrelated topic box sitting between its endpoints.
+      layer.classList.toggle("spotlight", !!unitId);
+    }
     dimToUnit(unitId);
     if (!unitId) return;
-    layer.querySelectorAll("g[data-edge-key]").forEach((g) => {
-      const [f, t] = g.dataset.edgeKey.split(">");
-      if (f === unitId || t === unitId) g.classList.add("edge-flow");
-    });
+    for (const layer of layers) {
+      layer.querySelectorAll("g[data-edge-key]").forEach((g) => {
+        const [f, t] = g.dataset.edgeKey.split(">");
+        if (f === unitId || t === unitId) g.classList.add("edge-flow");
+      });
+    }
   }
 
   // Re-assert the spotlight for the current selection (used after temporary
@@ -671,6 +743,13 @@
   }
 
   function render() {
+    // Wipe the previous level's edges synchronously, the instant we navigate.
+    // The new level's board lays out asynchronously (ELK) and its cards stay
+    // visibility:hidden until `.laid-out`, while its edges are only drawn after
+    // that layout. Without this, the old level's edges keep floating over the
+    // blank incoming board for the duration of the layout (see drawCategoryEdges,
+    // which is the next time the layers would otherwise be cleared).
+    window.WikiEdges.clear();
     const s = window.WikiState.get();
     if (s.level === "category" && s.categoryId) renderCategory(s.categoryId);
     else renderOverview();
@@ -705,5 +784,7 @@
     });
   }
 
-  window.WikiViews = { render, redrawEdges, highlightUnit, drawCategoryEdges, applySpotlight, refreshSpotlight };
+  window.WikiViews = {
+    render, redrawEdges, highlightUnit, drawCategoryEdges, applySpotlight, refreshSpotlight, focusSelectedUnit,
+  };
 })();

--- a/cli/src/graph/assets/styles/main.css
+++ b/cli/src/graph/assets/styles/main.css
@@ -44,6 +44,13 @@
   --kind-mechanism: #4ece8d;
   --kind-fix: #e0ac2b;
   --kind-migration: #b494f0;
+
+  /* Topic-box fill — OPAQUE (unlike the translucent --surface) so the back edge
+     layer is occluded where a cross edge passes over a box. Mapped onto the
+     editor tokens so it still follows the host theme (no light override needed:
+     --bg/--bg-raised already resolve per-theme via --vscode-*). */
+  --group-bg: var(--bg-raised);
+  --group-bg-collapsed: var(--bg);
 }
 
 /* ── Light theme: black-over-light overlays + darker accent labels ── */
@@ -118,17 +125,27 @@ body {
 .board-wrap { position: relative; width: max-content; will-change: transform; }
 .edge-layer {
   position: absolute; inset: 0; width: 100%; height: 100%;
-  pointer-events: none; z-index: 1;
+  pointer-events: none;
   /* An HTML-embedded <svg> clips to its box by default; a card dragged into
      negative coords would lose its edges. The real viewport clip is .main
      (overflow:hidden), so let edges draw past the svg box freely. */
   overflow: visible;
 }
-/* While a unit is focused, lift the edge layer above the cards so the
-   highlighted edges are never hidden behind an unrelated topic box that
-   happens to sit between the two endpoints. Dimmed edges are nearly
-   invisible, so drawing them over dimmed cards is harmless. */
-.edge-layer.spotlight { z-index: 3; }
+/* Back layer — cross-topic / cross-category edges. Sits BEHIND the board
+   (z < .board), so an opaque topic box occludes any cross edge passing over
+   it: cross edges read as clean connectors in the gaps between boxes instead
+   of threading through box interiors behind the unit cards. */
+#edge-layer-back { z-index: 1; }
+/* Front layer — intra-topic edges (and any edge that enters a box at a unit).
+   Sits ABOVE the board so it stays visible over the now-opaque topic boxes.
+   There is no per-edge occlusion: a front edge rides above every box, so it may
+   thread over an unrelated box it merely passes — accepted over fragile masking. */
+#edge-layer { z-index: 3; }
+/* While a unit is focused, lift the back layer above the boxes too, so a
+   highlighted cross edge is never hidden behind a topic box sitting between
+   its two endpoints. Dimmed edges are nearly invisible, so showing them over
+   boxes is harmless. */
+#edge-layer-back.spotlight { z-index: 4; }
 .edge-layer .edge-hit { pointer-events: stroke; cursor: pointer; }
 .board { position: relative; z-index: 2; padding: 26px 30px 60px; }
 
@@ -197,11 +214,18 @@ body {
 .category-detail.masonry { position: relative; visibility: hidden; }
 .category-detail.masonry.laid-out { visibility: visible; }
 .topic-group {
-  background: var(--surface);
+  background: var(--group-bg);
   border: 1.5px solid var(--line);
   border-radius: 10px;
   padding: 12px 16px 16px;
   box-shadow: inset 0 0 0 1px var(--surface);
+}
+/* Active topic: its detail is showing in the side panel (whether reached by
+   click or by Back navigation). The second-level "big card" — mirrors the
+   overview category card's selected look, in this category's color (--tcolor). */
+.topic-group.selected {
+  border-color: var(--tcolor, var(--accent));
+  box-shadow: 0 0 0 1px var(--tcolor, var(--accent)) inset, 0 6px 24px rgba(0,0,0,.45);
 }
 .masonry .topic-group { position: absolute; margin: 0; }
 /* ELK child-mode: the engine positions each card absolutely inside the
@@ -213,7 +237,7 @@ body {
    its layout space, cards are hidden, a centered hint takes their place.
    Neighbors never move. */
 .topic-group.collapsed .unit-grid { visibility: hidden; }
-.topic-group.collapsed { background: var(--surface); }
+.topic-group.collapsed { background: var(--group-bg-collapsed); }
 .collapsed-hint {
   display: none;
   position: absolute; left: 0; right: 0; top: 46px; bottom: 0;
@@ -226,7 +250,8 @@ body {
   display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap;
   padding: 2px 0 10px;
 }
-/* Title + caret = collapse toggle; the rest of the bar is the drag handle */
+/* Caret + title (.tg-toggle) = collapse toggle; clicking the rest of the card
+   selects the topic. The bar is also the drag handle. */
 .topic-head .tg-toggle {
   display: inline-flex; align-items: baseline; gap: 10px;
   cursor: pointer; border-radius: 5px; padding: 1px 4px; margin: -1px -4px;
@@ -236,12 +261,6 @@ body {
 .topic-group.collapsed .topic-head .caret { transform: rotate(-90deg); }
 .topic-head h4 { margin: 0; font-size: 15px; }
 .topic-head .t-sub { font-size: 12px; color: var(--muted); }
-.topic-head .t-open {
-  margin: -4px -6px -4px auto; font-size: 11px; color: var(--muted); cursor: pointer;
-  display: inline-flex; align-items: center; min-height: 28px;
-  padding: 5px 11px; border-radius: 5px; border: 1px solid transparent;
-}
-.topic-head .t-open:hover { color: var(--ink); border-color: var(--line); }
 
 /* Compact cards, generous gaps (UA-style): the vertical gap is where the
    intra-group edges live, so it gets the space the card padding gives up */
@@ -267,7 +286,10 @@ body {
 .unit-card, .category-card, .portal, .topic-group { cursor: grab; }
 .wiki-dragging { cursor: grabbing !important; z-index: 50 !important; }
 .wiki-dragging.unit-card { transform: none; }
-.unit-card.selected { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent-soft) inset; }
+.unit-card.selected {
+  border-color: var(--tcolor, var(--accent));
+  box-shadow: 0 0 0 1px var(--tcolor, var(--accent)) inset;
+}
 .unit-card.dimmed { opacity: .3; }
 .unit-card .u-kind {
   display: inline-block; font-size: 9px; font-weight: 700; letter-spacing: .1em;
@@ -294,7 +316,8 @@ body {
 .portal {
   border: 2px dashed var(--tcolor, var(--muted));
   border-radius: 9px;
-  background: var(--surface);
+  /* Opaque so back-layer cross edges routed past a portal are occluded too */
+  background: var(--group-bg);
   box-shadow: 0 0 0 1px rgba(0,0,0,.3), inset 0 0 24px var(--surface);
   padding: 11px 15px 10px;
   cursor: pointer;


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Graph edges between related units are now deduplicated, so the knowledge graph renders cleanly without redundant arrows. Previously, a pair of units sharing a symmetric relationship like "related-to" would show two opposing arrows and list the same peer twice in the side panel. Both of those visual artifacts are gone: each relationship between two units now appears as a single line, and the side panel lists each peer exactly once. When a more specific relationship already exists between two units, the generic "related-to" edge is dropped entirely, keeping the graph free of duplicate lines for the same real connection.

Clicking a unit card in the graph now zooms the camera to a consistent, readable size and keeps the selected card stable on screen. The view pans only enough to keep the card and its immediate neighbours visible, without snapping the entire graph to a new center. Clicking anywhere on a topic card body now opens the topic detail panel directly, replacing the small "details →" button that previously appeared in the card header. The collapse toggle on the title row still works as before, so expanding and opening the detail remain two distinct, predictable actions.

---

## E2E Test (3)
<details>
<summary><strong>1. Symmetric relationships render as a single line without arrowheads</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a graph open that contains units linked by a "related-to" or "contradicts" relationship.

**Steps:**
1. Open the graph viewer and navigate to a category or topic that shows units connected by a "related to" or "contradicts" relationship.
2. Look at the line drawn between those two units.
3. Check how many lines appear between the pair and whether the line has arrowheads.
4. Click one of the connected units to open its detail panel, then look at the related units list in the side panel.

**Expected Results:**
- Only one line should appear between a "related to" or "contradicts" pair — not two lines pointing in opposite directions.
- The line should have no arrowhead (it should look like a plain connecting line, not a directed arrow).
- The side panel should list the connected unit only once, not twice.

</blockquote>
</details>
<details>
<summary><strong>2. Clicking a unit when zoomed out zooms in to readable size</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a graph open with multiple units visible on the board.

**Steps:**
1. Open the graph viewer and zoom out as far as possible using the zoom controls (or pinch/scroll) so the unit cards appear very small and their text is hard to read.
2. Click on any unit card.
3. Observe the zoom level and position of the view after the click.
4. Click a different unit card that is near the edge of the visible area and observe the pan behavior.

**Expected Results:**
- After clicking a unit while zoomed out, the view should zoom in enough that the unit card's text is comfortably readable (the zoom should increase, not stay at the tiny level).
- The clicked unit should remain roughly centered or clearly visible on screen — the view should not snap to a completely different area.
- If the view was already zoomed in to a readable level, clicking a unit should not zoom out — the zoom level should stay the same or increase only slightly.
- The pan should be minimal: nearby related units should stay visible where possible rather than the view jumping far away.

</blockquote>
</details>
<details>
<summary><strong>3. Clicking a topic card body opens the topic detail panel</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a graph open that shows at least one expanded topic card containing unit cards.

**Steps:**
1. Open the graph viewer and navigate to a category that shows topic cards on the board.
2. Make sure a topic card is expanded (showing its unit cards inside it).
3. Click on an empty area inside the topic card body — not on a unit card, and not on the title/caret at the top.
4. Check the side panel that appears.
5. Now click the title or caret area of the same topic card and check what happens to the card's expanded/collapsed state.
6. Click directly on a unit card inside the topic and check what opens in the side panel.

**Expected Results:**
- Clicking the empty body area of an expanded topic card should open that topic's detail in the side panel (showing topic-level information, not a unit detail).
- There should be no separate "details →" button visible anywhere on the topic card header.
- Clicking the title or caret should collapse or expand the topic card, not open the detail panel.
- Clicking a unit card inside the topic should open that unit's detail in the side panel, not the topic detail.

</blockquote>
</details>

---

## Topics (5)
<details>
<summary><strong>01 · Symmetric edge deduplication at graph build time and in the viewer</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Two units connected by a `related-to` relationship were rendering as two separate arrowed lines pointing in opposite directions, and the side panel listed the same peer unit twice. The root cause was the knowledge extractor emitting both directions of a symmetric relationship as independent edges.

**💡 Decisions Behind the Code**

- **Source normalisation at the assembly chokepoint**: Deduplication was placed in `assembleGraph` rather than only in the viewer runtime. Every code path that writes a graph file (full build, incremental, and the no-LLM reassemble) passes through this single function, so the fix is permanent and the viewer-side mirror is purely defensive for pre-existing files.
- **Subsumption rule drops `related-to` regardless of confidence**: When a specific edge (`extends`, `caused-by`, etc.) exists between a pair, the generic `related-to` is dropped even if it carries higher confidence. The reasoning is that a specific edge already implies relatedness, so the generic one adds no information — keeping both would draw two redundant lines for one real fact.

**✅ What Was Implemented**

- Added `SYMMETRIC_EDGE_TYPES`, `normalizeSymmetricEdges`, and `dropSubsumedRelatedTo` to `GraphSchema.ts`. `normalizeSymmetricEdges` collapses reversed symmetric pairs to one edge per unordered endpoint pair (keeping the higher-confidence side), and `dropSubsumedRelatedTo` removes a generic `related-to` whenever a more specific typed edge already links the same pair. Both run inside `assembleGraph` before validation, stats, and file emit, so every written `graph.json` is clean at the source.
- `data.js` in the graph viewer carries a defensive mirror of both normalisation steps to clean up `graph.json` files written before this change was deployed, with comments noting these become no-ops once a repo rebuilds its graph.
- `views.js` passes `arrow: false` for symmetric edges so they render as plain lines without arrowheads, and `panel.js` omits the direction arrow in the related-units list and uses `↔` instead of `→` in the category-pair detail view.

**📋 Future Enhancements**

Consider normalising symmetric edges at the `GraphBuilder` data-generation layer as well, so the raw distilled output never contains the duplicates in the first place. The current fix is at assembly time, which is correct but one step downstream of the origin.

**📁 FILES**
- `cli/src/graph/GraphSchema.ts`
- `cli/src/graph/GraphSchema.test.ts`
- `cli/src/graph/assets/js/data.js`
- `cli/src/graph/assets/js/views.js`
- `cli/src/graph/assets/js/panel.js`

</blockquote>
</details>
<details>
<summary><strong>02 · Unit-focus camera zooms in to readable size and pans minimally on click</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Clicking a unit card when the graph was zoomed out far would either leave the card too small to read or snap the view in a disorienting way. The user wanted a consistent rule: zoom in only enough to make the card readable, keep the card's center fixed on screen, and pan as little as possible to keep the card and its neighbours visible.

**💡 Decisions Behind the Code**

- **Anchor zoom on the unit's own centre, not the viewport centre**: Zooming around the unit's current screen position means the card stays exactly where the user's eye already is. The alternative — recentering the unit in the viewport — was the previous behaviour and felt like a disorienting jump, especially when the unit was already visible.
- **Related units are a soft preference, never a reason to zoom out**: The camera will try to fit the unit and its neighbours together, but if they are too spread apart it keeps the selected unit fully visible and leans toward the group's centre as far as the unit's slack allows. Zooming out to fit everything was explicitly rejected: the readability of the selected card takes priority.

**✅ What Was Implemented**

- Added `focusUnit(el, relatedEls)` and `solveAxis()` to `camera.js`. `focusUnit` raises the current scale to a `READABLE_SCALE` floor (set to 0.8) only when below it, anchors the zoom pivot on the unit's own screen centre, then calls `solveAxis` per axis to compute the smallest pan that keeps the unit fully visible while biasing toward fitting its related neighbours. The scale is never lowered.
- Added `focusSelectedUnit(unitId)` and `relatedUnitEls(unitId)` to `views.js` and exported the function on `window.WikiViews`. `settleCamera` now routes unit selections through `focusSelectedUnit` instead of the generic `focusOn` call. The selection-only path in `main.js` (clicking a unit already on the board without a navigation) was also updated to call `focusSelectedUnit`, making both entry points behave identically.

**📁 FILES**
- `cli/src/graph/assets/js/camera.js`
- `cli/src/graph/assets/js/views.js`
- `cli/src/graph/assets/js/main.js`

</blockquote>
</details>
<details>
<summary><strong>03 · Topic card click opens topic detail panel, removing the details button</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The topic card had a small "details →" button in its header to open the topic's side panel. The user wanted clicking anywhere on the topic card body to open the topic detail instead, making the button redundant.

**💡 Decisions Behind the Code**

The title zone (caret plus heading text) was kept as the collapse control rather than making it open the topic detail. This preserves the existing mental model where the caret and title read as one toggle, and avoids a situation where clicking the most prominent part of the card header does something different from clicking the caret directly beside it.

**✅ What Was Implemented**

- Removed the "details →" button from the topic card HTML in `views.js`. The card's click handler was rewritten to distinguish three zones: the caret-and-title strip collapses or expands the group; clicking a unit card inside the topic selects that unit (the unit's own handler fires and the topic handler bails); clicking anywhere else on an expanded topic card selects the topic and opens its detail in the panel.
- `wireCanvasClear` in `main.js` was updated to exclude the entire `.topic-group` element (not just the header) from the "clear selection" click, so clicking a topic card body selects the topic rather than clearing the selection and falling back to the category summary.
- Stale references to the removed button and its data attribute were cleaned up in `drag.js` and `main.css`.

**📁 FILES**
- `cli/src/graph/assets/js/views.js`
- `cli/src/graph/assets/js/main.js`
- `cli/src/graph/assets/js/drag.js`
- `cli/src/graph/assets/styles/main.css`

</blockquote>
</details>
<details>
<summary><strong>04 · Home panel copy updated and wiki button moved under topic description</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The home panel described the graph as coming from "the team wiki" and used "Knowledge topics" and "Knowledge units" as labels. The user wanted the source described as the local knowledge base, the "Knowledge" prefix removed, and the link statistics broken into three meaningful scopes. The "Open full wiki page" button was also in the wrong place.

**💡 Decisions Behind the Code**

The three-bucket edge breakdown (within topic / within category / across categories) was chosen over a single total count because the three numbers are mutually exclusive and sum to the total, giving readers a meaningful sense of how tightly coupled the knowledge graph is at each level of granularity.

**✅ What Was Implemented**

- Updated the home panel subtitle in `panel.js` to read "Distilled from your local knowledge base · regenerated on every merge" and renamed the stat labels to "Topics" and "Units". The single edge count was replaced with three scoped rows: links within a topic, links within a category (cross-topic), and links across categories.
- Moved the "Open full wiki page" button in `renderTopic` to appear directly below the topic description, matching the placement of the "Open category" button. The old "Source wiki page" heading and bottom block were removed. A `scrollTop = 0` reset was added so opening the wiki page always starts at the top.
- The search box placeholder in `index.html` was updated from "Search topics & decisions…" to "Search topics & units…".

**📁 FILES**
- `cli/src/graph/assets/js/panel.js`
- `cli/src/graph/assets/index.html`

</blockquote>
</details>
<details>
<summary><strong>05 · Stale edge layer cleared immediately on navigation to prevent ghost lines</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When navigating from the overview into a category, the previous level's edge lines remained visible floating over the blank incoming board for the duration of the asynchronous layout calculation, before the new edges were drawn.

**💡 Decisions Behind the Code**

Clearing at the top of `render()` rather than at the start of `drawCategoryEdges` (which runs after layout) was chosen because the layout is asynchronous and the cards stay hidden until it completes. Any earlier clear point inside the layout pipeline would still leave a window where old edges are visible over a blank board.

**✅ What Was Implemented**

A `WikiEdges.clear()` call was added at the very start of the `render()` function in `views.js`, before the asynchronous ELK layout begins. This wipes both edge layers synchronously the instant navigation occurs, so the board is blank during the layout gap rather than showing the previous level's lines.

**📁 FILES**
- `cli/src/graph/assets/js/views.js`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 25, 2026 at 5:01 PM · via Anthropic*
<!-- jollimemory-summary-end -->