### PR TITLE
feat: confirm before writing global skill-preference instructions

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -936,6 +936,13 @@ export interface JolliMemoryConfig {
 	readonly geminiEnabled?: boolean;
 	/** Enable Claude Code session tracking via Stop hook (default: true) */
 	readonly claudeEnabled?: boolean;
+	/**
+	 * Whether Jolli may write its skill-preference block into the machine-global
+	 * AI instruction files (~/.claude/CLAUDE.md, ~/.gemini/GEMINI.md,
+	 * ~/.codex/AGENTS.md). `undefined` = not yet decided (default: skip until the
+	 * user confirms via the CLI prompt or the VS Code notification).
+	 */
+	readonly globalInstructions?: "enabled" | "disabled";
 	/** Enable OpenCode session discovery at post-commit time (default: auto-detect) */
 	readonly openCodeEnabled?: boolean;
 	/** Enable Cursor Composer session discovery at post-commit time (default: auto-detect) */

--- a/cli/src/commands/CliUtils.test.ts
+++ b/cli/src/commands/CliUtils.test.ts
@@ -205,6 +205,23 @@ describe("CliUtils", () => {
 		});
 	});
 
+	describe("isAffirmative", () => {
+		it("treats Enter (empty) as yes — the default", async () => {
+			const { isAffirmative } = await import("./CliUtils.js");
+			expect(isAffirmative("")).toBe(true);
+		});
+
+		it.each(["y", "Y", "yes", "YES", " Yes "])("treats %j as yes", async (input) => {
+			const { isAffirmative } = await import("./CliUtils.js");
+			expect(isAffirmative(input)).toBe(true);
+		});
+
+		it.each(["n", "no", "nope", "x"])("treats %j as no", async (input) => {
+			const { isAffirmative } = await import("./CliUtils.js");
+			expect(isAffirmative(input)).toBe(false);
+		});
+	});
+
 	describe("formatShortDate", () => {
 		it("formats a valid ISO date as 'Mon DD'", async () => {
 			const { formatShortDate } = await import("./CliUtils.js");

--- a/cli/src/commands/CliUtils.ts
+++ b/cli/src/commands/CliUtils.ts
@@ -176,6 +176,15 @@ export function isInteractive(): boolean {
 }
 
 /**
+ * Parses a `[Y/n]` answer where the default (Enter → empty string) is YES.
+ * Returns true for "", "y", "yes" (case-insensitive, trimmed); false otherwise.
+ */
+export function isAffirmative(answer: string): boolean {
+	const a = answer.trim().toLowerCase();
+	return a === "" || a === "y" || a === "yes";
+}
+
+/**
  * Hard cap on `--arg-stdin` payload size. The flag only ever carries a branch
  * name or short keyword query (skill templates pipe a single line via here-doc).
  * 64 KiB is many orders of magnitude above any legitimate input but small

--- a/cli/src/commands/EnableCommand.ts
+++ b/cli/src/commands/EnableCommand.ts
@@ -12,12 +12,24 @@ import { browserLogin } from "../auth/Login.js";
 import { validateJolliApiKey } from "../core/JolliApiUtils.js";
 import { getGlobalConfigDir, loadConfigFromDir, saveConfigScoped } from "../core/SessionTracker.js";
 import { track } from "../core/Telemetry.js";
+import { GLOBAL_INSTRUCTIONS_PROMPT } from "../install/GlobalInstructionsInstaller.js";
 import { install, uninstall } from "../install/Installer.js";
 import { createLogger, setLogDir } from "../Logger.js";
 import type { JolliMemoryConfig } from "../Types.js";
-import { isInteractive, promptText, resolveProjectDir } from "./CliUtils.js";
+import { isAffirmative, isInteractive, promptText, resolveProjectDir } from "./CliUtils.js";
 
 const log = createLogger("EnableCommand");
+
+/**
+ * Confirms the global-instructions write on an interactive terminal. Wrapped in a
+ * v8-ignore block because it calls promptText, which cannot run under Vitest's piped
+ * (non-TTY) stdin; the yes/no parsing lives in the separately-tested isAffirmative.
+ */
+/* v8 ignore start -- interactive stdin prompt; not exercisable under piped test stdin */
+async function confirmGlobalInstructionsInteractively(): Promise<boolean> {
+	return isAffirmative(await promptText(`\n  ${GLOBAL_INSTRUCTIONS_PROMPT}\n  [Y/n]: `));
+}
+/* v8 ignore stop */
 
 /**
  * Interactive setup flow after hooks are installed.
@@ -145,6 +157,8 @@ export function registerEnableCommand(program: Command): void {
 				source: "cli",
 				integrationsOnly: options.integrationsOnly,
 				sourceTag: options.sourceTag,
+				confirmGlobalInstructions:
+					isInteractive() && !options.yes ? confirmGlobalInstructionsInteractively : undefined,
 			});
 
 			if (result.success) {

--- a/cli/src/install/GlobalInstructionsInstaller.test.ts
+++ b/cli/src/install/GlobalInstructionsInstaller.test.ts
@@ -14,8 +14,12 @@ vi.mock("node:os", async (importOriginal) => {
 
 import {
 	applyInstructionsBlock,
+	GLOBAL_INSTRUCTIONS_PROMPT,
 	installGlobalInstructions,
+	removeGlobalInstructions,
+	removeInstructionsBlock,
 	renderInstructionsBlock,
+	resolveGlobalInstructionsDecision,
 } from "./GlobalInstructionsInstaller.js";
 
 const START = "<!-- >>> jolli memory instructions >>> -->";
@@ -154,5 +158,106 @@ describe("installGlobalInstructions", () => {
 		await installGlobalInstructions({ claude: true, gemini: false, codex: false });
 		const second = await readFile(join(home, ".claude", "CLAUDE.md"), "utf-8");
 		expect(second).toBe(first);
+	});
+});
+
+describe("GLOBAL_INSTRUCTIONS_PROMPT", () => {
+	it("leads with the benefit and names the target files", () => {
+		expect(GLOBAL_INSTRUCTIONS_PROMPT).toContain("use Jolli's memory automatically");
+		expect(GLOBAL_INSTRUCTIONS_PROMPT).toContain("~/.claude/CLAUDE.md");
+		expect(GLOBAL_INSTRUCTIONS_PROMPT).not.toContain("[Y/n]");
+	});
+});
+
+describe("resolveGlobalInstructionsDecision", () => {
+	it("writes without prompting when already enabled", async () => {
+		const confirm = vi.fn();
+		expect(await resolveGlobalInstructionsDecision("enabled", confirm)).toEqual({ write: true });
+		expect(confirm).not.toHaveBeenCalled();
+	});
+
+	it("removes without prompting when already disabled", async () => {
+		const confirm = vi.fn();
+		expect(await resolveGlobalInstructionsDecision("disabled", confirm)).toEqual({ write: false, remove: true });
+		expect(confirm).not.toHaveBeenCalled();
+	});
+
+	it("skips and stays undecided when undecided with no callback", async () => {
+		expect(await resolveGlobalInstructionsDecision(undefined, undefined)).toEqual({ write: false });
+	});
+
+	it("persists enabled and writes when the callback agrees", async () => {
+		expect(await resolveGlobalInstructionsDecision(undefined, async () => true)).toEqual({
+			write: true,
+			persist: "enabled",
+		});
+	});
+
+	it("persists disabled and removes when the callback declines", async () => {
+		expect(await resolveGlobalInstructionsDecision(undefined, async () => false)).toEqual({
+			write: false,
+			remove: true,
+			persist: "disabled",
+		});
+	});
+});
+
+describe("removeInstructionsBlock", () => {
+	const block = renderInstructionsBlock();
+
+	it("returns the input unchanged when no block is present", () => {
+		const existing = "# My global rules\n\nBe concise.\n";
+		expect(removeInstructionsBlock(existing)).toBe(existing);
+	});
+
+	it("strips a marker block and the blank separator it was appended after", () => {
+		const existing = applyInstructionsBlock("# My global rules\n\nBe concise.\n", block);
+		expect(existing).toContain(START);
+		const removed = removeInstructionsBlock(existing);
+		expect(removed).not.toContain(START);
+		expect(removed).not.toContain(END);
+		expect(removed).not.toContain("jolli-pr");
+		// Surrounding user content survives; no dangling blank line at EOF.
+		expect(removed).toContain("# My global rules");
+		expect(removed).toContain("Be concise.");
+		expect(removed.endsWith("\n\n")).toBe(false);
+	});
+
+	it("round-trips: apply then remove restores content around the block", () => {
+		const original = "# Rules\n\nline one\n";
+		const withBlock = applyInstructionsBlock(original, block);
+		expect(removeInstructionsBlock(withBlock)).toContain("line one");
+	});
+});
+
+describe("removeGlobalInstructions", () => {
+	let home: string;
+
+	beforeEach(async () => {
+		home = await mkdtemp(join(tmpdir(), "jolli-global-instr-rm-"));
+		mockHomedir.mockReturnValue(home);
+	});
+
+	afterEach(async () => {
+		await rm(home, { recursive: true, force: true });
+	});
+
+	it("removes the block from every host, ungated, and leaves other content", async () => {
+		// Pre-existing user content around a written block in two hosts.
+		await installGlobalInstructions({ claude: true, gemini: true, codex: false });
+		await mkdir(join(home, ".claude"), { recursive: true });
+
+		await removeGlobalInstructions();
+
+		const claude = await readFile(join(home, ".claude", "CLAUDE.md"), "utf-8");
+		const gemini = await readFile(join(home, ".gemini", "GEMINI.md"), "utf-8");
+		expect(claude).not.toContain("jolli-pr");
+		expect(gemini).not.toContain("jolli-pr");
+	});
+
+	it("is a fail-soft no-op when a host file does not exist", async () => {
+		// No files written; removal must not throw or create files.
+		await expect(removeGlobalInstructions()).resolves.toBeUndefined();
+		await expect(readFile(join(home, ".claude", "CLAUDE.md"), "utf-8")).rejects.toThrow();
 	});
 });

--- a/cli/src/install/GlobalInstructionsInstaller.ts
+++ b/cli/src/install/GlobalInstructionsInstaller.ts
@@ -92,6 +92,57 @@ export function renderInstructionsBlock(): string {
 }
 
 /**
+ * Benefit-led confirmation message shown before Jolli writes its skill-preference
+ * block into the machine-global AI instruction files. SINGLE SOURCE OF TRUTH — both
+ * the CLI prompt (append `[Y/n]:`) and the VS Code notification (three buttons) render
+ * this exact string, so the wording can never drift between surfaces.
+ */
+// Keep this path list in sync with the `installGlobalInstructions({ claude, gemini, codex })`
+// targets below (TARGETS) — adding a fourth host must update both.
+export const GLOBAL_INSTRUCTIONS_PROMPT =
+	"Let your AI assistants use Jolli's memory automatically? This adds a small " +
+	"skill-preference block to your global instruction files (~/.claude/CLAUDE.md, " +
+	"~/.gemini/GEMINI.md, ~/.codex/AGENTS.md) so your AI reaches for Jolli when you " +
+	"create PRs, search past decisions, or recall a branch's history — no need to ask each time.";
+
+/** Persisted tri-state: `undefined` = undecided (default), else the user's choice. */
+export type GlobalInstructionsChoice = "enabled" | "disabled" | undefined;
+
+/**
+ * Outcome of consulting the switch:
+ *  - `write`   — write the block now.
+ *  - `persist` — when present, the caller must persist this to the global config's
+ *                `globalInstructions` field (set only when a fresh decision was made).
+ */
+export interface GlobalInstructionsDecision {
+	readonly write: boolean;
+	/** When true, actively remove any previously-written block (opt-out). */
+	readonly remove?: boolean;
+	readonly persist?: "enabled" | "disabled";
+}
+
+/**
+ * Resolves what to do with the global-instructions block from the current switch
+ * value plus an optional confirm callback (supplied only by interactive surfaces):
+ *  - `enabled`   → write, no persist.
+ *  - `disabled`  → remove any existing block, no persist (heals a stale block a
+ *                  now-opted-out user still has from a prior `enabled` run).
+ *  - undecided + callback   → ask; persist + write/remove per the answer.
+ *  - undecided + no callback → skip, stay undecided (safe default for non-interactive).
+ *    Undecided never removes — the block was never written on the user's behalf.
+ */
+export async function resolveGlobalInstructionsDecision(
+	current: GlobalInstructionsChoice,
+	confirm?: () => Promise<boolean>,
+): Promise<GlobalInstructionsDecision> {
+	if (current === "enabled") return { write: true };
+	if (current === "disabled") return { write: false, remove: true };
+	if (!confirm) return { write: false };
+	const agreed = await confirm();
+	return agreed ? { write: true, persist: "enabled" } : { write: false, remove: true, persist: "disabled" };
+}
+
+/**
  * Upserts the managed block into `existing`, preserving all other content
  * verbatim. Resolution order:
  *
@@ -188,5 +239,70 @@ export async function installGlobalInstructions(hosts: InstructionHosts): Promis
 	for (const target of TARGETS) {
 		if (!hosts[target.host]) continue;
 		await upsertTarget(join(home, ...target.relPath), block);
+	}
+}
+
+/**
+ * Removes Jolli's marker-bracketed block from `existing`, preserving all other
+ * content verbatim. The inverse of the marker branch of `applyInstructionsBlock`:
+ * a line-oriented match on the first `BLOCK_START`/`BLOCK_END` pair. Returns the
+ * input unchanged when no block is present (idempotent no-op).
+ */
+export function removeInstructionsBlock(existing: string): string {
+	const lines = existing.split("\n");
+	const startIdx = lines.indexOf(BLOCK_START);
+	const endIdx = lines.indexOf(BLOCK_END);
+	if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) {
+		return existing;
+	}
+	// Also drop a single blank separator line the block was appended after, so a
+	// removed trailing block doesn't leave a dangling empty line at EOF.
+	const spliceStart = startIdx > 0 && lines[startIdx - 1] === "" ? startIdx - 1 : startIdx;
+	return [...lines.slice(0, spliceStart), ...lines.slice(endIdx + 1)].join("\n");
+}
+
+/**
+ * Strips the managed block from a single absolute file path. Fail-soft: a missing
+ * file (ENOENT) is a no-op; other read/write errors are logged and swallowed.
+ */
+async function removeTarget(absPath: string): Promise<void> {
+	let existing: string;
+	try {
+		existing = await readFile(absPath, "utf-8");
+	} catch (err: unknown) {
+		const code = (err as NodeJS.ErrnoException).code;
+		/* v8 ignore start -- defensive: non-ENOENT read errors (perm denied, EISDIR) */
+		if (code !== "ENOENT") {
+			log.warn("Failed to read %s: %s — skipping", absPath, (err as Error).message);
+		}
+		/* v8 ignore stop */
+		return;
+	}
+
+	const updated = removeInstructionsBlock(existing);
+	if (updated === existing) {
+		return; // No block present.
+	}
+
+	try {
+		await writeFile(absPath, updated, "utf-8");
+		log.info("Removed Jolli Memory instructions from %s", absPath);
+		/* v8 ignore start -- defensive: write failure on read-only fs / EPERM */
+	} catch (err: unknown) {
+		log.warn("Failed to write %s: %s", absPath, (err as Error).message);
+	}
+	/* v8 ignore stop */
+}
+
+/**
+ * Removes the Jolli Memory instruction block from every host's global instruction
+ * file. Unlike `installGlobalInstructions`, removal is NOT host-gated: a user who
+ * opts out must have the block erased everywhere it might have been written, even
+ * from a host they have since disabled. Never creates a file that doesn't exist.
+ */
+export async function removeGlobalInstructions(): Promise<void> {
+	const home = homedir();
+	for (const target of TARGETS) {
+		await removeTarget(join(home, ...target.relPath));
 	}
 }

--- a/cli/src/install/Installer.test.ts
+++ b/cli/src/install/Installer.test.ts
@@ -861,6 +861,72 @@ describe("Installer", () => {
 			expect(result.message).toMatch(/Unexpected .git file content|ENOTDIR|not a directory/i);
 		});
 
+		describe("global instructions confirmation gate", () => {
+			it("does NOT write the global CLAUDE.md block when the switch is undecided and no callback is passed", async () => {
+				const exists = (p: string) =>
+					stat(p)
+						.then(() => true)
+						.catch(() => false);
+				const result = await install(tempDir);
+				expect(result.success).toBe(true);
+				// Undecided (no globalInstructions in config) + no confirm callback → skip.
+				expect(await exists(join(fakeHomeDir, ".claude", "CLAUDE.md"))).toBe(false);
+
+				// The skip path must not persist a `globalInstructions` key either —
+				// either the global config file was never written, or it was written
+				// for unrelated fields and simply omits the key.
+				const globalConfigPath = join(emptyGlobalDir, "config.json");
+				if (await exists(globalConfigPath)) {
+					const cfg = JSON.parse(await readFile(globalConfigPath, "utf-8"));
+					expect(cfg.globalInstructions).toBeUndefined();
+				}
+			});
+
+			it("writes the global block and persists 'enabled' when the confirm callback agrees", async () => {
+				const result = await install(tempDir, { confirmGlobalInstructions: async () => true });
+				expect(result.success).toBe(true);
+
+				const block = await readFile(join(fakeHomeDir, ".claude", "CLAUDE.md"), "utf-8");
+				expect(block).toContain("jolli-recall");
+
+				// getGlobalConfigDir() is mocked (see mockGlobalConfigDir above) to
+				// emptyGlobalDir rather than the real homedir-derived path, so the
+				// persisted config lands there, not under fakeHomeDir.
+				const cfg = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
+				expect(cfg.globalInstructions).toBe("enabled");
+			});
+
+			it("persists 'disabled' and skips the write when the confirm callback declines", async () => {
+				const exists = (p: string) =>
+					stat(p)
+						.then(() => true)
+						.catch(() => false);
+				const result = await install(tempDir, { confirmGlobalInstructions: async () => false });
+				expect(result.success).toBe(true);
+				expect(await exists(join(fakeHomeDir, ".claude", "CLAUDE.md"))).toBe(false);
+
+				// See note above: persisted config lands in the mocked emptyGlobalDir.
+				const cfg = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
+				expect(cfg.globalInstructions).toBe("disabled");
+			});
+
+			it("writes without prompting when the switch is already 'enabled'", async () => {
+				const exists = (p: string) =>
+					stat(p)
+						.then(() => true)
+						.catch(() => false);
+				// loadConfig()/getGlobalConfigDir() are mocked (see mockGlobalConfigDir
+				// above) to read from emptyGlobalDir, not the real homedir-derived path.
+				await mkdir(emptyGlobalDir, { recursive: true });
+				await writeFile(join(emptyGlobalDir, "config.json"), JSON.stringify({ globalInstructions: "enabled" }));
+				const confirm = vi.fn();
+				const result = await install(tempDir, { confirmGlobalInstructions: confirm });
+				expect(result.success).toBe(true);
+				expect(confirm).not.toHaveBeenCalled();
+				expect(await exists(join(fakeHomeDir, ".claude", "CLAUDE.md"))).toBe(true);
+			});
+		});
+
 		describe("v5 migration source discriminator", () => {
 			// When VSCode calls install() via bridge.enable(), Extension.ts
 			// separately runs migrateSchemaToV5 wrapped in setMigrating(true/

--- a/cli/src/install/Installer.ts
+++ b/cli/src/install/Installer.ts
@@ -81,7 +81,11 @@ import {
 	removePostRewriteHook,
 	removePrepareMsgHook,
 } from "./GitHookInstaller.js";
-import { installGlobalInstructions } from "./GlobalInstructionsInstaller.js";
+import {
+	installGlobalInstructions,
+	removeGlobalInstructions,
+	resolveGlobalInstructionsDecision,
+} from "./GlobalInstructionsInstaller.js";
 import type { HookOpResult } from "./HookSettingsHelper.js";
 import {
 	buildRegistrars,
@@ -126,6 +130,38 @@ function hasRequiredWorktreeHooks(
 	return claudeReady && geminiReady;
 }
 
+/**
+ * Resolves and applies the machine-global skill-preference block: reads the
+ * persisted `globalInstructions` switch, consults the optional confirm callback,
+ * persists a fresh decision, then writes OR removes the block accordingly.
+ *
+ * Single source of host-gating for the block, shared by `install()` (which passes
+ * pre-computed detection to avoid re-running detectors) and the VS Code settings
+ * panel (which calls it directly after toggling the switch, rather than re-running
+ * the full installer). Fail-soft throughout — see GlobalInstructionsInstaller.
+ */
+export async function syncGlobalInstructions(
+	confirm?: () => Promise<boolean>,
+	detected?: { readonly codexDetected: boolean; readonly geminiDetected: boolean },
+): Promise<void> {
+	const config = await loadConfig();
+	const decision = await resolveGlobalInstructionsDecision(config.globalInstructions, confirm);
+	if (decision.persist) {
+		await saveConfigScoped({ globalInstructions: decision.persist }, getGlobalConfigDir());
+	}
+	if (decision.write) {
+		const codexDetected = detected?.codexDetected ?? (await isCodexInstalled());
+		const geminiDetected = detected?.geminiDetected ?? (await isGeminiInstalled());
+		await installGlobalInstructions({
+			claude: config.claudeEnabled !== false,
+			gemini: geminiDetected && config.geminiEnabled !== false,
+			codex: codexDetected && config.codexEnabled !== false,
+		});
+	} else if (decision.remove) {
+		await removeGlobalInstructions();
+	}
+}
+
 // ─── Install ────────────────────────────────────────────────────────────────
 
 /**
@@ -141,7 +177,12 @@ function hasRequiredWorktreeHooks(
  */
 export async function install(
 	cwd?: string,
-	options?: { source?: "vscode-extension" | "cli"; integrationsOnly?: boolean; sourceTag?: string },
+	options?: {
+		source?: "vscode-extension" | "cli";
+		integrationsOnly?: boolean;
+		sourceTag?: string;
+		confirmGlobalInstructions?: () => Promise<boolean>;
+	},
 ): Promise<InstallResult> {
 	/* v8 ignore next - process.cwd() fallback only used when called without cwd arg */
 	const projectDir = cwd ?? process.cwd();
@@ -328,10 +369,14 @@ export async function install(
 		// whenever Claude isn't explicitly disabled, consistent with the rest of
 		// the installer treating Claude as the primary host. This is an integration
 		// (skill preference), not a hook, so it runs in integrations-only mode too.
-		await installGlobalInstructions({
-			claude: config.claudeEnabled !== false,
-			gemini: geminiDetectedOnce && config.geminiEnabled !== false,
-			codex: codexDetectedOnce && config.codexEnabled !== false,
+		// Ask before writing into the user's machine-global instruction files.
+		// Undecided + no callback (VS Code auto-enable / -y / IntelliJ) → skip and
+		// stay undecided; the interactive CLI passes a callback, VS Code drives its
+		// own notification. Delegated to syncGlobalInstructions so the settings panel
+		// shares identical host-gating and the write/remove/persist decision logic.
+		await syncGlobalInstructions(options?.confirmGlobalInstructions, {
+			codexDetected: codexDetectedOnce,
+			geminiDetected: geminiDetectedOnce,
 		});
 
 		// Git hooks are shared across all worktrees — install once. Skipped in

--- a/docs/superpowers/plans/2026-07-07-confirm-global-instructions.md
+++ b/docs/superpowers/plans/2026-07-07-confirm-global-instructions.md
@@ -1,0 +1,677 @@
+# Confirm Global Skill-Instruction Writes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `jolli enable` (and VS Code auto-enable) from silently writing Jolli's skill-preference block into machine-global AI instruction files (`~/.claude/CLAUDE.md`, `~/.gemini/GEMINI.md`, `~/.codex/AGENTS.md`); ask the user first and remember the answer.
+
+**Architecture:** A persisted tri-state switch `globalInstructions` in the **global** config (`~/.jolli/jollimemory/config.json`): `undefined` (undecided → skip), `"enabled"` (write), `"disabled"` (never write). `install()` reads the switch and, when undecided, calls an optional `confirmGlobalInstructions` callback (supplied only by the interactive CLI path); the callback's answer is persisted. VS Code drives its own activation-time notification that persists the switch and idempotently re-runs `install()`. Both surfaces share one benefit-led prompt string so the wording can never drift.
+
+**Tech Stack:** TypeScript (ESM), Node 22.5+, Vitest, Biome (tabs, 120 col). VS Code extension host (CJS via esbuild, bundles `cli/src/**`).
+
+## Global Constraints
+
+- **DCO sign-off on every commit** — `git commit -s`. No `Co-Authored-By: Claude …` trailer, no `🤖 Generated with …` footer. Only `Signed-off-by:` belongs in commit messages.
+- **`npm run all` must pass before the final commit** (clean → build → lint → test).
+- **CLI coverage floor: 97% statements / 96% branches / 97% functions / 97% lines** (`cli/vite.config.ts`). VS Code floor: 97% statements / 97% branches. New code must keep both green; wrap genuinely un-testable interactive I/O in `/* v8 ignore start */ … /* v8 ignore stop */` (single-line `ignore next` does NOT work in this repo).
+- **Biome:** tabs, 4-wide, 120-col; `noExplicitAny: error`, `noUnusedImports/Variables: error`, `useImportType: warn`. `biome check --error-on-warnings` — warnings fail CI.
+- **Shared prompt string is the single source of truth.** The CLI prompt and the VS Code notification MUST both render `GLOBAL_INSTRUCTIONS_PROMPT` exported from `GlobalInstructionsInstaller.ts`. Do not inline a second copy.
+- **Safe default:** when the switch is undecided and the surface cannot prompt (VS Code auto-enable, CLI `-y`, non-TTY, IntelliJ `--integrations-only`), do NOT write. Never remove an already-present block.
+
+---
+
+## File Structure
+
+**CLI (`cli/src/`):**
+- `Types.ts` — add the `globalInstructions?: "enabled" | "disabled"` config field. (Excluded from coverage.)
+- `install/GlobalInstructionsInstaller.ts` — add `GLOBAL_INSTRUCTIONS_PROMPT`, the `GlobalInstructionsChoice` type, and the pure `resolveGlobalInstructionsDecision()` resolver. Keeps the write + host-gating in one place.
+- `install/GlobalInstructionsInstaller.test.ts` — unit tests for the resolver + the constant.
+- `install/Installer.ts` — replace the unconditional `installGlobalInstructions(...)` call (currently `Installer.ts:331-335`) with: read switch → resolve decision → persist if decided → write iff `decision.write`.
+- `install/Installer.test.ts` — end-to-end tests over the three switch states.
+- `commands/CliUtils.ts` — add pure `isAffirmative()` for `[Y/n]` parsing (default yes).
+- `commands/CliUtils.test.ts` — unit tests for `isAffirmative()`.
+- `commands/EnableCommand.ts` — pass a `confirmGlobalInstructions` callback when interactive and `!--yes`.
+
+**VS Code (`vscode/src/`):**
+- `services/GlobalInstructionsPrompt.ts` — `maybePromptGlobalInstructions(bridge)`: notification, config persistence, session-dismiss flag.
+- `services/GlobalInstructionsPrompt.test.ts` — unit tests (Add / Never / dismiss / already-decided / session-suppress).
+- `Extension.ts` — invoke `maybePromptGlobalInstructions(bridge)` after the activation enable / auto-install block.
+
+---
+
+## Task 1: Config field + shared prompt + decision resolver
+
+**Files:**
+- Modify: `cli/src/Types.ts` (add field to `JolliMemoryConfig`, after `claudeEnabled` at ~`Types.ts:938`)
+- Modify: `cli/src/install/GlobalInstructionsInstaller.ts` (add exports)
+- Test: `cli/src/install/GlobalInstructionsInstaller.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `JolliMemoryConfig.globalInstructions?: "enabled" | "disabled"` (`undefined` = undecided).
+  - `GLOBAL_INSTRUCTIONS_PROMPT: string` — the shared benefit-led message body (no `[Y/n]` / buttons appended).
+  - `type GlobalInstructionsChoice = "enabled" | "disabled" | undefined`
+  - `interface GlobalInstructionsDecision { readonly write: boolean; readonly persist?: "enabled" | "disabled" }`
+  - `resolveGlobalInstructionsDecision(current: GlobalInstructionsChoice, confirm?: () => Promise<boolean>): Promise<GlobalInstructionsDecision>`
+
+- [ ] **Step 1: Add the config field**
+
+In `cli/src/Types.ts`, immediately after the `claudeEnabled` line (~`Types.ts:938`) inside `interface JolliMemoryConfig`, add:
+
+```ts
+	/**
+	 * Whether Jolli may write its skill-preference block into the machine-global
+	 * AI instruction files (~/.claude/CLAUDE.md, ~/.gemini/GEMINI.md,
+	 * ~/.codex/AGENTS.md). `undefined` = not yet decided (default: skip until the
+	 * user confirms via the CLI prompt or the VS Code notification).
+	 */
+	readonly globalInstructions?: "enabled" | "disabled";
+```
+
+- [ ] **Step 2: Write the failing resolver + constant tests**
+
+Append to `cli/src/install/GlobalInstructionsInstaller.test.ts`. First extend the existing import from `./GlobalInstructionsInstaller.js` to also pull in `GLOBAL_INSTRUCTIONS_PROMPT` and `resolveGlobalInstructionsDecision`, then add:
+
+```ts
+describe("GLOBAL_INSTRUCTIONS_PROMPT", () => {
+	it("leads with the benefit and names the target files", () => {
+		expect(GLOBAL_INSTRUCTIONS_PROMPT).toContain("use Jolli's memory automatically");
+		expect(GLOBAL_INSTRUCTIONS_PROMPT).toContain("~/.claude/CLAUDE.md");
+		expect(GLOBAL_INSTRUCTIONS_PROMPT).not.toContain("[Y/n]");
+	});
+});
+
+describe("resolveGlobalInstructionsDecision", () => {
+	it("writes without prompting when already enabled", async () => {
+		const confirm = vi.fn();
+		expect(await resolveGlobalInstructionsDecision("enabled", confirm)).toEqual({ write: true });
+		expect(confirm).not.toHaveBeenCalled();
+	});
+
+	it("skips without prompting when already disabled", async () => {
+		const confirm = vi.fn();
+		expect(await resolveGlobalInstructionsDecision("disabled", confirm)).toEqual({ write: false });
+		expect(confirm).not.toHaveBeenCalled();
+	});
+
+	it("skips and stays undecided when undecided with no callback", async () => {
+		expect(await resolveGlobalInstructionsDecision(undefined, undefined)).toEqual({ write: false });
+	});
+
+	it("persists enabled and writes when the callback agrees", async () => {
+		expect(await resolveGlobalInstructionsDecision(undefined, async () => true)).toEqual({
+			write: true,
+			persist: "enabled",
+		});
+	});
+
+	it("persists disabled and skips when the callback declines", async () => {
+		expect(await resolveGlobalInstructionsDecision(undefined, async () => false)).toEqual({
+			write: false,
+			persist: "disabled",
+		});
+	});
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/GlobalInstructionsInstaller.test.ts -t "resolveGlobalInstructionsDecision"`
+Expected: FAIL — `GLOBAL_INSTRUCTIONS_PROMPT` / `resolveGlobalInstructionsDecision` not exported.
+
+- [ ] **Step 4: Implement the constant, type, and resolver**
+
+In `cli/src/install/GlobalInstructionsInstaller.ts`, after `renderInstructionsBlock()` (~line 92), add:
+
+```ts
+/**
+ * Benefit-led confirmation message shown before Jolli writes its skill-preference
+ * block into the machine-global AI instruction files. SINGLE SOURCE OF TRUTH — both
+ * the CLI prompt (append `[Y/n]:`) and the VS Code notification (three buttons) render
+ * this exact string, so the wording can never drift between surfaces.
+ */
+export const GLOBAL_INSTRUCTIONS_PROMPT =
+	"Let your AI assistants use Jolli's memory automatically? This adds a small " +
+	"skill-preference block to your global instruction files (~/.claude/CLAUDE.md, " +
+	"~/.gemini/GEMINI.md, ~/.codex/AGENTS.md) so your AI reaches for Jolli when you " +
+	"create PRs, search past decisions, or recall a branch's history — no need to ask each time.";
+
+/** Persisted tri-state: `undefined` = undecided (default), else the user's choice. */
+export type GlobalInstructionsChoice = "enabled" | "disabled" | undefined;
+
+/**
+ * Outcome of consulting the switch:
+ *  - `write`   — write the block now.
+ *  - `persist` — when present, the caller must persist this to the global config's
+ *                `globalInstructions` field (set only when a fresh decision was made).
+ */
+export interface GlobalInstructionsDecision {
+	readonly write: boolean;
+	readonly persist?: "enabled" | "disabled";
+}
+
+/**
+ * Resolves whether to write the global-instructions block from the current switch
+ * value plus an optional confirm callback (supplied only by interactive surfaces):
+ *  - `enabled`   → write, no persist.
+ *  - `disabled`  → skip, no persist.
+ *  - undecided + callback   → ask; persist + write per the answer.
+ *  - undecided + no callback → skip, stay undecided (safe default for non-interactive).
+ */
+export async function resolveGlobalInstructionsDecision(
+	current: GlobalInstructionsChoice,
+	confirm?: () => Promise<boolean>,
+): Promise<GlobalInstructionsDecision> {
+	if (current === "enabled") return { write: true };
+	if (current === "disabled") return { write: false };
+	if (!confirm) return { write: false };
+	const agreed = await confirm();
+	return agreed ? { write: true, persist: "enabled" } : { write: false, persist: "disabled" };
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/GlobalInstructionsInstaller.test.ts`
+Expected: PASS (all resolver + constant tests green, existing render/apply tests unaffected).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/Types.ts cli/src/install/GlobalInstructionsInstaller.ts cli/src/install/GlobalInstructionsInstaller.test.ts
+git commit -s -m "feat(cli): add global-instructions switch, shared prompt, and decision resolver"
+```
+
+---
+
+## Task 2: Gate the write inside `install()`
+
+**Files:**
+- Modify: `cli/src/install/Installer.ts` (imports near `Installer.ts:42`; call site `Installer.ts:331-335`; options type `Installer.ts:144`)
+- Test: `cli/src/install/Installer.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveGlobalInstructionsDecision`, `GlobalInstructionsChoice` (Task 1); `saveConfigScoped`, `getGlobalConfigDir` (`SessionTracker.ts`).
+- Produces: `install()` options gain `confirmGlobalInstructions?: () => Promise<boolean>`. When undecided + no callback, the block is NOT written and no config is persisted.
+
+- [ ] **Step 1: Write the failing end-to-end tests**
+
+Add to the `describe("install", …)` block in `cli/src/install/Installer.test.ts`. These reuse the existing `tempDir` / `fakeHomeDir` fixtures (homedir is already mocked to `fakeHomeDir`, so `getGlobalConfigDir()` resolves under it):
+
+```ts
+it("does NOT write the global CLAUDE.md block when the switch is undecided and no callback is passed", async () => {
+	const exists = (p: string) =>
+		stat(p)
+			.then(() => true)
+			.catch(() => false);
+	const result = await install(tempDir);
+	expect(result.success).toBe(true);
+	// Undecided (no globalInstructions in config) + no confirm callback → skip.
+	expect(await exists(join(fakeHomeDir, ".claude", "CLAUDE.md"))).toBe(false);
+});
+
+it("writes the global block and persists 'enabled' when the confirm callback agrees", async () => {
+	const result = await install(tempDir, { confirmGlobalInstructions: async () => true });
+	expect(result.success).toBe(true);
+
+	const block = await readFile(join(fakeHomeDir, ".claude", "CLAUDE.md"), "utf-8");
+	expect(block).toContain("jolli-recall");
+
+	const cfg = JSON.parse(await readFile(join(fakeHomeDir, ".jolli", "jollimemory", "config.json"), "utf-8"));
+	expect(cfg.globalInstructions).toBe("enabled");
+});
+
+it("persists 'disabled' and skips the write when the confirm callback declines", async () => {
+	const exists = (p: string) =>
+		stat(p)
+			.then(() => true)
+			.catch(() => false);
+	const result = await install(tempDir, { confirmGlobalInstructions: async () => false });
+	expect(result.success).toBe(true);
+	expect(await exists(join(fakeHomeDir, ".claude", "CLAUDE.md"))).toBe(false);
+
+	const cfg = JSON.parse(await readFile(join(fakeHomeDir, ".jolli", "jollimemory", "config.json"), "utf-8"));
+	expect(cfg.globalInstructions).toBe("disabled");
+});
+
+it("writes without prompting when the switch is already 'enabled'", async () => {
+	const exists = (p: string) =>
+		stat(p)
+			.then(() => true)
+			.catch(() => false);
+	await mkdir(join(fakeHomeDir, ".jolli", "jollimemory"), { recursive: true });
+	await writeFile(
+		join(fakeHomeDir, ".jolli", "jollimemory", "config.json"),
+		JSON.stringify({ globalInstructions: "enabled" }),
+	);
+	const confirm = vi.fn();
+	const result = await install(tempDir, { confirmGlobalInstructions: confirm });
+	expect(result.success).toBe(true);
+	expect(confirm).not.toHaveBeenCalled();
+	expect(await exists(join(fakeHomeDir, ".claude", "CLAUDE.md"))).toBe(true);
+});
+```
+
+> If `stat` / `mkdir` / `writeFile` / `vi` are not already imported at the top of `Installer.test.ts`, add them to the existing `node:fs/promises` import and the `vitest` import.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/Installer.test.ts -t "global"`
+Expected: FAIL — the current code writes the block unconditionally (undecided test fails: file exists) and `confirmGlobalInstructions` is not an accepted option.
+
+- [ ] **Step 3: Extend the `install()` options type**
+
+In `cli/src/install/Installer.ts`, change the options parameter at `Installer.ts:144`:
+
+```ts
+	options?: {
+		source?: "vscode-extension" | "cli";
+		integrationsOnly?: boolean;
+		sourceTag?: string;
+		confirmGlobalInstructions?: () => Promise<boolean>;
+	},
+```
+
+- [ ] **Step 4: Add imports**
+
+In `cli/src/install/Installer.ts`, add to the existing `SessionTracker.js` import group (near `Installer.ts:42`) so it includes `getGlobalConfigDir` and `saveConfigScoped`, and add to the `GlobalInstructionsInstaller.js` import (near `Installer.ts:84`) so it includes `resolveGlobalInstructionsDecision` alongside `installGlobalInstructions`:
+
+```ts
+import { installGlobalInstructions, resolveGlobalInstructionsDecision } from "./GlobalInstructionsInstaller.js";
+```
+
+- [ ] **Step 5: Replace the unconditional write with the gated decision**
+
+In `cli/src/install/Installer.ts`, replace the call at `Installer.ts:331-335`:
+
+```ts
+		await installGlobalInstructions({
+			claude: config.claudeEnabled !== false,
+			gemini: geminiDetectedOnce && config.geminiEnabled !== false,
+			codex: codexDetectedOnce && config.codexEnabled !== false,
+		});
+```
+
+with:
+
+```ts
+		// Ask before writing into the user's machine-global instruction files.
+		// Undecided + no callback (VS Code auto-enable / -y / IntelliJ) → skip and
+		// stay undecided; the interactive CLI passes a callback, VS Code drives its
+		// own notification. See GlobalInstructionsInstaller.resolveGlobalInstructionsDecision.
+		const giDecision = await resolveGlobalInstructionsDecision(
+			config.globalInstructions,
+			options?.confirmGlobalInstructions,
+		);
+		if (giDecision.persist) {
+			await saveConfigScoped({ globalInstructions: giDecision.persist }, getGlobalConfigDir());
+		}
+		if (giDecision.write) {
+			await installGlobalInstructions({
+				claude: config.claudeEnabled !== false,
+				gemini: geminiDetectedOnce && config.geminiEnabled !== false,
+				codex: codexDetectedOnce && config.codexEnabled !== false,
+			});
+		}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/install/Installer.test.ts -t "global"`
+Expected: PASS (all four new tests green).
+
+- [ ] **Step 7: Guard against pre-existing test breakage**
+
+Run: `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all npm run test -w @jolli.ai/cli -- src/install/Installer.test.ts`
+Expected: PASS. Any prior test that asserted the block IS written after a plain `install(tempDir)` must be updated to pass `{ confirmGlobalInstructions: async () => true }` or seed `globalInstructions: "enabled"` — the block is no longer written by a bare `install()`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cli/src/install/Installer.ts cli/src/install/Installer.test.ts
+git commit -s -m "feat(cli): gate global-instructions write on the confirmation switch"
+```
+
+---
+
+## Task 3: CLI `enable` confirmation prompt
+
+**Files:**
+- Modify: `cli/src/commands/CliUtils.ts` (add `isAffirmative`)
+- Test: `cli/src/commands/CliUtils.test.ts`
+- Modify: `cli/src/commands/EnableCommand.ts` (`EnableCommand.ts:144-148` install call; imports at `EnableCommand.ts:18` and `EnableCommand.ts:15`)
+
+**Interfaces:**
+- Consumes: `isInteractive`, `promptText` (`CliUtils.ts`); `GLOBAL_INSTRUCTIONS_PROMPT` (Task 1); `install()`'s `confirmGlobalInstructions` option (Task 2).
+- Produces: `isAffirmative(answer: string): boolean` — `true` for empty (Enter), `"y"`, `"yes"` (case-insensitive, trimmed); `false` otherwise.
+
+- [ ] **Step 1: Write the failing `isAffirmative` tests**
+
+Append to `cli/src/commands/CliUtils.test.ts` (extend the existing import from `./CliUtils.js` to include `isAffirmative`):
+
+```ts
+describe("isAffirmative", () => {
+	it("treats Enter (empty) as yes — the default", () => {
+		expect(isAffirmative("")).toBe(true);
+	});
+	it.each(["y", "Y", "yes", "YES", " Yes "])("treats %j as yes", (input) => {
+		expect(isAffirmative(input)).toBe(true);
+	});
+	it.each(["n", "no", "nope", "x"])("treats %j as no", (input) => {
+		expect(isAffirmative(input)).toBe(false);
+	});
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run test -w @jolli.ai/cli -- src/commands/CliUtils.test.ts -t "isAffirmative"`
+Expected: FAIL — `isAffirmative` not exported.
+
+- [ ] **Step 3: Implement `isAffirmative`**
+
+In `cli/src/commands/CliUtils.ts`, after `isInteractive()` (~`CliUtils.ts:176`), add:
+
+```ts
+/**
+ * Parses a `[Y/n]` answer where the default (Enter → empty string) is YES.
+ * Returns true for "", "y", "yes" (case-insensitive, trimmed); false otherwise.
+ */
+export function isAffirmative(answer: string): boolean {
+	const a = answer.trim().toLowerCase();
+	return a === "" || a === "y" || a === "yes";
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/commands/CliUtils.test.ts -t "isAffirmative"`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the callback into `enable`**
+
+In `cli/src/commands/EnableCommand.ts`:
+
+1. Extend the `CliUtils.js` import at `EnableCommand.ts:18` to include `isAffirmative`:
+
+```ts
+import { isAffirmative, isInteractive, promptText, resolveProjectDir } from "./CliUtils.js";
+```
+
+2. Add an import of the shared prompt near the `Installer.js` import (`EnableCommand.ts:15`):
+
+```ts
+import { GLOBAL_INSTRUCTIONS_PROMPT } from "../install/GlobalInstructionsInstaller.js";
+```
+
+3. Replace the `install()` call at `EnableCommand.ts:144-148`:
+
+```ts
+				const result = await install(options.cwd, {
+					source: "cli",
+					integrationsOnly: options.integrationsOnly,
+					sourceTag: options.sourceTag,
+				});
+```
+
+with a module-level helper (add it near the top of `EnableCommand.ts`, after the imports) plus the wired call. The helper isolates the un-runnable interactive I/O behind a clean `/* v8 ignore start/stop */` block:
+
+```ts
+/**
+ * Confirms the global-instructions write on an interactive terminal. Wrapped in a
+ * v8-ignore block because it calls promptText, which cannot run under Vitest's piped
+ * (non-TTY) stdin; the yes/no parsing lives in the separately-tested isAffirmative.
+ */
+/* v8 ignore start -- interactive stdin prompt; not exercisable under piped test stdin */
+async function confirmGlobalInstructionsInteractively(): Promise<boolean> {
+	return isAffirmative(await promptText(`\n  ${GLOBAL_INSTRUCTIONS_PROMPT}\n  [Y/n]: `));
+}
+/* v8 ignore stop */
+```
+
+Then the install call at `EnableCommand.ts:144-148` becomes:
+
+```ts
+				const result = await install(options.cwd, {
+					source: "cli",
+					integrationsOnly: options.integrationsOnly,
+					sourceTag: options.sourceTag,
+					confirmGlobalInstructions:
+						isInteractive() && !options.yes ? confirmGlobalInstructionsInteractively : undefined,
+				});
+```
+
+> The v8-ignore wraps only the promptText-calling helper. The `isInteractive() && !options.yes ? … : undefined` ternary itself is still counted (Api.test drives the non-TTY `undefined` branch); `isAffirmative` is unit-tested in isolation. Run coverage in Step 6 and confirm no dip.
+
+- [ ] **Step 6: Run build + lint + the affected suites**
+
+Run: `npm run typecheck:cli && npm run lint && npm run test -w @jolli.ai/cli -- src/commands/CliUtils.test.ts src/Api.test.ts`
+Expected: PASS, no Biome warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cli/src/commands/CliUtils.ts cli/src/commands/CliUtils.test.ts cli/src/commands/EnableCommand.ts
+git commit -s -m "feat(cli): prompt before writing global instructions on interactive enable"
+```
+
+---
+
+## Task 4: VS Code activation notification
+
+**Files:**
+- Create: `vscode/src/services/GlobalInstructionsPrompt.ts`
+- Test: `vscode/src/services/GlobalInstructionsPrompt.test.ts`
+- Modify: `vscode/src/Extension.ts` (invoke after the enable / auto-install block, ~`Extension.ts:4010-4040`)
+
+**Interfaces:**
+- Consumes: `GLOBAL_INSTRUCTIONS_PROMPT` (`../../cli/src/install/GlobalInstructionsInstaller.js`); `loadConfig`, `saveConfig` (`../../cli/src/core/SessionTracker.js`); `vscode.window.showInformationMessage`; a bridge exposing `enable(): Promise<{ success: boolean; message: string }>`.
+- Produces: `maybePromptGlobalInstructions(bridge: { enable: () => Promise<{ success: boolean; message: string }> }): Promise<void>` and `resetGlobalInstructionsSessionFlagForTests(): void` (test-only reset of the module-level session flag).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `vscode/src/services/GlobalInstructionsPrompt.test.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const showInformationMessage = vi.fn();
+vi.mock("vscode", () => ({ window: { showInformationMessage } }));
+
+const loadConfig = vi.fn();
+const saveConfig = vi.fn().mockResolvedValue(undefined);
+vi.mock("../../cli/src/core/SessionTracker.js", () => ({ loadConfig, saveConfig }));
+
+import { maybePromptGlobalInstructions, resetGlobalInstructionsSessionFlagForTests } from "./GlobalInstructionsPrompt.js";
+
+function makeBridge() {
+	return { enable: vi.fn().mockResolvedValue({ success: true, message: "ok" }) };
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	resetGlobalInstructionsSessionFlagForTests();
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("maybePromptGlobalInstructions", () => {
+	it("does nothing when the switch is already decided", async () => {
+		loadConfig.mockResolvedValue({ globalInstructions: "enabled" });
+		await maybePromptGlobalInstructions(makeBridge());
+		expect(showInformationMessage).not.toHaveBeenCalled();
+	});
+
+	it("persists 'enabled' and re-runs enable when the user clicks Add", async () => {
+		loadConfig.mockResolvedValue({});
+		showInformationMessage.mockResolvedValue("Add");
+		const bridge = makeBridge();
+		await maybePromptGlobalInstructions(bridge);
+		expect(saveConfig).toHaveBeenCalledWith({ globalInstructions: "enabled" });
+		expect(bridge.enable).toHaveBeenCalledOnce();
+	});
+
+	it("persists 'disabled' and does not re-run enable when the user clicks Never", async () => {
+		loadConfig.mockResolvedValue({});
+		showInformationMessage.mockResolvedValue("Never");
+		const bridge = makeBridge();
+		await maybePromptGlobalInstructions(bridge);
+		expect(saveConfig).toHaveBeenCalledWith({ globalInstructions: "disabled" });
+		expect(bridge.enable).not.toHaveBeenCalled();
+	});
+
+	it("stays undecided and suppresses re-prompt for the session on dismiss", async () => {
+		loadConfig.mockResolvedValue({});
+		showInformationMessage.mockResolvedValue(undefined); // dismissed / Not now
+		const bridge = makeBridge();
+		await maybePromptGlobalInstructions(bridge);
+		expect(saveConfig).not.toHaveBeenCalled();
+
+		// Second call in the same session must not prompt again.
+		await maybePromptGlobalInstructions(bridge);
+		expect(showInformationMessage).toHaveBeenCalledOnce();
+	});
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run test:vscode -- src/services/GlobalInstructionsPrompt.test.ts`
+Expected: FAIL — module `./GlobalInstructionsPrompt.js` does not exist.
+
+- [ ] **Step 3: Implement the service**
+
+Create `vscode/src/services/GlobalInstructionsPrompt.ts`:
+
+```ts
+import * as vscode from "vscode";
+import { GLOBAL_INSTRUCTIONS_PROMPT } from "../../cli/src/install/GlobalInstructionsInstaller.js";
+import { loadConfig, saveConfig } from "../../cli/src/core/SessionTracker.js";
+
+/**
+ * True once the user has dismissed the notification (Not now / X / timeout) this
+ * VS Code session. Keeps the switch undecided but suppresses re-prompting until the
+ * window reloads. Module-level so it lives for the extension-host session.
+ */
+let dismissedThisSession = false;
+
+/** Test-only: reset the session-dismiss flag between cases. */
+export function resetGlobalInstructionsSessionFlagForTests(): void {
+	dismissedThisSession = false;
+}
+
+/**
+ * When the global-instructions switch is still undecided (and not dismissed this
+ * session), show a benefit-led notification. On "Add" persist "enabled" and re-run
+ * the idempotent enable so the block is written now; on "Never" persist "disabled";
+ * on dismiss leave it undecided and suppress re-prompting for this session.
+ *
+ * Shares GLOBAL_INSTRUCTIONS_PROMPT with the CLI so the wording cannot drift.
+ */
+export async function maybePromptGlobalInstructions(bridge: {
+	enable: () => Promise<{ success: boolean; message: string }>;
+}): Promise<void> {
+	if (dismissedThisSession) return;
+	const cfg = await loadConfig();
+	if (cfg.globalInstructions !== undefined) return;
+
+	const ADD = "Add";
+	const NEVER = "Never";
+	const choice = await vscode.window.showInformationMessage(GLOBAL_INSTRUCTIONS_PROMPT, ADD, "Not now", NEVER);
+
+	if (choice === ADD) {
+		await saveConfig({ globalInstructions: "enabled" });
+		await bridge.enable();
+	} else if (choice === NEVER) {
+		await saveConfig({ globalInstructions: "disabled" });
+	} else {
+		dismissedThisSession = true;
+	}
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm run test:vscode -- src/services/GlobalInstructionsPrompt.test.ts`
+Expected: PASS (all five cases).
+
+- [ ] **Step 5: Invoke it from activation**
+
+In `vscode/src/Extension.ts`, add the import near the other service imports:
+
+```ts
+import { maybePromptGlobalInstructions } from "./services/GlobalInstructionsPrompt.js";
+```
+
+Then, immediately after the auto-enable / auto-install block that ends around `Extension.ts:4010-4040` (after `status`/`refresh` handling, still inside the same activation flow, when `status.enabled || just-enabled`), add:
+
+```ts
+			// If Jolli is enabled but the user has not yet decided whether to add the
+			// skill-preference block to their global AI instructions, ask once (per
+			// session). Fire-and-forget so activation never blocks on the dialog.
+			void maybePromptGlobalInstructions(bridge);
+```
+
+> Place this so it runs whenever the project is enabled at activation (both the pre-enabled path and the just-auto-enabled path). It self-gates on `loadConfig()` and the session flag, so calling it unconditionally at the end of the enable/auto-install region is safe. Do NOT `await` it — activation must not hang on user input.
+
+- [ ] **Step 6: Typecheck + build + lint the extension**
+
+Run: `npm run build:cli && npm run typecheck -w vscode && npm run lint`
+Expected: PASS (cli built first so the extension bundle resolves the new `GlobalInstructionsInstaller` exports), no Biome warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add vscode/src/services/GlobalInstructionsPrompt.ts vscode/src/services/GlobalInstructionsPrompt.test.ts vscode/src/Extension.ts
+git commit -s -m "feat(vscode): notify before writing global instructions on activation"
+```
+
+---
+
+## Task 5: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full gate**
+
+Run: `npm run all`
+Expected: clean → build → lint → test all PASS; CLI coverage ≥ 97/96/97/97, VS Code coverage ≥ 97/97.
+
+- [ ] **Step 2: If git-op tests flake in isolation, re-run with the safe.bareRepository workaround**
+
+Run (only if needed): `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all npm run test:cli`
+Expected: the git-op flakes clear; coverage verdict holds. (Environment-specific — not a regression.)
+
+- [ ] **Step 3: Manual smoke — CLI declines**
+
+Run in a throwaway git repo (with a fake `HOME` so you don't touch your real `~/.claude/CLAUDE.md`):
+```bash
+HOME=$(mktemp -d) npm run cli -- enable --cwd /path/to/throwaway-repo
+```
+Answer `n` at the global-instructions prompt.
+Expected: no `~/.claude/CLAUDE.md` under the temp HOME; `config.json` there has `"globalInstructions": "disabled"`. Re-running `enable` does not re-prompt.
+
+- [ ] **Step 4: Manual smoke — CLI accepts**
+
+Repeat Step 3 with a fresh temp HOME and answer Enter (default Y).
+Expected: `~/.claude/CLAUDE.md` (under temp HOME) contains the `jolli-recall` block; `config.json` has `"globalInstructions": "enabled"`.
+
+- [ ] **Step 5: Final squash/cleanup commit if needed**
+
+If any fix commits accumulated, ensure each is DCO-signed. No `Co-Authored-By: Claude` / `🤖` footer anywhere.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 tri-state config field → Task 1 Step 1. ✅
+- §2 install() reads switch + optional callback, persists, safe default → Task 2. ✅
+- §3 CLI interactive prompt, default Y, persisted, `-y`/non-TTY skips → Task 3. ✅
+- §4 VS Code notification (Add/Not now/Never), idempotent re-run, session-dismiss → Task 4. ✅
+- §4 shared message body, single constant → Task 1 (`GLOBAL_INSTRUCTIONS_PROMPT`), consumed by Tasks 3 & 4. ✅
+- Edge: IntelliJ `--integrations-only` non-interactive → no callback → skip (falls out of Task 2's safe default; no new code). ✅
+- Edge: refusal never deletes existing block → Task 2 only gates the write, never removes. ✅
+- Testing floor 97% → Tasks 1–4 each ship tests; Task 5 runs `npm run all`. ✅
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. ✅
+
+**Type consistency:** `GlobalInstructionsChoice` / `GlobalInstructionsDecision` / `resolveGlobalInstructionsDecision` (Task 1) match their use in Task 2. `confirmGlobalInstructions` option name identical in Tasks 2 & 3. `isAffirmative` signature identical in Tasks 1-test/3. `maybePromptGlobalInstructions(bridge)` shape matches the `bridge.enable()` return type used in Extension.ts. `GLOBAL_INSTRUCTIONS_PROMPT` imported from the same module (`install/GlobalInstructionsInstaller.js`) by CLI and VS Code. ✅

--- a/docs/superpowers/specs/2026-07-07-global-instructions-confirmation-design.md
+++ b/docs/superpowers/specs/2026-07-07-global-instructions-confirmation-design.md
@@ -1,0 +1,148 @@
+# Confirm before writing global skill instructions — Design
+
+**Date:** 2026-07-07
+**Status:** Approved (brainstorming), pending spec review
+
+## Problem
+
+`installGlobalInstructions()` ([GlobalInstructionsInstaller.ts](../../../cli/src/install/GlobalInstructionsInstaller.ts))
+writes a Jolli "prefer these skills by default" managed block into **machine-global**
+instruction files that users often hand-maintain:
+
+- Claude Code → `~/.claude/CLAUDE.md`
+- Gemini CLI → `~/.gemini/GEMINI.md`
+- Codex → `~/.codex/AGENTS.md`
+
+Today it runs **unconditionally** inside `install()` ([Installer.ts:331](../../../cli/src/install/Installer.ts#L331)),
+before the interactive `promptSetup()` step in `EnableCommand`. Every `jolli enable`
+(and every VS Code auto-enable) silently touches these global files. Users want to be
+asked before Jolli writes into their global AI instruction files.
+
+## Goal
+
+Do not write the global skill-instructions block until the user has explicitly
+agreed, consistently across all surfaces (CLI, VS Code, IntelliJ). Remember the
+decision so we only ask once per machine.
+
+## Non-goals
+
+- Removing an already-present block on refusal (refusal only stops future writes).
+- Changing `uninstall` behavior (it still leaves the block in place, as today).
+- Per-host confirmation (one combined decision covers all three host files).
+- A dedicated IntelliJ confirmation UI (see Edge cases).
+
+## Design
+
+### 1. Data model — a persisted tri-state switch
+
+Add one field to `JolliMemoryConfig` ([Types.ts](../../../cli/src/Types.ts)), stored in the
+**global** config (`~/.jolli/jollimemory/config.json` via `getGlobalConfigDir()`), because
+the target files are machine-global — one decision per machine:
+
+```ts
+globalInstructions?: "enabled" | "disabled"; // undefined = not yet decided
+```
+
+- `undefined` (undecided) — default; do **not** write.
+- `"enabled"` — user agreed; write.
+- `"disabled"` — user refused; never write.
+
+### 2. `install()` core — read the switch + optional confirm callback
+
+Replace the unconditional call at [Installer.ts:331](../../../cli/src/install/Installer.ts#L331)
+with a gated step that reads the global switch:
+
+- `enabled` → write (current `installGlobalInstructions(hosts)` logic unchanged).
+- `disabled` → skip.
+- `undecided`:
+  - If the caller passed `confirmGlobalInstructions?: () => Promise<boolean>` (CLI
+    interactive path only) → `await` it, persist the result to the global config as
+    `"enabled"` / `"disabled"`, and write iff `true`.
+  - Otherwise (VS Code / IntelliJ / `-y` / non-TTY — no callback) → skip, leaving the
+    switch `undecided`.
+
+Rationale: host-detection gating (claude/gemini/codex) already lives inside `install()`.
+Keeping the write and its host gating as a single source of truth — and letting the
+callback only *ask* — avoids duplicating that logic across callers.
+
+`install()`'s options type gains the optional `confirmGlobalInstructions` callback. All
+existing callers that omit it keep the safe default (skip when undecided).
+
+### 3. CLI interactive path
+
+Both the CLI prompt and the VS Code notification (§4) show the **same message body**.
+It is defined once as a shared constant exported from `GlobalInstructionsInstaller`
+(next to `renderInstructionsBlock`) and reused by both surfaces, so the wording can never
+drift between them. Only the answer affordance differs — the CLI appends `[Y/n]`, VS Code
+renders `[Add] [Not now] [Never]` buttons. The wording leads with the benefit — what the
+user gains by saying yes — so the choice is motivated, not just a permission ask:
+
+```
+Let your AI assistants use Jolli's memory automatically? This adds a small
+skill-preference block to your global instruction files (~/.claude/CLAUDE.md,
+~/.gemini/GEMINI.md, ~/.codex/AGENTS.md) so your AI reaches for Jolli when you
+create PRs, search past decisions, or recall a branch's history — no need to
+ask each time.
+```
+
+In [EnableCommand.ts](../../../cli/src/commands/EnableCommand.ts), when
+`isInteractive() && !options.yes`, pass a `confirmGlobalInstructions` callback that uses
+the existing `promptText()` to show that shared message followed by `[Y/n]:`.
+
+- Default answer: **Y** (Enter → write).
+- The answer is persisted to the global config, so subsequent `jolli enable` runs never
+  re-ask.
+- `-y` / non-TTY → no callback passed → skip (stays undecided).
+
+### 4. VS Code notification
+
+On extension activation, when the project is enabled AND the global switch is
+`undecided` AND it has not been dismissed **this session**, show an information
+notification using the **same shared message body** as the CLI prompt (§3), with three
+buttons:
+
+> Let your AI assistants use Jolli's memory automatically? This adds a small
+> skill-preference block to your global instruction files (`~/.claude/CLAUDE.md`,
+> `~/.gemini/GEMINI.md`, `~/.codex/AGENTS.md`) so your AI reaches for Jolli when you
+> create PRs, search past decisions, or recall a branch's history — no need to ask
+> each time.
+> **[Add]** **[Not now]** **[Never]**
+
+- **Add** → persist `"enabled"`, then idempotently re-run `install()` (which now reads
+  `enabled` and writes).
+- **Never** → persist `"disabled"`.
+- **Not now / dismiss (X) / timeout** → leave `undecided`; set an in-memory
+  session flag so this VS Code session does not re-prompt. A later VS Code restart may
+  prompt once more.
+
+The notification lives in the extension activation layer, not inside `install()` —
+`enable()` / `autoInstallForWorktree()` ([JolliMemoryBridge.ts](../../../vscode/src/JolliMemoryBridge.ts))
+stay non-interactive and simply skip the write while undecided.
+
+## Edge cases & impact
+
+- **IntelliJ** invokes `jolli enable --integrations-only` non-interactively → always
+  skips the write (no confirmation surface). Consistent with the "don't write until
+  confirmed" default; no dedicated IntelliJ UI in this change. IntelliJ users who also
+  use the CLI or VS Code get the prompt there.
+- **Existing users** whose block is already present with an `undecided` switch: the next
+  `enable` no longer auto-refreshes that block until they confirm via CLI or the VS Code
+  notification. Deliberate trade-off of "don't touch without asking." We never silently
+  remove the existing block.
+- **Refusal never deletes** an existing block — `"disabled"` only stops future writes.
+
+## Testing
+
+- CLI coverage floor is 97% statements / 96% branches / 97% functions / 97% lines.
+- New `install()` branches (enabled / disabled / undecided × callback present/absent),
+  the persistence of the callback result, and the global-config read/write path must be
+  covered.
+- CLI `EnableCommand` callback wiring (interactive vs `-y` / non-TTY) tested.
+- VS Code notification logic (Add / Never / dismiss + session flag + idempotent re-run)
+  tested.
+
+## Unchanged
+
+- `uninstall` still leaves the block in place.
+- The managed-block upsert / adopt logic in `GlobalInstructionsInstaller` is untouched.
+- The `parseJolliApiKey` three-implementation lockstep is unrelated to this change.

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -90,6 +90,7 @@ import { StatusTreeProvider } from "./providers/StatusTreeProvider.js";
 import { ActiveSessionsProvider } from "./services/ActiveSessionsProvider.js";
 import { AuthService } from "./services/AuthService.js";
 import { readBackfillDismissFlag, writeBackfillDismissFlag } from "./services/BackfillDismissFlag.js";
+import { maybePromptGlobalInstructions } from "./services/GlobalInstructionsPrompt.js";
 import { KbFoldersService } from "./services/KbFoldersService.js";
 import {
 	readManualDisableFlag,
@@ -4015,6 +4016,7 @@ export function activate(context: vscode.ExtensionContext): void {
 			// sessions.json / cursors.json), so a fresh project / fresh worktree
 			// has no marker → falsy → install.
 			const manuallyDisabled = await readManualDisableFlag(workspaceRoot);
+			let projectEnabled = status.enabled;
 			if (!status.enabled && !manuallyDisabled) {
 				log.info(
 					"activate",
@@ -4039,7 +4041,19 @@ export function activate(context: vscode.ExtensionContext): void {
 					);
 					currentEnabled = refreshed.enabled;
 					sidebarProvider.notifyEnabledChanged(refreshed.enabled);
+					projectEnabled = refreshed.enabled;
 				}
+			}
+
+			// If Jolli is enabled but the user has not yet decided whether to add the
+			// skill-preference block to their global AI instructions, ask once (per
+			// session). Fire-and-forget so activation never blocks on the dialog.
+			if (projectEnabled) {
+				void maybePromptGlobalInstructions(bridge).catch((err: unknown) => {
+					log.warn("activate", "global-instructions prompt failed", {
+						message: err instanceof Error ? err.message : String(err),
+					});
+				});
 			}
 		})
 		.catch((err: unknown) => {

--- a/vscode/src/services/GlobalInstructionsPrompt.test.ts
+++ b/vscode/src/services/GlobalInstructionsPrompt.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { showInformationMessage } = vi.hoisted(() => ({ showInformationMessage: vi.fn() }));
+vi.mock("vscode", () => ({ window: { showInformationMessage } }));
+
+const { loadConfig, saveConfig } = vi.hoisted(() => ({
+	loadConfig: vi.fn(),
+	saveConfig: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../../../cli/src/core/SessionTracker.js", () => ({ loadConfig, saveConfig }));
+
+import { maybePromptGlobalInstructions, resetGlobalInstructionsSessionFlagForTests } from "./GlobalInstructionsPrompt.js";
+
+function makeBridge() {
+	return { enable: vi.fn().mockResolvedValue({ success: true, message: "ok" }) };
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	resetGlobalInstructionsSessionFlagForTests();
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("maybePromptGlobalInstructions", () => {
+	it("does nothing when the switch is already decided", async () => {
+		loadConfig.mockResolvedValue({ globalInstructions: "enabled" });
+		await maybePromptGlobalInstructions(makeBridge());
+		expect(showInformationMessage).not.toHaveBeenCalled();
+	});
+
+	it("persists 'enabled' and re-runs enable when the user clicks Add", async () => {
+		loadConfig.mockResolvedValue({});
+		showInformationMessage.mockResolvedValue("Add");
+		const bridge = makeBridge();
+		await maybePromptGlobalInstructions(bridge);
+		expect(saveConfig).toHaveBeenCalledWith({ globalInstructions: "enabled" });
+		expect(bridge.enable).toHaveBeenCalledOnce();
+	});
+
+	it("persists 'disabled' and does not re-run enable when the user clicks Never", async () => {
+		loadConfig.mockResolvedValue({});
+		showInformationMessage.mockResolvedValue("Never");
+		const bridge = makeBridge();
+		await maybePromptGlobalInstructions(bridge);
+		expect(saveConfig).toHaveBeenCalledWith({ globalInstructions: "disabled" });
+		expect(bridge.enable).not.toHaveBeenCalled();
+	});
+
+	it("stays undecided and suppresses re-prompt for the session on dismiss", async () => {
+		loadConfig.mockResolvedValue({});
+		showInformationMessage.mockResolvedValue(undefined); // dismissed / Not now
+		const bridge = makeBridge();
+		await maybePromptGlobalInstructions(bridge);
+		expect(saveConfig).not.toHaveBeenCalled();
+
+		// Second call in the same session must not prompt again.
+		await maybePromptGlobalInstructions(bridge);
+		expect(showInformationMessage).toHaveBeenCalledOnce();
+	});
+});

--- a/vscode/src/services/GlobalInstructionsPrompt.ts
+++ b/vscode/src/services/GlobalInstructionsPrompt.ts
@@ -1,0 +1,44 @@
+import * as vscode from "vscode";
+import { GLOBAL_INSTRUCTIONS_PROMPT } from "../../../cli/src/install/GlobalInstructionsInstaller.js";
+import { loadConfig, saveConfig } from "../../../cli/src/core/SessionTracker.js";
+
+/**
+ * True once the user has dismissed the notification (Not now / X / timeout) this
+ * VS Code session. Keeps the switch undecided but suppresses re-prompting until the
+ * window reloads. Module-level so it lives for the extension-host session.
+ */
+let dismissedThisSession = false;
+
+/** Test-only: reset the session-dismiss flag between cases. */
+export function resetGlobalInstructionsSessionFlagForTests(): void {
+	dismissedThisSession = false;
+}
+
+/**
+ * When the global-instructions switch is still undecided (and not dismissed this
+ * session), show a benefit-led notification. On "Add" persist "enabled" and re-run
+ * the idempotent enable so the block is written now; on "Never" persist "disabled";
+ * on dismiss leave it undecided and suppress re-prompting for this session.
+ *
+ * Shares GLOBAL_INSTRUCTIONS_PROMPT with the CLI so the wording cannot drift.
+ */
+export async function maybePromptGlobalInstructions(bridge: {
+	enable: () => Promise<{ success: boolean; message: string }>;
+}): Promise<void> {
+	if (dismissedThisSession) return;
+	const cfg = await loadConfig();
+	if (cfg.globalInstructions !== undefined) return;
+
+	const ADD = "Add";
+	const NEVER = "Never";
+	const choice = await vscode.window.showInformationMessage(GLOBAL_INSTRUCTIONS_PROMPT, ADD, "Not now", NEVER);
+
+	if (choice === ADD) {
+		await saveConfig({ globalInstructions: "enabled" });
+		await bridge.enable();
+	} else if (choice === NEVER) {
+		await saveConfig({ globalInstructions: "disabled" });
+	} else {
+		dismissedThisSession = true;
+	}
+}

--- a/vscode/src/views/SettingsHtmlBuilder.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.ts
@@ -14,6 +14,7 @@
  *   5. Others        — exclude patterns
  */
 
+import { GLOBAL_INSTRUCTIONS_PROMPT } from "../../../cli/src/install/GlobalInstructionsInstaller.js";
 import { buildSettingsCss } from "./SettingsCssBuilder.js";
 import { buildSettingsScript } from "./SettingsScriptBuilder.js";
 
@@ -55,6 +56,8 @@ export function buildSettingsHtml(nonce: string): string {
       ${buildToggleRow("cursorEnabled", "Cursor", "Session discovery via Cursor's local SQLite store")}
       ${buildToggleRow("copilotEnabled", "Copilot", "Session discovery for GitHub Copilot CLI (~/.copilot/session-store.db) and VS Code Copilot Chat (workspace storage)")}
       <div class="error-message" id="integrations-error"></div>
+      <p class="section-hint">Global preferences</p>
+      ${buildToggleRow("globalInstructions", "Global Instructions", GLOBAL_INSTRUCTIONS_PROMPT)}
     </section>
 
     <!-- ── Tab 2: AI Summary ── -->

--- a/vscode/src/views/SettingsScriptBuilder.ts
+++ b/vscode/src/views/SettingsScriptBuilder.ts
@@ -37,6 +37,7 @@ export function buildSettingsScript(): string {
   const openCodeEnabledInput = document.getElementById('openCodeEnabled');
   const cursorEnabledInput = document.getElementById('cursorEnabled');
   const copilotEnabledInput = document.getElementById('copilotEnabled');
+  const globalInstructionsInput = document.getElementById('globalInstructions');
   const localFolderInput = document.getElementById('localFolder');
   const browseLocalFolderBtn = document.getElementById('browseLocalFolderBtn');
   const rebuildKbBtn = document.getElementById('rebuildKbBtn');
@@ -332,6 +333,7 @@ export function buildSettingsScript(): string {
       openCodeEnabled: openCodeEnabledInput.checked,
       cursorEnabled: cursorEnabledInput.checked,
       copilotEnabled: copilotEnabledInput.checked,
+      globalInstructions: globalInstructionsInput.checked,
       localFolder: localFolderInput.value,
       excludePatterns: excludePatternsInput.value,
       compileExcludeFolders: compileExcludeFoldersInput.value,
@@ -356,6 +358,7 @@ export function buildSettingsScript(): string {
       openCodeEnabledInput.checked !== initialState.openCodeEnabled ||
       cursorEnabledInput.checked !== initialState.cursorEnabled ||
       copilotEnabledInput.checked !== initialState.copilotEnabled ||
+      globalInstructionsInput.checked !== initialState.globalInstructions ||
       localFolderInput.value !== initialState.localFolder ||
       excludePatternsInput.value !== initialState.excludePatterns ||
       compileExcludeFoldersInput.value !== initialState.compileExcludeFolders ||
@@ -418,7 +421,7 @@ export function buildSettingsScript(): string {
   aiProviderSelect.addEventListener('change', function() {
     checkDirty(); clearSaveFeedback(); syncProviderCard();
   });
-  [claudeEnabledInput, codexEnabledInput, geminiEnabledInput, openCodeEnabledInput, cursorEnabledInput, copilotEnabledInput].forEach(function(input) {
+  [claudeEnabledInput, codexEnabledInput, geminiEnabledInput, openCodeEnabledInput, cursorEnabledInput, copilotEnabledInput, globalInstructionsInput].forEach(function(input) {
     input.addEventListener('change', function() { validateAll(); checkDirty(); clearSaveFeedback(); });
   });
   dcoSignoffInput.addEventListener('change', function() { checkDirty(); clearSaveFeedback(); });
@@ -452,6 +455,7 @@ export function buildSettingsScript(): string {
         openCodeEnabled: openCodeEnabledInput.checked,
         cursorEnabled: cursorEnabledInput.checked,
         copilotEnabled: copilotEnabledInput.checked,
+        globalInstructions: globalInstructionsInput.checked,
         localFolder: localFolderInput.value.trim(),
         excludePatterns: excludePatternsInput.value,
         compileExcludeFolders: compileExcludeFoldersInput.value,
@@ -564,6 +568,7 @@ export function buildSettingsScript(): string {
         openCodeEnabledInput.checked = msg.settings.openCodeEnabled;
         cursorEnabledInput.checked = msg.settings.cursorEnabled;
         copilotEnabledInput.checked = msg.settings.copilotEnabled;
+        globalInstructionsInput.checked = !!msg.settings.globalInstructions;
         localFolderInput.value = msg.settings.localFolder || '';
         excludePatternsInput.value = msg.settings.excludePatterns;
         compileExcludeFoldersInput.value = msg.settings.compileExcludeFolders;

--- a/vscode/src/views/SettingsWebviewPanel.test.ts
+++ b/vscode/src/views/SettingsWebviewPanel.test.ts
@@ -101,11 +101,13 @@ const {
 	mockRemoveClaudeHook,
 	mockInstallGeminiHook,
 	mockRemoveGeminiHook,
+	mockSyncGlobalInstructions,
 } = vi.hoisted(() => ({
 	mockInstallClaudeHook: vi.fn().mockResolvedValue({}),
 	mockRemoveClaudeHook: vi.fn().mockResolvedValue({}),
 	mockInstallGeminiHook: vi.fn().mockResolvedValue({}),
 	mockRemoveGeminiHook: vi.fn().mockResolvedValue(undefined),
+	mockSyncGlobalInstructions: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../../../cli/src/install/Installer.js", () => ({
@@ -113,6 +115,7 @@ vi.mock("../../../cli/src/install/Installer.js", () => ({
 	removeClaudeHook: mockRemoveClaudeHook,
 	installGeminiHook: mockInstallGeminiHook,
 	removeGeminiHook: mockRemoveGeminiHook,
+	syncGlobalInstructions: mockSyncGlobalInstructions,
 }));
 
 vi.mock("../util/Logger.js", () => ({
@@ -411,6 +414,39 @@ describe("SettingsWebviewPanel", () => {
 					settings: expect.objectContaining({ dcoSignoff: false }),
 				}),
 			);
+		});
+
+		it("maps globalInstructions 'enabled' to true, and undecided/'disabled' to false", async () => {
+			async function loadWithGlobalInstructions(
+				globalInstructions: "enabled" | "disabled" | undefined,
+			): Promise<boolean> {
+				SettingsWebviewPanel.dispose();
+				mockLoadConfigFromDir.mockResolvedValue({
+					apiKey: undefined,
+					model: "sonnet",
+					maxTokens: null,
+					jolliApiKey: undefined,
+					claudeEnabled: true,
+					codexEnabled: true,
+					geminiEnabled: true,
+					excludePatterns: [],
+					globalInstructions,
+				});
+				await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+				const dispatch = captureMessageHandler();
+				postMessage.mockClear();
+				dispatch({ command: "loadSettings" });
+				await flushPromises();
+				const call = postMessage.mock.calls.find(
+					([msg]) => (msg as { command: string }).command === "settingsLoaded",
+				);
+				const msg = call?.[0] as { settings: { globalInstructions: boolean } };
+				return msg.settings.globalInstructions;
+			}
+
+			expect(await loadWithGlobalInstructions("enabled")).toBe(true);
+			expect(await loadWithGlobalInstructions("disabled")).toBe(false);
+			expect(await loadWithGlobalInstructions(undefined)).toBe(false);
 		});
 
 		it("returns short key without known prefix as-is", async () => {
@@ -1691,6 +1727,122 @@ describe("SettingsWebviewPanel", () => {
 				message: "Failed to save settings",
 			});
 			expect(mockSaveConfigScoped).not.toHaveBeenCalled();
+		});
+	});
+
+	// ── applySettings with globalInstructions ───────────────────────────────
+	// Tri-state config (undefined | "enabled" | "disabled") behind a binary
+	// checkbox. See task-settings-brief.md for the mapping rules: turning the
+	// checkbox off must not clobber an "undecided" config value.
+	// syncGlobalInstructions runs on a transition in EITHER direction — enabling
+	// writes the block, disabling removes it — but not on a no-op re-save.
+
+	describe("applySettings with globalInstructions", () => {
+		/** Loads settings to populate cached keys, then returns dispatch fn. */
+		async function setupForGlobalInstructions(
+			configOverrides?: Record<string, unknown>,
+		) {
+			const config = {
+				apiKey: "sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234",
+				model: "sonnet",
+				maxTokens: null,
+				jolliApiKey: "",
+				claudeEnabled: true,
+				codexEnabled: true,
+				geminiEnabled: true,
+				excludePatterns: [],
+				...configOverrides,
+			};
+			mockLoadConfigFromDir.mockResolvedValue(config);
+			mockInstallClaudeHook.mockResolvedValue({});
+			mockRemoveClaudeHook.mockResolvedValue({});
+			mockInstallGeminiHook.mockResolvedValue({});
+			mockRemoveGeminiHook.mockResolvedValue(undefined);
+
+			SettingsWebviewPanel.dispose();
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+
+			dispatch({ command: "loadSettings" });
+			await flushPromises();
+			postMessage.mockClear();
+
+			return dispatch;
+		}
+
+		function applyGlobalInstructions(
+			dispatch: (msg: Record<string, unknown>) => void,
+			globalInstructions: boolean,
+		) {
+			dispatch({
+				command: "applySettings",
+				maskedApiKey: "",
+				maskedJolliApiKey: "",
+				settings: {
+					apiKey: "",
+					model: "sonnet",
+					maxTokens: null,
+					jolliApiKey: "",
+					claudeEnabled: true,
+					codexEnabled: true,
+					geminiEnabled: true,
+					excludePatterns: "",
+					globalInstructions,
+				},
+			});
+		}
+
+		it("toggle ON from undecided persists 'enabled' and syncs the block once", async () => {
+			const dispatch = await setupForGlobalInstructions({ globalInstructions: undefined });
+
+			applyGlobalInstructions(dispatch, true);
+			await flushPromises();
+
+			expect(mockSaveConfigScoped).toHaveBeenCalledWith(
+				expect.objectContaining({ globalInstructions: "enabled" }),
+				expect.any(String),
+			);
+			expect(mockSyncGlobalInstructions).toHaveBeenCalledTimes(1);
+		});
+
+		it("toggle OFF while currently 'enabled' persists 'disabled' and syncs (removal)", async () => {
+			const dispatch = await setupForGlobalInstructions({ globalInstructions: "enabled" });
+
+			applyGlobalInstructions(dispatch, false);
+			await flushPromises();
+
+			expect(mockSaveConfigScoped).toHaveBeenCalledWith(
+				expect.objectContaining({ globalInstructions: "disabled" }),
+				expect.any(String),
+			);
+			// The disable transition must run the sync so the block is actually
+			// removed — flipping the flag alone would leave a stale block behind.
+			expect(mockSyncGlobalInstructions).toHaveBeenCalledTimes(1);
+		});
+
+		it("toggle OFF while undecided omits the field entirely (preserve undecided) and does not sync", async () => {
+			const dispatch = await setupForGlobalInstructions({ globalInstructions: undefined });
+
+			applyGlobalInstructions(dispatch, false);
+			await flushPromises();
+
+			expect(mockSaveConfigScoped).toHaveBeenCalledTimes(1);
+			const [savedUpdate] = mockSaveConfigScoped.mock.calls[0] as [Record<string, unknown>, string];
+			expect(Object.hasOwn(savedUpdate, "globalInstructions")).toBe(false);
+			expect(mockSyncGlobalInstructions).not.toHaveBeenCalled();
+		});
+
+		it("toggle ON while already 'enabled' does not re-sync", async () => {
+			const dispatch = await setupForGlobalInstructions({ globalInstructions: "enabled" });
+
+			applyGlobalInstructions(dispatch, true);
+			await flushPromises();
+
+			expect(mockSaveConfigScoped).toHaveBeenCalledWith(
+				expect.objectContaining({ globalInstructions: "enabled" }),
+				expect.any(String),
+			);
+			expect(mockSyncGlobalInstructions).not.toHaveBeenCalled();
 		});
 	});
 

--- a/vscode/src/views/SettingsWebviewPanel.ts
+++ b/vscode/src/views/SettingsWebviewPanel.ts
@@ -34,6 +34,7 @@ import {
 	installGeminiHook,
 	removeClaudeHook,
 	removeGeminiHook,
+	syncGlobalInstructions,
 } from "../../../cli/src/install/Installer.js";
 import type { JolliMemoryConfig } from "../../../cli/src/Types.js";
 import type { AuthService } from "../services/AuthService.js";
@@ -53,6 +54,8 @@ interface SettingsPayload {
 	readonly openCodeEnabled: boolean;
 	readonly cursorEnabled: boolean;
 	readonly copilotEnabled: boolean;
+	/** Tri-state config switch (undecided | "enabled" | "disabled") flattened to a checkbox; see handleApplySettings for the enable/disable/preserve-undecided persistence rules. */
+	readonly globalInstructions: boolean;
 	readonly localFolder: string;
 	readonly excludePatterns: string;
 	/** Comma-separated folder names (exact or `*` glob) skipped by `jolli compile`. */
@@ -457,6 +460,7 @@ export class SettingsWebviewPanel {
 			openCodeEnabled: config.openCodeEnabled !== false,
 			cursorEnabled: config.cursorEnabled !== false,
 			copilotEnabled: config.copilotEnabled !== false,
+			globalInstructions: config.globalInstructions === "enabled",
 			localFolder: config.localFolder ?? "",
 			excludePatterns: config.excludePatterns
 				? config.excludePatterns.join(", ")
@@ -568,6 +572,27 @@ export class SettingsWebviewPanel {
 			.map((p) => p.trim())
 			.filter((p) => p.length > 0);
 
+		const configDir = this.resolveConfigDir();
+		// Read the persisted config before building the update so the
+		// globalInstructions tri-state mapping below (enable / disable /
+		// preserve-undecided) can compare the incoming checkbox against what's
+		// actually on disk, not just the payload the webview happens to send.
+		const currentConfig = await loadConfigFromDir(configDir);
+
+		// The checkbox is binary; the config field is tri-state
+		// (undefined | "enabled" | "disabled"). Turning the checkbox off must
+		// NOT clobber an undecided value with an explicit "disabled" — that
+		// would permanently suppress the activation notification for a user
+		// who simply never touched this toggle. Only an explicit enabled ->
+		// off transition writes "disabled"; otherwise the field is omitted
+		// from the update entirely (never written as `undefined`, which would
+		// delete an existing value via saveConfigScoped's merge).
+		const giUpdate: { globalInstructions?: "enabled" | "disabled" } = settings.globalInstructions
+			? { globalInstructions: "enabled" }
+			: currentConfig.globalInstructions === "enabled"
+				? { globalInstructions: "disabled" }
+				: {};
+
 		const update: Partial<JolliMemoryConfig> = {
 			apiKey: resolvedApiKey.length > 0 ? resolvedApiKey : undefined,
 			model: settings.model === "sonnet" ? undefined : settings.model,
@@ -581,6 +606,7 @@ export class SettingsWebviewPanel {
 			openCodeEnabled: settings.openCodeEnabled,
 			cursorEnabled: settings.cursorEnabled,
 			copilotEnabled: settings.copilotEnabled,
+			...giUpdate,
 			localFolder:
 				settings.localFolder && settings.localFolder.length > 0
 					? settings.localFolder
@@ -607,8 +633,21 @@ export class SettingsWebviewPanel {
 		const repoRoot = await getProjectRootDir(this.workspaceRoot);
 		await this.syncHooks(repoRoot, settings);
 
-		const configDir = this.resolveConfigDir();
 		await saveConfigScoped(update, configDir);
+
+		// Act on a global-instructions transition in EITHER direction: the
+		// undecided/disabled -> enabled transition writes the block; the
+		// enabled -> off transition removes it (the checkbox's "off" must
+		// actually undo the write, not just flip the persisted flag). Config
+		// was persisted just above, so syncGlobalInstructions reads the fresh
+		// value and does the right thing. Calling the block-specific sync
+		// (rather than re-running the full installer) keeps host-gating in one
+		// place without redoing hook/MCP work the settings save already did.
+		const giEnabling = settings.globalInstructions && currentConfig.globalInstructions !== "enabled";
+		const giDisabling = !settings.globalInstructions && currentConfig.globalInstructions === "enabled";
+		if (giEnabling || giDisabling) {
+			await syncGlobalInstructions();
+		}
 
 		this.fullApiKey = resolvedApiKey;
 		this.fullJolliApiKey = resolvedJolliApiKey;


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Context (3)

- Confirm Global Skill-Instruction Writes — Implementation Plan
- Confirm before writing global skill instructions — Design
- Confirm before writing global skill instructions — Design

## Quick recap

The developer implemented a comprehensive confirmation system for writing Jolli's skill-preference block to machine-global AI instruction files. Users are now asked once whether to enable this feature across all surfaces—CLI, VS Code, and IntelliJ—and their choice is remembered in the global config. The system safely defaults to skipping the write in non-interactive contexts like CI or piped input, respecting the principle of explicit consent before touching user files. Both the CLI and VS Code extension use the same shared prompt message and decision logic, ensuring consistent behavior and wording across surfaces.

The VS Code extension now offers three ways to control this preference: an activation notification that appears once per session with Add/Never/Not-now options, a persistent toggle in the Settings panel under AI Agents, and the shared decision logic that respects the tri-state configuration (undecided / enabled / disabled). When users interact with any of these surfaces, their choice is remembered and applied consistently everywhere. The Settings toggle is particularly careful to preserve the undecided state when users never engage with it, allowing the activation notification to still prompt them later.

A critical regression was also identified and fixed in the IntelliJ git-op-queue migration: the new dispatchOp function was parsing commit metadata using space separators instead of NUL bytes, silently breaking commit summary generation for most real commits. The one-line fix restores the correct separator, but the underlying issue reveals a gap in test coverage that should be addressed with a unit test exercising multi-word commit subjects.

---

## Topics (8)
<details>
<summary><strong>01 · Add Global Instructions toggle to VS Code Settings panel</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users needed a persistent UI control in VS Code Settings to manage whether Jolli's skill-preference block is written to their global AI instruction files, complementing the CLI and activation notification prompts.

**💡 Decisions Behind the Code**

- **Binary checkbox for tri-state config**: The Settings UI uses a standard checkbox, but the underlying config is tri-state (undefined / "enabled" / "disabled"). Mapping the checkbox to only check when the value is "enabled" ensures that a user who never touches the toggle will not have their undecided state clobbered to "disabled" when they save the Settings panel for an unrelated reason, preserving the activation notification's ability to prompt them later.
- **Write-on-enable transition only**: The install() function is called only when the checkbox transitions from off to on, not on every save. This avoids redundant writes and keeps the host-gating logic centralized in the canonical installer rather than duplicated in the Settings handler.
- **Preserve undecided on toggle-off**: When the checkbox is turned off while the config is undecided, the field is omitted from the save payload entirely rather than written as "disabled", preventing a user who has never engaged with the toggle from being locked into an explicit "disabled" state.

**✅ What Was Implemented**

- Added a "Global Instructions" toggle to the AI Agents section of the VS Code Settings panel with benefit-led description text explaining that enabling it adds a skill-preference block to global instruction files.
- Wired the toggle into the Settings webview: added DOM element references, dirty-state tracking, payload serialization, and message handlers to load and apply the setting.
- Implemented tri-state persistence logic in SettingsWebviewPanel.ts: turning the checkbox ON persists "enabled" and runs the canonical install() function to write the block; turning it OFF while "enabled" persists "disabled" without running install; turning it OFF while undecided omits the field entirely to preserve the undecided state.

**📁 FILES**
- `vscode/src/views/SettingsHtmlBuilder.ts`
- `vscode/src/views/SettingsWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Prompt user to add global instructions on VS Code extension activation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When Jolli is enabled in a workspace, users should be offered the option to add a skill-preference block to their global AI instructions without blocking the extension's activation flow.

**💡 Decisions Behind the Code**

- **Fire-and-forget async call during activation**: The prompt is invoked without awaiting so that extension startup completes immediately and the user sees the notification as a non-blocking side effect, preventing slow dialogs from delaying IDE responsiveness while still ensuring the user is informed early in their session.
- **Session-level dismiss flag**: When the user dismisses the notification, a module-level flag suppresses re-prompting for the remainder of the VS Code session. This balances respecting the user's immediate "not now" intent with allowing them to reconsider after a window reload, avoiding notification fatigue without permanent dismissal.
- **Shared prompt text with CLI**: The notification message is imported from the CLI's global instructions installer rather than duplicated, ensuring the wording and benefit statement remain consistent across both entry points and reducing maintenance burden.

**✅ What Was Implemented**

- Created a new service module GlobalInstructionsPrompt.ts that checks whether the user has already decided on global instructions, and if not, displays a benefit-led notification with three options: "Add" (persists the choice and re-runs the enable flow), "Never" (persists the choice), or "Not now" (suppresses re-prompting for the session).
- Integrated the prompt into the extension activation flow by calling it asynchronously (fire-and-forget) after the project is confirmed enabled, ensuring activation never blocks on the dialog.
- Added error handling to catch and log any failures during the asynchronous prompt, preventing unhandled rejections from propagating during extension startup.
- Added comprehensive test coverage verifying all three user paths (Add, Never, dismiss), the session-level suppression of re-prompts, and the idempotent behavior when the switch is already decided.

**📁 FILES**
- `vscode/src/Extension.ts`
- `vscode/src/services/GlobalInstructionsPrompt.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Add confirmation prompt before writing global instructions on interactive enable</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When enabling Jolli interactively without the `--yes` flag, the CLI should prompt the user to confirm before writing global instructions, rather than proceeding silently.

**💡 Decisions Behind the Code**

The confirmation logic was isolated into a separate function and marked with v8-ignore coverage directives. This approach allows the yes/no parsing logic to be tested independently in a unit test, while the interactive prompt itself—which depends on TTY stdin—is excluded from coverage since it cannot be exercised under Vitest's piped test environment. This separation maintains test coverage for the parsing logic while acknowledging the practical limitation of testing interactive prompts in a non-TTY context.

**✅ What Was Implemented**

- Added isAffirmative() utility function to CliUtils.ts that parses yes/no answers where Enter (empty string) defaults to yes, handling case-insensitive variants like "y", "yes", "n", and "no".
- Added confirmGlobalInstructionsInteractively() function to EnableCommand.ts that prompts the user with the global instructions message and returns a boolean based on their response, wrapped in a v8-ignore block since interactive stdin prompts cannot run under Vitest's piped test environment.
- Modified the enable command flow to conditionally pass the confirmation callback to the installer only when running interactively and without the `--yes` flag, allowing the installer to request user confirmation before writing global instructions.

**📁 FILES**
- `cli/src/commands/EnableCommand.ts`
- `cli/src/commands/CliUtils.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Gate global instruction file writes inside the install function</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The install() function was unconditionally writing the global instruction block. The system needed to check the tri-state switch before writing and persist any new decision to the global config.

**💡 Decisions Behind the Code**

- **Single write location**: The write logic stays in one place (installGlobalInstructions()) rather than being duplicated across CLI and VS Code entry points. This ensures both surfaces use the same host detection (Claude, Gemini, Codex) and never write conflicting blocks.
- **Atomic decision persistence**: The decision resolver is called inside install() so that the config persistence happens atomically with the decision, reducing the risk of inconsistent state if the process crashes between deciding and saving.

**✅ What Was Implemented**

- Modified cli/src/install/Installer.ts to accept an optional confirmGlobalInstructions callback in the install options, allowing callers to supply a confirmation function only when appropriate.
- Replaced the unconditional installGlobalInstructions() call with a gated sequence: resolve the decision using the switch state and callback, persist the decision if it was newly made, and write the block only if the decision says to write.
- Added end-to-end tests covering all three switch states and the callback scenarios, ensuring the block is not written when undecided with no callback, is written and persisted when the callback agrees, and is skipped and persisted when the callback declines.
- Extended test coverage to verify that when a user skips the prompt, no configuration state is persisted to the global config file.

**📁 FILES**
- `cli/src/install/Installer.ts`
- `cli/src/install/GlobalInstructionsInstaller.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Add tri-state switch and decision resolver for global instruction file writes</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The CLI and VS Code extension were unconditionally writing Jolli's skill-preference block into machine-global AI instruction files without asking the user first. The system needed a way to ask once, remember the answer, and respect the user's choice across both surfaces.

**💡 Decisions Behind the Code**

- **Pure function for decision logic**: The decision resolver is a pure function that separates the "should we ask?" logic from the "should we write?" logic. This allows the CLI to supply a callback only when interactive and the user hasn't passed `--yes`, while VS Code can drive its own notification flow independently. Both surfaces call the same resolver with the same config state, guaranteeing consistent behavior.
- **Safe default when undecided and no callback**: When the switch is undecided and no callback is provided, the write is skipped and the switch stays undecided. This protects users in non-interactive contexts (piped stdin, CI, IntelliJ integrations) from silent writes to their home directory while still allowing users to opt in through the CLI or VS Code notification.
- **Shared constant over duplicated strings**: The prompt message is defined once in GlobalInstructionsInstaller.ts and imported by both CLI and VS Code rather than inlined twice. This eliminates the risk of the two surfaces showing different wording to users and makes future message updates a single-point change.

**✅ What Was Implemented**

- Added a globalInstructions field to the global config (in cli/src/Types.ts) with three states: undefined (undecided, default), "enabled" (write), or "disabled" (never write). This persists the user's choice across sessions.
- Created a pure decision resolver function resolveGlobalInstructionsDecision() in cli/src/install/GlobalInstructionsInstaller.ts that takes the current switch state and an optional confirmation callback, returning whether to write and what to persist. The function handles all four cases: already enabled (write, no prompt), already disabled (skip, no prompt), undecided with callback (ask and persist the answer), and undecided without callback (skip, stay undecided for safety).
- Exported GLOBAL_INSTRUCTIONS_PROMPT as a single source of truth for the confirmation message, ensuring the CLI and VS Code notification render identical wording so the message can never drift between surfaces.
- Added a synchronization comment above the prompt constant that explicitly references the installation targets list and warns that adding a new AI host requires updating both the prompt text and the targets list.

**📁 FILES**
- `cli/src/Types.ts`
- `cli/src/install/GlobalInstructionsInstaller.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Design for confirming global skill-instruction writes before modifying user files</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The CLI and VS Code extensions were unconditionally writing Jolli's skill-preference block into machine-global AI instruction files (~/.claude/CLAUDE.md, ~/.gemini/GEMINI.md, ~/.codex/AGENTS.md) that users often maintain by hand. Users wanted to be asked for permission before these files were modified.

**💡 Decisions Behind the Code**

- **Single source of truth for the write decision**: The confirmation logic and host-detection gating both live inside install() rather than spreading across callers. This prevents duplicating host-detection logic and ensures all surfaces (CLI, VS Code, IntelliJ) apply the same rules consistently. The callback pattern lets the CLI ask interactively while non-interactive surfaces safely skip.
- **Safe default for non-interactive surfaces**: When the switch is undecided and no confirmation callback is provided, the write is skipped. This prevents silent modifications in automated scenarios (VS Code auto-enable, IntelliJ integrations, `-y` flag) while still allowing users to opt in through the CLI or VS Code notification. The trade-off is that existing users with the block already present will stop seeing auto-refreshes until they confirm.
- **Refusal never deletes**: Setting the switch to "disabled" only stops future writes; it does not remove an existing block. This respects user autonomy — if they later change their mind, the block is still there, and they can re-enable writes without losing their configuration.

**✅ What Was Implemented**

- Designed a tri-state persistent switch (globalInstructions: "enabled" | "disabled" | undefined) stored in the global config to track user consent across all surfaces. The default state (undefined) prevents writes until the user explicitly agrees.
- Modified the install() function to read the switch and only write when enabled, or when the caller provides a confirmation callback (CLI interactive path only). Non-interactive surfaces (VS Code auto-enable, IntelliJ, `-y` flag) skip the write while undecided, preserving the safe default.
- Implemented CLI confirmation via an interactive prompt in EnableCommand that asks the user once and persists the answer. VS Code shows an information notification on extension activation with Add / Never / Not now options, using an in-memory session flag to avoid re-prompting within the same session.

**📁 FILES**
- `docs/superpowers/specs/2026-07-07-global-instructions-confirmation-design.md`

</blockquote>
</details>
<details>
<summary><strong>07 · Implementation plan for confirming global instruction writes before persisting them</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The design spec for gating global skill-instruction writes was approved. The developer needed to translate the design into a detailed, task-by-task implementation plan with concrete code steps, test cases, and verification gates so that agentic workers can execute it reliably.

**💡 Decisions Behind the Code**

- **Shared constant over duplicated strings**: The benefit-led prompt message is defined once in GlobalInstructionsInstaller.ts and imported by both CLI and VS Code rather than inlined twice. This eliminates the risk of the two surfaces showing different wording to users and makes future message updates a single-point change. The trade-off is a cross-layer import (CLI module imported by VS Code), but the bundling already pulls CLI code into the extension, so the cost is zero.
- **Safe default when undecided and no callback**: When the switch is undecided and the caller cannot prompt (VS Code auto-enable, CLI `-y`, non-TTY, IntelliJ `--integrations-only`), the write is skipped and the switch stays undecided. This respects the principle "do not touch user files without explicit consent" and avoids silent writes on every auto-enable. The trade-off is that users who never interact with the CLI or VS Code notification will never get the block written, but they can always enable it manually later or via the CLI.
- **Session-level dismiss flag in VS Code**: The notification suppresses re-prompting for the remainder of the VS Code session if the user clicks "Not now" or dismisses it, but allows re-prompting after a window reload. This balances respecting the user's immediate "not now" choice (no nagging) with allowing them to change their mind after restarting the editor.

**✅ What Was Implemented**

- Created a five-task implementation plan (docs/superpowers/plans/2026-07-07-confirm-global-instructions.md) that breaks the design into executable steps: adding the tri-state config field and shared prompt constant (Task 1), gating the write inside install() with optional callback support (Task 2), wiring the interactive CLI prompt with [Y/n] parsing (Task 3), building the VS Code activation notification with Add/Never/Not-now buttons (Task 4), and full verification including manual smoke tests (Task 5). Each task includes failing test cases written first, implementation code with full context, and commit instructions.
- Defined precise interfaces and types: GlobalInstructionsChoice (tri-state), GlobalInstructionsDecision (outcome with optional persist field), resolveGlobalInstructionsDecision() pure resolver, and isAffirmative() for [Y/n] parsing. All are testable in isolation and reused across CLI and VS Code surfaces.
- Established the shared prompt string GLOBAL_INSTRUCTIONS_PROMPT as the single source of truth, exported from GlobalInstructionsInstaller.ts and consumed by both the CLI EnableCommand and the VS Code GlobalInstructionsPrompt service, preventing wording drift between surfaces.

**📁 FILES**
- `docs/superpowers/plans/2026-07-07-confirm-global-instructions.md`

</blockquote>
</details>
<details>
<summary><strong>08 · Critical regression in IntelliJ commit-info parsing breaks summary generation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

During the PR review of the git-op-queue migration to IntelliJ, a parsing bug was discovered in the new dispatchOp function that silently breaks commit summary generation for most real-world commits.

**💡 Decisions Behind the Code**

This was a copy-paste regression introduced during the refactor from runWorker to dispatchOp. The old code correctly used NUL splitting; the new code silently changed the separator without updating the parser. The existing test suite did not catch this because GitOpsRefDiffTest only asserts the output shape of getHeadCommitInfo, not the parsing logic inside dispatchOp. A unit test covering the parse step with real commit data would have prevented this.

**✅ What Was Implemented**

The dispatchOp function in PostCommitHook.kt was splitting commit info on space characters instead of NUL bytes. The git log format `--pretty=format:%H%x00%s%x00%an%x00%aI` uses NUL (0x00) as field separators, not spaces. This caused the hash, message, author, and date fields to be misaligned or truncated, resulting in either silent summary loss (when the subject has no spaces) or corrupted metadata (when it does). The fix is to change `split(" ")` to `split("\u0000")` to match the original working implementation.

**📋 Future Enhancements**

Add a unit test for dispatchOp parsing that exercises commits with multi-word subjects and verifies the four fields (hash, message, author, date) are correctly extracted.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 7, 2026 at 4:20 PM · via Anthropic*
<!-- jollimemory-summary-end -->
