### PR TITLE
Surface real error messages and skip empty org-member cache entries

### DIFF
--- a/cli/src/core/BranchShareStore.test.ts
+++ b/cli/src/core/BranchShareStore.test.ts
@@ -3,7 +3,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { JOLLI_DIR, JOLLIMEMORY_DIR } from "../Logger.js";
-import { type BranchShareRecord, getShare, putBranchShare, removeShare } from "./BranchShareStore.js";
+import {
+	type BranchShareRecord,
+	getShare,
+	getShareWithBranchLatest,
+	putBranchShare,
+	removeShare,
+} from "./BranchShareStore.js";
 
 let cwd: string;
 
@@ -165,5 +171,85 @@ describe("BranchShareStore", () => {
 		expect((await getShare(cwd, "a"))?.shareId).toBe("a");
 		expect((await getShare(cwd, "b"))?.shareId).toBe("b");
 		expect((await getShare(cwd, "c"))?.shareId).toBe("c");
+	});
+
+	describe("getShareWithBranchLatest", () => {
+		it("both undefined when the branch has no subjects at all", async () => {
+			const { record, seed } = await getShareWithBranchLatest(cwd, "feature/x");
+			expect(record).toBeUndefined();
+			expect(seed).toBeUndefined();
+		});
+
+		it("returns a commit subject's own record and no seed when it's the only commit share", async () => {
+			const hash = "a".repeat(40);
+			await putBranchShare(cwd, "feature/x", { ...MEMBER, shareId: "own" }, hash);
+			const { record, seed } = await getShareWithBranchLatest(cwd, "feature/x", hash);
+			expect(record?.shareId).toBe("own");
+			expect(seed).toBeUndefined(); // no OTHER commit share to seed from
+		});
+
+		it("seeds a fresh commit subject from a stranded (same-kind) commit share, latest expiry wins", async () => {
+			await putBranchShare(
+				cwd,
+				"feature/x",
+				{ ...MEMBER, shareId: "old", recipients: ["ada@jolli.ai"], expiresAt: "2026-08-01T00:00:00.000Z" },
+				"a".repeat(40),
+			);
+			await putBranchShare(
+				cwd,
+				"feature/x",
+				{ ...MEMBER, shareId: "new", recipients: ["tom@jolli.ai"], expiresAt: "2026-10-01T00:00:00.000Z" },
+				"b".repeat(40),
+			);
+			// Open a brand-new commit subject (no record): seed is the newest stranded commit share.
+			const { record, seed } = await getShareWithBranchLatest(cwd, "feature/x", "c".repeat(40));
+			expect(record).toBeUndefined();
+			expect(seed?.shareId).toBe("new");
+			expect(seed?.recipients).toEqual(["tom@jolli.ai"]);
+		});
+
+		it("does NOT seed a commit subject from a live branch share (cross-kind → no duplicate grant)", async () => {
+			// The branch share grants branch-wide access; seeding a commit modal from it and
+			// auto-staging its people would double-grant. A commit subject only seeds from
+			// other commit shares.
+			await putBranchShare(cwd, "feature/x", { ...MEMBER, shareId: "branch", recipients: ["ada@jolli.ai"] });
+			const { record, seed } = await getShareWithBranchLatest(cwd, "feature/x", "a".repeat(40));
+			expect(record).toBeUndefined();
+			expect(seed).toBeUndefined(); // the branch share is not a seed source for a commit subject
+		});
+
+		it("a branch subject never seeds (its key is stable, never stranded)", async () => {
+			await putBranchShare(cwd, "feature/x", { ...MEMBER, shareId: "branch" });
+			await putBranchShare(cwd, "feature/x", { ...MEMBER, shareId: "commit" }, "a".repeat(40));
+			const { record, seed } = await getShareWithBranchLatest(cwd, "feature/x");
+			expect(record?.shareId).toBe("branch"); // its own record
+			expect(seed).toBeUndefined(); // does not seed from the commit share (cross-kind)
+		});
+
+		it("excludes the queried commit subject itself when picking the seed", async () => {
+			await putBranchShare(
+				cwd,
+				"feature/x",
+				{ ...MEMBER, shareId: "self", expiresAt: "2026-10-01T00:00:00.000Z" },
+				"a".repeat(40),
+			);
+			await putBranchShare(
+				cwd,
+				"feature/x",
+				{ ...MEMBER, shareId: "other", expiresAt: "2026-08-01T00:00:00.000Z" },
+				"b".repeat(40),
+			);
+			// Query the newer subject: its own record is returned; the seed is the OTHER one,
+			// even though the queried subject has a later expiry.
+			const { record, seed } = await getShareWithBranchLatest(cwd, "feature/x", "a".repeat(40));
+			expect(record?.shareId).toBe("self");
+			expect(seed?.shareId).toBe("other");
+		});
+
+		it("does not match a branch whose name is a prefix of another (feat vs feature/x)", async () => {
+			await putBranchShare(cwd, "feature/x", PUB, "a".repeat(40));
+			const { seed } = await getShareWithBranchLatest(cwd, "feat", "b".repeat(40));
+			expect(seed).toBeUndefined();
+		});
 	});
 });

--- a/cli/src/core/BranchShareStore.ts
+++ b/cli/src/core/BranchShareStore.ts
@@ -208,6 +208,66 @@ export async function putBranchShare(
 }
 
 /**
+ * The best prior record to SEED a subject's defaults from when it has no link yet — the
+ * most-recently-minted (max `expiresAt`) record of the SAME KIND, excluding the subject
+ * itself. A commit share's key carries its commit hash, so an amend/rebase strands the
+ * previous commit share; seeding lets the modal bring back that last-used tier + people
+ * instead of starting blank.
+ *
+ * Same-kind is deliberate: a commit subject seeds only from OTHER commit shares (the
+ * stranded ones), NOT from the branch share. The branch share is a live sibling of a
+ * different scope — seeding a commit modal from it (and auto-staging its recipients) would
+ * duplicate-grant people who already have branch-wide access. A branch subject's key is
+ * stable (never stranded), so it has no same-kind prior and gets no seed.
+ *
+ * Expiry is NOT filtered here (the store has no clock); the caller passes the result
+ * through its liveness check so an intentionally-lapsed grant never seeds.
+ */
+function pickSeedForSubject(
+	subjects: Readonly<Record<string, BranchShareRecord>>,
+	branch: string,
+	commitHash: string | undefined,
+	currentKey: string,
+): BranchShareRecord | undefined {
+	const wantCommit = commitHash !== undefined;
+	let seed: BranchShareRecord | undefined;
+	let seedAt = Number.NEGATIVE_INFINITY;
+	for (const [key, record] of Object.entries(subjects)) {
+		if (key === currentKey) continue; // never seed a subject from itself
+		const sameKind = wantCommit ? key.startsWith(branch + COMMIT_KEY_SEP) : key === branch;
+		if (!sameKind) continue;
+		const parsed = Date.parse(record.expiresAt);
+		// Unparseable expiry sorts oldest — a well-formed record always wins over it.
+		const at = Number.isNaN(parsed) ? 0 : parsed;
+		if (at >= seedAt) {
+			seedAt = at;
+			seed = record;
+		}
+	}
+	return seed;
+}
+
+/**
+ * One read that returns BOTH a subject's own record (`record`) and the best prior record
+ * to seed its defaults from (`seed`, see {@link pickSeedForSubject}). The share modal's
+ * no-link path needs both; doing it in one pass avoids reading + JSON-parsing
+ * `branch-shares.json` twice on every open. `seed` is subject-scoped and expiry-unfiltered
+ * — the caller applies its liveness check before using it.
+ */
+export async function getShareWithBranchLatest(
+	projectDir: string,
+	branch: string,
+	commitHash?: string,
+): Promise<{ record: BranchShareRecord | undefined; seed: BranchShareRecord | undefined }> {
+	const all = await readAll(projectDir);
+	const currentKey = subjectKey(branch, commitHash);
+	return {
+		record: all.subjects[currentKey],
+		seed: pickSeedForSubject(all.subjects, branch, commitHash, currentKey),
+	};
+}
+
+/**
  * Removes a subject's share record (e.g. after a Stop). Idempotent; an absent
  * subject is a no-op and the entry is dropped entirely.
  */

--- a/cli/src/core/GitRemoteUtils.test.ts
+++ b/cli/src/core/GitRemoteUtils.test.ts
@@ -10,7 +10,9 @@ import {
 	deriveRepoNameFromUrl,
 	getCanonicalRepoUrl,
 	normalizeRemoteUrl,
+	sameCanonicalRemote,
 	sanitizeBranchSlug,
+	sharedRepoIdentityMatches,
 } from "./GitRemoteUtils.js";
 
 const gitResult = (stdout: string, exitCode = 0): GitCommandResult => ({ stdout, stderr: "", exitCode });
@@ -142,5 +144,93 @@ describe("deriveOwnerRepoFromUrl", () => {
 	it("returns '' on empty or unparseable input", () => {
 		expect(deriveOwnerRepoFromUrl("")).toBe("");
 		expect(deriveOwnerRepoFromUrl("not a url")).toBe("");
+	});
+});
+
+describe("sameCanonicalRemote", () => {
+	it("matches raw-vs-normalized forms of the same repo (.git suffix, scp form)", () => {
+		expect(sameCanonicalRemote("https://github.com/acme/widgets.git", "https://github.com/acme/widgets")).toBe(
+			true,
+		);
+		expect(sameCanonicalRemote("git@github.com:acme/widgets.git", "https://github.com/acme/widgets")).toBe(true);
+	});
+
+	it("does not match two distinct repos", () => {
+		expect(sameCanonicalRemote("https://github.com/acme/widgets", "https://github.com/acme/gadgets")).toBe(false);
+	});
+
+	it("does NOT collapse two distinct unparseable remotes into a match via the file:/// sentinel", () => {
+		// Both normalize to the empty-fallback `file:///` sentinel; treating that as equal
+		// would ingest a share into the wrong local repo. It must stay a non-match.
+		expect(sameCanonicalRemote("not-a-url", "also-not-a-url")).toBe(false);
+		expect(sameCanonicalRemote("", "")).toBe(false);
+	});
+
+	it("still matches two real file:// remotes with the same path", () => {
+		expect(sameCanonicalRemote("file:///home/x/repo", "file:///home/x/repo")).toBe(true);
+	});
+
+	it("still matches an IDENTICAL bare local-path remote (preserves pre-canonical === behavior)", () => {
+		// A bare path is unparseable → the `file:///` sentinel; identical raw strings must
+		// still match so a local-path remote isn't newly dropped by the canonical compare.
+		expect(sameCanonicalRemote("/srv/git/foo.git", "/srv/git/foo.git")).toBe(true);
+	});
+
+	it("does NOT match two DIFFERENT bare local-path remotes (both hit the sentinel)", () => {
+		expect(sameCanonicalRemote("/srv/git/foo.git", "/srv/git/bar.git")).toBe(false);
+	});
+});
+
+describe("sharedRepoIdentityMatches", () => {
+	it("matches by canonical remote when both sides carry a URL (raw .git vs normalized)", () => {
+		expect(
+			sharedRepoIdentityMatches(
+				"acmewidgets",
+				"https://github.com/acme/widgets",
+				"widgets",
+				"https://github.com/acme/widgets.git",
+			),
+		).toBe(true);
+	});
+
+	it("rejects a name match when both sides have a URL but the remotes differ", () => {
+		expect(
+			sharedRepoIdentityMatches(
+				"widgets",
+				"https://github.com/acme/widgets",
+				"widgets",
+				"https://github.com/other/widgets",
+			),
+		).toBe(false);
+	});
+
+	it("reconstructs owner/repo from the candidate remote for a public-tier share (URL withheld)", () => {
+		// Public tier: shareRepoUrl is null, but the candidate still knows its own remote.
+		// Backend stored sanitize("acme/widgets") = "acmewidgets"; the bank keeps bare "widgets".
+		expect(sharedRepoIdentityMatches("acmewidgets", null, "widgets", "https://github.com/acme/widgets.git")).toBe(
+			true,
+		);
+	});
+
+	it("matches a public-tier share case-insensitively (Acme/Widgets vs acme/widgets)", () => {
+		// GitHub owner/repo is case-insensitive; the two users' remotes differ only in case.
+		expect(sharedRepoIdentityMatches("AcmeWidgets", null, "widgets", "https://github.com/acme/widgets.git")).toBe(
+			true,
+		);
+	});
+
+	it("preserves the owner dimension — a shared basename under a different owner does not match", () => {
+		expect(sharedRepoIdentityMatches("acmewidgets", null, "widgets", "https://github.com/other/widgets.git")).toBe(
+			false,
+		);
+	});
+
+	it("falls back to a bare-name compare when neither side has a remote", () => {
+		expect(sharedRepoIdentityMatches("widgets", null, "widgets", null)).toBe(true);
+		expect(sharedRepoIdentityMatches("widgets", null, "gadgets", null)).toBe(false);
+	});
+
+	it("does not match a public-tier share when the candidate has no owner segment and the name differs", () => {
+		expect(sharedRepoIdentityMatches("acmewidgets", null, "widgets", "https://example.com/widgets")).toBe(false);
 	});
 });

