### PR TITLE
IntelliJ: dedicated Create PR view + Working Memory review token meter & inline edit

### DIFF
--- a/cli/src/Api.test.ts
+++ b/cli/src/Api.test.ts
@@ -269,6 +269,19 @@ vi.mock("./core/TopicWikiRenderer.js", () => ({
 	renderTopicKBWiki: vi.fn(async () => {}),
 }));
 
+// `compile` also runs buildKnowledgeGraph (LLM-bearing) and SearchIndex.rebuild
+// after the ingest. Both are non-fatal/best-effort in the command, but left un-
+// mocked they attempt real work: buildKnowledgeGraph opens an LLM connection that
+// fails fast in CI but can HANG until the 45s test timeout in a sandbox with no
+// network. Mock them so the compile tests are deterministic and network-free.
+vi.mock("./graph/GraphBuilder.js", () => ({
+	buildKnowledgeGraph: vi.fn(async () => {}),
+}));
+
+vi.mock("./core/SearchIndex.js", () => ({
+	SearchIndex: { rebuild: vi.fn(async () => {}) },
+}));
+
 vi.mock("./core/ProcessedSourceStore.js", () => ({
 	saveProcessedSet: vi.fn(async () => {}),
 	emptyProcessedSet: vi.fn(() => ({ schemaVersion: 1, processed: {} })),

--- a/intellij/CHANGELOG.md
+++ b/intellij/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.99.4
 
+### New Features
+
+- **Redesigned Create PR view** — the **Create pull request (PR)** button now opens a dedicated, branch-level Create PR tab that matches the new design: a branch → main header with diff stats, the drafted title and a rendered-markdown body, the memories included in the PR, the E2E test guide, and the changed files. When you're signed in to Jolli, creating the PR **also shares the included memories to Jolli in the same action** (a sign-in hint appears when you're signed out; the PR is still a normal git PR either way)
+
 ### Changes
 
 - **Selection is now a one-time discard** — unchecking a conversation, plan, note, or reference in CONTEXT now removes it from the working area when you commit, instead of keeping it around to re-check later. Unchecked conversations are consumed (they leave the list) but their content is dropped from the summary; unchecked plans/notes/references have their working-area entries removed without being saved into committed memory. Your own `~/.claude/plans` files and external note sources are never deleted

--- a/intellij/CHANGELOG.md
+++ b/intellij/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 - **Redesigned Create PR view** — the **Create pull request (PR)** button now opens a dedicated, branch-level Create PR tab that matches the new design: a branch → main header with diff stats, the drafted title and a rendered-markdown body, the memories included in the PR, the E2E test guide, and the changed files. When you're signed in to Jolli, creating the PR **also shares the included memories to Jolli in the same action** (a sign-in hint appears when you're signed out; the PR is still a normal git PR either way)
+- **Working Memory review — token meter + inline edit** — the review now shows a token-usage meter (input / output / cached breakdown, aggregated from the included conversations, with a graceful "recorded at commit" state when a source doesn't report usage), and each conversation / context row has an inline **✕ leave out** / **+ add back** toggle so you can shape exactly what the next memory captures without leaving the review
 
 ### Changes
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliShareService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliShareService.kt
@@ -1,0 +1,151 @@
+package ai.jolli.jollimemory.services
+
+import ai.jolli.jollimemory.bridge.GitRemoteUtils
+import ai.jolli.jollimemory.core.CommitSummary
+import ai.jolli.jollimemory.core.JmLogger
+import ai.jolli.jollimemory.core.SummaryStore
+import ai.jolli.jollimemory.core.telemetry.Telemetry
+import ai.jolli.jollimemory.toolwindow.views.SummaryMarkdownBuilder
+import ai.jolli.jollimemory.toolwindow.views.SummaryUtils
+
+/**
+ * JolliShareService — the reusable core of the "Share in Jolli" push.
+ *
+ * Extracted verbatim from `SummaryPanel.handlePushToJolli` so the same push
+ * logic backs both the single-memory Share button AND the Create-PR view's
+ * one-click "create the PR and share the included memories" flow.
+ *
+ * [shareSummary] runs SYNCHRONOUSLY — call it from a pooled thread. It pushes a
+ * summary's plans, then the summary itself, stores the updated summary back
+ * (with `jolliDocUrl`/`jolliDocId`), and best-effort deletes orphaned docs. It
+ * does NOT touch the UI: typed failures (`BindingRequiredError`,
+ * `PluginOutdatedError`, `UnauthorizedError`) propagate to the caller, which
+ * owns the binding dialog / re-auth / toast decisions.
+ */
+object JolliShareService {
+
+    private val log = JmLogger.create("JolliShareService")
+
+    /** Outcome of a successful [shareSummary] call. */
+    data class ShareResult(
+        val updatedSummary: CommitSummary,
+        val created: Boolean,
+        val planCount: Int,
+    )
+
+    private data class PlanPushResult(val slug: String, val url: String, val docId: Int)
+
+    /**
+     * Pushes [summary] (and its plans) to the Jolli site, persists the updated
+     * summary, and cleans up orphaned docs. Returns the stored summary.
+     *
+     * @param resolvedBaseUrl the Jolli site base URL already resolved from the API key.
+     * @throws JolliApiClient.BindingRequiredError when the repo has no space binding yet.
+     * @throws JolliApiClient.PluginOutdatedError / UnauthorizedError on server rejection.
+     */
+    fun shareSummary(
+        store: SummaryStore,
+        summary: CommitSummary,
+        cwd: String,
+        apiKey: String,
+        resolvedBaseUrl: String,
+    ): ShareResult {
+        val baseUrl = resolvedBaseUrl.trimEnd('/')
+        val repoUrl = GitRemoteUtils.getCanonicalRepoUrl(cwd)
+        val relativePath = GitRemoteUtils.sanitizeBranchSlug(summary.branch)
+
+        val planUrls = mutableListOf<PlanPushResult>()
+        for (plan in summary.plans ?: emptyList()) {
+            val planContent = store.readPlanFromBranch(plan.slug) ?: continue
+            if (planContent.isBlank()) continue
+            val planResult = JolliApiClient.pushToJolli(
+                resolvedBaseUrl, apiKey,
+                JolliApiClient.JolliPushPayload(
+                    title = SummaryUtils.buildPlanPushTitle(summary, plan.title),
+                    content = planContent,
+                    commitHash = summary.commitHash,
+                    docType = "plan",
+                    branch = summary.branch,
+                    docId = plan.jolliPlanDocId,
+                    repoUrl = repoUrl,
+                    relativePath = relativePath,
+                ),
+            )
+            planUrls.add(PlanPushResult(plan.slug, "$baseUrl/articles?doc=${planResult.docId}", planResult.docId))
+        }
+
+        // Fold pushed plan URLs back into the summary so the pushed markdown links
+        // to the freshly-created plan docs (mirrors the original inline logic).
+        var plansWithUrls = summary.plans
+        if (planUrls.isNotEmpty() && plansWithUrls != null) {
+            val urlMap = planUrls.associateBy { it.slug }
+            plansWithUrls = plansWithUrls.map { p ->
+                val pushed = urlMap[p.slug]
+                if (pushed != null) p.copy(jolliPlanDocUrl = pushed.url, jolliPlanDocId = pushed.docId) else p
+            }
+        }
+
+        val summaryForMarkdown = if (plansWithUrls !== summary.plans) summary.copy(plans = plansWithUrls) else summary
+        val markdown = SummaryMarkdownBuilder.buildMarkdown(summaryForMarkdown)
+
+        val result = JolliApiClient.pushToJolli(
+            resolvedBaseUrl, apiKey,
+            JolliApiClient.JolliPushPayload(
+                title = SummaryUtils.buildPushTitle(summary),
+                content = markdown,
+                commitHash = summary.commitHash,
+                docType = "summary",
+                branch = summary.branch,
+                docId = summary.jolliDocId,
+                repoUrl = repoUrl,
+                relativePath = relativePath,
+            ),
+        )
+
+        val fullUrl = "$baseUrl/articles?doc=${result.docId}"
+        val updatedSummary = summary.copy(jolliDocUrl = fullUrl, jolliDocId = result.docId, plans = plansWithUrls)
+        store.storeSummary(updatedSummary, force = true)
+
+        val cleanedSummary = cleanupOrphanedDocs(store, summary, updatedSummary, baseUrl, apiKey) ?: updatedSummary
+
+        Telemetry.track(
+            "memory_pushed",
+            mapOf(
+                "kind" to "summary",
+                "created" to result.created,
+                "plans_bucket" to Telemetry.bucket(planUrls.size),
+            ),
+        )
+
+        return ShareResult(cleanedSummary, result.created, planUrls.size)
+    }
+
+    /**
+     * Best-effort deletes docs left orphaned by a prior push (e.g. a plan that was
+     * removed), then persists the summary with the survivors. Returns the cleaned
+     * summary, or null when there was nothing to clean.
+     */
+    private fun cleanupOrphanedDocs(
+        store: SummaryStore,
+        originalSummary: CommitSummary,
+        updatedSummary: CommitSummary,
+        baseUrl: String,
+        apiKey: String,
+    ): CommitSummary? {
+        val orphanedIds = originalSummary.orphanedDocIds ?: return null
+        if (orphanedIds.isEmpty()) return null
+        val deleted = mutableSetOf<Int>()
+        for (id in orphanedIds) {
+            try {
+                JolliApiClient.deleteFromJolli(baseUrl, apiKey, id)
+                deleted.add(id)
+            } catch (e: Exception) {
+                log.warn("Failed to delete orphaned doc %d: %s", id, e.message ?: e.toString())
+            }
+        }
+        val remaining = orphanedIds.filter { it !in deleted }
+        val cleaned = updatedSummary.copy(orphanedDocIds = remaining.takeIf { it.isNotEmpty() })
+        store.storeSummary(cleaned, force = true)
+        return cleaned
+    }
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActionBarPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActionBarPanel.kt
@@ -152,18 +152,21 @@ class ActionBarPanel(
 	// ── Create PR ─────────────────────────────────────────────────────────────
 
 	/**
-	 * Opens the branch's most recent committed memory in its detail webview, where
-	 * the Create PR flow lives — identical to the memory row's "⋯ → Create PR".
+	 * Opens the dedicated branch-level Create PR webview (the mockup design). It
+	 * aggregates the branch's committed memories and, when signed in, also shares
+	 * them to Jolli on submit. Shows the "commit first" hint when there are none.
 	 */
 	private fun handleCreatePr() {
-		val opened = service.panelRegistry?.commitsPanel?.openMostRecentMemory() ?: false
-		if (!opened) {
+		val panel = service.panelRegistry?.commitsPanel
+		if (panel == null) {
 			Messages.showInfoMessage(
 				project,
-				"No committed memory on this branch yet. Commit first, then create a PR from the memory view.",
+				"Create PR is unavailable right now — open the Jolli Memory tool window and try again.",
 				"Create PR",
 			)
+			return
 		}
+		panel.openCreatePrView()
 	}
 
 	private fun handleShare() {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
@@ -1540,6 +1540,29 @@ class CommitsPanel(
         return true
     }
 
+    /**
+     * Opens the dedicated branch-level Create PR webview (matches the design mockup).
+     * Builds the view model off the EDT (git/gh), then opens the editor tab — or shows
+     * the "commit first" hint when the branch has no committed memories.
+     */
+    fun openCreatePrView() {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val vm = ai.jolli.jollimemory.toolwindow.views.CreatePrData.build(project)
+            SwingUtilities.invokeLater {
+                if (vm == null) {
+                    com.intellij.openapi.ui.Messages.showInfoMessage(
+                        project,
+                        "No committed memory on this branch yet. Commit first, then create a PR.",
+                        "Create PR",
+                    )
+                } else {
+                    com.intellij.openapi.fileEditor.FileEditorManager.getInstance(project)
+                        .openFile(CreatePrVirtualFile(vm), true)
+                }
+            }
+        }
+    }
+
     private fun viewSummary(commitHash: String) {
         ApplicationManager.getApplication().executeOnPooledThread {
             val summary = service.getSummary(commitHash)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrEditorProvider.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrEditorProvider.kt
@@ -1,0 +1,21 @@
+package ai.jolli.jollimemory.toolwindow
+
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.fileEditor.FileEditorPolicy
+import com.intellij.openapi.fileEditor.FileEditorProvider
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+
+/** Provides the custom editor for [CreatePrVirtualFile] instances. */
+class CreatePrEditorProvider : FileEditorProvider, DumbAware {
+
+    override fun accept(project: Project, file: VirtualFile): Boolean = file is CreatePrVirtualFile
+
+    override fun createEditor(project: Project, file: VirtualFile): FileEditor =
+        CreatePrFileEditor(project, file as CreatePrVirtualFile)
+
+    override fun getEditorTypeId(): String = "jollimemory-create-pr"
+
+    override fun getPolicy(): FileEditorPolicy = FileEditorPolicy.HIDE_DEFAULT_EDITOR
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrFileEditor.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrFileEditor.kt
@@ -1,0 +1,28 @@
+package ai.jolli.jollimemory.toolwindow
+
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.fileEditor.FileEditorState
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.UserDataHolderBase
+import java.beans.PropertyChangeListener
+import javax.swing.JComponent
+
+/** FileEditor that embeds a [CreatePrPanel] as an editor tab. */
+class CreatePrFileEditor(
+    project: Project,
+    private val file: CreatePrVirtualFile,
+) : UserDataHolderBase(), FileEditor {
+
+    private val panel = CreatePrPanel(project, file.vm)
+
+    override fun getComponent(): JComponent = panel
+    override fun getPreferredFocusedComponent(): JComponent = panel
+    override fun getName(): String = "Create PR"
+    override fun setState(state: FileEditorState) {}
+    override fun isModified(): Boolean = false
+    override fun isValid(): Boolean = true
+    override fun addPropertyChangeListener(listener: PropertyChangeListener) {}
+    override fun removePropertyChangeListener(listener: PropertyChangeListener) {}
+    override fun getFile() = file
+    override fun dispose() { panel.dispose() }
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrPanel.kt
@@ -157,6 +157,7 @@ class CreatePrPanel(
     private fun handleCopyBody() {
         val body = PrService.wrapWithMarkers(vm.bodyMarkdown)
         Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(body), null)
+        postToWebview("bodyCopied", mapOf("text" to "Copied PR body markdown to clipboard"))
     }
 
     private fun handleOpenMemory(hash: String) {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrPanel.kt
@@ -1,0 +1,301 @@
+package ai.jolli.jollimemory.toolwindow
+
+import ai.jolli.jollimemory.bridge.GitOps
+import ai.jolli.jollimemory.bridge.GitRemoteUtils
+import ai.jolli.jollimemory.core.SessionTracker
+import ai.jolli.jollimemory.core.StorageFactory
+import ai.jolli.jollimemory.core.SummaryStore
+import ai.jolli.jollimemory.core.TraceContext
+import ai.jolli.jollimemory.services.JolliApiClient
+import ai.jolli.jollimemory.services.JolliAuthService
+import ai.jolli.jollimemory.services.JolliMemoryService
+import ai.jolli.jollimemory.services.JolliShareService
+import ai.jolli.jollimemory.services.PrService
+import ai.jolli.jollimemory.toolwindow.views.CreatePrData
+import ai.jolli.jollimemory.toolwindow.views.CreatePrHtmlBuilder
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.intellij.ide.BrowserUtil
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.intellij.ui.JBColor
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.jcef.JBCefBrowser
+import com.intellij.ui.jcef.JBCefBrowserBase
+import com.intellij.ui.jcef.JBCefJSQuery
+import org.cef.browser.CefBrowser
+import org.cef.browser.CefFrame
+import org.cef.handler.CefRequestHandlerAdapter
+import org.cef.network.CefRequest
+import java.awt.BorderLayout
+import java.awt.Font
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
+import java.io.File
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.JTextArea
+
+/**
+ * Dedicated "Create PR" JCEF webview — the branch-level Create-PR surface matching
+ * the design mockup's `#pane-pr`. Mirrors [SummaryPanel]'s JCEF bridge.
+ *
+ * On submit it creates (or updates) the PR via [PrService] and, when a Jolli site
+ * key is configured, ALSO shares the included memories to Jolli via
+ * [JolliShareService] — the one-click "create the PR and share" flow. Binding-
+ * required (412) is resolved once via [BindingChooserDialog], then sharing resumes.
+ */
+class CreatePrPanel(
+    private val project: Project,
+    initialVm: CreatePrData.ViewModel,
+) : JPanel(BorderLayout()) {
+
+    @Volatile
+    private var vm: CreatePrData.ViewModel = initialVm
+
+    private var browser: JBCefBrowser? = null
+    private var jsQuery: JBCefJSQuery? = null
+    private var bridgeScript: String = ""
+    private val gson = Gson()
+    private val store: SummaryStore
+    private val cwd: String
+
+    init {
+        val service = project.getService(JolliMemoryService::class.java)
+        cwd = service?.mainRepoRoot ?: project.basePath ?: ""
+        val git = service?.getGitOps() ?: GitOps(cwd)
+        store = SummaryStore(cwd, git, StorageFactory.create(git, cwd))
+        add(createContent(), BorderLayout.CENTER)
+    }
+
+    private fun createContent(): JComponent {
+        return try {
+            val b = JBCefBrowser()
+            browser = b
+            val query = JBCefJSQuery.create(b as JBCefBrowserBase)
+            jsQuery = query
+            query.addHandler { request ->
+                try {
+                    val decoded = String(java.util.Base64.getDecoder().decode(request), Charsets.UTF_8)
+                    dispatchWebviewMessage(JsonParser.parseString(decoded).asJsonObject)
+                } catch (e: Exception) {
+                    LOG.warn("Failed to parse webview message: ${e.message}", e)
+                }
+                JBCefJSQuery.Response("ok")
+            }
+            bridgeScript = """
+                window.__jbQuery = function(msg) {
+                    ${query.inject("msg")}
+                };
+            """.trimIndent()
+            b.jbCefClient.addRequestHandler(object : CefRequestHandlerAdapter() {
+                override fun onBeforeBrowse(
+                    browser: CefBrowser?,
+                    frame: CefFrame?,
+                    request: CefRequest?,
+                    userGesture: Boolean,
+                    isRedirect: Boolean,
+                ): Boolean {
+                    val url = request?.url ?: return false
+                    if (url.startsWith("http://") || url.startsWith("https://")) {
+                        BrowserUtil.browse(url)
+                        return true
+                    }
+                    return false
+                }
+            }, b.cefBrowser)
+            b.loadHTML(CreatePrHtmlBuilder.buildHtml(vm, !JBColor.isBright(), bridgeScript))
+            b.component
+        } catch (e: Exception) {
+            LOG.info("JCEF unavailable: ${e.message}")
+            JBScrollPane(
+                JTextArea(vm.bodyMarkdown).apply {
+                    isEditable = false
+                    font = Font("Monospaced", Font.PLAIN, 13)
+                    lineWrap = true
+                    wrapStyleWord = true
+                    caretPosition = 0
+                },
+            )
+        }
+    }
+
+    fun dispose() {
+        jsQuery?.dispose()
+        browser?.dispose()
+    }
+
+    private fun postToWebview(command: String, data: Map<String, Any?> = emptyMap()) {
+        val payload = gson.toJson(data + ("command" to command))
+        val b64 = java.util.Base64.getEncoder().encodeToString(payload.toByteArray(Charsets.UTF_8))
+        browser?.cefBrowser?.executeJavaScript(
+            "window.dispatchEvent(new CustomEvent('jollimemory', { detail: JSON.parse(new TextDecoder().decode(Uint8Array.from(atob('$b64'), function(c){ return c.charCodeAt(0); }))) }));",
+            browser?.cefBrowser?.url ?: "",
+            0,
+        )
+    }
+
+    private fun refreshHtml() {
+        browser?.loadHTML(CreatePrHtmlBuilder.buildHtml(vm, !JBColor.isBright(), bridgeScript))
+    }
+
+    private fun dispatchWebviewMessage(json: JsonObject) {
+        when (json.get("command")?.asString) {
+            "createPr" -> handleCreatePr(json.get("title")?.asString, json.get("body")?.asString)
+            "copyBody" -> handleCopyBody()
+            "openMemory" -> handleOpenMemory(json.get("hash")?.asString ?: return)
+            "openDiff" -> handleOpenDiff(json.get("path")?.asString ?: return)
+            "openPr" -> json.get("url")?.asString?.let { BrowserUtil.browse(it) }
+            "signIn" -> handleSignIn()
+        }
+    }
+
+    private fun handleCopyBody() {
+        val body = PrService.wrapWithMarkers(vm.bodyMarkdown)
+        Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(body), null)
+    }
+
+    private fun handleOpenMemory(hash: String) {
+        val summary = vm.includedSummaries.firstOrNull { it.commitHash == hash } ?: return
+        FileEditorManager.getInstance(project).openFile(SummaryVirtualFile(summary), true)
+    }
+
+    private fun handleOpenDiff(path: String) {
+        // Repo-relative path only — reject traversal/absolute paths.
+        if (path.startsWith("/") || path.contains("..")) return
+        val file = File(cwd, path)
+        val vfile = com.intellij.openapi.vfs.LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file) ?: return
+        FileEditorManager.getInstance(project).openFile(vfile, true)
+    }
+
+    private fun handleSignIn() {
+        JolliAuthService.login(
+            onSuccess = {
+                ApplicationManager.getApplication().invokeLater {
+                    vm = vm.copy(signedIn = true)
+                    refreshHtml()
+                }
+            },
+            onError = { msg ->
+                ApplicationManager.getApplication().invokeLater {
+                    Messages.showErrorDialog(project, "Sign-in failed: $msg", "Jolli Memory")
+                }
+            },
+        )
+    }
+
+    private fun handleCreatePr(titleArg: String?, bodyArg: String?) {
+        val title = titleArg?.takeIf { it.isNotBlank() } ?: vm.title
+        val rawBody = bodyArg?.takeIf { it.isNotBlank() } ?: vm.bodyMarkdown
+        val body = PrService.wrapWithMarkers(rawBody)
+
+        postToWebview("prCreating", mapOf("text" to "Pushing branch…"))
+        ApplicationManager.getApplication().executeOnPooledThread {
+            TraceContext.withTrace {
+                try {
+                    PrService.pushBranch(cwd)
+                    val lookup = PrService.findPrForBranch(cwd, vm.branch)
+                    val prUrl = if (lookup is PrService.PrLookup.Found) {
+                        PrService.updatePr(lookup.pr.number, title, body, cwd)
+                        lookup.pr.url
+                    } else {
+                        PrService.createPr(title, body, cwd)
+                    }
+
+                    // One-click share: when signed in, push the included memories to Jolli.
+                    val shareMsg = shareIncludedMemoriesIfSignedIn()
+
+                    ApplicationManager.getApplication().invokeLater {
+                        postToWebview("prCreated", mapOf("text" to "Pull request ready.$shareMsg"))
+                        Messages.showInfoMessage(project, "Pull request ready.\n$prUrl$shareMsg", "Create PR")
+                    }
+                } catch (e: Exception) {
+                    ApplicationManager.getApplication().invokeLater {
+                        postToWebview("prCreateError", mapOf("text" to (e.message ?: "Create failed")))
+                        Messages.showErrorDialog(project, "Create PR failed: ${e.message}", "PR Error")
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Shares the included memories to Jolli when a site key is configured. Returns a
+     * human-readable suffix for the success toast (empty when not signed in). Runs on
+     * the calling pooled thread; best-effort per memory. Resolves a binding-required
+     * (412) once via the chooser dialog, then continues.
+     */
+    private fun shareIncludedMemoriesIfSignedIn(): String {
+        val config = SessionTracker.loadConfig(cwd)
+        val apiKey = config.jolliApiKey?.takeIf { it.isNotBlank() } ?: return ""
+        val resolvedBaseUrl = JolliApiClient.parseJolliApiKey(apiKey)?.u
+            ?: ai.jolli.jollimemory.auth.JolliUrlConfig.getJolliUrl()
+        if (resolvedBaseUrl.isBlank()) return ""
+
+        postToWebview("prProgress", mapOf("text" to "PR ready — sharing memories to Jolli…"))
+        var shared = 0
+        var bindingResolved = false
+        for (summary in vm.includedSummaries) {
+            try {
+                JolliShareService.shareSummary(store, summary, cwd, apiKey, resolvedBaseUrl)
+                shared++
+            } catch (e: JolliApiClient.BindingRequiredError) {
+                if (bindingResolved || !resolveBinding(e.repoUrl, resolvedBaseUrl, apiKey)) {
+                    LOG.info("Share aborted: binding not resolved")
+                    break
+                }
+                bindingResolved = true
+                // Retry this memory now that the repo is bound.
+                try {
+                    JolliShareService.shareSummary(store, summary, cwd, apiKey, resolvedBaseUrl)
+                    shared++
+                } catch (e2: Exception) {
+                    LOG.warn("Share retry failed for ${summary.commitHash.take(8)}: ${e2.message}")
+                }
+            } catch (e: JolliApiClient.UnauthorizedError) {
+                LOG.warn("Share stopped — key rejected: ${e.message}")
+                break
+            } catch (e: JolliApiClient.PluginOutdatedError) {
+                LOG.warn("Share stopped — plugin outdated: ${e.message}")
+                break
+            } catch (e: Exception) {
+                LOG.warn("Share failed for ${summary.commitHash.take(8)}: ${e.message}")
+            }
+        }
+        return if (shared > 0) " Shared $shared ${if (shared == 1) "memory" else "memories"} to Jolli." else ""
+    }
+
+    /**
+     * Shows the space-binding chooser (412 handling) synchronously and returns true
+     * when the user selected a space. Blocks the calling pooled thread via
+     * invokeAndWait since the dialog is modal on the EDT.
+     */
+    private fun resolveBinding(repoUrl: String, baseUrl: String, apiKey: String): Boolean {
+        val spaces = try {
+            JolliApiClient.listSpaces(baseUrl, apiKey)
+        } catch (e: Exception) {
+            LOG.warn("resolveBinding: listSpaces failed: ${e.message}")
+            return false
+        }
+        val suggestedRepoName = GitRemoteUtils.deriveRepoNameFromUrl(repoUrl).ifEmpty { "repo" }
+        var selected = false
+        ApplicationManager.getApplication().invokeAndWait {
+            if (BindingChooserDialog.isAlreadyOpen(repoUrl)) return@invokeAndWait
+            val dialog = BindingChooserDialog.open(
+                project, repoUrl, suggestedRepoName,
+                spaces.spaces, spaces.defaultSpaceId, baseUrl, apiKey,
+            )
+            dialog.show()
+            selected = dialog.getOutcome() is BindingChooserOutcome.Selected
+        }
+        return selected
+    }
+
+    companion object {
+        private val LOG = Logger.getInstance(CreatePrPanel::class.java)
+    }
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrVirtualFile.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrVirtualFile.kt
@@ -1,0 +1,24 @@
+package ai.jolli.jollimemory.toolwindow
+
+import ai.jolli.jollimemory.toolwindow.views.CreatePrData
+import com.intellij.testFramework.LightVirtualFile
+
+/**
+ * Lightweight virtual file carrying a [CreatePrData.ViewModel]. Opens the dedicated
+ * Create-PR webview as an editor tab. Identity is the branch, so re-triggering
+ * "Create PR" on the same branch reuses the existing tab instead of stacking tabs.
+ */
+class CreatePrVirtualFile(
+    val vm: CreatePrData.ViewModel,
+) : LightVirtualFile("✨ Create PR — ${vm.branch}", "") {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is CreatePrVirtualFile) return false
+        return vm.branch == other.vm.branch
+    }
+
+    override fun hashCode(): Int = vm.branch.hashCode()
+
+    override fun isWritable(): Boolean = false
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
@@ -18,6 +18,7 @@ import ai.jolli.jollimemory.core.TranscriptEntry
 import ai.jolli.jollimemory.core.references.SourceId
 import ai.jolli.jollimemory.services.JolliApiClient
 import ai.jolli.jollimemory.services.JolliMemoryService
+import ai.jolli.jollimemory.services.JolliShareService
 import ai.jolli.jollimemory.services.PlanService
 import ai.jolli.jollimemory.services.PrService
 import ai.jolli.jollimemory.toolwindow.views.SummaryHtmlBuilder
@@ -297,10 +298,6 @@ class SummaryPanel(
         }
 
         postToWebview("pushStarted")
-        val baseUrl = resolvedBaseUrl.trimEnd('/')
-
-        val repoUrl = GitRemoteUtils.getCanonicalRepoUrl(cwd)
-        val relativePath = GitRemoteUtils.sanitizeBranchSlug(summary.branch)
 
         ApplicationManager.getApplication().executeOnPooledThread {
             // One trace per push operation (on this pooled thread) so the push
@@ -308,75 +305,16 @@ class SummaryPanel(
             // call share one id; ThreadLocal must be set on the worker thread.
             TraceContext.withTrace {
                 try {
-                    val planUrls = mutableListOf<PlanPushResult>()
-
-                    for (plan in summary.plans ?: emptyList()) {
-                        val planContent = store.readPlanFromBranch(plan.slug) ?: continue
-                        if (planContent.isBlank()) continue
-
-                        val planResult = JolliApiClient.pushToJolli(resolvedBaseUrl, config.jolliApiKey!!, JolliApiClient.JolliPushPayload(
-                            title = SummaryUtils.buildPlanPushTitle(summary, plan.title),
-                            content = planContent,
-                            commitHash = summary.commitHash,
-                            docType = "plan",
-                            branch = summary.branch,
-                            docId = plan.jolliPlanDocId,
-                            repoUrl = repoUrl,
-                            relativePath = relativePath,
-                        ))
-                        planUrls.add(PlanPushResult(plan.slug, plan.title, "$baseUrl/articles?doc=${planResult.docId}", planResult.docId))
-                    }
-
-                    var plansWithUrls = summary.plans
-                    if (planUrls.isNotEmpty() && plansWithUrls != null) {
-                        val urlMap = planUrls.associateBy { it.slug }
-                        plansWithUrls = plansWithUrls.map { p ->
-                            val pushed = urlMap[p.slug]
-                            if (pushed != null) p.copy(jolliPlanDocUrl = pushed.url, jolliPlanDocId = pushed.docId) else p
-                        }
-                    }
-
-                    val summaryForMarkdown = if (plansWithUrls !== summary.plans) summary.copy(plans = plansWithUrls) else summary
-                    val markdown = SummaryMarkdownBuilder.buildMarkdown(summaryForMarkdown)
-                    val pushTitle = SummaryUtils.buildPushTitle(summary)
-
-                    val result = JolliApiClient.pushToJolli(resolvedBaseUrl, config.jolliApiKey!!, JolliApiClient.JolliPushPayload(
-                        title = pushTitle, content = markdown, commitHash = summary.commitHash,
-                        docType = "summary",
-                        branch = summary.branch, docId = summary.jolliDocId,
-                        repoUrl = repoUrl, relativePath = relativePath,
-                    ))
-
-                    val fullUrl = "$baseUrl/articles?doc=${result.docId}"
-                    var updatedPlans = summary.plans
-                    if (updatedPlans != null && planUrls.isNotEmpty()) {
-                        val planResultMap = planUrls.associateBy { it.slug }
-                        updatedPlans = updatedPlans.map { p ->
-                            val pushResult = planResultMap[p.slug]
-                            if (pushResult != null) p.copy(jolliPlanDocUrl = pushResult.url, jolliPlanDocId = pushResult.docId) else p
-                        }
-                    }
-
-                    val updatedSummary = summary.copy(jolliDocUrl = fullUrl, jolliDocId = result.docId, plans = updatedPlans)
-                    store.storeSummary(updatedSummary, force = true)
-                    currentSummary = updatedSummary
-
-                    val cleanedSummary = cleanupOrphanedDocs(summary, updatedSummary, baseUrl, config.jolliApiKey!!)
-                    if (cleanedSummary != null) currentSummary = cleanedSummary
-
-                    ai.jolli.jollimemory.core.telemetry.Telemetry.track(
-                        "memory_pushed",
-                        mapOf(
-                            "kind" to "summary",
-                            "created" to result.created,
-                            "plans_bucket" to ai.jolli.jollimemory.core.telemetry.Telemetry.bucket(planUrls.size),
-                        ),
-                    )
+                    // The push core lives in JolliShareService so the Create-PR view can
+                    // reuse the exact same logic; the binding/re-auth/UI handling below
+                    // stays panel-side.
+                    val res = JolliShareService.shareSummary(store, summary, cwd, config.jolliApiKey!!, resolvedBaseUrl)
+                    currentSummary = res.updatedSummary
 
                     ApplicationManager.getApplication().invokeLater {
                         refreshHtml()
                         val verb = if (summary.jolliDocUrl != null) "Updated" else "Pushed"
-                        val planMsg = if (planUrls.isNotEmpty()) " (with ${planUrls.size} plan${if (planUrls.size > 1) "s" else ""})" else ""
+                        val planMsg = if (res.planCount > 0) " (with ${res.planCount} plan${if (res.planCount > 1) "s" else ""})" else ""
                         Messages.showInfoMessage(project, "$verb on Jolli Space$planMsg.", "Push Successful")
                     }
                 } catch (e: JolliApiClient.BindingRequiredError) {
@@ -1207,19 +1145,7 @@ class SummaryPanel(
         } catch (_: Exception) { "" }
     }
 
-    private fun cleanupOrphanedDocs(originalSummary: CommitSummary, updatedSummary: CommitSummary, baseUrl: String, apiKey: String): CommitSummary? {
-        val orphanedIds = originalSummary.orphanedDocIds ?: return null
-        if (orphanedIds.isEmpty()) return null
-        val deleted = mutableSetOf<Int>()
-        for (id in orphanedIds) { try { JolliApiClient.deleteFromJolli(baseUrl, apiKey, id); deleted.add(id) } catch (e: Exception) { LOG.warn("Failed to delete orphaned doc $id: ${e.message}") } }
-        val remaining = orphanedIds.filter { it !in deleted }
-        val cleanedSummary = updatedSummary.copy(orphanedDocIds = remaining.takeIf { it.isNotEmpty() })
-        store.storeSummary(cleanedSummary, force = true)
-        return cleanedSummary
-    }
-
     private data class RebuildSession(val sessionId: String, val source: String, val transcriptPath: String?, val entries: MutableList<TranscriptEntry> = mutableListOf())
-    private data class PlanPushResult(val slug: String, val title: String, val url: String, val docId: Int)
 
     companion object {
         private val LOG = Logger.getInstance(SummaryPanel::class.java)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/WorkingMemoryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/WorkingMemoryPanel.kt
@@ -1,14 +1,20 @@
 package ai.jolli.jollimemory.toolwindow
 
+import ai.jolli.jollimemory.core.ActiveConversationItem
 import ai.jolli.jollimemory.core.ActiveSessionAggregator
 import ai.jolli.jollimemory.core.CommitSelectionStore
 import ai.jolli.jollimemory.core.SessionTracker
+import ai.jolli.jollimemory.core.StoredSession
+import ai.jolli.jollimemory.core.TokenUsage
+import ai.jolli.jollimemory.core.TranscriptReader
+import ai.jolli.jollimemory.core.TranscriptSource
 import ai.jolli.jollimemory.core.references.SourceId
 import ai.jolli.jollimemory.services.JolliMemoryService
 import ai.jolli.jollimemory.toolwindow.views.WorkingMemoryHtmlBuilder
 import ai.jolli.jollimemory.toolwindow.views.WorkingMemoryHtmlBuilder.WmContext
 import ai.jolli.jollimemory.toolwindow.views.WorkingMemoryHtmlBuilder.WmConversation
 import ai.jolli.jollimemory.toolwindow.views.WorkingMemoryHtmlBuilder.WmFile
+import ai.jolli.jollimemory.toolwindow.views.WorkingMemoryHtmlBuilder.WmTokens
 import ai.jolli.jollimemory.toolwindow.views.WorkingMemoryHtmlBuilder.WorkingMemoryView
 import com.google.gson.JsonParser
 import com.intellij.ide.BrowserUtil
@@ -64,8 +70,16 @@ class WorkingMemoryPanel(private val project: Project) : JPanel(BorderLayout()) 
             query.addHandler { request ->
                 try {
                     val json = JsonParser.parseString(request).asJsonObject
-                    if (json.get("command")?.asString == "commitMemory") {
-                        SwingUtilities.invokeLater { runCommit() }
+                    when (json.get("command")?.asString) {
+                        "commitMemory" -> SwingUtilities.invokeLater { runCommit() }
+                        "toggleExclude" -> {
+                            val kind = json.get("kind")?.asString
+                            val key = json.get("key")?.asString
+                            val excluded = json.get("excluded")?.asBoolean ?: false
+                            if (kind != null && key != null) {
+                                SwingUtilities.invokeLater { handleToggleExclude(kind, key, excluded) }
+                            }
+                        }
                     }
                 } catch (e: Exception) {
                     LOG.warn("Failed to parse working-memory message: ${e.message}")
@@ -149,20 +163,36 @@ class WorkingMemoryPanel(private val project: Project) : JPanel(BorderLayout()) 
             CommitSelectionStore.CommitExclusions()
         }
 
-        val conversations = try {
+        // Show ALL active conversations, not just the included ones: excluded rows stay
+        // visible (struck through) with a + to add them back — the mockup's inline
+        // "leave out / add back" editing. `excluded` drives the ✕/+ toggle state.
+        val rawConversations = try {
             ActiveSessionAggregator.listActiveConversations(cwd)
-                .filter { CommitSelectionStore.conversationKey(it.source, it.sessionId) !in exclusions.conversations }
-                .map {
-                    WmConversation(it.source.name, it.title.ifBlank { "${it.source.name} conversation" }, it.messageCount)
-                }
         } catch (_: Exception) {
             emptyList()
+        }
+        val conversations = rawConversations.map {
+            val key = CommitSelectionStore.conversationKey(it.source, it.sessionId)
+            WmConversation(
+                source = it.source.name,
+                title = it.title.ifBlank { "${it.source.name} conversation" },
+                messageCount = it.messageCount,
+                key = key,
+                excluded = key in exclusions.conversations,
+            )
         }
 
         val context = gatherContext(exclusions)
         val detectedTicket = context.firstOrNull { it.tag == "L" || it.tag == "J" }
             ?.let { Regex("[A-Z]+-\\d+").find(it.title)?.value }
             ?: Regex("[A-Z]+-\\d+").find(branch)?.value
+
+        // Token usage is aggregated from the INCLUDED conversations' transcripts (the
+        // ones that will actually enter the memory), so unchecking a conversation drops
+        // its tokens from the meter too.
+        val includedConversations = rawConversations.filter {
+            CommitSelectionStore.conversationKey(it.source, it.sessionId) !in exclusions.conversations
+        }
 
         return WorkingMemoryView(
             branch = branch,
@@ -171,13 +201,59 @@ class WorkingMemoryPanel(private val project: Project) : JPanel(BorderLayout()) 
             deletions = del,
             detectedTicket = detectedTicket,
             proposedTitle = buildProposedTitle(branch, detectedTicket),
-            // Live sessions don't carry token usage in the plugin; usage is captured
-            // when the memory is generated at commit time.
-            tokenLabel = "N/A tokens",
+            token = computeTokens(includedConversations),
             conversations = conversations,
             context = context,
             files = selectedFiles,
         )
+    }
+
+    /**
+     * Aggregates AI coding-session token usage from the included conversations'
+     * transcripts. Only JSONL sources that emit per-message `usage` (Claude, Codex,
+     * Gemini) are read; others count toward the session total but not the reported
+     * count, so [TokenUsage.partial] flags an understated meter. Returns null when no
+     * included source reported usage — the meter then shows its "recorded at commit"
+     * state instead of a misleading zero. Runs on the caller's pooled thread.
+     */
+    private fun computeTokens(included: List<ActiveConversationItem>): WmTokens? {
+        if (included.isEmpty()) return null
+        val usageSources = setOf(TranscriptSource.claude, TranscriptSource.codex, TranscriptSource.gemini)
+        val sessions = included.map { c ->
+            val entries = if (c.source in usageSources) {
+                try {
+                    TranscriptReader.readTranscript(c.transcriptPath).entries
+                } catch (_: Exception) {
+                    emptyList()
+                }
+            } else {
+                emptyList()
+            }
+            StoredSession(c.sessionId, c.source, c.transcriptPath, entries)
+        }
+        val usage = TokenUsage.aggregate(sessions) ?: return null
+        return WmTokens(
+            total = usage.total,
+            input = usage.inputTokens,
+            output = usage.outputTokens,
+            cacheRead = usage.cacheReadTokens,
+            cacheWrite = usage.cacheWriteTokens,
+            partial = usage.partial,
+        )
+    }
+
+    /** Flips a working-memory item's commit-selection exclusion, then refreshes. */
+    private fun handleToggleExclude(kind: String, key: String, excluded: Boolean) {
+        try {
+            CommitSelectionStore.setExcluded(cwd, kind, key, excluded)
+        } catch (e: Exception) {
+            LOG.warn("toggleExclude failed: ${e.message}")
+            return
+        }
+        // Refresh the sidebar panels + this review. notifySelectionChanged fans out to
+        // our own selectionListener (→ reload); fall back to a direct reload if the
+        // service is unavailable.
+        if (service != null) service.notifySelectionChanged() else reload()
     }
 
     /**
@@ -243,20 +319,19 @@ class WorkingMemoryPanel(private val project: Project) : JPanel(BorderLayout()) 
             // No branch filter on any kind: uncommitted working-area items follow the
             // user across branches (matches CLI/VS Code). `branch` is stamped but not
             // filtered on; only committed memory is branch-tagged.
+            // Excluded items stay listed (struck through, with a + to add back), so
+            // only committed/ignored ones are dropped. `excluded` drives the toggle.
             registry.plans.values.forEach { p ->
-                if (p.slug in exclusions.plans) return@forEach
                 if (p.ignored == true || p.commitHash != null) return@forEach
                 if (!File(p.sourcePath).exists()) return@forEach
-                out.add(WmContext("P", p.title))
+                out.add(WmContext("P", p.title, "plans", p.slug, p.slug in exclusions.plans))
             }
             registry.notes?.values?.forEach { n ->
-                if (n.id in exclusions.notes) return@forEach
                 if (n.ignored == true || n.commitHash != null) return@forEach
-                out.add(WmContext("N", n.title))
+                out.add(WmContext("N", n.title, "notes", n.id, n.id in exclusions.notes))
             }
             registry.references?.forEach { (mapKey, r) ->
-                if (mapKey in exclusions.references) return@forEach
-                out.add(WmContext(referenceTag(r.source), r.title))
+                out.add(WmContext(referenceTag(r.source), r.title, "references", mapKey, mapKey in exclusions.references))
             }
         } catch (_: Exception) {
             // best-effort

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/WorkingMemoryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/WorkingMemoryPanel.kt
@@ -250,10 +250,23 @@ class WorkingMemoryPanel(private val project: Project) : JPanel(BorderLayout()) 
             LOG.warn("toggleExclude failed: ${e.message}")
             return
         }
-        // Refresh the sidebar panels + this review. notifySelectionChanged fans out to
-        // our own selectionListener (→ reload); fall back to a direct reload if the
-        // service is unavailable.
-        if (service != null) service.notifySelectionChanged() else reload()
+        val svc = service
+        if (svc == null) {
+            reload()
+            return
+        }
+        // notifySelectionChanged wakes this review (our selectionListener → reload) and
+        // any other open review. The sidebar panels listen on the *status* channel, not
+        // selection, so refresh the ones that mirror this state directly — otherwise a
+        // remove/add here wouldn't update the sidebar's checkboxes (and both must agree,
+        // since the commit reads the same CommitSelectionStore they all write to).
+        svc.notifySelectionChanged()
+        svc.panelRegistry?.let { reg ->
+            when (kind) {
+                "conversations" -> reg.activeConversationsPanel?.refresh()
+                else -> reg.plansPanel?.refresh() // plans / notes / references live in the CONTEXT (Plans) panel
+            }
+        }
     }
 
     /**

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrCssBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrCssBuilder.kt
@@ -121,8 +121,7 @@ ${if (isDark) darkVars() else lightVars()}
   .btn.secondary:hover { background: var(--btn-secondary-hover-bg); color: var(--text-primary); }
   .btn:disabled { opacity: 0.5; cursor: not-allowed; pointer-events: none; }
 
-  /* ── Edit form ── */
-  .edit-form { display: flex; flex-direction: column; gap: 8px; margin-top: 14px; }
+  /* ── Inline editors (revealed by Edit, replace the read-only display in place) ── */
   .pr-input, .pr-textarea {
     width: 100%; box-sizing: border-box; padding: 8px 10px; border-radius: 4px;
     background: var(--input-bg); color: var(--input-fg); border: 1px solid var(--input-border);
@@ -130,6 +129,15 @@ ${if (isDark) darkVars() else lightVars()}
   }
   .pr-textarea { min-height: 240px; resize: vertical; font-family: $MONO_FONT_FAMILY; font-size: 0.85em; }
   .pr-input:focus, .pr-textarea:focus { outline: 1px solid var(--focus-border); outline-offset: -1px; }
+
+  /* ── Toast (copy confirmation) ── */
+  .toast {
+    position: fixed; bottom: 22px; left: 50%; transform: translateX(-50%) translateY(8px); z-index: 80;
+    background: var(--toast-bg); border: 1px solid var(--border-light); color: var(--text-primary);
+    border-radius: 7px; padding: 8px 16px; font-size: 0.82em; box-shadow: 0 4px 14px rgba(0,0,0,0.3);
+    opacity: 0; pointer-events: none; transition: all 0.18s ease;
+  }
+  .toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
 """
 
     private fun darkVars() = """
@@ -143,7 +151,7 @@ ${if (isDark) darkVars() else lightVars()}
     --btn-secondary-bg: #3a3d41; --btn-secondary-fg: #fff; --btn-secondary-hover-bg: #45494e;
     --btn-border: rgba(255,255,255,0.06);
     --input-bg: #1e1e1e; --input-fg: #ccc; --input-border: #444;
-    --ship-ok: #4ece8d;
+    --toast-bg: #2b2d30; --ship-ok: #4ece8d;
     --gs-modified: #e0ac2b; --gs-added: #4ece8d; --gs-deleted: #f47067;
     --gs-renamed: #b494f0; --gs-untracked: #8c8c8c;"""
 
@@ -158,7 +166,7 @@ ${if (isDark) darkVars() else lightVars()}
     --btn-secondary-bg: #e8e8e8; --btn-secondary-fg: #444; --btn-secondary-hover-bg: #d6d6d6;
     --btn-border: rgba(0,0,0,0.06);
     --input-bg: #ffffff; --input-fg: #1e1e1e; --input-border: #cecece;
-    --ship-ok: #1b8a4f;
+    --toast-bg: #ffffff; --ship-ok: #1b8a4f;
     --gs-modified: #96680e; --gs-added: #1b8a4f; --gs-deleted: #c0392b;
     --gs-renamed: #5c35a0; --gs-untracked: #6e6e6e;"""
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrCssBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrCssBuilder.kt
@@ -1,0 +1,164 @@
+package ai.jolli.jollimemory.toolwindow.views
+
+/**
+ * CreatePrCssBuilder — stylesheet for the dedicated "Create PR" webview, matching
+ * the design mockup's `#pane-pr`.
+ *
+ * Self-contained (own `:root` token block per theme) rather than pulling in the
+ * ~1900-line summary stylesheet — it only needs the pane's own vocabulary. Emits
+ * hardcoded colours from an `isDark` flag because the IntelliJ JCEF webview has no
+ * `var(--vscode-*)` theme tokens (those are VS Code-only). Token values mirror
+ * [SummaryCssBuilder] so the two views read as one design system.
+ */
+object CreatePrCssBuilder {
+
+    private const val FONT_FAMILY = "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+    private const val MONO_FONT_FAMILY = "'JetBrains Mono', Menlo, Consolas, 'Courier New', monospace"
+
+    fun buildCss(isDark: Boolean): String = """
+  :root {
+${if (isDark) darkVars() else lightVars()}
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  .hidden { display: none !important; }
+  body {
+    font-family: $FONT_FAMILY; font-size: 14px; color: var(--text-primary);
+    background: var(--bg); line-height: 1.65; -webkit-font-smoothing: antialiased;
+  }
+  .pane { max-width: 860px; margin: 0 auto; padding: 26px 34px 60px; }
+  h1 { font-size: 1.4em; font-weight: 700; margin-bottom: 12px; }
+
+  /* ── Meta strip ── */
+  .meta-strip {
+    display: flex; flex-wrap: wrap; align-items: center; gap: 5px 9px;
+    font-size: 0.86em; color: var(--text-secondary); margin-bottom: 6px;
+  }
+  .meta-strip .meta-sep { color: var(--text-tertiary); opacity: 0.55; }
+  .meta-branch {
+    display: inline-block; max-width: 240px; overflow: hidden; text-overflow: ellipsis;
+    white-space: nowrap; vertical-align: bottom; padding: 1px 8px; border-radius: 5px;
+    background: var(--pill-bg); color: var(--pill-text); font-size: 0.92em;
+  }
+  .pr-open-link { cursor: pointer; color: var(--link-fg); font-weight: 600; }
+  .pr-open-link:hover { text-decoration: underline; }
+
+  /* ── Sign-in / share sub-message ── */
+  .ship-sub {
+    font-size: 0.82em; color: var(--text-secondary); line-height: 1.45;
+    margin: 2px 0 14px; display: flex; align-items: baseline; gap: 5px;
+  }
+  .ship-sub .sw-link { color: var(--link-fg); cursor: pointer; text-decoration: underline; }
+
+  /* ── Status chip ── */
+  .ship-status {
+    display: inline-flex; align-items: center; gap: 5px; flex-shrink: 0;
+    font-size: 0.72em; font-weight: 650; letter-spacing: 0.02em; padding: 2px 9px;
+    border-radius: 11px; background: var(--surface-hover); color: var(--text-secondary);
+  }
+  .ship-status.is-ok { color: var(--ship-ok); }
+
+  /* ── Panels ── */
+  .panel {
+    border: 1px solid var(--border-light); border-radius: 12px;
+    background: var(--panel-bg); padding: 16px; margin-bottom: 20px;
+  }
+  .panel-header {
+    display: flex; align-items: center; gap: 8px;
+    padding-bottom: 8px; margin-bottom: 12px; border-bottom: 1px solid var(--border-light);
+  }
+  .panel-title {
+    font-size: 0.78em; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 0.09em; color: var(--text-secondary);
+  }
+  .panel > p { margin: 0; }
+  .sec-count { margin-left: auto; font-size: 0.78em; font-weight: 600; color: var(--text-tertiary); }
+  .ship-status.is-ok, .panel-header .ship-status { margin-left: auto; }
+
+  /* ── Rows (memories + files) ── */
+  .row { display: flex; align-items: center; gap: 10px; padding: 7px 4px; border-radius: 6px; cursor: pointer; }
+  .row:hover { background: var(--surface-hover); }
+  .mem-ico { font-size: 1em; opacity: 0.5; flex-shrink: 0; }
+  .r-main { flex: 1; min-width: 0; }
+  .r-title { font-size: 0.9em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .r-sub { font-size: 0.78em; color: var(--text-secondary); }
+  .meta-hash { font-family: $MONO_FONT_FAMILY; color: var(--link-fg); }
+
+  /* ── Git-status letter badge ── */
+  .gs { flex-shrink: 0; font-size: 0.75em; font-weight: 700; width: 16px; text-align: center; font-family: $MONO_FONT_FAMILY; }
+  .gs-M, .fname-M { color: var(--gs-modified); }
+  .gs-A, .fname-A { color: var(--gs-added); }
+  .gs-D, .fname-D { color: var(--gs-deleted); }
+  .gs-R, .fname-R { color: var(--gs-renamed); }
+  .gs-U, .fname-U { color: var(--gs-untracked); }
+  .gs-C, .fname-C { color: var(--gs-deleted); }
+
+  /* ── Rendered markdown body ── */
+  .md-mock { line-height: 1.65; font-size: 0.93em; }
+  .md-mock .md-heading { font-weight: 700; margin: 10px 0 4px; }
+  .md-mock h2.md-heading { font-size: 1.05em; } .md-mock h3.md-heading { font-size: 1em; }
+  .md-mock .md-list { margin: 4px 0 8px 20px; } .md-mock .md-list li { margin: 2px 0; }
+  .md-mock .md-blank { height: 6px; }
+  .md-mock .md-inline-code, .md-mock code {
+    background: var(--code-block-bg); padding: 1px 5px; border-radius: 4px;
+    font-family: $MONO_FONT_FAMILY; font-size: 0.9em;
+  }
+  .md-mock .md-code-block {
+    background: var(--code-block-bg); padding: 10px 12px; border-radius: 6px;
+    overflow-x: auto; margin: 6px 0; font-family: $MONO_FONT_FAMILY; font-size: 0.85em;
+  }
+  .md-mock .md-link { color: var(--link-fg); }
+
+  /* ── Actions ── */
+  .actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px; }
+  .btn {
+    font-family: $FONT_FAMILY; font-size: 0.88em; padding: 8px 16px; border-radius: 6px;
+    cursor: pointer; border: 1px solid var(--btn-border);
+    background: var(--btn-primary-bg); color: var(--btn-primary-fg); font-weight: 600;
+    display: inline-flex; align-items: center; gap: 6px;
+  }
+  .btn:hover { background: var(--btn-primary-hover-bg); }
+  .btn.secondary { background: var(--btn-secondary-bg); color: var(--btn-secondary-fg); }
+  .btn.secondary:hover { background: var(--btn-secondary-hover-bg); color: var(--text-primary); }
+  .btn:disabled { opacity: 0.5; cursor: not-allowed; pointer-events: none; }
+
+  /* ── Edit form ── */
+  .edit-form { display: flex; flex-direction: column; gap: 8px; margin-top: 14px; }
+  .pr-input, .pr-textarea {
+    width: 100%; box-sizing: border-box; padding: 8px 10px; border-radius: 4px;
+    background: var(--input-bg); color: var(--input-fg); border: 1px solid var(--input-border);
+    font-family: $FONT_FAMILY; font-size: 0.9em;
+  }
+  .pr-textarea { min-height: 240px; resize: vertical; font-family: $MONO_FONT_FAMILY; font-size: 0.85em; }
+  .pr-input:focus, .pr-textarea:focus { outline: 1px solid var(--focus-border); outline-offset: -1px; }
+"""
+
+    private fun darkVars() = """
+    --bg: #1e1e1e; --text-primary: #e0e0e0;
+    --text-secondary: rgba(255,255,255,0.45); --text-tertiary: rgba(255,255,255,0.30);
+    --link-fg: #3794ff; --focus-border: #007acc;
+    --surface-hover: rgba(255,255,255,0.035); --border-light: rgba(255,255,255,0.06);
+    --pill-bg: rgba(255,255,255,0.08); --pill-text: rgba(255,255,255,0.60);
+    --panel-bg: rgba(255,255,255,0.018); --code-block-bg: rgba(128,128,128,0.1);
+    --btn-primary-bg: #0e639c; --btn-primary-fg: #fff; --btn-primary-hover-bg: #1177bb;
+    --btn-secondary-bg: #3a3d41; --btn-secondary-fg: #fff; --btn-secondary-hover-bg: #45494e;
+    --btn-border: rgba(255,255,255,0.06);
+    --input-bg: #1e1e1e; --input-fg: #ccc; --input-border: #444;
+    --ship-ok: #4ece8d;
+    --gs-modified: #e0ac2b; --gs-added: #4ece8d; --gs-deleted: #f47067;
+    --gs-renamed: #b494f0; --gs-untracked: #8c8c8c;"""
+
+    private fun lightVars() = """
+    --bg: #ffffff; --text-primary: #1e1e1e;
+    --text-secondary: rgba(0,0,0,0.45); --text-tertiary: rgba(0,0,0,0.32);
+    --link-fg: #0066bf; --focus-border: #007acc;
+    --surface-hover: rgba(0,0,0,0.028); --border-light: rgba(0,0,0,0.06);
+    --pill-bg: rgba(0,0,0,0.06); --pill-text: rgba(0,0,0,0.55);
+    --panel-bg: rgba(0,0,0,0.015); --code-block-bg: rgba(128,128,128,0.1);
+    --btn-primary-bg: #007acc; --btn-primary-fg: #fff; --btn-primary-hover-bg: #0062a3;
+    --btn-secondary-bg: #e8e8e8; --btn-secondary-fg: #444; --btn-secondary-hover-bg: #d6d6d6;
+    --btn-border: rgba(0,0,0,0.06);
+    --input-bg: #ffffff; --input-fg: #1e1e1e; --input-border: #cecece;
+    --ship-ok: #1b8a4f;
+    --gs-modified: #96680e; --gs-added: #1b8a4f; --gs-deleted: #c0392b;
+    --gs-renamed: #5c35a0; --gs-untracked: #6e6e6e;"""
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrData.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrData.kt
@@ -1,0 +1,186 @@
+package ai.jolli.jollimemory.toolwindow.views
+
+import ai.jolli.jollimemory.bridge.GitOps
+import ai.jolli.jollimemory.core.CommitSummary
+import ai.jolli.jollimemory.core.E2eTestScenario
+import ai.jolli.jollimemory.core.JmLogger
+import ai.jolli.jollimemory.core.SessionTracker
+import ai.jolli.jollimemory.services.JolliMemoryService
+import ai.jolli.jollimemory.services.PrService
+import com.intellij.openapi.project.Project
+
+/**
+ * CreatePrData — assembles the branch-level view model rendered by the dedicated
+ * "Create PR" webview. Kotlin port of the VS Code `CreatePrData.ts`: it aggregates
+ * every committed memory on the branch (not just the newest one) so the pane can
+ * show the mockup's meta-strip, "Memories included" list, and branch-wide
+ * "Files changed".
+ *
+ * The **anchor** is the newest memory ([JolliMemoryService.getBranchCommits] returns
+ * newest-first). Title, body, and E2E scenarios are drawn from the anchor, mirroring
+ * the current single-memory create flow; the full memory set is listed separately.
+ *
+ * The pure functions ([assemble], [parseNameStatus], [parseNumstat]) are split out
+ * from [build] so they are unit-testable without an IDE/git surface.
+ */
+object CreatePrData {
+
+    private val log = JmLogger.create("CreatePrData")
+
+    data class FileRow(val path: String, val dir: String, val status: String)
+
+    data class MemoryRow(val hash: String, val title: String, val jolliDocUrl: String?)
+
+    data class ExistingPr(val number: Int, val url: String)
+
+    data class ViewModel(
+        val branch: String,
+        val mainBranch: String,
+        val memoryCount: Int,
+        val insertions: Int,
+        val deletions: Int,
+        val filesChanged: Int,
+        /** PR title — first line of the newest memory's commit message. */
+        val title: String,
+        /** Raw PR body markdown (no idempotent markers; wrapped on submit). */
+        val bodyMarkdown: String,
+        val memories: List<MemoryRow>,
+        val files: List<FileRow>,
+        val e2eScenarios: List<E2eTestScenario>,
+        /** Open PR already on this branch — renders "Update PR" + link when present. */
+        val existingPr: ExistingPr?,
+        /** True when a Jolli site key is configured — gates the "also share to Jolli" copy + action. */
+        val signedIn: Boolean,
+        /** Summaries included in this PR, newest-first — the payload the share step pushes. */
+        val includedSummaries: List<CommitSummary>,
+    )
+
+    /**
+     * Gathers real branch data and builds the view model. Returns null when the
+     * branch has no committed memories (caller shows the "commit first" hint).
+     * Call from a pooled thread — it shells out to git/gh.
+     */
+    fun build(project: Project, mainBranch: String = "main"): ViewModel? {
+        val service = project.getService(JolliMemoryService::class.java) ?: return null
+        val cwd = service.mainRepoRoot ?: project.basePath ?: return null
+        val git = service.getGitOps() ?: return null
+
+        val summaries = service.getBranchCommits()
+            .filter { it.hasSummary }
+            .mapNotNull { service.getSummary(it.hash) }
+        if (summaries.isEmpty()) return null
+
+        val anchor = summaries.first() // newest-first
+        val branch = anchor.branch.ifBlank { git.getCurrentBranch()?.trim() ?: "" }
+
+        val base = resolveDeltaBase(git, branch, mainBranch)
+        val (stats, files) = computeStats(git, base)
+
+        val existingPr = when (val lookup = PrService.findPrForBranch(cwd, branch)) {
+            is PrService.PrLookup.Found -> ExistingPr(lookup.pr.number, lookup.pr.url)
+            else -> null
+        }
+        val signedIn = !SessionTracker.loadConfig(cwd).jolliApiKey.isNullOrBlank()
+
+        return assemble(branch, mainBranch, summaries, stats, files, existingPr, signedIn)
+    }
+
+    /** Aggregate insertions/deletions/filesChanged. */
+    data class Stats(val insertions: Int, val deletions: Int, val filesChanged: Int)
+
+    /** Pure assembly from already-fetched inputs — the unit-test seam. */
+    fun assemble(
+        branch: String,
+        mainBranch: String,
+        summaries: List<CommitSummary>,
+        stats: Stats,
+        files: List<FileRow>,
+        existingPr: ExistingPr?,
+        signedIn: Boolean,
+    ): ViewModel {
+        val anchor = summaries.first()
+        return ViewModel(
+            branch = branch,
+            mainBranch = mainBranch,
+            memoryCount = summaries.size,
+            insertions = stats.insertions,
+            deletions = stats.deletions,
+            filesChanged = stats.filesChanged,
+            title = firstLine(anchor.commitMessage),
+            bodyMarkdown = SummaryPrMarkdownBuilder.buildPrMarkdown(anchor),
+            memories = summaries.map { MemoryRow(it.commitHash, firstLine(it.commitMessage), it.jolliDocUrl) },
+            files = files,
+            e2eScenarios = anchor.e2eTestGuide ?: emptyList(),
+            existingPr = existingPr,
+            signedIn = signedIn,
+            includedSummaries = summaries,
+        )
+    }
+
+    private fun firstLine(s: String): String = s.substringBefore("\n").trim()
+
+    /**
+     * Resolves the base commit for the branch delta (`base..HEAD`), matching the
+     * merge-base + reflog-creation-point logic in [JolliMemoryService.getBranchCommits]
+     * so the stats/files line up with the listed commits. Returns null when there is
+     * no common ancestor.
+     */
+    private fun resolveDeltaBase(git: GitOps, branch: String, mainBranch: String): String? {
+        val baseRef = listOf("origin/$mainBranch", "upstream/$mainBranch", mainBranch)
+            .firstOrNull { git.exec("rev-parse", "--verify", it) != null } ?: mainBranch
+        val headHash = git.getHeadHash()
+        val mergeBase = git.exec("merge-base", "HEAD", baseRef)?.trim()?.takeIf { it.isNotBlank() } ?: return null
+        // A fresh branch with no own commits (base == HEAD) has an empty delta.
+        if (mergeBase == headHash) return mergeBase
+        return git.resolveOwnCommitsBase(branch, mergeBase)
+    }
+
+    /** Runs numstat + name-status over `base..HEAD` and parses both. */
+    private fun computeStats(git: GitOps, base: String?): Pair<Stats, List<FileRow>> {
+        if (base == null) return Stats(0, 0, 0) to emptyList()
+        val numstat = git.exec("diff", "--numstat", base, "HEAD") ?: ""
+        val nameStatus = git.exec("diff", "--name-status", base, "HEAD") ?: ""
+        val (ins, del) = parseNumstat(numstat)
+        val files = parseNameStatus(nameStatus)
+        return Stats(ins, del, files.size) to files
+    }
+
+    /**
+     * Sums insertions/deletions from `git diff --numstat` output. Each line is
+     * `<ins>\t<del>\t<path>`; binary files use `-` for the counts and are skipped.
+     */
+    fun parseNumstat(raw: String): Pair<Int, Int> {
+        var ins = 0
+        var del = 0
+        for (line in raw.split("\n")) {
+            val entry = line.trimEnd('\r')
+            if (entry.isBlank()) continue
+            val parts = entry.split("\t")
+            if (parts.size < 3) continue
+            ins += parts[0].toIntOrNull() ?: 0
+            del += parts[1].toIntOrNull() ?: 0
+        }
+        return ins to del
+    }
+
+    /**
+     * Parses `git diff --name-status` output into [FileRow]s. Each line is
+     * `<STATUS>\t<path>` or `R<pct>\t<old>\t<new>` for renames; rename codes like
+     * "R100" normalise to "R". Mirrors the VS Code `parseNameStatus`.
+     */
+    fun parseNameStatus(raw: String): List<FileRow> {
+        val rows = mutableListOf<FileRow>()
+        for (line in raw.split("\n")) {
+            val entry = line.trimEnd('\r')
+            if (entry.isBlank() || !entry.contains("\t")) continue
+            val parts = entry.split("\t")
+            val rawStatus = parts[0]
+            val status = if (rawStatus.startsWith("R")) "R" else rawStatus
+            val filePath = if (status == "R" && parts.size >= 3) parts[2] else parts[1]
+            val lastSlash = filePath.lastIndexOf("/")
+            val dir = if (lastSlash >= 0) filePath.substring(0, lastSlash) else ""
+            rows.add(FileRow(path = filePath, dir = dir, status = status))
+        }
+        return rows
+    }
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrHtmlBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrHtmlBuilder.kt
@@ -1,0 +1,147 @@
+package ai.jolli.jollimemory.toolwindow.views
+
+import ai.jolli.jollimemory.core.E2eTestScenario
+import ai.jolli.jollimemory.toolwindow.views.SummaryUtils.escAttr
+
+/**
+ * CreatePrHtmlBuilder — builds the full HTML document for the dedicated "Create PR"
+ * JCEF webview, matching the design mockup's `#pane-pr`.
+ *
+ * Reuses the existing JCEF document skeleton (inline `<style>` + bridge `<script>`
+ * + behaviour `<script>`, no CSP nonce) from [SummaryHtmlBuilder]. Data comes from
+ * [CreatePrData.ViewModel]; the PR body is rendered as markdown client-side by
+ * [CreatePrScriptBuilder].
+ */
+object CreatePrHtmlBuilder {
+
+    fun buildHtml(vm: CreatePrData.ViewModel, isDark: Boolean, bridgeScript: String): String {
+        val isUpdate = vm.existingPr != null
+        val heading = if (isUpdate) "Update Pull Request" else "Create Pull Request"
+        val primaryLabel = if (isUpdate) "Update PR" else "Create PR"
+        val editedLabel = if (isUpdate) "Update with these" else "Create with these"
+
+        return """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>$heading</title>
+  <style>${CreatePrCssBuilder.buildCss(isDark)}</style>
+</head>
+<body>
+<div class="pane" id="pane-pr">
+  <h1>$heading</h1>
+  ${buildMetaStrip(vm)}
+  ${buildShipSub(vm)}
+  <div class="panel">
+    <div class="panel-header"><span class="panel-title">Title</span></div>
+    <p>${escAttr(vm.title)}</p>
+  </div>
+  <div class="panel">
+    <div class="panel-header"><span class="panel-title">Body — drafted from this branch&#39;s memories</span></div>
+    <div class="md-mock" id="prBody" data-body="${escAttr(vm.bodyMarkdown)}"></div>
+  </div>
+  <div class="panel">
+    <div class="panel-header">
+      <span class="panel-title">Memories included</span>
+      <span class="sec-count">${vm.memoryCount}</span>
+    </div>
+    ${buildMemoryRows(vm)}
+  </div>
+  ${buildE2ePanel(vm.e2eScenarios)}
+  <div class="panel">
+    <div class="panel-header">
+      <span class="panel-title">Files changed</span>
+      <span class="sec-count">${vm.filesChanged}</span>
+    </div>
+    ${buildFileRows(vm)}
+  </div>
+  <div class="actions">
+    <button class="btn" id="cmdCreatePr">$primaryLabel</button>
+    <button class="btn secondary" id="cmdEdit">Edit</button>
+    <button class="btn secondary" id="cmdCopyBody">Copy body</button>
+  </div>
+  <p class="ship-sub" id="prStatusText"></p>
+  <div class="edit-form hidden" id="editForm">
+    <input id="prTitleInput" class="pr-input" value="${escAttr(vm.title)}" />
+    <textarea id="prBodyInput" class="pr-textarea" rows="12">${escAttr(vm.bodyMarkdown)}</textarea>
+    <button class="btn" id="cmdCreateEdited">$editedLabel</button>
+  </div>
+</div>
+<script>$bridgeScript</script>
+<script>${CreatePrScriptBuilder.buildScript()}</script>
+</body>
+</html>"""
+    }
+
+    private fun buildMetaStrip(vm: CreatePrData.ViewModel): String {
+        val countLabel = if (vm.memoryCount == 1) "memory" else "memories"
+        val fileLabel = if (vm.filesChanged == 1) "file" else "files"
+        val prLink = vm.existingPr?.let {
+            """<span class="meta-sep">·</span>""" +
+                """<span class="pr-open-link" id="prOpenLink" data-pr-url="${escAttr(it.url)}">PR #${it.number}</span>"""
+        } ?: ""
+        return """<div class="meta-strip">""" +
+            """<span class="meta-branch">${escAttr(vm.branch)}</span>""" +
+            """<span class="meta-sep">→</span>""" +
+            """<span class="meta-branch">${escAttr(vm.mainBranch)}</span>""" +
+            prLink +
+            """<span class="meta-sep">·</span>""" +
+            """<span>drafted from ${vm.memoryCount} $countLabel</span>""" +
+            """<span class="meta-sep">·</span>""" +
+            """<span class="ship-status">+${vm.insertions} −${vm.deletions} · ${vm.filesChanged} $fileLabel</span>""" +
+            """</div>"""
+    }
+
+    /** Sign-in-aware sub-message describing the one-click "also share to Jolli" behaviour. */
+    private fun buildShipSub(vm: CreatePrData.ViewModel): String {
+        return if (vm.signedIn) {
+            """<div class="ship-sub">Signed in — creating this PR also shares the included memories to Jolli.</div>"""
+        } else {
+            """<div class="ship-sub">""" +
+                """<span class="sw-link" id="prSignInLink" role="button" tabindex="0">Sign in</span>""" +
+                """<span>to also share these memories to Jolli when you create the PR — or create the PR now; it stays a normal git PR.</span>""" +
+                """</div>"""
+        }
+    }
+
+    private fun buildMemoryRows(vm: CreatePrData.ViewModel): String =
+        vm.memories.joinToString("") { m ->
+            val sharedSuffix = if (m.jolliDocUrl != null) """ · <span style="opacity:0.7">shared</span>""" else ""
+            """<div class="row" data-hash="${escAttr(m.hash)}">""" +
+                """<span class="mem-ico">▤</span>""" +
+                """<div class="r-main">""" +
+                """<div class="r-title">${escAttr(m.title)}</div>""" +
+                """<div class="r-sub"><span class="meta-hash">${escAttr(m.hash.take(8))}</span>$sharedSuffix</div>""" +
+                """</div></div>"""
+        }
+
+    private fun buildFileRows(vm: CreatePrData.ViewModel): String =
+        vm.files.joinToString("") { f ->
+            val fname = f.path.substringAfterLast('/')
+            """<div class="row" data-path="${escAttr(f.path)}">""" +
+                """<div class="r-main">""" +
+                """<div class="r-title fname-${escAttr(f.status)}">${escAttr(fname)}</div>""" +
+                """<div class="r-sub">${escAttr(f.dir)}</div>""" +
+                """</div>""" +
+                """<span class="gs gs-${escAttr(f.status)}">${escAttr(f.status)}</span>""" +
+                """</div>"""
+        }
+
+    private fun buildE2ePanel(scenarios: List<E2eTestScenario>): String {
+        if (scenarios.isEmpty()) return ""
+        val label = if (scenarios.size == 1) "SCENARIO" else "SCENARIOS"
+        val body = scenarios.joinToString("") { s ->
+            """<p><b>${escAttr(s.title)}</b></p>""" +
+                """<ol>${s.steps.joinToString("") { "<li>${escAttr(it)}</li>" }}</ol>""" +
+                """<p><i>Expect:</i> ${s.expectedResults.joinToString("; ") { escAttr(it) }}</p>"""
+        }
+        return """<div class="panel">""" +
+            """<div class="panel-header">""" +
+            """<span class="panel-title">E2E Test Guide</span>""" +
+            """<span class="ship-status is-ok">${scenarios.size} $label</span>""" +
+            """</div>""" +
+            """<div class="md-mock">$body</div>""" +
+            """</div>"""
+    }
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrHtmlBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrHtmlBuilder.kt
@@ -18,7 +18,6 @@ object CreatePrHtmlBuilder {
         val isUpdate = vm.existingPr != null
         val heading = if (isUpdate) "Update Pull Request" else "Create Pull Request"
         val primaryLabel = if (isUpdate) "Update PR" else "Create PR"
-        val editedLabel = if (isUpdate) "Update with these" else "Create with these"
 
         return """<!DOCTYPE html>
 <html lang="en">
@@ -35,11 +34,13 @@ object CreatePrHtmlBuilder {
   ${buildShipSub(vm)}
   <div class="panel">
     <div class="panel-header"><span class="panel-title">Title</span></div>
-    <p>${escAttr(vm.title)}</p>
+    <p id="prTitleDisplay">${escAttr(vm.title)}</p>
+    <input id="prTitleInput" class="pr-input hidden" value="${escAttr(vm.title)}" />
   </div>
   <div class="panel">
     <div class="panel-header"><span class="panel-title">Body — drafted from this branch&#39;s memories</span></div>
     <div class="md-mock" id="prBody" data-body="${escAttr(vm.bodyMarkdown)}"></div>
+    <textarea id="prBodyInput" class="pr-textarea hidden" rows="12">${escAttr(vm.bodyMarkdown)}</textarea>
   </div>
   <div class="panel">
     <div class="panel-header">
@@ -62,12 +63,8 @@ object CreatePrHtmlBuilder {
     <button class="btn secondary" id="cmdCopyBody">Copy body</button>
   </div>
   <p class="ship-sub" id="prStatusText"></p>
-  <div class="edit-form hidden" id="editForm">
-    <input id="prTitleInput" class="pr-input" value="${escAttr(vm.title)}" />
-    <textarea id="prBodyInput" class="pr-textarea" rows="12">${escAttr(vm.bodyMarkdown)}</textarea>
-    <button class="btn" id="cmdCreateEdited">$editedLabel</button>
-  </div>
 </div>
+<div class="toast" id="prToast"></div>
 <script>$bridgeScript</script>
 <script>${CreatePrScriptBuilder.buildScript()}</script>
 </body>

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrScriptBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrScriptBuilder.kt
@@ -1,0 +1,130 @@
+package ai.jolli.jollimemory.toolwindow.views
+
+/**
+ * CreatePrScriptBuilder — inline JS for the Create PR JCEF webview.
+ *
+ * Mirrors [SummaryScriptBuilder]'s bridge (`jmSend` → `window.__jbQuery`, and an
+ * inbound `jollimemory` CustomEvent from the Kotlin `postToWebview`). Renders the
+ * PR body markdown client-side via a ported `renderMarkdown`, and wires the
+ * create/edit/copy actions plus memory/file row clicks. No CSP nonce is needed —
+ * the IntelliJ JCEF webview does not enforce a CSP (unlike VS Code).
+ */
+object CreatePrScriptBuilder {
+
+    fun buildScript(): String = """
+  function jmSend(msg) {
+    if (window.__jbQuery) {
+      var json = JSON.stringify(msg);
+      var bytes = new TextEncoder().encode(json);
+      var binary = '';
+      for (var i = 0; i < bytes.length; i++) { binary += String.fromCharCode(bytes[i]); }
+      window.__jbQuery(btoa(binary));
+    }
+  }
+
+  function esc(s) {
+    return (s == null ? '' : String(s))
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+  /** Inline markdown: code, bold, italic, links. Uses function replacers to keep it robust. */
+  function applyInline(text) {
+    text = text.replace(/`([^`]+)`/g, function(m, g) { return '<code class="md-inline-code">' + g + '</code>'; });
+    text = text.replace(/\*\*(.+?)\*\*/g, function(m, g) { return '<strong>' + g + '</strong>'; });
+    text = text.replace(/__(.+?)__/g, function(m, g) { return '<strong>' + g + '</strong>'; });
+    text = text.replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, function(m, label, url) {
+      return '<a href="' + url + '" class="md-link">' + label + '</a>';
+    });
+    return text;
+  }
+
+  /** Minimal block-level markdown → HTML (headings, lists, code fences, paragraphs). */
+  function renderMarkdown(raw) {
+    if (!raw) return '';
+    var text = esc(raw);
+    text = text.replace(/```[a-zA-Z]*\n([\s\S]*?)```/g, function(m, code) {
+      return '<pre class="md-code-block"><code>' + code.replace(/\n$/, '') + '</code></pre>';
+    });
+    var lines = text.split('\n');
+    var out = [];
+    var inList = false;
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+      if (line.indexOf('<pre class="md-code-block">') !== -1) {
+        if (inList) { out.push('</ul>'); inList = false; }
+        var block = line;
+        while (block.indexOf('</pre>') === -1 && i + 1 < lines.length) { i++; block += '\n' + lines[i]; }
+        out.push(block);
+        continue;
+      }
+      var headerMatch = line.match(/^(#{1,4})\s+(.+)${'$'}/);
+      if (headerMatch) {
+        if (inList) { out.push('</ul>'); inList = false; }
+        var level = headerMatch[1].length + 1;
+        out.push('<h' + level + ' class="md-heading">' + applyInline(headerMatch[2]) + '</h' + level + '>');
+        continue;
+      }
+      var listMatch = line.match(/^[\-\*]\s+(.+)${'$'}/);
+      if (listMatch) {
+        if (!inList) { out.push('<ul class="md-list">'); inList = true; }
+        out.push('<li>' + applyInline(listMatch[1]) + '</li>');
+        continue;
+      }
+      if (inList) { out.push('</ul>'); inList = false; }
+      if (line.trim() === '') { out.push('<div class="md-blank"></div>'); continue; }
+      out.push('<div>' + applyInline(line) + '</div>');
+    }
+    if (inList) out.push('</ul>');
+    return out.join('');
+  }
+
+  (function () {
+    var bodyEl = document.getElementById('prBody');
+    if (bodyEl) { bodyEl.innerHTML = renderMarkdown(bodyEl.getAttribute('data-body') || ''); }
+  })();
+
+  var inFlight = false;
+  function submitButtons() {
+    return ['cmdCreatePr', 'cmdCreateEdited'].map(function (id) { return document.getElementById(id); }).filter(Boolean);
+  }
+  function setInFlight(on) { inFlight = on; submitButtons().forEach(function (b) { b.disabled = on; }); }
+  function setStatus(t) { var s = document.getElementById('prStatusText'); if (s) s.textContent = t || ''; }
+  function submit(payload) { if (inFlight) return; setInFlight(true); jmSend(payload); }
+
+  var createBtn = document.getElementById('cmdCreatePr');
+  if (createBtn) createBtn.addEventListener('click', function () { submit({ command: 'createPr' }); });
+  var editBtn = document.getElementById('cmdEdit');
+  if (editBtn) editBtn.addEventListener('click', function () {
+    var f = document.getElementById('editForm'); if (f) f.classList.toggle('hidden');
+  });
+  var copyBtn = document.getElementById('cmdCopyBody');
+  if (copyBtn) copyBtn.addEventListener('click', function () { jmSend({ command: 'copyBody' }); });
+  var editedBtn = document.getElementById('cmdCreateEdited');
+  if (editedBtn) editedBtn.addEventListener('click', function () {
+    var t = document.getElementById('prTitleInput');
+    var b = document.getElementById('prBodyInput');
+    submit({ command: 'createPr', title: t ? t.value : undefined, body: b ? b.value : undefined });
+  });
+
+  document.querySelectorAll('.row[data-hash]').forEach(function (r) {
+    r.addEventListener('click', function () { jmSend({ command: 'openMemory', hash: r.getAttribute('data-hash') }); });
+  });
+  document.querySelectorAll('.row[data-path]').forEach(function (r) {
+    r.addEventListener('click', function () { jmSend({ command: 'openDiff', path: r.getAttribute('data-path') }); });
+  });
+  var prLink = document.getElementById('prOpenLink');
+  if (prLink) prLink.addEventListener('click', function () { jmSend({ command: 'openPr', url: prLink.getAttribute('data-pr-url') }); });
+  var signInLink = document.getElementById('prSignInLink');
+  if (signInLink) signInLink.addEventListener('click', function () { jmSend({ command: 'signIn' }); });
+
+  window.addEventListener('jollimemory', function (e) {
+    var msg = e.detail || {};
+    switch (msg.command) {
+      case 'prCreating': setInFlight(true); setStatus(msg.text || 'Creating PR…'); break;
+      case 'prProgress': setStatus(msg.text || ''); break;
+      case 'prCreated': setInFlight(false); setStatus(msg.text || ''); break;
+      case 'prCreateError': setInFlight(false); setStatus(msg.text || ''); break;
+    }
+  });
+"""
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrScriptBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrScriptBuilder.kt
@@ -84,27 +84,49 @@ object CreatePrScriptBuilder {
   })();
 
   var inFlight = false;
-  function submitButtons() {
-    return ['cmdCreatePr', 'cmdCreateEdited'].map(function (id) { return document.getElementById(id); }).filter(Boolean);
-  }
-  function setInFlight(on) { inFlight = on; submitButtons().forEach(function (b) { b.disabled = on; }); }
+  function setInFlight(on) { inFlight = on; var b = document.getElementById('cmdCreatePr'); if (b) b.disabled = on; }
   function setStatus(t) { var s = document.getElementById('prStatusText'); if (s) s.textContent = t || ''; }
   function submit(payload) { if (inFlight) return; setInFlight(true); jmSend(payload); }
 
+  function show(id, visible) { var el = document.getElementById(id); if (el) el.classList.toggle('hidden', !visible); }
+
+  // Edit toggles the Title/Body panels between their read-only display and inline
+  // editors (no separate form). Toggling back re-renders the display from the edits.
+  var editing = false;
+  function setEditing(on) {
+    editing = on;
+    show('prTitleDisplay', !on); show('prTitleInput', on);
+    show('prBody', !on); show('prBodyInput', on);
+    var eb = document.getElementById('cmdEdit');
+    if (eb) eb.textContent = on ? 'Done' : 'Edit';
+    if (!on) {
+      var t = document.getElementById('prTitleInput'), d = document.getElementById('prTitleDisplay');
+      if (t && d) d.textContent = t.value;
+      var b = document.getElementById('prBodyInput'), body = document.getElementById('prBody');
+      if (b && body) body.innerHTML = renderMarkdown(b.value);
+    }
+  }
+
+  function showToast(text) {
+    var el = document.getElementById('prToast');
+    if (!el) return;
+    el.textContent = text;
+    el.classList.add('show');
+    setTimeout(function () { el.classList.remove('show'); }, 2200);
+  }
+
+  // Create/Update always submits the (possibly edited) title + body inputs so the
+  // read-only path and the edited path share one code path.
   var createBtn = document.getElementById('cmdCreatePr');
-  if (createBtn) createBtn.addEventListener('click', function () { submit({ command: 'createPr' }); });
-  var editBtn = document.getElementById('cmdEdit');
-  if (editBtn) editBtn.addEventListener('click', function () {
-    var f = document.getElementById('editForm'); if (f) f.classList.toggle('hidden');
-  });
-  var copyBtn = document.getElementById('cmdCopyBody');
-  if (copyBtn) copyBtn.addEventListener('click', function () { jmSend({ command: 'copyBody' }); });
-  var editedBtn = document.getElementById('cmdCreateEdited');
-  if (editedBtn) editedBtn.addEventListener('click', function () {
+  if (createBtn) createBtn.addEventListener('click', function () {
     var t = document.getElementById('prTitleInput');
     var b = document.getElementById('prBodyInput');
     submit({ command: 'createPr', title: t ? t.value : undefined, body: b ? b.value : undefined });
   });
+  var editBtn = document.getElementById('cmdEdit');
+  if (editBtn) editBtn.addEventListener('click', function () { setEditing(!editing); });
+  var copyBtn = document.getElementById('cmdCopyBody');
+  if (copyBtn) copyBtn.addEventListener('click', function () { jmSend({ command: 'copyBody' }); });
 
   document.querySelectorAll('.row[data-hash]').forEach(function (r) {
     r.addEventListener('click', function () { jmSend({ command: 'openMemory', hash: r.getAttribute('data-hash') }); });
@@ -124,6 +146,7 @@ object CreatePrScriptBuilder {
       case 'prProgress': setStatus(msg.text || ''); break;
       case 'prCreated': setInFlight(false); setStatus(msg.text || ''); break;
       case 'prCreateError': setInFlight(false); setStatus(msg.text || ''); break;
+      case 'bodyCopied': showToast(msg.text || 'Copied PR body to clipboard'); break;
     }
   });
 """

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/WorkingMemoryHtmlBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/WorkingMemoryHtmlBuilder.kt
@@ -1,20 +1,54 @@
 package ai.jolli.jollimemory.toolwindow.views
 
+import ai.jolli.jollimemory.toolwindow.CommitMemoryFormat
+
 /**
  * Renders the "Working Memory" review web view — the full memory the next commit
  * will save. Mirrors the mockup's `pane-working` and reuses [SummaryCssBuilder]
  * for theme tokens so it matches the Memory Summary / PR webviews.
  *
- * Read-only/presentational: it shows what's included, plus a Commit Memory button
- * that bridges back to the IDE to run the AI commit.
+ * Interactive: each conversation / context row carries a ✕ (leave out) / + (add
+ * back) toggle that flips its commit-selection exclusion in place, and a token
+ * meter shows the AI usage captured by the included conversations. A Commit
+ * Memory button bridges back to the IDE to run the AI commit.
  */
 object WorkingMemoryHtmlBuilder {
 
-    /** A conversation feeding the next memory. */
-    data class WmConversation(val source: String, val title: String, val messageCount: Int)
+    /** Aggregate AI token usage captured by the included conversations. */
+    data class WmTokens(
+        val total: Long,
+        val input: Long,
+        val output: Long,
+        val cacheRead: Long,
+        val cacheWrite: Long,
+        /** Some included sources didn't report usage — the total understates reality. */
+        val partial: Boolean,
+    )
 
-    /** A linked context item (plan / note / reference / snippet). `tag` is the kb glyph. */
-    data class WmContext(val tag: String, val title: String)
+    /**
+     * A conversation feeding the next memory. [key] is the commit-selection key
+     * (`conversationKey`); [excluded] reflects whether the user has left it out.
+     */
+    data class WmConversation(
+        val source: String,
+        val title: String,
+        val messageCount: Int,
+        val key: String,
+        val excluded: Boolean,
+    )
+
+    /**
+     * A linked context item (plan / note / reference). `tag` is the kb glyph;
+     * [kind] is the commit-selection kind (`plans` / `notes` / `references`) and
+     * [key] its selection key (slug / id / mapKey).
+     */
+    data class WmContext(
+        val tag: String,
+        val title: String,
+        val kind: String,
+        val key: String,
+        val excluded: Boolean,
+    )
 
     /** A changed file that will be committed. */
     data class WmFile(val name: String, val dir: String, val status: String)
@@ -32,7 +66,8 @@ object WorkingMemoryHtmlBuilder {
          * useful signal — the view then shows an explanatory placeholder.
          */
         val proposedTitle: String?,
-        val tokenLabel: String,
+        /** AI usage captured by the included conversations; null when none reported. */
+        val token: WmTokens?,
         val conversations: List<WmConversation>,
         val context: List<WmContext>,
         val files: List<WmFile>,
@@ -53,10 +88,10 @@ object WorkingMemoryHtmlBuilder {
                 <h1 class="wm-title">Working Memory</h1>
                 ${metaStrip(view)}
                 <p class="wm-intro">The full memory your next commit will save — your final review.
-                Everything here is included. Nothing is committed until you choose
-                <b>Commit Memory</b> below.</p>
+                Everything here is included; leave an item out with <b>✕</b> or add it back with <b>+</b>.
+                Nothing is committed until you choose <b>Commit Memory</b> below.</p>
                 ${proposedTitle(view)}
-                ${tokenMeter(view)}
+                ${tokenMeter(view.token)}
                 ${conversationsPanel(view, isDark)}
                 ${contextPanel(view)}
                 ${filesPanel(view)}
@@ -73,6 +108,17 @@ object WorkingMemoryHtmlBuilder {
                 function __wmCommit() {
                   if (window.__jbQuery) window.__jbQuery(JSON.stringify({ command: 'commitMemory' }));
                 }
+                function __wmToggle(kind, key, excluded) {
+                  if (window.__jbQuery) window.__jbQuery(JSON.stringify({ command: 'toggleExclude', kind: kind, key: key, excluded: excluded }));
+                }
+                document.querySelectorAll('.wm-excl').forEach(function (btn) {
+                  btn.addEventListener('click', function (e) {
+                    e.stopPropagation();
+                    // data-excluded holds the CURRENT state; clicking flips it.
+                    var nowExcluded = btn.getAttribute('data-excluded') !== 'true';
+                    __wmToggle(btn.getAttribute('data-kind'), btn.getAttribute('data-key'), nowExcluded);
+                  });
+                });
               </script>
             </body>
             </html>
@@ -96,7 +142,6 @@ object WorkingMemoryHtmlBuilder {
         val ticket = v.detectedTicket?.let {
             "<span>Detected&nbsp;ticket&nbsp;<b>${esc(it)}</b></span>"
         } ?: ""
-        // A heuristic preview when we have one; otherwise the honest "written at commit" note.
         val titleHtml = if (v.proposedTitle != null) {
             "<div class=\"wm-title-text\">${esc(v.proposedTitle)}</div>" +
                 "<div class=\"wm-title-note\">Preview — the AI writes the final message when you commit.</div>"
@@ -115,15 +160,53 @@ object WorkingMemoryHtmlBuilder {
         """.trimIndent()
     }
 
-    private fun tokenMeter(v: WorkingMemoryView): String {
+    /**
+     * Token usage meter: a segmented input/output/cache bar + legend when usage was
+     * reported, or an honest "recorded at commit" note when it wasn't (live sessions
+     * from sources that don't emit per-message usage). Mirrors the mockup's `.tmeter`.
+     */
+    private fun tokenMeter(t: WmTokens?): String {
+        if (t == null || t.total <= 0) {
+            return """
+                <div class="wm-tmeter wm-tmeter-na">
+                  <div class="wm-tmeter-head">
+                    <span class="wm-tmeter-total">Token usage is recorded when you commit</span>
+                  </div>
+                </div>
+            """.trimIndent()
+        }
+        val cache = t.cacheRead + t.cacheWrite
+        fun pct(n: Long): Int = if (t.total <= 0) 0 else Math.round(n * 100.0 / t.total).toInt()
+        val partialNote = if (t.partial) """<span class="wm-tmeter-sub">· partial (some sources don't report)</span>""" else ""
+        val tip = "${CommitMemoryFormat.formatTokens(t.input)} input · ${CommitMemoryFormat.formatTokens(t.output)} output · " +
+            "${CommitMemoryFormat.formatTokens(t.cacheRead)} cache read · ${CommitMemoryFormat.formatTokens(t.cacheWrite)} cache write"
         return """
             <div class="wm-tmeter">
               <div class="wm-tmeter-head">
-                <span class="wm-tmeter-total">${esc(v.tokenLabel)}</span>
+                <span class="wm-tmeter-total">${CommitMemoryFormat.formatTokens(t.total)} tokens</span>
                 <span class="wm-tmeter-sub">· captured by this memory</span>
+                $partialNote
+              </div>
+              <div class="wm-tmeter-bar" title="${esc(tip)}">
+                <span class="wm-seg-in" style="width:${pct(t.input)}%"></span>
+                <span class="wm-seg-out" style="width:${pct(t.output)}%"></span>
+                <span class="wm-seg-cache" style="width:${pct(cache)}%"></span>
+              </div>
+              <div class="wm-tmeter-legend">
+                <span><i class="wm-lg-dot wm-seg-in"></i>${CommitMemoryFormat.formatTokens(t.input)} input</span>
+                <span><i class="wm-lg-dot wm-seg-out"></i>${CommitMemoryFormat.formatTokens(t.output)} output</span>
+                <span><i class="wm-lg-dot wm-seg-cache"></i>${CommitMemoryFormat.formatTokens(cache)} cached</span>
               </div>
             </div>
         """.trimIndent()
+    }
+
+    /** ✕ (leave out) / + (add back) toggle appended to a row. */
+    private fun exclBtn(kind: String, key: String, excluded: Boolean): String {
+        val glyph = if (excluded) "+" else "✕"
+        val title = if (excluded) "Add back to this memory" else "Leave out of this memory"
+        return """<button class="wm-excl" data-kind="${esc(kind)}" data-key="${esc(key)}" """ +
+            """data-excluded="$excluded" title="$title" aria-label="$title">$glyph</button>"""
     }
 
     private fun conversationsPanel(v: WorkingMemoryView, isDark: Boolean): String {
@@ -133,10 +216,11 @@ object WorkingMemoryHtmlBuilder {
             v.conversations.joinToString("") { c ->
                 val meta = if (c.messageCount > 0) "${c.messageCount} msg${if (c.messageCount != 1) "s" else ""}" else ""
                 """
-                <div class="wm-row">
+                <div class="wm-row${if (c.excluded) " wm-excluded" else ""}">
                   <span class="wm-logo" title="${esc(sourceLabel(c.source))}">${sourceIconSvg(c.source, isDark)}</span>
                   <div class="wm-rmain"><div class="wm-rtitle">${esc(c.title)}</div></div>
                   <span class="wm-rmeta">$meta</span>
+                  ${exclBtn("conversations", c.key, c.excluded)}
                 </div>
                 """.trimIndent()
             }
@@ -144,11 +228,6 @@ object WorkingMemoryHtmlBuilder {
         return panel("Conversations", v.conversations.size, rows)
     }
 
-    /**
-     * Inlines the per-tool logo SVG (the same `source-*.svg` icons the sidebar
-     * uses) so it renders inside the JCEF page. Picks the `_dark` variant in dark
-     * themes when one exists; falls back to the source initial on a miss.
-     */
     private fun sourceIconSvg(source: String, isDark: Boolean): String {
         val name = if (source == "copilot-chat") "copilot" else source
         val base = "/icons/source-$name"
@@ -166,9 +245,10 @@ object WorkingMemoryHtmlBuilder {
         } else {
             v.context.joinToString("") { c ->
                 """
-                <div class="wm-row">
+                <div class="wm-row${if (c.excluded) " wm-excluded" else ""}">
                   <span class="wm-kbtag">${esc(c.tag)}</span>
                   <div class="wm-rmain"><div class="wm-rtitle">${esc(c.title)}</div></div>
+                  ${exclBtn(c.kind, c.key, c.excluded)}
                 </div>
                 """.trimIndent()
             }
@@ -213,7 +293,6 @@ object WorkingMemoryHtmlBuilder {
         else -> source.replaceFirstChar { it.uppercase() }
     }
 
-    /** Small database glyph for the Local-first note; inherits the note's color. */
     private const val DB_ICON =
         "<svg class=\"wm-db\" viewBox=\"0 0 16 16\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.3\">" +
             "<ellipse cx=\"8\" cy=\"3.5\" rx=\"5\" ry=\"2\"/>" +
@@ -223,7 +302,6 @@ object WorkingMemoryHtmlBuilder {
     private fun esc(s: String): String = s
         .replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;")
 
-    /** Working-memory-specific styling layered on top of the shared summary theme. */
     private fun extraCss(): String = """
         .wm { padding: 14px 16px 22px; }
         .wm-title { font-size: 19px; margin: 0 0 8px; color: var(--text-primary); }
@@ -240,9 +318,20 @@ object WorkingMemoryHtmlBuilder {
         .wm-title-note { font-size: 11px; color: var(--text-tertiary); margin-bottom: 8px; }
         .wm-grid { display: flex; flex-wrap: wrap; gap: 4px 18px; font-size: 11.5px; color: var(--text-secondary); }
         .wm-grid b { color: var(--text-primary); font-weight: 600; }
-        .wm-tmeter { margin: 0 0 12px; }
-        .wm-tmeter-total { font-weight: 700; color: var(--text-primary); }
-        .wm-tmeter-sub { color: var(--text-tertiary); font-size: 11.5px; margin-left: 4px; }
+        /* ── Token meter ── */
+        .wm-tmeter { margin: 2px 0 14px; }
+        .wm-tmeter-head { font-size: 12.5px; color: var(--text-secondary); display: flex; align-items: baseline; gap: 7px; flex-wrap: wrap; }
+        .wm-tmeter-total { font-size: 15px; font-weight: 700; color: var(--text-primary); font-variant-numeric: tabular-nums; }
+        .wm-tmeter-sub { color: var(--text-tertiary); font-size: 11px; }
+        .wm-tmeter-na .wm-tmeter-total { font-size: 12.5px; font-weight: 400; font-style: italic; color: var(--text-tertiary); }
+        .wm-tmeter-bar { display: flex; height: 8px; border-radius: 4px; overflow: hidden; margin: 8px 2px; max-width: 380px; background: rgba(128,128,128,0.16); }
+        .wm-tmeter-bar > span { display: block; height: 100%; }
+        .wm-seg-in { background: var(--stat-add); }
+        .wm-seg-out { background: var(--link-fg); }
+        .wm-seg-cache { background: rgba(128,128,128,0.55); }
+        .wm-tmeter-legend { display: flex; flex-wrap: wrap; gap: 13px; font-size: 10.5px; color: var(--text-secondary); }
+        .wm-tmeter-legend span { display: inline-flex; align-items: center; gap: 5px; font-variant-numeric: tabular-nums; }
+        .wm-lg-dot { width: 8px; height: 8px; border-radius: 2px; flex-shrink: 0; display: inline-block; }
         .wm-panel-head { display: flex; align-items: center; margin-bottom: 6px; }
         .wm-panel-title { font-weight: 600; color: var(--text-primary); font-size: 12.5px; }
         .wm-count { margin-left: auto; color: var(--text-tertiary); font-size: 11.5px; }
@@ -261,6 +350,12 @@ object WorkingMemoryHtmlBuilder {
         .wm-gs-A { color: var(--stat-add); }
         .wm-gs-D { color: var(--stat-del); }
         .wm-fname { font-family: ui-monospace, monospace; }
+        /* ── Remove / add toggle ── */
+        .wm-excl { flex-shrink: 0; width: 20px; height: 20px; padding: 0; display: inline-flex; align-items: center; justify-content: center; background: none; border: none; border-radius: 4px; cursor: pointer; color: var(--text-secondary); font-size: 14px; font-weight: 600; line-height: 1; }
+        .wm-excl:hover { background: var(--surface-hover); color: var(--text-primary); }
+        .wm-excluded { opacity: 0.6; }
+        .wm-excluded .wm-rtitle { text-decoration: line-through; }
+        .wm-excluded .wm-excl { color: var(--link-fg); }
         .wm-privacy { display: flex; gap: 6px; align-items: flex-start; font-size: 11.5px; color: var(--text-secondary); margin: 10px 0 6px; }
         .wm-ccnote { font-size: 11.5px; color: var(--text-secondary); line-height: 1.5; margin: 0 0 8px; }
         .wm-localfirst { display: flex; align-items: center; gap: 6px; font-size: 11px; color: var(--ship-ok); margin: 0 0 10px; }

--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -59,6 +59,10 @@
         <fileEditorProvider
             implementation="ai.jolli.jollimemory.toolwindow.WorkingMemoryEditorProvider"/>
 
+        <!-- Editor tab provider for the dedicated Create PR webview -->
+        <fileEditorProvider
+            implementation="ai.jolli.jollimemory.toolwindow.CreatePrEditorProvider"/>
+
         <!-- Notification group for balloon notifications (e.g., no-Git warning) -->
         <notificationGroup
             id="JolliMemory"

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliShareServiceTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliShareServiceTest.kt
@@ -1,0 +1,99 @@
+package ai.jolli.jollimemory.services
+
+import ai.jolli.jollimemory.bridge.GitRemoteUtils
+import ai.jolli.jollimemory.core.CommitSummary
+import ai.jolli.jollimemory.core.SummaryStore
+import ai.jolli.jollimemory.core.telemetry.Telemetry
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class JolliShareServiceTest {
+
+    private lateinit var store: SummaryStore
+    private val baseUrl = "https://acme.jolli.ai"
+    private val apiKey = "sk-jol-test"
+
+    private fun summary(orphaned: List<Int>? = null) = CommitSummary(
+        commitHash = "abc12345", commitMessage = "feat: change", commitAuthor = "Dev",
+        commitDate = "t", branch = "feature/x", generatedAt = "t",
+        jolliDocId = null, orphanedDocIds = orphaned,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        store = mockk(relaxed = true)
+        every { store.readPlanFromBranch(any()) } returns null // no plans in these cases
+
+        mockkObject(JolliApiClient)
+        mockkObject(GitRemoteUtils)
+        mockkObject(Telemetry)
+        every { GitRemoteUtils.getCanonicalRepoUrl(any()) } returns "https://github.com/o/r"
+        every { GitRemoteUtils.sanitizeBranchSlug(any()) } returns "feature-x"
+        every { Telemetry.track(any(), any()) } returns Unit
+        every { Telemetry.bucket(any()) } returns "0"
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `pushes the summary and writes the jolli doc url back`() {
+        every { JolliApiClient.pushToJolli(any(), any(), any()) } returns
+            JolliApiClient.JolliPushResult(url = "ignored", docId = 99, jrn = "jrn:1", created = true)
+
+        val res = JolliShareService.shareSummary(store, summary(), "/repo", apiKey, baseUrl)
+
+        res.created shouldBe true
+        res.planCount shouldBe 0
+        res.updatedSummary.jolliDocId shouldBe 99
+        res.updatedSummary.jolliDocUrl shouldBe "$baseUrl/articles?doc=99"
+        // The updated summary is persisted.
+        verify { store.storeSummary(match { it.jolliDocId == 99 }, force = true) }
+    }
+
+    @Test
+    fun `deletes orphaned docs and clears them from the stored summary`() {
+        every { JolliApiClient.pushToJolli(any(), any(), any()) } returns
+            JolliApiClient.JolliPushResult(url = "ignored", docId = 5, jrn = "jrn:2", created = false)
+        every { JolliApiClient.deleteFromJolli(any(), any(), any()) } returns Unit
+
+        val res = JolliShareService.shareSummary(store, summary(orphaned = listOf(7)), "/repo", apiKey, baseUrl)
+
+        verify { JolliApiClient.deleteFromJolli(baseUrl, apiKey, 7) }
+        res.updatedSummary.orphanedDocIds shouldBe null
+    }
+
+    @Test
+    fun `propagates a binding-required error to the caller`() {
+        every { JolliApiClient.pushToJolli(any(), any(), any()) } throws
+            JolliApiClient.BindingRequiredError(repoUrl = "https://github.com/o/r")
+
+        val threw = try {
+            JolliShareService.shareSummary(store, summary(), "/repo", apiKey, baseUrl)
+            false
+        } catch (_: JolliApiClient.BindingRequiredError) {
+            true
+        }
+        threw shouldBe true
+    }
+
+    @Test
+    fun `sends the summary docType payload for a summary push`() {
+        val payloadSlot = slot<JolliApiClient.JolliPushPayload>()
+        every { JolliApiClient.pushToJolli(any(), any(), capture(payloadSlot)) } returns
+            JolliApiClient.JolliPushResult(url = "ignored", docId = 1, jrn = "jrn", created = true)
+
+        JolliShareService.shareSummary(store, summary(), "/repo", apiKey, baseUrl)
+
+        payloadSlot.captured.docType shouldBe "summary"
+        payloadSlot.captured.commitHash shouldBe "abc12345"
+    }
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrDataTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrDataTest.kt
@@ -1,0 +1,106 @@
+package ai.jolli.jollimemory.toolwindow.views
+
+import ai.jolli.jollimemory.core.CommitSummary
+import ai.jolli.jollimemory.core.E2eTestScenario
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class CreatePrDataTest {
+
+    private fun summary(hash: String, message: String, e2e: List<E2eTestScenario>? = null, jolliUrl: String? = null) =
+        CommitSummary(
+            commitHash = hash,
+            commitMessage = message,
+            commitAuthor = "Dev",
+            commitDate = "2026-01-01T00:00:00Z",
+            branch = "feature/x",
+            generatedAt = "2026-01-01T00:00:00Z",
+            e2eTestGuide = e2e,
+            jolliDocUrl = jolliUrl,
+        )
+
+    @Nested
+    inner class ParseNameStatus {
+        @Test
+        fun `parses modified, added, and rename rows with normalized status and dir`() {
+            val raw = "M\tsrc/app/A.kt\nA\tREADME.md\nR100\told/x.kt\tnew/y.kt\n"
+            val rows = CreatePrData.parseNameStatus(raw)
+            rows shouldHaveSize 3
+            rows[0] shouldBe CreatePrData.FileRow("src/app/A.kt", "src/app", "M")
+            rows[1] shouldBe CreatePrData.FileRow("README.md", "", "A")
+            // Rename → status "R", path is the NEW path.
+            rows[2] shouldBe CreatePrData.FileRow("new/y.kt", "new", "R")
+        }
+
+        @Test
+        fun `skips blank and malformed lines`() {
+            CreatePrData.parseNameStatus("\n   \nnotabs\n") shouldHaveSize 0
+        }
+    }
+
+    @Nested
+    inner class ParseNumstat {
+        @Test
+        fun `sums insertions and deletions, skipping binary rows`() {
+            val raw = "10\t2\tsrc/a.kt\n-\t-\tassets/logo.png\n5\t3\tb.kt"
+            CreatePrData.parseNumstat(raw) shouldBe (15 to 5)
+        }
+
+        @Test
+        fun `empty input yields zero`() {
+            CreatePrData.parseNumstat("") shouldBe (0 to 0)
+        }
+    }
+
+    @Nested
+    inner class Assemble {
+        @Test
+        fun `derives title, body, memories, files, and e2e from the anchor and inputs`() {
+            val e2e = listOf(E2eTestScenario(title = "Scenario A", steps = listOf("step 1"), expectedResults = listOf("ok")))
+            // newest-first: anchor is the first element.
+            val summaries = listOf(
+                summary("aaaaaaaa1111", "feat: newest change\n\nbody", e2e = e2e),
+                summary("bbbbbbbb2222", "fix: older change"),
+            )
+            val files = listOf(CreatePrData.FileRow("src/A.kt", "src", "M"))
+            val vm = CreatePrData.assemble(
+                branch = "feature/x",
+                mainBranch = "main",
+                summaries = summaries,
+                stats = CreatePrData.Stats(10, 2, 1),
+                files = files,
+                existingPr = null,
+                signedIn = true,
+            )
+
+            vm.title shouldBe "feat: newest change"
+            vm.memoryCount shouldBe 2
+            vm.insertions shouldBe 10
+            vm.deletions shouldBe 2
+            vm.filesChanged shouldBe 1
+            vm.files shouldBe files
+            vm.memories.map { it.hash } shouldContainExactly listOf("aaaaaaaa1111", "bbbbbbbb2222")
+            vm.memories[0].title shouldBe "feat: newest change"
+            vm.e2eScenarios shouldBe e2e
+            vm.existingPr shouldBe null
+            vm.signedIn shouldBe true
+            vm.includedSummaries shouldHaveSize 2
+        }
+
+        @Test
+        fun `carries existing PR when present`() {
+            val vm = CreatePrData.assemble(
+                "feature/x", "main",
+                listOf(summary("h1", "only change")),
+                CreatePrData.Stats(0, 0, 0), emptyList(),
+                existingPr = CreatePrData.ExistingPr(42, "https://github.com/o/r/pull/42"),
+                signedIn = false,
+            )
+            vm.existingPr shouldBe CreatePrData.ExistingPr(42, "https://github.com/o/r/pull/42")
+            vm.signedIn shouldBe false
+        }
+    }
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrHtmlBuilderTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrHtmlBuilderTest.kt
@@ -1,0 +1,95 @@
+package ai.jolli.jollimemory.toolwindow.views
+
+import ai.jolli.jollimemory.core.CommitSummary
+import ai.jolli.jollimemory.core.E2eTestScenario
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import org.junit.jupiter.api.Test
+
+class CreatePrHtmlBuilderTest {
+
+    private fun summary(hash: String, message: String) = CommitSummary(
+        commitHash = hash, commitMessage = message, commitAuthor = "Dev",
+        commitDate = "t", branch = "feature/x", generatedAt = "t",
+    )
+
+    private fun vm(
+        existingPr: CreatePrData.ExistingPr? = null,
+        signedIn: Boolean = true,
+        title: String = "feat: redesign",
+        e2e: List<E2eTestScenario> = emptyList(),
+    ) = CreatePrData.ViewModel(
+        branch = "feature/x",
+        mainBranch = "main",
+        memoryCount = 2,
+        insertions = 10,
+        deletions = 2,
+        filesChanged = 1,
+        title = title,
+        bodyMarkdown = "## Summary\n\nDid the thing.",
+        memories = listOf(
+            CreatePrData.MemoryRow("aaaaaaaa1111", "feat: redesign", jolliDocUrl = null),
+            CreatePrData.MemoryRow("bbbbbbbb2222", "fix: bug", jolliDocUrl = "https://x/articles?doc=1"),
+        ),
+        files = listOf(CreatePrData.FileRow("src/App.kt", "src", "M")),
+        e2eScenarios = e2e,
+        existingPr = existingPr,
+        signedIn = signedIn,
+        includedSummaries = listOf(summary("aaaaaaaa1111", "feat: redesign")),
+    )
+
+    @Test
+    fun `renders create mode with meta strip, memories, files, and body data`() {
+        val html = CreatePrHtmlBuilder.buildHtml(vm(), isDark = true, bridgeScript = "")
+        html shouldContain "Create Pull Request"
+        html shouldContain """id="cmdCreatePr">Create PR"""
+        html shouldContain """<span class="meta-branch">feature/x</span>"""
+        html shouldContain "drafted from 2 memories"
+        html shouldContain "+10 −2 · 1 file"
+        // memory + file rows
+        html shouldContain """data-hash="aaaaaaaa1111""""
+        html shouldContain """data-path="src/App.kt""""
+        html shouldContain """gs gs-M"""
+        // body markdown carried for client-side rendering (not raw <pre>)
+        html shouldContain """id="prBody""""
+        html shouldContain "## Summary"
+    }
+
+    @Test
+    fun `renders update mode with PR link when an open PR exists`() {
+        val html = CreatePrHtmlBuilder.buildHtml(
+            vm(existingPr = CreatePrData.ExistingPr(42, "https://github.com/o/r/pull/42")),
+            isDark = false, bridgeScript = "",
+        )
+        html shouldContain "Update Pull Request"
+        html shouldContain """id="cmdCreatePr">Update PR"""
+        html shouldContain "PR #42"
+        html shouldContain """data-pr-url="https://github.com/o/r/pull/42""""
+    }
+
+    @Test
+    fun `shows signed-in share copy when signed in, sign-in prompt otherwise`() {
+        CreatePrHtmlBuilder.buildHtml(vm(signedIn = true), true, "") shouldContain "also shares the included memories to Jolli"
+        val signedOut = CreatePrHtmlBuilder.buildHtml(vm(signedIn = false), true, "")
+        signedOut shouldContain "prSignInLink"
+        signedOut shouldContain "stays a normal git PR"
+    }
+
+    @Test
+    fun `renders E2E panel with scenario count when scenarios exist`() {
+        val html = CreatePrHtmlBuilder.buildHtml(
+            vm(e2e = listOf(E2eTestScenario(title = "S1", steps = listOf("do"), expectedResults = listOf("ok")))),
+            true, "",
+        )
+        html shouldContain "E2E Test Guide"
+        html shouldContain "1 SCENARIO"
+    }
+
+    @Test
+    fun `escapes HTML in the title to prevent injection`() {
+        val html = CreatePrHtmlBuilder.buildHtml(vm(title = "<img src=x onerror=alert(1)>"), true, "")
+        html shouldContain "&lt;img src=x onerror=alert(1)&gt;"
+        html shouldNotContain "<img src=x onerror=alert(1)>"
+    }
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrHtmlBuilderTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrHtmlBuilderTest.kt
@@ -87,6 +87,20 @@ class CreatePrHtmlBuilderTest {
     }
 
     @Test
+    fun `edits title and body in place — no separate edit form — and includes a copy toast`() {
+        val html = CreatePrHtmlBuilder.buildHtml(vm(), isDark = true, bridgeScript = "")
+        // Inline editors live inside the Title/Body panels (hidden until Edit).
+        html shouldContain """id="prTitleDisplay""""
+        html shouldContain """id="prTitleInput" class="pr-input hidden""""
+        html shouldContain """id="prBodyInput" class="pr-textarea hidden""""
+        // Toast target for the copy confirmation.
+        html shouldContain """id="prToast""""
+        // The old separate edit form is gone.
+        html shouldNotContain """id="editForm""""
+        html shouldNotContain "cmdCreateEdited"
+    }
+
+    @Test
     fun `escapes HTML in the title to prevent injection`() {
         val html = CreatePrHtmlBuilder.buildHtml(vm(title = "<img src=x onerror=alert(1)>"), true, "")
         html shouldContain "&lt;img src=x onerror=alert(1)&gt;"

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/WorkingMemoryHtmlBuilderTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/WorkingMemoryHtmlBuilderTest.kt
@@ -1,0 +1,112 @@
+package ai.jolli.jollimemory.toolwindow.views
+
+import ai.jolli.jollimemory.toolwindow.views.WorkingMemoryHtmlBuilder.WmContext
+import ai.jolli.jollimemory.toolwindow.views.WorkingMemoryHtmlBuilder.WmConversation
+import ai.jolli.jollimemory.toolwindow.views.WorkingMemoryHtmlBuilder.WmFile
+import ai.jolli.jollimemory.toolwindow.views.WorkingMemoryHtmlBuilder.WmTokens
+import ai.jolli.jollimemory.toolwindow.views.WorkingMemoryHtmlBuilder.WorkingMemoryView
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import org.junit.jupiter.api.Test
+
+class WorkingMemoryHtmlBuilderTest {
+
+    private fun view(
+        token: WmTokens? = null,
+        conversations: List<WmConversation> = emptyList(),
+        context: List<WmContext> = emptyList(),
+        files: List<WmFile> = emptyList(),
+    ) = WorkingMemoryView(
+        branch = "feature/x",
+        filesChanged = files.size,
+        insertions = 10,
+        deletions = 2,
+        detectedTicket = null,
+        proposedTitle = "feat: thing",
+        token = token,
+        conversations = conversations,
+        context = context,
+        files = files,
+    )
+
+    private fun build(v: WorkingMemoryView) = WorkingMemoryHtmlBuilder.buildHtml(v, isDark = true, bridgeScript = "")
+
+    @Test
+    fun `renders the token meter with total, segments and legend when usage is reported`() {
+        val html = build(view(token = WmTokens(total = 1_400_000, input = 96_000, output = 47_000, cacheRead = 1_200_000, cacheWrite = 61_000, partial = false)))
+        html shouldContain "1.4M tokens"
+        html shouldContain "captured by this memory"
+        html shouldContain "wm-tmeter-bar"
+        html shouldContain "wm-seg-in"
+        html shouldContain "wm-seg-out"
+        html shouldContain "wm-seg-cache"
+        // legend numbers (input / output / cached = read+write)
+        html shouldContain "96k input"
+        html shouldContain "47k output"
+        html shouldContain "1.3M cached"
+        // tooltip breaks cache into read + write
+        html shouldContain "cache read"
+        html shouldContain "cache write"
+        html shouldNotContain "recorded when you commit"
+    }
+
+    @Test
+    fun `shows the not-reported state when no usage is available`() {
+        val html = build(view(token = null))
+        html shouldContain "wm-tmeter-na"
+        html shouldContain "Token usage is recorded when you commit"
+        // No rendered meter head/bar element in the not-reported state (the CSS class
+        // definitions are always present in <style>, so assert on rendered content).
+        html shouldNotContain "captured by this memory"
+        html shouldNotContain """<div class="wm-tmeter-bar""""
+    }
+
+    @Test
+    fun `flags partial usage`() {
+        val html = build(view(token = WmTokens(1000, 600, 400, 0, 0, partial = true)))
+        html shouldContain "partial"
+    }
+
+    @Test
+    fun `included conversation shows leave-out toggle and excluded shows add-back with strikethrough`() {
+        val html = build(
+            view(
+                conversations = listOf(
+                    WmConversation("claude", "Kept convo", 7, key = "claude:s1", excluded = false),
+                    WmConversation("codex", "Dropped convo", 3, key = "codex:s2", excluded = true),
+                ),
+            ),
+        )
+        // Included → ✕ (leave out), data-excluded=false, kind=conversations
+        html shouldContain """data-kind="conversations" data-key="claude:s1" data-excluded="false""""
+        html shouldContain "Leave out of this memory"
+        // Excluded → + (add back), dimmed/strikethrough row
+        html shouldContain """data-kind="conversations" data-key="codex:s2" data-excluded="true""""
+        html shouldContain "Add back to this memory"
+        html shouldContain "wm-excluded"
+    }
+
+    @Test
+    fun `context rows carry the correct kind and key for plans, notes, and references`() {
+        val html = build(
+            view(
+                context = listOf(
+                    WmContext("P", "My plan", kind = "plans", key = "my-plan", excluded = false),
+                    WmContext("N", "My note", kind = "notes", key = "note-1", excluded = true),
+                    WmContext("L", "ENG-1", kind = "references", key = "linear:ENG-1", excluded = false),
+                ),
+            ),
+        )
+        html shouldContain """data-kind="plans" data-key="my-plan""""
+        html shouldContain """data-kind="notes" data-key="note-1""""
+        html shouldContain """data-kind="references" data-key="linear:ENG-1""""
+    }
+
+    @Test
+    fun `escapes HTML in titles`() {
+        val html = build(view(conversations = listOf(WmConversation("claude", "<img onerror=x>", 1, "claude:s", false))))
+        html shouldContain "&lt;img onerror=x&gt;"
+        html shouldNotContain "<img onerror=x>"
+    }
+}


### PR DESCRIPTION
## Summary

Redesigns two IntelliJ webviews to match the design mockup, and hardens a flaky CLI test. All work is IntelliJ-only except the test fix.

### Create PR view (new, dedicated)
- Clicking **Create pull request (PR)** now opens a dedicated, branch-level **Create PR** editor tab (JCEF) matching the mockup, instead of the old single-memory summary with an embedded PR form. It aggregates every committed memory on the branch: branch → main header with diff stats, drafted title, rendered-markdown body, memories included, E2E test guide, and changed files.
- **One-click Create PR + Share in Jolli**: on submit it creates/updates the PR via `PrService`, and — when a Jolli site key is configured — also shares the included memories to Jolli in the same action (reusing the existing push logic, extracted into `JolliShareService`; the standalone Share button behavior is unchanged). Signed-out shows a sign-in hint; the PR is a normal git PR either way.
- **Edit in place**: the Edit button toggles the Title/Body panels between read-only display and inline editors (no separate form). **Copy body** shows a transient toast on success.

### Working Memory review
- **Token meter**: replaces the hardcoded "N/A tokens" with a real usage meter (input / output / cached bar + legend + total, tooltip splitting cache read/write), aggregated from the included conversations' transcripts. Sources that don't report usage flag the total as partial; when none report, it shows an honest "recorded at commit" state.
- **Inline remove / add**: each conversation and context (plan / note / reference) row now has a ✕ (leave out) / + (add back) toggle backed by `CommitSelectionStore`; excluded items stay listed (dimmed, struck through) so they can be re-added. Unchecking a conversation drops its tokens from the meter.

### CLI test fix
- The two `compile command` tests in `Api.test.ts` left `buildKnowledgeGraph` (LLM-bearing) and `SearchIndex.rebuild` un-mocked, so they hung to the 45s timeout in sandboxes with no network. Mocked both — deterministic and network-free now, no product change.

## Test plan
- `./gradlew build` (IntelliJ): full suite + koverVerify green, including new `CreatePr*`, `JolliShareService`, and `WorkingMemoryHtmlBuilder` tests.
- `./gradlew verifyPlugin`: Compatible on IC-243 and IC-251.
- `npm run all` (CLI + VSCode): green.