### PR TITLE
Refactor force-push logic into shared ForcePushPrompt util and add non-fast-forward handling to Create PR flow

### DIFF
--- a/vscode/src/commands/PushCommand.ts
+++ b/vscode/src/commands/PushCommand.ts
@@ -26,10 +26,12 @@ import type { CommitsStore } from "../stores/CommitsStore.js";
 import type { FilesStore } from "../stores/FilesStore.js";
 import type { StatusStore } from "../stores/StatusStore.js";
 import type { BranchCommit } from "../Types.js";
+import {
+	confirmForcePush,
+	isNonFastForwardError,
+} from "../util/ForcePushPrompt.js";
 import { log } from "../util/Logger.js";
 import type { StatusBarManager } from "../util/StatusBarManager.js";
-
-const FORCE_PUSH_CONFIRM_LABEL = "Force Push (--force-with-lease)";
 
 export class PushCommand {
 	constructor(
@@ -80,7 +82,7 @@ export class PushCommand {
 				try {
 					await this.bridge.pushCurrentBranch();
 				} catch (err: unknown) {
-					if (!this.isNonFastForwardError(err)) {
+					if (!isNonFastForwardError(err)) {
 						throw err;
 					}
 					log.warn(
@@ -113,11 +115,11 @@ export class PushCommand {
 	}
 
 	/**
-	 * Shows a modal force-push confirmation dialog.
-	 *
-	 * Single-commit branches show "Commit: <hash> <msg>"; multi-commit branches
-	 * show "HEAD (N commits): <hash> <msg>" so the user can see at a glance how
-	 * many commits the force-push will replace on the remote.
+	 * Shows the shared modal force-push confirmation, adding the commit detail
+	 * line this flow has the context for: single-commit branches show
+	 * "Commit: <hash> <msg>"; multi-commit branches show
+	 * "HEAD (N commits): <hash> <msg>" so the user can see at a glance how many
+	 * commits the force-push will replace on the remote.
 	 */
 	private async showForcePushWarning(
 		commits: ReadonlyArray<BranchCommit>,
@@ -126,31 +128,12 @@ export class PushCommand {
 		const head = commits[0];
 		const headLabel =
 			commits.length === 1 ? "Commit" : `HEAD (${commits.length} commits)`;
-		const answer = await vscode.window.showWarningMessage(
-			[
-				"This operation may rewrite remote history.",
-				"",
+		return confirmForcePush({
+			detailLines: [
 				`${headLabel}: ${head.shortHash} ${head.message.substring(0, 80)}`,
-				"",
-				reason,
-				"This may affect collaborators on the same branch.",
-			].join("\n"),
-			{ modal: true },
-			FORCE_PUSH_CONFIRM_LABEL,
-		);
-		return answer === FORCE_PUSH_CONFIRM_LABEL;
-	}
-
-	private isNonFastForwardError(err: unknown): boolean {
-		const message = (
-			err instanceof Error ? err.message : String(err)
-		).toLowerCase();
-		return (
-			message.includes("non-fast-forward") ||
-			message.includes("fetch first") ||
-			message.includes("[rejected]") ||
-			message.includes("tip of your current branch is behind")
-		);
+			],
+			reason,
+		});
 	}
 
 	private async refreshAll(): Promise<void> {

--- a/vscode/src/services/PrCommentService.test.ts
+++ b/vscode/src/services/PrCommentService.test.ts
@@ -1835,6 +1835,184 @@ describe("PrCommentService", () => {
 				expect.stringContaining("Cannot determine the current branch"),
 			);
 		});
+
+		// ── Non-fast-forward push → force-push confirmation (mirrors Push Branch) ──
+		//
+		// When the branch was pushed and its local history was later rewritten
+		// (rebase / amend / squash / reset), the normal `git push -u origin HEAD`
+		// is rejected as non-fast-forward. Create PR mirrors the sidebar Push
+		// Branch flow: confirm via a modal, then retry with --force-with-lease.
+
+		/** A git stderr that matches `isNonFastForwardError`. */
+		const NON_FAST_FORWARD_ERROR =
+			" ! [rejected]          HEAD -> feature/branch (non-fast-forward)\n" +
+			"error: failed to push some refs to 'origin'\n" +
+			"hint: Updates were rejected because the tip of your current branch is behind";
+		const FORCE_PUSH_LABEL = "Force Push (--force-with-lease)";
+
+		it("non-fast-forward push + user confirms → force-pushes with --force-with-lease and continues creating the PR", async () => {
+			const prUrl = "https://github.com/org/repo/pull/88";
+			let normalPushCalled = false;
+			let forcePushCalled = false;
+			let prCreateCalled = false;
+			setupExecFile(
+				buildRouter({
+					"git:push:-u": () => {
+						normalPushCalled = true;
+						throw new Error(NON_FAST_FORWARD_ERROR);
+					},
+					"git:push:--force-with-lease": () => {
+						forcePushCalled = true;
+						return { stdout: "" };
+					},
+					"gh:pr:create": () => {
+						prCreateCalled = true;
+						return { stdout: `${prUrl}\n` };
+					},
+					"git:rev-list": () => ({ stdout: "1\n" }),
+					"git:rev-parse": () => ({ stdout: "feature/branch\n" }),
+					"gh:--version": () => ({ stdout: "gh 2.40.0\n" }),
+					"gh:auth": () => ({ stdout: "ok\n" }),
+					"gh:pr:list": () => ({
+						stdout: JSON.stringify([
+							{
+								number: 88,
+								url: prUrl,
+								title: "Rebased PR",
+								body: "",
+								state: "OPEN",
+							},
+						]),
+					}),
+				}),
+			);
+			showWarningMessage.mockResolvedValue(FORCE_PUSH_LABEL);
+			showInformationMessage.mockResolvedValue(undefined);
+
+			await handleCreatePr("Rebased PR", "PR body", CWD, postMessage);
+
+			expect(normalPushCalled).toBe(true);
+			// The modal must be a force-push confirmation, shown modally.
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("Force push will overwrite"),
+				expect.objectContaining({ modal: true }),
+				FORCE_PUSH_LABEL,
+			);
+			expect(forcePushCalled).toBe(true);
+			expect(prCreateCalled).toBe(true);
+			expect(postMessage).toHaveBeenCalledWith({ command: "prCreating" });
+			expect(postMessage).not.toHaveBeenCalledWith({
+				command: "prCreateFailed",
+			});
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({ command: "prStatus", status: "ready" }),
+			);
+		});
+
+		it("non-fast-forward push + user cancels → does not force-push, does not create the PR, posts prCreateFailed", async () => {
+			let forcePushCalled = false;
+			let prCreateCalled = false;
+			setupExecFile(
+				buildRouter({
+					"git:push:-u": () => {
+						throw new Error(NON_FAST_FORWARD_ERROR);
+					},
+					"git:push:--force-with-lease": () => {
+						forcePushCalled = true;
+						return { stdout: "" };
+					},
+					"gh:pr:create": () => {
+						prCreateCalled = true;
+						return { stdout: "https://example/0\n" };
+					},
+					"git:rev-parse": () => ({ stdout: "feature/branch\n" }),
+				}),
+			);
+			// User dismisses the modal (no button clicked).
+			showWarningMessage.mockResolvedValue(undefined);
+
+			await handleCreatePr("T", "B", CWD, postMessage);
+
+			expect(showWarningMessage).toHaveBeenCalledWith(
+				expect.stringContaining("rewrite remote history"),
+				expect.objectContaining({ modal: true }),
+				FORCE_PUSH_LABEL,
+			);
+			expect(forcePushCalled).toBe(false);
+			expect(prCreateCalled).toBe(false);
+			expect(postMessage).toHaveBeenCalledWith({ command: "prCreating" });
+			expect(postMessage).toHaveBeenCalledWith({ command: "prCreateFailed" });
+			// Symmetric with the confirm test: the PR-ready status must never
+			// leak through on a cancelled create.
+			expect(postMessage).not.toHaveBeenCalledWith(
+				expect.objectContaining({ command: "prStatus", status: "ready" }),
+			);
+			// A cancel is not an error — no error toast.
+			expect(showErrorMessage).not.toHaveBeenCalled();
+		});
+
+		it("non-fast-forward push + confirm, but force-push itself rejected (lease stale) → no PR, prCreateFailed + error toast", async () => {
+			// --force-with-lease is exactly the guard that fires when the remote
+			// moved in a way this clone hasn't observed (e.g. a collaborator
+			// pushed). When it rejects, the throw propagates to the outer catch:
+			// no PR is created, and the user sees the real git error.
+			let prCreateCalled = false;
+			setupExecFile(
+				buildRouter({
+					"git:push:-u": () => {
+						throw new Error(NON_FAST_FORWARD_ERROR);
+					},
+					"git:push:--force-with-lease": () => {
+						throw new Error(
+							"! [rejected] HEAD -> feature/branch (stale info)\n" +
+								"error: failed to push some refs — remote ref moved",
+						);
+					},
+					"gh:pr:create": () => {
+						prCreateCalled = true;
+						return { stdout: "https://example/0\n" };
+					},
+					"git:rev-parse": () => ({ stdout: "feature/branch\n" }),
+				}),
+			);
+			showWarningMessage.mockResolvedValue(FORCE_PUSH_LABEL);
+
+			await handleCreatePr("T", "B", CWD, postMessage);
+
+			expect(prCreateCalled).toBe(false);
+			expect(postMessage).toHaveBeenCalledWith({ command: "prCreating" });
+			expect(postMessage).toHaveBeenCalledWith({ command: "prCreateFailed" });
+			expect(showErrorMessage).toHaveBeenCalledWith(
+				expect.stringContaining("stale info"),
+			);
+		});
+
+		it("non-NFF push error (auth/network) → no force-push modal, original prCreateFailed error path", async () => {
+			let forcePushCalled = false;
+			setupExecFile(
+				buildRouter({
+					"git:push:-u": () => {
+						throw new Error("fatal: Authentication failed for 'origin'");
+					},
+					"git:push:--force-with-lease": () => {
+						forcePushCalled = true;
+						return { stdout: "" };
+					},
+					"git:rev-parse": () => ({ stdout: "feature/branch\n" }),
+				}),
+			);
+
+			await handleCreatePr("T", "B", CWD, postMessage);
+
+			// No modal for a non-fast-forward-unrelated failure.
+			expect(showWarningMessage).not.toHaveBeenCalled();
+			expect(forcePushCalled).toBe(false);
+			expect(postMessage).toHaveBeenCalledWith({ command: "prCreating" });
+			expect(postMessage).toHaveBeenCalledWith({ command: "prCreateFailed" });
+			expect(showErrorMessage).toHaveBeenCalledWith(
+				expect.stringContaining("Authentication failed"),
+			);
+		});
 	});
 
 	// ─── handlePrepareUpdatePr ──────────────────────────────────────────────

--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -20,6 +20,7 @@ import * as vscode from "vscode";
 import { execFileAsyncHidden } from "../../../cli/src/util/Subprocess.js";
 import { MARKER_END, MARKER_START, wrapWithMarkers } from "../../../cli/src/core/PrDescription.js";
 import { detachedHeadMessage } from "./CreatePrBranchClassifier.js";
+import { confirmForcePush, isNonFastForwardError } from "../util/ForcePushPrompt.js";
 import { log } from "../util/Logger.js";
 
 const TAG = "PrSection";
@@ -224,6 +225,18 @@ async function getCurrentBranchSafe(cwd: string): Promise<string> {
 /** Pushes the current branch to origin (no-op if already pushed). */
 async function pushBranch(cwd: string): Promise<void> {
 	await execGit(["push", "-u", "origin", "HEAD"], cwd);
+}
+
+/**
+ * Force-pushes the current branch with `--force-with-lease`. Only invoked
+ * after the user confirms the shared modal warning, when a normal push was
+ * rejected as non-fast-forward. `--force-with-lease` (never bare `--force`)
+ * refuses when the remote moved in a way the local clone hasn't observed,
+ * giving the collaborator-pushed-too case a chance to be caught before the
+ * overwrite. Mirrors `PushCommand`'s `bridge.forcePush()`.
+ */
+async function forcePushBranch(cwd: string): Promise<void> {
+	await execGit(["push", "--force-with-lease", "origin", "HEAD"], cwd);
 }
 
 interface PrInfo {
@@ -644,9 +657,30 @@ export async function handleCreatePr(
 
 		postMessage({ command: "prCreating" });
 
-		// Ensure branch is pushed
+		// Ensure branch is pushed. A normal push is rejected as non-fast-forward
+		// when this branch was already pushed and its local history was then
+		// rewritten (rebase / amend / squash / reset). Mirror Push Branch:
+		// confirm via a modal, then retry with --force-with-lease. Any other
+		// push error (auth, network) propagates to the outer catch unchanged.
 		log.info(TAG, "Pushing branch to origin...");
-		await pushBranch(cwd);
+		try {
+			await pushBranch(cwd);
+		} catch (pushErr: unknown) {
+			if (!isNonFastForwardError(pushErr)) {
+				throw pushErr;
+			}
+			log.warn(
+				TAG,
+				"Create PR push rejected (non-fast-forward) — offering force push",
+			);
+			const confirmed = await confirmForcePush();
+			if (!confirmed) {
+				log.info(TAG, "Create PR force-push declined — aborting");
+				postMessage({ command: "prCreateFailed" });
+				return;
+			}
+			await forcePushBranch(cwd);
+		}
 
 		// Create the PR
 		log.info(TAG, `Creating PR: "${title}"`);

--- a/vscode/src/util/ForcePushPrompt.test.ts
+++ b/vscode/src/util/ForcePushPrompt.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { showWarningMessage } = vi.hoisted(() => ({
+	showWarningMessage: vi.fn(),
+}));
+
+vi.mock("vscode", () => ({
+	window: { showWarningMessage },
+}));
+
+import {
+	FORCE_PUSH_CONFIRM_LABEL,
+	confirmForcePush,
+	isNonFastForwardError,
+} from "./ForcePushPrompt.js";
+
+describe("ForcePushPrompt", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("isNonFastForwardError", () => {
+		it.each([
+			["! [rejected] HEAD -> main (non-fast-forward)"],
+			["hint: Updates were rejected; fetch first"],
+			["error: [rejected] main"],
+			["the tip of your current branch is behind its remote counterpart"],
+		])("returns true for the git rejection phrase: %s", (message) => {
+			expect(isNonFastForwardError(new Error(message))).toBe(true);
+		});
+
+		it("is case-insensitive (matches upper-cased stderr)", () => {
+			expect(isNonFastForwardError(new Error("NON-FAST-FORWARD"))).toBe(true);
+		});
+
+		it("returns false for an unrelated push error (auth/network)", () => {
+			expect(
+				isNonFastForwardError(new Error("fatal: Authentication failed")),
+			).toBe(false);
+		});
+
+		it("coerces a non-Error throw via String() before matching", () => {
+			// A bare string rejection still classifies correctly.
+			expect(isNonFastForwardError("push rejected: fetch first")).toBe(true);
+			expect(isNonFastForwardError({ nope: 1 })).toBe(false);
+		});
+	});
+
+	describe("confirmForcePush", () => {
+		it("returns true only when the user clicks the force-push button", async () => {
+			showWarningMessage.mockResolvedValue(FORCE_PUSH_CONFIRM_LABEL);
+			await expect(confirmForcePush()).resolves.toBe(true);
+		});
+
+		it("returns false when the user dismisses the modal", async () => {
+			showWarningMessage.mockResolvedValue(undefined);
+			await expect(confirmForcePush()).resolves.toBe(false);
+		});
+
+		it("shows a modal with the default diverged-branch reason and no detail line when called with no opts", async () => {
+			showWarningMessage.mockResolvedValue(undefined);
+
+			await confirmForcePush();
+
+			const [message, options, label] = showWarningMessage.mock.calls[0];
+			expect(message).toContain("This operation may rewrite remote history.");
+			expect(message).toContain(
+				"Remote branch has diverged. Force push will overwrite remote history.",
+			);
+			expect(message).toContain(
+				"This may affect collaborators on the same branch.",
+			);
+			expect(options).toEqual({ modal: true });
+			expect(label).toBe(FORCE_PUSH_CONFIRM_LABEL);
+		});
+
+		it("inserts caller-supplied detail lines and a custom reason between the lead-in and collaborators warning", async () => {
+			showWarningMessage.mockResolvedValue(FORCE_PUSH_CONFIRM_LABEL);
+
+			await confirmForcePush({
+				detailLines: ["HEAD (3 commits): abc123 do a thing"],
+				reason: "HEAD is already on remote.",
+			});
+
+			const message = showWarningMessage.mock.calls[0][0] as string;
+			expect(message).toContain("HEAD (3 commits): abc123 do a thing");
+			expect(message).toContain("HEAD is already on remote.");
+			// The default reason must be replaced, not appended.
+			expect(message).not.toContain("Remote branch has diverged");
+			// Ordering: lead-in → detail → reason → collaborators.
+			const leadIdx = message.indexOf("rewrite remote history");
+			const detailIdx = message.indexOf("HEAD (3 commits)");
+			const reasonIdx = message.indexOf("HEAD is already on remote.");
+			const collabIdx = message.indexOf("affect collaborators");
+			expect(leadIdx).toBeLessThan(detailIdx);
+			expect(detailIdx).toBeLessThan(reasonIdx);
+			expect(reasonIdx).toBeLessThan(collabIdx);
+		});
+	});
+});

--- a/vscode/src/util/ForcePushPrompt.ts
+++ b/vscode/src/util/ForcePushPrompt.ts
@@ -1,0 +1,71 @@
+/**
+ * ForcePushPrompt
+ *
+ * Single source of truth for the modal force-push confirmation shown when a
+ * normal `git push` is rejected because the branch's local history was
+ * rewritten after it was first pushed (rebase / amend / squash / reset), or
+ * the HEAD is already on remote.
+ *
+ * Two push entry points share this so users see byte-identical wording and the
+ * same button regardless of where they triggered it:
+ * - the sidebar Push Branch flow (`PushCommand`), which adds a HEAD/commit line
+ * - the Create PR push step (`PrCommentService`), which has no commit context
+ *
+ * The squash pre-warning in `SquashCommand` is intentionally NOT routed here:
+ * it's a different decision (confirming a history rewrite *before* squashing,
+ * with its own button text), not a post-rejection force-push confirmation.
+ */
+
+import * as vscode from "vscode";
+
+/** Button label for the modal force-push confirmation. */
+export const FORCE_PUSH_CONFIRM_LABEL = "Force Push (--force-with-lease)";
+
+/** Default reason line for the diverged-branch (non-fast-forward) case. */
+const DEFAULT_FORCE_PUSH_REASON =
+	"Remote branch has diverged. Force push will overwrite remote history.";
+
+/**
+ * Recognizes git's non-fast-forward push rejection. A normal push emits this
+ * when the local branch was rewritten after it was first pushed. Both push
+ * entry points classify the same stderr identically through this helper.
+ */
+export function isNonFastForwardError(err: unknown): boolean {
+	const message = (
+		err instanceof Error ? err.message : String(err)
+	).toLowerCase();
+	return (
+		message.includes("non-fast-forward") ||
+		message.includes("fetch first") ||
+		message.includes("[rejected]") ||
+		message.includes("tip of your current branch is behind")
+	);
+}
+
+/**
+ * Shows the shared modal force-push confirmation. Returns true only when the
+ * user clicks the explicit force-push button.
+ *
+ * - `detailLines` are inserted between the lead-in and the reason — Push Branch
+ *   passes the HEAD/commit-count line; Create PR passes none.
+ * - `reason` overrides the default diverged-branch wording (Push Branch's
+ *   already-pushed path uses a slightly different sentence).
+ */
+export async function confirmForcePush(
+	opts: { detailLines?: ReadonlyArray<string>; reason?: string } = {},
+): Promise<boolean> {
+	const detailLines = opts.detailLines ?? [];
+	const lines = [
+		"This operation may rewrite remote history.",
+		"",
+		...(detailLines.length > 0 ? [...detailLines, ""] : []),
+		opts.reason ?? DEFAULT_FORCE_PUSH_REASON,
+		"This may affect collaborators on the same branch.",
+	];
+	const answer = await vscode.window.showWarningMessage(
+		lines.join("\n"),
+		{ modal: true },
+		FORCE_PUSH_CONFIRM_LABEL,
+	);
+	return answer === FORCE_PUSH_CONFIRM_LABEL;
+}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The Create PR panel now handles the common situation where a branch was pushed, its history was rewritten locally, and the user then tries to open a pull request. Previously this produced a raw error with no recovery path. Now the panel shows the same force-push confirmation dialog that the sidebar Push Branch button has always shown: the user can confirm to proceed or cancel to return to the editing state. If the user confirms but the remote has since been updated by a collaborator, the safer push variant detects the conflict and surfaces the real error rather than silently overwriting the remote work.

To support this, the force-push confirmation dialog and the push-rejection detection logic were extracted into a shared utility. Both the Create PR flow and the Push Branch flow now draw from this single source, so the button label, message wording, and dialog style are guaranteed to stay identical across both surfaces. The Push Branch flow continues to show the additional commit-detail line it has always shown; Create PR omits that line because it does not have commit context available at that point in the flow.

---

## E2E Test (1)
<details>
<summary><strong>1. Create PR with rewritten history — user confirms force push</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a local branch that has already been pushed to the remote, then rewrite its history locally (for example, amend the last commit or do an interactive rebase). The branch should have at least one commit ahead of the remote after the rewrite.

**Steps:**
1. Open the Jolli Memory sidebar in VS Code.
2. Click "Create PR" (or open the Create PR panel) for the branch whose history was rewritten.
3. Fill in a pull request title and description, then click the button to create the PR.
4. When a warning dialog appears asking about force-pushing, read the message and click "Force Push (--force-with-lease)".
5. Wait for the panel to finish and check whether a pull request was created.

**Expected Results:**
- A modal warning dialog appears with the text "This operation may rewrite remote history." and a note about affecting collaborators, before any PR is created.
- After clicking "Force Push (--force-with-lease)", the dialog closes and the PR is created successfully.
- The panel shows the new PR link or a "ready" status — no error message or toast appears.

</blockquote>
</details>

---

## Topics (2)
<details>
<summary><strong>01 · Extract shared force-push confirmation utility used by both push flows</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Create PR flow and the sidebar Push Branch flow each had their own separate copy of the force-push confirmation dialog and the logic for detecting a rejected push. The user noticed this duplication and asked for a single shared implementation so both surfaces show identical wording.

**💡 Decisions Behind the Code**

- **Shared module over inline duplication**: Keeping two independent copies of the dialog text and rejection classifier meant any future wording change would need to be applied in two places, and the two surfaces could silently drift apart. A dedicated utility file makes the button label and message text a single literal source, so both flows are guaranteed to stay in sync with no coordination overhead.
- **SquashCommand deliberately excluded**: The squash flow shows a pre-action warning with different button text and a different decision framing (confirming intent before rewriting, not recovering from a rejected push). Merging it into the shared utility would have forced an awkward API to accommodate semantically unrelated behavior, so it was left untouched.
- **`detailLines` injection over subclassing or callbacks**: Push Branch has commit context (hash, count) that Create PR lacks. Rather than creating two separate exported functions or a class hierarchy, the shared function accepts an optional array of extra lines to splice into the message. This keeps the API flat and the call sites simple while still producing the richer dialog for the flow that has the data.

**✅ What Was Implemented**

- Created `vscode/src/util/ForcePushPrompt.ts` as the single source of truth, exporting three items: a button label constant, a push-rejection classifier function, and a `confirmForcePush` function that accepts optional detail lines and a reason override. The message assembly concatenates a fixed lead-in, optional caller-supplied detail lines, a reason sentence, and a collaborators warning — producing the same structure regardless of call site.
- Refactored `vscode/src/commands/PushCommand.ts` to delete its local label constant, local classifier method, and inline dialog assembly, replacing all three with imports from the new shared module. The commit-detail line (showing HEAD hash and count) is now passed as `detailLines` so the shared function can insert it in the correct position.
- Added `vscode/src/util/ForcePushPrompt.test.ts` covering all four rejection phrases, case-insensitivity, non-Error throw coercion, default-options dialog shape, and custom detail-line ordering.

**📁 FILES**
- `vscode/src/util/ForcePushPrompt.ts`
- `vscode/src/commands/PushCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Add force-push confirmation to Create PR when push is rejected</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a branch had already been pushed and its local history was later rewritten (through rebase, amend, squash, or reset), clicking Create PR would fail with a raw git error message and no recovery path. The sidebar Push Branch button already handled this gracefully with a confirmation dialog, but the Create PR flow had no equivalent.

**💡 Decisions Behind the Code**

- **Mirror Push Branch behavior exactly**: The two entry points for pushing a branch should present the same recovery experience. Using the same shared confirmation utility (rather than a bespoke dialog) ensures the wording, button label, and modal style are identical, so users encounter a consistent mental model regardless of which surface they used.
- **Use force-with-lease, never bare force**: The safer variant refuses to overwrite the remote if it has moved in a way the local clone has not observed — catching the case where a collaborator pushed to the same branch in the interim. A bare force flag would silently discard that work. The lease variant surfaces the conflict as an error, which then reaches the outer catch and shows the user the real git message.
- **Cancel resets panel state without showing an error toast**: A deliberate cancel is not an error condition. Showing an error message on cancel would be misleading and noisy. The panel is returned to its pre-creating state so the user can adjust and try again, but no error notification is raised.

**✅ What Was Implemented**

- In `vscode/src/services/PrCommentService.ts`, the push step inside `handleCreatePr` now catches non-fast-forward rejections specifically. On detection it shows the shared modal confirmation; if the user confirms, it retries with the safer force-push variant and continues to create the PR; if the user cancels, it resets the panel state and returns without creating. Auth and network errors bypass this path entirely and surface as before.
- Added `forcePushBranch` as a local async helper in `PrCommentService.ts` that issues the force-push command with the lease flag, mirroring the equivalent call in the sidebar push flow.
- Added four tests in `PrCommentService.test.ts` covering: confirm → force-push succeeds → PR created; cancel → no force-push → panel reset; force-push itself rejected by a stale lease → no PR, error toast shown; unrelated push error → no modal shown, original error path taken.

**📁 FILES**
- `vscode/src/services/PrCommentService.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 29, 2026 at 3:07 PM · via Anthropic*
<!-- jollimemory-summary-end -->