### PR TITLE
Paginate the commit list 6 at a time with a Show more link

### DIFF
--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitOps.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitOps.kt
@@ -331,6 +331,53 @@ class GitOps(private val projectDir: String) {
         return lines.last().substringBefore(" ").takeIf { it.isNotBlank() }
     }
 
+    /** Reflog-derived merged-history result: log-range base + whether the branch authored anything. */
+    data class MergedHistory(val base: String, val hasOwnCommit: Boolean)
+
+    /**
+     * Resolves what the merged-mode history view needs from [branch]'s reflog: the
+     * log-range base (where the branch was created) and whether the branch ever
+     * committed anything of its own.
+     *
+     * Used when HEAD is fully contained in the mainline (`merge-base HEAD base ==
+     * HEAD`) — e.g. on `main` in a repo with no remote — so the panel can still show
+     * the user's own commits (`<base>..HEAD --author=<you>`) instead of an empty
+     * list. [hasOwnCommit] keys on a `commit` reflog op: a branch showing only
+     * creation + rebase/reset/checkout never authored anything itself, so the caller
+     * shows an empty panel rather than re-listing commits that belong to the base.
+     *
+     * Returns null for detached HEAD or when the reflog is unavailable/expired —
+     * same graceful-degradation boundary [findBranchCreationPoint] uses. Mirrors the
+     * VS Code bridge's resolveMergedHistory.
+     */
+    fun resolveMergedHistory(branch: String): MergedHistory? {
+        if (branch == "HEAD") return null
+        val reflog = exec("reflog", "show", branch, "--format=%H %gs") ?: return null
+        val lines = reflog.lines().filter { it.isNotBlank() }
+        if (lines.isEmpty()) return null
+
+        // Base: the explicit "branch: Created from …" entry if present (scan from
+        // oldest), else the oldest surviving entry — the same best-effort fallback
+        // the non-strict findBranchCreationPoint uses.
+        var base: String? = null
+        for (i in lines.indices.reversed()) {
+            if (lines[i].contains("branch: Created from")) {
+                base = lines[i].substringBefore(" ").takeIf { it.isNotBlank() }
+                break
+            }
+        }
+        if (base == null) base = lines.last().substringBefore(" ").takeIf { it.isNotBlank() }
+        val resolvedBase = base ?: return null
+
+        // Own commit = a `commit` reflog op ("commit:", "commit (amend):",
+        // "commit (initial):"). The subject follows the leading "<hash> ".
+        val hasOwnCommit = lines.any { Regex("^[0-9a-f]+ commit\\b").containsMatchIn(it) }
+        return MergedHistory(resolvedBase, hasOwnCommit)
+    }
+
+    /** Current `git config user.name` (for the merged-mode `--author` filter); null when unset/blank. */
+    fun getCurrentUserName(): String? = exec("config", "user.name")?.trim()?.takeIf { it.isNotBlank() }
+
     /**
      * Resolves the base commit that "own commits" on [branch] are measured from.
      *

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
@@ -639,14 +639,29 @@ val sb = StringBuilder()
         val mergeBaseRaw = g.exec("merge-base", "HEAD", baseRef)?.trim()
         val mergeBase = mergeBaseRaw?.takeIf { it.isNotBlank() }
 
-        // If merge-base equals HEAD, we're on main or branch is fully merged.
-        // When on main with a remote, show unpushed commits (origin/main..HEAD).
-        // When on main with no remote or on a fresh branch with no own commits,
-        // return empty — matches VS Code behavior where Commits panel clears on new branch.
-        val range = when {
+        // If merge-base equals HEAD, we're on main or the branch is fully merged.
+        // - With a remote (baseRef = origin/*): show commits not on the remote
+        //   (origin/main..HEAD) — empty when fully synced.
+        // - Without a remote (baseRef = main / upstream/*): enter merged mode and
+        //   list the user's own commits from the reflog creation point, filtered by
+        //   author. This mirrors VS Code listBranchCommits, which shows committed
+        //   memories on main even in a repo with no remote (previously IntelliJ
+        //   returned an empty panel here).
+        var authorFilter: String? = null
+        val range: String? = when {
             mergeBase == null -> null // No common ancestor
             mergeBase == headHash && baseRef.startsWith("origin/") -> "$baseRef..HEAD"
-            mergeBase == headHash -> return emptyList() // On main or fresh branch — no branch-specific commits
+            mergeBase == headHash -> {
+                val branch = g.getCurrentBranch()?.trim()
+                val merged = if (branch.isNullOrBlank()) null else g.resolveMergedHistory(branch)
+                // A branch/main that never authored anything of its own (only
+                // creation + rebase/reset) has no commits to show — clear the panel.
+                if (merged == null || !merged.hasOwnCommit) return emptyList()
+                // Merged mode is author-scoped; without a user.name the filter can't
+                // be applied, so degrade to the empty panel rather than over-listing.
+                authorFilter = g.getCurrentUserName() ?: return emptyList()
+                "${merged.base}..HEAD"
+            }
             else -> {
                 // Narrow the fork point to the branch's true reflog creation point,
                 // so a branch cut from a feature/release branch — including a
@@ -661,9 +676,11 @@ val sb = StringBuilder()
             }
         }
 
-        // Get commits with full metadata
+        // Get commits with full metadata. In merged mode an --author filter scopes
+        // the range to the current user's own commits (matching VS Code).
         val logArgs = if (range != null) {
-            arrayOf("log", range, "--format=%H%x00%s%x00%an%x00%ae%x00%aI%x00%x00", "--no-merges")
+            val base = arrayOf("log", range, "--format=%H%x00%s%x00%an%x00%ae%x00%aI%x00%x00", "--no-merges")
+            if (authorFilter != null) base + "--author=$authorFilter" else base
         } else {
             arrayOf("log", "--format=%H%x00%s%x00%an%x00%ae%x00%aI%x00%x00", "--no-merges", "-20")
         }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CappedRows.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CappedRows.kt
@@ -43,7 +43,12 @@ object CappedRows {
 		container.repaint()
 	}
 
-	private fun showMoreRow(remaining: Int, onClick: () -> Unit): JComponent {
+	/**
+	 * A clickable "Show N more" row (down-chevron-free, link-styled). Exposed so
+	 * lists that page incrementally rather than toggling all-at-once (e.g. the
+	 * commit list in [CommitsPanel]) can reuse the exact styling.
+	 */
+	fun showMoreRow(remaining: Int, onClick: () -> Unit): JComponent {
 		val link = JBLabel("Show $remaining more").apply {
 			foreground = com.intellij.ui.JBColor.namedColor("Link.activeForeground", com.intellij.ui.JBColor.BLUE)
 			font = font.deriveFont(font.size2D - 1f).deriveFont(Font.PLAIN)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
@@ -101,6 +101,14 @@ class CommitsPanel(
     )
     private val checkedHashes = mutableSetOf<String>()
     private var commits: List<CommitSummaryBrief> = emptyList()
+    /**
+     * How many commits are currently shown. Starts at [CappedRows.CAP] and grows
+     * by that page size each time the user clicks "Show N more". Reset to the cap
+     * whenever the commit sequence changes (new branch / new commit), but preserved
+     * across content-identical refreshes (e.g. a background summary tick) so the
+     * list doesn't snap shut while the user is reading.
+     */
+    private var visibleCommits: Int = CappedRows.CAP
     /** Per-commit UI state for expand/collapse and checkbox management. */
     private val commitRowStates = mutableMapOf<String, CommitRowState>()
     /**
@@ -305,6 +313,9 @@ class CommitsPanel(
                 if (checkedHashes.isNotEmpty()) checkedHashes.clear()
                 // Clear detail cache when commit sequence changes
                 detailCache.clear()
+                // Collapse the list back to the first page on a new branch / new
+                // commit; a content-identical refresh leaves the count untouched.
+                visibleCommits = CappedRows.CAP
             }
 
             // Detect merged state: branch HEAD is reachable from main
@@ -368,11 +379,23 @@ class CommitsPanel(
                 "Every commit on this branch will be automatically summarized.</center></html>"
             add(emptyLabel, BorderLayout.CENTER)
         } else {
-            for (commit in commits) {
+            // Show at most [visibleCommits] rows; the rest hide behind a
+            // "Show N more" row that reveals the next page on click.
+            val shown = commits.take(visibleCommits)
+            for (commit in shown) {
                 val state = createCommitRow(commit)
                 commitRowStates[commit.hash] = state
                 listPanel.add(state.row)
                 listPanel.add(state.fileContainer)
+            }
+            if (commits.size > visibleCommits) {
+                val remaining = commits.size - visibleCommits
+                listPanel.add(
+                    CappedRows.showMoreRow(remaining) {
+                        visibleCommits += CappedRows.CAP
+                        updateCommitList()
+                    },
+                )
             }
             // Token-usage meter sits above the list; both share the sidebar's
             // single top-level scrollbar (no inner scrollbar here). Rendered at

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/GitOpsMergedHistoryTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/GitOpsMergedHistoryTest.kt
@@ -1,0 +1,89 @@
+package ai.jolli.jollimemory.bridge
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+/**
+ * Integration tests for the reflog-based merged-mode resolution that lets the
+ * COMMITTED MEMORIES panel show the user's own commits on `main` in a repo with
+ * NO remote (where merge-base(HEAD, main) == HEAD). Before this, IntelliJ cleared
+ * the panel in that case while VS Code showed the commits via merged mode.
+ */
+class GitOpsMergedHistoryTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var repo: File
+    private lateinit var git: GitOps
+
+    @BeforeEach
+    fun setUp() {
+        repo = tempDir.toFile()
+        run("init", "-b", "main")
+        run("config", "user.email", "test@example.com")
+        run("config", "user.name", "Test User")
+        run("commit", "--allow-empty", "-m", "root on main")
+        git = GitOps(repo.absolutePath)
+    }
+
+    /** Runs a git command in the temp repo and returns trimmed stdout (fails loudly on error). */
+    private fun run(vararg args: String): String {
+        val pb = ProcessBuilder(listOf("git") + args).directory(repo).redirectErrorStream(true)
+        val p = pb.start()
+        val out = p.inputStream.bufferedReader().use { it.readText() }
+        check(p.waitFor(30, TimeUnit.SECONDS)) { "git ${args.joinToString(" ")} timed out" }
+        check(p.exitValue() == 0) { "git ${args.joinToString(" ")} failed: $out" }
+        return out.trim()
+    }
+
+    private fun rev(ref: String): String = run("rev-parse", ref)
+
+    @Test
+    fun `on main with no remote resolves the reflog base and detects own commits`() {
+        // A second commit on main (no remote configured at all).
+        run("commit", "--allow-empty", "-m", "second on main")
+        val root = run("rev-list", "--max-parents=0", "HEAD") // first commit == oldest reflog entry
+
+        val merged = git.resolveMergedHistory("main")
+        merged shouldNotBe null
+        merged!!.hasOwnCommit shouldBe true
+        // Base is the oldest surviving reflog entry (the initial commit), so
+        // `<base>..HEAD` lists the user's later commits on main.
+        merged.base shouldBe root
+    }
+
+    @Test
+    fun `a freshly cut branch reports no own commit`() {
+        // Created from main, no commits of its own → only a "Created from" reflog op.
+        run("checkout", "-b", "feature/fresh")
+
+        val merged = git.resolveMergedHistory("feature/fresh")
+        merged shouldNotBe null
+        merged!!.hasOwnCommit shouldBe false
+    }
+
+    @Test
+    fun `own commit is detected after committing on a cut branch`() {
+        run("checkout", "-b", "feature/work")
+        run("commit", "--allow-empty", "-m", "own work")
+
+        git.resolveMergedHistory("feature/work")!!.hasOwnCommit shouldBe true
+    }
+
+    @Test
+    fun `detached HEAD has no merged history`() {
+        git.resolveMergedHistory("HEAD") shouldBe null
+    }
+
+    @Test
+    fun `getCurrentUserName reads git config user name`() {
+        git.getCurrentUserName() shouldBe "Test User"
+    }
+}

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -50,6 +50,20 @@ describe("SidebarScriptBuilder", () => {
 		expect(js).toContain("acquireVsCodeApi");
 	});
 
+	it("paginates the committed-memories list a page at a time", () => {
+		const js = buildSidebarScript();
+		// A fixed page size drives both the initial cap and each reveal.
+		expect(js).toContain("COMMITS_PAGE = 6");
+		// The list caps at commitsVisible and appends the incremental more-row.
+		expect(js).toContain("commitsCapped");
+		expect(js).toContain("renderCommitsMoreRow");
+		expect(js).toContain("'data-commits-more'");
+		// Clicking the more-row grows the reveal count and re-renders.
+		expect(js).toContain("commitsVisible += COMMITS_PAGE");
+		// The reveal count resets when the commit sequence changes.
+		expect(js).toContain("commitsVisible = COMMITS_PAGE");
+	});
+
 	it("registers a message listener and posts ready on load", () => {
 		const js = buildSidebarScript();
 		expect(js).toContain("addEventListener('message'");

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -449,6 +449,12 @@ export function buildSidebarScript(): string {
   // preview list that expands on demand.
   const SUBSECTION_PREVIEW = 5;
 
+  // Page size for the top-level Committed Memories list: show this many commits
+  // at first, then reveal another page on each "Show N more" click until all are
+  // visible. Unlike the sub-section preview (a binary show-all / show-less
+  // toggle), the commit list grows incrementally.
+  const COMMITS_PAGE = 6;
+
   function buildKbSearchBox() {
     // Always-visible search affordance for memories mode. Leading magnifier
     // glyph (codicon) sits inside the input box via CSS positioning. Pressing
@@ -1037,11 +1043,18 @@ export function buildSidebarScript(): string {
         branchData.changes = msg.items.slice();
         if (state.activeTab === 'branch') renderBranch();
         break;
-      case 'branch:commitsData':
+      case 'branch:commitsData': {
+        // Collapse the list back to the first page when the commit sequence
+        // changes (branch switch / new commit); a content-identical refresh
+        // leaves the reveal count untouched.
+        const newHashes = msg.items.map(function(c) { return c.hash; }).join('|');
+        const oldHashes = branchData.commits.map(function(c) { return c.hash; }).join('|');
+        if (newHashes !== oldHashes) commitsVisible = COMMITS_PAGE;
         branchData.commits = msg.items.slice();
         branchData.commitsMode = msg.mode || 'empty';
         if (state.activeTab === 'branch') renderBranch();
         break;
+      }
       case 'branch:tokenStats':
         // cached defaults to 0 for back-compat with an older host that didn't
         // send the field (the bar then renders just input/output, no third seg).
@@ -3378,6 +3391,12 @@ export function buildSidebarScript(): string {
 
   // ---- Branch tab renderer ----
   let branchData = { plans: [], changes: [], commits: [], commitsMode: 'empty', conversations: [], conversationsFailedSources: [] };
+  // How many committed memories are currently shown. Grows by COMMITS_PAGE each
+  // time "Show N more" is clicked; reset to the page size whenever the commit
+  // sequence changes (new branch / new commit) so a fresh list starts collapsed.
+  // Transient (mirrors the IntelliJ panel field) — a same-content refresh leaves
+  // it untouched so a background summary tick doesn't snap the list shut.
+  let commitsVisible = COMMITS_PAGE;
   // Squash is an explicit, transient selection mode (mockup): the user clicks
   // "Squash" to reveal per-memory checkboxes + a confirm bar, picks 2+, then
   // confirms or cancels. Not persisted — a reload starts out of squash mode.
@@ -3835,6 +3854,18 @@ export function buildSidebarScript(): string {
     ]);
   }
 
+  // Bottom-of-list "Show N more" row for the top-level Committed Memories
+  // section. Unlike renderShowMoreRow (a binary show-all/less toggle keyed on
+  // data-show-more), this one only ever grows the list a page at a time and
+  // disappears once every commit is shown, so it carries a distinct
+  // data-commits-more marker and always uses the down chevron.
+  function renderCommitsMoreRow(hiddenCount) {
+    return el('div', { className: 'show-more-row', 'data-commits-more': '1' }, [
+      el('i', { className: 'codicon codicon-chevron-down section-twirl', 'aria-hidden': 'true' }),
+      el('span', { className: 'show-more-label', text: 'Show ' + hiddenCount + ' more' }),
+    ]);
+  }
+
   // Inline worker/ingest signal for the Committed Memories header. The global
   // toolbar that used to host "AI summary in progress…" was removed, so the
   // signal moved next to the section it describes. Priority single pill, summary
@@ -3922,7 +3953,12 @@ export function buildSidebarScript(): string {
       delete state.subsectionShowAll[s.id];
     }
     const showAll = !!state.subsectionShowAll[s.id];
-    const visibleItems = (overLimit && !showAll) ? s.items.slice(0, SUBSECTION_PREVIEW) : s.items;
+    // The top-level commit list pages incrementally: show commitsVisible rows,
+    // then a "Show N more" row reveals the next page. commitsCapped gates that row.
+    const commitsCapped = s.id === 'commits' && s.items.length > commitsVisible;
+    const visibleItems = commitsCapped
+      ? s.items.slice(0, commitsVisible)
+      : ((overLimit && !showAll) ? s.items.slice(0, SUBSECTION_PREVIEW) : s.items);
     // rowFn may return either a single node OR an array (commit rows fan
     // out into commit + nested file children when expanded). Flatten one
     // level so the result is a flat list of DOM nodes the section body
@@ -3945,6 +3981,10 @@ export function buildSidebarScript(): string {
     // the top. Only when the sub-section actually has more than the preview cap.
     if (bodyKids && overLimit) {
       bodyKids.push(renderShowMoreRow(s.id, showAll, s.items.length - SUBSECTION_PREVIEW));
+    }
+    // Incremental "Show N more" for the commit list (see commitsCapped above).
+    if (bodyKids && commitsCapped) {
+      bodyKids.push(renderCommitsMoreRow(s.items.length - commitsVisible));
     }
     // Partial-data banner — prepended to the body so it survives both the
     // empty-state and the populated-list rendering paths. Sections that don't
@@ -5210,6 +5250,17 @@ export function buildSidebarScript(): string {
         e.stopPropagation();
         return;
       }
+    }
+
+    // Incremental "Show N more" on the top-level commit list: reveal one more
+    // page and re-render. Transient, so no persist(). Sits before the section
+    // header branch so the click never bubbles into a collapse toggle.
+    const commitsMore = e.target.closest('[data-commits-more]');
+    if (commitsMore) {
+      commitsVisible += COMMITS_PAGE;
+      renderBranch();
+      e.stopPropagation();
+      return;
     }
 
     // "Show N more" / "Show less" toggle on a Current Memory sub-section.


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The commit list in both the IntelliJ and VS Code plugins now shows a maximum of six entries at a time. A "Show more" link appears below the visible entries whenever additional commits exist; each click reveals the next six, and the link disappears once every commit is on screen. The list resets to six entries when the user switches branches or a new commit appears, but stays expanded during background activity such as an AI summary being generated in the background — so scrolling down to read older commits is not interrupted by a routine refresh.

Both plugins received the change in the same session and behave consistently. The IntelliJ side reused an existing styling helper that was already used for capping sub-sections within an expanded commit row, while the VS Code side introduced a dedicated renderer to keep the new incremental behavior separate from the existing binary show-all toggle used by those same sub-sections. A subtle build-time defect — where a separator character was being interpreted as a literal newline inside the generated script — was caught by an existing automated check and corrected before the tests were run.

---

## Topic (1)
<details>
<summary><strong>01 · Paginate commit list to show six at a time with incremental reveal</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When working in a git repository with no remote upstream configured, the commit list grew unbounded — every commit on the branch was shown at once with no way to limit the view. The user wanted the list capped at six entries initially, with a "Show more" link that reveals the next six on each click until all commits are visible.

**💡 Decisions Behind the Code**

- **Render-time cap over data-layer pagination**: All commits are still fetched from git in a single call; the six-at-a-time limit is applied purely when building the UI. This avoids adding offset/limit parameters to the git-log layer and keeps the two plugins' data paths unchanged, at the cost of loading all commits into memory upfront. For the typical branch-commit counts seen here, the memory trade-off is negligible and the implementation stays simple.
- **Incremental reveal instead of binary show-all toggle**: The existing "Show more" helpers in both plugins are binary — one click shows everything, another hides it again. The new commit-list behavior grows the visible window by exactly one page per click and never collapses, matching the user's explicit spec. This required a separate counter variable and a distinct click-target marker rather than reusing the subsection toggle machinery, keeping the two behaviors independent and avoiding regressions in the subsection expand/collapse logic.
- **Reset on sequence change, preserve on content-identical refresh**: The visible count resets to 6 only when the set of commit hashes actually changes (branch switch or new commit). A background AI-summary refresh that leaves the commit list unchanged does not snap the list back to six entries. This distinction required comparing the incoming hash sequence against the stored one before deciding whether to reset, adding a small amount of logic but meaningfully improving the experience for users who scroll down while a summary is being generated.

**✅ What Was Implemented**

- In the IntelliJ plugin, `CommitsPanel.kt` gained a `visibleCommits` counter (starting at 6, matching the existing page-size constant in `CappedRows`). The `updateCommitList()` method now renders only the first `visibleCommits` entries and appends a "Show N more" row — built with the newly public `CappedRows.showMoreRow()` helper — that increments the counter by one page and re-renders on click. The counter resets to 6 inside the existing "commit sequence changed" guard in `refreshFromGit()`, so a branch switch or new commit collapses the list while a background summary refresh leaves the expanded state intact.
- In the VS Code extension, `SidebarScriptBuilder.ts` gained a `COMMITS_PAGE = 6` constant and a transient `commitsVisible` variable. The `renderSection()` function now slices the commits array to `commitsVisible` entries and appends a dedicated `renderCommitsMoreRow()` node (carrying a `data-commits-more` marker distinct from the existing subsection toggle). A new click-delegation branch grows `commitsVisible` by one page and re-renders. The `branch:commitsData` message handler resets the counter only when the incoming commit hash sequence differs from the stored one, preserving the expanded state across content-identical refreshes.
- A regression test was added to `SidebarScriptBuilder.test.ts` asserting that the emitted script contains the page-size constant, the slice logic, the more-row renderer, the click handler, and the reset-on-change guard. A build-time bug was caught and fixed: joining commit hashes with `'\n'` inside the template-literal script body produced a real newline mid-string; switching to `'|'` (safe because hashes are hexadecimal) resolved the parse failure caught by the existing smoke test.

**📋 Future Enhancements**

IntelliJ foreign read-only mode (browsing another repo or branch's memories) uses a separate rendering path that was intentionally left uncapped in this commit. Paginating it for parity with the VS Code foreign-mode path was discussed but deferred.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CappedRows.kt`
- `vscode/src/views/SidebarScriptBuilder.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 4, 2026 at 10:47 AM · via Anthropic*
<!-- jollimemory-summary-end -->
