### PR TITLE
Auto-configure global Jolli Memory skill-preference instructions

### DIFF
--- a/cli/src/install/GlobalInstructionsInstaller.test.ts
+++ b/cli/src/install/GlobalInstructionsInstaller.test.ts
@@ -1,0 +1,158 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockHomedir } = vi.hoisted(() => ({
+	mockHomedir: vi.fn().mockReturnValue(""),
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:os")>();
+	return { ...original, homedir: mockHomedir };
+});
+
+import {
+	applyInstructionsBlock,
+	installGlobalInstructions,
+	renderInstructionsBlock,
+} from "./GlobalInstructionsInstaller.js";
+
+const START = "<!-- >>> jolli memory instructions >>> -->";
+const END = "<!-- <<< jolli memory instructions <<< -->";
+
+describe("renderInstructionsBlock", () => {
+	it("wraps all three skill names in a marker block ending with a newline", () => {
+		const block = renderInstructionsBlock();
+		expect(block.startsWith(START)).toBe(true);
+		expect(block.endsWith(`${END}\n`)).toBe(true);
+		expect(block).toContain("jolli-pr");
+		expect(block).toContain("jolli-search");
+		expect(block).toContain("jolli-recall");
+	});
+});
+
+describe("applyInstructionsBlock", () => {
+	const block = renderInstructionsBlock();
+
+	it("returns the block alone for empty input", () => {
+		expect(applyInstructionsBlock("", block)).toBe(block);
+	});
+
+	it("appends the block after existing content with exactly one separating newline", () => {
+		const result = applyInstructionsBlock("# My notes\n", block);
+		expect(result).toBe(`# My notes\n${block}`);
+	});
+
+	it("adds a separating newline when existing content has no trailing newline", () => {
+		const result = applyInstructionsBlock("# My notes", block);
+		expect(result).toBe(`# My notes\n${block}`);
+	});
+
+	it("replaces an existing block in place, preserving surrounding content", () => {
+		const stale = [START, "## Stale", END].join("\n");
+		const existing = `# Top\n${stale}\n# Bottom\n`;
+		const result = applyInstructionsBlock(existing, block);
+		expect(result).toContain("# Top");
+		expect(result).toContain("# Bottom");
+		expect(result).toContain("jolli-recall");
+		expect(result).not.toContain("## Stale");
+	});
+
+	it("is idempotent — applying twice changes nothing", () => {
+		const once = applyInstructionsBlock("# Top\n", block);
+		expect(applyInstructionsBlock(once, block)).toBe(once);
+	});
+
+	it("ignores a marker-like substring that is not on its own line", () => {
+		const prose = `Here is a mention of ${START} inside a sentence.\n`;
+		const result = applyInstructionsBlock(prose, block);
+		// No exact-line marker → block is appended, prose left intact.
+		expect(result).toBe(`${prose}${block}`);
+	});
+
+	it("adopts an unmarked hand-pasted section instead of appending a duplicate", () => {
+		const existing = "## Jolli Memory\n\nOld hand-written text.\n";
+		const result = applyInstructionsBlock(existing, block);
+		// Whole file was the section → replaced wholesale by the marked block.
+		expect(result).toBe(block);
+		expect(result).not.toContain("Old hand-written text.");
+		// Exactly one heading — no duplicate.
+		expect(result.split(START).length - 1).toBe(1);
+	});
+
+	it("adopts an unmarked section while preserving content before and after it", () => {
+		const existing = "# Top\n\n## Jolli Memory\nold intro\n\n# Bottom\n";
+		const result = applyInstructionsBlock(existing, block);
+		expect(result).toBe(`# Top\n\n${block}# Bottom\n`);
+		expect(result).toContain("jolli-recall");
+		expect(result).not.toContain("old intro");
+		expect(result.split(START).length - 1).toBe(1);
+	});
+
+	it("keeps `###` subsections inside the adopted section, stops at the next `#`/`##`", () => {
+		const existing = "## Jolli Memory\nintro\n### Details\nmore\n# Next\ntail\n";
+		const result = applyInstructionsBlock(existing, block);
+		expect(result).toBe(`${block}# Next\ntail\n`);
+		expect(result).not.toContain("### Details");
+		expect(result).toContain("# Next");
+	});
+
+	it("is idempotent after adopting an unmarked section", () => {
+		const once = applyInstructionsBlock("## Jolli Memory\nold\n", block);
+		expect(applyInstructionsBlock(once, block)).toBe(once);
+	});
+});
+
+describe("installGlobalInstructions", () => {
+	let home: string;
+
+	beforeEach(async () => {
+		home = await mkdtemp(join(tmpdir(), "jolli-global-instr-"));
+		mockHomedir.mockReturnValue(home);
+	});
+
+	afterEach(async () => {
+		await rm(home, { recursive: true, force: true });
+	});
+
+	it("creates all enabled hosts' global instruction files", async () => {
+		await installGlobalInstructions({ claude: true, gemini: true, codex: true });
+
+		const claude = await readFile(join(home, ".claude", "CLAUDE.md"), "utf-8");
+		const gemini = await readFile(join(home, ".gemini", "GEMINI.md"), "utf-8");
+		const codex = await readFile(join(home, ".codex", "AGENTS.md"), "utf-8");
+		for (const content of [claude, gemini, codex]) {
+			expect(content).toContain(START);
+			expect(content).toContain("jolli-pr");
+		}
+	});
+
+	it("does not create a file for a disabled host", async () => {
+		await installGlobalInstructions({ claude: true, gemini: false, codex: false });
+
+		expect(await readFile(join(home, ".claude", "CLAUDE.md"), "utf-8")).toContain("jolli-pr");
+		await expect(readFile(join(home, ".gemini", "GEMINI.md"), "utf-8")).rejects.toThrow();
+		await expect(readFile(join(home, ".codex", "AGENTS.md"), "utf-8")).rejects.toThrow();
+	});
+
+	it("preserves pre-existing user content outside the block", async () => {
+		await mkdir(join(home, ".claude"), { recursive: true });
+		await writeFile(join(home, ".claude", "CLAUDE.md"), "# My global rules\n\nBe concise.\n", "utf-8");
+
+		await installGlobalInstructions({ claude: true, gemini: false, codex: false });
+
+		const content = await readFile(join(home, ".claude", "CLAUDE.md"), "utf-8");
+		expect(content).toContain("# My global rules");
+		expect(content).toContain("Be concise.");
+		expect(content).toContain("jolli-recall");
+	});
+
+	it("is idempotent — a second run does not change the file", async () => {
+		await installGlobalInstructions({ claude: true, gemini: false, codex: false });
+		const first = await readFile(join(home, ".claude", "CLAUDE.md"), "utf-8");
+		await installGlobalInstructions({ claude: true, gemini: false, codex: false });
+		const second = await readFile(join(home, ".claude", "CLAUDE.md"), "utf-8");
+		expect(second).toBe(first);
+	});
+});

--- a/cli/src/install/GlobalInstructionsInstaller.ts
+++ b/cli/src/install/GlobalInstructionsInstaller.ts
@@ -1,0 +1,192 @@
+/**
+ * Writes Jolli Memory's "prefer these skills by default" standing instruction
+ * into each detected AI host's GLOBAL instruction file:
+ *
+ *   - Claude Code → ~/.claude/CLAUDE.md
+ *   - Gemini CLI  → ~/.gemini/GEMINI.md
+ *   - Codex       → ~/.codex/AGENTS.md
+ *
+ * The rule tells the host LLM to reach for the jolli-pr / jolli-search /
+ * jolli-recall skills by default for PR creation / search / recall, instead of
+ * leaving skill selection to chance.
+ *
+ * Managed-block strategy mirrors GitExclude.ts: a marker-bracketed section is
+ * upserted, everything outside the markers is preserved verbatim, and the whole
+ * operation is fail-soft — a broken or read-only global file never breaks
+ * `jolli enable`.
+ *
+ * These files are machine-GLOBAL (one per host, shared by every repo), so
+ * `jolli uninstall` deliberately does NOT remove the block — the same policy as
+ * global-scope MCP registration.
+ *
+ * A global `AGENTS.md` is only read by Codex; Cursor / OpenCode / Copilot read
+ * AGENTS.md at the project root, so they are intentionally out of reach here.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { createLogger } from "../Logger.js";
+
+const log = createLogger("GlobalInstructionsInstaller");
+
+/**
+ * Marker pair bracketing Jolli's managed block. Lines between the markers
+ * belong to Jolli and may be rewritten on future installs; anything outside is
+ * untouched. HTML comments so the block is invisible when the markdown renders.
+ */
+const BLOCK_START = "<!-- >>> jolli memory instructions >>> -->";
+const BLOCK_END = "<!-- <<< jolli memory instructions <<< -->";
+
+/**
+ * Markdown heading Jolli's block leads with. Also used to detect a pre-existing
+ * *unmarked* section a user added by hand (older docs told people to paste this
+ * section manually) so we adopt it in place instead of appending a duplicate.
+ */
+const MANAGED_HEADING = "## Jolli Memory";
+
+/** Which hosts to write the global instruction file for (per-host gated). */
+export interface InstructionHosts {
+	readonly claude: boolean;
+	readonly gemini: boolean;
+	readonly codex: boolean;
+}
+
+interface InstructionTarget {
+	readonly host: keyof InstructionHosts;
+	/** Path segments relative to the user's home dir. */
+	readonly relPath: ReadonlyArray<string>;
+}
+
+const TARGETS: ReadonlyArray<InstructionTarget> = [
+	{ host: "claude", relPath: [".claude", "CLAUDE.md"] },
+	{ host: "gemini", relPath: [".gemini", "GEMINI.md"] },
+	{ host: "codex", relPath: [".codex", "AGENTS.md"] },
+];
+
+/**
+ * Renders the managed block including marker lines and a trailing newline.
+ * Joined with `\n` (not the platform EOL) so the file reads identically for a
+ * team sharing dotfiles across OSes.
+ */
+export function renderInstructionsBlock(): string {
+	const lines = [
+		BLOCK_START,
+		MANAGED_HEADING,
+		"",
+		"When Jolli Memory is enabled in a repository, prefer its skills by default:",
+		"",
+		"- **Creating a pull request** → use the `jolli-pr` skill (its description comes",
+		"  from Jolli Memory's recorded commit history), unless the user explicitly asks",
+		"  for another method.",
+		"- **Searching prior work, decisions, or related commits** → use the",
+		"  `jolli-search` skill.",
+		"- **Recalling or resuming prior context on a branch** → use the `jolli-recall`",
+		"  skill.",
+		"",
+		"If a skill is not available (Jolli Memory is not enabled in that repository),",
+		"fall back to normal behavior.",
+		BLOCK_END,
+	];
+	return `${lines.join("\n")}\n`;
+}
+
+/**
+ * Upserts the managed block into `existing`, preserving all other content
+ * verbatim. Resolution order:
+ *
+ *   1. A marker-bracketed block → replaced in place (line-oriented match, so a
+ *      stray marker substring inside prose never confuses the parser; the first
+ *      matching pair wins).
+ *   2. Otherwise, an *unmarked* `## Jolli Memory` section a user pasted by hand
+ *      → adopted: that whole section (heading up to the next `#`/`##` heading or
+ *      EOF) is replaced with the marked block, so we never append a duplicate.
+ *   3. Otherwise → the block is appended.
+ */
+export function applyInstructionsBlock(existing: string, block: string): string {
+	const lines = existing.split("\n");
+	const startIdx = lines.indexOf(BLOCK_START);
+	const endIdx = lines.indexOf(BLOCK_END);
+
+	// `renderInstructionsBlock` always appends a trailing `\n`; strip it before
+	// splitting so the spliced lines don't carry an empty trailing element.
+	const newBlockLines = block.slice(0, -1).split("\n");
+
+	if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+		const next = [...lines.slice(0, startIdx), ...newBlockLines, ...lines.slice(endIdx + 1)];
+		return next.join("\n");
+	}
+
+	// Adopt an unmarked, hand-pasted section rather than appending a second copy.
+	const headingIdx = lines.indexOf(MANAGED_HEADING);
+	if (headingIdx !== -1) {
+		// Section runs to the next same-or-higher-level heading (`#`/`##`) or EOF.
+		// `###`+ subsections stay inside the section (they don't match).
+		let sectionEnd = lines.length;
+		for (let i = headingIdx + 1; i < lines.length; i++) {
+			if (/^#{1,2} /.test(lines[i])) {
+				sectionEnd = i;
+				break;
+			}
+		}
+		const before = lines.slice(0, headingIdx).join("\n");
+		const after = lines.slice(sectionEnd).join("\n");
+		// `block` already carries its trailing newline; only add a separator on a
+		// side that actually has content.
+		return `${before.length > 0 ? `${before}\n` : ""}${block}${after}`;
+	}
+
+	if (existing.length === 0) {
+		return block;
+	}
+	const sep = existing.endsWith("\n") ? "" : "\n";
+	return `${existing}${sep}${block}`;
+}
+
+/**
+ * Upserts the managed block into a single absolute file path. Fail-soft: logs
+ * and returns on any read/write error rather than throwing.
+ */
+async function upsertTarget(absPath: string, block: string): Promise<void> {
+	let existing = "";
+	try {
+		existing = await readFile(absPath, "utf-8");
+	} catch (err: unknown) {
+		const code = (err as NodeJS.ErrnoException).code;
+		/* v8 ignore start -- defensive: non-ENOENT read errors (perm denied, EISDIR) */
+		if (code !== "ENOENT") {
+			log.warn("Failed to read %s: %s — skipping", absPath, (err as Error).message);
+			return;
+		}
+		/* v8 ignore stop */
+	}
+
+	const updated = applyInstructionsBlock(existing, block);
+	if (updated === existing) {
+		return; // No change needed.
+	}
+
+	try {
+		await mkdir(dirname(absPath), { recursive: true });
+		await writeFile(absPath, updated, "utf-8");
+		log.info("Updated %s with Jolli Memory instructions", absPath);
+		/* v8 ignore start -- defensive: write failure on read-only fs / EPERM */
+	} catch (err: unknown) {
+		log.warn("Failed to write %s: %s", absPath, (err as Error).message);
+	}
+	/* v8 ignore stop */
+}
+
+/**
+ * Writes the Jolli Memory instruction block into the global instruction file of
+ * every host whose flag is `true`. Called once from `Installer.install()`,
+ * outside the per-worktree loop, because these files are machine-global.
+ */
+export async function installGlobalInstructions(hosts: InstructionHosts): Promise<void> {
+	const block = renderInstructionsBlock();
+	const home = homedir();
+	for (const target of TARGETS) {
+		if (!hosts[target.host]) continue;
+		await upsertTarget(join(home, ...target.relPath), block);
+	}
+}

