### PR TITLE
 Add Slack thread references to knowledge system

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -769,7 +769,7 @@ export interface Reference {
 	/** Stable id native to the source (Linear ticket id, Jira key, `owner/repo#number`, 32-hex Notion page id). */
 	readonly nativeId: string;
 	readonly title: string;
-	/** Absent only when the definition's `url` FieldSpec is marked `optional` and the payload has no url (e.g. Slack with no permalink and no configured workspace). */
+	/** Optional in the type as a forward-compat allowance for a url-optional source definition; every source shipping today marks `url` as required in its FieldSpec, so an extracted reference always carries one. */
 	readonly url?: string;
 	readonly description?: string;
 	/** Opaque, source-specific display fields. Built and consumed only by the adapter. */

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -732,7 +732,7 @@ export interface NoteReference {
 export type SourceId = string;
 
 /** The four source ids that ship as built-in `SourceDefinition`s. Docs/reference only — not an exhaustive runtime set. */
-export type KnownSourceId = "linear" | "jira" | "github" | "notion";
+export type KnownSourceId = "linear" | "jira" | "github" | "notion" | "slack";
 
 /**
  * ReferenceField — one displayable field produced by a `SourceDefinition`'s `fields` pipes.
@@ -769,7 +769,8 @@ export interface Reference {
 	/** Stable id native to the source (Linear ticket id, Jira key, `owner/repo#number`, 32-hex Notion page id). */
 	readonly nativeId: string;
 	readonly title: string;
-	readonly url: string;
+	/** Absent only when the definition's `url` FieldSpec is marked `optional` and the payload has no url (e.g. Slack with no permalink and no configured workspace). */
+	readonly url?: string;
 	readonly description?: string;
 	/** Opaque, source-specific display fields. Built and consumed only by the adapter. */
 	readonly fields?: ReadonlyArray<ReferenceField>;
@@ -792,7 +793,8 @@ export interface ReferenceEntry {
 	readonly source: SourceId;
 	readonly nativeId: string;
 	readonly title: string;
-	readonly url: string;
+	/** Absent only when the source `Reference.url` was absent (e.g. Slack with no permalink). */
+	readonly url?: string;
 	/** Absolute path to `<jolliMemoryDir>/references/<source>/<sanitized-key>.md`. */
 	readonly sourcePath: string;
 	readonly addedAt: string;
@@ -815,7 +817,8 @@ export interface ReferenceCommitRef {
 	readonly source: SourceId;
 	readonly nativeId: string;
 	readonly title: string;
-	readonly url: string;
+	/** Absent only when the source `Reference.url` was absent (e.g. Slack with no permalink). */
+	readonly url?: string;
 	/** Opaque, source-specific display fields — snapshot of the Reference's `fields` at archive time. */
 	readonly fields?: ReadonlyArray<ReferenceField>;
 	readonly referencedAt: string;
@@ -1150,6 +1153,15 @@ export interface JolliMemoryConfig {
 	 * and skew the AI-source-mix view. Source names only (e.g. "codex"), no PII.
 	 */
 	readonly telemetrySeenSources?: ReadonlyArray<string>;
+	/**
+	 * Slack integration config. `workspaceUrl` (e.g. "https://my-team.slack.com")
+	 * lets the reference extractor reconstruct a thread permalink when the user
+	 * never pasted one into the transcript — the `slack_read_thread` MCP result
+	 * carries neither a url nor the workspace subdomain.
+	 */
+	readonly slack?: {
+		readonly workspaceUrl?: string;
+	};
 }
 
 /** Result of enable/disable operations */

--- a/cli/src/commands/ConfigureCommand.test.ts
+++ b/cli/src/commands/ConfigureCommand.test.ts
@@ -176,6 +176,122 @@ describe("ConfigureCommand — settable keys", () => {
 		expect(help).toContain("globalInstructions");
 	});
 
+	describe("slack.workspaceUrl validation", () => {
+		it("accepts an https://<workspace>.slack.com URL and persists it nested under slack", async () => {
+			// Fallback source for the reference extractor's thread permalinks when
+			// the user never pasted one into the transcript (see Slack capture).
+			await runConfigure(["--set", "slack.workspaceUrl=https://flyer-q4r7867.slack.com"]);
+			expect(mockSaveConfig).toHaveBeenCalledWith(
+				expect.objectContaining({ slack: { workspaceUrl: "https://flyer-q4r7867.slack.com" } }),
+			);
+			expect((await loadConfig()).slack?.workspaceUrl).toBe("https://flyer-q4r7867.slack.com");
+		});
+
+		it("normalizes a trailing-slash URL to its origin (no double slash on permalink reconstruction)", async () => {
+			await runConfigure(["--set", "slack.workspaceUrl=https://flyer-q4r7867.slack.com/"]);
+			expect((await loadConfig()).slack?.workspaceUrl).toBe("https://flyer-q4r7867.slack.com");
+		});
+
+		it("merges with an existing slack object instead of clobbering it", async () => {
+			mockLoadConfig.mockResolvedValue({ slack: { workspaceUrl: "https://old-team.slack.com" } });
+			await runConfigure(["--set", "slack.workspaceUrl=https://new-team.slack.com"]);
+			expect(mockSaveConfig).toHaveBeenCalledWith(
+				expect.objectContaining({ slack: { workspaceUrl: "https://new-team.slack.com" } }),
+			);
+		});
+
+		it("rejects a non-slack.com host", async () => {
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const prevExitCode = process.exitCode;
+			try {
+				await runConfigure(["--set", "slack.workspaceUrl=https://evil.example"]);
+				expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("slack.com"));
+				expect(process.exitCode).toBe(1);
+				expect(mockSaveConfig).not.toHaveBeenCalled();
+			} finally {
+				errorSpy.mockRestore();
+				process.exitCode = prevExitCode;
+			}
+		});
+
+		it("rejects a non-https URL", async () => {
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const prevExitCode = process.exitCode;
+			try {
+				await runConfigure(["--set", "slack.workspaceUrl=http://team.slack.com"]);
+				expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("slack.com"));
+				expect(process.exitCode).toBe(1);
+				expect(mockSaveConfig).not.toHaveBeenCalled();
+			} finally {
+				errorSpy.mockRestore();
+				process.exitCode = prevExitCode;
+			}
+		});
+
+		it("lists slack.workspaceUrl in help/description output", async () => {
+			const help = await runConfigureHelp();
+			expect(help).toContain("slack.workspaceUrl");
+		});
+
+		it("rejects a malformed URL (not-a-url string)", async () => {
+			// Closes the untested `catch` branch in coerceConfigValue when
+			// `new URL(raw)` throws. Confirms the error is propagated and config
+			// is not persisted.
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const prevExitCode = process.exitCode;
+			try {
+				await runConfigure(["--set", "slack.workspaceUrl=not-a-url"]);
+				expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("slack.com"));
+				expect(process.exitCode).toBe(1);
+				expect(mockSaveConfig).not.toHaveBeenCalled();
+			} finally {
+				errorSpy.mockRestore();
+				process.exitCode = prevExitCode;
+			}
+		});
+
+		it("rejects a spoof host matching .slack.com suffix but with evil prefix", async () => {
+			// https://evilslack.com does not end with `.slack.com`, so the
+			// suffix-boundary host check in isAllowedSlackHost rejects it.
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const prevExitCode = process.exitCode;
+			try {
+				await runConfigure(["--set", "slack.workspaceUrl=https://evilslack.com"]);
+				expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("slack.com"));
+				expect(process.exitCode).toBe(1);
+				expect(mockSaveConfig).not.toHaveBeenCalled();
+			} finally {
+				errorSpy.mockRestore();
+				process.exitCode = prevExitCode;
+			}
+		});
+
+		it("rejects a URL with .slack.com in the domain but evil TLD", async () => {
+			// https://x.slack.com.evil.com has `.slack.com` in the name but ends
+			// with `.evil.com`, so the suffix boundary check rejects it.
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const prevExitCode = process.exitCode;
+			try {
+				await runConfigure(["--set", "slack.workspaceUrl=https://x.slack.com.evil.com"]);
+				expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("slack.com"));
+				expect(process.exitCode).toBe(1);
+				expect(mockSaveConfig).not.toHaveBeenCalled();
+			} finally {
+				errorSpy.mockRestore();
+				process.exitCode = prevExitCode;
+			}
+		});
+
+		it("removes slack.workspaceUrl via --remove", async () => {
+			// Set a valid workspace URL first, then remove it.
+			mockLoadConfig.mockResolvedValue({ slack: { workspaceUrl: "https://team.slack.com" } });
+			await runConfigure(["--remove", "slack.workspaceUrl"]);
+			expect(mockSaveConfig).toHaveBeenCalledWith(
+				expect.objectContaining({ slack: { workspaceUrl: undefined } }),
+			);
+		});
+	});
+
 	describe("maxTokens validation (positive integer only)", () => {
 		async function expectMaxTokensRejected(value: string): Promise<void> {
 			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/cli/src/commands/ConfigureCommand.ts
+++ b/cli/src/commands/ConfigureCommand.ts
@@ -30,6 +30,12 @@ const VALID_GLOBAL_INSTRUCTIONS: ReadonlyArray<NonNullable<JolliMemoryConfig["gl
 /**
  * Valid config keys exposed via `jolli configure --set/--remove`.
  * Must stay in sync with {@link JolliMemoryConfig} in Types.ts.
+ *
+ * `"slack.workspaceUrl"` is the one exception: it's a dotted pseudo-key for
+ * the nested `slack.workspaceUrl` field, not a top-level `keyof
+ * JolliMemoryConfig`. It's coerced and validated like any other key, then
+ * folded into a nested `{ slack: { workspaceUrl } }` update just before
+ * `saveConfig` — see the flattening step in the `--set`/`--remove` handler.
  */
 const VALID_CONFIG_KEYS = [
 	"apiKey",
@@ -50,9 +56,15 @@ const VALID_CONFIG_KEYS = [
 	"aiProvider",
 	"syncTranscripts",
 	"syncPollIntervalSec",
-] as const satisfies ReadonlyArray<keyof JolliMemoryConfig>;
+	"slack.workspaceUrl",
+] as const satisfies ReadonlyArray<keyof JolliMemoryConfig | "slack.workspaceUrl">;
 
 type ConfigKey = (typeof VALID_CONFIG_KEYS)[number];
+
+/** Hosts allowed for `slack.workspaceUrl`: `slack.com` or any subdomain of it. */
+function isAllowedSlackHost(hostname: string): boolean {
+	return hostname === "slack.com" || hostname.endsWith(".slack.com");
+}
 
 /** Keys whose values should be masked when displayed (contain secrets). */
 const SENSITIVE_KEYS: ReadonlySet<string> = new Set(["apiKey", "jolliApiKey", "authToken"]);
@@ -141,6 +153,23 @@ function coerceConfigValue(key: ConfigKey, raw: string): string | number | boole
 			.map((s) => s.trim())
 			.filter(Boolean);
 	}
+	// Nested field: validated like the JolliApiUtils origin allowlist —
+	// HTTPS-only, suffix-boundary host check — before it's ever persisted.
+	if (key === "slack.workspaceUrl") {
+		let parsed: URL;
+		try {
+			parsed = new URL(raw);
+		} catch {
+			throw new Error(`slack.workspaceUrl must be an https://<workspace>.slack.com URL (got: ${raw})`);
+		}
+		if (parsed.protocol !== "https:" || !isAllowedSlackHost(parsed.hostname)) {
+			throw new Error(`slack.workspaceUrl must be an https://<workspace>.slack.com URL (got: ${raw})`);
+		}
+		// Persist the normalized origin (scheme + host, no trailing slash or path)
+		// so the reference extractor's `${workspaceUrl}/archives/...` permalink
+		// reconstruction can't produce a double slash from a trailing-slash input.
+		return parsed.origin;
+	}
 	// String fields (apiKey, model, jolliApiKey, authToken, localFolder)
 	return raw;
 }
@@ -197,6 +226,12 @@ const CONFIG_KEY_INFO: ReadonlyArray<{ key: ConfigKey; type: string; description
 		key: "syncPollIntervalSec",
 		type: "number",
 		description: "Sync poll interval in seconds (5400-86400; default + floor = 90 min, ceiling = 24h; plugin only)",
+	},
+	{
+		key: "slack.workspaceUrl",
+		type: "string",
+		description:
+			"Slack workspace base URL (https://<workspace>.slack.com) — fallback for thread permalinks when none was pasted",
 	},
 ];
 
@@ -280,6 +315,18 @@ export function registerConfigureCommand(program: Command): void {
 						return;
 					}
 					update[key] = undefined;
+				}
+
+				// Fold the dotted "slack.workspaceUrl" pseudo-key into a nested update.
+				// saveConfig/saveConfigScoped only shallow-merge top-level keys, so a
+				// bare `update.slack = { workspaceUrl }` would clobber sibling `slack`
+				// fields on disk — read the current config and spread its `slack`
+				// object first.
+				if ("slack.workspaceUrl" in update) {
+					const workspaceUrl = update["slack.workspaceUrl"] as string | undefined;
+					delete update["slack.workspaceUrl"];
+					const existing = await loadConfig();
+					update.slack = { ...existing.slack, workspaceUrl };
 				}
 
 				await saveConfig(update as Partial<JolliMemoryConfig>);

--- a/cli/src/core/Regenerator.test.ts
+++ b/cli/src/core/Regenerator.test.ts
@@ -971,11 +971,11 @@ describe("regenerateSummary", () => {
 		expect(params.notes).toContain("NB");
 	});
 
