### PR TITLE
Refactor context association into reusable consumeWorkspaceContext helper

### DIFF
--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -454,7 +454,15 @@ import { buildKnowledgeGraph } from "../graph/GraphBuilder.js";
 import { recordPendingIngest, wakePendingIngest } from "../sync/PendingIngest.js";
 import { recordPendingWorker, wakePendingWorkers } from "../sync/PendingWorkers.js";
 import { acquireVaultWriteLock, withVaultWriteLock } from "../sync/VaultWriteLock.js";
-import type { CommitGitOperation, IngestOperation } from "../Types.js";
+import type {
+	CommitGitOperation,
+	CommitInfo,
+	CommitSummary,
+	ExcludedContextItem,
+	IngestOperation,
+	PlanReference,
+	ReferenceCommitRef,
+} from "../Types.js";
 import { __test__, buildWorkerStartupBanner, launchWorker, runWorker } from "./QueueWorker.js";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -3359,6 +3367,330 @@ describe("QueueWorker", () => {
 			} finally {
 				rmSync(cwd, { recursive: true, force: true });
 			}
+		});
+	});
+
+	// ─── amend Context consumption: new-wins ref union, audit filter, plan soft-exclude, fresh-leaf refs ───
+	describe("amend workspace-Context consumption", () => {
+		const bySlug = (r: { slug: string }) => r.slug;
+
+		describe("mergeRefsNewWins", () => {
+			it("returns [] for empty / undefined inputs", () => {
+				expect(__test__.mergeRefsNewWins(undefined, undefined, bySlug)).toEqual([]);
+				expect(__test__.mergeRefsNewWins([], [], bySlug)).toEqual([]);
+			});
+
+			it("keeps old refs when there are no new refs", () => {
+				const old = [{ slug: "a" }, { slug: "b" }];
+				expect(__test__.mergeRefsNewWins(old, undefined, bySlug)).toEqual(old);
+			});
+
+			it("unions non-colliding new refs after the old ones", () => {
+				const merged = __test__.mergeRefsNewWins([{ slug: "a" }], [{ slug: "b" }], bySlug);
+				expect(merged.map(bySlug)).toEqual(["a", "b"]);
+			});
+
+			it("new ref wins on base-key collision (drops the stale old snapshot)", () => {
+				const merged = __test__.mergeRefsNewWins(
+					[{ slug: "a", tag: "old" }],
+					[{ slug: "a", tag: "new" }],
+					bySlug,
+				);
+				expect(merged).toEqual([{ slug: "a", tag: "new" }]);
+			});
+		});
+
+		describe("buildHoistedAmendRoot ref merge + audit", () => {
+			const newInfo: CommitInfo = {
+				hash: "new67890abcdef12",
+				message: "Amended commit",
+				author: "Jane",
+				date: "2026-04-02T10:00:00.000Z",
+			};
+			const hoisted = {
+				topics: [{ title: "T", trigger: "x", response: "y", decisions: "z" }],
+				transcripts: [] as string[],
+			};
+			const fullDiffStats = { filesChanged: 1, insertions: 2, deletions: 1 };
+			const refABCold: ReferenceCommitRef = {
+				archivedKey: "linear:ABC-old12345",
+				source: "linear",
+				nativeId: "ABC",
+				title: "Issue ABC",
+				url: "https://linear.app/x/ABC",
+				referencedAt: "2026-04-01T00:00:00Z",
+				sourceToolName: "mcp__linear__get_issue",
+			};
+
+			function makeOld(over: Partial<CommitSummary> = {}): CommitSummary {
+				return {
+					version: 5,
+					commitHash: "old12345",
+					commitMessage: "Old",
+					commitAuthor: "Jane",
+					commitDate: "2026-04-01T10:00:00.000Z",
+					branch: "feature/test",
+					generatedAt: "2026-04-01T10:00:00.000Z",
+					topics: [{ title: "Old", trigger: "t", response: "r", decisions: "d" }],
+					transcripts: [],
+					...over,
+				} as CommitSummary;
+			}
+
+			it("hoists old references into the merged root (references truthy arm)", () => {
+				const root = __test__.buildHoistedAmendRoot(
+					makeOld({ references: [refABCold] }),
+					newInfo,
+					hoisted,
+					{},
+					fullDiffStats,
+				);
+				expect(root.references?.map((r) => `${r.source}:${r.nativeId}`)).toEqual(["linear:ABC"]);
+			});
+
+			it("unions old + new references with new winning on collision", () => {
+				const refABCnew: ReferenceCommitRef = { ...refABCold, archivedKey: "linear:ABC-new67890" };
+				const refXYZnew: ReferenceCommitRef = {
+					...refABCold,
+					archivedKey: "linear:XYZ-new67890",
+					nativeId: "XYZ",
+				};
+				const root = __test__.buildHoistedAmendRoot(
+					makeOld({ references: [refABCold] }),
+					newInfo,
+					hoisted,
+					{},
+					fullDiffStats,
+					undefined,
+					{ references: [refABCnew, refXYZnew] },
+				);
+				expect(root.references?.map((r) => `${r.source}:${r.nativeId}`)).toEqual(["linear:ABC", "linear:XYZ"]);
+				// new wins: the ABC ref carries the NEW archivedKey, not the old snapshot.
+				expect(root.references?.find((r) => r.nativeId === "ABC")?.archivedKey).toBe("linear:ABC-new67890");
+			});
+
+			it("merges new plans with new winning on slug base-key collision", () => {
+				// Both slugs share base "foo" after the `-<8 hex>` suffix strip → collision.
+				const planOld: PlanReference = { slug: "foo-0abc1234", title: "Foo", addedAt: "a", updatedAt: "a" };
+				const planNew: PlanReference = { slug: "foo-9def5678", title: "Foo", addedAt: "a", updatedAt: "b" };
+				const root = __test__.buildHoistedAmendRoot(
+					makeOld({ plans: [planOld] }),
+					newInfo,
+					hoisted,
+					{},
+					fullDiffStats,
+					undefined,
+					{ plans: [planNew] },
+				);
+				expect(root.plans?.map((p) => p.slug)).toEqual(["foo-9def5678"]);
+			});
+
+			it("writes the excludedContext audit when the soft-excluded item is NOT attached", () => {
+				const excluded: ExcludedContextItem[] = [
+					{ kind: "note", key: "n-unrelated", title: "N", reason: "unrelated", tier: "low" },
+				];
+				const root = __test__.buildHoistedAmendRoot(
+					makeOld(),
+					newInfo,
+					hoisted,
+					{},
+					fullDiffStats,
+					undefined,
+					undefined,
+					excluded,
+				);
+				expect(root.excludedContext).toEqual(excluded);
+			});
+
+			it("drops a soft-excluded item from the audit when it is attached via a hoisted ref", () => {
+				// Re-referenced linear:ABC: committed earlier (hoisted), then soft-excluded now.
+				// It must appear in references (attached) but NOT also in excludedContext.
+				const excluded: ExcludedContextItem[] = [
+					{ kind: "reference", key: "linear:ABC", title: "Issue ABC", reason: "unrelated", tier: "low" },
+				];
+				const root = __test__.buildHoistedAmendRoot(
+					makeOld({ references: [refABCold] }),
+					newInfo,
+					hoisted,
+					{},
+					fullDiffStats,
+					undefined,
+					undefined,
+					excluded,
+				);
+				expect(root.references?.map((r) => `${r.source}:${r.nativeId}`)).toEqual(["linear:ABC"]);
+				expect(root.excludedContext).toBeUndefined();
+			});
+		});
+
+		it("consumeWorkspaceContext skips an AI soft-excluded plan from association", async () => {
+			vi.mocked(loadPlansRegistry).mockResolvedValue({
+				version: 1,
+				plans: {
+					foo: {
+						slug: "foo",
+						title: "Foo",
+						sourcePath: "/x/foo.md",
+						addedAt: "2026-04-01T00:00:00Z",
+						updatedAt: "2026-04-01T00:00:00Z",
+						commitHash: null,
+					},
+				},
+			} as Awaited<ReturnType<typeof loadPlansRegistry>>);
+
+			const result = await __test__.consumeWorkspaceContext({
+				cwd: "/test/cwd",
+				branch: "feature/test",
+				commitHash: "new67890abcdef12",
+				exclusions: { plans: new Set(), notes: new Set(), references: new Set() },
+				excludedContext: [{ kind: "plan", key: "foo", title: "Foo", reason: "unrelated", tier: "low" }],
+			});
+
+			// foo was detected (commitHash null) but soft-excluded → dropped before associate.
+			expect(result.planAssociation.refs).toEqual([]);
+		});
+
+		it("amend fresh-leaf attaches an active reference to the summary (references spread)", async () => {
+			const op = makeCommitOp({
+				type: "amend",
+				commitHash: "abc12345def67890",
+				branch: "feature/x",
+				sourceHashes: ["0123456789abcdef0123456789abcdef01234567"],
+			});
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/entry.json" }])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+			setupPipelineMocks("abc12345def67890");
+			vi.mocked(getCurrentBranch).mockResolvedValue("feature/x");
+			// Non-trivial delta + no old summary → fresh-leaf path.
+			vi.mocked(getDiffStats).mockResolvedValue({ filesChanged: 1, insertions: 60, deletions: 1 });
+			vi.mocked(detectUncommittedReferenceIds).mockResolvedValue([
+				{ mapKey: "linear:PROJ-1", source: "linear", sourcePath: "/ref.md" },
+			]);
+			vi.mocked(loadPlansRegistry).mockResolvedValue({
+				version: 1,
+				plans: {},
+				references: {
+					"linear:PROJ-1": {
+						source: "linear",
+						nativeId: "PROJ-1",
+						title: "Proj one",
+						url: "https://linear.app/x/PROJ-1",
+						sourcePath: "/ref.md",
+						addedAt: "2026-04-01T00:00:00Z",
+						updatedAt: "2026-04-01T00:00:00Z",
+						sourceToolName: "mcp__linear__get_issue",
+					},
+				},
+			});
+			const { readReferenceMarkdown } = await import("../core/references/ReferenceStore.js");
+			vi.mocked(readReferenceMarkdown).mockResolvedValue({
+				mapKey: "linear:PROJ-1",
+				source: "linear",
+				nativeId: "PROJ-1",
+				title: "Proj one",
+				url: "https://linear.app/x/PROJ-1",
+				toolName: "mcp__linear__get_issue",
+				referencedAt: "2026-05-14T06:06:01.123Z",
+			});
+			const { readFile } = await import("node:fs/promises");
+			(readFile as unknown as { mockResolvedValue: (v: string) => void }).mockResolvedValue("file content");
+
+			await runWorker("/test/cwd");
+
+			expect(storeSummary).toHaveBeenCalledTimes(1);
+			const saved = vi.mocked(storeSummary).mock.calls[0][0];
+			expect(saved.references?.[0].archivedKey).toBe("linear:PROJ-1-abc12345");
+		});
+
+		it("clears the AI selection layer once, up front, on an amend", async () => {
+			// A `git commit --amend` moves HEAD → the panel's cached fingerprint is
+			// stale, so every amend path invalidates it (mirrors the normal pipeline's
+			// pre-LLM clear). Verified here via the fresh-leaf path.
+			const op = makeCommitOp({
+				type: "amend",
+				commitHash: "abc12345def67890",
+				branch: "feature/x",
+				sourceHashes: ["0123456789abcdef0123456789abcdef01234567"],
+			});
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/entry.json" }])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+			setupPipelineMocks("abc12345def67890");
+			vi.mocked(getCurrentBranch).mockResolvedValue("feature/x");
+			vi.mocked(getDiffStats).mockResolvedValue({ filesChanged: 1, insertions: 60, deletions: 1 });
+			vi.mocked(clearAiSelection).mockClear();
+
+			await runWorker("/test/cwd");
+
+			expect(clearAiSelection).toHaveBeenCalledWith("/test/cwd");
+		});
+
+		it("amend pre-LLM short-circuit inherits a v5 oldSummary's transcripts into the hoisted root", async () => {
+			// Exercises the whole short-circuit consume+hoist path end-to-end with a real
+			// oldSummary, and covers the `oldSummary.transcripts !== undefined` (v5) arm.
+			const { getSummary } = await import("../core/SummaryStore.js");
+			vi.mocked(getSummary).mockResolvedValue({
+				version: 5,
+				commitHash: "old12345",
+				commitMessage: "Old",
+				commitAuthor: "Jane",
+				commitDate: "2026-04-01T10:00:00.000Z",
+				branch: "feature/x",
+				generatedAt: "2026-04-01T10:00:00.000Z",
+				topics: [{ title: "Old", trigger: "t", response: "r", decisions: "d" }],
+				transcripts: ["t-existing"],
+			} as Awaited<ReturnType<typeof getSummary>>);
+			const op = makeCommitOp({
+				type: "amend",
+				commitHash: "abc12345def67890",
+				branch: "feature/x",
+				sourceHashes: ["0123456789abcdef0123456789abcdef01234567"],
+			});
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/entry.json" }])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+			// setupPipelineMocks' default diff (7 lines) is ≤ TRIVIAL_AMEND_DELTA_LINES → pre-LLM short-circuit.
+			setupPipelineMocks("abc12345def67890");
+			vi.mocked(getCurrentBranch).mockResolvedValue("feature/x");
+
+			await runWorker("/test/cwd");
+
+			expect(storeSummary).toHaveBeenCalledTimes(1);
+			expect(vi.mocked(storeSummary).mock.calls[0][0].transcripts).toContain("t-existing");
+		});
+
+		it("normal commit writes the excludedContext audit onto the summary", async () => {
+			const op = makeCommitOp();
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/entry.json" }])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+			setupPipelineMocks();
+			vi.mocked(assessContextRelevance).mockResolvedValueOnce({
+				plans: [],
+				notes: [],
+				references: [],
+				excludedContext: [{ kind: "note", key: "n-x", title: "N", reason: "unrelated", tier: "low" }],
+				results: [],
+			});
+
+			await runWorker("/test/cwd");
+
+			expect(storeSummary).toHaveBeenCalledTimes(1);
+			expect(vi.mocked(storeSummary).mock.calls[0][0].excludedContext).toEqual([
+				{ kind: "note", key: "n-x", title: "N", reason: "unrelated", tier: "low" },
+			]);
+		});
+
+		it("finalizeReferenceArchive returns early when nothing was committed", async () => {
+			vi.mocked(loadPlansRegistry).mockClear();
+			await __test__.finalizeReferenceArchive([], "/test/cwd");
+			// Early return before the registry read — no lock/registry work for an empty set.
+			expect(loadPlansRegistry).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -1471,6 +1471,111 @@ async function assembleReferenceBlocks(activeReferenceEntries: ReadonlyArray<Ref
 	return parts.join("\n");
 }
 
+/** Result of consuming the working-area Context for one commit. */
+export interface ConsumedWorkspaceContext {
+	readonly planAssociation: PlanAssociationResult;
+	readonly noteRefs: ReadonlyArray<NoteReference>;
+	readonly referenceRefs: ReadonlyArray<ReferenceCommitRef>;
+}
+
+/**
+ * Consumes the checked working-area Context (plans / notes / references) for a
+ * commit: associates each kind with `commitHash` (moving it out of the working
+ * area, i.e. setting the registry `commitHash` for plans/notes and archiving
+ * references to the orphan branch), then discards the user's hard-excluded rows.
+ *
+ * Apply per-item exclusions BEFORE associate* — these helpers have side effects
+ * (savePlansRegistry archive entry + orphan-branch store), so a post-filter on
+ * the returned refs would still leave an excluded item archived on disk. The
+ * prompt-block filter only governs LLM input; this archive path is a separate
+ * registry scan and must be filtered here.
+ *
+ * AI soft-excluded items (`excludedContext`) are skipped from association too —
+ * otherwise they'd get a commitHash (moved out of the working area) while ALSO
+ * being listed in excludedContext. Soft-excluded items must keep NO commitHash
+ * and stay in the working area for re-evaluation on the next commit. Unlike user
+ * hard-excludes they are NOT discarded (discardExcludedWorkingItems only sees the
+ * `exclusions` set), so they simply remain uncommitted.
+ *
+ * Extracted from the normal commit pipeline so all four amend paths consume
+ * Context identically — the old bug was that only the normal path and the amend
+ * fresh-leaf did this, so `git commit --amend` on the short-circuit / full paths
+ * left checked items stuck on the panel. Deliberately does NOT run
+ * evaluatePlanProgress (normal-path-only, caller-owned) and does NOT call
+ * clearAiSelection (caller-owned — see the LLM-window race note at its call site).
+ *
+ * `archiveLabel` only flavours the orphan-branch storeReferences commit message.
+ */
+async function consumeWorkspaceContext(args: {
+	readonly cwd: string;
+	readonly branch: string;
+	readonly commitHash: string;
+	readonly exclusions: {
+		readonly plans: ReadonlySet<string>;
+		readonly notes: ReadonlySet<string>;
+		readonly references: ReadonlySet<string>;
+	};
+	readonly excludedContext: ReadonlyArray<ExcludedContextItem>;
+	readonly archiveLabel?: "commit" | "amend";
+}): Promise<ConsumedWorkspaceContext> {
+	const { cwd, branch, commitHash, exclusions, excludedContext, archiveLabel = "commit" } = args;
+
+	const aiExcludedKeys = {
+		plan: new Set<string>(),
+		note: new Set<string>(),
+		reference: new Set<string>(),
+	};
+	for (const e of excludedContext) aiExcludedKeys[e.kind].add(e.key);
+
+	const planSlugs = await detectPlanSlugsFromRegistry(cwd, branch);
+	for (const excludedSlug of exclusions.plans) planSlugs.delete(excludedSlug);
+	for (const s of aiExcludedKeys.plan) planSlugs.delete(s);
+	const planAssociation = await associatePlansWithCommit(planSlugs, commitHash, cwd, branch);
+
+	const noteIds = await detectUncommittedNoteIds(cwd, branch);
+	for (const excludedId of exclusions.notes) noteIds.delete(excludedId);
+	for (const id of aiExcludedKeys.note) noteIds.delete(id);
+	const noteRefs = await associateNotesWithCommit(noteIds, commitHash, cwd, branch);
+
+	// Reference mapKeys across every source (linear / jira / github / notion). The
+	// returned filesToStore is forwarded directly to storeReferences — captured
+	// BEFORE the local rename so the orphan-branch snapshot is independent of
+	// rename success.
+	const rawReferenceIds = await detectUncommittedReferenceIds(cwd, branch);
+	const referenceIds = rawReferenceIds.filter(
+		(e) => !exclusions.references.has(e.mapKey) && !aiExcludedKeys.reference.has(e.mapKey),
+	);
+	const {
+		refs: referenceRefs,
+		filesToStore: referenceFiles,
+		committed: referenceCommitted,
+	} = await associateReferencesWithCommit(referenceIds, commitHash, cwd, branch);
+	if (referenceFiles.length > 0) {
+		// Write-ahead: persist the orphan-branch snapshot FIRST, then tear down
+		// local state. If storeReferences throws, the active rows stay in
+		// plans.json and re-archive on the next commit (no permanent loss).
+		await storeReferences(
+			referenceFiles,
+			`Archive ${referenceFiles.length} reference ref(s) for ${archiveLabel} ${commitHash.substring(0, 8)}`,
+			cwd,
+			branch,
+		);
+		await finalizeReferenceArchive(referenceCommitted, cwd);
+	}
+
+	// Discard the unchecked working items: the CHECKED ones were archived above;
+	// the excluded ones are useless per the user's selection, so remove their
+	// registry rows (+ .jolli-owned backing files) WITHOUT writing them into the
+	// committed memory. Runs after associate* so the checked-item archival (which
+	// reloads the registry under lock) has already settled.
+	await discardExcludedWorkingItems(
+		{ plans: exclusions.plans, notes: exclusions.notes, references: exclusions.references },
+		cwd,
+	);
+
+	return { planAssociation, noteRefs, referenceRefs };
+}
+
 /**
  * The core LLM summarization pipeline. Now driven by a GitOperation from the queue.
  *
@@ -1712,78 +1817,19 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 	}
 	log.info("API summary generated (%s)", formatElapsed(stepStart));
 
-	// Read uncommitted plan slugs from plans.json registry.
-	// Apply per-item exclusions BEFORE associate* — these helpers have side effects
-	// (savePlansRegistry archive entry + storePlans to the orphan branch), so a
-	// post-filter on `planAssociation.refs` would still leave the excluded plan
-	// archived on disk. The prompt-block filter only governs LLM input;
-	// the archive path is a separate registry scan and must be filtered here.
-	// The excluded rows are then DISCARDED by `discardExcludedWorkingItems` below
-	// (removed from the working area, but never archived into committed memory).
-	// AI soft-excluded items must ALSO be skipped from association — otherwise they
-	// get a commitHash (moved out of the working area) while ALSO being listed in
-	// excludedContext. Soft-excluded items must keep NO commitHash and stay in the
-	// working area for re-evaluation on the next commit.
-	// Unlike user hard-excludes they are NOT discarded (discardExcludedWorkingItems
-	// only sees the user `exclusions` set), so they simply remain uncommitted.
-	const aiExcludedKeys = {
-		plan: new Set<string>(),
-		note: new Set<string>(),
-		reference: new Set<string>(),
-	};
-	for (const e of excludedContext) aiExcludedKeys[e.kind].add(e.key);
-
-	const planSlugs = await detectPlanSlugsFromRegistry(cwd, branch);
-	for (const excludedSlug of exclusions.plans) planSlugs.delete(excludedSlug);
-	for (const s of aiExcludedKeys.plan) planSlugs.delete(s);
-	const planAssociation = await associatePlansWithCommit(planSlugs, commitInfo.hash, cwd, branch);
-	const planRefs = planAssociation.refs;
-
-	// Read uncommitted note IDs from plans.json registry.
-	// Same archive-side exclusion as the plan slugs — see comment above.
-	const noteIds = await detectUncommittedNoteIds(cwd, branch);
-	for (const excludedId of exclusions.notes) noteIds.delete(excludedId);
-	for (const id of aiExcludedKeys.note) noteIds.delete(id);
-	const noteRefs = await associateNotesWithCommit(noteIds, commitInfo.hash, cwd, branch);
-
-	// Read uncommitted reference mapKeys from plans.json.references and
-	// archive them across every source (linear / jira / github / notion). The
-	// returned filesToStore is forwarded directly to storeReferences — captured
-	// BEFORE the local rename so the orphan-branch snapshot is independent of
-	// rename success. Mirrors the plans / notes archive-side filter — excluded
-	// references are dropped from archival here and DISCARDED (row + markdown
-	// removed) by `discardExcludedWorkingItems` below.
-	const rawReferenceIds = await detectUncommittedReferenceIds(cwd, branch);
-	const referenceIds = rawReferenceIds.filter(
-		(e) => !exclusions.references.has(e.mapKey) && !aiExcludedKeys.reference.has(e.mapKey),
-	);
-	const {
-		refs: referenceRefs,
-		filesToStore: referenceFiles,
-		committed: referenceCommitted,
-	} = await associateReferencesWithCommit(referenceIds, commitInfo.hash, cwd, branch);
-	if (referenceFiles.length > 0) {
-		// Write-ahead: persist the orphan-branch snapshot FIRST, then tear down
-		// local state. If storeReferences throws, the active rows stay in
-		// plans.json and re-archive on the next commit (no permanent loss).
-		await storeReferences(
-			referenceFiles,
-			`Archive ${referenceFiles.length} reference ref(s) for commit ${commitInfo.hash.substring(0, 8)}`,
-			cwd,
-			branch,
-		);
-		await finalizeReferenceArchive(referenceCommitted, cwd);
-	}
-
-	// Discard the unchecked working items: the CHECKED ones were archived above;
-	// the excluded ones are useless per the user's selection, so remove their
-	// registry rows (+ .jolli-owned backing files) WITHOUT writing them into the
-	// committed memory. Runs after associate* so the checked-item archival (which
-	// reloads the registry under lock) has already settled.
-	await discardExcludedWorkingItems(
-		{ plans: exclusions.plans, notes: exclusions.notes, references: exclusions.references },
+	// Consume the checked working-area Context (plans / notes / references):
+	// associate with this commit + discard user hard-excludes. AI soft-excludes
+	// (excludedContext) stay uncommitted. See consumeWorkspaceContext for the full
+	// archive-side-exclusion rationale.
+	const { planAssociation, noteRefs, referenceRefs } = await consumeWorkspaceContext({
 		cwd,
-	);
+		branch,
+		commitHash: commitInfo.hash,
+		exclusions,
+		excludedContext,
+		archiveLabel: "commit",
+	});
+	const planRefs = planAssociation.refs;
 
 	// Step 8b: Evaluate plan progress for each linked plan (Haiku calls parallelized)
 	const planProgressArtifacts: PlanProgressArtifact[] = [];
@@ -2219,7 +2265,7 @@ function isTrivialAmendDelta(deltaStats: DiffStats): boolean {
  * — inherited IDs plus the newly written delta's ID if amend captured new
  * sessions. Short-circuit paths that don't write a delta pass only inherited.
  */
-interface AmendHoistedFields {
+export interface AmendHoistedFields {
 	readonly topics: ReadonlyArray<TopicSummary>;
 	readonly recap?: string;
 	readonly ticketId?: string;
@@ -2266,6 +2312,30 @@ function conversationUsageFields(
 	};
 }
 
+/** Trailing `-<8 hex>` short-hash suffix that association appends to plan slugs / note ids. */
+const REF_HASH_SUFFIX = /-[0-9a-f]{8}$/;
+
+/**
+ * Unions old (hoisted) refs with newly-associated refs, deduped by BASE key,
+ * with **new refs winning** on collision. Base key strips the per-commit
+ * `-<shortHash>` suffix (plans/notes) or uses `<source>:<nativeId>` (references),
+ * so a revived guard that re-archives `foo-<oldHash>` as `foo-<newHash>` lists
+ * once — as the NEW ref. New-wins is a data-integrity requirement: the new ref
+ * is the one whose markdown was just written to the orphan branch, so dropping
+ * it in favour of the old ref would leave an orphan-branch file with no summary
+ * pointer (the exact bug this consumption fix exists to prevent).
+ */
+function mergeRefsNewWins<T>(
+	oldRefs: ReadonlyArray<T> | undefined,
+	newRefs: ReadonlyArray<T> | undefined,
+	baseKey: (ref: T) => string,
+): T[] {
+	const byKey = new Map<string, T>();
+	for (const ref of oldRefs ?? []) byKey.set(baseKey(ref), ref);
+	for (const ref of newRefs ?? []) byKey.set(baseKey(ref), ref);
+	return [...byKey.values()];
+}
+
 /**
  * Builds the v4 amend root with all 8 Hoist fields populated and the old
  * summary attached as a stripped child. Used by all three amend paths
@@ -2277,6 +2347,14 @@ function conversationUsageFields(
  * the user amended a commit that was never summarised). In that case the
  * new root is effectively a fresh leaf -- still v4, no children, no Hoist
  * source -- and `hoisted` is whatever the caller derived from delta alone.
+ *
+ * `newRefs` are the plans/notes/references this amend just associated (via
+ * consumeWorkspaceContext). They are merged into the hoisted old refs with
+ * NEW winning per base key (see mergeRefsNewWins) — without this, the newly
+ * archived orphan-branch snapshots would have no pointer in the summary root.
+ * `excludedContext` is the AI soft-exclude audit, written only on the paths
+ * that generate a new summary (full path / fresh leaf), mirroring the normal
+ * commit pipeline; the short-circuit paths pass `[]`.
  */
 function buildHoistedAmendRoot(
 	// All three call sites are gated on `if (oldSummary)` so a non-undefined
@@ -2294,7 +2372,35 @@ function buildHoistedAmendRoot(
 		readonly conversationTokenBreakdown?: ConversationTokenBreakdown;
 		readonly conversationModels?: ReadonlyArray<ModelTokenUsage>;
 	},
+	newRefs?: {
+		readonly plans?: ReadonlyArray<PlanReference>;
+		readonly notes?: ReadonlyArray<NoteReference>;
+		readonly references?: ReadonlyArray<ReferenceCommitRef>;
+	},
+	excludedContext?: ReadonlyArray<ExcludedContextItem>,
 ): CommitSummary {
+	// Old (hoisted) refs ∪ new refs, deduped by base key with new winning.
+	const hoistedMeta = hoistMetadataFromOldSummary(oldSummary);
+	const mergedPlans = mergeRefsNewWins(hoistedMeta.plans, newRefs?.plans, (p) => p.slug.replace(REF_HASH_SUFFIX, ""));
+	const mergedNotes = mergeRefsNewWins(hoistedMeta.notes, newRefs?.notes, (n) => n.id.replace(REF_HASH_SUFFIX, ""));
+	const mergedReferences = mergeRefsNewWins(
+		hoistedMeta.references,
+		newRefs?.references,
+		(r) => `${r.source}:${r.nativeId}`,
+	);
+	// Drop from the AI-exclude audit any item that is nonetheless ATTACHED to this
+	// summary via a hoisted (inherited) ref — otherwise the same item would appear
+	// in BOTH the attached list and the "AI excluded" list, a self-contradiction.
+	// Only references collide in practice: a re-referenced item that was committed
+	// earlier has no guard row, so it can re-enter the soft-exclude set while its
+	// old snapshot is still hoisted. plans/notes skip committed guards upstream
+	// (detectActive*ForBranch), but we filter all three kinds for symmetry.
+	const attachedBaseKeys: Record<ExcludedContextItem["kind"], ReadonlySet<string>> = {
+		plan: new Set(mergedPlans.map((p) => p.slug.replace(REF_HASH_SUFFIX, ""))),
+		note: new Set(mergedNotes.map((n) => n.id.replace(REF_HASH_SUFFIX, ""))),
+		reference: new Set(mergedReferences.map((r) => `${r.source}:${r.nativeId}`)),
+	};
+	const auditedExclusions = (excludedContext ?? []).filter((e) => !attachedBaseKeys[e.kind].has(e.key));
 	return {
 		version: CURRENT_SCHEMA_VERSION,
 		commitHash: newInfo.hash,
@@ -2320,7 +2426,15 @@ function buildHoistedAmendRoot(
 		),
 		...(hoisted.summaryError && { summaryError: hoisted.summaryError }),
 		/* v8 ignore stop */
-		...hoistMetadataFromOldSummary(oldSummary),
+		// hoistedMeta carries the non-ref hoist fields (jolliDocId, e2eTestGuide, …)
+		// plus the OLD plans/notes/references; the merged overrides below replace the
+		// three ref fields with "old ∪ new" (new wins). Set only when non-empty so the
+		// "omit when absent" contract the hoist spread already honoured is preserved.
+		...hoistedMeta,
+		...(mergedPlans.length > 0 ? { plans: mergedPlans } : {}),
+		...(mergedNotes.length > 0 ? { notes: mergedNotes } : {}),
+		...(mergedReferences.length > 0 ? { references: mergedReferences } : {}),
+		...(auditedExclusions.length > 0 ? { excludedContext: auditedExclusions } : {}),
 		topics: hoisted.topics,
 		/* v8 ignore next */
 		...(hoisted.recap && { recap: hoisted.recap }),
@@ -2351,6 +2465,18 @@ async function applyAmendShortCircuit(
 	commitInfo: CommitInfo,
 	metadata: { readonly commitType?: CommitType; readonly commitSource?: CommitSource } | undefined,
 	amendFullDiffStats: DiffStats,
+	// Branch + user exclusions so the short-circuit can consume its working-area
+	// Context like the other paths (the old bug: it didn't, so amend left checked
+	// plans/notes/references stuck on the panel). Both short-circuit call sites pass
+	// an EMPTY excludedContext: they don't generate a new summary, so relevance
+	// filtering (which serves "keep the new summary focused") is moot — the user's
+	// panel selection is fully associated (minus hard-excludes).
+	branch: string,
+	exclusions: {
+		readonly plans: ReadonlySet<string>;
+		readonly notes: ReadonlySet<string>;
+		readonly references: ReadonlySet<string>;
+	},
 	// v5: the caller hoists transcript-artifact construction so the same delta
 	// ID can be stamped on both the stored artifact and the new root's
 	// `transcripts` field. `amendTranscripts` already contains the inherited
@@ -2369,6 +2495,16 @@ async function applyAmendShortCircuit(
 	label: string,
 	markError: boolean,
 ): Promise<void> {
+	// Consume the working-area Context BEFORE building the root so the newly
+	// associated refs can be merged in (empty excludedContext → full associate).
+	const consumed = await consumeWorkspaceContext({
+		cwd,
+		branch,
+		commitHash: commitInfo.hash,
+		exclusions,
+		excludedContext: [],
+		archiveLabel: "amend",
+	});
 	const root = buildHoistedAmendRoot(
 		oldSummary,
 		commitInfo,
@@ -2391,9 +2527,15 @@ async function applyAmendShortCircuit(
 			conversationTokenBreakdown,
 			conversationModels,
 		},
+		{ plans: consumed.planAssociation.refs, notes: consumed.noteRefs, references: consumed.referenceRefs },
+		// No excludedContext audit on short-circuit: it associates the full user
+		// selection, so there is no AI soft-exclude set to record.
 	);
 
 	await storeSummary(root, cwd, false, transcriptArtifact ? { transcript: transcriptArtifact } : undefined);
+	// Associate (above) runs BEFORE reassociateMetadata so a revived guard's
+	// commitHash has already moved to the new hash — reassociate's old-short-hash
+	// guard is then a no-op for it, avoiding a double migration.
 	await reassociateMetadata([oldSummary], commitInfo.hash, cwd);
 	log.info(
 		"Amend short-circuit (%s) complete: %s -> %s (%s)",
@@ -2447,6 +2589,21 @@ async function handleAmendPipeline(
 	// exclusion read here drives prompt-block filtering and the discard pass below.
 	const amendConfig = await loadConfig();
 	const amendExclusions = await readExclusions(cwd);
+	// Resolve the branch once for every amend path that consumes Context (both
+	// short-circuits, full path, fresh leaf). Prefer the captured hint over a live
+	// read for the same reason as executePipeline; see line 1529.
+	const amendBranch = branchHint ?? (await getCurrentBranch(cwd));
+
+	// Invalidate the panel's cached AI ranking up front, for EVERY amend path. A
+	// `git commit --amend` always moves HEAD, so the panel's change fingerprint is
+	// now stale and a LATER commit must not reuse it. Clearing here (before any LLM)
+	// matches the normal pipeline's "clear before the LLM window" placement — so a
+	// user re-ranking the panel DURING amend summarisation isn't clobbered (see the
+	// race note at executePipeline's clearAiSelection). This does NOT read the
+	// selection file, so it's independent of the per-path consumeWorkspaceContext
+	// (which takes its excludedContext as an argument). Best-effort — a clear failure
+	// must never break summary generation.
+	await clearAiSelection(cwd).catch((err) => log.warn("clearAiSelection failed: %s", (err as Error).message));
 	const {
 		sessionTranscripts,
 		totalEntries,
@@ -2540,6 +2697,8 @@ async function handleAmendPipeline(
 			commitInfo,
 			metadata,
 			amendFullDiffStats,
+			amendBranch,
+			amendExclusions,
 			transcriptArtifact,
 			amendTranscripts,
 			totalEntries,
@@ -2582,12 +2741,10 @@ async function handleAmendPipeline(
 
 	// Same registry-driven prompt assembly as executePipeline (see Stage 2 wiring).
 	/* v8 ignore start -- amend-pipeline prompt-block assembly mirrors executePipeline's Stage 2 path. The amend path is exercised via PostCommitHook.helpers tests but not the prompt-block content specifically; the helpers and shapes are covered by their own dedicated tests. */
-	// Prefer the captured branch over a live read for the same reason as executePipeline; see line 1529.
-	const branchForBlocks = branchHint ?? (await getCurrentBranch(cwd));
 	const [rawAmendPlanEntries, rawAmendNoteEntries, rawAmendReferenceEntries] = await Promise.all([
-		detectActivePlansForBranch(cwd, branchForBlocks),
-		detectActiveNotesForBranch(cwd, branchForBlocks),
-		getReferenceEntriesForBranch(cwd, branchForBlocks),
+		detectActivePlansForBranch(cwd, amendBranch),
+		detectActiveNotesForBranch(cwd, amendBranch),
+		getReferenceEntriesForBranch(cwd, amendBranch),
 	]);
 	// User hard-excludes first (mirrors executePipeline). Reference key is
 	// `<source>:<nativeId>`, same shape as the plans.json.references map key.
@@ -2600,13 +2757,12 @@ async function handleAmendPipeline(
 	// git / content-read / LLM / parse failure falls back to the full user-kept set).
 	// assessContextRelevance is fail-open and unit-tested; this call site is amend-only,
 	// covered by the same v8-ignore rationale as the surrounding prompt-block assembly.
-	// Soft-excluded items shape the amend prompt AND are skipped from fresh-leaf
-	// association below (so they keep NO commitHash and stay in the working area for
-	// re-evaluation, matching executePipeline). FOLLOW-UP: the authoritative
-	// excludedContext audit is still only recorded on the normal path — amended
-	// summaries omit it, so the "AI excluded these" list won't show for an amend.
-	// `amendExcludedContext` is hoisted out of the try so the fresh-leaf branch
-	// further down can read it.
+	// Soft-excluded items shape the amend prompt AND are skipped from association
+	// on the summary-generating paths below (consumeWorkspaceContext with this
+	// excludedContext), so they keep NO commitHash and stay in the working area for
+	// re-evaluation — and they're recorded on the amend summary's excludedContext
+	// audit, matching executePipeline. `amendExcludedContext` is hoisted out of the
+	// try so the full path and fresh-leaf branch further down can read it.
 	let amendPlanEntries = userKeptAmendPlans;
 	let amendNoteEntries = userKeptAmendNotes;
 	let amendReferenceEntries = userKeptAmendRefs;
@@ -2714,6 +2870,8 @@ async function handleAmendPipeline(
 			commitInfo,
 			metadata,
 			amendFullDiffStats,
+			amendBranch,
+			amendExclusions,
 			transcriptArtifact,
 			amendTranscripts,
 			totalEntries,
@@ -2796,6 +2954,18 @@ async function handleAmendPipeline(
 		);
 		/* v8 ignore stop */
 
+		// Consume the working-area Context BEFORE building the root: the full path
+		// generates a new summary, so it honours the AI soft-exclude set computed for
+		// the prompt (amendExcludedContext) — soft-excluded items keep NO commitHash
+		// and stay in the working area, matching the normal commit pipeline.
+		const consumed = await consumeWorkspaceContext({
+			cwd,
+			branch: amendBranch,
+			commitHash: commitInfo.hash,
+			exclusions: amendExclusions,
+			excludedContext: amendExcludedContext,
+			archiveLabel: "amend",
+		});
 		const root = buildHoistedAmendRoot(
 			oldSummary,
 			commitInfo,
@@ -2825,6 +2995,8 @@ async function handleAmendPipeline(
 				conversationTokenBreakdown,
 				conversationModels,
 			},
+			{ plans: consumed.planAssociation.refs, notes: consumed.noteRefs, references: consumed.referenceRefs },
+			amendExcludedContext,
 		);
 		await storeSummary(
 			root,
@@ -2834,6 +3006,9 @@ async function handleAmendPipeline(
 				? { transcript: transcriptArtifact }
 				: undefined,
 		);
+		// Associate (above) runs BEFORE reassociateMetadata so a revived guard's
+		// commitHash has already moved to the new hash — reassociate is then a no-op
+		// for it (its old-short-hash guard no longer matches), avoiding a double migration.
 		await reassociateMetadata([oldSummary], commitInfo.hash, cwd);
 		log.info("=== Amend full path completed in %s ===", formatElapsed(pipelineStart));
 		log.info("=== Summary content (%d topics) ===", finalConsolidated.topics.length);
@@ -2844,65 +3019,27 @@ async function handleAmendPipeline(
 	}
 
 	// ── No old summary AND non-trivial delta -> store delta as a fresh leaf ────
-	// Prefer the captured branch over a live read for the same reason as executePipeline; see line 1529.
-	const branch = branchHint ?? (await getCurrentBranch(cwd));
+	const branch = amendBranch;
 
-	// Associate plans/notes/references on the branch with this amend commit,
-	// mirroring executePipeline. Without this the fresh leaf silently drops
-	// references for plans/notes authored before the previous (un-summarised)
-	// commit — the user wouldn't see them in plan-progress aggregation or
-	// reverse-lookups. The oldSummary path handles this via reassociateMetadata;
-	// fresh leaves have no oldSummary to migrate from, so we associate fresh.
-	// AI soft-excluded items must NOT be associated (mirroring executePipeline's
-	// aiExcludedKeys handling): they keep no commitHash and stay in the working area
-	// for re-evaluation on the next commit. Key sets are per-kind, single-form kinds.
-	const amendAiExcluded = {
-		plan: new Set<string>(),
-		note: new Set<string>(),
-		reference: new Set<string>(),
-	};
-	for (const e of amendExcludedContext) amendAiExcluded[e.kind].add(e.key);
-
-	const freshLeafPlanSlugs = await detectPlanSlugsFromRegistry(cwd, branch);
-	for (const excludedSlug of amendExclusions.plans) freshLeafPlanSlugs.delete(excludedSlug);
-	for (const s of amendAiExcluded.plan) freshLeafPlanSlugs.delete(s);
-	const freshLeafPlanAssoc = await associatePlansWithCommit(freshLeafPlanSlugs, commitInfo.hash, cwd, branch);
-	const freshLeafPlanRefs = freshLeafPlanAssoc.refs;
-
-	const freshLeafNoteIds = await detectUncommittedNoteIds(cwd, branch);
-	for (const excludedId of amendExclusions.notes) freshLeafNoteIds.delete(excludedId);
-	for (const id of amendAiExcluded.note) freshLeafNoteIds.delete(id);
-	const freshLeafNoteRefs = await associateNotesWithCommit(freshLeafNoteIds, commitInfo.hash, cwd, branch);
-
-	const rawFreshLeafReferenceIds = await detectUncommittedReferenceIds(cwd, branch);
-	// Mirror plans/notes: honour user deselections from the sidebar so the amend
-	// fresh-leaf doesn't silently re-archive references the user removed; and drop
-	// AI soft-excluded references (keyed by mapKey === `source:nativeId`).
-	const freshLeafReferenceIds = rawFreshLeafReferenceIds.filter(
-		(e) => !amendExclusions.references.has(e.mapKey) && !amendAiExcluded.reference.has(e.mapKey),
-	);
-	const {
-		refs: freshLeafReferenceRefs,
-		filesToStore: freshLeafReferenceFiles,
-		committed: freshLeafReferenceCommitted,
-	} = await associateReferencesWithCommit(freshLeafReferenceIds, commitInfo.hash, cwd, branch);
-	// CRITICAL: the generic associateReferencesWithCommit does NOT call
-	// storeReferences itself (unlike the legacy Linear-only path which was
-	// self-contained). The amend fresh-leaf path MUST explicitly drive the
-	// orphan-branch write — otherwise Regenerator can't read back the
-	// archived markdown at recall time. Write-ahead: store first, then finalize
-	// the local-state teardown (so a store failure leaves the rows recoverable).
-	/* v8 ignore start -- amend fresh-leaf reference-files write path: only hit when a `git commit --amend` lands without an existing summary AND active references exist on the branch. Both arms (files-present vs files-absent) are tested mechanically through the StopHook → PostCommit happy path; this defensive branch in the amend-only fresh-leaf code path is reachable only via a race (StopHook upserted between detect and commit), and that race resolves the same way either way. */
-	if (freshLeafReferenceFiles.length > 0) {
-		await storeReferences(
-			freshLeafReferenceFiles,
-			`Archive ${freshLeafReferenceFiles.length} reference ref(s) for amend ${commitInfo.hash.substring(0, 8)}`,
-			cwd,
-			branch,
-		);
-		await finalizeReferenceArchive(freshLeafReferenceCommitted, cwd);
-	}
-	/* v8 ignore stop */
+	// Consume the working-area Context for this amend, mirroring executePipeline.
+	// Without this the fresh leaf silently drops plans/notes/references authored
+	// before the previous (un-summarised) commit — the user wouldn't see them in
+	// plan-progress aggregation or reverse-lookups. The oldSummary paths associate
+	// via consumeWorkspaceContext + reassociateMetadata; fresh leaves have no
+	// oldSummary to migrate from, so they associate fresh. This is a summary-
+	// generating path, so it honours the AI soft-exclude set (amendExcludedContext):
+	// soft-excluded items keep NO commitHash and stay in the working area.
+	const consumed = await consumeWorkspaceContext({
+		cwd,
+		branch,
+		commitHash: commitInfo.hash,
+		exclusions: amendExclusions,
+		excludedContext: amendExcludedContext,
+		archiveLabel: "amend",
+	});
+	const freshLeafPlanRefs = consumed.planAssociation.refs;
+	const freshLeafNoteRefs = consumed.noteRefs;
+	const freshLeafReferenceRefs = consumed.referenceRefs;
 
 	const freshLeaf: CommitSummary = {
 		version: CURRENT_SCHEMA_VERSION,
@@ -2921,9 +3058,10 @@ async function handleAmendPipeline(
 		...(deltaLlmFailed && { summaryError: LLM_FAILED }),
 		...(freshLeafPlanRefs.length > 0 ? { plans: freshLeafPlanRefs } : {}),
 		...(freshLeafNoteRefs.length > 0 ? { notes: freshLeafNoteRefs } : {}),
-		/* v8 ignore start -- amend fresh-leaf references spread: same race-only path as the reference-files write above; truthy arm only fires when active references are present on the branch at amend time, which the StopHook → PostCommit happy path exercises elsewhere. */
 		...(freshLeafReferenceRefs.length > 0 ? { references: freshLeafReferenceRefs } : {}),
-		/* v8 ignore stop */
+		// AI soft-exclude audit, mirroring the normal commit pipeline: this path
+		// generated a new summary, so record what the relevance layer set aside.
+		...(amendExcludedContext.length > 0 ? { excludedContext: amendExcludedContext } : {}),
 		// v5 contract: always present, even if empty. Fresh leaf has no
 		// inherited IDs; only the new delta (if any).
 		transcripts: amendDeltaTranscriptId !== undefined ? [amendDeltaTranscriptId] : [],
@@ -2935,13 +3073,6 @@ async function handleAmendPipeline(
 		/* v8 ignore next -- defensive: transcriptArtifact is set when sessions exist; falsy arm only fires when there are no sessions, which the empty-transcript guard upstream already short-circuits. */ transcriptArtifact
 			? { transcript: transcriptArtifact }
 			: undefined,
-	);
-	// Discard the unchecked working items on the amend fresh-leaf path too — the
-	// checked ones were archived above; the excluded ones are removed from the
-	// working area without entering committed memory.
-	await discardExcludedWorkingItems(
-		{ plans: amendExclusions.plans, notes: amendExclusions.notes, references: amendExclusions.references },
-		cwd,
 	);
 
 	log.info(
@@ -3401,6 +3532,9 @@ export const __test__ = {
 	detectPlanSlugsFromRegistry,
 	detectUncommittedNoteIds,
 	hoistMetadataFromOldSummary,
+	mergeRefsNewWins,
+	buildHoistedAmendRoot,
+	consumeWorkspaceContext,
 	associatePlansWithCommit,
 	finalizeReferenceArchive,
 	executePipeline,


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Amending a commit that already had a summary previously left all checked context items — plans, notes, and external issue references — stuck on the context panel as if the amend had never happened. The fix consolidated the context association logic into a single shared entry point and wired it into every internal amend path. Short-circuit paths that reuse an existing summary now fully honor the user's panel selection; paths that generate a new summary continue to apply the AI relevance ranking, leaving lower-priority items available for the next commit.

The merge behavior for reference snapshots was made explicit and safe: when an amend brings in a freshly fetched copy of a reference alongside an older version carried over from the original commit, the newer copy always wins. A related integrity fix prevents the same item from appearing in both the attached references list and the exclusion audit — a contradiction that could arise when a previously committed reference re-entered the soft-exclude set during an amend.

The timing of when the context panel's cached AI ranking is cleared was also corrected. The clear now happens once at the start of every amend operation, before any summarization work begins. A user who re-ranks the panel while a long amend is running will find their new selection intact when the amend completes.

---

## Topics (3)
<details>
<summary><strong>01 · Shared context consumption helper wired into all commit and amend paths</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user amended a commit that already had a summary, the plans, notes, and external references they had checked in the context panel were never marked as consumed — they stayed visible on the panel as if the amend had never happened.

**💡 Decisions Behind the Code**

- **New refs must win on deduplication**: when an amended commit re-archives a plan or reference that was previously committed, the newly written orphan-branch snapshot must be the one pointed to by the summary root. Keeping the old ref instead would leave a file on the orphan branch with no pointer in any summary — the exact data-integrity gap the fix was designed to prevent. The deduplication key strips the per-commit short-hash suffix so old and new variants of the same item collapse to one entry.
- **Short-circuit paths associate with an empty soft-exclude set**: the AI relevance ranking exists to keep a newly generated summary focused. Short-circuit paths reuse the old summary without generating new content, so relevance filtering has no purpose there. Applying it anyway would leave checked items stranded on the panel with no principled reason, so the user's explicit panel selection is fully honored on these paths.
- **Shared helper over per-path duplication**: keeping the association logic inline in each commit path made it easy for the two paths to drift apart silently. Extracting a single helper means any future change to how context is consumed — new item kinds, new exclusion rules — only needs to happen in one place, and the test suite covers both paths automatically.
- **Consume-before-store ordering on short-circuit paths accepted as intentional parity**: the alternative — wrapping context consumption in a try/catch that falls back to empty refs — would produce a partial state where items are associated in the registry but absent from the summary root. The current ordering matches the normal commit pipeline's acknowledged write-ahead risk and keeps the two paths structurally identical.
- **Audit filter: attached items excluded from the excluded-context record**: if an item was soft-excluded by the AI but is already attached to the summary via a hoisted reference from a prior commit, recording it in the exclusion audit would be misleading — it is present in the summary, just not newly associated. Filtering it out keeps the audit honest about what was genuinely omitted.

**✅ What Was Implemented**

- Extracted `consumeWorkspaceContext` from the normal commit pipeline into a standalone async function in `QueueWorker.ts`. The function centralizes detection of uncommitted plans, notes, and references, applies soft-exclusion filters, archives references to the orphan branch, discards user hard-excluded items, and returns structured association results — replacing inline duplication across the normal commit and amend commit pipelines.
- Wired `consumeWorkspaceContext` into all four amend paths (pre-LLM short-circuit, post-LLM short-circuit, full consolidation path, and fresh-leaf) and into the normal commit pipeline as a call-through replacement. Short-circuit paths pass an empty soft-exclude set so the full user selection is consumed; summary-generating paths pass the AI relevance soft-exclude set so lower-relevance items remain in the working area for re-evaluation.
- Extended `buildHoistedAmendRoot` in `QueueWorker.ts` to accept newly associated refs and an excluded-context audit field. A `mergeRefsNewWins` helper unions old hoisted refs with newly associated refs, deduplicated by base key with new entries always winning, preventing orphan-branch snapshots from losing their summary pointer on revival.
- Added an audit filter that removes any soft-excluded item whose base key already appears in the merged reference list before writing the audit field, closing a self-contradiction where the same item could appear in both the attached references list and the AI-excluded audit.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Context panel AI selection cleared once at amend entry point</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The cached AI ranking written by the context panel was being cleared at the end of each amend path, after any LLM calls had already run. A user who re-ranked the panel during a long amend summarization could have their new ranking silently overwritten when the amend completed.

**💡 Decisions Behind the Code**

- **Single entry-point clear over per-path clears**: placing the clear before any branching eliminates the need to track which paths need it and removes the risk of missing a newly added path in the future. Every amend moves the commit hash, making the panel's cached fingerprint stale regardless of which internal path runs, so clearing unconditionally at entry is both simpler and more correct than clearing selectively at exit.
- **Clear before the LLM window, not after**: the normal commit pipeline deliberately clears before its LLM call so that a user re-ranking the panel during summarization writes a fresh entry that survives. Placing the amend clear at the entry point achieves the same guarantee across all amend paths, including the two that run multiple sequential LLM calls.

**✅ What Was Implemented**

Removed three separate `clearAiSelection` calls from the ends of the short-circuit, full-path, and fresh-leaf amend branches in `QueueWorker.ts`. Added a single call at the top of `handleAmendPipeline`, before any LLM window opens and before any branching. The call is wrapped in a best-effort catch so a failure never blocks summary generation.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Adversarial review and expanded unit test coverage for context refactor</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After implementing the context consumption refactor, the team needed confidence that edge cases around data integrity, behavioral parity with the normal commit pipeline, and code correctness had been caught before tests were written.

**💡 Decisions Behind the Code**

- **Direct unit tests on exported helpers over full-pipeline integration tests**: the new helpers were exported via the existing test-only export object and tested directly, matching the established pattern. This approach covers the specific new-code lines precisely without requiring complex pipeline mock setup, and keeps test maintenance cost proportional to the scope of the change.
- **End-to-end test for the amend short-circuit**: rather than a narrow unit test, the amend case was written as a full pipeline invocation so it exercises the consume-and-hoist sequence in realistic conditions. This gives the test more durability: it validates the integration of several cooperating pieces rather than a single isolated function, making it less likely to become a false positive after future refactors.
- **Selective coverage over exhaustive coverage**: every uncovered line was explicitly reviewed and only the three directly related to code added or refactored in the preceding commit were covered. The remaining uncovered lines — defensive catch blocks, default-parameter thunks, concurrency busy signals, and telemetry gates — were judged not worth covering because tests for them would be brittle and low-value.

**✅ What Was Implemented**

- Three independent review agents examined the code from behavioral-parity, data-integrity, and code-quality angles. The data-integrity agent identified the real bug where a re-referenced item committed in a prior run could appear simultaneously in the attached references list and the AI-excluded audit; this was fixed by filtering the audit against the merged reference set before writing it to the summary root. The behavioral-parity agent's finding on `clearAiSelection` placement was resolved by the entry-point refactor. The consume-before-store ordering on short-circuit paths was accepted as intentional parity with the normal commit pipeline.
- Eight new unit tests were added to `QueueWorker.test.ts` covering: the merge helper's new-wins behavior, the audit filter, the plan soft-exclude loop inside the shared helper, the fresh-leaf references spread, and the AI selection layer clear-on-amend invariant. New helpers were exported via the existing test-only export object and tested directly, matching the pattern already used for `hoistMetadataFromOldSummary`.
- Three additional targeted tests were added to close specific uncovered branches: an end-to-end test for the amend pre-LLM short-circuit path exercising the full consume-and-hoist flow with a v5-format existing summary; a test for the normal commit pipeline verifying soft-excluded context items are written onto the stored summary; and a test for the reference archive finalization helper confirming it returns immediately when called with an empty set.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`
- `cli/src/hooks/QueueWorker.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 9, 2026 at 6:57 PM · via Anthropic*
<!-- jollimemory-summary-end -->