### PR TITLE
Block force-push when branch is merely behind remote via divergence gate

### DIFF
--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -112,6 +112,10 @@ import type {
 	ReferenceInfo,
 } from "./Types.js";
 import { mergeCommitMessages } from "./util/CommitMessageUtils.js";
+import {
+	type ForcePushSafety,
+	inspectForcePushSafety,
+} from "./util/ForcePushSafety.js";
 import { log } from "./util/Logger.js";
 import { loadGlobalConfig } from "./util/WorkspaceUtils.js";
 
@@ -1734,6 +1738,20 @@ export class JolliMemoryBridge {
 	/** Force-pushes the current branch. */
 	async forcePush(): Promise<void> {
 		await this.execPush(["--force-with-lease"]);
+	}
+
+	/**
+	 * Measures how the current branch diverges from its remote after a
+	 * non-fast-forward rejection, so the push UI can tell a real history rewrite
+	 * apart from a branch that is merely behind. Returns null when inconclusive.
+	 * See {@link inspectForcePushSafety}.
+	 */
+	async inspectForcePushSafety(): Promise<ForcePushSafety | null> {
+		const branch = await this.getCurrentBranch();
+		return inspectForcePushSafety(
+			(args) => execGit([...args], this.cwd),
+			branch,
+		);
 	}
 
 	// ── Summary access ────────────────────────────────────────────────────

--- a/vscode/src/commands/PushCommand.test.ts
+++ b/vscode/src/commands/PushCommand.test.ts
@@ -49,6 +49,11 @@ function makeDeps(commits = [makeCommit()]) {
 	const bridge = {
 		pushCurrentBranch: vi.fn().mockResolvedValue(undefined),
 		forcePush: vi.fn().mockResolvedValue(undefined),
+		// Default: divergence probe is inconclusive, so the gate falls back to
+		// the plain confirm modal — matching the pre-gate behavior the existing
+		// force-push tests assert. Tests exercising the behind-only block
+		// override this to return a behindOnly result.
+		inspectForcePushSafety: vi.fn().mockResolvedValue(null),
 		getStatus: vi.fn(async () => ({ enabled: true })),
 	};
 	const commitsStore = {
@@ -236,6 +241,36 @@ describe("PushCommand", () => {
 		);
 	});
 
+	it("blocks force-push of an already-pushed HEAD when the branch is merely behind the remote", async () => {
+		// Regression guard: the "HEAD already pushed" pre-warning path used to
+		// force-push unconditionally on confirm. It must now route through the
+		// divergence gate so a behind-only branch can't clobber collaborator commits.
+		const deps = makeDeps([makeCommit({ isPushed: true })]);
+		deps.bridge.inspectForcePushSafety.mockResolvedValueOnce({
+			branch: "feature",
+			remoteOnly: 2,
+			localOnly: 0,
+			behindOnly: true,
+		});
+		const command = new PushCommand(
+			deps.bridge as never,
+			deps.commitsStore as never,
+			deps.filesStore as never,
+			deps.statusStore as never,
+			deps.statusBar as never,
+		);
+
+		await command.execute();
+
+		expect(showWarningMessage).toHaveBeenCalled();
+		expect(deps.bridge.forcePush).not.toHaveBeenCalled();
+		expect(showInformationMessage).not.toHaveBeenCalled();
+		expect(info).toHaveBeenCalledWith(
+			"push",
+			"Push blocked — remote is ahead; rebase first",
+		);
+	});
+
 	it("returns early when force-push fallback is cancelled after non-fast-forward rejection", async () => {
 		const deps = makeDeps();
 		deps.bridge.pushCurrentBranch.mockRejectedValueOnce(
@@ -255,6 +290,38 @@ describe("PushCommand", () => {
 		expect(deps.bridge.forcePush).not.toHaveBeenCalled();
 		expect(showInformationMessage).not.toHaveBeenCalled();
 		expect(info).toHaveBeenCalledWith("push", "Force-push fallback cancelled");
+	});
+
+	it("blocks force-push (sends user to rebase) when the branch is merely behind the remote", async () => {
+		const deps = makeDeps();
+		deps.bridge.pushCurrentBranch.mockRejectedValueOnce(
+			new Error("! [rejected] (fetch first)"),
+		);
+		// Remote is strictly ahead: this is not a rewrite, force-push would clobber.
+		deps.bridge.inspectForcePushSafety.mockResolvedValueOnce({
+			branch: "feature",
+			remoteOnly: 2,
+			localOnly: 0,
+			behindOnly: true,
+		});
+		const command = new PushCommand(
+			deps.bridge as never,
+			deps.commitsStore as never,
+			deps.filesStore as never,
+			deps.statusStore as never,
+			deps.statusBar as never,
+		);
+
+		await command.execute();
+
+		// The behind-only modal is shown, but force-push is never invoked.
+		expect(showWarningMessage).toHaveBeenCalled();
+		expect(deps.bridge.forcePush).not.toHaveBeenCalled();
+		expect(showInformationMessage).not.toHaveBeenCalled();
+		expect(info).toHaveBeenCalledWith(
+			"push",
+			"Push blocked — remote is ahead; rebase first",
+		);
 	});
 
 	it("coerces non-Error thrown from push to string in error message", async () => {

--- a/vscode/src/commands/PushCommand.ts
+++ b/vscode/src/commands/PushCommand.ts
@@ -26,10 +26,7 @@ import type { CommitsStore } from "../stores/CommitsStore.js";
 import type { FilesStore } from "../stores/FilesStore.js";
 import type { StatusStore } from "../stores/StatusStore.js";
 import type { BranchCommit } from "../Types.js";
-import {
-	confirmForcePush,
-	isNonFastForwardError,
-} from "../util/ForcePushPrompt.js";
+import { gateForcePush, isNonFastForwardError } from "../util/ForcePushPrompt.js";
 import { log } from "../util/Logger.js";
 import type { StatusBarManager } from "../util/StatusBarManager.js";
 
@@ -64,16 +61,21 @@ export class PushCommand {
 
 		try {
 			if (headCommit.isPushed) {
+				// HEAD is already on remote, so any push here rewrites remote
+				// history. Gate on the actual divergence first — this path used to
+				// offer force-push unconditionally, which would clobber a
+				// collaborator's commits when the branch was merely behind.
 				log.info(
 					"push",
-					`HEAD already pushed (${commits.length} commit(s) on branch) — asking for force-push confirmation`,
+					`HEAD already pushed (${commits.length} commit(s) on branch) — checking divergence`,
 				);
-				const confirmed = await this.showForcePushWarning(
-					commits,
-					"HEAD is already on remote. Force push will rewrite remote branch history.",
-				);
-				if (!confirmed) {
-					log.info("push", "Force-push confirmation cancelled");
+				if (
+					!(await this.runForcePushGate(
+						commits,
+						"HEAD is already on remote. Force push will rewrite remote branch history.",
+						"Force-push confirmation cancelled",
+					))
+				) {
 					return;
 				}
 				await this.bridge.forcePush();
@@ -87,14 +89,15 @@ export class PushCommand {
 					}
 					log.warn(
 						"push",
-						"Normal push rejected (non-fast-forward) — offering force push",
+						"Normal push rejected (non-fast-forward) — checking divergence",
 					);
-					const confirmed = await this.showForcePushWarning(
-						commits,
-						"Remote branch has diverged. Force push will overwrite remote history.",
-					);
-					if (!confirmed) {
-						log.info("push", "Force-push fallback cancelled");
+					if (
+						!(await this.runForcePushGate(
+							commits,
+							"Remote branch has diverged. Force push will overwrite remote history.",
+							"Force-push fallback cancelled",
+						))
+					) {
 						return;
 					}
 					await this.bridge.forcePush();
@@ -115,25 +118,47 @@ export class PushCommand {
 	}
 
 	/**
-	 * Shows the shared modal force-push confirmation, adding the commit detail
-	 * line this flow has the context for: single-commit branches show
-	 * "Commit: <hash> <msg>"; multi-commit branches show
+	 * Builds the commit detail line this flow has the context for: single-commit
+	 * branches show "Commit: <hash> <msg>"; multi-commit branches show
 	 * "HEAD (N commits): <hash> <msg>" so the user can see at a glance how many
-	 * commits the force-push will replace on the remote.
+	 * commits the force-push will replace on the remote. Shared by both the
+	 * already-pushed pre-warning and the non-fast-forward gate so the wording
+	 * can't drift between them.
 	 */
-	private async showForcePushWarning(
-		commits: ReadonlyArray<BranchCommit>,
-		reason: string,
-	): Promise<boolean> {
+	private headDetailLine(commits: ReadonlyArray<BranchCommit>): string {
 		const head = commits[0];
 		const headLabel =
 			commits.length === 1 ? "Commit" : `HEAD (${commits.length} commits)`;
-		return confirmForcePush({
-			detailLines: [
-				`${headLabel}: ${head.shortHash} ${head.message.substring(0, 80)}`,
-			],
+		return `${headLabel}: ${head.shortHash} ${head.message.substring(0, 80)}`;
+	}
+
+	/**
+	 * Runs the shared force-push gate (divergence check → block-or-confirm) with
+	 * this flow's commit detail line. Returns true only when the caller should go
+	 * ahead and force-push. Both push entry points — the "HEAD already pushed"
+	 * pre-warning and the non-fast-forward fallback — route through here so a
+	 * branch that is merely behind the remote is never force-pushed over a
+	 * collaborator's commits.
+	 */
+	private async runForcePushGate(
+		commits: ReadonlyArray<BranchCommit>,
+		reason: string,
+		declinedLog: string,
+	): Promise<boolean> {
+		const outcome = await gateForcePush({
+			inspect: () => this.bridge.inspectForcePushSafety(),
+			detailLines: [this.headDetailLine(commits)],
 			reason,
 		});
+		if (outcome === "blocked") {
+			log.info("push", "Push blocked — remote is ahead; rebase first");
+			return false;
+		}
+		if (outcome === "declined") {
+			log.info("push", declinedLog);
+			return false;
+		}
+		return true;
 	}
 
 	private async refreshAll(): Promise<void> {

--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -20,7 +20,8 @@ import * as vscode from "vscode";
 import { execFileAsyncHidden } from "../../../cli/src/util/Subprocess.js";
 import { MARKER_END, MARKER_START, wrapWithMarkers } from "../../../cli/src/core/PrDescription.js";
 import { detachedHeadMessage } from "./CreatePrBranchClassifier.js";
-import { confirmForcePush, isNonFastForwardError } from "../util/ForcePushPrompt.js";
+import { gateForcePush, isNonFastForwardError } from "../util/ForcePushPrompt.js";
+import { inspectForcePushSafety } from "../util/ForcePushSafety.js";
 import { log } from "../util/Logger.js";
 
 const TAG = "PrSection";
@@ -228,12 +229,14 @@ async function pushBranch(cwd: string): Promise<void> {
 }
 
 /**
- * Force-pushes the current branch with `--force-with-lease`. Only invoked
- * after the user confirms the shared modal warning, when a normal push was
- * rejected as non-fast-forward. `--force-with-lease` (never bare `--force`)
- * refuses when the remote moved in a way the local clone hasn't observed,
- * giving the collaborator-pushed-too case a chance to be caught before the
- * overwrite. Mirrors `PushCommand`'s `bridge.forcePush()`.
+ * Force-pushes the current branch with `--force-with-lease`. Only invoked after
+ * the divergence gate (`gateForcePush`) cleared it and the user confirmed the
+ * shared modal, when a normal push was rejected as non-fast-forward. The gate is
+ * the primary guard against overwriting collaborator commits — it already
+ * fetched and counted what would be lost. `--force-with-lease` (never bare
+ * `--force`) is the secondary backstop: it still refuses if the remote moves
+ * again between the gate's fetch and this push. Mirrors `PushCommand`'s
+ * `bridge.forcePush()`.
  */
 async function forcePushBranch(cwd: string): Promise<void> {
 	await execGit(["push", "--force-with-lease", "origin", "HEAD"], cwd);
@@ -658,10 +661,12 @@ export async function handleCreatePr(
 		postMessage({ command: "prCreating" });
 
 		// Ensure branch is pushed. A normal push is rejected as non-fast-forward
-		// when this branch was already pushed and its local history was then
-		// rewritten (rebase / amend / squash / reset). Mirror Push Branch:
-		// confirm via a modal, then retry with --force-with-lease. Any other
-		// push error (auth, network) propagates to the outer catch unchanged.
+		// both when this branch's local history was rewritten (rebase / amend /
+		// squash / reset) AND when it is simply behind the remote. Mirror Push
+		// Branch: gate on the actual divergence before offering force-push, so a
+		// branch that is merely behind a collaborator's commits is sent to rebase
+		// rather than overwritten. Any other push error (auth, network)
+		// propagates to the outer catch unchanged.
 		log.info(TAG, "Pushing branch to origin...");
 		try {
 			await pushBranch(cwd);
@@ -671,11 +676,19 @@ export async function handleCreatePr(
 			}
 			log.warn(
 				TAG,
-				"Create PR push rejected (non-fast-forward) — offering force push",
+				"Create PR push rejected (non-fast-forward) — checking divergence",
 			);
-			const confirmed = await confirmForcePush();
-			if (!confirmed) {
-				log.info(TAG, "Create PR force-push declined — aborting");
+			const outcome = await gateForcePush({
+				inspect: () =>
+					inspectForcePushSafety((args) => execGit([...args], cwd), currentBranch),
+			});
+			if (outcome !== "confirmed") {
+				log.info(
+					TAG,
+					outcome === "blocked"
+						? "Create PR push blocked — remote is ahead; rebase first"
+						: "Create PR force-push declined — aborting",
+				);
 				postMessage({ command: "prCreateFailed" });
 				return;
 			}

--- a/vscode/src/util/ForcePushPrompt.test.ts
+++ b/vscode/src/util/ForcePushPrompt.test.ts
@@ -11,8 +11,28 @@ vi.mock("vscode", () => ({
 import {
 	FORCE_PUSH_CONFIRM_LABEL,
 	confirmForcePush,
+	gateForcePush,
 	isNonFastForwardError,
 } from "./ForcePushPrompt.js";
+import { inspectForcePushSafety } from "./ForcePushSafety.js";
+
+/**
+ * Builds a fake GitRunner from a map of `git <args joined by space>` → stdout.
+ * `rev-list --count A..B` lookups read the joined-args key. Unknown commands
+ * (e.g. `fetch origin <branch>`) resolve to "" so the fetch is a no-op success;
+ * a key mapped to the THROW sentinel rejects, exercising the catch path.
+ */
+const THROW = Symbol("throw");
+function fakeGit(table: Record<string, string | typeof THROW>) {
+	return (args: ReadonlyArray<string>): Promise<string> => {
+		const key = args.join(" ");
+		const v = table[key];
+		if (v === THROW) {
+			return Promise.reject(new Error(`git failed: ${key}`));
+		}
+		return Promise.resolve(v ?? "");
+	};
+}
 
 describe("ForcePushPrompt", () => {
 	beforeEach(() => {
@@ -95,6 +115,156 @@ describe("ForcePushPrompt", () => {
 			expect(leadIdx).toBeLessThan(detailIdx);
 			expect(detailIdx).toBeLessThan(reasonIdx);
 			expect(reasonIdx).toBeLessThan(collabIdx);
+		});
+	});
+
+	describe("inspectForcePushSafety", () => {
+		it("returns null for a detached HEAD / empty branch (no remote ref to compare)", async () => {
+			const git = fakeGit({});
+			expect(await inspectForcePushSafety(git, "HEAD")).toBeNull();
+			expect(await inspectForcePushSafety(git, "")).toBeNull();
+		});
+
+		it("flags behind-only when the remote is strictly ahead (rewrite NOT detected)", async () => {
+			const git = fakeGit({
+				"rev-list --count HEAD..origin/feature": "3",
+				"rev-list --count origin/feature..HEAD": "0",
+			});
+			expect(await inspectForcePushSafety(git, "feature")).toEqual({
+				branch: "feature",
+				remoteOnly: 3,
+				localOnly: 0,
+				behindOnly: true,
+			});
+		});
+
+		it("reports a true divergence (both sides have unique commits) without flagging behind-only", async () => {
+			const git = fakeGit({
+				"rev-list --count HEAD..origin/feature": "2",
+				"rev-list --count origin/feature..HEAD": "5",
+			});
+			expect(await inspectForcePushSafety(git, "feature")).toEqual({
+				branch: "feature",
+				remoteOnly: 2,
+				localOnly: 5,
+				behindOnly: false,
+			});
+		});
+
+		it("reports no remote-only commits when local is the superset (pure rewrite)", async () => {
+			const git = fakeGit({
+				"rev-list --count HEAD..origin/feature": "0",
+				"rev-list --count origin/feature..HEAD": "4",
+			});
+			const safety = await inspectForcePushSafety(git, "feature");
+			expect(safety).toMatchObject({ remoteOnly: 0, behindOnly: false });
+		});
+
+		it("returns null when fetch fails (inconclusive → caller keeps prior behavior)", async () => {
+			const git = fakeGit({ "fetch origin feature": THROW });
+			expect(await inspectForcePushSafety(git, "feature")).toBeNull();
+		});
+
+		it("returns null when a rev-list count is non-numeric", async () => {
+			const git = fakeGit({
+				"rev-list --count HEAD..origin/feature": "not-a-number",
+				"rev-list --count origin/feature..HEAD": "0",
+			});
+			expect(await inspectForcePushSafety(git, "feature")).toBeNull();
+		});
+	});
+
+	describe("gateForcePush", () => {
+		it("blocks (no force-push offered) when the branch is merely behind", async () => {
+			const outcome = await gateForcePush({
+				inspect: async () => ({
+					branch: "feature",
+					remoteOnly: 2,
+					localOnly: 0,
+					behindOnly: true,
+				}),
+			});
+			expect(outcome).toBe("blocked");
+			const [message, options] = showWarningMessage.mock.calls[0];
+			expect(message).toContain('Remote branch "feature" has 2 commits');
+			expect(message).toContain("simply behind");
+			expect(options).toEqual({ modal: true });
+			// The force-push confirm button must NOT be offered in the blocked path:
+			// the call has exactly (message, {modal:true}) and no label argument.
+			expect(showWarningMessage.mock.calls[0]).toHaveLength(2);
+		});
+
+		it("appends a lost-commits warning line to the confirm modal on a true divergence", async () => {
+			showWarningMessage.mockResolvedValue(FORCE_PUSH_CONFIRM_LABEL);
+			const outcome = await gateForcePush({
+				inspect: async () => ({
+					branch: "feature",
+					remoteOnly: 2,
+					localOnly: 5,
+					behindOnly: false,
+				}),
+				detailLines: ["Commit: abc123 do a thing"],
+			});
+			expect(outcome).toBe("confirmed");
+			const message = showWarningMessage.mock.calls[0][0] as string;
+			expect(message).toContain("Commit: abc123 do a thing");
+			expect(message).toContain(
+				"this will permanently delete 2 commits that exist only on the remote",
+			);
+		});
+
+		it("falls back to the plain confirm modal when divergence is inconclusive (null)", async () => {
+			showWarningMessage.mockResolvedValue(undefined);
+			const outcome = await gateForcePush({ inspect: async () => null });
+			expect(outcome).toBe("declined");
+			const message = showWarningMessage.mock.calls[0][0] as string;
+			// No lost-commits line when the probe is inconclusive.
+			expect(message).not.toContain("permanently delete");
+		});
+
+		it("uses singular wording when exactly one commit would be lost", async () => {
+			showWarningMessage.mockResolvedValue(FORCE_PUSH_CONFIRM_LABEL);
+			// behindOnly path: blocked message singular.
+			const blocked = await gateForcePush({
+				inspect: async () => ({
+					branch: "feature",
+					remoteOnly: 1,
+					localOnly: 0,
+					behindOnly: true,
+				}),
+			});
+			expect(blocked).toBe("blocked");
+			expect(showWarningMessage.mock.calls[0][0]).toContain(
+				'has 1 commit you don\'t have',
+			);
+			showWarningMessage.mockClear();
+			// diverged path: lost-commits line singular.
+			await gateForcePush({
+				inspect: async () => ({
+					branch: "feature",
+					remoteOnly: 1,
+					localOnly: 2,
+					behindOnly: false,
+				}),
+			});
+			expect(showWarningMessage.mock.calls[0][0]).toContain(
+				"delete 1 commit that exist only on the remote",
+			);
+		});
+
+		it("returns confirmed when no remote-only commits would be lost", async () => {
+			showWarningMessage.mockResolvedValue(FORCE_PUSH_CONFIRM_LABEL);
+			const outcome = await gateForcePush({
+				inspect: async () => ({
+					branch: "feature",
+					remoteOnly: 0,
+					localOnly: 4,
+					behindOnly: false,
+				}),
+			});
+			expect(outcome).toBe("confirmed");
+			const message = showWarningMessage.mock.calls[0][0] as string;
+			expect(message).not.toContain("permanently delete");
 		});
 	});
 });

--- a/vscode/src/util/ForcePushPrompt.ts
+++ b/vscode/src/util/ForcePushPrompt.ts
@@ -17,6 +17,10 @@
  */
 
 import * as vscode from "vscode";
+// The divergence inspection lives in the vscode-free `ForcePushSafety` module so
+// non-UI callers (e.g. JolliMemoryBridge, tested under node) can import it
+// without pulling in `vscode`. The gate below only needs the result shape.
+import type { ForcePushSafety } from "./ForcePushSafety.js";
 
 /** Button label for the modal force-push confirmation. */
 export const FORCE_PUSH_CONFIRM_LABEL = "Force Push (--force-with-lease)";
@@ -27,8 +31,11 @@ const DEFAULT_FORCE_PUSH_REASON =
 
 /**
  * Recognizes git's non-fast-forward push rejection. A normal push emits this
- * when the local branch was rewritten after it was first pushed. Both push
- * entry points classify the same stderr identically through this helper.
+ * both when the local branch was rewritten after it was first pushed (the
+ * force-push case) AND when the branch is merely behind a collaborator's new
+ * remote commits (the rebase case) — git uses the same stderr for both, so this
+ * matcher alone cannot tell them apart. Callers must run `gateForcePush` after
+ * a match to measure the actual divergence before offering a force-push.
  */
 export function isNonFastForwardError(err: unknown): boolean {
 	const message = (
@@ -40,6 +47,65 @@ export function isNonFastForwardError(err: unknown): boolean {
 		message.includes("[rejected]") ||
 		message.includes("tip of your current branch is behind")
 	);
+}
+
+/** Modal warning shown when the branch is merely behind the remote (no force-push offered). */
+export function remoteAheadMessage(branch: string, remoteOnly: number): string {
+	const commits = remoteOnly === 1 ? "commit" : "commits";
+	return [
+		`Remote branch "${branch}" has ${remoteOnly} ${commits} you don't have locally,`,
+		"and your branch has no commits the remote is missing.",
+		"",
+		"This is not a history rewrite — your branch is simply behind. Pull or",
+		"rebase to integrate the remote commits, then push again. Force-pushing",
+		`here would permanently delete those ${remoteOnly} remote ${commits}.`,
+	].join("\n");
+}
+
+/** Detail line appended to the force-push modal when remote-only commits would be lost. */
+export function lostRemoteCommitsLine(remoteOnly: number): string {
+	const commits = remoteOnly === 1 ? "commit" : "commits";
+	return `Warning: this will permanently delete ${remoteOnly} ${commits} that exist only on the remote.`;
+}
+
+/** Result of the post-rejection force-push gate. */
+export type ForcePushOutcome = "confirmed" | "declined" | "blocked";
+
+/**
+ * Post-rejection gate shared by both push entry points. Inspects the divergence,
+ * then either:
+ * - blocks (returns `"blocked"` after a modal warning) when the branch is merely
+ *   behind the remote — force-push is never offered, the user must rebase first;
+ * - shows the shared force-push modal (annotated with the count of remote-only
+ *   commits that will be lost) and returns the user's choice (`"confirmed"` /
+ *   `"declined"`).
+ *
+ * When the divergence can't be measured (inconclusive probe), it falls back to
+ * the plain confirm modal so a legitimate rewrite is never blocked by a transient
+ * git/network failure.
+ */
+export async function gateForcePush(opts: {
+	inspect: () => Promise<ForcePushSafety | null>;
+	detailLines?: ReadonlyArray<string>;
+	reason?: string;
+}): Promise<ForcePushOutcome> {
+	const safety = await opts.inspect();
+	if (safety?.behindOnly) {
+		await vscode.window.showWarningMessage(
+			remoteAheadMessage(safety.branch, safety.remoteOnly),
+			{ modal: true },
+		);
+		return "blocked";
+	}
+	const lostLine =
+		safety && safety.remoteOnly > 0
+			? [lostRemoteCommitsLine(safety.remoteOnly)]
+			: [];
+	const confirmed = await confirmForcePush({
+		detailLines: [...(opts.detailLines ?? []), ...lostLine],
+		reason: opts.reason,
+	});
+	return confirmed ? "confirmed" : "declined";
 }
 
 /**

--- a/vscode/src/util/ForcePushSafety.ts
+++ b/vscode/src/util/ForcePushSafety.ts
@@ -1,0 +1,86 @@
+/**
+ * ForcePushSafety
+ *
+ * Pure (vscode-free) divergence inspection used to gate force-push after a
+ * non-fast-forward rejection. Kept separate from `ForcePushPrompt` — which owns
+ * the vscode modal UI — so non-UI callers (e.g. `JolliMemoryBridge`, which runs
+ * under the node test harness without a `vscode` mock) can import the git logic
+ * without pulling in `vscode`.
+ */
+
+/** Runs a git command (args only — cwd is bound by the caller) and returns stdout. */
+export type GitRunner = (args: ReadonlyArray<string>) => Promise<string>;
+
+/**
+ * How the local branch and its remote-tracking ref diverge after a
+ * non-fast-forward rejection. `remoteOnly` is the count of commits a force-push
+ * would permanently drop; `behindOnly` flags the dangerous "I didn't rewrite
+ * anything, I'm just behind" case where force-push must NOT be offered.
+ */
+export interface ForcePushSafety {
+	readonly branch: string;
+	/** Commits on `origin/<branch>` missing from local HEAD — lost by force-push. */
+	readonly remoteOnly: number;
+	/** Commits on local HEAD missing from `origin/<branch>`. */
+	readonly localOnly: number;
+	/**
+	 * True when the remote is strictly ahead (`remoteOnly > 0 && localOnly === 0`):
+	 * the local branch was not rewritten, it is simply behind. Force-pushing here
+	 * would discard collaborator commits, so callers refuse and ask the user to
+	 * integrate the remote first.
+	 */
+	readonly behindOnly: boolean;
+}
+
+async function countRevs(
+	runGit: GitRunner,
+	range: string,
+): Promise<number | null> {
+	const out = (await runGit(["rev-list", "--count", range])).trim();
+	const n = Number.parseInt(out, 10);
+	return Number.isNaN(n) ? null : n;
+}
+
+/**
+ * After a non-fast-forward rejection, refreshes the branch's remote-tracking ref
+ * and measures how local and remote diverge, so the caller can tell an actual
+ * history rewrite (safe to force-push) apart from a branch that is merely behind
+ * a collaborator's new commits (must rebase, never force).
+ *
+ * The fetch is deliberate: the rejection means the *real* remote has commits the
+ * local branch lacks, but the local `origin/<branch>` ref may be stale, so the
+ * counts would be wrong without first observing the true remote.
+ *
+ * Returns null when the comparison can't be made (detached HEAD, no remote-tracking
+ * ref, git/network error) — the caller then falls back to its existing
+ * confirm-then-force behavior rather than block a legitimate force-push on an
+ * inconclusive probe.
+ */
+export async function inspectForcePushSafety(
+	runGit: GitRunner,
+	branch: string,
+): Promise<ForcePushSafety | null> {
+	if (!branch || branch === "HEAD") {
+		return null;
+	}
+	const remoteRef = `origin/${branch}`;
+	try {
+		// Refresh just this branch's tracking ref so the counts reflect the true
+		// remote. A failure here (network, no such remote branch) falls through to
+		// the catch and yields null → caller keeps its prior behavior.
+		await runGit(["fetch", "origin", branch]);
+		const remoteOnly = await countRevs(runGit, `HEAD..${remoteRef}`);
+		const localOnly = await countRevs(runGit, `${remoteRef}..HEAD`);
+		if (remoteOnly === null || localOnly === null) {
+			return null;
+		}
+		return {
+			branch,
+			remoteOnly,
+			localOnly,
+			behindOnly: remoteOnly > 0 && localOnly === 0,
+		};
+	} catch {
+		return null;
+	}
+}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The Push Branch and Create PR flows previously offered a force-push option whenever git rejected a push as non-fast-forward, treating every rejection as evidence of a local history rewrite. This meant that if a collaborator had pushed new commits to the same branch, a user could silently overwrite that work — the safety check had no awareness of whether the local branch had actually diverged or was simply behind.

A divergence gate now runs before any force-push option is presented. After a rejection, the extension fetches the latest remote state and counts commits in both directions. If the local branch has no unique commits and the remote is strictly ahead, the force-push option is never shown — the user sees a blocking warning directing them to integrate the remote commits first. If both sides have genuinely diverged, the confirmation dialog now states explicitly how many remote commits would be permanently deleted, giving the user the information needed to make an informed choice. If the check cannot complete due to a network or git error, the original confirmation dialog appears unchanged, preserving the existing experience for legitimate rewrites.

Critically, this protection now covers every path that can reach a force-push. An earlier gap existed in the Push Branch button's pre-warning flow, which bypassed divergence inspection entirely and would proceed to a force-push confirmation even when the branch was purely behind the remote. Both entry points — the pre-warning path and the non-fast-forward fallback — now share a single gate, and a regression test locks in the behavior for the previously unguarded purely-behind scenario.

---

## Topic (1)
<details>
<summary><strong>01 · Block force-push when branch is only behind or diverged from remote</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Push Branch and Create PR flows offered a force-push option whenever git rejected a push as non-fast-forward, regardless of whether the local branch had actually been rewritten. If a collaborator had pushed new commits to the same branch, accepting the force-push would permanently overwrite their work with no warning.

**💡 Decisions Behind the Code**

- **Separate pure module over embedding git logic in the UI module**: The divergence inspection logic was placed in a dedicated file with no vscode dependency rather than inside the existing force-push prompt module. The bridge layer is imported by Node-environment tests that have no vscode mock, so mixing UI and git logic would have broken those tests. Splitting the modules keeps each concern independently testable and avoids a transitive vscode dependency in non-UI callers.
- **Fallback to plain confirmation on inconclusive probe**: When the git fetch or rev-list commands fail, the gate returns null and the caller falls back to the original confirmation modal rather than blocking the push entirely. This preserves pre-existing behavior for legitimate force-push scenarios where divergence simply cannot be measured, trading a small residual risk for never blocking a valid operation on a transient failure.
- **Unify both push entry points through one gate rather than patching the pre-warning path in isolation**: The pre-warning path and the non-fast-forward fallback path had diverged in behavior — one checked divergence, one did not. Merging them into a single private helper eliminates the risk of the two paths drifting apart again and makes the safety invariant enforceable in one place. The trade-off is a slightly larger refactor than a minimal patch, but the safety guarantee is stronger.
- **Remove the simple confirmation dialog entirely from the push command**: Keeping both the old confirmation dialog and the new gate available would leave a tempting shortcut for future callers to bypass the divergence check. Removing the import makes the unsafe path unavailable within the file, so any new force-push entry point must go through the gate.
- **`--force-with-lease` role clarified, not removed**: A review concern was raised that the gate's own fetch advances the bare lease reference, neutering it as a safety net. After verification, the conclusion was that the lease still protects against a collaborator pushing again during the confirmation modal window — the gate covers the pre-fetch divergence and the lease covers the post-fetch race. The existing lease mechanism was kept intact; only the comments describing its role were updated to reflect that the gate is now the primary guard.

**✅ What Was Implemented**

- A new vscode-free module (`vscode/src/util/ForcePushSafety.ts`) was introduced containing `inspectForcePushSafety`, which runs `git fetch` then counts commits in both directions between local HEAD and the remote-tracking ref. It returns a structured result indicating how many remote-only commits would be lost and whether the branch is purely behind (no local-only commits). Keeping this logic in a separate file with no vscode dependency allows the bridge layer — which runs under a Node test harness without a vscode mock — to import it cleanly.
- `gateForcePush` was added to `vscode/src/util/ForcePushPrompt.ts` as the shared decision point for both push entry points. It calls the inspector and branches on three outcomes: if the branch is purely behind, it shows a modal warning with no force-push button and returns a blocked result; if there is a true divergence, it appends a "will permanently delete N remote commits" line to the existing confirmation modal; if the probe is inconclusive (fetch failure, detached HEAD, no remote-tracking ref), it falls back to the original plain confirmation modal so a legitimate rewrite is never blocked by a transient failure.
- `vscode/src/commands/PushCommand.ts` was refactored so that both force-push entry points — the "HEAD already pushed" pre-warning path and the non-fast-forward fallback path — route through a single private `runForcePushGate` helper. The pre-warning path previously called a simple confirmation dialog that skipped divergence inspection entirely; it now uses the same gate. The `confirmForcePush` import was removed from `PushCommand.ts` entirely, making the unsafe bypass path unavailable within the file. A `headDetailLine` private helper was also extracted to eliminate a byte-for-byte duplication between the two call sites.
- `vscode/src/services/PrCommentService.ts` (Create PR) was wired through `gateForcePush`, replacing its direct call to the old confirmation dialog.
- A regression test was added to `PushCommand.test.ts` covering the previously unguarded purely-behind path: when the remote is strictly ahead and the local branch has no unique commits, the gate blocks the push, no force-push is issued, and the correct log message is recorded.

**📁 FILES**
- `vscode/src/util/ForcePushSafety.ts`
- `vscode/src/util/ForcePushPrompt.ts`
- `vscode/src/commands/PushCommand.ts`
- `vscode/src/services/PrCommentService.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 29, 2026 at 5:59 PM · via Anthropic*
<!-- jollimemory-summary-end -->