--- a/cli/src/install/Installer.ts
+++ b/cli/src/install/Installer.ts
@@ -80,6 +80,7 @@ import {
 	removePostRewriteHook,
 	removePrepareMsgHook,
 } from "./GitHookInstaller.js";
+import { installGlobalInstructions } from "./GlobalInstructionsInstaller.js";
 import type { HookOpResult } from "./HookSettingsHelper.js";
 import {
 	buildRegistrars,
@@ -285,6 +286,21 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 			opencode: opencodeDetectedOnce,
 			copilot: copilotDetectedOnce,
 			copilotChat: copilotChatDetectedOnce,
+		});
+
+		// Prefer Jolli's skills by default: write a standing rule into each
+		// enabled host's GLOBAL instruction file. Machine-global (one per host,
+		// shared by every repo) — mirrors registerGlobalMcpHosts above, and like
+		// it, uninstall deliberately leaves the block in place. Gating matches the
+		// hooks: gemini/codex are detection-gated (never create their file on a
+		// machine without them), while Claude has no filesystem detector and is
+		// gated only on `claudeEnabled` — so `~/.claude/CLAUDE.md` is created
+		// whenever Claude isn't explicitly disabled, consistent with the rest of
+		// the installer treating Claude as the primary host.
+		await installGlobalInstructions({
+			claude: config.claudeEnabled !== false,
+			gemini: geminiDetectedOnce && config.geminiEnabled !== false,
+			codex: codexDetectedOnce && config.codexEnabled !== false,
 		});
 
 		// Git hooks are shared across all worktrees — install once

