### PR TITLE
Add historical back-fill (cold-start) to the IntelliJ plugin

### DIFF
--- a/.github/workflows/publish-intellij.yaml
+++ b/.github/workflows/publish-intellij.yaml
@@ -1,8 +1,30 @@
+# JolliMemory IntelliJ Plugin Release Workflow
+#
+# Authentication (all already configured as repo secrets):
+#   - CERTIFICATE_CHAIN — plugin signing certificate chain (chain.crt)
+#   - PRIVATE_KEY       — plugin signing private key (private.pem, unencrypted)
+#   - PUBLISH_TOKEN     — JetBrains Marketplace publish token (marketplace-token)
+#
+# Triggering: workflow_dispatch only. A human starts the run from the Actions
+# UI ("Run workflow"). It publishes the version currently in
+# intellij/build.gradle.kts on the ref you select in the branch dropdown — no
+# tag or version input. Pick the branch you want to ship from (e.g.
+# release/0.99.x) before clicking Run.
+#
+# NOTE: JetBrains Marketplace versions are immutable. Bump `version` in
+# intellij/build.gradle.kts before publishing — re-running with a version that
+# is already on the Marketplace will fail at the publishPlugin step.
+
 name: Publish to JetBrains Marketplace
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'If true, run all checks + build + sign but skip the actual Marketplace publish'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -11,8 +33,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    permissions:
-      contents: write   # gh release upload attaches the signed plugin to the release
+    concurrency:
+      group: release-intellij
+      cancel-in-progress: false
     defaults:
       run:
         working-directory: intellij
@@ -53,24 +76,49 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: npm run build
 
+      - name: Resolve plugin version from build.gradle.kts
+        id: meta
+        run: |
+          set -euo pipefail
+          VERSION="$(grep -E '^version = ' build.gradle.kts | head -1 | sed -E 's/^version = "(.*)"/\1/')"
+          if [ -z "${VERSION}" ]; then
+            echo "::error::could not resolve version from intellij/build.gradle.kts"
+            exit 1
+          fi
+          echo "Publishing IntelliJ plugin version ${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Run tests
         run: ./gradlew test
 
       - name: Build plugin
         run: ./gradlew buildPlugin
 
-      - name: Sign and publish plugin
+      - name: Sign plugin
+        env:
+          CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+        run: ./gradlew signPlugin
+
+      - name: Publish plugin to JetBrains Marketplace
+        if: inputs.dry_run != true
         env:
           CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
-        run: ./gradlew signPlugin publishPlugin
+        run: ./gradlew publishPlugin
 
-      - name: Upload signed plugin to release
+      - name: Dry-run summary
+        if: inputs.dry_run == true
         env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.event.release.tag_name }}
+          VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          gh release upload "${TAG}" \
-            build/distributions/*.zip \
-            --clobber
+          echo "::notice::DRY RUN — real run would publish IntelliJ plugin ${VERSION} to JetBrains Marketplace"
+          echo "All build + sign steps completed successfully."
+          echo "To perform the real release, re-run this workflow with dry_run=false."
+
+      - name: Upload signed plugin artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: jollimemory-intellij-${{ steps.meta.outputs.version }}
+          path: intellij/build/distributions/*.zip

--- a/cli/src/commands/BackfillCommand.test.ts
+++ b/cli/src/commands/BackfillCommand.test.ts
@@ -4,6 +4,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../backfill/BackfillEngine.js", () => ({
 	runBackfill: vi.fn(),
 	recentCommitHashes: vi.fn(),
+	repoHasAnyMemory: vi.fn(),
+	countMissingSummaries: vi.fn(),
+	listMissingCommits: vi.fn(),
 	DEFAULT_BACKFILL_TIER: "low",
 }));
 vi.mock("../Logger.js", () => ({
@@ -11,7 +14,13 @@ vi.mock("../Logger.js", () => ({
 	createLogger: () => ({ info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() }),
 }));
 
-import { recentCommitHashes, runBackfill } from "../backfill/BackfillEngine.js";
+import {
+	countMissingSummaries,
+	listMissingCommits,
+	recentCommitHashes,
+	repoHasAnyMemory,
+	runBackfill,
+} from "../backfill/BackfillEngine.js";
 import { registerBackfillCommand } from "./BackfillCommand.js";
 
 function makeProgram(): Command {
@@ -138,5 +147,63 @@ describe("jolli backfill command", () => {
 		await makeProgram().parseAsync(["backfill"], { from: "user" });
 		expect(process.exitCode).toBe(1);
 		expect(vi.mocked(runBackfill)).not.toHaveBeenCalled();
+	});
+
+	it("--hashes passes an explicit subset and skips recentCommitHashes", async () => {
+		vi.mocked(runBackfill).mockResolvedValue({ ...report, outcomes: [] });
+		await makeProgram().parseAsync(["backfill", "--hashes", " h1 , h2 ,,h3 "], { from: "user" });
+		expect(vi.mocked(recentCommitHashes)).not.toHaveBeenCalled();
+		expect(vi.mocked(runBackfill)).toHaveBeenCalledWith(expect.objectContaining({ hashes: ["h1", "h2", "h3"] }));
+	});
+
+	it("--hashes with only blanks falls back to the --last range", async () => {
+		vi.mocked(recentCommitHashes).mockResolvedValue(["h1"]);
+		vi.mocked(runBackfill).mockResolvedValue({ ...report, outcomes: [] });
+		await makeProgram().parseAsync(["backfill", "--hashes", " , ,"], { from: "user" });
+		expect(vi.mocked(recentCommitHashes)).toHaveBeenCalled();
+	});
+
+	it("--stream emits NDJSON progress events then a final report line", async () => {
+		vi.mocked(recentCommitHashes).mockResolvedValue(["h1", "h2"]);
+		vi.mocked(runBackfill).mockImplementation(async (opts) => {
+			opts.onProgress?.(1, 2, { commitHash: "h1", status: "generated" });
+			opts.onProgress?.(2, 2, { commitHash: "h2", status: "error", message: "boom" });
+			return report;
+		});
+		await makeProgram().parseAsync(["backfill", "--stream"], { from: "user" });
+		const lines = logSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+		const parsed = lines.map((l: string) => JSON.parse(l));
+		expect(parsed[0]).toMatchObject({ type: "progress", done: 1, total: 2 });
+		expect(parsed[1]).toMatchObject({ type: "progress", done: 2, total: 2 });
+		expect(parsed[2]).toMatchObject({ type: "report", generated: 1 });
+	});
+
+	it("--list-candidates emits cold-start signals as one JSON line and skips runBackfill", async () => {
+		vi.mocked(repoHasAnyMemory).mockResolvedValue(false);
+		vi.mocked(countMissingSummaries).mockResolvedValue({ missing: 3, total: 5 });
+		vi.mocked(listMissingCommits).mockResolvedValue([{ commitHash: "h1", subject: "fix x", ts: 1000 }]);
+
+		await makeProgram().parseAsync(
+			["backfill", "--cwd", "e:/r", "--list-candidates", "--since-days", "30", "--limit", "10"],
+			{ from: "user" },
+		);
+
+		expect(vi.mocked(runBackfill)).not.toHaveBeenCalled();
+		expect(vi.mocked(listMissingCommits)).toHaveBeenCalledWith("e:/r", 30 * 24 * 60 * 60 * 1000, 10);
+		const out = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
+		expect(JSON.parse(out)).toEqual({
+			hasAnyMemory: false,
+			total: 5,
+			missing: 3,
+			candidates: [{ commitHash: "h1", subject: "fix x", ts: 1000 }],
+		});
+	});
+
+	it("--list-candidates without --since-days passes undefined window", async () => {
+		vi.mocked(repoHasAnyMemory).mockResolvedValue(true);
+		vi.mocked(countMissingSummaries).mockResolvedValue({ missing: 0, total: 2 });
+		vi.mocked(listMissingCommits).mockResolvedValue([]);
+		await makeProgram().parseAsync(["backfill", "--list-candidates"], { from: "user" });
+		expect(vi.mocked(listMissingCommits)).toHaveBeenCalledWith(expect.any(String), undefined, undefined);
 	});
 });

--- a/cli/src/commands/BackfillCommand.test.ts
+++ b/cli/src/commands/BackfillCommand.test.ts
@@ -149,6 +149,15 @@ describe("jolli backfill command", () => {
 		expect(vi.mocked(runBackfill)).not.toHaveBeenCalled();
 	});
 
+	it("--stream with no commits emits an empty report and does NOT exit non-zero", async () => {
+		vi.mocked(recentCommitHashes).mockResolvedValue([]);
+		await makeProgram().parseAsync(["backfill", "--stream"], { from: "user" });
+		expect(process.exitCode).toBeUndefined();
+		expect(vi.mocked(runBackfill)).not.toHaveBeenCalled();
+		const out = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
+		expect(JSON.parse(out)).toMatchObject({ type: "report", total: 0, generated: 0, skipped: 0, errors: 0 });
+	});
+
 	it("--hashes passes an explicit subset and skips recentCommitHashes", async () => {
 		vi.mocked(runBackfill).mockResolvedValue({ ...report, outcomes: [] });
 		await makeProgram().parseAsync(["backfill", "--hashes", " h1 , h2 ,,h3 "], { from: "user" });

--- a/cli/src/commands/BackfillCommand.ts
+++ b/cli/src/commands/BackfillCommand.ts
@@ -5,19 +5,29 @@
  * attributing on-disk Claude transcripts to those commits offline. Fully
  * isolated from the live post-commit pipeline.
  *
- *   jolli backfill                       # last 20 commits, window-collect-all (low)
- *   jolli backfill --last 50             # last 50 commits
- *   jolli backfill --all                 # every commit reachable from HEAD
- *   jolli backfill --dry-run             # report attribution + confidence, no LLM call
- *   jolli backfill --min-confidence high # only file-overlap (high) attributions
+ *   jolli backfill                        # last 20 commits, window-collect-all (low)
+ *   jolli backfill --last 50              # last 50 commits
+ *   jolli backfill --all                  # every commit reachable from HEAD
+ *   jolli backfill --hashes h1,h2,h3      # an explicit commit subset (newest-first)
+ *   jolli backfill --dry-run              # report attribution + confidence, no LLM call
+ *   jolli backfill --min-confidence high  # only file-overlap (high) attributions
+ *   jolli backfill --stream               # NDJSON progress events + final report line
+ *   jolli backfill --list-candidates      # cold-start signals JSON (no LLM, no scan)
+ *
+ * The `--stream` and `--list-candidates` modes exist so out-of-process hosts
+ * (the IntelliJ plugin) can drive the same cold-start / progress UX the VS Code
+ * extension gets by calling the engine in-process.
  */
 
 import type { Command } from "commander";
 import {
 	type BackfillOutcome,
 	type BackfillReport,
+	countMissingSummaries,
 	DEFAULT_BACKFILL_TIER,
+	listMissingCommits,
 	recentCommitHashes,
+	repoHasAnyMemory,
 	runBackfill,
 } from "../backfill/BackfillEngine.js";
 import { setLogDir } from "../Logger.js";
