### PR TITLE
Run topic-KB ingest under its own ingest.lock, off the summary worker.lock

### DIFF
--- a/cli/src/core/Locks.test.ts
+++ b/cli/src/core/Locks.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -26,17 +26,20 @@ vi.spyOn(console, "error").mockImplementation(() => {});
 import { getJolliMemoryDir } from "../Logger.js";
 import {
 	__resetSharedLockDirCache,
+	acquireIngestLock,
 	acquireOrphanWriteLock,
 	acquireWorkerLock,
 	DEFAULT_ORPHAN_WRITE_POLL_MS,
 	getWorkerBusyState,
-	isWorkerBlockingBusy,
+	INGEST_LOCK_FILE,
 	isWorkerLockHeld,
 	isWorkerLockStale,
 	LOCK_TIMEOUT_MS,
 	ORPHAN_WRITE_LOCK_FILE,
 	PLANS_LOCK_FILE,
+	refreshIngestLockMtime,
 	refreshWorkerLockMtime,
+	releaseIngestLock,
 	releaseOrphanWriteLock,
 	releaseWorkerLock,
 	WORKER_LOCK_FILE,
@@ -88,6 +91,7 @@ describe("Locks", () => {
 		// starts with both locks definitively unheld. `force: true` covers the
 		// usual "file does not exist" case.
 		await rm(join(tempDir, ".jolli", "jollimemory", WORKER_LOCK_FILE), { force: true });
+		await rm(join(tempDir, ".jolli", "jollimemory", INGEST_LOCK_FILE), { force: true });
 		await rm(join(tempDir, ".git", "jollimemory", ORPHAN_WRITE_LOCK_FILE), { force: true });
 		await rm(plansLockPath(tempDir), { force: true });
 	});
@@ -583,51 +587,6 @@ describe("Locks", () => {
 		});
 	});
 