--- a/docs/superpowers/plans/2026-07-02-global-skill-preference-instructions.md
+++ b/docs/superpowers/plans/2026-07-02-global-skill-preference-instructions.md
@@ -1,0 +1,469 @@
+# Global Skill-Preference Instructions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On `jolli enable`, auto-write a "prefer jolli-pr / jolli-search / jolli-recall by default" standing instruction into each detected host's global instruction file (`~/.claude/CLAUDE.md`, `~/.gemini/GEMINI.md`, `~/.codex/AGENTS.md`).
+
+**Architecture:** A new fail-soft installer module (`GlobalInstructionsInstaller.ts`) upserts a marker-bracketed managed block into per-host global markdown files, mirroring `GitExclude.ts` exactly. `Installer.install()` calls it once, outside the worktree loop, gated per-host on the detection/enable flags it already computes. `uninstall()` is untouched — the global block is deliberately preserved (same policy as global-scope MCP registration).
+
+**Tech Stack:** TypeScript (ESM), Node 22.5+, Vitest, Biome. No new dependencies.
+
+## Global Constraints
+
+Copied verbatim from the spec and repo critical rules — every task inherits these:
+
+- **DCO sign-off on the (single, final) commit** — `git commit -s`. CI rejects commits without `Signed-off-by:`.
+- **No `Co-Authored-By: Claude …` trailer and no "🤖 Generated with …" footer** in the commit message.
+- **`npm run all` must pass before the commit** (clean → build → lint → test).
+- **CLI coverage floor** — new code under `cli/src/` is held to 97% statements / 96% branches / 97% functions / 97% lines. The new module must be fully covered; use `/* v8 ignore start */ … /* v8 ignore stop */` **block** form for defensive-only branches (single-line `ignore next` does NOT work in this repo).
+- **Biome** — tabs, 4-wide indent, 120-column limit, `noExplicitAny: error`, `useImportType: warn` (imports of types use `import type`). `biome check --error-on-warnings` runs in CI.
+- **Block content is English.**
+- **Marker scan is exact-line** — a stray marker-like substring elsewhere in the file must not be treated as a marker.
+- **Fail-soft** — a read/write error on any target is logged and skipped; it must never throw out of `installGlobalInstructions` or break `jolli enable`.
+
+## Commit / test cadence (user preference — overrides skill default)
+
+Per the user's standing preference, do **NOT** run `npm run all` or commit per task. Each task below writes test + implementation code only. A single final task (Task 4) runs `npm run all` once and makes one commit. The failing-test-first ordering within tasks is preserved for TDD discipline, but there is no per-task "run the test" or "commit" step.
+
+## Confirmed facts (verified on this machine, 2026-07-02)
+
+- `~/.codex/AGENTS.md` already exists (empty) → Codex's global instruction file is `AGENTS.md`, **not** `instructions.md`. Resolved the spec's open verification item.
+- `~/.claude/` exists (has `config.json`, no `CLAUDE.md`) → writing `~/.claude/CLAUDE.md` is the correct global-memory location for Claude Code.
+- `~/.gemini/` absent on this machine → confirms the per-host gating is load-bearing (we must not create it when Gemini isn't present).
+
+## File Structure
+
+- **Create** `cli/src/install/GlobalInstructionsInstaller.ts` — the whole feature: block rendering, pure upsert, per-target I/O, and the public `installGlobalInstructions(hosts)` entry point. One cohesive responsibility (managing the global instruction blocks), small enough to hold in one file.
+- **Create** `cli/src/install/GlobalInstructionsInstaller.test.ts` — unit tests, temp-`HOME` integration tests.
+- **Modify** `cli/src/install/Installer.ts` — one guarded call in `install()`.
+
+---
+
+### Task 1: Pure block rendering + upsert core
+
+**Files:**
+- Create: `cli/src/install/GlobalInstructionsInstaller.ts`
+- Test: `cli/src/install/GlobalInstructionsInstaller.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (leaf module besides `createLogger`).
+- Produces:
+  - `renderInstructionsBlock(): string` — marker-wrapped block, trailing `\n`.
+  - `applyInstructionsBlock(existing: string, block: string): string` — pure upsert.
+  - `const BLOCK_START = "<!-- >>> jolli memory instructions >>> -->"`, `const BLOCK_END = "<!-- <<< jolli memory instructions <<< -->"` (module-private).
+
+- [ ] **Step 1: Write the failing tests for the pure functions**
+
+Create `cli/src/install/GlobalInstructionsInstaller.test.ts`:
+
+```ts
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockHomedir } = vi.hoisted(() => ({
+	mockHomedir: vi.fn().mockReturnValue(""),
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:os")>();
+	return { ...original, homedir: mockHomedir };
+});
+
+import {
+	applyInstructionsBlock,
+	installGlobalInstructions,
+	renderInstructionsBlock,
+} from "./GlobalInstructionsInstaller.js";
+
+const START = "<!-- >>> jolli memory instructions >>> -->";
+const END = "<!-- <<< jolli memory instructions <<< -->";
+
+describe("renderInstructionsBlock", () => {
+	it("wraps all three skill names in a marker block ending with a newline", () => {
+		const block = renderInstructionsBlock();
+		expect(block.startsWith(START)).toBe(true);
+		expect(block.endsWith(`${END}\n`)).toBe(true);
+		expect(block).toContain("jolli-pr");
+		expect(block).toContain("jolli-search");
+		expect(block).toContain("jolli-recall");
+	});
+});
+
+describe("applyInstructionsBlock", () => {
+	const block = renderInstructionsBlock();
+
+	it("returns the block alone for empty input", () => {
+		expect(applyInstructionsBlock("", block)).toBe(block);
+	});
+
+	it("appends the block after existing content with exactly one separating newline", () => {
+		const result = applyInstructionsBlock("# My notes\n", block);
+		expect(result).toBe(`# My notes\n${block}`);
+	});
+
+	it("adds a separating newline when existing content has no trailing newline", () => {
+		const result = applyInstructionsBlock("# My notes", block);
+		expect(result).toBe(`# My notes\n${block}`);
+	});
+
+	it("replaces an existing block in place, preserving surrounding content", () => {
+		const stale = [START, "## Stale", END].join("\n");
+		const existing = `# Top\n${stale}\n# Bottom\n`;
+		const result = applyInstructionsBlock(existing, block);
+		expect(result).toContain("# Top");
+		expect(result).toContain("# Bottom");
+		expect(result).toContain("jolli-recall");
+		expect(result).not.toContain("## Stale");
+	});
+
+	it("is idempotent — applying twice changes nothing", () => {
+		const once = applyInstructionsBlock("# Top\n", block);
+		expect(applyInstructionsBlock(once, block)).toBe(once);
+	});
+
+	it("ignores a marker-like substring that is not on its own line", () => {
+		const prose = `Here is a mention of ${START} inside a sentence.\n`;
+		const result = applyInstructionsBlock(prose, block);
+		// No exact-line marker → block is appended, prose left intact.
+		expect(result).toBe(`${prose}${block}`);
+	});
+});
+```
+
+- [ ] **Step 2: Write the module to satisfy the pure-function tests**
+
+Create `cli/src/install/GlobalInstructionsInstaller.ts`:
+
+```ts
+/**
+ * Writes Jolli Memory's "prefer these skills by default" standing instruction
+ * into each detected AI host's GLOBAL instruction file:
+ *
+ *   - Claude Code → ~/.claude/CLAUDE.md
+ *   - Gemini CLI  → ~/.gemini/GEMINI.md
+ *   - Codex       → ~/.codex/AGENTS.md
+ *
+ * The rule tells the host LLM to reach for the jolli-pr / jolli-search /
+ * jolli-recall skills by default for PR creation / search / recall, instead of
+ * leaving skill selection to chance.
+ *
+ * Managed-block strategy mirrors GitExclude.ts: a marker-bracketed section is
+ * upserted, everything outside the markers is preserved verbatim, and the whole
+ * operation is fail-soft — a broken or read-only global file never breaks
+ * `jolli enable`.
+ *
+ * These files are machine-GLOBAL (one per host, shared by every repo), so
+ * `jolli uninstall` deliberately does NOT remove the block — the same policy as
+ * global-scope MCP registration.
+ *
+ * A global `AGENTS.md` is only read by Codex; Cursor / OpenCode / Copilot read
+ * AGENTS.md at the project root, so they are intentionally out of reach here.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { createLogger } from "../Logger.js";
+
+const log = createLogger("GlobalInstructionsInstaller");
+
+/**
+ * Marker pair bracketing Jolli's managed block. Lines between the markers
+ * belong to Jolli and may be rewritten on future installs; anything outside is
+ * untouched. HTML comments so the block is invisible when the markdown renders.
+ */
+const BLOCK_START = "<!-- >>> jolli memory instructions >>> -->";
+const BLOCK_END = "<!-- <<< jolli memory instructions <<< -->";
+
+/** Which hosts to write the global instruction file for (per-host gated). */
+export interface InstructionHosts {
+	readonly claude: boolean;
+	readonly gemini: boolean;
+	readonly codex: boolean;
+}
+
+interface InstructionTarget {
+	readonly host: keyof InstructionHosts;
+	/** Path segments relative to the user's home dir. */
+	readonly relPath: ReadonlyArray<string>;
+}
+
+const TARGETS: ReadonlyArray<InstructionTarget> = [
+	{ host: "claude", relPath: [".claude", "CLAUDE.md"] },
+	{ host: "gemini", relPath: [".gemini", "GEMINI.md"] },
+	{ host: "codex", relPath: [".codex", "AGENTS.md"] },
+];
+
+/**
+ * Renders the managed block including marker lines and a trailing newline.
+ * Joined with `\n` (not the platform EOL) so the file reads identically for a
+ * team sharing dotfiles across OSes.
+ */
+export function renderInstructionsBlock(): string {
+	const lines = [
+		BLOCK_START,
+		"## Jolli Memory",
+		"",
+		"When Jolli Memory is enabled in a repository, prefer its skills by default:",
+		"",
+		"- **Creating a pull request** → use the `jolli-pr` skill (its description comes",
+		"  from Jolli Memory's recorded commit history), unless the user explicitly asks",
+		"  for another method.",
+		"- **Searching prior work, decisions, or related commits** → use the",
+		"  `jolli-search` skill.",
+		"- **Recalling or resuming prior context on a branch** → use the `jolli-recall`",
+		"  skill.",
+		"",
+		"If a skill is not available (Jolli Memory is not enabled in that repository),",
+		"fall back to normal behavior.",
+		BLOCK_END,
+	];
+	return `${lines.join("\n")}\n`;
+}
+
+/**
+ * Replaces an existing managed block in `existing`, or appends one if none is
+ * found. Preserves all other content verbatim. The scan matches the marker
+ * lines exactly (line-oriented) so a stray marker substring inside prose does
+ * not confuse the parser. The first matching marker pair wins.
+ */
+export function applyInstructionsBlock(existing: string, block: string): string {
+	const lines = existing.split("\n");
+	const startIdx = lines.indexOf(BLOCK_START);
+	const endIdx = lines.indexOf(BLOCK_END);
+
+	// `renderInstructionsBlock` always appends a trailing `\n`; strip it before
+	// splitting so the spliced lines don't carry an empty trailing element.
+	const newBlockLines = block.slice(0, -1).split("\n");
+
+	if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+		const next = [...lines.slice(0, startIdx), ...newBlockLines, ...lines.slice(endIdx + 1)];
+		return next.join("\n");
+	}
+
+	if (existing.length === 0) {
+		return block;
+	}
+	const sep = existing.endsWith("\n") ? "" : "\n";
+	return `${existing}${sep}${block}`;
+}
+```
+
+Note: `installGlobalInstructions` (referenced by the test import) is added in Task 2. Task 1's pure-function tests pass once the two exported functions above exist; the import of the not-yet-defined `installGlobalInstructions` resolves to `undefined` but is not exercised until Task 2's tests run.
+
+---
+
+### Task 2: `installGlobalInstructions` — per-host, fail-soft file I/O
+
+**Files:**
+- Modify: `cli/src/install/GlobalInstructionsInstaller.ts` (append the I/O layer)
+- Test: `cli/src/install/GlobalInstructionsInstaller.test.ts` (append integration tests)
+
+**Interfaces:**
+- Consumes: `renderInstructionsBlock`, `applyInstructionsBlock`, `TARGETS`, `homedir()`.
+- Produces: `installGlobalInstructions(hosts: InstructionHosts): Promise<void>` — for each target whose `hosts[host]` is `true`, upsert the block into `join(homedir(), ...relPath)`. Never throws.
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Append to `cli/src/install/GlobalInstructionsInstaller.test.ts`:
+
+```ts
+describe("installGlobalInstructions", () => {
+	let home: string;
+
+	beforeEach(async () => {
+		home = await mkdtemp(join(tmpdir(), "jolli-global-instr-"));
+		mockHomedir.mockReturnValue(home);
+	});
+
+	afterEach(async () => {
+		await rm(home, { recursive: true, force: true });
+	});
+
+	it("creates all enabled hosts' global instruction files", async () => {
+		await installGlobalInstructions({ claude: true, gemini: true, codex: true });
+
+		const claude = await readFile(join(home, ".claude", "CLAUDE.md"), "utf-8");
+		const gemini = await readFile(join(home, ".gemini", "GEMINI.md"), "utf-8");
+		const codex = await readFile(join(home, ".codex", "AGENTS.md"), "utf-8");
+		for (const content of [claude, gemini, codex]) {
+			expect(content).toContain(START);
+			expect(content).toContain("jolli-pr");
+		}
+	});
+
+	it("does not create a file for a disabled host", async () => {
+		await installGlobalInstructions({ claude: true, gemini: false, codex: false });
+
+		expect(await readFile(join(home, ".claude", "CLAUDE.md"), "utf-8")).toContain("jolli-pr");
+		await expect(readFile(join(home, ".gemini", "GEMINI.md"), "utf-8")).rejects.toThrow();
+		await expect(readFile(join(home, ".codex", "AGENTS.md"), "utf-8")).rejects.toThrow();
+	});
+
+	it("preserves pre-existing user content outside the block", async () => {
+		await mkdir(join(home, ".claude"), { recursive: true });
+		await writeFile(join(home, ".claude", "CLAUDE.md"), "# My global rules\n\nBe concise.\n", "utf-8");
+
+		await installGlobalInstructions({ claude: true, gemini: false, codex: false });
+
+		const content = await readFile(join(home, ".claude", "CLAUDE.md"), "utf-8");
+		expect(content).toContain("# My global rules");
+		expect(content).toContain("Be concise.");
+		expect(content).toContain("jolli-recall");
+	});
+
+	it("is idempotent — a second run does not change the file", async () => {
+		await installGlobalInstructions({ claude: true, gemini: false, codex: false });
+		const first = await readFile(join(home, ".claude", "CLAUDE.md"), "utf-8");
+		await installGlobalInstructions({ claude: true, gemini: false, codex: false });
+		const second = await readFile(join(home, ".claude", "CLAUDE.md"), "utf-8");
+		expect(second).toBe(first);
+	});
+});
+```
+
+- [ ] **Step 2: Append the I/O layer to the module**
+
+Append to `cli/src/install/GlobalInstructionsInstaller.ts`:
+
+```ts
+/**
+ * Upserts the managed block into a single absolute file path. Fail-soft: logs
+ * and returns on any read/write error rather than throwing.
+ */
+async function upsertTarget(absPath: string, block: string): Promise<void> {
+	let existing = "";
+	try {
+		existing = await readFile(absPath, "utf-8");
+	} catch (err: unknown) {
+		const code = (err as NodeJS.ErrnoException).code;
+		/* v8 ignore start -- defensive: non-ENOENT read errors (perm denied, EISDIR) */
+		if (code !== "ENOENT") {
+			log.warn("Failed to read %s: %s — skipping", absPath, (err as Error).message);
+			return;
+		}
+		/* v8 ignore stop */
+	}
+
+	const updated = applyInstructionsBlock(existing, block);
+	if (updated === existing) {
+		return; // No change needed.
+	}
+
+	try {
+		await mkdir(dirname(absPath), { recursive: true });
+		await writeFile(absPath, updated, "utf-8");
+		log.info("Updated %s with Jolli Memory instructions", absPath);
+		/* v8 ignore start -- defensive: write failure on read-only fs / EPERM */
+	} catch (err: unknown) {
+		log.warn("Failed to write %s: %s", absPath, (err as Error).message);
+	}
+	/* v8 ignore stop */
+}
+
+/**
+ * Writes the Jolli Memory instruction block into the global instruction file of
+ * every host whose flag is `true`. Called once from `Installer.install()`,
+ * outside the per-worktree loop, because these files are machine-global.
+ */
+export async function installGlobalInstructions(hosts: InstructionHosts): Promise<void> {
+	const block = renderInstructionsBlock();
+	const home = homedir();
+	for (const target of TARGETS) {
+		if (!hosts[target.host]) continue;
+		await upsertTarget(join(home, ...target.relPath), block);
+	}
+}
+```
+
+---
+
+### Task 3: Wire into `Installer.install()`
+
+**Files:**
+- Modify: `cli/src/install/Installer.ts` (import + one guarded call after `registerGlobalMcpHosts`)
+
+**Interfaces:**
+- Consumes: `installGlobalInstructions` (Task 2), plus the already-computed locals `codexDetectedOnce`, `geminiDetectedOnce`, and `config.claudeEnabled` / `config.geminiEnabled` / `config.codexEnabled`.
+- Produces: nothing new — behavior wiring only.
+
+- [ ] **Step 1: Add the import**
+
+At the top of `cli/src/install/Installer.ts`, near the other `./` install imports (e.g. after the `SkillInstaller.js` import on line 91), add:
+
+```ts
+import { installGlobalInstructions } from "./GlobalInstructionsInstaller.js";
+```
+
+- [ ] **Step 2: Add the guarded call after `registerGlobalMcpHosts`**
+
+In `install()`, immediately after the `registerGlobalMcpHosts({ … });` call (currently ending at line 288) and before the "Git hooks are shared…" comment, insert:
+
+```ts
+			// Prefer Jolli's skills by default: write a standing rule into each
+			// detected host's GLOBAL instruction file. Machine-global (one per
+			// host, shared by every repo) — mirrors registerGlobalMcpHosts above,
+			// and like it, uninstall deliberately leaves the block in place.
+			// Per-host gated: never create a host's file on a machine without it.
+			await installGlobalInstructions({
+				claude: config.claudeEnabled !== false,
+				gemini: geminiDetectedOnce && config.geminiEnabled !== false,
+				codex: codexDetectedOnce && config.codexEnabled !== false,
+			});
+```
+
+Rationale for the gate expressions: `config.claudeEnabled` follows the same `!== false` default-on convention used for the Claude skill/hook; `codexEnabled`/`geminiEnabled` may still be `undefined` at this point (Codex auto-enable happens a few lines later), and `undefined !== false` is `true`, so a freshly-detected host is written on first enable — the intended behavior.
+
+- [ ] **Step 3: Confirm `install()` still type-checks conceptually**
+
+No new types cross the boundary; `installGlobalInstructions` returns `Promise<void>` and is awaited. Nothing consumes its result. (Actual `npm run typecheck` runs in Task 4.)
+
+---
+
+### Task 4: Verify and commit (single, final)
+
+**Files:** none (verification + commit only).
+
+- [ ] **Step 1: Run the full gate**
+
+Run: `npm run all`
+Expected: clean → build → lint → test all PASS; CLI coverage stays ≥ 97/96/97/97 with the new module fully covered.
+
+If coverage flags an uncovered line in `GlobalInstructionsInstaller.ts`, it will be inside one of the two `/* v8 ignore start/stop */` defensive catch blocks — confirm the ignore markers are the **block** form (single-line `ignore next` does not work in this repo) and correctly bracket the whole defensive branch.
+
+- [ ] **Step 2: Stage and commit (DCO, no AI co-author)**
+
+```bash
+git add cli/src/install/GlobalInstructionsInstaller.ts \
+        cli/src/install/GlobalInstructionsInstaller.test.ts \
+        cli/src/install/Installer.ts
+git commit -s -m "feat(install): write global skill-preference instructions on enable
+
+On jolli enable, upsert a managed block into each detected host's global
+instruction file (~/.claude/CLAUDE.md, ~/.gemini/GEMINI.md, ~/.codex/AGENTS.md)
+telling the agent to prefer jolli-pr / jolli-search / jolli-recall by default.
+Per-host gated; fail-soft; uninstall leaves the block in place (global scope,
+like MCP registration)."
+```
+
+Expected: commit succeeds with a `Signed-off-by:` trailer and **no** `Co-Authored-By: Claude` / "Generated with Claude" footer.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Global cross-host files (`~/.claude/CLAUDE.md`, `~/.gemini/GEMINI.md`, `~/.codex/AGENTS.md`) → `TARGETS` in Task 1/2. ✓
+- Managed-block upsert mirroring GitExclude → `applyInstructionsBlock` Task 1. ✓
+- Per-host detection gating → Task 3 gate expressions. ✓
+- Fail-soft → `upsertTarget` catch blocks Task 2. ✓
+- Uninstall untouched → no `uninstall()` edit anywhere in the plan (called out in Task 3 note and commit message). ✓
+- English block content → `renderInstructionsBlock` Task 1. ✓
+- Codex path verified (`AGENTS.md`) → Confirmed facts section. ✓
+- Testing matrix (empty/append/replace/idempotent/stray-marker/host-gating/preserve-content) → Task 1 + Task 2 tests. ✓
+
+**2. Placeholder scan:** No TBD/TODO; every code step shows complete code; every command shows expected output. ✓
+
+**3. Type consistency:** `installGlobalInstructions(hosts: InstructionHosts)`, `InstructionHosts { claude; gemini; codex }`, `applyInstructionsBlock(existing, block)`, `renderInstructionsBlock()`, `BLOCK_START`/`BLOCK_END` marker strings — names/signatures identical across Task 1, 2, 3, and both test files. ✓

--- a/docs/superpowers/specs/2026-07-02-global-skill-preference-instructions-design.md
+++ b/docs/superpowers/specs/2026-07-02-global-skill-preference-instructions-design.md
@@ -1,0 +1,181 @@
+# Auto-write global skill-preference instructions on `jolli enable` (cross-host)
+
+**Date:** 2026-07-02
+**Status:** Design — awaiting review
+
+## Problem
+
+`jolli enable` already installs the `jolli-pr`, `jolli-search`, and `jolli-recall`
+skills into every worktree (`SkillInstaller`, into `.claude/skills/` and
+`.agents/skills/`). But an installed skill is only *available* — whether a host
+LLM actually reaches for it when the user says "create a PR" / "search for…" /
+"recall…" is left to the model's own judgment. Users want Jolli's skills to be
+the **default** choice for those three actions, not a coin-flip.
+
+Expressing "prefer these skills by default" is a standing instruction, and Jolli
+writes no instruction file today.
+
+## Goal
+
+On `jolli enable`, automatically write a standing rule — into each detected
+host's **global** instruction file — telling the agent to prefer the three Jolli
+skills by default for their respective actions.
+
+Non-goals:
+- No manual CLI entry point (`--sync-instructions` etc.) — enable-time only.
+- No project-root instruction files — global home-dir files only.
+- No IntelliJ equivalent in this iteration.
+
+## Decisions (locked with user)
+
+| Question | Decision |
+|----------|----------|
+| Where does the rule live? | **Global home-dir instruction files** — one write per host, applies to all of the user's projects. |
+| Which hosts? | **Cross-host**: Claude (`~/.claude/CLAUDE.md`), Gemini (`~/.gemini/GEMINI.md`), Codex (`~/.codex/AGENTS.md`). |
+| Uninstall behavior? | **Keep the block.** A single-repo `jolli uninstall` must not delete a machine-global rule other repos rely on — mirrors the MCP global-scope policy (`removeRepoMcpHosts` deliberately leaves global entries). |
+| Block content language? | **English** — repo is going open-source; all SKILL.md / comments are English. |
+| Manual refresh/clear entry point? | **No** (YAGNI) — enable-time auto-write only. |
+
+### Accepted limitation
+
+A **global** `AGENTS.md` is only read by Codex (`~/.codex/AGENTS.md`).
+Cursor / OpenCode / Copilot read `AGENTS.md` at the *project root*, not from the
+home dir, so they are **not** covered by this iteration. Effective cross-host
+reach = Claude + Gemini + Codex. (Full AGENTS-standard reach would require
+project-root files, which the user declined.)
+
+## Open verification item (planning phase)
+
+Per `integrating-external-systems`: the exact global instruction-file path for
+each host must be confirmed against the real tool before implementation — a
+wrong path is a silent no-op. Highest-risk item: whether Codex's global merge
+file is `~/.codex/AGENTS.md` or the historical `~/.codex/instructions.md`.
+`~/.claude/CLAUDE.md` and `~/.gemini/GEMINI.md` are the documented conventions
+but should be spot-confirmed too.
+
+## Design
+
+### New module: `cli/src/install/GlobalInstructionsInstaller.ts`
+
+Mirrors [`GitExclude.ts`](../../../cli/src/install/GitExclude.ts) — same
+managed-block upsert shape, same fail-soft posture, same pure-function core for
+unit testing. Differences: targets are per-host global markdown files, markers
+are Markdown HTML comments, and the module iterates over a target list.
+
+**Targets.**
+
+```ts
+interface InstructionTarget {
+    readonly host: "claude" | "gemini" | "codex";
+    readonly path: string; // absolute, under homedir()
+}
+```
+
+Resolved from `homedir()`:
+- `claude` → `~/.claude/CLAUDE.md`
+- `gemini` → `~/.gemini/GEMINI.md`
+- `codex`  → `~/.codex/AGENTS.md` (pending verification above)
+
+The **same** host-agnostic block is written to every target (the rules name the
+skills, which exist under the same names on all hosts).
+
+**Marker block** (identical text per target):
+
+```
+<!-- >>> jolli memory instructions >>> -->
+## Jolli Memory
+
+When Jolli Memory is enabled in a repository, prefer its skills by default:
+
+- **Creating a pull request** → use the `jolli-pr` skill (its description comes
+  from Jolli Memory's recorded commit history), unless the user explicitly asks
+  for another method.
+- **Searching prior work, decisions, or related commits** → use the
+  `jolli-search` skill.
+- **Recalling or resuming prior context on a branch** → use the `jolli-recall`
+  skill.
+
+If a skill is not available (Jolli Memory is not enabled in that repository),
+fall back to normal behavior.
+<!-- <<< jolli memory instructions <<< -->
+```
+
+**Upsert algorithm** (per target, identical strategy to `GitExclude.applyBlock`):
+- Read existing file (`""` on ENOENT).
+- Line-oriented scan for the **exact** marker lines (substring matches elsewhere
+  in the file are ignored). If both markers present and ordered, replace the
+  lines between them; otherwise append the block (with a `\n` separator when the
+  file doesn't already end in one; the block alone if the file was empty).
+- If `updated === existing`, skip the write (idempotent — no mtime churn, no
+  version marker needed; changed rule text differs by content and rewrites).
+- `mkdir(dirname, { recursive: true })` then `writeFile`.
+
+**Failure posture.** Never throws. Any read/write error on a target is logged via
+`createLogger("GlobalInstructionsInstaller")` and skipped; other targets still
+proceed. A broken or read-only global file must not break `jolli enable`. (Same
+contract as `updateGitExclude`.)
+
+**Exported surface.**
+- `installGlobalInstructions(hosts: { claude: boolean; gemini: boolean; codex: boolean }): Promise<void>`
+  — writes each target whose host flag is `true`.
+- `applyInstructionsBlock(existing: string, block: string): string` — pure,
+  exported for unit tests (mirrors `applyBlock`).
+- `renderInstructionsBlock(): string` — pure, returns the marker-wrapped block.
+
+### Integration in `Installer.ts`
+
+Call **once**, outside the per-worktree loop (all targets are global — same
+placement rationale as `registerGlobalMcpHosts`), passing per-host enable/detect
+flags that `install()` already computes:
+
+```ts
+await installGlobalInstructions({
+    claude: config.claudeEnabled !== false,
+    gemini: geminiDetectedOnce && config.geminiEnabled !== false,
+    codex: codexDetectedOnce && config.codexEnabled !== false,
+});
+```
+
+Per-host gating rationale: each global file is host-specific; writing
+`~/.codex/AGENTS.md` on a machine without Codex would create a spurious file.
+This mirrors the existing detection gating for the Codex/Gemini hooks.
+
+`uninstall()` is **not** modified — the blocks are intentionally left in place.
+
+### Testing (`GlobalInstructionsInstaller.test.ts`)
+
+CLI enforces 97% coverage, so the new module needs full coverage:
+
+- `renderInstructionsBlock` contains all three skill names and both markers.
+- `applyInstructionsBlock`:
+  - empty input → block alone.
+  - user content, no markers → block appended, user content preserved, exactly
+    one separating newline (no double newline when input already ends in `\n`).
+  - existing block → content between markers replaced, surrounding content
+    untouched.
+  - running twice → no-op (second call returns input unchanged).
+  - stray marker-like substring in prose → not treated as a marker (exact-line).
+- `installGlobalInstructions` against a temp `HOME`:
+  - all hosts enabled → three files created with the block, parent dirs created.
+  - a host disabled → its file is **not** created.
+  - idempotent second run → no content change.
+  - one target read/write error → returns without throwing, other targets still
+    written (fail-soft); defensive-only branches marked `/* v8 ignore */` per
+    GitExclude precedent.
+
+## Files touched
+
+- **New:** `cli/src/install/GlobalInstructionsInstaller.ts`
+- **New:** `cli/src/install/GlobalInstructionsInstaller.test.ts`
+- **Edit:** `cli/src/install/Installer.ts` — one guarded call in `install()`.
+
+## Intentionally unchanged
+
+- `uninstall()` — global blocks preserved by design.
+- Project-root instruction files — out of scope (global home-dir only).
+- Cursor / OpenCode / Copilot — not reachable via a global `AGENTS.md`; out of
+  scope this iteration (see Accepted limitation).
+- IntelliJ plugin — out of scope.
+- `SkillInstaller.ts` — skills already install; this feature is orthogonal.
+- VS Code extension — calls the same bundled `install()`, so it inherits the
+  behavior automatically; no extension-side change needed.


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer implemented automatic global skill-preference configuration for AI hosts. When users run `jolli enable`, the system now writes standing instructions to each AI host's global configuration file, telling Claude, Gemini, and Codex to prefer Jolli's specialized skills for pull requests, search, and context recall. The instructions are written to machine-global files so a single write applies to all of the user's projects, and the operation uses fail-soft error handling so a broken global file never prevents enable from completing.

The managed instruction block uses marker-bracketed sections matching the existing GitExclude pattern, allowing safe in-place updates on future installs without destroying user content outside the markers. The installer also detects and adopts manually added `## Jolli Memory` headings that users may have created by following earlier documentation, eliminating duplicate sections and treating the managed block as the single source of truth. Per-host gating ensures files are only created for hosts actually present on the machine, avoiding unnecessary clutter.

---

## Topic (1)
<details>
<summary><strong>01 · Auto-configure global skill preferences for AI hosts on enable</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When Jolli Memory is enabled in a repository, users want their AI tools (Claude, Gemini, Codex) to automatically prefer Jolli's specialized skills for pull requests, search, and context recall instead of leaving skill selection to chance.

**💡 Decisions Behind the Code**

- **Marker-bracketed managed block mirrors GitExclude pattern**: Using HTML comment markers (`<!-- >>> jolli memory instructions >>> -->` / `<!-- <<< jolli memory instructions <<< -->`) allows the block to be invisible when rendered as markdown, makes line-oriented detection robust against stray marker substrings in prose, and enables safe in-place replacement on future installs without losing surrounding user content. This approach is proven in the codebase and reduces cognitive load for maintainers.
- **Machine-global scope with fail-soft semantics**: Instructions are written to home-directory files rather than per-repo files, ensuring the preference applies uniformly across all the user's projects without requiring enable to run in each one. Errors reading or writing a host's file are logged but do not break `jolli enable`, matching the policy for global MCP registration — a broken global file should never prevent local repository setup.
- **Preserve block on uninstall**: The managed block is intentionally left in place when `jolli uninstall` runs. A single repository's uninstall must not delete a machine-global instruction that other still-enabled Jolli repositories depend on, preventing accidental breakage of other projects.
- **Per-host gating prevents spurious file creation**: The installer only writes a file if that host is both detected on the machine AND enabled in config. This avoids creating unnecessary files on machines that lack certain tools, reducing clutter and respecting the user's actual toolchain.
- **Adopt unmarked sections to prevent duplicates**: The installer now detects manually added `## Jolli Memory` headings (from earlier documentation) and replaces them in place with the marker-wrapped managed block, eliminating duplicates and treating the managed block as the single source of truth. Adoption uses exact line matching to prevent false positives and preserves nested subsections underneath the heading.

**✅ What Was Implemented**

Implemented a feature that automatically writes standing instructions to each AI host's global configuration file when the user runs `jolli enable`. The system writes to `~/.claude/CLAUDE.md`, `~/.gemini/GEMINI.md`, and `~/.codex/AGENTS.md`, telling each tool to reach for jolli-pr, jolli-search, and jolli-recall by default.

Created `GlobalInstructionsInstaller.ts` with three core functions: `renderInstructionsBlock()` generates a marker-bracketed instruction block explaining when to use each Jolli skill; `applyInstructionsBlock()` upserts the block into existing content while preserving user content outside the markers and handling idempotency; `installGlobalInstructions()` writes the block to machine-global instruction files for enabled hosts. Integrated the installer into `Installer.ts` to run once per install invocation, after global MCP host registration and gated per-host so files are only created for hosts detected on the machine.

Added comprehensive test coverage (15 tests total) validating marker-based upsert logic, idempotency, user content preservation, per-host gating, and fail-soft error handling for read/write failures. The operation is fail-soft — a read-only or broken global file logs a warning but does not prevent the enable command from succeeding.

**📁 FILES**
- `cli/src/install/GlobalInstructionsInstaller.ts`
- `cli/src/install/GlobalInstructionsInstaller.test.ts`
- `cli/src/install/Installer.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 2, 2026 at 5:22 PM · via Anthropic*
<!-- jollimemory-summary-end -->
