### PR TITLE
Attribute queued summaries to op.branch, not the live branch

### DIFF
--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -2212,6 +2212,94 @@ describe("QueueWorker", () => {
 		});
 	});
 
+	// The branch written onto summary.branch must come from the op captured at enqueue
+	// time (inside the git hook), NOT a live getCurrentBranch read during drain. Reading
+	// live mis-attributes the summary when the user has `git checkout`'d away between
+	// enqueue and drain (e.g. `git commit && git checkout main`). Live read survives only
+	// as a fallback for pre-0.99.x queue entries lacking op.branch.
+	describe("branch attribution (op.branch over live getCurrentBranch)", () => {
+		it("executePipeline writes op.branch, not the live branch", async () => {
+			const op = makeCommitOp({ commitHash: "abc12345def67890", branch: "feature/x" });
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/entry.json" }])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+			setupPipelineMocks("abc12345def67890");
+			// Simulate the user having switched to main after committing on feature/x.
+			vi.mocked(getCurrentBranch).mockResolvedValue("main");
+
+			await runWorker("/test/cwd");
+
+			expect(storeSummary).toHaveBeenCalledTimes(1);
+			expect(vi.mocked(storeSummary).mock.calls[0][0].branch).toBe("feature/x");
+		});
+
+		it("executePipeline falls back to live branch when op.branch is missing (pre-0.99.x entry)", async () => {
+			const op = makeCommitOp({ commitHash: "abc12345def67890" }); // no branch field
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/entry.json" }])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+			setupPipelineMocks("abc12345def67890");
+			vi.mocked(getCurrentBranch).mockResolvedValue("main");
+
+			await runWorker("/test/cwd");
+
+			expect(storeSummary).toHaveBeenCalledTimes(1);
+			expect(vi.mocked(storeSummary).mock.calls[0][0].branch).toBe("main");
+		});
+
+		it("amend fresh-leaf writes op.branch via branchHint, not the live branch", async () => {
+			const op = makeCommitOp({
+				type: "amend",
+				commitHash: "abc12345def67890",
+				branch: "feature/x",
+				sourceHashes: ["0123456789abcdef0123456789abcdef01234567"],
+			});
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/entry.json" }])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+			setupPipelineMocks("abc12345def67890");
+			vi.mocked(getCurrentBranch).mockResolvedValue("main");
+			// No old summary → fresh-leaf path (getSummary defaults to undefined).
+			// Non-trivial delta (>50 lines) so the trivial-amend short-circuit is skipped.
+			vi.mocked(getDiffStats).mockResolvedValue({ filesChanged: 1, insertions: 60, deletions: 1 });
+			// One uncommitted reference (registry-miss, tolerated) so the fresh-leaf
+			// reference-association path runs on op.branch too — references suffer the
+			// same mis-attribution as summary.branch.
+			vi.mocked(detectUncommittedReferenceIds).mockResolvedValue([
+				{ mapKey: "linear:GHOST-1", source: "linear", sourcePath: "/tmp/ghost.md" },
+			]);
+			vi.mocked(loadPlansRegistry).mockResolvedValue({ version: 1, plans: {}, references: {} });
+
+			await runWorker("/test/cwd");
+
+			expect(storeSummary).toHaveBeenCalledTimes(1);
+			expect(vi.mocked(storeSummary).mock.calls[0][0].branch).toBe("feature/x");
+		});
+
+		it("amend fresh-leaf falls back to live branch when op.branch is missing", async () => {
+			const op = makeCommitOp({
+				type: "amend",
+				commitHash: "abc12345def67890",
+				sourceHashes: ["0123456789abcdef0123456789abcdef01234567"],
+			}); // no branch field
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/entry.json" }])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+			setupPipelineMocks("abc12345def67890");
+			vi.mocked(getCurrentBranch).mockResolvedValue("main");
+			vi.mocked(getDiffStats).mockResolvedValue({ filesChanged: 1, insertions: 60, deletions: 1 });
+
+			await runWorker("/test/cwd");
+
+			expect(storeSummary).toHaveBeenCalledTimes(1);
+			expect(vi.mocked(storeSummary).mock.calls[0][0].branch).toBe("main");
+		});
+	});
+
 	describe("buildWorkerStartupBanner", () => {
 		it("reports source=cli verbatim for the CLI surface (no path derivation)", () => {
 			expect(

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -1502,6 +1502,7 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 				{ fromRef: oldHash, toRef: op.commitHash },
 				{ commitType: "amend", commitSource },
 				op.createdAt,
+				op.branch,
 			);
 		} catch (err: unknown) {
 			log.error("Amend pipeline failed: %s", (err as Error).message);
@@ -2284,6 +2285,7 @@ async function handleAmendPipeline(
 	diffOverride?: { readonly fromRef: string; readonly toRef: string },
 	metadata?: { readonly commitType?: CommitType; readonly commitSource?: CommitSource },
 	beforeTimestamp?: string,
+	branchHint?: string,
 ): Promise<void> {
 	// Load old summary (may not exist if the original commit had no LLM summary).
 	const oldSummary = await getSummary(oldHash, cwd);
@@ -2427,7 +2429,8 @@ async function handleAmendPipeline(
 
 	// Same registry-driven prompt assembly as executePipeline (see Stage 2 wiring).
 	/* v8 ignore start -- amend-pipeline prompt-block assembly mirrors executePipeline's Stage 2 path. The amend path is exercised via PostCommitHook.helpers tests but not the prompt-block content specifically; the helpers and shapes are covered by their own dedicated tests. */
-	const branchForBlocks = await getCurrentBranch(cwd);
+	// Prefer the captured branch over a live read for the same reason as executePipeline; see line 1529.
+	const branchForBlocks = branchHint ?? (await getCurrentBranch(cwd));
 	const [rawAmendPlanEntries, rawAmendNoteEntries, rawAmendReferenceEntries] = await Promise.all([
 		detectActivePlansForBranch(cwd, branchForBlocks),
 		detectActiveNotesForBranch(cwd, branchForBlocks),
@@ -2638,7 +2641,8 @@ async function handleAmendPipeline(
 	}
 
 	// ── No old summary AND non-trivial delta -> store delta as a fresh leaf ────
-	const branch = await getCurrentBranch(cwd);
+	// Prefer the captured branch over a live read for the same reason as executePipeline; see line 1529.
+	const branch = branchHint ?? (await getCurrentBranch(cwd));
 
 	// Associate plans/notes/references on the branch with this amend commit,
 	// mirroring executePipeline. Without this the fresh leaf silently drops


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Commit memory summaries generated by JolliMemory are now reliably filed under the branch where the commit actually happened. A common workflow — committing on a feature branch and immediately switching back to the main branch — was enough to permanently mislabel the archived memory, making the summary invisible in the feature branch's history view and unreachable by branch-scoped search. The fix captures the branch name at the moment of the commit and uses that recorded value when the background worker later processes the queue entry, with the live branch query kept only as a safety net for entries written by older versions of the tool.

The amend workflow received the same correction. Both the prompt assembly step and the final summary storage step now use the branch captured at commit time, closing the same race condition for amended commits. Four new automated tests lock in this behavior across both the corrected path and the legacy fallback path, verifying that entries missing the captured branch field continue to work correctly.

---

## Topic (1)
<details>
<summary><strong>01 · Fix commit memory summaries filed under wrong branch after branch switch</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user committed on one branch and immediately switched to another, JolliMemory would permanently archive that commit's memory summary under the wrong branch. The summary would be invisible in the original branch's history view and unreachable by branch-scoped recall.

**💡 Decisions Behind the Code**

- **Captured value with fallback over unconditional replacement**: The fix uses `??` rather than replacing the live read outright, preserving backward compatibility with queue entries written by older versions of the hook that did not record the branch. This avoids a hard migration requirement while immediately correcting behavior for all new entries, and aligns with an existing convention already used in the worker's stale-child cleanup code.
- **Optional parameter over refactoring the call chain**: Adding `branchHint` as a trailing optional parameter to `handleAmendPipeline` kept all nineteen existing call sites unmodified and required no type changes elsewhere. A deeper refactor passing a richer context object would have been safer long-term but would have touched far more code for a targeted bug fix, increasing review surface and regression risk.
- **Full entry-point tests over inner-function unit tests**: The new tests drive the fix through the full enqueue-to-drain path rather than calling internal pipeline functions directly. This catches wiring mistakes — such as forgetting to thread the captured branch value through to the call site — that tests on the inner functions alone would miss.

**✅ What Was Implemented**

- In `QueueWorker.ts`, `executePipeline` was changed to read the branch from the queued operation record rather than querying the live git state at drain time. A `??` fallback preserves the live query for older queue entries that predate the captured-branch field, maintaining backward compatibility without a hard migration.
- `handleAmendPipeline` in `QueueWorker.ts` received a new optional `branchHint` parameter. Two internal reads of the live branch — one controlling which plans/notes blocks are assembled for the prompt, and one setting the branch on a fresh-leaf summary — were each replaced with `branchHint ?? (live read)`. The amend call site inside `executePipeline` now passes the operation's captured branch as this hint.
- Four regression tests were added to `QueueWorker.test.ts` covering: normal commit using the captured branch, normal commit falling back to live branch when the field is absent, amend fresh-leaf using the captured branch via the hint parameter, and amend falling back to live branch when no hint is provided. Tests drive the fix through the full `runWorker` entry point to catch wiring mistakes that inner-function unit tests would miss.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 29, 2026 at 10:51 AM · via Anthropic*
<!-- jollimemory-summary-end -->