### PR TITLE
Build the bundled CLI before the IntelliJ Gradle build in CI

### DIFF
--- a/.github/workflows/build-intellij.yaml
+++ b/.github/workflows/build-intellij.yaml
@@ -37,6 +37,19 @@ jobs:
             .nvmrc
             .github/workflows/build-intellij.yaml
 
+      # Narrower flag for the expensive Kotlin `test` + Plugin Verifier steps. Those
+      # exercise only Kotlin code: they never exec the bundled Cli.js (CliIntegrationsTest
+      # runs with NO cli-dist on the classpath) and `test` has no sandbox dependency, so a
+      # cli/vscode/deps-only change cannot change their outcome. On such a change we still
+      # rebuild the plugin below (which re-runs copyCliDistToSandbox — the one thing a
+      # bundle change can break) but skip the ~20 min test suite and the Verifier.
+      - id: intellij-changes
+        uses: ./.github/actions/detect-relevant-paths
+        with:
+          globs: |
+            intellij/*
+            .github/workflows/build-intellij.yaml
+
       - if: steps.changes.outputs.relevant == 'true'
         name: Set up JDK 21
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
@@ -78,11 +91,11 @@ jobs:
         name: Build plugin
         run: ./gradlew buildPlugin
 
-      - if: steps.changes.outputs.relevant == 'true'
+      - if: steps.intellij-changes.outputs.relevant == 'true'
         name: Run tests
         run: ./gradlew test
 
-      - if: steps.changes.outputs.relevant == 'true'
+      - if: steps.intellij-changes.outputs.relevant == 'true'
         name: Run Plugin Verifier
         run: ./gradlew verifyPlugin
 

--- a/.github/workflows/build-intellij.yaml
+++ b/.github/workflows/build-intellij.yaml
@@ -30,6 +30,11 @@ jobs:
         with:
           globs: |
             intellij/*
+            cli/*
+            vscode/*
+            package.json
+            package-lock.json
+            .nvmrc
             .github/workflows/build-intellij.yaml
 
       - if: steps.changes.outputs.relevant == 'true'
@@ -48,6 +53,26 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           validate-wrappers: true
+
+      # The plugin bundles the self-contained CLI (vscode/dist/*.js, produced by the
+      # esbuild build) into cli-dist/ so it can run `node Cli.js enable --integrations-only`.
+      # copyCliDistToSandbox fails hard if vscode/dist/Cli.js is missing, so build the JS
+      # bundle at the repo root before any Gradle task that prepares the sandbox.
+      - if: steps.changes.outputs.relevant == 'true'
+        name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+
+      - if: steps.changes.outputs.relevant == 'true'
+        name: Install workspace dependencies
+        working-directory: ${{ github.workspace }}
+        run: npm ci
+
+      - if: steps.changes.outputs.relevant == 'true'
+        name: Build bundled CLI (vscode/dist/*.js)
+        working-directory: ${{ github.workspace }}
+        run: npm run build
 
       - if: steps.changes.outputs.relevant == 'true'
         name: Build plugin

--- a/.github/workflows/build-intellij.yaml
+++ b/.github/workflows/build-intellij.yaml
@@ -25,25 +25,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # Only IntelliJ (Kotlin/Gradle) changes need this job. cli/vscode/deps changes are
+      # covered by build-vscode, which also asserts the vscode → IntelliJ bundling contract
+      # (vscode/dist/Cli.js exists). The Kotlin tests never exec the bundled Cli.js
+      # (CliIntegrationsTest runs with NO cli-dist on the classpath) and don't depend on the
+      # sandbox, so a bundle-only change can't change this job's outcome — no need to
+      # rebuild the plugin here just because cli/ or vscode/ moved.
       - id: changes
-        uses: ./.github/actions/detect-relevant-paths
-        with:
-          globs: |
-            intellij/*
-            cli/*
-            vscode/*
-            package.json
-            package-lock.json
-            .nvmrc
-            .github/workflows/build-intellij.yaml
-
-      # Narrower flag for the expensive Kotlin `test` + Plugin Verifier steps. Those
-      # exercise only Kotlin code: they never exec the bundled Cli.js (CliIntegrationsTest
-      # runs with NO cli-dist on the classpath) and `test` has no sandbox dependency, so a
-      # cli/vscode/deps-only change cannot change their outcome. On such a change we still
-      # rebuild the plugin below (which re-runs copyCliDistToSandbox — the one thing a
-      # bundle change can break) but skip the ~20 min test suite and the Verifier.
-      - id: intellij-changes
         uses: ./.github/actions/detect-relevant-paths
         with:
           globs: |
@@ -91,11 +79,11 @@ jobs:
         name: Build plugin
         run: ./gradlew buildPlugin
 
-      - if: steps.intellij-changes.outputs.relevant == 'true'
+      - if: steps.changes.outputs.relevant == 'true'
         name: Run tests
         run: ./gradlew test
 
-      - if: steps.intellij-changes.outputs.relevant == 'true'
+      - if: steps.changes.outputs.relevant == 'true'
         name: Run Plugin Verifier
         run: ./gradlew verifyPlugin
 

--- a/.github/workflows/build-vscode.yaml
+++ b/.github/workflows/build-vscode.yaml
@@ -54,3 +54,17 @@ jobs:
             -   if: steps.changes.outputs.relevant == 'true'
                 name: Build, lint, and test (CLI + VS Code)
                 run: npm run all
+
+            # Enforce the vscode → IntelliJ bundling contract here (cheaply) so
+            # build-intellij no longer has to rebuild the bundle on every cli/vscode
+            # change. The IntelliJ plugin bundles vscode/dist/Cli.js (esbuild output) into
+            # its distribution; intellij/build.gradle.kts copyCliDistToSandbox hard-fails
+            # if this file is missing. `npm run all` just built it, so this is a no-op
+            # unless the esbuild output moved or disappeared.
+            -   if: steps.changes.outputs.relevant == 'true'
+                name: Assert IntelliJ bundling contract (vscode/dist/Cli.js)
+                run: |
+                    test -f vscode/dist/Cli.js || {
+                        echo "::error::vscode/dist/Cli.js missing after build — the IntelliJ plugin bundles this file (see intellij/build.gradle.kts copyCliDistToSandbox). Did the esbuild output path change?"
+                        exit 1
+                    }

--- a/.github/workflows/publish-intellij.yaml
+++ b/.github/workflows/publish-intellij.yaml
@@ -37,6 +37,22 @@ jobs:
         with:
           validate-wrappers: true
 
+      # The plugin bundles the self-contained CLI (vscode/dist/*.js) into cli-dist/;
+      # copyCliDistToSandbox fails hard if it's missing, so build the JS bundle at the
+      # repo root before any Gradle task that prepares the sandbox.
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install workspace dependencies
+        working-directory: ${{ github.workspace }}
+        run: npm ci
+
+      - name: Build bundled CLI (vscode/dist/*.js)
+        working-directory: ${{ github.workspace }}
+        run: npm run build
+
       - name: Run tests
         run: ./gradlew test
 

--- a/cli/src/commands/EnableCommand.ts
+++ b/cli/src/commands/EnableCommand.ts
@@ -129,31 +129,53 @@ export function registerEnableCommand(program: Command): void {
 		.description("Install Jolli Memory hooks (AI agent + git hooks)")
 		.option("--cwd <dir>", "Project directory (default: git repo root)", resolveProjectDir())
 		.option("-y, --yes", "Skip interactive prompts")
-		.action(async (options: { cwd: string; yes?: boolean }) => {
+		.option(
+			"--integrations-only",
+			"Set up MCP + skills + dispatch scripts only; install no git/agent hooks (for hosts that manage their own hooks, e.g. the IntelliJ plugin)",
+		)
+		.option(
+			"--source-tag <tag>",
+			"Override the dist-paths source tag (e.g. 'intellij') so this install coexists with other surfaces",
+		)
+		.action(async (options: { cwd: string; yes?: boolean; integrationsOnly?: boolean; sourceTag?: string }) => {
 			setLogDir(options.cwd);
 
 			log.info("Running 'enable' command");
-			const result = await install(options.cwd, { source: "cli" });
+			const result = await install(options.cwd, {
+				source: "cli",
+				integrationsOnly: options.integrationsOnly,
+				sourceTag: options.sourceTag,
+			});
 
 			if (result.success) {
 				track("surface_enabled", { trigger: "cli" });
-				console.log("\n  Jolli Memory enabled successfully!\n");
-				console.log("  Hooks installed:");
-				console.log(`    - Git post-commit hook (${result.gitHookPath ?? ".git/hooks/post-commit"})`);
-				console.log(`    - Git post-rewrite hook (${result.postRewriteHookPath ?? ".git/hooks/post-rewrite"})`);
-				console.log(
-					`    - Git prepare-commit-msg hook (${result.prepareMsgHookPath ?? ".git/hooks/prepare-commit-msg"})`,
-				);
-				console.log(`    - Claude Code hooks (${result.claudeSettingsPath ?? ".claude/settings.local.json"})`);
-				if (result.geminiSettingsPath) {
-					console.log(`    - Gemini CLI hook (${result.geminiSettingsPath})`);
+				if (options.integrationsOnly) {
+					console.log("\n  Jolli Memory integrations enabled (MCP + skills; no hooks installed).\n");
+				} else {
+					console.log("\n  Jolli Memory enabled successfully!\n");
+					console.log("  Hooks installed:");
+					console.log(`    - Git post-commit hook (${result.gitHookPath ?? ".git/hooks/post-commit"})`);
+					console.log(
+						`    - Git post-rewrite hook (${result.postRewriteHookPath ?? ".git/hooks/post-rewrite"})`,
+					);
+					console.log(
+						`    - Git prepare-commit-msg hook (${result.prepareMsgHookPath ?? ".git/hooks/prepare-commit-msg"})`,
+					);
+					console.log(
+						`    - Claude Code hooks (${result.claudeSettingsPath ?? ".claude/settings.local.json"})`,
+					);
+					if (result.geminiSettingsPath) {
+						console.log(`    - Gemini CLI hook (${result.geminiSettingsPath})`);
+					}
 				}
 
 				for (const warning of result.warnings) {
 					console.warn(`  Warning: ${warning}`);
 				}
 
-				console.log("\n  IMPORTANT: Restart your AI agent session for the hooks to take effect.");
+				if (!options.integrationsOnly) {
+					console.log("\n  IMPORTANT: Restart your AI agent session for the hooks to take effect.");
+				}
 				console.log("  Run 'jolli doctor' to verify installation.");
 
 				// Onboarding disclosure: telemetry is opt-out, so state it plainly here
@@ -193,15 +215,23 @@ export function registerDisableCommand(program: Command): void {
 		.command("disable")
 		.description("Remove all Jolli Memory hooks")
 		.option("--cwd <dir>", "Project directory (default: git repo root)", resolveProjectDir())
-		.action(async (options: { cwd: string }) => {
+		.option(
+			"--integrations-only",
+			"Remove only the repo-scoped MCP registration; leave hooks, skills, and dist-paths (mirror of enable --integrations-only)",
+		)
+		.action(async (options: { cwd: string; integrationsOnly?: boolean }) => {
 			setLogDir(options.cwd);
 
 			log.info("Running 'disable' command");
-			const result = await uninstall(options.cwd);
+			const result = await uninstall(options.cwd, { integrationsOnly: options.integrationsOnly });
 
 			if (result.success) {
 				track("surface_disabled", { reason: "manual" });
-				console.log("\n  Jolli Memory disabled. Hooks removed.\n");
+				console.log(
+					options.integrationsOnly
+						? "\n  Jolli Memory integrations removed (MCP).\n"
+						: "\n  Jolli Memory disabled. Hooks removed.\n",
+				);
 			} else {
 				console.error(`\n  Error: ${result.message}\n`);
 				process.exitCode = 1;

--- a/cli/src/commands/TelemetryCommand.test.ts
+++ b/cli/src/commands/TelemetryCommand.test.ts
@@ -3,13 +3,25 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Redirect homedir() so getGlobalConfigDir() lands in a temp dir — these tests must
+// never read or mutate the developer's real ~/.jolli/jollimemory/config.json.
+// Cross-platform: unlike process.env.HOME, this also works on Windows, where
+// homedir() reads %USERPROFILE% and ignores $HOME.
+const { mockHomedir } = vi.hoisted(() => ({
+	mockHomedir: vi.fn<typeof import("node:os").homedir>(),
+}));
+vi.mock("node:os", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:os")>();
+	mockHomedir.mockImplementation(original.homedir);
+	return { ...original, homedir: mockHomedir };
+});
+
 import { loadConfig } from "../core/SessionTracker.js";
 import { appendTelemetryEvent, readTelemetryEvents, type TelemetryEnvelope } from "../core/TelemetryBuffer.js";
 import { registerTelemetryCommand } from "./TelemetryCommand.js";
 
-// Redirect HOME so getGlobalConfigDir() lands in a temp dir — never the real ~/.jolli.
 let home: string;
-let savedHome: string | undefined;
 let logs: string[];
 
 const run = async (...argv: string[]): Promise<void> => {
@@ -37,8 +49,7 @@ const env = (over: Partial<TelemetryEnvelope> = {}): TelemetryEnvelope => ({
 
 beforeEach(async () => {
 	home = await mkdtemp(join(tmpdir(), "telemetry-cmd-home-"));
-	savedHome = process.env.HOME;
-	process.env.HOME = home;
+	mockHomedir.mockReturnValue(home);
 	logs = [];
 	vi.spyOn(console, "log").mockImplementation((msg?: unknown) => {
 		logs.push(String(msg));
@@ -46,8 +57,6 @@ beforeEach(async () => {
 });
 afterEach(async () => {
 	vi.restoreAllMocks();
-	if (savedHome === undefined) delete process.env.HOME;
-	else process.env.HOME = savedHome;
 	await rm(home, { recursive: true, force: true });
 });
 

--- a/cli/src/install/DistPathResolver.test.ts
+++ b/cli/src/install/DistPathResolver.test.ts
@@ -8,6 +8,7 @@ import {
 	deriveSourceTag,
 	migrateLegacyDistPath,
 	pickBestDistPath,
+	pruneStaleDistPaths,
 	readDistPathInfo,
 	resolveDistPath,
 	traverseDistPaths,
@@ -287,6 +288,44 @@ describe("DistPathResolver", () => {
 			await writeFile(join(distPaths, "broken"), "single-line", "utf-8");
 
 			expect(traverseDistPaths(tempDir)).toEqual([]);
+		});
+	});
+
+	// ── pruneStaleDistPaths ──────────────────────────────────────────────
+
+	describe("pruneStaleDistPaths", () => {
+		it("should remove only entries whose dist dir is missing, keeping live ones", async () => {
+			const distPaths = join(tempDir, "dist-paths");
+			await mkdir(distPaths, { recursive: true });
+
+			// Live source: dist dir exists → must survive.
+			const liveDist = join(tempDir, "intellij-dist");
+			await mkdir(liveDist, { recursive: true });
+			await writeFile(join(distPaths, "intellij"), `0.99.4\n${liveDist}`, "utf-8");
+
+			// Ghost source: dist dir removed (e.g. uninstalled VS Code extension) → must go.
+			await writeFile(join(distPaths, "vscode"), "0.99.4\n/gone/extensions/jolli/dist", "utf-8");
+
+			const pruned = await pruneStaleDistPaths(tempDir);
+
+			expect(pruned).toEqual(["vscode"]);
+			const remaining = traverseDistPaths(tempDir);
+			expect(remaining.map((e) => e.source)).toEqual(["intellij"]);
+		});
+
+		it("should return [] when every entry is available", async () => {
+			const distPaths = join(tempDir, "dist-paths");
+			await mkdir(distPaths, { recursive: true });
+			const cliDist = join(tempDir, "cli-dist");
+			await mkdir(cliDist, { recursive: true });
+			await writeFile(join(distPaths, "cli"), `0.99.3\n${cliDist}`, "utf-8");
+
+			expect(await pruneStaleDistPaths(tempDir)).toEqual([]);
+			expect(traverseDistPaths(tempDir).map((e) => e.source)).toEqual(["cli"]);
+		});
+
+		it("should return [] when dist-paths/ directory does not exist", async () => {
+			expect(await pruneStaleDistPaths(tempDir)).toEqual([]);
 		});
 	});
 

--- a/cli/src/install/DistPathResolver.ts
+++ b/cli/src/install/DistPathResolver.ts
@@ -154,6 +154,45 @@ export function traverseDistPaths(globalDir?: string): DistPathInfo[] {
 	return results;
 }
 
+/**
+ * Deletes `dist-paths/<source>` entries whose recorded dist directory no longer
+ * exists — e.g. a ghost `vscode` entry left behind after an IDE extension is
+ * uninstalled, still pointing at a deleted `.../extensions/<name>/dist`.
+ *
+ * Runtime hook selection already tolerates such ghosts (`pickBestDistPath` filters
+ * on `.available`), so why sweep them? The Windows `.mcp.json` entry bakes an
+ * ABSOLUTE `node <dist>/Cli.js` path resolved at registration time. If a ghost won
+ * selection when `.mcp.json` was last written and its dir was later removed, the
+ * baked path is dead until something re-registers — and nothing re-resolves it as
+ * long as the ghost still outranks the live sources on disk. Sweeping ghosts on
+ * every `enable` keeps both selection and the next re-registration pointed at live
+ * dists, and keeps `getStatus().allSources` free of phantom rows.
+ *
+ * Only unavailable entries are removed; an entry whose dir exists is never touched.
+ * Best-effort — a per-entry unlink failure is logged and skipped (a leftover ghost
+ * is harmless, being filtered at selection time). `globalDir` is injectable for
+ * tests; production omits it and uses the machine-global config dir.
+ *
+ * @returns the source tags that were pruned (for logging/tests).
+ */
+export async function pruneStaleDistPaths(globalDir?: string): Promise<string[]> {
+	const dir = join(globalDir ?? join(homedir(), ".jolli", "jollimemory"), "dist-paths");
+	const pruned: string[] = [];
+	for (const entry of traverseDistPaths(globalDir)) {
+		if (entry.available) continue;
+		try {
+			await unlink(join(dir, entry.source));
+			pruned.push(entry.source);
+			log.info("Pruned stale dist-paths/%s (dir gone: %s)", entry.source, entry.distDir);
+		} catch (error: unknown) {
+			/* v8 ignore start -- defensive: unlink race (already deleted) or EPERM is non-fatal */
+			log.warn("Failed to prune stale dist-paths/%s: %s", entry.source, (error as Error).message);
+			/* v8 ignore stop */
+		}
+	}
+	return pruned;
+}
+
 // ─── Version comparison ──────────────────────────────────────────────────────
 
 /**

--- a/cli/src/install/Installer.test.ts
+++ b/cli/src/install/Installer.test.ts
@@ -243,6 +243,33 @@ describe("Installer", () => {
 			expect(matcherGroup.hooks[0].async).toBe(true);
 		});
 
+		it("integrations-only installs MCP + skills but no git/agent hooks", async () => {
+			const exists = (p: string) =>
+				stat(p)
+					.then(() => true)
+					.catch(() => false);
+
+			const result = await install(tempDir, { integrationsOnly: true, sourceTag: "intellij" });
+			expect(result.success).toBe(true);
+
+			// No hooks: git post-commit + Claude settings must NOT be written.
+			expect(await exists(join(tempDir, ".git", "hooks", "post-commit"))).toBe(false);
+			expect(await exists(join(tempDir, ".git", "hooks", "post-rewrite"))).toBe(false);
+			expect(await exists(join(tempDir, ".git", "hooks", "prepare-commit-msg"))).toBe(false);
+			expect(await exists(join(tempDir, ".claude", "settings.local.json"))).toBe(false);
+
+			// Integrations ARE set up: MCP registered for Claude (repo-scoped) + skills written.
+			const mcp = JSON.parse(await readFile(join(tempDir, ".mcp.json"), "utf-8"));
+			expect(mcp.mcpServers?.jollimemory).toBeDefined();
+			expect(await exists(join(tempDir, ".agents", "skills", "jolli-recall", "SKILL.md"))).toBe(true);
+
+			// The explicit source tag lands the dist-paths entry under "intellij", not "cli",
+			// so an IntelliJ install coexists with a real CLI install.
+			const distPaths = join(fakeHomeDir, ".jolli", "jollimemory", "dist-paths");
+			expect(await exists(join(distPaths, "intellij"))).toBe(true);
+			expect(await exists(join(distPaths, "cli"))).toBe(false);
+		});
+
 		it("should auto-enable Codex discovery when Codex is detected and not configured", async () => {
 			const { isCodexInstalled } = await import("../core/CodexSessionDiscoverer.js");
 			vi.mocked(isCodexInstalled).mockResolvedValueOnce(true);
@@ -942,6 +969,30 @@ describe("Installer", () => {
 			const content = await readFile(settingsPath, "utf-8");
 			const settings = JSON.parse(content);
 			expect(settings.hooks).toBeUndefined();
+		});
+
+		it("integrations-only uninstall removes repo MCP but leaves hooks + skills", async () => {
+			const exists = (p: string) =>
+				stat(p)
+					.then(() => true)
+					.catch(() => false);
+
+			// Install the full stack (hooks + MCP + skills), then remove ONLY integrations.
+			await install(tempDir);
+			expect(
+				JSON.parse(await readFile(join(tempDir, ".mcp.json"), "utf-8")).mcpServers?.jollimemory,
+			).toBeDefined();
+
+			const result = await uninstall(tempDir, { integrationsOnly: true });
+			expect(result.success).toBe(true);
+
+			// MCP entry gone…
+			expect(
+				JSON.parse(await readFile(join(tempDir, ".mcp.json"), "utf-8")).mcpServers?.jollimemory,
+			).toBeUndefined();
+			// …but hooks and skills are untouched (the caller owns its hooks).
+			expect(await exists(join(tempDir, ".git", "hooks", "post-commit"))).toBe(true);
+			expect(await exists(join(tempDir, ".agents", "skills", "jolli-recall", "SKILL.md"))).toBe(true);
 		});
 
 		it("continues removing git hooks when removeRepoMcpHosts throws (e.g. read-only .mcp.json)", async () => {

--- a/cli/src/install/Installer.ts
+++ b/cli/src/install/Installer.ts
@@ -61,6 +61,7 @@ import {
 	installDistPath,
 	migrateLegacyDistPath,
 	pickBestDistPath,
+	pruneStaleDistPaths,
 	traverseDistPaths,
 } from "./DistPathResolver.js";
 import { installGeminiHook, isGeminiHookInstalled, removeGeminiHook } from "./GeminiHookInstaller.js";
@@ -198,6 +199,20 @@ export async function install(
 				warnings,
 			};
 		}
+
+		// Sweep dist-paths entries whose dist dir was removed (e.g. an uninstalled IDE
+		// extension). Keeps dist-path selection — and the absolute Cli.js path it bakes
+		// into .mcp.json on Windows — pointed at live dists, so a ghost entry can't leave
+		// a dead MCP registration behind. Runs after writing our own (live) entry, so it
+		// never prunes the caller. Non-fatal: a leftover ghost is filtered at selection time.
+		try {
+			const pruned = await pruneStaleDistPaths();
+			if (pruned.length > 0) log.info("Pruned stale dist-paths entries: %s", pruned.join(", "));
+			/* v8 ignore start -- defensive: pruneStaleDistPaths swallows its own per-entry errors */
+		} catch (error: unknown) {
+			log.warn("Pruning stale dist-paths failed (non-fatal): %s", (error as Error).message);
+		}
+		/* v8 ignore stop */
 
 		// Run host detectors once before the per-worktree loop so each detector
 		// is called exactly once. Results are reused both inside the loop (for MCP

