### PR TITLE
Fixes JOLLI-1842: Add robust Claude session resume via terminal across panels

### DIFF
--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
         intellijIdeaCommunity("2024.3")
         bundledPlugin("com.intellij.java")
         bundledPlugin("Git4Idea")
+        bundledPlugin("org.jetbrains.plugins.terminal")
         pluginVerifier()
         instrumentationTools()
         // Use the JetBrains Runtime for runIde/tests so JCEF is available — the

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt
@@ -118,13 +118,22 @@ class SummaryReader(private val projectDir: String, private val git: GitOps) {
     }
 
     /**
-     * Reads the committed AI conversations for a commit from the orphan-branch
-     * `transcripts/<hash>.json` (the system of record). Returns one row per
-     * stored session (source, derived title, message count). Empty when no
-     * transcript was stored or it can't be parsed — the panel falls back to the
-     * summary's `conversationTurns` count in that case.
+     * Reads the committed AI conversations for a commit. Looks up the
+     * summary's `transcripts` array for the real transcript IDs (UUIDs in v5,
+     * commit hashes in legacy data), then reads each transcript file and
+     * aggregates all sessions. Falls back to `transcripts/{commitHash}.json`
+     * for pre-v5 data that has no summary or no `transcripts` field.
      */
-    fun getCommittedConversations(commitHash: String): List<ConversationBrief> {
+    fun getCommittedConversations(commitHash: String, summary: CommitSummary? = null): List<ConversationBrief> {
+        val resolved = summary ?: getSummary(commitHash)
+        val ids = resolved?.transcripts
+        if (!ids.isNullOrEmpty()) {
+            return ids.flatMap { id ->
+                val json = git.readBranchFile(ORPHAN_BRANCH, "transcripts/$id.json")
+                parseConversations(json)
+            }
+        }
+        // Legacy fallback: transcript file named by commit hash.
         val json = git.readBranchFile(ORPHAN_BRANCH, "transcripts/$commitHash.json")
         return parseConversations(json)
     }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SummaryStore.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SummaryStore.kt
@@ -277,7 +277,10 @@ class SummaryStore(private val cwd: String, private val git: GitOps, private val
                 val key = session.sessionId.ifBlank { "${session.source}|${session.transcriptPath}" }
                 val existing = mergedSessions[key]
                 mergedSessions[key] =
-                    if (existing == null) session else existing.copy(entries = existing.entries + session.entries)
+                    if (existing == null) session else existing.copy(
+                        entries = existing.entries + session.entries,
+                        transcriptPath = existing.transcriptPath ?: session.transcriptPath,
+                    )
             }
         }
         val mergedTranscript = mergedSessions.values.toList()

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
@@ -228,6 +228,7 @@ data class CommitSummary(
     val notes: List<NoteReference>? = null,
     val references: List<ReferenceCommitRef>? = null,
     val summaryError: String? = null,
+    val transcripts: List<String>? = null,
 )
 
 /** A single E2E test scenario */
