### PR TITLE
Add NFF detection and force-push gate for push and PR flows

### DIFF
--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/PushAction.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/PushAction.kt
@@ -2,6 +2,7 @@ package ai.jolli.jollimemory.actions
 
 import ai.jolli.jollimemory.core.SessionTracker
 import ai.jolli.jollimemory.services.JolliMemoryService
+import ai.jolli.jollimemory.util.ForcePushUtil
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
@@ -12,6 +13,8 @@ import com.intellij.openapi.ui.Messages
 
 /**
  * Push current branch to remote with upstream tracking.
+ * On non-fast-forward rejection, offers a force-push confirmation via
+ * [ForcePushUtil.gateForcePush] with divergence inspection.
  * Matches VS Code PushCommand.ts.
  */
 class PushAction : AnAction() {
@@ -39,17 +42,37 @@ class PushAction : AnAction() {
                 }
 
                 indicator.text = "Pushing $branch to origin..."
-                val result = git.exec("push", "-u", "origin", branch, timeoutSeconds = 60)
+                val result = git.execWithResult("push", "-u", "origin", branch, timeoutSeconds = 60)
 
-                ApplicationManager.getApplication().invokeLater {
-                    if (result != null) {
+                if (result.exitCode == 0) {
+                    ApplicationManager.getApplication().invokeLater {
                         Messages.showInfoMessage(project, "Pushed $branch to origin.", "Jolli Memory")
-                    } else {
-                        Messages.showErrorDialog(
-                            project,
-                            "Push may have failed for $branch. Check git output for details.",
-                            "Push Warning"
-                        )
+                        service.refreshStatus()
+                    }
+                    return
+                }
+
+                if (!ForcePushUtil.isNonFastForwardError(result.stderr)) {
+                    ApplicationManager.getApplication().invokeLater {
+                        Messages.showErrorDialog(project, "Push failed for $branch:\n\n${result.stderr}", "Push Failed")
+                        service.refreshStatus()
+                    }
+                    return
+                }
+
+                // NFF rejection — switch to EDT for divergence gate + dialog
+                ApplicationManager.getApplication().invokeAndWait {
+                    val outcome = ForcePushUtil.gateForcePush(
+                        project, git, branch,
+                        reason = "Remote branch has diverged. Force push will overwrite remote history.",
+                    )
+                    if (outcome == ForcePushUtil.ForcePushOutcome.CONFIRMED) {
+                        val forceResult = ForcePushUtil.forcePushBranch(git, branch)
+                        if (forceResult.exitCode == 0) {
+                            Messages.showInfoMessage(project, "Force-pushed $branch to origin.", "Jolli Memory")
+                        } else {
+                            Messages.showErrorDialog(project, "Force push failed:\n\n${forceResult.stderr}", "Push Failed")
+                        }
                     }
                     service.refreshStatus()
                 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitOps.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitOps.kt
@@ -68,10 +68,15 @@ class GitOps(private val projectDir: String) {
         return basePath
     }
 
+    /** Full result of a git invocation — exit code plus captured stdout and stderr. */
+    data class ExecResult(val exitCode: Int, val stdout: String, val stderr: String)
+
     /**
-     * Runs a git command and returns stdout, or null on failure.
+     * Runs a git command and returns the full [ExecResult] (exit code, stdout, stderr).
+     * Callers that need to classify failures (e.g. non-fast-forward detection) use this
+     * instead of [exec] which discards stderr on failure.
      */
-    fun exec(vararg args: String, timeoutSeconds: Long = 15, trim: Boolean = true): String? {
+    fun execWithResult(vararg args: String, timeoutSeconds: Long = 15, trim: Boolean = true): ExecResult {
         return try {
             val cmdArgs = mutableListOf("git")
             cmdArgs.addAll(args)
@@ -79,37 +84,47 @@ class GitOps(private val projectDir: String) {
             val pb = ProcessBuilder(cmdArgs)
                 .directory(File(projectDir))
                 .redirectErrorStream(false)
-            // Inject the user's full PATH so git hooks can find node (nvm/homebrew)
             pb.environment()["PATH"] = shellPath
             val process = pb.start()
 
-            // Read stdout on a separate thread to avoid pipe buffer deadlock.
-            // If stdout exceeds the OS pipe buffer (~64 KB) and we wait for the
-            // process to finish before reading, the process blocks on write and
-            // we block on waitFor → deadlock → timeout.
+            // Read stdout and stderr concurrently to avoid pipe buffer deadlock.
             val stdoutFuture = java.util.concurrent.CompletableFuture.supplyAsync {
                 process.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+            }
+            val stderrFuture = java.util.concurrent.CompletableFuture.supplyAsync {
+                process.errorStream.bufferedReader(Charsets.UTF_8).use { it.readText().trim() }
             }
 
             val completed = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
             if (!completed) {
                 process.destroyForcibly()
                 stdoutFuture.cancel(true)
+                stderrFuture.cancel(true)
                 log.warn("Git command timed out: %s (cwd=%s)", args.toList(), projectDir)
-                return null
+                return ExecResult(-1, "", "Timed out after ${timeoutSeconds}s")
             }
 
-            if (process.exitValue() != 0) {
-                val stderr = process.errorStream.bufferedReader(Charsets.UTF_8).use { it.readText().trim() }
-                log.warn("Git command exit=%d: %s stderr=%s (cwd=%s)", process.exitValue(), args.toList(), stderr.take(200), projectDir)
-                return null
+            val exitCode = process.exitValue()
+            val stdout = stdoutFuture.get(5, TimeUnit.SECONDS)
+            val stderr = stderrFuture.get(5, TimeUnit.SECONDS)
+            if (exitCode != 0) {
+                log.warn("Git command exit=%d: %s stderr=%s (cwd=%s)", exitCode, args.toList(), stderr.take(200), projectDir)
             }
-            val output = stdoutFuture.get(5, TimeUnit.SECONDS)
-            if (trim) output?.trim() else output?.trimEnd()
+            val out = if (trim) stdout.trim() else stdout.trimEnd()
+            ExecResult(exitCode, out, stderr)
         } catch (e: Exception) {
             log.warn("Git command exception: %s: %s (cwd=%s)", args.toList(), e.message, projectDir)
-            null
+            ExecResult(-1, "", e.message ?: e.toString())
         }
+    }
+
+    /**
+     * Runs a git command and returns stdout, or null on failure.
+     * Delegates to [execWithResult] — use that directly when stderr is needed.
+     */
+    fun exec(vararg args: String, timeoutSeconds: Long = 15, trim: Boolean = true): String? {
+        val result = execWithResult(*args, timeoutSeconds = timeoutSeconds, trim = trim)
+        return if (result.exitCode == 0) result.stdout else null
     }
 
     /** Check if a branch exists. */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/PrService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/PrService.kt
@@ -322,12 +322,18 @@ object PrService {
         }
     }
 
-    /** Pushes the current branch to origin (sets upstream tracking). */
-    fun pushBranch(cwd: String) {
-        val result = execGit(listOf("push", "-u", "origin", "HEAD"), cwd)
-        if (result == null) {
-            log.warn("Push may have failed, but stderr output is common for push")
+    /** Result of a push attempt — exit code plus stderr for failure classification. */
+    data class PushResult(val exitCode: Int, val stderr: String) {
+        val success: Boolean get() = exitCode == 0
+    }
+
+    /** Pushes the current branch to origin (sets upstream tracking). Returns the result for NFF classification. */
+    fun pushBranch(cwd: String): PushResult {
+        val result = execCommandResult("git", listOf("push", "-u", "origin", "HEAD"), cwd, timeoutSeconds = 60)
+        if (result.exitCode != 0) {
+            log.warn("Push may have failed: stderr='%s'", result.stderr)
         }
+        return PushResult(result.exitCode, result.stderr)
     }
 
     /**

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
@@ -13,6 +13,7 @@ import ai.jolli.jollimemory.core.SummaryStore
 import ai.jolli.jollimemory.core.SummaryTree
 import ai.jolli.jollimemory.core.TopicUpdates
 import ai.jolli.jollimemory.core.TraceContext
+import ai.jolli.jollimemory.util.ForcePushUtil
 import ai.jolli.jollimemory.core.TranscriptEntry
 import ai.jolli.jollimemory.core.references.SourceId
 import ai.jolli.jollimemory.services.JolliApiClient
@@ -928,9 +929,49 @@ class SummaryPanel(
         postToWebview("prCreating")
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
-                PrService.pushBranch(cwd)
+                val git = GitOps(cwd)
+                val branch = currentSummary.branch
+
+                // Push — detect NFF and offer force-push retry
+                val pushResult = PrService.pushBranch(cwd)
+                if (!pushResult.success) {
+                    if (git != null && ForcePushUtil.isNonFastForwardError(pushResult.stderr)) {
+                        // Switch to EDT for the divergence gate dialog
+                        var outcome = ForcePushUtil.ForcePushOutcome.DECLINED
+                        ApplicationManager.getApplication().invokeAndWait {
+                            outcome = ForcePushUtil.gateForcePush(
+                                project, git, branch,
+                                reason = "The remote has changes your branch does not include.",
+                            )
+                        }
+                        when (outcome) {
+                            ForcePushUtil.ForcePushOutcome.CONFIRMED -> {
+                                val forceResult = ForcePushUtil.forcePushBranch(git, branch)
+                                if (forceResult.exitCode != 0) {
+                                    ApplicationManager.getApplication().invokeLater {
+                                        postToWebview("prCreateError", mapOf("message" to "Force push failed: ${forceResult.stderr}"))
+                                    }
+                                    return@executeOnPooledThread
+                                }
+                            }
+                            else -> {
+                                ApplicationManager.getApplication().invokeLater {
+                                    postToWebview("prCreateError", mapOf("message" to "Push cancelled."))
+                                }
+                                return@executeOnPooledThread
+                            }
+                        }
+                    } else {
+                        // Non-NFF push error — surface it
+                        ApplicationManager.getApplication().invokeLater {
+                            postToWebview("prCreateError", mapOf("message" to "Push failed: ${pushResult.stderr}"))
+                        }
+                        return@executeOnPooledThread
+                    }
+                }
+
                 // Check if PR already exists for this branch — update instead of create
-                val lookup = PrService.findPrForBranch(cwd, currentSummary.branch)
+                val lookup = PrService.findPrForBranch(cwd, branch)
                 val prUrl: String
                 if (lookup is PrService.PrLookup.Found) {
                     PrService.updatePr(lookup.pr.number, title, body, cwd)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/util/ForcePushUtil.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/util/ForcePushUtil.kt
@@ -1,0 +1,137 @@
+package ai.jolli.jollimemory.util
+
+import ai.jolli.jollimemory.bridge.GitOps
+import ai.jolli.jollimemory.core.JmLogger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+
+/**
+ * Shared force-push utilities — Kotlin port of ForcePushPrompt.ts + ForcePushSafety.ts.
+ *
+ * Single source of truth for NFF detection, divergence inspection, and the
+ * force-push confirmation dialog. Used by PushAction and SummaryPanel's
+ * Create PR flow. The squash pre-warning in SquashAction is intentionally NOT
+ * routed here (different decision, different wording).
+ */
+object ForcePushUtil {
+
+	private val log = JmLogger.create("ForcePushUtil")
+
+	/** Result of the post-rejection force-push gate. */
+	enum class ForcePushOutcome { CONFIRMED, DECLINED, BLOCKED }
+
+	/** How the local branch and its remote-tracking ref diverge. */
+	data class ForcePushSafety(
+		val branch: String,
+		/** Commits on origin/<branch> missing from local HEAD — lost by force-push. */
+		val remoteOnly: Int,
+		/** Commits on local HEAD missing from origin/<branch>. */
+		val localOnly: Int,
+		/** True when remote is strictly ahead and local has no unique commits. */
+		val behindOnly: Boolean,
+	)
+
+	/**
+	 * Recognizes git's non-fast-forward push rejection from stderr.
+	 * Matches the same four patterns as ForcePushPrompt.ts:isNonFastForwardError.
+	 */
+	fun isNonFastForwardError(stderr: String): Boolean {
+		val lower = stderr.lowercase()
+		return lower.contains("non-fast-forward") ||
+			lower.contains("fetch first") ||
+			lower.contains("[rejected]") ||
+			lower.contains("tip of your current branch is behind")
+	}
+
+	/**
+	 * Inspects divergence between local branch and its remote-tracking ref.
+	 * Fetches the remote first so counts reflect the true state.
+	 * Returns null when comparison can't be made (detached HEAD, network error).
+	 * Mirrors ForcePushSafety.ts:inspectForcePushSafety.
+	 */
+	fun inspectForcePushSafety(git: GitOps, branch: String): ForcePushSafety? {
+		if (branch.isBlank() || branch == "HEAD") return null
+		val remoteRef = "origin/$branch"
+		return try {
+			git.exec("fetch", "origin", branch, timeoutSeconds = 30) ?: return null
+			val remoteOnly = git.exec("rev-list", "--count", "HEAD..$remoteRef")?.trim()?.toIntOrNull() ?: return null
+			val localOnly = git.exec("rev-list", "--count", "$remoteRef..HEAD")?.trim()?.toIntOrNull() ?: return null
+			ForcePushSafety(
+				branch = branch,
+				remoteOnly = remoteOnly,
+				localOnly = localOnly,
+				behindOnly = remoteOnly > 0 && localOnly == 0,
+			)
+		} catch (e: Exception) {
+			log.warn("inspectForcePushSafety failed: %s", e.message)
+			null
+		}
+	}
+
+	/**
+	 * Post-rejection gate. Inspects divergence, then either:
+	 * - blocks when the branch is merely behind (force-push never offered),
+	 * - shows the shared force-push confirmation with lost-commit count.
+	 *
+	 * When divergence can't be measured, falls back to plain confirm so a
+	 * legitimate rewrite is never blocked by a transient failure.
+	 *
+	 * MUST be called from the EDT (shows dialogs).
+	 */
+	fun gateForcePush(
+		project: Project,
+		git: GitOps,
+		branch: String,
+		reason: String = "Remote branch has diverged. Force push will overwrite remote history.",
+	): ForcePushOutcome {
+		val safety = inspectForcePushSafety(git, branch)
+
+		if (safety?.behindOnly == true) {
+			val commits = if (safety.remoteOnly == 1) "commit" else "commits"
+			val message = buildString {
+				appendLine("Remote branch \"$branch\" has ${safety.remoteOnly} $commits you don't have locally,")
+				appendLine("and your branch has no commits the remote is missing.")
+				appendLine()
+				appendLine("This is not a history rewrite — your branch is simply behind. Pull or")
+				appendLine("rebase to integrate the remote commits, then push again. Force-pushing")
+				append("here would permanently delete those ${safety.remoteOnly} remote $commits.")
+			}
+			Messages.showWarningDialog(project, message, "Cannot Force Push")
+			return ForcePushOutcome.BLOCKED
+		}
+
+		val lostLine = if (safety != null && safety.remoteOnly > 0) {
+			val commits = if (safety.remoteOnly == 1) "commit" else "commits"
+			"\nWarning: this will permanently delete ${safety.remoteOnly} $commits that exist only on the remote."
+		} else {
+			""
+		}
+
+		val message = buildString {
+			appendLine("This operation may rewrite remote history.")
+			appendLine()
+			append(reason)
+			if (lostLine.isNotEmpty()) append(lostLine)
+			appendLine()
+			append("This may affect collaborators on the same branch.")
+		}
+
+		val result = Messages.showYesNoDialog(
+			project,
+			message,
+			"Force Push Required",
+			"Force Push (--force-with-lease)",
+			"Cancel",
+			Messages.getWarningIcon(),
+		)
+		return if (result == Messages.YES) ForcePushOutcome.CONFIRMED else ForcePushOutcome.DECLINED
+	}
+
+	/**
+	 * Runs `git push --force-with-lease origin <branch>`.
+	 * Returns the ExecResult so callers can check success and surface errors.
+	 */
+	fun forcePushBranch(git: GitOps, branch: String): GitOps.ExecResult {
+		return git.execWithResult("push", "--force-with-lease", "origin", branch, timeoutSeconds = 60)
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/util/ForcePushUtilTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/util/ForcePushUtilTest.kt
@@ -1,0 +1,42 @@
+package ai.jolli.jollimemory.util
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class ForcePushUtilTest {
+
+	@Test
+	fun `detects non-fast-forward error`() {
+		ForcePushUtil.isNonFastForwardError("! [rejected] main -> main (non-fast-forward)") shouldBe true
+	}
+
+	@Test
+	fun `detects fetch first hint`() {
+		ForcePushUtil.isNonFastForwardError("hint: Updates were rejected because the tip of your current branch is behind\nhint: its remote counterpart. If you want to integrate the remote changes,\nhint: use 'git pull' before pushing again.\nhint: See the 'Note about fast-forwards' in 'git push --help' for details.") shouldBe true
+	}
+
+	@Test
+	fun `detects rejected bracket marker`() {
+		ForcePushUtil.isNonFastForwardError("To github.com:user/repo.git\n ! [rejected]        feature -> feature (fetch first)") shouldBe true
+	}
+
+	@Test
+	fun `detects tip behind message`() {
+		ForcePushUtil.isNonFastForwardError("error: failed to push some refs to 'origin'\nhint: tip of your current branch is behind") shouldBe true
+	}
+
+	@Test
+	fun `returns false for auth error`() {
+		ForcePushUtil.isNonFastForwardError("remote: Permission to user/repo.git denied to user.\nfatal: unable to access 'https://github.com/user/repo.git/': The requested URL returned error: 403") shouldBe false
+	}
+
+	@Test
+	fun `returns false for empty string`() {
+		ForcePushUtil.isNonFastForwardError("") shouldBe false
+	}
+
+	@Test
+	fun `detection is case insensitive`() {
+		ForcePushUtil.isNonFastForwardError("NON-FAST-FORWARD") shouldBe true
+	}
+}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Before this commit, the IntelliJ plugin had no meaningful response when a push was rejected because the remote branch had diverged. Clicking Push would produce a vague warning and stop, while triggering Create PR would silently ignore the push failure and attempt to open a pull request against whatever code was already on the remote. Users had no path forward from the plugin UI and were forced to resolve the situation manually in a terminal.

This commit introduced a shared force-push utility that all push entry points now route through. When a rejection is detected, the plugin first fetches the remote and inspects how the branches have actually diverged. If the local branch is simply behind with no unique commits of its own, force-pushing is blocked entirely and the user is told to pull instead — preventing accidental deletion of remote history. If the branches have genuinely diverged, the user sees a confirmation dialog that shows exactly how many remote commits would be lost, and can choose to proceed with a lease-protected force-push or cancel. Both the Push action and the Create PR flow now handle this correctly, and the Create PR flow will only proceed to open the pull request after confirming the push actually succeeded.

---

## E2E Test (5)
<details>
<summary><strong>1. Push rejected with force-push offer when remote has diverged</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a local branch where the remote version has been updated by someone else (so your local branch is behind and has its own commits too — a true diverged state). The branch should be open in the IntelliJ plugin.

**Steps:**
1. Open the JolliMemory plugin panel in IntelliJ.
2. Click the "Push" button for your current branch.
3. Wait for the push to be attempted.
4. Check that a dialog appears warning you that the remote branch has diverged and telling you how many remote commits would be lost.
5. Click "Force Push (--force-with-lease)" to confirm.
6. Check the result message that appears after the push completes.

**Expected Results:**
- A warning dialog should appear explaining that the remote has diverged, not a vague generic error.
- The dialog should show the number of commits on the remote that would be permanently deleted.
- After clicking the force push button, a success message should appear saying the branch was force-pushed to origin.
- The plugin status should refresh automatically.

</blockquote>
</details>
<details>
<summary><strong>2. Push blocked when local branch is simply behind remote (no local-only commits)</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a local branch that is strictly behind its remote counterpart — meaning the remote has new commits but your local branch has no unique commits of its own.

**Steps:**
1. Open the JolliMemory plugin panel in IntelliJ.
2. Click the "Push" button for the branch that is behind the remote.
3. Wait for the push to be attempted.
4. Check the dialog that appears.

**Expected Results:**
- A warning dialog should appear explaining that the remote has commits you do not have locally, and that your branch has no commits the remote is missing.
- The dialog should advise you to pull or rebase before pushing again.
- No "Force Push" option should be offered — the dialog should only allow you to dismiss it.
- The push should not proceed.

</blockquote>
</details>
<details>
<summary><strong>3. Push failure for non-divergence reasons shows a clear error message</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a branch set up where the push will fail for a reason other than divergence — for example, no network access or insufficient permissions on the remote repository.

**Steps:**
1. Open the JolliMemory plugin panel in IntelliJ.
2. Click the "Push" button for your current branch.
3. Wait for the push to be attempted.
4. Check the message that appears.

**Expected Results:**
- An error dialog should appear with a clear description of why the push failed (such as a permission or network error message).
- The dialog should NOT offer a force-push option.
- The plugin status should refresh automatically after the error is shown.

</blockquote>
</details>
<details>
<summary><strong>4. Create PR flow offers force-push when remote has diverged</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a local branch in a diverged state (both local and remote have unique commits). Open the JolliMemory summary panel and have a PR title and description ready to submit.

**Steps:**
1. Open the JolliMemory summary panel in IntelliJ.
2. Fill in the PR title and description, then click "Create PR".
3. Wait for the push step to run and a dialog to appear.
4. Check that the dialog explains the remote has changes your branch does not include.
5. Click "Force Push (--force-with-lease)" to confirm.
6. Check that PR creation continues and completes after the force push succeeds.

**Expected Results:**
- A warning dialog should appear during the Create PR flow explaining the divergence, before any PR is created.
- After confirming the force push, the flow should continue and the PR should be created or updated successfully.
- If you click "Cancel" instead, a message should appear saying the push was cancelled and no PR should be created.

</blockquote>
</details>
<details>
<summary><strong>5. Cancelling the force-push dialog during Create PR stops the flow cleanly</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a local branch in a diverged state. Open the JolliMemory summary panel with a PR title and description ready.

**Steps:**
1. Open the JolliMemory summary panel in IntelliJ.
2. Fill in the PR title and description, then click "Create PR".
3. When the force-push warning dialog appears, click "Cancel".
4. Check the message shown in the panel.

**Expected Results:**
- The panel should display a message saying the push was cancelled.
- No pull request should be created or updated.
- The plugin should remain in a stable state with no crash or frozen spinner.

</blockquote>
</details>

---

## Topics (2)
<details>
<summary><strong>01 · NFF detection and force-push gate added to push and Create PR flows</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a push was rejected because the remote had diverged, the IntelliJ plugin either showed a vague warning and gave up, or silently ignored the failure and tried to create a pull request against stale code. Users had no way to resolve the situation from the plugin and had to fall back to the terminal.

**💡 Decisions Behind the Code**

- **Divergence gate before dialog**: Rather than immediately offering force-push on any NFF rejection, the implementation first fetches the remote and inspects commit counts. If the local branch is purely behind (no unique local commits), force-push is blocked entirely with a pull-instead message — matching `ForcePushSafety.ts` behavior and preventing accidental history deletion.
- **`execWithResult()` alongside `exec()`**: Adding a second entry point that returns exit code and stderr, while keeping `exec()` as a thin wrapper returning `String?`, avoided touching every existing call site across the plugin while eliminating the duplicated process-execution logic.
- **Squash flow left untouched**: `SquashAction`'s existing `ForcePushWarningDialog` was intentionally not routed through the new util — it has different wording and a different decision context, matching the explicit exclusion in the VSCode source PR.

**✅ What Was Implemented**

- Created `ForcePushUtil.kt` — shared object with `isNonFastForwardError()` (four-pattern regex matching VSCode parity), `inspectForcePushSafety()` (fetches remote and counts diverged commits), `gateForcePush()` (EDT-safe dialog that blocks pure behind-only cases and shows lost-commit count for true divergence), and `forcePushBranch()` (runs `git push --force-with-lease`).
- Refactored `PushAction.kt` to call `execWithResult()`, classify NFF vs. other failures, and route through `ForcePushUtil.gateForcePush()` with an EDT hop before retrying.
- Updated `SummaryPanel.handleCreatePr()` and `PrService.pushBranch()` to surface push stderr, detect NFF, prompt via `ForcePushUtil`, and only continue to PR creation after a successful push.

**📋 Future Enhancements**

- `SummaryPanel` constructs `GitOps` directly with a null-check guard (`if (git != null)`) because no shared accessor exists — a follow-up should expose a project-scoped `GitOps` accessor so callers don't instantiate it inline.
- Integration tests for the `PushAction` and `SummaryPanel` NFF paths (mock git returning NFF stderr → confirm → force-push) were called out in the plan but not yet written; only `ForcePushUtilTest` unit tests were added.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/util/ForcePushUtil.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitOps.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/actions/PushAction.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/PrService.kt`
- `intellij/src/test/kotlin/ai/jolli/jollimemory/util/ForcePushUtilTest.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Unit tests added for NFF error pattern detection</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The new NFF detection logic needed test coverage to verify all four rejection patterns were correctly recognized and that unrelated errors like auth failures were not misclassified.

**💡 Decisions Behind the Code**

Tests were scoped to the pure pattern-matching function only, since the dialog and git-execution paths require IntelliJ platform test infrastructure (EDT, `ApplicationRule`) that was not set up in this session.

**✅ What Was Implemented**

Added `ForcePushUtilTest.kt` with seven cases: the four NFF patterns (non-fast-forward, fetch first, rejected bracket, tip-behind), an auth error negative case, an empty string negative case, and a case-insensitivity check.

**📁 FILES**
- `intellij/src/test/kotlin/ai/jolli/jollimemory/util/ForcePushUtilTest.kt`

</blockquote>
</details>

---

*Generated by JolliMemory · June 30, 2026 at 3:04 PM · via Anthropic*
<!-- jollimemory-summary-end -->