### PR TITLE
Add backfill command and engine for historical commit summarization

### DIFF
--- a/cli/src/Api.ts
+++ b/cli/src/Api.ts
@@ -9,6 +9,7 @@
 
 import { Command, Help } from "commander";
 import { registerAuthCommands } from "./commands/AuthCommand.js";
+import { registerBackfillCommand } from "./commands/BackfillCommand.js";
 import { registerCleanCommand } from "./commands/CleanCommand.js";
 import { checkVersionMismatch, VERSION } from "./commands/CliUtils.js";
 import { registerCompileCommand } from "./commands/CompileCommand.js";
@@ -157,6 +158,7 @@ const MEMORY_COMMAND_NAMES = new Set([
 	"view",
 	"recall",
 	"search",
+	"backfill",
 	"pr-description",
 	"compile",
 	"graph",
@@ -333,6 +335,7 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 	registerViewCommand(program);
 	registerRecallCommand(program);
 	registerSearchCommand(program);
+	registerBackfillCommand(program);
 	registerPrDescriptionCommand(program);
 	registerCompileCommand(program);
 	registerGraphCommand(program);

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -486,6 +486,29 @@ export interface CommitSummary {
 	 * Release N keeps reading legacy data; Release N+M will make it required.
 	 */
 	readonly transcripts?: ReadonlyArray<string>;
+	/**
+	 * Marks a summary produced by the historical back-fill flow (`jolli backfill`
+	 * / enable-time catch-up) rather than the live post-commit pipeline. The
+	 * back-fill flow is fully isolated from QueueWorker: it reconstructs the
+	 * conversation by attributing on-disk Claude transcripts to historical
+	 * commits offline. Absent on summaries written by the live pipeline.
+	 */
+	readonly backfilled?: boolean;
+	/**
+	 * Confidence of the back-fill conversation attribution. "high" = an edited
+	 * file in the attributed conversation matches this commit's diff
+	 * (file-orthogonality anchor). "medium" = time-window / branch match only.
+	 * Absent when no conversation was confidently attributed (a `diff-only`
+	 * summary). Only meaningful when `backfilled`.
+	 */
+	readonly backfillConfidence?: "high" | "medium";
+	/**
+	 * Which back-fill signal produced this summary. `file-overlap` / `time-window`
+	 * mean a conversation was attributed; `diff-only` means no conversation was
+	 * confidently found, so the summary was generated from the git diff alone
+	 * (mirrors the live pipeline's no-session path). Only meaningful when `backfilled`.
+	 */
+	readonly backfillMethod?: "file-overlap" | "time-window" | "diff-only";
 }
 
 /** A single E2E test scenario for one feature or bug fix */

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -495,20 +495,22 @@ export interface CommitSummary {
 	 */
 	readonly backfilled?: boolean;
 	/**
-	 * Confidence of the back-fill conversation attribution. "high" = an edited
-	 * file in the attributed conversation matches this commit's diff
-	 * (file-orthogonality anchor). "medium" = time-window / branch match only.
-	 * Absent when no conversation was confidently attributed (a `diff-only`
-	 * summary). Only meaningful when `backfilled`.
+	 * Confidence of the back-fill conversation attribution — the *weakest* tier of
+	 * the turns actually included (so a badge never overclaims). "high" = a turn's
+	 * segment edited a file in this commit's diff (file-orthogonality anchor);
+	 * "medium" = matched by effective branch only; "low" = pure time-window (e.g.
+	 * planning on main). Absent when no conversation was attributed (`diff-only`).
+	 * Only meaningful when `backfilled`.
 	 */
-	readonly backfillConfidence?: "high" | "medium";
+	readonly backfillConfidence?: "high" | "medium" | "low";
 	/**
-	 * Which back-fill signal produced this summary. `file-overlap` / `time-window`
-	 * mean a conversation was attributed; `diff-only` means no conversation was
-	 * confidently found, so the summary was generated from the git diff alone
-	 * (mirrors the live pipeline's no-session path). Only meaningful when `backfilled`.
+	 * Which back-fill signal produced this summary. `file-overlap` (HIGH) /
+	 * `branch-match` (MEDIUM) / `time-window` (LOW) mean a conversation was
+	 * attributed; `diff-only` means no conversation was confidently found, so the
+	 * summary was generated from the git diff alone (mirrors the live pipeline's
+	 * no-session path). Only meaningful when `backfilled`.
 	 */
-	readonly backfillMethod?: "file-overlap" | "time-window" | "diff-only";
+	readonly backfillMethod?: "file-overlap" | "branch-match" | "time-window" | "diff-only";
 }
 
 /** A single E2E test scenario for one feature or bug fix */

--- a/cli/src/backfill/BackfillEngine.test.ts
+++ b/cli/src/backfill/BackfillEngine.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks (hoisted) ──────────────────────────────────────────────────────────
+vi.mock("../core/StorageFactory.js", () => ({
+	createStorage: vi.fn().mockResolvedValue({ id: "store" }),
+}));
+vi.mock("../core/SummaryStore.js", () => ({
+	getIndexEntryMap: vi.fn(),
+	setActiveStorage: vi.fn(),
+	storeSummary: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../core/Summarizer.js", () => ({
+	generateSummary: vi.fn(),
+}));
+vi.mock("../core/SessionTracker.js", () => ({
+	loadConfig: vi.fn(),
+}));
+vi.mock("../core/GitOps.js", () => ({
+	execGit: vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" }),
+	getCommitInfo: vi.fn().mockResolvedValue({ hash: "h", message: "m", author: "a", date: "2026-06-01" }),
+	getDiffContent: vi.fn().mockResolvedValue("diff"),
+	getDiffStats: vi.fn().mockResolvedValue({ filesChanged: 1, insertions: 2, deletions: 0 }),
+	getCurrentBranch: vi.fn().mockResolvedValue("main"),
+}));
+vi.mock("../core/TranscriptReader.js", () => ({
+	buildMultiSessionContext: vi.fn().mockReturnValue("conversation"),
+}));
+vi.mock("./RawTranscriptScanner.js", () => ({
+	scanClaudeTranscripts: vi.fn().mockResolvedValue(new Map()),
+	cwdInRoots: vi.fn().mockReturnValue(() => true),
+}));
+vi.mock("./CommitTargetIndex.js", () => ({
+	buildCommitTargetIndex: vi.fn().mockResolvedValue({
+		commitMeta: new Map(),
+		fileToCommits: new Map(),
+		baseToCommits: new Map(),
+	}),
+}));
+vi.mock("./CommitAttributor.js", () => ({
+	attributeCommits: vi.fn(),
+}));
+vi.mock("../core/IngestTrigger.js", () => ({
+	enqueueIngestOperation: vi.fn().mockResolvedValue(true),
+}));
+vi.mock("../hooks/QueueWorker.js", () => ({
+	launchWorker: vi.fn(),
+}));
+
+import { getCurrentBranch } from "../core/GitOps.js";
+import { enqueueIngestOperation } from "../core/IngestTrigger.js";
+import { loadConfig } from "../core/SessionTracker.js";
+import { generateSummary } from "../core/Summarizer.js";
+import { getIndexEntryMap, storeSummary } from "../core/SummaryStore.js";
+import { launchWorker } from "../hooks/QueueWorker.js";
+import { countMissingSummaries, runBackfill } from "./BackfillEngine.js";
+import { attributeCommits } from "./CommitAttributor.js";
+
+const CWD = "e:/repo";
+
+function attrFor(hash: string, confidence: "high" | "medium" = "high") {
+	return {
+		commitHash: hash,
+		confidence,
+		method: confidence === "high" ? ("file-overlap" as const) : ("time-window" as const),
+		branch: "feat",
+		sessions: [
+			{
+				sessionId: "S1",
+				transcriptPath: "/p/S1.jsonl",
+				source: "claude" as const,
+				entries: [{ role: "human" as const, content: "hi" }],
+			},
+		],
+		transcriptEntries: 1,
+		conversationTurns: 1,
+	};
+}
+
+const summaryResult = {
+	transcriptEntries: 1,
+	conversationTurns: 1,
+	llm: { model: "m", inputTokens: 1, outputTokens: 1, apiLatencyMs: 1, stopReason: "end_turn" },
+	stats: { filesChanged: 1, insertions: 2, deletions: 0 },
+	topics: [{ title: "T", trigger: "x", response: "y", decisions: "z" }],
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(getIndexEntryMap).mockResolvedValue(new Map());
+	vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-ant-test" } as never);
+	vi.mocked(generateSummary).mockResolvedValue(summaryResult as never);
+	vi.mocked(getCurrentBranch).mockResolvedValue("main");
+});
+afterEach(() => {
+	delete process.env.ANTHROPIC_API_KEY;
+});
+
+describe("runBackfill", () => {
+	it("generates a summary for an attributed commit and triggers ONE ingest after the batch", async () => {
+		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map([["c1", attrFor("c1")]]), skipped: [] });
+
+		const report = await runBackfill({ cwd: CWD, hashes: ["c1"] });
+
+		expect(report.generated).toBe(1);
+		expect(vi.mocked(storeSummary)).toHaveBeenCalledTimes(1);
+		const stored = vi.mocked(storeSummary).mock.calls[0][0];
+		expect(stored.backfilled).toBe(true);
+		expect(stored.backfillConfidence).toBe("high");
+		expect(stored.backfillMethod).toBe("file-overlap");
+		expect(stored.branch).toBe("feat");
+		// Exactly one ingest trigger for the whole batch.
+		expect(vi.mocked(enqueueIngestOperation)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(launchWorker)).toHaveBeenCalledTimes(1);
+	});
+
+	it("dry-run reports would-generate without calling the LLM or triggering ingest", async () => {
+		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map([["c1", attrFor("c1")]]), skipped: [] });
+
+		const report = await runBackfill({ cwd: CWD, hashes: ["c1"], dryRun: true });
+
+		expect(report.outcomes[0].status).toBe("would-generate");
+		expect(vi.mocked(generateSummary)).not.toHaveBeenCalled();
+		expect(vi.mocked(enqueueIngestOperation)).not.toHaveBeenCalled();
+		expect(vi.mocked(launchWorker)).not.toHaveBeenCalled();
+	});
+
+	it("skips commits that already have a summary", async () => {
+		vi.mocked(getIndexEntryMap).mockResolvedValue(new Map([["c1", {} as never]]));
+		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map(), skipped: [] });
+
+		const report = await runBackfill({ cwd: CWD, hashes: ["c1"] });
+		expect(report.outcomes[0].status).toBe("skipped-has-summary");
+		// All candidates already summarized → no attribution / ingest at all.
+		expect(vi.mocked(attributeCommits)).not.toHaveBeenCalled();
+	});
+
+	it("generates a diff-only summary when no conversation is attributed (mirrors live no-session path)", async () => {
+		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map(), skipped: ["c1"] });
+		const report = await runBackfill({ cwd: CWD, hashes: ["c1"] });
+		expect(report.outcomes[0].status).toBe("generated");
+		expect(report.outcomes[0].method).toBe("diff-only");
+		expect(report.generated).toBe(1);
+		const stored = vi.mocked(storeSummary).mock.calls[0][0];
+		expect(stored.backfilled).toBe(true);
+		expect(stored.backfillMethod).toBe("diff-only");
+		expect(stored.backfillConfidence).toBeUndefined();
+		expect(stored.transcripts).toBeUndefined(); // no transcript artifact for diff-only
+		// No transcript artifact passed to storeSummary.
+		expect(vi.mocked(storeSummary).mock.calls[0][3]).toBeUndefined();
+		// Diff-only summaries still count as generated → ingest fires once.
+		expect(vi.mocked(enqueueIngestOperation)).toHaveBeenCalledTimes(1);
+	});
+
+	it("errors (not throws) when no LLM credentials are configured", async () => {
+		vi.mocked(loadConfig).mockResolvedValue({} as never);
+		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map([["c1", attrFor("c1")]]), skipped: [] });
+		const report = await runBackfill({ cwd: CWD, hashes: ["c1"] });
+		expect(report.errors).toBe(1);
+		expect(report.outcomes[0].message).toMatch(/credentials/);
+		expect(vi.mocked(generateSummary)).not.toHaveBeenCalled();
+	});
+
+	it("turns a per-commit LLM failure into an error outcome and keeps going", async () => {
+		vi.mocked(attributeCommits).mockReturnValue({
+			attributed: new Map([
+				["c1", attrFor("c1")],
+				["c2", attrFor("c2")],
+			]),
+			skipped: [],
+		});
+		vi.mocked(generateSummary)
+			.mockRejectedValueOnce(new Error("boom"))
+			.mockResolvedValueOnce(summaryResult as never);
+
+		const report = await runBackfill({ cwd: CWD, hashes: ["c1", "c2"], onProgress: vi.fn() });
+		expect(report.errors).toBe(1);
+		expect(report.generated).toBe(1);
+		// One generated → ingest still fires once.
+		expect(vi.mocked(launchWorker)).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls back to the current branch when attribution has no branch", async () => {
+		const a = { ...attrFor("c1"), branch: "" };
+		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map([["c1", a]]), skipped: [] });
+		await runBackfill({ cwd: CWD, hashes: ["c1"] });
+		expect(vi.mocked(storeSummary).mock.calls[0][0].branch).toBe("main");
+	});
+
+	it("discovers worktree roots and tolerates a failed tree-hash lookup", async () => {
+		const { execGit } = await import("../core/GitOps.js");
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			if (args[0] === "worktree")
+				return { exitCode: 0, stdout: "worktree e:/repo\nworktree e:/repo-wt2\n", stderr: "" } as never;
+			if (args[0] === "rev-parse") return { exitCode: 1, stdout: "", stderr: "bad" } as never; // tree lookup fails
+			return { exitCode: 0, stdout: "", stderr: "" } as never;
+		});
+		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map([["c1", attrFor("c1")]]), skipped: [] });
+		await runBackfill({ cwd: CWD, hashes: ["c1"] });
+		const stored = vi.mocked(storeSummary).mock.calls[0][0];
+		expect(stored.treeHash).toBeUndefined(); // rev-parse failed → no treeHash
+	});
+
+	it("dry-run reports diff-only would-generate when no conversation is attributed", async () => {
+		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map(), skipped: ["c1"] });
+		const report = await runBackfill({ cwd: CWD, hashes: ["c1"], dryRun: true });
+		expect(report.outcomes[0].status).toBe("would-generate");
+		expect(report.outcomes[0].method).toBe("diff-only");
+		expect(report.outcomes[0].confidence).toBeUndefined();
+	});
+
+	it("stamps treeHash, ticketId, and recap; tolerates getCurrentBranch failure", async () => {
+		const { execGit, getCurrentBranch } = await import("../core/GitOps.js");
+		vi.mocked(getCurrentBranch).mockRejectedValue(new Error("detached"));
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			if (args[0] === "rev-parse") return { exitCode: 0, stdout: "treeSHA123", stderr: "" } as never;
+			return { exitCode: 0, stdout: "", stderr: "" } as never;
+		});
+		vi.mocked(generateSummary).mockResolvedValue({
+			...summaryResult,
+			ticketId: "JOLLI-9",
+			recap: "did stuff",
+		} as never);
+		const a = { ...attrFor("c1"), branch: "" };
+		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map([["c1", a]]), skipped: [] });
+
+		await runBackfill({ cwd: CWD, hashes: ["c1"] });
+		const stored = vi.mocked(storeSummary).mock.calls[0][0];
+		expect(stored.treeHash).toBe("treeSHA123");
+		expect(stored.ticketId).toBe("JOLLI-9");
+		expect(stored.recap).toBe("did stuff");
+		// attribution empty + getCurrentBranch threw → ORPHAN_BRANCH fallback (non-empty).
+		expect(stored.branch).toMatch(/summaries/);
+	});
+});
+
+describe("countMissingSummaries / own-commit scoping", () => {
+	it("counts only commits whose hash is absent from the summary index", async () => {
+		const { execGit } = await import("../core/GitOps.js");
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			if (args[0] === "config") return { exitCode: 0, stdout: "me@dev.io", stderr: "" } as never;
+			return { exitCode: 0, stdout: "h1\nh2\nh3", stderr: "" } as never;
+		});
+		vi.mocked(getIndexEntryMap).mockResolvedValue(new Map([["h2", {} as never]]));
+		const { missing, total } = await countMissingSummaries(CWD);
+		expect(total).toBe(3);
+		expect(missing).toBe(2);
+	});
+
+	it("scopes rev-list to the local author when git user.email is set", async () => {
+		const { execGit } = await import("../core/GitOps.js");
+		const calls: string[][] = [];
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			calls.push([...args]);
+			if (args[0] === "config") return { exitCode: 0, stdout: "me@dev.io", stderr: "" } as never;
+			return { exitCode: 0, stdout: "h1", stderr: "" } as never;
+		});
+		vi.mocked(getIndexEntryMap).mockResolvedValue(new Map());
+		await countMissingSummaries(CWD);
+		const revList = calls.find((c) => c[0] === "rev-list");
+		expect(revList).toContain("--author=me@dev.io");
+	});
+
+	it("returns [] when rev-list fails or is empty", async () => {
+		const { execGit } = await import("../core/GitOps.js");
+		vi.mocked(execGit).mockResolvedValue({ exitCode: 1, stdout: "", stderr: "boom" } as never);
+		const { recentCommitHashes } = await import("./BackfillEngine.js");
+		expect(await recentCommitHashes(CWD)).toEqual([]);
+		expect(await recentCommitHashes(CWD, 10)).toEqual([]);
+	});
+
+	it("drops the author filter when no git email is configured", async () => {
+		const { execGit } = await import("../core/GitOps.js");
+		const calls: string[][] = [];
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			calls.push([...args]);
+			if (args[0] === "config") return { exitCode: 0, stdout: "", stderr: "" } as never;
+			return { exitCode: 0, stdout: "h1", stderr: "" } as never;
+		});
+		vi.mocked(getIndexEntryMap).mockResolvedValue(new Map());
+		await countMissingSummaries(CWD);
+		const revList = calls.find((c) => c[0] === "rev-list");
+		expect(revList?.some((a) => a.startsWith("--author="))).toBe(false);
+	});
+});

--- a/cli/src/backfill/BackfillEngine.test.ts
+++ b/cli/src/backfill/BackfillEngine.test.ts
@@ -32,6 +32,7 @@ vi.mock("./RawTranscriptScanner.js", () => ({
 vi.mock("./CommitTargetIndex.js", () => ({
 	buildCommitTargetIndex: vi.fn().mockResolvedValue({
 		commitMeta: new Map(),
+		commitFiles: new Map(),
 		fileToCommits: new Map(),
 		baseToCommits: new Map(),
 	}),
@@ -113,6 +114,32 @@ describe("runBackfill", () => {
 		expect(vi.mocked(launchWorker)).toHaveBeenCalledTimes(1);
 	});
 
+	it("falls back to [cwd] when `git worktree list` fails", async () => {
+		const { execGit } = await import("../core/GitOps.js");
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) =>
+			args[0] === "worktree"
+				? ({ exitCode: 1, stdout: "", stderr: "no worktrees" } as never)
+				: ({ exitCode: 0, stdout: "", stderr: "" } as never),
+		);
+		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map([["c1", attrFor("c1")]]), skipped: [] });
+		const report = await runBackfill({ cwd: CWD, hashes: ["c1"] });
+		// worktree-list failure must not abort the run — roots defaults to just [cwd].
+		expect(report.generated).toBe(1);
+	});
+
+	it("attaches the commit subject (from the target index) to the outcome", async () => {
+		const { buildCommitTargetIndex } = await import("./CommitTargetIndex.js");
+		vi.mocked(buildCommitTargetIndex).mockResolvedValue({
+			commitMeta: new Map([["c1", { ts: 1, subject: "Fix the login bug" }]]),
+			commitFiles: new Map(),
+			fileToCommits: new Map(),
+			baseToCommits: new Map(),
+		} as never);
+		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map([["c1", attrFor("c1")]]), skipped: [] });
+		const report = await runBackfill({ cwd: CWD, hashes: ["c1"] });
+		expect(report.outcomes[0].commitSubject).toBe("Fix the login bug");
+	});
+
 	it("dry-run reports would-generate without calling the LLM or triggering ingest", async () => {
 		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map([["c1", attrFor("c1")]]), skipped: [] });
 
@@ -179,11 +206,19 @@ describe("runBackfill", () => {
 		expect(vi.mocked(launchWorker)).toHaveBeenCalledTimes(1);
 	});
 
-	it("falls back to the current branch when attribution has no branch", async () => {
-		const a = { ...attrFor("c1"), branch: "" };
-		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map([["c1", a]]), skipped: [] });
+	it("labels the branch 'backfilled' when no conversation branch is known (diff-only)", async () => {
+		// A historical commit's dev branch can't be recovered after the fact, so a
+		// diff-only summary uses an explicit "backfilled" marker rather than the
+		// run-time HEAD (which would be wrong).
+		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map(), skipped: ["c1"] });
 		await runBackfill({ cwd: CWD, hashes: ["c1"] });
-		expect(vi.mocked(storeSummary).mock.calls[0][0].branch).toBe("main");
+		expect(vi.mocked(storeSummary).mock.calls[0][0].branch).toBe("backfilled");
+	});
+
+	it("keeps the attributed conversation's branch when one was found", async () => {
+		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map([["c1", attrFor("c1")]]), skipped: [] });
+		await runBackfill({ cwd: CWD, hashes: ["c1"] });
+		expect(vi.mocked(storeSummary).mock.calls[0][0].branch).toBe("feat"); // attrFor sets branch "feat"
 	});
 
 	it("discovers worktree roots and tolerates a failed tree-hash lookup", async () => {
@@ -208,9 +243,8 @@ describe("runBackfill", () => {
 		expect(report.outcomes[0].confidence).toBeUndefined();
 	});
 
-	it("stamps treeHash, ticketId, and recap; tolerates getCurrentBranch failure", async () => {
-		const { execGit, getCurrentBranch } = await import("../core/GitOps.js");
-		vi.mocked(getCurrentBranch).mockRejectedValue(new Error("detached"));
+	it("stamps treeHash, ticketId, and recap", async () => {
+		const { execGit } = await import("../core/GitOps.js");
 		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
 			if (args[0] === "rev-parse") return { exitCode: 0, stdout: "treeSHA123", stderr: "" } as never;
 			return { exitCode: 0, stdout: "", stderr: "" } as never;
@@ -228,8 +262,8 @@ describe("runBackfill", () => {
 		expect(stored.treeHash).toBe("treeSHA123");
 		expect(stored.ticketId).toBe("JOLLI-9");
 		expect(stored.recap).toBe("did stuff");
-		// attribution empty + getCurrentBranch threw → ORPHAN_BRANCH fallback (non-empty).
-		expect(stored.branch).toMatch(/summaries/);
+		// attribution has no branch → diff-only "backfilled" label.
+		expect(stored.branch).toBe("backfilled");
 	});
 });
 
@@ -246,18 +280,20 @@ describe("countMissingSummaries / own-commit scoping", () => {
 		expect(missing).toBe(2);
 	});
 
-	it("scopes rev-list to the local author when git user.email is set", async () => {
+	it("scopes rev-list to the local author, regex-escaping the email", async () => {
 		const { execGit } = await import("../core/GitOps.js");
 		const calls: string[][] = [];
 		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
 			calls.push([...args]);
-			if (args[0] === "config") return { exitCode: 0, stdout: "me@dev.io", stderr: "" } as never;
+			// Gmail-style alias with regex metacharacters ('+' and '.').
+			if (args[0] === "config") return { exitCode: 0, stdout: "me+tag@dev.io", stderr: "" } as never;
 			return { exitCode: 0, stdout: "h1", stderr: "" } as never;
 		});
 		vi.mocked(getIndexEntryMap).mockResolvedValue(new Map());
 		await countMissingSummaries(CWD);
 		const revList = calls.find((c) => c[0] === "rev-list");
-		expect(revList).toContain("--author=me@dev.io");
+		// '+' and '.' must be escaped so git's --author regex matches them literally.
+		expect(revList).toContain("--author=me\\+tag@dev\\.io");
 	});
 
 	it("returns [] when rev-list fails or is empty", async () => {

--- a/cli/src/backfill/BackfillEngine.test.ts
+++ b/cli/src/backfill/BackfillEngine.test.ts
@@ -58,11 +58,17 @@ import { attributeCommits } from "./CommitAttributor.js";
 
 const CWD = "e:/repo";
 
-function attrFor(hash: string, confidence: "high" | "medium" = "high") {
+const TIER_METHOD = {
+	high: "file-overlap",
+	medium: "branch-match",
+	low: "time-window",
+} as const;
+
+function attrFor(hash: string, confidence: "high" | "medium" | "low" = "high") {
 	return {
 		commitHash: hash,
 		confidence,
-		method: confidence === "high" ? ("file-overlap" as const) : ("time-window" as const),
+		method: TIER_METHOD[confidence],
 		branch: "feat",
 		sessions: [
 			{
@@ -221,6 +227,77 @@ describe("runBackfill", () => {
 		expect(vi.mocked(storeSummary).mock.calls[0][0].branch).toBe("feat"); // attrFor sets branch "feat"
 	});
 
+	it("passes cursor candidates (incl. an out-of-range neighbor), emitOnly, worktreeRoots and minTier", async () => {
+		const c1Ts = Date.parse("2026-06-10T00:00:00Z");
+		const c0Ts = Date.parse("2026-06-09T00:00:00Z"); // within [c1Ts − 7d, c1Ts]
+		const { buildCommitTargetIndex } = await import("./CommitTargetIndex.js");
+		vi.mocked(buildCommitTargetIndex).mockResolvedValue({
+			commitMeta: new Map([["c1", { ts: c1Ts, subject: "s" }]]),
+			commitFiles: new Map(),
+			fileToCommits: new Map(),
+			baseToCommits: new Map(),
+		} as never);
+		const { execGit } = await import("../core/GitOps.js");
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			if (args[0] === "worktree")
+				return { exitCode: 0, stdout: "worktree e:/repo\nworktree e:/repo-wt2\n", stderr: "" } as never;
+			// gatherCursorCandidates own-commit range query (author time in seconds).
+			// Includes a malformed line (skipped) and an ancient out-of-range commit (filtered).
+			if (args[0] === "log") {
+				const ancient = Math.floor(Date.parse("2026-01-01T00:00:00Z") / 1000);
+				return {
+					exitCode: 0,
+					stdout: `c1|${Math.floor(c1Ts / 1000)}\nc0|${Math.floor(c0Ts / 1000)}\ngarbage-no-pipe\ncAncient|${ancient}`,
+					stderr: "",
+				} as never;
+			}
+			return { exitCode: 0, stdout: "", stderr: "" } as never;
+		});
+		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map([["c1", attrFor("c1")]]), skipped: [] });
+
+		await runBackfill({ cwd: CWD, hashes: ["c1"], minTier: "medium" });
+
+		const call = vi.mocked(attributeCommits).mock.calls[0];
+		// c0 (out of `--last N`, but in the 7-day range) is pulled in as a cursor boundary.
+		expect(call[0]).toEqual(expect.arrayContaining(["c1", "c0"]));
+		// The ancient commit is outside [minTs−7d, maxTs] and the garbage line is ignored.
+		expect(call[0]).not.toContain("cAncient");
+		expect(call[0]).not.toContain("garbage-no-pipe");
+		const opts = call[3] as { minTier: string; emitOnly: Set<string>; worktreeRoots: string[] };
+		expect(opts.minTier).toBe("medium");
+		expect(opts.worktreeRoots).toEqual(["e:/repo", "e:/repo-wt2"]);
+		expect([...opts.emitOnly]).toEqual(["c1"]); // only the missing commit is emitted
+	});
+
+	it("passes through low-confidence / branch-match attribution to storeSummary and outcome", async () => {
+		vi.mocked(attributeCommits).mockReturnValue({
+			attributed: new Map([["c1", attrFor("c1", "low")]]),
+			skipped: [],
+		});
+		const report = await runBackfill({ cwd: CWD, hashes: ["c1"], minTier: "low" });
+		const stored = vi.mocked(storeSummary).mock.calls[0][0];
+		expect(stored.backfillConfidence).toBe("low");
+		expect(stored.backfillMethod).toBe("time-window");
+		expect(report.outcomes[0].confidence).toBe("low");
+		expect(report.outcomes[0].method).toBe("time-window");
+
+		vi.mocked(storeSummary).mockClear();
+		vi.mocked(attributeCommits).mockReturnValue({
+			attributed: new Map([["c2", attrFor("c2", "medium")]]),
+			skipped: [],
+		});
+		await runBackfill({ cwd: CWD, hashes: ["c2"], minTier: "medium" });
+		expect(vi.mocked(storeSummary).mock.calls[0][0].backfillMethod).toBe("branch-match");
+		expect(vi.mocked(storeSummary).mock.calls[0][0].backfillConfidence).toBe("medium");
+	});
+
+	it("defaults minTier to the unified 'low' tier when the caller omits it", async () => {
+		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map([["c1", attrFor("c1")]]), skipped: [] });
+		await runBackfill({ cwd: CWD, hashes: ["c1"] });
+		const opts = vi.mocked(attributeCommits).mock.calls[0][3] as { minTier: string };
+		expect(opts.minTier).toBe("low");
+	});
+
 	it("discovers worktree roots and tolerates a failed tree-hash lookup", async () => {
 		const { execGit } = await import("../core/GitOps.js");
 		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
@@ -280,20 +357,60 @@ describe("countMissingSummaries / own-commit scoping", () => {
 		expect(missing).toBe(2);
 	});
 
-	it("scopes rev-list to the local author, regex-escaping the email", async () => {
+	it("matches the author literally via --fixed-strings (regex metachars are not escaped)", async () => {
 		const { execGit } = await import("../core/GitOps.js");
 		const calls: string[][] = [];
 		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
 			calls.push([...args]);
-			// Gmail-style alias with regex metacharacters ('+' and '.').
+			// Gmail-style alias: '+' is a BRE literal — escaping it would match nothing.
 			if (args[0] === "config") return { exitCode: 0, stdout: "me+tag@dev.io", stderr: "" } as never;
 			return { exitCode: 0, stdout: "h1", stderr: "" } as never;
 		});
 		vi.mocked(getIndexEntryMap).mockResolvedValue(new Map());
 		await countMissingSummaries(CWD);
 		const revList = calls.find((c) => c[0] === "rev-list");
-		// '+' and '.' must be escaped so git's --author regex matches them literally.
-		expect(revList).toContain("--author=me\\+tag@dev\\.io");
+		// Literal substring match: no backslash escaping, and --fixed-strings present.
+		expect(revList).toContain("--author=me+tag@dev.io");
+		expect(revList).toContain("--fixed-strings");
+	});
+
+	it("scopes rev-list to BOTH author email and name (git --author OR, literal)", async () => {
+		const { execGit } = await import("../core/GitOps.js");
+		const calls: string[][] = [];
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			calls.push([...args]);
+			if (args[0] === "config" && args[1] === "user.email")
+				return { exitCode: 0, stdout: "me@dev.io", stderr: "" } as never;
+			if (args[0] === "config" && args[1] === "user.name")
+				return { exitCode: 0, stdout: "J. Doe (Acme)", stderr: "" } as never;
+			return { exitCode: 0, stdout: "h1", stderr: "" } as never;
+		});
+		const { recentCommitHashes } = await import("./BackfillEngine.js");
+		await recentCommitHashes(CWD, 10);
+		const revList = calls.find((c) => c[0] === "rev-list");
+		// Two --author patterns → git ORs them; both passed verbatim (name with '( )'
+		// would match zero commits if regex-escaped, hence --fixed-strings).
+		expect(revList).toContain("--author=me@dev.io");
+		expect(revList).toContain("--author=J. Doe (Acme)");
+		expect(revList).toContain("--fixed-strings");
+	});
+
+	it("uses the name filter alone when only user.name is set", async () => {
+		const { execGit } = await import("../core/GitOps.js");
+		const calls: string[][] = [];
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			calls.push([...args]);
+			if (args[0] === "config" && args[1] === "user.name")
+				return { exitCode: 0, stdout: "Me Dev", stderr: "" } as never;
+			if (args[0] === "config") return { exitCode: 0, stdout: "", stderr: "" } as never; // no email
+			return { exitCode: 0, stdout: "h1", stderr: "" } as never;
+		});
+		const { recentCommitHashes } = await import("./BackfillEngine.js");
+		await recentCommitHashes(CWD, 10);
+		const revList = calls.find((c) => c[0] === "rev-list");
+		const authors = revList?.filter((a) => a.startsWith("--author=")) ?? [];
+		expect(authors).toEqual(["--author=Me Dev"]);
+		expect(revList).toContain("--fixed-strings");
 	});
 
 	it("returns [] when rev-list fails or is empty", async () => {
@@ -315,6 +432,8 @@ describe("countMissingSummaries / own-commit scoping", () => {
 		vi.mocked(getIndexEntryMap).mockResolvedValue(new Map());
 		await countMissingSummaries(CWD);
 		const revList = calls.find((c) => c[0] === "rev-list");
+		// No identity → neither --author nor the --fixed-strings that accompanies it.
 		expect(revList?.some((a) => a.startsWith("--author="))).toBe(false);
+		expect(revList).not.toContain("--fixed-strings");
 	});
 });

--- a/cli/src/backfill/BackfillEngine.ts
+++ b/cli/src/backfill/BackfillEngine.ts
@@ -14,7 +14,7 @@
  * any LLM call — used for validation and to tune thresholds.
  */
 
-import { execGit, getCommitInfo, getCurrentBranch, getDiffContent, getDiffStats } from "../core/GitOps.js";
+import { execGit, getCommitInfo, getDiffContent, getDiffStats } from "../core/GitOps.js";
 import { enqueueIngestOperation } from "../core/IngestTrigger.js";
 import { loadConfig } from "../core/SessionTracker.js";
 import { createStorage } from "../core/StorageFactory.js";
@@ -24,7 +24,7 @@ import { getIndexEntryMap, setActiveStorage, storeSummary } from "../core/Summar
 import { generateTranscriptId } from "../core/TranscriptId.js";
 import { buildMultiSessionContext } from "../core/TranscriptReader.js";
 import { launchWorker } from "../hooks/QueueWorker.js";
-import { createLogger, ORPHAN_BRANCH } from "../Logger.js";
+import { createLogger } from "../Logger.js";
 import { type CommitSummary, CURRENT_SCHEMA_VERSION, type StoredTranscript } from "../Types.js";
 import { type AttributedCommit, attributeCommits } from "./CommitAttributor.js";
 import { buildCommitTargetIndex } from "./CommitTargetIndex.js";
@@ -32,10 +32,23 @@ import { cwdInRoots, scanClaudeTranscripts } from "./RawTranscriptScanner.js";
 
 const log = createLogger("BackfillEngine");
 
+/**
+ * Branch label for a diff-only back-filled summary (no conversation attributed).
+ * A historical commit's *development* branch cannot be reliably recovered after
+ * the fact — git stores no "made on branch X" in the commit object; the original
+ * branch may be merged/deleted and `git branch --contains` / `git log --source`
+ * return arbitrary refs. So instead of stamping the run-time HEAD (wrong) we use
+ * an explicit "backfilled" marker. When a conversation IS attributed, its
+ * transcript `gitBranch` (captured at edit time) is used — that one is reliable.
+ */
+const DIFF_ONLY_BRANCH = "backfilled";
+
 export type BackfillStatus = "generated" | "would-generate" | "skipped-has-summary" | "error";
 
 export interface BackfillOutcome {
 	readonly commitHash: string;
+	/** Commit subject (first line) for human-friendly progress display. */
+	readonly commitSubject?: string;
 	readonly status: BackfillStatus;
 	readonly confidence?: "high" | "medium";
 	readonly method?: "file-overlap" | "time-window" | "diff-only";
@@ -103,7 +116,6 @@ async function generateAndStore(
 	hash: string,
 	attr: AttributedCommit | null,
 	cwd: string,
-	fallbackBranch: string,
 	llmConfig: { apiKey?: string; model?: string; jolliApiKey?: string; aiProvider?: "anthropic" | "jolli" },
 	storage: StorageProvider,
 ): Promise<number> {
@@ -133,7 +145,7 @@ async function generateAndStore(
 		commitMessage: commitInfo.message,
 		commitAuthor: commitInfo.author,
 		commitDate: commitInfo.date,
-		branch: attr?.branch || fallbackBranch,
+		branch: attr?.branch || DIFF_ONLY_BRANCH,
 		generatedAt: new Date().toISOString(),
 		commitType: "commit",
 		commitSource: "cli",
@@ -214,7 +226,6 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
 		jolliApiKey: config.jolliApiKey,
 		aiProvider: config.aiProvider,
 	};
-	const fallbackBranch = await getCurrentBranch(cwd).catch(() => ORPHAN_BRANCH);
 	const credsOk = hasLlmCredentials(config);
 
 	let done = 0;
@@ -224,6 +235,9 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
 		// an unsure conversation; every own-commit still gets at least a diff summary.
 		const attr = attributed.get(hash) ?? null;
 		const method = attr?.method ?? "diff-only";
+		// Subject is already in the target index (no extra git call) — carry it so
+		// progress UIs can show the commit's one-line message instead of a bare hash.
+		const subject = index.commitMeta.get(hash)?.subject;
 		let outcome: BackfillOutcome;
 		if (dryRun) {
 			outcome = {
@@ -236,7 +250,7 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
 			outcome = { commitHash: hash, status: "error", message: "no LLM credentials configured" };
 		} else {
 			try {
-				const topics = await generateAndStore(hash, attr, cwd, fallbackBranch, llmConfig, storage);
+				const topics = await generateAndStore(hash, attr, cwd, llmConfig, storage);
 				log.info("Back-fill generated %s via %s (%d topics)", hash.substring(0, 8), method, topics);
 				outcome = {
 					commitHash: hash,
@@ -250,6 +264,7 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
 				log.error("Back-fill failed for %s: %s", hash.substring(0, 8), (err as Error).message);
 			}
 		}
+		if (subject) outcome = { ...outcome, commitSubject: subject };
 		outcomes.push(outcome);
 		done++;
 		onProgress?.(done, missing.length, outcome);
@@ -297,6 +312,16 @@ async function localAuthorEmail(cwd: string): Promise<string | null> {
 }
 
 /**
+ * Escapes regex metacharacters so a string matches literally. `git rev-list
+ * --author=<v>` treats `<v>` as a regex, so an unescaped `.`/`+` in an email
+ * (e.g. a Gmail `user+tag@…` alias) would match unintended authors and pull in
+ * other people's commits — breaking the "own commits only" scoping.
+ */
+function escapeRegex(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
  * Returns commit hashes reachable from HEAD, newest-first. Capped to `limit`
  * when given (`undefined` → all reachable commits). Shared by the CLI command,
  * the enable-time worker, and the VS Code "missing summaries" count/button.
@@ -311,7 +336,7 @@ export async function recentCommitHashes(cwd: string, limit?: number): Promise<s
 	const args = ["rev-list", "HEAD"];
 	if (limit && limit > 0) args.push("--max-count", String(limit));
 	const email = await localAuthorEmail(cwd);
-	if (email) args.push(`--author=${email}`);
+	if (email) args.push(`--author=${escapeRegex(email)}`);
 	const res = await execGit(args, cwd);
 	if (res.exitCode !== 0 || !res.stdout.trim()) return [];
 	return res.stdout

--- a/cli/src/backfill/BackfillEngine.ts
+++ b/cli/src/backfill/BackfillEngine.ts
@@ -27,7 +27,7 @@ import { launchWorker } from "../hooks/QueueWorker.js";
 import { createLogger } from "../Logger.js";
 import { type CommitSummary, CURRENT_SCHEMA_VERSION, type StoredTranscript } from "../Types.js";
 import { type AttributedCommit, attributeCommits } from "./CommitAttributor.js";
-import { buildCommitTargetIndex } from "./CommitTargetIndex.js";
+import { buildCommitTargetIndex, type CommitTargetIndex } from "./CommitTargetIndex.js";
 import { cwdInRoots, scanClaudeTranscripts } from "./RawTranscriptScanner.js";
 
 const log = createLogger("BackfillEngine");
@@ -43,6 +43,26 @@ const log = createLogger("BackfillEngine");
  */
 const DIFF_ONLY_BRANCH = "backfilled";
 
+/**
+ * Back-margin (matches {@link WINDOW_CAP_MS} in CommitAttributor) applied to the
+ * oldest emitted commit's author time when gathering cursor-boundary candidates:
+ * a commit's attribution window can reach back this far, so a neighbor commit that
+ * old must still be present to truncate ownership.
+ */
+const CURSOR_BACK_MARGIN_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * The single confidence tier EVERY back-fill entry point uses — manual `jolli
+ * backfill`, the enable-time background worker, and the VS Code enable trigger.
+ * "low" = window-collect-all: attach every in-window conversation turn within the
+ * commit's effective worktree + cursor slice, and let the per-summary confidence
+ * badge flag the weaker ones honestly. Chosen for maximal historical-context
+ * recovery (highest recall, closest to the live pipeline's behavior). Still
+ * overridable per invocation via `BackfillOptions.minTier` (the CLI exposes it as
+ * `--min-confidence`); this is only the default when a caller omits it.
+ */
+export const DEFAULT_BACKFILL_TIER: "high" | "medium" | "low" = "low";
+
 export type BackfillStatus = "generated" | "would-generate" | "skipped-has-summary" | "error";
 
 export interface BackfillOutcome {
@@ -50,8 +70,8 @@ export interface BackfillOutcome {
 	/** Commit subject (first line) for human-friendly progress display. */
 	readonly commitSubject?: string;
 	readonly status: BackfillStatus;
-	readonly confidence?: "high" | "medium";
-	readonly method?: "file-overlap" | "time-window" | "diff-only";
+	readonly confidence?: "high" | "medium" | "low";
+	readonly method?: "file-overlap" | "branch-match" | "time-window" | "diff-only";
 	readonly topics?: number;
 	readonly message?: string;
 }
@@ -69,7 +89,12 @@ export interface BackfillOptions {
 	/** Candidate commit hashes, newest-first (engine drops those already summarized). */
 	readonly hashes: ReadonlyArray<string>;
 	readonly dryRun?: boolean;
-	readonly includeMedium?: boolean;
+	/**
+	 * Lowest confidence tier to attribute. Defaults to {@link DEFAULT_BACKFILL_TIER}
+	 * ("low" = window-collect-all) for every entry point; pass an explicit value only
+	 * to override (e.g. the CLI `--min-confidence` flag).
+	 */
+	readonly minTier?: "high" | "medium" | "low";
 	/** Override for `~/.claude/projects` (tests inject a temp dir). */
 	readonly projectsRoot?: string;
 	/** Progress callback fired after each commit is processed. */
@@ -176,16 +201,10 @@ async function generateAndStore(
  * failure — per-commit errors become `error` outcomes so a batch always finishes.
  */
 export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport> {
-	const { cwd, hashes, dryRun = false, includeMedium = false, projectsRoot, onProgress } = opts;
+	const { cwd, hashes, dryRun = false, minTier = DEFAULT_BACKFILL_TIER, projectsRoot, onProgress } = opts;
 	const outcomes: BackfillOutcome[] = [];
 
-	log.info(
-		"Back-fill start: cwd=%s candidates=%d dryRun=%s includeMedium=%s",
-		cwd,
-		hashes.length,
-		dryRun,
-		includeMedium,
-	);
+	log.info("Back-fill start: cwd=%s candidates=%d dryRun=%s minTier=%s", cwd, hashes.length, dryRun, minTier);
 
 	const storage = await createStorage(cwd, cwd);
 	setActiveStorage(storage);
@@ -215,8 +234,17 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
 		roots,
 	);
 
-	// 3. Attribute.
-	const { attributed } = attributeCommits(missing, bySession, index, { includeMedium });
+	// 3. Attribute. `attributeCommits` needs cursor boundaries beyond the emitted
+	// set: an already-summarized or out-of-`--last N` neighbor in the same worktree
+	// must truncate the window so its conversation isn't mis-attributed. So we pass
+	// EVERY own commit whose author time falls in the emitted range
+	// `[minTs − 7d, maxTs]` as `candidates`, but only `missing` as `emitOnly`.
+	const cursorCandidates = await gatherCursorCandidates(cwd, missing, index);
+	const { attributed } = attributeCommits(cursorCandidates, bySession, index, {
+		minTier,
+		emitOnly: new Set(missing),
+		worktreeRoots: roots,
+	});
 
 	// 4. Generate + store (unless dry-run).
 	const config = await loadConfig();
@@ -304,21 +332,39 @@ function summarize(total: number, outcomes: BackfillOutcome[]): BackfillReport {
 	return { total, generated, skipped, errors, outcomes };
 }
 
-/** The local git author email, or null when unset (used to scope to own commits). */
-async function localAuthorEmail(cwd: string): Promise<string | null> {
-	const res = await execGit(["config", "user.email"], cwd);
-	const email = res.exitCode === 0 ? res.stdout.trim() : "";
-	return email.length > 0 ? email : null;
+/** The local git author identity (email + name); each field null when unset. */
+async function localAuthorIdentity(cwd: string): Promise<{ email: string | null; name: string | null }> {
+	const read = async (key: string): Promise<string | null> => {
+		const res = await execGit(["config", key], cwd);
+		const v = res.exitCode === 0 ? res.stdout.trim() : "";
+		return v.length > 0 ? v : null;
+	};
+	return { email: await read("user.email"), name: await read("user.name") };
 }
 
 /**
- * Escapes regex metacharacters so a string matches literally. `git rev-list
- * --author=<v>` treats `<v>` as a regex, so an unescaped `.`/`+` in an email
- * (e.g. a Gmail `user+tag@…` alias) would match unintended authors and pull in
- * other people's commits — breaking the "own commits only" scoping.
+ * Pushes the local author filter onto `args`. git treats multiple `--author` as
+ * OR, so we match EITHER the configured email OR name — a commit made under a
+ * different-but-equivalent identity (local/remote email mismatch, or a name-only
+ * remote) still counts as the local user's own work, mirroring the live
+ * `isLocallyAuthored` (email OR name).
+ *
+ * `--author` is matched as a regex by default (git's BRE), where `+ ( ) ? { } |`
+ * are LITERALS — escaping them (as a naive regex-escape does) turns them into
+ * operators and matches nothing (a Gmail `user+tag@…` alias or a `J. Doe (Acme)`
+ * name would silently match zero commits). So we add `--fixed-strings` and pass
+ * the identity verbatim as a literal substring, mirroring `BranchCommitLister`.
+ * `--fixed-strings` is global but safe here since `--author` is the only pattern
+ * operand (no `--grep`). Returns whether any filter was added (false → no git
+ * identity configured, every commit is a candidate).
  */
-function escapeRegex(s: string): string {
-	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+async function pushAuthorFilter(args: string[], cwd: string): Promise<boolean> {
+	const { email, name } = await localAuthorIdentity(cwd);
+	if (!email && !name) return false;
+	args.push("--fixed-strings");
+	if (email) args.push(`--author=${email}`);
+	if (name) args.push(`--author=${name}`);
+	return true;
 }
 
 /**
@@ -326,23 +372,63 @@ function escapeRegex(s: string): string {
  * when given (`undefined` → all reachable commits). Shared by the CLI command,
  * the enable-time worker, and the VS Code "missing summaries" count/button.
  *
- * Scoped to the local user's OWN commits via `--author=<git user.email>`:
- * commits authored by others (merged or pulled in) never have Claude transcripts
- * on this machine, so back-filling them is pointless — they would always resolve
- * to "no conversation found" and inflate the missing-summary count. When no git
- * author email is configured, the filter is dropped (every commit is a candidate).
+ * Scoped to the local user's OWN commits (author email OR name): commits authored
+ * by others (merged or pulled in) never have Claude transcripts on this machine,
+ * so back-filling them is pointless — they would always resolve to "no
+ * conversation found" and inflate the missing-summary count. When no git author
+ * identity is configured, the filter is dropped (every commit is a candidate).
  */
 export async function recentCommitHashes(cwd: string, limit?: number): Promise<string[]> {
 	const args = ["rev-list", "HEAD"];
 	if (limit && limit > 0) args.push("--max-count", String(limit));
-	const email = await localAuthorEmail(cwd);
-	if (email) args.push(`--author=${escapeRegex(email)}`);
+	await pushAuthorFilter(args, cwd);
 	const res = await execGit(args, cwd);
 	if (res.exitCode !== 0 || !res.stdout.trim()) return [];
 	return res.stdout
 		.trim()
 		.split("\n")
 		.filter((h) => h.length > 0);
+}
+
+/**
+ * Builds the cursor-boundary candidate set for `attributeCommits`: every own
+ * commit whose AUTHOR time (rebase-stable, unlike committer time) falls in the
+ * emitted range `[min(emit ts) − 7d, max(emit ts)]`, unioned with `emitOnly`
+ * itself. This pulls in already-summarized / out-of-`--last N` neighbors so they
+ * can truncate the attribution window. The range is derived from the target
+ * index's author times; `emitOnly` commits absent from the index (no real files)
+ * simply keep the fallback (just `emitOnly`).
+ */
+async function gatherCursorCandidates(
+	cwd: string,
+	emitOnly: ReadonlyArray<string>,
+	index: CommitTargetIndex,
+): Promise<string[]> {
+	const emitTimes: number[] = [];
+	for (const h of emitOnly) {
+		const ts = index.commitMeta.get(h)?.ts;
+		if (typeof ts === "number") emitTimes.push(ts);
+	}
+	if (emitTimes.length === 0) return [...emitOnly];
+	const minTs = Math.min(...emitTimes) - CURSOR_BACK_MARGIN_MS;
+	const maxTs = Math.max(...emitTimes);
+
+	// `git log --pretty=format:%H|%at` — one clean line per commit (no "commit"
+	// header), %at = author epoch seconds. Own-author scoped (email OR name).
+	const args = ["log", "HEAD", "--pretty=format:%H|%at"];
+	await pushAuthorFilter(args, cwd);
+	const res = await execGit(args, cwd);
+	const candidates = new Set(emitOnly);
+	if (res.exitCode === 0 && res.stdout.trim()) {
+		for (const line of res.stdout.trim().split("\n")) {
+			const sep = line.indexOf("|");
+			if (sep < 0) continue;
+			const hash = line.slice(0, sep);
+			const ts = Number.parseInt(line.slice(sep + 1), 10) * 1000;
+			if (hash && !Number.isNaN(ts) && ts >= minTs && ts <= maxTs) candidates.add(hash);
+		}
+	}
+	return [...candidates];
 }
 
 /**

--- a/cli/src/backfill/BackfillEngine.ts
+++ b/cli/src/backfill/BackfillEngine.ts
@@ -1,0 +1,336 @@
+/**
+ * BackfillEngine — orchestrates historical summary back-fill.
+ *
+ * Fully isolated from the live post-commit pipeline (QueueWorker / sessions.json
+ * / cursors.json). For a list of candidate commit hashes it:
+ *   1. drops the ones that already have a summary;
+ *   2. scans on-disk Claude transcripts and the repo's real-commit index;
+ *   3. attributes transcript slices to commits ({@link attributeCommits});
+ *   4. for each confidently-attributed commit, reuses the SAME summary
+ *      generation + storage path as the live flow (`generateSummary` /
+ *      `storeSummary`), tagging the result `backfilled`.
+ *
+ * `dryRun` stops after step 3 and reports the attribution + confidence without
+ * any LLM call — used for validation and to tune thresholds.
+ */
+
+import { execGit, getCommitInfo, getCurrentBranch, getDiffContent, getDiffStats } from "../core/GitOps.js";
+import { enqueueIngestOperation } from "../core/IngestTrigger.js";
+import { loadConfig } from "../core/SessionTracker.js";
+import { createStorage } from "../core/StorageFactory.js";
+import type { StorageProvider } from "../core/StorageProvider.js";
+import { generateSummary } from "../core/Summarizer.js";
+import { getIndexEntryMap, setActiveStorage, storeSummary } from "../core/SummaryStore.js";
+import { generateTranscriptId } from "../core/TranscriptId.js";
+import { buildMultiSessionContext } from "../core/TranscriptReader.js";
+import { launchWorker } from "../hooks/QueueWorker.js";
+import { createLogger, ORPHAN_BRANCH } from "../Logger.js";
+import { type CommitSummary, CURRENT_SCHEMA_VERSION, type StoredTranscript } from "../Types.js";
+import { type AttributedCommit, attributeCommits } from "./CommitAttributor.js";
+import { buildCommitTargetIndex } from "./CommitTargetIndex.js";
+import { cwdInRoots, scanClaudeTranscripts } from "./RawTranscriptScanner.js";
+
+const log = createLogger("BackfillEngine");
+
+export type BackfillStatus = "generated" | "would-generate" | "skipped-has-summary" | "error";
+
+export interface BackfillOutcome {
+	readonly commitHash: string;
+	readonly status: BackfillStatus;
+	readonly confidence?: "high" | "medium";
+	readonly method?: "file-overlap" | "time-window" | "diff-only";
+	readonly topics?: number;
+	readonly message?: string;
+}
+
+export interface BackfillReport {
+	readonly total: number;
+	readonly generated: number;
+	readonly skipped: number;
+	readonly errors: number;
+	readonly outcomes: ReadonlyArray<BackfillOutcome>;
+}
+
+export interface BackfillOptions {
+	readonly cwd: string;
+	/** Candidate commit hashes, newest-first (engine drops those already summarized). */
+	readonly hashes: ReadonlyArray<string>;
+	readonly dryRun?: boolean;
+	readonly includeMedium?: boolean;
+	/** Override for `~/.claude/projects` (tests inject a temp dir). */
+	readonly projectsRoot?: string;
+	/** Progress callback fired after each commit is processed. */
+	readonly onProgress?: (done: number, total: number, outcome: BackfillOutcome) => void;
+}
+
+/** Returns the repo's worktree roots (for scoping transcripts by cwd). */
+async function worktreeRoots(cwd: string): Promise<string[]> {
+	const roots = new Set<string>([cwd]);
+	const res = await execGit(["worktree", "list", "--porcelain"], cwd);
+	if (res.exitCode === 0) {
+		for (const line of res.stdout.split("\n")) {
+			if (line.startsWith("worktree ")) roots.add(line.slice("worktree ".length).trim());
+		}
+	}
+	return [...roots];
+}
+
+function hasLlmCredentials(config: { apiKey?: string; jolliApiKey?: string }): boolean {
+	return Boolean(config.apiKey || config.jolliApiKey || process.env.ANTHROPIC_API_KEY);
+}
+
+/** Converts an attributed commit's sessions into the orphan-branch transcript artifact. */
+function toStoredTranscript(attr: AttributedCommit): StoredTranscript {
+	return {
+		sessions: attr.sessions.map((s) => ({
+			sessionId: s.sessionId,
+			source: s.source,
+			transcriptPath: s.transcriptPath,
+			entries: [...s.entries],
+		})),
+	};
+}
+
+/**
+ * Generates and stores one back-filled summary. Throws on LLM/storage failure.
+ *
+ * `attr === null` is the **diff-only** path: no conversation was confidently
+ * attributed, so the summary is generated from the git diff alone — mirroring
+ * the live pipeline's no-active-session behavior. 宁缺毋滥 governs only whether a
+ * conversation is *attached* (never guess); the diff summary is always produced.
+ */
+async function generateAndStore(
+	hash: string,
+	attr: AttributedCommit | null,
+	cwd: string,
+	fallbackBranch: string,
+	llmConfig: { apiKey?: string; model?: string; jolliApiKey?: string; aiProvider?: "anthropic" | "jolli" },
+	storage: StorageProvider,
+): Promise<number> {
+	const commitInfo = await getCommitInfo(hash, cwd);
+	const diff = await getDiffContent(`${hash}~1`, hash, cwd);
+	const diffStats = await getDiffStats(`${hash}~1`, hash, cwd);
+	const conversation = attr ? buildMultiSessionContext(attr.sessions) : "";
+	// Tree hash gives the summary parity with the live pipeline's cross-branch
+	// matching (same tree on a different branch resolves to this summary).
+	const treeRes = await execGit(["rev-parse", `${hash}^{tree}`], cwd);
+	const treeHash = treeRes.exitCode === 0 ? treeRes.stdout.trim() : undefined;
+
+	const result = await generateSummary({
+		conversation,
+		diff,
+		commitInfo,
+		diffStats,
+		transcriptEntries: attr?.transcriptEntries ?? 0,
+		conversationTurns: attr?.conversationTurns ?? 0,
+		config: llmConfig,
+	});
+
+	const transcriptId = attr ? generateTranscriptId() : undefined;
+	const summary: CommitSummary = {
+		version: CURRENT_SCHEMA_VERSION,
+		commitHash: hash,
+		commitMessage: commitInfo.message,
+		commitAuthor: commitInfo.author,
+		commitDate: commitInfo.date,
+		branch: attr?.branch || fallbackBranch,
+		generatedAt: new Date().toISOString(),
+		commitType: "commit",
+		commitSource: "cli",
+		transcriptEntries: result.transcriptEntries,
+		conversationTurns: result.conversationTurns,
+		llm: result.llm,
+		stats: result.stats,
+		diffStats: result.stats,
+		topics: result.topics,
+		backfilled: true,
+		backfillMethod: attr?.method ?? "diff-only",
+		...(attr ? { backfillConfidence: attr.confidence } : {}),
+		...(transcriptId ? { transcripts: [transcriptId] } : {}),
+		...(treeHash ? { treeHash } : {}),
+		...(result.ticketId ? { ticketId: result.ticketId } : {}),
+		...(result.recap ? { recap: result.recap } : {}),
+	};
+
+	// Only attach a transcript artifact when a conversation was attributed.
+	const artifacts =
+		attr && transcriptId ? { transcript: { id: transcriptId, data: toStoredTranscript(attr) } } : undefined;
+	await storeSummary(summary, cwd, false, artifacts, storage);
+	return result.topics.length;
+}
+
+/**
+ * Runs the back-fill flow for `opts.hashes`. Never throws for a single commit's
+ * failure — per-commit errors become `error` outcomes so a batch always finishes.
+ */
+export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport> {
+	const { cwd, hashes, dryRun = false, includeMedium = false, projectsRoot, onProgress } = opts;
+	const outcomes: BackfillOutcome[] = [];
+
+	log.info(
+		"Back-fill start: cwd=%s candidates=%d dryRun=%s includeMedium=%s",
+		cwd,
+		hashes.length,
+		dryRun,
+		includeMedium,
+	);
+
+	const storage = await createStorage(cwd, cwd);
+	setActiveStorage(storage);
+
+	// 1. Drop commits that already have a summary.
+	const existing = await getIndexEntryMap(cwd, storage);
+	const missing: string[] = [];
+	for (const h of hashes) {
+		if (existing.has(h)) outcomes.push({ commitHash: h, status: "skipped-has-summary" });
+		else missing.push(h);
+	}
+	log.info("Back-fill: %d/%d commits lack a summary", missing.length, hashes.length);
+
+	if (missing.length === 0) {
+		log.info("Back-fill: nothing to do — all candidates already summarized");
+		return summarize(hashes.length, outcomes);
+	}
+
+	// 2. Build offline indexes.
+	const roots = await worktreeRoots(cwd);
+	const bySession = await scanClaudeTranscripts(cwdInRoots(roots), projectsRoot);
+	const index = await buildCommitTargetIndex(cwd);
+	log.info(
+		"Back-fill indexes: %d transcript session(s), %d target commit(s), worktree roots=%j",
+		bySession.size,
+		index.commitMeta.size,
+		roots,
+	);
+
+	// 3. Attribute.
+	const { attributed } = attributeCommits(missing, bySession, index, { includeMedium });
+
+	// 4. Generate + store (unless dry-run).
+	const config = await loadConfig();
+	const llmConfig = {
+		apiKey: config.apiKey,
+		model: config.model,
+		jolliApiKey: config.jolliApiKey,
+		aiProvider: config.aiProvider,
+	};
+	const fallbackBranch = await getCurrentBranch(cwd).catch(() => ORPHAN_BRANCH);
+	const credsOk = hasLlmCredentials(config);
+
+	let done = 0;
+	for (const hash of missing) {
+		// `null` attribution → diff-only summary (no conversation confidently found),
+		// mirroring the live pipeline's no-session path. 宁缺毋滥 only blocks *attaching*
+		// an unsure conversation; every own-commit still gets at least a diff summary.
+		const attr = attributed.get(hash) ?? null;
+		const method = attr?.method ?? "diff-only";
+		let outcome: BackfillOutcome;
+		if (dryRun) {
+			outcome = {
+				commitHash: hash,
+				status: "would-generate",
+				method,
+				...(attr ? { confidence: attr.confidence } : {}),
+			};
+		} else if (!credsOk) {
+			outcome = { commitHash: hash, status: "error", message: "no LLM credentials configured" };
+		} else {
+			try {
+				const topics = await generateAndStore(hash, attr, cwd, fallbackBranch, llmConfig, storage);
+				log.info("Back-fill generated %s via %s (%d topics)", hash.substring(0, 8), method, topics);
+				outcome = {
+					commitHash: hash,
+					status: "generated",
+					method,
+					topics,
+					...(attr ? { confidence: attr.confidence } : {}),
+				};
+			} catch (err) {
+				outcome = { commitHash: hash, status: "error", message: (err as Error).message };
+				log.error("Back-fill failed for %s: %s", hash.substring(0, 8), (err as Error).message);
+			}
+		}
+		outcomes.push(outcome);
+		done++;
+		onProgress?.(done, missing.length, outcome);
+	}
+
+	// After the WHOLE batch (never per-summary), trigger ONE repo-wide wiki/graph
+	// ingest via the same path the live post-commit flow uses. `force` bypasses
+	// the debounce cooldown so a deliberate back-fill always refreshes the
+	// knowledge wiki/graph; `launchWorker` drains the enqueued ingest op in a
+	// detached worker. Skipped on dry-run and when nothing was generated.
+	if (!dryRun && outcomes.some((o) => o.status === "generated")) {
+		log.info("Back-fill batch done — triggering one repo-wide wiki/graph ingest");
+		await enqueueIngestOperation(cwd, "manual", { force: true });
+		launchWorker(cwd);
+	}
+
+	const report = summarize(hashes.length, outcomes);
+	log.info(
+		"Back-fill complete: generated=%d skipped=%d errors=%d (of %d candidates)",
+		report.generated,
+		report.skipped,
+		report.errors,
+		report.total,
+	);
+	return report;
+}
+
+function summarize(total: number, outcomes: BackfillOutcome[]): BackfillReport {
+	let generated = 0;
+	let errors = 0;
+	let skipped = 0;
+	for (const o of outcomes) {
+		if (o.status === "generated") generated++;
+		else if (o.status === "error") errors++;
+		else if (o.status !== "would-generate") skipped++;
+	}
+	return { total, generated, skipped, errors, outcomes };
+}
+
+/** The local git author email, or null when unset (used to scope to own commits). */
+async function localAuthorEmail(cwd: string): Promise<string | null> {
+	const res = await execGit(["config", "user.email"], cwd);
+	const email = res.exitCode === 0 ? res.stdout.trim() : "";
+	return email.length > 0 ? email : null;
+}
+
+/**
+ * Returns commit hashes reachable from HEAD, newest-first. Capped to `limit`
+ * when given (`undefined` → all reachable commits). Shared by the CLI command,
+ * the enable-time worker, and the VS Code "missing summaries" count/button.
+ *
+ * Scoped to the local user's OWN commits via `--author=<git user.email>`:
+ * commits authored by others (merged or pulled in) never have Claude transcripts
+ * on this machine, so back-filling them is pointless — they would always resolve
+ * to "no conversation found" and inflate the missing-summary count. When no git
+ * author email is configured, the filter is dropped (every commit is a candidate).
+ */
+export async function recentCommitHashes(cwd: string, limit?: number): Promise<string[]> {
+	const args = ["rev-list", "HEAD"];
+	if (limit && limit > 0) args.push("--max-count", String(limit));
+	const email = await localAuthorEmail(cwd);
+	if (email) args.push(`--author=${email}`);
+	const res = await execGit(args, cwd);
+	if (res.exitCode !== 0 || !res.stdout.trim()) return [];
+	return res.stdout
+		.trim()
+		.split("\n")
+		.filter((h) => h.length > 0);
+}
+
+/**
+ * Counts how many commits reachable from HEAD lack a summary. Cheap — only an
+ * index membership check, no transcript scan or LLM call. Used by the Settings
+ * panel to show "N commits lack a summary".
+ */
+export async function countMissingSummaries(cwd: string): Promise<{ missing: number; total: number }> {
+	const hashes = await recentCommitHashes(cwd);
+	const storage = await createStorage(cwd, cwd);
+	setActiveStorage(storage);
+	const existing = await getIndexEntryMap(cwd, storage);
+	let missing = 0;
+	for (const h of hashes) if (!existing.has(h)) missing++;
+	return { missing, total: hashes.length };
+}

--- a/cli/src/backfill/BackfillWorker.test.ts
+++ b/cli/src/backfill/BackfillWorker.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", () => ({ existsSync: vi.fn() }));
+vi.mock("../util/Subprocess.js", () => ({
+	spawnHidden: vi.fn().mockReturnValue({ unref: vi.fn(), pid: 4321 }),
+}));
+vi.mock("./BackfillEngine.js", () => ({
+	runBackfill: vi.fn().mockResolvedValue({ total: 0, generated: 0, skipped: 0, errors: 0, outcomes: [] }),
+	recentCommitHashes: vi.fn(),
+}));
+vi.mock("../Logger.js", () => ({
+	setLogDir: vi.fn(),
+	createLogger: () => ({ info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() }),
+}));
+
+import { existsSync } from "node:fs";
+import { spawnHidden } from "../util/Subprocess.js";
+import { recentCommitHashes, runBackfill } from "./BackfillEngine.js";
+import { ENABLE_BACKFILL_COUNT, launchBackfillWorker, parseCwd, runWorker } from "./BackfillWorker.js";
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.restoreAllMocks());
+
+describe("launchBackfillWorker", () => {
+	it("spawns a detached worker when the script exists", () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		launchBackfillWorker("e:/repo");
+		expect(vi.mocked(spawnHidden)).toHaveBeenCalledTimes(1);
+		const [, args] = vi.mocked(spawnHidden).mock.calls[0];
+		expect(args).toContain("--worker");
+		expect(args).toContain("e:/repo");
+	});
+
+	it("does not spawn when the worker script is missing", () => {
+		vi.mocked(existsSync).mockReturnValue(false);
+		launchBackfillWorker("e:/repo");
+		expect(vi.mocked(spawnHidden)).not.toHaveBeenCalled();
+	});
+
+	it("tolerates a spawned child with no pid", () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+		vi.mocked(spawnHidden).mockReturnValueOnce({ unref: vi.fn(), pid: undefined } as never);
+		expect(() => launchBackfillWorker("e:/repo")).not.toThrow();
+	});
+});
+
+describe("runWorker", () => {
+	it("back-fills the user's last N commits", async () => {
+		vi.mocked(recentCommitHashes).mockResolvedValue(["h1", "h2"]);
+		await runWorker("e:/repo");
+		expect(vi.mocked(recentCommitHashes)).toHaveBeenCalledWith("e:/repo", ENABLE_BACKFILL_COUNT);
+		expect(vi.mocked(runBackfill)).toHaveBeenCalledWith(
+			expect.objectContaining({ cwd: "e:/repo", hashes: ["h1", "h2"] }),
+		);
+	});
+
+	it("no-ops when there are no commits", async () => {
+		vi.mocked(recentCommitHashes).mockResolvedValue([]);
+		await runWorker("e:/repo");
+		expect(vi.mocked(runBackfill)).not.toHaveBeenCalled();
+	});
+});
+
+describe("parseCwd", () => {
+	it("reads the --cwd value when present", () => {
+		expect(parseCwd(["--worker", "--cwd", "e:/x"])).toBe("e:/x");
+	});
+	it("falls back to process.cwd() when --cwd is absent or dangling", () => {
+		expect(parseCwd(["--worker"])).toBe(process.cwd());
+		expect(parseCwd(["--cwd"])).toBe(process.cwd());
+	});
+});

--- a/cli/src/backfill/BackfillWorker.ts
+++ b/cli/src/backfill/BackfillWorker.ts
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * BackfillWorker — detached background worker that back-fills summaries for the
+ * most recent commits right after `jolli enable`.
+ *
+ * The attribution + generation phase is isolated from the live QueueWorker (no
+ * shared lock, queue, or cursor). The ONE exception is intentional: after the
+ * whole batch, BackfillEngine enqueues a single ingest op and launches the live
+ * QueueWorker to drain it (reusing the post-commit wiki/graph path). It is
+ * spawned detached (stdio ignored) so `enable` returns immediately and the
+ * (potentially slow, LLM-bound) catch-up never blocks the user. Failures are
+ * logged to debug.log only — they must never affect the enable result.
+ *
+ * Invoked as: `node BackfillWorker.js --worker --cwd <dir>`
+ */
+
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createLogger, setLogDir } from "../Logger.js";
+import { spawnHidden } from "../util/Subprocess.js";
+import { recentCommitHashes, runBackfill } from "./BackfillEngine.js";
+
+const log = createLogger("BackfillWorker");
+
+/** Number of most-recent commits the enable-time catch-up considers. */
+export const ENABLE_BACKFILL_COUNT = 20;
+
+/**
+ * Spawns the BackfillWorker as a detached process. Mirrors
+ * `QueueWorker.launchWorker`: resolves the sibling `BackfillWorker.js` by
+ * directory + filename (NOT import.meta.url, which would point at the caller's
+ * bundle once esbuild inlines this function) and never blocks the caller.
+ */
+export function launchBackfillWorker(cwd: string): void {
+	const dir = dirname(fileURLToPath(import.meta.url));
+	const scriptPath = join(dir, "BackfillWorker.js");
+	if (!existsSync(scriptPath)) {
+		log.error("BackfillWorker.js not found at %s — skipping enable-time back-fill", scriptPath);
+		return;
+	}
+	const child = spawnHidden(process.execPath, [scriptPath, "--worker", "--cwd", cwd], {
+		detached: true,
+		stdio: "ignore",
+		cwd,
+	});
+	child.unref();
+	log.info("Back-fill worker spawned (PID: %d)", child.pid ?? -1);
+}
+
+/** Parses `--cwd <dir>` from argv (defaults to process.cwd()). Exported for tests. */
+export function parseCwd(argv: ReadonlyArray<string>): string {
+	const i = argv.indexOf("--cwd");
+	return i >= 0 && argv[i + 1] ? argv[i + 1] : process.cwd();
+}
+
+/** Worker entry point: back-fills the last {@link ENABLE_BACKFILL_COUNT} commits. */
+export async function runWorker(cwd: string): Promise<void> {
+	setLogDir(cwd);
+	log.info("Back-fill worker started (cwd=%s)", cwd);
+	// recentCommitHashes scopes to the local user's own commits (see its doc).
+	const hashes = await recentCommitHashes(cwd, ENABLE_BACKFILL_COUNT);
+	if (hashes.length === 0) {
+		log.info("No commits to back-fill — exiting");
+		return;
+	}
+	const report = await runBackfill({ cwd, hashes });
+	log.info(
+		"Back-fill complete: %d generated, %d skipped, %d error(s) of %d candidate(s)",
+		report.generated,
+		report.skipped,
+		report.errors,
+		report.total,
+	);
+}
+
+// Auto-execute only when run directly as a worker (not when imported).
+/* v8 ignore start */
+function isWorkerInvocation(): boolean {
+	return !process.env.VITEST && process.argv.includes("--worker");
+}
+
+if (isWorkerInvocation()) {
+	runWorker(parseCwd(process.argv)).catch((error: unknown) => {
+		log.error("Back-fill worker fatal error: %s", (error as Error).message);
+		process.exit(1);
+	});
+}
+/* v8 ignore stop */

--- a/cli/src/backfill/BackfillWorker.ts
+++ b/cli/src/backfill/BackfillWorker.ts
@@ -64,6 +64,8 @@ export async function runWorker(cwd: string): Promise<void> {
 		log.info("No commits to back-fill — exiting");
 		return;
 	}
+	// Uses the shared DEFAULT_BACKFILL_TIER (see BackfillEngine) — every entry point
+	// attributes at the same tier; the per-summary confidence badge flags weaker turns.
 	const report = await runBackfill({ cwd, hashes });
 	log.info(
 		"Back-fill complete: %d generated, %d skipped, %d error(s) of %d candidate(s)",

--- a/cli/src/backfill/CommitAttributor.test.ts
+++ b/cli/src/backfill/CommitAttributor.test.ts
@@ -5,6 +5,7 @@ import type { RawEntry } from "./RawTranscriptScanner.js";
 
 const T0 = Date.parse("2026-06-01T00:00:00.000Z");
 const min = (n: number) => n * 60_000;
+const ROOTS = ["e:/repo"];
 
 function entry(over: Partial<RawEntry> & { offsetMin: number }): RawEntry {
 	const tsMs = T0 + min(over.offsetMin);
@@ -16,7 +17,7 @@ function entry(over: Partial<RawEntry> & { offsetMin: number }): RawEntry {
 		ts: new Date(tsMs).toISOString(),
 		tsMs,
 		gitBranch: over.gitBranch ?? "feat",
-		cwd: over.cwd ?? "e:/repo",
+		cwd: "cwd" in over ? over.cwd : "e:/repo",
 		role: over.role,
 		content: over.content,
 		editedRel: over.editedRel ?? [],
@@ -53,15 +54,18 @@ function index(commits: { hash: string; offsetMin: number; files: string[]; bran
 	return { commitMeta, commitFiles, fileToCommits, baseToCommits };
 }
 
-describe("attributeCommits — file-overlap window model", () => {
+const sess = (entries: RawEntry[], sid = "S1") => new Map([[sid, entries]]);
+
+describe("attributeCommits — file-overlap window model (HIGH)", () => {
 	it("attributes a session that edited the commit's files within (L, T]", () => {
 		const idx = index([{ hash: "C1", offsetMin: 10, files: ["foo.ts"] }]);
 		const entries = [entry({ offsetMin: 5, editedRel: ["foo.ts"], role: "assistant", content: "editing foo" })];
-		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		const res = attributeCommits(["C1"], sess(entries), idx, { worktreeRoots: ROOTS });
 		const a = res.attributed.get("C1");
 		expect(a?.confidence).toBe("high");
 		expect(a?.method).toBe("file-overlap");
 		expect(a?.sessions).toHaveLength(1);
+		expect(a?.branch).toBe("feat");
 	});
 
 	it("② caps attribution at the commit time — later entries are excluded", () => {
@@ -70,7 +74,7 @@ describe("attributeCommits — file-overlap window model", () => {
 			entry({ offsetMin: 5, editedRel: ["foo.ts"], role: "assistant", content: "before commit" }),
 			entry({ offsetMin: 20, role: "human", content: "after commit — must be excluded" }),
 		];
-		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		const res = attributeCommits(["C1"], sess(entries), idx, { minTier: "low", worktreeRoots: ROOTS });
 		const a = res.attributed.get("C1");
 		expect(a?.transcriptEntries).toBe(1);
 		expect(a?.sessions[0].entries[0].content).toBe("before commit");
@@ -86,7 +90,7 @@ describe("attributeCommits — file-overlap window model", () => {
 			entry({ offsetMin: 3, editedRel: ["foo.ts"], role: "assistant", content: "C0 work (before L)" }),
 			entry({ offsetMin: 20, editedRel: ["foo.ts"], role: "assistant", content: "C1 work (in window)" }),
 		];
-		const res = attributeCommits(["C0", "C1"], new Map([["S1", entries]]), idx);
+		const res = attributeCommits(["C0", "C1"], sess(entries), idx, { minTier: "low", worktreeRoots: ROOTS });
 		// C1 only gets the 20m entry (3m belongs to C0's window, before C1's L=5m).
 		const c1 = res.attributed.get("C1");
 		expect(c1?.transcriptEntries).toBe(1);
@@ -94,35 +98,31 @@ describe("attributeCommits — file-overlap window model", () => {
 	});
 
 	it("recovers a commit even when its files were first committed by a sibling (the recall fix)", () => {
-		// bar.ts is committed first by SIB @8m, then by C @20m. The work session edits
-		// bar.ts at 12m — in C's window (8m, 20m]. Old first-committer logic gave this
-		// to SIB; the window model correctly attributes it to C.
 		const idx = index([
 			{ hash: "SIB", offsetMin: 8, files: ["bar.ts"] },
 			{ hash: "C", offsetMin: 20, files: ["bar.ts"] },
 		]);
 		const entries = [entry({ offsetMin: 12, editedRel: ["bar.ts"], role: "assistant", content: "work for C" })];
-		const res = attributeCommits(["C"], new Map([["S1", entries]]), idx);
+		const res = attributeCommits(["SIB", "C"], sess(entries), idx, { worktreeRoots: ROOTS });
 		expect(res.attributed.get("C")?.method).toBe("file-overlap");
 	});
 
 	it("skips a commit no session touched (→ engine diff-only)", () => {
 		const idx = index([{ hash: "C1", offsetMin: 10, files: ["foo.ts"] }]);
 		const entries = [entry({ offsetMin: 5, editedRel: ["other.ts"], role: "assistant", content: "unrelated" })];
-		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		const res = attributeCommits(["C1"], sess(entries), idx, { minTier: "low", worktreeRoots: ROOTS });
 		expect(res.attributed.has("C1")).toBe(false);
 		expect(res.skipped).toContain("C1");
 	});
 
 	it("skips a target absent from the index (no files)", () => {
 		const idx = index([{ hash: "C1", offsetMin: 10, files: ["foo.ts"] }]);
-		const res = attributeCommits(["UNKNOWN"], new Map(), idx);
+		const res = attributeCommits(["UNKNOWN"], new Map(), idx, { worktreeRoots: ROOTS });
 		expect(res.skipped).toContain("UNKNOWN");
 	});
 
 	it("matches by basename when the edit's relative path differs", () => {
 		const idx = index([{ hash: "C1", offsetMin: 10, files: ["cli/src/foo.ts"] }]);
-		// edit recorded under a different relative path but same basename
 		const entries = [
 			entry({
 				offsetMin: 5,
@@ -132,7 +132,7 @@ describe("attributeCommits — file-overlap window model", () => {
 				content: "x",
 			}),
 		];
-		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		const res = attributeCommits(["C1"], sess(entries), idx, { worktreeRoots: ROOTS });
 		expect(res.attributed.get("C1")?.method).toBe("file-overlap");
 	});
 
@@ -142,22 +142,22 @@ describe("attributeCommits — file-overlap window model", () => {
 			entry({ offsetMin: 4, editedRel: ["foo.ts"] }), // pure tool call, no role/content
 			entry({ offsetMin: 5, editedRel: ["foo.ts"], role: "assistant", content: "kept turn" }),
 		];
-		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		const res = attributeCommits(["C1"], sess(entries), idx, { worktreeRoots: ROOTS });
 		const a = res.attributed.get("C1");
 		expect(a?.transcriptEntries).toBe(1);
 		expect(a?.sessions[0].entries[0].content).toBe("kept turn");
 	});
 
-	it("splits the in-window slice on a >2h idle gap (keeps the touching segment)", () => {
+	it("splits the in-window slice on a >2h idle gap (keeps only the touching segment at HIGH)", () => {
 		const idx = index([{ hash: "C1", offsetMin: 200, files: ["foo.ts"] }]);
 		const entries = [
 			entry({ offsetMin: 10, role: "human", content: "early unrelated chat" }),
 			// >2h gap → new segment; this later segment edits foo.ts
 			entry({ offsetMin: 190, editedRel: ["foo.ts"], role: "assistant", content: "the actual work" }),
 		];
-		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		// minTier high: the early-chat segment has no anchor → dropped; only the work segment survives.
+		const res = attributeCommits(["C1"], sess(entries), idx, { minTier: "high", worktreeRoots: ROOTS });
 		const a = res.attributed.get("C1");
-		// Only the touching segment (190m) is collected, not the early-chat segment.
 		expect(a?.transcriptEntries).toBe(1);
 		expect(a?.sessions[0].entries[0].content).toBe("the actual work");
 	});
@@ -165,116 +165,364 @@ describe("attributeCommits — file-overlap window model", () => {
 	it("skips a commit whose only in-window touch is a non-conversational tool call", () => {
 		const idx = index([{ hash: "C1", offsetMin: 10, files: ["foo.ts"] }]);
 		const entries = [entry({ offsetMin: 5, editedRel: ["foo.ts"] })]; // edit only, no role/content
-		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		const res = attributeCommits(["C1"], sess(entries), idx, { worktreeRoots: ROOTS });
 		expect(res.attributed.has("C1")).toBe(false);
 		expect(res.skipped).toContain("C1");
 	});
 
-	it("uses the modal branch of attributed entries", () => {
-		const idx = index([{ hash: "C1", offsetMin: 10, files: ["foo.ts"] }]);
-		const entries = [
-			entry({ offsetMin: 5, gitBranch: "feat-x", editedRel: ["foo.ts"], role: "assistant", content: "e1" }),
-			entry({ offsetMin: 6, gitBranch: "feat-x", role: "human", content: "q" }),
-		];
-		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
-		expect(res.attributed.get("C1")?.branch).toBe("feat-x");
-	});
-
 	it("splits a session on a branch change so each branch segment is collected", () => {
-		// Adjacent entries on different (both-known) branches break the segment;
-		// both segments edit foo.ts in-window, so both slices are collected.
 		const idx = index([{ hash: "C1", offsetMin: 30, files: ["foo.ts"] }]);
 		const entries = [
 			entry({ offsetMin: 5, gitBranch: "a", editedRel: ["foo.ts"], role: "assistant", content: "on a" }),
 			entry({ offsetMin: 6, gitBranch: "b", editedRel: ["foo.ts"], role: "assistant", content: "on b" }),
 		];
-		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		const res = attributeCommits(["C1"], sess(entries), idx, { worktreeRoots: ROOTS });
 		expect(res.attributed.get("C1")?.transcriptEntries).toBe(2);
-	});
-
-	it("modalBranch ignores blank-branch entries and keeps the first on a tie", () => {
-		const idx = index([{ hash: "C1", offsetMin: 30, files: ["foo.ts"] }]);
-		const entries = [
-			entry({ offsetMin: 5, gitBranch: "x", editedRel: ["foo.ts"], role: "assistant", content: "e1" }),
-			entry({ offsetMin: 6, gitBranch: "", role: "human", content: "blank branch" }),
-			entry({ offsetMin: 7, gitBranch: "y", role: "human", content: "y1" }),
-		];
-		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
-		// x and y each occur once; the first to reach the max (x) wins; "" is skipped.
-		expect(res.attributed.get("C1")?.branch).toBe("x");
-	});
-
-	it("drops an entry that has text content but no role", () => {
-		const idx = index([{ hash: "C1", offsetMin: 10, files: ["foo.ts"] }]);
-		const entries = [
-			entry({ offsetMin: 5, editedRel: ["foo.ts"], content: "content but no role" }),
-			entry({ offsetMin: 6, editedRel: ["foo.ts"], role: "assistant", content: "kept" }),
-		];
-		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
-		const a = res.attributed.get("C1");
-		expect(a?.transcriptEntries).toBe(1);
-		expect(a?.sessions[0].entries[0].content).toBe("kept");
 	});
 });
 
-describe("attributeCommits — time-window MEDIUM (③, opt-in)", () => {
-	it("attributes an in-window segment ending just before the commit when no file edit matches", () => {
-		const idx = index([{ hash: "C1", offsetMin: 30, files: ["foo.ts"], branch: "feat" }]);
-		// session discusses, edits NOTHING in foo.ts, ends ~5m before commit
-		const entries = [
-			entry({ offsetMin: 24, gitBranch: "feat", role: "human", content: "let's plan" }),
-			entry({ offsetMin: 25, gitBranch: "feat", role: "assistant", content: "ok" }),
-		];
-		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx, { includeMedium: true });
+describe("attributeCommits — effective worktree", () => {
+	it("narrows to the worktree that edited the commit's files (other worktrees excluded)", () => {
+		const idx = index([{ hash: "C1", offsetMin: 20, files: ["foo.ts"] }]);
+		const bySession = new Map([
+			["S1", [entry({ offsetMin: 10, editedRel: ["foo.ts"], role: "assistant", content: "work in wt1" })]],
+			[
+				"S2",
+				[
+					entry({
+						sessionId: "S2",
+						transcriptPath: "/p/S2.jsonl",
+						cwd: "e:/repo-wt2",
+						offsetMin: 12,
+						role: "human",
+						content: "unrelated chat in wt2",
+					}),
+				],
+			],
+		]);
+		const res = attributeCommits(["C1"], bySession, idx, {
+			minTier: "low",
+			worktreeRoots: ["e:/repo", "e:/repo-wt2"],
+		});
 		const a = res.attributed.get("C1");
-		expect(a?.confidence).toBe("medium");
-		expect(a?.method).toBe("time-window");
-	});
-
-	it("does not emit MEDIUM by default (includeMedium off)", () => {
-		const idx = index([{ hash: "C1", offsetMin: 30, files: ["foo.ts"] }]);
-		const entries = [entry({ offsetMin: 25, role: "human", content: "plan" })];
-		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
-		expect(res.attributed.has("C1")).toBe(false);
-	});
-
-	it("MEDIUM branch gate rejects a segment on a different known branch", () => {
-		const idx = index([{ hash: "C1", offsetMin: 30, files: ["foo.ts"], branch: "main" }]);
-		const entries = [entry({ offsetMin: 25, gitBranch: "feat", role: "human", content: "on feat, not main" })];
-		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx, { includeMedium: true });
-		expect(res.attributed.has("C1")).toBe(false);
-	});
-
-	it("MEDIUM ignores a segment that ended long before the commit", () => {
-		const idx = index([{ hash: "C1", offsetMin: 600, files: ["foo.ts"], branch: "feat" }]);
-		// segment ends at 25m, commit at 600m (~9.6h later, > 2h gap) → not "led into it"
-		const entries = [entry({ offsetMin: 25, gitBranch: "feat", role: "human", content: "stale" })];
-		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx, { includeMedium: true });
-		expect(res.attributed.has("C1")).toBe(false);
-	});
-
-	it("MEDIUM collects the in-window segment and skips a later out-of-window one", () => {
-		const idx = index([{ hash: "C1", offsetMin: 100, files: ["foo.ts"], branch: "feat" }]);
-		const entries = [
-			entry({ offsetMin: 95, gitBranch: "feat", role: "human", content: "in window" }),
-			// >2h gap → new segment; offset 300 is AFTER the commit (100) → out of window → empty slice.
-			entry({ offsetMin: 300, gitBranch: "feat", role: "human", content: "after commit" }),
-		];
-		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx, { includeMedium: true });
-		const a = res.attributed.get("C1");
-		expect(a?.confidence).toBe("medium");
+		// Even at minTier "low", the wt2 chat is excluded — its worktree has no anchor.
 		expect(a?.transcriptEntries).toBe(1);
-		expect(a?.sessions[0].entries[0].content).toBe("in window");
+		expect(a?.sessions[0].entries[0].content).toBe("work in wt1");
 	});
 
-	it("MEDIUM keeps a segment whose two entries share a timestamp", () => {
-		// Equal timestamps exercise the `tsMs > segEnd` false branch (segEnd not bumped).
+	it("normalizes a subdirectory cwd to its worktree root (no split)", () => {
+		const idx = index([{ hash: "C1", offsetMin: 20, files: ["foo.ts"] }]);
+		const bySession = new Map([
+			["S1", [entry({ offsetMin: 10, editedRel: ["foo.ts"], role: "assistant", content: "root work" })]],
+			[
+				"S2",
+				[
+					entry({
+						sessionId: "S2",
+						transcriptPath: "/p/S2.jsonl",
+						cwd: "e:/repo/cli", // launched from a subdir of the same worktree
+						offsetMin: 12,
+						editedRel: ["foo.ts"],
+						role: "assistant",
+						content: "subdir work",
+					}),
+				],
+			],
+		]);
+		const res = attributeCommits(["C1"], bySession, idx, { worktreeRoots: ROOTS });
+		// Both cwds normalize to worktree root "e:/repo" → both anchored, both collected.
+		expect(res.attributed.get("C1")?.transcriptEntries).toBe(2);
+	});
+
+	it("falls back to the cwd itself when it matches no worktree root", () => {
+		const idx = index([{ hash: "C1", offsetMin: 10, files: ["foo.ts"] }]);
+		const entries = [entry({ offsetMin: 5, editedRel: ["foo.ts"], role: "assistant", content: "x" })];
+		// worktreeRoots doesn't contain the entry cwd → key falls back to the cwd.
+		const res = attributeCommits(["C1"], sess(entries), idx, { worktreeRoots: ["e:/somewhere-else"] });
+		expect(res.attributed.get("C1")?.transcriptEntries).toBe(1);
+	});
+
+	it("handles an entry with no cwd (worktree key '')", () => {
+		const idx = index([{ hash: "C1", offsetMin: 10, files: ["foo.ts"] }]);
+		const entries = [
+			entry({ offsetMin: 5, cwd: undefined, editedRel: ["foo.ts"], role: "assistant", content: "x" }),
+		];
+		const res = attributeCommits(["C1"], sess(entries), idx, { worktreeRoots: ROOTS });
+		expect(res.attributed.get("C1")?.transcriptEntries).toBe(1);
+	});
+});
+
+describe("attributeCommits — cursor slicing", () => {
+	// Two commits with DISJOINT files (so C2's window reaches back past C1) in ONE worktree.
+	const idx = index([
+		{ hash: "C1", offsetMin: 10, files: ["a.ts"] },
+		{ hash: "C2", offsetMin: 30, files: ["b.ts"] },
+	]);
+	// One long session: two turns of C1 work, then two of C2 work, all one segment.
+	const entries = () => [
+		entry({ offsetMin: 4, lineNo: 1, editedRel: ["a.ts"], role: "assistant", content: "C1 work a" }),
+		entry({ offsetMin: 6, lineNo: 2, role: "human", content: "C1 work b" }),
+		entry({ offsetMin: 24, lineNo: 3, editedRel: ["b.ts"], role: "assistant", content: "C2 work a" }),
+		entry({ offsetMin: 26, lineNo: 4, role: "human", content: "C2 work b" }),
+	];
+
+	it("a neighbor candidate truncates the window (no bleed into C2)", () => {
+		const res = attributeCommits(["C1", "C2"], sess(entries()), idx, {
+			minTier: "low",
+			emitOnly: new Set(["C2"]),
+			worktreeRoots: ROOTS,
+		});
+		const c2 = res.attributed.get("C2");
+		// C1 (@10m) owns everything up to 10m, so C2 gets only its own two ≥24m turns.
+		expect(c2?.sessions[0].entries.map((e) => e.content)).toEqual(["C2 work a", "C2 work b"]);
+	});
+
+	it("WITHOUT the neighbor as a candidate, C2 wrongly absorbs C1's turns (the bug being fixed)", () => {
+		const res = attributeCommits(["C2"], sess(entries()), idx, {
+			minTier: "low",
+			emitOnly: new Set(["C2"]),
+			worktreeRoots: ROOTS,
+		});
+		// No C1 boundary → C2's 7-day window swallows the earlier "C1 work" turns too.
+		expect(res.attributed.get("C2")?.transcriptEntries).toBe(4);
+	});
+
+	it("slices one long session into contiguous per-commit blocks (no interleaving)", () => {
+		const res = attributeCommits(["C1", "C2"], sess(entries()), idx, { minTier: "low", worktreeRoots: ROOTS });
+		const c1 = res.attributed.get("C1");
+		const c2 = res.attributed.get("C2");
+		// Each commit gets a contiguous 2-turn block; the split is clean, not interleaved.
+		expect(c1?.sessions[0].entries.map((e) => e.content)).toEqual(["C1 work a", "C1 work b"]);
+		expect(c2?.sessions[0].entries.map((e) => e.content)).toEqual(["C2 work a", "C2 work b"]);
+	});
+
+	it("skips a commit whose only anchor is claimed by a later neighbor commit", () => {
+		// C2's file was edited at 15m, but C1 committed at 16m (after that edit) — the
+		// cursor assigns the 15m slice to C1, leaving C2 with nothing → diff-only.
+		const idx2 = index([
+			{ hash: "C1", offsetMin: 16, files: ["a.ts"] },
+			{ hash: "C2", offsetMin: 20, files: ["foo.ts"] },
+		]);
+		const entries2 = [
+			entry({ offsetMin: 14, editedRel: ["a.ts"], role: "assistant", content: "C1 anchor" }),
+			entry({ offsetMin: 15, editedRel: ["foo.ts"], role: "assistant", content: "C2 edit, claimed by C1" }),
+		];
+		const res = attributeCommits(["C1", "C2"], sess(entries2), idx2, {
+			minTier: "low",
+			emitOnly: new Set(["C2"]),
+			worktreeRoots: ROOTS,
+		});
+		expect(res.attributed.has("C2")).toBe(false);
+		expect(res.skipped).toContain("C2");
+	});
+});
+
+describe("attributeCommits — confidence tiers", () => {
+	it("MEDIUM (branch-match): an on-effBranch turn in an anchor-free segment", () => {
+		const idx = index([{ hash: "C1", offsetMin: 400, files: ["foo.ts"] }]);
+		const entries = [
+			entry({ offsetMin: 10, gitBranch: "feat", role: "human", content: "feat planning" }), // seg1, no anchor, on effBranch
+			// >2h gap → new segment; a pure tool-call anchor (no role/content) fixes effWt/effBranch
+			entry({ offsetMin: 350, gitBranch: "feat", editedRel: ["foo.ts"] }),
+		];
+		const res = attributeCommits(["C1"], sess(entries), idx, { minTier: "medium", worktreeRoots: ROOTS });
+		const a = res.attributed.get("C1");
+		expect(a?.confidence).toBe("medium");
+		expect(a?.method).toBe("branch-match");
+		expect(a?.transcriptEntries).toBe(1); // only the conversational planning turn survives
+		expect(a?.sessions[0].entries[0].content).toBe("feat planning");
+	});
+
+	it("LOW (time-window): an off-branch, anchor-free turn is kept only at minTier low", () => {
+		const idx = index([{ hash: "C1", offsetMin: 400, files: ["foo.ts"] }]);
+		const mk = () => [
+			entry({ offsetMin: 10, gitBranch: "main", role: "human", content: "planning on main" }), // LOW
+			entry({ offsetMin: 350, gitBranch: "feat", editedRel: ["foo.ts"], role: "assistant", content: "the work" }), // HIGH anchor
+		];
+		const low = attributeCommits(["C1"], sess(mk()), idx, { minTier: "low", worktreeRoots: ROOTS });
+		const a = low.attributed.get("C1");
+		// Weakest kept tier is LOW → the whole attribution is reported as low/time-window.
+		expect(a?.confidence).toBe("low");
+		expect(a?.method).toBe("time-window");
+		expect(a?.transcriptEntries).toBe(2);
+
+		const high = attributeCommits(["C1"], sess(mk()), idx, { minTier: "high", worktreeRoots: ROOTS });
+		const b = high.attributed.get("C1");
+		// minTier high drops the LOW turn → only the file-overlap turn remains.
+		expect(b?.confidence).toBe("high");
+		expect(b?.transcriptEntries).toBe(1);
+		expect(b?.sessions[0].entries[0].content).toBe("the work");
+	});
+
+	it("rolls confidence up to the WEAKEST tier kept, never overclaiming", () => {
+		// HIGH anchor turn + a MEDIUM (on-branch, anchor-free) turn → reported medium.
+		const idx = index([{ hash: "C1", offsetMin: 400, files: ["foo.ts"] }]);
+		const entries = [
+			entry({ offsetMin: 10, gitBranch: "feat", role: "human", content: "feat planning (MED)" }),
+			entry({
+				offsetMin: 350,
+				gitBranch: "feat",
+				editedRel: ["foo.ts"],
+				role: "assistant",
+				content: "work (HIGH)",
+			}),
+		];
+		const res = attributeCommits(["C1"], sess(entries), idx, { minTier: "medium", worktreeRoots: ROOTS });
+		expect(res.attributed.get("C1")?.confidence).toBe("medium");
+	});
+
+	it("does NOT mark a turn HIGH when the segment's anchor is owned by a neighbor commit", () => {
+		// Cprev floors C's window at 10m; Cmid (edits other.ts @18m) steals the foo.ts
+		// edit @15m via the cursor. C legitimately owns only the discussion turn @25m,
+		// which must NOT be reported as file-overlap just because @15m sits in its segment.
+		const idx = index([
+			{ hash: "Cprev", offsetMin: 10, files: ["foo.ts"] },
+			{ hash: "Cmid", offsetMin: 20, files: ["other.ts"] },
+			{ hash: "C", offsetMin: 30, files: ["foo.ts"] },
+		]);
+		const entries = [
+			entry({ offsetMin: 15, lineNo: 1, editedRel: ["foo.ts"], role: "assistant", content: "foo edit" }),
+			entry({ offsetMin: 18, lineNo: 2, editedRel: ["other.ts"], role: "assistant", content: "other edit" }),
+			entry({ offsetMin: 25, lineNo: 3, gitBranch: "feat", role: "human", content: "C discussion" }),
+		];
+		const res = attributeCommits(["Cprev", "Cmid", "C"], sess(entries), idx, {
+			minTier: "low",
+			emitOnly: new Set(["C"]),
+			worktreeRoots: ROOTS,
+		});
+		const c = res.attributed.get("C");
+		// @15m foo edit is owned by Cmid → C's @25m turn is branch-match, not file-overlap.
+		expect(c?.sessions[0].entries.map((e) => e.content)).toEqual(["C discussion"]);
+		expect(c?.confidence).toBe("medium");
+		expect(c?.method).toBe("branch-match");
+	});
+
+	it("effBranch is the anchors' modal branch, not stolen by dominant main chatter", () => {
+		const idx = index([{ hash: "C1", offsetMin: 400, files: ["foo.ts"] }]);
+		const entries = [
+			entry({ offsetMin: 10, gitBranch: "main", role: "human", content: "m1" }),
+			entry({ offsetMin: 12, gitBranch: "main", role: "human", content: "m2" }),
+			entry({ offsetMin: 14, gitBranch: "main", role: "human", content: "m3" }),
+			// branch change → new segment; the sole anchor is on "feat"
+			entry({ offsetMin: 16, gitBranch: "feat", editedRel: ["foo.ts"], role: "assistant", content: "feat work" }),
+		];
+		const low = attributeCommits(["C1"], sess(entries), idx, { minTier: "low", worktreeRoots: ROOTS });
+		// Despite 3 main turns vs 1 feat turn, effBranch = the anchor's branch.
+		expect(low.attributed.get("C1")?.branch).toBe("feat");
+
+		const med = attributeCommits(["C1"], sess(entries), idx, { minTier: "medium", worktreeRoots: ROOTS });
+		// At medium, the 3 main turns (LOW) are dropped; only the feat anchor turn remains.
+		expect(med.attributed.get("C1")?.transcriptEntries).toBe(1);
+	});
+
+	it("keeps the anchors' branch even when the index %S branch differs (rename-safe)", () => {
+		const idx = index([{ hash: "C1", offsetMin: 10, files: ["foo.ts"], branch: "new-name-after-rename" }]);
+		const entries = [
+			entry({ offsetMin: 5, gitBranch: "old-name", editedRel: ["foo.ts"], role: "assistant", content: "x" }),
+		];
+		const res = attributeCommits(["C1"], sess(entries), idx, { worktreeRoots: ROOTS });
+		expect(res.attributed.get("C1")?.branch).toBe("old-name");
+	});
+
+	it("falls back to the in-window modal branch when anchors carry no branch", () => {
+		const idx = index([{ hash: "C1", offsetMin: 20, files: ["foo.ts"] }]);
+		const entries = [
+			entry({
+				offsetMin: 10,
+				gitBranch: "",
+				editedRel: ["foo.ts"],
+				role: "assistant",
+				content: "anchor no branch",
+			}),
+			entry({ offsetMin: 12, gitBranch: "feat", role: "human", content: "later turn with branch" }),
+		];
+		const res = attributeCommits(["C1"], sess(entries), idx, { minTier: "low", worktreeRoots: ROOTS });
+		expect(res.attributed.get("C1")?.branch).toBe("feat");
+	});
+
+	it("does NOT attribute a commit with no file anchor, even on a matching branch", () => {
 		const idx = index([{ hash: "C1", offsetMin: 30, files: ["foo.ts"], branch: "feat" }]);
 		const entries = [
-			entry({ offsetMin: 25, lineNo: 1, gitBranch: "feat", role: "human", content: "a" }),
-			entry({ offsetMin: 25, lineNo: 2, gitBranch: "feat", role: "assistant", content: "b" }),
+			entry({ offsetMin: 25, gitBranch: "feat", role: "human", content: "just discussing, no edits" }),
 		];
-		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx, { includeMedium: true });
+		const res = attributeCommits(["C1"], sess(entries), idx, { minTier: "low", worktreeRoots: ROOTS });
+		expect(res.attributed.has("C1")).toBe(false);
+		expect(res.skipped).toContain("C1");
+	});
+});
+
+describe("attributeCommits — emit scope & defaults", () => {
+	it("emits for every candidate when emitOnly is omitted", () => {
+		const idx = index([{ hash: "C1", offsetMin: 10, files: ["foo.ts"] }]);
+		const entries = [entry({ offsetMin: 5, editedRel: ["foo.ts"], role: "assistant", content: "x" })];
+		const res = attributeCommits(["C1"], sess(entries), idx, { worktreeRoots: ROOTS });
+		expect(res.attributed.has("C1")).toBe(true);
+	});
+
+	it("does not emit a candidate that is only a cursor boundary (not in emitOnly)", () => {
+		const idx = index([
+			{ hash: "C1", offsetMin: 10, files: ["a.ts"] },
+			{ hash: "C2", offsetMin: 30, files: ["b.ts"] },
+		]);
+		const entries = [
+			entry({ offsetMin: 5, editedRel: ["a.ts"], role: "assistant", content: "C1 work" }),
+			entry({ offsetMin: 25, editedRel: ["b.ts"], role: "assistant", content: "C2 work" }),
+		];
+		const res = attributeCommits(["C1", "C2"], sess(entries), idx, {
+			emitOnly: new Set(["C2"]),
+			worktreeRoots: ROOTS,
+		});
+		expect(res.attributed.has("C1")).toBe(false); // boundary only
+		expect(res.attributed.has("C2")).toBe(true);
+	});
+
+	it("treats each distinct cwd as its own worktree when worktreeRoots is omitted", () => {
+		const idx = index([{ hash: "C1", offsetMin: 20, files: ["foo.ts"] }]);
+		const bySession = new Map([
+			[
+				"S1",
+				[
+					entry({
+						offsetMin: 10,
+						cwd: "e:/repoA",
+						editedRel: ["foo.ts"],
+						role: "assistant",
+						content: "A work",
+					}),
+				],
+			],
+			[
+				"S2",
+				[
+					entry({
+						sessionId: "S2",
+						transcriptPath: "/p/S2.jsonl",
+						cwd: "e:/repoB", // a different cwd → a different worktree key
+						offsetMin: 12,
+						role: "human",
+						content: "B chat (no edit)",
+					}),
+				],
+			],
+		]);
+		// No worktreeRoots → each cwd is its own key. Only repoA anchored C1, so repoB's
+		// chat is excluded (were the keys wrongly merged, it would leak in at minTier low).
+		const res = attributeCommits(["C1"], bySession, idx, { minTier: "low" });
+		const a = res.attributed.get("C1");
+		expect(a?.transcriptEntries).toBe(1);
+		expect(a?.sessions[0].entries[0].content).toBe("A work");
+	});
+
+	it("defaults minTier to low (window-collect-all) — the unified tier", () => {
+		const idx = index([{ hash: "C1", offsetMin: 400, files: ["foo.ts"] }]);
+		const entries = [
+			entry({ offsetMin: 10, gitBranch: "main", role: "human", content: "planning on main" }), // LOW
+			entry({ offsetMin: 350, gitBranch: "feat", editedRel: ["foo.ts"], role: "assistant", content: "work" }), // HIGH
+		];
+		const res = attributeCommits(["C1"], sess(entries), idx, { worktreeRoots: ROOTS });
+		// No minTier → low default keeps the LOW planning turn too; confidence rolls
+		// up to the weakest kept tier (low).
+		expect(res.attributed.get("C1")?.confidence).toBe("low");
 		expect(res.attributed.get("C1")?.transcriptEntries).toBe(2);
 	});
 });

--- a/cli/src/backfill/CommitAttributor.test.ts
+++ b/cli/src/backfill/CommitAttributor.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from "vitest";
+import { attributeCommits } from "./CommitAttributor.js";
+import type { CommitTargetIndex } from "./CommitTargetIndex.js";
+import type { RawEntry } from "./RawTranscriptScanner.js";
+
+const T0 = Date.parse("2026-06-01T00:00:00.000Z");
+const min = (n: number) => n * 60_000;
+
+function entry(over: Partial<RawEntry> & { offsetMin: number }): RawEntry {
+	const tsMs = T0 + min(over.offsetMin);
+	return {
+		sessionId: over.sessionId ?? "S1",
+		transcriptPath: over.transcriptPath ?? "/p/S1.jsonl",
+		source: "claude",
+		lineNo: over.lineNo ?? Math.round(over.offsetMin),
+		ts: new Date(tsMs).toISOString(),
+		tsMs,
+		gitBranch: over.gitBranch ?? "feat",
+		cwd: over.cwd ?? "e:/repo",
+		role: over.role,
+		content: over.content,
+		editedRel: over.editedRel ?? [],
+		editedBase: over.editedBase ?? (over.editedRel ?? []).map((p) => p.split("/").pop() ?? p),
+	};
+}
+
+/** Build a target index where each file maps to one commit committed at `commitOffsetMin`. */
+function index(files: Record<string, { hash: string; commitOffsetMin: number }>): CommitTargetIndex {
+	const fileToCommits = new Map<string, { ts: number; hash: string }[]>();
+	const baseToCommits = new Map<string, { ts: number; hash: string }[]>();
+	const commitMeta = new Map<string, { ts: number; subject: string }>();
+	for (const [rel, { hash, commitOffsetMin }] of Object.entries(files)) {
+		const ref = { ts: T0 + min(commitOffsetMin), hash };
+		fileToCommits.set(rel, [ref]);
+		baseToCommits.set(rel.split("/").pop() ?? rel, [ref]);
+		commitMeta.set(hash, { ts: ref.ts, subject: `commit ${hash}` });
+	}
+	return { commitMeta, fileToCommits, baseToCommits };
+}
+
+describe("attributeCommits — file-overlap (HIGH)", () => {
+	it("attributes an edited file to the commit that next touches it", () => {
+		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 10 } });
+		const entries = [entry({ offsetMin: 5, editedRel: ["foo.ts"], role: "assistant", content: "editing foo" })];
+		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		const a = res.attributed.get("C1");
+		expect(a?.confidence).toBe("high");
+		expect(a?.method).toBe("file-overlap");
+		expect(a?.branch).toBe("feat");
+		expect(a?.sessions).toHaveLength(1);
+	});
+
+	it("propagates to a discussion entry enclosed by two same-commit anchors", () => {
+		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 30 } });
+		const entries = [
+			entry({ offsetMin: 1, editedRel: ["foo.ts"], role: "assistant", content: "edit 1" }),
+			entry({ offsetMin: 2, role: "human", content: "what about edge cases?" }), // no edit
+			entry({ offsetMin: 3, editedRel: ["foo.ts"], role: "assistant", content: "edit 2" }),
+		];
+		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		const a = res.attributed.get("C1");
+		// All three conversational turns belong to C1 (the middle one via propagation).
+		expect(a?.transcriptEntries).toBe(3);
+		expect(a?.conversationTurns).toBe(1);
+	});
+
+	it("drops a contested entry between anchors of different commits", () => {
+		const idx = index({
+			"foo.ts": { hash: "C1", commitOffsetMin: 30 },
+			"bar.ts": { hash: "C2", commitOffsetMin: 31 },
+		});
+		const entries = [
+			entry({ offsetMin: 1, editedRel: ["foo.ts"], role: "assistant", content: "edit foo" }),
+			entry({ offsetMin: 2, role: "human", content: "contested middle" }),
+			entry({ offsetMin: 3, editedRel: ["bar.ts"], role: "assistant", content: "edit bar" }),
+		];
+		const res = attributeCommits(["C1", "C2"], new Map([["S1", entries]]), idx);
+		// The middle turn is contested → excluded from both.
+		expect(res.attributed.get("C1")?.transcriptEntries).toBe(1);
+		expect(res.attributed.get("C2")?.transcriptEntries).toBe(1);
+	});
+
+	it("propagates one-sided only within the reach window", () => {
+		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 120 } });
+		const entries = [
+			entry({ offsetMin: 0, editedRel: ["foo.ts"], role: "assistant", content: "anchor edit" }),
+			entry({ offsetMin: 10, role: "human", content: "near (10m)" }), // within 30m reach
+			entry({ offsetMin: 90, role: "human", content: "far (90m, but same segment? no)" }),
+		];
+		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		// The 90m entry is in a separate segment (gap > 2h? no, 80m < 2h) but beyond
+		// one-sided reach (30m) → excluded. Near entry included with the anchor.
+		expect(res.attributed.get("C1")?.transcriptEntries).toBe(2);
+	});
+
+	it("does not attribute a commit outside the target set", () => {
+		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 10 } });
+		const entries = [entry({ offsetMin: 5, editedRel: ["foo.ts"], role: "assistant", content: "x" })];
+		const res = attributeCommits(["OTHER"], new Map([["S1", entries]]), idx);
+		expect(res.attributed.size).toBe(0);
+		expect(res.skipped).toContain("OTHER");
+	});
+
+	it("skips a target whose attributed entries carry no conversational text", () => {
+		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 10 } });
+		// edit entry with no role/content (pure tool call)
+		const entries = [entry({ offsetMin: 5, editedRel: ["foo.ts"] })];
+		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		expect(res.attributed.has("C1")).toBe(false);
+		expect(res.skipped).toContain("C1");
+	});
+});
+
+describe("attributeCommits — segmentation & branch", () => {
+	it("splits segments on branch change so cross-branch anchors don't bleed", () => {
+		const idx = index({
+			"foo.ts": { hash: "C1", commitOffsetMin: 30 },
+			"bar.ts": { hash: "C2", commitOffsetMin: 31 },
+		});
+		const entries = [
+			entry({ offsetMin: 1, gitBranch: "a", editedRel: ["foo.ts"], role: "assistant", content: "on a" }),
+			entry({ offsetMin: 2, gitBranch: "b", role: "human", content: "on b, no anchor" }),
+		];
+		const res = attributeCommits(["C1", "C2"], new Map([["S1", entries]]), idx);
+		// The 'b' entry is in its own anchor-less segment → not attributed to C1.
+		expect(res.attributed.get("C1")?.transcriptEntries).toBe(1);
+	});
+
+	it("splits a segment on a >2h idle gap so a distant anchor doesn't bleed across", () => {
+		const idx = index({
+			"foo.ts": { hash: "C1", commitOffsetMin: 5 },
+			"bar.ts": { hash: "C2", commitOffsetMin: 605 },
+		});
+		const entries = [
+			entry({ offsetMin: 1, editedRel: ["foo.ts"], role: "assistant", content: "morning work" }),
+			// 10h later — beyond the 2h gap → new segment.
+			entry({ offsetMin: 600, editedRel: ["bar.ts"], role: "assistant", content: "evening work" }),
+		];
+		const res = attributeCommits(["C1", "C2"], new Map([["S1", entries]]), idx);
+		expect(res.attributed.get("C1")?.transcriptEntries).toBe(1);
+		expect(res.attributed.get("C2")?.transcriptEntries).toBe(1);
+	});
+
+	it("tolerates entries without a timestamp", () => {
+		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 10 } });
+		const noTs = {
+			...entry({ offsetMin: 5, editedRel: ["foo.ts"], role: "assistant", content: "x" }),
+			ts: undefined,
+			tsMs: Number.NaN,
+		};
+		const res = attributeCommits(["C1"], new Map([["S1", [noTs]]]), idx);
+		// No timestamp → no anchor (anchorForEntry bails on NaN) → skipped.
+		expect(res.skipped).toContain("C1");
+	});
+
+	it("uses the modal branch of attributed entries", () => {
+		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 30 } });
+		const entries = [
+			entry({ offsetMin: 1, gitBranch: "feat-x", editedRel: ["foo.ts"], role: "assistant", content: "e1" }),
+			entry({ offsetMin: 2, gitBranch: "feat-x", editedRel: ["foo.ts"], role: "assistant", content: "e2" }),
+		];
+		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		expect(res.attributed.get("C1")?.branch).toBe("feat-x");
+	});
+
+	it("returns an empty branch when no attributed entry carries a gitBranch", () => {
+		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 30 } });
+		const e = entry({ offsetMin: 1, editedRel: ["foo.ts"], role: "assistant", content: "e1" });
+		const res = attributeCommits(["C1"], new Map([["S1", [{ ...e, gitBranch: undefined }]]]), idx);
+		expect(res.attributed.get("C1")?.branch).toBe("");
+	});
+
+	it("excludes pure tool-call entries (no text) from the built session while keeping the commit", () => {
+		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 30 } });
+		const entries = [
+			entry({ offsetMin: 1, editedRel: ["foo.ts"] }), // pure tool call, no role/content
+			entry({ offsetMin: 2, editedRel: ["foo.ts"], role: "assistant", content: "kept turn" }),
+		];
+		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		const a = res.attributed.get("C1");
+		// Both edits anchor C1, but only the one with text becomes a session entry.
+		expect(a?.transcriptEntries).toBe(1);
+		expect(a?.sessions[0].entries[0].content).toBe("kept turn");
+	});
+});
+
+describe("attributeCommits — medium (time-window)", () => {
+	it("attributes an anchor-less segment to the single commit right after it", () => {
+		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 1000 } }); // unrelated file/commit
+		// add a target commit C9 right after the discussion segment
+		(idx.commitMeta as Map<string, { ts: number; subject: string }>).set("C9", { ts: T0 + min(20), subject: "C9" });
+		const entries = [
+			entry({ offsetMin: 5, role: "human", content: "let's plan the refactor" }),
+			entry({ offsetMin: 8, role: "assistant", content: "here is the plan" }),
+		];
+		const res = attributeCommits(["C9"], new Map([["S1", entries]]), idx, { includeMedium: true });
+		const a = res.attributed.get("C9");
+		expect(a?.confidence).toBe("medium");
+		expect(a?.method).toBe("time-window");
+		expect(a?.transcriptEntries).toBe(2);
+	});
+
+	it("does not emit medium when includeMedium is off", () => {
+		const idx = index({});
+		(idx.commitMeta as Map<string, { ts: number; subject: string }>).set("C9", { ts: T0 + min(20), subject: "C9" });
+		const entries = [entry({ offsetMin: 5, role: "human", content: "plan" })];
+		const res = attributeCommits(["C9"], new Map([["S1", entries]]), idx);
+		expect(res.attributed.has("C9")).toBe(false);
+	});
+
+	it("rejects a medium candidate on a different branch than the segment", () => {
+		const idx = index({});
+		// Candidate C9 is committed in-window but on branch "other"; segment is "feat".
+		(idx.commitMeta as Map<string, { ts: number; subject: string; branch?: string }>).set("C9", {
+			ts: T0 + min(20),
+			subject: "C9",
+			branch: "other",
+		});
+		const entries = [entry({ offsetMin: 5, gitBranch: "feat", role: "human", content: "plan" })];
+		const res = attributeCommits(["C9"], new Map([["S1", entries]]), idx, { includeMedium: true });
+		expect(res.attributed.has("C9")).toBe(false); // branch gate rejects
+	});
+
+	it("allows a medium candidate whose branch matches the segment", () => {
+		const idx = index({});
+		(idx.commitMeta as Map<string, { ts: number; subject: string; branch?: string }>).set("C9", {
+			ts: T0 + min(20),
+			subject: "C9",
+			branch: "feat",
+		});
+		const entries = [entry({ offsetMin: 5, gitBranch: "feat", role: "human", content: "plan" })];
+		const res = attributeCommits(["C9"], new Map([["S1", entries]]), idx, { includeMedium: true });
+		expect(res.attributed.get("C9")?.confidence).toBe("medium");
+	});
+
+	it("ignores an anchor-less segment whose entries have no timestamps", () => {
+		const idx = index({});
+		(idx.commitMeta as Map<string, { ts: number; subject: string }>).set("C9", { ts: T0 + min(20), subject: "C9" });
+		const noTs = { ...entry({ offsetMin: 5, role: "human", content: "plan" }), ts: undefined, tsMs: Number.NaN };
+		const res = attributeCommits(["C9"], new Map([["S1", [noTs]]]), idx, { includeMedium: true });
+		expect(res.attributed.has("C9")).toBe(false); // no usable timestamps → no medium window
+	});
+
+	it("does not emit medium when two commits compete for the same segment", () => {
+		const idx = index({});
+		(idx.commitMeta as Map<string, { ts: number; subject: string }>).set("C9", { ts: T0 + min(20), subject: "C9" });
+		(idx.commitMeta as Map<string, { ts: number; subject: string }>).set("C8", { ts: T0 + min(25), subject: "C8" });
+		const entries = [entry({ offsetMin: 5, role: "human", content: "plan" })];
+		const res = attributeCommits(["C9", "C8"], new Map([["S1", entries]]), idx, { includeMedium: true });
+		expect(res.attributed.size).toBe(0);
+	});
+});

--- a/cli/src/backfill/CommitAttributor.test.ts
+++ b/cli/src/backfill/CommitAttributor.test.ts
@@ -24,229 +24,257 @@ function entry(over: Partial<RawEntry> & { offsetMin: number }): RawEntry {
 	};
 }
 
-/** Build a target index where each file maps to one commit committed at `commitOffsetMin`. */
-function index(files: Record<string, { hash: string; commitOffsetMin: number }>): CommitTargetIndex {
+/**
+ * Build a target index from commit specs. `files` are repo-relative paths; the
+ * file→commit history is derived so attributionLowerBound works. `ts` is author
+ * time in minutes from T0.
+ */
+function index(commits: { hash: string; offsetMin: number; files: string[]; branch?: string }[]): CommitTargetIndex {
+	const commitMeta = new Map<string, { ts: number; subject: string; branch?: string }>();
+	const commitFiles = new Map<string, string[]>();
 	const fileToCommits = new Map<string, { ts: number; hash: string }[]>();
 	const baseToCommits = new Map<string, { ts: number; hash: string }[]>();
-	const commitMeta = new Map<string, { ts: number; subject: string }>();
-	for (const [rel, { hash, commitOffsetMin }] of Object.entries(files)) {
-		const ref = { ts: T0 + min(commitOffsetMin), hash };
-		fileToCommits.set(rel, [ref]);
-		baseToCommits.set(rel.split("/").pop() ?? rel, [ref]);
-		commitMeta.set(hash, { ts: ref.ts, subject: `commit ${hash}` });
+	const push = (m: Map<string, { ts: number; hash: string }[]>, k: string, v: { ts: number; hash: string }) => {
+		const l = m.get(k);
+		if (l) l.push(v);
+		else m.set(k, [v]);
+	};
+	for (const c of commits) {
+		const ts = T0 + min(c.offsetMin);
+		commitMeta.set(c.hash, { ts, subject: `c ${c.hash}`, ...(c.branch ? { branch: c.branch } : {}) });
+		commitFiles.set(c.hash, c.files);
+		for (const f of c.files) {
+			push(fileToCommits, f, { ts, hash: c.hash });
+			push(baseToCommits, f.split("/").pop() ?? f, { ts, hash: c.hash });
+		}
 	}
-	return { commitMeta, fileToCommits, baseToCommits };
+	for (const l of fileToCommits.values()) l.sort((a, b) => a.ts - b.ts);
+	for (const l of baseToCommits.values()) l.sort((a, b) => a.ts - b.ts);
+	return { commitMeta, commitFiles, fileToCommits, baseToCommits };
 }
 
-describe("attributeCommits — file-overlap (HIGH)", () => {
-	it("attributes an edited file to the commit that next touches it", () => {
-		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 10 } });
+describe("attributeCommits — file-overlap window model", () => {
+	it("attributes a session that edited the commit's files within (L, T]", () => {
+		const idx = index([{ hash: "C1", offsetMin: 10, files: ["foo.ts"] }]);
 		const entries = [entry({ offsetMin: 5, editedRel: ["foo.ts"], role: "assistant", content: "editing foo" })];
 		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
 		const a = res.attributed.get("C1");
 		expect(a?.confidence).toBe("high");
 		expect(a?.method).toBe("file-overlap");
-		expect(a?.branch).toBe("feat");
 		expect(a?.sessions).toHaveLength(1);
 	});
 
-	it("propagates to a discussion entry enclosed by two same-commit anchors", () => {
-		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 30 } });
+	it("② caps attribution at the commit time — later entries are excluded", () => {
+		const idx = index([{ hash: "C1", offsetMin: 10, files: ["foo.ts"] }]);
 		const entries = [
-			entry({ offsetMin: 1, editedRel: ["foo.ts"], role: "assistant", content: "edit 1" }),
-			entry({ offsetMin: 2, role: "human", content: "what about edge cases?" }), // no edit
-			entry({ offsetMin: 3, editedRel: ["foo.ts"], role: "assistant", content: "edit 2" }),
+			entry({ offsetMin: 5, editedRel: ["foo.ts"], role: "assistant", content: "before commit" }),
+			entry({ offsetMin: 20, role: "human", content: "after commit — must be excluded" }),
 		];
 		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
 		const a = res.attributed.get("C1");
-		// All three conversational turns belong to C1 (the middle one via propagation).
-		expect(a?.transcriptEntries).toBe(3);
-		expect(a?.conversationTurns).toBe(1);
+		expect(a?.transcriptEntries).toBe(1);
+		expect(a?.sessions[0].entries[0].content).toBe("before commit");
 	});
 
-	it("drops a contested entry between anchors of different commits", () => {
-		const idx = index({
-			"foo.ts": { hash: "C1", commitOffsetMin: 30 },
-			"bar.ts": { hash: "C2", commitOffsetMin: 31 },
-		});
+	it("① floors at the previous commit of the files — sibling commits don't bleed", () => {
+		// foo.ts committed by C0 @5m and C1 @30m. C1's window = (5m, 30m].
+		const idx = index([
+			{ hash: "C0", offsetMin: 5, files: ["foo.ts"] },
+			{ hash: "C1", offsetMin: 30, files: ["foo.ts"] },
+		]);
 		const entries = [
-			entry({ offsetMin: 1, editedRel: ["foo.ts"], role: "assistant", content: "edit foo" }),
-			entry({ offsetMin: 2, role: "human", content: "contested middle" }),
-			entry({ offsetMin: 3, editedRel: ["bar.ts"], role: "assistant", content: "edit bar" }),
+			entry({ offsetMin: 3, editedRel: ["foo.ts"], role: "assistant", content: "C0 work (before L)" }),
+			entry({ offsetMin: 20, editedRel: ["foo.ts"], role: "assistant", content: "C1 work (in window)" }),
 		];
-		const res = attributeCommits(["C1", "C2"], new Map([["S1", entries]]), idx);
-		// The middle turn is contested → excluded from both.
-		expect(res.attributed.get("C1")?.transcriptEntries).toBe(1);
-		expect(res.attributed.get("C2")?.transcriptEntries).toBe(1);
+		const res = attributeCommits(["C0", "C1"], new Map([["S1", entries]]), idx);
+		// C1 only gets the 20m entry (3m belongs to C0's window, before C1's L=5m).
+		const c1 = res.attributed.get("C1");
+		expect(c1?.transcriptEntries).toBe(1);
+		expect(c1?.sessions[0].entries[0].content).toBe("C1 work (in window)");
 	});
 
-	it("propagates one-sided only within the reach window", () => {
-		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 120 } });
-		const entries = [
-			entry({ offsetMin: 0, editedRel: ["foo.ts"], role: "assistant", content: "anchor edit" }),
-			entry({ offsetMin: 10, role: "human", content: "near (10m)" }), // within 30m reach
-			entry({ offsetMin: 90, role: "human", content: "far (90m, but same segment? no)" }),
-		];
-		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
-		// The 90m entry is in a separate segment (gap > 2h? no, 80m < 2h) but beyond
-		// one-sided reach (30m) → excluded. Near entry included with the anchor.
-		expect(res.attributed.get("C1")?.transcriptEntries).toBe(2);
+	it("recovers a commit even when its files were first committed by a sibling (the recall fix)", () => {
+		// bar.ts is committed first by SIB @8m, then by C @20m. The work session edits
+		// bar.ts at 12m — in C's window (8m, 20m]. Old first-committer logic gave this
+		// to SIB; the window model correctly attributes it to C.
+		const idx = index([
+			{ hash: "SIB", offsetMin: 8, files: ["bar.ts"] },
+			{ hash: "C", offsetMin: 20, files: ["bar.ts"] },
+		]);
+		const entries = [entry({ offsetMin: 12, editedRel: ["bar.ts"], role: "assistant", content: "work for C" })];
+		const res = attributeCommits(["C"], new Map([["S1", entries]]), idx);
+		expect(res.attributed.get("C")?.method).toBe("file-overlap");
 	});
 
-	it("does not attribute a commit outside the target set", () => {
-		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 10 } });
-		const entries = [entry({ offsetMin: 5, editedRel: ["foo.ts"], role: "assistant", content: "x" })];
-		const res = attributeCommits(["OTHER"], new Map([["S1", entries]]), idx);
-		expect(res.attributed.size).toBe(0);
-		expect(res.skipped).toContain("OTHER");
-	});
-
-	it("skips a target whose attributed entries carry no conversational text", () => {
-		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 10 } });
-		// edit entry with no role/content (pure tool call)
-		const entries = [entry({ offsetMin: 5, editedRel: ["foo.ts"] })];
+	it("skips a commit no session touched (→ engine diff-only)", () => {
+		const idx = index([{ hash: "C1", offsetMin: 10, files: ["foo.ts"] }]);
+		const entries = [entry({ offsetMin: 5, editedRel: ["other.ts"], role: "assistant", content: "unrelated" })];
 		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
 		expect(res.attributed.has("C1")).toBe(false);
 		expect(res.skipped).toContain("C1");
 	});
-});
 
-describe("attributeCommits — segmentation & branch", () => {
-	it("splits segments on branch change so cross-branch anchors don't bleed", () => {
-		const idx = index({
-			"foo.ts": { hash: "C1", commitOffsetMin: 30 },
-			"bar.ts": { hash: "C2", commitOffsetMin: 31 },
-		});
-		const entries = [
-			entry({ offsetMin: 1, gitBranch: "a", editedRel: ["foo.ts"], role: "assistant", content: "on a" }),
-			entry({ offsetMin: 2, gitBranch: "b", role: "human", content: "on b, no anchor" }),
-		];
-		const res = attributeCommits(["C1", "C2"], new Map([["S1", entries]]), idx);
-		// The 'b' entry is in its own anchor-less segment → not attributed to C1.
-		expect(res.attributed.get("C1")?.transcriptEntries).toBe(1);
+	it("skips a target absent from the index (no files)", () => {
+		const idx = index([{ hash: "C1", offsetMin: 10, files: ["foo.ts"] }]);
+		const res = attributeCommits(["UNKNOWN"], new Map(), idx);
+		expect(res.skipped).toContain("UNKNOWN");
 	});
 
-	it("splits a segment on a >2h idle gap so a distant anchor doesn't bleed across", () => {
-		const idx = index({
-			"foo.ts": { hash: "C1", commitOffsetMin: 5 },
-			"bar.ts": { hash: "C2", commitOffsetMin: 605 },
-		});
+	it("matches by basename when the edit's relative path differs", () => {
+		const idx = index([{ hash: "C1", offsetMin: 10, files: ["cli/src/foo.ts"] }]);
+		// edit recorded under a different relative path but same basename
 		const entries = [
-			entry({ offsetMin: 1, editedRel: ["foo.ts"], role: "assistant", content: "morning work" }),
-			// 10h later — beyond the 2h gap → new segment.
-			entry({ offsetMin: 600, editedRel: ["bar.ts"], role: "assistant", content: "evening work" }),
+			entry({
+				offsetMin: 5,
+				editedRel: ["other/foo.ts"],
+				editedBase: ["foo.ts"],
+				role: "assistant",
+				content: "x",
+			}),
 		];
-		const res = attributeCommits(["C1", "C2"], new Map([["S1", entries]]), idx);
-		expect(res.attributed.get("C1")?.transcriptEntries).toBe(1);
-		expect(res.attributed.get("C2")?.transcriptEntries).toBe(1);
+		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		expect(res.attributed.get("C1")?.method).toBe("file-overlap");
 	});
 
-	it("tolerates entries without a timestamp", () => {
-		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 10 } });
-		const noTs = {
-			...entry({ offsetMin: 5, editedRel: ["foo.ts"], role: "assistant", content: "x" }),
-			ts: undefined,
-			tsMs: Number.NaN,
-		};
-		const res = attributeCommits(["C1"], new Map([["S1", [noTs]]]), idx);
-		// No timestamp → no anchor (anchorForEntry bails on NaN) → skipped.
+	it("excludes pure tool-call entries (no text) from the built session", () => {
+		const idx = index([{ hash: "C1", offsetMin: 10, files: ["foo.ts"] }]);
+		const entries = [
+			entry({ offsetMin: 4, editedRel: ["foo.ts"] }), // pure tool call, no role/content
+			entry({ offsetMin: 5, editedRel: ["foo.ts"], role: "assistant", content: "kept turn" }),
+		];
+		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		const a = res.attributed.get("C1");
+		expect(a?.transcriptEntries).toBe(1);
+		expect(a?.sessions[0].entries[0].content).toBe("kept turn");
+	});
+
+	it("splits the in-window slice on a >2h idle gap (keeps the touching segment)", () => {
+		const idx = index([{ hash: "C1", offsetMin: 200, files: ["foo.ts"] }]);
+		const entries = [
+			entry({ offsetMin: 10, role: "human", content: "early unrelated chat" }),
+			// >2h gap → new segment; this later segment edits foo.ts
+			entry({ offsetMin: 190, editedRel: ["foo.ts"], role: "assistant", content: "the actual work" }),
+		];
+		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		const a = res.attributed.get("C1");
+		// Only the touching segment (190m) is collected, not the early-chat segment.
+		expect(a?.transcriptEntries).toBe(1);
+		expect(a?.sessions[0].entries[0].content).toBe("the actual work");
+	});
+
+	it("skips a commit whose only in-window touch is a non-conversational tool call", () => {
+		const idx = index([{ hash: "C1", offsetMin: 10, files: ["foo.ts"] }]);
+		const entries = [entry({ offsetMin: 5, editedRel: ["foo.ts"] })]; // edit only, no role/content
+		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		expect(res.attributed.has("C1")).toBe(false);
 		expect(res.skipped).toContain("C1");
 	});
 
 	it("uses the modal branch of attributed entries", () => {
-		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 30 } });
+		const idx = index([{ hash: "C1", offsetMin: 10, files: ["foo.ts"] }]);
 		const entries = [
-			entry({ offsetMin: 1, gitBranch: "feat-x", editedRel: ["foo.ts"], role: "assistant", content: "e1" }),
-			entry({ offsetMin: 2, gitBranch: "feat-x", editedRel: ["foo.ts"], role: "assistant", content: "e2" }),
+			entry({ offsetMin: 5, gitBranch: "feat-x", editedRel: ["foo.ts"], role: "assistant", content: "e1" }),
+			entry({ offsetMin: 6, gitBranch: "feat-x", role: "human", content: "q" }),
 		];
 		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
 		expect(res.attributed.get("C1")?.branch).toBe("feat-x");
 	});
 
-	it("returns an empty branch when no attributed entry carries a gitBranch", () => {
-		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 30 } });
-		const e = entry({ offsetMin: 1, editedRel: ["foo.ts"], role: "assistant", content: "e1" });
-		const res = attributeCommits(["C1"], new Map([["S1", [{ ...e, gitBranch: undefined }]]]), idx);
-		expect(res.attributed.get("C1")?.branch).toBe("");
+	it("splits a session on a branch change so each branch segment is collected", () => {
+		// Adjacent entries on different (both-known) branches break the segment;
+		// both segments edit foo.ts in-window, so both slices are collected.
+		const idx = index([{ hash: "C1", offsetMin: 30, files: ["foo.ts"] }]);
+		const entries = [
+			entry({ offsetMin: 5, gitBranch: "a", editedRel: ["foo.ts"], role: "assistant", content: "on a" }),
+			entry({ offsetMin: 6, gitBranch: "b", editedRel: ["foo.ts"], role: "assistant", content: "on b" }),
+		];
+		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		expect(res.attributed.get("C1")?.transcriptEntries).toBe(2);
 	});
 
-	it("excludes pure tool-call entries (no text) from the built session while keeping the commit", () => {
-		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 30 } });
+	it("modalBranch ignores blank-branch entries and keeps the first on a tie", () => {
+		const idx = index([{ hash: "C1", offsetMin: 30, files: ["foo.ts"] }]);
 		const entries = [
-			entry({ offsetMin: 1, editedRel: ["foo.ts"] }), // pure tool call, no role/content
-			entry({ offsetMin: 2, editedRel: ["foo.ts"], role: "assistant", content: "kept turn" }),
+			entry({ offsetMin: 5, gitBranch: "x", editedRel: ["foo.ts"], role: "assistant", content: "e1" }),
+			entry({ offsetMin: 6, gitBranch: "", role: "human", content: "blank branch" }),
+			entry({ offsetMin: 7, gitBranch: "y", role: "human", content: "y1" }),
+		];
+		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		// x and y each occur once; the first to reach the max (x) wins; "" is skipped.
+		expect(res.attributed.get("C1")?.branch).toBe("x");
+	});
+
+	it("drops an entry that has text content but no role", () => {
+		const idx = index([{ hash: "C1", offsetMin: 10, files: ["foo.ts"] }]);
+		const entries = [
+			entry({ offsetMin: 5, editedRel: ["foo.ts"], content: "content but no role" }),
+			entry({ offsetMin: 6, editedRel: ["foo.ts"], role: "assistant", content: "kept" }),
 		];
 		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
 		const a = res.attributed.get("C1");
-		// Both edits anchor C1, but only the one with text becomes a session entry.
 		expect(a?.transcriptEntries).toBe(1);
-		expect(a?.sessions[0].entries[0].content).toBe("kept turn");
+		expect(a?.sessions[0].entries[0].content).toBe("kept");
 	});
 });
 
-describe("attributeCommits — medium (time-window)", () => {
-	it("attributes an anchor-less segment to the single commit right after it", () => {
-		const idx = index({ "foo.ts": { hash: "C1", commitOffsetMin: 1000 } }); // unrelated file/commit
-		// add a target commit C9 right after the discussion segment
-		(idx.commitMeta as Map<string, { ts: number; subject: string }>).set("C9", { ts: T0 + min(20), subject: "C9" });
+describe("attributeCommits — time-window MEDIUM (③, opt-in)", () => {
+	it("attributes an in-window segment ending just before the commit when no file edit matches", () => {
+		const idx = index([{ hash: "C1", offsetMin: 30, files: ["foo.ts"], branch: "feat" }]);
+		// session discusses, edits NOTHING in foo.ts, ends ~5m before commit
 		const entries = [
-			entry({ offsetMin: 5, role: "human", content: "let's plan the refactor" }),
-			entry({ offsetMin: 8, role: "assistant", content: "here is the plan" }),
+			entry({ offsetMin: 24, gitBranch: "feat", role: "human", content: "let's plan" }),
+			entry({ offsetMin: 25, gitBranch: "feat", role: "assistant", content: "ok" }),
 		];
-		const res = attributeCommits(["C9"], new Map([["S1", entries]]), idx, { includeMedium: true });
-		const a = res.attributed.get("C9");
+		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx, { includeMedium: true });
+		const a = res.attributed.get("C1");
 		expect(a?.confidence).toBe("medium");
 		expect(a?.method).toBe("time-window");
-		expect(a?.transcriptEntries).toBe(2);
 	});
 
-	it("does not emit medium when includeMedium is off", () => {
-		const idx = index({});
-		(idx.commitMeta as Map<string, { ts: number; subject: string }>).set("C9", { ts: T0 + min(20), subject: "C9" });
-		const entries = [entry({ offsetMin: 5, role: "human", content: "plan" })];
-		const res = attributeCommits(["C9"], new Map([["S1", entries]]), idx);
-		expect(res.attributed.has("C9")).toBe(false);
+	it("does not emit MEDIUM by default (includeMedium off)", () => {
+		const idx = index([{ hash: "C1", offsetMin: 30, files: ["foo.ts"] }]);
+		const entries = [entry({ offsetMin: 25, role: "human", content: "plan" })];
+		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx);
+		expect(res.attributed.has("C1")).toBe(false);
 	});
 
-	it("rejects a medium candidate on a different branch than the segment", () => {
-		const idx = index({});
-		// Candidate C9 is committed in-window but on branch "other"; segment is "feat".
-		(idx.commitMeta as Map<string, { ts: number; subject: string; branch?: string }>).set("C9", {
-			ts: T0 + min(20),
-			subject: "C9",
-			branch: "other",
-		});
-		const entries = [entry({ offsetMin: 5, gitBranch: "feat", role: "human", content: "plan" })];
-		const res = attributeCommits(["C9"], new Map([["S1", entries]]), idx, { includeMedium: true });
-		expect(res.attributed.has("C9")).toBe(false); // branch gate rejects
+	it("MEDIUM branch gate rejects a segment on a different known branch", () => {
+		const idx = index([{ hash: "C1", offsetMin: 30, files: ["foo.ts"], branch: "main" }]);
+		const entries = [entry({ offsetMin: 25, gitBranch: "feat", role: "human", content: "on feat, not main" })];
+		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx, { includeMedium: true });
+		expect(res.attributed.has("C1")).toBe(false);
 	});
 
-	it("allows a medium candidate whose branch matches the segment", () => {
-		const idx = index({});
-		(idx.commitMeta as Map<string, { ts: number; subject: string; branch?: string }>).set("C9", {
-			ts: T0 + min(20),
-			subject: "C9",
-			branch: "feat",
-		});
-		const entries = [entry({ offsetMin: 5, gitBranch: "feat", role: "human", content: "plan" })];
-		const res = attributeCommits(["C9"], new Map([["S1", entries]]), idx, { includeMedium: true });
-		expect(res.attributed.get("C9")?.confidence).toBe("medium");
+	it("MEDIUM ignores a segment that ended long before the commit", () => {
+		const idx = index([{ hash: "C1", offsetMin: 600, files: ["foo.ts"], branch: "feat" }]);
+		// segment ends at 25m, commit at 600m (~9.6h later, > 2h gap) → not "led into it"
+		const entries = [entry({ offsetMin: 25, gitBranch: "feat", role: "human", content: "stale" })];
+		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx, { includeMedium: true });
+		expect(res.attributed.has("C1")).toBe(false);
 	});
 
-	it("ignores an anchor-less segment whose entries have no timestamps", () => {
-		const idx = index({});
-		(idx.commitMeta as Map<string, { ts: number; subject: string }>).set("C9", { ts: T0 + min(20), subject: "C9" });
-		const noTs = { ...entry({ offsetMin: 5, role: "human", content: "plan" }), ts: undefined, tsMs: Number.NaN };
-		const res = attributeCommits(["C9"], new Map([["S1", [noTs]]]), idx, { includeMedium: true });
-		expect(res.attributed.has("C9")).toBe(false); // no usable timestamps → no medium window
+	it("MEDIUM collects the in-window segment and skips a later out-of-window one", () => {
+		const idx = index([{ hash: "C1", offsetMin: 100, files: ["foo.ts"], branch: "feat" }]);
+		const entries = [
+			entry({ offsetMin: 95, gitBranch: "feat", role: "human", content: "in window" }),
+			// >2h gap → new segment; offset 300 is AFTER the commit (100) → out of window → empty slice.
+			entry({ offsetMin: 300, gitBranch: "feat", role: "human", content: "after commit" }),
+		];
+		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx, { includeMedium: true });
+		const a = res.attributed.get("C1");
+		expect(a?.confidence).toBe("medium");
+		expect(a?.transcriptEntries).toBe(1);
+		expect(a?.sessions[0].entries[0].content).toBe("in window");
 	});
 
-	it("does not emit medium when two commits compete for the same segment", () => {
-		const idx = index({});
-		(idx.commitMeta as Map<string, { ts: number; subject: string }>).set("C9", { ts: T0 + min(20), subject: "C9" });
-		(idx.commitMeta as Map<string, { ts: number; subject: string }>).set("C8", { ts: T0 + min(25), subject: "C8" });
-		const entries = [entry({ offsetMin: 5, role: "human", content: "plan" })];
-		const res = attributeCommits(["C9", "C8"], new Map([["S1", entries]]), idx, { includeMedium: true });
-		expect(res.attributed.size).toBe(0);
+	it("MEDIUM keeps a segment whose two entries share a timestamp", () => {
+		// Equal timestamps exercise the `tsMs > segEnd` false branch (segEnd not bumped).
+		const idx = index([{ hash: "C1", offsetMin: 30, files: ["foo.ts"], branch: "feat" }]);
+		const entries = [
+			entry({ offsetMin: 25, lineNo: 1, gitBranch: "feat", role: "human", content: "a" }),
+			entry({ offsetMin: 25, lineNo: 2, gitBranch: "feat", role: "assistant", content: "b" }),
+		];
+		const res = attributeCommits(["C1"], new Map([["S1", entries]]), idx, { includeMedium: true });
+		expect(res.attributed.get("C1")?.transcriptEntries).toBe(2);
 	});
 });

--- a/cli/src/backfill/CommitAttributor.ts
+++ b/cli/src/backfill/CommitAttributor.ts
@@ -2,30 +2,37 @@
  * CommitAttributor — maps on-disk Claude transcript slices to historical commits.
  *
  * Isolated from the live cursor/queue flow. Operates on the offline indexes built
- * by {@link RawTranscriptScanner} and {@link CommitTargetIndex}. The algorithm and
- * its confidence tiers were validated against real local data (see the plan):
- * locality holds — a commit's edits form a single contiguous run in a session, so
- * attribution propagates safely from a file-overlap anchor to its neighbours.
+ * by {@link RawTranscriptScanner} and {@link CommitTargetIndex}.
  *
- * Per target commit C the result is one of:
- *   - HIGH (file-overlap): at least one edited file in the attributed run matches
- *     C's diff (C is the first commit to touch that file after the edit). The run
- *     = the anchor edits + the conversational turns the propagation reaches.
- *   - MEDIUM (time-window, opt-in): no file overlap, but a single anchor-less work
- *     segment ends immediately before C with no competing commit in the gap.
- *   - skipped: contested / no signal — nothing is generated (宁缺毋滥).
+ * Model (per target commit C, see the recall study doc for why this replaced the
+ * earlier "first-committer" anchoring):
+ *   - Window = (L, T]  where T = C's commit time (② upper bound: a commit's
+ *     conversation can only precede the commit) and L = the previous time any of
+ *     C's files was committed (① commit-boundary lower bound: consecutive commits
+ *     touching overlapping files don't bleed into each other). L is capped to a
+ *     max lookback so a long-dormant file doesn't open a huge window.
+ *   - HIGH (file-overlap): a session segment that *edited one of C's files inside
+ *     the window* contributes its in-window slice — independent of which commit
+ *     "first committed" the file. This is what recovers the conversation even for
+ *     commits that are not the first committer of their files.
+ *   - MEDIUM (time-window, opt-in via includeMedium / ③): when no session edited
+ *     C's files in the window, fall back to in-window segments that end right
+ *     before C on a branch-compatible session.
+ *   - none → the engine falls back to a diff-only summary.
  */
 
+import { normalizePathForCompare } from "../core/PathUtils.js";
 import type { SessionTranscript } from "../core/TranscriptReader.js";
 import { createLogger } from "../Logger.js";
 import type { TranscriptEntry } from "../Types.js";
-import { anchorCommitForEdit, type CommitTargetIndex } from "./CommitTargetIndex.js";
+import { attributionLowerBound, type CommitTargetIndex } from "./CommitTargetIndex.js";
 import type { RawEntry } from "./RawTranscriptScanner.js";
 
 const log = createLogger("CommitAttributor");
 
 const SEGMENT_GAP_MS = 2 * 60 * 60 * 1000; // 2h idle splits a work segment
-const ONE_SIDED_MS = 30 * 60 * 1000; // one-sided propagation reach
+/** Max window lookback when a commit's files have no earlier commit (e.g. new files). */
+const WINDOW_CAP_MS = 7 * 24 * 60 * 60 * 1000;
 
 export interface AttributedCommit {
 	readonly commitHash: string;
@@ -40,7 +47,7 @@ export interface AttributedCommit {
 export interface AttributionResult {
 	/** Target commits that earned a confident attribution. */
 	readonly attributed: ReadonlyMap<string, AttributedCommit>;
-	/** Target commits with no confident attribution (skipped under 宁缺毋滥). */
+	/** Target commits with no confident attribution (engine → diff-only). */
 	readonly skipped: ReadonlyArray<string>;
 }
 
@@ -49,7 +56,12 @@ interface Segment {
 	readonly end: number; // exclusive
 }
 
-/** Splits a session's time-ordered entries into work segments. */
+interface SessionSegments {
+	readonly entries: ReadonlyArray<RawEntry>;
+	readonly segs: ReadonlyArray<Segment>;
+}
+
+/** Splits a session's time-ordered entries into work segments (branch change / >2h gap). */
 function segmentSession(entries: ReadonlyArray<RawEntry>): Segment[] {
 	const segs: Segment[] = [];
 	let start = 0;
@@ -60,8 +72,7 @@ function segmentSession(entries: ReadonlyArray<RawEntry>): Segment[] {
 			const cur = entries[i];
 			// Split on a branch change only when BOTH sides have a known branch and
 			// they differ. Early Claude transcripts omit `gitBranch` on some lines;
-			// treating undefined as a new branch would shred a continuous work run
-			// into spurious segments. Undefined inherits the surrounding branch.
+			// treating undefined as a new branch would shred a continuous work run.
 			if (cur.gitBranch && prev.gitBranch && cur.gitBranch !== prev.gitBranch) brk = true;
 			else if (!Number.isNaN(cur.tsMs) && !Number.isNaN(prev.tsMs) && cur.tsMs - prev.tsMs > SEGMENT_GAP_MS)
 				brk = true;
@@ -74,133 +85,34 @@ function segmentSession(entries: ReadonlyArray<RawEntry>): Segment[] {
 	return segs;
 }
 
-/** Modal commit hash among an entry's edited files (first file wins on ties). */
-function anchorForEntry(index: CommitTargetIndex, e: RawEntry): string | null {
-	if (e.editedRel.length === 0 || Number.isNaN(e.tsMs)) return null;
-	const counts = new Map<string, number>();
-	let bestHash: string | null = null;
-	let bestCount = 0;
-	for (let k = 0; k < e.editedRel.length; k++) {
-		const hash = anchorCommitForEdit(index, e.editedRel[k], e.editedBase[k] ?? "", e.tsMs);
-		if (!hash) continue;
-		const c = (counts.get(hash) ?? 0) + 1;
-		counts.set(hash, c);
-		if (c > bestCount) {
-			bestCount = c;
-			bestHash = hash;
-		}
-	}
-	return bestHash;
+/**
+ * True when entry `e` edited one of the commit's files (by repo-relative path or
+ * basename). Both sides are folded through {@link normalizePathForCompare} so a
+ * transcript path whose case differs from git's (common on case-insensitive
+ * Windows/macOS filesystems, where `Src/Foo.ts` and `src/foo.ts` are the same
+ * file) still matches. On case-sensitive Linux the fold is a no-op, so genuinely
+ * distinct `Foo.ts`/`foo.ts` are NOT merged. `relSet`/`baseSet` are pre-folded.
+ */
+function touchesFiles(e: RawEntry, relSet: ReadonlySet<string>, baseSet: ReadonlySet<string>): boolean {
+	for (const r of e.editedRel) if (relSet.has(normalizePathForCompare(r))) return true;
+	for (const b of e.editedBase) if (baseSet.has(normalizePathForCompare(b))) return true;
+	return false;
 }
 
-/** Appends `e` to the per-commit collection map. */
+function inWindow(e: RawEntry, lo: number, hi: number): boolean {
+	return !Number.isNaN(e.tsMs) && e.tsMs > lo && e.tsMs <= hi;
+}
+
+function basename(p: string): string {
+	const i = p.lastIndexOf("/");
+	return i >= 0 ? p.slice(i + 1) : p;
+}
+
+/** Appends `e` to the per-commit collection map (dedup by lineNo+session within a commit). */
 function collect(map: Map<string, RawEntry[]>, commit: string, e: RawEntry): void {
 	const list = map.get(commit);
 	if (list) list.push(e);
 	else map.set(commit, [e]);
-}
-
-/**
- * File-overlap (HIGH) attribution within one session: anchor edits, then
- * propagate to no-signal neighbours bounded by the segment and by competing
- * anchors. Only commits in `targetSet` are collected. Anchors pointing at
- * non-target commits still act as propagation boundaries.
- */
-function attributeSessionHigh(
-	entries: ReadonlyArray<RawEntry>,
-	index: CommitTargetIndex,
-	targetSet: ReadonlySet<string>,
-	into: Map<string, RawEntry[]>,
-	anchorlessSegments: { entries: RawEntry[] }[],
-): void {
-	const anchors = entries.map((e) => anchorForEntry(index, e));
-	for (const seg of segmentSession(entries)) {
-		const anchored: { idx: number; commit: string }[] = [];
-		for (let i = seg.start; i < seg.end; i++) {
-			const a = anchors[i];
-			if (a) anchored.push({ idx: i, commit: a });
-		}
-		if (anchored.length === 0) {
-			anchorlessSegments.push({ entries: entries.slice(seg.start, seg.end) });
-			continue;
-		}
-		for (let i = seg.start; i < seg.end; i++) {
-			let commit: string | null = anchors[i];
-			if (!commit) {
-				const before = lastBefore(anchored, i);
-				const after = firstAfter(anchored, i);
-				if (before && after && before.commit === after.commit) {
-					commit = before.commit; // enclosed by same commit → inherit
-				} else if (before && after) {
-					commit = null; // contested boundary → skip
-				} else {
-					const one = before ?? after;
-					if (one && withinReach(entries[i], entries[one.idx])) commit = one.commit;
-				}
-			}
-			if (commit && targetSet.has(commit)) collect(into, commit, entries[i]);
-		}
-	}
-}
-
-function lastBefore(anchored: ReadonlyArray<{ idx: number; commit: string }>, i: number) {
-	let res: { idx: number; commit: string } | undefined;
-	for (const a of anchored) {
-		if (a.idx < i) res = a;
-		else break;
-	}
-	return res;
-}
-
-function firstAfter(anchored: ReadonlyArray<{ idx: number; commit: string }>, i: number) {
-	for (const a of anchored) if (a.idx > i) return a;
-	return undefined;
-}
-
-function withinReach(a: RawEntry, b: RawEntry): boolean {
-	if (Number.isNaN(a.tsMs) || Number.isNaN(b.tsMs)) return false;
-	return Math.abs(a.tsMs - b.tsMs) <= ONE_SIDED_MS;
-}
-
-/**
- * Time-window (MEDIUM) attribution: for an anchor-less work segment, attribute it
- * to a target commit iff exactly one *uncovered* target was committed within
- * `SEGMENT_GAP_MS` after the segment ended (the work led straight into it).
- *
- * Branch gate: a candidate on a *different* branch than the segment is dropped —
- * a branch-A discussion must not be attributed to a branch-B commit that merely
- * happened to land next. The gate only fires when BOTH branches are known
- * (commit branch from `%S`, segment branch from its entries' modal `gitBranch`);
- * when either is unknown it does not constrain (mirrors the undefined-inherit
- * rule in segmentation).
- */
-function attributeMedium(
-	anchorlessSegments: ReadonlyArray<{ entries: RawEntry[] }>,
-	index: CommitTargetIndex,
-	targets: ReadonlyArray<string>,
-	covered: ReadonlySet<string>,
-	into: Map<string, RawEntry[]>,
-): void {
-	const uncovered = targets.filter((t) => !covered.has(t) && index.commitMeta.has(t));
-	for (const seg of anchorlessSegments) {
-		const times = seg.entries.map((e) => e.tsMs).filter((t) => !Number.isNaN(t));
-		if (times.length === 0) continue;
-		// reduce (not Math.max(...spread)) — a session segment can hold tens of
-		// thousands of entries, and spreading that many args overflows the call stack.
-		const segEnd = times.reduce((m, t) => (t > m ? t : m), Number.NEGATIVE_INFINITY);
-		const segBranch = modalBranch(seg.entries);
-		const cands = uncovered.filter((t) => {
-			const meta = index.commitMeta.get(t);
-			const ts = meta?.ts ?? Number.NaN;
-			if (ts < segEnd || ts - segEnd > SEGMENT_GAP_MS) return false;
-			// Branch gate: reject only when both branches are known and differ.
-			if (meta?.branch && segBranch && meta.branch !== segBranch) return false;
-			return true;
-		});
-		if (cands.length === 1) {
-			for (const e of seg.entries) collect(into, cands[0], e);
-		}
-	}
 }
 
 /** Picks the most frequent gitBranch among entries (fallback: ""). */
@@ -231,6 +143,7 @@ function buildSessions(entries: ReadonlyArray<RawEntry>): SessionTranscript[] {
 	}
 	const sessions: SessionTranscript[] = [];
 	for (const [sessionId, list] of bySid) {
+		// Disjoint segments mean each entry is collected at most once; just order it.
 		list.sort((a, b) => a.lineNo - b.lineNo);
 		const tEntries: TranscriptEntry[] = list.map((e) => ({
 			role: e.role as "human" | "assistant",
@@ -243,12 +156,74 @@ function buildSessions(entries: ReadonlyArray<RawEntry>): SessionTranscript[] {
 }
 
 /**
+ * HIGH (file-overlap) collection for commit C over one pre-segmented session:
+ * any segment that edited one of C's files inside the window contributes its
+ * in-window slice.
+ */
+function collectFileOverlap(
+	session: SessionSegments,
+	relSet: ReadonlySet<string>,
+	baseSet: ReadonlySet<string>,
+	lo: number,
+	hi: number,
+	commit: string,
+	into: Map<string, RawEntry[]>,
+): boolean {
+	const { entries, segs } = session;
+	let got = false;
+	for (const seg of segs) {
+		let touched = false;
+		for (let i = seg.start; i < seg.end; i++) {
+			if (inWindow(entries[i], lo, hi) && touchesFiles(entries[i], relSet, baseSet)) {
+				touched = true;
+				break;
+			}
+		}
+		if (!touched) continue;
+		got = true;
+		for (let i = seg.start; i < seg.end; i++) {
+			if (inWindow(entries[i], lo, hi)) collect(into, commit, entries[i]);
+		}
+	}
+	return got;
+}
+
+/**
+ * MEDIUM (time-window, ③) collection for commit C: in-window segments that end
+ * within SEGMENT_GAP before C and are branch-compatible, with no file overlap.
+ */
+function collectTimeWindow(
+	session: SessionSegments,
+	lo: number,
+	hi: number,
+	commitBranch: string | undefined,
+	commit: string,
+	into: Map<string, RawEntry[]>,
+): void {
+	const { entries, segs } = session;
+	for (const seg of segs) {
+		const slice: RawEntry[] = [];
+		let segEnd = Number.NEGATIVE_INFINITY;
+		for (let i = seg.start; i < seg.end; i++) {
+			if (!inWindow(entries[i], lo, hi)) continue;
+			slice.push(entries[i]);
+			if (entries[i].tsMs > segEnd) segEnd = entries[i].tsMs;
+		}
+		if (slice.length === 0) continue;
+		if (hi - segEnd > SEGMENT_GAP_MS) continue; // work didn't lead straight into the commit
+		const sb = modalBranch(slice);
+		if (commitBranch && sb && commitBranch !== sb) continue; // branch gate
+		for (const e of slice) collect(into, commit, e);
+	}
+}
+
+/**
  * Attributes transcript slices to the given target commits.
  *
  * @param targets   commit hashes (lacking summaries) to attribute
  * @param bySession scanner output (sessionId → time-ordered RawEntry[])
  * @param index     real-commit target index
- * @param opts.includeMedium  also emit time-window (MEDIUM) attributions
+ * @param opts.includeMedium  also emit time-window (MEDIUM) attributions (③)
  */
 export function attributeCommits(
 	targets: ReadonlyArray<string>,
@@ -256,49 +231,60 @@ export function attributeCommits(
 	index: CommitTargetIndex,
 	opts: { includeMedium?: boolean } = {},
 ): AttributionResult {
-	const targetSet = new Set(targets);
-	const highEntries = new Map<string, RawEntry[]>();
-	const anchorlessSegments: { entries: RawEntry[] }[] = [];
-
-	for (const entries of bySession.values()) {
-		attributeSessionHigh(entries, index, targetSet, highEntries, anchorlessSegments);
-	}
-
-	const medEntries = new Map<string, RawEntry[]>();
-	if (opts.includeMedium) {
-		attributeMedium(anchorlessSegments, index, targets, new Set(highEntries.keys()), medEntries);
-	}
+	// Pre-segment every session once (reused across all targets).
+	const sessions: SessionSegments[] = [];
+	for (const entries of bySession.values()) sessions.push({ entries, segs: segmentSession(entries) });
 
 	const attributed = new Map<string, AttributedCommit>();
 	const skipped: string[] = [];
+
 	for (const hash of targets) {
-		const high = highEntries.get(hash);
-		const med = high ? undefined : medEntries.get(hash);
-		const entries = high ?? med;
-		const confidence: "high" | "medium" = high ? "high" : "medium";
-		const method: "file-overlap" | "time-window" = high ? "file-overlap" : "time-window";
+		const meta = index.commitMeta.get(hash);
+		const files = index.commitFiles.get(hash);
+		if (!meta || !files || files.length === 0) {
+			skipped.push(hash); // not a real code commit / no files → diff-only by engine
+			continue;
+		}
+		const hi = meta.ts; // ② commit-time upper bound
+		const lo = attributionLowerBound(index, hash, hi, WINDOW_CAP_MS); // ① commit-boundary lower bound
+		const relSet = new Set(files.map(normalizePathForCompare));
+		const baseSet = new Set(files.map((f) => normalizePathForCompare(basename(f))));
+
+		const high = new Map<string, RawEntry[]>();
+		let gotFileOverlap = false;
+		for (const s of sessions) {
+			if (collectFileOverlap(s, relSet, baseSet, lo, hi, hash, high)) gotFileOverlap = true;
+		}
+
+		let method: "file-overlap" | "time-window" = "file-overlap";
+		let entries = high.get(hash);
+		if (!gotFileOverlap && opts.includeMedium) {
+			const med = new Map<string, RawEntry[]>();
+			for (const s of sessions) collectTimeWindow(s, lo, hi, meta.branch, hash, med);
+			entries = med.get(hash);
+			method = "time-window";
+		}
+
 		if (!entries || entries.length === 0) {
 			skipped.push(hash);
 			continue;
 		}
-		const sessions = buildSessions(entries);
-		if (sessions.length === 0) {
-			// All attributed entries were non-conversational (pure tool calls) — no
-			// text to summarize, so there is nothing useful to generate.
-			skipped.push(hash);
+		const sessionsOut = buildSessions(entries);
+		if (sessionsOut.length === 0) {
+			skipped.push(hash); // attributed entries were all non-conversational tool calls
 			continue;
 		}
-		const conversationTurns = sessions.reduce(
+		const conversationTurns = sessionsOut.reduce(
 			(sum, s) => sum + s.entries.filter((e) => e.role === "human").length,
 			0,
 		);
-		const transcriptEntries = sessions.reduce((sum, s) => sum + s.entries.length, 0);
+		const transcriptEntries = sessionsOut.reduce((sum, s) => sum + s.entries.length, 0);
 		attributed.set(hash, {
 			commitHash: hash,
-			confidence,
+			confidence: method === "file-overlap" ? "high" : "medium",
 			method,
 			branch: modalBranch(entries),
-			sessions,
+			sessions: sessionsOut,
 			transcriptEntries,
 			conversationTurns,
 		});

--- a/cli/src/backfill/CommitAttributor.ts
+++ b/cli/src/backfill/CommitAttributor.ts
@@ -1,0 +1,309 @@
+/**
+ * CommitAttributor — maps on-disk Claude transcript slices to historical commits.
+ *
+ * Isolated from the live cursor/queue flow. Operates on the offline indexes built
+ * by {@link RawTranscriptScanner} and {@link CommitTargetIndex}. The algorithm and
+ * its confidence tiers were validated against real local data (see the plan):
+ * locality holds — a commit's edits form a single contiguous run in a session, so
+ * attribution propagates safely from a file-overlap anchor to its neighbours.
+ *
+ * Per target commit C the result is one of:
+ *   - HIGH (file-overlap): at least one edited file in the attributed run matches
+ *     C's diff (C is the first commit to touch that file after the edit). The run
+ *     = the anchor edits + the conversational turns the propagation reaches.
+ *   - MEDIUM (time-window, opt-in): no file overlap, but a single anchor-less work
+ *     segment ends immediately before C with no competing commit in the gap.
+ *   - skipped: contested / no signal — nothing is generated (宁缺毋滥).
+ */
+
+import type { SessionTranscript } from "../core/TranscriptReader.js";
+import { createLogger } from "../Logger.js";
+import type { TranscriptEntry } from "../Types.js";
+import { anchorCommitForEdit, type CommitTargetIndex } from "./CommitTargetIndex.js";
+import type { RawEntry } from "./RawTranscriptScanner.js";
+
+const log = createLogger("CommitAttributor");
+
+const SEGMENT_GAP_MS = 2 * 60 * 60 * 1000; // 2h idle splits a work segment
+const ONE_SIDED_MS = 30 * 60 * 1000; // one-sided propagation reach
+
+export interface AttributedCommit {
+	readonly commitHash: string;
+	readonly confidence: "high" | "medium";
+	readonly method: "file-overlap" | "time-window";
+	readonly branch: string;
+	readonly sessions: ReadonlyArray<SessionTranscript>;
+	readonly transcriptEntries: number;
+	readonly conversationTurns: number;
+}
+
+export interface AttributionResult {
+	/** Target commits that earned a confident attribution. */
+	readonly attributed: ReadonlyMap<string, AttributedCommit>;
+	/** Target commits with no confident attribution (skipped under 宁缺毋滥). */
+	readonly skipped: ReadonlyArray<string>;
+}
+
+interface Segment {
+	readonly start: number;
+	readonly end: number; // exclusive
+}
+
+/** Splits a session's time-ordered entries into work segments. */
+function segmentSession(entries: ReadonlyArray<RawEntry>): Segment[] {
+	const segs: Segment[] = [];
+	let start = 0;
+	for (let i = 1; i <= entries.length; i++) {
+		let brk = i === entries.length;
+		if (!brk) {
+			const prev = entries[i - 1];
+			const cur = entries[i];
+			// Split on a branch change only when BOTH sides have a known branch and
+			// they differ. Early Claude transcripts omit `gitBranch` on some lines;
+			// treating undefined as a new branch would shred a continuous work run
+			// into spurious segments. Undefined inherits the surrounding branch.
+			if (cur.gitBranch && prev.gitBranch && cur.gitBranch !== prev.gitBranch) brk = true;
+			else if (!Number.isNaN(cur.tsMs) && !Number.isNaN(prev.tsMs) && cur.tsMs - prev.tsMs > SEGMENT_GAP_MS)
+				brk = true;
+		}
+		if (brk) {
+			segs.push({ start, end: i });
+			start = i;
+		}
+	}
+	return segs;
+}
+
+/** Modal commit hash among an entry's edited files (first file wins on ties). */
+function anchorForEntry(index: CommitTargetIndex, e: RawEntry): string | null {
+	if (e.editedRel.length === 0 || Number.isNaN(e.tsMs)) return null;
+	const counts = new Map<string, number>();
+	let bestHash: string | null = null;
+	let bestCount = 0;
+	for (let k = 0; k < e.editedRel.length; k++) {
+		const hash = anchorCommitForEdit(index, e.editedRel[k], e.editedBase[k] ?? "", e.tsMs);
+		if (!hash) continue;
+		const c = (counts.get(hash) ?? 0) + 1;
+		counts.set(hash, c);
+		if (c > bestCount) {
+			bestCount = c;
+			bestHash = hash;
+		}
+	}
+	return bestHash;
+}
+
+/** Appends `e` to the per-commit collection map. */
+function collect(map: Map<string, RawEntry[]>, commit: string, e: RawEntry): void {
+	const list = map.get(commit);
+	if (list) list.push(e);
+	else map.set(commit, [e]);
+}
+
+/**
+ * File-overlap (HIGH) attribution within one session: anchor edits, then
+ * propagate to no-signal neighbours bounded by the segment and by competing
+ * anchors. Only commits in `targetSet` are collected. Anchors pointing at
+ * non-target commits still act as propagation boundaries.
+ */
+function attributeSessionHigh(
+	entries: ReadonlyArray<RawEntry>,
+	index: CommitTargetIndex,
+	targetSet: ReadonlySet<string>,
+	into: Map<string, RawEntry[]>,
+	anchorlessSegments: { entries: RawEntry[] }[],
+): void {
+	const anchors = entries.map((e) => anchorForEntry(index, e));
+	for (const seg of segmentSession(entries)) {
+		const anchored: { idx: number; commit: string }[] = [];
+		for (let i = seg.start; i < seg.end; i++) {
+			const a = anchors[i];
+			if (a) anchored.push({ idx: i, commit: a });
+		}
+		if (anchored.length === 0) {
+			anchorlessSegments.push({ entries: entries.slice(seg.start, seg.end) });
+			continue;
+		}
+		for (let i = seg.start; i < seg.end; i++) {
+			let commit: string | null = anchors[i];
+			if (!commit) {
+				const before = lastBefore(anchored, i);
+				const after = firstAfter(anchored, i);
+				if (before && after && before.commit === after.commit) {
+					commit = before.commit; // enclosed by same commit → inherit
+				} else if (before && after) {
+					commit = null; // contested boundary → skip
+				} else {
+					const one = before ?? after;
+					if (one && withinReach(entries[i], entries[one.idx])) commit = one.commit;
+				}
+			}
+			if (commit && targetSet.has(commit)) collect(into, commit, entries[i]);
+		}
+	}
+}
+
+function lastBefore(anchored: ReadonlyArray<{ idx: number; commit: string }>, i: number) {
+	let res: { idx: number; commit: string } | undefined;
+	for (const a of anchored) {
+		if (a.idx < i) res = a;
+		else break;
+	}
+	return res;
+}
+
+function firstAfter(anchored: ReadonlyArray<{ idx: number; commit: string }>, i: number) {
+	for (const a of anchored) if (a.idx > i) return a;
+	return undefined;
+}
+
+function withinReach(a: RawEntry, b: RawEntry): boolean {
+	if (Number.isNaN(a.tsMs) || Number.isNaN(b.tsMs)) return false;
+	return Math.abs(a.tsMs - b.tsMs) <= ONE_SIDED_MS;
+}
+
+/**
+ * Time-window (MEDIUM) attribution: for an anchor-less work segment, attribute it
+ * to a target commit iff exactly one *uncovered* target was committed within
+ * `SEGMENT_GAP_MS` after the segment ended (the work led straight into it).
+ *
+ * Branch gate: a candidate on a *different* branch than the segment is dropped —
+ * a branch-A discussion must not be attributed to a branch-B commit that merely
+ * happened to land next. The gate only fires when BOTH branches are known
+ * (commit branch from `%S`, segment branch from its entries' modal `gitBranch`);
+ * when either is unknown it does not constrain (mirrors the undefined-inherit
+ * rule in segmentation).
+ */
+function attributeMedium(
+	anchorlessSegments: ReadonlyArray<{ entries: RawEntry[] }>,
+	index: CommitTargetIndex,
+	targets: ReadonlyArray<string>,
+	covered: ReadonlySet<string>,
+	into: Map<string, RawEntry[]>,
+): void {
+	const uncovered = targets.filter((t) => !covered.has(t) && index.commitMeta.has(t));
+	for (const seg of anchorlessSegments) {
+		const times = seg.entries.map((e) => e.tsMs).filter((t) => !Number.isNaN(t));
+		if (times.length === 0) continue;
+		// reduce (not Math.max(...spread)) — a session segment can hold tens of
+		// thousands of entries, and spreading that many args overflows the call stack.
+		const segEnd = times.reduce((m, t) => (t > m ? t : m), Number.NEGATIVE_INFINITY);
+		const segBranch = modalBranch(seg.entries);
+		const cands = uncovered.filter((t) => {
+			const meta = index.commitMeta.get(t);
+			const ts = meta?.ts ?? Number.NaN;
+			if (ts < segEnd || ts - segEnd > SEGMENT_GAP_MS) return false;
+			// Branch gate: reject only when both branches are known and differ.
+			if (meta?.branch && segBranch && meta.branch !== segBranch) return false;
+			return true;
+		});
+		if (cands.length === 1) {
+			for (const e of seg.entries) collect(into, cands[0], e);
+		}
+	}
+}
+
+/** Picks the most frequent gitBranch among entries (fallback: ""). */
+function modalBranch(entries: ReadonlyArray<RawEntry>): string {
+	const counts = new Map<string, number>();
+	let best = "";
+	let bestCount = 0;
+	for (const e of entries) {
+		if (!e.gitBranch) continue;
+		const c = (counts.get(e.gitBranch) ?? 0) + 1;
+		counts.set(e.gitBranch, c);
+		if (c > bestCount) {
+			bestCount = c;
+			best = e.gitBranch;
+		}
+	}
+	return best;
+}
+
+/** Groups attributed entries into per-session SessionTranscripts for the summarizer. */
+function buildSessions(entries: ReadonlyArray<RawEntry>): SessionTranscript[] {
+	const bySid = new Map<string, RawEntry[]>();
+	for (const e of entries) {
+		if (!e.content || !e.role) continue; // only conversational turns reach the LLM
+		const list = bySid.get(e.sessionId);
+		if (list) list.push(e);
+		else bySid.set(e.sessionId, [e]);
+	}
+	const sessions: SessionTranscript[] = [];
+	for (const [sessionId, list] of bySid) {
+		list.sort((a, b) => a.lineNo - b.lineNo);
+		const tEntries: TranscriptEntry[] = list.map((e) => ({
+			role: e.role as "human" | "assistant",
+			content: e.content as string,
+			...(e.ts ? { timestamp: e.ts } : {}),
+		}));
+		sessions.push({ sessionId, transcriptPath: list[0].transcriptPath, source: "claude", entries: tEntries });
+	}
+	return sessions;
+}
+
+/**
+ * Attributes transcript slices to the given target commits.
+ *
+ * @param targets   commit hashes (lacking summaries) to attribute
+ * @param bySession scanner output (sessionId → time-ordered RawEntry[])
+ * @param index     real-commit target index
+ * @param opts.includeMedium  also emit time-window (MEDIUM) attributions
+ */
+export function attributeCommits(
+	targets: ReadonlyArray<string>,
+	bySession: ReadonlyMap<string, RawEntry[]>,
+	index: CommitTargetIndex,
+	opts: { includeMedium?: boolean } = {},
+): AttributionResult {
+	const targetSet = new Set(targets);
+	const highEntries = new Map<string, RawEntry[]>();
+	const anchorlessSegments: { entries: RawEntry[] }[] = [];
+
+	for (const entries of bySession.values()) {
+		attributeSessionHigh(entries, index, targetSet, highEntries, anchorlessSegments);
+	}
+
+	const medEntries = new Map<string, RawEntry[]>();
+	if (opts.includeMedium) {
+		attributeMedium(anchorlessSegments, index, targets, new Set(highEntries.keys()), medEntries);
+	}
+
+	const attributed = new Map<string, AttributedCommit>();
+	const skipped: string[] = [];
+	for (const hash of targets) {
+		const high = highEntries.get(hash);
+		const med = high ? undefined : medEntries.get(hash);
+		const entries = high ?? med;
+		const confidence: "high" | "medium" = high ? "high" : "medium";
+		const method: "file-overlap" | "time-window" = high ? "file-overlap" : "time-window";
+		if (!entries || entries.length === 0) {
+			skipped.push(hash);
+			continue;
+		}
+		const sessions = buildSessions(entries);
+		if (sessions.length === 0) {
+			// All attributed entries were non-conversational (pure tool calls) — no
+			// text to summarize, so there is nothing useful to generate.
+			skipped.push(hash);
+			continue;
+		}
+		const conversationTurns = sessions.reduce(
+			(sum, s) => sum + s.entries.filter((e) => e.role === "human").length,
+			0,
+		);
+		const transcriptEntries = sessions.reduce((sum, s) => sum + s.entries.length, 0);
+		attributed.set(hash, {
+			commitHash: hash,
+			confidence,
+			method,
+			branch: modalBranch(entries),
+			sessions,
+			transcriptEntries,
+			conversationTurns,
+		});
+	}
+
+	log.info("Attribution: %d high/med, %d skipped (of %d targets)", attributed.size, skipped.length, targets.length);
+	return { attributed, skipped };
+}

--- a/cli/src/backfill/CommitAttributor.ts
+++ b/cli/src/backfill/CommitAttributor.ts
@@ -4,21 +4,27 @@
  * Isolated from the live cursor/queue flow. Operates on the offline indexes built
  * by {@link RawTranscriptScanner} and {@link CommitTargetIndex}.
  *
- * Model (per target commit C, see the recall study doc for why this replaced the
- * earlier "first-committer" anchoring):
- *   - Window = (L, T]  where T = C's commit time (② upper bound: a commit's
+ * Model (v6 — "effective worktree + time window + cursor slicing", which replaced
+ * the earlier HIGH-only / opt-in-MEDIUM model). Per target commit C:
+ *   - Window = (L, T]  where T = C's author time (② upper bound: a commit's
  *     conversation can only precede the commit) and L = the previous time any of
- *     C's files was committed (① commit-boundary lower bound: consecutive commits
- *     touching overlapping files don't bleed into each other). L is capped to a
- *     max lookback so a long-dormant file doesn't open a huge window.
- *   - HIGH (file-overlap): a session segment that *edited one of C's files inside
- *     the window* contributes its in-window slice — independent of which commit
- *     "first committed" the file. This is what recovers the conversation even for
- *     commits that are not the first committer of their files.
- *   - MEDIUM (time-window, opt-in via includeMedium / ③): when no session edited
- *     C's files in the window, fall back to in-window segments that end right
- *     before C on a branch-compatible session.
- *   - none → the engine falls back to a diff-only summary.
+ *     C's files was committed (① commit-boundary lower bound, capped to a max
+ *     lookback so a long-dormant file doesn't open a huge window).
+ *   - Anchor = an in-window entry that edited one of C's files. The set of
+ *     worktrees (cwd, normalized to a repo worktree root) that hold C's anchors is
+ *     C's **effective worktree** `effWt`; the modal `gitBranch` of the anchors is
+ *     C's **effective branch** `effBranch`. A commit with no anchor is not
+ *     attributed (→ engine diff-only).
+ *   - Cursor: within one worktree, target commits are ordered by author time and
+ *     an in-window entry is owned by the *earliest* commit at/after it — so a long
+ *     session spanning two commits is sliced into contiguous per-commit blocks and
+ *     an already-summarized / out-of-range neighbor truncates the window.
+ *   - Tiers of the collected in-window turns (within effWt + owning cursor):
+ *       HIGH   (file-overlap)  — the turn's segment contains an anchor;
+ *       MEDIUM (branch-match)  — the turn is on `effBranch`;
+ *       LOW    (time-window)   — pure window (catches "planning on main").
+ *     `minTier` drops turns below the threshold. The commit-level confidence is
+ *     the *weakest* tier actually kept (so a badge never overclaims).
  */
 
 import { normalizePathForCompare } from "../core/PathUtils.js";
@@ -34,10 +40,19 @@ const SEGMENT_GAP_MS = 2 * 60 * 60 * 1000; // 2h idle splits a work segment
 /** Max window lookback when a commit's files have no earlier commit (e.g. new files). */
 const WINDOW_CAP_MS = 7 * 24 * 60 * 60 * 1000;
 
+/** Confidence tiers, weakest → strongest. */
+export type ConfidenceTier = "low" | "medium" | "high";
+const TIER_RANK: Record<ConfidenceTier, number> = { low: 0, medium: 1, high: 2 };
+const TIER_METHOD: Record<ConfidenceTier, AttributedCommit["method"]> = {
+	high: "file-overlap",
+	medium: "branch-match",
+	low: "time-window",
+};
+
 export interface AttributedCommit {
 	readonly commitHash: string;
-	readonly confidence: "high" | "medium";
-	readonly method: "file-overlap" | "time-window";
+	readonly confidence: ConfidenceTier;
+	readonly method: "file-overlap" | "branch-match" | "time-window";
 	readonly branch: string;
 	readonly sessions: ReadonlyArray<SessionTranscript>;
 	readonly transcriptEntries: number;
@@ -47,8 +62,20 @@ export interface AttributedCommit {
 export interface AttributionResult {
 	/** Target commits that earned a confident attribution. */
 	readonly attributed: ReadonlyMap<string, AttributedCommit>;
-	/** Target commits with no confident attribution (engine → diff-only). */
+	/** `emitOnly` commits with no confident attribution (engine → diff-only). */
 	readonly skipped: ReadonlyArray<string>;
+}
+
+export interface AttributeOptions {
+	/** Lowest tier to emit (default "high"). "low" = window-collect-all. */
+	readonly minTier?: ConfidenceTier;
+	/** Only produce attributions for these hashes. Others in `candidates` act as
+	 *  cursor boundaries only. Default: every candidate is emitted. */
+	readonly emitOnly?: ReadonlySet<string>;
+	/** Repo worktree roots; each entry's `cwd` is normalized to its longest-matching
+	 *  root as its worktree identity (NOT the transcript dir — subdir launches would
+	 *  split one worktree into several). Default: cwd is its own identity. */
+	readonly worktreeRoots?: ReadonlyArray<string>;
 }
 
 interface Segment {
@@ -56,9 +83,21 @@ interface Segment {
 	readonly end: number; // exclusive
 }
 
-interface SessionSegments {
+interface PreparedSession {
 	readonly entries: ReadonlyArray<RawEntry>;
 	readonly segs: ReadonlyArray<Segment>;
+	/** worktreeKey per entry (parallel to `entries`). */
+	readonly wkeys: ReadonlyArray<string>;
+}
+
+interface CommitCtx {
+	readonly hash: string;
+	readonly lo: number;
+	readonly hi: number;
+	readonly relSet: ReadonlySet<string>;
+	readonly baseSet: ReadonlySet<string>;
+	readonly effWt: Set<string>;
+	effBranch: string;
 }
 
 /** Splits a session's time-ordered entries into work segments (branch change / >2h gap). */
@@ -108,11 +147,20 @@ function basename(p: string): string {
 	return i >= 0 ? p.slice(i + 1) : p;
 }
 
-/** Appends `e` to the per-commit collection map (dedup by lineNo+session within a commit). */
-function collect(map: Map<string, RawEntry[]>, commit: string, e: RawEntry): void {
-	const list = map.get(commit);
-	if (list) list.push(e);
-	else map.set(commit, [e]);
+/**
+ * Resolves the worktree identity of a transcript entry's `cwd`: the longest
+ * normalized worktree root that `cwd` equals or is nested under. Falls back to the
+ * normalized `cwd` itself when it matches no root (isolated repo / test), or ""
+ * when `cwd` is absent. Longest-match handles nested roots / submodules.
+ */
+function resolveWorktreeKey(cwd: string | undefined, normRoots: ReadonlyArray<string>): string {
+	if (!cwd) return "";
+	const c = normalizePathForCompare(cwd);
+	let best = "";
+	for (const r of normRoots) {
+		if ((c === r || c.startsWith(`${r}/`)) && r.length > best.length) best = r;
+	}
+	return best || c;
 }
 
 /** Picks the most frequent gitBranch among entries (fallback: ""). */
@@ -156,124 +204,182 @@ function buildSessions(entries: ReadonlyArray<RawEntry>): SessionTranscript[] {
 }
 
 /**
- * HIGH (file-overlap) collection for commit C over one pre-segmented session:
- * any segment that edited one of C's files inside the window contributes its
- * in-window slice.
- */
-function collectFileOverlap(
-	session: SessionSegments,
-	relSet: ReadonlySet<string>,
-	baseSet: ReadonlySet<string>,
-	lo: number,
-	hi: number,
-	commit: string,
-	into: Map<string, RawEntry[]>,
-): boolean {
-	const { entries, segs } = session;
-	let got = false;
-	for (const seg of segs) {
-		let touched = false;
-		for (let i = seg.start; i < seg.end; i++) {
-			if (inWindow(entries[i], lo, hi) && touchesFiles(entries[i], relSet, baseSet)) {
-				touched = true;
-				break;
-			}
-		}
-		if (!touched) continue;
-		got = true;
-		for (let i = seg.start; i < seg.end; i++) {
-			if (inWindow(entries[i], lo, hi)) collect(into, commit, entries[i]);
-		}
-	}
-	return got;
-}
-
-/**
- * MEDIUM (time-window, ③) collection for commit C: in-window segments that end
- * within SEGMENT_GAP before C and are branch-compatible, with no file overlap.
- */
-function collectTimeWindow(
-	session: SessionSegments,
-	lo: number,
-	hi: number,
-	commitBranch: string | undefined,
-	commit: string,
-	into: Map<string, RawEntry[]>,
-): void {
-	const { entries, segs } = session;
-	for (const seg of segs) {
-		const slice: RawEntry[] = [];
-		let segEnd = Number.NEGATIVE_INFINITY;
-		for (let i = seg.start; i < seg.end; i++) {
-			if (!inWindow(entries[i], lo, hi)) continue;
-			slice.push(entries[i]);
-			if (entries[i].tsMs > segEnd) segEnd = entries[i].tsMs;
-		}
-		if (slice.length === 0) continue;
-		if (hi - segEnd > SEGMENT_GAP_MS) continue; // work didn't lead straight into the commit
-		const sb = modalBranch(slice);
-		if (commitBranch && sb && commitBranch !== sb) continue; // branch gate
-		for (const e of slice) collect(into, commit, e);
-	}
-}
-
-/**
- * Attributes transcript slices to the given target commits.
+ * Attributes transcript slices to the given target commits (v6 model).
  *
- * @param targets   commit hashes (lacking summaries) to attribute
- * @param bySession scanner output (sessionId → time-ordered RawEntry[])
- * @param index     real-commit target index
- * @param opts.includeMedium  also emit time-window (MEDIUM) attributions (③)
+ * @param candidates  every candidate commit hash — used to build cursor
+ *   boundaries (⊇ `emitOnly`; already-summarized / out-of-range neighbors matter).
+ * @param bySession   scanner output (sessionId → time-ordered RawEntry[]).
+ * @param index       real-commit target index.
+ * @param opts        see {@link AttributeOptions}.
  */
 export function attributeCommits(
-	targets: ReadonlyArray<string>,
+	candidates: ReadonlyArray<string>,
 	bySession: ReadonlyMap<string, RawEntry[]>,
 	index: CommitTargetIndex,
-	opts: { includeMedium?: boolean } = {},
+	opts: AttributeOptions = {},
 ): AttributionResult {
-	// Pre-segment every session once (reused across all targets).
-	const sessions: SessionSegments[] = [];
-	for (const entries of bySession.values()) sessions.push({ entries, segs: segmentSession(entries) });
+	// Default "low" (window-collect-all) — the same unified tier every product entry
+	// point uses; the per-commit confidence rollup still labels weaker turns honestly.
+	const minTier: ConfidenceTier = opts.minTier ?? "low";
+	const emitOnly = opts.emitOnly ?? new Set(candidates);
+	const normRoots = (opts.worktreeRoots ?? []).map((r) => normalizePathForCompare(r));
 
+	// Pre-segment every session once and resolve each entry's worktree identity.
+	const sessions: PreparedSession[] = [];
+	for (const entries of bySession.values()) {
+		sessions.push({
+			entries,
+			segs: segmentSession(entries),
+			wkeys: entries.map((e) => resolveWorktreeKey(e.cwd, normRoots)),
+		});
+	}
+
+	// Per-candidate window + file signature (only commits that are real code targets).
+	const ctxByHash = new Map<string, CommitCtx>();
+	for (const hash of candidates) {
+		const meta = index.commitMeta.get(hash);
+		const files = index.commitFiles.get(hash);
+		if (!meta || !files || files.length === 0) continue;
+		const hi = meta.ts; // ② commit-time upper bound
+		const lo = attributionLowerBound(index, hash, hi, WINDOW_CAP_MS); // ① commit-boundary lower bound
+		ctxByHash.set(hash, {
+			hash,
+			lo,
+			hi,
+			relSet: new Set(files.map(normalizePathForCompare)),
+			baseSet: new Set(files.map((f) => normalizePathForCompare(basename(f)))),
+			effWt: new Set<string>(),
+			effBranch: "",
+		});
+	}
+
+	// Phase 1 — derive effective worktree + branch for EVERY candidate (anchors =
+	// in-window file edits). `effBranch` is the modal branch of the anchor turns,
+	// NOT the whole window (main chatter must not out-vote the real feature work).
+	for (const ctx of ctxByHash.values()) {
+		const anchors: RawEntry[] = [];
+		for (const s of sessions) {
+			for (let i = 0; i < s.entries.length; i++) {
+				const e = s.entries[i];
+				if (inWindow(e, ctx.lo, ctx.hi) && touchesFiles(e, ctx.relSet, ctx.baseSet)) {
+					anchors.push(e);
+					ctx.effWt.add(s.wkeys[i]);
+				}
+			}
+		}
+		if (ctx.effWt.size === 0) continue;
+		let eb = modalBranch(anchors);
+		if (!eb) {
+			// Anchors carried no branch — fall back to the modal branch across the
+			// whole in-window slice within the effective worktree.
+			const inWt: RawEntry[] = [];
+			for (const s of sessions) {
+				for (let i = 0; i < s.entries.length; i++) {
+					if (ctx.effWt.has(s.wkeys[i]) && inWindow(s.entries[i], ctx.lo, ctx.hi)) inWt.push(s.entries[i]);
+				}
+			}
+			eb = modalBranch(inWt);
+		}
+		ctx.effBranch = eb;
+	}
+
+	// Phase 2 — cursor: order each worktree's candidate commits by author time; an
+	// entry is owned by the earliest commit at/after it (contiguous slicing).
+	const wt2commits = new Map<string, { hash: string; ts: number }[]>();
+	for (const ctx of ctxByHash.values()) {
+		for (const wt of ctx.effWt) {
+			const rec = { hash: ctx.hash, ts: ctx.hi };
+			const list = wt2commits.get(wt);
+			if (list) list.push(rec);
+			else wt2commits.set(wt, [rec]);
+		}
+	}
+	for (const list of wt2commits.values()) list.sort((a, b) => a.ts - b.ts);
+	// The owner is the earliest commit at/after `tms`. Callers only pass a `wt` that
+	// is in some commit's effWt (so `list` is present) and an in-window entry (so the
+	// owning commit C, with ts = C.hi >= tms, is in `list`) — the guards below are
+	// unreachable defensive fall-throughs, hence the coverage ignores.
+	const cursorOwner = (wt: string, tms: number): string => {
+		const list = wt2commits.get(wt);
+		/* v8 ignore next -- list always present: caller filters on effWt membership */
+		if (!list) return "";
+		for (const rec of list) if (rec.ts >= tms) return rec.hash;
+		/* v8 ignore next -- unreachable: the owning commit C has ts = C.hi >= tms */
+		return "";
+	};
+
+	// Phase 3 — collect + tier for each emitted commit.
 	const attributed = new Map<string, AttributedCommit>();
 	const skipped: string[] = [];
 
-	for (const hash of targets) {
-		const meta = index.commitMeta.get(hash);
-		const files = index.commitFiles.get(hash);
-		if (!meta || !files || files.length === 0) {
-			skipped.push(hash); // not a real code commit / no files → diff-only by engine
+	for (const hash of candidates) {
+		if (!emitOnly.has(hash)) continue;
+		const ctx = ctxByHash.get(hash);
+		if (!ctx || ctx.effWt.size === 0) {
+			skipped.push(hash); // no anchor / not a code commit → engine diff-only
 			continue;
 		}
-		const hi = meta.ts; // ② commit-time upper bound
-		const lo = attributionLowerBound(index, hash, hi, WINDOW_CAP_MS); // ① commit-boundary lower bound
-		const relSet = new Set(files.map(normalizePathForCompare));
-		const baseSet = new Set(files.map((f) => normalizePathForCompare(basename(f))));
 
-		const high = new Map<string, RawEntry[]>();
-		let gotFileOverlap = false;
+		const collected: RawEntry[] = [];
+		let sawMed = false;
+		let sawLow = false;
+
 		for (const s of sessions) {
-			if (collectFileOverlap(s, relSet, baseSet, lo, hi, hash, high)) gotFileOverlap = true;
+			for (const seg of s.segs) {
+				// HIGH applies to a turn whose segment holds a file edit that THIS commit
+				// actually owns — an anchor that is in-window, touches C's files, and whose
+				// worktree slice the cursor assigns to C. Scope it per worktree key: a turn
+				// is HIGH only if its own worktree has such an anchor in this segment (so a
+				// neighbor-owned edit, or an edit in a different worktree the segment spans,
+				// never inflates it).
+				const anchorWks = new Set<string>();
+				for (let i = seg.start; i < seg.end; i++) {
+					const e = s.entries[i];
+					const wk = s.wkeys[i];
+					if (
+						ctx.effWt.has(wk) &&
+						inWindow(e, ctx.lo, ctx.hi) &&
+						touchesFiles(e, ctx.relSet, ctx.baseSet) &&
+						cursorOwner(wk, e.tsMs) === hash
+					) {
+						anchorWks.add(wk);
+					}
+				}
+				for (let i = seg.start; i < seg.end; i++) {
+					const e = s.entries[i];
+					const wk = s.wkeys[i];
+					if (!ctx.effWt.has(wk)) continue;
+					if (!inWindow(e, ctx.lo, ctx.hi)) continue;
+					if (cursorOwner(wk, e.tsMs) !== hash) continue; // owned by a neighbor commit
+					const tier: ConfidenceTier = anchorWks.has(wk)
+						? "high"
+						: e.gitBranch && ctx.effBranch && e.gitBranch === ctx.effBranch
+							? "medium"
+							: "low";
+					if (TIER_RANK[tier] < TIER_RANK[minTier]) continue;
+					collected.push(e);
+					// Roll up confidence over CONVERSATIONAL turns only (pure tool calls
+					// are dropped by buildSessions and must not inflate the tier). HIGH is
+					// the implicit default when neither weaker tier appears.
+					if (e.role && e.content) {
+						if (tier === "medium") sawMed = true;
+						else if (tier === "low") sawLow = true;
+					}
+				}
+			}
 		}
 
-		let method: "file-overlap" | "time-window" = "file-overlap";
-		let entries = high.get(hash);
-		if (!gotFileOverlap && opts.includeMedium) {
-			const med = new Map<string, RawEntry[]>();
-			for (const s of sessions) collectTimeWindow(s, lo, hi, meta.branch, hash, med);
-			entries = med.get(hash);
-			method = "time-window";
-		}
-
-		if (!entries || entries.length === 0) {
+		if (collected.length === 0) {
 			skipped.push(hash);
 			continue;
 		}
-		const sessionsOut = buildSessions(entries);
+		const sessionsOut = buildSessions(collected);
 		if (sessionsOut.length === 0) {
-			skipped.push(hash); // attributed entries were all non-conversational tool calls
+			skipped.push(hash); // collected entries were all non-conversational tool calls
 			continue;
 		}
+		// Weakest tier actually kept → honest commit-level confidence.
+		const tier: ConfidenceTier = sawLow ? "low" : sawMed ? "medium" : "high";
 		const conversationTurns = sessionsOut.reduce(
 			(sum, s) => sum + s.entries.filter((e) => e.role === "human").length,
 			0,
@@ -281,15 +387,15 @@ export function attributeCommits(
 		const transcriptEntries = sessionsOut.reduce((sum, s) => sum + s.entries.length, 0);
 		attributed.set(hash, {
 			commitHash: hash,
-			confidence: method === "file-overlap" ? "high" : "medium",
-			method,
-			branch: modalBranch(entries),
+			confidence: tier,
+			method: TIER_METHOD[tier],
+			branch: ctx.effBranch,
 			sessions: sessionsOut,
 			transcriptEntries,
 			conversationTurns,
 		});
 	}
 
-	log.info("Attribution: %d high/med, %d skipped (of %d targets)", attributed.size, skipped.length, targets.length);
+	log.info("Attribution: %d attributed, %d skipped (of %d emitted)", attributed.size, skipped.length, emitOnly.size);
 	return { attributed, skipped };
 }

--- a/cli/src/backfill/CommitTargetIndex.test.ts
+++ b/cli/src/backfill/CommitTargetIndex.test.ts
@@ -1,0 +1,111 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { execGit } from "../core/GitOps.js";
+import { anchorCommitForEdit, buildCommitTargetIndex, shortBranch } from "./CommitTargetIndex.js";
+
+describe("shortBranch", () => {
+	it("reduces a source ref to a short branch name", () => {
+		expect(shortBranch("refs/heads/feat-x")).toBe("feat-x");
+		expect(shortBranch("refs/remotes/origin/feat-x")).toBe("feat-x");
+		expect(shortBranch("refs/remotes/origin")).toBeUndefined(); // no branch segment
+		expect(shortBranch("refs/tags/v1")).toBeUndefined();
+		expect(shortBranch("HEAD")).toBeUndefined();
+	});
+});
+
+describe("CommitTargetIndex (real temp git repo)", () => {
+	let repo: string;
+
+	beforeEach(async () => {
+		repo = mkdtempSync(join(tmpdir(), "bf-tgt-"));
+		await execGit(["init", "-b", "main"], repo);
+		await execGit(["config", "user.email", "t@t.dev"], repo);
+		await execGit(["config", "user.name", "T"], repo);
+		await execGit(["config", "commit.gpgsign", "false"], repo);
+	});
+	afterEach(() => {
+		rmSync(repo, { recursive: true, force: true });
+	});
+
+	async function commit(file: string, message: string): Promise<string> {
+		writeFileSync(join(repo, file), `// ${message}\n`);
+		await execGit(["add", "."], repo);
+		await execGit(["commit", "-m", message], repo);
+		return (await execGit(["rev-parse", "HEAD"], repo)).stdout.trim();
+	}
+
+	it("indexes real code commits and excludes 'Add summary for' bookkeeping commits", async () => {
+		const a = await commit("a.ts", "feat: add A");
+		const b = await commit("b.ts", "feat: add B");
+		// jolli bookkeeping commit — must be excluded from the target set.
+		await commit("c.ts", "Add summary for deadbeef: feat: add A");
+
+		const idx = await buildCommitTargetIndex(repo);
+
+		expect(idx.commitMeta.has(a)).toBe(true);
+		expect(idx.commitMeta.has(b)).toBe(true);
+		// The "Add summary for" commit is excluded even though it touched c.ts.
+		expect([...idx.commitMeta.values()].some((m) => m.subject.startsWith("Add summary for"))).toBe(false);
+		expect(idx.fileToCommits.has("a.ts")).toBe(true);
+		expect(idx.fileToCommits.has("c.ts")).toBe(false);
+	});
+
+	it("anchorCommitForEdit resolves the earliest commit touching the file after the edit", async () => {
+		const a = await commit("a.ts", "feat: add A");
+		const idx = await buildCommitTargetIndex(repo);
+		const commitTs = idx.commitMeta.get(a)?.ts ?? 0;
+
+		// Edit slightly before the commit → resolves to A.
+		expect(anchorCommitForEdit(idx, "a.ts", "a.ts", commitTs - 1000)).toBe(a);
+		// Basename fallback works when the rel path is unknown.
+		expect(anchorCommitForEdit(idx, "weird/a.ts", "a.ts", commitTs - 1000)).toBe(a);
+		// Unknown file → null.
+		expect(anchorCommitForEdit(idx, "nope.ts", "nope.ts", commitTs)).toBeNull();
+		// NaN edit time → null.
+		expect(anchorCommitForEdit(idx, "a.ts", "a.ts", Number.NaN)).toBeNull();
+		// Edit far AFTER the commit (beyond horizon) → null (no later commit touches it).
+		expect(anchorCommitForEdit(idx, "a.ts", "a.ts", commitTs + 60 * 24 * 60 * 60 * 1000)).toBeNull();
+	});
+
+	it("excludes the orphan summaries branch when it exists", async () => {
+		const a = await commit("a.ts", "feat: real");
+		// Create an orphan ref (no parent) via plumbing so `--not <orphan>` has
+		// something to exclude without disturbing the working tree.
+		const tree = (await execGit(["rev-parse", "HEAD^{tree}"], repo)).stdout.trim();
+		const orphanCommit = (await execGit(["commit-tree", "-m", "orphan bookkeeping", tree], repo)).stdout.trim();
+		await execGit(["branch", "jollimemory/summaries/v3", orphanCommit], repo);
+
+		const idx = await buildCommitTargetIndex(repo);
+		expect(idx.commitMeta.has(a)).toBe(true); // real commit still indexed
+		expect(idx.commitMeta.has(orphanCommit)).toBe(false); // orphan excluded via --not
+	});
+
+	it("records every commit that touches a file, time-sorted", async () => {
+		const c1 = await commit("a.ts", "feat: a v1");
+		const c2 = await commit("a.ts", "feat: a v2");
+		const idx = await buildCommitTargetIndex(repo);
+		const refs = idx.fileToCommits.get("a.ts");
+		expect(refs).toHaveLength(2); // pushRef appended the second commit to the same key
+		expect(new Set(refs?.map((r) => r.hash))).toEqual(new Set([c1, c2]));
+	});
+
+	it("excludes a real-branch commit whose diff is purely orphan bookkeeping", async () => {
+		const real = await commit("a.ts", "feat: real");
+		await commit("catalog.json", "chore: bookkeeping only"); // only an orphan-prefix/bookkeeping file
+		const idx = await buildCommitTargetIndex(repo);
+		expect(idx.commitMeta.has(real)).toBe(true);
+		expect(idx.fileToCommits.has("catalog.json")).toBe(false); // orphan bookkeeping file dropped
+	});
+
+	it("returns empty index on a non-repo directory", async () => {
+		const notRepo = mkdtempSync(join(tmpdir(), "bf-norepo-"));
+		try {
+			const idx = await buildCommitTargetIndex(notRepo);
+			expect(idx.commitMeta.size).toBe(0);
+		} finally {
+			rmSync(notRepo, { recursive: true, force: true });
+		}
+	});
+});

--- a/cli/src/backfill/CommitTargetIndex.test.ts
+++ b/cli/src/backfill/CommitTargetIndex.test.ts
@@ -1,9 +1,62 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { execGit } from "../core/GitOps.js";
-import { anchorCommitForEdit, buildCommitTargetIndex, shortBranch } from "./CommitTargetIndex.js";
+import {
+	attributionLowerBound,
+	buildCommitTargetIndex,
+	type CommitTargetIndex,
+	shortBranch,
+} from "./CommitTargetIndex.js";
+
+describe("attributionLowerBound", () => {
+	const idx: CommitTargetIndex = {
+		commitMeta: new Map([
+			["C0", { ts: 1000, subject: "" }],
+			["C1", { ts: 5000, subject: "" }],
+		]),
+		commitFiles: new Map([
+			["C1", ["foo.ts", "bar.ts"]],
+			["NOFILES", []],
+		]),
+		fileToCommits: new Map([
+			[
+				"foo.ts",
+				[
+					{ ts: 1000, hash: "C0" },
+					{ ts: 5000, hash: "C1" },
+				],
+			], // prior commit @1000
+			["bar.ts", [{ ts: 5000, hash: "C1" }]], // only committed by C1 itself
+		]),
+		baseToCommits: new Map(),
+	};
+
+	it("floors at the previous commit of the files (most recent before commitTs)", () => {
+		expect(attributionLowerBound(idx, "C1", 5000, 1_000_000)).toBe(1000); // foo.ts prior @1000
+	});
+	it("caps to commitTs - maxLookback when no earlier commit exists", () => {
+		// If only bar.ts mattered there'd be no prior → cap. Force via a commit whose
+		// file has no earlier commit:
+		const idx2: CommitTargetIndex = { ...idx, commitFiles: new Map([["X", ["bar.ts"]]]) };
+		expect(attributionLowerBound(idx2, "X", 5000, 2000)).toBe(3000); // 5000 - 2000 (bar.ts has no commit < 5000)
+	});
+	it("returns commitTs - maxLookback for a commit with no files", () => {
+		expect(attributionLowerBound(idx, "NOFILES", 9000, 1500)).toBe(7500);
+	});
+	it("caps immediately when every commit of the files is at/after commitTs", () => {
+		// foo.ts committed @1000 and @5000; commitTs=500 → first ref (1000) is NOT < 500,
+		// so the loop breaks at once, prev stays -Inf, and lb falls back to the cap.
+		const idx3: CommitTargetIndex = { ...idx, commitFiles: new Map([["Z", ["foo.ts"]]]) };
+		expect(attributionLowerBound(idx3, "Z", 500, 100)).toBe(400);
+	});
+	it("skips files that have no commit history", () => {
+		// ghost.ts is not in fileToCommits → the `!refs` branch skips it; foo.ts@1000 floors it.
+		const idx4: CommitTargetIndex = { ...idx, commitFiles: new Map([["Q", ["ghost.ts", "foo.ts"]]]) };
+		expect(attributionLowerBound(idx4, "Q", 5000, 1_000_000)).toBe(1000);
+	});
+});
 
 describe("shortBranch", () => {
 	it("reduces a source ref to a short branch name", () => {
@@ -52,23 +105,6 @@ describe("CommitTargetIndex (real temp git repo)", () => {
 		expect(idx.fileToCommits.has("c.ts")).toBe(false);
 	});
 
-	it("anchorCommitForEdit resolves the earliest commit touching the file after the edit", async () => {
-		const a = await commit("a.ts", "feat: add A");
-		const idx = await buildCommitTargetIndex(repo);
-		const commitTs = idx.commitMeta.get(a)?.ts ?? 0;
-
-		// Edit slightly before the commit → resolves to A.
-		expect(anchorCommitForEdit(idx, "a.ts", "a.ts", commitTs - 1000)).toBe(a);
-		// Basename fallback works when the rel path is unknown.
-		expect(anchorCommitForEdit(idx, "weird/a.ts", "a.ts", commitTs - 1000)).toBe(a);
-		// Unknown file → null.
-		expect(anchorCommitForEdit(idx, "nope.ts", "nope.ts", commitTs)).toBeNull();
-		// NaN edit time → null.
-		expect(anchorCommitForEdit(idx, "a.ts", "a.ts", Number.NaN)).toBeNull();
-		// Edit far AFTER the commit (beyond horizon) → null (no later commit touches it).
-		expect(anchorCommitForEdit(idx, "a.ts", "a.ts", commitTs + 60 * 24 * 60 * 60 * 1000)).toBeNull();
-	});
-
 	it("excludes the orphan summaries branch when it exists", async () => {
 		const a = await commit("a.ts", "feat: real");
 		// Create an orphan ref (no parent) via plumbing so `--not <orphan>` has
@@ -107,5 +143,14 @@ describe("CommitTargetIndex (real temp git repo)", () => {
 		} finally {
 			rmSync(notRepo, { recursive: true, force: true });
 		}
+	});
+
+	it("derives the basename for a file in a subdirectory", async () => {
+		mkdirSync(join(repo, "sub"), { recursive: true });
+		await commit("sub/x.ts", "feat: nested file");
+		const idx = await buildCommitTargetIndex(repo);
+		expect(idx.fileToCommits.has("sub/x.ts")).toBe(true);
+		// basename() takes the path after the last "/" — the idx>=0 branch.
+		expect(idx.baseToCommits.has("x.ts")).toBe(true);
 	});
 });

--- a/cli/src/backfill/CommitTargetIndex.ts
+++ b/cli/src/backfill/CommitTargetIndex.ts
@@ -1,0 +1,184 @@
+/**
+ * CommitTargetIndex — the set of real code commits a back-fill attribution may
+ * point at, plus a file→commits index for file-orthogonality anchoring.
+ *
+ * Built from `git log` over all refs EXCEPT the jolli orphan summaries branch.
+ * Two classes of commit are excluded because they are never valid attribution
+ * targets and would pollute matching (both observed in real history):
+ *   1. jolli's own "Add summary for <hash>: <msg>" bookkeeping commits — they
+ *      echo the original commit message and would steal message/file matches.
+ *   2. Commits whose entire diff is orphan-branch bookkeeping
+ *      (summaries/ transcripts/ plans/ notes/ catalog.json / index.json).
+ *
+ * Anchoring contract: an edit of file F at time t belongs to the *earliest
+ * commit that touches F at or after t* (within a horizon). `fileToCommits` is
+ * therefore sorted by commit time ascending so the attributor can binary-walk
+ * to that commit. History rewrites (squash/rebase) mean the original commit may
+ * be gone; pointing at the current commit that now carries F is exactly right.
+ */
+
+import { execGit } from "../core/GitOps.js";
+import { toForwardSlash } from "../core/PathUtils.js";
+import { createLogger, ORPHAN_BRANCH } from "../Logger.js";
+
+const log = createLogger("CommitTargetIndex");
+
+/** Commit time (epoch ms) + hash, used as a file→commit anchor candidate. */
+export interface CommitRef {
+	readonly ts: number;
+	readonly hash: string;
+}
+
+export interface CommitTargetIndex {
+	/**
+	 * hash → { ts (epoch ms), subject, branch? } for every real code commit.
+	 * `branch` is the short name of the ref the commit was reached from in the
+	 * `--all` traversal (via `git log --source` / `%S`); used by the MEDIUM
+	 * time-window attribution to reject a candidate on a different branch than
+	 * the conversation segment. Absent when the source ref isn't a branch.
+	 */
+	readonly commitMeta: ReadonlyMap<string, { ts: number; subject: string; branch?: string }>;
+	/** repo-relative forward-slash path → commits touching it, sorted by ts asc. */
+	readonly fileToCommits: ReadonlyMap<string, ReadonlyArray<CommitRef>>;
+	/** basename → commits touching a file with that basename, sorted by ts asc. */
+	readonly baseToCommits: ReadonlyMap<string, ReadonlyArray<CommitRef>>;
+}
+
+const ORPHAN_PREFIXES = ["summaries/", "transcripts/", "plans/", "plan-progress/", "notes/", "linear-issues/"];
+const ORPHAN_BOOKKEEPING_FILES = new Set(["catalog.json", "index.json"]);
+
+function isOrphanPath(p: string): boolean {
+	return ORPHAN_BOOKKEEPING_FILES.has(p) || ORPHAN_PREFIXES.some((pre) => p.startsWith(pre));
+}
+
+function basename(p: string): string {
+	const idx = p.lastIndexOf("/");
+	return idx >= 0 ? p.slice(idx + 1) : p;
+}
+
+/**
+ * Reduces a `%S` source ref to a short branch name for matching against the
+ * transcript's `gitBranch`: `refs/heads/feat-x` → `feat-x`,
+ * `refs/remotes/origin/feat-x` → `feat-x`. Returns undefined for non-branch refs
+ * (tags, HEAD, etc.) so the MEDIUM gate simply doesn't constrain on them.
+ */
+export function shortBranch(ref: string): string | undefined {
+	if (ref.startsWith("refs/heads/")) return ref.slice("refs/heads/".length);
+	if (ref.startsWith("refs/remotes/")) {
+		const rest = ref.slice("refs/remotes/".length);
+		const slash = rest.indexOf("/"); // drop the remote name segment
+		return slash >= 0 ? rest.slice(slash + 1) : undefined;
+	}
+	return undefined;
+}
+
+function pushRef(map: Map<string, CommitRef[]>, key: string, ref: CommitRef): void {
+	const list = map.get(key);
+	if (list) list.push(ref);
+	else map.set(key, [ref]);
+}
+
+/** Returns true when the orphan summaries branch exists (so `--not` is safe). */
+async function orphanRefExists(cwd: string): Promise<boolean> {
+	const res = await execGit(["rev-parse", "--verify", "--quiet", `${ORPHAN_BRANCH}^{commit}`], cwd);
+	return res.exitCode === 0;
+}
+
+/**
+ * Builds the {@link CommitTargetIndex} for the repo at `cwd`.
+ *
+ * Uses one `git log --all --name-only` pass with NUL-free record markers. The
+ * orphan branch is excluded via `--not` only when it actually exists.
+ */
+export async function buildCommitTargetIndex(cwd: string): Promise<CommitTargetIndex> {
+	const args = ["log", "--all", "--source"];
+	if (await orphanRefExists(cwd)) {
+		args.push("--not", ORPHAN_BRANCH);
+	}
+	// @@ record marker keeps parsing simple; %ct is author-independent commit time;
+	// %S (needs --source) is the ref the commit was reached from → its branch.
+	args.push("--name-only", "--pretty=format:@@%H|%ct|%S|%s");
+
+	const res = await execGit(args, cwd);
+	if (res.exitCode !== 0) {
+		log.warn("git log failed building target index: %s", res.stderr.substring(0, 200));
+		return { commitMeta: new Map(), fileToCommits: new Map(), baseToCommits: new Map() };
+	}
+
+	const commitMeta = new Map<string, { ts: number; subject: string; branch?: string }>();
+	const fileToCommits = new Map<string, CommitRef[]>();
+	const baseToCommits = new Map<string, CommitRef[]>();
+
+	let curHash: string | null = null;
+	let curTs = 0;
+	let curFiles: string[] = [];
+	let curSubject = "";
+	let curBranch: string | undefined;
+
+	const flush = (): void => {
+		if (!curHash) return;
+		const real = curFiles.filter((f) => !isOrphanPath(f));
+		// Skip jolli bookkeeping commits and orphan-only commits — never targets.
+		if (!curSubject.startsWith("Add summary for") && real.length > 0) {
+			commitMeta.set(curHash, { ts: curTs, subject: curSubject, ...(curBranch ? { branch: curBranch } : {}) });
+			const ref: CommitRef = { ts: curTs, hash: curHash };
+			for (const f of real) {
+				pushRef(fileToCommits, f, ref);
+				pushRef(baseToCommits, basename(f), ref);
+			}
+		}
+		curHash = null;
+		curFiles = [];
+		curBranch = undefined;
+	};
+
+	for (const rawLine of res.stdout.split("\n")) {
+		const line = rawLine.trimEnd();
+		if (line.startsWith("@@")) {
+			flush();
+			const body = line.slice(2);
+			const sep1 = body.indexOf("|");
+			const sep2 = body.indexOf("|", sep1 + 1);
+			const sep3 = body.indexOf("|", sep2 + 1);
+			if (sep1 < 0 || sep2 < 0 || sep3 < 0) continue;
+			curHash = body.slice(0, sep1);
+			curTs = Number.parseInt(body.slice(sep1 + 1, sep2), 10) * 1000;
+			curBranch = shortBranch(body.slice(sep2 + 1, sep3));
+			curSubject = body.slice(sep3 + 1);
+		} else if (line.length > 0 && curHash) {
+			curFiles.push(toForwardSlash(line));
+		}
+	}
+	flush();
+
+	for (const list of fileToCommits.values()) list.sort((a, b) => a.ts - b.ts);
+	for (const list of baseToCommits.values()) list.sort((a, b) => a.ts - b.ts);
+
+	log.info("Target index: %d commits, %d files", commitMeta.size, fileToCommits.size);
+	return { commitMeta, fileToCommits, baseToCommits };
+}
+
+const ANCHOR_SKEW_MS = 60_000; // allow a commit up to 60s before the edit (clock skew)
+const ANCHOR_HORIZON_MS = 21 * 24 * 60 * 60 * 1000; // 21 days
+
+/**
+ * Resolves the commit an edit of `rel` (basename fallback `base`) at epoch-ms
+ * `editMs` belongs to: the earliest commit touching that file at or after the
+ * edit time (minus skew), within the horizon. Returns null when no such commit
+ * exists (file never committed, or only committed long after / before).
+ */
+export function anchorCommitForEdit(
+	index: CommitTargetIndex,
+	rel: string,
+	base: string,
+	editMs: number,
+): string | null {
+	if (Number.isNaN(editMs)) return null;
+	const candidates = index.fileToCommits.get(rel) ?? index.baseToCommits.get(base);
+	if (!candidates) return null;
+	const lower = editMs - ANCHOR_SKEW_MS;
+	for (const c of candidates) {
+		if (c.ts >= lower && c.ts - editMs <= ANCHOR_HORIZON_MS) return c.hash;
+	}
+	return null;
+}

--- a/cli/src/backfill/CommitTargetIndex.ts
+++ b/cli/src/backfill/CommitTargetIndex.ts
@@ -38,6 +38,8 @@ export interface CommitTargetIndex {
 	 * the conversation segment. Absent when the source ref isn't a branch.
 	 */
 	readonly commitMeta: ReadonlyMap<string, { ts: number; subject: string; branch?: string }>;
+	/** hash → repo-relative forward-slash paths the commit changed (real files only). */
+	readonly commitFiles: ReadonlyMap<string, ReadonlyArray<string>>;
 	/** repo-relative forward-slash path → commits touching it, sorted by ts asc. */
 	readonly fileToCommits: ReadonlyMap<string, ReadonlyArray<CommitRef>>;
 	/** basename → commits touching a file with that basename, sorted by ts asc. */
@@ -95,17 +97,21 @@ export async function buildCommitTargetIndex(cwd: string): Promise<CommitTargetI
 	if (await orphanRefExists(cwd)) {
 		args.push("--not", ORPHAN_BRANCH);
 	}
-	// @@ record marker keeps parsing simple; %ct is author-independent commit time;
-	// %S (needs --source) is the ref the commit was reached from → its branch.
-	args.push("--name-only", "--pretty=format:@@%H|%ct|%S|%s");
+	// @@ record marker keeps parsing simple. %at = AUTHOR date (seconds): unlike
+	// committer date (%ct) it is preserved across rebase/amend, so it tracks when
+	// the work was actually done — which is what the attribution window must align
+	// with (the on-disk transcript edits happened at author time, not at the later
+	// rebase/commit time). %S (needs --source) is the ref reached → its branch.
+	args.push("--name-only", "--pretty=format:@@%H|%at|%S|%s");
 
 	const res = await execGit(args, cwd);
 	if (res.exitCode !== 0) {
 		log.warn("git log failed building target index: %s", res.stderr.substring(0, 200));
-		return { commitMeta: new Map(), fileToCommits: new Map(), baseToCommits: new Map() };
+		return { commitMeta: new Map(), commitFiles: new Map(), fileToCommits: new Map(), baseToCommits: new Map() };
 	}
 
 	const commitMeta = new Map<string, { ts: number; subject: string; branch?: string }>();
+	const commitFiles = new Map<string, string[]>();
 	const fileToCommits = new Map<string, CommitRef[]>();
 	const baseToCommits = new Map<string, CommitRef[]>();
 
@@ -121,6 +127,7 @@ export async function buildCommitTargetIndex(cwd: string): Promise<CommitTargetI
 		// Skip jolli bookkeeping commits and orphan-only commits — never targets.
 		if (!curSubject.startsWith("Add summary for") && real.length > 0) {
 			commitMeta.set(curHash, { ts: curTs, subject: curSubject, ...(curBranch ? { branch: curBranch } : {}) });
+			commitFiles.set(curHash, real);
 			const ref: CommitRef = { ts: curTs, hash: curHash };
 			for (const f of real) {
 				pushRef(fileToCommits, f, ref);
@@ -155,30 +162,35 @@ export async function buildCommitTargetIndex(cwd: string): Promise<CommitTargetI
 	for (const list of baseToCommits.values()) list.sort((a, b) => a.ts - b.ts);
 
 	log.info("Target index: %d commits, %d files", commitMeta.size, fileToCommits.size);
-	return { commitMeta, fileToCommits, baseToCommits };
+	return { commitMeta, commitFiles, fileToCommits, baseToCommits };
 }
 
-const ANCHOR_SKEW_MS = 60_000; // allow a commit up to 60s before the edit (clock skew)
-const ANCHOR_HORIZON_MS = 21 * 24 * 60 * 60 * 1000; // 21 days
-
 /**
- * Resolves the commit an edit of `rel` (basename fallback `base`) at epoch-ms
- * `editMs` belongs to: the earliest commit touching that file at or after the
- * edit time (minus skew), within the horizon. Returns null when no such commit
- * exists (file never committed, or only committed long after / before).
+ * Returns the lower-bound time for commit `hash`'s attribution window: the most
+ * recent commit-time strictly before `commitTs` among commits that touch any of
+ * `hash`'s files — i.e. "the last time these files were committed before this
+ * commit". Conversation slices are floored at this so consecutive commits that
+ * touch overlapping files don't bleed into each other (improvement ①). Capped to
+ * `commitTs - maxLookbackMs` so a long-dormant file doesn't open a huge window.
  */
-export function anchorCommitForEdit(
+export function attributionLowerBound(
 	index: CommitTargetIndex,
-	rel: string,
-	base: string,
-	editMs: number,
-): string | null {
-	if (Number.isNaN(editMs)) return null;
-	const candidates = index.fileToCommits.get(rel) ?? index.baseToCommits.get(base);
-	if (!candidates) return null;
-	const lower = editMs - ANCHOR_SKEW_MS;
-	for (const c of candidates) {
-		if (c.ts >= lower && c.ts - editMs <= ANCHOR_HORIZON_MS) return c.hash;
+	hash: string,
+	commitTs: number,
+	maxLookbackMs: number,
+): number {
+	const files = index.commitFiles.get(hash) ?? [];
+	let lb = commitTs - maxLookbackMs;
+	for (const f of files) {
+		const refs = index.fileToCommits.get(f);
+		if (!refs) continue;
+		// refs sorted asc by ts; find the latest with ts < commitTs.
+		let prev = Number.NEGATIVE_INFINITY;
+		for (const r of refs) {
+			if (r.ts < commitTs) prev = r.ts;
+			else break;
+		}
+		if (prev > lb) lb = prev;
 	}
-	return null;
+	return lb;
 }

--- a/cli/src/backfill/RawTranscriptScanner.test.ts
+++ b/cli/src/backfill/RawTranscriptScanner.test.ts
@@ -9,8 +9,11 @@ describe("relativizeUnderCwd", () => {
 		expect(relativizeUnderCwd("e:/repo/src/foo.ts", "e:/repo")).toBe("src/foo.ts");
 		expect(relativizeUnderCwd("e:\\repo\\src\\foo.ts", "e:\\repo")).toBe("src/foo.ts");
 	});
-	it("is case-insensitive on the cwd prefix but preserves case in the slice", () => {
-		expect(relativizeUnderCwd("E:/Repo/Src/Foo.ts", "e:/repo")).toBe("Src/Foo.ts");
+	it("folds case on the cwd prefix on case-insensitive platforms; preserves slice case", () => {
+		// normalizePathForCompare folds case on win32/darwin but NOT on Linux, so on a
+		// case-sensitive filesystem the differing-case prefix legitimately does not match.
+		const caseInsensitive = process.platform === "win32" || process.platform === "darwin";
+		expect(relativizeUnderCwd("E:/Repo/Src/Foo.ts", "e:/repo")).toBe(caseInsensitive ? "Src/Foo.ts" : null);
 	});
 	it("returns null when the path is not under cwd, and '' when equal", () => {
 		expect(relativizeUnderCwd("e:/other/x.ts", "e:/repo")).toBeNull();
@@ -24,7 +27,8 @@ describe("cwdInRoots", () => {
 		const pred = cwdInRoots(["e:/repo", "e:/wt2"]);
 		expect(pred("e:/repo")).toBe(true);
 		expect(pred("e:/repo/sub")).toBe(true);
-		expect(pred("E:\\WT2")).toBe(true);
+		// A differing-case root match only holds on case-insensitive platforms (win32/darwin).
+		expect(pred("E:\\WT2")).toBe(process.platform === "win32" || process.platform === "darwin");
 		expect(pred("e:/elsewhere")).toBe(false);
 		expect(pred(undefined)).toBe(false);
 	});
@@ -208,5 +212,30 @@ describe("scanClaudeTranscripts", () => {
 		writeFileSync(join(root, "loose.jsonl"), "ignored-at-root");
 		const bySession = await scanClaudeTranscripts(() => true, root);
 		expect(bySession.size).toBe(0);
+	});
+
+	it("tolerates null/non-object blocks, nameless tools, bare filenames, and missing cwd/sessionId", async () => {
+		writeProject("proj", "weird.jsonl", [
+			{
+				// no cwd, no gitBranch, no sessionId → cwd/gitBranch undefined, sessionId falls back to file name
+				timestamp: "2026-06-01T00:00:00.000Z",
+				type: "assistant",
+				message: {
+					role: "assistant",
+					content: [
+						null, // block === null → skipped
+						"a string block", // typeof !== "object" → skipped
+						{ type: "tool_use", name: "Edit" }, // no input → (b.input ?? {}) fallback
+						{ type: "tool_use", input: { file_path: "bare.ts" } }, // no name → not extracted
+						{ type: "tool_use", name: "Edit", input: { file_path: "bare.ts" } }, // bare basename (no "/")
+					],
+				},
+			},
+		]);
+		const bySession = await scanClaudeTranscripts(() => true, root);
+		const entries = bySession.get("weird"); // sessionId fell back to the file basename
+		expect(entries).toHaveLength(1);
+		expect(entries?.[0].editedBase).toEqual(["bare.ts"]);
+		expect(entries?.[0].cwd).toBeUndefined();
 	});
 });

--- a/cli/src/backfill/RawTranscriptScanner.test.ts
+++ b/cli/src/backfill/RawTranscriptScanner.test.ts
@@ -1,0 +1,212 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cwdInRoots, relativizeUnderCwd, scanClaudeTranscripts } from "./RawTranscriptScanner.js";
+
+describe("relativizeUnderCwd", () => {
+	it("returns the path relative to cwd in forward-slash form", () => {
+		expect(relativizeUnderCwd("e:/repo/src/foo.ts", "e:/repo")).toBe("src/foo.ts");
+		expect(relativizeUnderCwd("e:\\repo\\src\\foo.ts", "e:\\repo")).toBe("src/foo.ts");
+	});
+	it("is case-insensitive on the cwd prefix but preserves case in the slice", () => {
+		expect(relativizeUnderCwd("E:/Repo/Src/Foo.ts", "e:/repo")).toBe("Src/Foo.ts");
+	});
+	it("returns null when the path is not under cwd, and '' when equal", () => {
+		expect(relativizeUnderCwd("e:/other/x.ts", "e:/repo")).toBeNull();
+		expect(relativizeUnderCwd("e:/repo", "e:/repo")).toBe("");
+		expect(relativizeUnderCwd("e:/repo/x.ts", undefined)).toBeNull();
+	});
+});
+
+describe("cwdInRoots", () => {
+	it("accepts cwd equal to or nested under a root", () => {
+		const pred = cwdInRoots(["e:/repo", "e:/wt2"]);
+		expect(pred("e:/repo")).toBe(true);
+		expect(pred("e:/repo/sub")).toBe(true);
+		expect(pred("E:\\WT2")).toBe(true);
+		expect(pred("e:/elsewhere")).toBe(false);
+		expect(pred(undefined)).toBe(false);
+	});
+});
+
+describe("scanClaudeTranscripts", () => {
+	let root: string;
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "bf-scan-"));
+	});
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	function writeProject(name: string, file: string, lines: object[]): void {
+		const dir = join(root, name);
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, file), `${lines.map((l) => JSON.stringify(l)).join("\n")}\nnot-json\n`);
+	}
+
+	const base = (over: object) => ({
+		timestamp: "2026-06-01T00:00:00.000Z",
+		cwd: "e:/repo",
+		gitBranch: "feat",
+		sessionId: "S1",
+		...over,
+	});
+
+	it("parses edits and conversational turns; filters by cwd; sorts by ts", () => {
+		writeProject("proj", "S1.jsonl", [
+			base({ timestamp: "2026-06-01T00:02:00.000Z", type: "user", message: { role: "user", content: "hello" } }),
+			base({
+				timestamp: "2026-06-01T00:01:00.000Z",
+				type: "assistant",
+				message: {
+					role: "assistant",
+					content: [
+						{ type: "text", text: "editing foo" },
+						{ type: "tool_use", name: "Edit", input: { file_path: "e:/repo/src/foo.ts" } },
+					],
+				},
+			}),
+			// cwd outside the repo → filtered out
+			base({ cwd: "e:/other", type: "user", message: { role: "user", content: "ignored" } }),
+		]);
+
+		return scanClaudeTranscripts(cwdInRoots(["e:/repo"]), root).then((bySession) => {
+			const entries = bySession.get("S1");
+			expect(entries).toBeDefined();
+			// 2 in-repo signal lines (the e:/other one is filtered, the "not-json" skipped)
+			expect(entries).toHaveLength(2);
+			// sorted ascending by ts: 00:01 (edit), 00:02 (hello)
+			expect(entries?.[0].editedRel).toEqual(["src/foo.ts"]);
+			expect(entries?.[0].editedBase).toEqual(["foo.ts"]);
+			expect(entries?.[1].content).toBe("hello");
+		});
+	});
+
+	it("keeps an edit line that has no timestamp (sorted last) without crashing", async () => {
+		writeProject("proj", "S2.jsonl", [
+			{
+				cwd: "e:/repo",
+				gitBranch: "feat",
+				sessionId: "S2",
+				type: "assistant",
+				// no timestamp field
+				message: {
+					role: "assistant",
+					content: [{ type: "tool_use", name: "Edit", input: { file_path: "e:/repo/x.ts" } }],
+				},
+			},
+			{
+				timestamp: "2026-06-01T00:00:00.000Z",
+				cwd: "e:/repo",
+				gitBranch: "feat",
+				sessionId: "S2",
+				type: "user",
+				message: { role: "user", content: "later turn" },
+			},
+		]);
+		const bySession = await scanClaudeTranscripts(cwdInRoots(["e:/repo"]), root);
+		const entries = bySession.get("S2");
+		expect(entries).toHaveLength(2);
+		// The timestamped entry sorts before the NaN-timestamp edit line.
+		expect(entries?.[0].content).toBe("later turn");
+		expect(Number.isNaN(entries?.[1].tsMs ?? 0)).toBe(true);
+	});
+
+	it("handles non-edit tools, non-commit Bash, and edits outside cwd", async () => {
+		writeProject("proj", "S3.jsonl", [
+			base({
+				timestamp: "2026-06-01T00:01:00.000Z",
+				sessionId: "S3",
+				type: "assistant",
+				message: {
+					role: "assistant",
+					content: [
+						{ type: "tool_use", name: "Read", input: { file_path: "e:/repo/r.ts" } }, // not an edit
+						{ type: "tool_use", name: "Bash", input: { command: "npm test" } }, // not a git commit
+						{ type: "tool_use", name: "Edit", input: { file_path: "/elsewhere/out.ts" } }, // outside cwd → fallback
+						{ type: "tool_use", name: "Edit", input: {} }, // missing file_path → ignored
+						{ type: "not_a_block" },
+					],
+				},
+			}),
+		]);
+		const bySession = await scanClaudeTranscripts(cwdInRoots(["e:/repo"]), root);
+		const e = bySession.get("S3")?.[0];
+		expect(e).toBeDefined();
+		// Only the out-of-cwd edit registers, kept as a forward-slashed absolute path.
+		expect(e?.editedRel).toEqual(["/elsewhere/out.ts"]);
+	});
+
+	it("breaks ts ties by line order and parses string message content", async () => {
+		writeProject("proj", "S4.jsonl", [
+			base({
+				timestamp: "2026-06-01T00:00:00.000Z",
+				sessionId: "S4",
+				type: "user",
+				message: { role: "user", content: "first" },
+			}),
+			// same timestamp → tiebreak on lineNo; string content (not array)
+			base({
+				timestamp: "2026-06-01T00:00:00.000Z",
+				sessionId: "S4",
+				type: "user",
+				message: { role: "user", content: "second" },
+			}),
+		]);
+		const entries = (await scanClaudeTranscripts(cwdInRoots(["e:/repo"]), root)).get("S4");
+		expect(entries?.map((e) => e.content)).toEqual(["first", "second"]);
+	});
+
+	it("drops signal-less lines and orders two timestamp-less entries by line", async () => {
+		writeProject("proj", "S5.jsonl", [
+			// no message, no timestamp, no tool → signal-less → dropped
+			{ cwd: "e:/repo", sessionId: "S5", type: "system", foo: "bar" },
+			// two edit-only lines without timestamps → both NaN → tiebreak on lineNo
+			{
+				cwd: "e:/repo",
+				sessionId: "S5",
+				type: "assistant",
+				message: {
+					role: "assistant",
+					content: [{ type: "tool_use", name: "Edit", input: { file_path: "e:/repo/a.ts" } }],
+				},
+			},
+			{
+				cwd: "e:/repo",
+				sessionId: "S5",
+				type: "assistant",
+				message: {
+					role: "assistant",
+					content: [{ type: "tool_use", name: "Edit", input: { file_path: "e:/repo/b.ts" } }],
+				},
+			},
+		]);
+		const entries = (await scanClaudeTranscripts(cwdInRoots(["e:/repo"]), root)).get("S5");
+		expect(entries).toHaveLength(2); // signal-less line dropped
+		expect(entries?.[0].editedRel).toEqual(["a.ts"]);
+		expect(entries?.[1].editedRel).toEqual(["b.ts"]);
+	});
+
+	it("returns an empty map when the projects root does not exist", async () => {
+		const bySession = await scanClaudeTranscripts(() => true, join(root, "nope"));
+		expect(bySession.size).toBe(0);
+	});
+
+	it("skips an unreadable transcript path without aborting the scan", async () => {
+		const dir = join(root, "proj");
+		mkdirSync(dir, { recursive: true });
+		// A directory named like a transcript → readFile throws EISDIR → caught + skipped.
+		mkdirSync(join(dir, "weird.jsonl"));
+		const bySession = await scanClaudeTranscripts(() => true, root);
+		expect(bySession.size).toBe(0);
+	});
+
+	it("skips non-jsonl files and unreadable dirs gracefully", async () => {
+		mkdirSync(join(root, "proj"), { recursive: true });
+		writeFileSync(join(root, "proj", "notes.txt"), "ignore me");
+		writeFileSync(join(root, "loose.jsonl"), "ignored-at-root");
+		const bySession = await scanClaudeTranscripts(() => true, root);
+		expect(bySession.size).toBe(0);
+	});
+});

--- a/cli/src/backfill/RawTranscriptScanner.ts
+++ b/cli/src/backfill/RawTranscriptScanner.ts
@@ -1,0 +1,232 @@
+/**
+ * RawTranscriptScanner — historical Claude transcript indexer for back-fill.
+ *
+ * This module is part of the **isolated** historical back-fill flow and is
+ * deliberately decoupled from the live pipeline (StopHook / sessions.json /
+ * QueueWorker cursors). The live flow learns a transcript's path from the Stop
+ * hook payload; back-fill instead scans every on-disk Claude transcript under
+ * `~/.claude/projects/<encoded-cwd>/*.jsonl` and reconstructs, per JSONL line,
+ * the signals the attributor needs to map a conversation slice to a historical
+ * commit:
+ *
+ *   - `ts` / `tsMs`      — entry timestamp (the time-window backbone)
+ *   - `gitBranch`        — branch the user was on at that moment
+ *   - `cwd`              — working dir, used to scope transcripts to this repo
+ *   - `editedRel`        — repo-relative paths from Edit/Write/MultiEdit tool
+ *                          calls (the file-orthogonality anchor)
+ *   - `role` / `content` — the conversational turn (fed to the summarizer)
+ *
+ * Only Claude Code is supported for now (the `source` field is fixed to
+ * "claude"); the record shape leaves room for other sources later.
+ */
+
+import { readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { normalizePathForCompare, toForwardSlash } from "../core/PathUtils.js";
+import { parseTranscriptLine } from "../core/TranscriptReader.js";
+import { createLogger } from "../Logger.js";
+
+const log = createLogger("RawTranscriptScanner");
+
+/** One indexed Claude JSONL line with the signals the attributor consumes. */
+export interface RawEntry {
+	readonly sessionId: string;
+	readonly transcriptPath: string;
+	readonly source: "claude";
+	readonly lineNo: number;
+	readonly ts?: string;
+	/** Epoch ms parsed from `ts`; `Number.NaN` when absent/unparseable. */
+	readonly tsMs: number;
+	readonly gitBranch?: string;
+	readonly cwd?: string;
+	/** Conversational role, when this line carried human/assistant text. */
+	readonly role?: "human" | "assistant";
+	/** Conversational text (IDE tags stripped), when present. */
+	readonly content?: string;
+	/** Repo-relative (forward-slash) paths of Edit/Write/MultiEdit targets. */
+	readonly editedRel: ReadonlyArray<string>;
+	/** Basenames of edited files (fallback matching when relative path drifts). */
+	readonly editedBase: ReadonlyArray<string>;
+}
+
+/** Predicate deciding whether a transcript entry's `cwd` belongs to the repo. */
+export type CwdPredicate = (cwd: string | undefined) => boolean;
+
+const EDIT_TOOLS = new Set(["Edit", "Write", "MultiEdit"]);
+
+/**
+ * Returns the path of `abs` relative to `cwd` in forward-slash form, or null
+ * when `abs` is not nested under `cwd`. Case-insensitive prefix match on
+ * Windows/macOS (via {@link normalizePathForCompare}) but the returned slice is
+ * taken from the original-case forward-slashed path so downstream git-path
+ * matching keeps the real casing.
+ */
+export function relativizeUnderCwd(abs: string, cwd: string | undefined): string | null {
+	if (!cwd) return null;
+	const absFwd = toForwardSlash(abs);
+	const cwdFwd = toForwardSlash(cwd).replace(/\/+$/, "");
+	const absCmp = normalizePathForCompare(abs);
+	const cwdCmp = normalizePathForCompare(cwd);
+	if (absCmp === cwdCmp) return "";
+	if (!absCmp.startsWith(`${cwdCmp}/`)) return null;
+	// Slice the original-case forward-slashed path by the cwd segment length + 1.
+	return absFwd.slice(cwdFwd.length + 1);
+}
+
+function basename(p: string): string {
+	const fwd = toForwardSlash(p);
+	const idx = fwd.lastIndexOf("/");
+	return idx >= 0 ? fwd.slice(idx + 1) : fwd;
+}
+
+interface ParsedLine {
+	editedRel: string[];
+	editedBase: string[];
+}
+
+/** Extracts edited file paths from one raw JSONL object's tool_use blocks. */
+function extractToolSignals(obj: Record<string, unknown>, cwd: string | undefined): ParsedLine {
+	const editedRel: string[] = [];
+	const editedBase: string[] = [];
+
+	const message = obj.message as Record<string, unknown> | undefined;
+	const content = message?.content;
+	if (!Array.isArray(content)) return { editedRel, editedBase };
+
+	for (const block of content) {
+		if (block === null || typeof block !== "object") continue;
+		const b = block as Record<string, unknown>;
+		if (b.type !== "tool_use") continue;
+		const name = b.name;
+		const input = (b.input ?? {}) as Record<string, unknown>;
+		if (typeof name === "string" && EDIT_TOOLS.has(name)) {
+			const fp = input.file_path;
+			if (typeof fp === "string" && fp.length > 0) {
+				editedBase.push(basename(fp));
+				const rel = relativizeUnderCwd(fp, cwd);
+				editedRel.push(rel && rel.length > 0 ? rel : toForwardSlash(fp));
+			}
+		}
+	}
+	return { editedRel, editedBase };
+}
+
+/** Parses one JSONL line into a {@link RawEntry}, or null when it should be skipped. */
+function parseLine(line: string, lineNo: number, fileSessionId: string, transcriptPath: string): RawEntry | null {
+	const trimmed = line.trim();
+	if (!trimmed) return null;
+	let obj: Record<string, unknown>;
+	try {
+		obj = JSON.parse(trimmed) as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+
+	const ts = typeof obj.timestamp === "string" ? obj.timestamp : undefined;
+	const cwd = typeof obj.cwd === "string" ? obj.cwd : undefined;
+	const gitBranch = typeof obj.gitBranch === "string" ? obj.gitBranch : undefined;
+	const sessionId = typeof obj.sessionId === "string" ? obj.sessionId : fileSessionId;
+
+	const { editedRel, editedBase } = extractToolSignals(obj, cwd);
+
+	// Reuse the live conversational parser so back-fill summaries see byte-identical
+	// turn text to the live pipeline (IDE-tag stripping, noise filtering, etc.).
+	const conv = parseTranscriptLine(trimmed, lineNo);
+
+	// Drop lines that carry no signal at all (no ts, no edits, no text).
+	if (!ts && editedRel.length === 0 && !conv) return null;
+
+	return {
+		sessionId,
+		transcriptPath,
+		source: "claude",
+		lineNo,
+		ts,
+		tsMs: ts ? Date.parse(ts) : Number.NaN,
+		gitBranch,
+		cwd,
+		role: conv?.role,
+		content: conv?.content,
+		editedRel,
+		editedBase,
+	};
+}
+
+/**
+ * Scans every `~/.claude/projects/<dir>/*.jsonl` transcript and returns the
+ * entries whose `cwd` satisfies `acceptCwd`, grouped by sessionId and sorted by
+ * timestamp ascending within each session.
+ *
+ * @param acceptCwd  predicate scoping entries to the target repo's worktree(s)
+ * @param projectsRoot  override for `~/.claude/projects` (tests inject a temp dir)
+ */
+export async function scanClaudeTranscripts(
+	acceptCwd: CwdPredicate,
+	projectsRoot: string = join(homedir(), ".claude", "projects"),
+): Promise<Map<string, RawEntry[]>> {
+	const bySession = new Map<string, RawEntry[]>();
+
+	let dirents: string[];
+	try {
+		dirents = await readdir(projectsRoot);
+	} catch (err) {
+		log.info("No Claude projects dir at %s: %s", projectsRoot, (err as Error).message);
+		return bySession;
+	}
+
+	for (const dir of dirents) {
+		const projectDir = join(projectsRoot, dir);
+		let files: string[];
+		try {
+			files = (await readdir(projectDir)).filter((f) => f.endsWith(".jsonl"));
+		} catch {
+			continue; // not a directory / unreadable — skip
+		}
+		for (const file of files) {
+			const transcriptPath = join(projectDir, file);
+			const fileSessionId = file.replace(/\.jsonl$/, "");
+			let raw: string;
+			try {
+				raw = await readFile(transcriptPath, "utf8");
+			} catch (err) {
+				log.debug("Skipping unreadable transcript %s: %s", transcriptPath, (err as Error).message);
+				continue;
+			}
+			const lines = raw.split("\n");
+			for (let i = 0; i < lines.length; i++) {
+				const entry = parseLine(lines[i], i, fileSessionId, transcriptPath);
+				if (!entry) continue;
+				if (!acceptCwd(entry.cwd)) continue;
+				const list = bySession.get(entry.sessionId);
+				if (list) list.push(entry);
+				else bySession.set(entry.sessionId, [entry]);
+			}
+		}
+	}
+
+	// Stable chronological order within each session (NaN timestamps sort last).
+	for (const list of bySession.values()) {
+		list.sort((a, b) => {
+			const at = Number.isNaN(a.tsMs) ? Number.POSITIVE_INFINITY : a.tsMs;
+			const bt = Number.isNaN(b.tsMs) ? Number.POSITIVE_INFINITY : b.tsMs;
+			return at - bt || a.lineNo - b.lineNo;
+		});
+	}
+
+	log.info("Indexed %d session(s) from %s", bySession.size, projectsRoot);
+	return bySession;
+}
+
+/**
+ * Builds a {@link CwdPredicate} accepting any cwd equal to or nested under one
+ * of `repoRoots` (worktree roots). Comparison is separator/case normalized.
+ */
+export function cwdInRoots(repoRoots: ReadonlyArray<string>): CwdPredicate {
+	const roots = repoRoots.map((r) => normalizePathForCompare(r));
+	return (cwd) => {
+		if (!cwd) return false;
+		const c = normalizePathForCompare(cwd);
+		return roots.some((r) => c === r || c.startsWith(`${r}/`));
+	};
+}

--- a/cli/src/commands/BackfillCommand.test.ts
+++ b/cli/src/commands/BackfillCommand.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../backfill/BackfillEngine.js", () => ({
 	runBackfill: vi.fn(),
 	recentCommitHashes: vi.fn(),
+	DEFAULT_BACKFILL_TIER: "low",
 }));
 vi.mock("../Logger.js", () => ({
 	setLogDir: vi.fn(),
@@ -51,18 +52,33 @@ const report = {
 };
 
 describe("jolli backfill command", () => {
-	it("passes --last / --dry-run / --include-medium through to runBackfill", async () => {
+	it("passes --last / --dry-run / --min-confidence through to runBackfill", async () => {
 		vi.mocked(recentCommitHashes).mockResolvedValue(["h1", "h2"]);
 		vi.mocked(runBackfill).mockResolvedValue({ ...report, outcomes: [] });
 
-		await makeProgram().parseAsync(["backfill", "--cwd", "e:/r", "--last", "5", "--dry-run", "--include-medium"], {
-			from: "user",
-		});
+		await makeProgram().parseAsync(
+			["backfill", "--cwd", "e:/r", "--last", "5", "--dry-run", "--min-confidence", "high"],
+			{ from: "user" },
+		);
 
 		expect(vi.mocked(recentCommitHashes)).toHaveBeenCalledWith("e:/r", 5);
 		expect(vi.mocked(runBackfill)).toHaveBeenCalledWith(
-			expect.objectContaining({ cwd: "e:/r", hashes: ["h1", "h2"], dryRun: true, includeMedium: true }),
+			expect.objectContaining({ cwd: "e:/r", hashes: ["h1", "h2"], dryRun: true, minTier: "high" }),
 		);
+	});
+
+	it("defaults minTier to 'low' (window-collect-all) when --min-confidence is omitted", async () => {
+		vi.mocked(recentCommitHashes).mockResolvedValue(["h1"]);
+		vi.mocked(runBackfill).mockResolvedValue({ ...report, outcomes: [] });
+		await makeProgram().parseAsync(["backfill"], { from: "user" });
+		expect(vi.mocked(runBackfill)).toHaveBeenCalledWith(expect.objectContaining({ minTier: "low" }));
+	});
+
+	it("rejects an invalid --min-confidence value", async () => {
+		vi.mocked(recentCommitHashes).mockResolvedValue(["h1"]);
+		await expect(
+			makeProgram().parseAsync(["backfill", "--min-confidence", "bogus"], { from: "user" }),
+		).rejects.toThrow(/min-confidence must be one of/);
 	});
 
 	it("--all considers every reachable commit (no cap)", async () => {

--- a/cli/src/commands/BackfillCommand.test.ts
+++ b/cli/src/commands/BackfillCommand.test.ts
@@ -1,0 +1,126 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../backfill/BackfillEngine.js", () => ({
+	runBackfill: vi.fn(),
+	recentCommitHashes: vi.fn(),
+}));
+vi.mock("../Logger.js", () => ({
+	setLogDir: vi.fn(),
+	createLogger: () => ({ info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() }),
+}));
+
+import { recentCommitHashes, runBackfill } from "../backfill/BackfillEngine.js";
+import { registerBackfillCommand } from "./BackfillCommand.js";
+
+function makeProgram(): Command {
+	const program = new Command();
+	program.exitOverride(); // throw instead of process.exit in tests
+	registerBackfillCommand(program);
+	return program;
+}
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	process.exitCode = undefined;
+	logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+	errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+afterEach(() => {
+	logSpy.mockRestore();
+	errSpy.mockRestore();
+});
+
+const report = {
+	total: 1,
+	generated: 1,
+	skipped: 0,
+	errors: 0,
+	outcomes: [
+		{
+			commitHash: "abcdef1234",
+			status: "generated" as const,
+			confidence: "high" as const,
+			method: "file-overlap" as const,
+			topics: 2,
+		},
+	],
+};
+
+describe("jolli backfill command", () => {
+	it("passes --last / --dry-run / --include-medium through to runBackfill", async () => {
+		vi.mocked(recentCommitHashes).mockResolvedValue(["h1", "h2"]);
+		vi.mocked(runBackfill).mockResolvedValue({ ...report, outcomes: [] });
+
+		await makeProgram().parseAsync(["backfill", "--cwd", "e:/r", "--last", "5", "--dry-run", "--include-medium"], {
+			from: "user",
+		});
+
+		expect(vi.mocked(recentCommitHashes)).toHaveBeenCalledWith("e:/r", 5);
+		expect(vi.mocked(runBackfill)).toHaveBeenCalledWith(
+			expect.objectContaining({ cwd: "e:/r", hashes: ["h1", "h2"], dryRun: true, includeMedium: true }),
+		);
+	});
+
+	it("--all considers every reachable commit (no cap)", async () => {
+		vi.mocked(recentCommitHashes).mockResolvedValue(["h1"]);
+		vi.mocked(runBackfill).mockResolvedValue({ ...report, outcomes: [] });
+		await makeProgram().parseAsync(["backfill", "--all"], { from: "user" });
+		expect(vi.mocked(recentCommitHashes)).toHaveBeenCalledWith(expect.any(String), undefined);
+	});
+
+	it("renders a text report by default", async () => {
+		vi.mocked(recentCommitHashes).mockResolvedValue(["h1"]);
+		vi.mocked(runBackfill).mockResolvedValue(report);
+		await makeProgram().parseAsync(["backfill"], { from: "user" });
+		const out = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
+		expect(out).toContain("generated");
+		expect(out).toContain("1 candidate(s)");
+	});
+
+	it("renders mixed outcomes (diff-only, error, skipped) in the text report", async () => {
+		vi.mocked(recentCommitHashes).mockResolvedValue(["h1", "h2", "h3", "h4"]);
+		vi.mocked(runBackfill).mockResolvedValue({
+			total: 4,
+			generated: 2,
+			skipped: 1,
+			errors: 1,
+			outcomes: [
+				{
+					commitHash: "aaaaaaaa11",
+					status: "generated",
+					confidence: "high",
+					method: "file-overlap",
+					topics: 3,
+				},
+				{ commitHash: "bbbbbbbb22", status: "generated", method: "diff-only", topics: 1 },
+				{ commitHash: "cccccccc33", status: "skipped-has-summary" },
+				{ commitHash: "dddddddd44", status: "error", message: "boom" },
+			],
+		});
+		await makeProgram().parseAsync(["backfill"], { from: "user" });
+		const out = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
+		expect(out).toContain("file-overlap");
+		expect(out).toContain("diff-only");
+		expect(out).toContain("already summarized");
+		expect(out).toContain("boom");
+	});
+
+	it("emits JSON with --format json", async () => {
+		vi.mocked(recentCommitHashes).mockResolvedValue(["h1"]);
+		vi.mocked(runBackfill).mockResolvedValue(report);
+		await makeProgram().parseAsync(["backfill", "--format", "json"], { from: "user" });
+		const out = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
+		expect(JSON.parse(out).generated).toBe(1);
+	});
+
+	it("exits non-zero when there are no commits", async () => {
+		vi.mocked(recentCommitHashes).mockResolvedValue([]);
+		await makeProgram().parseAsync(["backfill"], { from: "user" });
+		expect(process.exitCode).toBe(1);
+		expect(vi.mocked(runBackfill)).not.toHaveBeenCalled();
+	});
+});

--- a/cli/src/commands/BackfillCommand.ts
+++ b/cli/src/commands/BackfillCommand.ts
@@ -5,37 +5,49 @@
  * attributing on-disk Claude transcripts to those commits offline. Fully
  * isolated from the live post-commit pipeline.
  *
- *   jolli backfill                  # last 20 commits, high-confidence only
- *   jolli backfill --last 50        # last 50 commits
- *   jolli backfill --all            # every commit reachable from HEAD
- *   jolli backfill --dry-run        # report attribution + confidence, no LLM call
- *   jolli backfill --include-medium # also accept time-window (medium) matches
+ *   jolli backfill                       # last 20 commits, window-collect-all (low)
+ *   jolli backfill --last 50             # last 50 commits
+ *   jolli backfill --all                 # every commit reachable from HEAD
+ *   jolli backfill --dry-run             # report attribution + confidence, no LLM call
+ *   jolli backfill --min-confidence high # only file-overlap (high) attributions
  */
 
 import type { Command } from "commander";
 import {
 	type BackfillOutcome,
 	type BackfillReport,
+	DEFAULT_BACKFILL_TIER,
 	recentCommitHashes,
 	runBackfill,
 } from "../backfill/BackfillEngine.js";
 import { setLogDir } from "../Logger.js";
 import { parsePositiveInt, resolveProjectDir } from "./CliUtils.js";
 
+type MinConfidence = "high" | "medium" | "low";
+
 interface BackfillCliOptions {
 	cwd: string;
 	last?: number;
 	all?: boolean;
 	dryRun?: boolean;
-	includeMedium?: boolean;
+	minConfidence?: MinConfidence;
 	format?: "json" | "text";
 }
 
 const DEFAULT_LAST = 20;
+/** Default tier is shared across all entry points (see DEFAULT_BACKFILL_TIER). */
+const DEFAULT_MIN_CONFIDENCE: MinConfidence = DEFAULT_BACKFILL_TIER;
+
+/** Commander parser for `--min-confidence`; rejects anything outside the tier set. */
+function parseMinConfidence(value: string): MinConfidence {
+	if (value === "high" || value === "medium" || value === "low") return value;
+	throw new Error(`--min-confidence must be one of: high, medium, low (got "${value}")`);
+}
 
 /** Resolves the candidate commit hash list (newest-first) from the CLI options. */
 async function resolveHashes(opts: BackfillCliOptions): Promise<ReadonlyArray<string>> {
-	return recentCommitHashes(opts.cwd, opts.all ? undefined : (opts.last ?? DEFAULT_LAST));
+	// Commander fills `last` with DEFAULT_LAST when the flag is omitted; `--all` drops the cap.
+	return recentCommitHashes(opts.cwd, opts.all ? undefined : opts.last);
 }
 
 const STATUS_LABEL: Record<BackfillOutcome["status"], string> = {
@@ -71,7 +83,12 @@ export function registerBackfillCommand(program: Command): void {
 		.option("--last <n>", "Number of most recent commits to consider", parsePositiveInt, DEFAULT_LAST)
 		.option("--all", "Consider every commit reachable from HEAD")
 		.option("--dry-run", "Report attribution and confidence without calling the LLM")
-		.option("--include-medium", "Also accept medium-confidence (time-window) attributions")
+		.option(
+			"--min-confidence <tier>",
+			"Lowest tier to attribute: high | medium | low",
+			parseMinConfidence,
+			DEFAULT_MIN_CONFIDENCE,
+		)
 		.option("--format <fmt>", "Output format: text | json", "text")
 		.action(async (opts: BackfillCliOptions) => {
 			setLogDir(opts.cwd);
@@ -85,7 +102,9 @@ export function registerBackfillCommand(program: Command): void {
 				cwd: opts.cwd,
 				hashes,
 				dryRun: opts.dryRun,
-				includeMedium: opts.includeMedium,
+				// Commander fills `minConfidence` with DEFAULT_MIN_CONFIDENCE when the flag
+				// is omitted, so it is always a valid tier here.
+				minTier: opts.minConfidence,
 			});
 			if (opts.format === "json") {
 				console.log(JSON.stringify(report, null, 2));

--- a/cli/src/commands/BackfillCommand.ts
+++ b/cli/src/commands/BackfillCommand.ts
@@ -1,0 +1,96 @@
+/**
+ * BackfillCommand — `jolli backfill` CLI command.
+ *
+ * Generates jolli memory summaries for historical commits that lack one, by
+ * attributing on-disk Claude transcripts to those commits offline. Fully
+ * isolated from the live post-commit pipeline.
+ *
+ *   jolli backfill                  # last 20 commits, high-confidence only
+ *   jolli backfill --last 50        # last 50 commits
+ *   jolli backfill --all            # every commit reachable from HEAD
+ *   jolli backfill --dry-run        # report attribution + confidence, no LLM call
+ *   jolli backfill --include-medium # also accept time-window (medium) matches
+ */
+
+import type { Command } from "commander";
+import {
+	type BackfillOutcome,
+	type BackfillReport,
+	recentCommitHashes,
+	runBackfill,
+} from "../backfill/BackfillEngine.js";
+import { setLogDir } from "../Logger.js";
+import { parsePositiveInt, resolveProjectDir } from "./CliUtils.js";
+
+interface BackfillCliOptions {
+	cwd: string;
+	last?: number;
+	all?: boolean;
+	dryRun?: boolean;
+	includeMedium?: boolean;
+	format?: "json" | "text";
+}
+
+const DEFAULT_LAST = 20;
+
+/** Resolves the candidate commit hash list (newest-first) from the CLI options. */
+async function resolveHashes(opts: BackfillCliOptions): Promise<ReadonlyArray<string>> {
+	return recentCommitHashes(opts.cwd, opts.all ? undefined : (opts.last ?? DEFAULT_LAST));
+}
+
+const STATUS_LABEL: Record<BackfillOutcome["status"], string> = {
+	generated: "✓ generated",
+	"would-generate": "○ would generate",
+	"skipped-has-summary": "· already summarized",
+	error: "✗ error",
+};
+
+function renderText(report: BackfillReport, dryRun: boolean): string {
+	const lines: string[] = [];
+	for (const o of report.outcomes) {
+		const short = o.commitHash.substring(0, 8);
+		const conf = o.method ? ` [${o.confidence ? `${o.confidence}/` : ""}${o.method}]` : "";
+		const topics = o.topics !== undefined ? ` (${o.topics} topics)` : "";
+		const msg = o.message ? ` — ${o.message}` : "";
+		lines.push(`  ${short}  ${STATUS_LABEL[o.status]}${conf}${topics}${msg}`);
+	}
+	const verb = dryRun ? "would generate" : "generated";
+	lines.push("");
+	lines.push(
+		`  ${report.total} candidate(s): ${report.generated} ${verb}, ${report.skipped} skipped, ${report.errors} error(s).`,
+	);
+	return lines.join("\n");
+}
+
+/** Registers the `backfill` command on the given Commander program. */
+export function registerBackfillCommand(program: Command): void {
+	program
+		.command("backfill")
+		.description("Generate summaries for historical commits that lack one (Claude transcripts only)")
+		.option("--cwd <dir>", "Project directory (default: git repo root)", resolveProjectDir())
+		.option("--last <n>", "Number of most recent commits to consider", parsePositiveInt, DEFAULT_LAST)
+		.option("--all", "Consider every commit reachable from HEAD")
+		.option("--dry-run", "Report attribution and confidence without calling the LLM")
+		.option("--include-medium", "Also accept medium-confidence (time-window) attributions")
+		.option("--format <fmt>", "Output format: text | json", "text")
+		.action(async (opts: BackfillCliOptions) => {
+			setLogDir(opts.cwd);
+			const hashes = await resolveHashes(opts);
+			if (hashes.length === 0) {
+				console.error("  No commits found to back-fill.");
+				process.exitCode = 1;
+				return;
+			}
+			const report = await runBackfill({
+				cwd: opts.cwd,
+				hashes,
+				dryRun: opts.dryRun,
+				includeMedium: opts.includeMedium,
+			});
+			if (opts.format === "json") {
+				console.log(JSON.stringify(report, null, 2));
+			} else {
+				console.log(renderText(report, Boolean(opts.dryRun)));
+			}
+		});
+}

--- a/cli/src/commands/EnableCommand.ts
+++ b/cli/src/commands/EnableCommand.ts
@@ -9,6 +9,7 @@ import { join } from "node:path";
 import type { Command } from "commander";
 import { getJolliUrl } from "../auth/AuthConfig.js";
 import { browserLogin } from "../auth/Login.js";
+import { ENABLE_BACKFILL_COUNT, launchBackfillWorker } from "../backfill/BackfillWorker.js";
 import { validateJolliApiKey } from "../core/JolliApiUtils.js";
 import { getGlobalConfigDir, loadConfigFromDir, saveConfigScoped } from "../core/SessionTracker.js";
 import { track } from "../core/Telemetry.js";
@@ -172,6 +173,14 @@ export function registerEnableCommand(program: Command): void {
 					console.log(`    Edit: ${join(configDir, "config.json")}`);
 					console.log('    Set "apiKey" (Anthropic) and/or "jolliApiKey" (Jolli Space)\n');
 				}
+
+				// Kick off a detached, best-effort back-fill of recent history so the
+				// user's existing commits get summaries too. Runs in the background
+				// (LLM-bound) and never blocks enable; failures are logged only.
+				launchBackfillWorker(options.cwd);
+				console.log(
+					`  Back-filling summaries for the last ${ENABLE_BACKFILL_COUNT} commits in the background…`,
+				);
 			} else {
 				console.error(`\n  Error: ${result.message}\n`);
 				process.exitCode = 1;

--- a/cli/src/core/Regenerator.ts
+++ b/cli/src/core/Regenerator.ts
@@ -30,8 +30,8 @@ export interface RegenerateResult {
  * Reads inputs straight from the orphan branch (transcripts, archived plans /
  * notes / linear issues) and rebuilds the commit diff via `git show`. No
  * disk-side registries are consulted, no archives are re-written, and no
- * cursors / locks / queue entries are touched — see the plan's §1.6 isolation
- * matrix. The single side effect this returns is the updated CommitSummary
+ * cursors / locks / queue entries are touched — fully isolated from the live
+ * ingest pipeline. The single side effect this returns is the updated CommitSummary
  * that callers pass to `storeSummary(_, _, true)` (force=true).
  *
  * Fields replaced:        topics, recap, diffStats, transcriptEntries,
@@ -61,7 +61,7 @@ export interface RegenerateResult {
  *     empty conversation to the LLM. Mirrors the webview's All Conversations
  *     card (`SummaryWebviewPanel.refreshTranscriptHashes`).
  *
- * Preservation of ticketId and e2eTestGuide is deliberate (see plan §1.2):
+ * Preservation of ticketId and e2eTestGuide is deliberate:
  *   - ticketId is a stable identifier; the LLM may not see the original
  *     ticket ID in this re-run and would otherwise drop or change it.
  *   - e2eTestGuide is a user-initiated secondary artifact; the user can

--- a/cli/vite.config.ts
+++ b/cli/vite.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
 				SessionStartHook: resolve(__dirname, "src/hooks/SessionStartHook.ts"),
 				PostMergeHook: resolve(__dirname, "src/hooks/PostMergeHook.ts"),
 				QueueWorker: resolve(__dirname, "src/hooks/QueueWorker.ts"),
+				BackfillWorker: resolve(__dirname, "src/backfill/BackfillWorker.ts"),
 			},
 			formats: ["es"],
 		},

--- a/vscode/esbuild.config.mjs
+++ b/vscode/esbuild.config.mjs
@@ -88,6 +88,7 @@ const cliOptions = {
 		{ in: `${jmSrc}/hooks/PrepareMsgHook.ts`,          out: "PrepareMsgHook" },
 		{ in: `${jmSrc}/hooks/GeminiAfterAgentHook.ts`,   out: "GeminiAfterAgentHook" },
 		{ in: `${jmSrc}/hooks/SessionStartHook.ts`,       out: "SessionStartHook" },
+		{ in: `${jmSrc}/backfill/BackfillWorker.ts`,       out: "BackfillWorker" },
 	],
 	outdir: "dist",
 	// CLI entry points live under ../cli/src/, so esbuild's Node module

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -1957,6 +1957,7 @@ describe("Extension", () => {
 				mockMemoriesStore.refresh.mockClear();
 				mockFilesStore.refresh.mockClear();
 				mockCommitsStore.refresh.mockClear();
+				executeCommand.mockClear();
 
 				const handler = getRegisteredCommand("jollimemory.enableJolliMemory");
 				await handler();
@@ -1969,6 +1970,10 @@ describe("Extension", () => {
 				// refetch so the panel is not stuck empty until a watcher fires.
 				expect(mockPlansStore.refresh).toHaveBeenCalled();
 				expect(mockMemoriesStore.refresh).toHaveBeenCalled();
+
+				// Enable also kicks off a best-effort back-fill of missing summaries
+				// (mirrors the CLI `jolli enable`); fire-and-forget via executeCommand.
+				expect(executeCommand).toHaveBeenCalledWith("jollimemory.generateMissingSummaries");
 
 				// Ordering guard: `plansStore.setEnabled(true)` (called inside
 				// refreshStatusBar) MUST run before `plansStore.refresh()`,

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -726,6 +726,11 @@ vi.mock("../../cli/src/Logger.js", () => ({
 	getJolliMemoryDir: vi.fn((cwd: string) => `${cwd}/.jolli/jollimemory`),
 }));
 
+vi.mock("../../cli/src/backfill/BackfillEngine.js", () => ({
+	recentCommitHashes: vi.fn(),
+	runBackfill: vi.fn(),
+}));
+
 vi.mock("./commands/CommitCommand.js", () => ({
 	CommitCommand: MockCommitCommand,
 }));
@@ -7330,6 +7335,37 @@ describe("Extension", () => {
 			expect(showInformationMessage).toHaveBeenCalledWith(
 				"Please open a folder to use Jolli Memory.",
 			);
+		});
+	});
+
+	describe("generateMissingSummaries command", () => {
+		it("returns ok:false with a message when there are no commits", async () => {
+			const { recentCommitHashes } = await import("../../cli/src/backfill/BackfillEngine.js");
+			vi.mocked(recentCommitHashes).mockResolvedValue([]);
+			activate(makeContext());
+			const handler = commandMap.get("jollimemory.generateMissingSummaries");
+			expect(handler).toBeDefined();
+			const result = await handler?.();
+			expect(result).toEqual(expect.objectContaining({ ok: false, message: "No commits found." }));
+		});
+
+		it("runs the back-fill and renders each progress label variant", async () => {
+			const { recentCommitHashes, runBackfill } = await import("../../cli/src/backfill/BackfillEngine.js");
+			vi.mocked(recentCommitHashes).mockResolvedValue(["h1", "h2", "h3"]);
+			vi.mocked(runBackfill).mockImplementation(async (opts) => {
+				// Drives the label branches: short subject (≤60), long subject (>60 →
+				// truncated) with an error tag, and no subject (→ falls back to hash).
+				opts.onProgress?.(1, 3, { commitHash: "aaaaaaaa1111", status: "generated", commitSubject: "short subject" });
+				opts.onProgress?.(2, 3, { commitHash: "bbbbbbbb2222", status: "error", commitSubject: "x".repeat(70) });
+				opts.onProgress?.(3, 3, { commitHash: "cccccccc3333", status: "generated" });
+				return { total: 3, generated: 2, skipped: 0, errors: 1, outcomes: [] };
+			});
+			mockMemoriesStore.hasFirstLoaded.mockReturnValueOnce(true);
+			activate(makeContext());
+			const handler = commandMap.get("jollimemory.generateMissingSummaries");
+			const result = await handler?.();
+			expect(vi.mocked(runBackfill)).toHaveBeenCalled();
+			expect(result).toEqual(expect.objectContaining({ total: 3, generated: 2 }));
 		});
 	});
 

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1914,6 +1914,65 @@ export function activate(context: vscode.ExtensionContext): void {
 				}
 			},
 		),
+		// Back-fill summaries for historical commits that lack one. Reuses the
+		// isolated CLI back-fill engine (Claude transcript attribution → the same
+		// generateSummary/storeSummary path as the live flow). Progress streams
+		// through a native notification; the result text goes back to the
+		// Settings panel's "Generate Missing Summaries" button.
+		vscode.commands.registerCommand(
+			"jollimemory.generateMissingSummaries",
+			async (): Promise<{
+				ok: boolean;
+				generated: number;
+				total: number;
+				skipped: number;
+				message: string;
+			}> => {
+				try {
+					const { runBackfill, recentCommitHashes } = await import(
+						"../../cli/src/backfill/BackfillEngine.js"
+					);
+					const hashes = await recentCommitHashes(workspaceRoot);
+					if (hashes.length === 0) {
+						return { ok: false, generated: 0, total: 0, skipped: 0, message: "No commits found." };
+					}
+					const report = await vscode.window.withProgress(
+						{
+							location: vscode.ProgressLocation.Notification,
+							title: "Jolli: back-filling summaries",
+							cancellable: false,
+						},
+						(progress) =>
+							runBackfill({
+								cwd: workspaceRoot,
+								hashes,
+								onProgress: (done, total, outcome) => {
+									progress.report({
+										message: `${done}/${total} — ${outcome.commitHash.substring(0, 8)} (${outcome.status})`,
+										increment: 100 / total,
+									});
+								},
+							}),
+					);
+					bridge.invalidateEntriesCache();
+					if (memoriesStore.hasFirstLoaded()) {
+						memoriesStore.refresh().catch(handleError("generateMissingSummaries.memories"));
+					}
+					// Newly back-filled summaries also land in the Memory Bank folder's
+					// visible layer — refresh the Folders tree like rebuildKnowledgeBase does.
+					sidebarProvider.refreshKnowledgeBaseFolders();
+					return {
+						ok: report.errors === 0,
+						generated: report.generated,
+						total: report.total,
+						skipped: report.skipped,
+						message: `${report.generated} generated, ${report.skipped} skipped, ${report.errors} error(s)`,
+					};
+				} catch (err) {
+					return { ok: false, generated: 0, total: 0, skipped: 0, message: (err as Error).message };
+				}
+			},
+		),
 		// Status panel
 		// Beyond refreshing the status store + status bar, this also re-pulls
 		// `bridge.getStatus()` (via refreshStatusBar's return value) and

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1939,7 +1939,7 @@ export function activate(context: vscode.ExtensionContext): void {
 					const report = await vscode.window.withProgress(
 						{
 							location: vscode.ProgressLocation.Notification,
-							title: "Jolli: back-filling summaries",
+							title: "Jolli Memory: Back-filling summaries",
 							cancellable: false,
 						},
 						(progress) =>
@@ -1947,10 +1947,17 @@ export function activate(context: vscode.ExtensionContext): void {
 								cwd: workspaceRoot,
 								hashes,
 								onProgress: (done, total, outcome) => {
-									progress.report({
-										message: `${done}/${total} — ${outcome.commitHash.substring(0, 8)} (${outcome.status})`,
-										increment: 100 / total,
-									});
+									// Show the commit's one-line message (more readable than a hash),
+									// truncated; flag only failures — success is the norm and the
+									// advancing count already signals progress.
+									const subject = outcome.commitSubject?.trim();
+									const label = subject
+										? subject.length > 60
+											? `${subject.slice(0, 57)}…`
+											: subject
+										: outcome.commitHash.substring(0, 8);
+									const tag = outcome.status === "error" ? " (failed)" : "";
+									progress.report({ message: `${done}/${total} — ${label}${tag}`, increment: 100 / total });
 								},
 							}),
 					);

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -2066,6 +2066,14 @@ export function activate(context: vscode.ExtensionContext): void {
 						filesStore.refresh(true),
 						commitsStore.refresh(),
 					]);
+					// Mirror the CLI `jolli enable`: kick off a best-effort back-fill of
+					// historical commits that lack a summary. Fire-and-forget so enable stays
+					// responsive — the command streams its own progress notification and
+					// refreshes panels when done. runBackfill self-limits (early-returns when
+					// every recent commit already has a summary), a cheap no-op then.
+					void vscode.commands
+						.executeCommand("jollimemory.generateMissingSummaries")
+						.then(undefined, handleError("enable.backfill"));
 				}
 			},
 		),

--- a/vscode/src/views/SettingsHtmlBuilder.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.ts
@@ -187,6 +187,12 @@ export function buildSettingsHtml(nonce: string): string {
         <div class="hint" id="rebuildKbStatus"></div>
       </div>
 
+      <div class="settings-row column rebuild-row">
+        <button type="button" class="browse-btn rebuild-btn" id="generateSummariesBtn">Generate Missing Summaries</button>
+        <div class="hint rebuild-hint"><span id="missingSummariesCount">Checking…</span> Back-fills summaries for your own historical commits, attributing Claude Code conversations where they can be found and falling back to a diff-only summary otherwise. May take a while and makes one AI call per commit.</div>
+        <div class="hint" id="generateSummariesStatus"></div>
+      </div>
+
       <!-- ── Cloud sync to Personal Space ───────────────────────────────── -->
       <hr class="settings-divider" />
 

--- a/vscode/src/views/SettingsHtmlBuilder.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.ts
@@ -187,12 +187,6 @@ export function buildSettingsHtml(nonce: string): string {
         <div class="hint" id="rebuildKbStatus"></div>
       </div>
 
-      <div class="settings-row column rebuild-row">
-        <button type="button" class="browse-btn rebuild-btn" id="generateSummariesBtn">Generate Missing Summaries</button>
-        <div class="hint rebuild-hint"><span id="missingSummariesCount">Checking…</span> Back-fills summaries for your own historical commits, attributing Claude Code conversations where they can be found and falling back to a diff-only summary otherwise. May take a while and makes one AI call per commit.</div>
-        <div class="hint" id="generateSummariesStatus"></div>
-      </div>
-
       <!-- ── Cloud sync to Personal Space ───────────────────────────────── -->
       <hr class="settings-divider" />
 
@@ -236,6 +230,15 @@ export function buildSettingsHtml(nonce: string): string {
         <div class="warning-banner" role="note">
           ⚠ Pick a <code>localFolder</code> only Jolli writes to. Sharing it with iCloud / Dropbox / Syncthing races on the same files — and turning off auto-sync isn't enough, since manual sync still writes.
         </div>
+      </div>
+
+      <!-- ── Back-fill summaries for historical commits ─────────────────── -->
+      <hr class="settings-divider" />
+
+      <div class="settings-row column rebuild-row">
+        <button type="button" class="browse-btn rebuild-btn" id="generateSummariesBtn" disabled>Generate Missing Summaries</button>
+        <div class="hint rebuild-hint"><span id="missingSummariesCount">Checking for commits without a summary…</span> Generates summaries for your own past commits in this repository that don't have one yet — using the Claude Code conversation behind each commit when it can be found, otherwise summarizing the code change alone. Runs one AI call per commit, so it may take a while.</div>
+        <div class="hint" id="generateSummariesStatus"></div>
       </div>
     </section>
 

--- a/vscode/src/views/SettingsScriptBuilder.ts
+++ b/vscode/src/views/SettingsScriptBuilder.ts
@@ -589,15 +589,21 @@ export function buildSettingsScript(): string {
         applyAuthState(msg);
         updateAnthropicWarning();
         // The count arrives separately via 'missingSummaryCountLoaded' (computed
-        // off the settings-load critical path). Reset to the pending state here.
+        // off the settings-load critical path). Reset to the pending state here,
+        // and keep the button disabled until the count lands so it can't be
+        // clicked on an unknown count.
         if (missingSummariesCount) missingSummariesCount.textContent = 'Checking…';
+        if (generateSummariesBtn) generateSummariesBtn.disabled = true;
         captureInitialState();
         break;
       case 'missingSummaryCountLoaded': {
         const n = msg.missingSummaryCount;
+        const where = msg.repoName ? ' in ' + msg.repoName : ' in this repository';
         if (missingSummariesCount) {
           missingSummariesCount.textContent = typeof n === 'number'
-            ? (n === 0 ? 'All your commits have summaries.' : n + ' of your commits lack a summary.')
+            ? (n === 0
+                ? 'All your commits' + where + ' already have summaries.'
+                : n + ' of your commits' + where + ' still need summaries.')
             : '';
         }
         if (generateSummariesBtn) generateSummariesBtn.disabled = n === 0;

--- a/vscode/src/views/SettingsScriptBuilder.ts
+++ b/vscode/src/views/SettingsScriptBuilder.ts
@@ -41,6 +41,9 @@ export function buildSettingsScript(): string {
   const browseLocalFolderBtn = document.getElementById('browseLocalFolderBtn');
   const rebuildKbBtn = document.getElementById('rebuildKbBtn');
   const rebuildKbStatus = document.getElementById('rebuildKbStatus');
+  const generateSummariesBtn = document.getElementById('generateSummariesBtn');
+  const generateSummariesStatus = document.getElementById('generateSummariesStatus');
+  const missingSummariesCount = document.getElementById('missingSummariesCount');
   const excludePatternsInput = document.getElementById('excludePatterns');
   const compileExcludeFoldersInput = document.getElementById('compileExcludeFolders');
   const dcoSignoffInput = document.getElementById('dcoSignoff');
@@ -291,6 +294,15 @@ export function buildSettingsScript(): string {
     }
     startRebuild();
   });
+
+  if (generateSummariesBtn) {
+    generateSummariesBtn.addEventListener('click', function() {
+      if (generateSummariesBtn.disabled) return;
+      generateSummariesBtn.disabled = true;
+      if (generateSummariesStatus) generateSummariesStatus.textContent = 'Generating… (see notification for progress)';
+      vscode.postMessage({ command: 'generateMissingSummaries' });
+    });
+  }
 
   // ── Dirty tracking ──
   function getActiveJolliApiKeyValue() {
@@ -576,8 +588,21 @@ export function buildSettingsScript(): string {
         hasErrors = false;
         applyAuthState(msg);
         updateAnthropicWarning();
+        // The count arrives separately via 'missingSummaryCountLoaded' (computed
+        // off the settings-load critical path). Reset to the pending state here.
+        if (missingSummariesCount) missingSummariesCount.textContent = 'Checking…';
         captureInitialState();
         break;
+      case 'missingSummaryCountLoaded': {
+        const n = msg.missingSummaryCount;
+        if (missingSummariesCount) {
+          missingSummariesCount.textContent = typeof n === 'number'
+            ? (n === 0 ? 'All your commits have summaries.' : n + ' of your commits lack a summary.')
+            : '';
+        }
+        if (generateSummariesBtn) generateSummariesBtn.disabled = n === 0;
+        break;
+      }
       case 'authStateChanged':
         // Pushed after sign-in / sign-out so the cards re-render without
         // requiring a full settings reload. Mirror IntelliJ's auth listener.
@@ -592,6 +617,14 @@ export function buildSettingsScript(): string {
         rebuildKbStatus.textContent = msg.success
           ? 'Rebuild complete: ' + (msg.message || '')
           : 'Rebuild failed: ' + (msg.message || 'unknown error');
+        break;
+      case 'generateMissingSummariesDone':
+        if (generateSummariesBtn) generateSummariesBtn.disabled = false;
+        if (generateSummariesStatus) {
+          generateSummariesStatus.textContent = msg.success
+            ? 'Done: ' + (msg.message || '')
+            : 'Failed: ' + (msg.message || 'unknown error');
+        }
         break;
       case 'confirmDirtyMigrateResult':
         if (!msg.proceed) {

--- a/vscode/src/views/SettingsWebviewPanel.test.ts
+++ b/vscode/src/views/SettingsWebviewPanel.test.ts
@@ -163,6 +163,23 @@ vi.mock("node:crypto", () => ({
 	randomBytes: mockRandomBytes,
 }));
 
+// refreshMissingSummaryCount dynamic-imports these; mock the count so the
+// success/failure branches are deterministic (real countMissingSummaries would
+// run git + storage against a non-existent workspace path).
+const { mockCountMissingSummaries, mockExtractRepoName } = vi.hoisted(() => ({
+	mockCountMissingSummaries: vi.fn().mockResolvedValue({ missing: 0, total: 0 }),
+	mockExtractRepoName: vi.fn(() => "myrepo"),
+}));
+
+vi.mock("../../../cli/src/backfill/BackfillEngine.js", () => ({
+	countMissingSummaries: mockCountMissingSummaries,
+}));
+
+vi.mock("../../../cli/src/core/KBPathResolver.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../../../cli/src/core/KBPathResolver.js")>()),
+	extractRepoName: mockExtractRepoName,
+}));
+
 // ── Import under test ────────────────────────────────────────────────────────
 
 import { SettingsWebviewPanel } from "./SettingsWebviewPanel.js";
@@ -2431,6 +2448,196 @@ describe("SettingsWebviewPanel", () => {
 				success: false,
 				message: "plain string failure",
 			});
+		});
+
+		it("bails out of the catch when the panel was disposed before the rebuild rejected", async () => {
+			let rejectCmd: (e: unknown) => void = () => {};
+			mockExecuteCommand.mockImplementation(() => new Promise((_res, rej) => {
+				rejectCmd = rej;
+			}));
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+			postMessage.mockClear();
+
+			dispatch({ command: "rebuildKnowledgeBase" });
+			(SettingsWebviewPanel as unknown as { currentPanel: undefined }).currentPanel = undefined;
+			rejectCmd(new Error("late rebuild"));
+			await flushPromises();
+
+			expect(postMessage).not.toHaveBeenCalledWith(
+				expect.objectContaining({ command: "rebuildKnowledgeBaseDone" }),
+			);
+		});
+	});
+
+	describe("generateMissingSummaries message", () => {
+		it("forwards the command, posts the result, and refreshes the count", async () => {
+			mockCountMissingSummaries.mockResolvedValue({ missing: 3, total: 10 });
+			mockExecuteCommand.mockImplementation(async (cmd: string) =>
+				cmd === "jollimemory.generateMissingSummaries"
+					? { ok: true, generated: 2, total: 2, skipped: 0, message: "done" }
+					: undefined,
+			);
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+			postMessage.mockClear();
+
+			dispatch({ command: "generateMissingSummaries" });
+			await flushPromises();
+			await flushPromises(); // let refreshMissingSummaryCount's dynamic import resolve
+
+			expect(mockExecuteCommand).toHaveBeenCalledWith("jollimemory.generateMissingSummaries");
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "generateMissingSummariesDone",
+				success: true,
+				message: "done",
+			});
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "missingSummaryCountLoaded",
+				missingSummaryCount: 3,
+				repoName: "myrepo",
+			});
+		});
+
+		it("falls back to success=false / empty message when the command returns undefined", async () => {
+			mockExecuteCommand.mockResolvedValue(undefined);
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+			postMessage.mockClear();
+
+			dispatch({ command: "generateMissingSummaries" });
+			await flushPromises();
+			await flushPromises();
+
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "generateMissingSummariesDone",
+				success: false,
+				message: "",
+			});
+		});
+
+		it("posts the error message back when the command rejects", async () => {
+			mockExecuteCommand.mockRejectedValue(new Error("gen boom"));
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+			postMessage.mockClear();
+
+			dispatch({ command: "generateMissingSummaries" });
+			await flushPromises();
+
+			expect(logError).toHaveBeenCalledWith("SettingsPanel", expect.stringContaining("gen boom"));
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "generateMissingSummariesDone",
+				success: false,
+				message: "gen boom",
+			});
+		});
+
+		it("bails out without posting when the panel was disposed while the command ran", async () => {
+			let release: (v: unknown) => void = () => {};
+			mockExecuteCommand.mockImplementation(() => new Promise((r) => {
+				release = r;
+			}));
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+			postMessage.mockClear();
+
+			dispatch({ command: "generateMissingSummaries" });
+			// Panel disposed/replaced before the command resolves.
+			(SettingsWebviewPanel as unknown as { currentPanel: undefined }).currentPanel = undefined;
+			release({ ok: true, generated: 0, total: 0, skipped: 0, message: "" });
+			await flushPromises();
+
+			expect(postMessage).not.toHaveBeenCalledWith(
+				expect.objectContaining({ command: "generateMissingSummariesDone" }),
+			);
+		});
+
+		it("stringifies a non-Error rejection in the failure message", async () => {
+			mockExecuteCommand.mockRejectedValue("plain gen failure");
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+			postMessage.mockClear();
+
+			dispatch({ command: "generateMissingSummaries" });
+			await flushPromises();
+
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "generateMissingSummariesDone",
+				success: false,
+				message: "plain gen failure",
+			});
+		});
+
+		it("bails out of the catch when the panel was disposed before the command rejected", async () => {
+			let rejectCmd: (e: unknown) => void = () => {};
+			mockExecuteCommand.mockImplementation(() => new Promise((_res, rej) => {
+				rejectCmd = rej;
+			}));
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+			postMessage.mockClear();
+
+			dispatch({ command: "generateMissingSummaries" });
+			(SettingsWebviewPanel as unknown as { currentPanel: undefined }).currentPanel = undefined;
+			rejectCmd(new Error("late boom"));
+			await flushPromises();
+
+			expect(postMessage).not.toHaveBeenCalledWith(
+				expect.objectContaining({ command: "generateMissingSummariesDone" }),
+			);
+		});
+	});
+
+	describe("missing-summary count refresh", () => {
+		it("posts the count on success (via loadSettings)", async () => {
+			mockCountMissingSummaries.mockResolvedValue({ missing: 5, total: 12 });
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+			postMessage.mockClear();
+
+			dispatch({ command: "loadSettings" });
+			await flushPromises();
+			await flushPromises();
+
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "missingSummaryCountLoaded",
+				missingSummaryCount: 5,
+				repoName: "myrepo",
+			});
+		});
+
+		it("posts an empty count message when the computation fails", async () => {
+			mockCountMissingSummaries.mockRejectedValue(new Error("count boom"));
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+			postMessage.mockClear();
+
+			dispatch({ command: "loadSettings" });
+			await flushPromises();
+			await flushPromises();
+
+			expect(warn).toHaveBeenCalledWith("SettingsPanel", expect.stringContaining("count boom"));
+			expect(postMessage).toHaveBeenCalledWith({ command: "missingSummaryCountLoaded" });
+		});
+
+		it("does not post when the count fails after the panel was disposed", async () => {
+			let rejectCount: (e: unknown) => void = () => {};
+			mockCountMissingSummaries.mockImplementation(() => new Promise((_res, rej) => {
+				rejectCount = rej;
+			}));
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+
+			dispatch({ command: "loadSettings" });
+			await flushPromises(); // let the dynamic import + countMissingSummaries call start
+			postMessage.mockClear();
+			(SettingsWebviewPanel as unknown as { currentPanel: undefined }).currentPanel = undefined;
+			rejectCount(new Error("count late"));
+			await flushPromises();
+			await flushPromises();
+
+			expect(postMessage).not.toHaveBeenCalledWith({ command: "missingSummaryCountLoaded" });
 		});
 	});
 

--- a/vscode/src/views/SettingsWebviewPanel.ts
+++ b/vscode/src/views/SettingsWebviewPanel.ts
@@ -256,6 +256,7 @@ export class SettingsWebviewPanel {
 			case "rebuildKnowledgeBase":
 				this.handleRebuildKnowledgeBase().catch((err: unknown) => {
 					log.error("SettingsPanel", `Rebuild failed: ${err}`);
+					if (SettingsWebviewPanel.currentPanel !== this) return;
 					this.panel.webview.postMessage({
 						command: "rebuildKnowledgeBaseDone",
 						success: false,
@@ -266,6 +267,7 @@ export class SettingsWebviewPanel {
 			case "generateMissingSummaries":
 				this.handleGenerateMissingSummaries().catch((err: unknown) => {
 					log.error("SettingsPanel", `Generate missing summaries failed: ${err}`);
+					if (SettingsWebviewPanel.currentPanel !== this) return;
 					this.panel.webview.postMessage({
 						command: "generateMissingSummariesDone",
 						success: false,
@@ -381,11 +383,20 @@ export class SettingsWebviewPanel {
 	private async refreshMissingSummaryCount(): Promise<void> {
 		try {
 			const { countMissingSummaries } = await import("../../../cli/src/backfill/BackfillEngine.js");
+			const { extractRepoName } = await import("../../../cli/src/core/KBPathResolver.js");
 			const { missing } = await countMissingSummaries(this.workspaceRoot);
 			if (SettingsWebviewPanel.currentPanel !== this) return; // panel closed meanwhile
-			this.panel.webview.postMessage({ command: "missingSummaryCountLoaded", missingSummaryCount: missing });
+			this.panel.webview.postMessage({
+				command: "missingSummaryCountLoaded",
+				missingSummaryCount: missing,
+				repoName: extractRepoName(this.workspaceRoot),
+			});
 		} catch (err) {
 			log.warn("SettingsPanel", `Missing-summary count failed: ${err}`);
+			if (SettingsWebviewPanel.currentPanel !== this) return;
+			// Count failed — release the button from its initial disabled state so the
+			// user isn't stuck (back-fill is idempotent for commits that already have one).
+			this.panel.webview.postMessage({ command: "missingSummaryCountLoaded" });
 		}
 	}
 

--- a/vscode/src/views/SettingsWebviewPanel.ts
+++ b/vscode/src/views/SettingsWebviewPanel.ts
@@ -75,6 +75,7 @@ type SettingsMessage =
 	| { command: "loadSettings" }
 	| { command: "browseLocalFolder" }
 	| { command: "rebuildKnowledgeBase" }
+	| { command: "generateMissingSummaries" }
 	| { command: "confirmDirtyMigrate" }
 	| { command: "signIn" }
 	| { command: "signOut" }
@@ -262,6 +263,16 @@ export class SettingsWebviewPanel {
 					});
 				});
 				break;
+			case "generateMissingSummaries":
+				this.handleGenerateMissingSummaries().catch((err: unknown) => {
+					log.error("SettingsPanel", `Generate missing summaries failed: ${err}`);
+					this.panel.webview.postMessage({
+						command: "generateMissingSummariesDone",
+						success: false,
+						message: err instanceof Error ? err.message : String(err),
+					});
+				});
+				break;
 			case "confirmDirtyMigrate":
 				this.handleConfirmDirtyMigrate().catch((err: unknown) => {
 					log.error("SettingsPanel", `Confirm dirty migrate failed: ${err}`);
@@ -337,6 +348,45 @@ export class SettingsWebviewPanel {
 			success: result?.ok ?? false,
 			message: result?.message ?? "",
 		});
+	}
+
+	/**
+	 * Forwards the Settings → Generate Missing Summaries button click to the
+	 * `jollimemory.generateMissingSummaries` command (back-fills historical
+	 * commits via the isolated CLI engine) and posts the result back.
+	 */
+	private async handleGenerateMissingSummaries(): Promise<void> {
+		const result = (await vscode.commands.executeCommand("jollimemory.generateMissingSummaries")) as
+			| { ok: boolean; generated: number; total: number; skipped: number; message: string }
+			| undefined;
+		// The command can run for minutes; the user may have closed the panel
+		// meanwhile. Bail out instead of posting to a disposed webview / doing
+		// the (git + index) count work for a panel nobody is looking at.
+		if (SettingsWebviewPanel.currentPanel !== this) return;
+		this.panel.webview.postMessage({
+			command: "generateMissingSummariesDone",
+			success: result?.ok ?? false,
+			message: result?.message ?? "",
+		});
+		// Counts changed — refresh just the missing-summary number (async).
+		void this.refreshMissingSummaryCount();
+	}
+
+	/**
+	 * Computes the "N commits lack a summary" count off the settings-load critical
+	 * path and posts it to the webview. Best-effort: any failure leaves the count
+	 * blank. Uses a dynamic import so the Node-only BackfillEngine dependency chain
+	 * (QueueWorker, node:child_process) is not statically bundled into the panel.
+	 */
+	private async refreshMissingSummaryCount(): Promise<void> {
+		try {
+			const { countMissingSummaries } = await import("../../../cli/src/backfill/BackfillEngine.js");
+			const { missing } = await countMissingSummaries(this.workspaceRoot);
+			if (SettingsWebviewPanel.currentPanel !== this) return; // panel closed meanwhile
+			this.panel.webview.postMessage({ command: "missingSummaryCountLoaded", missingSummaryCount: missing });
+		} catch (err) {
+			log.warn("SettingsPanel", `Missing-summary count failed: ${err}`);
+		}
 	}
 
 	/** Opens a folder picker and posts the selected path back to the webview. */
@@ -424,6 +474,12 @@ export class SettingsWebviewPanel {
 			hasJolliKey,
 			jolliSiteLabel: buildJolliSiteLabel(config.jolliApiKey, config.jolliUrl),
 		});
+
+		// The missing-summary count runs `git rev-list` over all of HEAD plus an
+		// index read — too slow to block the form render on. Compute it off the
+		// critical path and push a separate update when ready (the count span
+		// shows "Checking…" until then).
+		void this.refreshMissingSummaryCount();
 
 		if (this.fullJolliApiKey.length > 0) {
 			try {

--- a/vscode/src/views/SummaryCssBuilder.ts
+++ b/vscode/src/views/SummaryCssBuilder.ts
@@ -1469,6 +1469,11 @@ export function buildCss(): string {
     white-space: nowrap; vertical-align: bottom;
     padding: 1px 8px; border-radius: 5px; background: var(--pill-bg); color: var(--pill-text); font-size: 0.92em;
   }
+  .meta-backfill {
+    padding: 1px 8px; border-radius: 5px; font-size: 0.92em; cursor: help;
+    background: var(--vscode-badge-background); color: var(--vscode-badge-foreground);
+    border: 1px solid var(--vscode-contrastBorder, transparent);
+  }
   .details-toggle {
     background: none; border: none; cursor: pointer; font-family: var(--vscode-font-family);
     font-size: 0.96em; color: var(--text-tertiary); padding: 1px 4px; border-radius: 4px;

--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -269,6 +269,22 @@ describe("SummaryHtmlBuilder", () => {
 			expect(html).toContain("<title>Commit Memory</title>");
 		});
 
+		it("shows a Back-filled badge only for back-filled summaries, with a method-specific tooltip", () => {
+			expect(buildHtml(makeSummary())).not.toContain("Back-filled"); // live summary → no badge
+
+			const fileOverlap = buildHtml(makeSummary({ backfilled: true, backfillMethod: "file-overlap" }));
+			expect(fileOverlap).toContain('class="meta-backfill"');
+			expect(fileOverlap).toContain(">Back-filled<");
+			expect(fileOverlap).toContain("conversation that edited these files");
+
+			expect(buildHtml(makeSummary({ backfilled: true, backfillMethod: "time-window" }))).toContain(
+				"matched by timing",
+			);
+			expect(buildHtml(makeSummary({ backfilled: true, backfillMethod: "diff-only" }))).toContain(
+				"written from the code changes alone",
+			);
+		});
+
 		it("includes CSS from buildCss() in a style tag", () => {
 			const html = buildHtml(makeSummary());
 			expect(html).toContain("<style>/* css */</style>");

--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -280,6 +280,9 @@ describe("SummaryHtmlBuilder", () => {
 			expect(buildHtml(makeSummary({ backfilled: true, backfillMethod: "time-window" }))).toContain(
 				"matched by timing",
 			);
+			expect(buildHtml(makeSummary({ backfilled: true, backfillMethod: "branch-match" }))).toContain(
+				"matched by the branch you were working on",
+			);
 			expect(buildHtml(makeSummary({ backfilled: true, backfillMethod: "diff-only" }))).toContain(
 				"written from the code changes alone",
 			);

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -419,12 +419,23 @@ export function buildJolliRow(
  */
 function buildBackfillBadge(summary: CommitSummary): string {
 	if (!summary.backfilled) return "";
-	const tip =
-		summary.backfillMethod === "diff-only"
-			? "Back-filled for an earlier commit. No matching AI conversation was found, so this summary was written from the code changes alone."
-			: summary.backfillMethod === "time-window"
-				? "Back-filled for an earlier commit. The AI conversation was matched by timing (same branch, right before the commit), so it may not be the exact one."
-				: "Back-filled for an earlier commit, reconstructed from the AI conversation that edited these files.";
+	let tip: string;
+	switch (summary.backfillMethod) {
+		case "diff-only":
+			tip =
+				"Back-filled for an earlier commit. No matching AI conversation was found, so this summary was written from the code changes alone.";
+			break;
+		case "time-window":
+			tip =
+				"Back-filled for an earlier commit. The AI conversation was matched by timing alone, so it may not be the exact one.";
+			break;
+		case "branch-match":
+			tip =
+				"Back-filled for an earlier commit. The AI conversation was matched by the branch you were working on, so it may not be the exact one.";
+			break;
+		default:
+			tip = "Back-filled for an earlier commit, reconstructed from the AI conversation that edited these files.";
+	}
 	return `<span class="meta-sep">&middot;</span><span class="meta-backfill" title="${escAttr(tip)}">Back-filled</span>`;
 }
 

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -411,6 +411,23 @@ export function buildJolliRow(
  * modes it stays in the DOM and is hidden by the readonly CSS rule (it is
  * intentionally not `data-foreign-safe`).
  */
+/**
+ * Renders the "Back-filled" badge shown in the meta strip for summaries produced
+ * by the historical back-fill flow (absent on live post-commit summaries). The
+ * badge text is deliberately plain ("Back-filled"); the *how* lives in the
+ * hover tooltip, phrased for end users rather than as a confidence tier.
+ */
+function buildBackfillBadge(summary: CommitSummary): string {
+	if (!summary.backfilled) return "";
+	const tip =
+		summary.backfillMethod === "diff-only"
+			? "Back-filled for an earlier commit. No matching AI conversation was found, so this summary was written from the code changes alone."
+			: summary.backfillMethod === "time-window"
+				? "Back-filled for an earlier commit. The AI conversation was matched by timing (same branch, right before the commit), so it may not be the exact one."
+				: "Back-filled for an earlier commit, reconstructed from the AI conversation that edited these files.";
+	return `<span class="meta-sep">&middot;</span><span class="meta-backfill" title="${escAttr(tip)}">Back-filled</span>`;
+}
+
 function buildHeader(
 	summary: CommitSummary,
 	totalFiles: number,
@@ -439,6 +456,7 @@ function buildHeader(
   <span class="meta-sep">&middot;</span>
   <span class="meta-changes"><span class="stat-add">+${totalInsertions}</span>/<span class="stat-del">\u2212${totalDeletions}</span></span>
   ${turnsMeta}
+  ${buildBackfillBadge(summary)}
   <button class="details-toggle" id="detailsToggle" data-foreign-safe aria-expanded="false">Details &#x25BE;</button>
 </div>
 <div class="properties collapsed" id="propTable">


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (3)

1. Add backfill command and engine for historical commit summarization (`c094fdb`)
2. Add commitSubject to BackfillOutcome and replace ORPHAN_BRANCH with DIFF_ONLY_BRANCH label (`e5c122f`)
3. Add branch-match tier and low-confidence attribution to backfill pipeline (`f73aec3`)

## Quick recap (3)

### Commit 1 of 3: Add backfill command and engine for historical commit summarization (`c094fdb`)

Jolli Memory gained a complete backfill system for generating summaries on commits that predate the tool's installation. A new isolated module scans Claude Code conversation files on disk, maps conversation slices to historical commits using file-overlap anchoring and adjacency propagation, and then generates summaries through the same AI pipeline used for live commits. Commits where no conversation can be confidently attributed still receive a summary derived from the code diff alone, matching the behavior of the live pipeline when no session is active. Only the user's own commits are considered, keeping the missing-summary count meaningful and avoiding wasted AI calls on merged work with no local conversation history. After the entire batch completes, a single wiki and knowledge graph rebuild is triggered rather than one per commit.

The Settings panel in VS Code now shows how many of a repository's commits lack summaries and provides a one-click button to generate them, with per-commit progress streamed through a native notification. The missing-summary count loads asynchronously so the panel remains responsive on large repositories. Newly generated summaries appear immediately in the Memory Bank Folders tree without requiring a reload. Commit summaries produced by backfill display a "Back-filled" badge in the meta strip; hovering the badge explains in plain language whether the summary came from a matched conversation or from the code changes alone.

### Commit 2 of 3: Add commitSubject to BackfillOutcome and replace ORPHAN_BRANCH with DIFF_ONLY_BRANCH label (`e5c122f`)

The historical commit back-fill feature received a substantial overhaul across attribution accuracy, correctness, and user experience. The core attribution algorithm was rewritten around a commit-time window model: each commit now claims conversation segments that fall within a window bounded by its own author timestamp and the most recent prior commit to the same files. On a five-commit real-data sample this lifted session recall from 13% to 33% and eliminated the commits that previously received no conversation at all. File path comparisons now account for case-insensitive filesystems on Windows and macOS, closing a gap where edits referenced with different casing would go unattributed entirely.

Three correctness bugs were also fixed. Back-filled summaries for commits with no attributed conversation now always carry an explicit "backfilled" branch label, routing historical commits to a dedicated Memory Bank folder rather than whichever branch happened to be checked out at generation time. The Settings panel's "Generate Missing Summaries" button now starts disabled and remains so until the commit count finishes loading; a count failure releases the button rather than leaving it permanently locked, and error responses are no longer dispatched to panels that have already been closed. Additionally, the author-scoping filter that restricts back-fill to the current user's own commits now correctly handles email addresses containing special characters such as plus signs, preventing commits from other authors from being silently included.

New test coverage was added across both the CLI back-fill module and the VS Code extension to exercise every newly introduced code path. The VS Code workspace's global branch coverage rose from 96.67% to 97.18%, clearing the required threshold, while the back-fill module itself reached 98.31%.

### Commit 3 of 3: Add branch-match tier and low-confidence attribution to backfill pipeline (`f73aec3`)

The backfill pipeline gained a third attribution tier — branch-match — sitting between the existing file-overlap and time-window levels. Conversations that happened on the same feature branch as a commit, but without directly editing that commit's files, are now captured and labeled honestly rather than being discarded or silently promoted to a higher confidence level. Each generated summary now carries the weakest tier actually present in its attributed conversations, so the tooltip shown in the Back-filled badge accurately reflects whether the match was based on file edits, branch alignment, or timing alone.

The attribution engine was also made more accurate about which conversations belong to which commit. A cursor-slicing mechanism now ensures that a long session spanning two commits is split into contiguous blocks at the commit boundary, and already-summarized commits that fall just outside the requested range are pulled in as boundary markers to prevent their conversations from bleeding into a neighbor. The author filter was corrected to match commits by either email or name, closing a silent failure where commits made under a different email identity were skipped entirely. Enabling Jolli Memory through the VS Code interface now automatically triggers a background backfill of recent commits, matching the behavior that was previously only available through the command line.

## Topics (14)
<details>
<summary><strong>01 · [c094fdb] New backfill command and engine for generating summaries on historical commits</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users who installed Jolli Memory after accumulating a commit history had no summaries for their earlier work. A way was needed to retroactively generate summaries for commits that predate the installation, using whatever Claude conversation history was still available on disk.

**💡 Decisions Behind the Code**

- **Complete isolation from the live pipeline**: The backfill module shares no queue, cursor, or session state with `QueueWorker`. This was a hard constraint: the live flow's cursor-based incremental model cannot be safely reused for historical reconstruction, and mixing the two would risk corrupting the active pipeline's state. The one deliberate exception is the final ingest trigger, which reuses the standard post-commit path to avoid duplicating wiki/graph rebuild logic.
- **Diff-only fallback instead of skipping**: Early designs skipped commits with no attributable conversation ("宁缺毋滥" — better to omit than to guess). The final decision was that this principle governs only *conversation attachment*, not summary generation itself. Every own-commit gets at least a diff-based summary, mirroring what the live pipeline does when no session is active. This maximizes coverage while still never fabricating a conversation link.
- **Own-commits only via author filter**: Back-filling commits authored by others (merged or pulled in) would always produce diff-only summaries and inflate the "missing summaries" count with work that has no local Claude transcript. Scoping `git rev-list` to `--author=<git user.email>` eliminates this noise; the filter is dropped gracefully when no email is configured.

**✅ What Was Implemented**

- A new standalone `cli/src/backfill/` module was created with five files: `RawTranscriptScanner.ts` scans all Claude JSONL transcripts under the user's home directory and indexes each line's timestamp, branch, working directory, edited files, and conversational text. `CommitTargetIndex.ts` runs a single `git log` pass to build a file-to-commits map, excluding jolli's own bookkeeping commits and the orphan summaries branch. `CommitAttributor.ts` implements the three-tier attribution algorithm (file-overlap anchoring, adjacency propagation, and optional time-window medium attribution) with a branch gate on medium candidates.
- `BackfillEngine.ts` orchestrates the full pipeline: it drops already-summarized commits, builds the offline indexes, runs attribution, then calls the same `generateSummary` and `storeSummary` functions used by the live post-commit flow. Commits with no attributed conversation fall back to a diff-only summary rather than being skipped. After the entire batch, exactly one wiki/graph ingest is triggered via the existing `enqueueIngestOperation` + `launchWorker` path.
- `BackfillCommand.ts` registers `jolli backfill` with `--last`, `--all`, `--dry-run`, `--include-medium`, and `--format` flags. `BackfillWorker.ts` provides a detached-process entry point launched by `EnableCommand` after a successful install, back-filling the last 20 commits silently in the background.

**📁 FILES**
- `cli/src/backfill/BackfillEngine.ts`
- `cli/src/backfill/CommitAttributor.ts`
- `cli/src/backfill/CommitTargetIndex.ts`
- `cli/src/backfill/RawTranscriptScanner.ts`
- `cli/src/backfill/BackfillWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [c094fdb] Settings panel button to generate missing summaries for a repository</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users needed a way to see how many of their commits lacked summaries and to trigger backfill generation directly from the VS Code Settings panel, without using the command line.

**💡 Decisions Behind the Code**

- **Async count decoupled from form render**: Computing the missing-summary count requires a full `git rev-list` traversal plus an index read, which is too slow to block the settings form on. The count is computed after the form data is posted, with the span showing "Checking…" until a separate `missingSummaryCountLoaded` message arrives. This keeps the panel responsive on large repositories.
- **Dynamic import for the backfill engine in the panel**: The rest of the VS Code extension uses dynamic imports for Node-only CLI modules to avoid pulling their dependency chains (including `node:child_process` and `QueueWorker`) into the static bundle. The panel's count helper follows the same convention, while the command registration in `Extension.ts` also uses a dynamic import for the same reason.
- **Dispose guard before posting results**: The backfill command can run for several minutes. If the user closes the Settings panel during that time, posting a result to the disposed webview and re-running the count would be wasted work. A check against `SettingsWebviewPanel.currentPanel` before each post prevents this.

**✅ What Was Implemented**

- `SettingsHtmlBuilder.ts` gained a "Generate Missing Summaries" row with a count span (initially "Checking…") and a button. `SettingsScriptBuilder.ts` wires the button click to post a `generateMissingSummaries` message and handles the `missingSummaryCountLoaded` and `generateMissingSummariesDone` response messages, disabling the button while work is in progress.
- `SettingsWebviewPanel.ts` routes the message to a new `handleGenerateMissingSummaries` method that executes the `jollimemory.generateMissingSummaries` VS Code command and posts the result back. A `refreshMissingSummaryCount` helper uses a dynamic import of `BackfillEngine` to compute the count off the settings-load critical path, posting a separate `missingSummaryCountLoaded` message when ready.
- `Extension.ts` registers the `jollimemory.generateMissingSummaries` command, which streams per-commit progress through a native VS Code notification, then invalidates the entries cache, refreshes the Memories store, and calls `sidebarProvider.refreshKnowledgeBaseFolders()` to update the Memory Bank Folders tree.

**📁 FILES**
- `vscode/src/Extension.ts`
- `vscode/src/views/SettingsWebviewPanel.ts`
- `vscode/src/views/SettingsHtmlBuilder.ts`
- `vscode/src/views/SettingsScriptBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [c094fdb] Back-filled badge in the commit summary panel</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Summaries generated by the backfill flow look identical to live summaries in the UI, giving users no way to know whether a summary was reconstructed from historical data or captured in real time.

**💡 Decisions Behind the Code**

The badge text was kept to just "Back-filled" with the explanation in the hover tooltip rather than exposing confidence tier labels ("high", "medium") directly in the UI. Confidence terminology is meaningful to developers tuning the algorithm but confusing to end users; plain descriptions of how the summary was produced ("from the conversation that edited these files" vs. "from code changes alone") communicate the same reliability signal in language anyone can act on.

**✅ What Was Implemented**

- `SummaryHtmlBuilder.ts` gained a `buildBackfillBadge` function that renders a "Back-filled" badge in the meta strip when `summary.backfilled` is true. The badge is absent on live summaries. The hover tooltip text varies by `backfillMethod`: file-overlap explains the conversation was reconstructed from edits to those files; time-window notes the match was by timing and may not be exact; diff-only states no conversation was found and the summary came from code changes alone.
- `SummaryCssBuilder.ts` adds a `.meta-backfill` class using VS Code's native badge color tokens and a `cursor: help` to signal the tooltip.

**📁 FILES**
- `vscode/src/views/SummaryHtmlBuilder.ts`
- `vscode/src/views/SummaryCssBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [c094fdb] Attribution algorithm validated against real local data before implementation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Before committing to an implementation approach, the team needed to verify that Claude transcript entries could be reliably mapped to specific historical commits using only the signals available in the JSONL files, and to quantify the expected accuracy and coverage.

**💡 Decisions Behind the Code**

- **Entry-level attribution rather than session-level**: Early intuition was to map whole sessions to commits. Real data showed sessions routinely span multiple branches, multiple days, and dozens of commits, making session-level attribution meaningless. The algorithm instead attributes each individual JSONL line to a commit and then aggregates, which is the only approach that handles the observed session shapes.
- **Adjacency propagation as a safe extension of file-overlap**: The locality finding (100% of tested cases) justified propagating attribution from a file-overlap anchor to neighboring entries with no file signal (pure discussion turns). Without propagation, those discussion turns would always be skipped, producing summaries with no conversational context. The 100% locality rate means propagation across a contiguous run never crosses a commit boundary.

**✅ What Was Implemented**

The feasibility study ran Python scripts against the full local transcript and commit history. Key findings: timestamp mapping was 100% exact across all ground-truth entries; the locality property held in 18/18 tested cases (a commit's edits always form a single contiguous run in a session timeline, never interleaving with other commits); file-overlap attribution reached 75.7% exact / 84.4% soft precision on the subset of ground-truth commits still present in current history; per-commit recall was approximately 65% across all history (pessimistic due to ~75% of old commits having been squashed or rebased away and ~56% of old transcripts having been deleted). Three hard constraints were identified: jolli's own bookkeeping commits must be excluded from the target set, squashed commits must never be matched by hash identity, and the UI must honestly represent when no transcript was found.

**📁 FILES**
- `cli/src/backfill/CommitAttributor.ts`
- `cli/src/backfill/CommitTargetIndex.ts`
- `cli/src/backfill/RawTranscriptScanner.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [c094fdb] Four-agent adversarial code review with targeted fixes applied</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Before merging, the implementation was reviewed from four independent angles (core algorithm correctness, orchestration isolation, VS Code integration, and plan-to-code consistency) to catch bugs and design gaps that a single reviewer might miss.

**💡 Decisions Behind the Code**

- **Removing the dead status rather than keeping it for future use**: The `skipped-no-conversation` status was originally intended for commits where no conversation was found. After the diff-only fallback was adopted, it became unreachable. Keeping dead code in a type union misleads future readers into thinking there is a path that produces it; removing it makes the actual behavior self-documenting.
- **Branch gate on medium attribution only when both sides are known**: The gate rejects a candidate only when the commit's branch and the segment's modal branch are both present and differ. When either is unknown, the gate does not fire. This mirrors the undefined-inheritance rule in segmentation: applying a strict constraint on incomplete data would silently drop valid attributions on older transcripts that lack branch metadata.

**✅ What Was Implemented**

- A stack overflow risk in the medium attribution path was fixed: `Math.max(...spread)` over a potentially tens-of-thousands-entry segment array was replaced with a `reduce` call. The dead `skipped-no-conversation` status (unreachable after the diff-only fallback was added) was removed from the type and CLI label map. The `BackfillWorker` header comment was corrected to accurately describe the one intentional exception to its isolation claim.
- Three VS Code integration issues were addressed: the Settings panel now checks whether it is still the active panel before posting results or rerunning the count after a long-running operation; the missing-summary count computation was moved off the form-render critical path to an async push message; the panel's import of `BackfillEngine` was changed from static to dynamic to match the extension's convention for Node-only modules.
- Two attribution algorithm improvements were made based on review findings: `segmentSession` now inherits `undefined` branch values from surrounding entries rather than treating them as branch changes (preventing spurious segment splits on early transcripts that omit the branch field); the medium time-window path gained a branch gate that rejects a candidate commit when both the commit's branch and the segment's modal branch are known and differ.

**📁 FILES**
- `cli/src/backfill/CommitAttributor.ts`
- `cli/src/backfill/CommitTargetIndex.ts`
- `vscode/src/views/SettingsWebviewPanel.ts`
- `cli/src/backfill/BackfillEngine.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · [e5c122f] Back-fill attribution rewritten to use commit-time windows for session recall</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The original attribution algorithm assigned a conversation to whichever commit first touched a given file after the edit. In practice, consecutive commits in the same development sequence all touched the same files, so only the earliest commit captured the conversation and later commits received nothing.

**💡 Decisions Behind the Code**

- **Author time over committer time**: Rebase and amend operations push the committer timestamp to the moment of the rebase, which can be days after the actual development. On-disk transcript entries are written at the original edit time, which aligns with the author timestamp. Using committer time caused the attribution window to exclude the entire real development session; switching to author time was the single change that lifted session recall from 13% to 33% on a five-commit real-data sample.
- **Window lower bound from file history, not a fixed lookback**: A fixed lookback (e.g. seven days) would allow consecutive commits touching the same files to bleed into each other's windows. Flooring at the previous commit time for the same files creates a natural boundary that matches how development actually proceeds — each commit's window starts where the prior commit's ended.
- **Platform-aware case folding rather than always-lowercase**: Folding case unconditionally would cause Linux to treat genuinely distinct files with the same name but different casing as identical. The chosen normalization function encodes the right platform check, so no new branching logic was needed. Both the commit's file list and the transcript's edited-file list are normalized when the sets are constructed, keeping the hot-path lookup a simple set membership test.
- **Dead code removed rather than kept as dormant fallback**: The old first-committer function had no production callers and its horizon constant (21 days) directly contradicted the active algorithm's window (7 days). Keeping contradictory constants is a maintenance hazard, so removal was preferred over retaining a dormant fallback.
- **No content-fingerprint or branch-filter implementation yet**: Real-data testing showed that branch filtering via git is ineffective for merged commits (a single commit can be reachable from dozens of branches). Content fingerprinting was validated as the only reliable signal for parallel-worktree same-file disambiguation, but the implementation cost was deferred. The current model accepts some over-attribution on wide-window commits as a known trade-off.

**✅ What Was Implemented**

- `CommitAttributor.ts` was rewritten from a propagation-based anchor model to a per-commit time-window model. For each target commit, a window `(L, T]` is computed: `T` is the commit's author timestamp (not committer timestamp, which rebase shifts), and `L` is the most recent prior commit time for any of the commit's files. Any session segment that edited one of the commit's files inside this window contributes its in-window slice, regardless of whether that commit was the file's first committer.
- `CommitTargetIndex.ts` gained a new `commitFiles` map (hash → file list) and an exported `attributionLowerBound` helper that computes `L` by scanning the sorted file-to-commits history. The git log format was changed from committer time to author time to align the window with when edits actually occurred on disk.
- The optional MEDIUM (time-window) path was rewritten to operate on the same window boundaries: in-window segments that end within two hours of the commit and pass a branch compatibility check are collected when no file-overlap match exists.
- Dead code from the earlier first-committer algorithm — the `anchorCommitForEdit` function and its associated horizon constants — was removed from `CommitTargetIndex.ts` after confirming zero production callers. The old constants contradicted the active algorithm's window size, creating a maintenance hazard.
- File path comparisons now run through a platform-aware normalization function before building lookup sets and before each lookup. On Linux the function is a no-op; on Windows and macOS it folds case, closing a gap where edits to a file referenced with different casing would go unattributed.

**📋 Future Enhancements**

Content fingerprinting — matching transcript edit content against commit diff hunks — was validated as the only reliable way to disambiguate parallel-branch commits that touch the same file. Implementation was deferred but confirmed effective in real-data testing.

**📁 FILES**
- `cli/src/backfill/CommitAttributor.ts`
- `cli/src/backfill/CommitTargetIndex.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · [e5c122f] Diff-only back-filled summaries routed to dedicated folder with explicit branch label</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When back-filling a commit with no attributed conversation, the branch field was set to whatever branch the user happened to have checked out at the moment they clicked Generate. This caused historical commits to appear under the wrong branch folder in the Memory Bank — for example, a commit from months ago landing in a freshly created feature branch directory.

**💡 Decisions Behind the Code**

An explicit "backfilled" marker was chosen over any git-derived branch name. A git commit object contains no record of which branch it was developed on; after merging or deleting the original feature branch, querying git returns dozens of branches or arbitrary refs such as tags and remote experiment branches. Stamping the run-time HEAD was actively wrong — it associated old commits with today's unrelated branch. An explicit label is honest about the uncertainty and routes these summaries to a dedicated Memory Bank folder.

**✅ What Was Implemented**

- Replaced the `getCurrentBranch` fallback in `BackfillEngine.ts` with a module-level constant `DIFF_ONLY_BRANCH = "backfilled"`. Diff-only summaries now always carry this explicit label rather than the run-time HEAD. The `getCurrentBranch` and `ORPHAN_BRANCH` imports were removed.
- When a conversation is successfully attributed, the branch is still taken from the transcript entries' recorded branch at edit time — that value is reliable and is preserved unchanged.
- Tests were updated to assert the new `"backfilled"` label for the no-conversation path and the attributed branch for the conversation path.

**📁 FILES**
- `cli/src/backfill/BackfillEngine.ts`
- `cli/src/backfill/BackfillEngine.test.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · [e5c122f] Settings panel &quot;Generate Missing Summaries&quot; button hardened against race conditions and panel closure</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The "Generate Missing Summaries" button in the Settings panel could be clicked before the system had finished counting how many commits needed summaries. If the count check failed, the button would stay permanently disabled with no way for the user to recover, and error messages could be posted to a panel that had already been closed.

**💡 Decisions Behind the Code**

- **Release on failure rather than stay disabled**: Keeping the button disabled when the count fails would leave users with no recourse. Releasing it is safe because the back-fill operation is idempotent — running it on commits that already have summaries does nothing harmful.
- **Dispose guard in catch blocks for consistency**: The success path already checked whether the panel was still active before posting messages. Adding the same check to the catch paths ensures no message is sent to a panel that has been closed or replaced, matching the established pattern throughout the class.

**✅ What Was Implemented**

- `SettingsHtmlBuilder.ts` now renders the button with `disabled` set from the start, so it is never clickable on first load. `SettingsScriptBuilder.ts` also resets the button to disabled whenever settings reload, preventing stale state from a previous count from enabling it prematurely.
- `SettingsWebviewPanel.ts` now posts an empty count-loaded message when the count check fails, which the frontend interprets as "unknown" and uses to release the button from its disabled state, preventing permanent lockout.
- Two catch blocks in the panel's message handler now check whether the panel is still the active one before posting error responses, matching the guard already present on the success path.

**📁 FILES**
- `vscode/src/views/SettingsHtmlBuilder.ts`
- `vscode/src/views/SettingsScriptBuilder.ts`
- `vscode/src/views/SettingsWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · [e5c122f] Fix email regex escaping in author-scoped commit filtering</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The tool that limits history back-fill to only the current user's commits was passing email addresses directly into a git pattern-matching argument. Email addresses containing special characters — such as Gmail-style aliases with plus signs or dots — could accidentally match commits from other authors.

**💡 Decisions Behind the Code**

The fix was applied only to the email string passed to git, leaving all other behavior unchanged. A Gmail alias with a literal plus sign is a realistic and common case that would silently pull in unintended commits without this fix, making it a correctness issue rather than an edge case.

**✅ What Was Implemented**

Added `escapeRegex()` in `BackfillEngine.ts` that escapes all regex metacharacters before the email is passed to git's author filter. The test was updated to use a Gmail-style alias (`me+tag@dev.io`) and assert that both `+` and `.` appear escaped in the resulting git call.

**📁 FILES**
- `cli/src/backfill/BackfillEngine.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · [e5c122f] Test coverage added for back-fill progress handler and Settings panel commands</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The continuous integration pipeline was failing on the VS Code workspace's branch coverage threshold. Changes to the Settings panel and the back-fill command had introduced new code paths — error exits, dispose guards, and progress-label formatting variants — that were never exercised by any test.

**💡 Decisions Behind the Code**

- **Test-only fix, no production code changes**: The coverage gap was entirely in newly added production code paths that had zero test coverage. Fixing coverage by removing or simplifying the production code would have degraded the feature; adding targeted tests was the only path that preserved behavior and met the threshold.
- **Mocking dynamic imports at the module level**: The missing-summary count refresh uses a dynamic import at runtime, which standard inline mocks cannot intercept. Hoisting the mock declarations above the module boundary ensured the dynamic import resolved to the controlled mock in all test scenarios, including the dispose-after-start failure path that was the hardest branch to reach.
- **Running coverage report despite local test failures**: Three pre-existing tests fail on Windows due to path handling differences and would have suppressed the coverage report under the default configuration. Running with the report-on-failure flag enabled was necessary to identify which specific lines were still uncovered rather than guessing from partial data.

**✅ What Was Implemented**

- Added a mock for the back-fill engine module and two new tests in `vscode/src/Extension.test.ts` covering the `generateMissingSummaries` command handler: one for the empty-commits early-exit path, and one that drives all three progress-label variants (short subject, long subject truncated with an error tag, and no subject falling back to a short hash).
- Added mocks for the back-fill engine's count function and the repo-name extractor, plus ten new tests in `vscode/src/views/SettingsWebviewPanel.test.ts` covering: the `generateMissingSummaries` message dispatch (success, undefined result, Error rejection, non-Error rejection, dispose-before-resolve, dispose-before-reject), the missing-summary count refresh (success, failure, dispose-before-reject), and the existing rebuild-knowledge-base dispose-before-reject branch that was also uncovered.
- Global branch coverage for the VS Code workspace rose from 96.67% to 97.18%, clearing the required threshold.

**📁 FILES**
- `vscode/src/Extension.test.ts`
- `vscode/src/views/SettingsWebviewPanel.test.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · [e5c122f] Progress notifications show commit subject instead of bare hash during back-fill</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When back-filling summaries, the progress notification displayed a raw commit hash, which gave users no meaningful context about which commit was being processed.

**💡 Decisions Behind the Code**

- **Subject from existing index, not a new git call**: The commit subject was already stored in the target index built at the start of each back-fill run. Pulling it from there avoids any per-commit overhead and keeps the hot path free of extra process spawns.
- **Failure-only tagging**: Marking every successful commit with `(generated)` added noise without value. The incrementing counter already signals forward progress, so only the failure case warrants an explicit label — this mirrors how other long-running VS Code notifications behave in the codebase.

**✅ What Was Implemented**

- Added a `commitSubject` field to `BackfillOutcome` in `BackfillEngine.ts`. The engine populates it from the target index's already-loaded commit metadata, requiring no additional git calls. The VS Code progress handler in `Extension.ts` then displays the subject truncated to 60 characters, falling back to the short hash when unavailable.
- Cleaned up the progress message format: the `(generated)` status tag was removed entirely, and only failures are flagged with `(failed)`.

**📁 FILES**
- `cli/src/backfill/BackfillEngine.ts`
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>12 · [e5c122f] Settings panel &quot;Generate Missing Summaries&quot; section moved to bottom with repository name in count text</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Generate Missing Summaries button was positioned in the middle of the Memory Bank settings tab, and the count text gave no indication of which repository it referred to.

**💡 Decisions Behind the Code**

Placing the section at the bottom with a divider follows the existing visual rhythm of the settings panel (the Cloud Sync section uses the same divider pattern) and avoids interrupting the primary configuration flow. Including the repo name was straightforward once the webview panel already had access to the workspace root — the name is derived from the same path resolver used elsewhere in the panel.

**✅ What Was Implemented**

- In `SettingsHtmlBuilder.ts`, the Generate Missing Summaries block was moved to the very bottom of the Memory Bank tab, below the local folder warning, separated by a horizontal divider. Button description text was rewritten to plain language.
- `SettingsWebviewPanel.ts` now fetches the repository name alongside the missing count and includes it in the `missingSummaryCountLoaded` message. `SettingsScriptBuilder.ts` renders it into the count string: "N of your commits in `<repo>` still need summaries." / "All your commits in `<repo>` already have summaries."

**📁 FILES**
- `vscode/src/views/SettingsHtmlBuilder.ts`
- `vscode/src/views/SettingsScriptBuilder.ts`
- `vscode/src/views/SettingsWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>13 · [e5c122f] Expand back-fill module branch coverage to meet 98% threshold</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After bug fixes and dead-code removal in the back-fill module, branch coverage sat at roughly 93%, below the project's 98% requirement. Several defensive edge-case branches had no test coverage.

**💡 Decisions Behind the Code**

The five branches that remained uncovered after all additions were confirmed structurally unreachable defensive guards (e.g. "collected entries always have a timestamp"). These were left uncovered rather than adding tests that would require artificially bypassing type constraints to reach them.

**✅ What Was Implemented**

Added tests across `CommitAttributor.test.ts`, `RawTranscriptScanner.test.ts`, `CommitTargetIndex.test.ts`, and `BackfillEngine.test.ts` covering: session splitting on branch changes, modal-branch tie-breaking, entries with content but no role, MEDIUM attribution with same-timestamp entries, worktree-list failure fallback, malformed JSON blocks in transcripts, and files in subdirectories. Branch coverage reached 98.31%.

**📁 FILES**
- `cli/src/backfill/CommitAttributor.test.ts`
- `cli/src/backfill/CommitTargetIndex.test.ts`
- `cli/src/backfill/BackfillEngine.test.ts`

</blockquote>
</details>
<details>
<summary><strong>14 · [f73aec3] Add branch-match tier and low-confidence attribution to backfill pipeline</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The existing backfill attribution only recognized two confidence levels (high file-overlap and medium time-window), missing a dedicated tier for branch-based matching and leaving no way to capture planning conversations that happened on the main branch before switching to a feature branch.

**💡 Decisions Behind the Code**

- **Weakest-tier rollup instead of strongest**: When a summary mixes HIGH file-overlap turns with LOW time-window turns, the stored confidence reflects the weakest tier present. Reporting the strongest tier would let the badge claim "reconstructed from file edits" even when most of the conversation was just timing-based, misleading users about how reliable the attribution is.
- **Anchor-modal branch over full-window modal branch**: The effective branch is computed from the modal `gitBranch` of the file-edit anchor turns only, not all in-window turns. A commit's feature-branch work often sits alongside many more main-branch planning turns in the same time window; using the full-window modal would let main chatter out-vote the real feature branch and cause the medium tier to admit the wrong conversations.
- **Unified `low` default across all entry points**: Rather than using different tiers for the manual command, the background worker, and the VS Code enable trigger, a single constant drives all three. The per-summary confidence badge makes the weaker attributions transparent to users, so the higher recall of the low tier is safe and produces summaries closest to what the live pipeline would have generated.

**✅ What Was Implemented**

- `CommitAttributor.ts` was rewritten with a three-phase v6 model: Phase 1 derives an effective worktree and effective branch per commit from file-edit anchors; Phase 2 builds a per-worktree cursor so a long session is sliced into contiguous per-commit blocks; Phase 3 collects turns at HIGH (file-overlap), MEDIUM (branch-match), or LOW (time-window) tiers, rolling up to the weakest tier actually kept so the confidence badge never overclaims. A new `resolveWorktreeKey` function normalizes each entry's `cwd` to its longest-matching worktree root rather than using the transcript directory name.
- `BackfillEngine.ts` gained `gatherCursorCandidates`, which queries every own-commit in the `[minTs − 7d, maxTs]` range so already-summarized or out-of-range neighbors can act as cursor boundaries. The author filter was changed from regex-escaped `--author=<email>` to `--fixed-strings` with both email and name patterns (matching git's BRE semantics and mirroring the live pipeline's identity check). A single exported constant `DEFAULT_BACKFILL_TIER = "low"` now serves as the unified default for every entry point.
- `Types.ts` and `BackfillOutcome` were extended to include `"low"` in `backfillConfidence` and `"branch-match"` in `backfillMethod`; the VS Code badge tooltip gained a dedicated message for branch-match attributions; the VS Code Enable handler now fires the generate-missing-summaries command in the background to mirror the CLI `jolli enable` behavior.

**📋 Future Enhancements**

Per-entry confidence labeling (storing the tier on each individual conversation turn rather than rolling up to the commit level) was explicitly deferred; it requires extending the transcript entry schema and is listed as a follow-up.

**📁 FILES**
- `cli/src/backfill/CommitAttributor.ts`
- `cli/src/backfill/BackfillEngine.ts`
- `cli/src/commands/BackfillCommand.ts`
- `cli/src/Types.ts`
- `vscode/src/Extension.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 2, 2026 at 5:46 PM*
<!-- jollimemory-summary-end -->