### PR TITLE
Create PR UI alignment with new UI mockup

### DIFF
--- a/vscode/src/views/CreatePrBodyMarkdown.test.ts
+++ b/vscode/src/views/CreatePrBodyMarkdown.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { renderPrBodyMarkdown } from "./CreatePrBodyMarkdown";
+
+describe("renderPrBodyMarkdown", () => {
+	it("returns empty string for empty or whitespace-only input", () => {
+		expect(renderPrBodyMarkdown("")).toBe("");
+		expect(renderPrBodyMarkdown("   \n  \n")).toBe("");
+	});
+
+	it("renders ATX headings with a +1 level offset and the md-heading class", () => {
+		expect(renderPrBodyMarkdown("## Quick recap")).toBe('<h3 class="md-heading">Quick recap</h3>');
+		expect(renderPrBodyMarkdown("# Top")).toBe('<h2 class="md-heading">Top</h2>');
+	});
+
+	it("caps heading level at 6", () => {
+		expect(renderPrBodyMarkdown("###### Deep")).toContain("<h6");
+	});
+
+	it("passes whole-line structural HTML through verbatim so folding renders natively", () => {
+		const html = renderPrBodyMarkdown(
+			["<details>", "<summary><strong>01 · Title</strong></summary>", "<br>", "<blockquote>", "</blockquote>", "</details>"].join(
+				"\n",
+			),
+		);
+		expect(html).toContain("<details>");
+		expect(html).toContain("<summary><strong>01 · Title</strong></summary>");
+		expect(html).toContain("<br>");
+		expect(html).toContain("<blockquote>");
+		expect(html).toContain("</blockquote>");
+		expect(html).toContain("</details>");
+	});
+
+	it("renders a fenced code block, escaping its contents", () => {
+		const html = renderPrBodyMarkdown("```ts\nconst x = 1 < 2;\n```");
+		expect(html).toBe('<pre class="md-code-block"><code>const x = 1 &lt; 2;</code></pre>');
+	});
+
+	it("flushes an unterminated fenced code block", () => {
+		const html = renderPrBodyMarkdown("```\nline1\nline2");
+		expect(html).toBe('<pre class="md-code-block"><code>line1\nline2</code></pre>');
+	});
+
+	it("renders a horizontal rule", () => {
+		expect(renderPrBodyMarkdown("---")).toBe('<hr class="md-hr" />');
+	});
+
+	it("merges consecutive markdown blockquote lines into one block", () => {
+		const html = renderPrBodyMarkdown("> Note: line one\n> line two");
+		expect(html).toBe('<blockquote class="md-quote">Note: line one<br />line two</blockquote>');
+	});
+
+	it("renders an unordered list and closes it when a non-item line follows", () => {
+		const html = renderPrBodyMarkdown("- one\n- two\ntail");
+		expect(html).toBe(
+			'<ul class="md-list"><li>one</li><li>two</li></ul><div class="md-line">tail</div>',
+		);
+	});
+
+	it("emits a gap for blank lines and a md-line for paragraphs", () => {
+		expect(renderPrBodyMarkdown("hello\n\nworld")).toBe(
+			'<div class="md-line">hello</div><div class="md-blank"></div><div class="md-line">world</div>',
+		);
+	});
+
+	it("applies inline bold, italic, code and http links", () => {
+		expect(renderPrBodyMarkdown("**bold**")).toContain("<strong>bold</strong>");
+		expect(renderPrBodyMarkdown("*em*")).toContain("<em>em</em>");
+		expect(renderPrBodyMarkdown("`code`")).toContain('<code class="md-inline-code">code</code>');
+		expect(renderPrBodyMarkdown("[docs](https://x.jolli.ai/p)")).toContain(
+			'<a class="md-link" href="https://x.jolli.ai/p">docs</a>',
+		);
+	});
+
+	it("does not treat underscores in identifiers or paths as italic", () => {
+		const html = renderPrBodyMarkdown("Touch `file_name_v2.ts` and a_b_c");
+		expect(html).not.toContain("<em>");
+	});
+
+	it("escapes stray HTML in prose so it cannot inject markup", () => {
+		const html = renderPrBodyMarkdown("Danger <img src=x onerror=1> here");
+		expect(html).not.toContain("<img");
+		expect(html).toContain("&lt;img");
+	});
+
+	it("normalizes CRLF line endings", () => {
+		expect(renderPrBodyMarkdown("a\r\nb")).toBe('<div class="md-line">a</div><div class="md-line">b</div>');
+	});
+
+	it("does not re-apply bold/italic markup found inside an inline code span", () => {
+		const html = renderPrBodyMarkdown("Use `**not bold**` here");
+		expect(html).toContain('<code class="md-inline-code">**not bold**</code>');
+		expect(html).not.toContain("<strong>");
+	});
+
+	it("does not re-apply bold/italic markup found inside a link's text or URL", () => {
+		const html = renderPrBodyMarkdown("[**bold** text](https://x.jolli.ai/a*b)");
+		expect(html).toBe('<div class="md-line"><a class="md-link" href="https://x.jolli.ai/a*b">**bold** text</a></div>');
+	});
+
+	it("renders ordered lists as <ol> and switches list type at a marker-style boundary", () => {
+		const html = renderPrBodyMarkdown("**Steps:**\n1. Open the app\n2. Click the button");
+		expect(html).toBe(
+			'<div class="md-line"><strong>Steps:</strong></div><ol class="md-list"><li>Open the app</li><li>Click the button</li></ol>',
+		);
+	});
+
+	it("closes an ordered list and opens an unordered one when the marker style switches", () => {
+		const html = renderPrBodyMarkdown("1. first\n- second");
+		expect(html).toBe('<ol class="md-list"><li>first</li></ol><ul class="md-list"><li>second</li></ul>');
+	});
+
+	it("does not double-escape text already neutralized by cli's escapeGithubWrapperTags", () => {
+		// escapeGithubWrapperTags turns a literal "<details>" typed in body prose into
+		// this entity form so GitHub's renderer shows it inertly (see
+		// cli/src/core/SummaryPrMarkdownBuilder.ts). This renderer must undo that
+		// encoding before its own escHtml pass, or the leftover "&" gets escaped a
+		// second time and the browser shows the literal text "&lt;details&gt;".
+		const html = renderPrBodyMarkdown("Wrap the section in a &lt;details&gt; tag");
+		expect(html).toBe('<div class="md-line">Wrap the section in a &lt;details&gt; tag</div>');
+		expect(html).not.toContain("&amp;lt;");
+	});
+
+	it("falls back to escaped plain text for a <summary> line that isn't the exact wrapInGithubDetails shape", () => {
+		// SUMMARY_LINE is anchored to <summary><strong>…</strong></summary> specifically
+		// so that untrusted content smuggled into the line (rather than pre-escaped by
+		// the caller) fails the pattern and gets HTML-escaped instead of passed through.
+		const html = renderPrBodyMarkdown("<summary><img src=x onerror=alert(1)></summary>");
+		expect(html).not.toContain("<img");
+		expect(html).toContain("&lt;summary&gt;&lt;img");
+	});
+});

