### PR TITLE
Fix token-meter bars: exact widths, unified palette, stale-bar reset

### DIFF
--- a/vscode/src/views/NextMemoryCssBuilder.test.ts
+++ b/vscode/src/views/NextMemoryCssBuilder.test.ts
@@ -102,13 +102,14 @@ describe("buildNextMemoryCss", () => {
 		expect(css).toContain(".cc-note");
 	});
 
-	it("defines bucketed segment width classes for the CSP-safe token bar", () => {
+	it("styles token-bar segments without bucketed width classes (exact widths set via JS property)", () => {
 		const css = buildNextMemoryCss();
-		// Mirrors the sidebar's token-seg--wN pattern; the script emits seg--wNN
-		// (floored to 10%) so widths never need an inline style.
-		expect(css).toContain(".seg--w0 { width: 0%; }");
-		expect(css).toContain(".seg--w40 { width: 40%; }");
-		expect(css).toContain(".seg--w100 { width: 100%; }");
+		// Segment colors are defined; widths are set as exact percentages by the
+		// script (el.style.width), so no .seg--wN bucket classes exist anymore.
+		expect(css).toContain(".seg-in { background: var(--vscode-charts-green); }");
+		expect(css).toContain(".seg-cache");
+		expect(css).not.toContain(".seg--w");
+		expect(css).not.toContain(".seg--present");
 	});
 
 	it("styles the anchored add-context dropdown (matching the sidebar menu)", () => {

--- a/vscode/src/views/NextMemoryCssBuilder.ts
+++ b/vscode/src/views/NextMemoryCssBuilder.ts
@@ -6,15 +6,13 @@
  * `#pane-working`. Uses the same VS Code theme CSS variables as the other
  * webviews (SummaryCssBuilder / SidebarCssBuilder) for light/dark parity.
  *
- * Token-meter segment widths use bucketed `.seg--wN` classes (N = 0..100 step
- * 10) rather than an inline `style="width"` — the webview CSP has no
- * `unsafe-inline` for styles. This mirrors the sidebar's own token bar
- * (`token-seg--wN`); the output segment takes the flex remainder.
+ * Token-meter segment widths are set as exact percentages via a JS property
+ * write (el.style.width) in NextMemoryScriptBuilder — the webview CSP forbids an
+ * inline `style="width"` attribute but allows the property write. This mirrors
+ * the memory-detail bar (SummaryHtmlBuilder buildTokenMeter); all three token
+ * bars now share the same exact-width, no-bucket approach.
  */
 export function buildNextMemoryCss(): string {
-	const widthBuckets = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
-		.map((n) => `.seg--w${n} { width: ${n}%; }`)
-		.join("\n");
 	return [
 		// Design tokens shared with the committed-memory panel (SummaryCssBuilder):
 		// subtle pill/chip surfaces + status hues that VS Code doesn't expose as
@@ -125,11 +123,15 @@ export function buildNextMemoryCss(): string {
 		".tmeter-head { font-size: 12px; margin-bottom: 4px; }",
 		".tmeter-total { font-weight: 600; }",
 		".tmeter-sub { color: var(--vscode-descriptionForeground); }",
-		".tmeter-bar { display: flex; height: 6px; border-radius: 3px; overflow: hidden; background: var(--vscode-widget-border); }",
+		// Palette + track background mirror the sidebar's Committed Memories bar
+		// (SidebarCssBuilder .token-seg--*): input=green, output=blue, cached=gray.
+		".tmeter-bar { display: flex; height: 6px; border-radius: 3px; overflow: hidden; background: var(--vscode-input-background); }",
+		// Exact widths are set as a JS property (el.style.width) by the script —
+		// CSP forbids an inline style attribute but allows the property write — so
+		// no bucketed width classes are needed and sub-10% segments stay visible.
 		".seg-in { background: var(--vscode-charts-green); }",
-		".seg-out { background: var(--vscode-charts-blue); flex: 1; }",
-		".seg-cache { background: var(--vscode-charts-gray); }",
-		widthBuckets,
+		".seg-out { background: var(--vscode-charts-blue); }",
+		".seg-cache { background: var(--vscode-descriptionForeground); opacity: 0.5; }",
 		".tmeter-legend { display: flex; gap: 12px; font-size: 11px; color: var(--vscode-descriptionForeground); margin-top: 4px; }",
 		".lg-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; margin-right: 3px; }",
 		".privacy-note { font-size: 11.5px; display: flex; gap: 6px; color: var(--vscode-descriptionForeground); margin: 10px 0; }",

--- a/vscode/src/views/NextMemoryScriptBuilder.test.ts
+++ b/vscode/src/views/NextMemoryScriptBuilder.test.ts
@@ -46,9 +46,13 @@ describe("buildNextMemoryScript", () => {
 		expect(js).toContain("'gs gs-' + item.gitStatus");
 	});
 
-	it("emits CSP-safe bucketed segment width classes for the token bar (no inline style)", () => {
+	it("sets exact token-bar segment widths via the style property, not an inline style attribute (CSP-safe)", () => {
 		const js = buildNextMemoryScript();
-		expect(js).toContain("seg-in seg--w");
+		// Widths are exact percentages set as a JS property write (allowed under
+		// CSP), replacing the old 10%-bucket width classes (which hid sub-10%
+		// segments). No inline style="…" attribute is ever emitted.
+		expect(js).toContain("s.style.width = pct + '%'");
+		expect(js).not.toContain("seg--w");
 		expect(js).not.toContain("style=");
 	});
 

--- a/vscode/src/views/NextMemoryScriptBuilder.ts
+++ b/vscode/src/views/NextMemoryScriptBuilder.ts
@@ -13,9 +13,11 @@
  * so toggling a row here and toggling the same row in the sidebar always
  * agree — there is no second, panel-only selection state.
  *
- * Token-meter segment widths use bucketed 'seg--wNN' classes (floored to
- * 10%), matching NextMemoryCssBuilder and the sidebar's own renderTokenBar —
- * the webview CSP forbids inline 'style="width"'.
+ * Token-meter segment widths are exact percentages set via a JS property write
+ * (el.style.width) — the webview CSP forbids an inline style attribute but allows
+ * the property write. Matches the memory-detail bar (SummaryHtmlBuilder
+ * buildTokenMeter) and the sidebar's renderTokenBar; all three share this
+ * exact-width, no-bucket approach so sub-10% segments never disappear.
  */
 export function buildNextMemoryScript(): string {
 	return `
@@ -464,13 +466,15 @@ export function buildNextMemoryScript(): string {
     mount('title-panel', el('div', { className: 'panel env-panel-body' }, kids));
   }
 
-  // Floor a token count to a 10%-of-total bucket, for the CSP-safe seg--wNN
-  // width class (an arbitrary 0-100 percent can't be expressed without an
-  // inline style; buckets match NextMemoryCssBuilder + the sidebar bar).
-  function segBucket(n, total) {
-    if (!total) return 0;
-    const p = Math.floor((n / total) * 100 / 10) * 10;
-    return p < 0 ? 0 : (p > 100 ? 100 : p);
+  // Build one bar segment at an EXACT width. The webview CSP does not exempt
+  // inline styles, so we can't emit an inline style attribute — but a JS property
+  // write (el.style.width) is allowed, so we set it here. Mirrors the
+  // memory-detail bar (SummaryHtmlBuilder buildTokenMeter): exact percentages, no
+  // 10%-bucket rounding, so sub-10% segments stay visible.
+  function seg(cls, pct) {
+    const s = el('span', { className: cls });
+    s.style.width = pct + '%';
+    return s;
   }
 
   function renderTokenMeter(msg) {
@@ -478,19 +482,29 @@ export function buildNextMemoryScript(): string {
       mount('token-meter', el('div', { className: 'muted', text: msg.totalCount > 0 ? 'Token usage not reported for this selection.' : '' }));
       return;
     }
-    const inputW = segBucket(msg.input, msg.total);
-    // Cap cached so input + cached stays <= 90%, leaving the flex output
-    // segment room (same guard the sidebar's renderTokenBar uses).
-    let cachedW = segBucket(msg.cached, msg.total);
-    if (cachedW > 90 - inputW) cachedW = 90 - inputW;
-    if (cachedW < 0) cachedW = 0;
+    // Denominator is the breakdown sum (NOT msg.total, which can exceed it when
+    // sessions report a scalar count with no per-segment usage), so the three
+    // segments fill the bar exactly. wCache absorbs the rounding remainder so
+    // the widths always sum to 100. Segment order matches the legend: in·out·cache.
+    const segTotal = (msg.input || 0) + (msg.output || 0) + (msg.cached || 0);
+    let bar;
+    if (segTotal > 0) {
+      const wIn = Math.round((msg.input / segTotal) * 100);
+      const wOut = Math.round((msg.output / segTotal) * 100);
+      const wCache = Math.max(0, 100 - wIn - wOut);
+      bar = el('div', { className: 'tmeter-bar' }, [
+        seg('seg-in', wIn),
+        seg('seg-out', wOut),
+        seg('seg-cache', wCache),
+      ]);
+    } else {
+      // Total-only degrade: a total with no breakdown fills the bar with a single
+      // input segment rather than fabricating a split we don't have.
+      bar = el('div', { className: 'tmeter-bar' }, [seg('seg-in', 100)]);
+    }
     mount('token-meter', el('div', { className: 'tmeter' }, [
       el('div', { className: 'tmeter-head' }, [el('span', { className: 'tmeter-total', text: formatTokens(msg.total) + ' tokens' }), el('span', { className: 'tmeter-sub', text: ' · captured by this memory' })]),
-      el('div', { className: 'tmeter-bar' }, [
-        el('span', { className: 'seg-in seg--w' + inputW }),
-        el('span', { className: 'seg-cache seg--w' + cachedW }),
-        el('span', { className: 'seg-out' }),
-      ]),
+      bar,
       el('div', { className: 'tmeter-legend' }, [
         el('span', {}, [el('i', { className: 'lg-dot seg-in' }), formatTokens(msg.input) + ' input']),
         el('span', {}, [el('i', { className: 'lg-dot seg-out' }), formatTokens(msg.output) + ' output']),

--- a/vscode/src/views/SidebarCssBuilder.test.ts
+++ b/vscode/src/views/SidebarCssBuilder.test.ts
@@ -659,9 +659,12 @@ describe("onboarding panel styles", () => {
 		const css = buildSidebarCss();
 		expect(css).toContain(".token-bar");
 		expect(css).toContain(".token-seg--input");
-		expect(css).toContain(".token-seg--w");
 		// cached segment + legend swatch, plus the "?" help affordance row.
 		expect(css).toContain(".token-seg--cached");
+		// Widths are exact percentages set via el.style.width (CSP-safe property
+		// write), so no bucketed width classes exist anymore.
+		expect(css).not.toContain(".token-seg--w");
+		expect(css).not.toContain(".token-seg--present");
 		expect(css).toContain(".tk-leg--cached::before");
 		expect(css).toContain(".token-bar-help");
 		expect(css).toContain(".token-bar-label-row");

--- a/vscode/src/views/SidebarCssBuilder.ts
+++ b/vscode/src/views/SidebarCssBuilder.ts
@@ -1946,8 +1946,10 @@ export function buildSidebarCss(): string {
      .token-bar       horizontal pill bar (input=green / output=blue)
      .token-seg       one colored segment inside the bar
      .token-bar-legend two-item row: "<n> input  <n> output"
-     Width classes .token-seg--wN (N = 0..100 step 10) set the INPUT segment
-     width; the OUTPUT segment (no width class) fills the remainder via flex. */
+     Segment widths are exact percentages set as a JS property (el.style.width)
+     by renderTokenBar — CSP forbids an inline style attribute but allows the
+     property write — so there are no bucketed width classes. Mirrors the
+     memory-detail bar (SummaryHtmlBuilder buildTokenMeter). */
   .token-bar-wrap { padding: 4px 12px 8px; }
   /* Label line + trailing "?" help affordance share one row so the icon hugs
      the right edge (margin-left:auto) without an inline style. */
@@ -1961,23 +1963,10 @@ export function buildSidebarCss(): string {
   .token-seg--input { background: var(--vscode-charts-green, #4ec9b0); }
   /* Cached sits between input and output as a neutral gray segment. */
   .token-seg--cached { background: var(--vscode-descriptionForeground); opacity: 0.5; }
-  .token-seg--output { background: var(--vscode-charts-blue, #4fc1ff); flex: 1 1 auto; }
+  .token-seg--output { background: var(--vscode-charts-blue, #4fc1ff); }
   .token-bar-legend { display: flex; gap: 12px; margin-top: 4px; font-size: 0.8em; color: var(--vscode-descriptionForeground); }
   .tk-leg--input::before { content: ''; display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: var(--vscode-charts-green, #4ec9b0); margin-right: 4px; vertical-align: middle; }
   .tk-leg--output::before { content: ''; display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: var(--vscode-charts-blue, #4fc1ff); margin-right: 4px; vertical-align: middle; }
   .tk-leg--cached::before { content: ''; display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: var(--vscode-descriptionForeground); opacity: 0.5; margin-right: 4px; vertical-align: middle; }
-  /* Bucketed input-segment width classes (0..100 in steps of 10).
-     The input segment gets one of these; output fills the rest via flex:1 1 auto. */
-  .token-seg--w0   { width: 0%; }
-  .token-seg--w10  { width: 10%; }
-  .token-seg--w20  { width: 20%; }
-  .token-seg--w30  { width: 30%; }
-  .token-seg--w40  { width: 40%; }
-  .token-seg--w50  { width: 50%; }
-  .token-seg--w60  { width: 60%; }
-  .token-seg--w70  { width: 70%; }
-  .token-seg--w80  { width: 80%; }
-  .token-seg--w90  { width: 90%; }
-  .token-seg--w100 { width: 100%; }
   `;
 }

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -3055,8 +3055,8 @@ describe("SidebarScriptBuilder", () => {
 		expect(js).toContain("' \xB7 this branch'");
 		// degrades to hidden when no stats received
 		expect(js).toContain("state.tokenStats");
-		// bucketed CSS width class (not inline style)
-		expect(js).toContain("token-seg--w");
+		// exact segment width via CSP-safe property write (not a bucket class)
+		expect(js).toContain("s.style.width = pct + '%'");
 		// cached is the third segment + legend item, gated on cached > 0.
 		expect(js).toContain("token-seg--cached");
 		expect(js).toContain("' cached'");
@@ -3222,50 +3222,47 @@ describe("SidebarScriptBuilder", () => {
 			expect(js).toContain("delete state.subsectionShowAll[s.id];");
 		});
 
-		it("S4: token bar floors buckets and clamps cached so input+cached never crowds out output", () => {
+		it("S4: token bar sets exact segment widths via the style property (no bucket classes)", () => {
 			const js = buildSidebarScript();
 			const fn = js.slice(
 				js.indexOf("function renderTokenBar"),
 				js.indexOf("function renderBranch"),
 			);
-			// Floor, not round — round-up on both segments could push the sum past 100.
-			expect(fn).toContain("Math.floor((n / stats.total) * 100 / 10) * 10");
-			// Cached is clamped to leave at least one 10% slot for the output segment.
-			expect(fn).toContain("Math.min(bucket(cached), 90 - inputW)");
-			// Negative clamp guard.
-			expect(fn).toContain("if (cachedW < 0) cachedW = 0;");
+			// Exact percentages against the breakdown sum, set as a CSP-safe property
+			// write — the 10%-bucket math is gone (it hid sub-10% segments).
+			expect(fn).toContain("s.style.width = pct + '%'");
+			expect(fn).toContain("var segTotal = stats.input + stats.output + cached;");
+			expect(fn).toContain("var wCache = Math.max(0, 100 - wIn - wOut);");
+			expect(fn).not.toContain("token-seg--w");
+			expect(fn).not.toContain("Math.floor");
 		});
 
-		// Pure-function repro for the S4 overflow: simulate the bucket+clamp math the
-		// way the webview computes it and assert the fixed widths can never sum to
-		// >= 100% (which would collapse the flex output segment / overflow the bar).
-		it("S4 repro: input% + cached% bucket+clamp stays <= 90 for adversarial splits", () => {
-			function bucket(n: number, total: number): number {
-				const pct = Math.floor((n / total) * 100 / 10) * 10;
-				return pct < 0 ? 0 : pct > 100 ? 100 : pct;
+		// Pure-function repro of the new exact-width math: the three segments must
+		// always sum to EXACTLY 100 (wCache absorbs the rounding remainder) so the
+		// bar fills without overflow or a gap, for any input/output/cached split.
+		it("S4 repro: exact segment widths always sum to 100 for adversarial splits", () => {
+			function widths(input: number, output: number, cached: number): [number, number, number] {
+				const segTotal = input + output + cached;
+				const wIn = Math.round((input / segTotal) * 100);
+				const wOut = Math.round((output / segTotal) * 100);
+				const wCache = Math.max(0, 100 - wIn - wOut);
+				return [wIn, wOut, wCache];
 			}
-			function widths(input: number, cached: number, total: number): [number, number] {
-				const inputW = bucket(input, total);
-				let cachedW = Math.min(bucket(cached, total), 90 - inputW);
-				if (cachedW < 0) cachedW = 0;
-				return [inputW, cachedW];
-			}
-			// The classic failing case: both segments ~46-49% → old round() gave 50+50=100,
-			// crushing output. floor+clamp keeps room.
 			const cases: Array<[number, number, number]> = [
-				[46, 46, 100],
-				[49, 49, 100],
-				[48, 48, 100],
-				[90, 9, 100],
-				[55, 44, 100],
-				[1, 99, 100],
+				[46, 46, 8],
+				[1, 1, 98],
+				[33, 33, 34],
+				[210, 717, 2600],
+				[1, 999, 0],
+				[0, 0, 5],
 			];
-			for (const [input, cached, total] of cases) {
-				const [iw, cw] = widths(input, cached, total);
-				expect(iw + cw).toBeLessThanOrEqual(90);
-				// Output (flex remainder) always has at least 10% of room.
-				expect(100 - (iw + cw)).toBeGreaterThanOrEqual(10);
+			for (const [input, output, cached] of cases) {
+				const [iw, ow, cw] = widths(input, output, cached);
+				expect(iw + ow + cw).toBe(100);
 			}
+			// The reported bug: input 210k of a 3.527M breakdown (~6%) was floored to
+			// 0% by the old 10% bucket and vanished. Exact rounding keeps it visible.
+			expect(widths(210, 717, 2600)[0]).toBe(6);
 		});
 
 		it("S6: kb:memoryEvidence updates one row in place and only full-renders on miss", () => {

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -3566,32 +3566,38 @@ export function buildSidebarScript(): string {
 
   // Builds the horizontal token-usage bar shown at the top of Committed
   // Memories (non-foreign). Returns null when stats are absent or total is 0.
-  // Uses bucketed CSS width classes on the input segment (no inline style).
   function renderTokenBar(stats) {
     if (!stats || !stats.total) return null;
     var cached = stats.cached || 0;
-    // Bucket input + cached to a 10% width class (no inline style — CSP). Output
-    // fills the remainder via flex. The two bucketed widths are FIXED-width
-    // classes, so their sum must stay strictly below 100% or the output segment
-    // (flex remainder) collapses to 0 and the bar can overflow. We FLOOR each to
-    // the nearest 10% (round-up on both could push the sum past 100 even when the
-    // real values sum below it) and clamp the cached segment to whatever width is
-    // left under 100% minus the input segment, guaranteeing output always has room.
-    function bucket(n) {
-      var pct = Math.floor((n / stats.total) * 100 / 10) * 10;
-      return pct < 0 ? 0 : (pct > 100 ? 100 : pct);
+    // Segment widths are EXACT percentages set via a JS property write
+    // (el.style.width) — CSP forbids an inline style="…" attribute but allows the
+    // property write. Denominator is the breakdown sum (NOT stats.total, which can
+    // exceed it when memories report a scalar count with no per-segment usage), so
+    // the three segments fill the bar exactly; wCache absorbs the rounding
+    // remainder. Order matches the legend: input · output · cached. Mirrors the
+    // memory-detail bar (SummaryHtmlBuilder buildTokenMeter) — all three token
+    // bars now share this exact-width, no-bucket approach.
+    function seg(cls, pct) {
+      var s = el('span', { className: cls });
+      s.style.width = pct + '%';
+      return s;
     }
-    var inputW = bucket(stats.input);
-    var segs = [
-      el('span', { className: 'token-seg token-seg--input token-seg--w' + inputW }),
-    ];
-    if (cached > 0) {
-      // Leave at least one 10% slot for output: cap the input + cached sum at 90%.
-      var cachedW = Math.min(bucket(cached), 90 - inputW);
-      if (cachedW < 0) cachedW = 0;
-      segs.push(el('span', { className: 'token-seg token-seg--cached token-seg--w' + cachedW }));
+    var segTotal = stats.input + stats.output + cached;
+    var segs;
+    if (segTotal > 0) {
+      var wIn = Math.round((stats.input / segTotal) * 100);
+      var wOut = Math.round((stats.output / segTotal) * 100);
+      var wCache = Math.max(0, 100 - wIn - wOut);
+      segs = [
+        seg('token-seg token-seg--input', wIn),
+        seg('token-seg token-seg--output', wOut),
+        seg('token-seg token-seg--cached', wCache),
+      ];
+    } else {
+      // Total-only floor: a branch total with no per-segment breakdown fills the
+      // bar with a single input segment rather than fabricating a split.
+      segs = [seg('token-seg token-seg--input', 100)];
     }
-    segs.push(el('span', { className: 'token-seg token-seg--output' }));
     var bar = el('div', { className: 'token-bar' }, segs);
     // 'total' is the scalar floor (includes legacy memories that carry
     // conversationTokens but no per-segment breakdown); the segments/cost derive

--- a/vscode/src/views/SidebarWebviewProvider.edgePaths.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.edgePaths.test.ts
@@ -408,11 +408,12 @@ describe("SidebarWebviewProvider edge paths", () => {
 			});
 		});
 
-		it("posts no token stats when the aggregate is zero (token bar stays hidden)", async () => {
+		it("posts a zero-total token stats message so an empty branch clears any stale bar", async () => {
 			const getBranchTokenStats = vi.fn().mockResolvedValue({
 				input: 0,
 				output: 0,
 				cached: 0,
+				total: 0,
 				reporting: 0,
 				memories: 0,
 			});
@@ -429,9 +430,13 @@ describe("SidebarWebviewProvider edge paths", () => {
 			await new Promise((r) => setTimeout(r, 0));
 			await new Promise((r) => setTimeout(r, 0));
 			expect(getBranchTokenStats).toHaveBeenCalled();
-			// …but a zero aggregate must not paint an empty token bar.
+			// …and a zero aggregate MUST still be posted (total 0) — the webview
+			// hides the bar itself, but only if it receives the reset. Withholding
+			// the message strands the previous branch's bar on the empty branch.
 			const all = view.webview.postMessage.mock.calls.map((c) => c[0] as SidebarInboundMsg);
-			expect(findMsg(all, "branch:tokenStats")).toBeUndefined();
+			const msg = findMsg(all, "branch:tokenStats") as { total?: number } | undefined;
+			expect(msg).toBeDefined();
+			expect(msg?.total).toBe(0);
 		});
 
 		it("degrades silently when getBranchTokenStats rejects", async () => {

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -376,8 +376,11 @@ export interface SidebarWebviewDeps {
 	 * Returns aggregated LLM token counts across all committed summaries on
 	 * the current branch. Called alongside `pushCommits` so the token bar
 	 * renders immediately when commits data arrives. Optional: when absent,
-	 * no `branch:tokenStats` message is posted and the token bar stays hidden.
-	 * Must never reject — caller uses `.catch(() => undefined)`.
+	 * no `branch:tokenStats` message is posted (the bar keeps whatever it last
+	 * showed). When present, a message is posted on every refresh — INCLUDING a
+	 * zero-total result — so a switch to an empty branch clears any prior bar
+	 * instead of stranding a stale one. Must never reject — caller uses
+	 * `.catch(() => undefined)`.
 	 */
 	getBranchTokenStats?: () => Promise<{
 		input: number;
@@ -1899,19 +1902,23 @@ export class SidebarWebviewProvider
 					// NOT input+output+cached: a branch with legacy roots that carry the
 					// scalar but no breakdown would otherwise read as LESS than the sum of
 					// its own rows. The coloured segments stay a floor of what's attributable.
-					const total = stats.total;
-					if (total > 0) {
-						this.postMessage({
-							type: "branch:tokenStats",
-							input: stats.input,
-							output: stats.output,
-							cached: stats.cached,
-							total,
-							reporting: stats.reporting,
-							memories: stats.memories,
-							scope: "branch",
-						});
-					}
+					// Post unconditionally, INCLUDING total === 0. Skipping the
+					// zero-total case leaves the webview's last `state.tokenStats`
+					// intact — so switching to a fresh/empty branch would keep the
+					// PREVIOUS branch's token bar on screen (a stale 300M+ bar above
+					// the "Start coding" empty state). The webview hides the bar when
+					// total === 0 (renderTokenBar returns null), so posting zeros is
+					// the self-healing reset; withholding the message is the bug.
+					this.postMessage({
+						type: "branch:tokenStats",
+						input: stats.input,
+						output: stats.output,
+						cached: stats.cached,
+						total: stats.total,
+						reporting: stats.reporting,
+						memories: stats.memories,
+						scope: "branch",
+					});
 				})
 				.catch(() => undefined);
 		}

--- a/vscode/src/views/SummaryCssBuilder.ts
+++ b/vscode/src/views/SummaryCssBuilder.ts
@@ -1176,16 +1176,19 @@ export function buildCss(): string {
   .tmeter-cost { color: var(--text-tertiary); }
   .tmeter-bar {
     display: flex; width: 100%; height: 6px; border-radius: 3px;
-    overflow: hidden; margin-top: 8px; background: var(--panel-inner);
+    overflow: hidden; margin-top: 8px; background: var(--vscode-input-background);
   }
   .tmeter-bar .seg-in,
   .tmeter-bar .seg-out,
   .tmeter-bar .seg-cache {
     height: 100%; width: 0; transition: width 0.2s ease;
   }
-  .seg-in { background: var(--vscode-charts-green, #4ece8d); }
-  .seg-out { background: var(--vscode-charts-orange, #e0ac2b); }
-  .seg-cache { background: var(--vscode-charts-blue, #6b8299); opacity: 0.7; }
+  /* Palette + track background mirror the sidebar's Committed Memories bar
+     (SidebarCssBuilder .token-seg--*): input=green, output=blue, cached=gray.
+     The two token bars must read identically across surfaces. */
+  .seg-in { background: var(--vscode-charts-green, #4ec9b0); }
+  .seg-out { background: var(--vscode-charts-blue, #4fc1ff); }
+  .seg-cache { background: var(--vscode-descriptionForeground); opacity: 0.5; }
   .tmeter-legend {
     display: flex; flex-wrap: wrap; gap: 4px 14px; margin-top: 7px;
     font-size: 0.8em; color: var(--text-secondary);


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The token usage bars across the memory detail page, committed memories sidebar, and next-memory review now present a unified, accurate view of token consumption. All three bars use the same color scheme (green input, blue output, gray cached) and the same exact-width rendering approach, eliminating visual inconsistencies and ensuring that even small segments remain visible. The shift from 10%-bucketed widths to precise percentages fixed a critical visibility bug where a 6% input segment disappeared entirely. Additionally, switching to an empty branch now correctly clears any stale token bar from the previous branch, instead of leaving outdated usage statistics on screen above the "Start coding" empty state.

---

## Topic (1)
<details>
<summary><strong>01 · Token meter bars: unified palette, exact widths, and stale-bar reset across three surfaces</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The token usage bars across three surfaces (memory detail, committed memories sidebar, and next-memory review page) had inconsistent colors, used bucketed 10%-step widths that hid small segments, and left stale bars visible when switching to empty branches.

**💡 Decisions Behind the Code**

- **Exact widths over bucketed classes**: The 10%-bucket approach was a CSP workaround that hid real data (a 6% input segment disappeared entirely). JavaScript property writes (el.style.width) are CSP-safe and allow precise percentages, eliminating the need for bucketed classes while maintaining security.
- **Three-segment math with cache absorption**: Instead of using flex remainder for the output segment, all three segments now use exact percentages that sum to exactly 100 (the cache segment absorbs rounding remainder). This simplifies the layout, makes all three bars identical in structure, and removes the constraint that input+cached must stay under 90%.
- **Always-post zero-total stats**: Withholding the branch:tokenStats message when total is zero left the webview's state unchanged, stranding the previous branch's bar on an empty branch. Posting zero-total results lets the webview self-heal by hiding the bar, turning a stale-state bug into a clean reset.

**✅ What Was Implemented**

- Unified the color palette across all three token bars: input green, output blue, cached gray, with matching track backgrounds. Updated SummaryCssBuilder, SidebarCssBuilder, and NextMemoryCssBuilder to use the same VS Code theme variables.
- Migrated NextMemory and Sidebar bars from 10%-bucketed CSS width classes (seg--wN, token-seg--wN) to exact percentages set via JavaScript property writes (el.style.width). This CSP-safe approach mirrors the memory-detail bar and ensures segments smaller than 10% remain visible instead of collapsing to zero width.
- Fixed stale token bars on empty branches by ensuring the host always posts branch:tokenStats messages, including zero-total results. The webview now receives the reset signal and hides the bar when switching to a branch with no committed memories.

**📁 FILES**
- `vscode/src/views/SummaryCssBuilder.ts`
- `vscode/src/views/SidebarScriptBuilder.ts`
- `vscode/src/views/SidebarCssBuilder.ts`
- `vscode/src/views/SidebarWebviewProvider.ts`
- `vscode/src/views/NextMemoryScriptBuilder.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 7, 2026 at 3:53 PM · via Anthropic*
<!-- jollimemory-summary-end -->
