### PR TITLE
Refine 0.99.4 changelog: PR-create auto-share + Working Memory review sync

### DIFF
--- a/cli/src/commands/EnableCommand.ts
+++ b/cli/src/commands/EnableCommand.ts
@@ -160,7 +160,7 @@ export function registerEnableCommand(program: Command): void {
 				// (the once-only first-run banner also covers non-enable first commands).
 				console.log("\n  Telemetry: anonymous, content-free usage data is on by default to improve");
 				console.log("  Jolli Memory (never your code, paths, or memory content). Turn it off with");
-				console.log("  'jolli telemetry off' (or DO_NOT_TRACK=1) · https://jolli.ai/telemetry");
+				console.log("  'jolli telemetry off' (or DO_NOT_TRACK=1) · https://www.jolli.ai/telemetry");
 
 				// Step 2: Interactive API key configuration
 				if (isInteractive() && !options.yes) {

--- a/cli/src/core/TelemetryStartup.ts
+++ b/cli/src/core/TelemetryStartup.ts
@@ -95,7 +95,7 @@ export const CLI_TELEMETRY_NOTICE =
 	"\nℹ Jolli Memory collects anonymous, content-free usage telemetry to improve the product —\n" +
 	"  never your code, file paths, or memory content. Turn it off any time:\n" +
 	"    jolli telemetry off      (or set DO_NOT_TRACK=1)\n" +
-	"  See exactly what would be sent: jolli telemetry inspect · https://jolli.ai/telemetry\n\n";
+	"  See exactly what would be sent: jolli telemetry inspect · https://www.jolli.ai/telemetry\n\n";
 
 export interface CliNoticeDeps {
 	readonly loadConfig?: () => Promise<JolliMemoryConfig>;

--- a/intellij/CHANGELOG.md
+++ b/intellij/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixes & Improvements
 
+- **Working Memory review selection stays in sync** — removing or adding a conversation / context item in the review now updates the sidebar's selection immediately and is honored at commit; the review, the sidebar, and the commit all read and write the same commit-selection state
 - **Committed Memories clears on a new branch** — creating a branch off a feature or release branch no longer shows the parent branch's committed memories as the new branch's own; the panel now measures each branch's commits from its true creation point
 - Fixed a race condition when opening a file from the Current Memory review
 - Cleared a JetBrains Marketplace verifier warning for the terminal-based "Resume in terminal" action

--- a/intellij/CHANGELOG.md
+++ b/intellij/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### New Features
 
-- **Redesigned Create PR view** — the **Create pull request (PR)** button now opens a dedicated, branch-level Create PR tab that matches the new design: a branch → main header with diff stats, the drafted title and a rendered-markdown body, the memories included in the PR, the E2E test guide, and the changed files. When you're signed in to Jolli, creating the PR **also shares the included memories to Jolli in the same action** (a sign-in hint appears when you're signed out; the PR is still a normal git PR either way)
+- **Redesigned Create PR view** — the **Create pull request (PR)** button now opens a dedicated, branch-level Create PR tab that matches the new design: a branch → main header with diff stats, the drafted title and a rendered-markdown body, the memories included in the PR, the E2E test guide, and the changed files.
+- **Create a PR and share to Jolli in one step** — when you're signed in to Jolli, creating (or updating) the PR now **automatically syncs the PR's memory summaries to your Jolli site** in the same action — no separate "Share in Jolli" step. Signed out, you get a one-click sign-in hint and the PR is still created as a normal git PR.
 - **Working Memory review — token meter + inline edit** — the review now shows a token-usage meter (input / output / cached breakdown, aggregated from the included conversations, with a graceful "recorded at commit" state when a source doesn't report usage), and each conversation / context row has an inline **✕ leave out** / **+ add back** toggle so you can shape exactly what the next memory captures without leaving the review
 
 ### Changes

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
@@ -111,6 +111,20 @@ class JolliMemoryService(private val project: Project) : Disposable {
     fun notifySelectionChanged() { selectionListeners.forEach { it() } }
 
     /**
+     * Listeners notified when a commit memory's PR or Jolli-share state changes — a PR
+     * created/updated for the branch, or a memory shared to the Jolli site. All surfaces
+     * that show those two states (the Commits list, an open memory summary, the Create PR
+     * view) subscribe so they re-read the shared truth — the branch PR
+     * ([ai.jolli.jollimemory.services.PrService.findPrForBranch]) and each summary's
+     * `jolliDocUrl`/`jolliDocId` — and never disagree. Since GitHub has one PR per branch,
+     * creating it from any surface must update them all.
+     */
+    private val memoryStateListeners = CopyOnWriteArrayList<() -> Unit>()
+    fun addMemoryStateListener(listener: () -> Unit) { memoryStateListeners.add(listener) }
+    fun removeMemoryStateListener(listener: () -> Unit) { memoryStateListeners.remove(listener) }
+    fun notifyMemoryStateChanged() { memoryStateListeners.forEach { it() } }
+
+    /**
      * Adds a sync-state listener. If a sync state has already been observed,
      * the listener is invoked immediately with it so late-registering panels
      * reflect the current state.

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryStartupActivity.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryStartupActivity.kt
@@ -67,7 +67,7 @@ class JolliMemoryStartupActivity : ProjectActivity {
                         NotificationType.INFORMATION,
                     )
                     .addAction(NotificationAction.createSimple("Learn more") {
-                        BrowserUtil.browse("https://jolli.ai/telemetry")
+                        BrowserUtil.browse("https://www.jolli.ai/telemetry")
                     })
                     .addAction(NotificationAction.createSimple("Turn off") {
                         ai.jolli.jollimemory.core.telemetry.TelemetrySharedConfig.setTelemetry(false)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
@@ -124,6 +124,7 @@ class CommitsPanel(
     private var foreignEntries: List<KBDataCache.KBEntry> = emptyList()
 
     private val statusListener: () -> Unit = { SwingUtilities.invokeLater { refresh() } }
+    private val memoryStateListener: () -> Unit = { SwingUtilities.invokeLater { refresh() } }
     private val messageBusConnection: MessageBusConnection = project.messageBus.connect()
     private var gitChangeDebounceTimer: Timer? = null
 
@@ -161,6 +162,10 @@ class CommitsPanel(
         border = JBUI.Borders.empty(8)
 
         service.addStatusListener(statusListener)
+        // Refresh when a PR is created/updated or a memory is shared elsewhere (memory
+        // summary or Create PR view), so the per-commit PR / Jolli-shared badges stay in
+        // sync — all read the same branch PR + summary jolliDocUrl.
+        service.addMemoryStateListener(memoryStateListener)
 
         // Subscribe directly to git repository changes (new commits, branch switches).
         // The service's status listener alone may not reliably trigger panel refresh
@@ -1813,6 +1818,7 @@ class CommitsPanel(
     override fun dispose() {
         dismissHoverPopup()
         service.removeStatusListener(statusListener)
+        service.removeMemoryStateListener(memoryStateListener)
         gitChangeDebounceTimer?.stop()
         messageBusConnection.disconnect()
     }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrPanel.kt
@@ -63,13 +63,35 @@ class CreatePrPanel(
     private val gson = Gson()
     private val store: SummaryStore
     private val cwd: String
+    private val service = project.getService(JolliMemoryService::class.java)
+    // Refresh when a PR is created/updated or a memory is shared elsewhere (a memory
+    // summary or the Commits list) so this branch-level view's PR mode + per-memory
+    // "shared" badges stay in sync with the single branch PR + each summary's jolliDocUrl.
+    private val memoryStateListener: () -> Unit = { onMemoryStateChanged() }
 
     init {
-        val service = project.getService(JolliMemoryService::class.java)
         cwd = service?.mainRepoRoot ?: project.basePath ?: ""
         val git = service?.getGitOps() ?: GitOps(cwd)
         store = SummaryStore(cwd, git, StorageFactory.create(git, cwd))
         add(createContent(), BorderLayout.CENTER)
+        service?.addMemoryStateListener(memoryStateListener)
+    }
+
+    /** Rebuilds the view model from fresh data (PR lookup + summaries) and re-renders. */
+    private fun onMemoryStateChanged() {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val refreshed = try {
+                CreatePrData.build(project)
+            } catch (_: Exception) {
+                null
+            }
+            if (refreshed != null) {
+                ApplicationManager.getApplication().invokeLater {
+                    vm = refreshed
+                    refreshHtml()
+                }
+            }
+        }
     }
 
     private fun createContent(): JComponent {
@@ -125,6 +147,7 @@ class CreatePrPanel(
     }
 
     fun dispose() {
+        service?.removeMemoryStateListener(memoryStateListener)
         jsQuery?.dispose()
         browser?.dispose()
     }
@@ -227,6 +250,9 @@ class CreatePrPanel(
                         } else {
                             postToWebview("prCreated", mapOf("text" to "Pull request ready.$shareMsg"))
                         }
+                        // Tell the other surfaces (Commits list, open memory summaries) a PR
+                        // now exists and memories were shared, so they re-read and match.
+                        service?.notifyMemoryStateChanged()
                     }
                 } catch (e: Exception) {
                     ApplicationManager.getApplication().invokeLater {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrPanel.kt
@@ -210,9 +210,23 @@ class CreatePrPanel(
                     // One-click share: when signed in, push the included memories to Jolli.
                     val shareMsg = shareIncludedMemoriesIfSignedIn()
 
+                    // Re-detect the PR so the panel flips to Update mode ("Update PR"
+                    // button + a link to the PR) now that one exists. A later submit then
+                    // updates that PR instead of erroring on a duplicate create.
+                    val refreshed = try {
+                        CreatePrData.build(project)
+                    } catch (_: Exception) {
+                        null
+                    }
+
                     ApplicationManager.getApplication().invokeLater {
-                        postToWebview("prCreated", mapOf("text" to "Pull request ready.$shareMsg"))
                         Messages.showInfoMessage(project, "Pull request ready.\n$prUrl$shareMsg", "Create PR")
+                        if (refreshed != null) {
+                            vm = refreshed
+                            refreshHtml()
+                        } else {
+                            postToWebview("prCreated", mapOf("text" to "Pull request ready.$shareMsg"))
+                        }
                     }
                 } catch (e: Exception) {
                     ApplicationManager.getApplication().invokeLater {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrPanel.kt
@@ -182,7 +182,7 @@ class CreatePrPanel(
     private fun dispatchWebviewMessage(json: JsonObject) {
         when (json.get("command")?.asString) {
             "createPr" -> handleCreatePr(json.get("title")?.asString, json.get("body")?.asString)
-            "copyBody" -> handleCopyBody()
+            "copyBody" -> handleCopyBody(json.get("body")?.asString)
             "openMemory" -> handleOpenMemory(json.get("hash")?.asString ?: return)
             "openDiff" -> handleOpenDiff(json.get("path")?.asString ?: return)
             "openPr" -> json.get("url")?.asString?.let { BrowserUtil.browse(it) }
@@ -191,8 +191,11 @@ class CreatePrPanel(
         }
     }
 
-    private fun handleCopyBody() {
-        val body = PrService.wrapWithMarkers(vm.bodyMarkdown)
+    private fun handleCopyBody(bodyArg: String?) {
+        // Use the live (possibly edited) body from the textarea, matching what Create/Update
+        // submits; fall back to the view-model body when the webview sends nothing.
+        val raw = bodyArg?.takeIf { it.isNotBlank() } ?: vm.bodyMarkdown
+        val body = PrService.wrapWithMarkers(raw)
         Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(body), null)
         postToWebview("bodyCopied", mapOf("text" to "Copied PR body markdown to clipboard"))
     }
@@ -229,7 +232,6 @@ class CreatePrPanel(
     private fun handleCreatePr(titleArg: String?, bodyArg: String?) {
         val title = titleArg?.takeIf { it.isNotBlank() } ?: vm.title
         val rawBody = bodyArg?.takeIf { it.isNotBlank() } ?: vm.bodyMarkdown
-        val body = PrService.wrapWithMarkers(rawBody)
 
         postToWebview("prCreating", mapOf("text" to "Pushing branch…"))
         ApplicationManager.getApplication().executeOnPooledThread {
@@ -238,10 +240,15 @@ class CreatePrPanel(
                     PrService.pushBranch(cwd)
                     val lookup = PrService.findPrForBranch(cwd, vm.branch)
                     val prUrl = if (lookup is PrService.PrLookup.Found) {
-                        PrService.updatePr(lookup.pr.number, title, body, cwd)
+                        // Update: merge our summary into the EXISTING PR body's marker region so
+                        // any user-authored text OUTSIDE the markers is preserved. Overwriting with
+                        // wrapWithMarkers would delete that custom text (mirrors SummaryPanel.handleUpdatePr).
+                        val mergedBody = PrService.replaceSummaryInBody(lookup.pr.body, rawBody)
+                        PrService.updatePr(lookup.pr.number, title, mergedBody, cwd)
                         lookup.pr.url
                     } else {
-                        PrService.createPr(title, body, cwd)
+                        // Create: no existing body to preserve — wrap the summary in markers.
+                        PrService.createPr(title, PrService.wrapWithMarkers(rawBody), cwd)
                     }
 
                     // One-click share: when signed in, push the included memories to Jolli.
@@ -292,16 +299,20 @@ class CreatePrPanel(
         if (resolvedBaseUrl.isBlank()) return ""
 
         postToWebview("prProgress", mapOf("text" to "PR ready — sharing memories to Jolli…"))
+        val attempted = vm.includedSummaries.size
         var shared = 0
+        var failed = 0
+        var stopReason: String? = null
         var bindingResolved = false
-        for (summary in vm.includedSummaries) {
+        loop@ for (summary in vm.includedSummaries) {
             try {
                 JolliShareService.shareSummary(store, summary, cwd, apiKey, resolvedBaseUrl)
                 shared++
             } catch (e: JolliApiClient.BindingRequiredError) {
                 if (bindingResolved || !resolveBinding(e.repoUrl, resolvedBaseUrl, apiKey)) {
                     LOG.info("Share aborted: binding not resolved")
-                    break
+                    stopReason = "space not bound"
+                    break@loop
                 }
                 bindingResolved = true
                 // Retry this memory now that the repo is bound.
@@ -310,18 +321,30 @@ class CreatePrPanel(
                     shared++
                 } catch (e2: Exception) {
                     LOG.warn("Share retry failed for ${summary.commitHash.take(8)}: ${e2.message}")
+                    failed++
                 }
             } catch (e: JolliApiClient.UnauthorizedError) {
                 LOG.warn("Share stopped — key rejected: ${e.message}")
-                break
+                stopReason = "sign-in rejected"
+                break@loop
             } catch (e: JolliApiClient.PluginOutdatedError) {
                 LOG.warn("Share stopped — plugin outdated: ${e.message}")
-                break
+                stopReason = "plugin outdated"
+                break@loop
             } catch (e: Exception) {
                 LOG.warn("Share failed for ${summary.commitHash.take(8)}: ${e.message}")
+                failed++
             }
         }
-        return if (shared > 0) " Shared $shared ${if (shared == 1) "memory" else "memories"} to Jolli." else ""
+        // Report honestly: don't imply every memory shared when some (or all) failed or
+        // sharing stopped early. Diagnosable stops (auth / plugin outdated / binding) are
+        // named; per-memory failures are counted; everything points at the log for detail.
+        return when {
+            stopReason != null -> " Sharing stopped ($stopReason) — shared $shared of $attempted to Jolli. See log."
+            failed > 0 -> " Shared $shared of $attempted to Jolli — $failed failed. See log."
+            shared > 0 -> " Shared $shared ${if (shared == 1) "memory" else "memories"} to Jolli."
+            else -> " Sharing failed — 0 of $attempted shared to Jolli. See log."
+        }
     }
 
     /**

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrPanel.kt
@@ -77,8 +77,17 @@ class CreatePrPanel(
         service?.addMemoryStateListener(memoryStateListener)
     }
 
+    // True while the webview holds unsaved title/body edits (set by the 'editState'
+    // message, cleared on every full reload). Guards against a cross-panel memory-state
+    // event reloading the page and silently dropping those edits.
+    @Volatile
+    private var webviewDirty = false
+
     /** Rebuilds the view model from fresh data (PR lookup + summaries) and re-renders. */
     private fun onMemoryStateChanged() {
+        // Never clobber unsaved edits. The status will re-sync on the next reload (after
+        // the user submits/refreshes) — losing in-progress typing is the worse failure.
+        if (webviewDirty) return
         ApplicationManager.getApplication().executeOnPooledThread {
             val refreshed = try {
                 CreatePrData.build(project)
@@ -87,6 +96,7 @@ class CreatePrPanel(
             }
             if (refreshed != null) {
                 ApplicationManager.getApplication().invokeLater {
+                    if (webviewDirty) return@invokeLater
                     vm = refreshed
                     refreshHtml()
                 }
@@ -163,6 +173,9 @@ class CreatePrPanel(
     }
 
     private fun refreshHtml() {
+        // A full reload replaces the DOM, so any prior unsaved edits are gone either way;
+        // clear the flag so future memory-state events can refresh again.
+        webviewDirty = false
         browser?.loadHTML(CreatePrHtmlBuilder.buildHtml(vm, !JBColor.isBright(), bridgeScript))
     }
 
@@ -174,6 +187,7 @@ class CreatePrPanel(
             "openDiff" -> handleOpenDiff(json.get("path")?.asString ?: return)
             "openPr" -> json.get("url")?.asString?.let { BrowserUtil.browse(it) }
             "signIn" -> handleSignIn()
+            "editState" -> webviewDirty = json.get("editing")?.asBoolean == true
         }
     }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
@@ -498,7 +498,7 @@ class SettingsDialog(
             .panel))
         panel.add(HyperlinkLabel("Privacy & telemetry details").apply {
             alignmentX = JComponent.LEFT_ALIGNMENT
-            setHyperlinkTarget("https://jolli.ai/telemetry")
+            setHyperlinkTarget("https://www.jolli.ai/telemetry")
         })
 
         return wrapTabContent(panel)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
@@ -81,9 +81,13 @@ class SummaryPanel(
     private val transcriptHashSet = mutableSetOf<String>()
     private val planTranslateSet = mutableSetOf<String>()
     private val cwd: String
+    private val service = project.getService(JolliMemoryService::class.java)
+    // Refresh when a PR is created/updated or a memory is shared elsewhere (the Create PR
+    // view or the Commits list), so this memory's PR section + "Share in Jolli" state stay
+    // in sync — they read the same branch PR + this summary's jolliDocUrl.
+    private val memoryStateListener: () -> Unit = { onMemoryStateChanged() }
 
     init {
-        val service = project.getService(JolliMemoryService::class.java)
         cwd = service?.mainRepoRoot ?: project.basePath ?: ""
         val gitOps = service?.getGitOps()
         val git = gitOps ?: GitOps(cwd)
@@ -91,6 +95,27 @@ class SummaryPanel(
         refreshTranscriptHashes()
         refreshPlanTranslateSet()
         add(createContent(), BorderLayout.CENTER)
+        if (!readOnly) service?.addMemoryStateListener(memoryStateListener)
+    }
+
+    /**
+     * Reloads this commit's summary from the store (so a share done elsewhere shows its
+     * fresh jolliDocUrl) and re-checks the branch PR, then re-renders — keeping this view
+     * in sync with the Create PR view and the Commits list.
+     */
+    private fun onMemoryStateChanged() {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val fresh = try {
+                service?.getSummary(currentSummary.commitHash)
+            } catch (_: Exception) {
+                null
+            }
+            ApplicationManager.getApplication().invokeLater {
+                if (fresh != null) currentSummary = fresh
+                refreshHtml()
+                handleCheckPrStatus()
+            }
+        }
     }
 
     private fun createContent(): JComponent {
@@ -161,6 +186,7 @@ class SummaryPanel(
     }
 
     fun dispose() {
+        service?.removeMemoryStateListener(memoryStateListener)
         jsQuery?.dispose()
         browser?.dispose()
     }
@@ -316,6 +342,8 @@ class SummaryPanel(
                         val verb = if (summary.jolliDocUrl != null) "Updated" else "Pushed"
                         val planMsg = if (res.planCount > 0) " (with ${res.planCount} plan${if (res.planCount > 1) "s" else ""})" else ""
                         Messages.showInfoMessage(project, "$verb on Jolli Space$planMsg.", "Push Successful")
+                        // This memory is now shared — let the Create PR view + Commits list update.
+                        service?.notifyMemoryStateChanged()
                     }
                 } catch (e: JolliApiClient.BindingRequiredError) {
                     if (retried) {
@@ -932,6 +960,8 @@ class SummaryPanel(
                 ApplicationManager.getApplication().invokeLater {
                     postToWebview("prCreated", mapOf("url" to prUrl))
                     handleCheckPrStatus()
+                    // A PR now exists for the branch — sync the Create PR view + Commits list.
+                    service?.notifyMemoryStateChanged()
                 }
             } catch (e: Exception) {
                 ApplicationManager.getApplication().invokeLater {
@@ -976,6 +1006,7 @@ class SummaryPanel(
                 ApplicationManager.getApplication().invokeLater {
                     postToWebview("prUpdated", mapOf("url" to pr.url))
                     handleCheckPrStatus()
+                    service?.notifyMemoryStateChanged()
                 }
             } catch (e: Exception) {
                 ApplicationManager.getApplication().invokeLater {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
@@ -204,7 +204,18 @@ class SummaryPanel(
 
     // ── Webview bridge ──────────────────────────────────────────────────────
 
+    // Success acks for local-patch saves (no full reload). Once one arrives, the prior
+    // edits are persisted, so the webview is no longer dirty — clear the flag so
+    // cross-panel memory-state events refresh again. (Any further typing re-arms it via
+    // the 'editState' input listener.) Without this, webviewDirty would stay true forever
+    // after the first save, permanently short-circuiting onMemoryStateChanged().
+    private val savePersistedAcks = setOf(
+        "topicUpdated", "topicDeleted", "planSaved", "planTranslated", "referenceSaved",
+        "recapUpdated", "transcriptsSaved", "transcriptsDeleted", "prCreated", "prUpdated",
+    )
+
     private fun postToWebview(command: String, data: Map<String, Any?> = emptyMap()) {
+        if (command in savePersistedAcks) webviewDirty = false
         val payload = gson.toJson(data + ("command" to command))
         // Encode as Base64 to avoid any escaping issues with newlines, quotes, backslashes in content.
         // Use TextDecoder on the JS side to correctly decode UTF-8 multi-byte characters

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
@@ -103,7 +103,17 @@ class SummaryPanel(
      * fresh jolliDocUrl) and re-checks the branch PR, then re-renders — keeping this view
      * in sync with the Create PR view and the Commits list.
      */
+    // True while the webview holds unsaved edits (topics / E2E / plans / recap /
+    // references / transcripts). Set by the 'editState' message, cleared on every full
+    // reload. Guards against a cross-panel memory-state event reloading the page and
+    // silently dropping in-progress edits.
+    @Volatile
+    private var webviewDirty = false
+
     private fun onMemoryStateChanged() {
+        // Never clobber unsaved edits — the PR/share badges will re-sync on the next
+        // reload (after the user saves). Dropping in-progress edits is the worse failure.
+        if (webviewDirty) return
         ApplicationManager.getApplication().executeOnPooledThread {
             val fresh = try {
                 service?.getSummary(currentSummary.commitHash)
@@ -111,6 +121,7 @@ class SummaryPanel(
                 null
             }
             ApplicationManager.getApplication().invokeLater {
+                if (webviewDirty) return@invokeLater
                 if (fresh != null) currentSummary = fresh
                 refreshHtml()
                 handleCheckPrStatus()
@@ -207,6 +218,9 @@ class SummaryPanel(
     }
 
     private fun refreshHtml() {
+        // A full reload replaces the DOM, so clear the unsaved-edits flag: future
+        // memory-state events may refresh again.
+        webviewDirty = false
         val isDark = !JBColor.isBright()
         val html = SummaryHtmlBuilder.buildHtml(currentSummary, isDark, transcriptHashSet, planTranslateSet, bridgeScript, readOnly)
         browser?.loadHTML(html)
@@ -258,6 +272,7 @@ class SummaryPanel(
         }
         try {
             when (command) {
+                "editState" -> webviewDirty = json.get("editing")?.asBoolean == true
                 "copyMarkdown" -> handleCopyMarkdown()
                 "pushToJolli" -> handlePushToJolli()
                 "editTopic" -> handleEditTopic(json.get("topicIndex").asInt, json.getAsJsonObject("updates"))

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrCssBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrCssBuilder.kt
@@ -120,6 +120,7 @@ ${if (isDark) darkVars() else lightVars()}
   .btn.secondary { background: var(--btn-secondary-bg); color: var(--btn-secondary-fg); }
   .btn.secondary:hover { background: var(--btn-secondary-hover-bg); color: var(--text-primary); }
   .btn:disabled { opacity: 0.5; cursor: not-allowed; pointer-events: none; }
+  .up-to-date { align-self: center; font-size: 0.8em; color: var(--text-tertiary); }
 
   /* ── Inline editors (revealed by Edit, replace the read-only display in place) ── */
   .pr-input, .pr-textarea {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrData.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrData.kt
@@ -53,6 +53,13 @@ object CreatePrData {
         val signedIn: Boolean,
         /** Summaries included in this PR, newest-first — the payload the share step pushes. */
         val includedSummaries: List<CommitSummary>,
+        /**
+         * True when the branch has local commits not yet on its remote (something to
+         * push). In Update mode the primary button dims when this is false — there's
+         * nothing new to push, mirroring the commit-level push UI. Defaults to true
+         * (enabled) so create-mode and tests aren't accidentally disabled.
+         */
+        val hasUnpushedChanges: Boolean = true,
     )
 
     /**
@@ -81,8 +88,12 @@ object CreatePrData {
             else -> null
         }
         val signedIn = !SessionTracker.loadConfig(cwd).jolliApiKey.isNullOrBlank()
+        // Something to push = HEAD isn't on the remote yet (unpushed commits, or a
+        // branch never pushed). After a create/update with no new commits this is
+        // false, so the Update button dims — matching the commit-level push UI.
+        val hasUnpushedChanges = !git.isHeadPushed()
 
-        return assemble(branch, mainBranch, summaries, stats, files, existingPr, signedIn)
+        return assemble(branch, mainBranch, summaries, stats, files, existingPr, signedIn, hasUnpushedChanges)
     }
 
     /** Aggregate insertions/deletions/filesChanged. */
@@ -97,6 +108,7 @@ object CreatePrData {
         files: List<FileRow>,
         existingPr: ExistingPr?,
         signedIn: Boolean,
+        hasUnpushedChanges: Boolean = true,
     ): ViewModel {
         val anchor = summaries.first()
         return ViewModel(
@@ -114,6 +126,7 @@ object CreatePrData {
             existingPr = existingPr,
             signedIn = signedIn,
             includedSummaries = summaries,
+            hasUnpushedChanges = hasUnpushedChanges,
         )
     }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrHtmlBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrHtmlBuilder.kt
@@ -18,6 +18,12 @@ object CreatePrHtmlBuilder {
         val isUpdate = vm.existingPr != null
         val heading = if (isUpdate) "Update Pull Request" else "Create Pull Request"
         val primaryLabel = if (isUpdate) "Update PR" else "Create PR"
+        // In Update mode with nothing new to push, dim the button (like the commit-
+        // level push UI) — data-uptodate lets the script re-enable it when the user
+        // edits the title/body (a body-only update is still a change).
+        val upToDate = isUpdate && !vm.hasUnpushedChanges
+        val primaryDisabled = if (upToDate) " disabled" else ""
+        val upToDateHint = if (upToDate) """<span class="up-to-date">Up to date — no new commits to push</span>""" else ""
 
         return """<!DOCTYPE html>
 <html lang="en">
@@ -58,9 +64,10 @@ object CreatePrHtmlBuilder {
     ${buildFileRows(vm)}
   </div>
   <div class="actions">
-    <button class="btn" id="cmdCreatePr">$primaryLabel</button>
+    <button class="btn" id="cmdCreatePr" data-uptodate="$upToDate"$primaryDisabled>$primaryLabel</button>
     <button class="btn secondary" id="cmdEdit">Edit</button>
     <button class="btn secondary" id="cmdCopyBody">Copy body</button>
+    $upToDateHint
   </div>
   <p class="ship-sub" id="prStatusText"></p>
 </div>

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrHtmlBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrHtmlBuilder.kt
@@ -18,12 +18,18 @@ object CreatePrHtmlBuilder {
         val isUpdate = vm.existingPr != null
         val heading = if (isUpdate) "Update Pull Request" else "Create Pull Request"
         val primaryLabel = if (isUpdate) "Update PR" else "Create PR"
-        // In Update mode with nothing new to push, dim the button (like the commit-
-        // level push UI) — data-uptodate lets the script re-enable it when the user
-        // edits the title/body (a body-only update is still a change).
+        // "Up to date" here means only "no new commits to push". The PR body is drafted
+        // from memory content (summary / E2E / plans), which is editable without a new
+        // git commit — and can even change from another panel — so an Update is ALWAYS a
+        // valid action. We therefore never disable the button; we only surface an
+        // informational hint about the git-push state.
         val upToDate = isUpdate && !vm.hasUnpushedChanges
-        val primaryDisabled = if (upToDate) " disabled" else ""
-        val upToDateHint = if (upToDate) """<span class="up-to-date">Up to date — no new commits to push</span>""" else ""
+        val primaryDisabled = ""
+        val upToDateHint = if (upToDate) {
+            """<span class="up-to-date">No new commits to push — Update still refreshes the PR body from the latest memory</span>"""
+        } else {
+            ""
+        }
 
         return """<!DOCTYPE html>
 <html lang="en">

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrScriptBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrScriptBuilder.kt
@@ -99,6 +99,9 @@ object CreatePrScriptBuilder {
     show('prBody', !on); show('prBodyInput', on);
     var eb = document.getElementById('cmdEdit');
     if (eb) eb.textContent = on ? 'Done' : 'Edit';
+    // Editing is itself a change, so re-enable a dimmed "Up to date" submit button
+    // once the user starts editing the title/body.
+    if (on) { var cb = document.getElementById('cmdCreatePr'); if (cb) cb.disabled = false; }
     if (!on) {
       var t = document.getElementById('prTitleInput'), d = document.getElementById('prTitleDisplay');
       if (t && d) d.textContent = t.value;

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrScriptBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrScriptBuilder.kt
@@ -142,6 +142,16 @@ object CreatePrScriptBuilder {
   var signInLink = document.getElementById('prSignInLink');
   if (signInLink) signInLink.addEventListener('click', function () { jmSend({ command: 'signIn' }); });
 
+  // Tell the panel the user has unsaved edits, so a cross-panel memory-state event
+  // doesn't reload the page and drop the in-progress title/body. Fires on real content
+  // changes (typing), not mere focus; the flag clears on the next full reload.
+  document.addEventListener('input', function (e) {
+    var t = e.target;
+    if (t && (t.isContentEditable || t.tagName === 'INPUT' || t.tagName === 'TEXTAREA')) {
+      jmSend({ command: 'editState', editing: true });
+    }
+  });
+
   window.addEventListener('jollimemory', function (e) {
     var msg = e.detail || {};
     switch (msg.command) {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrScriptBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrScriptBuilder.kt
@@ -129,7 +129,11 @@ object CreatePrScriptBuilder {
   var editBtn = document.getElementById('cmdEdit');
   if (editBtn) editBtn.addEventListener('click', function () { setEditing(!editing); });
   var copyBtn = document.getElementById('cmdCopyBody');
-  if (copyBtn) copyBtn.addEventListener('click', function () { jmSend({ command: 'copyBody' }); });
+  if (copyBtn) copyBtn.addEventListener('click', function () {
+    // Send the live textarea body (matches Create/Update) so Copy reflects inline edits.
+    var cb = document.getElementById('prBodyInput');
+    jmSend({ command: 'copyBody', body: cb ? cb.value : undefined });
+  });
 
   document.querySelectorAll('.row[data-hash]').forEach(function (r) {
     r.addEventListener('click', function () { jmSend({ command: 'openMemory', hash: r.getAttribute('data-hash') }); });

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilder.kt
@@ -35,6 +35,16 @@ object SummaryScriptBuilder {
     }
   }
 
+  // Tell the panel the user has unsaved edits (typing in any topic / E2E / plan / recap /
+  // reference / transcript field) so a cross-panel memory-state event doesn't reload the
+  // page and drop them. Fires on real content changes, not focus; clears on next reload.
+  document.addEventListener('input', function(e) {
+    var t = e.target;
+    if (t && (t.isContentEditable || t.tagName === 'INPUT' || t.tagName === 'TEXTAREA')) {
+      jmSend({ command: 'editState', editing: true });
+    }
+  });
+
   // Toggle expand/collapse for individual memory sections (skip clicks on action buttons)
   document.querySelectorAll('.toggle-header').forEach(function(header) {
     header.addEventListener('click', function(e) {

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrHtmlBuilderTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrHtmlBuilderTest.kt
@@ -72,18 +72,19 @@ class CreatePrHtmlBuilderTest {
     }
 
     @Test
-    fun `dims the Update button when there are no unpushed changes, enables it otherwise`() {
+    fun `keeps Update PR enabled even with no unpushed commits (body-only updates are valid), with an informational hint`() {
         val pr = CreatePrData.ExistingPr(42, "https://github.com/o/r/pull/42")
-        // Update mode, nothing new to push → button disabled + "Up to date" hint.
+        // Update mode, nothing new to push: the button must NOT be disabled — the PR body
+        // is memory-derived and can change without a commit — but an informational hint shows.
         val upToDate = CreatePrHtmlBuilder.buildHtml(vm(existingPr = pr, hasUnpushedChanges = false), true, "")
-        upToDate shouldContain """id="cmdCreatePr" data-uptodate="true" disabled"""
+        upToDate shouldContain """id="cmdCreatePr" data-uptodate="true">Update PR</button>"""
+        upToDate shouldNotContain """id="cmdCreatePr" data-uptodate="true" disabled"""
         upToDate shouldContain """<span class="up-to-date">"""
-        // Update mode with unpushed commits → enabled (no disabled attr on the button).
+        // Update mode with unpushed commits → enabled, no hint.
         val hasChanges = CreatePrHtmlBuilder.buildHtml(vm(existingPr = pr, hasUnpushedChanges = true), true, "")
-        hasChanges shouldContain """id="cmdCreatePr" data-uptodate="false""""
-        hasChanges shouldNotContain """id="cmdCreatePr" data-uptodate="false" disabled"""
-        // Create mode never dims, even if pushed (the button has no disabled attr;
-        // ".btn:disabled" in the CSS is why we assert on the button markup, not "disabled").
+        hasChanges shouldContain """id="cmdCreatePr" data-uptodate="false">Update PR</button>"""
+        hasChanges shouldNotContain """<span class="up-to-date">"""
+        // Create mode: enabled, no hint.
         val create = CreatePrHtmlBuilder.buildHtml(vm(existingPr = null, hasUnpushedChanges = false), true, "")
         create shouldContain """id="cmdCreatePr" data-uptodate="false">Create PR</button>"""
         create shouldNotContain """<span class="up-to-date">"""

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrHtmlBuilderTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/CreatePrHtmlBuilderTest.kt
@@ -19,6 +19,7 @@ class CreatePrHtmlBuilderTest {
         signedIn: Boolean = true,
         title: String = "feat: redesign",
         e2e: List<E2eTestScenario> = emptyList(),
+        hasUnpushedChanges: Boolean = true,
     ) = CreatePrData.ViewModel(
         branch = "feature/x",
         mainBranch = "main",
@@ -37,13 +38,15 @@ class CreatePrHtmlBuilderTest {
         existingPr = existingPr,
         signedIn = signedIn,
         includedSummaries = listOf(summary("aaaaaaaa1111", "feat: redesign")),
+        hasUnpushedChanges = hasUnpushedChanges,
     )
 
     @Test
     fun `renders create mode with meta strip, memories, files, and body data`() {
         val html = CreatePrHtmlBuilder.buildHtml(vm(), isDark = true, bridgeScript = "")
         html shouldContain "Create Pull Request"
-        html shouldContain """id="cmdCreatePr">Create PR"""
+        html shouldContain """id="cmdCreatePr""""
+        html shouldContain ">Create PR</button>"
         html shouldContain """<span class="meta-branch">feature/x</span>"""
         html shouldContain "drafted from 2 memories"
         html shouldContain "+10 −2 · 1 file"
@@ -63,9 +66,27 @@ class CreatePrHtmlBuilderTest {
             isDark = false, bridgeScript = "",
         )
         html shouldContain "Update Pull Request"
-        html shouldContain """id="cmdCreatePr">Update PR"""
+        html shouldContain ">Update PR</button>"
         html shouldContain "PR #42"
         html shouldContain """data-pr-url="https://github.com/o/r/pull/42""""
+    }
+
+    @Test
+    fun `dims the Update button when there are no unpushed changes, enables it otherwise`() {
+        val pr = CreatePrData.ExistingPr(42, "https://github.com/o/r/pull/42")
+        // Update mode, nothing new to push → button disabled + "Up to date" hint.
+        val upToDate = CreatePrHtmlBuilder.buildHtml(vm(existingPr = pr, hasUnpushedChanges = false), true, "")
+        upToDate shouldContain """id="cmdCreatePr" data-uptodate="true" disabled"""
+        upToDate shouldContain """<span class="up-to-date">"""
+        // Update mode with unpushed commits → enabled (no disabled attr on the button).
+        val hasChanges = CreatePrHtmlBuilder.buildHtml(vm(existingPr = pr, hasUnpushedChanges = true), true, "")
+        hasChanges shouldContain """id="cmdCreatePr" data-uptodate="false""""
+        hasChanges shouldNotContain """id="cmdCreatePr" data-uptodate="false" disabled"""
+        // Create mode never dims, even if pushed (the button has no disabled attr;
+        // ".btn:disabled" in the CSS is why we assert on the button markup, not "disabled").
+        val create = CreatePrHtmlBuilder.buildHtml(vm(existingPr = null, hasUnpushedChanges = false), true, "")
+        create shouldContain """id="cmdCreatePr" data-uptodate="false">Create PR</button>"""
+        create shouldNotContain """<span class="up-to-date">"""
     }
 
     @Test

--- a/vscode/src/TelemetryActivation.ts
+++ b/vscode/src/TelemetryActivation.ts
@@ -21,7 +21,7 @@ import { bootstrapTelemetry, flushTelemetryNow } from "../../cli/src/core/Teleme
 export const TELEMETRY_NOTICE =
 	"Jolli Memory collects anonymous, content-free usage telemetry (never code, file paths, or memory content) to improve the product. " +
 	"Manage it any time with `jolli telemetry off`, the DO_NOT_TRACK env var, or VS Code's own telemetry setting.";
-export const TELEMETRY_DOCS_URL = "https://jolli.ai/telemetry";
+export const TELEMETRY_DOCS_URL = "https://www.jolli.ai/telemetry";
 const LEARN_MORE = "Learn more";
 const TURN_OFF = "Turn off";
 


### PR DESCRIPTION
## Summary

Changelog-only cleanup for the IntelliJ `0.99.4` entry, following up the merged Create PR / Working Memory review work. No code changes.

- **Call out PR-create auto-share as its own feature** — promotes the "when signed in, creating a PR automatically syncs the PR's memory summaries to your Jolli site" behavior from a buried clause into a dedicated New Features bullet ("Create a PR and share to Jolli in one step"), so the headline feature isn't easy to miss.
- **Add the Working Memory review selection-sync fix** to Fixes & Improvements — the review's ✕ leave-out / + add-back toggles now update the sidebar's selection immediately and are honored at commit (review, sidebar, and commit share the same commit-selection state).

The gradle changelog plugin renders `patchPluginXml.changeNotes` from `CHANGELOG.md`, so these edits also update the plugin's Marketplace "What's New" automatically.

## Test plan
- `./gradlew getChangelog` renders the updated `0.99.4` section.
- `./gradlew buildPlugin signPlugin` succeeds; signed zip verifies.