-	describe("isWorkerBlockingBusy", () => {
-		async function jmDir(cwd: string): Promise<string> {
-			const dir = getJolliMemoryDir(cwd);
-			await mkdir(dir, { recursive: true });
-			return dir;
-		}
-
-		it("is false when no worker lock is held", async () => {
-			expect(await isWorkerBlockingBusy(tempDir)).toBe(false);
-		});
-
-		it("is true when the lock is held and no phase marker exists (default summary phase)", async () => {
-			const dir = await jmDir(tempDir);
-			await writeFile(join(dir, "worker.lock"), String(process.pid));
-			expect(await isWorkerBlockingBusy(tempDir)).toBe(true);
-		});
-
-		it("is false when the lock is held and a fresh ingest phase is active", async () => {
-			const dir = await jmDir(tempDir);
-			await writeFile(join(dir, "worker.lock"), String(process.pid));
-			await writeFile(join(dir, "worker-phase"), "ingest:wiki");
-			expect(await isWorkerBlockingBusy(tempDir)).toBe(false);
-		});
-
-		it("is true when the phase marker is a non-ingest value", async () => {
-			const dir = await jmDir(tempDir);
-			await writeFile(join(dir, "worker.lock"), String(process.pid));
-			await writeFile(join(dir, "worker-phase"), "summary");
-			expect(await isWorkerBlockingBusy(tempDir)).toBe(true);
-		});
-
-		it("is true when the ingest phase marker is stale (fail-safe: treated as blocking)", async () => {
-			const dir = await jmDir(tempDir);
-			// worker.lock stays fresh — only the phase marker is backdated past
-			// LOCK_TIMEOUT_MS, simulating a worker that died mid-ingest without
-			// heartbeating the marker.
-			await writeFile(join(dir, "worker.lock"), String(process.pid));
-			const phasePath = join(dir, "worker-phase");
-			await writeFile(phasePath, "ingest:wiki");
-			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
-			await utimes(phasePath, past, past);
-			expect(await isWorkerBlockingBusy(tempDir)).toBe(true);
-		});
-	});
-
 	describe("getWorkerBusyState", () => {
 		async function jmDir(cwd: string): Promise<string> {
 			const dir = getJolliMemoryDir(cwd);
@@ -639,26 +598,79 @@ describe("Locks", () => {
 			expect(await getWorkerBusyState(tempDir)).toEqual({ held: false, blocking: false });
 		});
 
-		it("returns held=true, blocking=true for a held lock with a non-ingest phase", async () => {
+		// worker.lock is held only during summary generation (ingest has its own
+		// lock), so blocking always equals held.
+		it("returns held=true, blocking=true whenever worker.lock is held", async () => {
 			const dir = await jmDir(tempDir);
 			await writeFile(join(dir, "worker.lock"), String(process.pid));
-			await writeFile(join(dir, "worker-phase"), "summary");
 			expect(await getWorkerBusyState(tempDir)).toEqual({ held: true, blocking: true });
 		});
 
-		it("returns held=true, blocking=false for a held lock in a fresh ingest phase", async () => {
+		it("treats a stale worker.lock as not held", async () => {
 			const dir = await jmDir(tempDir);
-			await writeFile(join(dir, "worker.lock"), String(process.pid));
-			await writeFile(join(dir, "worker-phase"), "ingest:wiki");
-			expect(await getWorkerBusyState(tempDir)).toEqual({ held: true, blocking: false });
+			const lockPath = join(dir, "worker.lock");
+			await writeFile(lockPath, String(process.pid));
+			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
+			await utimes(lockPath, past, past);
+			expect(await getWorkerBusyState(tempDir)).toEqual({ held: false, blocking: false });
 		});
 
-		// The whole point of the combined read: blocking can never be true while
-		// held is false (that impossible pair was reachable when the two axes were
-		// two independent lock stats).
 		it("never reports blocking=true with held=false", async () => {
 			const state = await getWorkerBusyState(tempDir);
 			expect(state.blocking && !state.held).toBe(false);
+		});
+	});
+
+	describe("ingest.lock", () => {
+		function ingestLockPath(cwd: string): string {
+			return join(cwd, ".jolli", "jollimemory", INGEST_LOCK_FILE);
+		}
+
+		it("acquires fail-fast and writes our PID", async () => {
+			expect(await acquireIngestLock(tempDir)).toBe(true);
+			const content = await readFile(ingestLockPath(tempDir), "utf-8");
+			expect(content.trim()).toBe(String(process.pid));
+		});
+
+		it("is fail-fast: a second acquire while held returns false", async () => {
+			// After we hold it (our own live PID written), a second acquire fails
+			// immediately — the PID-liveness check sees us alive, so no reclaim.
+			expect(await acquireIngestLock(tempDir)).toBe(true);
+			expect(await acquireIngestLock(tempDir)).toBe(false);
+			await releaseIngestLock(tempDir);
+		});
+
+		it("reclaims a stale ingest.lock", async () => {
+			const lockPath = ingestLockPath(tempDir);
+			await mkdir(join(tempDir, ".jolli", "jollimemory"), { recursive: true });
+			await writeFile(lockPath, "999999");
+			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
+			await utimes(lockPath, past, past);
+			expect(await acquireIngestLock(tempDir)).toBe(true);
+			expect((await readFile(lockPath, "utf-8")).trim()).toBe(String(process.pid));
+		});
+
+		it("releaseIngestLock only removes a lock we own (PID gate)", async () => {
+			const lockPath = ingestLockPath(tempDir);
+			await mkdir(join(tempDir, ".jolli", "jollimemory"), { recursive: true });
+			await writeFile(lockPath, "999999"); // foreign PID
+			await releaseIngestLock(tempDir);
+			// Not ours → left in place.
+			await expect(stat(lockPath)).resolves.toBeDefined();
+			// Ours → removed.
+			await acquireIngestLock(tempDir);
+			await releaseIngestLock(tempDir);
+			await expect(stat(lockPath)).rejects.toThrow();
+		});
+
+		it("refreshIngestLockMtime bumps mtime for a lock we own", async () => {
+			const lockPath = ingestLockPath(tempDir);
+			await acquireIngestLock(tempDir);
+			const past = new Date(Date.now() - 120_000);
+			await utimes(lockPath, past, past);
+			await refreshIngestLockMtime(tempDir);
+			const fresh = await stat(lockPath);
+			expect(Date.now() - fresh.mtimeMs).toBeLessThan(LOCK_TIMEOUT_MS);
 		});
 	});
 });

--- a/cli/src/core/Locks.ts
+++ b/cli/src/core/Locks.ts
@@ -59,7 +59,7 @@
  * release path.
  */
 
-import { mkdir, readFile, stat } from "node:fs/promises";
+import { mkdir, stat } from "node:fs/promises";
 import { isAbsolute, join, resolve as resolvePath } from "node:path";
 import { createLogger, getJolliMemoryDir } from "../Logger.js";
 import * as Subprocess from "../util/Subprocess.js";
@@ -90,22 +90,31 @@ function gitRevParseCommonDir(cwd: string): Promise<{ stdout: string; stderr: st
 export const WORKER_LOCK_FILE = "worker.lock";
 
 /**
- * Best-effort marker the QueueWorker writes while running a phase the UI
- * treats specially (currently only `ingest`). Lives next to `worker.lock` in
- * `<cwd>/.jolli/jollimemory/`. It is NOT a lock and carries no mutual-exclusion
- * role, but it is more than cosmetic: the extension's worker-busy gates
- * (`isWorkerBlockingBusy` in vscode LockUtils) exempt Commit/Squash from
- * blocking while the marker reads `ingest`, so a wrongly-surviving marker
- * under-protects. Three mechanisms bound its lifetime:
- *   - reader side: the phase is ignored whenever `worker.lock` is gone/stale,
- *     and an `ingest` marker whose own mtime is stale is treated as blocking
- *     (the worker heartbeats the marker during a genuine ingest);
- *   - writer side: each commit-typed queue entry clears a leftover marker
- *     before processing (`clearLeftoverIngestMarker` in QueueWorker);
- *   - acquisition: a fresh worker removes any crash-orphaned marker right
- *     after taking `worker.lock`.
+ * Fail-fast per-worktree lock the QueueWorker holds for the duration of a
+ * topic-KB ingest (wiki render + graph build). Split out from `worker.lock`
+ * so a long ingest (minutes, mostly graph build) no longer blocks summary
+ * generation: summary drain keeps `worker.lock`, ingest runs concurrently
+ * under `ingest.lock`. Lives next to `worker.lock` at
+ * `<cwd>/.jolli/jollimemory/ingest.lock`. Heartbeated the same way (an ingest
+ * can outlast `LOCK_TIMEOUT_MS`, so its mtime must be bumped to avoid a
+ * stale-reclaim by the next worker).
  */
-export const WORKER_PHASE_FILE = "worker-phase";
+export const INGEST_LOCK_FILE = "ingest.lock";
+
+/**
+ * Purely-cosmetic phase file the QueueWorker writes while running an ingest so
+ * the VS Code sidebar can show a "Building knowledge wiki/graph…" pill. Lives
+ * next to `worker.lock` in `<cwd>/.jolli/jollimemory/`. It is NOT a lock and
+ * carries **no gate role**: since ingest no longer holds `worker.lock`, the
+ * commit/squash gates
+ * (which key off `worker.lock` alone) are already open during ingest, so this
+ * file only drives display. It holds the full sub-phase value (`ingest:wiki`
+ * while ingesting + rendering the wiki, `ingest:graph` while building the
+ * graph), is heartbeated for its lifetime, and is removed when ingest ends. A
+ * surviving file only leaves the pill up a little longer (bounded by its own
+ * mtime staleness + `ingest.lock` liveness on the reader side).
+ */
+export const INGEST_PHASE_FILE = "ingest-phase";
 export const ORPHAN_WRITE_LOCK_FILE = "orphan-write.lock";
 export const SYNC_LOCK_FILE = "sync.lock";
 export const PLANS_LOCK_FILE = "plans.lock";
@@ -260,48 +269,16 @@ export async function isWorkerLockStale(cwd?: string): Promise<boolean> {
 }
 
 /**
- * True when the `worker-phase` marker is a fresh `ingest*` phase. Mirrors the
- * vscode `LockUtils.isFreshIngestPhase`: the worker writes `ingest:wiki` /
- * `ingest:graph` (older workers: bare `ingest`) and heartbeats the marker, so a
- * stale marker is residue from a failed cleanup and is treated as NOT ingest
- * (fail-safe → the run is assumed to be a blocking summary).
- */
-async function isFreshIngestPhase(cwd?: string): Promise<boolean> {
-	const phasePath = join(getJolliMemoryDir(cwd), WORKER_PHASE_FILE);
-	try {
-		const content = await readFile(phasePath, "utf-8");
-		if (!content.trim().startsWith("ingest")) return false;
-		const phaseStat = await stat(phasePath);
-		return Date.now() - phaseStat.mtimeMs < LOCK_TIMEOUT_MS;
-	} catch {
-		return false;
-	}
-}
-
-/**
- * True only when the worker is busy with a phase that generates memory
- * summaries — i.e. `worker.lock` is held AND the current phase is not a fresh
- * ingest (wiki/graph) phase. Callers waiting on "is a summary still being
- * written?" use this, not `isWorkerLockHeld`, so they never block on Memory
- * Bank wiki/graph rendering. CLI analogue of vscode `LockUtils.isWorkerBlockingBusy`.
- */
-export async function isWorkerBlockingBusy(cwd?: string): Promise<boolean> {
-	if (!(await isWorkerLockHeld(cwd))) return false;
-	return !(await isFreshIngestPhase(cwd));
-}
-
-/**
- * Reads both worker-busy axes with `held` gating `blocking` — `blocking` is only
- * computed when `held` is true, so the two can never contradict each other.
- * Callers that need both (e.g. `getQueueStatus`) must use this rather than calling
- * `isWorkerLockHeld` and `isWorkerBlockingBusy` separately — those evaluate the
- * lock independently, and a cross-process lock release between them can interleave
- * into the impossible pair `held=false, blocking=true`.
+ * Reads the worker-busy state. `worker.lock` is held ONLY during summary
+ * generation (ingest has its own `ingest.lock`), so "blocking" (a summary is in
+ * flight, callers should wait) is exactly "held" — ingest can never make this
+ * report blocking. Kept as a single atomic read (rather than inlining
+ * `isWorkerLockHeld` at call sites) so the `held`/`blocking` pair is always
+ * self-consistent.
  */
 export async function getWorkerBusyState(cwd?: string): Promise<{ held: boolean; blocking: boolean }> {
 	const held = await isWorkerLockHeld(cwd);
-	if (!held) return { held: false, blocking: false };
-	return { held, blocking: !(await isFreshIngestPhase(cwd)) };
+	return { held, blocking: held };
 }
 
 /**
@@ -317,6 +294,37 @@ export async function getWorkerBusyState(cwd?: string): Promise<{ held: boolean;
 export async function refreshWorkerLockMtime(cwd?: string): Promise<void> {
 	const dir = getJolliMemoryDir(cwd);
 	await refreshLockMtime(join(dir, WORKER_LOCK_FILE));
+}
+
+/**
+ * Acquires `ingest.lock`. Fail-fast: returns false immediately when another
+ * worker already holds it, so only one ingest runs per worktree at a time.
+ * Mirrors `acquireWorkerLock` — per-worktree, since ingest is a worktree-local
+ * operation (same rationale as `worker.lock`).
+ */
+export async function acquireIngestLock(cwd?: string): Promise<boolean> {
+	const dir = await ensureWorktreeLockDir(cwd);
+	return tryAcquireOnce(join(dir, INGEST_LOCK_FILE));
+}
+
+/**
+ * Releases `ingest.lock` — only if the lock file's PID matches us (see
+ * `releaseWorkerLock` for the stale-reclaim rationale).
+ */
+export async function releaseIngestLock(cwd?: string): Promise<void> {
+	const dir = getJolliMemoryDir(cwd);
+	await releaseIfOwned(join(dir, INGEST_LOCK_FILE), INGEST_LOCK_FILE);
+}
+
+/**
+ * Bumps `ingest.lock`'s mtime so a long ingest (wiki + graph build can run for
+ * minutes) is not stolen by the stale-lock reclaimer. The worker calls this on
+ * a periodic timer for the duration of the ingest. Skips the bump when a
+ * different PID owns the lock (same guard as `refreshWorkerLockMtime`).
+ */
+export async function refreshIngestLockMtime(cwd?: string): Promise<void> {
+	const dir = getJolliMemoryDir(cwd);
+	await refreshLockMtime(join(dir, INGEST_LOCK_FILE));
 }
 
 /**

--- a/cli/src/core/QueueStatus.ts
+++ b/cli/src/core/QueueStatus.ts
@@ -4,8 +4,10 @@
  *
  * `drained` is decided by two axes only: (1) no non-ingest queue entries remain,
  * and (2) the worker is not blocking-busy (not mid-summary). Wiki/graph ingest
- * entries and the ingest worker phase are intentionally excluded so the PR-wait
- * path never blocks on Memory Bank wiki rendering. The other fields are
+ * entries are intentionally excluded so the PR-wait path never blocks on Memory
+ * Bank wiki rendering — and because ingest runs under its own `ingest.lock`,
+ * `worker.lock` is held only during summary, so this exclusion is now automatic
+ * (ingest simply doesn't touch `worker.lock`). The other fields are
  * informational (debugging / progress messaging).
  */
 
@@ -17,9 +19,9 @@ export interface QueueStatus {
 	active: number;
 	/** Non-stale ingest (wiki/graph) entries — informational. */
 	ingestActive: number;
-	/** worker.lock held, any phase — informational. */
+	/** worker.lock held — informational. */
 	workerBusy: boolean;
-	/** worker.lock held AND not a fresh ingest phase (a summary is in flight). */
+	/** worker.lock held (a summary is in flight). Equals `workerBusy`. */
 	workerBlocking: boolean;
 	/** active === 0 && !workerBlocking. */
 	drained: boolean;

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -133,7 +133,7 @@ const ORPHAN_WRITE_BEST_EFFORT_TIMEOUT_MS = 1000;
  * (worker path). Throws on timeout — see `ORPHAN_WRITE_REQUIRED_TIMEOUT_MS`
  * for why "lose this entry" is the chosen failure mode.
  */
-async function withRequiredOrphanWriteLock<T>(
+export async function withRequiredOrphanWriteLock<T>(
 	cwd: string | undefined,
 	label: string,
 	fn: () => Promise<T>,

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -2188,8 +2188,10 @@ describe("queue-driven Worker", () => {
 				.mockResolvedValueOnce([DEFAULT_COMMIT_OP])
 				// Second call inside the while loop: empty → break
 				.mockResolvedValueOnce([])
-				// Third call after the finally block: one remaining entry → chain spawn
-				.mockResolvedValueOnce([DEFAULT_COMMIT_OP]);
+				// Third call (chain-spawn probe): one remaining summary entry → chain spawn
+				.mockResolvedValueOnce([DEFAULT_COMMIT_OP])
+				// Fourth call (ingest-phase pre-check) and beyond: no ingest entries
+				.mockResolvedValue([]);
 			vi.mocked(deleteQueueEntry).mockResolvedValue(undefined);
 			vi.mocked(getCommitInfo).mockResolvedValue({
 				hash: "abc123",

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -63,10 +63,20 @@ vi.mock("../core/Locks.js", () => ({
 	releaseWorkerLock: vi.fn(),
 	refreshWorkerLockMtime: vi.fn(),
 	isWorkerLockHeld: vi.fn(),
+	// ingest.lock: default to "acquired" so the ingest phase runs in tests. The
+	// lock contract itself is covered in Locks.test.ts.
+	acquireIngestLock: vi.fn().mockResolvedValue(true),
+	releaseIngestLock: vi.fn(),
+	refreshIngestLockMtime: vi.fn(),
 	// Passthrough: run the RMW body without touching the real lock file. The
 	// per-worktree lock contract itself is covered in Locks.test.ts.
 	withPlansLock: (_cwd: string | undefined, fn: () => Promise<unknown>) => fn(),
-	WORKER_PHASE_FILE: "worker-phase",
+	INGEST_PHASE_FILE: "ingest-phase",
+}));
+
+vi.mock("../sync/PendingIngest.js", () => ({
+	recordPendingIngest: vi.fn().mockResolvedValue(undefined),
+	wakePendingIngest: vi.fn().mockResolvedValue(undefined),
 }));
 
 // `vault-write.lock` integration: the Standalone Hotfix now wraps the worker
@@ -361,7 +371,7 @@ vi.spyOn(console, "warn").mockImplementation(() => {});
 vi.spyOn(console, "error").mockImplementation(() => {});
 
 import { spawn } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
@@ -378,7 +388,7 @@ import { drainIngest } from "../core/IngestPipeline.js";
 import { appendCredentialMissingRun } from "../core/IngestRunStore.js";
 import { enqueueIngestOperation } from "../core/IngestTrigger.js";
 import { LlmCredentialError } from "../core/LlmClient.js";
-import { acquireWorkerLock, releaseWorkerLock } from "../core/Locks.js";
+import { acquireIngestLock, acquireWorkerLock, releaseIngestLock, releaseWorkerLock } from "../core/Locks.js";
 import { discoverOpenCodeSessions, isOpenCodeInstalled } from "../core/OpenCodeSessionDiscoverer.js";
 import { readOpenCodeTranscript } from "../core/OpenCodeTranscriptReader.js";
 import {
@@ -401,6 +411,7 @@ import { storeSummary, withRequiredOrphanWriteLock } from "../core/SummaryStore.
 import { renderTopicKBWiki } from "../core/TopicWikiRenderer.js";
 import { buildMultiSessionContext, readTranscript } from "../core/TranscriptReader.js";
 import { buildKnowledgeGraph } from "../graph/GraphBuilder.js";
+import { recordPendingIngest, wakePendingIngest } from "../sync/PendingIngest.js";
 import { recordPendingWorker, wakePendingWorkers } from "../sync/PendingWorkers.js";
 import { acquireVaultWriteLock, withVaultWriteLock } from "../sync/VaultWriteLock.js";
 import type { CommitGitOperation, IngestOperation } from "../Types.js";
@@ -436,6 +447,9 @@ describe("QueueWorker", () => {
 		vi.resetAllMocks();
 		vi.mocked(acquireWorkerLock).mockResolvedValue(true);
 		vi.mocked(releaseWorkerLock).mockResolvedValue(undefined);
+		// ingest.lock: re-establish "acquired" after resetAllMocks wipes the factory
+		// default, so the queue-driven ingest phase runs (release/refresh are void).
+		vi.mocked(acquireIngestLock).mockResolvedValue(true);
 		// vault-write.lock: re-establish the always-succeed implementation
 		// after `resetAllMocks` wipes the factory default. The handle's
 		// `release` / `refresh` are themselves `vi.fn()` so per-test
@@ -506,7 +520,9 @@ describe("QueueWorker", () => {
 			//       the loop (which broke out after 20), once after finally
 			const { deleteQueueEntry } = await import("../core/SessionTracker.js");
 			expect(vi.mocked(deleteQueueEntry)).toHaveBeenCalledTimes(20);
-			expect(vi.mocked(dequeueAllGitOperations)).toHaveBeenCalledTimes(2);
+			// Three dequeues now: the capped drain (broke at 20), the chain-spawn
+			// probe, and the ingest-phase pre-check (which finds no ingest entries).
+			expect(vi.mocked(dequeueAllGitOperations)).toHaveBeenCalledTimes(3);
 		});
 	});
 
@@ -592,10 +608,11 @@ describe("QueueWorker", () => {
 
 			await runWorker("/test/cwd");
 
-			// The third call to dequeueAllGitOperations happens after the finally block
-			// and returns non-empty, triggering lines 234-235 (log + launchWorker).
-			// launchWorker is in v8 ignore, so we verify by checking dequeue was called 3 times.
-			expect(dequeueAllGitOperations).toHaveBeenCalledTimes(3);
+			// Four dequeues: two in the drain loop (entry, then empty → break), the
+			// chain-spawn probe (returns a remaining summary entry → log + launchWorker),
+			// and the ingest-phase pre-check (empty by default). launchWorker is in a
+			// v8-ignore branch, so we verify via the dequeue count.
+			expect(dequeueAllGitOperations).toHaveBeenCalledTimes(4);
 		});
 	});
 
@@ -2403,74 +2420,6 @@ describe("QueueWorker", () => {
 		});
 	});
 
-	describe("runWorker — stale phase cleanup on lock acquisition", () => {
-		it("removes a worker-phase file left by a crashed worker when it acquires the lock", async () => {
-			const tmp = mkdtempSync(join(tmpdir(), "jolli-stalephase-"));
-			mkdirSync(join(tmp, ".jolli", "jollimemory"), { recursive: true });
-			const phaseFile = join(tmp, ".jolli", "jollimemory", "worker-phase");
-			// Simulate crash residue: a previous worker was SIGKILL'd mid-ingest, so
-			// its `finally` cleanup never ran and the 'ingest' marker persists.
-			writeFileSync(phaseFile, "ingest");
-
-			const { existsSync: realExistsSync } = await vi.importActual<typeof import("node:fs")>("node:fs");
-			expect(realExistsSync(phaseFile)).toBe(true);
-
-			// Minimal storage so setActiveStorage() has something to hold; empty
-			// queue so the worker just acquires the lock and drains nothing.
-			vi.mocked(createStorage).mockResolvedValue({
-				readFile: vi.fn().mockResolvedValue(null),
-				writeFiles: vi.fn().mockResolvedValue(undefined),
-				listFiles: vi.fn().mockResolvedValue([]),
-				exists: vi.fn().mockResolvedValue(true),
-				ensure: vi.fn().mockResolvedValue(undefined),
-			} as never);
-			vi.mocked(dequeueAllGitOperations).mockResolvedValue([]);
-
-			await runWorker(tmp);
-
-			// The fresh worker holds the lock, proving the previous one is gone, so
-			// the stale marker is cleared at the source — not left to mislabel the
-			// next genuine summary run as "Building knowledge wiki…".
-			expect(realExistsSync(phaseFile)).toBe(false);
-
-			rmSync(tmp, { recursive: true, force: true });
-		});
-	});
-
-	describe("clearLeftoverIngestMarker", () => {
-		it("removes an ingest marker that a failed cleanup left behind", async () => {
-			const tmp = mkdtempSync(join(tmpdir(), "jolli-leftover-"));
-			mkdirSync(join(tmp, ".jolli", "jollimemory"), { recursive: true });
-			const phaseFile = join(tmp, ".jolli", "jollimemory", "worker-phase");
-			// Simulate the ingest `finally` rmSync having failed (e.g. Windows AV
-			// briefly holding the file): the marker still reads 'ingest' while the
-			// same drain is about to process a blocking summary entry.
-			writeFileSync(phaseFile, "ingest");
-
-			const { existsSync: realExistsSync } = await vi.importActual<typeof import("node:fs")>("node:fs");
-			vi.mocked(existsSync).mockImplementation(realExistsSync);
-
-			__test__.clearLeftoverIngestMarker(tmp);
-
-			// Gate readers must no longer see an exempt phase.
-			expect(realExistsSync(phaseFile)).toBe(false);
-
-			rmSync(tmp, { recursive: true, force: true });
-		});
-
-		it("is a no-op when no marker exists", async () => {
-			const tmp = mkdtempSync(join(tmpdir(), "jolli-leftover-"));
-			mkdirSync(join(tmp, ".jolli", "jollimemory"), { recursive: true });
-
-			const { existsSync: realExistsSync } = await vi.importActual<typeof import("node:fs")>("node:fs");
-			vi.mocked(existsSync).mockImplementation(realExistsSync);
-
-			expect(() => __test__.clearLeftoverIngestMarker(tmp)).not.toThrow();
-
-			rmSync(tmp, { recursive: true, force: true });
-		});
-	});
-
 	describe("runWorker — ingest dispatch", () => {
 		function makeIngestOp(triggeredBy: IngestOperation["triggeredBy"] = "post-merge"): IngestOperation {
 			return { type: "ingest", triggeredBy, createdAt: new Date().toISOString() };
@@ -2494,10 +2443,10 @@ describe("QueueWorker", () => {
 			vi.mocked(createStorage).mockResolvedValue(storageWithWiki(true));
 		});
 
-		it("writes worker-phase=ingest:wiki during ingest, advances to ingest:graph before the graph build, and removes it after", async () => {
+		it("writes ingest-phase=ingest:wiki during ingest, advances to ingest:graph before the graph build, and removes it after", async () => {
 			const tmp = mkdtempSync(join(tmpdir(), "jolli-phase-"));
 			mkdirSync(join(tmp, ".jolli", "jollimemory"), { recursive: true });
-			const phaseFile = join(tmp, ".jolli", "jollimemory", "worker-phase");
+			const phaseFile = join(tmp, ".jolli", "jollimemory", "ingest-phase");
 
 			// Use the actual fs functions so we can observe real disk writes from
 			// production code (writeFileSync / rmSync are actual in the mock spread).
@@ -2533,7 +2482,7 @@ describe("QueueWorker", () => {
 		it("leaves the marker at ingest:wiki (never ingest:graph) when the graph build is skipped", async () => {
 			const tmp = mkdtempSync(join(tmpdir(), "jolli-phase-"));
 			mkdirSync(join(tmp, ".jolli", "jollimemory"), { recursive: true });
-			const phaseFile = join(tmp, ".jolli", "jollimemory", "worker-phase");
+			const phaseFile = join(tmp, ".jolli", "jollimemory", "ingest-phase");
 
 			const { existsSync: realExistsSync, readFileSync: realReadFileSync } =
 				await vi.importActual<typeof import("node:fs")>("node:fs");
@@ -2558,10 +2507,10 @@ describe("QueueWorker", () => {
 			rmSync(tmp, { recursive: true, force: true });
 		});
 
-		it("removes worker-phase even when ingest throws", async () => {
+		it("removes ingest-phase even when ingest throws", async () => {
 			const tmp = mkdtempSync(join(tmpdir(), "jolli-phase-"));
 			mkdirSync(join(tmp, ".jolli", "jollimemory"), { recursive: true });
-			const phaseFile = join(tmp, ".jolli", "jollimemory", "worker-phase");
+			const phaseFile = join(tmp, ".jolli", "jollimemory", "ingest-phase");
 
 			const { existsSync: realExistsSync } = await vi.importActual<typeof import("node:fs")>("node:fs");
 			vi.mocked(existsSync).mockImplementation(realExistsSync);
@@ -2583,9 +2532,7 @@ describe("QueueWorker", () => {
 			vi.mocked(drainIngest).mockResolvedValue({ batches: 1, ingested: 2, outcome: "OK", topicFailures: [] });
 
 			const op = makeIngestOp("post-merge");
-			vi.mocked(dequeueAllGitOperations)
-				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/ingest.json" }])
-				.mockResolvedValueOnce([]);
+			vi.mocked(dequeueAllGitOperations).mockResolvedValue([{ op, filePath: "/tmp/queue/ingest.json" }]);
 
 			await runWorker("/test/cwd");
 
@@ -2601,9 +2548,7 @@ describe("QueueWorker", () => {
 			vi.mocked(buildKnowledgeGraph).mockRejectedValueOnce(new Error("graph boom"));
 
 			const op = makeIngestOp("post-merge");
-			vi.mocked(dequeueAllGitOperations)
-				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/ingest.json" }])
-				.mockResolvedValueOnce([]);
+			vi.mocked(dequeueAllGitOperations).mockResolvedValue([{ op, filePath: "/tmp/queue/ingest.json" }]);
 
 			// Must not throw despite the graph build rejecting.
 			await expect(runWorker("/test/cwd")).resolves.not.toThrow();
@@ -2638,22 +2583,18 @@ describe("QueueWorker", () => {
 			});
 
 			const op = makeIngestOp("post-merge");
-			vi.mocked(dequeueAllGitOperations)
-				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/ingest.json" }])
-				.mockResolvedValueOnce([]);
+			vi.mocked(dequeueAllGitOperations).mockResolvedValue([{ op, filePath: "/tmp/queue/ingest.json" }]);
 
 			await runWorker("/test/cwd");
 
 			expect(order).toEqual(["release", "drainIngest"]);
 		});
 
-		it("holds worker.lock THROUGH the ingest LLM phase, releasing it only after the drain", async () => {
-			// Direction-A guarantee: vault-write.lock is dropped before ingest (so
-			// cross-repo summary workers proceed) but the per-repo worker.lock stays
-			// held across the whole ingest. That serialises same-repo workers, so no
-			// concurrent summary run can clear the `ingest` worker-phase marker and no
-			// second ingest can race this one. Hence: drainIngest runs BEFORE
-			// releaseWorkerLock, while vault release happens BEFORE drainIngest.
+		it("releases worker.lock BEFORE the ingest phase so a concurrent summary worker can run", async () => {
+			// The whole point of the ingest.lock split: ingest no longer holds
+			// worker.lock. Both entry-level locks (vault, then worker) are released
+			// BEFORE the ingest phase runs, so a same-repo summary worker can proceed
+			// concurrently. Hence the order: vault-release, worker-release, drainIngest.
 			vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-test" } as never);
 			const order: string[] = [];
 			vi.mocked(acquireVaultWriteLock).mockResolvedValue({
@@ -2671,13 +2612,14 @@ describe("QueueWorker", () => {
 			});
 
 			const op = makeIngestOp("post-merge");
-			vi.mocked(dequeueAllGitOperations)
-				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/ingest.json" }])
-				.mockResolvedValueOnce([]);
+			vi.mocked(dequeueAllGitOperations).mockResolvedValue([{ op, filePath: "/tmp/queue/ingest.json" }]);
 
 			await runWorker("/test/cwd");
 
-			expect(order).toEqual(["vault-release", "drainIngest", "worker-release"]);
+			// releaseWorkerLock also runs in the outer finally (idempotent), so assert
+			// the first worker-release lands before drainIngest rather than exact equality.
+			expect(order.indexOf("vault-release")).toBeLessThan(order.indexOf("worker-release"));
+			expect(order.indexOf("worker-release")).toBeLessThan(order.indexOf("drainIngest"));
 		});
 
 		it("passes a per-write guard to drainIngest and renderTopicKBWiki so ingest writes self-lock", async () => {
@@ -2685,9 +2627,7 @@ describe("QueueWorker", () => {
 			vi.mocked(drainIngest).mockResolvedValue({ batches: 1, ingested: 2, outcome: "OK", topicFailures: [] });
 
 			const op = makeIngestOp("post-merge");
-			vi.mocked(dequeueAllGitOperations)
-				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/ingest.json" }])
-				.mockResolvedValueOnce([]);
+			vi.mocked(dequeueAllGitOperations).mockResolvedValue([{ op, filePath: "/tmp/queue/ingest.json" }]);
 
 			await runWorker("/test/cwd");
 
@@ -2696,8 +2636,8 @@ describe("QueueWorker", () => {
 			expect(typeof vi.mocked(renderTopicKBWiki).mock.calls[0]?.[2]).toBe("function");
 		});
 
-		it("routes each ingest write through orphan-write.lock (PR1: ingest orphan-ref writes self-lock)", async () => {
-			// PR1 wraps the ingest writeGuard body in `withRequiredOrphanWriteLock`
+		it("routes each ingest write through orphan-write.lock so ingest orphan-ref writes self-lock", async () => {
+			// The ingest writeGuard body is wrapped in `withRequiredOrphanWriteLock`
 			// so ingest's orphan-ref writes serialise against summary writes on the
 			// same lock. Drive the guard with a sentinel write and assert it flowed
 			// through the orphan lock with the "ingest-write" label.
@@ -2711,9 +2651,7 @@ describe("QueueWorker", () => {
 			});
 
 			const op = makeIngestOp("post-merge");
-			vi.mocked(dequeueAllGitOperations)
-				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/ingest.json" }])
-				.mockResolvedValueOnce([]);
+			vi.mocked(dequeueAllGitOperations).mockResolvedValue([{ op, filePath: "/tmp/queue/ingest.json" }]);
 
 			await runWorker("/test/cwd");
 
@@ -2752,13 +2690,62 @@ describe("QueueWorker", () => {
 			});
 
 			const op = makeIngestOp("post-merge");
-			vi.mocked(dequeueAllGitOperations)
-				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/ingest.json" }])
-				.mockResolvedValueOnce([]);
+			vi.mocked(dequeueAllGitOperations).mockResolvedValue([{ op, filePath: "/tmp/queue/ingest.json" }]);
 
 			await runWorker("/test/cwd");
 
 			expect(order).toEqual(["vault", "orphan:ingest-write", "write"]);
+		});
+
+		it("records a pending ingest and retries once when ingest.lock is initially lost, then runs", async () => {
+			vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-test" } as never);
+			// Lose the fail-fast acquire, then win the retry after recording intent.
+			vi.mocked(acquireIngestLock).mockResolvedValueOnce(false).mockResolvedValue(true);
+			vi.mocked(drainIngest).mockResolvedValue({ batches: 1, ingested: 1, outcome: "OK", topicFailures: [] });
+
+			const op = makeIngestOp("post-merge");
+			vi.mocked(dequeueAllGitOperations).mockResolvedValue([{ op, filePath: "/tmp/queue/ingest.json" }]);
+
+			await runWorker("/test/cwd");
+
+			expect(vi.mocked(recordPendingIngest)).toHaveBeenCalled();
+			expect(vi.mocked(drainIngest)).toHaveBeenCalledOnce();
+		});
+
+		it("skips the ingest and leaves its entries when ingest.lock stays lost after recording", async () => {
+			vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-test" } as never);
+			vi.mocked(acquireIngestLock).mockResolvedValue(false); // both the fail-fast and the retry miss
+			const { deleteQueueEntry } = await import("../core/SessionTracker.js");
+			vi.mocked(deleteQueueEntry).mockClear();
+
+			const op = makeIngestOp("post-merge");
+			vi.mocked(dequeueAllGitOperations).mockResolvedValue([{ op, filePath: "/tmp/queue/ingest.json" }]);
+
+			await runWorker("/test/cwd");
+
+			expect(vi.mocked(recordPendingIngest)).toHaveBeenCalled();
+			// Never ran ingest, and the queued ingest entry is left for the holder's wake.
+			expect(vi.mocked(drainIngest)).not.toHaveBeenCalled();
+			expect(vi.mocked(deleteQueueEntry)).not.toHaveBeenCalled();
+		});
+
+		it("releases ingest.lock BEFORE waking a pending ingest (detached spawn needs a free lock)", async () => {
+			vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-test" } as never);
+			const order: string[] = [];
+			vi.mocked(releaseIngestLock).mockImplementation(async () => {
+				order.push("release-ingest");
+			});
+			vi.mocked(wakePendingIngest).mockImplementation(async () => {
+				order.push("wake-ingest");
+			});
+			vi.mocked(drainIngest).mockResolvedValue({ batches: 1, ingested: 1, outcome: "OK", topicFailures: [] });
+
+			const op = makeIngestOp("post-merge");
+			vi.mocked(dequeueAllGitOperations).mockResolvedValue([{ op, filePath: "/tmp/queue/ingest.json" }]);
+
+			await runWorker("/test/cwd");
+
+			expect(order).toEqual(["release-ingest", "wake-ingest"]);
 		});
 
 		it("skips drainIngest when no API key is configured", async () => {
@@ -2767,9 +2754,7 @@ describe("QueueWorker", () => {
 			delete process.env.ANTHROPIC_API_KEY;
 
 			const op = makeIngestOp("recall-miss");
-			vi.mocked(dequeueAllGitOperations)
-				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/ingest.json" }])
-				.mockResolvedValueOnce([]);
+			vi.mocked(dequeueAllGitOperations).mockResolvedValue([{ op, filePath: "/tmp/queue/ingest.json" }]);
 
 			await runWorker("/test/cwd");
 
@@ -2785,9 +2770,7 @@ describe("QueueWorker", () => {
 			vi.mocked(drainIngest).mockResolvedValue({ batches: 1, ingested: 0, outcome: "OK", topicFailures: [] });
 
 			const op = makeIngestOp("manual");
-			vi.mocked(dequeueAllGitOperations)
-				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/ingest.json" }])
-				.mockResolvedValueOnce([]);
+			vi.mocked(dequeueAllGitOperations).mockResolvedValue([{ op, filePath: "/tmp/queue/ingest.json" }]);
 
 			await runWorker("/test/cwd");
 
@@ -2803,9 +2786,7 @@ describe("QueueWorker", () => {
 			vi.mocked(createStorage).mockResolvedValueOnce(storageWithWiki(false));
 
 			const op = makeIngestOp("manual");
-			vi.mocked(dequeueAllGitOperations)
-				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/ingest.json" }])
-				.mockResolvedValueOnce([]);
+			vi.mocked(dequeueAllGitOperations).mockResolvedValue([{ op, filePath: "/tmp/queue/ingest.json" }]);
 
 			await runWorker("/test/cwd");
 
@@ -2818,9 +2799,7 @@ describe("QueueWorker", () => {
 			vi.mocked(createStorage).mockResolvedValueOnce(storageWithWiki(true));
 
 			const op = makeIngestOp("manual");
-			vi.mocked(dequeueAllGitOperations)
-				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/ingest.json" }])
-				.mockResolvedValueOnce([]);
+			vi.mocked(dequeueAllGitOperations).mockResolvedValue([{ op, filePath: "/tmp/queue/ingest.json" }]);
 
 			await runWorker("/test/cwd");
 
@@ -2832,9 +2811,7 @@ describe("QueueWorker", () => {
 			vi.mocked(drainIngest).mockResolvedValue({ batches: 1, ingested: 2, outcome: "OK", topicFailures: [] });
 
 			const op = makeIngestOp("post-merge");
-			vi.mocked(dequeueAllGitOperations)
-				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/ingest.json" }])
-				.mockResolvedValueOnce([]);
+			vi.mocked(dequeueAllGitOperations).mockResolvedValue([{ op, filePath: "/tmp/queue/ingest.json" }]);
 
 			await runWorker("/test/cwd");
 

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -223,6 +223,13 @@ vi.mock("../core/SummaryStore.js", async (importOriginal) => {
 		storeNotes: vi.fn(),
 		storeReferences: vi.fn().mockResolvedValue(undefined),
 		setActiveStorage: vi.fn(),
+		// Passthrough spy for the ingest writeGuard's inner orphan-write.lock. Runs
+		// the body without touching the real lock file (the acquire/release contract
+		// is covered in SummaryStore.test.ts); tests here assert the WIRING — that
+		// ingest writes now flow through this lock, nested inside vault-write.lock.
+		withRequiredOrphanWriteLock: vi.fn(
+			async (_cwd: string | undefined, _label: string, fn: () => Promise<unknown>) => fn(),
+		),
 		// Real implementations -- runSquashPipeline / handleAmendPipeline call
 		// these to expand source commits and copy-hoist topics. The mocks above
 		// cover the storage write side; these helpers are pure tree transforms
@@ -390,12 +397,12 @@ import {
 import { cleanupBranchStaleChildMarkdown } from "../core/StaleChildMarkdownCleanup.js";
 import { createStorage } from "../core/StorageFactory.js";
 import { generateSummary } from "../core/Summarizer.js";
-import { storeSummary } from "../core/SummaryStore.js";
+import { storeSummary, withRequiredOrphanWriteLock } from "../core/SummaryStore.js";
 import { renderTopicKBWiki } from "../core/TopicWikiRenderer.js";
 import { buildMultiSessionContext, readTranscript } from "../core/TranscriptReader.js";
 import { buildKnowledgeGraph } from "../graph/GraphBuilder.js";
 import { recordPendingWorker, wakePendingWorkers } from "../sync/PendingWorkers.js";
-import { acquireVaultWriteLock } from "../sync/VaultWriteLock.js";
+import { acquireVaultWriteLock, withVaultWriteLock } from "../sync/VaultWriteLock.js";
 import type { CommitGitOperation, IngestOperation } from "../Types.js";
 import { __test__, buildWorkerStartupBanner, launchWorker, runWorker } from "./QueueWorker.js";
 
@@ -2687,6 +2694,71 @@ describe("QueueWorker", () => {
 			const drainOpts = vi.mocked(drainIngest).mock.calls[0]?.[2];
 			expect(typeof drainOpts?.writeGuard).toBe("function");
 			expect(typeof vi.mocked(renderTopicKBWiki).mock.calls[0]?.[2]).toBe("function");
+		});
+
+		it("routes each ingest write through orphan-write.lock (PR1: ingest orphan-ref writes self-lock)", async () => {
+			// PR1 wraps the ingest writeGuard body in `withRequiredOrphanWriteLock`
+			// so ingest's orphan-ref writes serialise against summary writes on the
+			// same lock. Drive the guard with a sentinel write and assert it flowed
+			// through the orphan lock with the "ingest-write" label.
+			vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-test" } as never);
+			let sentinelRan = false;
+			vi.mocked(drainIngest).mockImplementation(async (_op, _cwd, opts) => {
+				await opts?.writeGuard?.(async () => {
+					sentinelRan = true;
+				});
+				return { batches: 1, ingested: 1, outcome: "OK", topicFailures: [] };
+			});
+
+			const op = makeIngestOp("post-merge");
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/ingest.json" }])
+				.mockResolvedValueOnce([]);
+
+			await runWorker("/test/cwd");
+
+			expect(sentinelRan).toBe(true);
+			expect(vi.mocked(withRequiredOrphanWriteLock)).toHaveBeenCalledWith(
+				"/test/cwd",
+				"ingest-write",
+				expect.any(Function),
+			);
+		});
+
+		it("nests orphan-write.lock INSIDE vault-write.lock in the ingest writeGuard (vault→orphan order)", async () => {
+			// Lock-ordering guarantee: the ingest writeGuard must take vault-write.lock
+			// (outer) then orphan-write.lock (inner), matching the summary path's
+			// vault→orphan direction so the two never deadlock. Record entry order of
+			// both locks plus the actual write.
+			vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-test" } as never);
+			const order: string[] = [];
+			vi.mocked(withVaultWriteLock).mockImplementationOnce(
+				async (_root: string, _mode: unknown, body: () => Promise<unknown>) => {
+					order.push("vault");
+					return { ran: true, value: await body() };
+				},
+			);
+			vi.mocked(withRequiredOrphanWriteLock).mockImplementationOnce(
+				async (_cwd: string | undefined, label: string, fn: () => Promise<unknown>) => {
+					order.push(`orphan:${label}`);
+					return fn();
+				},
+			);
+			vi.mocked(drainIngest).mockImplementation(async (_op, _cwd, opts) => {
+				await opts?.writeGuard?.(async () => {
+					order.push("write");
+				});
+				return { batches: 1, ingested: 1, outcome: "OK", topicFailures: [] };
+			});
+
+			const op = makeIngestOp("post-merge");
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/ingest.json" }])
+				.mockResolvedValueOnce([]);
+
+			await runWorker("/test/cwd");
+
+			expect(order).toEqual(["vault", "orphan:ingest-write", "write"]);
 		});
 
 		it("skips drainIngest when no API key is configured", async () => {

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -93,6 +93,7 @@ import {
 	storeReferences,
 	storeSummary,
 	stripFunctionalMetadata,
+	withRequiredOrphanWriteLock,
 } from "../core/SummaryStore.js";
 import { resolveTranscriptIdsFiltered } from "../core/SummaryTree.js";
 import { getTelemetryContext, track } from "../core/Telemetry.js";
@@ -605,10 +606,24 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 			// final backstop.
 			await wakeWaiters();
 			const writeGuard = async (fn: () => Promise<void>): Promise<void> => {
-				const r = await withVaultWriteLock(memoryBankRoot, { wait: DEFAULT_VAULT_WRITE_WAIT_MS }, fn, {
-					launch: launchWorker,
-					selfCwd: cwd,
-				});
+				const r = await withVaultWriteLock(
+					memoryBankRoot,
+					{ wait: DEFAULT_VAULT_WRITE_WAIT_MS },
+					// Inner orphan-write.lock: matches the summary write path's
+					// vault→orphan lock ordering so ingest's orphan-ref writes
+					// (saveTopicPage / saveTopicIndex / saveProcessedSet) serialise
+					// against summary writes on the same lock. Today the two run
+					// serially so this never contends; it's the groundwork for
+					// splitting worker.lock (lets summary + ingest run concurrently)
+					// without an orphan-ref torn write. The folder-only wiki write
+					// this also wraps is already covered by vault-write.lock — the
+					// extra orphan lock there is harmless.
+					() => withRequiredOrphanWriteLock(cwd, "ingest-write", fn),
+					{
+						launch: launchWorker,
+						selfCwd: cwd,
+					},
+				);
 				// Typed busy signal (shared verbatim with the compile guards) so
 				// drainIngest's page-write catch can tell contention from a real fault.
 				if (!r.ran) throw new VaultWriteBusyError();

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -36,10 +36,13 @@ import { readGeminiTranscript } from "../core/GeminiTranscriptReader.js";
 import { getCommitInfo, getCurrentBranch, getDiffContent, getDiffStats } from "../core/GitOps.js";
 import { enqueueIngestOperation } from "../core/IngestTrigger.js";
 import {
+	acquireIngestLock,
 	acquireWorkerLock,
+	INGEST_PHASE_FILE,
+	refreshIngestLockMtime,
 	refreshWorkerLockMtime,
+	releaseIngestLock,
 	releaseWorkerLock,
-	WORKER_PHASE_FILE,
 	withPlansLock,
 } from "../core/Locks.js";
 import { formatNotesBlock } from "../core/NotePromptFormatter.js";
@@ -106,6 +109,7 @@ import { buildMultiSessionContext, readTranscript } from "../core/TranscriptRead
 import { buildKnowledgeGraph } from "../graph/GraphBuilder.js";
 import { deriveSourceTag } from "../install/DistPathResolver.js";
 import { createLogger, errMsg, getJolliMemoryDir, setLogDir, setLogLevel } from "../Logger.js";
+import { recordPendingIngest, wakePendingIngest } from "../sync/PendingIngest.js";
 import { recordPendingWorker, wakePendingWorkers } from "../sync/PendingWorkers.js";
 import { deriveMemoryBankRoot } from "../sync/SyncBootstrap.js";
 import {
@@ -409,13 +413,11 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 	}, WORKER_LOCK_REFRESH_INTERVAL_MS);
 	/* v8 ignore stop */
 
-	// vault-write.lock is released BEFORE the unlocked-ingest phase, but worker.lock
-	// is held THROUGH it (see that phase below). Releasing the vault-wide lock lets
-	// cross-repo commit-summary workers proceed; holding the per-repo worker.lock
-	// keeps the ingest's worker-phase marker and topic-page writes uncontested
-	// within this repo — no same-repo summary worker (which would clear the marker)
-	// and no second ingest can race. `releaseVault` is idempotent: called explicitly
-	// before ingest and again in the outer finally as the error-path backstop.
+	// vault-write.lock is released BEFORE the ingest phase, and so is worker.lock,
+	// so a same-repo summary worker can run concurrently with the ingest (which
+	// takes its own `ingest.lock`).
+	// `releaseVault` is idempotent: called explicitly before ingest and again in
+	// the outer finally as the error-path backstop.
 	let vaultReleased = false;
 	const releaseVault = async (): Promise<void> => {
 		if (vaultReleased) return;
@@ -436,16 +438,13 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 		await wakePendingWorkers(memoryBankRoot, launchWorker, cwd);
 	};
 
-	// A dequeued ingest entry only flips this flag inside the locked drain; its long
-	// reconcile LLM phase runs in the unlocked-ingest phase below (worker.lock held,
-	// vault-write.lock released) so it never holds the vault-wide lock.
+	// Storage is created once worker.lock is held; the ingest phase (below,
+	// after worker.lock is already released) reuses it under `ingest.lock`.
 	let storage: StorageProvider | null = null;
-	let ingestRequested = false;
-	let ingestTriggeredBy: IngestOperation["triggeredBy"] = "post-commit";
-	// worker.lock (per-repo) is released only AFTER the unlocked-ingest phase, so its
-	// mtime-refresh timer must outlive ingest too — otherwise the stale-lock reclaimer
-	// could hand the lock to a second worker mid-ingest. `releaseWorker` is idempotent
-	// (explicit release before the chain-spawn check, backstop in the outer finally).
+	// worker.lock (per-repo) is released BEFORE the ingest phase: ingest runs under
+	// its own `ingest.lock` so a same-repo summary worker can proceed concurrently.
+	// `releaseWorker` is idempotent (explicit release before the chain-spawn check,
+	// backstop in the outer finally).
 	let workerRefreshTimer: ReturnType<typeof setInterval> | undefined;
 	let workerLockReleased = true;
 	const releaseWorker = async (): Promise<void> => {
@@ -476,20 +475,6 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 		}
 		workerLockReleased = false;
 
-		// Clear a stale `worker-phase` marker at the source. Holding worker.lock
-		// proves no other worker for this repo is alive, so any leftover phase file
-		// was orphaned by a crashed/SIGKILL'd predecessor whose `finally` cleanup
-		// (in processQueueEntry) never ran. Removing it here keeps the file's
-		// lifetime genuinely lock-bound — otherwise it survives indefinitely and
-		// mislabels the next plain summary run as "Building knowledge wiki…".
-		try {
-			rmSync(join(getJolliMemoryDir(cwd), WORKER_PHASE_FILE), { force: true });
-		} catch (e) {
-			/* v8 ignore start -- best-effort cleanup; only an EPERM-class error reaches here and is non-fatal */
-			log.debug("stale worker-phase cleanup skipped (non-fatal): %s", errMsg(e));
-			/* v8 ignore stop */
-		}
-
 		// Periodically bump the worker.lock mtime — same rationale as
 		// vault-write.lock above.
 		/* v8 ignore start -- setInterval's lambda only fires on a real timer tick; unit tests finish in milliseconds and never observe the callback. */
@@ -509,25 +494,22 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 
 			while (processedCount < MAX_ENTRIES_PER_RUN) {
 				const entries = await dequeueAllGitOperations(cwd);
-				if (entries.length === 0) break;
+				// Drain ONLY summary (non-ingest) entries under worker.lock; ingest
+				// entries stay queued for the ingest phase below (run under ingest.lock,
+				// concurrently with any successor summary worker). Filtering — rather
+				// than the old "divert + delete" — is what stops the loop from spinning:
+				// an ingest-only queue yields an empty `summaryEntries` and we break,
+				// leaving the ingest entries intact for the ingest phase to consume.
+				const summaryEntries = entries.filter(
+					(e): e is { op: CommitGitOperation; filePath: string } => !isIngestOperation(e.op),
+				);
+				if (summaryEntries.length === 0) break;
 
-				for (const { op, filePath } of entries) {
+				for (const { op, filePath } of summaryEntries) {
 					// Hard cap: if a single dequeue batch returns more than MAX_ENTRIES_PER_RUN,
 					// stop inside the inner loop so the outer while condition can re-check and
 					// exit cleanly. The subsequent chain-spawn (line below) picks up leftovers.
 					if (processedCount >= MAX_ENTRIES_PER_RUN) break;
-					// Divert ingest out of the locked drain: record the request and consume
-					// the trigger entry. The reconcile runs in the unlocked-ingest phase
-					// after both entry-level locks are released, so its minutes-long LLM
-					// phase never holds vault-write.lock. Deleting here (we hold worker.lock)
-					// avoids an infinite re-dequeue; losing the trigger on a crash is benign
-					// — the next commit re-triggers and unprocessed sources stay pending.
-					if (isIngestOperation(op)) {
-						ingestRequested = true;
-						ingestTriggeredBy = op.triggeredBy;
-						await deleteQueueEntry(filePath);
-						continue;
-					}
 					try {
 						// Adopt the trace id stamped on the entry at enqueue time so this
 						// commit's summarize/consolidate logs + outbound LLM/push calls
@@ -550,11 +532,12 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 						// TODO: Support re-summarize for specific commits (e.g., after LLM quota
 						// replenishment). Requires persisting transcripts to the orphan branch BEFORE
 						// the LLM call so re-summarize can read them back without cursor dependency.
-						// Ingest is diverted before this try, so `op` here is always commit-typed.
+						// Only summary entries reach here (ingest entries are filtered out of
+						// `summaryEntries` above), so `op` is narrowed to CommitGitOperation.
 						log.error(
 							"Failed to process queue entry type=%s ref=%s: %s",
 							op.type,
-							(op as CommitGitOperation).commitHash.substring(0, 8),
+							op.commitHash.substring(0, 8),
 							(error as Error).message,
 						);
 					}
@@ -583,74 +566,101 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 		}
 		/* v8 ignore stop */
 
-		// Release vault-write.lock BEFORE the (potentially minutes-long) ingest:
-		// cross-repo commit-summary workers only need the vault-wide lock, which we
-		// no longer hold. worker.lock stays held so no same-repo worker races us.
+		// Release BOTH entry-level locks BEFORE ingest. vault-write.lock so
+		// cross-repo summary workers proceed; worker.lock so a SAME-repo summary
+		// worker (a commit landing during/after our drain) runs concurrently with
+		// the ingest below. Ingest re-acquires its writes' locks per-write via
+		// `writeGuard`, and takes its own `ingest.lock`.
 		await releaseVault();
-
-		// ── Unlocked-ingest phase (vault-write.lock released; worker.lock held) ───
-		// The reconcile LLM phase runs with NO vault-write.lock; only each individual
-		// write re-acquires it briefly via `writeGuard` (per topic page, plus the
-		// index / processed-set / wiki render), so a slow ingest never blocks the
-		// cross-repo commit-summary workers that wait on the same lock. Holding
-		// worker.lock throughout is what keeps it safe within THIS repo: no same-repo
-		// summary worker can run startup cleanup or processQueueEntry (and thus clear
-		// the `ingest` worker-phase marker) mid-run, and no second ingest can race
-		// this one. `storage` is null only if createStorage threw before the drain.
-		if (ingestRequested && storage !== null) {
-			// Wake cross-repo waiters now (vault-write.lock is free) so they don't idle
-			// through our ingest. Each per-write guard below ALSO wakes on its release
-			// (via the releaseHook), so a worker that times out and registers DURING the
-			// ingest is woken at the next per-write release rather than waiting for the
-			// whole drain — matching the compile paths. The outer-finally wake is the
-			// final backstop.
-			await wakeWaiters();
-			const writeGuard = async (fn: () => Promise<void>): Promise<void> => {
-				const r = await withVaultWriteLock(
-					memoryBankRoot,
-					{ wait: DEFAULT_VAULT_WRITE_WAIT_MS },
-					// Inner orphan-write.lock: matches the summary write path's
-					// vault→orphan lock ordering so ingest's orphan-ref writes
-					// (saveTopicPage / saveTopicIndex / saveProcessedSet) serialise
-					// against summary writes on the same lock. Today the two run
-					// serially so this never contends; it's the groundwork for
-					// splitting worker.lock (lets summary + ingest run concurrently)
-					// without an orphan-ref torn write. The folder-only wiki write
-					// this also wraps is already covered by vault-write.lock — the
-					// extra orphan lock there is harmless.
-					() => withRequiredOrphanWriteLock(cwd, "ingest-write", fn),
-					{
-						launch: launchWorker,
-						selfCwd: cwd,
-					},
-				);
-				// Typed busy signal (shared verbatim with the compile guards) so
-				// drainIngest's page-write catch can tell contention from a real fault.
-				if (!r.ran) throw new VaultWriteBusyError();
-			};
-			try {
-				const ingestOp: IngestOperation = {
-					type: "ingest",
-					triggeredBy: ingestTriggeredBy,
-					createdAt: new Date().toISOString(),
-				};
-				await runIngestEntry(ingestOp, cwd, storage, writeGuard);
-			} catch (e) {
-				log.error("Unlocked ingest phase failed (non-fatal): %s", errMsg(e));
-			}
-		}
-
-		// Release worker.lock, THEN chain-spawn: a same-repo successor (commits that
-		// arrived while we held the lock through ingest, plus the post-commit ingest
-		// trigger enqueued above) can acquire worker.lock immediately on its spawn.
 		await releaseWorker();
+		// Wake cross-repo vault waiters now that vault-write.lock is free.
+		await wakeWaiters();
+
+		// Chain-spawn only for SUMMARY leftovers: commits that arrived past the
+		// MAX_ENTRIES cap or during the drain. Ingest entries are deliberately NOT a
+		// chain-spawn trigger — they're consumed by the ingest phase below (and its
+		// `wakePendingIngest` hand-off), so spawning for them would double-run.
 		const remaining = await dequeueAllGitOperations(cwd);
-		/* v8 ignore start -- chain spawn only occurs when new entries arrive during worker processing */
-		if (remaining.length > 0) {
-			log.info("Queue has %d remaining entries — spawning chain worker", remaining.length);
+		/* v8 ignore start -- chain spawn only occurs when new summary entries arrive during processing */
+		if (remaining.some(({ op }) => !isIngestOperation(op))) {
+			log.info("Queue has remaining summary entries — spawning chain worker");
 			launchWorker(cwd);
 		}
 		/* v8 ignore stop */
+
+		// ── Ingest phase (no worker.lock; own ingest.lock) ───────────────────────
+		// Fully queue-driven and symmetric with summary: acquire the per-worktree
+		// `ingest.lock` fail-fast; if we lose it, record intent + retry once (closing
+		// the record/acquire TOCTOU) and otherwise leave the queued ingest entries for
+		// the current holder's `wakePendingIngest` to hand off. The holder captures the
+		// ingest entries, runs ONE ingest, and deletes them only on success (a crash /
+		// throw leaves them for the next run). `storage` is null only if createStorage
+		// threw before the drain.
+		if (storage !== null) {
+			const ingestEntries = (await dequeueAllGitOperations(cwd)).filter(({ op }) => isIngestOperation(op));
+			if (ingestEntries.length > 0) {
+				let acquired = await acquireIngestLock(cwd);
+				if (!acquired) {
+					await recordPendingIngest(cwd);
+					acquired = await acquireIngestLock(cwd);
+				}
+				if (acquired) {
+					// Declared before the try so the finally can always clear it; assigned
+					// as the try's first statement so a throw between acquire and here
+					// can't leak the lock or the timer (both are torn down in finally).
+					let ingestRefreshTimer: ReturnType<typeof setInterval> | undefined;
+					const writeGuard = async (fn: () => Promise<void>): Promise<void> => {
+						const r = await withVaultWriteLock(
+							memoryBankRoot,
+							{ wait: DEFAULT_VAULT_WRITE_WAIT_MS },
+							// Inner orphan-write.lock: matches the summary write path's
+							// vault→orphan lock ordering so ingest's orphan-ref writes serialise
+							// against the now-concurrent summary writes on the same lock. The
+							// folder-only wiki write this also wraps is already covered by
+							// vault-write.lock — the extra orphan lock there is harmless.
+							() => withRequiredOrphanWriteLock(cwd, "ingest-write", fn),
+							{ launch: launchWorker, selfCwd: cwd },
+						);
+						// Typed busy signal (shared verbatim with the compile guards) so
+						// drainIngest's page-write catch can tell contention from a real fault.
+						if (!r.ran) throw new VaultWriteBusyError();
+					};
+					try {
+						/* v8 ignore start -- timer callback only fires on a real timer tick; unit tests finish before it */
+						ingestRefreshTimer = setInterval(() => {
+							void refreshIngestLockMtime(cwd);
+						}, WORKER_LOCK_REFRESH_INTERVAL_MS);
+						/* v8 ignore stop */
+						// Re-read AFTER acquiring the lock: between the pre-check above and the
+						// acquire, another holder may have already consumed + deleted the batch.
+						const toRun = (await dequeueAllGitOperations(cwd)).filter(({ op }) => isIngestOperation(op));
+						if (toRun.length > 0) {
+							// triggeredBy from the OLDEST ingest entry (queue is timestamp-ordered).
+							const oldest = toRun[0].op as IngestOperation;
+							const ingestOp: IngestOperation = {
+								type: "ingest",
+								triggeredBy: oldest.triggeredBy,
+								createdAt: new Date().toISOString(),
+							};
+							await runIngestEntry(ingestOp, cwd, storage, writeGuard);
+							// Delete this batch only AFTER a successful run: a throw above skips
+							// these deletes, so the entries survive for the next run.
+							for (const { filePath } of toRun) await deleteQueueEntry(filePath);
+						}
+					} catch (e) {
+						log.error("Ingest phase failed (non-fatal): %s", errMsg(e));
+					} finally {
+						if (ingestRefreshTimer) clearInterval(ingestRefreshTimer);
+						// Release BEFORE waking: launchWorker is a detached spawn, so the woken
+						// worker must find the lock free to make progress.
+						await releaseIngestLock(cwd);
+						await wakePendingIngest(cwd, launchWorker);
+					}
+				}
+				// else (still lost the lock after recording): the current holder's
+				// `wakePendingIngest` will re-spawn us once it releases.
+			}
+		}
 	} finally {
 		// Backstops (idempotent): cover the early-return and mid-run-throw paths
 		// where the explicit releases above didn't run. worker.lock is released
@@ -662,49 +672,24 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 }
 
 /**
- * Second line of defense for the worker-phase marker. If the ingest `finally`
- * cleanup failed (e.g. Windows AV briefly holding the file), the marker still
- * reads an `ingest:*` sub-phase while this same drain processes blocking summary
- * entries — and the extension's Commit/Squash gates would stay open during
- * exactly the runs they must block. Retry the delete here; if the file is still
- * undeletable, overwrite the content so readers see a blocking phase (any value
- * not starting with `ingest` blocks). The reader-side mtime staleness check is
- * the final backstop when both attempts fail.
+ * Ingest sub-phases written to the cosmetic `ingest-phase` file. Ingest runs
+ * under its own `ingest.lock`, so this value has NO gate role — it only drives
+ * the VS Code sidebar's "Building knowledge wiki/graph…" pill. The full value is
+ * written verbatim so the extension's existing `indexOf('ingest')` /
+ * `indexOf('ingest:graph')` webview checks keep working unchanged.
  */
-function clearLeftoverIngestMarker(cwd: string): void {
-	const phaseFile = join(getJolliMemoryDir(cwd), WORKER_PHASE_FILE);
-	if (!existsSync(phaseFile)) return;
-	try {
-		rmSync(phaseFile, { force: true });
-	} catch {
-		/* v8 ignore start -- needs an OS-level rm failure; the inner catch additionally needs a write failure */
-		try {
-			writeFileSync(phaseFile, "summary");
-		} catch (e) {
-			log.warn("leftover worker-phase marker could not be cleared or overwritten: %s", errMsg(e));
-		}
-		/* v8 ignore stop */
-	}
-}
+type IngestSubPhase = "ingest:wiki" | "ingest:graph";
 
 /**
- * Ingest sub-phases written to the `worker-phase` marker. Both keep the
- * `ingest` prefix so the extension's commit/squash gates (which key off the
- * prefix) treat them identically — only the cosmetic label differs.
- */
-type IngestPhase = "ingest:wiki" | "ingest:graph";
-
-/**
- * Runs a topic-KB ingest with the extension's worker-phase marker around it.
+ * Runs a topic-KB ingest, writing the cosmetic `ingest-phase` file around it.
  *
- * Called from runWorker's UNLOCKED ingest phase (both entry-level locks already
- * released). The phase marker (`ingest:wiki` / `ingest:graph`) is consumed by
- * the extension's worker-busy gates (and the toolbar label): while it starts
- * with `ingest` AND is fresh, Commit/Squash stay enabled and the toolbar shows
- * the matching "Building knowledge wiki/graph…" label. `writeGuard` is threaded
- * down to drainIngest + renderTopicKBWiki so each individual write re-acquires
- * `vault-write.lock` briefly — the reconcile LLM phase between writes holds no
- * lock.
+ * Called from runWorker's ingest phase (both entry-level locks released; the
+ * worker holds `ingest.lock`). The phase file (`ingest:wiki` / `ingest:graph`)
+ * is purely a display signal for the extension's sidebar pill — it carries no
+ * gate role (commit/squash gate on `worker.lock`, which ingest no longer holds).
+ * `writeGuard` is threaded down to drainIngest + renderTopicKBWiki so each
+ * individual write re-acquires `vault-write.lock` (+ orphan-write.lock) briefly —
+ * the reconcile LLM phase between writes holds no lock.
  */
 async function runIngestEntry(
 	op: IngestOperation,
@@ -713,33 +698,30 @@ async function runIngestEntry(
 	writeGuard: (fn: () => Promise<void>) => Promise<void> = (fn) => fn(),
 ): Promise<void> {
 	log.info("Processing queue entry: type=ingest triggeredBy=%s", op.triggeredBy);
-	// Best-effort marker — a failure only over-blocks (missing marker = blocking
-	// summary phase), never under-blocks. The marker carries the ingest SUB-PHASE
-	// (`ingest:wiki` while ingesting + rendering the wiki, `ingest:graph` while
-	// building the knowledge graph) so the extension can show the matching label.
-	// Both keep the `ingest` prefix the gates key off — every `ingest:*` value is
-	// commit-exempt, so the prefix preserves the gating semantics unchanged.
-	const phaseFile = join(getJolliMemoryDir(cwd), WORKER_PHASE_FILE);
+	// Best-effort cosmetic phase file — drives the sidebar pill only. It carries
+	// the ingest SUB-PHASE (`ingest:wiki` while ingesting + rendering the wiki,
+	// `ingest:graph` while building the knowledge graph) so the extension can show
+	// the matching label. A write/cleanup failure only leaves the pill up a little
+	// longer (reader side bounds it by mtime staleness + `ingest.lock` liveness).
+	const phaseFile = join(getJolliMemoryDir(cwd), INGEST_PHASE_FILE);
 	// Shared by the initial write, the heartbeat, and the graph-phase switch
 	// (threaded into runIngestFromQueue as `setPhase`). The heartbeat MUST write
 	// this variable, not a literal, or it would clobber an already-advanced phase
 	// back to wiki and strand the sidebar on the wrong label.
-	let currentPhase: IngestPhase = "ingest:wiki";
-	const writePhase = (phase: IngestPhase) => {
+	let currentPhase: IngestSubPhase = "ingest:wiki";
+	const writePhase = (phase: IngestSubPhase) => {
 		currentPhase = phase;
 		try {
 			writeFileSync(phaseFile, phase);
 		} catch (e) {
-			/* v8 ignore next -- best-effort marker; a write failure only over-blocks */
-			log.debug("worker-phase write skipped (non-fatal): %s", errMsg(e));
+			/* v8 ignore next -- best-effort cosmetic file; a write failure only delays the pill */
+			log.debug("ingest-phase write skipped (non-fatal): %s", errMsg(e));
 		}
 	};
 	writePhase("ingest:wiki");
-	// Heartbeat: keep the marker's mtime fresh for the whole ingest. Readers
-	// treat a stale marker as blocking (fail-safe), so a long ingest needs this
-	// to stay exempt — and conversely an orphaned `ingest:*` marker (both the
-	// cleanup below and the per-entry guard failed) ages out instead of holding
-	// the gates open during a later summary run.
+	// Heartbeat: keep the file's mtime fresh for the whole ingest so the reader's
+	// staleness check keeps the pill up during a long ingest, and conversely an
+	// orphaned file (cleanup failed) ages out and the pill clears on its own.
 	/* v8 ignore start -- timer callback never fires inside fast unit tests */
 	const phaseRefreshTimer = setInterval(() => {
 		try {
@@ -750,8 +732,8 @@ async function runIngestEntry(
 	}, WORKER_LOCK_REFRESH_INTERVAL_MS);
 	/* v8 ignore stop */
 	try {
-		// `setPhase` lets runIngestFromQueue advance the marker to `ingest:graph`
-		// right before the (in-function) graph build — the marker owner lives here
+		// `setPhase` lets runIngestFromQueue advance the phase file to `ingest:graph`
+		// right before the (in-function) graph build — the file owner lives here
 		// but the graph phase boundary lives there.
 		await runIngestFromQueue(op, cwd, storage, writeGuard, (phase) => writePhase(phase));
 	} finally {
@@ -760,19 +742,17 @@ async function runIngestEntry(
 			rmSync(phaseFile, { force: true });
 		} catch (e) {
 			/* v8 ignore start -- needs an OS-level rm failure (e.g. Windows AV briefly holding the file) */
-			// A surviving `ingest` marker would keep the extension's gates open while
-			// a later summary run is in flight. Two backstops cover it:
-			// clearLeftoverIngestMarker before each commit-typed entry, and the
-			// reader-side mtime staleness check.
-			log.warn("worker-phase cleanup failed — relying on per-entry guard + staleness: %s", errMsg(e));
+			// A surviving phase file only keeps the sidebar pill up a bit longer;
+			// the reader-side staleness + `ingest.lock` liveness check clears it.
+			log.warn("ingest-phase cleanup failed — relying on reader-side staleness: %s", errMsg(e));
 			/* v8 ignore stop */
 		}
 	}
 }
 
 /**
- * Processes a single commit-typed queue entry. Ingest entries are diverted to
- * the unlocked-ingest phase by runWorker and never reach here.
+ * Processes a single commit-typed queue entry. Ingest entries are consumed by
+ * runWorker's ingest phase and never reach here.
  * Called by runWorker() for each entry in the queue.
  */
 async function processQueueEntry(
@@ -781,9 +761,6 @@ async function processQueueEntry(
 	storage: StorageProvider,
 	force: boolean,
 ): Promise<void> {
-	// A summary run must present a blocking phase to the extension's gates, so
-	// clear any `ingest` marker a failed cleanup left behind before starting.
-	clearLeftoverIngestMarker(cwd);
 	const commitOp = op as CommitGitOperation;
 	log.info("Processing queue entry: type=%s hash=%s", commitOp.type, commitOp.commitHash.substring(0, 8));
 
@@ -856,10 +833,10 @@ async function runIngestFromQueue(
 	cwd: string,
 	storage: StorageProvider,
 	writeGuard: (fn: () => Promise<void>) => Promise<void> = (fn) => fn(),
-	// Advances the worker-phase marker (the marker owner lives in runIngestEntry).
+	// Advances the cosmetic ingest-phase file (the file owner lives in runIngestEntry).
 	// Required — the sole caller always threads it — so there is no dead default
 	// branch to leave uncovered.
-	setPhase: (phase: IngestPhase) => void,
+	setPhase: (phase: IngestSubPhase) => void,
 ): Promise<void> {
 	const { drainIngest } = await import("../core/IngestPipeline.js");
 	const { renderTopicKBWiki } = await import("../core/TopicWikiRenderer.js");
@@ -879,10 +856,10 @@ async function runIngestFromQueue(
 	const wikiMissing = storage.isTopicWikiPresent ? !storage.isTopicWikiPresent() : false;
 	if (result.ingested > 0 || wikiMissing) {
 		await renderTopicKBWiki(cwd, storage, writeGuard);
-		// Advance the marker to the graph sub-phase right before the build so the
-		// sidebar swaps to "Building knowledge graph…". Still commit-exempt (same
-		// `ingest` prefix). Only reached when there was wiki work, so on a no-source
-		// commit the marker stays `ingest:wiki` and `ingest:graph` never shows.
+		// Advance the phase file to the graph sub-phase right before the build so the
+		// sidebar swaps to "Building knowledge graph…". Only reached when there was
+		// wiki work, so on a no-source commit the file stays `ingest:wiki` and
+		// `ingest:graph` never shows.
 		setPhase("ingest:graph");
 		// Refresh the knowledge graph alongside the wiki, on the same gate. Cheap
 		// now that it's diff-based: a no-op build (nothing changed) costs 0 LLM
@@ -3212,7 +3189,6 @@ export const __test__ = {
 	detectPlanSlugsFromRegistry,
 	detectUncommittedNoteIds,
 	hoistMetadataFromOldSummary,
-	clearLeftoverIngestMarker,
 	associatePlansWithCommit,
 	finalizeReferenceArchive,
 	executePipeline,

--- a/cli/src/sync/PendingIngest.test.ts
+++ b/cli/src/sync/PendingIngest.test.ts
@@ -1,0 +1,98 @@
+import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.spyOn(console, "log").mockImplementation(() => {});
+vi.spyOn(console, "warn").mockImplementation(() => {});
+
+import { getJolliMemoryDir } from "../Logger.js";
+import { consumePendingIngest, INGEST_PENDING_FILE, recordPendingIngest, wakePendingIngest } from "./PendingIngest.js";
+
+describe("PendingIngest", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "jolli-pending-ingest-"));
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	function flagPath(cwd: string): string {
+		return join(getJolliMemoryDir(cwd), INGEST_PENDING_FILE);
+	}
+
+	it("recordPendingIngest writes the single-slot flag", async () => {
+		await recordPendingIngest(tempDir);
+		await expect(stat(flagPath(tempDir))).resolves.toBeDefined();
+	});
+
+	it("recordPendingIngest is idempotent (same single slot)", async () => {
+		await recordPendingIngest(tempDir);
+		await recordPendingIngest(tempDir);
+		// Still exactly one flag; a second consume finds nothing.
+		expect(await consumePendingIngest(tempDir)).toBe(true);
+		expect(await consumePendingIngest(tempDir)).toBe(false);
+	});
+
+	it("consumePendingIngest returns false when no flag exists", async () => {
+		expect(await consumePendingIngest(tempDir)).toBe(false);
+	});
+
+	it("consumePendingIngest returns true and deletes the flag", async () => {
+		await recordPendingIngest(tempDir);
+		expect(await consumePendingIngest(tempDir)).toBe(true);
+		await expect(stat(flagPath(tempDir))).rejects.toThrow();
+	});
+
+	it("wakePendingIngest launches once when a waiter was recorded, then clears the flag", async () => {
+		await recordPendingIngest(tempDir);
+		const launch = vi.fn();
+		await wakePendingIngest(tempDir, launch);
+		expect(launch).toHaveBeenCalledOnce();
+		expect(launch).toHaveBeenCalledWith(tempDir);
+		// Flag consumed — a second wake is a no-op.
+		launch.mockClear();
+		await wakePendingIngest(tempDir, launch);
+		expect(launch).not.toHaveBeenCalled();
+	});
+
+	it("wakePendingIngest does not launch when no waiter was recorded", async () => {
+		const launch = vi.fn();
+		await wakePendingIngest(tempDir, launch);
+		expect(launch).not.toHaveBeenCalled();
+	});
+
+	it("wakePendingIngest swallows a launch failure (best-effort)", async () => {
+		await recordPendingIngest(tempDir);
+		const launch = vi.fn(() => {
+			throw new Error("spawn boom");
+		});
+		await expect(wakePendingIngest(tempDir, launch)).resolves.toBeUndefined();
+		expect(launch).toHaveBeenCalledOnce();
+	});
+
+	it("consumePendingIngest tolerates a pre-existing raw flag file", async () => {
+		// A flag written directly (e.g. by another process) is still consumable.
+		await mkdir(getJolliMemoryDir(tempDir), { recursive: true });
+		await writeFile(flagPath(tempDir), "2026-01-01T00:00:00.000Z", "utf-8");
+		expect(await consumePendingIngest(tempDir)).toBe(true);
+	});
+
+	it("recordPendingIngest swallows a filesystem failure (best-effort)", async () => {
+		// Make the jollimemory dir un-creatable: put a FILE where its parent
+		// (`<cwd>/.jolli`) must be a directory, so mkdir(recursive) throws ENOTDIR.
+		await writeFile(join(tempDir, ".jolli"), "not a dir", "utf-8");
+		await expect(recordPendingIngest(tempDir)).resolves.toBeUndefined();
+	});
+
+	it("consumePendingIngest returns true even when the flag delete fails", async () => {
+		// A directory at the flag path: stat() sees it (so "pending" is true), but
+		// rm(force:true) without recursive refuses a directory → the catch fires and
+		// we still report the waiter as consumed.
+		await mkdir(flagPath(tempDir), { recursive: true });
+		expect(await consumePendingIngest(tempDir)).toBe(true);
+	});
+});

--- a/cli/src/sync/PendingIngest.ts
+++ b/cli/src/sync/PendingIngest.ts
@@ -1,0 +1,103 @@
+/**
+ * Per-worktree pending-ingest hand-off for the QueueWorker ingest phase.
+ *
+ * The degenerate sibling of {@link ./PendingWorkers}. `PendingWorkers` is the
+ * per-VAULT, cross-repo registry for workers that time out on the per-vault
+ * `vault-write.lock`; it must fan out to many sibling repos. `ingest.lock` is
+ * per-worktree, so the only worker that ever needs waking is THIS worktree's
+ * own next run — the registry collapses to a single `ingest-pending` flag file
+ * next to `ingest.lock`.
+ *
+ * Flow (see `QueueWorker.runWorker`'s ingest phase):
+ *   - A worker that loses the fail-fast `acquireIngestLock` calls
+ *     `recordPendingIngest`, then retries the acquire once. Recording BEFORE
+ *     the retry closes the record/acquire TOCTOU: if the holder releases in the
+ *     gap, either our retry wins the lock, or the holder's `wakePendingIngest`
+ *     already sees our flag — the ingest can't be stranded either way (mirrors
+ *     the `vault-write.lock` fail-fast retry in `runWorker`).
+ *   - The worker that DID hold `ingest.lock` calls `wakePendingIngest` AFTER
+ *     `releaseIngestLock` in its `finally`. The wake must follow the release
+ *     because `launchWorker` is a detached spawn — the freshly-spawned worker
+ *     has to be able to win the now-free lock.
+ *
+ * `launchWorker` is idempotent: a worker that starts against an ingest-free
+ * queue drains nothing in its ingest phase and exits cheaply, so waking after
+ * the holder already consumed every ingest entry is a benign no-op. We
+ * therefore do NOT re-check the queue here — keeping this module free of any
+ * SessionTracker/queue coupling, exactly as `PendingWorkers` stays free of the
+ * spawn helper.
+ */
+
+import { mkdir, rm, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createLogger, getJolliMemoryDir } from "../Logger.js";
+
+const log = createLogger("Sync:PendingIngest");
+
+/** Single-slot flag file; presence = "this worktree has an ingest worker waiting". */
+export const INGEST_PENDING_FILE = "ingest-pending";
+
+function pendingIngestPath(cwd?: string): string {
+	return join(getJolliMemoryDir(cwd), INGEST_PENDING_FILE);
+}
+
+/**
+ * Records that a worker wanted to run ingest for `cwd` but lost the
+ * `ingest.lock` race, so the current holder should re-spawn it on release.
+ * Idempotent (single flag file) and best-effort — a write failure only means
+ * this waiter won't be auto-woken; its queue entry stays on disk for the next
+ * post-commit hook.
+ */
+export async function recordPendingIngest(cwd?: string): Promise<void> {
+	try {
+		await mkdir(getJolliMemoryDir(cwd), { recursive: true });
+		await writeFile(pendingIngestPath(cwd), new Date().toISOString(), "utf-8");
+		log.info("Recorded pending ingest for this worktree");
+	} catch (e) {
+		log.warn("recordPendingIngest failed (non-fatal): %s", (e as Error).message);
+	}
+}
+
+/**
+ * Reads-and-clears the pending-ingest flag. Returns true when a waiter was
+ * recorded (and has now been consumed). Deleting BEFORE the caller acts on the
+ * result mirrors `consumePendingWorkers`: a producer that races in after the
+ * `rm` simply re-arms the flag for the next release.
+ */
+export async function consumePendingIngest(cwd?: string): Promise<boolean> {
+	const path = pendingIngestPath(cwd);
+	try {
+		await stat(path);
+	} catch {
+		return false; // no flag — nothing pending
+	}
+	try {
+		await rm(path, { force: true });
+	} catch (e) {
+		// The stat above proved it existed; a failed rm would leave the flag to
+		// trigger one redundant (idempotent) spawn next time. Non-fatal.
+		log.warn("consumePendingIngest: rm failed (non-fatal): %s", (e as Error).message);
+	}
+	return true;
+}
+
+/**
+ * If a pending-ingest waiter was recorded for `cwd`, consume the flag and
+ * `launch` a fresh worker so the recorded waiter's ingest work isn't stranded
+ * until the next commit. MUST be called AFTER `releaseIngestLock` so the
+ * spawned worker can win the lock.
+ *
+ * `launch` is injected (not imported) so this stays in the sync layer, matching
+ * `wakePendingWorkers`. Best-effort: a launch failure is logged and swallowed —
+ * the waiter's queue entry remains on disk for the next post-commit hook.
+ */
+export async function wakePendingIngest(cwd: string, launch: (cwd: string) => void): Promise<void> {
+	const wasPending = await consumePendingIngest(cwd);
+	if (!wasPending) return;
+	try {
+		log.info("Waking pending ingest worker for this worktree");
+		launch(cwd);
+	} catch (e) {
+		log.warn("wakePendingIngest: launch failed (non-fatal): %s", (e as Error).message);
+	}
+}

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -45,8 +45,9 @@ const { mockNotifyEnabledChanged, mockNotifyAuthChanged, mockToggleStatus, mockN
 		mockNotifyColdStart: vi.fn(),
 	}));
 
-const { isWorkerBusy } = vi.hoisted(() => ({
+const { isWorkerBusy, readIngestPhase } = vi.hoisted(() => ({
 	isWorkerBusy: vi.fn(),
+	readIngestPhase: vi.fn(),
 }));
 
 const { loadConfig, getGlobalConfigDir, saveConfig, saveConfigScoped } =
@@ -475,9 +476,9 @@ const {
 		checkboxCallbacks: checkboxCallbacks_,
 		visibilityCallbacks: visibilityCallbacks_,
 		openExternal: vi.fn().mockResolvedValue(true),
-		// Backs `vscode.workspace.fs.readFile` (worker-phase marker reads).
+		// Backs `vscode.workspace.fs.readFile` (ingest-phase marker reads).
 		// Defaults to rejection = file missing, matching the pre-mock behavior
-		// where the absent `fs` property made readWorkerPhase throw-and-catch.
+		// where the absent `fs` property made the phase read throw-and-catch.
 		fsReadFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
 	};
 });
@@ -844,7 +845,7 @@ const {
 			setEnabled: vi.fn(),
 			setMigrating: vi.fn(),
 			setWorkerBusy: vi.fn(),
-			setWorkerPhase: vi.fn(),
+			setIngest: vi.fn(),
 			setExtensionOutdated: vi.fn(),
 			setStatus: vi.fn(),
 			setMainBranch: vi.fn(),
@@ -908,6 +909,7 @@ vi.mock("./util/ExcludeFilterManager.js", () => ({
 
 vi.mock("./util/LockUtils.js", () => ({
 	isWorkerBusy,
+	readIngestPhase,
 }));
 
 vi.mock("./util/Logger.js", () => ({
@@ -1174,6 +1176,7 @@ describe("Extension", () => {
 		indexNeedsMigration.mockResolvedValue(false);
 		cleanupV1IfExpired.mockResolvedValue(undefined);
 		isWorkerBusy.mockResolvedValue(false);
+		readIngestPhase.mockResolvedValue({ busy: false, phase: null });
 		loadConfig.mockResolvedValue({});
 
 		// Reset provider mocks to defaults
@@ -5238,188 +5241,80 @@ describe("Extension", () => {
 			);
 		});
 
-		// The workerBusy context key gates the commitAI / squash commands'
-		// `enablement`. The ingest phase (Memory Bank wiki update) must NOT
-		// block them — only summary runs do — so when the worker-phase marker
-		// reads an `ingest:*` sub-phase the context flips to false even while the
-		// lock is held, and flips back when the marker is deleted (lock still held).
-		it("exempts an ingest sub-phase from the workerBusy context key and forwards the full phase", async () => {
-			// Watcher indices: 0=sessions, 1=head, 2=orphan-ref, 3=lock, 4=phase.
-			const lockWatcher = createFileSystemWatcher.mock.results[3]?.value;
+		// The ingest phase is purely cosmetic: it drives the sidebar
+		// "Building knowledge wiki/graph…" pill via statusStore.setIngest and
+		// never touches the `jollimemory.workerBusy` context key. Ingest runs
+		// under its own `ingest.lock`, so it can never gate Commit/Squash.
+		it("forwards the ingest state to setIngest on create/change and never touches the workerBusy context", async () => {
+			// Watcher indices: 0=sessions, 1=head, 2=orphan-ref, 3=lock, 4=ingest-phase.
 			const phaseWatcher = createFileSystemWatcher.mock.results[4]?.value;
-			const onLockCreate = lockWatcher?.onDidCreate.mock.calls[0]?.[0] as
-				| (() => void)
-				| undefined;
 			const onPhaseCreate = phaseWatcher?.onDidCreate.mock.calls[0]?.[0] as
-				| (() => void)
-				| undefined;
-			const onPhaseDelete = phaseWatcher?.onDidDelete.mock.calls[0]?.[0] as
-				| (() => void)
-				| undefined;
-			expect(onPhaseCreate).toBeDefined();
-			expect(onPhaseDelete).toBeDefined();
-
-			onLockCreate?.();
-			executeCommand.mockClear();
-
-			fsReadFile.mockResolvedValueOnce(Buffer.from("ingest:wiki"));
-			onPhaseCreate?.();
-
-			await vi.waitFor(() => {
-				// The full sub-phase value is forwarded (not collapsed to "ingest"),
-				// so the sidebar can pick the wiki vs graph label.
-				expect(mockStatusStore.setWorkerPhase).toHaveBeenCalledWith("ingest:wiki");
-				expect(executeCommand).toHaveBeenCalledWith(
-					"setContext",
-					"jollimemory.workerBusy",
-					false,
-				);
-			});
-
-			// Phase advances to the graph build — still commit-exempt (ingest prefix),
-			// and the graph value is forwarded verbatim.
-			executeCommand.mockClear();
-			mockStatusStore.setWorkerPhase.mockClear();
-			fsReadFile.mockResolvedValueOnce(Buffer.from("ingest:graph"));
-			onPhaseCreate?.();
-
-			await vi.waitFor(() => {
-				expect(mockStatusStore.setWorkerPhase).toHaveBeenCalledWith("ingest:graph");
-				expect(executeCommand).toHaveBeenCalledWith(
-					"setContext",
-					"jollimemory.workerBusy",
-					false,
-				);
-			});
-
-			// Marker removed (ingest finished) while the lock is still held →
-			// back to blocking semantics for the rest of the drain.
-			executeCommand.mockClear();
-			onPhaseDelete?.();
-
-			expect(mockStatusStore.setWorkerPhase).toHaveBeenCalledWith(null);
-			expect(executeCommand).toHaveBeenCalledWith(
-				"setContext",
-				"jollimemory.workerBusy",
-				true,
-			);
-		});
-
-		// Regression: readWorkerPhase awaits a readFile, and the lock-delete path
-		// clears the phase flag synchronously. A phase read that started during
-		// ingest but resolved AFTER the worker finished used to resurrect a stale
-		// "ingest" flag with no worker running; the next summary run's
-		// setWorkerBusy(true) then computed a non-blocking context and left
-		// Commit/Squash enabled mid-summary. The epoch token must discard the
-		// superseded read.
-		it("discards an in-flight phase read superseded by the lock-delete clear", async () => {
-			const lockWatcher = createFileSystemWatcher.mock.results[3]?.value;
-			const phaseWatcher = createFileSystemWatcher.mock.results[4]?.value;
-			const onLockCreate = lockWatcher?.onDidCreate.mock.calls[0]?.[0] as
-				| (() => void)
-				| undefined;
-			const onLockDelete = lockWatcher?.onDidDelete.mock.calls[0]?.[0] as
 				| (() => void)
 				| undefined;
 			const onPhaseChange = phaseWatcher?.onDidChange.mock.calls[0]?.[0] as
 				| (() => void)
 				| undefined;
-			expect(onLockDelete).toBeDefined();
+			expect(onPhaseCreate).toBeDefined();
 			expect(onPhaseChange).toBeDefined();
 
-			// Worker running an ingest; a phase read kicks off but its readFile
-			// stays pending until after the worker has finished.
-			onLockCreate?.();
-			let resolveRead: ((bytes: Buffer) => void) | undefined;
-			fsReadFile.mockImplementationOnce(
-				() =>
-					new Promise<Buffer>(resolve => {
-						resolveRead = resolve;
-					}),
-			);
+			executeCommand.mockClear();
+			mockStatusStore.setIngest.mockClear();
+			readIngestPhase.mockResolvedValueOnce({ busy: true, phase: "wiki" });
+			onPhaseCreate?.();
+
+			await vi.waitFor(() => {
+				expect(mockStatusStore.setIngest).toHaveBeenCalledWith(true, "wiki");
+			});
+
+			// Phase advances to the graph build — forwarded verbatim.
+			mockStatusStore.setIngest.mockClear();
+			readIngestPhase.mockResolvedValueOnce({ busy: true, phase: "graph" });
 			onPhaseChange?.();
 
-			// Worker finishes: the lock-delete handler clears the phase flag
-			// synchronously and bumps the read epoch.
-			onLockDelete?.();
-			mockStatusStore.setWorkerPhase.mockClear();
+			await vi.waitFor(() => {
+				expect(mockStatusStore.setIngest).toHaveBeenCalledWith(true, "graph");
+			});
 
-			// The stale read resolves with pre-delete content — must be discarded.
-			resolveRead?.(Buffer.from("ingest"));
-			await new Promise(resolve => setTimeout(resolve, 0));
-			expect(mockStatusStore.setWorkerPhase).not.toHaveBeenCalledWith("ingest");
-
-			// Next (non-ingest) summary run: the context must be blocking, proving
-			// the stale ingest flag did not survive into setWorkerBusy(true).
-			executeCommand.mockClear();
-			onLockCreate?.();
-			expect(executeCommand).toHaveBeenCalledWith(
+			// The ingest watcher must never write the workerBusy context key.
+			expect(executeCommand).not.toHaveBeenCalledWith(
 				"setContext",
 				"jollimemory.workerBusy",
-				true,
+				expect.anything(),
 			);
 		});
 
-		it("clears the phase when the marker holds a non-ingest value", async () => {
-			// content !== "ingest" → the false arm of `workerPhaseIsIngest ? ... : null`.
+		it("clears the pill directly with setIngest(false, null) when the marker is deleted", () => {
+			// An explicit delete is authoritative teardown — clear the pill directly
+			// rather than re-reading (the ingest.lock backstop could otherwise
+			// momentarily resurrect a stale pill until the staleness timer fires).
 			const phaseWatcher = createFileSystemWatcher.mock.results[4]?.value;
-			const onPhaseChange = phaseWatcher?.onDidChange.mock.calls[0]?.[0] as (() => void) | undefined;
+			const onPhaseDelete = phaseWatcher?.onDidDelete.mock.calls[0]?.[0] as
+				| (() => void)
+				| undefined;
+			expect(onPhaseDelete).toBeDefined();
+
+			mockStatusStore.setIngest.mockClear();
+			onPhaseDelete?.();
+
+			expect(mockStatusStore.setIngest).toHaveBeenCalledWith(false, null);
+		});
+
+		it("forwards a not-busy ingest read (stale / non-ingest marker) to setIngest(false, null)", async () => {
+			// readIngestPhase resolves not-busy for a stale or non-ingest marker;
+			// whatever it returns is forwarded straight to setIngest.
+			const phaseWatcher = createFileSystemWatcher.mock.results[4]?.value;
+			const onPhaseChange = phaseWatcher?.onDidChange.mock.calls[0]?.[0] as
+				| (() => void)
+				| undefined;
 			expect(onPhaseChange).toBeDefined();
 
-			fsReadFile.mockResolvedValueOnce(Buffer.from("summary"));
-			mockStatusStore.setWorkerPhase.mockClear();
+			mockStatusStore.setIngest.mockClear();
+			readIngestPhase.mockResolvedValueOnce({ busy: false, phase: null });
 			onPhaseChange?.();
 
 			await vi.waitFor(() => {
-				expect(mockStatusStore.setWorkerPhase).toHaveBeenCalledWith(null);
+				expect(mockStatusStore.setIngest).toHaveBeenCalledWith(false, null);
 			});
-		});
-
-		it("clears the phase when the marker read fails (missing / unreadable file)", async () => {
-			// readFile rejection → the catch clears the phase (epoch unchanged).
-			const phaseWatcher = createFileSystemWatcher.mock.results[4]?.value;
-			const onPhaseChange = phaseWatcher?.onDidChange.mock.calls[0]?.[0] as (() => void) | undefined;
-			expect(onPhaseChange).toBeDefined();
-
-			fsReadFile.mockRejectedValueOnce(new Error("ENOENT"));
-			mockStatusStore.setWorkerPhase.mockClear();
-			onPhaseChange?.();
-
-			await vi.waitFor(() => {
-				expect(mockStatusStore.setWorkerPhase).toHaveBeenCalledWith(null);
-			});
-		});
-
-		it("discards a FAILED in-flight phase read superseded by the lock-delete clear", async () => {
-			// The catch path also honours the epoch token: a read that REJECTS after a
-			// lock-delete bumped the epoch must not apply its (now stale) clear.
-			const lockWatcher = createFileSystemWatcher.mock.results[3]?.value;
-			const phaseWatcher = createFileSystemWatcher.mock.results[4]?.value;
-			const onLockCreate = lockWatcher?.onDidCreate.mock.calls[0]?.[0] as (() => void) | undefined;
-			const onLockDelete = lockWatcher?.onDidDelete.mock.calls[0]?.[0] as (() => void) | undefined;
-			const onPhaseChange = phaseWatcher?.onDidChange.mock.calls[0]?.[0] as (() => void) | undefined;
-			expect(onLockDelete).toBeDefined();
-			expect(onPhaseChange).toBeDefined();
-
-			onLockCreate?.();
-			let rejectRead: ((e: Error) => void) | undefined;
-			fsReadFile.mockImplementationOnce(
-				() =>
-					new Promise<Buffer>((_resolve, reject) => {
-						rejectRead = reject;
-					}),
-			);
-			onPhaseChange?.();
-
-			// Worker finishes → epoch bumps before the read settles.
-			onLockDelete?.();
-			mockStatusStore.setWorkerPhase.mockClear();
-
-			rejectRead?.(new Error("read aborted"));
-			await new Promise((resolve) => setTimeout(resolve, 0));
-
-			// epoch changed → the catch early-returns; no stale phase write.
-			expect(mockStatusStore.setWorkerPhase).not.toHaveBeenCalled();
 		});
 
 		it("refreshes status and plans when sessions watcher fires", async () => {

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -102,13 +102,13 @@ import { CommitsStore } from "./stores/CommitsStore.js";
 import { FilesStore } from "./stores/FilesStore.js";
 import { MemoriesStore } from "./stores/MemoriesStore.js";
 import { PlansStore } from "./stores/PlansStore.js";
-import { StatusStore, type WorkerPhase } from "./stores/StatusStore.js";
+import { StatusStore } from "./stores/StatusStore.js";
 import { registerCompileCommand } from "./CompileCommand.js";
 import { openKnowledgeGraph } from "./views/KnowledgeGraphPanel.js";
 import { activateSync } from "./sync/VsCodeSyncBootstrap.js";
 import { ExcludeFilterManager } from "./util/ExcludeFilterManager.js";
 import { formatShortRelativeDate } from "./util/FormatUtils.js";
-import { isWorkerBusy } from "./util/LockUtils.js";
+import { isWorkerBusy, readIngestPhase } from "./util/LockUtils.js";
 import { initLogger, log } from "./util/Logger.js";
 import { StatusBarManager } from "./util/StatusBarManager.js";
 import { getWorkspaceRoot } from "./util/WorkspaceUtils.js";
@@ -1051,7 +1051,10 @@ export function activate(context: vscode.ExtensionContext): void {
 				statusProvider.onDidChangeTreeData.bind(statusProvider),
 			getWorkerBusy: () => statusProvider.getWorkerBusy(),
 			getSyncPhase: () => statusStore.getSnapshot().syncPhase,
-			getWorkerPhase: () => statusStore.getSnapshot().workerPhase,
+			getIngest: () => {
+				const s = statusStore.getSnapshot();
+				return { busy: s.ingestBusy, phase: s.ingestPhase };
+			},
 		},
 		memoriesProvider: {
 			serialize: () => memoriesProvider.serialize(),
@@ -1821,44 +1824,18 @@ export function activate(context: vscode.ExtensionContext): void {
 		new vscode.RelativePattern(workspaceRoot, ".jolli/jollimemory/worker.lock"),
 	);
 	// The `jollimemory.workerBusy` context key drives `enablement` of the
-	// commitAI / squash contributed commands, so it carries BLOCKING semantics:
-	// busy with any phase except ingest. The ingest phase (Memory Bank wiki
-	// update, ~80s+) never touches the commit pipeline or code-branch history,
-	// so commit/squash stay enabled during it — git ops landed mid-ingest are
-	// enqueued and drained right after the ingest entry, usually by the SAME
-	// worker in the same lock hold. That worker can move into a blocking
-	// summary run while the user is mid-flow, so the command handlers re-check
-	// the gate right before executing their git operations. Display
-	// surfaces (StatusStore.workerBusy → toolbar indicator) keep the raw busy
-	// flag so progress still shows during ingest.
-	// Local mirrors of the two watcher-fed inputs. Mirrored here (rather than
-	// read back from StatusStore's snapshot) so the context computation stays a
-	// pure function of what the two watchers below reported.
+	// commitAI / squash contributed commands. `worker.lock` is held ONLY during
+	// summary generation (ingest has its own `ingest.lock`), so this key is now
+	// exactly the raw worker-busy flag — ingest can't hold `worker.lock`, so it
+	// never trips the gate. The command handlers still re-check the gate right
+	// before executing, since the click-time check goes stale during LLM message
+	// generation + QuickPick.
 	let workerBusyRaw = false;
-	let workerPhaseIsIngest = false;
-	// Invalidation token for in-flight async phase reads. readWorkerPhase awaits
-	// a readFile; if a synchronous phase clear (lock delete / phase-file delete)
-	// runs while that read is in flight, the read's continuation must NOT apply
-	// its result — it would resurrect a stale `workerPhaseIsIngest = true` with
-	// no worker running, and the next summary run's setWorkerBusy(true) would
-	// then compute a non-blocking context and leave Commit/Squash enabled
-	// mid-summary (the exact race the ingest exemption must not reopen).
-	let workerPhaseEpoch = 0;
 	const updateWorkerBusyContext = () => {
-		void vscode.commands.executeCommand(
-			"setContext",
-			"jollimemory.workerBusy",
-			workerBusyRaw && !workerPhaseIsIngest,
-		);
+		void vscode.commands.executeCommand("setContext", "jollimemory.workerBusy", workerBusyRaw);
 	};
 	const setWorkerBusy = (busy: boolean) => {
 		workerBusyRaw = busy;
-		// Phase lifetime is bound to the lock (mirrors StatusStore.setWorkerBusy):
-		// a crash-left 'ingest' marker must not leak into the next summary run.
-		if (!busy) {
-			workerPhaseIsIngest = false;
-			workerPhaseEpoch++;
-		}
 		statusStore.setWorkerBusy(busy);
 		updateWorkerBusyContext();
 	};
@@ -1893,73 +1870,39 @@ export function activate(context: vscode.ExtensionContext): void {
 	// Check initial state — lock file might already exist on activation
 	void isWorkerBusy(workspaceRoot).then(setWorkerBusy);
 
-	// ── Worker phase file watcher ───────────────────────────────────────
-	// The worker writes `.jolli/jollimemory/worker-phase` (content
-	// "ingest:wiki" / "ingest:graph") while running a topic-KB ingest, so the
-	// Branch toolbar can show "Building knowledge wiki/graph…" instead of
-	// "AI summary in progress…". The phase
-	// is purely cosmetic; its busy-bound lifetime (StatusStore clears it on
-	// workerBusy=false) means a stale marker left by a crashed worker can't
-	// outlive the lock. Separate from the lock watcher because a phase-file
-	// write does not touch worker.lock, so onDidChange there would not fire.
-	const phaseWatcher = vscode.workspace.createFileSystemWatcher(
-		new vscode.RelativePattern(workspaceRoot, ".jolli/jollimemory/worker-phase"),
+	// ── Ingest phase file watcher (cosmetic sidebar pill) ───────────────
+	// The worker writes `.jolli/jollimemory/ingest-phase` (content "ingest:wiki" /
+	// "ingest:graph") while running a topic-KB ingest, so the Branch toolbar can
+	// show a "Building knowledge wiki/graph…" pill. It is purely cosmetic and
+	// carries NO gate role: ingest runs under its own `ingest.lock`, which the
+	// commit/squash gate ignores. So it feeds only `statusStore.setIngest`, never
+	// the `jollimemory.workerBusy` context. Separate from the lock watcher because
+	// writing the phase file does not touch `worker.lock`.
+	const ingestPhaseWatcher = vscode.workspace.createFileSystemWatcher(
+		new vscode.RelativePattern(workspaceRoot, ".jolli/jollimemory/ingest-phase"),
 	);
-	const readWorkerPhase = async (): Promise<void> => {
-		// Capture the epoch before awaiting; a clear that runs during the await
-		// bumps it, marking this read's result stale (see workerPhaseEpoch).
-		const epoch = workerPhaseEpoch;
-		try {
-			const uri = vscode.Uri.joinPath(
-				vscode.Uri.file(workspaceRoot),
-				".jolli",
-				"jollimemory",
-				"worker-phase",
-			);
-			const bytes = await vscode.workspace.fs.readFile(uri);
-			if (epoch !== workerPhaseEpoch) {
-				// A synchronous clear superseded this read; its flag/store writes
-				// are already correct, so applying the pre-clear file content here
-				// would resurrect a stale phase.
-				return;
-			}
-			const content = Buffer.from(bytes).toString("utf-8").trim();
-			// Prefix match: every `ingest:*` sub-phase (wiki / graph) plus the legacy
-			// bare `ingest` is commit-exempt — only the prefix decides the gate. Map
-			// the raw marker to a known WorkerPhase rather than casting: `ingest:graph`
-			// keeps the graph label, everything else ingest-prefixed (incl. legacy
-			// bare `ingest`) collapses to the wiki label; non-ingest clears to null.
-			workerPhaseIsIngest = content.startsWith("ingest");
-			const phase: WorkerPhase = !workerPhaseIsIngest
-				? null
-				: content === "ingest:graph"
-					? "ingest:graph"
-					: "ingest:wiki";
-			statusStore.setWorkerPhase(phase);
-		} catch {
-			if (epoch !== workerPhaseEpoch) {
-				return;
-			}
-			// File missing / unreadable → no special phase.
-			workerPhaseIsIngest = false;
-			statusStore.setWorkerPhase(null);
-		}
-		// Phase flips change the blocking decision (ingest is exempt), so the
-		// context key must be recomputed alongside the cosmetic label.
-		updateWorkerBusyContext();
+	const refreshIngestState = async (): Promise<void> => {
+		const { busy, phase } = await readIngestPhase(workspaceRoot);
+		statusStore.setIngest(busy, phase);
 	};
-	phaseWatcher.onDidCreate(() => void readWorkerPhase());
-	phaseWatcher.onDidChange(() => void readWorkerPhase());
-	phaseWatcher.onDidDelete(() => {
-		workerPhaseIsIngest = false;
-		workerPhaseEpoch++;
-		statusStore.setWorkerPhase(null);
-		updateWorkerBusyContext();
-	});
-	context.subscriptions.push(phaseWatcher);
-	// Check initial state — phase file might already exist on activation
-	// (extension started while a worker is mid-ingest).
-	void readWorkerPhase();
+	ingestPhaseWatcher.onDidCreate(() => void refreshIngestState());
+	ingestPhaseWatcher.onDidChange(() => void refreshIngestState());
+	// An explicit delete of the phase file is authoritative teardown: the worker
+	// removes it when the ingest ends. Clear the pill directly rather than going
+	// through readIngestPhase — otherwise the `ingest.lock` liveness backstop
+	// (the lock is released just AFTER the phase file) could momentarily resurrect
+	// a stale (and possibly mislabeled) pill until the 60s timer catches it.
+	ingestPhaseWatcher.onDidDelete(() => statusStore.setIngest(false, null));
+	context.subscriptions.push(ingestPhaseWatcher);
+	// The watcher fires on file writes but NOT when the phase file / `ingest.lock`
+	// simply age out (a crashed ingest leaves them behind). Re-check on a 60s timer
+	// while a pill is showing so `readIngestPhase`'s staleness check clears it.
+	const ingestStaleTimer = setInterval(() => {
+		if (statusStore.getSnapshot().ingestBusy) void refreshIngestState();
+	}, 60_000);
+	context.subscriptions.push({ dispose: () => clearInterval(ingestStaleTimer) });
+	// Check initial state — an ingest might already be running on activation.
+	void refreshIngestState();
 
 	// COMMITS title updates are handled by the commitsStore.onChange subscription
 	// the sidebar webview wires up — no provider hook needed.

--- a/vscode/src/commands/CommitCommand.test.ts
+++ b/vscode/src/commands/CommitCommand.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { isWorkerBlockingBusy } = vi.hoisted(() => ({
-	isWorkerBlockingBusy: vi.fn(),
+const { isWorkerBusy } = vi.hoisted(() => ({
+	isWorkerBusy: vi.fn(),
 }));
 
 const { info, warn, error, debug } = vi.hoisted(() => ({
@@ -100,7 +100,7 @@ vi.mock("vscode", () => ({
 }));
 
 vi.mock("../util/LockUtils.js", () => ({
-	isWorkerBlockingBusy,
+	isWorkerBusy,
 }));
 
 vi.mock("../util/Logger.js", () => ({
@@ -232,8 +232,8 @@ function makeCommand(deps: ReturnType<typeof makeDeps>): CommitCommand {
 
 describe("CommitCommand", () => {
 	beforeEach(() => {
-		isWorkerBlockingBusy.mockReset();
-		isWorkerBlockingBusy.mockResolvedValue(false);
+		isWorkerBusy.mockReset();
+		isWorkerBusy.mockResolvedValue(false);
 		showWarningMessage.mockReset();
 		showErrorMessage.mockReset();
 		showInformationMessage.mockReset();
@@ -246,7 +246,7 @@ describe("CommitCommand", () => {
 	});
 
 	it("stops immediately when the worker lock is held", async () => {
-		isWorkerBlockingBusy.mockResolvedValue(true);
+		isWorkerBusy.mockResolvedValue(true);
 		const deps = makeDeps();
 		const command = makeCommand(deps);
 
@@ -259,11 +259,11 @@ describe("CommitCommand", () => {
 	});
 
 	it("re-checks the worker gate after the QuickPick and restores the index when it turned busy", async () => {
-		// Click-time check passes (e.g. exempt ingest phase), but the same
-		// drain moves into a blocking summary run during message generation /
+		// Click-time check passes (worker idle), but the same drain moves into
+		// a blocking summary run during message generation /
 		// QuickPick review — the commit (possibly an Amend rewriting HEAD)
 		// must not execute, and the user's index must be restored.
-		isWorkerBlockingBusy
+		isWorkerBusy
 			.mockResolvedValueOnce(false)
 			.mockResolvedValueOnce(true);
 		const deps = makeDeps();
@@ -275,7 +275,7 @@ describe("CommitCommand", () => {
 
 		await command.execute();
 
-		expect(isWorkerBlockingBusy).toHaveBeenCalledTimes(2);
+		expect(isWorkerBusy).toHaveBeenCalledTimes(2);
 		expect(deps.bridge.commit).not.toHaveBeenCalled();
 		expect(deps.bridge.amendCommit).not.toHaveBeenCalled();
 		expect(deps.bridge.restoreIndexTree).toHaveBeenCalledWith("tree-sha");

--- a/vscode/src/commands/CommitCommand.ts
+++ b/vscode/src/commands/CommitCommand.ts
@@ -25,7 +25,7 @@ import type { JolliMemoryBridge } from "../JolliMemoryBridge.js";
 import type { CommitsStore } from "../stores/CommitsStore.js";
 import type { FilesStore } from "../stores/FilesStore.js";
 import type { StatusStore } from "../stores/StatusStore.js";
-import { isWorkerBlockingBusy } from "../util/LockUtils.js";
+import { isWorkerBusy } from "../util/LockUtils.js";
 import { log } from "../util/Logger.js";
 import type { StatusBarManager } from "../util/StatusBarManager.js";
 
@@ -77,10 +77,10 @@ export class CommitCommand {
 	 * Called when the user clicks [✦] in the Changes panel header.
 	 */
 	async execute(): Promise<void> {
-		// Guard: block while the post-commit Worker holds the lock for a summary
-		// run. The ingest phase (Memory Bank wiki update) is exempt — it never
-		// touches the commit pipeline, so committing during it is safe.
-		if (await isWorkerBlockingBusy(this.workspaceRoot)) {
+		// Guard: block while the post-commit Worker holds worker.lock for a summary
+		// run. Ingest (Memory Bank wiki/graph) runs under its own ingest.lock, so it
+		// does not trip this gate — committing during it is safe.
+		if (await isWorkerBusy(this.workspaceRoot)) {
 			vscode.window.showWarningMessage(
 				"Jolli Memory: AI summary is being generated. Please wait a moment.",
 			);
@@ -182,12 +182,11 @@ export class CommitCommand {
 		}
 
 		// Re-check the worker gate: the click-time check at the top goes stale
-		// during message generation + QuickPick review. A drain that was in the
-		// exempt ingest phase at click time may since have moved on to a blocking
-		// summary entry, and the Amend actions rewrite HEAD under its reads
-		// (same Bug-3 race class as Squash). Restore the index like the cancel
-		// path so the user's staging state survives the abort.
-		if (await isWorkerBlockingBusy(this.workspaceRoot)) {
+		// during message generation + QuickPick review. A summary drain may have
+		// started since click time, and the Amend actions rewrite HEAD under its
+		// reads (same Bug-3 race class as Squash). Restore the index like the
+		// cancel path so the user's staging state survives the abort.
+		if (await isWorkerBusy(this.workspaceRoot)) {
 			log.warn("commit", "Worker became busy during QuickPick — aborting");
 			vscode.window.showWarningMessage(
 				"Jolli Memory: AI summary is being generated. Please wait a moment.",

--- a/vscode/src/commands/SquashCommand.test.ts
+++ b/vscode/src/commands/SquashCommand.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { isWorkerBlockingBusy } = vi.hoisted(() => ({
-	isWorkerBlockingBusy: vi.fn(),
+const { isWorkerBusy } = vi.hoisted(() => ({
+	isWorkerBusy: vi.fn(),
 }));
 
 const { info, warn, error, debug } = vi.hoisted(() => ({
@@ -89,7 +89,7 @@ vi.mock("vscode", () => ({
 }));
 
 vi.mock("../util/LockUtils.js", () => ({
-	isWorkerBlockingBusy,
+	isWorkerBusy,
 }));
 
 vi.mock("../util/Logger.js", () => ({
@@ -154,8 +154,8 @@ function makeDeps(selected = [makeCommit("cccc3333"), makeCommit("bbbb2222")]) {
 
 describe("SquashCommand", () => {
 	beforeEach(() => {
-		isWorkerBlockingBusy.mockReset();
-		isWorkerBlockingBusy.mockResolvedValue(false);
+		isWorkerBusy.mockReset();
+		isWorkerBusy.mockResolvedValue(false);
 		showWarningMessage.mockReset();
 		showErrorMessage.mockReset();
 		showInformationMessage.mockReset();
@@ -168,7 +168,7 @@ describe("SquashCommand", () => {
 	});
 
 	it("blocks while the worker is busy", async () => {
-		isWorkerBlockingBusy.mockResolvedValue(true);
+		isWorkerBusy.mockResolvedValue(true);
 		const deps = makeDeps();
 		const command = new SquashCommand(
 			deps.bridge as never,
@@ -187,10 +187,10 @@ describe("SquashCommand", () => {
 	});
 
 	it("re-checks the worker gate after the QuickPick and aborts when it turned busy", async () => {
-		// Click-time check passes (e.g. the worker was in the exempt ingest
-		// phase), but the same drain moves into a blocking summary run while
-		// the user reviews the QuickPick — the squash must not execute.
-		isWorkerBlockingBusy
+		// Click-time check passes (worker idle), but the same drain moves into
+		// a blocking summary run while the user reviews the QuickPick — the
+		// squash must not execute.
+		isWorkerBusy
 			.mockResolvedValueOnce(false)
 			.mockResolvedValueOnce(true);
 		const deps = makeDeps();
@@ -209,7 +209,7 @@ describe("SquashCommand", () => {
 
 		await command.execute();
 
-		expect(isWorkerBlockingBusy).toHaveBeenCalledTimes(2);
+		expect(isWorkerBusy).toHaveBeenCalledTimes(2);
 		expect(deps.bridge.getStagedFilePaths).not.toHaveBeenCalled();
 		expect(deps.bridge.squashCommits).not.toHaveBeenCalled();
 		expect(showWarningMessage).toHaveBeenCalledWith(

--- a/vscode/src/commands/SquashCommand.ts
+++ b/vscode/src/commands/SquashCommand.ts
@@ -20,7 +20,7 @@ import type { CommitsStore } from "../stores/CommitsStore.js";
 import type { FilesStore } from "../stores/FilesStore.js";
 import type { StatusStore } from "../stores/StatusStore.js";
 import type { BranchCommit } from "../Types.js";
-import { isWorkerBlockingBusy } from "../util/LockUtils.js";
+import { isWorkerBusy } from "../util/LockUtils.js";
 import { log } from "../util/Logger.js";
 import type { StatusBarManager } from "../util/StatusBarManager.js";
 
@@ -57,13 +57,11 @@ export class SquashCommand {
 	async execute(): Promise<void> {
 		// Guard: block while the post-commit Worker holds the lock for a summary
 		// run (squashing a commit mid-pipeline races the worker's history reads).
-		// The ingest phase (Memory Bank wiki update) is exempt — it never touches
-		// the code branch; a squash landed during it is enqueued and drained
-		// right after the ingest entry, usually by the SAME worker in the same
-		// lock hold. That worker can therefore move into a blocking summary run
-		// while the user is still mid-flow here, which is why the gate is
-		// re-checked after the QuickPick below.
-		if (await isWorkerBlockingBusy(this.workspaceRoot)) {
+		// Ingest (Memory Bank wiki/graph) runs under its own ingest.lock, so it
+		// never trips this gate. A summary drain can still start while the
+		// user is mid-flow here (message generation + QuickPick), which is why the
+		// gate is re-checked after the QuickPick below.
+		if (await isWorkerBusy(this.workspaceRoot)) {
 			vscode.window.showWarningMessage(
 				"Jolli Memory: AI summary is being generated. Please wait a moment.",
 			);
@@ -138,10 +136,9 @@ export class SquashCommand {
 
 		// Re-check the worker gate: the click-time check at the top goes stale
 		// during LLM message generation + QuickPick review (seconds to minutes).
-		// A drain that was in the exempt ingest phase at click time may since
-		// have moved on to a blocking summary entry — rewriting history under
-		// its reads is exactly the Bug-3 race the gate exists to prevent.
-		if (await isWorkerBlockingBusy(this.workspaceRoot)) {
+		// A summary drain may have started since click time — rewriting history
+		// under its reads is exactly the Bug-3 race the gate exists to prevent.
+		if (await isWorkerBusy(this.workspaceRoot)) {
 			log.warn("squash", "Worker became busy during QuickPick — aborting");
 			vscode.window.showWarningMessage(
 				"Jolli Memory: AI summary is being generated. Please wait a moment.",

--- a/vscode/src/stores/StatusStore.test.ts
+++ b/vscode/src/stores/StatusStore.test.ts
@@ -167,56 +167,70 @@ describe("StatusStore", () => {
 		});
 	});
 
-	it("setWorkerPhase updates the snapshot and reason", () => {
-		const store = new StatusStore({ getStatus: vi.fn() } as never);
-		store.setWorkerBusy(true);
-		store.setWorkerPhase("ingest");
-		expect(store.getSnapshot().workerPhase).toBe("ingest");
-		expect(store.getSnapshot().changeReason).toBe("workerPhase");
-	});
-
-	it("setWorkerPhase carries the ingest sub-phases verbatim (wiki / graph)", () => {
-		const store = new StatusStore({ getStatus: vi.fn() } as never);
-		store.setWorkerBusy(true);
-		store.setWorkerPhase("ingest:wiki");
-		expect(store.getSnapshot().workerPhase).toBe("ingest:wiki");
-		store.setWorkerPhase("ingest:graph");
-		expect(store.getSnapshot().workerPhase).toBe("ingest:graph");
-	});
-
-	it("setWorkerPhase is a no-op when unchanged", () => {
-		const store = new StatusStore({ getStatus: vi.fn() } as never);
-		let emits = 0;
-		store.onChange(() => {
-			emits++;
+	// ── setIngest — cosmetic sidebar ingest pill ───────────────────────────
+	describe("setIngest", () => {
+		it("sets busy + phase on the snapshot and emits the 'ingest' reason", () => {
+			const store = new StatusStore({ getStatus: vi.fn() } as never);
+			const listener = vi.fn();
+			store.onChange(listener);
+			store.setIngest(true, "wiki");
+			expect(store.getSnapshot().ingestBusy).toBe(true);
+			expect(store.getSnapshot().ingestPhase).toBe("wiki");
+			expect(store.getSnapshot().changeReason).toBe("ingest");
+			expect(listener).toHaveBeenCalledTimes(1);
 		});
-		store.setWorkerPhase(null);
-		expect(emits).toBe(0);
-	});
 
-	it("setWorkerBusy(false) clears a set workerPhase (lock-bound lifetime)", () => {
-		const store = new StatusStore({ getStatus: vi.fn() } as never);
-		store.setWorkerBusy(true);
-		store.setWorkerPhase("ingest");
-		store.setWorkerBusy(false);
-		expect(store.getSnapshot().workerPhase).toBeNull();
-		expect(store.getSnapshot().workerBusy).toBe(false);
-	});
+		it("carries the graph sub-phase verbatim", () => {
+			const store = new StatusStore({ getStatus: vi.fn() } as never);
+			store.setIngest(true, "graph");
+			expect(store.getSnapshot().ingestPhase).toBe("graph");
+		});
 
-	it("setWorkerBusy(false) clears a stale workerPhase even when already not busy (crash-residue activation path)", () => {
-		// Activation order is unspecified: readWorkerPhase() may read a stale
-		// 'ingest' marker (left by a SIGKILL'd worker) BEFORE
-		// isWorkerBusy().then(setWorkerBusy) resolves false. Because workerBusy
-		// starts false, setWorkerBusy(false) would hit the equality early-return
-		// and skip the phase clear — leaving a stale phase that mislabels the
-		// next genuine summary run as "Building knowledge wiki…". The busy-bound
-		// invariant must hold here too.
-		const store = new StatusStore({ getStatus: vi.fn() } as never);
-		store.setWorkerPhase("ingest"); // stale marker read while workerBusy is still false
-		const listener = vi.fn();
-		store.onChange(listener);
-		store.setWorkerBusy(false); // isWorkerBusy() resolved false — no busy transition
-		expect(store.getSnapshot().workerPhase).toBeNull();
-		expect(listener).toHaveBeenCalled(); // snapshot changed (phase cleared), so subscribers must re-render
+		it("forces phase to null when busy is false", () => {
+			const store = new StatusStore({ getStatus: vi.fn() } as never);
+			store.setIngest(true, "wiki");
+			// Even if a stale phase is passed alongside busy=false, it must clear.
+			store.setIngest(false, "graph");
+			expect(store.getSnapshot().ingestBusy).toBe(false);
+			expect(store.getSnapshot().ingestPhase).toBeNull();
+		});
+
+		it("is a no-op when busy + phase are unchanged", () => {
+			const store = new StatusStore({ getStatus: vi.fn() } as never);
+			store.setIngest(true, "wiki");
+			const listener = vi.fn();
+			store.onChange(listener);
+			store.setIngest(true, "wiki");
+			expect(listener).not.toHaveBeenCalled();
+		});
+
+		it("is a no-op for a redundant idle call (busy=false already idle)", () => {
+			const store = new StatusStore({ getStatus: vi.fn() } as never);
+			const listener = vi.fn();
+			store.onChange(listener);
+			store.setIngest(false, null);
+			expect(listener).not.toHaveBeenCalled();
+		});
+
+		it("is independent of workerBusy — both can be live on the snapshot at once", () => {
+			const store = new StatusStore({ getStatus: vi.fn() } as never);
+			store.setWorkerBusy(true);
+			store.setIngest(true, "graph");
+			expect(store.getSnapshot().workerBusy).toBe(true);
+			expect(store.getSnapshot().ingestBusy).toBe(true);
+			expect(store.getSnapshot().ingestPhase).toBe("graph");
+		});
+
+		it("setWorkerBusy(false) leaves the ingest state untouched (ingest has its own lock)", () => {
+			// Ingest runs under ingest.lock, not worker.lock, so toggling the
+			// summary-busy flag off must not clear a live ingest pill.
+			const store = new StatusStore({ getStatus: vi.fn() } as never);
+			store.setWorkerBusy(true);
+			store.setIngest(true, "wiki");
+			store.setWorkerBusy(false);
+			expect(store.getSnapshot().workerBusy).toBe(false);
+			expect(store.getSnapshot().ingestBusy).toBe(true);
+			expect(store.getSnapshot().ingestPhase).toBe("wiki");
+		});
 	});
 });

--- a/vscode/src/stores/StatusStore.ts
+++ b/vscode/src/stores/StatusStore.ts
@@ -33,7 +33,7 @@ export type StatusChangeReason =
 	| "refresh"
 	| "setStatus"
 	| "workerBusy"
-	| "workerPhase"
+	| "ingest"
 	| "syncPhase"
 	| "extensionOutdated"
 	| "migrating";
@@ -56,20 +56,22 @@ export interface SyncPhaseState {
 }
 
 /**
- * Post-commit worker phase surfaced to the sidebar. The QueueWorker writes the
- * ingest sub-phase (`ingest:wiki` / `ingest:graph`); `"ingest"` is the legacy
- * bare value, still accepted as a wiki-equivalent fallback. All non-null values
- * keep the `ingest` prefix, which the commit/squash gates key off. `null` is the
- * default (blocking) summary phase.
+ * Cosmetic ingest sub-phase surfaced to the sidebar pill. Ingest runs under its
+ * own `ingest.lock` (not `worker.lock`), so this is display-only and fully
+ * decoupled from `workerBusy`/the commit-squash gates. `null` means no ingest is
+ * live.
  */
-export type WorkerPhase = "ingest" | "ingest:wiki" | "ingest:graph" | null;
+export type IngestPhase = "wiki" | "graph" | null;
 
 export interface StatusSnapshot extends Snapshot<StatusChangeReason> {
 	readonly status: StatusInfo | null;
 	readonly config: JolliMemoryConfig | null;
 	readonly derived: StatusDerived;
 	readonly workerBusy: boolean;
-	readonly workerPhase: WorkerPhase;
+	/** An ingest (wiki/graph) is in flight. Independent of `workerBusy`. */
+	readonly ingestBusy: boolean;
+	/** Which ingest sub-phase, for the pill label. `null` when `ingestBusy` is false. */
+	readonly ingestPhase: IngestPhase;
 	readonly syncPhase: SyncPhaseState | null;
 	readonly extensionOutdated: boolean;
 	readonly migrating: boolean;
@@ -87,7 +89,8 @@ const EMPTY: StatusSnapshot = {
 	config: null,
 	derived: INITIAL_DERIVED,
 	workerBusy: false,
-	workerPhase: null,
+	ingestBusy: false,
+	ingestPhase: null,
 	syncPhase: null,
 	extensionOutdated: false,
 	migrating: false,
@@ -99,7 +102,8 @@ export class StatusStore extends BaseStore<StatusChangeReason, StatusSnapshot> {
 	private status: StatusInfo | null = null;
 	private config: JolliMemoryConfig | null = null;
 	private workerBusy = false;
-	private workerPhase: WorkerPhase = null;
+	private ingestBusy = false;
+	private ingestPhase: IngestPhase = null;
 	private syncPhase: SyncPhaseState | null = null;
 	private extensionOutdated = false;
 	private migrating = false;
@@ -135,35 +139,31 @@ export class StatusStore extends BaseStore<StatusChangeReason, StatusSnapshot> {
 	}
 
 	setWorkerBusy(busy: boolean): void {
-		// Phase lifetime is bound to the lock: whenever the worker is not busy the
-		// phase marker is meaningless, so a (possibly stale, crash-left) phase must
-		// be cleared even when `workerBusy` is already false. Otherwise the equality
-		// early-return below would skip the clear, and a stale 'ingest' marker read
-		// at activation — before `isWorkerBusy()` resolves false — would survive into
-		// the next genuine summary run and mislabel it "Building knowledge wiki…".
-		const staleClear = !busy && this.workerPhase !== null;
-		if (this.workerBusy === busy && !staleClear) {
+		// `workerBusy` is now purely the `worker.lock` (summary) signal — ingest
+		// display state lives in `ingestBusy`/`ingestPhase` and is set independently
+		// (see `setIngest`), so toggling summary-busy no longer touches it.
+		if (this.workerBusy === busy) {
 			return;
 		}
 		this.workerBusy = busy;
-		if (!busy) {
-			this.workerPhase = null;
-		}
 		this.rebuildSnapshot("workerBusy");
 	}
 
 	/**
-	 * Push (or clear) the post-commit worker's phase. Non-null values are the
-	 * `ingest:*` sub-phases (wiki / graph), each selecting a distinct sidebar
-	 * label; `null` is the default "AI summary in progress…" phase. Equality-
-	 * checked so a redundant call is a no-op.
+	 * Push the ingest display state (cosmetic sidebar pill). Fully decoupled from
+	 * `workerBusy`: ingest runs under its own `ingest.lock`, so its pill can show
+	 * while a summary is NOT running (and is suppressed when one IS, by the
+	 * renderer's summary-first priority). Equality-checked so a redundant push is a
+	 * no-op. When `busy` is false, `phase` is forced to `null`.
 	 */
-	setWorkerPhase(phase: WorkerPhase): void {
-		if (this.workerPhase === phase) {
+	setIngest(busy: boolean, phase: IngestPhase): void {
+		const nextPhase = busy ? phase : null;
+		if (this.ingestBusy === busy && this.ingestPhase === nextPhase) {
 			return;
 		}
-		this.workerPhase = phase;
-		this.rebuildSnapshot("workerPhase");
+		this.ingestBusy = busy;
+		this.ingestPhase = nextPhase;
+		this.rebuildSnapshot("ingest");
 	}
 
 	/**
@@ -201,7 +201,8 @@ export class StatusStore extends BaseStore<StatusChangeReason, StatusSnapshot> {
 			config: this.config,
 			derived: StatusDataService.derive(this.status, this.config),
 			workerBusy: this.workerBusy,
-			workerPhase: this.workerPhase,
+			ingestBusy: this.ingestBusy,
+			ingestPhase: this.ingestPhase,
 			syncPhase: this.syncPhase,
 			extensionOutdated: this.extensionOutdated,
 			migrating: this.migrating,

--- a/vscode/src/util/LockUtils.test.ts
+++ b/vscode/src/util/LockUtils.test.ts
@@ -1,129 +1,137 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { isWorkerBusy, readIngestPhase } from "./LockUtils.js";
 
-const { stat, readFile } = vi.hoisted(() => ({
-	stat: vi.fn(),
-	readFile: vi.fn(),
-}));
+// LockUtils reads the filesystem directly (stat + readFile on
+// `.jolli/jollimemory/*`), so these tests exercise real temp files rather than
+// mocking node:fs/promises. Freshness is driven by mtime vs Date.now(); a file
+// is "stale" once its mtime is older than the 5-minute lock window, which we
+// simulate with utimesSync.
 
-vi.mock("node:fs/promises", () => ({
-	stat,
-	readFile,
-}));
+let repo: string;
 
-import { isWorkerBlockingBusy, isWorkerBusy } from "./LockUtils.js";
+function jolliFile(name: string): string {
+	return join(repo, ".jolli", "jollimemory", name);
+}
+
+function writeFresh(name: string, content = ""): string {
+	const path = jolliFile(name);
+	writeFileSync(path, content);
+	return path;
+}
+
+/** Back-date a file's mtime past the 5-minute freshness window. */
+function makeStale(path: string): void {
+	const tenMinAgoSec = Date.now() / 1000 - 10 * 60;
+	utimesSync(path, tenMinAgoSec, tenMinAgoSec);
+}
+
+beforeEach(() => {
+	repo = mkdtempSync(join(tmpdir(), "lockutils-"));
+	mkdirSync(join(repo, ".jolli", "jollimemory"), { recursive: true });
+});
+
+afterEach(() => {
+	rmSync(repo, { recursive: true, force: true });
+});
 
 describe("isWorkerBusy", () => {
-	beforeEach(() => {
-		stat.mockReset();
-		vi.useRealTimers();
+	it("returns true when worker.lock is fresh", async () => {
+		writeFresh("worker.lock");
+		await expect(isWorkerBusy(repo)).resolves.toBe(true);
 	});
 
-	it("returns true when the lock file is fresh", async () => {
-		vi.useFakeTimers();
-		vi.setSystemTime(new Date("2026-03-30T00:05:00.000Z"));
-		stat.mockResolvedValue({
-			mtimeMs: new Date("2026-03-30T00:01:00.000Z").getTime(),
-		});
-
-		await expect(isWorkerBusy("/repo")).resolves.toBe(true);
+	it("returns false when worker.lock is missing", async () => {
+		await expect(isWorkerBusy(repo)).resolves.toBe(false);
 	});
 
-	it("returns false when the lock file is stale or missing", async () => {
-		vi.useFakeTimers();
-		vi.setSystemTime(new Date("2026-03-30T00:10:00.000Z"));
-		stat.mockResolvedValueOnce({
-			mtimeMs: new Date("2026-03-30T00:00:00.000Z").getTime(),
-		});
-		stat.mockRejectedValueOnce(new Error("ENOENT"));
-
-		await expect(isWorkerBusy("/repo")).resolves.toBe(false);
-		await expect(isWorkerBusy("/repo")).resolves.toBe(false);
+	it("returns false when worker.lock is stale (older than the lock window)", async () => {
+		const lock = writeFresh("worker.lock");
+		makeStale(lock);
+		await expect(isWorkerBusy(repo)).resolves.toBe(false);
 	});
 });
 
-describe("isWorkerBlockingBusy", () => {
-	beforeEach(() => {
-		stat.mockReset();
-		readFile.mockReset();
-		vi.useFakeTimers();
-		vi.setSystemTime(new Date("2026-03-30T00:05:00.000Z"));
-		// Fresh lock by default — individual tests override.
-		stat.mockResolvedValue({
-			mtimeMs: new Date("2026-03-30T00:04:00.000Z").getTime(),
+describe("readIngestPhase", () => {
+	it("reports busy + 'wiki' for a fresh ingest-phase file", async () => {
+		writeFresh("ingest-phase", "ingest:wiki");
+		await expect(readIngestPhase(repo)).resolves.toEqual({
+			busy: true,
+			phase: "wiki",
 		});
 	});
 
-	it("returns false when the worker is not busy at all", async () => {
-		stat.mockRejectedValue(new Error("ENOENT"));
-
-		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(false);
-		expect(readFile).not.toHaveBeenCalled();
+	it("reports 'graph' when the phase file carries the ingest:graph marker", async () => {
+		writeFresh("ingest-phase", "ingest:graph");
+		await expect(readIngestPhase(repo)).resolves.toEqual({
+			busy: true,
+			phase: "graph",
+		});
 	});
 
-	it("returns true when busy with the default summary phase (no marker)", async () => {
-		readFile.mockRejectedValue(new Error("ENOENT"));
-
-		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(true);
-	});
-
-	it("returns false when busy with a fresh ingest phase", async () => {
-		readFile.mockResolvedValue("ingest");
-
-		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(false);
-		expect(readFile).toHaveBeenCalledWith(
-			expect.stringContaining("worker-phase"),
-			"utf-8",
-		);
-	});
-
-	it("returns false for the ingest:wiki / ingest:graph sub-phases (prefix match)", async () => {
-		readFile.mockResolvedValue("ingest:wiki");
-		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(false);
-
-		readFile.mockResolvedValue("ingest:graph");
-		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(false);
+	it("treats a bare 'ingest' marker as the wiki phase", async () => {
+		writeFresh("ingest-phase", "ingest");
+		await expect(readIngestPhase(repo)).resolves.toEqual({
+			busy: true,
+			phase: "wiki",
+		});
 	});
 
 	it("trims whitespace around the phase marker content", async () => {
-		readFile.mockResolvedValue("ingest\n");
-
-		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(false);
+		writeFresh("ingest-phase", "ingest:graph\n");
+		await expect(readIngestPhase(repo)).resolves.toEqual({
+			busy: true,
+			phase: "graph",
+		});
 	});
 
-	it("treats an unknown phase as blocking", async () => {
-		readFile.mockResolvedValue("something-else");
-
-		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(true);
+	it("falls back to busy + 'wiki' when the phase file is missing but ingest.lock is fresh", async () => {
+		// A heartbeat missed the phase-file write but the ingest is still alive
+		// (fresh lock) — keep the pill up, defaulting to the wiki label.
+		writeFresh("ingest.lock");
+		await expect(readIngestPhase(repo)).resolves.toEqual({
+			busy: true,
+			phase: "wiki",
+		});
 	});
 
-	it("treats a stale ingest marker as blocking", async () => {
-		// The worker heartbeats an active ingest marker every 60 s; a marker
-		// whose mtime fell past the 5-min window is residue from a failed
-		// cleanup — the run in progress may be a blocking summary.
-		readFile.mockResolvedValue("ingest");
-		stat.mockImplementation((path: string) =>
-			Promise.resolve({
-				mtimeMs: path.includes("worker-phase")
-					? new Date("2026-03-29T23:59:00.000Z").getTime()
-					: new Date("2026-03-30T00:04:00.000Z").getTime(),
-			}),
-		);
-
-		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(true);
+	it("keeps the pill up when the phase file is stale but ingest.lock is still fresh", async () => {
+		const phase = writeFresh("ingest-phase", "ingest:graph");
+		makeStale(phase);
+		writeFresh("ingest.lock");
+		await expect(readIngestPhase(repo)).resolves.toEqual({
+			busy: true,
+			phase: "graph",
+		});
 	});
 
-	it("treats an ingest marker whose stat fails as blocking", async () => {
-		// readFile succeeded but the marker vanished (or is unreadable) before
-		// the freshness stat — fail safe to blocking.
-		readFile.mockResolvedValue("ingest");
-		stat.mockImplementation((path: string) =>
-			path.includes("worker-phase")
-				? Promise.reject(new Error("ENOENT"))
-				: Promise.resolve({
-						mtimeMs: new Date("2026-03-30T00:04:00.000Z").getTime(),
-					}),
-		);
+	it("reports not busy when both the phase file and ingest.lock are stale", async () => {
+		const phase = writeFresh("ingest-phase", "ingest:wiki");
+		const lock = writeFresh("ingest.lock");
+		makeStale(phase);
+		makeStale(lock);
+		await expect(readIngestPhase(repo)).resolves.toEqual({
+			busy: false,
+			phase: null,
+		});
+	});
 
-		await expect(isWorkerBlockingBusy("/repo")).resolves.toBe(true);
+	it("reports not busy when neither the phase file nor ingest.lock exists", async () => {
+		await expect(readIngestPhase(repo)).resolves.toEqual({
+			busy: false,
+			phase: null,
+		});
+	});
+
+	it("reports not busy for fresh non-ingest phase content", async () => {
+		// Content that does not begin with `ingest` is not an ingest run — the
+		// pill stays hidden even though the file itself is fresh.
+		writeFresh("ingest-phase", "summary");
+		await expect(readIngestPhase(repo)).resolves.toEqual({
+			busy: false,
+			phase: null,
+		});
 	});
 });

--- a/vscode/src/util/LockUtils.ts
+++ b/vscode/src/util/LockUtils.ts
@@ -3,20 +3,21 @@
  *
  * The post-commit Worker holds `.jolli/jollimemory/worker.lock` while running
  * the LLM summarization pipeline (~20-40s). These helpers let the extension and
- * command classes check the lock state to prevent race conditions
- * (Commit / Squash are gated on it — via `isWorkerBlockingBusy`, which exempts
- * the ingest phase). Push is intentionally NOT gated: it only runs `git push`
- * on the current branch and shares no state with the worker.
+ * command classes check the lock state to prevent race conditions (Commit /
+ * Squash are gated on `isWorkerBusy`). Push is intentionally NOT gated: it only
+ * runs `git push` on the current branch and shares no state with the worker.
+ *
+ * Ingest runs under its own `ingest.lock`, so `worker.lock` is held ONLY during
+ * summary generation and the gate is a plain `isWorkerBusy` — there is no
+ * "exempt the ingest phase" logic, because ingest can never hold `worker.lock`.
+ * The ingest phase drives only the cosmetic sidebar pill, via `readIngestPhase`
+ * below (the `ingest-phase` file + `ingest.lock` liveness backstop).
  *
  * Notes on the lock split:
- *   - `worker.lock` is the QueueWorker's "I'm draining the queue" marker; this
- *     is the file we watch here.
- *   - The sibling `orphan-write.lock` is a short-lived (millisecond-scale)
- *     mutex around individual orphan-branch writes; it is irrelevant to the
- *     worker-busy state and intentionally not surfaced.
- *   - Pre-split, both roles shared a single `lock` file. Watching that path
- *     after the split would silently always return false — which is why this
- *     module is updated in lockstep with `Locks.ts`.
+ *   - `worker.lock` is the QueueWorker's "I'm draining summaries" marker.
+ *   - `ingest.lock` is the QueueWorker's "I'm running wiki/graph ingest" marker.
+ *   - The sibling `orphan-write.lock` is a short-lived (millisecond-scale) mutex
+ *     around individual orphan-branch writes; irrelevant to busy state.
  */
 
 import { readFile, stat } from "node:fs/promises";
@@ -24,71 +25,61 @@ import { join } from "node:path";
 
 /**
  * Lock timeout matches `LOCK_TIMEOUT_MS` in cli/src/core/Locks.ts (5 minutes).
- * Doubles as the freshness window for the `worker-phase` marker: the worker
- * heartbeats both `worker.lock` and an active `ingest` marker every 60 s
+ * Doubles as the freshness window for the cosmetic `ingest-phase` file: the
+ * worker heartbeats both `ingest.lock` and the `ingest-phase` file every 60 s
  * (WORKER_LOCK_REFRESH_INTERVAL_MS in QueueWorker), so the same 5× margin
- * applies to both files.
+ * applies to all three files.
  */
 const LOCK_TIMEOUT_MS = 5 * 60 * 1000;
 
+function jolliMemoryFile(cwd: string, name: string): string {
+	return join(cwd, ".jolli", "jollimemory", name);
+}
+
+async function isFileFresh(path: string): Promise<boolean> {
+	try {
+		const st = await stat(path);
+		return Date.now() - st.mtimeMs < LOCK_TIMEOUT_MS;
+	} catch {
+		return false;
+	}
+}
+
 /**
  * Returns true if the JolliMemory worker lock file exists and is not stale.
- * A lock older than 5 minutes is considered stale (crashed worker).
+ * A lock older than 5 minutes is considered stale (crashed worker). This is the
+ * sole gate for Commit / Squash: `worker.lock` is held only during summary
+ * generation (ingest has its own `ingest.lock`).
  */
 export async function isWorkerBusy(cwd: string): Promise<boolean> {
-	try {
-		const lockStat = await stat(
-			join(cwd, ".jolli", "jollimemory", "worker.lock"),
-		);
-		const ageMs = Date.now() - lockStat.mtimeMs;
-		return ageMs < LOCK_TIMEOUT_MS;
-	} catch {
-		return false;
-	}
+	return isFileFresh(jolliMemoryFile(cwd, "worker.lock"));
 }
+
+/** Cosmetic ingest sub-phase for the sidebar pill; null when no ingest is live. */
+export type IngestPhaseLabel = "wiki" | "graph" | null;
 
 /**
- * Returns true only when the worker is busy with a phase that must block user
- * git actions (Commit / Squash). The topic-KB ingest phase is exempt: it only
- * reads already-stored summaries and renders the Memory Bank wiki, never the
- * code branch or the commit pipeline, so blocking commit/squash for its
- * ~80s+ duration is pure UX damage. Any git op landed during ingest is queued
- * and drained right after the ingest entry — usually by the SAME worker, in
- * the same lock hold (the drain loop re-dequeues between entries; a
- * chain-spawned successor only covers ops that land after the drain exits).
- * That is why callers with a long user interaction between the gate check and
- * the actual git op (Commit/Squash: LLM message generation + QuickPick) must
- * re-check this gate immediately before executing.
+ * Reads the cosmetic ingest display state from the `ingest-phase` file, with
+ * `ingest.lock` freshness as a liveness backstop (a phase file that missed a
+ * heartbeat but whose ingest is still alive should keep the pill).
  *
- * The phase comes from the `worker-phase` marker the QueueWorker writes next
- * to `worker.lock` (see WORKER_PHASE_FILE in cli/src/core/Locks.ts). A
- * missing/unreadable marker means the default summary phase → blocking. An
- * `ingest` marker is honoured only while its mtime is fresh: the worker
- * heartbeats the marker during a genuine ingest, so a stale one is residue
- * from a failed cleanup and the run in progress may well be a blocking
- * summary — treat it as such (fail-safe).
+ * Returns `busy: true` only while an ingest is genuinely in flight — either the
+ * phase file OR `ingest.lock` is fresh. `phase` is derived from the file's full
+ * value (`ingest:graph` → "graph", otherwise "wiki"), defaulting to "wiki" when
+ * the lock is fresh but the phase file is momentarily missing/stale.
  */
-export async function isWorkerBlockingBusy(cwd: string): Promise<boolean> {
-	if (!(await isWorkerBusy(cwd))) {
-		return false;
-	}
-	return !(await isFreshIngestPhase(cwd));
-}
-
-async function isFreshIngestPhase(cwd: string): Promise<boolean> {
-	const phasePath = join(cwd, ".jolli", "jollimemory", "worker-phase");
+export async function readIngestPhase(cwd: string): Promise<{ busy: boolean; phase: IngestPhaseLabel }> {
+	const phasePath = jolliMemoryFile(cwd, "ingest-phase");
+	const lockFresh = await isFileFresh(jolliMemoryFile(cwd, "ingest.lock"));
+	let content = "";
+	let phaseFresh = false;
 	try {
-		const content = await readFile(phasePath, "utf-8");
-		// Prefix match: the worker writes `ingest:wiki` / `ingest:graph` (and, for
-		// older workers, bare `ingest`). Every `ingest*` value is commit-exempt;
-		// only a non-ingest phase (e.g. `summary`) blocks. An equality check here
-		// would wrongly block commits during the new sub-phases.
-		if (!content.trim().startsWith("ingest")) {
-			return false;
-		}
-		const phaseStat = await stat(phasePath);
-		return Date.now() - phaseStat.mtimeMs < LOCK_TIMEOUT_MS;
+		content = (await readFile(phasePath, "utf-8")).trim();
+		phaseFresh = await isFileFresh(phasePath);
 	} catch {
-		return false;
+		// No phase file — fall back to lock liveness below.
 	}
+	if (!phaseFresh && !lockFresh) return { busy: false, phase: null };
+	if (phaseFresh && content.indexOf("ingest") !== 0) return { busy: false, phase: null };
+	return { busy: true, phase: content.indexOf("ingest:graph") === 0 ? "graph" : "wiki" };
 }

--- a/vscode/src/views/CreatePrWebviewPanel.test.ts
+++ b/vscode/src/views/CreatePrWebviewPanel.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
 	handleCreatePr: vi.fn().mockResolvedValue("succeeded"),
 	handleUpdatePrWithPush: vi.fn().mockResolvedValue("succeeded"),
 	findOpenPrForBranch: vi.fn().mockResolvedValue(undefined),
-	isWorkerBlockingBusy: vi.fn().mockResolvedValue(false),
+	isWorkerBusy: vi.fn().mockResolvedValue(false),
 	buildCreatePrViewModel: vi.fn().mockResolvedValue({
 		branch: "feature/x", mainBranch: "main", memoryCount: 1, missingCount: 0,
 		insertions: 1, deletions: 0, filesChanged: 1, title: "feat: x", bodyMarkdown: "B",
@@ -101,7 +101,7 @@ vi.mock("../services/PrCommentService.js", () => ({
 	}),
 }));
 vi.mock("./CreatePrData", () => ({ buildCreatePrViewModel: mocks.buildCreatePrViewModel }));
-vi.mock("../util/LockUtils.js", () => ({ isWorkerBlockingBusy: mocks.isWorkerBlockingBusy }));
+vi.mock("../util/LockUtils.js", () => ({ isWorkerBusy: mocks.isWorkerBusy }));
 vi.mock("../util/Logger.js", () => ({
 	log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), show: vi.fn(), dispose: vi.fn() },
 	initLogger: vi.fn(),
@@ -143,7 +143,7 @@ beforeEach(() => {
 	created.length = 0;
 	CreatePrWebviewPanel.dispose();
 	vi.clearAllMocks();
-	mocks.isWorkerBlockingBusy.mockResolvedValue(false);
+	mocks.isWorkerBusy.mockResolvedValue(false);
 	mocks.handleCreatePr.mockResolvedValue("succeeded");
 	mocks.handleUpdatePrWithPush.mockResolvedValue("succeeded");
 	mocks.pushBranchMemories.mockResolvedValue({ pushedCount: 2, attachmentCount: 0, attachmentFailures: [], summaryFailures: [] });
@@ -218,7 +218,7 @@ describe("CreatePrWebviewPanel", () => {
 	});
 
 	it("worker-busy guard: shows toast and skips handleCreatePr when worker is blocking", async () => {
-		mocks.isWorkerBlockingBusy.mockResolvedValue(true);
+		mocks.isWorkerBusy.mockResolvedValue(true);
 		const vscode = await import("vscode");
 		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "createPr" });
@@ -232,7 +232,7 @@ describe("CreatePrWebviewPanel", () => {
 
 	it("worker-busy guard: update path also posts a settling message (buttons re-enable)", async () => {
 		mocks.findOpenPrForBranch.mockResolvedValueOnce({ number: 7, url: "https://gh/pr/7" });
-		mocks.isWorkerBlockingBusy.mockResolvedValue(true);
+		mocks.isWorkerBusy.mockResolvedValue(true);
 		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
 		created[0].onMsg({ command: "createPr" });
 		await Promise.resolve(); await Promise.resolve();

--- a/vscode/src/views/CreatePrWebviewPanel.ts
+++ b/vscode/src/views/CreatePrWebviewPanel.ts
@@ -33,7 +33,7 @@ import {
 	handleUpdatePrWithPush,
 } from "../services/PrCommentService.js";
 import { log } from "../util/Logger.js";
-import { isWorkerBlockingBusy } from "../util/LockUtils.js";
+import { isWorkerBusy } from "../util/LockUtils.js";
 import { loadGlobalConfig } from "../util/WorkspaceUtils.js";
 import { resolveBindingViaChooser } from "./BindingResolver.js";
 import { buildCreatePrViewModel, type CreatePrViewModel } from "./CreatePrData.js";
@@ -243,7 +243,7 @@ export class CreatePrWebviewPanel {
 
 		switch (m.command) {
 			case "createPr": {
-				if (await isWorkerBlockingBusy(this.workspaceRoot)) {
+				if (await isWorkerBusy(this.workspaceRoot)) {
 					vscode.window.showWarningMessage(
 						"Jolli Memory: AI summary is being generated. Please wait a moment.",
 					);

--- a/vscode/src/views/SidebarMessages.ts
+++ b/vscode/src/views/SidebarMessages.ts
@@ -11,7 +11,7 @@
 import type { ActiveConversationItem } from "../../../cli/src/core/ActiveSessionAggregator.js";
 import type { PinEntry, PinKind } from "../../../cli/src/core/PinStore.js";
 import type { ReferenceField, SourceId, TranscriptSource } from "../../../cli/src/Types.js";
-import type { WorkerPhase } from "../stores/StatusStore.js";
+import type { IngestPhase } from "../stores/StatusStore.js";
 
 export type SidebarTab = "kb" | "branch" | "status";
 export type KbMode = "folders" | "memories";
@@ -936,15 +936,15 @@ export type SidebarInboundMsg =
 	  }
 	| {
 			/**
-			 * Worker-phase indicator for the Branch-tab toolbar. Selects a
-			 * distinct label per ingest sub-phase: `"ingest:wiki"` → "Building
-			 * knowledge wiki…", `"ingest:graph"` → "Building knowledge graph…"
-			 * (the legacy bare `"ingest"` falls back to the wiki label). `null`
-			 * falls back to the default "AI summary in progress…". Lifetime is
-			 * bound to `worker:busy` on the reader side.
+			 * Ingest indicator for the Branch-tab toolbar's cosmetic pill. `busy`
+			 * drives whether the "Building knowledge …" pill shows; `phase` selects
+			 * the label (`"wiki"` → "Building knowledge wiki…", `"graph"` → "Building
+			 * knowledge graph…"). Fully independent of `worker:busy` — an ingest runs
+			 * under its own lock and can show while no summary is in flight.
 			 */
-			readonly type: "worker:phase";
-			readonly phase: WorkerPhase;
+			readonly type: "ingest:phase";
+			readonly busy: boolean;
+			readonly phase: IngestPhase;
 	  }
 	| {
 			/**

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -1459,7 +1459,7 @@ describe("SidebarScriptBuilder", () => {
 		it("gates entering squash mode while a background AI summary is in progress", () => {
 			const js = buildSidebarScript();
 			// The "Squash memories…" enter button is disabled during a blocking
-			// worker run (ingest exempt via isWorkerBlocking), mirroring the
+			// worker run (worker.lock held, via isWorkerBlocking), mirroring the
 			// SquashCommand handler gate. The actual confirm lives in the squash
 			// bar (gated on 2+ selected || worker busy — asserted below).
 			expect(js).toMatch(
@@ -1473,14 +1473,12 @@ describe("SidebarScriptBuilder", () => {
 			);
 		});
 
-		it("exempts the ingest phase from disabling commit actions", () => {
+		it("gates commit actions on workerBusy alone (ingest never blocks)", () => {
 			const js = buildSidebarScript();
-			// isWorkerBlocking is the single busy predicate for commit actions:
-			// busy in any phase except an `ingest*` sub-phase (prefix match so
-			// ingest:wiki / ingest:graph both stay exempt).
-			expect(js).toContain(
-				"return state.workerBusy && !(state.workerPhase && state.workerPhase.indexOf('ingest') === 0);",
-			);
+			// isWorkerBlocking is the single busy predicate for commit actions and
+			// mirrors worker.lock only. Ingest runs under its own lock and can
+			// never hold worker.lock, so there is no phase exemption to check.
+			expect(js).toContain("return state.workerBusy;");
 			// Both commit entry points go through it: the Commit-AI icon button
 			// (asserted above) and the body-bar Commit Memory button.
 			expect(js).toMatch(
@@ -2772,7 +2770,7 @@ describe("SidebarScriptBuilder", () => {
 
 	it("renders a compact build pill (Wiki / Graph) for the ingest phase, full label in the title", () => {
 		const js = buildSidebarScript();
-		// Non-blocking Memory Bank build → a compact pill mirroring the ● AI pill:
+		// A live ingest (running alone) → a compact pill mirroring the ● AI pill:
 		// a spinner + a short phase word that never truncates in a narrow header.
 		expect(js).toContain("className: 'section-build-pill'");
 		expect(js).toContain("section-build-spin");
@@ -2781,35 +2779,39 @@ describe("SidebarScriptBuilder", () => {
 		expect(js).toContain("const short = isGraph ? 'Graph' : 'Wiki';");
 		expect(js).toContain("Building knowledge graph…");
 		expect(js).toContain("Building knowledge wiki…");
-		// graph is the more specific prefix and must be tested before the wiki
-		// fallback, else 'ingest:graph' would match the wiki branch.
-		expect(js).toContain("state.workerPhase.indexOf('ingest:graph') === 0");
-		expect(js).toContain("state.workerPhase.indexOf('ingest') === 0");
+		// The pill reads the dedicated ingestBusy / ingestPhase state, not the
+		// worker (summary) phase — ingest has its own lock.
+		expect(js).toContain("if (state.ingestBusy)");
+		expect(js).toContain("const isGraph = state.ingestPhase === 'graph';");
 		// The retired single-value label must be gone.
 		expect(js).not.toContain("Updating Memory Bank…");
 	});
 
-	it("keeps the default AI summary label for non-ingest busy state", () => {
+	it("renders a compact '● AI' pill for the blocking summary and gives it priority over the ingest pill", () => {
 		const js = buildSidebarScript();
-		expect(js).toContain("AI summary in progress…");
+		// Summary-first priority: workerBusy returns the "● AI" pill before the
+		// ingestBusy branch is ever reached, so a concurrent ingest is suppressed
+		// while a summary runs. The full phrase survives only as the pill's title.
+		const start = js.indexOf("function renderWorkerSignal(");
+		const end = js.indexOf("function renderSection(", start);
+		const body = js.slice(start, end);
+		expect(start).toBeGreaterThan(-1);
+		// workerBusy check comes first (priority), ingestBusy check comes after.
+		const workerIdx = body.indexOf("if (state.workerBusy)");
+		const ingestIdx = body.indexOf("if (state.ingestBusy)");
+		expect(workerIdx).toBeGreaterThan(-1);
+		expect(ingestIdx).toBeGreaterThan(workerIdx);
+		expect(body).toContain("className: 'section-ai-pill'");
+		expect(body).toContain("className: 'section-ai-dot'");
+		expect(body).toContain("className: 'section-ai-text', text: 'AI'");
 	});
 
-	it("renders a compact '● AI' pill for the blocking summary instead of inline text", () => {
-		const js = buildSidebarScript();
-		// Blocking (non-ingest) branch returns the pill; the full phrase survives
-		// only as the pill's hover title.
-		expect(js).toContain("className: 'section-ai-pill'");
-		expect(js).toContain("className: 'section-ai-dot'");
-		expect(js).toContain("className: 'section-ai-text', text: 'AI'");
-		// The spinner-and-text status is now reserved for the ingest phases only.
-		expect(js).toContain("const isIngest = state.workerPhase && state.workerPhase.indexOf('ingest') === 0;");
-	});
-
-	it("renders the 'Summarizing <hash>…' Working Memory row gated on blocking busy state", () => {
+	it("renders the 'Summarizing <hash>…' Working Memory row gated on workerBusy alone", () => {
 		const js = buildSidebarScript();
 		expect(js).toContain("function renderSummarizingRow(");
-		// Only during a blocking worker run (busy && no ingest phase).
-		expect(js).toContain("if (!state.workerBusy || state.workerPhase) return null;");
+		// Only during a summary run (worker.lock held). No phase check — ingest
+		// never holds worker.lock.
+		expect(js).toContain("if (!state.workerBusy) return null;");
 		// Per the redesign mockup the row reads "Summarizing <hash>…", naming the
 		// commit from the host-attached hash and degrading to a bare "Summarizing…".
 		expect(js).toContain("'Summarizing ' + hash + '…'");
@@ -2822,32 +2824,22 @@ describe("SidebarScriptBuilder", () => {
 		expect(js).toContain("if (summarizing) bodyKids.push(summarizing);");
 	});
 
-	it("worker:phase keeps any ingest* sub-phase verbatim and clears anything else", () => {
+	it("ingest:phase carries busy + phase and re-renders the Branch tab", () => {
 		const js = buildSidebarScript();
-		const handlerStart = js.indexOf("case 'worker:phase'");
-		const handlerEnd = js.indexOf("case ", handlerStart + 1);
-		const body = js.slice(handlerStart, handlerEnd);
-		// Prefix-gated pass-through: ingest:wiki / ingest:graph survive, summary → null.
-		expect(body).toContain("(msg.phase && msg.phase.indexOf('ingest') === 0) ? msg.phase : null");
-	});
-
-	it("handles the worker:phase message channel", () => {
-		const js = buildSidebarScript();
-		expect(js).toContain("case 'worker:phase'");
-	});
-
-	it("re-renders toolbar AND branch when worker:phase changes on the Branch tab", () => {
-		const js = buildSidebarScript();
-		// The phase drives the commit buttons' disabled state (ingest is exempt
-		// from blocking — isWorkerBlocking), so renderToolbar alone is not
-		// enough: section actions live in renderBranch.
-		const handlerStart = js.indexOf("case 'worker:phase'");
-		const handlerEnd = js.indexOf("case ", handlerStart + 1);
+		const handlerStart = js.indexOf("case 'ingest:phase'");
 		expect(handlerStart).toBeGreaterThan(-1);
+		const handlerEnd = js.indexOf("case ", handlerStart + 1);
 		const body = js.slice(handlerStart, handlerEnd);
-		// Idempotent: skip re-render when the phase did not change.
-		expect(body).toContain("if (state.workerPhase === nextPhase) break;");
-		expect(body).toContain("renderToolbar()");
+		// Busy + phase are read off the message; phase defaults to 'wiki' and is
+		// forced to null when not busy.
+		expect(body).toContain("const nextBusy = !!msg.busy;");
+		expect(body).toContain("const nextPhase = nextBusy ? (msg.phase || 'wiki') : null;");
+		// Idempotent: skip the re-render when neither busy nor phase changed.
+		expect(body).toContain(
+			"if (state.ingestBusy === nextBusy && state.ingestPhase === nextPhase) break;",
+		);
+		// The pill lives in the Committed Memories header, which only re-mounts
+		// via renderBranch().
 		expect(body).toContain("renderBranch()");
 	});
 

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -127,11 +127,12 @@ export function buildSidebarScript(): string {
     // toolbar. Not persisted — start from false on every load and let the next
     // worker:busy or status push correct it.
     workerBusy: false,
-    // Live phase of the running worker ('ingest:wiki' / 'ingest:graph', or the
-    // legacy bare 'ingest'), pushed on the worker:phase channel. Selects the
-    // matching "Building knowledge wiki/graph…" label over the default summary
-    // label. Not persisted -- host re-pushes on reload.
-    workerPhase: null,
+    // Live ingest indicator pushed on the ingest:phase channel — fully independent
+    // of workerBusy (ingest runs under its own lock). ingestBusy drives whether the
+    // "Building knowledge …" pill shows; ingestPhase ('wiki' | 'graph' | null)
+    // selects the label. Not persisted -- host re-pushes on reload.
+    ingestBusy: false,
+    ingestPhase: null,
     // Workspace HEAD short hash attached to worker:busy while the blocking
     // summary runs — drives the "Summarizing <hash>…" Working Memory row.
     // null when idle or when the host can't resolve it. Not persisted.
@@ -169,7 +170,8 @@ export function buildSidebarScript(): string {
   // workerBusy is intentionally reset on load (above), even if persisted state
   // had it set — the lock is process-bound and cannot survive a reload.
   state.workerBusy = false;
-  state.workerPhase = null;
+  state.ingestBusy = false;
+  state.ingestPhase = null;
   state.summarizingHash = null;
   state.syncPhase = null;
   state.tokenStats = null;
@@ -821,19 +823,22 @@ export function buildSidebarScript(): string {
         }
         break;
       }
-      case 'worker:phase': {
-        // Per-phase label for the post-commit Worker. Independent of
-        // worker:busy; any 'ingest'-prefixed sub-phase ('ingest', 'ingest:wiki',
-        // 'ingest:graph') is kept verbatim so renderToolbar can pick the matching
-        // wiki/graph label, anything else clears to the default summary label.
-        // Only the Branch tab reacts. renderBranch runs too because the commit
-        // buttons' disabled state depends on the phase (ingest is exempt from
-        // blocking — see isWorkerBlocking), not just on worker:busy.
-        const nextPhase = (msg.phase && msg.phase.indexOf('ingest') === 0) ? msg.phase : null;
-        if (state.workerPhase === nextPhase) break;
-        state.workerPhase = nextPhase;
+      case 'ingest:phase': {
+        // Cosmetic ingest pill state. Fully independent of worker:busy — an
+        // ingest runs under its own lock, so its pill can show while no summary
+        // is in flight (and is suppressed by renderWorkerSignal's summary-first
+        // priority when one is). Does NOT gate the commit buttons.
+        const nextBusy = !!msg.busy;
+        const nextPhase = nextBusy ? (msg.phase || 'wiki') : null;
+        if (state.ingestBusy === nextBusy && state.ingestPhase === nextPhase) break;
+        state.ingestBusy = nextBusy;
+        state.ingestPhase = nextPhase;
+        // The pill is painted by renderWorkerSignal() inside the Committed
+        // Memories section header, which only re-runs via renderBranch() — NOT
+        // renderToolbar (a no-op for this pill on the Branch tab). Re-render the
+        // branch body so the pill actually appears/clears. setIngest is
+        // equality-checked upstream, so 60s heartbeats don't churn this.
         if (state.activeTab === 'branch') {
-          renderToolbar();
           renderBranch();
         }
         break;
@@ -3527,20 +3532,16 @@ export function buildSidebarScript(): string {
   }
 
   // Read-only summarizing-indicator row shown at the top of Working Memory while
-  // the blocking post-commit worker runs (workerBusy && no ingest phase —
-  // ingest:wiki/graph keep their own header label and add no row).
+  // the post-commit summary worker runs. workerBusy is the worker.lock signal,
+  // which (with ingest split onto its own lock) is held only during summary — so
+  // it maps directly to this row, no phase check needed.
   //
   // Per the redesign mockup this row reads "Summarizing <hash>…" (matching the
-  // .summarizing-row class name and every surrounding reference). worker:busy and
-  // worker:phase are independent channels (busy is lock-file-driven; phase only
-  // ever stores 'ingest'-prefixed values, else null), so "busy && no phase" is
-  // overwhelmingly the blocking summary — a Memory Bank ingest run can briefly
-  // land here before its phase signal arrives, but that transient window is rare
-  // and the mockup accepts the summarize wording over a vaguer neutral label.
-  // The short hash is the workspace HEAD the host attaches to worker:busy;
-  // absent (older host / detached edge) it degrades to a bare "Summarizing…".
+  // .summarizing-row class name and every surrounding reference). The short hash
+  // is the workspace HEAD the host attaches to worker:busy; absent (older host /
+  // detached edge) it degrades to a bare "Summarizing…".
   function renderSummarizingRow() {
-    if (!state.workerBusy || state.workerPhase) return null;
+    if (!state.workerBusy) return null;
     const hash = state.summarizingHash;
     const label = hash ? ('Summarizing ' + hash + '…') : 'Summarizing…';
     return el('div', { className: 'tree-node summarizing-row', title: label }, [
@@ -3834,26 +3835,21 @@ export function buildSidebarScript(): string {
     ]);
   }
 
-  // Inline post-commit worker signal for the Committed Memories header. The
-  // global toolbar that used to host "AI summary in progress…" was removed, so
-  // the signal moved next to the section it describes (a committed memory's
-  // summary is what the Worker is generating). Returns null when idle so the
-  // header stays clean. The phase is the ingest:* family ('ingest:wiki' /
-  // 'ingest:graph', or legacy bare 'ingest') during the non-blocking Memory
-  // Bank build; null/anything else means the blocking AI summary run. Match the
-  // sub-phase via prefix (the host only ever emits the prefixed form — exact
-  // '=== ingest' would never hit) and mirror the worker:phase label contract in
-  // SidebarMessages.ts. The label truncates on narrow sidebars (CSS); the
-  // spinner alone still reads as "working".
+  // Inline worker/ingest signal for the Committed Memories header. The global
+  // toolbar that used to host "AI summary in progress…" was removed, so the
+  // signal moved next to the section it describes. Priority single pill, summary
+  // first (the summary is what the user is actively waiting on):
+  //   - workerBusy (summary running)       → compact "● AI" pill;
+  //   - else ingestBusy (Memory Bank build) → compact "⟳ Wiki/Graph" pill;
+  //   - else                                → null (header stays clean).
+  // So when summary + ingest run concurrently, only "AI" shows; the build pill
+  // appears only while ingest runs alone. The label truncates on narrow sidebars
+  // (CSS); the spinner/dot alone still reads as "working".
   function renderWorkerSignal() {
-    if (!state.workerBusy) return null;
-    const isIngest = state.workerPhase && state.workerPhase.indexOf('ingest') === 0;
-    // Blocking AI summary run: the header carries only a compact "● AI" pill
-    // (the visible text stays short so it never crowds the narrow header). The
-    // hover title names the commit being summarized — "Summarizing <hash>…",
-    // matching the Working Memory row — degrading to a bare "Summarizing…" when
-    // the host attached no hash (older host / detached edge).
-    if (!isIngest) {
+    // Summary first: the blocking AI run the user is waiting on. Hover title
+    // names the commit — "Summarizing <hash>…", matching the Working Memory row,
+    // degrading to a bare "Summarizing…" when the host attached no hash.
+    if (state.workerBusy) {
       const hash = state.summarizingHash;
       const aiTitle = hash ? ('Summarizing ' + hash + '…') : 'Summarizing…';
       return el('span', { className: 'section-ai-pill', title: aiTitle }, [
@@ -3861,19 +3857,20 @@ export function buildSidebarScript(): string {
         el('span', { className: 'section-ai-text', text: 'AI' }),
       ]);
     }
-    // Non-blocking Memory Bank build → a compact pill mirroring the "● AI" pill:
-    // a small spinner + a short phase word (Wiki / Graph) so it never truncates
-    // in a narrow header. The verbose "Building knowledge …" phrasing survives
-    // only as the pill's hover title. graph is the more specific prefix → test
-    // it before the wiki fallback, else 'ingest:graph' would match the bare
-    // 'ingest' branch and mislabel.
-    const isGraph = state.workerPhase.indexOf('ingest:graph') === 0;
-    const label = isGraph ? 'Building knowledge graph…' : 'Building knowledge wiki…';
-    const short = isGraph ? 'Graph' : 'Wiki';
-    return el('span', { className: 'section-build-pill', title: label }, [
-      el('i', { className: 'codicon codicon-loading codicon-modifier-spin section-build-spin', 'aria-hidden': 'true' }),
-      el('span', { className: 'section-build-text', text: short }),
-    ]);
+    // Ingest running alone → a compact pill mirroring the "● AI" pill: a small
+    // spinner + a short phase word (Wiki / Graph) so it never truncates in a
+    // narrow header. The verbose "Building knowledge …" phrasing survives only as
+    // the pill's hover title.
+    if (state.ingestBusy) {
+      const isGraph = state.ingestPhase === 'graph';
+      const label = isGraph ? 'Building knowledge graph…' : 'Building knowledge wiki…';
+      const short = isGraph ? 'Graph' : 'Wiki';
+      return el('span', { className: 'section-build-pill', title: label }, [
+        el('i', { className: 'codicon codicon-loading codicon-modifier-spin section-build-spin', 'aria-hidden': 'true' }),
+        el('span', { className: 'section-build-text', text: short }),
+      ]);
+    }
+    return null;
   }
 
   function renderSection(s) {
@@ -3988,12 +3985,11 @@ export function buildSidebarScript(): string {
   }
 
   function isWorkerBlocking() {
-    // Busy with a phase that must disable commit actions. The ingest family
-    // (Memory Bank wiki update + graph build, ~80s+) is exempt: it never touches
-    // the commit pipeline, so commits landed during it are simply queued for the
-    // next worker. Prefix match so every 'ingest:*' sub-phase stays exempt.
-    // Mirrors isWorkerBlockingBusy in util/LockUtils.ts.
-    return state.workerBusy && !(state.workerPhase && state.workerPhase.indexOf('ingest') === 0);
+    // A summary run (worker.lock) must disable commit actions. Ingest runs under
+    // its own lock and never touches the commit pipeline, so it does not block —
+    // and it isn't reflected in workerBusy at all. Mirrors isWorkerBusy in
+    // util/LockUtils.ts.
+    return state.workerBusy;
   }
 
   function renderCommitReviewBar() {

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -5441,7 +5441,7 @@ describe("SidebarWebviewProvider", () => {
 			}
 		});
 
-		it("posts worker:phase on ready when statusProvider exposes getWorkerPhase", async () => {
+		it("posts ingest:phase on ready when statusProvider exposes getIngest", async () => {
 			const view = makeMockView();
 			const provider = new SidebarWebviewProvider({
 				executeCommand: vi.fn(),
@@ -5458,7 +5458,7 @@ describe("SidebarWebviewProvider", () => {
 					serialize: () => [],
 					onDidChangeTreeData: () => ({ dispose: () => {} }),
 					getWorkerBusy: () => false,
-					getWorkerPhase: () => "ingest",
+					getIngest: () => ({ busy: true, phase: "graph" }),
 				},
 			});
 			provider.resolveWebviewView(view as unknown as never);
@@ -5466,9 +5466,10 @@ describe("SidebarWebviewProvider", () => {
 			await flushReady();
 			const phaseMsg = view.webview.postMessage.mock.calls
 				.map((c) => c[0])
-				.find((m) => m.type === "worker:phase");
+				.find((m) => m.type === "ingest:phase");
 			expect(phaseMsg).toBeDefined();
-			expect(phaseMsg.phase).toBe("ingest");
+			expect(phaseMsg.busy).toBe(true);
+			expect(phaseMsg.phase).toBe("graph");
 		});
 
 		describe("kb:requestPrStatus → kb:prStatus", () => {

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -24,7 +24,7 @@ import type { ActiveConversationItem } from "../../../cli/src/core/ActiveSession
 import type { ActiveSessionsProvider } from "../services/ActiveSessionsProvider.js";
 import type { CommitFileInfo } from "../Types.js";
 import { flushExtensionTelemetry } from "../TelemetryActivation.js";
-import type { WorkerPhase } from "../stores/StatusStore.js";
+import type { IngestPhase } from "../stores/StatusStore.js";
 import { log } from "../util/Logger.js";
 import { ConversationDetailsPanel } from "./ConversationDetailsPanel.js";
 import { SIDEBAR_EMPTY_STRINGS } from "./SidebarEmptyMessages.js";
@@ -129,12 +129,13 @@ export interface SidebarWebviewDeps {
 			readonly severity: "info" | "error";
 		} | null;
 		/**
-		 * Returns the current post-commit worker phase from StatusStore. Pushed
-		 * to the webview as `worker:phase` so the Branch tab toolbar can show the
-		 * matching "Building knowledge wiki/graph…" label during a topic-KB ingest.
-		 * Optional so existing tests that only stub `getWorkerBusy` keep compiling.
+		 * Returns the current ingest display state from StatusStore. Pushed to the
+		 * webview as `ingest:phase` so the Branch tab toolbar can show the matching
+		 * "Building knowledge wiki/graph…" pill during a topic-KB ingest. Fully
+		 * independent of worker-busy (ingest has its own lock). Optional so existing
+		 * tests that only stub `getWorkerBusy` keep compiling.
 		 */
-		getWorkerPhase?: () => WorkerPhase;
+		getIngest?: () => { readonly busy: boolean; readonly phase: IngestPhase };
 	};
 	kbFolders?: {
 		listChildren(relPath: string): Promise<FolderNode>;
@@ -1794,13 +1795,16 @@ export class SidebarWebviewProvider
 				phase: getSyncPhase(),
 			});
 		}
-		// Worker-phase indicator (ingest). Same StatusStore change event as
-		// worker:busy; optional getter so existing stubs keep compiling.
-		const getWorkerPhase = this.deps.statusProvider.getWorkerPhase;
-		if (getWorkerPhase) {
+		// Ingest indicator. Same StatusStore change event as worker:busy; optional
+		// getter so existing stubs keep compiling. Independent of worker:busy — the
+		// ingest pill shows even when no summary (worker.lock) is running.
+		const getIngest = this.deps.statusProvider.getIngest;
+		if (getIngest) {
+			const ingest = getIngest();
 			this.postMessage({
-				type: "worker:phase",
-				phase: getWorkerPhase(),
+				type: "ingest:phase",
+				busy: ingest.busy,
+				phase: ingest.phase,
 			});
 		}
 	}

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -407,12 +407,12 @@ vi.mock("../services/PrCommentService.js", () => ({
 	wrapWithMarkers: (s: string) => `[MARKERS]${s}[/MARKERS]`,
 }));
 
-const { mockIsWorkerBlockingBusy } = vi.hoisted(() => ({
-	mockIsWorkerBlockingBusy: vi.fn().mockResolvedValue(false),
+const { mockIsWorkerBusy } = vi.hoisted(() => ({
+	mockIsWorkerBusy: vi.fn().mockResolvedValue(false),
 }));
 
 vi.mock("../util/LockUtils.js", () => ({
-	isWorkerBlockingBusy: mockIsWorkerBlockingBusy,
+	isWorkerBusy: mockIsWorkerBusy,
 }));
 
 const { mockLoadBranchSummaries } = vi.hoisted(() => ({
@@ -4006,7 +4006,7 @@ describe("SummaryWebviewPanel", () => {
 			});
 
 			it("worker-busy: shows warning + re-runs handleCheckPrStatus to reset the button", async () => {
-				mockIsWorkerBlockingBusy.mockResolvedValueOnce(true);
+				mockIsWorkerBusy.mockResolvedValueOnce(true);
 				const dispatch = await setupPanel();
 
 				dispatch({ command: "prepareCreatePr" });
@@ -4240,7 +4240,7 @@ describe("SummaryWebviewPanel", () => {
 			});
 
 			it("worker-busy: shows warning + re-runs handleCheckPrStatus to reset the button", async () => {
-				mockIsWorkerBlockingBusy.mockResolvedValueOnce(true);
+				mockIsWorkerBusy.mockResolvedValueOnce(true);
 				const dispatch = await setupPanel();
 
 				dispatch({ command: "prepareUpdatePr" });
@@ -11925,7 +11925,7 @@ describe("SummaryWebviewPanel", () => {
 				// Worker busy → handleWorkerBusyOrContinue runs the PR status re-check,
 				// which for a foreign panel passes foreignRepoUrl (the truthy arm of
 				// `this.foreignRepoName ? this.foreignRepoUrl : null`).
-				mockIsWorkerBlockingBusy.mockResolvedValueOnce(true);
+				mockIsWorkerBusy.mockResolvedValueOnce(true);
 				// Reset (not just clear): an earlier test sets a persistent
 				// mockRejectedValue on this mock, which clearMocks does not undo.
 				mockHandleCheckPrStatus.mockReset();

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -82,7 +82,7 @@ import {
 	handleUpdatePr,
 } from "../services/PrCommentService.js";
 import { deriveRepoNameFromUrl, getCanonicalRepoUrl } from "../util/GitRemoteUtils.js";
-import { isWorkerBlockingBusy } from "../util/LockUtils.js";
+import { isWorkerBusy } from "../util/LockUtils.js";
 import { log } from "../util/Logger.js";
 import { loadGlobalConfig } from "../util/WorkspaceUtils.js";
 import {
@@ -1798,13 +1798,13 @@ export class SummaryWebviewPanel {
 
 	// Returns true when worker is busy with a blocking (summary) run: shows the
 	// toast and re-runs the status check so the click-time "Loading..." button
-	// gets rebuilt. The ingest phase is exempt, same as the Commit/Squash gates:
-	// PR creation reads already-stored orphan-branch summaries, which ingest
-	// never writes — blocking it for ingest's ~80s+ duration is pure UX damage.
+	// gets rebuilt. Ingest is not gated: it runs under its own ingest.lock, not
+	// worker.lock, and PR creation reads already-stored orphan-branch summaries
+	// that ingest never writes.
 	private async handleWorkerBusyOrContinue(
 		postMessage: (msg: Record<string, unknown>) => void,
 	): Promise<boolean> {
-		if (!(await isWorkerBlockingBusy(this.workspaceRoot))) {
+		if (!(await isWorkerBusy(this.workspaceRoot))) {
 			return false;
 		}
 		vscode.window.showWarningMessage(


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (2)

1. Nest orphan-write.lock inside vault-write.lock in ingest writeGuard (`28fb38a`) — [Memory](https://jolli.ai/very/articles?doc=6930)
2. Run topic-KB ingest under its own ingest.lock, off the summary worker.lock (`134b2d3`) — [Memory](https://jolli.ai/very/articles?doc=6931)

## Quick recap (2)

### Commit 1 of 2: Nest orphan-write.lock inside vault-write.lock in ingest writeGuard (`28fb38a`)

The ingest background process now uses the correct lock when writing to the shared orphan git branch. Previously, ingest held a vault-level lock during these writes, which is the right lock for folder and wiki data but the wrong one for orphan branch data — the lock that summary generation uses for the same resource. This mismatch meant the two processes could theoretically write to the orphan branch simultaneously and corrupt it. The fix adds the orphan lock as an inner layer inside the existing vault lock, with the acquisition order deliberately matching the summary path's order to prevent any possibility of deadlock when the two processes eventually run concurrently. Two new automated tests were added alongside the change: one confirms the orphan lock is actually invoked during ingest writes, and the other records the live acquisition sequence and asserts vault is always acquired before orphan.

### Commit 2 of 2: Run topic-KB ingest under its own ingest.lock, off the summary worker.lock (`134b2d3`)

The knowledge-base ingest process — which builds the wiki and graph views of stored memories — now runs under its own dedicated lock, fully separated from the AI summary worker. Previously, both processes shared a single lock, and the extension required special exemption logic to let commits through during an ingest. With the split in place, the commit and squash gates check only the summary lock with no special cases: commits proceed freely during an ingest, and a slow wiki or graph rebuild no longer delays summarization of new commits. A new handoff mechanism ensures that a worker arriving while an ingest is already running records its intent and retries, so no ingest request is silently lost even under contention.

The VS Code sidebar gained an independent display channel for ingest activity. The "Building knowledge wiki/graph…" pill now tracks ingest state separately from the summarization indicator, and the two can be active at the same time. Finishing a summary no longer accidentally clears a live ingest pill, and a 60-second background check clears any pill left behind by a crashed ingest process. When both a summary and an ingest happen to run concurrently, the sidebar shows only the summarization pill, keeping the most immediately relevant signal prominent.

A bug was also fixed where the ingest pill silently failed to appear or clear for users already viewing the branch tab when ingest started. The tab-switch path independently triggered a branch render, which masked the failure in casual testing, but anyone who stayed on the branch tab throughout an ingest would never see the pill at all. The fix ensures the pill renders correctly regardless of whether the user was already on the branch tab when ingest began.

## Topics (7)
<details>
<summary><strong>01 · [28fb38a] Ingest writes now use the correct lock for orphan branch data</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The background ingest process was using the wrong lock when writing to the shared orphan git branch. This meant that if summary generation and ingest ever ran concurrently, their writes to the orphan branch could collide and corrupt data.

**💡 Decisions Behind the Code**

- **Nest rather than replace**: The ingest write guard already held the vault-level lock for folder/wiki writes, which is correct and must be preserved. Adding the orphan lock as an inner layer — rather than swapping one for the other — means both resources remain protected by their appropriate locks simultaneously. Replacing the outer lock would have left folder writes unprotected.
- **Match the summary path's lock order**: The summary write path acquires vault-write first, then orphan-write. Ingest was made to follow the same order deliberately. If the two paths ever acquired these locks in opposite orders, a future concurrent run could deadlock. Aligning the order now eliminates that risk before concurrency is introduced.
- **No behavior change today, groundwork for future concurrency**: Currently summary generation and ingest run back-to-back in a single worker, so the orphan lock will never actually contend. The change is safe to land now precisely because it is a no-op under the current serial schedule, and it makes the system correct-by-construction for the planned split into concurrent workers.

**✅ What Was Implemented**

- `withRequiredOrphanWriteLock` in `cli/src/core/SummaryStore.ts` was changed from a module-private function to an exported one, making it available to the worker orchestration layer.
- In `cli/src/hooks/QueueWorker.ts`, the `writeGuard` closure that wraps all ingest writes was updated to nest `withRequiredOrphanWriteLock` (labeled `"ingest-write"`) inside the existing outer vault write lock. The lock acquisition order is vault-write first, orphan-write second — matching the order used by the summary path, which prevents deadlocks when both run concurrently.

**📋 Future Enhancements**

Run `npm run all` (build, lint, full test suite with coverage gate) to confirm the complete pipeline passes — the session ended after per-file test runs passed but before the full gate was confirmed.

**📁 FILES**
- `cli/src/core/SummaryStore.ts`
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [28fb38a] Tests verify ingest lock wiring and vault-then-orphan acquisition order</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After adding the orphan lock to the ingest write path, there were no automated checks confirming that the lock was actually being acquired, or that it was acquired in the correct order relative to the outer vault lock.

**💡 Decisions Behind the Code**

The tests assert wiring and ordering rather than real lock-file behavior. The actual acquire/release contract of the orphan lock primitive is already covered in its own unit tests. Testing the wiring in isolation — using spies that pass through to the real callback — keeps these tests fast, deterministic, and focused on the one new invariant: that ingest writes flow through both locks in the right sequence.

**✅ What Was Implemented**

- Two new tests were added to `cli/src/hooks/QueueWorker.test.ts`. The first drives the ingest write guard with a sentinel callback and asserts that the orphan lock function was called with the correct label. The second records the entry order of both locks and the actual write, then asserts the sequence is vault → orphan → write.
- The `SummaryStore` mock in the test file was extended with a passthrough spy for `withRequiredOrphanWriteLock`, and the import block was updated to bring in both `withRequiredOrphanWriteLock` and `withVaultWriteLock` for use in the new assertions.

**📁 FILES**
- `cli/src/hooks/QueueWorker.test.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [28fb38a] Planning documents corrected to remove false claim about manifest file protection</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The PR1 planning document incorrectly listed the vault manifest file as a second resource needing protection from the orphan lock change. Investigation showed the manifest is already fully protected by a different, pre-existing lock on both the summary and ingest paths.

**💡 Decisions Behind the Code**

Before deleting the manifest argument, the full lock-holding structure of the worker was traced through the code to confirm the claim was definitively wrong rather than merely imprecise. The summary generation phase runs entirely inside a vault write lock that is held from start to finish, so the manifest write that happens during summary generation is already protected. Removing the argument without this verification would have risked deleting a claim that was actually correct in some edge case.

**✅ What Was Implemented**

The PR1 planning document (`docs/pr1-ingest-orphan-write-lock.md`) was revised to remove the section arguing that the manifest file was at risk of concurrent corruption. A corrective explanation was added noting that the manifest is a folder-layer resource already serialized by the vault write lock on both paths, and was never within scope for this change.

**📁 FILES**
- `docs/pr1-ingest-orphan-write-lock.md`

</blockquote>
</details>
<details>
<summary><strong>04 · [134b2d3] Decouple topic knowledge-base ingest onto its own dedicated lock</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Rebuilding the wiki and knowledge graph held the same lock as commit summarization, so a slow ingest job could block new commits from being summarized for several minutes. The goal was to let ingest and summarization run concurrently within the same repository.

**💡 Decisions Behind the Code**

- **Separate locks over phase exemption**: The previous design held a single lock for both summary and ingest, then used a phase-file exemption to let commits through during ingest. This required an epoch token to guard against stale async reads resurrecting the exemption flag after the lock was released — a subtle race that was hard to reason about. Giving ingest its own lock eliminates the exemption entirely: the summary lock is held only during summarization, so the gate is a plain boolean with no special cases.
- **Fail-fast with record-before-retry over a polling queue**: Ingest uses a single-slot flag file and one retry rather than a wait loop, matching the vault-write lock pattern already in the codebase. The record step happens before the retry to close the time-of-check/time-of-use window: if the holder releases in the gap between the failed acquire and the record, either the retry wins the lock or the holder's wake call sees the flag. A polling loop would add complexity and hold the calling process open; a pure fail-fast with no handoff would strand ingest entries until the next commit.
- **Delete ingest queue entries only after a successful run**: The ingest phase reads entries, runs the ingest, and only then deletes the queue files. A crash or thrown error leaves the entries on disk for the next run to pick up. The old approach deleted the trigger entry during the summary drain, which meant a mid-ingest crash silently lost the work request.
- **Cosmetic phase file carries no gate role**: The renamed phase file now only drives the sidebar's display pill. Removing the gate exemption logic was safe because ingest no longer holds the summary lock at all — the gates are naturally open during ingest without any special-casing.

**✅ What Was Implemented**

- A new `ingest.lock` file was introduced in `cli/src/core/Locks.ts` alongside acquire, release, and refresh-mtime operations, mirroring the existing worker lock pattern. The old `worker-phase` marker file was renamed to `ingest-phase` and demoted to a purely cosmetic display signal with no gate role, since commit and squash gates now key off `worker.lock` alone.
- `cli/src/hooks/QueueWorker.ts` was restructured so the summary drain loop filters out ingest entries entirely, both entry-level locks are released before the ingest phase begins, and ingest then acquires `ingest.lock` fail-fast. A new `cli/src/sync/PendingIngest.ts` module implements a single-slot flag file handoff: a worker that loses the ingest lock records its intent, retries once, and if still blocked leaves its queue entries for the current holder's wake call to re-spawn a worker on completion.
- `cli/src/core/QueueStatus.ts` was updated so `workerBlocking` equals `workerBusy` exactly, since ingest can never hold `worker.lock`. The `getWorkerBusyState` function was simplified accordingly.
- On the VS Code side, `LockUtils.ts` removed `isWorkerBlockingBusy` entirely. The commit and squash gate is now a plain `isWorkerBusy` check against `worker.lock` only. A new `readIngestPhase` function reads the `ingest-phase` file and uses `ingest.lock` as a liveness backstop, returning a `{ busy, phase }` object for the cosmetic sidebar pill. All four gate call sites (`CommitCommand`, `SquashCommand`, `CreatePrWebviewPanel`, `SummaryWebviewPanel`) were updated to use the simplified `isWorkerBusy`.

**📁 FILES**
- `cli/src/core/Locks.ts`
- `cli/src/hooks/QueueWorker.ts`
- `cli/src/sync/PendingIngest.ts`
- `cli/src/core/QueueStatus.ts`
- `vscode/src/util/LockUtils.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [134b2d3] Decouple ingest display state from summary worker state in VS Code sidebar</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

With ingest now running independently of summarization, the sidebar needed its own state channel for ingest activity so the two indicators could be live at the same time without interfering with each other.

**💡 Decisions Behind the Code**

- **Ingest state fully decoupled from worker-busy in the store**: Rather than clearing ingest display state when the summary worker finishes, the two states are independent fields updated by separate code paths. A concurrent summary and ingest can both show their respective indicators, and toggling the summary off never accidentally clears a live ingest pill. The trade-off is a slightly larger state shape, but the correctness gain is significant.
- **`onDidDelete` as authoritative teardown over timer-only clearing**: When the phase file is deleted, the extension immediately clears ingest state rather than relying on the periodic stale check. This closes a timing window where the lock file could still appear fresh in the brief gap between phase file deletion and lock release, which would otherwise cause the liveness backstop to report the ingest as busy for up to 60 seconds after it had already completed.
- **Staleness timer over epoch tokens for crash recovery**: The old design used an in-memory epoch counter to discard async reads that resolved after a synchronous clear. The new design avoids async reads on the delete path entirely and uses a 60-second polling timer only to clear a pill left by a crashed ingest. This is simpler to audit and eliminates the class of race the epoch token was defending against.
- **Summary-first priority in the single pill slot**: When both a summary and an ingest are running concurrently, only the summarization pill is shown; the ingest pill is suppressed until the summary finishes. This keeps the most immediately relevant signal prominent and avoids a confusing double-pill layout. The ingest pill reappears automatically once the summary lock is released.

**✅ What Was Implemented**

- `vscode/src/stores/StatusStore.ts` gained independent `ingestBusy` and `ingestPhase` fields with a dedicated `setIngest` method. The old `setWorkerPhase` / `workerPhase` machinery was removed, and `setWorkerBusy(false)` no longer clears ingest state. The `WorkerPhase` type was replaced by `IngestPhase` with values `"wiki" | "graph" | null`.
- `vscode/src/Extension.ts` replaced the `phaseWatcher` / `readWorkerPhase` / epoch-token machinery with a simpler `ingestPhaseWatcher` and `refreshIngestState` that calls `readIngestPhase` and forwards the result to `statusStore.setIngest`. A 60-second staleness timer was added to clear a pill left by a crashed ingest process. The `onDidDelete` event for the phase file is treated as an authoritative teardown signal, directly clearing ingest state rather than waiting for the timer.
- `vscode/src/views/SidebarScriptBuilder.ts` updated client-side state from `workerPhase: null` to `ingestBusy: false` / `ingestPhase: null`, rewrote the `ingest:phase` message handler to read `msg.busy` and `msg.phase`, simplified `isWorkerBlocking()` to a direct pass-through of `state.workerBusy` (no phase exemption), and updated `renderWorkerSignal()` to check `state.ingestBusy` / `state.ingestPhase` directly.
- `vscode/src/views/SidebarMessages.ts` renamed the `worker:phase` message type to `ingest:phase` and changed its payload from a single `phase` field to `busy: boolean` plus `phase: IngestPhase`. `vscode/src/views/SidebarWebviewProvider.ts` updated the `statusProvider` interface to expose `getIngest()` returning `{ busy, phase }` instead of `getWorkerPhase()`.

**📁 FILES**
- `vscode/src/stores/StatusStore.ts`
- `vscode/src/Extension.ts`
- `vscode/src/views/SidebarScriptBuilder.ts`
- `vscode/src/views/SidebarMessages.ts`
- `vscode/src/views/SidebarWebviewProvider.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · [134b2d3] Fix ingest progress pill never rendering while user stays on branch view</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the lock split, the "Building knowledge wiki/graph…" pill in the VS Code sidebar silently failed to appear or clear when the user was already viewing the branch tab — the primary context where the new concurrent ingest display matters.

**💡 Decisions Behind the Code**

A three-agent adversarial review identified this as a clear-cut bug rather than a debatable style issue. The masking effect of the tab-switch path made the failure easy to miss in manual testing, so the review process was the primary mechanism that surfaced it.

**✅ What Was Implemented**

The `ingest:phase` message handler in `vscode/src/views/SidebarScriptBuilder.ts` was corrected to call the branch rendering function rather than the toolbar-only function. The toolbar call was a no-op on the branch tab and never reached the function responsible for painting the pill. The pill would appear correctly if the user switched tabs mid-ingest (the tab-switch path independently triggers a branch render), which masked the failure in casual testing while leaving it broken for anyone already on the branch tab when ingest started.

**📁 FILES**
- `vscode/src/views/SidebarScriptBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · [134b2d3] Remove dead ingest lock helper and rename ambiguous internal type</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

An adversarial review found a newly added helper function with zero callers and documentation that incorrectly described a consumer that did not exist. A separately named internal type also collided with a different type in another part of the codebase, creating a maintenance trap.

**💡 Decisions Behind the Code**

The VS Code side independently implements its own freshness check using local file stat calls rather than importing the CLI helper, matching the existing pattern for the worker lock. Keeping the dead export would have left misleading documentation claiming a consumer that never existed, and the type rename eliminates a future confusion point where two identically named types in separate packages hold different values.

**✅ What Was Implemented**

The unused `isIngestLockHeld` export was deleted from `cli/src/core/Locks.ts`. The CLI-local `IngestPhase` type was renamed to `IngestSubPhase` in `cli/src/hooks/QueueWorker.ts` to distinguish it from the VS Code-side type of the same name, which uses a different value space.

**📁 FILES**
- `cli/src/core/Locks.ts`
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 7, 2026 at 9:34 AM · via Anthropic*
<!-- jollimemory-summary-end -->