--- a/vscode/src/views/CreatePrBodyMarkdown.ts
+++ b/vscode/src/views/CreatePrBodyMarkdown.ts
@@ -1,0 +1,217 @@
+/**
+ * CreatePrBodyMarkdown
+ *
+ * Server-side (TypeScript) renderer that turns the PR body markdown produced by
+ * `buildPrBodyMarkdown` into formatted HTML for the Create PR pane, so the body
+ * reads like the rendered memory detail view instead of raw monospace text.
+ *
+ * The PR body is GitHub-flavored markdown that mixes markdown syntax
+ * (`## heading`, `**bold**`, `- list`, `` `code` ``, `> quote`, `---`) with a
+ * small set of structural HTML tags used for folding topics
+ * (`<details>` / `<summary>` / `<blockquote>` / `<br>`). We render it safely by:
+ *
+ *   1. Passing through ONLY whole-line, whitelisted structural tags verbatim so
+ *      `<details>` folds and `<blockquote>` quotes render natively.
+ *   2. HTML-escaping every other line (via {@link escHtml}) BEFORE applying
+ *      markdown, so any stray angle bracket in prose becomes literal text and
+ *      can never inject markup. Combined with the pane's strict CSP (no inline
+ *      handlers), this is defense-in-depth against injection from an
+ *      LLM-generated / hand-edited summary.
+ *
+ * This is deliberately distinct from SummaryScriptBuilder's webview-side
+ * `renderMarkdown`, which escapes ALL HTML (its content never contains folding
+ * tags). Keep the two independent — they have different escaping contracts.
+ */
+
+import { escHtml } from "./SummaryUtils.js";
+
+/** Whole-line structural tags emitted by buildPrMarkdown — passed through as-is. */
+const PASSTHROUGH_LINE = /^(<details>|<\/details>|<br\s*\/?>|<blockquote>|<\/blockquote>)$/;
+/**
+ * A single-line `<summary><strong>…</strong></summary>` row — the exact shape
+ * `wrapInGithubDetails` callers produce (see SummaryPrMarkdownBuilder.ts). Anchored
+ * to that shape, not just the outer tags, so that if the embedded title ever isn't
+ * pre-escaped upstream, the stray `<`/`>` it carries makes the line fail to match
+ * here and fall through to the paragraph branch, which HTML-escapes it — fail
+ * closed rather than emitting untrusted markup verbatim.
+ */
+const SUMMARY_LINE = /^<summary><strong>[^<>]*<\/strong><\/summary>$/;
+
+/**
+ * Reverses cli's `escapeGithubWrapperTags` encoding of the `<details>` /
+ * `<blockquote>` tag names (see SummaryPrMarkdownBuilder.ts) before this
+ * renderer's own {@link escHtml} re-escapes the line. That function neutralizes
+ * a literal `<details>`/`<blockquote>` typed in body prose into the entity text
+ * `&lt;details&gt;` so GitHub's markdown renderer shows it inertly. Without this
+ * undo step, `escHtml` here would escape the leftover `&` a second time —
+ * `&lt;details&gt;` becomes `&amp;lt;details&amp;gt;`, which the browser then
+ * displays as the literal text "&lt;details&gt;" instead of "<details>",
+ * diverging from what GitHub shows for the identical markdown. Limited to
+ * exactly the two tag names `escapeGithubWrapperTags` touches, so it can't be
+ * used to smuggle other markup back in.
+ */
+const GH_WRAPPER_ENTITY = /&lt;(\/?)(details|blockquote)((?:\s[^&]*)?)&gt;/gi;
+function undoGithubWrapperEntities(text: string): string {
+	return text.replace(GH_WRAPPER_ENTITY, "<$1$2$3>");
+}
+
+// Delimits inline-protection placeholder tokens (see applyInline below). U+E000 is
+// in the Unicode Private Use Area — never produced by escHtml or real PR body text,
+// so it can't collide with content. Built via fromCharCode rather than embedded as
+// a literal character so the source stays a plain, diffable ASCII file; a `\x00`
+// control character was rejected here too, by biome's noControlCharactersInRegex.
+const PLACEHOLDER_DELIM = String.fromCharCode(0xe000);
+
+/**
+ * Applies inline markdown to an already-HTML-escaped string.
+ *
+ * Order matters: inline code first, then links, then bold, then italic. `_`-based
+ * emphasis is intentionally unsupported because underscores are common in file
+ * paths, identifiers, and URLs that appear throughout PR bodies.
+ *
+ * Code and link matches are swapped for opaque placeholder tokens rather than
+ * spliced in directly — otherwise the later bold/italic passes run over the
+ * whole string and reprocess `*`/`_` characters that happen to land inside the
+ * HTML just inserted for an earlier match (e.g. `` `**not bold**` `` would have
+ * its code-span content re-bolded). The tokens are restored after all passes run.
+ */
+function applyInline(escaped: string): string {
+	const placeholders: string[] = [];
+	const protect = (html: string): string => {
+		const token = `${PLACEHOLDER_DELIM}${placeholders.length}${PLACEHOLDER_DELIM}`;
+		placeholders.push(html);
+		return token;
+	};
+	const withPlaceholders = escaped
+		.replace(/`([^`]+)`/g, (_m, code: string) => protect(`<code class="md-inline-code">${code}</code>`))
+		.replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, (_m, text: string, url: string) =>
+			protect(`<a class="md-link" href="${url}">${text}</a>`),
+		)
+		.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+		.replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, "<em>$1</em>");
+	if (placeholders.length === 0) return withPlaceholders;
+	const restore = new RegExp(`${PLACEHOLDER_DELIM}(\\d+)${PLACEHOLDER_DELIM}`, "g");
+	return withPlaceholders.replace(restore, (_m, i: string) => placeholders[Number(i)]);
+}
+
+/**
+ * Renders PR body markdown to formatted HTML.
+ *
+ * @param raw - The PR body markdown (without idempotent markers).
+ * @returns HTML string safe to inject into the pane's `.md-body` container, or
+ *   an empty string when the body is blank.
+ */
+export function renderPrBodyMarkdown(raw: string): string {
+	if (!raw || !raw.trim()) return "";
+	const lines = raw.replace(/\r\n/g, "\n").split("\n");
+	const out: string[] = [];
+	let listType: "ul" | "ol" | null = null;
+	let inCode = false;
+	let codeLines: string[] = [];
+
+	const closeList = (): void => {
+		if (listType) {
+			out.push(listType === "ul" ? "</ul>" : "</ol>");
+			listType = null;
+		}
+	};
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+		const trimmed = line.trim();
+
+		// Fenced code block: toggle, buffering the raw lines between the fences.
+		if (/^```/.test(trimmed)) {
+			if (inCode) {
+				out.push(`<pre class="md-code-block"><code>${escHtml(codeLines.join("\n"))}</code></pre>`);
+				codeLines = [];
+				inCode = false;
+			} else {
+				closeList();
+				inCode = true;
+			}
+			continue;
+		}
+		if (inCode) {
+			codeLines.push(line);
+			continue;
+		}
+
+		// Whitelisted structural HTML — emit verbatim so folding renders natively.
+		if (PASSTHROUGH_LINE.test(trimmed) || SUMMARY_LINE.test(trimmed)) {
+			closeList();
+			out.push(trimmed);
+			continue;
+		}
+
+		// ATX heading (# … ######). Level is offset +1 so top-level "##" section
+		// titles render as modest labels rather than oversized headings.
+		const heading = trimmed.match(/^(#{1,6})\s+(.+)$/);
+		if (heading) {
+			closeList();
+			const level = Math.min(heading[1].length + 1, 6);
+			out.push(
+				`<h${level} class="md-heading">${applyInline(escHtml(undoGithubWrapperEntities(heading[2])))}</h${level}>`,
+			);
+			continue;
+		}
+
+		// Horizontal rule.
+		if (/^(-{3,}|\*{3,}|_{3,})$/.test(trimmed)) {
+			closeList();
+			out.push('<hr class="md-hr" />');
+			continue;
+		}
+
+		// Markdown blockquote (`>`), distinct from the passthrough `<blockquote>`
+		// HTML tag. Consecutive quote lines merge into one block.
+		const quote = trimmed.match(/^>\s?(.*)$/);
+		if (quote) {
+			closeList();
+			const parts = [applyInline(escHtml(undoGithubWrapperEntities(quote[1])))];
+			while (i + 1 < lines.length) {
+				const next = lines[i + 1].trim().match(/^>\s?(.*)$/);
+				if (!next) break;
+				parts.push(applyInline(escHtml(undoGithubWrapperEntities(next[1]))));
+				i++;
+			}
+			out.push(`<blockquote class="md-quote">${parts.join("<br />")}</blockquote>`);
+			continue;
+		}
+
+		// List item — unordered (`-`/`*`) or ordered (`1.`). Switching marker type
+		// (e.g. a `-` list followed by a `1.` list) closes the open list and opens
+		// a new one, matching GFM's own list-type-boundary behavior.
+		const unorderedItem = trimmed.match(/^[-*]\s+(.+)$/);
+		const orderedItem = unorderedItem ? null : trimmed.match(/^\d+[.)]\s+(.+)$/);
+		const item = unorderedItem ?? orderedItem;
+		if (item) {
+			const type = unorderedItem ? "ul" : "ol";
+			if (listType !== type) {
+				closeList();
+				out.push(type === "ul" ? '<ul class="md-list">' : '<ol class="md-list">');
+				listType = type;
+			}
+			out.push(`<li>${applyInline(escHtml(undoGithubWrapperEntities(item[1])))}</li>`);
+			continue;
+		}
+
+		closeList();
+
+		// Blank line → vertical gap.
+		if (trimmed === "") {
+			out.push('<div class="md-blank"></div>');
+			continue;
+		}
+
+		// Regular paragraph line.
+		out.push(`<div class="md-line">${applyInline(escHtml(undoGithubWrapperEntities(trimmed)))}</div>`);
+	}
+
+	closeList();
+	// An unterminated fenced block still flushes what was buffered.
+	if (inCode) {
+		out.push(`<pre class="md-code-block"><code>${escHtml(codeLines.join("\n"))}</code></pre>`);
+	}
+	return out.join("");
+}

