### PR TITLE
Add Codex session resume support with correct session ID lookup

### DIFF
--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/CodexSessionDiscoverer.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/CodexSessionDiscoverer.kt
@@ -1,5 +1,6 @@
 package ai.jolli.jollimemory.core
 
+import com.google.gson.JsonParser
 import java.io.File
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -36,7 +37,11 @@ object CodexSessionDiscoverer {
 
             val files = dayDir.listFiles { f -> f.extension == "jsonl" } ?: continue
             for (file in files) {
-                val sessionId = file.nameWithoutExtension
+                // The resumable session id is `payload.id` (a UUID) from the file's
+                // first `session_meta` line — NOT the rollout filename. `codex resume
+                // <id>` rejects the filename form. Fall back to the filename only when
+                // the meta line can't be parsed, so the conversation still appears.
+                val sessionId = readSessionId(file) ?: file.nameWithoutExtension
                 sessions.add(SessionInfo(
                     sessionId = sessionId,
                     transcriptPath = file.absolutePath,
@@ -48,5 +53,26 @@ object CodexSessionDiscoverer {
 
         log.info("Discovered %d Codex session(s)", sessions.size)
         return sessions
+    }
+
+    /**
+     * Reads the resumable session id from a Codex rollout file's first line
+     * (`session_meta`): `payload.id`, falling back to `payload.session_id`.
+     * Returns null when the line isn't valid session_meta — this is the UUID
+     * `codex resume` expects, distinct from the rollout filename.
+     */
+    private fun readSessionId(file: File): String? {
+        return try {
+            val firstLine = file.bufferedReader().use { it.readLine() } ?: return null
+            val obj = JsonParser.parseString(firstLine).asJsonObject
+            if (obj.get("type")?.asString != "session_meta") return null
+            val payload = obj.getAsJsonObject("payload") ?: return null
+            val id = payload.get("id")?.takeIf { !it.isJsonNull }?.asString
+                ?: payload.get("session_id")?.takeIf { !it.isJsonNull }?.asString
+            id?.takeIf { it.isNotBlank() }
+        } catch (e: Exception) {
+            log.debug("Failed to read Codex session_id from %s: %s", file.name, e.message)
+            null
+        }
     }
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActiveConversationsPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActiveConversationsPanel.kt
@@ -163,9 +163,9 @@ class ActiveConversationsPanel(
 	}
 
 	private fun onResume(item: ActiveConversationItem) {
-		if (item.source != TranscriptSource.claude) return
+		if (!TerminalUtils.canResumeSource(item.source.name)) return
 		val cwd = service.mainRepoRoot ?: project.basePath ?: return
-		TerminalUtils.resumeClaudeSession(project, item.sessionId, cwd, "Claude – ${item.title}")
+		TerminalUtils.resumeSession(project, item.source.name, item.sessionId, cwd, item.title)
 	}
 
 	private fun onSelectionChanged(item: ActiveConversationItem, selected: Boolean) {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
@@ -1058,12 +1058,12 @@ class CommitsPanel(
         // Hover actions (hidden until hover): Open conversation · Resume (only if local session exists).
         val openBtn = convoActionIcon(JolliMemoryIcons.Eye, "Open conversation") { _ -> openCommittedConversation(c) }
         val fileExists = !c.transcriptPath.isNullOrBlank() && File(c.transcriptPath).exists()
-        val canResume = c.source == "claude" && fileExists
+        val canResume = TerminalUtils.canResumeSource(c.source) && fileExists
         log.info("conversationRow: source=${c.source}, sessionId=${c.sessionId}, transcriptPath=${c.transcriptPath}, fileExists=$fileExists, canResume=$canResume")
         val actions = if (canResume) {
             val continueBtn = convoActionIcon(AllIcons.Actions.Execute, "Resume session in terminal") { _ ->
                 log.info("continueBtn clicked: sessionId=${c.sessionId}, commitHash=${commit.hash}")
-                resumeInTerminal(c.sessionId)
+                resumeInTerminal(c.source, c.sessionId)
             }
             listOf(openBtn, continueBtn)
         } else {
@@ -1528,12 +1528,12 @@ class CommitsPanel(
 
     // ─── Resume session ──────────────────────────────────────────────────────
 
-    /** Opens a new terminal tab and runs `claude --resume <sessionId>`. */
-    private fun resumeInTerminal(sessionId: String) {
+    /** Opens a new terminal tab and runs the source-appropriate resume command. */
+    private fun resumeInTerminal(source: String, sessionId: String) {
         val cwd = service.mainRepoRoot ?: project.basePath
-        log.info("resumeInTerminal: sessionId=$sessionId, cwd=$cwd")
+        log.info("resumeInTerminal: source=$source, sessionId=$sessionId, cwd=$cwd")
         if (cwd == null) return
-        TerminalUtils.resumeClaudeSession(project, sessionId, cwd)
+        TerminalUtils.resumeSession(project, source, sessionId, cwd)
     }
 
     // ─── Copy recall prompt ──────────────────────────────────────────────────

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt
@@ -122,7 +122,7 @@ class PinnedPanel(
 		left.add(title)
 		row.add(left, BorderLayout.CENTER)
 
-		// Hover actions, right edge: Open (eye) · Resume (play, Claude only) · Unpin.
+		// Hover actions, right edge: Open (eye) · Resume (play, Claude/Codex only) · Unpin.
 		val openBtn = actionIcon(JolliMemoryIcons.Eye, "Open") { openPinned(entry) }
 		val unpinBtn = actionIcon(AllIcons.Actions.Close, "Unpin") {
 			val dir = cwd() ?: return@actionIcon
@@ -131,7 +131,7 @@ class PinnedPanel(
 				refresh()
 			}
 		}
-		val canResume = entry.kind == "conversations" && entry.badge.lowercase() == "claude"
+		val canResume = entry.kind == "conversations" && TerminalUtils.canResumeSource(entry.badge)
 		val actions = if (canResume) {
 			val resumeBtn = actionIcon(AllIcons.Actions.Execute, "Resume session in terminal") { resumeInTerminal(entry) }
 			listOf(openBtn, resumeBtn, unpinBtn)
@@ -184,12 +184,12 @@ class PinnedPanel(
 		})
 	}
 
-	/** Resume a pinned Claude conversation directly in terminal. */
+	/** Resume a pinned conversation directly in terminal (Claude or Codex). */
 	private fun resumeInTerminal(entry: PinStore.PinnedEntry) {
 		val cwd = cwd() ?: return
 		val sessionId = entry.key.substringAfter(":")
 		if (sessionId.isNotBlank()) {
-			TerminalUtils.resumeClaudeSession(project, sessionId, cwd, "Claude – ${entry.title}")
+			TerminalUtils.resumeSession(project, entry.badge, sessionId, cwd, entry.title)
 		}
 	}
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/TerminalUtils.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/TerminalUtils.kt
@@ -12,12 +12,33 @@ object TerminalUtils {
 
 	private val log = Logger.getInstance(TerminalUtils::class.java)
 
-	/** Opens a new terminal tab in the given [cwd] and runs `claude --resume <sessionId>`. */
-	fun resumeClaudeSession(project: Project, sessionId: String, cwd: String, title: String = "Claude – resume") {
+	/** Whether [source] supports resuming a session from the terminal. */
+	fun canResumeSource(source: String): Boolean = source.lowercase() in setOf("claude", "codex")
+
+	/**
+	 * Opens a new terminal tab in the given [cwd] and runs the source-appropriate
+	 * resume command: `claude --resume <id>` for Claude, `codex resume <id>` for
+	 * Codex. Unsupported sources are a no-op (a warning notification).
+	 */
+	fun resumeSession(project: Project, source: String, sessionId: String, cwd: String, title: String? = null) {
+		val src = source.lowercase()
+		val command = when (src) {
+			"codex" -> "codex resume $sessionId"
+			"claude" -> "claude --resume $sessionId"
+			else -> {
+				log.warn("Resume requested for unsupported source: $source")
+				Notifications.Bus.notify(
+					Notification("JolliMemory", "Resume Session", "Resuming isn't supported for this conversation type.", NotificationType.WARNING),
+					project,
+				)
+				return
+			}
+		}
+		val tabTitle = title ?: if (src == "codex") "Codex – resume" else "Claude – resume"
 		try {
 			val widget = TerminalToolWindowManager.getInstance(project)
-				.createLocalShellWidget(cwd, title)
-			widget.executeCommand("claude --resume $sessionId")
+				.createLocalShellWidget(cwd, tabTitle)
+			widget.executeCommand(command)
 		} catch (e: Exception) {
 			log.warn("Failed to open terminal for session resume: ${e.message}", e)
 			Notifications.Bus.notify(


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Resuming a Codex conversation from the IntelliJ plugin now works end-to-end. Two separate problems had to be solved together to make this happen. First, the plugin was constructing the wrong identifier to hand to the resume command: Codex writes session files to disk with names that include a timestamp prefix, and the plugin was using that filename directly. The correct identifier is stored inside the file itself, and the plugin now reads it from there, matching the behavior the VS Code version of the same feature has always used. Sessions whose files cannot be read still appear in the Active Conversations list using the filename as a fallback, so no conversations silently disappear.

Second, the resume button itself was wired only for Claude sessions. The plugin now recognizes Codex sessions as resumable and launches the correct terminal command for each tool. This applies consistently across the committed memories list, the active conversations panel, and the pinned conversations panel. The logic for deciding whether a session can be resumed lives in a single shared location, so all three panels stay in sync automatically.

---

## E2E Test (3)
<details>
<summary><strong>1. Codex session resume from Active Conversations panel</strong></summary>
<br>
<blockquote>

**Preconditions:** At least one Codex conversation must appear in the Active Conversations panel (i.e. a Codex session file exists on disk that the plugin has already discovered).

**Steps:**
1. Open IntelliJ and click on the Jolli Memory tool window to open it.
2. Navigate to the Active Conversations panel.
3. Find a conversation listed with a "Codex" badge or label.
4. Hover over that conversation row to reveal the action buttons on the right side.
5. Click the play/resume button (the triangle "Execute" icon) for that Codex conversation.
6. Check that a new terminal tab opens and watch for a command to run automatically.

**Expected Results:**
- A new terminal tab opens inside IntelliJ.
- The terminal automatically runs a command beginning with "codex resume" followed by a session ID (a string of letters and numbers).
- The terminal does not show an error saying the session could not be found.
- The tab title reflects the conversation name (not "Claude – resume").

</blockquote>
</details>
<details>
<summary><strong>2. Codex session resume from Pinned panel</strong></summary>
<br>
<blockquote>

**Preconditions:** At least one Codex conversation must be pinned in the Pinned panel.

**Steps:**
1. Open the Jolli Memory tool window and navigate to the Pinned panel.
2. Find a pinned item that shows a "Codex" badge.
3. Hover over that pinned item to reveal the action icons on the right.
4. Click the play/resume (Execute) icon next to the Codex pinned conversation.
5. Watch the terminal that opens.

**Expected Results:**
- A new terminal tab opens.
- The terminal runs "codex resume" followed by a valid session ID — not a filename or a "claude" command.
- No error or warning notification appears saying resuming is unsupported.

</blockquote>
</details>
<details>
<summary><strong>3. Unsupported source shows warning instead of crashing on resume</strong></summary>
<br>
<blockquote>

**Preconditions:** A conversation from a source other than Claude or Codex (for example, a "GPT" or unknown-badge entry) must be visible in any panel that shows a resume button, OR you can temporarily pin such an entry if one exists.

**Steps:**
1. Open the Jolli Memory tool window.
2. Locate a conversation whose badge or source label is neither "Claude" nor "Codex".
3. Attempt to trigger a resume action on it (hover and click the play icon if it appears, or note whether the button is hidden entirely).
4. If a resume button is visible and clickable, click it and observe what happens.

**Expected Results:**
- Either the resume button does not appear at all for unsupported sources (preferred), OR if it is somehow triggered, a warning notification pops up saying resuming is not supported for this conversation type.
- No terminal tab opens, and the app does not crash or freeze.

</blockquote>
</details>

---

## Topics (2)
<details>
<summary><strong>01 · Fix Codex session resume by reading true identifier from session file</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Resuming a Codex conversation from the IntelliJ plugin failed with an error saying no saved session could be found. The identifier the plugin was passing to the resume command did not match what the command expected.

**💡 Decisions Behind the Code**

- **Read the file rather than trust the filename**: The rollout filenames Codex writes to disk embed a timestamp prefix and are not the identifiers the resume command accepts. The TypeScript VS Code implementation already opened each file to read the correct identifier; the Kotlin port had skipped that step. Aligning with the existing TypeScript behavior was the natural fix, and the data was always present in the file.
- **Fall back to filename rather than skip unreadable sessions**: The TypeScript version skips a session entirely when the metadata line cannot be parsed. The Kotlin fix instead falls back to the filename so the conversation still appears in the Active Conversations list even if it cannot be resumed. A session that shows up but fails on resume is more informative to the user than one that silently disappears, and the conversation content remains viewable either way.
- **Defer cwd-match and staleness filtering**: The TypeScript discoverer also filters sessions by working directory and drops sessions older than 48 hours; the Kotlin port does neither. These gaps were identified during the session but left as follow-up work to keep this change narrowly focused on the resume-breaking bug.

**✅ What Was Implemented**

- `CodexSessionDiscoverer.kt` was updated to open each Codex session file and read the true resumable identifier from the first line of metadata (`payload.id`, with a `payload.session_id` fallback), mirroring the approach already used by the VS Code version of the same discoverer. The filename-derived value is now only used as a last resort when the metadata line cannot be parsed.
- A new private `readSessionId` helper was added to encapsulate the JSON parsing, null-safety checks, and exception handling, keeping the main discovery loop clean.

**📋 Future Enhancements**

- Add working-directory filtering to the Codex session discoverer so it only returns sessions belonging to the current project, matching the TypeScript implementation (currently returns sessions from all projects).
- Revisit parse-failure behavior: consider skipping unreadable sessions entirely to fully match the TypeScript version, rather than falling back to the filename.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/CodexSessionDiscoverer.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Extend session resume support to Codex across all plugin panels</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The IntelliJ plugin's resume button only worked for Claude sessions. Developers using Codex had no way to continue a conversation from within the plugin.

**💡 Decisions Behind the Code**

- **Centralizing the supported-source check in one helper**: Rather than duplicating the list of resumable sources across three panels, a single helper in `TerminalUtils` owns the allowed-source list. This keeps all three call sites thin and means adding support for a third AI tool in the future requires touching only one location.
- **Reusing the existing file-existence gate for Codex**: The team considered building a more accurate check that also looks in Codex's archive directory, but chose to reuse the same file-existence check already used for Claude. The archived-session case produces a false negative (button hidden for a session that could still be resumed), but this failure mode is rare, consistent with Claude's behavior, and fails safely — no broken action, just a hidden button.
- **Threading source through call sites rather than inferring it**: The `source` value is passed explicitly from each panel into `TerminalUtils` rather than being inferred inside the utility from the session ID format or other heuristics. This keeps the command-building logic straightforward and avoids fragile pattern-matching on identifiers that could change across CLI versions.

**✅ What Was Implemented**

- `TerminalUtils.kt` was refactored from a Claude-specific `resumeClaudeSession` function into a source-agnostic `resumeSession` function that accepts a `source` parameter and branches on it: Codex sessions run `codex resume <id>` while Claude sessions run `claude --resume <id>`. A `canResumeSource` helper was added to centralize the supported-source check, and unsupported sources produce a warning notification instead of silently failing.
- `CommitsPanel.kt` was updated from a hardcoded Claude-only check to use the new `canResumeSource` helper, and its internal resume helper was updated to pass `source` through to `TerminalUtils.resumeSession`.
- `ActiveConversationsPanel.kt` and `PinnedPanel.kt` received the same gate-widening and call-site updates. `PinnedPanel` derives source from `entry.badge` and extracts the session ID via `entry.key.substringAfter(":")`, which works cleanly for Codex's `codex:<uuid>` key format.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/TerminalUtils.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActiveConversationsPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt`

</blockquote>
</details>

---

*Generated by Jolli Memory · June 29, 2026 at 4:55 PM · via Anthropic*
<!-- jollimemory-summary-end -->