### PR TITLE
Fix disposed webview crash in NextMemoryPreviewPanel singleton

### DIFF
--- a/vscode/src/views/NextMemoryPreviewPanel.test.ts
+++ b/vscode/src/views/NextMemoryPreviewPanel.test.ts
@@ -92,6 +92,35 @@ describe("NextMemoryPreviewPanel.show", () => {
 		);
 	});
 
+	it("reopens a fresh panel after the previous one was disposed", async () => {
+		await NextMemoryPreviewPanel.show("file:///ext" as never, "/repo", makeBridge() as never, makeSidebarProvider() as never);
+		expect(createWebviewPanel).toHaveBeenCalledTimes(1);
+		// Close the panel — onDidDispose must clear the singleton so a re-open works.
+		lastPanel().onDispose();
+		await NextMemoryPreviewPanel.show("file:///ext" as never, "/repo", makeBridge() as never, makeSidebarProvider() as never);
+		expect(createWebviewPanel).toHaveBeenCalledTimes(2);
+	});
+
+	it("clears the singleton on dispose even when the disposed webview getter throws", async () => {
+		// Regression for the real crash (dev-tools log: "Webview is disposed" thrown
+		// from onDidDispose). After teardown, reading panel.webview throws; the
+		// dispose callback must use the cached webview reference so it neither throws
+		// nor leaves a dead panel as the singleton. Otherwise the next Review click
+		// reveal()s a disposed webview and silently does nothing.
+		await NextMemoryPreviewPanel.show("file:///ext" as never, "/repo", makeBridge() as never, makeSidebarProvider() as never);
+		expect(createWebviewPanel).toHaveBeenCalledTimes(1);
+		const panel = lastPanel();
+		// Emulate VS Code: once disposed, the webview getter throws.
+		Object.defineProperty(panel, "webview", {
+			get() {
+				throw new Error("Webview is disposed");
+			},
+		});
+		expect(() => panel.onDispose()).not.toThrow();
+		await NextMemoryPreviewPanel.show("file:///ext" as never, "/repo", makeBridge() as never, makeSidebarProvider() as never);
+		expect(createWebviewPanel).toHaveBeenCalledTimes(2);
+	});
+
 	it("reuses the existing panel on a second show() instead of creating a new one", async () => {
 		const bridge = makeBridge();
 		const sidebarProvider = makeSidebarProvider();

--- a/vscode/src/views/NextMemoryPreviewPanel.ts
+++ b/vscode/src/views/NextMemoryPreviewPanel.ts
@@ -131,17 +131,28 @@ export class NextMemoryPreviewPanel {
 				// extension host process.
 				sidebarProvider.handleOutbound(msg);
 			});
-			sidebarProvider.registerBroadcastTarget(panel.webview);
-			// Capture `panel` (not the module `currentPanel`) so dispose always
-			// unregisters THIS panel's webview and stays safe under double-dispose;
-			// only clear the singleton if it still points at this panel.
+			// Cache the webview reference. `panel.webview` is a getter that throws
+			// "Webview is disposed" once the panel is torn down — and onDidDispose
+			// fires exactly at teardown, so reading `panel.webview` *inside* the
+			// dispose callback throws, aborting the callback before it clears
+			// `currentPanel`. That left a disposed panel lingering as the singleton,
+			// so the next Review click reveal()-ed a dead webview and silently did
+			// nothing. Referencing the cached webview never touches the getter.
+			// (Other webview panels don't hit this because their dispose callbacks
+			// don't read the webview at all — this panel is the only one that must
+			// unregister a broadcast target on dispose.)
+			const webview = panel.webview;
+			sidebarProvider.registerBroadcastTarget(webview);
+			// Capture `panel`/`webview` (not the module `currentPanel`) so dispose
+			// always unregisters THIS panel's webview and stays safe under
+			// double-dispose; only clear the singleton if it still points here.
 			panel.onDidDispose(() => {
 				if (refreshTimer) {
 					clearTimeout(refreshTimer);
 					refreshTimer = undefined;
 				}
 				pendingSections.clear();
-				sidebarProvider.unregisterBroadcastTarget(panel.webview);
+				sidebarProvider.unregisterBroadcastTarget(webview);
 				if (currentPanel === panel) currentPanel = undefined;
 			});
 			currentPanel = panel;


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Jolli Memory

[https://jolli.ai/very/articles?doc=7224](https://jolli.ai/very/articles?doc=7224)

## Quick recap

The Working Memory review panel could silently stop opening after being closed. When a user dismissed the panel and clicked to reopen it, the extension would attempt to reveal a panel that had already been torn down, and nothing would appear on screen. The panel's cleanup logic read a property that VS Code intentionally makes unavailable after a panel closes, which caused the cleanup to crash partway through and leave the closed panel incorrectly registered as still active.

The fix captures the necessary reference at the moment the panel is first created, so the cleanup logic never needs to touch a property that may no longer be accessible. Two new automated tests lock in this behavior: one confirms that closing and reopening the panel always produces a fresh, working panel, and a second directly simulates VS Code's post-close behavior to ensure the cleanup completes without error even under those conditions.

---

## Topic (1)
<details>
<summary><strong>01 · Fix disposed webview crash in Working Memory review panel singleton</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After a user closed the Working Memory review panel and reopened it, the panel sometimes silently failed to appear. The root cause was a crash inside the panel's cleanup logic that left a dead, already-closed panel registered as the active singleton, so the next open attempt tried to reveal a panel that no longer existed.

**💡 Decisions Behind the Code**

- **Cache the webview reference at creation, not at dispose time**: Reading the webview through the panel getter inside the dispose callback is the direct cause of the crash, and the fix is to snapshot the reference the moment the panel is created. The alternative — wrapping the getter call in a try/catch inside the dispose callback — was implicitly rejected: it would suppress the error but still leave the broadcast-target unregistered inconsistently, and it obscures the real invariant (the cached reference is always valid for the lifetime of the callback closure).
- **Scope the fix narrowly to this panel**: The commit note observes that other webview panels in the codebase do not read the webview inside their dispose callbacks, so they are not affected by this class of bug. Applying a broader defensive pattern across all panels would add noise without benefit; the targeted fix keeps the change minimal and the reasoning local.

**✅ What Was Implemented**

- In `NextMemoryPreviewPanel.ts`, the dispose callback was changed to capture the webview reference in a local variable at panel-creation time rather than reading it through the panel's getter at dispose time. VS Code's panel getter throws "Webview is disposed" once a panel is torn down, and since the dispose callback fired at exactly that moment, the throw aborted the callback before it could clear the singleton pointer or unregister the broadcast target.
- Two new tests were added in `NextMemoryPreviewPanel.test.ts` to cover the regression: one verifies that a disposed panel is cleared from the singleton so a subsequent open creates a fresh panel, and a second specifically emulates VS Code's behavior of making the webview getter throw after disposal, asserting that the dispose callback neither throws nor leaves the dead panel as the singleton.

**📁 FILES**
- `vscode/src/views/NextMemoryPreviewPanel.ts`
- `vscode/src/views/NextMemoryPreviewPanel.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 8, 2026 at 10:52 AM · via Anthropic*
<!-- jollimemory-summary-end -->