### PR TITLE
Feature/intellij memory panel ux

### DIFF
--- a/.github/workflows/build-intellij.yaml
+++ b/.github/workflows/build-intellij.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - if: steps.changes.outputs.relevant == 'true'
         name: Set up JDK 21
-        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: temurin
           java-version: 21

--- a/.github/workflows/publish-intellij.yaml
+++ b/.github/workflows/publish-intellij.yaml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up JDK 21
-        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: temurin
           java-version: 21

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -71,6 +71,17 @@ disk **before** they are sent.
 | `error_occurred` | A structured error code was raised. |
 | `queue_drained` | QueueWorker finished a drain. |
 | `sync_completed` | A memory-bank sync round finished. |
+| `toolwindow_opened` | The memory tool window was opened. |
+| `view_switched` | Tool window view switched (current/bank/knowledge). |
+| `memory_committed` | User committed a memory via the Commit button. |
+| `memory_expanded` | A committed memory's details were expanded. |
+| `memory_item_opened` | An item inside a memory was opened (conversation/file/context/shipped). |
+| `session_resumed` | A conversation session was resumed in a terminal. |
+| `recall_prompt_copied` | A recall prompt was copied to the clipboard. |
+| `memory_pinned` | An item was pinned. |
+| `memory_unpinned` | An item was unpinned. |
+| `key_rejected` | The server rejected the API key (401/403). |
+| `reauth_completed` | Re-authentication after a rejected key finished. |
 
 ---
 *Generated from `cli/src/core/TelemetryEvents.ts`. The IntelliJ plugin is an

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -500,6 +500,13 @@ export interface PlanEntry {
 	readonly commitHash: string | null;
 	/** SHA-256 hash of the plan file content when associated with a commit. Used as a guard to detect if the file was overwritten with new content. */
 	readonly contentHashAtCommit?: string;
+	/**
+	 * Branch the plan was created/last touched on. Optional: legacy rows and rows
+	 * written before branch-scoping omit it (treated as visible on every branch).
+	 * The CLI does not filter on it, but persists it so the IntelliJ plugin — which
+	 * shares this plans.json — can branch-scope its CONTEXT view.
+	 */
+	readonly branch?: string;
 }
 
 /**
@@ -536,6 +543,12 @@ export interface NoteEntry {
 	readonly contentHashAtCommit?: string;
 	/** File path in .jolli/jollimemory/notes/<id>.md (all notes are file-backed) */
 	readonly sourcePath?: string;
+	/**
+	 * Branch the note was created on. Optional for the same reason as
+	 * {@link PlanEntry.branch}: persisted by the CLI (not filtered on) so the
+	 * IntelliJ plugin can branch-scope its shared CONTEXT view.
+	 */
+	readonly branch?: string;
 }
 
 // ─── Plan progress types ────────────────────────────────────────────────────
@@ -653,8 +666,9 @@ export interface Reference {
  * `<source>:<nativeId>`. Unlike Plan / Note rows, a reference is DELETED from
  * the registry when its commit lands — its value-snapshot lives on in the
  * orphan branch's `CommitSummary.references`. So there is no archive row,
- * `contentHashAtCommit` guard, branch scoping, or ignored flag: every row
- * here is an active, uncommitted reference.
+ * `contentHashAtCommit` guard, or ignored flag: every row here is an active,
+ * uncommitted reference. The optional `branch` is persisted (not filtered on by
+ * the CLI) so the IntelliJ plugin can branch-scope its shared CONTEXT view.
  */
 export interface ReferenceEntry {
 	readonly source: SourceId;
@@ -667,6 +681,8 @@ export interface ReferenceEntry {
 	readonly updatedAt: string;
 	/** MCP tool name that originally surfaced this reference. */
 	readonly sourceToolName: string;
+	/** Branch the reference was last captured on; see {@link PlanEntry.branch}. */
+	readonly branch?: string;
 }
 
 /**

--- a/cli/src/core/GitBranch.ts
+++ b/cli/src/core/GitBranch.ts
@@ -1,0 +1,28 @@
+/**
+ * GitBranch — the single lightweight current-branch helper.
+ *
+ * Deliberately tiny and dependency-light (only `execFileSyncHidden`): it is
+ * imported by plan/note/reference creation paths in BOTH the CLI and the VS Code
+ * extension. Pulling it out of `TranscriptReferenceDiscovery` (which drags in the
+ * whole reference-extraction module graph) keeps importers — and their test
+ * mocks — from having to stub that graph just to read the branch name.
+ */
+import { execFileSyncHidden } from "../util/Subprocess.js";
+
+/**
+ * Current git branch (synchronous, never throws). Returns "unknown" on any
+ * failure or empty output. Named `…Safe` to NOT collide with the async, throwing
+ * `GitOps.getCurrentBranch` — the two have opposite error semantics.
+ */
+export function getCurrentBranchSafe(cwd: string): string {
+	try {
+		const out = execFileSyncHidden("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+			cwd,
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+		}).trim();
+		return out.length > 0 ? out : "unknown";
+	} catch {
+		return "unknown";
+	}
+}

--- a/cli/src/core/SessionTracker.test.ts
+++ b/cli/src/core/SessionTracker.test.ts
@@ -64,6 +64,7 @@ import {
 	detectActiveNotesForBranch,
 	detectActivePlansForBranch,
 	detectUncommittedReferenceIds,
+	discardExcludedWorkingItems,
 	enqueueGitOperation,
 	ensureJolliMemoryDir,
 	filterSessionsByEnabledIntegrations,
@@ -138,6 +139,116 @@ describe("SessionTracker", () => {
 			await ensureJolliMemoryDir(tempDir);
 			await ensureJolliMemoryDir(tempDir);
 			// No error thrown
+		});
+	});
+
+	describe("discardExcludedWorkingItems", () => {
+		it("removes excluded uncommitted rows + .jolli files; keeps checked/committed rows and external plan files", async () => {
+			const jolliDir = join(tempDir, ".jolli", "jollimemory");
+			const notesDir = join(jolliDir, "notes");
+			const refsDir = join(jolliDir, "references", "linear");
+			const extDir = join(tempDir, "ext-plans");
+			await mkdir(notesDir, { recursive: true });
+			await mkdir(refsDir, { recursive: true });
+			await mkdir(extDir, { recursive: true });
+
+			const keepPlanFile = join(extDir, "keep.md");
+			const dropPlanFile = join(extDir, "drop.md");
+			const noteFile = join(notesDir, "n1.md");
+			const refFile = join(refsDir, "L-1.md");
+			await writeFile(keepPlanFile, "# Keep");
+			await writeFile(dropPlanFile, "# Drop");
+			await writeFile(noteFile, "note body");
+			await writeFile(refFile, "ref body");
+
+			await savePlansRegistry(
+				{
+					version: 1,
+					plans: {
+						"keep-plan": {
+							slug: "keep-plan",
+							title: "Keep",
+							sourcePath: keepPlanFile,
+							addedAt: "t",
+							updatedAt: "t",
+							commitHash: null,
+						},
+						"drop-plan": {
+							slug: "drop-plan",
+							title: "Drop",
+							sourcePath: dropPlanFile,
+							addedAt: "t",
+							updatedAt: "t",
+							commitHash: null,
+						},
+						// committed guard: excluded key must NOT clobber it.
+						"committed-plan": {
+							slug: "committed-plan",
+							title: "Committed",
+							sourcePath: keepPlanFile,
+							addedAt: "t",
+							updatedAt: "t",
+							commitHash: "abc12345",
+							contentHashAtCommit: "hash",
+						},
+					},
+					notes: {
+						n1: {
+							id: "n1",
+							title: "Note",
+							format: "snippet",
+							addedAt: "t",
+							updatedAt: "t",
+							commitHash: null,
+							sourcePath: noteFile,
+						},
+					},
+					references: {
+						"linear:L-1": {
+							source: "linear",
+							nativeId: "L-1",
+							title: "Ref",
+							url: "https://x",
+							sourcePath: refFile,
+							addedAt: "t",
+							updatedAt: "t",
+							sourceToolName: "mcp__linear__get_issue",
+						},
+					},
+				},
+				tempDir,
+			);
+
+			const removed = await discardExcludedWorkingItems(
+				{
+					plans: new Set(["drop-plan", "committed-plan"]),
+					notes: new Set(["n1"]),
+					references: new Set(["linear:L-1"]),
+				},
+				tempDir,
+			);
+			expect(removed).toEqual({ plans: 1, notes: 1, references: 1 });
+
+			const reg = await loadPlansRegistry(tempDir);
+			// drop-plan removed; keep-plan + committed guard preserved.
+			expect(Object.keys(reg.plans).sort()).toEqual(["committed-plan", "keep-plan"]);
+			expect(reg.notes ?? {}).toEqual({});
+			expect(reg.references ?? {}).toEqual({});
+
+			const { existsSync } = await import("node:fs");
+			// .jolli-owned note + reference files deleted…
+			expect(existsSync(noteFile)).toBe(false);
+			expect(existsSync(refFile)).toBe(false);
+			// …but the external plan file is never touched.
+			expect(existsSync(dropPlanFile)).toBe(true);
+		});
+
+		it("is a no-op when nothing is excluded", async () => {
+			const removed = await discardExcludedWorkingItems(
+				{ plans: new Set(), notes: new Set(), references: new Set() },
+				tempDir,
+			);
+			expect(removed).toEqual({ plans: 0, notes: 0, references: 0 });
 		});
 	});
 

--- a/cli/src/core/SessionTracker.test.ts
+++ b/cli/src/core/SessionTracker.test.ts
@@ -1995,6 +1995,21 @@ describe("SessionTracker", () => {
 			expect(e?.sourcePath).toContain("PROJ-1528.md");
 			expect(e?.sourceToolName).toBe("mcp__linear__get_issue");
 			expect(e?.title).toBe("Treat referenced Linear issues");
+			// Branch is stamped so IntelliJ can branch-scope the shared plans.json.
+			expect(e?.branch).toBe("main");
+		});
+
+		it("stamps the current branch on insert and re-stamps it on update", async () => {
+			await upsertReferenceEntry(ref(), tempDir, "feature/x");
+			expect(linearIssuesOfReg(await loadPlansRegistry(tempDir))?.["PROJ-1528"]?.branch).toBe("feature/x");
+			// Re-surfaced on another branch → follows the new branch.
+			await upsertReferenceEntry(ref({ title: "v2" }), tempDir, "feature/y");
+			expect(linearIssuesOfReg(await loadPlansRegistry(tempDir))?.["PROJ-1528"]?.branch).toBe("feature/y");
+		});
+
+		it("omits branch on an unknown git lookup (stays visible on every branch)", async () => {
+			await upsertReferenceEntry(ref(), tempDir, "unknown");
+			expect(linearIssuesOfReg(await loadPlansRegistry(tempDir))?.["PROJ-1528"]?.branch).toBeUndefined();
 		});
 
 		it("refreshes title/url/sourceToolName on an existing entry, preserving addedAt", async () => {
@@ -2351,7 +2366,7 @@ describe("normalizePlansRegistry", () => {
 		...over,
 	});
 
-	it("plans: drops ignored rows, strips ignored/branch/editCount, keeps guard", () => {
+	it("plans: drops ignored rows, strips ignored/editCount, keeps guard and branch", () => {
 		const raw = {
 			version: 1,
 			plans: {
@@ -2371,12 +2386,15 @@ describe("normalizePlansRegistry", () => {
 
 		expect(changed).toBe(true);
 		expect(Object.keys(registry.plans).sort()).toEqual(["active", "guard"]);
-		expect(JSON.stringify(registry.plans)).not.toMatch(/editCount|"branch"|"ignored"/);
+		expect(JSON.stringify(registry.plans)).not.toMatch(/editCount|"ignored"/);
+		// `branch` is preserved (IntelliJ branch-scopes off it via the shared plans.json).
+		expect(registry.plans.active?.branch).toBe("main");
+		expect(registry.plans.guard?.branch).toBe("main");
 		expect(registry.plans.guard?.commitHash).toBe("abc");
 		expect(registry.plans.guard?.contentHashAtCommit).toBe("h");
 	});
 
-	it("notes: drops ignored rows, strips ignored/branch, keeps guard", () => {
+	it("notes: drops ignored rows, strips ignored, keeps guard and branch", () => {
 		const raw = {
 			version: 1,
 			plans: {},
@@ -2406,7 +2424,9 @@ describe("normalizePlansRegistry", () => {
 
 		expect(changed).toBe(true);
 		expect(Object.keys(registry.notes ?? {})).toEqual(["keep"]);
-		expect(JSON.stringify(registry.notes)).not.toMatch(/"branch"|"ignored"/);
+		expect(JSON.stringify(registry.notes)).not.toMatch(/"ignored"/);
+		// `branch` is preserved for the IntelliJ shared-plans.json branch filter.
+		expect(registry.notes?.keep?.branch).toBe("main");
 	});
 
 	it("references: drops ignored/committed/guard rows, keeps active rows, strips dead fields", () => {
@@ -2428,7 +2448,9 @@ describe("normalizePlansRegistry", () => {
 
 		expect(changed).toBe(true);
 		expect(Object.keys(registry.references ?? {}).sort()).toEqual(["linear:ACTIVE-1", "linear:ENG-12345678"]);
-		expect(JSON.stringify(registry.references)).not.toMatch(/"branch"|"ignored"|"commitHash"|contentHashAtCommit/);
+		expect(JSON.stringify(registry.references)).not.toMatch(/"ignored"|"commitHash"|contentHashAtCommit/);
+		// `branch` is preserved on the surviving active rows.
+		expect(registry.references?.["linear:ACTIVE-1"]?.branch).toBe("main");
 	});
 
 	it("is idempotent: an already-clean registry returns changed=false and equal data", () => {

--- a/cli/src/core/SessionTracker.ts
+++ b/cli/src/core/SessionTracker.ts
@@ -875,11 +875,16 @@ async function pruneOrphanedCursors(dir: string, stalePaths: ReadonlyArray<strin
 
 // ─── Plans Registry ───────────────────────────────────────────────────────────
 
-/** Legacy fields removed from PlanEntry (`editCount` is plan-only) and NoteEntry. */
-const LEGACY_PLAN_FIELDS = ["ignored", "branch", "editCount"] as const;
-const LEGACY_NOTE_FIELDS = ["ignored", "branch"] as const;
-/** Reference rows are now always active/uncommitted — these all became dead fields. */
-const LEGACY_REFERENCE_FIELDS = ["ignored", "branch", "commitHash", "contentHashAtCommit"] as const;
+/**
+ * Legacy fields removed from PlanEntry (`editCount` is plan-only) and NoteEntry.
+ * `branch` is intentionally NOT stripped: the CLI does not filter on it, but the
+ * IntelliJ plugin shares this plans.json and branch-scopes its CONTEXT view, so
+ * stripping it here would erase IntelliJ's value on every CLI write.
+ */
+const LEGACY_PLAN_FIELDS = ["ignored", "editCount"] as const;
+const LEGACY_NOTE_FIELDS = ["ignored"] as const;
+/** Reference committed/guard rows became dead fields (a live row is uncommitted). */
+const LEGACY_REFERENCE_FIELDS = ["ignored", "commitHash", "contentHashAtCommit"] as const;
 
 /** Deletes `fields` from a shallow copy of `entry`; returns the copy + whether anything was dropped. */
 function stripLegacyFields<T>(entry: T, fields: ReadonlyArray<string>): { value: T; changed: boolean } {
@@ -900,13 +905,15 @@ function stripLegacyFields<T>(entry: T, fields: ReadonlyArray<string>): { value:
  *
  * Pure + idempotent — clean input returns `changed: false`. Per type:
  *   - plans / notes: drop rows with `ignored === true`; strip dead fields
- *     (`ignored` / `branch` / `editCount`); keep the `commitHash` +
- *     `contentHashAtCommit` guard.
+ *     (`ignored` / `editCount`); keep the `commitHash` + `contentHashAtCommit`
+ *     guard. `branch` is preserved (see LEGACY_PLAN_FIELDS) so IntelliJ's
+ *     branch-scoping survives CLI writes to the shared plans.json.
  *   - references: also drop committed / guard rows — detected ONLY by the
  *     `commitHash` / `contentHashAtCommit` fields, deliberately NOT by a
  *     `-<8hex>` key shape (an active ticket id can legitimately end in 8 digits;
  *     see the predicate below) — a reference row is now always
- *     active/uncommitted — and strip the four now-dead fields from survivors.
+ *     active/uncommitted — and strip the now-dead fields from survivors (but
+ *     keep `branch`).
  *
  * `JSON.parse` keeps unknown keys and `savePlansRegistry` re-serialises the
  * whole object, so legacy fields/rows do NOT disappear on their own; this is
@@ -1170,10 +1177,14 @@ export async function detectUncommittedReferenceIds(
  * happens there). The near-write reread only overwrites our own mapKey, so a
  * concurrent writer touching other mapKeys is preserved.
  */
-export async function upsertReferenceEntry(ref: Reference, cwd: string, _branch: string): Promise<void> {
+export async function upsertReferenceEntry(ref: Reference, cwd: string, branch: string): Promise<void> {
 	const { sourcePath } = await writeReferenceMarkdown(ref, cwd);
 	const mapKey = `${ref.source}:${ref.nativeId}`;
 	const now = new Date().toISOString();
+	// Persist a real branch only — a failed git lookup ("unknown") is left off so
+	// the row stays branch-less (visible on every branch) rather than scoped to a
+	// non-existent "unknown" branch. The CLI never reads this; IntelliJ does.
+	const branchField = branch && branch !== "unknown" ? { branch } : {};
 
 	// Whole load→save under plans.lock so a concurrent StopHook / QueueWorker /
 	// Codex-discovery write to plans.json can't clobber this reference (and vice
@@ -1193,6 +1204,9 @@ export async function upsertReferenceEntry(ref: Reference, cwd: string, _branch:
 						sourcePath,
 						sourceToolName: ref.toolName,
 						updatedAt: now,
+						// Re-stamp to the current branch (a re-surfaced ref follows it);
+						// an "unknown" lookup keeps the existing branch via the spread.
+						...branchField,
 					}
 				: {
 						source: ref.source,
@@ -1203,6 +1217,7 @@ export async function upsertReferenceEntry(ref: Reference, cwd: string, _branch:
 						addedAt: now,
 						updatedAt: now,
 						sourceToolName: ref.toolName,
+						...branchField,
 					};
 
 		// Near-write reread — only overwrites our own mapKey, so a concurrent writer

--- a/cli/src/core/SessionTracker.ts
+++ b/cli/src/core/SessionTracker.ts
@@ -35,7 +35,8 @@ import {
 } from "../Types.js";
 import { atomicWriteFile as atomicWrite } from "./AtomicWrite.js";
 import { withPlansLock } from "./Locks.js";
-import { writeReferenceMarkdown } from "./references/ReferenceStore.js";
+import { isPathInside } from "./PathUtils.js";
+import { deleteReferenceMarkdown, writeReferenceMarkdown } from "./references/ReferenceStore.js";
 
 const log = createLogger("SessionTracker");
 
@@ -1075,6 +1076,107 @@ export async function associatePlanWithCommit(archivedSlug: string, commitHash: 
 		await savePlansRegistry(updated, cwd);
 		log.info("associatePlanWithCommit: migrated guard %s → %s", split.baseKey, commitHash.substring(0, 8));
 	});
+}
+
+/**
+ * Discards the working-area items the user left UNCHECKED at commit time.
+ *
+ * Selection semantics: checked items are archived into committed memory (elsewhere);
+ * unchecked items are "useless" and must leave the working area WITHOUT being written
+ * into committed memory. This removes the excluded rows from plans.json and deletes
+ * their `.jolli`-owned backing files.
+ *
+ * - Plans: registry row removed; the external `~/.claude/plans/<slug>.md` is left
+ *   untouched (user-owned — a later edit legitimately re-discovers it).
+ * - Notes: registry row removed; backing file deleted only when it lives inside
+ *   `.jolli/jollimemory/` (external note sources are preserved).
+ * - References: registry row removed; backing markdown (always under `.jolli`) deleted.
+ *
+ * Only uncommitted rows (`commitHash === null` and no `contentHashAtCommit`) are
+ * touched, so a stale exclusion key can never clobber a committed guard row.
+ * References carry no commit state, so any matching key is an active row.
+ */
+export async function discardExcludedWorkingItems(
+	exclusions: {
+		readonly plans: ReadonlySet<string>;
+		readonly notes: ReadonlySet<string>;
+		readonly references: ReadonlySet<string>;
+	},
+	cwd?: string,
+): Promise<{ plans: number; notes: number; references: number }> {
+	const removed = { plans: 0, notes: 0, references: 0 };
+	const noteFilesToDelete: string[] = [];
+	const refFilesToDelete: string[] = [];
+
+	await withPlansLock(cwd, async () => {
+		const registry = await loadPlansRegistry(cwd);
+		const plans = { ...registry.plans };
+		const notes = { ...(registry.notes ?? {}) };
+		const references = { ...(registry.references ?? {}) };
+
+		for (const slug of exclusions.plans) {
+			const entry = plans[slug];
+			if (entry && entry.commitHash === null && entry.contentHashAtCommit === undefined) {
+				delete plans[slug];
+				removed.plans++;
+			}
+		}
+		for (const id of exclusions.notes) {
+			const entry = notes[id];
+			if (entry && entry.commitHash === null && entry.contentHashAtCommit === undefined) {
+				if (entry.sourcePath) noteFilesToDelete.push(entry.sourcePath);
+				delete notes[id];
+				removed.notes++;
+			}
+		}
+		for (const key of exclusions.references) {
+			const entry = references[key];
+			if (entry) {
+				if (entry.sourcePath) refFilesToDelete.push(entry.sourcePath);
+				delete references[key];
+				removed.references++;
+			}
+		}
+
+		if (removed.plans > 0 || removed.notes > 0 || removed.references > 0) {
+			await savePlansRegistry(
+				{
+					...registry,
+					plans,
+					notes: Object.keys(notes).length > 0 ? notes : undefined,
+					references: Object.keys(references).length > 0 ? references : undefined,
+				},
+				cwd,
+			);
+		}
+	});
+
+	// Backing-file cleanup AFTER the lock — the rows are already gone, so a failed
+	// unlink can never strand registry state. Note sources outside `.jolli` (the
+	// user's own markdown files added via "Add Markdown File") are never deleted.
+	const jolliDir = getJolliMemoryDir(cwd);
+	for (const p of noteFilesToDelete) {
+		if (isPathInside(p, jolliDir)) {
+			try {
+				await rm(p, { force: true });
+			} catch {
+				/* best-effort */
+			}
+		}
+	}
+	for (const p of refFilesToDelete) {
+		await deleteReferenceMarkdown(p);
+	}
+
+	if (removed.plans > 0 || removed.notes > 0 || removed.references > 0) {
+		log.info(
+			"Discarded excluded working items: %d plan(s), %d note(s), %d reference(s)",
+			removed.plans,
+			removed.notes,
+			removed.references,
+		);
+	}
+	return removed;
 }
 
 /**

--- a/cli/src/core/TelemetryEvents.ts
+++ b/cli/src/core/TelemetryEvents.ts
@@ -46,6 +46,18 @@ export const TELEMETRY_EVENTS = {
 	error_occurred: "A structured error code was raised.",
 	queue_drained: "QueueWorker finished a drain.",
 	sync_completed: "A memory-bank sync round finished.",
+	// ── IDE tool-window UI / engagement (IntelliJ, VS Code) ──
+	toolwindow_opened: "The memory tool window was opened.",
+	view_switched: "Tool window view switched (current/bank/knowledge).",
+	memory_committed: "User committed a memory via the Commit button.",
+	memory_expanded: "A committed memory's details were expanded.",
+	memory_item_opened: "An item inside a memory was opened (conversation/file/context/shipped).",
+	session_resumed: "A conversation session was resumed in a terminal.",
+	recall_prompt_copied: "A recall prompt was copied to the clipboard.",
+	memory_pinned: "An item was pinned.",
+	memory_unpinned: "An item was unpinned.",
+	key_rejected: "The server rejected the API key (401/403).",
+	reauth_completed: "Re-authentication after a rejected key finished.",
 } as const;
 
 /** Union of every registered event name. */

--- a/cli/src/core/plans/TranscriptPlanDiscovery.ts
+++ b/cli/src/core/plans/TranscriptPlanDiscovery.ts
@@ -15,6 +15,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { createLogger } from "../../Logger.js";
 import type { PlanEntry, TranscriptSource } from "../../Types.js";
+import { getCurrentBranchSafe } from "../GitBranch.js";
 import { withPlansLock } from "../Locks.js";
 import { normalizePathForCompare } from "../PathUtils.js";
 import { loadPlansRegistry, savePlansRegistry } from "../SessionTracker.js";
@@ -165,6 +166,12 @@ export async function scanPlansFrom(
 	const registry = await loadPlansRegistry(cwd);
 	const plans = { ...registry.plans };
 	const now = new Date().toISOString();
+	// Stamp the branch on newly-created rows so the IntelliJ plugin (which shares
+	// this plans.json) can branch-scope its CONTEXT view. Omit on an "unknown" git
+	// lookup so the row stays branch-less (visible everywhere) rather than scoped
+	// to a non-existent branch. The CLI itself does not filter on it.
+	const discoveredBranch = getCurrentBranchSafe(cwd);
+	const branchField = discoveredBranch && discoveredBranch !== "unknown" ? { branch: discoveredBranch } : {};
 	let changed = false;
 	// Tracks slugs we actually modified in this run. Used at writeback time to
 	// merge our changes onto the freshest registry snapshot per-slug rather
@@ -186,6 +193,7 @@ export async function scanPlansFrom(
 					addedAt: now,
 					updatedAt: now,
 					commitHash: null,
+					...branchField,
 				};
 				changed = true;
 				touchedSlugs.add(slug);
@@ -205,6 +213,7 @@ export async function scanPlansFrom(
 				addedAt: now,
 				updatedAt: now,
 				commitHash: null,
+				...branchField,
 			};
 			changed = true;
 			touchedSlugs.add(slug);

--- a/cli/src/core/references/TranscriptReferenceDiscovery.ts
+++ b/cli/src/core/references/TranscriptReferenceDiscovery.ts
@@ -11,7 +11,7 @@
 
 import { createLogger } from "../../Logger.js";
 import type { TranscriptSource } from "../../Types.js";
-import { execFileSyncHidden } from "../../util/Subprocess.js";
+import { getCurrentBranchSafe } from "../GitBranch.js";
 import { upsertReferenceEntry } from "../SessionTracker.js";
 import { extractReferencesFromTranscript } from "./ReferenceExtractor.js";
 import { getAdaptersForSource } from "./sources/index.js";
@@ -68,21 +68,4 @@ export async function scanReferencesFrom(
 	);
 
 	return lastLineNumberScanned;
-}
-
-/**
- * Current git branch (synchronous, never throws). Returns "unknown" on any
- * failure. Named `…Safe` to NOT collide with the async, throwing
- * `GitOps.getCurrentBranch` — the two have opposite error semantics.
- */
-export function getCurrentBranchSafe(cwd: string): string {
-	try {
-		return execFileSyncHidden("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
-			cwd,
-			encoding: "utf-8",
-			stdio: ["ignore", "pipe", "ignore"],
-		}).trim();
-	} catch {
-		return "unknown";
-	}
 }

--- a/cli/src/hooks/PostCommitHook.helpers.test.ts
+++ b/cli/src/hooks/PostCommitHook.helpers.test.ts
@@ -134,6 +134,7 @@ vi.mock("../core/SessionTracker.js", () => ({
 	associateNoteWithCommit: vi.fn(),
 	associateReferenceWithCommit: vi.fn(),
 	detectUncommittedReferenceIds: vi.fn().mockResolvedValue([]),
+	discardExcludedWorkingItems: vi.fn().mockResolvedValue({ plans: 0, notes: 0, references: 0 }),
 	detectActivePlansForBranch: vi.fn().mockResolvedValue([]),
 	detectActiveNotesForBranch: vi.fn().mockResolvedValue([]),
 	getReferenceEntriesForBranch: vi.fn().mockResolvedValue([]),

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -45,6 +45,7 @@ vi.mock("../core/SessionTracker.js", async (importOriginal) => {
 		associatePlanWithCommit: vi.fn(),
 		associateNoteWithCommit: vi.fn(),
 		detectUncommittedReferenceIds: vi.fn().mockResolvedValue([]),
+		discardExcludedWorkingItems: vi.fn().mockResolvedValue({ plans: 0, notes: 0, references: 0 }),
 		detectActivePlansForBranch: vi.fn().mockResolvedValue([]),
 		detectActiveNotesForBranch: vi.fn().mockResolvedValue([]),
 		getReferenceEntriesForBranch: vi.fn().mockResolvedValue([]),

--- a/cli/src/hooks/QueueWorker.selection.test.ts
+++ b/cli/src/hooks/QueueWorker.selection.test.ts
@@ -65,6 +65,7 @@ vi.mock("../core/SessionTracker.js", async (importOriginal) => {
 		associateNoteWithCommit: vi.fn().mockResolvedValue(undefined),
 		associateReferenceWithCommit: vi.fn().mockResolvedValue(undefined),
 		detectUncommittedReferenceIds: vi.fn().mockResolvedValue([]),
+		discardExcludedWorkingItems: vi.fn().mockResolvedValue({ plans: 0, notes: 0, references: 0 }),
 		detectActivePlansForBranch: vi.fn().mockResolvedValue([]),
 		detectActiveNotesForBranch: vi.fn().mockResolvedValue([]),
 		getReferenceEntriesForBranch: vi.fn().mockResolvedValue([]),
@@ -267,6 +268,7 @@ import {
 	detectActiveNotesForBranch,
 	detectActivePlansForBranch,
 	detectUncommittedReferenceIds,
+	discardExcludedWorkingItems,
 	getReferenceEntriesForBranch,
 	loadAllSessions,
 	loadConfig,
@@ -406,11 +408,12 @@ describe("QueueWorker selection filter", () => {
 		expect(capturedSessions).toHaveLength(1);
 	});
 
-	it("does not advance the cursor for an excluded conversation", async () => {
-		// Regression: when the worker advanced cursors for excluded sessions, the
-		// sidebar's "messageCount > 0" filter dropped them on the next 60-second
-		// refresh — making the *unchecked* rows disappear alongside the committed
-		// ones. The fix is to skip the read entirely for excluded sessions.
+	it("advances the cursor for an excluded conversation (discard)", async () => {
+		// Selection is a one-time discard: an unchecked conversation is consumed
+		// (cursor → commit boundary) so it leaves the working area on the next
+		// refresh, even though its entries never enter the summary. So the excluded
+		// session IS read and its cursor IS advanced — it is just dropped from the
+		// summary input (verified elsewhere).
 		const claudeSessionId = "claude-sess-excluded";
 		seedGitMocks(projectDir);
 		seedClaudeSession(claudeSessionId, "EXCLUDED_CONTENT");
@@ -419,8 +422,8 @@ describe("QueueWorker selection filter", () => {
 
 		await executePipeline(projectDir, makeCommitOp());
 
-		expect(vi.mocked(saveCursor)).not.toHaveBeenCalled();
-		expect(vi.mocked(readTranscript)).not.toHaveBeenCalled();
+		expect(vi.mocked(saveCursor)).toHaveBeenCalled();
+		expect(vi.mocked(readTranscript)).toHaveBeenCalled();
 	});
 
 	it("advances the cursor for a non-excluded conversation", async () => {
@@ -433,7 +436,9 @@ describe("QueueWorker selection filter", () => {
 		expect(vi.mocked(saveCursor)).toHaveBeenCalledTimes(1);
 	});
 
-	it("does not advance the cursor for an excluded conversation on the amend path", async () => {
+	it("advances the cursor for an excluded conversation on the amend path (discard)", async () => {
+		// The amend path shares loadSessionTranscripts, so excluded conversations are
+		// discarded there too: consumed (cursor advanced) but dropped from the summary.
 		const claudeSessionId = "claude-sess-amend-excluded";
 		seedGitMocks(projectDir);
 		seedClaudeSession(claudeSessionId, "EXCLUDED_AMEND_CONTENT");
@@ -443,8 +448,26 @@ describe("QueueWorker selection filter", () => {
 		const amendOp = makeCommitOp({ type: "amend", sourceHashes: ["old-hash-0001"] });
 		await executePipeline(projectDir, amendOp);
 
-		expect(vi.mocked(saveCursor)).not.toHaveBeenCalled();
-		expect(vi.mocked(readTranscript)).not.toHaveBeenCalled();
+		expect(vi.mocked(saveCursor)).toHaveBeenCalled();
+		expect(vi.mocked(readTranscript)).toHaveBeenCalled();
+	});
+
+	it("discards excluded plans/notes/references after archival (commit path)", async () => {
+		seedGitMocks(projectDir);
+		vi.mocked(loadAllSessions).mockResolvedValue([]);
+		vi.mocked(buildMultiSessionContext).mockReturnValue("");
+
+		await setExcluded(projectDir, "plans", "plan-skip", true);
+		await setExcluded(projectDir, "notes", "note-skip", true);
+		await setExcluded(projectDir, "references", "linear:L-9", true);
+
+		await executePipeline(projectDir, makeCommitOp());
+
+		expect(vi.mocked(discardExcludedWorkingItems)).toHaveBeenCalledTimes(1);
+		const arg = vi.mocked(discardExcludedWorkingItems).mock.calls[0][0];
+		expect(arg.plans.has("plan-skip")).toBe(true);
+		expect(arg.notes.has("note-skip")).toBe(true);
+		expect(arg.references.has("linear:L-9")).toBe(true);
 	});
 
 	it("filters excluded plans out of the plans block input", async () => {

--- a/cli/src/hooks/QueueWorker.selection.test.ts
+++ b/cli/src/hooks/QueueWorker.selection.test.ts
@@ -436,6 +436,47 @@ describe("QueueWorker selection filter", () => {
 		expect(vi.mocked(saveCursor)).toHaveBeenCalledTimes(1);
 	});
 
+	it("excludes an unchecked conversation's usage tokens from stored conversationTokens", async () => {
+		// Both conversations are read (so the unchecked one's cursor advances), but only
+		// the kept conversation's tokens may count toward the stored total — otherwise
+		// the token bar reports A+B while the body/entries reflect only A.
+		seedGitMocks(projectDir);
+		vi.mocked(buildMultiSessionContext).mockReturnValue("ctx");
+		vi.mocked(loadAllSessions).mockResolvedValue([
+			{
+				sessionId: "sess-keep",
+				transcriptPath: "/fake/sess-keep.jsonl",
+				updatedAt: "2026-01-01T00:00:00Z",
+				source: "claude" as const,
+			},
+			{
+				sessionId: "sess-drop",
+				transcriptPath: "/fake/sess-drop.jsonl",
+				updatedAt: "2026-01-01T00:00:00Z",
+				source: "claude" as const,
+			},
+		]);
+		vi.mocked(loadCursorForTranscript).mockResolvedValue(null);
+		vi.mocked(readTranscript).mockImplementation(async (transcriptPath: string) => {
+			const isKeep = transcriptPath.includes("sess-keep");
+			return {
+				entries: [{ role: "human", content: isKeep ? "KEEP" : "DROP", timestamp: "t0" }],
+				newCursor: { transcriptPath, lineNumber: 1, updatedAt: "2026-01-01T00:00:00Z" },
+				totalLinesRead: 1,
+				usageTokens: isKeep ? 100 : 999,
+			};
+		});
+
+		await setExcluded(projectDir, "conversations", conversationKey("claude", "sess-drop"), true);
+
+		await executePipeline(projectDir, makeCommitOp());
+
+		expect(vi.mocked(storeSummary)).toHaveBeenCalledTimes(1);
+		const summaryArg = vi.mocked(storeSummary).mock.calls[0][0];
+		// 100 (kept) only — NOT 1099 (would include the excluded conversation's 999).
+		expect(summaryArg.conversationTokens).toBe(100);
+	});
+
 	it("advances the cursor for an excluded conversation on the amend path (discard)", async () => {
 		// The amend path shares loadSessionTranscripts, so excluded conversations are
 		// discarded there too: consumed (cursor advanced) but dropped from the summary.

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -26,6 +26,7 @@ vi.mock("../core/SessionTracker.js", async (importOriginal) => {
 		associatePlanWithCommit: vi.fn(),
 		associateNoteWithCommit: vi.fn(),
 		detectUncommittedReferenceIds: vi.fn().mockResolvedValue([]),
+		discardExcludedWorkingItems: vi.fn().mockResolvedValue({ plans: 0, notes: 0, references: 0 }),
 		detectActivePlansForBranch: vi.fn().mockResolvedValue([]),
 		detectActiveNotesForBranch: vi.fn().mockResolvedValue([]),
 		getReferenceEntriesForBranch: vi.fn().mockResolvedValue([]),

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -2875,9 +2875,17 @@ async function loadSessionTranscripts(
 
 	const rawAll = await readAllTranscripts(allSessions, cwd, beforeTimestamp);
 	// Keep only checked conversations for the summary; excluded ones were read
-	// purely to advance their cursor (discard).
+	// purely to advance their cursor (discard). Their usage tokens must be dropped
+	// from conversationTokens too — otherwise the stored token bar overcounts by the
+	// excluded conversations' tokens while the summary body and entry counts reflect
+	// only the kept ones. Sum tokens over the retained conversations only.
+	let retainedConversationTokens = 0;
+	for (const [key, tokens] of rawAll.tokensByKey) {
+		if (!excludedConversationKeys.has(key)) retainedConversationTokens += tokens;
+	}
 	const raw = {
 		...rawAll,
+		conversationTokens: retainedConversationTokens,
 		sessionTranscripts: rawAll.sessionTranscripts.filter(
 			(s) => !excludedConversationKeys.has(conversationKey(s.source ?? "claude", s.sessionId)),
 		),
@@ -2959,11 +2967,17 @@ async function readAllTranscripts(
 	totalEntries: number;
 	humanEntries: number;
 	conversationTokens: number;
+	tokensByKey: Map<string, number>;
 }> {
 	const sessionTranscripts: SessionTranscript[] = [];
 	let totalEntries = 0;
 	let humanEntries = 0;
 	let conversationTokens = 0;
+	// Per-conversation token attribution so the caller can drop excluded
+	// conversations' tokens from the stored total. Keyed by conversationKey and
+	// populated even when a slice yields zero merged entries (a usage-only slice),
+	// so the subtraction stays exact.
+	const tokensByKey = new Map<string, number>();
 
 	for (const session of sessions) {
 		const cursor = await loadCursorForTranscript(session.transcriptPath, cwd);
@@ -3047,7 +3061,10 @@ async function readAllTranscripts(
 		// (as the entry/session bookkeeping below is) would silently drop those tokens
 		// from conversationTokens. Token accounting and entry accounting are
 		// independent concerns, so accumulate tokens here, before the entries gate.
-		conversationTokens += result.usageTokens ?? 0;
+		const usage = result.usageTokens ?? 0;
+		conversationTokens += usage;
+		const convKey = conversationKey(source, session.sessionId);
+		tokensByKey.set(convKey, (tokensByKey.get(convKey) ?? 0) + usage);
 
 		if (result.entries.length > 0) {
 			sessionTranscripts.push({
@@ -3072,7 +3089,7 @@ async function readAllTranscripts(
 		await saveCursor(result.newCursor, cwd);
 	}
 
-	return { sessionTranscripts, totalEntries, humanEntries, conversationTokens };
+	return { sessionTranscripts, totalEntries, humanEntries, conversationTokens, tokensByKey };
 }
 
 /**

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -57,6 +57,7 @@ import {
 	detectActiveNotesForBranch,
 	detectActivePlansForBranch,
 	detectUncommittedReferenceIds,
+	discardExcludedWorkingItems,
 	filterSessionsByEnabledIntegrations,
 	getReferenceEntriesForBranch,
 	loadAllSessions,
@@ -1511,9 +1512,9 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 	}
 
 	// Step 3+4: Load sessions and read transcripts with time cutoff for queue-driven attribution.
-	// Excluded conversations are filtered inside `loadSessionTranscripts` BEFORE any cursor
-	// advance — keep the plans/notes exclusion read here, but no `sessionTranscripts.filter`
-	// step is needed.
+	// Excluded conversations are DISCARDED inside `loadSessionTranscripts` — their cursor is
+	// advanced (consumed) but their entries are dropped from the summary. The plans/notes/refs
+	// exclusion read here drives both prompt-block filtering and the discard pass below.
 	const exclusions = await readExclusions(cwd);
 	const { sessionTranscripts, totalEntries, humanEntries, conversationTokens } = await loadSessionTranscripts(
 		cwd,
@@ -1671,6 +1672,8 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 	// post-filter on `planAssociation.refs` would still leave the excluded plan
 	// archived on disk. The prompt-block filter only governs LLM input;
 	// the archive path is a separate registry scan and must be filtered here.
+	// The excluded rows are then DISCARDED by `discardExcludedWorkingItems` below
+	// (removed from the working area, but never archived into committed memory).
 	const planSlugs = await detectPlanSlugsFromRegistry(cwd, branch);
 	for (const excludedSlug of exclusions.plans) planSlugs.delete(excludedSlug);
 	const planAssociation = await associatePlansWithCommit(planSlugs, commitInfo.hash, cwd, branch);
@@ -1687,8 +1690,8 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 	// returned filesToStore is forwarded directly to storeReferences — captured
 	// BEFORE the local rename so the orphan-branch snapshot is independent of
 	// rename success. Mirrors the plans / notes archive-side filter — excluded
-	// references are dropped here too, so the row reappears on the
-	// next commit (skip-don't-archive semantics).
+	// references are dropped from archival here and DISCARDED (row + markdown
+	// removed) by `discardExcludedWorkingItems` below.
 	const rawReferenceIds = await detectUncommittedReferenceIds(cwd, branch);
 	const referenceIds = rawReferenceIds.filter((e) => !exclusions.references.has(e.mapKey));
 	const {
@@ -1708,6 +1711,17 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 		);
 		await finalizeReferenceArchive(referenceCommitted, cwd);
 	}
+
+	// Discard the unchecked working items: the CHECKED ones were archived above;
+	// the excluded ones are useless per the user's selection, so remove their
+	// registry rows (+ .jolli-owned backing files) WITHOUT writing them into the
+	// committed memory. Runs after associate* so the checked-item archival (which
+	// reloads the registry under lock) has already settled.
+	await discardExcludedWorkingItems(
+		{ plans: exclusions.plans, notes: exclusions.notes, references: exclusions.references },
+		cwd,
+	);
+
 	// Step 8b: Evaluate plan progress for each linked plan (Haiku calls parallelized)
 	const planProgressArtifacts: PlanProgressArtifact[] = [];
 	if (planRefs.length > 0) {
@@ -2319,8 +2333,8 @@ async function handleAmendPipeline(
 	}
 
 	// Load sessions and read transcripts with time cutoff. Excluded conversations are
-	// filtered inside `loadSessionTranscripts` BEFORE any cursor advance — keep the
-	// plans/notes exclusion read here, but no `sessionTranscripts.filter` step is needed.
+	// DISCARDED inside `loadSessionTranscripts` (cursor advanced, entries dropped). The
+	// exclusion read here drives prompt-block filtering and the discard pass below.
 	const amendConfig = await loadConfig();
 	const amendExclusions = await readExclusions(cwd);
 	const { sessionTranscripts, totalEntries, humanEntries, conversationTokens } = await loadSessionTranscripts(
@@ -2752,6 +2766,14 @@ async function handleAmendPipeline(
 			? { transcript: transcriptArtifact }
 			: undefined,
 	);
+	// Discard the unchecked working items on the amend fresh-leaf path too — the
+	// checked ones were archived above; the excluded ones are removed from the
+	// working area without entering committed memory.
+	await discardExcludedWorkingItems(
+		{ plans: amendExclusions.plans, notes: amendExclusions.notes, references: amendExclusions.references },
+		cwd,
+	);
+
 	log.info(
 		"Amend with no old summary -> stored as fresh leaf for %s (%s)",
 		commitInfo.hash.substring(0, 8),
@@ -2837,21 +2859,29 @@ async function loadSessionTranscripts(
 		log.info("No active sessions found — will infer topics from diff if available");
 	}
 
-	// Drop sessions the user unchecked in the sidebar BEFORE reading transcripts.
-	// Reading advances per-transcript cursors via `saveCursor`, and the sidebar's
-	// active-conversations list uses `messageCount > 0` (unread = cursor → EOF)
-	// to decide whether to render a row — so any cursor advance silently removes
-	// the row on the next 60-second refresh. That regression made *unchecked*
-	// conversations disappear alongside the committed ones after every commit;
-	// excluding here keeps them visible with the unchecked box, as the per-item
-	// selection design spec requires ("excluded items stay visible so the user
-	// knows the item exists and can put it back in").
+	// Read ALL sessions (including the ones the user unchecked) so their cursors
+	// advance too. Selection semantics are "unchecked ⇒ discard": an excluded
+	// conversation is consumed (cursor → EOF/commit boundary via `saveCursor`
+	// inside readAllTranscripts) so it leaves the working area, but its entries are
+	// dropped below so they never enter the summary. (This intentionally reverses
+	// the earlier "keep excluded conversations visible so the user can re-check
+	// them" behavior — the per-item selection is now a one-time discard.)
 	const conversationExclusions = (await readExclusions(cwd)).conversations;
-	const includedSessions = allSessions.filter(
-		(s) => !conversationExclusions.has(conversationKey(s.source ?? "claude", s.sessionId)),
+	const excludedConversationKeys = new Set(
+		allSessions
+			.filter((s) => conversationExclusions.has(conversationKey(s.source ?? "claude", s.sessionId)))
+			.map((s) => conversationKey(s.source ?? "claude", s.sessionId)),
 	);
 
-	const raw = await readAllTranscripts(includedSessions, cwd, beforeTimestamp);
+	const rawAll = await readAllTranscripts(allSessions, cwd, beforeTimestamp);
+	// Keep only checked conversations for the summary; excluded ones were read
+	// purely to advance their cursor (discard).
+	const raw = {
+		...rawAll,
+		sessionTranscripts: rawAll.sessionTranscripts.filter(
+			(s) => !excludedConversationKeys.has(conversationKey(s.source ?? "claude", s.sessionId)),
+		),
+	};
 
 	// Apply per-session conversation-edit overlays (panel-authored deletes/edits
 	// from ConversationDetailsPanel) BEFORE the values flow into either the

--- a/intellij/CHANGELOG.md
+++ b/intellij/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes & Improvements
 
+- **Committed Memories clears on a new branch** — creating a branch off a feature or release branch no longer shows the parent branch's committed memories as the new branch's own; the panel now measures each branch's commits from its true creation point
 - Fixed a race condition when opening a file from the Current Memory review
 - Cleared a JetBrains Marketplace verifier warning for the terminal-based "Resume in terminal" action
 

--- a/intellij/CHANGELOG.md
+++ b/intellij/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.99.3
+
+### UI
+
+- **Memory panel polish** — consistent row hover, full-text wrapping, vertically centered icons, and tighter, aligned section headers across the Pinned, Current Memory, and Committed Memories sections
+- **Open committed items inline** — click a conversation, context entry, or file inside a committed memory to read its content in an editor tab, reusing the stored transcript when the original is gone
+
+### Fixes & Improvements
+
+- **Share in Jolli** — fixed "Invalid or disabled API key" on push: credentials are now shared across surfaces, and a rejected key triggers a one-time silent re-authenticate & retry instead of failing
+- Fixed the Jolli API key parser to scan every token segment, keeping it in lockstep with the CLI
+- Fixed an IDE freeze when applying Settings — install, uninstall, and Memory Bank migration now run off the UI thread
+- Added opt-out anonymous usage telemetry (content-free — never code, paths, or memory content). Disable it under Settings → General
+
 ## 0.99.2
 
 ### New Features

--- a/intellij/CHANGELOG.md
+++ b/intellij/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.99.4
+
+### Changes
+
+- **Selection is now a one-time discard** — unchecking a conversation, plan, note, or reference in CONTEXT now removes it from the working area when you commit, instead of keeping it around to re-check later. Unchecked conversations are consumed (they leave the list) but their content is dropped from the summary; unchecked plans/notes/references have their working-area entries removed without being saved into committed memory. Your own `~/.claude/plans` files and external note sources are never deleted
+- **Plans surface from your session** — plans now appear in CONTEXT via transcript discovery (matching the VS Code extension) rather than scanning `~/.claude/plans`, so a plan shows up only once you actually create or edit it in a session, and the panel refreshes live as plans and references are discovered
+- **Working-area items follow you across branches** — uncommitted plans, notes, and references are no longer hidden when you switch branches; only committed memory stays branch-tagged
+
+### Fixes & Improvements
+
+- Fixed a race condition when opening a file from the Current Memory review
+- Cleared a JetBrains Marketplace verifier warning for the terminal-based "Resume in terminal" action
+
 ## 0.99.3
 
 ### UI

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "ai.jolli"
-version = "0.99.3"
+version = "0.99.4"
 
 repositories {
     mavenCentral()

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -5,6 +5,7 @@ import java.util.zip.ZipEntry
 import java.io.ByteArrayOutputStream
 import java.io.FileOutputStream
 import java.util.concurrent.atomic.AtomicInteger
+import org.jetbrains.changelog.Changelog
 
 plugins {
     id("java")
@@ -12,10 +13,11 @@ plugins {
     id("org.jetbrains.intellij.platform") version "2.5.0"
     id("com.gradleup.shadow") version "9.0.0-beta12"
     id("org.jetbrains.kotlinx.kover") version "0.9.1"
+    id("org.jetbrains.changelog") version "2.2.1"
 }
 
 group = "ai.jolli"
-version = "0.99.2"
+version = "0.99.3"
 
 repositories {
     mavenCentral()
@@ -156,167 +158,16 @@ intellijPlatform {
                 by the background summary worker.
             </p>
         """.trimIndent()
-        changeNotes = """
-            <h3>0.99.2</h3>
-
-            <h4>New Features</h4>
-            <ul>
-                <li><b>Reference extraction</b> &mdash; automatically extracts Linear, Jira, GitHub, and
-                    Notion references from Claude and Codex transcripts and surfaces them in summaries.
-                    Includes per-source envelope parsers, a persistent <code>ReferenceStore</code>, and
-                    transcript-level discovery at both StopHook and post-commit time</li>
-                <li><b>References in Plans panel</b> &mdash; plan entries now show clickable
-                    "Open in &lt;Source&gt;" links instead of static source labels, with a Select All
-                    toolbar action</li>
-                <li><b>PR history strip</b> &mdash; the summary viewer shows previously merged or closed
-                    PRs for the same branch alongside the active PR. Uses <code>gh pr list --state all</code>
-                    so reopened or multi-PR branches no longer lose history</li>
-                <li><b>Conversation multi-select</b> &mdash; active conversation rows now have a checkbox
-                    ("Include in next memory") and a Select All toolbar action</li>
-            </ul>
-
-            <h4>Fixes &amp; Improvements</h4>
-            <ul>
-                <li>Removed periodic polling timer for branch updates; the tool window now updates on
-                    events only</li>
-                <li>Resolved JetBrains Marketplace Plugin Verifier internal-API warnings &mdash; plugin
-                    version and install path are derived from pure JVM APIs instead of
-                    <code>PluginManager</code></li>
-                <li>Commit selection state is now tracked via <code>CommitSelectionStore</code></li>
-            </ul>
-
-            <h3>0.99.1</h3>
-
-            <h4>New Features</h4>
-            <ul>
-                <li><b>Active Conversations</b> &mdash; a new panel showing in-progress AI agent
-                    sessions live, with inline transcript editing, message counts, and the ability
-                    to hide sessions</li>
-                <li><b>Knowledge Wiki</b> &mdash; build a browsable topic wiki from your Memory Bank
-                    via an LLM ingest pipeline. Trigger it with the <b>Build Knowledge Wiki</b> button
-                    or let it auto-compile after each commit; supports both Anthropic and Jolli
-                    summarization providers</li>
-                <li><b>Full-text search &amp; MCP server</b> &mdash; search across all memories, plus
-                    an MCP server that exposes your memory to AI tools, with ingest-phase progress UI</li>
-                <li><b>Full vault sync pipeline</b> &mdash; sync your Memory Bank to your Jolli space
-                    with live UI feedback, a space-binding dialog, and binding-required (412) handling</li>
-                <li><b>Quick Recap</b> &mdash; generate, regenerate, and edit a branch recap section</li>
-                <li><b>Memory scope filter</b> &mdash; filter the Memories panel by scope; auto-refreshes
-                    on branch switch</li>
-                <li><b>Discard selected</b> &mdash; discard multiple selected files at once in the
-                    Changes panel</li>
-                <li><b>"Push to Jolli" is now "Share in Jolli"</b> &mdash; the cloud-publish button is
-                    relabeled across all surfaces. Behavior is unchanged; only the label was updated</li>
-            </ul>
-
-            <h4>UI</h4>
-            <ul>
-                <li><b>Tool window redesign</b> &mdash; breadcrumb navigation and foreign-mode support</li>
-                <li><b>Summary panel redesign</b> &mdash; realigned to match the VS Code layout</li>
-                <li><b>LLM provider attribution</b> &mdash; summary footers now show which provider
-                    generated the summary</li>
-            </ul>
-
-            <h4>Fixes &amp; Improvements</h4>
-            <ul>
-                <li>Fixed Jolli API key clearing not triggering the status indicator, and not saving
-                    as <code>null</code> when cleared</li>
-                <li>Fixed SSH/HTTPS remote mismatch that split Memory Banks and created duplicate repo
-                    entries; repo identity is now canonicalized on merge</li>
-                <li>Fixed Migrate-to-Memory-Bank creating duplicate repo folders; consolidated onto the
-                    base folder name</li>
-                <li>Auto-clear stale sync-status badges in the status bar</li>
-                <li>Windows: mark the <code>.jolli</code> directory as hidden, fix path-separator drift
-                    in the storage layer, and fix the build &amp; test suite</li>
-                <li>Fixed SQLite JDBC driver loading</li>
-                <li>Fixed a stderr deadlock and refined the sync poll interval</li>
-                <li>Fixed OnboardingPanel font rendering and added an API key help tooltip</li>
-                <li>Added <code>client_version</code> to OAuth login URLs</li>
-            </ul>
-
-            <h3>0.99.0</h3>
-
-            <h4>Memory Bank</h4>
-            <ul>
-                <li><b>Memory Bank</b> &mdash; a new local storage layer that keeps human-readable
-                    Markdown summaries, plans, and notes alongside canonical JSON in a user-configurable
-                    folder. Summaries are dual-written to both the git orphan branch (system of record)
-                    and the Memory Bank folder by default</li>
-                <li><b>Memory Bank explorer</b> &mdash; browse your Memory Bank as a tree view in the
-                    tool window with commit/plan/note badges, double-click to open the formatted summary
-                    viewer. Supports file operations (New Folder, File, Import, Rename, Move, Delete) and
-                    drag-and-drop</li>
-                <li><b>Auto-migration</b> &mdash; existing orphan branch data is automatically migrated
-                    to the Memory Bank folder on plugin startup</li>
-            </ul>
-
-            <h4>AI Agent Support</h4>
-            <ul>
-                <li><b>Claude Code</b> &mdash; StopHook after each response, SessionStartHook briefing at startup</li>
-                <li><b>Gemini CLI</b> &mdash; AfterAgent hook after each agent completion</li>
-                <li><b>Codex CLI</b> &mdash; automatic filesystem discovery, no hook needed</li>
-                <li><b>OpenCode</b> &mdash; session discovery via SQLite database scan</li>
-                <li><b>Cursor IDE</b> &mdash; Composer session discovery via SQLite database scan</li>
-                <li><b>GitHub Copilot CLI &amp; Copilot Chat</b> &mdash; session discovery via filesystem scan</li>
-            </ul>
-
-            <h4>Settings &amp; Setup</h4>
-            <ul>
-                <li><b>Simplified setup flow</b> &mdash; hooks auto-install on credential save and
-                    auto-remove on credential clear; no separate Enable/Disable step</li>
-                <li><b>Onboarding screen</b> &mdash; detects existing API keys (config or
-                    <code>ANTHROPIC_API_KEY</code> env var) and skips onboarding automatically</li>
-                <li><b>Tabbed Settings dialog</b> &mdash; reorganized into five tabs: General,
-                    AI Agents, AI Summary, Sync to Jolli, and Memory Bank</li>
-                <li><b>AI Summary provider selection</b> &mdash; choose between Anthropic and Jolli
-                    as the summarization provider</li>
-                <li><b>Pause toggle</b> &mdash; temporarily disable hooks without losing configuration</li>
-            </ul>
-
-            <h4>Plugin Distribution</h4>
-            <ul>
-                <li><b>Reduced plugin size</b> &mdash; stripped unused platform natives from sqlite-jdbc
-                    (FreeBSD, Android, ARM32, RISC-V, ppc64) and deduplicated the sqlite-jdbc dependency
-                    between the plugin and hooks JAR. Plugin zip reduced from 31 MB to 7 MB</li>
-                <li><b>Quality improvements</b> &mdash; resolved JetBrains Marketplace internal API
-                    warnings, fixed binary compatibility issues across IntelliJ versions, improved UI
-                    layout and panel management, fixed encoding issues, and added Plugin Verifier to CI</li>
-            </ul>
-
-            <h3>0.97.9</h3>
-            <ul>
-                <li><b>Privacy consent notice</b> &mdash; display a privacy notice with link to privacy
-                    policy at the top of the Settings page, satisfying JetBrains Marketplace guideline
-                    2.2 for explicit user consent before data processing</li>
-            </ul>
-
-            <h3>0.97.0</h3>
-            <ul>
-                <li><b>Initial IntelliJ plugin release</b> &mdash; pure Kotlin port of the VS Code extension</li>
-                <li><b>Four-panel tool window</b>: STATUS, PLANS &amp; NOTES, CHANGES, COMMITS in a right
-                    sidebar with collapsible panels</li>
-                <li><b>AI Commit</b> &mdash; generate commit messages from staged diffs using Anthropic API</li>
-                <li><b>Squash</b> &mdash; squash selected commits with LLM-generated combined message and
-                    automatic memory merging</li>
-                <li><b>Push</b> &mdash; git push with force-push confirmation dialog</li>
-                <li><b>View Summary</b> &mdash; JCEF-based HTML viewer for commit summaries with dark/light
-                    theme support</li>
-                <li><b>Plans &amp; Notes</b> &mdash; auto-detect Claude Code plans, add custom notes
-                    (Markdown files or text snippets)</li>
-                <li><b>Hook installation</b> &mdash; pure Kotlin file I/O, no Node.js; installs git hooks
-                    and Claude Code stop hook</li>
-                <li><b>Standalone hooks JAR</b> &mdash; git hooks run as <code>jollimemory-hooks.jar</code>
-                    fat JAR outside the IDE</li>
-                <li><b>Orphan branch storage</b> &mdash; summaries stored in
-                    <code>jollimemory/summaries/v3</code> with tree-hash aliases</li>
-                <li><b>Push to Jolli Space</b> &mdash; publish summaries to team knowledge base via API</li>
-                <li><b>Create &amp; Update PR</b> &mdash; GitHub PR management via <code>gh</code> CLI
-                    with summary markers</li>
-                <li><b>Settings page</b> &mdash; Anthropic API key, model selection, Jolli API key at
-                    Settings &gt; Tools &gt; Jolli Memory</li>
-                <li><b>Compatibility</b>: IntelliJ IDEA 2024.3+ (build 243&ndash;262.*)</li>
-            </ul>
-        """.trimIndent()
+        // Source the marketplace "What's New" from CHANGELOG.md (single source of
+        // truth). Render every released section so the full history ships with each build.
+        changeNotes = provider {
+            changelog.getAll().values.joinToString("\n") { item ->
+                changelog.renderItem(
+                    item.withHeader(true).withEmptySections(false),
+                    Changelog.OutputType.HTML,
+                )
+            }
+        }
         vendor {
             name = "Jolli"
             url = "https://jolli.ai"
@@ -687,4 +538,17 @@ tasks {
             }),
         )
     }
+}
+
+// Changelog config: CHANGELOG.md is the single source of truth for the
+// marketplace change notes (rendered into patchPluginXml.changeNotes above).
+// Headers are bare "## <version>"; sections use custom group names, so we
+// disable the standard-group templating.
+changelog {
+    version = project.version.toString()
+    path = file("CHANGELOG.md").canonicalPath
+    header = provider { version.get() }
+    headerParserRegex = """(\d+\.\d+\.\d+)""".toRegex()
+    groups = emptyList()
+    keepUnreleasedSection = false
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/JolliDynamicUnloadCleaner.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/JolliDynamicUnloadCleaner.kt
@@ -1,0 +1,33 @@
+package ai.jolli.jollimemory
+
+import ai.jolli.jollimemory.core.JmLogger
+import ai.jolli.jollimemory.core.telemetry.Telemetry
+import ai.jolli.jollimemory.services.JolliAuthService
+import com.intellij.ide.plugins.DynamicPluginListener
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+
+/**
+ * Releases the plugin's **app-level (`object`-held) background resources** right
+ * before a dynamic unload, so they don't pin the plugin classloader.
+ *
+ * Project-scoped resources (the tool window, project service, panels, watchers,
+ * Swing timers, message-bus connections) are released by their own Disposable
+ * chains when the project service / tool-window content is disposed. The static
+ * singletons below have no such owner — without this hook their executor threads
+ * and listener lists keep the classloader alive after unload, which leaves
+ * `FileBasedIndexTumbler` with the file index turned off and never turned back
+ * on (the IDE then hangs in perpetual "indexing").
+ */
+class JolliDynamicUnloadCleaner : DynamicPluginListener {
+	override fun beforePluginUnload(pluginDescriptor: IdeaPluginDescriptor, isUpdate: Boolean) {
+		if (pluginDescriptor.pluginId.idString != PLUGIN_ID) return
+		JolliAuthService.shutdownForUnload()
+		Telemetry.shutdown()
+		// Stop the log writer LAST so the lines above can still be recorded.
+		JmLogger.shutdown()
+	}
+
+	private companion object {
+		const val PLUGIN_ID = "ai.jolli.jollimemory"
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/CloudSyncAction.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/CloudSyncAction.kt
@@ -94,6 +94,8 @@ class CloudSyncAction : AnAction() {
 			signInButton.isEnabled = false
 			signInButton.text = "Signing in..."
 			JolliAuthService.login(
+				// User-initiated sign-in: mint a fresh key so a revoked same-tenant key recovers.
+				forceFreshApiKey = true,
 				onSuccess = { _ ->
 					SwingUtilities.invokeLater {
 						// Popup will be stale after sign-in; close the parent popup

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/CommitAIAction.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/CommitAIAction.kt
@@ -46,7 +46,17 @@ class CommitAIAction : AnAction() {
     private data class CommitDialogResult(val action: CommitAction, val message: String)
 
     override fun actionPerformed(e: AnActionEvent) {
-        val project = e.project ?: return
+        performCommit(e.project ?: return)
+    }
+
+    /**
+     * Runs the AI commit for [project]. Exposed so callers with an explicit project
+     * (e.g. the Working Memory webview, whose JCEF data context doesn't reliably
+     * carry the project) can invoke it directly, instead of going through the
+     * action-invocation API — `ActionUtil.invokeAction`'s overloads are deprecated
+     * inconsistently across IDE versions, so calling the logic directly is stable.
+     */
+    fun performCommit(project: com.intellij.openapi.project.Project) {
         val service = project.getService(JolliMemoryService::class.java)
         val cwd = service.mainRepoRoot ?: project.basePath ?: return
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitOps.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitOps.kt
@@ -264,6 +264,80 @@ class GitOps(private val projectDir: String) {
         return result != null
     }
 
+    /** True when [ancestor] is an ancestor of (or equal to) [descendant]. */
+    fun isAncestor(ancestor: String, descendant: String): Boolean {
+        // `merge-base --is-ancestor` exits 0 when true, non-zero when false;
+        // exec() returns "" on exit 0 and null on a non-zero exit.
+        return exec("merge-base", "--is-ancestor", ancestor, descendant) != null
+    }
+
+    /**
+     * Uses git reflog to find the commit where [branch] was originally created.
+     * Returns the hash at creation, or null when the reflog has expired or is
+     * unavailable (e.g. after a fresh clone).
+     *
+     * When [requireExplicit] is true, returns null unless an explicit
+     * "branch: Created from …" entry is found. Reflog entries expire oldest-first,
+     * so once the creation entry is gone the oldest surviving entry is often the
+     * branch's own first commit — guessing it as the creation point would silently
+     * drop that commit from history. Callers feeding history decisions pass true so
+     * they degrade to a safe base instead of trusting a guess. Mirrors the VS Code
+     * bridge's findBranchCreationPoint.
+     */
+    fun findBranchCreationPoint(branch: String, requireExplicit: Boolean = false): String? {
+        // Detached HEAD has no branch reflog of its own — `reflog show HEAD` would
+        // surface HEAD's whole movement history (oldest entry = the repo's first
+        // commit), which is not a creation point. Bail rather than mislead.
+        if (branch == "HEAD") return null
+        val reflog = exec("reflog", "show", branch, "--format=%H %gs") ?: return null
+        val lines = reflog.lines().filter { it.isNotBlank() }
+        if (lines.isEmpty()) return null
+
+        // Explicit "branch: Created from ..." entry (scan from oldest).
+        for (i in lines.indices.reversed()) {
+            if (lines[i].contains("branch: Created from")) {
+                return lines[i].substringBefore(" ").takeIf { it.isNotBlank() }
+            }
+        }
+
+        // No explicit creation record. Only guess the oldest surviving entry when
+        // the caller tolerates it (see requireExplicit).
+        if (requireExplicit) return null
+        return lines.last().substringBefore(" ").takeIf { it.isNotBlank() }
+    }
+
+    /**
+     * Resolves the base commit that "own commits" on [branch] are measured from.
+     *
+     * Own commits should be counted from where the branch was actually cut, not
+     * from the mainline. A branch freshly created from a feature/release branch
+     * starts with its tip equal to that base branch's tip — comparing against main
+     * would wrongly count the base branch's shared commits (and a brand-new
+     * branch's inherited history) as this branch's own work.
+     *
+     * Prefers the branch's reflog creation point when it sits downstream of (is a
+     * descendant of) the mainline merge-base. Falls back to [mergeBaseMain] when
+     * the creation point is unavailable (reflog expired), equals it (cut directly
+     * from main), or is no longer an ancestor of HEAD (stale after reset --hard /
+     * rebase --onto). When the mainline ref is unresolvable ([mergeBaseMain] is
+     * empty) the validated creation point is used directly. Mirrors the VS Code
+     * bridge's resolveOwnCommitsBase.
+     */
+    fun resolveOwnCommitsBase(branch: String, mergeBaseMain: String): String {
+        val creationPoint = findBranchCreationPoint(branch, requireExplicit = true) ?: return mergeBaseMain
+        // Cut directly from main: mergeBaseMain is already an ancestor of HEAD.
+        if (creationPoint == mergeBaseMain) return mergeBaseMain
+        // A stale creation point (after reset/rebase --onto) is no longer behind
+        // HEAD — `<stalePoint>..HEAD` would be meaningless. Fall back to mainline.
+        if (!isAncestor(creationPoint, "HEAD")) return mergeBaseMain
+        // Mainline unresolvable (e.g. master/trunk default with no origin): trust
+        // the validated fork point directly.
+        if (mergeBaseMain.isEmpty()) return creationPoint
+        // Adopt the creation point only when downstream of the mainline merge-base
+        // (the "cut from release/develop" case).
+        return if (isAncestor(mergeBaseMain, creationPoint)) creationPoint else mergeBaseMain
+    }
+
     /** Resolve the main worktree root (handles worktrees). */
     fun resolveMainWorktreeRoot(): String? {
         val gitFile = File(projectDir, ".git")

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitOps.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitOps.kt
@@ -207,9 +207,15 @@ class GitOps(private val projectDir: String) {
         return exec("rev-parse", "HEAD")
     }
 
-    /** Get git status in porcelain format (preserves leading spaces in status codes). */
+    /**
+     * Get git status in NUL-separated porcelain format (preserves leading spaces in
+     * status codes). `-uall` lists every file inside a freshly created directory
+     * individually instead of collapsing them into one `?? dir/` row; `-z` makes
+     * entries NUL-separated so paths with spaces and rename pairs parse unambiguously.
+     * Mirrors the VS Code bridge's `listFiles` flags.
+     */
     fun getStatus(): String? {
-        return exec("status", "--porcelain=v1", trim = false)
+        return exec("status", "-z", "--porcelain=v1", "-uall", trim = false)
     }
 
     /**

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt
@@ -117,6 +117,12 @@ class SummaryReader(private val projectDir: String, private val git: GitOps) {
         return git.readBranchFile(ORPHAN_BRANCH, "summaries/$commitHash.json")
     }
 
+    /** Reads an archived plan body (`plans/<slug>.md`) from the orphan branch. */
+    fun readPlanBody(slug: String): String? = git.readBranchFile(ORPHAN_BRANCH, "plans/$slug.md")
+
+    /** Reads an archived markdown-note body (`notes/<id>.md`) from the orphan branch. */
+    fun readNoteBody(id: String): String? = git.readBranchFile(ORPHAN_BRANCH, "notes/$id.md")
+
     /**
      * Reads the committed AI conversations for a commit. Looks up the
      * summary's `transcripts` array for the real transcript IDs (UUIDs in v5,
@@ -138,8 +144,56 @@ class SummaryReader(private val projectDir: String, private val git: GitOps) {
         return parseConversations(json)
     }
 
+    /**
+     * Renders a committed conversation (matched by [sessionId]) from the stored
+     * transcript JSON into a read-only markdown transcript — used to display a
+     * conversation whose original live file is gone. Returns null if not found.
+     */
+    fun renderCommittedConversationMarkdown(commitHash: String, sessionId: String, summary: CommitSummary? = null): String? {
+        val resolved = summary ?: getSummary(commitHash)
+        val ids = resolved?.transcripts
+        val jsons = if (!ids.isNullOrEmpty()) {
+            ids.map { git.readBranchFile(ORPHAN_BRANCH, "transcripts/$it.json") }
+        } else {
+            listOf(git.readBranchFile(ORPHAN_BRANCH, "transcripts/$commitHash.json"))
+        }
+        for (json in jsons) {
+            val md = sessionToMarkdown(json, sessionId)
+            if (md != null) return md
+        }
+        return null
+    }
+
     companion object {
         const val ORPHAN_BRANCH = JmLogger.ORPHAN_BRANCH
+
+        /** Renders the matching session's entries from a stored transcript JSON as markdown. */
+        private fun sessionToMarkdown(json: String?, sessionId: String): String? {
+            if (json.isNullOrBlank()) return null
+            return try {
+                val obj = JsonParser.parseString(json).asJsonObject
+                val sessions = obj.getAsJsonArray("sessions") ?: return null
+                val session = sessions.map { it.asJsonObject }.firstOrNull {
+                    (it.get("sessionId")?.takeIf { e -> !e.isJsonNull }?.asString ?: "") == sessionId
+                } ?: sessions.firstOrNull()?.asJsonObject ?: return null
+                val entries = session.getAsJsonArray("entries") ?: return null
+                val sb = StringBuilder()
+                for (el in entries) {
+                    val e = el.asJsonObject
+                    val role = e.get("role")?.takeIf { !it.isJsonNull }?.asString ?: "?"
+                    val content = e.get("content")?.takeIf { !it.isJsonNull }?.asString ?: ""
+                    val who = when (role.lowercase()) {
+                        "human", "user" -> "User"
+                        "assistant" -> "Assistant"
+                        else -> role.replaceFirstChar { it.uppercase() }
+                    }
+                    sb.append("### ").append(who).append("\n\n").append(content.trim()).append("\n\n---\n\n")
+                }
+                sb.toString().ifBlank { null }
+            } catch (_: Exception) {
+                null
+            }
+        }
 
         /**
          * Parses a stored `transcripts/<hash>.json` body (a [StoredTranscript]:
@@ -229,4 +283,12 @@ data class ConversationBrief(
     val sessionId: String = "",
     /** Original transcript path on disk; null when not recorded. */
     val transcriptPath: String? = null,
+    /**
+     * Commit hash whose stored transcript actually holds this conversation. Null
+     * means "the commit being displayed". It differs from the displayed hash only
+     * for squashed memories whose transcripts live on a child commit, not the
+     * squashed parent — without it, opening the stored transcript would look under
+     * the parent hash (which has none) and fail. See [CommitsPanel.gatherConversations].
+     */
+    val sourceCommitHash: String? = null,
 )

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/JmLogger.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/JmLogger.kt
@@ -33,13 +33,31 @@ object JmLogger {
     private var writerRunning = false
     private val writerLock = Any()
 
+    @Volatile
+    private var writerThread: Thread? = null
+
+    @Volatile
+    private var stopped = false
+
+    /**
+     * Stops the writer thread for plugin unload. This is an `object`, so the
+     * daemon writer thread would otherwise pin the plugin classloader until its
+     * idle timeout. Interrupting it drains the queue and exits immediately; the
+     * [stopped] guard prevents a late log call from respawning (and re-pinning) it.
+     */
+    fun shutdown() {
+        stopped = true
+        writerThread?.interrupt()
+        writerThread = null
+    }
+
     /** Ensures a single daemon writer thread is active. Starts one if needed. */
     private fun ensureWriterThread() {
-        if (writerRunning) return
+        if (stopped || writerRunning) return
         synchronized(writerLock) {
-            if (writerRunning) return
+            if (stopped || writerRunning) return
             writerRunning = true
-            Thread({
+            writerThread = Thread({
                 try {
                     while (true) {
                         // Poll with timeout so the thread exits when idle (prevents thread-leak false positives)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SessionTracker.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SessionTracker.kt
@@ -201,11 +201,60 @@ object SessionTracker {
                 }
             }
         }
-        return try {
+        val base = try {
             gson.fromJson(target.readText(Charsets.UTF_8), JolliMemoryConfig::class.java)
         } catch (_: Exception) {
-            JolliMemoryConfig()
+            null
+        } ?: JolliMemoryConfig()
+
+        // Credentials (jolliApiKey / authToken) are account-level and shared across all
+        // surfaces (CLI / VS Code / IntelliJ) via the legacy config.json — the source of
+        // truth. IntelliJ keeps its own settings in config-intellij.json but overlays the
+        // shared credentials on read so a re-login on any surface is picked up here (no
+        // stale-key drift). Falls back to this file's own values when config.json is absent.
+        val (sharedKey, sharedAuth) = readSharedCredentials(dir)
+        return base.copy(
+            jolliApiKey = sharedKey ?: base.jolliApiKey,
+            authToken = sharedAuth ?: base.authToken,
+        )
+    }
+
+    /** Reads jolliApiKey/authToken from the shared config.json (or null/null if absent). */
+    private fun readSharedCredentials(dir: String): Pair<String?, String?> {
+        val shared = File(dir, LEGACY_CONFIG_FILE)
+        if (!shared.exists()) return null to null
+        return try {
+            val obj = com.google.gson.JsonParser.parseString(shared.readText(Charsets.UTF_8)).asJsonObject
+            fun str(k: String) = obj.get(k)?.takeIf { !it.isJsonNull }?.asString?.takeIf { it.isNotBlank() }
+            str("jolliApiKey") to str("authToken")
+        } catch (_: Exception) {
+            null to null
         }
+    }
+
+    /**
+     * Merges jolliApiKey/authToken into the shared config.json at the JSON level so a
+     * login/refresh on IntelliJ propagates to CLI / VS Code — preserving every other
+     * field (we never deserialize-then-overwrite, which would drop fields this surface
+     * doesn't model and clobber the other surfaces' settings). A null value clears the
+     * field (sign-out), which all save paths only produce intentionally because they
+     * load-first (carrying the shared credential forward).
+     */
+    private fun writeSharedCredentials(dir: String, jolliApiKey: String?, authToken: String?) {
+        val shared = File(dir, LEGACY_CONFIG_FILE)
+        val obj = try {
+            if (shared.exists()) {
+                com.google.gson.JsonParser.parseString(shared.readText(Charsets.UTF_8)).asJsonObject
+            } else {
+                com.google.gson.JsonObject()
+            }
+        } catch (_: Exception) {
+            com.google.gson.JsonObject()
+        }
+        if (jolliApiKey != null) obj.addProperty("jolliApiKey", jolliApiKey) else obj.remove("jolliApiKey")
+        if (authToken != null) obj.addProperty("authToken", authToken) else obj.remove("authToken")
+        File(dir).mkdirs()
+        atomicWrite(shared, gson.toJson(obj))
     }
 
     fun saveConfig(update: JolliMemoryConfig, cwd: String? = null) {
@@ -230,6 +279,7 @@ object SessionTracker {
             storageMode = update.storageMode ?: existing.storageMode,
         )
         atomicWrite(File(dir, CONFIG_FILE), gson.toJson(merged))
+        writeSharedCredentials(dir, merged.jolliApiKey, merged.authToken)
         log.info("Config saved")
     }
 
@@ -240,6 +290,7 @@ object SessionTracker {
     fun saveConfigToDir(config: JolliMemoryConfig, dir: String) {
         File(dir).mkdirs()
         atomicWrite(File(dir, CONFIG_FILE), gson.toJson(config))
+        writeSharedCredentials(dir, config.jolliApiKey, config.authToken)
         log.info("Config saved to %s", dir)
     }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SummaryStore.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SummaryStore.kt
@@ -329,6 +329,13 @@ class SummaryStore(private val cwd: String, private val git: GitOps, private val
         log.info("Stored %d plan file(s): %s", files.size, commitMessage)
     }
 
+    /** Batch write note files (`notes/<id>.md`) to storage — dual-writes like plans. */
+    fun storeNoteFiles(files: List<FileWrite>, commitMessage: String) {
+        if (files.isEmpty()) return
+        storage.writeFiles(files, commitMessage)
+        log.info("Stored %d note file(s): %s", files.size, commitMessage)
+    }
+
     /** Reads a plan file from storage. */
     fun readPlanFromBranch(slug: String): String? {
         return storage.readFile("plans/$slug.md")

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/plans/ClaudePlanScanner.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/plans/ClaudePlanScanner.kt
@@ -1,0 +1,97 @@
+package ai.jolli.jollimemory.core.plans
+
+import com.google.gson.Gson
+import java.io.File
+
+/** Result of scanning a transcript for plan signals. */
+data class PlanScanResult(
+    val slugs: Set<String>,
+    val externalPlans: Set<String>,
+    val totalLines: Int,
+)
+
+/**
+ * ClaudePlanScanner — Kotlin port of ClaudePlanScanner.ts.
+ *
+ * Reads a Claude Code transcript (JSONL) for two plan signal classes:
+ *   1. Plan mode: a `"slug":"xxx"` field → canonical `~/.claude/plans/<slug>`.
+ *   2. Write/Edit tool_use targeting a `.md` path → `~/.claude/plans/` paths key
+ *      by slug; every other `.md` is collected as an UNFILTERED external path
+ *      (the `isExternalPlanCandidate` policy lives in the driver so it is shared).
+ */
+object ClaudePlanScanner {
+
+    /** Regex to extract slug from plan-mode transcript lines: "slug":"xxx" */
+    private val SLUG_REGEX = Regex("\"slug\":\"([^\"]+)\"")
+
+    /** Regex to detect Write/Edit tool calls */
+    private val WRITE_EDIT_REGEX = Regex("\"name\":\"(?:Write|Edit)\"")
+
+    /**
+     * Regex to extract slug from file_path values targeting ~/.claude/plans/.
+     * Uses [/\\]{1,2} to handle both raw paths (/) and JSON-escaped Windows paths (\\).
+     */
+    private val PLANS_PATH_SLUG_REGEX = Regex("[/\\\\]{1,2}\\.claude[/\\\\]{1,2}plans[/\\\\]{1,2}([^/\\\\.]+)\\.md")
+
+    /**
+     * Fallback regex: matches any Write/Edit tool_use file_path ending in .md.
+     * Runs only when PLANS_PATH_SLUG_REGEX misses, so ~/.claude/plans/ stays
+     * handled by the slug-keyed code path.
+     */
+    private val ANY_MD_PATH_REGEX = Regex("\"file_path\":\"([^\"]+\\.md)\"")
+
+    private val gson = Gson()
+
+    /**
+     * Scans [transcriptPath] from [fromLine] (exclusive) up to [toLine] (inclusive,
+     * default EOF), collecting plan-mode slugs and external `.md` paths. Returns the
+     * furthest line number reached (so the caller can advance the discovery cursor).
+     */
+    fun scan(transcriptPath: String, fromLine: Int, toLine: Int = Int.MAX_VALUE): PlanScanResult {
+        val slugs = mutableSetOf<String>()
+        val externalPlans = mutableSetOf<String>()
+        var lineNumber = 0
+
+        try {
+            File(transcriptPath).bufferedReader(Charsets.UTF_8).useLines { lines ->
+                for (line in lines) {
+                    lineNumber++
+                    if (lineNumber <= fromLine || lineNumber > toLine) continue
+
+                    // Detect plan-mode slug: "slug":"xxx"
+                    if (line.contains("\"slug\":\"")) {
+                        SLUG_REGEX.find(line)?.groupValues?.get(1)?.let { if (it.isNotEmpty()) slugs.add(it) }
+                    }
+
+                    // Detect Write/Edit tool calls. First try the slug-keyed
+                    // ~/.claude/plans/ path; only fall back to the generic .md regex
+                    // when that misses, so existing behavior is preserved.
+                    if (line.contains("\"type\":\"tool_use\"") && WRITE_EDIT_REGEX.containsMatchIn(line)) {
+                        val pathSlug = PLANS_PATH_SLUG_REGEX.find(line)?.groupValues?.get(1)
+                        if (!pathSlug.isNullOrEmpty()) {
+                            slugs.add(pathSlug)
+                        } else {
+                            val raw = ANY_MD_PATH_REGEX.find(line)?.groupValues?.get(1)
+                            if (raw != null) {
+                                // JSONL: the captured substring lives inside a JSON string
+                                // literal, so `\\`, `\"`, `\n`, `\uXXXX` etc. are all possible.
+                                // Decode via Gson to handle every escape uniformly — a simple
+                                // replace(\\\\ → \\) misses unicode-escaped filenames.
+                                val absPath = try {
+                                    gson.fromJson("\"$raw\"", String::class.java)
+                                } catch (_: Exception) {
+                                    null
+                                }
+                                if (absPath != null) externalPlans.add(absPath)
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (_: Exception) {
+            // Defensive: rare stream failure — return what we have so far.
+        }
+
+        return PlanScanResult(slugs, externalPlans, lineNumber)
+    }
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/plans/TranscriptPlanDiscovery.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/plans/TranscriptPlanDiscovery.kt
@@ -1,0 +1,255 @@
+package ai.jolli.jollimemory.core.plans
+
+import ai.jolli.jollimemory.core.JmLogger
+import ai.jolli.jollimemory.core.PlanEntry
+import ai.jolli.jollimemory.core.SessionTracker
+import ai.jolli.jollimemory.core.TranscriptSource
+import ai.jolli.jollimemory.core.normalizePathForMatch
+import ai.jolli.jollimemory.core.references.TranscriptReferenceDiscovery
+import ai.jolli.jollimemory.services.PlanService
+import java.io.File
+import java.security.MessageDigest
+import java.time.Instant
+
+/**
+ * TranscriptPlanDiscovery — Kotlin port of TranscriptPlanDiscovery.ts.
+ *
+ * `scanPlansFrom` is a pure scan + upsert: it runs [ClaudePlanScanner], applies the
+ * shared external-plan exclusion policy, then upserts each surviving plan into
+ * plans.json (archive-guard revive, note dedup, resolveUniqueSlug, concurrent
+ * per-slug merge). It does NOT own the discovery cursor — the caller (StopHook)
+ * persists the merged line target.
+ *
+ * This replaces the old directory-scan (`PlanService.autoRegisterNewPlans`) so that,
+ * like the CLI/VS Code, a plan enters the registry only when the user actually
+ * created/edited it in a tracked session — never by enumerating ~/.claude/plans/.
+ */
+object TranscriptPlanDiscovery {
+
+    private val log = JmLogger.create("PlanDiscovery")
+
+    private val PLANS_DIR = File(System.getProperty("user.home"), ".claude/plans")
+
+    /** Path segments excluded from external plan detection (case-insensitive). */
+    private val EXTERNAL_EXCLUDE_SEGMENTS = listOf(
+        Regex("[/\\\\]\\.claude[/\\\\]", RegexOption.IGNORE_CASE),
+        Regex("[/\\\\]node_modules[/\\\\]", RegexOption.IGNORE_CASE),
+        Regex("[/\\\\]\\.github[/\\\\]", RegexOption.IGNORE_CASE),
+    )
+
+    /** Basenames excluded — stored lowercase, compared after lowercasing input. */
+    private val EXTERNAL_EXCLUDE_BASENAMES = setOf(
+        "claude.md",
+        "claude.local.md",
+        "agents.md",
+        "readme.md",
+        "changelog.md",
+        "contributing.md",
+        "license.md",
+        "security.md",
+        "code_of_conduct.md",
+    )
+
+    /**
+     * Scans the transcript for plan file references from [fromLine] (exclusive) up to
+     * EOF and upserts them into plans.json. Returns the furthest line scanned.
+     *
+     * Covers three scenarios (Claude): plan-mode `"slug"`, direct write to
+     * ~/.claude/plans/, and external `.md` files not excluded by
+     * [isExternalPlanCandidate]. `source` is accepted for parity with the CLI driver;
+     * only Claude transcripts are scanned today.
+     */
+    fun scanPlansFrom(transcriptPath: String, fromLine: Int, cwd: String, source: TranscriptSource): Int {
+        val scan = ClaudePlanScanner.scan(transcriptPath, fromLine)
+
+        // Apply the shared external-plan exclusion policy here (not in the scanner).
+        val filteredExternal = scan.externalPlans.filter { isExternalPlanCandidate(it) }.toSet()
+
+        if (scan.slugs.isEmpty() && filteredExternal.isEmpty()) {
+            return scan.totalLines
+        }
+
+        // Load registry right before writing to minimize the race window with the worker.
+        val registry = SessionTracker.loadPlansRegistry(cwd)
+        val plans = registry.plans.toMutableMap()
+        val now = Instant.now().toString()
+        // Stamp the branch on newly-created rows so the panel can branch-scope CONTEXT.
+        // Omit on an "unknown" git lookup so the row stays branch-less (visible everywhere).
+        val discoveredBranch = TranscriptReferenceDiscovery.getCurrentBranchSafe(cwd)
+        val branchField: String? = if (discoveredBranch.isNotEmpty() && discoveredBranch != "unknown") discoveredBranch else null
+        var changed = false
+        val touchedSlugs = mutableSetOf<String>()
+
+        // Paths already owned by a markdown note — never also register them as a plan
+        // (would shadow the note, double-archive, and surface the same file twice).
+        val noteSourcePaths = mutableSetOf<String>()
+        for (note in (registry.notes ?: emptyMap()).values) {
+            note.sourcePath?.let { if (it.isNotBlank()) noteSourcePaths.add(normalizePath(it)) }
+        }
+
+        fun upsertEntry(slug: String, planFile: File) {
+            val existing = plans[slug]
+            when {
+                existing?.contentHashAtCommit != null -> {
+                    // Archived guard: revive when the source file diverged from the guard hash.
+                    val currentHash = sha256(planFile.readText(Charsets.UTF_8))
+                    if (currentHash != existing.contentHashAtCommit) {
+                        plans[slug] = PlanEntry(
+                            slug = slug,
+                            title = titleOf(planFile),
+                            sourcePath = planFile.absolutePath,
+                            addedAt = now,
+                            updatedAt = now,
+                            branch = branchField,
+                            commitHash = null,
+                        )
+                        changed = true
+                        touchedSlugs.add(slug)
+                        log.info("Plan discovery: archived plan %s file changed — creating new entry", slug)
+                    }
+                }
+                existing != null -> {
+                    if (existing.commitHash == null) {
+                        plans[slug] = existing.copy(updatedAt = now)
+                        changed = true
+                        touchedSlugs.add(slug)
+                    }
+                }
+                else -> {
+                    plans[slug] = PlanEntry(
+                        slug = slug,
+                        title = titleOf(planFile),
+                        sourcePath = planFile.absolutePath,
+                        addedAt = now,
+                        updatedAt = now,
+                        branch = branchField,
+                        commitHash = null,
+                    )
+                    changed = true
+                    touchedSlugs.add(slug)
+                }
+            }
+        }
+
+        // 1. Canonical ~/.claude/plans/ slugs — routed through resolveUniqueSlug so an
+        //    external entry registered first under the same slug isn't overwritten.
+        for (rawSlug in scan.slugs) {
+            val planFile = File(PLANS_DIR, "$rawSlug.md")
+            if (!planFile.exists()) continue
+            if (noteSourcePaths.contains(normalizePath(planFile.absolutePath))) {
+                log.info("Plan discovery: %s already a note — skipping plan registration", planFile.absolutePath)
+                continue
+            }
+            val slug = resolveUniqueSlug(rawSlug, planFile.absolutePath, plans)
+            upsertEntry(slug, planFile)
+        }
+
+        // 2. External .md paths — already filtered to candidates. existsSync is the ONLY
+        //    success gate, intentionally: scanners read the write REQUEST, not the result.
+        for (absPath in filteredExternal) {
+            val file = File(absPath)
+            if (!file.exists()) continue
+            if (noteSourcePaths.contains(normalizePath(absPath))) {
+                log.info("Plan discovery: %s already a note — skipping plan registration", absPath)
+                continue
+            }
+            val baseSlug = basenameNoExt(absPath, ".md")
+            val slug = resolveUniqueSlug(baseSlug, absPath, plans)
+            upsertEntry(slug, file)
+        }
+
+        if (changed) {
+            // Re-read under lock and merge per-slug onto the freshest snapshot so a
+            // sibling writer (PostCommitHook archival, a parallel StopHook, an
+            // extension delete) between our load and save is not clobbered.
+            val locked = SessionTracker.acquireLock(cwd)
+            if (!locked) {
+                log.warn("scanPlansFrom: could not acquire lock — writing without lock")
+            }
+            try {
+                val freshRegistry = SessionTracker.loadPlansRegistry(cwd)
+                val merged = freshRegistry.plans.toMutableMap()
+                for (slug in touchedSlugs) {
+                    val ours = plans[slug] ?: continue
+                    val fresh = freshRegistry.plans[slug]
+                    val freshCommitHash = fresh?.commitHash
+                    val existedAtLoad = registry.plans.containsKey(slug)
+                    val originalCommitHash = registry.plans[slug]?.commitHash
+                    when {
+                        // A sibling (typically the worker) transitioned this slug to
+                        // archived (set commitHash + contentHashAtCommit) — take it whole.
+                        fresh != null && freshCommitHash != null && freshCommitHash != originalCommitHash -> {
+                            merged[slug] = fresh
+                        }
+                        // Write our version unless it was concurrently hard-deleted.
+                        fresh != null || !existedAtLoad -> {
+                            merged[slug] = ours
+                        }
+                        // else: fresh == null && existedAtLoad → concurrent hard delete;
+                        // leave `merged` without it so the explicit delete wins.
+                    }
+                }
+                // Preserve notes/references written by sibling pipelines between load and save.
+                SessionTracker.savePlansRegistry(freshRegistry.copy(version = 1, plans = merged), cwd)
+            } finally {
+                if (locked) SessionTracker.releaseLock(cwd)
+            }
+            log.info(
+                "Plan discovery: upserted %d slug(s) + %d external path(s) into plans.json",
+                scan.slugs.size,
+                filteredExternal.size,
+            )
+        }
+
+        return scan.totalLines
+    }
+
+    /**
+     * Whether an external .md path is a plan candidate. Excludes any path under
+     * `.claude/`, `node_modules/`, or `.github/`, plus common non-plan filenames.
+     */
+    private fun isExternalPlanCandidate(absPath: String): Boolean {
+        if (EXTERNAL_EXCLUDE_SEGMENTS.any { it.containsMatchIn(absPath) }) return false
+        val base = absPath.split('/', '\\').last().lowercase()
+        return !EXTERNAL_EXCLUDE_BASENAMES.contains(base)
+    }
+
+    /** Platform-agnostic basename with the given extension stripped (case-insensitive). */
+    private fun basenameNoExt(absPath: String, ext: String): String {
+        val last = absPath.split('/', '\\').last()
+        return if (last.lowercase().endsWith(ext.lowercase())) last.dropLast(ext.length) else last
+    }
+
+    /**
+     * Returns a unique registry slug for [absPath]:
+     *   1. Reverse-lookup: a slug whose sourcePath normalize-equals absPath (idempotent).
+     *   2. baseSlug free → baseSlug.
+     *   3. baseSlug taken by a different file → `<baseSlug>-<sha256(normPath)[0:8]>`.
+     */
+    private fun resolveUniqueSlug(baseSlug: String, absPath: String, plans: Map<String, PlanEntry>): String {
+        val targetNorm = normalizePath(absPath)
+        for ((slug, entry) in plans) {
+            if (normalizePath(entry.sourcePath) == targetNorm) return slug
+        }
+        if (!plans.containsKey(baseSlug)) return baseSlug
+        return "$baseSlug-${sha256(targetNorm).take(8)}"
+    }
+
+    /** First `# ` heading of the plan file, falling back to the basename. */
+    private fun titleOf(planFile: File): String {
+        val content = try {
+            planFile.readText(Charsets.UTF_8)
+        } catch (_: Exception) {
+            return planFile.name
+        }
+        val match = Regex("^#\\s+(.+)", RegexOption.MULTILINE).find(content)
+        return match?.groupValues?.get(1)?.trim() ?: planFile.name
+    }
+
+    private fun normalizePath(p: String): String = normalizePathForMatch(p)
+
+    private fun sha256(s: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        return digest.digest(s.toByteArray(Charsets.UTF_8)).joinToString("") { "%02x".format(it) }
+    }
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/references/ReferenceTypes.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/references/ReferenceTypes.kt
@@ -65,6 +65,15 @@ data class ReferenceEntry(
 	val addedAt: String,
 	val updatedAt: String,
 	val sourceToolName: String,
+	/**
+	 * Branch the reference was last captured on. Nullable/blank for legacy rows
+	 * written before branch-scoping; those are treated as visible on every branch
+	 * (same graceful fallback as [ai.jolli.jollimemory.core.PlanEntry.branch] /
+	 * [ai.jolli.jollimemory.core.NoteEntry.branch]). Stamped by
+	 * `TranscriptReferenceDiscovery.upsertReferenceEntry` and filtered at the
+	 * CONTEXT / Working Memory display sites + the post-commit archive selection.
+	 */
+	val branch: String? = null,
 )
 
 /**

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/references/TranscriptReferenceDiscovery.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/references/TranscriptReferenceDiscovery.kt
@@ -110,6 +110,9 @@ object TranscriptReferenceDiscovery {
 					sourcePath = result.sourcePath,
 					sourceToolName = ref.toolName,
 					updatedAt = now,
+					// Re-stamp the branch: a reference re-surfaced on a new branch
+					// follows that branch (matches plan/note upsert semantics).
+					branch = branch,
 				)
 			} else {
 				ReferenceEntry(
@@ -121,6 +124,7 @@ object TranscriptReferenceDiscovery {
 					addedAt = now,
 					updatedAt = now,
 					sourceToolName = ref.toolName,
+					branch = branch,
 				)
 			}
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/references/TranscriptReferenceDiscovery.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/references/TranscriptReferenceDiscovery.kt
@@ -43,13 +43,18 @@ object TranscriptReferenceDiscovery {
 			return result.lastLineNumberScanned
 		}
 
-		val branch = getCurrentBranchSafe(cwd)
-		log.debug("scanReferencesFrom: branch=%s, upserting %d ref(s)", branch, result.references.size)
+		// Stamp the branch on newly-created rows so the panel can branch-scope.
+		// Omit on an "unknown" git lookup (a transient rev-parse failure) so the row
+		// stays branch-less — writing the literal "unknown" would silently exclude
+		// the reference from every branch's summary prompt. Mirrors the plan path.
+		val discoveredBranch = getCurrentBranchSafe(cwd)
+		val branchField: String? = if (discoveredBranch.isNotEmpty() && discoveredBranch != "unknown") discoveredBranch else null
+		log.debug("scanReferencesFrom: branch=%s, upserting %d ref(s)", branchField ?: "(none)", result.references.size)
 		val upserted = mutableListOf<String>()
 		val failed = mutableListOf<String>()
 		for (ref in result.references) {
 			try {
-				upsertReferenceEntry(ref, cwd, branch)
+				upsertReferenceEntry(ref, cwd, branchField)
 				upserted.add(ref.mapKey)
 			} catch (err: Exception) {
 				log.warn(
@@ -88,15 +93,19 @@ object TranscriptReferenceDiscovery {
 	/**
 	 * Upsert a reference entry: write markdown + update plans.json.references.
 	 */
-	private fun upsertReferenceEntry(ref: Reference, cwd: String, branch: String) {
+	private fun upsertReferenceEntry(ref: Reference, cwd: String, branch: String?) {
 		log.debug("upsertReferenceEntry: writing markdown for %s (title=%s)", ref.mapKey, ref.title)
 		val result = ReferenceStore.writeReferenceMarkdown(ref, cwd)
 		log.debug("upsertReferenceEntry: markdown written to %s", result.sourcePath)
 		val mapKey = ref.mapKey
 		val now = java.time.Instant.now().toString()
 
-		// Load → merge → save under lock
-		if (!SessionTracker.acquireLock(cwd)) {
+		// Load → merge → save under lock. Only release the lock if we actually hold
+		// it — releaseLock is an unconditional file delete, so releasing a lock we
+		// never acquired would wipe the holder's lock (the PostCommitHook worker or a
+		// parallel StopHook) and let a second writer interleave plans.json writes.
+		val locked = SessionTracker.acquireLock(cwd)
+		if (!locked) {
 			log.warn("upsertReferenceEntry: could not acquire lock for %s — writing without lock", mapKey)
 		}
 		try {
@@ -110,9 +119,11 @@ object TranscriptReferenceDiscovery {
 					sourcePath = result.sourcePath,
 					sourceToolName = ref.toolName,
 					updatedAt = now,
-					// Re-stamp the branch: a reference re-surfaced on a new branch
-					// follows that branch (matches plan/note upsert semantics).
-					branch = branch,
+					// Re-stamp the branch only on a known git lookup: a reference
+					// re-surfaced on a new branch follows it (matches plan/note
+					// upsert). On an "unknown" lookup keep the existing branch rather
+					// than clobber a real value with a summary-excluding sentinel.
+					branch = branch ?: existing.branch,
 				)
 			} else {
 				ReferenceEntry(
@@ -136,7 +147,7 @@ object TranscriptReferenceDiscovery {
 			log.debug("upsertReferenceEntry: saved plans.json with %d reference(s)", freshRefs.size)
 			log.info("upsertReferenceEntry: %s (%s)", mapKey, if (existing == null) "new" else "updated")
 		} finally {
-			SessionTracker.releaseLock(cwd)
+			if (locked) SessionTracker.releaseLock(cwd)
 		}
 	}
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
@@ -37,6 +37,18 @@ object TelemetryEvents {
             "error_occurred" to "A structured error code was raised.",
             "queue_drained" to "QueueWorker finished a drain.",
             "sync_completed" to "A memory-bank sync round finished.",
+            // ── IDE tool-window UI / engagement (IntelliJ, VS Code) ──
+            "toolwindow_opened" to "The memory tool window was opened.",
+            "view_switched" to "Tool window view switched (current/bank/knowledge).",
+            "memory_committed" to "User committed a memory via the Commit button.",
+            "memory_expanded" to "A committed memory's details were expanded.",
+            "memory_item_opened" to "An item inside a memory was opened (conversation/file/context/shipped).",
+            "session_resumed" to "A conversation session was resumed in a terminal.",
+            "recall_prompt_copied" to "A recall prompt was copied to the clipboard.",
+            "memory_pinned" to "An item was pinned.",
+            "memory_unpinned" to "An item was unpinned.",
+            "key_rejected" to "The server rejected the API key (401/403).",
+            "reauth_completed" to "Re-authentication after a rejected key finished.",
         )
 
     /** `object_action`: lowercase snake_case with at least two words. */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
@@ -160,6 +160,14 @@ object PostCommitHook {
             log.info("Step 4: Loading sessions")
             val allSessions = SessionTracker.loadAllSessions(cwd).toMutableList()
 
+            // On-demand discovery: Codex (filesystem scan, no hook). Codex has no
+            // Stop/Session hook, so without this scan a Codex-only memory finds no
+            // sessions and is silently skipped at commit time. Mirrors the CLI worker
+            // and the sidebar aggregator, which both discover Codex this way.
+            if (config.codexEnabled != false && CodexSessionDiscoverer.isCodexInstalled()) {
+                allSessions.addAll(CodexSessionDiscoverer.discoverSessions())
+            }
+
             // On-demand discovery: OpenCode (SQLite-backed, no hook)
             if (config.openCodeEnabled != false && OpenCodeSupport.isOpenCodeInstalled()) {
                 allSessions.addAll(OpenCodeSupport.discoverSessions(cwd).sessions)
@@ -417,6 +425,50 @@ object PostCommitHook {
             val branch = git.getCurrentBranch() ?: "unknown"
             val commitType = detectCommitType()
 
+            // 8d. Detect uncommitted notes on this branch, archive, and attach to the summary.
+            //     Mirrors the plan path (8b): the note body is written through the StorageProvider
+            //     (so it dual-writes to the orphan branch AND the Memory Bank folder), a
+            //     NoteReference goes into the summary so the committed memory shows it, and the
+            //     registry row is later stamped committed (finalizeNoteArchive) so it clears from
+            //     the CONTEXT panel. Excluded notes and notes from other branches stay pending.
+            val noteRefs = mutableListOf<NoteReference>()
+            val noteFilesToStore = mutableListOf<FileWrite>()
+            val noteGuards = mutableListOf<Pair<String, String>>() // id -> contentHashAtCommit
+            val snippetFilesToDelete = mutableListOf<String>()
+            run {
+                val noteNow = Instant.now().toString()
+                val shortHash = commitInfo.hash.take(8)
+                val uncommittedNotes = detectUncommittedNotes(cwd, branch, exclusions.notes)
+                if (uncommittedNotes.isNotEmpty()) {
+                    log.info("Detected %d uncommitted note(s): %s", uncommittedNotes.size, uncommittedNotes.keys.joinToString(", "))
+                    for ((id, entry) in uncommittedNotes) {
+                        try {
+                            val sourcePath = entry.sourcePath
+                            if (sourcePath == null || !File(sourcePath).exists()) {
+                                log.warn("Note archive: source file missing for %s — skipping", id)
+                                continue
+                            }
+                            val content = File(sourcePath).readText(Charsets.UTF_8)
+                            val newId = "$id-$shortHash"
+                            noteFilesToStore.add(FileWrite("notes/$newId.md", content))
+                            noteRefs.add(NoteReference(
+                                id = newId,
+                                title = entry.title,
+                                format = entry.format,
+                                content = if (entry.format == NoteFormat.snippet) content else null,
+                                addedAt = entry.addedAt,
+                                updatedAt = noteNow,
+                            ))
+                            noteGuards.add(id to sha256Hex(content))
+                            if (entry.format == NoteFormat.snippet) snippetFilesToDelete.add(sourcePath)
+                            log.info("Note snapshot captured: %s → %s", id, newId)
+                        } catch (e: Exception) {
+                            log.warn("Note archive failed for %s (non-fatal, skipping): %s", id, e.message)
+                        }
+                    }
+                }
+            }
+
             // Build stored sessions first so we can aggregate this commit's
             // coding-session token usage from their per-message usage.
             val storedSessions = sessionTranscripts.map { st ->
@@ -445,6 +497,7 @@ object PostCommitHook {
                 ticketId = summaryResult.ticketId,
                 recap = summaryResult.recap,
                 plans = planRefs.takeIf { it.isNotEmpty() },
+                notes = noteRefs.takeIf { it.isNotEmpty() },
                 references = referenceCommitRefs.takeIf { it.isNotEmpty() },
             )
 
@@ -458,10 +511,21 @@ object PostCommitHook {
                 referenceFiles = referenceFilesToStore.takeIf { it.isNotEmpty() },
             )
 
+            // Persist note bodies through the StorageProvider so they dual-write to the
+            // orphan branch and the Memory Bank folder, then stamp/clean up the registry.
+            if (noteFilesToStore.isNotEmpty()) {
+                store.storeNoteFiles(noteFilesToStore, "Associate notes with commit ${commitInfo.hash.take(8)}")
+            }
+
             // Finalize: delete archived references from plans.json + local markdown
             // (only if updatedAt matches — a re-upsert during this window preserves the fresh row)
             if (referenceCommitted.isNotEmpty()) {
                 finalizeReferenceArchive(referenceCommitted, cwd)
+            }
+            // Finalize notes: stamp the original rows committed (so they clear from CONTEXT)
+            // and delete the now-archived snippet files.
+            if (noteGuards.isNotEmpty() || snippetFilesToDelete.isNotEmpty()) {
+                finalizeNoteArchive(noteGuards, commitInfo.hash, snippetFilesToDelete, cwd)
             }
             log.info("=== PostCommitHook worker finished successfully for %s ===", commitInfo.hash.take(8))
 
@@ -618,6 +682,58 @@ object PostCommitHook {
         val registry = SessionTracker.loadPlansRegistry(cwd)
         return registry.references ?: emptyMap()
     }
+
+    /**
+     * Notes eligible to be captured by this commit: uncommitted, not ignored, on the
+     * current branch (legacy blank-branch rows allowed), and not excluded via the
+     * sidebar checkbox. Mirrors the CONTEXT panel's note visibility so what the user
+     * sees cleared is exactly what gets committed.
+     */
+    private fun detectUncommittedNotes(cwd: String, branch: String, excluded: Set<String>): Map<String, NoteEntry> {
+        val registry = SessionTracker.loadPlansRegistry(cwd)
+        return (registry.notes ?: emptyMap()).filter { (id, entry) ->
+            entry.commitHash == null &&
+                entry.ignored != true &&
+                (entry.branch.isBlank() || entry.branch == branch) &&
+                id !in excluded
+        }
+    }
+
+    /**
+     * Stamps each captured note's registry row as committed (commitHash +
+     * contentHashAtCommit) so `PlansPanel.filterNotes` hides it, and deletes the
+     * now-archived snippet source files. Stamping skips a row that became committed
+     * or was edited since capture (commitHash already set), so a concurrent change
+     * is never clobbered.
+     */
+    private fun finalizeNoteArchive(
+        guards: List<Pair<String, String>>,
+        commitHash: String,
+        snippetFilesToDelete: List<String>,
+        cwd: String,
+    ) {
+        if (guards.isNotEmpty()) {
+            val now = Instant.now().toString()
+            val fresh = SessionTracker.loadPlansRegistry(cwd)
+            val notes = (fresh.notes ?: emptyMap()).toMutableMap()
+            for ((id, contentHash) in guards) {
+                val entry = notes[id] ?: continue
+                if (entry.commitHash != null) continue
+                notes[id] = entry.copy(commitHash = commitHash, updatedAt = now, contentHashAtCommit = contentHash)
+            }
+            SessionTracker.savePlansRegistry(fresh.copy(notes = notes.takeIf { it.isNotEmpty() }), cwd)
+        }
+        for (path in snippetFilesToDelete) {
+            try { File(path).delete() } catch (_: Exception) { /* best-effort */ }
+        }
+        log.info("Note finalize: stamped %d note(s), removed %d snippet file(s)", guards.size, snippetFilesToDelete.size)
+    }
+
+    /** Lowercase hex SHA-256 of a string — used for the note archive guard. */
+    private fun sha256Hex(s: String): String =
+        java.security.MessageDigest.getInstance("SHA-256")
+            .digest(s.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
 
     /**
      * Deletes archived references from plans.json + local markdown.

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
@@ -188,18 +188,16 @@ object PostCommitHook {
                 allSessions.addAll(CopilotChatSupport.discoverSessions(cwd).sessions)
             }
 
-            // Filter out conversations the user excluded via sidebar checkboxes
+            // Read ALL sessions so excluded conversations' cursors advance too:
+            // selection is a one-time discard — an unchecked conversation is consumed
+            // (cursor → commit boundary) so it leaves the working area, but its entries
+            // are dropped below and never enter the summary. (Reverses the earlier
+            // "keep excluded conversations visible so the user can re-check them".)
             val exclusions = CommitSelectionStore.readExclusions(cwd)
-            val sessions = allSessions.filter { session ->
-                val source = session.source ?: TranscriptSource.claude
-                val key = CommitSelectionStore.conversationKey(source, session.sessionId)
-                val excluded = key in exclusions.conversations
-                if (excluded) log.info("Excluding session %s (user-excluded)", session.sessionId.take(8))
-                !excluded
-            }
+            val sessions = allSessions
 
-            log.info("Discovered %d session(s) (%d excluded): %s",
-                allSessions.size, allSessions.size - sessions.size,
+            log.info("Discovered %d session(s): %s",
+                allSessions.size,
                 sessions.joinToString(", ") { "${it.source ?: "claude"}:${it.sessionId.take(8)}" })
             if (sessions.isEmpty()) {
                 log.info("No active sessions — skipping summarization")
@@ -259,13 +257,20 @@ object PostCommitHook {
                         log.info("  ...and %d more entries", result.entries.size - 3)
                     }
 
-                    if (result.entries.isNotEmpty()) {
+                    // Discard unchecked conversations: still advance the cursor (below)
+                    // so the row leaves the working area, but drop the entries so they
+                    // never enter the summary.
+                    val excludedConversation =
+                        CommitSelectionStore.conversationKey(source, session.sessionId) in exclusions.conversations
+                    if (result.entries.isNotEmpty() && !excludedConversation) {
                         sessionTranscripts.add(TranscriptReader.SessionTranscript(
                             session.sessionId, session.transcriptPath, result.entries, source
                         ))
                     }
-                    totalEntries += result.totalLinesRead
-                    totalTurns += result.entries.count { it.role == "human" }
+                    if (!excludedConversation) {
+                        totalEntries += result.totalLinesRead
+                        totalTurns += result.entries.count { it.role == "human" }
+                    }
                     SessionTracker.saveCursor(result.newCursor, cwd)
                 } catch (e: Exception) {
                     log.warn("Failed to read transcript for session %s (%s), skipping: %s",
@@ -331,7 +336,7 @@ object PostCommitHook {
             val planRefs = mutableListOf<PlanReference>()
             val planProgressArtifacts = mutableListOf<PlanProgressArtifact>()
 
-            val uncommittedSlugs = detectUncommittedPlanSlugs(cwd)
+            val uncommittedSlugs = detectUncommittedPlanSlugs(cwd, exclusions.plans)
             if (uncommittedSlugs.isNotEmpty()) {
                 log.info("Detected %d uncommitted plan(s): %s", uncommittedSlugs.size, uncommittedSlugs.joinToString(", "))
                 val plansDir = File(System.getProperty("user.home"), ".claude/plans")
@@ -389,7 +394,7 @@ object PostCommitHook {
             val referenceFilesToStore = mutableListOf<FileWrite>()
             val referenceCommitted = mutableListOf<Triple<String, String, String>>() // mapKey, sourcePath, updatedAt
 
-            val uncommittedRefResult = detectUncommittedReferences(cwd, branch)
+            val uncommittedRefResult = detectUncommittedReferences(cwd, exclusions.references)
             if (uncommittedRefResult.isNotEmpty()) {
                 log.info("Detected %d uncommitted reference(s)", uncommittedRefResult.size)
                 val shortHash = commitInfo.hash.substring(0, 8)
@@ -445,7 +450,7 @@ object PostCommitHook {
             run {
                 val noteNow = Instant.now().toString()
                 val shortHash = commitInfo.hash.take(8)
-                val uncommittedNotes = detectUncommittedNotes(cwd, branch, exclusions.notes)
+                val uncommittedNotes = detectUncommittedNotes(cwd, exclusions.notes)
                 if (uncommittedNotes.isNotEmpty()) {
                     log.info("Detected %d uncommitted note(s): %s", uncommittedNotes.size, uncommittedNotes.keys.joinToString(", "))
                     for ((id, entry) in uncommittedNotes) {
@@ -534,6 +539,12 @@ object PostCommitHook {
             if (noteGuards.isNotEmpty() || snippetFilesToDelete.isNotEmpty()) {
                 finalizeNoteArchive(noteGuards, commitInfo.hash, snippetFilesToDelete, cwd)
             }
+
+            // Discard the unchecked working items: the CHECKED ones were archived above;
+            // the excluded ones are useless per the user's selection, so remove their
+            // registry rows (+ .jolli-owned backing files) WITHOUT archiving them into
+            // committed memory.
+            discardExcludedWorkingItems(exclusions, cwd)
             log.info("=== PostCommitHook worker finished successfully for %s ===", commitInfo.hash.take(8))
 
         } finally {
@@ -654,11 +665,16 @@ object PostCommitHook {
         }
     }
 
-    /** Returns slugs of plans in plans.json that are not yet committed and not ignored. */
-    private fun detectUncommittedPlanSlugs(cwd: String): Set<String> {
+    /**
+     * Slugs of plans to ARCHIVE into this commit: uncommitted, not ignored, and NOT
+     * unchecked by the user. Excluded (unchecked) plans are left out here — they are
+     * discarded separately by [discardExcludedWorkingItems], never archived. No branch
+     * filter: uncommitted plans follow the user across branches (matches the CLI).
+     */
+    private fun detectUncommittedPlanSlugs(cwd: String, excluded: Set<String>): Set<String> {
         val registry = SessionTracker.loadPlansRegistry(cwd)
         return registry.plans.entries
-            .filter { (_, entry) -> entry.commitHash == null && entry.ignored != true }
+            .filter { (slug, entry) -> entry.commitHash == null && entry.ignored != true && slug !in excluded }
             .map { (slug, _) -> slug }
             .toSet()
     }
@@ -685,33 +701,30 @@ object PostCommitHook {
     }
 
     /**
-     * References eligible to be archived by this commit: every plans.json row is
-     * uncommitted (a commit deletes the row), scoped to the current branch with the
-     * legacy blank-branch fallback — mirrors [detectUncommittedNotes] so committing
-     * on one branch does not sweep up references stamped for another.
+     * References to ARCHIVE into this commit: every plans.json reference row is
+     * uncommitted (a commit deletes the row) and NOT unchecked by the user. Excluded
+     * references are left out here — they are discarded by [discardExcludedWorkingItems],
+     * never archived. No branch filter: uncommitted references follow the user across
+     * branches (matches the CLI).
      */
     private fun detectUncommittedReferences(
         cwd: String,
-        branch: String,
+        excluded: Set<String>,
     ): Map<String, ai.jolli.jollimemory.core.references.ReferenceEntry> {
         val registry = SessionTracker.loadPlansRegistry(cwd)
-        return (registry.references ?: emptyMap()).filter { (_, entry) ->
-            entry.branch.isNullOrBlank() || entry.branch == branch
-        }
+        return (registry.references ?: emptyMap()).filter { (mapKey, _) -> mapKey !in excluded }
     }
 
     /**
-     * Notes eligible to be captured by this commit: uncommitted, not ignored, on the
-     * current branch (legacy blank-branch rows allowed), and not excluded via the
-     * sidebar checkbox. Mirrors the CONTEXT panel's note visibility so what the user
-     * sees cleared is exactly what gets committed.
+     * Notes to ARCHIVE into this commit: uncommitted, not ignored, and not unchecked via
+     * the sidebar. Excluded notes are discarded by [discardExcludedWorkingItems], never
+     * archived. No branch filter: uncommitted notes follow the user across branches.
      */
-    private fun detectUncommittedNotes(cwd: String, branch: String, excluded: Set<String>): Map<String, NoteEntry> {
+    private fun detectUncommittedNotes(cwd: String, excluded: Set<String>): Map<String, NoteEntry> {
         val registry = SessionTracker.loadPlansRegistry(cwd)
         return (registry.notes ?: emptyMap()).filter { (id, entry) ->
             entry.commitHash == null &&
                 entry.ignored != true &&
-                (entry.branch.isBlank() || entry.branch == branch) &&
                 id !in excluded
         }
     }
@@ -783,6 +796,90 @@ object PostCommitHook {
             ReferenceStore.deleteReferenceMarkdown(path)
         }
         log.info("Reference finalize: deleted %d of %d ref(s)", toDeleteMarkdown.size, committed.size)
+    }
+
+    /**
+     * Discards the working-area items the user left UNCHECKED: removes the excluded
+     * uncommitted rows from plans.json (+ their `.jolli`-owned backing files) WITHOUT
+     * archiving them into committed memory. Mirrors the CLI `discardExcludedWorkingItems`.
+     *
+     * - Plans: registry row removed; the external `~/.claude/plans/<slug>.md` is left
+     *   untouched (user-owned). Hard-deletes the row (not `ignored=true`) so the on-disk
+     *   plans.json state matches whichever worker — CLI or native — ran the commit.
+     * - Notes: registry row removed; backing file deleted only for uncommitted snippet
+     *   notes (external markdown note sources are preserved).
+     * - References: registry row removed; backing markdown (always `.jolli`) deleted.
+     *
+     * Only uncommitted rows are touched, so a stale exclusion key can never clobber a
+     * committed guard row.
+     */
+    private fun discardExcludedWorkingItems(exclusions: CommitSelectionStore.CommitExclusions, cwd: String) {
+        if (exclusions.plans.isEmpty() && exclusions.notes.isEmpty() && exclusions.references.isEmpty()) return
+
+        val registry = SessionTracker.loadPlansRegistry(cwd)
+        val plans = registry.plans.toMutableMap()
+        val notes = (registry.notes ?: emptyMap()).toMutableMap()
+        val references = (registry.references ?: emptyMap()).toMutableMap()
+        val noteFilesToDelete = mutableListOf<String>()
+        val refFilesToDelete = mutableListOf<String>()
+        var removedPlans = 0
+        var removedNotes = 0
+        var removedRefs = 0
+
+        for (slug in exclusions.plans) {
+            val entry = plans[slug]
+            if (entry != null && entry.commitHash == null && entry.contentHashAtCommit == null) {
+                plans.remove(slug)
+                removedPlans++
+            }
+        }
+        for (id in exclusions.notes) {
+            val entry = notes[id]
+            if (entry != null && entry.commitHash == null && entry.contentHashAtCommit == null) {
+                if (entry.format == NoteFormat.snippet && entry.sourcePath != null) noteFilesToDelete.add(entry.sourcePath)
+                notes.remove(id)
+                removedNotes++
+            }
+        }
+        for (mapKey in exclusions.references) {
+            val entry = references[mapKey]
+            if (entry != null) {
+                refFilesToDelete.add(entry.sourcePath)
+                references.remove(mapKey)
+                removedRefs++
+            }
+        }
+
+        if (removedPlans > 0 || removedNotes > 0 || removedRefs > 0) {
+            SessionTracker.savePlansRegistry(
+                registry.copy(
+                    plans = plans,
+                    notes = notes.takeIf { it.isNotEmpty() },
+                    references = references.takeIf { it.isNotEmpty() },
+                ),
+                cwd,
+            )
+        }
+
+        // Backing-file cleanup after the registry write — snippet note bodies and
+        // reference markdown live under .jolli/jollimemory/ (owned); external note
+        // sources and ~/.claude/plans files are never deleted.
+        for (path in noteFilesToDelete) {
+            try {
+                val file = File(path)
+                if (file.exists()) file.delete()
+            } catch (_: Exception) { /* best-effort */ }
+        }
+        for (path in refFilesToDelete) {
+            ReferenceStore.deleteReferenceMarkdown(path)
+        }
+
+        if (removedPlans > 0 || removedNotes > 0 || removedRefs > 0) {
+            log.info(
+                "Discarded excluded working items: %d plan(s), %d note(s), %d reference(s)",
+                removedPlans, removedNotes, removedRefs,
+            )
+        }
     }
 
     /** Get the path to this JAR file (for spawning the worker). */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
@@ -296,10 +296,15 @@ object PostCommitHook {
                 return
             }
 
-            // 7b. Assemble reference blocks for prompt injection
+            // 7b. Assemble reference blocks for prompt injection — branch-scoped to
+            //     this commit's branch (legacy blank-branch rows allowed) so the
+            //     summary prompt never sees another branch's references.
+            val branch = git.getCurrentBranch() ?: "unknown"
             val registry = SessionTracker.loadPlansRegistry(cwd)
             val referenceBlocks = PromptRenderer.assembleReferenceBlocks(
-                registry.references ?: emptyMap(),
+                (registry.references ?: emptyMap()).filter { (_, entry) ->
+                    entry.branch.isNullOrBlank() || entry.branch == branch
+                },
                 exclusions.references,
             )
             if (referenceBlocks.isNotEmpty()) {
@@ -376,12 +381,15 @@ object PostCommitHook {
                 log.info("Plan progress: evaluated %d/%d plan(s)", planProgressArtifacts.size, planRefs.size)
             }
 
-            // 8c. Detect uncommitted references, archive to orphan branch
+            // 8c. Detect uncommitted references on this branch, archive to orphan branch.
+            //     Branch-scoped like notes (8d) so a commit on this branch leaves other
+            //     branches' references pending instead of sweeping them up. `branch` is
+            //     declared at the 7b prompt-assembly step above.
             val referenceCommitRefs = mutableListOf<ReferenceCommitRef>()
             val referenceFilesToStore = mutableListOf<FileWrite>()
             val referenceCommitted = mutableListOf<Triple<String, String, String>>() // mapKey, sourcePath, updatedAt
 
-            val uncommittedRefResult = detectUncommittedReferences(cwd)
+            val uncommittedRefResult = detectUncommittedReferences(cwd, branch)
             if (uncommittedRefResult.isNotEmpty()) {
                 log.info("Detected %d uncommitted reference(s)", uncommittedRefResult.size)
                 val shortHash = commitInfo.hash.substring(0, 8)
@@ -422,7 +430,6 @@ object PostCommitHook {
             }
 
             // 9. Build and store CommitSummary
-            val branch = git.getCurrentBranch() ?: "unknown"
             val commitType = detectCommitType()
 
             // 8d. Detect uncommitted notes on this branch, archive, and attach to the summary.
@@ -677,10 +684,20 @@ object PostCommitHook {
         return DiffStats(files, ins, del)
     }
 
-    /** Returns all entries from plans.json.references (every entry is uncommitted). */
-    private fun detectUncommittedReferences(cwd: String): Map<String, ai.jolli.jollimemory.core.references.ReferenceEntry> {
+    /**
+     * References eligible to be archived by this commit: every plans.json row is
+     * uncommitted (a commit deletes the row), scoped to the current branch with the
+     * legacy blank-branch fallback — mirrors [detectUncommittedNotes] so committing
+     * on one branch does not sweep up references stamped for another.
+     */
+    private fun detectUncommittedReferences(
+        cwd: String,
+        branch: String,
+    ): Map<String, ai.jolli.jollimemory.core.references.ReferenceEntry> {
         val registry = SessionTracker.loadPlansRegistry(cwd)
-        return registry.references ?: emptyMap()
+        return (registry.references ?: emptyMap()).filter { (_, entry) ->
+            entry.branch.isNullOrBlank() || entry.branch == branch
+        }
     }
 
     /**

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/StopHook.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/StopHook.kt
@@ -7,6 +7,7 @@ import ai.jolli.jollimemory.core.SessionInfo
 import ai.jolli.jollimemory.core.SessionTracker
 import ai.jolli.jollimemory.core.TranscriptCursor
 import ai.jolli.jollimemory.core.TranscriptSource
+import ai.jolli.jollimemory.core.plans.TranscriptPlanDiscovery
 import ai.jolli.jollimemory.core.references.TranscriptReferenceDiscovery
 import com.google.gson.Gson
 import java.io.File
@@ -70,8 +71,9 @@ object StopHook {
     }
 
     /**
-     * Incremental reference discovery for one transcript. Loads discovery cursor,
-     * scans for references, advances cursor on success.
+     * Incremental discovery for one transcript. Loads the discovery cursor, scans
+     * for both references AND plans from the same line, then advances the cursor to
+     * the furthest line either scan reached.
      */
     private fun discoverFromTranscript(sessionInfo: SessionInfo, cwd: String) {
         val transcriptPath = sessionInfo.transcriptPath
@@ -92,13 +94,25 @@ object StopHook {
             log.error("Reference discovery failed: %s", e.message)
         }
 
-        log.debug("discoverFromTranscript: scanned to line %d (was %d)", referenceLine, fromLine)
+        var planLine = fromLine
+        try {
+            planLine = TranscriptPlanDiscovery.scanPlansFrom(
+                transcriptPath, fromLine, cwd, TranscriptSource.claude,
+            )
+        } catch (e: Exception) {
+            log.error("Plan discovery failed: %s", e.message)
+        }
 
-        if (referenceLine > fromLine) {
+        // Persist the furthest line either scan reached — both read from the same
+        // fromLine to EOF, so the merged cursor advances past everything scanned.
+        val scannedLine = maxOf(referenceLine, planLine)
+        log.debug("discoverFromTranscript: scanned to line %d (was %d)", scannedLine, fromLine)
+
+        if (scannedLine > fromLine) {
             SessionTracker.saveDiscoveryCursor(
                 TranscriptCursor(
                     transcriptPath = transcriptPath,
-                    lineNumber = referenceLine,
+                    lineNumber = scannedLine,
                     updatedAt = Instant.now().toString(),
                 ),
                 cwd,

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliApiClient.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliApiClient.kt
@@ -107,6 +107,9 @@ object JolliApiClient {
     /** Thrown when the server rejects the request due to outdated plugin version (HTTP 426). */
     class PluginOutdatedError(message: String) : RuntimeException(message)
 
+    /** Thrown when the server rejects the API key (HTTP 401/403) — invalid/disabled/wrong org. */
+    class UnauthorizedError(message: String) : RuntimeException(message)
+
     /** Thrown when the server returns 412 because the repo has no space binding yet. */
     class BindingRequiredError(
         val repoUrl: String,
@@ -137,25 +140,30 @@ object JolliApiClient {
         if (!key.startsWith("sk-jol-")) return null
 
         val rest = key.substring("sk-jol-".length)
-        val dotIndex = rest.indexOf('.')
-        if (dotIndex == -1) return null
+        // Old format `sk-jol-<32 hex chars>` has no embedded meta.
+        if (!rest.contains(".")) return null
 
-        return try {
-            // Base64 URL decode the metadata portion
-            val metaPart = rest.substring(0, dotIndex)
-            val decoder = Base64.getUrlDecoder()
-            val metaJson = String(decoder.decode(metaPart), Charsets.UTF_8)
-
-            @Suppress("UNCHECKED_CAST")
-            val meta = gson.fromJson(metaJson, Map::class.java) as Map<String, Any?>
-            val t = meta["t"] as? String ?: return null
-            val u = meta["u"] as? String ?: return null
-            val o = meta["o"] as? String
-
-            JolliApiKeyMeta(t = t, u = u, o = o)
-        } catch (_: Exception) {
-            null
+        // Scan EVERY dot-separated segment (not just the first) and return the first
+        // that base64url-decodes to JSON carrying string `t` + `u`. This handles both
+        // Format A (`sk-jol-<metaB64>.<secretB64>`, meta in segment 0) and Format B /
+        // JWT-shaped (`sk-jol-<headerB64>.<payloadB64>.<sigB64>`, meta in segment 1).
+        // Must stay in lockstep with the canonical parser in
+        // cli/src/core/JolliApiUtils.ts (and the VS Code bundle).
+        val decoder = Base64.getUrlDecoder()
+        for (segment in rest.split(".")) {
+            try {
+                val metaJson = String(decoder.decode(segment), Charsets.UTF_8)
+                @Suppress("UNCHECKED_CAST")
+                val meta = gson.fromJson(metaJson, Map::class.java) as? Map<String, Any?> ?: continue
+                val t = meta["t"] as? String ?: continue
+                val u = meta["u"] as? String ?: continue
+                val o = meta["o"] as? String
+                return JolliApiKeyMeta(t = t, u = u, o = o)
+            } catch (_: Exception) {
+                // Segment isn't valid base64url JSON — try the next one.
+            }
         }
+        return null
     }
 
     /**
@@ -544,6 +552,10 @@ object JolliApiClient {
                 throw PluginOutdatedError(
                     json["message"] as? String
                         ?: "Plugin version is outdated. Please update to the latest version."
+                )
+            } else if (statusCode == 401 || statusCode == 403) {
+                throw UnauthorizedError(
+                    json["error"] as? String ?: "Invalid or disabled API key"
                 )
             } else {
                 throw RuntimeException(

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliAuthService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliAuthService.kt
@@ -75,6 +75,13 @@ object JolliAuthService {
 
     fun login(
         timeoutSeconds: Long = DEFAULT_LOGIN_TIMEOUT_SECONDS,
+        /**
+         * Force the server to mint a fresh Jolli API key even when the existing key
+         * already matches the target tenant. User-initiated "Sign In" actions pass
+         * true so a manual recovery from a revoked same-tenant key actually replaces
+         * the dead key (otherwise [JolliAuthUtils.shouldRequestFreshApiKey] keeps it).
+         */
+        forceFreshApiKey: Boolean = false,
         onSuccess: (result: LoginResult) -> Unit,
         onError: (message: String) -> Unit,
     ) {
@@ -110,7 +117,7 @@ object JolliAuthService {
                 jolliUrl = jolliUrl,
                 callbackUrl = callbackUrl,
                 clientVersion = JolliApiClient.pluginVersion,
-                generateApiKey = JolliAuthUtils.shouldRequestFreshApiKey(existingApiKey, jolliUrl),
+                generateApiKey = forceFreshApiKey || JolliAuthUtils.shouldRequestFreshApiKey(existingApiKey, jolliUrl),
                 installId = TelemetrySharedConfig.getOrCreateInstallId().first,
             )
             log.info("Login URL: %s", loginUrl)
@@ -251,6 +258,18 @@ object JolliAuthService {
         server = null
         serverExecutor?.shutdownNow()
         serverExecutor = null
+    }
+
+    /**
+     * Full teardown for plugin unload. This is an `object`, so its
+     * [timeoutExecutor] thread and the [authListeners] list would otherwise pin
+     * the plugin classloader after a dynamic unload. Called from
+     * [ai.jolli.jollimemory.JolliDynamicUnloadCleaner] on `beforePluginUnload`.
+     */
+    fun shutdownForUnload() {
+        shutdown()
+        timeoutExecutor.shutdownNow()
+        authListeners.clear()
     }
 
     /**

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
@@ -99,6 +99,18 @@ class JolliMemoryService(private val project: Project) : Disposable {
     private fun notifyListeners() { listeners.forEach { it() } }
 
     /**
+     * Listeners notified whenever a commit-selection toggle changes — a conversation
+     * or context checkbox ([CommitSelectionStore]) or an in-memory file selection in
+     * [ChangesPanel]. Kept separate from the status listeners so toggling a checkbox
+     * can refresh the open Working Memory review without forcing the sidebar panels to
+     * rebuild (which would, for files, reset their in-memory selection).
+     */
+    private val selectionListeners = CopyOnWriteArrayList<() -> Unit>()
+    fun addSelectionListener(listener: () -> Unit) { selectionListeners.add(listener) }
+    fun removeSelectionListener(listener: () -> Unit) { selectionListeners.remove(listener) }
+    fun notifySelectionChanged() { selectionListeners.forEach { it() } }
+
+    /**
      * Adds a sync-state listener. If a sync state has already been observed,
      * the listener is invoked immediately with it so late-registering panels
      * reflect the current state.
@@ -523,16 +535,39 @@ val sb = StringBuilder()
 
     fun getSummaryJson(commitHash: String): String? = reader?.getSummaryJson(commitHash)
 
+    /** Archived plan body (`plans/<slug>.md`) from committed-memory storage, or null. */
+    fun readArchivedPlan(slug: String): String? = reader?.readPlanBody(slug)
+
+    /** Archived markdown-note body (`notes/<id>.md`) from committed-memory storage, or null. */
+    fun readArchivedNote(id: String): String? = reader?.readNoteBody(id)
+
+    /** Stored committed conversation (by session) rendered as read-only markdown, or null. */
+    fun readCommittedConversationMarkdown(commitHash: String, sessionId: String): String? =
+        reader?.renderCommittedConversationMarkdown(commitHash, sessionId)
+
     fun getChangedFiles(): List<FileChange> {
         val output = git?.getStatus() ?: return emptyList()
-        return output.lines()
-            .filter { it.isNotBlank() && it.length > 3 }
-            .map { line ->
-                FileChange(
-                    relativePath = line.substring(3),
-                    statusCode = line.substring(0, 2).trim(),
-                )
-            }
+        // Parse the NUL-separated `git status -z` stream (mirrors VS Code's listFiles):
+        //   normal entry: <XY><space><path>; rename/copy adds the old path as the next segment.
+        val segments = output.split("\u0000")
+        val files = mutableListOf<FileChange>()
+        var i = 0
+        while (i < segments.size) {
+            val segment = segments[i]
+            if (segment.length < 3) { i++; continue }
+            val stagedCode = segment[0]
+            val unstagedCode = segment[1]
+            val resolvedPath = segment.substring(3)
+            // Rename/copy carries the original path in the next NUL segment — consume it.
+            if (stagedCode == 'R' || stagedCode == 'C') i++
+            // Belt-and-suspenders: skip any directory-shaped row (files-only list).
+            if (resolvedPath.endsWith("/")) { i++; continue }
+            // Single display code: the index column when staged, else the worktree column.
+            val code = if (stagedCode != ' ' && stagedCode != '?') stagedCode else unstagedCode
+            files.add(FileChange(relativePath = resolvedPath, statusCode = code.toString()))
+            i++
+        }
+        return files
     }
 
     fun getBranchCommits(): List<CommitSummaryBrief> {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
@@ -291,8 +291,6 @@ val sb = StringBuilder()
         val orphanRefDir = Path.of(repoRoot, ".git", "refs", "heads", orphanBranch).parent
         // Watch .jolli/jollimemory/ for lock file changes
         val lockDir = Path.of(repoRoot, ".jolli", "jollimemory")
-        // Watch ~/.claude/plans/ so plans Claude generates appear live in CONTEXT.
-        val claudePlansDir = Path.of(System.getProperty("user.home"), ".claude", "plans")
 
         // The ref file name we're looking for (e.g., "v3")
         val orphanRefFileName = Path.of(orphanBranch).fileName.toString()
@@ -315,20 +313,16 @@ val sb = StringBuilder()
             if (Files.isDirectory(lockDir)) {
                 lockDir.register(watchService,
                     StandardWatchEventKinds.ENTRY_CREATE,
-                    StandardWatchEventKinds.ENTRY_DELETE)
+                    StandardWatchEventKinds.ENTRY_DELETE,
+                    // ENTRY_MODIFY so a live plans.json write (StopHook reference/plan
+                    // discovery) refreshes the panel. The lock-file create/delete signal
+                    // is too brief for the macOS polling WatchService to catch reliably,
+                    // and plans.json persists — so watching the data file itself is the
+                    // reliable trigger for CONTEXT updates during a session.
+                    StandardWatchEventKinds.ENTRY_MODIFY)
                 log.info("NIO watcher registered on: $lockDir")
             } else {
                 log.info("Lock dir does not exist yet, skipping NIO watch: $lockDir")
-            }
-
-            if (Files.isDirectory(claudePlansDir)) {
-                claudePlansDir.register(watchService,
-                    StandardWatchEventKinds.ENTRY_CREATE,
-                    StandardWatchEventKinds.ENTRY_MODIFY,
-                    StandardWatchEventKinds.ENTRY_DELETE)
-                log.info("NIO watcher registered on: $claudePlansDir")
-            } else {
-                log.info("Claude plans dir does not exist yet, skipping NIO watch: $claudePlansDir")
             }
 
             // Background thread to poll watch events
@@ -339,10 +333,14 @@ val sb = StringBuilder()
                         var shouldRefresh = false
                         for (event in key.pollEvents()) {
                             val fileName = (event.context() as? Path)?.toString() ?: continue
-                            // `.md` events only come from the Claude plans dir (the other
-                            // watched dirs hold the orphan ref + lock file), so matching the
-                            // extension is enough to catch a newly generated plan.
-                            if (fileName == orphanRefFileName || fileName == lockFileName || fileName.endsWith(".md")) {
+                            // Refresh on: orphan-ref updates (summary written), lock file
+                            // create/delete (worker start/finish), and plans.json writes
+                            // (StopHook reference/plan discovery during a live session —
+                            // this is what surfaces a newly created plan in CONTEXT without
+                            // waiting for the next commit). Other files in the dir
+                            // (debug.log, sessions.json, cursors.json) are ignored here so
+                            // their churn doesn't spam refreshes.
+                            if (fileName == orphanRefFileName || fileName == lockFileName || fileName == "plans.json") {
                                 shouldRefresh = true
                             }
                         }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
@@ -581,11 +581,9 @@ val sb = StringBuilder()
 
         val headHash = g.getHeadHash()
 
-        // Find merge-base
-        var mergeBase = g.exec("merge-base", "HEAD", baseRef)?.trim()
-        if (mergeBase.isNullOrBlank()) {
-            mergeBase = null
-        }
+        // Find merge-base (val so the else arm below smart-casts it to non-null).
+        val mergeBaseRaw = g.exec("merge-base", "HEAD", baseRef)?.trim()
+        val mergeBase = mergeBaseRaw?.takeIf { it.isNotBlank() }
 
         // If merge-base equals HEAD, we're on main or branch is fully merged.
         // When on main with a remote, show unpushed commits (origin/main..HEAD).
@@ -595,7 +593,18 @@ val sb = StringBuilder()
             mergeBase == null -> null // No common ancestor
             mergeBase == headHash && baseRef.startsWith("origin/") -> "$baseRef..HEAD"
             mergeBase == headHash -> return emptyList() // On main or fresh branch — no branch-specific commits
-            else -> "$mergeBase..HEAD"
+            else -> {
+                // Narrow the fork point to the branch's true reflog creation point,
+                // so a branch cut from a feature/release branch — including a
+                // brand-new branch that still shares its parent's tip — does not
+                // inherit the base branch's commits as its own. When the refined
+                // base equals HEAD the branch has no own commits yet, so the panel
+                // clears. Mirrors VS Code listBranchCommits -> resolveOwnCommitsBase.
+                val branch = g.getCurrentBranch()?.trim()
+                val ownBase = if (branch.isNullOrBlank()) mergeBase else g.resolveOwnCommitsBase(branch, mergeBase)
+                if (ownBase == headHash) return emptyList()
+                "$ownBase..HEAD"
+            }
         }
 
         // Get commits with full metadata

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/PlanService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/PlanService.kt
@@ -65,52 +65,6 @@ object PlanService {
     }
 
     /**
-     * Auto-registers plan files that exist in ~/.claude/plans/ but aren't yet in
-     * the project's plans.json registry, so a plan Claude just generated shows up
-     * live in the WORKING MEMORY → CONTEXT section without a manual "Add plan".
-     *
-     * New entries are uncommitted (commitHash = null) and tagged with the current
-     * branch — mirroring the VS Code extension's handleNewPlanFile. Slugs already
-     * present in the registry (in any state, including ignored or committed) are
-     * left untouched, so this never resurrects a removed plan or duplicates one.
-     *
-     * @return true when at least one new plan was registered (caller should refresh).
-     */
-    fun autoRegisterNewPlans(cwd: String, branch: String?): Boolean {
-        if (!PLANS_DIR.exists() || !PLANS_DIR.isDirectory) return false
-        val files = PLANS_DIR.listFiles { file -> file.extension == "md" } ?: return false
-        if (files.isEmpty()) return false
-
-        val registry = SessionTracker.loadPlansRegistry(cwd)
-        val updated = registry.plans.toMutableMap()
-        val now = Instant.now().toString()
-        val resolvedBranch = branch ?: getCurrentBranch(cwd)
-        var changed = false
-
-        for (file in files) {
-            val slug = file.nameWithoutExtension
-            if (registry.plans.containsKey(slug)) continue
-            updated[slug] = ai.jolli.jollimemory.core.PlanEntry(
-                slug = slug,
-                title = extractPlanTitle(file.readText(Charsets.UTF_8)),
-                sourcePath = file.absolutePath,
-                addedAt = now,
-                updatedAt = now,
-                branch = resolvedBranch,
-                commitHash = null,
-                editCount = 0,
-            )
-            changed = true
-        }
-
-        if (changed) {
-            SessionTracker.savePlansRegistry(registry.copy(plans = updated), cwd)
-            log.info("Auto-registered new plan(s) from %s on branch %s", PLANS_DIR.absolutePath, resolvedBranch)
-        }
-        return changed
-    }
-
-    /**
      * Archives a plan and associates it with a commit.
      *
      * Mirrors PostCommitHook's archive logic: renames slug to slug-hash,

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/settings/JolliMemoryConfigurable.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/settings/JolliMemoryConfigurable.kt
@@ -102,6 +102,8 @@ class JolliMemoryConfigurable(private val project: Project) : Configurable {
                 accountButton?.isEnabled = false
                 accountButton?.text = "Signing in..."
                 JolliAuthService.login(
+                    // User-initiated sign-in: mint a fresh key so a revoked same-tenant key recovers.
+                    forceFreshApiKey = true,
                     onSuccess = { _ ->
                         SwingUtilities.invokeLater {
                             loadFromConfig()

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActionBarPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActionBarPanel.kt
@@ -62,7 +62,10 @@ class ActionBarPanel(
 		add(prBtn, BorderLayout.CENTER)
 		val east = JPanel(java.awt.FlowLayout(java.awt.FlowLayout.RIGHT, JBUI.scale(4), 0)).apply {
 			isOpaque = false
-			add(shareBtn)
+			// "Share" (share branch memories to a Jolli Space) isn't wired yet — keep it
+			// out of the bar until it does something. shareBtn stays constructed so
+			// setForeign() still compiles; it's just not added to the layout.
+			if (FeatureFlags.SHOW_UNFINISHED) add(shareBtn)
 			add(moreBtn)
 		}
 		add(east, BorderLayout.EAST)
@@ -131,10 +134,14 @@ class ActionBarPanel(
 			menu.add(javax.swing.JMenuItem("Copy recall prompt for other tools").apply {
 				addActionListener { copyRecallPrompt() }
 			})
-			menu.addSeparator()
-			menu.add(javax.swing.JMenuItem("Sync to Memory Bank", JolliMemoryIcons.CloudUpload).apply {
-				addActionListener { syncToMemoryBank() }
-			})
+			// "Sync to Memory Bank" silently no-ops unless the sync orchestrator is built
+			// (sign-in + binding); hide it until that lazy-build path is wired here.
+			if (FeatureFlags.SHOW_UNFINISHED) {
+				menu.addSeparator()
+				menu.add(javax.swing.JMenuItem("Sync to Memory Bank", JolliMemoryIcons.CloudUpload).apply {
+					addActionListener { syncToMemoryBank() }
+				})
+			}
 		}
 		menu.add(javax.swing.JMenuItem("Refresh", JolliMemoryIcons.Refresh).apply {
 			addActionListener { refreshAll() }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActiveConversationsPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActiveConversationsPanel.kt
@@ -34,6 +34,8 @@ class ActiveConversationsPanel(
 
 	private val rowsPanel = JPanel().apply {
 		layout = BoxLayout(this, BoxLayout.Y_AXIS)
+		// Match PINNED's container insets so the first/last row edge gaps line up.
+		border = JBUI.Borders.empty(2, 4)
 	}
 	private val emptyLabel = JBLabel("No active conversations").apply {
 		horizontalAlignment = SwingConstants.CENTER
@@ -60,9 +62,16 @@ class ActiveConversationsPanel(
 	private val pollTimer = Timer(60_000) {
 		if (isShowing) {
 			refresh()
-			// JOLLI-1785: piggyback the 60s tick to flush buffered telemetry.
+			// JOLLI-1785: piggyback the 60s tick to flush buffered telemetry — on a
+			// pooled thread, NOT the EDT. The Swing Timer fires on the EDT and
+			// flushNow does a blocking HTTP send (kept synchronous for the hook path),
+			// so a slow DNS lookup / network would otherwise freeze the UI.
 			// Best-effort; the helper swallows errors and no-ops on an empty buffer.
-			project.basePath?.let { ai.jolli.jollimemory.core.telemetry.TelemetryActivation.flushNow(it) }
+			project.basePath?.let { base ->
+				ApplicationManager.getApplication().executeOnPooledThread {
+					ai.jolli.jollimemory.core.telemetry.TelemetryActivation.flushNow(base)
+				}
+			}
 		}
 	}.apply { isRepeats = true }
 
@@ -173,6 +182,7 @@ class ActiveConversationsPanel(
 		val key = CommitSelectionStore.conversationKey(item.source, item.sessionId)
 		ApplicationManager.getApplication().executeOnPooledThread {
 			CommitSelectionStore.setExcluded(cwd, "conversations", key, !selected)
+			service.notifySelectionChanged()
 		}
 	}
 
@@ -182,6 +192,7 @@ class ActiveConversationsPanel(
 		val keys = conversations.map { CommitSelectionStore.conversationKey(it.source, it.sessionId) }
 		ApplicationManager.getApplication().executeOnPooledThread {
 			CommitSelectionStore.setAllExcluded(cwd, "conversations", keys, !anyUnchecked)
+			service.notifySelectionChanged()
 			SwingUtilities.invokeLater { refresh() }
 		}
 	}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BreadcrumbHeaderPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BreadcrumbHeaderPanel.kt
@@ -6,19 +6,22 @@ import ai.jolli.jollimemory.core.KBRepoDiscoverer
 import ai.jolli.jollimemory.services.JolliMemoryService
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.ui.components.JBLabel
 import com.intellij.util.ui.JBUI
 import java.awt.BorderLayout
+import java.awt.Cursor
 import java.awt.Dimension
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
 import javax.swing.BorderFactory
 import javax.swing.Box
 import javax.swing.BoxLayout
-import javax.swing.DefaultComboBoxModel
 import javax.swing.DefaultListCellRenderer
-import javax.swing.JComboBox
 import javax.swing.JLabel
 import javax.swing.JList
 import javax.swing.JPanel
+import javax.swing.SwingConstants
 import javax.swing.SwingUtilities
 
 /**
@@ -33,6 +36,11 @@ import javax.swing.SwingUtilities
  * live here moved to the view switch and the tool window title bar respectively;
  * this row is now just the repo/branch selectors. Selecting a foreign repo/branch
  * fires [onSelectionChanged] so the factory can toggle read-only mode.
+ *
+ * The pickers are flat label + chevron "crumbs" (mockup `.crumb` styling) backed by
+ * a popup list rather than `JComboBox`: the LaF combo paints its own (lighter) field
+ * + arrow-button background that can't be flattened to the header, so a label that
+ * inherits the header background is the only way to make them blend in.
  */
 class BreadcrumbHeaderPanel(
 	private val service: JolliMemoryService,
@@ -41,11 +49,20 @@ class BreadcrumbHeaderPanel(
 
 	enum class Mode { BRANCH, REPO_FILTER }
 
-	private val repoCombo = JComboBox<String>()
-	private val branchCombo = JComboBox<String>()
 	private val showingLabel = JBLabel("Showing:")
 	private val slashLabel = JBLabel("/")
-	private val branchIcon = JBLabel(AllIcons.Vcs.Branch)
+
+	private val repoPicker = CrumbPicker(
+		isWorkspaceItem = { _, index -> index == 0 && repos.any { it.isCurrentRepo } },
+		onPick = { onRepoSelected() },
+	)
+	private val branchPicker = CrumbPicker(
+		isWorkspaceItem = { value, _ ->
+			val isCurrentRepo = repos.find { it.repoName == repoPicker.selected }?.isCurrentRepo == true
+			isCurrentRepo && value == currentBranch
+		},
+		onPick = { onBranchSelected() },
+	)
 
 	private var mode = Mode.BRANCH
 
@@ -53,48 +70,28 @@ class BreadcrumbHeaderPanel(
 	private var currentBranch: String? = null
 	private var repos: List<KBRepoDiscoverer.DiscoveredRepo> = emptyList()
 
-	private var suppressEvents = false
-
 	init {
 		border = JBUI.Borders.empty(4, 8)
 
-		// Custom renderers: bold + "(current)" + separator for workspace items
-		repoCombo.renderer = WorkspaceAwareCellRenderer { _, index -> index == 0 && repos.any { it.isCurrentRepo } }
-		branchCombo.renderer = WorkspaceAwareCellRenderer { value, _ ->
-			val selectedRepo = repoCombo.selectedItem as? String
-			val isCurrentRepo = repos.find { it.repoName == selectedRepo }?.isCurrentRepo == true
-			isCurrentRepo && value == currentBranch
+		// Breadcrumb text is 12px in the mockup (base − 1).
+		for (c in listOf<JLabel>(slashLabel, showingLabel)) {
+			c.font = c.font.deriveFont(c.font.size2D - 1f)
 		}
 
-		// Left: repo / branch selectors — BoxLayout so they shrink when the tool window is narrow
-		repoCombo.minimumSize = Dimension(JBUI.scale(30), repoCombo.preferredSize.height)
-		branchCombo.minimumSize = Dimension(JBUI.scale(30), branchCombo.preferredSize.height)
 		showingLabel.isVisible = false
+		// Mockup breadcrumb is text label + chevron only (no leading repo/branch icons).
 		val selectorPanel = JPanel().apply {
 			layout = BoxLayout(this, BoxLayout.X_AXIS)
+			isOpaque = false
 			add(showingLabel)
 			add(Box.createHorizontalStrut(JBUI.scale(4)))
-			add(JBLabel(AllIcons.Nodes.Module))
-			add(Box.createHorizontalStrut(JBUI.scale(4)))
-			add(repoCombo)
+			add(repoPicker)
 			add(Box.createHorizontalStrut(JBUI.scale(4)))
 			add(slashLabel)
 			add(Box.createHorizontalStrut(JBUI.scale(4)))
-			add(branchIcon)
-			add(Box.createHorizontalStrut(JBUI.scale(4)))
-			add(branchCombo)
+			add(branchPicker)
 		}
 		add(selectorPanel, BorderLayout.CENTER)
-
-		// Selection listeners
-		repoCombo.addActionListener {
-			if (suppressEvents) return@addActionListener
-			onRepoSelected()
-		}
-		branchCombo.addActionListener {
-			if (suppressEvents) return@addActionListener
-			onBranchSelected()
-		}
 	}
 
 	/** Switches between branch selectors and the repo-filter ("Showing:") display. */
@@ -103,14 +100,13 @@ class BreadcrumbHeaderPanel(
 		mode = newMode
 		val branchVisible = newMode == Mode.BRANCH
 		slashLabel.isVisible = branchVisible
-		branchIcon.isVisible = branchVisible
-		branchCombo.isVisible = branchVisible
+		branchPicker.isVisible = branchVisible
 		showingLabel.isVisible = !branchVisible
 		revalidate()
 		repaint()
 	}
 
-	/** Populate combos. Call from a background thread after KB data is loaded. */
+	/** Populate pickers. Call from a background thread after KB data is loaded. */
 	fun refresh() {
 		val gitOps = service.getGitOps() ?: return
 		currentRepoName = service.mainRepoRoot?.let { KBPathResolver.extractRepoName(it) }
@@ -128,12 +124,9 @@ class BreadcrumbHeaderPanel(
 		val repoNames = discoveredRepos.map { it.repoName }
 
 		SwingUtilities.invokeLater {
-			suppressEvents = true
-			repoCombo.model = DefaultComboBoxModel(repoNames.toTypedArray())
-			if (repoNames.isNotEmpty()) {
-				repoCombo.selectedIndex = 0 // current repo is first
-			}
-			suppressEvents = false
+			repoPicker.setItems(repoNames)
+			// Current repo is first.
+			repoPicker.setSelectedSilently(repoNames.firstOrNull())
 			refreshBranches()
 		}
 	}
@@ -143,7 +136,7 @@ class BreadcrumbHeaderPanel(
 	}
 
 	private fun refreshBranches() {
-		val selectedRepo = repoCombo.selectedItem as? String ?: return
+		val selectedRepo = repoPicker.selected ?: return
 		val isCurrentRepo = repos.find { it.repoName == selectedRepo }?.isCurrentRepo == true
 
 		ApplicationManager.getApplication().executeOnPooledThread {
@@ -159,22 +152,20 @@ class BreadcrumbHeaderPanel(
 			}
 
 			SwingUtilities.invokeLater {
-				suppressEvents = true
-				branchCombo.model = DefaultComboBoxModel(branches.toTypedArray())
+				branchPicker.setItems(branches)
 				if (isCurrentRepo && currentBranch != null) {
-					branchCombo.selectedItem = currentBranch
-				} else if (branches.isNotEmpty()) {
-					branchCombo.selectedIndex = 0
+					branchPicker.setSelectedSilently(currentBranch)
+				} else {
+					branchPicker.setSelectedSilently(branches.firstOrNull())
 				}
-				suppressEvents = false
 				onBranchSelected()
 			}
 		}
 	}
 
 	private fun onBranchSelected() {
-		val selectedRepo = repoCombo.selectedItem as? String ?: return
-		val selectedBranch = branchCombo.selectedItem as? String ?: return
+		val selectedRepo = repoPicker.selected ?: return
+		val selectedBranch = branchPicker.selected ?: return
 		val isCurrentRepo = repos.find { it.repoName == selectedRepo }?.isCurrentRepo == true
 		val isForeign = !isCurrentRepo || selectedBranch != currentBranch
 
@@ -183,6 +174,79 @@ class BreadcrumbHeaderPanel(
 			if (isForeign) selectedBranch else null,
 			isForeign,
 		)
+	}
+
+	/** Update the current branch display without full refresh (e.g., on branch switch). */
+	fun updateCurrentBranch(branch: String) {
+		currentBranch = branch
+		SwingUtilities.invokeLater {
+			val isCurrentRepo = repos.find { it.repoName == repoPicker.selected }?.isCurrentRepo == true
+			if (!isCurrentRepo) return@invokeLater
+			// A freshly created branch isn't in the picker's list yet, so simply
+			// selecting it by name is a no-op. Re-list branches from git in that case
+			// so the new branch appears and gets selected.
+			if (branchPicker.hasItem(branch)) {
+				branchPicker.setSelectedSilently(branch)
+			} else {
+				refreshBranches()
+			}
+		}
+	}
+
+	/**
+	 * A flat breadcrumb "crumb": current value as label text + a trailing chevron,
+	 * opening a popup list on click. Inherits the header background (no boxed combo
+	 * field), matching the mockup's `.crumb` styling.
+	 */
+	private inner class CrumbPicker(
+		private val isWorkspaceItem: (value: String, index: Int) -> Boolean,
+		private val onPick: (String) -> Unit,
+	) : JBLabel() {
+
+		private var items: List<String> = emptyList()
+		var selected: String? = null
+			private set
+
+		init {
+			icon = AllIcons.General.ArrowDown
+			horizontalTextPosition = SwingConstants.LEFT // chevron sits to the right of the text
+			iconTextGap = JBUI.scale(2)
+			font = font.deriveFont(font.size2D - 1f)
+			cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+			border = JBUI.Borders.empty(1, 2)
+			// Allow the elastic branch crumb to shrink (and clip to "…") on narrow windows.
+			minimumSize = Dimension(JBUI.scale(30), preferredSize.height)
+			addMouseListener(object : MouseAdapter() {
+				override fun mouseClicked(e: MouseEvent) {
+					if (SwingUtilities.isLeftMouseButton(e)) showPopup()
+				}
+			})
+		}
+
+		fun setItems(newItems: List<String>) {
+			items = newItems
+		}
+
+		fun hasItem(value: String): Boolean = items.contains(value)
+
+		/** Set the displayed selection without firing [onPick] (programmatic update). */
+		fun setSelectedSilently(value: String?) {
+			selected = value
+			text = value ?: ""
+		}
+
+		private fun showPopup() {
+			if (items.isEmpty()) return
+			JBPopupFactory.getInstance()
+				.createPopupChooserBuilder(items)
+				.setRenderer(WorkspaceAwareCellRenderer(isWorkspaceItem))
+				.setItemChosenCallback { chosen ->
+					setSelectedSilently(chosen)
+					onPick(chosen)
+				}
+				.createPopup()
+				.showUnderneathOf(this)
+		}
 	}
 
 	/**
@@ -202,7 +266,7 @@ class BreadcrumbHeaderPanel(
 
 			if (isWorkspace) {
 				label.text = "<html><b>$strValue</b> <span style='color:gray'>(current)</span></html>"
-				// Separator line below the workspace item (only in dropdown, not in the collapsed combo)
+				// Separator line below the workspace item.
 				if (index >= 0) {
 					label.border = BorderFactory.createCompoundBorder(
 						BorderFactory.createMatteBorder(0, 0, 1, 0, com.intellij.ui.JBColor.border()),
@@ -216,28 +280,6 @@ class BreadcrumbHeaderPanel(
 				}
 			}
 			return label
-		}
-	}
-
-	/** Update the current branch display without full refresh (e.g., on branch switch). */
-	fun updateCurrentBranch(branch: String) {
-		currentBranch = branch
-		SwingUtilities.invokeLater {
-			val selectedRepo = repoCombo.selectedItem as? String
-			val isCurrentRepo = repos.find { it.repoName == selectedRepo }?.isCurrentRepo == true
-			if (!isCurrentRepo) return@invokeLater
-			// A freshly created branch isn't in the dropdown model yet, so simply
-			// selecting it by name is a no-op. Re-list branches from git in that
-			// case so the new branch appears and gets selected.
-			val model = branchCombo.model
-			val present = (0 until model.size).any { model.getElementAt(it) == branch }
-			if (present) {
-				suppressEvents = true
-				branchCombo.selectedItem = branch
-				suppressEvents = false
-			} else {
-				refreshBranches()
-			}
 		}
 	}
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ChangesPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ChangesPanel.kt
@@ -29,6 +29,7 @@ import java.awt.Cursor
 import java.awt.Dimension
 import java.awt.FlowLayout
 import java.awt.event.MouseAdapter
+import java.awt.font.TextAttribute
 import java.awt.event.MouseEvent
 import java.io.File
 import com.intellij.openapi.actionSystem.ActionManager
@@ -39,7 +40,6 @@ import javax.swing.Box
 import javax.swing.BoxLayout
 import javax.swing.JButton
 import com.intellij.ui.JBColor
-import java.awt.font.TextAttribute
 import javax.swing.JLabel
 import javax.swing.JMenuItem
 import javax.swing.JPanel
@@ -90,8 +90,11 @@ class ChangesPanel(
     /** Tracks which row panel is currently hovered (for showing discard icon). */
     private var hoveredRow: JPanel? = null
 
+
     init {
-        border = JBUI.Borders.empty(8)
+        // Match PINNED's container insets (empty(2,4)) so all sections share the same
+        // first-row/last-row edge gaps. Each row adds empty(2,4) → 4px edge, 8px sides.
+        border = JBUI.Borders.empty(2, 4)
 
         // Listen for status changes (enable/disable)
         service.addStatusListener(statusListener)
@@ -228,6 +231,7 @@ class ChangesPanel(
         val anyUnselected = selectedStates.any { !it }
         for (i in selectedStates.indices) selectedStates[i] = anyUnselected
         updateFileList()
+        service.notifySelectionChanged()
     }
 
     /** Discards changes for all selected files after confirmation. */
@@ -301,40 +305,35 @@ class ChangesPanel(
 
         val displayStatus = displayStatusCode(change.statusCode)
 
-        val nameLabel = JLabel(fileName)
+        // Filename (line 1) + parent directory (line 2). Always two lines so the row
+        // has room for the hover icons and the full name/path are readable; each line
+        // ellipsizes when too narrow.
+        val parentDir = File(change.relativePath).parent?.let { "$it/" } ?: ""
+
+        val nameLabel = JLabel(fileName).apply {
+            minimumSize = Dimension(0, preferredSize.height)
+            alignmentX = Component.LEFT_ALIGNMENT
+        }
         val baseNameFont = nameLabel.font
         val strikeNameFont = baseNameFont.deriveFont(mapOf(TextAttribute.STRIKETHROUGH to TextAttribute.STRIKETHROUGH_ON))
-
-        // Parent directory (gray, smaller font — follows directly after filename)
-        val parentDir = File(change.relativePath).parent?.let { "$it/" } ?: ""
         val pathLabel = JLabel(parentDir).apply {
             foreground = Color.GRAY
             font = font.deriveFont(font.size2D - 1f)
-            // Allow the label to shrink so it truncates instead of forcing wider rows
             minimumSize = Dimension(0, preferredSize.height)
+            alignmentX = Component.LEFT_ALIGNMENT
+            isVisible = parentDir.isNotBlank()
+        }
+        val centerPanel = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            isOpaque = false
+            add(nameLabel)
+            add(pathLabel)
         }
 
-        // Left side: GridBagLayout ensures checkbox + icon + filename get their preferred
-        // widths and the path label fills remaining space without clipping.
-        val leftPanel = JPanel(java.awt.GridBagLayout()).apply {
+        // Icon, vertically centered next to the two-line text.
+        val iconWrap = JPanel(java.awt.GridBagLayout()).apply {
             isOpaque = false
-            val gbc = java.awt.GridBagConstraints()
-            gbc.gridy = 0
-            gbc.anchor = java.awt.GridBagConstraints.WEST
-            gbc.fill = java.awt.GridBagConstraints.NONE
-            gbc.weightx = 0.0
-
-            gbc.gridx = 0
-            add(iconLabel, gbc)
-
-            gbc.gridx = 1
-            add(nameLabel, gbc)
-
-            gbc.gridx = 2
-            gbc.weightx = 1.0
-            gbc.fill = java.awt.GridBagConstraints.HORIZONTAL
-            gbc.insets = JBUI.insetsLeft(4)
-            add(pathLabel, gbc)
+            add(iconLabel, java.awt.GridBagConstraints())
         }
 
         // Status badge (colored letter matching VS Code: M, A, D, U, R)
@@ -366,20 +365,34 @@ class ChangesPanel(
             border = JBUI.Borders.emptyLeft(2)
         }
 
-        // Right side: status badge + discard + select toggle
-        val rightPanel = JPanel(FlowLayout(FlowLayout.RIGHT, 0, 0)).apply {
+        // Right side: status badge + discard + select toggle, vertically centered with a
+        // reserved width measured with the hover actions visible (and the toggle icon set,
+        // so its width is counted) — otherwise the last icon is clipped.
+        val rightInner = JPanel(FlowLayout(FlowLayout.RIGHT, 0, 0)).apply {
             isOpaque = false
             add(statusLabel)
             add(discardLabel)
             add(toggleLabel)
+        }
+        toggleLabel.icon = AllIcons.Actions.Close
+        discardLabel.isVisible = true; toggleLabel.isVisible = true
+        val reservedRightW = rightInner.preferredSize.width
+        discardLabel.isVisible = false; toggleLabel.isVisible = false
+        val rightWrap = JPanel(java.awt.GridBagLayout()).apply {
+            isOpaque = false
+            add(rightInner, java.awt.GridBagConstraints())
+            preferredSize = Dimension(reservedRightW, JBUI.scale(16))
+            minimumSize = Dimension(reservedRightW, 0)
         }
 
         val row = JPanel(BorderLayout()).apply {
             isOpaque = false
             border = JBUI.Borders.empty(2, 4)
             alignmentX = Component.LEFT_ALIGNMENT
-            add(leftPanel, BorderLayout.CENTER)
-            add(rightPanel, BorderLayout.EAST)
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+            add(iconWrap, BorderLayout.WEST)
+            add(centerPanel, BorderLayout.CENTER)
+            add(rightWrap, BorderLayout.EAST)
         }
 
         // Strike + dim the filename when deselected; flip the toggle icon (✕/＋).
@@ -389,7 +402,6 @@ class ChangesPanel(
             nameLabel.foreground = if (sel) statusColor(change.statusCode) else JBColor.GRAY
             toggleLabel.icon = if (sel) AllIcons.Actions.Close else AllIcons.General.Add
             toggleLabel.toolTipText = if (sel) "Exclude from commit" else "Include in commit"
-            leftPanel.revalidate()
             row.repaint()
         }
         applySelection()
@@ -401,6 +413,7 @@ class ChangesPanel(
                     selectedStates[index] = !(selectedStates.getOrNull(index) ?: true)
                 }
                 applySelection()
+                service.notifySelectionChanged()
             }
         })
 
@@ -408,6 +421,8 @@ class ChangesPanel(
         val hoverListener = object : MouseAdapter() {
             override fun mouseEntered(e: MouseEvent) {
                 hoveredRow = row
+                row.isOpaque = true
+                row.background = RowStyle.HOVER_BG
                 discardLabel.isVisible = true
                 toggleLabel.isVisible = true
                 row.repaint()
@@ -417,6 +432,8 @@ class ChangesPanel(
                 val point = SwingUtilities.convertPoint(e.component, e.point, row)
                 if (!row.contains(point)) {
                     hoveredRow = null
+                    row.isOpaque = false
+                    row.background = null
                     discardLabel.isVisible = false
                     toggleLabel.isVisible = false
                     row.repaint()
@@ -454,12 +471,12 @@ class ChangesPanel(
         // Attach hover listener to the row and all child components
         row.addMouseListener(hoverListener)
         row.addMouseListener(contextMenuListener)
-        for (child in listOf(leftPanel, rightPanel, iconLabel, nameLabel, pathLabel, statusLabel, discardLabel, toggleLabel)) {
+        for (child in listOf(iconWrap, rightWrap, rightInner, centerPanel, iconLabel, nameLabel, pathLabel, statusLabel, discardLabel, toggleLabel)) {
             child.addMouseListener(hoverListener)
             child.addMouseListener(contextMenuListener)
         }
 
-        // Constrain row height so BoxLayout doesn't stretch rows apart
+        // Constrain row height so BoxLayout doesn't stretch rows apart.
         row.maximumSize = Dimension(Int.MAX_VALUE, row.preferredSize.height)
         return row
     }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CollapsiblePanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CollapsiblePanel.kt
@@ -5,13 +5,19 @@ import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionToolbar
 import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.ui.ColorUtil
+import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBLabel
 import com.intellij.util.ui.JBUI
 import java.awt.BorderLayout
 import java.awt.Cursor
 import java.awt.Dimension
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
+import javax.swing.Box
+import javax.swing.Icon
 import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.UIManager
@@ -42,6 +48,10 @@ class CollapsiblePanel(
      *  instead of giving it a share of the surplus space. Used for the Pinned panel
      *  so its height tracks the number of pinned items. */
     private val fitContent: Boolean = false,
+    /** Optional accent icon shown between the expand arrow and the title text,
+     *  e.g. the pin badge on the PINNED section (matches the mockup, which gives
+     *  only that section a leading icon). */
+    private val titleIcon: Icon? = null,
 ) : JPanel(BorderLayout()) {
 
     private val persistenceKey = "JolliMemory.CollapsiblePanel.expanded.$title"
@@ -52,16 +62,37 @@ class CollapsiblePanel(
 
     init {
         // Build header
+        val separatorColor = UIManager.getColor("Separator.separatorColor")
+            ?: UIManager.getColor("Component.borderColor")
+            ?: java.awt.Color.GRAY
         headerPanel.apply {
-            border = JBUI.Borders.empty(4, 4, 4, 0)
+            // Grey divider along the top edge + padding, so every section title reads
+            // as a banded header even when collapsed (matches the mockup's
+            // section-header border-top).
+            // Line is the OUTER border (drawn at the very top edge); the empty padding
+            // is INNER so it sits between the divider line and the title text. The top
+            // value is the gap below the line — bump it to give the title more room
+            // (also offsets the bold font's descent, which reads top-heavy).
+            border = javax.swing.BorderFactory.createCompoundBorder(
+                JBUI.Borders.customLineTop(separatorColor),
+                JBUI.Borders.empty(8, 4, 5, 0),
+            )
             cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
             isOpaque = true
-            background = UIManager.getColor("ToolWindow.HeaderTab.selectedInactiveBackground")
-                ?: UIManager.getColor("Panel.background")
+            // A header band that stands apart from the panel body: lighter in dark
+            // themes, a touch darker in light themes — mirroring VS Code's
+            // sideBarSectionHeader background.
+            background = JBColor.lazy {
+                val panel = UIManager.getColor("Panel.background") ?: JBColor.background()
+                if (ColorUtil.isDark(panel)) ColorUtil.brighter(panel, 2) else ColorUtil.darker(panel, 1)
+            }
         }
 
         titleLabel.apply {
-            font = font.deriveFont(java.awt.Font.BOLD)
+            // Mockup section headers are 11px (base − 2) — smaller than the row titles
+            // below them. Keeping them at the full label size inverted that hierarchy
+            // and made the sidebar read crowded.
+            font = font.deriveFont(java.awt.Font.BOLD, font.size2D - 2f)
             border = JBUI.Borders.emptyLeft(4)
         }
 
@@ -73,13 +104,34 @@ class CollapsiblePanel(
         val leftPanel = JPanel(java.awt.FlowLayout(java.awt.FlowLayout.LEFT, 0, 0)).apply {
             isOpaque = false
             add(arrowLabel)
+            if (titleIcon != null) {
+                add(Box.createHorizontalStrut(JBUI.scale(2)))
+                add(JBLabel(titleIcon))
+            }
             add(titleLabel)
             if (headerExtra != null) {
                 headerExtra.isOpaque = false
                 add(headerExtra)
             }
         }
-        headerPanel.add(leftPanel, BorderLayout.CENTER)
+        // BorderLayout.CENTER stretches leftPanel to the full header height, but a
+        // FlowLayout pins its row to the top of that space — leaving the title looking
+        // top-aligned whenever the toolbar/arrow make the header taller than the text.
+        // Wrap it in a GridBag cell so the row keeps its preferred height and is
+        // vertically centered (WEST anchor + horizontal fill keeps it left-aligned and
+        // full-width).
+        val centerWrap = JPanel(GridBagLayout()).apply {
+            isOpaque = false
+            add(
+                leftPanel,
+                GridBagConstraints().apply {
+                    anchor = GridBagConstraints.WEST
+                    fill = GridBagConstraints.HORIZONTAL
+                    weightx = 1.0
+                },
+            )
+        }
+        headerPanel.add(centerWrap, BorderLayout.CENTER)
 
         // Right side: action toolbar
         val actionGroup = ActionManager.getInstance().getAction(actionGroupId)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
@@ -5,6 +5,7 @@ import ai.jolli.jollimemory.bridge.CommitSummaryBrief
 import ai.jolli.jollimemory.bridge.ConversationBrief
 import ai.jolli.jollimemory.core.ActiveConversationItem
 import ai.jolli.jollimemory.core.CommitSummary
+import ai.jolli.jollimemory.core.NoteFormat
 import ai.jolli.jollimemory.core.TranscriptSource
 import ai.jolli.jollimemory.core.KBDataCache
 import com.google.gson.Gson
@@ -50,6 +51,7 @@ import javax.swing.BoxLayout
 import javax.swing.JCheckBox
 import javax.swing.JComponent
 import javax.swing.JLabel
+import javax.swing.JTextArea
 import javax.swing.JOptionPane
 import javax.swing.JPanel
 import javax.swing.SwingConstants
@@ -606,16 +608,28 @@ class CommitsPanel(
         val displayMessage = commit.message.ifBlank { commit.shortHash }
         val pushedBadge = if (commit.isPushed) " \u2601" else ""
         val typeBadge = if (commit.commitType != null) " [${commit.commitType}]" else ""
-        val titleLabel = JLabel("$displayMessage$pushedBadge$typeBadge").apply {
-            minimumSize = Dimension(0, preferredSize.height)
+        val titleLabel = JTextArea("$displayMessage$pushedBadge$typeBadge").apply {
+            // Wrapping title so long commit messages wrap and grow the row instead of
+            // clipping. Styled like a label at the mockup's 12px (base − 1).
+            isEditable = false
+            isFocusable = false
+            isOpaque = false
+            lineWrap = true
+            wrapStyleWord = true
+            margin = JBUI.insets(0)
+            border = JBUI.Borders.empty()
+            font = JBUI.Fonts.label().let { it.deriveFont(it.size2D - 1f) }
             alignmentX = Component.LEFT_ALIGNMENT
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
         }
 
         // Sub-line: "<relative time> \u00b7 <shortHash> \u00b7 <token spend>".
         val dimFg = UIManager.getColor("Component.infoForeground") ?: Color.GRAY
         val subLabel = JLabel(buildSubLine(commit)).apply {
             foreground = dimFg
-            font = font.deriveFont(font.size2D - 1f)
+            // Mockup sub-line is ~10.5px (base − 2.5); base − 2 keeps it clearly
+            // smaller than the title while still legible at the IDE's font scale.
+            font = font.deriveFont(font.size2D - 2f)
             alignmentX = Component.LEFT_ALIGNMENT
         }
 
@@ -672,34 +686,59 @@ class CommitsPanel(
             rowActions.forEach { add(it) }
         }
 
-        // Title line: arrow/checkbox · title+sub · eye/more.
-        val topLine = JPanel(BorderLayout(2, 0)).apply {
+        // Title line: arrow/checkbox · title+sub · eye/more. Height tracks the wrapped
+        // title at the current width (the title + sub stack in CENTER).
+        val topLine = object : JPanel(BorderLayout(2, 0)) {
+            override fun getMaximumSize(): Dimension = Dimension(Int.MAX_VALUE, preferredSize.height)
+            override fun getPreferredSize(): Dimension {
+                val base = super.getPreferredSize()
+                val w = width
+                if (w <= 0) return base
+                val ins = insets
+                val cW = (w - ins.left - ins.right - leftPanel.preferredSize.width - rightPanel.preferredSize.width - 2 * 2)
+                    .coerceAtLeast(JBUI.scale(20))
+                titleLabel.setSize(cW, Short.MAX_VALUE.toInt())
+                val centerH = titleLabel.preferredSize.height + subLabel.preferredSize.height
+                val h = maxOf(centerH, leftPanel.preferredSize.height, rightPanel.preferredSize.height)
+                return Dimension(base.width, h + ins.top + ins.bottom)
+            }
+        }.apply {
             isOpaque = false
             alignmentX = Component.LEFT_ALIGNMENT
             add(leftPanel, BorderLayout.WEST)
             add(centerPanel, BorderLayout.CENTER)
             add(rightPanel, BorderLayout.EAST)
-            maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
         }
 
         // The row is a vertical stack so the chips + "Show memory details" rows
         // span the full width and right-align to the window edge (matching the
         // "Hide memory details" link at the bottom of the expanded section),
         // rather than being boxed inside the title's CENTER region.
-        val row = JPanel().apply {
+        val row = object : JPanel() {
+            // Height tracks content (the title wraps and grows topLine), so the max must
+            // follow the current preferred height rather than a value fixed at build time.
+            override fun getMaximumSize(): Dimension = Dimension(Int.MAX_VALUE, preferredSize.height)
+        }.apply {
             layout = BoxLayout(this, BoxLayout.Y_AXIS)
             isOpaque = true
             border = JBUI.Borders.empty(2, 4)
             alignmentX = Component.LEFT_ALIGNMENT
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
             add(topLine)
             add(chipsRow)
             add(detailsToggle)
         }
+        // Re-wrap the title (recompute height) when the row width changes on resize.
+        row.addComponentListener(object : java.awt.event.ComponentAdapter() {
+            override fun componentResized(e: java.awt.event.ComponentEvent) { row.revalidate() }
+        })
         // Hover: reveal the Pin/Copy/Share actions + the sticky hover popup
         // (1s show delay, 200ms hide grace). Hiding is bounds-checked so moving
         // between the row's children doesn't flicker the icons away.
         val hoverListener = object : MouseAdapter() {
             override fun mouseEntered(e: MouseEvent) {
+                row.background = RowStyle.HOVER_BG
+                row.repaint()
                 rowActions.forEach { it.isVisible = true }
                 scheduleShowHoverPopup(row, commit)
             }
@@ -708,6 +747,8 @@ class CommitsPanel(
                 val screen = src.locationOnScreen.apply { translate(e.x, e.y) }
                 val loc = row.locationOnScreen
                 if (!java.awt.Rectangle(loc.x, loc.y, row.width, row.height).contains(screen)) {
+                    row.background = null
+                    row.repaint()
                     rowActions.forEach { it.isVisible = false }
                 }
                 scheduleHoverDismiss()
@@ -768,6 +809,7 @@ class CommitsPanel(
     private fun pinMemory(commit: CommitSummaryBrief) {
         val cwd = service.mainRepoRoot ?: project.basePath ?: return
         val title = commit.message.ifBlank { commit.shortHash }
+        ai.jolli.jollimemory.core.telemetry.Telemetry.track("memory_pinned", mapOf("kind" to "memories"))
         ApplicationManager.getApplication().executeOnPooledThread {
             ai.jolli.jollimemory.core.PinStore.pin(cwd, "memories", commit.hash, title, "M")
             SwingUtilities.invokeLater { service.panelRegistry?.pinnedPanel?.refresh() }
@@ -787,6 +829,7 @@ class CommitsPanel(
     private fun toggleExpand(hash: String) {
         val state = commitRowStates[hash] ?: return
         state.isExpanded = !state.isExpanded
+        ai.jolli.jollimemory.core.telemetry.Telemetry.track("memory_expanded", mapOf("expanded" to state.isExpanded))
         state.arrowLabel.text = if (state.isExpanded) ARROW_DOWN else ARROW_RIGHT
         state.fileContainer.isVisible = state.isExpanded
         // The "Show memory details" line only makes sense while collapsed; once
@@ -870,9 +913,13 @@ class CommitsPanel(
         fun collect(s: CommitSummary?) {
             s?.children?.forEach { child ->
                 for (c in service.getCommittedConversations(child.commitHash, child)) {
-                    val key = c.sessionId.ifBlank { "${c.source}|${c.title}" }
+                    // Remember which child commit owns this transcript so the stored-markdown
+                    // fallback in openCommittedConversation reads from the right hash, not the
+                    // squashed parent (which has no transcript of its own).
+                    val cc = if (c.sourceCommitHash == null) c.copy(sourceCommitHash = child.commitHash) else c
+                    val key = cc.sessionId.ifBlank { "${cc.source}|${cc.title}" }
                     val existing = merged[key]
-                    merged[key] = existing?.copy(messageCount = existing.messageCount + c.messageCount) ?: c
+                    merged[key] = existing?.copy(messageCount = existing.messageCount + cc.messageCount) ?: cc
                 }
                 collect(child) // nested squashes
             }
@@ -911,7 +958,9 @@ class CommitsPanel(
                 viewSummary(commit.hash)
             })
         } else {
-            shippedRows.add(detailRow(stateIcon(AllIcons.RunConfigurations.TestState.Green2, false), "E2E test guide — not generated yet", null, dim = true))
+            shippedRows.add(detailRow(stateIcon(AllIcons.RunConfigurations.TestState.Green2, false), "E2E test guide — not generated yet", null, dim = true) {
+                if (commit.hasSummary) viewSummary(commit.hash)
+            })
         }
         if (commit.isSyncedToJolli) {
             val url = commit.jolliDocUrl ?: summary?.jolliDocUrl
@@ -919,7 +968,9 @@ class CommitsPanel(
                 if (url != null) BrowserUtil.browse(url)
             })
         } else {
-            shippedRows.add(detailRow(stateIcon(AllIcons.Actions.Refresh, false), "Not synced to Jolli yet", chip("LOCAL", CHIP_DIM_COLOR), dim = true))
+            shippedRows.add(detailRow(stateIcon(AllIcons.Actions.Refresh, false), "Not synced to Jolli yet", chip("LOCAL", CHIP_DIM_COLOR), dim = true) {
+                if (commit.hasSummary) viewSummary(commit.hash)
+            })
         }
         addGroup(container, "SHIPPED", shippedRows.size, shippedRows)
 
@@ -937,10 +988,29 @@ class CommitsPanel(
 
         // ── CONTEXT (plans / notes / references) ───────────────────────────────
         val contextRows = mutableListOf<JComponent>()
-        summary?.plans?.forEach { contextRows.add(contextRow("P", it.title, null)) }
-        summary?.notes?.forEach { contextRows.add(contextRow("N", it.title, null)) }
+        summary?.plans?.forEach { p ->
+            contextRows.add(contextRow("P", p.title, isLink = false) {
+                trackItemOpened("plan")
+                openArchivedMarkdown(commit, p.title) { service.readArchivedPlan(p.slug) }
+            })
+        }
+        summary?.notes?.forEach { n ->
+            val tag = if (n.format == NoteFormat.snippet) "S" else "N"
+            contextRows.add(contextRow(tag, n.title, isLink = false) {
+                trackItemOpened("note")
+                if (n.format == NoteFormat.snippet && n.content != null) {
+                    openMarkdownContent(n.content, n.title)
+                } else {
+                    openArchivedMarkdown(commit, n.title) { service.readArchivedNote(n.id) }
+                }
+            })
+        }
         summary?.references?.forEach { ref ->
-            contextRows.add(contextRow(referenceTag(ref.source), ref.title, ref.url.ifBlank { null }))
+            val url = ref.url.ifBlank { null }
+            contextRows.add(contextRow(referenceTag(ref.source), ref.title, isLink = url != null) {
+                trackItemOpened("reference")
+                if (url != null) BrowserUtil.browse(url) else if (commit.hasSummary) viewSummary(commit.hash)
+            })
         }
         val contextCount = contextRows.size
         if (contextRows.isEmpty()) contextRows.add(plainDetailRow("No linked context"))
@@ -1002,28 +1072,112 @@ class CommitsPanel(
         dim: Boolean = false,
         onClick: (() -> Unit)? = null,
     ): JComponent {
-        val label = JLabel(text, icon, SwingConstants.LEFT).apply {
-            iconTextGap = JBUI.scale(6)
+        val iconWrap = RowStyle.vCenter(JLabel(icon))
+        val textArea = wrappingTitleArea(text).apply {
             if (dim) foreground = CHIP_DIM_COLOR
+            if (onClick == null) cursor = Cursor.getDefaultCursor()
         }
-        val row = JPanel(BorderLayout()).apply {
-            isOpaque = false
-            border = JBUI.Borders.empty(1, 24, 1, 4)
-            alignmentX = Component.LEFT_ALIGNMENT
-            add(label, BorderLayout.CENTER)
-            if (trailing != null) {
-                add(JPanel(FlowLayout(FlowLayout.RIGHT, 0, 0)).apply { isOpaque = false; add(trailing) }, BorderLayout.EAST)
-            }
-        }
+        val east = trailing?.let { RowStyle.vCenter(JPanel(FlowLayout(FlowLayout.RIGHT, 0, 0)).apply { isOpaque = false; add(it) }) }
+        val row = wrappingRow(iconWrap, textArea, east, leftIndent = 24)
         if (onClick != null) {
-            row.cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
             val click = object : MouseAdapter() {
-                override fun mouseClicked(e: MouseEvent) { if (e.clickCount == 1) onClick() }
+                override fun mouseClicked(e: MouseEvent) {
+                    if (e.clickCount == 1) { trackItemOpened("shipped"); onClick() }
+                }
             }
-            label.addMouseListener(click); row.addMouseListener(click)
+            textArea.addMouseListener(click); row.addMouseListener(click)
         }
-        row.maximumSize = Dimension(Int.MAX_VALUE, row.preferredSize.height)
+        attachRowHoverBar(row, listOfNotNull(textArea, iconWrap, east))
         return row
+    }
+
+    /** Records that an item inside a memory was opened (conversation/file/context/shipped). */
+    private fun trackItemOpened(itemType: String) {
+        ai.jolli.jollimemory.core.telemetry.Telemetry.track("memory_item_opened", mapOf("item_type" to itemType))
+    }
+
+    /** A label-styled, word-wrapping title for sub-section rows. */
+    private fun wrappingTitleArea(text: String): JTextArea = JTextArea(text).apply {
+        isEditable = false
+        isFocusable = false
+        isOpaque = false
+        lineWrap = true
+        wrapStyleWord = true
+        margin = JBUI.insets(0)
+        border = JBUI.Borders.empty()
+        font = JBUI.Fonts.label()
+        foreground = UIManager.getColor("Label.foreground") ?: foreground
+        cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+    }
+
+    /**
+     * A BorderLayout sub-section row whose height tracks the wrapped [title] at the
+     * current width. [west]/[east] (badge/tag/actions) stay vertically centered; their
+     * widths are reserved so the title's wrap width — and the row height — are stable.
+     */
+    private fun wrappingRow(west: JComponent?, title: JTextArea, east: JComponent?, leftIndent: Int): JPanel {
+        val gap = JBUI.scale(4)
+        val row = object : JPanel(BorderLayout(gap, 0)) {
+            override fun getMaximumSize(): Dimension = Dimension(Int.MAX_VALUE, preferredSize.height)
+            override fun getPreferredSize(): Dimension {
+                val base = super.getPreferredSize()
+                val w = width
+                if (w <= 0) return base
+                val ins = insets
+                val wW = west?.preferredSize?.width ?: 0
+                val eW = east?.preferredSize?.width ?: 0
+                val gaps = gap * listOfNotNull(west, east).size
+                val tW = (w - ins.left - ins.right - wW - eW - gaps).coerceAtLeast(JBUI.scale(20))
+                title.setSize(tW, Short.MAX_VALUE.toInt())
+                val cH = maxOf(
+                    title.preferredSize.height,
+                    west?.preferredSize?.height ?: 0,
+                    east?.preferredSize?.height ?: 0,
+                    JBUI.scale(16),
+                )
+                return Dimension(w, cH + ins.top + ins.bottom)
+            }
+        }.apply {
+            isOpaque = false
+            border = JBUI.Borders.empty(1, leftIndent, 1, 4)
+            alignmentX = Component.LEFT_ALIGNMENT
+            if (west != null) add(west, BorderLayout.WEST)
+            add(title, BorderLayout.CENTER)
+            if (east != null) add(east, BorderLayout.EAST)
+        }
+        row.addComponentListener(object : java.awt.event.ComponentAdapter() {
+            override fun componentResized(e: java.awt.event.ComponentEvent) { row.revalidate() }
+        })
+        return row
+    }
+
+    /**
+     * Adds the shared translucent hover bar to an expanded sub-section row (the row is
+     * transparent until hovered). Attached to the row + its children so the bar shows
+     * regardless of which child the pointer enters; the exit is bounds-checked against
+     * the row so moving between children doesn't flicker it.
+     */
+    private fun attachRowHoverBar(row: JPanel, children: List<Component>) {
+        val hover = object : MouseAdapter() {
+            override fun mouseEntered(e: MouseEvent) {
+                row.isOpaque = true
+                row.background = RowStyle.HOVER_BG
+                row.repaint()
+            }
+            override fun mouseExited(e: MouseEvent) {
+                val src = e.source as? Component ?: return
+                if (src.isShowing && row.isShowing) {
+                    val screen = src.locationOnScreen.apply { translate(e.x, e.y) }
+                    val loc = row.locationOnScreen
+                    if (java.awt.Rectangle(loc.x, loc.y, row.width, row.height).contains(screen)) return
+                }
+                row.isOpaque = false
+                row.background = null
+                row.repaint()
+            }
+        }
+        row.addMouseListener(hover)
+        children.forEach { it.addMouseListener(hover) }
     }
 
     /**
@@ -1041,22 +1195,14 @@ class CommitsPanel(
      */
     private fun conversationRow(commit: CommitSummaryBrief, c: ConversationBrief): JComponent {
         val badge = SourceBadge.leadFor(c.source)
-        val title = JLabel(c.title).apply { minimumSize = Dimension(0, preferredSize.height) }
+        val title = wrappingTitleArea(c.title)
         val count = JLabel("${c.messageCount} msg${if (c.messageCount != 1) "s" else ""}").apply {
             foreground = UIManager.getColor("Component.infoForeground") ?: Color.GRAY
             font = font.deriveFont(font.size2D - 1f)
         }
-        // hgap 0 (+ explicit strut) so the badge starts flush at the 24px indent —
-        // a FlowLayout hgap would add a leading gap and push it right of SHIPPED/FILES.
-        val left = JPanel(FlowLayout(FlowLayout.LEFT, 0, 0)).apply {
-            isOpaque = false
-            add(badge)
-            add(Box.createHorizontalStrut(JBUI.scale(6)))
-            add(title)
-        }
 
         // Hover actions (hidden until hover): Open conversation · Resume (only if local session exists).
-        val openBtn = convoActionIcon(JolliMemoryIcons.Eye, "Open conversation") { _ -> openCommittedConversation(c) }
+        val openBtn = convoActionIcon(JolliMemoryIcons.Eye, "Open conversation") { _ -> openCommittedConversation(commit, c) }
         val fileExists = !c.transcriptPath.isNullOrBlank() && File(c.transcriptPath).exists()
         val canResume = c.source == "claude" && fileExists
         log.info("conversationRow: source=${c.source}, sessionId=${c.sessionId}, transcriptPath=${c.transcriptPath}, fileExists=$fileExists, canResume=$canResume")
@@ -1069,53 +1215,64 @@ class CommitsPanel(
         } else {
             listOf(openBtn)
         }
-        val east = JPanel(FlowLayout(FlowLayout.RIGHT, JBUI.scale(2), 0)).apply {
+        val eastInner = JPanel(FlowLayout(FlowLayout.RIGHT, JBUI.scale(2), 0)).apply {
             isOpaque = false
             add(count)
             actions.forEach { add(it) }
         }
-
-        val row = JPanel(BorderLayout()).apply {
-            isOpaque = false
-            border = JBUI.Borders.empty(1, 24, 1, 4)
-            alignmentX = Component.LEFT_ALIGNMENT
-            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-            add(left, BorderLayout.CENTER)
-            add(east, BorderLayout.EAST)
-            maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
+        // Reserve the wider of the count vs hover-actions widths so the title's wrap
+        // width (and the row height) stay stable when they swap on hover.
+        count.isVisible = false; actions.forEach { it.isVisible = true }
+        val actionsW = eastInner.preferredSize.width
+        count.isVisible = true; actions.forEach { it.isVisible = false }
+        val reservedEastW = maxOf(actionsW, eastInner.preferredSize.width)
+        val west = RowStyle.vCenter(badge)
+        val east = RowStyle.vCenter(eastInner).apply {
+            preferredSize = Dimension(reservedEastW, JBUI.scale(16))
+            minimumSize = Dimension(reservedEastW, 0)
         }
+        val row = wrappingRow(west, title, east, leftIndent = 24)
 
         // Swap count ↔ actions on hover; bounds-check on exit so moving onto the
         // action icons (still inside the row) doesn't flicker them away.
         val hover = object : MouseAdapter() {
             override fun mouseEntered(e: MouseEvent) {
+                row.isOpaque = true
+                row.background = RowStyle.HOVER_BG
+                row.repaint()
                 count.isVisible = false
                 actions.forEach { it.isVisible = true }
             }
             override fun mouseExited(e: MouseEvent) {
                 val src = e.source as Component
-                if (!src.isShowing || !row.isShowing) {
+                fun clear() {
+                    row.isOpaque = false
+                    row.background = null
+                    row.repaint()
                     count.isVisible = true
                     actions.forEach { it.isVisible = false }
+                }
+                if (!src.isShowing || !row.isShowing) {
+                    clear()
                     return
                 }
                 val screen = src.locationOnScreen.apply { translate(e.x, e.y) }
                 val loc = row.locationOnScreen
                 if (!java.awt.Rectangle(loc.x, loc.y, row.width, row.height).contains(screen)) {
-                    count.isVisible = true
-                    actions.forEach { it.isVisible = false }
+                    clear()
                 }
             }
         }
         val click = object : MouseAdapter() {
             override fun mouseClicked(e: MouseEvent) {
-                if (SwingUtilities.isLeftMouseButton(e)) openCommittedConversation(c)
+                if (SwingUtilities.isLeftMouseButton(e)) openCommittedConversation(commit, c)
             }
         }
-        for (cc in listOf(row, left, title, badge, count)) {
+        for (cc in listOf(row, west, badge, title)) {
             cc.addMouseListener(hover)
             cc.addMouseListener(click)
         }
+        for (cc in listOf(eastInner, count)) cc.addMouseListener(hover)
         actions.forEach { it.addMouseListener(hover) }
         return row
     }
@@ -1140,18 +1297,40 @@ class CommitsPanel(
      * transcript path; degrades to a message when the original file isn't
      * recorded / resolvable.
      */
-    private fun openCommittedConversation(c: ConversationBrief) {
+    private fun openCommittedConversation(commit: CommitSummaryBrief, c: ConversationBrief) {
         val cwd = service.mainRepoRoot ?: project.basePath ?: return
         val source = TranscriptSource.entries.firstOrNull { it.name == c.source }
         val path = c.transcriptPath
-        if (source == null || path.isNullOrBlank()) {
-            com.intellij.openapi.ui.Messages.showInfoMessage(
-                project,
-                "The original conversation file for this memory isn't available to open.",
-                "Open Conversation",
+        // The live transcript file may be gone (deleted / never recorded). When it can't
+        // be opened, render the conversation stored in the memory itself (read-only),
+        // falling back to the commit memory only if even that isn't available.
+        if (source == null || path.isNullOrBlank() || !File(path).exists()) {
+            ai.jolli.jollimemory.core.telemetry.Telemetry.track(
+                "memory_item_opened",
+                mapOf("item_type" to "conversation", "render" to "stored", "source" to c.source),
             )
+            ApplicationManager.getApplication().executeOnPooledThread {
+                // For squashed memories the transcript lives on the child commit, not the
+                // displayed parent — read from sourceCommitHash when present.
+                val md = service.readCommittedConversationMarkdown(c.sourceCommitHash ?: commit.hash, c.sessionId)
+                SwingUtilities.invokeLater {
+                    when {
+                        md != null -> openMarkdownContent(md, c.title)
+                        commit.hasSummary -> viewSummary(commit.hash)
+                        else -> com.intellij.openapi.ui.Messages.showInfoMessage(
+                            project,
+                            "The conversation for this memory isn't available to open.",
+                            "Open Conversation",
+                        )
+                    }
+                }
+            }
             return
         }
+        ai.jolli.jollimemory.core.telemetry.Telemetry.track(
+            "memory_item_opened",
+            mapOf("item_type" to "conversation", "render" to "live", "source" to c.source),
+        )
         val item = ActiveConversationItem(
             sessionId = c.sessionId,
             source = source,
@@ -1165,32 +1344,50 @@ class CommitsPanel(
             .openFile(ConversationVirtualFile(item, cwd), true)
     }
 
-    /** A CONTEXT row: a small kind tag (P / N / L / GH …) + title, optionally a link. */
-    private fun contextRow(tag: String, title: String, url: String?): JComponent {
+    /**
+     * A CONTEXT row: a small kind tag (P / N / L / GH …) + wrapping title. Clicking runs
+     * [onClick] (open the plan/note body or the reference link). [isLink] styles the
+     * title as a link.
+     */
+    private fun contextRow(tag: String, title: String, isLink: Boolean, onClick: () -> Unit): JComponent {
         val tagLabel = chip(tag, CHIP_DIM_COLOR)
-        val titleLabel = JLabel(title).apply {
-            if (url != null) {
-                foreground = JBUI.CurrentTheme.Link.Foreground.ENABLED
-                cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+        val titleArea = wrappingTitleArea(title).apply {
+            if (isLink) foreground = JBUI.CurrentTheme.Link.Foreground.ENABLED
+        }
+        val west = RowStyle.vCenter(JPanel(FlowLayout(FlowLayout.LEFT, 0, 0)).apply { isOpaque = false; add(tagLabel) })
+        val row = wrappingRow(west, titleArea, east = null, leftIndent = 24)
+        val click = object : MouseAdapter() {
+            override fun mouseClicked(e: MouseEvent) {
+                if (e.clickCount == 1 && SwingUtilities.isLeftMouseButton(e)) onClick()
             }
-            minimumSize = Dimension(0, preferredSize.height)
         }
-        val row = JPanel(FlowLayout(FlowLayout.LEFT, 0, 0)).apply {
-            isOpaque = false
-            border = JBUI.Borders.empty(1, 24, 1, 4)
-            alignmentX = Component.LEFT_ALIGNMENT
-            add(tagLabel)
-            add(Box.createHorizontalStrut(JBUI.scale(6)))
-            add(titleLabel)
-            maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
-        }
-        if (url != null) {
-            val click = object : MouseAdapter() {
-                override fun mouseClicked(e: MouseEvent) { if (e.clickCount == 1) BrowserUtil.browse(url) }
-            }
-            titleLabel.addMouseListener(click); row.addMouseListener(click)
-        }
+        titleArea.addMouseListener(click); row.addMouseListener(click)
+        attachRowHoverBar(row, listOf(tagLabel, titleArea, west))
         return row
+    }
+
+    /** Opens markdown [content] read-only in a preview editor (in-memory, no disk file). */
+    private fun openMarkdownContent(content: String, name: String) {
+        val safeName = if (name.endsWith(".md")) name else "$name.md"
+        val vf = com.intellij.testFramework.LightVirtualFile(safeName, content).apply { isWritable = false }
+        MarkdownPreview.open(project, vf)
+    }
+
+    /**
+     * Reads an archived plan/note body from committed-memory storage (off the EDT) and
+     * opens it read-only; falls back to the commit memory if the body isn't found.
+     */
+    private fun openArchivedMarkdown(commit: CommitSummaryBrief, title: String, read: () -> String?) {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val body = read()
+            SwingUtilities.invokeLater {
+                if (body != null) {
+                    openMarkdownContent(body, title)
+                } else if (commit.hasSummary) {
+                    viewSummary(commit.hash)
+                }
+            }
+        }
     }
 
     /** A plain indented detail row (fallbacks / placeholders). */
@@ -1224,53 +1421,43 @@ class CommitsPanel(
             border = JBUI.Borders.emptyRight(4)
         }
 
+        // Filename (line 1, status-colored) + relative path (line 2, grey) — always two
+        // lines so long paths are readable; each ellipsizes when too narrow. Matches the
+        // WORKING MEMORY Files rows.
         val nameLabel = JLabel(fileName).apply {
             foreground = statusColor(file.statusCode)
+            minimumSize = Dimension(0, preferredSize.height)
+            alignmentX = Component.LEFT_ALIGNMENT
         }
-
         val pathLabel = JLabel(file.relativePath).apply {
             foreground = Color.GRAY
+            font = font.deriveFont(font.size2D - 1f)
             minimumSize = Dimension(0, preferredSize.height)
+            alignmentX = Component.LEFT_ALIGNMENT
         }
-
-        // Left side: icon + filename + path
-        val leftPanel = JPanel(GridBagLayout()).apply {
+        val centerPanel = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
             isOpaque = false
-            val gbc = GridBagConstraints().apply {
-                gridy = 0
-                anchor = GridBagConstraints.WEST
-                fill = GridBagConstraints.NONE
-                weighty = 1.0
-            }
-
-            gbc.gridx = 0; gbc.weightx = 0.0; gbc.insets = JBUI.insetsRight(4)
-            add(iconLabel, gbc)
-
-            gbc.gridx = 1; gbc.insets = JBUI.emptyInsets()
-            add(nameLabel, gbc)
-
-            gbc.gridx = 2; gbc.weightx = 1.0; gbc.fill = GridBagConstraints.HORIZONTAL
-            gbc.insets = JBUI.insetsLeft(6)
-            add(pathLabel, gbc)
+            add(nameLabel)
+            add(pathLabel)
         }
+        val iconWrap = RowStyle.vCenter(iconLabel)
 
-        // Right side: status badge
+        // Right side: status badge, vertically centered.
         val statusLabel = JLabel(file.statusCode).apply {
             foreground = statusColor(file.statusCode)
             border = JBUI.Borders.emptyRight(4)
         }
-        val rightPanel = JPanel(FlowLayout(FlowLayout.RIGHT, 0, 0)).apply {
-            isOpaque = false
-            add(statusLabel)
-        }
+        val rightWrap = RowStyle.vCenter(JPanel(FlowLayout(FlowLayout.RIGHT, 0, 0)).apply { isOpaque = false; add(statusLabel) })
 
-        val row = JPanel(BorderLayout()).apply {
+        val row = JPanel(BorderLayout(JBUI.scale(4), 0)).apply {
             isOpaque = false
             // Indent file rows under their parent commit
             border = JBUI.Borders.empty(1, 24, 1, 4)
             alignmentX = Component.LEFT_ALIGNMENT
-            add(leftPanel, BorderLayout.CENTER)
-            add(rightPanel, BorderLayout.EAST)
+            add(iconWrap, BorderLayout.WEST)
+            add(centerPanel, BorderLayout.CENTER)
+            add(rightWrap, BorderLayout.EAST)
             toolTipText = file.relativePath
         }
 
@@ -1284,6 +1471,7 @@ class CommitsPanel(
             child.cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
             child.addMouseListener(diffClickListener)
         }
+        attachRowHoverBar(row, listOf(iconLabel, nameLabel, pathLabel, statusLabel, centerPanel, iconWrap, rightWrap))
 
         row.maximumSize = Dimension(Int.MAX_VALUE, row.preferredSize.height)
         return row
@@ -1299,6 +1487,10 @@ class CommitsPanel(
      * - Modified/Renamed files: parent content -> commit content
      */
     private fun openCommitFileDiff(commitHash: String, file: CommitFileInfo) {
+        ai.jolli.jollimemory.core.telemetry.Telemetry.track(
+            "memory_item_opened",
+            mapOf("item_type" to "file", "status" to file.statusCode),
+        )
         ApplicationManager.getApplication().executeOnPooledThread {
             val gitOps = service.getGitOps() ?: return@executeOnPooledThread
 
@@ -1533,6 +1725,7 @@ class CommitsPanel(
         val cwd = service.mainRepoRoot ?: project.basePath
         log.info("resumeInTerminal: sessionId=$sessionId, cwd=$cwd")
         if (cwd == null) return
+        ai.jolli.jollimemory.core.telemetry.Telemetry.track("session_resumed", mapOf("source" to "claude"))
         TerminalUtils.resumeClaudeSession(project, sessionId, cwd)
     }
 
@@ -1563,6 +1756,7 @@ class CommitsPanel(
         val prompt = "Invoke the \"jolli-recall\" skill with args \"$branch\"."
         val clipboard = Toolkit.getDefaultToolkit().systemClipboard
         clipboard.setContents(StringSelection(prompt), null)
+        ai.jolli.jollimemory.core.telemetry.Telemetry.track("recall_prompt_copied")
         com.intellij.openapi.ui.Messages.showInfoMessage(
             project,
             "Recall prompt copied \u2014 paste it into Claude Code.",

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationRowComponent.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationRowComponent.kt
@@ -13,6 +13,7 @@ import java.awt.font.TextAttribute
 import javax.swing.JComponent
 import javax.swing.JLabel
 import javax.swing.JPanel
+import javax.swing.JTextArea
 
 /**
  * A single row in the [ActiveConversationsPanel]. Shows a color-coded source
@@ -36,14 +37,36 @@ class ConversationRowComponent(
 	/** Live selection state; strikethrough + the ✕/＋ toggle mirror this. */
 	private var selected = item.isSelected
 
-	private val titleLabel = JLabel(item.title).apply { border = JBUI.Borders.emptyLeft(8) }
+	// Wrapping title: long conversation names wrap and grow the row taller instead of
+	// clipping to one line. JTextArea (styled like a label) gives word-wrap.
+	private val titleLabel = JTextArea(item.title).apply {
+		border = JBUI.Borders.emptyLeft(8)
+		isEditable = false
+		isFocusable = false
+		isOpaque = false
+		lineWrap = true
+		wrapStyleWord = true
+		margin = JBUI.insets(0)
+		// Match the mockup's 12px row title (base − 1) for a denser, less cluttered list.
+		font = JBUI.Fonts.label().let { it.deriveFont(it.size2D - 1f) }
+	}
 	private val baseFont = titleLabel.font
 	private val strikeFont = baseFont.deriveFont(mapOf(TextAttribute.STRIKETHROUGH to TextAttribute.STRIKETHROUGH_ON))
 	private val baseFg = titleLabel.foreground
 
+	// vCenter wrappers around the badge / right-side controls so they stay vertically
+	// centered as the title wraps and the row grows taller.
+	private var leftWrap: JComponent? = null
+	private var rightWrap: JComponent? = null
+
 	private val pinLabel = actionIcon(AllIcons.General.Pin_tab, "Pin") { onPin(item) }
 	private val eyeLabel = actionIcon(JolliMemoryIcons.Eye, "Open conversation") { onRowClicked(item) }
 	private val resumeLabel = actionIcon(AllIcons.Actions.Execute, "Resume session in terminal") { onResume(item) }
+
+	// Resume runs `claude --resume <id>`, which only works for Claude sessions. For
+	// other sources (Codex, etc.) the icon was shown but the handler silently no-op'd,
+	// so hide it entirely for non-Claude rows (matches the Committed/Pinned panels).
+	private val canResume = item.source == TranscriptSource.claude
 	private val toggleLabel = JLabel().apply {
 		cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
 		isVisible = false
@@ -60,7 +83,7 @@ class ConversationRowComponent(
 
 	private val countLabel = JLabel(if (item.messageCount > 0) "${item.messageCount}" else "").apply {
 		foreground = JBColor.GRAY
-		font = font.deriveFont(font.size2D - 1f)
+		font = font.deriveFont(font.size2D - 2f)
 	}
 
 	private fun actionIcon(icon: javax.swing.Icon, tip: String, onClick: () -> Unit): JLabel =
@@ -84,26 +107,30 @@ class ConversationRowComponent(
 
 	/** Swaps the right side between the message count and the hover actions. */
 	private fun setHovered(hovered: Boolean) {
-		background = if (hovered) JBColor(Color(0, 0, 0, 20), Color(255, 255, 255, 20)) else null
+		background = if (hovered) RowStyle.HOVER_BG else null
 		countLabel.isVisible = !hovered
 		pinLabel.isVisible = hovered
 		eyeLabel.isVisible = hovered
-		resumeLabel.isVisible = hovered
+		resumeLabel.isVisible = hovered && canResume
 		toggleLabel.isVisible = hovered
 	}
 
 	init {
-		border = JBUI.Borders.empty(4, 8)
+		// Match PINNED's row insets (empty(2,4)); the rowsPanel adds the other 4px of
+		// side padding so the edge gaps line up across all sections.
+		border = JBUI.Borders.empty(2, 4)
 		isOpaque = true
 		cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
 
-		// Left side: source badge / logo (no more checkbox)
+		// Left side: source badge / logo (no more checkbox), vertically centered.
 		val badge = SourceBadge.leadFor(item.source.name)
 		val leftPanel = JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(2), 0)).apply {
 			isOpaque = false
 			add(badge)
 		}
-		add(leftPanel, BorderLayout.WEST)
+		val left = RowStyle.vCenter(leftPanel)
+		leftWrap = left
+		add(left, BorderLayout.WEST)
 		add(titleLabel, BorderLayout.CENTER)
 
 		// Right side: count (default) swaps to Pin · Open · Continue · toggle on hover.
@@ -111,9 +138,24 @@ class ConversationRowComponent(
 		rightPanel.add(countLabel)
 		rightPanel.add(pinLabel)
 		rightPanel.add(eyeLabel)
-		rightPanel.add(resumeLabel)
+		if (canResume) rightPanel.add(resumeLabel)
 		rightPanel.add(toggleLabel)
-		add(rightPanel, BorderLayout.EAST)
+		// Reserve the widest state's width (hover actions) so the title's wrap width is
+		// stable whether or not the row is hovered. The toggle icon is set in
+		// applySelectionState() — give it one here first so its width is counted (else
+		// the 4th icon is clipped).
+		toggleLabel.icon = AllIcons.Actions.Close
+		countLabel.isVisible = false
+		pinLabel.isVisible = true; eyeLabel.isVisible = true; resumeLabel.isVisible = canResume; toggleLabel.isVisible = true
+		val reservedRightW = rightPanel.preferredSize.width
+		countLabel.isVisible = true
+		pinLabel.isVisible = false; eyeLabel.isVisible = false; resumeLabel.isVisible = false; toggleLabel.isVisible = false
+		val right = RowStyle.vCenter(rightPanel).apply {
+			preferredSize = Dimension(reservedRightW, JBUI.scale(16))
+			minimumSize = Dimension(reservedRightW, 0)
+		}
+		rightWrap = right
+		add(right, BorderLayout.EAST)
 
 		applySelectionState()
 
@@ -144,12 +186,33 @@ class ConversationRowComponent(
 		addMouseListener(hoverListener)
 		addMouseListener(clickListener)
 		// Icons handle their own clicks; the row body (badge/title/count) opens the conversation.
-		for (c in listOf(leftPanel, badge, titleLabel, rightPanel, countLabel, pinLabel, eyeLabel, resumeLabel, toggleLabel)) {
+		for (c in listOf(left, leftPanel, badge, titleLabel, right, rightPanel, countLabel, pinLabel, eyeLabel, resumeLabel, toggleLabel)) {
 			c.addMouseListener(hoverListener)
-			if (c === leftPanel || c === badge || c === titleLabel || c === rightPanel || c === countLabel) {
+			if (c === left || c === leftPanel || c === badge || c === titleLabel || c === rightPanel || c === countLabel) {
 				c.addMouseListener(clickListener)
 			}
 		}
+
+		// Recompute the wrapped height when the row width changes (tool-window resize).
+		addComponentListener(object : java.awt.event.ComponentAdapter() {
+			override fun componentResized(e: java.awt.event.ComponentEvent) { revalidate() }
+		})
+	}
+
+	override fun getPreferredSize(): Dimension {
+		val base = super.getPreferredSize()
+		val lw = leftWrap
+		val rw = rightWrap
+		val w = width
+		if (w <= 0 || lw == null || rw == null) return base
+		val ins = insets
+		val titleW = (w - ins.left - ins.right - lw.preferredSize.width - rw.preferredSize.width)
+			.coerceAtLeast(JBUI.scale(20))
+		// Sizing the text area to the available width makes its preferred height reflect
+		// the wrapped line count.
+		titleLabel.setSize(titleW, Short.MAX_VALUE.toInt())
+		val contentH = maxOf(titleLabel.preferredSize.height, lw.preferredSize.height, JBUI.scale(16))
+		return Dimension(base.width, contentH + ins.top + ins.bottom)
 	}
 
 	override fun getMaximumSize(): Dimension =

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CurrentMemoryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CurrentMemoryPanel.kt
@@ -8,6 +8,9 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionToolbar
 import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBLabel
@@ -166,8 +169,19 @@ class CurrentMemoryPanel(
 
 	/** Opens the Working Memory web view — the full memory the next commit will save. */
 	private fun onReview() {
-		com.intellij.openapi.fileEditor.FileEditorManager.getInstance(project)
-			.openFile(WorkingMemoryVirtualFile(), true)
+		// openFile() can race editor/project teardown — e.g. right after a project
+		// frame is reused via closeAndDisposeKeepingFrame — which surfaces as a
+		// "parent already disposed" Alarm error inside the platform's editor-tab
+		// creation. Defer to a clean EDT cycle and skip the open if the project has
+		// been disposed in the meantime.
+		ApplicationManager.getApplication().invokeLater(
+			{
+				if (project.isDisposed) return@invokeLater
+				FileEditorManager.getInstance(project).openFile(WorkingMemoryVirtualFile(), true)
+			},
+			ModalityState.defaultModalityState(),
+			{ project.isDisposed },
+		)
 	}
 
 	/** A grey divider between sections (mockup parity) — a stronger, 2px line. */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CurrentMemoryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CurrentMemoryPanel.kt
@@ -49,6 +49,9 @@ class CurrentMemoryPanel(
 
 	private val statusListener: () -> Unit = { SwingUtilities.invokeLater { updateHeader() } }
 
+	/** The three section headers, normalized to a uniform height after construction. */
+	private val sectionHeaders = mutableListOf<JComponent>()
+
 	init {
 		layout = BoxLayout(this, BoxLayout.Y_AXIS)
 
@@ -60,6 +63,9 @@ class CurrentMemoryPanel(
 		addSection(this, "CONVERSATIONS", conversationsActions, conversationsPanel, separatorAfter = true)
 		addSection(this, "CONTEXT", contextActions, contextPanel, separatorAfter = true)
 		addSection(this, "FILES", filesActions, filesPanel, separatorAfter = false)
+		// Headers with an action toolbar are taller than those without; pin all three to
+		// the tallest so the CONVERSATIONS / CONTEXT / FILES titles align consistently.
+		normalizeSectionHeaderHeights()
 		// Commit lives right after the Files list (the bottom bar keeps Create PR).
 		add(commitButtonRow())
 
@@ -70,14 +76,28 @@ class CurrentMemoryPanel(
 	override fun getMaximumSize(): Dimension = Dimension(Int.MAX_VALUE, preferredSize.height)
 
 	private fun addSection(stack: JPanel, title: String, actionGroupId: String, body: JComponent, separatorAfter: Boolean) {
-		stack.add(sectionHeader(title, actionGroupId, body))
+		val header = sectionHeader(title, actionGroupId, body)
+		sectionHeaders.add(header)
+		stack.add(header)
 		body.alignmentX = Component.LEFT_ALIGNMENT
 		stack.add(body)
-		if (separatorAfter) stack.add(blueSeparator())
+		if (separatorAfter) stack.add(sectionSeparator())
+	}
+
+	/** Pins every section header to the tallest header's height so the titles align. */
+	private fun normalizeSectionHeaderHeights() {
+		val maxH = sectionHeaders.maxOfOrNull { it.preferredSize.height } ?: return
+		for (h in sectionHeaders) {
+			h.preferredSize = Dimension(h.preferredSize.width, maxH)
+			h.minimumSize = Dimension(h.minimumSize.width, maxH)
+			h.maximumSize = Dimension(Int.MAX_VALUE, maxH)
+		}
 	}
 
 	private fun sectionHeader(title: String, actionGroupId: String, target: JComponent): JComponent {
-		val titleLabel = JBLabel(title).apply { font = font.deriveFont(Font.BOLD) }
+		// Match the top-level section headers (mockup: 11px / base − 2) so the folded
+		// sub-section titles don't tower over the rows beneath them.
+		val titleLabel = JBLabel(title).apply { font = font.deriveFont(Font.BOLD, font.size2D - 2f) }
 
 		// Live row count in the header, e.g. "CONTEXT (4)".
 		(target as? RowCountSource)?.let { src ->
@@ -87,9 +107,11 @@ class CurrentMemoryPanel(
 		}
 		val header = JPanel(BorderLayout()).apply {
 			isOpaque = false
-			border = JBUI.Borders.empty(4, 6, 2, 2)
+			// Tight header insets: bottom 0 so the title sits right above its first row
+			// (the body keeps its 4px PINNED-aligned top), top 2 to pull consecutive
+			// sections closer together.
+			border = JBUI.Borders.empty(2, 6, 0, 2)
 			alignmentX = Component.LEFT_ALIGNMENT
-			maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
 			add(titleLabel, BorderLayout.WEST)
 		}
 		val group = ActionManager.getInstance().getAction(actionGroupId)
@@ -98,6 +120,9 @@ class CurrentMemoryPanel(
 				.createActionToolbar("JolliMemory.CurrentMemory.$title", group, true)
 			toolbar.targetComponent = target
 			toolbar.setReservePlaceAutoPopupIcon(false)
+			// Compact buttons so the header (whose height is driven by the toolbar) stays
+			// short and consistent with toolbar-less sections.
+			toolbar.minimumButtonSize = Dimension(JBUI.scale(18), JBUI.scale(18))
 			toolbar.component.isOpaque = false
 			header.add(toolbar.component, BorderLayout.EAST)
 		}
@@ -111,6 +136,15 @@ class CurrentMemoryPanel(
 		val commit = JolliButtons.primary("Commit", JolliMemoryIcons.Sparkle).apply {
 			toolTipText = "Commit the checked files with an AI-written message and save a memory."
 			addActionListener {
+				val reg = service.panelRegistry
+				ai.jolli.jollimemory.core.telemetry.Telemetry.track(
+					"memory_committed",
+					mapOf(
+						"files_bucket" to ai.jolli.jollimemory.core.telemetry.Telemetry.bucket(reg?.changesPanel?.currentRowCount() ?: 0),
+						"has_conversations" to ((reg?.activeConversationsPanel?.currentRowCount() ?: 0) > 0),
+						"context_bucket" to ai.jolli.jollimemory.core.telemetry.Telemetry.bucket(reg?.plansPanel?.currentRowCount() ?: 0),
+					),
+				)
 				val action = ActionManager.getInstance().getAction("JolliMemory.CommitAI") ?: return@addActionListener
 				ActionManager.getInstance().tryToExecute(action, null, this, "JolliMemoryCurrentMemory", true)
 			}
@@ -136,9 +170,19 @@ class CurrentMemoryPanel(
 			.openFile(WorkingMemoryVirtualFile(), true)
 	}
 
-	private fun blueSeparator(): JComponent = JPanel().apply {
+	/** A grey divider between sections (mockup parity) — a stronger, 2px line. */
+	private fun sectionSeparator(): JComponent = JPanel().apply {
 		isOpaque = true
-		background = LIGHT_BLUE
+		val base = javax.swing.UIManager.getColor("Separator.separatorColor")
+			?: javax.swing.UIManager.getColor("Component.borderColor")
+			?: JBColor.border()
+		// More prominent than the faint theme separator: darker in light themes,
+		// brighter (so it reads on dark backgrounds) in dark themes.
+		background = if (com.intellij.ui.ColorUtil.isDark(base)) {
+			com.intellij.ui.ColorUtil.brighter(base, 3)
+		} else {
+			com.intellij.ui.ColorUtil.darker(base, 3)
+		}
 		alignmentX = Component.LEFT_ALIGNMENT
 		preferredSize = Dimension(0, JBUI.scale(2))
 		maximumSize = Dimension(Int.MAX_VALUE, JBUI.scale(2))
@@ -174,9 +218,5 @@ class CurrentMemoryPanel(
 
 	override fun dispose() {
 		service.removeStatusListener(statusListener)
-	}
-
-	private companion object {
-		val LIGHT_BLUE = JBColor(0xBFD7F2, 0x2C3E55)
 	}
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/FeatureFlags.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/FeatureFlags.kt
@@ -1,0 +1,14 @@
+package ai.jolli.jollimemory.toolwindow
+
+/**
+ * Master switch for surfaces that exist in code but aren't finished yet. They are
+ * built and wired but render only placeholder content, so they're gated off for
+ * shipped builds. Flip to `true` to bring them all back once they're complete.
+ *
+ * Currently gates:
+ * - The **Knowledge** view-switch tab (wiki + decision graph — placeholder card only).
+ * - The **Agent Access** title-bar action ("coming soon" settings stub).
+ */
+object FeatureFlags {
+	const val SHOW_UNFINISHED = false
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
@@ -132,6 +132,7 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         if (!service.isInitialized) {
             service.initialize()
         }
+        ai.jolli.jollimemory.core.telemetry.Telemetry.track("toolwindow_opened", mapOf("view" to "current"))
 
         // Listen for .git removal — switch back to placeholder when detected.
         // Two detection paths: VCS config change (rm -rf .git) and service error (git command failure).
@@ -201,6 +202,7 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         // rather than taking an equal share of the accordion's surplus space.
         val pinnedCollapsible = CollapsiblePanel(
             "PINNED", "JolliMemory.PinnedActions", pinnedPanel, fitContent = true,
+            titleIcon = AllIcons.General.Pin_tab,
         )
         val currentMemoryCollapsible = CollapsiblePanel(
             "WORKING MEMORY", "JolliMemory.CurrentMemoryActions", currentMemoryPanel,
@@ -296,7 +298,15 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
                 setStatusShown(state)
             }
         }
-        toolWindow.setTitleActions(listOf(agentsAction, settingsAction, statusAction, CloudSyncAction()))
+        // "Agent Access" is a coming-soon stub — keep it out of the title bar until
+        // it does something (the action object stays defined so re-enabling is a flag flip).
+        val titleActions = buildList {
+            if (FeatureFlags.SHOW_UNFINISHED) add(agentsAction)
+            add(settingsAction)
+            add(statusAction)
+            add(CloudSyncAction())
+        }
+        toolWindow.setTitleActions(titleActions)
 
         // Breadcrumb header: repo/branch selectors (icon buttons now live in the title bar)
         val breadcrumb = BreadcrumbHeaderPanel(
@@ -318,6 +328,10 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         val viewSwitch = ViewSwitchPanel { view ->
             // Switching views replaces the status card with a real view card.
             statusShown = false
+            ai.jolli.jollimemory.core.telemetry.Telemetry.track(
+                "view_switched",
+                mapOf("view" to view.name.lowercase()),
+            )
             when (view) {
                 ViewSwitchPanel.View.CURRENT -> {
                     contentCardLayout.show(contentCards, CARD_ACCORDION)
@@ -418,6 +432,7 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
                 if (!hasCredentials) {
                     ApplicationManager.getApplication().executeOnPooledThread {
                         service.uninstall()
+                        ai.jolli.jollimemory.core.telemetry.Telemetry.track("surface_disabled", mapOf("trigger" to "auto_signout"))
                         service.refreshStatus()
                     }
                 }
@@ -434,22 +449,25 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         }
 
         // Single content — breadcrumb stays visible across accordion/KB views
+        // Hoisted so the breadcrumb message-bus connection below can also be tied to
+        // it — a project.messageBus.connect() with no parent Disposable would keep its
+        // plugin-class handler subscribed after a dynamic unload and pin the classloader.
+        val contentDisposable = Disposer.newDisposable("JolliMemoryContent")
+        Disposer.register(contentDisposable, onboardingPanel)
+        Disposer.register(contentDisposable, factoryAuthDisposable)
+        Disposer.register(contentDisposable, statusListenerDisposable)
+        Disposer.register(contentDisposable, syncViewDisposable)
+        Disposer.register(contentDisposable, statusPanel)
+        Disposer.register(contentDisposable, plansPanel)
+        Disposer.register(contentDisposable, changesPanel)
+        Disposer.register(contentDisposable, commitsPanel)
+        Disposer.register(contentDisposable, conversationsPanel)
+        Disposer.register(contentDisposable, pinnedPanel)
+        Disposer.register(contentDisposable, currentMemoryPanel)
+        Disposer.register(contentDisposable, kbPanel)
         val content = ContentFactory.getInstance().createContent(rootPanel, "", false).apply {
             isCloseable = false
-            setDisposer(Disposer.newDisposable("JolliMemoryContent").also { parentDisposable ->
-                Disposer.register(parentDisposable, onboardingPanel)
-                Disposer.register(parentDisposable, factoryAuthDisposable)
-                Disposer.register(parentDisposable, statusListenerDisposable)
-                Disposer.register(parentDisposable, syncViewDisposable)
-                Disposer.register(parentDisposable, statusPanel)
-                Disposer.register(parentDisposable, plansPanel)
-                Disposer.register(parentDisposable, changesPanel)
-                Disposer.register(parentDisposable, commitsPanel)
-                Disposer.register(parentDisposable, conversationsPanel)
-                Disposer.register(parentDisposable, pinnedPanel)
-                Disposer.register(parentDisposable, currentMemoryPanel)
-                Disposer.register(parentDisposable, kbPanel)
-            })
+            setDisposer(contentDisposable)
         }
 
         // Update breadcrumb on branch switch — multiple detection paths
@@ -459,7 +477,7 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         }
 
         // Path 1: IntelliJ git repository change event
-        val branchUpdateConnection = project.messageBus.connect()
+        val branchUpdateConnection = project.messageBus.connect(contentDisposable)
         branchUpdateConnection.subscribe(
             GitRepository.GIT_REPO_CHANGE,
             GitRepositoryChangeListener { updateBreadcrumbBranch() },

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/OnboardingPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/OnboardingPanel.kt
@@ -183,6 +183,7 @@ class OnboardingPanel(
 			ApplicationManager.getApplication().executeOnPooledThread {
 				if (!service.isInitialized) service.initialize()
 				service.install()
+				ai.jolli.jollimemory.core.telemetry.Telemetry.track("surface_enabled", mapOf("trigger" to "onboarding"))
 				service.refreshStatus()
 				SwingUtilities.invokeLater {
 					saveButton.isEnabled = true
@@ -245,6 +246,8 @@ class OnboardingPanel(
 		signInButton.isEnabled = false
 		signInButton.text = "Signing in..."
 		JolliAuthService.login(
+			// User-initiated sign-in: mint a fresh key so a revoked same-tenant key recovers.
+			forceFreshApiKey = true,
 			onSuccess = { _ ->
 				// Save aiProvider to config so isConfigured() picks it up
 				val configDir = SessionTracker.getGlobalConfigDir()
@@ -258,6 +261,7 @@ class OnboardingPanel(
 				ApplicationManager.getApplication().executeOnPooledThread {
 					if (!service.isInitialized) service.initialize()
 					service.install()
+					ai.jolli.jollimemory.core.telemetry.Telemetry.track("surface_enabled", mapOf("trigger" to "onboarding"))
 					service.refreshStatus()
 					// Button state reset handled by auth listener
 				}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt
@@ -24,13 +24,17 @@ import java.awt.FlowLayout
 import java.awt.Font
 import java.awt.Graphics
 import java.awt.Graphics2D
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
 import java.awt.RenderingHints
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.io.File
 import javax.swing.BoxLayout
+import javax.swing.JComponent
 import javax.swing.JLabel
 import javax.swing.JPanel
+import javax.swing.JTextArea
 import javax.swing.SwingConstants
 import javax.swing.SwingUtilities
 
@@ -101,31 +105,43 @@ class PinnedPanel(
 	override fun getMaximumSize(): Dimension = Dimension(Int.MAX_VALUE, preferredSize.height)
 
 	private fun pinRow(entry: PinStore.PinnedEntry): JPanel {
-		val row = JPanel(BorderLayout()).apply {
-			border = JBUI.Borders.empty(2, 4)
-			maximumSize = Dimension(Int.MAX_VALUE, JBUI.scale(26))
-			alignmentX = Component.LEFT_ALIGNMENT
+		val hgap = JBUI.scale(4)
+
+		// Title wraps to the available width so long pins grow the row taller instead
+		// of clipping. JTextArea (not JBLabel) gives us word-wrapping; styled to read
+		// like a label.
+		val title = JTextArea(entry.title).apply {
+			isEditable = false
+			isFocusable = false
 			isOpaque = false
+			lineWrap = true
+			wrapStyleWord = true
+			border = JBUI.Borders.empty()
+			margin = JBUI.insets(0)
+			font = JBUI.Fonts.label()
+			foreground = JBColor.foreground()
 			cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
 		}
 
-		val left = JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(4), 0)).apply { isOpaque = false }
 		// Conversation pins lead with the AI tool's real logo (badge = source name);
-		// other kinds keep their letter/tag pill.
+		// other kinds keep their letter/tag pill. Wrapped in a GridBag cell so the
+		// badge keeps its natural size and stays vertically centered as the row grows.
 		val sourceLogo = if (entry.kind == "conversations") JolliMemoryIcons.sourceLogo(entry.badge.lowercase()) else null
-		if (sourceLogo != null) {
-			left.add(JLabel(sourceLogo).apply { toolTipText = entry.badge })
+		val badge: JComponent = if (sourceLogo != null) {
+			JLabel(sourceLogo).apply { toolTipText = entry.badge }
 		} else {
-			left.add(BadgePill(entry.badge, badgeColor(entry)))
+			BadgePill(entry.badge, badgeColor(entry))
 		}
-		val title = JBLabel(entry.title).apply { minimumSize = Dimension(0, 0) }
-		left.add(title)
-		row.add(left, BorderLayout.CENTER)
+		val west = JPanel(GridBagLayout()).apply {
+			isOpaque = false
+			add(badge, GridBagConstraints())
+		}
 
 		// Hover actions, right edge: Open (eye) · Resume (play, Claude only) · Unpin.
 		val openBtn = actionIcon(JolliMemoryIcons.Eye, "Open") { openPinned(entry) }
 		val unpinBtn = actionIcon(AllIcons.Actions.Close, "Unpin") {
 			val dir = cwd() ?: return@actionIcon
+			ai.jolli.jollimemory.core.telemetry.Telemetry.track("memory_unpinned", mapOf("kind" to entry.kind))
 			ApplicationManager.getApplication().executeOnPooledThread {
 				PinStore.unpin(dir, entry.kind, entry.key)
 				refresh()
@@ -138,32 +154,86 @@ class PinnedPanel(
 		} else {
 			listOf(openBtn, unpinBtn)
 		}
-		val east = JPanel(FlowLayout(FlowLayout.RIGHT, JBUI.scale(2), 0)).apply {
+		val iconsRow = JPanel(FlowLayout(FlowLayout.RIGHT, JBUI.scale(2), 0)).apply {
 			isOpaque = false
 			actions.forEach { add(it) }
 		}
-		row.add(east, BorderLayout.EAST)
+		// Reserve the icons' full width up-front (measured while visible) so the title
+		// wrap width stays constant whether or not the row is hovered — no reflow when
+		// the icons appear. GridBag keeps the icons vertically centered as the row grows.
+		actions.forEach { it.isVisible = true }
+		val reservedIconsW = iconsRow.preferredSize.width
+		actions.forEach { it.isVisible = false }
+		val east = JPanel(GridBagLayout()).apply {
+			isOpaque = false
+			add(iconsRow, GridBagConstraints())
+			preferredSize = Dimension(reservedIconsW, JBUI.scale(16))
+			minimumSize = Dimension(reservedIconsW, 0)
+		}
 
+		// Row height follows the wrapped title at the row's actual width; the badge and
+		// icons stay vertically centered (BorderLayout WEST/EAST + GridBag).
+		val row = object : JPanel(BorderLayout(hgap, 0)) {
+			override fun getMaximumSize(): Dimension = Dimension(Int.MAX_VALUE, preferredSize.height)
+
+			override fun getPreferredSize(): Dimension {
+				val base = super.getPreferredSize()
+				val w = width
+				if (w <= 0) return base
+				val ins = insets
+				val titleW = (w - ins.left - ins.right - west.preferredSize.width - east.preferredSize.width - hgap * 2)
+					.coerceAtLeast(JBUI.scale(20))
+				// Sizing the text area to the available width makes its preferred height
+				// reflect the wrapped line count.
+				title.setSize(titleW, Short.MAX_VALUE.toInt())
+				val contentH = maxOf(title.preferredSize.height, west.preferredSize.height, JBUI.scale(16))
+				return Dimension(base.width, contentH + ins.top + ins.bottom)
+			}
+		}.apply {
+			border = JBUI.Borders.empty(2, 4)
+			alignmentX = Component.LEFT_ALIGNMENT
+			isOpaque = false
+			cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+			add(west, BorderLayout.WEST)
+			add(title, BorderLayout.CENTER)
+			add(east, BorderLayout.EAST)
+		}
+		// Recompute the wrapped height when the row's width changes (tool-window resize).
+		row.addComponentListener(object : java.awt.event.ComponentAdapter() {
+			override fun componentResized(e: java.awt.event.ComponentEvent) {
+				row.revalidate()
+			}
+		})
+
+		// Hover: reveal the action icons and paint a subtle highlight bar across the
+		// row (mirrors the Active Conversations rows). The row is transparent until
+		// hovered, then opaque with a translucent overlay.
+		fun setRowHovered(hovered: Boolean) {
+			row.isOpaque = hovered
+			row.background = if (hovered) RowStyle.HOVER_BG else null
+			actions.forEach { it.isVisible = hovered }
+			row.repaint()
+		}
 		val hover = object : MouseAdapter() {
-			override fun mouseEntered(e: MouseEvent) { actions.forEach { it.isVisible = true } }
+			override fun mouseEntered(e: MouseEvent) { setRowHovered(true) }
 			override fun mouseExited(e: MouseEvent) {
 				val src = e.source as Component
 				if (!src.isShowing || !row.isShowing) {
-					actions.forEach { it.isVisible = false }
+					setRowHovered(false)
 					return
 				}
 				val p = e.point
 				val screen = src.locationOnScreen.apply { translate(p.x, p.y) }
 				val loc = row.locationOnScreen
 				if (!java.awt.Rectangle(loc.x, loc.y, row.width, row.height).contains(screen)) {
-					actions.forEach { it.isVisible = false }
+					setRowHovered(false)
 				}
 			}
 		}
 		val click = object : MouseAdapter() {
 			override fun mouseClicked(e: MouseEvent) { openPinned(entry) }
 		}
-		for (c in listOf(row, left, title)) {
+		for (c in listOf(row, west, badge, title)) {
 			c.addMouseListener(hover)
 			c.addMouseListener(click)
 		}
@@ -189,6 +259,7 @@ class PinnedPanel(
 		val cwd = cwd() ?: return
 		val sessionId = entry.key.substringAfter(":")
 		if (sessionId.isNotBlank()) {
+			ai.jolli.jollimemory.core.telemetry.Telemetry.track("session_resumed", mapOf("source" to "claude"))
 			TerminalUtils.resumeClaudeSession(project, sessionId, cwd, "Claude – ${entry.title}")
 		}
 	}
@@ -276,6 +347,7 @@ class PinnedPanel(
 	}
 
 	private companion object {
+
 		// Mirrors ConversationRowComponent.SourceBadge colors.
 		val SOURCE_COLORS = mapOf(
 			"claude" to JBColor(Color(217, 119, 6), Color(217, 119, 6)),

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PlansPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PlansPanel.kt
@@ -14,14 +14,11 @@ import ai.jolli.jollimemory.services.JolliMemoryService
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBLabel
-import com.intellij.ui.components.JBList
-import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.ui.JBUI
 import java.awt.BorderLayout
 import java.awt.Color
@@ -33,42 +30,38 @@ import java.awt.FlowLayout
 import java.awt.Font
 import java.awt.Graphics
 import java.awt.Graphics2D
+import java.awt.Rectangle
 import java.awt.RenderingHints
-import java.awt.event.KeyEvent
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
+import java.awt.font.TextAttribute
 import java.io.File
 import java.net.URI
 import javax.swing.Box
 import javax.swing.BoxLayout
-import javax.swing.DefaultListModel
-import java.awt.font.TextAttribute
 import javax.swing.JComponent
 import javax.swing.JLabel
-import javax.swing.JList
+import javax.swing.JTextArea
 import javax.swing.JMenuItem
 import javax.swing.JOptionPane
 import javax.swing.JPanel
 import javax.swing.JPopupMenu
 import javax.swing.JSeparator
 import javax.swing.JWindow
-import javax.swing.KeyStroke
-import javax.swing.ListCellRenderer
-import javax.swing.ListSelectionModel
 import javax.swing.SwingConstants
 import javax.swing.SwingUtilities
 import javax.swing.Timer
 import javax.swing.UIManager
 
 /**
- * Plans & Notes panel — shows Claude Code plan files and user-created notes.
- * Matches VS Code PlansTreeProvider: merges plans and notes into a single
- * list sorted by lastModified (newest first).
+ * Plans & Notes panel ("CONTEXT") — shows Claude Code plan files, user notes and
+ * references. Merges them into a single list sorted by lastModified (newest first).
  *
- * Plans are tracked in .jolli/jollimemory/plans.json by the StopHook.
- * Notes are stored in .jolli/jollimemory/notes/ directory.
- * Each item shows title, icon (plan/note type), edit count or format, and commit association.
- * Double-click to open in editor.
+ * Rows are individual [JPanel]s (one per item), mirroring [ConversationRowComponent]
+ * and the Files panel: each row word-wraps its title and grows taller as the window
+ * narrows, with a hover highlight bar, hand cursor and per-row hover actions. (This
+ * replaced an earlier JBList, whose cached cell heights made wrapping/auto-height
+ * unreliable on resize.)
  */
 class PlansPanel(
     private val project: Project,
@@ -94,16 +87,9 @@ class PlansPanel(
         )
     }
 
-    private val listModel = DefaultListModel<ListItem>()
-    private val cellRenderer = PlansAndNotesCellRenderer()
-    private val itemList = JBList(listModel).apply {
-        cellRenderer = this@PlansPanel.cellRenderer
-        selectionMode = ListSelectionModel.SINGLE_SELECTION
-    }
-
     // ─── Sticky hover popup (JWindow, same pattern as CommitsPanel) ──────
     private var hoverPopup: JWindow? = null
-    private var hoverIndex: Int = -1
+    private var hoverAnchor: Component? = null
     private var hoverShowTimer: Timer? = null
     private val hoverDismissTimer = Timer(HOVER_HIDE_GRACE_MS) { dismissHoverPopup() }.apply { isRepeats = false }
 
@@ -125,13 +111,10 @@ class PlansPanel(
     private var excludedPlans: Set<String> = emptySet()
     private var excludedNotes: Set<String> = emptySet()
 
-    /** Row index whose hover actions (pin/edit/delete) are currently shown. */
-    private var actionHoverIndex: Int = -1
-
     /** Full item list + expand state for the 6-row cap ("Show N more"). */
     private var allContextItems: List<ListItem> = emptyList()
     private var contextExpanded = false
-    private val northStack = JPanel().apply {
+    private val rowsPanel = JPanel().apply {
         layout = BoxLayout(this, BoxLayout.Y_AXIS)
         isOpaque = false
     }
@@ -139,117 +122,9 @@ class PlansPanel(
     private val statusListener: () -> Unit = { SwingUtilities.invokeLater { refresh() } }
 
     init {
-        border = JBUI.Borders.empty(8)
-
-        // Row interaction. Left→right zones: [checkbox] [tag] [title] … [pin][edit][delete].
-        // The pin/edit/delete actions render only on the hovered row.
-        itemList.addMouseListener(object : MouseAdapter() {
-            override fun mouseClicked(e: MouseEvent) {
-                val index = itemList.locationToIndex(e.point)
-                if (index < 0) return
-                val cellBounds = itemList.getCellBounds(index, index) ?: return
-                val item = listModel.getElementAt(index)
-
-                // Action zone (right edge): pin | edit | toggle (left→right).
-                val offsetFromRight = (cellBounds.x + cellBounds.width) - e.x
-                if (e.clickCount == 1 && offsetFromRight in 0..cellRenderer.getActionsWidth()) {
-                    val slot = cellRenderer.getActionSlotWidth()
-                    when {
-                        offsetFromRight <= slot -> toggleExclusion(item) // select toggle (✕/＋)
-                        offsetFromRight <= slot * 2 -> openItem(item) // edit
-                        else -> pinItem(item) // pin
-                    }
-                    return
-                }
-
-                if (e.clickCount == 2) openItem(item)
-            }
-        })
-
-        // Hover: reveal the action icons on the hovered row + hand cursor over click zones.
-        itemList.addMouseMotionListener(object : MouseAdapter() {
-            override fun mouseMoved(e: MouseEvent) {
-                val index = itemList.locationToIndex(e.point)
-                val cellBounds = if (index >= 0) itemList.getCellBounds(index, index) else null
-                if (cellBounds != null && cellBounds.contains(e.point)) {
-                    if (index != actionHoverIndex) {
-                        val old = actionHoverIndex
-                        actionHoverIndex = index
-                        repaintRow(old)
-                        repaintRow(index)
-                    }
-                    val offsetFromRight = (cellBounds.x + cellBounds.width) - e.x
-                    val overActions = offsetFromRight in 0..cellRenderer.getActionsWidth()
-                    itemList.cursor = if (overActions) {
-                        Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-                    } else {
-                        Cursor.getDefaultCursor()
-                    }
-                    if (index != hoverIndex || hoverPopup?.isVisible != true) {
-                        scheduleShowHoverPopup(index)
-                    }
-                    return
-                }
-                itemList.cursor = Cursor.getDefaultCursor()
-                clearActionHover()
-                scheduleHoverDismiss()
-            }
-        })
-
-        // Dismiss hover popup + action icons when mouse leaves the list
-        itemList.addMouseListener(object : MouseAdapter() {
-            override fun mouseExited(e: MouseEvent) {
-                clearActionHover()
-                scheduleHoverDismiss()
-            }
-        })
-
-        // Right-click context menu with "Remove" option
-        itemList.addMouseListener(object : MouseAdapter() {
-            override fun mousePressed(e: MouseEvent) { maybeShowPopup(e) }
-            override fun mouseReleased(e: MouseEvent) { maybeShowPopup(e) }
-
-            private fun maybeShowPopup(e: MouseEvent) {
-                if (!e.isPopupTrigger) return
-                val index = itemList.locationToIndex(e.point)
-                if (index < 0) return
-                itemList.selectedIndex = index
-                val selected = itemList.selectedValue ?: return
-                val popup = JPopupMenu()
-
-                if (selected is ListItem.ReferenceItem) {
-                    val previewItem = JMenuItem("Preview", JolliMemoryIcons.Eye)
-                    previewItem.addActionListener { openReference(selected.ref) }
-                    popup.add(previewItem)
-
-                    if (selected.ref.url.isNotBlank()) {
-                        val openItem = JMenuItem("Open in Browser", JolliMemoryIcons.Globe)
-                        openItem.addActionListener { openReferenceInBrowser(selected.ref.url) }
-                        popup.add(openItem)
-                    }
-
-                    popup.add(JSeparator())
-                }
-
-                val removeItem = JMenuItem("Remove", JolliMemoryIcons.Trash)
-                removeItem.addActionListener { removeSelectedItem() }
-                popup.add(removeItem)
-                popup.show(itemList, e.x, e.y)
-            }
-        })
-
-        // Delete / Backspace key to remove selected item
-        itemList.registerKeyboardAction(
-            { removeSelectedItem() },
-            KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0),
-            JComponent.WHEN_FOCUSED,
-        )
-        itemList.registerKeyboardAction(
-            { removeSelectedItem() },
-            KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SPACE, 0),
-            JComponent.WHEN_FOCUSED,
-        )
-
+        // Match PINNED's container insets (empty(2,4)) so all sections share the same
+        // first-row/last-row edge gaps. Each row adds empty(2,4) → 4px edge, 8px sides.
+        border = JBUI.Borders.empty(2, 4)
         service.addStatusListener(statusListener)
         ApplicationManager.getApplication().executeOnPooledThread { refreshFromDisk() }
     }
@@ -259,12 +134,11 @@ class PlansPanel(
     }
 
     /**
-     * Prompts the user to confirm removal of the selected plan or note.
-     * Plans are soft-deleted (ignored: true); notes are fully removed from
+     * Prompts the user to confirm removal of a plan / note / reference.
+     * Plans are soft-deleted (ignored: true); notes/references are removed from
      * the registry (matching VS Code semantics).
      */
-    private fun removeSelectedItem() {
-        val selected = itemList.selectedValue ?: return
+    private fun removeItem(selected: ListItem) {
         val (itemType, itemName) = when (selected) {
             is ListItem.PlanItem -> "plan" to (selected.plan.title.ifBlank { selected.plan.slug })
             is ListItem.NoteItem -> "note" to selected.note.title
@@ -365,18 +239,19 @@ class PlansPanel(
         }
     }
 
-    /** Toggles include/exclude for any item kind (checkbox click). */
+    /** Toggles include/exclude for any item kind (select toggle click). */
     private fun toggleExclusion(item: ListItem) {
         val (kind, key) = kindKeyOf(item)
         val nowExcluded = !isExcluded(item)
         val cwd = service.mainRepoRoot ?: project.basePath ?: return
         ApplicationManager.getApplication().executeOnPooledThread {
             CommitSelectionStore.setExcluded(cwd, kind, key, nowExcluded)
+            service.notifySelectionChanged()
             val ex = CommitSelectionStore.readExclusions(cwd)
             excludedReferences = ex.references
             excludedPlans = ex.plans
             excludedNotes = ex.notes
-            SwingUtilities.invokeLater { itemList.repaint() }
+            SwingUtilities.invokeLater { renderList() }
         }
     }
 
@@ -403,31 +278,19 @@ class PlansPanel(
             }
         }
         val cwd = service.mainRepoRoot ?: project.basePath ?: return
+        ai.jolli.jollimemory.core.telemetry.Telemetry.track("memory_pinned", mapOf("kind" to kind))
         ApplicationManager.getApplication().executeOnPooledThread {
             PinStore.pin(cwd, kind, key, title, badge)
             SwingUtilities.invokeLater { service.panelRegistry?.pinnedPanel?.refresh() }
         }
     }
 
-    /** Opens an item in its editor / detail view (edit hover action, double-click). */
+    /** Opens an item in its editor / detail view (edit hover action, row click). */
     private fun openItem(item: ListItem) {
         when (item) {
             is ListItem.PlanItem -> openPlan(item.plan)
             is ListItem.NoteItem -> openNote(item.note)
             is ListItem.ReferenceItem -> openReference(item.ref)
-        }
-    }
-
-    private fun repaintRow(index: Int) {
-        if (index < 0) return
-        itemList.getCellBounds(index, index)?.let { itemList.repaint(it) }
-    }
-
-    private fun clearActionHover() {
-        if (actionHoverIndex != -1) {
-            val old = actionHoverIndex
-            actionHoverIndex = -1
-            repaintRow(old)
         }
     }
 
@@ -557,16 +420,15 @@ class PlansPanel(
         revalidate(); repaint()
     }
 
-
     private fun updateList(items: List<ListItem>) {
         allContextItems = items
         renderList()
     }
 
     /**
-     * Renders the list without an inner scrollbar, showing at most [CappedRows.CAP]
-     * rows; the rest collapse behind a "Show N more" row below the list. Current
-     * Memory provides a single scrollbar across all three sections.
+     * Renders the rows without an inner scrollbar, showing at most [CappedRows.CAP]
+     * rows; the rest collapse behind a "Show N more" row below. Current Memory
+     * provides a single scrollbar across all three sections.
      */
     private fun renderList() {
         onRowCountChanged?.invoke(allContextItems.size)
@@ -582,17 +444,204 @@ class PlansPanel(
         val collapsed = !contextExpanded && allContextItems.size > CappedRows.CAP
         val shown = if (collapsed) allContextItems.take(CappedRows.CAP) else allContextItems
 
-        listModel.clear()
-        shown.forEach { listModel.addElement(it) }
-        itemList.alignmentX = Component.LEFT_ALIGNMENT
-        itemList.maximumSize = Dimension(Int.MAX_VALUE, itemList.preferredSize.height)
-
-        northStack.removeAll()
-        northStack.add(itemList)
-        if (collapsed) northStack.add(showMoreRow(allContextItems.size - CappedRows.CAP))
-        add(northStack, BorderLayout.NORTH)
+        rowsPanel.removeAll()
+        shown.forEach { rowsPanel.add(contextRow(it)) }
+        if (collapsed) rowsPanel.add(showMoreRow(allContextItems.size - CappedRows.CAP))
+        add(rowsPanel, BorderLayout.NORTH)
 
         revalidate(); repaint()
+    }
+
+    // ─── Row construction ─────────────────────────────────────────────────
+
+    private fun rowActionIcon(icon: javax.swing.Icon, tip: String, onClick: () -> Unit): JLabel =
+        JLabel(icon).apply {
+            toolTipText = tip
+            isVisible = false
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+            border = JBUI.Borders.empty(0, 3)
+            addMouseListener(object : MouseAdapter() {
+                override fun mouseClicked(e: MouseEvent) {
+                    if (!SwingUtilities.isLeftMouseButton(e)) return
+                    e.consume()
+                    onClick()
+                }
+            })
+        }
+
+    /**
+     * Builds one Context row: [tag] [wrapping title] …hover[pin][edit][toggle]. The
+     * title wraps and the row grows on narrow windows; tag + actions stay vertically
+     * centered. The action strip reserves width only while hovered, so short titles
+     * stay on a single line by default.
+     */
+    private fun contextRow(item: ListItem): JPanel {
+        val excluded = isExcluded(item)
+        val (letter, color) = tagFor(item)
+        val baseFont = JBUI.Fonts.label()
+        val strikeFont = baseFont.deriveFont(mapOf(TextAttribute.STRIKETHROUGH to TextAttribute.STRIKETHROUGH_ON))
+
+        val tag = TagLabel().apply { setBadge(letter, color) }
+        val tagInner = JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(2), 0)).apply {
+            isOpaque = false
+            add(tag)
+        }
+        val tagWrap = RowStyle.vCenter(tagInner)
+
+        val title = JTextArea(titleFor(item)).apply {
+            isEditable = false
+            isFocusable = false
+            isOpaque = false
+            lineWrap = true
+            wrapStyleWord = true
+            margin = JBUI.insets(0)
+            border = JBUI.Borders.empty()
+            font = if (excluded) strikeFont else baseFont
+            foreground = if (excluded) JBColor.GRAY else (UIManager.getColor("Label.foreground") ?: foreground)
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+        }
+
+        val pin = rowActionIcon(AllIcons.General.Pin_tab, "Pin") { pinItem(item) }
+        val edit = rowActionIcon(AllIcons.Actions.Edit, "Open") { openItem(item) }
+        val toggle = rowActionIcon(
+            if (excluded) AllIcons.General.Add else AllIcons.Actions.Close,
+            if (excluded) "Include in next memory" else "Exclude from next memory",
+        ) { toggleExclusion(item) }
+        val icons = listOf(pin, edit, toggle)
+        val iconsRow = JPanel(FlowLayout(FlowLayout.RIGHT, 0, 0)).apply {
+            isOpaque = false
+            icons.forEach { add(it) }
+        }
+        // Measure the icons' width (while visible) to reserve on hover; hide by default.
+        icons.forEach { it.isVisible = true }
+        val reservedW = iconsRow.preferredSize.width
+        icons.forEach { it.isVisible = false }
+        // Reserve width only while hovered → short titles stay single-line by default.
+        val rightWrap = RowStyle.vCenter(iconsRow).apply {
+            preferredSize = Dimension(0, JBUI.scale(16))
+        }
+
+        val row = object : JPanel(BorderLayout(JBUI.scale(4), 0)) {
+            override fun getMaximumSize(): Dimension = Dimension(Int.MAX_VALUE, preferredSize.height)
+            override fun getPreferredSize(): Dimension {
+                val base = super.getPreferredSize()
+                val w = width
+                if (w <= 0) return base
+                val ins = insets
+                val titleW = (w - ins.left - ins.right - tagWrap.preferredSize.width - rightWrap.preferredSize.width)
+                    .coerceAtLeast(JBUI.scale(20))
+                title.setSize(titleW, Short.MAX_VALUE.toInt())
+                val contentH = maxOf(title.preferredSize.height, tagWrap.preferredSize.height, JBUI.scale(18))
+                return Dimension(w, contentH + ins.top + ins.bottom)
+            }
+        }.apply {
+            isOpaque = false
+            border = JBUI.Borders.empty(2, 4)
+            alignmentX = Component.LEFT_ALIGNMENT
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+            add(tagWrap, BorderLayout.WEST)
+            add(title, BorderLayout.CENTER)
+            add(rightWrap, BorderLayout.EAST)
+        }
+        // Re-wrap (recompute height) when the row width changes (tool-window resize).
+        row.addComponentListener(object : java.awt.event.ComponentAdapter() {
+            override fun componentResized(e: java.awt.event.ComponentEvent) { row.revalidate() }
+        })
+
+        fun setHovered(hovered: Boolean) {
+            row.isOpaque = hovered
+            row.background = if (hovered) RowStyle.HOVER_BG else null
+            icons.forEach { it.isVisible = hovered }
+            rightWrap.preferredSize = Dimension(if (hovered) reservedW else 0, JBUI.scale(16))
+            row.revalidate()
+            row.repaint()
+            this@PlansPanel.revalidate()
+        }
+
+        val hover = object : MouseAdapter() {
+            override fun mouseEntered(e: MouseEvent) {
+                setHovered(true)
+                scheduleShowHoverPopup(item, row)
+            }
+            override fun mouseExited(e: MouseEvent) {
+                val src = e.source as? Component ?: return
+                if (!src.isShowing || !row.isShowing) {
+                    setHovered(false); scheduleHoverDismiss(); return
+                }
+                val screen = src.locationOnScreen.apply { translate(e.x, e.y) }
+                val loc = row.locationOnScreen
+                if (!Rectangle(loc.x, loc.y, row.width, row.height).contains(screen)) {
+                    setHovered(false)
+                    scheduleHoverDismiss()
+                }
+            }
+        }
+        val click = object : MouseAdapter() {
+            override fun mouseClicked(e: MouseEvent) {
+                if (SwingUtilities.isLeftMouseButton(e)) openItem(item)
+            }
+        }
+        val contextMenu = object : MouseAdapter() {
+            override fun mousePressed(e: MouseEvent) { maybeShowPopup(e) }
+            override fun mouseReleased(e: MouseEvent) { maybeShowPopup(e) }
+            private fun maybeShowPopup(e: MouseEvent) {
+                if (e.isPopupTrigger) showRowContextMenu(item, e)
+            }
+        }
+        for (c in listOf(row, tagWrap, tagInner, tag, title)) {
+            c.addMouseListener(hover)
+            c.addMouseListener(click)
+            c.addMouseListener(contextMenu)
+        }
+        icons.forEach { it.addMouseListener(hover) }
+
+        row.maximumSize = Dimension(Int.MAX_VALUE, row.preferredSize.height)
+        return row
+    }
+
+    private fun showRowContextMenu(item: ListItem, e: MouseEvent) {
+        val popup = JPopupMenu()
+        if (item is ListItem.ReferenceItem) {
+            popup.add(JMenuItem("Preview", JolliMemoryIcons.Eye).apply { addActionListener { openReference(item.ref) } })
+            if (item.ref.url.isNotBlank()) {
+                popup.add(JMenuItem("Open in Browser", JolliMemoryIcons.Globe).apply {
+                    addActionListener { openReferenceInBrowser(item.ref.url) }
+                })
+            }
+            popup.add(JSeparator())
+        }
+        popup.add(JMenuItem("Remove", JolliMemoryIcons.Trash).apply { addActionListener { removeItem(item) } })
+        popup.show(e.component, e.x, e.y)
+    }
+
+    /** Single/double-letter type tag + accent color (mockup `kb-tag` parity). */
+    private fun tagFor(item: ListItem): Pair<String, Color> = when (item) {
+        is ListItem.PlanItem -> "P" to TAG_PLAN
+        is ListItem.NoteItem ->
+            if (item.note.format == NoteFormat.snippet) "S" to TAG_SNIPPET else "N" to TAG_NOTE
+        is ListItem.ReferenceItem -> when (item.ref.source) {
+            SourceId.linear -> "L" to TAG_LINEAR
+            SourceId.github -> "GH" to TAG_GITHUB
+            SourceId.jira -> "J" to TAG_JIRA
+            SourceId.notion -> "No" to TAG_NOTION
+        }
+    }
+
+    private fun titleFor(item: ListItem): String = when (item) {
+        is ListItem.PlanItem -> {
+            val t = item.plan.title.ifBlank { item.plan.slug }
+            if (item.plan.commitHash != null) "${item.plan.commitHash.take(8)} · $t" else t
+        }
+        is ListItem.NoteItem ->
+            if (item.note.commitHash != null) {
+                "${item.note.commitHash.take(8)} · ${item.note.title}"
+            } else {
+                item.note.title
+            }
+        is ListItem.ReferenceItem -> when (item.ref.source) {
+            SourceId.notion -> item.ref.title
+            else -> "${item.ref.nativeId} — ${item.ref.title}"
+        }
     }
 
     private fun showMoreRow(remaining: Int): JPanel {
@@ -622,9 +671,7 @@ class PlansPanel(
 
     /** Toggles all reference checkboxes: if any excluded → select all, otherwise → deselect all. */
     fun toggleSelectAll() {
-        val refItems = (0 until listModel.size())
-            .map { listModel.getElementAt(it) }
-            .filterIsInstance<ListItem.ReferenceItem>()
+        val refItems = allContextItems.filterIsInstance<ListItem.ReferenceItem>()
         if (refItems.isEmpty()) return
 
         val anyExcluded = refItems.any { it.mapKey in excludedReferences }
@@ -635,30 +682,30 @@ class PlansPanel(
             for (item in refItems) {
                 CommitSelectionStore.setExcluded(cwd, "references", item.mapKey, !select)
             }
+            service.notifySelectionChanged()
             excludedReferences = CommitSelectionStore.readExclusions(cwd).references
-            SwingUtilities.invokeLater { itemList.repaint() }
+            SwingUtilities.invokeLater { renderList() }
         }
     }
 
     // ─── Hover popup logic (mirrors CommitsPanel) ─────────────────────────
 
-    private fun scheduleShowHoverPopup(index: Int) {
+    private fun scheduleShowHoverPopup(item: ListItem, anchor: Component) {
         hoverDismissTimer.stop()
-        if (hoverIndex == index && hoverPopup?.isVisible == true) return
+        if (hoverAnchor === anchor && hoverPopup?.isVisible == true) return
         hoverShowTimer?.stop()
-        hoverShowTimer = Timer(HOVER_SHOW_DELAY_MS) { showHoverPopup(index) }.apply {
+        hoverShowTimer = Timer(HOVER_SHOW_DELAY_MS) { showHoverPopup(item, anchor) }.apply {
             isRepeats = false
             start()
         }
     }
 
-    private fun showHoverPopup(index: Int) {
+    private fun showHoverPopup(item: ListItem, anchor: Component) {
         hoverShowTimer?.stop()
         dismissHoverPopup()
 
-        if (index < 0 || index >= listModel.size()) return
-        val item = listModel.getElementAt(index)
-        val window = SwingUtilities.getWindowAncestor(itemList) ?: return
+        if (!anchor.isShowing) return
+        val window = SwingUtilities.getWindowAncestor(anchor) ?: return
         val popup = JWindow(window)
 
         val bg = UIManager.getColor("ToolTip.background") ?: background
@@ -685,12 +732,9 @@ class PlansPanel(
         }
         popup.pack()
 
-        // Position below the hovered cell
-        val cellBounds = itemList.getCellBounds(index, index)
-        if (cellBounds != null) {
-            val listLoc = itemList.locationOnScreen
-            popup.setLocation(listLoc.x + cellBounds.x, listLoc.y + cellBounds.y + cellBounds.height + 2)
-        }
+        // Position below the hovered row.
+        val loc = anchor.locationOnScreen
+        popup.setLocation(loc.x, loc.y + anchor.height + 2)
 
         val popupHoverListener = object : MouseAdapter() {
             override fun mouseEntered(e: MouseEvent) { hoverDismissTimer.stop() }
@@ -700,7 +744,7 @@ class PlansPanel(
         content.addMouseListener(popupHoverListener)
 
         hoverPopup = popup
-        hoverIndex = index
+        hoverAnchor = anchor
         popup.isVisible = true
     }
 
@@ -750,7 +794,7 @@ class PlansPanel(
         }
 
         // Title
-        content.add(JBLabel("${ref.nativeId} \u2014 ${ref.title}").apply {
+        content.add(JBLabel("${ref.nativeId} — ${ref.title}").apply {
             foreground = fg; font = font.deriveFont(java.awt.Font.BOLD); alignmentX = Component.LEFT_ALIGNMENT
         })
 
@@ -803,7 +847,7 @@ class PlansPanel(
         hoverDismissTimer.stop()
         hoverPopup?.dispose()
         hoverPopup = null
-        hoverIndex = -1
+        hoverAnchor = null
     }
 
     override fun dispose() {
@@ -844,128 +888,6 @@ class PlansPanel(
             }
         }
         JOptionPane.showMessageDialog(this, "Note file not found: ${note.id}", "Note", JOptionPane.WARNING_MESSAGE)
-    }
-
-    /**
-     * Unified cell renderer for both plans and notes.
-     * Icons match VS Code:
-     * - Plan (uncommitted): file-text icon
-     * - Plan (committed): lock (green) icon
-     * - Note markdown (uncommitted): note icon
-     * - Note snippet (uncommitted): comment icon
-     * - Note (committed): lock (green) icon
-     */
-    private inner class PlansAndNotesCellRenderer : ListCellRenderer<ListItem> {
-        private val panel = JPanel(BorderLayout()).apply { border = JBUI.Borders.empty(3, 8) }
-        private val tagLabel = TagLabel()
-        private val titleLabel = JLabel()
-        private val pinLabel = actionIcon(AllIcons.General.Pin_tab, "Pin")
-        private val editLabel = actionIcon(AllIcons.Actions.Edit, "Edit")
-        // Rightmost action: the select toggle (✕ exclude / ＋ include). Icon + tooltip
-        // are set per row in getListCellRendererComponent.
-        private val toggleLabel = actionIcon(AllIcons.Actions.Close, "Exclude from next memory")
-
-        /** No checkbox column anymore — selection is the strikethrough toggle on the right. */
-        fun getCheckboxWidth(): Int = 0
-
-        /** Width of one hover-action slot (icon + gap). */
-        fun getActionSlotWidth(): Int = JBUI.scale(24)
-
-        /** Total width of the pin/edit/delete action strip on the right. */
-        fun getActionsWidth(): Int = getActionSlotWidth() * 3
-
-        private fun actionIcon(icon: javax.swing.Icon, tip: String): JLabel = JLabel(icon).apply {
-            toolTipText = tip
-            border = JBUI.Borders.empty(0, 3)
-            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-        }
-
-        override fun getListCellRendererComponent(
-            list: JList<out ListItem>, value: ListItem, index: Int,
-            isSelected: Boolean, cellHasFocus: Boolean,
-        ): Component {
-            // Column layout: [type tag] [title] …hover[pin][edit][toggle ✕/＋].
-            // Deselected (excluded) items render struck-through + dimmed.
-            val (letter, color) = tagFor(value)
-            val excluded = isExcluded(value)
-            tagLabel.setBadge(letter, color)
-            titleLabel.text = titleFor(value)
-            titleLabel.font = if (excluded) {
-                list.font.deriveFont(mapOf(TextAttribute.STRIKETHROUGH to TextAttribute.STRIKETHROUGH_ON))
-            } else {
-                list.font
-            }
-            titleLabel.foreground = when {
-                isSelected -> list.selectionForeground
-                excluded -> JBColor.GRAY
-                else -> list.foreground
-            }
-
-            panel.removeAll()
-
-            val left = JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(2), 0)).apply {
-                isOpaque = false
-                add(tagLabel)
-            }
-            panel.add(left, BorderLayout.WEST)
-            // Min size 0 so BorderLayout.CENTER can shrink the title and it ellipsizes ("…").
-            titleLabel.minimumSize = Dimension(0, 0)
-            panel.add(titleLabel, BorderLayout.CENTER)
-
-            // Action icons appear only on the hovered row, anchored to the right edge.
-            if (index == actionHoverIndex) {
-                toggleLabel.icon = if (excluded) AllIcons.General.Add else AllIcons.Actions.Close
-                toggleLabel.toolTipText = if (excluded) "Include in next memory" else "Exclude from next memory"
-                val actions = JPanel(FlowLayout(FlowLayout.RIGHT, 0, 0)).apply {
-                    isOpaque = false
-                    add(pinLabel)
-                    add(editLabel)
-                    add(toggleLabel)
-                }
-                panel.add(actions, BorderLayout.EAST)
-            }
-
-            panel.background = if (isSelected) list.selectionBackground else list.background
-
-            // Pin the cell to the list's visible width so a long title truncates with "…"
-            // instead of widening the cell and pushing the hover icons past the window edge.
-            panel.preferredSize = null
-            val listWidth = list.width
-            if (listWidth > 0) {
-                panel.preferredSize = Dimension(listWidth, panel.preferredSize.height)
-            }
-            return panel
-        }
-
-        /** Single/double-letter type tag + accent color (mockup `kb-tag` parity). */
-        private fun tagFor(item: ListItem): Pair<String, Color> = when (item) {
-            is ListItem.PlanItem -> "P" to TAG_PLAN
-            is ListItem.NoteItem ->
-                if (item.note.format == NoteFormat.snippet) "S" to TAG_SNIPPET else "N" to TAG_NOTE
-            is ListItem.ReferenceItem -> when (item.ref.source) {
-                SourceId.linear -> "L" to TAG_LINEAR
-                SourceId.github -> "GH" to TAG_GITHUB
-                SourceId.jira -> "J" to TAG_JIRA
-                SourceId.notion -> "No" to TAG_NOTION
-            }
-        }
-
-        private fun titleFor(item: ListItem): String = when (item) {
-            is ListItem.PlanItem -> {
-                val t = item.plan.title.ifBlank { item.plan.slug }
-                if (item.plan.commitHash != null) "${item.plan.commitHash.take(8)} · $t" else t
-            }
-            is ListItem.NoteItem ->
-                if (item.note.commitHash != null) {
-                    "${item.note.commitHash.take(8)} · ${item.note.title}"
-                } else {
-                    item.note.title
-                }
-            is ListItem.ReferenceItem -> when (item.ref.source) {
-                SourceId.notion -> item.ref.title
-                else -> "${item.ref.nativeId} — ${item.ref.title}"
-            }
-        }
     }
 
     /** A small rounded badge painting a 1–2 letter context-type tag (mockup `kb-tag`). */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PlansPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PlansPanel.kt
@@ -337,9 +337,9 @@ class PlansPanel(
                 .map { ListItem.PlanItem(it) }
             val noteItems = filterNotes(registry.notes ?: emptyMap(), gitOps, currentBranch)
                 .map { ListItem.NoteItem(it) }
-            val refItems = (registry.references ?: emptyMap()).map { (mapKey, entry) ->
-                ListItem.ReferenceItem(entry, mapKey)
-            }
+            val refItems = (registry.references ?: emptyMap())
+                .filter { (_, entry) -> filterReference(entry, currentBranch) }
+                .map { (mapKey, entry) -> ListItem.ReferenceItem(entry, mapKey) }
 
             // Merge and sort by lastModified descending (newest first), matching VS Code
             (planItems + noteItems + refItems).sortedByDescending { it.lastModified }
@@ -411,6 +411,17 @@ class PlansPanel(
             }
             true
         }
+    }
+
+    /**
+     * References are branch-scoped like plans/notes: a row stamped with a branch
+     * only shows on that branch; legacy blank-branch rows (written before
+     * branch-scoping) stay visible everywhere. References carry no committed /
+     * guard state — a commit deletes the row — so there is nothing else to filter.
+     */
+    private fun filterReference(entry: ReferenceEntry, currentBranch: String?): Boolean {
+        if (currentBranch != null && !entry.branch.isNullOrBlank() && entry.branch != currentBranch) return false
+        return true
     }
 
     private fun showInitializing() {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PlansPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PlansPanel.kt
@@ -323,9 +323,10 @@ class PlansPanel(
             val cwd = service.mainRepoRoot ?: project.basePath ?: ""
             val gitOps = service.getGitOps()
             val currentBranch = gitOps?.getCurrentBranch()
-            // Pull in any plan Claude generated under ~/.claude/plans/ that isn't
-            // registered yet, so it appears in CONTEXT without a manual "Add plan".
-            ai.jolli.jollimemory.services.PlanService.autoRegisterNewPlans(cwd, currentBranch)
+            // Plans enter the registry via transcript discovery (StopHook →
+            // TranscriptPlanDiscovery), mirroring VS Code — so a plan appears in
+            // CONTEXT only when the user actually created/edited it in a session, and
+            // is consumed on commit. We no longer directory-scan ~/.claude/plans/.
             val registry = SessionTracker.loadPlansRegistry(cwd)
 
             val ex = CommitSelectionStore.readExclusions(cwd)
@@ -337,8 +338,9 @@ class PlansPanel(
                 .map { ListItem.PlanItem(it) }
             val noteItems = filterNotes(registry.notes ?: emptyMap(), gitOps, currentBranch)
                 .map { ListItem.NoteItem(it) }
+            // No branch filter: uncommitted references follow the user across branches
+            // (a commit deletes the row; there is no committed/guard state to filter).
             val refItems = (registry.references ?: emptyMap())
-                .filter { (_, entry) -> filterReference(entry, currentBranch) }
                 .map { (mapKey, entry) -> ListItem.ReferenceItem(entry, mapKey) }
 
             // Merge and sort by lastModified descending (newest first), matching VS Code
@@ -359,8 +361,8 @@ class PlansPanel(
         val plansDir = File(System.getProperty("user.home"), ".claude/plans")
         return plans.values.filter { entry ->
             if (entry.ignored == true) return@filter false
-            // Skip entries from other branches
-            if (currentBranch != null && entry.branch != null && entry.branch != currentBranch) return@filter false
+            // No branch filter: uncommitted working-area plans follow the user across
+            // branches (matches CLI/VS Code). `branch` is stamped but not filtered on.
             // Skip committed snapshot copies (slug-<shortHash> entries created by archivePlanForCommit).
             // These exist only for orphan branch storage / Summary WebView, not for the sidebar panel.
             if (entry.commitHash != null && entry.contentHashAtCommit == null) return@filter false
@@ -389,8 +391,8 @@ class PlansPanel(
     ): List<NoteEntry> {
         return notes.values.filter { entry ->
             if (entry.ignored == true) return@filter false
-            // Skip entries from other branches
-            if (currentBranch != null && entry.branch != null && entry.branch != currentBranch) return@filter false
+            // No branch filter: uncommitted working-area notes follow the user across
+            // branches (matches CLI/VS Code). `branch` is stamped but not filtered on.
             // Skip committed snapshot copies (created by archiveNoteForCommit).
             // These exist only for orphan branch storage / Summary WebView, not for the sidebar panel.
             if (entry.commitHash != null && entry.contentHashAtCommit == null) return@filter false
@@ -413,16 +415,6 @@ class PlansPanel(
         }
     }
 
-    /**
-     * References are branch-scoped like plans/notes: a row stamped with a branch
-     * only shows on that branch; legacy blank-branch rows (written before
-     * branch-scoping) stay visible everywhere. References carry no committed /
-     * guard state — a commit deletes the row — so there is nothing else to filter.
-     */
-    private fun filterReference(entry: ReferenceEntry, currentBranch: String?): Boolean {
-        if (currentBranch != null && !entry.branch.isNullOrBlank() && entry.branch != currentBranch) return false
-        return true
-    }
 
     private fun showInitializing() {
         removeAll()

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/RowStyle.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/RowStyle.kt
@@ -1,0 +1,25 @@
+package ai.jolli.jollimemory.toolwindow
+
+import com.intellij.ui.JBColor
+import java.awt.Color
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/**
+ * Shared row-styling primitives for the sidebar panels (Pinned, Current Memory,
+ * Committed Memories, Changes). These were copy-pasted into each panel; keeping
+ * one definition stops the hover tint and the vertical-centering wrapper from
+ * drifting apart across panels.
+ */
+object RowStyle {
+	/** Subtle row-hover tint — faint dark overlay on light themes, faint light overlay on dark. */
+	val HOVER_BG = JBColor(Color(0, 0, 0, 20), Color(255, 255, 255, 20))
+
+	/** Wraps [c] in a single-cell GridBag panel that vertically centers it within the row. */
+	fun vCenter(c: JComponent): JPanel = JPanel(GridBagLayout()).apply {
+		isOpaque = false
+		add(c, GridBagConstraints())
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
@@ -12,8 +12,10 @@ import ai.jolli.jollimemory.services.JolliAuthService
 import ai.jolli.jollimemory.services.JolliMemoryService
 import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.DialogWrapper
@@ -576,6 +578,8 @@ class SettingsDialog(
         button.isEnabled = false
         button.text = "Signing in..."
         JolliAuthService.login(
+            // User-initiated sign-in: mint a fresh key so a revoked same-tenant key recovers.
+            forceFreshApiKey = true,
             onSuccess = { _ ->
                 SwingUtilities.invokeLater {
                     button.isEnabled = true
@@ -715,39 +719,58 @@ class SettingsDialog(
             !System.getenv("ANTHROPIC_API_KEY").isNullOrBlank() ||
             !config.jolliApiKey.isNullOrBlank()
 
-        // Handle pause toggle or credential removal, then always refresh status
+        // Snapshot the inputs needed off the EDT, then close the dialog immediately. All
+        // the heavy work (git subprocesses, hook install/uninstall, Memory Bank init +
+        // migration) runs in ONE ordered background task so the IDE never freezes and the
+        // enable/disable and migration steps can't race each other.
         val wasPaused = existing.paused == true
         val nowPaused = pauseCheckbox.isSelected
-        ApplicationManager.getApplication().executeOnPooledThread {
-            if (!hasCredentials || (nowPaused && !wasPaused)) {
-                service.uninstall()
-            } else if (!nowPaused && wasPaused) {
-                if (!service.isInitialized) service.initialize()
-                service.install()
-            }
-            service.refreshStatus()
-        }
-
-        // Initialize Memory Bank folder + auto-migrate data from orphan branch
         val projectPath = service.mainRepoRoot ?: project.basePath
-        if (projectPath != null) {
-            val repoName = KBPathResolver.extractRepoName(projectPath)
-            val remoteUrl = KBPathResolver.getRemoteUrl(projectPath)
-            val kbRoot = KBPathResolver.resolve(repoName, remoteUrl, config.knowledgeBasePath)
-            KBPathResolver.initializeKBFolder(kbRoot, repoName, remoteUrl)
-
-            val gitOps = GitOps(projectPath)
-            val orphan = OrphanBranchStorage(gitOps)
-            if (orphan.exists()) {
-                val mm = MetadataManager(kbRoot.resolve(".jolli"))
-                val folder = FolderStorage(kbRoot, mm)
-                folder.ensure()
-                val engine = MigrationEngine(orphan, folder, mm)
-                engine.runMigration()
-            }
-        }
+        val kbCustomPath = config.knowledgeBasePath
 
         super.doOKAction()
+
+        ProgressManager.getInstance().run(
+            object : Task.Backgroundable(project, "Applying Jolli Memory settings…", false) {
+                override fun run(indicator: ProgressIndicator) {
+                    indicator.isIndeterminate = true
+
+                    // 1. Enable / disable hooks (was already off-EDT; now ordered before migration).
+                    if (!hasCredentials || (nowPaused && !wasPaused)) {
+                        indicator.text = "Disabling Jolli Memory…"
+                        service.uninstall()
+                        ai.jolli.jollimemory.core.telemetry.Telemetry.track("surface_disabled", mapOf("trigger" to "settings"))
+                    } else if (!nowPaused && wasPaused) {
+                        indicator.text = "Enabling Jolli Memory…"
+                        if (!service.isInitialized) service.initialize()
+                        service.install()
+                        ai.jolli.jollimemory.core.telemetry.Telemetry.track("surface_enabled", mapOf("trigger" to "settings"))
+                    }
+
+                    // 2. Initialize Memory Bank folder + auto-migrate data from the orphan branch.
+                    if (projectPath != null) {
+                        indicator.text = "Initializing Memory Bank…"
+                        val repoName = KBPathResolver.extractRepoName(projectPath)
+                        val remoteUrl = KBPathResolver.getRemoteUrl(projectPath)
+                        val kbRoot = KBPathResolver.resolve(repoName, remoteUrl, kbCustomPath)
+                        KBPathResolver.initializeKBFolder(kbRoot, repoName, remoteUrl)
+
+                        val gitOps = GitOps(projectPath)
+                        val orphan = OrphanBranchStorage(gitOps)
+                        if (orphan.exists()) {
+                            indicator.text = "Migrating memories to Memory Bank…"
+                            val mm = MetadataManager(kbRoot.resolve(".jolli"))
+                            val folder = FolderStorage(kbRoot, mm)
+                            folder.ensure()
+                            MigrationEngine(orphan, folder, mm).runMigration()
+                        }
+                    }
+
+                    // 3. Refresh status once, after everything settled.
+                    service.refreshStatus()
+                }
+            },
+        )
     }
 
     private fun getEffectiveAnthropicKey(): String {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SignInBar.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SignInBar.kt
@@ -88,6 +88,8 @@ class SignInBar(
         signInButton.isEnabled = false
         signInButton.text = "Signing in..."
         JolliAuthService.login(
+            // User-initiated sign-in: mint a fresh key so a revoked same-tenant key recovers.
+            forceFreshApiKey = true,
             onSuccess = { _ ->
                 SwingUtilities.invokeLater {
                     signInButton.isEnabled = true

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
@@ -5,6 +5,7 @@ import ai.jolli.jollimemory.bridge.GitRemoteUtils
 import ai.jolli.jollimemory.core.CommitSummary
 import ai.jolli.jollimemory.core.E2eTestScenario
 import ai.jolli.jollimemory.core.SessionTracker
+import ai.jolli.jollimemory.services.JolliAuthService
 import ai.jolli.jollimemory.core.StorageFactory
 import ai.jolli.jollimemory.core.StoredSession
 import ai.jolli.jollimemory.core.StoredTranscript
@@ -363,7 +364,14 @@ class SummaryPanel(
                     val cleanedSummary = cleanupOrphanedDocs(summary, updatedSummary, baseUrl, config.jolliApiKey!!)
                     if (cleanedSummary != null) currentSummary = cleanedSummary
 
-                    ai.jolli.jollimemory.core.telemetry.Telemetry.track("memory_pushed", mapOf("kind" to "summary"))
+                    ai.jolli.jollimemory.core.telemetry.Telemetry.track(
+                        "memory_pushed",
+                        mapOf(
+                            "kind" to "summary",
+                            "created" to result.created,
+                            "plans_bucket" to ai.jolli.jollimemory.core.telemetry.Telemetry.bucket(planUrls.size),
+                        ),
+                    )
 
                     ApplicationManager.getApplication().invokeLater {
                         refreshHtml()
@@ -385,12 +393,57 @@ class SummaryPanel(
                         postToWebview("pushFailed")
                         Messages.showErrorDialog(project, "Push failed -- your JolliMemory plugin is outdated. Please update.", "Plugin Outdated")
                     }
+                } catch (e: JolliApiClient.UnauthorizedError) {
+                    // Server rejected the key (invalid/disabled). Offer to re-authenticate
+                    // and retry once — self-heals a stale/deleted key.
+                    ai.jolli.jollimemory.core.telemetry.Telemetry.track("key_rejected", mapOf("retried" to retried, "where" to "push"))
+                    ApplicationManager.getApplication().invokeLater {
+                        postToWebview("pushFailed")
+                        if (retried) {
+                            Messages.showErrorDialog(project, "Push failed: ${e.message}", "Push Error")
+                            return@invokeLater
+                        }
+                        val choice = Messages.showYesNoDialog(
+                            project,
+                            "Your Jolli key was rejected by the server (invalid or disabled).\n\nRe-authenticate and retry the push?",
+                            "Re-authenticate",
+                            Messages.getQuestionIcon(),
+                        )
+                        if (choice == Messages.YES) reauthenticateAndRetry()
+                    }
                 } catch (e: Exception) {
+                    ai.jolli.jollimemory.core.telemetry.Telemetry.track("error_occurred", mapOf("code" to "push_failed", "where" to "push"))
                     ApplicationManager.getApplication().invokeLater {
                         postToWebview("pushFailed")
                         Messages.showErrorDialog(project, "Push failed: ${e.message}", "Push Error")
                     }
                 }
+            }
+        }
+    }
+
+    /**
+     * Clears the stale Jolli key, runs the login flow (which mints a FRESH key — a
+     * same-tenant re-login would otherwise keep the existing, now-disabled one), and
+     * retries the push once on success.
+     */
+    private fun reauthenticateAndRetry() {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val dir = SessionTracker.getGlobalConfigDir()
+            SessionTracker.saveConfigToDir(SessionTracker.loadConfigFromDir(dir).copy(jolliApiKey = null), dir)
+            ApplicationManager.getApplication().invokeLater {
+                JolliAuthService.login(
+                    onSuccess = {
+                        ai.jolli.jollimemory.core.telemetry.Telemetry.track("reauth_completed", mapOf("outcome" to "success"))
+                        handlePushToJolli(retried = true)
+                    },
+                    onError = { msg ->
+                        ai.jolli.jollimemory.core.telemetry.Telemetry.track("reauth_completed", mapOf("outcome" to "failed"))
+                        ApplicationManager.getApplication().invokeLater {
+                            Messages.showErrorDialog(project, "Re-authentication failed: $msg", "Push Error")
+                        }
+                    },
+                )
             }
         }
     }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/TerminalUtils.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/TerminalUtils.kt
@@ -5,6 +5,7 @@ import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
+import com.intellij.terminal.ui.TerminalWidget
 import org.jetbrains.plugins.terminal.TerminalToolWindowManager
 
 /** Shared terminal helpers used by sidebar panels for resuming conversations. */
@@ -15,10 +16,7 @@ object TerminalUtils {
 	/** Opens a new terminal tab in the given [cwd] and runs `claude --resume <sessionId>`. */
 	fun resumeClaudeSession(project: Project, sessionId: String, cwd: String, title: String = "Claude – resume") {
 		try {
-			// createLocalShellWidget / executeCommand are scheduled for removal; use the
-			// current createShellWidget + sendCommandToExecute API.
-			val widget = TerminalToolWindowManager.getInstance(project)
-				.createShellWidget(cwd, title, true, true)
+			val widget = createShellWidget(project, cwd, title)
 			widget.sendCommandToExecute("claude --resume $sessionId")
 		} catch (e: Exception) {
 			log.warn("Failed to open terminal for session resume: ${e.message}", e)
@@ -27,5 +25,28 @@ object TerminalUtils {
 				project,
 			)
 		}
+	}
+
+	/**
+	 * Opens a shell terminal tab via reflection.
+	 *
+	 * `TerminalToolWindowManager.createShellWidget(...)` is the only terminal-creation
+	 * entry point available on our 2024.3 compile baseline (the older
+	 * `createLocalShellWidget` is already scheduled for removal). JetBrains marks it as
+	 * internal API in newer builds within our `until-build` range, so a direct call is
+	 * flagged by the Marketplace verifier. Invoking it reflectively keeps the call out
+	 * of the bytecode the verifier scans while remaining fully functional; a signature
+	 * change or removal degrades gracefully to the caller's notification fallback.
+	 */
+	private fun createShellWidget(project: Project, cwd: String, title: String): TerminalWidget {
+		val manager = TerminalToolWindowManager.getInstance(project)
+		val method = manager.javaClass.getMethod(
+			"createShellWidget",
+			String::class.java,
+			String::class.java,
+			Boolean::class.javaPrimitiveType,
+			Boolean::class.javaPrimitiveType,
+		)
+		return method.invoke(manager, cwd, title, true, true) as TerminalWidget
 	}
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/TerminalUtils.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/TerminalUtils.kt
@@ -15,9 +15,11 @@ object TerminalUtils {
 	/** Opens a new terminal tab in the given [cwd] and runs `claude --resume <sessionId>`. */
 	fun resumeClaudeSession(project: Project, sessionId: String, cwd: String, title: String = "Claude – resume") {
 		try {
+			// createLocalShellWidget / executeCommand are scheduled for removal; use the
+			// current createShellWidget + sendCommandToExecute API.
 			val widget = TerminalToolWindowManager.getInstance(project)
-				.createLocalShellWidget(cwd, title)
-			widget.executeCommand("claude --resume $sessionId")
+				.createShellWidget(cwd, title, true, true)
+			widget.sendCommandToExecute("claude --resume $sessionId")
 		} catch (e: Exception) {
 			log.warn("Failed to open terminal for session resume: ${e.message}", e)
 			Notifications.Bus.notify(

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ViewSwitchPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ViewSwitchPanel.kt
@@ -35,8 +35,12 @@ class ViewSwitchPanel(
 	private val tabs = linkedMapOf(
 		View.CURRENT to "Current Branch",
 		View.BANK to "Memory Bank",
-		View.KNOWLEDGE to "Knowledge",
-	)
+	).apply {
+		// Knowledge (wiki + decision graph) is still a placeholder — hide the tab
+		// until it's built. The View.KNOWLEDGE enum + handler stay so re-enabling
+		// is a one-line flag flip.
+		if (FeatureFlags.SHOW_UNFINISHED) put(View.KNOWLEDGE, "Knowledge")
+	}
 
 	private val labels = mutableMapOf<View, TabLabel>()
 	private var selected: View = View.CURRENT

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/WorkingMemoryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/WorkingMemoryPanel.kt
@@ -159,7 +159,7 @@ class WorkingMemoryPanel(private val project: Project) : JPanel(BorderLayout()) 
             emptyList()
         }
 
-        val context = gatherContext(branch, exclusions)
+        val context = gatherContext(exclusions)
         val detectedTicket = context.firstOrNull { it.tag == "L" || it.tag == "J" }
             ?.let { Regex("[A-Z]+-\\d+").find(it.title)?.value }
             ?: Regex("[A-Z]+-\\d+").find(branch)?.value
@@ -236,28 +236,26 @@ class WorkingMemoryPanel(private val project: Project) : JPanel(BorderLayout()) 
      * minus anything the user unchecked in the CONTEXT list (same exclusion keys
      * the CONTEXT panel and PostCommitHook use: plan slug, note id, reference map key).
      */
-    private fun gatherContext(branch: String, exclusions: CommitSelectionStore.CommitExclusions): List<WmContext> {
+    private fun gatherContext(exclusions: CommitSelectionStore.CommitExclusions): List<WmContext> {
         val out = mutableListOf<WmContext>()
         try {
             val registry = SessionTracker.loadPlansRegistry(cwd)
+            // No branch filter on any kind: uncommitted working-area items follow the
+            // user across branches (matches CLI/VS Code). `branch` is stamped but not
+            // filtered on; only committed memory is branch-tagged.
             registry.plans.values.forEach { p ->
                 if (p.slug in exclusions.plans) return@forEach
                 if (p.ignored == true || p.commitHash != null) return@forEach
-                if (!p.branch.isNullOrBlank() && p.branch != branch) return@forEach
                 if (!File(p.sourcePath).exists()) return@forEach
                 out.add(WmContext("P", p.title))
             }
             registry.notes?.values?.forEach { n ->
                 if (n.id in exclusions.notes) return@forEach
                 if (n.ignored == true || n.commitHash != null) return@forEach
-                if (n.branch.isNotBlank() && n.branch != branch) return@forEach
                 out.add(WmContext("N", n.title))
             }
             registry.references?.forEach { (mapKey, r) ->
                 if (mapKey in exclusions.references) return@forEach
-                // Branch-scope like plans/notes above: legacy blank-branch rows stay
-                // visible everywhere; a branch-stamped row only shows on its branch.
-                if (!r.branch.isNullOrBlank() && r.branch != branch) return@forEach
                 out.add(WmContext(referenceTag(r.source), r.title))
             }
         } catch (_: Exception) {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/WorkingMemoryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/WorkingMemoryPanel.kt
@@ -255,6 +255,9 @@ class WorkingMemoryPanel(private val project: Project) : JPanel(BorderLayout()) 
             }
             registry.references?.forEach { (mapKey, r) ->
                 if (mapKey in exclusions.references) return@forEach
+                // Branch-scope like plans/notes above: legacy blank-branch rows stay
+                // visible everywhere; a branch-stamped row only shows on its branch.
+                if (!r.branch.isNullOrBlank() && r.branch != branch) return@forEach
                 out.add(WmContext(referenceTag(r.source), r.title))
             }
         } catch (_: Exception) {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/WorkingMemoryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/WorkingMemoryPanel.kt
@@ -1,6 +1,7 @@
 package ai.jolli.jollimemory.toolwindow
 
 import ai.jolli.jollimemory.core.ActiveSessionAggregator
+import ai.jolli.jollimemory.core.CommitSelectionStore
 import ai.jolli.jollimemory.core.SessionTracker
 import ai.jolli.jollimemory.core.references.SourceId
 import ai.jolli.jollimemory.services.JolliMemoryService
@@ -11,7 +12,6 @@ import ai.jolli.jollimemory.toolwindow.views.WorkingMemoryHtmlBuilder.WmFile
 import ai.jolli.jollimemory.toolwindow.views.WorkingMemoryHtmlBuilder.WorkingMemoryView
 import com.google.gson.JsonParser
 import com.intellij.ide.BrowserUtil
-import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
@@ -49,6 +49,9 @@ class WorkingMemoryPanel(private val project: Project) : JPanel(BorderLayout()) 
     init {
         add(createContent(), BorderLayout.CENTER)
         service?.addStatusListener(statusListener)
+        // Live-refresh when the user toggles a conversation / context / file selection
+        // in the sidebar while this review is open.
+        service?.addSelectionListener(statusListener)
     }
 
     private fun createContent(): JComponent {
@@ -120,12 +123,10 @@ class WorkingMemoryPanel(private val project: Project) : JPanel(BorderLayout()) 
      * the JCEF panel's own component context would otherwise risk a null project.
      */
     private fun runCommit() {
-        val action = ActionManager.getInstance().getAction("JolliMemory.CommitAI") ?: return
-        val dataContext = com.intellij.openapi.actionSystem.impl.SimpleDataContext.getProjectContext(project)
-        val event = com.intellij.openapi.actionSystem.AnActionEvent.createFromAnAction(
-            action, null, "JolliMemoryWorkingMemory", dataContext,
-        )
-        action.actionPerformed(event)
+        // Call the commit logic directly with our explicit project — the JCEF panel's
+        // own data context doesn't reliably carry the project, and the action-invocation
+        // API (ActionUtil.invokeAction) is deprecated inconsistently across IDE versions.
+        ai.jolli.jollimemory.actions.CommitAIAction().performCommit(project)
     }
 
     // ── Data gathering ────────────────────────────────────────────────────────
@@ -134,34 +135,70 @@ class WorkingMemoryPanel(private val project: Project) : JPanel(BorderLayout()) 
         val gitOps = service?.getGitOps()
         val branch = gitOps?.getCurrentBranch() ?: "unknown"
 
-        val (files, ins, del) = diffStats(branch)
+        // Insertions/deletions reflect the whole working-tree change; the file *count*
+        // tracks the selected files below so it agrees with the Files section.
+        val (_, ins, del) = diffStats(branch)
+        val selectedFiles = changedFiles()
+
+        // The review must show exactly what the next commit will save, so honor the
+        // same sidebar exclusions the PostCommitHook applies (conversations unchecked
+        // in the CONVERSATIONS list, plans/notes/references unchecked in CONTEXT).
+        val exclusions = try {
+            CommitSelectionStore.readExclusions(cwd)
+        } catch (_: Exception) {
+            CommitSelectionStore.CommitExclusions()
+        }
 
         val conversations = try {
-            ActiveSessionAggregator.listActiveConversations(cwd).map {
-                WmConversation(it.source.name, it.title.ifBlank { "${it.source.name} conversation" }, it.messageCount)
-            }
+            ActiveSessionAggregator.listActiveConversations(cwd)
+                .filter { CommitSelectionStore.conversationKey(it.source, it.sessionId) !in exclusions.conversations }
+                .map {
+                    WmConversation(it.source.name, it.title.ifBlank { "${it.source.name} conversation" }, it.messageCount)
+                }
         } catch (_: Exception) {
             emptyList()
         }
 
-        val context = gatherContext(branch)
+        val context = gatherContext(branch, exclusions)
         val detectedTicket = context.firstOrNull { it.tag == "L" || it.tag == "J" }
             ?.let { Regex("[A-Z]+-\\d+").find(it.title)?.value }
             ?: Regex("[A-Z]+-\\d+").find(branch)?.value
 
         return WorkingMemoryView(
             branch = branch,
-            filesChanged = files,
+            filesChanged = selectedFiles.size,
             insertions = ins,
             deletions = del,
             detectedTicket = detectedTicket,
+            proposedTitle = buildProposedTitle(branch, detectedTicket),
             // Live sessions don't carry token usage in the plugin; usage is captured
             // when the memory is generated at commit time.
             tokenLabel = "N/A tokens",
             conversations = conversations,
             context = context,
-            files = changedFiles(),
+            files = selectedFiles,
         )
+    }
+
+    /**
+     * Heuristic preview of the next commit's title, shown before the AI writes the
+     * real one at commit time. Combines any detected ticket with a humanized branch
+     * name (drop the `feature/`-style prefix and a leading ticket token, turn
+     * separators into spaces). Returns null when there's no useful signal (e.g. an
+     * unknown/empty branch), so the view falls back to its explanatory placeholder.
+     */
+    private fun buildProposedTitle(branch: String, ticket: String?): String? {
+        if (branch.isBlank() || branch == "unknown") return ticket
+        val humanized = branch.substringAfterLast('/')
+            .replace(Regex("^[A-Za-z]+-\\d+[-_]?"), "") // strip a leading ticket token (jolli-1785-…)
+            .replace(Regex("[-_]+"), " ")
+            .trim()
+        return when {
+            ticket != null && humanized.isNotBlank() -> "$ticket — $humanized"
+            ticket != null -> ticket
+            humanized.isNotBlank() -> humanized.replaceFirstChar { it.uppercase() }
+            else -> null
+        }
     }
 
     /** +insertions / −deletions / files changed vs HEAD (staged + unstaged). */
@@ -175,34 +212,49 @@ class WorkingMemoryPanel(private val project: Project) : JPanel(BorderLayout()) 
         return Triple(fileCount, ins, del)
     }
 
+    /**
+     * Files the next commit will include. Prefers the Changes panel's live selection
+     * (the same set [JolliMemory.CommitAI] commits) so unchecking a file in the sidebar
+     * removes it here too; falls back to all changed files when the panel isn't mounted.
+     */
     private fun changedFiles(): List<WmFile> = try {
-        service?.getChangedFiles()?.map { fc ->
+        val source = service?.panelRegistry?.changesPanel?.getSelectedFiles()
+            ?: service?.getChangedFiles()
+            ?: emptyList()
+        source.map { fc ->
             val slash = fc.relativePath.lastIndexOf('/')
             val name = if (slash >= 0) fc.relativePath.substring(slash + 1) else fc.relativePath
             val dir = if (slash > 0) fc.relativePath.substring(0, slash) else ""
             WmFile(name, dir, fc.statusCode.take(1).ifBlank { "M" })
-        } ?: emptyList()
+        }
     } catch (_: Exception) {
         emptyList()
     }
 
-    /** Uncommitted plans + notes on the current branch, plus all references. */
-    private fun gatherContext(branch: String): List<WmContext> {
+    /**
+     * Uncommitted plans + notes on the current branch, plus all references —
+     * minus anything the user unchecked in the CONTEXT list (same exclusion keys
+     * the CONTEXT panel and PostCommitHook use: plan slug, note id, reference map key).
+     */
+    private fun gatherContext(branch: String, exclusions: CommitSelectionStore.CommitExclusions): List<WmContext> {
         val out = mutableListOf<WmContext>()
         try {
             val registry = SessionTracker.loadPlansRegistry(cwd)
             registry.plans.values.forEach { p ->
+                if (p.slug in exclusions.plans) return@forEach
                 if (p.ignored == true || p.commitHash != null) return@forEach
                 if (!p.branch.isNullOrBlank() && p.branch != branch) return@forEach
                 if (!File(p.sourcePath).exists()) return@forEach
                 out.add(WmContext("P", p.title))
             }
             registry.notes?.values?.forEach { n ->
+                if (n.id in exclusions.notes) return@forEach
                 if (n.ignored == true || n.commitHash != null) return@forEach
                 if (n.branch.isNotBlank() && n.branch != branch) return@forEach
                 out.add(WmContext("N", n.title))
             }
-            registry.references?.values?.forEach { r ->
+            registry.references?.forEach { (mapKey, r) ->
+                if (mapKey in exclusions.references) return@forEach
                 out.add(WmContext(referenceTag(r.source), r.title))
             }
         } catch (_: Exception) {
@@ -220,6 +272,7 @@ class WorkingMemoryPanel(private val project: Project) : JPanel(BorderLayout()) 
 
     fun dispose() {
         service?.removeStatusListener(statusListener)
+        service?.removeSelectionListener(statusListener)
         jsQuery?.dispose()
         browser?.dispose()
     }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/WorkingMemoryHtmlBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/WorkingMemoryHtmlBuilder.kt
@@ -26,6 +26,12 @@ object WorkingMemoryHtmlBuilder {
         val insertions: Int,
         val deletions: Int,
         val detectedTicket: String?,
+        /**
+         * Heuristic preview of the commit title (ticket + humanized branch), shown
+         * before the AI writes the real one at commit time. Null when there's no
+         * useful signal — the view then shows an explanatory placeholder.
+         */
+        val proposedTitle: String?,
         val tokenLabel: String,
         val conversations: List<WmConversation>,
         val context: List<WmContext>,
@@ -90,10 +96,17 @@ object WorkingMemoryHtmlBuilder {
         val ticket = v.detectedTicket?.let {
             "<span>Detected&nbsp;ticket&nbsp;<b>${esc(it)}</b></span>"
         } ?: ""
+        // A heuristic preview when we have one; otherwise the honest "written at commit" note.
+        val titleHtml = if (v.proposedTitle != null) {
+            "<div class=\"wm-title-text\">${esc(v.proposedTitle)}</div>" +
+                "<div class=\"wm-title-note\">Preview — the AI writes the final message when you commit.</div>"
+        } else {
+            "<div class=\"wm-title-text\">An AI-written commit message is generated when you commit.</div>"
+        }
         return """
             <div class="wm-panel">
               <div class="wm-label">Proposed title <span class="wm-ai">AI</span></div>
-              <div class="wm-title-text">An AI-written commit message is generated when you commit.</div>
+              $titleHtml
               <div class="wm-grid">
                 <span>Target&nbsp;commit&nbsp;<b>next on ${esc(v.branch)}</b></span>
                 $ticket
@@ -223,7 +236,8 @@ object WorkingMemoryHtmlBuilder {
         .wm-panel { background: var(--panel-bg); border: 1px solid var(--widget-border); border-radius: 8px; padding: 10px 12px; margin: 0 0 12px; }
         .wm-label { font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--text-tertiary); margin-bottom: 4px; }
         .wm-ai { background: var(--pill-bg); color: var(--pill-text); border-radius: 5px; padding: 0 5px; font-size: 9.5px; font-weight: 700; margin-left: 4px; }
-        .wm-title-text { font-size: 13.5px; color: var(--text-primary); margin-bottom: 8px; }
+        .wm-title-text { font-size: 13.5px; color: var(--text-primary); margin-bottom: 4px; }
+        .wm-title-note { font-size: 11px; color: var(--text-tertiary); margin-bottom: 8px; }
         .wm-grid { display: flex; flex-wrap: wrap; gap: 4px 18px; font-size: 11.5px; color: var(--text-secondary); }
         .wm-grid b { color: var(--text-primary); font-weight: 600; }
         .wm-tmeter { margin: 0 0 12px; }

--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -1,4 +1,11 @@
-<idea-plugin>
+<!-- require-restart: even after releasing the static-singleton resources (see
+     JolliDynamicUnloadCleaner) the platform's dynamic unload still hangs on this
+     plugin's coroutine scope + project-service/NIO-watcher dispose ordering,
+     leaving the file index turned off and never turned back on (the IDE wedges in
+     perpetual "indexing"). Sandbox-verified. Until a full coroutine/lifecycle
+     refactor makes hot-unload provably clean, require a restart so enable/disable/
+     uninstall does one clean full reload instead of a fragile hot-unload. -->
+<idea-plugin require-restart="true">
     <id>ai.jolli.jollimemory</id>
     <name>Jolli Memory</name>
     <vendor url="https://jolli.ai" email="support@jolli.ai">Jolli</vendor>
@@ -14,6 +21,14 @@
 
     <depends>com.intellij.modules.platform</depends>
     <depends>Git4Idea</depends>
+
+    <!-- Release app-level (object-held) background resources before a dynamic
+         unload so they don't pin the plugin classloader. Lets the plugin be
+         enabled/disabled without an IDE restart. -->
+    <applicationListeners>
+        <listener class="ai.jolli.jollimemory.JolliDynamicUnloadCleaner"
+                  topic="com.intellij.ide.plugins.DynamicPluginListener"/>
+    </applicationListeners>
 
     <extensions defaultExtensionNs="com.intellij">
         <!-- Project-level service: manages hook installation and core library integration -->

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/GitOpsOwnCommitsBaseTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/GitOpsOwnCommitsBaseTest.kt
@@ -1,0 +1,102 @@
+package ai.jolli.jollimemory.bridge
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+/**
+ * Integration tests for the reflog-based fork-point resolution that backs the
+ * COMMITTED MEMORIES panel's branch scoping. Exercises a real git repo so the
+ * behavior matches production (the panel clears when a fresh branch has no own
+ * commits, even when cut from a feature/release branch rather than main).
+ */
+class GitOpsOwnCommitsBaseTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var repo: File
+    private lateinit var git: GitOps
+
+    @BeforeEach
+    fun setUp() {
+        repo = tempDir.toFile()
+        run("init", "-b", "main")
+        run("config", "user.email", "test@example.com")
+        run("config", "user.name", "Test User")
+        run("commit", "--allow-empty", "-m", "root on main")
+        git = GitOps(repo.absolutePath)
+    }
+
+    /** Runs a git command in the temp repo and returns trimmed stdout (fails loudly on error). */
+    private fun run(vararg args: String): String {
+        val pb = ProcessBuilder(listOf("git") + args).directory(repo).redirectErrorStream(true)
+        val p = pb.start()
+        val out = p.inputStream.bufferedReader().use { it.readText() }
+        check(p.waitFor(30, TimeUnit.SECONDS)) { "git ${args.joinToString(" ")} timed out" }
+        check(p.exitValue() == 0) { "git ${args.joinToString(" ")} failed: $out" }
+        return out.trim()
+    }
+
+    private fun rev(ref: String): String = run("rev-parse", ref)
+
+    @Test
+    fun `fresh branch cut from a feature branch has no own commits (base equals HEAD)`() {
+        // main → A ; feature/base adds B, C ; feature/new is cut from feature/base
+        // and adds nothing of its own — so its "own commits" base must be its tip.
+        run("checkout", "-b", "feature/base")
+        run("commit", "--allow-empty", "-m", "B on feature/base")
+        run("commit", "--allow-empty", "-m", "C on feature/base")
+        run("checkout", "-b", "feature/new")
+
+        val head = rev("HEAD")
+        val mergeBaseMain = rev("main") // merge-base(HEAD, main) collapses to A here anyway
+
+        // The reflog records "Created from feature/base" at C == HEAD.
+        val creationPoint = git.findBranchCreationPoint("feature/new", requireExplicit = true)
+        creationPoint shouldBe head
+
+        // Own-commits base is the creation point (downstream of the mainline base),
+        // which equals HEAD → getBranchCommits returns empty → panel clears.
+        git.resolveOwnCommitsBase("feature/new", mergeBaseMain) shouldBe head
+    }
+
+    @Test
+    fun `branch cut directly from main measures own commits from the mainline base`() {
+        val mainTip = rev("main")
+        run("checkout", "-b", "feature/direct")
+        run("commit", "--allow-empty", "-m", "own work")
+
+        // Cut from main: creation point equals the mainline merge-base, so the base
+        // stays at the mainline fork point and the branch's own commit is listed.
+        git.resolveOwnCommitsBase("feature/direct", mainTip) shouldBe mainTip
+    }
+
+    @Test
+    fun `feature branch with its own commits keeps them (base is the parent tip)`() {
+        run("checkout", "-b", "feature/base")
+        run("commit", "--allow-empty", "-m", "B on feature/base")
+        val baseTip = rev("HEAD")
+        run("checkout", "-b", "feature/work")
+        run("commit", "--allow-empty", "-m", "own work on feature/work")
+
+        // Cut from feature/base then committed: base is feature/base's tip, so
+        // only feature/work's own commit is in `<base>..HEAD`, not feature/base's.
+        git.resolveOwnCommitsBase("feature/work", rev("main")) shouldBe baseTip
+    }
+
+    @Test
+    fun `findBranchCreationPoint returns null when no explicit creation entry and requireExplicit`() {
+        // main's own reflog has no "branch: Created from" entry (it is the initial branch).
+        git.findBranchCreationPoint("main", requireExplicit = true) shouldBe null
+    }
+
+    @Test
+    fun `detached HEAD has no creation point`() {
+        git.findBranchCreationPoint("HEAD", requireExplicit = true) shouldBe null
+    }
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/plans/TranscriptPlanDiscoveryTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/plans/TranscriptPlanDiscoveryTest.kt
@@ -1,0 +1,305 @@
+package ai.jolli.jollimemory.core.plans
+
+import ai.jolli.jollimemory.core.NoteEntry
+import ai.jolli.jollimemory.core.NoteFormat
+import ai.jolli.jollimemory.core.PlanEntry
+import ai.jolli.jollimemory.core.PlansRegistry
+import ai.jolli.jollimemory.core.SessionTracker
+import ai.jolli.jollimemory.core.TranscriptSource
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldEndWith
+import io.kotest.matchers.string.shouldStartWith
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.security.MessageDigest
+
+class TranscriptPlanDiscoveryTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private lateinit var cwd: String
+    private var plansRegistry = PlansRegistry()
+
+    @BeforeEach
+    fun setUp() {
+        cwd = tempDir.absolutePath
+        plansRegistry = PlansRegistry()
+
+        mockkObject(SessionTracker)
+        every { SessionTracker.acquireLock(any()) } returns true
+        every { SessionTracker.releaseLock(any()) } returns Unit
+        every { SessionTracker.loadPlansRegistry(any<String>()) } answers { plansRegistry }
+        every { SessionTracker.savePlansRegistry(any(), any<String>()) } answers { plansRegistry = firstArg() }
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /** A Write/Edit tool_use line that targets an absolute .md `file_path`. */
+    private fun writeMdLine(path: String, name: String = "Write"): String {
+        val esc = path.replace("\\", "\\\\")
+        return """{"message":{"role":"assistant","content":[{"type":"tool_use","id":"tu","name":"$name","input":{"file_path":"$esc","content":"x"}}]}}"""
+    }
+
+    /** A plan-mode line carrying a "slug" field. */
+    private fun slugLine(slug: String): String =
+        """{"message":{"role":"assistant","content":[{"type":"text","text":"planning"}]},"slug":"$slug"}"""
+
+    private fun writeTranscript(vararg lines: String): String {
+        val file = File(tempDir, "transcript.jsonl")
+        file.writeText(lines.joinToString("\n") + "\n")
+        return file.absolutePath
+    }
+
+    private fun mdFile(dir: File, name: String, content: String = "# My Plan\n\nbody"): File {
+        dir.mkdirs()
+        val f = File(dir, name)
+        f.writeText(content)
+        return f
+    }
+
+    private fun sha256(s: String): String =
+        MessageDigest.getInstance("SHA-256").digest(s.toByteArray()).joinToString("") { "%02x".format(it) }
+
+    // ── ClaudePlanScanner (signal detection) ───────────────────────────────────
+
+    @Nested
+    inner class Scanner {
+
+        @Test
+        fun `extracts plan-mode slug`() {
+            val path = writeTranscript(slugLine("wandering-otter"))
+            val result = ClaudePlanScanner.scan(path, 0)
+            result.slugs shouldBe setOf("wandering-otter")
+            result.externalPlans.isEmpty() shouldBe true
+            result.totalLines shouldBe 1
+        }
+
+        @Test
+        fun `extracts slug from a Write to ~ slash claude slash plans`() {
+            val path = writeTranscript(writeMdLine("/Users/x/.claude/plans/brave-fox.md"))
+            val result = ClaudePlanScanner.scan(path, 0)
+            result.slugs shouldBe setOf("brave-fox")
+            result.externalPlans.isEmpty() shouldBe true
+        }
+
+        @Test
+        fun `collects external md path from Write and Edit`() {
+            val path = writeTranscript(
+                writeMdLine("/repo/docs/design.md", "Write"),
+                writeMdLine("/repo/docs/notes.md", "Edit"),
+            )
+            val result = ClaudePlanScanner.scan(path, 0)
+            result.slugs.isEmpty() shouldBe true
+            result.externalPlans shouldBe setOf("/repo/docs/design.md", "/repo/docs/notes.md")
+        }
+
+        @Test
+        fun `ignores non Write or Edit tool_use`() {
+            val path = writeTranscript(writeMdLine("/repo/docs/design.md", "Read"))
+            val result = ClaudePlanScanner.scan(path, 0)
+            result.externalPlans.isEmpty() shouldBe true
+        }
+
+        @Test
+        fun `respects fromLine and skips already-scanned lines`() {
+            val path = writeTranscript(
+                writeMdLine("/repo/a.md"),
+                writeMdLine("/repo/b.md"),
+            )
+            val result = ClaudePlanScanner.scan(path, 1)
+            result.externalPlans shouldBe setOf("/repo/b.md")
+            result.totalLines shouldBe 2
+        }
+
+        @Test
+        fun `decodes JSON-escaped unicode paths`() {
+            // file_path with a é escape → decoded to é
+            val path = writeTranscript(
+                """{"message":{"content":[{"type":"tool_use","name":"Write","input":{"file_path":"/repo/café.md"}}]}}""",
+            )
+            val result = ClaudePlanScanner.scan(path, 0)
+            result.externalPlans shouldBe setOf("/repo/café.md")
+        }
+    }
+
+    // ── scanPlansFrom (persist + policy) ───────────────────────────────────────
+
+    @Nested
+    inner class ScanPlansFrom {
+
+        @Test
+        fun `registers a new external plan into plans json`() {
+            val plan = mdFile(File(tempDir, "docs"), "feature.md", "# Feature Plan\n")
+            val path = writeTranscript(writeMdLine(plan.absolutePath))
+
+            val last = TranscriptPlanDiscovery.scanPlansFrom(path, 0, cwd, TranscriptSource.claude)
+            last shouldBe 1
+
+            plansRegistry.plans.size shouldBe 1
+            val entry = plansRegistry.plans["feature"]
+            entry shouldNotBe null
+            entry!!.sourcePath shouldBe plan.absolutePath
+            entry.title shouldBe "Feature Plan"
+            entry.commitHash shouldBe null
+            // temp dir is not a git repo → branch omitted (visible everywhere)
+            entry.branch shouldBe null
+        }
+
+        @Test
+        fun `returns totalLines and writes nothing when no plan signals`() {
+            val path = writeTranscript("""{"message":{"content":[{"type":"text","text":"hi"}]}}""")
+            val last = TranscriptPlanDiscovery.scanPlansFrom(path, 0, cwd, TranscriptSource.claude)
+            last shouldBe 1
+            plansRegistry.plans.isEmpty() shouldBe true
+        }
+
+        @Test
+        fun `excludes README and node_modules and dot-claude and dot-github paths`() {
+            val readme = mdFile(File(tempDir, "docs"), "README.md")
+            val nodeMod = mdFile(File(tempDir, "node_modules/pkg"), "plan.md")
+            val gh = mdFile(File(tempDir, ".github"), "plan.md")
+            val path = writeTranscript(
+                writeMdLine(readme.absolutePath),
+                writeMdLine(nodeMod.absolutePath),
+                writeMdLine(gh.absolutePath),
+            )
+
+            TranscriptPlanDiscovery.scanPlansFrom(path, 0, cwd, TranscriptSource.claude)
+            plansRegistry.plans.isEmpty() shouldBe true
+        }
+
+        @Test
+        fun `skips a canonical slug whose plan file does not exist`() {
+            // slug points at ~/.claude/plans/<slug>.md which won't exist for this random slug
+            val path = writeTranscript(slugLine("nonexistent-slug-xyz-12345"))
+            val last = TranscriptPlanDiscovery.scanPlansFrom(path, 0, cwd, TranscriptSource.claude)
+            last shouldBe 1
+            plansRegistry.plans.isEmpty() shouldBe true
+        }
+
+        @Test
+        fun `suppresses plan registration when path already a note`() {
+            val plan = mdFile(File(tempDir, "docs"), "shared.md")
+            plansRegistry = PlansRegistry(
+                notes = mapOf(
+                    "n1" to NoteEntry(
+                        id = "n1", title = "Shared", format = NoteFormat.markdown,
+                        addedAt = "t", updatedAt = "t", branch = "", commitHash = null,
+                        sourcePath = plan.absolutePath,
+                    ),
+                ),
+            )
+            val path = writeTranscript(writeMdLine(plan.absolutePath))
+
+            TranscriptPlanDiscovery.scanPlansFrom(path, 0, cwd, TranscriptSource.claude)
+            plansRegistry.plans.isEmpty() shouldBe true
+        }
+
+        @Test
+        fun `bumps updatedAt for an existing uncommitted entry`() {
+            val plan = mdFile(File(tempDir, "docs"), "feature.md")
+            plansRegistry = PlansRegistry(
+                plans = mapOf(
+                    "feature" to PlanEntry(
+                        slug = "feature", title = "Old", sourcePath = plan.absolutePath,
+                        addedAt = "2020-01-01T00:00:00Z", updatedAt = "2020-01-01T00:00:00Z",
+                        commitHash = null,
+                    ),
+                ),
+            )
+            val path = writeTranscript(writeMdLine(plan.absolutePath))
+
+            TranscriptPlanDiscovery.scanPlansFrom(path, 0, cwd, TranscriptSource.claude)
+            val entry = plansRegistry.plans["feature"]!!
+            entry.updatedAt shouldNotBe "2020-01-01T00:00:00Z"
+        }
+
+        @Test
+        fun `leaves a committed entry untouched`() {
+            val plan = mdFile(File(tempDir, "docs"), "feature.md")
+            val committed = PlanEntry(
+                slug = "feature", title = "Committed", sourcePath = plan.absolutePath,
+                addedAt = "2020-01-01T00:00:00Z", updatedAt = "2020-01-01T00:00:00Z",
+                commitHash = "abc12345", // committed, no contentHashAtCommit
+            )
+            plansRegistry = PlansRegistry(plans = mapOf("feature" to committed))
+            val path = writeTranscript(writeMdLine(plan.absolutePath))
+
+            TranscriptPlanDiscovery.scanPlansFrom(path, 0, cwd, TranscriptSource.claude)
+            plansRegistry.plans["feature"] shouldBe committed
+        }
+
+        @Test
+        fun `revives an archived guard entry when the file changed`() {
+            val plan = mdFile(File(tempDir, "docs"), "feature.md", "# New content\n")
+            val guard = PlanEntry(
+                slug = "feature", title = "Archived", sourcePath = plan.absolutePath,
+                addedAt = "2020-01-01T00:00:00Z", updatedAt = "2020-01-01T00:00:00Z",
+                commitHash = "abc12345", contentHashAtCommit = sha256("# Old content\n"),
+            )
+            plansRegistry = PlansRegistry(plans = mapOf("feature" to guard))
+            val path = writeTranscript(writeMdLine(plan.absolutePath))
+
+            TranscriptPlanDiscovery.scanPlansFrom(path, 0, cwd, TranscriptSource.claude)
+            val entry = plansRegistry.plans["feature"]!!
+            entry.commitHash shouldBe null
+            entry.contentHashAtCommit shouldBe null
+        }
+
+        @Test
+        fun `hash-suffixes a slug when the base name is taken by a different file`() {
+            val first = mdFile(File(tempDir, "a"), "plan.md")
+            plansRegistry = PlansRegistry(
+                plans = mapOf(
+                    "plan" to PlanEntry(
+                        slug = "plan", title = "First", sourcePath = first.absolutePath,
+                        addedAt = "t", updatedAt = "t", commitHash = null,
+                    ),
+                ),
+            )
+            val second = mdFile(File(tempDir, "b"), "plan.md")
+            val path = writeTranscript(writeMdLine(second.absolutePath))
+
+            TranscriptPlanDiscovery.scanPlansFrom(path, 0, cwd, TranscriptSource.claude)
+            plansRegistry.plans.size shouldBe 2
+            val suffixed = plansRegistry.plans.keys.first { it != "plan" }
+            suffixed shouldStartWith "plan-"
+            suffixed.length shouldBe "plan-".length + 8
+        }
+
+        @Test
+        fun `incremental scan finds nothing new from the last line`() {
+            val plan = mdFile(File(tempDir, "docs"), "feature.md")
+            val path = writeTranscript(writeMdLine(plan.absolutePath))
+
+            val last = TranscriptPlanDiscovery.scanPlansFrom(path, 0, cwd, TranscriptSource.claude)
+            plansRegistry.plans.size shouldBe 1
+
+            plansRegistry = PlansRegistry() // prove no re-discovery
+            val second = TranscriptPlanDiscovery.scanPlansFrom(path, last, cwd, TranscriptSource.claude)
+            second shouldBe last
+            plansRegistry.plans.isEmpty() shouldBe true
+        }
+
+        @Test
+        fun `derives a slug basename ending in md`() {
+            val plan = mdFile(File(tempDir, "docs"), "my-cool-plan.md")
+            val path = writeTranscript(writeMdLine(plan.absolutePath))
+            TranscriptPlanDiscovery.scanPlansFrom(path, 0, cwd, TranscriptSource.claude)
+            plansRegistry.plans.keys.first() shouldBe "my-cool-plan"
+            plansRegistry.plans.values.first().sourcePath shouldEndWith "my-cool-plan.md"
+        }
+    }
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/references/TranscriptReferenceDiscoveryTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/references/TranscriptReferenceDiscoveryTest.kt
@@ -94,8 +94,10 @@ class TranscriptReferenceDiscoveryTest {
 			entry!!.nativeId shouldBe "PROJ-42"
 			entry.title shouldBe "Test issue"
 			entry.source shouldBe SourceId.linear
-			// Branch is stamped at capture (temp dir is not a git repo → "unknown").
-			entry.branch shouldBe "unknown"
+			// Temp dir is not a git repo → getCurrentBranchSafe returns "unknown", which
+			// is left OFF the row (branch = null) rather than written literally. Writing
+			// "unknown" would exclude the reference from every branch's summary prompt.
+			entry.branch shouldBe null
 		}
 
 		@Test
@@ -163,6 +165,51 @@ class TranscriptReferenceDiscoveryTest {
 			val secondLast = TranscriptReferenceDiscovery.scanReferencesFrom(path, firstLast, cwd, TranscriptSource.claude)
 			secondLast shouldBe firstLast
 			plansRegistry.references shouldBe null
+		}
+
+		@Test
+		fun `preserves an existing real branch when the git lookup is unknown`() {
+			// Seed a row stamped with a real branch (as if captured on feature/x).
+			plansRegistry = PlansRegistry(
+				references = mapOf(
+					"linear:PROJ-42" to ReferenceEntry(
+						source = SourceId.linear,
+						nativeId = "PROJ-42",
+						title = "Old title",
+						url = "https://linear.app/x/issue/PROJ-42",
+						sourcePath = "",
+						addedAt = "t",
+						updatedAt = "t",
+						sourceToolName = "mcp__linear__get_issue",
+						branch = "feature/x",
+					),
+				),
+			)
+			val path = writeTranscript(
+				toolUseLine("tu1", "mcp__linear__get_issue"),
+				toolResultLine("tu1", LINEAR_PAYLOAD),
+			)
+
+			// Non-git temp dir → lookup is "unknown"; the re-upsert must keep the
+			// existing branch rather than clobber it with a summary-excluding value.
+			TranscriptReferenceDiscovery.scanReferencesFrom(path, 0, cwd, TranscriptSource.claude)
+
+			plansRegistry.references!!["linear:PROJ-42"]!!.branch shouldBe "feature/x"
+		}
+
+		@Test
+		fun `does not release the lock when it was not acquired`() {
+			// When another writer (PostCommitHook worker / parallel StopHook) holds the
+			// lock, acquire fails — we must NOT release it, or we'd delete their lock.
+			every { SessionTracker.acquireLock(any()) } returns false
+			val path = writeTranscript(
+				toolUseLine("tu1", "mcp__linear__get_issue"),
+				toolResultLine("tu1", LINEAR_PAYLOAD),
+			)
+
+			TranscriptReferenceDiscovery.scanReferencesFrom(path, 0, cwd, TranscriptSource.claude)
+
+			io.mockk.verify(exactly = 0) { SessionTracker.releaseLock(any()) }
 		}
 
 		@Test

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/references/TranscriptReferenceDiscoveryTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/references/TranscriptReferenceDiscoveryTest.kt
@@ -94,6 +94,8 @@ class TranscriptReferenceDiscoveryTest {
 			entry!!.nativeId shouldBe "PROJ-42"
 			entry.title shouldBe "Test issue"
 			entry.source shouldBe SourceId.linear
+			// Branch is stamped at capture (temp dir is not a git repo → "unknown").
+			entry.branch shouldBe "unknown"
 		}
 
 		@Test

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/hooks/PostCommitHookTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/hooks/PostCommitHookTest.kt
@@ -5,6 +5,8 @@ import ai.jolli.jollimemory.core.NoteEntry
 import ai.jolli.jollimemory.core.NoteFormat
 import ai.jolli.jollimemory.core.PlansRegistry
 import ai.jolli.jollimemory.core.SessionTracker
+import ai.jolli.jollimemory.core.references.ReferenceEntry
+import ai.jolli.jollimemory.core.references.SourceId
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.BeforeEach
@@ -51,6 +53,27 @@ class PostCommitHookTest {
         )
         method.isAccessible = true
         return method.invoke(PostCommitHook, cwd, branch, excluded) as Map<String, NoteEntry>
+    }
+
+    private fun ref(nativeId: String, branch: String?) = ReferenceEntry(
+        source = SourceId.linear,
+        nativeId = nativeId,
+        title = "Ref $nativeId",
+        url = "https://linear.app/x/issue/$nativeId",
+        sourcePath = "/references/linear/$nativeId.md",
+        addedAt = "2026-01-01T00:00:00Z",
+        updatedAt = "2026-01-01T00:00:00Z",
+        sourceToolName = "linear",
+        branch = branch,
+    )
+
+    @Suppress("UNCHECKED_CAST")
+    private fun detectUncommittedReferences(branch: String): Map<String, ReferenceEntry> {
+        val method = PostCommitHook::class.java.getDeclaredMethod(
+            "detectUncommittedReferences", String::class.java, String::class.java,
+        )
+        method.isAccessible = true
+        return method.invoke(PostCommitHook, cwd, branch) as Map<String, ReferenceEntry>
     }
 
     private fun sha256Hex(s: String): String {
@@ -137,6 +160,34 @@ invalid line
         fun `returns empty when there are no notes`() {
             SessionTracker.savePlansRegistry(PlansRegistry(), cwd)
             detectUncommittedNotes(branch = "main", excluded = emptySet()) shouldBe emptyMap()
+        }
+    }
+
+    @Nested
+    inner class DetectUncommittedReferences {
+        @Test
+        fun `includes only current-branch and legacy blank-branch references`() {
+            SessionTracker.savePlansRegistry(
+                PlansRegistry(
+                    references = mapOf(
+                        "linear:ENG-1" to ref("ENG-1", branch = "feature/x"),
+                        "linear:ENG-2" to ref("ENG-2", branch = null),
+                        "linear:ENG-3" to ref("ENG-3", branch = ""),
+                        "linear:ENG-4" to ref("ENG-4", branch = "feature/y"),
+                    ),
+                ),
+                cwd,
+            )
+
+            val result = detectUncommittedReferences(branch = "feature/x")
+
+            result.keys shouldContainExactlyInAnyOrder listOf("linear:ENG-1", "linear:ENG-2", "linear:ENG-3")
+        }
+
+        @Test
+        fun `returns empty when there are no references`() {
+            SessionTracker.savePlansRegistry(PlansRegistry(), cwd)
+            detectUncommittedReferences(branch = "main") shouldBe emptyMap()
         }
     }
 

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/hooks/PostCommitHookTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/hooks/PostCommitHookTest.kt
@@ -1,18 +1,62 @@
 package ai.jolli.jollimemory.hooks
 
 import ai.jolli.jollimemory.core.DiffStats
+import ai.jolli.jollimemory.core.NoteEntry
+import ai.jolli.jollimemory.core.NoteFormat
+import ai.jolli.jollimemory.core.PlansRegistry
+import ai.jolli.jollimemory.core.SessionTracker
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
 import java.lang.reflect.Method
 
 class PostCommitHookTest {
+
+    @TempDir
+    lateinit var tempDir: File
+    private val cwd get() = tempDir.absolutePath
+
+    @BeforeEach
+    fun setUp() {
+        File(tempDir, ".jolli/jollimemory").mkdirs()
+    }
 
     /** Access the private parseDiffStats method via reflection for testing. */
     private fun parseDiffStats(statOutput: String): DiffStats {
         val method: Method = PostCommitHook::class.java.getDeclaredMethod("parseDiffStats", String::class.java)
         method.isAccessible = true
         return method.invoke(PostCommitHook, statOutput) as DiffStats
+    }
+
+    private fun note(id: String, branch: String, commitHash: String?, ignored: Boolean? = null) = NoteEntry(
+        id = id,
+        title = "Note $id",
+        format = NoteFormat.markdown,
+        addedAt = "2026-01-01T00:00:00Z",
+        updatedAt = "2026-01-01T00:00:00Z",
+        branch = branch,
+        commitHash = commitHash,
+        ignored = ignored,
+        sourcePath = "/notes/$id.md",
+    )
+
+    @Suppress("UNCHECKED_CAST")
+    private fun detectUncommittedNotes(branch: String, excluded: Set<String>): Map<String, NoteEntry> {
+        val method = PostCommitHook::class.java.getDeclaredMethod(
+            "detectUncommittedNotes", String::class.java, String::class.java, Set::class.java,
+        )
+        method.isAccessible = true
+        return method.invoke(PostCommitHook, cwd, branch, excluded) as Map<String, NoteEntry>
+    }
+
+    private fun sha256Hex(s: String): String {
+        val method = PostCommitHook::class.java.getDeclaredMethod("sha256Hex", String::class.java)
+        method.isAccessible = true
+        return method.invoke(PostCommitHook, s) as String
     }
 
     @Nested
@@ -63,6 +107,45 @@ invalid line
             stats.filesChanged shouldBe 2
             stats.insertions shouldBe 13
             stats.deletions shouldBe 7
+        }
+    }
+
+    @Nested
+    inner class DetectUncommittedNotes {
+        @Test
+        fun `includes only uncommitted, non-ignored, current-branch, non-excluded notes`() {
+            SessionTracker.savePlansRegistry(
+                PlansRegistry(
+                    notes = mapOf(
+                        "eligible" to note("eligible", branch = "feature/x", commitHash = null),
+                        "blank-branch" to note("blank-branch", branch = "", commitHash = null),
+                        "committed" to note("committed", branch = "feature/x", commitHash = "abc123"),
+                        "ignored" to note("ignored", branch = "feature/x", commitHash = null, ignored = true),
+                        "other-branch" to note("other-branch", branch = "feature/y", commitHash = null),
+                        "excluded" to note("excluded", branch = "feature/x", commitHash = null),
+                    ),
+                ),
+                cwd,
+            )
+
+            val result = detectUncommittedNotes(branch = "feature/x", excluded = setOf("excluded"))
+
+            result.keys shouldContainExactlyInAnyOrder listOf("eligible", "blank-branch")
+        }
+
+        @Test
+        fun `returns empty when there are no notes`() {
+            SessionTracker.savePlansRegistry(PlansRegistry(), cwd)
+            detectUncommittedNotes(branch = "main", excluded = emptySet()) shouldBe emptyMap()
+        }
+    }
+
+    @Nested
+    inner class Sha256Hex {
+        @Test
+        fun `matches the known SHA-256 of a string`() {
+            // echo -n "abc" | shasum -a 256
+            sha256Hex("abc") shouldBe "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
         }
     }
 }

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/hooks/PostCommitHookTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/hooks/PostCommitHookTest.kt
@@ -1,8 +1,10 @@
 package ai.jolli.jollimemory.hooks
 
+import ai.jolli.jollimemory.core.CommitSelectionStore
 import ai.jolli.jollimemory.core.DiffStats
 import ai.jolli.jollimemory.core.NoteEntry
 import ai.jolli.jollimemory.core.NoteFormat
+import ai.jolli.jollimemory.core.PlanEntry
 import ai.jolli.jollimemory.core.PlansRegistry
 import ai.jolli.jollimemory.core.SessionTracker
 import ai.jolli.jollimemory.core.references.ReferenceEntry
@@ -47,12 +49,12 @@ class PostCommitHookTest {
     )
 
     @Suppress("UNCHECKED_CAST")
-    private fun detectUncommittedNotes(branch: String, excluded: Set<String>): Map<String, NoteEntry> {
+    private fun detectUncommittedNotes(excluded: Set<String>): Map<String, NoteEntry> {
         val method = PostCommitHook::class.java.getDeclaredMethod(
-            "detectUncommittedNotes", String::class.java, String::class.java, Set::class.java,
+            "detectUncommittedNotes", String::class.java, Set::class.java,
         )
         method.isAccessible = true
-        return method.invoke(PostCommitHook, cwd, branch, excluded) as Map<String, NoteEntry>
+        return method.invoke(PostCommitHook, cwd, excluded) as Map<String, NoteEntry>
     }
 
     private fun ref(nativeId: String, branch: String?) = ReferenceEntry(
@@ -68,12 +70,30 @@ class PostCommitHookTest {
     )
 
     @Suppress("UNCHECKED_CAST")
-    private fun detectUncommittedReferences(branch: String): Map<String, ReferenceEntry> {
+    private fun detectUncommittedReferences(excluded: Set<String>): Map<String, ReferenceEntry> {
         val method = PostCommitHook::class.java.getDeclaredMethod(
-            "detectUncommittedReferences", String::class.java, String::class.java,
+            "detectUncommittedReferences", String::class.java, Set::class.java,
         )
         method.isAccessible = true
-        return method.invoke(PostCommitHook, cwd, branch) as Map<String, ReferenceEntry>
+        return method.invoke(PostCommitHook, cwd, excluded) as Map<String, ReferenceEntry>
+    }
+
+    private fun plan(slug: String, commitHash: String?, contentHashAtCommit: String? = null, sourcePath: String) = PlanEntry(
+        slug = slug,
+        title = "Plan $slug",
+        sourcePath = sourcePath,
+        addedAt = "2026-01-01T00:00:00Z",
+        updatedAt = "2026-01-01T00:00:00Z",
+        commitHash = commitHash,
+        contentHashAtCommit = contentHashAtCommit,
+    )
+
+    private fun discardExcludedWorkingItems(exclusions: CommitSelectionStore.CommitExclusions) {
+        val method = PostCommitHook::class.java.getDeclaredMethod(
+            "discardExcludedWorkingItems", CommitSelectionStore.CommitExclusions::class.java, String::class.java,
+        )
+        method.isAccessible = true
+        method.invoke(PostCommitHook, exclusions, cwd)
     }
 
     private fun sha256Hex(s: String): String {
@@ -136,7 +156,7 @@ invalid line
     @Nested
     inner class DetectUncommittedNotes {
         @Test
-        fun `includes only uncommitted, non-ignored, current-branch, non-excluded notes`() {
+        fun `includes uncommitted non-ignored non-excluded notes regardless of branch`() {
             SessionTracker.savePlansRegistry(
                 PlansRegistry(
                     notes = mapOf(
@@ -144,6 +164,7 @@ invalid line
                         "blank-branch" to note("blank-branch", branch = "", commitHash = null),
                         "committed" to note("committed", branch = "feature/x", commitHash = "abc123"),
                         "ignored" to note("ignored", branch = "feature/x", commitHash = null, ignored = true),
+                        // Uncommitted items follow the user across branches — no branch filter.
                         "other-branch" to note("other-branch", branch = "feature/y", commitHash = null),
                         "excluded" to note("excluded", branch = "feature/x", commitHash = null),
                     ),
@@ -151,35 +172,36 @@ invalid line
                 cwd,
             )
 
-            val result = detectUncommittedNotes(branch = "feature/x", excluded = setOf("excluded"))
+            val result = detectUncommittedNotes(excluded = setOf("excluded"))
 
-            result.keys shouldContainExactlyInAnyOrder listOf("eligible", "blank-branch")
+            result.keys shouldContainExactlyInAnyOrder listOf("eligible", "blank-branch", "other-branch")
         }
 
         @Test
         fun `returns empty when there are no notes`() {
             SessionTracker.savePlansRegistry(PlansRegistry(), cwd)
-            detectUncommittedNotes(branch = "main", excluded = emptySet()) shouldBe emptyMap()
+            detectUncommittedNotes(excluded = emptySet()) shouldBe emptyMap()
         }
     }
 
     @Nested
     inner class DetectUncommittedReferences {
         @Test
-        fun `includes only current-branch and legacy blank-branch references`() {
+        fun `includes all uncommitted references regardless of branch, minus excluded`() {
             SessionTracker.savePlansRegistry(
                 PlansRegistry(
                     references = mapOf(
                         "linear:ENG-1" to ref("ENG-1", branch = "feature/x"),
                         "linear:ENG-2" to ref("ENG-2", branch = null),
                         "linear:ENG-3" to ref("ENG-3", branch = ""),
+                        // Other-branch reference is still included — no branch filter.
                         "linear:ENG-4" to ref("ENG-4", branch = "feature/y"),
                     ),
                 ),
                 cwd,
             )
 
-            val result = detectUncommittedReferences(branch = "feature/x")
+            val result = detectUncommittedReferences(excluded = setOf("linear:ENG-4"))
 
             result.keys shouldContainExactlyInAnyOrder listOf("linear:ENG-1", "linear:ENG-2", "linear:ENG-3")
         }
@@ -187,7 +209,68 @@ invalid line
         @Test
         fun `returns empty when there are no references`() {
             SessionTracker.savePlansRegistry(PlansRegistry(), cwd)
-            detectUncommittedReferences(branch = "main") shouldBe emptyMap()
+            detectUncommittedReferences(excluded = emptySet()) shouldBe emptyMap()
+        }
+    }
+
+    @Nested
+    inner class DiscardExcludedWorkingItems {
+        @Test
+        fun `removes excluded uncommitted rows and jolli files but keeps committed rows and external plan files`() {
+            val jolliDir = File(tempDir, ".jolli/jollimemory")
+            val notesDir = File(jolliDir, "notes").apply { mkdirs() }
+            val refsDir = File(jolliDir, "references/linear").apply { mkdirs() }
+            val extDir = File(tempDir, "ext-plans").apply { mkdirs() }
+
+            val dropPlanFile = File(extDir, "drop.md").apply { writeText("# Drop") }
+            val noteFile = File(notesDir, "n1.md").apply { writeText("note") }
+            val refFile = File(refsDir, "L-1.md").apply { writeText("ref") }
+
+            SessionTracker.savePlansRegistry(
+                PlansRegistry(
+                    plans = mapOf(
+                        "drop-plan" to plan("drop-plan", commitHash = null, sourcePath = dropPlanFile.absolutePath),
+                        // committed guard must survive even if its key is in the exclusion set.
+                        "committed-plan" to plan("committed-plan", commitHash = "abc12345", contentHashAtCommit = "h", sourcePath = dropPlanFile.absolutePath),
+                    ),
+                    notes = mapOf(
+                        "n1" to NoteEntry(
+                            id = "n1", title = "Note", format = NoteFormat.snippet,
+                            addedAt = "t", updatedAt = "t", branch = "", commitHash = null,
+                            sourcePath = noteFile.absolutePath,
+                        ),
+                    ),
+                    references = mapOf("linear:L-1" to ref("L-1", branch = null).copy(sourcePath = refFile.absolutePath)),
+                ),
+                cwd,
+            )
+
+            discardExcludedWorkingItems(
+                CommitSelectionStore.CommitExclusions(
+                    plans = setOf("drop-plan", "committed-plan"),
+                    notes = setOf("n1"),
+                    references = setOf("linear:L-1"),
+                ),
+            )
+
+            val reg = SessionTracker.loadPlansRegistry(cwd)
+            reg.plans.keys shouldContainExactlyInAnyOrder listOf("committed-plan")
+            (reg.notes ?: emptyMap()) shouldBe emptyMap()
+            (reg.references ?: emptyMap()) shouldBe emptyMap()
+            // .jolli-owned files deleted; external plan file preserved.
+            noteFile.exists() shouldBe false
+            refFile.exists() shouldBe false
+            dropPlanFile.exists() shouldBe true
+        }
+
+        @Test
+        fun `is a no-op when nothing is excluded`() {
+            SessionTracker.savePlansRegistry(
+                PlansRegistry(plans = mapOf("p" to plan("p", commitHash = null, sourcePath = "/ext/p.md"))),
+                cwd,
+            )
+            discardExcludedWorkingItems(CommitSelectionStore.CommitExclusions())
+            SessionTracker.loadPlansRegistry(cwd).plans.keys shouldContainExactlyInAnyOrder listOf("p")
         }
     }
 

--- a/vscode/src/core/NoteService.ts
+++ b/vscode/src/core/NoteService.ts
@@ -20,6 +20,7 @@ import {
 import { basename, join } from "node:path";
 import { withPlansLock } from "../../../cli/src/core/Locks.js";
 import { isPathInside } from "../../../cli/src/core/PathUtils.js";
+import { getCurrentBranchSafe } from "../../../cli/src/core/GitBranch.js";
 import {
 	loadPlansRegistry,
 	loadPlansRegistryWithStatus,
@@ -122,6 +123,10 @@ export async function saveNote(
 		resolvedTitle = title || extractTitle(sourcePath);
 	}
 
+	// Stamp the current branch so the IntelliJ plugin (sharing this plans.json)
+	// can branch-scope its CONTEXT view; an "unknown" git lookup keeps any branch
+	// already on the existing row via the leading spread.
+	const noteBranch = getCurrentBranchSafe(cwd);
 	const entry: NoteEntry = {
 		...(existingNotes[noteId] ?? {}),
 		id: noteId,
@@ -131,6 +136,7 @@ export async function saveNote(
 		addedAt: existingNotes[noteId]?.addedAt ?? now,
 		updatedAt: now,
 		commitHash: existingNotes[noteId]?.commitHash ?? null,
+		...(noteBranch && noteBranch !== "unknown" ? { branch: noteBranch } : {}),
 	};
 
 	// plans.lock + fresh re-read so this single-note upsert can't clobber a

--- a/vscode/src/core/PlanService.ts
+++ b/vscode/src/core/PlanService.ts
@@ -24,6 +24,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { withPlansLock } from "../../../cli/src/core/Locks.js";
 import { isPathInside } from "../../../cli/src/core/PathUtils.js";
+import { getCurrentBranchSafe } from "../../../cli/src/core/GitBranch.js";
 import {
 	loadAllSessions,
 	loadPlansRegistry,
@@ -272,6 +273,11 @@ export async function addPlanToRegistry(
 	const existing = registry.plans[slug];
 	const now = new Date().toISOString();
 
+	// Stamp the current branch so the IntelliJ plugin (sharing this plans.json)
+	// can branch-scope its CONTEXT view; omit on an "unknown" git lookup.
+	const planBranch = getCurrentBranchSafe(cwd);
+	const branchField = planBranch && planBranch !== "unknown" ? { branch: planBranch } : {};
+
 	// Always reset to a fresh uncommitted entry — clears contentHashAtCommit
 	// and commitHash so the plan becomes visible and editable again.
 	const entry: PlanEntry = {
@@ -281,6 +287,7 @@ export async function addPlanToRegistry(
 		addedAt: existing?.addedAt ?? now,
 		updatedAt: now,
 		commitHash: null,
+		...branchField,
 	};
 
 	// plans.lock + fresh re-read so this single-plan upsert merges onto the latest
@@ -413,6 +420,7 @@ export async function archivePlanForCommit(
 		if (!existsSync(planFile)) {
 			return null;
 		}
+		const planBranch = getCurrentBranchSafe(cwd);
 		entry = {
 			slug,
 			title: extractTitle(planFile),
@@ -420,6 +428,7 @@ export async function archivePlanForCommit(
 			addedAt: new Date().toISOString(),
 			updatedAt: new Date().toISOString(),
 			commitHash: null,
+			...(planBranch && planBranch !== "unknown" ? { branch: planBranch } : {}),
 		};
 	}
 

--- a/vscode/tsconfig.json
+++ b/vscode/tsconfig.json
@@ -5,6 +5,14 @@
 		"moduleResolution": "bundler",
 		"lib": ["ES2022"],
 		"outDir": "dist",
+		// tsc is type-check only here (esbuild produces dist/). Cross-package imports of
+		// ../../../cli/src/** pull files outside this package into the program, so their
+		// common source dir is the repo root — TS then can't infer a rootDir (TS6059),
+		// which the IDE language server flags even though tsc never emits here. noEmit
+		// stops emission; rootDir ".." pins the layout root explicitly so the IDE's
+		// project-layout check is satisfied. Both are inert for the esbuild build.
+		"noEmit": true,
+		"rootDir": "..",
 		"strict": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,


### PR DESCRIPTION
# Polish IntelliJ plugin: UI consistency, auth reliability, and telemetry

- **Commit:** `c847b2b98eb60217856a08afdb3dc2a6afbcda61`
- **Branch:** `feature/intellij-memory-panel-ux`
- **Author:** Summer Fang
- **Date:** June 28, 2026 at 5:58 PM
- **Duration:** 2 days (Jun 27, 2026 — Jun 28, 2026)
- **Changes:** 25 files changed, +1350 insertions, −787 deletions
- **Conversations:** 121 turns

---

## Plans & Notes



## Quick recap

The IntelliJ plugin now shares login credentials with the CLI and VS Code extension automatically. Previously, signing in through another tool left the IntelliJ plugin holding a stale key that caused every push to fail silently. Now the plugin reads from and writes to the shared credentials file, so a login on any surface is immediately reflected in IntelliJ. When the server rejects a stored API key, the plugin also prompts the user to re-authenticate on the spot and retries the push once — eliminating the need to manually navigate to Settings, sign out, and sign back in.

The tool window received a significant visual overhaul. Every memory panel section — Conversations, Context, Files, and Committed Memories — now shows a hover highlight bar and a hand cursor consistent with the existing Pinned panel. Row titles word-wrap and the row grows taller automatically as the panel narrows, with icons staying vertically centered. Clicking any row in the Committed Memories view now opens its content: conversation transcripts, plans, notes, and code snippets are all readable inline. Spacing and header heights are also normalized across all four sections, removing the uneven gaps that appeared after the hover work landed.

Two placeholder surfaces — a Knowledge tab and an Agent Access button — are hidden in the marketplace release. Users browsing the plugin on JetBrains Marketplace will see a clean, finished interface. The IDE freeze that occurred when clicking Apply in the Settings panel is also resolved; the panel now closes immediately and heavy work completes in the background, keeping the editor fully responsive throughout.

---

## Source Commits (7)
- `818bfb30` Deduplicate row-styling helpers; drop a dead maximumSize assignment  _(+43 −44 · Jun 28, 2026)_
- `7d2190d7` Prepare IntelliJ 0.99.3: hide unfinished surfaces, source changelog from CHANGELOG.md  _(+69 −165 · 9 turns · Jun 28, 2026)_
- `d8482348` Add IntelliJ telemetry: tool-window, memory, share & reliability events  _(+99 −3 · 5 turns · Jun 28, 2026)_
- `82b80ef5` Share credentials across surfaces + self-heal on rejected key  _(+100 −2 · 5 turns · Jun 28, 2026)_
- `60b2e989` Fix Jolli API key parser to scan all segments (lockstep with CLI)  _(+23 −18 · 5 turns · Jun 28, 2026)_
- `61eff6f8` Fix IDE freeze on Settings apply: run install/uninstall + migration off the EDT  _(+48 −29 · 3 turns · Jun 28, 2026)_
- `805adc13` Polish IntelliJ memory panels: hover, wrapping, spacing, committed-memory open  _(+1015 −570 · 93 turns · Jun 27, 2026)_

---

## Topics (15)

### 01 · Share login credentials across all editor surfaces automatically `feature`

**⚡ Why This Change**

The IntelliJ plugin stored its own separate copy of the user's login credentials, independent of the credentials used by the CLI and VS Code extension. When the user logged in through any other tool, IntelliJ kept its old, now-invalidated credentials and failed silently on every push.

**💡 Decisions Behind the Code**

- **Merge at the JSON level, not through the data model**: Deserializing the shared file into IntelliJ's data class and writing it back would silently erase any fields that IntelliJ's model doesn't know about — exactly the problem that originally motivated keeping a separate file. Reading and writing only the two credential fields as raw JSON properties preserves everything else untouched, giving IntelliJ write access to the shared file without that risk.
- **Keep IntelliJ's own settings file**: Eliminating the IntelliJ-specific file entirely would have been simpler, but IntelliJ-only preferences (such as knowledge base path and panel layout) have no equivalent in the shared schema. Keeping the file for those settings and routing only the account-level credentials through the shared file avoids forcing unrelated concerns into a schema owned by other tools.

**✅ What Was Implemented**

- `SessionTracker.kt` was updated to treat the shared `config.json` as the authoritative source for credentials. Two new helpers (`readSharedCredentials`, `writeSharedCredentials`) overlay the shared file's key and auth token on top of IntelliJ's own settings file at the raw JSON level, so fields written by other tools are never silently dropped.
- Both save paths in `SessionTracker.kt` (`saveConfig` and `saveConfigToDir`) now call `writeSharedCredentials` after writing IntelliJ's own settings file, so any login or refresh performed inside IntelliJ is immediately visible to the CLI and VS Code extension.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/SessionTracker.kt`

### 02 · Auto-recover from a rejected API key without manual sign-out `feature`

**⚡ Why This Change**

When the server rejected IntelliJ's stored API key — whether it had been deleted by a re-login on another device or replaced by a colleague — the push would fail with an error and offer no recovery path. The user had to manually sign out, sign back in, and retry the push themselves.

**💡 Decisions Behind the Code**

- **Prompt the user rather than re-authenticating silently**: A silent automatic re-login would require storing the user's password or triggering an OAuth redirect with no visible feedback, which is disruptive and potentially confusing. Showing a confirmation dialog keeps the user in control and makes the recovery action visible, while still eliminating the need to manually navigate to settings and sign out.
- **Retry exactly once after re-authentication**: Allowing unlimited retries on auth failure risks an infinite loop if the account itself is suspended or the new key is immediately invalidated. A single retry covers the common case of a stale key and surfaces a clean error message for anything more serious.

**✅ What Was Implemented**

- `JolliApiClient.kt` now throws a typed `UnauthorizedError` on HTTP 401 and 403 responses instead of a generic runtime exception, carrying the server's error message. This lets callers distinguish a bad-key failure from other push errors.
- `SummaryPanel.kt` catches `UnauthorizedError` and prompts the user to re-authenticate. If the user agrees, `reauthenticateAndRetry()` clears the stored key, runs the login flow with a forced fresh-key request, and retries the push once on success. A `retried` flag prevents infinite loops if the new key is also rejected.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliApiClient.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt`

### 03 · API key parser updated to scan all segments for cross-format compatibility `bugfix`

**⚡ Why This Change**

The Kotlin plugin's API key parser only looked at the first segment of a key, while the authoritative command-line parser scanned every segment. JWT-shaped keys — where the metadata lives in a later segment — would silently fail to parse, producing the same "Push failed: Invalid or disabled API key" error even when the key itself was valid.

**💡 Decisions Behind the Code**

- **Scan all segments rather than fixing the index**: The canonical CLI parser was already the authoritative reference, and the fix needed to match it exactly. Hardcoding segment 1 as a fallback would have handled JWT-shaped keys today but would diverge again if a future key format placed metadata elsewhere; scanning all segments is the only approach that stays correct for any format the server might issue.
- **Catch exceptions per segment rather than pre-validating**: Base64url decoding and JSON parsing can fail for many reasons (padding, character set, non-object JSON), and pre-validating each segment before attempting decode would duplicate logic already handled by the decoder and Gson. Catching per segment keeps the loop tight and ensures a malformed segment never aborts parsing of a key that has a valid segment later in the sequence.

**✅ What Was Implemented**

- Rewrote `parseJolliApiKey` in `JolliApiClient.kt` to iterate over every dot-separated segment of the key's payload, attempting base64url-decode and JSON parsing on each one. The first segment that decodes to a valid object containing the required tenant and URL fields is accepted and returned. This mirrors the canonical logic in `cli/src/core/JolliApiUtils.ts` and restores lockstep behavior across all three parsers (IntelliJ, VS Code, CLI).
- Added an early-exit guard for keys with no dot separator (the legacy 32-hex-char format), replacing the previous single-dot index check. Per-segment exceptions are caught and silently skipped, so a malformed segment never aborts parsing of a key that has a valid segment later in the sequence.

**📋 Future Enhancements**

The re-login flow does not replace the stored API key when the user re-authenticates against the same tenant. A freshly-obtained key can therefore remain unused if the old key is still present, leaving the user with a rejected key even after signing in again. Re-login should always mint and persist a new key regardless of whether the tenant has changed.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliApiClient.kt`

### 04 · Add telemetry for tool window activation, view navigation, and surface enable/disable `feature`

**⚡ Why This Change**

The team wanted to understand whether users actually open the memory panel and which views they navigate to, and to distinguish deliberate opt-outs from credential-driven automatic sign-outs — none of which were previously measured.

**💡 Decisions Behind the Code**

- **Tracking decisions, not presentation**: Hover, scroll, and resize interactions were explicitly ruled out as noise. Only view switches and surface enable/disable — actions that reflect a deliberate user choice — were instrumented, keeping event volume low and signal high.
- **Trigger property on enable/disable**: Rather than a single generic event, the `trigger` field distinguishes whether the surface change came from onboarding, settings, or an automatic sign-out. This lets the team separate intentional opt-outs from credential-driven ones without needing to cross-reference other data.

**✅ What Was Implemented**

- In `JolliMemoryToolWindowFactory.kt`, a `toolwindow_opened` event fires with `view=current` when the tool window content is first created, and a `view_switched` event with the selected view name fires each time the user clicks a view tab.
- In `SettingsDialog.kt` and `OnboardingPanel.kt`, `surface_enabled` and `surface_disabled` events fire with a `trigger` property (`settings`, `onboarding`, or `auto_signout`) at every code path that installs or uninstalls the plugin surface, covering the settings background task and both onboarding install flows.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/OnboardingPanel.kt`

### 05 · Track user engagement with committed memory items, panel interactions, and commit actions `feature`

**⚡ Why This Change**

The team had recently built a rich committed-memory UI with expandable rows, conversation previews, file diffs, plans, notes, and references, but had no way to know whether users were actually exploring these details or ignoring them.

**💡 Decisions Behind the Code**

- **Bucketing numeric properties**: File counts and context counts are passed through the existing `bucket()` helper rather than sent as raw integers. This preserves privacy and prevents high-cardinality dimensions in the analytics backend — a deliberate trade-off already established by the existing telemetry infrastructure.
- **Shared helper for item-open tracking**: A single `trackItemOpened` function was introduced in `CommitsPanel` rather than inlining the same call at every click site. This reduces the chance of typos in the event name and makes it easy to add properties uniformly later.
- **Conversation render mode as a property**: The `render=live|stored` distinction on conversation opens was included specifically to measure how often the stored-markdown fallback path is hit, directly quantifying the reliability of the live-file path without requiring a separate error event.

**✅ What Was Implemented**

- In `CommitsPanel.kt`, a `memory_expanded` event fires when a row is toggled open or closed. A shared `trackItemOpened(itemType)` helper fires `memory_item_opened` for plans, notes, references, and shipped items at each click handler. Conversation opens fire the same event with additional `render=live|stored` and `source` properties to distinguish live-file renders from stored-markdown fallbacks. File diff opens fire `memory_item_opened` with `item_type=file` and the git status code.
- Recall-prompt copies fire `recall_prompt_copied`, and terminal session resumes fire `session_resumed` with `source=claude` in both `CommitsPanel.kt` and `PinnedPanel.kt`.
- In `PlansPanel.kt` and `PinnedPanel.kt`, `memory_pinned` and `memory_unpinned` events fire with the item `kind` at the pin/unpin action sites. In `CurrentMemoryPanel.kt`, a `memory_committed` event fires at the Commit button with bucketed file count, a boolean for whether conversations are present, and a bucketed context count.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CurrentMemoryPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PlansPanel.kt`

### 06 · Instrument API key rejection and re-authentication self-heal outcomes `feature`

**⚡ Why This Change**

A credential-drift bug had just been fixed where IntelliJ was silently using a stale, rejected API key. The team wanted ongoing visibility into how often keys get rejected in production and whether the new self-heal flow actually succeeds.

**💡 Decisions Behind the Code**

- **Retried flag on key_rejected**: Including whether the rejection happened on a first attempt or a retry attempt in the same event avoids needing to join two separate event streams to detect retry loops. It also immediately surfaces cases where the self-heal itself triggers another 401, which would indicate a deeper credential problem.
- **Separate reauth_completed event**: Rather than folding re-auth outcome into `key_rejected` or `error_occurred`, a dedicated event was used. This keeps the funnel readable — rejection rate and recovery rate are independent metrics — and matches the pattern already used for `signin_completed` in the existing event catalog.

**✅ What Was Implemented**

- In `SummaryPanel.kt`, a `key_rejected` event fires in the `UnauthorizedError` catch block with `retried` (whether this is already a retry attempt) and `where=push`. A generic `error_occurred` event with `code=push_failed` and `where=push` fires in the outer catch for non-auth push failures.
- `reauth_completed` events with `outcome=success` or `outcome=failed` fire inside the `onSuccess` and `onError` callbacks of the self-heal re-authentication flow, measuring end-to-end success rate of the recovery path.
- The existing `memory_pushed` event was extended with `created` (boolean, new vs. update) and `plans_bucket` (bucketed plan count) to add depth to push analytics.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt`

### 07 · Fix IDE freeze when applying plugin settings by moving heavy work off the UI thread `bugfix`

**⚡ Why This Change**

Clicking Apply in the plugin's Settings panel caused the IDE to freeze completely. Any time a user enabled, disabled, or changed settings, the interface became unresponsive for several seconds or longer while git operations and memory migration ran on the UI thread.

**💡 Decisions Behind the Code**

- **Single ordered background task over parallel threads**: The previous code ran install/uninstall on a pool thread while migration ran concurrently on the UI thread, creating a race where migration could operate on an incomplete install state. Consolidating everything into one sequential background task eliminates the race entirely and makes the execution order predictable. The safety and correctness gain was judged more important than any parallelism benefit from overlapping the steps.
- **Closing the dialog immediately before the background task starts**: The dialog is dismissed on the UI thread before the background work begins, so the user gets instant feedback that their action was accepted. Keeping the dialog open until work completes would have required disabling UI controls and managing dialog state across threads, adding complexity with little user benefit given the progress indicator already communicates ongoing work.
- **Non-cancellable background task**: Wrapping the work in a non-cancellable `ProgressManager` task avoids leaving the plugin in a half-installed state if the user dismissed the indicator mid-migration, which is the standard IntelliJ pattern for settings-apply operations.

**✅ What Was Implemented**

- Replaced the previous approach in `SettingsDialog.doOKAction()` — which ran git subprocesses and full Memory Bank migration synchronously on the UI thread — with an immediate dialog close followed by a `ProgressManager.Backgroundable` task. The background task runs in a single ordered sequence: hook install/uninstall first, then Memory Bank folder initialization, then orphan-branch migration, then a status refresh.
- Removed the `ApplicationManager.executeOnPooledThread` call that previously ran install/uninstall concurrently with the EDT-blocking migration block. The two operations now run sequentially in the same background task, eliminating the race condition where migration could start before install/uninstall completed.
- Added `ProgressIndicator` text updates ("Disabling Jolli Memory…", "Enabling Jolli Memory…", "Initializing Memory Bank…", "Migrating memories to Memory Bank…") so users see meaningful progress feedback during the background task.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt`

### 08 · Committed Memories rows made clickable to open stored conversation and context content `feature`

**⚡ Why This Change**

In the expanded Committed Memories view, clicking a Conversation or Context row either showed an error dialog when the original transcript file was deleted, or did nothing for plan and note rows. Users expected every row to open its own content the same way the Working Memory panel does.

**💡 Decisions Behind the Code**

- **Read-only change on the IntelliJ side only**: All four content types (conversation transcripts, plan bodies, note bodies, snippet content) are already written to committed-memory storage at commit time by the CLI's save path. The fix required only adding Kotlin readers — no changes to the dual-write or save code, so the CLI and VS Code surfaces are unaffected.
- **Stored transcript rendered as markdown rather than the rich viewer**: The rich conversation viewer reads a live file on disk; feeding it stored JSON entries would require a deeper change to that viewer. Rendering the stored entries as a plain markdown transcript is a self-contained fallback that gives the user readable content without modifying the viewer's file-based contract. The rich viewer still opens when the live file exists.

**✅ What Was Implemented**

- `SummaryReader` gained `readPlanBody(slug)` and `readNoteBody(id)` methods that read archived plan and note bodies from the orphan branch. A new `renderCommittedConversationMarkdown()` method reads the stored transcript JSON for a given session and renders it as a readable markdown document with User/Assistant turns separated by horizontal rules. These are exposed as service methods in `JolliMemoryService`.
- `CommitsPanel.openCommittedConversation()` now checks whether the live transcript file exists before trying to open it. When the file is gone, it reads the stored transcript from committed-memory storage off the EDT and opens it as a read-only in-memory markdown file, falling back to the commit memory summary only if the stored transcript is also unavailable.
- Context rows (`contextRow()`) were refactored to accept a click action. Plans open their archived body, snippet notes open their inline content snapshot, markdown notes read their archived body, and references open their URL. A shared `openArchivedMarkdown()` helper reads storage off the EDT and opens the result as a `LightVirtualFile` via `MarkdownPreview`.

**📋 Future Enhancements**

The rich conversation viewer could be extended to accept stored transcript entries directly, so committed conversations whose live file is gone render with the same per-message UI as active conversations rather than a plain markdown transcript.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt`

### 09 · Hover highlight bar and hand cursor added to all memory panel rows `ux`

**⚡ Why This Change**

The PINNED panel had a polished hover treatment — a grey highlight bar and hand cursor — that the Conversations, Context, Files, and Committed Memories panels were missing. Users experienced inconsistent hover behavior across the tool window.

**💡 Decisions Behind the Code**

- **Shared helper in CommitsPanel vs. duplicated code**: A private `attachRowHoverBar(row, children)` helper was introduced rather than repeating the bounds-checked enter/exit logic in each of the five row builders. The bounds check is subtle enough that duplicating it would have introduced divergent bugs; centralizing it also made the five builders shorter and easier to read.
- **Translucent overlay color**: The hover color is a 20/255-alpha black (light themes) or white (dark themes) overlay rather than a hard-coded hex. This keeps the bar visible on any theme background without fighting the look-and-feel's own selection colors, and matches the approach already used by the Active Conversations rows.
- **Singleton object for shared primitives over inheritance or extension functions**: A plain Kotlin `object` was chosen for `RowStyle.kt` rather than a base class or extension functions on Swing types. A base class would force an inheritance relationship between panels that are otherwise unrelated; extension functions would scatter the definitions. A singleton object is the lightest-weight option that still gives a single, findable home for these primitives.

**✅ What Was Implemented**

- `PinnedPanel` received the hover bar first: each row toggles an opaque translucent overlay (`HOVER_BG`) on mouse-enter and clears it on bounds-checked mouse-exit, with a hand cursor set on the row body. Action icons are revealed on the same hover event.
- `ConversationRowComponent`, `ChangesPanel`, and `PlansPanel` each received the same `HOVER_BG` overlay wired through their existing mouse listeners, with bounds-checking so moving between child components does not flicker the bar.
- `CommitsPanel` gained the hover bar on both the top-level commit rows and all four expanded sub-section row types (SHIPPED, Conversations, Context, Files) via a shared `attachRowHoverBar()` helper that attaches to the row and its children in one call.
- After all panels were updated, the hover color constant and a vertical-centering layout utility were extracted into a shared `RowStyle.kt` object, removing five local duplicate definitions and ensuring all panels stay visually consistent from a single source.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/RowStyle.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationRowComponent.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ChangesPanel.kt`

### 10 · Row text wrapping and auto-height across all memory panel sections `ux`

**⚡ Why This Change**

After the hover bar was added, rows still clipped long titles to a single line. Every row in the tool window needed to word-wrap its text and grow taller automatically as the panel narrowed, with icons staying vertically centered as the row expanded.

**💡 Decisions Behind the Code**

- **Action-icon width reserved up front**: The hover action icons are measured while visible before being hidden, and that width is reserved permanently in a fixed-size wrapper panel. This prevents the title's available wrap width from changing when icons appear on hover, which would cause the row to reflow and jump in height mid-hover. The trade-off is a small amount of wasted horizontal space on non-hovered rows.
- **Fixed two-line layout for Files instead of flowing wrap**: Files rows always show filename on line 1 and path on line 2, rather than wrapping them as a single flowing string. The two pieces of information have different visual weights (status color vs. grey), and the fixed layout makes the hover action icons reliably visible — a single flowing string made it hard to reserve the right icon width without clipping.
- **Panel-based rows over list for Context**: After multiple attempts to make the list-based Context panel recompute cell heights on resize (invalidating the height cache, lifting the maximum-size cap), the approach was abandoned and the panel was rewritten as individual rows matching the Conversations and Files pattern. Panel rows recompute their preferred height naturally on layout, eliminating the need for manual cache invalidation.

**✅ What Was Implemented**

- In `PinnedPanel` and `ConversationRowComponent`, the title label was replaced with a borderless, non-editable text area with line wrapping enabled. Each row overrides its preferred size to reflect the wrapped line count, and a resize listener triggers revalidation so the wrap recomputes as the tool window narrows.
- `ChangesPanel` switched to a fixed two-line layout (filename on line 1, grey parent path on line 2) with the file icon and status/action icons wrapped for vertical centering. `CommitsPanel`'s file sub-rows received the same two-line treatment.
- `CommitsPanel` introduced wrapping title and row helpers used by the SHIPPED, Conversations, and Context sub-section rows. The top-level commit title also became a wrapping text area, and the row's maximum size follows its preferred size so the layout manager does not cap it at the build-time height.
- The Context panel was rebuilt from scratch as individual panel rows to achieve reliable resize-triggered rewrapping; the previous list-based implementation cached row heights in a way that made incremental fixes impossible.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationRowComponent.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ChangesPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PlansPanel.kt`

### 11 · Hide unfinished surfaces behind a feature flag for marketplace release `ux`

**⚡ Why This Change**

The team wanted to publish version 0.99.3 to the JetBrains Marketplace, but two surfaces — a Knowledge tab and an Agent Access button — were placeholder stubs with "coming soon" messages that would confuse users and invite negative reviews.

**💡 Decisions Behind the Code**

- **Flag over deletion**: Keeping the code intact behind a compile-time constant was chosen over removing the UI code entirely. Deletion would have made re-enabling the features require reconstructing the implementation from git history, adding friction and risk. A flag costs nothing at runtime and makes the intent explicit to future contributors.
- **Single shared constant over per-file booleans**: Centralizing both gates in one object means a future developer enabling these features changes exactly one file and one line, with no risk of enabling one surface while forgetting the other. Scattering the flags across individual panel files would have made the "done, flip the switch" moment harder to find and easier to get wrong.

**✅ What Was Implemented**

- Created `FeatureFlags.kt`, a new singleton with a single `SHOW_UNFINISHED` boolean constant set to `false`. The file includes documentation listing exactly which surfaces it gates, so re-enabling either surface is a one-line change.
- Modified `ViewSwitchPanel.kt` to conditionally insert the Knowledge tab into the tab map only when the flag is `true`, and modified `JolliMemoryToolWindowFactory.kt` to conditionally include the Agent Access action in the title-bar action list. Both the enum value and the action object remain fully defined in code — nothing was deleted.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/FeatureFlags.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ViewSwitchPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt`

### 12 · Spacing and alignment polish across all Working Memory sub-sections

**⚡ Why This Change**

After the hover and wrapping work, the first and last rows in the Conversations, Context, and Files panels had noticeably larger gaps to the section edges than the PINNED panel, and the three sub-section header bars were different heights from each other.

**💡 Decisions Behind the Code**

- **PINNED as the reference rather than a new value**: Rather than picking an arbitrary inset value, the existing PINNED panel's spacing was used as the target. This gave a concrete, already-approved reference and ensured all four sections converge on the same numbers without further visual tuning.
- **Normalize to the tallest header**: Pinning all headers to the tallest (rather than the shortest or a fixed value) ensures no toolbar is clipped. The toolbar drives the height, so shrinking to the shortest would have cut off

**✅ What Was Implemented**

- Container and row borders in `ActiveConversationsPanel`, `ChangesPanel`, and `PlansPanel` were aligned to PINNED's reference values: container `empty(2, 4)` and row `empty(2, 4)`, giving a 4px edge gap, 4px inter-row spacing, and 8px side padding consistent across all four sections.
- `CurrentMemoryPanel.sectionHeader()` insets were tightened to reduce the gap between consecutive sections and between each section title and its first row.
- A `normalizeSectionHeaderHeights()` call after all three headers are built measures the tallest header and pins all three to that height, so sections with an action toolbar do not render taller than those without. Toolbar button size was also reduced to 18×18 to keep the normalized height compact.

### 13 · Register eleven new telemetry event names in shared cross-platform allowlist `feature`

**⚡ Why This Change**

The telemetry infrastructure enforces a strict allowlist of permitted event names shared between the IntelliJ plugin and the CLI. Any new event fired without a registry entry is silently dropped, so all eleven new names had to be registered before the tracking calls would take effect.

**💡 Decisions Behind the Code**

Both allowlists must stay in lockstep across languages to prevent the CLI and IntelliJ plugin from diverging on event names. Appending to both files in the same commit, under the same comment block, was the lowest-friction way to enforce this — the doc-sync test acts as the ongoing guard.

**✅ What Was Implemented**

- Eleven new event names were appended to `TelemetryEvents.kt` (Kotlin) and `TelemetryEvents.ts` (TypeScript) in lockstep, under a shared comment block marking them as IDE tool-window events.
- `TELEMETRY.md` was regenerated from the TypeScript source to include descriptions of all eleven new events, and the doc-sync test (`TelemetryDoc.test.ts`) was confirmed passing.

**📁 FILES**
- `cli/src/core/TelemetryEvents.ts`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt`
- `TELEMETRY.md`

### 14 · Breadcrumb repo and branch selectors replaced with flat label pickers `ux`

**⚡ Why This Change**

The repo and branch dropdowns in the tool window header rendered with a visible border and a lighter background fill that did not match the surrounding header, making them look like boxed input fields rather than inline breadcrumb labels.

**💡 Decisions Behind the Code**

**Label + popup instead of further combo flattening**: Every Swing/Darcula technique for removing the combo box's background (setting opacity, forcing a plain background color, flattening the arrow button child) was tried and failed — the look-and-feel repainted its own fill on each approach. Replacing the combo with a label that inherits the panel background was the only way to guarantee the header blends in across all themes and IDE versions, at the cost of losing the built-in keyboard navigation that a standard combo box provides.

**✅ What Was Implemented**

- `BreadcrumbHeaderPanel` replaced both combo box controls with a new inner class `CrumbPicker`: a label showing the current value with a trailing chevron icon, backed by a popup list that opens on click. The label inherits the header's background, so there is no boxed field or arrow-button fill to fight.
- All selection logic was preserved: repo pick re-lists branches, branch pick fires the foreign/read-only callback, and `updateCurrentBranch` detects whether the new branch is already in the picker's item list and either selects it silently or triggers a full branch refresh. Leading repo and branch icons were removed to match the mockup's text-only breadcrumb style.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BreadcrumbHeaderPanel.kt`

### 15 · Section header styling: banded background, top divider line, and reduced font size `ux`

**⚡ Why This Change**

The collapsible section headers and sub-section headers were visually crowded: they used the full base font size, making them larger than the row titles beneath them, and they lacked the banded appearance and top divider line shown in the mockup.

**💡 Decisions Behind the Code**

- **Compound border with line as outer layer**: An earlier attempt placed the empty padding outside the line, so the divider was drawn just above the text and increasing the padding pushed the line downward. Switching to an explicit compound border with the line as the outer border fixed the inversion: the gap now correctly sits between the line and the title text.
- **Theme-relative header background**: A hard-coded hex would fight the user's chosen theme. Using brightness adjustment on the panel background produces a band that is always perceptible but never jarring, and adapts automatically to light and dark themes without requiring separate color constants.

**✅ What Was Implemented**

- `CollapsiblePanel` header border was changed to a compound border with the grey divider line as the outer layer and an empty inset as the inner layer, so the gap between the line and the title text is controlled by the inner padding. The header background is now a theme-relative value that brightens the panel background in dark themes and darkens it in light themes.
- Section header title font was reduced from the full label size to base − 2 (bold), making headers smaller than the row titles beneath them. The same reduction was applied to the CONVERSATIONS / CONTEXT / FILES sub-section headers in `CurrentMemoryPanel`.
- `CurrentMemoryPanel` replaced the light-blue inter-section separator with one that uses the theme's separator color contrast-boosted by 3 levels at 2px height, giving a clearly visible grey divider between sub-sections.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CollapsiblePanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CurrentMemoryPanel.kt`

---

*Generated by Jolli Memory · June 28, 2026 at 6:00 PM · via Anthropic*

<!-- jollimemory-summary-start -->

## Jolli Memory

https://jolli.ai/very/articles?doc=4271

## Plans & Notes

- [pr-body](https://jolli.ai/very/articles?doc=4270)

## Quick recap

The IntelliJ plugin now shares login credentials with the CLI and VS Code extension automatically. Previously, signing in through another tool left the IntelliJ plugin holding a stale key that caused every push to fail silently. Now the plugin reads from and writes to the shared credentials file, so a login on any surface is immediately reflected in IntelliJ. When the server rejects a stored API key, the plugin also prompts the user to re-authenticate on the spot and retries the push once — eliminating the need to manually navigate to Settings, sign out, and sign back in.

The tool window received a significant visual overhaul. Every memory panel section — Conversations, Context, Files, and Committed Memories — now shows a hover highlight bar and a hand cursor consistent with the existing Pinned panel. Row titles word-wrap and the row grows taller automatically as the panel narrows, with icons staying vertically centered. Clicking any row in the Committed Memories view now opens its content: conversation transcripts, plans, notes, and code snippets are all readable inline. Spacing and header heights are also normalized across all four sections, removing the uneven gaps that appeared after the hover work landed.

Two placeholder surfaces — a Knowledge tab and an Agent Access button — are hidden in the marketplace release. Users browsing the plugin on JetBrains Marketplace will see a clean, finished interface. The IDE freeze that occurred when clicking Apply in the Settings panel is also resolved; the panel now closes immediately and heavy work completes in the background, keeping the editor fully responsive throughout.

---

## Topics (15)
<details>
<summary><strong>01 · Share login credentials across all editor surfaces automatically</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The IntelliJ plugin stored its own separate copy of the user's login credentials, independent of the credentials used by the CLI and VS Code extension. When the user logged in through any other tool, IntelliJ kept its old, now-invalidated credentials and failed silently on every push.

**💡 Decisions Behind the Code**

- **Merge at the JSON level, not through the data model**: Deserializing the shared file into IntelliJ's data class and writing it back would silently erase any fields that IntelliJ's model doesn't know about — exactly the problem that originally motivated keeping a separate file. Reading and writing only the two credential fields as raw JSON properties preserves everything else untouched, giving IntelliJ write access to the shared file without that risk.
- **Keep IntelliJ's own settings file**: Eliminating the IntelliJ-specific file entirely would have been simpler, but IntelliJ-only preferences (such as knowledge base path and panel layout) have no equivalent in the shared schema. Keeping the file for those settings and routing only the account-level credentials through the shared file avoids forcing unrelated concerns into a schema owned by other tools.

**✅ What Was Implemented**

- `SessionTracker.kt` was updated to treat the shared `config.json` as the authoritative source for credentials. Two new helpers (`readSharedCredentials`, `writeSharedCredentials`) overlay the shared file's key and auth token on top of IntelliJ's own settings file at the raw JSON level, so fields written by other tools are never silently dropped.
- Both save paths in `SessionTracker.kt` (`saveConfig` and `saveConfigToDir`) now call `writeSharedCredentials` after writing IntelliJ's own settings file, so any login or refresh performed inside IntelliJ is immediately visible to the CLI and VS Code extension.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/SessionTracker.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Auto-recover from a rejected API key without manual sign-out</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When the server rejected IntelliJ's stored API key — whether it had been deleted by a re-login on another device or replaced by a colleague — the push would fail with an error and offer no recovery path. The user had to manually sign out, sign back in, and retry the push themselves.

**💡 Decisions Behind the Code**

- **Prompt the user rather than re-authenticating silently**: A silent automatic re-login would require storing the user's password or triggering an OAuth redirect with no visible feedback, which is disruptive and potentially confusing. Showing a confirmation dialog keeps the user in control and makes the recovery action visible, while still eliminating the need to manually navigate to settings and sign out.
- **Retry exactly once after re-authentication**: Allowing unlimited retries on auth failure risks an infinite loop if the account itself is suspended or the new key is immediately invalidated. A single retry covers the common case of a stale key and surfaces a clean error message for anything more serious.

**✅ What Was Implemented**

- `JolliApiClient.kt` now throws a typed `UnauthorizedError` on HTTP 401 and 403 responses instead of a generic runtime exception, carrying the server's error message. This lets callers distinguish a bad-key failure from other push errors.
- `SummaryPanel.kt` catches `UnauthorizedError` and prompts the user to re-authenticate. If the user agrees, `reauthenticateAndRetry()` clears the stored key, runs the login flow with a forced fresh-key request, and retries the push once on success. A `retried` flag prevents infinite loops if the new key is also rejected.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliApiClient.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt`

</blockquote>
</details>
<details>
<summary><strong>03 · API key parser updated to scan all segments for cross-format compatibility</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Kotlin plugin's API key parser only looked at the first segment of a key, while the authoritative command-line parser scanned every segment. JWT-shaped keys — where the metadata lives in a later segment — would silently fail to parse, producing the same "Push failed: Invalid or disabled API key" error even when the key itself was valid.

**💡 Decisions Behind the Code**

- **Scan all segments rather than fixing the index**: The canonical CLI parser was already the authoritative reference, and the fix needed to match it exactly. Hardcoding segment 1 as a fallback would have handled JWT-shaped keys today but would diverge again if a future key format placed metadata elsewhere; scanning all segments is the only approach that stays correct for any format the server might issue.
- **Catch exceptions per segment rather than pre-validating**: Base64url decoding and JSON parsing can fail for many reasons (padding, character set, non-object JSON), and pre-validating each segment before attempting decode would duplicate logic already handled by the decoder and Gson. Catching per segment keeps the loop tight and ensures a malformed segment never aborts parsing of a key that has a valid segment later in the sequence.

**✅ What Was Implemented**

- Rewrote `parseJolliApiKey` in `JolliApiClient.kt` to iterate over every dot-separated segment of the key's payload, attempting base64url-decode and JSON parsing on each one. The first segment that decodes to a valid object containing the required tenant and URL fields is accepted and returned. This mirrors the canonical logic in `cli/src/core/JolliApiUtils.ts` and restores lockstep behavior across all three parsers (IntelliJ, VS Code, CLI).
- Added an early-exit guard for keys with no dot separator (the legacy 32-hex-char format), replacing the previous single-dot index check. Per-segment exceptions are caught and silently skipped, so a malformed segment never aborts parsing of a key that has a valid segment later in the sequence.

**📋 Future Enhancements**

The re-login flow does not replace the stored API key when the user re-authenticates against the same tenant. A freshly-obtained key can therefore remain unused if the old key is still present, leaving the user with a rejected key even after signing in again. Re-login should always mint and persist a new key regardless of whether the tenant has changed.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliApiClient.kt`

</blockquote>
</details>
<details>
<summary><strong>04 · Add telemetry for tool window activation, view navigation, and surface enable/disable</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team wanted to understand whether users actually open the memory panel and which views they navigate to, and to distinguish deliberate opt-outs from credential-driven automatic sign-outs — none of which were previously measured.

**💡 Decisions Behind the Code**

- **Tracking decisions, not presentation**: Hover, scroll, and resize interactions were explicitly ruled out as noise. Only view switches and surface enable/disable — actions that reflect a deliberate user choice — were instrumented, keeping event volume low and signal high.
- **Trigger property on enable/disable**: Rather than a single generic event, the `trigger` field distinguishes whether the surface change came from onboarding, settings, or an automatic sign-out. This lets the team separate intentional opt-outs from credential-driven ones without needing to cross-reference other data.

**✅ What Was Implemented**

- In `JolliMemoryToolWindowFactory.kt`, a `toolwindow_opened` event fires with `view=current` when the tool window content is first created, and a `view_switched` event with the selected view name fires each time the user clicks a view tab.
- In `SettingsDialog.kt` and `OnboardingPanel.kt`, `surface_enabled` and `surface_disabled` events fire with a `trigger` property (`settings`, `onboarding`, or `auto_signout`) at every code path that installs or uninstalls the plugin surface, covering the settings background task and both onboarding install flows.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/OnboardingPanel.kt`

</blockquote>
</details>
<details>
<summary><strong>05 · Track user engagement with committed memory items, panel interactions, and commit actions</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team had recently built a rich committed-memory UI with expandable rows, conversation previews, file diffs, plans, notes, and references, but had no way to know whether users were actually exploring these details or ignoring them.

**💡 Decisions Behind the Code**

- **Bucketing numeric properties**: File counts and context counts are passed through the existing `bucket()` helper rather than sent as raw integers. This preserves privacy and prevents high-cardinality dimensions in the analytics backend — a deliberate trade-off already established by the existing telemetry infrastructure.
- **Shared helper for item-open tracking**: A single `trackItemOpened` function was introduced in `CommitsPanel` rather than inlining the same call at every click site. This reduces the chance of typos in the event name and makes it easy to add properties uniformly later.
- **Conversation render mode as a property**: The `render=live|stored` distinction on conversation opens was included specifically to measure how often the stored-markdown fallback path is hit, directly quantifying the reliability of the live-file path without requiring a separate error event.

**✅ What Was Implemented**

- In `CommitsPanel.kt`, a `memory_expanded` event fires when a row is toggled open or closed. A shared `trackItemOpened(itemType)` helper fires `memory_item_opened` for plans, notes, references, and shipped items at each click handler. Conversation opens fire the same event with additional `render=live|stored` and `source` properties to distinguish live-file renders from stored-markdown fallbacks. File diff opens fire `memory_item_opened` with `item_type=file` and the git status code.
- Recall-prompt copies fire `recall_prompt_copied`, and terminal session resumes fire `session_resumed` with `source=claude` in both `CommitsPanel.kt` and `PinnedPanel.kt`.
- In `PlansPanel.kt` and `PinnedPanel.kt`, `memory_pinned` and `memory_unpinned` events fire with the item `kind` at the pin/unpin action sites. In `CurrentMemoryPanel.kt`, a `memory_committed` event fires at the Commit button with bucketed file count, a boolean for whether conversations are present, and a bucketed context count.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CurrentMemoryPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PlansPanel.kt`

</blockquote>
</details>
<details>
<summary><strong>06 · Instrument API key rejection and re-authentication self-heal outcomes</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A credential-drift bug had just been fixed where IntelliJ was silently using a stale, rejected API key. The team wanted ongoing visibility into how often keys get rejected in production and whether the new self-heal flow actually succeeds.

**💡 Decisions Behind the Code**

- **Retried flag on key_rejected**: Including whether the rejection happened on a first attempt or a retry attempt in the same event avoids needing to join two separate event streams to detect retry loops. It also immediately surfaces cases where the self-heal itself triggers another 401, which would indicate a deeper credential problem.
- **Separate reauth_completed event**: Rather than folding re-auth outcome into `key_rejected` or `error_occurred`, a dedicated event was used. This keeps the funnel readable — rejection rate and recovery rate are independent metrics — and matches the pattern already used for `signin_completed` in the existing event catalog.

**✅ What Was Implemented**

- In `SummaryPanel.kt`, a `key_rejected` event fires in the `UnauthorizedError` catch block with `retried` (whether this is already a retry attempt) and `where=push`. A generic `error_occurred` event with `code=push_failed` and `where=push` fires in the outer catch for non-auth push failures.
- `reauth_completed` events with `outcome=success` or `outcome=failed` fire inside the `onSuccess` and `onError` callbacks of the self-heal re-authentication flow, measuring end-to-end success rate of the recovery path.
- The existing `memory_pushed` event was extended with `created` (boolean, new vs. update) and `plans_bucket` (bucketed plan count) to add depth to push analytics.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt`

</blockquote>
</details>
<details>
<summary><strong>07 · Fix IDE freeze when applying plugin settings by moving heavy work off the UI thread</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Clicking Apply in the plugin's Settings panel caused the IDE to freeze completely. Any time a user enabled, disabled, or changed settings, the interface became unresponsive for several seconds or longer while git operations and memory migration ran on the UI thread.

**💡 Decisions Behind the Code**

- **Single ordered background task over parallel threads**: The previous code ran install/uninstall on a pool thread while migration ran concurrently on the UI thread, creating a race where migration could operate on an incomplete install state. Consolidating everything into one sequential background task eliminates the race entirely and makes the execution order predictable. The safety and correctness gain was judged more important than any parallelism benefit from overlapping the steps.
- **Closing the dialog immediately before the background task starts**: The dialog is dismissed on the UI thread before the background work begins, so the user gets instant feedback that their action was accepted. Keeping the dialog open until work completes would have required disabling UI controls and managing dialog state across threads, adding complexity with little user benefit given the progress indicator already communicates ongoing work.
- **Non-cancellable background task**: Wrapping the work in a non-cancellable `ProgressManager` task avoids leaving the plugin in a half-installed state if the user dismissed the indicator mid-migration, which is the standard IntelliJ pattern for settings-apply operations.

**✅ What Was Implemented**

- Replaced the previous approach in `SettingsDialog.doOKAction()` — which ran git subprocesses and full Memory Bank migration synchronously on the UI thread — with an immediate dialog close followed by a `ProgressManager.Backgroundable` task. The background task runs in a single ordered sequence: hook install/uninstall first, then Memory Bank folder initialization, then orphan-branch migration, then a status refresh.
- Removed the `ApplicationManager.executeOnPooledThread` call that previously ran install/uninstall concurrently with the EDT-blocking migration block. The two operations now run sequentially in the same background task, eliminating the race condition where migration could start before install/uninstall completed.
- Added `ProgressIndicator` text updates ("Disabling Jolli Memory…", "Enabling Jolli Memory…", "Initializing Memory Bank…", "Migrating memories to Memory Bank…") so users see meaningful progress feedback during the background task.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt`

</blockquote>
</details>
<details>
<summary><strong>08 · Committed Memories rows made clickable to open stored conversation and context content</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

In the expanded Committed Memories view, clicking a Conversation or Context row either showed an error dialog when the original transcript file was deleted, or did nothing for plan and note rows. Users expected every row to open its own content the same way the Working Memory panel does.

**💡 Decisions Behind the Code**

- **Read-only change on the IntelliJ side only**: All four content types (conversation transcripts, plan bodies, note bodies, snippet content) are already written to committed-memory storage at commit time by the CLI's save path. The fix required only adding Kotlin readers — no changes to the dual-write or save code, so the CLI and VS Code surfaces are unaffected.
- **Stored transcript rendered as markdown rather than the rich viewer**: The rich conversation viewer reads a live file on disk; feeding it stored JSON entries would require a deeper change to that viewer. Rendering the stored entries as a plain markdown transcript is a self-contained fallback that gives the user readable content without modifying the viewer's file-based contract. The rich viewer still opens when the live file exists.

**✅ What Was Implemented**

- `SummaryReader` gained `readPlanBody(slug)` and `readNoteBody(id)` methods that read archived plan and note bodies from the orphan branch. A new `renderCommittedConversationMarkdown()` method reads the stored transcript JSON for a given session and renders it as a readable markdown document with User/Assistant turns separated by horizontal rules. These are exposed as service methods in `JolliMemoryService`.
- `CommitsPanel.openCommittedConversation()` now checks whether the live transcript file exists before trying to open it. When the file is gone, it reads the stored transcript from committed-memory storage off the EDT and opens it as a read-only in-memory markdown file, falling back to the commit memory summary only if the stored transcript is also unavailable.
- Context rows (`contextRow()`) were refactored to accept a click action. Plans open their archived body, snippet notes open their inline content snapshot, markdown notes read their archived body, and references open their URL. A shared `openArchivedMarkdown()` helper reads storage off the EDT and opens the result as a `LightVirtualFile` via `MarkdownPreview`.

**📋 Future Enhancements**

The rich conversation viewer could be extended to accept stored transcript entries directly, so committed conversations whose live file is gone render with the same per-message UI as active conversations rather than a plain markdown transcript.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt`

</blockquote>
</details>
<details>
<summary><strong>09 · Hover highlight bar and hand cursor added to all memory panel rows</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The PINNED panel had a polished hover treatment — a grey highlight bar and hand cursor — that the Conversations, Context, Files, and Committed Memories panels were missing. Users experienced inconsistent hover behavior across the tool window.

**💡 Decisions Behind the Code**

- **Shared helper in CommitsPanel vs. duplicated code**: A private `attachRowHoverBar(row, children)` helper was introduced rather than repeating the bounds-checked enter/exit logic in each of the five row builders. The bounds check is subtle enough that duplicating it would have introduced divergent bugs; centralizing it also made the five builders shorter and easier to read.
- **Translucent overlay color**: The hover color is a 20/255-alpha black (light themes) or white (dark themes) overlay rather than a hard-coded hex. This keeps the bar visible on any theme background without fighting the look-and-feel's own selection colors, and matches the approach already used by the Active Conversations rows.
- **Singleton object for shared primitives over inheritance or extension functions**: A plain Kotlin `object` was chosen for `RowStyle.kt` rather than a base class or extension functions on Swing types. A base class would force an inheritance relationship between panels that are otherwise unrelated; extension functions would scatter the definitions. A singleton object is the lightest-weight option that still gives a single, findable home for these primitives.

**✅ What Was Implemented**

- `PinnedPanel` received the hover bar first: each row toggles an opaque translucent overlay (`HOVER_BG`) on mouse-enter and clears it on bounds-checked mouse-exit, with a hand cursor set on the row body. Action icons are revealed on the same hover event.
- `ConversationRowComponent`, `ChangesPanel`, and `PlansPanel` each received the same `HOVER_BG` overlay wired through their existing mouse listeners, with bounds-checking so moving between child components does not flicker the bar.
- `CommitsPanel` gained the hover bar on both the top-level commit rows and all four expanded sub-section row types (SHIPPED, Conversations, Context, Files) via a shared `attachRowHoverBar()` helper that attaches to the row and its children in one call.
- After all panels were updated, the hover color constant and a vertical-centering layout utility were extracted into a shared `RowStyle.kt` object, removing five local duplicate definitions and ensuring all panels stay visually consistent from a single source.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/RowStyle.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationRowComponent.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ChangesPanel.kt`

</blockquote>
</details>
<details>
<summary><strong>10 · Row text wrapping and auto-height across all memory panel sections</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the hover bar was added, rows still clipped long titles to a single line. Every row in the tool window needed to word-wrap its text and grow taller automatically as the panel narrowed, with icons staying vertically centered as the row expanded.

**💡 Decisions Behind the Code**

- **Action-icon width reserved up front**: The hover action icons are measured while visible before being hidden, and that width is reserved permanently in a fixed-size wrapper panel. This prevents the title's available wrap width from changing when icons appear on hover, which would cause the row to reflow and jump in height mid-hover. The trade-off is a small amount of wasted horizontal space on non-hovered rows.
- **Fixed two-line layout for Files instead of flowing wrap**: Files rows always show filename on line 1 and path on line 2, rather than wrapping them as a single flowing string. The two pieces of information have different visual weights (status color vs. grey), and the fixed layout makes the hover action icons reliably visible — a single flowing string made it hard to reserve the right icon width without clipping.
- **Panel-based rows over list for Context**: After multiple attempts to make the list-based Context panel recompute cell heights on resize (invalidating the height cache, lifting the maximum-size cap), the approach was abandoned and the panel was rewritten as individual rows matching the Conversations and Files pattern. Panel rows recompute their preferred height naturally on layout, eliminating the need for manual cache invalidation.

**✅ What Was Implemented**

- In `PinnedPanel` and `ConversationRowComponent`, the title label was replaced with a borderless, non-editable text area with line wrapping enabled. Each row overrides its preferred size to reflect the wrapped line count, and a resize listener triggers revalidation so the wrap recomputes as the tool window narrows.
- `ChangesPanel` switched to a fixed two-line layout (filename on line 1, grey parent path on line 2) with the file icon and status/action icons wrapped for vertical centering. `CommitsPanel`'s file sub-rows received the same two-line treatment.
- `CommitsPanel` introduced wrapping title and row helpers used by the SHIPPED, Conversations, and Context sub-section rows. The top-level commit title also became a wrapping text area, and the row's maximum size follows its preferred size so the layout manager does not cap it at the build-time height.
- The Context panel was rebuilt from scratch as individual panel rows to achieve reliable resize-triggered rewrapping; the previous list-based implementation cached row heights in a way that made incremental fixes impossible.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ConversationRowComponent.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ChangesPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PlansPanel.kt`

</blockquote>
</details>
<details>
<summary><strong>11 · Hide unfinished surfaces behind a feature flag for marketplace release</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team wanted to publish version 0.99.3 to the JetBrains Marketplace, but two surfaces — a Knowledge tab and an Agent Access button — were placeholder stubs with "coming soon" messages that would confuse users and invite negative reviews.

**💡 Decisions Behind the Code**

- **Flag over deletion**: Keeping the code intact behind a compile-time constant was chosen over removing the UI code entirely. Deletion would have made re-enabling the features require reconstructing the implementation from git history, adding friction and risk. A flag costs nothing at runtime and makes the intent explicit to future contributors.
- **Single shared constant over per-file booleans**: Centralizing both gates in one object means a future developer enabling these features changes exactly one file and one line, with no risk of enabling one surface while forgetting the other. Scattering the flags across individual panel files would have made the "done, flip the switch" moment harder to find and easier to get wrong.

**✅ What Was Implemented**

- Created `FeatureFlags.kt`, a new singleton with a single `SHOW_UNFINISHED` boolean constant set to `false`. The file includes documentation listing exactly which surfaces it gates, so re-enabling either surface is a one-line change.
- Modified `ViewSwitchPanel.kt` to conditionally insert the Knowledge tab into the tab map only when the flag is `true`, and modified `JolliMemoryToolWindowFactory.kt` to conditionally include the Agent Access action in the title-bar action list. Both the enum value and the action object remain fully defined in code — nothing was deleted.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/FeatureFlags.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ViewSwitchPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt`

</blockquote>
</details>
<details>
<summary><strong>12 · Spacing and alignment polish across all Working Memory sub-sections</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the hover and wrapping work, the first and last rows in the Conversations, Context, and Files panels had noticeably larger gaps to the section edges than the PINNED panel, and the three sub-section header bars were different heights from each other.

**💡 Decisions Behind the Code**

- **PINNED as the reference rather than a new value**: Rather than picking an arbitrary inset value, the existing PINNED panel's spacing was used as the target. This gave a concrete, already-approved reference and ensured all four sections converge on the same numbers without further visual tuning.
- **Normalize to the tallest header**: Pinning all headers to the tallest (rather than the shortest or a fixed value) ensures no toolbar is clipped. The toolbar drives the height, so shrinking to the shortest would have cut off

**✅ What Was Implemented**

- Container and row borders in `ActiveConversationsPanel`, `ChangesPanel`, and `PlansPanel` were aligned to PINNED's reference values: container `empty(2, 4)` and row `empty(2, 4)`, giving a 4px edge gap, 4px inter-row spacing, and 8px side padding consistent across all four sections.
- `CurrentMemoryPanel.sectionHeader()` insets were tightened to reduce the gap between consecutive sections and between each section title and its first row.
- A `normalizeSectionHeaderHeights()` call after all three headers are built measures the tallest header and pins all three to that height, so sections with an action toolbar do not render taller than those without. Toolbar button size was also reduced to 18×18 to keep the normalized height compact.

</blockquote>
</details>
<details>
<summary><strong>13 · Register eleven new telemetry event names in shared cross-platform allowlist</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The telemetry infrastructure enforces a strict allowlist of permitted event names shared between the IntelliJ plugin and the CLI. Any new event fired without a registry entry is silently dropped, so all eleven new names had to be registered before the tracking calls would take effect.

**💡 Decisions Behind the Code**

Both allowlists must stay in lockstep across languages to prevent the CLI and IntelliJ plugin from diverging on event names. Appending to both files in the same commit, under the same comment block, was the lowest-friction way to enforce this — the doc-sync test acts as the ongoing guard.

**✅ What Was Implemented**

- Eleven new event names were appended to `TelemetryEvents.kt` (Kotlin) and `TelemetryEvents.ts` (TypeScript) in lockstep, under a shared comment block marking them as IDE tool-window events.
- `TELEMETRY.md` was regenerated from the TypeScript source to include descriptions of all eleven new events, and the doc-sync test (`TelemetryDoc.test.ts`) was confirmed passing.

**📁 FILES**
- `cli/src/core/TelemetryEvents.ts`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt`
- `TELEMETRY.md`

</blockquote>
</details>
<details>
<summary><strong>14 · Breadcrumb repo and branch selectors replaced with flat label pickers</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The repo and branch dropdowns in the tool window header rendered with a visible border and a lighter background fill that did not match the surrounding header, making them look like boxed input fields rather than inline breadcrumb labels.

**💡 Decisions Behind the Code**

**Label + popup instead of further combo flattening**: Every Swing/Darcula technique for removing the combo box's background (setting opacity, forcing a plain background color, flattening the arrow button child) was tried and failed — the look-and-feel repainted its own fill on each approach. Replacing the combo with a label that inherits the panel background was the only way to guarantee the header blends in across all themes and IDE versions, at the cost of losing the built-in keyboard navigation that a standard combo box provides.

**✅ What Was Implemented**

- `BreadcrumbHeaderPanel` replaced both combo box controls with a new inner class `CrumbPicker`: a label showing the current value with a trailing chevron icon, backed by a popup list that opens on click. The label inherits the header's background, so there is no boxed field or arrow-button fill to fight.
- All selection logic was preserved: repo pick re-lists branches, branch pick fires the foreign/read-only callback, and `updateCurrentBranch` detects whether the new branch is already in the picker's item list and either selects it silently or triggers a full branch refresh. Leading repo and branch icons were removed to match the mockup's text-only breadcrumb style.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BreadcrumbHeaderPanel.kt`

</blockquote>
</details>
<details>
<summary><strong>15 · Section header styling: banded background, top divider line, and reduced font size</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The collapsible section headers and sub-section headers were visually crowded: they used the full base font size, making them larger than the row titles beneath them, and they lacked the banded appearance and top divider line shown in the mockup.

**💡 Decisions Behind the Code**

- **Compound border with line as outer layer**: An earlier attempt placed the empty padding outside the line, so the divider was drawn just above the text and increasing the padding pushed the line downward. Switching to an explicit compound border with the line as the outer border fixed the inversion: the gap now correctly sits between the line and the title text.
- **Theme-relative header background**: A hard-coded hex would fight the user's chosen theme. Using brightness adjustment on the panel background produces a band that is always perceptible but never jarring, and adapts automatically to light and dark themes without requiring separate color constants.

**✅ What Was Implemented**

- `CollapsiblePanel` header border was changed to a compound border with the grey divider line as the outer layer and an empty inset as the inner layer, so the gap between the line and the title text is controlled by the inner padding. The header background is now a theme-relative value that brightens the panel background in dark themes and darkens it in light themes.
- Section header title font was reduced from the full label size to base − 2 (bold), making headers smaller than the row titles beneath them. The same reduction was applied to the CONVERSATIONS / CONTEXT / FILES sub-section headers in `CurrentMemoryPanel`.
- `CurrentMemoryPanel` replaced the light-blue inter-section separator with one that uses the theme's separator color contrast-boosted by 3 levels at 2px height, giving a clearly visible grey divider between sub-sections.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CollapsiblePanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CurrentMemoryPanel.kt`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 28, 2026 at 6:18 PM · via Anthropic*
<!-- jollimemory-summary-end -->