### PR TITLE
Migrate NFF force-push handling and Codex session resume

### DIFF
--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/PushAction.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/PushAction.kt
@@ -60,21 +60,31 @@ class PushAction : AnAction() {
                     return
                 }
 
-                // NFF rejection — switch to EDT for divergence gate + dialog
+                // NFF rejection — inspect divergence off the EDT (git fetch), then
+                // show the gate dialog on the EDT, then force-push off the EDT again.
+                val safety = ForcePushUtil.inspectForcePushSafety(git, branch)
+                var outcome = ForcePushUtil.ForcePushOutcome.DECLINED
                 ApplicationManager.getApplication().invokeAndWait {
-                    val outcome = ForcePushUtil.gateForcePush(
-                        project, git, branch,
+                    outcome = ForcePushUtil.gateForcePush(
+                        project, branch, safety,
                         reason = "Remote branch has diverged. Force push will overwrite remote history.",
                     )
-                    if (outcome == ForcePushUtil.ForcePushOutcome.CONFIRMED) {
-                        val forceResult = ForcePushUtil.forcePushBranch(git, branch)
+                }
+
+                if (outcome == ForcePushUtil.ForcePushOutcome.CONFIRMED) {
+                    val forceResult = ForcePushUtil.forcePushBranch(git, branch)
+                    ApplicationManager.getApplication().invokeLater {
                         if (forceResult.exitCode == 0) {
                             Messages.showInfoMessage(project, "Force-pushed $branch to origin.", "Jolli Memory")
                         } else {
                             Messages.showErrorDialog(project, "Force push failed:\n\n${forceResult.stderr}", "Push Failed")
                         }
+                        service.refreshStatus()
                     }
-                    service.refreshStatus()
+                } else {
+                    ApplicationManager.getApplication().invokeLater {
+                        service.refreshStatus()
+                    }
                 }
             }
         })

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/PushAction.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/PushAction.kt
@@ -2,6 +2,7 @@ package ai.jolli.jollimemory.actions
 
 import ai.jolli.jollimemory.core.SessionTracker
 import ai.jolli.jollimemory.services.JolliMemoryService