@@ -29,14 +39,20 @@ interface BackfillCliOptions {
 	cwd: string;
 	last?: number;
 	all?: boolean;
+	hashes?: ReadonlyArray<string>;
 	dryRun?: boolean;
 	minConfidence?: MinConfidence;
 	format?: "json" | "text";
+	stream?: boolean;
+	listCandidates?: boolean;
+	sinceDays?: number;
+	limit?: number;
 }
 
 const DEFAULT_LAST = 20;
 /** Default tier is shared across all entry points (see DEFAULT_BACKFILL_TIER). */
 const DEFAULT_MIN_CONFIDENCE: MinConfidence = DEFAULT_BACKFILL_TIER;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 /** Commander parser for `--min-confidence`; rejects anything outside the tier set. */
 function parseMinConfidence(value: string): MinConfidence {
@@ -44,8 +60,19 @@ function parseMinConfidence(value: string): MinConfidence {
 	throw new Error(`--min-confidence must be one of: high, medium, low (got "${value}")`);
 }
 
+/** Commander parser for `--hashes`: splits a comma-separated list, dropping blanks. */
+function parseHashes(value: string): string[] {
+	return value
+		.split(",")
+		.map((h) => h.trim())
+		.filter((h) => h.length > 0);
+}
+
 /** Resolves the candidate commit hash list (newest-first) from the CLI options. */
 async function resolveHashes(opts: BackfillCliOptions): Promise<ReadonlyArray<string>> {
+	// An explicit `--hashes` subset wins over the --last/--all range (the UI passes
+	// exactly the commits the user selected in the cold-start card).
+	if (opts.hashes && opts.hashes.length > 0) return opts.hashes;
 	// Commander fills `last` with DEFAULT_LAST when the flag is omitted; `--all` drops the cap.
 	return recentCommitHashes(opts.cwd, opts.all ? undefined : opts.last);
 }
@@ -74,6 +101,28 @@ function renderText(report: BackfillReport, dryRun: boolean): string {
 	return lines.join("\n");
 }
 
+/**
+ * `--list-candidates` — emits cold-start signals as a single JSON line, without
+ * scanning transcripts or calling the LLM. This is the out-of-process sibling of
+ * the VS Code `computeColdStartSignals()` in-process call: `hasAnyMemory` +
+ * `missing`/`total` counts + the (windowed, capped) candidate rows the offer card
+ * renders. `--since-days` bounds the candidate window; `--limit` caps the rows.
+ */
+async function emitCandidates(opts: BackfillCliOptions): Promise<void> {
+	const hasAnyMemory = await repoHasAnyMemory(opts.cwd);
+	const counts = await countMissingSummaries(opts.cwd);
+	const sinceMs = typeof opts.sinceDays === "number" ? opts.sinceDays * MS_PER_DAY : undefined;
+	const candidates = await listMissingCommits(opts.cwd, sinceMs, opts.limit);
+	console.log(
+		JSON.stringify({
+			hasAnyMemory,
+			total: counts.total,
+			missing: counts.missing,
+			candidates,
+		}),
+	);
+}
+
 /** Registers the `backfill` command on the given Commander program. */
 export function registerBackfillCommand(program: Command): void {
 	program
@@ -82,6 +131,7 @@ export function registerBackfillCommand(program: Command): void {
 		.option("--cwd <dir>", "Project directory (default: git repo root)", resolveProjectDir())
 		.option("--last <n>", "Number of most recent commits to consider", parsePositiveInt, DEFAULT_LAST)
 		.option("--all", "Consider every commit reachable from HEAD")
+		.option("--hashes <list>", "Comma-separated commit hashes to back-fill (overrides --last/--all)", parseHashes)
 		.option("--dry-run", "Report attribution and confidence without calling the LLM")
 		.option(
 			"--min-confidence <tier>",
@@ -90,14 +140,33 @@ export function registerBackfillCommand(program: Command): void {
 			DEFAULT_MIN_CONFIDENCE,
 		)
 		.option("--format <fmt>", "Output format: text | json", "text")
+		.option("--stream", "Emit NDJSON progress events (one per commit) then a final report line")
+		.option("--list-candidates", "Emit cold-start signals as JSON (no attribution, no LLM) and exit")
+		.option("--since-days <n>", "For --list-candidates: only commits authored in the last N days", parsePositiveInt)
+		.option("--limit <n>", "For --list-candidates: cap the number of candidate rows", parsePositiveInt)
 		.action(async (opts: BackfillCliOptions) => {
 			setLogDir(opts.cwd);
+
+			if (opts.listCandidates) {
+				await emitCandidates(opts);
+				return;
+			}
+
 			const hashes = await resolveHashes(opts);
 			if (hashes.length === 0) {
 				console.error("  No commits found to back-fill.");
 				process.exitCode = 1;
 				return;
 			}
+
+			// `--stream` fires a NDJSON line per commit as the engine drains, so the
+			// host UI can advance a progress bar without waiting for the whole batch.
+			const onProgress = opts.stream
+				? (done: number, total: number, outcome: BackfillOutcome) => {
+						console.log(JSON.stringify({ type: "progress", done, total, outcome }));
+					}
+				: undefined;
+
 			const report = await runBackfill({
 				cwd: opts.cwd,
 				hashes,
@@ -105,8 +174,12 @@ export function registerBackfillCommand(program: Command): void {
 				// Commander fills `minConfidence` with DEFAULT_MIN_CONFIDENCE when the flag
 				// is omitted, so it is always a valid tier here.
 				minTier: opts.minConfidence,
+				onProgress,
 			});
-			if (opts.format === "json") {
+
+			if (opts.stream) {
+				console.log(JSON.stringify({ type: "report", ...report }));
+			} else if (opts.format === "json") {
 				console.log(JSON.stringify(report, null, 2));
 			} else {
 				console.log(renderText(report, Boolean(opts.dryRun)));

--- a/cli/src/commands/BackfillCommand.ts
+++ b/cli/src/commands/BackfillCommand.ts
@@ -154,6 +154,15 @@ export function registerBackfillCommand(program: Command): void {
 
 			const hashes = await resolveHashes(opts);
 			if (hashes.length === 0) {
+				// A machine consumer (`--stream`, e.g. the IntelliJ plugin) expects a terminal
+				// report even when there is nothing to do — a repo with no own-authored commits.
+				// Emit an empty report and exit 0 so the host renders "nothing to build" instead
+				// of a spurious "no report emitted (exit 1)". The human text path still errors.
+				if (opts.stream) {
+					const empty: BackfillReport = { total: 0, generated: 0, skipped: 0, errors: 0, outcomes: [] };
+					console.log(JSON.stringify({ type: "report", ...empty }));
+					return;
+				}
 				console.error("  No commits found to back-fill.");
 				process.exitCode = 1;
 				return;

--- a/cli/src/core/LlmClient.test.ts
+++ b/cli/src/core/LlmClient.test.ts
@@ -434,6 +434,86 @@ describe("LlmClient", () => {
 			);
 		});
 
+		// A streaming MessageStream whose finalMessage() rejects with [err]; when
+		// [received] is provided it fires the `message` event (as message_stop would),
+		// simulating "response fully arrived, then the socket close raced the iterator".
+		const rejectingStream = (err: unknown, received?: unknown) => ({
+			finalMessage: vi.fn().mockRejectedValue(err),
+			on: vi.fn((event: string, cb: (m: unknown) => void) => {
+				if (event === "message" && received !== undefined) cb(received);
+			}),
+			abort: vi.fn(),
+		});
+		const streamedMessage = {
+			content: [{ type: "text", text: "recovered response" }],
+			model: "claude-sonnet-4-6",
+			usage: { input_tokens: 1000, output_tokens: 5000 },
+			stop_reason: "end_turn",
+		};
+
+		it("recovers the received message when finalMessage() premature-closes after message_stop (Node 24)", async () => {
+			// Node 24's async-iterator teardown rejects finalMessage() with a premature
+			// close even though the full response arrived. The call must succeed by
+			// recovering the message captured from the `message` event, not fail.
+			const err = Object.assign(new Error("Premature close"), { code: "ERR_STREAM_PREMATURE_CLOSE" });
+			mockStream.mockReturnValueOnce(rejectingStream(err, streamedMessage));
+
+			const result = await callLlm({
+				action: "translate",
+				params: { content: "x" },
+				apiKey: "sk-ant-test",
+				maxTokens: 8192,
+			});
+
+			expect(result.text).toBe("recovered response");
+			expect(result.outputTokens).toBe(5000);
+			expect(mockLogWarn).toHaveBeenCalledWith(
+				expect.stringContaining("premature-close after the response completed"),
+				expect.any(String),
+				"translate",
+			);
+		});
+
+		it("recognizes a premature close nested in error.cause and recovers", async () => {
+			const err = Object.assign(new Error("fetch failed"), { cause: { code: "ERR_STREAM_PREMATURE_CLOSE" } });
+			mockStream.mockReturnValueOnce(rejectingStream(err, streamedMessage));
+			const result = await callLlm({
+				action: "translate",
+				params: { content: "x" },
+				apiKey: "sk-ant-test",
+				maxTokens: 8192,
+			});
+			expect(result.text).toBe("recovered response");
+		});
+
+		it("recognizes a premature close by message text (no code) and recovers", async () => {
+			mockStream.mockReturnValueOnce(rejectingStream(new Error("terminated: Premature close"), streamedMessage));
+			const result = await callLlm({
+				action: "translate",
+				params: { content: "x" },
+				apiKey: "sk-ant-test",
+				maxTokens: 8192,
+			});
+			expect(result.text).toBe("recovered response");
+		});
+
+		it("does not recover a non-premature streaming error even if a message was received", async () => {
+			// A 500 is a real failure; recovering the partial message would mask it.
+			const err = Object.assign(new Error("500 server error"), { status: 500 });
+			mockStream.mockReturnValueOnce(rejectingStream(err, streamedMessage));
+			await expect(
+				callLlm({ action: "translate", params: { content: "x" }, apiKey: "sk-ant-test", maxTokens: 8192 }),
+			).rejects.toThrow("500 server error");
+		});
+
+		it("rethrows a premature close when no message was received (genuine truncation)", async () => {
+			const err = Object.assign(new Error("Premature close"), { code: "ERR_STREAM_PREMATURE_CLOSE" });
+			mockStream.mockReturnValueOnce(rejectingStream(err)); // no `message` event → nothing to recover
+			await expect(
+				callLlm({ action: "translate", params: { content: "x" }, apiKey: "sk-ant-test", maxTokens: 8192 }),
+			).rejects.toThrow(/premature close/i);
+		});
+
 		it("uses streaming when maxTokens exceeds the SDK's non-streaming guardrail", async () => {
 			// The Anthropic SDK refuses non-streaming requests whose estimated
 			// duration exceeds 10 minutes. The topic-KB `reconcile` action raises

--- a/cli/src/core/LlmClient.ts
+++ b/cli/src/core/LlmClient.ts
@@ -338,6 +338,20 @@ export function isLlmCredentialError(err: unknown): err is LlmCredentialError {
 }
 
 /** Direct mode: call Anthropic SDK locally */
+/**
+ * True for the Node ≥24 async-iterator teardown error the Anthropic SDK surfaces from
+ * `stream.finalMessage()` when the HTTP connection closes right after the final SSE event.
+ * Matched by `code` (ERR_STREAM_PREMATURE_CLOSE) or message text, on the error or its `cause`
+ * (undici nests the transport reason there). Kept narrow so only this specific spurious close
+ * is recovered — genuine transport failures still propagate.
+ */
+function isPrematureClose(err: unknown): boolean {
+	const e = err as { code?: unknown; message?: unknown; cause?: { code?: unknown; message?: unknown } };
+	if (e?.code === "ERR_STREAM_PREMATURE_CLOSE" || e?.cause?.code === "ERR_STREAM_PREMATURE_CLOSE") return true;
+	const text = `${String(e?.message ?? "")} ${String(e?.cause?.message ?? "")}`.toLowerCase();
+	return text.includes("premature close");
+}
+
 async function callDirect(
 	options: LlmCallOptions,
 	apiKey: string,
@@ -412,6 +426,17 @@ async function callDirect(
 			// while a wedged socket produces nothing and is aborted — restoring the
 			// fail-fast guarantee without capping valid long responses.
 			const stream = client.messages.stream(body);
+			// Node 24's async-iterator teardown can make `finalMessage()` reject with
+			// ERR_STREAM_PREMATURE_CLOSE *after* the full response was already received (the
+			// `message_stop` event fired) — the socket close races the iterator's own end.
+			// Capture the completed message from the `message` event (emitted on message_stop)
+			// so a call that actually succeeded is recovered rather than failed. VS Code never
+			// hit this because its extension host runs on Electron's Node 22; the IntelliJ
+			// plugin shells out to the user's system Node (24+), which does.
+			let receivedMessage: Anthropic.Message | undefined;
+			stream.on("message", (m) => {
+				receivedMessage = m;
+			});
 			let idleTimer: ReturnType<typeof setTimeout> | undefined;
 			const armIdleWatchdog = (): void => {
 				clearTimeout(idleTimer);
@@ -427,6 +452,20 @@ async function callDirect(
 			hardTimer.unref?.();
 			try {
 				response = await stream.finalMessage();
+			} catch (streamErr) {
+				// Only recover when the message genuinely completed (message_stop → `message`
+				// event). A premature close with no received message is a real truncation and
+				// must propagate so the caller retries.
+				if (receivedMessage !== undefined && isPrematureClose(streamErr)) {
+					log.warn(
+						"stream.finalMessage() threw a premature-close after the response completed; recovering the received message (Node %s async-iterator teardown). action=%s",
+						process.version,
+						options.action,
+					);
+					response = receivedMessage;
+				} else {
+					throw streamErr;
+				}
 			} finally {
 				clearTimeout(idleTimer);
 				clearTimeout(hardTimer);

--- a/intellij/CHANGELOG.md
+++ b/intellij/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### New Features
 
 - **Build memory from your history** — open a repository that has no memory yet (or has recent commits without one) and a **BUILD MEMORY** card now offers to generate summaries for those past commits. Pick which commits to reconstruct — each row shows how many AI conversations were attributed to it — then watch per-commit progress and a final summary. Run a full back-fill any time from **Settings → Memory Bank → Generate Missing Summaries**, and dismiss the card per repository (the choice is shared with the VS Code extension, so a dismiss in one is honored in the other).
+- **Share a memory to Jolli** — share an individual commit memory to your Jolli site straight from the memory detail view via an inline overlay (no separate dialog). Creating a pull request continues to share that PR's memories in the same step, so sharing works at both the single-memory and the PR level.
+- **Token usage & estimated cost** — the memory detail view and the Committed Memories list now show token usage (input / output / cached) and an estimated USD cost — your stored per-model figure when available, otherwise a Sonnet-rate estimate for token-only memories — aggregated across squash/amend trees. The same **Task usage** line is now included in the memory you share or export to Jolli, so the cost estimate travels with the memory.
 - **Resume a Codex session** — Codex conversations can now be resumed directly, using the correct session-ID lookup.
 
 ### Changes

--- a/intellij/CHANGELOG.md
+++ b/intellij/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changes
 
 - **Force-push protection** — the push and Create PR flows now detect when the remote branch has been rewritten (a non-fast-forward) and gate the force-push behind a confirmation; the git checks run off the UI thread so the IDE stays responsive.
+- **Minimum IDE is now IntelliJ IDEA 2025.1** (build 251). This lets the plugin use current, non-deprecated platform APIs (e.g. the file-save dialog), clearing a Marketplace compatibility warning.
 
 ### Fixes & Improvements
 

--- a/intellij/CHANGELOG.md
+++ b/intellij/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.99.5
+
+### New Features
+
+- **Build memory from your history** — open a repository that has no memory yet (or has recent commits without one) and a **BUILD MEMORY** card now offers to generate summaries for those past commits. Pick which commits to reconstruct — each row shows how many AI conversations were attributed to it — then watch per-commit progress and a final summary. Run a full back-fill any time from **Settings → Memory Bank → Generate Missing Summaries**, and dismiss the card per repository (the choice is shared with the VS Code extension, so a dismiss in one is honored in the other).
+- **Resume a Codex session** — Codex conversations can now be resumed directly, using the correct session-ID lookup.
+
+### Changes
+
+- **Force-push protection** — the push and Create PR flows now detect when the remote branch has been rewritten (a non-fast-forward) and gate the force-push behind a confirmation; the git checks run off the UI thread so the IDE stays responsive.
+
+### Fixes & Improvements
+
+- **Self-healing MCP config** — `.mcp.json` is repaired automatically when it points at an extension dist that has been removed.
+- Fixed a NUL-delimiter parsing bug in the IntelliJ post-commit hook.
+
 ## 0.99.4
 
 ### New Features

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -34,12 +34,14 @@ val hooksRuntime: Configuration by configurations.creating
 
 dependencies {
     intellijPlatform {
-        intellijIdeaCommunity("2024.3")
+        // 2025.1 is the minimum: the non-deprecated FileSaverDescriptor(title, description) +
+        // withExtensionFilter API only exists from 2025.1 (2024.3 had only the vararg ctor that
+        // 2025.1 deprecates), so building against 2025.1 lets us avoid the deprecated API.
+        intellijIdeaCommunity("2025.1")
         bundledPlugin("com.intellij.java")
         bundledPlugin("Git4Idea")
         bundledPlugin("org.jetbrains.plugins.terminal")
         pluginVerifier()
-        instrumentationTools()
         // Use the JetBrains Runtime for runIde/tests so JCEF is available — the
         // commit-memory panel renders via JBCefBrowser and otherwise falls back to
         // a raw-markdown text view (e.g. when launched on a plain Homebrew JDK).
@@ -174,15 +176,18 @@ intellijPlatform {
             email = "support@jolli.ai"
         }
         ideaVersion {
-            sinceBuild = "243"
+            sinceBuild = "251"
             untilBuild = "262.*"
         }
     }
 
     pluginVerification {
+        // Verify the supported range only (sinceBuild = 251). 2024.3 was dropped because the
+        // non-deprecated FileSaverDescriptor API doesn't exist before 2025.1. Cover the low end
+        // (2025.1) and a recent build so both ends of 251–262.* are checked.
         ides {
-            ide(IntelliJPlatformType.IntellijIdeaCommunity, "2024.3")
             ide(IntelliJPlatformType.IntellijIdeaCommunity, "2025.1.3")
+            ide(IntelliJPlatformType.IntellijIdeaCommunity, "2025.2")
         }
     }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/JolliMemoryIcons.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/JolliMemoryIcons.kt
@@ -30,6 +30,9 @@ object JolliMemoryIcons {
     /** Sparkle — matches VSCode codicon "sparkle" for AI commit. */
     val Sparkle: Icon = IconLoader.getIcon("/icons/sparkle.svg", JolliMemoryIcons::class.java)
 
+    /** Database cylinder — matches VSCode codicon "database" for the back-fill build action. */
+    val Database: Icon = IconLoader.getIcon("/icons/database.svg", JolliMemoryIcons::class.java)
+
     /** Git merge — matches VSCode codicon "git-merge" for squash. */
     val GitMerge: Icon = IconLoader.getIcon("/icons/git-merge.svg", JolliMemoryIcons::class.java)
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/backfill/BackfillCli.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/backfill/BackfillCli.kt
@@ -203,10 +203,18 @@ object BackfillCli {
 			var report: Report? = null
 			val acted = ArrayList<Progress>()
 			var cancelled = false
+			// Keep the last few non-JSON lines (stderr merged in) so a genuine failure surfaces
+			// the real reason instead of a bare exit code.
+			val diagnostics = ArrayDeque<String>()
 			proc.inputStream.bufferedReader(Charsets.UTF_8).useLines { lines ->
 				for (line in lines) {
 					val trimmed = line.trim()
-					if (trimmed.isEmpty() || !trimmed.startsWith("{")) continue
+					if (trimmed.isEmpty()) continue
+					if (!trimmed.startsWith("{")) {
+						diagnostics.addLast(trimmed)
+						while (diagnostics.size > 5) diagnostics.removeFirst()
+						continue
+					}
 					val obj = try {
 						JsonParser.parseString(trimmed).asJsonObject
 					} catch (_: Exception) {
@@ -232,7 +240,11 @@ object BackfillCli {
 				proc.destroyForcibly()
 				return Outcome.Failed("back-fill timed out")
 			}
-			report?.let { Outcome.Ok(it) } ?: Outcome.Failed("no report emitted (exit ${proc.exitValue()})")
+			report?.let { Outcome.Ok(it) } ?: run {
+				val detail = diagnostics.lastOrNull()?.let { ": $it" } ?: ""
+				log.warn("backfill emitted no report (exit %d)%s", proc.exitValue(), detail)
+				Outcome.Failed("back-fill did not complete (exit ${proc.exitValue()})$detail")
+			}
 		} catch (e: Exception) {
 			log.warn("backfill run failed: %s", e.message)
 			Outcome.Failed(e.message ?: "unknown error")

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/backfill/BackfillCli.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/backfill/BackfillCli.kt
@@ -84,18 +84,24 @@ object BackfillCli {
 	}
 
 	/**
-	 * Resolves a runnable `Cli.js`, preferring the already-extracted integrations dist
-	 * (`~/.jolli/jollimemory/dist-intellij/Cli.js`) so a normal back-fill never re-copies
-	 * the bundle. Falls back to extracting it, then to the plugin-bundled copy.
+	 * Resolves a runnable `Cli.js`, preferring the plugin's OWN bundled copy
+	 * (`<plugin>/cli-dist/Cli.js`) because it always matches the running plugin's code —
+	 * it therefore always understands the CLI flags this class emits (`--list-candidates`,
+	 * `--stream`, …).
+	 *
+	 * We deliberately do NOT prefer the extracted `~/.jolli/jollimemory/dist-intellij/Cli.js`:
+	 * that copy is refreshed only on a plugin **version change** (via `enableIntegrations`),
+	 * so a same-version rebuild — or an upgrade whose bundled CLI gained new flags without a
+	 * matching re-extract — leaves it stale. A stale copy silently rejects the new flags
+	 * (exit 1), which manifests as "the cold-start card never appears." The extracted dist
+	 * exists for the hook/MCP dispatch indirection, not for the plugin's own subprocess
+	 * calls; it is only a fallback here for the rare layout where the bundle can't be found.
 	 */
 	private fun resolveCliJs(): File? {
+		CliIntegrations.resolveBundledCliJs()?.let { return it }
 		val installed = File(CliIntegrations.distIntellijDir(), "Cli.js")
 		if (installed.exists()) return installed
-		CliIntegrations.extractCliDist()?.let { dist ->
-			val f = File(dist, "Cli.js")
-			if (f.exists()) return f
-		}
-		return CliIntegrations.resolveBundledCliJs()
+		return CliIntegrations.extractCliDist()?.let { File(it, "Cli.js").takeIf(File::exists) }
 	}
 
 	/** Common prefix `[node, Cli.js, "backfill"]`, or an Outcome explaining why it can't run. */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/backfill/BackfillCli.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/backfill/BackfillCli.kt
@@ -1,0 +1,302 @@
+package ai.jolli.jollimemory.backfill
+
+import ai.jolli.jollimemory.bridge.CliIntegrations
+import ai.jolli.jollimemory.core.JmLogger
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * BackfillCli — out-of-process bridge to the `jolli backfill` engine.
+ *
+ * The VS Code extension bundles the CLI and calls `runBackfill` / `listMissingCommits`
+ * in-process. The IntelliJ plugin generates memory with native Java hooks and has no
+ * in-process JS runtime, so it drives the SAME engine over the CLI's subprocess
+ * surface (see cli/src/commands/BackfillCommand.ts):
+ *
+ *   - [listCandidates] → `jolli backfill --list-candidates` (cold-start signals, no LLM)
+ *   - [preview]        → `jolli backfill --hashes … --dry-run` (per-commit session/turn
+ *                        counts for the selectable list, no LLM)
+ *   - [run]            → `jolli backfill --hashes … --stream` (real generation, one NDJSON
+ *                        progress line per commit)
+ *
+ * Node + the bundled `Cli.js` are resolved via [CliIntegrations] (the same resolution
+ * the MCP/skills enable path uses), so a machine without Node degrades to
+ * [Outcome.NodeMissing] rather than crashing — memory generation itself never needs it.
+ */
+object BackfillCli {
+
+	private val log = JmLogger.create("BackfillCli")
+
+	/** A commit that lacks a summary — mirrors the CLI's `MissingCommitInfo`. */
+	data class Candidate(
+		val commitHash: String,
+		val subject: String,
+		val ts: Long,
+		/** Attributed AI conversations (0 = diff-only). Populated by [preview], else 0. */
+		val sessions: Int = 0,
+		/** User-initiated turns across those conversations. Populated by [preview], else 0. */
+		val conversationTurns: Int = 0,
+	)
+
+	/** Cold-start signals from `--list-candidates` (the offer card's inputs). */
+	data class ColdStartSignals(
+		val hasAnyMemory: Boolean,
+		val total: Int,
+		val missing: Int,
+		val candidates: List<Candidate>,
+	)
+
+	/** One per-commit progress event from `--stream`. */
+	data class Progress(
+		val done: Int,
+		val total: Int,
+		val commitHash: String,
+		val subject: String,
+		val status: String,
+		val sessions: Int,
+		val topics: Int,
+	)
+
+	/** Final tally from a `--stream` run (or a `--dry-run` report). */
+	data class Report(
+		val total: Int,
+		val generated: Int,
+		val skipped: Int,
+		val errors: Int,
+		/** Only the acted-on rows (generated / error), for the card's done view. */
+		val rows: List<Progress>,
+	)
+
+	/** Result of a subprocess call: success, or a reason the engine could not run. */
+	sealed class Outcome<out T> {
+		data class Ok<T>(val value: T) : Outcome<T>()
+
+		/** Node is not on PATH — back-fill is unavailable (memory generation still works). */
+		object NodeMissing : Outcome<Nothing>()
+
+		/** The bundled `Cli.js` could not be located (packaging problem). */
+		object BundleMissing : Outcome<Nothing>()
+
+		/** The CLI ran but failed (non-zero exit, timeout, or malformed output). */
+		data class Failed(val message: String) : Outcome<Nothing>()
+	}
+
+	/**
+	 * Resolves a runnable `Cli.js`, preferring the already-extracted integrations dist
+	 * (`~/.jolli/jollimemory/dist-intellij/Cli.js`) so a normal back-fill never re-copies
+	 * the bundle. Falls back to extracting it, then to the plugin-bundled copy.
+	 */
+	private fun resolveCliJs(): File? {
+		val installed = File(CliIntegrations.distIntellijDir(), "Cli.js")
+		if (installed.exists()) return installed
+		CliIntegrations.extractCliDist()?.let { dist ->
+			val f = File(dist, "Cli.js")
+			if (f.exists()) return f
+		}
+		return CliIntegrations.resolveBundledCliJs()
+	}
+
+	/** Common prefix `[node, Cli.js, "backfill"]`, or an Outcome explaining why it can't run. */
+	private fun baseCommand(): Pair<List<String>, Outcome<Nothing>?> {
+		val node = CliIntegrations.resolveNode() ?: return emptyList<String>() to Outcome.NodeMissing
+		val cliJs = resolveCliJs() ?: return emptyList<String>() to Outcome.BundleMissing
+		return listOf(node, cliJs.absolutePath, "backfill") to null
+	}
+
+	/**
+	 * `jolli backfill --list-candidates` — cold-start signals only (no attribution, no LLM).
+	 * [sinceDays]/[limit] bound + cap the candidate rows (the offer card uses 30 / 10).
+	 */
+	fun listCandidates(projectDir: String, sinceDays: Int? = null, limit: Int? = null): Outcome<ColdStartSignals> {
+		val (base, err) = baseCommand()
+		if (err != null) return err
+		val args = base.toMutableList()
+		args.add("--list-candidates")
+		args.add("--cwd"); args.add(projectDir)
+		if (sinceDays != null) { args.add("--since-days"); args.add(sinceDays.toString()) }
+		if (limit != null) { args.add("--limit"); args.add(limit.toString()) }
+		return capture(args, projectDir, timeoutSeconds = 30) { out ->
+			val obj = JsonParser.parseString(out.trim()).asJsonObject
+			ColdStartSignals(
+				hasAnyMemory = obj.bool("hasAnyMemory"),
+				total = obj.int("total"),
+				missing = obj.int("missing"),
+				candidates = obj.getAsJsonArray("candidates")?.map { parseCandidate(it.asJsonObject) } ?: emptyList(),
+			)
+		}
+	}
+
+	/**
+	 * `jolli backfill --hashes … --dry-run` — enriches the selectable list with per-commit
+	 * session/turn counts without an LLM call. Returns candidates in the SAME order as
+	 * [hashes], each carrying its dry-run `sessions` / `conversationTurns` (0 when the
+	 * dry-run could not attribute a commit, so the list never contradicts the offer count).
+	 */
+	fun preview(projectDir: String, candidates: List<Candidate>): Outcome<List<Candidate>> {
+		if (candidates.isEmpty()) return Outcome.Ok(emptyList())
+		val (base, err) = baseCommand()
+		if (err != null) return err
+		val args = base.toMutableList()
+		args.add("--hashes"); args.add(candidates.joinToString(",") { it.commitHash })
+		args.add("--dry-run")
+		args.add("--format"); args.add("json")
+		args.add("--cwd"); args.add(projectDir)
+		return capture(args, projectDir, timeoutSeconds = 120) { out ->
+			val report = JsonParser.parseString(out.trim()).asJsonObject
+			val byHash = HashMap<String, JsonObject>()
+			report.getAsJsonArray("outcomes")?.forEach { el ->
+				val o = el.asJsonObject
+				byHash[o.str("commitHash")] = o
+			}
+			candidates.map { c ->
+				val o = byHash[c.commitHash]
+				c.copy(
+					sessions = o?.int("sessions") ?: 0,
+					conversationTurns = o?.int("conversationTurns") ?: 0,
+				)
+			}
+		}
+	}
+
+	/**
+	 * `jolli backfill --hashes … --stream` — real generation. Emits one [Progress] per commit
+	 * (via [onProgress]) as the engine drains, then returns the final [Report]. [shouldCancel]
+	 * is polled after each event; when it flips true the subprocess is killed and the call
+	 * returns [Outcome.Failed] ("cancelled").
+	 *
+	 * An empty [hashes] means FULL SCOPE (`--all`): every own commit reachable from HEAD that
+	 * lacks a summary — the Settings "Generate Missing Summaries" path. A non-empty list backs
+	 * the cold-start card's selection.
+	 */
+	fun run(
+		projectDir: String,
+		hashes: List<String>,
+		onProgress: (Progress) -> Unit,
+		shouldCancel: () -> Boolean = { false },
+	): Outcome<Report> {
+		val (base, err) = baseCommand()
+		if (err != null) return err
+		val args = base.toMutableList()
+		if (hashes.isEmpty()) {
+			args.add("--all")
+		} else {
+			args.add("--hashes"); args.add(hashes.joinToString(","))
+		}
+		args.add("--stream")
+		args.add("--cwd"); args.add(projectDir)
+		return try {
+			// Merge stderr into stdout: the CLI routes its logs to a file (setLogDir), so
+			// stdout is the NDJSON stream; any stray stderr line simply fails to parse and
+			// is skipped. Merging also removes the two-pipe deadlock risk (no unread pipe).
+			val proc = ProcessBuilder(args)
+				.directory(File(projectDir))
+				.redirectErrorStream(true)
+				.start()
+			var report: Report? = null
+			val acted = ArrayList<Progress>()
+			var cancelled = false
+			proc.inputStream.bufferedReader(Charsets.UTF_8).useLines { lines ->
+				for (line in lines) {
+					val trimmed = line.trim()
+					if (trimmed.isEmpty() || !trimmed.startsWith("{")) continue
+					val obj = try {
+						JsonParser.parseString(trimmed).asJsonObject
+					} catch (_: Exception) {
+						continue
+					}
+					when (obj.str("type")) {
+						"progress" -> {
+							val p = parseProgress(obj)
+							if (p.status == "generated" || p.status == "error") acted.add(p)
+							onProgress(p)
+						}
+						"report" -> report = parseReport(obj, acted)
+					}
+					if (shouldCancel()) {
+						cancelled = true
+						proc.destroyForcibly()
+						break
+					}
+				}
+			}
+			if (cancelled) return Outcome.Failed("cancelled")
+			if (!proc.waitFor(30, TimeUnit.MINUTES)) {
+				proc.destroyForcibly()
+				return Outcome.Failed("back-fill timed out")
+			}
+			report?.let { Outcome.Ok(it) } ?: Outcome.Failed("no report emitted (exit ${proc.exitValue()})")
+		} catch (e: Exception) {
+			log.warn("backfill run failed: %s", e.message)
+			Outcome.Failed(e.message ?: "unknown error")
+		}
+	}
+
+	/** Runs [args], captures full stdout, and maps a zero-exit result through [parse]. */
+	private fun <T> capture(
+		args: List<String>,
+		projectDir: String,
+		timeoutSeconds: Long,
+		parse: (String) -> T,
+	): Outcome<T> {
+		return try {
+			val proc = ProcessBuilder(args)
+				.directory(File(projectDir))
+				.redirectErrorStream(false)
+				.start()
+			val out = proc.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+			if (!proc.waitFor(timeoutSeconds, TimeUnit.SECONDS)) {
+				proc.destroyForcibly()
+				return Outcome.Failed("command timed out")
+			}
+			if (proc.exitValue() != 0) {
+				val stderr = proc.errorStream.bufferedReader(Charsets.UTF_8).use { it.readText().trim() }
+				log.warn("backfill exit=%d: %s", proc.exitValue(), stderr.take(200))
+				return Outcome.Failed(if (stderr.isNotBlank()) stderr.take(200) else "exit ${proc.exitValue()}")
+			}
+			Outcome.Ok(parse(out))
+		} catch (e: Exception) {
+			log.warn("backfill command failed: %s", e.message)
+			Outcome.Failed(e.message ?: "unknown error")
+		}
+	}
+
+	private fun parseCandidate(o: JsonObject): Candidate =
+		Candidate(commitHash = o.str("commitHash"), subject = o.str("subject"), ts = o.long("ts"))
+
+	private fun parseProgress(o: JsonObject): Progress {
+		val outcome = o.getAsJsonObject("outcome") ?: JsonObject()
+		val hash = outcome.str("commitHash")
+		val subject = outcome.strOrNull("commitSubject")?.takeIf { it.isNotBlank() } ?: hash.take(8)
+		return Progress(
+			done = o.int("done"),
+			total = o.int("total"),
+			commitHash = hash,
+			subject = subject,
+			status = outcome.str("status"),
+			sessions = outcome.int("sessions"),
+			topics = outcome.int("topics"),
+		)
+	}
+
+	private fun parseReport(o: JsonObject, rows: List<Progress>): Report =
+		Report(
+			total = o.int("total"),
+			generated = o.int("generated"),
+			skipped = o.int("skipped"),
+			errors = o.int("errors"),
+			rows = rows,
+		)
+
+	// --- Gson null-safe accessors (the engine omits absent optional fields) ---
+	private fun JsonObject.str(key: String): String = strOrNull(key) ?: ""
+	private fun JsonObject.strOrNull(key: String): String? =
+		get(key)?.takeIf { !it.isJsonNull }?.asString
+	private fun JsonObject.int(key: String): Int =
+		get(key)?.takeIf { !it.isJsonNull }?.asInt ?: 0
+	private fun JsonObject.long(key: String): Long =
+		get(key)?.takeIf { !it.isJsonNull }?.asLong ?: 0L
+	private fun JsonObject.bool(key: String): Boolean =
+		get(key)?.takeIf { !it.isJsonNull }?.asBoolean ?: false
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/backfill/BackfillDismissFlag.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/backfill/BackfillDismissFlag.kt
@@ -1,0 +1,67 @@
+package ai.jolli.jollimemory.backfill
+
+import ai.jolli.jollimemory.bridge.GitOps
+import ai.jolli.jollimemory.core.JmLogger
+import java.io.File
+
+/**
+ * BackfillDismissFlag — repo-wide marker for "user dismissed the back-fill cold-start
+ * card in this repository." Kotlin port of vscode/src/services/BackfillDismissFlag.ts;
+ * both surfaces MUST use the same path so a dismiss in one is honored in the other.
+ *
+ * Stored under the **shared git common dir** (`git rev-parse --git-common-dir`, the one
+ * `.git` every worktree of a repo points at) at
+ * `<git-common-dir>/jollimemory/backfill-card-dismissed`. Deliberately REPO-WIDE, not
+ * per-worktree: the cold-start decision itself is repo-wide (`repoHasAnyMemory` reads the
+ * shared orphan branch), so dismissing in one worktree must suppress the card in every
+ * worktree of the same repo. It is inherently local + untracked (nothing under `.git` is
+ * committed).
+ *
+ * Marker semantics: the file's *existence* is the boolean. The body holds a millisecond
+ * timestamp for human debugging. Once a back-fill generates a memory the marker is cleared
+ * (see the cold-start panel's done handling) so a future fresh-empty transition re-shows it.
+ */
+object BackfillDismissFlag {
+
+	private const val FILE_NAME = "backfill-card-dismissed"
+	private val log = JmLogger.create("BackfillDismissFlag")
+
+	/**
+	 * `<git-common-dir>/jollimemory/backfill-card-dismissed`, or null when the common dir
+	 * can't be resolved (not a git repo) — the card never shows there anyway.
+	 */
+	private fun markerFile(projectDir: String): File? {
+		val common = GitOps(projectDir).exec("rev-parse", "--git-common-dir")?.trim()
+		if (common.isNullOrBlank()) return null
+		val base = File(common)
+		val dir = if (base.isAbsolute) base else File(projectDir, common)
+		return File(File(dir, "jollimemory"), FILE_NAME)
+	}
+
+	/** True iff the dismiss marker exists for this repo. */
+	fun isDismissed(projectDir: String): Boolean =
+		try {
+			markerFile(projectDir)?.exists() ?: false
+		} catch (e: Exception) {
+			log.warn("isDismissed failed: %s", e.message)
+			false
+		}
+
+	/**
+	 * Sets the marker. `dismissed=true` writes the file (creating the directory if needed);
+	 * `dismissed=false` removes it (no-op if already absent).
+	 */
+	fun setDismissed(projectDir: String, dismissed: Boolean) {
+		try {
+			val file = markerFile(projectDir) ?: return
+			if (dismissed) {
+				file.parentFile?.mkdirs()
+				file.writeText(System.currentTimeMillis().toString())
+			} else if (file.exists()) {
+				file.delete()
+			}
+		} catch (e: Exception) {
+			log.warn("setDismissed failed: %s", e.message)
+		}
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/backfill/BackfillRunner.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/backfill/BackfillRunner.kt
@@ -1,0 +1,137 @@
+package ai.jolli.jollimemory.backfill
+
+import ai.jolli.jollimemory.core.JmLogger
+import ai.jolli.jollimemory.services.JolliMemoryService
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.Project
+
+/**
+ * BackfillRunner — the single background entry point for generating summaries over
+ * historical commits, shared by BOTH the tool-window cold-start card and the Settings
+ * "Generate Missing Summaries" button. Kotlin analog of the VS Code extension's shared
+ * `runBackfillJob` (vscode/src/Extension.ts): it drives [BackfillCli.run] inside an
+ * IntelliJ [Task.Backgroundable] (cancellable, with a determinate progress bar), then
+ * updates cold-start bookkeeping and shows a completion balloon.
+ */
+object BackfillRunner {
+
+	private val log = JmLogger.create("BackfillRunner")
+
+	/**
+	 * Runs a back-fill in the background.
+	 *
+	 * @param hashes commit subset to generate; EMPTY means full scope (every own commit
+	 *   lacking a summary) — the Settings path.
+	 * @param onProgress optional per-commit callback on the EDT (the card's inline list).
+	 * @param onComplete optional completion callback on the EDT with the final report
+	 *   (null when the engine could not run — see the balloon for the reason).
+	 */
+	fun run(
+		project: Project,
+		service: JolliMemoryService,
+		hashes: List<String>,
+		onProgress: ((BackfillCli.Progress) -> Unit)? = null,
+		onComplete: ((BackfillCli.Report?) -> Unit)? = null,
+	) {
+		val cwd = service.mainRepoRoot ?: project.basePath
+		if (cwd == null) {
+			onComplete?.let { ApplicationManager.getApplication().invokeLater { it(null) } }
+			return
+		}
+		ProgressManager.getInstance().run(object : Task.Backgroundable(project, "Jolli Memory: Back-filling summaries", true) {
+			override fun run(indicator: ProgressIndicator) {
+				indicator.isIndeterminate = false
+				val outcome = BackfillCli.run(
+					projectDir = cwd,
+					hashes = hashes,
+					onProgress = { p ->
+						if (p.total > 0) indicator.fraction = p.done.toDouble() / p.total
+						indicator.text = "${p.done}/${p.total} — ${label(p.subject)}${if (p.status == "error") " (failed)" else ""}"
+						onProgress?.let { cb -> ApplicationManager.getApplication().invokeLater { cb(p) } }
+					},
+					shouldCancel = { indicator.isCanceled },
+				)
+				ApplicationManager.getApplication().invokeLater { finish(project, service, outcome, onComplete) }
+			}
+		})
+	}
+
+	private fun finish(
+		project: Project,
+		service: JolliMemoryService,
+		outcome: BackfillCli.Outcome<BackfillCli.Report>,
+		onComplete: ((BackfillCli.Report?) -> Unit)?,
+	) {
+		when (outcome) {
+			is BackfillCli.Outcome.Ok -> {
+				val r = outcome.value
+				service.onBackfillCompleted(r.generated > 0)
+				// Refresh the surfaces that render summary state (Committed Memories list, etc.).
+				service.notifyMemoryStateChanged()
+				if (r.errors > 0) {
+					notify(
+						project,
+						"Jolli Memory: back-fill finished with errors",
+						"${r.generated} generated, ${r.skipped} skipped, ${r.errors} error(s).",
+						NotificationType.WARNING,
+					)
+				} else {
+					notify(
+						project,
+						"Jolli Memory: back-fill complete",
+						"${r.generated} summary(ies) generated, ${r.skipped} already had one.",
+						NotificationType.INFORMATION,
+					)
+				}
+				onComplete?.invoke(r)
+			}
+			is BackfillCli.Outcome.NodeMissing -> {
+				notify(
+					project,
+					"Jolli Memory: back-fill unavailable",
+					"Node.js was not found on your PATH — historical summaries need it to run. " +
+						"Install Node.js and reopen the project.",
+					NotificationType.WARNING,
+				)
+				onComplete?.invoke(null)
+			}
+			is BackfillCli.Outcome.BundleMissing -> {
+				notify(
+					project,
+					"Jolli Memory: back-fill unavailable",
+					"The bundled CLI could not be located — try reinstalling the Jolli Memory plugin.",
+					NotificationType.WARNING,
+				)
+				onComplete?.invoke(null)
+			}
+			is BackfillCli.Outcome.Failed -> {
+				log.warn("back-fill failed: %s", outcome.message)
+				if (outcome.message != "cancelled") {
+					notify(
+						project,
+						"Jolli Memory: back-fill failed",
+						outcome.message,
+						NotificationType.WARNING,
+					)
+				}
+				onComplete?.invoke(null)
+			}
+		}
+	}
+
+	/** Truncates a commit subject for the progress line (matches VS Code's 60-char cap). */
+	private fun label(subject: String): String =
+		if (subject.length > 60) "${subject.take(57)}…" else subject
+
+	private fun notify(project: Project, title: String, content: String, type: NotificationType) {
+		NotificationGroupManager.getInstance()
+			.getNotificationGroup("JolliMemory")
+			.createNotification(title, content, type)
+			.notify(project)
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/backfill/BackfillRunner.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/backfill/BackfillRunner.kt
@@ -73,7 +73,15 @@ object BackfillRunner {
 				service.onBackfillCompleted(r.generated > 0)
 				// Refresh the surfaces that render summary state (Committed Memories list, etc.).
 				service.notifyMemoryStateChanged()
-				if (r.errors > 0) {
+				if (r.total == 0) {
+					// No candidate commits — e.g. a repo where none of the commits are yours.
+					notify(
+						project,
+						"Jolli Memory: nothing to back-fill",
+						"No commits authored by you are missing a memory.",
+						NotificationType.INFORMATION,
+					)
+				} else if (r.errors > 0) {
 					notify(
 						project,
 						"Jolli Memory: back-fill finished with errors",

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
@@ -124,6 +124,93 @@ class JolliMemoryService(private val project: Project) : Disposable {
     fun removeMemoryStateListener(listener: () -> Unit) { memoryStateListeners.remove(listener) }
     fun notifyMemoryStateChanged() { memoryStateListeners.forEach { it() } }
 
+    // ── Back-fill cold-start signals ─────────────────────────────────────
+    // Mirrors the VS Code extension's `computeColdStartSignals()` /
+    // `currentColdStartVariant` host state (vscode/src/Extension.ts). Drives the
+    // "build memory from your history" card in the tool window. Computed off-EDT
+    // by [computeColdStartSignals] via the `jolli backfill --list-candidates`
+    // subprocess (no LLM). The card is visible only when
+    // `coldStartVariant != null && !backfillDismissed`.
+    /** "empty" (repo has zero memories) | "gaps" (recent own commits lack one) | null. */
+    @Volatile
+    var coldStartVariant: String? = null
+        private set
+
+    /** Count of recent (last month, capped) own commits lacking a summary — card copy. */
+    @Volatile
+    var recentMissingCount: Int = 0
+        private set
+
+    /** Whether the user dismissed the card for this repo (repo-wide marker). */
+    @Volatile
+    var backfillDismissed: Boolean = false
+        private set
+
+    private val backfillListeners = CopyOnWriteArrayList<() -> Unit>()
+
+    /** Notified (invoke on the EDT) when cold-start signals or the dismiss flag change. */
+    fun addBackfillListener(listener: () -> Unit) {
+        backfillListeners.add(listener)
+        if (isInitialized) listener()
+    }
+    fun removeBackfillListener(listener: () -> Unit) { backfillListeners.remove(listener) }
+    private fun notifyBackfillListeners() { backfillListeners.forEach { it() } }
+
+    private fun backfillCwd(): String? = mainRepoRoot ?: project.basePath
+
+    /**
+     * Resolves cold-start signals for the card. Best-effort and atomic: on any failure
+     * the prior snapshot is left intact (never a mixed state). Safe to call off the EDT —
+     * it shells out to the CLI. Same window/cap as VS Code (30 days, top 10).
+     */
+    fun computeColdStartSignals() {
+        val cwd = backfillCwd() ?: return
+        when (val r = ai.jolli.jollimemory.backfill.BackfillCli.listCandidates(cwd, sinceDays = 30, limit = 10)) {
+            is ai.jolli.jollimemory.backfill.BackfillCli.Outcome.Ok -> {
+                val s = r.value
+                coldStartVariant = when {
+                    !s.hasAnyMemory -> "empty"
+                    s.candidates.isNotEmpty() -> "gaps"
+                    else -> null
+                }
+                recentMissingCount = s.candidates.size
+                backfillDismissed = ai.jolli.jollimemory.backfill.BackfillDismissFlag.isDismissed(cwd)
+                notifyBackfillListeners()
+            }
+            else -> {
+                log.info("Back-fill cold-start signals unavailable (${r::class.simpleName}); keeping prior snapshot")
+            }
+        }
+    }
+
+    /** True when the tool-window card should be shown. */
+    fun shouldShowBackfillCard(): Boolean = coldStartVariant != null && !backfillDismissed
+
+    /** Records that the user dismissed the card (writes the repo-wide marker). Idempotent. */
+    fun dismissBackfillCard() {
+        val cwd = backfillCwd() ?: return
+        backfillDismissed = true
+        ai.jolli.jollimemory.backfill.BackfillDismissFlag.setDismissed(cwd, true)
+        notifyBackfillListeners()
+    }
+
+    /**
+     * Post-back-fill bookkeeping shared by both entry points (card + Settings), mirroring
+     * VS Code's `runBackfillJob`: once any summary is generated the repo is no longer in
+     * cold start and the dismiss marker is cleared so a future fresh-empty transition
+     * re-surfaces the card.
+     */
+    fun onBackfillCompleted(generatedAny: Boolean) {
+        if (generatedAny) {
+            val cwd = backfillCwd()
+            coldStartVariant = null
+            recentMissingCount = 0
+            backfillDismissed = false
+            if (cwd != null) ai.jolli.jollimemory.backfill.BackfillDismissFlag.setDismissed(cwd, false)
+        }
+        notifyBackfillListeners()
+    }
+
     /**
      * Adds a sync-state listener. If a sync state has already been observed,
      * the listener is invoked immediately with it so late-registering panels

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryStartupActivity.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryStartupActivity.kt
@@ -49,6 +49,18 @@ class JolliMemoryStartupActivity : ProjectActivity {
         log.info("JolliMemory: activating sync for project at $basePath")
         ai.jolli.jollimemory.sync.SyncActivation.activateSync(project, service)
 
+        // Cold-start back-fill signals (Kotlin analog of VS Code's computeColdStartSignals):
+        // decide whether to offer "build memory from your history" in the tool window. Runs
+        // on a pooled thread because it shells out to `jolli backfill --list-candidates`, so
+        // it never delays project startup; the tool window updates via a backfill listener.
+        com.intellij.openapi.application.ApplicationManager.getApplication().executeOnPooledThread {
+            try {
+                service.computeColdStartSignals()
+            } catch (e: Exception) {
+                log.warn("Cold-start signal compute failed (ignored): ${e.message}")
+            }
+        }
+
         // Telemetry (JOLLI-1785): bootstrap anonymous, content-free usage
         // telemetry, fire app_installed once per machine, flush anything buffered
         // by prior sessions/hooks, and show the loud first-run notice once.

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/settings/JolliMemoryConfigurable.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/settings/JolliMemoryConfigurable.kt
@@ -72,8 +72,32 @@ class JolliMemoryConfigurable(private val project: Project) : Configurable {
             .addSeparator()
             .addLabeledComponent(jolliApiKeyLabel!!, jolliApiKeyField!!, 1, false)
             .addTooltip("For pushing summaries to Jolli Space (sk-jol-...). Fallback if not signed in.")
+            .addSeparator()
+            .addLabeledComponent(JBLabel("Historical memory:"), backfillPanel(), 1, false)
+            .addTooltip("Generate summaries for past commits that don't have one yet (uses on-disk Claude transcripts).")
             .addComponentFillVertically(JPanel(), 0)
             .panel
+    }
+
+    /**
+     * "Generate Missing Summaries" — full-scope back-fill for every own commit lacking a
+     * summary. Mirrors the VS Code Settings button (jollimemory.generateMissingSummaries):
+     * shares [BackfillRunner] with the tool-window cold-start card, so both entry points
+     * report progress + completion identically. An empty hash list means full scope.
+     */
+    private fun backfillPanel(): JPanel {
+        val button = JButton("Generate Missing Summaries")
+        button.addActionListener {
+            val service = project.getService(ai.jolli.jollimemory.services.JolliMemoryService::class.java)
+            button.isEnabled = false
+            ai.jolli.jollimemory.backfill.BackfillRunner.run(
+                project = project,
+                service = service,
+                hashes = emptyList(),
+                onComplete = { SwingUtilities.invokeLater { button.isEnabled = true } },
+            )
+        }
+        return JPanel(java.awt.FlowLayout(java.awt.FlowLayout.LEFT, 0, 0)).apply { add(button) }
     }
 
     private fun accountPanel(): JPanel {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/settings/JolliMemoryConfigurable.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/settings/JolliMemoryConfigurable.kt
@@ -72,32 +72,8 @@ class JolliMemoryConfigurable(private val project: Project) : Configurable {
             .addSeparator()
             .addLabeledComponent(jolliApiKeyLabel!!, jolliApiKeyField!!, 1, false)
             .addTooltip("For pushing summaries to Jolli Space (sk-jol-...). Fallback if not signed in.")
-            .addSeparator()
-            .addLabeledComponent(JBLabel("Historical memory:"), backfillPanel(), 1, false)
-            .addTooltip("Generate summaries for past commits that don't have one yet (uses on-disk Claude transcripts).")
             .addComponentFillVertically(JPanel(), 0)
             .panel
-    }
-
-    /**
-     * "Generate Missing Summaries" — full-scope back-fill for every own commit lacking a
-     * summary. Mirrors the VS Code Settings button (jollimemory.generateMissingSummaries):
-     * shares [BackfillRunner] with the tool-window cold-start card, so both entry points
-     * report progress + completion identically. An empty hash list means full scope.
-     */
-    private fun backfillPanel(): JPanel {
-        val button = JButton("Generate Missing Summaries")
-        button.addActionListener {
-            val service = project.getService(ai.jolli.jollimemory.services.JolliMemoryService::class.java)
-            button.isEnabled = false
-            ai.jolli.jollimemory.backfill.BackfillRunner.run(
-                project = project,
-                service = service,
-                hashes = emptyList(),
-                onComplete = { SwingUtilities.invokeLater { button.isEnabled = true } },
-            )
-        }
-        return JPanel(java.awt.FlowLayout(java.awt.FlowLayout.LEFT, 0, 0)).apply { add(button) }
     }
 
     private fun accountPanel(): JPanel {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BackfillPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BackfillPanel.kt
@@ -67,7 +67,7 @@ class BackfillPanel(
 	private val doneHolder = holder()
 
 	private val checkboxes = mutableListOf<Pair<JBCheckBox, BackfillCli.Candidate>>()
-	private val generateButton = blueButton("", whiteIcon(DATABASE_ICON)) { onGenerate() }
+	private val generateButton = blueButton("", white(DATABASE_ICON)) { onGenerate() }
 	private val progressBar = JProgressBar(0, 100)
 
 	/** Width-tracking text blocks for the currently mounted card: (label, leftIndentPx, htmlBody). */
@@ -108,16 +108,16 @@ class BackfillPanel(
 			isOpaque = false
 			alignmentX = LEFT
 			for ((i, b) in BENEFITS.withIndex()) {
-				add(iconRow(blueIcon(BENEFIT_ICONS[i]), "<b>${b.first}</b> ${b.second}"))
+				add(iconRow(blue(BENEFIT_ICONS[i]), "<b>${b.first}</b> ${b.second}"))
 				if (i < BENEFITS.lastIndex) add(Box.createVerticalStrut(JBUI.scale(4)))
 			}
 		}
 		return listOf(
-			header("Never re-explain a decision again", blueIcon(JolliMemoryIcons.Sparkle)),
+			header("Never re-explain a decision again", blue(JolliMemoryIcons.Sparkle, TITLE_ICON_PX)),
 			grayWrap("The conversations, plans and the why behind every commit, replayed into your next session — in any AI tool.", 0),
 			benefits,
-			iconRow(JolliMemoryIcons.Check, coldStartNote(service.coldStartVariant, service.recentMissingCount, COLD_START_CAP)),
-			blueButton("Build memories from commits", whiteIcon(DATABASE_ICON)) { onBuildNow() },
+			iconRow(sized(JolliMemoryIcons.Check), coldStartNote(service.coldStartVariant, service.recentMissingCount, COLD_START_CAP)),
+			blueButton("Build memories from commits", white(DATABASE_ICON)) { onBuildNow() },
 			grayWrap("🔒 Runs locally on your machine: nothing leaves unless you Share or Sync.", 0),
 		)
 	}
@@ -254,8 +254,8 @@ class BackfillPanel(
 				header("Couldn't build memories", null),
 				iconRow(JolliMemoryIcons.Warning, "$nErr commit${plural(nErr)} couldn't be built. Check your AI credentials, then try again."),
 			)
-			for (r in report.rows) children.add(iconRow(JolliMemoryIcons.Warning, "${escape(trim(r.subject))} — failed"))
-			children.add(blueButton("Try again", whiteIcon(JolliMemoryIcons.Refresh)) { onBuildNow() })
+			for (r in report.rows) children.add(iconRow(sized(JolliMemoryIcons.Warning), "${escape(trim(r.subject))} — failed"))
+			children.add(blueButton("Try again", white(JolliMemoryIcons.Refresh)) { onBuildNow() })
 			mount(doneHolder, DONE, children)
 			onVisibilityRefresh()
 			return
@@ -268,9 +268,9 @@ class BackfillPanel(
 		for (r in report.rows) {
 			val icon = if (r.status == "error") JolliMemoryIcons.Warning else JolliMemoryIcons.Sparkle
 			val meta = if (r.status == "error") "failed" else backfillResult(r.sessions, r.topics)
-			children.add(iconRow(icon, "${escape(trim(r.subject))} — $meta"))
+			children.add(iconRow(sized(icon), "${escape(trim(r.subject))} — $meta"))
 		}
-		children.add(blueButton("Open your Memory Bank", whiteIcon(JolliMemoryIcons.Book)) { closeToOffer() })
+		children.add(blueButton("Open your Memory Bank", white(JolliMemoryIcons.Book)) { closeToOffer() })
 		mount(doneHolder, DONE, children)
 		onVisibilityRefresh()
 	}
@@ -355,7 +355,7 @@ class BackfillPanel(
 	/** A leading icon (top-aligned) beside a width-tracking HTML body. */
 	private fun iconRow(icon: Icon, body: String): JComponent {
 		val label = wrapLabelFor(0)
-		val indent = JBUI.scale(16 + 8)
+		val indent = icon.iconWidth + JBUI.scale(8)
 		setWrap(label, body, indent)
 		return JPanel(BorderLayout(JBUI.scale(8), 0)).apply {
 			isOpaque = false
@@ -451,14 +451,21 @@ class BackfillPanel(
 		// exists across versions; tinted blue it reads the same.
 		private val BENEFIT_ICONS = listOf(AllIcons.Actions.Execute, JolliMemoryIcons.Eye, JolliMemoryIcons.Book)
 
-		/** Blue accent tint for the title + benefit icons (the tick stays its own green). */
-		private fun blueIcon(icon: Icon): Icon = TintIcon(icon, Color(0x35, 0x74, 0xF0))
+		/** Leading icons are sized to the adjacent text's font height so they don't tower over it. */
+		private val BODY_ICON_PX: Int = UIUtil.getLabelFont().size
+		private val TITLE_ICON_PX: Int = BODY_ICON_PX + 1
 
-		/** White tint so an icon reads on the blue accent button. */
-		private fun whiteIcon(icon: Icon): Icon = TintIcon(icon, Color.WHITE)
+		/** Blue accent, sized to text (title + benefit icons; the tick keeps its own green). */
+		private fun blue(icon: Icon, size: Int = BODY_ICON_PX): Icon = CardIcon(icon, Color(0x35, 0x74, 0xF0), size)
 
-		/** Database icon for the "build memories" action (mirrors VS Code's codicon-database). */
-		private val DATABASE_ICON: Icon = AllIcons.Nodes.DataTables
+		/** White, sized to text — reads on the blue accent button. */
+		private fun white(icon: Icon, size: Int = BODY_ICON_PX): Icon = CardIcon(icon, Color.WHITE, size)
+
+		/** Untinted but sized to text (e.g. the green tick, the done-row status icons). */
+		private fun sized(icon: Icon, size: Int = BODY_ICON_PX): Icon = CardIcon(icon, null, size)
+
+		/** Database cylinder for the "build memories" action (mirrors VS Code's codicon-database). */
+		private val DATABASE_ICON: Icon = JolliMemoryIcons.Database
 
 		private fun plural(n: Int): String = if (n == 1) "" else "s"
 
@@ -491,28 +498,35 @@ class BackfillPanel(
 }
 
 /**
- * Recolors an icon to a solid [color] (keeping its alpha/shape), using only core AWT so it
- * is stable across IntelliJ platform versions. Replaces `IconUtil.colorize`, whose signature
- * drifts between SDKs (a NoSuchMethodError from that call crashed the whole tool window when
- * the plugin was built against one IDE version and run on another).
+ * Renders [base] optionally recolored to [tint] (keeping its alpha/shape) and scaled to a
+ * [size]×[size] logical box — so a leading icon can match the height of the text beside it.
+ * Uses only core AWT so it is stable across IntelliJ platform versions; this replaces
+ * `IconUtil.colorize`, whose signature drifts between SDKs (a NoSuchMethodError from that
+ * call once crashed the whole tool window when the build SDK and runtime IDE differed).
  */
-private class TintIcon(private val base: Icon, private val color: Color) : Icon {
-	override fun getIconWidth(): Int = base.iconWidth
-	override fun getIconHeight(): Int = base.iconHeight
+private class CardIcon(private val base: Icon, private val tint: Color?, private val size: Int) : Icon {
+	override fun getIconWidth(): Int = size
+	override fun getIconHeight(): Int = size
 	override fun paintIcon(c: Component?, g: Graphics, x: Int, y: Int) {
-		val w = iconWidth
-		val h = iconHeight
-		if (w <= 0 || h <= 0) return
-		// HiDPI-aware buffer so retina rendering stays crisp.
-		val img = UIUtil.createImage(c, w, h, BufferedImage.TYPE_INT_ARGB)
-		val g2 = img.createGraphics()
+		val bw = base.iconWidth.coerceAtLeast(1)
+		val bh = base.iconHeight.coerceAtLeast(1)
+		// Render (and tint) the base at its natural size into a HiDPI-aware buffer …
+		val buf = UIUtil.createImage(c, bw, bh, BufferedImage.TYPE_INT_ARGB)
+		val bg = buf.createGraphics()
+		bg.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+		base.paintIcon(c, bg, 0, 0)
+		if (tint != null) {
+			// Paint the tint only where the icon has pixels (SrcAtop preserves alpha).
+			bg.composite = AlphaComposite.SrcAtop
+			bg.color = tint
+			bg.fillRect(0, 0, bw, bh)
+		}
+		bg.dispose()
+		// … then blit it scaled to the target square, centered if the source isn't square.
+		val g2 = g.create() as Graphics2D
+		g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR)
 		g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
-		base.paintIcon(c, g2, 0, 0)
-		// Paint the tint only where the icon already has pixels (SrcAtop preserves alpha).
-		g2.composite = AlphaComposite.SrcAtop
-		g2.color = color
-		g2.fillRect(0, 0, w, h)
+		g2.drawImage(buf, x, y, size, size, null)
 		g2.dispose()
-		g.drawImage(img, x, y, null)
 	}
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BackfillPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BackfillPanel.kt
@@ -101,8 +101,15 @@ class BackfillPanel(
 	/** Fit its own height in the accordion's vertical BoxLayout (never stretch vertically). */
 	override fun getMaximumSize(): Dimension = Dimension(Int.MAX_VALUE, preferredSize.height)
 
-	/** Mid-flow (LOADING/LIST/PROGRESS/DONE) stays visible; OFFER defers to the service. */
-	fun shouldBeVisible(): Boolean = currentCard != OFFER || service.shouldShowBackfillCard()
+	/**
+	 * A ✕ dismiss always hides the card (matching VS Code, whose visibility is purely
+	 * `!dismissed && …`). Otherwise mid-flow (LOADING/LIST/PROGRESS/DONE) stays visible so a
+	 * signal change can't yank it away, and OFFER defers to the service's cold-start decision.
+	 */
+	fun shouldBeVisible(): Boolean {
+		if (service.backfillDismissed) return false
+		return currentCard != OFFER || service.shouldShowBackfillCard()
+	}
 
 	/** Refreshes the offer copy from current signals without disturbing a mid-flow view. */
 	fun syncOffer() {
@@ -290,6 +297,16 @@ class BackfillPanel(
 		onVisibilityRefresh()
 	}
 
+	/**
+	 * ✕ handler for every state: reset to OFFER (so a later re-show starts clean) and mark the
+	 * card dismissed — which flips [shouldBeVisible] to false and hides it. Works from any state,
+	 * including the LIST/"No commits" view reached by clicking Build.
+	 */
+	private fun onDismiss() {
+		showOffer()
+		service.dismissBackfillCard()
+	}
+
 	private fun openSettings() = SettingsDialog(project, service).show()
 
 	// ── mount + reflow ─────────────────────────────────────────────────────
@@ -351,7 +368,7 @@ class BackfillPanel(
 			isFocusPainted = false
 			margin = JBUI.emptyInsets()
 			cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-			addActionListener { service.dismissBackfillCard() }
+			addActionListener { onDismiss() }
 		}
 		return JPanel(BorderLayout(JBUI.scale(8), 0)).apply {
 			isOpaque = false

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BackfillPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BackfillPanel.kt
@@ -8,6 +8,8 @@ import ai.jolli.jollimemory.core.JmLogger
 import ai.jolli.jollimemory.services.JolliMemoryService
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
+import com.intellij.ui.JBColor
+import com.intellij.ui.RoundedLineBorder
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
@@ -76,7 +78,12 @@ class BackfillPanel(
 
 	init {
 		isOpaque = false
-		border = JBUI.Borders.empty(8, 10, 12, 10)
+		// A bare bordered card (matching VS Code's `.backfill-panel` div), NOT a titled
+		// accordion section — an outer margin, a rounded outline, then inner padding.
+		border = JBUI.Borders.compound(
+			JBUI.Borders.empty(6),
+			JBUI.Borders.compound(RoundedLineBorder(JBColor.border(), JBUI.scale(10), 1), JBUI.Borders.empty(8, 10, 12, 10)),
+		)
 		deck.isOpaque = false
 		deck.add(offerHolder, OFFER)
 		deck.add(loadingHolder, LOADING)
@@ -90,6 +97,9 @@ class BackfillPanel(
 		})
 		showOffer()
 	}
+
+	/** Fit its own height in the accordion's vertical BoxLayout (never stretch vertically). */
+	override fun getMaximumSize(): Dimension = Dimension(Int.MAX_VALUE, preferredSize.height)
 
 	/** Mid-flow (LOADING/LIST/PROGRESS/DONE) stays visible; OFFER defers to the service. */
 	fun shouldBeVisible(): Boolean = currentCard != OFFER || service.shouldShowBackfillCard()

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BackfillPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BackfillPanel.kt
@@ -1,6 +1,8 @@
 package ai.jolli.jollimemory.toolwindow
 
+import ai.jolli.jollimemory.JolliMemoryIcons
 import ai.jolli.jollimemory.backfill.BackfillCli
+import com.intellij.icons.AllIcons
 import ai.jolli.jollimemory.backfill.BackfillRunner
 import ai.jolli.jollimemory.core.JmLogger
 import ai.jolli.jollimemory.services.JolliMemoryService
@@ -10,14 +12,25 @@ import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
+import java.awt.AlphaComposite
 import java.awt.BorderLayout
 import java.awt.CardLayout
+import java.awt.Color
 import java.awt.Component
 import java.awt.Cursor
 import java.awt.Dimension
 import java.awt.Font
+import java.awt.Graphics
+import java.awt.Graphics2D
+import java.awt.RenderingHints
+import java.awt.image.BufferedImage
+import java.awt.event.ComponentAdapter
+import java.awt.event.ComponentEvent
+import javax.swing.BorderFactory
 import javax.swing.Box
 import javax.swing.BoxLayout
+import javax.swing.Icon
 import javax.swing.JButton
 import javax.swing.JComponent
 import javax.swing.JPanel
@@ -27,20 +40,14 @@ import javax.swing.SwingConstants
 /**
  * BackfillPanel — the tool-window "build memory from your history" card. Native-Swing
  * port of the VS Code sidebar cold-start card (vscode/src/views/SidebarScriptBuilder.ts).
- * Titles, subtitles, button labels, benefit lines, and footer copy are kept as close to
- * the VS Code wording as Swing allows so the two editors read identically. State machine
- * driven by a [CardLayout]:
+ * Styling mirrors the plugin's own onboarding card (OnboardingPanel): a blue accent CTA,
+ * a title/benefit icon column, and copy that reads the same as VS Code.
  *
- *   OFFER    → pitch (title/subtitle/benefits) + ✓ note + "Build memories from commits"
- *   LOADING  → "Scanning your recent commits…"
- *   LIST     → selectable commits + "Build N memories" + "N more … manage all in Settings"
- *   PROGRESS → "N / total built" + bar
- *   DONE     → "N memories built from your history" + rows, or the "Couldn't build" retry view
- *
- * Every state carries a header ✕ that dismisses the card (writes the repo-wide marker).
- * Owns its own visibility via [shouldBeVisible] so mid-flow states aren't clobbered when
- * cold-start signals change. Row/note wording lives in the shared companion helpers, kept
- * 1:1 with vscode BackfillListRenderer.ts.
+ * States (CardLayout): OFFER → LOADING → LIST → PROGRESS → DONE. Every state has a header
+ * ✕ that dismisses (writes the repo-wide marker). Text blocks reflow to the current tool-
+ * window width via [reflow] (registered [wrapEntries] re-set their HTML width on resize),
+ * so content tracks the sidebar rather than a fixed column. Row/note wording lives in the
+ * companion helpers, kept 1:1 with vscode BackfillListRenderer.ts.
  */
 class BackfillPanel(
 	private val project: Project,
@@ -53,8 +60,6 @@ class BackfillPanel(
 	private val deck = JPanel(cards)
 	private var currentCard = OFFER
 
-	// Rebuilt per state (native Swing has no virtual DOM), so each render replaces the
-	// single card panel's contents. We keep references only to the widgets we mutate live.
 	private val offerHolder = holder()
 	private val loadingHolder = holder()
 	private val listHolder = holder()
@@ -62,9 +67,12 @@ class BackfillPanel(
 	private val doneHolder = holder()
 
 	private val checkboxes = mutableListOf<Pair<JBCheckBox, BackfillCli.Candidate>>()
-	private val generateButton = JButton()
+	private val generateButton = blueButton("", whiteIcon(DATABASE_ICON)) { onGenerate() }
 	private val progressBar = JProgressBar(0, 100)
-	private val progressLabel = htmlLabel("")
+
+	/** Width-tracking text blocks for the currently mounted card: (label, leftIndentPx, htmlBody). */
+	private val wrapEntries = mutableListOf<WrapEntry>()
+	private class WrapEntry(val label: JBLabel, val indent: Int, val body: String)
 
 	init {
 		isOpaque = false
@@ -76,6 +84,10 @@ class BackfillPanel(
 		deck.add(progressHolder, PROGRESS)
 		deck.add(doneHolder, DONE)
 		add(deck, BorderLayout.CENTER)
+		// Reflow wrapped copy whenever the tool window is resized so it fills the sidebar.
+		addComponentListener(object : ComponentAdapter() {
+			override fun componentResized(e: ComponentEvent) = reflow()
+		})
 		showOffer()
 	}
 
@@ -84,45 +96,38 @@ class BackfillPanel(
 
 	/** Refreshes the offer copy from current signals without disturbing a mid-flow view. */
 	fun syncOffer() {
-		if (currentCard == OFFER) renderInto(offerHolder, offerChildren())
+		if (currentCard == OFFER) mount(offerHolder, OFFER, offerChildren())
 	}
 
 	// ── OFFER ────────────────────────────────────────────────────────────
-	private fun showOffer() {
-		currentCard = OFFER
-		renderInto(offerHolder, offerChildren())
-		cards.show(deck, OFFER)
-	}
+	private fun showOffer() = mount(offerHolder, OFFER, offerChildren())
 
 	private fun offerChildren(): List<JComponent> {
 		val benefits = JPanel().apply {
 			layout = BoxLayout(this, BoxLayout.Y_AXIS)
 			isOpaque = false
 			alignmentX = LEFT
-			for (b in BENEFITS) add(bodyLabel("<b>${b.first}</b> ${b.second}"))
+			for ((i, b) in BENEFITS.withIndex()) {
+				add(iconRow(blueIcon(BENEFIT_ICONS[i]), "<b>${b.first}</b> ${b.second}"))
+				if (i < BENEFITS.lastIndex) add(Box.createVerticalStrut(JBUI.scale(4)))
+			}
 		}
-		val cta = primaryButton("Build memories from commits") { onBuildNow() }
 		return listOf(
-			header("Never re-explain a decision again"),
-			subtitle("The conversations, plans and the why behind every commit, replayed into your next session — in any AI tool."),
+			header("Never re-explain a decision again", blueIcon(JolliMemoryIcons.Sparkle)),
+			grayWrap("The conversations, plans and the why behind every commit, replayed into your next session — in any AI tool.", 0),
 			benefits,
-			noteLabel("✓ ${coldStartNote(service.coldStartVariant, service.recentMissingCount, COLD_START_CAP)}"),
-			cta,
-			footer("🔒 Runs locally on your machine: nothing leaves unless you Share or Sync."),
+			iconRow(JolliMemoryIcons.Check, coldStartNote(service.coldStartVariant, service.recentMissingCount, COLD_START_CAP)),
+			blueButton("Build memories from commits", whiteIcon(DATABASE_ICON)) { onBuildNow() },
+			grayWrap("🔒 Runs locally on your machine: nothing leaves unless you Share or Sync.", 0),
 		)
 	}
 
 	private fun onBuildNow() {
 		val cwd = service.mainRepoRoot ?: project.basePath ?: return
-		currentCard = LOADING
-		renderInto(
-			loadingHolder,
-			listOf(
-				header("Scanning your recent commits…"),
-				bodyLabel("Looking for the conversations behind each commit. This stays on your machine."),
-			),
-		)
-		cards.show(deck, LOADING)
+		mount(loadingHolder, LOADING, listOf(
+			header("Scanning your recent commits…", null),
+			grayWrap("Looking for the conversations behind each commit. This stays on your machine.", 0),
+		))
 		ApplicationManager.getApplication().executeOnPooledThread {
 			var totalMissing = 0
 			val enriched: List<BackfillCli.Candidate> = when (val listed = BackfillCli.listCandidates(cwd, sinceDays = 30, limit = COLD_START_CAP)) {
@@ -144,16 +149,11 @@ class BackfillPanel(
 
 	// ── LIST ─────────────────────────────────────────────────────────────
 	private fun showList(candidates: List<BackfillCli.Candidate>, totalMissing: Int) {
-		currentCard = LIST
 		if (candidates.isEmpty()) {
-			renderInto(
-				listHolder,
-				listOf(
-					header("No commits to build from"),
-					noteLabel("No commits from the last month need a memory. Keep coding — new commits capture automatically."),
-				),
-			)
-			cards.show(deck, LIST)
+			mount(listHolder, LIST, listOf(
+				header("No commits to build from", null),
+				grayWrap("No commits from the last month need a memory. Keep coding — new commits capture automatically.", 0),
+			))
 			return
 		}
 
@@ -163,11 +163,12 @@ class BackfillPanel(
 			isOpaque = false
 			alignmentX = LEFT
 			for (c in candidates) {
-				val cb = JBCheckBox(rowText(c), true)
-				cb.isOpaque = false
-				cb.alignmentX = LEFT
-				cb.toolTipText = c.subject
-				cb.addActionListener { updateGenerateButton() }
+				val cb = JBCheckBox(rowText(c), true).apply {
+					isOpaque = false
+					alignmentX = LEFT
+					toolTipText = c.subject
+					addActionListener { updateGenerateButton() }
+				}
 				checkboxes.add(cb to c)
 				add(cb)
 			}
@@ -180,27 +181,22 @@ class BackfillPanel(
 			isOpaque = false
 			viewport.isOpaque = false
 		}
-
-		generateButton.addActionListenerOnce { onGenerate() }
 		updateGenerateButton()
 
-		val children = mutableListOf(
-			header("Build memories from your recent commits"),
-			subtitle("Pick the commits to reconstruct. We attach the AI conversation behind each one when we can find it."),
-			scroll as JComponent,
+		val children = mutableListOf<JComponent>(
+			header("Build memories from your recent commits", null),
+			grayWrap("Pick the commits to reconstruct. We attach the AI conversation behind each one when we can find it.", 0),
+			scroll,
 		)
 		val more = totalMissing - candidates.size
-		if (more > 0) {
-			children.add(linkLabel("$more more commit${plural(more)} without a memory — manage all in Settings") { openSettings() })
-		}
-		children.add(wrap(generateButton))
-		children.add(footer("Runs one AI call per commit, locally. Nothing leaves unless you Share or Sync."))
-		renderInto(listHolder, children)
-		cards.show(deck, LIST)
+		if (more > 0) children.add(linkLabel("$more more commit${plural(more)} without a memory — manage all in Settings") { openSettings() })
+		children.add(generateButton)
+		children.add(grayWrap("Runs one AI call per commit, locally. Nothing leaves unless you Share or Sync.", 0))
+		mount(listHolder, LIST, children)
 	}
 
 	private fun rowText(c: BackfillCli.Candidate): String =
-		"${trim(c.subject)}   ${backfillMeta(c.sessions, c.conversationTurns)}"
+		"${trim(c.subject)}   —   ${backfillMeta(c.sessions, c.conversationTurns)}"
 
 	private fun selectedHashes(): List<String> =
 		checkboxes.filter { it.first.isSelected }.map { it.second.commitHash }
@@ -225,63 +221,57 @@ class BackfillPanel(
 	}
 
 	// ── PROGRESS ───────────────────────────────────────────────────────────
+	private val progressText = wrapLabelFor(0)
+
 	private fun startProgress(total: Int) {
-		currentCard = PROGRESS
 		progressBar.value = 0
-		progressLabel.text = html("<b>0</b> / $total built")
-		renderInto(
-			progressHolder,
-			listOf(
-				header("Building memories from your commits…"),
-				progressLabel,
-				progressBar.also { it.isStringPainted = false; it.alignmentX = LEFT },
-				footer("Reading each commit's message + diff. This stays on your machine."),
-			),
-		)
-		cards.show(deck, PROGRESS)
+		progressBar.isStringPainted = false
+		progressBar.alignmentX = LEFT
+		setWrap(progressText, "<b>0</b> / $total built", 0)
+		mount(progressHolder, PROGRESS, listOf(
+			header("Building memories from your commits…", null),
+			progressText,
+			progressBar,
+			grayWrap("Reading each commit's message + diff. This stays on your machine.", 0),
+		))
 	}
 
 	private fun updateProgress(done: Int, total: Int) {
 		if (total > 0) progressBar.value = done * 100 / total
-		progressLabel.text = html("<b>$done</b> / $total built")
+		setWrap(progressText, "<b>$done</b> / $total built", 0)
+		reflow()
 	}
 
 	// ── DONE ─────────────────────────────────────────────────────────────
 	private fun showDone(report: BackfillCli.Report?) {
-		currentCard = DONE
 		if (report == null) {
-			// Engine could not run (Node/bundle missing, cancelled) — the balloon explained
-			// why; fall back to the offer so the user can retry.
 			showOffer()
 			return
 		}
-
 		if (report.generated == 0) {
 			val nErr = report.errors
 			val children = mutableListOf<JComponent>(
-				header("Couldn't build memories"),
-				noteLabel("⚠ $nErr commit${plural(nErr)} couldn't be built. Check your AI credentials, then try again."),
+				header("Couldn't build memories", null),
+				iconRow(JolliMemoryIcons.Warning, "$nErr commit${plural(nErr)} couldn't be built. Check your AI credentials, then try again."),
 			)
-			for (r in report.rows) children.add(bodyLabel("⚠ ${trim(r.subject)} — failed"))
-			children.add(primaryButton("Try again") { onBuildNow() })
-			renderInto(doneHolder, children)
-			cards.show(deck, DONE)
+			for (r in report.rows) children.add(iconRow(JolliMemoryIcons.Warning, "${escape(trim(r.subject))} — failed"))
+			children.add(blueButton("Try again", whiteIcon(JolliMemoryIcons.Refresh)) { onBuildNow() })
+			mount(doneHolder, DONE, children)
 			onVisibilityRefresh()
 			return
 		}
-
 		val errNote = if (report.errors > 0) " · ${report.errors} could not be built" else ""
 		val children = mutableListOf<JComponent>(
-			header("${report.generated} memor${if (report.generated == 1) "y" else "ies"} built from your history"),
-			noteLabel("Reconstructed from each commit + diff$errNote. Live AI sessions will add richer memories as you work."),
+			header("${report.generated} memor${if (report.generated == 1) "y" else "ies"} built from your history", null),
+			grayWrap("Reconstructed from each commit + diff$errNote. Live AI sessions will add richer memories as you work.", 0),
 		)
 		for (r in report.rows) {
+			val icon = if (r.status == "error") JolliMemoryIcons.Warning else JolliMemoryIcons.Sparkle
 			val meta = if (r.status == "error") "failed" else backfillResult(r.sessions, r.topics)
-			children.add(bodyLabel("${if (r.status == "error") "⚠" else "✦"} ${trim(r.subject)} — $meta"))
+			children.add(iconRow(icon, "${escape(trim(r.subject))} — $meta"))
 		}
-		children.add(primaryButton("Open your Memory Bank") { closeToOffer() })
-		renderInto(doneHolder, children)
-		cards.show(deck, DONE)
+		children.add(blueButton("Open your Memory Bank", whiteIcon(JolliMemoryIcons.Book)) { closeToOffer() })
+		mount(doneHolder, DONE, children)
 		onVisibilityRefresh()
 	}
 
@@ -290,34 +280,60 @@ class BackfillPanel(
 		onVisibilityRefresh()
 	}
 
-	private fun openSettings() {
-		SettingsDialog(project, service).show()
-	}
+	private fun openSettings() = SettingsDialog(project, service).show()
 
-	// ── layout + label helpers ─────────────────────────────────────────────
-	private fun holder(): JPanel =
-		JPanel().apply {
-			layout = BoxLayout(this, BoxLayout.Y_AXIS)
-			isOpaque = false
-		}
-
-	/** Replaces a card holder's contents with [comps], each left-aligned + spaced. */
-	private fun renderInto(target: JPanel, comps: List<JComponent>) {
-		target.removeAll()
+	// ── mount + reflow ─────────────────────────────────────────────────────
+	/** Replaces [holder]'s contents, switches to it, and reflows wrapped copy to the width. */
+	private fun mount(holder: JPanel, card: String, comps: List<JComponent>) {
+		currentCard = card
+		holder.removeAll()
 		for (c in comps) {
 			c.alignmentX = LEFT
-			target.add(c)
-			target.add(Box.createVerticalStrut(JBUI.scale(6)))
+			holder.add(c)
+			holder.add(Box.createVerticalStrut(JBUI.scale(6)))
 		}
-		target.revalidate()
-		target.repaint()
+		// Drop wrap-labels detached by this holder's removeAll (labels still mounted in
+		// other holders keep their parent and stay registered).
+		wrapEntries.removeAll { it.label.parent == null }
+		holder.revalidate()
+		holder.repaint()
+		cards.show(deck, card)
+		ApplicationManager.getApplication().invokeLater { reflow() }
 	}
 
-	/** Header row: bold title on the left, a ✕ dismiss button on the right. */
-	private fun header(title: String): JComponent {
-		val titleLabel = JBLabel(title).apply {
-			font = font.deriveFont(Font.BOLD, font.size2D + 1f)
+	/** Content width available to text (panel width minus horizontal insets). */
+	private fun contentWidth(): Int {
+		val ins = insets
+		return (width - ins.left - ins.right).coerceAtLeast(JBUI.scale(140))
+	}
+
+	/** Re-sets each registered wrap label's HTML width so long copy wraps to the sidebar. */
+	private fun reflow() {
+		val w = contentWidth()
+		for (e in wrapEntries) {
+			e.label.text = "<html><body style='width:${(w - e.indent).coerceAtLeast(JBUI.scale(60))}px'>${e.body}</body></html>"
 		}
+		revalidate()
+		repaint()
+	}
+
+	// ── widget helpers ─────────────────────────────────────────────────────
+	private fun holder(): JPanel = JPanel().apply {
+		layout = BoxLayout(this, BoxLayout.Y_AXIS)
+		isOpaque = false
+	}
+
+	/**
+	 * Header row: an optional leading icon, a bold **wrapping** title beside it (so the icon
+	 * and title stay on the same line while long titles wrap to the right of the icon), and a
+	 * ✕ dismiss on the right.
+	 */
+	private fun header(title: String, icon: Icon?): JComponent {
+		val titleLabel = wrapLabelFor(0).apply { font = font.deriveFont(Font.BOLD, font.size2D + 1f) }
+		// Reserve room for the trailing ✕ (and the leading icon, when present) so the wrapped
+		// title width matches the space actually allocated to the CENTER cell.
+		val indent = JBUI.scale(30) + (if (icon != null) JBUI.scale(24) else 0)
+		setWrap(titleLabel, escape(title), indent)
 		val dismiss = JButton("✕").apply {
 			toolTipText = "Dismiss"
 			isContentAreaFilled = false
@@ -327,21 +343,46 @@ class BackfillPanel(
 			cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
 			addActionListener { service.dismissBackfillCard() }
 		}
-		return JPanel(BorderLayout()).apply {
+		return JPanel(BorderLayout(JBUI.scale(8), 0)).apply {
 			isOpaque = false
 			alignmentX = LEFT
+			if (icon != null) add(JBLabel(icon).apply { verticalAlignment = SwingConstants.TOP; border = JBUI.Borders.emptyTop(2) }, BorderLayout.WEST)
 			add(titleLabel, BorderLayout.CENTER)
 			add(dismiss, BorderLayout.EAST)
-			maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
 		}
 	}
 
-	private fun subtitle(text: String): JComponent = grayLabel(text)
-	private fun noteLabel(text: String): JComponent = bodyLabel(text)
-	private fun footer(text: String): JComponent = grayLabel(text)
+	/** A leading icon (top-aligned) beside a width-tracking HTML body. */
+	private fun iconRow(icon: Icon, body: String): JComponent {
+		val label = wrapLabelFor(0)
+		val indent = JBUI.scale(16 + 8)
+		setWrap(label, body, indent)
+		return JPanel(BorderLayout(JBUI.scale(8), 0)).apply {
+			isOpaque = false
+			alignmentX = LEFT
+			add(JBLabel(icon).apply { verticalAlignment = SwingConstants.TOP; border = JBUI.Borders.emptyTop(1) }, BorderLayout.WEST)
+			add(label, BorderLayout.CENTER)
+		}
+	}
 
-	private fun primaryButton(text: String, onClick: () -> Unit): JComponent =
-		wrap(JButton(text).apply { addActionListener { onClick() } })
+	private fun grayWrap(text: String, indent: Int): JComponent {
+		val label = wrapLabelFor(indent)
+		setWrap(label, "<span style='color:gray'>${escape(text)}</span>", indent)
+		return label
+	}
+
+	private fun wrapLabelFor(indent: Int): JBLabel = JBLabel().apply {
+		horizontalAlignment = SwingConstants.LEFT
+		verticalAlignment = SwingConstants.TOP
+		alignmentX = LEFT
+	}
+
+	/** Registers [label] for width-tracking with the given HTML [body] and left [indent]. */
+	private fun setWrap(label: JBLabel, body: String, indent: Int) {
+		wrapEntries.removeAll { it.label === label }
+		wrapEntries.add(WrapEntry(label, indent, body))
+		label.text = "<html><body style='width:${(contentWidth() - indent).coerceAtLeast(JBUI.scale(60))}px'>$body</body></html>"
+	}
 
 	private fun linkLabel(text: String, onClick: () -> Unit): JComponent =
 		JBLabel("<html><a href=''>${escape(text)}</a></html>").apply {
@@ -352,49 +393,42 @@ class BackfillPanel(
 			})
 		}
 
-	/** Wrap a button in a left-aligned flow row so it keeps its natural width. */
-	private fun wrap(c: JComponent): JComponent =
-		JPanel(java.awt.FlowLayout(java.awt.FlowLayout.LEFT, 0, 0)).apply {
+	/** Full-width blue accent button (matches OnboardingPanel.createBlueButton), with an icon. */
+	private fun blueButton(text: String, icon: Icon?, onClick: () -> Unit): JButton = object : JButton(text) {
+		init {
+			this.icon = icon
+			iconTextGap = JBUI.scale(6)
+			horizontalAlignment = SwingConstants.CENTER
+			alignmentX = Component.LEFT_ALIGNMENT
+			foreground = Color.WHITE
 			isOpaque = false
-			alignmentX = LEFT
-			add(c)
+			isContentAreaFilled = false
+			isFocusPainted = false
+			isBorderPainted = false
+			border = BorderFactory.createEmptyBorder(JBUI.scale(7), JBUI.scale(12), JBUI.scale(7), JBUI.scale(12))
+			cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+			maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
+			addActionListener { onClick() }
 		}
-
-	private fun bodyLabel(htmlBody: String): JBLabel =
-		JBLabel(html(htmlBody)).apply {
-			horizontalAlignment = SwingConstants.LEFT
-			verticalAlignment = SwingConstants.TOP
-			alignmentX = LEFT
+		override fun paintComponent(g: Graphics) {
+			val g2 = g.create() as Graphics2D
+			g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+			g2.color = when {
+				!isEnabled -> Color(0x3C, 0x52, 0x7A)
+				model.isRollover -> Color(0x2D, 0x65, 0xD8)
+				else -> Color(0x35, 0x74, 0xF0)
+			}
+			g2.fillRoundRect(0, 0, width, height, JBUI.scale(8), JBUI.scale(8))
+			g2.dispose()
+			super.paintComponent(g)
 		}
-
-	private fun grayLabel(text: String): JBLabel =
-		JBLabel(html("<span style='color:gray'>${escape(text)}</span>")).apply {
-			horizontalAlignment = SwingConstants.LEFT
-			verticalAlignment = SwingConstants.TOP
-			alignmentX = LEFT
-		}
-
-	private fun htmlLabel(text: String): JBLabel =
-		JBLabel(text).apply {
-			horizontalAlignment = SwingConstants.LEFT
-			verticalAlignment = SwingConstants.TOP
-			alignmentX = LEFT
-		}
-
-	/** Width-constrained HTML so long copy wraps in the narrow tool window. */
-	private fun html(body: String): String = "<html><body style='width:230px'>$body</body></html>"
+	}
 
 	private fun escape(s: String): String =
 		s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 	private fun trim(subject: String): String =
-		if (subject.length > 52) "${subject.take(49)}…" else subject
-
-	/** Adds [action] as the sole listener (clears prior ones so re-render doesn't stack them). */
-	private fun JButton.addActionListenerOnce(action: () -> Unit) {
-		actionListeners.forEach { removeActionListener(it) }
-		addActionListener { action() }
-	}
+		if (subject.length > 48) "${subject.take(45)}…" else subject
 
 	companion object {
 		const val COLD_START_CAP = 10
@@ -406,12 +440,25 @@ class BackfillPanel(
 		private const val PROGRESS = "progress"
 		private const val DONE = "done"
 
-		/** The three offer benefits, mirroring the VS Code card (icon dropped in Swing). */
+		/** Offer benefits, mirroring the VS Code card (bold lead + normal continuation). */
 		private val BENEFITS = listOf(
 			"Pick up where you left off." to "Sessions and plans replay next time.",
 			"Recall in any tool." to "Claude, Cursor, Codex via MCP. No copy-paste.",
 			"Knowledge builds itself." to "A wiki + graph from your commits.",
 		)
+		// Blue-tinted per request: run (pick up) / recall / knowledge. `AllIcons.Gutter.Run`
+		// isn't in the plugin's build SDK (2024.3), so use the equivalent run/play glyph that
+		// exists across versions; tinted blue it reads the same.
+		private val BENEFIT_ICONS = listOf(AllIcons.Actions.Execute, JolliMemoryIcons.Eye, JolliMemoryIcons.Book)
+
+		/** Blue accent tint for the title + benefit icons (the tick stays its own green). */
+		private fun blueIcon(icon: Icon): Icon = TintIcon(icon, Color(0x35, 0x74, 0xF0))
+
+		/** White tint so an icon reads on the blue accent button. */
+		private fun whiteIcon(icon: Icon): Icon = TintIcon(icon, Color.WHITE)
+
+		/** Database icon for the "build memories" action (mirrors VS Code's codicon-database). */
+		private val DATABASE_ICON: Icon = AllIcons.Nodes.DataTables
 
 		private fun plural(n: Int): String = if (n == 1) "" else "s"
 
@@ -440,5 +487,32 @@ class BackfillPanel(
 			return "You are set up — this repo has no memories yet. Build them from your recent commits, " +
 				"or just keep coding and they capture automatically."
 		}
+	}
+}
+
+/**
+ * Recolors an icon to a solid [color] (keeping its alpha/shape), using only core AWT so it
+ * is stable across IntelliJ platform versions. Replaces `IconUtil.colorize`, whose signature
+ * drifts between SDKs (a NoSuchMethodError from that call crashed the whole tool window when
+ * the plugin was built against one IDE version and run on another).
+ */
+private class TintIcon(private val base: Icon, private val color: Color) : Icon {
+	override fun getIconWidth(): Int = base.iconWidth
+	override fun getIconHeight(): Int = base.iconHeight
+	override fun paintIcon(c: Component?, g: Graphics, x: Int, y: Int) {
+		val w = iconWidth
+		val h = iconHeight
+		if (w <= 0 || h <= 0) return
+		// HiDPI-aware buffer so retina rendering stays crisp.
+		val img = UIUtil.createImage(c, w, h, BufferedImage.TYPE_INT_ARGB)
+		val g2 = img.createGraphics()
+		g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+		base.paintIcon(c, g2, 0, 0)
+		// Paint the tint only where the icon already has pixels (SrcAtop preserves alpha).
+		g2.composite = AlphaComposite.SrcAtop
+		g2.color = color
+		g2.fillRect(0, 0, w, h)
+		g2.dispose()
+		g.drawImage(img, x, y, null)
 	}
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BackfillPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BackfillPanel.kt
@@ -13,8 +13,9 @@ import com.intellij.util.ui.JBUI
 import java.awt.BorderLayout
 import java.awt.CardLayout
 import java.awt.Component
+import java.awt.Cursor
 import java.awt.Dimension
-import java.awt.FlowLayout
+import java.awt.Font
 import javax.swing.Box
 import javax.swing.BoxLayout
 import javax.swing.JButton
@@ -25,19 +26,21 @@ import javax.swing.SwingConstants
 
 /**
  * BackfillPanel — the tool-window "build memory from your history" card. Native-Swing
- * port of the VS Code sidebar cold-start card (vscode/src/views/SidebarScriptBuilder.ts),
- * with the same four states driven by a [CardLayout]:
+ * port of the VS Code sidebar cold-start card (vscode/src/views/SidebarScriptBuilder.ts).
+ * Titles, subtitles, button labels, benefit lines, and footer copy are kept as close to
+ * the VS Code wording as Swing allows so the two editors read identically. State machine
+ * driven by a [CardLayout]:
  *
- *   OFFER    → note ("N recent commits without a memory yet") + [Build now] / [Dismiss]
- *   LIST     → selectable commits ("subject · N sessions · M turns") + [Generate selected]
- *   PROGRESS → determinate bar with the current commit
- *   DONE     → tally + acted-on rows + [Close]
+ *   OFFER    → pitch (title/subtitle/benefits) + ✓ note + "Build memories from commits"
+ *   LOADING  → "Scanning your recent commits…"
+ *   LIST     → selectable commits + "Build N memories" + "N more … manage all in Settings"
+ *   PROGRESS → "N / total built" + bar
+ *   DONE     → "N memories built from your history" + rows, or the "Couldn't build" retry view
  *
- * Owns its own visibility lifecycle via [shouldBeVisible]: while the user is engaged
- * (LIST / PROGRESS / DONE) the card stays visible even after cold-start state changes
- * (e.g. a generation clears `coldStartVariant`); it defers to the service only in the
- * OFFER state. [onVisibilityRefresh] asks the host (the collapsible wrapper) to re-read
- * [shouldBeVisible]. Wording is kept in lockstep with vscode BackfillListRenderer.ts.
+ * Every state carries a header ✕ that dismisses the card (writes the repo-wide marker).
+ * Owns its own visibility via [shouldBeVisible] so mid-flow states aren't clobbered when
+ * cold-start signals change. Row/note wording lives in the shared companion helpers, kept
+ * 1:1 with vscode BackfillListRenderer.ts.
  */
 class BackfillPanel(
 	private val project: Project,
@@ -50,167 +53,234 @@ class BackfillPanel(
 	private val deck = JPanel(cards)
 	private var currentCard = OFFER
 
-	private val offerNote = htmlLabel("")
-	private val listContainer = JPanel().apply {
-		layout = BoxLayout(this, BoxLayout.Y_AXIS)
-		isOpaque = false
-	}
+	// Rebuilt per state (native Swing has no virtual DOM), so each render replaces the
+	// single card panel's contents. We keep references only to the widgets we mutate live.
+	private val offerHolder = holder()
+	private val loadingHolder = holder()
+	private val listHolder = holder()
+	private val progressHolder = holder()
+	private val doneHolder = holder()
+
 	private val checkboxes = mutableListOf<Pair<JBCheckBox, BackfillCli.Candidate>>()
-	private val generateButton = JButton("Generate selected")
+	private val generateButton = JButton()
 	private val progressBar = JProgressBar(0, 100)
 	private val progressLabel = htmlLabel("")
-	private val doneSummary = htmlLabel("")
-	private val doneRows = JPanel().apply {
-		layout = BoxLayout(this, BoxLayout.Y_AXIS)
-		isOpaque = false
-	}
 
 	init {
 		isOpaque = false
-		border = JBUI.Borders.empty(8, 10, 10, 10)
+		border = JBUI.Borders.empty(8, 10, 12, 10)
 		deck.isOpaque = false
-		deck.add(offerCard(), OFFER)
-		deck.add(listCard(), LIST)
-		deck.add(progressCard(), PROGRESS)
-		deck.add(doneCard(), DONE)
+		deck.add(offerHolder, OFFER)
+		deck.add(loadingHolder, LOADING)
+		deck.add(listHolder, LIST)
+		deck.add(progressHolder, PROGRESS)
+		deck.add(doneHolder, DONE)
 		add(deck, BorderLayout.CENTER)
 		showOffer()
 	}
 
-	/**
-	 * Whether the host collapsible should be visible. Mid-flow (LIST / PROGRESS / DONE)
-	 * always stays visible until the user closes it; in OFFER we defer to the service's
-	 * cold-start decision.
-	 */
+	/** Mid-flow (LOADING/LIST/PROGRESS/DONE) stays visible; OFFER defers to the service. */
 	fun shouldBeVisible(): Boolean = currentCard != OFFER || service.shouldShowBackfillCard()
 
 	/** Refreshes the offer copy from current signals without disturbing a mid-flow view. */
 	fun syncOffer() {
-		offerNote.text = html(coldStartNote(service.coldStartVariant, service.recentMissingCount, COLD_START_CAP))
+		if (currentCard == OFFER) renderInto(offerHolder, offerChildren())
 	}
 
 	// ── OFFER ────────────────────────────────────────────────────────────
-	private fun offerCard(): JPanel {
-		val buttons = row(
-			JButton("Build now").apply { addActionListener { onBuildNow() } },
-			JButton("Dismiss").apply { addActionListener { service.dismissBackfillCard() } },
-		)
-		return column(offerNote, buttons)
+	private fun showOffer() {
+		currentCard = OFFER
+		renderInto(offerHolder, offerChildren())
+		cards.show(deck, OFFER)
 	}
 
-	private fun showOffer() {
-		syncOffer()
-		currentCard = OFFER
-		cards.show(deck, OFFER)
+	private fun offerChildren(): List<JComponent> {
+		val benefits = JPanel().apply {
+			layout = BoxLayout(this, BoxLayout.Y_AXIS)
+			isOpaque = false
+			alignmentX = LEFT
+			for (b in BENEFITS) add(bodyLabel("<b>${b.first}</b> ${b.second}"))
+		}
+		val cta = primaryButton("Build memories from commits") { onBuildNow() }
+		return listOf(
+			header("Never re-explain a decision again"),
+			subtitle("The conversations, plans and the why behind every commit, replayed into your next session — in any AI tool."),
+			benefits,
+			noteLabel("✓ ${coldStartNote(service.coldStartVariant, service.recentMissingCount, COLD_START_CAP)}"),
+			cta,
+			footer("🔒 Runs locally on your machine: nothing leaves unless you Share or Sync."),
+		)
 	}
 
 	private fun onBuildNow() {
 		val cwd = service.mainRepoRoot ?: project.basePath ?: return
-		offerNote.text = html("Scanning your recent commits…")
+		currentCard = LOADING
+		renderInto(
+			loadingHolder,
+			listOf(
+				header("Scanning your recent commits…"),
+				bodyLabel("Looking for the conversations behind each commit. This stays on your machine."),
+			),
+		)
+		cards.show(deck, LOADING)
 		ApplicationManager.getApplication().executeOnPooledThread {
-			val listed = BackfillCli.listCandidates(cwd, sinceDays = 30, limit = COLD_START_CAP)
-			val enriched = if (listed is BackfillCli.Outcome.Ok) {
-				when (val p = BackfillCli.preview(cwd, listed.value.candidates)) {
-					is BackfillCli.Outcome.Ok -> p.value
-					else -> listed.value.candidates
+			var totalMissing = 0
+			val enriched: List<BackfillCli.Candidate> = when (val listed = BackfillCli.listCandidates(cwd, sinceDays = 30, limit = COLD_START_CAP)) {
+				is BackfillCli.Outcome.Ok -> {
+					totalMissing = listed.value.missing
+					when (val p = BackfillCli.preview(cwd, listed.value.candidates)) {
+						is BackfillCli.Outcome.Ok -> p.value
+						else -> listed.value.candidates
+					}
 				}
-			} else {
-				log.info("Build-now candidate scan unavailable")
-				emptyList()
+				else -> {
+					log.info("Build-now candidate scan unavailable")
+					emptyList()
+				}
 			}
-			ApplicationManager.getApplication().invokeLater {
-				if (enriched.isEmpty()) showOffer() else showList(enriched)
-			}
+			ApplicationManager.getApplication().invokeLater { showList(enriched, totalMissing) }
 		}
 	}
 
 	// ── LIST ─────────────────────────────────────────────────────────────
-	private fun listCard(): JPanel {
-		generateButton.addActionListener { onGenerate() }
-		val scroll = JBScrollPane(listContainer).apply {
+	private fun showList(candidates: List<BackfillCli.Candidate>, totalMissing: Int) {
+		currentCard = LIST
+		if (candidates.isEmpty()) {
+			renderInto(
+				listHolder,
+				listOf(
+					header("No commits to build from"),
+					noteLabel("No commits from the last month need a memory. Keep coding — new commits capture automatically."),
+				),
+			)
+			cards.show(deck, LIST)
+			return
+		}
+
+		checkboxes.clear()
+		val list = JPanel().apply {
+			layout = BoxLayout(this, BoxLayout.Y_AXIS)
+			isOpaque = false
+			alignmentX = LEFT
+			for (c in candidates) {
+				val cb = JBCheckBox(rowText(c), true)
+				cb.isOpaque = false
+				cb.alignmentX = LEFT
+				cb.toolTipText = c.subject
+				cb.addActionListener { updateGenerateButton() }
+				checkboxes.add(cb to c)
+				add(cb)
+			}
+		}
+		val scroll = JBScrollPane(list).apply {
 			border = JBUI.Borders.empty()
-			preferredSize = Dimension(0, JBUI.scale(160))
+			preferredSize = Dimension(0, JBUI.scale(150))
+			maximumSize = Dimension(Int.MAX_VALUE, JBUI.scale(150))
+			alignmentX = LEFT
 			isOpaque = false
 			viewport.isOpaque = false
 		}
-		val buttons = row(
-			generateButton,
-			JButton("Cancel").apply { addActionListener { showOffer() } },
-		)
-		return column(htmlLabel(html("Select the commits to build memory for:")), scroll, buttons)
-	}
 
-	private fun showList(candidates: List<BackfillCli.Candidate>) {
-		listContainer.removeAll()
-		checkboxes.clear()
-		for (c in candidates) {
-			val cb = JBCheckBox("${trim(c.subject)}  —  ${backfillMeta(c.sessions, c.conversationTurns)}", true)
-			cb.isOpaque = false
-			cb.alignmentX = Component.LEFT_ALIGNMENT
-			cb.addActionListener { updateGenerateEnabled() }
-			checkboxes.add(cb to c)
-			listContainer.add(cb)
+		generateButton.addActionListenerOnce { onGenerate() }
+		updateGenerateButton()
+
+		val children = mutableListOf(
+			header("Build memories from your recent commits"),
+			subtitle("Pick the commits to reconstruct. We attach the AI conversation behind each one when we can find it."),
+			scroll as JComponent,
+		)
+		val more = totalMissing - candidates.size
+		if (more > 0) {
+			children.add(linkLabel("$more more commit${plural(more)} without a memory — manage all in Settings") { openSettings() })
 		}
-		listContainer.revalidate()
-		listContainer.repaint()
-		updateGenerateEnabled()
-		currentCard = LIST
+		children.add(wrap(generateButton))
+		children.add(footer("Runs one AI call per commit, locally. Nothing leaves unless you Share or Sync."))
+		renderInto(listHolder, children)
 		cards.show(deck, LIST)
 	}
 
-	private fun updateGenerateEnabled() {
-		generateButton.isEnabled = checkboxes.any { it.first.isSelected }
+	private fun rowText(c: BackfillCli.Candidate): String =
+		"${trim(c.subject)}   ${backfillMeta(c.sessions, c.conversationTurns)}"
+
+	private fun selectedHashes(): List<String> =
+		checkboxes.filter { it.first.isSelected }.map { it.second.commitHash }
+
+	private fun updateGenerateButton() {
+		val n = selectedHashes().size
+		generateButton.isEnabled = n > 0
+		generateButton.text = if (n == 0) "Select commits to build" else "Build $n memor${if (n == 1) "y" else "ies"}"
 	}
 
 	private fun onGenerate() {
-		val selected = checkboxes.filter { it.first.isSelected }.map { it.second.commitHash }
+		val selected = selectedHashes()
 		if (selected.isEmpty()) return
-		progressBar.value = 0
-		progressLabel.text = html("Starting…")
-		currentCard = PROGRESS
-		cards.show(deck, PROGRESS)
+		startProgress(selected.size)
 		BackfillRunner.run(
 			project = project,
 			service = service,
 			hashes = selected,
-			onProgress = { p ->
-				if (p.total > 0) progressBar.value = p.done * 100 / p.total
-				progressLabel.text = html("${p.done}/${p.total} — ${trim(p.subject)}")
-			},
+			onProgress = { p -> updateProgress(p.done, p.total) },
 			onComplete = { report -> showDone(report) },
 		)
 	}
 
 	// ── PROGRESS ───────────────────────────────────────────────────────────
-	private fun progressCard(): JPanel {
-		progressBar.isStringPainted = false
-		return column(htmlLabel(html("Building memory…")), progressBar, progressLabel)
+	private fun startProgress(total: Int) {
+		currentCard = PROGRESS
+		progressBar.value = 0
+		progressLabel.text = html("<b>0</b> / $total built")
+		renderInto(
+			progressHolder,
+			listOf(
+				header("Building memories from your commits…"),
+				progressLabel,
+				progressBar.also { it.isStringPainted = false; it.alignmentX = LEFT },
+				footer("Reading each commit's message + diff. This stays on your machine."),
+			),
+		)
+		cards.show(deck, PROGRESS)
+	}
+
+	private fun updateProgress(done: Int, total: Int) {
+		if (total > 0) progressBar.value = done * 100 / total
+		progressLabel.text = html("<b>$done</b> / $total built")
 	}
 
 	// ── DONE ─────────────────────────────────────────────────────────────
-	private fun doneCard(): JPanel {
-		val close = row(JButton("Close").apply { addActionListener { closeToOffer() } })
-		return column(doneSummary, doneRows, close)
-	}
-
 	private fun showDone(report: BackfillCli.Report?) {
-		doneRows.removeAll()
+		currentCard = DONE
 		if (report == null) {
-			// Engine could not run (Node/bundle missing, cancelled, or failure) — the
-			// balloon already explained why. Fall back to the offer so the user can retry.
+			// Engine could not run (Node/bundle missing, cancelled) — the balloon explained
+			// why; fall back to the offer so the user can retry.
 			showOffer()
 			return
 		}
-		doneSummary.text = html(
-			"Done — ${report.generated} generated, ${report.skipped} skipped, ${report.errors} error(s).",
+
+		if (report.generated == 0) {
+			val nErr = report.errors
+			val children = mutableListOf<JComponent>(
+				header("Couldn't build memories"),
+				noteLabel("⚠ $nErr commit${plural(nErr)} couldn't be built. Check your AI credentials, then try again."),
+			)
+			for (r in report.rows) children.add(bodyLabel("⚠ ${trim(r.subject)} — failed"))
+			children.add(primaryButton("Try again") { onBuildNow() })
+			renderInto(doneHolder, children)
+			cards.show(deck, DONE)
+			onVisibilityRefresh()
+			return
+		}
+
+		val errNote = if (report.errors > 0) " · ${report.errors} could not be built" else ""
+		val children = mutableListOf<JComponent>(
+			header("${report.generated} memor${if (report.generated == 1) "y" else "ies"} built from your history"),
+			noteLabel("Reconstructed from each commit + diff$errNote. Live AI sessions will add richer memories as you work."),
 		)
 		for (r in report.rows) {
 			val meta = if (r.status == "error") "failed" else backfillResult(r.sessions, r.topics)
-			doneRows.add(htmlLabel(html("• ${trim(r.subject)} — $meta")))
+			children.add(bodyLabel("${if (r.status == "error") "⚠" else "✦"} ${trim(r.subject)} — $meta"))
 		}
-		doneRows.revalidate()
-		doneRows.repaint()
-		currentCard = DONE
+		children.add(primaryButton("Open your Memory Bank") { closeToOffer() })
+		renderInto(doneHolder, children)
 		cards.show(deck, DONE)
 		onVisibilityRefresh()
 	}
@@ -220,48 +290,128 @@ class BackfillPanel(
 		onVisibilityRefresh()
 	}
 
-	// ── layout + label helpers ─────────────────────────────────────────────
-	private fun row(vararg comps: JComponent): JPanel =
-		JPanel(FlowLayout(FlowLayout.LEFT, 6, 0)).apply {
-			isOpaque = false
-			alignmentX = Component.LEFT_ALIGNMENT
-			for (c in comps) add(c)
-		}
+	private fun openSettings() {
+		SettingsDialog(project, service).show()
+	}
 
-	private fun column(vararg comps: JComponent): JPanel =
+	// ── layout + label helpers ─────────────────────────────────────────────
+	private fun holder(): JPanel =
 		JPanel().apply {
 			layout = BoxLayout(this, BoxLayout.Y_AXIS)
 			isOpaque = false
-			for (c in comps) {
-				c.alignmentX = Component.LEFT_ALIGNMENT
-				add(c)
-				add(Box.createVerticalStrut(JBUI.scale(6)))
-			}
+		}
+
+	/** Replaces a card holder's contents with [comps], each left-aligned + spaced. */
+	private fun renderInto(target: JPanel, comps: List<JComponent>) {
+		target.removeAll()
+		for (c in comps) {
+			c.alignmentX = LEFT
+			target.add(c)
+			target.add(Box.createVerticalStrut(JBUI.scale(6)))
+		}
+		target.revalidate()
+		target.repaint()
+	}
+
+	/** Header row: bold title on the left, a ✕ dismiss button on the right. */
+	private fun header(title: String): JComponent {
+		val titleLabel = JBLabel(title).apply {
+			font = font.deriveFont(Font.BOLD, font.size2D + 1f)
+		}
+		val dismiss = JButton("✕").apply {
+			toolTipText = "Dismiss"
+			isContentAreaFilled = false
+			isBorderPainted = false
+			isFocusPainted = false
+			margin = JBUI.emptyInsets()
+			cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+			addActionListener { service.dismissBackfillCard() }
+		}
+		return JPanel(BorderLayout()).apply {
+			isOpaque = false
+			alignmentX = LEFT
+			add(titleLabel, BorderLayout.CENTER)
+			add(dismiss, BorderLayout.EAST)
+			maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
+		}
+	}
+
+	private fun subtitle(text: String): JComponent = grayLabel(text)
+	private fun noteLabel(text: String): JComponent = bodyLabel(text)
+	private fun footer(text: String): JComponent = grayLabel(text)
+
+	private fun primaryButton(text: String, onClick: () -> Unit): JComponent =
+		wrap(JButton(text).apply { addActionListener { onClick() } })
+
+	private fun linkLabel(text: String, onClick: () -> Unit): JComponent =
+		JBLabel("<html><a href=''>${escape(text)}</a></html>").apply {
+			alignmentX = LEFT
+			cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+			addMouseListener(object : java.awt.event.MouseAdapter() {
+				override fun mouseClicked(e: java.awt.event.MouseEvent) = onClick()
+			})
+		}
+
+	/** Wrap a button in a left-aligned flow row so it keeps its natural width. */
+	private fun wrap(c: JComponent): JComponent =
+		JPanel(java.awt.FlowLayout(java.awt.FlowLayout.LEFT, 0, 0)).apply {
+			isOpaque = false
+			alignmentX = LEFT
+			add(c)
+		}
+
+	private fun bodyLabel(htmlBody: String): JBLabel =
+		JBLabel(html(htmlBody)).apply {
+			horizontalAlignment = SwingConstants.LEFT
+			verticalAlignment = SwingConstants.TOP
+			alignmentX = LEFT
+		}
+
+	private fun grayLabel(text: String): JBLabel =
+		JBLabel(html("<span style='color:gray'>${escape(text)}</span>")).apply {
+			horizontalAlignment = SwingConstants.LEFT
+			verticalAlignment = SwingConstants.TOP
+			alignmentX = LEFT
 		}
 
 	private fun htmlLabel(text: String): JBLabel =
 		JBLabel(text).apply {
 			horizontalAlignment = SwingConstants.LEFT
 			verticalAlignment = SwingConstants.TOP
+			alignmentX = LEFT
 		}
 
-	/** Wrap text in width-constrained HTML so long copy wraps inside the narrow sidebar. */
-	private fun html(text: String): String =
-		"<html><body style='width:220px'>${escape(text)}</body></html>"
+	/** Width-constrained HTML so long copy wraps in the narrow tool window. */
+	private fun html(body: String): String = "<html><body style='width:230px'>$body</body></html>"
 
 	private fun escape(s: String): String =
 		s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 	private fun trim(subject: String): String =
-		if (subject.length > 60) "${subject.take(57)}…" else subject
+		if (subject.length > 52) "${subject.take(49)}…" else subject
+
+	/** Adds [action] as the sole listener (clears prior ones so re-render doesn't stack them). */
+	private fun JButton.addActionListenerOnce(action: () -> Unit) {
+		actionListeners.forEach { removeActionListener(it) }
+		addActionListener { action() }
+	}
 
 	companion object {
 		const val COLD_START_CAP = 10
+		private val LEFT: Float = Component.LEFT_ALIGNMENT
 
 		private const val OFFER = "offer"
+		private const val LOADING = "loading"
 		private const val LIST = "list"
 		private const val PROGRESS = "progress"
 		private const val DONE = "done"
+
+		/** The three offer benefits, mirroring the VS Code card (icon dropped in Swing). */
+		private val BENEFITS = listOf(
+			"Pick up where you left off." to "Sessions and plans replay next time.",
+			"Recall in any tool." to "Claude, Cursor, Codex via MCP. No copy-paste.",
+			"Knowledge builds itself." to "A wiki + graph from your commits.",
+		)
 
 		private fun plural(n: Int): String = if (n == 1) "" else "s"
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BackfillPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BackfillPanel.kt
@@ -17,7 +17,6 @@ import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import java.awt.AlphaComposite
 import java.awt.BorderLayout
-import java.awt.CardLayout
 import java.awt.Color
 import java.awt.Component
 import java.awt.Cursor
@@ -45,7 +44,8 @@ import javax.swing.SwingConstants
  * Styling mirrors the plugin's own onboarding card (OnboardingPanel): a blue accent CTA,
  * a title/benefit icon column, and copy that reads the same as VS Code.
  *
- * States (CardLayout): OFFER → LOADING → LIST → PROGRESS → DONE. Every state has a header
+ * States: OFFER → LOADING → LIST → PROGRESS → DONE (one content panel rebuilt per state, so
+ * the card sizes to the current state). Every state has a header
  * ✕ that dismisses (writes the repo-wide marker). Text blocks reflow to the current tool-
  * window width via [reflow] (registered [wrapEntries] re-set their HTML width on resize),
  * so content tracks the sidebar rather than a fixed column. Row/note wording lives in the
@@ -55,18 +55,14 @@ class BackfillPanel(
 	private val project: Project,
 	private val service: JolliMemoryService,
 	private val onVisibilityRefresh: () -> Unit = {},
+	private val onOpenMemoryBank: () -> Unit = {},
 ) : JPanel(BorderLayout()) {
 
 	private val log = JmLogger.create("BackfillPanel")
-	private val cards = CardLayout()
-	private val deck = JPanel(cards)
+	// A single content panel rebuilt per state — NOT a CardLayout, which would size to the
+	// tallest card (the offer) and leave the short "No commits" state in an over-tall box.
+	private val content = holder()
 	private var currentCard = OFFER
-
-	private val offerHolder = holder()
-	private val loadingHolder = holder()
-	private val listHolder = holder()
-	private val progressHolder = holder()
-	private val doneHolder = holder()
 
 	private val checkboxes = mutableListOf<Pair<JBCheckBox, BackfillCli.Candidate>>()
 	private val generateButton = blueButton("", white(DATABASE_ICON)) { onGenerate() }
@@ -84,13 +80,8 @@ class BackfillPanel(
 			JBUI.Borders.empty(6),
 			JBUI.Borders.compound(RoundedLineBorder(JBColor.border(), JBUI.scale(10), 1), JBUI.Borders.empty(8, 10, 12, 10)),
 		)
-		deck.isOpaque = false
-		deck.add(offerHolder, OFFER)
-		deck.add(loadingHolder, LOADING)
-		deck.add(listHolder, LIST)
-		deck.add(progressHolder, PROGRESS)
-		deck.add(doneHolder, DONE)
-		add(deck, BorderLayout.CENTER)
+		content.isOpaque = false
+		add(content, BorderLayout.CENTER)
 		// Reflow wrapped copy whenever the tool window is resized so it fills the sidebar.
 		addComponentListener(object : ComponentAdapter() {
 			override fun componentResized(e: ComponentEvent) = reflow()
@@ -113,11 +104,11 @@ class BackfillPanel(
 
 	/** Refreshes the offer copy from current signals without disturbing a mid-flow view. */
 	fun syncOffer() {
-		if (currentCard == OFFER) mount(offerHolder, OFFER, offerChildren())
+		if (currentCard == OFFER) mount(OFFER, offerChildren())
 	}
 
 	// ── OFFER ────────────────────────────────────────────────────────────
-	private fun showOffer() = mount(offerHolder, OFFER, offerChildren())
+	private fun showOffer() = mount(OFFER, offerChildren())
 
 	private fun offerChildren(): List<JComponent> {
 		val benefits = JPanel().apply {
@@ -141,7 +132,7 @@ class BackfillPanel(
 
 	private fun onBuildNow() {
 		val cwd = service.mainRepoRoot ?: project.basePath ?: return
-		mount(loadingHolder, LOADING, listOf(
+		mount(LOADING, listOf(
 			header("Scanning your recent commits…", null),
 			grayWrap("Looking for the conversations behind each commit. This stays on your machine.", 0),
 		))
@@ -167,7 +158,7 @@ class BackfillPanel(
 	// ── LIST ─────────────────────────────────────────────────────────────
 	private fun showList(candidates: List<BackfillCli.Candidate>, totalMissing: Int) {
 		if (candidates.isEmpty()) {
-			mount(listHolder, LIST, listOf(
+			mount(LIST, listOf(
 				header("No commits to build from", null),
 				grayWrap("No commits from the last month need a memory. Keep coding — new commits capture automatically.", 0),
 			))
@@ -209,7 +200,7 @@ class BackfillPanel(
 		if (more > 0) children.add(linkLabel("$more more commit${plural(more)} without a memory — manage all in Settings") { openSettings() })
 		children.add(generateButton)
 		children.add(grayWrap("Runs one AI call per commit, locally. Nothing leaves unless you Share or Sync.", 0))
-		mount(listHolder, LIST, children)
+		mount(LIST, children)
 	}
 
 	private fun rowText(c: BackfillCli.Candidate): String =
@@ -245,7 +236,7 @@ class BackfillPanel(
 		progressBar.isStringPainted = false
 		progressBar.alignmentX = LEFT
 		setWrap(progressText, "<b>0</b> / $total built", 0)
-		mount(progressHolder, PROGRESS, listOf(
+		mount(PROGRESS, listOf(
 			header("Building memories from your commits…", null),
 			progressText,
 			progressBar,
@@ -273,7 +264,7 @@ class BackfillPanel(
 			)
 			for (r in report.rows) children.add(iconRow(sized(JolliMemoryIcons.Warning), "${escape(trim(r.subject))} — failed"))
 			children.add(blueButton("Try again", white(JolliMemoryIcons.Refresh)) { onBuildNow() })
-			mount(doneHolder, DONE, children)
+			mount(DONE, children)
 			onVisibilityRefresh()
 			return
 		}
@@ -287,8 +278,8 @@ class BackfillPanel(
 			val meta = if (r.status == "error") "failed" else backfillResult(r.sessions, r.topics)
 			children.add(iconRow(sized(icon), "${escape(trim(r.subject))} — $meta"))
 		}
-		children.add(blueButton("Open your Memory Bank", white(JolliMemoryIcons.Book)) { closeToOffer() })
-		mount(doneHolder, DONE, children)
+		children.add(blueButton("Open your Memory Bank", white(JolliMemoryIcons.Book)) { onOpenMemoryBank(); closeToOffer() })
+		mount(DONE, children)
 		onVisibilityRefresh()
 	}
 
@@ -310,21 +301,25 @@ class BackfillPanel(
 	private fun openSettings() = SettingsDialog(project, service).show()
 
 	// ── mount + reflow ─────────────────────────────────────────────────────
-	/** Replaces [holder]'s contents, switches to it, and reflows wrapped copy to the width. */
-	private fun mount(holder: JPanel, card: String, comps: List<JComponent>) {
+	/**
+	 * Rebuilds the single content panel with [comps] so the card sizes to the CURRENT state's
+	 * content (a CardLayout would instead reserve the tallest card's height). Reflows wrapped
+	 * copy to the width afterward.
+	 */
+	private fun mount(card: String, comps: List<JComponent>) {
 		currentCard = card
-		holder.removeAll()
+		content.removeAll()
 		for (c in comps) {
 			c.alignmentX = LEFT
-			holder.add(c)
-			holder.add(Box.createVerticalStrut(JBUI.scale(6)))
+			content.add(c)
+			content.add(Box.createVerticalStrut(JBUI.scale(6)))
 		}
-		// Drop wrap-labels detached by this holder's removeAll (labels still mounted in
-		// other holders keep their parent and stay registered).
+		// Prior components were detached by removeAll → drop their now-parentless wrap labels.
 		wrapEntries.removeAll { it.label.parent == null }
-		holder.revalidate()
-		holder.repaint()
-		cards.show(deck, card)
+		content.revalidate()
+		content.repaint()
+		revalidate()
+		repaint()
 		ApplicationManager.getApplication().invokeLater { reflow() }
 	}
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BackfillPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BackfillPanel.kt
@@ -1,0 +1,294 @@
+package ai.jolli.jollimemory.toolwindow
+
+import ai.jolli.jollimemory.backfill.BackfillCli
+import ai.jolli.jollimemory.backfill.BackfillRunner
+import ai.jolli.jollimemory.core.JmLogger
+import ai.jolli.jollimemory.services.JolliMemoryService
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import java.awt.CardLayout
+import java.awt.Component
+import java.awt.Dimension
+import java.awt.FlowLayout
+import javax.swing.Box
+import javax.swing.BoxLayout
+import javax.swing.JButton
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.JProgressBar
+import javax.swing.SwingConstants
+
+/**
+ * BackfillPanel — the tool-window "build memory from your history" card. Native-Swing
+ * port of the VS Code sidebar cold-start card (vscode/src/views/SidebarScriptBuilder.ts),
+ * with the same four states driven by a [CardLayout]:
+ *
+ *   OFFER    → note ("N recent commits without a memory yet") + [Build now] / [Dismiss]
+ *   LIST     → selectable commits ("subject · N sessions · M turns") + [Generate selected]
+ *   PROGRESS → determinate bar with the current commit
+ *   DONE     → tally + acted-on rows + [Close]
+ *
+ * Owns its own visibility lifecycle via [shouldBeVisible]: while the user is engaged
+ * (LIST / PROGRESS / DONE) the card stays visible even after cold-start state changes
+ * (e.g. a generation clears `coldStartVariant`); it defers to the service only in the
+ * OFFER state. [onVisibilityRefresh] asks the host (the collapsible wrapper) to re-read
+ * [shouldBeVisible]. Wording is kept in lockstep with vscode BackfillListRenderer.ts.
+ */
+class BackfillPanel(
+	private val project: Project,
+	private val service: JolliMemoryService,
+	private val onVisibilityRefresh: () -> Unit = {},
+) : JPanel(BorderLayout()) {
+
+	private val log = JmLogger.create("BackfillPanel")
+	private val cards = CardLayout()
+	private val deck = JPanel(cards)
+	private var currentCard = OFFER
+
+	private val offerNote = htmlLabel("")
+	private val listContainer = JPanel().apply {
+		layout = BoxLayout(this, BoxLayout.Y_AXIS)
+		isOpaque = false
+	}
+	private val checkboxes = mutableListOf<Pair<JBCheckBox, BackfillCli.Candidate>>()
+	private val generateButton = JButton("Generate selected")
+	private val progressBar = JProgressBar(0, 100)
+	private val progressLabel = htmlLabel("")
+	private val doneSummary = htmlLabel("")
+	private val doneRows = JPanel().apply {
+		layout = BoxLayout(this, BoxLayout.Y_AXIS)
+		isOpaque = false
+	}
+
+	init {
+		isOpaque = false
+		border = JBUI.Borders.empty(8, 10, 10, 10)
+		deck.isOpaque = false
+		deck.add(offerCard(), OFFER)
+		deck.add(listCard(), LIST)
+		deck.add(progressCard(), PROGRESS)
+		deck.add(doneCard(), DONE)
+		add(deck, BorderLayout.CENTER)
+		showOffer()
+	}
+
+	/**
+	 * Whether the host collapsible should be visible. Mid-flow (LIST / PROGRESS / DONE)
+	 * always stays visible until the user closes it; in OFFER we defer to the service's
+	 * cold-start decision.
+	 */
+	fun shouldBeVisible(): Boolean = currentCard != OFFER || service.shouldShowBackfillCard()
+
+	/** Refreshes the offer copy from current signals without disturbing a mid-flow view. */
+	fun syncOffer() {
+		offerNote.text = html(coldStartNote(service.coldStartVariant, service.recentMissingCount, COLD_START_CAP))
+	}
+
+	// ── OFFER ────────────────────────────────────────────────────────────
+	private fun offerCard(): JPanel {
+		val buttons = row(
+			JButton("Build now").apply { addActionListener { onBuildNow() } },
+			JButton("Dismiss").apply { addActionListener { service.dismissBackfillCard() } },
+		)
+		return column(offerNote, buttons)
+	}
+
+	private fun showOffer() {
+		syncOffer()
+		currentCard = OFFER
+		cards.show(deck, OFFER)
+	}
+
+	private fun onBuildNow() {
+		val cwd = service.mainRepoRoot ?: project.basePath ?: return
+		offerNote.text = html("Scanning your recent commits…")
+		ApplicationManager.getApplication().executeOnPooledThread {
+			val listed = BackfillCli.listCandidates(cwd, sinceDays = 30, limit = COLD_START_CAP)
+			val enriched = if (listed is BackfillCli.Outcome.Ok) {
+				when (val p = BackfillCli.preview(cwd, listed.value.candidates)) {
+					is BackfillCli.Outcome.Ok -> p.value
+					else -> listed.value.candidates
+				}
+			} else {
+				log.info("Build-now candidate scan unavailable")
+				emptyList()
+			}
+			ApplicationManager.getApplication().invokeLater {
+				if (enriched.isEmpty()) showOffer() else showList(enriched)
+			}
+		}
+	}
+
+	// ── LIST ─────────────────────────────────────────────────────────────
+	private fun listCard(): JPanel {
+		generateButton.addActionListener { onGenerate() }
+		val scroll = JBScrollPane(listContainer).apply {
+			border = JBUI.Borders.empty()
+			preferredSize = Dimension(0, JBUI.scale(160))
+			isOpaque = false
+			viewport.isOpaque = false
+		}
+		val buttons = row(
+			generateButton,
+			JButton("Cancel").apply { addActionListener { showOffer() } },
+		)
+		return column(htmlLabel(html("Select the commits to build memory for:")), scroll, buttons)
+	}
+
+	private fun showList(candidates: List<BackfillCli.Candidate>) {
+		listContainer.removeAll()
+		checkboxes.clear()
+		for (c in candidates) {
+			val cb = JBCheckBox("${trim(c.subject)}  —  ${backfillMeta(c.sessions, c.conversationTurns)}", true)
+			cb.isOpaque = false
+			cb.alignmentX = Component.LEFT_ALIGNMENT
+			cb.addActionListener { updateGenerateEnabled() }
+			checkboxes.add(cb to c)
+			listContainer.add(cb)
+		}
+		listContainer.revalidate()
+		listContainer.repaint()
+		updateGenerateEnabled()
+		currentCard = LIST
+		cards.show(deck, LIST)
+	}
+
+	private fun updateGenerateEnabled() {
+		generateButton.isEnabled = checkboxes.any { it.first.isSelected }
+	}
+
+	private fun onGenerate() {
+		val selected = checkboxes.filter { it.first.isSelected }.map { it.second.commitHash }
+		if (selected.isEmpty()) return
+		progressBar.value = 0
+		progressLabel.text = html("Starting…")
+		currentCard = PROGRESS
+		cards.show(deck, PROGRESS)
+		BackfillRunner.run(
+			project = project,
+			service = service,
+			hashes = selected,
+			onProgress = { p ->
+				if (p.total > 0) progressBar.value = p.done * 100 / p.total
+				progressLabel.text = html("${p.done}/${p.total} — ${trim(p.subject)}")
+			},
+			onComplete = { report -> showDone(report) },
+		)
+	}
+
+	// ── PROGRESS ───────────────────────────────────────────────────────────
+	private fun progressCard(): JPanel {
+		progressBar.isStringPainted = false
+		return column(htmlLabel(html("Building memory…")), progressBar, progressLabel)
+	}
+
+	// ── DONE ─────────────────────────────────────────────────────────────
+	private fun doneCard(): JPanel {
+		val close = row(JButton("Close").apply { addActionListener { closeToOffer() } })
+		return column(doneSummary, doneRows, close)
+	}
+
+	private fun showDone(report: BackfillCli.Report?) {
+		doneRows.removeAll()
+		if (report == null) {
+			// Engine could not run (Node/bundle missing, cancelled, or failure) — the
+			// balloon already explained why. Fall back to the offer so the user can retry.
+			showOffer()
+			return
+		}
+		doneSummary.text = html(
+			"Done — ${report.generated} generated, ${report.skipped} skipped, ${report.errors} error(s).",
+		)
+		for (r in report.rows) {
+			val meta = if (r.status == "error") "failed" else backfillResult(r.sessions, r.topics)
+			doneRows.add(htmlLabel(html("• ${trim(r.subject)} — $meta")))
+		}
+		doneRows.revalidate()
+		doneRows.repaint()
+		currentCard = DONE
+		cards.show(deck, DONE)
+		onVisibilityRefresh()
+	}
+
+	private fun closeToOffer() {
+		showOffer()
+		onVisibilityRefresh()
+	}
+
+	// ── layout + label helpers ─────────────────────────────────────────────
+	private fun row(vararg comps: JComponent): JPanel =
+		JPanel(FlowLayout(FlowLayout.LEFT, 6, 0)).apply {
+			isOpaque = false
+			alignmentX = Component.LEFT_ALIGNMENT
+			for (c in comps) add(c)
+		}
+
+	private fun column(vararg comps: JComponent): JPanel =
+		JPanel().apply {
+			layout = BoxLayout(this, BoxLayout.Y_AXIS)
+			isOpaque = false
+			for (c in comps) {
+				c.alignmentX = Component.LEFT_ALIGNMENT
+				add(c)
+				add(Box.createVerticalStrut(JBUI.scale(6)))
+			}
+		}
+
+	private fun htmlLabel(text: String): JBLabel =
+		JBLabel(text).apply {
+			horizontalAlignment = SwingConstants.LEFT
+			verticalAlignment = SwingConstants.TOP
+		}
+
+	/** Wrap text in width-constrained HTML so long copy wraps inside the narrow sidebar. */
+	private fun html(text: String): String =
+		"<html><body style='width:220px'>${escape(text)}</body></html>"
+
+	private fun escape(s: String): String =
+		s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+	private fun trim(subject: String): String =
+		if (subject.length > 60) "${subject.take(57)}…" else subject
+
+	companion object {
+		const val COLD_START_CAP = 10
+
+		private const val OFFER = "offer"
+		private const val LIST = "list"
+		private const val PROGRESS = "progress"
+		private const val DONE = "done"
+
+		private fun plural(n: Int): String = if (n == 1) "" else "s"
+
+		/** Mirror of BackfillListRenderer.formatBackfillMeta. */
+		fun backfillMeta(sessions: Int, conversationTurns: Int): String =
+			if (sessions <= 0) "Code change only"
+			else "$sessions session${plural(sessions)} · $conversationTurns turn${plural(conversationTurns)}"
+
+		/** Mirror of BackfillListRenderer.formatBackfillResult. */
+		fun backfillResult(sessions: Int, topics: Int): String =
+			if (sessions <= 0) "$topics topic${plural(topics)}"
+			else "$sessions session${plural(sessions)} · $topics topic${plural(topics)}"
+
+		/** Mirror of BackfillListRenderer.formatColdStartNote. */
+		fun coldStartNote(variant: String?, recentMissingCount: Int, cap: Int): String {
+			if (variant == "gaps") {
+				val n = recentMissingCount
+				return if (n >= cap) {
+					"You are set up. The $cap most recent commits from the last month without a memory yet — " +
+						"build now, or manage all in Settings (new commits capture automatically)."
+				} else {
+					"You are set up. $n recent commit${plural(n)} from the last month (up to $cap) without a memory yet — " +
+						"build now, or keep coding (new commits capture automatically)."
+				}
+			}
+			return "You are set up — this repo has no memories yet. Build them from your recent commits, " +
+				"or just keep coding and they capture automatically."
+		}
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitMemoryFormat.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitMemoryFormat.kt
@@ -1,6 +1,7 @@
 package ai.jolli.jollimemory.toolwindow
 
 import ai.jolli.jollimemory.bridge.CommitSummaryBrief
+import java.util.Locale
 
 /**
  * Pure (UI-free, git-free) helpers backing the redesigned Committed Memories
@@ -70,6 +71,28 @@ object CommitMemoryFormat {
 	 */
 	fun formatCost(usd: Double): String =
 		if (usd >= 0.01) "≈$" + "%.2f".format(usd) else "<$0.01"
+
+	/**
+	 * Exact token count with thousands separators (`3000000` → `"3,000,000"`), for the
+	 * pushed/shared-memory Markdown "Task usage" line — which shows precise figures rather
+	 * than the compact `formatTokens` form the space-constrained UI bar uses. Mirrors the
+	 * CLI/VS Code `formatTokensExact`.
+	 */
+	fun formatTokensExact(n: Long): String = String.format(Locale.US, "%,d", n)
+
+	/**
+	 * Exact USD cost for the shared-memory "Task usage" line: two decimals at/above a cent
+	 * (`"$21.75"`), four for a sub-cent value (`"$0.0034"`), and the floor `"<$0.0001"` for a
+	 * real amount too small to survive four decimals — so a real cost never shows as all-zeros.
+	 * No `≈` prefix (the article surfaces the precise computed figure). Mirrors the CLI/VS Code
+	 * `formatExactCostUsd`; the value is still a Sonnet-rate estimate.
+	 */
+	fun formatExactCostUsd(usd: Double): String = when {
+		usd >= 0.01 -> "$" + String.format(Locale.US, "%.2f", usd)
+		usd >= 0.00005 -> "$" + String.format(Locale.US, "%.4f", usd)
+		usd > 0 -> "<$0.0001"
+		else -> "$0.00"
+	}
 
 	/**
 	 * Sum input/output tokens over the branch's commits. A commit contributes

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
@@ -11,6 +11,7 @@ import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
@@ -214,22 +215,32 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         // no memories yet or has recent own commits lacking one — the panel owns that
         // decision via shouldBeVisible() (it stays up mid-flow). Fits its content and has
         // no action toolbar (the id resolves to nothing — CollapsiblePanel tolerates that).
-        lateinit var backfillCollapsible: CollapsiblePanel
-        lateinit var backfillPanel: BackfillPanel
-        val syncBackfillVisibility = {
-            backfillCollapsible.isVisible = backfillPanel.shouldBeVisible()
-            backfillPanel.syncOffer()
+        // Built defensively: a failure constructing this card (e.g. an SDK API drift between
+        // the plugin's build target and the running IDE) must NEVER blank the whole tool
+        // window — so on any throwable we log and simply omit the card. `null` = unavailable.
+        var backfillCollapsible: CollapsiblePanel? = null
+        try {
+            lateinit var bfCollapsible: CollapsiblePanel
+            lateinit var bfPanel: BackfillPanel
+            val syncBackfillVisibility = {
+                bfCollapsible.isVisible = bfPanel.shouldBeVisible()
+                bfPanel.syncOffer()
+            }
+            bfPanel = BackfillPanel(project, service) {
+                SwingUtilities.invokeLater { syncBackfillVisibility() }
+            }
+            bfCollapsible = CollapsiblePanel(
+                "BUILD MEMORY", "JolliMemory.BackfillActions", bfPanel, fitContent = true,
+                titleIcon = AllIcons.Actions.Refresh,
+            )
+            // Immediate-invoke on add (service fires once when initialized) sets the initial
+            // visibility; later cold-start recomputes / dismissals re-run it on the EDT.
+            service.addBackfillListener { SwingUtilities.invokeLater(syncBackfillVisibility) }
+            backfillCollapsible = bfCollapsible
+        } catch (e: Throwable) {
+            Logger.getInstance(JolliMemoryToolWindowFactory::class.java)
+                .warn("Back-fill cold-start card unavailable (rest of the tool window unaffected): ${e.message}", e)
         }
-        backfillPanel = BackfillPanel(project, service) {
-            SwingUtilities.invokeLater { syncBackfillVisibility() }
-        }
-        backfillCollapsible = CollapsiblePanel(
-            "BUILD MEMORY", "JolliMemory.BackfillActions", backfillPanel, fitContent = true,
-            titleIcon = AllIcons.Actions.Refresh,
-        )
-        // Immediate-invoke on add (service fires once when initialized) sets the initial
-        // visibility; later cold-start recomputes / dismissals re-run it on the EDT.
-        service.addBackfillListener { SwingUtilities.invokeLater(syncBackfillVisibility) }
 
         // Live row-count suffix in the section headers, e.g. "PINNED (3)".
         pinnedCollapsible.setCount(pinnedPanel.currentRowCount())
@@ -243,11 +254,11 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         val accordionStack = WidthTrackingPanel().apply {
             layout = BoxLayout(this, BoxLayout.Y_AXIS)
             isOpaque = false
-            backfillCollapsible.alignmentX = Component.LEFT_ALIGNMENT
+            backfillCollapsible?.alignmentX = Component.LEFT_ALIGNMENT
             pinnedCollapsible.alignmentX = Component.LEFT_ALIGNMENT
             currentMemoryCollapsible.alignmentX = Component.LEFT_ALIGNMENT
             memoriesCollapsible.alignmentX = Component.LEFT_ALIGNMENT
-            add(backfillCollapsible)
+            backfillCollapsible?.let { add(it) }
             add(pinnedCollapsible)
             add(currentMemoryCollapsible)
             add(memoriesCollapsible)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
@@ -219,6 +219,9 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         // Built defensively: a failure constructing this card (e.g. an SDK API drift between the
         // plugin's build target and the running IDE) must NEVER blank the whole tool window — so
         // on any throwable we log and simply omit the card. `null` = unavailable.
+        // Assigned once the view switcher exists (below): navigates the tool window to the
+        // Memory Bank view. The card's "Open your Memory Bank" button invokes it via this var.
+        var openMemoryBank: () -> Unit = {}
         var backfillCard: BackfillPanel? = null
         try {
             lateinit var bfPanel: BackfillPanel
@@ -232,9 +235,12 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
                     stack.repaint()
                 }
             }
-            bfPanel = BackfillPanel(project, service) {
-                SwingUtilities.invokeLater { syncBackfillVisibility() }
-            }
+            bfPanel = BackfillPanel(
+                project,
+                service,
+                onVisibilityRefresh = { SwingUtilities.invokeLater { syncBackfillVisibility() } },
+                onOpenMemoryBank = { openMemoryBank() },
+            )
             // Immediate-invoke on add (service fires once when initialized) sets the initial
             // visibility; later cold-start recomputes / dismissals re-run it on the EDT.
             service.addBackfillListener { SwingUtilities.invokeLater(syncBackfillVisibility) }
@@ -369,7 +375,9 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         )
 
         // View switch (Current Branch / Memory Bank / Knowledge) above the breadcrumb.
-        val viewSwitch = ViewSwitchPanel { view ->
+        // The switch logic is a named function so the back-fill card's "Open your Memory Bank"
+        // button can drive it too (via `openMemoryBank`), keeping the switcher UI in sync.
+        fun applyView(view: ViewSwitchPanel.View) {
             // Switching views replaces the status card with a real view card.
             statusShown = false
             ai.jolli.jollimemory.core.telemetry.Telemetry.track(
@@ -394,6 +402,13 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
                     actionBar.isVisible = false
                 }
             }
+        }
+        val viewSwitch = ViewSwitchPanel { view -> applyView(view) }
+        // Wire the back-fill card's "Open your Memory Bank" button: select the Bank tab in the
+        // switcher (updates its highlight) and apply the view (switches the content card).
+        openMemoryBank = {
+            viewSwitch.setSelected(ViewSwitchPanel.View.BANK)
+            applyView(ViewSwitchPanel.View.BANK)
         }
 
         // Auto-switch to the STATUS card when Jolli Memory is disabled (preserves

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
@@ -210,6 +210,26 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         val memoriesCollapsible = CollapsiblePanel(
             "COMMITTED MEMORIES", "JolliMemory.CommitsActions", commitsPanel,
         )
+        // Cold-start "build memory from your history" card. Visible only when the repo has
+        // no memories yet or has recent own commits lacking one — the panel owns that
+        // decision via shouldBeVisible() (it stays up mid-flow). Fits its content and has
+        // no action toolbar (the id resolves to nothing — CollapsiblePanel tolerates that).
+        lateinit var backfillCollapsible: CollapsiblePanel
+        lateinit var backfillPanel: BackfillPanel
+        val syncBackfillVisibility = {
+            backfillCollapsible.isVisible = backfillPanel.shouldBeVisible()
+            backfillPanel.syncOffer()
+        }
+        backfillPanel = BackfillPanel(project, service) {
+            SwingUtilities.invokeLater { syncBackfillVisibility() }
+        }
+        backfillCollapsible = CollapsiblePanel(
+            "BUILD MEMORY", "JolliMemory.BackfillActions", backfillPanel, fitContent = true,
+            titleIcon = AllIcons.Actions.Refresh,
+        )
+        // Immediate-invoke on add (service fires once when initialized) sets the initial
+        // visibility; later cold-start recomputes / dismissals re-run it on the EDT.
+        service.addBackfillListener { SwingUtilities.invokeLater(syncBackfillVisibility) }
 
         // Live row-count suffix in the section headers, e.g. "PINNED (3)".
         pinnedCollapsible.setCount(pinnedPanel.currentRowCount())
@@ -223,9 +243,11 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         val accordionStack = WidthTrackingPanel().apply {
             layout = BoxLayout(this, BoxLayout.Y_AXIS)
             isOpaque = false
+            backfillCollapsible.alignmentX = Component.LEFT_ALIGNMENT
             pinnedCollapsible.alignmentX = Component.LEFT_ALIGNMENT
             currentMemoryCollapsible.alignmentX = Component.LEFT_ALIGNMENT
             memoriesCollapsible.alignmentX = Component.LEFT_ALIGNMENT
+            add(backfillCollapsible)
             add(pinnedCollapsible)
             add(currentMemoryCollapsible)
             add(memoriesCollapsible)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
@@ -211,32 +211,28 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         val memoriesCollapsible = CollapsiblePanel(
             "COMMITTED MEMORIES", "JolliMemory.CommitsActions", commitsPanel,
         )
-        // Cold-start "build memory from your history" card. Visible only when the repo has
-        // no memories yet or has recent own commits lacking one — the panel owns that
-        // decision via shouldBeVisible() (it stays up mid-flow). Fits its content and has
-        // no action toolbar (the id resolves to nothing — CollapsiblePanel tolerates that).
-        // Built defensively: a failure constructing this card (e.g. an SDK API drift between
-        // the plugin's build target and the running IDE) must NEVER blank the whole tool
-        // window — so on any throwable we log and simply omit the card. `null` = unavailable.
-        var backfillCollapsible: CollapsiblePanel? = null
+        // Cold-start "build memory from your history" card. Rendered as a BARE bordered card
+        // at the top of the stack (matching VS Code's `.backfill-panel` div) — deliberately NOT
+        // a titled accordion section, so there is no persistent "BUILD MEMORY" header: the card
+        // simply appears during cold start and hides on dismiss / once memory exists. The panel
+        // owns its visibility via shouldBeVisible() (it stays up mid-flow).
+        // Built defensively: a failure constructing this card (e.g. an SDK API drift between the
+        // plugin's build target and the running IDE) must NEVER blank the whole tool window — so
+        // on any throwable we log and simply omit the card. `null` = unavailable.
+        var backfillCard: BackfillPanel? = null
         try {
-            lateinit var bfCollapsible: CollapsiblePanel
             lateinit var bfPanel: BackfillPanel
             val syncBackfillVisibility = {
-                bfCollapsible.isVisible = bfPanel.shouldBeVisible()
+                bfPanel.isVisible = bfPanel.shouldBeVisible()
                 bfPanel.syncOffer()
             }
             bfPanel = BackfillPanel(project, service) {
                 SwingUtilities.invokeLater { syncBackfillVisibility() }
             }
-            bfCollapsible = CollapsiblePanel(
-                "BUILD MEMORY", "JolliMemory.BackfillActions", bfPanel, fitContent = true,
-                titleIcon = AllIcons.Actions.Refresh,
-            )
             // Immediate-invoke on add (service fires once when initialized) sets the initial
             // visibility; later cold-start recomputes / dismissals re-run it on the EDT.
             service.addBackfillListener { SwingUtilities.invokeLater(syncBackfillVisibility) }
-            backfillCollapsible = bfCollapsible
+            backfillCard = bfPanel
         } catch (e: Throwable) {
             Logger.getInstance(JolliMemoryToolWindowFactory::class.java)
                 .warn("Back-fill cold-start card unavailable (rest of the tool window unaffected): ${e.message}", e)
@@ -254,11 +250,11 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         val accordionStack = WidthTrackingPanel().apply {
             layout = BoxLayout(this, BoxLayout.Y_AXIS)
             isOpaque = false
-            backfillCollapsible?.alignmentX = Component.LEFT_ALIGNMENT
+            backfillCard?.alignmentX = Component.LEFT_ALIGNMENT
             pinnedCollapsible.alignmentX = Component.LEFT_ALIGNMENT
             currentMemoryCollapsible.alignmentX = Component.LEFT_ALIGNMENT
             memoriesCollapsible.alignmentX = Component.LEFT_ALIGNMENT
-            backfillCollapsible?.let { add(it) }
+            backfillCard?.let { add(it) }
             add(pinnedCollapsible)
             add(currentMemoryCollapsible)
             add(memoriesCollapsible)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
@@ -225,6 +225,12 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
             val syncBackfillVisibility = {
                 bfPanel.isVisible = bfPanel.shouldBeVisible()
                 bfPanel.syncOffer()
+                // Relayout the accordion so hiding the card collapses its space immediately.
+                val stack = bfPanel.parent
+                if (stack != null) {
+                    stack.revalidate()
+                    stack.repaint()
+                }
             }
             bfPanel = BackfillPanel(project, service) {
                 SwingUtilities.invokeLater { syncBackfillVisibility() }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
@@ -458,7 +458,48 @@ class SettingsDialog(
             .addComponent(createMigrateButton(), 12)
             .panel))
 
+        // Historical memory — the re-entry point for the cold-start "build memory" flow.
+        // Runs a full-scope back-fill regardless of whether the tool-window card was
+        // dismissed; on success BackfillRunner clears the repo-wide dismiss marker, so a
+        // dismissed card can resurface. Mirrors the VS Code Memory Bank settings button.
+        panel.add(Box.createVerticalStrut(16))
+        panel.add(JBLabel("<html><b>Historical memory</b></html>").apply {
+            alignmentX = JComponent.LEFT_ALIGNMENT
+            border = JBUI.Borders.emptyBottom(2)
+        })
+        panel.add(JBLabel("<html><span style='color:gray'>Build memory for past commits that don't have one yet.</span></html>").apply {
+            alignmentX = JComponent.LEFT_ALIGNMENT
+            border = JBUI.Borders.emptyBottom(4)
+        })
+        panel.add(JPanel(java.awt.FlowLayout(java.awt.FlowLayout.LEFT, 0, 0)).apply {
+            alignmentX = JComponent.LEFT_ALIGNMENT
+            isOpaque = false
+            add(createGenerateMissingButton())
+        })
+
         return wrapTabContent(panel)
+    }
+
+    /**
+     * "Generate Missing Summaries" — full-scope back-fill (every own commit lacking a
+     * summary). Analog of the VS Code Memory Bank settings button. Shares [BackfillRunner]
+     * with the tool-window cold-start card, so progress + completion behave identically;
+     * an empty hash list maps to the CLI's `--all`. On success the runner clears the card's
+     * dismiss marker, which is how a dismissed repo gets the card back.
+     */
+    private fun createGenerateMissingButton(): JComponent {
+        return JButton("Generate Missing Summaries").apply {
+            toolTipText = "Generate memory for past commits that don't have one yet (uses on-disk Claude transcripts)"
+            addActionListener {
+                isEnabled = false
+                ai.jolli.jollimemory.backfill.BackfillRunner.run(
+                    project = project,
+                    service = service,
+                    hashes = emptyList(),
+                    onComplete = { javax.swing.SwingUtilities.invokeLater { isEnabled = true } },
+                )
+            }
+        }
     }
 
     private fun buildGeneralTab(): JComponent {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
@@ -428,11 +428,16 @@ class SummaryPanel(
             .take(80)
             .ifBlank { "memory" }
         ApplicationManager.getApplication().invokeLater {
+            // 2-arg constructor + withExtensionFilter is the non-deprecated form (2025.1+);
+            // the vararg-extensions constructor is deprecated and flagged by the Marketplace
+            // verifier. withExtensionFilter mutates the descriptor in place and returns the
+            // FileChooserDescriptor base, so call it as a statement and keep `descriptor` typed
+            // as FileSaverDescriptor for createSaveFileDialog.
             val descriptor = com.intellij.openapi.fileChooser.FileSaverDescriptor(
                 "Save Memory As Markdown",
                 "Export this memory to a Markdown file.",
-                "md",
             )
+            descriptor.withExtensionFilter("Markdown", "md")
             val baseDir = project.basePath
                 ?.let { com.intellij.openapi.vfs.LocalFileSystem.getInstance().findFileByPath(it) }
             val wrapper = com.intellij.openapi.fileChooser.FileChooserFactory.getInstance()

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryMarkdownBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryMarkdownBuilder.kt
@@ -2,7 +2,9 @@ package ai.jolli.jollimemory.toolwindow.views
 
 import ai.jolli.jollimemory.core.CommitSummary
 import ai.jolli.jollimemory.core.E2eTestScenario
+import ai.jolli.jollimemory.core.ModelPricing
 import ai.jolli.jollimemory.core.SummaryTree
+import ai.jolli.jollimemory.toolwindow.CommitMemoryFormat
 import ai.jolli.jollimemory.toolwindow.views.SummaryUtils.ViewTopicWithDate
 import ai.jolli.jollimemory.toolwindow.views.SummaryUtils.collectSortedTopics
 import ai.jolli.jollimemory.toolwindow.views.SummaryUtils.formatDate
@@ -69,6 +71,26 @@ object SummaryMarkdownBuilder {
 
         if (totalTurns > 0) {
             lines.add("- **Conversations:** $totalTurns turn${if (totalTurns != 1) "s" else ""}")
+        }
+
+        // Task usage: token total + cache-aware Sonnet-rate cost, aggregated across the whole
+        // consolidation tree (a squash/amend memory carries its tokens on folded children).
+        // Exact figures (thousands-separated counts, precise $) — the shared article shows more
+        // precision than the compact UI token bar. Omit-when-zero mirrors the Conversations line.
+        // Matches vscode SummaryMarkdownBuilder.pushPropertiesSection so both tools push the same line.
+        val totalTokens = SummaryTree.aggregateConversationTokens(summary)
+        if (totalTokens > 0) {
+            val agg = SummaryTree.aggregateConversationTokenBreakdown(summary)
+            val hasBreakdown = agg.input > 0 || agg.output > 0 || agg.cached > 0
+            val cost = CommitMemoryFormat.formatExactCostUsd(ModelPricing.estimateSonnetCostUsd(agg, totalTokens))
+            val split = if (hasBreakdown) {
+                " (${CommitMemoryFormat.formatTokensExact(agg.input)} input, " +
+                    "${CommitMemoryFormat.formatTokensExact(agg.output)} output, " +
+                    "${CommitMemoryFormat.formatTokensExact(agg.cached)} cached)"
+            } else {
+                ""
+            }
+            lines.add("- **Task usage:** ${CommitMemoryFormat.formatTokensExact(totalTokens)} tokens · $cost$split")
         }
 
         val memoryDocUrl = summary.jolliDocUrl

--- a/intellij/src/main/resources/icons/database.svg
+++ b/intellij/src/main/resources/icons/database.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <ellipse cx="8" cy="3.5" rx="5" ry="2" stroke="#6C707E" stroke-width="1.2"/>
+  <path d="M3 3.5 V12.5 C3 13.66 5.24 14.5 8 14.5 C10.76 14.5 13 13.66 13 12.5 V3.5" stroke="#6C707E" stroke-width="1.2" stroke-linecap="round"/>
+  <path d="M3 8 C3 9.1 5.24 9.9 8 9.9 C10.76 9.9 13 9.1 13 8" stroke="#6C707E" stroke-width="1.2" stroke-linecap="round"/>
+</svg>

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/backfill/BackfillDismissFlagTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/backfill/BackfillDismissFlagTest.kt
@@ -1,0 +1,68 @@
+package ai.jolli.jollimemory.backfill
+
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+/**
+ * Round-trips the dismiss marker against a real git repo, asserting it lands under the
+ * shared git common dir (`<git-common-dir>/jollimemory/backfill-card-dismissed`) so it is
+ * repo-wide — the same location the VS Code extension reads/writes.
+ */
+class BackfillDismissFlagTest {
+
+	@TempDir
+	lateinit var tempDir: Path
+	private lateinit var repo: File
+
+	@BeforeEach
+	fun setUp() {
+		repo = tempDir.toFile()
+		run("init", "-b", "main")
+		run("config", "user.email", "test@example.com")
+		run("config", "user.name", "Test User")
+	}
+
+	private fun run(vararg args: String) {
+		val p = ProcessBuilder(listOf("git") + args).directory(repo).redirectErrorStream(true).start()
+		check(p.waitFor(30, TimeUnit.SECONDS)) { "git ${args.joinToString(" ")} timed out" }
+		check(p.exitValue() == 0) { "git ${args.joinToString(" ")} failed" }
+	}
+
+	@Test
+	fun `defaults to not dismissed`() {
+		BackfillDismissFlag.isDismissed(repo.absolutePath).shouldBeFalse()
+	}
+
+	@Test
+	fun `set true writes the marker under the git common dir, set false removes it`() {
+		BackfillDismissFlag.setDismissed(repo.absolutePath, true)
+		BackfillDismissFlag.isDismissed(repo.absolutePath).shouldBeTrue()
+		File(repo, ".git/jollimemory/backfill-card-dismissed").exists().shouldBeTrue()
+
+		BackfillDismissFlag.setDismissed(repo.absolutePath, false)
+		BackfillDismissFlag.isDismissed(repo.absolutePath).shouldBeFalse()
+	}
+
+	@Test
+	fun `setting false when absent is a no-op (no throw)`() {
+		BackfillDismissFlag.setDismissed(repo.absolutePath, false)
+		BackfillDismissFlag.isDismissed(repo.absolutePath).shouldBeFalse()
+	}
+
+	@Test
+	fun `outside a git repo it reports not dismissed and does not throw`(@TempDir nonRepo: Path) {
+		// A SEPARATE temp dir (not the git-inited class tempDir, nor a child of it), so
+		// `git rev-parse --git-common-dir` finds no repo.
+		val dir = nonRepo.toFile().absolutePath
+		BackfillDismissFlag.isDismissed(dir).shouldBeFalse()
+		// Writing is inert (no common dir) — must not throw.
+		BackfillDismissFlag.setDismissed(dir, true)
+		BackfillDismissFlag.isDismissed(dir).shouldBeFalse()
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/BackfillPanelLabelsTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/BackfillPanelLabelsTest.kt
@@ -1,0 +1,50 @@
+package ai.jolli.jollimemory.toolwindow
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * The card's row/note wording MUST match vscode/src/views/BackfillListRenderer.ts 1:1
+ * (the two surfaces share a repo and users move between them). These assertions pin the
+ * exact strings so a drift in either implementation is caught.
+ */
+class BackfillPanelLabelsTest {
+
+	@Test
+	fun `backfillMeta reads sessions and turns, singularizing at 1`() {
+		BackfillPanel.backfillMeta(0, 0) shouldBe "Code change only"
+		BackfillPanel.backfillMeta(1, 1) shouldBe "1 session · 1 turn"
+		BackfillPanel.backfillMeta(3, 12) shouldBe "3 sessions · 12 turns"
+	}
+
+	@Test
+	fun `backfillResult reads sessions and topics, diff-only shows topics alone`() {
+		BackfillPanel.backfillResult(0, 1) shouldBe "1 topic"
+		BackfillPanel.backfillResult(0, 5) shouldBe "5 topics"
+		BackfillPanel.backfillResult(3, 5) shouldBe "3 sessions · 5 topics"
+	}
+
+	@Test
+	fun `coldStartNote empty variant invites building from scratch`() {
+		BackfillPanel.coldStartNote("empty", 0, 10) shouldBe
+			"You are set up — this repo has no memories yet. Build them from your recent commits, " +
+			"or just keep coding and they capture automatically."
+	}
+
+	@Test
+	fun `coldStartNote gaps variant states the count when under the cap`() {
+		BackfillPanel.coldStartNote("gaps", 1, 10) shouldBe
+			"You are set up. 1 recent commit from the last month (up to 10) without a memory yet — " +
+			"build now, or keep coding (new commits capture automatically)."
+		BackfillPanel.coldStartNote("gaps", 4, 10) shouldBe
+			"You are set up. 4 recent commits from the last month (up to 10) without a memory yet — " +
+			"build now, or keep coding (new commits capture automatically)."
+	}
+
+	@Test
+	fun `coldStartNote gaps variant switches to capped copy at the cap`() {
+		BackfillPanel.coldStartNote("gaps", 10, 10) shouldBe
+			"You are set up. The 10 most recent commits from the last month without a memory yet — " +
+			"build now, or manage all in Settings (new commits capture automatically)."
+	}
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryMarkdownBuilderTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryMarkdownBuilderTest.kt
@@ -1,6 +1,7 @@
 package ai.jolli.jollimemory.toolwindow.views
 
 import ai.jolli.jollimemory.core.CommitSummary
+import ai.jolli.jollimemory.core.ConversationTokenBreakdown
 import ai.jolli.jollimemory.core.DiffStats
 import ai.jolli.jollimemory.core.E2eTestScenario
 import ai.jolli.jollimemory.core.LlmCallMetadata
@@ -90,6 +91,33 @@ class SummaryMarkdownBuilderTest {
         fun `includes conversations when turns greater than 0`() {
             val md = SummaryMarkdownBuilder.buildMarkdown(makeSummary())
             md shouldContain "**Conversations:**"
+        }
+
+        // Token/cost "Task usage" line shared to the Jolli site — must match the VS Code
+        // SummaryMarkdownBuilder output verbatim (exact counts, Sonnet-rate $) so a memory
+        // reads the same whichever editor pushed it.
+        @Test
+        fun `includes Task usage with cost and segment split when a breakdown is present`() {
+            val summary = makeSummary().copy(
+                conversationTokenBreakdown = ConversationTokenBreakdown(1_000_000, 1_000_000, 1_000_000),
+            )
+            val md = SummaryMarkdownBuilder.buildMarkdown(summary)
+            md shouldContain
+                "- **Task usage:** 3,000,000 tokens · \$21.75 (1,000,000 input, 1,000,000 output, 1,000,000 cached)"
+        }
+
+        @Test
+        fun `Task usage prices a breakdown-less token total at the input rate, no split`() {
+            val summary = makeSummary().copy(conversationTokens = 1_000_000)
+            val md = SummaryMarkdownBuilder.buildMarkdown(summary)
+            md shouldContain "- **Task usage:** 1,000,000 tokens · \$3.00"
+            md shouldNotContain "input, "
+        }
+
+        @Test
+        fun `Task usage omitted when there are no conversation tokens`() {
+            val md = SummaryMarkdownBuilder.buildMarkdown(makeSummary())
+            md shouldNotContain "**Task usage:**"
         }
 
         @Test


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (2)

1. Add historical back-fill (cold-start) to the IntelliJ plugin (`1bb08d7`)
2. Move &quot;Generate Missing Summaries&quot; to the Memory Bank settings tab (`dc245ea`)

## Quick recap (2)

### Commit 1 of 2: Add historical back-fill (cold-start) to the IntelliJ plugin (`1bb08d7`)

The IntelliJ plugin gained a complete historical back-fill feature, bringing it to parity with the VS Code extension. When a user opens a repository that has no memory summaries yet, or has recent commits without one, a "BUILD MEMORY" card now appears at the top of the Jolli Memory tool window. The card walks through four states: an offer with a plain-language description of what is missing, a selectable list of commits showing how many AI conversations were attributed to each, a live progress bar that advances commit by commit, and a done view summarizing what was generated. Users can also dismiss the card permanently for a repository, and the dismissal is shared with VS Code — opening the same repository in either editor will respect the choice made in the other.

A "Generate Missing Summaries" button was also added to the IntelliJ settings panel, giving users a way to run a full back-fill over every commit lacking a summary at any time, not just on cold start. Both the card and the settings button share the same background runner, so progress reporting and completion notifications behave identically regardless of which entry point triggered the generation.

To make all of this possible, the command-line engine gained three new output modes: one that returns cold-start signals as structured data without touching the LLM, one that accepts an explicit list of commits to process, and one that streams a progress event per commit as generation proceeds. These additions let the IntelliJ plugin drive the same interactive experience that VS Code achieves by calling the engine directly, with the actual summary generation remaining in one shared implementation.

### Commit 2 of 2: Move &quot;Generate Missing Summaries&quot; to the Memory Bank settings tab (`dc245ea`)

The IntelliJ plugin's "Generate Missing Summaries" action moved from the IDE-level preferences page to the Memory Bank tab inside the plugin's own Settings panel — the same location where VS Code users already find this feature. Previously, dismissing the back-fill card left no visible path to restart the process; now users can open the plugin's Settings panel, navigate to the Memory Bank tab, and trigger a full back-fill at any time. A successful run from this new location also clears the dismissed state, so the back-fill card can reappear automatically if new unprocessed commits are detected later.

## Topics (4)
<details>
<summary><strong>01 · [1bb08d7] Add historical back-fill cold-start card to IntelliJ plugin</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The VS Code extension already offered users a way to generate memory summaries for past commits when first setting up a repository, but the IntelliJ plugin had no equivalent feature at all. The user wanted the IntelliJ plugin to reach the same level of capability.

**💡 Decisions Behind the Code**

- **Subprocess bridge over in-process JS runtime**: VS Code calls the backfill engine directly as a JavaScript function. Rather than embedding a JS runtime in the JVM plugin, IntelliJ shells out to the same bundled CLI that the plugin already uses for other operations. This keeps the generation logic in one place and means any engine improvement automatically benefits both editors, at the cost of slightly higher per-call overhead that is acceptable for a background task.
- **New CLI modes to expose the engine surface**: The existing CLI only exposed `runBackfill` as a batch command with text output. Three new modes were added — `--list-candidates` for cold-start signals, `--hashes` for user-selected subsets, and `--stream` for NDJSON per-commit progress — so IntelliJ can drive the same interactive UX that VS Code gets from in-process calls. This kept the CLI as the single source of truth rather than duplicating attribution or summary logic in Kotlin.
- **Repo-wide dismiss marker at the git common dir**: The dismiss flag is stored under the shared git common directory rather than per-worktree, matching the VS Code implementation exactly. This means dismissing the card in IntelliJ suppresses it in VS Code (and vice versa) across all worktrees of the same repository, which is the correct scope since memory presence itself is repo-wide.

**✅ What Was Implemented**

- Created a new `backfill` package in the IntelliJ plugin with three core files. `BackfillCli.kt` is a subprocess bridge that drives the CLI engine via three modes: candidate listing (no LLM), dry-run preview for session/turn counts, and streaming real generation with NDJSON progress events. `BackfillDismissFlag.kt` manages the repo-wide dismiss marker at the same git-common-dir path used by VS Code, ensuring a dismiss in one editor is honored in the other. `BackfillRunner.kt` is the shared background task entry point (using `Task.Backgroundable`) used by both the tool-window card and the Settings button, handling progress reporting and completion balloons.
- Added `BackfillPanel.kt` to the tool window: a four-state native Swing card (offer → selectable commit list → progress bar → done summary) that mirrors the VS Code sidebar card's wording and state machine exactly, with label strings asserted in tests to prevent drift.
- Wired cold-start detection into `JolliMemoryService` and `JolliMemoryStartupActivity`: on project open, a pooled thread calls `jolli backfill --list-candidates` to compute `coldStartVariant` (`empty`/`gaps`/null) and `recentMissingCount`, then notifies listeners so the tool window card appears or hides without blocking startup.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/backfill/BackfillCli.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/backfill/BackfillDismissFlag.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/backfill/BackfillRunner.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BackfillPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · [1bb08d7] Expose backfill engine over CLI subprocess boundary for out-of-process callers</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The IntelliJ plugin can only reach the backfill engine by running it as a subprocess, but the CLI command only supported batch text output with no way to list cold-start candidates, select a commit subset, or receive per-commit progress events.

**💡 Decisions Behind the Code**

- **Additive CLI surface rather than a separate IPC channel**: Rather than introducing a socket, named pipe, or dedicated IPC protocol between the plugin and the engine, the new modes extend the existing CLI command with structured output flags. This reuses the node/dist resolution and process lifecycle the plugin already manages, avoids a persistent daemon, and keeps the CLI self-contained and testable with standard unit tests.
- **NDJSON for streaming over plain JSON**: A single JSON object cannot be streamed incrementally, so `--stream` emits one line per event. NDJSON is trivially parseable line-by-line in both Kotlin and any future caller, and the final `type:"report"` line gives a clean termination signal without a separate exit-code convention.

**✅ What Was Implemented**

- Added `--hashes <csv>` to `BackfillCommand.ts` so callers can pass an explicit commit subset (overriding `--last`/`--all`), enabling the tool-window card to back-fill only the commits the user checked.
- Added `--list-candidates` mode that calls `repoHasAnyMemory`, `countMissingSummaries`, and `listMissingCommits` and emits a single JSON object with cold-start signals — no attribution scan, no LLM call. Accepts `--since-days` and `--limit` to match the VS Code 30-day/10-row defaults.
- Added `--stream` flag that emits one NDJSON progress line per commit (wired to `runBackfill`'s `onProgress` callback) followed by a final report line, allowing the IntelliJ progress bar to advance in real time without waiting for the full batch.

**📁 FILES**
- `cli/src/commands/BackfillCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [1bb08d7] Add Settings button to generate missing summaries from IntelliJ settings panel</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

VS Code provides a "Generate Missing Summaries" button in its settings panel that runs a full-scope back-fill over every commit lacking a summary. The IntelliJ settings panel had no equivalent entry point.

**💡 Decisions Behind the Code**

Sharing `BackfillRunner` between the Settings button and the tool-window card ensures both entry points produce identical progress and completion behavior without duplicating the background-task and notification logic. An empty hash list was chosen as the "full scope" signal rather than a separate flag, keeping the runner's interface simple and matching the CLI's `--all` semantics.

**✅ What Was Implemented**

Added a "Generate Missing Summaries" button to `JolliMemoryConfigurable.kt` under a new "Historical memory" label. Clicking it invokes `BackfillRunner.run` with an empty hash list (which maps to `--all` in the CLI), disables the button during the run, and re-enables it on completion. The runner handles progress reporting and the completion balloon identically to the tool-window card path.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/settings/JolliMemoryConfigurable.kt`

</blockquote>
</details>
<details>
<summary><strong>04 · [dc245ea] Move &quot;Generate Missing Summaries&quot; button to Memory Bank settings tab</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The user noticed that dismissing the back-fill card in the IntelliJ plugin made it disappear permanently with no obvious way to re-trigger it. The VS Code extension already exposes this action in its Memory Bank settings panel, and the user wanted the same experience in IntelliJ.

**💡 Decisions Behind the Code**

- **Placement mirrors VS Code parity**: The Memory Bank tab in the IntelliJ tool-window Settings dialog is the structural equivalent of VS Code's Memory Bank settings panel. Placing the button there means users who know where to find it in one IDE will find it in the same conceptual location in the other, rather than hunting through IDE-level preferences which are a less natural home for a per-repo memory action.
- **Shared runner preserves dismiss-marker clearing**: Reusing the existing back-fill runner (rather than a separate code path) means a successful run from the Settings dialog clears the repo-wide dismiss marker, allowing the tool-window card to resurface on future activity. A separate path would have silently left the card permanently suppressed even after a successful re-run.

**✅ What Was Implemented**

- Removed the "Generate Missing Summaries" button and its supporting panel builder from the IDE Preferences page (`JolliMemoryConfigurable.kt`), eliminating the misplaced entry point. The `backfillPanel()` helper method and its associated separator and label were deleted entirely.
- Added a new "Historical memory" section to the Memory Bank tab of the tool-window Settings dialog (`SettingsDialog.kt`), containing a heading, a descriptive subtitle, and a new `createGenerateMissingButton()` method. The button invokes `BackfillRunner` with an empty hash list (full scope), disables itself during the run, and re-enables on completion via `SwingUtilities.invokeLater`.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/settings/JolliMemoryConfigurable.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 7, 2026 at 4:40 PM · via Anthropic*
<!-- jollimemory-summary-end -->