-	it("uses empty string for ref.url when ReferenceCommitRef.url is missing", async () => {
+	it("omits the <url> line when ReferenceCommitRef.url is missing", async () => {
 		// Legacy/corrupt ReferenceCommitRef may lack the url field — the
-		// adapter's renderPromptBlock receives an Reference whose url is "" so
-		// escapeForText doesn't choke. Output renders `<url></url>` (empty
-		// inner text) the same as the first-run LinearAdapter path.
+		// adapter's renderPromptBlock receives a Reference whose url is "" so
+		// escapeForText doesn't choke. renderOne omits the <url> line entirely
+		// for an empty/undefined url rather than emitting `<url></url>`.
 		const noUrl: CommitSummary = {
 			...baseSummary,
 			references: [
@@ -995,7 +995,8 @@ describe("regenerateSummary", () => {
 		await regenerateSummary(noUrl, "/repo", config);
 
 		const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
-		expect(params.referenceBlocks).toContain("<url></url>");
+		expect(params.referenceBlocks).not.toContain("<url>");
+		expect(params.referenceBlocks).toContain('<issue id="JOLLI-9">');
 	});
 
 	it("caps the total <plans> block at PLAN_TOTAL_CHARS (60000) and drops the oldest plan when exceeded", async () => {

--- a/cli/src/core/SummaryMarkdownBuilder.test.ts
+++ b/cli/src/core/SummaryMarkdownBuilder.test.ts
@@ -470,6 +470,28 @@ describe("pushPlansAndNotesSection references gating", () => {
 		pushPlansAndNotesSection(lines, summary, { includeReferences: true });
 		expect(lines.join("\n")).toContain("[ENG-1 — Fix](https://l/ENG-1)");
 	});
+	it("drops the nativeId lead for non-tracker sources (Slack / Notion) but keeps it for trackers", () => {
+		const lines: string[] = [];
+		pushPlansAndNotesSection(
+			lines,
+			{
+				plans: [],
+				notes: [],
+				references: [
+					{ source: "linear", nativeId: "ENG-1", title: "Fix", url: "https://l/ENG-1" },
+					{ source: "slack", nativeId: "C1-1700000000.1", title: "Thread title", url: "https://s/t" },
+					{ source: "notion", nativeId: "abcdef12", title: "Page title", url: "https://n/p" },
+				],
+			} as never,
+			{ includeReferences: true },
+		);
+		const out = lines.join("\n");
+		expect(out).toContain("[ENG-1 — Fix](https://l/ENG-1)");
+		expect(out).toContain("[Thread title](https://s/t)");
+		expect(out).toContain("[Page title](https://n/p)");
+		expect(out).not.toContain("C1-1700000000.1 —");
+		expect(out).not.toContain("abcdef12 —");
+	});
 });
 
 describe("pushExcludedContextSection", () => {

--- a/cli/src/core/SummaryMarkdownBuilder.ts
+++ b/cli/src/core/SummaryMarkdownBuilder.ts
@@ -8,6 +8,7 @@
 
 import type { CommitSummary, E2eTestScenario, ReferenceCommitRef, SourceId } from "../Types.js";
 import { escMdLinkText, escMdUrl } from "./MarkdownEscape.js";
+import { referenceDisplayTitle } from "./references/ReferenceDisplay.js";
 import { getRegistry } from "./references/SourceDefinitionRegistry.js";
 import {
 	collectSortedTopics,
@@ -187,7 +188,7 @@ export function pushPlansAndNotesSection(
 	}
 
 	for (const e of referencesBySourceOrder(references)) {
-		const label = `${escMdLinkText(e.nativeId)} — ${escMdLinkText(e.title)}`;
+		const label = escMdLinkText(referenceDisplayTitle(e));
 		lines.push(e.url ? `- [${label}](${escMdUrl(e.url)})` : `- ${label}`);
 	}
 }

--- a/cli/src/core/SummaryMarkdownBuilder.ts
+++ b/cli/src/core/SummaryMarkdownBuilder.ts
@@ -187,7 +187,8 @@ export function pushPlansAndNotesSection(
 	}
 
 	for (const e of referencesBySourceOrder(references)) {
-		lines.push(`- [${escMdLinkText(e.nativeId)} — ${escMdLinkText(e.title)}](${escMdUrl(e.url)})`);
+		const label = `${escMdLinkText(e.nativeId)} — ${escMdLinkText(e.title)}`;
+		lines.push(e.url ? `- [${label}](${escMdUrl(e.url)})` : `- ${label}`);
 	}
 }
 

--- a/cli/src/core/references/ClaudeEnvelopeParser.test.ts
+++ b/cli/src/core/references/ClaudeEnvelopeParser.test.ts
@@ -45,7 +45,11 @@ describe("ClaudeEnvelopeParser slack", () => {
 		});
 		expect((results[0].payload as { url?: string }).url).toBe(PERMALINK);
 	});
-	it("captures linklessly when neither permalink nor config present", () => {
+	it("emits a urlless canonical when neither permalink nor config present (extractRef voids it downstream)", () => {
+		// The parser is a lower layer than extractRef: it still surfaces the
+		// canonical thread object with no url. The slack definition marks url
+		// required, so `SourceEngine.extractRef` is where this urlless payload
+		// is voided (see slack.test.ts / SourceEngine.test.ts) — nothing is stored.
 		const { results } = claudeEnvelopeParser.parse(lines().slice(1), {});
 		expect((results[0].payload as { url?: string }).url).toBeUndefined();
 	});

--- a/cli/src/core/references/ClaudeEnvelopeParser.test.ts
+++ b/cli/src/core/references/ClaudeEnvelopeParser.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { claudeEnvelopeParser } from "./ClaudeEnvelopeParser.js";
+
+const PERMALINK = "https://flyer-q4r7867.slack.com/archives/C0BFF9UHBD1/p1783413984700009";
+const BLOB =
+	"=== THREAD PARENT MESSAGE ===\nMessage TS: 1783413984.700009\nConsolidate…\n\n=== THREAD REPLIES (2 total) ===\n";
+
+function lines(): string[] {
+	return [
+		JSON.stringify({ message: { role: "user", content: [{ type: "text", text: `look ${PERMALINK}` }] } }),
+		JSON.stringify({
+			message: {
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "t1",
+						name: "mcp__claude_ai_Slack__slack_read_thread",
+						input: { channel_id: "C0BFF9UHBD1", message_ts: "1783413984.700009" },
+					},
+				],
+			},
+		}),
+		JSON.stringify({
+			message: {
+				role: "user",
+				content: [{ type: "tool_result", tool_use_id: "t1", content: JSON.stringify({ messages: BLOB }) }],
+			},
+		}),
+	];
+}
+
+describe("ClaudeEnvelopeParser slack", () => {
+	it("correlates the pasted permalink with the thread result", () => {
+		const { results } = claudeEnvelopeParser.parse(lines(), {});
+		expect(results).toHaveLength(1);
+		const p = results[0].payload as { channelId: string; parentTs: string; url?: string };
+		expect(results[0].def.id).toBe("slack");
+		expect(p).toMatchObject({ channelId: "C0BFF9UHBD1", parentTs: "1783413984.700009", url: PERMALINK });
+	});
+	it("reconstructs url from slackWorkspaceUrl when no permalink pasted", () => {
+		const noPermalink = lines().slice(1); // drop the user permalink line
+		const { results } = claudeEnvelopeParser.parse(noPermalink, {
+			slackWorkspaceUrl: "https://flyer-q4r7867.slack.com",
+		});
+		expect((results[0].payload as { url?: string }).url).toBe(PERMALINK);
+	});
+	it("captures linklessly when neither permalink nor config present", () => {
+		const { results } = claudeEnvelopeParser.parse(lines().slice(1), {});
+		expect((results[0].payload as { url?: string }).url).toBeUndefined();
+	});
+});

--- a/cli/src/core/references/ClaudeEnvelopeParser.ts
+++ b/cli/src/core/references/ClaudeEnvelopeParser.ts
@@ -27,8 +27,10 @@ import { createLogger } from "../../Logger.js";
 import { CLAUDE_SHELL_TOOL_NAMES, CLAUDE_TOOL_PREFIXES } from "./bindings/claude/index.js";
 import { matchCliCommand } from "./bindings/cli/index.js";
 import { isObject } from "./guards.js";
+import { scanUserPermalinks } from "./SlackPermalink.js";
 import type { SourceDefinition } from "./SourceDefinition.js";
 import { getRegistry } from "./SourceDefinitionRegistry.js";
+import { normalizeSlackThread } from "./sources/SlackNormalize.js";
 import type {
 	EnvelopeParseResult,
 	ExtractOptions,
@@ -64,6 +66,14 @@ interface PendingEntry {
 	/** CLI (shell) entries require a successful command — drop the result if
 	 *  `is_error: true`. MCP entries set this false to keep prior behaviour. */
 	readonly requireSuccess: boolean;
+	/**
+	 * The tool_use `input`, retained only for Slack (`def.id === "slack"`).
+	 * Slack's `normalize` needs both the tool result payload AND out-of-payload
+	 * context (`channel_id` / `message_ts` from the originating tool_use) that no
+	 * other source needs — every other MCP source's `normalize` is `identity`
+	 * and never looks at this field.
+	 */
+	readonly toolInput?: unknown;
 }
 
 class ClaudeEnvelopeParser implements TranscriptEnvelopeParser {
@@ -72,6 +82,11 @@ class ClaudeEnvelopeParser implements TranscriptEnvelopeParser {
 		const pending = new Map<string, PendingEntry>();
 		const results: NormalizedToolResult[] = [];
 		let lastConsumed = fromLine;
+		// Slack's normalize needs a url no MCP payload carries; the pasted
+		// permalink (if any) is the only place it lives. Scanned once up front so
+		// every user text line is visited exactly once regardless of how many
+		// Slack tool_results follow it.
+		const permalinks = scanUserPermalinks(lines);
 
 		for (let i = fromLine; i < lines.length; i++) {
 			const line = lines[i];
@@ -107,7 +122,7 @@ class ClaudeEnvelopeParser implements TranscriptEnvelopeParser {
 				/* v8 ignore start -- readRole returns only "assistant" | "user" | undefined; undefined is filtered above, so the else-if's false branch is unreachable. */
 			} else if (role === "user") {
 				/* v8 ignore stop */
-				collectToolResults(blocks, i + 1, timestamp, opts.beforeTimestamp, pending, results);
+				collectToolResults(blocks, i + 1, timestamp, opts.beforeTimestamp, pending, results, permalinks, opts);
 			}
 		}
 
@@ -168,7 +183,17 @@ function collectToolUses(
 		// `notion-fetch`) live in the registry's `match.claude` rules.
 		const mcpDef = registry.match("claude", name);
 		if (mcpDef !== undefined) {
-			pending.set(b.id, { toolName: name, timestamp, def: mcpDef, normalize: identity, requireSuccess: false });
+			pending.set(b.id, {
+				toolName: name,
+				timestamp,
+				def: mcpDef,
+				normalize: identity,
+				requireSuccess: false,
+				// Only Slack's normalize needs the tool_use input (channel_id /
+				// message_ts); every other source's `normalize` is `identity` and
+				// never reads `toolInput`, so it's left undefined for them.
+				...(mcpDef.id === "slack" ? { toolInput: b.input } : {}),
+			});
 			continue;
 		}
 		// CLI/shell fallback (e.g. `Bash` running `gh issue view … --json`): the
@@ -195,6 +220,17 @@ function collectToolUses(
 	}
 }
 
+/** `{channel_id, message_ts}` off a Slack tool_use's `input`, or undefined if malformed. */
+function readSlackToolInput(input: unknown): { channelId: string; messageTs: string } | undefined {
+	/* v8 ignore start -- defensive: real `slack_read_thread` tool_use input always carries both string fields; guarded for totality against a malformed/future MCP shape. */
+	if (!isObject(input)) return undefined;
+	const channelId = (input as { channel_id?: unknown }).channel_id;
+	const messageTs = (input as { message_ts?: unknown }).message_ts;
+	if (typeof channelId !== "string" || typeof messageTs !== "string") return undefined;
+	/* v8 ignore stop */
+	return { channelId, messageTs };
+}
+
 function collectToolResults(
 	blocks: readonly unknown[],
 	lineNumber: number,
@@ -202,6 +238,8 @@ function collectToolResults(
 	beforeTimestamp: string | undefined,
 	pending: Map<string, PendingEntry>,
 	results: NormalizedToolResult[],
+	permalinks: Map<string, string>,
+	opts: ExtractOptions,
 ): void {
 	if (beforeTimestamp !== undefined && timestamp !== undefined && timestamp > beforeTimestamp) return;
 	for (const block of blocks) {
@@ -241,6 +279,43 @@ function collectToolResults(
 			pending.delete(b.tool_use_id);
 			continue;
 		}
+
+		// Slack needs both the payload AND out-of-payload context (channel_id /
+		// message_ts from the tool_use, url from the permalink map or config) that
+		// no other source's `normalize` (all `identity`) reads — handled as a
+		// distinct branch rather than folding into `pendingEntry.normalize` so
+		// that hook stays a pure `(payload, command) => payload` shape for every
+		// other source.
+		if (pendingEntry.def.id === "slack") {
+			const slackInput = readSlackToolInput(pendingEntry.toolInput);
+			/* v8 ignore start -- defensive: paired with a real slack_read_thread tool_use, input is always well-formed. */
+			if (slackInput === undefined) {
+				pending.delete(b.tool_use_id);
+				continue;
+			}
+			/* v8 ignore stop */
+			const { channelId, messageTs } = slackInput;
+			const url =
+				permalinks.get(`${channelId}:${messageTs}`) ??
+				(opts.slackWorkspaceUrl !== undefined
+					? `${opts.slackWorkspaceUrl}/archives/${channelId}/p${messageTs.replace(".", "")}`
+					: undefined);
+			const canonical = normalizeSlackThread(parsedPayload, { channelId, url });
+			if (canonical === null) {
+				pending.delete(b.tool_use_id);
+				continue;
+			}
+			results.push({
+				def: pendingEntry.def,
+				toolName: pendingEntry.toolName,
+				payload: canonical,
+				lineNumber,
+				referencedAt: timestamp ?? "",
+			});
+			pending.delete(b.tool_use_id);
+			continue;
+		}
+
 		results.push({
 			def: pendingEntry.def,
 			toolName: pendingEntry.toolName,

--- a/cli/src/core/references/GoldenParity.test.ts
+++ b/cli/src/core/references/GoldenParity.test.ts
@@ -23,6 +23,7 @@ import { githubDefinition } from "./sources/definitions/github.js";
 import { jiraDefinition } from "./sources/definitions/jira.js";
 import { linearDefinition } from "./sources/definitions/linear.js";
 import { notionDefinition } from "./sources/definitions/notion.js";
+import { slackDefinition } from "./sources/definitions/slack.js";
 
 const ts = "2026-05-27T00:00:00.000Z";
 const tsOld = "2026-01-01T00:00:00Z";
@@ -670,5 +671,110 @@ Body text from the page.</content>
 
 	it("renders an empty string for no refs", () => {
 		expect(renderBlock(notionDefinition, [])).toBe("");
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Slack
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("GoldenParity: slack", () => {
+	const tool = "mcp__claude_ai_Slack__slack_read_thread";
+
+	// The literal `=== THREAD PARENT MESSAGE ===` blob shape produced by the real
+	// `slack_read_thread` tool, already trimmed the way `normalizeSlackThread`
+	// trims it. The engine here only ever sees the POST-normalize canonical
+	// object below (channelId/parentTs/title/text/replyCount/url), never this
+	// raw blob — SlackNormalize.test.ts covers the raw-blob → canonical parse.
+	const THREAD_TEXT = `=== THREAD PARENT MESSAGE ===
+From: Flyer Li (U0BGFSM16DN)
+Time: 2026-07-07 16:46:24 CST
+Message TS: 1783413984.700009
+Consolidate the existing Linear / Jira / GitHub / Notion …
+
+=== THREAD REPLIES (2 total) ===
+
+--- Reply 1 of 2 ---
+From: Flyer Li (U0BGFSM16DN)
+Time: 2026-07-07 17:18:37 CST
+Message TS: 1783415917.422609
+Config-driven MCP integration
+
+--- Reply 2 of 2 ---
+From: Flyer Li (U0BGFSM16DN)
+Time: 2026-07-07 17:23:48 CST
+Message TS: 1783416228.715669
+How to do?`;
+
+	const CANON = {
+		channelId: "C0BFF9UHBD1",
+		parentTs: "1783413984.700009",
+		title: "Consolidate the existing Linear / Jira / GitHub / Notion …",
+		text: THREAD_TEXT,
+		replyCount: 2,
+		url: "https://flyer-q4r7867.slack.com/archives/C0BFF9UHBD1/p1783413984700009",
+	};
+	const GOLDEN_HAPPY_REF: Reference = {
+		mapKey: "slack:C0BFF9UHBD1-1783413984.700009",
+		source: "slack",
+		nativeId: "C0BFF9UHBD1-1783413984.700009",
+		title: "Consolidate the existing Linear / Jira / GitHub / Notion …",
+		url: "https://flyer-q4r7867.slack.com/archives/C0BFF9UHBD1/p1783413984700009",
+		fields: [
+			{ key: "entity-type", label: "Type", value: "thread", icon: "comment-discussion" },
+			{ key: "replies", label: "Replies", value: "2", icon: "reply" },
+			{ key: "channel", label: "Channel", value: "C0BFF9UHBD1", icon: "symbol-namespace" },
+		],
+		description: THREAD_TEXT,
+		toolName: tool,
+		referencedAt: ts,
+	};
+	const GOLDEN_HAPPY_XML = `<slack-threads>\n<thread id="C0BFF9UHBD1-1783413984.700009" entity-type="thread" replies="2" channel="C0BFF9UHBD1">\n  <title>Consolidate the existing Linear / Jira / GitHub / Notion …</title>\n  <url>https://flyer-q4r7867.slack.com/archives/C0BFF9UHBD1/p1783413984700009</url>\n  <messages>\n${THREAD_TEXT}\n  </messages>\n</thread>\n</slack-threads>`;
+
+	it("extracts and renders the real captured thread payload", () => {
+		const ref = extractRef(slackDefinition, CANON, tool, ts);
+		expect(ref).toEqual(GOLDEN_HAPPY_REF);
+		expect(renderBlock(slackDefinition, [ref as Reference])).toBe(GOLDEN_HAPPY_XML);
+	});
+
+	it("voids on a nativeId that doesn't match the channel-dash-ts shape", () => {
+		expect(extractRef(slackDefinition, { ...CANON, channelId: "not valid!" }, tool, ts)).toBeNull();
+	});
+
+	it("voids on missing title", () => {
+		expect(extractRef(slackDefinition, { ...CANON, title: "" }, tool, ts)).toBeNull();
+	});
+
+	it("captures a linkless thread (no url, no url field, no <url> line) when the canonical object has no url", () => {
+		const canonNoUrl = {
+			channelId: "C0BFF9UHBD1",
+			parentTs: "1783413984.700009",
+			title: "Consolidate the existing Linear / Jira / GitHub / Notion …",
+			text: THREAD_TEXT,
+			replyCount: 2,
+		};
+		const ref = extractRef(slackDefinition, canonNoUrl, tool, ts);
+		expect(ref).toEqual({
+			mapKey: "slack:C0BFF9UHBD1-1783413984.700009",
+			source: "slack",
+			nativeId: "C0BFF9UHBD1-1783413984.700009",
+			title: "Consolidate the existing Linear / Jira / GitHub / Notion …",
+			fields: [
+				{ key: "entity-type", label: "Type", value: "thread", icon: "comment-discussion" },
+				{ key: "replies", label: "Replies", value: "2", icon: "reply" },
+				{ key: "channel", label: "Channel", value: "C0BFF9UHBD1", icon: "symbol-namespace" },
+			],
+			description: THREAD_TEXT,
+			toolName: tool,
+			referencedAt: ts,
+		});
+		expect(ref?.url).toBeUndefined();
+		expect(renderBlock(slackDefinition, [ref as Reference])).toBe(
+			`<slack-threads>\n<thread id="C0BFF9UHBD1-1783413984.700009" entity-type="thread" replies="2" channel="C0BFF9UHBD1">\n  <title>Consolidate the existing Linear / Jira / GitHub / Notion …</title>\n  <messages>\n${THREAD_TEXT}\n  </messages>\n</thread>\n</slack-threads>`,
+		);
+	});
+
+	it("renders an empty string for no refs", () => {
+		expect(renderBlock(slackDefinition, [])).toBe("");
 	});
 });

--- a/cli/src/core/references/GoldenParity.test.ts
+++ b/cli/src/core/references/GoldenParity.test.ts
@@ -745,7 +745,7 @@ How to do?`;
 		expect(extractRef(slackDefinition, { ...CANON, title: "" }, tool, ts)).toBeNull();
 	});
 
-	it("captures a linkless thread (no url, no url field, no <url> line) when the canonical object has no url", () => {
+	it("voids a thread with no resolvable url — linkless threads are not stored", () => {
 		const canonNoUrl = {
 			channelId: "C0BFF9UHBD1",
 			parentTs: "1783413984.700009",
@@ -753,25 +753,7 @@ How to do?`;
 			text: THREAD_TEXT,
 			replyCount: 2,
 		};
-		const ref = extractRef(slackDefinition, canonNoUrl, tool, ts);
-		expect(ref).toEqual({
-			mapKey: "slack:C0BFF9UHBD1-1783413984.700009",
-			source: "slack",
-			nativeId: "C0BFF9UHBD1-1783413984.700009",
-			title: "Consolidate the existing Linear / Jira / GitHub / Notion …",
-			fields: [
-				{ key: "entity-type", label: "Type", value: "thread", icon: "comment-discussion" },
-				{ key: "replies", label: "Replies", value: "2", icon: "reply" },
-				{ key: "channel", label: "Channel", value: "C0BFF9UHBD1", icon: "symbol-namespace" },
-			],
-			description: THREAD_TEXT,
-			toolName: tool,
-			referencedAt: ts,
-		});
-		expect(ref?.url).toBeUndefined();
-		expect(renderBlock(slackDefinition, [ref as Reference])).toBe(
-			`<slack-threads>\n<thread id="C0BFF9UHBD1-1783413984.700009" entity-type="thread" replies="2" channel="C0BFF9UHBD1">\n  <title>Consolidate the existing Linear / Jira / GitHub / Notion …</title>\n  <messages>\n${THREAD_TEXT}\n  </messages>\n</thread>\n</slack-threads>`,
-		);
+		expect(extractRef(slackDefinition, canonNoUrl, tool, ts)).toBeNull();
 	});
 
 	it("renders an empty string for no refs", () => {

--- a/cli/src/core/references/ReferenceDisplay.test.ts
+++ b/cli/src/core/references/ReferenceDisplay.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { labelLeadsWithNativeId, referenceDisplayTitle } from "./ReferenceDisplay.js";
+
+describe("labelLeadsWithNativeId", () => {
+	it("leads with the nativeId for the issue trackers (recognizable keys)", () => {
+		for (const s of ["linear", "jira", "github"]) expect(labelLeadsWithNativeId(s)).toBe(true);
+	});
+	it("is title-only for machine-id sources (notion, slack) and any unknown/phase-2 source", () => {
+		for (const s of ["notion", "slack", "zoom", "phase2-custom", ""]) expect(labelLeadsWithNativeId(s)).toBe(false);
+	});
+});
+
+describe("referenceDisplayTitle", () => {
+	it("composes `<nativeId> — <title>` for the issue trackers", () => {
+		expect(referenceDisplayTitle({ source: "linear", nativeId: "ENG-1", title: "Fix" })).toBe("ENG-1 — Fix");
+		expect(referenceDisplayTitle({ source: "github", nativeId: "o/r#4", title: "Bug" })).toBe("o/r#4 — Bug");
+	});
+	it("returns the title alone for machine-id and unknown sources", () => {
+		expect(referenceDisplayTitle({ source: "slack", nativeId: "C1-1700000000.1", title: "Thread" })).toBe("Thread");
+		expect(referenceDisplayTitle({ source: "notion", nativeId: "abcdef12", title: "Page" })).toBe("Page");
+		expect(referenceDisplayTitle({ source: "zoom", nativeId: "z1", title: "Recording" })).toBe("Recording");
+	});
+});

--- a/cli/src/core/references/ReferenceDisplay.ts
+++ b/cli/src/core/references/ReferenceDisplay.ts
@@ -1,0 +1,37 @@
+/**
+ * Reference-label display policy — shared by every surface that renders a
+ * reference row / bullet (VS Code Plans tree + hover card, committed-memory
+ * HTML, PR / clipboard markdown).
+ *
+ * A label reads `<nativeId> — <title>` ONLY when the nativeId is an identifier
+ * a user recognizes at a glance: the issue keys of the ticket trackers
+ * (Linear `PROJ-1234`, Jira `KAN-5`, GitHub `owner/repo#42`). Every other
+ * source's nativeId is a machine id — a Notion 32-hex page id, a Slack
+ * `<channel>-<ts>`, or any phase-2 config-registered source — so its label
+ * leads with the title alone. The default is title-only; the three trackers
+ * opt in, so a new source needs no change here to render sensibly.
+ */
+const NATIVE_ID_TRACKER_SOURCES: ReadonlySet<string> = new Set(["linear", "jira", "github"]);
+
+/** True when a reference label should lead with `<nativeId> — ` before its title. */
+export function labelLeadsWithNativeId(source: string): boolean {
+	return NATIVE_ID_TRACKER_SOURCES.has(source);
+}
+
+/** The minimal shape {@link referenceDisplayTitle} reads — satisfied by both the cli `Reference`/`ReferenceCommitRef` and the vscode `ReferenceInfo`. */
+export interface DisplayableReference {
+	readonly source: string;
+	readonly nativeId: string;
+	readonly title: string;
+}
+
+/**
+ * The reference's row / bullet / label display title. This is the SINGLE home
+ * for both the decision (does the label lead with the nativeId?) AND the
+ * composition (`<nativeId> — <title>`), so no display site re-implements
+ * either — a caller passes the reference and applies only its own escaping
+ * (Markdown / HTML / raw) to the returned string.
+ */
+export function referenceDisplayTitle(reference: DisplayableReference): string {
+	return labelLeadsWithNativeId(reference.source) ? `${reference.nativeId} — ${reference.title}` : reference.title;
+}

--- a/cli/src/core/references/ReferenceExtractor.ts
+++ b/cli/src/core/references/ReferenceExtractor.ts
@@ -29,6 +29,7 @@
 import { readFile } from "node:fs/promises";
 import { createLogger } from "../../Logger.js";
 import type { Reference } from "../../Types.js";
+import { loadConfig } from "../SessionTracker.js";
 import { isObject } from "./guards.js";
 import type { SourceDefinition } from "./SourceDefinition.js";
 import * as SourceEngine from "./SourceEngine.js";
@@ -69,7 +70,22 @@ export async function extractReferencesFromTranscript(
 	/* v8 ignore stop */
 
 	const parser = getEnvelopeParser(opts.source);
-	const { results, lastLineNumberScanned } = parser.parse(lines, opts);
+	// Slack's normalize needs the workspace URL to reconstruct a permalink when
+	// none was pasted into the transcript. `parse()` is sync, so the one async
+	// config read happens here, once per call, and is threaded down via
+	// `ExtractOptions`. Tolerate a throw (e.g. an exotic mocked `readFile` in a
+	// caller's test) by falling back to undefined — never let a config-read
+	// failure abort reference extraction.
+	let slackWorkspaceUrl: string | undefined;
+	try {
+		slackWorkspaceUrl = (await loadConfig()).slack?.workspaceUrl;
+	} catch (err) {
+		log.debug("Failed to load config for Slack workspace URL: %s", (err as Error).message);
+	}
+	const { results, lastLineNumberScanned } = parser.parse(lines, {
+		...opts,
+		slackWorkspaceUrl: opts.slackWorkspaceUrl ?? slackWorkspaceUrl,
+	});
 
 	const collected: Reference[] = [];
 	for (const r of results) {

--- a/cli/src/core/references/ReferenceStore.test.ts
+++ b/cli/src/core/references/ReferenceStore.test.ts
@@ -213,11 +213,12 @@ describe("ReferenceStore", () => {
 			expect(after).toContain('"new"');
 		});
 
-		it("round-trips a Slack ref with no url (no permalink)", async () => {
-			// Slack references may legitimately lack a url — no configured
-			// workspace / no permalink in the payload. renderMarkdown must omit
-			// the `url:` line, and parseMarkdown must come back with `undefined`
-			// (not `""`) rather than rejecting the reference for a missing url.
+		it("round-trips a ref with no url line", async () => {
+			// Storage is source-agnostic: the frontmatter contract keeps only
+			// nativeId/title required (url may be absent for a legacy or
+			// hand-built ref), so renderMarkdown must omit the `url:` line and
+			// parseMarkdown must come back with `undefined` (not `""`) rather
+			// than rejecting the reference for a missing url.
 			const ref = slackRef();
 			const { sourcePath } = await writeReferenceMarkdown(ref, tempDir);
 			const raw = await readFile(sourcePath, "utf-8");

--- a/cli/src/core/references/ReferenceStore.test.ts
+++ b/cli/src/core/references/ReferenceStore.test.ts
@@ -30,6 +30,19 @@ function linearRef(overrides: Partial<Reference> = {}): Reference {
 	};
 }
 
+function slackRef(overrides: Partial<Reference> = {}): Reference {
+	return {
+		mapKey: "slack:C1-1700000000.000001",
+		source: "slack",
+		nativeId: "C1-1700000000.000001",
+		title: "t",
+		description: "body",
+		toolName: "tool",
+		referencedAt: "2026-01-01T00:00:00Z",
+		...overrides,
+	};
+}
+
 function githubRef(overrides: Partial<Reference> = {}): Reference {
 	return {
 		mapKey: "github:owner/repo#42",
@@ -198,6 +211,28 @@ describe("ReferenceStore", () => {
 			const after = await readFile(sourcePath, "utf-8");
 			expect(after).not.toBe(before);
 			expect(after).toContain('"new"');
+		});
+
+		it("round-trips a Slack ref with no url (no permalink)", async () => {
+			// Slack references may legitimately lack a url — no configured
+			// workspace / no permalink in the payload. renderMarkdown must omit
+			// the `url:` line, and parseMarkdown must come back with `undefined`
+			// (not `""`) rather than rejecting the reference for a missing url.
+			const ref = slackRef();
+			const { sourcePath } = await writeReferenceMarkdown(ref, tempDir);
+			const raw = await readFile(sourcePath, "utf-8");
+			expect(raw).not.toMatch(/^url:/m);
+			const back = await readReferenceMarkdown(sourcePath);
+			expect(back).toEqual({
+				mapKey: "slack:C1-1700000000.000001",
+				source: "slack",
+				nativeId: "C1-1700000000.000001",
+				title: "t",
+				referencedAt: ref.referencedAt,
+				toolName: ref.toolName,
+				description: "body",
+			});
+			expect(back?.url).toBeUndefined();
 		});
 
 		it("writes GitHub markdown under sanitized filename", async () => {

--- a/cli/src/core/references/ReferenceStore.ts
+++ b/cli/src/core/references/ReferenceStore.ts
@@ -192,7 +192,13 @@ function renderMarkdown(ref: Reference): string {
 	lines.push(`source: ${JSON.stringify(ref.source)}`);
 	lines.push(`nativeId: ${JSON.stringify(ref.nativeId)}`);
 	lines.push(`title: ${JSON.stringify(ref.title)}`);
-	lines.push(`url: ${JSON.stringify(ref.url)}`);
+	// Absent only for sources whose `url` FieldSpec is optional and the payload
+	// carried none (e.g. Slack with no permalink) — omit the frontmatter line
+	// entirely rather than writing `url: undefined` / `url: ""`, so parseMarkdown's
+	// missing-key path (→ undefined) is what round-trips it back.
+	if (ref.url !== undefined && ref.url.length > 0) {
+		lines.push(`url: ${JSON.stringify(ref.url)}`);
+	}
 	if (ref.fields !== undefined && ref.fields.length > 0) {
 		lines.push("fields:");
 		for (const f of ref.fields) lines.push(`  - ${JSON.stringify(f)}`);
@@ -211,8 +217,11 @@ function renderMarkdown(ref: Reference): string {
 /**
  * Parse markdown frontmatter into a Reference.
  *
- * Requires `source` and `nativeId` frontmatter (plus title / url / referencedAt /
- * sourceToolName). Returns null on malformed input or missing required fields.
+ * Requires `source`, `nativeId`, `title`, `referencedAt`, and `sourceToolName`
+ * frontmatter. `url` is optional — a missing `url:` key parses as `undefined`
+ * (Slack references may legitimately lack a permalink), not an empty string,
+ * and does not fail the reference. Returns null on malformed input or missing
+ * required fields.
  */
 function parseMarkdown(content: string): Reference | null {
 	/* v8 ignore start -- defensive typeof guard: callers (readReferenceMarkdown / parseFrontmatter callers) already pass `string` per the function signature; this branch only triggers if a future caller hands in `undefined`/`null` via an untyped path. */
@@ -286,19 +295,22 @@ function parseMarkdown(content: string): Reference | null {
 	const nativeId: string = nativeIdField;
 
 	const title = readString("title");
+	// A missing `url` key parses as `undefined`, not `""` — Slack references may
+	// legitimately lack a permalink, so url is NOT part of the required-field guard
+	// below (only nativeId/title stay required, per the frontmatter contract).
 	const url = readString("url");
 	const referencedAt = readString("referencedAt");
 	const sourceToolName = readString("sourceToolName");
-	if (!title || !url || referencedAt === undefined || !sourceToolName) return null;
+	if (!title || referencedAt === undefined || !sourceToolName) return null;
 
 	const ref: Reference = {
 		mapKey: `${source}:${nativeId}`,
 		source,
 		nativeId,
 		title,
-		url,
 		referencedAt,
 		toolName: sourceToolName,
+		...(url !== undefined ? { url } : {}),
 		...(refFields.length > 0 ? { fields: refFields } : {}),
 		...(body.length > 0 ? { description: body } : {}),
 	};

--- a/cli/src/core/references/SlackPermalink.test.ts
+++ b/cli/src/core/references/SlackPermalink.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { parseSlackPermalink, scanUserPermalinks } from "./SlackPermalink.js";
+
+const URL = "https://flyer-q4r7867.slack.com/archives/C0BFF9UHBD1/p1783413984700009";
+
+describe("parseSlackPermalink", () => {
+	it("parses workspace, channel, and dotted parentTs", () => {
+		expect(parseSlackPermalink(URL)).toEqual({
+			workspace: "flyer-q4r7867",
+			channel: "C0BFF9UHBD1",
+			parentTs: "1783413984.700009",
+			url: URL,
+		});
+	});
+	it("rejects a non-slack host", () => {
+		expect(parseSlackPermalink("https://evil.example/archives/C1/p1")).toBeNull();
+	});
+	it("rejects a channel message url with no p<ts> segment", () => {
+		expect(parseSlackPermalink("https://x.slack.com/archives/C1")).toBeNull();
+	});
+	it("rejects a permalink with wrong-length ts (not 16 digits)", () => {
+		expect(parseSlackPermalink("https://x.slack.com/archives/C1/p123456789012345")).toBeNull();
+	});
+});
+
+describe("scanUserPermalinks", () => {
+	it("reads only role:user message text and keys by channel:ts", () => {
+		const lines = [
+			JSON.stringify({ message: { role: "user", content: [{ type: "text", text: `see ${URL}` }] } }),
+			JSON.stringify({ message: { role: "assistant", content: [{ type: "text", text: URL }] } }),
+			JSON.stringify({ type: "last-prompt", lastPrompt: URL }),
+		];
+		const map = scanUserPermalinks(lines);
+		expect(map.get("C0BFF9UHBD1:1783413984.700009")).toBe(URL);
+		expect(map.size).toBe(1); // assistant text + last-prompt line ignored
+	});
+	it("ignores tool_result content inside a user message", () => {
+		const lines = [JSON.stringify({ message: { role: "user", content: [{ type: "tool_result", content: URL }] } })];
+		expect(scanUserPermalinks(lines).size).toBe(0);
+	});
+	it("ignores invalid JSON lines", () => {
+		const lines = [
+			'{"message": {"role": "user", "content": [{"type": "text", "text": "https://x.slack.com/archives/C1/p1"}',
+		];
+		expect(scanUserPermalinks(lines).size).toBe(0);
+	});
+	it("ignores lines without slack.com/archives/ prefix", () => {
+		const lines = [
+			JSON.stringify({ message: { role: "user", content: [{ type: "text", text: "https://example.com" }] } }),
+		];
+		expect(scanUserPermalinks(lines).size).toBe(0);
+	});
+	it("ignores user messages with non-array content", () => {
+		const lines = [
+			JSON.stringify({ message: { role: "user", content: "not an array" } }),
+			JSON.stringify({ message: { role: "user", content: null } }),
+		];
+		expect(scanUserPermalinks(lines).size).toBe(0);
+	});
+	it("ignores content blocks that are null or non-objects", () => {
+		const lines = [
+			JSON.stringify({
+				message: {
+					role: "user",
+					content: [null, "string", 123, true],
+					text: "https://x.slack.com/archives/C1/p1",
+				},
+			}),
+		];
+		expect(scanUserPermalinks(lines).size).toBe(0);
+	});
+	it("ignores blocks without type or non-text types", () => {
+		const lines = [
+			JSON.stringify({ message: { role: "user", content: [{ text: URL }] } }),
+			JSON.stringify({ message: { role: "user", content: [{ type: "image", text: URL }] } }),
+		];
+		expect(scanUserPermalinks(lines).size).toBe(0);
+	});
+	it("ignores blocks with non-string text", () => {
+		const lines = [
+			JSON.stringify({ message: { role: "user", content: [{ type: "text", text: null }] } }),
+			JSON.stringify({ message: { role: "user", content: [{ type: "text", text: 123 }] } }),
+		];
+		expect(scanUserPermalinks(lines).size).toBe(0);
+	});
+	it("handles multiple blocks in one message", () => {
+		const lines = [
+			JSON.stringify({
+				message: {
+					role: "user",
+					content: [
+						{ type: "text", text: "first block with no link" },
+						{ type: "image", url: "https://example.com" },
+						{ type: "text", text: `link here: ${URL}` },
+						{ type: "text", text: "final block" },
+					],
+				},
+			}),
+		];
+		const map = scanUserPermalinks(lines);
+		expect(map.size).toBe(1);
+		expect(map.get("C0BFF9UHBD1:1783413984.700009")).toBe(URL);
+	});
+	it("ignores lines missing the message key entirely", () => {
+		const lines = [JSON.stringify({ someOtherKey: "https://x.slack.com/archives/C1/p1" })];
+		expect(scanUserPermalinks(lines).size).toBe(0);
+	});
+});

--- a/cli/src/core/references/SlackPermalink.ts
+++ b/cli/src/core/references/SlackPermalink.ts
@@ -1,0 +1,59 @@
+/**
+ * SlackPermalink — parse a Slack thread permalink and harvest permalinks from a
+ * transcript's role:user text blocks. The permalink is the capture anchor for
+ * Slack references: it carries the workspace subdomain (absent from every MCP
+ * payload) plus the channel + parent ts, so it supplies the authoritative url.
+ *
+ * We scan ONLY role:user `message.content` text blocks — not "last-prompt"
+ * metadata lines and not tool_result content — because the same permalink can
+ * appear in several line types, which would otherwise double-count one thread.
+ */
+
+/** `.../archives/<channel>/p<16 digits>` — the dotless ts (16 digits: 10-digit seconds + 6-digit microseconds) becomes `<10>.<6>`. */
+const PERMALINK_RE = /https:\/\/([a-z0-9][a-z0-9-]*)\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d{16})/;
+
+export interface SlackPermalink {
+	readonly workspace: string;
+	readonly channel: string;
+	readonly parentTs: string;
+	readonly url: string;
+}
+
+/** Insert the decimal point 6 digits from the end (Slack ts format). */
+function dottedTs(pDigits: string): string {
+	return `${pDigits.slice(0, pDigits.length - 6)}.${pDigits.slice(pDigits.length - 6)}`;
+}
+
+export function parseSlackPermalink(raw: string): SlackPermalink | null {
+	const m = PERMALINK_RE.exec(raw);
+	if (m === null) return null;
+	return { workspace: m[1], channel: m[2], parentTs: dottedTs(m[3]), url: m[0] };
+}
+
+interface UserTextLine {
+	message?: { role?: unknown; content?: unknown };
+}
+
+/** Map keyed by `<channel>:<parentTs>` → permalink url, from role:user text only. */
+export function scanUserPermalinks(lines: string[]): Map<string, string> {
+	const out = new Map<string, string>();
+	for (const line of lines) {
+		if (!line.includes(".slack.com/archives/")) continue;
+		let parsed: UserTextLine;
+		try {
+			parsed = JSON.parse(line) as UserTextLine;
+		} catch {
+			continue;
+		}
+		const msg = parsed.message;
+		if (msg?.role !== "user" || !Array.isArray(msg.content)) continue;
+		for (const block of msg.content) {
+			if (typeof block !== "object" || block === null) continue;
+			const b = block as { type?: unknown; text?: unknown };
+			if (b.type !== "text" || typeof b.text !== "string") continue;
+			const link = parseSlackPermalink(b.text);
+			if (link !== null) out.set(`${link.channel}:${link.parentTs}`, link.url);
+		}
+	}
+	return out;
+}

--- a/cli/src/core/references/SourceDefinitionRegistry.test.ts
+++ b/cli/src/core/references/SourceDefinitionRegistry.test.ts
@@ -22,12 +22,12 @@ describe("SourceDefinitionRegistry", () => {
 		expect(r.match("codex", "linear.get_issue")?.id).toBe("linear"); // invocation-tool path (no namespace)
 	});
 
-	it("all() is stable order linear,jira,github,notion", () => {
+	it("all() is stable order linear,jira,github,notion,slack", () => {
 		expect(
 			getRegistry()
 				.all()
 				.map((d) => d.id),
-		).toEqual(["linear", "jira", "github", "notion"]);
+		).toEqual(["linear", "jira", "github", "notion", "slack"]);
 	});
 
 	it("byId() finds a known definition and returns undefined for unknown ids", () => {

--- a/cli/src/core/references/SourceEngine.test.ts
+++ b/cli/src/core/references/SourceEngine.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import type { Reference } from "../../Types.js";
 import type { SourceDefinition } from "./SourceDefinition.js";
 import { evalPipe, extractRef, renderBlock, TRANSFORMS } from "./SourceEngine.js";
+import { linearDefinition } from "./sources/definitions/linear.js";
+import { slackDefinition } from "./sources/definitions/slack.js";
 
 function miniLinearDef(): SourceDefinition {
 	return {
@@ -481,6 +483,18 @@ describe("extractRef", () => {
 	});
 });
 
+describe("extractRef optional url", () => {
+	const canonNoUrl = { channelId: "C1", parentTs: "1700000000.000001", title: "t", text: "body", replyCount: 0 };
+	it("produces a reference with url absent when url.optional and missing", () => {
+		const ref = extractRef(slackDefinition, canonNoUrl, "tool", "2026-01-01T00:00:00Z");
+		expect(ref).not.toBeNull();
+		expect(ref?.url).toBeUndefined();
+	});
+	it("still voids a source whose url is required and missing (linear)", () => {
+		expect(extractRef(linearDefinition, { id: "PROJ-1", title: "x" }, "tool", "2026-01-01T00:00:00Z")).toBeNull();
+	});
+});
+
 describe("renderBlock", () => {
 	it("renderBlock reproduces the Linear XML byte-for-byte", () => {
 		const def = miniLinearDef();
@@ -517,6 +531,20 @@ describe("renderBlock", () => {
 		expect(out).toBe(
 			'<notion-pages>\n<page id="36c4fc101d34805ab1fdfb3e69144580">\n  <title>Page</title>\n  <url>https://www.notion.so/36c4fc101d34805ab1fdfb3e69144580</url>\n</page>\n</notion-pages>',
 		);
+	});
+
+	it("renderBlock omits the <url> line entirely when a reference has no url (Slack linkless capture)", () => {
+		const def = miniLinearDef();
+		const ref: Reference = {
+			mapKey: "linear:X-1",
+			source: "linear",
+			nativeId: "X-1",
+			title: "T",
+			toolName: "t",
+			referencedAt: "2026-01-01",
+		};
+		const out = renderBlock(def, [ref]);
+		expect(out).not.toContain("<url>");
 	});
 
 	it("renderBlock returns an empty string for an empty ref list", () => {

--- a/cli/src/core/references/SourceEngine.test.ts
+++ b/cli/src/core/references/SourceEngine.test.ts
@@ -483,12 +483,10 @@ describe("extractRef", () => {
 	});
 });
 
-describe("extractRef optional url", () => {
+describe("extractRef required url", () => {
 	const canonNoUrl = { channelId: "C1", parentTs: "1700000000.000001", title: "t", text: "body", replyCount: 0 };
-	it("produces a reference with url absent when url.optional and missing", () => {
-		const ref = extractRef(slackDefinition, canonNoUrl, "tool", "2026-01-01T00:00:00Z");
-		expect(ref).not.toBeNull();
-		expect(ref?.url).toBeUndefined();
+	it("voids Slack when its (now-required) url is missing", () => {
+		expect(extractRef(slackDefinition, canonNoUrl, "tool", "2026-01-01T00:00:00Z")).toBeNull();
 	});
 	it("still voids a source whose url is required and missing (linear)", () => {
 		expect(extractRef(linearDefinition, { id: "PROJ-1", title: "x" }, "tool", "2026-01-01T00:00:00Z")).toBeNull();
@@ -533,7 +531,7 @@ describe("renderBlock", () => {
 		);
 	});
 
-	it("renderBlock omits the <url> line entirely when a reference has no url (Slack linkless capture)", () => {
+	it("renderBlock omits the <url> line entirely when a reference has no url", () => {
 		const def = miniLinearDef();
 		const ref: Reference = {
 			mapKey: "linear:X-1",

--- a/cli/src/core/references/SourceEngine.ts
+++ b/cli/src/core/references/SourceEngine.ts
@@ -198,7 +198,9 @@ export function extractRef(
 	const titleR = evalField(def.reference.title, payload);
 	const urlR = evalField(def.reference.url, payload);
 	if (!nativeIdR.ok || !titleR.ok || !urlR.ok) return null;
-	if (nativeIdR.value === undefined || titleR.value === undefined || urlR.value === undefined) return null;
+	if (nativeIdR.value === undefined || titleR.value === undefined) return null;
+	// url may be undefined only when the definition marks it optional (Slack);
+	// evalField already voided a required-but-missing url via urlR.ok === false.
 
 	const descR = def.reference.description
 		? evalField(def.reference.description, payload)
@@ -217,7 +219,7 @@ export function extractRef(
 		source: def.id,
 		nativeId: nativeIdR.value,
 		title: titleR.value,
-		url: urlR.value,
+		...(urlR.value !== undefined ? { url: urlR.value } : {}),
 		...(descR.value !== undefined ? { description: descR.value } : {}),
 		...(fields.length > 0 ? { fields } : {}),
 		toolName,
@@ -236,7 +238,7 @@ function renderOne(def: SourceDefinition, ref: Reference): string {
 	}
 	const lines = [`<${def.render.itemTag} ${attrs.join(" ")}>`];
 	lines.push(`  <title>${escapeForText(ref.title)}</title>`);
-	lines.push(`  <url>${escapeForText(ref.url)}</url>`);
+	if (ref.url !== undefined && ref.url.length > 0) lines.push(`  <url>${escapeForText(ref.url)}</url>`);
 	if (ref.description !== undefined && ref.description.length > 0) {
 		lines.push(`  <${def.render.bodyTag}>`);
 		lines.push(escapeForText(truncate(ref.description, def.render.maxCharsPerReference)));

--- a/cli/src/core/references/TranscriptEnvelopeParser.ts
+++ b/cli/src/core/references/TranscriptEnvelopeParser.ts
@@ -38,6 +38,13 @@ export interface ExtractOptions {
 	 * passing this. The Codex polling path passes "codex".
 	 */
 	readonly source?: TranscriptSource;
+	/**
+	 * The user's configured Slack workspace URL (`config.slack.workspaceUrl`),
+	 * used to reconstruct a thread permalink when the transcript never had one
+	 * pasted into it. Threaded in by `extractReferencesFromTranscript` (which
+	 * does the async `loadConfig()` read) since `parse()` itself is sync.
+	 */
+	readonly slackWorkspaceUrl?: string;
 }
 
 /**

--- a/cli/src/core/references/bindings/claude/index.test.ts
+++ b/cli/src/core/references/bindings/claude/index.test.ts
@@ -4,7 +4,7 @@ import { CLAUDE_SHELL_TOOL_NAMES, CLAUDE_TOOL_PREFIXES } from "./index.js";
 describe("Claude producer binding", () => {
 	describe("CLAUDE_TOOL_PREFIXES", () => {
 		it("lists every vendor prefix for the envelope pre-filter (both Linear prefixes included)", () => {
-			// Order follows BUILTIN_DEFINITIONS (linear, jira, github, notion) —
+			// Order follows BUILTIN_DEFINITIONS (linear, jira, github, notion, slack) —
 			// derived from the SourceDefinitionRegistry. Order is not semantically
 			// significant here (the needles are only used via `.some()`), so this
 			// pins the registry-driven order for regression visibility rather than a
@@ -15,6 +15,7 @@ describe("Claude producer binding", () => {
 				"mcp__claude_ai_Atlassian__",
 				"mcp__github__",
 				"mcp__claude_ai_Notion__",
+				"mcp__claude_ai_Slack__",
 			]);
 		});
 	});

--- a/cli/src/core/references/sources/SlackNormalize.test.ts
+++ b/cli/src/core/references/sources/SlackNormalize.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSlackThread } from "./SlackNormalize.js";
+
+const BLOB = `=== THREAD PARENT MESSAGE ===
+From: Flyer Li <li.chengbin2008@gmail.com> (U0BGFSM16DN)
+Time: 2026-07-07 16:46:24 CST
+Message TS: 1783413984.700009
+Consolidate the existing Linear / Jira / GitHub / Notion …
+
+=== THREAD REPLIES (2 total) ===
+
+--- Reply 1 of 2 ---
+From: Flyer Li <…> (U0BGFSM16DN)
+Time: 2026-07-07 17:18:37 CST
+Message TS: 1783415917.422609
+Config-driven MCP integration
+
+--- Reply 2 of 2 ---
+From: Flyer Li <…> (U0BGFSM16DN)
+Time: 2026-07-07 17:23:48 CST
+Message TS: 1783416228.715669
+How to do?
+`;
+
+describe("normalizeSlackThread", () => {
+	it("extracts parentTs, title, replyCount and threads url/channel through", () => {
+		const c = normalizeSlackThread({ messages: BLOB }, { channelId: "C0BFF9UHBD1", url: "https://x" });
+		expect(c).toMatchObject({
+			channelId: "C0BFF9UHBD1",
+			parentTs: "1783413984.700009",
+			title: "Consolidate the existing Linear / Jira / GitHub / Notion …",
+			replyCount: 2,
+			url: "https://x",
+		});
+		expect(c?.text).toContain("Config-driven MCP integration");
+	});
+	it("returns null (never throws) on a blob with no parent ts", () => {
+		expect(normalizeSlackThread({ messages: "garbage" }, { channelId: "C1" })).toBeNull();
+	});
+	it("returns null when messages is not a string", () => {
+		expect(normalizeSlackThread({ messages: 42 }, { channelId: "C1" })).toBeNull();
+	});
+	it("omits url when ctx.url is absent", () => {
+		const c = normalizeSlackThread({ messages: BLOB }, { channelId: "C0BFF9UHBD1" });
+		expect(c?.url).toBeUndefined();
+	});
+	it("handles blob with no reply section (replyCount defaults to 0)", () => {
+		const blobNoReplies = `=== THREAD PARENT MESSAGE ===
+From: User <email@example.com> (U123456)
+Time: 2026-07-07 16:46:24 CST
+Message TS: 1783413984.700009
+Test message`;
+		const c = normalizeSlackThread({ messages: blobNoReplies }, { channelId: "C1" });
+		expect(c).not.toBeNull();
+		expect(c?.replyCount).toBe(0);
+	});
+	it("handles blob with no title line (uses fallback title)", () => {
+		const blobNoTitle = `=== THREAD PARENT MESSAGE ===
+Message TS: 1783413984.700009`;
+		const c = normalizeSlackThread({ messages: blobNoTitle }, { channelId: "C1" });
+		expect(c).not.toBeNull();
+		expect(c?.title).toBe("Slack thread 1783413984.700009");
+	});
+	it("returns null when rawResult is not an object", () => {
+		expect(normalizeSlackThread("not an object", { channelId: "C1" })).toBeNull();
+	});
+	it("returns null when rawResult is null", () => {
+		expect(normalizeSlackThread(null, { channelId: "C1" })).toBeNull();
+	});
+	it("returns null when messages property is missing", () => {
+		expect(normalizeSlackThread({ other: "data" }, { channelId: "C1" })).toBeNull();
+	});
+	it("falls back to `Slack thread <ts>` when the parent has no body, never borrowing a reply's text", () => {
+		// Parent is a text-less post (Message TS then a blank line into the replies
+		// section); the reply DOES have a body. Title must not become the reply's.
+		const parentNoBody = `=== THREAD PARENT MESSAGE ===
+From: User <email@example.com> (U123456)
+Time: 2026-07-07 16:46:24 CST
+Message TS: 1783413984.700009
+
+=== THREAD REPLIES (1 total) ===
+
+--- Reply 1 of 1 ---
+From: Other (U654321)
+Time: 2026-07-07 17:18:37 CST
+Message TS: 1783415917.422609
+This reply body must not become the title`;
+		const c = normalizeSlackThread({ messages: parentNoBody }, { channelId: "C1" });
+		expect(c?.title).toBe("Slack thread 1783413984.700009");
+		expect(c?.replyCount).toBe(1);
+	});
+});

--- a/cli/src/core/references/sources/SlackNormalize.test.ts
+++ b/cli/src/core/references/sources/SlackNormalize.test.ts
@@ -28,11 +28,23 @@ describe("normalizeSlackThread", () => {
 		expect(c).toMatchObject({
 			channelId: "C0BFF9UHBD1",
 			parentTs: "1783413984.700009",
-			title: "Consolidate the existing Linear / Jira / GitHub / Notion …",
+			// Parent body is 58 chars → truncated to 50 + … (see truncateTitle).
+			title: "Consolidate the existing Linear / Jira / GitHub /…",
 			replyCount: 2,
 			url: "https://x",
 		});
 		expect(c?.text).toContain("Config-driven MCP integration");
+	});
+	it("truncates a long parent-message title to 50 chars + …", () => {
+		const longBody = "X".repeat(60);
+		const blob = `=== THREAD PARENT MESSAGE ===\nMessage TS: 1783413984.700009\n${longBody}`;
+		const c = normalizeSlackThread({ messages: blob }, { channelId: "C1", url: "https://x" });
+		expect(c?.title).toBe(`${"X".repeat(50)}…`);
+	});
+	it("leaves a title at/under 50 chars untouched (no ellipsis)", () => {
+		const blob = `=== THREAD PARENT MESSAGE ===\nMessage TS: 1783413984.700009\nShort thread title`;
+		const c = normalizeSlackThread({ messages: blob }, { channelId: "C1", url: "https://x" });
+		expect(c?.title).toBe("Short thread title");
 	});
 	it("returns null (never throws) on a blob with no parent ts", () => {
 		expect(normalizeSlackThread({ messages: "garbage" }, { channelId: "C1" })).toBeNull();

--- a/cli/src/core/references/sources/SlackNormalize.ts
+++ b/cli/src/core/references/sources/SlackNormalize.ts
@@ -1,0 +1,69 @@
+/**
+ * SlackNormalize — parse the `slack_read_thread` result blob into a canonical
+ * object the `slack` SourceDefinition can read with plain `path` ops.
+ *
+ * The MCP result is human-readable text (`=== THREAD PARENT MESSAGE ===`,
+ * `Message TS: …`, `--- Reply N of M ---`), NOT structured JSON, and carries
+ * neither a url nor the channel id. The url (from the pasted permalink) and the
+ * channel id (from the tool_use input) are threaded in via `ctx`.
+ *
+ * Defensive by contract: any shape we can't parse returns null (the caller
+ * voids the reference), never throws — the blob format is defined by the MCP
+ * wrapper's presentation layer, not a stable API, so it may drift.
+ */
+
+export interface SlackCanonical {
+	readonly channelId: string;
+	readonly parentTs: string;
+	readonly title: string;
+	readonly text: string;
+	readonly replyCount: number;
+	readonly url?: string;
+}
+
+const PARENT_TS_RE = /Message TS:\s*(\d{7,}\.\d+)/;
+const REPLY_MARKER = "=== THREAD REPLIES";
+const REPLY_COUNT_RE = /=== THREAD REPLIES \((\d+) total\) ===/;
+/**
+ * First non-empty line after the parent's `Message TS:` line → title. Applied
+ * ONLY to the parent segment (everything before the first `=== THREAD REPLIES`
+ * marker): a parent message with no text body (e.g. a file-only post) must fall
+ * back to `Slack thread <ts>`, never borrow a reply's body as the title.
+ */
+const PARENT_BODY_RE = /Message TS:\s*\d{7,}\.\d+\r?\n([^\r\n]+)/;
+
+function readMessages(rawResult: unknown): string | undefined {
+	if (typeof rawResult !== "object" || rawResult === null) return undefined;
+	const m = (rawResult as { messages?: unknown }).messages;
+	return typeof m === "string" ? m : undefined;
+}
+
+export function normalizeSlackThread(
+	rawResult: unknown,
+	ctx: { channelId: string; url?: string },
+): SlackCanonical | null {
+	const blob = readMessages(rawResult);
+	if (blob === undefined) return null;
+
+	const tsMatch = PARENT_TS_RE.exec(blob);
+	if (tsMatch === null) return null; // no parent ts → not a usable thread
+
+	const parentTs = tsMatch[1];
+	// Confine title extraction to the parent block so an empty-bodied parent
+	// can't pick up the first reply's text as the title.
+	const replyIdx = blob.indexOf(REPLY_MARKER);
+	const parentSegment = replyIdx === -1 ? blob : blob.slice(0, replyIdx);
+	const titleMatch = PARENT_BODY_RE.exec(parentSegment);
+	const title = titleMatch !== null ? titleMatch[1].trim() : `Slack thread ${parentTs}`;
+	const replyMatch = REPLY_COUNT_RE.exec(blob);
+	const replyCount = replyMatch !== null ? Number(replyMatch[1]) : 0;
+
+	return {
+		channelId: ctx.channelId,
+		parentTs,
+		title,
+		text: blob.trim(),
+		replyCount,
+		...(ctx.url !== undefined ? { url: ctx.url } : {}),
+	};
+}

--- a/cli/src/core/references/sources/SlackNormalize.ts
+++ b/cli/src/core/references/sources/SlackNormalize.ts
@@ -32,6 +32,17 @@ const REPLY_COUNT_RE = /=== THREAD REPLIES \((\d+) total\) ===/;
  */
 const PARENT_BODY_RE = /Message TS:\s*\d{7,}\.\d+\r?\n([^\r\n]+)/;
 
+/**
+ * The "title" is the parent message's first line, which — unlike an issue title
+ * or page name — is free-form message text with no length bound. Cap it so the
+ * stored title stays a short label across every surface (sidebar row, PR bullet,
+ * committed-memory HTML); the full text is preserved in `text`/`description`.
+ */
+const MAX_TITLE_LEN = 50;
+function truncateTitle(title: string): string {
+	return title.length > MAX_TITLE_LEN ? `${title.slice(0, MAX_TITLE_LEN).trimEnd()}…` : title;
+}
+
 function readMessages(rawResult: unknown): string | undefined {
 	if (typeof rawResult !== "object" || rawResult === null) return undefined;
 	const m = (rawResult as { messages?: unknown }).messages;
@@ -54,7 +65,7 @@ export function normalizeSlackThread(
 	const replyIdx = blob.indexOf(REPLY_MARKER);
 	const parentSegment = replyIdx === -1 ? blob : blob.slice(0, replyIdx);
 	const titleMatch = PARENT_BODY_RE.exec(parentSegment);
-	const title = titleMatch !== null ? titleMatch[1].trim() : `Slack thread ${parentTs}`;
+	const title = titleMatch !== null ? truncateTitle(titleMatch[1].trim()) : `Slack thread ${parentTs}`;
 	const replyMatch = REPLY_COUNT_RE.exec(blob);
 	const replyCount = replyMatch !== null ? Number(replyMatch[1]) : 0;
 

--- a/cli/src/core/references/sources/definitions/index.ts
+++ b/cli/src/core/references/sources/definitions/index.ts
@@ -11,5 +11,12 @@ import { githubDefinition } from "./github.js";
 import { jiraDefinition } from "./jira.js";
 import { linearDefinition } from "./linear.js";
 import { notionDefinition } from "./notion.js";
+import { slackDefinition } from "./slack.js";
 
-export const BUILTIN_DEFINITIONS = [linearDefinition, jiraDefinition, githubDefinition, notionDefinition] as const;
+export const BUILTIN_DEFINITIONS = [
+	linearDefinition,
+	jiraDefinition,
+	githubDefinition,
+	notionDefinition,
+	slackDefinition,
+] as const;

--- a/cli/src/core/references/sources/definitions/slack.test.ts
+++ b/cli/src/core/references/sources/definitions/slack.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { getRegistry } from "../../SourceDefinitionRegistry.js";
+import { extractRef } from "../../SourceEngine.js";
+import { slackDefinition } from "./slack.js";
+
+// The engine sees the CANONICAL object (post-normalize), not the raw blob.
+const CANON = {
+	channelId: "C0BFF9UHBD1",
+	parentTs: "1783413984.700009",
+	title: "Consolidate the existing Linear / Jira / GitHub / Notion …",
+	text: "=== THREAD PARENT MESSAGE ===\n…",
+	replyCount: 2,
+	url: "https://flyer-q4r7867.slack.com/archives/C0BFF9UHBD1/p1783413984700009",
+};
+
+describe("slack definition", () => {
+	it("is registered and matches slack_read_thread", () => {
+		expect(getRegistry().byId("slack")?.id).toBe("slack");
+		expect(getRegistry().match("claude", "mcp__claude_ai_Slack__slack_read_thread")?.id).toBe("slack");
+	});
+	it("extracts a Reference from the canonical object", () => {
+		const ref = extractRef(
+			slackDefinition,
+			CANON,
+			"mcp__claude_ai_Slack__slack_read_thread",
+			"2026-07-08T00:00:00Z",
+		);
+		expect(ref).toMatchObject({
+			mapKey: "slack:C0BFF9UHBD1-1783413984.700009",
+			source: "slack",
+			nativeId: "C0BFF9UHBD1-1783413984.700009",
+			url: CANON.url,
+		});
+		expect(ref?.fields?.find((f) => f.key === "channel")?.value).toBe("C0BFF9UHBD1");
+	});
+});

--- a/cli/src/core/references/sources/definitions/slack.test.ts
+++ b/cli/src/core/references/sources/definitions/slack.test.ts
@@ -33,4 +33,10 @@ describe("slack definition", () => {
 		});
 		expect(ref?.fields?.find((f) => f.key === "channel")?.value).toBe("C0BFF9UHBD1");
 	});
+	it("voids the reference when url is absent — a thread with no resolvable url is not stored", () => {
+		const { url: _url, ...canonNoUrl } = CANON;
+		expect(
+			extractRef(slackDefinition, canonNoUrl, "mcp__claude_ai_Slack__slack_read_thread", "2026-07-08T00:00:00Z"),
+		).toBeNull();
+	});
 });

--- a/cli/src/core/references/sources/definitions/slack.ts
+++ b/cli/src/core/references/sources/definitions/slack.ts
@@ -1,0 +1,53 @@
+/**
+ * Slack built-in source definition. Operates on the POST-normalize canonical
+ * object from `SlackNormalize.normalizeSlackThread` (channelId + parentTs +
+ * title + text + replyCount + optional url), NOT the raw MCP blob. `url` is
+ * OPTIONAL here (unique among sources): when no permalink was pasted and no
+ * `slack.workspaceUrl` is configured, the thread is still captured, linkless.
+ */
+
+import type { SourceDefinition } from "../../SourceDefinition.js";
+
+export const slackDefinition: SourceDefinition = {
+	id: "slack",
+	label: "Slack",
+	icon: "comment-discussion",
+	match: {
+		claude: { prefixes: ["mcp__claude_ai_Slack__"], acceptSuffix: "slack_read_thread" },
+		codex: {
+			namespaceSuffix: "slack",
+			functionCallNames: ["_read_thread"],
+			invocationTools: ["slack_read_thread"],
+		},
+	},
+	wrapperKeys: [],
+	reference: {
+		nativeId: {
+			pipe: [
+				{
+					op: "template",
+					template: "{c}-{t}",
+					from: { c: [{ op: "path", path: "channelId" }], t: [{ op: "path", path: "parentTs" }] },
+				},
+			],
+			require: "^[A-Z0-9]+-\\d{7,}\\.\\d+$",
+		},
+		title: { pipe: [{ op: "path", path: "title" }], require: ".+" },
+		url: { pipe: [{ op: "path", path: "url" }], require: "^https://", optional: true },
+		description: { pipe: [{ op: "path", path: "text" }], optional: true },
+	},
+	fields: [
+		{ key: "entity-type", label: "Type", icon: "comment-discussion", pipe: [{ op: "const", value: "thread" }] },
+		{ key: "replies", label: "Replies", icon: "reply", pipe: [{ op: "path", path: "replyCount" }] },
+		{ key: "channel", label: "Channel", icon: "symbol-namespace", pipe: [{ op: "path", path: "channelId" }] },
+	],
+	storage: { nativeIdPathSafe: true },
+	render: {
+		wrapperTag: "slack-threads",
+		itemTag: "thread",
+		bodyTag: "messages",
+		fieldAttrs: true,
+		maxCharsPerReference: 8000,
+		maxTotalChars: 40000,
+	},
+};

--- a/cli/src/core/references/sources/definitions/slack.ts
+++ b/cli/src/core/references/sources/definitions/slack.ts
@@ -1,9 +1,11 @@
 /**
  * Slack built-in source definition. Operates on the POST-normalize canonical
  * object from `SlackNormalize.normalizeSlackThread` (channelId + parentTs +
- * title + text + replyCount + optional url), NOT the raw MCP blob. `url` is
- * OPTIONAL here (unique among sources): when no permalink was pasted and no
- * `slack.workspaceUrl` is configured, the thread is still captured, linkless.
+ * title + text + replyCount + url), NOT the raw MCP blob. `url` is REQUIRED:
+ * a thread whose url could not be resolved (no permalink pasted AND no
+ * `slack.workspaceUrl` configured — e.g. the user pasted a bare channel URL,
+ * which carries no message ts) is voided by `extractRef` and never stored,
+ * since a linkless reference has nothing to jump to.
  */
 
 import type { SourceDefinition } from "../../SourceDefinition.js";
@@ -33,7 +35,7 @@ export const slackDefinition: SourceDefinition = {
 			require: "^[A-Z0-9]+-\\d{7,}\\.\\d+$",
 		},
 		title: { pipe: [{ op: "path", path: "title" }], require: ".+" },
-		url: { pipe: [{ op: "path", path: "url" }], require: "^https://", optional: true },
+		url: { pipe: [{ op: "path", path: "url" }], require: "^https://" },
 		description: { pipe: [{ op: "path", path: "text" }], optional: true },
 	},
 	fields: [

--- a/docs/superpowers/plans/2026-07-08-slack-thread-context-capture.md
+++ b/docs/superpowers/plans/2026-07-08-slack-thread-context-capture.md
@@ -1,0 +1,806 @@
+# Slack Thread Context Capture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture a Slack discussion thread an AI agent read via the Slack MCP server into a `Reference`, anchored on the user-pasted permalink, injected into Working Memory alongside Linear/Jira/GitHub/Notion references.
+
+**Architecture:** Reuse the JOLLI-1877 reference pipeline (`SourceDefinition` + `SourceEngine` + envelope). Slack is a built-in source with a code-side `normalize` (the MCP result is a text blob, not structured JSON). The permalink — pasted by the user into `role:user` text — supplies the authoritative `url` + channel + parent ts; the `slack_read_thread` tool result supplies the body; the two are correlated by `(channel, ts)`.
+
+**Tech Stack:** TypeScript (ESM, Node 22.5+), Vitest, Biome (tabs, 120 cols). CLI workspace `@jolli.ai/cli`; VS Code workspace bundles the CLI.
+
+## Global Constraints
+
+- Node 22.5+, pure ESM. Imports use `.js` extensions.
+- Biome: tabs, 4-wide, 120-column limit; `noExplicitAny: error`, `noUnusedImports/Variables: error`, `useImportType: warn`. CI runs `biome check --error-on-warnings`.
+- CLI coverage floor **97% statements / 96% branches / 97% functions / 97% lines** (`cli/vite.config.ts`). Use `/* v8 ignore start/stop */` blocks (single-line `ignore next` does NOT work here).
+- Path normalization: use `toForwardSlash` from `cli/src/core/PathUtils.ts`; never inline `.replace(/\\/g,"/")`.
+- Commits: `git commit -s` (DCO). **No** `Co-Authored-By: Claude` / `🤖 Generated with` trailers.
+- Run `npm run all` (clean→build→lint→test) once before the final commit, not per task. Per-task commits are code-only (test + impl); batch the full gate at the end.
+- Keep the 4 existing sources' behavior byte-identical (their `GoldenParity.test.ts` must stay green).
+
+## Verified fixtures (pin these — captured from the real session 2026-07-07/08)
+
+**Real `slack_read_thread` body blob** (the `messages` string of the tool result):
+```
+=== THREAD PARENT MESSAGE ===
+From: Flyer Li <li.chengbin2008@gmail.com> (U0BGFSM16DN)
+Time: 2026-07-07 16:46:24 CST
+Message TS: 1783413984.700009
+Consolidate the existing Linear / Jira / GitHub / Notion MCP reference integrations from "one hand-written TS adapter per source + scattered binding RULES" into *a single set of declarative source definitions + one generic engine*. Adding an MCP source should go from "edit 4 places in code" to "write one config rule", while leaving clean seams for Phase 2 (runtime, zero-code user extension).
+
+=== THREAD REPLIES (2 total) ===
+
+--- Reply 1 of 2 ---
+From: Flyer Li <li.chengbin2008@gmail.com> (U0BGFSM16DN)
+Time: 2026-07-07 17:18:37 CST
+Message TS: 1783415917.422609
+Config-driven MCP integration
+
+--- Reply 2 of 2 ---
+From: Flyer Li <li.chengbin2008@gmail.com> (U0BGFSM16DN)
+Time: 2026-07-07 17:23:48 CST
+Message TS: 1783416228.715669
+How to do?
+```
+
+**Real permalink** (as pasted in `role:user` text): `https://flyer-q4r7867.slack.com/archives/C0BFF9UHBD1/p1783413984700009`
+
+**Real tool_use input**: `{"channel_id":"C0BFF9UHBD1","message_ts":"1783413984.700009"}`
+
+---
+
+## File Structure
+
+- Create `cli/src/core/references/SlackPermalink.ts` — parse a Slack permalink; scan `role:user` transcript text for permalinks. Pure.
+- Create `cli/src/core/references/sources/SlackNormalize.ts` — parse the body blob → canonical object, merge url/channel. Pure.
+- Create `cli/src/core/references/sources/definitions/slack.ts` — the `SourceDefinition`.
+- Modify `cli/src/core/references/sources/definitions/index.ts` — register `slackDefinition`.
+- Modify `cli/src/Types.ts` — `KnownSourceId` += `"slack"`; `Reference.url` optional; `JolliMemoryConfig.slack`.
+- Modify `cli/src/core/references/SourceEngine.ts` — `extractRef` treats `url` as optional-aware; `renderOne` omits absent url.
+- Modify `cli/src/core/references/ReferenceStore.ts` — markdown read/write tolerate absent url.
+- Modify `cli/src/core/references/ClaudeEnvelopeParser.ts` — retain `slack_read_thread` tool_use input; scan permalinks; correlate; apply Slack normalize with `{channelId, url, config}`.
+- Modify `cli/src/commands/ConfigureCommand.ts` — `--set slack.workspaceUrl` + validation.
+- Modify `vscode/src/views/SourceLabels.ts` — `SOURCE_META.slack`.
+- Modify `vscode/src/views/NextMemoryScriptBuilder.ts` — inline "configure workspaceUrl" hint for a url-less Slack ref.
+
+---
+
+## Task 1: SlackPermalink — parse + scan
+
+**Files:**
+- Create: `cli/src/core/references/SlackPermalink.ts`
+- Test: `cli/src/core/references/SlackPermalink.test.ts`
+
+**Interfaces:**
+- Produces: `parseSlackPermalink(raw: string): { workspace: string; channel: string; parentTs: string; url: string } | null` and `scanUserPermalinks(lines: string[]): Map<string, string>` (key `"<channel>:<parentTs>"` → permalink url). `parentTs` is dotted form (`1783413984.700009`); the permalink carries the dotless `p<16digits>` form which this converts.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { parseSlackPermalink, scanUserPermalinks } from "./SlackPermalink.js";
+
+const URL = "https://flyer-q4r7867.slack.com/archives/C0BFF9UHBD1/p1783413984700009";
+
+describe("parseSlackPermalink", () => {
+	it("parses workspace, channel, and dotted parentTs", () => {
+		expect(parseSlackPermalink(URL)).toEqual({
+			workspace: "flyer-q4r7867",
+			channel: "C0BFF9UHBD1",
+			parentTs: "1783413984.700009",
+			url: URL,
+		});
+	});
+	it("rejects a non-slack host", () => {
+		expect(parseSlackPermalink("https://evil.example/archives/C1/p1")).toBeNull();
+	});
+	it("rejects a channel message url with no p<ts> segment", () => {
+		expect(parseSlackPermalink("https://x.slack.com/archives/C1")).toBeNull();
+	});
+});
+
+describe("scanUserPermalinks", () => {
+	it("reads only role:user message text and keys by channel:ts", () => {
+		const lines = [
+			JSON.stringify({ message: { role: "user", content: [{ type: "text", text: `see ${URL}` }] } }),
+			JSON.stringify({ message: { role: "assistant", content: [{ type: "text", text: URL }] } }),
+			JSON.stringify({ type: "last-prompt", lastPrompt: URL }),
+		];
+		const map = scanUserPermalinks(lines);
+		expect(map.get("C0BFF9UHBD1:1783413984.700009")).toBe(URL);
+		expect(map.size).toBe(1); // assistant text + last-prompt line ignored
+	});
+	it("ignores tool_result content inside a user message", () => {
+		const lines = [
+			JSON.stringify({ message: { role: "user", content: [{ type: "tool_result", content: URL }] } }),
+		];
+		expect(scanUserPermalinks(lines).size).toBe(0);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/references/SlackPermalink.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+/**
+ * SlackPermalink — parse a Slack thread permalink and harvest permalinks from a
+ * transcript's role:user text blocks. The permalink is the capture anchor for
+ * Slack references: it carries the workspace subdomain (absent from every MCP
+ * payload) plus the channel + parent ts, so it supplies the authoritative url.
+ *
+ * We scan ONLY role:user `message.content` text blocks — not "last-prompt"
+ * metadata lines and not tool_result content — because the same permalink can
+ * appear in several line types, which would otherwise double-count one thread.
+ */
+
+/** `.../archives/<channel>/p<16 digits>` — the dotless ts becomes `<10>.<6>`. */
+const PERMALINK_RE = /https:\/\/([a-z0-9][a-z0-9-]*)\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d{7,})/;
+
+export interface SlackPermalink {
+	readonly workspace: string;
+	readonly channel: string;
+	readonly parentTs: string;
+	readonly url: string;
+}
+
+/** Insert the decimal point 6 digits from the end (Slack ts format). */
+function dottedTs(pDigits: string): string {
+	return `${pDigits.slice(0, pDigits.length - 6)}.${pDigits.slice(pDigits.length - 6)}`;
+}
+
+export function parseSlackPermalink(raw: string): SlackPermalink | null {
+	const m = PERMALINK_RE.exec(raw);
+	if (m === null) return null;
+	return { workspace: m[1], channel: m[2], parentTs: dottedTs(m[3]), url: m[0] };
+}
+
+interface UserTextLine {
+	message?: { role?: unknown; content?: unknown };
+}
+
+/** Map keyed by `<channel>:<parentTs>` → permalink url, from role:user text only. */
+export function scanUserPermalinks(lines: string[]): Map<string, string> {
+	const out = new Map<string, string>();
+	for (const line of lines) {
+		if (!line.includes(".slack.com/archives/")) continue;
+		let parsed: UserTextLine;
+		try {
+			parsed = JSON.parse(line) as UserTextLine;
+		} catch {
+			continue;
+		}
+		const msg = parsed.message;
+		if (msg?.role !== "user" || !Array.isArray(msg.content)) continue;
+		for (const block of msg.content) {
+			if (typeof block !== "object" || block === null) continue;
+			const b = block as { type?: unknown; text?: unknown };
+			if (b.type !== "text" || typeof b.text !== "string") continue;
+			const link = parseSlackPermalink(b.text);
+			if (link !== null) out.set(`${link.channel}:${link.parentTs}`, link.url);
+		}
+	}
+	return out;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/references/SlackPermalink.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/core/references/SlackPermalink.ts cli/src/core/references/SlackPermalink.test.ts
+git commit -s -m "feat(references): parse Slack permalinks and scan user text"
+```
+
+---
+
+## Task 2: SlackNormalize — parse the thread body blob
+
+**Files:**
+- Create: `cli/src/core/references/sources/SlackNormalize.ts`
+- Test: `cli/src/core/references/sources/SlackNormalize.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `normalizeSlackThread(rawResult: unknown, ctx: { channelId: string; url?: string }): SlackCanonical | null` where
+  `interface SlackCanonical { channelId: string; parentTs: string; title: string; text: string; replyCount: number; url?: string }`.
+  Returns `null` when the blob is unparseable (defensive — never throws). This is the object the `slack` definition's DSL reads.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { normalizeSlackThread } from "./SlackNormalize.js";
+
+const BLOB = `=== THREAD PARENT MESSAGE ===
+From: Flyer Li <li.chengbin2008@gmail.com> (U0BGFSM16DN)
+Time: 2026-07-07 16:46:24 CST
+Message TS: 1783413984.700009
+Consolidate the existing Linear / Jira / GitHub / Notion …
+
+=== THREAD REPLIES (2 total) ===
+
+--- Reply 1 of 2 ---
+From: Flyer Li <…> (U0BGFSM16DN)
+Time: 2026-07-07 17:18:37 CST
+Message TS: 1783415917.422609
+Config-driven MCP integration
+
+--- Reply 2 of 2 ---
+From: Flyer Li <…> (U0BGFSM16DN)
+Time: 2026-07-07 17:23:48 CST
+Message TS: 1783416228.715669
+How to do?
+`;
+
+describe("normalizeSlackThread", () => {
+	it("extracts parentTs, title, replyCount and threads url/channel through", () => {
+		const c = normalizeSlackThread({ messages: BLOB }, { channelId: "C0BFF9UHBD1", url: "https://x" });
+		expect(c).toMatchObject({
+			channelId: "C0BFF9UHBD1",
+			parentTs: "1783413984.700009",
+			title: "Consolidate the existing Linear / Jira / GitHub / Notion …",
+			replyCount: 2,
+			url: "https://x",
+		});
+		expect(c?.text).toContain("Config-driven MCP integration");
+	});
+	it("returns null (never throws) on a blob with no parent ts", () => {
+		expect(normalizeSlackThread({ messages: "garbage" }, { channelId: "C1" })).toBeNull();
+	});
+	it("returns null when messages is not a string", () => {
+		expect(normalizeSlackThread({ messages: 42 }, { channelId: "C1" })).toBeNull();
+	});
+	it("omits url when ctx.url is absent", () => {
+		const c = normalizeSlackThread({ messages: BLOB }, { channelId: "C0BFF9UHBD1" });
+		expect(c?.url).toBeUndefined();
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/references/sources/SlackNormalize.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+/**
+ * SlackNormalize — parse the `slack_read_thread` result blob into a canonical
+ * object the `slack` SourceDefinition can read with plain `path` ops.
+ *
+ * The MCP result is human-readable text (`=== THREAD PARENT MESSAGE ===`,
+ * `Message TS: …`, `--- Reply N of M ---`), NOT structured JSON, and carries
+ * neither a url nor the channel id. The url (from the pasted permalink) and the
+ * channel id (from the tool_use input) are threaded in via `ctx`.
+ *
+ * Defensive by contract: any shape we can't parse returns null (the caller
+ * voids the reference), never throws — the blob format is defined by the MCP
+ * wrapper's presentation layer, not a stable API, so it may drift.
+ */
+
+export interface SlackCanonical {
+	readonly channelId: string;
+	readonly parentTs: string;
+	readonly title: string;
+	readonly text: string;
+	readonly replyCount: number;
+	readonly url?: string;
+}
+
+const PARENT_TS_RE = /Message TS:\s*(\d{7,}\.\d+)/;
+const REPLY_COUNT_RE = /=== THREAD REPLIES \((\d+) total\) ===/;
+/** First non-empty line after the parent's `Message TS:` line → title. */
+const PARENT_BODY_RE = /Message TS:\s*\d{7,}\.\d+\r?\n([^\r\n]+)/;
+
+function readMessages(rawResult: unknown): string | undefined {
+	if (typeof rawResult !== "object" || rawResult === null) return undefined;
+	const m = (rawResult as { messages?: unknown }).messages;
+	return typeof m === "string" ? m : undefined;
+}
+
+export function normalizeSlackThread(
+	rawResult: unknown,
+	ctx: { channelId: string; url?: string },
+): SlackCanonical | null {
+	const blob = readMessages(rawResult);
+	if (blob === undefined) return null;
+
+	const tsMatch = PARENT_TS_RE.exec(blob);
+	if (tsMatch === null) return null; // no parent ts → not a usable thread
+
+	const parentTs = tsMatch[1];
+	const titleMatch = PARENT_BODY_RE.exec(blob);
+	const title = titleMatch !== null ? titleMatch[1].trim() : `Slack thread ${parentTs}`;
+	const replyMatch = REPLY_COUNT_RE.exec(blob);
+	const replyCount = replyMatch !== null ? Number(replyMatch[1]) : 0;
+
+	return {
+		channelId: ctx.channelId,
+		parentTs,
+		title,
+		text: blob.trim(),
+		replyCount,
+		...(ctx.url !== undefined ? { url: ctx.url } : {}),
+	};
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/references/sources/SlackNormalize.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/core/references/sources/SlackNormalize.ts cli/src/core/references/sources/SlackNormalize.test.ts
+git commit -s -m "feat(references): defensively parse Slack thread body blob"
+```
+
+---
+
+## Task 3: slack SourceDefinition + registration + KnownSourceId
+
+**Files:**
+- Create: `cli/src/core/references/sources/definitions/slack.ts`
+- Modify: `cli/src/core/references/sources/definitions/index.ts`
+- Modify: `cli/src/Types.ts:713` (`KnownSourceId`)
+- Test: `cli/src/core/references/sources/definitions/slack.test.ts`
+
+**Interfaces:**
+- Consumes: `SlackCanonical` field names from Task 2 (`channelId`, `parentTs`, `title`, `text`, `replyCount`, `url`).
+- Produces: `slackDefinition: SourceDefinition` with `id: "slack"`; registered in `BUILTIN_DEFINITIONS`.
+
+- [ ] **Step 1: Add `"slack"` to `KnownSourceId`**
+
+In `cli/src/Types.ts:713`:
+```typescript
+export type KnownSourceId = "linear" | "jira" | "github" | "notion" | "slack";
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { extractRef } from "../../SourceEngine.js";
+import { getRegistry } from "../../SourceDefinitionRegistry.js";
+import { slackDefinition } from "./slack.js";
+
+// The engine sees the CANONICAL object (post-normalize), not the raw blob.
+const CANON = {
+	channelId: "C0BFF9UHBD1",
+	parentTs: "1783413984.700009",
+	title: "Consolidate the existing Linear / Jira / GitHub / Notion …",
+	text: "=== THREAD PARENT MESSAGE ===\n…",
+	replyCount: 2,
+	url: "https://flyer-q4r7867.slack.com/archives/C0BFF9UHBD1/p1783413984700009",
+};
+
+describe("slack definition", () => {
+	it("is registered and matches slack_read_thread", () => {
+		expect(getRegistry().byId("slack")?.id).toBe("slack");
+		expect(getRegistry().match("claude", "mcp__claude_ai_Slack__slack_read_thread")?.id).toBe("slack");
+	});
+	it("extracts a Reference from the canonical object", () => {
+		const ref = extractRef(slackDefinition, CANON, "mcp__claude_ai_Slack__slack_read_thread", "2026-07-08T00:00:00Z");
+		expect(ref).toMatchObject({
+			mapKey: "slack:C0BFF9UHBD1-1783413984.700009",
+			source: "slack",
+			nativeId: "C0BFF9UHBD1-1783413984.700009",
+			url: CANON.url,
+		});
+		expect(ref?.fields?.find((f) => f.key === "channel")?.value).toBe("C0BFF9UHBD1");
+	});
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/references/sources/definitions/slack.test.ts`
+Expected: FAIL — `slack.js` not found / not registered.
+
+- [ ] **Step 4: Write `slack.ts`**
+
+```typescript
+/**
+ * Slack built-in source definition. Operates on the POST-normalize canonical
+ * object from `SlackNormalize.normalizeSlackThread` (channelId + parentTs +
+ * title + text + replyCount + optional url), NOT the raw MCP blob. `url` is
+ * OPTIONAL here (unique among sources): when no permalink was pasted and no
+ * `slack.workspaceUrl` is configured, the thread is still captured, linkless.
+ */
+
+import type { SourceDefinition } from "../../SourceDefinition.js";
+
+export const slackDefinition: SourceDefinition = {
+	id: "slack",
+	label: "Slack",
+	icon: "comment-discussion",
+	match: {
+		claude: { prefixes: ["mcp__claude_ai_Slack__"], acceptSuffix: "slack_read_thread" },
+		codex: { namespaceSuffix: "slack", functionCallNames: ["_read_thread"], invocationTools: ["slack_read_thread"] },
+	},
+	wrapperKeys: [],
+	reference: {
+		nativeId: {
+			pipe: [{ op: "template", template: "{c}-{t}", from: { c: [{ op: "path", path: "channelId" }], t: [{ op: "path", path: "parentTs" }] } }],
+			require: "^[A-Z0-9]+-\\d{7,}\\.\\d+$",
+		},
+		title: { pipe: [{ op: "path", path: "title" }], require: ".+" },
+		url: { pipe: [{ op: "path", path: "url" }], require: "^https://", optional: true },
+		description: { pipe: [{ op: "path", path: "text" }], optional: true },
+	},
+	fields: [
+		{ key: "entity-type", label: "Type", icon: "comment-discussion", pipe: [{ op: "const", value: "thread" }] },
+		{ key: "replies", label: "Replies", icon: "reply", pipe: [{ op: "path", path: "replyCount" }] },
+		{ key: "channel", label: "Channel", icon: "symbol-namespace", pipe: [{ op: "path", path: "channelId" }] },
+	],
+	storage: { nativeIdPathSafe: true },
+	render: {
+		wrapperTag: "slack-threads",
+		itemTag: "thread",
+		bodyTag: "messages",
+		fieldAttrs: true,
+		maxCharsPerReference: 8000,
+		maxTotalChars: 40000,
+	},
+};
+```
+
+- [ ] **Step 5: Register in `index.ts`**
+
+In `cli/src/core/references/sources/definitions/index.ts`, import `slackDefinition` and add it to the `BUILTIN_DEFINITIONS` array (append after `notionDefinition`).
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/references/sources/definitions/slack.test.ts`
+Expected: PASS. (Requires Task 4's `url.optional` support in `extractRef`; if run before Task 4, the `extractRef` test asserting a url-present ref still passes — only the *absent*-url path needs Task 4. Reorder: do Task 4 first if executing strictly.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cli/src/core/references/sources/definitions/slack.ts cli/src/core/references/sources/definitions/index.ts cli/src/core/references/sources/definitions/slack.test.ts cli/src/Types.ts
+git commit -s -m "feat(references): add Slack thread source definition"
+```
+
+---
+
+## Task 4: engine — optional `url`
+
+**Files:**
+- Modify: `cli/src/Types.ts` (`Reference.url` → optional)
+- Modify: `cli/src/core/references/SourceEngine.ts` (`extractRef` url handling; `renderOne` skips absent url)
+- Test: `cli/src/core/references/SourceEngine.test.ts` (add cases)
+
+**Interfaces:**
+- Produces: `Reference.url?: string`; `extractRef` yields a `Reference` with `url` absent when the def's `url` FieldSpec is `optional` and the value is missing; still voids when `url` is required (the 4 existing defs).
+
+- [ ] **Step 1: Write the failing test** (append to `SourceEngine.test.ts`)
+
+```typescript
+import { slackDefinition } from "./sources/definitions/slack.js";
+
+describe("extractRef optional url", () => {
+	const canonNoUrl = { channelId: "C1", parentTs: "1700000000.000001", title: "t", text: "body", replyCount: 0 };
+	it("produces a reference with url absent when url.optional and missing", () => {
+		const ref = extractRef(slackDefinition, canonNoUrl, "tool", "2026-01-01T00:00:00Z");
+		expect(ref).not.toBeNull();
+		expect(ref?.url).toBeUndefined();
+	});
+	it("still voids a source whose url is required and missing (linear)", () => {
+		expect(extractRef(linearDefinition, { id: "PROJ-1", title: "x" }, "tool", "2026-01-01T00:00:00Z")).toBeNull();
+	});
+});
+```
+(Import `linearDefinition` if not already imported in this test file.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/references/SourceEngine.test.ts -t "optional url"`
+Expected: FAIL — `extractRef` currently voids on missing url.
+
+- [ ] **Step 3: Change `Reference.url` to optional**
+
+In `cli/src/Types.ts` `Reference` interface: `readonly url?: string;`
+
+- [ ] **Step 4: Update `extractRef` and `renderOne` in `SourceEngine.ts`**
+
+Replace the url handling in `extractRef` (currently lines ~157-159) so `url` is evaluated like `description`:
+```typescript
+	const nativeIdR = evalField(def.reference.nativeId, payload);
+	const titleR = evalField(def.reference.title, payload);
+	const urlR = evalField(def.reference.url, payload);
+	if (!nativeIdR.ok || !titleR.ok || !urlR.ok) return null;
+	if (nativeIdR.value === undefined || titleR.value === undefined) return null;
+	// url may be undefined only when the definition marks it optional (Slack);
+	// evalField already voided a required-but-missing url via urlR.ok === false.
+```
+And in the returned object, make url conditional:
+```typescript
+		...(urlR.value !== undefined ? { url: urlR.value } : {}),
+```
+In `renderOne`, guard the url line:
+```typescript
+	if (ref.url !== undefined && ref.url.length > 0) lines.push(`  <url>${escapeForText(ref.url)}</url>`);
+```
+
+- [ ] **Step 5: Run tests to verify pass (engine + goldens still green)**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/references/SourceEngine.test.ts src/core/references/GoldenParity.test.ts`
+Expected: PASS — new optional-url cases pass; the 4 existing sources' goldens unchanged (they always have url).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/Types.ts cli/src/core/references/SourceEngine.ts cli/src/core/references/SourceEngine.test.ts
+git commit -s -m "feat(references): allow url-optional source definitions"
+```
+
+---
+
+## Task 5: ReferenceStore — markdown round-trip with absent url
+
+**Files:**
+- Modify: `cli/src/core/references/ReferenceStore.ts` (renderMarkdown / parseMarkdown)
+- Test: `cli/src/core/references/ReferenceStore.test.ts`
+
+**Interfaces:**
+- Consumes: `Reference.url?` from Task 4.
+- Produces: a `Reference` written with no `url` frontmatter round-trips back to `url === undefined`.
+
+- [ ] **Step 1: Write the failing test** (append)
+
+```typescript
+it("round-trips a reference with no url", async () => {
+	const ref = {
+		mapKey: "slack:C1-1700000000.000001", source: "slack", nativeId: "C1-1700000000.000001",
+		title: "t", description: "body", toolName: "tool", referencedAt: "2026-01-01T00:00:00Z",
+	} as const;
+	const md = renderMarkdown(ref); // exported helper
+	const parsed = await /* parse */ parseReferenceMarkdownString(md);
+	expect(parsed?.url).toBeUndefined();
+	expect(parsed?.title).toBe("t");
+});
+```
+(Use whichever render/parse helpers the file already exports/tests; mirror an existing round-trip test in this file for the exact call shape.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/references/ReferenceStore.test.ts -t "no url"`
+Expected: FAIL — url written as `url: undefined`/empty or parse asserts a string.
+
+- [ ] **Step 3: Implement**
+
+In `renderMarkdown`, emit the `url:` frontmatter line only when `ref.url` is defined and non-empty. In `parseMarkdown`, treat a missing `url` frontmatter key as `undefined` (do not default to `""`), and do NOT reject a reference for a missing url (Slack is allowed to lack it). Keep the existing required-field checks for `nativeId`/`title`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/references/ReferenceStore.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/core/references/ReferenceStore.ts cli/src/core/references/ReferenceStore.test.ts
+git commit -s -m "feat(references): tolerate absent url in markdown round-trip"
+```
+
+---
+
+## Task 6: envelope — retain input, scan permalinks, correlate, normalize
+
+**Files:**
+- Modify: `cli/src/core/references/ClaudeEnvelopeParser.ts`
+- Test: `cli/src/core/references/ClaudeEnvelopeParser.test.ts`
+
+**Interfaces:**
+- Consumes: `scanUserPermalinks` (Task 1), `normalizeSlackThread` (Task 2), `slackDefinition` id (Task 3), `loadConfig` (`SessionTracker`).
+- Produces: for a transcript containing a pasted permalink + a `slack_read_thread` result, one `NormalizedToolResult` whose `payload` is the `SlackCanonical` (with `url` from the permalink).
+
+**Design notes for the implementer:**
+- Slack is the first source whose `normalize` needs both the tool_use `input` and out-of-payload context (url from the permalink map, config). Introduce a per-source hook rather than special-casing Slack inline: in `collectToolUses`'s MCP branch, when `mcpDef.id === "slack"`, store the tool_use `input` on the `PendingEntry` (add `readonly toolInput?: unknown`). In `collectToolResults`, when the entry is Slack, call `normalizeSlackThread(parsedPayload, { channelId, url })` where `channelId` comes from `toolInput.channel_id` and `url` from the permalink map keyed `"<channelId>:<parentTs>"` (parentTs from `toolInput.message_ts`). Push the canonical object as `payload`. If `normalizeSlackThread` returns null, drop the entry (skip the result).
+- Build the permalink map once per `parse()` via `scanUserPermalinks(lines)` before the main loop.
+- Config: `parse()` is sync; `loadConfig` is async. Read config **once** in the async caller (`extractReferencesFromTranscript`) and thread `config.slack?.workspaceUrl` into `ExtractOptions` (add `readonly slackWorkspaceUrl?: string`). In `collectToolResults`, when the permalink map has no entry but `slackWorkspaceUrl` is set, reconstruct `url = ${slackWorkspaceUrl}/archives/${channelId}/p${parentTs.replace(".","")}`. When neither is available, pass `url: undefined` (linkless capture).
+- Add `"mcp__claude_ai_Slack__"` — it is auto-added to the pre-filter via `CLAUDE_TOOL_PREFIXES` (derived from the registry) once Task 3 registers the def. No edit to `bindings/claude`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { claudeEnvelopeParser } from "./ClaudeEnvelopeParser.js";
+
+const PERMALINK = "https://flyer-q4r7867.slack.com/archives/C0BFF9UHBD1/p1783413984700009";
+const BLOB = "=== THREAD PARENT MESSAGE ===\nMessage TS: 1783413984.700009\nConsolidate…\n\n=== THREAD REPLIES (2 total) ===\n";
+
+function lines(): string[] {
+	return [
+		JSON.stringify({ message: { role: "user", content: [{ type: "text", text: `look ${PERMALINK}` }] } }),
+		JSON.stringify({ message: { role: "assistant", content: [
+			{ type: "tool_use", id: "t1", name: "mcp__claude_ai_Slack__slack_read_thread",
+			  input: { channel_id: "C0BFF9UHBD1", message_ts: "1783413984.700009" } },
+		] } }),
+		JSON.stringify({ message: { role: "user", content: [
+			{ type: "tool_result", tool_use_id: "t1", content: JSON.stringify({ messages: BLOB }) },
+		] } }),
+	];
+}
+
+describe("ClaudeEnvelopeParser slack", () => {
+	it("correlates the pasted permalink with the thread result", () => {
+		const { results } = claudeEnvelopeParser.parse(lines(), {});
+		expect(results).toHaveLength(1);
+		const p = results[0].payload as { channelId: string; parentTs: string; url?: string };
+		expect(results[0].def.id).toBe("slack");
+		expect(p).toMatchObject({ channelId: "C0BFF9UHBD1", parentTs: "1783413984.700009", url: PERMALINK });
+	});
+	it("reconstructs url from slackWorkspaceUrl when no permalink pasted", () => {
+		const noPermalink = lines().slice(1); // drop the user permalink line
+		const { results } = claudeEnvelopeParser.parse(noPermalink, { slackWorkspaceUrl: "https://flyer-q4r7867.slack.com" });
+		expect((results[0].payload as { url?: string }).url).toBe(PERMALINK);
+	});
+	it("captures linklessly when neither permalink nor config present", () => {
+		const { results } = claudeEnvelopeParser.parse(lines().slice(1), {});
+		expect((results[0].payload as { url?: string }).url).toBeUndefined();
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/references/ClaudeEnvelopeParser.test.ts -t "slack"`
+Expected: FAIL — no correlation logic; `slackWorkspaceUrl` not in `ExtractOptions`.
+
+- [ ] **Step 3: Implement**
+
+- Add `readonly slackWorkspaceUrl?: string;` to `ExtractOptions` in `TranscriptEnvelopeParser.ts`.
+- In `extractReferencesFromTranscript` (`ReferenceExtractor.ts`), before `parser.parse`, if any registered def is Slack, `const cfg = await loadConfig();` and pass `slackWorkspaceUrl: cfg.slack?.workspaceUrl` merged into `opts`. (Import `loadConfig` from `../SessionTracker.js`.)
+- In `ClaudeEnvelopeParser.parse`, compute `const permalinks = scanUserPermalinks(lines);` once.
+- Extend `PendingEntry` with `readonly toolInput?: unknown;`. In the MCP branch of `collectToolUses`, set `toolInput: b.input` when `mcpDef.id === "slack"`.
+- In `collectToolResults`, when `pendingEntry.def.id === "slack"`: read `channelId`/`messageTs` from `pendingEntry.toolInput`; `const url = permalinks.get(`${channelId}:${messageTs}`) ?? (opts.slackWorkspaceUrl ? `${opts.slackWorkspaceUrl}/archives/${channelId}/p${messageTs.replace(".","")}` : undefined);` then `const canonical = normalizeSlackThread(parsedPayload, { channelId, url });` — push `payload: canonical` (skip if null). Thread `permalinks` and `opts` into `collectToolResults` (add params).
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/references/ClaudeEnvelopeParser.test.ts`
+Expected: PASS (3 new + existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/core/references/ClaudeEnvelopeParser.ts cli/src/core/references/TranscriptEnvelopeParser.ts cli/src/core/references/ReferenceExtractor.ts cli/src/core/references/ClaudeEnvelopeParser.test.ts
+git commit -s -m "feat(references): capture Slack threads via permalink correlation"
+```
+
+---
+
+## Task 7: config — `slack.workspaceUrl` set + validation
+
+**Files:**
+- Modify: `cli/src/Types.ts` (`JolliMemoryConfig.slack`)
+- Modify: `cli/src/commands/ConfigureCommand.ts`
+- Test: `cli/src/commands/ConfigureCommand.test.ts`
+
+**Interfaces:**
+- Produces: `jolli configure --set slack.workspaceUrl=https://x.slack.com` persists `{ slack: { workspaceUrl } }`; a non-`.slack.com` or non-https value is rejected with a clear error and non-zero exit.
+
+- [ ] **Step 1: Add the config field** — in `JolliMemoryConfig`:
+```typescript
+	/** Slack workspace base URL (https://<sub>.slack.com), fallback source for
+	 *  thread permalinks when the user did not paste one. See Slack capture. */
+	readonly slack?: { readonly workspaceUrl?: string };
+```
+
+- [ ] **Step 2: Write the failing test** (mirror an existing ConfigureCommand set-test)
+
+```typescript
+it("accepts slack.workspaceUrl and rejects a non-slack host", async () => {
+	await runConfigure(["--set", "slack.workspaceUrl=https://flyer-q4r7867.slack.com"], dir);
+	expect((await loadConfigFromDir(dir)).slack?.workspaceUrl).toBe("https://flyer-q4r7867.slack.com");
+	await expect(runConfigure(["--set", "slack.workspaceUrl=https://evil.example"], dir)).rejects.toThrow(/slack\.com/);
+});
+```
+(Use the file's existing harness for invoking the command + temp dir.)
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/commands/ConfigureCommand.test.ts -t "slack.workspaceUrl"`
+Expected: FAIL — key not handled.
+
+- [ ] **Step 4: Implement** — add `"slack.workspaceUrl"` to the valid-keys handling. On set, validate: parse with `new URL(value)`; require `protocol === "https:"` and `hostname === "slack.com" || hostname.endsWith(".slack.com")`; else throw `Error("slack.workspaceUrl must be an https://<workspace>.slack.com URL")`. Persist as nested `{ slack: { workspaceUrl: value } }` (merge with any existing `slack`).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm run test -w @jolli.ai/cli -- src/commands/ConfigureCommand.test.ts -t "slack.workspaceUrl"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/Types.ts cli/src/commands/ConfigureCommand.ts cli/src/commands/ConfigureCommand.test.ts
+git commit -s -m "feat(config): slack.workspaceUrl set + validation"
+```
+
+---
+
+## Task 8: VS Code — SOURCE_META row + config-needed hint
+
+**Files:**
+- Modify: `vscode/src/views/SourceLabels.ts`
+- Modify: `vscode/src/views/NextMemoryScriptBuilder.ts`
+- Test: `vscode/src/views/SourceLabels.test.ts`
+
+**Interfaces:**
+- Consumes: `KnownSourceId` now includes `"slack"` (Task 3).
+- Produces: `SOURCE_META.slack`; the CSS/badge builders auto-derive (they map over `SOURCE_META`), so no separate CSS edit is needed.
+
+- [ ] **Step 1: Write the failing test** (append to `SourceLabels.test.ts`)
+
+```typescript
+it("has slack metadata", () => {
+	expect(SOURCE_META.slack).toEqual({ label: "Slack", letter: "S", icon: "comment-discussion", color: "#4a154b" });
+	expect(getSourceMeta("slack").label).toBe("Slack");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:vscode -- src/views/SourceLabels.test.ts -t "slack"`
+Expected: FAIL — `SOURCE_META.slack` missing (also a TS error: `Record<KnownSourceId>` now requires `slack`).
+
+- [ ] **Step 3: Implement SOURCE_META row** — in `SourceLabels.ts` `SOURCE_META`:
+```typescript
+	slack: { label: "Slack", letter: "S", icon: "comment-discussion", color: "#4a154b" },
+```
+
+- [ ] **Step 4: Add the config-needed hint** — in `NextMemoryScriptBuilder.ts`, where a reference row is built (near the `SOURCE_META[s]` badge, ~line 251), when `source === "slack"` and the reference has no `url`, render a small non-link affordance instead of the "Open in Slack" link: an inline element with title "Set slack.workspaceUrl to enable jump-to-thread" that, on click, posts `{ type: "openSetting", key: "slack.workspaceUrl" }` to the host (reuse the existing `vscode.postMessage` channel this builder already uses; grep the file for its existing `postMessage`/command pattern and mirror it). The host side maps that message to opening the settings UI at the Slack field. Do NOT put the hint text into the reference `description`/prompt.
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `npm run test:vscode -- src/views/SourceLabels.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vscode/src/views/SourceLabels.ts vscode/src/views/NextMemoryScriptBuilder.ts vscode/src/views/SourceLabels.test.ts
+git commit -s -m "feat(vscode): Slack source badge + configure-workspace hint"
+```
+
+---
+
+## Task 9: Full gate + GoldenParity for Slack
+
+**Files:**
+- Modify: `cli/src/core/references/GoldenParity.test.ts` (add a Slack block)
+
+- [ ] **Step 1: Add a Slack golden** asserting the full `Reference` + rendered `<slack-threads>` block from the real fixture (pin the exact `<slack-threads>\n<thread id="C0BFF9UHBD1-1783413984.700009" …>…</thread>\n</slack-threads>` bytes; compute the expected string from `renderBlock(slackDefinition, [ref])`).
+
+- [ ] **Step 2: Run the full gate with the git-op env workaround**
+
+Run: `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all npm run all`
+Expected: build + lint clean; all tests pass; CLI coverage ≥ 97/96/97/97. (The two `src/sync/GitClient.test.ts` failures seen without the env prefix are a known local-environment issue, unrelated to this feature.)
+
+- [ ] **Step 3: Final commit**
+
+```bash
+git add cli/src/core/references/GoldenParity.test.ts
+git commit -s -m "test(references): Slack thread golden parity"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** capture unit (Task 3 def) ✓; permalink anchor + scan (Task 1) ✓; body normalize (Task 2) ✓; correlation + config fallback + linkless degrade (Task 6) ✓; url-optional engine (Task 4) + storage (Task 5) ✓; config schema + validation (Task 7) ✓; rendering slots (Task 3 render) ✓; VS Code SOURCE_META + hint (Task 8) ✓; real fixtures + defensive parse (Tasks 1/2/9) ✓; duplicate-across-line-types guard (Task 1 test) ✓.
+- **Type consistency:** `SlackCanonical` field names (`channelId`/`parentTs`/`title`/`text`/`replyCount`/`url`) are identical in Tasks 2, 3, 6. `nativeId` = `<channelId>-<parentTs>` and `mapKey` = `slack:<nativeId>` consistent across Tasks 3 and 6. `ExtractOptions.slackWorkspaceUrl` defined in Task 6 and used only there.
+- **Ordering note:** Task 4 (url-optional) is a prerequisite for Task 3's absent-url path and Task 6's linkless test — execute Task 4 before Task 6 (Task 3 before Task 4 is fine since Task 3's own test uses a url-present canonical).
+- **Out of scope (per spec §9):** channel/search capture, IntelliJ hint parity, per-repo override, permalink→config auto-seed.

--- a/docs/superpowers/specs/2026-07-07-slack-thread-context-capture-design.md
+++ b/docs/superpowers/specs/2026-07-07-slack-thread-context-capture-design.md
@@ -1,128 +1,139 @@
 # Slack Thread Context Capture Design
 
-- **Date**: 2026-07-07
+- **Date**: 2026-07-07 (revised 2026-07-08: permalink-anchored model)
 - **Status**: Design under review
-- **Goal**: Capture Slack **discussion threads** (parent message + replies) that an AI agent reads via the Slack MCP server during a session, turning each thread into a `Reference` that is injected into Working Memory (the SUMMARIZE prompt) and stored alongside the existing Linear / Jira / GitHub / Notion references.
-- **Relationship to JOLLI-1877**: This is a **separate new feature**, not part of JOLLI-1877 (the source-definition consolidation). It *builds on* that work (the `SourceDefinition` / `SourceEngine` / envelope architecture) and needs its own Linear issue.
+- **Goal**: Capture Slack **discussion threads** (parent message + replies) that an AI agent reads via the Slack MCP server during a session, turning each thread into a `Reference` injected into Working Memory (the SUMMARIZE prompt) and stored alongside the existing Linear / Jira / GitHub / Notion references.
+- **Relationship to JOLLI-1877**: A **separate new feature**, not part of JOLLI-1877 (source-definition consolidation). It builds on that architecture (`SourceDefinition` / `SourceEngine` / envelope) and needs its own Linear issue.
 
 ---
 
 ## 1. Background & the fit problem
 
-JOLLI-1877 established a reference pipeline: an **Envelope** layer recognizes an MCP tool call + return payload in a transcript line, a **`SourceDefinition`** (declarative) describes how to extract a `Reference`, and the **`SourceEngine`** evaluates it. Adding a well-shaped source (issue-like entity with a stable `nativeId`/`title`/`url`/`description`) is now one definition file.
+JOLLI-1877 established a reference pipeline: an **Envelope** layer recognizes an MCP tool call + return payload in a transcript line; a declarative **`SourceDefinition`** describes how to extract a `Reference`; the **`SourceEngine`** evaluates it. Adding an issue-shaped source (stable `nativeId`/`title`/`url`/`description`) is one definition file.
 
-Slack does **not** fit that happy path, for three verified reasons (all checked against real MCP payloads on 2026-07-07):
+Slack does not fit that happy path, for reasons verified against **real MCP payloads and the real session transcript** (2026-07-07/08):
 
-1. **The result is a text blob, not structured data.** `slack_read_thread` returns `{ messages: "<one big formatted string>", pagination_info }`. There are no per-field JSON keys — author / time / ts / text are baked into human-readable text (`=== THREAD PARENT MESSAGE ===`, `--- Reply N of M ---`, `Message TS: …`).
-2. **No `url` anywhere in the result.** Slack's underlying `conversations.replies` API does not return message permalinks, and the MCP wrapper does not add them. A thread permalink is `https://<workspace>.slack.com/archives/<channelId>/p<parentTs>` — buildable only from workspace (config) + channelId + parentTs.
-3. **No `channelId` in the thread result either.** The thread blob contains only per-message `From / Time / Message TS / text`. The `channelId` exists **only in the tool-call input** (`{ channel_id, message_ts }`), which the envelope currently **discards** for MCP calls (`normalize: identity`, input not retained).
+1. **The result is a text blob, not structured data.** `slack_read_thread` returns `{ messages: "<one formatted string>", pagination_info }`; author / time / ts / text are baked into human-readable text (`=== THREAD PARENT MESSAGE ===`, `--- Reply N of M ---`, `Message TS: …`).
+2. **No `url` and no `channelId` in the result.** The thread blob has only per-message `From / Time / Message TS / text`. Slack's `conversations.replies` returns no permalinks, and the MCP wrapper adds none.
+3. **But the user pastes a full permalink.** The observed workflow: the user types a thread permalink into the conversation — `https://flyer-q4r7867.slack.com/archives/C0BFF9UHBD1/p1783413984700009` — which contains **everything**: workspace `flyer-q4r7867`, channel `C0BFF9UHBD1`, parent ts `1783413984.700009`. Claude then derives `channel_id`/`message_ts` from it to call `slack_read_thread`.
 
-So the permalink's three inputs come from three different places: `workspace` = **config**, `channelId` = **tool_use input**, `parentTs` = **result blob**.
+**This reframes the capture anchor**: the source of the identity + link is the **user-pasted permalink in the transcript**, not the tool result. The tool result supplies only the body. No workspace config is required.
 
-### Real captured payload (the pinned fixture, verified today)
+### Verified facts (real session transcript `…/ca9cb9b2-….jsonl`, 2026-07-08)
 
-```
-{"messages":"=== THREAD PARENT MESSAGE ===\nFrom: Flyer Li <…> (U0BGFSM16DN)\nTime: 2026-07-07 16:46:24 CST\nMessage TS: 1783413984.700009\nConsolidate the existing Linear / Jira / GitHub / Notion …\n\n=== THREAD REPLIES (2 total) ===\n\n--- Reply 1 of 2 ---\nFrom: … (U0BGFSM16DN)\nTime: 2026-07-07 17:18:37 CST\nMessage TS: 1783415917.422609\nConfig-driven MCP integration\n\n--- Reply 2 of 2 ---\nFrom: … (U0BGFSM16DN)\nTime: 2026-07-07 17:23:48 CST\nMessage TS: 1783416228.715669\nHow to do?\n","pagination_info":"There are no more messages in this thread.\n"}
-```
+- `slack_read_thread` tool_use input keys are exactly `{"channel_id":"C0BFF9UHBD1","message_ts":"1783413984.700009"}`.
+- The permalink appears verbatim in `role: user` message text.
+- Permalink `(channel, ts)` **exactly equals** the tool_use input `(channel_id, message_ts)` → correlation is sound.
+- ⚠️ The permalink also appears in a `"type":"last-prompt"` metadata line — the scanner must read **only `role:user` `message.content` text blocks**, or the same thread is captured twice.
 
 ## 2. Decisions (from brainstorming)
 
 | Decision point | Choice | Rationale |
 |---|---|---|
-| Capture unit | **Thread** (parent + replies), one thread → one `Reference` | Bounded discussion unit with a stable permalink; best fit for the issue/document-shaped `Reference` model |
-| Trigger tool | **`slack_read_thread` only** (v1) | Channel reads (`slack_read_channel`) and `slack_search_public` are **out of scope for v1** — a channel is a stream, not a titled entity; search returns fragments |
-| `url` source | **Construct from a configured workspace URL** + channelId + parentTs | The only reliable way to a working permalink; payload permalink doesn't exist, and dropping the link loses half the value |
-| Missing config | **Degrade, do not disable** | Content is still captured (title + thread body + fields); only the clickable link is missing, and the UI prompts the user to configure `slack.workspaceUrl` |
-| Where the messy work lives | **Code-side `normalize`** (blob parse + input merge + permalink build); DSL definition only selects fields | Matches JOLLI-1877's philosophy: "normalize/recover stays as code; the DSL sees the canonical payload." Concentrates brittle parsing in one testable function |
-| Config-needed hint | **UI-only** (VS Code panel), never in the Reference data / SUMMARIZE prompt | Capture is headless (post-commit worker); a hint in `fields`/`description` would pollute the LLM prompt |
+| Capture unit | **Thread** (parent + replies), one thread → one `Reference` | Bounded discussion unit; fits the issue/document-shaped model |
+| **Capture anchor** | **The user-pasted Slack permalink** in `role:user` text | It carries workspace + channel + ts; makes `url` authoritative and config-free |
+| Trigger for the body | **`slack_read_thread`** result, correlated to the permalink by `(channel, ts)` | Supplies the thread text; `slack_read_channel` / `slack_search_public` are OUT of v1 |
+| `url` source (priority) | **① pasted permalink (primary, zero-config) → ② `config.slack.workspaceUrl` reconstruction (fallback) → ③ degrade** | Permalink is present in the real workflow; config only matters when no permalink was pasted |
+| Missing all url sources | **Degrade, not disable** | Body still captured (title + thread text + fields); UI prompts to set `slack.workspaceUrl` |
+| Where the messy work lives | **Code-side `normalize`** parses the body blob only (url now comes from the permalink) | Matches JOLLI-1877: "normalize stays as code; DSL sees the canonical payload" |
+| Config-needed hint | **UI-only** (VS Code panel), never in Reference data / SUMMARIZE prompt | Capture is headless; a hint in `fields`/`description` would pollute the LLM prompt |
 
 ### Explicitly NOT config-driven
 
-Because Slack needs a code-side `normalize` (blob parsing + config injection), it is a **built-in source** on par with GitHub/Jira. It can **never** be added via Phase-2 zero-code user config — it is not "one config rule." This must be stated so it isn't mistaken for a declarative-only source.
+Slack needs a code-side `normalize` (blob parsing) **and** a new transcript-scanning channel, so it is a **built-in source** like GitHub/Jira — it can never be added via Phase-2 zero-code user config. Not "one config rule."
 
 ## 3. Data model — one thread → one `Reference`
 
 | `Reference` field | Value | Source |
 |---|---|---|
-| `mapKey` / `nativeId` | `slack:<channelId>-<parentTs>` / `<channelId>-<parentTs>` (e.g. `C0BFF9UHBD1-1783413984.700009`) | channelId (tool input) + parentTs (result blob) |
-| `title` | Parent message first line, truncated (e.g. "Consolidate the existing Linear / Jira / GitHub…") | result blob |
-| `url` | `https://<workspace>/archives/<channelId>/p<parentTs-without-dot>` **when configured; otherwise absent** | config + input + blob |
-| `description` | Full thread text (parent + all replies, with author/time), lightly cleaned | result blob |
-| `fields[]` | `entity-type=thread`, `replies=<N>`, `channel=<channelId>` | blob + input |
+| `mapKey` / `nativeId` | `slack:<channelId>-<parentTs>` / `<channelId>-<parentTs>` (e.g. `C0BFF9UHBD1-1783413984.700009`) | permalink (channel, ts) |
+| `title` | Parent message first line, truncated | body blob |
+| `url` | The pasted permalink verbatim; else reconstructed from `config.slack.workspaceUrl` + channel + ts; else **absent** | ① permalink → ② config |
+| `description` | Full thread text (parent + replies, with author/time), lightly cleaned | body blob |
+| `fields[]` | `entity-type=thread`, `replies=<N>`, `channel=<channelId>` | blob + permalink |
 | `referencedAt` | transcript timestamp | envelope |
 
-**Path safety**: `nativeId` = `<channelId>-<parentTs>` contains only `\w . -` (the ts dot is allowed by `[^\w.-]`), no `/`, no `..` → `storage.nativeIdPathSafe: true` (identity, the `..`/`/\` guard passes).
+**Path safety**: `nativeId` = `<channelId>-<parentTs>` contains only `\w . -` (ts dot allowed), no `/`, no `..` → `storage.nativeIdPathSafe: true` (identity; the `..`/`/\` guard passes).
 
-**No channel name**: the thread blob has no `#channel-name` (only channel-read does), so `title` uses the parent text, not `#channel`.
+**No channel name** in the thread blob, so `title` uses the parent text, not `#channel`.
 
-## 4. Architecture (5 changes; reference pipeline otherwise untouched)
+## 4. Architecture (permalink-anchored)
 
 ```
-transcript ──▶ ClaudeEnvelopeParser
-                 · [①] MCP branch also retains tool_use.input (for channelId)
-                 · [②] passes { toolInput, config } to a per-def normalize
-                 │      (today the Claude-MCP path is hardcoded normalize: identity)
-                 │  NormalizedToolResult{ def, payload = normalize(rawResult, {toolInput, config}) }
-                 ▼
-              SourceEngine.extractRef(slackDef, canonicalPayload)   ← DSL only selects fields
-                 · [④] `url` respects FieldSpec.optional (was hard-required)
-                 ▼
-              Reference → ReferenceStore → assembleReferenceBlocks / renderBlock   ← unchanged
-                 ▼
-              [⑤] VS Code panel: slack ref without url + workspaceUrl unset → inline config hint + one-time toast
+transcript
+  ├─ [①] scan role:user message.content TEXT blocks for  *.slack.com/archives/<ch>/p<ts>
+  │        → permalinkMap keyed by (channel, ts):  { url, workspace, channel, parentTs }
+  │        (read ONLY role:user text blocks — not "last-prompt" metadata, not tool results)
+  │
+  └─ ClaudeEnvelopeParser  (slack_read_thread tool_use/tool_result)
+        · [②] retain tool_use.input {channel_id, message_ts}  (correlation key)
+        · [③] normalize(rawResultBlob) → { parentTs, title, text, replyCount }   (body only)
+             │
+             ▼  correlate on (channel_id/message_ts) == permalinkMap key
+        SourceEngine.extractRef(slackDef, { ...body, channelId, url? })  ← DSL selects fields
+             · [④] `url` respects FieldSpec.optional (was hard-required)
+             ▼
+        Reference → ReferenceStore → assembleReferenceBlocks / renderBlock   (unchanged)
+             ▼
+        [⑤] VS Code panel: slack ref with no url + workspaceUrl unset → inline hint + one-time toast
 ```
 
 ### The change set
 
-1. **Envelope: thread the MCP `tool_use.input` through.** Today `collectToolUses`'s MCP branch stores only `{ toolName, def, normalize: identity }`. Retain the tool_use `input` object and carry it on `NormalizedToolResult` (or hand it to `normalize`). This is the same capability the CLI/shell path already uses (`readCommand(b.input)`); it just wasn't wired for MCP.
-2. **Open the Claude-MCP `normalize` seam.** Extend the `normalize` signature from `(business) => unknown` to `(business, ctx: { toolInput?: unknown; config: JolliConfig }) => unknown`. Existing Codex/CLI callers ignore `ctx` (backward compatible). The Slack definition's source registers a real `normalize`.
-3. **`SlackNormalize.ts` (code) + `slack.ts` (definition).** `SlackNormalize` parses the blob (defensively) into a canonical object `{ channelId, parentTs, title, text, replyCount, permalink? }`, merging `channelId` from `toolInput` and building `permalink` from `config.slack.workspaceUrl` (omitted when unset). `slack.ts` is a trivial `path`-only definition over that canonical shape.
-4. **Engine: `url` respects `optional`.** `extractRef` currently hard-voids when `url` is missing ([SourceEngine.ts:158-159](../../../cli/src/core/references/SourceEngine.ts)). Change it to evaluate `url` through the same optional-aware path as `description`. The other 4 definitions do **not** set `url.optional`, so they remain hard-required — behavior unchanged.
-5. **VS Code config-needed hint (UI-only).** When the panel renders a `source === "slack"` reference whose `url` is empty and `config.slack.workspaceUrl` is unset, show an inline "configure `slack.workspaceUrl` to enable jump-to-thread" hint with a settings deep-link, plus a one-time toast on first occurrence. No data-model or prompt change.
+1. **New: scan `role:user` message text for Slack permalinks.** A small pre-pass (or an added branch in the Claude envelope) that reads **only** `role:user` `message.content` text blocks, extracts `*.slack.com/archives/<channel>/p<ts>` permalinks, and builds a map keyed by `(channel, ts)`. Deliberately excludes `"type":"last-prompt"` lines and tool-result content to avoid duplicate capture (verified real risk).
+2. **Retain the `slack_read_thread` tool_use input** `{channel_id, message_ts}` as the correlation key (the envelope discards MCP input today).
+3. **`SlackNormalize.ts` (code) + `slack.ts` (definition).** `SlackNormalize` defensively parses the body blob into `{ parentTs, title, text, replyCount }`. The permalink-derived `url` + `channelId` are merged in at correlation time. `slack.ts` is a `path`-only definition over that canonical shape.
+4. **Engine: `url` respects `optional`.** `extractRef` hard-voids on missing `url` today ([SourceEngine.ts:158-159](../../../cli/src/core/references/SourceEngine.ts)); change it to evaluate `url` via the same optional-aware path as `description`. The other 4 definitions omit `url.optional`, so they stay hard-required — behavior unchanged.
+5. **VS Code config-needed hint (UI-only).** When the panel renders a `source === "slack"` reference with empty `url` and `config.slack.workspaceUrl` unset, show an inline "configure `slack.workspaceUrl` to enable jump-to-thread" hint + settings deep-link, plus a one-time toast. No data-model / prompt change.
 
-## 5. Config schema
+### Correlation & fallback
 
-Machine-global `~/.jolli/jollimemory/config.json` (Slack workspace is user/machine-level, shared across repos):
+- Match permalink `(channel, ts)` ↔ tool_use input `(channel_id, message_ts)`. On match: `url` = pasted permalink (authoritative), body = normalized result.
+- **No permalink, config set**: reconstruct `url` from `config.slack.workspaceUrl` + `channelId` (input) + `parentTs` (body).
+- **No permalink, no config**: `Reference` still produced with `url` absent → UI hint.
+
+## 5. Config schema (fallback only)
+
+Machine-global `~/.jolli/jollimemory/config.json`:
 
 ```jsonc
 { "slack": { "workspaceUrl": "https://flyer-q4r7867.slack.com" } }
 ```
 
-- **Save-time validation** (mirrors the repo's origin-allowlist discipline): `https://` only, host must end with `.slack.com`.
-- **Unset ≠ disabled**: capture still runs; `permalink` is omitted, the `Reference` is still produced (url absent), and the VS Code hint fires. Setting `slack.workspaceUrl` upgrades subsequent captures to include a working link.
+- **No longer the primary path** — only used when no permalink was pasted in the session.
+- **Save-time validation**: `https://` only, host ends with `.slack.com`.
+- Optional to set; the permalink workflow makes it unnecessary in the common case.
 
 ## 6. Rendering / injection
 
-No engine change — the existing slot vocabulary covers it:
+No engine change — the slot vocabulary covers it:
 
 ```jsonc
 "render": { "wrapperTag": "slack-threads", "itemTag": "thread", "bodyTag": "messages",
             "fieldAttrs": true, "maxCharsPerReference": 8000, "maxTotalChars": 40000 }
 ```
 
-Injection reuses `assembleReferenceBlocks` (bucketed by source, `registry.all()` order). VS Code `SOURCE_META` gains one row: `slack: { label: "Slack", letter: "S", icon: "comment-discussion", color: "#4a154b" }`.
+Injection reuses `assembleReferenceBlocks` (bucketed by source, `registry.all()` order). VS Code `SOURCE_META` gains: `slack: { label: "Slack", letter: "S", icon: "comment-discussion", color: "#4a154b" }`.
 
-## 7. Testing (real fixtures, defensive parsing)
+## 7. Testing (real fixtures)
 
-1. **Pinned real fixture**: the 2026-07-07 `slack_read_thread` blob above (parent + 2 replies). `SlackNormalize` unit test asserts the canonical object; a GoldenParity-style test asserts the final `Reference` + rendered `<slack-threads>` block.
-2. **Config matrix**: workspaceUrl set → `url` present; unset → `Reference` still produced with `url` absent (does NOT void).
-3. **Defensive parsing**: malformed / format-drifted blob → `normalize` returns a shape that voids (never throws). `replies (N total)` count parse, `Message TS:` extraction, first-reply detection.
-4. **Envelope test**: `tool_use.input.channel_id` is threaded through to `normalize`.
-5. **Engine test**: a definition with `url.optional: true` produces a `Reference` without url; the 4 existing definitions (no `optional`) still void on missing url.
+1. **Pinned real fixtures** (both captured this session): the `slack_read_thread` body blob (parent + 2 replies) and the pasted permalink. `SlackNormalize` unit test asserts the canonical body object; a GoldenParity-style test asserts the correlated `Reference` (url = permalink) + rendered `<slack-threads>` block.
+2. **Correlation**: permalink `(channel, ts)` == tool input → url from permalink. Permalink absent + config set → reconstructed url. Both absent → `Reference` produced with url absent (does NOT void).
+3. **Duplicate-guard**: a permalink present in both a `role:user` text block and a `"last-prompt"` line yields **one** Reference, not two.
+4. **Defensive parsing**: malformed / format-drifted body blob → `normalize` voids (never throws).
+5. **Engine**: a definition with `url.optional: true` produces a Reference without url; the 4 existing definitions still void on missing url.
 6. **Coverage**: hold 97/96/97/97; batch `npm run all` + commit at the end.
 
 ## 8. Pre-implementation verification gates
 
-Confirm against real data **before** writing the plan (the JOLLI-1877 "Confirm before writing the plan" discipline):
-
-1. ✅ **Real `slack_read_thread` payload shape** — captured 2026-07-07; pinned as fixture.
-2. ⚠️ **Blob text format stability** — only one real sample so far. The format (`=== THREAD PARENT MESSAGE ===`, `--- Reply N of M ---`, `THREAD REPLIES (N total)`, `Message TS:`) is defined by the MCP wrapper (human-facing text, not a stable API schema). `normalize` MUST be defensive: unparseable → void, never throw. Capture a second real thread if possible.
-3. **tool_use input keys** — confirm a real Claude Code transcript records the input under `input` with keys `channel_id` / `message_ts`.
-4. **Scope** — `slack_read_channel` / `slack_search_public` confirmed OUT of v1.
+1. ✅ **Real `slack_read_thread` payload shape** — captured; pinned fixture.
+2. ⚠️ **Body-blob format stability** — one real sample; format is MCP-wrapper text, not a stable schema. `normalize` MUST be defensive (unparseable → void, never throw). Capture a second real thread if possible.
+3. ✅ **tool_use input keys + permalink-in-user-text + correlation** — verified against the real session transcript (§1). Duplicate-across-line-types risk identified and handled by change #1.
+4. ✅ **Scope** — `slack_read_channel` / `slack_search_public` OUT of v1.
 
 ## 9. Out of scope (future)
 
-- Channel-snapshot capture (`slack_read_channel`) and search-result capture.
-- IntelliJ panel parity for the config-needed hint (VS Code first).
-- Per-repo (vs machine-global) workspace override.
-- Auto-resolving the permalink via a `chat.getPermalink`-style call (avoids needing configured workspace) — rejected for v1 (extra round-trip, not available through the current MCP tool set).
+- Channel-snapshot and search-result capture.
+- IntelliJ panel parity for the config-needed hint.
+- Per-repo workspace override.
+- Harvesting the workspace from a permalink to **auto-seed** `config.slack.workspaceUrl` for later permalink-free captures (a natural extension of change #1; deferred to keep v1 focused).

--- a/vscode/src/core/ReferenceService.test.ts
+++ b/vscode/src/core/ReferenceService.test.ts
@@ -233,7 +233,7 @@ describe("detectReferences", () => {
 		expect(await detectReferences("/repo")).toEqual([]);
 	});
 
-	it("defaults url to empty string for a linkless Slack entry (no permalink/workspace configured)", async () => {
+	it("defaults url to empty string for a persisted entry with no url (defensive — no shipping source emits one)", async () => {
 		mockLoadPlansRegistry.mockResolvedValue({
 			version: 1,
 			plans: {},

--- a/vscode/src/core/ReferenceService.test.ts
+++ b/vscode/src/core/ReferenceService.test.ts
@@ -233,6 +233,27 @@ describe("detectReferences", () => {
 		expect(await detectReferences("/repo")).toEqual([]);
 	});
 
+	it("defaults url to empty string for a linkless Slack entry (no permalink/workspace configured)", async () => {
+		mockLoadPlansRegistry.mockResolvedValue({
+			version: 1,
+			plans: {},
+			references: {
+				"slack:C0-123.456": makeEntry({
+					source: "slack",
+					nativeId: "C0-123.456",
+					title: "Thread about the release",
+					url: undefined,
+					sourcePath: "/repo/.jolli/jollimemory/references/slack/C0-123.456.md",
+					sourceToolName: "mcp__claude_ai_Slack__slack_read_thread",
+				}),
+			},
+		});
+
+		const result = await detectReferences("/repo");
+
+		expect(result[0].url).toBe("");
+	});
+
 	it("sorts by lastModified descending", async () => {
 		mockLoadPlansRegistry.mockResolvedValue({
 			version: 1,

--- a/vscode/src/core/ReferenceService.ts
+++ b/vscode/src/core/ReferenceService.ts
@@ -186,7 +186,11 @@ function toReferenceInfo(mapKey: string, entry: ReferenceEntry): ReferenceInfo {
 		nativeId: entry.nativeId,
 		mapKey,
 		title: entry.title,
-		url: entry.url,
+		// entry.url is absent only for a Slack reference captured with no
+		// permalink/workspace URL (ReferenceEntry doc comment); ReferenceInfo.url
+		// stays a required string end-to-end (empty = "no url"), matching how the
+		// Next Memory panel's config-needed hint checks for a falsy url.
+		url: entry.url ?? "",
 		sourcePath: entry.sourcePath,
 		...(frontmatter.fields !== undefined ? { fields: frontmatter.fields } : {}),
 		...(frontmatter.description !== undefined

--- a/vscode/src/core/ReferenceService.ts
+++ b/vscode/src/core/ReferenceService.ts
@@ -186,10 +186,9 @@ function toReferenceInfo(mapKey: string, entry: ReferenceEntry): ReferenceInfo {
 		nativeId: entry.nativeId,
 		mapKey,
 		title: entry.title,
-		// entry.url is absent only for a Slack reference captured with no
-		// permalink/workspace URL (ReferenceEntry doc comment); ReferenceInfo.url
-		// stays a required string end-to-end (empty = "no url"), matching how the
-		// Next Memory panel's config-needed hint checks for a falsy url.
+		// entry.url is optional in the model, but every shipping source requires
+		// it, so it is effectively always present; ReferenceInfo.url stays a
+		// required string end-to-end (empty = "no url") as a defensive default.
 		url: entry.url ?? "",
 		sourcePath: entry.sourcePath,
 		...(frontmatter.fields !== undefined ? { fields: frontmatter.fields } : {}),

--- a/vscode/src/providers/PlansTreeProvider.test.ts
+++ b/vscode/src/providers/PlansTreeProvider.test.ts
@@ -310,6 +310,20 @@ describe("ReferenceItem", () => {
 		expect(item.contextValue).toBe("reference");
 	});
 
+	it("Slack entities render title-only label (the <channel>-<ts> nativeId is meaningless to users)", () => {
+		const item = new ReferenceItem(
+			makeReference({
+				source: "slack",
+				nativeId: "C0BFF9UHBD1-1783413984.700009",
+				title: "Consolidate the existing Linear /…",
+				mapKey: "slack:C0BFF9UHBD1-1783413984.700009",
+				url: "https://x.slack.com/archives/C0BFF9UHBD1/p1783413984700009",
+			}),
+		);
+		expect(item.label).toBe("Consolidate the existing Linear /…");
+		expect(item.tooltip).not.toContain("C0BFF9UHBD1-1783413984.700009");
+	});
+
 	it("Jira and GitHub entities use the issues icon with prefixed labels", () => {
 		const jira = new ReferenceItem(
 			makeReference({

--- a/vscode/src/providers/PlansTreeProvider.ts
+++ b/vscode/src/providers/PlansTreeProvider.ts
@@ -11,6 +11,7 @@ import {
 	type CommitExclusions,
 	readExclusions,
 } from "../../../cli/src/core/CommitSelectionStore.js";
+import { referenceDisplayTitle } from "../../../cli/src/core/references/ReferenceDisplay.js";
 import type { ReferenceField, SourceId } from "../../../cli/src/Types.js";
 import type { PlansStore } from "../stores/PlansStore.js";
 import type { NoteInfo, PlanInfo, ReferenceInfo } from "../Types.js";
@@ -139,7 +140,7 @@ export class ReferenceItem extends vscode.TreeItem {
 	};
 
 	constructor(reference: ReferenceInfo) {
-		super(buildReferenceLabel(reference), vscode.TreeItemCollapsibleState.None);
+		super(referenceDisplayTitle(reference), vscode.TreeItemCollapsibleState.None);
 		this.reference = reference;
 		this.description = buildReferenceDescription(reference);
 		this.iconPath = new vscode.ThemeIcon(buildReferenceIconKey(reference.source));
@@ -158,7 +159,7 @@ export class ReferenceItem extends vscode.TreeItem {
 		// multi-paragraph blobs that bloat the popover). Users who want the
 		// full text click "Open in <Source>".
 		this.referenceHover = {
-			title: buildReferenceLabel(reference),
+			title: referenceDisplayTitle(reference),
 			source: reference.source,
 			...(reference.fields && reference.fields.length > 0 ? { fields: reference.fields } : {}),
 			url: reference.url,
@@ -344,18 +345,6 @@ function buildNoteTooltip(note: NoteInfo): vscode.MarkdownString {
 
 // ─── Reference label / tooltip helpers ──────────────────────────────────────
 
-/**
- * Reference row label. Linear / Jira / GitHub issues all carry a stable native id
- * (PROJ-1234, KAN-5, owner/repo#42) that users recognize at a glance, so the
- * label leads with it. Notion pages are nameless beyond their title (the 32-hex
- * page id is meaningless to the user), so the label drops the prefix and just
- * shows the title.
- */
-function buildReferenceLabel(reference: ReferenceInfo): string {
-	if (reference.source === "notion") return reference.title;
-	return `${reference.nativeId} — ${reference.title}`;
-}
-
 function buildReferenceIconKey(source: SourceId): string {
 	// Per-source codicon id, from the single SOURCE_META table (SourceLabels.ts).
 	// Notion references are pages, not tickets — `file-text` matches the
@@ -382,11 +371,7 @@ function buildReferenceTooltip(reference: ReferenceInfo): string {
 	// MarkdownString here would render its escaped source verbatim.
 	// Plain text round-trips identically through both surfaces.
 	const lines: Array<string> = [];
-	if (reference.source === "notion") {
-		lines.push(reference.title);
-	} else {
-		lines.push(`${reference.nativeId} — ${reference.title}`);
-	}
+	lines.push(referenceDisplayTitle(reference));
 	const refFields = reference.fields ?? [];
 	if (refFields.length > 0) {
 		lines.push("");

--- a/vscode/src/views/NextMemoryCssBuilder.ts
+++ b/vscode/src/views/NextMemoryCssBuilder.ts
@@ -90,6 +90,11 @@ export function buildNextMemoryCss(): string {
 		".r-main { flex: 1; min-width: 0; }",
 		".r-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }",
 		".r-meta { flex-shrink: 0; font-size: 11.5px; color: var(--vscode-descriptionForeground); }",
+		// Config-needed hint (e.g. a linkless Slack reference): a static, muted
+		// gear glyph — not a button — with the reason on its native tooltip
+		// (title attribute). No hover/active states: it isn't clickable.
+		".ref-config-hint { flex-shrink: 0; display: inline-flex; align-items: center; color: var(--text-tertiary); }",
+		".ref-config-hint .codicon { font-size: 13px; }",
 		// Conversation source icon — the per-source brand glyph (convSourceIcon),
 		// matching the sidebar's Working Memory card rather than a text badge.
 		".conv-source-icon { flex-shrink: 0; width: 16px; height: 16px; display: inline-flex; align-items: center; justify-content: center; color: var(--vscode-icon-foreground); }",

--- a/vscode/src/views/NextMemoryCssBuilder.ts
+++ b/vscode/src/views/NextMemoryCssBuilder.ts
@@ -90,11 +90,6 @@ export function buildNextMemoryCss(): string {
 		".r-main { flex: 1; min-width: 0; }",
 		".r-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }",
 		".r-meta { flex-shrink: 0; font-size: 11.5px; color: var(--vscode-descriptionForeground); }",
-		// Config-needed hint (e.g. a linkless Slack reference): a static, muted
-		// gear glyph — not a button — with the reason on its native tooltip
-		// (title attribute). No hover/active states: it isn't clickable.
-		".ref-config-hint { flex-shrink: 0; display: inline-flex; align-items: center; color: var(--text-tertiary); }",
-		".ref-config-hint .codicon { font-size: 13px; }",
 		// Conversation source icon — the per-source brand glyph (convSourceIcon),
 		// matching the sidebar's Working Memory card rather than a text badge.
 		".conv-source-icon { flex-shrink: 0; width: 16px; height: 16px; display: inline-flex; align-items: center; justify-content: center; color: var(--vscode-icon-foreground); }",

--- a/vscode/src/views/NextMemoryScriptBuilder.test.ts
+++ b/vscode/src/views/NextMemoryScriptBuilder.test.ts
@@ -143,15 +143,6 @@ describe("buildNextMemoryScript", () => {
 		expect(js).toContain("rowActions([excludeToggle(");
 	});
 
-	it("renders a config-needed hint for a linkless Slack reference, with no click handler", () => {
-		const js = buildNextMemoryScript();
-		expect(js).toContain("rh.source === 'slack' && !rh.url");
-		expect(js).toContain("'ref-config-hint'");
-		expect(js).toContain("Set slack.workspaceUrl to enable jump-to-thread");
-		// Non-interactive: the hint carries no addEventListener/postMessage of its
-		// own — it's title-attribute-only (see the file-level comment on why).
-		expect(js).not.toContain("openSetting");
-	});
 });
 
 describe("click-to-open parity with the sidebar Working Memory rows", () => {

--- a/vscode/src/views/NextMemoryScriptBuilder.test.ts
+++ b/vscode/src/views/NextMemoryScriptBuilder.test.ts
@@ -142,6 +142,16 @@ describe("buildNextMemoryScript", () => {
 		expect(js).toContain("className: 'row-actions'");
 		expect(js).toContain("rowActions([excludeToggle(");
 	});
+
+	it("renders a config-needed hint for a linkless Slack reference, with no click handler", () => {
+		const js = buildNextMemoryScript();
+		expect(js).toContain("rh.source === 'slack' && !rh.url");
+		expect(js).toContain("'ref-config-hint'");
+		expect(js).toContain("Set slack.workspaceUrl to enable jump-to-thread");
+		// Non-interactive: the hint carries no addEventListener/postMessage of its
+		// own — it's title-attribute-only (see the file-level comment on why).
+		expect(js).not.toContain("openSetting");
+	});
 });
 
 describe("click-to-open parity with the sidebar Working Memory rows", () => {

--- a/vscode/src/views/NextMemoryScriptBuilder.ts
+++ b/vscode/src/views/NextMemoryScriptBuilder.ts
@@ -321,21 +321,6 @@ export function buildNextMemoryScript(): string {
     const row = el('div', { className: 'row', 'data-id': item.id });
     row.appendChild(ctxBadge(item.contextValue, item.iconKey));
     row.appendChild(el('div', { className: 'r-main' }, [el('div', { className: 'r-title', text: item.label })]));
-    // A Slack thread captured with no configured workspace URL (and no pasted
-    // permalink) has nothing to jump to (see the CLI's slackDefinition.reference.url,
-    // which is optional for this source only). Surface a small, non-interactive
-    // affordance instead of silently having no open-in-source action at all. This
-    // is intentionally NOT wired to a click handler: there is no VS Code settings
-    // UI field for slack.workspaceUrl (jolli configure is CLI-only today), so a
-    // postMessage here would have no host-side handler to land on. A working
-    // "jump straight to Settings" click is left as a follow-up once that field exists.
-    const rh = item.referenceHover;
-    if (item.contextValue === 'reference' && rh && rh.source === 'slack' && !rh.url) {
-      row.appendChild(el('span', {
-        className: 'ref-config-hint',
-        title: 'Set slack.workspaceUrl to enable jump-to-thread',
-      }, [el('i', { className: 'codicon codicon-gear' })]));
-    }
     let toggleMsg;
     let removeCmd;
     if (item.contextValue === 'plan') {

--- a/vscode/src/views/NextMemoryScriptBuilder.ts
+++ b/vscode/src/views/NextMemoryScriptBuilder.ts
@@ -321,6 +321,21 @@ export function buildNextMemoryScript(): string {
     const row = el('div', { className: 'row', 'data-id': item.id });
     row.appendChild(ctxBadge(item.contextValue, item.iconKey));
     row.appendChild(el('div', { className: 'r-main' }, [el('div', { className: 'r-title', text: item.label })]));
+    // A Slack thread captured with no configured workspace URL (and no pasted
+    // permalink) has nothing to jump to (see the CLI's slackDefinition.reference.url,
+    // which is optional for this source only). Surface a small, non-interactive
+    // affordance instead of silently having no open-in-source action at all. This
+    // is intentionally NOT wired to a click handler: there is no VS Code settings
+    // UI field for slack.workspaceUrl (jolli configure is CLI-only today), so a
+    // postMessage here would have no host-side handler to land on. A working
+    // "jump straight to Settings" click is left as a follow-up once that field exists.
+    const rh = item.referenceHover;
+    if (item.contextValue === 'reference' && rh && rh.source === 'slack' && !rh.url) {
+      row.appendChild(el('span', {
+        className: 'ref-config-hint',
+        title: 'Set slack.workspaceUrl to enable jump-to-thread',
+      }, [el('i', { className: 'codicon codicon-gear' })]));
+    }
     let toggleMsg;
     let removeCmd;
     if (item.contextValue === 'plan') {

--- a/vscode/src/views/SidebarCssBuilder.test.ts
+++ b/vscode/src/views/SidebarCssBuilder.test.ts
@@ -560,6 +560,23 @@ describe("onboarding panel styles", () => {
 		});
 	});
 
+	// Same class of bug as BUG 4: the reference hover-card's source badge shipped
+	// as a bare unstyled letter glued to the title ("SConsolidate…"). The card now
+	// reuses the shared context-row chip (.mem-ctx-badge, per-source brand hue) so
+	// it matches the sidebar context rows; .hc-title stays a plain block, so the
+	// only card-scoped tweak is spacing/alignment of the inline chip.
+	describe(".mem-ctx-badge inside the reference hover-card title", () => {
+		it("nudges the reused context chip with spacing + inline alignment", () => {
+			const css = buildSidebarCss();
+			expect(css).toMatch(
+				/\.hover-card\s+\.hc-title\s+\.mem-ctx-badge\s*\{[^}]*margin-right/,
+			);
+			expect(css).toMatch(
+				/\.hover-card\s+\.hc-title\s+\.mem-ctx-badge\s*\{[^}]*vertical-align/,
+			);
+		});
+	});
+
 	describe(".edited-icon — applies to both conversation rows and KB folder file rows", () => {
 		it("declares the visual block under both scopes with the same color token", () => {
 			// The KB folders tree renders the same codicon-edit ✎ glyph that

--- a/vscode/src/views/SidebarCssBuilder.ts
+++ b/vscode/src/views/SidebarCssBuilder.ts
@@ -1407,6 +1407,16 @@ export function buildSidebarCss(): string {
     margin-bottom: 6px;
     word-break: break-word;
   }
+  /* The reference card reuses the sidebar's per-source context badge
+     (.mem-ctx-badge, coloured by SOURCE_META hue) so the provider chip looks
+     identical here and on the context rows. .hc-title stays a plain block (the
+     three text-only memory / plan / note cards share it), so nudge the inline
+     badge to sit centred against the first title line with a little breathing
+     room before the title text. */
+  .hover-card .hc-title .mem-ctx-badge {
+    margin-right: 6px;
+    vertical-align: middle;
+  }
   .hover-card .hc-row { display: flex; align-items: center; gap: 6px; margin: 2px 0; }
   .hover-card .hc-row .codicon { color: var(--vscode-icon-foreground); flex-shrink: 0; }
   .hover-card hr {

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -2457,15 +2457,14 @@ describe("SidebarScriptBuilder", () => {
 		});
 
 		it("includes a per-source badge in the title row so users can disambiguate Linear / Jira / GitHub / Notion at a glance", () => {
-			// The badge is the minimum-viable source-surfacing — single letter
-			// (L / J / G / N), looked up from the injected SOURCE_META table
-			// (single ./SourceLabels.ts source of truth) rather than a
-			// hardcoded per-call-site object.
+			// The title badge reuses the shared context-row chip (ctxBadge →
+			// .mem-ctx-badge) so the provider glyph + brand hue read identically
+			// here and on the sidebar context rows, rather than a bespoke
+			// hover-card-only badge.
 			const js = buildSidebarScript();
-			expect(js).toContain("hc-source-badge");
 			const fnStart = js.indexOf("function renderReferenceHoverCard");
 			const body = js.slice(fnStart, fnStart + 700);
-			expect(body).toContain("SOURCE_META[h.source]");
+			expect(body).toContain("ctxBadge('reference', h.source)");
 			expect(body).not.toContain("github: 'GH'");
 			expect(js).toContain('"linear":{"label":"Linear","letter":"L"');
 			expect(js).toContain('"jira":{"label":"Jira","letter":"J"');

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -2902,15 +2902,13 @@ export function buildSidebarScript(): string {
   // opaque per-source fields rows, and an Open-in-<Source> link.
   function renderReferenceHoverCard(mapKey, h) {
     if (!h) return null;
-    // Title row: bold title plus a tiny source badge so the user can tell
-    // at a glance which provider the reference came from (L / J / G / N).
-    // Per-source colour is intentionally NOT applied — the Linear-only
-    // ancestor of this card explicitly rejected brand tints to keep rows
-    // visually uniform; the badge alone is the minimum-viable surfacing.
-    const sourceMeta = SOURCE_META[h.source];
-    const sourceLabel = sourceMeta ? sourceMeta.letter : (h.source || '').slice(0, 1).toUpperCase();
+    // Title row: bold title prefixed by the shared per-source context badge
+    // (ctxBadge) so the provider reads identically here and on the sidebar
+    // context rows (same solid letter chip, same brand hue). The Linear-only
+    // ancestor's "no brand tints" rule was reversed in favour of matching
+    // committed-memory styling — see the ctxBadge comment above.
     const titleRow = el('div', { className: 'hc-title' }, [
-      el('span', { className: 'hc-source-badge', text: sourceLabel }),
+      ctxBadge('reference', h.source),
       el('span', { text: h.title }),
     ]);
     const kids = [titleRow];

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -4377,6 +4377,27 @@ describe("SidebarWebviewProvider", () => {
 			);
 		});
 
+		it("kb:openEvidenceReference routes a Slack committed reference through (source in the allowlist)", () => {
+			// Regression: REFERENCE_SOURCE_IDS is derived from SOURCE_META keys, so
+			// `slack` (added as a built-in reference source) is in the allowlist and
+			// its committed-memory evidence rows dispatch instead of being dropped.
+			const { view, executeCommand } = makeEvidenceProvider();
+			view.webview.triggerMessage({
+				type: "kb:openEvidenceReference",
+				archivedKey: "slack:C0-123.456-ab12cd34",
+				source: "slack",
+				sourceRepoName: null,
+				sourceRemoteUrl: null,
+			});
+			expect(executeCommand).toHaveBeenCalledWith(
+				"jollimemory.previewCommittedReference",
+				"slack:C0-123.456-ab12cd34",
+				"slack",
+				null,
+				null,
+			);
+		});
+
 		it("kb:openEvidenceReference drops an unknown source without dispatching", () => {
 			const { view, executeCommand } = makeEvidenceProvider();
 			view.webview.triggerMessage({

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -29,6 +29,7 @@ import { log } from "../util/Logger.js";
 import { ConversationDetailsPanel } from "./ConversationDetailsPanel.js";
 import { SIDEBAR_EMPTY_STRINGS } from "./SidebarEmptyMessages.js";
 import { buildSidebarHtml } from "./SidebarHtmlBuilder.js";
+import { SOURCE_META } from "./SourceLabels.js";
 import type {
 	BackfillCandidate,
 	BackfillResultRow,
@@ -47,12 +48,17 @@ import type {
 import { sliceStartTime } from "./TranscriptSliceOrder.js";
 
 /**
- * Closed set of reference `SourceId`s (mirrors `SourceId` in cli Types.ts).
- * Used to validate the `source` on an inbound `kb:openEvidenceReference`
- * message — webview messages cross a trust boundary, so an unknown source is
- * dropped rather than forwarded into the archived-snapshot read path.
+ * Closed set of reference `SourceId`s. Used to validate the `source` on an
+ * inbound `kb:openEvidenceReference` message — webview messages cross a trust
+ * boundary, so an unknown source is dropped rather than forwarded into the
+ * archived-snapshot read path.
+ *
+ * Derived from {@link SOURCE_META}'s keys (the `KnownSourceId` single source of
+ * truth) rather than a hand-written literal, so a newly added built-in source
+ * (e.g. `slack`) can never silently fall out of this allowlist and have its
+ * committed-reference rows become un-openable.
  */
-const REFERENCE_SOURCE_IDS = new Set<string>(["linear", "jira", "github", "notion"]);
+const REFERENCE_SOURCE_IDS: ReadonlySet<string> = new Set<string>(Object.keys(SOURCE_META));
 
 /**
  * Built-in VS Code commands the sidebar webview is allowed to dispatch, in

--- a/vscode/src/views/SourceLabels.test.ts
+++ b/vscode/src/views/SourceLabels.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { getSourceMeta } from "./SourceLabels";
+import { getSourceMeta, SOURCE_META } from "./SourceLabels";
+
+describe("SOURCE_META", () => {
+	it("has slack metadata", () => {
+		expect(SOURCE_META.slack).toEqual({ label: "Slack", letter: "S", icon: "comment-discussion", color: "#4a154b" });
+		expect(getSourceMeta("slack").label).toBe("Slack");
+	});
+});
 
 describe("getSourceMeta", () => {
 	it("returns the table entry for a known source id", () => {

--- a/vscode/src/views/SourceLabels.ts
+++ b/vscode/src/views/SourceLabels.ts
@@ -28,17 +28,21 @@ export interface SourceMeta {
 }
 
 /**
- * Metadata for the four built-in sources. Colors match the prior per-file
+ * Metadata for the five built-in sources. Colors match the prior per-file
  * `.mem-ctx-badge--<source>` CSS rules byte-for-byte; letters match the prior
  * per-file switch statements, with one intentional normalization: the
  * hover-card badge previously showed 'GH' for GitHub while every other call
- * site showed 'G' — this table standardizes on 'G' everywhere.
+ * site showed 'G' — this table standardizes on 'G' everywhere. `slack`'s
+ * color is Slack's official aubergine brand hue; the icon mirrors the
+ * `comment-discussion` codicon used by the CLI's `slackDefinition.icon`
+ * (references/sources/definitions/slack.ts) so the two stay in visual lockstep.
  */
 export const SOURCE_META: Record<KnownSourceId, SourceMeta> = {
 	linear: { label: "Linear", letter: "L", icon: "issues", color: "#5e6ad2" },
 	jira: { label: "Jira", letter: "J", icon: "issues", color: "#0052cc" },
 	github: { label: "GitHub", letter: "G", icon: "issues", color: "#6e7681" },
 	notion: { label: "Notion", letter: "N", icon: "file-text", color: "#787774" },
+	slack: { label: "Slack", letter: "S", icon: "comment-discussion", color: "#4a154b" },
 };
 
 /** Neutral badge color for a source outside {@link SOURCE_META} (matches the prior `.mem-ctx-badge--reference` fallback hue). */

--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -1068,11 +1068,11 @@ describe("SummaryHtmlBuilder", () => {
 			expect(html).toContain('id="reference-slack-1704067200.000100-aaaa1111"');
 
 			// Order: linear < jira < github < notion < slack regardless of input order.
-			const iLinear = html.indexOf("PROJ-7 ");
-			const iJira = html.indexOf("KAN-5 ");
-			const iGithub = html.indexOf("owner/repo#42 ");
-			const iNotion = html.indexOf("abcdef12 ");
-			const iSlack = html.indexOf("1704067200.000100 ");
+			const iLinear = html.indexOf("reference-linear-");
+			const iJira = html.indexOf("reference-jira-");
+			const iGithub = html.indexOf("reference-github-");
+			const iNotion = html.indexOf("reference-notion-");
+			const iSlack = html.indexOf("reference-slack-");
 			expect(iLinear).toBeGreaterThan(-1);
 			expect(iJira).toBeGreaterThan(iLinear);
 			expect(iGithub).toBeGreaterThan(iJira);
@@ -1093,6 +1093,22 @@ describe("SummaryHtmlBuilder", () => {
 			expect(html).toContain(
 				'data-reference-url="https://example.slack.com/archives/C123456/p1704067200000100"',
 			);
+
+			// The r-title leads with the nativeId only for the issue trackers.
+			// escHtml leaves the em-dash literal (it is not an HTML metachar).
+			expect(html).toContain(">PROJ-7 — Linear ticket</a>");
+			expect(html).toContain(">owner/repo#42 — GitHub issue</a>");
+			// Notion / Slack lead with the title alone (machine-id nativeId dropped
+			// from the r-title — and the `<nativeId> (Source)` metaline is omitted too).
+			expect(html).toContain(">Notion page</a>");
+			expect(html).toContain(">Slack message</a>");
+				// The `<nativeId> (Source)` metaline is kept only for the trackers;
+				// omitted entirely for machine-id sources (Notion / Slack).
+				expect(html).toContain(">PROJ-7 (Linear)</div>");
+				expect(html).not.toContain("(Notion)");
+				expect(html).not.toContain("(Slack)");
+			expect(html).not.toContain("abcdef12 — Notion page");
+			expect(html).not.toContain("1704067200.000100 — Slack message");
 		});
 
 		it("linear issues count rolls into the section header count badge", () => {
@@ -1264,11 +1280,11 @@ describe("SummaryHtmlBuilder", () => {
 				expect(html).toContain('data-action="translateReference"');
 			});
 
-			it("renders a linkless reference (url absent — e.g. a Slack thread with no permalink/workspace configured) with an empty data-reference-url", () => {
-				// ReferenceCommitRef.url is optional (absent only for a source whose
-				// Reference.url was absent — today only Slack with no permalink) —
-				// buildReferenceRow must not blow up or emit the literal string
-				// "undefined" into the Open-in-<Source> button's data attribute.
+			it("renders a reference with no url (defensive — no shipping source emits one) with an empty data-reference-url", () => {
+				// ReferenceCommitRef.url is optional in the type but every shipping
+				// source requires it, so this is a defensive case — buildReferenceRow
+				// must not blow up or emit the literal string "undefined" into the
+				// Open-in-<Source> button's data attribute.
 				const html = buildHtml(makeSummary({ references: [makeLinear({ url: undefined })] }));
 				expect(html).toContain('data-reference-url=""');
 				expect(html).not.toContain('data-reference-url="undefined"');

--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -1006,7 +1006,7 @@ describe("SummaryHtmlBuilder", () => {
 			expect(html).not.toContain("entity-linear-linear:PROJ-7");
 		});
 
-		it("renders multi-source entities (linear → jira → github → notion) with grouped order", () => {
+		it("renders multi-source entities (linear → jira → github → notion → slack) with grouped order", () => {
 			// Multi-source replacement for the legacy linearIssues path: the
 			// renderer consumes summary.entities and groups by source so the
 			// row order is deterministic across regenerations.
@@ -1047,6 +1047,15 @@ describe("SummaryHtmlBuilder", () => {
 					referencedAt: "2026-01-15T10:00:00Z",
 					sourceToolName: "mcp__github__issue_read",
 				},
+				{
+					archivedKey: "slack:1704067200.000100-aaaa1111",
+					source: "slack",
+					nativeId: "1704067200.000100",
+					title: "Slack message",
+					url: "https://example.slack.com/archives/C123456/p1704067200000100",
+					referencedAt: "2026-01-15T10:00:00Z",
+					sourceToolName: "mcp__claude_ai_Slack__slack_read_thread",
+				},
 			];
 			const html = buildHtml(makeSummary({ references: entities }));
 
@@ -1056,16 +1065,19 @@ describe("SummaryHtmlBuilder", () => {
 			expect(html).toContain('id="reference-jira-KAN-5-aaaa1111"');
 			expect(html).toContain('id="reference-github-owner/repo#42-aaaa1111"');
 			expect(html).toContain('id="reference-notion-abcdef12-aaaa1111"');
+			expect(html).toContain('id="reference-slack-1704067200.000100-aaaa1111"');
 
-			// Order: linear < jira < github < notion regardless of input order.
+			// Order: linear < jira < github < notion < slack regardless of input order.
 			const iLinear = html.indexOf("PROJ-7 ");
 			const iJira = html.indexOf("KAN-5 ");
 			const iGithub = html.indexOf("owner/repo#42 ");
 			const iNotion = html.indexOf("abcdef12 ");
+			const iSlack = html.indexOf("1704067200.000100 ");
 			expect(iLinear).toBeGreaterThan(-1);
 			expect(iJira).toBeGreaterThan(iLinear);
 			expect(iGithub).toBeGreaterThan(iJira);
 			expect(iNotion).toBeGreaterThan(iGithub);
+			expect(iSlack).toBeGreaterThan(iNotion);
 
 			// Every row now goes through previewEntity (title click) +
 			// openEntityExternal (🌍 button) — the upstream URL flows as
@@ -1078,6 +1090,9 @@ describe("SummaryHtmlBuilder", () => {
 				'data-reference-url="https://github.com/owner/repo/issues/42"',
 			);
 			expect(html).toContain('data-reference-url="https://notion.so/abcdef12"');
+			expect(html).toContain(
+				'data-reference-url="https://example.slack.com/archives/C123456/p1704067200000100"',
+			);
 		});
 
 		it("linear issues count rolls into the section header count badge", () => {
@@ -1247,6 +1262,16 @@ describe("SummaryHtmlBuilder", () => {
 				// showTranslate === true arm: the 🌐 translate button is emitted.
 				expect(html).toContain("reference-translate-btn");
 				expect(html).toContain('data-action="translateReference"');
+			});
+
+			it("renders a linkless reference (url absent — e.g. a Slack thread with no permalink/workspace configured) with an empty data-reference-url", () => {
+				// ReferenceCommitRef.url is optional (absent only for a source whose
+				// Reference.url was absent — today only Slack with no permalink) —
+				// buildReferenceRow must not blow up or emit the literal string
+				// "undefined" into the Open-in-<Source> button's data attribute.
+				const html = buildHtml(makeSummary({ references: [makeLinear({ url: undefined })] }));
+				expect(html).toContain('data-reference-url=""');
+				expect(html).not.toContain('data-reference-url="undefined"');
 			});
 
 			it("does not render a plansCard or sourceCard wrapper id", () => {

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -1149,7 +1149,7 @@ export function buildFilesPanelShell(): string {
 </div>`;
 }
 
-const HTML_REFERENCE_SOURCE_ORDER: ReadonlyArray<SourceId> = ["linear", "jira", "github", "notion"];
+const HTML_REFERENCE_SOURCE_ORDER: ReadonlyArray<SourceId> = ["linear", "jira", "github", "notion", "slack"];
 
 /**
  * Returns references ordered by source (linear → jira → github → notion),
@@ -1231,7 +1231,7 @@ function buildReferenceRow(
       <div class="r-sub plan-meta">${escHtml(e.nativeId)} (${escHtml(sourceLabel)})</div>
     </div>
     <span class="r-actions plan-header-actions">
-      <button class="icon-btn topic-action-btn" title="Open in ${escAttr(sourceLabel)}" data-reference-key="${escAttr(e.archivedKey)}" data-reference-source="${escAttr(e.source)}" data-reference-url="${escAttr(e.url)}" data-action="openReferenceExternal">&#x1F30D;</button>
+      <button class="icon-btn topic-action-btn" title="Open in ${escAttr(sourceLabel)}" data-reference-key="${escAttr(e.archivedKey)}" data-reference-source="${escAttr(e.source)}" data-reference-url="${escAttr(e.url ?? "")}" data-action="openReferenceExternal">&#x1F30D;</button>
       ${translateBtn}<button class="icon-btn topic-action-btn plan-edit-btn" title="Edit ${escAttr(sourceLabel)} snapshot" data-reference-key="${escAttr(e.archivedKey)}" data-reference-source="${escAttr(e.source)}" data-action="loadReferenceContent">&#x270E;</button>
       <button class="icon-btn topic-action-btn plan-remove-btn" title="Remove ${escAttr(sourceLabel)} Reference" data-reference-key="${escAttr(e.archivedKey)}" data-reference-source="${escAttr(e.source)}" data-reference-native-id="${escAttr(e.nativeId)}" data-reference-title="${escAttr(e.title)}" data-action="removeReference">&#x1F5D1;</button>
     </span>

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -9,6 +9,7 @@
  * this document does not host a PR section.
  */
 
+import { labelLeadsWithNativeId, referenceDisplayTitle } from "../../../cli/src/core/references/ReferenceDisplay.js";
 import { isSummaryError } from "../../../cli/src/core/SummaryErrorMarker.js";
 import {
 	aggregateConversationTokenBreakdown,
@@ -1219,6 +1220,14 @@ function buildReferenceRow(
 	// by the dispatcher). The earlier Linear-only `data-linear-*` attributes
 	// were removed alongside the openLinearIssue* / removeLinearIssue
 	// data-actions in favour of the `*Reference` names.
+	// The `<nativeId> (Source)` sub-line only carries meaning for the issue
+	// trackers (whose key the user recognizes); for machine-id sources (Notion /
+	// Slack / phase-2) it is a meaningless blob already dropped from the title,
+	// and the source is conveyed by the left badge + "Open in <Source>" button —
+	// so the whole metaline is omitted rather than rendered as noise.
+	const subLine = labelLeadsWithNativeId(e.source)
+		? `\n      <div class="r-sub plan-meta">${escHtml(e.nativeId)} (${escHtml(sourceLabel)})</div>`
+		: "";
 	const showTranslate = referenceTranslateSet?.has(e.archivedKey) ?? false;
 	const translateBtn = showTranslate
 		? `<button class="topic-action-btn reference-translate-btn" title="Translate to English" data-reference-key="${escAttr(e.archivedKey)}" data-reference-source="${escAttr(e.source)}" data-action="translateReference">&#x1F310;</button>`
@@ -1227,8 +1236,7 @@ function buildReferenceRow(
   <div class="row plan-item" id="reference-${escAttr(e.source)}-${escAttr(domKey)}">
     <span class="kb-tag t-ref">${escHtml(sourceLetter)}</span>
     <div class="r-main">
-      <a class="r-title plan-title plan-title-link" href="#" title="Click to preview" data-action="previewReference" data-reference-key="${escAttr(e.archivedKey)}" data-reference-source="${escAttr(e.source)}" data-reference-native-id="${escAttr(e.nativeId)}" data-reference-title="${escAttr(e.title)}">${escHtml(e.nativeId)} &mdash; ${escHtml(e.title)}</a>
-      <div class="r-sub plan-meta">${escHtml(e.nativeId)} (${escHtml(sourceLabel)})</div>
+      <a class="r-title plan-title plan-title-link" href="#" title="Click to preview" data-action="previewReference" data-reference-key="${escAttr(e.archivedKey)}" data-reference-source="${escAttr(e.source)}" data-reference-native-id="${escAttr(e.nativeId)}" data-reference-title="${escAttr(e.title)}">${escHtml(referenceDisplayTitle(e))}</a>${subLine}
     </div>
     <span class="r-actions plan-header-actions">
       <button class="icon-btn topic-action-btn" title="Open in ${escAttr(sourceLabel)}" data-reference-key="${escAttr(e.archivedKey)}" data-reference-source="${escAttr(e.source)}" data-reference-url="${escAttr(e.url ?? "")}" data-action="openReferenceExternal">&#x1F30D;</button>

--- a/vscode/src/views/SummaryMarkdownBuilder.test.ts
+++ b/vscode/src/views/SummaryMarkdownBuilder.test.ts
@@ -613,8 +613,9 @@ describe("SummaryMarkdownBuilder", () => {
 
 			it("renders summary.entities (v5+) across multiple sources in deterministic order", () => {
 				// Order in input: jira, notion, linear, github — must come out as
-				// linear → jira → github → notion per REFERENCE_SOURCE_ORDER. Each
-				// bullet uses `nativeId — title` (URL = upstream).
+				// linear → jira → github → notion per REFERENCE_SOURCE_ORDER. Tracker
+				// bullets use `nativeId — title`; Notion uses the title alone (URL =
+				// upstream).
 				const summary = makeSummary({
 					references: [
 						{
@@ -662,7 +663,9 @@ describe("SummaryMarkdownBuilder", () => {
 				const idxLinear = md.indexOf("PROJ-1 — Linear ticket");
 				const idxJira = md.indexOf("KAN-5 — Jira ticket");
 				const idxGithub = md.indexOf("owner/repo#42 — GitHub issue");
-				const idxNotion = md.indexOf("abcdef12 — Notion page");
+				// Notion leads with the title alone — its 32-hex nativeId is dropped
+				// (only Linear/Jira/GitHub keep the recognizable key prefix).
+				const idxNotion = md.indexOf("Notion page");
 				expect(idxLinear).toBeGreaterThan(-1);
 				expect(idxJira).toBeGreaterThan(idxLinear);
 				expect(idxGithub).toBeGreaterThan(idxJira);


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Quick recap (2)

### Commit 1 of 2: Add Slack thread references to knowledge system (`f5a0981`)

The developer added end-to-end Slack thread capture to the reference system, enabling users to turn Slack discussions into structured references that integrate seamlessly with existing Linear, Jira, GitHub, and Notion sources. When a user pastes a Slack thread permalink into a transcript and the AI agent calls the Slack thread reader tool, the system correlates the two by channel and timestamp, extracts the thread body, and produces a reference with the URL, title, and full thread text. The reference is then injected into Working Memory and rendered in the committed-memory panel alongside other sources.

The implementation handles three URL sources in priority order: the pasted permalink (primary, zero-config), a configured workspace URL (fallback), or no URL at all (linkless capture). This design makes the feature work immediately in the common case — when a user pastes a permalink — while still capturing thread content even when no link is available. Users can configure their Slack workspace URL once via the CLI, and the system uses it to reconstruct thread permalinks automatically. The VS Code panel shows a configuration hint for linkless references, guiding users to set their workspace URL if they want clickable links in future captures.

All parsing is defensive: the thread body blob is human-readable text with no stable schema, so the normalizer gracefully voids on unparseable input rather than throwing. The feature integrates cleanly into the existing reference pipeline (SourceDefinition, SourceEngine, envelope) and maintains byte-identical rendering of the four existing sources' golden tests. A critical bug was fixed where Slack references in committed memory would render visually but fail to open when clicked — the sidebar's trust-boundary validation now derives its allowlist from the single source of truth, ensuring future reference sources are automatically included without manual synchronization.

### Commit 2 of 2: Unify reference labels and require Slack URLs (`f503459`)

The developer unified how reference labels are displayed across the sidebar, committed memory, and PR markdown by introducing a centralized `referenceDisplayTitle()` helper function. Issue trackers like Linear, Jira, and GitHub now consistently show their user-recognizable keys alongside titles, while non-tracker sources like Slack and Notion display titles only. This eliminated duplication across three separate display surfaces and ensures consistency across all future sources.

Slack thread titles are now truncated to 50 characters at storage time, keeping reference labels compact across all surfaces while preserving the full text in underlying fields. The truncation happens at the normalization layer, so all three display surfaces automatically show the same shortened title without any per-surface logic.

Slack references without a resolvable URL are no longer stored at all — the requirement is enforced at the source definition level, so both extraction paths respect it automatically. The detail panel for memories was also cleaned up: non-tracker references no longer display a redundant machine-ID metaline, keeping the UI focused on user-meaningful information. Tracker sources retain their metaline because their keys are searchable and recognizable to users.

## Topics (10)
<details>
<summary><strong>01 · [f5a0981] Slack thread reference extraction and rendering with golden parity tests</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team needed to capture Slack discussion threads that an AI agent reads via the Slack MCP server during a session, turning each thread into a structured reference that can be injected into Working Memory alongside existing Linear, Jira, GitHub, and Notion references.

**💡 Decisions Behind the Code**

- **Permalink as the primary capture anchor**: The user-pasted Slack permalink in the transcript carries the workspace, channel, and timestamp — everything needed to build a working link. This makes the permalink the authoritative source of identity and URL, eliminating the need for workspace configuration in the common case. Configuration becomes a fallback only when no permalink was pasted, reducing friction for users and making the feature work out of the box.
- **Defensive blob parsing with graceful degradation**: The MCP result is human-readable text defined by the wrapper's presentation layer, not a stable API schema. Rather than fail on format drift, `SlackNormalize` returns null when it cannot parse the blob, allowing the reference to be voided cleanly. This trades strict validation for robustness — a thread with an unparseable body is dropped, but a thread with a parseable body but missing URL is still captured (linkless), preserving as much context as possible.
- **Linkless capture as a first-class outcome**: Unlike the four existing sources (Linear, Jira, GitHub, Notion), which all require a URL, Slack allows references to be captured without a link. This required making `url` optional in the engine and storage layer. The trade-off is that users see a configuration hint in the UI when a link is missing, but the thread content is never lost — the reference is still available for the LLM to read in the SUMMARIZE prompt.
- **Scan permalinks once upfront rather than on-demand per tool result**: Visiting every user text line once during parsing is simpler and more efficient than searching backward from each Slack tool result. This avoids redundant scans when multiple Slack threads appear in a single transcript and keeps the permalink map a simple lookup by channel:timestamp key.
- **Preserve tool_use input in PendingEntry only for Slack**: Slack's normalize function needs both the MCP payload AND out-of-payload context (channel_id, message_ts) that no other source requires. Rather than bloat the normalize signature for all sources, the tool input is retained only when `def.id === "slack"`, keeping every other source's normalize as a pure identity function.

**✅ What Was Implemented**

- Created `SlackPermalink.ts` to parse Slack thread permalinks from user-pasted text in transcripts, extracting workspace subdomain, channel ID, and message timestamp. The scanner harvests permalinks only from `role:user` message blocks to prevent duplicate capture, and builds a map keyed by `(channel, ts)` for correlation with tool results.
- Created `SlackNormalize.ts` to defensively parse the MCP result's human-readable text blob into a canonical object with `parentTs`, `title`, `text`, and `replyCount` fields. Returns null on unparseable input rather than throwing, ensuring robustness against format drift. Fixed a regression where empty-bodied parent messages would borrow text from replies as their title by confining extraction to the parent segment only.
- Added `slackDefinition` as a built-in `SourceDefinition` with declarative field mappings for thread metadata (channel ID, parent timestamp, title, message text, reply count, optional URL). The definition supports matching against `mcp__claude_ai_Slack__slack_read_thread` tool invocations and produces a composite native ID combining channel and timestamp.
- Modified `SourceEngine.ts` to support optional `url` fields, allowing Slack references to be captured linkless when no permalink was pasted and no workspace URL is configured. Updated `Reference.url` to be optional in the type system and markdown round-trip storage.
- Extended `ClaudeEnvelopeParser.ts` to retain the `slack_read_thread` tool_use input (`channel_id`, `message_ts`) as the correlation key, scan user permalinks before processing tool results, and merge the permalink-derived URL with the normalized body. Added fallback URL reconstruction from `config.slack.workspaceUrl` when no permalink was pasted.
- Added Slack to the source metadata table in the VS Code panel with official branding (aubergine color, "S" badge, comment-discussion icon). Implemented a non-interactive configuration hint for linkless Slack references, displaying a gear icon with a tooltip prompting users to set the workspace URL.
- Added Slack to the committed-memory panel's reference rendering order in `SummaryHtmlBuilder.ts`, ensuring Slack references now appear alongside other reference types in the display.
- Added comprehensive test coverage including golden parity tests verifying byte-identical rendering of the `<slack-threads>` XML block, happy-path extraction with URL from permalink, linkless capture scenarios, and validation of the nativeId format.

**📁 FILES**
- `cli/src/core/references/SlackPermalink.ts`
- `cli/src/core/references/sources/SlackNormalize.ts`
- `cli/src/core/references/sources/definitions/slack.ts`
- `cli/src/core/references/ClaudeEnvelopeParser.ts`
- `cli/src/core/references/SourceEngine.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [f5a0981] Slack workspace URL configuration with validation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The reference extractor needs a fallback source for Slack thread permalinks when users have not pasted one into the transcript. The workspace URL must be stored in configuration and validated to ensure it points to a legitimate Slack workspace.

**💡 Decisions Behind the Code**

- **Dotted pseudo-key approach for nested config**: The dotted pseudo-key (`slack.workspaceUrl`) exposes nested config fields through the flat `--set` interface without requiring users to understand JSON structure. Rather than shallow-merge at the `saveConfig` level (which would risk clobbering sibling `slack` fields), the command reads the current config and spreads the existing `slack` object before applying the update — this preserves any other slack-related settings that may exist.
- **URL validation and normalization at coercion time**: Validation mirrors the pattern used in `JolliApiUtils` for origin allowlists: suffix-boundary host checking and HTTPS enforcement happen at coercion time, before the value ever reaches persistence. Normalizing the URL to its origin at storage time (rather than at reconstruction time) fixes the problem once at the source and prevents the same issue from recurring if the URL is used elsewhere.

**✅ What Was Implemented**

- Added `slack.workspaceUrl` as a settable configuration key in `ConfigureCommand.ts`. The key is treated as a dotted pseudo-key that maps to a nested `slack.workspaceUrl` field in the config object, with special handling to merge updates into the existing `slack` object rather than clobbering sibling fields.
- Implemented validation in the `coerceConfigValue` function to enforce that the URL is HTTPS-only and uses a `slack.com` host or subdomain via the `isAllowedSlackHost` helper. Invalid URLs are rejected with a clear error message before persistence.
- Modified the storage layer to persist the normalized `origin` (scheme + host, no trailing slash or path) instead of the raw input. This ensures permalink reconstruction always produces valid URLs without double slashes.
- Added comprehensive test coverage including acceptance of valid workspace URLs, merging with existing slack config, rejection of non-slack.com hosts, rejection of non-HTTPS URLs, domain-spoofing attack scenarios, and the remove configuration option.

**📁 FILES**
- `cli/src/commands/ConfigureCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [f5a0981] Optional URL support in reference system</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Some data sources like Slack can produce valid references without a URL (e.g., when a message has no permalink and no workspace is configured). The system previously required a URL for all references, forcing sources to either fabricate URLs or discard valid data.

**💡 Decisions Behind the Code**

- **Omit the `url:` frontmatter line entirely rather than writing empty strings**: Omitting the line entirely (rather than writing `url: ""` or `url: undefined`) ensures that the missing-key parsing path naturally produces `undefined` on deserialization, making the round-trip symmetric and avoiding special-case handling. This approach treats the absence of a URL as a first-class state rather than a sentinel value, which is clearer for sources like Slack where a missing permalink is legitimate and expected.
- **Empty string over undefined for missing URLs in VS Code**: Keeping `ReferenceInfo.url` as a required string (never undefined) simplifies downstream code that renders HTML attributes and checks for falsy values. Using empty string as the sentinel for "no URL" is more robust than allowing undefined to propagate through the UI layer, where it could accidentally render as the literal string "undefined" in data attributes.

**✅ What Was Implemented**

- Modified the `Reference` interface in `Types.ts` to make the `url` field optional (`url?: string`) with a comment explaining when it may be absent.
- Updated `extractRef()` in `SourceEngine.ts` to permit undefined URL values when the source definition marks the URL field as optional. The function now only returns null if the URL is required but missing; if optional and missing, the reference is created without a URL property.
- Updated `renderBlock()` in `SourceEngine.ts` to omit the `<url>` XML element entirely when a reference has no URL, rather than rendering an empty or invalid element.
- Made `url` optional in `ReferenceEntry` and `ReferenceCommitRef` type definitions in `Types.ts` to support markdown round-trip storage.
- Updated `renderMarkdown` in `ReferenceStore.ts` to omit the `url:` frontmatter line entirely when URL is absent or empty, ensuring the markdown round-trips cleanly without writing `undefined` or empty strings.
- Updated `parseMarkdown` in `ReferenceStore.ts` to treat a missing `url` key as `undefined` rather than failing validation.
- Modified `SummaryMarkdownBuilder.ts` to render reference links conditionally: when a URL exists, render as a markdown link; when absent, render as plain text without a link wrapper.
- Updated `ReferenceService.ts` in the VS Code extension to default `url` to an empty string when a Slack reference entry has no URL, ensuring the `ReferenceInfo` contract remains a required string end-to-end and preventing undefined values from leaking into HTML attributes.

**📁 FILES**
- `cli/src/Types.ts`
- `cli/src/core/references/SourceEngine.ts`
- `cli/src/core/ReferenceStore.ts`
- `cli/src/core/SummaryMarkdownBuilder.ts`
- `vscode/src/core/ReferenceService.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [f5a0981] Slack source definition and registry integration</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The reference system needed to support Slack threads as a built-in source alongside Linear, Jira, GitHub, and Notion. This enables capturing and linking to Slack thread conversations within the knowledge management workflow.

**💡 Decisions Behind the Code**

- **Slack source definition operates on post-normalized canonical object**: The definition operates on a post-normalized canonical object (channel ID, parent timestamp, title, text, reply count, optional URL) rather than the raw MCP blob. This abstraction boundary isolates the reference system from MCP protocol details and allows the normalization layer to handle workspace URL configuration and permalink generation separately.
- **Composite native ID format combining channel and timestamp**: The composite native ID format (`channelId-parentTs`) ensures uniqueness within a workspace and aligns with Slack's thread addressing model, where a thread is identified by its parent message timestamp within a channel.

**✅ What Was Implemented**

- Added `slackDefinition` source definition in `cli/src/core/references/sources/definitions/slack.ts`. The definition extracts thread metadata (channel ID, parent timestamp, title, message text, reply count, and optional URL) and produces a normalized reference with a composite native ID combining channel and timestamp. The definition supports matching against MCP tool invocations (`mcp__claude_ai_Slack__slack_read_thread`) and includes field extraction for entity type, reply count, and channel identifier.
- Updated `cli/src/Types.ts` to add `"slack"` to the `KnownSourceId` union type, expanding the set of recognized built-in sources from four to five.
- Registered the new definition in `cli/src/core/references/sources/definitions/index.ts` by importing `slackDefinition` and adding it to the `BUILTIN_DEFINITIONS` export array in stable order.
- Added comprehensive test coverage in `cli/src/core/references/sources/definitions/slack.test.ts` verifying registry lookup, tool matching, and reference extraction with realistic thread data.

**📁 FILES**
- `cli/src/core/references/sources/definitions/slack.ts`
- `cli/src/Types.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [f5a0981] Fix Slack references becoming un-clickable in sidebar due to missing allowlist entry</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When Slack thread references were added as a built-in reference source, the sidebar's trust-boundary validation for `kb:openEvidenceReference` messages was not updated. Slack references in committed memory would render visually but fail to open when clicked, silently dropping the command.

**💡 Decisions Behind the Code**

Deriving the allowlist from the single source of truth (`SOURCE_META`, which mirrors `KnownSourceId`) rather than maintaining a separate hardcoded set eliminates the class of bugs where new sources silently fall out of sync. This is a depth-level fix: it generalizes the underlying mechanism rather than patching the symptom. The CLI side already uses registry-driven ordering (safe by design); the vscode side now matches that pattern.

**✅ What Was Implemented**

- Modified `SidebarWebviewProvider.ts` to derive `REFERENCE_SOURCE_IDS` from `SOURCE_META` keys instead of a hardcoded literal set. This ensures any newly added built-in reference source (like `slack`) is automatically included in the allowlist without manual synchronization.
- Added regression test confirming Slack references now dispatch `previewCommittedReference` correctly.

**📁 FILES**
- `vscode/src/views/SidebarWebviewProvider.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · [f5a0981] Test expectations updated for Slack registry and URL omission</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Two test suites had stale expectations after earlier changes: one expected empty URL tags to be rendered, and another expected a Slack prefix to be absent from the tool list.

**💡 Decisions Behind the Code**

Both changes were identified as stale test expectations rather than real bugs in the underlying code. The test fixes confirm that earlier feature work (registry addition and empty-URL omission) was implemented correctly, and the tests now accurately reflect the intended behavior.

**✅ What Was Implemented**

- Updated `Regenerator.test.ts` to expect the `<url>` line to be omitted entirely when a reference has no URL, rather than rendering an empty `<url></url>` tag. The test comment was clarified to document the new omit-empty behavior.
- Updated `bindings/claude/index.test.ts` to include the Slack prefix in the expected tool prefixes list. The comment was updated to reflect that the registry now includes five vendors (linear, jira, github, notion, slack) instead of four.

**📁 FILES**
- `cli/src/core/Regenerator.test.ts`
- `cli/src/core/references/bindings/claude/index.test.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · [f503459] Unify reference label display across all surfaces</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Reference labels were inconsistently displayed across the sidebar, committed memory HTML, and PR markdown. Some sources showed machine-generated IDs that meant nothing to users, while others showed recognizable issue keys. The logic for deciding what to display was duplicated in three separate files.

**💡 Decisions Behind the Code**

- **Free function over class method**: The decision to centralize this logic in a free function rather than a class method was driven by the need to work across both the CLI and VS Code packages, which exchange plain serialized `Reference` objects across trust boundaries. A class method would break serialization; a structural-type free function keyed on the reference's fields is the idiomatic equivalent and works seamlessly in both contexts.
- **Title-only as default**: The default behavior is title-only (new sources need no changes here), with only the three recognizable issue trackers opting in to the nativeId prefix. This makes the system forward-compatible for phase-2 user-defined sources.

**✅ What Was Implemented**

- Created a new `ReferenceDisplay.ts` module with `referenceDisplayTitle()` helper that centralizes both the decision (which sources lead with nativeId) and the composition. The function reads the reference's source and returns the appropriate display string: issue trackers (Linear, Jira, GitHub) lead with their recognizable keys; all other sources (Slack, Notion, and future sources) show title-only.
- Updated three display surfaces to call the unified helper: `SummaryMarkdownBuilder.ts` (PR and clipboard markdown), `PlansTreeProvider.ts` (sidebar labels and tooltips), and `SummaryHtmlBuilder.ts` (committed memory HTML). Removed the per-surface `if/else` branches and string concatenation logic that had been duplicated.
- Added comprehensive test coverage for the new predicate and composition function, plus updated existing tests across all three surfaces to verify the new behavior.

**📁 FILES**
- `cli/src/core/references/ReferenceDisplay.ts`
- `cli/src/core/SummaryMarkdownBuilder.ts`
- `vscode/src/providers/PlansTreeProvider.ts`
- `vscode/src/views/SummaryHtmlBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · [f503459] Truncate Slack thread titles to 50 characters in stored references</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Slack thread titles are free-form message text with no length bound, causing long titles to bloat reference labels across every display surface. The full text was preserved nowhere, making truncation lossy.

**💡 Decisions Behind the Code**

Truncation happens at the normalization layer (a single point in the pipeline) rather than at each display site. This ensures all three surfaces (markdown, HTML, sidebar) automatically show the same shortened title without duplication, and future sources inherit the same behavior if they adopt the same pattern. The 50-character limit was chosen as a practical balance: long enough to capture meaningful context in most thread titles, short enough to fit comfortably in a sidebar row or PR bullet without wrapping.

**✅ What Was Implemented**

- Modified `SlackNormalize.ts` to truncate titles longer than 50 characters at normalization time, appending an ellipsis. Titles at or under 50 characters are left untouched. The full original text is preserved in the `text` and `description` fields, so no information is lost — only the stored label is shortened.
- Added test cases covering both the truncation boundary and the no-op case.

**📁 FILES**
- `cli/src/core/references/sources/SlackNormalize.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · [f503459] Require Slack URL and void linkless thread references</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Slack references could be stored without a resolvable URL when neither a permalink was pasted nor a workspace URL was configured. These linkless references had no way to jump to the source, making them useless in the sidebar and committed memory.

**💡 Decisions Behind the Code**

The enforcement happens at the declarative source definition level (a single `require` constraint) rather than scattered across parser or storage code. This keeps the decision in one place and automatically applies to both Claude and Codex extraction paths without duplication. The parser remains a lower layer that surfaces the canonical object; the voiding happens only at `extractRef`, preserving the separation of concerns and making the true source of truth clear.

**✅ What Was Implemented**

- Removed the `optional: true` flag from the `url` field in the Slack source definition, making URL required. Threads with no resolvable URL are now voided by `SourceEngine.extractRef()` and never stored.
- Deleted the gear-icon hint and associated CSS that had been prepared for linkless Slack references (in `NextMemoryScriptBuilder.ts` and `NextMemoryCssBuilder.ts`), since the scenario no longer occurs.
- Updated parser and engine tests to reflect the new behavior: the parser still emits urlless canonical objects (keeping the parser layer pure), but `extractRef` voids them downstream before storage.

**📁 FILES**
- `cli/src/core/references/sources/definitions/slack.ts`
- `vscode/src/views/NextMemoryScriptBuilder.ts`
- `vscode/src/views/NextMemoryCssBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · [f503459] Remove machine-ID metaline from non-tracker reference rows in detail panel</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The detail panel for each memory was displaying a redundant machine-ID line below reference titles for non-tracker sources like Slack and Notion. These machine IDs are meaningless to users and were already dropped from the title itself; the source is already conveyed by the left badge and action buttons.

**💡 Decisions Behind the Code**

The metaline was made conditional on `labelLeadsWithNativeId()` rather than always rendered because tracker keys carry semantic meaning users recognize and search for, while machine IDs are noise. Omitting the entire line for non-trackers is cleaner than rendering an empty or source-only label, since the source is already visible in the UI chrome (badge + button). This keeps the detail panel focused on user-meaningful information.

**✅ What Was Implemented**

- Modified `SummaryHtmlBuilder.ts` to conditionally render the metaline only for tracker sources (Linear, Jira, GitHub) that have user-recognizable keys. Non-tracker sources (Notion, Slack) now omit the entire metaline, keeping only the title and action buttons for a cleaner UI.
- Updated `SummaryHtmlBuilder.test.ts` to verify the metaline is present for trackers and absent for non-trackers, and adjusted test anchors to use stable reference IDs instead of brittle nativeId strings.

**📁 FILES**
- `vscode/src/views/SummaryHtmlBuilder.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 9, 2026 at 5:12 PM · via Anthropic*
<!-- jollimemory-summary-end -->