+import ai.jolli.jollimemory.util.ForcePushUtil
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
@@ -12,6 +13,8 @@ import com.intellij.openapi.ui.Messages
 
 /**
  * Push current branch to remote with upstream tracking.
+ * On non-fast-forward rejection, offers a force-push confirmation via
+ * [ForcePushUtil.gateForcePush] with divergence inspection.
  * Matches VS Code PushCommand.ts.
  */
 class PushAction : AnAction() {
@@ -39,17 +42,37 @@ class PushAction : AnAction() {
                 }
 
                 indicator.text = "Pushing $branch to origin..."
-                val result = git.exec("push", "-u", "origin", branch, timeoutSeconds = 60)
+                val result = git.execWithResult("push", "-u", "origin", branch, timeoutSeconds = 60)
 
-                ApplicationManager.getApplication().invokeLater {
-                    if (result != null) {
+                if (result.exitCode == 0) {
+                    ApplicationManager.getApplication().invokeLater {
                         Messages.showInfoMessage(project, "Pushed $branch to origin.", "Jolli Memory")
-                    } else {
-                        Messages.showErrorDialog(
-                            project,
-                            "Push may have failed for $branch. Check git output for details.",
-                            "Push Warning"
-                        )
+                        service.refreshStatus()
+                    }
+                    return
+                }
+
+                if (!ForcePushUtil.isNonFastForwardError(result.stderr)) {
+                    ApplicationManager.getApplication().invokeLater {
+                        Messages.showErrorDialog(project, "Push failed for $branch:\n\n${result.stderr}", "Push Failed")
+                        service.refreshStatus()
+                    }
+                    return
+                }
+
+                // NFF rejection — switch to EDT for divergence gate + dialog
+                ApplicationManager.getApplication().invokeAndWait {
+                    val outcome = ForcePushUtil.gateForcePush(
+                        project, git, branch,
+                        reason = "Remote branch has diverged. Force push will overwrite remote history.",
+                    )
+                    if (outcome == ForcePushUtil.ForcePushOutcome.CONFIRMED) {
+                        val forceResult = ForcePushUtil.forcePushBranch(git, branch)
+                        if (forceResult.exitCode == 0) {
+                            Messages.showInfoMessage(project, "Force-pushed $branch to origin.", "Jolli Memory")
+                        } else {
+                            Messages.showErrorDialog(project, "Force push failed:\n\n${forceResult.stderr}", "Push Failed")
+                        }
                     }
                     service.refreshStatus()
                 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitOps.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitOps.kt
@@ -68,10 +68,15 @@ class GitOps(private val projectDir: String) {
         return basePath
     }
 
+    /** Full result of a git invocation — exit code plus captured stdout and stderr. */
+    data class ExecResult(val exitCode: Int, val stdout: String, val stderr: String)
+
     /**
-     * Runs a git command and returns stdout, or null on failure.
+     * Runs a git command and returns the full [ExecResult] (exit code, stdout, stderr).
+     * Callers that need to classify failures (e.g. non-fast-forward detection) use this
+     * instead of [exec] which discards stderr on failure.
      */
-    fun exec(vararg args: String, timeoutSeconds: Long = 15, trim: Boolean = true): String? {
+    fun execWithResult(vararg args: String, timeoutSeconds: Long = 15, trim: Boolean = true): ExecResult {
         return try {
             val cmdArgs = mutableListOf("git")
             cmdArgs.addAll(args)
@@ -79,37 +84,47 @@ class GitOps(private val projectDir: String) {
             val pb = ProcessBuilder(cmdArgs)
                 .directory(File(projectDir))
                 .redirectErrorStream(false)
-            // Inject the user's full PATH so git hooks can find node (nvm/homebrew)
             pb.environment()["PATH"] = shellPath
             val process = pb.start()
 
-            // Read stdout on a separate thread to avoid pipe buffer deadlock.
-            // If stdout exceeds the OS pipe buffer (~64 KB) and we wait for the
-            // process to finish before reading, the process blocks on write and
-            // we block on waitFor → deadlock → timeout.
+            // Read stdout and stderr concurrently to avoid pipe buffer deadlock.
             val stdoutFuture = java.util.concurrent.CompletableFuture.supplyAsync {
                 process.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+            }
+            val stderrFuture = java.util.concurrent.CompletableFuture.supplyAsync {
+                process.errorStream.bufferedReader(Charsets.UTF_8).use { it.readText().trim() }
             }
 
             val completed = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
             if (!completed) {
                 process.destroyForcibly()
                 stdoutFuture.cancel(true)
+                stderrFuture.cancel(true)
                 log.warn("Git command timed out: %s (cwd=%s)", args.toList(), projectDir)
-                return null
+                return ExecResult(-1, "", "Timed out after ${timeoutSeconds}s")
             }
 
-            if (process.exitValue() != 0) {
-                val stderr = process.errorStream.bufferedReader(Charsets.UTF_8).use { it.readText().trim() }
-                log.warn("Git command exit=%d: %s stderr=%s (cwd=%s)", process.exitValue(), args.toList(), stderr.take(200), projectDir)
-                return null
+            val exitCode = process.exitValue()
+            val stdout = stdoutFuture.get(5, TimeUnit.SECONDS)
+            val stderr = stderrFuture.get(5, TimeUnit.SECONDS)
+            if (exitCode != 0) {
+                log.warn("Git command exit=%d: %s stderr=%s (cwd=%s)", exitCode, args.toList(), stderr.take(200), projectDir)
             }
-            val output = stdoutFuture.get(5, TimeUnit.SECONDS)
-            if (trim) output?.trim() else output?.trimEnd()
+            val out = if (trim) stdout.trim() else stdout.trimEnd()
+            ExecResult(exitCode, out, stderr)
         } catch (e: Exception) {
             log.warn("Git command exception: %s: %s (cwd=%s)", args.toList(), e.message, projectDir)
-            null
+            ExecResult(-1, "", e.message ?: e.toString())
         }
+    }
+
+    /**
+     * Runs a git command and returns stdout, or null on failure.
+     * Delegates to [execWithResult] — use that directly when stderr is needed.
+     */
+    fun exec(vararg args: String, timeoutSeconds: Long = 15, trim: Boolean = true): String? {
+        val result = execWithResult(*args, timeoutSeconds = timeoutSeconds, trim = trim)
+        return if (result.exitCode == 0) result.stdout else null
     }
 
     /** Check if a branch exists. */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/CodexSessionDiscoverer.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/CodexSessionDiscoverer.kt
@@ -1,5 +1,6 @@
 package ai.jolli.jollimemory.core
 
+import com.google.gson.JsonParser
 import java.io.File
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -36,7 +37,11 @@ object CodexSessionDiscoverer {
 
             val files = dayDir.listFiles { f -> f.extension == "jsonl" } ?: continue
             for (file in files) {
-                val sessionId = file.nameWithoutExtension
+                // The resumable session id is `payload.id` (a UUID) from the file's
+                // first `session_meta` line — NOT the rollout filename. `codex resume
+                // <id>` rejects the filename form. Fall back to the filename only when
+                // the meta line can't be parsed, so the conversation still appears.
+                val sessionId = readSessionId(file) ?: file.nameWithoutExtension
                 sessions.add(SessionInfo(
                     sessionId = sessionId,
                     transcriptPath = file.absolutePath,
@@ -48,5 +53,26 @@ object CodexSessionDiscoverer {
 
         log.info("Discovered %d Codex session(s)", sessions.size)
         return sessions
+    }
+
+    /**
+     * Reads the resumable session id from a Codex rollout file's first line
+     * (`session_meta`): `payload.id`, falling back to `payload.session_id`.
+     * Returns null when the line isn't valid session_meta — this is the UUID
+     * `codex resume` expects, distinct from the rollout filename.
+     */
+    private fun readSessionId(file: File): String? {
+        return try {
+            val firstLine = file.bufferedReader().use { it.readLine() } ?: return null
+            val obj = JsonParser.parseString(firstLine).asJsonObject
+            if (obj.get("type")?.asString != "session_meta") return null
+            val payload = obj.getAsJsonObject("payload") ?: return null
+            val id = payload.get("id")?.takeIf { !it.isJsonNull }?.asString
+                ?: payload.get("session_id")?.takeIf { !it.isJsonNull }?.asString
+            id?.takeIf { it.isNotBlank() }
+        } catch (e: Exception) {
+            log.debug("Failed to read Codex session_id from %s: %s", file.name, e.message)
+            null
+        }
     }
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/PrService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/PrService.kt
@@ -322,12 +322,18 @@ object PrService {
         }
     }
 
-    /** Pushes the current branch to origin (sets upstream tracking). */
-    fun pushBranch(cwd: String) {
-        val result = execGit(listOf("push", "-u", "origin", "HEAD"), cwd)
-        if (result == null) {
-            log.warn("Push may have failed, but stderr output is common for push")
+    /** Result of a push attempt — exit code plus stderr for failure classification. */
+    data class PushResult(val exitCode: Int, val stderr: String) {
+        val success: Boolean get() = exitCode == 0
+    }
+
+    /** Pushes the current branch to origin (sets upstream tracking). Returns the result for NFF classification. */
+    fun pushBranch(cwd: String): PushResult {
+        val result = execCommandResult("git", listOf("push", "-u", "origin", "HEAD"), cwd, timeoutSeconds = 60)
+        if (result.exitCode != 0) {
+            log.warn("Push may have failed: stderr='%s'", result.stderr)
         }
+        return PushResult(result.exitCode, result.stderr)
     }
 
     /**

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActiveConversationsPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActiveConversationsPanel.kt
@@ -172,9 +172,9 @@ class ActiveConversationsPanel(
 	}
 
 	private fun onResume(item: ActiveConversationItem) {
-		if (item.source != TranscriptSource.claude) return
+		if (!TerminalUtils.canResumeSource(item.source.name)) return
 		val cwd = service.mainRepoRoot ?: project.basePath ?: return
-		TerminalUtils.resumeClaudeSession(project, item.sessionId, cwd, "Claude – ${item.title}")
+		TerminalUtils.resumeSession(project, item.source.name, item.sessionId, cwd, item.title)
 	}
 
 	private fun onSelectionChanged(item: ActiveConversationItem, selected: Boolean) {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
@@ -1209,12 +1209,12 @@ class CommitsPanel(
         // Hover actions (hidden until hover): Open conversation · Resume (only if local session exists).
         val openBtn = convoActionIcon(JolliMemoryIcons.Eye, "Open conversation") { _ -> openCommittedConversation(commit, c) }
         val fileExists = !c.transcriptPath.isNullOrBlank() && File(c.transcriptPath).exists()
-        val canResume = c.source == "claude" && fileExists
+        val canResume = TerminalUtils.canResumeSource(c.source) && fileExists
         log.info("conversationRow: source=${c.source}, sessionId=${c.sessionId}, transcriptPath=${c.transcriptPath}, fileExists=$fileExists, canResume=$canResume")
         val actions = if (canResume) {
             val continueBtn = convoActionIcon(AllIcons.Actions.Execute, "Resume session in terminal") { _ ->
                 log.info("continueBtn clicked: sessionId=${c.sessionId}, commitHash=${commit.hash}")
-                resumeInTerminal(c.sessionId)
+                resumeInTerminal(c.source, c.sessionId)
             }
             listOf(openBtn, continueBtn)
         } else {
@@ -1748,13 +1748,13 @@ class CommitsPanel(
 
     // ─── Resume session ──────────────────────────────────────────────────────
 
-    /** Opens a new terminal tab and runs `claude --resume <sessionId>`. */
-    private fun resumeInTerminal(sessionId: String) {
+    /** Opens a new terminal tab and runs the source-appropriate resume command. */
+    private fun resumeInTerminal(source: String, sessionId: String) {
         val cwd = service.mainRepoRoot ?: project.basePath
-        log.info("resumeInTerminal: sessionId=$sessionId, cwd=$cwd")
+        log.info("resumeInTerminal: source=$source, sessionId=$sessionId, cwd=$cwd")
         if (cwd == null) return
-        ai.jolli.jollimemory.core.telemetry.Telemetry.track("session_resumed", mapOf("source" to "claude"))
-        TerminalUtils.resumeClaudeSession(project, sessionId, cwd)
+        ai.jolli.jollimemory.core.telemetry.Telemetry.track("session_resumed", mapOf("source" to source.lowercase()))
+        TerminalUtils.resumeSession(project, source, sessionId, cwd)
     }
 
     // ─── Copy recall prompt ──────────────────────────────────────────────────

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt
@@ -137,7 +137,7 @@ class PinnedPanel(
 			add(badge, GridBagConstraints())
 		}
 
-		// Hover actions, right edge: Open (eye) · Resume (play, Claude only) · Unpin.
+		// Hover actions, right edge: Open (eye) · Resume (play, Claude/Codex only) · Unpin.
 		val openBtn = actionIcon(JolliMemoryIcons.Eye, "Open") { openPinned(entry) }
 		val unpinBtn = actionIcon(AllIcons.Actions.Close, "Unpin") {
 			val dir = cwd() ?: return@actionIcon
@@ -147,7 +147,7 @@ class PinnedPanel(
 				refresh()
 			}
 		}
-		val canResume = entry.kind == "conversations" && entry.badge.lowercase() == "claude"
+		val canResume = entry.kind == "conversations" && TerminalUtils.canResumeSource(entry.badge)
 		val actions = if (canResume) {
 			val resumeBtn = actionIcon(AllIcons.Actions.Execute, "Resume session in terminal") { resumeInTerminal(entry) }
 			listOf(openBtn, resumeBtn, unpinBtn)
@@ -254,13 +254,13 @@ class PinnedPanel(
 		})
 	}
 
-	/** Resume a pinned Claude conversation directly in terminal. */
+	/** Resume a pinned conversation directly in terminal (Claude or Codex). */
 	private fun resumeInTerminal(entry: PinStore.PinnedEntry) {
 		val cwd = cwd() ?: return
 		val sessionId = entry.key.substringAfter(":")
 		if (sessionId.isNotBlank()) {
-			ai.jolli.jollimemory.core.telemetry.Telemetry.track("session_resumed", mapOf("source" to "claude"))
-			TerminalUtils.resumeClaudeSession(project, sessionId, cwd, "Claude – ${entry.title}")
+			ai.jolli.jollimemory.core.telemetry.Telemetry.track("session_resumed", mapOf("source" to entry.badge.lowercase()))
+			TerminalUtils.resumeSession(project, entry.badge, sessionId, cwd, entry.title)
 		}
 	}
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
@@ -14,6 +14,7 @@ import ai.jolli.jollimemory.core.SummaryStore
 import ai.jolli.jollimemory.core.SummaryTree
 import ai.jolli.jollimemory.core.TopicUpdates
 import ai.jolli.jollimemory.core.TraceContext
+import ai.jolli.jollimemory.util.ForcePushUtil
 import ai.jolli.jollimemory.core.TranscriptEntry
 import ai.jolli.jollimemory.core.references.SourceId
 import ai.jolli.jollimemory.services.JolliApiClient
@@ -973,9 +974,49 @@ class SummaryPanel(
         postToWebview("prCreating")
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
-                PrService.pushBranch(cwd)
+                val git = GitOps(cwd)
+                val branch = currentSummary.branch
+
+                // Push — detect NFF and offer force-push retry
+                val pushResult = PrService.pushBranch(cwd)
+                if (!pushResult.success) {
+                    if (git != null && ForcePushUtil.isNonFastForwardError(pushResult.stderr)) {
+                        // Switch to EDT for the divergence gate dialog
+                        var outcome = ForcePushUtil.ForcePushOutcome.DECLINED
+                        ApplicationManager.getApplication().invokeAndWait {
+                            outcome = ForcePushUtil.gateForcePush(
+                                project, git, branch,
+                                reason = "The remote has changes your branch does not include.",
+                            )
+                        }
+                        when (outcome) {
+                            ForcePushUtil.ForcePushOutcome.CONFIRMED -> {
+                                val forceResult = ForcePushUtil.forcePushBranch(git, branch)
+                                if (forceResult.exitCode != 0) {
+                                    ApplicationManager.getApplication().invokeLater {
+                                        postToWebview("prCreateError", mapOf("message" to "Force push failed: ${forceResult.stderr}"))
+                                    }
+                                    return@executeOnPooledThread
+                                }
+                            }
+                            else -> {
+                                ApplicationManager.getApplication().invokeLater {
+                                    postToWebview("prCreateError", mapOf("message" to "Push cancelled."))
+                                }
+                                return@executeOnPooledThread
+                            }
+                        }
+                    } else {
+                        // Non-NFF push error — surface it
+                        ApplicationManager.getApplication().invokeLater {
+                            postToWebview("prCreateError", mapOf("message" to "Push failed: ${pushResult.stderr}"))
+                        }
+                        return@executeOnPooledThread
+                    }
+                }
+
                 // Check if PR already exists for this branch — update instead of create
-                val lookup = PrService.findPrForBranch(cwd, currentSummary.branch)
+                val lookup = PrService.findPrForBranch(cwd, branch)
                 val prUrl: String
                 if (lookup is PrService.PrLookup.Found) {
                     PrService.updatePr(lookup.pr.number, title, body, cwd)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
@@ -14,7 +14,6 @@ import ai.jolli.jollimemory.core.SummaryStore
 import ai.jolli.jollimemory.core.SummaryTree
 import ai.jolli.jollimemory.core.TopicUpdates
 import ai.jolli.jollimemory.core.TraceContext
-import ai.jolli.jollimemory.util.ForcePushUtil
 import ai.jolli.jollimemory.core.TranscriptEntry
 import ai.jolli.jollimemory.core.references.SourceId
 import ai.jolli.jollimemory.services.JolliApiClient
@@ -26,6 +25,7 @@ import ai.jolli.jollimemory.toolwindow.views.SummaryHtmlBuilder
 import ai.jolli.jollimemory.toolwindow.views.SummaryMarkdownBuilder
 import ai.jolli.jollimemory.toolwindow.views.SummaryPrMarkdownBuilder
 import ai.jolli.jollimemory.toolwindow.views.SummaryUtils
+import ai.jolli.jollimemory.util.ForcePushUtil
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
@@ -980,12 +980,13 @@ class SummaryPanel(
                 // Push — detect NFF and offer force-push retry
                 val pushResult = PrService.pushBranch(cwd)
                 if (!pushResult.success) {
-                    if (git != null && ForcePushUtil.isNonFastForwardError(pushResult.stderr)) {
-                        // Switch to EDT for the divergence gate dialog
+                    if (ForcePushUtil.isNonFastForwardError(pushResult.stderr)) {
+                        // Inspect divergence off the EDT (git fetch), then show the gate dialog on the EDT
+                        val safety = ForcePushUtil.inspectForcePushSafety(git, branch)
                         var outcome = ForcePushUtil.ForcePushOutcome.DECLINED
                         ApplicationManager.getApplication().invokeAndWait {
                             outcome = ForcePushUtil.gateForcePush(
-                                project, git, branch,
+                                project, branch, safety,
                                 reason = "The remote has changes your branch does not include.",
                             )
                         }
@@ -999,7 +1000,13 @@ class SummaryPanel(
                                     return@executeOnPooledThread
                                 }
                             }
-                            else -> {
+                            ForcePushUtil.ForcePushOutcome.BLOCKED -> {
+                                ApplicationManager.getApplication().invokeLater {
+                                    postToWebview("prCreateError", mapOf("message" to "Push blocked — your branch is behind the remote. Pull or rebase, then try again."))
+                                }
+                                return@executeOnPooledThread
+                            }
+                            ForcePushUtil.ForcePushOutcome.DECLINED -> {
                                 ApplicationManager.getApplication().invokeLater {
                                     postToWebview("prCreateError", mapOf("message" to "Push cancelled."))
                                 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/TerminalUtils.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/TerminalUtils.kt
@@ -13,11 +13,32 @@ object TerminalUtils {
 
 	private val log = Logger.getInstance(TerminalUtils::class.java)
 
-	/** Opens a new terminal tab in the given [cwd] and runs `claude --resume <sessionId>`. */
-	fun resumeClaudeSession(project: Project, sessionId: String, cwd: String, title: String = "Claude – resume") {
+	/** Whether [source] supports resuming a session from the terminal. */
+	fun canResumeSource(source: String): Boolean = source.lowercase() in setOf("claude", "codex")
+
+	/**
+	 * Opens a new terminal tab in the given [cwd] and runs the source-appropriate
+	 * resume command: `claude --resume <id>` for Claude, `codex resume <id>` for
+	 * Codex. Unsupported sources are a no-op (a warning notification).
+	 */
+	fun resumeSession(project: Project, source: String, sessionId: String, cwd: String, title: String? = null) {
+		val src = source.lowercase()
+		val command = when (src) {
+			"codex" -> "codex resume $sessionId"
+			"claude" -> "claude --resume $sessionId"
+			else -> {
+				log.warn("Resume requested for unsupported source: $source")
+				Notifications.Bus.notify(
+					Notification("JolliMemory", "Resume Session", "Resuming isn't supported for this conversation type.", NotificationType.WARNING),
+					project,
+				)
+				return
+			}
+		}
+		val tabTitle = title ?: if (src == "codex") "Codex – resume" else "Claude – resume"
 		try {
-			val widget = createShellWidget(project, cwd, title)
-			widget.sendCommandToExecute("claude --resume $sessionId")
+			val widget = createShellWidget(project, cwd, tabTitle)
+			widget.sendCommandToExecute(command)
 		} catch (e: Exception) {
 			log.warn("Failed to open terminal for session resume: ${e.message}", e)
 			Notifications.Bus.notify(

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/util/ForcePushUtil.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/util/ForcePushUtil.kt
@@ -69,23 +69,24 @@ object ForcePushUtil {
 	}
 
 	/**
-	 * Post-rejection gate. Inspects divergence, then either:
+	 * Post-rejection gate. Given the divergence [safety] (computed by
+	 * [inspectForcePushSafety]), either:
 	 * - blocks when the branch is merely behind (force-push never offered),
 	 * - shows the shared force-push confirmation with lost-commit count.
 	 *
-	 * When divergence can't be measured, falls back to plain confirm so a
-	 * legitimate rewrite is never blocked by a transient failure.
+	 * When [safety] is null (divergence couldn't be measured), falls back to a
+	 * plain confirm so a legitimate rewrite is never blocked by a transient
+	 * failure.
 	 *
-	 * MUST be called from the EDT (shows dialogs).
+	 * Dialog-only: MUST be called from the EDT. Run [inspectForcePushSafety] on a
+	 * background thread first and pass its result in — this function does no I/O.
 	 */
 	fun gateForcePush(
 		project: Project,
-		git: GitOps,
 		branch: String,
+		safety: ForcePushSafety?,
 		reason: String = "Remote branch has diverged. Force push will overwrite remote history.",
 	): ForcePushOutcome {
-		val safety = inspectForcePushSafety(git, branch)
-
 		if (safety?.behindOnly == true) {
 			val commits = if (safety.remoteOnly == 1) "commit" else "commits"
 			val message = buildString {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/util/ForcePushUtil.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/util/ForcePushUtil.kt
@@ -1,0 +1,137 @@
+package ai.jolli.jollimemory.util
+
+import ai.jolli.jollimemory.bridge.GitOps
+import ai.jolli.jollimemory.core.JmLogger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+
+/**
+ * Shared force-push utilities — Kotlin port of ForcePushPrompt.ts + ForcePushSafety.ts.
+ *
+ * Single source of truth for non-fast-forward (NFF) detection, divergence
+ * inspection, and the force-push confirmation dialog. Used by PushAction and
+ * SummaryPanel's Create PR flow. The squash pre-warning in SquashAction is
+ * intentionally NOT routed here (different decision, different wording).
+ */
+object ForcePushUtil {
+
+	private val log = JmLogger.create("ForcePushUtil")
+
+	/** Result of the post-rejection force-push gate. */
+	enum class ForcePushOutcome { CONFIRMED, DECLINED, BLOCKED }
+
+	/** How the local branch and its remote-tracking ref diverge. */
+	data class ForcePushSafety(
+		val branch: String,
+		/** Commits on origin/<branch> missing from local HEAD — lost by force-push. */
+		val remoteOnly: Int,
+		/** Commits on local HEAD missing from origin/<branch>. */
+		val localOnly: Int,
+		/** True when remote is strictly ahead and local has no unique commits. */
+		val behindOnly: Boolean,
+	)
+
+	/**
+	 * Recognizes git's non-fast-forward push rejection from stderr.
+	 * Matches the same four patterns as ForcePushPrompt.ts:isNonFastForwardError.
+	 */
+	fun isNonFastForwardError(stderr: String): Boolean {
+		val lower = stderr.lowercase()
+		return lower.contains("non-fast-forward") ||
+			lower.contains("fetch first") ||
+			lower.contains("[rejected]") ||
+			lower.contains("tip of your current branch is behind")
+	}
+
+	/**
+	 * Inspects divergence between local branch and its remote-tracking ref.
+	 * Fetches the remote first so counts reflect the true state.
+	 * Returns null when comparison can't be made (detached HEAD, network error).
+	 * Mirrors ForcePushSafety.ts:inspectForcePushSafety.
+	 */
+	fun inspectForcePushSafety(git: GitOps, branch: String): ForcePushSafety? {
+		if (branch.isBlank() || branch == "HEAD") return null
+		val remoteRef = "origin/$branch"
+		return try {
+			git.exec("fetch", "origin", branch, timeoutSeconds = 30) ?: return null
+			val remoteOnly = git.exec("rev-list", "--count", "HEAD..$remoteRef")?.trim()?.toIntOrNull() ?: return null
+			val localOnly = git.exec("rev-list", "--count", "$remoteRef..HEAD")?.trim()?.toIntOrNull() ?: return null
+			ForcePushSafety(
+				branch = branch,
+				remoteOnly = remoteOnly,
+				localOnly = localOnly,
+				behindOnly = remoteOnly > 0 && localOnly == 0,
+			)
+		} catch (e: Exception) {
+			log.warn("inspectForcePushSafety failed: %s", e.message)
+			null
+		}
+	}
+
+	/**
+	 * Post-rejection gate. Inspects divergence, then either:
+	 * - blocks when the branch is merely behind (force-push never offered),
+	 * - shows the shared force-push confirmation with lost-commit count.
+	 *
+	 * When divergence can't be measured, falls back to plain confirm so a
+	 * legitimate rewrite is never blocked by a transient failure.
+	 *
+	 * MUST be called from the EDT (shows dialogs).
+	 */
+	fun gateForcePush(
+		project: Project,
+		git: GitOps,
+		branch: String,
+		reason: String = "Remote branch has diverged. Force push will overwrite remote history.",
+	): ForcePushOutcome {
+		val safety = inspectForcePushSafety(git, branch)
+
+		if (safety?.behindOnly == true) {
+			val commits = if (safety.remoteOnly == 1) "commit" else "commits"
+			val message = buildString {
+				appendLine("Remote branch \"$branch\" has ${safety.remoteOnly} $commits you don't have locally,")
+				appendLine("and your branch has no commits the remote is missing.")
+				appendLine()
+				appendLine("This is not a history rewrite — your branch is simply behind. Pull or")
+				appendLine("rebase to integrate the remote commits, then push again. Force-pushing")
+				append("here would permanently delete those ${safety.remoteOnly} remote $commits.")
+			}
+			Messages.showWarningDialog(project, message, "Cannot Force Push")
+			return ForcePushOutcome.BLOCKED
+		}
+
+		val lostLine = if (safety != null && safety.remoteOnly > 0) {
+			val commits = if (safety.remoteOnly == 1) "commit" else "commits"
+			"\nWarning: this will permanently delete ${safety.remoteOnly} $commits that exist only on the remote."
+		} else {
+			""
+		}
+
+		val message = buildString {
+			appendLine("This operation may rewrite remote history.")
+			appendLine()
+			append(reason)
+			if (lostLine.isNotEmpty()) append(lostLine)
+			appendLine()
+			append("This may affect collaborators on the same branch.")
+		}
+
+		val result = Messages.showYesNoDialog(
+			project,
+			message,
+			"Force Push Required",
+			"Force Push (--force-with-lease)",
+			"Cancel",
+			Messages.getWarningIcon(),
+		)
+		return if (result == Messages.YES) ForcePushOutcome.CONFIRMED else ForcePushOutcome.DECLINED
+	}
+
+	/**
+	 * Runs `git push --force-with-lease origin <branch>`.
+	 * Returns the ExecResult so callers can check success and surface errors.
+	 */
+	fun forcePushBranch(git: GitOps, branch: String): GitOps.ExecResult {
+		return git.execWithResult("push", "--force-with-lease", "origin", branch, timeoutSeconds = 60)
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/util/ForcePushUtilTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/util/ForcePushUtilTest.kt
@@ -1,0 +1,42 @@
+package ai.jolli.jollimemory.util
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class ForcePushUtilTest {
+
+	@Test
+	fun `detects non-fast-forward error`() {
+		ForcePushUtil.isNonFastForwardError("! [rejected] main -> main (non-fast-forward)") shouldBe true
+	}
+
+	@Test
+	fun `detects fetch first hint`() {
+		ForcePushUtil.isNonFastForwardError("hint: Updates were rejected because the tip of your current branch is behind\nhint: its remote counterpart. If you want to integrate the remote changes,\nhint: use 'git pull' before pushing again.\nhint: See the 'Note about fast-forwards' in 'git push --help' for details.") shouldBe true
+	}
+
+	@Test
+	fun `detects rejected bracket marker`() {
+		ForcePushUtil.isNonFastForwardError("To github.com:user/repo.git\n ! [rejected]        feature -> feature (fetch first)") shouldBe true
+	}
+
+	@Test
+	fun `detects tip behind message`() {
+		ForcePushUtil.isNonFastForwardError("error: failed to push some refs to 'origin'\nhint: tip of your current branch is behind") shouldBe true
+	}
+
+	@Test
+	fun `returns false for auth error`() {
+		ForcePushUtil.isNonFastForwardError("remote: Permission to user/repo.git denied to user.\nfatal: unable to access 'https://github.com/user/repo.git/': The requested URL returned error: 403") shouldBe false
+	}
+
+	@Test
+	fun `returns false for empty string`() {
+		ForcePushUtil.isNonFastForwardError("") shouldBe false
+	}
+
+	@Test
+	fun `detection is case insensitive`() {
+		ForcePushUtil.isNonFastForwardError("NON-FAST-FORWARD") shouldBe true
+	}
+}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The plugin's resume-in-terminal feature was extended to cover Codex sessions alongside Claude. Previously, the resume button was hidden for any conversation that wasn't from Claude, and even when Codex sessions were discovered, the identifier used to resume them was the rollout filename rather than the UUID the command-line tool actually accepts. Both gaps were closed in this batch of changes.

The session discovery layer now reads the correct resumable UUID directly from each Codex rollout file's metadata, falling back to the filename only when the file cannot be parsed. The resume action itself was generalized across all three panels — Active Conversations, Commits, and Pinned — so the button now appears for Codex sessions and dispatches the right command for each source. Telemetry was updated to record the actual conversation source rather than always attributing resumes to Claude.

---

## Topics (2)
<details>
<summary><strong>01 · Extend session resume support to Codex conversations</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The resume-in-terminal feature only worked for Claude conversations. Users with Codex sessions had no way to resume them from the Active Conversations, Commits, or Pinned panels — the resume button was hidden or the action was silently ignored for anything that wasn't Claude.

**💡 Decisions Behind the Code**

- **Single dispatch point over per-panel branching**: All source-to-command mapping was centralized in `TerminalUtils` rather than duplicating conditional logic in each of the three panels. This keeps the panels thin and means adding a third resumable source in the future requires a change in exactly one place, reducing the risk of panels falling out of sync.
- **Graceful degradation for unknown sources**: Rather than throwing an exception or silently doing nothing when an unrecognized source is encountered, the implementation shows a user-facing warning notification. This makes the failure visible without crashing the IDE, and gives users actionable feedback if a session's source metadata is unexpected.

**✅ What Was Implemented**

- `TerminalUtils.kt` was refactored to replace the Claude-specific `resumeClaudeSession` function with a general-purpose `resumeSession` function and a `canResumeSource` predicate. The new function dispatches to `claude --resume <id>` or `codex resume <id>` based on the source string, and shows a warning notification for any unsupported source rather than silently doing nothing.
- `ActiveConversationsPanel.kt`, `CommitsPanel.kt`, and `PinnedPanel.kt` were each updated to call `canResumeSource` for their resume-button visibility checks and to pass the source name through to `resumeSession`, replacing the previous hardcoded Claude-only guards. Telemetry calls were also updated to record the actual source rather than always logging "claude".

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/TerminalUtils.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActiveConversationsPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Fix Codex session IDs so resume command actually works</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Codex stores its sessions in rollout files whose filename is not the ID that the `codex resume` command accepts. Using the filename as the session ID caused resume attempts to fail silently — the command would reject the identifier without explanation.

**💡 Decisions Behind the Code**

- **Parse only the first line**: The resumable ID is always in the first `session_meta` line of the file, so there is no need to scan the entire (potentially large) rollout file. Reading a single line keeps discovery fast regardless of transcript length.
- **Filename as fallback rather than hard failure**: Keeping the filename fallback means a session with an unreadable metadata line still surfaces in the UI. Users see the conversation and can open it; they just cannot resume it via terminal. A hard failure would silently drop sessions from the list, which is a worse outcome.

**✅ What Was Implemented**

- `CodexSessionDiscoverer.kt` gained a new `readSessionId` private function that opens a Codex rollout file, reads its first line, and extracts the resumable UUID from the `payload.id` field (falling back to `payload.session_id`) of the `session_meta` JSON entry. This UUID is what the `codex resume` command actually expects.
- The session discovery loop now calls `readSessionId` and uses its result as the session ID, falling back to the filename only when the metadata line cannot be parsed. This ensures sessions still appear in the UI even if the file is malformed, while providing a correct ID whenever possible.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/CodexSessionDiscoverer.kt`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 4, 2026 at 10:24 AM · via Anthropic*

> Note: 3 commit(s) without summary were skipped.
<!-- jollimemory-summary-end -->