--- a/cli/src/install/Installer.ts
+++ b/cli/src/install/Installer.ts
@@ -138,12 +138,22 @@ function hasRequiredWorktreeHooks(
  *   Written to the global dist-path file so refreshHookPathsIfStale() can distinguish
  *   extension-managed paths from CLI-managed paths and avoid unwanted overwrites.
  */
-export async function install(cwd?: string, options?: { source?: "vscode-extension" | "cli" }): Promise<InstallResult> {
+export async function install(
+	cwd?: string,
+	options?: { source?: "vscode-extension" | "cli"; integrationsOnly?: boolean; sourceTag?: string },
+): Promise<InstallResult> {
 	/* v8 ignore next - process.cwd() fallback only used when called without cwd arg */
 	const projectDir = cwd ?? process.cwd();
 	const warnings: string[] = [];
 
-	log.info("Installing Jolli Memory hooks");
+	// integrations-only: set up the node-side integrations (dispatch scripts,
+	// dist-paths, MCP registration, skills) but install NO hooks (git or agent).
+	// Used by the IntelliJ plugin, which manages its own Java hooks and only needs
+	// this to light up MCP + skills — installing node hooks here would clobber
+	// IntelliJ's Java hooks and make memory generation depend on Node.
+	const integrationsOnly = options?.integrationsOnly === true;
+
+	log.info(integrationsOnly ? "Installing Jolli Memory integrations (no hooks)" : "Installing Jolli Memory hooks");
 
 	try {
 		// Load config to check integration enabled flags (always global)
@@ -173,10 +183,12 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 		/* v8 ignore stop */
 
 		// Determine this caller's source tag and write its per-source dist-paths/ entry.
-		// CLI -> "cli"; VSCode-family -> derive from extension path (vscode/cursor/...).
+		// An explicit sourceTag (e.g. "intellij" passed by the IntelliJ plugin) wins;
+		// otherwise CLI -> "cli"; VSCode-family -> derive from extension path.
 		const callerDistDir = dirname(fileURLToPath(import.meta.url));
 		const callerSource = options?.source ?? "cli";
-		const sourceTag = callerSource === "vscode-extension" ? deriveSourceTag(callerDistDir) : "cli";
+		const sourceTag =
+			options?.sourceTag ?? (callerSource === "vscode-extension" ? deriveSourceTag(callerDistDir) : "cli");
 
 		const distPathOk = await installDistPath(sourceTag);
 		if (!distPathOk) {
@@ -259,6 +271,9 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 			// others. Global hosts are registered once after the loop (below).
 			await registerRepoMcpHosts(wt, detected);
 
+			// integrations-only stops here: MCP + skills + git-exclude are done, but no
+			// Claude/SessionStart hooks (the caller manages its own hooks).
+			if (integrationsOnly) continue;
 			if (config.claudeEnabled === false) continue;
 			const result = await installClaudeHook(wt);
 			/* v8 ignore start -- defensive: installClaudeHook currently never returns warnings */
@@ -296,35 +311,44 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 		// machine without them), while Claude has no filesystem detector and is
 		// gated only on `claudeEnabled` — so `~/.claude/CLAUDE.md` is created
 		// whenever Claude isn't explicitly disabled, consistent with the rest of
-		// the installer treating Claude as the primary host.
+		// the installer treating Claude as the primary host. This is an integration
+		// (skill preference), not a hook, so it runs in integrations-only mode too.
 		await installGlobalInstructions({
 			claude: config.claudeEnabled !== false,
 			gemini: geminiDetectedOnce && config.geminiEnabled !== false,
 			codex: codexDetectedOnce && config.codexEnabled !== false,
 		});
 
-		// Git hooks are shared across all worktrees — install once
-		const gitResult = await installGitHook(projectDir);
-		if (gitResult.warning) {
-			warnings.push(gitResult.warning);
-		}
+		// Git hooks are shared across all worktrees — install once. Skipped in
+		// integrations-only mode (the caller owns its own git hooks); the *HookPath
+		// results then stay undefined, which the return below handles.
+		let gitResult: HookOpResult = {};
+		let postRewriteResult: HookOpResult = {};
+		let prepareMsgResult: HookOpResult = {};
+		let postMergeResult: HookOpResult = {};
+		if (!integrationsOnly) {
+			gitResult = await installGitHook(projectDir);
+			if (gitResult.warning) {
+				warnings.push(gitResult.warning);
+			}
 
-		// Install Git post-rewrite hook (handles amend/rebase summary migration)
-		const postRewriteResult = await installPostRewriteHook(projectDir);
-		if (postRewriteResult.warning) {
-			warnings.push(postRewriteResult.warning);
-		}
+			// Install Git post-rewrite hook (handles amend/rebase summary migration)
+			postRewriteResult = await installPostRewriteHook(projectDir);
+			if (postRewriteResult.warning) {
+				warnings.push(postRewriteResult.warning);
+			}
 
-		// Install Git prepare-commit-msg hook (handles git merge --squash)
-		const prepareMsgResult = await installPrepareMsgHook(projectDir);
-		if (prepareMsgResult.warning) {
-			warnings.push(prepareMsgResult.warning);
-		}
+			// Install Git prepare-commit-msg hook (handles git merge --squash)
+			prepareMsgResult = await installPrepareMsgHook(projectDir);
+			if (prepareMsgResult.warning) {
+				warnings.push(prepareMsgResult.warning);
+			}
 
-		// Install Git post-merge hook (auto-compiles merged branch summaries after pull/merge)
-		const postMergeResult = await installPostMergeHook(projectDir);
-		if (postMergeResult.warning) {
-			warnings.push(postMergeResult.warning);
+			// Install Git post-merge hook (auto-compiles merged branch summaries after pull/merge)
+			postMergeResult = await installPostMergeHook(projectDir);
+			if (postMergeResult.warning) {
+				warnings.push(postMergeResult.warning);
+			}
 		}
 
 		// Auto-detect Codex CLI and enable session discovery (saved to global config)
@@ -335,14 +359,18 @@ export async function install(cwd?: string, options?: { source?: "vscode-extensi
 			}
 		}
 
-		// Auto-detect Gemini CLI and install AfterAgent hook in all worktrees (if enabled)
+		// Auto-detect Gemini CLI and install AfterAgent hook in all worktrees (if enabled).
+		// The AfterAgent hook install is skipped in integrations-only mode; the config
+		// flag is still recorded so session discovery works for the caller's own hooks.
 		let geminiSettingsPath: string | undefined;
 		if (geminiDetectedOnce && config.geminiEnabled !== false) {
-			for (const wt of worktrees) {
-				const geminiResult = await installGeminiHook(wt);
-				// Capture the path from the primary worktree
-				if (wt === projectDir || geminiSettingsPath === undefined) {
-					geminiSettingsPath = geminiResult.path;
+			if (!integrationsOnly) {
+				for (const wt of worktrees) {
+					const geminiResult = await installGeminiHook(wt);
+					// Capture the path from the primary worktree
+					if (wt === projectDir || geminiSettingsPath === undefined) {
+						geminiSettingsPath = geminiResult.path;
+					}
 				}
 			}
 			if (config.geminiEnabled === undefined) {
@@ -549,12 +577,18 @@ async function migrateWorktreeConfig(worktreeDir: string): Promise<void> {
  *
  * @param cwd - Optional working directory (defaults to process.cwd())
  */
-export async function uninstall(cwd?: string): Promise<InstallResult> {
+export async function uninstall(cwd?: string, options?: { integrationsOnly?: boolean }): Promise<InstallResult> {
 	/* v8 ignore next - process.cwd() fallback only used when called without cwd arg */
 	const projectDir = cwd ?? process.cwd();
 	const warnings: string[] = [];
 
-	log.info("Removing Jolli Memory hooks");
+	// integrations-only: mirror of `install --integrations-only` — remove only the
+	// repo-scoped MCP registration (the caller owns its own hooks, so leave them,
+	// the git hooks, skills, and dist-paths alone). Used by the IntelliJ plugin on
+	// disable so it doesn't tear out hooks it never installed.
+	const integrationsOnly = options?.integrationsOnly === true;
+
+	log.info(integrationsOnly ? "Removing Jolli Memory integrations (MCP)" : "Removing Jolli Memory hooks");
 
 	try {
 		// Attempt to list all worktrees; fall back to just this directory if it fails
@@ -563,6 +597,18 @@ export async function uninstall(cwd?: string): Promise<InstallResult> {
 			worktrees = await listWorktrees(projectDir);
 		} catch {
 			worktrees = [projectDir];
+		}
+
+		if (integrationsOnly) {
+			for (const wt of worktrees) {
+				try {
+					await removeRepoMcpHosts(wt);
+				} catch (mcpErr) {
+					log.warn("MCP removal failed in %s (non-fatal): %s", wt, (mcpErr as Error).message);
+				}
+			}
+			log.info("Integrations removal complete");
+			return { success: true, message: "Jolli Memory integrations removed (MCP)", warnings };
 		}
 
 		// Remove Claude Code and Gemini hooks from every worktree

--- a/cli/src/install/mcp/CodexTomlWriter.test.ts
+++ b/cli/src/install/mcp/CodexTomlWriter.test.ts
@@ -1,7 +1,21 @@
-import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+// Spy on readFile so a single test can simulate a non-ENOENT read failure (EACCES)
+// deterministically on every platform. Default passes through to the real impl.
+// (chmod(0o000) can't make a file unreadable on Windows — it only sets read-only,
+// which leaves reads working and instead fails the later write.)
+const { mockReadFile } = vi.hoisted(() => ({
+	mockReadFile: vi.fn<typeof import("node:fs/promises").readFile>(),
+}));
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:fs/promises")>();
+	mockReadFile.mockImplementation(original.readFile);
+	return { ...original, readFile: mockReadFile };
+});
+
 import { removeCodexMcpServer, upsertCodexMcpServer } from "./CodexTomlWriter.js";
 
 const entry = { command: "/h/.jolli/jollimemory/run-cli", args: ["mcp"] };
@@ -44,14 +58,11 @@ describe("CodexTomlWriter", () => {
 	it("upsertCodexMcpServer skips and warns when file exists but is unreadable (non-ENOENT)", async () => {
 		const p = join(await mkdtemp(join(tmpdir(), "c-")), "config.toml");
 		await writeFile(p, 'model = "o4"\n', "utf-8");
-		await chmod(p, 0o000);
-		try {
-			await upsertCodexMcpServer(p, entry);
-			// file should be untouched (chmod 000 means we cannot write either)
-		} finally {
-			await chmod(p, 0o644);
-		}
-		const t = await readFile(p, "utf-8");
+		// Simulate an unreadable-but-present file (EACCES). The writer must skip rather
+		// than treat it like ENOENT and clobber the user's other Codex config.
+		mockReadFile.mockRejectedValueOnce(Object.assign(new Error("EACCES"), { code: "EACCES" }));
+		await upsertCodexMcpServer(p, entry);
+		const t = await readFile(p, "utf-8"); // passthrough (real impl) — file untouched
 		expect(t).toBe('model = "o4"\n');
 	});
 	it("removeCodexMcpServer is a no-op when file is absent", async () => {

--- a/cli/src/install/mcp/HostRegistrars.test.ts
+++ b/cli/src/install/mcp/HostRegistrars.test.ts
@@ -35,11 +35,14 @@ describe("buildRegistrars", () => {
 		expect(registrars).toHaveLength(0);
 	});
 
-	it("claude registrar.register() writes .mcp.json with mcpServers.jollimemory.args === ['mcp']", async () => {
+	it("claude registrar.register() writes .mcp.json with the jollimemory mcp subcommand", async () => {
 		const [claude] = buildRegistrars({ ...NONE, claude: true });
 		await claude.register(dir);
 		const json = JSON.parse(await readFile(join(dir, ".mcp.json"), "utf-8"));
-		expect(json.mcpServers.jollimemory.args).toEqual(["mcp"]);
+		// `.toContain` not `.toEqual(["mcp"])`: on Windows the args are prefixed with
+		// the resolved `Cli.js` path (see mcpServerEntry). The exact per-platform shape
+		// is asserted by the mcpServerEntry unit tests and the "jolliEntry — Windows" test.
+		expect(json.mcpServers.jollimemory.args).toContain("mcp");
 	});
 
 	it("claude registrar.gitExcludePaths() returns [MCP_GIT_EXCLUDE_PATH]", () => {
@@ -57,7 +60,7 @@ describe("registerRepoMcpHosts", () => {
 	it("registers claude (repo-scoped) when detected", async () => {
 		await registerRepoMcpHosts(dir, { ...NONE, claude: true });
 		const json = JSON.parse(await readFile(join(dir, ".mcp.json"), "utf-8"));
-		expect(json.mcpServers.jollimemory.args).toEqual(["mcp"]);
+		expect(json.mcpServers.jollimemory.args).toContain("mcp");
 	});
 
 	it("skips registration when no hosts detected", async () => {
@@ -100,7 +103,7 @@ describe("cursor registrar", () => {
 		await cursor.register(dir);
 		const json = JSON.parse(await readFile(join(dir, ".cursor", "mcp.json"), "utf-8"));
 		expect(json.mcpServers.jollimemory).toBeDefined();
-		expect(json.mcpServers.jollimemory.args).toEqual(["mcp"]);
+		expect(json.mcpServers.jollimemory.args).toContain("mcp");
 	});
 
 	it("remove() is a no-op when .cursor/mcp.json is absent", async () => {
@@ -307,7 +310,7 @@ describe("new registrars — register targets & entry shape (mocked writer)", ()
 		const [path, entry, key] = upsertMock.mock.calls[0];
 		expect(path).toBe(join(homedir(), ".copilot", "mcp-config.json"));
 		expect(key).toBeUndefined(); // default mcpServers
-		expect(entry.args).toEqual(["mcp"]);
+		expect(entry.args).toContain("mcp");
 	});
 
 	it("copilotChat register() → VS Code User/mcp.json, key `servers`, type:stdio", async () => {
@@ -318,7 +321,7 @@ describe("new registrars — register targets & entry shape (mocked writer)", ()
 		expect(path).toBe(join(getVscodeUserDataDir("Code"), "User", "mcp.json"));
 		expect(key).toBe("servers");
 		expect(entry.type).toBe("stdio");
-		expect(entry.args).toEqual(["mcp"]);
+		expect(entry.args).toContain("mcp");
 	});
 
 	it("opencode/copilotChat remove() pass the right serversKey", async () => {

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -528,11 +528,14 @@ tasks {
         // unit tests in one sequential JVM by default (~20 min); separate forks give
         // full isolation (each fork has its own System.out and mockk global state, so
         // the System.out-swapping and mockkStatic/mockkObject tests can't race), unlike
-        // in-JVM JUnit parallelism. Capped to avoid oversubscribing the IDE-sandbox JVMs.
+        // in-JVM JUnit parallelism. These are plain unit tests (no IDE boot), so use ALL
+        // available cores, capped at 6 to bound heap on large dev machines. (The old
+        // `processors / 2` left CI's 4-core public runner at 2 forks — a ~20 min run;
+        // full utilization fits comfortably in the 16 GB runner and roughly halves it.)
         // Partitioning captured output per fork (vs. one shared buffer) also avoids the
         // Gradle "Could not write XML test results" failure that the serial run hit when a
         // test emitted a NUL byte that is illegal in XML 1.0. Cuts a full run to ~5 min.
-        maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceIn(1, 6)
+        maxParallelForks = Runtime.getRuntime().availableProcessors().coerceIn(1, 6)
         javaLauncher.set(
             project.the<JavaToolchainService>().launcherFor {
                 languageVersion.set(JavaLanguageVersion.of(21))

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "ai.jolli"
-version = "0.99.4"
+version = "0.99.4.5"
 
 repositories {
     mavenCentral()
@@ -306,31 +306,71 @@ tasks.register("copyHookJarToSandbox") {
     }
 }
 
-// buildSearchableOptions reads from sandbox — make sure hooks JAR is there
+// Bundle the self-contained CLI bundle (esbuild output — all deps inlined, no
+// node_modules) so the plugin can run `node Cli.js enable --integrations-only`
+// to light up MCP + skills without depending on a global CLI install. Source is
+// vscode/dist/Cli.js (produced by `npm run build`); copied into the plugin's
+// cli-dist/ (like the hooks JAR's bin/), off the classloader path.
+// Bundle the FULL self-contained CLI dist (all esbuild bundles: Cli.js + the hook
+// entry scripts PostCommitHook.js / PrepareMsgHook.js / …). Cli.js alone is enough
+// for MCP + skills, but the shared `run-hook` dispatcher execs the per-hook .js
+// files by name — so a single-file bundle would break node git hooks whenever the
+// IntelliJ dist wins dist-paths arbitration (mixed installs). Excludes Extension.js
+// (the VS Code extension-host bundle, not needed here).
+val vscodeDistDir = rootProject.layout.projectDirectory.dir("../vscode/dist")
+tasks.register("copyCliDistToSandbox") {
+    dependsOn("prepareSandbox")
+    doLast {
+        val srcDir = vscodeDistDir.asFile
+        val cliJs = File(srcDir, "Cli.js")
+        if (!cliJs.exists()) {
+            throw GradleException(
+                "Bundled CLI not found at ${cliJs.path}. Run `npm run build` at the repo root " +
+                    "first (it builds vscode/dist/*.js), then re-run the Gradle build.",
+            )
+        }
+        val cliDist = layout.buildDirectory.dir("idea-sandbox/plugins/jollimemory-intellij/cli-dist").get().asFile
+        cliDist.mkdirs()
+        val copied = srcDir.listFiles { f -> f.isFile && f.name.endsWith(".js") && f.name != "Extension.js" }
+            ?.onEach { it.copyTo(File(cliDist, it.name), overwrite = true) }
+            ?.size ?: 0
+        logger.lifecycle("Copied bundled CLI dist ($copied .js files) to: $cliDist")
+    }
+}
+
+// buildSearchableOptions reads from sandbox — make sure hooks JAR + CLI bundle are there
 tasks.named("buildSearchableOptions") {
-    dependsOn("copyHookJarToSandbox")
+    dependsOn("copyHookJarToSandbox", "copyCliDistToSandbox")
 }
 
 // After buildPlugin creates the zip, inject bin/ JARs and strip unused sqlite-jdbc natives from lib/.
 tasks.named("buildPlugin") {
-    dependsOn("copyHookJarToSandbox")
+    dependsOn("copyHookJarToSandbox", "copyCliDistToSandbox")
+    val buildPluginArchive = layout.buildDirectory.file("distributions/jollimemory-intellij-${project.version}.zip")
     doLast {
-        val zipFile = layout.buildDirectory.dir("distributions").get().asFile
-            .listFiles()?.firstOrNull { it.name.endsWith(".zip") } ?: return@doLast
+        // Target THIS build's archive by exact name. Using listFiles().firstOrNull { .zip }
+        // grabbed a stale prior-version (or already-signed) zip when build/distributions/
+        // still held old artifacts, leaving the real output un-injected and unstripped.
+        val zipFile = buildPluginArchive.get().asFile.takeIf { it.exists() } ?: return@doLast
         val pluginBin = layout.buildDirectory.dir("idea-sandbox/plugins/jollimemory-intellij/bin").get().asFile
+        val pluginCliDist = layout.buildDirectory.dir("idea-sandbox/plugins/jollimemory-intellij/cli-dist").get().asFile
 
         // 1. Add hooks JAR to bin/ (outside lib/ so Plugin Verifier skips it).
         //    sqlite-jdbc.jar is NOT duplicated here — the hooks JAR's Class-Path manifest
         //    references ../lib/sqlite-jdbc-*.jar when running from the plugin directory.
         //    A separate copy is only made to ~/.jolli/bin/ by HookInstaller at install time.
+        //    The bundled CLI goes to cli-dist/ (also off the classloader path).
         ant.withGroovyBuilder {
             "zip"("destfile" to zipFile.absolutePath, "update" to true) {
                 "zipfileset"("dir" to pluginBin.absolutePath, "prefix" to "jollimemory-intellij/bin") {
                     "include"("name" to "jollimemory-hooks.jar")
                 }
+                "zipfileset"("dir" to pluginCliDist.absolutePath, "prefix" to "jollimemory-intellij/cli-dist") {
+                    "include"("name" to "*.js")
+                }
             }
         }
-        logger.lifecycle("Injected hooks JAR into: ${zipFile.name}")
+        logger.lifecycle("Injected hooks JAR + CLI bundle into: ${zipFile.name}")
 
         // 2. Strip sqlite-jdbc native libraries in lib/ for platforms IntelliJ never runs on.
         //    The lib/ copy is used by the IDE plugin classloader; bin/sqlite-jdbc.jar is for hooks.

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "ai.jolli"
-version = "0.99.4.5"
+version = "0.99.4.6"
 
 repositories {
     mavenCentral()

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/CliIntegrations.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/CliIntegrations.kt
@@ -103,15 +103,43 @@ object CliIntegrations {
         return null
     }
 
+    /** The extracted-CLI directory that `dist-paths/intellij` points at. */
+    internal fun distIntellijDir(): File =
+        File(System.getProperty("user.home"), ".jolli/jollimemory/dist-intellij")
+
     /**
-     * True when the integrations have already been set up for the CURRENT plugin
-     * version — i.e. the bundled Cli.js is extracted and its version stamp matches.
-     * Lets startup skip re-running node on every launch, but re-run after an upgrade.
+     * True when integrations were **successfully enabled** for the CURRENT plugin version.
+     * The `.version` stamp is written ONLY after [enableIntegrations] returns [Result.Ok]
+     * (see [markIntegrationsEnabled]) — NOT when the bundle is merely extracted. That
+     * distinction matters: a failed `enable` (skills/MCP not written) must not look "done",
+     * otherwise startup never retries it and the StatusPanel shows a false "active".
+     * Lets startup skip re-running node on every launch, but re-run after an upgrade or a
+     * previous failure.
      */
-    fun integrationsUpToDate(): Boolean {
-        val distDir = File(System.getProperty("user.home"), ".jolli/jollimemory/dist-intellij")
+    fun integrationsUpToDate(): Boolean = integrationsUpToDate(distIntellijDir())
+
+    /** Testable seam: same predicate against an explicit dist dir. */
+    internal fun integrationsUpToDate(distDir: File): Boolean {
         val stamp = File(distDir, ".version")
         return File(distDir, "Cli.js").exists() && stamp.exists() && stamp.readText().trim() == readPluginVersion()
+    }
+
+    /** Records a successful enable by stamping the current plugin version. */
+    internal fun markIntegrationsEnabled(distDir: File) {
+        try {
+            File(distDir, ".version").writeText(readPluginVersion())
+        } catch (e: Exception) {
+            log.warn("Failed to write integrations version stamp: %s", e.message)
+        }
+    }
+
+    /** Clears the enabled stamp so the next startup retries `enable`. */
+    internal fun clearIntegrationsEnabled(distDir: File) {
+        try {
+            File(distDir, ".version").delete()
+        } catch (_: Exception) {
+            // best-effort — a stale stamp only means one extra retry
+        }
     }
 
     /** Resolves the plugin-bundled `cli-dist/Cli.js`. */
@@ -132,21 +160,19 @@ object CliIntegrations {
     fun extractCliDist(): File? {
         val cliJs = resolveBundledCliJs() ?: return null
         val srcDir = cliJs.parentFile ?: return null // the bundled cli-dist directory
-        val distDir = File(System.getProperty("user.home"), ".jolli/jollimemory/dist-intellij")
-        val stamp = File(distDir, ".version")
-        val version = readPluginVersion()
+        val distDir = distIntellijDir()
         return try {
             distDir.mkdirs()
-            val current = if (stamp.exists()) stamp.readText().trim() else null
-            if (!File(distDir, "Cli.js").exists() || current != version) {
-                // Copy the WHOLE dist (Cli.js + the per-hook entry scripts) so this dist
-                // also satisfies `run-hook`, not just `run-cli`/MCP/skills.
-                val n = srcDir.listFiles { f -> f.isFile && f.name.endsWith(".js") }
-                    ?.onEach { it.copyTo(File(distDir, it.name), overwrite = true) }
-                    ?.size ?: 0
-                stamp.writeText(version)
-                log.info("Extracted bundled CLI dist (%d files) to %s (version=%s)", n, distDir.absolutePath, version)
-            }
+            // Copy the WHOLE dist (Cli.js + the per-hook entry scripts) so this dist also
+            // satisfies `run-hook`, not just `run-cli`/MCP/skills. This runs only from
+            // [enableIntegrations]/[disableIntegrations] (i.e. when NOT already enabled),
+            // so an unconditional overwrite is off the hot path. Deliberately writes NO
+            // version stamp — the stamp means "enable succeeded" and is written by
+            // [markIntegrationsEnabled] only after the enable subprocess returns Ok.
+            val n = srcDir.listFiles { f -> f.isFile && f.name.endsWith(".js") }
+                ?.onEach { it.copyTo(File(distDir, it.name), overwrite = true) }
+                ?.size ?: 0
+            log.info("Extracted bundled CLI dist (%d files) to %s", n, distDir.absolutePath)
             distDir
         } catch (e: Exception) {
             log.error("Failed to extract bundled CLI: %s", e.message)
@@ -220,13 +246,18 @@ object CliIntegrations {
                 return Result.Failed("integrations enable timed out")
             }
             if (proc.exitValue() == 0) {
+                // Stamp "enabled" ONLY now — after a confirmed success — so a later failure
+                // or an interrupted run is never mistaken for a completed one.
+                markIntegrationsEnabled(distDir)
                 log.info("Integrations enabled via bundled CLI")
                 Result.Ok
             } else {
+                clearIntegrationsEnabled(distDir)
                 log.warn("Integrations enable exited %d: %s", proc.exitValue(), out.take(500))
                 Result.Failed("exit ${proc.exitValue()}")
             }
         } catch (e: Exception) {
+            clearIntegrationsEnabled(distDir)
             log.error("Failed to run integrations enable: %s", e.message)
             Result.Failed(e.message ?: "unknown")
         }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/CliIntegrations.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/CliIntegrations.kt
@@ -1,5 +1,6 @@
 package ai.jolli.jollimemory.bridge
 
+import com.google.gson.JsonParser
 import ai.jolli.jollimemory.core.JmLogger
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -122,6 +123,44 @@ object CliIntegrations {
     internal fun integrationsUpToDate(distDir: File): Boolean {
         val stamp = File(distDir, ".version")
         return File(distDir, "Cli.js").exists() && stamp.exists() && stamp.readText().trim() == readPluginVersion()
+    }
+
+    /**
+     * True when `<projectDir>/.mcp.json` registers the jollimemory MCP server at a
+     * command that can no longer be spawned — specifically the Windows form
+     * `node <abs Cli.js>` whose Cli.js no longer exists on disk. That happens when the
+     * dist that won dist-path selection at registration time was later removed (e.g. a
+     * VS Code extension uninstall) and nothing re-registered since, leaving a dead
+     * `.mcp.json` the AI host fails to launch.
+     *
+     * The version stamp alone can't catch this: the registration goes stale from an
+     * environment change (another surface uninstalled), not a plugin-version change, so
+     * [integrationsUpToDate] stays true and startup would otherwise never re-register.
+     * Used as an extra re-enable trigger alongside the version gate — one healing
+     * re-enable re-resolves `.mcp.json` to a live dist (the CLI also prunes the ghost
+     * dist-paths entry as part of that enable).
+     *
+     * The POSIX form registers the `run-cli` dispatch script (indirection that
+     * re-resolves at spawn time and never goes stale), so this only fires on the
+     * baked-absolute-path Windows form. Pure file I/O — no node — so it's cheap on every
+     * startup. Returns false when there is no `.mcp.json`, no jollimemory entry, the
+     * entry isn't the `node <Cli.js>` form, or its Cli.js still exists.
+     */
+    fun mcpRegistrationStale(projectDir: String): Boolean {
+        val f = File(projectDir, ".mcp.json")
+        if (!f.exists()) return false
+        return try {
+            val root = JsonParser.parseString(f.readText(Charsets.UTF_8)).asJsonObject
+            val server = root.getAsJsonObject("mcpServers")?.getAsJsonObject("jollimemory") ?: return false
+            val command = server.get("command")?.asString ?: return false
+            // POSIX form uses the run-cli dispatch script (never stales); only the Windows
+            // `node <Cli.js>` form bakes an absolute path that can point at a removed dist.
+            if (!command.equals("node", ignoreCase = true)) return false
+            val cliJs = server.getAsJsonArray("args")?.firstOrNull()?.asString ?: return false
+            !File(cliJs).exists()
+        } catch (_: Exception) {
+            false
+        }
     }
 
     /** Records a successful enable by stamping the current plugin version. */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/CliIntegrations.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/CliIntegrations.kt
@@ -1,0 +1,241 @@
+package ai.jolli.jollimemory.bridge
+
+import ai.jolli.jollimemory.core.JmLogger
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * CliIntegrations — lights up MCP + skills for an IntelliJ-only install by shelling
+ * out to the plugin-bundled, self-contained CLI (`cli-dist/Cli.js`, an esbuild bundle
+ * with all deps inlined — no node_modules).
+ *
+ * The plugin runs its own Java git hooks and generates memory without Node, so it does
+ * NOT install Node hooks. But the MCP server (`jolli mcp`) and the recall/search/pr
+ * skills are inherently Node programs — the only way to provide them is a Node runtime.
+ * So this reuses the CLI's own `enable --integrations-only` (dispatch scripts +
+ * dist-paths + MCP registration + skills, NO hooks) instead of re-porting all of that
+ * to Kotlin.
+ *
+ * Node is required only at MCP/skill run time (in the AI host) — and here, at enable
+ * time, to run the setup. When Node is absent, this is a clean no-op-with-signal:
+ * memory generation keeps working via the Java hooks; the caller notifies the user.
+ */
+object CliIntegrations {
+
+    private val log = JmLogger.create("CliIntegrations")
+    private val isWindows = System.getProperty("os.name").lowercase().contains("win")
+
+    sealed class Result {
+        /** Integrations set up successfully. */
+        object Ok : Result()
+
+        /** Node is not on PATH — integrations skipped (memory generation still works). */
+        object NodeMissing : Result()
+
+        /** The bundled Cli.js could not be located (packaging problem). */
+        object BundleMissing : Result()
+
+        /** The bundled CLI ran but failed. */
+        data class Failed(val message: String) : Result()
+    }
+
+    /**
+     * Locates the installed plugin's root directory. Tries the class's codeSource
+     * first, then falls back to parsing a bundled resource's URL — because on newer
+     * IntelliJ (2026.1+) `protectionDomain.codeSource.location` is null for plugin
+     * classes under the module classloader, which broke the codeSource-only lookup.
+     */
+    fun resolvePluginDir(): File? {
+        // Strategy 1: codeSource → …/<plugin>/lib/<jar>.jar → <plugin>
+        try {
+            val loc = javaClass.protectionDomain?.codeSource?.location
+            if (loc != null) {
+                val jar = File(loc.toURI())
+                val dir = jar.parentFile?.parentFile
+                if (dir != null && dir.isDirectory) return dir
+            }
+        } catch (_: Throwable) {
+            // fall through to the resource-URL strategy
+        }
+        // Strategy 2: a bundled resource's URL → jar path → plugin dir. getResource works
+        // even when codeSource.location is null (it's how readPluginVersion already reads).
+        try {
+            val url = javaClass.getResource("/jollimemory-plugin-version.txt") ?: return null
+            val s = url.toString()
+            when {
+                // jar:file:/…/<plugin>/lib/<jar>.jar!/jollimemory-plugin-version.txt
+                s.startsWith("jar:") -> {
+                    val jar = File(java.net.URI(s.removePrefix("jar:").substringBefore("!/")))
+                    val dir = jar.parentFile?.parentFile
+                    if (dir != null && dir.isDirectory) return dir
+                }
+                // file:/…/<plugin>/classes/… (sandbox/unpacked) — climb to the dir holding cli-dist/bin
+                s.startsWith("file:") -> {
+                    var d: File? = File(java.net.URI(s.substringBefore("!/"))).parentFile
+                    repeat(6) {
+                        val cur = d
+                        if (cur != null && (File(cur, "cli-dist").isDirectory || File(cur, "bin").isDirectory)) return cur
+                        d = cur?.parentFile
+                    }
+                }
+            }
+        } catch (e: Throwable) {
+            log.warn("resolvePluginDir fallback failed: %s", e.message)
+        }
+        return null
+    }
+
+    /**
+     * True when the integrations have already been set up for the CURRENT plugin
+     * version — i.e. the bundled Cli.js is extracted and its version stamp matches.
+     * Lets startup skip re-running node on every launch, but re-run after an upgrade.
+     */
+    fun integrationsUpToDate(): Boolean {
+        val distDir = File(System.getProperty("user.home"), ".jolli/jollimemory/dist-intellij")
+        val stamp = File(distDir, ".version")
+        return File(distDir, "Cli.js").exists() && stamp.exists() && stamp.readText().trim() == readPluginVersion()
+    }
+
+    /** Resolves the plugin-bundled `cli-dist/Cli.js`. */
+    fun resolveBundledCliJs(): File? {
+        val dir = resolvePluginDir() ?: return null
+        val candidate = File(dir, "cli-dist/Cli.js")
+        if (candidate.exists()) return candidate
+        // Non-standard layout fallback: walk for cli-dist/Cli.js.
+        return dir.walkTopDown().maxDepth(5)
+            .firstOrNull { it.name == "Cli.js" && it.parentFile?.name == "cli-dist" }
+    }
+
+    /**
+     * Extracts the bundled Cli.js to `~/.jolli/jollimemory/dist-intellij/` (version-gated
+     * on the plugin version) and returns that dist directory. `dist-paths/intellij` will
+     * point here after [enableIntegrations] runs.
+     */
+    fun extractCliDist(): File? {
+        val cliJs = resolveBundledCliJs() ?: return null
+        val srcDir = cliJs.parentFile ?: return null // the bundled cli-dist directory
+        val distDir = File(System.getProperty("user.home"), ".jolli/jollimemory/dist-intellij")
+        val stamp = File(distDir, ".version")
+        val version = readPluginVersion()
+        return try {
+            distDir.mkdirs()
+            val current = if (stamp.exists()) stamp.readText().trim() else null
+            if (!File(distDir, "Cli.js").exists() || current != version) {
+                // Copy the WHOLE dist (Cli.js + the per-hook entry scripts) so this dist
+                // also satisfies `run-hook`, not just `run-cli`/MCP/skills.
+                val n = srcDir.listFiles { f -> f.isFile && f.name.endsWith(".js") }
+                    ?.onEach { it.copyTo(File(distDir, it.name), overwrite = true) }
+                    ?.size ?: 0
+                stamp.writeText(version)
+                log.info("Extracted bundled CLI dist (%d files) to %s (version=%s)", n, distDir.absolutePath, version)
+            }
+            distDir
+        } catch (e: Exception) {
+            log.error("Failed to extract bundled CLI: %s", e.message)
+            null
+        }
+    }
+
+    private fun readPluginVersion(): String =
+        try {
+            javaClass.getResourceAsStream("/jollimemory-plugin-version.txt")
+                ?.bufferedReader()?.use { it.readText().trim() } ?: "dev"
+        } catch (_: Exception) {
+            "dev"
+        }
+
+    /**
+     * The user's login-shell PATH. GUI-launched IDEs inherit a minimal PATH that often
+     * omits node installed via nvm/homebrew, so we ask the login shell (matches
+     * PrService's gh resolution).
+     */
+    private val resolvedPath: String by lazy {
+        try {
+            if (isWindows) {
+                System.getenv("PATH") ?: ""
+            } else {
+                val shell = System.getenv("SHELL")?.takeIf { it.isNotBlank() && File(it).canExecute() } ?: "/bin/zsh"
+                val proc = ProcessBuilder(shell, "-l", "-c", "echo \$PATH").redirectErrorStream(true).start()
+                val out = proc.inputStream.bufferedReader().use { it.readText().trim() }
+                proc.waitFor(5, TimeUnit.SECONDS)
+                if (out.isNotBlank()) out else System.getenv("PATH") ?: ""
+            }
+        } catch (_: Exception) {
+            System.getenv("PATH") ?: ""
+        }
+    }
+
+    /** Absolute path to a `node` executable on the login-shell PATH, or null if absent. */
+    fun resolveNode(): String? {
+        val candidates = if (isWindows) listOf("node.exe", "node.cmd", "node") else listOf("node")
+        for (dir in resolvedPath.split(File.pathSeparator)) {
+            if (dir.isBlank()) continue
+            for (name in candidates) {
+                val f = File(dir, name)
+                if (f.canExecute()) return f.absolutePath
+            }
+        }
+        return null
+    }
+
+    fun isNodeAvailable(): Boolean = resolveNode() != null
+
+    /**
+     * Sets up MCP + skills by running the bundled CLI's `enable --integrations-only`
+     * (tagged `intellij` so its dist-paths entry coexists with any CLI/VS Code install).
+     * Returns [Result.NodeMissing] when Node is absent — a clean skip, not an error.
+     */
+    fun enableIntegrations(projectDir: String): Result {
+        val node = resolveNode() ?: return Result.NodeMissing
+        val distDir = extractCliDist() ?: return Result.BundleMissing
+        val cliJs = File(distDir, "Cli.js")
+        return try {
+            val proc = ProcessBuilder(
+                node, cliJs.absolutePath, "enable", "--integrations-only", "--source-tag", "intellij",
+            )
+                .directory(File(projectDir))
+                .redirectErrorStream(true)
+                .start()
+            val out = proc.inputStream.bufferedReader().use { it.readText() }
+            if (!proc.waitFor(60, TimeUnit.SECONDS)) {
+                proc.destroyForcibly()
+                return Result.Failed("integrations enable timed out")
+            }
+            if (proc.exitValue() == 0) {
+                log.info("Integrations enabled via bundled CLI")
+                Result.Ok
+            } else {
+                log.warn("Integrations enable exited %d: %s", proc.exitValue(), out.take(500))
+                Result.Failed("exit ${proc.exitValue()}")
+            }
+        } catch (e: Exception) {
+            log.error("Failed to run integrations enable: %s", e.message)
+            Result.Failed(e.message ?: "unknown")
+        }
+    }
+
+    /**
+     * Tears down the MCP registration via `disable --integrations-only` (best-effort).
+     * No-op when Node or the bundle is missing — nothing to undo that we could reach.
+     */
+    fun disableIntegrations(projectDir: String): Result {
+        val node = resolveNode() ?: return Result.NodeMissing
+        val distDir = extractCliDist() ?: return Result.BundleMissing
+        val cliJs = File(distDir, "Cli.js")
+        return try {
+            val proc = ProcessBuilder(node, cliJs.absolutePath, "disable", "--integrations-only")
+                .directory(File(projectDir))
+                .redirectErrorStream(true)
+                .start()
+            proc.inputStream.bufferedReader().use { it.readText() }
+            if (!proc.waitFor(60, TimeUnit.SECONDS)) {
+                proc.destroyForcibly()
+                return Result.Failed("integrations disable timed out")
+            }
+            if (proc.exitValue() == 0) Result.Ok else Result.Failed("exit ${proc.exitValue()}")
+        } catch (e: Exception) {
+            log.warn("Failed to run integrations disable (non-fatal): %s", e.message)
+            Result.Failed(e.message ?: "unknown")
+        }
+    }
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/CliIntegrations.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/CliIntegrations.kt
@@ -40,6 +40,24 @@ object CliIntegrations {
     }
 
     /**
+     * Human-readable warning for a non-successful integrations result, or `null` when
+     * everything is fine ([Result.Ok]). Centralized here so the install path and the
+     * startup catch-up path surface identical wording (balloon + StatusPanel tooltip).
+     */
+    fun warningFor(result: Result): String? = when (result) {
+        is Result.Ok -> null
+        is Result.NodeMissing ->
+            "Node.js not found — the MCP tools and the /jolli-search and /jolli-pr skills were skipped. " +
+                "Memory generation still works (native hooks). Install Node.js and reopen the project to activate them."
+        is Result.BundleMissing ->
+            "MCP and skills could not be set up — the bundled CLI was not found in the plugin. " +
+                "Try reinstalling the Jolli Memory plugin."
+        is Result.Failed ->
+            "MCP and skills failed to set up: ${result.message}. Memory generation still works. " +
+                "See ~/.jolli/logs/jollimemory-install-debug.log for details."
+    }
+
+    /**
      * Locates the installed plugin's root directory. Tries the class's codeSource
      * first, then falls back to parsing a bundled resource's URL — because on newer
      * IntelliJ (2026.1+) `protectionDomain.codeSource.location` is null for plugin

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitOps.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitOps.kt
@@ -187,19 +187,29 @@ class GitOps(private val projectDir: String) {
         }
     }
 
-    /** Get diff content for HEAD commit. */
-    fun getDiffContent(): String? {
-        return exec("diff", "HEAD~1..HEAD")
+    /**
+     * Get diff content for a commit (defaults to HEAD). Pass a specific [ref] when
+     * the queue drains a commit that is no longer HEAD — the diff must be that
+     * commit's own change, not whatever HEAD points at now. A root commit (no
+     * parent) has no `<ref>~1`, so fall back to `git show` against the empty tree.
+     */
+    fun getDiffContent(ref: String = "HEAD"): String? {
+        return if (hasParent(ref)) exec("diff", "$ref~1..$ref")
+        else exec("show", "--format=", ref)
     }
 
-    /** Get diff stats for HEAD commit. */
-    fun getDiffStats(): String? {
-        return exec("diff", "--stat", "--numstat", "HEAD~1..HEAD")
+    /** Get diff stats for a commit (defaults to HEAD). See [getDiffContent] for the [ref] rationale. */
+    fun getDiffStats(ref: String = "HEAD"): String? {
+        return if (hasParent(ref)) exec("diff", "--stat", "--numstat", "$ref~1..$ref")
+        else exec("show", "--stat", "--numstat", "--format=", ref)
     }
 
-    /** Get HEAD commit info. */
-    fun getHeadCommitInfo(): String? {
-        return exec("log", "-1", "--pretty=format:%H%x00%s%x00%an%x00%aI")
+    /** True when [ref] has a first parent (so `<ref>~1` resolves). */
+    private fun hasParent(ref: String): Boolean = exec("rev-parse", "--verify", "-q", "$ref~1") != null
+
+    /** Get commit info (hash subject author authorDate) for [ref] (defaults to HEAD). */
+    fun getHeadCommitInfo(ref: String = "HEAD"): String? {
+        return exec("log", "-1", "--pretty=format:%H%x00%s%x00%an%x00%aI", ref)
     }
 
     /** Get HEAD hash. */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/HookInstaller.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/HookInstaller.kt
@@ -193,22 +193,19 @@ class HookInstaller(private val projectDir: String, private val mainRepoRoot: St
             // Light up MCP + the full skill set (recall/search/pr) by shelling the bundled
             // CLI's integrations-only enable. Node-only: when Node is absent this is a clean
             // skip — Java hooks above already made memory generation work. Never fatal.
-            var nodeMissing = false
-            when (val integ = CliIntegrations.enableIntegrations(projectDir)) {
-                is CliIntegrations.Result.Ok -> installLog.appendLine("Integrations (MCP + skills) enabled")
-                is CliIntegrations.Result.NodeMissing -> {
-                    nodeMissing = true
-                    warnings.add(
-                        "Node.js not found — MCP and skills were skipped. Memory generation still works; " +
-                            "install Node.js and re-enable to activate MCP + skills.",
-                    )
-                    installLog.appendLine("Integrations skipped: Node.js not found")
-                }
-                is CliIntegrations.Result.BundleMissing ->
-                    installLog.appendLine("Integrations skipped: bundled Cli.js not found")
-                is CliIntegrations.Result.Failed ->
-                    installLog.appendLine("Integrations failed (non-fatal): ${integ.message}")
-            }
+            // ALL non-Ok results surface a warning (not just NodeMissing) so a failed/absent
+            // bundle no longer fails silently.
+            val integ = CliIntegrations.enableIntegrations(projectDir)
+            val integrationsIssue = CliIntegrations.warningFor(integ)
+            if (integrationsIssue != null) warnings.add(integrationsIssue)
+            installLog.appendLine(
+                when (integ) {
+                    is CliIntegrations.Result.Ok -> "Integrations (MCP + skills) enabled"
+                    is CliIntegrations.Result.NodeMissing -> "Integrations skipped: Node.js not found"
+                    is CliIntegrations.Result.BundleMissing -> "Integrations skipped: bundled Cli.js not found"
+                    is CliIntegrations.Result.Failed -> "Integrations failed (non-fatal): ${integ.message}"
+                },
+            )
 
             // Final verification: re-read Claude hook file
             val finalVerify = File(mainRepoRoot, ".claude/settings.local.json")
@@ -219,7 +216,7 @@ class HookInstaller(private val projectDir: String, private val mainRepoRoot: St
             // Write install log
             writeInstallLog(installLog.toString())
 
-            return InstallResult(true, "JolliMemory hooks installed successfully", warnings, nodeMissing = nodeMissing)
+            return InstallResult(true, "JolliMemory hooks installed successfully", warnings, integrationsIssue = integrationsIssue)
         } catch (e: Exception) {
             installLog.appendLine("ERROR: ${e.message}\n${e.stackTraceToString()}")
             writeInstallLog(installLog.toString())
@@ -240,11 +237,13 @@ class HookInstaller(private val projectDir: String, private val mainRepoRoot: St
      * upgrade activates them without a manual re-enable — `install()` doesn't re-run
      * once hooks are already installed. Idempotent + version-gated; node-only.
      *
-     * @return true if Node was missing (so the caller can notify).
+     * @return a human-readable warning when integrations could not be set up (Node missing,
+     *   bundle missing, or the CLI failed) so the caller can notify, or `null` when they are
+     *   already up to date or were set up successfully.
      */
-    fun ensureIntegrations(): Boolean {
-        if (CliIntegrations.integrationsUpToDate()) return false
-        return CliIntegrations.enableIntegrations(projectDir) is CliIntegrations.Result.NodeMissing
+    fun ensureIntegrations(): String? {
+        if (CliIntegrations.integrationsUpToDate()) return null
+        return CliIntegrations.warningFor(CliIntegrations.enableIntegrations(projectDir))
     }
 
     /**
@@ -655,6 +654,10 @@ data class InstallResult(
     val success: Boolean,
     val message: String,
     val warnings: List<String>,
-    /** True when Node.js was absent so MCP + skills were skipped (memory generation still works). */
-    val nodeMissing: Boolean = false,
+    /**
+     * Human-readable reason MCP + skills were not set up (Node missing, bundle missing, or
+     * the bundled CLI failed), or `null` when they succeeded. Memory generation works either
+     * way. Drives the balloon notification; the StatusPanel row reflects the live state.
+     */
+    val integrationsIssue: String? = null,
 )

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/HookInstaller.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/HookInstaller.kt
@@ -237,12 +237,19 @@ class HookInstaller(private val projectDir: String, private val mainRepoRoot: St
      * upgrade activates them without a manual re-enable — `install()` doesn't re-run
      * once hooks are already installed. Idempotent + version-gated; node-only.
      *
+     * Beyond the version gate, this also re-runs when the project's `.mcp.json` points
+     * the jollimemory server at a `node <Cli.js>` path that no longer exists (see
+     * [CliIntegrations.mcpRegistrationStale]). Such a dead registration comes from an
+     * environment change — another surface's dist being removed — not a plugin-version
+     * change, so the version stamp can't catch it; one re-enable re-resolves `.mcp.json`
+     * to a live dist.
+     *
      * @return a human-readable warning when integrations could not be set up (Node missing,
      *   bundle missing, or the CLI failed) so the caller can notify, or `null` when they are
      *   already up to date or were set up successfully.
      */
     fun ensureIntegrations(): String? {
-        if (CliIntegrations.integrationsUpToDate()) return null
+        if (CliIntegrations.integrationsUpToDate() && !CliIntegrations.mcpRegistrationStale(projectDir)) return null
         return CliIntegrations.warningFor(CliIntegrations.enableIntegrations(projectDir))
     }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/HookInstaller.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/HookInstaller.kt
@@ -190,6 +190,26 @@ class HookInstaller(private val projectDir: String, private val mainRepoRoot: St
             SkillInstaller(mainRepoRoot).updateSkillIfNeeded()
             installLog.appendLine("Skill installed")
 
+            // Light up MCP + the full skill set (recall/search/pr) by shelling the bundled
+            // CLI's integrations-only enable. Node-only: when Node is absent this is a clean
+            // skip — Java hooks above already made memory generation work. Never fatal.
+            var nodeMissing = false
+            when (val integ = CliIntegrations.enableIntegrations(projectDir)) {
+                is CliIntegrations.Result.Ok -> installLog.appendLine("Integrations (MCP + skills) enabled")
+                is CliIntegrations.Result.NodeMissing -> {
+                    nodeMissing = true
+                    warnings.add(
+                        "Node.js not found — MCP and skills were skipped. Memory generation still works; " +
+                            "install Node.js and re-enable to activate MCP + skills.",
+                    )
+                    installLog.appendLine("Integrations skipped: Node.js not found")
+                }
+                is CliIntegrations.Result.BundleMissing ->
+                    installLog.appendLine("Integrations skipped: bundled Cli.js not found")
+                is CliIntegrations.Result.Failed ->
+                    installLog.appendLine("Integrations failed (non-fatal): ${integ.message}")
+            }
+
             // Final verification: re-read Claude hook file
             val finalVerify = File(mainRepoRoot, ".claude/settings.local.json")
             val finalContent = if (finalVerify.exists()) finalVerify.readText(Charsets.UTF_8) else "FILE NOT FOUND"
@@ -199,7 +219,7 @@ class HookInstaller(private val projectDir: String, private val mainRepoRoot: St
             // Write install log
             writeInstallLog(installLog.toString())
 
-            return InstallResult(true, "JolliMemory hooks installed successfully", warnings)
+            return InstallResult(true, "JolliMemory hooks installed successfully", warnings, nodeMissing = nodeMissing)
         } catch (e: Exception) {
             installLog.appendLine("ERROR: ${e.message}\n${e.stackTraceToString()}")
             writeInstallLog(installLog.toString())
@@ -215,6 +235,19 @@ class HookInstaller(private val projectDir: String, private val mainRepoRoot: St
     }
 
     /**
+     * Ensures the node integrations (MCP + skills + bundled Cli.js) are set up for the
+     * CURRENT plugin version WITHOUT touching hooks. Called on startup so a plugin
+     * upgrade activates them without a manual re-enable — `install()` doesn't re-run
+     * once hooks are already installed. Idempotent + version-gated; node-only.
+     *
+     * @return true if Node was missing (so the caller can notify).
+     */
+    fun ensureIntegrations(): Boolean {
+        if (CliIntegrations.integrationsUpToDate()) return false
+        return CliIntegrations.enableIntegrations(projectDir) is CliIntegrations.Result.NodeMissing
+    }
+
+    /**
      * Remove all hooks.
      */
     fun uninstall(): InstallResult {
@@ -224,6 +257,10 @@ class HookInstaller(private val projectDir: String, private val mainRepoRoot: St
             removeGitHookSection("post-commit", POST_COMMIT_START, POST_COMMIT_END)
             removeGitHookSection("post-rewrite", POST_REWRITE_START, POST_REWRITE_END)
             removeGitHookSection("prepare-commit-msg", PREPARE_MSG_START, PREPARE_MSG_END)
+            // Mirror of enable: tear down the MCP registration via the bundled CLI
+            // (best-effort, node-only). Leaves hooks/skills/dist-paths per the CLI's
+            // conservative uninstall policy. Never fails the disable over this.
+            CliIntegrations.disableIntegrations(projectDir)
             return InstallResult(true, "JolliMemory hooks removed", emptyList())
         } catch (e: Exception) {
             return InstallResult(false, "Uninstallation failed: ${e.message}", emptyList())
@@ -469,12 +506,10 @@ class HookInstaller(private val projectDir: String, private val mainRepoRoot: St
             // class is loaded from `<pluginPath>/lib/<jar>.jar`, so the plugin root is two
             // levels up. Pure JVM API — also resolves to null cleanly when running from
             // the hooks JAR outside the IDE, which the null-guards below handle.
-            val codeSource = File(javaClass.protectionDomain.codeSource.location.toURI())
-            searchLog.appendLine("codeSource=$codeSource")
-
-            // <pluginPath>/lib/<jar>.jar -> parent (lib/) -> parent (pluginPath)
-            val pluginPath = codeSource.parentFile?.parentFile?.toPath()
-            searchLog.appendLine("pluginPath=$pluginPath")
+            // Robust plugin-dir resolution: codeSource first, then a bundled-resource URL
+            // fallback (codeSource.location is null under IntelliJ 2026.1's module loader).
+            val pluginPath = CliIntegrations.resolvePluginDir()?.toPath()
+            searchLog.appendLine("pluginPath=$pluginPath (via resolvePluginDir)")
 
             if (pluginPath != null) {
                 // Check bin/ first (hooks JAR lives outside lib/ to avoid Plugin Verifier scanning)
@@ -620,4 +655,6 @@ data class InstallResult(
     val success: Boolean,
     val message: String,
     val warnings: List<String>,
+    /** True when Node.js was absent so MCP + skills were skipped (memory generation still works). */
+    val nodeMissing: Boolean = false,
 )

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt
@@ -44,6 +44,12 @@ class SummaryReader(private val projectDir: String, private val git: GitOps) {
 
         val copilotChatInstalled = CopilotChatSupport.isCopilotChatInstalled()
 
+        // Node-powered integrations (MCP + full skill set). getStatus() runs off the EDT
+        // (refreshStatus is invoked on a pooled thread / the startup coroutine), so the
+        // login-shell PATH probe inside isNodeAvailable() never blocks the UI.
+        val nodeAvailable = CliIntegrations.isNodeAvailable()
+        val integrationsActive = CliIntegrations.integrationsUpToDate()
+
         return StatusInfo(
             enabled = hooksInstalled,
             claudeHookInstalled = installer.isClaudeHookInstalled(),
@@ -70,6 +76,8 @@ class SummaryReader(private val projectDir: String, private val git: GitOps) {
             copilotScanError = copilotError,
             copilotChatDetected = copilotChatInstalled,
             copilotChatScanError = null,
+            nodeAvailable = nodeAvailable,
+            integrationsActive = integrationsActive,
         )
     }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/GitOpQueue.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/GitOpQueue.kt
@@ -1,0 +1,113 @@
+package ai.jolli.jollimemory.core
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import java.io.File
+
+/**
+ * GitOpQueue — Kotlin port of the CLI's git-op-queue (cli/src/hooks/PostCommitHook.ts
+ * enqueue + cli/src/core/SessionTracker.ts dequeueAllGitOperations).
+ *
+ * Each git operation (commit / amend / squash / cherry-pick / revert) is written as
+ * one timestamped JSON file under `.jolli/jollimemory/git-op-queue/`. A single drain
+ * worker processes them in chronological order. This replaces the old
+ * "spawn one worker per commit, serialized by a lock" model whose loser (a second
+ * commit that arrived while the first worker held the lock) silently dropped its
+ * summary — the exact bug the CLI queue was built to fix for rapid amend/rebase.
+ *
+ * File name: `{epochMillis}-{hash8}.json`. The 13-digit ms prefix sorts
+ * lexicographically == chronologically (until year 2286), but we sort by the parsed
+ * numeric prefix to be safe.
+ */
+object GitOpQueue {
+
+    private val log = JmLogger.create("GitOpQueue")
+    private val gson: Gson = GsonBuilder().setPrettyPrinting().create()
+
+    private const val QUEUE_DIR = "git-op-queue"
+
+    /** Entries older than 24h are pruned on dequeue (mirrors the CLI GIT_OP_QUEUE_STALE_MS). */
+    private const val STALE_MS = 24L * 60 * 60 * 1000
+
+    /**
+     * One queued git operation. Field shape matches the CLI `GitOperation` so a queue
+     * written by either engine is readable by the other.
+     *
+     * @param type one of: commit, amend, squash, cherry-pick, revert, rebase-pick, rebase-squash
+     * @param commitHash the (new) commit hash this op produced
+     * @param sourceHashes old hashes — [oldHash] for amend, the merged source hashes for squash
+     * @param commitSource "cli" or "plugin"
+     * @param createdAt ISO-8601 timestamp at enqueue time (transcript-attribution cutoff)
+     */
+    data class GitOperation(
+        val type: String,
+        val commitHash: String,
+        val branch: String? = null,
+        val sourceHashes: List<String>? = null,
+        val commitSource: String? = null,
+        val createdAt: String,
+    )
+
+    private fun queueDir(cwd: String?): File = File(JmLogger.getJolliMemoryDir(cwd), QUEUE_DIR)
+
+    /** Synchronous, <5ms: append one operation as its own file. Must never throw into the git hook. */
+    fun enqueue(op: GitOperation, cwd: String? = null): Boolean {
+        return try {
+            val dir = queueDir(cwd)
+            dir.mkdirs()
+            val fileName = "${System.currentTimeMillis()}-${op.commitHash.take(8)}.json"
+            File(dir, fileName).writeText(gson.toJson(op), Charsets.UTF_8)
+            log.info("Enqueued %s op for %s", op.type, op.commitHash.take(8))
+            true
+        } catch (e: Exception) {
+            log.error("Failed to enqueue git op: %s", e.message)
+            false
+        }
+    }
+
+    /**
+     * Reads all queued operations in chronological order. Stale entries (>24h) and
+     * unparseable files are pruned (deleted) and skipped. Returns (op, file) pairs so
+     * the caller can [deleteEntry] each after processing.
+     */
+    fun dequeueAll(cwd: String? = null): List<Pair<GitOperation, File>> {
+        val dir = queueDir(cwd)
+        val files = dir.listFiles { f -> f.isFile && f.name.endsWith(".json") } ?: return emptyList()
+        val now = System.currentTimeMillis()
+        val out = mutableListOf<Pair<GitOperation, File>>()
+        for (file in files.sortedBy { parseTimestamp(it.name) }) {
+            val ts = parseTimestamp(file.name)
+            if (ts > 0 && now - ts > STALE_MS) {
+                log.info("Pruning stale queue entry (%dh old): %s", (now - ts) / 3600000, file.name)
+                deleteEntry(file)
+                continue
+            }
+            val op = try {
+                gson.fromJson(file.readText(Charsets.UTF_8), GitOperation::class.java)
+            } catch (e: Exception) {
+                log.warn("Unparseable queue entry %s — deleting: %s", file.name, e.message)
+                deleteEntry(file)
+                null
+            }
+            if (op?.commitHash?.isNotBlank() == true && op.type.isNotBlank()) out.add(op to file)
+            else if (op != null) deleteEntry(file)
+        }
+        return out
+    }
+
+    fun deleteEntry(file: File) {
+        try {
+            file.delete()
+        } catch (e: Exception) {
+            log.warn("Failed to delete queue entry %s: %s", file.name, e.message)
+        }
+    }
+
+    /** True when the queue directory holds at least one `.json` entry. */
+    fun hasEntries(cwd: String? = null): Boolean =
+        (queueDir(cwd).listFiles { f -> f.isFile && f.name.endsWith(".json") }?.isNotEmpty()) == true
+
+    /** Parse the `{epochMillis}-...` prefix; returns 0 when the name has no numeric prefix. */
+    private fun parseTimestamp(name: String): Long =
+        name.substringBefore('-', "").toLongOrNull() ?: 0L
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SessionTracker.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SessionTracker.kt
@@ -335,6 +335,17 @@ object SessionTracker {
     }
 
     /**
+     * Bumps the lock file's mtime to now, keeping it fresh while a drain worker runs.
+     * Without this, a drain that spends >[LOCK_TIMEOUT_MS] in LLM calls would look
+     * stale to a concurrent commit's worker, which could then reclaim it and race.
+     */
+    fun refreshLock(cwd: String? = null) {
+        val dir = JmLogger.getJolliMemoryDir(cwd)
+        val lockFile = File(dir, LOCK_FILE)
+        if (lockFile.exists()) lockFile.setLastModified(System.currentTimeMillis())
+    }
+
+    /**
      * Checks if the post-commit worker is currently running.
      * Returns true if the lock file exists and is younger than [LOCK_TIMEOUT_MS].
      * Matches VS Code's isWorkerBusy() in LockUtils.ts.

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/TranscriptReader.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/TranscriptReader.kt
@@ -26,13 +26,26 @@ object TranscriptReader {
         "<(?:system-reminder|ide_opened_file|ide_selection|local-command-caveat|command-name|command-message|command-args|local-command-stdout)>[\\s\\S]*?</(?:system-reminder|ide_opened_file|ide_selection|local-command-caveat|command-name|command-message|command-args|local-command-stdout)>"
     )
 
-    /** Reads a transcript file and returns parsed entries since the cursor position. */
+    /**
+     * Reads a transcript file and returns parsed entries since the cursor position.
+     *
+     * @param beforeTimestamp Optional ISO-8601 cutoff for commit attribution. When set,
+     *   entries whose timestamp is strictly after the cutoff are NOT consumed — the cursor
+     *   stops just before them so the next commit's drain picks them up. This is what keeps
+     *   a queued burst of commits from all folding the same conversation into the oldest
+     *   commit; each commit gets only the slice that predates it. Entries without a parsable
+     *   timestamp are always consumed (can't attribute them otherwise).
+     */
     fun readTranscript(
         transcriptPath: String,
         cursor: TranscriptCursor? = null,
         parser: TranscriptParser? = null,
+        beforeTimestamp: String? = null,
     ): TranscriptReadResult {
         val startLine = cursor?.lineNumber ?: 0
+        val cutoffMs = beforeTimestamp?.let {
+            try { java.time.Instant.parse(it).toEpochMilli() } catch (_: Exception) { null }
+        }
         val parseFn: (String, Int) -> TranscriptEntry? = parser?.let { p -> { line, num -> p.parseLine(line, num) } }
             ?: { line, num -> parseTranscriptLine(line, num) }
 
@@ -53,6 +66,9 @@ object TranscriptReader {
         val rawEntries = mutableListOf<TranscriptEntry>()
         var totalLines = 0
         var newLinesRead = 0
+        // Cursor advances only over lines we actually consumed, so an over-cutoff line
+        // is re-read next time rather than skipped.
+        var consumedLine = startLine
 
         try {
             file.bufferedReader(Charsets.UTF_8).useLines { lineSequence ->
@@ -60,8 +76,14 @@ object TranscriptReader {
                     if (line.isBlank()) continue
                     totalLines++
                     if (totalLines <= startLine) continue
-                    newLinesRead++
                     val entry = parseFn(line, totalLines - 1)
+                    // Stop (without consuming this line) at the first entry past the cutoff.
+                    if (cutoffMs != null && entry?.timestamp != null) {
+                        val ts = try { java.time.Instant.parse(entry.timestamp).toEpochMilli() } catch (_: Exception) { null }
+                        if (ts != null && ts > cutoffMs) return@useLines
+                    }
+                    newLinesRead++
+                    consumedLine = totalLines
                     if (entry != null) rawEntries.add(entry)
                 }
             }
@@ -74,7 +96,7 @@ object TranscriptReader {
 
         val newCursor = TranscriptCursor(
             transcriptPath = transcriptPath,
-            lineNumber = totalLines,
+            lineNumber = consumedLine,
             updatedAt = java.time.Instant.now().toString(),
         )
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
@@ -475,6 +475,10 @@ data class StatusInfo(
     val copilotScanError: SqliteScanError? = null,
     val copilotChatDetected: Boolean? = null,
     val copilotChatScanError: CopilotChatScanError? = null,
+    /** Node.js resolvable on PATH — required for the MCP server + full skill set. */
+    val nodeAvailable: Boolean = true,
+    /** MCP + full skills are set up (bundled CLI extracted and version-matched). */
+    val integrationsActive: Boolean = false,
 )
 
 /** Log levels */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/HookRunner.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/HookRunner.kt
@@ -25,15 +25,23 @@ object HookRunner {
         when (hook) {
             "post-commit" -> {
                 if (hookArgs.contains("--worker")) {
+                    // Legacy path: a stray `post-commit --worker` (from an older hook
+                    // script still on disk) now drains the queue like queue-drain.
                     val cwd = System.getProperty("user.dir")
-                    // JOLLI-1785: this worker is a fresh JVM — bootstrap telemetry so
-                    // queue_drained/ingest events emit, then flush before exit.
                     ai.jolli.jollimemory.core.telemetry.TelemetryActivation.bootstrap(cwd)
-                    PostCommitHook.runWorker(cwd)
+                    PostCommitHook.drainWorker(cwd)
                     ai.jolli.jollimemory.core.telemetry.TelemetryActivation.flushNow(cwd)
                 } else {
                     PostCommitHook.launch(hookArgs)
                 }
+            }
+            "queue-drain" -> {
+                val cwd = System.getProperty("user.dir")
+                // Fresh JVM — bootstrap telemetry so queue_drained/ingest events emit,
+                // then flush before exit.
+                ai.jolli.jollimemory.core.telemetry.TelemetryActivation.bootstrap(cwd)
+                PostCommitHook.drainWorker(cwd)
+                ai.jolli.jollimemory.core.telemetry.TelemetryActivation.flushNow(cwd)
             }
             "post-rewrite" -> PostRewriteHook.run(hookArgs)
             "prepare-commit-msg" -> PrepareMsgHook.run(hookArgs)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
@@ -251,7 +251,7 @@ object PostCommitHook {
             log.warn("Cannot resolve commit %s (rewritten/gone?) — skipping op", op.commitHash.take(8))
             return
         }
-        val infoParts = commitInfoStr.split(" ")
+        val infoParts = commitInfoStr.split("\u0000")
         if (infoParts.size < 4) return
         val commitInfo = CommitInfo(infoParts[0], infoParts[1], infoParts[2], infoParts[3])
         log.info("Processing %s op: %s — %s", op.type, commitInfo.hash.take(8), commitInfo.message.take(60))

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
@@ -52,110 +52,226 @@ object PostCommitHook {
             java.io.File(gitDir, "rebase-apply").isDirectory
     }
 
-    /** Launcher: spawns the worker as a background process. */
+    /** How many queue entries one drain worker processes before deferring to a successor. */
+    private const val MAX_ENTRIES_PER_RUN = 20
+
+    /**
+     * Launcher (git post-commit): enqueues one git operation, then spawns the drain
+     * worker. Synchronous and fast (a few git calls + one file write) so it never
+     * blocks the commit. Rebase replays are skipped here — post-rewrite migrates those.
+     *
+     * Enqueue (instead of the old spawn-one-worker-per-commit) is what makes rapid
+     * commit/amend bursts safe: every op lands as its own file, and the drain worker
+     * processes them all in order — so a second commit that arrives while the first is
+     * still summarizing no longer loses its memory.
+     */
     fun launch(args: Array<String>) {
         val cwd = System.getProperty("user.dir")
         JmLogger.setLogDir(cwd)
 
         if (isRebase(cwd)) {
-            log.info("Rebase in progress — skipping post-commit worker")
+            log.info("Rebase in progress — skipping post-commit enqueue (post-rewrite handles it)")
             return
         }
 
-        log.info("PostCommitHook launcher — spawning background worker")
+        val git = GitOps(cwd)
+        val headHash = git.getHeadHash()?.trim()
+        if (headHash.isNullOrBlank()) {
+            log.error("Cannot resolve HEAD — skipping enqueue")
+            return
+        }
 
+        // Capture commit source at enqueue time (consume the one-shot plugin marker here,
+        // not in the worker — the worker may run much later, against a different commit).
+        val commitSource = if (SessionTracker.loadPluginSource(cwd)) {
+            SessionTracker.deletePluginSource(cwd)
+            CommitSource.plugin
+        } else CommitSource.cli
+
+        val branch = git.getCurrentBranch()
+
+        // Resolve op type + source hashes from the pending markers written by
+        // prepare-commit-msg, else from the reflog (cherry-pick / revert / plain commit).
+        var type = "commit"
+        var sourceHashes: List<String>? = null
+
+        val squashPending = SessionTracker.loadSquashPending(cwd)
+        if (squashPending != null) {
+            SessionTracker.deleteSquashPending(cwd)
+            // A stale squash-pending (from a prior failed run) can be adopted by an
+            // unrelated commit — validate its recorded parent against HEAD~1.
+            val parent = git.exec("rev-parse", "HEAD~1")?.trim()
+            if (parent == null || parent == squashPending.expectedParentHash) {
+                type = "squash"; sourceHashes = squashPending.sourceHashes
+            } else {
+                log.warn("Stale squash-pending (parent %s != HEAD~1 %s) — treating as plain commit",
+                    squashPending.expectedParentHash.take(8), parent.take(8))
+            }
+        } else {
+            val amendPending = SessionTracker.loadAmendPending(cwd)
+            if (amendPending != null) {
+                SessionTracker.deleteAmendPending(cwd)
+                type = "amend"; sourceHashes = listOf(amendPending.oldHash)
+            } else {
+                type = detectQueueCommitType()
+            }
+        }
+
+        val op = GitOpQueue.GitOperation(
+            type = type,
+            commitHash = headHash,
+            branch = branch,
+            sourceHashes = sourceHashes,
+            commitSource = commitSource.name,
+            createdAt = Instant.now().toString(),
+        )
+        GitOpQueue.enqueue(op, cwd)
+        spawnDrainWorker(cwd)
+    }
+
+    /** Spawns the drain worker as a detached background process (never blocks git). */
+    private fun spawnDrainWorker(cwd: String) {
         val javaHome = System.getProperty("java.home")
         val javaBin = "$javaHome/bin/java"
         val jarPath = getJarPath() ?: return
-        val cmd = listOf(javaBin, "-jar", jarPath, "post-commit", "--worker")
-
+        val cmd = listOf(javaBin, "-jar", jarPath, "queue-drain")
         try {
-            // Redirect worker output to log file instead of inheritIO().
-            // inheritIO() causes the worker to hold git's stdout/stderr FDs open,
-            // which makes git wait for the hook to finish (blocking the commit).
+            // Redirect worker output to a log file, not inheritIO(): inheritIO() would
+            // hold git's stdout/stderr FDs open and make git wait for the worker.
             val logDir = java.io.File(JmLogger.getJolliMemoryDir(cwd))
             logDir.mkdirs()
             val workerLog = java.io.File(logDir, "post-commit-worker.log")
-
             ProcessBuilder(cmd)
                 .directory(java.io.File(cwd))
                 .redirectOutput(ProcessBuilder.Redirect.appendTo(workerLog))
                 .redirectError(ProcessBuilder.Redirect.appendTo(workerLog))
                 .start()
-            log.info("Worker process spawned (output → %s)", workerLog.absolutePath)
+            log.info("Drain worker spawned (output → %s)", workerLog.absolutePath)
         } catch (e: Exception) {
-            log.error("Failed to spawn worker: %s", e.message)
+            log.error("Failed to spawn drain worker: %s", e.message)
         }
     }
 
-    /** Worker: runs the actual summarization pipeline. */
-    fun runWorker(cwd: String, force: Boolean = false) {
+    /** Detects the git-op type from GIT_REFLOG_ACTION for the non-squash/non-amend path. */
+    private fun detectQueueCommitType(): String {
+        val reflogAction = System.getenv("GIT_REFLOG_ACTION") ?: return "commit"
+        return when {
+            reflogAction.startsWith("cherry-pick") -> "cherry-pick"
+            reflogAction.startsWith("revert") -> "revert"
+            else -> "commit"
+        }
+    }
+
+    /** Backward-compatible entry: a stray `post-commit --worker` now drains the queue. */
+    fun runWorker(cwd: String, force: Boolean = false) = drainWorker(cwd, force)
+
+    /**
+     * Drain worker: holds the per-repo lock and processes every queued git op in
+     * chronological order (bounded by [MAX_ENTRIES_PER_RUN]), runs the wiki ingest
+     * once, then chain-spawns a successor if new entries arrived mid-drain. The lock's
+     * mtime is refreshed every 60s so a long LLM call never lets a concurrent commit's
+     * worker judge the lock stale and start a racing drain.
+     */
+    fun drainWorker(cwd: String, force: Boolean = false) {
         JmLogger.setLogDir(cwd)
         val drainStart = System.currentTimeMillis()
-        log.info("=== PostCommitHook worker started (cwd=%s, force=%s) ===", cwd, force)
+        log.info("=== Queue drain worker started (cwd=%s, force=%s) ===", cwd, force)
 
         val git = GitOps(cwd)
-        log.info("Creating storage via StorageFactory.create")
         val storage = StorageFactory.create(git, cwd)
-        log.info("Storage created: %s", storage::class.simpleName)
         val store = SummaryStore(cwd, git, storage)
         val config = SessionTracker.loadConfig(cwd)
-        log.info("Config loaded: apiKey=%s, jolliApiKey=%s, model=%s", if (config.apiKey != null) "set" else "null", if (config.jolliApiKey != null) "set" else "null", config.model ?: "default")
+        log.info("Config loaded: apiKey=%s, jolliApiKey=%s, model=%s",
+            if (config.apiKey != null) "set" else "null",
+            if (config.jolliApiKey != null) "set" else "null", config.model ?: "default")
 
-        // Load log level from config
         val logLevel = config.logLevel?.let { try { LogLevel.valueOf(it) } catch (_: Exception) { null } }
         if (logLevel != null) JmLogger.setLogLevel(logLevel)
 
-        // Acquire lock
         if (!SessionTracker.acquireLock(cwd)) {
-            log.warn("Cannot acquire lock — another worker is running")
+            log.warn("Cannot acquire lock — another drain worker is running")
             return
         }
 
+        // Keep the lock fresh during long LLM calls so a concurrent commit's worker
+        // doesn't reclaim it as stale mid-drain.
+        val refresher = java.util.concurrent.Executors.newSingleThreadScheduledExecutor { r ->
+            Thread(r, "jolli-lock-refresh").apply { isDaemon = true }
+        }
+        refresher.scheduleAtFixedRate(
+            { SessionTracker.refreshLock(cwd) }, 60, 60, java.util.concurrent.TimeUnit.SECONDS,
+        )
+
+        var processed = 0
         try {
-            // 1. Get HEAD commit info
-            val commitInfoStr = git.getHeadCommitInfo()
-            if (commitInfoStr == null) {
-                log.error("Cannot get HEAD commit info")
-                return
-            }
-            val parts = commitInfoStr.split("\u0000")
-            if (parts.size < 4) return
-            val commitInfo = CommitInfo(parts[0], parts[1], parts[2], parts[3])
-            log.info("HEAD: %s — %s", commitInfo.hash.take(8), commitInfo.message.take(60))
-
-            // Detect commit source (plugin or CLI)
-            val commitSource = if (SessionTracker.loadPluginSource(cwd)) {
-                SessionTracker.deletePluginSource(cwd)
-                CommitSource.plugin
-            } else CommitSource.cli
-
-            // 2. Check for squash-pending
-            val squashPending = SessionTracker.loadSquashPending(cwd)
-            if (squashPending != null) {
-                SessionTracker.deleteSquashPending(cwd)
-                // Validate: a stale squash-pending from a failed lock can be consumed
-                // by an unrelated future commit. Compare expectedParentHash against HEAD~1.
-                val parentHash = git.exec("rev-parse", "HEAD~1")?.trim()
-                if (parentHash != null && parentHash != squashPending.expectedParentHash) {
-                    log.warn(
-                        "Stale squash-pending: expected parent %s but HEAD~1 is %s — discarding",
-                        squashPending.expectedParentHash.take(8), parentHash.take(8)
-                    )
-                } else {
-                    handleSquash(store, squashPending, commitInfo, config)
-                    return
+            loop@ while (processed < MAX_ENTRIES_PER_RUN) {
+                val entries = GitOpQueue.dequeueAll(cwd)
+                if (entries.isEmpty()) break
+                for ((op, file) in entries) {
+                    if (processed >= MAX_ENTRIES_PER_RUN) break@loop
+                    try {
+                        dispatchOp(op, cwd, git, store, config, force)
+                    } catch (e: Exception) {
+                        log.error("Failed to process queue op type=%s ref=%s: %s",
+                            op.type, op.commitHash.take(8), e.message ?: e.toString())
+                    }
+                    GitOpQueue.deleteEntry(file)
+                    processed++
                 }
             }
-
-            // 3. Check for amend-pending
-            val amendPending = SessionTracker.loadAmendPending(cwd)
-            if (amendPending != null) {
-                SessionTracker.deleteAmendPending(cwd)
-                handleAmend(store, amendPending, commitInfo)
-                return
+        } finally {
+            // Auto-ingest + re-render the wiki once per drain (no-op when nothing pending).
+            try {
+                runIngestAndRender(cwd, config)
+            } catch (e: Exception) {
+                log.warn("Post-commit ingest/render failed (non-fatal): %s", e.message)
             }
+            refresher.shutdownNow()
+            SessionTracker.releaseLock(cwd)
+            ai.jolli.jollimemory.core.telemetry.Telemetry.track(
+                "queue_drained",
+                mapOf("ops" to processed, "duration_ms" to (System.currentTimeMillis() - drainStart)),
+            )
+            // Chain-spawn: entries that landed after our last dequeue get their own worker.
+            if (GitOpQueue.hasEntries(cwd)) {
+                log.info("Queue non-empty after drain — chain-spawning successor")
+                spawnDrainWorker(cwd)
+            }
+        }
+        log.info("=== Queue drain worker finished (%d op(s)) ===", processed)
+    }
 
+    /** Resolves the op's commit, then dispatches to the matching handler. */
+    private fun dispatchOp(
+        op: GitOpQueue.GitOperation, cwd: String, git: GitOps,
+        store: SummaryStore, config: JolliMemoryConfig, force: Boolean,
+    ) {
+        val commitInfoStr = git.getHeadCommitInfo(op.commitHash)
+        if (commitInfoStr == null) {
+            log.warn("Cannot resolve commit %s (rewritten/gone?) — skipping op", op.commitHash.take(8))
+            return
+        }
+        val infoParts = commitInfoStr.split(" ")
+        if (infoParts.size < 4) return
+        val commitInfo = CommitInfo(infoParts[0], infoParts[1], infoParts[2], infoParts[3])
+        log.info("Processing %s op: %s — %s", op.type, commitInfo.hash.take(8), commitInfo.message.take(60))
+
+        when (op.type) {
+            "squash", "rebase-squash" -> processSquash(op.sourceHashes ?: emptyList(), commitInfo, store, config)
+            "amend", "rebase-pick" -> processAmend(op.sourceHashes?.firstOrNull(), commitInfo, store)
+            else -> processCommitOp(op, commitInfo, cwd, git, store, config, force)
+        }
+    }
+
+    /** Full summarization pipeline for a real commit (commit / cherry-pick / revert). */
+    private fun processCommitOp(
+        op: GitOpQueue.GitOperation, commitInfo: CommitInfo, cwd: String, git: GitOps,
+        store: SummaryStore, config: JolliMemoryConfig, force: Boolean,
+    ) {
+        val commitSource =
+            if (op.commitSource == CommitSource.plugin.name) CommitSource.plugin else CommitSource.cli
+
+        run {
             // 4. Load sessions and read transcripts
             log.info("Step 4: Loading sessions")
             val allSessions = SessionTracker.loadAllSessions(cwd).toMutableList()
@@ -242,7 +358,9 @@ object PostCommitHook {
                         }
                         else -> {
                             val parser = getParserForSource(source)
-                            TranscriptReader.readTranscript(session.transcriptPath, cursor, parser)
+                            // Slice to this commit's window (commitInfo.date) so a queued burst
+                            // of commits doesn't fold the whole conversation into the oldest one.
+                            TranscriptReader.readTranscript(session.transcriptPath, cursor, parser, commitInfo.date)
                         }
                     }
 
@@ -280,8 +398,10 @@ object PostCommitHook {
 
             // 5. Get diff
             log.info("Step 5: Getting diff (transcripts=%d entries, %d turns)", totalEntries, totalTurns)
-            val diff = git.getDiffContent() ?: ""
-            val diffStatStr = git.getDiffStats() ?: ""
+            // Diff this op's OWN commit — by the time the queue drains, HEAD may have
+            // moved past it, so HEAD~1..HEAD would be the wrong change.
+            val diff = git.getDiffContent(op.commitHash) ?: ""
+            val diffStatStr = git.getDiffStats(op.commitHash) ?: ""
             val diffStats = parseDiffStats(diffStatStr)
             log.info("Diff: %d files changed, +%d -%d, diff length=%d chars", diffStats.filesChanged, diffStats.insertions, diffStats.deletions, diff.length)
 
@@ -304,7 +424,7 @@ object PostCommitHook {
             // 7b. Assemble reference blocks for prompt injection — branch-scoped to
             //     this commit's branch (legacy blank-branch rows allowed) so the
             //     summary prompt never sees another branch's references.
-            val branch = git.getCurrentBranch() ?: "unknown"
+            val branch = op.branch ?: git.getCurrentBranch() ?: "unknown"
             val registry = SessionTracker.loadPlansRegistry(cwd)
             val referenceBlocks = PromptRenderer.assembleReferenceBlocks(
                 (registry.references ?: emptyMap()).filter { (_, entry) ->
@@ -434,8 +554,13 @@ object PostCommitHook {
                 }
             }
 
-            // 9. Build and store CommitSummary
-            val commitType = detectCommitType()
+            // 9. Build and store CommitSummary — type comes from the op captured at
+            //    enqueue time (the drained JVM has no GIT_REFLOG_ACTION to read).
+            val commitType = when (op.type) {
+                "cherry-pick" -> CommitType.`cherry-pick`
+                "revert" -> CommitType.revert
+                else -> CommitType.commit
+            }
 
             // 8d. Detect uncommitted notes on this branch, archive, and attach to the summary.
             //     Mirrors the plan path (8b): the note body is written through the StorageProvider
@@ -547,21 +672,6 @@ object PostCommitHook {
             discardExcludedWorkingItems(exclusions, cwd)
             log.info("=== PostCommitHook worker finished successfully for %s ===", commitInfo.hash.take(8))
 
-        } finally {
-            // Auto-ingest + re-render the wiki for this repo after summaries are
-            // written — covers the normal, squash, amend, and no-session paths
-            // (a no-op when nothing is pending). Failures here never fail the worker.
-            try {
-                runIngestAndRender(cwd, config)
-            } catch (e: Exception) {
-                log.warn("Post-commit ingest/render failed (non-fatal): %s", e.message)
-            }
-            SessionTracker.releaseLock(cwd)
-            // JOLLI-1785: the IntelliJ worker processes one commit per run.
-            ai.jolli.jollimemory.core.telemetry.Telemetry.track(
-                "queue_drained",
-                mapOf("ops" to 1, "duration_ms" to (System.currentTimeMillis() - drainStart)),
-            )
         }
     }
 
@@ -628,9 +738,11 @@ object PostCommitHook {
         return shouldRender
     }
 
-    private fun handleSquash(store: SummaryStore, pending: SquashPendingState, commitInfo: CommitInfo, config: JolliMemoryConfig) {
-        val oldSummaries = pending.sourceHashes.mapNotNull { store.getSummary(it) }
+    /** Squash / rebase-squash: consolidate the source summaries into the new commit. */
+    private fun processSquash(sourceHashes: List<String>, commitInfo: CommitInfo, store: SummaryStore, config: JolliMemoryConfig) {
+        val oldSummaries = sourceHashes.mapNotNull { store.getSummary(it) }
         if (oldSummaries.isEmpty()) {
+            log.warn("Squash op for %s: no source summaries found — skipping", commitInfo.hash.take(8))
             return
         }
         val apiKey = config.apiKey ?: System.getenv("ANTHROPIC_API_KEY")
@@ -643,26 +755,17 @@ object PostCommitHook {
         )
     }
 
-    private fun handleAmend(store: SummaryStore, pending: AmendPendingState, commitInfo: CommitInfo) {
-        log.info("Handling amend: %s → %s", pending.oldHash.take(8), commitInfo.hash.take(8))
-        val oldSummary = store.getSummary(pending.oldHash) ?: return
-        store.migrateOneToOne(oldSummary, commitInfo)
-    }
-
-    /**
-     * Detects the commit type from GIT_REFLOG_ACTION environment variable.
-     * Values: cherry-pick, revert, commit (regular), etc.
-     */
-    private fun detectCommitType(): CommitType? {
-        val reflogAction = System.getenv("GIT_REFLOG_ACTION") ?: return CommitType.commit
-        return when {
-            reflogAction.startsWith("cherry-pick") -> CommitType.`cherry-pick`
-            reflogAction.startsWith("revert") -> CommitType.revert
-            reflogAction.startsWith("rebase") -> CommitType.rebase
-            reflogAction.startsWith("commit --amend") -> CommitType.amend
-            reflogAction.startsWith("commit") -> CommitType.commit
-            else -> CommitType.commit
+    /** Amend / rebase-pick: 1:1 migrate the old summary to the new hash (no LLM). */
+    private fun processAmend(oldHash: String?, commitInfo: CommitInfo, store: SummaryStore) {
+        if (oldHash == null) {
+            log.warn("Amend/pick op for %s: no source hash — skipping", commitInfo.hash.take(8))
+            return
         }
+        log.info("Migrating summary: %s -> %s", oldHash.take(8), commitInfo.hash.take(8))
+        val oldSummary = store.getSummary(oldHash)
+            ?: store.findRootHash(oldHash)?.let { store.getSummary(it) }
+            ?: return
+        store.migrateOneToOne(oldSummary, commitInfo)
     }
 
     /**

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
@@ -264,7 +264,11 @@ val sb = StringBuilder()
             // so this is a no-op once current.
             com.intellij.openapi.application.ApplicationManager.getApplication().executeOnPooledThread {
                 try {
-                    if (installer?.ensureIntegrations() == true) notifyNodeMissing()
+                    val issue = installer?.ensureIntegrations()
+                    if (issue != null) {
+                        refreshStatus() // so the StatusPanel row reflects the new integration state
+                        notifyIntegrationsIssue(issue)
+                    }
                 } catch (e: Exception) {
                     log.warn("Integrations catch-up failed (non-fatal): ${e.message}")
                 }
@@ -468,7 +472,7 @@ val sb = StringBuilder()
             // Protect against GIT_REPO_CHANGE flapping: for 3 seconds after install,
             // refreshStatus() will not downgrade enabled:true → enabled:false.
             installProtectionUntil = System.currentTimeMillis() + 3000
-            if (result.nodeMissing) notifyNodeMissing()
+            result.integrationsIssue?.let { notifyIntegrationsIssue(it) }
             refreshStatus()
             return true
         }
@@ -477,22 +481,24 @@ val sb = StringBuilder()
     }
 
     /**
-     * Non-blocking heads-up when Node.js was absent at enable time: memory generation
-     * works (Java hooks), but MCP + skills need Node. Never an error — just guidance.
+     * Non-blocking heads-up when MCP + skills could not be set up (Node missing, bundle
+     * missing, or the bundled CLI failed): memory generation works (Java hooks), but the
+     * Node-powered features are unavailable. Never an error — just guidance. The durable
+     * surface is the StatusPanel "MCP & Skills" row; this balloon is the first-time nudge.
      */
-    private fun notifyNodeMissing() {
+    private fun notifyIntegrationsIssue(message: String) {
         try {
             com.intellij.notification.NotificationGroupManager.getInstance()
                 .getNotificationGroup("JolliMemory")
                 .createNotification(
-                    "Jolli Memory: Node.js not found",
-                    "Memory generation is active. MCP and skills need Node.js — install it and " +
-                        "re-enable Jolli Memory to activate them.",
+                    "Jolli Memory: MCP & skills unavailable",
+                    message,
                     com.intellij.notification.NotificationType.WARNING,
                 )
                 .notify(project)
-        } catch (_: Throwable) {
-            // Notification is best-effort; never fail install over it.
+        } catch (t: Throwable) {
+            // Notification is best-effort; never fail install over it — but no longer silent.
+            log.warn("Failed to show integrations notification: ${t.message}")
         }
     }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
@@ -256,6 +256,19 @@ val sb = StringBuilder()
             install()
             refreshStatus()
             sb.appendLine("status after auto-install=${cachedStatus}")
+        } else if (hasCredentials && !isPaused && cachedStatus?.enabled == true) {
+            // Plugin-upgrade catch-up: hooks are already installed (so the block above is
+            // skipped), but the node integrations (MCP + skills + bundled Cli.js) may be
+            // absent or built for an older plugin version. Refresh them off the EDT so a
+            // plugin update activates MCP/skills without a manual re-enable. Version-gated,
+            // so this is a no-op once current.
+            com.intellij.openapi.application.ApplicationManager.getApplication().executeOnPooledThread {
+                try {
+                    if (installer?.ensureIntegrations() == true) notifyNodeMissing()
+                } catch (e: Exception) {
+                    log.warn("Integrations catch-up failed (non-fatal): ${e.message}")
+                }
+            }
         }
 
         isInitialized = true
@@ -455,11 +468,32 @@ val sb = StringBuilder()
             // Protect against GIT_REPO_CHANGE flapping: for 3 seconds after install,
             // refreshStatus() will not downgrade enabled:true → enabled:false.
             installProtectionUntil = System.currentTimeMillis() + 3000
+            if (result.nodeMissing) notifyNodeMissing()
             refreshStatus()
             return true
         }
         lastError = result?.message ?: "Installer not available"
         return false
+    }
+
+    /**
+     * Non-blocking heads-up when Node.js was absent at enable time: memory generation
+     * works (Java hooks), but MCP + skills need Node. Never an error — just guidance.
+     */
+    private fun notifyNodeMissing() {
+        try {
+            com.intellij.notification.NotificationGroupManager.getInstance()
+                .getNotificationGroup("JolliMemory")
+                .createNotification(
+                    "Jolli Memory: Node.js not found",
+                    "Memory generation is active. MCP and skills need Node.js — install it and " +
+                        "re-enable Jolli Memory to activate them.",
+                    com.intellij.notification.NotificationType.WARNING,
+                )
+                .notify(project)
+        } catch (_: Throwable) {
+            // Notification is best-effort; never fail install over it.
+        }
     }
 
     fun uninstall(): Boolean {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
@@ -291,12 +291,21 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
             }
         }
         val statusAction = object : com.intellij.openapi.actionSystem.ToggleAction(
-            "Status", "Toggle the Jolli Memory status panel", JolliMemoryIcons.Pulse,
+            "Status", "Toggle the Jolli Memory status panel", JolliMemoryIcons.CircleGreen,
         ), DumbAware {
             override fun isSelected(e: com.intellij.openapi.actionSystem.AnActionEvent): Boolean = statusShown
             override fun setSelected(e: com.intellij.openapi.actionSystem.AnActionEvent, state: Boolean) {
                 setStatusShown(state)
             }
+
+            // The title-bar status glyph reflects health: green / yellow / red — matching
+            // the STATUS panel and the MCP & Skills row (yellow when Node is missing).
+            override fun update(e: com.intellij.openapi.actionSystem.AnActionEvent) {
+                super.update(e)
+                e.presentation.icon = statusCircleIcon(service)
+            }
+
+            override fun getActionUpdateThread() = com.intellij.openapi.actionSystem.ActionUpdateThread.BGT
         }
         // "Agent Access" is a coming-soon stub — keep it out of the title bar until
         // it does something (the action object stays defined so re-enabling is a flag flip).
@@ -529,6 +538,62 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
 }
 
 /**
+ * Picks the status-circle icon (green / yellow / red) for the current service state.
+ * Shared by the title-bar Status action and the hover status indicator so both always agree:
+ *   - red    → not enabled / no status
+ *   - yellow → enabled but degraded (missing creds/hooks, scan errors, Node/MCP unavailable)
+ *   - green  → all good
+ */
+private fun statusCircleIcon(service: JolliMemoryService): javax.swing.Icon {
+    val status = service.getStatus()
+    return when {
+        status == null || !status.enabled -> JolliMemoryIcons.CircleRed
+        statusHasWarnings(service, status) -> JolliMemoryIcons.CircleYellow
+        else -> JolliMemoryIcons.CircleGreen
+    }
+}
+
+/**
+ * Whether the current status is degraded but still functional (→ yellow):
+ * - No LLM credentials configured (selected provider can't work)
+ * - Service has a lastError
+ * - Git hooks not fully installed
+ * - Claude/Gemini hooks not installed when that host is detected
+ * - OpenCode/Cursor scan errors
+ * - Node missing, or present but MCP + skills integrations not set up (non-blocking)
+ */
+private fun statusHasWarnings(
+    service: JolliMemoryService,
+    status: ai.jolli.jollimemory.core.StatusInfo,
+): Boolean {
+    val config = SessionTracker.loadConfigFromDir(SessionTracker.getGlobalConfigDir())
+    when (config.aiProvider) {
+        "anthropic" ->
+            if (config.apiKey.isNullOrBlank() && System.getenv("ANTHROPIC_API_KEY").isNullOrBlank()) return true
+        "jolli" ->
+            if (config.jolliApiKey.isNullOrBlank()) return true
+        else -> {
+            val hasAny = !config.apiKey.isNullOrBlank() ||
+                !System.getenv("ANTHROPIC_API_KEY").isNullOrBlank() ||
+                !config.jolliApiKey.isNullOrBlank()
+            if (!hasAny) return true
+        }
+    }
+
+    if (service.lastError != null) return true
+    if (!status.gitHookInstalled) return true
+    if (status.claudeDetected == true && !status.claudeHookInstalled) return true
+    if (status.geminiDetected == true && !status.geminiHookInstalled) return true
+    if (status.openCodeScanError != null) return true
+    if (status.cursorScanError != null) return true
+    // MCP + skills degraded — Node missing, or present but integrations not set up.
+    // Non-blocking (memory generation uses native hooks), so it's a warning, not an
+    // error. Mirrors the "MCP & Skills" WARN row in StatusPanel.mcpStatusRow().
+    if (!status.nodeAvailable || !status.integrationsActive) return true
+    return false
+}
+
+/**
  * A small status indicator label that shows a colored circle icon
  * (green/yellow/red) based on the JolliMemory service state.
  *
@@ -565,53 +630,7 @@ private class StatusIndicatorLabel(
     }
 
     private fun updateIcon() {
-        val status = service.getStatus()
-        icon = when {
-            // Not enabled or no status — red
-            status == null || !status.enabled -> JolliMemoryIcons.CircleRed
-
-            // Enabled but has warnings (missing hooks, lastError set)
-            hasWarnings(status) -> JolliMemoryIcons.CircleYellow
-
-            // All good — green
-            else -> JolliMemoryIcons.CircleGreen
-        }
-    }
-
-    /**
-     * Checks whether the current status has any warnings:
-     * - No LLM credentials configured (selected provider can't work)
-     * - Service has a lastError
-     * - Git hooks not fully installed
-     * - Claude hooks not installed when Claude is detected
-     * - Gemini hooks not installed when Gemini is detected
-     */
-    private fun hasWarnings(status: ai.jolli.jollimemory.core.StatusInfo): Boolean {
-        // Check if the selected provider's credential is missing
-        val config = SessionTracker.loadConfigFromDir(SessionTracker.getGlobalConfigDir())
-        when (config.aiProvider) {
-            "anthropic" -> {
-                if (config.apiKey.isNullOrBlank() && System.getenv("ANTHROPIC_API_KEY").isNullOrBlank()) return true
-            }
-            "jolli" -> {
-                if (config.jolliApiKey.isNullOrBlank()) return true
-            }
-            else -> {
-                // No provider set — warn if nothing at all
-                val hasAny = !config.apiKey.isNullOrBlank() ||
-                    !System.getenv("ANTHROPIC_API_KEY").isNullOrBlank() ||
-                    !config.jolliApiKey.isNullOrBlank()
-                if (!hasAny) return true
-            }
-        }
-
-        if (service.lastError != null) return true
-        if (!status.gitHookInstalled) return true
-        if (status.claudeDetected == true && !status.claudeHookInstalled) return true
-        if (status.geminiDetected == true && !status.geminiHookInstalled) return true
-        if (status.openCodeScanError != null) return true
-        if (status.cursorScanError != null) return true
-        return false
+        icon = statusCircleIcon(service)
     }
 
     private fun showStatusPopup(e: MouseEvent) {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/StatusPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/StatusPanel.kt
@@ -19,6 +19,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBList
 import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.JBColor
 import com.intellij.util.ui.JBUI
 import java.awt.BorderLayout
 import java.awt.Color
@@ -414,6 +415,19 @@ class StatusPanel(
         private val textLabel = JLabel()
         private val descLabel = JLabel()
 
+        /**
+         * Severity color for a row's description text so a non-healthy status reads
+         * by color, not just by a small icon. Mirrors VS Code's charts.yellow / charts.red:
+         *   - WARN  → amber (non-blocking: e.g. MCP & Skills not enabled — memory still works)
+         *   - ERROR → red   (blocking: e.g. required hooks missing)
+         *   - everything else → null (falls back to the normal gray)
+         */
+        private fun statusColor(icon: StatusPanel.Icon): Color? = when (icon) {
+            StatusPanel.Icon.WARN -> WARN_COLOR
+            StatusPanel.Icon.ERROR -> ERROR_COLOR
+            else -> null
+        }
+
         /** Cache of white-tinted icons for selected state. */
         private val whiteIconCache = mutableMapOf<javax.swing.Icon, javax.swing.Icon>()
 
@@ -465,7 +479,10 @@ class StatusPanel(
             textLabel.font = list.font
             descLabel.text = "  ${value.description}"
             descLabel.font = list.font
-            descLabel.foreground = if (isSelected) list.selectionForeground else Color.GRAY
+            descLabel.foreground = when {
+                isSelected -> list.selectionForeground
+                else -> statusColor(value.icon) ?: Color.GRAY
+            }
 
             panel.removeAll()
             val left = JPanel(BorderLayout()).apply {
@@ -485,12 +502,21 @@ class StatusPanel(
             textLabel.foreground = if (isSelected) list.selectionForeground else list.foreground
             panel.toolTipText = value.tooltip
 
-            // Show hand cursor for clickable items
-            if (value.onClick != null) {
-                descLabel.foreground = if (isSelected) list.selectionForeground else Color(0x4A90D9)
+            // Clickable rows read blue as an affordance — but a warning/error color wins,
+            // since severity is more important to convey than clickability.
+            if (value.onClick != null && !isSelected && statusColor(value.icon) == null) {
+                descLabel.foreground = Color(0x4A90D9)
             }
 
             return panel
+        }
+
+        companion object {
+            /** Amber for non-blocking warnings — theme-aware (darker on light, brighter on dark). */
+            private val WARN_COLOR = JBColor(Color(0xB8860B), Color(0xE0A030))
+
+            /** Red for blocking errors — theme-aware. */
+            private val ERROR_COLOR = JBColor(Color(0xC0392B), Color(0xE57373))
         }
     }
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/StatusPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/StatusPanel.kt
@@ -134,6 +134,10 @@ class StatusPanel(
             tooltip = hooksTooltip,
         ))
 
+        // 1b. MCP & Skills — the Node-powered features. Always shown so a missing/failed
+        // Node runtime is a durable, hover-explained status (not just a transient balloon).
+        listModel.addElement(mcpStatusRow(status.nodeAvailable, status.integrationsActive))
+
         // 2. Sessions (Claude/Gemini — other sources are discovered on-demand at commit time)
         listModel.addElement(StatusRow(
             icon = Icon.PULSE,
@@ -351,6 +355,44 @@ class StatusPanel(
 
     override fun dispose() {
         service.removeStatusListener(statusListener)
+    }
+
+    companion object {
+        /**
+         * Maps the Node integration state to the "MCP & Skills" status row. Pure (no Swing,
+         * no I/O) so it can be unit-tested. Three states:
+         *   - node present + integrations set up → OK "active"
+         *   - node missing                       → WARN, lists what's unavailable
+         *   - node present but not set up        → WARN "setup incomplete" (enable failed / bundle missing)
+         */
+        fun mcpStatusRow(nodeAvailable: Boolean, integrationsActive: Boolean): StatusRow = when {
+            nodeAvailable && integrationsActive -> StatusRow(
+                icon = Icon.OK,
+                label = "MCP & Skills",
+                description = "active",
+                tooltip = "Node.js found — the MCP tools (search / recall / decision timeline) and the " +
+                    "/jolli-recall, /jolli-search, /jolli-pr skills are active.",
+            )
+            !nodeAvailable -> StatusRow(
+                icon = Icon.WARN,
+                label = "MCP & Skills",
+                description = "Node.js not found",
+                tooltip = "Node.js was not detected on your PATH, so these are unavailable:\n" +
+                    "  • MCP tools (search / recall / decision timeline)\n" +
+                    "  • /jolli-search\n" +
+                    "  • /jolli-pr\n" +
+                    "Memory generation is unaffected (native Java hooks). Install Node.js and reopen " +
+                    "the project to activate them.",
+            )
+            else -> StatusRow(
+                icon = Icon.WARN,
+                label = "MCP & Skills",
+                description = "setup incomplete",
+                tooltip = "Node.js is available but MCP + skills are not fully set up — the bundled CLI " +
+                    "failed to enable or was not found. See ~/.jolli/logs/jollimemory-install-debug.log " +
+                    "for details, then reopen the project to retry.",
+            )
+        }
     }
 
     // ── Data model ──────────────────────────────────────────────────────────

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/CliIntegrationsTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/CliIntegrationsTest.kt
@@ -1,6 +1,9 @@
 package ai.jolli.jollimemory.bridge
 
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -30,5 +33,35 @@ class CliIntegrationsTest {
         val result = CliIntegrations.enableIntegrations(tempDir.absolutePath)
         result shouldNotBe CliIntegrations.Result.Ok
         result.shouldBeInstanceOf<CliIntegrations.Result>()
+    }
+
+    // ── warningFor — every non-Ok result yields a user-facing message ──────
+
+    @Test
+    fun `warningFor Ok is null`() {
+        CliIntegrations.warningFor(CliIntegrations.Result.Ok).shouldBeNull()
+    }
+
+    @Test
+    fun `warningFor NodeMissing mentions Node and the skipped skills`() {
+        val msg = CliIntegrations.warningFor(CliIntegrations.Result.NodeMissing)
+        msg shouldNotBe null
+        msg!! shouldContain "Node.js"
+        msg shouldContain "/jolli-search"
+        msg shouldContain "/jolli-pr"
+    }
+
+    @Test
+    fun `warningFor BundleMissing is surfaced (not silent)`() {
+        val msg = CliIntegrations.warningFor(CliIntegrations.Result.BundleMissing)
+        msg shouldNotBe null
+        msg!! shouldContain "bundled CLI"
+    }
+
+    @Test
+    fun `warningFor Failed includes the underlying message`() {
+        val msg = CliIntegrations.warningFor(CliIntegrations.Result.Failed("exit 1"))
+        msg shouldNotBe null
+        msg!! shouldContain "exit 1"
     }
 }

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/CliIntegrationsTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/CliIntegrationsTest.kt
@@ -90,4 +90,54 @@ class CliIntegrationsTest {
         CliIntegrations.clearIntegrationsEnabled(tempDir) // e.g. a later failure
         CliIntegrations.integrationsUpToDate(tempDir) shouldBe false // retries again
     }
+
+    // ── mcpRegistrationStale — self-heal trigger for a dead .mcp.json ──────
+    // Regression guard for the bug where .mcp.json's jollimemory entry pointed at a
+    // `node <Cli.js>` under a removed VS Code extension dist. The version stamp stayed
+    // current (env change, not a plugin upgrade), so startup never re-registered.
+
+    @Test
+    fun `mcpRegistrationStale false when there is no mcp json`() {
+        CliIntegrations.mcpRegistrationStale(tempDir.absolutePath) shouldBe false
+    }
+
+    @Test
+    fun `mcpRegistrationStale true when node Cli js path no longer exists`() {
+        val gone = File(tempDir, "removed-extension/dist/Cli.js").absolutePath.replace("\\", "/")
+        File(tempDir, ".mcp.json").writeText(
+            """{"mcpServers":{"jollimemory":{"command":"node","args":["$gone","mcp"]}}}""",
+        )
+        CliIntegrations.mcpRegistrationStale(tempDir.absolutePath) shouldBe true
+    }
+
+    @Test
+    fun `mcpRegistrationStale false when the node Cli js still exists`() {
+        val cliJs = File(tempDir, "dist/Cli.js").apply { parentFile.mkdirs(); writeText("bundle") }
+        File(tempDir, ".mcp.json").writeText(
+            """{"mcpServers":{"jollimemory":{"command":"node","args":["${cliJs.absolutePath.replace("\\", "/")}","mcp"]}}}""",
+        )
+        CliIntegrations.mcpRegistrationStale(tempDir.absolutePath) shouldBe false
+    }
+
+    @Test
+    fun `mcpRegistrationStale false for the POSIX run-cli indirection form`() {
+        // The run-cli dispatch form re-resolves at spawn time and never goes stale, so a
+        // non-node command is always treated as healthy regardless of whether it exists.
+        File(tempDir, ".mcp.json").writeText(
+            """{"mcpServers":{"jollimemory":{"command":"/home/u/.jolli/jollimemory/run-cli","args":["mcp"]}}}""",
+        )
+        CliIntegrations.mcpRegistrationStale(tempDir.absolutePath) shouldBe false
+    }
+
+    @Test
+    fun `mcpRegistrationStale false when there is no jollimemory entry`() {
+        File(tempDir, ".mcp.json").writeText("""{"mcpServers":{"other":{"command":"node","args":["x"]}}}""")
+        CliIntegrations.mcpRegistrationStale(tempDir.absolutePath) shouldBe false
+    }
+
+    @Test
+    fun `mcpRegistrationStale false on malformed json`() {
+        File(tempDir, ".mcp.json").writeText("{ not json")
+        CliIntegrations.mcpRegistrationStale(tempDir.absolutePath) shouldBe false
+    }
 }

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/CliIntegrationsTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/CliIntegrationsTest.kt
@@ -1,0 +1,34 @@
+package ai.jolli.jollimemory.bridge
+
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Smoke tests for [CliIntegrations]. The heavy paths (running the bundled CLI, PATH
+ * resolution) depend on the environment, so these assert the null-safe contract:
+ * nothing throws, and a missing bundle degrades gracefully instead of erroring.
+ */
+class CliIntegrationsTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    @Test
+    fun `resolveBundledCliJs does not throw (no cli-dist in the test classpath)`() {
+        // In the test runtime there is no plugin cli-dist/, so this resolves to null
+        // rather than throwing — the graceful path the installer relies on.
+        CliIntegrations.resolveBundledCliJs() // must not throw
+    }
+
+    @Test
+    fun `enableIntegrations degrades gracefully without a bundle or node`() {
+        // With no bundled Cli.js on the test classpath, the result is never Ok and never
+        // throws: NodeMissing (no node on PATH) or BundleMissing (node present, no bundle).
+        val result = CliIntegrations.enableIntegrations(tempDir.absolutePath)
+        result shouldNotBe CliIntegrations.Result.Ok
+        result.shouldBeInstanceOf<CliIntegrations.Result>()
+    }
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/CliIntegrationsTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/CliIntegrationsTest.kt
@@ -64,4 +64,30 @@ class CliIntegrationsTest {
         msg shouldNotBe null
         msg!! shouldContain "exit 1"
     }
+
+    // ── integrationsUpToDate — stamp means "enabled", not merely "extracted" ──
+    // Regression guard for the bug where extractCliDist() wrote the version stamp at
+    // extraction time, so a FAILED enable still looked "up to date" and was never retried
+    // (and the StatusPanel showed a false "active").
+
+    @Test
+    fun `extracted-but-not-enabled is NOT up to date`() {
+        // Simulate the bundle having been copied (Cli.js present) with no successful enable
+        // recorded (no .version stamp). This is exactly the extract-succeeded-enable-failed
+        // state — it must report false so startup retries.
+        File(tempDir, "Cli.js").writeText("bundle")
+        CliIntegrations.integrationsUpToDate(tempDir) shouldBe false
+    }
+
+    @Test
+    fun `up to date only after a successful enable is recorded`() {
+        File(tempDir, "Cli.js").writeText("bundle")
+        CliIntegrations.integrationsUpToDate(tempDir) shouldBe false // extracted only
+
+        CliIntegrations.markIntegrationsEnabled(tempDir) // enable succeeded
+        CliIntegrations.integrationsUpToDate(tempDir) shouldBe true
+
+        CliIntegrations.clearIntegrationsEnabled(tempDir) // e.g. a later failure
+        CliIntegrations.integrationsUpToDate(tempDir) shouldBe false // retries again
+    }
 }

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/GitOpsRefDiffTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/GitOpsRefDiffTest.kt
@@ -1,0 +1,91 @@
+package ai.jolli.jollimemory.bridge
+
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+/**
+ * Tests the hash-parametric GitOps accessors the git-op-queue depends on. When the
+ * queue drains, a commit may no longer be HEAD, so the diff / stats / commit info
+ * must be resolved by the op's OWN commit hash — a plain `HEAD~1..HEAD` would be the
+ * wrong change. Also covers the root-commit (no parent) fallback.
+ */
+class GitOpsRefDiffTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+    private lateinit var repo: File
+    private lateinit var git: GitOps
+
+    @BeforeEach
+    fun setUp() {
+        repo = tempDir.toFile()
+        run("init", "-b", "main")
+        run("config", "user.email", "test@example.com")
+        run("config", "user.name", "Test User")
+        git = GitOps(repo.absolutePath)
+    }
+
+    private fun run(vararg args: String): String {
+        val pb = ProcessBuilder(listOf("git") + args).directory(repo).redirectErrorStream(true)
+        val p = pb.start()
+        val out = p.inputStream.bufferedReader().use { it.readText() }
+        check(p.waitFor(30, TimeUnit.SECONDS)) { "git ${args.joinToString(" ")} timed out" }
+        check(p.exitValue() == 0) { "git ${args.joinToString(" ")} failed: $out" }
+        return out.trim()
+    }
+
+    private fun commitFile(name: String, content: String, msg: String): String {
+        File(repo, name).writeText(content)
+        run("add", ".")
+        run("commit", "-m", msg)
+        return run("rev-parse", "HEAD")
+    }
+
+    @Test
+    fun `getDiffContent resolves the given commit, not HEAD`() {
+        val c1 = commitFile("a.txt", "alpha\n", "add a")
+        val c2 = commitFile("b.txt", "beta\n", "add b")
+
+        // HEAD is c2. Diffing c1 (no longer HEAD) must show a.txt, not b.txt.
+        val diffC1 = git.getDiffContent(c1) ?: ""
+        diffC1 shouldContain "a.txt"
+        diffC1 shouldNotContain "b.txt"
+
+        val diffC2 = git.getDiffContent(c2) ?: ""
+        diffC2 shouldContain "b.txt"
+        diffC2 shouldNotContain "a.txt"
+    }
+
+    @Test
+    fun `getDiffContent handles a root commit (no parent) via git show`() {
+        val root = commitFile("a.txt", "alpha\n", "root commit")
+        // Must not fail resolving <root>~1 — falls back to `git show`.
+        val diff = git.getDiffContent(root) ?: ""
+        diff shouldContain "a.txt"
+    }
+
+    @Test
+    fun `getDiffStats resolves the given commit's stats`() {
+        val c1 = commitFile("a.txt", "l1\nl2\nl3\n", "add a")
+        commitFile("b.txt", "x\n", "add b")
+        val stats = git.getDiffStats(c1) ?: ""
+        stats shouldContain "a.txt"
+        stats shouldNotContain "b.txt"
+    }
+
+    @Test
+    fun `getHeadCommitInfo resolves a non-HEAD ref`() {
+        val c1 = commitFile("a.txt", "alpha\n", "first message")
+        commitFile("b.txt", "beta\n", "second message")
+
+        val info = git.getHeadCommitInfo(c1) ?: ""
+        info shouldContain c1.take(8)
+        info shouldContain "first message"
+    }
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/GitOpQueueTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/GitOpQueueTest.kt
@@ -1,0 +1,121 @@
+package ai.jolli.jollimemory.core
+
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class GitOpQueueTest {
+
+    @TempDir
+    lateinit var tempDir: File
+    private val cwd get() = tempDir.absolutePath
+    private fun queueDir() = File(tempDir, ".jolli/jollimemory/git-op-queue")
+
+    /** Write a queue file directly with a chosen timestamp prefix + valid op JSON. */
+    private fun writeEntry(ts: Long, hash: String, type: String = "commit") {
+        queueDir().mkdirs()
+        File(queueDir(), "$ts-${hash.take(8)}.json").writeText(
+            """{"type":"$type","commitHash":"$hash","createdAt":"2026-07-02T00:00:00Z"}""",
+            Charsets.UTF_8,
+        )
+    }
+
+    @Test
+    fun `enqueue then dequeueAll round-trips the operation`() {
+        val op = GitOpQueue.GitOperation(
+            type = "amend", commitHash = "abc123def456", branch = "feature/x",
+            sourceHashes = listOf("oldhash1"), commitSource = "plugin", createdAt = "2026-07-02T00:00:00Z",
+        )
+        GitOpQueue.enqueue(op, cwd).shouldBeTrue()
+
+        val entries = GitOpQueue.dequeueAll(cwd)
+        entries shouldHaveSize 1
+        val (loaded, _) = entries.first()
+        loaded.type shouldBe "amend"
+        loaded.commitHash shouldBe "abc123def456"
+        loaded.branch shouldBe "feature/x"
+        loaded.sourceHashes shouldBe listOf("oldhash1")
+        loaded.commitSource shouldBe "plugin"
+    }
+
+    @Test
+    fun `round-trips squash and rebase op types with their source hashes`() {
+        val cases = listOf(
+            "squash" to listOf("s1", "s2", "s3"),
+            "rebase-pick" to listOf("old1"),
+            "rebase-squash" to listOf("r1", "r2"),
+            "cherry-pick" to null,
+            "revert" to null,
+        )
+        for ((type, sources) in cases) {
+            GitOpQueue.enqueue(
+                GitOpQueue.GitOperation(
+                    type = type, commitHash = "${type}00000000", sourceHashes = sources,
+                    createdAt = "2026-07-02T00:00:00Z",
+                ),
+                cwd,
+            )
+        }
+        val byType = GitOpQueue.dequeueAll(cwd).associate { it.first.type to it.first.sourceHashes }
+        byType["squash"] shouldBe listOf("s1", "s2", "s3")
+        byType["rebase-pick"] shouldBe listOf("old1")
+        byType["rebase-squash"] shouldBe listOf("r1", "r2")
+        byType["cherry-pick"] shouldBe null
+        byType["revert"] shouldBe null
+    }
+
+    @Test
+    fun `dequeueAll returns entries in chronological (timestamp) order`() {
+        val base = System.currentTimeMillis()
+        writeEntry(base + 2000, "bbbbbbbb")
+        writeEntry(base + 1000, "aaaaaaaa")
+        writeEntry(base + 1500, "cccccccc")
+
+        val order = GitOpQueue.dequeueAll(cwd).map { it.first.commitHash }
+        order shouldBe listOf("aaaaaaaa", "cccccccc", "bbbbbbbb")
+    }
+
+    @Test
+    fun `dequeueAll prunes entries older than 24h`() {
+        val old = System.currentTimeMillis() - 25L * 60 * 60 * 1000
+        val fresh = System.currentTimeMillis()
+        writeEntry(old, "staaaale0")
+        writeEntry(fresh, "freshhh00")
+
+        val entries = GitOpQueue.dequeueAll(cwd)
+        entries shouldHaveSize 1
+        entries.first().first.commitHash shouldBe "freshhh00"
+        // stale file was deleted from disk
+        (queueDir().listFiles()?.size ?: 0) shouldBe 1
+    }
+
+    @Test
+    fun `dequeueAll deletes and skips an unparseable entry`() {
+        queueDir().mkdirs()
+        File(queueDir(), "${System.currentTimeMillis()}-garbage0.json").writeText("{ not json", Charsets.UTF_8)
+
+        GitOpQueue.dequeueAll(cwd) shouldHaveSize 0
+        (queueDir().listFiles()?.size ?: 0) shouldBe 0
+    }
+
+    @Test
+    fun `dequeueAll on a missing queue dir is empty, not an error`() {
+        GitOpQueue.dequeueAll(cwd) shouldHaveSize 0
+        GitOpQueue.hasEntries(cwd).shouldBeFalse()
+    }
+
+    @Test
+    fun `deleteEntry removes the file and hasEntries flips`() {
+        writeEntry(System.currentTimeMillis(), "aaaaaaaa")
+        GitOpQueue.hasEntries(cwd).shouldBeTrue()
+
+        val (_, file) = GitOpQueue.dequeueAll(cwd).first()
+        GitOpQueue.deleteEntry(file)
+
+        GitOpQueue.hasEntries(cwd).shouldBeFalse()
+    }
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/TranscriptReaderTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/TranscriptReaderTest.kt
@@ -115,6 +115,29 @@ class TranscriptReaderTest {
         }
 
         @Test
+        fun `beforeTimestamp stops at the cutoff and leaves later entries for the next read`(@TempDir tempDir: File) {
+            val file = File(tempDir, "test.jsonl")
+            file.writeText(
+                """
+{"message":{"role":"user","content":"Before"},"timestamp":"2026-01-01T00:00:01Z"}
+{"message":{"role":"assistant","content":"AlsoBefore"},"timestamp":"2026-01-01T00:00:02Z"}
+{"message":{"role":"user","content":"After"},"timestamp":"2026-01-01T00:00:09Z"}
+                """.trimIndent(),
+            )
+
+            // Cutoff between the 2nd and 3rd entries: only the first two are consumed.
+            val first = TranscriptReader.readTranscript(file.absolutePath, null, null, "2026-01-01T00:00:05Z")
+            first.entries shouldHaveSize 2
+            first.entries.last().content shouldBe "AlsoBefore"
+
+            // The cursor stopped before "After", so a later read (no cutoff) picks it up —
+            // it was NOT skipped.
+            val second = TranscriptReader.readTranscript(file.absolutePath, first.newCursor)
+            second.entries shouldHaveSize 1
+            second.entries.first().content shouldBe "After"
+        }
+
+        @Test
         fun `merges consecutive same-role entries`(@TempDir tempDir: File) {
             val file = File(tempDir, "test.jsonl")
             file.writeText("""

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/telemetry/JetBrainsConsentTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/telemetry/JetBrainsConsentTest.kt
@@ -1,14 +1,16 @@
 package ai.jolli.jollimemory.core.telemetry
 
-import io.kotest.matchers.shouldBe
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import org.junit.jupiter.api.Test
 
 class JetBrainsConsentTest {
     @Test
-    fun `degrades gracefully — never throws, returns false when consent API unavailable`() {
-        // In a plain unit-test JVM there is no running IDE application, so the
-        // reflective ConsentOptions lookup fails and we must default to not-denied
-        // (false) rather than throwing or wrongly suppressing telemetry.
-        JetBrainsConsent.isUsageStatsDenied() shouldBe false
+    fun `degrades gracefully — never throws regardless of consent API availability`() {
+        // The reflective ConsentOptions lookup must never propagate an exception:
+        // when the API is absent (headless worker JVM) it catches and returns false;
+        // when the platform IS on the test classpath it resolves to the runtime's
+        // ThreeState. Both are valid — the only environment-independent guarantee is
+        // that the call returns cleanly rather than throwing or wrongly suppressing.
+        shouldNotThrowAny { JetBrainsConsent.isUsageStatsDenied() }
     }
 }

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliApiClientTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliApiClientTest.kt
@@ -199,8 +199,9 @@ class JolliApiClientTest {
         @Test
         fun `pluginVersion is populated from build-time resource`() {
             // Asserts the processResources expand step ran and produced a real
-            // semver — not the 0.0.0 fallback that signals a packaging bug.
-            JolliApiClient.pluginVersion shouldMatch Regex("""^\d+\.\d+\.\d+$""")
+            // version — not the 0.0.0 fallback that signals a packaging bug. Allows an
+            // optional 4th segment for local dev builds (e.g. 0.99.4.2).
+            JolliApiClient.pluginVersion shouldMatch Regex("""^\d+\.\d+\.\d+(\.\d+)?$""")
             JolliApiClient.pluginVersion shouldNotBe "0.0.0"
         }
     }

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/StatusPanelMcpRowTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/StatusPanelMcpRowTest.kt
@@ -1,0 +1,39 @@
+package ai.jolli.jollimemory.toolwindow
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests the pure state → row mapping for the "MCP & Skills" status row. The three states
+ * must always be visible and self-explanatory (the durable replacement for the transient
+ * balloon), so we assert icon + description + the key tooltip contents.
+ */
+class StatusPanelMcpRowTest {
+
+    @Test
+    fun `node present and integrations active is OK active`() {
+        val row = StatusPanel.mcpStatusRow(nodeAvailable = true, integrationsActive = true)
+        row.icon shouldBe StatusPanel.Icon.OK
+        row.label shouldBe "MCP & Skills"
+        row.description shouldBe "active"
+    }
+
+    @Test
+    fun `node missing warns and lists the unavailable features`() {
+        val row = StatusPanel.mcpStatusRow(nodeAvailable = false, integrationsActive = false)
+        row.icon shouldBe StatusPanel.Icon.WARN
+        row.description shouldBe "Node.js not found"
+        row.tooltip!! shouldContain "/jolli-search"
+        row.tooltip!! shouldContain "/jolli-pr"
+        row.tooltip!! shouldContain "MCP"
+    }
+
+    @Test
+    fun `node present but integrations inactive is setup incomplete`() {
+        val row = StatusPanel.mcpStatusRow(nodeAvailable = true, integrationsActive = false)
+        row.icon shouldBe StatusPanel.Icon.WARN
+        row.description shouldBe "setup incomplete"
+        row.tooltip!! shouldContain "jollimemory-install-debug.log"
+    }
+}

--- a/vscode/src/views/CreatePrWebviewPanel.test.ts
+++ b/vscode/src/views/CreatePrWebviewPanel.test.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -158,13 +159,13 @@ beforeEach(() => {
 
 describe("CreatePrWebviewPanel", () => {
 	it("opens a panel and renders the Create PR HTML", async () => {
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		expect(created).toHaveLength(1);
 		expect(created[0].webview.html).toContain("Create Pull Request");
 	});
 
 	it("createPr message routes to handleCreatePr with title+wrapped body", async () => {
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "createPr" });
 		await Promise.resolve(); await Promise.resolve();
 		expect(mocks.handleCreatePr).toHaveBeenCalledTimes(1);
@@ -185,7 +186,7 @@ describe("CreatePrWebviewPanel", () => {
 				postFn({ command: "prCreated", prUrl: "https://github.com/example/1" });
 			},
 		);
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "createPr" });
 		await Promise.resolve(); await Promise.resolve();
 		expect(created[0].webview.postMessage).toHaveBeenCalledWith(
@@ -194,7 +195,7 @@ describe("CreatePrWebviewPanel", () => {
 	});
 
 	it("createPr with edited title/body overrides the drafted values", async () => {
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "createPr", title: "edited title", body: "edited body" });
 		await Promise.resolve(); await Promise.resolve();
 		expect(mocks.handleCreatePr.mock.calls[0][0]).toBe("edited title");
@@ -203,15 +204,15 @@ describe("CreatePrWebviewPanel", () => {
 
 	it("copyBody writes the wrapped markdown to the clipboard", async () => {
 		const vscode = await import("vscode");
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "copyBody" });
 		await Promise.resolve();
 		expect((vscode.env.clipboard.writeText as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
 	});
 
 	it("is a singleton — second show reveals, not re-creates", async () => {
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		expect(created).toHaveLength(1);
 		expect(created[0].reveal).toHaveBeenCalled();
 	});
@@ -219,7 +220,7 @@ describe("CreatePrWebviewPanel", () => {
 	it("worker-busy guard: shows toast and skips handleCreatePr when worker is blocking", async () => {
 		mocks.isWorkerBlockingBusy.mockResolvedValue(true);
 		const vscode = await import("vscode");
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "createPr" });
 		await Promise.resolve(); await Promise.resolve();
 		expect(mocks.handleCreatePr).not.toHaveBeenCalled();
@@ -232,7 +233,7 @@ describe("CreatePrWebviewPanel", () => {
 	it("worker-busy guard: update path also posts a settling message (buttons re-enable)", async () => {
 		mocks.findOpenPrForBranch.mockResolvedValueOnce({ number: 7, url: "https://gh/pr/7" });
 		mocks.isWorkerBlockingBusy.mockResolvedValue(true);
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "createPr" });
 		await Promise.resolve(); await Promise.resolve();
 		expect(mocks.handleUpdatePrWithPush).not.toHaveBeenCalled();
@@ -243,14 +244,14 @@ describe("CreatePrWebviewPanel", () => {
 	it("empty guard: shows info message and does NOT open panel when VM is empty", async () => {
 		mocks.buildCreatePrViewModel.mockResolvedValueOnce({ empty: true });
 		const vscode = await import("vscode");
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		expect(created).toHaveLength(0);
 		expect(vscode.window.showInformationMessage).toHaveBeenCalled();
 	});
 
 	it("openMemory: executes jollimemory.viewMemorySummary with the message hash", async () => {
 		const vscode = await import("vscode");
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "openMemory", hash: "abc123def456" });
 		await Promise.resolve();
 		expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
@@ -262,7 +263,7 @@ describe("CreatePrWebviewPanel", () => {
 	it("openDiff: opens a base..HEAD diff (base + HEAD virtual URIs) for the given path", async () => {
 		const vscode = await import("vscode");
 		(bridge as { getBranchDiffBase: ReturnType<typeof vi.fn> }).getBranchDiffBase.mockResolvedValueOnce("basehash");
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "openDiff", path: "vscode/src/a.ts" });
 		for (let i = 0; i < 5; i++) await Promise.resolve();
 		expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
@@ -279,7 +280,7 @@ describe("CreatePrWebviewPanel", () => {
 	it("openDiff: reads the base (left) side from oldPath for a rename, HEAD (right) from the new path", async () => {
 		const vscode = await import("vscode");
 		(bridge as { getBranchDiffBase: ReturnType<typeof vi.fn> }).getBranchDiffBase.mockResolvedValueOnce("basehash");
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "openDiff", path: "vscode/src/new.ts", oldPath: "vscode/src/old.ts" });
 		for (let i = 0; i < 5; i++) await Promise.resolve();
 		expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
@@ -295,7 +296,7 @@ describe("CreatePrWebviewPanel", () => {
 		const vscode = await import("vscode");
 		const logMod = await import("../util/Logger.js");
 		// No getBranchDiffBase mock: the traversal guard rejects before it is reached.
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "openDiff", path: "vscode/src/new.ts", oldPath: "../../etc/passwd" });
 		for (let i = 0; i < 10; i++) await Promise.resolve();
 		expect(vscode.commands.executeCommand).not.toHaveBeenCalledWith(
@@ -313,7 +314,7 @@ describe("CreatePrWebviewPanel", () => {
 	it("registers a jolli-prdiff content provider whose reader delegates to bridge.readFileAtRef", async () => {
 		const vscode = await import("vscode");
 		(bridge as { readFileAtRef: ReturnType<typeof vi.fn> }).readFileAtRef.mockResolvedValueOnce("BODY");
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		const reg = vscode.workspace.registerTextDocumentContentProvider as ReturnType<typeof vi.fn>;
 		const [scheme, provider] = reg.mock.calls[0] as [string, { provideTextDocumentContent: (u: unknown) => Promise<string> }];
 		expect(scheme).toBe("jolli-prdiff");
@@ -325,13 +326,16 @@ describe("CreatePrWebviewPanel", () => {
 	it("openDiff: falls back to opening the working-tree file when no diff base resolves", async () => {
 		const vscode = await import("vscode");
 		(bridge as { getBranchDiffBase: ReturnType<typeof vi.fn> }).getBranchDiffBase.mockResolvedValueOnce(undefined);
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		// Resolve the workspace root against the host so path.resolve/isPathInside behave
+		// identically on POSIX and Windows (a bare "/repo" is drive-qualified by resolve()).
+		const root = resolve("/repo");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, root, bridge, "main");
 		created[0].onMsg({ command: "openDiff", path: "vscode/src/a.ts" });
 		for (let i = 0; i < 5; i++) await Promise.resolve();
 		expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
 			"vscode.open",
-			// Repo-relative path resolved against the workspace root ("/repo").
-			expect.objectContaining({ fsPath: "/repo/vscode/src/a.ts" }),
+			// Repo-relative path resolved against the workspace root.
+			expect.objectContaining({ fsPath: resolve(root, "vscode/src/a.ts") }),
 		);
 		expect(vscode.commands.executeCommand).not.toHaveBeenCalledWith("vscode.diff", expect.anything(), expect.anything(), expect.anything());
 	});
@@ -339,7 +343,7 @@ describe("CreatePrWebviewPanel", () => {
 	it("openDiff: rejects a path that escapes the workspace via ../ and never opens it", async () => {
 		const vscode = await import("vscode");
 		const logMod = await import("../util/Logger.js");
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "openDiff", path: "../../etc/passwd" });
 		for (let i = 0; i < 10; i++) await Promise.resolve();
 		expect(vscode.commands.executeCommand).not.toHaveBeenCalledWith(
@@ -357,7 +361,7 @@ describe("CreatePrWebviewPanel", () => {
 
 	it("openDiff: rejects an absolute path outside the workspace", async () => {
 		const vscode = await import("vscode");
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "openDiff", path: "/etc/passwd" });
 		for (let i = 0; i < 10; i++) await Promise.resolve();
 		expect(vscode.commands.executeCommand).not.toHaveBeenCalledWith("vscode.open", expect.anything());
@@ -376,7 +380,7 @@ describe("CreatePrWebviewPanel", () => {
 		(vscode.commands.executeCommand as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
 			new Error("diff failed"),
 		);
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "openDiff", path: "missing/file.ts" });
 		// Drain all microtasks until the rejection handler has run.
 		for (let i = 0; i < 10; i++) await Promise.resolve();
@@ -401,7 +405,7 @@ describe("CreatePrWebviewPanel", () => {
 		(vscode.commands.executeCommand as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
 			"permission denied",
 		);
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "openDiff", path: "another/file.ts" });
 		for (let i = 0; i < 10; i++) await Promise.resolve();
 		expect((logMod.log.warn as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(
@@ -444,7 +448,7 @@ describe("CreatePrWebviewPanel", () => {
 
 	it("update mode: when an open PR exists, the panel renders Update PR and routes to handleUpdatePrWithPush", async () => {
 		mocks.findOpenPrForBranch.mockResolvedValueOnce({ number: 7, url: "https://gh/pr/7" });
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		expect(created[0].webview.html).toContain("Update Pull Request");
 		expect(created[0].webview.html).toContain("PR #7");
 
@@ -456,7 +460,7 @@ describe("CreatePrWebviewPanel", () => {
 
 	it("create mode (no open PR): routes to handleCreatePr, not handleUpdatePrWithPush", async () => {
 		mocks.findOpenPrForBranch.mockResolvedValueOnce(undefined);
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "createPr" });
 		await Promise.resolve(); await Promise.resolve();
 		expect(mocks.handleCreatePr).toHaveBeenCalledTimes(1);
@@ -466,7 +470,7 @@ describe("CreatePrWebviewPanel", () => {
 	it("existing-PR lookup failure: logs a warning and falls back to create mode", async () => {
 		const logMod = await import("../util/Logger.js");
 		mocks.findOpenPrForBranch.mockRejectedValueOnce(new Error("gh not installed"));
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		expect(created[0].webview.html).toContain("Create Pull Request");
 		expect((logMod.log.warn as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(
 			"CreatePrPanel",
@@ -521,7 +525,7 @@ describe("CreatePrWebviewPanel", () => {
 		// Reject with a plain string (not an Error) to cover the String(e) arm of
 		// the `e instanceof Error ? e.message : String(e)` ternary.
 		mocks.findOpenPrForBranch.mockRejectedValueOnce("gh exploded");
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		expect(created[0].webview.html).toContain("Create Pull Request");
 		expect((logMod.log.warn as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(
 			"CreatePrPanel",
@@ -531,7 +535,7 @@ describe("CreatePrWebviewPanel", () => {
 
 	it("openPr: opens the PR url externally", async () => {
 		const vscode = await import("vscode");
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "openPr", url: "https://gh/pr/7" });
 		await Promise.resolve();
 		expect(vscode.env.openExternal).toHaveBeenCalled();
@@ -540,7 +544,7 @@ describe("CreatePrWebviewPanel", () => {
 	it("openPr: rejects a non-http(s) scheme (file:) and never opens it", async () => {
 		const vscode = await import("vscode");
 		const logMod = await import("../util/Logger.js");
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "openPr", url: "file:///etc/passwd" });
 		for (let i = 0; i < 5; i++) await Promise.resolve();
 		expect(vscode.env.openExternal).not.toHaveBeenCalled();
@@ -560,7 +564,7 @@ describe("CreatePrWebviewPanel", () => {
 			releaseFirst = () => resolve();
 		});
 		mocks.handleCreatePr.mockReturnValueOnce(pending);
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "createPr" });
 		created[0].onMsg({ command: "createPr" });
 		for (let i = 0; i < 10; i++) await Promise.resolve();
@@ -576,7 +580,7 @@ describe("CreatePrWebviewPanel", () => {
 
 	it("signIn message: executes the jollimemory.signIn command", async () => {
 		const vscode = await import("vscode");
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "signIn" });
 		await Promise.resolve();
 		expect(vscode.commands.executeCommand).toHaveBeenCalledWith("jollimemory.signIn");
@@ -591,13 +595,13 @@ describe("CreatePrWebviewPanel", () => {
 	});
 
 	it("signedIn defaults to false: renders the Sign In link (signed-in variant hidden)", async () => {
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		expect(created[0].webview.html).toContain('id="pr-signin-link"');
 		expect(created[0].webview.html).toContain('class="share-signed-in hidden"');
 	});
 
 	it("notifyAuthChanged: posts an authChanged message to the open panel", async () => {
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		CreatePrWebviewPanel.notifyAuthChanged(true);
 		expect(created[0].webview.postMessage).toHaveBeenCalledWith({
 			command: "authChanged",
@@ -612,12 +616,12 @@ describe("CreatePrWebviewPanel", () => {
 	});
 
 	it("onDidDispose: clears the singleton so the next show() creates a new panel", async () => {
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		expect(created).toHaveLength(1);
 		// Simulate VS Code disposing the panel (e.g. user closes the tab).
 		created[0].onDispose();
 		// Now show() must create a fresh panel, not reveal the disposed one.
-		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, "/repo", bridge, "main");
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		expect(created).toHaveLength(2);
 	});
 });


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it to 1-3 sentences. -->

## Motivation

<!-- Why is this change needed? Link to any related issue with #123. -->

## Changes

<!-- Bullet list of the main changes. -->
-
-

## Testing

<!-- How did you verify this works? -->
- [ ] Added/updated unit tests
- [ ] Ran `./gradlew test` locally
- [ ] Tested in sandbox IDE via `./gradlew runIde`
- [ ] Tested on: (e.g. macOS + IntelliJ 2025.1)

## Screenshots / Recordings

<!-- For UI changes, attach before/after screenshots. Delete section if not applicable. -->

## Checklist

- [ ] Code follows the existing style
- [ ] Documentation updated (README / CHANGELOG) if user-facing
- [ ] No new warnings from Plugin Verifier


<!-- jollimemory-summary-start -->
## Plans & Notes

- PR #274 Review — IntelliJ git-op queue + MCP/skills integrations

## Quick recap

The IntelliJ plugin's continuous integration and release pipelines were broken: every build attempt failed partway through Gradle because a required JavaScript bundle was never produced in those environments. Both the build and publish workflows now set up Node, install dependencies, and compile the CLI bundle as explicit steps before any Gradle work begins. The build workflow's change-detection filter was also expanded to cover CLI and VS Code source files, so future changes to those areas correctly trigger a plugin rebuild rather than being silently skipped.

---

## Topic (1)
<details>
<summary><strong>01 · Fix CI failure: build bundled CLI before IntelliJ Gradle build</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The IntelliJ CI and publish workflows were failing because a Gradle task that packages the CLI JavaScript bundle into the plugin could not find the bundle — it had never been built in those workflows.

**💡 Decisions Behind the Code**

- **Fix both workflows together**: The same missing-bundle failure would have hit the publish workflow on the next release even after fixing the build workflow, so both were updated in the same commit rather than discovering the second failure later. Fixing only the build workflow would have left a latent breakage on the release path.
- **Widen the path filter in the build workflow**: The plugin now embeds the CLI bundle, so changes to CLI or VS Code sources affect the plugin artifact. Keeping the old narrow filter (only `intellij/*`) would have allowed the plugin to ship with a stale bundle when upstream sources changed without touching IntelliJ files.

**✅ What Was Implemented**

- Updated `.github/workflows/build-intellij.yaml` to add three new steps before the Gradle build: set up Node using the version from `.nvmrc`, run `npm ci` to install workspace dependencies, and run `npm run build` to produce the CLI bundle. Also widened the path-change filter to include CLI, VS Code, and package manifest files so the job re-runs when those sources change.
- Updated `.github/workflows/publish-intellij.yaml` with the same three Node/build steps before the Gradle test and build tasks, ensuring release builds have the same prerequisite satisfied.

**📁 FILES**
- `.github/workflows/build-intellij.yaml`
- `.github/workflows/publish-intellij.yaml`

</blockquote>
</details>

---

*Generated by JolliMemory · July 5, 2026 at 10:37 PM · via Anthropic*
<!-- jollimemory-summary-end -->