### PR TITLE
Sync CONTEXT chip count when plans and notes section updates

### DIFF
--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -504,7 +504,7 @@ export function buildPropTable(
 	const shortHash = escHtml(summary.commitHash.substring(0, 8));
 
 	const convCount = transcriptHashSet?.size ?? 0;
-	const ctxCount = (summary.plans?.length ?? 0) + (summary.notes?.length ?? 0) + (summary.references?.length ?? 0);
+	const ctxCount = contextChipCount(summary);
 	// CommitSummary has no commit-level aggregated `filesAffected` (only
 	// per-topic TopicSummary.filesAffected exists — see Search.ts) — the
 	// diff-derived totalFiles (buildHtml's resolveDiffStats().filesChanged)
@@ -714,6 +714,17 @@ function buildE2ePanel(summary: CommitSummary): string {
 }
 
 /**
+ * The "CONTEXT N" chip count: plans + notes + references on the summary.
+ * Single source of truth for both the initial render (buildContextPanel) and
+ * the in-place `plansAndNotesUpdated` refresh (SummaryWebviewPanel.refreshPlansAndNotes),
+ * which must agree — the chip lives in #contextPanel's header, outside the
+ * #plansAndNotesSection HTML that the refresh replaces.
+ */
+export function contextChipCount(summary: CommitSummary): number {
+	return (summary.plans?.length ?? 0) + (summary.notes?.length ?? 0) + (summary.references?.length ?? 0);
+}
+
+/**
  * Builds the flat "Context" panel (plans + notes + references), replacing
  * the former collapsible-card "Attachments & context" panel. Per the mockup,
  * Context is a single flat `.panel` \u2014 no `.attach-card` wrappers \u2014 with a
@@ -750,8 +761,7 @@ export function buildContextPanel(
 		noteTranslateSet,
 		referenceTranslateSet,
 	);
-	const contextCount =
-		(summary.plans?.length ?? 0) + (summary.notes?.length ?? 0) + (summary.references?.length ?? 0);
+	const contextCount = contextChipCount(summary);
 	return `
 <div class="panel" id="contextPanel">
   <div class="panel-header">

--- a/vscode/src/views/SummaryScriptBuilder.test.ts
+++ b/vscode/src/views/SummaryScriptBuilder.test.ts
@@ -434,6 +434,16 @@ describe("SummaryScriptBuilder", () => {
 			expect(script).toContain("bindPlansAndNotesSection()");
 		});
 
+		it("plansAndNotesUpdated syncs the CONTEXT chip in #contextPanel's header (outside the replaced section)", () => {
+			// The visible "CONTEXT N" count is #contextPanel's panel-header .sec-count,
+			// which sits OUTSIDE #plansAndNotesSection (that section's own header is
+			// CSS-hidden), so replaceSection can't touch it — it must be updated from
+			// the message's count field.
+			expect(script).toContain("getElementById('contextPanel')");
+			expect(script).toContain(".panel-header .sec-count");
+			expect(script).toContain("String(msg.count)");
+		});
+
 		it("jolliRowUpdated targets the header row by id", () => {
 			expect(script).toContain("msg.command === 'jolliRowUpdated'");
 			expect(script).toContain("getElementById('jolliRow')");

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -1726,6 +1726,15 @@ export function buildScript(options: SummaryScriptOptions = {}): string {
   if (msg.command === 'plansAndNotesUpdated' && typeof msg.html === 'string') {
     replaceSection('plansAndNotesSection', msg.html);
     bindPlansAndNotesSection();
+    // The visible "CONTEXT N" chip is #contextPanel's panel-header .sec-count,
+    // which sits OUTSIDE the just-replaced #plansAndNotesSection (that section's
+    // own header is CSS-hidden), so replaceSection can't update it — sync it here
+    // from the recomputed count the host sent alongside the html.
+    if (typeof msg.count === 'number') {
+      var ctxPanel = document.getElementById('contextPanel');
+      var ctxCount = ctxPanel ? ctxPanel.querySelector('.panel-header .sec-count') : null;
+      if (ctxCount) ctxCount.textContent = String(msg.count);
+    }
   }
 
   // ── Header Jolli row (published Plans & Notes link list) ──

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -509,16 +509,23 @@ const {
 	mockBuildJolliRow: vi.fn().mockReturnValue("<div>jolliRow</div>"),
 }));
 
-vi.mock("./SummaryHtmlBuilder.js", () => ({
-	buildHtml: mockBuildHtml,
-	buildE2eTestSection: mockBuildE2eTestSection,
-	buildRecapSection: mockBuildRecapSection,
-	buildTopicsSection: mockBuildTopicsSection,
-	renderTopic: mockRenderTopic,
-	renderE2eScenario: mockRenderE2eScenario,
-	buildPlansAndNotesSection: mockBuildPlansAndNotesSection,
-	buildJolliRow: mockBuildJolliRow,
-}));
+vi.mock("./SummaryHtmlBuilder.js", async (importActual) => {
+	// contextChipCount is a pure helper with no side effects — use the real one
+	// so the "CONTEXT N" count assertion exercises the actual formula rather than
+	// a hand-copied stub that could silently drift from production.
+	const actual = await importActual<typeof import("./SummaryHtmlBuilder.js")>();
+	return {
+		buildHtml: mockBuildHtml,
+		buildE2eTestSection: mockBuildE2eTestSection,
+		buildRecapSection: mockBuildRecapSection,
+		buildTopicsSection: mockBuildTopicsSection,
+		renderTopic: mockRenderTopic,
+		renderE2eScenario: mockRenderE2eScenario,
+		buildPlansAndNotesSection: mockBuildPlansAndNotesSection,
+		buildJolliRow: mockBuildJolliRow,
+		contextChipCount: actual.contextChipCount,
+	};
+});
 
 const { mockBuildMarkdown, mockBuildPrMarkdown } = vi.hoisted(() => ({
 	mockBuildMarkdown: vi.fn().mockReturnValue("# Markdown Output"),
@@ -1465,6 +1472,37 @@ describe("SummaryWebviewPanel", () => {
 			expect(commands).toContain("jolliRowUpdated");
 			// references (3rd positional arg) forwarded, not dropped.
 			expect(mockBuildPlansAndNotesSection.mock.calls[0][2]).toEqual([reference]);
+		});
+
+		it("refreshPlansAndNotes carries the context count so the CONTEXT chip (outside #plansAndNotesSection) stays in sync", async () => {
+			// The visible "CONTEXT N" chip lives in #contextPanel's panel-header,
+			// which is NOT part of the #plansAndNotesSection HTML that plansAndNotesUpdated
+			// replaces — so the count must ride along the message to be re-applied.
+			const summary = makeSummary({
+				commitHash: "aaa",
+				plans: [{ slug: "plan-1", title: "p", status: "active", commitHash: "aaa" }],
+				notes: [{ id: "note-1", title: "n", format: "markdown", commitHash: "aaa" }],
+				references: [
+					{
+						source: "linear" as const,
+						archivedKey: "linear:ENG-1",
+						nativeId: "ENG-1",
+						title: "Ref",
+						url: "https://linear.app/x/ENG-1",
+						referencedAt: "2025-01-01T00:00:00Z",
+						sourceToolName: "Linear",
+					},
+				],
+			});
+			const instance = await getPanelInstance(summary);
+			postMessage.mockClear();
+
+			instance.refreshPlansAndNotes(summary);
+
+			const call = postMessage.mock.calls.find(
+				(c) => c[0].command === "plansAndNotesUpdated",
+			);
+			expect(call?.[0].count).toBe(3);
 		});
 
 		it("refreshTopicsSection threads readOnly=true on a foreign panel", async () => {

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -112,6 +112,7 @@ import {
 	buildPlansAndNotesSection,
 	buildRecapSection,
 	buildTopicsSection,
+	contextChipCount,
 	type FileRow,
 	renderE2eScenario,
 	renderTopic,
@@ -1487,6 +1488,12 @@ export class SummaryWebviewPanel {
 				this.noteTranslateSet,
 				this.referenceTranslateSet,
 			),
+			// The visible "CONTEXT N" chip lives in #contextPanel's panel-header
+			// (buildContextPanel), OUTSIDE the #plansAndNotesSection HTML above —
+			// so it can't be refreshed by the section replace. Carry the recomputed
+			// count along so the client can sync the chip. Shared with
+			// buildContextPanel via contextChipCount so the two can't drift.
+			count: contextChipCount(summary),
 		});
 		this.panel.webview.postMessage({
 			command: "jolliRowUpdated",


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Quick recap

The developer fixed a stale count display in the Memory detail page. When users deleted a context, the underlying plans and notes section refreshed correctly, but the visible "CONTEXT N" chip in the panel header remained unchanged. The root cause was architectural: the visible chip and the refreshed section are separate DOM elements, with the section's own header hidden by CSS.

The fix carries the recomputed count alongside the section HTML update and applies it directly to the visible chip, ensuring the display stays current. To prevent future maintenance hazards, the context chip count formula was consolidated from three separate locations into a single shared helper function. Any code that needs the count now calls the same function, making it impossible to accidentally use stale or inconsistent logic. The test was updated to exercise the real formula rather than a mock copy, further protecting against divergence.

---

## Topic (1)
<details>
<summary><strong>01 · Sync CONTEXT chip count when plans and notes section updates</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user deleted a context from the Memory detail page, the visible "CONTEXT N" count in the panel header did not update, even though the underlying section was refreshed.

**💡 Decisions Behind the Code**

- **Shared helper over duplication**: The context chip count formula was extracted into a single `contextChipCount` helper function to eliminate maintenance risk. The formula was previously duplicated across three locations, maintained only by a comment saying they "must match." Consolidating into one function enforces the formula at compile time and prevents silent divergence if future changes are made to what counts as "context."
- **Function declaration over const arrow**: The helper was declared as an `export function` rather than a const arrow function because function declarations are hoisted in JavaScript, allowing it to be called from earlier in the file (line 507 in buildPropTable) without triggering a temporal dead zone error.
- **Message-carried count over client recomputation**: The visible chip and the refreshed section are separate DOM elements, with the section's own header hidden by CSS. Carrying the count in the message and applying it separately ensures the visible chip stays in sync without requiring the client to recompute or re-query the DOM. This mirrors the existing pattern used for the Conversations panel when detaching references.

**✅ What Was Implemented**

- **SummaryWebviewPanel.ts**: Modified `refreshPlansAndNotes` to compute and include a `count` field in the `plansAndNotesUpdated` message. The count is calculated using a shared helper function that sums plans, notes, and references.
- **SummaryScriptBuilder.ts**: Updated the `plansAndNotesUpdated` message handler to sync the visible chip count. After replacing the section HTML, the handler now updates the `.sec-count` element inside `#contextPanel`'s panel header using the count value from the message.
- **SummaryHtmlBuilder.ts**: Created a new shared helper function `contextChipCount(summary)` that computes the plans + notes + references count. This function is called from three locations: the property table's context count, the context panel's header chip count, and the webview message sent during plans/notes refresh.
- **Tests**: Added test cases in SummaryWebviewPanel.test.ts verifying the host sends the correct count, and in SummaryScriptBuilder.test.ts verifying the client applies it to the correct DOM element. The test mock uses the real `contextChipCount` function via `importActual` to ensure the test exercises the actual formula rather than a hand-copied stub.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.ts`
- `vscode/src/views/SummaryScriptBuilder.ts`
- `vscode/src/views/SummaryHtmlBuilder.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 8, 2026 at 4:29 PM · via Anthropic*
<!-- jollimemory-summary-end -->