### PR TITLE
feat: show token count & cost in pushed memory articles

### DIFF
--- a/cli/src/core/SummaryMarkdownBuilder.test.ts
+++ b/cli/src/core/SummaryMarkdownBuilder.test.ts
@@ -62,6 +62,42 @@ describe("buildMarkdown", () => {
 		expect(md).not.toContain("1 turns");
 	});
 
+	it("renders Task usage with cost and segment split when a breakdown is present", () => {
+		const md = buildMarkdown(
+			leaf({
+				conversationTokens: 3_000_000,
+				conversationTokenBreakdown: { input: 1_000_000, output: 1_000_000, cached: 1_000_000 },
+			}),
+		);
+		expect(md).toContain(
+			"**Task usage:** 3,000,000 tokens · $21.75 (1,000,000 input, 1,000,000 output, 1,000,000 cached)",
+		);
+	});
+
+	it("renders Task usage total + cost only when no breakdown is present", () => {
+		const md = buildMarkdown(leaf({ conversationTokens: 1_000_000 }));
+		expect(md).toContain("**Task usage:** 1,000,000 tokens · $3.00");
+		expect(md).not.toContain("input,");
+	});
+
+	it("omits Task usage entirely when there are no conversation tokens", () => {
+		const md = buildMarkdown(leaf());
+		expect(md).not.toContain("Task usage");
+	});
+
+	it("aggregates Task usage across the consolidation tree, not the root scalar", () => {
+		const md = buildMarkdown(
+			leaf({
+				conversationTokens: 0,
+				children: [
+					leaf({ commitHash: "child1", conversationTokens: 2_000_000 }),
+					leaf({ commitHash: "child2", conversationTokens: 1_000_000 }),
+				],
+			}),
+		);
+		expect(md).toContain("**Task usage:** 3,000,000 tokens");
+	});
+
 	it("renders Jolli Memory URL when present", () => {
 		const md = buildMarkdown(leaf({ jolliDocUrl: "https://acme.jolli.app/articles?doc=42" }));
 		expect(md).toContain("**Jolli Memory:**");

--- a/cli/src/core/SummaryMarkdownBuilder.ts
+++ b/cli/src/core/SummaryMarkdownBuilder.ts
@@ -17,7 +17,14 @@ import {
 	padIndex,
 	type TopicWithDate,
 } from "./SummaryFormat.js";
-import { aggregateTurns, formatDurationLabel, resolveDiffStats } from "./SummaryTree.js";
+import {
+	aggregateConversationTokenBreakdown,
+	aggregateConversationTokens,
+	aggregateTurns,
+	formatDurationLabel,
+	resolveDiffStats,
+} from "./SummaryTree.js";
+import { estimateConversationCostUsd, formatExactCostUsd, formatTokensExact } from "./TokenCost.js";
 
 /**
  * Builds a Markdown string from a CommitSummary for clipboard export.
@@ -68,6 +75,23 @@ export function pushPropertiesSection(lines: Array<string>, summary: CommitSumma
 
 	if (totalTurns > 0) {
 		lines.push(`- **Conversations:** ${totalTurns} turn${totalTurns !== 1 ? "s" : ""}`);
+	}
+
+	// Task usage: token total + cache-aware cost estimate, aggregated across the
+	// whole consolidation tree (a squash/amend memory carries its tokens on folded
+	// children). Three states mirror the VS Code token meter; omit-when-zero matches
+	// the Conversations line above (no "not reported" state in a property list).
+	// The article shows EXACT figures (thousands-separated counts, precise $) rather
+	// than the compact form the space-constrained UI token bar uses.
+	const totalTokens = aggregateConversationTokens(summary);
+	if (totalTokens > 0) {
+		const agg = aggregateConversationTokenBreakdown(summary);
+		const b = agg.input > 0 || agg.output > 0 || agg.cached > 0 ? agg : undefined;
+		const cost = formatExactCostUsd(estimateConversationCostUsd(b, totalTokens));
+		const split = b
+			? ` (${formatTokensExact(b.input)} input, ${formatTokensExact(b.output)} output, ${formatTokensExact(b.cached)} cached)`
+			: "";
+		lines.push(`- **Task usage:** ${formatTokensExact(totalTokens)} tokens · ${cost}${split}`);
 	}
 
 	const memoryDocUrl = summary.jolliDocUrl;

--- a/cli/src/core/SummaryPrMarkdownBuilder.test.ts
+++ b/cli/src/core/SummaryPrMarkdownBuilder.test.ts
@@ -13,6 +13,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
 	aggregateStats: vi.fn(),
 	aggregateTurns: vi.fn(),
+	aggregateConversationTokens: vi.fn(),
+	aggregateConversationTokenBreakdown: vi.fn(),
 	formatDurationLabel: vi.fn(),
 	resolveDiffStats: vi.fn(),
 	collectSortedTopics: vi.fn(),
@@ -26,6 +28,8 @@ const mocks = vi.hoisted(() => ({
 vi.mock("./SummaryTree.js", () => ({
 	aggregateStats: mocks.aggregateStats,
 	aggregateTurns: mocks.aggregateTurns,
+	aggregateConversationTokens: mocks.aggregateConversationTokens,
+	aggregateConversationTokenBreakdown: mocks.aggregateConversationTokenBreakdown,
 	formatDurationLabel: mocks.formatDurationLabel,
 	resolveDiffStats: mocks.resolveDiffStats,
 }));
@@ -101,6 +105,10 @@ function setupDefaults(
 		return { filesChanged: 0, insertions: 0, deletions: 0 };
 	});
 	mocks.aggregateTurns.mockReturnValue(5);
+	// Default to no task-token usage so the Task usage line is omitted, keeping
+	// these PR/clipboard-markdown regression assertions focused on their own concerns.
+	mocks.aggregateConversationTokens.mockReturnValue(0);
+	mocks.aggregateConversationTokenBreakdown.mockReturnValue({ input: 0, output: 0, cached: 0 });
 	mocks.formatDurationLabel.mockReturnValue("1 day (1 commit)");
 	mocks.formatFullDate.mockReturnValue("March 30, 2026 at 10:00 AM");
 	mocks.formatDate.mockReturnValue("Mar 30, 2026");

--- a/cli/src/core/TokenCost.test.ts
+++ b/cli/src/core/TokenCost.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+	estimateConversationCostUsd,
+	formatExactCostUsd,
+	formatSonnetCostEstimate,
+	formatTokensCompact,
+	formatTokensExact,
+	SONNET_CACHE_WRITE_PER_TOKEN,
+	SONNET_INPUT_PER_TOKEN,
+	SONNET_OUTPUT_PER_TOKEN,
+} from "./TokenCost.js";
+
+describe("formatTokensCompact", () => {
+	it("renders raw counts under 1000", () => {
+		expect(formatTokensCompact(500)).toBe("500");
+		expect(formatTokensCompact(0)).toBe("0");
+	});
+	it("renders k for thousands", () => {
+		expect(formatTokensCompact(1_000)).toBe("1k");
+		expect(formatTokensCompact(5000)).toBe("5k");
+		expect(formatTokensCompact(96499)).toBe("96k");
+	});
+	it("renders M for millions", () => {
+		expect(formatTokensCompact(1443000)).toBe("1.4M");
+		expect(formatTokensCompact(2000000)).toBe("2M");
+	});
+	it("promotes the k→M boundary at 999_500", () => {
+		expect(formatTokensCompact(999_500)).toBe("1M");
+		expect(formatTokensCompact(999_499)).toBe("999k");
+	});
+});
+
+describe("formatSonnetCostEstimate", () => {
+	it("renders <$0.01 below one cent", () => {
+		expect(formatSonnetCostEstimate(0.001)).toBe("<$0.01");
+	});
+	it("renders ≈$ at and above one cent", () => {
+		expect(formatSonnetCostEstimate(0.01)).toBe("≈$0.01");
+		expect(formatSonnetCostEstimate(4.329)).toBe("≈$4.33");
+	});
+});
+
+describe("formatTokensExact", () => {
+	it("inserts thousands separators", () => {
+		expect(formatTokensExact(3_000_000)).toBe("3,000,000");
+		expect(formatTokensExact(1_200_000)).toBe("1,200,000");
+		expect(formatTokensExact(96_499)).toBe("96,499");
+	});
+	it("leaves counts under 1000 unseparated", () => {
+		expect(formatTokensExact(0)).toBe("0");
+		expect(formatTokensExact(999)).toBe("999");
+		expect(formatTokensExact(1_000)).toBe("1,000");
+	});
+});
+
+describe("formatExactCostUsd", () => {
+	it("renders two decimals at and above one cent", () => {
+		expect(formatExactCostUsd(21.75)).toBe("$21.75");
+		expect(formatExactCostUsd(0.01)).toBe("$0.01");
+		expect(formatExactCostUsd(4.329)).toBe("$4.33");
+	});
+	it("renders four decimals for a sub-cent value instead of $0.00", () => {
+		expect(formatExactCostUsd(0.0034)).toBe("$0.0034");
+		expect(formatExactCostUsd(0.001)).toBe("$0.0010");
+	});
+	it("floors a positive value too small for four decimals to <$0.0001 instead of $0.0000", () => {
+		expect(formatExactCostUsd(0.00003)).toBe("<$0.0001");
+		expect(formatExactCostUsd(0.0000001)).toBe("<$0.0001");
+		// The rounding boundary: 0.00005 rounds up to $0.0001, below it floors.
+		expect(formatExactCostUsd(0.00005)).toBe("$0.0001");
+	});
+	it("renders $0.00 for exactly zero", () => {
+		expect(formatExactCostUsd(0)).toBe("$0.00");
+	});
+});
+
+describe("estimateConversationCostUsd", () => {
+	it("prices each segment at its own rate when a breakdown is given", () => {
+		const cost = estimateConversationCostUsd({ input: 1_000_000, output: 1_000_000, cached: 1_000_000 }, 3_000_000);
+		expect(cost).toBeCloseTo(
+			SONNET_INPUT_PER_TOKEN * 1e6 + SONNET_OUTPUT_PER_TOKEN * 1e6 + SONNET_CACHE_WRITE_PER_TOKEN * 1e6,
+			6,
+		);
+		expect(cost).toBeCloseTo(3 + 15 + 3.75, 6);
+	});
+	it("falls back to the input rate on the total when no breakdown", () => {
+		expect(estimateConversationCostUsd(undefined, 1_000_000)).toBeCloseTo(3, 6);
+	});
+});

--- a/cli/src/core/TokenCost.ts
+++ b/cli/src/core/TokenCost.ts
@@ -1,0 +1,85 @@
+/**
+ * TokenCost
+ *
+ * Single source of truth for conversation token/cost formatting, shared by the
+ * CLI Markdown builder (pushed Space article + clipboard export) and the VS Code
+ * token meter / sidebar token bar (which re-export these via SummaryUtils). The
+ * two surfaces must never disagree on the same underlying token counts, so the
+ * constants and formatters live here rather than in the VS Code layer.
+ */
+
+import type { ConversationTokenBreakdown } from "../Types.js";
+
+/** Formats a token count compactly (e.g. `1443000` -> `1.4M`, `2000000` -> `2M`, `96000` -> `96k`). */
+export function formatTokensCompact(n: number): string {
+	// 999_500 is the point at which `Math.round(n / 1_000)` would round up to
+	// 1000 — promote to the `M` form so a count like 999_800 renders `1M`, not
+	// the nonsensical `1000k`.
+	if (n >= 999_500) {
+		return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+	}
+	if (n >= 1_000) {
+		return `${Math.round(n / 1_000)}k`;
+	}
+	return String(n);
+}
+
+// Rough per-token $ constants at Sonnet pricing (per token, not per-million).
+// `cached` (= cache_creation) is priced at the cache-write rate, which is
+// pricier than a standard input token but cheaper than treating it as fresh
+// input twice over. This is a ballpark estimate, not a billing-accurate
+// figure — actual cost varies by model and by any cache-read savings not
+// represented here.
+export const SONNET_INPUT_PER_TOKEN = 3 / 1_000_000;
+export const SONNET_OUTPUT_PER_TOKEN = 15 / 1_000_000;
+export const SONNET_CACHE_WRITE_PER_TOKEN = 3.75 / 1_000_000;
+
+/** Formats a cache-aware $ estimate at Sonnet pricing as `"≈$X.XX"` / `"<$0.01"`. */
+export function formatSonnetCostEstimate(costUsd: number): string {
+	return costUsd >= 0.01 ? `≈$${costUsd.toFixed(2)}` : "<$0.01";
+}
+
+/**
+ * Formats an exact token count with thousands separators (e.g. `3000000` ->
+ * `"3,000,000"`). Used by the pushed-memory Markdown "Task usage" line, which
+ * shows precise figures rather than the compact `formatTokensCompact` form the
+ * space-constrained UI token bar uses.
+ */
+export function formatTokensExact(n: number): string {
+	return Math.round(n)
+		.toString()
+		.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+/**
+ * Formats an exact USD cost for the pushed-memory Markdown "Task usage" line:
+ * two decimals at or above a cent (`"$21.75"`), and four decimals for a sub-cent
+ * value (`"$0.0034"`) so a real small amount shows instead of a misleading
+ * `"$0.00"`. A positive value too small to survive four decimals (below
+ * `$0.00005`, which would itself round to `"$0.0000"`) renders as the floor
+ * `"<$0.0001"` — mirroring {@link formatSonnetCostEstimate}'s `"<$0.01"` — so a
+ * real cost never displays as an all-zeros figure. Unlike that function there is
+ * no `≈` prefix: the article surfaces the precise computed figure. The value is
+ * still a Sonnet-pricing estimate (see {@link estimateConversationCostUsd});
+ * precision here is about not rounding the number away, not billing accuracy.
+ */
+export function formatExactCostUsd(costUsd: number): string {
+	if (costUsd >= 0.01) return `$${costUsd.toFixed(2)}`;
+	if (costUsd >= 0.00005) return `$${costUsd.toFixed(4)}`;
+	if (costUsd > 0) return "<$0.0001";
+	return "$0.00";
+}
+
+/**
+ * Cache-aware cost estimate (USD) at Sonnet pricing. With a breakdown, each
+ * segment is priced at its own rate; without one, the total is priced at the
+ * input rate (a floor — we never fabricate a split we don't have). Pair with
+ * {@link formatSonnetCostEstimate} to render.
+ */
+export function estimateConversationCostUsd(breakdown: ConversationTokenBreakdown | undefined, total: number): number {
+	return breakdown
+		? breakdown.input * SONNET_INPUT_PER_TOKEN +
+				breakdown.output * SONNET_OUTPUT_PER_TOKEN +
+				breakdown.cached * SONNET_CACHE_WRITE_PER_TOKEN
+		: total * SONNET_INPUT_PER_TOKEN;
+}

--- a/docs/superpowers/plans/2026-07-07-push-memory-token-count-and-cost.md
+++ b/docs/superpowers/plans/2026-07-07-push-memory-token-count-and-cost.md
@@ -1,0 +1,370 @@
+# Push memory token count & cost Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `Task usage` line (token total · estimated cost · input/output/cached split) to the shared Markdown Properties section, so the pushed Jolli Space article and the clipboard export both show what the VS Code token meter shows.
+
+**Architecture:** Sink the token/cost formatting primitives from `vscode/src/views/SummaryUtils.ts` down into a new CLI core module `cli/src/core/TokenCost.ts` (single source of truth). VS Code re-exports them so its imports are unchanged. The CLI Markdown builder's `pushPropertiesSection` then appends the new line, aggregating tokens across the consolidation tree with the existing `SummaryTree` helpers.
+
+**Tech Stack:** TypeScript (ESM, Node 22.5+), Vitest, Biome. VS Code extension bundles `cli/src/**` at esbuild time — the `../../../cli/src/core/*.js` import paths resolve then.
+
+## Global Constraints
+
+- **DCO sign-off on every commit** — `git commit -s`. No `Co-Authored-By: Claude …` trailer or `🤖 Generated with …` footer.
+- **`npm run all` must pass before commit** (clean → build → lint → test). Run once at the end, not per task.
+- **CLI coverage floor:** 97% statements / 96% branches / 97% functions / 97% lines for code under `cli/src/`. New `TokenCost.ts` and the `pushPropertiesSection` addition must be covered.
+- **Biome:** tabs, 4-wide, 120 column limit. `noExplicitAny: error`, `noUnusedImports/Variables: error`. `biome check --error-on-warnings` — warnings fail.
+- **Cross-package imports in `vscode/src/**` are intentional** — `../../../cli/src/core/*.js` resolves at bundle time. Do not "clean up" into a package import.
+- **Token/cost constants must have one source of truth** — the two surfaces must never disagree on the same underlying counts.
+
+---
+
+### Task 1: Create `cli/src/core/TokenCost.ts`
+
+Move the token/cost primitives out of `vscode/src/views/SummaryUtils.ts` (lines 87–118) into a CLI core module, and add the pure cost-arithmetic core `estimateConversationCostUsd`.
+
+**Files:**
+- Create: `cli/src/core/TokenCost.ts`
+- Test: `cli/src/core/TokenCost.test.ts`
+
+**Interfaces:**
+- Consumes: `ConversationTokenBreakdown` from `cli/src/Types.ts` (`{ input: number; output: number; cached: number }`).
+- Produces:
+  - `SONNET_INPUT_PER_TOKEN`, `SONNET_OUTPUT_PER_TOKEN`, `SONNET_CACHE_WRITE_PER_TOKEN` — `number` constants.
+  - `formatTokensCompact(n: number): string`
+  - `formatSonnetCostEstimate(costUsd: number): string`
+  - `estimateConversationCostUsd(breakdown: ConversationTokenBreakdown | undefined, total: number): number`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cli/src/core/TokenCost.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import {
+	estimateConversationCostUsd,
+	formatSonnetCostEstimate,
+	formatTokensCompact,
+	SONNET_CACHE_WRITE_PER_TOKEN,
+	SONNET_INPUT_PER_TOKEN,
+	SONNET_OUTPUT_PER_TOKEN,
+} from "./TokenCost.js";
+
+describe("formatTokensCompact", () => {
+	it("renders raw counts under 1000", () => {
+		expect(formatTokensCompact(500)).toBe("500");
+		expect(formatTokensCompact(0)).toBe("0");
+	});
+	it("renders k for thousands", () => {
+		expect(formatTokensCompact(5000)).toBe("5k");
+		expect(formatTokensCompact(96499)).toBe("96k");
+	});
+	it("renders M for millions", () => {
+		expect(formatTokensCompact(1443000)).toBe("1.4M");
+		expect(formatTokensCompact(2000000)).toBe("2M");
+	});
+	it("promotes the k→M boundary at 999_500", () => {
+		expect(formatTokensCompact(999_500)).toBe("1M");
+		expect(formatTokensCompact(999_499)).toBe("999k");
+	});
+});
+
+describe("formatSonnetCostEstimate", () => {
+	it("renders <$0.01 below one cent", () => {
+		expect(formatSonnetCostEstimate(0.001)).toBe("<$0.01");
+	});
+	it("renders ≈$ at and above one cent", () => {
+		expect(formatSonnetCostEstimate(0.01)).toBe("≈$0.01");
+		expect(formatSonnetCostEstimate(4.329)).toBe("≈$4.33");
+	});
+});
+
+describe("estimateConversationCostUsd", () => {
+	it("prices each segment at its own rate when a breakdown is given", () => {
+		const cost = estimateConversationCostUsd({ input: 1_000_000, output: 1_000_000, cached: 1_000_000 }, 3_000_000);
+		expect(cost).toBeCloseTo(SONNET_INPUT_PER_TOKEN * 1e6 + SONNET_OUTPUT_PER_TOKEN * 1e6 + SONNET_CACHE_WRITE_PER_TOKEN * 1e6, 6);
+		expect(cost).toBeCloseTo(3 + 15 + 3.75, 6);
+	});
+	it("falls back to the input rate on the total when no breakdown", () => {
+		expect(estimateConversationCostUsd(undefined, 1_000_000)).toBeCloseTo(3, 6);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/TokenCost.test.ts`
+Expected: FAIL — cannot resolve `./TokenCost.js` (module not found).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `cli/src/core/TokenCost.ts`:
+
+```typescript
+/**
+ * TokenCost
+ *
+ * Single source of truth for conversation token/cost formatting, shared by the
+ * CLI Markdown builder (pushed Space article + clipboard export) and the VS Code
+ * token meter / sidebar token bar (which re-export these via SummaryUtils). The
+ * two surfaces must never disagree on the same underlying token counts, so the
+ * constants and formatters live here rather than in the VS Code layer.
+ */
+
+import type { ConversationTokenBreakdown } from "../Types.js";
+
+/** Formats a token count compactly (e.g. `1443000` -> `1.4M`, `2000000` -> `2M`, `96000` -> `96k`). */
+export function formatTokensCompact(n: number): string {
+	// 999_500 is the point at which `Math.round(n / 1_000)` would round up to
+	// 1000 — promote to the `M` form so a count like 999_800 renders `1M`, not
+	// the nonsensical `1000k`.
+	if (n >= 999_500) {
+		return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+	}
+	if (n >= 1_000) {
+		return `${Math.round(n / 1_000)}k`;
+	}
+	return String(n);
+}
+
+// Rough per-token $ constants at Sonnet pricing (per token, not per-million).
+// `cached` (= cache_creation) is priced at the cache-write rate, which is
+// pricier than a standard input token but cheaper than treating it as fresh
+// input twice over. This is a ballpark estimate, not a billing-accurate
+// figure — actual cost varies by model and by any cache-read savings not
+// represented here.
+export const SONNET_INPUT_PER_TOKEN = 3 / 1_000_000;
+export const SONNET_OUTPUT_PER_TOKEN = 15 / 1_000_000;
+export const SONNET_CACHE_WRITE_PER_TOKEN = 3.75 / 1_000_000;
+
+/** Formats a cache-aware $ estimate at Sonnet pricing as `"≈$X.XX"` / `"<$0.01"`. */
+export function formatSonnetCostEstimate(costUsd: number): string {
+	return costUsd >= 0.01 ? `≈$${costUsd.toFixed(2)}` : "<$0.01";
+}
+
+/**
+ * Cache-aware cost estimate (USD) at Sonnet pricing. With a breakdown, each
+ * segment is priced at its own rate; without one, the total is priced at the
+ * input rate (a floor — we never fabricate a split we don't have). Pair with
+ * {@link formatSonnetCostEstimate} to render.
+ */
+export function estimateConversationCostUsd(
+	breakdown: ConversationTokenBreakdown | undefined,
+	total: number,
+): number {
+	return breakdown
+		? breakdown.input * SONNET_INPUT_PER_TOKEN +
+				breakdown.output * SONNET_OUTPUT_PER_TOKEN +
+				breakdown.cached * SONNET_CACHE_WRITE_PER_TOKEN
+		: total * SONNET_INPUT_PER_TOKEN;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/TokenCost.test.ts`
+Expected: PASS — all cases green.
+
+(No commit yet — Task 2 removes the now-duplicated VS Code definitions in the same logical change. Commit at the end of Task 2.)
+
+---
+
+### Task 2: Re-point VS Code to the CLI primitives
+
+Delete the moved definitions from `SummaryUtils.ts`, re-export them from `TokenCost.js` so `SummaryHtmlBuilder.ts` / `SidebarScriptBuilder.ts` imports keep resolving, and delegate `SummaryHtmlBuilder.estimateCost` to the shared arithmetic so the cost formula exists in exactly one place.
+
+**Files:**
+- Modify: `vscode/src/views/SummaryUtils.ts` (delete lines 87–118: `formatTokensCompact`, the three `SONNET_*` constants, `formatSonnetCostEstimate`; add a re-export block)
+- Modify: `vscode/src/views/SummaryHtmlBuilder.ts:559-564` (`estimateCost` delegates) and its import block (lines 33–49)
+
+**Interfaces:**
+- Consumes: everything Task 1 produces, from `../../../cli/src/core/TokenCost.js`.
+- Produces: no new symbols — `SummaryUtils.ts` continues to export `formatTokensCompact`, `formatSonnetCostEstimate`, `SONNET_INPUT_PER_TOKEN`, `SONNET_OUTPUT_PER_TOKEN`, `SONNET_CACHE_WRITE_PER_TOKEN` (now via re-export), plus newly `estimateConversationCostUsd`.
+
+- [ ] **Step 1: Delete the moved block from `SummaryUtils.ts`**
+
+Remove the entire section from the comment header `// ─── Token/cost formatting …` through the end of `formatSonnetCostEstimate` (the current lines 87–118): the three-line header comment, `formatTokensCompact`, the pricing comment + three `SONNET_*` constants, and `formatSonnetCostEstimate`.
+
+- [ ] **Step 2: Add the re-export in `SummaryUtils.ts`**
+
+In the "Re-exports from core" area near the top (after the `MarkdownEscape.js` re-export on line 30), add:
+
+```typescript
+export {
+	estimateConversationCostUsd,
+	formatSonnetCostEstimate,
+	formatTokensCompact,
+	SONNET_CACHE_WRITE_PER_TOKEN,
+	SONNET_INPUT_PER_TOKEN,
+	SONNET_OUTPUT_PER_TOKEN,
+} from "../../../cli/src/core/TokenCost.js";
+```
+
+- [ ] **Step 3: Delegate `SummaryHtmlBuilder.estimateCost`**
+
+In `vscode/src/views/SummaryHtmlBuilder.ts`, add `estimateConversationCostUsd` to the import from `./SummaryUtils.js` (the block at lines 33–49), then replace the body of `estimateCost` (lines 559–564):
+
+```typescript
+function estimateCost(b: ConversationTokenBreakdown | undefined, total: number): string {
+	return formatSonnetCostEstimate(estimateConversationCostUsd(b, total));
+}
+```
+
+The `SONNET_*` imports in `SummaryHtmlBuilder.ts` are still used by `SidebarScriptBuilder`-style call sites elsewhere; leave any that remain referenced. If `noUnusedImports` flags a `SONNET_*` import that `estimateCost` no longer uses directly, remove only the now-unused names from this file's import list.
+
+- [ ] **Step 4: Verify VS Code build + tests**
+
+Run: `npm run build:cli && npm run typecheck:vscode && npm run test:vscode -- src/views/SummaryUtils.test.ts src/views/SummaryHtmlBuilder.test.ts src/views/SidebarScriptBuilder.test.ts`
+Expected: PASS. The existing `SummaryUtils.test.ts` cases for `formatTokensCompact` / `formatSonnetCostEstimate` still pass because those names are re-exported from the same module path.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/core/TokenCost.ts cli/src/core/TokenCost.test.ts vscode/src/views/SummaryUtils.ts vscode/src/views/SummaryHtmlBuilder.ts
+git commit -s -m "refactor: move token/cost formatting into cli core TokenCost"
+```
+
+---
+
+### Task 3: Render the `Task usage` line in `pushPropertiesSection`
+
+Append the new line to the shared properties section, aggregating tokens across the whole consolidation tree.
+
+**Files:**
+- Modify: `cli/src/core/SummaryMarkdownBuilder.ts` (import block lines 11–20; `pushPropertiesSection` body ends at line 78)
+- Test: `cli/src/core/SummaryMarkdownBuilder.test.ts`
+
+**Interfaces:**
+- Consumes: `aggregateConversationTokens`, `aggregateConversationTokenBreakdown` from `./SummaryTree.js`; `estimateConversationCostUsd`, `formatSonnetCostEstimate`, `formatTokensCompact` from `./TokenCost.js`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `cli/src/core/SummaryMarkdownBuilder.test.ts` inside the `describe("buildMarkdown", …)` block (the `leaf()` helper already exists at the top of the file):
+
+```typescript
+	it("renders Task usage with cost and segment split when a breakdown is present", () => {
+		const md = buildMarkdown(
+			leaf({
+				conversationTokens: 3_000_000,
+				conversationTokenBreakdown: { input: 1_000_000, output: 1_000_000, cached: 1_000_000 },
+			}),
+		);
+		expect(md).toContain("**Task usage:** 3M tokens · ≈$21.75 (1M input, 1M output, 1M cached)");
+	});
+
+	it("renders Task usage total + cost only when no breakdown is present", () => {
+		const md = buildMarkdown(leaf({ conversationTokens: 1_000_000 }));
+		expect(md).toContain("**Task usage:** 1M tokens · ≈$3.00");
+		expect(md).not.toContain("input,");
+	});
+
+	it("omits Task usage entirely when there are no conversation tokens", () => {
+		const md = buildMarkdown(leaf());
+		expect(md).not.toContain("Task usage");
+	});
+
+	it("aggregates Task usage across the consolidation tree, not the root scalar", () => {
+		const md = buildMarkdown(
+			leaf({
+				conversationTokens: 0,
+				children: [
+					leaf({ commitHash: "child1", conversationTokens: 2_000_000 }),
+					leaf({ commitHash: "child2", conversationTokens: 1_000_000 }),
+				],
+			}),
+		);
+		expect(md).toContain("**Task usage:** 3M tokens");
+	});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/SummaryMarkdownBuilder.test.ts -t "Task usage"`
+Expected: FAIL — the `Task usage` line is not emitted yet.
+
+- [ ] **Step 3: Add the imports**
+
+In `cli/src/core/SummaryMarkdownBuilder.ts`, extend the `SummaryTree.js` import (line 20) and add a `TokenCost.js` import:
+
+```typescript
+import {
+	aggregateConversationTokenBreakdown,
+	aggregateConversationTokens,
+	aggregateTurns,
+	formatDurationLabel,
+	resolveDiffStats,
+} from "./SummaryTree.js";
+import { estimateConversationCostUsd, formatSonnetCostEstimate, formatTokensCompact } from "./TokenCost.js";
+```
+
+- [ ] **Step 4: Emit the line in `pushPropertiesSection`**
+
+In `pushPropertiesSection`, insert after the `Conversations` block (the current `if (totalTurns > 0) { … }` ending at line 71) and before the `memoryDocUrl` block:
+
+```typescript
+	// Task usage: token total + cache-aware cost estimate, aggregated across the
+	// whole consolidation tree (a squash/amend memory carries its tokens on folded
+	// children). Mirrors the VS Code token meter's three states; omit-when-zero
+	// matches the Conversations line above (no "not reported" state in a property list).
+	const totalTokens = aggregateConversationTokens(summary);
+	if (totalTokens > 0) {
+		const agg = aggregateConversationTokenBreakdown(summary);
+		const b = agg.input > 0 || agg.output > 0 || agg.cached > 0 ? agg : undefined;
+		const cost = formatSonnetCostEstimate(estimateConversationCostUsd(b, totalTokens));
+		const split = b
+			? ` (${formatTokensCompact(b.input)} input, ${formatTokensCompact(b.output)} output, ${formatTokensCompact(b.cached)} cached)`
+			: "";
+		lines.push(`- **Task usage:** ${formatTokensCompact(totalTokens)} tokens · ${cost}${split}`);
+	}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/SummaryMarkdownBuilder.test.ts -t "Task usage"`
+Expected: PASS — all four cases green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/core/SummaryMarkdownBuilder.ts cli/src/core/SummaryMarkdownBuilder.test.ts
+git commit -s -m "feat: show task token count & cost in pushed memory article"
+```
+
+---
+
+### Task 4: Full verification gate
+
+- [ ] **Step 1: Run the full chain**
+
+Run: `npm run all`
+Expected: clean → build → lint → test all PASS; CLI coverage thresholds (97/96/97/97) hold.
+
+- [ ] **Step 2: Manual spot-check of the rendered line**
+
+Run the CLI Markdown export against a real memory that has token usage, e.g. via the export path or an ad-hoc `npm run cli -- <a command that prints a summary markdown>`, and confirm a `- **Task usage:** … tokens · ≈$… (… input, … output, … cached)` line appears in the Properties block. If no such command is convenient, this is covered by the unit tests in Task 3; note that in the completion report.
+
+- [ ] **Step 3: Final commit (only if `npm run all` produced formatting/lockfile changes)**
+
+```bash
+git add -A
+git commit -s -m "chore: lint/format fixups for task usage line"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Display format three states → Task 3 Step 1 tests + Step 4 code (breakdown / total-only / omitted). ✓
+- Data source (tree aggregation via `SummaryTree`) → Task 3 Step 3 imports + Step 4 code; tree test in Step 1. ✓
+- Cost estimate (segment rates vs input-rate floor) → Task 1 `estimateConversationCostUsd` + tests. ✓
+- Single source of truth (sink to CLI core, VS Code re-exports) → Task 1 + Task 2. ✓
+- `pushPropertiesSection` shared by push + clipboard export → Task 3 modifies the shared function; `buildMarkdown` (clipboard) exercised in tests, and `buildPushMarkdown` reuses the same function. ✓
+- Non-goals (no `PushPayload` field, no wire change) → no task touches `JolliMemoryPushClient` / `JolliMemoryPushOrchestrator`. ✓
+- Testing + coverage floor → Task 1 & 3 tests, Task 4 gate. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code and exact commands. Task 4 Step 2's "ad-hoc command" is an acknowledged fallback whose safety net (unit tests) is explicit. ✓
+
+**Type consistency:** `estimateConversationCostUsd(breakdown: ConversationTokenBreakdown | undefined, total: number): number` is used identically in Task 1 (definition + test), Task 2 (`SummaryHtmlBuilder.estimateCost` delegation), and Task 3 (`pushPropertiesSection`). `ConversationTokenBreakdown = { input, output, cached }` matches `cli/src/Types.ts`. `aggregateConversationTokens` / `aggregateConversationTokenBreakdown` signatures match `SummaryTree.ts`. ✓
+
+**Cost arithmetic sanity check (Task 3 Step 1 expected values):** breakdown `{1M,1M,1M}` → `1M·3/1e6 + 1M·15/1e6 + 1M·3.75/1e6 = 3 + 15 + 3.75 = 21.75` → `≈$21.75`. ✓ Total-only `1M` → `1M·3/1e6 = 3.00` → `≈$3.00`. ✓

--- a/docs/superpowers/specs/2026-07-07-push-memory-token-count-and-cost-design.md
+++ b/docs/superpowers/specs/2026-07-07-push-memory-token-count-and-cost-design.md
@@ -1,0 +1,123 @@
+# Push memory: token count & cost in the article body
+
+## Problem
+
+A memory pushed to a Jolli Space renders a Markdown article whose Properties
+section lists Commit / Branch / Author / Date / Duration / Changes /
+Conversations — but **not** the conversation token count or its estimated cost.
+The VS Code Commit Memory panel already shows a token meter
+(`12.4M tokens · ≈$4.20 · input / output / cached`, `buildTokenMeter` in
+`vscode/src/views/SummaryHtmlBuilder.ts`), so the pushed article is missing
+information the local surface already displays.
+
+The structured data is *already* pushed: `pushSummary` sends `summaryJson`
+(the full `CommitSummary`, including `conversationTokens` and
+`conversationTokenBreakdown`). Only the human-readable Markdown body omits it.
+Cost is a derived estimate (not stored anywhere) computed at display time from
+per-token Sonnet-pricing constants.
+
+## Goal
+
+Add a single `Task usage` line to the shared Markdown Properties section so both
+the pushed Space article and the clipboard export show the token total, an
+estimated cost, and (when available) the input/output/cached split — matching
+the VS Code token meter's numbers exactly.
+
+## Non-goals
+
+- No new structured field on `PushPayload`. `summaryJson` already carries
+  `conversationTokens` / `conversationTokenBreakdown`; cost is derived and, per
+  existing convention, never persisted.
+- No backend / wire-schema change.
+- No change to the VS Code token meter's own rendering.
+
+## Display format (three states)
+
+The line is appended to `pushPropertiesSection` (shared by `buildPushMarkdown`
+and the clipboard-export `buildMarkdown`), placed after the `Conversations`
+line. It mirrors the three states of `buildTokenMeter`:
+
+| State | Rendered line |
+|-------|---------------|
+| Breakdown present | `- **Task usage:** 12.4M tokens · ≈$4.20 (8.1M input, 1.2M output, 3.1M cached)` |
+| Total > 0, no breakdown | `- **Task usage:** 12.4M tokens · ≈$4.20` |
+| Total == 0 | line omitted entirely |
+
+Omit-when-zero matches the established pattern in the same function
+(`Conversations` is only emitted when `totalTurns > 0`) — a Markdown property
+list has no "empty state" analogue to the panel's "Task usage not reported".
+
+Token counts use `formatTokensCompact`; the cost uses the `≈$X.XX` / `<$0.01`
+formatting of `formatSonnetCostEstimate`, so the article and the panel never
+disagree on the same underlying counts.
+
+## Data source
+
+Aggregate across the whole consolidation tree — NOT the root's own scalar — via
+the existing helpers in `cli/src/core/SummaryTree.ts`:
+
+- `aggregateConversationTokens(summary)` → the headline total.
+- `aggregateConversationTokenBreakdown(summary)` → the input/output/cached split
+  (returns zeros when no segment data exists; treat all-zero as "no breakdown").
+
+This is the same tree walk the VS Code meter uses, so a squash/amend memory that
+carries its tokens on folded children totals correctly.
+
+## Cost estimate
+
+Cost is derived, mirroring `estimateCost` in `SummaryHtmlBuilder.ts`:
+
+- With a breakdown: `input·INPUT + output·OUTPUT + cached·CACHE_WRITE`.
+- Without: `total·INPUT` (a floor — we don't fabricate a split we don't have).
+
+Constants are the current Sonnet-pricing per-token values
+(`3 / 15 / 3.75` per million). The `≈$` prefix already signals "estimate";
+actual cost varies by model, as the existing tooltip notes.
+
+## Code structure — single source of truth
+
+The cost constants and formatting helpers currently live only in
+`vscode/src/views/SummaryUtils.ts`. The CLI Markdown builder
+(`cli/src/core/`) is the lower layer and cannot depend on VS Code, yet the
+repo's standing constraint is that the two surfaces "never disagree on the same
+number". Resolution: sink the primitives into CLI core; VS Code re-exports them.
+
+1. **New `cli/src/core/TokenCost.ts`** — moved from `SummaryUtils.ts`:
+   - `SONNET_INPUT_PER_TOKEN`, `SONNET_OUTPUT_PER_TOKEN`,
+     `SONNET_CACHE_WRITE_PER_TOKEN`
+   - `formatTokensCompact(n)`
+   - `formatSonnetCostEstimate(costUsd)`
+   - `estimateConversationCostUsd(breakdown | undefined, total)` → number — the
+     non-HTML core of `SummaryHtmlBuilder.estimateCost`.
+
+2. **`vscode/src/views/SummaryUtils.ts`** re-exports the moved symbols from
+   `../../../cli/src/core/TokenCost.js` (the intentional bundle-time
+   cross-package import pattern) and drops the local definitions. Existing
+   imports in `SummaryHtmlBuilder.ts` / `SidebarScriptBuilder.ts` keep resolving
+   the same numeric values, so those files are untouched. `SummaryHtmlBuilder`'s
+   `estimateCost` may delegate to `estimateConversationCostUsd` +
+   `formatSonnetCostEstimate` to avoid a second copy of the arithmetic.
+
+3. **`cli/src/core/SummaryMarkdownBuilder.ts` `pushPropertiesSection`** appends
+   the `Task usage` line using `SummaryTree`'s aggregation helpers and
+   `TokenCost`'s formatting.
+
+## Testing
+
+- `cli/src/core/TokenCost.test.ts` — `formatTokensCompact` boundaries
+  (`999_500` → `1M`, `1_000` → `1k`), `formatSonnetCostEstimate` (`<$0.01`
+  boundary), `estimateConversationCostUsd` with and without a breakdown.
+- `cli/src/core/SummaryMarkdownBuilder.test.ts` — the three `Task usage` states
+  (breakdown / total-only / omitted), and that a squash tree aggregates across
+  children rather than reading the root scalar.
+- VS Code: update any test that asserted on the moved symbols' original import
+  location; the numbers are unchanged.
+- Hold the CLI coverage floor (97% statements / 96% branches / 97% functions /
+  97% lines).
+
+## Files touched
+
+- `cli/src/core/TokenCost.ts` (new) + `TokenCost.test.ts` (new)
+- `cli/src/core/SummaryMarkdownBuilder.ts` + its test
+- `vscode/src/views/SummaryUtils.ts` (re-export; delete local defs)
+- `vscode/src/views/SummaryHtmlBuilder.ts` (optional: delegate `estimateCost`)

--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -66,6 +66,7 @@ const {
 	collectSortedTopics,
 	escAttr,
 	escHtml,
+	estimateConversationCostUsd,
 	formatDate,
 	formatFullDate,
 	formatProviderLabel,
@@ -74,53 +75,62 @@ const {
 	getDisplayDate,
 	padIndex,
 	renderCalloutText,
-	SONNET_CACHE_WRITE_PER_TOKEN,
-	SONNET_INPUT_PER_TOKEN,
-	SONNET_OUTPUT_PER_TOKEN,
 	timeAgo,
-} = vi.hoisted(() => ({
-	collectSortedTopics: vi.fn(
-		(): {
-			topics: Array<unknown>;
-			sourceNodes: Array<unknown>;
-		} => ({
-			topics: [],
-			sourceNodes: [],
+} = vi.hoisted(() => {
+	// Mirrors the real TokenCost.ts constants — used only inside the
+	// estimateConversationCostUsd mock below.
+	const SONNET_INPUT_PER_TOKEN = 3 / 1_000_000;
+	const SONNET_OUTPUT_PER_TOKEN = 15 / 1_000_000;
+	const SONNET_CACHE_WRITE_PER_TOKEN = 3.75 / 1_000_000;
+	return {
+		collectSortedTopics: vi.fn(
+			(): {
+				topics: Array<unknown>;
+				sourceNodes: Array<unknown>;
+			} => ({
+				topics: [],
+				sourceNodes: [],
+			}),
+		),
+		escAttr: vi.fn((s: string) => s),
+		escHtml: vi.fn((s: string) => s),
+		// Mirrors the real TokenCost.ts implementation — these format visible
+		// token-meter output the tests assert on, so a stub would break every
+		// assertion checking for "1.4M"/"96k"/"≈$X.XX" text in the rendered HTML.
+		estimateConversationCostUsd: vi.fn(
+			(b: { input: number; output: number; cached: number } | undefined, total: number) =>
+				b
+					? b.input * SONNET_INPUT_PER_TOKEN +
+						b.output * SONNET_OUTPUT_PER_TOKEN +
+						b.cached * SONNET_CACHE_WRITE_PER_TOKEN
+					: total * SONNET_INPUT_PER_TOKEN,
+		),
+		formatDate: vi.fn(() => "Jan 1, 2026"),
+		formatFullDate: vi.fn(() => "January 1, 2026 at 12:00 PM"),
+		// Default to undefined so existing footer assertions stay stable; tests
+		// that exercise provider attribution override via .mockReturnValueOnce.
+		formatProviderLabel: vi.fn((): string | undefined => undefined),
+		formatSonnetCostEstimate: vi.fn((costUsd: number) =>
+			costUsd >= 0.01 ? `≈$${costUsd.toFixed(2)}` : "<$0.01",
+		),
+		formatTokensCompact: vi.fn((n: number) => {
+			if (n >= 999_500) {
+				return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+			}
+			if (n >= 1_000) {
+				return `${Math.round(n / 1_000)}k`;
+			}
+			return String(n);
 		}),
-	),
-	escAttr: vi.fn((s: string) => s),
-	escHtml: vi.fn((s: string) => s),
-	formatDate: vi.fn(() => "Jan 1, 2026"),
-	formatFullDate: vi.fn(() => "January 1, 2026 at 12:00 PM"),
-	// Default to undefined so existing footer assertions stay stable; tests
-	// that exercise provider attribution override via .mockReturnValueOnce.
-	formatProviderLabel: vi.fn((): string | undefined => undefined),
-	// Mirrors the real SummaryUtils.ts implementations — these format visible
-	// token-meter output the tests assert on, so a stub would break every
-	// assertion checking for "1.4M"/"96k"/"≈$X.XX" text in the rendered HTML.
-	formatSonnetCostEstimate: vi.fn((costUsd: number) =>
-		costUsd >= 0.01 ? `≈$${costUsd.toFixed(2)}` : "<$0.01",
-	),
-	formatTokensCompact: vi.fn((n: number) => {
-		if (n >= 1_000_000) {
-			return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
-		}
-		if (n >= 1_000) {
-			return `${Math.round(n / 1_000)}k`;
-		}
-		return String(n);
-	}),
-	getDisplayDate: vi.fn(
-		(e: { generatedAt?: string; commitDate: string }) =>
-			e.generatedAt || e.commitDate,
-	),
-	padIndex: vi.fn((i: number) => String(i + 1).padStart(2, "0")),
-	renderCalloutText: vi.fn((s: string) => s),
-	SONNET_CACHE_WRITE_PER_TOKEN: 3.75 / 1_000_000,
-	SONNET_INPUT_PER_TOKEN: 3 / 1_000_000,
-	SONNET_OUTPUT_PER_TOKEN: 15 / 1_000_000,
-	timeAgo: vi.fn(() => "3 hours ago"),
-}));
+		getDisplayDate: vi.fn(
+			(e: { generatedAt?: string; commitDate: string }) =>
+				e.generatedAt || e.commitDate,
+		),
+		padIndex: vi.fn((i: number) => String(i + 1).padStart(2, "0")),
+		renderCalloutText: vi.fn((s: string) => s),
+		timeAgo: vi.fn(() => "3 hours ago"),
+	};
+});
 
 // ─── vi.mock declarations ───────────────────────────────────────────────────
 
@@ -145,6 +155,7 @@ vi.mock("./SummaryUtils.js", () => ({
 	collectSortedTopics,
 	escAttr,
 	escHtml,
+	estimateConversationCostUsd,
 	formatDate,
 	formatFullDate,
 	formatProviderLabel,
@@ -153,9 +164,6 @@ vi.mock("./SummaryUtils.js", () => ({
 	getDisplayDate,
 	padIndex,
 	renderCalloutText,
-	SONNET_CACHE_WRITE_PER_TOKEN,
-	SONNET_INPUT_PER_TOKEN,
-	SONNET_OUTPUT_PER_TOKEN,
 	timeAgo,
 }));
 

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -34,6 +34,7 @@ import {
 	collectSortedTopics,
 	escAttr,
 	escHtml,
+	estimateConversationCostUsd,
 	formatFullDate,
 	formatProviderLabel,
 	formatSonnetCostEstimate,
@@ -41,9 +42,6 @@ import {
 	getDisplayDate,
 	padIndex,
 	renderCalloutText,
-	SONNET_CACHE_WRITE_PER_TOKEN,
-	SONNET_INPUT_PER_TOKEN,
-	SONNET_OUTPUT_PER_TOKEN,
 	type TopicWithDate,
 	timeAgo,
 } from "./SummaryUtils.js";
@@ -557,10 +555,7 @@ export function buildPropTable(
  * the same underlying token counts.
  */
 function estimateCost(b: ConversationTokenBreakdown | undefined, total: number): string {
-	const cost = b
-		? b.input * SONNET_INPUT_PER_TOKEN + b.output * SONNET_OUTPUT_PER_TOKEN + b.cached * SONNET_CACHE_WRITE_PER_TOKEN
-		: total * SONNET_INPUT_PER_TOKEN;
-	return formatSonnetCostEstimate(cost);
+	return formatSonnetCostEstimate(estimateConversationCostUsd(b, total));
 }
 
 /**

--- a/vscode/src/views/SummaryMarkdownBuilder.test.ts
+++ b/vscode/src/views/SummaryMarkdownBuilder.test.ts
@@ -13,7 +13,33 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
 	aggregateStats: vi.fn(),
 	aggregateTurns: vi.fn(),
+	aggregateConversationTokens: vi.fn(),
+	aggregateConversationTokenBreakdown: vi.fn(),
 	formatDurationLabel: vi.fn(),
+	// Real implementations (mirroring cli/src/core/TokenCost.ts) so the "Task
+	// usage" line assertions exercise real Sonnet-pricing math, not a stub.
+	formatTokensExact: vi.fn((n: number) =>
+		Math.round(n)
+			.toString()
+			.replace(/\B(?=(\d{3})+(?!\d))/g, ","),
+	),
+	formatExactCostUsd: vi.fn((costUsd: number) => {
+		if (costUsd >= 0.01) return `$${costUsd.toFixed(2)}`;
+		if (costUsd > 0) return `$${costUsd.toFixed(4)}`;
+		return "$0.00";
+	}),
+	estimateConversationCostUsd: vi.fn(
+		(breakdown: { input: number; output: number; cached: number } | undefined, total: number) => {
+			const SONNET_INPUT_PER_TOKEN = 3 / 1_000_000;
+			const SONNET_OUTPUT_PER_TOKEN = 15 / 1_000_000;
+			const SONNET_CACHE_WRITE_PER_TOKEN = 3.75 / 1_000_000;
+			return breakdown
+				? breakdown.input * SONNET_INPUT_PER_TOKEN +
+						breakdown.output * SONNET_OUTPUT_PER_TOKEN +
+						breakdown.cached * SONNET_CACHE_WRITE_PER_TOKEN
+				: total * SONNET_INPUT_PER_TOKEN;
+		},
+	),
 	// resolveDiffStats: new helper that prefers node.diffStats (new data) and
 	// falls back to aggregateStats (legacy path). Tests that previously set up
 	// aggregateStats return values keep working without change.
@@ -43,8 +69,18 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../../../cli/src/core/SummaryTree.js", () => ({
 	aggregateStats: mocks.aggregateStats,
 	aggregateTurns: mocks.aggregateTurns,
+	aggregateConversationTokens: mocks.aggregateConversationTokens,
+	aggregateConversationTokenBreakdown: mocks.aggregateConversationTokenBreakdown,
 	formatDurationLabel: mocks.formatDurationLabel,
 	resolveDiffStats: mocks.resolveDiffStats,
+}));
+
+// Mock the core TokenCost module (re-exported by the local SummaryUtils.js) so
+// the "Task usage" row assertions run against real Sonnet-pricing math.
+vi.mock("../../../cli/src/core/TokenCost.js", () => ({
+	formatTokensExact: mocks.formatTokensExact,
+	formatExactCostUsd: mocks.formatExactCostUsd,
+	estimateConversationCostUsd: mocks.estimateConversationCostUsd,
 }));
 
 // Mock the core SummaryFormat module (used by the core SummaryMarkdownBuilder)
@@ -125,6 +161,14 @@ function setupDefaults(
 		return { filesChanged: 0, insertions: 0, deletions: 0 };
 	});
 	mocks.aggregateTurns.mockReturnValue(5);
+	// Task usage line is omitted by default (totalTokens === 0); individual
+	// tests override these to exercise the three rendered states.
+	mocks.aggregateConversationTokens.mockReturnValue(0);
+	mocks.aggregateConversationTokenBreakdown.mockReturnValue({
+		input: 0,
+		output: 0,
+		cached: 0,
+	});
 	mocks.formatDurationLabel.mockReturnValue("1 day (1 commit)");
 	mocks.formatFullDate.mockReturnValue("March 30, 2026 at 10:00 AM");
 	mocks.formatDate.mockReturnValue("Mar 30, 2026");
@@ -219,6 +263,50 @@ describe("SummaryMarkdownBuilder", () => {
 				const md = buildMarkdown(summary);
 
 				expect(md).not.toContain("**Conversations:**");
+			});
+		});
+
+		describe("task usage row", () => {
+			it("renders tokens, cost, and input/output/cached split when a breakdown is present", () => {
+				const summary = makeSummary();
+				setupDefaults(summary);
+				mocks.aggregateConversationTokens.mockReturnValue(3_000_000);
+				mocks.aggregateConversationTokenBreakdown.mockReturnValue({
+					input: 1_000_000,
+					output: 1_000_000,
+					cached: 1_000_000,
+				});
+
+				const md = buildMarkdown(summary);
+
+				expect(md).toContain(
+					"- **Task usage:** 3,000,000 tokens · $21.75 (1,000,000 input, 1,000,000 output, 1,000,000 cached)",
+				);
+			});
+
+			it("renders tokens and cost without a split when the breakdown is all-zero", () => {
+				const summary = makeSummary();
+				setupDefaults(summary);
+				mocks.aggregateConversationTokens.mockReturnValue(1_000_000);
+				mocks.aggregateConversationTokenBreakdown.mockReturnValue({
+					input: 0,
+					output: 0,
+					cached: 0,
+				});
+
+				const md = buildMarkdown(summary);
+
+				expect(md).toContain("- **Task usage:** 1,000,000 tokens · $3.00");
+			});
+
+			it("omits the task usage row when totalTokens is 0", () => {
+				const summary = makeSummary();
+				setupDefaults(summary);
+				mocks.aggregateConversationTokens.mockReturnValue(0);
+
+				const md = buildMarkdown(summary);
+
+				expect(md).not.toContain("**Task usage:**");
 			});
 		});
 

--- a/vscode/src/views/SummaryMarkdownBuilder.ts
+++ b/vscode/src/views/SummaryMarkdownBuilder.ts
@@ -13,6 +13,8 @@
  */
 
 import {
+	aggregateConversationTokenBreakdown,
+	aggregateConversationTokens,
 	aggregateTurns,
 	formatDurationLabel,
 	resolveDiffStats,
@@ -24,8 +26,11 @@ import type {
 import { pushFooter, pushPlansAndNotesSection, pushRecapSection } from "../../../cli/src/core/SummaryMarkdownBuilder.js";
 import {
 	collectSortedTopics,
+	estimateConversationCostUsd,
 	formatDate,
+	formatExactCostUsd,
 	formatFullDate,
+	formatTokensExact,
 	getDisplayDate,
 	padIndex,
 	type TopicWithDate,
@@ -85,6 +90,22 @@ function pushPropertiesSection(
 		lines.push(
 			`- **Conversations:** ${totalTurns} turn${totalTurns !== 1 ? "s" : ""}`,
 		);
+	}
+
+	// Task usage: token total + cache-aware cost estimate, aggregated across the
+	// whole consolidation tree (a squash/amend memory carries its tokens on folded
+	// children). Three states mirror the VS Code token meter; omit-when-zero matches
+	// the Conversations line above. The article shows EXACT figures (thousands-
+	// separated counts, precise $) rather than the compact form the UI token bar uses.
+	const totalTokens = aggregateConversationTokens(summary);
+	if (totalTokens > 0) {
+		const agg = aggregateConversationTokenBreakdown(summary);
+		const b = agg.input > 0 || agg.output > 0 || agg.cached > 0 ? agg : undefined;
+		const cost = formatExactCostUsd(estimateConversationCostUsd(b, totalTokens));
+		const split = b
+			? ` (${formatTokensExact(b.input)} input, ${formatTokensExact(b.output)} output, ${formatTokensExact(b.cached)} cached)`
+			: "";
+		lines.push(`- **Task usage:** ${formatTokensExact(totalTokens)} tokens · ${cost}${split}`);
 	}
 
 	const memoryDocUrl = summary.jolliDocUrl;

--- a/vscode/src/views/SummaryUtils.ts
+++ b/vscode/src/views/SummaryUtils.ts
@@ -29,6 +29,17 @@ export {
 
 export { escHtml, escMdLinkText, escMdUrl } from "../../../cli/src/core/MarkdownEscape.js";
 
+export {
+	estimateConversationCostUsd,
+	formatExactCostUsd,
+	formatSonnetCostEstimate,
+	formatTokensCompact,
+	formatTokensExact,
+	SONNET_CACHE_WRITE_PER_TOKEN,
+	SONNET_INPUT_PER_TOKEN,
+	SONNET_OUTPUT_PER_TOKEN,
+} from "../../../cli/src/core/TokenCost.js";
+
 import { escHtml } from "../../../cli/src/core/MarkdownEscape.js";
 import { resolveLlmCredentialSource } from "../../../cli/src/core/LlmClient.js";
 import { formatDate as coreFormatDate } from "../../../cli/src/core/SummaryFormat.js";
@@ -82,39 +93,6 @@ export function formatActiveProviderLabel(
  */
 export function buildBranchRelativePath(branch: string | undefined): string {
 	return sanitizeBranchSlug(branch);
-}
-
-// ─── Token/cost formatting (shared by the sidebar's token bar and the Commit
-// Memory panel's token meter, so the two surfaces never disagree on the same
-// number) ────────────────────────────────────────────────────────────────────
-
-/** Formats a token count compactly (e.g. `1443000` -> `1.4M`, `2000000` -> `2M`, `96000` -> `96k`). */
-export function formatTokensCompact(n: number): string {
-	// 999_500 is the point at which `Math.round(n / 1_000)` would round up to
-	// 1000 — promote to the `M` form so a count like 999_800 renders `1M`, not
-	// the nonsensical `1000k`.
-	if (n >= 999_500) {
-		return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
-	}
-	if (n >= 1_000) {
-		return `${Math.round(n / 1_000)}k`;
-	}
-	return String(n);
-}
-
-// Rough per-token $ constants at Sonnet pricing (per token, not per-million).
-// `cached` (= cache_creation) is priced at the cache-write rate, which is
-// pricier than a standard input token but cheaper than treating it as fresh
-// input twice over. This is a ballpark estimate, not a billing-accurate
-// figure — actual cost varies by model and by any cache-read savings not
-// represented here.
-export const SONNET_INPUT_PER_TOKEN = 3 / 1_000_000;
-export const SONNET_OUTPUT_PER_TOKEN = 15 / 1_000_000;
-export const SONNET_CACHE_WRITE_PER_TOKEN = 3.75 / 1_000_000;
-
-/** Formats a cache-aware $ estimate at Sonnet pricing as `"≈$X.XX"` / `"<$0.01"`. */
-export function formatSonnetCostEstimate(costUsd: number): string {
-	return costUsd >= 0.01 ? `≈$${costUsd.toFixed(2)}` : "<$0.01";
 }
 
 // ─── HTML escaping ────────────────────────────────────────────────────────────


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer implemented token count and cost display in pushed memory articles, completing a feature that shows users the computational resources their tasks consumed. Both the CLI-core push path and the VS Code Push to Jolli button now display exact token counts with thousands separators and precise cost estimates in the article properties section. When token breakdown data is available, the summary shows the split between input, output, and cached tokens; otherwise it displays only the total and cost. Token counts aggregate across the entire consolidation tree, ensuring squashed or amended commits show the complete work performed.

To eliminate duplication and prevent divergence between surfaces, the developer created a shared `TokenCost` module in the CLI core that both the CLI and VS Code extension import from. This module exports pricing constants and formatting functions for both compact display (used in the space-constrained UI token meter) and exact display (used in the permanent article record). The module handles the edge case where token breakdown is unavailable by conservatively pricing the total at the input rate rather than guessing a split.

A design specification and implementation plan documented the approach before code was written, establishing how token usage and cost would appear in pushed articles while keeping the wire contract stable and reusing existing aggregation logic from the VS Code token meter. The work also surfaced a critical issue in a related pull request: the public-visibility share path silently downgrades to read-only sandbox mode instead of ingesting into the user's current repo due to unormalized name matching, with tests masking the failure through unrealistic fixtures.

---

## Topics (6)
<details>
<summary><strong>01 · Show exact token counts and costs in pushed memory articles</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Pushed memory articles needed to display the token consumption and estimated cost of tasks, helping users understand the computational resources their conversations consumed.

**💡 Decisions Behind the Code**

- **Exact figures in articles, compact in UI**: The pushed article is a permanent record that should surface precise figures with thousands separators, while the live token meter in the sidebar remains compact (e.g., "3M") because space constraints make abbreviation necessary. This separation allows each surface to optimize for its context without compromising accuracy in the persistent record.
- **Aggregate across the consolidation tree, not root scalar**: Squash and amend operations fold child commits' tokens into the parent but preserve their token counts on the children. Aggregating across the entire tree ensures the displayed total reflects all work represented in the memory, not just the root commit's own tokens, matching how the VS Code token meter displays usage.
- **No approximation prefix for exact costs**: The `≈` prefix is dropped in the article because the figure is the precise computed estimate, not a rounded approximation. For costs below a cent, four decimals are shown instead of rounding to "$0.00", which would misrepresent a real (albeit small) expense.

**✅ What Was Implemented**

- Added exact token count and cost display to pushed memory article summaries. Token counts now appear with thousands separators (e.g., "3,000,000" instead of "3M"), and costs render to two decimal places for amounts at or above a cent, or four decimal places for sub-cent values with no approximation prefix.
- Implemented token aggregation across the entire consolidation tree, ensuring squashed or amended commits show the complete work performed rather than a partial view. When token breakdown data is available, the summary displays the split between input, output, and cached tokens; otherwise it shows only the total and cost.
- Extended both the CLI-core and VS Code push paths to display the new "Task usage" line in the article properties section, ensuring users see consistent token and cost information regardless of which push method they use.

**📁 FILES**
- `cli/src/core/TokenCost.ts`
- `cli/src/core/SummaryMarkdownBuilder.ts`
- `vscode/src/views/SummaryMarkdownBuilder.ts`
- `vscode/src/views/SummaryUtils.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Create shared TokenCost module for token and cost formatting</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Token count and cost calculations were duplicated across the CLI markdown builder and VS Code extension, risking inconsistency between the pushed article and the sidebar token meter.

**💡 Decisions Behind the Code**

- **Single source of truth in CLI core, re-exported by VS Code**: Rather than duplicate the Sonnet pricing constants and formatting logic across VS Code and CLI, the design moves these primitives into the lower CLI layer and has VS Code re-export them. This prevents the two surfaces from ever disagreeing on the same underlying number and simplifies future pricing updates to a single location.
- **Conservative fallback when breakdown unavailable**: The module accepts an optional token breakdown (input, output, cached) and falls back to pricing the total at the input rate when no breakdown is available. This conservative approach avoids fabricating a cost split that was not actually measured, ensuring estimates are never artificially inflated.

**✅ What Was Implemented**

- Created `cli/src/core/TokenCost.ts` with five exported functions: `formatTokensCompact` (renders token counts as compact strings like "1.4M" or "96k"), `formatTokensExact` (renders counts with thousands separators), `formatSonnetCostEstimate` (formats USD cost estimates as "≈$X.XX" or "<$0.01"), `formatExactCostUsd` (renders costs to two or four decimals with no approximation prefix), and `estimateConversationCostUsd` (calculates cache-aware cost at Sonnet pricing). The module also exports three pricing constants: `SONNET_INPUT_PER_TOKEN`, `SONNET_OUTPUT_PER_TOKEN`, and `SONNET_CACHE_WRITE_PER_TOKEN`.
- Added comprehensive test coverage with boundary cases (e.g., the 999,500 token threshold where thousands round up to millions, and the 1,000 token boundary for "k" abbreviation), cost formatting thresholds, and cache-aware pricing with and without token breakdowns.
- Consolidated token and cost formatting logic by removing duplicate implementations from the VS Code extension and re-exporting them from the CLI's shared `TokenCost` module, eliminating the risk that the two surfaces could display different values for the same token counts.

**📁 FILES**
- `cli/src/core/TokenCost.ts`
- `cli/src/core/TokenCost.test.ts`
- `vscode/src/views/SummaryUtils.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Design for token count and cost display in pushed memory articles</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Memory articles pushed to Jolli Space showed commit metadata but omitted the conversation token count and estimated cost, even though this information was already computed locally in the VS Code panel and included in the push payload's structured data.

**💡 Decisions Behind the Code**

- **Reuse existing aggregation functions**: The design leverages the tree-walk aggregation helpers already in `SummaryTree.ts` (used by the VS Code meter) rather than introducing new aggregation logic, ensuring consistency and reducing maintenance burden.
- **No payload or schema changes**: Cost is a derived estimate and, per existing convention, is never persisted. The structured token data already travels in `summaryJson`; only the human-readable Markdown body gains the new line, keeping the wire contract stable.

**✅ What Was Implemented**

Created a design specification that defines how token usage and cost will be displayed in the Markdown properties section of pushed articles, mirroring the existing VS Code token meter format. The specification establishes a three-state display format: full breakdown (input/output/cached split) when available, total-only when breakdown is absent, and omitted entirely when total is zero. The design establishes a code structure to sink cost constants and formatting helpers from VS Code into a new CLI core module, ensuring both surfaces compute and display identical numbers without duplication or drift.

**📁 FILES**
- `docs/superpowers/specs/2026-07-07-push-memory-token-count-and-cost-design.md`

</blockquote>
</details>
<details>
<summary><strong>04 · Implementation plan for token count and cost display in pushed memory articles</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A design specification for adding token usage and cost information to pushed Jolli Space articles needed to be translated into concrete, testable tasks with exact code signatures and test cases.

**💡 Decisions Behind the Code**

- **Aggregate tokens across the consolidation tree, not the root scalar**: A squash or amend memory folds child commits into the parent but preserves their token counts on the children. The plan uses aggregation helpers from `SummaryTree.ts` to sum the whole tree, ensuring the displayed total reflects all work represented in the memory, not just the root commit's own tokens.
- **Omit the line entirely when zero, matching the Conversations line**: The specification called for three states (full breakdown, total-only, "not reported"). The plan implements "not reported" as omission from the properties list rather than a visible label, keeping the Markdown Properties section clean and consistent with how the existing Conversations line behaves.

**✅ What Was Implemented**

Created a four-task implementation plan that moves token/cost formatting primitives from the VS Code layer into a new CLI core module `TokenCost.ts`, making them the single source of truth for both surfaces. Task 1 defines `TokenCost.ts` with three exports for token formatting, cost estimation, and cache-aware pricing. Task 2 refactors `SummaryUtils.ts` to re-export the moved primitives so existing VS Code imports continue to resolve. Task 3 adds the new "Task usage" line to `pushPropertiesSection()` in `SummaryMarkdownBuilder.ts`, aggregating tokens across the consolidation tree and rendering three states: full breakdown with segment split, total-only when no breakdown exists, and omitted when zero. Task 4 is a verification gate running the full build/lint/test chain and confirming coverage thresholds.

**📁 FILES**
- `docs/superpowers/plans/2026-07-07-push-memory-token-count-and-cost.md`

</blockquote>
</details>
<details>
<summary><strong>05 · PR #284 review: shared branch memory import and share flow hardening</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A large pull request implementing shared-branch memory import into local memory banks and hardening the share flow with origin validation, error transparency, and org-member caching fixes required review for correctness and completeness.

**💡 Decisions Behind the Code**

- **Fixture realism is load-bearing for external parsers**: The test suite uses `repoName: "acme/widgets"` on both sides, but production backend strips slashes (storing `acmewidgets`) while local discovery extracts basename (`widgets`). This self-consistent but unrealistic fixture hides the real mismatch. Future external-parser tests must use true production forms to catch such gaps.
- **Prioritize the High finding for pre-merge fix**: The public-share ingest failure is the PR's headline feature breaking silently on a common path (any repo with a remote). This warrants either a pre-merge fix (normalize names in the fallback path) or a failing repro test that documents the limitation, rather than merging with the issue masked by bad fixtures.

**✅ What Was Implemented**

The review identified a critical issue in the public-visibility share path: shares are silently downgraded to read-only sandbox mode instead of being ingested into the user's current repo, because the name-matching fallback compares `owner/repo` (from backend) against `basename` (from local discovery) without normalization, causing a guaranteed mismatch. Tests mask this failure by using identical fabricated names on both sides, creating a false-positive pass. A secondary issue affects the foreign-repo display path, which lacks the canonicalization logic present in the main ingest path, making it nearly unreachable in practice. A tertiary issue involves a medium-severity name-collision risk when both sides lack a usable remote URL, allowing unrelated repos with the same name to collide.

**📋 Future Enhancements**

- Add a failing repro test for public-share ingest using realistic fixture forms (`owner/repo` vs `basename`), then fix the name-matching fallback to normalize both sides before comparison.
- Audit Mode 2 (`createStorageForRepo`) to apply the same canonicalization logic as Mode 1, or document the limitation explicitly.
- Consider adding a lint rule or test helper that flags fixture reuse across production and test code to catch similar self-consistent-but-wrong patterns earlier.

**📁 FILES**
- `vscode/src/services/SharedBranchImporter.ts`
- `vscode/src/JolliMemoryBridge.ts`
- `vscode/src/services/SharedBranchImporter.test.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Add token-aggregation exports to PR builder test mock</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The PR builder test suite was failing because its mock of the SummaryTree module was missing two new exports that the production code now calls: `aggregateConversationTokens` and `aggregateConversationTokenBreakdown`.

**💡 Decisions Behind the Code**

The mock needed to match the real module's exports exactly to prevent test failures when production code calls the new token-aggregation functions. Defaulting the mocks to zero/empty values keeps the regression tests focused on their original concerns rather than introducing token-usage assertions that belong in separate tests for the token-aggregation feature itself.

**✅ What Was Implemented**

Added `aggregateConversationTokens` and `aggregateConversationTokenBreakdown` to the hoisted mocks object in `SummaryPrMarkdownBuilder.test.ts`, with default return values (0 and `{ input: 0, output: 0, cached: 0 }` respectively) to keep test assertions focused on PR markdown concerns rather than token-usage behavior.

**📁 FILES**
- `cli/src/core/SummaryPrMarkdownBuilder.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 7, 2026 at 4:17 PM · via Anthropic*
<!-- jollimemory-summary-end -->