--- a/cli/src/core/GitRemoteUtils.ts
+++ b/cli/src/core/GitRemoteUtils.ts
@@ -152,6 +152,80 @@ export function deriveOwnerRepoFromUrl(repoUrl: string): string {
 }
 
 /**
+ * Whether two raw remote strings denote the same repo, compared CANONICALLY (see
+ * {@link normalizeRemoteUrl}). Guards the `file:///` sentinel: an empty or unparseable
+ * remote canonicalizes to `file:///` via the empty fallback, and two DISTINCT unparseable
+ * remotes must NOT be judged equal just because they both collapse to that sentinel. A
+ * real `file://` remote normalizes to `file:///<path>` and still compares by path.
+ */
+export function sameCanonicalRemote(a: string, b: string): boolean {
+	const na = normalizeRemoteUrl(a, "");
+	const nb = normalizeRemoteUrl(b, "");
+	if (na !== nb) {
+		return false;
+	}
+	// Equal canonical form. If it's the empty-fallback `file:///` sentinel, the inputs were
+	// empty or unparseable (e.g. a bare local path like `/srv/git/foo.git`): fall back to
+	// raw-string equality so two DIFFERENT unparseable remotes don't collapse into a false
+	// match, while an identical local-path remote still matches (preserving the pre-canonical
+	// `===` behavior). Two empty strings are never a real repo, so require non-empty.
+	if (na === "file:///") {
+		const rawA = a.trim();
+		return rawA.length > 0 && rawA === b.trim();
+	}
+	return true;
+}
+
+/**
+ * Mirror of the backend's `sanitizeRepoNameInput` (BranchShareRouter →
+ * `GitRemoteUrl.sanitizeRepoNameInput`): the share row stores `repoName` with the
+ * path-unsafe chars — crucially `/` — stripped, so `owner/repo` becomes `ownerrepo`.
+ * Only the `/`-class strip matters for URL-derived input (the backend's extra
+ * control-char sweep and 120-char clip never fire here). Kept in lockstep with the
+ * backend regex; drift only ever yields a safe false-negative (the share falls through
+ * to the read-only sandbox), never a wrong-repo write.
+ */
+function sanitizeSharedRepoName(name: string): string {
+	return name.replace(/[/\\:*?"<>|]/g, "");
+}
+
+/**
+ * Whether a local repo (`candidate*`) is the repo a share was made from (`share*`). The
+ * single identity rule shared by the foreign-bank lookup
+ * (`JolliMemoryBridge.createStorageForRepo`) and the current-repo lookup
+ * (`SharedBranchImporter`), so both paths benefit from every case below:
+ *
+ *  1. Both sides carry a remote → canonical remote compare ({@link sameCanonicalRemote}).
+ *     The `/export` payload carries the backend's normalized `repoUrl` while the local
+ *     bank keeps the raw git remote, so a strict `===` would miss (`…/x.git` vs `…/x`).
+ *  2. Public-tier share (`shareRepoUrl == null`, the backend withholds the URL) but the
+ *     candidate has a remote → reconstruct the backend's `ownerrepo` form from the
+ *     candidate remote and compare to `shareRepoName` CASE-INSENSITIVELY. GitHub-family
+ *     owner/repo is case-insensitive (and `normalizeRemoteUrl` already folds those host
+ *     paths), so `Acme/Widgets` and `acme/widgets` are the same repo. This preserves the
+ *     owner dimension — two repos sharing a basename under different owners don't collide.
+ *  3. Last-ditch bare-name compare for the remote-less-on-both-sides case (the backend
+ *     stored a basename, not `owner/repo`).
+ */
+export function sharedRepoIdentityMatches(
+	shareRepoName: string,
+	shareRepoUrl: string | null,
+	candidateRepoName: string,
+	candidateRemoteUrl: string | null,
+): boolean {
+	if (shareRepoUrl != null && candidateRemoteUrl != null) {
+		return sameCanonicalRemote(shareRepoUrl, candidateRemoteUrl);
+	}
+	if (candidateRemoteUrl != null) {
+		const ownerRepo = deriveOwnerRepoFromUrl(candidateRemoteUrl);
+		if (ownerRepo.length > 0 && sanitizeSharedRepoName(ownerRepo).toLowerCase() === shareRepoName.toLowerCase()) {
+			return true;
+		}
+	}
+	return candidateRepoName === shareRepoName;
+}
+
+/**
  * Sanitizes a branch name into a path-safe slug for use inside `relativePath`.
  * Mirrors the server's `stripPathUnsafeChars` (replace anything outside
  * `[A-Za-z0-9._-]` and `/` with `_`, collapse runs, trim leading/trailing

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -957,6 +957,20 @@ vi.mock("./views/SummaryWebviewPanel.js", () => ({
 	SummaryWebviewPanel: MockSummaryWebviewPanel,
 }));
 
+// /share deep-link route deps. JolliShareService is partial-mocked (other exports feed
+// the share-modal graph SummaryWebviewPanel pulls in); SharedBranchImporter is a leaf.
+const { mockExportSharedBranch, mockImportSharedBranchForDisplay } = vi.hoisted(() => ({
+	mockExportSharedBranch: vi.fn(),
+	mockImportSharedBranchForDisplay: vi.fn(),
+}));
+vi.mock("./services/JolliShareService.js", async (orig) => ({
+	...(await orig<typeof import("./services/JolliShareService.js")>()),
+	exportSharedBranch: mockExportSharedBranch,
+}));
+vi.mock("./services/SharedBranchImporter.js", () => ({
+	importSharedBranchForDisplay: mockImportSharedBranchForDisplay,
+}));
+
 vi.mock("./views/SettingsWebviewPanel.js", () => ({
 	SettingsWebviewPanel: MockSettingsWebviewPanel,
 }));
@@ -7346,6 +7360,177 @@ describe("Extension", () => {
 				expect(mockBridge.getSummary).not.toHaveBeenCalled();
 				expect(MockSummaryWebviewPanel.show).not.toHaveBeenCalled();
 				expect(mockAuthService.handleAuthCallback).not.toHaveBeenCalled();
+			});
+		});
+
+		describe("/share route", () => {
+			function getHandler() {
+				const ctx = makeContext();
+				activate(ctx);
+				const registerUriHandler = (
+					vscode.window as unknown as { registerUriHandler: ReturnType<typeof vi.fn> }
+				).registerUriHandler;
+				return registerUriHandler.mock.calls[0]?.[0] as { handleUri: (uri: unknown) => Promise<void> };
+			}
+			const shareUri = (query: string) => ({
+				path: "/share",
+				query,
+				toString: () => `vscode://jolli.jollimemory-vscode/share?${query}`,
+			});
+
+			beforeEach(() => {
+				mockExportSharedBranch.mockReset();
+				mockImportSharedBranchForDisplay.mockReset();
+				loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-key" });
+			});
+
+			it("downloads the shared branch and renders it read-only", async () => {
+				mockExportSharedBranch.mockResolvedValue({
+					branch: "feat/x",
+					repoName: "acme/widgets",
+					repoUrl: "https://github.com/acme/widgets",
+					kind: "branch",
+					headCommitHash: "h1",
+					commits: [],
+				});
+				const storage = {};
+				mockImportSharedBranchForDisplay.mockResolvedValue({ storage, head: { commitHash: "h1" }, commitCount: 1 });
+
+				const handler = getHandler();
+				await handler.handleUri(shareUri("origin=https%3A%2F%2Facme.jolli.ai&token=tok"));
+
+				expect(mockExportSharedBranch).toHaveBeenCalledWith(undefined, "sk-jol-key", "tok");
+				expect(MockSummaryWebviewPanel.show).toHaveBeenCalledWith(
+					{ commitHash: "h1" },
+					expect.anything(),
+					"/test/workspace",
+					expect.anything(),
+					"main",
+					"commit",
+					"acme/widgets",
+					"https://github.com/acme/widgets",
+					storage,
+				);
+			});
+
+			it("opens a normal writable local panel when the share was ingested into the current repo", async () => {
+				mockExportSharedBranch.mockResolvedValue({
+					branch: "feat/x",
+					repoName: "acme/widgets",
+					repoUrl: "https://github.com/acme/widgets",
+					kind: "branch",
+					headCommitHash: "h1",
+					commits: [],
+				});
+				const storage = {};
+				mockImportSharedBranchForDisplay.mockResolvedValue({
+					storage,
+					head: { commitHash: "h1" },
+					commitCount: 1,
+					ingestedLocally: true,
+				});
+
+				const handler = getHandler();
+				await handler.handleUri(shareUri("origin=https%3A%2F%2Facme.jolli.ai&token=tok"));
+
+				// No foreign identity — the panel is the same writable local view the
+				// sidebar opens, NOT the read-only shared rendering.
+				expect(MockSummaryWebviewPanel.show).toHaveBeenCalledWith(
+					{ commitHash: "h1" },
+					expect.anything(),
+					"/test/workspace",
+					expect.anything(),
+					"main",
+					"commit",
+					null,
+					null,
+					storage,
+				);
+			});
+
+			it("keeps the read-only foreign view for a display-only import (not ingested)", async () => {
+				mockExportSharedBranch.mockResolvedValue({
+					branch: "feat/x",
+					repoName: "acme/widgets",
+					repoUrl: "https://github.com/acme/widgets",
+					kind: "branch",
+					headCommitHash: "h1",
+					commits: [],
+				});
+				const storage = {};
+				mockImportSharedBranchForDisplay.mockResolvedValue({
+					storage,
+					head: { commitHash: "h1" },
+					commitCount: 1,
+					ingestedLocally: false,
+				});
+
+				const handler = getHandler();
+				await handler.handleUri(shareUri("origin=https%3A%2F%2Facme.jolli.ai&token=tok"));
+
+				expect(MockSummaryWebviewPanel.show).toHaveBeenCalledWith(
+					{ commitHash: "h1" },
+					expect.anything(),
+					"/test/workspace",
+					expect.anything(),
+					"main",
+					"commit",
+					"acme/widgets",
+					"https://github.com/acme/widgets",
+					storage,
+				);
+			});
+
+			it("shows info and skips download when the link carries no token", async () => {
+				const handler = getHandler();
+				await handler.handleUri(shareUri("origin=https%3A%2F%2Facme.jolli.ai"));
+				expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("no token"));
+				expect(mockExportSharedBranch).not.toHaveBeenCalled();
+			});
+
+			it("refuses a link from a non-allowlisted origin", async () => {
+				const handler = getHandler();
+				await handler.handleUri(shareUri("origin=https%3A%2F%2Fevil.example&token=tok"));
+				expect(showErrorMessage).toHaveBeenCalledWith(expect.stringContaining("unrecognized origin"));
+				expect(mockExportSharedBranch).not.toHaveBeenCalled();
+			});
+
+			it("refuses a link that omits the origin entirely (fail-closed, no download)", async () => {
+				const handler = getHandler();
+				await handler.handleUri(shareUri("token=tok"));
+				expect(showErrorMessage).toHaveBeenCalledWith(expect.stringContaining("no origin"));
+				expect(mockExportSharedBranch).not.toHaveBeenCalled();
+			});
+
+			it("prompts sign-in when no API key is configured", async () => {
+				loadConfig.mockResolvedValue({});
+				const handler = getHandler();
+				await handler.handleUri(shareUri("origin=https%3A%2F%2Facme.jolli.ai&token=tok"));
+				expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("Sign in"));
+				expect(mockExportSharedBranch).not.toHaveBeenCalled();
+			});
+
+			it("shows info when the share has no structured memory to display", async () => {
+				mockExportSharedBranch.mockResolvedValue({
+					branch: "feat/x",
+					repoName: "r",
+					repoUrl: "u",
+					kind: "branch",
+					headCommitHash: "h1",
+					commits: [],
+				});
+				mockImportSharedBranchForDisplay.mockResolvedValue(null);
+				const handler = getHandler();
+				await handler.handleUri(shareUri("origin=https%3A%2F%2Facme.jolli.ai&token=tok"));
+				expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("no structured memory"));
+				expect(MockSummaryWebviewPanel.show).not.toHaveBeenCalled();
+			});
+
+			it("surfaces a download failure as an error toast", async () => {
+				mockExportSharedBranch.mockRejectedValue(new Error("forbidden (HTTP 403)"));
+				const handler = getHandler();
+				await handler.handleUri(shareUri("origin=https%3A%2F%2Facme.jolli.ai&token=tok"));
+				expect(showErrorMessage).toHaveBeenCalledWith(expect.stringContaining("HTTP 403"));
 			});
 		});
 	});

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -23,6 +23,9 @@ import {
 } from "../../cli/src/core/KBPathResolver.js";
 import type { ManifestEntry } from "../../cli/src/core/KBTypes.js";
 import { isPathInside, toForwardSlash } from "../../cli/src/core/PathUtils.js";
+import { assertJolliOriginAllowed } from "../../cli/src/core/JolliApiUtils.js";
+import { exportSharedBranch } from "./services/JolliShareService.js";
+import { importSharedBranchForDisplay } from "./services/SharedBranchImporter.js";
 import { activateExtensionTelemetry, reinitExtensionTelemetry } from "./TelemetryActivation.js";
 import {
 	getGlobalConfigDir,
@@ -3841,6 +3844,80 @@ export function activate(context: vscode.ExtensionContext): void {
 						sourceRemoteUrl,
 						readStorageResult?.storage ?? null,
 					);
+					return;
+				}
+
+				// Deep link from a web share page's "Open in VS Code" button: download the
+				// shared branch's structured memory over the api-key-authed /export endpoint
+				// and render it read-only. `token` is the share's opaque code; `origin` is the
+				// web origin (validated against the Jolli allowlist — the request itself goes to
+				// the user's own tenant from their API key, and the token self-routes).
+				if (uri.path === "/share") {
+					const params = new URLSearchParams(uri.query);
+					const token = params.get("token");
+					const origin = params.get("origin");
+					if (!token) {
+						vscode.window.showInformationMessage(
+							"Jolli Memory: This share link has no token to load — open it on the web instead.",
+						);
+						return;
+					}
+					// Origin is REQUIRED and must be on the Jolli allowlist. A link that omits
+					// it can't be vetted, so it's refused too (fail-closed) — skipping the
+					// check on a missing param would let a crafted `?token=…` link through.
+					// The legit web share page always includes origin.
+					if (!origin) {
+						log.info("uriHandler", "Rejected /share deep link: missing origin");
+						vscode.window.showErrorMessage(
+							"Jolli Memory: Refused a share link with no origin to verify.",
+						);
+						return;
+					}
+					try {
+						assertJolliOriginAllowed(origin);
+					} catch {
+						log.info("uriHandler", "Rejected /share deep link: origin not on the Jolli allowlist");
+						vscode.window.showErrorMessage(
+							"Jolli Memory: Refused a share link from an unrecognized origin.",
+						);
+						return;
+					}
+					const cfg = await loadConfig();
+					const apiKey = cfg.jolliApiKey ?? cfg.apiKey;
+					if (!apiKey) {
+						vscode.window.showInformationMessage("Jolli Memory: Sign in to Jolli to open a shared branch.");
+						return;
+					}
+					try {
+						const data = await exportSharedBranch(undefined, apiKey, token);
+						const imported = await importSharedBranchForDisplay(data, bridge, context);
+						if (!imported) {
+							vscode.window.showInformationMessage(
+								`Jolli Memory: The shared branch "${data.branch}" has no structured memory to display.`,
+							);
+							return;
+						}
+						// When the share was ingested into the currently-open repo (recall/search
+						// now find it), open the normal writable local panel — same shape as the
+						// /summary deep link's local path. The read-only foreign view is reserved
+						// for display-only imports (foreign local repo, or pure-external sandbox).
+						const openAsLocal = imported.ingestedLocally;
+						await SummaryWebviewPanel.show(
+							imported.head,
+							context.extensionUri,
+							workspaceRoot,
+							bridge,
+							commitsStore.getMainBranch(),
+							"commit",
+							openAsLocal ? null : data.repoName,
+							openAsLocal ? null : data.repoUrl,
+							imported.storage,
+						);
+					} catch (err) {
+						const message = err instanceof Error ? err.message : String(err);
+						log.warn("uriHandler", `/share load failed: ${message}`);
+						vscode.window.showErrorMessage(`Jolli Memory: Couldn't open the shared branch — ${message}`);
+					}
 					return;
 				}
 

--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -3156,6 +3156,26 @@ describe("JolliMemoryBridge", () => {
 			expect(result?.kbRoot).toBe("/mock/home/Documents/jolli/b");
 		});
 
+		it("matches a foreign repo when the caller's canonical remote differs only by .git from the raw local remote", async () => {
+			// The bank keeps the raw git remote (`.git` suffix) while a shared-branch import
+			// passes the backend's normalized form. A strict === missed this and dropped the
+			// foreign display-only path into the sandbox; canonical comparison recovers it.
+			discoverRepos.mockReturnValue([
+				{
+					kbRoot: "/mock/home/Documents/jolli/foreign",
+					repoName: "foreignrepo",
+					dirName: "foreign",
+					remoteUrl: "https://github.com/acme/foreign.git",
+					isCurrentRepo: false,
+				},
+			]);
+			const bridge = makeBridge();
+
+			const result = await bridge.createStorageForRepo("acmeforeign", "https://github.com/acme/foreign");
+
+			expect(result?.kbRoot).toBe("/mock/home/Documents/jolli/foreign");
+		});
+
 		it("returns null when no DiscoveredRepo matches (foreign entry has neither matching name nor remote)", async () => {
 			// Two-repo scan covering both early-skip branches of the loop:
 			// (1) the currentRepo continue and (2) the `!urlMatches &&
@@ -3255,6 +3275,10 @@ describe("JolliMemoryBridge", () => {
 			expect((result?.storage as { rootPath: string }).rootPath).toBe(
 				"/mock/home/Documents/jolli/cur",
 			);
+			// Identity fields: SharedBranchImporter verifies the current repo IS the
+			// share's repo before writing into its bank.
+			expect(result?.repoName).toBe("cur");
+			expect(result?.remoteUrl).toBeNull();
 		});
 
 		it("returns null when no DiscoveredRepo is flagged isCurrentRepo", async () => {

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -16,6 +16,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { FolderStorage } from "../../cli/src/core/FolderStorage.js";
 import { getDiffStats } from "../../cli/src/core/GitOps.js";
+import { sharedRepoIdentityMatches } from "../../cli/src/core/GitRemoteUtils.js";
 import { filterToBranchHeads } from "../../cli/src/core/HeadEntryFilter.js";
 import {
 	extractRepoName,
@@ -2266,10 +2267,16 @@ export class JolliMemoryBridge {
 	 *     of-truth contract for users who opted out of dual-write.
 	 *   - No matching kbRoot is discoverable yet (fresh repo whose KB
 	 *     folder hasn't been created).
+	 *
+	 * Also returns the current repo's identity (`repoName` + `remoteUrl`)
+	 * so callers holding content for a NAMED repo (SharedBranchImporter)
+	 * can verify this is that repo before writing into its bank.
 	 */
 	async createReadStorageForCurrentRepo(): Promise<{
 		storage: StorageProvider;
 		kbRoot: string;
+		repoName: string;
+		remoteUrl: string | null;
 	} | null> {
 		try {
 			const { cfg, repos } = await this.getDiscoveryCached();
@@ -2278,7 +2285,7 @@ export class JolliMemoryBridge {
 				if (!repo.isCurrentRepo) continue;
 				const mm = new MetadataManager(join(repo.kbRoot, ".jolli"));
 				const storage = new FolderStorage(repo.kbRoot, mm);
-				return { storage, kbRoot: repo.kbRoot };
+				return { storage, kbRoot: repo.kbRoot, repoName: repo.repoName, remoteUrl: repo.remoteUrl };
 			}
 			/* v8 ignore start -- defensive logger coercion: same pattern as listSummaryEntries above; non-Error rejections are rare. */
 		} catch (err) {
@@ -2303,21 +2310,13 @@ export class JolliMemoryBridge {
 			const { repos } = await this.getDiscoveryCached();
 			for (const repo of repos) {
 				if (repo.isCurrentRepo) continue;
-				const urlMatches =
-					remoteUrl != null &&
-					repo.remoteUrl != null &&
-					repo.remoteUrl === remoteUrl;
-				const nameMatches = repo.repoName === repoName;
-				if (!urlMatches && !nameMatches) continue;
-				// When the caller supplied a remoteUrl AND this repo has one, we
-				// require the remote to match — name-only matches across distinct
-				// remotes would be a silent identity collision (folder renames
-				// produce this; see KBRepoDiscoverer.isCurrentRepo).
-				if (
-					remoteUrl != null &&
-					repo.remoteUrl != null &&
-					repo.remoteUrl !== remoteUrl
-				) {
+				// One identity rule for foreign banks and shared-repo lookups alike
+				// (`sharedRepoIdentityMatches`): canonical remote compare (raw-vs-normalized
+				// `.git` no longer misses), owner/repo reconstruction for public-tier shares
+				// that withhold the URL, then bare name. It also guards the `file:///` sentinel
+				// so two unparseable remotes don't collapse into a false match, and rejects a
+				// name-only match across distinct remotes (a folder-rename identity collision).
+				if (!sharedRepoIdentityMatches(repoName, remoteUrl, repo.repoName, repo.remoteUrl)) {
 					continue;
 				}
 				const mm = new MetadataManager(join(repo.kbRoot, ".jolli"));

--- a/vscode/src/services/BranchShareController.ts
+++ b/vscode/src/services/BranchShareController.ts
@@ -15,6 +15,7 @@
 import {
 	type BranchShareRecord,
 	getShare,
+	getShareWithBranchLatest,
 	putBranchShare,
 	removeShare,
 } from "../../../cli/src/core/BranchShareStore.js";
@@ -87,4 +88,4 @@ export async function patchShareAudience(
 }
 
 /** Re-exports the persistence reads the panel/modal need when (re)opening the modal. */
-export { getShare, putBranchShare };
+export { getShare, getShareWithBranchLatest, putBranchShare };

--- a/vscode/src/services/BranchShareModal.test.ts
+++ b/vscode/src/services/BranchShareModal.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const h = vi.hoisted(() => ({
 	getShare: vi.fn(),
+	getLatestShareForBranch: vi.fn(),
+	getShareWithBranchLatest: vi.fn(),
 	patchShareAudience: vi.fn(),
 	putBranchShare: vi.fn(),
 	revokeShare: vi.fn(),
@@ -14,6 +16,7 @@ const h = vi.hoisted(() => ({
 
 vi.mock("./BranchShareController.js", () => ({
 	getShare: h.getShare,
+	getShareWithBranchLatest: h.getShareWithBranchLatest,
 	patchShareAudience: h.patchShareAudience,
 	putBranchShare: h.putBranchShare,
 	revokeShare: h.revokeShare,
@@ -39,6 +42,9 @@ vi.mock("./JolliPushOrchestrator.js", () => ({
 }));
 vi.mock("../../../cli/src/core/JolliApiUtils.js", () => ({
 	assertJolliOriginAllowed: h.assertJolliOriginAllowed,
+}));
+vi.mock("../util/Logger.js", () => ({
+	log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
 import { ShareBindingError } from "./JolliPushOrchestrator.js";
@@ -111,6 +117,14 @@ beforeEach(() => {
 	h.reconcileLiveShare.mockResolvedValue(undefined);
 	h.countSubjectDecisions.mockResolvedValue(0);
 	h.sendShareInviteAndGrantAccess.mockResolvedValue({ sent: [], failed: [] });
+	// postReadyState reads via the single combined getter; compose it from the two knobs
+	// so existing setups keep driving it. `getLatestShareForBranch` here is a test double
+	// standing in for the store's subject-scoped seed pick (real filtering is covered in
+	// BranchShareStore.test.ts); the modal then applies its own expiry filter to it.
+	h.getShareWithBranchLatest.mockImplementation(async (cwd: string, branch: string, commit?: string) => ({
+		record: await h.getShare(cwd, branch, commit),
+		seed: await h.getLatestShareForBranch(cwd, branch),
+	}));
 });
 
 describe("openShareModal", () => {
@@ -154,6 +168,69 @@ describe("openShareModal", () => {
 		await openShareModal(io, CTX);
 		const state = io.states.at(-1) as { share?: { recipients: string[] } };
 		expect(state.share?.recipients).toEqual([]);
+	});
+
+	it("seeds defaults from the branch's latest prior share when THIS subject has no record (amend re-key)", async () => {
+		// The commit share's subject key carries the commit hash; an amend strands the
+		// old record. The ready state must bring back the last-used tier + people.
+		h.getShare.mockResolvedValue(undefined);
+		h.getLatestShareForBranch.mockResolvedValue({
+			...MEMBER_RECORD,
+			visibility: "people",
+			recipients: ["ada@example.com", "tom@jolli.ai"],
+		});
+		const io = makeIO();
+		await openShareModal(io, CTX);
+		expect(h.getLatestShareForBranch).toHaveBeenCalledWith("/repo", "feature/x");
+		expect(io.states.at(-1)).toMatchObject({
+			kind: "ready",
+			defaults: { visibility: "people", recipients: ["ada@example.com", "tom@jolli.ai"] },
+		});
+		const state = io.states.at(-1) as { share?: unknown };
+		expect(state.share).toBeUndefined(); // seed values only — no live link
+	});
+
+	it("defaults a prior record's missing recipients to [] in the seed", async () => {
+		h.getShare.mockResolvedValue(undefined);
+		h.getLatestShareForBranch.mockResolvedValue({ ...PUBLIC_RECORD, recipients: undefined });
+		const io = makeIO();
+		await openShareModal(io, CTX);
+		expect(io.states.at(-1)).toMatchObject({ defaults: { visibility: "public", recipients: [] } });
+	});
+
+	it("omits defaults when the subject HAS a live link (no seeding over real state)", async () => {
+		// The branch's latest record is read in the same single pass, but a live link on
+		// THIS subject means it's never used to seed — defaults stay absent.
+		h.getShare.mockResolvedValue(MEMBER_RECORD);
+		h.getLatestShareForBranch.mockResolvedValue({ ...PUBLIC_RECORD, recipients: ["x@y.io"] });
+		const io = makeIO();
+		await openShareModal(io, CTX);
+		const state = io.states.at(-1) as { defaults?: unknown };
+		expect(state.defaults).toBeUndefined();
+	});
+
+	it("omits defaults when the branch has no prior share at all", async () => {
+		h.getShare.mockResolvedValue(undefined);
+		h.getLatestShareForBranch.mockResolvedValue(undefined);
+		const io = makeIO();
+		await openShareModal(io, CTX);
+		const state = io.states.at(-1) as { defaults?: unknown };
+		expect(state.defaults).toBeUndefined();
+	});
+
+	it("does NOT seed from an expired prior record (a lapsed grant must not be re-staged)", async () => {
+		// Issue #4: the seed candidate is expiry-filtered — seeding people from a share
+		// whose access intentionally lapsed would let one Send re-grant them.
+		h.getShare.mockResolvedValue(undefined);
+		h.getLatestShareForBranch.mockResolvedValue({
+			...MEMBER_RECORD,
+			recipients: ["ada@example.com"],
+			expiresAt: "2026-01-01T00:00:00.000Z", // before CTX.nowMs (2026-06-25)
+		});
+		const io = makeIO();
+		await openShareModal(io, CTX);
+		const state = io.states.at(-1) as { defaults?: unknown };
+		expect(state.defaults).toBeUndefined();
 	});
 
 	it("reconciles an existing branch collection link before rendering", async () => {
@@ -550,8 +627,17 @@ describe("sendInviteModal", () => {
 		const io = makeIO();
 		await sendInviteModal(io, CTX, ["cy@example.com"]);
 		expect(io.states.at(-1)).toEqual({ kind: "error", message: "Could not create share link: space unavailable" });
-		// The webview closed the popover optimistically, so a toast is the only visible channel.
-		expect(io.notifyError).toHaveBeenCalledWith(expect.stringContaining("Couldn't create the share link"));
+		// The webview closed the popover optimistically, so a toast is the only visible
+		// channel — it must carry the REAL reason, not a generic guess.
+		expect(io.notifyError).toHaveBeenCalledWith("Could not create share link: space unavailable");
+		expect(h.sendShareInviteAndGrantAccess).not.toHaveBeenCalled();
+	});
+
+	it("surfaces the specific binding reason in the invite toast (not a generic guess)", async () => {
+		h.generateLiveShare.mockRejectedValue(new ShareBindingError("cancelled"));
+		const io = makeIO();
+		await sendInviteModal(io, CTX, ["cy@example.com"]);
+		expect(io.notifyError).toHaveBeenCalledWith(expect.stringContaining("none was chosen"));
 		expect(h.sendShareInviteAndGrantAccess).not.toHaveBeenCalled();
 	});
 

--- a/vscode/src/services/BranchShareModal.ts
+++ b/vscode/src/services/BranchShareModal.ts
@@ -20,7 +20,13 @@
  * would be a dead owner-only link, so it is revoked rather than kept.
  */
 
-import { getShare, patchShareAudience, putBranchShare, revokeShare } from "./BranchShareController.js";
+import {
+	getShare,
+	getShareWithBranchLatest,
+	patchShareAudience,
+	putBranchShare,
+	revokeShare,
+} from "./BranchShareController.js";
 import { assertJolliOriginAllowed } from "../../../cli/src/core/JolliApiUtils.js";
 import type { BindingOutcome } from "./JolliPushOrchestrator.js";
 import type { BranchShareRecord } from "../../../cli/src/core/BranchShareStore.js";
@@ -29,6 +35,7 @@ import type { JolliMemoryBridge } from "../JolliMemoryBridge.js";
 import { sendShareInviteAndGrantAccess } from "./JolliShareService.js";
 import { ShareBindingError } from "./JolliPushOrchestrator.js";
 import type { CommitSummary } from "../../../cli/src/Types.js";
+import { log } from "../util/Logger.js";
 
 /** Whether a share covers a whole branch or a single commit. */
 export type ShareKind = "branch" | "commit";
@@ -67,6 +74,16 @@ export type ShareModalState =
 			readonly canOrg: boolean;
 			/** The subject's single link, when minted. */
 			readonly share?: ShareLinkState;
+			/**
+			 * Last-used choices for a subject with NO link yet — UI seed values only, no
+			 * live grant. Present when the branch has a prior share record whose subject
+			 * was stranded (an amend/rebase re-keyed the commit share), so reopening the
+			 * modal brings back the previous access tier + invited people.
+			 */
+			readonly defaults?: {
+				readonly visibility: ShareVisibility;
+				readonly recipients: ReadonlyArray<string>;
+			};
 			/** "From your jolli account" suggestion group (org members). */
 			readonly accountMembers: ReadonlyArray<ShareMember>;
 			/** "Git collaborators" suggestion group (repo contributors not in the account group). */
@@ -187,7 +204,7 @@ export async function copyShareLinkModal(io: ShareModalIO, ctx: ShareModalContex
 		// Silent mint: the pane must NOT swap to a spinner (mockup keeps the card
 		// still); the webview disables the button until the copy-result ack lands.
 		const generated = await generate(io, ctx, visibility, null);
-		if (!generated) {
+		if (!generated.ok) {
 			io.postCopyResult({ ok: false });
 			return;
 		}
@@ -236,7 +253,7 @@ export async function setShareAccessModal(io: ShareModalIO, ctx: ShareModalConte
 			const generated = await generate(io, ctx, visibility, null);
 			// On failure generate() already posted the error pane — don't overwrite it
 			// with a ready render (which would silently hide the failure).
-			if (!generated) return;
+			if (!generated.ok) return;
 		}
 		await postReadyState(io, ctx);
 		return;
@@ -290,10 +307,11 @@ export async function sendInviteModal(
 	let reTieredFrom: ShareVisibility | undefined;
 	if (!isLive(record, ctx.nowMs)) {
 		const generated = await generate(io, ctx, targetTier, "Creating link…");
-		if (!generated) {
-			// The webview optimistically closed the popover before this ran, so an
-			// error posted into the hidden overlay is invisible — report via a toast.
-			io.notifyError("Couldn't create the share link — there may be nothing to share, or it couldn't be bound to your Jolli account.");
+		if (!generated.ok) {
+			// The webview optimistically closed the popover before this ran, so the
+			// error posted into the hidden overlay is invisible — surface the REAL
+			// reason via a toast (binding / nothing-to-share / HTTP), not a guess.
+			io.notifyError(generated.message);
 			return;
 		}
 		mintedForInvite = true;
@@ -407,7 +425,7 @@ async function generate(
 	ctx: ShareModalContext,
 	visibility: ShareVisibility,
 	label: string | null,
-): Promise<boolean> {
+): Promise<{ ok: true } | { ok: false; message: string }> {
 	if (label !== null) io.postState({ kind: "loading", label });
 	try {
 		// apiKey is guaranteed non-null by the callers' guards.
@@ -421,10 +439,16 @@ async function generate(
 			commitSummary: ctx.commitSummary,
 			visibility,
 		});
-		return true;
+		return { ok: true };
 	} catch (err) {
-		io.postState({ kind: "error", message: generateErrorMessage(err) });
-		return false;
+		// Post the specific reason into the (usually visible) error pane AND return it,
+		// so a caller whose pane is already gone (invite closes the popover) can toast
+		// the real message instead of a generic guess.
+		const message = generateErrorMessage(err);
+		// Also record it: share-link failures were previously invisible in the debug log.
+		log.warn("BranchShareModal", `share link generation failed: ${message}`);
+		io.postState({ kind: "error", message });
+		return { ok: false, message };
 	}
 }
 
@@ -445,12 +469,26 @@ function generateErrorMessage(err: unknown): string {
 
 /** Reads the subject's link and posts the `ready` state (expired/untrusted links render as absent). */
 async function postReadyState(io: ShareModalIO, ctx: ShareModalContext): Promise<void> {
-	const record = presentable(await getShare(ctx.workspaceRoot, ctx.branch, ctx.commitHash), ctx.nowMs);
+	// One read of branch-shares.json yields BOTH this subject's record and the best prior
+	// record to seed from — the no-link path needs both, and reading + parsing the file
+	// twice (getShare then a separate latest scan) was pure waste on every open.
+	const { record: rawRecord, seed: rawSeed } = await getShareWithBranchLatest(
+		ctx.workspaceRoot,
+		ctx.branch,
+		ctx.commitHash,
+	);
+	const record = presentable(rawRecord, ctx.nowMs);
 	// A shared subject's count is cached on the record; before the first share there is
 	// no record, so compute the current subject's count (commit: free from the open
 	// summary; branch: one base..HEAD load) rather than showing a misleading "0".
 	const decisionCount =
 		record?.decisionCount ?? (await countSubjectDecisions(ctx.bridge, ctx.workspaceRoot, ctx.commitHash, ctx.commitSummary));
+	// No link on THIS subject: seed the UI with the branch's last-used choices from a
+	// same-kind stranded record (an amend/rebase re-keyed the previous commit share).
+	// Filter expiry here — an intentionally-lapsed grant must NOT seed people back
+	// (which a one-click Send would then re-grant). Seed values only; nothing is granted
+	// until the user acts (Send invite / Copy).
+	const prior = record ? undefined : presentable(rawSeed, ctx.nowMs);
 	io.postState({
 		kind: "ready",
 		branch: ctx.branch,
@@ -464,6 +502,14 @@ async function postReadyState(io: ShareModalIO, ctx: ShareModalContext): Promise
 						shareUrl: record.shareUrl,
 						visibility: record.visibility,
 						recipients: record.recipients ?? [],
+					},
+				}
+			: {}),
+		...(prior
+			? {
+					defaults: {
+						visibility: prior.visibility,
+						recipients: prior.recipients ?? [],
 					},
 				}
 			: {}),

--- a/vscode/src/services/JolliShareService.test.ts
+++ b/vscode/src/services/JolliShareService.test.ts
@@ -9,10 +9,14 @@ const { mockHttpRequest, mockHttpsRequest } = vi.hoisted(() => ({
 
 vi.mock("node:http", () => ({ request: mockHttpRequest }));
 vi.mock("node:https", () => ({ request: mockHttpsRequest }));
+vi.mock("../util/Logger.js", () => ({
+	log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
 
 import {
 	clearOrgMembersCache,
 	createLiveShare,
+	exportSharedBranch,
 	type LiveSharePayload,
 	listOrgMembers,
 	sendShareInviteAndGrantAccess,
@@ -273,6 +277,66 @@ describe("updateLiveShare", () => {
 	});
 });
 
+describe("exportSharedBranch", () => {
+	const EXPORT_BODY = JSON.stringify({
+		branch: "feature/x",
+		repoName: "acme/widgets",
+		repoUrl: "https://github.com/acme/widgets",
+		kind: "branch",
+		headCommitHash: "a1b2c3",
+		commits: [{ commitHash: "a1b2c3", summaryJson: '{"commitHash":"a1b2c3"}', attachments: [] }],
+	});
+
+	it("resolves the structured export on 2xx", async () => {
+		replyHttps(200, EXPORT_BODY);
+		const res = await exportSharedBranch(BASE, KEY, "tok");
+		expect(res.repoUrl).toBe("https://github.com/acme/widgets");
+		expect(res.commits).toHaveLength(1);
+		expect(res.commits[0].commitHash).toBe("a1b2c3");
+	});
+
+	it("hits the api-key-authed /export path with the encoded token", async () => {
+		let requestedUrl: URL | undefined;
+		mockHttpsRequest.mockImplementation((url: unknown, _opts: unknown, cb: (res: unknown) => void) => {
+			requestedUrl = url as URL;
+			cb(mockResponse(200, EXPORT_BODY));
+			return mockRequest();
+		});
+		await exportSharedBranch(BASE, KEY, "tok/en");
+		expect(requestedUrl?.pathname).toBe("/api/share/branch/tok%2Fen/export");
+	});
+
+	it("rejects a 2xx that is not a real export payload (missing commits array)", async () => {
+		replyHttps(200, JSON.stringify({ branch: "x" }));
+		await expect(exportSharedBranch(BASE, KEY, "tok")).rejects.toThrow(/HTTP 200|request failed/);
+	});
+
+	it("rejects a 2xx whose commits are an array but the identity fields are missing", async () => {
+		// commits is an array, but repoName/branch/headCommitHash are absent — the importer
+		// would otherwise feed `undefined` into path building and throw a raw TypeError.
+		replyHttps(200, JSON.stringify({ commits: [] }));
+		await expect(exportSharedBranch(BASE, KEY, "tok")).rejects.toThrow(/HTTP 200|request failed/);
+	});
+
+	it("rejects a 403 (not authorized for this share)", async () => {
+		replyHttps(403, JSON.stringify({ error: "forbidden" }));
+		await expect(exportSharedBranch(BASE, KEY, "tok")).rejects.toThrow(/forbidden \(HTTP 403\)/);
+	});
+
+	it("accepts a public-tier payload whose repoUrl is null (backend withholds it)", async () => {
+		const body = JSON.parse(EXPORT_BODY) as Record<string, unknown>;
+		replyHttps(200, JSON.stringify({ ...body, repoUrl: null }));
+		const res = await exportSharedBranch(BASE, KEY, "tok");
+		expect(res.repoUrl).toBeNull();
+		expect(res.repoName).toBe("acme/widgets");
+	});
+
+	it("rejects a 404 — a cross-deployment/unknown token", async () => {
+		replyHttps(404, JSON.stringify({ error: "not_found" }));
+		await expect(exportSharedBranch(BASE, KEY, "tok")).rejects.toThrow(/HTTP 404/);
+	});
+});
+
 describe("listOrgMembers", () => {
 	beforeEach(() => {
 		// Each case wires its own reply; a cached list from a prior case would mask it.
@@ -361,6 +425,14 @@ describe("listOrgMembers", () => {
 
 	it("does not cache a failed fetch — the next call retries", async () => {
 		replyHttps(500, JSON.stringify({ error: "boom" }));
+		expect(await listOrgMembers(BASE, KEY)).toEqual([]);
+		replyHttps(200, JSON.stringify({ members: [{ name: "Ada", email: "ada@example.com" }] }));
+		expect(await listOrgMembers(BASE, KEY)).toEqual([{ name: "Ada", email: "ada@example.com" }]);
+		expect(mockHttpsRequest).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not cache an empty result — the next call re-fetches", async () => {
+		replyHttps(200, JSON.stringify({ members: [] }));
 		expect(await listOrgMembers(BASE, KEY)).toEqual([]);
 		replyHttps(200, JSON.stringify({ members: [{ name: "Ada", email: "ada@example.com" }] }));
 		expect(await listOrgMembers(BASE, KEY)).toEqual([{ name: "Ada", email: "ada@example.com" }]);

--- a/vscode/src/services/JolliShareService.ts
+++ b/vscode/src/services/JolliShareService.ts
@@ -18,6 +18,7 @@ import { request as httpsRequest } from "node:https";
 import { type JolliApiKeyMeta, parseBaseUrl, parseJolliApiKey } from "../../../cli/src/core/JolliApiUtils.js";
 import type { LiveRef } from "../../../cli/src/core/BranchShareStore.js";
 import { buildJolliApiHeaders, PluginOutdatedError } from "./JolliPushService.js";
+import { log } from "../util/Logger.js";
 
 export { PluginOutdatedError };
 
@@ -77,6 +78,8 @@ export interface LiveSharePayload {
 	readonly commitHashes: ReadonlyArray<string>;
 	/** Display slug (slugify) — distinct from the push folder identity in `ref`. */
 	readonly branchSlug?: string;
+	/** One-line blurb for the share page / invite email description line (≤200 chars). */
+	readonly description?: string;
 	readonly ref: LiveRef;
 	/** `people` access allowlist (lowercased emails). Server-gated; omit for public/org. */
 	readonly recipients?: ReadonlyArray<string>;
@@ -155,13 +158,21 @@ function requestJson<T>(
 	});
 }
 
-/** Maps a non-2xx response to the right error (426 → outdated, else detail + status). */
-function rejectForStatus(status: number, json: ErrorBody | null, raw: string): Error {
+/**
+ * Maps a non-2xx response to the right error (426 → outdated, else detail + status)
+ * AND logs it — backend error responses were previously invisible in the debug log,
+ * so a failed share/invite left no trace. `context` names the failing operation.
+ */
+function rejectForStatus(status: number, json: ErrorBody | null, raw: string, context: string): Error {
+	// Single source of truth for the failure text, so the logged reason and the thrown
+	// message never diverge (e.g. a json-present-but-empty body).
+	const errText = [json?.error, json?.message].filter(Boolean).join(" — ") || "request failed";
+	const rawTail = json ? "" : `: ${raw.slice(0, 200)}`;
+	log.warn("JolliShareService", `${context} failed (HTTP ${status}): ${errText}${rawTail}`);
 	if (status === 426) {
 		return new PluginOutdatedError(json?.message ?? "Plugin version is outdated. Please update to the latest version.");
 	}
-	const detail = [json?.error, json?.message].filter(Boolean).join(" — ");
-	return new Error(`${detail || "request failed"} (HTTP ${status})${json ? "" : `: ${raw.slice(0, 200)}`}`);
+	return new Error(`${errText} (HTTP ${status})${rawTail}`);
 }
 
 /** Narrow an unknown wire visibility to the plugin's tier union, or undefined when unrecognized. */
@@ -193,19 +204,21 @@ export async function createLiveShare(
 		}
 		return { ...json, visibility: asVisibility(json.visibility) ?? payload.visibility };
 	}
-	throw rejectForStatus(status, json, raw);
+	throw rejectForStatus(status, json, raw, "create share (POST /api/share/branch)");
 }
 
-/** Patch type for a live share update — expiry, visibility, recipients, and/or the `covered` ref. */
+/** Patch type for a live share update — expiry, visibility, recipients, description, and/or the `covered` ref. */
 export interface LiveSharePatch {
 	readonly visibility?: "public" | "org" | "people";
 	readonly expiresAt?: string;
 	readonly ref?: LiveRef;
+	/** One-line blurb for the share page / invite email description line (≤200 chars). */
+	readonly description?: string;
 	/** `people` allowlist (lowercased emails); sent when changing audience. */
 	readonly recipients?: ReadonlyArray<string>;
 }
 
-/** Updates a live share (visibility / covered ref / expiry) via PATCH. */
+/** Updates a live share (visibility / covered ref / expiry / description) via PATCH. */
 export async function updateLiveShare(
 	baseUrl: string | undefined,
 	apiKey: string,
@@ -227,7 +240,7 @@ export async function updateLiveShare(
 		const visibility = asVisibility(wireVisibility);
 		return { ...rest, ...(visibility && { visibility }) };
 	}
-	throw rejectForStatus(status, json, raw);
+	throw rejectForStatus(status, json, raw, "update share (PATCH /api/share/branch/:id)");
 }
 
 /** What the invite endpoint reports back: who got the email, and who couldn't be reached. */
@@ -271,7 +284,61 @@ export async function sendShareInviteAndGrantAccess(
 			return { sent: [...body.recipients], failed: [] };
 		}
 	}
-	throw rejectForStatus(status, json, raw);
+	throw rejectForStatus(status, json, raw, "send invite (POST /api/share/branch/:id/invite)");
+}
+
+/** One commit's downloaded share content: the sanitized structured summary + attachment (plan/note) bodies. */
+export interface SharedCommitExport {
+	readonly commitHash: string;
+	readonly summaryJson: string | null;
+	readonly attachments: ReadonlyArray<{ readonly title: string; readonly body: string }>;
+}
+
+/** The `/export` payload: a shared branch's structured memory, downloaded for local render. */
+export interface SharedBranchExport {
+	readonly branch: string;
+	readonly repoName: string;
+	/** Remote URL; null on public-tier shares (the backend withholds it from non-member callers). */
+	readonly repoUrl: string | null;
+	readonly kind: "branch" | "commit";
+	readonly headCommitHash: string;
+	readonly commits: ReadonlyArray<SharedCommitExport>;
+}
+
+/**
+ * Downloads a shared branch's structured memory (sanitized summaries + plan/note bodies)
+ * via the api-key-authenticated `GET /api/share/branch/<token>/export`. The request goes
+ * to the caller's OWN tenant (`keyMeta.u`); the token self-routes to the share's tenant
+ * within the same deployment. A cross-deployment token (a share on a different Jolli
+ * instance the user isn't signed into) resolves to a 404 — surfaced as a normal error.
+ */
+export async function exportSharedBranch(
+	baseUrl: string | undefined,
+	apiKey: string,
+	token: string,
+): Promise<SharedBranchExport> {
+	const { status, json, raw } = await requestJson<SharedBranchExport>(
+		"GET",
+		baseUrl,
+		apiKey,
+		`/api/share/branch/${encodeURIComponent(token)}/export`,
+	);
+	// Validate the string identity fields too, not just `commits`: the importer feeds
+	// repoName/branch/headCommitHash straight into path building + display, so a truncated
+	// 2xx body missing them would throw a raw TypeError instead of a clean error toast.
+	const body = json as Partial<SharedBranchExport> | null;
+	if (
+		status >= 200 &&
+		status < 300 &&
+		body &&
+		Array.isArray(body.commits) &&
+		typeof body.repoName === "string" &&
+		typeof body.branch === "string" &&
+		typeof body.headCommitHash === "string"
+	) {
+		return body as SharedBranchExport;
+	}
+	throw rejectForStatus(status, json, raw, "export shared branch (GET /api/share/branch/:token/export)");
 }
 
 /** Directory cap: the share popover's suggestion list never needs more than this many members. */
@@ -293,8 +360,8 @@ export function clearOrgMembersCache(): void {
  * error (the recipient picker still has git contributors + manual entry).
  *
  * Capped at {@link ORG_MEMBERS_MAX} and cached per (baseUrl, apiKey) for
- * {@link ORG_MEMBERS_TTL_MS} — only successful fetches are cached, so a transient
- * failure never sticks for the TTL.
+ * {@link ORG_MEMBERS_TTL_MS} — only a NON-EMPTY result is cached, so neither a
+ * transient failure nor an empty read sticks for the TTL (the next call re-fetches).
  */
 export async function listOrgMembers(baseUrl: string | undefined, apiKey: string): Promise<OrgMember[]> {
 	// NUL joiner: can't occur in a URL or an API key, so keys never collide.
@@ -310,7 +377,10 @@ export async function listOrgMembers(baseUrl: string | undefined, apiKey: string
 			apiKey,
 			"/api/jolli-memory/org-members",
 		);
-		if (status < 200 || status >= 300 || json === null) return [];
+		if (status < 200 || status >= 300 || json === null) {
+			log.warn("JolliShareService", `list org-members failed (HTTP ${status}) — not caching`);
+			return [];
+		}
 		const rows = Array.isArray(json.members) ? json.members : [];
 		const members: OrgMember[] = [];
 		for (const row of rows) {
@@ -320,9 +390,17 @@ export async function listOrgMembers(baseUrl: string | undefined, apiKey: string
 			const name = typeof row.name === "string" ? row.name : "";
 			members.push({ name, email });
 		}
-		orgMembersCache.set(cacheKey, { members, ts: Date.now() });
+		// Cache ONLY a non-empty result: an empty list means no members were resolved
+		// (indistinguishable from a soft failure), so it must not stick for the TTL —
+		// the next call re-fetches. Non-2xx/null above already return [] without caching.
+		if (members.length > 0) {
+			orgMembersCache.set(cacheKey, { members, ts: Date.now() });
+		} else {
+			log.warn("JolliShareService", "list org-members returned no members — not caching");
+		}
 		return members;
-	} catch {
+	} catch (err) {
+		log.warn("JolliShareService", `list org-members threw — not caching: ${err instanceof Error ? err.message : String(err)}`);
 		return [];
 	}
 }

--- a/vscode/src/services/LiveShareController.test.ts
+++ b/vscode/src/services/LiveShareController.test.ts
@@ -43,6 +43,7 @@ vi.mock("../util/Logger.js", () => ({ log: { info: vi.fn(), warn: vi.fn(), error
 import {
 	AttachmentPushError,
 	BranchMismatchError,
+	deriveShareDescription,
 	generateLiveShare,
 	NothingToShareError,
 	pushBranchMemoriesToSpace,
@@ -154,6 +155,44 @@ describe("subjectFingerprint", () => {
 	});
 });
 
+describe("deriveShareDescription", () => {
+	it("prefers the head commit's recap over its commit message", () => {
+		const head = { ...summary("B"), recap: "Reworked the share flow." } as unknown as CommitSummary;
+		expect(deriveShareDescription([summary("A"), head])).toBe("Reworked the share flow.");
+	});
+
+	it("falls back to the commit-message subject when the head has no recap", () => {
+		const head = { ...summary("B"), commitMessage: "Fix share blurb\n\nBody text" } as unknown as CommitSummary;
+		expect(deriveShareDescription([head])).toBe("Fix share blurb");
+	});
+
+	it("collapses whitespace and truncates to 200 chars with an ellipsis", () => {
+		const head = { ...summary("B"), recap: `${"word ".repeat(60)}tail` } as unknown as CommitSummary;
+		const blurb = deriveShareDescription([head]);
+		expect(blurb).toHaveLength(200);
+		expect(blurb?.endsWith("…")).toBe(true);
+		expect(blurb).not.toContain("\n");
+	});
+
+	it("returns undefined for an empty subject or a blank head", () => {
+		expect(deriveShareDescription([])).toBeUndefined();
+		const blank = { ...summary("B"), commitMessage: "   " } as unknown as CommitSummary;
+		expect(deriveShareDescription([blank])).toBeUndefined();
+	});
+
+	it("falls back to the commit subject when a unified-hoist head carries an empty recap", () => {
+		// version>=4 makes resolveEffectiveRecap return the recap verbatim — `""` here — so a
+		// `??` fallback would keep it; the truthy fallback must reach the commit subject.
+		const head = {
+			...summary("B"),
+			version: 4,
+			recap: "",
+			commitMessage: "Fix share blurb\n\nBody",
+		} as unknown as CommitSummary;
+		expect(deriveShareDescription([head])).toBe("Fix share blurb");
+	});
+});
+
 describe("generateLiveShare", () => {
 	it("throws NothingToShareError when the subject has no summaries", async () => {
 		mockLoad.mockResolvedValue({ summaries: [], missingCount: 0 });
@@ -199,6 +238,8 @@ describe("generateLiveShare", () => {
 		expect(payload.commitHashes).toEqual(["A", "B"]);
 		expect(payload.decisionCount).toBe(2); // one topic per commit
 		expect(payload.visibility).toBe("org");
+		// Blurb derived from the head commit (fixture has no recap → commit-message subject).
+		expect(payload.description).toBe("commit B");
 
 		const stored = mockPutShare.mock.calls[0][2];
 		expect(stored.visibility).toBe("public"); // from the (mocked) create result
@@ -506,6 +547,23 @@ describe("reconcileLiveShare", () => {
 		expect(mockUpdate).toHaveBeenCalledOnce();
 		const ref = mockUpdate.mock.calls[0][3].ref;
 		expect(ref.covered).toEqual([{ commitHash: "A", summaryDocId: 1001, attachmentDocIds: [] }]);
+	});
+
+	it("refreshes the description from the current head on PATCH", async () => {
+		mockGetShare.mockResolvedValue({
+			shareId: "7",
+			shareUrl: "https://acme.jolli.ai/b/x",
+			visibility: "public",
+			ref: { kind: "branchCollection", relativePath: "feature/x", covered: [] },
+			expiresAt: "2026-09-01T00:00:00.000Z",
+			decisionCount: 1,
+		});
+		const head = { ...summary("B"), recap: "Now with a recap." } as unknown as CommitSummary;
+		mockLoad.mockResolvedValue({ summaries: [summary("A"), head], missingCount: 0 });
+
+		await reconcileLiveShare(deps(), "feature/x");
+
+		expect(mockUpdate.mock.calls[0][3].description).toBe("Now with a recap.");
 	});
 
 	it("refreshes the cached decision count from the current base..HEAD (and writes no titles)", async () => {

--- a/vscode/src/services/LiveShareController.ts
+++ b/vscode/src/services/LiveShareController.ts
@@ -348,6 +348,28 @@ export function subjectFingerprint(summaries: ReadonlyArray<CommitSummary>): str
 	return createHash("sha1").update(JSON.stringify(projection)).digest("hex").slice(0, 16);
 }
 
+/** Server accepts up to 500; 200 keeps the email card / share page line to a true one-liner. */
+const SHARE_DESCRIPTION_MAX = 200;
+
+/**
+ * One-line blurb sent as the share's `description` (share page description line +
+ * invite email card): the head commit's recap, falling back to its commit-message
+ * subject. Whitespace-collapsed and capped at {@link SHARE_DESCRIPTION_MAX} chars.
+ * Undefined when the head summary yields no text — the server keeps `null` and the
+ * email simply omits the blurb block.
+ */
+export function deriveShareDescription(summaries: ReadonlyArray<CommitSummary>): string | undefined {
+	const head = summaries[summaries.length - 1];
+	if (!head) return undefined;
+	// Truthy fallback, not `??`: a unified-hoist summary can carry `recap: ""`, and `??`
+	// would keep the empty string instead of falling back to the commit subject.
+	const raw = resolveEffectiveRecap(head) || head.commitMessage.split("\n")[0] || "";
+	const oneLine = raw.replace(/\s+/g, " ").trim();
+	if (oneLine.length === 0) return undefined;
+	if (oneLine.length <= SHARE_DESCRIPTION_MAX) return oneLine;
+	return `${oneLine.slice(0, SHARE_DESCRIPTION_MAX - 1).trimEnd()}…`;
+}
+
 /** Builds the push context (binding chooser injected) for a subject push. */
 function buildPushContext(deps: LiveShareDeps, baseUrl: string, repoUrl: string): PushContext {
 	return {
@@ -391,6 +413,7 @@ export function generateLiveShare(params: GenerateLiveShareParams): Promise<Live
 		// on the record so the modal subtitle needn't reload summaries to count.
 		const decisionCount = countDecisions(subjectSummaries);
 		const contentHash = subjectFingerprint(subjectSummaries);
+		const description = deriveShareDescription(subjectSummaries);
 
 		const result = await createLiveShare(baseUrl, params.apiKey, {
 			repoUrl,
@@ -402,6 +425,7 @@ export function generateLiveShare(params: GenerateLiveShareParams): Promise<Live
 			headCommitHash,
 			commitHashes,
 			branchSlug: slugify(params.branch),
+			...(description && { description }),
 			ref,
 			...(params.recipients && { recipients: params.recipients }),
 		});
@@ -462,7 +486,13 @@ export function reconcileLiveShare(deps: LiveShareDeps, branch: string): Promise
 		const ctx = buildPushContext(deps, baseUrl, repoUrl);
 		const ref = await pushSubjectAndBuildRef(subjectSummaries, "branch", branch, ctx);
 
-		const result = await updateLiveShare(baseUrl, deps.apiKey, existing.shareId, { ref });
+		// Recap edits move `contentHash` (see subjectFingerprint), so the blurb refreshes
+		// on the same reconcile that republishes the content.
+		const description = deriveShareDescription(subjectSummaries);
+		const result = await updateLiveShare(baseUrl, deps.apiKey, existing.shareId, {
+			ref,
+			...(description && { description }),
+		});
 		// A ref-only PATCH legitimately omits unchanged fields (shareUrl/recipients/…).
 		// Preserve the existing values so the cached record stays reopen-able and the
 		// allowlist isn't dropped; only `ref` and anything the server actually returned change.

--- a/vscode/src/services/SharedBranchImporter.test.ts
+++ b/vscode/src/services/SharedBranchImporter.test.ts
@@ -1,0 +1,704 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../util/Logger.js", () => ({
+	log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { FolderStorageMock, MetadataManagerMock } = vi.hoisted(() => ({
+	FolderStorageMock: vi.fn(),
+	MetadataManagerMock: vi.fn(),
+}));
+vi.mock("../../../cli/src/core/FolderStorage.js", () => ({ FolderStorage: FolderStorageMock }));
+vi.mock("../../../cli/src/core/MetadataManager.js", () => ({ MetadataManager: MetadataManagerMock }));
+
+import type * as vscode from "vscode";
+import type { JolliMemoryBridge } from "../JolliMemoryBridge.js";
+import type { SharedBranchExport } from "./JolliShareService.js";
+import { importSharedBranchForDisplay } from "./SharedBranchImporter.js";
+
+interface FakeStorage {
+	writeFiles: ReturnType<typeof vi.fn>;
+	listFiles: ReturnType<typeof vi.fn>;
+	readFile: ReturnType<typeof vi.fn>;
+}
+
+function makeStorage(existingPaths: string[] = [], localSummaries: Record<string, string> = {}): FakeStorage {
+	return {
+		writeFiles: vi.fn().mockResolvedValue(undefined),
+		listFiles: vi.fn().mockImplementation((prefix: string) =>
+			Promise.resolve(existingPaths.filter(p => p.startsWith(`${prefix}/`))),
+		),
+		readFile: vi.fn().mockImplementation((path: string) => Promise.resolve(localSummaries[path] ?? null)),
+	};
+}
+
+/** The resolved shape of createReadStorageForCurrentRepo — folder storage + identity. */
+function currentRepo(storage: FakeStorage, over: { repoName?: string; remoteUrl?: string | null } = {}) {
+	return {
+		storage,
+		kbRoot: "/kb/widgets",
+		repoName: over.repoName ?? "acme/widgets",
+		remoteUrl: over.remoteUrl === undefined ? "https://github.com/acme/widgets" : over.remoteUrl,
+	};
+}
+
+/** A summary.json string with the given hash + optional plan/note refs. */
+function summaryJson(over: Record<string, unknown>): string {
+	return JSON.stringify({ version: 4, commitHash: "h1", commitMessage: "m", branch: "feature/x", ...over });
+}
+
+function makeExport(over: Partial<SharedBranchExport> = {}): SharedBranchExport {
+	return {
+		branch: "feature/x",
+		repoName: "acme/widgets",
+		repoUrl: "https://github.com/acme/widgets",
+		kind: "branch",
+		headCommitHash: "h1",
+		commits: [{ commitHash: "h1", summaryJson: summaryJson({ commitHash: "h1" }), attachments: [] }],
+		...over,
+	};
+}
+
+describe("importSharedBranchForDisplay", () => {
+	let bridge: {
+		createStorageForRepo: ReturnType<typeof vi.fn>;
+		createReadStorageForCurrentRepo: ReturnType<typeof vi.fn>;
+		storeSummary: ReturnType<typeof vi.fn>;
+	};
+	const context = { globalStorageUri: { fsPath: "/gs" } } as unknown as vscode.ExtensionContext;
+
+	beforeEach(() => {
+		// Both repo lookups default to "not found"; each test wires the one it exercises.
+		bridge = {
+			createStorageForRepo: vi.fn().mockResolvedValue(null),
+			createReadStorageForCurrentRepo: vi.fn().mockResolvedValue(null),
+			storeSummary: vi.fn().mockResolvedValue(undefined),
+		};
+		FolderStorageMock.mockReset();
+		// Default sandbox storage so the fallback path has a working target.
+		// biome-ignore lint/complexity/useArrowFunction: `new`-ed by the importer — arrows aren't constructible.
+		FolderStorageMock.mockImplementation(function () {
+			return makeStorage();
+		});
+		MetadataManagerMock.mockReset();
+	});
+
+	function run(data: SharedBranchExport) {
+		return importSharedBranchForDisplay(data, bridge as unknown as JolliMemoryBridge, context);
+	}
+
+	it("returns null when no commit carries a usable summary.json", async () => {
+		bridge.createStorageForRepo.mockResolvedValue({ storage: makeStorage(), kbRoot: "/kb" });
+		const res = await run(makeExport({ commits: [{ commitHash: "h1", summaryJson: null, attachments: [] }] }));
+		expect(res).toBeNull();
+	});
+
+	// ── Mode 1: currently-open repo → real ingest so recall/search find it ──────────
+
+	describe("current repo (ingest via storeSummary)", () => {
+		it("ingests every shared commit via storeSummary(force=false) and reports ingestedLocally", async () => {
+			const storage = makeStorage();
+			bridge.createReadStorageForCurrentRepo.mockResolvedValue(currentRepo(storage));
+			const res = await run(
+				makeExport({
+					headCommitHash: "h2",
+					commits: [
+						{ commitHash: "h1", summaryJson: summaryJson({ commitHash: "h1" }), attachments: [] },
+						{ commitHash: "h2", summaryJson: summaryJson({ commitHash: "h2" }), attachments: [] },
+					],
+				}),
+			);
+			expect(res?.ingestedLocally).toBe(true);
+			expect(res?.storage).toBe(storage as never);
+			expect(bridge.storeSummary).toHaveBeenCalledTimes(2);
+			// force=false: the commitHash duplicate guard keeps the recipient's own copy.
+			expect(bridge.storeSummary.mock.calls.every(c => c[1] === false)).toBe(true);
+			expect(FolderStorageMock).not.toHaveBeenCalled();
+		});
+
+		it("injects a zero diffStats when the shared summary lacks it (keeps storeSummary git-free)", async () => {
+			bridge.createReadStorageForCurrentRepo.mockResolvedValue(currentRepo(makeStorage()));
+			await run(makeExport());
+			expect(bridge.storeSummary.mock.calls[0][0].diffStats).toEqual({ filesChanged: 0, insertions: 0, deletions: 0 });
+		});
+
+		it("preserves an existing diffStats on the shared summary", async () => {
+			bridge.createReadStorageForCurrentRepo.mockResolvedValue(currentRepo(makeStorage()));
+			const stats = { filesChanged: 3, insertions: 10, deletions: 2 };
+			await run(makeExport({ commits: [{ commitHash: "h1", summaryJson: summaryJson({ diffStats: stats }), attachments: [] }] }));
+			expect(bridge.storeSummary.mock.calls[0][0].diffStats).toEqual(stats);
+		});
+
+		it("fills plan/note fold bodies into the repo folder (gaps only), never summary files", async () => {
+			const storage = makeStorage(["plans/plan-a.md"]);
+			bridge.createReadStorageForCurrentRepo.mockResolvedValue(currentRepo(storage));
+			await run(
+				makeExport({
+					commits: [
+						{
+							commitHash: "h1",
+							summaryJson: summaryJson({
+								commitHash: "h1",
+								plans: [{ slug: "plan-a", title: "Plan A" }],
+								notes: [{ id: "n1", title: "Note 1", format: "markdown" }],
+							}),
+							attachments: [
+								{ title: "Plan A", body: "SHARE PLAN BODY" },
+								{ title: "Note 1", body: "NOTE BODY" },
+							],
+						},
+					],
+				}),
+			);
+			const files = storage.writeFiles.mock.calls[0][0] as Array<{ path: string }>;
+			// plan-a already local → skipped; only the missing note is written; no summaries/*.
+			expect(files.map(f => f.path)).toEqual(["notes/n1.md"]);
+		});
+
+		it("does not touch writeFiles when the repo already has every plan/note", async () => {
+			const storage = makeStorage(["plans/plan-a.md"]);
+			bridge.createReadStorageForCurrentRepo.mockResolvedValue(currentRepo(storage));
+			await run(
+				makeExport({
+					commits: [
+						{
+							commitHash: "h1",
+							summaryJson: summaryJson({ commitHash: "h1", plans: [{ slug: "plan-a", title: "Plan A" }] }),
+							attachments: [{ title: "Plan A", body: "SHARE PLAN BODY" }],
+						},
+					],
+				}),
+			);
+			expect(storage.writeFiles).not.toHaveBeenCalled();
+			expect(bridge.storeSummary).toHaveBeenCalledTimes(1); // ingest still ran
+		});
+
+		it("prefers the repo's authoritative head summary for display when it pre-exists", async () => {
+			const local = JSON.stringify({ version: 4, commitHash: "h1", commitMessage: "the full local version", branch: "feature/x" });
+			const storage = makeStorage([], { "summaries/h1.json": local });
+			bridge.createReadStorageForCurrentRepo.mockResolvedValue(currentRepo(storage));
+			const res = await run(makeExport());
+			expect(res?.ingestedLocally).toBe(true);
+			expect(res?.head.commitMessage).toBe("the full local version");
+		});
+
+		it("ingests a public-tier share of the current repo by reconstructing owner/repo from the local remote", async () => {
+			// Public tier withholds repoUrl, but the recipient still knows its OWN remote. Real
+			// fixture forms pin the production contract: the backend stored repoName as
+			// sanitize("acme/widgets")="acmewidgets" (slash gone) while the local bank keeps the
+			// bare basename "widgets" — a naive repoName===data.repoName would MISS (this is the
+			// bug the reconstruction fixes). We rebuild "acme/widgets"→"acmewidgets" from the
+			// local remote and match.
+			const storage = makeStorage();
+			bridge.createReadStorageForCurrentRepo.mockResolvedValue(
+				currentRepo(storage, { repoName: "widgets", remoteUrl: "https://github.com/acme/widgets.git" }),
+			);
+			const res = await run(makeExport({ repoName: "acmewidgets", repoUrl: null }));
+			expect(res?.ingestedLocally).toBe(true);
+			expect(bridge.storeSummary).toHaveBeenCalled();
+		});
+
+		it("routes a public-tier share to the sandbox when the basename matches but the owner differs", async () => {
+			// Owner dimension is preserved: a public share of acme/widgets must NOT land in a
+			// local OTHER/widgets repo just because the basename collides. Reconstructed
+			// "OTHERwidgets" != stored "acmewidgets" → read-only sandbox, not a wrong-repo write.
+			bridge.createReadStorageForCurrentRepo.mockResolvedValue(
+				currentRepo(makeStorage(), { repoName: "widgets", remoteUrl: "https://github.com/OTHER/widgets.git" }),
+			);
+			const res = await run(makeExport({ repoName: "acmewidgets", repoUrl: null }));
+			expect(res?.ingestedLocally).toBe(false);
+			expect(bridge.storeSummary).not.toHaveBeenCalled();
+		});
+
+		it("falls back to a bare-name match when neither side has a remote (local-only repo)", async () => {
+			// No remote on either side → the backend stored a basename, not owner/repo, so the
+			// bare-name compare is the last-ditch identity for this case.
+			const storage = makeStorage();
+			bridge.createReadStorageForCurrentRepo.mockResolvedValue(
+				currentRepo(storage, { repoName: "widgets", remoteUrl: null }),
+			);
+			const res = await run(makeExport({ repoName: "widgets", repoUrl: null }));
+			expect(res?.ingestedLocally).toBe(true);
+			expect(bridge.storeSummary).toHaveBeenCalled();
+		});
+
+		it("adopts the current repo on a remote-URL match even when the display names differ", async () => {
+			// A folder rename changes repoName but not the remote — URL identity wins.
+			const storage = makeStorage();
+			bridge.createReadStorageForCurrentRepo.mockResolvedValue(currentRepo(storage, { repoName: "widgets-2" }));
+			const res = await run(makeExport());
+			expect(res?.ingestedLocally).toBe(true);
+		});
+
+		it("matches when the local raw remote differs only by canonicalization from the export URL", async () => {
+			// Real-world regression: the bank keeps the raw git remote (`.git` suffix) while
+			// the backend export returns the normalized form. A strict === missed this and
+			// misrouted a current-repo share into the read-only sandbox.
+			const storage = makeStorage();
+			bridge.createReadStorageForCurrentRepo.mockResolvedValue(
+				currentRepo(storage, { repoName: "jolliai", remoteUrl: "https://github.com/jolliai/jolliai.git" }),
+			);
+			const res = await run(
+				makeExport({ repoName: "jolliaijolliai", repoUrl: "https://github.com/jolliai/jolliai" }),
+			);
+			expect(res?.ingestedLocally).toBe(true); // URL canonicalizes equal despite .git + repoName mismatch
+			expect(bridge.storeSummary).toHaveBeenCalled();
+		});
+
+		it("rejects a same-name current repo whose remote URL differs (identity collision) → sandbox", async () => {
+			bridge.createReadStorageForCurrentRepo.mockResolvedValue(
+				currentRepo(makeStorage(), { remoteUrl: "https://github.com/OTHER/widgets" }),
+			);
+			const res = await run(makeExport());
+			expect(res?.ingestedLocally).toBe(false);
+			expect(bridge.storeSummary).not.toHaveBeenCalled();
+			expect(FolderStorageMock).toHaveBeenCalledWith("/gs/shared-imports/acme-widgets", expect.anything());
+		});
+
+		it("rejects a current repo that is a different repo entirely → sandbox", async () => {
+			bridge.createReadStorageForCurrentRepo.mockResolvedValue(
+				currentRepo(makeStorage(), { repoName: "acme/unrelated", remoteUrl: null }),
+			);
+			const res = await run(makeExport());
+			expect(res?.ingestedLocally).toBe(false);
+			expect(bridge.storeSummary).not.toHaveBeenCalled();
+		});
+	});
+
+	// ── Mode 2: foreign local repo (discovered, not open) → display-only ────────────
+
+	describe("foreign local repo (display-only, no ingest)", () => {
+		it("returns the foreign bank storage and never ingests", async () => {
+			const storage = makeStorage();
+			bridge.createStorageForRepo.mockResolvedValue({ storage, kbRoot: "/kb" });
+			const res = await run(
+				makeExport({
+					headCommitHash: "h2",
+					commits: [
+						{ commitHash: "h1", summaryJson: summaryJson({ commitHash: "h1" }), attachments: [] },
+						{ commitHash: "h2", summaryJson: summaryJson({ commitHash: "h2" }), attachments: [] },
+					],
+				}),
+			);
+			expect(res?.ingestedLocally).toBe(false);
+			expect(res?.storage).toBe(storage as never);
+			expect(res?.head.commitHash).toBe("h2");
+			expect(res?.commitCount).toBe(2);
+			expect(bridge.storeSummary).not.toHaveBeenCalled();
+			expect(FolderStorageMock).not.toHaveBeenCalled();
+		});
+
+		it("writes plan + note bodies matched by title (snippet note uses inline content), no summaries", async () => {
+			const storage = makeStorage();
+			bridge.createStorageForRepo.mockResolvedValue({ storage, kbRoot: "/kb" });
+			await run(
+				makeExport({
+					commits: [
+						{
+							commitHash: "h1",
+							summaryJson: summaryJson({
+								commitHash: "h1",
+								plans: [{ slug: "plan-a", title: "Plan A" }],
+								notes: [
+									{ id: "n1", title: "Note 1", format: "markdown" },
+									{ id: "n2", title: "Snippet", format: "snippet", content: "inline body" },
+								],
+							}),
+							attachments: [
+								{ title: "Plan A", body: "PLAN BODY" },
+								{ title: "Note 1", body: "NOTE BODY" },
+							],
+						},
+					],
+				}),
+			);
+			const files = storage.writeFiles.mock.calls[0][0] as Array<{ path: string; content: string }>;
+			expect(files).toContainEqual({ path: "plans/plan-a.md", content: "# Plan A\n\nPLAN BODY", branch: "feature/x" });
+			expect(files).toContainEqual({ path: "notes/n1.md", content: "# Note 1\n\nNOTE BODY", branch: "feature/x" });
+			expect(files).toContainEqual({ path: "notes/n2.md", content: "# Snippet\n\ninline body", branch: "feature/x" });
+			expect(files.every(f => !f.path.startsWith("summaries/"))).toBe(true);
+		});
+
+		it("never overwrites a file the foreign bank already has — fills gaps only", async () => {
+			const storage = makeStorage(["plans/plan-a.md"]);
+			bridge.createStorageForRepo.mockResolvedValue({ storage, kbRoot: "/kb" });
+			await run(
+				makeExport({
+					commits: [
+						{
+							commitHash: "h1",
+							summaryJson: summaryJson({
+								commitHash: "h1",
+								plans: [{ slug: "plan-a", title: "Plan A" }],
+								notes: [{ id: "n1", title: "Note 1", format: "markdown" }],
+							}),
+							attachments: [
+								{ title: "Plan A", body: "SHARE PLAN BODY" },
+								{ title: "Note 1", body: "NOTE BODY" },
+							],
+						},
+					],
+				}),
+			);
+			const files = storage.writeFiles.mock.calls[0][0] as Array<{ path: string }>;
+			expect(files.map(f => f.path)).toEqual(["notes/n1.md"]);
+		});
+
+		it("prefers the foreign bank's authoritative head over the lossy import", async () => {
+			const local = JSON.stringify({ version: 4, commitHash: "h1", commitMessage: "authoritative", branch: "feature/x" });
+			const storage = makeStorage([], { "summaries/h1.json": local });
+			bridge.createStorageForRepo.mockResolvedValue({ storage, kbRoot: "/kb" });
+			const res = await run(makeExport());
+			expect(res?.ingestedLocally).toBe(false);
+			expect(res?.head.commitMessage).toBe("authoritative");
+		});
+
+		it("falls back to the imported head when the foreign bank's copy is unparseable", async () => {
+			const storage = makeStorage([], { "summaries/h1.json": "{not json" });
+			bridge.createStorageForRepo.mockResolvedValue({ storage, kbRoot: "/kb" });
+			const res = await run(makeExport());
+			expect(res?.head.commitHash).toBe("h1");
+		});
+
+		it("does not call writeFiles when there are no attachment bodies to write", async () => {
+			const storage = makeStorage();
+			bridge.createStorageForRepo.mockResolvedValue({ storage, kbRoot: "/kb" });
+			await run(makeExport());
+			expect(storage.writeFiles).not.toHaveBeenCalled();
+		});
+
+		it("prefers the head commit's body when several commits carry the same plan slug", async () => {
+			const storage = makeStorage();
+			bridge.createStorageForRepo.mockResolvedValue({ storage, kbRoot: "/kb" });
+			const planCommit = (hash: string, body: string) => ({
+				commitHash: hash,
+				summaryJson: summaryJson({ commitHash: hash, plans: [{ slug: "plan-a", title: "Plan A" }] }),
+				attachments: [{ title: "Plan A", body }],
+			});
+			// Head listed FIRST to prove priority comes from headCommitHash, not array order.
+			await run(makeExport({ headCommitHash: "h2", commits: [planCommit("h2", "HEAD BODY"), planCommit("h1", "OLD BODY")] }));
+			const files = storage.writeFiles.mock.calls[0][0] as Array<{ path: string; content: string }>;
+			expect(files).toEqual([{ path: "plans/plan-a.md", content: "# Plan A\n\nHEAD BODY", branch: "feature/x" }]);
+		});
+
+		it("skips an unparseable summary.json but still imports the valid commits", async () => {
+			const storage = makeStorage();
+			bridge.createStorageForRepo.mockResolvedValue({ storage, kbRoot: "/kb" });
+			const res = await run(
+				makeExport({
+					headCommitHash: "bad",
+					commits: [
+						{ commitHash: "bad", summaryJson: "{not json", attachments: [] },
+						{ commitHash: "h1", summaryJson: summaryJson({ commitHash: "h1" }), attachments: [] },
+					],
+				}),
+			);
+			expect(res?.commitCount).toBe(1);
+			expect(res?.head.commitHash).toBe("h1");
+		});
+
+		it("skips a summary.json whose commitHash is missing (parses but no identity)", async () => {
+			const storage = makeStorage();
+			bridge.createStorageForRepo.mockResolvedValue({ storage, kbRoot: "/kb" });
+			const res = await run(
+				makeExport({
+					headCommitHash: "h1",
+					commits: [
+						{ commitHash: "empty", summaryJson: "{}", attachments: [] },
+						{ commitHash: "h1", summaryJson: summaryJson({ commitHash: "h1" }), attachments: [] },
+					],
+				}),
+			);
+			// The `{}` body has no commitHash → rejected; only the well-formed commit survives.
+			expect(res?.commitCount).toBe(1);
+			expect(res?.head.commitHash).toBe("h1");
+		});
+
+		it("skips a summary.json whose commitHash disagrees with the envelope (misrouted payload)", async () => {
+			const storage = makeStorage();
+			bridge.createStorageForRepo.mockResolvedValue({ storage, kbRoot: "/kb" });
+			const res = await run(
+				makeExport({
+					commits: [{ commitHash: "h1", summaryJson: summaryJson({ commitHash: "OTHER" }), attachments: [] }],
+				}),
+			);
+			expect(res).toBeNull(); // the only commit was rejected → no usable summary
+		});
+
+		it("skips a summary.json that parses to a non-object (array / primitive)", async () => {
+			const storage = makeStorage();
+			bridge.createStorageForRepo.mockResolvedValue({ storage, kbRoot: "/kb" });
+			const res = await run(
+				makeExport({ commits: [{ commitHash: "h1", summaryJson: "[1,2,3]", attachments: [] }] }),
+			);
+			expect(res).toBeNull();
+		});
+	});
+
+	it("does not ingest a mismatched summary into the current repo (validation precedes storeSummary)", async () => {
+		bridge.createReadStorageForCurrentRepo.mockResolvedValue(currentRepo(makeStorage()));
+		const res = await run(
+			makeExport({
+				commits: [{ commitHash: "h1", summaryJson: summaryJson({ commitHash: "OTHER" }), attachments: [] }],
+			}),
+		);
+		expect(res).toBeNull();
+		expect(bridge.storeSummary).not.toHaveBeenCalled();
+	});
+
+	// ── Mode 3: no local repo (pure external) → sandbox display, self-contained ─────
+
+	describe("pure external (sandbox import dir)", () => {
+		it("falls back to a per-repo import dir under global storage and does not ingest", async () => {
+			const res = await run(makeExport());
+			expect(res?.ingestedLocally).toBe(false);
+			expect(res?.head.commitHash).toBe("h1");
+			expect(bridge.storeSummary).not.toHaveBeenCalled();
+			expect(FolderStorageMock).toHaveBeenCalledWith("/gs/shared-imports/acme-widgets", expect.anything());
+		});
+
+		it("persists each commit's raw summary JSON so the sandbox is a self-contained copy", async () => {
+			const sandbox = makeStorage();
+			// biome-ignore lint/complexity/useArrowFunction: `new`-ed by the importer — arrows aren't constructible.
+			FolderStorageMock.mockImplementation(function () {
+				return sandbox;
+			});
+			await run(makeExport());
+			const files = sandbox.writeFiles.mock.calls[0][0] as Array<{ path: string; content: string }>;
+			expect(files).toContainEqual({
+				path: "summaries/h1.json",
+				content: summaryJson({ commitHash: "h1" }),
+				branch: "feature/x",
+			});
+		});
+
+		it("refreshes the sandbox on re-visit — overwrites freely, no existence probe", async () => {
+			const sandbox = makeStorage(["plans/plan-a.md"]);
+			// biome-ignore lint/complexity/useArrowFunction: `new`-ed by the importer — arrows aren't constructible.
+			FolderStorageMock.mockImplementation(function () {
+				return sandbox;
+			});
+			await run(
+				makeExport({
+					commits: [
+						{
+							commitHash: "h1",
+							summaryJson: summaryJson({ commitHash: "h1", plans: [{ slug: "plan-a", title: "Plan A" }] }),
+							attachments: [{ title: "Plan A", body: "UPDATED SHARE BODY" }],
+						},
+					],
+				}),
+			);
+			expect(sandbox.listFiles).not.toHaveBeenCalled();
+			const files = sandbox.writeFiles.mock.calls[0][0] as Array<{ path: string; content: string }>;
+			expect(files).toContainEqual({ path: "plans/plan-a.md", content: "# Plan A\n\nUPDATED SHARE BODY", branch: "feature/x" });
+			expect(files).toContainEqual({
+				path: "summaries/h1.json",
+				content: summaryJson({ commitHash: "h1", plans: [{ slug: "plan-a", title: "Plan A" }] }),
+				branch: "feature/x",
+			});
+		});
+
+		it("slugs an all-punctuation repo name to 'repo' for the import dir", async () => {
+			await run(makeExport({ repoName: "///" }));
+			expect(FolderStorageMock).toHaveBeenCalledWith("/gs/shared-imports/repo", expect.anything());
+		});
+
+		it("neutralizes a '.'/'..' repo name so the import dir can't escape shared-imports/", async () => {
+			// A crafted repoName of "." or ".." would otherwise survive as a path segment and
+			// join() would resolve OUT of the per-repo sandbox (".." → the parent dir).
+			await run(makeExport({ repoName: ".." }));
+			expect(FolderStorageMock).toHaveBeenCalledWith("/gs/shared-imports/repo", expect.anything());
+			FolderStorageMock.mockClear();
+			await run(makeExport({ repoName: "." }));
+			expect(FolderStorageMock).toHaveBeenCalledWith("/gs/shared-imports/repo", expect.anything());
+		});
+	});
+
+	it("writes distinct bodies when a commit carries two docs sharing a title", async () => {
+		// bodies keyed by title are consumed as an in-order queue, so two same-titled plans
+		// don't collapse to one (last-write-wins) body.
+		const storage = makeStorage();
+		bridge.createStorageForRepo.mockResolvedValue({ storage, kbRoot: "/kb" });
+		await run(
+			makeExport({
+				commits: [
+					{
+						commitHash: "h1",
+						summaryJson: summaryJson({
+							commitHash: "h1",
+							plans: [
+								{ slug: "plan-a", title: "Notes" },
+								{ slug: "plan-b", title: "Notes" },
+							],
+						}),
+						attachments: [
+							{ title: "Notes", body: "FIRST" },
+							{ title: "Notes", body: "SECOND" },
+						],
+					},
+				],
+			}),
+		);
+		const files = storage.writeFiles.mock.calls[0][0] as Array<{ path: string; content: string }>;
+		expect(files).toContainEqual({ path: "plans/plan-a.md", content: "# Notes\n\nFIRST", branch: "feature/x" });
+		expect(files).toContainEqual({ path: "plans/plan-b.md", content: "# Notes\n\nSECOND", branch: "feature/x" });
+	});
+
+	// ── Untrusted path-segment hardening (slug / id / commitHash traversal) ─────────
+	describe("rejects unsafe path segments from the /export payload", () => {
+		/** Grab the paths handed to writeFiles across all calls (empty if none). */
+		function writtenPaths(storage: FakeStorage): string[] {
+			return storage.writeFiles.mock.calls.flatMap(call => (call[0] as Array<{ path: string }>).map(f => f.path));
+		}
+
+		it("drops a plan whose slug would traverse out of the per-repo bank", async () => {
+			const storage = makeStorage();
+			bridge.createStorageForRepo.mockResolvedValue({ storage, kbRoot: "/kb" });
+			await run(
+				makeExport({
+					commits: [
+						{
+							commitHash: "h1",
+							summaryJson: summaryJson({
+								commitHash: "h1",
+								plans: [
+									{ slug: "../../../otherRepo/.jolli/plans/pwn", title: "Evil" },
+									{ slug: "plan-a", title: "Good" },
+								],
+							}),
+							attachments: [
+								{ title: "Evil", body: "EVIL" },
+								{ title: "Good", body: "GOOD" },
+							],
+						},
+					],
+				}),
+			);
+			const paths = writtenPaths(storage);
+			expect(paths).toContain("plans/plan-a.md");
+			expect(paths.some(p => p.includes(".."))).toBe(false);
+		});
+
+		it("drops a note whose id would traverse, keeps the safe note", async () => {
+			const storage = makeStorage();
+			bridge.createStorageForRepo.mockResolvedValue({ storage, kbRoot: "/kb" });
+			await run(
+				makeExport({
+					commits: [
+						{
+							commitHash: "h1",
+							summaryJson: summaryJson({
+								commitHash: "h1",
+								notes: [
+									{ id: "../../evil", title: "Evil", format: "markdown" },
+									{ id: "n1", title: "Note 1", format: "markdown" },
+								],
+							}),
+							attachments: [
+								{ title: "Evil", body: "EVIL" },
+								{ title: "Note 1", body: "OK" },
+							],
+						},
+					],
+				}),
+			);
+			const paths = writtenPaths(storage);
+			expect(paths).toContain("notes/n1.md");
+			expect(paths.some(p => p.includes(".."))).toBe(false);
+		});
+
+		it("rejects a commit whose envelope commitHash is unsafe (would traverse the sandbox summaries path)", async () => {
+			const res = await run(
+				makeExport({
+					headCommitHash: "h1",
+					commits: [
+						{ commitHash: "../../../etc/pwn", summaryJson: summaryJson({ commitHash: "h1" }), attachments: [] },
+						{ commitHash: "h1", summaryJson: summaryJson({ commitHash: "h1" }), attachments: [] },
+					],
+				}),
+			);
+			expect(res?.commitCount).toBe(1);
+			expect(res?.head.commitHash).toBe("h1");
+		});
+
+		it("does not throw when a commit element is missing its commitHash entirely", async () => {
+			// A truncated /export element with no commitHash reached `commitHash.slice(…)` before.
+			const commits = [
+				{ summaryJson: "{not json", attachments: [] },
+				{ commitHash: "h1", summaryJson: summaryJson({ commitHash: "h1" }), attachments: [] },
+			] as unknown as SharedBranchExport["commits"];
+			const res = await run(makeExport({ headCommitHash: "h1", commits }));
+			expect(res?.commitCount).toBe(1);
+		});
+
+		it("skips null / non-object plan and note entries without throwing", async () => {
+			const storage = makeStorage();
+			bridge.createStorageForRepo.mockResolvedValue({ storage, kbRoot: "/kb" });
+			const res = await run(
+				makeExport({
+					commits: [
+						{
+							commitHash: "h1",
+							summaryJson: JSON.stringify({
+								version: 4,
+								commitHash: "h1",
+								commitMessage: "m",
+								branch: "feature/x",
+								plans: [null, "loose-string", { slug: "plan-a", title: "Good" }],
+								notes: [null, 42],
+							}),
+							attachments: [{ title: "Good", body: "GOOD" }],
+						},
+					],
+				}),
+			);
+			expect(res?.commitCount).toBe(1);
+			const paths = writtenPaths(storage);
+			expect(paths).toEqual(["plans/plan-a.md"]);
+		});
+
+		it("skips a valid-id note that has no resolvable body", async () => {
+			const storage = makeStorage();
+			bridge.createStorageForRepo.mockResolvedValue({ storage, kbRoot: "/kb" });
+			await run(
+				makeExport({
+					commits: [
+						{
+							commitHash: "h1",
+							// note id is safe, but no attachment matches its title and it carries no inline content
+							summaryJson: summaryJson({ commitHash: "h1", notes: [{ id: "n1", title: "Orphan", format: "markdown" }] }),
+							attachments: [],
+						},
+					],
+				}),
+			);
+			expect(storage.writeFiles).not.toHaveBeenCalled();
+		});
+
+		it("tolerates a non-array plans/notes value instead of throwing on for..of", async () => {
+			const storage = makeStorage();
+			bridge.createStorageForRepo.mockResolvedValue({ storage, kbRoot: "/kb" });
+			const res = await run(
+				makeExport({
+					commits: [
+						{
+							commitHash: "h1",
+							summaryJson: JSON.stringify({
+								version: 4,
+								commitHash: "h1",
+								commitMessage: "m",
+								branch: "feature/x",
+								plans: 123,
+								notes: "oops",
+							}),
+							attachments: [],
+						},
+					],
+				}),
+			);
+			expect(res?.commitCount).toBe(1);
+			expect(storage.writeFiles).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/vscode/src/services/SharedBranchImporter.ts
+++ b/vscode/src/services/SharedBranchImporter.ts
@@ -1,0 +1,369 @@
+import { join } from "node:path";
+import type * as vscode from "vscode";
+import type { CommitSummary, FileWrite } from "../../../cli/src/Types.js";
+import { FolderStorage } from "../../../cli/src/core/FolderStorage.js";
+import { MetadataManager } from "../../../cli/src/core/MetadataManager.js";
+import type { StorageProvider } from "../../../cli/src/core/StorageProvider.js";
+import type { JolliMemoryBridge } from "../JolliMemoryBridge.js";
+import { sharedRepoIdentityMatches } from "../util/GitRemoteUtils.js";
+import { log } from "../util/Logger.js";
+import type { SharedBranchExport, SharedCommitExport } from "./JolliShareService.js";
+
+/** The materialized shared branch, ready to hand to a {@link SummaryWebviewPanel}. */
+export interface ImportedSharedBranch {
+	/** Storage the panel reads plan/note/transcript fold bodies from. */
+	readonly storage: StorageProvider;
+	/** The head commit's summary — what the panel renders. */
+	readonly head: CommitSummary;
+	/** How many commits carried a usable structured summary. */
+	readonly commitCount: number;
+	/**
+	 * True when the share was ingested into the CURRENTLY-OPEN repo's memory (via
+	 * `storeSummary` — index.json + catalog + orphan branch), so `recall`/`search`
+	 * for the shared branch now surface it, and `head` is a first-class local summary.
+	 * The caller renders a normal writable local panel instead of the read-only shared
+	 * view. False for the pure-external sandbox case (display-only, not recallable).
+	 */
+	readonly ingestedLocally: boolean;
+}
+
+/**
+ * Whether an untrusted `/export` field is safe to interpolate into a write path — i.e. a
+ * single filesystem segment: a non-empty `[A-Za-z0-9._-]` string that is neither `.` nor
+ * `..` (both would otherwise pass the char class). This is the SharedBranchImporter twin of
+ * {@link KbFoldersService.validateRelPath}: the backend that produces `slug` / `note.id` /
+ * `commitHash` lives in a separate repo, so plugin-side validation is the trust boundary
+ * that keeps a hostile value like `../../otherRepo/.jolli/plans/pwn` out of the write path.
+ *
+ * The `FolderStorage` symlink guard does NOT backstop this: its containment check is anchored
+ * at `<localFolder>` (`dirname` of the per-repo root), so a `..` that stays inside the Memory
+ * Bank folder but escapes the current repo sails through and can clobber a SIBLING repo's bank.
+ * `generatePlanMarkdown` re-derives the slug from the write path, so validating here also
+ * covers the visible `<branch>/plan--<slug>.md` layer, not just the hidden `plans/<slug>.md`.
+ */
+function isSafeSegment(value: unknown): value is string {
+	return typeof value === "string" && value.length > 0 && value !== "." && value !== ".." && /^[A-Za-z0-9._-]+$/.test(value);
+}
+
+/** Read `field` off an untrusted object and return it only when it is a safe path segment. */
+function safeSegmentField(obj: unknown, field: "slug" | "id"): string | null {
+	if (typeof obj !== "object" || obj === null) return null;
+	const value = (obj as Record<string, unknown>)[field];
+	return isSafeSegment(value) ? value : null;
+}
+
+/** Sanitize a repo name into a filesystem-safe directory segment for the fallback import dir. */
+function slugForDir(repoName: string): string {
+	const slug = repoName
+		.replace(/[^a-zA-Z0-9._-]+/g, "-")
+		// Strip leading/trailing dots too, so a name of "." / ".." can't survive as a
+		// path segment that escapes the import root (join(root, "..") → the parent dir).
+		.replace(/^[.-]+|[.-]+$/g, "")
+		.toLowerCase();
+	return slug || "repo";
+}
+
+/**
+ * Parse + validate one commit's sanitized summary.json. Returns null (and logs) when the
+ * envelope `commitHash` is missing/unsafe, or when the body is absent, unparseable, not an
+ * object, or its `commitHash` is missing / unsafe / disagrees with the envelope's. `/export`
+ * only guarantees `commits` is an array — a truncated or misrouted payload can carry an
+ * element with no `commitHash` (so `commitHash.slice(…)` would throw a raw TypeError) or a
+ * body like `"{}"` that parses fine but has no `commitHash`. Since the ingest path keys the
+ * index by `commitHash` (`storeSummary`), the panel keys its map the same way, and the
+ * sandbox path writes `summaries/<commitHash>.json`, the hash must be both present and a safe
+ * path segment: an unvalidated cast would index/render under `undefined` or let a hostile hash
+ * traverse the write path. Requiring the inner hash to equal the (validated) envelope hash the
+ * backend routed by rejects the mismatch cases too.
+ */
+function parseCommitSummary(commit: SharedCommitExport): CommitSummary | null {
+	if (!isSafeSegment(commit.commitHash)) {
+		log.warn("SharedBranchImporter", `skipping commit — missing or unsafe commitHash (${String(commit.commitHash)})`);
+		return null;
+	}
+	if (!commit.summaryJson) {
+		return null;
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(commit.summaryJson);
+	} catch {
+		log.warn("SharedBranchImporter", `skipping commit ${commit.commitHash.slice(0, 8)} — unparseable summary.json`);
+		return null;
+	}
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		log.warn("SharedBranchImporter", `skipping commit ${commit.commitHash.slice(0, 8)} — summary.json is not an object`);
+		return null;
+	}
+	const summary = parsed as CommitSummary;
+	if (summary.commitHash !== commit.commitHash) {
+		log.warn(
+			"SharedBranchImporter",
+			`skipping commit ${commit.commitHash.slice(0, 8)} — summary.json commitHash mismatch (${String(summary.commitHash)})`,
+		);
+		return null;
+	}
+	return summary;
+}
+
+/**
+ * Reconstruct plan/note body files for one commit so the panel's folds resolve. The
+ * export ships attachment bodies keyed by title (the doc's first heading); the structured
+ * summary carries the plan slugs / note ids. Match by title (they share the same source
+ * heading) and write `plans/<slug>.md` / `notes/<id>.md` in the doc's original shape.
+ * Snippet notes carry their body inline (`NoteReference.content`) and need no file.
+ *
+ * `plans` / `notes` are treated as untrusted: a non-array value is coerced to empty (a raw
+ * `for..of` over `123` would throw), and each `slug` / `id` must be a safe path segment
+ * ({@link isSafeSegment}) before it reaches the write path — a hostile `slug` could otherwise
+ * traverse out of the per-repo bank (see the isSafeSegment docstring for why the vault guard
+ * doesn't catch it).
+ *
+ * Files land in a path-keyed map: a slug referenced by several commits resolves to one
+ * entry, and the caller feeds the head commit last so its body wins the duplicate.
+ */
+function collectAttachmentFiles(
+	commit: SharedCommitExport,
+	summary: CommitSummary,
+	branch: string,
+	files: Map<string, FileWrite>,
+): void {
+	// Bodies are keyed by title (the doc's first heading), but a commit can carry two
+	// docs sharing a title — so consume them as an in-order queue per title instead of a
+	// last-write-wins Map, or the second same-titled doc would steal the first's body.
+	const bodiesByTitle = new Map<string, string[]>();
+	for (const a of commit.attachments) {
+		const queue = bodiesByTitle.get(a.title);
+		if (queue) queue.push(a.body);
+		else bodiesByTitle.set(a.title, [a.body]);
+	}
+	const takeBody = (title: string): string | undefined => bodiesByTitle.get(title)?.shift();
+	for (const plan of Array.isArray(summary.plans) ? summary.plans : []) {
+		const slug = safeSegmentField(plan, "slug");
+		if (slug === null) {
+			log.warn("SharedBranchImporter", `skipping plan with missing or unsafe slug (${String(plan?.slug)})`);
+			continue;
+		}
+		const body = takeBody(plan.title);
+		if (body !== undefined) {
+			const path = `plans/${slug}.md`;
+			files.set(path, { path, content: `# ${plan.title}\n\n${body}`, branch });
+		}
+	}
+	for (const note of Array.isArray(summary.notes) ? summary.notes : []) {
+		const id = safeSegmentField(note, "id");
+		if (id === null) {
+			log.warn("SharedBranchImporter", `skipping note with missing or unsafe id (${String(note?.id)})`);
+			continue;
+		}
+		const body = note.content ?? takeBody(note.title);
+		if (body !== undefined) {
+			const path = `notes/${id}.md`;
+			files.set(path, { path, content: `# ${note.title}\n\n${body}`, branch });
+		}
+	}
+}
+
+/** Zero-fill a missing root `diffStats` so `storeSummary`'s `flattenSummaryTree` skips the
+ * `getDiffStats` (`git diff <hash>^..<hash>`) fallback on a commit the recipient's checkout
+ * may not even have. `flattenSummaryTree` still calls `getTreeHash` per node unconditionally,
+ * but that degrades gracefully (returns null for a commit not in the object store → the index
+ * entry is simply written without a `treeHash`); it is the `git diff` that this guards. */
+function ensureDiffStats(summary: CommitSummary): CommitSummary {
+	if (summary.diffStats) return summary;
+	return { ...summary, diffStats: { filesChanged: 0, insertions: 0, deletions: 0 } };
+}
+
+/** Read + parse a summary JSON from a storage; null (and log) on absence/parse error. */
+async function readStoredSummary(storage: StorageProvider, commitHash: string): Promise<CommitSummary | null> {
+	const json = await storage.readFile(`summaries/${commitHash}.json`);
+	if (!json) return null;
+	try {
+		return JSON.parse(json) as CommitSummary;
+	} catch {
+		log.warn("SharedBranchImporter", `local summary for ${commitHash.slice(0, 8)} is unparseable`);
+		return null;
+	}
+}
+
+/**
+ * The head summary to render, local-authoritative-first: the target bank's own copy when it
+ * pre-exists (a superset of the lossy export), else the just-parsed export head, else the
+ * first parsed commit. Shared by the ingest and display-only paths so the precedence stays
+ * one contract. `summaryByHash` is non-empty by the time this runs.
+ */
+async function resolveHeadSummary(
+	storage: StorageProvider,
+	data: SharedBranchExport,
+	summaryByHash: Map<string, CommitSummary>,
+): Promise<CommitSummary> {
+	return (
+		(await readStoredSummary(storage, data.headCommitHash)) ??
+		summaryByHash.get(data.headCommitHash) ??
+		[...summaryByHash.values()][0]
+	);
+}
+
+/** Collect plan/note fold bodies for every parsed commit, head last so its body wins a
+ * slug shared across commits. */
+function collectAllAttachmentFiles(
+	data: SharedBranchExport,
+	summaryByHash: Map<string, CommitSummary>,
+): Map<string, FileWrite> {
+	const files = new Map<string, FileWrite>();
+	const ordered = [...data.commits].sort((a, b) =>
+		Number(a.commitHash === data.headCommitHash) - Number(b.commitHash === data.headCommitHash),
+	);
+	for (const commit of ordered) {
+		const summary = summaryByHash.get(commit.commitHash);
+		if (summary) collectAttachmentFiles(commit, summary, data.branch, files);
+	}
+	return files;
+}
+
+/**
+ * Materialize a downloaded shared branch, in one of three modes keyed on where the
+ * recipient stands relative to the share's repo. Returns null when no commit carried a
+ * usable structured summary (e.g. a legacy share with no sidecar).
+ *
+ * 1. **Currently-open repo** (`ingestedLocally: true`) — the share is for the repo the
+ *    recipient has open. Each commit they don't already have is REALLY ingested via
+ *    `bridge.storeSummary` (force=false → the commitHash duplicate guard skips ones they
+ *    have under any branch, so their authoritative copy is never clobbered), which writes
+ *    the summary + index.json + catalog on the orphan branch (system of record) + folder.
+ *    That is what makes `recall <branch>` / `search` surface the shared content — the
+ *    whole point of importing. Plan/note fold bodies are filled into the repo's folder
+ *    (gaps only) and the caller renders a normal writable local panel.
+ *
+ *    Caveat: this requires the folder layer. Under `storageMode === "orphan"`
+ *    `createReadStorageForCurrentRepo` returns null, so an orphan-only user opening a share
+ *    of their OWN repo silently falls through to mode 3 (read-only sandbox) and the share is
+ *    never indexed for recall/search. Acceptable today (fold bodies need the folder), but a
+ *    known capability gap, not a repo-identity decision.
+ *
+ * 2. **Foreign local repo, not open** — a discovered bank for a different repo. recall /
+ *    search are scoped to the active repo, so ingesting here buys nothing until it's
+ *    opened, and `storeSummary` would need that repo's own cwd/lock. Treated as display-
+ *    only: fill plan/note gaps into its folder, render read-only foreign.
+ *
+ * 3. **No local repo** (pure external recipient) — a dedicated import dir under the
+ *    extension's global storage, OUTSIDE the Memory-Bank discovery namespace (so it never
+ *    masquerades as a real repo, and stays invisible to recall/search — there is no repo
+ *    context to search it within). Holds nothing but share copies, so plan/note bodies AND
+ *    the raw summary JSON are written and overwritten freely (single-slot re-visits stay
+ *    fresh), making the dir a self-contained re-openable copy. Rendered read-only.
+ *
+ * Local-authoritative-first for display in modes 2/3: when the target bank already holds
+ * the head summary, `head` is that (superset) local copy, not the export's lossy one.
+ */
+export async function importSharedBranchForDisplay(
+	data: SharedBranchExport,
+	bridge: JolliMemoryBridge,
+	context: vscode.ExtensionContext,
+): Promise<ImportedSharedBranch | null> {
+	const summaryByHash = new Map<string, CommitSummary>();
+	for (const commit of data.commits) {
+		const summary = parseCommitSummary(commit);
+		if (summary) summaryByHash.set(commit.commitHash, summary);
+	}
+	if (summaryByHash.size === 0) return null;
+
+	// createStorageForRepo is foreign-only (it skips the isCurrentRepo entry), so a share
+	// of the repo the recipient has open needs the current-repo lookup, gated on an
+	// identity check so a share of some OTHER repo never lands in the current repo's bank.
+	const foreign = await bridge.createStorageForRepo(data.repoName, data.repoUrl);
+	if (foreign) {
+		return await importDisplayOnly(data, summaryByHash, foreign.storage);
+	}
+	const current = await bridge.createReadStorageForCurrentRepo();
+	if (current && sharedRepoIdentityMatches(data.repoName, data.repoUrl, current.repoName, current.remoteUrl)) {
+		return await ingestIntoCurrentRepo(data, summaryByHash, bridge, current.storage);
+	}
+
+	// Pure external: sandbox dir under global storage, outside the discovery namespace.
+	const importRoot = join(context.globalStorageUri.fsPath, "shared-imports", slugForDir(data.repoName));
+	const sandbox = new FolderStorage(importRoot, new MetadataManager(join(importRoot, ".jolli")));
+	return await importDisplayOnly(data, summaryByHash, sandbox, { persistSummaries: true, overwrite: true });
+}
+
+/**
+ * Mode 1: really ingest the commits the recipient lacks into the currently-open repo so
+ * `recall`/`search` find them, then hand back the local writable view.
+ */
+async function ingestIntoCurrentRepo(
+	data: SharedBranchExport,
+	summaryByHash: Map<string, CommitSummary>,
+	bridge: JolliMemoryBridge,
+	folderStorage: StorageProvider,
+): Promise<ImportedSharedBranch> {
+	let ingested = 0;
+	for (const summary of summaryByHash.values()) {
+		// force=false: the commitHash duplicate guard keeps the recipient's own summary
+		// (under whatever branch) instead of overwriting it with the lossy export.
+		await bridge.storeSummary(ensureDiffStats(summary), false);
+		ingested++;
+	}
+	log.info("SharedBranchImporter", `ingested ${ingested} shared commit(s) into the current repo for recall/search`);
+
+	// Plan/note fold bodies → the repo's folder (gaps only): the writable panel reads
+	// folds from this same folder storage (the sidebar's local-commit path does the same).
+	const files = collectAllAttachmentFiles(data, summaryByHash);
+	if (files.size > 0) {
+		const existing = new Set([
+			...(await folderStorage.listFiles("plans")),
+			...(await folderStorage.listFiles("notes")),
+		]);
+		const toWrite = [...files.values()].filter(f => !existing.has(f.path));
+		if (toWrite.length > 0) await folderStorage.writeFiles(toWrite, "shared branch import (plan/note bodies)");
+	}
+
+	// Prefer whatever authoritative summary now backs the head (the recipient's own if it
+	// pre-existed, else the just-ingested one).
+	const head = await resolveHeadSummary(folderStorage, data, summaryByHash);
+	return { storage: folderStorage, head, commitCount: summaryByHash.size, ingestedLocally: true };
+}
+
+/**
+ * Modes 2/3: no ingest — write plan/note fold bodies (and, for the sandbox, the raw
+ * summary JSON) into `storage`, then render read-only. `fillGaps` protects a real bank's
+ * existing files; the sandbox overwrites freely.
+ */
+async function importDisplayOnly(
+	data: SharedBranchExport,
+	summaryByHash: Map<string, CommitSummary>,
+	storage: StorageProvider,
+	opts: { persistSummaries?: boolean; overwrite?: boolean } = {},
+): Promise<ImportedSharedBranch> {
+	const files = collectAllAttachmentFiles(data, summaryByHash);
+	if (opts.persistSummaries) {
+		// Sandbox only: raw summary JSON makes the dir a self-contained re-openable copy.
+		for (const commit of data.commits) {
+			if (summaryByHash.has(commit.commitHash) && commit.summaryJson) {
+				files.set(`summaries/${commit.commitHash}.json`, {
+					path: `summaries/${commit.commitHash}.json`,
+					content: commit.summaryJson,
+					branch: data.branch,
+				});
+			}
+		}
+	}
+	if (files.size > 0) {
+		let toWrite = [...files.values()];
+		if (!opts.overwrite) {
+			// Real bank: fill gaps only — the local authoritative version always wins.
+			const existing = new Set([...(await storage.listFiles("plans")), ...(await storage.listFiles("notes"))]);
+			toWrite = toWrite.filter(f => !existing.has(f.path));
+			if (toWrite.length < files.size) {
+				log.info(
+					"SharedBranchImporter",
+					`kept ${files.size - toWrite.length} existing local file(s) — the share only fills gaps`,
+				);
+			}
+		}
+		if (toWrite.length > 0) await storage.writeFiles(toWrite, "shared branch import (display)");
+	}
+
+	// Local-authoritative-first: show the bank's own head summary over the lossy import.
+	const head = await resolveHeadSummary(storage, data, summaryByHash);
+	return { storage, head, commitCount: summaryByHash.size, ingestedLocally: false };
+}

--- a/vscode/src/util/GitRemoteUtils.ts
+++ b/vscode/src/util/GitRemoteUtils.ts
@@ -18,5 +18,7 @@ export {
 	deriveRepoNameFromUrl,
 	getCanonicalRepoUrl,
 	normalizeRemoteUrl,
+	sameCanonicalRemote,
 	sanitizeBranchSlug,
+	sharedRepoIdentityMatches,
 } from "../../../cli/src/core/GitRemoteUtils.js";

--- a/vscode/src/views/SummaryScriptBuilder.test.ts
+++ b/vscode/src/views/SummaryScriptBuilder.test.ts
@@ -52,10 +52,56 @@ describe("SummaryScriptBuilder", () => {
 	it("preserves the user's picked access tier across a linkless re-render (no revert to the org default)", () => {
 		// Regression: selecting "people" before a link exists must not snap the dropdown
 		// back to the org default (which a later Copy would mint as an org-wide link).
+		// Fallback order: user's explicit pick → the branch's last-used tier (defaults,
+		// seeded when an amend re-keyed the previous subject) → org/people default.
 		expect(script).toContain("shareUserPickedTier = v;");
-		expect(script).toContain("shareUserPickedTier || (shareCanOrg ? 'org' : 'people')");
+		expect(script).toContain(
+			"shareUserPickedTier || (shareDefaults && shareDefaults.visibility) || (shareCanOrg ? 'org' : 'people')",
+		);
 		// The old unconditional revert must be gone.
 		expect(script).not.toContain("shareAccessSelect.value = shareLink ? shareLink.visibility : (shareCanOrg ? 'org' : 'people')");
+		expect(() => new Function(script)).not.toThrow();
+	});
+
+	it("resets the in-session picked tier on open so it can't leak into the next subject", () => {
+		// Issue #5: shareUserPickedTier is per-open state; a tier picked on one subject
+		// must not shadow the next subject's seeded default. shareOpen clears it.
+		const openBody = script.slice(script.indexOf("function shareOpen(kind)"), script.indexOf("function shareClose()"));
+		expect(openBody).toContain("shareUserPickedTier = '';");
+		expect(() => new Function(script)).not.toThrow();
+	});
+
+	it("clamps a seeded 'org' tier to 'people' when the current key has no org capability", () => {
+		// Issue #6: a prior share's 'org' default (or a stale picked tier) is invalid when
+		// shareCanOrg is false (org <option> hidden+disabled) — seeding it would leave the
+		// select on an unrepresentable tier and a later Copy would mint an org link the key
+		// can't back. The clamp downgrades it to 'people'.
+		expect(script).toContain("if (seededTier === 'org' && !shareCanOrg) { seededTier = 'people'; }");
+		expect(() => new Function(script)).not.toThrow();
+	});
+
+	it("shows an existing link's tier verbatim — the org→people clamp is seed-only", () => {
+		// A real link renders its actual visibility; clamping it would mislabel a live 'org'
+		// link as 'people' if the key's org capability later lapsed. The clamp lives in the
+		// no-link (seed) branch only, AFTER the real-link assignment.
+		expect(script).toContain("seededTier = shareLink.visibility;");
+		const clampIdx = script.indexOf("if (seededTier === 'org' && !shareCanOrg)");
+		const linkTierIdx = script.indexOf("seededTier = shareLink.visibility;");
+		expect(linkTierIdx).toBeGreaterThanOrEqual(0);
+		expect(clampIdx).toBeGreaterThan(linkTierIdx);
+		expect(() => new Function(script)).not.toThrow();
+	});
+
+	it("restores the branch's last-used people ONCE per open (staged in invite mode, nothing auto-granted)", () => {
+		// A subject with no link but last-used defaults (amend re-keyed the previous
+		// commit share) prefills the previous recipients as staged invitees and enters
+		// invite mode — a single Send re-grants them; Cancel drops to the main pane.
+		expect(script).toContain("shareDefaults = state.defaults || null;");
+		expect(script).toContain("shareDefaultsPrefilled = true;");
+		expect(script).toContain("shareDefaults.recipients.forEach(function(e) { shareStagePending(e); });");
+		// One prefill per modal open: the flag resets when the modal opens.
+		const openBody = script.slice(script.indexOf("function shareOpen(kind)"), script.indexOf("function shareClose()"));
+		expect(openBody).toContain("shareDefaultsPrefilled = false;");
 		expect(() => new Function(script)).not.toThrow();
 	});
 

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -209,6 +209,11 @@ export function buildScript(options: SummaryScriptOptions = {}): string {
   // shares) and returns 'ready' — nothing is created until Copy / invite / org-on.
   function shareOpen(kind) {
     if (!shareOverlay) { return; }
+    shareDefaultsPrefilled = false;
+    // The explicit tier pick is in-session only — it must NOT leak into the next open of
+    // a different subject (which has its own link tier / prior default). Without this, a
+    // 'people' picked here would shadow the next subject's seeded default (issue #5).
+    shareUserPickedTier = '';
     shareKind = (kind === 'branch') ? 'branch' : 'commit';
     // Text only — the share glyph is a sibling SVG in the modal head, so setting
     // textContent here must not wipe it.
@@ -256,6 +261,8 @@ export function buildScript(options: SummaryScriptOptions = {}): string {
   var shareOwnerName = '';
   var shareInvitePending = [];       // emails staged in the invite pane, sent on "Send invite"
   var shareUserPickedTier = '';      // the access tier the user explicitly chose (preserved across re-renders while no link exists)
+  var shareDefaults = null;          // last-used {visibility, recipients[]} for a subject with no link (amend re-keyed it)
+  var shareDefaultsPrefilled = false; // one prefill per modal open — a later ready re-render must not re-stage removed people
   function shareSetSyncBadge(mode) {
     var badge = document.getElementById('shareSyncBadge');
     if (!badge) { return; }
@@ -668,18 +675,48 @@ export function buildScript(options: SummaryScriptOptions = {}): string {
       orgOption.hidden = !shareCanOrg;
       orgOption.textContent = 'Anyone within your Jolli Account';
     }
+    shareDefaults = state.defaults || null;
     // Preselect the access that matches the existing link's tier. With no link yet,
     // keep whatever tier the user explicitly picked (so selecting "people" isn't
-    // reverted to the org default and later Copy-minted as an org link); on the first
-    // render (nothing picked) fall back to org — or "only people you add" without an
-    // org-carrying key — so a public (anyone-with-link) share is always explicit.
+    // reverted to the org default and later Copy-minted as an org link); then the
+    // branch's last-used tier (the previous subject was re-keyed by an amend); on the
+    // first render (nothing picked, no history) fall back to org — or "only people
+    // you add" without an org-carrying key — so a public share is always explicit.
     if (shareAccessSelect) {
-      shareAccessSelect.value = shareLink
-        ? shareLink.visibility
-        : (shareUserPickedTier || (shareCanOrg ? 'org' : 'people'));
+      var seededTier;
+      if (shareLink) {
+        // A real link: show its actual tier verbatim — never clamp, or an existing org
+        // link would misrender as 'people' if the key's org capability later lapsed.
+        seededTier = shareLink.visibility;
+      } else {
+        seededTier = shareUserPickedTier || (shareDefaults && shareDefaults.visibility) || (shareCanOrg ? 'org' : 'people');
+        // Clamp only the SEEDED (no-link) tier to what THIS key can back: a seeded 'org'
+        // from a prior share (or a stale picked tier) is invalid when the current key has
+        // no org — the org <option> is hidden+disabled, so 'org' would leave the select on a
+        // tier the UI can't represent and a later Copy/mint would use an org tier the key
+        // can't carry. Fall to 'people'.
+        if (seededTier === 'org' && !shareCanOrg) { seededTier = 'people'; }
+      }
+      shareAccessSelect.value = seededTier;
     }
     shareSyncAccessUi();
     shareRenderInvited();
+    // No link but the branch has last-used people (the previous commit share's subject
+    // was stranded by an amend): restore them ONCE per open — staged in invite mode so a
+    // single "Send invite" re-grants everyone on the fresh link. Cancel drops to the
+    // normal main pane; nothing is granted until the user sends.
+    if (!shareLink && !shareDefaultsPrefilled && shareDefaults
+        && shareDefaults.recipients && shareDefaults.recipients.length > 0) {
+      shareDefaultsPrefilled = true;
+      shareInvitePending = [];
+      shareDefaults.recipients.forEach(function(e) { shareStagePending(e); });
+      var prefillSearch = document.getElementById('shareTeammateSearch');
+      if (prefillSearch) { prefillSearch.value = ''; }
+      shareHideSuggests();
+      shareSetSyncBadge('hide');
+      shareInviteEnter();
+      return;
+    }
     // A ready render always lands on the main pane: drop any staged-but-unsent
     // invitees (a completed send re-renders here too) and reset the search box.
     shareInvitePending = [];


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The "Open in VS Code" button on shared branch pages now works for all share visibility tiers — public, org-restricted, and people-restricted — and the content it delivers is no longer display-only. When a recipient opens a share link for a repository they already have active in the editor, each commit in the share is written into that repository's memory index and becomes findable through recall and search commands. Content the recipient already has is left untouched; only the gaps are filled. For recipients who do not have the repository locally, the previous display-only behavior continues, with shared content stored in a self-contained sandbox that persists across sessions.

The share invite flow received several reliability improvements. When share link creation fails, users now see the actual reason — whether that is an account binding problem, nothing to share, or a backend error — directly in the toast notification, replacing a vague hardcoded guess. The org-member suggestion list in the share popover can now recover automatically from soft failures: empty results from the backend are no longer cached, so the list repopulates on the next fetch once the backend returns real data. Share invite emails now include a one-line description drawn from the branch's latest recap or commit message, which had been blank since the feature launched.

When a user amends a commit and reopens the share modal, the previously chosen access tier and invited recipients are pre-populated automatically. The lookup that finds the previous record now filters out expired shares and shares from a different scope, preventing a single click from re-granting access that had intentionally lapsed or duplicating access already granted through a branch-wide share. The access tier dropdown no longer carries over a choice made on a previous subject, and it no longer silently selects an organization-wide option when the current account does not support that tier.

Two security gaps in the share flow were closed. The export endpoint no longer returns the full remote repository URL to callers holding only a public share link — the URL is withheld and only the repository name is returned, consistent with what the web share page already showed. The share deep link handler now rejects links that omit the origin parameter entirely, treating a missing origin as a hard failure rather than a pass-through.

---

## Topics (10)
<details>
<summary><strong>01 · Shared branch memory now imports into local recall and search index</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user received a shared branch link and opened it in the editor, the imported content was display-only: it could be viewed in a panel but could not be found through recall or search commands. The design intent was that shared content for a repository the recipient already has open should join that repository's memory and be discoverable.

**💡 Decisions Behind the Code**

- **Ingest unit is branch, not commit hash**: Recall and search are scoped by branch, and a commit can exist in the recipient's local history under a different branch. Checking whether a commit hash already exists would incorrectly skip ingestion when the recipient has the commit on `main` but not on the shared feature branch. Using `force=false` with the store's commit-hash duplicate guard gives the right behavior: the branch triggers the import decision, and the guard prevents overwriting any commit the recipient already has under any branch.
- **Global storage sandbox stays outside the discovery namespace**: Placing imported content inside the Memory Bank folder structure would cause the discovery scanner to treat it as a real repository, potentially matching it as the authoritative source for future imports or local operations. Keeping the sandbox in global storage — a location the scanner never reads — ensures imported content from repositories the user does not have locally never contaminates their real memory banks.
- **Fill gaps only in real Memory Banks, always overwrite fallback storage**: The existence check protects a recipient's own authoritative local content from being overwritten by a sanitized share reconstruction. That concern does not apply to the fallback import directory, which holds nothing but previous share copies. Applying the same guard there would silently serve stale content on re-visits, so the check is restricted to the real Memory Bank path.
- **Head commit wins on duplicate slugs**: Plan slugs are stable across a branch's history, so multiple commits in a single share often reference the same plan. Picking the head commit's body deterministically by sort order avoids silent last-write-wins behavior that would depend on unpredictable server ordering, and is the version most consistent with what the rendered summary panel shows.
- **Ingest is permanent; revoking a share does not remove ingested content**: Once a shared branch is imported into a recipient's memory, the content belongs to them, analogous to pulling a git branch. Tracking and removing ingested content on revocation would require a reverse-index of all recipients and their ingested commits, adding significant complexity for a security model already defined as "authorization controls access to the share link, not to content already received."

**✅ What Was Implemented**

- Rewrote `SharedBranchImporter.ts` into a three-mode importer. Mode 1 (currently-open repo): each shared commit is ingested via `bridge.storeSummary` with `force=false`, using the existing duplicate guard to skip commits the recipient already has while writing new ones into the index, catalog, and orphan branch — making them findable by recall and search. Mode 2 (foreign local repo, not currently open): display-only with plan/note gap-filling into that repo's folder. Mode 3 (no local repo): a self-contained sandbox directory under global storage, outside the discovery namespace, with both plan/note bodies and raw summary JSON written for re-openability.
- Added `currentRepoMatchesShare` identity verification so a share of one repository never accidentally lands in a different repository's memory bank. The check mirrors existing foreign-repo matching rules: remote URL match or name match qualifies, but when both sides carry a remote URL they must agree.
- Updated `Extension.ts` to open a normal writable local panel (identical to the sidebar's commit view) when the import was ingested locally, reserving the read-only foreign view for display-only imports.
- Refined the gap-fill behavior in `SharedBranchImporter.ts`: existing plan and note files in a discovered local Memory Bank are left untouched; only missing files are written. The fallback global-storage sandbox skips this filter and always overwrites with the freshest share content, so revisiting a share link after its content has been updated always reflects the latest version. Head-commit priority is deterministic — commits are sorted so the head commit is processed last, ensuring its body wins when multiple commits reference the same plan slug.
- Extended `parseCommitSummary` to validate that the parsed value is a non-null, non-array object and that its inner commit identifier matches the envelope's identifier. Mismatched or malformed payloads are skipped with a log warning rather than passed to the ingest path.

**📋 Future Enhancements**

- The "foreign local repo, not currently open" mode (mode 2) is display-only. Making it recallable would require ingesting into a non-active repository's storage, which needs that repository's working directory and write lock. Deferred as a follow-up.
- The panel reuse bug — when a shared branch's head commit hash matches an already-open local panel, the foreign storage context is silently dropped — was identified in review but not fixed in this batch.

**📁 FILES**
- `vscode/src/services/SharedBranchImporter.ts`
- `vscode/src/Extension.ts`
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Plugin opens shared branch memory in VS Code for all share visibility tiers</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The web share page had an "Open in VS Code" button, but clicking it only worked for public shares. Org-restricted and people-restricted shares could not carry enough information for the plugin to download the memory, and there was no plugin-side handler to receive and render the content at all.

**💡 Decisions Behind the Code**

- **Display-first import with no git operations for unknown repos**: The importer deliberately skips the full summary-store pipeline for repos the user has never set up locally — no index update, no git diff, no write lock. Storage is only needed so the panel's fold sections can resolve plan and note bodies. This avoids any risk of corrupting a local repo's memory index with foreign data and keeps the import fast and safe.
- **Token included for all visibility tiers**: The share page already had the token available for org and people shares — it was being withheld from the deep link on the assumption that the editor couldn't use it. Now that the backend export endpoint authenticates via API key rather than browser session, the token is the correct credential for all visibility tiers and should always be included.
- **Partial mock for the share service in extension tests**: The share service is also imported transitively by the share modal UI graph, so a full replacement mock would break unrelated tests. The handler test uses a spread-and-override pattern that preserves all existing exports while replacing only the new functions, keeping the test suite stable without restructuring the module graph.

**✅ What Was Implemented**

- Added `exportSharedBranch` to `JolliShareService.ts`, a typed download client that calls the backend export endpoint using the plugin's API key. The function encodes the share token in the URL path and surfaces non-2xx responses as descriptive errors so the user sees a meaningful toast rather than a raw exception.
- Added a `/share` URI handler branch in `Extension.ts` that validates the origin against the Jolli allowlist, checks for a configured API key (prompting sign-in if absent), calls the download and import pipeline, and opens the result in the appropriate panel. Cross-deployment 404s and other failures surface as error toasts with the original message.
- Fixed `SharePage.tsx` so the deep link token is included for every visibility tier (public, org-restricted, and people-restricted), completing the end-to-end credential flow. A frontend test that previously asserted org and people links did not contain a token was updated to assert the opposite.

**📁 FILES**
- `vscode/src/Extension.ts`
- `vscode/src/services/JolliShareService.ts`
- `frontend/src/ui/share/SharePage.tsx`

</blockquote>
</details>
<details>
<summary><strong>03 · Share modal restores access tier and recipients after amending a commit</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user amended a commit and reopened the share modal, the previously chosen access level and list of invited people were gone. Each amend creates a new share record keyed to the new commit hash, stranding the old record with no way for the modal to recover the user's last choices.

**💡 Decisions Behind the Code**

- **Same-kind filtering over a simpler "latest record" approach**: A branch share and a commit share on the same branch have different scopes — the branch share already grants access to everyone on it, so seeding a commit modal from it and auto-staging those recipients would issue a redundant second grant. Restricting seeds to same-kind records (commit-to-commit only) keeps the pre-fill semantically meaningful: it only carries forward choices from a previous commit share stranded by an amend.
- **Expiry filtering at the call site, not in the store**: The store has no clock and no concept of "now," so filtering expired records there would require injecting a timestamp into a persistence layer that otherwise has none. Applying the liveness check in the modal keeps the store's responsibility narrow and makes the check consistent with how the modal already filters the subject's own record.
- **Seed on open, not on create**: The defaults are surfaced as UI seed values only — no access is granted until the user explicitly acts (Send invite or Copy). This keeps the security model unchanged: an amend does not silently re-grant access to the new commit's share.
- **One prefill per open**: The `shareDefaultsPrefilled` flag is reset each time the modal opens and blocks re-staging on subsequent ready re-renders within the same session. Without this guard, a user who removes a pre-staged person would see them re-appear on the next server round-trip re-render.
- **Reset tier on open rather than on close**: The picked tier is meaningful only within a single modal session for a specific subject. Resetting it when the modal opens ensures the state is always clean at the start of a new interaction, regardless of how the previous session ended. The capability clamp is applied after full seed resolution, covering both stale explicit picks and historical defaults loaded from a previous share.

**✅ What Was Implemented**

- Replaced `getLatestShareForBranch` with `getShareWithBranchLatest` in `BranchShareStore.ts`, which performs a single file read and returns both the subject's own record and a same-kind seed candidate. The seed picker (`pickSeedForSubject`) enforces two constraints: it only seeds a commit subject from other commit shares (never from a branch share), and it excludes the subject itself. This eliminates the cross-scope duplicate-grant path.
- Updated `BranchShareModal.ts` to apply an expiry filter (`presentable`) to the raw seed before using it as defaults, so a lapsed grant never pre-stages recipients for a one-click re-grant. The seeding is one-shot per modal open — a subsequent re-render does not re-stage people the user may have removed.
- In `vscode/src/views/SummaryScriptBuilder.ts`, the share modal's render logic reads `state.defaults` to preselect the access tier and, when there are prior recipients, automatically stages them in invite mode. A `shareDefaultsPrefilled` flag prevents the prefill from firing again on later re-renders within the same open session. A reset of the in-session picked tier was also added on modal open so each new subject starts with a clean slate.
- Added a capability clamp after the tier seed is resolved: if the seeded tier is organization-wide but the current API key lacks that permission, the tier is downgraded to the people-only option before being applied to the dropdown.

**📁 FILES**
- `cli/src/core/BranchShareStore.ts`
- `vscode/src/services/BranchShareModal.ts`
- `vscode/src/views/SummaryScriptBuilder.ts`
- `vscode/src/services/BranchShareController.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Share deep link rejects requests with missing or unrecognized origin</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The handler for share deep links validated the origin parameter only when it was present, meaning a crafted link with no origin at all would bypass the allowlist check entirely. After the importer was upgraded to write real content into the user's memory bank, this gap became more serious.

**💡 Decisions Behind the Code**

Fail-closed on missing origin rather than fail-open. The legitimate web share page always includes the origin parameter, so real users are unaffected. A link that omits origin cannot be vetted against the allowlist, and after the importer upgrade a successful import writes into the user's actual memory bank — making the cost of a bypass higher than before.

**✅ What Was Implemented**

Updated the `/share` URI handler in `Extension.ts` to treat a missing origin as a rejection rather than a pass-through. The check now requires origin to be present before proceeding, and returns an error message referencing "no origin to verify" when it is absent.

**📁 FILES**
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Repository URL withheld from publicly shared branch exports</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The export endpoint returned the full remote repository URL to any registered user holding a public share link. A public share only proves the caller is a registered user — it does not verify any membership — so the URL of a potentially private repository was reachable by anyone who signed up, inconsistent with the web share page which deliberately omits it.

**💡 Decisions Behind the Code**

- **Null field rather than omitted field**: The response still includes `repoUrl` as an explicit `null` rather than dropping the key entirely. This makes the contract unambiguous — callers must handle the null case at the type level rather than treating an absent field as an empty string or ignoring it. The cost is a few extra bytes in the payload; the benefit is that future callers cannot accidentally assume the field is always present.
- **Public tier only**: Org and people shares already require the caller to pass a membership check, so those callers have an established relationship with the repository. Withholding the URL from them would break precise local repository matching and pull-request queries with no security benefit. The restriction is therefore scoped to the one tier where the caller's identity is unverified beyond "registered user."

**✅ What Was Implemented**

- In `BranchShareRouter.ts`, `buildExportResponse` now returns `repoUrl: null` for public-tier shares and the full URL only for org/people-tier shares, where the caller has already passed a membership check. The accompanying comment was rewritten to accurately describe the per-tier rationale.
- In `vscode/src/services/JolliShareService.ts`, `SharedBranchExport.repoUrl` was widened to `string | null`. Downstream consumers already handled null gracefully — local repository matching falls back to name-only matching, and pull-request status queries short-circuit to unavailable — so no behavioral change was needed in those paths.

**📁 FILES**
- `vscode/src/services/JolliShareService.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Share invite email now includes a one-line description from the branch's latest recap</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The share invite email card had a description field that was always blank. The backend model had always supported a description supplied by the editor plugin, but the plugin had never implemented sending one.

**💡 Decisions Behind the Code**

- **Recap preferred over commit message**: The recap is a human-edited summary of what the branch accomplished, making it more meaningful as an email blurb than the raw commit message subject line. The commit message is kept as a fallback for branches where no recap has been written yet.
- **200-character cap below the server's 500-character limit**: The server accepts up to 500 characters, but a true one-liner in an email card reads better at 200. The gap also provides headroom if the limit is enforced differently across email clients.

**✅ What Was Implemented**

- Added `deriveShareDescription` to `LiveShareController.ts`, which takes the head commit's recap text (falling back to the first line of the commit message), collapses whitespace into a single line, and truncates to 200 characters with an ellipsis.
- Wired the derived description into both the share creation payload and the reconcile PATCH in `LiveShareController.ts`, so the blurb is sent on first share and refreshed whenever the recap changes.
- Added `description` as an optional field to `LiveSharePayload` and `LiveSharePatch` in `JolliShareService.ts`.

**📁 FILES**
- `vscode/src/services/LiveShareController.ts`
- `vscode/src/services/JolliShareService.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Invite flow surfaces the real failure reason instead of a generic message</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user clicked "Send invite" in the share panel and the underlying share link creation failed, they saw a vague hardcoded message naming two possible causes without knowing which applied. The actual reason for the failure was computed internally but discarded before reaching the notification.

**💡 Decisions Behind the Code**

- **Return the message rather than re-derive it at each call site**: The error message was already computed inside the generation function for the UI overlay. Returning it directly avoided duplicating the error-classification logic at each call site and guaranteed the toast and the overlay always show the same text.
- **Toast the real reason instead of a generic guess**: The hardcoded fallback string named two possible causes without knowing which applied. Surfacing the actual computed message gives users and developers an immediately actionable signal — binding failure, nothing to share, or an HTTP error — without requiring them to open developer tools or read log files.

**✅ What Was Implemented**

- Modified `generate()` in `BranchShareModal.ts` to return a typed result object (`{ ok: true }` or `{ ok: false; message: string }`) instead of a plain boolean. The real error message is now carried back to every call site rather than only being posted into a UI overlay that may already be hidden.
- Updated the invite path in `sendInviteModal` to use the returned message directly in the toast notification, replacing the hardcoded fallback string. The other two call sites (`copyShareLinkModal`, `setShareAccessModal`) were updated to check the new result shape with no behavior change.
- Added `log.warn` inside `generate()`'s catch block so share link generation failures now appear in the debug log with the specific reason.

**📁 FILES**
- `vscode/src/services/BranchShareModal.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Empty org-member suggestion list no longer gets permanently cached after a soft failure</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The member suggestion list in the share popover could get stuck showing no results after a soft failure or a race where the backend returned an empty list. Once cached, the empty result would persist for the full cache lifetime with no way to recover short of restarting the extension.

**💡 Decisions Behind the Code**

An empty member list is indistinguishable from a soft failure at the plugin level — the backend may have returned nothing due to a timing issue, a missing org association, or a transient error. Caching it would lock the UI into a degraded state for the full TTL with no recovery path. Treating empty results as non-cacheable keeps the retry cost low (one extra HTTP call per TTL window at most) while ensuring the list recovers automatically once the backend returns real data.

**✅ What Was Implemented**

- Updated `listOrgMembers` in `JolliShareService.ts` to only write to the cache when the returned member list is non-empty. An empty-but-successful response is now treated the same as a failure: the result is returned to the caller but not stored, so the next invocation re-fetches from the backend.
- Added `log.warn` calls for all three non-caching exit paths (non-2xx status, empty result, thrown exception), which were previously silent.

**📁 FILES**
- `vscode/src/services/JolliShareService.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Current repo identity fields added to storage lookup result for share import verification</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The share importer needed to verify that the currently-open repository matched the repository a share was made from before writing imported content into that repository's memory bank. The existing lookup for the current repository's storage did not return the repository's name or remote URL, making identity verification impossible at the call site.

**💡 Decisions Behind the Code**

Identity verification was placed in the importer rather than inside the storage lookup method. The lookup method's contract is to return the current repository's storage; deciding whether that repository matches a share's repository is a policy question that belongs at the point of use. This keeps the bridge method's responsibility narrow and avoids adding share-specific logic to a general-purpose infrastructure layer.

**✅ What Was Implemented**

Extended the return value of `createReadStorageForCurrentRepo` in `JolliMemoryBridge.ts` to include `repoName` and `remoteUrl` alongside the existing storage and root path fields.

**📁 FILES**
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · Backend HTTP errors from share and invite operations now appear in the debug log</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When share creation, update, or invite calls to the backend failed, the extension produced no log output. Diagnosing failures required attaching a debugger or reading network traffic, since the error was only ever shown transiently in the UI.

**💡 Decisions Behind the Code**

- **Log at the HTTP choke point, not at each caller**: All non-2xx responses flow through a single helper function. Adding logging there meant every operation gained visibility in one change rather than requiring updates at each individual call site, and future operations will inherit the same coverage automatically.
- **Reuse the existing trace context rather than adding new instrumentation**: Every share action already runs inside a trace scope established by the webview message handler, and the backend already reads and logs the same trace identifier from the request header. Importing the logger was sufficient to make the new log lines carry the correct trace identifier automatically, with no new wiring needed.

**✅ What Was Implemented**

- Added a `context` parameter to the internal `rejectForStatus` helper in `JolliShareService.ts` and added a `log.warn` call there. All three call sites (create share, update share, send invite) now pass a descriptive label, so every non-2xx backend response is recorded in the debug log with the HTTP status and error detail before the error is thrown. The error text computation was also unified into a single expression used by both the log statement and the thrown error, eliminating a divergence where the logged reason and the user-visible message could differ.
- Added the `Logger` import to both `JolliShareService.ts` and `BranchShareModal.ts`, which previously had no logging at all. Both files now participate in the existing trace-context system, meaning each log line automatically carries the trace identifier that is also sent to the backend, enabling end-to-end correlation without any additional instrumentation.

**📁 FILES**
- `vscode/src/services/JolliShareService.ts`
- `vscode/src/services/BranchShareModal.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 6, 2026 at 4:54 PM · via Anthropic*
<!-- jollimemory-summary-end -->