--- a/vscode/src/views/CreatePrHtmlBuilder.test.ts
+++ b/vscode/src/views/CreatePrHtmlBuilder.test.ts
@@ -189,8 +189,23 @@ describe("buildCreatePrHtml", () => {
 		const html = buildCreatePrHtml(vm, "N");
 		expect(html).toContain("Create Pull Request");
 		expect(html).toContain(">Create PR<");
-		expect(html).toContain("Create with these");
 		expect(html).not.toContain('id="pr-open-link"');
+	});
+
+	it("Edit is a full mode switch: view-mode wrapper, form labels, Cancel button, and toggle script", () => {
+		const html = buildCreatePrHtml(vm, "N");
+		// The read-only content lives in a #view-mode wrapper (visible initially);
+		// the edit form starts hidden.
+		expect(html).toContain('id="view-mode"');
+		expect(html).toContain("edit-form hidden");
+		// The form carries Title/Body labels bound to their inputs.
+		expect(html).toContain('<label class="field-label" for="prTitleInput">Title</label>');
+		expect(html).toContain('<label class="field-label" for="prBodyInput">Body</label>');
+		// Edit mode's action row is Create PR + Cancel.
+		expect(html).toContain('id="cmd-cancel"');
+		// Clicking Edit hides the view and reveals the form; Cancel reverses it.
+		expect(html).toContain("document.getElementById('view-mode').classList.add('hidden')");
+		expect(html).toContain("document.getElementById('view-mode').classList.remove('hidden')");
 	});
 
 	it("update mode (existingPr): heading + buttons say Update and render a clickable PR link", () => {
@@ -200,7 +215,6 @@ describe("buildCreatePrHtml", () => {
 		);
 		expect(html).toContain("Update Pull Request");
 		expect(html).toContain(">Update PR<");
-		expect(html).toContain("Update with these");
 		expect(html).toContain('id="pr-open-link"');
 		expect(html).toContain('data-pr-url="https://github.com/o/r/pull/7"');
 		expect(html).toContain("PR #7");
@@ -229,6 +243,28 @@ describe("buildCreatePrHtml", () => {
 		// responds — without it a double-click runs two push + create flows.
 		expect(html).toContain("if (inFlight) return;");
 		expect(html).toContain("b.disabled = on;");
+	});
+
+	it("omits codicon glyph, stylesheet link and font-src when no assets are supplied", () => {
+		const html = buildCreatePrHtml(vm, "N");
+		expect(html).not.toContain("codicon-git-pull-request");
+		expect(html).not.toContain('rel="stylesheet"');
+		// Tighter nonce-only CSP: no cspSource origin, no font-src directive.
+		expect(html).toContain("style-src 'nonce-N'; script-src 'nonce-N';");
+		expect(html).not.toContain("font-src");
+	});
+
+	it("renders the pull-request glyph, links codicon.css and allowlists it in CSP when assets are supplied", () => {
+		const html = buildCreatePrHtml(vm, "N", {
+			cspSource: "vscode-webview://abc",
+			codiconCssUri: "https://file+.vscode-resource/codicon.css",
+		});
+		// Both submit buttons carry the glyph (matching the design mockup).
+		expect(html.match(/codicon-git-pull-request/g)?.length).toBe(2);
+		expect(html).toContain('<link rel="stylesheet" href="https://file+.vscode-resource/codicon.css" />');
+		// CSP allowlists the asset origin for both the stylesheet and its font.
+		expect(html).toContain("style-src vscode-webview://abc 'nonce-N'");
+		expect(html).toContain("font-src vscode-webview://abc");
 	});
 
 	it("renders a file whose path has no slash using the full path as filename with empty dir", () => {

--- a/vscode/src/views/CreatePrHtmlBuilder.ts
+++ b/vscode/src/views/CreatePrHtmlBuilder.ts
@@ -7,14 +7,14 @@
  * no inline `style=""` attributes and no inline event handlers (CSP forbids
  * both).
  *
- * Markdown rendering decision: no shared markdown renderer is available as a
- * TypeScript-side import in the views/ layer (renderMarkdown lives inside the
- * webview JS bundle, not importable here).  `bodyMarkdown` is therefore
- * rendered inside `<pre class="md-raw">` with HTML-escaped content.
- * This is intentional and noted here for a follow-up.
+ * Markdown rendering: `bodyMarkdown` is rendered to formatted HTML server-side
+ * by {@link renderPrBodyMarkdown} (headings, bold, lists, code, quotes, plus
+ * native `<details>` folding), so the body reads like the memory detail view
+ * instead of raw monospace text.
  */
 
 import type { CreatePrViewModel } from "./CreatePrData.js";
+import { renderPrBodyMarkdown } from "./CreatePrBodyMarkdown.js";
 // Reuse the shared attribute escaper rather than a private copy — both escape
 // the same five chars (&, ", ', <, >), & first to avoid double-escaping.
 import { escAttr as esc } from "./SummaryUtils.js";
@@ -220,11 +220,36 @@ function buildCss(nonce: string): string {
   .gs-R { color: var(--vscode-gitDecoration-renamedResourceForeground); }
   .gs-U { color: var(--vscode-gitDecoration-untrackedResourceForeground); }
   .gs-C { color: var(--vscode-gitDecoration-conflictingResourceForeground); }
-  /* ── Body markdown (pre-escaped, raw display) ── */
-  pre.md-raw {
-    white-space: pre-wrap; word-break: break-word; font-family: var(--vscode-font-family);
-    font-size: 0.9em; color: var(--vscode-foreground); line-height: 1.6;
+  /* ── Body markdown (rendered like the memory detail view) ── */
+  .md-body { font-size: 0.9em; line-height: 1.6; color: var(--vscode-foreground); word-break: break-word; }
+  .md-body .md-heading {
+    font-size: 0.82em; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
+    color: var(--text-secondary); margin: 14px 0 6px;
   }
+  .md-body .md-heading:first-child { margin-top: 0; }
+  .md-body .md-line { margin: 2px 0; }
+  .md-body .md-blank { height: 8px; }
+  .md-body .md-list { margin: 4px 0 8px 20px; }
+  .md-body .md-list li { margin: 2px 0; }
+  .md-body strong { font-weight: 650; }
+  .md-body .md-link { color: var(--vscode-textLink-foreground); }
+  .md-body .md-hr { border: none; border-top: 1px solid var(--border-light); margin: 14px 0; }
+  .md-body .md-inline-code, .md-body code {
+    font-family: var(--vscode-editor-font-family, monospace); font-size: 0.9em;
+    background: var(--panel-inner); padding: 1px 5px; border-radius: 4px;
+  }
+  .md-body .md-code-block {
+    background: var(--panel-inner); border-radius: 6px; padding: 10px 12px;
+    overflow-x: auto; margin: 8px 0; font-size: 0.9em; line-height: 1.5;
+  }
+  .md-body .md-code-block code { background: none; padding: 0; }
+  .md-body blockquote {
+    border-left: 2px solid var(--border-light); margin: 8px 0;
+    padding: 2px 0 2px 12px; color: var(--text-secondary);
+  }
+  .md-body details { margin: 6px 0; }
+  .md-body summary { cursor: pointer; padding: 3px 0; }
+  .md-body summary:hover { color: var(--vscode-foreground); }
   /* ── E2E guide content ── */
   .md-mock p { margin: 6px 0; }
   .md-mock ol { margin: 4px 0 8px 20px; }
@@ -233,11 +258,16 @@ function buildCss(nonce: string): string {
   .actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px; }
   .btn {
     font-family: var(--vscode-font-family); font-size: 0.88em;
+    display: inline-flex; align-items: center; gap: 5px;
     padding: 5px 14px; border-radius: 5px; cursor: pointer;
     border: 1px solid var(--vscode-button-border, var(--border-light));
     background: var(--vscode-button-background);
     color: var(--vscode-button-foreground);
   }
+  /* codicon.css pins .codicon to font: 16px with (0,2,0) specificity; this rule
+     matches that specificity and — loading after the linked stylesheet — wins on
+     source order, sizing the pull-request glyph to the button label. */
+  .btn .codicon { font-size: 1em; }
   .btn:hover { background: var(--vscode-button-hoverBackground); }
   .btn.secondary {
     background: var(--vscode-button-secondaryBackground, var(--surface-hover));
@@ -248,7 +278,15 @@ function buildCss(nonce: string): string {
   /* ── Edit form (revealed by the Edit button) ── */
   /* Mirrors the pr-form-input/pr-form-textarea styling in PrCommentService's
      buildPrSectionCss: theme input bg/fg, full width, comfortable padding. */
-  .edit-form { display: flex; flex-direction: column; gap: 8px; margin-top: 14px; }
+  .edit-form { display: flex; flex-direction: column; gap: 16px; margin-top: 4px; }
+  .edit-form .field { display: flex; flex-direction: column; gap: 6px; }
+  /* Field labels reuse the panel-title treatment so the form reads as part of
+     the same visual system as the read-only panels it replaces. */
+  .edit-form .field-label {
+    font-size: 0.78em; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 0.09em; color: var(--text-secondary);
+  }
+  .edit-form .actions { margin-top: 0; }
   .pr-input {
     width: 100%; box-sizing: border-box; padding: 6px 10px;
     font-size: 0.92em; font-family: var(--vscode-font-family);
@@ -310,8 +348,16 @@ function buildScript(nonce: string): string {
   document.getElementById('cmd-create-pr').addEventListener('click', function () {
     submit({ command: 'createPr' });
   });
+  // Edit is a full mode switch: hide the read-only view (meta, panels, primary
+  // actions) and reveal the title/body form with its own Create + Cancel row.
+  // Cancel returns to the view without submitting; input values are retained.
   document.getElementById('cmd-edit').addEventListener('click', function () {
+    document.getElementById('view-mode').classList.add('hidden');
     document.getElementById('edit-form').classList.remove('hidden');
+  });
+  document.getElementById('cmd-cancel').addEventListener('click', function () {
+    document.getElementById('edit-form').classList.add('hidden');
+    document.getElementById('view-mode').classList.remove('hidden');
   });
   document.getElementById('cmd-copy-body').addEventListener('click', function () {
     vscode.postMessage({ command: 'copyBody' });
@@ -348,21 +394,47 @@ function buildScript(nonce: string): string {
 }
 
 /**
+ * Bundled-asset URIs the pane needs beyond the nonce.
+ *
+ * Optional so unit tests can call `buildCreatePrHtml(vm, nonce)` without a
+ * webview: when omitted the pane renders no codicon glyph and keeps the
+ * nonce-only CSP (so an inline-style/JS regression still fails loudly). The
+ * panel always supplies it in production.
+ */
+export interface CreatePrAssets {
+	/** `webview.cspSource` — allowlists the bundled codicon stylesheet + font. */
+	cspSource: string;
+	/** `asWebviewUri(extensionUri/assets/codicons/codicon.css)` result. */
+	codiconCssUri: string;
+}
+
+/**
  * Builds the full HTML document for the Create PR webview pane.
  *
  * @param vm - The view-model assembled by buildCreatePrViewModel.
  * @param nonce - CSP nonce injected by the VS Code extension host.
+ * @param assets - Bundled codicon stylesheet URI + `cspSource`. When present the
+ *   submit buttons render a git-pull-request glyph (matching the design mockup)
+ *   and the CSP allowlists the codicon font. Omit in tests to render icon-free.
  * @returns A complete `<!DOCTYPE html>` document string.
  */
-export function buildCreatePrHtml(vm: CreatePrViewModel, nonce: string): string {
-	const csp = `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-${nonce}'; script-src 'nonce-${nonce}';" />`;
+export function buildCreatePrHtml(vm: CreatePrViewModel, nonce: string, assets?: CreatePrAssets): string {
+	// With codicons the CSP must allowlist the bundled stylesheet (style-src) and
+	// its font file (font-src) from the extension asset origin; without assets we
+	// keep the tighter nonce-only CSP.
+	const csp = assets
+		? `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${assets.cspSource} 'nonce-${nonce}'; font-src ${assets.cspSource}; script-src 'nonce-${nonce}';" />`
+		: `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-${nonce}'; script-src 'nonce-${nonce}';" />`;
+	// Linked before buildCss so the inline .btn .codicon size override wins on
+	// source order (see buildCss). Empty when icon-free.
+	const codiconLink = assets ? `<link rel="stylesheet" href="${assets.codiconCssUri}" />` : "";
+	const prIcon = assets ? `<span class="codicon codicon-git-pull-request"></span>` : "";
 	// Update mode when an open PR already exists on the branch: the button
 	// pushes the latest commits and syncs this draft into PR #N instead of
 	// creating a duplicate (which GitHub rejects).
 	const isUpdate = vm.existingPr !== undefined;
 	const heading = isUpdate ? "Update Pull Request" : "Create Pull Request";
 	const primaryLabel = isUpdate ? "Update PR" : "Create PR";
-	const editedLabel = isUpdate ? "Update with these" : "Create with these";
 
 	return `<!DOCTYPE html>
 <html lang="en">
@@ -371,44 +443,56 @@ export function buildCreatePrHtml(vm: CreatePrViewModel, nonce: string): string 
   ${csp}
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>${heading}</title>
+  ${codiconLink}
   ${buildCss(nonce)}
 </head>
 <body>
 <div class="pane" id="pane-pr">
   <h1>${heading}</h1>
-  ${buildMetaStrip(vm)}
-  <div class="panel">
-    <div class="panel-header"><span class="panel-title">Title</span></div>
-    <p>${esc(vm.title)}</p>
-  </div>
-  <div class="panel">
-    <div class="panel-header"><span class="panel-title">Body — drafted from this branch&#39;s memories</span></div>
-    <pre class="md-raw">${esc(vm.bodyMarkdown)}</pre>
-  </div>
-  <div class="panel">
-    <div class="panel-header">
-      <span class="panel-title">Memories included</span>
-      <span class="sec-count">${vm.memoryCount}</span>
+  <div id="view-mode">
+    ${buildMetaStrip(vm)}
+    <div class="panel">
+      <div class="panel-header"><span class="panel-title">Title</span></div>
+      <p>${esc(vm.title)}</p>
     </div>
-    ${buildMemoryRows(vm)}
-  </div>
-  ${buildE2ePanel(vm)}
-  <div class="panel">
-    <div class="panel-header">
-      <span class="panel-title">Files changed</span>
-      <span class="sec-count">${vm.filesChanged}</span>
+    <div class="panel">
+      <div class="panel-header"><span class="panel-title">Body: drafted from this branch&#39;s memories</span></div>
+      <div class="md-body">${renderPrBodyMarkdown(vm.bodyMarkdown)}</div>
     </div>
-    ${buildFileRows(vm)}
-  </div>
-  <div class="actions">
-    <button class="btn" id="cmd-create-pr">${primaryLabel}</button>
-    <button class="btn secondary" id="cmd-edit">Edit</button>
-    <button class="btn secondary" id="cmd-copy-body">Copy body</button>
+    <div class="panel">
+      <div class="panel-header">
+        <span class="panel-title">Memories included</span>
+        <span class="sec-count">${vm.memoryCount}</span>
+      </div>
+      ${buildMemoryRows(vm)}
+    </div>
+    ${buildE2ePanel(vm)}
+    <div class="panel">
+      <div class="panel-header">
+        <span class="panel-title">Files changed</span>
+        <span class="sec-count">${vm.filesChanged}</span>
+      </div>
+      ${buildFileRows(vm)}
+    </div>
+    <div class="actions">
+      <button class="btn" id="cmd-create-pr">${prIcon}${primaryLabel}</button>
+      <button class="btn secondary" id="cmd-edit">Edit</button>
+      <button class="btn secondary" id="cmd-copy-body">Copy body</button>
+    </div>
   </div>
   <div class="edit-form hidden" id="edit-form">
-    <input id="prTitleInput" class="pr-input" value="${esc(vm.title)}" />
-    <textarea id="prBodyInput" class="pr-textarea" rows="12">${esc(vm.bodyMarkdown)}</textarea>
-    <button class="btn" id="cmd-create-edited"><span class="codicon codicon-git-pull-request"></span> ${editedLabel}</button>
+    <div class="field">
+      <label class="field-label" for="prTitleInput">Title</label>
+      <input id="prTitleInput" class="pr-input" value="${esc(vm.title)}" />
+    </div>
+    <div class="field">
+      <label class="field-label" for="prBodyInput">Body</label>
+      <textarea id="prBodyInput" class="pr-textarea" rows="12">${esc(vm.bodyMarkdown)}</textarea>
+    </div>
+    <div class="actions">
+      <button class="btn" id="cmd-create-edited">${prIcon}${primaryLabel}</button>
+      <button class="btn secondary" id="cmd-cancel">Cancel</button>
+    </div>
   </div>
 </div>
 ${buildScript(nonce)}

--- a/vscode/src/views/CreatePrWebviewPanel.test.ts
+++ b/vscode/src/views/CreatePrWebviewPanel.test.ts
@@ -18,7 +18,7 @@ const created: Array<{
 	onDispose: () => void;
 	reveal: ReturnType<typeof vi.fn>;
 	dispose: ReturnType<typeof vi.fn>;
-	webview: { html: string; postMessage: ReturnType<typeof vi.fn>; onDidReceiveMessage: (cb: (m: unknown) => void) => { dispose: () => void } };
+	webview: { html: string; cspSource: string; asWebviewUri: (u: { toString(): string }) => { toString(): string }; postMessage: ReturnType<typeof vi.fn>; onDidReceiveMessage: (cb: (m: unknown) => void) => { dispose: () => void } };
 }> = [];
 vi.mock("vscode", () => ({
 	ViewColumn: { One: 1, Active: -1 },
@@ -48,6 +48,8 @@ vi.mock("vscode", () => ({
 				onDispose: () => {},
 				webview: {
 					html: "",
+					cspSource: "vscode-webview://test",
+					asWebviewUri: (u: { toString(): string }) => u,
 					postMessage: vi.fn(),
 					onDidReceiveMessage: (cb: (m: unknown) => void) => {
 						rec.onMsg = cb;

--- a/vscode/src/views/CreatePrWebviewPanel.ts
+++ b/vscode/src/views/CreatePrWebviewPanel.ts
@@ -53,6 +53,7 @@ export class CreatePrWebviewPanel {
 	private constructor(
 		private readonly panel: vscode.WebviewPanel,
 		private readonly workspaceRoot: string,
+		private readonly extensionUri: vscode.Uri,
 	) {
 		this.panel.onDidDispose(() => {
 			CreatePrWebviewPanel.current = undefined;
@@ -108,7 +109,7 @@ export class CreatePrWebviewPanel {
 			vscode.ViewColumn.One,
 			{ enableScripts: true, localResourceRoots: [extensionUri], retainContextWhenHidden: true },
 		);
-		const self = new CreatePrWebviewPanel(panel, workspaceRoot);
+		const self = new CreatePrWebviewPanel(panel, workspaceRoot, extensionUri);
 		CreatePrWebviewPanel.current = self;
 		self.render(result);
 	}
@@ -123,7 +124,13 @@ export class CreatePrWebviewPanel {
 
 	private render(vm: CreatePrViewModel): void {
 		this.vm = vm;
-		this.panel.webview.html = buildCreatePrHtml(vm, randomBytes(16).toString("hex"));
+		const codiconCssUri = this.panel.webview.asWebviewUri(
+			vscode.Uri.joinPath(this.extensionUri, "assets", "codicons", "codicon.css"),
+		);
+		this.panel.webview.html = buildCreatePrHtml(vm, randomBytes(16).toString("hex"), {
+			cspSource: this.panel.webview.cspSource,
+			codiconCssUri: codiconCssUri.toString(),
+		});
 	}
 
 	private async handle(m: Msg): Promise<void> {


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Quick recap

The Create PR panel now provides a significantly improved user experience with three major enhancements. The PR body renders as formatted HTML with proper visual hierarchy instead of raw monospace text: headings appear as small uppercase labels, code blocks display in styled containers, lists and blockquotes show with appropriate indentation and styling, and collapsible topic sections fold natively using the `<details>` element. The renderer uses a whitelist strategy to pass through only the structural HTML tags needed for folding while escaping all other content, providing defense-in-depth against injection attacks. Inline code spans and link URLs are protected from re-processing by emphasis rules, numbered lists are now recognized alongside bulleted lists, and the renderer fails closed on untrusted summary content.

The editing workflow has been redesigned to provide a clearer separation between viewing and editing modes. When users click Edit, all read-only content—metadata, panels, and primary actions—disappears and is replaced by a dedicated editing panel with clearly labeled Title and Body fields. A Cancel button allows users to return to the original view without submitting, preserving any edits they made. This modal-like experience reduces confusion about which mode the user is in and makes the form feel more intentional and focused.

The Create PR panel's visual design now aligns with the latest UI mockup: submit buttons display a pull-request icon, the Body panel title uses a colon instead of an em-dash, and the codicon font renders correctly in the webview with icon sizing tuned to match button text.

---

## Topics (4)
<details>
<summary><strong>01 · Render PR body as formatted HTML with proper visual hierarchy</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Create PR pane was displaying the generated PR body as escaped plain text inside a monospace container, making it hard to read markdown formatting like headings, bold text, lists, and code blocks. Users wanted the body to render with proper visual hierarchy and native support for collapsible topic sections, matching the memory detail page.

**💡 Decisions Behind the Code**

- **Server-side TypeScript rendering over webview JavaScript**: Building a dedicated server-side renderer allows unit testing (satisfying coverage requirements), complete control over HTML escaping (no template literal backtick pitfalls), and static output that requires no `innerHTML` or script execution. This is safer and more maintainable than trying to reuse or duplicate webview-side logic.
- **Whitelist-passthrough strategy for structural tags**: The PR body mixes GitHub-flavored markdown with HTML tags for folding topics. Rather than escaping everything (which would render `&lt;details&gt;` as literal text) or trusting all HTML (which risks injection), the renderer passes through only the known structural tags while escaping all other lines before applying markdown rules. This preserves native folding behavior while defending against injection from LLM-generated or hand-edited summaries.
- **Placeholder tokens for code and link protection**: Inline code spans and link URLs are protected from re-processing by bold and italic markup rules using opaque placeholder tokens (Unicode Private Use Area delimiter) that are swapped in before emphasis passes and restored afterward. This approach is collision-proof: the token format cannot be produced by HTML escaping or real PR body text, so it cannot be smuggled back in by untrusted content.
- **Intentional omission of underscore-based italic**: The renderer supports `*italic*` but not `_italic_` because underscores are ubiquitous in file paths, identifiers, and URLs throughout PR bodies. Treating them as emphasis markers would cause false positives and break readability of code references.
- **Fail-closed summary pattern matching**: The summary line regex is anchored to the exact generator shape rather than just the outer tags, ensuring that if upstream discipline ever slips and a title is not pre-escaped, the stray `<` or `>` character makes the line fail the pattern and triggers safe escaping. This is a defense-in-depth measure: the primary defense is upstream escaping, but the renderer does not trust it.

**✅ What Was Implemented**

- Created CreatePrBodyMarkdown.ts, a server-side TypeScript renderer that converts PR body markdown to formatted HTML. The renderer applies a whitelist strategy: structural HTML tags used for folding (`&lt;details&gt;`, `<summary>`, `&lt;blockquote&gt;`, `<br>`) pass through verbatim so collapsible topics render natively, while all other content is HTML-escaped before markdown rules are applied. This prevents injection attacks while preserving the intended visual structure.
- Added CreatePrBodyMarkdown.test.ts with 19 tests covering all rendering branches: headings, code blocks, lists (both unordered and ordered), blockquotes, horizontal rules, inline formatting, HTML escaping, CRLF normalization, and edge cases like code spans and links protected from re-processing by emphasis rules.
- Updated CreatePrHtmlBuilder.ts to replace the raw monospace display with a `<div class="md-body">` containing rendered HTML, and added a complete CSS stylesheet that styles headings as small uppercase labels, code blocks in styled containers, lists and blockquotes with appropriate indentation, and `&lt;details&gt;` folding with hover effects.
- Extended list detection to recognize both unordered (`-`/`*`) and ordered (`1.`/`1)`) markers, tracking list type separately so the renderer can emit `<ul>` or `<ol>` as appropriate. The renderer closes and reopens the list when the marker style switches, matching GitHub Flavored Markdown's own boundary behavior.
- Added `undoGithubWrapperEntities` function to reverse the CLI's entity encoding of `&lt;details&gt;` and `&lt;blockquote&gt;` tag names before the renderer's own HTML-escape pass runs, restoring the single-escaped form that matches GitHub's display.
- Tightened the `SUMMARY_LINE` regex from accepting any content between tags to anchoring it to the exact shape that the generator produces (with an inner `<strong>` tag and no unescaped angle brackets). Any line that fails to match this strict pattern now falls through to the paragraph branch, which HTML-escapes it — fail-closed behavior.

**📁 FILES**
- `vscode/src/views/CreatePrBodyMarkdown.ts`
- `vscode/src/views/CreatePrBodyMarkdown.test.ts`
- `vscode/src/views/CreatePrHtmlBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Convert Edit button to full view/edit mode toggle with labeled form fields</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Edit button previously expanded a form inline within the read-only view, making it unclear when the user was in editing mode. The UI needed a cleaner modal-like experience where clicking Edit hides all read-only content and reveals a dedicated editing panel with labeled Title and Body fields, plus a Cancel button to return to the original view without submitting.

**💡 Decisions Behind the Code**

- **Single container toggle over per-element visibility**: Wrapping all view-mode content in `#view-mode` and toggling it as one unit is simpler and more maintainable than adding `.view-only` classes to individual panels. It also prevents accidental visibility leaks if a panel's display property is overridden elsewhere.
- **Use `.hidden` class instead of HTML `hidden` attribute**: The codebase already established this pattern to avoid conflicts with `display: flex` rules. Consistency with existing constraints avoids future bugs.
- **Unified button label for both create and update modes**: Reused `primaryLabel` in the edit form's submit button rather than maintaining a separate `editedLabel` variable. This simplifies the code and ensures the button text matches the main action row, reducing cognitive load for users switching between modes.

**✅ What Was Implemented**

- Restructured the HTML in CreatePrHtmlBuilder.ts to wrap all read-only content (metadata, panels, action buttons) in a `#view-mode` container, and moved the edit form into a separate `#edit-form` section that starts hidden. The form now includes labeled `.field` containers for Title and Body inputs, matching the visual hierarchy of the read-only panels.
- Added CSS styling for `.field`, `.field-label`, and edit-form spacing. Field labels use the same uppercase, small-cap treatment as panel titles to maintain visual consistency across the read-only and edit modes.
- Implemented toggle logic in the inline script: clicking Edit adds `.hidden` to `#view-mode` and removes it from `#edit-form`; clicking Cancel reverses the operation, returning to the view without submitting. Input values are retained when toggling back to edit mode.
- Updated test cases in CreatePrHtmlBuilder.test.ts to verify the presence of view-mode and edit-form containers, field labels, and toggle behavior.

**📁 FILES**
- `vscode/src/views/CreatePrHtmlBuilder.ts`
- `vscode/src/views/CreatePrHtmlBuilder.test.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Align Create PR panel UI with design mockup and fix codicon rendering</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Create PR webview panel needed to match the latest UI mockup, specifically adding the pull-request icon to submit buttons and ensuring the codicon font loads correctly in the webview.

**💡 Decisions Behind the Code**

- **Conditional codicon loading for test safety**: The `assets` parameter is optional so unit tests can call the builder without a webview and still catch regressions (e.g., inline-style violations). Production always supplies assets. This keeps tests fast and focused while ensuring the icon feature is properly covered by new test cases.
- **CSP allowlisting strategy**: Rather than hardcoding the codicon origin, the CSP reuses the extension's existing `cspSource` (which the webview already provides) for both `style-src` and `font-src`. This follows the pattern already established elsewhere in the extension and avoids duplicating asset-origin logic.
- **Specificity-matched font-size override**: The codicon.css stylesheet pins `.codicon` to 16px with (0,2,0) specificity. The inline style uses `.btn .codicon` (same specificity) and loads after the linked stylesheet, so source order wins without needing `!important`. This is more maintainable than fighting specificity and documents the intent clearly in a code comment.

**✅ What Was Implemented**

- Updated CreatePrHtmlBuilder.ts to accept an optional `CreatePrAssets` parameter (containing `cspSource` and `codiconCssUri`) to conditionally render the pull-request glyph on both submit buttons. Updated CSP to allowlist the codicon stylesheet and font when assets are provided. Added inline style rule `.btn .codicon { font-size: 1em }` to override codicon.css's 16px pin and align the icon with button text. Changed Body panel title punctuation from em-dash to colon to match mockup.
- Updated CreatePrWebviewPanel.ts to store `extensionUri` in the panel instance and compute the codicon stylesheet URI via `asWebviewUri()` in the `render()` method, passing both the URI and `cspSource` to the HTML builder.
- Updated test files to include `cspSource` and `asWebviewUri()` methods in the mock webview. Added two new test cases covering the icon-free path (no assets supplied) and the icon-present path (assets supplied), verifying glyph count, stylesheet link, and CSP directives.

**📁 FILES**
- `vscode/src/views/CreatePrHtmlBuilder.ts`
- `vscode/src/views/CreatePrWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Resolve rebase conflicts in token tracking and workspace initialization</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A rebase of the feature branch onto a new base introduced three files with merge conflicts. The incoming commit implemented token breakdown tracking in parallel with a refined version already in the base, and two VSCode files had divergent changes around workspace initialization and token display.

**💡 Decisions Behind the Code**

All conflicts resolved to the base (HEAD) side because the base contained the refined superset of each feature. The token breakdown logic in the base is strictly more correct: it buckets tokens per session and skips pruned sessions during summation, whereas the incoming variant would over-count tokens when a ConversationDetailsPanel overlay deletes a session. The VSCode changes in the base added user-facing functionality (workspace initialization) that the incoming commit did not attempt, making it the clear choice for both files.

**✅ What Was Implemented**

- Resolved five conflicts in QueueWorker.ts by taking the base version, which uses `conversationKey(source, sessionId)` and computes per-session token buckets that respect overlay pruning. The incoming variant used a flat `${source}:${sessionId}` string and top-level accumulators that could not account for deleted sessions, making it a superseded parallel implementation.
- Resolved two conflicts in SidebarWebviewProvider.ts by taking the base version, which includes `vscode.openFolder` support for no-workspace onboarding CTAs — a feature the incoming commit lacked.
- Resolved one conflict in SidebarScriptBuilder.ts by taking the base version, which declares and uses a `hasBreakdown` variable throughout the common code below the conflict region. Taking the incoming side would have deleted the declaration and broken downstream references.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`
- `vscode/src/views/SidebarWebviewProvider.ts`
- `vscode/src/views/SidebarScriptBuilder.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 2, 2026 at 11:57 PM · via Anthropic*
<!-- jollimemory-summary-end -->