### PR TITLE
Add branch and commit share feature with expiry, social sharing, and staleness detection

### DIFF
--- a/cli/src/core/BranchShareSnapshot.test.ts
+++ b/cli/src/core/BranchShareSnapshot.test.ts
@@ -1,0 +1,332 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommitSummary, TopicSummary } from "../Types.js";
+
+// Source the branch's summaries from the shared reader (loadBranchSummaries) and
+// the default-branch resolver — both git-backed, so mock them here. Plan/note
+// bodies are read from storage; mock those too. resolveEffectiveTopics + buildMarkdown
+// stay real (pure, operate on the summary objects we construct).
+const h = vi.hoisted(() => ({
+	loadBranchSummaries: vi.fn(),
+	getDefaultBranch: vi.fn(),
+	readPlanFromBranch: vi.fn(),
+	readNoteFromBranch: vi.fn(),
+}));
+
+vi.mock("./PrDescription.js", () => ({ loadBranchSummaries: h.loadBranchSummaries }));
+vi.mock("./GitOps.js", async (orig) => ({
+	...(await orig<typeof import("./GitOps.js")>()),
+	getDefaultBranch: h.getDefaultBranch,
+}));
+vi.mock("./SummaryStore.js", async (orig) => ({
+	...(await orig<typeof import("./SummaryStore.js")>()),
+	readPlanFromBranch: h.readPlanFromBranch,
+	readNoteFromBranch: h.readNoteFromBranch,
+}));
+
+import { assembleBranchShareSnapshot, resolveShareHead } from "./BranchShareSnapshot.js";
+
+const HASH = { c1: "a".repeat(40), c2: "b".repeat(40), c3: "c".repeat(40) };
+
+function topic(title: string): TopicSummary {
+	return { title, trigger: `why ${title}`, response: `did ${title}`, decisions: `chose ${title}` };
+}
+
+function makeSummary(over: Partial<CommitSummary> & Pick<CommitSummary, "commitHash">): CommitSummary {
+	return {
+		version: 4,
+		commitMessage: `msg-${over.commitHash.slice(0, 4)}`,
+		commitAuthor: "Dev",
+		commitDate: "2026-01-01T00:00:00.000Z",
+		branch: "feature/x",
+		generatedAt: "2026-01-01T00:00:00.000Z",
+		topics: [topic("t1")],
+		...over,
+	};
+}
+
+/** Drives the shared reader to return `summaries` (chronological, oldest-first). */
+function withSummaries(summaries: CommitSummary[]): void {
+	h.loadBranchSummaries.mockResolvedValue({ summaries, missingCount: 0 });
+}
+
+beforeEach(() => {
+	for (const fn of Object.values(h)) fn.mockReset();
+	h.getDefaultBranch.mockResolvedValue("main");
+	h.loadBranchSummaries.mockResolvedValue({ summaries: [], missingCount: 0 });
+	h.readPlanFromBranch.mockResolvedValue(null);
+	h.readNoteFromBranch.mockResolvedValue(null);
+});
+
+describe("assembleBranchShareSnapshot", () => {
+	it("returns null when the branch has no generated summaries", async () => {
+		expect(await assembleBranchShareSnapshot("feature/x", "/repo")).toBeNull();
+	});
+
+	it("sources from loadBranchSummaries(base..HEAD) — chronological content, count, head", async () => {
+		withSummaries([
+			makeSummary({ commitHash: HASH.c1, topics: [topic("a"), topic("b")] }),
+			makeSummary({ commitHash: HASH.c2, topics: [topic("c")] }),
+		]);
+		const snap = await assembleBranchShareSnapshot("feature/x", "/repo");
+		expect(h.getDefaultBranch).toHaveBeenCalledWith("/repo");
+		expect(h.loadBranchSummaries).toHaveBeenCalledWith("/repo", "main");
+		expect(snap).not.toBeNull();
+		if (!snap) return;
+		expect(snap.branch).toBe("feature/x");
+		expect(snap.commitHashes).toEqual([HASH.c1, HASH.c2]);
+		expect(snap.headCommitHash).toBe(HASH.c2); // newest included (last chronological)
+		expect(snap.decisionCount).toBe(3);
+		expect(snap.titles).toEqual(["a", "b", "c"]);
+		expect(snap.content.indexOf("msg-aaaa")).toBeLessThan(snap.content.indexOf("msg-bbbb"));
+	});
+
+	it("embeds plan content as an expandable section, gated by includePlans", async () => {
+		withSummaries([
+			makeSummary({
+				commitHash: HASH.c1,
+				plans: [
+					{
+						slug: "p1",
+						title: "My Plan",
+						addedAt: "2026-01-01T00:00:00.000Z",
+						updatedAt: "2026-01-01T00:00:00.000Z",
+					},
+				],
+			}),
+		]);
+		h.readPlanFromBranch.mockResolvedValue("# My Plan\n\nThe full plan body.");
+
+		const def = await assembleBranchShareSnapshot("feature/x", "/repo");
+		expect(def?.content).toContain("## Plans & Notes");
+		expect(def?.content).toContain("<details>");
+		expect(def?.content).toContain("Plan — My Plan");
+		expect(def?.content).toContain("The full plan body.");
+
+		const noPlans = await assembleBranchShareSnapshot("feature/x", "/repo", { includePlans: false });
+		expect(noPlans?.content).not.toContain("My Plan");
+		expect(noPlans?.content).not.toContain("Plans & Notes");
+	});
+
+	it("embeds note content (file or snippet fallback), gated by includeNotes", async () => {
+		withSummaries([
+			makeSummary({
+				commitHash: HASH.c1,
+				notes: [
+					{
+						id: "n1",
+						title: "Doc Note",
+						format: "markdown",
+						addedAt: "2026-01-01T00:00:00.000Z",
+						updatedAt: "2026-01-01T00:00:00.000Z",
+					},
+					{
+						id: "n2",
+						title: "Snippet Note",
+						format: "snippet",
+						content: "inline snippet body",
+						addedAt: "2026-01-01T00:00:00.000Z",
+						updatedAt: "2026-01-01T00:00:00.000Z",
+					},
+				],
+			}),
+		]);
+		h.readNoteFromBranch.mockImplementation(async (id: string) => (id === "n1" ? "markdown note body" : null));
+
+		const def = await assembleBranchShareSnapshot("feature/x", "/repo");
+		expect(def?.content).toContain("Note — Doc Note");
+		expect(def?.content).toContain("markdown note body");
+		expect(def?.content).toContain("Note — Snippet Note");
+		expect(def?.content).toContain("inline snippet body"); // file missing → snippet fallback
+
+		const noNotes = await assembleBranchShareSnapshot("feature/x", "/repo", { includeNotes: false });
+		expect(noNotes?.content).not.toContain("Doc Note");
+	});
+
+	it("HTML-escapes plan/note titles in the <summary> tag", async () => {
+		withSummaries([
+			makeSummary({
+				commitHash: HASH.c1,
+				plans: [
+					{
+						slug: "p1",
+						title: "</summary><script>alert(1)</script>",
+						addedAt: "2026-01-01T00:00:00.000Z",
+						updatedAt: "2026-01-01T00:00:00.000Z",
+					},
+				],
+			}),
+		]);
+		const snap = await assembleBranchShareSnapshot("feature/x", "/repo");
+		expect(snap?.content).toContain("&lt;/summary&gt;&lt;script&gt;");
+		expect(snap?.content).not.toContain("<summary></summary><script>");
+	});
+
+	it("shows a placeholder when a plan body cannot be read", async () => {
+		withSummaries([
+			makeSummary({
+				commitHash: HASH.c1,
+				plans: [
+					{
+						slug: "missing",
+						title: "Ghost Plan",
+						addedAt: "2026-01-01T00:00:00.000Z",
+						updatedAt: "2026-01-01T00:00:00.000Z",
+					},
+				],
+			}),
+		]);
+		const snap = await assembleBranchShareSnapshot("feature/x", "/repo");
+		expect(snap?.content).toContain("Plan — Ghost Plan");
+		expect(snap?.content).toContain("(no content captured)");
+	});
+
+	it("dedupes same-named plans to a single block, keeping the latest updatedAt's body", async () => {
+		// Same title, different slugs (e.g. plan recreated) — share only the latest.
+		withSummaries([
+			makeSummary({
+				commitHash: HASH.c1,
+				plans: [
+					{
+						slug: "old-slug",
+						title: "Refactor plan",
+						addedAt: "2026-01-01T00:00:00.000Z",
+						updatedAt: "2026-01-01T00:00:00.000Z",
+					},
+				],
+			}),
+			makeSummary({
+				commitHash: HASH.c2,
+				plans: [
+					{
+						slug: "new-slug",
+						title: "Refactor plan",
+						addedAt: "2026-01-01T00:00:00.000Z",
+						updatedAt: "2026-01-02T00:00:00.000Z",
+					},
+				],
+			}),
+		]);
+		h.readPlanFromBranch.mockImplementation(async (slug: string) =>
+			slug === "new-slug" ? "newest body" : "stale body",
+		);
+		const snap = await assembleBranchShareSnapshot("feature/x", "/repo");
+		// One block (title appears once), body read from the latest-updated slug.
+		expect(snap?.content.match(/Plan — Refactor plan/g)?.length).toBe(1);
+		expect(snap?.content).toContain("newest body");
+		expect(snap?.content).not.toContain("stale body");
+	});
+
+	it("keeps the newer same-named plan when a later commit carries an older updatedAt", async () => {
+		withSummaries([
+			makeSummary({
+				commitHash: HASH.c1,
+				plans: [
+					{
+						slug: "new-slug",
+						title: "Refactor plan",
+						addedAt: "2026-01-01T00:00:00.000Z",
+						updatedAt: "2026-02-01T00:00:00.000Z",
+					},
+				],
+			}),
+			makeSummary({
+				commitHash: HASH.c2,
+				plans: [
+					{
+						slug: "old-slug",
+						title: "Refactor plan",
+						addedAt: "2026-01-01T00:00:00.000Z",
+						updatedAt: "2026-01-01T00:00:00.000Z",
+					},
+				],
+			}),
+		]);
+		h.readPlanFromBranch.mockImplementation(async (slug: string) =>
+			slug === "new-slug" ? "newest body" : "stale body",
+		);
+		const snap = await assembleBranchShareSnapshot("feature/x", "/repo");
+		expect(snap?.content.match(/Plan — Refactor plan/g)?.length).toBe(1);
+		expect(snap?.content).toContain("newest body");
+		expect(snap?.content).not.toContain("stale body");
+	});
+
+	it("dedupes same-named notes to a single block (case/space-insensitive)", async () => {
+		withSummaries([
+			makeSummary({
+				commitHash: HASH.c1,
+				notes: [
+					{
+						id: "n1",
+						title: "Design Note",
+						format: "snippet",
+						content: "stale note body",
+						addedAt: "2026-01-01T00:00:00.000Z",
+						updatedAt: "2026-01-01T00:00:00.000Z",
+					},
+				],
+			}),
+			makeSummary({
+				commitHash: HASH.c2,
+				notes: [
+					{
+						id: "n2",
+						title: "  design note  ",
+						format: "snippet",
+						content: "newest note body",
+						addedAt: "2026-01-01T00:00:00.000Z",
+						updatedAt: "2026-01-02T00:00:00.000Z",
+					},
+				],
+			}),
+		]);
+		const snap = await assembleBranchShareSnapshot("feature/x", "/repo");
+		expect(snap?.content).toContain("newest note body");
+		expect(snap?.content).not.toContain("stale note body");
+	});
+
+	it("does not choke when includePlans is false and a summary has no plans", async () => {
+		withSummaries([makeSummary({ commitHash: HASH.c1 })]);
+		const snap = await assembleBranchShareSnapshot("feature/x", "/repo", { includePlans: false });
+		expect(snap?.commitHashes).toEqual([HASH.c1]);
+	});
+
+	it("commit share: restricts to the one commit drawn from the branch set", async () => {
+		withSummaries([
+			makeSummary({ commitHash: HASH.c1, topics: [topic("a"), topic("b")] }),
+			makeSummary({ commitHash: HASH.c2, topics: [topic("c")] }),
+		]);
+		const snap = await assembleBranchShareSnapshot("feature/x", "/repo", { commitHash: HASH.c2 });
+		expect(snap?.commitHashes).toEqual([HASH.c2]);
+		expect(snap?.headCommitHash).toBe(HASH.c2);
+		expect(snap?.decisionCount).toBe(1); // only c2's topic
+		expect(snap?.content).toContain("msg-bbbb");
+		expect(snap?.content).not.toContain("msg-aaaa");
+	});
+
+	it("commit share: null when the commit is not on the branch", async () => {
+		withSummaries([makeSummary({ commitHash: HASH.c1 })]);
+		expect(await assembleBranchShareSnapshot("feature/x", "/repo", { commitHash: HASH.c3 })).toBeNull();
+	});
+});
+
+describe("resolveShareHead", () => {
+	it("returns the newest included summary's hash (same source as assemble)", async () => {
+		withSummaries([makeSummary({ commitHash: HASH.c1 }), makeSummary({ commitHash: HASH.c2 })]);
+		expect(await resolveShareHead("feature/x", "/repo")).toBe(HASH.c2);
+	});
+
+	it("returns undefined when the branch has no summaries", async () => {
+		expect(await resolveShareHead("feature/x", "/repo")).toBeUndefined();
+	});
+
+	it("tolerates an undefined cwd", async () => {
+		withSummaries([makeSummary({ commitHash: HASH.c1 })]);
+		expect(await resolveShareHead("feature/x")).toBe(HASH.c1);
+		expect(h.loadBranchSummaries).toHaveBeenCalledWith("", "main");
+	});
+
+	it("commit share: returns that commit's hash (frozen, never stale)", async () => {
+		withSummaries([makeSummary({ commitHash: HASH.c1 }), makeSummary({ commitHash: HASH.c2 })]);
+		expect(await resolveShareHead("feature/x", "/repo", HASH.c2)).toBe(HASH.c2);
+	});
+});

--- a/cli/src/core/BranchShareSnapshot.ts
+++ b/cli/src/core/BranchShareSnapshot.ts
@@ -1,0 +1,207 @@
+/**
+ * BranchShareSnapshot
+ *
+ * Assembles the public-share snapshot from the summaries that are ALREADY
+ * generated for the branch — the same `base..HEAD` set the Memories panel / PR
+ * description use (via `loadBranchSummaries`). Branch membership and reachability
+ * are NOT re-derived here: that is the shared reader's job, so a `git reset
+ * --hard` / dropped commit / force-push / rename can't leak commits that are no
+ * longer on the branch into a public share, and the share stays consistent with
+ * what the user sees in the panel.
+ *
+ * Two share kinds, selected by `options.commitHash`:
+ *  - **branch share** (no `commitHash`): every commit's summary on the branch,
+ *    organized by commit (chronological, oldest-first).
+ *  - **commit share** (`commitHash` set): just that one commit's summary, drawn
+ *    from the same branch set (so the "still on the branch" guarantee holds).
+ *
+ * Scope is **summary + plan + note, never transcripts/conversations** —
+ * `buildMarkdown` emits only a conversation-turn *count*, no conversation
+ * content, and plans/notes are embedded unless the caller opts out. Conversations
+ * are layered in on the recipient side from local data (see the share viewer), so
+ * they must never reach this cloud snapshot.
+ */
+
+import type { CommitSummary } from "../Types.js";
+import { getDefaultBranch } from "./GitOps.js";
+import { escHtml } from "./MarkdownEscape.js";
+import { loadBranchSummaries } from "./PrDescription.js";
+import { buildMarkdown } from "./SummaryMarkdownBuilder.js";
+import { readNoteFromBranch, readPlanFromBranch, resolveEffectiveTopics } from "./SummaryStore.js";
+
+export interface BranchShareSnapshotOptions {
+	/** Embed plans as expandable sections. Defaults to true. */
+	readonly includePlans?: boolean;
+	/** Embed notes as expandable sections. Defaults to true. */
+	readonly includeNotes?: boolean;
+	/**
+	 * Restrict the snapshot to a single commit's summary (commit share). When
+	 * omitted, every commit on the branch is included (branch share).
+	 */
+	readonly commitHash?: string;
+}
+
+export interface BranchShareSnapshot {
+	/** Branch label (the share's key); sourcing is HEAD-based, so this is the current branch. */
+	readonly branch: string;
+	/** Newest included summary — the snapshot's identity; drives the staleness check. */
+	readonly headCommitHash: string;
+	/** Included commit hashes, chronological (oldest first). */
+	readonly commitHashes: ReadonlyArray<string>;
+	/** Sum of effective topics across the included summaries — the "N decisions" headline. */
+	readonly decisionCount: number;
+	/** A few distinct decision titles across the whole branch — teaser for share copy. */
+	readonly titles: ReadonlyArray<string>;
+	/**
+	 * Rendered Markdown, chronological: per-commit summaries followed by a
+	 * "Plans & Notes" section embedding each plan/note as a collapsible
+	 * `<details>` block (title visible, content expandable). Never includes
+	 * transcripts/conversations.
+	 */
+	readonly content: string;
+}
+
+/**
+ * The branch's generated summaries (`base..HEAD`, chronological oldest-first) —
+ * the single source of truth shared with the Memories panel / PR path. Empty
+ * when nothing is summarized on the branch.
+ *
+ * When `commitHash` is given (commit share), the result is filtered to just that
+ * commit — still drawn from the branch set, so a commit no longer on the branch
+ * yields an empty result (nothing shareable) rather than a stale leak.
+ */
+async function loadShareSummaries(cwd?: string, commitHash?: string): Promise<ReadonlyArray<CommitSummary>> {
+	const baseBranch = await getDefaultBranch(cwd);
+	const { summaries } = await loadBranchSummaries(cwd ?? "", baseBranch);
+	return commitHash ? summaries.filter((s) => s.commitHash === commitHash) : summaries;
+}
+
+/**
+ * Builds the share snapshot for `branch`, or `null` when the branch has no
+ * generated summaries (nothing shareable).
+ */
+export async function assembleBranchShareSnapshot(
+	branch: string,
+	cwd?: string,
+	options?: BranchShareSnapshotOptions,
+): Promise<BranchShareSnapshot | null> {
+	const chronological = await loadShareSummaries(cwd, options?.commitHash);
+	if (chronological.length === 0) return null;
+
+	const topicsByCommit = chronological.map((s) => resolveEffectiveTopics(s));
+	const decisionCount = topicsByCommit.reduce((total, topics) => total + topics.length, 0);
+	// A few distinct decision titles across the whole branch (not just one commit),
+	// so share copy teases the branch's headline decisions.
+	const titles = [
+		...new Set(topicsByCommit.flatMap((topics) => topics.map((t) => t.title.trim())).filter((t) => t.length > 0)),
+	].slice(0, 5);
+
+	const includePlans = options?.includePlans ?? true;
+	const includeNotes = options?.includeNotes ?? true;
+
+	// Per-commit summaries with the inline plan/note title list stripped — each
+	// plan/note renders once below as an expandable section (title + content),
+	// so the recipient page can expand it in place without duplication.
+	const perCommit = chronological.map((s) => buildMarkdown(stripAttachments(s)));
+	const attachments = await buildAttachmentsSection(chronological, includePlans, includeNotes, cwd);
+	const content = [perCommit.join("\n\n---\n\n"), attachments].filter((part) => part.length > 0).join("\n\n---\n\n");
+
+	// Head = newest included summary (chronological is oldest-first). The staleness
+	// check compares this to the same value recomputed on reopen, so a new commit
+	// advances it (and fires stale) exactly once its summary is generated.
+	const headCommitHash = chronological[chronological.length - 1].commitHash;
+	const commitHashes = chronological.map((s) => s.commitHash);
+
+	return { branch, headCommitHash, commitHashes, decisionCount, titles, content };
+}
+
+/**
+ * The head used for the staleness check, WITHOUT building content. Same source as
+ * the snapshot, so create-time and reopen-time heads agree by construction.
+ * `undefined` when the branch (or specified commit) has no shareable summary.
+ *
+ * For a commit share (`commitHash` set) the head is that commit, so the share is
+ * frozen and never reads as stale — only branch shares advance with new commits.
+ */
+export async function resolveShareHead(
+	_branch: string,
+	cwd?: string,
+	commitHash?: string,
+): Promise<string | undefined> {
+	const chronological = await loadShareSummaries(cwd, commitHash);
+	return chronological.length > 0 ? chronological[chronological.length - 1].commitHash : undefined;
+}
+
+/** Returns a shallow copy of `summary` with plan + note references removed. */
+function stripAttachments(summary: CommitSummary): CommitSummary {
+	const hasPlans = summary.plans && summary.plans.length > 0;
+	const hasNotes = summary.notes && summary.notes.length > 0;
+	if (!hasPlans && !hasNotes) return summary;
+	const { plans: _plans, notes: _notes, ...rest } = summary;
+	return rest;
+}
+
+/**
+ * Builds the "Plans & Notes" section: each unique plan/note as a collapsible
+ * `<details>` block (title = visible summary, full content = expandable body).
+ * Deduped by **title** (case-insensitive, trimmed) so same-named plans/notes
+ * collapse to a single block — the latest `updatedAt` wins. Returns "" when
+ * there is nothing to embed.
+ */
+async function buildAttachmentsSection(
+	summaries: ReadonlyArray<CommitSummary>,
+	includePlans: boolean,
+	includeNotes: boolean,
+	cwd?: string,
+): Promise<string> {
+	const blocks: string[] = [];
+
+	if (includePlans) {
+		for (const plan of latestByKey(
+			summaries.flatMap((s) => s.plans ?? []),
+			(p) => p.title.trim().toLowerCase(),
+		)) {
+			const body = (await readPlanFromBranch(plan.slug, cwd))?.trim();
+			blocks.push(detailsBlock(`\u{1F4C4} Plan — ${escHtml(plan.title)}`, body));
+		}
+	}
+
+	if (includeNotes) {
+		for (const note of latestByKey(
+			summaries.flatMap((s) => s.notes ?? []),
+			(n) => n.title.trim().toLowerCase(),
+		)) {
+			const body = ((await readNoteFromBranch(note.id, cwd)) ?? note.content)?.trim();
+			blocks.push(detailsBlock(`\u{1F4DD} Note — ${escHtml(note.title)}`, body));
+		}
+	}
+
+	if (blocks.length === 0) return "";
+	return ["## Plans & Notes", "", ...blocks].join("\n");
+}
+
+/** Dedups by key, keeping the latest `updatedAt`. Preserves first-seen order. */
+function latestByKey<T extends { readonly updatedAt: string }>(items: ReadonlyArray<T>, key: (t: T) => string): T[] {
+	const byKey = new Map<string, T>();
+	for (const item of items) {
+		const k = key(item);
+		const prev = byKey.get(k);
+		if (!prev || Date.parse(item.updatedAt) >= Date.parse(prev.updatedAt)) byKey.set(k, item);
+	}
+	return [...byKey.values()];
+}
+
+/**
+ * A collapsible block: always-visible title + expandable body.
+ *
+ * SECURITY: `title` is HTML-escaped by the caller (it sits inside the `<summary>`
+ * tag we emit). `body` is the plan/note **Markdown**, embedded verbatim so the
+ * public renderer can format it — which means the renderer is the trust boundary:
+ * it MUST sanitize the rendered HTML with an allowlist (keep `details`/`summary`;
+ * strip `script`, `iframe`, `on*` handlers, `javascript:` URLs, etc.). Without
+ * that, user-authored plan/note content is a stored-XSS vector on the public page.
+ */
+function detailsBlock(title: string, body: string | undefined): string {
+	const content = body && body.length > 0 ? body : "_(no content captured)_";
+	return `<details>\n<summary>${title}</summary>\n\n${content}\n\n</details>\n`;
+}

--- a/cli/src/core/BranchShareStore.test.ts
+++ b/cli/src/core/BranchShareStore.test.ts
@@ -1,0 +1,194 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { JOLLI_DIR, JOLLIMEMORY_DIR } from "../Logger.js";
+import {
+	type BranchShareRecord,
+	getBranchShare,
+	isPublicConfirmed,
+	markPublicConfirmed,
+	putBranchShare,
+	removeBranchShare,
+} from "./BranchShareStore.js";
+
+let cwd: string;
+
+beforeEach(async () => {
+	cwd = join(tmpdir(), `branch-share-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	await mkdir(join(cwd, JOLLI_DIR, JOLLIMEMORY_DIR), { recursive: true });
+});
+
+afterEach(async () => {
+	await rm(cwd, { recursive: true, force: true });
+});
+
+function filePath(): string {
+	return join(cwd, JOLLI_DIR, JOLLIMEMORY_DIR, "branch-shares.json");
+}
+
+const REC: Omit<BranchShareRecord, "confirmedPublic"> = {
+	shareId: "sh_1",
+	shareUrl: "https://acme.jolli.ai/b/feature-x-tok12345",
+	visibility: "public",
+	token8: "tok12345",
+	headCommitHash: "a".repeat(40),
+	expiresAt: "2026-09-01T00:00:00.000Z",
+	decisionCount: 4,
+};
+
+describe("BranchShareStore", () => {
+	it("returns undefined for a missing file", async () => {
+		expect(await getBranchShare(cwd, "feature/x")).toBeUndefined();
+	});
+
+	it("round-trips a share record", async () => {
+		await putBranchShare(cwd, "feature/x", REC);
+		const got = await getBranchShare(cwd, "feature/x");
+		expect(got?.shareId).toBe("sh_1");
+		expect(got?.token8).toBe("tok12345");
+		expect(got?.decisionCount).toBe(4);
+		expect(got?.confirmedPublic).toBeUndefined();
+	});
+
+	it("round-trips a `people` share with its recipients allowlist (no token)", async () => {
+		await putBranchShare(cwd, "feature/x", {
+			...REC,
+			shareId: "sh_people",
+			visibility: "people",
+			token8: undefined,
+			recipients: ["marta@jolli.ai", "tom@jolli.ai"],
+		});
+		const got = await getBranchShare(cwd, "feature/x");
+		expect(got?.visibility).toBe("people");
+		expect(got?.recipients).toEqual(["marta@jolli.ai", "tom@jolli.ai"]);
+		expect(got?.token8).toBeUndefined();
+	});
+
+	it("keeps separate records per branch", async () => {
+		await putBranchShare(cwd, "feature/x", REC);
+		await putBranchShare(cwd, "feature/y", { ...REC, shareId: "sh_2" });
+		expect((await getBranchShare(cwd, "feature/x"))?.shareId).toBe("sh_1");
+		expect((await getBranchShare(cwd, "feature/y"))?.shareId).toBe("sh_2");
+	});
+
+	it("keeps a commit share separate from the branch share on the same branch", async () => {
+		const commitHash = "c".repeat(40);
+		await putBranchShare(cwd, "feature/x", REC); // branch share
+		await putBranchShare(cwd, "feature/x", { ...REC, shareId: "sh_commit" }, commitHash); // commit share
+		expect((await getBranchShare(cwd, "feature/x"))?.shareId).toBe("sh_1");
+		expect((await getBranchShare(cwd, "feature/x", commitHash))?.shareId).toBe("sh_commit");
+		// removing the commit share leaves the branch share intact
+		await removeBranchShare(cwd, "feature/x", commitHash);
+		expect(await getBranchShare(cwd, "feature/x", commitHash)).toBeUndefined();
+		expect((await getBranchShare(cwd, "feature/x"))?.shareId).toBe("sh_1");
+	});
+
+	it("shares the public-confirmation flag (branch-level) across both kinds", async () => {
+		const commitHash = "c".repeat(40);
+		await markPublicConfirmed(cwd, "feature/x");
+		// confirmation is keyed on the bare branch, so a commit share on it is also confirmed
+		expect(await isPublicConfirmed(cwd, "feature/x")).toBe(true);
+		await putBranchShare(cwd, "feature/x", { ...REC, shareId: "sh_commit" }, commitHash);
+		expect(await isPublicConfirmed(cwd, "feature/x")).toBe(true);
+	});
+
+	it("removes a record and tolerates removing a missing one", async () => {
+		await putBranchShare(cwd, "feature/x", REC);
+		await removeBranchShare(cwd, "feature/x");
+		expect(await getBranchShare(cwd, "feature/x")).toBeUndefined();
+		// idempotent
+		await removeBranchShare(cwd, "feature/x");
+		await removeBranchShare(cwd, "never-shared");
+	});
+
+	it("tracks the public-confirmation flag independently of the share", async () => {
+		expect(await isPublicConfirmed(cwd, "feature/x")).toBe(false);
+		await markPublicConfirmed(cwd, "feature/x");
+		expect(await isPublicConfirmed(cwd, "feature/x")).toBe(true);
+		// a share with no record yet still carries the placeholder + flag
+		const rec = await getBranchShare(cwd, "feature/x");
+		expect(rec?.confirmedPublic).toBe(true);
+		expect(rec?.shareId).toBe("");
+	});
+
+	it("preserves confirmedPublic across a later putBranchShare", async () => {
+		await markPublicConfirmed(cwd, "feature/x");
+		await putBranchShare(cwd, "feature/x", REC);
+		const rec = await getBranchShare(cwd, "feature/x");
+		expect(rec?.shareId).toBe("sh_1");
+		expect(rec?.confirmedPublic).toBe(true);
+	});
+
+	it("preserves confirmedPublic when the share is revoked (removeBranchShare)", async () => {
+		await markPublicConfirmed(cwd, "feature/x");
+		await putBranchShare(cwd, "feature/x", REC);
+		expect(await isPublicConfirmed(cwd, "feature/x")).toBe(true);
+
+		await removeBranchShare(cwd, "feature/x"); // "Stop sharing"
+		// the share itself is gone (blank placeholder), but the confirmation survives,
+		// so the next share on this branch won't re-prompt the PUBLIC confirmation.
+		expect((await getBranchShare(cwd, "feature/x"))?.shareId).toBe("");
+		expect(await isPublicConfirmed(cwd, "feature/x")).toBe(true);
+	});
+
+	it("treats a malformed file as empty", async () => {
+		await writeFile(filePath(), "{not json", "utf8");
+		expect(await getBranchShare(cwd, "feature/x")).toBeUndefined();
+	});
+
+	it("round-trips a live org record (no token8, with a branchCollection ref + recipients)", async () => {
+		const live: Omit<BranchShareRecord, "confirmedPublic"> = {
+			shareId: "sh_org",
+			shareUrl: "https://acme.jolli.ai/share/branch/7/view",
+			visibility: "org",
+			recipients: ["ada@example.com", "grace@example.com"],
+			ref: {
+				kind: "branchCollection",
+				relativePath: "feature/x",
+				covered: [{ commitHash: "a".repeat(40), summaryDocId: 11, attachmentDocIds: [12, 13] }],
+			},
+			expiresAt: "2026-09-01T00:00:00.000Z",
+			decisionCount: 2,
+		};
+		await putBranchShare(cwd, "feature/x", live);
+		const got = await getBranchShare(cwd, "feature/x");
+		expect(got?.visibility).toBe("org");
+		expect(got?.token8).toBeUndefined();
+		expect(got?.recipients).toEqual(["ada@example.com", "grace@example.com"]);
+		expect(got?.ref).toEqual(live.ref);
+	});
+
+	it("drops an old v1 file on the version bump (no migration)", async () => {
+		await writeFile(filePath(), JSON.stringify({ version: 1, branches: { "feature/x": REC } }), "utf8");
+		expect(await getBranchShare(cwd, "feature/x")).toBeUndefined();
+	});
+
+	it("ignores a file with an unrecognized version", async () => {
+		await writeFile(filePath(), JSON.stringify({ version: 99, branches: { "feature/x": REC } }), "utf8");
+		expect(await getBranchShare(cwd, "feature/x")).toBeUndefined();
+	});
+
+	it("ignores a file whose branches field is not an object", async () => {
+		await writeFile(filePath(), JSON.stringify({ version: 1, branches: "nope" }), "utf8");
+		expect(await getBranchShare(cwd, "feature/x")).toBeUndefined();
+	});
+
+	it("cleans up and propagates when the atomic rename fails", async () => {
+		// Make the target path a directory so the temp→target rename fails; this
+		// drives the cleanup-and-rethrow arm and the non-ENOENT read warning.
+		await mkdir(filePath(), { recursive: true });
+		await expect(putBranchShare(cwd, "feature/x", REC)).rejects.toBeTruthy();
+	});
+
+	it("serializes concurrent writes without losing updates", async () => {
+		await Promise.all([
+			putBranchShare(cwd, "a", { ...REC, shareId: "a" }),
+			putBranchShare(cwd, "b", { ...REC, shareId: "b" }),
+			putBranchShare(cwd, "c", { ...REC, shareId: "c" }),
+		]);
+		expect((await getBranchShare(cwd, "a"))?.shareId).toBe("a");
+		expect((await getBranchShare(cwd, "b"))?.shareId).toBe("b");
+		expect((await getBranchShare(cwd, "c"))?.shareId).toBe("c");
+	});
+});

--- a/cli/src/core/BranchShareStore.ts
+++ b/cli/src/core/BranchShareStore.ts
@@ -1,0 +1,239 @@
+/**
+ * BranchShareStore
+ *
+ * Per-project record of the public shares this machine has created, stored in
+ * `<projectDir>/.jolli/jollimemory/branch-shares.json` (gitignored).
+ *
+ * Records are keyed by *share subject*: a branch share keys on the bare branch
+ * name; a commit share keys on `<branch>\0<commitHash>` (see `recordKey`). The
+ * NUL separator can't appear in a git ref or hash, so the two namespaces never
+ * collide.
+ *
+ * Two jobs:
+ *  - Remember the issued share per subject so the Share modal can re-open to the
+ *    same link, drive Revoke, and detect "branch moved since I shared" (the
+ *    stored `headCommitHash` differs from the branch tip → offer re-share).
+ *  - Remember that the user acknowledged the one-time "this is a PUBLIC link"
+ *    confirmation. Confirmation is tracked **per branch** (keyed on the bare
+ *    branch name) and intentionally covers both branch and commit shares on that
+ *    branch — once you've accepted public links for a branch, commit shares on it
+ *    don't re-prompt.
+ *
+ * This is a local cache, not the system of record — the backend owns share
+ * lifecycle. The account-level management view (web dashboard) is the
+ * authoritative cross-repo surface; both align on `shareId`.
+ */
+
+import { mkdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createLogger, errMsg, isEnoent, JOLLI_DIR, JOLLIMEMORY_DIR } from "../Logger.js";
+import { atomicWriteFile } from "./AtomicWrite.js";
+
+const log = createLogger("BranchShare");
+
+const SHARES_FILE = "branch-shares.json";
+// v2: live Space-backed shares (visibility/recipients/ref); v1 snapshot records
+// are dropped on read (the snapshot share was never released, so no migration).
+const SHARES_VERSION = 2 as const;
+
+/**
+ * Reference to the live Space content a share renders from. Branch shares carry a
+ * per-commit allowlist (`covered`) = the current `base..HEAD` docs, so the server
+ * renders exactly those; commit shares carry a fixed doc list.
+ */
+export type LiveRef =
+	| {
+			readonly kind: "branchCollection";
+			readonly relativePath: string;
+			readonly covered: ReadonlyArray<{
+				readonly commitHash: string;
+				readonly summaryDocId: number;
+				readonly attachmentDocIds: ReadonlyArray<number>;
+			}>;
+	  }
+	| {
+			readonly kind: "commitDocs";
+			readonly summaryDocIds: ReadonlyArray<number>;
+			readonly attachmentDocIds: ReadonlyArray<number>;
+	  };
+
+/** One share record (branch share or single-commit share). Every share is live. */
+export interface BranchShareRecord {
+	readonly shareId: string;
+	readonly shareUrl: string;
+	/**
+	 * Access level: `public` (anyone-with-link bearer), `org` (auth-gated to the org),
+	 * or `people` (auth-gated to the `recipients` allowlist).
+	 */
+	readonly visibility: "public" | "org" | "people";
+	/**
+	 * The `people` access allowlist (lowercased emails). For `people` shares this is
+	 * **server-authoritative** (sent on the audience PATCH, echoed back, gated on the
+	 * view route); cached here for re-open. Absent/empty for public/org.
+	 */
+	readonly recipients?: ReadonlyArray<string>;
+	/** Reference to the live Space content this share renders from. */
+	readonly ref?: LiveRef;
+	/**
+	 * First 8 chars of the bearer token — enough to display/build the deep link, not
+	 * the secret. Optional: `org` shares are auth-gated and have no token.
+	 */
+	readonly token8?: string;
+	/**
+	 * The subject's tip at create time (still sent to the server; backs the NOT-NULL
+	 * column + idempotency index). Optional in the cache — a live share renders current
+	 * membership, so it's not used for a client-side staleness check.
+	 */
+	readonly headCommitHash?: string;
+	readonly expiresAt: string;
+	/** Decision (topic) count captured at share time — drives the modal preview on reuse. */
+	readonly decisionCount: number;
+	/** A few decision titles captured at share time — teaser for share copy. */
+	readonly titles?: ReadonlyArray<string>;
+	/** Set on a commit-share record so the kind is recoverable from the cache alone. */
+	readonly commitHash?: string;
+	/** Set once the user acknowledged the public-link confirmation for this branch. */
+	readonly confirmedPublic?: boolean;
+}
+
+/**
+ * Map key for a share subject. Branch share → bare branch; commit share →
+ * `<branch>\0<commitHash>` (NUL can't occur in a ref/hash, so no collision).
+ */
+function recordKey(branch: string, commitHash?: string): string {
+	return commitHash ? `${branch}\u0000${commitHash}` : branch;
+}
+
+interface PersistedShape {
+	readonly version: typeof SHARES_VERSION;
+	readonly branches: Readonly<Record<string, BranchShareRecord>>;
+}
+
+function sharesPath(projectDir: string): string {
+	return join(projectDir, JOLLI_DIR, JOLLIMEMORY_DIR, SHARES_FILE);
+}
+
+function emptyShape(): PersistedShape {
+	return { version: SHARES_VERSION, branches: {} };
+}
+
+async function readAll(projectDir: string): Promise<PersistedShape> {
+	let raw: string;
+	try {
+		raw = await readFile(sharesPath(projectDir), "utf8");
+	} catch (err) {
+		if (!isEnoent(err)) log.warn("readAll read failed: %s", errMsg(err));
+		return emptyShape();
+	}
+	let parsed: Partial<PersistedShape>;
+	try {
+		parsed = JSON.parse(raw) as Partial<PersistedShape>;
+	} catch (err) {
+		log.warn("readAll JSON parse failed: %s", errMsg(err));
+		return emptyShape();
+	}
+	if (parsed.version !== SHARES_VERSION || typeof parsed.branches !== "object" || parsed.branches === null) {
+		log.warn("readAll version/shape mismatch (got %s) — ignoring file", String(parsed.version));
+		return emptyShape();
+	}
+	return { version: SHARES_VERSION, branches: parsed.branches };
+}
+
+async function writeAll(projectDir: string, next: PersistedShape): Promise<void> {
+	const dir = join(projectDir, JOLLI_DIR, JOLLIMEMORY_DIR);
+	await mkdir(dir, { recursive: true });
+	// Shared atomic write (tmpfile + rename) with the Windows EPERM/EACCES overwrite
+	// fallback — rapid Share/Revoke clicks are serialized by writeChains above.
+	await atomicWriteFile(sharesPath(projectDir), JSON.stringify(next, null, "\t"));
+}
+
+// One read-modify-write chain per projectDir — rapid Share/Revoke clicks must
+// not lose updates or collide on the temp filename. Mirrors CommitSelectionStore.
+const writeChains = new Map<string, Promise<void>>();
+
+function serialize<T>(projectDir: string, work: () => Promise<T>): Promise<T> {
+	const prior = writeChains.get(projectDir) ?? Promise.resolve();
+	const next = prior.then(work, work);
+	writeChains.set(
+		projectDir,
+		next.then(
+			() => undefined,
+			() => undefined,
+		),
+	);
+	return next;
+}
+
+/**
+ * Returns the stored share record for a subject, or undefined. Pass `commitHash`
+ * for a commit share; omit it for a branch share.
+ */
+export async function getBranchShare(
+	projectDir: string,
+	branch: string,
+	commitHash?: string,
+): Promise<BranchShareRecord | undefined> {
+	const all = await readAll(projectDir);
+	return all.branches[recordKey(branch, commitHash)];
+}
+
+/** Upserts a subject's share record (preserves the existing `confirmedPublic` flag). */
+export async function putBranchShare(
+	projectDir: string,
+	branch: string,
+	record: Omit<BranchShareRecord, "confirmedPublic">,
+	commitHash?: string,
+): Promise<void> {
+	const key = recordKey(branch, commitHash);
+	return serialize(projectDir, async () => {
+		const all = await readAll(projectDir);
+		const prev = all.branches[key];
+		const branches = { ...all.branches, [key]: { ...record, confirmedPublic: prev?.confirmedPublic } };
+		await writeAll(projectDir, { version: SHARES_VERSION, branches });
+	});
+}
+
+/**
+ * Removes a subject's share record (e.g. after revoke). Idempotent.
+ *
+ * The one-time public-link confirmation (`confirmedPublic`) is independent of the
+ * share's lifecycle, so revoking a share must NOT make the user re-confirm next
+ * time. When the dropped record carried `confirmedPublic`, we keep a blank
+ * placeholder that preserves only that flag rather than deleting the entry.
+ */
+export async function removeBranchShare(projectDir: string, branch: string, commitHash?: string): Promise<void> {
+	const key = recordKey(branch, commitHash);
+	return serialize(projectDir, async () => {
+		const all = await readAll(projectDir);
+		const prev = all.branches[key];
+		if (!prev) return;
+		if (prev.confirmedPublic) {
+			const branches = { ...all.branches, [key]: { ...blankRecord(), confirmedPublic: true } };
+			await writeAll(projectDir, { version: SHARES_VERSION, branches });
+			return;
+		}
+		const { [key]: _drop, ...rest } = all.branches;
+		await writeAll(projectDir, { version: SHARES_VERSION, branches: rest });
+	});
+}
+
+/** Whether the user has acknowledged the public-link confirmation for this branch. */
+export async function isPublicConfirmed(projectDir: string, branch: string): Promise<boolean> {
+	const all = await readAll(projectDir);
+	return all.branches[branch]?.confirmedPublic === true;
+}
+
+/** Records that the user acknowledged the public-link confirmation for this branch. */
+export async function markPublicConfirmed(projectDir: string, branch: string): Promise<void> {
+	return serialize(projectDir, async () => {
+		const all = await readAll(projectDir);
+		const prev = all.branches[branch];
+		const branches = { ...all.branches, [branch]: { ...(prev ?? blankRecord()), confirmedPublic: true } };
+		await writeAll(projectDir, { version: SHARES_VERSION, branches });
+	});
+}
+
+/** A placeholder record for a branch confirmed-public before any share exists. */
+function blankRecord(): BranchShareRecord {
+	return { shareId: "", shareUrl: "", visibility: "public", expiresAt: "", decisionCount: 0 };
+}

--- a/cli/src/core/GitOps.test.ts
+++ b/cli/src/core/GitOps.test.ts
@@ -51,6 +51,7 @@ import {
 	getLastReflogAction,
 	getParentHash,
 	getProjectRootDir,
+	getRepoContributors,
 	getTreeHash,
 	isAncestor,
 	listFilesInBranch,
@@ -417,6 +418,71 @@ describe("GitOps", () => {
 		it("falls back to main when origin/HEAD resolves empty", async () => {
 			mockSuccess("\n");
 			expect(await getDefaultBranch()).toBe("main");
+		});
+	});
+
+	describe("getRepoContributors", () => {
+		it("dedupes by lowercased email, tallies counts, sorts most-commits-first", async () => {
+			mockSuccess(
+				[
+					`Ada Lovelace\x00ada@example.com`,
+					`A. Lovelace\x00ADA@example.com`,
+					`Grace Hopper\x00grace@example.com`,
+					`Ada Lovelace\x00ada@example.com`,
+				].join("\n"),
+			);
+			const contributors = await getRepoContributors();
+			expect(contributors).toEqual([
+				{ name: "Ada Lovelace", email: "ada@example.com", commitCount: 3 },
+				{ name: "Grace Hopper", email: "grace@example.com", commitCount: 1 },
+			]);
+		});
+
+		it("keeps the most recent non-empty name across renames (git log is newest-first)", async () => {
+			mockSuccess(
+				[
+					`\x00bob@example.com`, // newest commit, empty name → fall through
+					`Bob Smith\x00bob@example.com`, // current display name (most recent non-empty)
+					`bob-old\x00bob@example.com`, // oldest name — must not win
+				].join("\n"),
+			);
+			expect(await getRepoContributors()).toEqual([
+				{ name: "Bob Smith", email: "bob@example.com", commitCount: 3 },
+			]);
+		});
+
+		it("returns [] when git log fails (e.g. outside a work tree)", async () => {
+			mockFailure(128, "fatal: not a git repository");
+			expect(await getRepoContributors()).toEqual([]);
+		});
+
+		it("returns [] for a repo with no commits (empty stdout)", async () => {
+			mockSuccess("");
+			expect(await getRepoContributors()).toEqual([]);
+		});
+
+		it("filters out non-deliverable placeholder emails (GitHub noreply)", async () => {
+			mockSuccess(
+				[
+					`Ada Lovelace\x00ada@example.com`,
+					`Bot\x0049699333+dependabot[bot]@users.noreply.github.com`,
+					`Ghost\x00noreply@github.com`,
+					`No Reply\x00no-reply@example.com`,
+				].join("\n"),
+			);
+			expect(await getRepoContributors()).toEqual([
+				{ name: "Ada Lovelace", email: "ada@example.com", commitCount: 1 },
+			]);
+		});
+
+		it("skips lines with no email and tolerates an empty name", async () => {
+			mockSuccess([`malformed-no-nul-line`, `\x00solo@example.com`].join("\n"));
+			expect(await getRepoContributors()).toEqual([{ name: "", email: "solo@example.com", commitCount: 1 }]);
+		});
+
+		it("caps the result at max", async () => {
+			mockSuccess([`A\x00a@x.com`, `B\x00b@x.com`, `C\x00c@x.com`].join("\n"));
+			expect(await getRepoContributors(undefined, 2)).toHaveLength(2);
 		});
 	});
 

--- a/cli/src/core/GitOps.ts
+++ b/cli/src/core/GitOps.ts
@@ -310,6 +310,57 @@ export async function getDefaultBranch(cwd?: string): Promise<string> {
 	return "main";
 }
 
+/** A distinct commit author of the repo, with how many commits they authored. */
+export interface RepoContributor {
+	readonly name: string;
+	readonly email: string;
+	readonly commitCount: number;
+}
+
+/**
+ * Whether an email looks deliverable — i.e. worth offering as a share recipient.
+ * Drops the placeholder addresses git history is full of (GitHub's privacy
+ * `noreply` addresses and the like), which a `mailto:` could never reach.
+ */
+function isDeliverableEmail(email: string): boolean {
+	const e = email.trim().toLowerCase();
+	if (!e.includes("@")) return false;
+	if (e.endsWith(".noreply.github.com") || e === "noreply@github.com") return false;
+	if (e.startsWith("noreply@") || e.startsWith("no-reply@")) return false;
+	return true;
+}
+
+/**
+ * Distinct commit authors of the repo (HEAD's history), most-commits-first — the
+ * people who participated in this repo, as candidate share recipients.
+ *
+ * Read-only and checkout-free; used only as a *source of candidate emails* for the
+ * share "send link to" picker — it never gates access. Deduped by lowercased
+ * email, with non-deliverable placeholder addresses (GitHub `noreply` etc.)
+ * filtered out so we never offer an address a `mailto:` can't reach. `max` caps the
+ * result. Returns `[]` when the repo has no commits or `git log` fails (e.g.
+ * outside a work tree).
+ */
+export async function getRepoContributors(cwd?: string, max = 200): Promise<RepoContributor[]> {
+	const result = await execGit(["log", "--no-merges", "--format=%an%x00%aE"], cwd);
+	if (result.exitCode !== 0) return [];
+	const byEmail = new Map<string, RepoContributor>();
+	for (const line of result.stdout.split("\n")) {
+		const [name, email] = line.split(NUL);
+		if (!email || !isDeliverableEmail(email)) continue;
+		const key = email.trim().toLowerCase();
+		const prev = byEmail.get(key);
+		byEmail.set(key, {
+			// `git log` streams newest-first, so keep the first (most recent) non-empty
+			// name we see — a contributor who has since renamed shows their current name.
+			name: prev?.name || (name?.trim() ?? ""),
+			email: email.trim(),
+			commitCount: (prev?.commitCount ?? 0) + 1,
+		});
+	}
+	return [...byEmail.values()].sort((a, b) => b.commitCount - a.commitCount).slice(0, max);
+}
+
 /**
  * Checks if an orphan branch exists.
  */

--- a/cli/src/core/SessionTitleResolver.test.ts
+++ b/cli/src/core/SessionTitleResolver.test.ts
@@ -48,6 +48,18 @@ describe("resolveSessionTitle", () => {
 		expect(readClaudeAiTitle).toHaveBeenCalledWith("/tmp/x.jsonl");
 	});
 
+	it("skips the Claude ai-title disk read when the session has no transcript path", async () => {
+		// Archived sessions (orphan-branch snapshots) often carry no live
+		// transcriptPath — streaming "" would be a guaranteed-ENOENT fs
+		// round-trip, and it made callers' evidence pipelines timing-sensitive.
+		const result = await resolveSessionTitle(
+			{ sessionId: "s1", transcriptPath: "", updatedAt: "2026-05-15T00:00:00Z", source: "claude" },
+			[{ role: "human", content: "bare turn" }],
+		);
+		expect(result).toBe("bare turn");
+		expect(readClaudeAiTitle).not.toHaveBeenCalled();
+	});
+
 	it("falls back to first-user-message when Claude has no ai-title", async () => {
 		vi.mocked(readClaudeAiTitle).mockResolvedValueOnce(undefined);
 		vi.mocked(readFirstUserMessageTitle).mockResolvedValueOnce("first user msg");

--- a/cli/src/core/SessionTitleResolver.ts
+++ b/cli/src/core/SessionTitleResolver.ts
@@ -55,7 +55,11 @@ export async function resolveSessionTitle(
 	// 2. Source-specific native reader (Claude only for now). `ai-title`
 	// rows are stripped by `parseClaude` in `loadTranscript`, so `mergedEntries`
 	// never contains them — we must keep this independent stream for Claude.
-	if (source === "claude") {
+	// Skipped when the session carries no transcript path (archived sessions
+	// whose live transcript is gone): opening a read stream on "" is a real
+	// fs round-trip that always ENOENTs — pure waste, and it made callers'
+	// evidence pipelines timing-sensitive for nothing.
+	if (source === "claude" && session.transcriptPath) {
 		try {
 			const ai = await readClaudeAiTitle(session.transcriptPath);
 			if (ai && ai.length > 0) {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -252,8 +252,13 @@
 				"category": "Jolli Memory"
 			},
 			{
-				"command": "jollimemory.shareBranchPlaceholder",
+				"command": "jollimemory.shareBranch",
 				"title": "Jolli Memory: Share Branch",
+				"category": "Jolli Memory"
+			},
+			{
+				"command": "jollimemory.shareMemory",
+				"title": "Jolli Memory: Share Memory",
 				"category": "Jolli Memory"
 			}
 		],
@@ -261,6 +266,10 @@
 			"commandPalette": [
 				{
 					"command": "jollimemory.viewKnowledgeGraph",
+					"when": "false"
+				},
+				{
+					"command": "jollimemory.shareMemory",
 					"when": "false"
 				}
 			],

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -1459,7 +1459,8 @@ describe("Extension", () => {
 				"jollimemory.openSettings",
 				"jollimemory.toggleStatus",
 				"jollimemory.reviewNextMemory",
-				"jollimemory.shareBranchPlaceholder",
+				"jollimemory.shareBranch",
+				"jollimemory.shareMemory",
 			];
 
 			for (const cmd of expectedCommands) {

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -321,7 +321,8 @@ const ALL_DECLARED_COMMANDS: ReadonlyArray<string> = [
 	"jollimemory.signOut",
 	"jollimemory.saveAnthropicApiKey",
 	"jollimemory.reviewNextMemory",
-	"jollimemory.shareBranchPlaceholder",
+	"jollimemory.shareBranch",
+	"jollimemory.shareMemory",
 ];
 
 /**
@@ -3232,10 +3233,62 @@ export function activate(context: vscode.ExtensionContext): void {
 			NextMemoryPreviewPanel.show(selection);
 		}),
 
-		// Placeholder for the share-branch feature (not yet implemented).
-		vscode.commands.registerCommand("jollimemory.shareBranchPlaceholder", () => {
-			vscode.window.showInformationMessage("Sharing is coming soon.");
+		// Sidebar footer "Share" → the in-panel "Share this branch" modal. The
+		// modal lives in the summary panel's webview, so this opens the NEWEST
+		// branch memory's panel as the host (the share content is branch-wide —
+		// base..HEAD — regardless of which memory hosts the modal; newest matches
+		// the share's headCommitHash and the "share current branch state" intent).
+		vscode.commands.registerCommand("jollimemory.shareBranch", async () => {
+			const { summaries } = await loadBranchSummaries(
+				bridge,
+				commitsStore.getMainBranch(),
+			);
+			const newest = summaries.at(-1);
+			if (!newest) {
+				vscode.window.showInformationMessage(
+					"Jolli Memory: No memories on this branch to share yet.",
+				);
+				return;
+			}
+			const readStorageResult = await bridge.createReadStorageForCurrentRepo();
+			await SummaryWebviewPanel.showWithShareModal(
+				newest,
+				context.extensionUri,
+				workspaceRoot,
+				bridge,
+				commitsStore.getMainBranch(),
+				"branch",
+				readStorageResult?.storage ?? null,
+			);
 		}),
+
+		// Committed-memory row "Share this memory" icon → the same in-panel modal
+		// in commit kind. Workspace rows only: sharing always targets the current
+		// workspace (the panel's foreign guard denies share commands anyway), so a
+		// hash that doesn't resolve in this repo's storage gets a clear message.
+		vscode.commands.registerCommand(
+			"jollimemory.shareMemory",
+			async (item: MemoryItem | string) => {
+				const hash = typeof item === "string" ? item : item.entry.commitHash;
+				const summary = await bridge.getSummary(hash);
+				if (!summary) {
+					vscode.window.showInformationMessage(
+						"Jolli Memory: Sharing works from the memory's own repository — open that workspace to share it.",
+					);
+					return;
+				}
+				const readStorageResult = await bridge.createReadStorageForCurrentRepo();
+				await SummaryWebviewPanel.showWithShareModal(
+					summary,
+					context.extensionUri,
+					workspaceRoot,
+					bridge,
+					commitsStore.getMainBranch(),
+					"commit",
+					readStorageResult?.storage ?? null,
+				);
+			},
+		),
 
 		// Open in Claude Code via URI scheme. Same cross-repo reasoning as
 		// copyRecallPrompt above — MemoryItem rows may belong to a non-current

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -2562,6 +2562,11 @@ export class JolliMemoryBridge {
 		return (await tryExecGit(["config", "user.name"], this.cwd)).trim();
 	}
 
+	/** Returns the git user.email configured for this repo (empty string if unset). */
+	async getCurrentUserEmail(): Promise<string> {
+		return (await tryExecGit(["config", "user.email"], this.cwd)).trim();
+	}
+
 	/** Returns the current branch name. */
 	async getCurrentBranch(): Promise<string> {
 		return (

--- a/vscode/src/services/BranchShareController.test.ts
+++ b/vscode/src/services/BranchShareController.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+	getBranchShare: vi.fn(),
+	putBranchShare: vi.fn(),
+	removeBranchShare: vi.fn(),
+	revokeBranchShare: vi.fn(),
+	updateBranchShareExpiry: vi.fn(),
+	updateLiveShare: vi.fn(),
+}));
+
+vi.mock("../../../cli/src/core/BranchShareStore.js", () => ({
+	getBranchShare: h.getBranchShare,
+	putBranchShare: h.putBranchShare,
+	removeBranchShare: h.removeBranchShare,
+	isPublicConfirmed: vi.fn(),
+	markPublicConfirmed: vi.fn(),
+}));
+vi.mock("./JolliShareService.js", () => ({
+	revokeBranchShare: h.revokeBranchShare,
+	updateBranchShareExpiry: h.updateBranchShareExpiry,
+	updateLiveShare: h.updateLiveShare,
+}));
+
+import { revokeBranchShareForBranch, setBranchShareExpiry, setBranchShareVisibility } from "./BranchShareController.js";
+
+beforeEach(() => {
+	for (const fn of Object.values(h)) fn.mockReset();
+});
+
+describe("revokeBranchShareForBranch", () => {
+	it("revokes the server share and clears the local record", async () => {
+		h.getBranchShare.mockResolvedValue({ shareId: "sh_1" });
+		await revokeBranchShareForBranch("/repo", "feature/x", "KEY");
+		expect(h.revokeBranchShare).toHaveBeenCalledWith(undefined, "KEY", "sh_1");
+		expect(h.removeBranchShare).toHaveBeenCalledWith("/repo", "feature/x", undefined);
+	});
+
+	it("revokes a commit share under its commit key", async () => {
+		const commitHash = "c".repeat(40);
+		h.getBranchShare.mockResolvedValue({ shareId: "sh_2" });
+		await revokeBranchShareForBranch("/repo", "feature/x", "KEY", commitHash);
+		expect(h.getBranchShare).toHaveBeenCalledWith("/repo", "feature/x", commitHash);
+		expect(h.revokeBranchShare).toHaveBeenCalledWith(undefined, "KEY", "sh_2");
+		expect(h.removeBranchShare).toHaveBeenCalledWith("/repo", "feature/x", commitHash);
+	});
+
+	it("skips the server call when there is no stored share", async () => {
+		h.getBranchShare.mockResolvedValue(undefined);
+		await revokeBranchShareForBranch("/repo", "feature/x", "KEY");
+		expect(h.revokeBranchShare).not.toHaveBeenCalled();
+		expect(h.removeBranchShare).toHaveBeenCalledWith("/repo", "feature/x", undefined);
+	});
+
+	it("skips the server call for a confirm-only placeholder (empty shareId)", async () => {
+		h.getBranchShare.mockResolvedValue({ shareId: "" });
+		await revokeBranchShareForBranch("/repo", "feature/x", "KEY");
+		expect(h.revokeBranchShare).not.toHaveBeenCalled();
+		expect(h.removeBranchShare).toHaveBeenCalledWith("/repo", "feature/x", undefined);
+	});
+});
+
+describe("setBranchShareExpiry", () => {
+	const EXPIRES = "2026-10-01T00:00:00.000Z";
+
+	it("PATCHes the share and preserves the live ref/visibility with the new expiry", async () => {
+		const ref = {
+			kind: "branchCollection" as const,
+			relativePath: "feature/x",
+			covered: [{ commitHash: "a".repeat(40), summaryDocId: 11, attachmentDocIds: [12] }],
+		};
+		h.getBranchShare.mockResolvedValue({
+			shareId: "sh_1",
+			shareUrl: "https://acme.jolli.ai/b/x",
+			visibility: "org",
+			ref,
+			headCommitHash: "a".repeat(40),
+			decisionCount: 4,
+		});
+		h.updateBranchShareExpiry.mockResolvedValue({ shareId: "sh_1", expiresAt: EXPIRES, visibility: "org" });
+
+		const out = await setBranchShareExpiry("/repo", "feature/x", "KEY", EXPIRES);
+
+		expect(out).toBe(EXPIRES);
+		expect(h.updateBranchShareExpiry).toHaveBeenCalledWith(undefined, "KEY", "sh_1", EXPIRES);
+		const [, , record] = h.putBranchShare.mock.calls[0];
+		expect(record).toMatchObject({
+			shareId: "sh_1",
+			visibility: "org",
+			ref,
+			expiresAt: EXPIRES, // server-confirmed new value
+		});
+	});
+
+	it("no-ops when there is no stored share", async () => {
+		h.getBranchShare.mockResolvedValue(undefined);
+		const out = await setBranchShareExpiry("/repo", "feature/x", "KEY", EXPIRES);
+		expect(out).toBeUndefined();
+		expect(h.updateBranchShareExpiry).not.toHaveBeenCalled();
+	});
+});
+
+describe("setBranchShareVisibility", () => {
+	const ref = {
+		kind: "branchCollection" as const,
+		relativePath: "feature/x",
+		covered: [{ commitHash: "a".repeat(40), summaryDocId: 11, attachmentDocIds: [12] }],
+	};
+	const EXISTING = {
+		shareId: "sh_1",
+		shareUrl: "https://acme.jolli.ai/b/x",
+		visibility: "public" as const,
+		token8: "tok_olde",
+		recipients: ["a@x.com"],
+		ref,
+		headCommitHash: "a".repeat(40),
+		expiresAt: "2026-09-01T00:00:00.000Z",
+		decisionCount: 4,
+		titles: ["A"],
+	};
+
+	it("public→org: PATCHes and persists the server URL/visibility, dropping the bearer token", async () => {
+		h.getBranchShare.mockResolvedValue(EXISTING);
+		// org switch returns no token (auth-gated link).
+		h.updateLiveShare.mockResolvedValue({
+			shareId: "sh_1",
+			shareUrl: "https://acme.jolli.ai/org/view/1",
+			expiresAt: "2026-10-01T00:00:00.000Z",
+			visibility: "org",
+		});
+
+		const out = await setBranchShareVisibility("/repo", "feature/x", "KEY", "org");
+
+		expect(out).toBe("org");
+		expect(h.updateLiveShare).toHaveBeenCalledWith(undefined, "KEY", "sh_1", { visibility: "org" });
+		const [, , record] = h.putBranchShare.mock.calls[0];
+		expect(record).toMatchObject({
+			shareId: "sh_1",
+			shareUrl: "https://acme.jolli.ai/org/view/1",
+			visibility: "org",
+			ref,
+		});
+		expect(record.token8).toBeUndefined();
+	});
+
+	it("org→public: persists the freshly minted bearer token (first 8 chars)", async () => {
+		h.getBranchShare.mockResolvedValue({ ...EXISTING, visibility: "org" });
+		h.updateLiveShare.mockResolvedValue({
+			shareId: "sh_1",
+			shareUrl: "https://acme.jolli.ai/b/x",
+			expiresAt: "2026-10-01T00:00:00.000Z",
+			visibility: "public",
+			token: "tok_abcdef_long",
+		});
+
+		await setBranchShareVisibility("/repo", "feature/x", "KEY", "public");
+
+		const [, , record] = h.putBranchShare.mock.calls[0];
+		expect(record).toMatchObject({ visibility: "public", token8: "tok_abcd" });
+	});
+
+	it("→people: sends the allowlist, persists the echo, keeps the URL on a recipients-only PATCH", async () => {
+		const recipients = ["b@x.com", "c@x.com"];
+		h.getBranchShare.mockResolvedValue(EXISTING);
+		// A recipients-only PATCH doesn't re-mint the link — the server omits shareUrl.
+		h.updateLiveShare.mockResolvedValue({
+			shareId: "sh_1",
+			expiresAt: "2026-10-01T00:00:00.000Z",
+			visibility: "people",
+			recipients,
+		});
+
+		const out = await setBranchShareVisibility("/repo", "feature/x", "KEY", "people", undefined, recipients);
+
+		expect(out).toBe("people");
+		expect(h.updateLiveShare).toHaveBeenCalledWith(undefined, "KEY", "sh_1", { visibility: "people", recipients });
+		const [, , record] = h.putBranchShare.mock.calls[0];
+		expect(record.shareUrl).toBe(EXISTING.shareUrl); // existing URL survives the omitted field
+		expect(record.recipients).toEqual(recipients); // server-confirmed allowlist replaces the local one
+	});
+
+	it("preserves unchanged cached fields when a visibility PATCH returns only changed fields", async () => {
+		h.getBranchShare.mockResolvedValue(EXISTING);
+		h.updateLiveShare.mockResolvedValue({ visibility: "public" });
+
+		const out = await setBranchShareVisibility("/repo", "feature/x", "KEY", "public");
+
+		expect(out).toBe("public");
+		const [, , record] = h.putBranchShare.mock.calls[0];
+		expect(record).toMatchObject({
+			shareId: EXISTING.shareId,
+			shareUrl: EXISTING.shareUrl,
+			visibility: "public",
+			token8: EXISTING.token8,
+			expiresAt: EXISTING.expiresAt,
+			ref,
+			headCommitHash: EXISTING.headCommitHash,
+			decisionCount: EXISTING.decisionCount,
+			titles: EXISTING.titles,
+		});
+	});
+
+	it("no-ops when there is no stored share", async () => {
+		h.getBranchShare.mockResolvedValue(undefined);
+		const out = await setBranchShareVisibility("/repo", "feature/x", "KEY", "org");
+		expect(out).toBeUndefined();
+		expect(h.updateLiveShare).not.toHaveBeenCalled();
+	});
+
+	it("no-ops for a confirm-only placeholder (empty shareId)", async () => {
+		h.getBranchShare.mockResolvedValue({ shareId: "" });
+		const out = await setBranchShareVisibility("/repo", "feature/x", "KEY", "org");
+		expect(out).toBeUndefined();
+		expect(h.updateLiveShare).not.toHaveBeenCalled();
+	});
+
+	it("keys a commit share by its commit hash", async () => {
+		const commitHash = "c".repeat(40);
+		h.getBranchShare.mockResolvedValue({ ...EXISTING, commitHash });
+		h.updateLiveShare.mockResolvedValue({
+			shareId: "sh_1",
+			shareUrl: "https://acme.jolli.ai/b/x",
+			expiresAt: "2026-10-01T00:00:00.000Z",
+			visibility: "org",
+		});
+		await setBranchShareVisibility("/repo", "feature/x", "KEY", "org", commitHash);
+		expect(h.getBranchShare).toHaveBeenCalledWith("/repo", "feature/x", commitHash);
+		expect(h.putBranchShare).toHaveBeenCalledWith("/repo", "feature/x", expect.any(Object), commitHash);
+	});
+});

--- a/vscode/src/services/BranchShareController.ts
+++ b/vscode/src/services/BranchShareController.ts
@@ -1,0 +1,121 @@
+/**
+ * BranchShareController
+ *
+ * Share lifecycle helpers shared by the modal: revoke a share and adjust its
+ * expiry. Pure orchestration — no VS Code/webview dependency — so it is
+ * unit-testable. Creation lives in `LiveShareController` (live, Space-backed);
+ * the old snapshot create path has been removed.
+ */
+
+import {
+	getBranchShare,
+	isPublicConfirmed,
+	markPublicConfirmed,
+	putBranchShare,
+	removeBranchShare,
+} from "../../../cli/src/core/BranchShareStore.js";
+import { revokeBranchShare, updateBranchShareExpiry, updateLiveShare } from "./JolliShareService.js";
+
+/** Access level for a live share. */
+type ShareVisibility = "public" | "org" | "people";
+
+/** Revokes a subject's share (if any) and clears the local record. Idempotent. */
+export async function revokeBranchShareForBranch(
+	workspaceRoot: string,
+	branch: string,
+	apiKey: string,
+	commitHash?: string,
+): Promise<void> {
+	const existing = await getBranchShare(workspaceRoot, branch, commitHash);
+	if (existing?.shareId) {
+		await revokeBranchShare(undefined, apiKey, existing.shareId);
+	}
+	await removeBranchShare(workspaceRoot, branch, commitHash);
+}
+
+/**
+ * Adjusts an existing share's expiry (absolute ISO `expiresAt`) via PATCH and
+ * mirrors the server-confirmed value into the local record, **preserving** the
+ * live reference (`ref`), visibility, and local recipient list. Returns the new
+ * `expiresAt`, or `undefined` when there is no share to patch.
+ */
+export async function setBranchShareExpiry(
+	workspaceRoot: string,
+	branch: string,
+	apiKey: string,
+	expiresAt: string,
+	commitHash?: string,
+): Promise<string | undefined> {
+	const existing = await getBranchShare(workspaceRoot, branch, commitHash);
+	if (!existing?.shareId) return undefined;
+	const result = await updateBranchShareExpiry(undefined, apiKey, existing.shareId, expiresAt);
+	await putBranchShare(
+		workspaceRoot,
+		branch,
+		{
+			shareId: existing.shareId,
+			shareUrl: existing.shareUrl,
+			visibility: existing.visibility,
+			ref: existing.ref,
+			token8: existing.token8,
+			recipients: existing.recipients,
+			headCommitHash: existing.headCommitHash,
+			expiresAt: result.expiresAt,
+			decisionCount: existing.decisionCount,
+			titles: existing.titles,
+			commitHash: existing.commitHash,
+		},
+		commitHash,
+	);
+	return result.expiresAt;
+}
+
+/**
+ * Changes an existing share's audience — access level (`public` / `org` / `people`) and,
+ * for `people`, the `recipients` allowlist — via PATCH, mirroring the server-confirmed
+ * values into the local record. Switching to/from `public` re-mints (or drops) the bearer
+ * link, so the returned `shareUrl`/`token` can change — all are persisted. Returns the new
+ * visibility, or `undefined` when there is no share.
+ */
+export async function setBranchShareVisibility(
+	workspaceRoot: string,
+	branch: string,
+	apiKey: string,
+	visibility: ShareVisibility,
+	commitHash?: string,
+	recipients?: ReadonlyArray<string>,
+): Promise<ShareVisibility | undefined> {
+	const existing = await getBranchShare(workspaceRoot, branch, commitHash);
+	if (!existing?.shareId) return undefined;
+	const result = await updateLiveShare(undefined, apiKey, existing.shareId, {
+		visibility,
+		...(recipients && { recipients }),
+	});
+	const nextVisibility = result.visibility ?? visibility;
+	const token8 = result.token ? result.token.slice(0, 8) : nextVisibility === "public" ? existing.token8 : undefined;
+	const nextRecipients = result.recipients ?? (nextVisibility === "people" ? recipients ?? existing.recipients : undefined);
+	await putBranchShare(
+		workspaceRoot,
+		branch,
+		{
+			shareId: String(result.shareId ?? existing.shareId),
+			// A recipients-only PATCH doesn't re-mint the link, so the server may omit
+			// `shareUrl` — keep the existing one in that case.
+			shareUrl: result.shareUrl || existing.shareUrl,
+			visibility: nextVisibility,
+			ref: existing.ref,
+			...(token8 ? { token8 } : {}),
+			...(nextRecipients ? { recipients: nextRecipients } : {}),
+			headCommitHash: existing.headCommitHash,
+			expiresAt: result.expiresAt ?? existing.expiresAt,
+			decisionCount: existing.decisionCount,
+			titles: existing.titles,
+			commitHash: existing.commitHash,
+		},
+		commitHash,
+	);
+	return nextVisibility;
+}
+
+/** Re-exports the persistence reads the panel/modal need when (re)opening the modal. */
+export { getBranchShare, isPublicConfirmed, markPublicConfirmed };

--- a/vscode/src/services/BranchShareModal.commitVsBranch.test.ts
+++ b/vscode/src/services/BranchShareModal.commitVsBranch.test.ts
@@ -1,0 +1,159 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommitSummary } from "../../../cli/src/Types.js";
+
+// Real BranchShareStore + BranchShareController + LiveShareController + BranchShareModal;
+// mock only the network (JolliShareService), the push orchestrator, and git/summary
+// metadata. Verifies that a commit share and a branch share on the same branch are
+// DISTINCT live shares (distinct store records + URLs), and reopening the branch
+// share re-serves the branch's own URL.
+const h = vi.hoisted(() => ({
+	push: vi.fn(),
+	createLiveShare: vi.fn(),
+	updateLiveShare: vi.fn(),
+	revokeBranchShare: vi.fn(),
+	updateBranchShareExpiry: vi.fn(),
+	loadBranchSummaries: vi.fn(),
+	getDefaultBranch: vi.fn(),
+	getCanonicalRepoUrl: vi.fn(),
+	extractRepoName: vi.fn(),
+	slugify: vi.fn(),
+}));
+
+vi.mock("./JolliShareService.js", () => ({
+	createLiveShare: h.createLiveShare,
+	updateLiveShare: h.updateLiveShare,
+	revokeBranchShare: h.revokeBranchShare,
+	updateBranchShareExpiry: h.updateBranchShareExpiry,
+}));
+vi.mock("./JolliPushOrchestrator.js", () => ({
+	pushSummaryWithAttachments: h.push,
+	ShareBindingError: class ShareBindingError extends Error {},
+}));
+vi.mock("../views/BranchSummaryLoader.js", () => ({ loadBranchSummaries: h.loadBranchSummaries }));
+vi.mock("../../../cli/src/core/GitOps.js", () => ({ getDefaultBranch: h.getDefaultBranch }));
+vi.mock("../util/GitRemoteUtils.js", () => ({ getCanonicalRepoUrl: h.getCanonicalRepoUrl }));
+vi.mock("../../../cli/src/core/KBPathResolver.js", () => ({ extractRepoName: h.extractRepoName }));
+vi.mock("../../../cli/src/core/SummaryExporter.js", () => ({ slugify: h.slugify }));
+vi.mock("../../../cli/src/core/SummaryStore.js", () => ({ resolveEffectiveTopics: () => [] }));
+vi.mock("../views/SummaryUtils.js", () => ({ buildBranchRelativePath: (b: string) => b }));
+vi.mock("../../../cli/src/core/JolliApiUtils.js", () => ({
+	parseJolliApiKey: () => ({ u: "https://acme.jolli.ai" }),
+	assertJolliOriginAllowed: vi.fn(),
+}));
+vi.mock("../util/Logger.js", () => ({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }));
+
+import { getBranchShare } from "../../../cli/src/core/BranchShareStore.js";
+import { createShareModal, openShareModal, type ShareModalContext, type ShareModalIO } from "./BranchShareModal.js";
+
+const BRANCH = "feature/x";
+const TIP = "z".repeat(40);
+const OLDER = "x".repeat(40);
+const COMMIT_URL = "https://acme.jolli.ai/b/COMMIT";
+const BRANCH_URL = "https://acme.jolli.ai/b/BRANCH";
+
+function summary(commitHash: string): CommitSummary {
+	return { commitHash, branch: BRANCH, commitMessage: "m", topics: [], plans: [], notes: [] } as unknown as CommitSummary;
+}
+
+function makeIO(): ShareModalIO & { states: Array<{ kind: string; shareUrl?: string }> } {
+	const states: Array<{ kind: string; shareUrl?: string }> = [];
+	return {
+		states,
+		postState: vi.fn((s) => states.push(s as { kind: string })),
+		openUrl: vi.fn().mockResolvedValue(undefined),
+		composeEmail: vi.fn().mockResolvedValue(undefined),
+		copyMessage: vi.fn().mockResolvedValue(undefined),
+		openSocial: vi.fn().mockResolvedValue(undefined),
+		formatExpiry: vi.fn(() => "expires"),
+		notifyError: vi.fn(),
+		notifyInfo: vi.fn(),
+	};
+}
+
+let cwd: string;
+const ctx = (over: Partial<ShareModalContext>): ShareModalContext => ({
+	workspaceRoot: cwd,
+	branch: BRANCH,
+	apiKey: "KEY",
+	subjectTitle: BRANCH,
+	visibility: "public",
+	recipients: [],
+	canOrg: false,
+	owner: { name: "Dev", email: "dev@example.com" },
+	directory: [],
+	bridge: { storeSummary: vi.fn() } as never,
+	resolveBinding: vi.fn(),
+	...over,
+});
+
+beforeEach(async () => {
+	cwd = await mkdtemp(join(tmpdir(), "share-live-"));
+	for (const fn of Object.values(h)) fn.mockReset();
+	h.getDefaultBranch.mockResolvedValue("main");
+	h.getCanonicalRepoUrl.mockResolvedValue("https://github.com/acme/repo");
+	h.extractRepoName.mockReturnValue("repo");
+	h.slugify.mockReturnValue("feature-x");
+	h.loadBranchSummaries.mockResolvedValue({ summaries: [summary(OLDER), summary(TIP)], missingCount: 0 });
+	h.push.mockImplementation((s: CommitSummary) =>
+		Promise.resolve({
+			pushedDoc: { commitHash: s.commitHash, summaryDocId: 100, plans: [], notes: [] },
+			updatedSummary: s,
+			attachmentFailures: [],
+			isUpdate: false,
+			attachmentCount: 0,
+		}),
+	);
+});
+
+afterEach(async () => {
+	await rm(cwd, { recursive: true, force: true });
+});
+
+describe("commit share then branch share (live)", () => {
+	it("creates two DISTINCT live shares (commit vs branch) keyed + URL'd separately", async () => {
+		h.createLiveShare
+			.mockResolvedValueOnce({ shareId: 1, shareUrl: COMMIT_URL, expiresAt: "2099-01-01T00:00:00Z", visibility: "public", token: "tok_commit" })
+			.mockResolvedValueOnce({ shareId: 2, shareUrl: BRANCH_URL, expiresAt: "2099-01-01T00:00:00Z", visibility: "public", token: "tok_branch" });
+
+		// 1) Share the OLDER commit.
+		const io1 = makeIO();
+		await createShareModal(io1, ctx({ commitHash: OLDER }));
+
+		// 2) Share the whole branch.
+		const io2 = makeIO();
+		await createShareModal(io2, ctx({ commitHash: undefined }));
+
+		expect(h.createLiveShare).toHaveBeenCalledTimes(2);
+		expect(h.createLiveShare.mock.calls[0][2]).toMatchObject({ kind: "commit", headCommitHash: OLDER });
+		expect(h.createLiveShare.mock.calls[1][2]).toMatchObject({ kind: "branch", headCommitHash: TIP });
+
+		// Distinct persisted records: commit-keyed vs branch-keyed, with distinct URLs.
+		expect((await getBranchShare(cwd, BRANCH, OLDER))?.shareUrl).toBe(COMMIT_URL);
+		expect((await getBranchShare(cwd, BRANCH))?.shareUrl).toBe(BRANCH_URL);
+	});
+
+	it("reopening the branch share re-serves the BRANCH url (not the commit's)", async () => {
+		h.createLiveShare
+			.mockResolvedValueOnce({ shareId: 2, shareUrl: BRANCH_URL, expiresAt: "2099-01-01T00:00:00Z", visibility: "public", token: "tok_branch" })
+			.mockResolvedValueOnce({ shareId: 1, shareUrl: COMMIT_URL, expiresAt: "2099-01-01T00:00:00Z", visibility: "public", token: "tok_commit" });
+
+		// 1) Branch share first.
+		const io1 = makeIO();
+		await createShareModal(io1, ctx({ commitHash: undefined }));
+
+		// 2) Commit share.
+		const io2 = makeIO();
+		await createShareModal(io2, ctx({ commitHash: OLDER }));
+
+		// 3) Reopen the branch share → re-serves the BRANCH url, no regenerate.
+		h.createLiveShare.mockClear();
+		const io3 = makeIO();
+		await openShareModal(io3, ctx({ commitHash: undefined }));
+		const ready = io3.states.find((s) => s.kind === "ready");
+		expect(ready?.shareUrl).toBe(BRANCH_URL);
+		expect(h.createLiveShare).not.toHaveBeenCalled();
+	});
+});

--- a/vscode/src/services/BranchShareModal.test.ts
+++ b/vscode/src/services/BranchShareModal.test.ts
@@ -1,0 +1,554 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+	getBranchShare: vi.fn(),
+	isPublicConfirmed: vi.fn(),
+	markPublicConfirmed: vi.fn(),
+	revokeBranchShareForBranch: vi.fn(),
+	setBranchShareExpiry: vi.fn(),
+	setBranchShareVisibility: vi.fn(),
+	generateLiveShare: vi.fn(),
+	reconcileLiveShare: vi.fn(),
+}));
+
+vi.mock("./BranchShareController.js", () => ({
+	getBranchShare: h.getBranchShare,
+	isPublicConfirmed: h.isPublicConfirmed,
+	markPublicConfirmed: h.markPublicConfirmed,
+	revokeBranchShareForBranch: h.revokeBranchShareForBranch,
+	setBranchShareExpiry: h.setBranchShareExpiry,
+	setBranchShareVisibility: h.setBranchShareVisibility,
+}));
+vi.mock("./LiveShareController.js", () => ({
+	generateLiveShare: h.generateLiveShare,
+	reconcileLiveShare: h.reconcileLiveShare,
+	NothingToShareError: class NothingToShareError extends Error {},
+}));
+vi.mock("./JolliPushOrchestrator.js", () => ({
+	ShareBindingError: class ShareBindingError extends Error {
+		readonly outcome: string;
+		constructor(outcome: string) {
+			super(`Space binding ${outcome}`);
+			this.name = "ShareBindingError";
+			this.outcome = outcome;
+		}
+	},
+}));
+
+import { ShareBindingError } from "./JolliPushOrchestrator.js";
+import { NothingToShareError } from "./LiveShareController.js";
+import {
+	createShareModal,
+	deriveShareCollaborators,
+	openShareModal,
+	revokeShareModal,
+	setShareExpiryModal,
+	setShareVisibilityModal,
+	type ShareMember,
+	type ShareModalContext,
+	type ShareModalIO,
+	shareModalTarget,
+} from "./BranchShareModal.js";
+
+const NOW_MS = Date.parse("2026-06-25T00:00:00.000Z");
+const OWNER: ShareMember = { name: "Ada", email: "ada@example.com" };
+const DIRECTORY: ShareMember[] = [
+	{ name: "Ada", email: "ada@example.com" },
+	{ name: "Bo", email: "bo@example.com" },
+];
+/** Collaborators for a share with no recipients: just the owner row. */
+const OWNER_ROWS = [{ name: "Ada", email: "ada@example.com", isOwner: true }];
+const CTX: ShareModalContext = {
+	workspaceRoot: "/repo",
+	branch: "feature/x",
+	apiKey: "KEY",
+	subjectTitle: "feature/x",
+	visibility: "public",
+	recipients: [],
+	canOrg: true,
+	owner: OWNER,
+	directory: DIRECTORY,
+	bridge: {} as never,
+	resolveBinding: vi.fn(),
+	nowMs: NOW_MS,
+};
+const URL = "https://acme.jolli.ai/b/x";
+const EXPIRES = "2026-09-01T00:00:00.000Z"; // 68 days after NOW_MS
+/** A stored live record, as getBranchShare would return after a successful generate. */
+const RECORD = { shareId: "sh", shareUrl: URL, expiresAt: EXPIRES, decisionCount: 4, visibility: "public" as const };
+
+function makeIO(): ShareModalIO & { states: Array<unknown> } {
+	const states: Array<unknown> = [];
+	return {
+		states,
+		postState: vi.fn((s) => states.push(s)),
+		openUrl: vi.fn().mockResolvedValue(undefined),
+		composeEmail: vi.fn().mockResolvedValue(undefined),
+		copyMessage: vi.fn().mockResolvedValue(undefined),
+		openSocial: vi.fn().mockResolvedValue(undefined),
+		notifyError: vi.fn(),
+		notifyInfo: vi.fn(),
+		formatExpiry: vi.fn(() => "expires Sep 1, 2026"),
+	};
+}
+
+beforeEach(() => {
+	for (const fn of Object.values(h)) fn.mockReset();
+	h.getBranchShare.mockResolvedValue(undefined);
+	h.isPublicConfirmed.mockResolvedValue(false);
+	h.generateLiveShare.mockResolvedValue({ shareId: "sh", shareUrl: URL, expiresAt: EXPIRES, visibility: "public" });
+	h.reconcileLiveShare.mockResolvedValue(undefined);
+});
+
+describe("deriveShareCollaborators", () => {
+	it("puts the owner first (flagged) then one row per recipient, names resolved from the directory", () => {
+		const rows = deriveShareCollaborators(OWNER, ["bo@example.com", "ext@gmail.com"], DIRECTORY);
+		expect(rows).toEqual([
+			{ name: "Ada", email: "ada@example.com", isOwner: true },
+			{ name: "Bo", email: "bo@example.com", isOwner: false },
+			{ name: "ext@gmail.com", email: "ext@gmail.com", isOwner: false },
+		]);
+	});
+
+	it("de-dupes the owner and repeated recipients (case-insensitive)", () => {
+		const rows = deriveShareCollaborators(OWNER, ["ADA@example.com", "bo@example.com", "BO@example.com"], DIRECTORY);
+		expect(rows.map((r) => r.email)).toEqual(["ada@example.com", "bo@example.com"]);
+	});
+
+	it("owner-only when there are no recipients", () => {
+		expect(deriveShareCollaborators(OWNER, [], DIRECTORY)).toEqual([
+			{ name: "Ada", email: "ada@example.com", isOwner: true },
+		]);
+	});
+
+	it("skips blank recipient entries", () => {
+		const rows = deriveShareCollaborators(OWNER, ["", "  ", "bo@example.com"], DIRECTORY);
+		expect(rows.map((r) => r.email)).toEqual(["ada@example.com", "bo@example.com"]);
+	});
+
+	it("falls back to the email as the owner name when unnamed", () => {
+		const rows = deriveShareCollaborators({ name: "", email: "x@y.com" }, [], []);
+		expect(rows[0]).toEqual({ name: "x@y.com", email: "x@y.com", isOwner: true });
+	});
+});
+
+describe("openShareModal — re-show existing", () => {
+	it("shows needsApiKey when no key", async () => {
+		const io = makeIO();
+		await openShareModal(io, { ...CTX, apiKey: undefined });
+		expect(io.states).toEqual([{ kind: "needsApiKey" }]);
+	});
+
+	it("re-shows an existing live share as ready (never re-syncs)", async () => {
+		h.getBranchShare.mockResolvedValue({ ...RECORD, decisionCount: 7 });
+		const io = makeIO();
+		await openShareModal(io, CTX);
+		expect(io.states[0]).toEqual({
+			kind: "ready",
+			branch: "feature/x",
+			subject: "feature/x",
+			subjectTitle: "feature/x",
+			shareUrl: URL,
+			expiresLabel: "expires Sep 1, 2026",
+			expiryDays: 68,
+			decisionCount: 7,
+			visibility: "public",
+			canOrg: true,
+			recipients: [],
+			orgMembers: DIRECTORY,
+			collaborators: OWNER_ROWS,
+		});
+		expect(h.generateLiveShare).not.toHaveBeenCalled();
+	});
+
+	it("reconciles an existing branch share before showing (live shares render current base..HEAD)", async () => {
+		const rec = { ...RECORD, ref: { kind: "branchCollection", relativePath: "feature/x", covered: [] } };
+		h.getBranchShare.mockResolvedValue(rec);
+		const io = makeIO();
+		await openShareModal(io, CTX);
+		expect(h.reconcileLiveShare).toHaveBeenCalledWith(
+			expect.objectContaining({ workspaceRoot: "/repo", apiKey: "KEY" }),
+			"feature/x",
+		);
+		expect(io.states[0]).toEqual({ kind: "loading", label: "Syncing to Jolli…" });
+		expect(io.states.at(-1)).toMatchObject({ kind: "ready", shareUrl: URL });
+	});
+
+	it("reconcile failure is non-fatal — surfaces a toast and still shows the cached record", async () => {
+		const rec = { ...RECORD, ref: { kind: "branchCollection", relativePath: "feature/x", covered: [] } };
+		h.getBranchShare.mockResolvedValue(rec);
+		h.reconcileLiveShare.mockRejectedValue(new Error("net down"));
+		const io = makeIO();
+		await openShareModal(io, CTX);
+		expect(io.notifyError).toHaveBeenCalledWith(expect.stringContaining("net down"));
+		expect(io.states.at(-1)).toMatchObject({ kind: "ready", shareUrl: URL });
+	});
+
+	it("does NOT reconcile a commit share (fixed doc list) or a ref-less record", async () => {
+		const commitHash = "c".repeat(40);
+		h.getBranchShare.mockResolvedValue({
+			...RECORD,
+			ref: { kind: "branchCollection", relativePath: "feature/x", covered: [] },
+		});
+		const io = makeIO();
+		await openShareModal(io, { ...CTX, commitHash });
+		expect(h.reconcileLiveShare).not.toHaveBeenCalled();
+		expect(io.states.at(-1)).toMatchObject({ kind: "ready" });
+	});
+
+	it("ready carries the commit message as subjectTitle for a commit share", async () => {
+		h.getBranchShare.mockResolvedValue(RECORD);
+		const io = makeIO();
+		await openShareModal(io, { ...CTX, commitHash: "c".repeat(40), subjectTitle: "fix: the thing" });
+		expect(io.states.at(-1)).toMatchObject({ kind: "ready", subjectTitle: "fix: the thing" });
+	});
+
+	it("ready expiry: a missing/unparseable expiresAt resolves to 0 days (still served)", async () => {
+		h.getBranchShare.mockResolvedValue({ ...RECORD, expiresAt: undefined });
+		const io = makeIO();
+		await openShareModal(io, CTX);
+		expect(io.states.at(-1)).toMatchObject({ kind: "ready", expiryDays: 0 });
+	});
+
+	it("refuses to render a cached share URL from an untrusted origin", async () => {
+		h.getBranchShare.mockResolvedValue({ ...RECORD, shareUrl: "https://evil.example/b/x" });
+		const io = makeIO();
+		await openShareModal(io, CTX);
+		expect(io.states.at(-1)).toMatchObject({ kind: "error", message: expect.stringContaining("not trusted") });
+		expect(h.generateLiveShare).not.toHaveBeenCalled();
+	});
+});
+
+describe("openShareModal — create confirmation", () => {
+	it("shows a create confirmation instead of generating a new link on open", async () => {
+		const io = makeIO();
+		await openShareModal(io, CTX);
+		expect(h.generateLiveShare).not.toHaveBeenCalled();
+		expect(h.markPublicConfirmed).not.toHaveBeenCalled();
+		expect(io.states).toEqual([
+			expect.objectContaining({
+				kind: "needsCreate",
+				branch: "feature/x",
+				subject: "feature/x",
+				subjectTitle: "feature/x",
+				visibility: "org",
+				canOrg: true,
+				recipients: [],
+				collaborators: OWNER_ROWS,
+			}),
+		]);
+	});
+
+	it("uses public as the create default when org access is unavailable", async () => {
+		const io = makeIO();
+		await openShareModal(io, { ...CTX, canOrg: false });
+		expect(io.states.at(-1)).toMatchObject({ kind: "needsCreate", visibility: "public", canOrg: false });
+		expect(h.generateLiveShare).not.toHaveBeenCalled();
+	});
+
+	it("does not re-serve an expired link; asks the user to create a fresh one", async () => {
+		h.getBranchShare.mockResolvedValue({ ...RECORD, expiresAt: "2020-01-01T00:00:00.000Z" });
+		const io = makeIO();
+		await openShareModal(io, { ...CTX, nowMs: NOW_MS });
+		expect(h.generateLiveShare).not.toHaveBeenCalled();
+		expect(io.states.at(-1)).toMatchObject({ kind: "needsCreate" });
+	});
+});
+
+describe("createShareModal", () => {
+	it("creates a new share with the selected audience", async () => {
+		h.getBranchShare.mockResolvedValue(RECORD);
+		const io = makeIO();
+		await createShareModal(io, { ...CTX, visibility: "org" });
+		expect(h.generateLiveShare).toHaveBeenCalledWith(expect.objectContaining({ visibility: "org" }));
+		expect(h.markPublicConfirmed).not.toHaveBeenCalled();
+		expect(io.states[0]).toEqual({ kind: "loading", label: "Syncing to Jolli…" });
+		expect(io.states.at(-1)).toMatchObject({ kind: "ready", shareUrl: URL, collaborators: OWNER_ROWS });
+	});
+
+	it("records the public ack when creating a public link", async () => {
+		h.getBranchShare.mockResolvedValue(RECORD);
+		const io = makeIO();
+		await createShareModal(io, { ...CTX, canOrg: false, visibility: "public" });
+		expect(h.generateLiveShare).toHaveBeenCalledWith(expect.objectContaining({ visibility: "public" }));
+		expect(h.markPublicConfirmed).toHaveBeenCalledWith("/repo", "feature/x");
+	});
+
+	it("commit share: keys the existing-share lookup by commit and threads commitHash into generate", async () => {
+		const commitHash = "c".repeat(40);
+		h.getBranchShare.mockResolvedValue(RECORD);
+		const io = makeIO();
+		await createShareModal(io, { ...CTX, commitHash, visibility: "org" });
+		expect(h.getBranchShare).toHaveBeenCalledWith("/repo", "feature/x", commitHash);
+		expect(h.generateLiveShare).toHaveBeenCalledWith(expect.objectContaining({ commitHash, visibility: "org" }));
+		expect(io.states.at(-1)).toMatchObject({ kind: "ready" });
+	});
+
+	it("does NOT auto-open the mail client", async () => {
+		h.getBranchShare.mockResolvedValue(RECORD);
+		const io = makeIO();
+		await createShareModal(io, { ...CTX, recipients: ["a@x.com"] });
+		expect(io.composeEmail).not.toHaveBeenCalled();
+	});
+
+	it("applies a caller-provided expiry via PATCH right after sync", async () => {
+		h.getBranchShare.mockResolvedValue(RECORD);
+		const io = makeIO();
+		await createShareModal(io, { ...CTX, expiryDays: 30, nowMs: NOW_MS });
+		expect(h.setBranchShareExpiry).toHaveBeenCalledWith("/repo", "feature/x", "KEY", "2026-07-25T00:00:00.000Z", undefined);
+		expect(io.states.at(-1)).toMatchObject({ kind: "ready", shareUrl: URL });
+	});
+
+	it("skips the expiry PATCH when no lifetime was chosen (server default)", async () => {
+		h.getBranchShare.mockResolvedValue(RECORD);
+		const io = makeIO();
+		await createShareModal(io, CTX);
+		expect(h.setBranchShareExpiry).not.toHaveBeenCalled();
+	});
+
+	it("sync succeeds but the expiry PATCH fails → toasts and still shows the link", async () => {
+		h.getBranchShare.mockResolvedValue(RECORD);
+		h.setBranchShareExpiry.mockRejectedValue(new Error("patch boom"));
+		const io = makeIO();
+		await createShareModal(io, { ...CTX, expiryDays: 7, nowMs: undefined });
+		expect(io.notifyError).toHaveBeenCalledWith(expect.stringContaining("patch boom"));
+		expect(io.states.at(-1)).toMatchObject({ kind: "ready", shareUrl: URL });
+	});
+
+	it("surfaces NothingToShareError verbatim", async () => {
+		h.generateLiveShare.mockRejectedValue(new NothingToShareError("nope, no memories on feature/x"));
+		const io = makeIO();
+		await createShareModal(io, CTX);
+		expect(io.states.at(-1)).toMatchObject({ kind: "error", message: expect.stringContaining("no memories") });
+	});
+
+	it("maps a cancelled binding to a friendly message", async () => {
+		h.generateLiveShare.mockRejectedValue(new ShareBindingError("cancelled"));
+		const io = makeIO();
+		await createShareModal(io, CTX);
+		expect(io.states.at(-1)).toMatchObject({ kind: "error", message: expect.stringContaining("none was chosen") });
+	});
+
+	it("maps an anotherOpen binding to the 'already open' message", async () => {
+		h.generateLiveShare.mockRejectedValue(new ShareBindingError("anotherOpen"));
+		const io = makeIO();
+		await createShareModal(io, CTX);
+		expect(io.states.at(-1)).toMatchObject({ kind: "error", message: expect.stringContaining("already open") });
+	});
+
+	it("maps a failed binding to the 'couldn't be set up' message", async () => {
+		h.generateLiveShare.mockRejectedValue(new ShareBindingError("failed"));
+		const io = makeIO();
+		await createShareModal(io, CTX);
+		expect(io.states.at(-1)).toMatchObject({ kind: "error", message: expect.stringContaining("couldn't be set up") });
+	});
+
+	it("errors when the record vanished right after a successful sync", async () => {
+		// getBranchShare returns undefined for both the existing-check and the read-back.
+		h.getBranchShare.mockResolvedValue(undefined);
+		const io = makeIO();
+		await createShareModal(io, CTX);
+		expect(io.states.at(-1)).toMatchObject({ kind: "error", message: expect.stringContaining("could not be created") });
+	});
+
+	it("wraps other generation errors", async () => {
+		h.generateLiveShare.mockRejectedValue(new Error("net down"));
+		const io = makeIO();
+		await createShareModal(io, CTX);
+		expect(io.states.at(-1)).toMatchObject({ kind: "error", message: expect.stringContaining("net down") });
+	});
+});
+
+describe("revokeShareModal", () => {
+	it("revokes in one action: toast + revoked state (no re-prompt to create a link)", async () => {
+		const io = makeIO();
+		await revokeShareModal(io, CTX);
+		expect(h.revokeBranchShareForBranch).toHaveBeenCalledWith("/repo", "feature/x", "KEY", undefined);
+		expect(io.states[0]).toEqual({ kind: "loading", label: "Stopping share…" });
+		expect(io.states[1]).toEqual({ kind: "revoked" });
+		expect(io.notifyInfo).toHaveBeenCalledWith(expect.stringContaining("Sharing stopped"));
+	});
+
+	it("guards on a missing API key", async () => {
+		const io = makeIO();
+		await revokeShareModal(io, { ...CTX, apiKey: undefined });
+		expect(io.states).toEqual([{ kind: "needsApiKey" }]);
+		expect(h.revokeBranchShareForBranch).not.toHaveBeenCalled();
+	});
+});
+
+describe("setShareExpiryModal", () => {
+	const NEW_EXPIRES = "2026-10-01T00:00:00.000Z";
+
+	it("needsApiKey guard", async () => {
+		const io = makeIO();
+		await setShareExpiryModal(io, { ...CTX, apiKey: undefined }, NEW_EXPIRES);
+		expect(io.states).toEqual([{ kind: "needsApiKey" }]);
+		expect(h.setBranchShareExpiry).not.toHaveBeenCalled();
+	});
+
+	it("PATCHes the expiry (no regenerate) and re-renders ready with the new label", async () => {
+		h.setBranchShareExpiry.mockResolvedValue(NEW_EXPIRES);
+		h.getBranchShare.mockResolvedValue({ ...RECORD, expiresAt: NEW_EXPIRES });
+		const io = makeIO();
+		await setShareExpiryModal(io, CTX, NEW_EXPIRES);
+		expect(h.setBranchShareExpiry).toHaveBeenCalledWith("/repo", "feature/x", "KEY", NEW_EXPIRES, undefined);
+		expect(h.generateLiveShare).not.toHaveBeenCalled();
+		expect(io.states.at(-1)).toMatchObject({ kind: "ready" });
+	});
+
+	it("on PATCH failure: toasts the error and re-renders the still-valid link", async () => {
+		h.setBranchShareExpiry.mockRejectedValue(new Error("bad date"));
+		h.getBranchShare.mockResolvedValue(RECORD);
+		const io = makeIO();
+		await setShareExpiryModal(io, CTX, NEW_EXPIRES);
+		expect(io.notifyError).toHaveBeenCalledWith(expect.stringContaining("bad date"));
+		expect(h.generateLiveShare).not.toHaveBeenCalled();
+		expect(io.states.at(-1)).toMatchObject({ kind: "ready" });
+	});
+
+	it("errors (not stuck loading) when the record vanished mid-update", async () => {
+		h.setBranchShareExpiry.mockResolvedValue(NEW_EXPIRES);
+		h.getBranchShare.mockResolvedValue(undefined);
+		const io = makeIO();
+		await setShareExpiryModal(io, CTX, NEW_EXPIRES);
+		expect(io.states.at(-1)).toMatchObject({ kind: "error", message: expect.stringContaining("no longer available") });
+	});
+});
+
+describe("setShareVisibilityModal", () => {
+	it("needsApiKey guard", async () => {
+		const io = makeIO();
+		await setShareVisibilityModal(io, { ...CTX, apiKey: undefined }, "org");
+		expect(io.states).toEqual([{ kind: "needsApiKey" }]);
+		expect(h.setBranchShareVisibility).not.toHaveBeenCalled();
+	});
+
+	it("PATCHes the visibility (no regenerate) and re-renders ready", async () => {
+		h.setBranchShareVisibility.mockResolvedValue("org");
+		h.getBranchShare.mockResolvedValue({ ...RECORD, visibility: "org" });
+		const io = makeIO();
+		await setShareVisibilityModal(io, CTX, "org");
+		expect(h.setBranchShareVisibility).toHaveBeenCalledWith("/repo", "feature/x", "KEY", "org", undefined, undefined);
+		expect(h.generateLiveShare).not.toHaveBeenCalled();
+		expect(io.states.at(-1)).toMatchObject({ kind: "ready", visibility: "org" });
+	});
+
+	it("people: PATCHes visibility + recipients and renders the added people as collaborators", async () => {
+		h.setBranchShareVisibility.mockResolvedValue("people");
+		h.getBranchShare.mockResolvedValue({ ...RECORD, visibility: "people", recipients: ["bo@example.com"] });
+		const io = makeIO();
+		await setShareVisibilityModal(io, CTX, "people", ["bo@example.com"]);
+		expect(h.setBranchShareVisibility).toHaveBeenCalledWith("/repo", "feature/x", "KEY", "people", undefined, [
+			"bo@example.com",
+		]);
+		expect(h.markPublicConfirmed).not.toHaveBeenCalled();
+		expect(io.states.at(-1)).toMatchObject({
+			kind: "ready",
+			visibility: "people",
+			recipients: ["bo@example.com"],
+			collaborators: [
+				{ name: "Ada", email: "ada@example.com", isOwner: true },
+				{ name: "Bo", email: "bo@example.com", isOwner: false },
+			],
+		});
+	});
+
+	it("records the public ack when switching to public (no separate confirm pane)", async () => {
+		h.setBranchShareVisibility.mockResolvedValue("public");
+		h.getBranchShare.mockResolvedValue(RECORD);
+		const io = makeIO();
+		await setShareVisibilityModal(io, CTX, "public");
+		expect(h.markPublicConfirmed).toHaveBeenCalledWith("/repo", "feature/x");
+	});
+
+	it("does NOT record a public ack when switching to org", async () => {
+		h.setBranchShareVisibility.mockResolvedValue("org");
+		h.getBranchShare.mockResolvedValue({ ...RECORD, visibility: "org" });
+		const io = makeIO();
+		await setShareVisibilityModal(io, CTX, "org");
+		expect(h.markPublicConfirmed).not.toHaveBeenCalled();
+	});
+
+	it("on PATCH failure: toasts the error and re-renders the still-valid link", async () => {
+		// Reject with a non-Error value to exercise the String(err) formatting path.
+		h.setBranchShareVisibility.mockRejectedValue("plain-string-boom");
+		h.getBranchShare.mockResolvedValue(RECORD);
+		const io = makeIO();
+		await setShareVisibilityModal(io, CTX, "org");
+		expect(io.notifyError).toHaveBeenCalledWith(expect.stringContaining("plain-string-boom"));
+		expect(io.states.at(-1)).toMatchObject({ kind: "ready" });
+	});
+
+	it("errors when the record vanished mid-update", async () => {
+		h.setBranchShareVisibility.mockResolvedValue("org");
+		h.getBranchShare.mockResolvedValue(undefined);
+		const io = makeIO();
+		await setShareVisibilityModal(io, CTX, "org");
+		expect(io.states.at(-1)).toMatchObject({ kind: "error", message: expect.stringContaining("no longer available") });
+	});
+});
+
+describe("shareModalTarget", () => {
+	it("opens the page", async () => {
+		h.getBranchShare.mockResolvedValue({ shareUrl: URL });
+		const io = makeIO();
+		await shareModalTarget(io, CTX, "page");
+		expect(io.openUrl).toHaveBeenCalledWith(URL);
+	});
+
+	it("composes an email with the live picker selection (ctx.recipients)", async () => {
+		h.getBranchShare.mockResolvedValue({ shareUrl: URL, decisionCount: 4, titles: ["A", "B"] });
+		const io = makeIO();
+		await shareModalTarget(io, { ...CTX, recipients: ["ctx@x.com"] }, "email");
+		expect(io.composeEmail).toHaveBeenCalledWith("feature/x", URL, 4, ["A", "B"], ["ctx@x.com"]);
+	});
+
+	it("ignores any recipients stored on the record — recipients are session-only", async () => {
+		h.getBranchShare.mockResolvedValue({ shareUrl: URL, recipients: ["stored@x.com"] });
+		const io = makeIO();
+		await shareModalTarget(io, CTX, "email"); // CTX.recipients === []
+		expect(io.composeEmail).toHaveBeenCalledWith("feature/x", URL, 0, [], []);
+	});
+
+	it("copies a message with the branch's decision count + titles", async () => {
+		h.getBranchShare.mockResolvedValue({ shareUrl: URL, decisionCount: 4, titles: ["A"] });
+		const io = makeIO();
+		await shareModalTarget(io, CTX, "copy");
+		expect(io.copyMessage).toHaveBeenCalledWith("feature/x", URL, 4, ["A"]);
+		expect(io.composeEmail).not.toHaveBeenCalled();
+	});
+
+	it("delegates a social platform to openSocial", async () => {
+		h.getBranchShare.mockResolvedValue({ shareUrl: URL, decisionCount: 4, titles: ["A"] });
+		const io = makeIO();
+		await shareModalTarget(io, CTX, "x");
+		expect(io.openSocial).toHaveBeenCalledWith("x", "feature/x", URL, 4, ["A"]);
+		expect(io.openUrl).not.toHaveBeenCalled();
+	});
+
+	it("does nothing when there is no stored share", async () => {
+		h.getBranchShare.mockResolvedValue(undefined);
+		const io = makeIO();
+		await shareModalTarget(io, CTX, "page");
+		expect(io.openUrl).not.toHaveBeenCalled();
+		expect(io.composeEmail).not.toHaveBeenCalled();
+	});
+
+	it("refuses to act on an expired link and surfaces an error", async () => {
+		h.getBranchShare.mockResolvedValue({ shareUrl: URL, expiresAt: "2020-01-01T00:00:00.000Z" });
+		const io = makeIO();
+		await shareModalTarget(io, { ...CTX, nowMs: NOW_MS }, "page");
+		expect(io.openUrl).not.toHaveBeenCalled();
+		expect(io.states.at(-1)).toMatchObject({ kind: "error", message: expect.stringContaining("expired") });
+	});
+
+	it("refuses to open/copy a cached share URL from an untrusted origin", async () => {
+		h.getBranchShare.mockResolvedValue({ shareUrl: "vscode://evil" });
+		const io = makeIO();
+		await shareModalTarget(io, CTX, "copy");
+		expect(io.copyMessage).not.toHaveBeenCalled();
+		expect(io.openUrl).not.toHaveBeenCalled();
+		expect(io.states.at(-1)).toMatchObject({ kind: "error", message: expect.stringContaining("not trusted") });
+	});
+});

--- a/vscode/src/services/BranchShareModal.ts
+++ b/vscode/src/services/BranchShareModal.ts
@@ -1,0 +1,469 @@
+/**
+ * BranchShareModal
+ *
+ * State machine behind the in-panel "Share" modal. Each webview message (open /
+ * confirm / revoke / set-expiry / open-target) maps to one entry point that
+ * computes the next modal state and pushes it back through the injected
+ * `ShareModalIO`. UI-agnostic so it is fully unit-testable; the panel supplies a
+ * VS Code-backed IO.
+ *
+ * Shares are **live** (Space-backed): `generate` pushes the subject's content to
+ * the bound Space and records a share that references the live docs (via
+ * `LiveShareController`). Access is `public` (anyone with the link), `org`
+ * (anyone in the org), or `people` (server-gated allowlist). The Email action
+ * still uses the current picker as a local `mailto:` delivery convenience. A live
+ * share is never "stale" (it renders current membership), so there is no refresh
+ * affordance.
+ */
+
+import {
+	getBranchShare,
+	markPublicConfirmed,
+	revokeBranchShareForBranch,
+	setBranchShareExpiry,
+	setBranchShareVisibility,
+} from "./BranchShareController.js";
+import { assertJolliOriginAllowed } from "../../../cli/src/core/JolliApiUtils.js";
+import type { BindingOutcome } from "./JolliPushOrchestrator.js";
+import { generateLiveShare, NothingToShareError, reconcileLiveShare } from "./LiveShareController.js";
+import type { JolliMemoryBridge } from "../JolliMemoryBridge.js";
+import { ShareBindingError } from "./JolliPushOrchestrator.js";
+import type { SocialPlatform } from "./ShareMessage.js";
+import type { CommitSummary } from "../../../cli/src/Types.js";
+
+/** Whether a share covers a whole branch or a single commit. */
+export type ShareKind = "branch" | "commit";
+
+/** Access level for a live share. */
+export type ShareVisibility = "public" | "org" | "people";
+
+/**
+ * A row in the redesigned popover's Collaborators list. Populated from the repo's
+ * git contributors — this is a **visual mock** (no add/remove/role backend); the
+ * current git user is flagged `isOwner`.
+ */
+export interface ShareCollaborator {
+	readonly name: string;
+	readonly email: string;
+	readonly isOwner: boolean;
+}
+
+/** A directory entry (org member or git contributor) offered as an add-people suggestion. */
+export interface ShareMember {
+	readonly name: string;
+	readonly email: string;
+}
+
+/**
+ * Builds the Collaborators rows for the popover: the owner first (fixed, `isOwner`), then
+ * one row per `recipients` email (the added people). Names are resolved from the `directory`
+ * (org members + git contributors); unknown emails render as the bare address. The owner is
+ * de-duped out of the recipients rows. Exported for unit testing.
+ */
+export function deriveShareCollaborators(
+	owner: ShareMember,
+	recipients: ReadonlyArray<string>,
+	directory: ReadonlyArray<ShareMember>,
+): ShareCollaborator[] {
+	const nameByEmail = new Map(directory.map((m) => [m.email.trim().toLowerCase(), m.name]));
+	const ownerLower = owner.email.trim().toLowerCase();
+	const rows: ShareCollaborator[] = [{ name: owner.name || owner.email, email: owner.email, isOwner: true }];
+	const seen = new Set<string>([ownerLower]);
+	for (const raw of recipients) {
+		const email = raw.trim();
+		const lower = email.toLowerCase();
+		if (!email || seen.has(lower)) continue;
+		seen.add(lower);
+		rows.push({ name: nameByEmail.get(lower) || email, email, isOwner: false });
+	}
+	return rows;
+}
+
+/** The render states the modal can be in. Mirrored by the webview client. */
+export type ShareModalState =
+	| { readonly kind: "needsApiKey" }
+	| {
+			readonly kind: "needsCreate";
+			readonly branch: string;
+			readonly subject: string;
+			readonly subjectTitle: string;
+			readonly visibility: ShareVisibility;
+			readonly canOrg: boolean;
+			readonly recipients: ReadonlyArray<string>;
+			readonly orgMembers: ReadonlyArray<ShareMember>;
+			readonly collaborators: ReadonlyArray<ShareCollaborator>;
+	  }
+	| { readonly kind: "loading"; readonly label: string }
+	| {
+			readonly kind: "ready";
+			readonly branch: string;
+			/** Display label for the share subject (branch name, or "branch · commit <hash8>"). */
+			readonly subject: string;
+			/** Human title for the popover subtitle: commit message (commit) or branch name (branch). */
+			readonly subjectTitle: string;
+			readonly shareUrl: string;
+			readonly expiresLabel: string;
+			/** Whole days until expiry (from `expiresAt`), so the picker can preselect the link's lifetime. */
+			readonly expiryDays: number;
+			readonly decisionCount: number;
+			/** Access level — drives copy + which buttons show. */
+			readonly visibility: ShareVisibility;
+			/** Whether the `org` access option is available (the API key carries an org). */
+			readonly canOrg: boolean;
+			/** `people` allowlist (lowercased emails) — the added people who can open. */
+			readonly recipients: ReadonlyArray<string>;
+			/** Search-suggestion directory (org members + git contributors) for adding people. */
+			readonly orgMembers: ReadonlyArray<ShareMember>;
+			/** Rendered Collaborators rows = owner + one per recipient (names resolved from the directory). */
+			readonly collaborators: ReadonlyArray<ShareCollaborator>;
+	  }
+	| { readonly kind: "error"; readonly message: string }
+	/** Terminal: the share was stopped — the client dismisses the modal. */
+	| { readonly kind: "revoked" };
+
+export type ShareTarget = "page" | "email" | "copy" | SocialPlatform;
+
+export interface ShareModalIO {
+	postState(state: ShareModalState): void;
+	openUrl(url: string): Promise<void>;
+	/** Opens the user's mail client (mailto:) with the chosen recipients prefilled in `To:`. */
+	composeEmail(
+		branch: string,
+		url: string,
+		decisionCount: number,
+		titles: ReadonlyArray<string>,
+		recipients: ReadonlyArray<string>,
+	): Promise<void>;
+	/** Copies an attractive, content-teasing message (for Slack/IM) to the clipboard. */
+	copyMessage(branch: string, url: string, decisionCount: number, titles: ReadonlyArray<string>): Promise<void>;
+	/** Opens a social platform's pre-filled compose screen (copy tailored per platform host-side). */
+	openSocial(
+		platform: SocialPlatform,
+		branch: string,
+		url: string,
+		decisionCount: number,
+		titles: ReadonlyArray<string>,
+	): Promise<void>;
+	/** Formats an ISO expiry into a short human label (e.g. "expires Sep 1, 2026"). */
+	formatExpiry(iso: string): string;
+	/** Surfaces a non-fatal error to the user (host toast) without tearing down the modal. */
+	notifyError(message: string): void;
+	/** Surfaces a confirmation (host info toast) — e.g. after the share is stopped. */
+	notifyInfo(message: string): void;
+}
+
+export interface ShareModalContext {
+	readonly workspaceRoot: string;
+	readonly branch: string;
+	readonly apiKey: string | undefined;
+	/** Set for a single-commit share; omit for a whole-branch share. Drives keying + subject. */
+	readonly commitHash?: string;
+	/** The exact open memory for a single-commit share; branch shares omit it. */
+	readonly commitSummary?: CommitSummary;
+	/** Human title for the popover subtitle: commit message (commit share) or branch name (branch share). */
+	readonly subjectTitle: string;
+	/** Access level chosen in the modal. Defaults to `public`. */
+	readonly visibility: ShareVisibility;
+	/**
+	 * Recipients for the Email action, chosen in the pane at click time (local-only
+	 * `mailto:` prefill — never sent to the server, and **not persisted**: a reopened
+	 * share starts with an empty picker).
+	 */
+	readonly recipients: ReadonlyArray<string>;
+	/** Link lifetime in days, chosen in step 1; applied at create time. Omit for the server default. */
+	readonly expiryDays?: number;
+	/** Whether the `org` access option is offered (API key carries an org). */
+	readonly canOrg: boolean;
+	/** The current user (share owner) — always the first, fixed Collaborators row. */
+	readonly owner: ShareMember;
+	/** Directory (org members + git contributors) for add-people search + name resolution. */
+	readonly directory: ReadonlyArray<ShareMember>;
+	/** Loads/persists summaries for the live push (LiveShareController needs it). */
+	readonly bridge: JolliMemoryBridge;
+	/** Opens the binding chooser; injected so chooser UI stays in the panel. */
+	readonly resolveBinding: (repoUrl: string) => Promise<BindingOutcome>;
+	/** Host clock (Date.now()) for the expiry check — injected for testability. */
+	readonly nowMs?: number;
+}
+
+/** Display label for the share subject: branch name, or "branch · commit <hash8>". */
+function shareSubject(ctx: ShareModalContext): string {
+	return ctx.commitHash ? `${ctx.branch} · commit ${ctx.commitHash.slice(0, 8)}` : ctx.branch;
+}
+
+/**
+ * Opens the modal. Existing, unexpired links re-show immediately; otherwise the
+ * user lands on a confirmation pane and must explicitly create the share link.
+ */
+export async function openShareModal(io: ShareModalIO, ctx: ShareModalContext): Promise<void> {
+	if (!ctx.apiKey) {
+		io.postState({ kind: "needsApiKey" });
+		return;
+	}
+	const existing = await getBranchShare(ctx.workspaceRoot, ctx.branch, ctx.commitHash);
+	// An expired link is a dead link — don't re-serve it; re-sync a fresh one below.
+	if (existing?.shareId && existing.shareUrl && !isExpired(existing.expiresAt, ctx.nowMs)) {
+		// A live BRANCH share renders the CURRENT base..HEAD, so reconcile the `covered`
+		// allowlist before showing — otherwise a share created before later commits keeps
+		// serving the stale commit set. Commit shares are a fixed doc list and don't reconcile.
+		// Best-effort: on failure fall back to the cached record.
+		if (!ctx.commitHash && existing.ref?.kind === "branchCollection") {
+			io.postState({ kind: "loading", label: "Syncing to Jolli…" });
+			try {
+				await reconcileLiveShare(
+					{
+						bridge: ctx.bridge,
+						workspaceRoot: ctx.workspaceRoot,
+						apiKey: ctx.apiKey,
+						resolveBinding: ctx.resolveBinding,
+					},
+					ctx.branch,
+				);
+			} catch (err) {
+				io.notifyError(`Couldn't refresh the shared content: ${errMessage(err)}`);
+			}
+		}
+		const fresh = (await getBranchShare(ctx.workspaceRoot, ctx.branch, ctx.commitHash)) ?? existing;
+		postReadyState(io, ctx, fresh);
+		return;
+	}
+	io.postState(needsCreateState(ctx));
+}
+
+/** Explicitly creates a share after the user confirms the audience/what-travels pane. */
+export async function createShareModal(io: ShareModalIO, ctx: ShareModalContext): Promise<void> {
+	if (!ctx.apiKey) {
+		io.postState({ kind: "needsApiKey" });
+		return;
+	}
+	await generate(io, ctx, ctx.visibility);
+}
+
+/**
+ * Adjusts the current share's expiry (absolute ISO `expiresAt`) via PATCH — does
+ * NOT re-push content. Re-renders the ready pane with the new expiry label.
+ */
+export async function setShareExpiryModal(io: ShareModalIO, ctx: ShareModalContext, expiresAt: string): Promise<void> {
+	if (!ctx.apiKey) {
+		io.postState({ kind: "needsApiKey" });
+		return;
+	}
+	io.postState({ kind: "loading", label: "Updating expiry…" });
+	try {
+		await setBranchShareExpiry(ctx.workspaceRoot, ctx.branch, ctx.apiKey, expiresAt, ctx.commitHash);
+	} catch (err) {
+		io.notifyError(`Couldn't update the link's expiry: ${errMessage(err)}`);
+	}
+	const existing = await getBranchShare(ctx.workspaceRoot, ctx.branch, ctx.commitHash);
+	if (existing?.shareId && existing.shareUrl) {
+		postReadyState(io, ctx, existing);
+	} else {
+		io.postState({ kind: "error", message: "This share is no longer available — create a new link." });
+	}
+}
+
+/**
+ * Changes an existing link's audience — access level (`public` / `org` / `people`) and,
+ * for `people`, the `recipients` allowlist — via PATCH. Does NOT re-push content.
+ * Re-renders the pane with the server-confirmed URL/visibility/recipients.
+ */
+export async function setShareVisibilityModal(
+	io: ShareModalIO,
+	ctx: ShareModalContext,
+	visibility: ShareVisibility,
+	recipients?: ReadonlyArray<string>,
+): Promise<void> {
+	if (!ctx.apiKey) {
+		io.postState({ kind: "needsApiKey" });
+		return;
+	}
+	// No `loading` pane here: the webview already reflected the audience change optimistically
+	// (add/remove/switch) and shows a SYNCING badge; flipping to the loading pane would hide the
+	// list. We post the authoritative `ready` (or `error`) once the PATCH resolves.
+	// Switching to `public` opens a forwardable "anyone with the link" link — record
+	// the one-time ack per branch (the redesigned popover has no separate confirm pane).
+	if (visibility === "public") await markPublicConfirmed(ctx.workspaceRoot, ctx.branch);
+	try {
+		await setBranchShareVisibility(ctx.workspaceRoot, ctx.branch, ctx.apiKey, visibility, ctx.commitHash, recipients);
+	} catch (err) {
+		io.notifyError(`Couldn't update who can open this link: ${errMessage(err)}`);
+	}
+	const existing = await getBranchShare(ctx.workspaceRoot, ctx.branch, ctx.commitHash);
+	if (existing?.shareId && existing.shareUrl) {
+		postReadyState(io, ctx, existing);
+	} else {
+		io.postState({ kind: "error", message: "This share is no longer available — create a new link." });
+	}
+}
+
+/**
+ * Stops sharing in one action: revoke the link, confirm via a toast, and signal
+ * the client to dismiss the modal. (Revoke removes the grant only — the Space docs
+ * are NOT deleted.)
+ */
+export async function revokeShareModal(io: ShareModalIO, ctx: ShareModalContext): Promise<void> {
+	if (!ctx.apiKey) {
+		io.postState({ kind: "needsApiKey" });
+		return;
+	}
+	io.postState({ kind: "loading", label: "Stopping share…" });
+	await revokeBranchShareForBranch(ctx.workspaceRoot, ctx.branch, ctx.apiKey, ctx.commitHash);
+	io.notifyInfo("Sharing stopped — the link no longer works.");
+	io.postState({ kind: "revoked" });
+}
+
+/** Opens the page, an email draft (with recipients), a copy, or a social compose for the current share. */
+export async function shareModalTarget(io: ShareModalIO, ctx: ShareModalContext, target: ShareTarget): Promise<void> {
+	const existing = await getBranchShare(ctx.workspaceRoot, ctx.branch, ctx.commitHash);
+	if (!existing?.shareUrl) return;
+	try {
+		assertSafeShareUrl(existing.shareUrl);
+	} catch (err) {
+		io.postState({ kind: "error", message: `This share link is not trusted: ${errMessage(err)}` });
+		return;
+	}
+	if (isExpired(existing.expiresAt, ctx.nowMs)) {
+		io.postState({ kind: "error", message: "This link has expired — reopen Share to create a new one." });
+		return;
+	}
+	const decisions = existing.decisionCount ?? 0;
+	const titles = existing.titles ?? [];
+	if (target === "page") await io.openUrl(existing.shareUrl);
+	else if (target === "copy") await io.copyMessage(ctx.branch, existing.shareUrl, decisions, titles);
+	else if (target === "email") {
+		// Recipients are the live picker selection (session-only; not persisted).
+		await io.composeEmail(ctx.branch, existing.shareUrl, decisions, titles, ctx.recipients);
+	} else {
+		await io.openSocial(target, ctx.branch, existing.shareUrl, decisions, titles);
+	}
+}
+
+function assertSafeShareUrl(url: string): void {
+	const parsed = new URL(url);
+	assertJolliOriginAllowed(parsed.origin);
+}
+
+/** Creates/syncs the subject and reveals the SYNCED pane. A `public` create records the one-time forwardable-link ack. */
+async function generate(io: ShareModalIO, ctx: ShareModalContext, visibility: ShareVisibility): Promise<void> {
+	io.postState({ kind: "loading", label: "Syncing to Jolli…" });
+	if (visibility === "public") await markPublicConfirmed(ctx.workspaceRoot, ctx.branch);
+	try {
+		// apiKey is guaranteed non-null by the callers' guards. Recipients are chosen
+		// post-create, so none are sent here.
+		await generateLiveShare({
+			bridge: ctx.bridge,
+			workspaceRoot: ctx.workspaceRoot,
+			apiKey: ctx.apiKey as string,
+			resolveBinding: ctx.resolveBinding,
+			branch: ctx.branch,
+			commitHash: ctx.commitHash,
+			commitSummary: ctx.commitSummary,
+			visibility,
+		});
+	} catch (err) {
+		io.postState({ kind: "error", message: generateErrorMessage(err) });
+		return;
+	}
+	// Apply the step-1 expiry choice before revealing the link (create uses the server
+	// default; a non-default lifetime is set via the same PATCH the ready pane uses).
+	if (ctx.expiryDays && ctx.expiryDays > 0) {
+		try {
+			const expiresAt = new Date((ctx.nowMs ?? Date.now()) + ctx.expiryDays * 24 * 60 * 60 * 1000).toISOString();
+			await setBranchShareExpiry(ctx.workspaceRoot, ctx.branch, ctx.apiKey as string, expiresAt, ctx.commitHash);
+		} catch (err) {
+			io.notifyError(`Link created, but its expiry couldn't be set: ${errMessage(err)}`);
+		}
+	}
+	// Read the freshly-stored record so the ready pane reflects what was persisted.
+	const rec = await getBranchShare(ctx.workspaceRoot, ctx.branch, ctx.commitHash);
+	if (!rec?.shareUrl) {
+		io.postState({ kind: "error", message: "Share link could not be created — please try again." });
+		return;
+	}
+	postReadyState(io, ctx, rec);
+}
+
+/** Maps a generate failure to a user-facing message (binding vs nothing-to-share vs generic). */
+function generateErrorMessage(err: unknown): string {
+	if (err instanceof ShareBindingError) {
+		if (err.outcome === "anotherOpen") {
+			return "A Memory space chooser is already open for this repo. Finish there, then share again.";
+		}
+		if (err.outcome === "cancelled") {
+			return "Sharing needs a Memory space — none was chosen. Reopen Share to pick one.";
+		}
+		return "Sharing needs a Memory space, but one couldn't be set up. Try again.";
+	}
+	if (err instanceof NothingToShareError) return err.message;
+	return `Could not create share link: ${errMessage(err)}`;
+}
+
+interface StoredShareLike {
+	readonly shareUrl: string;
+	readonly expiresAt: string;
+	readonly decisionCount: number;
+	readonly visibility: ShareVisibility;
+	readonly recipients?: ReadonlyArray<string>;
+}
+
+function readyStateFromRecord(io: ShareModalIO, ctx: ShareModalContext, rec: StoredShareLike): ShareModalState {
+	assertSafeShareUrl(rec.shareUrl);
+	const recipients = rec.recipients ?? [];
+	return {
+		kind: "ready",
+		branch: ctx.branch,
+		subject: shareSubject(ctx),
+		subjectTitle: ctx.subjectTitle,
+		shareUrl: rec.shareUrl,
+		expiresLabel: io.formatExpiry(rec.expiresAt),
+		expiryDays: remainingDays(rec.expiresAt, ctx.nowMs),
+		decisionCount: rec.decisionCount,
+		visibility: rec.visibility,
+		canOrg: ctx.canOrg,
+		recipients,
+		orgMembers: ctx.directory,
+		collaborators: deriveShareCollaborators(ctx.owner, recipients, ctx.directory),
+	};
+}
+
+function postReadyState(io: ShareModalIO, ctx: ShareModalContext, rec: StoredShareLike): void {
+	try {
+		io.postState(readyStateFromRecord(io, ctx, rec));
+	} catch (err) {
+		io.postState({ kind: "error", message: `This share link is not trusted: ${errMessage(err)}` });
+	}
+}
+
+function needsCreateState(ctx: ShareModalContext): ShareModalState {
+	const visibility = ctx.visibility === "public" && ctx.canOrg ? "org" : ctx.visibility;
+	const recipients = visibility === "people" ? ctx.recipients : [];
+	return {
+		kind: "needsCreate",
+		branch: ctx.branch,
+		subject: shareSubject(ctx),
+		subjectTitle: ctx.subjectTitle,
+		visibility,
+		canOrg: ctx.canOrg,
+		recipients,
+		orgMembers: ctx.directory,
+		collaborators: deriveShareCollaborators(ctx.owner, recipients, ctx.directory),
+	};
+}
+
+function errMessage(e: unknown): string {
+	return e instanceof Error ? e.message : String(e);
+}
+
+/** Whole days from now until `expiresAt` (≥0), so the picker preselects the link's lifetime. */
+function remainingDays(expiresAt: string | undefined, nowMs: number | undefined): number {
+	const end = expiresAt ? Date.parse(expiresAt) : Number.NaN;
+	if (Number.isNaN(end)) return 0;
+	return Math.max(0, Math.round((end - (nowMs ?? Date.now())) / (24 * 60 * 60 * 1000)));
+}
+
+/** Whether a stored share's expiry has passed. Unknown clock / unparseable → treat as live. */
+function isExpired(expiresAt: string | undefined, nowMs: number | undefined): boolean {
+	if (!expiresAt || nowMs === undefined) return false;
+	const t = Date.parse(expiresAt);
+	return !Number.isNaN(t) && t <= nowMs;
+}

--- a/vscode/src/services/JolliPushOrchestrator.test.ts
+++ b/vscode/src/services/JolliPushOrchestrator.test.ts
@@ -1,0 +1,346 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommitSummary } from "../../../cli/src/Types.js";
+
+const { mockPushToJolli, mockDeleteFromJolli } = vi.hoisted(() => ({
+	mockPushToJolli: vi.fn(),
+	mockDeleteFromJolli: vi.fn(),
+}));
+const { mockReadPlan, mockReadNote } = vi.hoisted(() => ({
+	mockReadPlan: vi.fn(),
+	mockReadNote: vi.fn(),
+}));
+
+// Stub only the network functions; keep BindingRequiredError / PluginOutdatedError real (instanceof).
+vi.mock("./JolliPushService.js", async (importActual) => {
+	const actual = await importActual<typeof import("./JolliPushService.js")>();
+	return { ...actual, pushToJolli: mockPushToJolli, deleteFromJolli: mockDeleteFromJolli };
+});
+vi.mock("../../../cli/src/core/SummaryStore.js", () => ({
+	readPlanFromBranch: mockReadPlan,
+	readNoteFromBranch: mockReadNote,
+}));
+vi.mock("../views/SummaryMarkdownBuilder.js", () => ({ buildMarkdown: () => "# markdown" }));
+vi.mock("../../../cli/src/core/Telemetry.js", () => ({ track: vi.fn() }));
+vi.mock("../util/Logger.js", () => ({
+	log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { BindingRequiredError, PluginOutdatedError } from "./JolliPushService.js";
+import {
+	type BindingOutcome,
+	type PushContext,
+	pushSummaryWithAttachments,
+	serializeSummaryJson,
+	ShareBindingError,
+} from "./JolliPushOrchestrator.js";
+
+function makeSummary(overrides: Partial<CommitSummary> = {}): CommitSummary {
+	return {
+		schemaVersion: 1,
+		commitHash: "abc123",
+		branch: "feature/x",
+		commitMessage: "A commit",
+		summary: "body",
+		topics: [],
+		...overrides,
+	} as unknown as CommitSummary;
+}
+
+function makeContext(overrides: Partial<PushContext> = {}): PushContext {
+	return {
+		baseUrl: "https://acme.jolli.ai/",
+		apiKey: "sk-jol-test",
+		repoUrl: "https://github.com/acme/repo",
+		workspaceRoot: "/repo",
+		storeSummary: vi.fn().mockResolvedValue(undefined),
+		resolveBinding: vi.fn<[string], Promise<BindingOutcome>>().mockResolvedValue({ status: "cancelled" }),
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockReadPlan.mockResolvedValue("plan body");
+	mockReadNote.mockResolvedValue("note body");
+});
+
+describe("pushSummaryWithAttachments", () => {
+	it("pushes the summary and persists it (first push → isUpdate false)", async () => {
+		mockPushToJolli.mockResolvedValue({ docId: 100 });
+		const ctx = makeContext();
+		const result = await pushSummaryWithAttachments(makeSummary(), ctx);
+
+		expect(result.pushedDoc.summaryDocId).toBe(100);
+		expect(result.pushedDoc.summaryUrl).toBe("https://acme.jolli.ai/articles?doc=100");
+		expect(result.isUpdate).toBe(false);
+		expect(result.attachmentCount).toBe(0);
+		expect(ctx.storeSummary).toHaveBeenCalledWith(expect.objectContaining({ jolliDocId: 100 }), true);
+	});
+
+	it("pushes only the caller-chosen attachments (empty selection → no plan/note pushes)", async () => {
+		mockPushToJolli.mockResolvedValue({ docId: 100 });
+		const summary = makeSummary({
+			plans: [{ slug: "p-abc12345", title: "Plan", addedAt: "t", updatedAt: "t" }],
+		});
+		await pushSummaryWithAttachments(summary, makeContext(), { plans: [], notes: [] });
+		// Only the summary doc is pushed — the summary's own plan is NOT, because the selection was empty.
+		expect(mockPushToJolli).toHaveBeenCalledTimes(1);
+		expect(mockPushToJolli).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.objectContaining({ docType: "summary" }));
+	});
+
+	it("pushes a chosen plan with its resolved docId and returns it keyed by slug", async () => {
+		mockPushToJolli.mockImplementation((_b, _k, p: { docType: string }) =>
+			Promise.resolve({ docId: p.docType === "summary" ? 100 : 200 }),
+		);
+		const plan = { slug: "p-abc12345", title: "Plan", addedAt: "t", updatedAt: "t", jolliPlanDocId: 200 };
+		const summary = makeSummary({ plans: [plan] });
+		const result = await pushSummaryWithAttachments(summary, makeContext(), { plans: [plan], notes: [] });
+
+		expect(result.pushedDoc.plans).toEqual([{ slug: "p-abc12345", title: "Plan", docId: 200, url: "https://acme.jolli.ai/articles?doc=200" }]);
+		expect(result.attachmentCount).toBe(1);
+		// The plan push reused the known docId so the Space doc updates in place.
+		expect(mockPushToJolli).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.objectContaining({ docType: "plan", docId: 200 }));
+	});
+
+	it("collects a per-attachment failure without aborting the summary push", async () => {
+		mockPushToJolli.mockImplementation((_b, _k, p: { docType: string }) => {
+			if (p.docType === "plan") return Promise.reject(new Error("500 already exists"));
+			return Promise.resolve({ docId: 100 });
+		});
+		const plan = { slug: "p-abc12345", title: "Plan", addedAt: "t", updatedAt: "t" };
+		const result = await pushSummaryWithAttachments(makeSummary({ plans: [plan] }), makeContext(), {
+			plans: [plan],
+			notes: [],
+		});
+		expect(result.pushedDoc.summaryDocId).toBe(100);
+		expect(result.attachmentFailures).toEqual([{ label: 'plan "Plan"', message: "500 already exists" }]);
+	});
+
+	it("collects a per-note failure without aborting the summary push", async () => {
+		mockPushToJolli.mockImplementation((_b, _k, p: { docType: string }) => {
+			if (p.docType === "note") return Promise.reject(new Error("note 500"));
+			return Promise.resolve({ docId: 100 });
+		});
+		const note = { id: "n1", title: "Note", format: "markdown" as const, addedAt: "t", updatedAt: "t" };
+		const result = await pushSummaryWithAttachments(makeSummary(), makeContext(), { plans: [], notes: [note] });
+		expect(result.pushedDoc.summaryDocId).toBe(100);
+		expect(result.attachmentFailures).toEqual([{ label: 'note "Note"', message: "note 500" }]);
+	});
+
+	it("skips a snippet note with no content and pushes a markdown note's body", async () => {
+		mockPushToJolli.mockImplementation((_b, _k, p: { docType: string }) =>
+			Promise.resolve({ docId: p.docType === "summary" ? 100 : 300 }),
+		);
+		const empty = { id: "empty", title: "Empty", format: "snippet" as const, content: "", addedAt: "t", updatedAt: "t" };
+		const md = { id: "md", title: "MD", format: "markdown" as const, addedAt: "t", updatedAt: "t" };
+		const result = await pushSummaryWithAttachments(makeSummary(), makeContext(), { plans: [], notes: [empty, md] });
+		expect(result.pushedDoc.notes).toEqual([{ id: "md", title: "MD", docId: 300, url: "https://acme.jolli.ai/articles?doc=300" }]);
+	});
+
+	it("retries once after a binding is established", async () => {
+		mockPushToJolli.mockRejectedValueOnce(new BindingRequiredError("bind")).mockResolvedValue({ docId: 100 });
+		const ctx = makeContext({ resolveBinding: vi.fn().mockResolvedValue({ status: "bound" }) });
+		const result = await pushSummaryWithAttachments(makeSummary(), ctx);
+		expect(ctx.resolveBinding).toHaveBeenCalledOnce();
+		expect(result.pushedDoc.summaryDocId).toBe(100);
+	});
+
+	it("throws ShareBindingError when the chooser is cancelled", async () => {
+		mockPushToJolli.mockRejectedValue(new BindingRequiredError("bind"));
+		const ctx = makeContext({ resolveBinding: vi.fn().mockResolvedValue({ status: "cancelled" }) });
+		await expect(pushSummaryWithAttachments(makeSummary(), ctx)).rejects.toMatchObject({
+			name: "ShareBindingError",
+			outcome: "cancelled",
+		});
+	});
+
+	it("surfaces anotherOpen as a ShareBindingError", async () => {
+		mockPushToJolli.mockRejectedValue(new BindingRequiredError("bind"));
+		const ctx = makeContext({ resolveBinding: vi.fn().mockResolvedValue({ status: "anotherOpen" }) });
+		await expect(pushSummaryWithAttachments(makeSummary(), ctx)).rejects.toBeInstanceOf(ShareBindingError);
+	});
+
+	it("propagates a binding-required failure from a plan push to the chooser", async () => {
+		// Fatal binding errors inside the plan loop must NOT be collected as attachment
+		// failures — they abort the push and drive the binding chooser.
+		mockPushToJolli.mockImplementation((_b, _k, p: { docType: string }) => {
+			if (p.docType === "plan") return Promise.reject(new BindingRequiredError("bind"));
+			return Promise.resolve({ docId: 100 });
+		});
+		const plan = { slug: "p-abc12345", title: "Plan", addedAt: "t", updatedAt: "t" };
+		const ctx = makeContext({ resolveBinding: vi.fn().mockResolvedValue({ status: "cancelled" }) });
+		await expect(
+			pushSummaryWithAttachments(makeSummary({ plans: [plan] }), ctx, { plans: [plan], notes: [] }),
+		).rejects.toBeInstanceOf(ShareBindingError);
+		expect(ctx.resolveBinding).toHaveBeenCalledOnce();
+	});
+
+	it("propagates a plugin-outdated failure from a note push unchanged", async () => {
+		mockPushToJolli.mockImplementation((_b, _k, p: { docType: string }) => {
+			if (p.docType === "note") return Promise.reject(new PluginOutdatedError("update the plugin"));
+			return Promise.resolve({ docId: 100 });
+		});
+		const note = { id: "n1", title: "Note", format: "markdown" as const, addedAt: "t", updatedAt: "t" };
+		const ctx = makeContext();
+		await expect(
+			pushSummaryWithAttachments(makeSummary(), ctx, { plans: [], notes: [note] }),
+		).rejects.toBeInstanceOf(PluginOutdatedError);
+		// Not a binding problem — the chooser must not open.
+		expect(ctx.resolveBinding).not.toHaveBeenCalled();
+	});
+
+	it("stringifies a non-Error plan failure into the collected message", async () => {
+		mockPushToJolli.mockImplementation((_b, _k, p: { docType: string }) => {
+			if (p.docType === "plan") return Promise.reject("wire failure");
+			return Promise.resolve({ docId: 100 });
+		});
+		const plan = { slug: "p-abc12345", title: "Plan", addedAt: "t", updatedAt: "t" };
+		const result = await pushSummaryWithAttachments(makeSummary({ plans: [plan] }), makeContext(), {
+			plans: [plan],
+			notes: [],
+		});
+		expect(result.attachmentFailures).toEqual([{ label: 'plan "Plan"', message: "wire failure" }]);
+	});
+
+	it("stringifies a non-Error note failure into the collected message", async () => {
+		mockPushToJolli.mockImplementation((_b, _k, p: { docType: string }) => {
+			if (p.docType === "note") return Promise.reject(404);
+			return Promise.resolve({ docId: 100 });
+		});
+		const note = { id: "n1", title: "Note", format: "markdown" as const, addedAt: "t", updatedAt: "t" };
+		const result = await pushSummaryWithAttachments(makeSummary(), makeContext(), { plans: [], notes: [note] });
+		expect(result.attachmentFailures).toEqual([{ label: 'note "Note"', message: "404" }]);
+	});
+
+	it("deletes orphaned docs and clears them from the persisted summary", async () => {
+		mockPushToJolli.mockResolvedValue({ docId: 100 });
+		mockDeleteFromJolli.mockResolvedValue(undefined);
+		const ctx = makeContext();
+		const result = await pushSummaryWithAttachments(makeSummary({ orphanedDocIds: [7, 8] }), ctx);
+		expect(mockDeleteFromJolli).toHaveBeenCalledTimes(2);
+		expect(result.updatedSummary.orphanedDocIds).toBeUndefined();
+	});
+
+	it("still resolves a successful push when best-effort orphan cleanup throws", async () => {
+		mockPushToJolli.mockResolvedValue({ docId: 100 });
+		mockDeleteFromJolli.mockResolvedValue(undefined);
+		// First storeSummary (persisting jolliDocId) succeeds; the second (cleanup bookkeeping) throws.
+		const storeSummary = vi
+			.fn()
+			.mockResolvedValueOnce(undefined)
+			.mockRejectedValueOnce(new Error("disk full"));
+		const ctx = makeContext({ storeSummary });
+
+		const result = await pushSummaryWithAttachments(makeSummary({ orphanedDocIds: [7] }), ctx);
+
+		// The push succeeded server-side, so it must not surface as a failure.
+		expect(result.pushedDoc.summaryDocId).toBe(100);
+		expect(result.updatedSummary.jolliDocId).toBe(100);
+	});
+
+	it("skips a plan whose body cannot be read", async () => {
+		mockPushToJolli.mockResolvedValue({ docId: 100 });
+		mockReadPlan.mockResolvedValue("");
+		const plan = { slug: "p-abc12345", title: "Plan", addedAt: "t", updatedAt: "t" };
+		const result = await pushSummaryWithAttachments(makeSummary({ plans: [plan] }), makeContext(), {
+			plans: [plan],
+			notes: [],
+		});
+		expect(result.pushedDoc.plans).toEqual([]);
+		expect(mockPushToJolli).toHaveBeenCalledTimes(1); // summary only
+	});
+
+	it("strict mode reports unreadable attachment bodies as failures instead of silently treating stale docIds as current", async () => {
+		mockPushToJolli.mockResolvedValue({ docId: 100 });
+		mockReadPlan.mockResolvedValue("");
+		mockReadNote.mockResolvedValue("");
+		const plan = { slug: "p-abc12345", title: "Plan", addedAt: "t", updatedAt: "t", jolliPlanDocId: 200 };
+		const note = { id: "n1", title: "Note", format: "markdown" as const, addedAt: "t", updatedAt: "t", jolliNoteDocId: 300 };
+		const snippet = { id: "s1", title: "Snippet", format: "snippet" as const, content: "", addedAt: "t", updatedAt: "t" };
+
+		const result = await pushSummaryWithAttachments(
+			makeSummary({ plans: [plan], notes: [note, snippet] }),
+			makeContext(),
+			{ plans: [plan], notes: [note, snippet] },
+			{ strictAttachments: true },
+		);
+
+		expect(result.attachmentFailures).toEqual([
+			{ label: 'plan "Plan"', message: "Plan content for p-abc12345 could not be read." },
+			{ label: 'note "Note"', message: "Note content for n1 could not be read." },
+			{ label: 'note "Snippet"', message: "Snippet note content for s1 is empty." },
+		]);
+		expect(result.pushedDoc.plans).toEqual([]);
+		expect(result.pushedDoc.notes).toEqual([]);
+		expect(mockPushToJolli).toHaveBeenCalledTimes(1); // summary only
+	});
+
+	it("attaches the serialized summary JSON to the summary push — bookkeeping stripped, pushed plan URLs woven in", async () => {
+		mockPushToJolli.mockImplementation((_b, _k, p: { docType: string }) =>
+			Promise.resolve({ docId: p.docType === "summary" ? 100 : 200 }),
+		);
+		mockDeleteFromJolli.mockResolvedValue(undefined);
+		const plan = { slug: "p-abc12345", title: "Plan", addedAt: "t", updatedAt: "t" };
+		const summary = makeSummary({
+			plans: [plan],
+			jolliDocId: 55,
+			jolliDocUrl: "https://acme.jolli.ai/articles?doc=55",
+			orphanedDocIds: [7],
+		});
+		await pushSummaryWithAttachments(summary, makeContext(), { plans: [plan], notes: [] });
+
+		const summaryCall = mockPushToJolli.mock.calls.find(c => (c[2] as { docType: string }).docType === "summary");
+		const payload = summaryCall?.[2] as { summaryJson?: string };
+		const parsed = JSON.parse(payload.summaryJson ?? "");
+		expect(parsed.commitHash).toBe("abc123");
+		// Client push-state never travels in the structured content.
+		expect(parsed.jolliDocId).toBeUndefined();
+		expect(parsed.jolliDocUrl).toBeUndefined();
+		expect(parsed.orphanedDocIds).toBeUndefined();
+		// The serialized copy is the ENRICHED one: this push's plan URL is woven in.
+		expect(parsed.plans[0].jolliPlanDocId).toBe(200);
+		expect(parsed.plans[0].jolliPlanDocUrl).toBe("https://acme.jolli.ai/articles?doc=200");
+	});
+
+	it("never attaches summaryJson to plan or note pushes", async () => {
+		mockPushToJolli.mockResolvedValue({ docId: 100 });
+		const plan = { slug: "p-abc12345", title: "Plan", addedAt: "t", updatedAt: "t" };
+		const note = { id: "n1", title: "Note", format: "markdown" as const, addedAt: "t", updatedAt: "t" };
+		await pushSummaryWithAttachments(makeSummary(), makeContext(), { plans: [plan], notes: [note] });
+
+		expect(mockPushToJolli).toHaveBeenCalledTimes(3);
+		for (const call of mockPushToJolli.mock.calls) {
+			const p = call[2] as { docType: string; summaryJson?: string };
+			if (p.docType !== "summary") {
+				expect(p.summaryJson).toBeUndefined();
+			}
+		}
+	});
+
+	it("omits summaryJson (and still pushes the markdown) when the summary serializes over the byte cap", async () => {
+		mockPushToJolli.mockResolvedValue({ docId: 100 });
+		const huge = makeSummary({ recap: "x".repeat(1_600_000) });
+		const result = await pushSummaryWithAttachments(huge, makeContext());
+
+		expect(result.pushedDoc.summaryDocId).toBe(100);
+		const payload = mockPushToJolli.mock.calls[0][2] as { summaryJson?: string };
+		expect(payload.summaryJson).toBeUndefined();
+	});
+});
+
+describe("serializeSummaryJson", () => {
+	it("strips jolliDocId/jolliDocUrl/orphanedDocIds and keeps content fields", () => {
+		const json = serializeSummaryJson(
+			makeSummary({ jolliDocId: 55, jolliDocUrl: "https://x", orphanedDocIds: [1], recap: "did things" }),
+		);
+		const parsed = JSON.parse(json ?? "");
+		expect(parsed).toEqual(expect.objectContaining({ commitHash: "abc123", recap: "did things" }));
+		expect(Object.keys(parsed)).not.toEqual(
+			expect.arrayContaining(["jolliDocId", "jolliDocUrl", "orphanedDocIds"]),
+		);
+	});
+
+	it("returns undefined for a summary that serializes over the byte cap", () => {
+		expect(serializeSummaryJson(makeSummary({ recap: "x".repeat(1_600_000) }))).toBeUndefined();
+	});
+});

--- a/vscode/src/services/JolliPushOrchestrator.ts
+++ b/vscode/src/services/JolliPushOrchestrator.ts
@@ -1,0 +1,445 @@
+/**
+ * JolliPushOrchestrator
+ *
+ * UI-agnostic push of ONE summary plus its plans/notes to a Jolli Memory Space.
+ * Extracted from SummaryWebviewPanel so both the per-summary "Share in Jolli"
+ * button and the subject-level live share (LiveShareController) drive the *same*
+ * push path — pushing twice would mint duplicate articles and desync jolliDocId.
+ *
+ * It does NO VS Code UI: no `vscode.window`, no `postMessage`, no panel re-render.
+ * Instead it RETURNS the data the caller needs to render (the pushed doc ids, the
+ * updated summary, the partial-attachment failures, whether it was an update vs a
+ * first push). The binding chooser is injected as `ctx.resolveBinding` so the
+ * chooser webview stays in the panel layer.
+ *
+ * Attachment selection is the CALLER's choice (`attachments`): the live-share
+ * controller dedupes plans/notes branch-wide to their latest revision and hands
+ * each summary only the attachments it should push (with `jolliPlanDocId` /
+ * `jolliNoteDocId` already resolved from its branch-wide map, so the push updates
+ * the one Space doc in place instead of creating a duplicate). When `attachments`
+ * is omitted, the summary's own `latestPlanPerName(plans)` + `notes` are pushed —
+ * the standalone button's existing behavior.
+ */
+
+import type { CommitSummary, NoteReference, PlanReference } from "../../../cli/src/Types.js";
+import { readNoteFromBranch, readPlanFromBranch } from "../../../cli/src/core/SummaryStore.js";
+import { track } from "../../../cli/src/core/Telemetry.js";
+import { log } from "../util/Logger.js";
+import { latestPlanPerName } from "../util/PlanGrouping.js";
+import { buildBranchRelativePath, buildNotePushTitle, buildPlanPushTitle, buildPushTitle } from "../views/SummaryUtils.js";
+import { buildMarkdown } from "../views/SummaryMarkdownBuilder.js";
+import { BindingRequiredError, deleteFromJolli, PluginOutdatedError, pushToJolli } from "./JolliPushService.js";
+
+/** Outcome of the injected binding-chooser callback. */
+export type BindingOutcome = { status: "bound" | "anotherOpen" | "cancelled" | "failed" };
+
+/** A per-plan/per-note push failure, collected (not thrown) so one bad attachment doesn't abort the push. */
+export interface PushAttachmentFailure {
+	/** Human-readable identifier, e.g. `plan "Fix P1/P2 review findings"`. */
+	readonly label: string;
+	/** Error message (includes the HTTP status from JolliPushService). */
+	readonly message: string;
+}
+
+/**
+ * Raised when the push can't proceed because a Space binding wasn't established.
+ * `outcome` lets the caller decide messaging: `anotherOpen` (a chooser is already
+ * open elsewhere) vs `cancelled` (the user dismissed it) vs `failed`.
+ */
+export class ShareBindingError extends Error {
+	constructor(readonly outcome: "anotherOpen" | "cancelled" | "failed") {
+		super(`Space binding ${outcome}`);
+		this.name = "ShareBindingError";
+	}
+}
+
+/**
+ * Byte cap for the serialized summary JSON riding on a summary push. The server
+ * rejects `summaryJson` above 2MB; staying well under leaves headroom for the
+ * markdown `content` sharing the same request body. Oversized JSON is simply
+ * omitted — the markdown push must never fail on account of the sidecar.
+ */
+const MAX_SUMMARY_JSON_BYTES = 1_572_864;
+
+/**
+ * Serializes a summary for the `summaryJson` push field: the enriched
+ * `summaryForMarkdown` copy (plan/note URLs woven in) minus the client push-state
+ * fields — `jolliDocId`/`jolliDocUrl` churn per push and `orphanedDocIds` is
+ * cleanup bookkeeping, none of which is commit content the share page should see
+ * (stripping them also keeps a re-push of unchanged content byte-identical, so
+ * the server upsert can no-op). Returns undefined (with a warning) above
+ * {@link MAX_SUMMARY_JSON_BYTES}.
+ */
+export function serializeSummaryJson(summary: CommitSummary): string | undefined {
+	const { jolliDocId: _docId, jolliDocUrl: _docUrl, orphanedDocIds: _orphaned, ...content } = summary;
+	const json = JSON.stringify(content);
+	if (Buffer.byteLength(json, "utf-8") > MAX_SUMMARY_JSON_BYTES) {
+		log.warn(
+			"PushOrchestrator",
+			`Summary JSON for ${summary.commitHash.substring(0, 8)} exceeds ${MAX_SUMMARY_JSON_BYTES} bytes — pushing markdown only`,
+		);
+		return;
+	}
+	return json;
+}
+
+/** Everything the orchestrator needs that isn't on the summary itself. */
+export interface PushContext {
+	/** Resolved site base URL (the API key's `u`), passed verbatim to `pushToJolli`. */
+	readonly baseUrl: string;
+	readonly apiKey: string;
+	readonly repoUrl: string;
+	/** Worktree root — plan/note bodies are read from the orphan branch relative to it. */
+	readonly workspaceRoot: string;
+	/** Persists the summary (and its rewritten doc ids) locally; `bridge.storeSummary`. */
+	readonly storeSummary: (summary: CommitSummary, syncToCloud: boolean) => Promise<void>;
+	/** Opens the binding chooser and reports the outcome. Injected so chooser UI stays in the panel. */
+	readonly resolveBinding: (repoUrl: string) => Promise<BindingOutcome>;
+}
+
+/** A pushed plan/note: keyed by slug/id so the caller can map it back across commits. */
+export interface PushedPlan {
+	readonly slug: string;
+	readonly title: string;
+	readonly docId: number;
+	readonly url: string;
+}
+export interface PushedNote {
+	readonly id: string;
+	readonly title: string;
+	readonly docId: number;
+	readonly url: string;
+}
+
+/** The doc ids one summary push produced — feeds the live share's `covered` allowlist. */
+export interface PushedDoc {
+	readonly commitHash: string;
+	readonly summaryDocId: number;
+	readonly summaryUrl: string;
+	readonly plans: ReadonlyArray<PushedPlan>;
+	readonly notes: ReadonlyArray<PushedNote>;
+}
+
+/** Result of pushing one summary; UI-renderable data only. */
+export interface PushSummaryResult {
+	readonly pushedDoc: PushedDoc;
+	/** Summary after URL rewrite + storeSummary + orphan cleanup — the caller adopts this as current. */
+	readonly updatedSummary: CommitSummary;
+	readonly attachmentFailures: ReadonlyArray<PushAttachmentFailure>;
+	/** True when the summary already had a `jolliDocUrl` (an update), false for a first push. */
+	readonly isUpdate: boolean;
+	/** Number of attachments (plans + notes) successfully pushed. */
+	readonly attachmentCount: number;
+}
+
+/** The plans/notes to push for a summary — caller-chosen, or the summary's own when omitted. */
+export interface AttachmentSelection {
+	readonly plans: ReadonlyArray<PlanReference>;
+	readonly notes: ReadonlyArray<NoteReference>;
+}
+
+export interface PushSummaryOptions {
+	/**
+	 * Treat unreadable local attachment bodies as upload failures. Regular manual
+	 * Push keeps the historic best-effort behavior; live share enables this so the
+	 * share page cannot point at stale seeded docIds when the current body is missing.
+	 */
+	readonly strictAttachments?: boolean;
+}
+
+/**
+ * Pushes one summary + a chosen attachment set; persists `jolliDocId`/url, cleans
+ * orphans, and returns the doc ids + renderable result. UI-free — see file header.
+ */
+export async function pushSummaryWithAttachments(
+	summary: CommitSummary,
+	ctx: PushContext,
+	attachments?: AttachmentSelection,
+	options: PushSummaryOptions = {},
+	retried = false,
+): Promise<PushSummaryResult> {
+	const displayBase = ctx.baseUrl.replace(/\/+$/, "");
+	const plansToPush = attachments ? attachments.plans : latestPlanPerName(summary.plans ?? []);
+	const notesToPush = attachments ? attachments.notes : (summary.notes ?? []);
+
+	try {
+		// Step 1: upload plans + notes. Per-attachment failures are collected, not
+		// thrown, so one bad plan/note doesn't abort the summary push. Fatal
+		// binding/plugin errors still propagate to drive the chooser below.
+		const { results: planUrls, failures: planFailures } = await pushPlanList(
+			plansToPush,
+			summary,
+			ctx,
+			displayBase,
+			Boolean(options.strictAttachments),
+		);
+		const { results: noteUrls, failures: noteFailures } = await pushNoteList(
+			notesToPush,
+			summary,
+			ctx,
+			displayBase,
+			Boolean(options.strictAttachments),
+		);
+		const attachmentFailures = [...planFailures, ...noteFailures];
+
+		// Step 2: weave the published URLs into the summary markdown (so the
+		// article's Plans & Notes list links to the published docs). Dedupe
+		// same-named plan snapshots — only the latest was uploaded.
+		const dedupedPlans = latestPlanPerName(summary.plans ?? []);
+		const plansWithUrls = applyPlanUrls(dedupedPlans, planUrls) ?? dedupedPlans;
+		const notesWithUrls = summary.notes ? applyNoteUrls(summary.notes, noteUrls) : summary.notes;
+		const summaryForMarkdown: CommitSummary = {
+			...summary,
+			plans: plansWithUrls,
+			...(notesWithUrls !== summary.notes && { notes: notesWithUrls }),
+		};
+		const markdown = buildMarkdown(summaryForMarkdown);
+		// The structured twin of the markdown article, from the same enriched copy —
+		// the share page renders it directly instead of regex-parsing the markdown.
+		const summaryJson = serializeSummaryJson(summaryForMarkdown);
+
+		const result = await pushToJolli(ctx.baseUrl, ctx.apiKey, {
+			title: buildPushTitle(summary),
+			content: markdown,
+			commitHash: summary.commitHash,
+			docType: "summary",
+			branch: summary.branch,
+			...(summary.jolliDocId && { docId: summary.jolliDocId }),
+			repoUrl: ctx.repoUrl,
+			relativePath: buildBranchRelativePath(summary.branch),
+			...(summaryJson && { summaryJson }),
+		});
+
+		track("memory_pushed", { kind: "summary" });
+
+		const summaryUrl = `${displayBase}/articles?doc=${result.docId}`;
+		const isUpdate = Boolean(summary.jolliDocUrl);
+
+		const updatedSummary: CommitSummary = {
+			...summary,
+			jolliDocUrl: summaryUrl,
+			jolliDocId: result.docId,
+			...(planUrls.length > 0 ? { plans: applyPlanUrls(summary.plans, planUrls) } : {}),
+			...(noteUrls.length > 0 && summary.notes ? { notes: applyNoteUrls(summary.notes, noteUrls) } : {}),
+		};
+		await ctx.storeSummary(updatedSummary, true);
+
+		// Clean up orphaned articles, then persist which ones were actually deleted.
+		// Best-effort: the summary + jolliDocId are already pushed and stored above, so a
+		// cleanup/bookkeeping failure must not surface to the caller as a failed push.
+		let cleanedSummary: CommitSummary | null = null;
+		try {
+			cleanedSummary = await cleanupOrphanedDocs(summary, updatedSummary, displayBase, ctx);
+		} catch (err) {
+			log.warn(
+				"PushOrchestrator",
+				`Orphan cleanup failed after a successful push: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+
+		return {
+			pushedDoc: {
+				commitHash: summary.commitHash,
+				summaryDocId: result.docId,
+				summaryUrl,
+				plans: planUrls,
+				notes: noteUrls,
+			},
+			updatedSummary: cleanedSummary ?? updatedSummary,
+			attachmentFailures,
+			isUpdate,
+			attachmentCount: planUrls.length + noteUrls.length,
+		};
+	} catch (err: unknown) {
+		if (err instanceof BindingRequiredError && !retried) {
+			const outcome = await ctx.resolveBinding(ctx.repoUrl);
+			if (outcome.status === "bound") {
+				return pushSummaryWithAttachments(summary, ctx, attachments, options, true);
+			}
+			throw new ShareBindingError(outcome.status);
+		}
+		throw err;
+	}
+}
+
+/**
+ * Uploads the given plans, returning their published URLs + per-plan failures.
+ * A single plan failure is collected (not thrown); fatal binding/plugin errors
+ * propagate so the caller can drive the chooser.
+ */
+async function pushPlanList(
+	plans: ReadonlyArray<PlanReference>,
+	summary: CommitSummary,
+	ctx: PushContext,
+	displayBase: string,
+	strictAttachments: boolean,
+): Promise<{ results: PushedPlan[]; failures: PushAttachmentFailure[] }> {
+	const failures: PushAttachmentFailure[] = [];
+	const results: PushedPlan[] = [];
+	for (const plan of plans) {
+		const planContent = (await readPlanFromBranch(plan.slug, ctx.workspaceRoot)) ?? "";
+		if (!planContent) {
+			if (strictAttachments) {
+				failures.push({
+					label: `plan "${plan.title}"`,
+					message: `Plan content for ${plan.slug} could not be read.`,
+				});
+			}
+			log.info("PushOrchestrator", `Plan ${plan.slug}: no content found, skipping`);
+			continue;
+		}
+		let planResult: Awaited<ReturnType<typeof pushToJolli>>;
+		try {
+			planResult = await pushToJolli(ctx.baseUrl, ctx.apiKey, {
+				title: buildPlanPushTitle(summary, plan.title),
+				content: planContent,
+				commitHash: summary.commitHash,
+				docType: "plan",
+				branch: summary.branch,
+				...(plan.jolliPlanDocId && { docId: plan.jolliPlanDocId }),
+				repoUrl: ctx.repoUrl,
+				relativePath: buildBranchRelativePath(summary.branch),
+			});
+		} catch (err) {
+			if (err instanceof BindingRequiredError || err instanceof PluginOutdatedError) throw err;
+			const msg = err instanceof Error ? err.message : String(err);
+			log.error("PushOrchestrator", `Plan ${plan.slug} push FAILED: ${msg}`);
+			failures.push({ label: `plan "${plan.title}"`, message: msg });
+			continue;
+		}
+		results.push({
+			slug: plan.slug,
+			title: plan.title,
+			url: `${displayBase}/articles?doc=${planResult.docId}`,
+			docId: planResult.docId,
+		});
+	}
+	return { results, failures };
+}
+
+/** Uploads the given notes; like {@link pushPlanList}, single-note failures are collected. */
+async function pushNoteList(
+	notes: ReadonlyArray<NoteReference>,
+	summary: CommitSummary,
+	ctx: PushContext,
+	displayBase: string,
+	strictAttachments: boolean,
+): Promise<{ results: PushedNote[]; failures: PushAttachmentFailure[] }> {
+	const failures: PushAttachmentFailure[] = [];
+	const results: PushedNote[] = [];
+	for (const note of notes) {
+		let noteContent: string;
+		if (note.format === "snippet") {
+			if (note.content === undefined || note.content === "") {
+				if (strictAttachments) {
+					failures.push({
+						label: `note "${note.title}"`,
+						message: `Snippet note content for ${note.id} is empty.`,
+					});
+				}
+				log.warn("PushOrchestrator", `Snippet note ${note.id} has no content — skipping push`);
+				continue;
+			}
+			noteContent = note.content;
+		} else {
+			noteContent = (await readNoteFromBranch(note.id, ctx.workspaceRoot)) ?? "";
+			if (!noteContent) {
+				if (strictAttachments) {
+					failures.push({
+						label: `note "${note.title}"`,
+						message: `Note content for ${note.id} could not be read.`,
+					});
+				}
+				log.info("PushOrchestrator", `Note ${note.id}: no content found, skipping`);
+				continue;
+			}
+		}
+		let noteResult: Awaited<ReturnType<typeof pushToJolli>>;
+		try {
+			noteResult = await pushToJolli(ctx.baseUrl, ctx.apiKey, {
+				title: buildNotePushTitle(summary, note.title),
+				content: noteContent,
+				commitHash: summary.commitHash,
+				docType: "note",
+				branch: summary.branch,
+				...(note.jolliNoteDocId && { docId: note.jolliNoteDocId }),
+				repoUrl: ctx.repoUrl,
+				relativePath: buildBranchRelativePath(summary.branch),
+			});
+		} catch (err) {
+			if (err instanceof BindingRequiredError || err instanceof PluginOutdatedError) throw err;
+			const msg = err instanceof Error ? err.message : String(err);
+			log.error("PushOrchestrator", `Note ${note.id} push FAILED: ${msg}`);
+			failures.push({ label: `note "${note.title}"`, message: msg });
+			continue;
+		}
+		results.push({
+			id: note.id,
+			title: note.title,
+			url: `${displayBase}/articles?doc=${noteResult.docId}`,
+			docId: noteResult.docId,
+		});
+	}
+	return { results, failures };
+}
+
+/** Merges published plan URLs/docIds into plan references (matched by exact slug). */
+export function applyPlanUrls(
+	plans: ReadonlyArray<PlanReference> | undefined,
+	planUrls: ReadonlyArray<{ slug: string; url: string; docId: number }>,
+): ReadonlyArray<PlanReference> | undefined {
+	if (!plans || planUrls.length === 0) return plans;
+	const urlMap = new Map(planUrls.map((p) => [p.slug, p]));
+	return plans.map((p) => {
+		const pushed = urlMap.get(p.slug);
+		return pushed ? { ...p, jolliPlanDocUrl: pushed.url, jolliPlanDocId: pushed.docId } : p;
+	});
+}
+
+/** Merges published note URLs/docIds into note references (matched by id). */
+export function applyNoteUrls(
+	notes: ReadonlyArray<NoteReference>,
+	noteUrls: ReadonlyArray<{ id: string; url: string; docId: number }>,
+): ReadonlyArray<NoteReference> {
+	const urlMap = new Map(noteUrls.map((n) => [n.id, n]));
+	return notes.map((n) => {
+		const pushed = urlMap.get(n.id);
+		return pushed ? { ...n, jolliNoteDocUrl: pushed.url, jolliNoteDocId: pushed.docId } : n;
+	});
+}
+
+/**
+ * Deletes orphaned articles from the Space, then persists the result: only ids
+ * that were successfully deleted are cleared from `orphanedDocIds`; failed ids are
+ * kept so the next push retries them. Returns the persisted summary, or null when
+ * there were no orphans.
+ */
+async function cleanupOrphanedDocs(
+	originalSummary: CommitSummary,
+	updatedSummary: CommitSummary,
+	displayBase: string,
+	ctx: PushContext,
+): Promise<CommitSummary | null> {
+	const orphanedIds = originalSummary.orphanedDocIds ? [...originalSummary.orphanedDocIds] : [];
+	if (orphanedIds.length === 0) return null;
+
+	const results = await Promise.allSettled(
+		orphanedIds.map((id) => deleteFromJolli(displayBase, ctx.apiKey, id).then(() => id)),
+	);
+	const deleted = new Set<number>();
+	for (const r of results) {
+		if (r.status === "fulfilled") deleted.add(r.value);
+	}
+	const remaining = orphanedIds.filter((id) => !deleted.has(id));
+	if (deleted.size > 0) log.info("PushOrchestrator", `Deleted ${deleted.size} orphaned article(s)`);
+	if (remaining.length > 0) {
+		log.warn("PushOrchestrator", `Failed to delete ${remaining.length} orphaned article(s), will retry on next push`);
+	}
+
+	const cleaned: CommitSummary = {
+		...updatedSummary,
+		...(remaining.length > 0 ? { orphanedDocIds: remaining } : { orphanedDocIds: undefined }),
+	};
+	await ctx.storeSummary(cleaned, true);
+	return cleaned;
+}

--- a/vscode/src/services/JolliPushService.test.ts
+++ b/vscode/src/services/JolliPushService.test.ts
@@ -294,6 +294,48 @@ describe("pushToJolli", () => {
 		expect(parsedDocTypes).toEqual(["summary", "plan", "note"]);
 	});
 
+	it("round-trips summaryJson into the request body when present, and omits the key when absent", async () => {
+		const responseBody = JSON.stringify({
+			url: "u",
+			docId: 1,
+			jrn: "j",
+			created: true,
+		});
+		const writtenBodies: Array<string> = [];
+		mockHttpsRequest.mockImplementation(
+			(
+				_url: unknown,
+				_opts: unknown,
+				cb: (res: MockIncomingMessage) => void,
+			) => {
+				cb(createMockResponse(200, responseBody));
+				const req = createMockRequest();
+				req.write.mockImplementation((body: string) => {
+					writtenBodies.push(body);
+					return true;
+				});
+				return req;
+			},
+		);
+
+		const summaryJson = JSON.stringify({ version: 4, commitHash: "abc123" });
+		await pushToJolli("https://acme.jolli.ai", OLD_KEY, {
+			...DEFAULT_PAYLOAD,
+			docType: "summary",
+			summaryJson,
+		});
+		await pushToJolli("https://acme.jolli.ai", OLD_KEY, {
+			...DEFAULT_PAYLOAD,
+			docType: "summary",
+		});
+
+		expect(writtenBodies).toHaveLength(2);
+		const withField = JSON.parse(writtenBodies[0]) as Record<string, unknown>;
+		expect(withField.summaryJson).toBe(summaryJson);
+		const withoutField = JSON.parse(writtenBodies[1]) as Record<string, unknown>;
+		expect("summaryJson" in withoutField).toBe(false);
+	});
+
 	it("throws PluginOutdatedError on HTTP 426", async () => {
 		const responseBody = JSON.stringify({
 			message: "Please update your plugin.",
@@ -670,6 +712,32 @@ describe("pushToJolli", () => {
 		);
 	});
 
+	it("falls back to an empty repoUrl when both the 412 body and the payload omit it", async () => {
+		const responseBody = JSON.stringify({ error: "binding_required" });
+		const mockReq = createMockRequest();
+		const mockRes = createMockResponse(412, responseBody);
+
+		mockHttpsRequest.mockImplementation(
+			(
+				_url: unknown,
+				_opts: unknown,
+				cb: (res: MockIncomingMessage) => void,
+			) => {
+				cb(mockRes);
+				return mockReq;
+			},
+		);
+
+		// DEFAULT_PAYLOAD carries no repoUrl, so the error's repoUrl bottoms out at "".
+		const err = await pushToJolli(
+			"https://acme.jolli.ai",
+			OLD_KEY,
+			DEFAULT_PAYLOAD,
+		).catch((e: unknown) => e);
+		expect(err).toBeInstanceOf(BindingRequiredError);
+		expect((err as BindingRequiredError).repoUrl).toBe("");
+	});
+
 	it("does not treat unrelated 412 errors as BindingRequiredError", async () => {
 		const responseBody = JSON.stringify({ error: "precondition_failed" });
 		const mockReq = createMockRequest();
@@ -1005,5 +1073,29 @@ describe("deleteFromJolli", () => {
 
 		expect(mockHttpRequest).toHaveBeenCalledOnce();
 		expect(mockHttpsRequest).not.toHaveBeenCalled();
+	});
+
+	it("defaults the port to 80 for an http URL without an explicit port", async () => {
+		const mockReq = createMockRequest();
+		const mockRes: MockIncomingMessage = {
+			statusCode: 204,
+			on: vi.fn(),
+			resume: vi.fn(),
+		};
+
+		mockHttpRequest.mockImplementation(
+			(_opts: unknown, cb: (res: MockIncomingMessage) => void) => {
+				cb(mockRes);
+				return mockReq;
+			},
+		);
+
+		await deleteFromJolli("http://localhost", OLD_KEY, 42);
+
+		expect(mockHttpRequest).toHaveBeenCalledOnce();
+		const callArgs = mockHttpRequest.mock.calls[0] as [
+			{ port: number | string },
+		];
+		expect(callArgs[0].port).toBe(80);
 	});
 });

--- a/vscode/src/services/JolliPushService.ts
+++ b/vscode/src/services/JolliPushService.ts
@@ -105,6 +105,13 @@ export interface JolliPushPayload {
 	readonly repoUrl?: string;
 	/** Folder chain below the repo folder — flat `<branchSlug>` for all docTypes. No leading `/`. */
 	readonly relativePath?: string;
+	/**
+	 * Serialized structured summary JSON (summary docType only). The server stores
+	 * it as a hidden sidecar at `<repoFolder>/.jolli/summaries/<commitHash>.json`
+	 * for the share page's structured rendering. Optional: old servers strip the
+	 * unknown field and the push succeeds unchanged.
+	 */
+	readonly summaryJson?: string;
 }
 
 /** Response from a successful push */
@@ -113,6 +120,12 @@ export interface JolliPushResult {
 	readonly docId: number;
 	readonly jrn: string;
 	readonly created: boolean;
+	/**
+	 * Doc id of the hidden summary-JSON sidecar the server upserted (summary
+	 * pushes that carried `summaryJson` only). Informational — the server keys
+	 * the sidecar by commit hash, so the client never needs to track this id.
+	 */
+	readonly summaryJsonDocId?: number;
 }
 
 /** Body shape the server emits for non-2xx responses we explicitly handle. */

--- a/vscode/src/services/JolliShareService.test.ts
+++ b/vscode/src/services/JolliShareService.test.ts
@@ -1,0 +1,533 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── Mock node:http / node:https ────────────────────────────────────────────
+
+const { mockHttpRequest, mockHttpsRequest } = vi.hoisted(() => ({
+	mockHttpRequest: vi.fn(),
+	mockHttpsRequest: vi.fn(),
+}));
+
+vi.mock("node:http", () => ({ request: mockHttpRequest }));
+vi.mock("node:https", () => ({ request: mockHttpsRequest }));
+
+import {
+	type BranchSharePayload,
+	createBranchShare,
+	createLiveShare,
+	fetchSharedSnapshot,
+	type LiveSharePayload,
+	listOrgMembers,
+	PluginOutdatedError,
+	revokeBranchShare,
+	ShareRevokedError,
+	updateBranchShareExpiry,
+	updateLiveShare,
+} from "./JolliShareService.js";
+
+// ─── Mock request/response plumbing ─────────────────────────────────────────
+
+interface Listeners {
+	[event: string]: Array<(...args: Array<unknown>) => void>;
+}
+
+function mockResponse(statusCode: number | undefined, body: string) {
+	const listeners: Listeners = {};
+	const res = {
+		statusCode,
+		on: vi.fn((event: string, cb: (...args: Array<unknown>) => void) => {
+			if (!listeners[event]) listeners[event] = [];
+			listeners[event].push(cb);
+			return res;
+		}),
+		resume: vi.fn(),
+	};
+	queueMicrotask(() => {
+		if (body) for (const cb of listeners.data ?? []) cb(Buffer.from(body));
+		for (const cb of listeners.end ?? []) cb();
+	});
+	return res;
+}
+
+function mockRequest() {
+	const listeners: Listeners = {};
+	return {
+		on: vi.fn((event: string, cb: (...args: Array<unknown>) => void) => {
+			if (!listeners[event]) listeners[event] = [];
+			listeners[event].push(cb);
+		}),
+		write: vi.fn(),
+		end: vi.fn(),
+		_emit(event: string, ...args: Array<unknown>) {
+			for (const cb of listeners[event] ?? []) cb(...args);
+		},
+	};
+}
+
+/** Wires the https mock to reply with the given status + body (`undefined` = response with no status code). */
+function replyHttps(statusCode: number | undefined, body: string): void {
+	mockHttpsRequest.mockImplementation((_url: unknown, _opts: unknown, cb: (res: unknown) => void) => {
+		cb(mockResponse(statusCode, body));
+		return mockRequest();
+	});
+}
+
+/** Wires the http (non-TLS) mock to reply — used for http base URLs in local dev. */
+function replyHttp(statusCode: number, body: string): void {
+	mockHttpRequest.mockImplementation((_url: unknown, _opts: unknown, cb: (res: unknown) => void) => {
+		cb(mockResponse(statusCode, body));
+		return mockRequest();
+	});
+}
+
+function encodeKeyMeta(meta: Record<string, unknown>): string {
+	return Buffer.from(JSON.stringify(meta)).toString("base64url");
+}
+function makeKey(meta: Record<string, unknown>): string {
+	return `sk-jol-${encodeKeyMeta(meta)}.${Buffer.from("a".repeat(32)).toString("base64url")}`;
+}
+
+const KEY = makeKey({ t: "acme", u: "https://acme.jolli.ai" });
+const BASE = "https://acme.jolli.ai";
+
+const PAYLOAD: BranchSharePayload = {
+	repoUrl: "https://github.com/acme/repo",
+	repoName: "repo",
+	branch: "feature/x",
+	branchSlug: "feature-x",
+	headCommitHash: "a".repeat(40),
+	commitHashes: ["a".repeat(40)],
+	decisionCount: 3,
+	scope: { summary: true, plans: true, notes: true, transcripts: false },
+	content: "# memory",
+};
+
+const OK_RESULT = JSON.stringify({
+	shareId: "sh_1",
+	token: "tok_abc",
+	shareUrl: "https://acme.jolli.ai/b/feature-x-tok_abc",
+	expiresAt: "2026-09-01T00:00:00.000Z",
+	visibility: "public",
+});
+
+beforeEach(() => {
+	mockHttpRequest.mockReset();
+	mockHttpsRequest.mockReset();
+});
+
+describe("createBranchShare", () => {
+	it("resolves the share result on 2xx", async () => {
+		replyHttps(200, OK_RESULT);
+		const res = await createBranchShare(BASE, KEY, PAYLOAD);
+		expect(res.shareUrl).toBe("https://acme.jolli.ai/b/feature-x-tok_abc");
+		expect(res.token).toBe("tok_abc");
+	});
+
+	it("rejects when no base URL can be determined", async () => {
+		await expect(createBranchShare(undefined, "sk-jol-plainnowurl", PAYLOAD)).rejects.toThrow(
+			/site URL could not be determined/,
+		);
+	});
+
+	it("derives the base URL from the API key when none is passed", async () => {
+		replyHttps(200, OK_RESULT);
+		const res = await createBranchShare(undefined, KEY, PAYLOAD);
+		expect(res.shareId).toBe("sh_1");
+	});
+
+	it("maps 426 to PluginOutdatedError", async () => {
+		replyHttps(426, JSON.stringify({ message: "too old" }));
+		await expect(createBranchShare(BASE, KEY, PAYLOAD)).rejects.toBeInstanceOf(PluginOutdatedError);
+	});
+
+	it("surfaces a detailed error on other non-2xx", async () => {
+		replyHttps(400, JSON.stringify({ error: "bad_request", message: "nope" }));
+		await expect(createBranchShare(BASE, KEY, PAYLOAD)).rejects.toThrow(/bad_request — nope \(HTTP 400\)/);
+	});
+
+	it("rejects on invalid JSON", async () => {
+		replyHttps(200, "not json");
+		await expect(createBranchShare(BASE, KEY, PAYLOAD)).rejects.toThrow(/Invalid JSON/);
+	});
+
+	it("accepts a numeric shareId (server auto-increment id)", async () => {
+		replyHttps(200, JSON.stringify({ ...JSON.parse(OK_RESULT), shareId: 1 }));
+		const res = await createBranchShare(BASE, KEY, PAYLOAD);
+		expect(res.shareId).toBe(1);
+	});
+
+	it("rejects a 2xx whose body is missing required fields, surfacing the raw body", async () => {
+		replyHttps(200, JSON.stringify({ token: null, url: "https://acme.jolli.ai/x" }));
+		await expect(createBranchShare(BASE, KEY, PAYLOAD)).rejects.toThrow(
+			/unexpected response \(missing shareId\/token\/shareUrl\).*acme\.jolli\.ai/s,
+		);
+	});
+
+	it("rejects on a network error", async () => {
+		mockHttpsRequest.mockImplementation((_url: unknown, _opts: unknown, _cb: unknown) => {
+			const req = mockRequest();
+			queueMicrotask(() => req._emit("error", new Error("boom")));
+			return req;
+		});
+		await expect(createBranchShare(BASE, KEY, PAYLOAD)).rejects.toThrow(/Network error: boom/);
+	});
+
+	it("uses plain http for an http base URL", async () => {
+		replyHttp(200, OK_RESULT);
+		const res = await createBranchShare("http://jolli-local.me/test1", KEY, PAYLOAD);
+		expect(res.shareId).toBe("sh_1");
+		expect(mockHttpRequest).toHaveBeenCalled();
+		expect(mockHttpsRequest).not.toHaveBeenCalled();
+	});
+
+	it("falls back to a generic message on 426 with no body message", async () => {
+		replyHttps(426, JSON.stringify({}));
+		await expect(createBranchShare(BASE, KEY, PAYLOAD)).rejects.toThrow(/Plugin version is outdated/);
+	});
+
+	it("falls back to 'request failed' when the error body is empty", async () => {
+		replyHttps(500, JSON.stringify({}));
+		await expect(createBranchShare(BASE, KEY, PAYLOAD)).rejects.toThrow(/request failed \(HTTP 500\)/);
+	});
+
+	it("treats a response with no status code as HTTP 0 and rejects", async () => {
+		replyHttps(undefined, JSON.stringify({}));
+		await expect(createBranchShare(BASE, KEY, PAYLOAD)).rejects.toThrow(/request failed \(HTTP 0\)/);
+	});
+});
+
+describe("revokeBranchShare", () => {
+	it.each([200, 204, 404])("resolves on status %i", async (status) => {
+		replyHttps(status, "");
+		await expect(revokeBranchShare(BASE, KEY, "sh_1")).resolves.toBeUndefined();
+	});
+
+	it("rejects on an unexpected status", async () => {
+		replyHttps(500, "");
+		await expect(revokeBranchShare(BASE, KEY, "sh_1")).rejects.toThrow(/Revoke failed with status 500/);
+	});
+
+	it("rejects when no base URL can be determined", async () => {
+		await expect(revokeBranchShare(undefined, "sk-jol-plain", "sh_1")).rejects.toThrow(
+			/site URL could not be determined/,
+		);
+	});
+
+	it("rejects on a network error", async () => {
+		mockHttpsRequest.mockImplementation((_url: unknown, _opts: unknown, _cb: unknown) => {
+			const req = mockRequest();
+			queueMicrotask(() => req._emit("error", new Error("down")));
+			return req;
+		});
+		await expect(revokeBranchShare(BASE, KEY, "sh_1")).rejects.toThrow(/Network error: down/);
+	});
+
+	it("uses plain http for an http base URL", async () => {
+		replyHttp(204, "");
+		await expect(revokeBranchShare("http://jolli-local.me/test1", KEY, "sh_1")).resolves.toBeUndefined();
+		expect(mockHttpRequest).toHaveBeenCalled();
+		expect(mockHttpsRequest).not.toHaveBeenCalled();
+	});
+
+	it("treats a response with no status code as HTTP 0 and rejects", async () => {
+		replyHttps(undefined, "");
+		await expect(revokeBranchShare(BASE, KEY, "sh_1")).rejects.toThrow(/Revoke failed with status 0/);
+	});
+});
+
+describe("updateBranchShareExpiry", () => {
+	const EXPIRES = "2026-10-01T00:00:00.000Z";
+
+	it("PATCHes and resolves the server-confirmed expiry", async () => {
+		replyHttps(200, JSON.stringify({ shareId: 1, expiresAt: EXPIRES, visibility: "public" }));
+		const res = await updateBranchShareExpiry(BASE, KEY, "1", EXPIRES);
+		expect(res.expiresAt).toBe(EXPIRES);
+		const opts = mockHttpsRequest.mock.calls[0][1] as { method: string };
+		expect(opts.method).toBe("PATCH");
+	});
+
+	it("rejects a non-2xx with detail", async () => {
+		replyHttps(400, JSON.stringify({ error: "invalid_expiry", message: "must be in the future" }));
+		await expect(updateBranchShareExpiry(BASE, KEY, "1", EXPIRES)).rejects.toThrow(/must be in the future/);
+	});
+
+	it("rejects when no base URL can be determined", async () => {
+		await expect(updateBranchShareExpiry(undefined, "sk-jol-plain", "1", EXPIRES)).rejects.toThrow(
+			/site URL could not be determined/,
+		);
+	});
+
+	it("rejects on invalid JSON", async () => {
+		replyHttps(200, "nope");
+		await expect(updateBranchShareExpiry(BASE, KEY, "1", EXPIRES)).rejects.toThrow(/Invalid JSON/);
+	});
+
+	it("uses plain http for an http base URL", async () => {
+		replyHttp(200, JSON.stringify({ shareId: 1, expiresAt: EXPIRES, visibility: "public" }));
+		const res = await updateBranchShareExpiry("http://jolli-local.me/test1", KEY, "1", EXPIRES);
+		expect(res.expiresAt).toBe(EXPIRES);
+		expect(mockHttpRequest).toHaveBeenCalled();
+		expect(mockHttpsRequest).not.toHaveBeenCalled();
+	});
+
+	it("treats a response with no status code as HTTP 0 and rejects", async () => {
+		replyHttps(undefined, JSON.stringify({ shareId: 1, expiresAt: EXPIRES, visibility: "public" }));
+		await expect(updateBranchShareExpiry(BASE, KEY, "1", EXPIRES)).rejects.toThrow(/\(HTTP 0\)/);
+	});
+
+	it("falls back to a generic message when the error body is empty", async () => {
+		replyHttps(500, JSON.stringify({}));
+		await expect(updateBranchShareExpiry(BASE, KEY, "1", EXPIRES)).rejects.toThrow(
+			/expiry update failed \(HTTP 500\)/,
+		);
+	});
+
+	it("rejects on a network error", async () => {
+		mockHttpsRequest.mockImplementation((_url: unknown, _opts: unknown, _cb: unknown) => {
+			const req = mockRequest();
+			queueMicrotask(() => req._emit("error", new Error("offline")));
+			return req;
+		});
+		await expect(updateBranchShareExpiry(BASE, KEY, "1", EXPIRES)).rejects.toThrow(/Network error: offline/);
+	});
+});
+
+describe("fetchSharedSnapshot", () => {
+	const SNAP = JSON.stringify({
+		branch: "feature/x",
+		repoName: "repo",
+		decisionCount: 3,
+		headCommitHash: "a".repeat(40),
+		generatedAt: "2026-01-01T00:00:00.000Z",
+		scope: { summary: true, plans: true, notes: true, transcripts: false },
+		content: "# shared",
+	});
+
+	it("rejects an empty token", async () => {
+		await expect(fetchSharedSnapshot(BASE, "")).rejects.toThrow(/Missing share token/);
+	});
+
+	it("rejects an off-allowlist origin", async () => {
+		await expect(fetchSharedSnapshot("https://evil.example.com", "tok")).rejects.toThrow(/Rejected Jolli origin/);
+	});
+
+	it("resolves the snapshot on 2xx", async () => {
+		replyHttps(200, SNAP);
+		const snap = await fetchSharedSnapshot(BASE, "tok_abc");
+		expect(snap.branch).toBe("feature/x");
+		expect(snap.content).toBe("# shared");
+	});
+
+	it("sends a tenant-slug header for a path-based origin", async () => {
+		replyHttps(200, SNAP);
+		await fetchSharedSnapshot("https://jolli-local.me/test1", "tok_abc");
+		const opts = mockHttpsRequest.mock.calls[0][1] as { headers: Record<string, string> };
+		expect(opts.headers["x-tenant-slug"]).toBe("test1");
+	});
+
+	it("maps 410 to ShareRevokedError", async () => {
+		replyHttps(410, "");
+		await expect(fetchSharedSnapshot(BASE, "tok_abc")).rejects.toBeInstanceOf(ShareRevokedError);
+	});
+
+	it("maps a 200 with revoked:true to ShareRevokedError", async () => {
+		replyHttps(200, JSON.stringify({ revoked: true }));
+		await expect(fetchSharedSnapshot(BASE, "tok_abc")).rejects.toBeInstanceOf(ShareRevokedError);
+	});
+
+	it("maps 426 to PluginOutdatedError", async () => {
+		replyHttps(426, JSON.stringify({ message: "old" }));
+		await expect(fetchSharedSnapshot(BASE, "tok_abc")).rejects.toBeInstanceOf(PluginOutdatedError);
+	});
+
+	it("surfaces a detailed error on other non-2xx", async () => {
+		replyHttps(404, JSON.stringify({ error: "not_found" }));
+		await expect(fetchSharedSnapshot(BASE, "tok_abc")).rejects.toThrow(/not_found \(HTTP 404\)/);
+	});
+
+	it("rejects on invalid JSON", async () => {
+		replyHttps(200, "nope");
+		await expect(fetchSharedSnapshot(BASE, "tok_abc")).rejects.toThrow(/Invalid JSON/);
+	});
+
+	it("rejects on a network error", async () => {
+		mockHttpsRequest.mockImplementation((_url: unknown, _opts: unknown, _cb: unknown) => {
+			const req = mockRequest();
+			queueMicrotask(() => req._emit("error", new Error("net")));
+			return req;
+		});
+		await expect(fetchSharedSnapshot(BASE, "tok_abc")).rejects.toThrow(/Network error: net/);
+	});
+
+	it("treats a response with no status code as HTTP 0 and rejects", async () => {
+		replyHttps(undefined, JSON.stringify({}));
+		await expect(fetchSharedSnapshot(BASE, "tok_abc")).rejects.toThrow(/request failed \(HTTP 0\)/);
+	});
+
+	it("falls back to the default 426 message when the body has none", async () => {
+		replyHttps(426, JSON.stringify({}));
+		await expect(fetchSharedSnapshot(BASE, "tok_abc")).rejects.toThrow(/Plugin version is outdated/);
+	});
+
+	it("falls back to 'request failed' when the error body is empty", async () => {
+		replyHttps(500, JSON.stringify({}));
+		await expect(fetchSharedSnapshot(BASE, "tok_abc")).rejects.toThrow(/request failed \(HTTP 500\)/);
+	});
+});
+
+const LIVE_PAYLOAD: LiveSharePayload = {
+	repoUrl: "https://github.com/acme/repo",
+	repoName: "repo",
+	branch: "feature/x",
+	kind: "branch",
+	visibility: "public",
+	decisionCount: 3,
+	headCommitHash: "a".repeat(40),
+	commitHashes: ["a".repeat(40)],
+	branchSlug: "feature-x",
+	ref: {
+		kind: "branchCollection",
+		relativePath: "feature/x",
+		covered: [{ commitHash: "a".repeat(40), summaryDocId: 11, attachmentDocIds: [12] }],
+	},
+};
+
+describe("createLiveShare", () => {
+	it("resolves a public share (with token) on 2xx", async () => {
+		replyHttps(200, OK_RESULT);
+		const res = await createLiveShare(BASE, KEY, LIVE_PAYLOAD);
+		expect(res.shareUrl).toBe("https://acme.jolli.ai/b/feature-x-tok_abc");
+		expect(res.token).toBe("tok_abc");
+	});
+
+	it("resolves an org share with no token on 2xx", async () => {
+		replyHttps(
+			201,
+			JSON.stringify({
+				shareId: 7,
+				shareUrl: "https://acme.jolli.ai/share/branch/7/view",
+				expiresAt: "2026-09-01T00:00:00.000Z",
+				visibility: "org",
+			}),
+		);
+		const res = await createLiveShare(BASE, KEY, { ...LIVE_PAYLOAD, visibility: "org" });
+		expect(res.visibility).toBe("org");
+		expect(res.token).toBeUndefined();
+	});
+
+	it("rejects an unexpected 2xx shape (missing shareUrl)", async () => {
+		replyHttps(200, JSON.stringify({ shareId: 1 }));
+		await expect(createLiveShare(BASE, KEY, LIVE_PAYLOAD)).rejects.toThrow(/unexpected response/);
+	});
+
+	it("maps 426 to PluginOutdatedError", async () => {
+		replyHttps(426, JSON.stringify({ message: "too old" }));
+		await expect(createLiveShare(BASE, KEY, LIVE_PAYLOAD)).rejects.toBeInstanceOf(PluginOutdatedError);
+	});
+
+	it("rejects with detail on a 4xx", async () => {
+		replyHttps(400, JSON.stringify({ error: "bad_request", message: "nope" }));
+		await expect(createLiveShare(BASE, KEY, LIVE_PAYLOAD)).rejects.toThrow(/bad_request — nope \(HTTP 400\)/);
+	});
+
+	it("rejects when no base URL can be determined", async () => {
+		await expect(createLiveShare(undefined, makeKey({ t: "acme" }), LIVE_PAYLOAD)).rejects.toThrow(
+			/site URL could not be determined/,
+		);
+	});
+
+	it("treats an unparseable 2xx body as a missing-field response", async () => {
+		replyHttps(200, "not json");
+		await expect(createLiveShare(BASE, KEY, LIVE_PAYLOAD)).rejects.toThrow(/unexpected response/);
+	});
+
+	it("uses plain http for an http base URL", async () => {
+		replyHttp(200, OK_RESULT);
+		const res = await createLiveShare("http://jolli-local.me/test1", KEY, LIVE_PAYLOAD);
+		expect(res.shareId).toBe("sh_1");
+		expect(mockHttpRequest).toHaveBeenCalled();
+		expect(mockHttpsRequest).not.toHaveBeenCalled();
+	});
+
+	it("treats a response with no status code as HTTP 0 and rejects", async () => {
+		replyHttps(undefined, OK_RESULT);
+		await expect(createLiveShare(BASE, KEY, LIVE_PAYLOAD)).rejects.toThrow(/request failed \(HTTP 0\)/);
+	});
+
+	it("falls back to the default 426 message when the body has none", async () => {
+		replyHttps(426, JSON.stringify({}));
+		await expect(createLiveShare(BASE, KEY, LIVE_PAYLOAD)).rejects.toThrow(/Plugin version is outdated/);
+	});
+
+	it("rejects on a network error", async () => {
+		mockHttpsRequest.mockImplementation((_url: unknown, _opts: unknown, _cb: unknown) => {
+			const req = mockRequest();
+			queueMicrotask(() => req._emit("error", new Error("gone")));
+			return req;
+		});
+		await expect(createLiveShare(BASE, KEY, LIVE_PAYLOAD)).rejects.toThrow(/Network error: gone/);
+	});
+});
+
+describe("updateLiveShare", () => {
+	it("resolves the updated share on 2xx", async () => {
+		replyHttps(200, OK_RESULT);
+		const res = await updateLiveShare(BASE, KEY, "sh_1", { ref: LIVE_PAYLOAD.ref });
+		expect(res.shareId).toBe("sh_1");
+	});
+
+	it("rejects on a non-2xx", async () => {
+		replyHttps(500, JSON.stringify({ error: "boom" }));
+		await expect(updateLiveShare(BASE, KEY, "sh_1", { visibility: "org" })).rejects.toThrow(/HTTP 500/);
+	});
+
+	it("treats an empty 2xx body as null json and rejects with the raw-body suffix", async () => {
+		replyHttps(200, "");
+		await expect(updateLiveShare(BASE, KEY, "sh_1", { visibility: "org" })).rejects.toThrow(
+			/request failed \(HTTP 200\)/,
+		);
+	});
+});
+
+describe("listOrgMembers", () => {
+	it("maps { members }, coalescing a non-string name to empty and skipping members with no email", async () => {
+		replyHttps(
+			200,
+			JSON.stringify({
+				members: [
+					{ name: "Ada", email: "ada@example.com" },
+					{ name: null, email: "grace@example.com" },
+					{ name: "No Email" },
+				],
+			}),
+		);
+		expect(await listOrgMembers(BASE, KEY)).toEqual([
+			{ name: "Ada", email: "ada@example.com" },
+			{ name: "", email: "grace@example.com" },
+		]);
+	});
+
+	it("requests the API-key-authenticated /api/jolli-memory/org-members endpoint", async () => {
+		let requestedUrl: URL | undefined;
+		mockHttpsRequest.mockImplementation((url: unknown, _opts: unknown, cb: (res: unknown) => void) => {
+			requestedUrl = url as URL;
+			cb(mockResponse(200, JSON.stringify({ members: [] })));
+			return mockRequest();
+		});
+		await listOrgMembers(BASE, KEY);
+		expect(requestedUrl?.pathname).toBe("/api/jolli-memory/org-members");
+	});
+
+	it("returns [] on a non-2xx (picker still has git contributors + manual entry)", async () => {
+		replyHttps(403, JSON.stringify({ error: "forbidden" }));
+		expect(await listOrgMembers(BASE, KEY)).toEqual([]);
+	});
+
+	it("returns [] (never throws) when the request itself fails — e.g. no base URL", async () => {
+		expect(await listOrgMembers(undefined, makeKey({ t: "acme" }))).toEqual([]);
+	});
+
+	it("returns [] when members is not an array", async () => {
+		replyHttps(200, JSON.stringify({ members: "not-an-array" }));
+		expect(await listOrgMembers(BASE, KEY)).toEqual([]);
+	});
+});

--- a/vscode/src/services/JolliShareService.ts
+++ b/vscode/src/services/JolliShareService.ts
@@ -1,0 +1,520 @@
+/**
+ * JolliShareService
+ *
+ * HTTP client for the public branch-share feature. Three operations:
+ *
+ * - `createBranchShare` (sharer side, authed) — POST a branch snapshot
+ *   (summary + plan + notes, never transcripts) and get back a public `shareUrl`.
+ * - `revokeBranchShare` (sharer side, authed) — DELETE a share.
+ * - `fetchSharedSnapshot` (recipient side, **login-free**) — GET a snapshot by
+ *   token to render in the read-only share viewer. The token is the credential;
+ *   no Authorization header is sent. The origin is validated against the Jolli
+ *   allowlist before any request leaves the machine.
+ *
+ * Mirrors JolliPushService: Node http/https (not fetch) to tolerate self-signed
+ * certs in local dev, and the shared `buildJolliApiHeaders` for authed calls.
+ */
+
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+import {
+	assertJolliOriginAllowed,
+	type JolliApiKeyMeta,
+	parseBaseUrl,
+	parseJolliApiKey,
+} from "../../../cli/src/core/JolliApiUtils.js";
+import type { LiveRef } from "../../../cli/src/core/BranchShareStore.js";
+import { currentTraceHeader, newTraceHeader, TRACE_HEADER_NAME } from "../../../cli/src/core/TraceContext.js";
+import { VSCODE_CLIENT_INFO } from "./ClientInfo.js";
+import { buildJolliApiHeaders, PluginOutdatedError } from "./JolliPushService.js";
+
+export { PluginOutdatedError };
+
+/** Thrown when a share has been revoked or expired (HTTP 410 / `revoked: true`). */
+export class ShareRevokedError extends Error {
+	constructor(message?: string) {
+		super(message ?? "This share has been stopped.");
+		this.name = "ShareRevokedError";
+	}
+}
+
+/** Snapshot scope — summary always, plans/notes opt-in, transcripts never (conversations stay local). */
+export interface ShareScope {
+	readonly summary: true;
+	readonly plans: boolean;
+	readonly notes: boolean;
+	readonly transcripts: false;
+}
+
+/** Body posted to create/refresh a public share (branch or single commit). */
+export interface BranchSharePayload {
+	readonly repoUrl: string;
+	readonly repoName: string;
+	readonly branch: string;
+	readonly branchSlug: string;
+	/**
+	 * "branch" → every commit's summary, organized by commit. "commit" → a single
+	 * commit's summary. The server keys idempotency on this `kind` (commit shares
+	 * additionally on `headCommitHash`), so a branch share and a commit share on
+	 * the same branch are distinct resources with distinct tokens. The field name
+	 * MUST be `kind` — the backend's zod schema strips unknown keys, so a misnamed
+	 * field silently defaults to "branch" and collapses both onto one resource.
+	 */
+	readonly kind: "branch" | "commit";
+	readonly headCommitHash: string;
+	readonly commitHashes: ReadonlyArray<string>;
+	readonly decisionCount: number;
+	readonly scope: ShareScope;
+	readonly content: string;
+}
+
+/** Response from a successful expiry update (PATCH). */
+export interface ShareExpiryResult {
+	readonly shareId: number | string;
+	readonly expiresAt: string;
+	readonly visibility: "public";
+}
+
+/** Response from a successful create. */
+export interface BranchShareResult {
+	/** Server share id — numeric in practice (auto-increment), but treated as opaque. */
+	readonly shareId: number | string;
+	readonly token: string;
+	readonly shareUrl: string;
+	readonly expiresAt: string;
+	readonly visibility: "public";
+}
+
+/** Login-free snapshot returned to the recipient viewer. */
+export interface SharedSnapshot {
+	readonly branch: string;
+	readonly repoName: string;
+	readonly repoUrl?: string;
+	readonly decisionCount: number;
+	readonly headCommitHash: string;
+	readonly generatedAt: string;
+	readonly scope: {
+		readonly summary: boolean;
+		readonly plans: boolean;
+		readonly notes: boolean;
+		readonly transcripts: boolean;
+	};
+	readonly content: string;
+	readonly revoked?: boolean;
+}
+
+interface ErrorBody {
+	error?: string;
+	message?: string;
+}
+
+/** Resolves the base URL from an explicit arg or the API key's embedded URL. */
+function resolveBaseUrl(baseUrl: string | undefined, keyMeta: JolliApiKeyMeta | null): string | undefined {
+	return baseUrl ?? keyMeta?.u;
+}
+
+/**
+ * Creates (or refreshes, idempotent per repo+branch) a public branch share.
+ * Returns the share URL and token.
+ */
+export function createBranchShare(
+	baseUrl: string | undefined,
+	apiKey: string,
+	payload: BranchSharePayload,
+): Promise<BranchShareResult> {
+	const keyMeta = parseJolliApiKey(apiKey);
+	const resolvedBaseUrl = resolveBaseUrl(baseUrl, keyMeta);
+	if (!resolvedBaseUrl) {
+		return Promise.reject(
+			new Error(
+				"Jolli site URL could not be determined. Please regenerate your Jolli API Key and set it again (STATUS panel → ...).",
+			),
+		);
+	}
+	const parsed = parseBaseUrl(resolvedBaseUrl);
+	const targetUrl = new URL("/api/share/branch", parsed.origin);
+	const body = JSON.stringify(payload);
+	const isHttps = targetUrl.protocol === "https:";
+	const headers = buildJolliApiHeaders({
+		apiKey,
+		keyMeta,
+		tenantSlug: parsed.tenantSlug,
+		bodyByteLength: Buffer.byteLength(body),
+	});
+	const requestFn = isHttps ? httpsRequest : httpRequest;
+
+	return new Promise<BranchShareResult>((resolve, reject) => {
+		const req = requestFn(targetUrl, { method: "POST", headers }, (res) => {
+			const chunks: Array<Buffer> = [];
+			res.on("data", (chunk: Buffer) => chunks.push(chunk));
+			res.on("end", () => {
+				const raw = Buffer.concat(chunks).toString("utf-8");
+				try {
+					const json = JSON.parse(raw) as BranchShareResult & ErrorBody;
+					const status = res.statusCode ?? 0;
+					if (status >= 200 && status < 300) {
+						// A 2xx whose body is missing shareId/token/shareUrl means the
+						// server's response shape doesn't match this client's contract
+						// (e.g. a stub, or a different field naming). Fail loud with the
+						// raw body instead of crashing later on `token.slice(...)`.
+						if (
+							json?.shareId === undefined ||
+							json?.shareId === null ||
+							typeof json?.token !== "string" ||
+							typeof json?.shareUrl !== "string"
+						) {
+							reject(
+								new Error(
+									`Share endpoint returned an unexpected response (missing shareId/token/shareUrl). HTTP ${status}: ${raw.slice(0, 300)}`,
+								),
+							);
+							return;
+						}
+						resolve(json);
+					} else if (status === 426) {
+						reject(
+							new PluginOutdatedError(
+								json.message ?? "Plugin version is outdated. Please update to the latest version.",
+							),
+						);
+					} else {
+						const detail = [json.error, json.message].filter(Boolean).join(" — ");
+						reject(new Error(`${detail || "request failed"} (HTTP ${status})`));
+					}
+				} catch {
+					reject(new Error(`Invalid JSON response (HTTP ${res.statusCode}): ${raw.slice(0, 200)}`));
+				}
+			});
+		});
+		req.on("error", (err) => reject(new Error(`Network error: ${err.message}`)));
+		req.write(body);
+		req.end();
+	});
+}
+
+/** Revokes a public branch share by id. */
+export function revokeBranchShare(baseUrl: string | undefined, apiKey: string, shareId: string): Promise<void> {
+	const keyMeta = parseJolliApiKey(apiKey);
+	const resolvedBaseUrl = resolveBaseUrl(baseUrl, keyMeta);
+	if (!resolvedBaseUrl) {
+		return Promise.reject(new Error("Jolli site URL could not be determined."));
+	}
+	const parsed = parseBaseUrl(resolvedBaseUrl);
+	const targetUrl = new URL(`/api/share/branch/${encodeURIComponent(shareId)}`, parsed.origin);
+	const isHttps = targetUrl.protocol === "https:";
+	const headers = buildJolliApiHeaders({ apiKey, keyMeta, tenantSlug: parsed.tenantSlug });
+	const requestFn = isHttps ? httpsRequest : httpRequest;
+
+	return new Promise<void>((resolve, reject) => {
+		const req = requestFn(targetUrl, { method: "DELETE", headers }, (res) => {
+			res.resume();
+			const status = res.statusCode ?? 0;
+			// 404 = already gone → idempotent success.
+			if (status === 200 || status === 204 || status === 404) resolve();
+			else reject(new Error(`Revoke failed with status ${status}`));
+		});
+		req.on("error", (err) => reject(new Error(`Network error: ${err.message}`)));
+		req.end();
+	});
+}
+
+/**
+ * Adjusts an existing share's expiry via `PATCH /api/share/branch/:shareId`.
+ * `expiresAt` is an absolute ISO timestamp (server requires future, ≤ now+365d).
+ * Returns the server-confirmed `expiresAt`.
+ */
+export function updateBranchShareExpiry(
+	baseUrl: string | undefined,
+	apiKey: string,
+	shareId: string,
+	expiresAt: string,
+): Promise<ShareExpiryResult> {
+	const keyMeta = parseJolliApiKey(apiKey);
+	const resolvedBaseUrl = resolveBaseUrl(baseUrl, keyMeta);
+	if (!resolvedBaseUrl) {
+		return Promise.reject(new Error("Jolli site URL could not be determined."));
+	}
+	const parsed = parseBaseUrl(resolvedBaseUrl);
+	const targetUrl = new URL(`/api/share/branch/${encodeURIComponent(shareId)}`, parsed.origin);
+	const body = JSON.stringify({ expiresAt });
+	const isHttps = targetUrl.protocol === "https:";
+	const headers = buildJolliApiHeaders({
+		apiKey,
+		keyMeta,
+		tenantSlug: parsed.tenantSlug,
+		bodyByteLength: Buffer.byteLength(body),
+	});
+	const requestFn = isHttps ? httpsRequest : httpRequest;
+
+	return new Promise<ShareExpiryResult>((resolve, reject) => {
+		const req = requestFn(targetUrl, { method: "PATCH", headers }, (res) => {
+			const chunks: Array<Buffer> = [];
+			res.on("data", (chunk: Buffer) => chunks.push(chunk));
+			res.on("end", () => {
+				const raw = Buffer.concat(chunks).toString("utf-8");
+				const status = res.statusCode ?? 0;
+				try {
+					const json = JSON.parse(raw) as ShareExpiryResult & ErrorBody;
+					if (status >= 200 && status < 300 && typeof json.expiresAt === "string") {
+						resolve(json);
+					} else {
+						const detail = [json.error, json.message].filter(Boolean).join(" — ");
+						reject(new Error(`${detail || "expiry update failed"} (HTTP ${status})`));
+					}
+				} catch {
+					reject(new Error(`Invalid JSON response (HTTP ${status}): ${raw.slice(0, 200)}`));
+				}
+			});
+		});
+		req.on("error", (err) => reject(new Error(`Network error: ${err.message}`)));
+		req.write(body);
+		req.end();
+	});
+}
+
+// ─── Live (Space-backed) shares ────────────────────────────────────────────────
+// These target the SAME /api/share/branch routes, now live-only: the share
+// references live Space docs (a `covered` allowlist) instead of a frozen `content`
+// blob. `visibility` is `public` (bearer link) or `org` (auth-gated, no token).
+
+/** Body posted to create a live share. No `content` blob. */
+export interface LiveSharePayload {
+	readonly repoUrl: string;
+	readonly repoName: string;
+	readonly branch: string;
+	readonly kind: "branch" | "commit";
+	readonly visibility: "public" | "org" | "people";
+	readonly decisionCount: number;
+	/** Still sent: backs the NOT-NULL columns + the server's idempotency indexes. */
+	readonly headCommitHash: string;
+	readonly commitHashes: ReadonlyArray<string>;
+	/** Display slug (slugify) — distinct from the push folder identity in `ref`. */
+	readonly branchSlug?: string;
+	readonly ref: LiveRef;
+	/** `people` access allowlist (lowercased emails). Server-gated; omit for public/org. */
+	readonly recipients?: ReadonlyArray<string>;
+}
+
+/** Response from creating a live share. `token` is absent for `org`/`people` shares. */
+export interface LiveShareResult {
+	readonly shareId: number | string;
+	readonly shareUrl: string;
+	readonly expiresAt: string;
+	readonly visibility: "public" | "org" | "people";
+	readonly token?: string;
+	/** Server-confirmed `people` allowlist (echoed back). */
+	readonly recipients?: ReadonlyArray<string>;
+}
+
+/** Response from updating a live share. PATCH endpoints may echo only changed fields. */
+export type LiveShareUpdateResult = Partial<LiveShareResult>;
+
+/** An org member offered as a recipient candidate (name + deliverable email). */
+export interface OrgMember {
+	readonly name: string;
+	readonly email: string;
+}
+
+/**
+ * Sends an authed JSON request to a Jolli API path and returns the status + parsed
+ * body. Centralizes the http/https + header + parse boilerplate the live endpoints
+ * share (the older snapshot functions predate this and inline it).
+ */
+function requestJson<T>(
+	method: "POST" | "PATCH" | "GET",
+	baseUrl: string | undefined,
+	apiKey: string,
+	path: string,
+	body?: unknown,
+): Promise<{ status: number; json: (T & ErrorBody) | null; raw: string }> {
+	const keyMeta = parseJolliApiKey(apiKey);
+	const resolvedBaseUrl = resolveBaseUrl(baseUrl, keyMeta);
+	if (!resolvedBaseUrl) {
+		return Promise.reject(
+			new Error(
+				"Jolli site URL could not be determined. Please regenerate your Jolli API Key and set it again (STATUS panel → ...).",
+			),
+		);
+	}
+	const parsed = parseBaseUrl(resolvedBaseUrl);
+	const targetUrl = new URL(path, parsed.origin);
+	const payload = body === undefined ? undefined : JSON.stringify(body);
+	const headers = buildJolliApiHeaders({
+		apiKey,
+		keyMeta,
+		tenantSlug: parsed.tenantSlug,
+		...(payload !== undefined && { bodyByteLength: Buffer.byteLength(payload) }),
+	});
+	const requestFn = targetUrl.protocol === "https:" ? httpsRequest : httpRequest;
+
+	return new Promise((resolve, reject) => {
+		const req = requestFn(targetUrl, { method, headers }, (res) => {
+			const chunks: Array<Buffer> = [];
+			res.on("data", (chunk: Buffer) => chunks.push(chunk));
+			res.on("end", () => {
+				const raw = Buffer.concat(chunks).toString("utf-8");
+				let json: (T & ErrorBody) | null = null;
+				try {
+					json = raw.length > 0 ? (JSON.parse(raw) as T & ErrorBody) : null;
+				} catch {
+					json = null;
+				}
+				resolve({ status: res.statusCode ?? 0, json, raw });
+			});
+		});
+		req.on("error", (err) => reject(new Error(`Network error: ${err.message}`)));
+		if (payload !== undefined) req.write(payload);
+		req.end();
+	});
+}
+
+/** Maps a non-2xx response to the right error (426 → outdated, else detail + status). */
+function rejectForStatus(status: number, json: ErrorBody | null, raw: string): Error {
+	if (status === 426) {
+		return new PluginOutdatedError(json?.message ?? "Plugin version is outdated. Please update to the latest version.");
+	}
+	const detail = [json?.error, json?.message].filter(Boolean).join(" — ");
+	return new Error(`${detail || "request failed"} (HTTP ${status})${json ? "" : `: ${raw.slice(0, 200)}`}`);
+}
+
+/** Creates a live share. Requires `shareId` + `shareUrl`; `token` only for `public`. */
+export async function createLiveShare(
+	baseUrl: string | undefined,
+	apiKey: string,
+	payload: LiveSharePayload,
+): Promise<LiveShareResult> {
+	const { status, json, raw } = await requestJson<LiveShareResult>(
+		"POST",
+		baseUrl,
+		apiKey,
+		"/api/share/branch",
+		payload,
+	);
+	if (status >= 200 && status < 300) {
+		if (json?.shareId === undefined || json?.shareId === null || typeof json?.shareUrl !== "string") {
+			throw new Error(
+				`Share endpoint returned an unexpected response (missing shareId/shareUrl). HTTP ${status}: ${raw.slice(0, 300)}`,
+			);
+		}
+		return json;
+	}
+	throw rejectForStatus(status, json, raw);
+}
+
+/** Patch type for a live share update — expiry, visibility, recipients, and/or the `covered` ref. */
+export interface LiveSharePatch {
+	readonly visibility?: "public" | "org" | "people";
+	readonly expiresAt?: string;
+	readonly ref?: LiveRef;
+	/** `people` allowlist (lowercased emails); sent when changing audience. */
+	readonly recipients?: ReadonlyArray<string>;
+}
+
+/** Updates a live share (visibility / covered ref / expiry) via PATCH. */
+export async function updateLiveShare(
+	baseUrl: string | undefined,
+	apiKey: string,
+	shareId: string,
+	patch: LiveSharePatch,
+): Promise<LiveShareUpdateResult> {
+	const { status, json, raw } = await requestJson<LiveShareUpdateResult>(
+		"PATCH",
+		baseUrl,
+		apiKey,
+		`/api/share/branch/${encodeURIComponent(shareId)}`,
+		patch,
+	);
+	// A recipients-only / non-`public`-toggle PATCH legitimately returns NO `shareUrl`
+	// (the link didn't change), so accept any 2xx with a body — the caller falls back to
+	// the existing URL. Only a missing body or a non-2xx is an error.
+	if (status >= 200 && status < 300 && json) {
+		return json;
+	}
+	throw rejectForStatus(status, json, raw);
+}
+
+/**
+ * Lists active org members as recipient candidates (name + email), via the
+ * API-key-authenticated `GET /api/jolli-memory/org-members`. The server returns
+ * `{ members: [{ email, name }] }` (active users only, deactivated excluded).
+ * Best-effort: skips entries without a deliverable email and returns `[]` on any
+ * error (the recipient picker still has git contributors + manual entry).
+ */
+export async function listOrgMembers(baseUrl: string | undefined, apiKey: string): Promise<OrgMember[]> {
+	try {
+		const { status, json } = await requestJson<{ members?: Array<Record<string, unknown>> }>(
+			"GET",
+			baseUrl,
+			apiKey,
+			"/api/jolli-memory/org-members",
+		);
+		if (status < 200 || status >= 300 || json === null) return [];
+		const rows = Array.isArray(json.members) ? json.members : [];
+		const members: OrgMember[] = [];
+		for (const row of rows) {
+			const email = typeof row.email === "string" ? row.email.trim() : "";
+			if (!email) continue;
+			const name = typeof row.name === "string" ? row.name : "";
+			members.push({ name, email });
+		}
+		return members;
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * Fetches a shared snapshot by token (login-free). Validates `origin` against
+ * the Jolli allowlist first. Throws `ShareRevokedError` on 410 / `revoked`.
+ */
+export function fetchSharedSnapshot(origin: string, token: string): Promise<SharedSnapshot> {
+	if (token.length === 0) {
+		return Promise.reject(new Error("Missing share token."));
+	}
+	return new Promise<SharedSnapshot>((resolve, reject) => {
+		const parsed = parseBaseUrl(origin);
+		// Refuse off-allowlist / non-HTTPS origins before any request leaves the machine.
+		// Inside the executor so a bad origin rejects rather than throwing synchronously.
+		assertJolliOriginAllowed(parsed.origin);
+		const targetUrl = new URL(`/api/share/snapshot/${encodeURIComponent(token)}`, parsed.origin);
+		const headers: Record<string, string> = {
+			"x-jolli-client": `${VSCODE_CLIENT_INFO.kind}/${VSCODE_CLIENT_INFO.version}`,
+			// Carry a trace id so this login-free outbound call is correlated in logs.
+			[TRACE_HEADER_NAME]: currentTraceHeader() ?? newTraceHeader(),
+		};
+		if (parsed.tenantSlug) headers["x-tenant-slug"] = parsed.tenantSlug;
+		// assertJolliOriginAllowed guarantees https, so no http fallback is needed here.
+		const req = httpsRequest(targetUrl, { method: "GET", headers }, (res) => {
+			const chunks: Array<Buffer> = [];
+			res.on("data", (chunk: Buffer) => chunks.push(chunk));
+			res.on("end", () => {
+				const raw = Buffer.concat(chunks).toString("utf-8");
+				const status = res.statusCode ?? 0;
+				if (status === 410) {
+					reject(new ShareRevokedError());
+					return;
+				}
+				try {
+					const json = JSON.parse(raw) as SharedSnapshot & ErrorBody;
+					if (status >= 200 && status < 300) {
+						if (json.revoked) reject(new ShareRevokedError());
+						else resolve(json);
+					} else if (status === 426) {
+						reject(
+							new PluginOutdatedError(
+								json.message ?? "Plugin version is outdated. Please update to the latest version.",
+							),
+						);
+					} else {
+						const detail = [json.error, json.message].filter(Boolean).join(" — ");
+						reject(new Error(`${detail || "request failed"} (HTTP ${status})`));
+					}
+				} catch {
+					reject(new Error(`Invalid JSON response (HTTP ${status}): ${raw.slice(0, 200)}`));
+				}
+			});
+		});
+		req.on("error", (err) => reject(new Error(`Network error: ${err.message}`)));
+		req.end();
+	});
+}

--- a/vscode/src/services/LiveShareController.test.ts
+++ b/vscode/src/services/LiveShareController.test.ts
@@ -1,0 +1,523 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommitSummary, PlanReference } from "../../../cli/src/Types.js";
+
+const { mockPush } = vi.hoisted(() => ({ mockPush: vi.fn() }));
+const { mockCreate, mockUpdate } = vi.hoisted(() => ({ mockCreate: vi.fn(), mockUpdate: vi.fn() }));
+const { mockGetShare, mockPutShare } = vi.hoisted(() => ({ mockGetShare: vi.fn(), mockPutShare: vi.fn() }));
+const { mockLoad } = vi.hoisted(() => ({ mockLoad: vi.fn() }));
+const { mockParseKey } = vi.hoisted(() => ({ mockParseKey: vi.fn() }));
+
+vi.mock("./JolliPushOrchestrator.js", () => ({ pushSummaryWithAttachments: mockPush }));
+vi.mock("./JolliShareService.js", () => ({ createLiveShare: mockCreate, updateLiveShare: mockUpdate }));
+vi.mock("../../../cli/src/core/BranchShareStore.js", () => ({
+	getBranchShare: mockGetShare,
+	putBranchShare: mockPutShare,
+}));
+vi.mock("../views/BranchSummaryLoader.js", () => ({ loadBranchSummaries: mockLoad }));
+vi.mock("../../../cli/src/core/GitOps.js", () => ({ getDefaultBranch: vi.fn().mockResolvedValue("main") }));
+vi.mock("../util/GitRemoteUtils.js", () => ({
+	getCanonicalRepoUrl: vi.fn().mockResolvedValue("https://github.com/acme/repo"),
+}));
+vi.mock("../../../cli/src/core/KBPathResolver.js", () => ({ extractRepoName: () => "repo" }));
+vi.mock("../../../cli/src/core/JolliApiUtils.js", () => ({ parseJolliApiKey: mockParseKey }));
+vi.mock("../../../cli/src/core/SummaryStore.js", () => ({
+	resolveEffectiveTopics: (s: CommitSummary) => s.topics ?? [],
+}));
+vi.mock("../views/SummaryUtils.js", () => ({ buildBranchRelativePath: (b: string) => b }));
+vi.mock("../../../cli/src/core/SummaryExporter.js", () => ({ slugify: (b: string) => b.replace(/\//g, "-") }));
+vi.mock("../util/Logger.js", () => ({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }));
+
+import { AttachmentPushError, generateLiveShare, NothingToShareError, reconcileLiveShare } from "./LiveShareController.js";
+
+// Maps a commit hash to a deterministic summary docId for assertions.
+const SUMMARY_DOC = { A: 1001, B: 1002, C: 1003 } as const;
+
+function plan(slug: string, updatedAt: string, jolliPlanDocId?: number): PlanReference {
+	return { slug, title: "Plan", addedAt: updatedAt, updatedAt, ...(jolliPlanDocId && { jolliPlanDocId }) };
+}
+
+interface NoteFix {
+	id: string;
+	title: string;
+	updatedAt: string;
+	jolliNoteDocId?: number;
+}
+function note(id: string, updatedAt: string, jolliNoteDocId?: number): NoteFix {
+	return { id, title: "Note", updatedAt, ...(jolliNoteDocId && { jolliNoteDocId }) };
+}
+
+function summary(
+	commitHash: keyof typeof SUMMARY_DOC,
+	plans: PlanReference[] = [],
+	notes: NoteFix[] = [],
+): CommitSummary {
+	return {
+		commitHash,
+		branch: "feature/x",
+		commitMessage: `commit ${commitHash}`,
+		topics: [{ title: `t-${commitHash}` }],
+		plans,
+		notes,
+	} as unknown as CommitSummary;
+}
+
+const storeSummarySpy = vi.fn().mockResolvedValue(undefined);
+const deps = () => ({
+	bridge: { storeSummary: storeSummarySpy } as never,
+	workspaceRoot: "/repo",
+	apiKey: "sk-jol-test",
+	resolveBinding: vi.fn().mockResolvedValue({ status: "bound" }),
+});
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockParseKey.mockReturnValue({ u: "https://acme.jolli.ai" });
+	mockCreate.mockResolvedValue({
+		shareId: 7,
+		shareUrl: "https://acme.jolli.ai/b/x",
+		expiresAt: "2026-09-01T00:00:00.000Z",
+		visibility: "public",
+		token: "tok_abcdefgh",
+	});
+	mockUpdate.mockResolvedValue({
+		shareId: 7,
+		shareUrl: "https://acme.jolli.ai/b/x",
+		expiresAt: "2026-09-01T00:00:00.000Z",
+		visibility: "public",
+	});
+	mockPutShare.mockResolvedValue(undefined);
+	// Default push: echo a docId for the chosen plan/note attachments; summary doc per commit.
+	type Att = { plans: PlanReference[]; notes: Array<{ id: string; title: string; jolliNoteDocId?: number }> };
+	mockPush.mockImplementation((s: CommitSummary, _ctx: unknown, attachments?: Att) => {
+		const plans = (attachments?.plans ?? []).map((p) => ({
+			slug: p.slug,
+			title: p.title,
+			docId: p.jolliPlanDocId ?? 9000 + p.slug.length,
+			url: "u",
+		}));
+		const notes = (attachments?.notes ?? []).map((n) => ({
+			id: n.id,
+			title: n.title,
+			docId: n.jolliNoteDocId ?? 8000 + n.id.length,
+			url: "u",
+		}));
+		return Promise.resolve({
+			pushedDoc: {
+				commitHash: s.commitHash,
+				summaryDocId: SUMMARY_DOC[s.commitHash as keyof typeof SUMMARY_DOC],
+				plans,
+				notes,
+			},
+			updatedSummary: s,
+			attachmentFailures: [],
+			isUpdate: false,
+			attachmentCount: plans.length + notes.length,
+		});
+	});
+});
+
+describe("generateLiveShare", () => {
+	it("throws NothingToShareError when the subject has no summaries", async () => {
+		mockLoad.mockResolvedValue({ summaries: [], missingCount: 0 });
+		await expect(generateLiveShare({ ...deps(), branch: "feature/x", visibility: "public" })).rejects.toBeInstanceOf(
+			NothingToShareError,
+		);
+	});
+
+	it("pushes the newest plan revision once (by its owner) and links both commits to the same doc", async () => {
+		// Same base plan "p" on commit A (old, docId 500 already minted) and B (newer revision, no docId yet).
+		const a = summary("A", [plan("p-aaaaaaaa", "2026-01-01T00:00:00Z", 500)]);
+		const b = summary("B", [plan("p-bbbbbbbb", "2026-02-01T00:00:00Z")]);
+		mockLoad.mockResolvedValue({ summaries: [a, b], missingCount: 0 });
+
+		await generateLiveShare({ ...deps(), branch: "feature/x", visibility: "public" });
+
+		// A (older) owns nothing; B (newer) owns the winner, pushed with the seed docId 500 so it updates in place.
+		const callA = mockPush.mock.calls.find((c) => c[0].commitHash === "A");
+		const callB = mockPush.mock.calls.find((c) => c[0].commitHash === "B");
+		expect(callA?.[2]).toEqual({ plans: [], notes: [] });
+		expect(callB?.[2].plans).toEqual([
+			expect.objectContaining({ slug: "p-bbbbbbbb", jolliPlanDocId: 500 }),
+		]);
+
+		// Both commits' covered reference the SAME live plan doc (500).
+		const ref = mockCreate.mock.calls[0][2].ref;
+		expect(ref.kind).toBe("branchCollection");
+		expect(ref.covered).toEqual([
+			{ commitHash: "A", summaryDocId: 1001, attachmentDocIds: [500] },
+			{ commitHash: "B", summaryDocId: 1002, attachmentDocIds: [500] },
+		]);
+	});
+
+	it("sends headCommitHash/commitHashes/decisionCount and records the share locally", async () => {
+		const a = summary("A");
+		const b = summary("B");
+		mockLoad.mockResolvedValue({ summaries: [a, b], missingCount: 0 });
+
+		await generateLiveShare({ ...deps(), branch: "feature/x", visibility: "org" });
+
+		const payload = mockCreate.mock.calls[0][2];
+		expect(payload.headCommitHash).toBe("B");
+		expect(payload.commitHashes).toEqual(["A", "B"]);
+		expect(payload.decisionCount).toBe(2); // one topic per commit
+		expect(payload.visibility).toBe("org");
+
+		const stored = mockPutShare.mock.calls[0][2];
+		expect(stored.visibility).toBe("public"); // from the (mocked) create result
+		expect(stored.recipients).toBeUndefined(); // recipients are session-only, never persisted
+		expect(stored.token8).toBe("tok_abcd");
+	});
+
+	it("dedupes a recurring NOTE to its newest revision and links both commits to the same doc", async () => {
+		// Note "n1" on A (old, docId 700) and B (newer revision, no docId).
+		const a = summary("A", [], [note("n1", "2026-01-01T00:00:00Z", 700)]);
+		const b = summary("B", [], [note("n1", "2026-02-01T00:00:00Z")]);
+		mockLoad.mockResolvedValue({ summaries: [a, b], missingCount: 0 });
+
+		await generateLiveShare({ ...deps(), branch: "feature/x", visibility: "public" });
+
+		const callA = mockPush.mock.calls.find((c) => c[0].commitHash === "A");
+		const callB = mockPush.mock.calls.find((c) => c[0].commitHash === "B");
+		expect(callA?.[2].notes).toEqual([]);
+		expect(callB?.[2].notes).toEqual([expect.objectContaining({ id: "n1", jolliNoteDocId: 700 })]);
+
+		const ref = mockCreate.mock.calls[0][2].ref;
+		expect(ref.covered).toEqual([
+			{ commitHash: "A", summaryDocId: 1001, attachmentDocIds: [700] },
+			{ commitHash: "B", summaryDocId: 1002, attachmentDocIds: [700] },
+		]);
+	});
+
+	it("keeps an out-of-order older revision's docId as the seed (plan + note else-if)", async () => {
+		// A (iterated first) has the NEWER updatedAt but no docId; B (iterated second) is
+		// OLDER but carries a docId — the else-if must adopt B's docId as the seed.
+		const a = summary("A", [plan("p-aaaaaaaa", "2026-02-01T00:00:00Z")], [note("n1", "2026-02-01T00:00:00Z")]);
+		const b = summary("B", [plan("p-bbbbbbbb", "2026-01-01T00:00:00Z", 900)], [note("n1", "2026-01-01T00:00:00Z", 950)]);
+		mockLoad.mockResolvedValue({ summaries: [a, b], missingCount: 0 });
+
+		await generateLiveShare({ ...deps(), branch: "feature/x", visibility: "public" });
+
+		// A owns the winners (newer updatedAt) but pushes them with B's seeded docIds.
+		const callA = mockPush.mock.calls.find((c) => c[0].commitHash === "A");
+		expect(callA?.[2].plans).toEqual([expect.objectContaining({ jolliPlanDocId: 900 })]);
+		expect(callA?.[2].notes).toEqual([expect.objectContaining({ jolliNoteDocId: 950 })]);
+	});
+
+	it("invokes the push context's storeSummary passthrough", async () => {
+		mockLoad.mockResolvedValue({ summaries: [summary("A")], missingCount: 0 });
+		const d = deps();
+		mockPush.mockImplementation((s: CommitSummary, ctx: { storeSummary: (x: unknown, b: boolean) => Promise<void> }) => {
+			ctx.storeSummary(s, true); // exercise the buildPushContext passthrough
+			return Promise.resolve({
+				pushedDoc: { commitHash: s.commitHash, summaryDocId: 1, plans: [], notes: [] },
+				updatedSummary: s,
+				attachmentFailures: [],
+				isUpdate: false,
+				attachmentCount: 0,
+			});
+		});
+		await generateLiveShare({ ...d, branch: "feature/x", visibility: "public" });
+		expect(storeSummarySpy).toHaveBeenCalledWith(expect.objectContaining({ commitHash: "A" }), true);
+	});
+
+	it("throws when the API key yields no site URL", async () => {
+		mockParseKey.mockReturnValue(undefined);
+		await expect(generateLiveShare({ ...deps(), branch: "feature/x", visibility: "public" })).rejects.toThrow(
+			/Jolli site URL could not be determined/,
+		);
+		expect(mockCreate).not.toHaveBeenCalled();
+	});
+
+	it("treats a summary with no plans/notes fields as an empty attachment set", async () => {
+		// Older summaries can omit `plans`/`notes` entirely — both the winner pass and
+		// the covered builder must fall back to empty lists instead of crashing.
+		const bare = {
+			commitHash: "A",
+			branch: "feature/x",
+			commitMessage: "commit A",
+			topics: [],
+		} as unknown as CommitSummary;
+		mockLoad.mockResolvedValue({ summaries: [bare], missingCount: 0 });
+
+		await generateLiveShare({ ...deps(), branch: "feature/x", visibility: "public" });
+
+		expect(mockPush.mock.calls[0][2]).toEqual({ plans: [], notes: [] });
+		const ref = mockCreate.mock.calls[0][2].ref;
+		expect(ref.covered).toEqual([{ commitHash: "A", summaryDocId: 1001, attachmentDocIds: [] }]);
+	});
+
+	it("ignores an older revision that brings no docId (winner and seed both unchanged)", async () => {
+		// A (newer, iterated first) wins; B's older revision has no docId to adopt, so
+		// the loop keeps A's entry untouched and A pushes without a seeded docId.
+		const a = summary("A", [plan("p-aaaaaaaa", "2026-02-01T00:00:00Z")], [note("n1", "2026-02-01T00:00:00Z")]);
+		const b = summary("B", [plan("p-bbbbbbbb", "2026-01-01T00:00:00Z")], [note("n1", "2026-01-01T00:00:00Z")]);
+		mockLoad.mockResolvedValue({ summaries: [a, b], missingCount: 0 });
+
+		await generateLiveShare({ ...deps(), branch: "feature/x", visibility: "public" });
+
+		const callA = mockPush.mock.calls.find((c) => c[0].commitHash === "A");
+		const callB = mockPush.mock.calls.find((c) => c[0].commitHash === "B");
+		expect(callA?.[2].plans).toEqual([expect.objectContaining({ slug: "p-aaaaaaaa" })]);
+		expect(callA?.[2].plans[0].jolliPlanDocId).toBeUndefined();
+		expect(callA?.[2].notes[0].jolliNoteDocId).toBeUndefined();
+		expect(callB?.[2]).toEqual({ plans: [], notes: [] });
+
+		// B's covered still references the docs pushed under A (same live docs).
+		const ref = mockCreate.mock.calls[0][2].ref;
+		expect(ref.covered[1].attachmentDocIds).toEqual(ref.covered[0].attachmentDocIds);
+		expect(ref.covered[0].attachmentDocIds).toHaveLength(2);
+	});
+
+	it("groups two distinct plan winners owned by the same commit into one attachment list", async () => {
+		const a = summary("A", [
+			plan("p1-aaaaaaaa", "2026-01-01T00:00:00Z", 501),
+			plan("p2-aaaaaaaa", "2026-01-01T00:00:00Z", 502),
+		]);
+		mockLoad.mockResolvedValue({ summaries: [a], missingCount: 0 });
+
+		await generateLiveShare({ ...deps(), branch: "feature/x", visibility: "public" });
+
+		const callA = mockPush.mock.calls[0];
+		expect(callA[2].plans.map((p: PlanReference) => p.jolliPlanDocId)).toEqual([501, 502]);
+	});
+
+	it("covers a commit whose attachments produced no docs with an empty allowlist", async () => {
+		// The push reports no plan/note docs (e.g. bodies unreadable → skipped), so the
+		// covered builder finds no docId for either attachment and adds nothing.
+		const a = summary("A", [plan("p-aaaaaaaa", "2026-01-01T00:00:00Z")], [note("n1", "2026-01-01T00:00:00Z")]);
+		mockLoad.mockResolvedValue({ summaries: [a], missingCount: 0 });
+		mockPush.mockResolvedValue({
+			pushedDoc: { commitHash: "A", summaryDocId: 1001, plans: [], notes: [] },
+			updatedSummary: a,
+			attachmentFailures: [],
+			isUpdate: false,
+			attachmentCount: 0,
+		});
+
+		await generateLiveShare({ ...deps(), branch: "feature/x", visibility: "public" });
+
+		const ref = mockCreate.mock.calls[0][2].ref;
+		expect(ref.covered).toEqual([{ commitHash: "A", summaryDocId: 1001, attachmentDocIds: [] }]);
+	});
+
+	it("fails instead of creating a share when a plan/note upload failed", async () => {
+		const a = summary("A", [plan("p-aaaaaaaa", "2026-01-01T00:00:00Z")], [note("n1", "2026-01-01T00:00:00Z")]);
+		mockLoad.mockResolvedValue({ summaries: [a], missingCount: 0 });
+		mockPush.mockResolvedValue({
+			pushedDoc: { commitHash: "A", summaryDocId: 1001, plans: [], notes: [] },
+			updatedSummary: a,
+			attachmentFailures: [
+				{ label: 'plan "Plan"', message: "Network error: socket hang up" },
+				{ label: 'note "Note"', message: "permission denied (HTTP 403)" },
+			],
+			isUpdate: false,
+			attachmentCount: 0,
+		});
+
+		const result = generateLiveShare({ ...deps(), branch: "feature/x", visibility: "public" });
+		await expect(result).rejects.toThrow(
+			/Could not sync shared plans\/notes: plan "Plan": Network error: socket hang up; note "Note": permission denied \(HTTP 403\)/,
+		);
+		await expect(result).rejects.toBeInstanceOf(AttachmentPushError);
+		expect(mockCreate).not.toHaveBeenCalled();
+		expect(mockPutShare).not.toHaveBeenCalled();
+	});
+
+	it("sends the people allowlist to the server and persists the echoed recipients", async () => {
+		mockLoad.mockResolvedValue({ summaries: [summary("A")], missingCount: 0 });
+		mockCreate.mockResolvedValue({
+			shareId: 7,
+			shareUrl: "https://acme.jolli.ai/b/x",
+			expiresAt: "2026-09-01T00:00:00.000Z",
+			visibility: "people",
+			recipients: ["marta@jolli.ai"],
+		});
+
+		await generateLiveShare({
+			...deps(),
+			branch: "feature/x",
+			visibility: "people",
+			recipients: ["marta@jolli.ai"],
+		});
+
+		expect(mockCreate.mock.calls[0][2].recipients).toEqual(["marta@jolli.ai"]);
+		const stored = mockPutShare.mock.calls[0][2];
+		expect(stored.visibility).toBe("people");
+		expect(stored.recipients).toEqual(["marta@jolli.ai"]);
+		expect(stored.token8).toBeUndefined(); // people shares carry no bearer token
+	});
+
+	it("builds a commitDocs ref for a single-commit share", async () => {
+		const a = summary("A", [plan("p-aaaaaaaa", "2026-01-01T00:00:00Z", 500)]);
+		mockLoad.mockResolvedValue({ summaries: [a], missingCount: 0 });
+
+		await generateLiveShare({ ...deps(), branch: "feature/x", commitHash: "A", visibility: "public" });
+
+		const ref = mockCreate.mock.calls[0][2].ref;
+		expect(ref).toEqual({ kind: "commitDocs", summaryDocIds: [1001], attachmentDocIds: [500] });
+	});
+
+	it("commit share can use the provided open summary instead of filtering current base..HEAD", async () => {
+		const openSummary = summary("A", [plan("p-aaaaaaaa", "2026-01-01T00:00:00Z", 500)]);
+		mockLoad.mockResolvedValue({ summaries: [summary("B")], missingCount: 0 });
+
+		await generateLiveShare({
+			...deps(),
+			branch: "feature/opened",
+			commitHash: "A",
+			commitSummary: openSummary,
+			visibility: "public",
+		});
+
+		expect(mockLoad).not.toHaveBeenCalled();
+		const ref = mockCreate.mock.calls[0][2].ref;
+		expect(ref).toEqual({ kind: "commitDocs", summaryDocIds: [1001], attachmentDocIds: [500] });
+		expect(mockPush.mock.calls[0][0]).toBe(openSummary);
+	});
+});
+
+describe("reconcileLiveShare", () => {
+	it("no-ops when there is no live branch-share record", async () => {
+		mockGetShare.mockResolvedValue(undefined);
+		await reconcileLiveShare(deps(), "feature/x");
+		expect(mockUpdate).not.toHaveBeenCalled();
+	});
+
+	it("no-ops for a commit-share record (only branchCollection reconciles)", async () => {
+		mockGetShare.mockResolvedValue({
+			shareId: "9",
+			shareUrl: "u",
+			visibility: "public",
+			ref: { kind: "commitDocs", summaryDocIds: [1], attachmentDocIds: [] },
+			expiresAt: "x",
+			decisionCount: 1,
+		});
+		await reconcileLiveShare(deps(), "feature/x");
+		expect(mockUpdate).not.toHaveBeenCalled();
+	});
+
+	it("no-ops when the branch has no summaries (leaves the share untouched)", async () => {
+		mockGetShare.mockResolvedValue({
+			shareId: "7",
+			shareUrl: "u",
+			visibility: "public",
+			ref: { kind: "branchCollection", relativePath: "feature/x", covered: [] },
+			expiresAt: "x",
+			decisionCount: 0,
+		});
+		mockLoad.mockResolvedValue({ summaries: [], missingCount: 0 });
+		await reconcileLiveShare(deps(), "feature/x");
+		expect(mockUpdate).not.toHaveBeenCalled();
+	});
+
+	it("rebuilds covered from the current base..HEAD and PATCHes (drops a removed commit)", async () => {
+		mockGetShare.mockResolvedValue({
+			shareId: "7",
+			shareUrl: "https://acme.jolli.ai/b/x",
+			visibility: "public",
+			ref: { kind: "branchCollection", relativePath: "feature/x", covered: [{ commitHash: "A", summaryDocId: 1, attachmentDocIds: [] }, { commitHash: "B", summaryDocId: 2, attachmentDocIds: [] }] },
+			expiresAt: "2026-09-01T00:00:00.000Z",
+			decisionCount: 2,
+		});
+		// B was dropped from the branch — only A remains now.
+		mockLoad.mockResolvedValue({ summaries: [summary("A")], missingCount: 0 });
+
+		await reconcileLiveShare(deps(), "feature/x");
+
+		expect(mockUpdate).toHaveBeenCalledOnce();
+		const ref = mockUpdate.mock.calls[0][3].ref;
+		expect(ref.covered).toEqual([{ commitHash: "A", summaryDocId: 1001, attachmentDocIds: [] }]);
+	});
+
+	it("recomputes decisionCount/titles from the current base..HEAD (not the stale create-time values)", async () => {
+		mockGetShare.mockResolvedValue({
+			shareId: "7",
+			shareUrl: "https://acme.jolli.ai/b/x",
+			visibility: "public",
+			ref: { kind: "branchCollection", relativePath: "feature/x", covered: [] },
+			expiresAt: "2026-09-01T00:00:00.000Z",
+			decisionCount: 1, // stale: recorded when the branch had a single commit
+			titles: ["t-A"],
+		});
+		// The branch now carries two commits — the reconciled record must reflect both.
+		mockLoad.mockResolvedValue({ summaries: [summary("A"), summary("B")], missingCount: 0 });
+
+		await reconcileLiveShare(deps(), "feature/x");
+
+		const stored = mockPutShare.mock.calls.at(-1)?.[2];
+		expect(stored.decisionCount).toBe(2);
+		expect(stored.titles).toEqual(["t-A", "t-B"]);
+	});
+
+	it("fails reconcile instead of PATCHing covered when an attachment upload failed", async () => {
+		const a = summary("A", [plan("p-aaaaaaaa", "2026-01-01T00:00:00Z")]);
+		mockGetShare.mockResolvedValue({
+			shareId: "7",
+			shareUrl: "https://acme.jolli.ai/b/x",
+			visibility: "public",
+			ref: { kind: "branchCollection", relativePath: "feature/x", covered: [] },
+			expiresAt: "2026-09-01T00:00:00.000Z",
+			decisionCount: 1,
+		});
+		mockLoad.mockResolvedValue({ summaries: [a], missingCount: 0 });
+		mockPush.mockResolvedValue({
+			pushedDoc: { commitHash: "A", summaryDocId: 1001, plans: [], notes: [] },
+			updatedSummary: a,
+			attachmentFailures: [{ label: 'plan "Plan"', message: "unauthorized (HTTP 401)" }],
+			isUpdate: false,
+			attachmentCount: 0,
+		});
+
+		await expect(reconcileLiveShare(deps(), "feature/x")).rejects.toThrow(
+			/Could not sync shared plans\/notes: plan "Plan": unauthorized \(HTTP 401\)/,
+		);
+		expect(mockUpdate).not.toHaveBeenCalled();
+		expect(mockPutShare).not.toHaveBeenCalled();
+	});
+
+	it("adopts a re-minted token but keeps the cached visibility when the PATCH omits it", async () => {
+		mockGetShare.mockResolvedValue({
+			shareId: "7",
+			shareUrl: "https://acme.jolli.ai/b/x",
+			visibility: "org",
+			ref: { kind: "branchCollection", relativePath: "feature/x", covered: [] },
+			expiresAt: "2026-09-01T00:00:00.000Z",
+			decisionCount: 1,
+		});
+		mockLoad.mockResolvedValue({ summaries: [summary("A")], missingCount: 0 });
+		// The PATCH re-minted a bearer token but echoed neither visibility nor shareUrl.
+		mockUpdate.mockResolvedValue({ shareId: "7", token: "tok_fresh_full" });
+
+		await reconcileLiveShare(deps(), "feature/x");
+
+		const stored = mockPutShare.mock.calls.at(-1)?.[2];
+		expect(stored.token8).toBe("tok_fres"); // fresh token wins over any cached token8
+		expect(stored.visibility).toBe("org"); // cached fallback
+		expect(stored.shareUrl).toBe("https://acme.jolli.ai/b/x"); // cached fallback
+	});
+
+	it("preserves the cached shareUrl/expiry/recipients/token when the ref-only PATCH omits them", async () => {
+		mockGetShare.mockResolvedValue({
+			shareId: "7",
+			shareUrl: "https://acme.jolli.ai/b/keep",
+			visibility: "people",
+			token8: "keeptok8",
+			recipients: ["marta@jolli.ai"],
+			ref: { kind: "branchCollection", relativePath: "feature/x", covered: [] },
+			expiresAt: "2026-09-01T00:00:00.000Z",
+			decisionCount: 2,
+		});
+		mockLoad.mockResolvedValue({ summaries: [summary("A")], missingCount: 0 });
+		// A ref-only PATCH response: no shareUrl / expiresAt / recipients / token echoed back.
+		mockUpdate.mockResolvedValue({ shareId: "7", visibility: "people" });
+
+		await reconcileLiveShare(deps(), "feature/x");
+
+		const stored = mockPutShare.mock.calls.at(-1)?.[2];
+		expect(stored.shareUrl).toBe("https://acme.jolli.ai/b/keep");
+		expect(stored.expiresAt).toBe("2026-09-01T00:00:00.000Z");
+		expect(stored.recipients).toEqual(["marta@jolli.ai"]);
+		expect(stored.token8).toBe("keeptok8");
+		expect(stored.visibility).toBe("people");
+	});
+});

--- a/vscode/src/services/LiveShareController.ts
+++ b/vscode/src/services/LiveShareController.ts
@@ -1,0 +1,376 @@
+/**
+ * LiveShareController
+ *
+ * Orchestrates a live, Space-backed share for a branch (or a single commit):
+ *   1. push every summary on `base..HEAD` (and its plans/notes) to the bound Space
+ *      via the shared push orchestrator, and
+ *   2. create/refresh a live share that REFERENCES the resulting doc ids (a
+ *      `covered` allowlist) — never a frozen content blob.
+ *
+ * UI-agnostic: the binding chooser is injected as `resolveBinding`. The webview
+ * layer (SummaryWebviewPanel) wires that callback and renders the result.
+ *
+ * Cross-summary doc-id identity is the crux. A plan/note's `jolliPlanDocId` /
+ * `jolliNoteDocId` is persisted onto whichever summary's push first minted it, and
+ * the SAME plan (by base slug) / note (by id) recurs across many commits, each
+ * mapping to ONE Space doc. So this controller owns a branch-wide map and:
+ *   - pushes each unique plan/note exactly once, by the summary carrying its latest
+ *     revision (oldest→newest, so the newest content wins), reusing the known docId
+ *     so the one Space doc updates in place (never a duplicate);
+ *   - builds each commit's `covered` attachment ids from that shared map, so a
+ *     commit that references a plan pushed "under" another commit still points at
+ *     the same live doc.
+ *
+ * A per-(workspaceRoot, branch) in-flight guard prevents overlapping generate /
+ * reconcile passes from lost-updating `covered` (PATCH replaces it wholesale).
+ */
+
+import type { CommitSummary, PlanReference, NoteReference } from "../../../cli/src/Types.js";
+import { type LiveRef, getBranchShare, putBranchShare } from "../../../cli/src/core/BranchShareStore.js";
+import { getDefaultBranch } from "../../../cli/src/core/GitOps.js";
+import { parseJolliApiKey } from "../../../cli/src/core/JolliApiUtils.js";
+import { extractRepoName } from "../../../cli/src/core/KBPathResolver.js";
+import { slugify } from "../../../cli/src/core/SummaryExporter.js";
+import { resolveEffectiveTopics } from "../../../cli/src/core/SummaryStore.js";
+import type { JolliMemoryBridge } from "../JolliMemoryBridge.js";
+import { getCanonicalRepoUrl } from "../util/GitRemoteUtils.js";
+import { log } from "../util/Logger.js";
+import { planBaseKey } from "../util/PlanGrouping.js";
+import { loadBranchSummaries } from "../views/BranchSummaryLoader.js";
+import { buildBranchRelativePath } from "../views/SummaryUtils.js";
+import type { BindingOutcome, PushAttachmentFailure, PushContext } from "./JolliPushOrchestrator.js";
+import { pushSummaryWithAttachments } from "./JolliPushOrchestrator.js";
+import { createLiveShare, type LiveShareResult, updateLiveShare } from "./JolliShareService.js";
+
+/** Raised when the share subject has no generated summaries to push. */
+export class NothingToShareError extends Error {
+	constructor(branch: string) {
+		super(`No memories on "${branch}" yet — make a commit so Jolli can summarize it, then share.`);
+		this.name = "NothingToShareError";
+	}
+}
+
+/** Raised when one or more plan/note Space docs failed to upload. */
+export class AttachmentPushError extends Error {
+	constructor(readonly failures: ReadonlyArray<PushAttachmentFailure>) {
+		super(`Could not sync shared plans/notes: ${formatAttachmentFailures(failures)}`);
+		this.name = "AttachmentPushError";
+	}
+}
+
+function formatAttachmentFailures(failures: ReadonlyArray<PushAttachmentFailure>): string {
+	return failures.map((f) => `${f.label}: ${f.message}`).join("; ");
+}
+
+/** Dependencies the controller needs that aren't on the params. */
+export interface LiveShareDeps {
+	readonly bridge: JolliMemoryBridge;
+	readonly workspaceRoot: string;
+	readonly apiKey: string;
+	readonly resolveBinding: (repoUrl: string) => Promise<BindingOutcome>;
+}
+
+export interface GenerateLiveShareParams extends LiveShareDeps {
+	readonly branch: string;
+	/** Set for a single-commit share; omit for a whole-branch share. */
+	readonly commitHash?: string;
+	/**
+	 * The already-open summary for a single-commit share. When present, commit
+	 * shares are sourced from this exact memory instead of filtering the current
+	 * checkout's `base..HEAD` set, so sharing an open memory is stable across
+	 * branch switches.
+	 */
+	readonly commitSummary?: CommitSummary;
+	readonly visibility: "public" | "org" | "people";
+	/** `people` allowlist (lowercased emails) sent to the server; omit for public/org. */
+	readonly recipients?: ReadonlyArray<string>;
+}
+
+// One in-flight pass per (workspaceRoot, branch) — generate/reconcile for the same
+// subject must not overlap, or a slower pass computed from an older base..HEAD
+// could PATCH a stale `covered` over a newer one (PATCH replaces it wholesale).
+const inFlight = new Map<string, Promise<unknown>>();
+
+function withSubjectLock<T>(workspaceRoot: string, branch: string, work: () => Promise<T>): Promise<T> {
+	const key = `${workspaceRoot}\u0000${branch}`;
+	const prior = inFlight.get(key) ?? Promise.resolve();
+	const next = prior.then(work, work);
+	inFlight.set(
+		key,
+		next.then(
+			() => undefined,
+			() => undefined,
+		),
+	);
+	return next;
+}
+
+/** Resolves the site base URL from the API key, or throws if it can't be derived. */
+function resolveBaseUrl(apiKey: string): string {
+	const baseUrl = parseJolliApiKey(apiKey)?.u;
+	if (!baseUrl) {
+		throw new Error(
+			"Jolli site URL could not be determined. Please regenerate your Jolli API Key and set it again (STATUS panel → ...).",
+		);
+	}
+	return baseUrl;
+}
+
+/** Loads the subject's summaries (chronological oldest→newest); a commit share filters to one. */
+async function loadSubjectSummaries(
+	deps: LiveShareDeps & { readonly commitSummary?: CommitSummary },
+	commitHash: string | undefined,
+): Promise<ReadonlyArray<CommitSummary>> {
+	if (commitHash && deps.commitSummary?.commitHash === commitHash) return [deps.commitSummary];
+	const base = await getDefaultBranch(deps.workspaceRoot);
+	const { summaries } = await loadBranchSummaries(deps.bridge, base);
+	return commitHash ? summaries.filter((s) => s.commitHash === commitHash) : summaries;
+}
+
+/** The winner revision of a recurring plan/note + which commit owns its push. */
+interface Winner<T> {
+	readonly ref: T;
+	readonly ownerCommit: string;
+	/** A known docId for this plan/note (from any commit's prior push) so the push updates in place. */
+	readonly seedDocId?: number;
+}
+
+/**
+ * Pushes the subject's summaries + deduped attachments and builds the live `ref`.
+ * Shared by generate + reconcile so create-time and reconcile produce identical refs.
+ */
+async function pushSubjectAndBuildRef(
+	subjectSummaries: ReadonlyArray<CommitSummary>,
+	kind: "branch" | "commit",
+	branch: string,
+	ctx: PushContext,
+): Promise<LiveRef> {
+	// 1. Pick the winner revision per plan base-slug / note id (latest updatedAt),
+	//    remembering the owner commit and any known docId to reuse.
+	const planWinners = new Map<string, Winner<PlanReference>>();
+	const noteWinners = new Map<string, Winner<NoteReference>>();
+	for (const summary of subjectSummaries) {
+		for (const plan of summary.plans ?? []) {
+			const key = planBaseKey(plan.slug);
+			const prev = planWinners.get(key);
+			const seedDocId = plan.jolliPlanDocId ?? prev?.seedDocId;
+			if (!prev || Date.parse(plan.updatedAt) >= Date.parse(prev.ref.updatedAt)) {
+				planWinners.set(key, { ref: plan, ownerCommit: summary.commitHash, seedDocId });
+			} else if (seedDocId !== prev.seedDocId) {
+				planWinners.set(key, { ...prev, seedDocId });
+			}
+		}
+		for (const note of summary.notes ?? []) {
+			const prev = noteWinners.get(note.id);
+			const seedDocId = note.jolliNoteDocId ?? prev?.seedDocId;
+			if (!prev || Date.parse(note.updatedAt) >= Date.parse(prev.ref.updatedAt)) {
+				noteWinners.set(note.id, { ref: note, ownerCommit: summary.commitHash, seedDocId });
+			} else if (seedDocId !== prev.seedDocId) {
+				noteWinners.set(note.id, { ...prev, seedDocId });
+			}
+		}
+	}
+
+	// 2. Assign each winner (with its known docId injected) to its owner commit.
+	const ownedPlans = new Map<string, PlanReference[]>();
+	const ownedNotes = new Map<string, NoteReference[]>();
+	const pushInto = <T>(map: Map<string, T[]>, commit: string, item: T): void => {
+		const arr = map.get(commit);
+		if (arr) arr.push(item);
+		else map.set(commit, [item]);
+	};
+	for (const w of planWinners.values()) {
+		pushInto(ownedPlans, w.ownerCommit, w.seedDocId ? { ...w.ref, jolliPlanDocId: w.seedDocId } : w.ref);
+	}
+	for (const w of noteWinners.values()) {
+		pushInto(ownedNotes, w.ownerCommit, w.seedDocId ? { ...w.ref, jolliNoteDocId: w.seedDocId } : w.ref);
+	}
+
+	// 3. Push each summary oldest→newest with only its owned attachments. Capture the
+	//    pushed summary docId per commit and accumulate the branch-wide attachment map.
+	const planDocIdByBase = new Map<string, number>();
+	const noteDocIdById = new Map<string, number>();
+	for (const w of planWinners.values()) if (w.seedDocId) planDocIdByBase.set(planBaseKey(w.ref.slug), w.seedDocId);
+	for (const [id, w] of noteWinners) if (w.seedDocId) noteDocIdById.set(id, w.seedDocId);
+
+	const summaryDocIds: number[] = [];
+	for (const summary of subjectSummaries) {
+		const result = await pushSummaryWithAttachments(summary, ctx, {
+			plans: ownedPlans.get(summary.commitHash) ?? [],
+			notes: ownedNotes.get(summary.commitHash) ?? [],
+		}, {
+			strictAttachments: true,
+		});
+		if (result.attachmentFailures.length > 0) {
+			throw new AttachmentPushError(result.attachmentFailures);
+		}
+		summaryDocIds.push(result.pushedDoc.summaryDocId);
+		for (const p of result.pushedDoc.plans) planDocIdByBase.set(planBaseKey(p.slug), p.docId);
+		for (const n of result.pushedDoc.notes) noteDocIdById.set(n.id, n.docId);
+	}
+
+	// 4. Build covered: each commit references its OWN plans/notes' docids (resolved
+	//    via the shared map, so a doc pushed under a different commit is still linked).
+	const coveredFor = (summary: CommitSummary): number[] => {
+		const ids = new Set<number>();
+		for (const plan of summary.plans ?? []) {
+			const docId = planDocIdByBase.get(planBaseKey(plan.slug));
+			if (docId) ids.add(docId);
+		}
+		for (const note of summary.notes ?? []) {
+			const docId = noteDocIdById.get(note.id);
+			if (docId) ids.add(docId);
+		}
+		return [...ids];
+	};
+
+	if (kind === "commit") {
+		return {
+			kind: "commitDocs",
+			summaryDocIds,
+			attachmentDocIds: coveredFor(subjectSummaries[0]),
+		};
+	}
+	return {
+		kind: "branchCollection",
+		relativePath: buildBranchRelativePath(branch),
+		covered: subjectSummaries.map((s, i) => ({
+			commitHash: s.commitHash,
+			summaryDocId: summaryDocIds[i],
+			attachmentDocIds: coveredFor(s),
+		})),
+	};
+}
+
+/**
+ * Aggregates the subject's decisions for the share headline/teaser: total topic
+ * count and the first 5 distinct topic titles. Shared by generate + reconcile so
+ * a reconciled share reflects the CURRENT base..HEAD, not the create-time set.
+ */
+function summarizeDecisions(summaries: ReadonlyArray<CommitSummary>): { decisionCount: number; titles: string[] } {
+	const topicsByCommit = summaries.map((s) => resolveEffectiveTopics(s));
+	const decisionCount = topicsByCommit.reduce((total, topics) => total + topics.length, 0);
+	const titles = [
+		...new Set(topicsByCommit.flatMap((ts) => ts.map((t) => t.title.trim())).filter((t) => t.length > 0)),
+	].slice(0, 5);
+	return { decisionCount, titles };
+}
+
+/** Builds the push context (binding chooser injected) for a subject push. */
+function buildPushContext(deps: LiveShareDeps, baseUrl: string, repoUrl: string): PushContext {
+	return {
+		baseUrl,
+		apiKey: deps.apiKey,
+		repoUrl,
+		workspaceRoot: deps.workspaceRoot,
+		storeSummary: (s, sync) => deps.bridge.storeSummary(s, sync),
+		resolveBinding: deps.resolveBinding,
+	};
+}
+
+/**
+ * Creates (or refreshes, idempotent per repo+branch) a live share: pushes the
+ * subject's content to the Space and records a share referencing the live docs.
+ */
+export function generateLiveShare(params: GenerateLiveShareParams): Promise<LiveShareResult> {
+	return withSubjectLock(params.workspaceRoot, params.branch, async () => {
+		const baseUrl = resolveBaseUrl(params.apiKey);
+		const repoUrl = await getCanonicalRepoUrl(params.workspaceRoot);
+		const repoName = extractRepoName(params.workspaceRoot);
+		const kind = params.commitHash ? "commit" : "branch";
+
+		const subjectSummaries = await loadSubjectSummaries(params, params.commitHash);
+		if (subjectSummaries.length === 0) throw new NothingToShareError(params.branch);
+
+		const ctx = buildPushContext(params, baseUrl, repoUrl);
+		const ref = await pushSubjectAndBuildRef(subjectSummaries, kind, params.branch, ctx);
+
+		const { decisionCount, titles } = summarizeDecisions(subjectSummaries);
+		const headCommitHash = subjectSummaries[subjectSummaries.length - 1].commitHash;
+		const commitHashes = subjectSummaries.map((s) => s.commitHash);
+
+		const result = await createLiveShare(baseUrl, params.apiKey, {
+			repoUrl,
+			repoName,
+			branch: params.branch,
+			kind,
+			visibility: params.visibility,
+			decisionCount,
+			headCommitHash,
+			commitHashes,
+			branchSlug: slugify(params.branch),
+			ref,
+			...(params.recipients && { recipients: params.recipients }),
+		});
+
+		await putBranchShare(
+			params.workspaceRoot,
+			params.branch,
+			{
+				shareId: String(result.shareId),
+				shareUrl: result.shareUrl,
+				visibility: result.visibility,
+				ref,
+				...(result.token && { token8: result.token.slice(0, 8) }),
+				...(result.recipients && { recipients: result.recipients }),
+				headCommitHash,
+				expiresAt: result.expiresAt,
+				decisionCount,
+				titles,
+				commitHash: params.commitHash,
+			},
+			params.commitHash,
+		);
+
+		return result;
+	});
+}
+
+/**
+ * Reconciles the live share for the CURRENT branch (only if one exists): re-pushes
+ * the current `base..HEAD` set and rebuilds `covered` from scratch (so dropped
+ * commits / removed attachments fall out), then PATCHes the server. No-op when
+ * there's no live branch-share record. Current-branch-only is a hard constraint —
+ * `loadBranchSummaries` reads HEAD's `base..HEAD`.
+ */
+export function reconcileLiveShare(deps: LiveShareDeps, branch: string): Promise<void> {
+	return withSubjectLock(deps.workspaceRoot, branch, async () => {
+		const existing = await getBranchShare(deps.workspaceRoot, branch);
+		// Only branch shares reconcile here; commit shares are a fixed doc list, and a
+		// blank confirmed-public placeholder has no shareId.
+		if (!existing?.shareId || existing.ref?.kind !== "branchCollection") return;
+
+		const baseUrl = resolveBaseUrl(deps.apiKey);
+		const repoUrl = await getCanonicalRepoUrl(deps.workspaceRoot);
+		const subjectSummaries = await loadSubjectSummaries(deps, undefined);
+		if (subjectSummaries.length === 0) {
+			log.info("LiveShare", `reconcile: ${branch} has no summaries; leaving share untouched`);
+			return;
+		}
+
+		const ctx = buildPushContext(deps, baseUrl, repoUrl);
+		const ref = await pushSubjectAndBuildRef(subjectSummaries, "branch", branch, ctx);
+		const result = await updateLiveShare(baseUrl, deps.apiKey, existing.shareId, { ref });
+
+		// A ref-only PATCH legitimately omits unchanged fields (shareUrl/token/recipients/…).
+		// Preserve the existing values so the cached record stays reopen-able and people-share
+		// allowlists aren't dropped; only `ref` and anything the server actually returned change.
+		const token8 = result.token ? result.token.slice(0, 8) : existing.token8;
+		const recipients = result.recipients ?? existing.recipients;
+		// Recompute the headline/teaser from the freshly-loaded summaries — the share now
+		// covers the current base..HEAD, so a stale create-time count/titles would misreport it.
+		const { decisionCount, titles } = summarizeDecisions(subjectSummaries);
+		await putBranchShare(deps.workspaceRoot, branch, {
+			shareId: String(result.shareId ?? existing.shareId),
+			shareUrl: result.shareUrl || existing.shareUrl,
+			visibility: result.visibility || existing.visibility,
+			ref,
+			...(token8 ? { token8 } : {}),
+			...(recipients ? { recipients } : {}),
+			headCommitHash: subjectSummaries[subjectSummaries.length - 1].commitHash,
+			expiresAt: result.expiresAt || existing.expiresAt,
+			decisionCount,
+			titles,
+		});
+	});
+}

--- a/vscode/src/services/ShareMessage.test.ts
+++ b/vscode/src/services/ShareMessage.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { buildShareCopyMessage, buildShareEmail, buildSocialShareUrl } from "./ShareMessage.js";
+
+const BASE = { branch: "feature/sidebar", url: "https://acme.jolli.ai/b/x", decisionCount: 4 };
+
+describe("buildShareEmail", () => {
+	it("teases the branch, decision count, and decision titles", () => {
+		const { subject, body } = buildShareEmail({ ...BASE, titles: ["Add dark mode", "Cache results"] });
+		expect(subject).toBe('How we built "feature/sidebar" — 4 decisions on Jolli Memory');
+		expect(body).toContain("4 decisions");
+		expect(body).toContain("• Add dark mode");
+		expect(body).toContain("• Cache results");
+		expect(body).toContain(BASE.url);
+		expect(body).toContain("no login, no install");
+	});
+
+	it("singularizes one decision and omits the bullet list when there are no titles", () => {
+		const { subject, body } = buildShareEmail({ ...BASE, decisionCount: 1, titles: [] });
+		expect(subject).toContain("1 decision on Jolli Memory");
+		expect(body).not.toContain("A few of the decisions inside:");
+		expect(body).toContain(BASE.url);
+	});
+});
+
+describe("buildShareCopyMessage", () => {
+	it("includes up to two teaser titles and the link", () => {
+		const msg = buildShareCopyMessage({ ...BASE, titles: ["Add dark mode", "Cache results", "Third"] });
+		expect(msg).toContain("feature/sidebar");
+		expect(msg).toContain("4 decisions");
+		expect(msg).toContain("Add dark mode");
+		expect(msg).toContain("Cache results");
+		expect(msg).not.toContain("Third"); // capped at 2
+		expect(msg).toContain(BASE.url);
+	});
+
+	it("drops the 'incl.' clause when there are no titles", () => {
+		const msg = buildShareCopyMessage({ ...BASE, titles: [] });
+		expect(msg).not.toContain("incl.");
+		expect(msg).toContain("4 decisions");
+		expect(msg).toContain(BASE.url);
+	});
+});
+
+describe("buildSocialShareUrl", () => {
+	const input = {
+		branch: "feature/x",
+		url: "https://acme.jolli.ai/b/abc",
+		decisionCount: 4,
+		titles: ["Drop Redux for signals", "Cache at the edge"],
+	};
+	const enc = encodeURIComponent(input.url);
+
+	it("X copy is punchy and teases concrete decisions (no emoji crutch)", () => {
+		const u = buildSocialShareUrl("x", input);
+		expect(u).toContain("https://twitter.com/intent/tweet?text=");
+		expect(u).toContain(`url=${enc}`);
+		const text = decodeURIComponent(u);
+		expect(text).toContain("Drop Redux for signals");
+		expect(text).toContain("not just the diff");
+		expect(text).not.toContain("👀");
+	});
+
+	it("LinkedIn carries only the URL (it renders from OG tags)", () => {
+		expect(buildSocialShareUrl("linkedin", input)).toBe(
+			`https://www.linkedin.com/sharing/share-offsite/?url=${enc}`,
+		);
+	});
+
+	it("Reddit gets a title-style headline", () => {
+		const u = buildSocialShareUrl("reddit", input);
+		expect(u).toContain("https://www.reddit.com/submit?url=");
+		expect(decodeURIComponent(u)).toContain("feature/x: 4 decisions");
+	});
+
+	it("WhatsApp copy is casual and embeds the URL", () => {
+		const u = buildSocialShareUrl("whatsapp", input);
+		expect(u).toContain("https://wa.me/?text=");
+		expect(decodeURIComponent(u)).toContain(input.url);
+		expect(decodeURIComponent(u)).toContain("How we built feature/x");
+	});
+
+	it("Telegram passes url + text separately", () => {
+		const u = buildSocialShareUrl("telegram", input);
+		expect(u).toContain("https://t.me/share/url?url=");
+		expect(u).toContain(enc);
+		expect(u).toContain("text=");
+	});
+
+	it("omits the 'incl.' teaser when there are no titles", () => {
+		const u = buildSocialShareUrl("x", { ...input, titles: [] });
+		expect(decodeURIComponent(u)).not.toContain("incl.");
+	});
+
+	it("commit-kind copy leads with 'A commit on' across platforms", () => {
+		expect(decodeURIComponent(buildSocialShareUrl("x", { ...input, kind: "commit" }))).toContain(
+			"A commit on feature/x",
+		);
+		expect(decodeURIComponent(buildSocialShareUrl("reddit", { ...input, kind: "commit" }))).toContain(
+			"A commit on feature/x: 4 decisions",
+		);
+		expect(decodeURIComponent(buildSocialShareUrl("whatsapp", { ...input, kind: "commit" }))).toContain(
+			"A commit on feature/x",
+		);
+		expect(decodeURIComponent(buildSocialShareUrl("telegram", { ...input, kind: "commit" }))).toContain(
+			"A commit on feature/x",
+		);
+	});
+});
+
+describe("commit-kind email + copy message", () => {
+	it("email leads with 'A commit on' and reasons about a commit", () => {
+		const { subject, body } = buildShareEmail({ ...BASE, titles: ["Add dark mode"], kind: "commit" });
+		expect(subject).toBe('A commit on "feature/sidebar" — 4 decisions on Jolli Memory');
+		expect(body).toContain("reasoning behind a commit");
+	});
+
+	it("copy message leads with 'A commit on'", () => {
+		const msg = buildShareCopyMessage({ ...BASE, titles: [], kind: "commit" });
+		expect(msg).toContain("A commit on feature/sidebar");
+	});
+});

--- a/vscode/src/services/ShareMessage.ts
+++ b/vscode/src/services/ShareMessage.ts
@@ -1,0 +1,116 @@
+/**
+ * ShareMessage
+ *
+ * Builds the human-facing share payloads (email subject/body, IM copy message)
+ * for a branch share. Pure and content-teasing: the recipient should see *what*
+ * is being shared and feel pulled to open it — the link is the hook, install is
+ * the conversion (the growth loop). Kept dependency-free for easy testing.
+ */
+
+export interface ShareMessageInput {
+	readonly branch: string;
+	readonly url: string;
+	readonly decisionCount: number;
+	/** A few decision titles to tease (already trimmed to a sensible count). */
+	readonly titles: ReadonlyArray<string>;
+	/** "branch" (whole branch) or "commit" (single commit). Defaults to "branch". */
+	readonly kind?: "branch" | "commit";
+}
+
+function decisionsLabel(n: number): string {
+	return `${n} decision${n === 1 ? "" : "s"}`;
+}
+
+/** Leading phrase, kind-aware: "How we built X" (branch) vs "A commit on X" (commit). */
+function lead(branch: string, kind: "branch" | "commit" | undefined, quoted = false): string {
+	const name = quoted ? `"${branch}"` : branch;
+	return kind === "commit" ? `A commit on ${name}` : `How we built ${name}`;
+}
+
+/** Email subject + body — the richer of the two, with a bulleted teaser. */
+export function buildShareEmail(input: ShareMessageInput): { subject: string; body: string } {
+	const decisions = decisionsLabel(input.decisionCount);
+	const subject = `${lead(input.branch, input.kind, true)} — ${decisions} on Jolli Memory`;
+
+	const intro =
+		input.kind === "commit"
+			? `Here's the reasoning behind a commit on the "${input.branch}" branch — ${decisions}, auto-captured as we built it.`
+			: `Here's the full story behind the "${input.branch}" branch — ${decisions}, auto-captured as we built it.`;
+	const lines: string[] = [intro, ""];
+	if (input.titles.length > 0) {
+		lines.push("A few of the decisions inside:");
+		for (const t of input.titles) lines.push(`  • ${t}`);
+		lines.push("");
+	}
+	lines.push(
+		"Open the read-only view — no login, no install:",
+		input.url,
+		"",
+		"You'll see the intent, the reasoning, and the trade-offs behind each change — not just the diff.",
+		"",
+		"— Shared via Jolli Memory",
+	);
+	return { subject, body: lines.join("\n") };
+}
+
+/** "incl. “A” & “B”" teaser clause from the first couple of decision titles. */
+function inclClause(titles: ReadonlyArray<string>): string {
+	const picked = titles
+		.slice(0, 2)
+		.map((t) => `“${t}”`)
+		.join(" & ");
+	return picked ? ` incl. ${picked}` : "";
+}
+
+/** Compact, concrete one-liner for pasting into Slack / IM (URL kept for unfurl). */
+export function buildShareCopyMessage(input: ShareMessageInput): string {
+	const decisions = decisionsLabel(input.decisionCount);
+	return `${lead(input.branch, input.kind)} — ${decisions}${inclClause(input.titles)}. The reasoning, not just the diff — read-only, no login:\n${input.url}`;
+}
+
+/** Social platforms we offer a one-click share-intent for. */
+export type SocialPlatform = "x" | "linkedin" | "reddit" | "whatsapp" | "telegram";
+
+export interface SocialShareInput {
+	readonly branch: string;
+	readonly url: string;
+	readonly decisionCount: number;
+	/** Decision titles to tease (per-platform copy leads with the first couple). */
+	readonly titles: ReadonlyArray<string>;
+	/** "branch" (whole branch) or "commit" (single commit). Defaults to "branch". */
+	readonly kind?: "branch" | "commit";
+}
+
+/**
+ * Builds a public web-intent share URL for a social platform, with copy tailored
+ * to each channel's voice (X punchy, Reddit title-style, WhatsApp/Telegram casual;
+ * LinkedIn renders from the page's OG tags so it carries only the URL). No API
+ * auth — the platform's compose screen opens pre-filled. Opened via openExternal.
+ */
+export function buildSocialShareUrl(platform: SocialPlatform, input: SocialShareInput): string {
+	const decisions = decisionsLabel(input.decisionCount);
+	const incl = inclClause(input.titles);
+	const u = encodeURIComponent(input.url);
+	switch (platform) {
+		case "x": {
+			const text = `${lead(input.branch, input.kind)}: ${decisions}${incl} — the reasoning behind each change, not just the diff.`;
+			return `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${u}`;
+		}
+		case "linkedin":
+			// LinkedIn ignores text/title params now — it renders from the page's OG tags.
+			return `https://www.linkedin.com/sharing/share-offsite/?url=${u}`;
+		case "reddit": {
+			const subject = input.kind === "commit" ? `A commit on ${input.branch}` : input.branch;
+			const title = `${subject}: ${decisions}${incl} — read-only dev memory (the reasoning, not just the diff)`;
+			return `https://www.reddit.com/submit?url=${u}&title=${encodeURIComponent(title)}`;
+		}
+		case "whatsapp": {
+			const text = `${lead(input.branch, input.kind)} — ${decisions}${incl}. The reasoning, not just the diff (read-only, no login): ${input.url}`;
+			return `https://wa.me/?text=${encodeURIComponent(text)}`;
+		}
+		case "telegram": {
+			const text = `${lead(input.branch, input.kind)} — ${decisions}${incl}. The reasoning, not just the diff (read-only, no login).`;
+			return `https://t.me/share/url?url=${u}&text=${encodeURIComponent(text)}`;
+		}
+	}
+}

--- a/vscode/src/views/NextMemoryPreviewPanel.test.ts
+++ b/vscode/src/views/NextMemoryPreviewPanel.test.ts
@@ -2,12 +2,27 @@ import { describe, expect, it, vi } from "vitest";
 
 // `vscode` is not available in the test environment — provide a minimal stub
 // so the module-level `import * as vscode from "vscode"` in NextMemoryPreviewPanel
-// does not throw. The tests only exercise `buildNextMemoryHtml`, which is pure
-// and never touches the vscode API.
+// does not throw.
+const { createWebviewPanel } = vi.hoisted(() => {
+	const createWebviewPanel = vi.fn(() => {
+		const panel = {
+			webview: { html: "" },
+			reveal: vi.fn(),
+			onDispose: () => {},
+			onDidDispose(cb: () => void) {
+				panel.onDispose = cb;
+				return { dispose() {} };
+			},
+		};
+		return panel;
+	});
+	return { createWebviewPanel };
+});
+
 vi.mock("vscode", () => ({
 	ViewColumn: { Active: -1 },
 	window: {
-		createWebviewPanel: vi.fn(),
+		createWebviewPanel,
 	},
 }));
 

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -3053,10 +3053,11 @@ describe("SidebarScriptBuilder", () => {
 		expect(js).toContain("'data-action': 'footer-more'");
 	});
 
-	it("Review dispatches reviewNextMemory and Share dispatches the placeholder", () => {
+	it("Review dispatches reviewNextMemory; footer Share and the row icon dispatch the share commands", () => {
 		const js = buildSidebarScript();
 		expect(js).toContain("jollimemory.reviewNextMemory");
-		expect(js).toContain("jollimemory.shareBranchPlaceholder");
+		expect(js).toContain("jollimemory.shareBranch");
+		expect(js).toContain("jollimemory.shareMemory");
 	});
 
 	it("renders a Committed Memories token bar from branch:tokenStats", () => {

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -4777,9 +4777,9 @@ export function buildSidebarScript(): string {
         }, [el('i', { className: 'codicon codicon-copy' })]),
         'Copy Recall Prompt',
       ));
-      // Share — placeholder for a dedicated PR. The button is rendered now
-      // so the slot is reserved in the UI, but the click handler is a no-op
-      // (see the 'share' case in the inline-action dispatcher below).
+      // Share this memory — opens the memory's summary panel with the
+      // commit-kind share modal (see the 'share' case in the inline-action
+      // dispatcher below).
       memActions.push(attachTextTip(
         el('button', {
           type: 'button',
@@ -5049,7 +5049,9 @@ export function buildSidebarScript(): string {
     }
     var footerShare = e.target.closest('.cmd-btn[data-action="footer-share"]');
     if (footerShare) {
-      vscode.postMessage({ type: 'command', command: 'jollimemory.shareBranchPlaceholder' });
+      // Opens the newest branch memory's panel with the "Share this branch"
+      // modal — the modal lives in the summary panel's webview, not here.
+      vscode.postMessage({ type: 'command', command: 'jollimemory.shareBranch' });
       e.stopPropagation(); return;
     }
     var footerMore = e.target.closest('.cmd-btn[data-action="footer-more"]');
@@ -5291,10 +5293,10 @@ export function buildSidebarScript(): string {
         vscode.postMessage({ type: 'command', command: 'jollimemory.copyRecallPrompt', args: [id] });
       }
       if (action === 'share') {
-        // Share is a placeholder — a dedicated PR will implement the full
-        // share flow (copy shareable link, open share sheet, etc.). The
-        // case is handled here so the click is swallowed cleanly and does
-        // NOT fall through to the row-open path below.
+        // Opens this memory's panel with the "Share this memory" (commit-kind)
+        // modal. Foreign rows resolve no summary in this workspace's storage —
+        // the command replies with a pointer to the memory's own repo.
+        vscode.postMessage({ type: 'command', command: 'jollimemory.shareMemory', args: [id] });
         e.stopPropagation();
         return;
       }

--- a/vscode/src/views/SidebarWebviewProvider.edgePaths.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.edgePaths.test.ts
@@ -1,0 +1,467 @@
+/**
+ * Edge-path tests for SidebarWebviewProvider — the degraded / fallback branches
+ * that the mainline suite doesn't reach: telemetry flush on the conversations
+ * tick, PR lookups that resolve empty, evidence projection fallbacks for
+ * malformed or failing sources, branch token-stat posting, and the
+ * next-memory selection projection.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SidebarInboundMsg, SidebarOutboundMsg, SidebarState } from "./SidebarMessages";
+import type { SidebarWebviewDeps } from "./SidebarWebviewProvider";
+import { SidebarWebviewProvider } from "./SidebarWebviewProvider";
+
+interface MockWebview {
+	html: string;
+	options: unknown;
+	cspSource: string;
+	postMessage: ReturnType<typeof vi.fn>;
+	onDidReceiveMessage: ReturnType<typeof vi.fn>;
+	asWebviewUri: ReturnType<typeof vi.fn>;
+	triggerMessage(msg: SidebarOutboundMsg): void;
+}
+interface MockWebviewView {
+	webview: MockWebview;
+	onDidDispose: ReturnType<typeof vi.fn>;
+	show: ReturnType<typeof vi.fn>;
+	visible: boolean;
+	badge: { value: number; tooltip: string } | undefined;
+}
+
+const mockExtensionUri = {
+	fsPath: "/mock/extension",
+	scheme: "file",
+	toString: () => "file:///mock/extension",
+};
+
+// Mutable slots the vscode mock reads through getters, so each test can flip
+// workspace / telemetry state without re-mocking the module.
+const mockWorkspaceFolders: Array<{ uri: { fsPath: string } }> = [];
+const telemetryState = { enabled: true };
+vi.mock("vscode", () => ({
+	Uri: {
+		joinPath: vi.fn((_base: unknown, ...segments: string[]) => ({
+			toString: () => `vscode-resource:/mock/${segments.join("/")}`,
+		})),
+		file: vi.fn((path: string) => ({
+			toString: () => `file://${path}`,
+		})),
+	},
+	window: {
+		createOutputChannel: vi.fn(() => ({
+			appendLine: vi.fn(),
+			show: vi.fn(),
+			dispose: vi.fn(),
+		})),
+	},
+	workspace: {
+		get workspaceFolders() {
+			return mockWorkspaceFolders.length > 0 ? mockWorkspaceFolders : undefined;
+		},
+	},
+	env: {
+		get isTelemetryEnabled() {
+			return telemetryState.enabled;
+		},
+	},
+}));
+
+// The 60s tick piggybacks a telemetry flush — stub it so tests can assert the
+// cwd / platform-opt-out wiring without touching the real telemetry buffer.
+const flushTelemetryMock = vi.fn();
+vi.mock("../TelemetryActivation.js", () => ({
+	flushExtensionTelemetry: (...args: unknown[]) => flushTelemetryMock(...args),
+}));
+
+// Stub the panel so archived-conversation opens can be asserted on their args.
+const showMock = vi.fn();
+vi.mock("./ConversationDetailsPanel.js", () => ({
+	ConversationDetailsPanel: {
+		show: (...args: unknown[]) => showMock(...args),
+	},
+}));
+
+function makeMockView(): MockWebviewView {
+	let messageHandler: ((msg: SidebarOutboundMsg) => void) | undefined;
+	const webview: MockWebview = {
+		html: "",
+		options: {},
+		cspSource: "vscode-resource:",
+		postMessage: vi.fn(),
+		onDidReceiveMessage: vi.fn((cb: (msg: SidebarOutboundMsg) => void) => {
+			messageHandler = cb;
+			return { dispose: () => {} };
+		}),
+		asWebviewUri: vi.fn((u: unknown) => u),
+		triggerMessage(msg) {
+			messageHandler?.(msg);
+		},
+	};
+	return {
+		webview,
+		onDidDispose: vi.fn(() => ({ dispose: () => {} })),
+		show: vi.fn(),
+		visible: true,
+		badge: undefined,
+	};
+}
+
+function makeProvider(extra: Partial<SidebarWebviewDeps> = {}): SidebarWebviewProvider {
+	return new SidebarWebviewProvider({
+		executeCommand: vi.fn().mockResolvedValue(undefined) as never,
+		getInitialState: (): SidebarState => ({
+			enabled: true,
+			authenticated: false,
+			activeTab: "kb",
+			kbMode: "memories",
+			branchName: "main",
+			detached: false,
+		}),
+		extensionUri: mockExtensionUri as unknown as never,
+		...extra,
+	});
+}
+
+/** Polls the posted messages until one of `type` shows up (handlers span multiple async turns). */
+async function flushUntilMessage(view: MockWebviewView, type: string, maxTicks = 50): Promise<SidebarInboundMsg[]> {
+	for (let i = 0; i < maxTicks; i++) {
+		const sent = view.webview.postMessage.mock.calls.map((c) => c[0] as SidebarInboundMsg);
+		if (sent.some((m) => m.type === type)) return sent;
+		await new Promise((r) => setTimeout(r, 0));
+	}
+	return view.webview.postMessage.mock.calls.map((c) => c[0] as SidebarInboundMsg);
+}
+
+function findMsg<T extends SidebarInboundMsg["type"]>(
+	msgs: ReadonlyArray<SidebarInboundMsg>,
+	type: T,
+): Extract<SidebarInboundMsg, { type: T }> | undefined {
+	return msgs.find((m): m is Extract<SidebarInboundMsg, { type: T }> => m.type === type);
+}
+
+const stubDisposable = () => ({ dispose: () => {} });
+
+beforeEach(() => {
+	flushTelemetryMock.mockReset();
+	showMock.mockReset();
+	mockWorkspaceFolders.length = 0;
+	telemetryState.enabled = true;
+});
+
+describe("SidebarWebviewProvider edge paths", () => {
+	describe("telemetry flush on the conversations tick", () => {
+		it("flushes buffered telemetry with the workspace cwd and inverted platform consent", async () => {
+			vi.useFakeTimers();
+			try {
+				mockWorkspaceFolders.push({ uri: { fsPath: "/proj" } });
+				const listWithDiagnostics = vi.fn().mockResolvedValue({ items: [], failedSources: [] });
+				const provider = makeProvider({
+					activeSessionsProvider: { listWithDiagnostics } as unknown as never,
+				});
+				const view = makeMockView();
+				provider.resolveWebviewView(view as unknown as never);
+				// First tick: platform telemetry enabled → platformDisabled false.
+				await vi.advanceTimersByTimeAsync(60_000);
+				expect(flushTelemetryMock).toHaveBeenCalledTimes(1);
+				expect(flushTelemetryMock).toHaveBeenCalledWith("/proj", false);
+				// The opt-out is read live per tick: flipping the VS Code toggle off
+				// must arrive as platformDisabled=true on the next flush.
+				telemetryState.enabled = false;
+				await vi.advanceTimersByTimeAsync(60_000);
+				expect(flushTelemetryMock).toHaveBeenCalledTimes(2);
+				expect(flushTelemetryMock).toHaveBeenLastCalledWith("/proj", true);
+				provider.dispose();
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("skips the flush when no workspace folder is open", async () => {
+			vi.useFakeTimers();
+			try {
+				const listWithDiagnostics = vi.fn().mockResolvedValue({ items: [], failedSources: [] });
+				const provider = makeProvider({
+					activeSessionsProvider: { listWithDiagnostics } as unknown as never,
+				});
+				const view = makeMockView();
+				provider.resolveWebviewView(view as unknown as never);
+				await vi.advanceTimersByTimeAsync(60_000);
+				// The conversations refresh still ran; only the telemetry flush is gated on cwd.
+				expect(listWithDiagnostics).toHaveBeenCalled();
+				expect(flushTelemetryMock).not.toHaveBeenCalled();
+				provider.dispose();
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+	});
+
+	describe("kb:requestPrStatus with no open PR", () => {
+		it("posts pr:null when findOpenPrForBranch resolves undefined", async () => {
+			const findOpenPrForBranch = vi.fn().mockResolvedValue(undefined);
+			const provider = makeProvider({ findOpenPrForBranch });
+			const view = makeMockView();
+			provider.resolveWebviewView(view as unknown as never);
+			view.webview.triggerMessage({ type: "kb:requestPrStatus", branch: "feat/none" });
+			const sent = await flushUntilMessage(view, "kb:prStatus");
+			const msg = findMsg(sent, "kb:prStatus");
+			expect(findOpenPrForBranch).toHaveBeenCalledWith("feat/none");
+			expect(msg?.branch).toBe("feat/none");
+			// "no PR found" (undefined) is normalized to the explicit null the client renders.
+			expect(msg?.pr).toBeNull();
+		});
+	});
+
+	describe("kb:expandMemory file fallback on non-Error rejection", () => {
+		it("falls back to topic paths when listCommitFiles rejects with a non-Error value", async () => {
+			const summary = {
+				version: 5,
+				commitHash: "str1234",
+				commitMessage: "feat: fallback",
+				commitAuthor: "Dev",
+				commitDate: "2024-01-01T00:00:00Z",
+				branch: "main",
+				generatedAt: "2024-01-01T00:01:00Z",
+				transcripts: [],
+				topics: [{ title: "t", trigger: "x", response: "y", decisions: "z", filesAffected: ["src/a.ts"] }],
+			};
+			// Rejecting with a plain string exercises the String(err) side of the
+			// warn formatting — the git bridge is not guaranteed to throw Errors.
+			const listCommitFiles = vi.fn().mockRejectedValue("diff-tree exploded");
+			const provider = makeProvider({
+				getSummaryByHash: vi.fn().mockResolvedValue(summary),
+				listCommitFiles,
+			});
+			const view = makeMockView();
+			provider.resolveWebviewView(view as unknown as never);
+			view.webview.postMessage.mockClear();
+			view.webview.triggerMessage({ type: "kb:expandMemory", commitHash: "str1234" });
+			const sent = await flushUntilMessage(view, "kb:memoryEvidence");
+			const ev = findMsg(sent, "kb:memoryEvidence");
+			expect(listCommitFiles).toHaveBeenCalledWith("str1234");
+			// The failure degrades to the path-only topic projection, not an error post.
+			expect(ev?.evidence.files).toEqual([
+				{ kind: "file", id: "src/a.ts", title: "src/a.ts", relativePath: "src/a.ts" },
+			]);
+		});
+	});
+
+	describe("kb:openEvidenceConversation via the source-aware summary lookup", () => {
+		const provenanceSummary = {
+			version: 5,
+			commitHash: "prov1234",
+			commitMessage: "feat: provenance",
+			commitAuthor: "Dev",
+			commitDate: "2024-01-01T00:00:00Z",
+			branch: "main",
+			generatedAt: "2024-01-01T00:01:00Z",
+			transcripts: ["t1"],
+			topics: [],
+		};
+
+		it("opens the panel for a source-less stored session (claude default) with an empty transcriptPath", async () => {
+			const getSummaryAnyRepoWithSource = vi.fn().mockResolvedValue({
+				summary: provenanceSummary,
+				sourceRepoName: null,
+				sourceRemoteUrl: null,
+			});
+			// Legacy stored session: neither `source` nor `transcriptPath` present —
+			// the match must default to "claude" and the panel must get "".
+			const readTranscriptById = vi.fn().mockResolvedValue({
+				sessions: [{ sessionId: "sess-p", entries: [{ role: "human", content: "hi" }] }],
+			});
+			const provider = makeProvider({ getSummaryAnyRepoWithSource, readTranscriptById });
+			const view = makeMockView();
+			provider.resolveWebviewView(view as unknown as never);
+			view.webview.triggerMessage({
+				type: "kb:openEvidenceConversation",
+				commitHash: "prov1234",
+				sessionId: "sess-p",
+				source: "claude",
+				title: "hi",
+			});
+			await new Promise((r) => setTimeout(r, 0));
+			expect(getSummaryAnyRepoWithSource).toHaveBeenCalledWith("prov1234");
+			expect(showMock).toHaveBeenCalledTimes(1);
+			const call = showMock.mock.calls[0][0] as {
+				sessionId: string;
+				source: string;
+				transcriptPath: string;
+				archivedEntries: unknown;
+			};
+			expect(call.sessionId).toBe("sess-p");
+			expect(call.source).toBe("claude");
+			expect(call.transcriptPath).toBe("");
+			expect(call.archivedEntries).toEqual([{ role: "human", content: "hi" }]);
+		});
+
+		it.each([
+			["an Error", new Error("storage offline")],
+			["a non-Error value", "storage offline (string)"],
+		])("swallows a summary lookup rejecting with %s without opening a panel", async (_label, reason) => {
+			const getSummaryAnyRepoWithSource = vi.fn().mockRejectedValue(reason);
+			const provider = makeProvider({ getSummaryAnyRepoWithSource });
+			const view = makeMockView();
+			provider.resolveWebviewView(view as unknown as never);
+			expect(() =>
+				view.webview.triggerMessage({
+					type: "kb:openEvidenceConversation",
+					commitHash: "prov1234",
+					sessionId: "sess-p",
+					source: "claude",
+					title: "hi",
+				}),
+			).not.toThrow();
+			await new Promise((r) => setTimeout(r, 0));
+			await new Promise((r) => setTimeout(r, 0));
+			expect(getSummaryAnyRepoWithSource).toHaveBeenCalledWith("prov1234");
+			expect(showMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("branch token stats alongside pushCommits", () => {
+		function makeHistoryProvider() {
+			return {
+				serialize: vi.fn().mockResolvedValue([]),
+				onDidChangeTreeData: vi.fn(stubDisposable),
+				getMode: () => "multi" as const,
+			};
+		}
+
+		it("posts branch:tokenStats with the reconciled total when the branch has usage", async () => {
+			const getBranchTokenStats = vi.fn().mockResolvedValue({
+				input: 100,
+				output: 40,
+				cached: 10,
+				reporting: 2,
+				memories: 3,
+			});
+			const provider = makeProvider({
+				historyProvider: makeHistoryProvider(),
+				getBranchTokenStats,
+			});
+			const view = makeMockView();
+			provider.resolveWebviewView(view as unknown as never);
+			view.webview.triggerMessage({ type: "ready" });
+			const sent = await flushUntilMessage(view, "branch:tokenStats");
+			const msg = findMsg(sent, "branch:tokenStats");
+			expect(msg).toMatchObject({
+				input: 100,
+				output: 40,
+				cached: 10,
+				// cached counts toward the total so input + output + cached reconcile.
+				total: 150,
+				reporting: 2,
+				memories: 3,
+				scope: "branch",
+			});
+		});
+
+		it("posts no token stats when the aggregate is zero (token bar stays hidden)", async () => {
+			const getBranchTokenStats = vi.fn().mockResolvedValue({
+				input: 0,
+				output: 0,
+				cached: 0,
+				reporting: 0,
+				memories: 0,
+			});
+			const provider = makeProvider({
+				historyProvider: makeHistoryProvider(),
+				getBranchTokenStats,
+			});
+			const view = makeMockView();
+			provider.resolveWebviewView(view as unknown as never);
+			view.webview.triggerMessage({ type: "ready" });
+			const sent = await flushUntilMessage(view, "branch:commitsData");
+			// Commits data went out and the stats promise settled…
+			expect(findMsg(sent, "branch:commitsData")).toBeDefined();
+			await new Promise((r) => setTimeout(r, 0));
+			await new Promise((r) => setTimeout(r, 0));
+			expect(getBranchTokenStats).toHaveBeenCalled();
+			// …but a zero aggregate must not paint an empty token bar.
+			const all = view.webview.postMessage.mock.calls.map((c) => c[0] as SidebarInboundMsg);
+			expect(findMsg(all, "branch:tokenStats")).toBeUndefined();
+		});
+
+		it("degrades silently when getBranchTokenStats rejects", async () => {
+			const getBranchTokenStats = vi.fn().mockRejectedValue(new Error("stats unavailable"));
+			const provider = makeProvider({
+				historyProvider: makeHistoryProvider(),
+				getBranchTokenStats,
+			});
+			const view = makeMockView();
+			provider.resolveWebviewView(view as unknown as never);
+			view.webview.triggerMessage({ type: "ready" });
+			const sent = await flushUntilMessage(view, "branch:commitsData");
+			expect(findMsg(sent, "branch:commitsData")).toBeDefined();
+			await new Promise((r) => setTimeout(r, 0));
+			await new Promise((r) => setTimeout(r, 0));
+			expect(getBranchTokenStats).toHaveBeenCalled();
+			const all = view.webview.postMessage.mock.calls.map((c) => c[0] as SidebarInboundMsg);
+			expect(findMsg(all, "branch:tokenStats")).toBeUndefined();
+		});
+	});
+
+	describe("getNextMemorySelection", () => {
+		it("projects only the selected items from the three provider feeds", async () => {
+			const listWithDiagnostics = vi.fn().mockResolvedValue({
+				items: [
+					{ title: "conv kept", isSelected: true },
+					{ title: "conv deselected", isSelected: false },
+					// Conversations require an explicit isSelected — absence means excluded.
+					{ title: "conv unset" },
+				],
+				failedSources: [],
+			});
+			const plansProvider = {
+				serialize: () => [
+					{ id: "p1", label: "plan kept", isSelected: true },
+					{ id: "p2", label: "plan deselected", isSelected: false },
+					// Plans/files treat an absent flag as selected (isSelected !== false).
+					{ id: "p3", label: "plan default" },
+				],
+				onDidChangeTreeData: vi.fn(stubDisposable),
+			};
+			const filesProvider = {
+				serialize: () => [
+					{ id: "f1", label: "a.ts", description: "src/a.ts" },
+					// No description → the basename label is the best available path.
+					{ id: "f2", label: "b.ts" },
+					{ id: "f3", label: "c.ts", description: "src/c.ts", isSelected: false },
+				],
+				onDidChangeTreeData: vi.fn(stubDisposable),
+			};
+			const provider = makeProvider({
+				activeSessionsProvider: { listWithDiagnostics } as unknown as never,
+				plansProvider,
+				filesProvider,
+			});
+			const result = await provider.getNextMemorySelection();
+			expect(result.conversations).toEqual([{ title: "conv kept" }]);
+			expect(result.context).toEqual([{ title: "plan kept" }, { title: "plan default" }]);
+			expect(result.files).toEqual([{ path: "src/a.ts" }, { path: "b.ts" }]);
+		});
+
+		it("returns empty groups when no providers are wired", async () => {
+			const provider = makeProvider();
+			const result = await provider.getNextMemorySelection();
+			expect(result).toEqual({ conversations: [], context: [], files: [] });
+		});
+
+		it("returns empty conversations when the sessions provider rejects, keeping the other groups", async () => {
+			const listWithDiagnostics = vi.fn().mockRejectedValue(new Error("aggregator down"));
+			const plansProvider = {
+				serialize: () => [{ id: "p1", label: "plan kept" }],
+				onDidChangeTreeData: vi.fn(stubDisposable),
+			};
+			const provider = makeProvider({
+				activeSessionsProvider: { listWithDiagnostics } as unknown as never,
+				plansProvider,
+			});
+			const result = await provider.getNextMemorySelection();
+			expect(result.conversations).toEqual([]);
+			expect(result.context).toEqual([{ title: "plan kept" }]);
+			expect(result.files).toEqual([]);
+		});
+	});
+});

--- a/vscode/src/views/SummaryCssBuilder.test.ts
+++ b/vscode/src/views/SummaryCssBuilder.test.ts
@@ -39,6 +39,11 @@ describe("SummaryCssBuilder", () => {
 		expect(css).toContain(".separator");
 	});
 
+	it("lets the [hidden] attribute actually hide a filtered collaborator row (display:flex must not override it)", () => {
+		const css = buildCss();
+		expect(css).toContain(".share-collab-row[hidden]");
+	});
+
 	it("contains the PR section CSS from buildPrSectionCss()", () => {
 		expect(css).toContain("/* pr-css */");
 	});

--- a/vscode/src/views/SummaryCssBuilder.ts
+++ b/vscode/src/views/SummaryCssBuilder.ts
@@ -1565,7 +1565,73 @@ export function buildCss(): string {
 
   @media (prefers-reduced-motion: reduce) {
     .attach-arrow, .ship-status.is-loading .led { transition: none; animation: none; }
+    .share-spinner { animation: none; }
   }
+
+  /* ── Share this branch modal ── */
+  /* ── Share popover: anchored dropdown under the Share button, no dimming ── */
+  .share-overlay { position: fixed; inset: 0; background: transparent; z-index: 1000; }
+  .share-overlay[hidden] { display: none; }
+  .share-popover { position: absolute; top: 0; left: 8px; background: var(--vscode-editorWidget-background, var(--vscode-editor-background)); border: 1px solid var(--vscode-widget-border, var(--vscode-editorGroup-border)); border-radius: 10px; width: 440px; max-width: calc(100vw - 24px); max-height: 82vh; overflow-y: auto; padding: 16px 18px; box-shadow: 0 12px 34px rgba(0,0,0,0.5); }
+  .share-modal-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 4px; }
+  .share-head-right { display: flex; align-items: center; gap: 8px; flex: 0 0 auto; }
+  .share-modal-close { background: none; border: none; color: var(--text-secondary); font-size: 1.05em; line-height: 1; cursor: pointer; padding: 4px 7px; border-radius: 4px; }
+  .share-modal-close:hover { background: var(--vscode-toolbar-hoverBackground); color: var(--vscode-foreground); }
+  .share-modal-title { font-size: 1.1em; font-weight: 650; display: inline-flex; align-items: center; gap: 6px; }
+  /* Inline share glyph (button + modal title) — CSP has no font-src, so this is an SVG, not a codicon. */
+  .share-icon { vertical-align: -2px; margin-right: 2px; flex: 0 0 auto; }
+  .share-modal-sub { color: var(--text-secondary); font-size: 0.85em; margin: 0 0 14px; }
+  .share-pane[hidden] { display: none; }
+  .share-modal-actions { display: flex; gap: 8px; align-items: center; margin-top: 16px; }
+  /* Sync status badge */
+  .share-sync-badge { flex: 0 0 auto; font-size: 0.72em; font-weight: 700; letter-spacing: 0.05em; padding: 2px 9px; border-radius: 10px; }
+  .share-sync-badge[hidden] { display: none; }
+  .share-sync-badge.synced { color: var(--vscode-testing-iconPassed, #3fb950); background: rgba(63,185,80,0.14); }
+  .share-sync-badge.syncing { color: var(--text-secondary); background: rgba(127,127,127,0.16); }
+  /* Teammate search + add-people suggestions dropdown */
+  .share-search-wrap { position: relative; margin-bottom: 14px; }
+  .share-search { display: block; width: 100%; box-sizing: border-box; background: var(--vscode-input-background); color: var(--vscode-input-foreground); border: 1px solid var(--vscode-input-border, var(--vscode-editorGroup-border)); border-radius: 6px; padding: 7px 10px; font-family: var(--vscode-font-family); font-size: 0.85em; }
+  .share-search:focus { outline: 1px solid var(--vscode-focusBorder); outline-offset: -1px; }
+  .share-suggest { position: absolute; left: 0; right: 0; top: calc(100% + 4px); z-index: 5; max-height: 200px; overflow-y: auto; background: var(--vscode-dropdown-background); border: 1px solid var(--vscode-dropdown-border, var(--vscode-editorGroup-border)); border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
+  .share-suggest[hidden] { display: none; }
+  .share-suggest-item { display: flex; align-items: baseline; gap: 8px; width: 100%; box-sizing: border-box; text-align: left; background: none; border: none; padding: 7px 10px; cursor: pointer; font-family: var(--vscode-font-family); font-size: 0.85em; color: var(--vscode-foreground); }
+  .share-suggest-item:hover { background: var(--vscode-list-hoverBackground); }
+  .share-suggest-name { font-weight: 600; }
+  .share-suggest-email { color: var(--text-secondary); font-size: 0.92em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .share-suggest-add { color: var(--vscode-textLink-foreground); }
+  .share-section-label { font-size: 0.72em; font-weight: 700; letter-spacing: 0.07em; color: var(--text-secondary); margin: 0 0 8px; }
+  /* Collaborators (visual mock) */
+  .share-collab-list { display: flex; flex-direction: column; gap: 2px; margin-bottom: 16px; max-height: 168px; overflow-y: auto; }
+  .share-collab-row { display: flex; align-items: center; gap: 10px; padding: 5px 4px; }
+  .share-collab-row[hidden] { display: none; }
+  .share-avatar { flex: 0 0 auto; width: 30px; height: 30px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 0.72em; font-weight: 700; color: #fff; background: var(--vscode-textLink-foreground, #4c8bf5); }
+  .share-collab-meta { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; line-height: 1.25; }
+  .share-collab-name { font-size: 0.88em; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .share-collab-email { font-size: 0.78em; color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .share-collab-role { flex: 0 0 auto; color: var(--text-secondary); font-size: 0.8em; }
+  .share-collab-remove { flex: 0 0 auto; background: none; border: none; color: var(--text-secondary); font-size: 1.05em; line-height: 1; cursor: pointer; padding: 2px 6px; border-radius: 4px; }
+  .share-collab-remove:hover { background: var(--vscode-toolbar-hoverBackground); color: var(--vscode-foreground); }
+  /* General access */
+  .share-access-row { display: flex; align-items: center; gap: 8px; }
+  .share-access-icon { flex: 0 0 auto; color: var(--text-secondary); }
+  .share-access-row .share-select { flex: 1 1 auto; }
+  .share-select { display: block; width: 100%; box-sizing: border-box; background: var(--vscode-dropdown-background); color: var(--vscode-dropdown-foreground); border: 1px solid var(--vscode-dropdown-border, var(--vscode-editorGroup-border)); border-radius: 6px; padding: 7px 9px; font-family: var(--vscode-font-family); font-size: 0.85em; cursor: pointer; }
+  .share-select:focus { outline: 1px solid var(--vscode-focusBorder); outline-offset: -1px; }
+  .share-access-sub { color: var(--text-secondary); font-size: 0.8em; margin: 6px 0 14px; }
+  /* "What travels" banner */
+  .share-travel-banner { display: flex; gap: 10px; align-items: flex-start; padding: 10px 12px; border-radius: 8px; background: var(--vscode-textBlockQuote-background, rgba(127,127,127,0.06)); font-size: 0.83em; line-height: 1.5; margin-bottom: 12px; }
+  .share-travel-icon { flex: 0 0 auto; color: var(--vscode-textLink-foreground); font-size: 1.05em; }
+  /* Transcript opt-in (disabled mock) */
+  .share-transcript-opt { display: flex; align-items: center; gap: 8px; font-size: 0.85em; color: var(--text-secondary); cursor: not-allowed; }
+  .share-transcript-opt input { margin: 0; }
+  .share-optin-badge { font-size: 0.7em; font-weight: 700; letter-spacing: 0.04em; padding: 1px 6px; border-radius: 4px; background: rgba(127,127,127,0.16); color: var(--text-secondary); text-transform: uppercase; }
+  .share-link-hidden { position: absolute; opacity: 0; pointer-events: none; height: 0; width: 0; }
+  /* Shared panes (loading / error / no-key) */
+  .share-loading { display: flex; align-items: center; gap: 10px; color: var(--text-secondary); }
+  .share-spinner { width: 14px; height: 14px; border: 2px solid var(--text-secondary); border-top-color: transparent; border-radius: 50%; animation: share-spin 0.8s linear infinite; }
+  @keyframes share-spin { to { transform: rotate(360deg); } }
+  .share-error-msg { color: var(--vscode-errorForeground); font-size: 0.9em; }
+  .share-nokey { color: var(--text-secondary); font-size: 0.9em; }
 
 ${buildPrSectionCss()}
 `;

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -65,6 +65,21 @@ export interface BuildHtmlOptions {
 	 */
 	readonly foreignRepoName?: string | null;
 	/**
+	 * Default kind of the header Share button — follows the panel's share
+	 * ENTRY (see SummaryScriptOptions.defaultShareKind). Persisted for the
+	 * panel's lifetime by SummaryWebviewPanel so re-renders keep the button
+	 * consistent with how the user opened the panel.
+	 */
+	readonly shareDefaultKind?: "branch" | "commit";
+	/**
+	 * One-shot: open the share modal (at `shareDefaultKind`) as soon as the
+	 * webview script loads. Set by the sidebar share entries via
+	 * `SummaryWebviewPanel.showWithShareModal` — the modal UI lives in this
+	 * webview, so the open call is baked into the script (see buildScript).
+	 * Ignored on readonly panels (they render no share modal at all).
+	 */
+	readonly autoOpenShare?: boolean;
+	/**
 	 * Full 40-char hash of the live root commit when the panel's commit has
 	 * been rewritten by amend / squash / rebase. The `.page` root receives
 	 * a `stale-readonly` hook class (parallel to `foreign-readonly`) so the
@@ -152,7 +167,7 @@ ${csp}
 <div class="${pageClass}">
 ${buildSummaryErrorBanner(summary, { readOnly })}
 ${staleBannerHtml}
-${buildHeader(summary, totalFiles, totalInsertions, totalDeletions, !!opts.foreignRepoName)}
+${buildHeader(summary, totalFiles, totalInsertions, totalDeletions, readOnly)}
 ${buildShipBar(summary)}
 ${buildMemoryPanel(summary, { readOnly })}
 ${buildE2ePanel(summary)}
@@ -160,9 +175,119 @@ ${buildConversationsSection(transcriptHashSet, !!opts.foreignRepoName)}
 ${buildAttachmentsPanel(summary, sourceNodes, planTranslateSet, noteTranslateSet, referenceTranslateSet)}
 ${buildFooter(summary)}
 </div>
-<script${nonceAttr}>${buildScript()}</script>
+${readOnly ? "" : buildShareModal()}
+<script${nonceAttr}>${buildScript(
+		readOnly
+			? {}
+			: { defaultShareKind: opts.shareDefaultKind ?? "commit", autoOpenShare: opts.autoOpenShare ?? false },
+	)}</script>
 </body>
 </html>`;
+}
+
+/**
+ * Inline share glyph — a tray with an up arrow, the same iconography as the
+ * sidebar's share entries. Inline SVG (not an icon font): this webview's CSP
+ * carries no `font-src`, so codicons can't load here; `currentColor` keeps the
+ * stroke matching the surrounding button/label text color.
+ */
+const SHARE_ICON_SVG = `<svg class="share-icon" width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 10V2.2M5.3 4.6 8 1.9l2.7 2.7" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><path d="M5.2 7H4.2c-.7 0-1.2.5-1.2 1.2v4.4c0 .7.5 1.2 1.2 1.2h7.6c.7 0 1.2-.5 1.2-1.2V8.2c0-.7-.5-1.2-1.2-1.2h-1" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg>`;
+
+/**
+ * Builds the hidden "Share this memory / branch" popover — a live, Space-backed share
+ * with an explicit create step for new links. The main pane shows the (mock)
+ * Collaborators list, the General-access selector, the "what travels" banner, a disabled
+ * transcript opt-in, Copy link, and a SYNCED status. The card is anchored under the Share
+ * button by the client script (`getBoundingClientRect`); the overlay is a transparent
+ * full-screen click-catcher (no dimming). The client toggles panes per share state and
+ * fills the collaborators list + link (see SummaryScriptBuilder).
+ */
+export function buildShareModal(): string {
+	return `
+<div class="share-overlay" id="shareOverlay" hidden>
+  <div class="share-modal share-popover" role="dialog" aria-modal="true" aria-labelledby="shareModalTitle">
+    <div class="share-modal-head">
+      <span class="share-modal-title">${SHARE_ICON_SVG}<span id="shareModalTitle">Share this memory</span></span>
+      <span class="share-head-right">
+        <span class="share-sync-badge" id="shareSyncBadge" hidden></span>
+        <button type="button" class="share-modal-close" id="shareModalClose" title="Close" aria-label="Close">&#x2715;</button>
+      </span>
+    </div>
+    <p class="share-modal-sub" id="shareModalSub"></p>
+
+    <div class="share-pane" id="sharePaneMain" hidden>
+      <div class="share-search-wrap">
+        <input type="text" class="share-search" id="shareTeammateSearch" placeholder="Search teammates by name or email…" aria-label="Search teammates or add an email" autocomplete="off" />
+        <div class="share-suggest" id="shareSuggest" hidden></div>
+      </div>
+
+      <div class="share-section-label">COLLABORATORS</div>
+      <div class="share-collab-list" id="shareCollabList" aria-label="Collaborators"></div>
+
+      <div class="share-section-label">GENERAL ACCESS</div>
+      <div class="share-access-row">
+        <span class="share-access-icon" aria-hidden="true">&#x1F441;</span>
+        <select class="share-select" id="shareVisibilitySelect" aria-label="Who can open this link">
+          <option value="org" id="shareOrgOption">Anyone at jolliai</option>
+          <option value="public">Anyone with the link</option>
+          <option value="people">Only people you add</option>
+        </select>
+      </div>
+      <p class="share-access-sub" id="shareAccessSub"></p>
+
+      <div class="share-travel-banner">
+        <span class="share-travel-icon" aria-hidden="true">&#x21C4;</span>
+        <span>Summaries + decisions + linked refs travel.<br /><strong>Conversation transcripts stay on your machine.</strong></span>
+      </div>
+
+      <label class="share-transcript-opt" title="Not available — transcripts stay on your machine.">
+        <input type="checkbox" id="shareIncludeTranscripts" disabled />
+        <span>Include conversation transcripts</span>
+        <span class="share-optin-badge">opt-in</span>
+      </label>
+
+      <input type="text" class="share-link-hidden" id="shareLinkInput" readonly aria-hidden="true" hidden />
+      <div class="share-modal-actions">
+        <button class="action-btn primary" id="shareCopyBtn" title="Copy the shareable link">&#x1F4CB; Copy link</button>
+      </div>
+    </div>
+
+    <div class="share-pane" id="sharePaneCreate" hidden>
+      <div class="share-section-label">GENERAL ACCESS</div>
+      <div class="share-access-row">
+        <span class="share-access-icon" aria-hidden="true">&#x1F441;</span>
+        <select class="share-select" id="shareCreateVisibilitySelect" aria-label="Who can open this link">
+          <option value="org" id="shareCreateOrgOption">Anyone at jolliai</option>
+          <option value="public">Anyone with the link</option>
+          <option value="people">Only people you add</option>
+        </select>
+      </div>
+      <p class="share-access-sub" id="shareCreateAccessSub"></p>
+
+      <div class="share-travel-banner">
+        <span class="share-travel-icon" aria-hidden="true">&#x21C4;</span>
+        <span>Summaries + decisions + linked refs travel.<br /><strong>Conversation transcripts stay on your machine.</strong></span>
+      </div>
+
+      <div class="share-modal-actions">
+        <button class="action-btn primary" id="shareCreateBtn" title="Create the share link">&#x1F517; Create link</button>
+      </div>
+    </div>
+
+    <div class="share-pane" id="sharePaneLoading" hidden>
+      <p class="share-loading"><span class="share-spinner" aria-hidden="true"></span><span id="shareLoadingLabel">Syncing to Jolli…</span></p>
+    </div>
+
+    <div class="share-pane" id="sharePaneNoKey" hidden>
+      <p class="share-nokey">Set your Jolli API Key first (STATUS panel → …) to share.</p>
+    </div>
+
+    <div class="share-pane" id="sharePaneError" hidden>
+      <p class="share-error-msg" id="shareErrorMsg"></p>
+      <div class="share-modal-actions"><button class="action-btn primary" id="shareRetryBtn">Try again</button></div>
+    </div>
+  </div>
+</div>`;
 }
 
 // ─── Header helpers ───────────────────────────────────────────────────────────
@@ -291,7 +416,7 @@ function buildHeader(
 	totalFiles: number,
 	totalInsertions: number,
 	totalDeletions: number,
-	isForeign: boolean = false,
+	readOnly: boolean = false,
 ): string {
 	const changesHtml = `${totalFiles} file${totalFiles !== 1 ? "s" : ""} changed, <span class="stat-add">${totalInsertions} insertion${totalInsertions !== 1 ? "s" : ""}(+)</span>, <span class="stat-del">${totalDeletions} deletion${totalDeletions !== 1 ? "s" : ""}(-)</span>`;
 	const totalTurns = aggregateTurns(summary);
@@ -354,7 +479,12 @@ function buildHeader(
       <button class="split-menu-item" id="downloadMdBtn" data-foreign-safe>Save as Markdown File</button>
     </div>
   </div>
-  ${isForeign ? "" : `<button class="action-btn" id="regenerateSummaryBtn" title="Re-run the LLM end-to-end">&#x21BB; Regenerate</button>`}
+  ${
+		readOnly
+			? ""
+			: `<button class="action-btn" id="shareBtn" title="Share this memory as a read-only link">${SHARE_ICON_SVG} Share</button>`
+	}
+  ${readOnly ? "" : `<button class="action-btn" id="regenerateSummaryBtn" title="Re-run the LLM end-to-end">&#x21BB; Regenerate</button>`}
 </div>`;
 }
 

--- a/vscode/src/views/SummaryScriptBuilder.test.ts
+++ b/vscode/src/views/SummaryScriptBuilder.test.ts
@@ -29,6 +29,32 @@ describe("SummaryScriptBuilder", () => {
 		expect(script).toContain("acquireVsCodeApi");
 	});
 
+	it("defaults the single header Share button to commit kind (no ▾ menu)", () => {
+		expect(script).toContain(`var defaultShareKind = "commit";`);
+		// The branch/memory choice lives in the sidebar entries — no dropdown here.
+		expect(script).not.toContain("shareDropdown");
+		expect(script).not.toContain("shareThisBranchBtn");
+		// No auto-open baked in by default.
+		expect(script).not.toContain('shareOpen("');
+	});
+
+	it("flips the button default when the panel was entered via share-this-branch", () => {
+		// Sidebar share entries thread the kind through so the button and modal
+		// title stay consistent with the entry the user clicked ("Share this
+		// branch" vs "Share this memory").
+		const branchScript = buildScript({ defaultShareKind: "branch", autoOpenShare: true });
+		expect(branchScript).toContain(`var defaultShareKind = "branch";`);
+		expect(branchScript).toContain("'Share this branch as a read-only link'");
+		expect(branchScript).toContain('shareOpen("branch");');
+		expect(() => new Function(branchScript)).not.toThrow();
+	});
+
+	it("bakes a one-shot commit-kind shareOpen for the per-memory share entry", () => {
+		const commitScript = buildScript({ defaultShareKind: "commit", autoOpenShare: true });
+		expect(commitScript).toContain('shareOpen("commit");');
+		expect(() => new Function(commitScript)).not.toThrow();
+	});
+
 	it("contains toggle expand/collapse handlers", () => {
 		expect(script).toContain(".toggle-header");
 		expect(script).toContain("classList.toggle");

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -15,8 +15,29 @@ import {
 import { buildContextMenuGuardScript } from "./ContextMenuGuard.js";
 import { buildTranscriptEntriesScript } from "./TranscriptEntryRenderer.js";
 
+/** Share-entry options threaded from the panel into the webview script. */
+export interface SummaryScriptOptions {
+	/**
+	 * Kind of the single header Share button — follows the panel's ENTRY so the
+	 * button stays consistent with how the user got here: opened via the
+	 * sidebar's "Share this branch" → `"branch"`; every other entry (commit
+	 * click, per-memory share icon) → `"commit"`. There is no ▾ menu — the
+	 * branch/memory choice lives in the sidebar's two share entries.
+	 */
+	readonly defaultShareKind?: "branch" | "commit";
+	/**
+	 * One-shot: open the share modal (at `defaultShareKind`) as soon as the
+	 * script loads — set when the panel was opened BY a share entry. Baked into
+	 * the script rather than posted from the host because a message sent right
+	 * after `webview.html` assignment can race the listener setup and get
+	 * dropped.
+	 */
+	readonly autoOpenShare?: boolean;
+}
+
 /** Returns the JavaScript for toggle interactions and the Copy Markdown button. */
-export function buildScript(): string {
+export function buildScript(options: SummaryScriptOptions = {}): string {
+	const defaultShareKind = options.defaultShareKind === "branch" ? "branch" : "commit";
 	return `
   ${buildContextMenuGuardScript()}
 
@@ -124,6 +145,355 @@ export function buildScript(): string {
     });
   }
 
+  // ── Share popover (live Space-backed share): this memory (commit) or whole branch ──
+  var shareOverlay = document.getElementById('shareOverlay');
+  var shareBtn = document.getElementById('shareBtn');
+  // Set on open; included in every share message so the host knows which subject
+  // (this commit vs whole branch) to act on. Defaults to commit (the primary button).
+  var shareKind = 'commit';
+  function sharePane(id) {
+    var panes = document.querySelectorAll('.share-pane');
+    for (var i = 0; i < panes.length; i++) { panes[i].hidden = (panes[i].id !== id); }
+  }
+  // Anchor the card under the Share button — the overlay is a transparent full-screen
+  // click-catcher with no DOM relationship to the button, so position it in JS.
+  function sharePositionCard() {
+    if (!shareBtn || !shareOverlay) { return; }
+    var card = shareOverlay.querySelector('.share-modal');
+    if (!card) { return; }
+    var r = shareBtn.getBoundingClientRect();
+    // The Share button is left-aligned in the header, so open the card RIGHTWARD from
+    // the button's left edge; clamp to the viewport so it never overflows (which looked
+    // like the sidebar was covering half of it).
+    var cardW = card.offsetWidth || 440;
+    var maxLeft = Math.max(8, window.innerWidth - cardW - 8);
+    var left = Math.min(Math.max(8, Math.round(r.left)), maxLeft);
+    card.style.top = Math.round(r.bottom + 6) + 'px';
+    card.style.left = left + 'px';
+    card.style.right = 'auto';
+  }
+  // Auto-sync on open: the host pushes + creates the live share and returns 'ready'.
+  function shareOpen(kind) {
+    if (!shareOverlay) { return; }
+    shareKind = (kind === 'branch') ? 'branch' : 'commit';
+    // Text only — the share glyph is a sibling SVG in the modal head, so setting
+    // textContent here must not wipe it.
+    var title = document.getElementById('shareModalTitle');
+    if (title) { title.textContent = (shareKind === 'branch') ? 'Share this branch' : 'Share this memory'; }
+    shareOverlay.hidden = false;
+    sharePositionCard();
+    sharePane('sharePaneLoading');
+    shareSetSyncBadge('loading');
+    vscode.postMessage({ command: 'shareBranch', shareKind: shareKind });
+  }
+  function shareClose() {
+    if (shareOverlay) { shareOverlay.hidden = true; }
+  }
+
+  // Single Share button (no ▾ menu — the branch/memory choice lives in the
+  // sidebar's two entries). It re-shares at the panel's ENTRY kind: 'commit'
+  // ("this memory") by default, 'branch' when the panel was opened via a
+  // share-this-branch entry, so the button stays consistent with how the user
+  // got here.
+  var defaultShareKind = ${JSON.stringify(defaultShareKind)};
+  if (shareBtn) {
+    if (defaultShareKind === 'branch') { shareBtn.title = 'Share this branch as a read-only link'; }
+    shareBtn.addEventListener('click', function() { shareClose(); shareOpen(defaultShareKind); });
+  }
+
+  var shareModalClose = document.getElementById('shareModalClose');
+  if (shareModalClose) { shareModalClose.addEventListener('click', shareClose); }
+
+  if (shareOverlay) {
+    shareOverlay.addEventListener('click', function(e) { if (e.target === shareOverlay) { shareClose(); } });
+  }
+  window.addEventListener('resize', function() { if (shareOverlay && !shareOverlay.hidden) { sharePositionCard(); } });
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape' && shareOverlay && !shareOverlay.hidden) { shareClose(); }
+  });
+
+  // people-tier state: the current allowlist (added people's emails) and the search
+  // suggestion directory (org members + git contributors), both set on each render.
+  var shareRecipients = [];
+  var shareOrgMembers = [];
+  var shareOwnerEmail = '';
+  var shareOwnerName = '';
+  function shareSetSyncBadge(mode) {
+    var badge = document.getElementById('shareSyncBadge');
+    if (!badge) { return; }
+    if (mode === 'ready') { badge.textContent = '\\u25CF SYNCED'; badge.className = 'share-sync-badge synced'; badge.hidden = false; }
+    else if (mode === 'loading') { badge.textContent = 'SYNCING\\u2026'; badge.className = 'share-sync-badge syncing'; badge.hidden = false; }
+    else { badge.hidden = true; }
+  }
+  function shareAccessSubText(vis) {
+    if (vis === 'org') { return 'Anyone in the jolliai workspace can open this.'; }
+    if (vis === 'people') { return 'Only the people above can open this.'; }
+    return 'Anyone with the link can open this \\u2014 no account needed.';
+  }
+  // PATCH the audience (access level + current recipients) and drop to the SYNCING pane;
+  // the host re-renders 'ready' when the server confirms.
+  function shareSendAudience() {
+    var sel = document.getElementById('shareVisibilitySelect');
+    var vis = sel && sel.value ? sel.value : 'public';
+    // Stay on the main pane (the list was already updated optimistically) — just show the
+    // SYNCING badge while the host PATCHes; the authoritative 'ready' re-render follows.
+    shareSetSyncBadge('loading');
+    vscode.postMessage({ command: 'shareSetAudience', visibility: vis, recipients: shareRecipients.slice(), shareKind: shareKind });
+  }
+  function shareCreate() {
+    var sel = document.getElementById('shareCreateVisibilitySelect');
+    var vis = sel && sel.value ? sel.value : 'public';
+    shareSetSyncBadge('loading');
+    sharePane('sharePaneLoading');
+    vscode.postMessage({ command: 'shareCreate', visibility: vis, recipients: shareRecipients.slice(), shareKind: shareKind });
+  }
+  // Resolve a display name for an email from the directory (org members + contributors).
+  function shareResolveName(email) {
+    var lower = (email || '').toLowerCase();
+    for (var i = 0; i < shareOrgMembers.length; i++) {
+      if ((shareOrgMembers[i].email || '').toLowerCase() === lower) { return shareOrgMembers[i].name || email; }
+    }
+    return email;
+  }
+  // Build the collaborator rows locally (owner + current recipients) for optimistic render.
+  function shareLocalCollabRows() {
+    var rows = [{ name: shareOwnerName || shareOwnerEmail, email: shareOwnerEmail, isOwner: true }];
+    var seen = {};
+    seen[(shareOwnerEmail || '').toLowerCase()] = true;
+    shareRecipients.forEach(function(e) {
+      var l = e.toLowerCase();
+      if (!seen[l]) { seen[l] = true; rows.push({ name: shareResolveName(e), email: e, isOwner: false }); }
+    });
+    return rows;
+  }
+  function shareRemoveRecipient(email) {
+    var lower = (email || '').toLowerCase();
+    shareRecipients = shareRecipients.filter(function(e) { return e.toLowerCase() !== lower; });
+    shareRenderCollaborators(shareLocalCollabRows()); // optimistic — reflect the removal immediately
+    shareSendAudience();
+  }
+  function shareAddRecipient(email) {
+    var e = (email || '').trim();
+    if (!e) { return; }
+    var lower = e.toLowerCase();
+    if (lower === (shareOwnerEmail || '').toLowerCase()) { return; }
+    if (shareRecipients.some(function(x) { return x.toLowerCase() === lower; })) { return; }
+    shareRecipients = shareRecipients.concat([e]);
+    // Adding someone means "Only people you add" — switch access to people so the
+    // allowlist actually gates (and persists server-side).
+    var sel = document.getElementById('shareVisibilitySelect');
+    if (sel) { sel.value = 'people'; }
+    var sub = document.getElementById('shareAccessSub');
+    if (sub) { sub.textContent = shareAccessSubText('people'); }
+    shareRenderCollaborators(shareLocalCollabRows()); // optimistic — show the new person immediately
+    shareSendAudience();
+  }
+  function shareInitials(name, email) {
+    var src = (name || '').trim() || (email || '').trim();
+    if (!src) { return '?'; }
+    var parts = src.split(/\\s+/);
+    if (name && parts.length >= 2) { return (parts[0].charAt(0) + parts[1].charAt(0)).toUpperCase(); }
+    return src.slice(0, 2).toUpperCase();
+  }
+  // Renders the Collaborators list (owner + added recipients). Rows use textContent so
+  // names/emails can never inject HTML. Non-owner rows get a functional remove ("\\u00D7").
+  function shareRenderCollaborators(list) {
+    var box = document.getElementById('shareCollabList');
+    if (!box) { return; }
+    box.innerHTML = '';
+    (list || []).forEach(function(c) {
+      var row = document.createElement('div');
+      row.className = 'share-collab-row';
+      var av = document.createElement('span');
+      av.className = 'share-avatar';
+      av.textContent = shareInitials(c.name, c.email);
+      var meta = document.createElement('div');
+      meta.className = 'share-collab-meta';
+      var nm = document.createElement('span');
+      nm.className = 'share-collab-name';
+      nm.textContent = (c.name || c.email) + (c.isOwner ? ' (you)' : '');
+      var em = document.createElement('span');
+      em.className = 'share-collab-email';
+      em.textContent = c.email || '';
+      meta.appendChild(nm); meta.appendChild(em);
+      row.appendChild(av); row.appendChild(meta);
+      if (c.isOwner) {
+        var role = document.createElement('span');
+        role.className = 'share-collab-role';
+        role.textContent = 'Owner';
+        row.appendChild(role);
+      } else {
+        var rm = document.createElement('button');
+        rm.type = 'button';
+        rm.className = 'share-collab-remove';
+        rm.title = 'Remove ' + (c.email || '');
+        rm.setAttribute('aria-label', 'Remove ' + (c.email || ''));
+        rm.textContent = '\\u00D7';
+        rm.addEventListener('click', function() { shareRemoveRecipient(c.email); });
+        row.appendChild(rm);
+      }
+      box.appendChild(row);
+    });
+  }
+  function shareHideSuggest() {
+    var s = document.getElementById('shareSuggest');
+    if (s) { s.hidden = true; s.innerHTML = ''; }
+  }
+  var EMAIL_RE = /^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/;
+  // Search → suggestions dropdown: matching directory members not already added, plus an
+  // "Add <email>" row for a valid, new email. Picking one adds it to the allowlist.
+  function shareRenderSuggest(q) {
+    var box = document.getElementById('shareSuggest');
+    if (!box) { return; }
+    box.innerHTML = '';
+    var query = (q || '').trim().toLowerCase();
+    if (!query) { box.hidden = true; return; }
+    var inList = {};
+    shareRecipients.forEach(function(e) { inList[e.toLowerCase()] = true; });
+    if (shareOwnerEmail) { inList[shareOwnerEmail.toLowerCase()] = true; }
+    var matches = (shareOrgMembers || []).filter(function(m) {
+      var hay = ((m.name || '') + ' ' + (m.email || '')).toLowerCase();
+      return hay.indexOf(query) !== -1 && !inList[(m.email || '').toLowerCase()];
+    }).slice(0, 6);
+    matches.forEach(function(m) {
+      var item = document.createElement('button');
+      item.type = 'button';
+      item.className = 'share-suggest-item';
+      var nm = document.createElement('span'); nm.className = 'share-suggest-name'; nm.textContent = m.name || m.email;
+      var em = document.createElement('span'); em.className = 'share-suggest-email'; em.textContent = m.email || '';
+      item.appendChild(nm); item.appendChild(em);
+      item.addEventListener('click', function() { var s = document.getElementById('shareTeammateSearch'); if (s) { s.value = ''; } shareHideSuggest(); shareAddRecipient(m.email); });
+      box.appendChild(item);
+    });
+    var raw = (q || '').trim();
+    if (EMAIL_RE.test(raw) && !inList[raw.toLowerCase()]) {
+      var add = document.createElement('button');
+      add.type = 'button';
+      add.className = 'share-suggest-item share-suggest-add';
+      add.textContent = '\\u2795 Add ' + raw;
+      add.addEventListener('click', function() { var s = document.getElementById('shareTeammateSearch'); if (s) { s.value = ''; } shareHideSuggest(); shareAddRecipient(raw); });
+      box.appendChild(add);
+    }
+    box.hidden = box.children.length === 0;
+  }
+  var shareSearch = document.getElementById('shareTeammateSearch');
+  if (shareSearch) {
+    shareSearch.addEventListener('input', function() { shareRenderSuggest(shareSearch.value); });
+    shareSearch.addEventListener('click', function(e) { e.stopPropagation(); });
+  }
+  document.addEventListener('click', shareHideSuggest);
+  // Access level: org / public / people are all functional. A live share exists by the
+  // time this pane shows (auto-sync), so a change PATCHes the audience (+ current people).
+  var shareVisSelect = document.getElementById('shareVisibilitySelect');
+  if (shareVisSelect) {
+    shareVisSelect.addEventListener('change', function() {
+      var sub = document.getElementById('shareAccessSub');
+      if (sub) { sub.textContent = shareAccessSubText(shareVisSelect.value); }
+      shareSendAudience();
+    });
+  }
+  var shareRetryBtn = document.getElementById('shareRetryBtn');
+  if (shareRetryBtn) { shareRetryBtn.addEventListener('click', function() { shareOpen(shareKind); }); }
+  var shareCreateBtn = document.getElementById('shareCreateBtn');
+  if (shareCreateBtn) { shareCreateBtn.addEventListener('click', shareCreate); }
+  var shareCreateVisSelect = document.getElementById('shareCreateVisibilitySelect');
+  if (shareCreateVisSelect) {
+    shareCreateVisSelect.addEventListener('change', function() {
+      var sub = document.getElementById('shareCreateAccessSub');
+      if (sub) { sub.textContent = shareAccessSubText(shareCreateVisSelect.value); }
+    });
+  }
+  // Copy the bare shareable URL (held in a hidden input), with "Copied!" feedback.
+  var shareCopyBtn = document.getElementById('shareCopyBtn');
+  if (shareCopyBtn) {
+    shareCopyBtn.addEventListener('click', function() {
+      var input = document.getElementById('shareLinkInput');
+      if (!input || !input.value) { return; }
+      var done = function() {
+        var orig = shareCopyBtn.textContent;
+        shareCopyBtn.textContent = 'Copied!';
+        setTimeout(function() { shareCopyBtn.textContent = orig; }, 1500);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(input.value).then(done, function() { input.select(); done(); });
+      } else {
+        input.select(); try { document.execCommand('copy'); } catch (e) {} done();
+      }
+    });
+  }
+
+  function shareRender(state) {
+    if (!state || !shareOverlay) { return; }
+    if (state.kind === 'revoked') { shareClose(); return; } // stopped → just dismiss (toast confirms)
+    if (state.kind === 'needsApiKey') { shareSetSyncBadge('hide'); sharePane('sharePaneNoKey'); return; }
+    if (state.kind === 'needsCreate') { shareRenderCreate(state); return; }
+    if (state.kind === 'ready') { shareRenderMain(state); return; }
+    if (state.kind === 'loading') {
+      var lbl = document.getElementById('shareLoadingLabel');
+      if (lbl && state.label) { lbl.textContent = state.label; }
+      shareSetSyncBadge('loading');
+      sharePane('sharePaneLoading');
+      return;
+    }
+    if (state.kind === 'error') {
+      var em = document.getElementById('shareErrorMsg');
+      if (em) { em.textContent = state.message || 'Something went wrong.'; }
+      shareSetSyncBadge('hide');
+      sharePane('sharePaneError');
+      return;
+    }
+  }
+
+  function shareRenderCreate(state) {
+    shareRecipients = (state.recipients || []).slice();
+    shareOrgMembers = state.orgMembers || [];
+    var ownerRow = (state.collaborators || []).filter(function(c) { return c.isOwner; })[0];
+    shareOwnerEmail = ownerRow ? (ownerRow.email || '') : '';
+    shareOwnerName = ownerRow ? (ownerRow.name || '') : '';
+    var sub = document.getElementById('shareModalSub');
+    if (sub) { sub.textContent = state.subjectTitle || state.subject || state.branch || ''; }
+    var orgOption = document.getElementById('shareCreateOrgOption');
+    if (orgOption) { orgOption.disabled = !state.canOrg; orgOption.hidden = !state.canOrg; }
+    var visSelect = document.getElementById('shareCreateVisibilitySelect');
+    if (visSelect) { visSelect.value = state.visibility || (state.canOrg ? 'org' : 'public'); }
+    var accessSub = document.getElementById('shareCreateAccessSub');
+    if (accessSub) { accessSub.textContent = shareAccessSubText(visSelect ? visSelect.value : (state.visibility || 'public')); }
+    shareSetSyncBadge('hide');
+    sharePane('sharePaneCreate');
+    sharePositionCard();
+  }
+
+  // The SYNCED popover: subtitle, collaborators, access selector + sub-copy, the
+  // (hidden) link input for Copy, and the SYNCED badge. Auto-sync means we only ever
+  // render 'ready' here (loading/error use their own panes).
+  function shareRenderMain(state) {
+    shareRecipients = (state.recipients || []).slice();
+    shareOrgMembers = state.orgMembers || [];
+    var ownerRow = (state.collaborators || []).filter(function(c) { return c.isOwner; })[0];
+    shareOwnerEmail = ownerRow ? (ownerRow.email || '') : '';
+    shareOwnerName = ownerRow ? (ownerRow.name || '') : '';
+    var sub = document.getElementById('shareModalSub');
+    if (sub) {
+      var n = state.decisionCount || 0;
+      sub.textContent = (state.subjectTitle || state.subject || state.branch) + ' \\u00B7 ' + n + ' decision' + (n === 1 ? '' : 's');
+    }
+    var orgOption = document.getElementById('shareOrgOption');
+    if (orgOption) { orgOption.disabled = !state.canOrg; orgOption.hidden = !state.canOrg; }
+    var visSelect = document.getElementById('shareVisibilitySelect');
+    if (visSelect) { visSelect.value = state.visibility || 'public'; }
+    var accessSub = document.getElementById('shareAccessSub');
+    if (accessSub) { accessSub.textContent = shareAccessSubText(state.visibility || 'public'); }
+    shareRenderCollaborators(state.collaborators);
+    var input = document.getElementById('shareLinkInput');
+    if (input) { input.value = state.shareUrl || ''; }
+    var search = document.getElementById('shareTeammateSearch');
+    if (search) { search.value = ''; }
+    shareHideSuggest();
+    shareSetSyncBadge('ready');
+    sharePane('sharePaneMain');
+    sharePositionCard();
+  }
+
   // Stale-readonly banner: "Open new commit's summary" button. The live
   // root hash is rendered into data-target-hash by buildHtml; the
   // extension routes the message to jollimemory.viewSummary.
@@ -145,6 +515,11 @@ ${buildPrSectionScript()}
   // itself is never changed mid-push.
   window.addEventListener('message', function(event) {
     var msg = event.data;
+
+    // ── Share modal state ──
+    if (msg.command === 'shareState') {
+      shareRender(msg.state);
+    }
 
     // ── Push status ──
     if (pushBtn && msg.command === 'pushStarted') {
@@ -1928,5 +2303,6 @@ ${buildTranscriptEntriesScript()}
     }
   });
 
+  ${options.autoOpenShare ? `shareOpen(${JSON.stringify(defaultShareKind)});` : ""}
 `;
 }

--- a/vscode/src/views/SummaryWebviewPanel.handlePush.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.handlePush.test.ts
@@ -28,6 +28,7 @@ const {
 	openExternal,
 	executeCommand,
 	getConfiguration,
+	withProgressMock,
 } = vi.hoisted(() => ({
 	postMessage: vi.fn().mockResolvedValue(true),
 	onDidReceiveMessage: vi.fn(),
@@ -44,6 +45,7 @@ const {
 	openExternal: vi.fn(),
 	executeCommand: vi.fn(),
 	getConfiguration: vi.fn(() => ({ get: vi.fn() })),
+	withProgressMock: vi.fn((_opts: unknown, work: () => unknown) => work()),
 }));
 
 const { createWebviewPanel } = vi.hoisted(() => ({
@@ -70,7 +72,9 @@ vi.mock("vscode", () => ({
 		showQuickPick,
 		showOpenDialog,
 		showSaveDialog,
+		withProgress: withProgressMock,
 	},
+	ProgressLocation: { Notification: 15 },
 	env: {
 		clipboard: { writeText: clipboardWriteText },
 		openExternal,
@@ -115,6 +119,41 @@ vi.mock("../../../cli/src/core/SessionTracker.js", () => ({
 
 vi.mock("../util/WorkspaceUtils.js", () => ({
 	loadGlobalConfig: mockLoadConfig,
+}));
+
+const {
+	mockOpenShareModal,
+	mockCreateShareModal,
+	mockRevokeShareModal,
+	mockShareModalTarget,
+	mockSetShareExpiryModal,
+	mockSetShareVisibilityModal,
+	mockListOrgMembers,
+} = vi.hoisted(() => ({
+	mockOpenShareModal: vi.fn().mockResolvedValue(undefined),
+	mockCreateShareModal: vi.fn().mockResolvedValue(undefined),
+	mockRevokeShareModal: vi.fn().mockResolvedValue(undefined),
+	mockShareModalTarget: vi.fn().mockResolvedValue(undefined),
+	mockSetShareExpiryModal: vi.fn().mockResolvedValue(undefined),
+	mockSetShareVisibilityModal: vi.fn().mockResolvedValue(undefined),
+	mockListOrgMembers: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../services/BranchShareModal.js", () => ({
+	openShareModal: mockOpenShareModal,
+	createShareModal: mockCreateShareModal,
+	revokeShareModal: mockRevokeShareModal,
+	shareModalTarget: mockShareModalTarget,
+	setShareExpiryModal: mockSetShareExpiryModal,
+	setShareVisibilityModal: mockSetShareVisibilityModal,
+}));
+
+vi.mock("../services/JolliShareService.js", () => ({
+	listOrgMembers: mockListOrgMembers,
+}));
+
+vi.mock("../../../cli/src/core/BranchShareSnapshot.js", () => ({
+	resolveShareHead: vi.fn().mockResolvedValue(undefined),
 }));
 
 const { mockGenerateE2eTest, mockTranslateToEnglish } = vi.hoisted(() => ({
@@ -164,6 +203,7 @@ vi.mock("../../../cli/src/core/SummaryStore.js", () => ({
 	storeNotes: mockStoreNotes,
 	storePlans: mockStorePlans,
 	storeSummary: mockStoreSummary,
+	resolveEffectiveTopics: vi.fn(() => []),
 }));
 
 const { mockDeleteTopicInTree, mockUpdateTopicInTree } = vi.hoisted(() => ({
@@ -464,6 +504,14 @@ const stubBridge = {
 						artifacts,
 					) as Promise<void>),
 	),
+	// Share path reads the current branch here (the snapshot content is sourced
+	// from the current checkout, so the share's branch label/key follows it).
+	// Defaults to the branch the share tests open the panel on.
+	getCurrentBranch: vi.fn().mockResolvedValue("feature/share"),
+	// Share popover flags the Owner collaborator row by matching this against the
+	// repo contributors' emails; the name falls back to git user.name.
+	getCurrentUserEmail: vi.fn().mockResolvedValue("dev@example.com"),
+	getCurrentUserName: vi.fn().mockResolvedValue("Dev"),
 	// Stale-commit guard reads the index via this bridge wrapper. Default to
 	// "empty index" so push tests stay on the happy path.
 	getSummaryIndexEntryMap: vi.fn().mockResolvedValue(new Map()),
@@ -877,5 +925,164 @@ describe("SummaryWebviewPanel handlePush", () => {
 				}),
 			);
 		});
+	});
+});
+
+describe("SummaryWebviewPanel share modal", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		(SummaryWebviewPanel as unknown as { currentMemoryPanel: undefined }).currentMemoryPanel = undefined;
+		(SummaryWebviewPanel as unknown as { commitPanels: Map<string, unknown> }).commitPanels.clear();
+		mockLoadConfig.mockResolvedValue({ apiKey: "test", jolliApiKey: "jk_valid" });
+	});
+
+	it("routes shareBranch / shareRevoke to the modal state machine", async () => {
+		const dispatch = await setupPanel({ branch: "feature/share" });
+
+		dispatch({ command: "shareBranch" });
+		await flushPromises();
+		expect(mockOpenShareModal).toHaveBeenCalledTimes(1);
+		const [, ctx] = mockOpenShareModal.mock.calls[0];
+		expect(ctx).toMatchObject({ workspaceRoot, branch: "feature/share", apiKey: "jk_valid" });
+
+		dispatch({ command: "shareRevoke" });
+		await flushPromises();
+		expect(mockRevokeShareModal).toHaveBeenCalledTimes(1);
+	});
+
+	it("routes shareSetAudience (people + recipients) to setShareVisibilityModal", async () => {
+		const dispatch = await setupPanel({ branch: "feature/share" });
+		dispatch({ command: "shareSetAudience", visibility: "people", recipients: ["Ext@GMAIL.com", "bad", "ext@gmail.com"] });
+		await flushPromises();
+		expect(mockSetShareVisibilityModal).toHaveBeenCalledTimes(1);
+		const [, , visibility, recipients] = mockSetShareVisibilityModal.mock.calls[0];
+		expect(visibility).toBe("people");
+		expect(recipients).toEqual(["ext@gmail.com"]);
+	});
+
+	it("routes shareCreate to createShareModal with validated audience and recipients", async () => {
+		const dispatch = await setupPanel({ branch: "feature/share" });
+		dispatch({ command: "shareCreate", visibility: "people", recipients: ["A@X.com", "nope"], shareKind: "commit" });
+		await flushPromises();
+		expect(mockCreateShareModal).toHaveBeenCalledTimes(1);
+		const [, ctx] = mockCreateShareModal.mock.calls[0];
+		expect(ctx).toMatchObject({ visibility: "people", recipients: ["a@x.com"] });
+	});
+
+	it("rejects invalid share messages before they reach the modal services", async () => {
+		const dispatch = await setupPanel({ branch: "feature/share" });
+		dispatch({ command: "shareSetAudience", visibility: "admin" });
+		dispatch({ command: "shareSetExpiry", days: 13 });
+		dispatch({ command: "shareOpenTarget", target: "javascript" });
+		dispatch({ command: "shareCreate", visibility: "admin" });
+		await flushPromises();
+		expect(mockSetShareVisibilityModal).not.toHaveBeenCalled();
+		expect(mockSetShareExpiryModal).not.toHaveBeenCalled();
+		expect(mockShareModalTarget).not.toHaveBeenCalled();
+		expect(mockCreateShareModal).not.toHaveBeenCalled();
+		expect(showErrorMessage).toHaveBeenCalledTimes(4);
+	});
+
+	it("resolves the owner name + builds the deduped add-people directory from org members", async () => {
+		// A case-insensitive duplicate exercises the directory dedupe.
+		mockListOrgMembers.mockResolvedValueOnce([
+			{ name: "Dev Eloper", email: "dev@example.com" },
+			{ name: "Dup", email: "DEV@example.com" },
+		]);
+		const dispatch = await setupPanel({ branch: "feature/share" });
+		dispatch({ command: "shareBranch" });
+		await flushPromises();
+		const [, ctx] = mockOpenShareModal.mock.calls[0];
+		expect(ctx.owner).toEqual({ name: "Dev Eloper", email: "dev@example.com" });
+		expect(ctx.directory).toEqual([{ name: "Dev Eloper", email: "dev@example.com" }]);
+	});
+
+	it("skips the org-member fetch when there is no API key", async () => {
+		mockLoadConfig.mockResolvedValue({});
+		const dispatch = await setupPanel({ branch: "feature/share" });
+		dispatch({ command: "shareBranch" });
+		await flushPromises();
+		expect(mockListOrgMembers).not.toHaveBeenCalled();
+		const [, ctx] = mockOpenShareModal.mock.calls[0];
+		expect(ctx.apiKey).toBeUndefined();
+	});
+
+	it("branch share is labeled with the CURRENT branch, not the opened summary's branch", async () => {
+		// Panel opened on feature/a, but the user has since checked out feature/b.
+		// The snapshot content comes from the current checkout, so the share must be
+		// labeled/keyed feature/b — otherwise it'd publish feature/b's content under
+		// a feature/a label.
+		const dispatch = await setupPanel({ branch: "feature/a" });
+		(stubBridge.getCurrentBranch as ReturnType<typeof vi.fn>).mockResolvedValue("feature/b");
+
+		dispatch({ command: "shareBranch" });
+		await flushPromises();
+		const [, ctx] = mockOpenShareModal.mock.calls[0];
+		expect(ctx).toMatchObject({ branch: "feature/b" });
+	});
+
+	it("commit share stays bound to the opened summary when the current branch changed", async () => {
+		const dispatch = await setupPanel({ branch: "feature/a", commitHash: "abc123" });
+		(stubBridge.getCurrentBranch as ReturnType<typeof vi.fn>).mockResolvedValue("feature/b");
+
+		dispatch({ command: "shareBranch", shareKind: "commit" });
+		await flushPromises();
+		const [, ctx] = mockOpenShareModal.mock.calls[0];
+		expect(ctx).toMatchObject({ branch: "feature/a", commitHash: "abc123" });
+		expect(ctx.commitSummary).toMatchObject({ branch: "feature/a", commitHash: "abc123" });
+	});
+
+	it("falls back to the summary branch when HEAD is detached", async () => {
+		const dispatch = await setupPanel({ branch: "feature/a" });
+		(stubBridge.getCurrentBranch as ReturnType<typeof vi.fn>).mockResolvedValue("HEAD");
+
+		dispatch({ command: "shareBranch" });
+		await flushPromises();
+		const [, ctx] = mockOpenShareModal.mock.calls[0];
+		expect(ctx).toMatchObject({ branch: "feature/a" });
+	});
+
+	it("routes shareOpenTarget to the modal target handler", async () => {
+		const dispatch = await setupPanel({ branch: "feature/share" });
+		dispatch({ command: "shareOpenTarget", target: "email" });
+		await flushPromises();
+		expect(mockShareModalTarget).toHaveBeenCalledWith(expect.anything(), expect.anything(), "email");
+	});
+
+	it("builds a VS Code-backed IO (postState, openUrl, composeEmail, formatExpiry)", async () => {
+		const dispatch = await setupPanel({ branch: "feature/share" });
+		dispatch({ command: "shareBranch" });
+		await flushPromises();
+		const [io] = mockOpenShareModal.mock.calls[0];
+
+		io.postState({ kind: "needsApiKey" });
+		expect(postMessage).toHaveBeenCalledWith({ command: "shareState", state: { kind: "needsApiKey" } });
+
+		await io.openUrl("https://acme.jolli.ai/b/x");
+		await io.composeEmail("feature/share", "https://acme.jolli.ai/b/x", 4, ["Add dark mode"]);
+		expect(openExternal).toHaveBeenCalledTimes(2);
+		const mailto = openExternal.mock.calls[1][0].toString();
+		expect(mailto).toContain("mailto:?subject=");
+		expect(mailto).toContain("body=");
+		// Rich payload: subject teases how-we-built + decision count; body teases the branch titles.
+		expect(decodeURIComponent(mailto)).toContain('How we built "feature/share" — 4 decisions');
+		expect(decodeURIComponent(mailto)).toContain("Add dark mode");
+
+		// Copy message → clipboard + a confirmation toast.
+		await io.copyMessage("feature/share", "https://acme.jolli.ai/b/x", 4, ["Add dark mode"]);
+		expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining("feature/share"));
+		expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("copied"));
+
+		// Social → opens the platform's intent URL externally.
+		await io.openSocial("x", "feature/share", "https://acme.jolli.ai/b/x", 4, ["Add dark mode"]);
+		expect(openExternal).toHaveBeenCalledTimes(3);
+		expect(openExternal.mock.calls[2][0].toString()).toContain("twitter.com/intent/tweet");
+
+		io.notifyError("boom");
+		expect(showErrorMessage).toHaveBeenCalledWith("boom");
+
+		expect(io.formatExpiry("2026-09-01T00:00:00.000Z")).toContain("expires");
+		expect(io.formatExpiry("")).toBe("");
+		expect(io.formatExpiry("not-a-date")).toBe("");
 	});
 });

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -1938,7 +1938,7 @@ describe("SummaryWebviewPanel", () => {
 				await flushPromises();
 
 				expect(warn).toHaveBeenCalledWith(
-					"SummaryPanel",
+					"PushOrchestrator",
 					expect.stringContaining("broken-snip"),
 				);
 				// mockPushToJolli is called for: summary + ok-snip (the broken one is skipped).

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -31,6 +31,7 @@ import {
 	generateRecap,
 	translateToEnglish,
 } from "../../../cli/src/core/Summarizer.js";
+import { getRepoContributors } from "../../../cli/src/core/GitOps.js";
 import { runWithTrace } from "../../../cli/src/core/TraceContext.js";
 import {
 	getTranscriptHashes as coreGetTranscriptHashes,
@@ -47,8 +48,6 @@ import {
 import type {
 	CommitSummary,
 	E2eTestScenario,
-	NoteReference,
-	PlanReference,
 	ReferenceCommitRef,
 	SourceId,
 	StoredTranscript,
@@ -60,13 +59,12 @@ import {
 	removePlan,
 } from "../core/PlanService.js";
 import type { JolliMemoryBridge } from "../JolliMemoryBridge.js";
+import { PluginOutdatedError, parseJolliApiKey } from "../services/JolliPushService.js";
 import {
-	BindingRequiredError,
-	deleteFromJolli,
-	PluginOutdatedError,
-	parseJolliApiKey,
-	pushToJolli,
-} from "../services/JolliPushService.js";
+	type PushContext,
+	pushSummaryWithAttachments,
+	ShareBindingError,
+} from "../services/JolliPushOrchestrator.js";
 import {
 	classifyCreatePrBranch,
 	createPrBlockMessage,
@@ -84,8 +82,24 @@ import {
 } from "../util/GitRemoteUtils.js";
 import { isWorkerBlockingBusy } from "../util/LockUtils.js";
 import { log } from "../util/Logger.js";
-import { latestPlanPerName } from "../util/PlanGrouping.js";
 import { loadGlobalConfig } from "../util/WorkspaceUtils.js";
+import {
+	type ShareKind,
+	type ShareMember,
+	createShareModal,
+	openShareModal,
+	revokeShareModal,
+	type ShareModalContext,
+	type ShareModalIO,
+	type ShareModalState,
+	type ShareTarget,
+	type ShareVisibility,
+	setShareExpiryModal,
+	setShareVisibilityModal,
+	shareModalTarget,
+} from "../services/BranchShareModal.js";
+import { listOrgMembers } from "../services/JolliShareService.js";
+import { buildShareCopyMessage, buildShareEmail, buildSocialShareUrl } from "../services/ShareMessage.js";
 import { BindingChooserWebviewPanel } from "./BindingChooserWebviewPanel.js";
 import { loadBranchSummaries } from "./BranchSummaryLoader.js";
 import { SOURCE_TITLES } from "./SourceLabels.js";
@@ -103,20 +117,81 @@ import {
 } from "./SummaryHtmlBuilder.js";
 import { buildMarkdown } from "./SummaryMarkdownBuilder.js";
 import { buildPrBodyMarkdown, pickPrTitle, wrapWithMarkers } from "../../../cli/src/core/PrDescription.js";
-import {
-	buildBranchRelativePath,
-	buildNotePushTitle,
-	buildPanelTitle,
-	buildPlanPushTitle,
-	buildPushTitle,
-	collectSortedTopics,
-	formatActiveProviderLabel,
-} from "./SummaryUtils.js";
+import { buildPanelTitle, collectSortedTopics, formatActiveProviderLabel } from "./SummaryUtils.js";
 import type { RegenerateContext } from "../../../cli/src/core/RegenerateContext.js";
 import { isSummaryError } from "../../../cli/src/core/SummaryErrorMarker.js";
 import { getTranscriptIds } from "../../../cli/src/core/SummaryTree.js";
-import { track } from "../../../cli/src/core/Telemetry.js";
 import type { LlmConfig } from "../../../cli/src/Types.js";
+
+/** The user's access + expiry + recipient choices from the share modal webview. */
+interface ShareSelection {
+	readonly visibility: ShareVisibility;
+	readonly recipients: ReadonlyArray<string>;
+	/** Link lifetime in days chosen in the pane; applied at create. Omit for the server default. */
+	readonly expiryDays?: number;
+}
+const DEFAULT_SHARE_SELECTION: ShareSelection = { visibility: "public", recipients: [] };
+
+const SHARE_VISIBILITIES = new Set<ShareVisibility>(["public", "org", "people"]);
+const SHARE_KINDS = new Set<ShareKind>(["branch", "commit"]);
+const SHARE_EXPIRY_DAYS = new Set([7, 30, 90, 365]);
+const SHARE_TARGETS = new Set<ShareTarget>([
+	"page",
+	"email",
+	"copy",
+	"x",
+	"linkedin",
+	"reddit",
+	"whatsapp",
+	"telegram",
+]);
+const SHARE_EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function normalizeShareVisibility(value: unknown): ShareVisibility | undefined {
+	return typeof value === "string" && SHARE_VISIBILITIES.has(value as ShareVisibility)
+		? (value as ShareVisibility)
+		: undefined;
+}
+
+function normalizeShareKind(value: unknown): ShareKind {
+	return typeof value === "string" && SHARE_KINDS.has(value as ShareKind) ? (value as ShareKind) : "branch";
+}
+
+function normalizeShareTarget(value: unknown): ShareTarget | undefined {
+	return typeof value === "string" && SHARE_TARGETS.has(value as ShareTarget) ? (value as ShareTarget) : undefined;
+}
+
+function normalizeShareExpiryDays(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isInteger(value) && SHARE_EXPIRY_DAYS.has(value) ? value : undefined;
+}
+
+function normalizeShareRecipients(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	const seen = new Set<string>();
+	const recipients: string[] = [];
+	for (const raw of value) {
+		if (typeof raw !== "string") continue;
+		const email = raw.trim().toLowerCase();
+		if (!email || !SHARE_EMAIL_RE.test(email) || seen.has(email)) continue;
+		seen.add(email);
+		recipients.push(email);
+		if (recipients.length >= 50) break;
+	}
+	return recipients;
+}
+
+/** Dedupes a member list by lowercased email, keeping the first (name-bearing) entry. */
+function dedupeMembersByEmail(members: ReadonlyArray<ShareMember>): ShareMember[] {
+	const seen = new Set<string>();
+	const out: ShareMember[] = [];
+	for (const m of members) {
+		const key = m.email.trim().toLowerCase();
+		if (!key || seen.has(key)) continue;
+		seen.add(key);
+		out.push({ name: m.name, email: m.email });
+	}
+	return out;
+}
 
 /** Memory field updates sent from the webview edit form. */
 interface TopicUpdates {
@@ -205,6 +280,27 @@ type WebviewMessage =
 	| { command: "editRecap"; recap: string }
 	| { command: "generateRecap" }
 	| { command: "regenerateSummary" }
+	| { command: "shareBranch"; shareKind?: ShareKind }
+	| { command: "shareRevoke"; shareKind?: ShareKind }
+	| {
+			command: "shareCreate";
+			visibility: ShareVisibility;
+			recipients?: ReadonlyArray<string>;
+			shareKind?: ShareKind;
+	  }
+	| {
+			command: "shareOpenTarget";
+			target: "page" | "email" | "copy" | "x" | "linkedin" | "reddit" | "whatsapp" | "telegram";
+			shareKind?: ShareKind;
+			recipients?: ReadonlyArray<string>;
+	  }
+	| { command: "shareSetExpiry"; days: number; shareKind?: ShareKind }
+	| {
+			command: "shareSetAudience";
+			visibility: ShareVisibility;
+			recipients?: ReadonlyArray<string>;
+			shareKind?: ShareKind;
+	  }
 	| { command: "openRewrittenCommit"; hash: string };
 
 /** Entry data sent back from the webview on Save All. */
@@ -216,14 +312,6 @@ interface TranscriptEntryUpdate {
 	readonly role: "human" | "assistant";
 	readonly content: string;
 	readonly timestamp?: string;
-}
-
-/** A plan/note that could not be pushed — surfaced to the user, not thrown. */
-interface PushAttachmentFailure {
-	/** Human-readable identifier, e.g. `plan "Fix P1/P2 review findings"`. */
-	readonly label: string;
-	/** Error message (includes the HTTP status from JolliPushService). */
-	readonly message: string;
 }
 
 /** Source of the panel — determines which static slot it occupies. */
@@ -313,6 +401,13 @@ function isRegenerateSafeCommand(command: WebviewMessage["command"]): boolean {
 	return REGENERATE_SAFE_COMMANDS.has(command);
 }
 
+/** Formats a share's ISO expiry into a short "expires Sep 1, 2026" label; "" when absent/invalid. */
+function formatExpiry(iso: string): string {
+	if (!iso) return "";
+	const t = Date.parse(iso);
+	if (Number.isNaN(t)) return "";
+	return `expires ${new Date(t).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })}`;
+}
 
 export class SummaryWebviewPanel {
 	/**
@@ -379,6 +474,21 @@ export class SummaryWebviewPanel {
 	 * computed at render time in `buildHtml`.
 	 */
 	private staleRewrittenInto: string | undefined;
+
+	/**
+	 * Default kind of the webview's header Share button — set by the panel's
+	 * share ENTRY (`showWithShareModal`) and persisted for the panel's lifetime
+	 * so full re-renders keep the button consistent with how the user got here
+	 * ("Share this branch" entry → branch-first button; everything else →
+	 * memory-first, the stock layout).
+	 */
+	private shareEntryKind: ShareKind = "commit";
+	/**
+	 * One-shot share-modal auto-open, consumed (and cleared) by the next
+	 * `update()`. Set only by `showWithShareModal`. Cleared immediately so
+	 * ordinary refreshes never re-pop the modal.
+	 */
+	private pendingShareOpen = false;
 
 	private readonly bridge: JolliMemoryBridge;
 	// Snapshot of `CommitsStore.getMainBranch()` at panel creation. Revisit
@@ -541,6 +651,71 @@ export class SummaryWebviewPanel {
 			case "push":
 				if (this.currentSummary) {
 					this.catchAndShow(this.handlePush(), "Push failed");
+				}
+				break;
+			case "shareBranch":
+				if (this.currentSummary) {
+					this.catchAndShow(this.handleShareModal("open", normalizeShareKind(message.shareKind)), "Share failed");
+				}
+				break;
+			case "shareRevoke":
+				if (this.currentSummary) {
+					this.catchAndShow(this.handleShareModal("revoke", normalizeShareKind(message.shareKind)), "Share failed");
+				}
+				break;
+			case "shareCreate":
+				if (this.currentSummary) {
+					const visibility = normalizeShareVisibility(message.visibility);
+					if (!visibility) {
+						vscode.window.showErrorMessage("Invalid share audience.");
+						break;
+					}
+					const selection: ShareSelection = {
+						visibility,
+						recipients: normalizeShareRecipients(message.recipients),
+					};
+					this.catchAndShow(this.handleShareModal("create", normalizeShareKind(message.shareKind), selection), "Share failed");
+				}
+				break;
+			case "shareOpenTarget":
+				if (this.currentSummary) {
+					const target = normalizeShareTarget(message.target);
+					if (!target) {
+						vscode.window.showErrorMessage("Invalid share action.");
+						break;
+					}
+					const selection: ShareSelection = {
+						visibility: "public",
+						recipients: normalizeShareRecipients(message.recipients),
+					};
+					this.catchAndShow(this.handleShareTarget(target, normalizeShareKind(message.shareKind), selection), "Share failed");
+				}
+				break;
+			case "shareSetExpiry":
+				if (this.currentSummary) {
+					const days = normalizeShareExpiryDays(message.days);
+					if (!days) {
+						vscode.window.showErrorMessage("Invalid share expiry.");
+						break;
+					}
+					this.catchAndShow(this.handleShareSetExpiry(days, normalizeShareKind(message.shareKind)), "Share failed");
+				}
+				break;
+			case "shareSetAudience":
+				if (this.currentSummary) {
+					const visibility = normalizeShareVisibility(message.visibility);
+					if (!visibility) {
+						vscode.window.showErrorMessage("Invalid share audience.");
+						break;
+					}
+					this.catchAndShow(
+						this.handleShareSetAudience(
+							visibility,
+							normalizeShareRecipients(message.recipients),
+							normalizeShareKind(message.shareKind),
+						),
+						"Share failed",
+					);
 				}
 				break;
 			case "editTopic":
@@ -1140,6 +1315,48 @@ export class SummaryWebviewPanel {
 		instance.update(summary);
 	}
 
+	/**
+	 * Opens (or reveals) the commit panel for `summary` with the in-panel share
+	 * modal already open — the entry point for the sidebar's share affordances
+	 * (footer "Share" → `kind: "branch"` on the newest branch memory; a row's
+	 * "Share this memory" icon → `kind: "commit"`). The modal lives in this
+	 * panel's webview, so sharing from anywhere else must route through here;
+	 * the kind is threaded into the webview so the modal title matches the
+	 * entry the user clicked. Workspace summaries only (foreign/readonly panels
+	 * render no share modal).
+	 */
+	static async showWithShareModal(
+		summary: CommitSummary,
+		extensionUri: vscode.Uri,
+		workspaceRoot: string,
+		bridge: JolliMemoryBridge,
+		mainBranch: string,
+		kind: ShareKind,
+		readStorage: StorageProvider | null = null,
+	): Promise<void> {
+		await SummaryWebviewPanel.show(
+			summary,
+			extensionUri,
+			workspaceRoot,
+			bridge,
+			mainBranch,
+			"commit",
+			null,
+			null,
+			readStorage,
+		);
+		// A full re-render with the one-shot flag: show() may have skipped its
+		// update (unchanged inputs on an already-open panel), and a baked-in
+		// script call is the only delivery that can't race webview listener
+		// setup on a fresh panel. The entry kind persists on the instance so the
+		// header Share button keeps matching this entry across later re-renders.
+		const instance = SummaryWebviewPanel.commitPanels.get(summary.commitHash);
+		if (!instance) return;
+		instance.shareEntryKind = kind;
+		instance.pendingShareOpen = true;
+		instance.update(instance.currentSummary ?? summary);
+	}
+
 	/** Updates the webview HTML content and tab title with a new summary. Stays synchronous. */
 	private update(summary: CommitSummary): void {
 		// A concurrent show() may have disposed this instance while the caller
@@ -1160,6 +1377,8 @@ export class SummaryWebviewPanel {
 		if (this.staleRewrittenInto) title = `⚠ Rewritten — ${title}`;
 		this.panel.title = title;
 		const nonce = randomBytes(16).toString("base64");
+		const autoOpenShare = this.pendingShareOpen;
+		this.pendingShareOpen = false;
 		this.panel.webview.html = buildHtml(summary, {
 			transcriptHashSet: this.transcriptHashSet,
 			planTranslateSet: this.planTranslateSet,
@@ -1168,6 +1387,8 @@ export class SummaryWebviewPanel {
 			nonce,
 			foreignRepoName: this.foreignRepoName,
 			staleRewrittenInto: this.staleRewrittenInto ?? null,
+			shareDefaultKind: this.shareEntryKind,
+			autoOpenShare,
 		});
 	}
 
@@ -1626,6 +1847,167 @@ export class SummaryWebviewPanel {
 	 * Trade-off is favourable for the common case; documented here so a
 	 * future maintainer doesn't quietly add the re-check without realising.
 	 */
+	/**
+	 * Builds the VS Code-backed ShareModalIO: pushes modal states to the webview
+	 * and opens external targets (browser page / mail client / clipboard).
+	 */
+	private buildShareModalIO(kind: ShareKind = "branch"): ShareModalIO {
+		// The share kind is fixed for the modal session; capture it (and derive the
+		// commit hash) here so the IO method signatures stay branch-shaped and the
+		// kind-aware copy is selected without threading extra params through.
+		const shareKind: "branch" | "commit" = kind === "commit" ? "commit" : "branch";
+		return {
+			postState: (state: ShareModalState) => {
+				this.panel.webview.postMessage({ command: "shareState", state });
+			},
+			openUrl: async (url) => {
+				await vscode.env.openExternal(vscode.Uri.parse(url));
+			},
+			composeEmail: async (branch, url, decisionCount, titles, recipients) => {
+				const { subject, body } = buildShareEmail({ branch, url, decisionCount, titles, kind: shareKind });
+				// Recipients go in the mailto `To:` (comma-separated). They are added only
+				// to this local link — they never reach the server (delivery is client-side).
+				const to = (recipients ?? []).map((r) => encodeURIComponent(r.trim())).join(",");
+				const qs = `subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+				await vscode.env.openExternal(vscode.Uri.parse(`mailto:${to}?${qs}`));
+			},
+			copyMessage: async (branch, url, decisionCount, titles) => {
+				const message = buildShareCopyMessage({ branch, url, decisionCount, titles, kind: shareKind });
+				await vscode.env.clipboard.writeText(message);
+				vscode.window.showInformationMessage("Share message copied — paste it into Slack, IM, or anywhere.");
+			},
+			openSocial: async (platform, branch, url, decisionCount, titles) => {
+				const intentUrl = buildSocialShareUrl(platform, { branch, url, decisionCount, titles, kind: shareKind });
+				await vscode.env.openExternal(vscode.Uri.parse(intentUrl));
+			},
+			formatExpiry,
+			notifyError: (message) => {
+				vscode.window.showErrorMessage(message);
+			},
+			notifyInfo: (message) => {
+				vscode.window.showInformationMessage(message);
+			},
+		};
+	}
+
+	/**
+	 * Resolves the share context for the current summary: the current branch, API
+	 * key, the chosen access level + recipients, the bridge (for the live push), and
+	 * a binding-chooser callback. `selection` carries the user's access/recipient
+	 * choices from the webview (defaults: `public`, no recipients).
+	 */
+	private async shareContext(
+		kind: ShareKind = "branch",
+		selection: ShareSelection = DEFAULT_SHARE_SELECTION,
+	): Promise<ShareModalContext | undefined> {
+		const summary = this.currentSummary;
+		if (!summary) return undefined;
+		const config = await loadGlobalConfig();
+		// Branch shares are sourced from the CURRENT git checkout (base..HEAD), so their
+		// label/key follows HEAD. Commit shares are the open memory itself; keep them
+		// bound to `summary.branch` so a later branch switch doesn't make "Share this
+		// memory" re-filter the wrong branch and lose the commit.
+		const current = await this.bridge.getCurrentBranch();
+		const branch = kind === "commit" ? summary.branch : current && current !== "HEAD" ? current : summary.branch;
+		const commitHash = kind === "commit" ? summary.commitHash : undefined;
+		const apiKey = config.jolliApiKey;
+		const keyMeta = apiKey ? parseJolliApiKey(apiKey) : null;
+		const baseUrl = keyMeta?.u || "";
+		// `org` access is only meaningful when the key carries an org. Repo contributors
+		// (deliverable emails) prefill the "send link to" field; read-only, no checkout.
+		const canOrg = Boolean(keyMeta?.o);
+		// Build the add-people directory (for `people` search + name resolution): org
+		// members (best-effort) + git contributors, deduped by lowercased email. The current
+		// git user is the fixed Owner row.
+		const contributors = await getRepoContributors(this.workspaceRoot);
+		const orgMembers = apiKey ? await listOrgMembers(baseUrl, apiKey).catch(() => []) : [];
+		const directory = dedupeMembersByEmail([...orgMembers, ...contributors.map((c) => ({ name: c.name, email: c.email }))]);
+		const ownerEmail = await this.bridge.getCurrentUserEmail();
+		const ownerName =
+			directory.find((m) => m.email.toLowerCase() === ownerEmail.toLowerCase())?.name ||
+			(await this.bridge.getCurrentUserName());
+		const owner = { name: ownerName, email: ownerEmail };
+		return {
+			workspaceRoot: this.workspaceRoot,
+			branch,
+			apiKey,
+			commitHash,
+			commitSummary: kind === "commit" ? summary : undefined,
+			subjectTitle: kind === "commit" ? summary.commitMessage : branch,
+			visibility: selection.visibility,
+			recipients: selection.recipients,
+			expiryDays: selection.expiryDays,
+			canOrg,
+			owner,
+			directory,
+			bridge: this.bridge,
+			resolveBinding: async (repo) => {
+				const outcome = await BindingChooserWebviewPanel.openAndAwait({
+					extensionUri: this.extensionUri,
+					baseUrl: baseUrl.replace(/\/+$/, ""),
+					apiKey: apiKey ?? "",
+					repoUrl: repo,
+					suggestedRepoName: deriveRepoNameFromUrl(repo),
+				});
+				if (outcome.kind === "selected") return { status: "bound" };
+				if (outcome.kind === "anotherOpen") return { status: "anotherOpen" };
+				return { status: "cancelled" };
+			},
+			nowMs: Date.now(),
+		};
+	}
+
+	/**
+	 * Drives the in-panel "Share this branch" modal (public read-only link).
+	 * Foreign summaries can't reach here (the share commands are not in
+	 * FOREIGN_SAFE_COMMANDS) — sharing always targets the current workspace.
+	 */
+	private async handleShareModal(
+		step: "open" | "create" | "revoke",
+		kind: ShareKind = "branch",
+		selection: ShareSelection = DEFAULT_SHARE_SELECTION,
+	): Promise<void> {
+		const ctx = await this.shareContext(kind, selection);
+		if (!ctx) return;
+		const io = this.buildShareModalIO(kind);
+		if (step === "open") await openShareModal(io, ctx);
+		else if (step === "create") await createShareModal(io, ctx);
+		else await revokeShareModal(io, ctx);
+	}
+
+	private async handleShareTarget(
+		target: "page" | "email" | "copy" | "x" | "linkedin" | "reddit" | "whatsapp" | "telegram",
+		kind: ShareKind = "branch",
+		selection: ShareSelection = DEFAULT_SHARE_SELECTION,
+	): Promise<void> {
+		const ctx = await this.shareContext(kind, selection);
+		if (!ctx) return;
+		await shareModalTarget(this.buildShareModalIO(kind), ctx, target);
+	}
+
+	private async handleShareSetExpiry(
+		days: number,
+		kind: ShareKind = "branch",
+		selection: ShareSelection = DEFAULT_SHARE_SELECTION,
+	): Promise<void> {
+		const ctx = await this.shareContext(kind, selection);
+		if (!ctx) return;
+		// PATCH wants an absolute timestamp; compute it from the chosen lifetime.
+		const expiresAt = new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+		await setShareExpiryModal(this.buildShareModalIO(kind), ctx, expiresAt);
+	}
+
+	private async handleShareSetAudience(
+		visibility: ShareVisibility,
+		recipients: ReadonlyArray<string>,
+		kind: ShareKind = "branch",
+		selection: ShareSelection = DEFAULT_SHARE_SELECTION,
+	): Promise<void> {
+		const ctx = await this.shareContext(kind, selection);
+		if (!ctx) return;
+		await setShareVisibilityModal(this.buildShareModalIO(kind), ctx, visibility, recipients);
+	}
+
 	private async handlePush(): Promise<void> {
 		// Prevent concurrent pushes: the button can be re-clicked when
 		// runJolliPush throws before posting pushStarted (button never
@@ -1670,19 +2052,15 @@ export class SummaryWebviewPanel {
 	}
 
 	/**
-	 * Runs the Jolli Cloud push (plans, notes, summary, orphan cleanup).
-	 * Returns the outcome so the caller can post the result message.
-	 *
-	 * On `412 binding_required` the plugin opens BindingChooserWebviewPanel for
-	 * the user to pick or create a JM space, registers the binding server-side,
-	 * and retries the push exactly once. The `retried` flag prevents infinite
-	 * recursion if a second 412 fires after binding registration (which would
-	 * indicate a server bug).
+	 * Runs the Jolli Cloud push for this panel's summary via the shared
+	 * {@link pushSummaryWithAttachments} orchestrator (so the per-summary button and
+	 * the subject-level live share never double-push or fight over jolliDocId). This
+	 * wrapper owns only the VS Code UI: the progress ping, the binding-chooser
+	 * wiring, the success/partial toasts, and adopting the returned summary.
 	 */
 	private async runJolliPush(
 		summary: CommitSummary,
 		jolliApiKey: string | undefined,
-		retried = false,
 	): Promise<{ url: string; docId: number }> {
 		if (!jolliApiKey) {
 			vscode.window.showWarningMessage(
@@ -1706,143 +2084,72 @@ export class SummaryWebviewPanel {
 		const baseUrl = resolvedBaseUrl.replace(/\/+$/, "");
 		const repoUrl = await getCanonicalRepoUrl(this.workspaceRoot);
 
-		try {
-			// Step 1: Upload associated plans and notes. Per-attachment failures
-			// are collected (not thrown) so one bad plan/note doesn't abort the
-			// whole push — the summary and the remaining attachments still go up.
-			const { results: planUrls, failures: planFailures } =
-				await this.pushPlans(
-					summary,
-					resolvedBaseUrl,
-					baseUrl,
-					jolliApiKey,
-					repoUrl,
-				);
-			const { results: noteUrls, failures: noteFailures } =
-				await this.pushNotes(
-					summary,
-					resolvedBaseUrl,
-					baseUrl,
-					jolliApiKey,
-					repoUrl,
-				);
-			const attachmentFailures = [...planFailures, ...noteFailures];
-
-			// Step 2: Update plan/note URLs in summary before building markdown
-			// (so the Plans & Notes section in markdown includes the published
-			// URLs). Dedupe same-named plan snapshots here too: only the latest
-			// was uploaded, so the pushed article's Plans & Notes list must not
-			// repeat the superseded duplicates. The locally-stored summary below
-			// still keeps every snapshot for the detail view.
-			const dedupedPlans = latestPlanPerName(summary.plans ?? []);
-			const plansWithUrls = applyPlanUrls(dedupedPlans, planUrls) ?? dedupedPlans;
-			const notesWithUrls = summary.notes
-				? applyNoteUrls(summary.notes, noteUrls)
-				: summary.notes;
-			const summaryForMarkdown: CommitSummary = {
-				...summary,
-				plans: plansWithUrls,
-				...(notesWithUrls !== summary.notes && { notes: notesWithUrls }),
-			};
-			const markdown = buildMarkdown(summaryForMarkdown);
-
-			const title = buildPushTitle(summary);
-			const result = await pushToJolli(resolvedBaseUrl, jolliApiKey, {
-				title,
-				content: markdown,
-				commitHash: summary.commitHash,
-				docType: "summary",
-				branch: summary.branch,
-				...(summary.jolliDocId && { docId: summary.jolliDocId }),
-				repoUrl,
-				relativePath: buildBranchRelativePath(summary.branch),
-			});
-
-			track("memory_pushed", { kind: "summary" });
-
-			// Build the full article URL using docId query param (matches frontend routing)
-			const fullUrl = `${baseUrl}/articles?doc=${result.docId}`;
-
-			const updatedSummary: CommitSummary = {
-				...summary,
-				jolliDocUrl: fullUrl,
-				jolliDocId: result.docId,
-				...(planUrls.length > 0
-					? { plans: applyPlanUrls(summary.plans, planUrls) }
-					: {}),
-				...(noteUrls.length > 0 && summary.notes
-					? { notes: applyNoteUrls(summary.notes, noteUrls) }
-					: {}),
-			};
-			await this.bridge.storeSummary(updatedSummary, true);
-
-			// Update in-memory state and fully re-render the WebView so PR section picks up
-			// the new plan/note URLs and jolliDocUrl in its markdown body
-			this.currentSummary = updatedSummary;
-			this.update(updatedSummary);
-			const docUrl = summary.jolliDocUrl;
-			const verb = docUrl ? "Updated" : "Pushed";
-			const attachments = planUrls.length + noteUrls.length;
-			const attachMsg =
-				attachments > 0
-					? ` (with ${attachments} attachment${attachments > 1 ? "s" : ""})`
-					: "";
-			if (attachmentFailures.length > 0) {
-				// Modal (not a transient toast): a partial failure must be as
-				// visible as the old fail-fast error — the panel otherwise
-				// re-renders to "Synced" and the failure would go unnoticed.
-				vscode.window.showWarningMessage(
-					`${verb} the memory on Jolli Space${attachMsg}, but ${attachmentFailures.length} attachment(s) failed to push.`,
-					{
-						modal: true,
-						detail: attachmentFailures
-							.map((f) => `• ${f.label}: ${f.message}`)
-							.join("\n"),
-					},
-				);
-			} else {
-				vscode.window.showInformationMessage(
-					`${verb} on Jolli Space${attachMsg}.`,
-				);
-			}
-
-			// Clean up orphaned memory articles, then persist which ones were actually deleted
-			const cleanedSummary = await cleanupOrphanedDocs(
-				summary,
-				updatedSummary,
-				baseUrl,
-				jolliApiKey,
-				this.bridge,
-			);
-			if (cleanedSummary) {
-				this.currentSummary = cleanedSummary;
-			}
-
-			return { url: fullUrl, docId: result.docId };
-		} catch (err: unknown) {
-			if (err instanceof BindingRequiredError && !retried) {
+		const ctx: PushContext = {
+			baseUrl: resolvedBaseUrl,
+			apiKey: jolliApiKey,
+			repoUrl,
+			workspaceRoot: this.workspaceRoot,
+			storeSummary: (s, syncToCloud) => this.bridge.storeSummary(s, syncToCloud),
+			// On 412 binding_required the orchestrator calls this; we open the chooser
+			// and map its outcome back. Chooser UI stays in the panel layer.
+			resolveBinding: async (repo) => {
 				const outcome = await BindingChooserWebviewPanel.openAndAwait({
 					extensionUri: this.extensionUri,
 					baseUrl,
 					apiKey: jolliApiKey,
-					repoUrl,
-					suggestedRepoName: deriveRepoNameFromUrl(repoUrl),
+					repoUrl: repo,
+					suggestedRepoName: deriveRepoNameFromUrl(repo),
 				});
-				if (outcome.kind === "selected") {
-					return this.runJolliPush(summary, jolliApiKey, true);
-				}
-				if (outcome.kind === "anotherOpen") {
-					// Another summary panel for the same repo already opened the
-					// chooser; that panel is the one driving the binding decision.
-					// Tell this caller to wait there and re-push afterwards — using
-					// "Push cancelled" here would be misleading (the user never
-					// cancelled anything in this panel).
+				if (outcome.kind === "selected") return { status: "bound" };
+				if (outcome.kind === "anotherOpen") return { status: "anotherOpen" };
+				return { status: "cancelled" };
+			},
+		};
+
+		try {
+			const result = await pushSummaryWithAttachments(summary, ctx);
+
+			// Adopt the pushed/cleaned summary and fully re-render so the PR section
+			// picks up the new plan/note URLs and jolliDocUrl in its markdown body.
+			this.currentSummary = result.updatedSummary;
+			this.update(result.updatedSummary);
+
+			const verb = result.isUpdate ? "Updated" : "Pushed";
+			const attachMsg =
+				result.attachmentCount > 0
+					? ` (with ${result.attachmentCount} attachment${result.attachmentCount > 1 ? "s" : ""})`
+					: "";
+			if (result.attachmentFailures.length > 0) {
+				// Modal (not a transient toast): a partial failure must be as visible as
+				// the old fail-fast error — the panel otherwise re-renders to "Synced".
+				vscode.window.showWarningMessage(
+					`${verb} the memory on Jolli Space${attachMsg}, but ${result.attachmentFailures.length} attachment(s) failed to push.`,
+					{
+						modal: true,
+						detail: result.attachmentFailures.map((f) => `• ${f.label}: ${f.message}`).join("\n"),
+					},
+				);
+			} else {
+				vscode.window.showInformationMessage(`${verb} on Jolli Space${attachMsg}.`);
+			}
+
+			return { url: result.pushedDoc.summaryUrl, docId: result.pushedDoc.summaryDocId };
+		} catch (err: unknown) {
+			if (err instanceof ShareBindingError) {
+				if (err.outcome === "anotherOpen") {
+					// Another summary panel for the same repo already opened the chooser;
+					// that panel drives the binding decision. Tell this caller to wait
+					// there and re-push — "cancelled" would be misleading here.
 					vscode.window.showInformationMessage(
 						"A Memory space chooser is already open for this repo. Finish there, then click the Jolli push button again.",
 					);
-				} else {
+				} else if (err.outcome === "cancelled") {
 					vscode.window.showErrorMessage(
 						"Push cancelled — no Memory space chosen for this repo. Click the Jolli push button again when you're ready.",
+					);
+				} else {
+					vscode.window.showErrorMessage(
+						"Push failed — could not bind a Memory space for this repo.",
 					);
 				}
 				throw err;
@@ -1858,187 +2165,6 @@ export class SummaryWebviewPanel {
 			}
 			throw err;
 		}
-	}
-
-	/**
-	 * Uploads associated plans to Jolli and returns their published URLs plus
-	 * any per-plan failures. A single plan's failure (e.g. a server 500 because
-	 * the document already exists) is collected and reported, NOT thrown, so it
-	 * doesn't abort the rest of the memory push. The fatal binding/plugin errors
-	 * still propagate — the outer handler drives the binding chooser off them.
-	 */
-	private async pushPlans(
-		summary: CommitSummary,
-		resolvedBaseUrl: string,
-		baseUrl: string,
-		apiKey: string,
-		repoUrl: string,
-	): Promise<{
-		results: Array<{ slug: string; title: string; url: string; docId: number }>;
-		failures: PushAttachmentFailure[];
-	}> {
-		const failures: PushAttachmentFailure[] = [];
-		// Same-named plans accumulate one snapshot per source commit after a
-		// squash (slug embeds the commit hash). Upload only the latest snapshot
-		// per name so Jolli gets one document per plan, not a duplicate per
-		// commit. latestPlanPerName is shared with the detail-panel display.
-		const allPlans = latestPlanPerName(summary.plans ?? []);
-		log.info(
-			"SummaryPanel",
-			`Push to Jolli: found ${allPlans.length} plan(s) to upload`,
-		);
-		const results: Array<{
-			slug: string;
-			title: string;
-			url: string;
-			docId: number;
-		}> = [];
-
-		for (const plan of allPlans) {
-			const planContent =
-				(await readPlanFromBranch(plan.slug, this.workspaceRoot)) ?? "";
-			if (!planContent) {
-				log.info(
-					"SummaryPanel",
-					`Plan ${plan.slug}: no content found, skipping`,
-				);
-				continue;
-			}
-			log.info(
-				"SummaryPanel",
-				`Uploading plan ${plan.slug} (${planContent.length} chars)`,
-			);
-
-			let planResult: Awaited<ReturnType<typeof pushToJolli>>;
-			try {
-				planResult = await pushToJolli(resolvedBaseUrl, apiKey, {
-					title: buildPlanPushTitle(summary, plan.title),
-					content: planContent,
-					commitHash: summary.commitHash,
-					docType: "plan",
-					branch: summary.branch,
-					...(plan.jolliPlanDocId && { docId: plan.jolliPlanDocId }),
-					repoUrl,
-					relativePath: buildBranchRelativePath(summary.branch),
-				});
-			} catch (err) {
-				if (
-					err instanceof BindingRequiredError ||
-					err instanceof PluginOutdatedError
-				) {
-					throw err;
-				}
-				const msg = err instanceof Error ? err.message : String(err);
-				log.error(
-					"SummaryPanel",
-					`Plan ${plan.slug} push FAILED (docId=${plan.jolliPlanDocId ?? "none"}, title="${buildPlanPushTitle(summary, plan.title)}"): ${msg}`,
-				);
-				failures.push({ label: `plan "${plan.title}"`, message: msg });
-				continue;
-			}
-			const planUrl = `${baseUrl}/articles?doc=${planResult.docId}`;
-			log.info(
-				"SummaryPanel",
-				`Plan ${plan.slug} uploaded: docId=${planResult.docId}, url=${planUrl}`,
-			);
-			results.push({
-				slug: plan.slug,
-				title: plan.title,
-				url: planUrl,
-				docId: planResult.docId,
-			});
-		}
-		return { results, failures };
-	}
-
-	/**
-	 * Uploads associated notes to Jolli. Like {@link pushPlans}, a single note's
-	 * failure is collected and reported rather than aborting the whole push.
-	 */
-	private async pushNotes(
-		summary: CommitSummary,
-		resolvedBaseUrl: string,
-		baseUrl: string,
-		apiKey: string,
-		repoUrl: string,
-	): Promise<{
-		results: Array<{ id: string; title: string; url: string; docId: number }>;
-		failures: PushAttachmentFailure[];
-	}> {
-		const failures: PushAttachmentFailure[] = [];
-		const allNotes = summary.notes ?? [];
-		log.info(
-			"SummaryPanel",
-			`Push to Jolli: found ${allNotes.length} note(s) to upload`,
-		);
-		const results: Array<{
-			id: string;
-			title: string;
-			url: string;
-			docId: number;
-		}> = [];
-
-		for (const note of allNotes) {
-			// Schema-guard for legacy/corrupt entries — see mirrored logic in
-			// buildSatellitesFromSummary. Snippets with missing `content` are warned
-			// (and reported back to the webview via the skipped tally below).
-			let noteContent: string;
-			if (note.format === "snippet") {
-				if (note.content === undefined || note.content === "") {
-					log.warn(
-						"SummaryPanel",
-						`Snippet note ${note.id} has no content — skipping push`,
-					);
-					continue;
-				}
-				noteContent = note.content;
-			} else {
-				noteContent =
-					(await readNoteFromBranch(note.id, this.workspaceRoot)) ?? "";
-				if (!noteContent) {
-					log.info(
-						"SummaryPanel",
-						`Note ${note.id}: no content found, skipping`,
-					);
-					continue;
-				}
-			}
-			let noteResult: Awaited<ReturnType<typeof pushToJolli>>;
-			try {
-				noteResult = await pushToJolli(resolvedBaseUrl, apiKey, {
-					title: buildNotePushTitle(summary, note.title),
-					content: noteContent,
-					commitHash: summary.commitHash,
-					docType: "note",
-					branch: summary.branch,
-					...(note.jolliNoteDocId && { docId: note.jolliNoteDocId }),
-					repoUrl,
-					relativePath: buildBranchRelativePath(summary.branch),
-				});
-			} catch (err) {
-				if (
-					err instanceof BindingRequiredError ||
-					err instanceof PluginOutdatedError
-				) {
-					throw err;
-				}
-				const msg = err instanceof Error ? err.message : String(err);
-				log.error(
-					"SummaryPanel",
-					`Note ${note.id} push FAILED (docId=${note.jolliNoteDocId ?? "none"}, title="${buildNotePushTitle(summary, note.title)}"): ${msg}`,
-				);
-				failures.push({ label: `note "${note.title}"`, message: msg });
-				continue;
-			}
-			const noteUrl = `${baseUrl}/articles?doc=${noteResult.docId}`;
-			results.push({
-				id: note.id,
-				title: note.title,
-				url: noteUrl,
-				docId: noteResult.docId,
-			});
-		}
-		return { results, failures };
 	}
 
 	/** Handles editing a memory at the given global index. */
@@ -3952,91 +4078,6 @@ function setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
 		}
 	}
 	return true;
-}
-
-/** Merges published plan URLs/docIds into plan references. */
-function applyPlanUrls(
-	plans: ReadonlyArray<PlanReference> | undefined,
-	planUrls: ReadonlyArray<{ slug: string; url: string; docId: number }>,
-): ReadonlyArray<PlanReference> | undefined {
-	if (!plans || planUrls.length === 0) {
-		return plans;
-	}
-	const urlMap = new Map(planUrls.map((p) => [p.slug, p]));
-	return plans.map((p) => {
-		const pushed = urlMap.get(p.slug);
-		return pushed
-			? { ...p, jolliPlanDocUrl: pushed.url, jolliPlanDocId: pushed.docId }
-			: p;
-	});
-}
-
-/** Merges published note URLs/docIds into note references. */
-function applyNoteUrls(
-	notes: ReadonlyArray<NoteReference>,
-	noteUrls: ReadonlyArray<{ id: string; url: string; docId: number }>,
-): ReadonlyArray<NoteReference> {
-	const urlMap = new Map(noteUrls.map((n) => [n.id, n]));
-	return notes.map((n) => {
-		const pushed = urlMap.get(n.id);
-		return pushed
-			? { ...n, jolliNoteDocUrl: pushed.url, jolliNoteDocId: pushed.docId }
-			: n;
-	});
-}
-
-/**
- * Deletes orphaned memory articles from Jolli Space, then persists the result.
- * Only IDs that were successfully deleted are removed from orphanedDocIds;
- * IDs that failed to delete are kept so the next push retries them.
- */
-async function cleanupOrphanedDocs(
-	originalSummary: CommitSummary,
-	updatedSummary: CommitSummary,
-	baseUrl: string,
-	apiKey: string,
-	bridge: JolliMemoryBridge,
-): Promise<CommitSummary | null> {
-	const orphanedIds = originalSummary.orphanedDocIds
-		? [...originalSummary.orphanedDocIds]
-		: [];
-	if (orphanedIds.length === 0) {
-		return null;
-	}
-
-	const results = await Promise.allSettled(
-		orphanedIds.map((id) =>
-			deleteFromJolli(baseUrl, apiKey, id).then(() => id),
-		),
-	);
-
-	const deleted = new Set<number>();
-	for (const r of results) {
-		if (r.status === "fulfilled") {
-			deleted.add(r.value);
-		}
-	}
-
-	const remaining = orphanedIds.filter((id) => !deleted.has(id));
-	if (deleted.size > 0) {
-		log.info("SummaryPanel", `Deleted ${deleted.size} orphaned article(s)`);
-	}
-	if (remaining.length > 0) {
-		log.warn(
-			"SummaryPanel",
-			`Failed to delete ${remaining.length} orphaned article(s), will retry on next push`,
-		);
-	}
-
-	// Persist: clear successfully deleted IDs, keep failed ones for retry
-	const cleaned: CommitSummary = {
-		...updatedSummary,
-		...(remaining.length > 0
-			? { orphanedDocIds: remaining }
-			: { orphanedDocIds: undefined }),
-	};
-	await bridge.storeSummary(cleaned, true);
-	return cleaned;
 }
 
 /** Extracts a human-readable error message from a rejected `PromiseSettledResult`. */


### PR DESCRIPTION
<!-- jollimemory-summary-start -->



## E2E Test (8)
<details>
<summary><strong>1. Branch label is correct when you switch branches before sharing</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with at least two branches, each with generated commit summaries. Open the commit summary panel while on branch A.

**Steps:**
1. Open the commit summary panel for a commit on branch A.
2. Without closing the panel, switch your active branch to branch B (using the VS Code source control panel or terminal).
3. In the still-open summary panel, click the "Share ▾" button and choose "Share whole branch."
4. Complete the share flow if prompted.
5. Check the share link or share label that appears in the modal.

**Expected Results:**
- The share is labeled with branch B (the currently checked-out branch), not branch A (the branch the panel was originally opened on).
- The public link reflects branch B's content, not branch A's.

</blockquote>
</details>
<details>
<summary><strong>2. Public confirmation prompt does not reappear after revoking a branch share</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with a branch that has generated commit summaries.

**Steps:**
1. Open the commit summary panel and click "Share ▾" → "Share whole branch."
2. When prompted with the public-link confirmation warning, accept it and complete the share. Note that a shareable link appears.
3. Click "Stop sharing" to revoke the share. Confirm the action is complete (a toast message should appear and the modal should close).
4. Open the share panel again for the same branch and click "Share whole branch" a second time.

**Expected Results:**
- The public-link confirmation prompt does NOT appear again on the second share attempt.
- The share flow proceeds directly to creating a new link, skipping the confirmation step.

</blockquote>
</details>
<details>
<summary><strong>3. Stale share banner appears after new commits and hides after refreshing the link</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with a branch that has at least one generated commit summary. Share the whole branch so a live link exists.

**Steps:**
1. Make one or more new commits on the shared branch and generate summaries for them (so the branch has moved forward since the share was created).
2. Open the commit summary panel and click "Share ▾" → "Share whole branch."
3. Observe the share modal that opens.
4. Click the "Refresh link" button shown in the orange warning banner.
5. Re-open the share modal immediately after refreshing.

**Expected Results:**
- When the modal first opens in step 3, an orange warning banner is visible indicating the shared snapshot is out of date.
- After clicking "Refresh link" in step 4, the banner disappears and the modal shows the updated share link.
- When the modal is re-opened in step 5, the orange banner is no longer shown (the share is no longer stale).

</blockquote>
</details>
<details>
<summary><strong>4. Changing share expiry shows a toast on failure instead of replacing the link</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with an active branch share (a live link already created). Simulate or wait for a network condition where the expiry update request will fail (e.g. disconnect from the internet or use a test environment that rejects PATCH requests).

**Steps:**
1. Open the commit summary panel and click "Share ▾" → "Share whole branch" to open the share modal showing the existing live link.
2. Open the expiry dropdown (labeled "Change expiry…") and select a different duration, such as "30 days."
3. Observe what happens in the modal and whether any notification appears.

**Expected Results:**
- A toast notification appears at the bottom of the screen indicating the expiry update failed.
- The share modal remains open and continues to display the original, still-valid share link — the link is NOT replaced with a new one.
- The original link is still copyable and usable.

</blockquote>
</details>
<details>
<summary><strong>5. Stop sharing closes the modal with a toast instead of showing a re-share prompt</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with an active branch share (a live link already created).

**Steps:**
1. Open the commit summary panel and click "Share ▾" → "Share whole branch" to open the share modal.
2. Click the "Stop sharing" button.
3. Observe what happens to the modal and whether any notification appears.

**Expected Results:**
- The share modal closes immediately.
- A toast notification appears saying something like "Sharing stopped — the public link no longer works."
- The modal does NOT drop back to a "Create public link" confirmation screen asking the user to re-share.

</blockquote>
</details>
<details>
<summary><strong>6. Expired share link is automatically replaced when the share panel is reopened</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with a branch share whose expiry date has already passed (set the expiry to the shortest available duration and wait, or use a test environment where you can set the clock forward).

**Steps:**
1. Open the commit summary panel for the branch with the expired share.
2. Click "Share ▾" → "Share whole branch" to open the share modal.
3. Observe the link and any warning shown in the modal.

**Expected Results:**
- The modal does NOT display the expired link as if it were still valid.
- Instead, the flow automatically creates a fresh new link (skipping the public-confirmation prompt if the branch was already confirmed).
- The new link shown in the modal is different from the expired one and is ready to copy and share.

</blockquote>
</details>
<details>
<summary><strong>7. Share chooser lets you share a single commit separately from the whole branch</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with a branch that has at least two generated commit summaries.

**Steps:**
1. Open the commit summary panel for a specific commit on the branch.
2. Click the "Share ▾" toggle button in the panel header to open the share chooser dropdown.
3. Choose "Share this commit" from the dropdown menu and complete the share flow.
4. Note the link that is created. Then click "Share ▾" again and choose "Share whole branch" and complete that share flow.
5. Compare the two links.

**Expected Results:**
- Two distinct share links are created — one for the single commit and one for the whole branch.
- The two links are different URLs.
- Revoking one share (e.g. "Stop sharing" on the commit share) does not affect the other share link.

</blockquote>
</details>
<details>
<summary><strong>8. Plans and notes are included in the share snapshot with correct consent wording</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with a branch that has at least one generated commit summary, and at least one plan or note attached to a commit on that branch.

**Steps:**
1. Open the commit summary panel and click "Share ▾" → "Share whole branch."
2. Read the public-link confirmation prompt carefully before accepting.
3. Accept the confirmation and complete the share to get a live link.
4. Open the share link in a browser (or preview it if the tool provides a preview).

**Expected Results:**
- The confirmation prompt mentions "summary, plans & notes" (not just "summary & plan").
- The share preview or public page includes a "Plans & Notes" section at the bottom.
- Each plan or note appears as a collapsible block — the title is always visible, and clicking it expands the full content.

</blockquote>
</details>

---

## Topics (15)
<details>
<summary><strong>01 · Branch share labels content from wrong branch after checkout switch</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A user could open a commit summary panel for one branch, check out a different branch, then click "Share whole branch." The share would be labeled and stored under the original branch but contain content from the currently checked-out branch, silently publishing mismatched information.

**💡 Decisions Behind the Code**

- **Read branch at share time, not panel-open time**: The snapshot content is always sourced from the current git checkout, so the branch label must be resolved at the moment the user clicks Share rather than when the panel was first opened. Capturing it at panel-open time would be simpler but would silently diverge whenever the user switches branches mid-session, which is a data-integrity problem rather than a cosmetic one.
- **Fallback to summary branch on detached HEAD**: When git reports "HEAD" as the current branch, the checkout is detached and there is no meaningful branch name to use. Falling back to the summary's branch preserves the existing behavior for that edge case rather than surfacing a confusing "HEAD" label to the user.

**✅ What Was Implemented**

- `SummaryWebviewPanel.shareContext()` now calls `bridge.getCurrentBranch()` to resolve the branch label at share time rather than reading it from the displayed summary. The result is used for both the share's branch label and its local cache key. A fallback to the summary's branch is applied only when the repository is in detached HEAD state (git reports "HEAD" as the branch name).
- Two regression tests were added to the panel test suite: one verifying that a panel opened on branch A but checked out to branch B produces a share labeled B, and one verifying the detached-HEAD fallback. The stub bridge was extended with a `getCurrentBranch` mock so existing share tests continue to pass.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Revoking a branch share erased the one-time public confirmation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After a user clicked "Stop sharing" on a branch, the next time they tried to share that same branch they were prompted again to confirm the public link — even though the design intent was that this confirmation is a one-time-per-branch acknowledgment that persists independently of whether an active share exists.

**💡 Decisions Behind the Code**

The confirmation and the share record were stored in the same data entry, so deleting the share also deleted the confirmation. Keeping a minimal placeholder entry after revocation was chosen over splitting confirmations into a separate storage structure, as it required the smallest change to the existing data model while correctly separating the two lifecycles. The trade-off is a slightly non-obvious "blank shareId" sentinel, which is documented in the test and store comments.

**✅ What Was Implemented**

- `removeBranchShare` in `BranchShareStore.ts` was changed to preserve the `confirmedPublic` flag when deleting a branch share record. Instead of removing the entry entirely, it now writes a blank placeholder record that retains only the confirmation flag, so the next share on that branch skips the public confirmation prompt.
- A regression test was added asserting that after confirm → share → revoke, `isPublicConfirmed` still returns true and the stored record has a blank share ID rather than being absent.

**📁 FILES**
- `cli/src/core/BranchShareStore.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Commit share and branch share incorrectly reused the same backend share resource</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user shared a specific commit and then shared the whole branch (or vice versa), both operations returned the same link. Revoking one would affect the other, and the second share often came back with a malformed URL containing literal quote characters around the token.

**💡 Decisions Behind the Code**

- **Tests as specification rather than plugin-side workaround**: Adding a workaround in the plugin would mask the backend bug and make the eventual backend fix harder to verify. The plugin-side tests were added to lock in the correct plugin behavior and prevent regression if the backend fix changes the response shape, while leaving the actual fix to the backend where the root cause lives.
- **Reproduce before fixing**: The investigation confirmed the plugin was sending the correct distinct payloads for commit vs. branch shares and storing them under separate local keys before any fix was attempted. This established a clear boundary between plugin responsibility and backend responsibility, avoiding unnecessary changes to correct plugin code.

**✅ What Was Implemented**

- A new integration test file (`BranchShareModal.commitVsBranch.test.ts`) was added covering three scenarios with real store and controller logic and only network calls mocked: (1) commit share then branch share produces two distinct backend requests with different subjects and the branch share is not flagged stale; (2) the exact same-tip-commit repro where the commit being viewed is also the branch tip; (3) reopening the branch share after a commit share re-serves the branch's own URL rather than the commit's.
- The tests confirm that the plugin sends distinct `shareType` and `commitHash` fields per kind, and that the bare-branch local record is never populated by a commit share, keeping the two share lifecycles independent.
- The investigation confirmed the plugin itself was behaving correctly — the root cause of both the shared link and the quoted token was identified as a backend bug: the backend's idempotency key ignores the `commitHash` field, collapsing both requests onto one resource, and the reuse path reads the token back from a JSON column without unquoting it.

**📋 Future Enhancements**

Backend fix needed in the share router: extend the idempotency key to include `commitHash` (null for branch shares) so commit and branch shares become distinct resources. Also fix the token reuse path that reads a JSONB-stored string back without unquoting it, which produces literal quote characters in the share URL.

**📁 FILES**
- `vscode/src/services/BranchShareModal.commitVsBranch.test.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Stale share banner CSS fix and unified head resolution for freshness checks</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After sharing a branch and then making new commits, the Share panel's warning banner appeared on every open — even when the branch had not changed — and continued to reappear immediately after a user refreshed their share link.

**💡 Decisions Behind the Code**

- **CSS specificity fix over a JavaScript workaround**: The banner's visibility was already being toggled correctly via the `hidden` attribute — the logic was sound. Fixing the CSS to respect `hidden` kept the JavaScript untouched and addressed the actual failure point. A JavaScript-side workaround such as toggling a class instead would have masked the underlying conflict and left the CSS broken for any future use of `hidden` on the same element.
- **Single shared head-resolution function**: Previously, snapshot creation and the reopen freshness check used different underlying calls to determine the branch head. Even small differences in fallback behavior between those two paths could produce permanently mismatched values, making the stale banner fire on every open after a refresh. Extracting one authoritative function and routing both paths through it eliminates the class of bug entirely rather than patching each path individually.
- **Newest-included summary as fallback head**: Using the raw git tip as the head when its summary is not yet generated means the share claims to cover work it does not actually contain, and the stale check will never trigger when that summary eventually arrives. Falling back to the newest summarized commit means the head advances — and the stale banner fires — exactly when new summarized work appears, keeping the freshness signal accurate.

**✅ What Was Implemented**

- The root cause was a CSS specificity conflict in `SummaryCssBuilder.ts`: `.share-stale { display: flex }` overrode the browser's built-in `[hidden] { display: none }` rule, so setting the `hidden` attribute on the banner had no effect. A `.share-stale[hidden] { display: none }` override was added to restore correct behavior, and a regression test in `SummaryCssBuilder.test.ts` asserts the override is present in the generated stylesheet.
- A new exported function `resolveShareHead` was extracted in `cli/src/core/BranchShareSnapshot.ts`, running the same root-collection logic as snapshot assembly but skipping content generation and returning only the head commit hash. Both the snapshot assembler and the panel's share context now call this single function, guaranteeing the stored head and the freshness-check head are always computed identically.
- The head identity rule was tightened: the git tip is used as the head only when its summary is already included in the snapshot; otherwise the newest included summary is used. This prevents a share from being stamped with a head commit whose summary has not yet been generated.
- `SummaryWebviewPanel.ts` was updated to call `resolveShareHead` (replacing a direct call to the lower-level branch-tip resolver), and `nowMs` is now injected into the share modal context for testable expiry checks.

**📁 FILES**
- `vscode/src/views/SummaryCssBuilder.ts`
- `cli/src/core/BranchShareSnapshot.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Expiry update failure surfaces as a toast instead of triggering link regeneration</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user tried to change how long a shared link stays active and the update failed, clicking "Try again" would silently create a brand-new link with a different token instead of retrying the expiry change, invalidating the previously distributed link.

**💡 Decisions Behind the Code**

- **Toast instead of error pane on PATCH failure**: The error pane's primary action is "Try again", which calls the share-generation flow — appropriate when no link exists yet, but destructive when a valid link is already live. Surfacing the failure as a dismissible toast keeps the existing link visible and actionable, matching the user's mental model that the link itself is unchanged.
- **Always re-render from stored record after PATCH attempt**: Moving the read outside the try/catch means both the success and failure paths converge on the same re-render logic. This eliminates a class of bugs where modal state diverges from the persisted record depending on which code path ran.

**✅ What Was Implemented**

- Restructured the expiry-update flow in `BranchShareModal.ts` so that a failed expiry PATCH surfaces as a non-destructive toast notification via a new `notifyError` IO method, then re-renders the still-valid ready pane. The error pane — whose retry action triggers full regeneration — is no longer shown for expiry failures.
- Added a guard for the case where the share record disappears mid-update (e.g. concurrent revoke): instead of leaving the modal stuck on a loading spinner, the code now transitions to an explicit error state with a readable message.
- Added `notifyError(message: string): void` to the `ShareModalIO` interface and wired it to `vscode.window.showErrorMessage` in `SummaryWebviewPanel.ts`.
- Moved the share-record read outside the try/catch so both the success and failure paths converge on the same re-render logic, eliminating a class of bugs where modal state diverges from the persisted record depending on which code path ran.

**📁 FILES**
- `vscode/src/services/BranchShareModal.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Stop sharing closes modal immediately with a toast instead of returning to confirmation pane</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After clicking "Stop sharing," the modal was dropping back into the "Create public link" confirmation pane, which looked like a second step asking the user to re-share rather than confirming the action was complete.

**💡 Decisions Behind the Code**

Revoking a share is a terminal action with no natural next step inside the modal — the user's intent is to stop, not to immediately create a new link. Returning to the confirmation pane implied the opposite. A toast outside the modal communicates success without keeping the user inside a flow that no longer applies.

**✅ What Was Implemented**

- `BranchShareModal.ts` was changed so that after revoking a share, the modal emits a terminal `revoked` state and calls a new `notifyInfo` IO method to show a toast ("Sharing stopped — the public link no longer works."), rather than posting a `confirm` state.
- `SummaryScriptBuilder.ts` handles the `revoked` state by calling `shareClose()` to dismiss the overlay.
- `SummaryWebviewPanel.ts` wires `notifyInfo` to VS Code's `showInformationMessage`.

**📁 FILES**
- `vscode/src/services/BranchShareModal.ts`
- `vscode/src/views/SummaryScriptBuilder.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Expired share links regenerated on open and blocked on action</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Once a shared branch link passed its expiry date, the Share panel continued to display and act on it as if it were still valid, allowing users to copy and send a dead link with no warning.

**💡 Decisions Behind the Code**

- **Silent regeneration on open, explicit error on action**: Two different expired-link encounters need different responses. When the user opens the Share panel, silently regenerating is the least disruptive path — the branch is already confirmed public, so no extra prompt is needed and the user gets a working link immediately. When the user tries to copy or send a link mid-session, failing loudly with an error is safer than silently delivering a URL that will 404 for the recipient.
- **Injected clock for testability**: Reading the system clock directly inside the modal logic would make expiry tests dependent on real wall-clock time or require patching globals. Passing `nowMs` through the context keeps the function pure and lets tests set an arbitrary "now" without side effects.

**✅ What Was Implemented**

- An `isExpired` helper was added to `BranchShareModal.ts` that compares a stored expiry timestamp against an injected `nowMs` clock value. Both `openShareModal` and `shareModalTarget` now call this check before treating an existing share as usable.
- In `openShareModal`, an expired stored share is treated as absent: the flow drops into the creation path (which skips the public-confirmation prompt if the branch was already confirmed) and mints a fresh link.
- In `shareModalTarget`, acting on an expired link surfaces an explicit error state instead of opening, copying, or emailing the dead URL.
- `nowMs` is injected via the modal context rather than read directly from the system clock, making the expiry logic fully unit-testable without time manipulation.

**📁 FILES**
- `vscode/src/services/BranchShareModal.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Notes included in share scope with accurate consent disclosures</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The share feature was uploading branch notes to the public snapshot by default, but every user-facing confirmation prompt and the scope declaration sent to the server only mentioned summaries and plans — notes were being shared without the user's explicit awareness.

**💡 Decisions Behind the Code**

Notes were kept on by default rather than switched off, preserving existing behavior for users who have no notes. The fix is disclosure accuracy: the consent text now matches what is actually uploaded. Turning notes off by default would silently change behavior for existing users who rely on notes appearing in their shared views, and would require a separate UI toggle to restore the previous experience.

**✅ What Was Implemented**

- `ShareScope` in `JolliShareService.ts` gained a `notes` boolean field. `generateBranchShare` in `BranchShareController.ts` now reads an `includeNotes` parameter (defaulting to `true`) and passes it through to both the snapshot assembler and the scope payload sent to the server.
- Three consent and preview strings in `SummaryHtmlBuilder.ts` were updated from "summary & plan" to "summary, plans & notes" — covering the public-confirmation warning, the preview card subtitle, and the footer consent line.

**📁 FILES**
- `vscode/src/services/JolliShareService.ts`
- `vscode/src/services/BranchShareController.ts`
- `vscode/src/views/SummaryHtmlBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Share snapshot sources branch summaries from shared reader, removing duplicate reachability logic</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The share snapshot logic was re-implementing branch membership and reachability checks that already existed in a shared reader used by the Memories panel and pull request description path, creating a risk of the two views drifting out of sync.

**💡 Decisions Behind the Code**

- **Shared reader over a dedicated reachability filter**: The previous implementation added a git reachability filter directly inside the snapshot module to prevent reset or force-pushed commits from leaking into a public share. The shared `loadBranchSummaries` reader already enforces `base..HEAD` membership, so duplicating that logic in the snapshot created two diverging definitions of "what's on this branch." Removing it makes the share consistent with what the panel shows and eliminates a maintenance surface.
- **Title-based deduplication for plans and notes**: The deduplication key for plans was changed from slug to normalized title, and for notes from id to normalized title. This catches the case where a plan is recreated under a new slug but retains the same name — the old slug-based key would have shown both versions, while title-based dedup collapses them to the latest. The trade-off is that two genuinely different plans with identical titles would also collapse, but that is considered an acceptable edge case given how plans are named in practice.

**✅ What Was Implemented**

- `BranchShareSnapshot.ts` was rewritten to source summaries from `loadBranchSummaries` (via `PrDescription.ts`) and `getDefaultBranch` (via `GitOps.ts`) instead of reading the raw index and summary files directly. The `storage` parameter was removed from both `assembleBranchShareSnapshot` and `resolveShareHead`, and the internal `collectBranchRoots` function was replaced with a thin `loadShareSummaries` helper that delegates entirely to the shared reader.
- `BranchShareTip.ts` and its test file were deleted entirely. The git-reachability filter (`listReachableCommits`) and tip-resolution logic (`resolveBranchTip`) that lived there are no longer needed because the shared reader already guarantees only reachable, branch-owned commits are returned.
- `BranchShareController.ts` and its test were updated to drop the now-removed `storage` argument from the snapshot call.
- Plans and notes embedded in a share gained smarter deduplication: the key for plans was changed from slug to normalized title (trimmed, lowercased), and for notes from id to normalized title, so recreated items with the same name appear only once in their most recent form.

**📁 FILES**
- `cli/src/core/BranchShareSnapshot.ts`
- `vscode/src/services/BranchShareController.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · Single-commit share mode added alongside whole-branch sharing</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The share feature only supported sharing an entire branch's worth of summaries. Users wanted to share just one specific commit's summary as a separate public link.

**💡 Decisions Behind the Code**

- **Filtering from the branch set rather than fetching independently**: A commit share still loads the full branch summary set first and then filters, rather than fetching the commit's summary directly. This preserves the guarantee that only commits currently on the branch can be shared — a force-push or dropped commit cannot produce a stale public snapshot.
- **Branch-level confirmation covers both share kinds**: The "make this public?" confirmation dialog is keyed on the branch, not on the individual commit. Confirming once for a branch means subsequent commit shares on that branch skip the prompt, avoiding repeatedly asking the same question for the same codebase while still surfacing the warning the first time any content from that branch goes public.
- **Separate persistence keys, shared branch record**: Storing branch and commit shares under distinct keys lets both coexist without one overwriting the other, while the idempotency logic on the server side keys on `(repoUrl, branch, commitHash ?? null)` — matching the client's keying strategy so re-sharing the same subject refreshes rather than duplicates.

**✅ What Was Implemented**

- `BranchShareSnapshot.ts` gained a `commitHash` option that filters the branch's loaded summaries down to the single matching commit. When the specified commit is not found in the branch's summary set, the function returns null. `resolveShareHead` was extended so a commit share's "head" is always frozen to that commit, never advancing with new branch activity.
- `BranchShareStore.ts` now keys stored share records by a composite subject (`branch` for a whole-branch share, `branch + \u0000 + commitHash` for a commit share), so both kinds coexist independently on the same branch. The public-confirmation flag remains keyed at the branch level and covers both kinds.
- The share payload sent to the backend (`JolliShareService.ts`) gained `shareType` ("branch" or "commit") and an optional `commitHash` field. `BranchShareController.ts`, `BranchShareModal.ts`, and `SummaryWebviewPanel.ts` were all updated to thread `commitHash` through generation, revocation, expiry updates, and context resolution.

**📁 FILES**
- `cli/src/core/BranchShareSnapshot.ts`
- `cli/src/core/BranchShareStore.ts`
- `vscode/src/services/BranchShareController.ts`
- `vscode/src/services/BranchShareModal.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · Branch share modal state machine with five states and decision count display</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Share panel needed a structured way to manage its states — waiting for confirmation, loading, ready with a live link, and error — and the preview card needed to show how many decisions a branch contains without requiring a re-scan each time the modal opened.

**💡 Decisions Behind the Code**

- **State machine extracted from the panel**: The modal logic was placed in a standalone module with an injected IO interface rather than embedded directly in the webview panel. This keeps the branching logic fully unit-testable without a VS Code environment, and lets the panel remain a thin adapter that wires VS Code APIs to the IO contract.
- **Decision count sourced from the snapshot, not recomputed on open**: The count is captured once at share-creation time and stored in the local share record. When the modal reopens an existing share it reads the stored value directly, avoiding a potentially slow re-scan of commit history just to populate a label. This also ensures the preview card always reflects the snapshot that was actually uploaded, not the current local state of the branch.

**✅ What Was Implemented**

- Introduced `BranchShareModal.ts` as a UI-agnostic state machine with five states (needsApiKey, confirm, loading, ready, error) and four entry points (open, confirm, revoke, target). The `ready` state carries `decisionCount` so the webview preview card can render "N decisions" without a round-trip.
- Added `decisionCount` to `BranchShareRecord` in `BranchShareStore.ts`, including the blank-record fallback, so the count survives across sessions and the modal can display it when reopening an existing share without regenerating.
- Updated `BranchShareController.ts` to define a `GenerateShareResult` type that extends the API result with `decisionCount`, extract it from the assembled snapshot, and persist it alongside the share record.
- Updated `SummaryWebviewPanel.ts` and `SummaryHtmlBuilder.ts` to reflect each state — showing a spinner during link creation, the shareable URL with a copy button and expiry label once ready, and an actionable error message on failure.

**📁 FILES**
- `vscode/src/services/BranchShareModal.ts`
- `vscode/src/services/BranchShareController.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`
- `vscode/src/views/SummaryHtmlBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>12 · Share expiry dropdown with dedicated PATCH endpoint and absolute timestamp</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The share link lifetime was fixed at the server's default with no way for the user to choose a shorter or longer duration, and when a dedicated expiry-update path was added, changing the selection had no effect because the backend's create endpoint ignores the lifetime parameter.

**💡 Decisions Behind the Code**

- **Dedicated PATCH over regenerating the snapshot**: The initial implementation triggered a full re-POST when the expiry changed, reusing the idempotent create path. After discovering the create endpoint ignores the lifetime field, the implementation was switched to a dedicated PATCH call, which avoids unnecessary snapshot reassembly and correctly updates the expiry on an existing share.
- **Absolute timestamp over relative days**: The PATCH endpoint requires an absolute `expiresAt` value. Converting days-to-timestamp on the client side at dispatch time keeps the service layer's contract clean and avoids clock-skew ambiguity that would arise if the server interpreted a relative value against its own clock.
- **Placeholder option instead of a pre-selected duration**: Pre-selecting any duration implies it reflects the current state, which it cannot reliably do without reading the stored expiry and mapping it back to a dropdown value. A placeholder makes the control unambiguously an action ("change to…") rather than a display of current state, eliminating a misleading affordance that could cause users to accidentally fire an update they did not intend.
- **Remove "never expires" option**: The backend caps expiry at 365 days and does not support permanent links. Keeping the option in the UI would produce a silent failure or a server error, so it was replaced with a one-year option that gives users the longest available lifetime without misrepresenting backend capabilities.

**✅ What Was Implemented**

- Added an expiry `<select>` dropdown (7 / 30 / 90 days / 1 year) to the ready pane of the share modal in `SummaryHtmlBuilder.ts`, defaulting to a neutral "Change expiry…" placeholder rather than a pre-selected duration. A client-side guard in `SummaryScriptBuilder.ts` ignores change events when the placeholder is selected, and the select is reset to the placeholder on every ready-state render.
- `JolliShareService.ts` adds `updateBranchShareExpiry`, which sends a PATCH request to `/api/share/branch/:shareId` with an absolute ISO expiry timestamp and returns the server-confirmed value. The `expiresInDays` field was removed from the create payload entirely.
- `BranchShareController.ts` adds `setBranchShareExpiry`, which retrieves the stored share record, calls the PATCH client, and writes the server-confirmed `expiresAt` back to local storage. `generateBranchShare` no longer accepts or forwards a lifetime parameter.
- `BranchShareModal.ts` rewires the expiry-change handler to call `setBranchShareExpiry` instead of regenerating, shows a "Updating expiry…" loading state, and re-renders the ready pane with the new label on success. `SummaryWebviewPanel.ts` converts the selected number of days to an absolute timestamp before dispatching.

**📋 Future Enhancements**

Backend expiry enforcement (maximum 365 days, must be in the future) is validated server-side; the client does not currently validate the computed timestamp before sending.

**📁 FILES**
- `vscode/src/services/JolliShareService.ts`
- `vscode/src/services/BranchShareController.ts`
- `vscode/src/services/BranchShareModal.ts`
- `vscode/src/views/SummaryHtmlBuilder.ts`
- `vscode/src/views/SummaryScriptBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>13 · Stale share detection with orange warning banner and refresh button</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After sharing a branch at one commit, making new commits and reopening the Share panel would silently serve the old public snapshot with no indication it was out of date.

**💡 Decisions Behind the Code**

- **No false positives when tip is unknown**: The stale flag is only set when both the stored head hash and the current tip are known and differ. If the git ref cannot be resolved, the flag stays false rather than incorrectly warning the user. This avoids alarming users in edge environments at the cost of occasionally missing a staleness signal.
- **Refresh reuses the existing confirm flow**: The "Refresh link" button posts the same message as the retry button, which re-runs snapshot assembly and overwrites the stored record. Reusing the existing path avoids a separate regeneration code branch and keeps the confirmation-already-accepted state intact.

**✅ What Was Implemented**

- `BranchShareModal.ts` computes a `stale` flag by comparing the stored snapshot head hash against the real current branch tip passed in via `ShareModalContext.currentHeadCommitHash`. The flag is threaded through `readyState()` and all callers, including the expiry-update path.
- `SummaryWebviewPanel.ts` resolves the real branch tip via `resolveShareHead` before building the share context, so the staleness check has an accurate value to compare against.
- `SummaryHtmlBuilder.ts` and `SummaryCssBuilder.ts` add a hidden orange warning banner with a "Refresh link" button; `SummaryScriptBuilder.ts` wires the button to re-trigger share generation and toggles the banner's visibility based on the `stale` field in the ready state.

**📁 FILES**
- `vscode/src/services/BranchShareModal.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`
- `vscode/src/views/SummaryHtmlBuilder.ts`
- `vscode/src/views/SummaryScriptBuilder.ts`
- `vscode/src/views/SummaryCssBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>14 · Plans and notes embedded as collapsible sections in branch share snapshot</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a branch share was opened by a recipient, plans and notes were only represented by their titles in the snapshot content, giving recipients no way to read the actual plan or note body without leaving the page.

**💡 Decisions Behind the Code**

- **Collapsible in-page expansion over new-tab links**: Rendering each plan/note as a native `&lt;details&gt;`/`<summary>` HTML block satisfies the requirement that the title is always visible and the body expands in place on click, with no per-attachment routing or backend changes needed. A new-tab approach would have required backend per-attachment URL routes and added navigation friction for recipients.
- **Single deduplicated section rather than per-commit repetition**: Plans and notes often appear across multiple commits on a branch. Rendering them once in a consolidated section avoids duplication and gives recipients a cleaner read; the per-commit summaries already convey what changed.
- **Deduplication by `updatedAt` rather than commit order**: Commit order on a branch does not reliably reflect which version of a plan is newest — a plan edited early can carry a later timestamp than one referenced in a more recent commit. Comparing `updatedAt` timestamps directly ensures the most recently edited version is always shown.
- **Plugin escapes titles only; renderer sanitizes bodies**: The plugin escapes only what it produces (the `<summary>` tag content). The plan/note body is user-authored Markdown that may contain intentional HTML, so stripping it on the plugin side would destroy legitimate formatting. The renderer is the correct trust boundary for body sanitization.

**✅ What Was Implemented**

- Rewrote `BranchShareSnapshot.ts` to strip plan/note title lists from per-commit summaries and instead append a dedicated "Plans & Notes" section at the end of the snapshot content. Each plan and note is rendered as an HTML `&lt;details&gt;` block with the title as the always-visible summary and the full body as the expandable content.
- Added `readPlanFromBranch` and `readNoteFromBranch` calls to fetch file-backed content; snippet-format notes fall back to their inline `content` field when no file exists, and a placeholder is shown when content cannot be read at all. Two options (`includePlans`, `includeNotes`) gate the section independently.
- Plans are deduplicated by normalized title and notes by normalized title, keeping the entry with the latest `updatedAt` timestamp. A `latestByKey` helper handles the edge case where a chronologically later commit carries an older `updatedAt` for the same attachment.
- Plan and note titles are HTML-escaped before embedding in the `<summary>` tag. A code comment documents the trust boundary: the title is escaped by the plugin, but the plan/note body is raw user Markdown and must be sanitized by the public renderer using an allowlist.

**📁 FILES**
- `cli/src/core/BranchShareSnapshot.ts`

</blockquote>
</details>
<details>
<summary><strong>15 · Share chooser dropdown replaces single share button in commit detail panel header</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

With two share kinds now available, the single "Share branch" button in the commit detail panel header needed to become a chooser so users could pick between sharing the whole branch or just the current commit.

**💡 Decisions Behind the Code**

- **Single button with a dropdown rather than two separate buttons**: A split-menu keeps the header uncluttered and makes the relationship between the two actions obvious. Two independent buttons at the same visual weight would imply they are unrelated operations.
- **Modal title updates dynamically to reflect the chosen kind**: Rather than having two separate modals, the same modal

**✅ What Was Implemented**

- `SummaryHtmlBuilder.ts` replaced the single share button with a split-button group containing a "Share ▾" toggle and a dropdown menu with "Share this commit" and "Share whole branch" items.
- `SummaryScriptBuilder.ts` wires the chooser: clicking the toggle opens the menu, clicking either menu item sets the active `shareKind` variable, updates the modal title, and opens the modal. Every subsequent message sent from the webview to the host carries `shareKind` so the host always knows which subject to act on.
- `SummaryCssBuilder.ts` added an override to restore full border-radius on the share button, since the existing split-button CSS strips the right edge expecting an adjacent toggle button that no longer exists here.

</blockquote>
</details>

---

*Generated by Jolli Memory · June 25, 2026 at 11:21 PM · via Anthropic*
<!-- jollimemory-summary-end -->