@@ -256,9 +257,9 @@ data class PlanEntry(
     val sourcePath: String,
     val addedAt: String,
     val updatedAt: String,
-    val branch: String,
+    val branch: String? = null,
     val commitHash: String?,
-    val editCount: Int,
+    val editCount: Int = 0,
     val contentHashAtCommit: String? = null,
     val ignored: Boolean? = null,
 )

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
@@ -326,39 +326,43 @@ object PostCommitHook {
                 val commitDate = Instant.parse(commitInfo.date).toString()
 
                 for (slug in uncommittedSlugs) {
-                    // Read plan markdown before archiving (retain for eval)
-                    val planFile = File(plansDir, "$slug.md")
-                    val planMarkdown = if (planFile.exists()) planFile.readText(Charsets.UTF_8) else null
+                    try {
+                        // Read plan markdown before archiving (retain for eval)
+                        val planFile = File(plansDir, "$slug.md")
+                        val planMarkdown = if (planFile.exists()) planFile.readText(Charsets.UTF_8) else null
 
-                    // Archive: renames slug to slug-hash in registry, stores plan on orphan branch
-                    val ref = PlanService.archivePlanForCommit(slug, commitInfo.hash, store, cwd)
-                    if (ref != null) {
-                        planRefs.add(ref)
+                        // Archive: renames slug to slug-hash in registry, stores plan on orphan branch
+                        val ref = PlanService.archivePlanForCommit(slug, commitInfo.hash, store, cwd)
+                        if (ref != null) {
+                            planRefs.add(ref)
 
-                        // Evaluate progress via Haiku LLM call
-                        if (planMarkdown != null) {
-                            val evalResult = try {
-                                PlanProgressEvaluator.evaluatePlanProgress(
-                                    planMarkdown, diff, topics, conversation, apiKey, config.model, config.jolliApiKey, config.aiProvider,
-                                )
-                            } catch (e: Exception) {
-                                log.warn("Plan progress eval failed for %s: %s", slug, e.message)
-                                null
-                            }
+                            // Evaluate progress via Haiku LLM call
+                            if (planMarkdown != null) {
+                                val evalResult = try {
+                                    PlanProgressEvaluator.evaluatePlanProgress(
+                                        planMarkdown, diff, topics, conversation, apiKey, config.model, config.jolliApiKey, config.aiProvider,
+                                    )
+                                } catch (e: Exception) {
+                                    log.warn("Plan progress eval failed for %s: %s", slug, e.message)
+                                    null
+                                }
 
-                            if (evalResult != null) {
-                                planProgressArtifacts.add(PlanProgressArtifact(
-                                    commitHash = commitInfo.hash,
-                                    commitMessage = commitInfo.message,
-                                    commitDate = commitDate,
-                                    planSlug = ref.slug,
-                                    originalSlug = slug,
-                                    summary = evalResult.summary,
-                                    steps = evalResult.steps,
-                                    llm = evalResult.llm,
-                                ))
+                                if (evalResult != null) {
+                                    planProgressArtifacts.add(PlanProgressArtifact(
+                                        commitHash = commitInfo.hash,
+                                        commitMessage = commitInfo.message,
+                                        commitDate = commitDate,
+                                        planSlug = ref.slug,
+                                        originalSlug = slug,
+                                        summary = evalResult.summary,
+                                        steps = evalResult.steps,
+                                        llm = evalResult.llm,
+                                    ))
+                                }
                             }
                         }
+                    } catch (e: Exception) {
+                        log.warn("Plan archive failed for %s (non-fatal, skipping): %s", slug, e.message)
                     }
                 }
                 log.info("Plan progress: evaluated %d/%d plan(s)", planProgressArtifacts.size, planRefs.size)
@@ -417,7 +421,7 @@ object PostCommitHook {
             // coding-session token usage from their per-message usage.
             val storedSessions = sessionTranscripts.map { st ->
                 log.info("StoredSession: sessionId=%s, source=%s, entries=%d", st.sessionId.take(8), st.source, st.entries.size)
-                StoredSession(st.sessionId, source = st.source, entries = st.entries)
+                StoredSession(st.sessionId, source = st.source, transcriptPath = st.transcriptPath, entries = st.entries)
             }
             val tokenUsage = TokenUsage.aggregate(storedSessions)
             log.info("TokenUsage: %s", tokenUsage?.let { "in=${it.inputTokens} out=${it.outputTokens} cr=${it.cacheReadTokens} cw=${it.cacheWriteTokens} reported=${it.reportedSessions}/${it.totalSessions}" } ?: "none")

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
@@ -679,8 +679,8 @@ val sb = StringBuilder()
     }
 
     /** Reads the committed AI conversations for a commit (CONVERSATIONS group). */
-    fun getCommittedConversations(hash: String): List<ConversationBrief> =
-        reader?.getCommittedConversations(hash) ?: emptyList()
+    fun getCommittedConversations(hash: String, summary: CommitSummary? = null): List<ConversationBrief> =
+        reader?.getCommittedConversations(hash, summary) ?: emptyList()
 
     /**
      * Lists files changed in a specific commit — matches VS Code listCommitFiles().

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActiveConversationsPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActiveConversationsPanel.kt
@@ -135,8 +135,8 @@ class ActiveConversationsPanel(
 			ConversationRowComponent(
 				item = item,
 				onRowClicked = ::onRowClicked,
-				onContinue = ::onContinue,
 				onPin = ::onPin,
+				onResume = ::onResume,
 				onSelectionChanged = ::onSelectionChanged,
 			)
 		}
@@ -162,6 +162,12 @@ class ActiveConversationsPanel(
 		}
 	}
 
+	private fun onResume(item: ActiveConversationItem) {
+		if (item.source != TranscriptSource.claude) return
+		val cwd = service.mainRepoRoot ?: project.basePath ?: return
+		TerminalUtils.resumeClaudeSession(project, item.sessionId, cwd, "Claude – ${item.title}")
+	}
+
 	private fun onSelectionChanged(item: ActiveConversationItem, selected: Boolean) {
 		val cwd = service.mainRepoRoot ?: project.basePath ?: return
 		val key = CommitSelectionStore.conversationKey(item.source, item.sessionId)
@@ -178,27 +184,6 @@ class ActiveConversationsPanel(
 			CommitSelectionStore.setAllExcluded(cwd, "conversations", keys, !anyUnchecked)
 			SwingUtilities.invokeLater { refresh() }
 		}
-	}
-
-	/**
-	 * Continue — copy a recall prompt for the current branch so the user can paste
-	 * it into their AI tool and resume with this branch's context. (The plugin
-	 * can't relaunch an external tool directly.)
-	 */
-	private fun onContinue(@Suppress("UNUSED_PARAMETER") item: ActiveConversationItem) {
-		val branch = service.getGitOps()?.getCurrentBranch()
-		val prompt = if (branch.isNullOrBlank()) {
-			"Invoke the \"jolli-recall\" skill."
-		} else {
-			"Invoke the \"jolli-recall\" skill with args \"$branch\"."
-		}
-		java.awt.Toolkit.getDefaultToolkit().systemClipboard
-			.setContents(java.awt.datatransfer.StringSelection(prompt), null)
-		com.intellij.openapi.ui.Messages.showInfoMessage(
-			project,
-			"Recall prompt copied — paste it into your AI tool to continue with this branch's context.",
-			"Continue",
-		)
 	}
 
 	private fun onPin(item: ActiveConversationItem) {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
@@ -132,6 +132,7 @@ class CommitsPanel(
     private val hoverDismissTimer = Timer(HOVER_HIDE_GRACE_MS) { dismissHoverPopup() }.apply { isRepeats = false }
     private companion object {
         val LOG: com.intellij.openapi.diagnostic.Logger = com.intellij.openapi.diagnostic.Logger.getInstance(CommitsPanel::class.java)
+        val log = ai.jolli.jollimemory.core.JmLogger.create("CommitsPanel")
         const val ARROW_RIGHT = "\u25B6" // ▶
         const val ARROW_DOWN = "\u25BC"  // ▼
         const val HOVER_SHOW_DELAY_MS = 1000
@@ -862,13 +863,13 @@ class CommitsPanel(
      * commits instead. Dedupes by session, summing per-commit message counts.
      */
     private fun gatherConversations(hash: String, summary: CommitSummary?): List<ConversationBrief> {
-        val own = service.getCommittedConversations(hash)
+        val own = service.getCommittedConversations(hash, summary)
         if (own.isNotEmpty() || summary?.children.isNullOrEmpty()) return own
 
         val merged = LinkedHashMap<String, ConversationBrief>()
         fun collect(s: CommitSummary?) {
             s?.children?.forEach { child ->
-                for (c in service.getCommittedConversations(child.commitHash)) {
+                for (c in service.getCommittedConversations(child.commitHash, child)) {
                     val key = c.sessionId.ifBlank { "${c.source}|${c.title}" }
                     val existing = merged[key]
                     merged[key] = existing?.copy(messageCount = existing.messageCount + c.messageCount) ?: c
@@ -1054,12 +1055,20 @@ class CommitsPanel(
             add(title)
         }
 
-        // Hover actions (hidden until hover): Open conversation · Continue.
-        val openBtn = convoActionIcon(JolliMemoryIcons.Eye, "Open conversation") { openCommittedConversation(c) }
-        val continueBtn = convoActionIcon(AllIcons.Actions.Execute, "Continue — reopen this session in your AI tool") {
-            copyRecallPrompt(commit.hash)
+        // Hover actions (hidden until hover): Open conversation · Resume (only if local session exists).
+        val openBtn = convoActionIcon(JolliMemoryIcons.Eye, "Open conversation") { _ -> openCommittedConversation(c) }
+        val fileExists = !c.transcriptPath.isNullOrBlank() && File(c.transcriptPath).exists()
+        val canResume = c.source == "claude" && fileExists
+        log.info("conversationRow: source=${c.source}, sessionId=${c.sessionId}, transcriptPath=${c.transcriptPath}, fileExists=$fileExists, canResume=$canResume")
+        val actions = if (canResume) {
+            val continueBtn = convoActionIcon(AllIcons.Actions.Execute, "Resume session in terminal") { _ ->
+                log.info("continueBtn clicked: sessionId=${c.sessionId}, commitHash=${commit.hash}")
+                resumeInTerminal(c.sessionId)
+            }
+            listOf(openBtn, continueBtn)
+        } else {
+            listOf(openBtn)
         }
-        val actions = listOf(openBtn, continueBtn)
         val east = JPanel(FlowLayout(FlowLayout.RIGHT, JBUI.scale(2), 0)).apply {
             isOpaque = false
             add(count)
@@ -1085,6 +1094,11 @@ class CommitsPanel(
             }
             override fun mouseExited(e: MouseEvent) {
                 val src = e.source as Component
+                if (!src.isShowing || !row.isShowing) {
+                    count.isVisible = true
+                    actions.forEach { it.isVisible = false }
+                    return
+                }
                 val screen = src.locationOnScreen.apply { translate(e.x, e.y) }
                 val loc = row.locationOnScreen
                 if (!java.awt.Rectangle(loc.x, loc.y, row.width, row.height).contains(screen)) {
@@ -1107,7 +1121,7 @@ class CommitsPanel(
     }
 
     /** A hover-revealed action icon for conversation rows. */
-    private fun convoActionIcon(icon: javax.swing.Icon, tip: String, onClick: () -> Unit): JLabel =
+    private fun convoActionIcon(icon: javax.swing.Icon, tip: String, onClick: (Component) -> Unit): JLabel =
         JLabel(icon).apply {
             toolTipText = tip
             cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
@@ -1115,7 +1129,7 @@ class CommitsPanel(
             isVisible = false
             addMouseListener(object : MouseAdapter() {
                 override fun mouseClicked(e: MouseEvent) {
-                    if (SwingUtilities.isLeftMouseButton(e)) { e.consume(); onClick() }
+                    if (SwingUtilities.isLeftMouseButton(e)) { e.consume(); onClick(e.component) }
                 }
             })
         }
@@ -1510,6 +1524,16 @@ class CommitsPanel(
                 }
             }
         }
+    }
+
+    // ─── Resume session ──────────────────────────────────────────────────────
+
+    /** Opens a new terminal tab and runs `claude --resume <sessionId>`. */
+    private fun resumeInTerminal(sessionId: String) {
+        val cwd = service.mainRepoRoot ?: project.basePath
+        log.info("resumeInTerminal: sessionId=$sessionId, cwd=$cwd")
+        if (cwd == null) return
+        TerminalUtils.resumeClaudeSession(project, sessionId, cwd)
     }
 
     // ─── Copy recall prompt ──────────────────────────────────────────────────

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationRowComponent.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationRowComponent.kt
@@ -28,8 +28,8 @@ import javax.swing.JPanel
 class ConversationRowComponent(
 	val item: ActiveConversationItem,
 	private val onRowClicked: (ActiveConversationItem) -> Unit,
-	private val onContinue: (ActiveConversationItem) -> Unit,
 	private val onPin: (ActiveConversationItem) -> Unit,
+	private val onResume: (ActiveConversationItem) -> Unit,
 	private val onSelectionChanged: (ActiveConversationItem, Boolean) -> Unit,
 ) : JPanel(BorderLayout()) {
 
@@ -43,7 +43,7 @@ class ConversationRowComponent(
 
 	private val pinLabel = actionIcon(AllIcons.General.Pin_tab, "Pin") { onPin(item) }
 	private val eyeLabel = actionIcon(JolliMemoryIcons.Eye, "Open conversation") { onRowClicked(item) }
-	private val continueLabel = actionIcon(AllIcons.Actions.Execute, "Continue — reopen this session in your AI tool") { onContinue(item) }
+	private val resumeLabel = actionIcon(AllIcons.Actions.Execute, "Resume session in terminal") { onResume(item) }
 	private val toggleLabel = JLabel().apply {
 		cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
 		isVisible = false
@@ -88,7 +88,7 @@ class ConversationRowComponent(
 		countLabel.isVisible = !hovered
 		pinLabel.isVisible = hovered
 		eyeLabel.isVisible = hovered
-		continueLabel.isVisible = hovered
+		resumeLabel.isVisible = hovered
 		toggleLabel.isVisible = hovered
 	}
 
@@ -111,7 +111,7 @@ class ConversationRowComponent(
 		rightPanel.add(countLabel)
 		rightPanel.add(pinLabel)
 		rightPanel.add(eyeLabel)
-		rightPanel.add(continueLabel)
+		rightPanel.add(resumeLabel)
 		rightPanel.add(toggleLabel)
 		add(rightPanel, BorderLayout.EAST)
 
@@ -125,8 +125,12 @@ class ConversationRowComponent(
 			override fun mouseExited(e: MouseEvent) {
 				// Only un-hover if the mouse actually left the row bounds (not when
 				// moving onto a child component within the row).
-				val p = e.point
 				val src = e.source as Component
+				if (!src.isShowing || !this@ConversationRowComponent.isShowing) {
+					setHovered(false)
+					return
+				}
+				val p = e.point
 				val screenPoint = src.locationOnScreen.apply { translate(p.x, p.y) }
 				val rowLoc = this@ConversationRowComponent.locationOnScreen
 				if (!Rectangle(rowLoc.x, rowLoc.y, width, height).contains(screenPoint)) {
@@ -140,7 +144,7 @@ class ConversationRowComponent(
 		addMouseListener(hoverListener)
 		addMouseListener(clickListener)
 		// Icons handle their own clicks; the row body (badge/title/count) opens the conversation.
-		for (c in listOf(leftPanel, badge, titleLabel, rightPanel, countLabel, pinLabel, eyeLabel, continueLabel, toggleLabel)) {
+		for (c in listOf(leftPanel, badge, titleLabel, rightPanel, countLabel, pinLabel, eyeLabel, resumeLabel, toggleLabel)) {
 			c.addMouseListener(hoverListener)
 			if (c === leftPanel || c === badge || c === titleLabel || c === rightPanel || c === countLabel) {
 				c.addMouseListener(clickListener)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt
@@ -11,7 +11,6 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBLabel
@@ -26,8 +25,6 @@ import java.awt.Font
 import java.awt.Graphics
 import java.awt.Graphics2D
 import java.awt.RenderingHints
-import java.awt.Toolkit
-import java.awt.datatransfer.StringSelection
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.io.File
@@ -125,9 +122,8 @@ class PinnedPanel(
 		left.add(title)
 		row.add(left, BorderLayout.CENTER)
 
-		// Hover actions, right edge: Open (eye) · Recall (play) · Unpin.
+		// Hover actions, right edge: Open (eye) · Resume (play, Claude only) · Unpin.
 		val openBtn = actionIcon(JolliMemoryIcons.Eye, "Open") { openPinned(entry) }
-		val recallBtn = actionIcon(AllIcons.Actions.Execute, "Recall") { recallPinned(entry) }
 		val unpinBtn = actionIcon(AllIcons.Actions.Close, "Unpin") {
 			val dir = cwd() ?: return@actionIcon
 			ApplicationManager.getApplication().executeOnPooledThread {
@@ -135,7 +131,13 @@ class PinnedPanel(
 				refresh()
 			}
 		}
-		val actions = listOf(openBtn, recallBtn, unpinBtn)
+		val canResume = entry.kind == "conversations" && entry.badge.lowercase() == "claude"
+		val actions = if (canResume) {
+			val resumeBtn = actionIcon(AllIcons.Actions.Execute, "Resume session in terminal") { resumeInTerminal(entry) }
+			listOf(openBtn, resumeBtn, unpinBtn)
+		} else {
+			listOf(openBtn, unpinBtn)
+		}
 		val east = JPanel(FlowLayout(FlowLayout.RIGHT, JBUI.scale(2), 0)).apply {
 			isOpaque = false
 			actions.forEach { add(it) }
@@ -145,8 +147,12 @@ class PinnedPanel(
 		val hover = object : MouseAdapter() {
 			override fun mouseEntered(e: MouseEvent) { actions.forEach { it.isVisible = true } }
 			override fun mouseExited(e: MouseEvent) {
-				val p = e.point
 				val src = e.source as Component
+				if (!src.isShowing || !row.isShowing) {
+					actions.forEach { it.isVisible = false }
+					return
+				}
+				val p = e.point
 				val screen = src.locationOnScreen.apply { translate(p.x, p.y) }
 				val loc = row.locationOnScreen
 				if (!java.awt.Rectangle(loc.x, loc.y, row.width, row.height).contains(screen)) {
@@ -178,16 +184,13 @@ class PinnedPanel(
 		})
 	}
 
-	/** Recall action (play): copies the recall prompt for the current branch. */
-	private fun recallPinned(entry: PinStore.PinnedEntry) {
-		val branch = service.getGitOps()?.getCurrentBranch()
-		if (branch.isNullOrBlank()) {
-			Messages.showWarningDialog(project, "Could not determine the current branch.", "Recall")
-			return
+	/** Resume a pinned Claude conversation directly in terminal. */
+	private fun resumeInTerminal(entry: PinStore.PinnedEntry) {
+		val cwd = cwd() ?: return
+		val sessionId = entry.key.substringAfter(":")
+		if (sessionId.isNotBlank()) {
+			TerminalUtils.resumeClaudeSession(project, sessionId, cwd, "Claude – ${entry.title}")
 		}
-		val prompt = "Invoke the \"jolli-recall\" skill with args \"$branch\"."
-		Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(prompt), null)
-		Messages.showInfoMessage(project, "Recall prompt copied — paste it into your AI coding tool.", "Recall")
 	}
 
 	private fun badgeColor(entry: PinStore.PinnedEntry): Color = when (entry.kind) {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/TerminalUtils.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/TerminalUtils.kt
@@ -1,0 +1,29 @@
+package ai.jolli.jollimemory.toolwindow
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationType
+import com.intellij.notification.Notifications
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import org.jetbrains.plugins.terminal.TerminalToolWindowManager
+
+/** Shared terminal helpers used by sidebar panels for resuming conversations. */
+object TerminalUtils {
+
+	private val log = Logger.getInstance(TerminalUtils::class.java)
+
+	/** Opens a new terminal tab in the given [cwd] and runs `claude --resume <sessionId>`. */
+	fun resumeClaudeSession(project: Project, sessionId: String, cwd: String, title: String = "Claude – resume") {
+		try {
+			val widget = TerminalToolWindowManager.getInstance(project)
+				.createLocalShellWidget(cwd, title)
+			widget.executeCommand("claude --resume $sessionId")
+		} catch (e: Exception) {
+			log.warn("Failed to open terminal for session resume: ${e.message}", e)
+			Notifications.Bus.notify(
+				Notification("JolliMemory", "Resume Session", "Could not resume session — terminal unavailable.", NotificationType.WARNING),
+				project,
+			)
+		}
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/WorkingMemoryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/WorkingMemoryPanel.kt
@@ -193,7 +193,7 @@ class WorkingMemoryPanel(private val project: Project) : JPanel(BorderLayout()) 
             val registry = SessionTracker.loadPlansRegistry(cwd)
             registry.plans.values.forEach { p ->
                 if (p.ignored == true || p.commitHash != null) return@forEach
-                if (p.branch.isNotBlank() && p.branch != branch) return@forEach
+                if (!p.branch.isNullOrBlank() && p.branch != branch) return@forEach
                 if (!File(p.sourcePath).exists()) return@forEach
                 out.add(WmContext("P", p.title))
             }


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Two bugs that surfaced together after a squash operation were fixed. The first was a severe crash loop in the commits panel: when a squash refreshed the panel, any rows the mouse cursor had been hovering over were removed from the UI, but the event system continued firing mouse-exit events on them. Each event attempted a screen-coordinate lookup on a detached component, producing an error that repeated thousands of times per second until the cursor moved away. Guard checks were added to the hover listeners across all three panel types that show action buttons on hover, so detached rows now reset cleanly to their default hidden state and the error loop no longer occurs.

The second fix addressed a data-loss edge case in the squash merge pipeline. When squash combines conversation transcripts from multiple commits into one, it processes slices oldest-first. Sessions recorded partly before and partly after an earlier fix that began saving the transcript file path would permanently lose that path in the merged result, even though newer slices had it. The merge logic now carries forward the first non-null path found across all slices, so those sessions correctly retain their path after squash.

---

## Topics (2)
<details>
<summary><strong>01 · Fix crash spam when hover listeners fire on removed UI rows</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After performing a squash operation, the plugin threw hundreds to thousands of errors per second because mouse-exit handlers were trying to read the screen position of rows that had already been removed from the panel.

**💡 Decisions Behind the Code**

- **Guard placement over exception handling**: The check is placed before `locationOnScreen` rather than wrapping it in a try/catch because `isShowing` is the documented precondition for that call — catching the exception would be treating a symptom rather than the cause.
- **State reset on early return**: Each guard explicitly resets hover-dependent UI state (hiding action buttons, clearing hover highlight) so rows don't get stuck in a visually active state after being detached.

**✅ What Was Implemented**

Added `isShowing` guard checks at the top of `mouseExited` handlers in three files before any call to `locationOnScreen`:
- `CommitsPanel.kt`: guard resets action button visibility and returns early
- `PinnedPanel.kt`: guard hides action buttons and returns early
- `ConversationRowComponent.kt`: guard calls `setHovered(false)` and returns early

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationRowComponent.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Preserve transcript path when squash merges conversation sessions</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When squashing commits, the plugin merges conversation transcript slices from multiple commits into one. If the earliest slice was recorded before a bug fix that populated the transcript file path, the merged result would permanently lose the path even though later slices had it.

**💡 Decisions Behind the Code**

The null-coalescing approach was chosen because transcript slices for the same session are ordered oldest-first, meaning the earliest slice is most likely to be missing the path. Taking the first non-null value across all slices recovers the path without requiring any backfill of historical data on the orphan branch.

**✅ What Was Implemented**

Modified the session merge logic in `SummaryStore.kt` to use `existing.transcriptPath ?: session.transcriptPath` so the path is carried forward from whichever slice has it, rather than always keeping the first slice's value.

**📋 Future Enhancements**

Existing orphan-branch transcript entries written before the transcript-path fix was deployed still have no path stored. Manually backfilling those entries was discussed but deferred.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/SummaryStore.kt`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 26, 2026 at 5:19 PM · via Anthropic*
<!-- jollimemory-summary-end -->
