### PR TITLE
Add Zoom meeting and doc source references

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -731,8 +731,8 @@ export interface NoteReference {
  */
 export type SourceId = string;
 
-/** The four source ids that ship as built-in `SourceDefinition`s. Docs/reference only — not an exhaustive runtime set. */
-export type KnownSourceId = "linear" | "jira" | "github" | "notion" | "slack";
+/** The source ids that ship as built-in `SourceDefinition`s. Docs/reference only — not an exhaustive runtime set. */
+export type KnownSourceId = "linear" | "jira" | "github" | "notion" | "slack" | "zoom-meeting" | "zoom-doc";
 
 /**
  * ReferenceField — one displayable field produced by a `SourceDefinition`'s `fields` pipes.

--- a/cli/src/core/references/ClaudeEnvelopeParser.test.ts
+++ b/cli/src/core/references/ClaudeEnvelopeParser.test.ts
@@ -1,5 +1,13 @@
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { symlinksSupported } from "../../testUtils/symlinkSupport.js";
 import { claudeEnvelopeParser } from "./ClaudeEnvelopeParser.js";
+
+// `symlinkSync` throws EPERM on a non-elevated Windows account, so skip the
+// symlink-guard test there rather than fail the build (see symlinkSupport.ts).
+const itIfSymlinks = symlinksSupported ? it : it.skip;
 
 const PERMALINK = "https://flyer-q4r7867.slack.com/archives/C0BFF9UHBD1/p1783413984700009";
 const BLOB =
@@ -52,5 +60,212 @@ describe("ClaudeEnvelopeParser slack", () => {
 		// is voided (see slack.test.ts / SourceEngine.test.ts) — nothing is stored.
 		const { results } = claudeEnvelopeParser.parse(lines().slice(1), {});
 		expect((results[0].payload as { url?: string }).url).toBeUndefined();
+	});
+});
+
+function zoomDocLines(): string[] {
+	return [
+		JSON.stringify({
+			message: {
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "z1",
+						name: "mcp__claude_ai_Zoom_for_Claude__hub_get_file_content",
+						input: { fileId: "y_sTD3ZsQv-o-f2pw3IQCA", format: "markdown" },
+					},
+				],
+			},
+		}),
+		JSON.stringify({
+			message: {
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "z1",
+						content: JSON.stringify({ file_name: "Doc Title", file_content: "body" }),
+					},
+				],
+			},
+		}),
+	];
+}
+
+describe("ClaudeEnvelopeParser zoom-doc", () => {
+	it("merges fileId from the tool_use input into the canonical payload", () => {
+		const { results } = claudeEnvelopeParser.parse(zoomDocLines(), {});
+		expect(results).toHaveLength(1);
+		expect(results[0].def.id).toBe("zoom-doc");
+		const p = results[0].payload as { fileId: string; url: string; title: string };
+		expect(p.fileId).toBe("y_sTD3ZsQv-o-f2pw3IQCA");
+		expect(p.url).toBe("https://docs.zoom.us/doc/y_sTD3ZsQv-o-f2pw3IQCA");
+		expect(p.title).toBe("Doc Title");
+	});
+});
+
+const MEETING_PAYLOAD = {
+	meeting_uuid: "CB9D57D1-D6B0-4ECC-A6C2-E00449DF9B8D",
+	topic: "US/China sync meeting",
+	deep_url: "https://zoom.us/rec/share/xyz",
+	start_time: "2026-07-09T01:30:00Z",
+	meeting_number: 98668434129,
+	meeting_summary: {
+		summary_markdown: "## Quick recap\nRelease 1.0 planning.",
+		summary_doc_url: "https://docs.zoom.us/doc/abc",
+	},
+};
+
+/**
+ * A `get_meeting_assets` exchange whose tool_result carries the given raw text
+ * instead of JSON — used to drive the offload-recovery path with either a real
+ * "Output has been saved to <path>" pointer or an arbitrary non-offload string.
+ */
+function meetingResultLines(resultContent: string): string[] {
+	return [
+		JSON.stringify({
+			message: {
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "m1",
+						name: "mcp__claude_ai_Zoom_for_Claude__get_meeting_assets",
+						input: { meetingId: "CB9D57D1-D6B0-4ECC-A6C2-E00449DF9B8D" },
+					},
+				],
+			},
+		}),
+		JSON.stringify({
+			message: {
+				role: "user",
+				content: [{ type: "tool_result", tool_use_id: "m1", content: resultContent }],
+			},
+		}),
+	];
+}
+
+/** The harness pointer text, with the sentence period + schema hint that follow the path in real transcripts. */
+function offloadPointer(savedPath: string): string {
+	return `Error: result (119,792 characters) exceeds maximum allowed tokens. Output has been saved to ${savedPath}.\nFormat: JSON with schema: {topic: string, meeting_uuid: string, ...}`;
+}
+
+/**
+ * The harness's SECOND offload format: the `<persisted-output>` wrapper used for
+ * large (non-error) tool outputs like `hub_get_file_content` — "Output too large
+ * (N KB). Full output saved to: <path>" on its own line, followed by a truncated
+ * preview (no trailing period after the path). Distinct wording from the
+ * oversized-error pointer above, so the recovery must recognise both.
+ */
+function persistedOutputPointer(savedPath: string): string {
+	return `<persisted-output>\nOutput too large (65.2KB). Full output saved to: ${savedPath}\n\nPreview (first 2KB):\n{"topic":"US/Chin`;
+}
+
+/** Fresh temp dir with a `tool-results/` subdir mirroring Claude Code's offload layout. */
+function freshToolResultsDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "jolli-offload-"));
+	const toolResults = join(dir, "tool-results");
+	mkdirSync(toolResults);
+	return toolResults;
+}
+
+function writeOffloadFile(body: string): string {
+	const saved = join(freshToolResultsDir(), "mcp-claude_ai_Zoom_for_Claude-get_meeting_assets-123.txt");
+	writeFileSync(saved, body);
+	return saved;
+}
+
+describe("ClaudeEnvelopeParser oversized/offloaded tool result", () => {
+	it("recovers the get_meeting_assets payload from the offloaded tool-results file", () => {
+		const saved = writeOffloadFile(JSON.stringify(MEETING_PAYLOAD));
+		const { results } = claudeEnvelopeParser.parse(meetingResultLines(offloadPointer(saved)), {});
+		expect(results).toHaveLength(1);
+		expect(results[0].def.id).toBe("zoom-meeting");
+		const p = results[0].payload as { meeting_uuid: string; topic: string };
+		expect(p.meeting_uuid).toBe("CB9D57D1-D6B0-4ECC-A6C2-E00449DF9B8D");
+		expect(p.topic).toBe("US/China sync meeting");
+	});
+
+	it("recovers a payload offloaded via the <persisted-output> 'Output too large' format", () => {
+		// Regression: `hub_get_file_content` (and other large non-error results)
+		// come back wrapped in the `<persisted-output>` "Output too large … Full
+		// output saved to: <path>" pointer, NOT the oversized-error pointer — the
+		// recovery must match both wordings or the reference is silently dropped.
+		const saved = writeOffloadFile(JSON.stringify(MEETING_PAYLOAD));
+		const { results } = claudeEnvelopeParser.parse(meetingResultLines(persistedOutputPointer(saved)), {});
+		expect(results).toHaveLength(1);
+		expect(results[0].def.id).toBe("zoom-meeting");
+		expect((results[0].payload as { meeting_uuid: string }).meeting_uuid).toBe(
+			"CB9D57D1-D6B0-4ECC-A6C2-E00449DF9B8D",
+		);
+	});
+
+	it("drops a non-offload malformed payload (no pointer to recover from)", () => {
+		const { results } = claudeEnvelopeParser.parse(meetingResultLines("not json and no pointer"), {});
+		expect(results).toHaveLength(0);
+	});
+
+	it("refuses a relative offload path", () => {
+		const { results } = claudeEnvelopeParser.parse(meetingResultLines(offloadPointer("tool-results/x.txt")), {});
+		expect(results).toHaveLength(0);
+	});
+
+	it("refuses a traversal offload path", () => {
+		const saved = writeOffloadFile(JSON.stringify(MEETING_PAYLOAD));
+		// Build the string by hand — `join(saved, "..", …)` would normalize the
+		// `..` away and instead exercise the parent-dir guard. A literal `..`
+		// keeps the pointer pointed at the `path.includes("..")` defense.
+		const traversal = `${saved}/../../../etc/passwd`;
+		const { results } = claudeEnvelopeParser.parse(meetingResultLines(offloadPointer(traversal)), {});
+		expect(results).toHaveLength(0);
+	});
+
+	it("refuses an offload path outside the tool-results dir", () => {
+		const dir = mkdtempSync(join(tmpdir(), "jolli-outside-"));
+		const saved = join(dir, "mcp-get_meeting_assets.txt");
+		writeFileSync(saved, JSON.stringify(MEETING_PAYLOAD));
+		const { results } = claudeEnvelopeParser.parse(meetingResultLines(offloadPointer(saved)), {});
+		expect(results).toHaveLength(0);
+	});
+
+	it("refuses when the offload path is a directory, not a file", () => {
+		const toolResults = freshToolResultsDir();
+		const { results } = claudeEnvelopeParser.parse(meetingResultLines(offloadPointer(toolResults)), {});
+		expect(results).toHaveLength(0);
+	});
+
+	itIfSymlinks("refuses a symlinked offload file (lstat rejects the link)", () => {
+		const realDir = mkdtempSync(join(tmpdir(), "jolli-symlink-"));
+		const realFile = join(realDir, "payload.json");
+		writeFileSync(realFile, JSON.stringify(MEETING_PAYLOAD));
+		const link = join(freshToolResultsDir(), "mcp-get_meeting_assets-link.txt");
+		symlinkSync(realFile, link);
+		const { results } = claudeEnvelopeParser.parse(meetingResultLines(offloadPointer(link)), {});
+		expect(results).toHaveLength(0);
+	});
+
+	it("refuses a tool-results segment that is not the immediate parent dir", () => {
+		// `tool-results` present in the path, but the file sits one level deeper —
+		// the containment requires it as the direct parent, not merely a segment.
+		const nested = join(freshToolResultsDir(), "nested");
+		mkdirSync(nested);
+		const saved = join(nested, "payload.json");
+		writeFileSync(saved, JSON.stringify(MEETING_PAYLOAD));
+		const { results } = claudeEnvelopeParser.parse(meetingResultLines(offloadPointer(saved)), {});
+		expect(results).toHaveLength(0);
+	});
+
+	it("refuses an offloaded file larger than the size cap", () => {
+		const saved = writeOffloadFile(`0${"0".repeat(10 * 1024 * 1024)}`);
+		const { results } = claudeEnvelopeParser.parse(meetingResultLines(offloadPointer(saved)), {});
+		expect(results).toHaveLength(0);
+	});
+
+	it("drops when the offloaded file is missing or unparseable", () => {
+		const missing = join(freshToolResultsDir(), "gone.txt");
+		expect(claudeEnvelopeParser.parse(meetingResultLines(offloadPointer(missing)), {}).results).toHaveLength(0);
+		const badJson = writeOffloadFile("{ not: valid json");
+		expect(claudeEnvelopeParser.parse(meetingResultLines(offloadPointer(badJson)), {}).results).toHaveLength(0);
 	});
 });

--- a/cli/src/core/references/ClaudeEnvelopeParser.ts
+++ b/cli/src/core/references/ClaudeEnvelopeParser.ts
@@ -23,6 +23,8 @@
  * layer was deleted once this parser became the only caller.
  */
 
+import { lstatSync, readFileSync } from "node:fs";
+import { isAbsolute } from "node:path";
 import { createLogger } from "../../Logger.js";
 import { CLAUDE_SHELL_TOOL_NAMES, CLAUDE_TOOL_PREFIXES } from "./bindings/claude/index.js";
 import { matchCliCommand } from "./bindings/cli/index.js";
@@ -31,6 +33,7 @@ import { scanUserPermalinks } from "./SlackPermalink.js";
 import type { SourceDefinition } from "./SourceDefinition.js";
 import { getRegistry } from "./SourceDefinitionRegistry.js";
 import { normalizeSlackThread } from "./sources/SlackNormalize.js";
+import { normalizeZoomDoc } from "./sources/ZoomDocNormalize.js";
 import type {
 	EnvelopeParseResult,
 	ExtractOptions,
@@ -67,11 +70,12 @@ interface PendingEntry {
 	 *  `is_error: true`. MCP entries set this false to keep prior behaviour. */
 	readonly requireSuccess: boolean;
 	/**
-	 * The tool_use `input`, retained only for Slack (`def.id === "slack"`).
-	 * Slack's `normalize` needs both the tool result payload AND out-of-payload
-	 * context (`channel_id` / `message_ts` from the originating tool_use) that no
-	 * other source needs — every other MCP source's `normalize` is `identity`
-	 * and never looks at this field.
+	 * The tool_use `input`, retained only for sources with a registered
+	 * {@link CONTEXT_NORMALIZERS} entry (Slack, zoom-doc). Those need the tool
+	 * result payload AND out-of-payload context from the originating tool_use —
+	 * Slack's `channel_id` / `message_ts`, zoom-doc's `fileId` — that no other
+	 * source needs; every other MCP source's `normalize` is `identity` and never
+	 * looks at this field.
 	 */
 	readonly toolInput?: unknown;
 }
@@ -189,10 +193,11 @@ function collectToolUses(
 				def: mcpDef,
 				normalize: identity,
 				requireSuccess: false,
-				// Only Slack's normalize needs the tool_use input (channel_id /
-				// message_ts); every other source's `normalize` is `identity` and
+				// Only sources with a registered context-normalizer read the
+				// tool_use input (Slack's channel_id/message_ts, zoom-doc's
+				// fileId); every other source's `normalize` is `identity` and
 				// never reads `toolInput`, so it's left undefined for them.
-				...(mcpDef.id === "slack" ? { toolInput: b.input } : {}),
+				...(CONTEXT_NORMALIZER_IDS.has(mcpDef.id) ? { toolInput: b.input } : {}),
 			});
 			continue;
 		}
@@ -230,6 +235,70 @@ function readSlackToolInput(input: unknown): { channelId: string; messageTs: str
 	/* v8 ignore stop */
 	return { channelId, messageTs };
 }
+
+/** `{fileId}` off a zoom-doc tool_use's `input`, or undefined if malformed. */
+function readZoomDocToolInput(input: unknown): { fileId: string } | undefined {
+	/* v8 ignore start -- defensive: real `hub_get_file_content` tool_use input always carries fileId; guarded for totality against a malformed/future MCP shape. */
+	if (!isObject(input)) return undefined;
+	const fileId = (input as { fileId?: unknown }).fileId;
+	if (typeof fileId !== "string" || fileId.length === 0) return undefined;
+	/* v8 ignore stop */
+	return { fileId };
+}
+
+/**
+ * Parse-scoped context a context-aware normalizer may read beyond the tool
+ * result payload: the pasted-permalink map and the caller's `ExtractOptions`
+ * (workspace url, etc.).
+ */
+interface ContextNormalizeEnv {
+	readonly permalinks: Map<string, string>;
+	readonly opts: ExtractOptions;
+}
+
+/**
+ * Closed registry of context-aware normalizers, keyed by source id. A source
+ * belongs here IFF its canonical shape needs out-of-payload context — the
+ * originating tool_use `input`, and/or parse-scoped state (permalink map,
+ * workspace url) — that the default `identity` path cannot supply. Every other
+ * MCP source's `normalize` is `identity` and never appears here.
+ *
+ * Returning null voids the reference. Adding a fourth such source is one entry
+ * here, not a new `def.id === …` branch in `collectToolResults`.
+ */
+const CONTEXT_NORMALIZERS: Record<
+	string,
+	(payload: unknown, toolInput: unknown, env: ContextNormalizeEnv) => object | null
+> = {
+	slack: (payload, toolInput, env) => {
+		const slackInput = readSlackToolInput(toolInput);
+		/* v8 ignore start -- defensive: paired with a real slack_read_thread tool_use, input is always well-formed. */
+		if (slackInput === undefined) return null;
+		/* v8 ignore stop */
+		const { channelId, messageTs } = slackInput;
+		const url =
+			env.permalinks.get(`${channelId}:${messageTs}`) ??
+			(env.opts.slackWorkspaceUrl !== undefined
+				? `${env.opts.slackWorkspaceUrl}/archives/${channelId}/p${messageTs.replace(".", "")}`
+				: undefined);
+		return normalizeSlackThread(payload, { channelId, url });
+	},
+	"zoom-doc": (payload, toolInput) => {
+		const zoomInput = readZoomDocToolInput(toolInput);
+		/* v8 ignore start -- defensive: paired with a real hub_get_file_content tool_use, input is always well-formed. */
+		if (zoomInput === undefined) return null;
+		/* v8 ignore stop */
+		return normalizeZoomDoc(payload, { fileId: zoomInput.fileId });
+	},
+};
+
+/**
+ * Own-key ids of {@link CONTEXT_NORMALIZERS}. Membership is checked through this
+ * set (own enumerable keys only) so a prototype-chain id (`toString`,
+ * `constructor`) can never resolve a normalizer — the same closed-registry
+ * boundary as SourceEngine's `TRANSFORM_NAMES`.
+ */
+const CONTEXT_NORMALIZER_IDS: ReadonlySet<string> = new Set(Object.keys(CONTEXT_NORMALIZERS));
 
 function collectToolResults(
 	blocks: readonly unknown[],
@@ -269,38 +338,45 @@ function collectToolResults(
 		try {
 			parsedPayload = JSON.parse(payloadText);
 		} catch (err) {
-			log.warn(
-				"Dropping tool_result for %s (%s): payload JSON.parse failed: %s | preview=%s",
-				b.tool_use_id,
-				pendingEntry.toolName,
-				(err as Error).message,
-				payloadText.slice(0, 200),
-			);
-			pending.delete(b.tool_use_id);
-			continue;
-		}
-
-		// Slack needs both the payload AND out-of-payload context (channel_id /
-		// message_ts from the tool_use, url from the permalink map or config) that
-		// no other source's `normalize` (all `identity`) reads — handled as a
-		// distinct branch rather than folding into `pendingEntry.normalize` so
-		// that hook stays a pure `(payload, command) => payload` shape for every
-		// other source.
-		if (pendingEntry.def.id === "slack") {
-			const slackInput = readSlackToolInput(pendingEntry.toolInput);
-			/* v8 ignore start -- defensive: paired with a real slack_read_thread tool_use, input is always well-formed. */
-			if (slackInput === undefined) {
+			// A result whose JSON exceeded Claude Code's tool-output cap is not in
+			// the transcript at all — the harness offloads it to a file and leaves
+			// only an "Output has been saved to <path>" pointer here. Recover the
+			// real payload from that file before giving up (e.g. get_meeting_assets,
+			// whose bundled transcript routinely blows the cap).
+			const recovered = recoverOffloadedPayload(payloadText);
+			if (recovered === undefined) {
+				log.warn(
+					"Dropping tool_result for %s (%s): payload JSON.parse failed: %s | preview=%s",
+					b.tool_use_id,
+					pendingEntry.toolName,
+					(err as Error).message,
+					payloadText.slice(0, 200),
+				);
 				pending.delete(b.tool_use_id);
 				continue;
 			}
-			/* v8 ignore stop */
-			const { channelId, messageTs } = slackInput;
-			const url =
-				permalinks.get(`${channelId}:${messageTs}`) ??
-				(opts.slackWorkspaceUrl !== undefined
-					? `${opts.slackWorkspaceUrl}/archives/${channelId}/p${messageTs.replace(".", "")}`
-					: undefined);
-			const canonical = normalizeSlackThread(parsedPayload, { channelId, url });
+			log.info(
+				"Recovered offloaded tool_result for %s (%s) from %s",
+				b.tool_use_id,
+				pendingEntry.toolName,
+				recovered.path,
+			);
+			parsedPayload = recovered.payload;
+		}
+
+		// A source whose canonical shape needs out-of-payload context (the
+		// tool_use input, and/or parse-scoped state like the permalink map /
+		// workspace url) runs its registered context-normalizer here instead of
+		// the identity path — a single data-driven branch rather than one
+		// `def.id === …` block per such source. Membership goes through
+		// CONTEXT_NORMALIZER_IDS (own keys only) so a prototype-chain id can
+		// never resolve a function, and every other source's `normalize` stays a
+		// pure `(payload, command) => payload` hook.
+		const contextNormalize = CONTEXT_NORMALIZER_IDS.has(pendingEntry.def.id)
+			? CONTEXT_NORMALIZERS[pendingEntry.def.id]
+			: undefined;
+		if (contextNormalize !== undefined) {
+			const canonical = contextNormalize(parsedPayload, pendingEntry.toolInput, { permalinks, opts });
 			if (canonical === null) {
 				pending.delete(b.tool_use_id);
 				continue;
@@ -339,4 +415,64 @@ function extractResultPayloadText(content: unknown): string | undefined {
 	}
 	return parts.length > 0 ? parts.join("") : undefined;
 	/* v8 ignore stop */
+}
+
+/** Cap on an offloaded file we'll read back — generous vs. observed ~130 KB bundles, but bounds a pathological read. */
+const MAX_OFFLOAD_BYTES = 10 * 1024 * 1024;
+/**
+ * Claude Code offloads an oversized tool result to a file and leaves only a
+ * pointer in the transcript — and it does so with TWO distinct wordings:
+ *  1. Oversized-result error path: "…exceeds maximum allowed tokens. Output has
+ *     been saved to <path>." (e.g. a ~120 KB get_meeting_assets bundle).
+ *  2. Large non-error persistence path: a `<persisted-output>` wrapper reading
+ *     "Output too large (N KB). Full output saved to: <path>" then a truncated
+ *     preview (e.g. a ~65 KB hub_get_file_content doc).
+ * Each capture group is the path (to end-of-line); recovery tries all patterns
+ * so neither wording silently drops the reference.
+ */
+const OFFLOAD_POINTER_RES: readonly RegExp[] = [
+	/exceeds maximum allowed tokens\. Output has been saved to (.+)/,
+	/Output too large \([^)]*\)\. Full output saved to: (.+)/,
+];
+
+/**
+ * When a tool result exceeds Claude Code's output cap, the transcript carries a
+ * pointer string instead of the JSON; the real payload is on disk. Detect that
+ * pointer, read the file back, and JSON-parse it. Returns undefined for any
+ * non-offload parse failure, a path not sitting directly in the harness
+ * `tool-results/` offload dir, a traversal attempt, a symlink, a
+ * missing/oversized file, or a still-unparseable body — every such case falls
+ * through to the caller's existing drop.
+ */
+function recoverOffloadedPayload(payloadText: string): { payload: unknown; path: string } | undefined {
+	let match: RegExpExecArray | null = null;
+	for (const re of OFFLOAD_POINTER_RES) {
+		match = re.exec(payloadText);
+		if (match !== null) break;
+	}
+	if (match === null) return undefined;
+	// The pointer sits on its own line and ends the sentence, so trim the line
+	// and strip a single trailing period before the "Format: …" schema hint.
+	let path = match[1].split("\n")[0].trim();
+	if (path.endsWith(".")) path = path.slice(0, -1);
+	// Containment: only read a file sitting DIRECTLY in Claude Code's
+	// `tool-results/` offload dir, and never a traversal path. Requiring
+	// `tool-results` as the immediate parent (not merely a segment somewhere in
+	// the path) keeps a crafted pointer from walking us into an unrelated tree
+	// that happens to contain a `tool-results` component. The config/transcript
+	// is not trusted with an arbitrary read.
+	if (!isAbsolute(path)) return undefined;
+	if (path.includes("..")) return undefined;
+	const segments = path.split(/[\\/]/);
+	if (segments[segments.length - 2] !== "tool-results") return undefined;
+	try {
+		// `lstatSync` (not `statSync`): a symlinked offload file reports
+		// `isFile() === false` here, so the existing guard rejects it — the real
+		// path Claude Code writes is a plain file, never a link.
+		const stat = lstatSync(path);
+		if (!stat.isFile() || stat.size > MAX_OFFLOAD_BYTES) return undefined;
+		return { payload: JSON.parse(readFileSync(path, "utf8")), path };
+	} catch {
+		return undefined;
+	}
 }

--- a/cli/src/core/references/SourceDefinitionRegistry.test.ts
+++ b/cli/src/core/references/SourceDefinitionRegistry.test.ts
@@ -22,12 +22,12 @@ describe("SourceDefinitionRegistry", () => {
 		expect(r.match("codex", "linear.get_issue")?.id).toBe("linear"); // invocation-tool path (no namespace)
 	});
 
-	it("all() is stable order linear,jira,github,notion,slack", () => {
+	it("all() is stable order linear,jira,github,notion,slack,zoom-meeting,zoom-doc", () => {
 		expect(
 			getRegistry()
 				.all()
 				.map((d) => d.id),
-		).toEqual(["linear", "jira", "github", "notion", "slack"]);
+		).toEqual(["linear", "jira", "github", "notion", "slack", "zoom-meeting", "zoom-doc"]);
 	});
 
 	it("byId() finds a known definition and returns undefined for unknown ids", () => {
@@ -281,5 +281,22 @@ describe("SourceDefinitionRegistry", () => {
 			],
 		};
 		expect(validateDefinition(ok).ok).toBe(true);
+	});
+
+	describe("zoom-meeting registration", () => {
+		it("resolves get_meeting_assets to zoom-meeting", () => {
+			const def = getRegistry().match("claude", "mcp__claude_ai_Zoom_for_Claude__get_meeting_assets");
+			expect(def?.id).toBe("zoom-meeting");
+		});
+		it("does NOT match other Zoom tools (suffix gate)", () => {
+			expect(getRegistry().match("claude", "mcp__claude_ai_Zoom_for_Claude__search_meetings")).toBeUndefined();
+		});
+	});
+
+	describe("zoom-doc registration", () => {
+		it("resolves hub_get_file_content to zoom-doc", () => {
+			const def = getRegistry().match("claude", "mcp__claude_ai_Zoom_for_Claude__hub_get_file_content");
+			expect(def?.id).toBe("zoom-doc");
+		});
 	});
 });

--- a/cli/src/core/references/bindings/claude/index.test.ts
+++ b/cli/src/core/references/bindings/claude/index.test.ts
@@ -3,12 +3,15 @@ import { CLAUDE_SHELL_TOOL_NAMES, CLAUDE_TOOL_PREFIXES } from "./index.js";
 
 describe("Claude producer binding", () => {
 	describe("CLAUDE_TOOL_PREFIXES", () => {
-		it("lists every vendor prefix for the envelope pre-filter (both Linear prefixes included)", () => {
-			// Order follows BUILTIN_DEFINITIONS (linear, jira, github, notion, slack) —
-			// derived from the SourceDefinitionRegistry. Order is not semantically
-			// significant here (the needles are only used via `.some()`), so this
-			// pins the registry-driven order for regression visibility rather than a
-			// hard functional requirement.
+		it("lists every vendor prefix for the envelope pre-filter, de-duplicated (both Linear prefixes included; Zoom prefix appears once even though zoom-meeting and zoom-doc both declare it)", () => {
+			// Order follows BUILTIN_DEFINITIONS (linear, jira, github, notion, slack,
+			// zoom-meeting, zoom-doc) — derived from the SourceDefinitionRegistry.
+			// zoom-meeting and zoom-doc share the same Claude MCP prefix, so
+			// CLAUDE_TOOL_PREFIXES de-dupes via a Set; the shared prefix still
+			// appears exactly once here. Order is not semantically significant
+			// here (the needles are only used via `.some()`), so this pins the
+			// registry-driven order for regression visibility rather than a hard
+			// functional requirement.
 			expect(CLAUDE_TOOL_PREFIXES).toEqual([
 				"mcp__linear__",
 				"mcp__claude_ai_Linear__",
@@ -16,6 +19,7 @@ describe("Claude producer binding", () => {
 				"mcp__github__",
 				"mcp__claude_ai_Notion__",
 				"mcp__claude_ai_Slack__",
+				"mcp__claude_ai_Zoom_for_Claude__",
 			]);
 		});
 	});

--- a/cli/src/core/references/bindings/claude/index.ts
+++ b/cli/src/core/references/bindings/claude/index.ts
@@ -23,8 +23,16 @@ export const CLAUDE_SHELL_TOOL_NAMES: ReadonlySet<string> = new Set(["Bash"]);
 /**
  * Tool-name prefixes for the envelope's cheap per-line substring pre-filter.
  * Derived from the `SourceDefinitionRegistry` so match identity has a single
- * source of truth.
+ * source of truth. De-duplicated: two definitions can share the same MCP
+ * prefix (e.g. zoom-meeting and zoom-doc both live under
+ * `mcp__claude_ai_Zoom_for_Claude__`, disambiguated later by `acceptSuffix`),
+ * and this list only feeds a `.some()` pre-filter, so a repeated needle would
+ * be redundant rather than incorrect — dedupe keeps it a clean prefix set.
  */
-export const CLAUDE_TOOL_PREFIXES: ReadonlyArray<string> = getRegistry()
-	.all()
-	.flatMap((d) => d.match.claude?.prefixes ?? []);
+export const CLAUDE_TOOL_PREFIXES: ReadonlyArray<string> = [
+	...new Set(
+		getRegistry()
+			.all()
+			.flatMap((d) => d.match.claude?.prefixes ?? []),
+	),
+];

--- a/cli/src/core/references/sources/ZoomDocNormalize.test.ts
+++ b/cli/src/core/references/sources/ZoomDocNormalize.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { normalizeZoomDoc } from "./ZoomDocNormalize.js";
+
+// Real 2026-07-08 hub_get_file_content result (design spec §6): fileId is NOT in the result.
+const RESULT = { file_name: "Flyer Li's Personal Meeting Room", file_content: "## Quick recap\n..." };
+const CTX = { fileId: "y_sTD3ZsQv-o-f2pw3IQCA" };
+
+describe("normalizeZoomDoc", () => {
+	it("merges fileId from ctx and builds the doc url", () => {
+		expect(normalizeZoomDoc(RESULT, CTX)).toEqual({
+			fileId: "y_sTD3ZsQv-o-f2pw3IQCA",
+			title: "Flyer Li's Personal Meeting Room",
+			content: "## Quick recap\n...",
+			url: "https://docs.zoom.us/doc/y_sTD3ZsQv-o-f2pw3IQCA",
+		});
+	});
+
+	it("returns null when file_name is missing", () => {
+		expect(normalizeZoomDoc({ file_content: "body" }, CTX)).toBeNull();
+	});
+
+	it("returns null when file_name is empty", () => {
+		expect(normalizeZoomDoc({ file_name: "", file_content: "body" }, CTX)).toBeNull();
+	});
+
+	it("omits content when file_content is absent", () => {
+		expect(normalizeZoomDoc({ file_name: "Title only" }, CTX)).toEqual({
+			fileId: "y_sTD3ZsQv-o-f2pw3IQCA",
+			title: "Title only",
+			url: "https://docs.zoom.us/doc/y_sTD3ZsQv-o-f2pw3IQCA",
+		});
+	});
+
+	it("does not throw on non-object rawResult", () => {
+		expect(() => normalizeZoomDoc(null, CTX)).not.toThrow();
+		expect(() => normalizeZoomDoc("oops", CTX)).not.toThrow();
+		expect(normalizeZoomDoc(null, CTX)).toBeNull();
+		expect(normalizeZoomDoc("oops", CTX)).toBeNull();
+	});
+});

--- a/cli/src/core/references/sources/ZoomDocNormalize.ts
+++ b/cli/src/core/references/sources/ZoomDocNormalize.ts
@@ -1,0 +1,36 @@
+/**
+ * ZoomDocNormalize — parse the `hub_get_file_content` result into a canonical
+ * object the `zoom-doc` SourceDefinition can read with plain `path` ops.
+ *
+ * The MCP result is only `{ file_name, file_content }` — the fileId lives ONLY
+ * in the tool-call input, so it's threaded in via `ctx` (mirrors Slack's
+ * channelId/url threading). Unlike Slack's workspace url, the doc url is a
+ * pure function of fileId — no config involved.
+ *
+ * Defensive by contract: any shape we can't parse returns null (the caller
+ * voids the reference), never throws.
+ */
+
+import { isObject } from "../guards.js";
+
+export interface ZoomDocCanonical {
+	readonly fileId: string;
+	readonly title: string;
+	readonly content?: string;
+	readonly url: string;
+}
+
+export function normalizeZoomDoc(rawResult: unknown, ctx: { fileId: string }): ZoomDocCanonical | null {
+	if (!isObject(rawResult)) return null;
+	const fileName = (rawResult as { file_name?: unknown }).file_name;
+	if (typeof fileName !== "string" || fileName.length === 0) return null;
+	const fileContent = (rawResult as { file_content?: unknown }).file_content;
+	const content = typeof fileContent === "string" ? fileContent : undefined;
+
+	return {
+		fileId: ctx.fileId,
+		title: fileName,
+		url: `https://docs.zoom.us/doc/${ctx.fileId}`,
+		...(content !== undefined ? { content } : {}),
+	};
+}

--- a/cli/src/core/references/sources/definitions/index.ts
+++ b/cli/src/core/references/sources/definitions/index.ts
@@ -2,9 +2,9 @@
  * Registry of built-in `SourceDefinition`s, driven by `SourceEngine`.
  *
  * Order matches the pre-migration adapter registry's list (linear, jira,
- * github, notion) — preserved here even though nothing currently depends on
- * definition order, for continuity with `SourceDefinitionRegistry` consumers
- * that pin this order (e.g. `CLAUDE_TOOL_PREFIXES`).
+ * github, notion) — preserved for continuity with `SourceDefinitionRegistry`
+ * consumers that pin this order (e.g. `CLAUDE_TOOL_PREFIXES`). `slack`,
+ * `zoom-meeting` and `zoom-doc` are appended after the migrated four.
  */
 
 import { githubDefinition } from "./github.js";
@@ -12,6 +12,8 @@ import { jiraDefinition } from "./jira.js";
 import { linearDefinition } from "./linear.js";
 import { notionDefinition } from "./notion.js";
 import { slackDefinition } from "./slack.js";
+import { zoomDocDefinition } from "./zoom-doc.js";
+import { zoomMeetingDefinition } from "./zoom-meeting.js";
 
 export const BUILTIN_DEFINITIONS = [
 	linearDefinition,
@@ -19,4 +21,6 @@ export const BUILTIN_DEFINITIONS = [
 	githubDefinition,
 	notionDefinition,
 	slackDefinition,
+	zoomMeetingDefinition,
+	zoomDocDefinition,
 ] as const;

--- a/cli/src/core/references/sources/definitions/zoom-doc.test.ts
+++ b/cli/src/core/references/sources/definitions/zoom-doc.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { extractRef, renderBlock } from "../../SourceEngine.js";
+import { zoomDocDefinition as def } from "./zoom-doc.js";
+
+// The definition runs over the POST-normalize canonical shape (Task 5 output).
+const CANONICAL = {
+	fileId: "y_sTD3ZsQv-o-f2pw3IQCA",
+	title: "Flyer Li's Personal Meeting Room",
+	content: "## Quick recap\n...",
+	url: "https://docs.zoom.us/doc/y_sTD3ZsQv-o-f2pw3IQCA",
+};
+const TOOL = "mcp__claude_ai_Zoom_for_Claude__hub_get_file_content";
+const AT = "2026-07-08T00:00:00Z";
+
+describe("zoom-doc definition", () => {
+	it("extracts a Reference from the canonical shape", () => {
+		const ref = extractRef(def, CANONICAL, TOOL, AT);
+		expect(ref?.source).toBe("zoom-doc");
+		expect(ref?.nativeId).toBe("y_sTD3ZsQv-o-f2pw3IQCA");
+		expect(ref?.title).toBe("Flyer Li's Personal Meeting Room");
+		expect(ref?.url).toBe("https://docs.zoom.us/doc/y_sTD3ZsQv-o-f2pw3IQCA");
+		expect(ref?.description).toContain("Quick recap");
+		expect(ref?.fields).toEqual([{ key: "entity-type", label: "Type", icon: "symbol-class", value: "doc" }]);
+	});
+
+	it("voids when fileId (nativeId) is missing", () => {
+		expect(extractRef(def, { ...CANONICAL, fileId: undefined, url: undefined }, TOOL, AT)).toBeNull();
+	});
+
+	it("renders a <zoom-docs> block", () => {
+		const ref = extractRef(def, CANONICAL, TOOL, AT);
+		if (ref === null) throw new Error("expected ref");
+		expect(renderBlock(def, [ref])).toContain("<zoom-docs>");
+		expect(renderBlock(def, [ref])).toContain("<content>");
+	});
+});

--- a/cli/src/core/references/sources/definitions/zoom-doc.ts
+++ b/cli/src/core/references/sources/definitions/zoom-doc.ts
@@ -1,0 +1,34 @@
+/**
+ * Zoom Hub doc built-in source — pure `path` DSL over the ZoomDocNormalize
+ * canonical shape ({ fileId, title, content, url }). The messy work (fileId
+ * from tool_use input, url construction) lives in
+ * `sources/ZoomDocNormalize.normalizeZoomDoc`, wired into the Claude envelope
+ * parser's `collectToolResults`; this definition only selects fields.
+ */
+
+import type { SourceDefinition } from "../../SourceDefinition.js";
+
+export const zoomDocDefinition: SourceDefinition = {
+	id: "zoom-doc",
+	label: "Zoom Doc",
+	icon: "file",
+	match: {
+		claude: { prefixes: ["mcp__claude_ai_Zoom_for_Claude__"], acceptSuffix: "hub_get_file_content" },
+	},
+	wrapperKeys: [],
+	reference: {
+		nativeId: { pipe: [{ op: "path", path: "fileId" }], require: "^[\\w.-]+$" },
+		title: { pipe: [{ op: "path", path: "title" }], require: ".+" },
+		url: { pipe: [{ op: "path", path: "url" }], require: "^https://docs\\.zoom\\.us/doc/" },
+		description: { pipe: [{ op: "path", path: "content" }], optional: true },
+	},
+	fields: [{ key: "entity-type", label: "Type", icon: "symbol-class", pipe: [{ op: "const", value: "doc" }] }],
+	storage: { nativeIdPathSafe: true },
+	render: {
+		wrapperTag: "zoom-docs",
+		itemTag: "doc",
+		bodyTag: "content",
+		maxCharsPerReference: 30000,
+		maxTotalChars: 60000,
+	},
+};

--- a/cli/src/core/references/sources/definitions/zoom-meeting.test.ts
+++ b/cli/src/core/references/sources/definitions/zoom-meeting.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { extractRef, renderBlock } from "../../SourceEngine.js";
+import { zoomMeetingDefinition as def } from "./zoom-meeting.js";
+
+// Trimmed from the real 2026-07-08 get_meeting_assets payload (design spec §6).
+const REAL_PAYLOAD = {
+	meeting_summary: {
+		summary_markdown: "## Quick recap\nFlyer and Joe updated a GitHub app slug.\n## Next steps\n- Verify dev.",
+		summary_plain_text: "Quick recap ...",
+		has_permission: true,
+		has_summary: true,
+		summary_doc_url: "https://docs.zoom.us/doc/y_sTD3ZsQv-o-f2pw3IQCA",
+	},
+	meeting_transcript: {
+		transcript_items: [{ start: "00:00:50.000", text: "hi", end: "00:00:52.000" }],
+		primary_language: "en",
+	},
+	my_notes: { has_my_notes: false },
+	meeting_number: 4456640966,
+	deep_url: "https://jolli.zoom.us/launch/edl?muid=1764e7b0-e935-4084-8e29-ce48ab11ab1c",
+	start_time: "2026-06-16T02:19:12Z",
+	end_time: "2026-06-16T02:26:41Z",
+	meeting_uuid: "25955010-93C3-48E7-9F25-9D98CE6B69F7",
+	topic: "Flyer Li's Personal Meeting Room",
+	meeting_category: "history",
+};
+const TOOL = "mcp__claude_ai_Zoom_for_Claude__get_meeting_assets";
+const AT = "2026-07-08T00:00:00Z";
+
+describe("zoom-meeting definition", () => {
+	it("extracts a Reference from a real get_meeting_assets payload", () => {
+		const ref = extractRef(def, REAL_PAYLOAD, TOOL, AT);
+		expect(ref).not.toBeNull();
+		expect(ref?.source).toBe("zoom-meeting");
+		expect(ref?.nativeId).toBe("25955010-93C3-48E7-9F25-9D98CE6B69F7");
+		expect(ref?.mapKey).toBe("zoom-meeting:25955010-93C3-48E7-9F25-9D98CE6B69F7");
+		expect(ref?.title).toBe("Flyer Li's Personal Meeting Room");
+		expect(ref?.url).toBe("https://docs.zoom.us/doc/y_sTD3ZsQv-o-f2pw3IQCA");
+		expect(ref?.description).toContain("Quick recap");
+		expect(ref?.fields).toEqual([
+			{ key: "entity-type", label: "Type", icon: "symbol-class", value: "meeting" },
+			{ key: "started", label: "Started", icon: "calendar", value: "2026-06-16T02:19:12Z" },
+			{ key: "meeting-number", label: "Meeting #", icon: "symbol-number", value: "4456640966" },
+		]);
+	});
+
+	it("falls back to deep_url when summary_doc_url is absent", () => {
+		const p = { ...REAL_PAYLOAD, meeting_summary: { ...REAL_PAYLOAD.meeting_summary, summary_doc_url: undefined } };
+		expect(extractRef(def, p, TOOL, AT)?.url).toBe(REAL_PAYLOAD.deep_url);
+	});
+
+	it("voids a meeting with no summary body (guard)", () => {
+		const p = { ...REAL_PAYLOAD, meeting_summary: { has_permission: true, has_summary: false } };
+		expect(extractRef(def, p, TOOL, AT)).toBeNull();
+	});
+
+	it("renders a <zoom-meetings> block", () => {
+		const ref = extractRef(def, REAL_PAYLOAD, TOOL, AT);
+		if (ref === null) throw new Error("expected ref");
+		const xml = renderBlock(def, [ref]);
+		expect(xml).toContain("<zoom-meetings>");
+		expect(xml).toContain('<meeting id="25955010-93C3-48E7-9F25-9D98CE6B69F7"');
+		expect(xml).toContain("<summary>");
+		expect(xml).toContain("</zoom-meetings>");
+	});
+});

--- a/cli/src/core/references/sources/definitions/zoom-meeting.ts
+++ b/cli/src/core/references/sources/definitions/zoom-meeting.ts
@@ -1,0 +1,57 @@
+/**
+ * Zoom meeting built-in source — pure-DSL over the get_meeting_assets result.
+ *
+ * The payload is a single meeting object (not a list), so wrapperKeys is empty
+ * and walkPayload runs extractRef on the top-level object directly. Self-contained:
+ * meeting_uuid / topic / summary_doc_url are all in the result, so no normalize
+ * and no tool_use.input is needed (contrast zoom-doc).
+ *
+ * Guard: require a non-empty meeting_summary.summary_markdown — a meeting with no
+ * AI summary voids rather than producing an empty-bodied reference.
+ * url: prefer the summary doc; fall back to the always-present deep_url.
+ */
+
+import type { SourceDefinition } from "../../SourceDefinition.js";
+
+export const zoomMeetingDefinition: SourceDefinition = {
+	id: "zoom-meeting",
+	label: "Zoom Meeting",
+	icon: "device-camera-video",
+	match: {
+		claude: { prefixes: ["mcp__claude_ai_Zoom_for_Claude__"], acceptSuffix: "get_meeting_assets" },
+	},
+	wrapperKeys: [],
+	reference: {
+		guard: { pipe: [{ op: "path", path: "meeting_summary.summary_markdown" }], require: ".+" },
+		nativeId: { pipe: [{ op: "path", path: "meeting_uuid" }], require: "^[\\w-]+$" },
+		title: { pipe: [{ op: "path", path: "topic" }], require: ".+" },
+		url: {
+			pipe: [
+				{
+					op: "coalesce",
+					of: [[{ op: "path", path: "meeting_summary.summary_doc_url" }], [{ op: "path", path: "deep_url" }]],
+				},
+			],
+			require: "^https://",
+		},
+		description: { pipe: [{ op: "path", path: "meeting_summary.summary_markdown" }], optional: true },
+	},
+	fields: [
+		{ key: "entity-type", label: "Type", icon: "symbol-class", pipe: [{ op: "const", value: "meeting" }] },
+		{ key: "started", label: "Started", icon: "calendar", pipe: [{ op: "path", path: "start_time" }] },
+		{
+			key: "meeting-number",
+			label: "Meeting #",
+			icon: "symbol-number",
+			pipe: [{ op: "path", path: "meeting_number" }],
+		},
+	],
+	storage: { nativeIdPathSafe: true },
+	render: {
+		wrapperTag: "zoom-meetings",
+		itemTag: "meeting",
+		bodyTag: "summary",
+		maxCharsPerReference: 20000,
+		maxTotalChars: 40000,
+	},
+};

--- a/docs/superpowers/plans/2026-07-08-zoom-context-capture.md
+++ b/docs/superpowers/plans/2026-07-08-zoom-context-capture.md
@@ -1,0 +1,538 @@
+# Zoom Meeting & Doc Context Capture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture Zoom meeting AI-summaries (`get_meeting_assets`) and Zoom Hub docs (`hub_get_file_content`) that an agent reads via the Zoom for Claude MCP server, turning each into a `Reference` injected into Working Memory.
+
+**Architecture:** Two new built-in `SourceDefinition`s (`zoom-meeting`, `zoom-doc`) on the existing JOLLI-1877 reference pipeline. `zoom-meeting` is pure-DSL (zero engine change). `zoom-doc` needs a code-side `ZoomDocNormalize` to merge the `fileId` from the tool-call input and build the doc URL — it consumes the shared Claude-MCP `normalize` seam being delivered by the parallel Slack work (do not re-implement that seam). Everything downstream (storage, folder, orphan snapshot, rendering) is already source-agnostic.
+
+**Tech Stack:** TypeScript (ESM, Node 22.5+), Vitest, Biome. Design spec: [`docs/superpowers/specs/2026-07-08-zoom-context-capture-design.md`](../specs/2026-07-08-zoom-context-capture-design.md).
+
+## Global Constraints
+
+- **DCO sign-off on every commit** — `git commit -s`.
+- **No `Co-Authored-By: Claude …` / `🤖 Generated with …`** in commit messages.
+- **`npm run all` must pass before commit** (clean → build → lint → test).
+- **CLI coverage floor**: 97% statements / 96% branches / 97% functions / 97% lines (`cli/vite.config.ts`).
+- **Biome**: tabs (4-wide), 120-column limit, `noExplicitAny: error`, `useImportType`.
+- **Path normalization**: use `toForwardSlash` from `cli/src/core/PathUtils.ts`; never inline `.replace(/\\/g,"/")`.
+- **Batch cadence**: per the repo convention, do NOT run `npm run all` + commit per task. Write code (tests + impl) task-by-task; run `npm run all` + one DCO-signed commit at the **end of each Phase**.
+- **Branch**: `feature/zoom-mcp-integration`.
+
+---
+
+## Phase 1 — `zoom-meeting` (independent; ship now)
+
+No dependency on the Slack seam. Pure-DSL definition.
+
+### Task 1: `zoom-meeting` SourceDefinition + GoldenParity test
+
+**Files:**
+- Create: `cli/src/core/references/sources/definitions/zoom-meeting.ts`
+- Create: `cli/src/core/references/sources/definitions/zoom-meeting.test.ts`
+
+**Interfaces:**
+- Consumes: `SourceDefinition` from `../../SourceDefinition.js`; `extractRef`, `renderBlock` from `../../SourceEngine.js`.
+- Produces: `export const zoomMeetingDefinition: SourceDefinition` (id `"zoom-meeting"`).
+
+- [ ] **Step 1: Write the failing test** — `cli/src/core/references/sources/definitions/zoom-meeting.test.ts`
+
+```ts
+import { describe, expect, it } from "vitest";
+import { extractRef, renderBlock } from "../../SourceEngine.js";
+import { zoomMeetingDefinition as def } from "./zoom-meeting.js";
+
+// Trimmed from the real 2026-07-08 get_meeting_assets payload (design spec §6).
+const REAL_PAYLOAD = {
+	meeting_summary: {
+		summary_markdown: "## Quick recap\nFlyer and Joe updated a GitHub app slug.\n## Next steps\n- Verify dev.",
+		summary_plain_text: "Quick recap ...",
+		has_permission: true,
+		has_summary: true,
+		summary_doc_url: "https://docs.zoom.us/doc/y_sTD3ZsQv-o-f2pw3IQCA",
+	},
+	meeting_transcript: { transcript_items: [{ start: "00:00:50.000", text: "hi", end: "00:00:52.000" }], primary_language: "en" },
+	my_notes: { has_my_notes: false },
+	meeting_number: 4456640966,
+	deep_url: "https://jolli.zoom.us/launch/edl?muid=1764e7b0-e935-4084-8e29-ce48ab11ab1c",
+	start_time: "2026-06-16T02:19:12Z",
+	end_time: "2026-06-16T02:26:41Z",
+	meeting_uuid: "25955010-93C3-48E7-9F25-9D98CE6B69F7",
+	topic: "Flyer Li's Personal Meeting Room",
+	meeting_category: "history",
+};
+const TOOL = "mcp__claude_ai_Zoom_for_Claude__get_meeting_assets";
+const AT = "2026-07-08T00:00:00Z";
+
+describe("zoom-meeting definition", () => {
+	it("extracts a Reference from a real get_meeting_assets payload", () => {
+		const ref = extractRef(def, REAL_PAYLOAD, TOOL, AT);
+		expect(ref).not.toBeNull();
+		expect(ref?.source).toBe("zoom-meeting");
+		expect(ref?.nativeId).toBe("25955010-93C3-48E7-9F25-9D98CE6B69F7");
+		expect(ref?.mapKey).toBe("zoom-meeting:25955010-93C3-48E7-9F25-9D98CE6B69F7");
+		expect(ref?.title).toBe("Flyer Li's Personal Meeting Room");
+		expect(ref?.url).toBe("https://docs.zoom.us/doc/y_sTD3ZsQv-o-f2pw3IQCA");
+		expect(ref?.description).toContain("Quick recap");
+		expect(ref?.fields).toEqual([
+			{ key: "entity-type", label: "Type", icon: "symbol-class", value: "meeting" },
+			{ key: "started", label: "Started", icon: "calendar", value: "2026-06-16T02:19:12Z" },
+			{ key: "meeting-number", label: "Meeting #", icon: "symbol-number", value: "4456640966" },
+		]);
+	});
+
+	it("falls back to deep_url when summary_doc_url is absent", () => {
+		const p = { ...REAL_PAYLOAD, meeting_summary: { ...REAL_PAYLOAD.meeting_summary, summary_doc_url: undefined } };
+		expect(extractRef(def, p, TOOL, AT)?.url).toBe(REAL_PAYLOAD.deep_url);
+	});
+
+	it("voids a meeting with no summary body (guard)", () => {
+		const p = { ...REAL_PAYLOAD, meeting_summary: { has_permission: true, has_summary: false } };
+		expect(extractRef(def, p, TOOL, AT)).toBeNull();
+	});
+
+	it("renders a <zoom-meetings> block", () => {
+		const ref = extractRef(def, REAL_PAYLOAD, TOOL, AT);
+		if (ref === null) throw new Error("expected ref");
+		const xml = renderBlock(def, [ref]);
+		expect(xml).toContain("<zoom-meetings>");
+		expect(xml).toContain('<meeting id="25955010-93C3-48E7-9F25-9D98CE6B69F7"');
+		expect(xml).toContain("<summary>");
+		expect(xml).toContain("</zoom-meetings>");
+	});
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd cli && npx vitest run src/core/references/sources/definitions/zoom-meeting.test.ts`
+Expected: FAIL — `Cannot find module './zoom-meeting.js'`.
+
+- [ ] **Step 3: Write the definition** — `cli/src/core/references/sources/definitions/zoom-meeting.ts`
+
+```ts
+/**
+ * Zoom meeting built-in source — pure-DSL over the get_meeting_assets result.
+ *
+ * The payload is a single meeting object (not a list), so wrapperKeys is empty
+ * and walkPayload runs extractRef on the top-level object directly. Self-contained:
+ * meeting_uuid / topic / summary_doc_url are all in the result, so no normalize
+ * and no tool_use.input is needed (contrast zoom-doc).
+ *
+ * Guard: require a non-empty meeting_summary.summary_markdown — a meeting with no
+ * AI summary voids rather than producing an empty-bodied reference.
+ * url: prefer the summary doc; fall back to the always-present deep_url.
+ */
+
+import type { SourceDefinition } from "../../SourceDefinition.js";
+
+export const zoomMeetingDefinition: SourceDefinition = {
+	id: "zoom-meeting",
+	label: "Zoom Meeting",
+	icon: "device-camera-video",
+	match: {
+		claude: { prefixes: ["mcp__claude_ai_Zoom_for_Claude__"], acceptSuffix: "get_meeting_assets" },
+	},
+	wrapperKeys: [],
+	reference: {
+		guard: { pipe: [{ op: "path", path: "meeting_summary.summary_markdown" }], require: ".+" },
+		nativeId: { pipe: [{ op: "path", path: "meeting_uuid" }], require: ".+" },
+		title: { pipe: [{ op: "path", path: "topic" }], require: ".+" },
+		url: {
+			pipe: [
+				{
+					op: "coalesce",
+					of: [[{ op: "path", path: "meeting_summary.summary_doc_url" }], [{ op: "path", path: "deep_url" }]],
+				},
+			],
+			require: "^https://",
+		},
+		description: { pipe: [{ op: "path", path: "meeting_summary.summary_markdown" }], optional: true },
+	},
+	fields: [
+		{ key: "entity-type", label: "Type", icon: "symbol-class", pipe: [{ op: "const", value: "meeting" }] },
+		{ key: "started", label: "Started", icon: "calendar", pipe: [{ op: "path", path: "start_time" }] },
+		{ key: "meeting-number", label: "Meeting #", icon: "symbol-number", pipe: [{ op: "path", path: "meeting_number" }] },
+	],
+	storage: { nativeIdPathSafe: true },
+	render: {
+		wrapperTag: "zoom-meetings",
+		itemTag: "meeting",
+		bodyTag: "summary",
+		maxCharsPerReference: 20000,
+		maxTotalChars: 40000,
+	},
+};
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd cli && npx vitest run src/core/references/sources/definitions/zoom-meeting.test.ts`
+Expected: PASS (4 tests).
+
+> Note: if the `meeting-number` field assertion fails because `meeting_number` (a JSON number) stringifies unexpectedly, confirm `toScalar` renders `4456640966` → `"4456640966"`; the `path` op reads the raw number and the engine scalar-izes it (same path the GitHub `number` field uses). Adjust the expected string only if the engine's number formatting differs.
+
+### Task 2: Register `zoom-meeting` + resolver test
+
+**Files:**
+- Modify: `cli/src/core/references/sources/definitions/index.ts:10-15`
+- Modify: `cli/src/core/references/SourceDefinitionRegistry.test.ts` (add a describe block)
+
+**Interfaces:**
+- Consumes: `zoomMeetingDefinition` (Task 1); `getRegistry` from `../SourceDefinitionRegistry.js`.
+
+- [ ] **Step 1: Write the failing resolver test** — append to `SourceDefinitionRegistry.test.ts`
+
+```ts
+import { getRegistry } from "./SourceDefinitionRegistry.js"; // if not already imported
+
+describe("zoom-meeting registration", () => {
+	it("resolves get_meeting_assets to zoom-meeting", () => {
+		const def = getRegistry().match("claude", "mcp__claude_ai_Zoom_for_Claude__get_meeting_assets");
+		expect(def?.id).toBe("zoom-meeting");
+	});
+	it("does NOT match other Zoom tools (suffix gate)", () => {
+		expect(getRegistry().match("claude", "mcp__claude_ai_Zoom_for_Claude__search_meetings")).toBeUndefined();
+	});
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd cli && npx vitest run src/core/references/SourceDefinitionRegistry.test.ts -t "zoom-meeting"`
+Expected: FAIL — `match` returns `undefined` (def not registered).
+
+- [ ] **Step 3: Register the definition** — edit `sources/definitions/index.ts`
+
+```ts
+import { githubDefinition } from "./github.js";
+import { jiraDefinition } from "./jira.js";
+import { linearDefinition } from "./linear.js";
+import { notionDefinition } from "./notion.js";
+import { zoomMeetingDefinition } from "./zoom-meeting.js";
+
+export const BUILTIN_DEFINITIONS = [
+	linearDefinition,
+	jiraDefinition,
+	githubDefinition,
+	notionDefinition,
+	zoomMeetingDefinition,
+] as const;
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd cli && npx vitest run src/core/references/SourceDefinitionRegistry.test.ts -t "zoom-meeting"`
+Expected: PASS (2 tests).
+
+### Task 3: VS Code badge metadata (`SOURCE_META`)
+
+Cosmetic — `getSourceMeta` already falls back for unknown ids, so capture works without this. This gives the sidebar a proper "Zoom Meeting" label, Zoom-blue badge, and camera icon.
+
+**Files:**
+- Modify: `cli/src/Types.ts:713`
+- Modify: `vscode/src/views/SourceLabels.ts:37-42`
+- Modify: `vscode/src/views/SidebarScriptBuilder.test.ts` (assert the new entry)
+
+**Interfaces:**
+- Consumes: `KnownSourceId` union; `SOURCE_META` record (exhaustive over `KnownSourceId`).
+
+- [ ] **Step 1: Write the failing test** — add to `SidebarScriptBuilder.test.ts` (or `SourceLabels` test if one exists)
+
+```ts
+import { getSourceMeta } from "./SourceLabels.js"; // adjust relative path to the test file location
+
+it("has bespoke Zoom Meeting badge metadata", () => {
+	const m = getSourceMeta("zoom-meeting");
+	expect(m).toEqual({ label: "Zoom Meeting", letter: "Z", icon: "device-camera-video", color: "#2D8CFF" });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd vscode && npm run test -- -t "Zoom Meeting badge"`
+Expected: FAIL — `getSourceMeta("zoom-meeting")` returns the neutral fallback (`icon: "link"`, `color: "#6e7681"`).
+
+- [ ] **Step 3a: Extend `KnownSourceId`** — `cli/src/Types.ts:713`
+
+```ts
+export type KnownSourceId = "linear" | "jira" | "github" | "notion" | "zoom-meeting";
+```
+
+- [ ] **Step 3b: Add the `SOURCE_META` row** — `vscode/src/views/SourceLabels.ts`
+
+```ts
+export const SOURCE_META: Record<KnownSourceId, SourceMeta> = {
+	linear: { label: "Linear", letter: "L", icon: "issues", color: "#5e6ad2" },
+	jira: { label: "Jira", letter: "J", icon: "issues", color: "#0052cc" },
+	github: { label: "GitHub", letter: "G", icon: "issues", color: "#6e7681" },
+	notion: { label: "Notion", letter: "N", icon: "file-text", color: "#787774" },
+	"zoom-meeting": { label: "Zoom Meeting", letter: "Z", icon: "device-camera-video", color: "#2D8CFF" },
+};
+```
+
+> TypeScript enforces exhaustiveness: after Step 3a, the build fails until this row is added.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd vscode && npm run test -- -t "Zoom Meeting badge"`
+Expected: PASS.
+
+### Task 4: Phase 1 verification gate + commit
+
+- [ ] **Step 1: Verify against a REAL transcript (spec §8 gate #3).** In a repo where Jolli is enabled, use `get_meeting_assets` from Claude Code, then confirm the tool_result was recorded intact in the Claude transcript JSONL (`~/.claude/projects/.../*.jsonl`) — specifically that `meeting_summary.summary_markdown` survives (it precedes the large `transcript_items` array in the object). Run `jolli` reference discovery over that transcript and confirm a `zoom-meeting` reference is produced.
+
+Run: `grep -l "get_meeting_assets" ~/.claude/projects/*/*.jsonl` then inspect the matching line's `tool_result` content.
+Expected: the JSONL line contains the full `meeting_summary` object. If Claude Code truncates the result below the summary, escalate — the guard would void and capture silently yields nothing.
+
+- [ ] **Step 2: Full gate.**
+
+Run: `npm run all`
+Expected: clean → build → lint → test all pass; CLI coverage ≥ 97/96/97/97.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add cli/src/core/references/sources/definitions/zoom-meeting.ts \
+        cli/src/core/references/sources/definitions/zoom-meeting.test.ts \
+        cli/src/core/references/sources/definitions/index.ts \
+        cli/src/core/references/SourceDefinitionRegistry.test.ts \
+        cli/src/Types.ts \
+        vscode/src/views/SourceLabels.ts \
+        vscode/src/views/SidebarScriptBuilder.test.ts
+git commit -s -m "Add zoom-meeting reference source (get_meeting_assets)"
+```
+
+---
+
+## Phase 2 — `zoom-doc` (`hub_get_file_content`)
+
+`ZoomDocNormalize` and the `zoom-doc` definition are implementable **now** (Tasks 5–6, no Slack dependency). Only the final envelope wiring (Task 7) is **blocked** on the Slack work landing the shared Claude-MCP `normalize` seam. Do Tasks 5–6 now; do Task 7 once that seam merges, mirroring its API.
+
+### Task 5: `ZoomDocNormalize` pure function + unit test
+
+The canonical-shape builder. Independent of Slack — it is a plain `(result, toolInput) → canonical` function.
+
+**Files:**
+- Create: `cli/src/core/references/bindings/claude/ZoomDocNormalize.ts`
+- Create: `cli/src/core/references/bindings/claude/ZoomDocNormalize.test.ts`
+
+**Interfaces:**
+- Produces: `export function zoomDocNormalize(result: unknown, toolInput: unknown): unknown` — returns `{ fileId, title, content, url }` on success, or a shape lacking `fileId`/`url` (which the definition voids) on malformed input. **Never throws.**
+
+- [ ] **Step 1: Write the failing test** — `ZoomDocNormalize.test.ts`
+
+```ts
+import { describe, expect, it } from "vitest";
+import { zoomDocNormalize } from "./ZoomDocNormalize.js";
+
+// Real 2026-07-08 hub_get_file_content result (design spec §6): fileId is NOT in the result.
+const RESULT = { file_name: "Flyer Li's Personal Meeting Room", file_content: "## Quick recap\n..." };
+const INPUT = { fileId: "y_sTD3ZsQv-o-f2pw3IQCA", format: "markdown" };
+
+describe("zoomDocNormalize", () => {
+	it("merges fileId from tool input and builds the doc url", () => {
+		expect(zoomDocNormalize(RESULT, INPUT)).toEqual({
+			fileId: "y_sTD3ZsQv-o-f2pw3IQCA",
+			title: "Flyer Li's Personal Meeting Room",
+			content: "## Quick recap\n...",
+			url: "https://docs.zoom.us/doc/y_sTD3ZsQv-o-f2pw3IQCA",
+		});
+	});
+
+	it("returns a fileId-less (voiding) shape when input has no fileId", () => {
+		const out = zoomDocNormalize(RESULT, { format: "markdown" }) as Record<string, unknown>;
+		expect(out.fileId).toBeUndefined();
+		expect(out.url).toBeUndefined();
+	});
+
+	it("does not throw on non-object result or input", () => {
+		expect(() => zoomDocNormalize(null, null)).not.toThrow();
+		expect(() => zoomDocNormalize("oops", 42)).not.toThrow();
+	});
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd cli && npx vitest run src/core/references/bindings/claude/ZoomDocNormalize.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement** — `ZoomDocNormalize.ts`
+
+```ts
+/**
+ * Canonical-shape builder for the zoom-doc source.
+ *
+ * hub_get_file_content's result is only { file_name, file_content } — the fileId
+ * lives ONLY in the tool-call input. This merges the two and builds the public
+ * doc url (a pure function of fileId; no config, unlike Slack). Defensive: any
+ * malformed input yields a shape without fileId/url, which the zoom-doc
+ * definition's `require` then voids. Never throws.
+ */
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+	return typeof v === "object" && v !== null;
+}
+
+export function zoomDocNormalize(result: unknown, toolInput: unknown): unknown {
+	const res = isRecord(result) ? result : {};
+	const input = isRecord(toolInput) ? toolInput : {};
+	const fileId = typeof input.fileId === "string" && input.fileId.length > 0 ? input.fileId : undefined;
+	const title = typeof res.file_name === "string" ? res.file_name : undefined;
+	const content = typeof res.file_content === "string" ? res.file_content : undefined;
+	const url = fileId !== undefined ? `https://docs.zoom.us/doc/${fileId}` : undefined;
+	return { fileId, title, content, url };
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd cli && npx vitest run src/core/references/bindings/claude/ZoomDocNormalize.test.ts`
+Expected: PASS (3 tests).
+
+### Task 6: `zoom-doc` SourceDefinition + test (over the canonical shape)
+
+**Files:**
+- Create: `cli/src/core/references/sources/definitions/zoom-doc.ts`
+- Create: `cli/src/core/references/sources/definitions/zoom-doc.test.ts`
+
+**Interfaces:**
+- Consumes: `SourceDefinition`; the canonical shape from `zoomDocNormalize` (Task 5).
+- Produces: `export const zoomDocDefinition: SourceDefinition` (id `"zoom-doc"`).
+
+- [ ] **Step 1: Write the failing test** — `zoom-doc.test.ts`
+
+```ts
+import { describe, expect, it } from "vitest";
+import { extractRef, renderBlock } from "../../SourceEngine.js";
+import { zoomDocDefinition as def } from "./zoom-doc.js";
+
+// The definition runs over the POST-normalize canonical shape (Task 5 output).
+const CANONICAL = {
+	fileId: "y_sTD3ZsQv-o-f2pw3IQCA",
+	title: "Flyer Li's Personal Meeting Room",
+	content: "## Quick recap\n...",
+	url: "https://docs.zoom.us/doc/y_sTD3ZsQv-o-f2pw3IQCA",
+};
+const TOOL = "mcp__claude_ai_Zoom_for_Claude__hub_get_file_content";
+const AT = "2026-07-08T00:00:00Z";
+
+describe("zoom-doc definition", () => {
+	it("extracts a Reference from the canonical shape", () => {
+		const ref = extractRef(def, CANONICAL, TOOL, AT);
+		expect(ref?.source).toBe("zoom-doc");
+		expect(ref?.nativeId).toBe("y_sTD3ZsQv-o-f2pw3IQCA");
+		expect(ref?.title).toBe("Flyer Li's Personal Meeting Room");
+		expect(ref?.url).toBe("https://docs.zoom.us/doc/y_sTD3ZsQv-o-f2pw3IQCA");
+		expect(ref?.description).toContain("Quick recap");
+		expect(ref?.fields).toEqual([{ key: "entity-type", label: "Type", icon: "symbol-class", value: "doc" }]);
+	});
+
+	it("voids when fileId (nativeId) is missing", () => {
+		expect(extractRef(def, { ...CANONICAL, fileId: undefined, url: undefined }, TOOL, AT)).toBeNull();
+	});
+
+	it("renders a <zoom-docs> block", () => {
+		const ref = extractRef(def, CANONICAL, TOOL, AT);
+		if (ref === null) throw new Error("expected ref");
+		expect(renderBlock(def, [ref])).toContain("<zoom-docs>");
+		expect(renderBlock(def, [ref])).toContain("<content>");
+	});
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd cli && npx vitest run src/core/references/sources/definitions/zoom-doc.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement** — `zoom-doc.ts`
+
+```ts
+/**
+ * Zoom Hub doc built-in source — pure `path` DSL over the ZoomDocNormalize
+ * canonical shape ({ fileId, title, content, url }). The messy work (fileId
+ * from tool input, url construction) lives in ZoomDocNormalize; this definition
+ * only selects fields. Requires the shared Claude-MCP normalize seam to be wired
+ * (see plan Task 7).
+ */
+
+import type { SourceDefinition } from "../../SourceDefinition.js";
+
+export const zoomDocDefinition: SourceDefinition = {
+	id: "zoom-doc",
+	label: "Zoom Doc",
+	icon: "file",
+	match: {
+		claude: { prefixes: ["mcp__claude_ai_Zoom_for_Claude__"], acceptSuffix: "hub_get_file_content" },
+	},
+	wrapperKeys: [],
+	reference: {
+		nativeId: { pipe: [{ op: "path", path: "fileId" }], require: "^[\\w.-]+$" },
+		title: { pipe: [{ op: "path", path: "title" }], require: ".+" },
+		url: { pipe: [{ op: "path", path: "url" }], require: "^https://docs\\.zoom\\.us/doc/" },
+		description: { pipe: [{ op: "path", path: "content" }], optional: true },
+	},
+	fields: [{ key: "entity-type", label: "Type", icon: "symbol-class", pipe: [{ op: "const", value: "doc" }] }],
+	storage: { nativeIdPathSafe: true },
+	render: {
+		wrapperTag: "zoom-docs",
+		itemTag: "doc",
+		bodyTag: "content",
+		maxCharsPerReference: 30000,
+		maxTotalChars: 60000,
+	},
+};
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd cli && npx vitest run src/core/references/sources/definitions/zoom-doc.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Register + badge (mirror Tasks 2 & 3).** Add `zoomDocDefinition` to `BUILTIN_DEFINITIONS` in `sources/definitions/index.ts`; extend `KnownSourceId` (`cli/src/Types.ts`) with `"zoom-doc"`; add the `SOURCE_META` row `"zoom-doc": { label: "Zoom Doc", letter: "Z", icon: "file", color: "#2D8CFF" }` (`vscode/src/views/SourceLabels.ts`). Add resolver + badge tests mirroring Task 2 Step 1 and Task 3 Step 1 (assert `match("claude", "mcp__claude_ai_Zoom_for_Claude__hub_get_file_content")?.id === "zoom-doc"` and `getSourceMeta("zoom-doc")`).
+
+### Task 7: Wire `ZoomDocNormalize` into the envelope — BLOCKED on the Slack seam
+
+**Prerequisite:** the parallel Slack work must have merged (a) the `ClaudeEnvelopeParser` MCP branch retaining `tool_use.input`, and (b) a per-def normalize registry under `bindings/claude/` (the `getClaudeNormalizer(defId)` analog of Codex's `getCodexNormalizer`). Rebase onto that branch first. **Do not implement the seam here** — the Slack change owns it.
+
+**Files (to confirm against the merged Slack API):**
+- Modify: `cli/src/core/references/ClaudeEnvelopeParser.ts` (the MCP branch around `:171`) — only if Slack's version does not already thread input generically.
+- Modify: `cli/src/core/references/bindings/claude/index.ts` — register `zoom-doc → zoomDocNormalize` in the normalizer map Slack introduces.
+- Modify: `cli/src/core/references/bindings/claude/index.test.ts`
+
+- [ ] **Step 1: Read the merged Slack seam.** Read `ClaudeEnvelopeParser.ts` and `bindings/claude/index.ts` on the rebased branch to learn the exact `getClaudeNormalizer` signature and how `tool_use.input` reaches `normalize` (mirror Slack doc change-set #1/#2). Record the real signature before writing any code — do not assume it matches this plan's guess.
+
+- [ ] **Step 2: Write the failing envelope test** — `bindings/claude/index.test.ts` (adapt to the real API)
+
+```ts
+// Given a Claude transcript tool_use(hub_get_file_content, input:{fileId}) + tool_result({file_name,file_content}),
+// the envelope produces a NormalizedToolResult whose payload is the ZoomDocNormalize canonical shape
+// (fileId merged from input, url built). Assert payload.url === "https://docs.zoom.us/doc/<fileId>".
+```
+
+- [ ] **Step 3: Register the normalizer.** Add `zoom-doc → zoomDocNormalize` to the `getClaudeNormalizer` map (exact call site per Step 1).
+
+- [ ] **Step 4: Run the envelope test.** Expected: PASS — `tool_use.input.fileId` is threaded to `zoomDocNormalize` and the canonical url appears on the payload.
+
+### Task 8: Phase 2 verification gate + commit
+
+- [ ] **Step 1: Verify against a REAL transcript (spec §8 gate #4).** Confirm a real Claude Code transcript records `hub_get_file_content`'s input under `input` with the key `fileId` (exact casing). If the recorded key differs (e.g. `file_id`), fix `zoomDocNormalize`'s input read and its test fixture to match the real key.
+
+Run: `grep -o '"name":"[^"]*hub_get_file_content"[^}]*"input":{[^}]*}' ~/.claude/projects/*/*.jsonl | head`
+Expected: the `input` object shows the real fileId key name.
+
+- [ ] **Step 2: Full gate.** Run: `npm run all` — Expected: all pass; coverage ≥ 97/96/97/97.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add cli/src/core/references/bindings/claude/ \
+        cli/src/core/references/sources/definitions/zoom-doc.ts \
+        cli/src/core/references/sources/definitions/zoom-doc.test.ts \
+        cli/src/core/references/sources/definitions/index.ts \
+        cli/src/core/references/ClaudeEnvelopeParser.ts \
+        cli/src/Types.ts vscode/src/views/SourceLabels.ts
+git commit -s -m "Add zoom-doc reference source (hub_get_file_content)"
+```

--- a/docs/superpowers/specs/2026-07-08-zoom-context-capture-design.md
+++ b/docs/superpowers/specs/2026-07-08-zoom-context-capture-design.md
@@ -1,0 +1,218 @@
+# Zoom Meeting & Doc Context Capture Design
+
+- **Date**: 2026-07-08
+- **Status**: Design under review
+- **Goal**: Capture Zoom **meeting assets** (AI summary + next steps) and **Zoom Hub docs** that an AI agent reads via the Zoom for Claude MCP server during a session, turning each into a `Reference` injected into Working Memory (the SUMMARIZE prompt) and stored alongside the existing Linear / Jira / GitHub / Notion references.
+- **Relationship to prior work**: A **separate new feature** that builds on JOLLI-1877 (the `SourceDefinition` / `SourceEngine` / envelope architecture). It is the direct analog of the [Slack Thread Context Capture design](2026-07-07-slack-thread-context-capture-design.md); the Slack work is landing the shared Claude-MCP `normalize` seam that `zoom-doc` depends on, and Zoom mirrors that implementation rather than re-deriving it.
+
+---
+
+## 1. Background & the fit assessment
+
+JOLLI-1877 established a reference pipeline: an **Envelope** layer recognizes an MCP tool call + return payload in a transcript line, a **`SourceDefinition`** (declarative, data-only, 7-op DSL) describes how to extract a `Reference`, and the **`SourceEngine`** evaluates it. The reference pipeline is **not an MCP client** — it replays the tool call + result that Claude Code / Codex already recorded in its on-disk transcript JSONL. The interactively-authenticated `claude.ai` Zoom connector therefore cannot be called headlessly by Jolli; the only supported ingestion path is: agent calls `mcp__claude_ai_Zoom_for_Claude__*` during a session → the call + payload land in the transcript → a Zoom `SourceDefinition` extracts it.
+
+Two Zoom tools are in scope, and they sit at **opposite ends** of the fit spectrum:
+
+- **`get_meeting_assets`** — a **well-shaped, structured JSON** payload with a stable `meeting_uuid` / `topic` / `summary_doc_url` in the result. It is the happy path: a **pure-DSL definition, zero engine change**, on par with `notion.ts`.
+- **`hub_get_file_content`** — a **partial** payload: the result is only `{ file_name, file_content }`. The document's `fileId` (needed for both `nativeId` and the doc URL) exists **only in the tool-call input**, which the envelope currently discards for MCP calls (`normalize: identity`). This is the same "input not retained" gap Slack hit, and it needs the shared Claude-MCP `normalize` seam.
+
+**Why Zoom is simpler than Slack:** Slack needed three things Zoom does not — a configured workspace URL (Zoom's doc URL is `https://docs.zoom.us/doc/<fileId>`, derivable from the input alone), an `optional`-url engine change (both Zoom tools stably produce a URL), and a VS Code config-needed hint. Zoom reuses only Slack's input-threading seam.
+
+---
+
+## 2. Decisions (from brainstorming)
+
+| Decision point | Choice | Rationale |
+|---|---|---|
+| Definition granularity | **Two independent sources**: `zoom-meeting` + `zoom-doc` | Heterogeneous payloads, different render buckets, and only `zoom-doc` needs a `normalize`. Keeps `zoom-meeting` decoupled from the Slack seam. Mirrors the single-tool `acceptSuffix` pattern of `notion.ts`. |
+| `zoom-meeting` body | **AI summary only** (`meeting_summary.summary_markdown`) | The summary already carries Quick recap + Next steps (the distilled, high-value content). The full transcript is an **object array** (`transcript_items[{start,text,end}]`) the DSL cannot join, would force a `normalize` onto the otherwise-pure-DSL meeting source, balloons context/token cost, and risks JSONL truncation. |
+| `zoom-doc` `url` source | **Construct `https://docs.zoom.us/doc/<fileId>` from the tool-call input** | The result has no id; `fileId` is in the input. Unlike Slack, **no config** is needed — the public doc URL is a pure function of `fileId`. |
+| Where the messy work lives (`zoom-doc`) | **Code-side `normalize`** (merge `fileId` from input + build url); DSL definition only selects fields | Matches JOLLI-1877's philosophy: normalize stays as code, the DSL sees the canonical payload. |
+| Shared seam ownership | **Consume the Claude-MCP `normalize` seam delivered by the Slack work**; do not re-implement | Avoids two divergent implementations of the same envelope change. |
+| Sequencing | **Phase 1 = `zoom-meeting` (independent, ship now); Phase 2 = `zoom-doc` (after the Slack seam lands)** | `zoom-meeting` has zero dependency and proves the source end-to-end immediately. |
+
+### Explicitly NOT in scope
+
+- **No config schema.** (Contrast Slack's `slack.workspaceUrl`.)
+- **No `url`-optional engine change.** Both tools stably produce a URL; the other definitions stay hard-required, unchanged.
+- **No VS Code config-needed hint / toast.**
+- **Meeting transcript, participants, whiteboards, agenda_doc, recording** capture — out of scope. Only the AI summary is captured for meetings.
+- **`search_meetings` / `search_zoom` / `get_recording_resource` / `recordings_list`** — not reference-producing triggers in v1 (list/search return candidates and fragments, not a single titled entity; recordings are unused in practice — see Observed Reality).
+
+---
+
+## 3. Data model
+
+### 3a. `zoom-meeting` (one meeting → one `Reference`)
+
+| `Reference` field | Value | Source |
+|---|---|---|
+| `mapKey` / `nativeId` | `zoom-meeting:<meeting_uuid>` / `<meeting_uuid>` (e.g. `25955010-93C3-48E7-9F25-9D98CE6B69F7`) | result |
+| `title` | `topic` | result |
+| `url` | `coalesce(meeting_summary.summary_doc_url, deep_url)`, require `^https://` | result |
+| `description` | `meeting_summary.summary_markdown`, optional | result |
+| `fields[]` | `entity-type=meeting`, `started=<start_time>`, `meeting-number=<meeting_number>` | result |
+| `referencedAt` | transcript timestamp | envelope |
+
+- **Guard**: `meeting_summary.has_summary === true` — a meeting instance with no AI summary (e.g. the empty PMI instance seen in Observed Reality) voids, so we never store an empty-bodied meeting reference.
+- **Path safety**: `meeting_uuid` is hex + `-` only → `storage.nativeIdPathSafe: true` (identity, `..`/`/\` guard passes).
+- **Pure DSL** — no `normalize`. Depends on nothing outside the merged JOLLI-1877 engine.
+
+### 3b. `zoom-doc` (one Hub doc read → one `Reference`)
+
+| `Reference` field | Value | Source |
+|---|---|---|
+| `mapKey` / `nativeId` | `zoom-doc:<fileId>` / `<fileId>` (e.g. `y_sTD3ZsQv-o-f2pw3IQCA`) | **tool input** |
+| `title` | `file_name` | result |
+| `url` | `https://docs.zoom.us/doc/<fileId>` | input (constructed) |
+| `description` | `file_content`, optional | result |
+| `fields[]` | `entity-type=doc` | const |
+| `referencedAt` | transcript timestamp | envelope |
+
+- **Path safety**: `fileId` (`y_sTD3ZsQv-o-f2pw3IQCA`) matches `[\w.-]+` → `storage.nativeIdPathSafe: true`.
+- **Needs `normalize`** (`ZoomDocNormalize`): the canonical shape is `{ fileId, title, content, url }`, merging `fileId` from `toolInput`; `zoom-doc.ts` is then a trivial `path`-only definition over that shape.
+
+---
+
+## 4. Architecture & change set
+
+```
+transcript ──▶ ClaudeEnvelopeParser
+                 · zoom-meeting: matched by acceptSuffix "get_meeting_assets", normalize: identity  (Phase 1)
+                 · zoom-doc:     matched by acceptSuffix "hub_get_file_content";
+                                 [SHARED SEAM, from Slack work] MCP branch retains tool_use.input and
+                                 hands it to a per-def normalize (getClaudeNormalizer)                (Phase 2)
+                 ▼
+              SourceEngine.extractRef(def, canonicalPayload)   ← DSL only selects fields (unchanged)
+                 ▼
+              Reference → ReferenceStore → assembleReferenceBlocks / renderBlock   ← unchanged
+```
+
+### Phase 1 — `zoom-meeting` (independent)
+
+1. **`cli/src/core/references/sources/definitions/zoom-meeting.ts`** — a pure-DSL `SourceDefinition`:
+   - `match: { claude: { prefixes: ["mcp__claude_ai_Zoom_for_Claude__"], acceptSuffix: "get_meeting_assets" } }`
+   - `wrapperKeys: []` (the payload is a single meeting object, not a list)
+   - `reference`: guard (`has_summary`), `nativeId`/`title`/`url`/`description` per §3a; `fields` per §3a
+   - `storage: { nativeIdPathSafe: true }`
+   - `render: { wrapperTag: "zoom-meetings", itemTag: "meeting", bodyTag: "summary", maxCharsPerReference: 20000, maxTotalChars: 40000 }`
+2. **Register** in `sources/definitions/index.ts` `BUILTIN_DEFINITIONS`.
+3. **VS Code `SOURCE_META`** gains one row: `"zoom-meeting": { label: "Zoom Meeting", letter: "Z", icon: "device-camera-video", color: "#2D8CFF" }`.
+4. **Codex parity** (`match.codex`): out of scope for v1 unless the Codex Zoom tool naming is confirmed against a real Codex rollout — Claude Code only for v1.
+
+### Phase 2 — `zoom-doc` (after the Slack shared seam lands)
+
+5. **Consume the shared Claude-MCP `normalize` seam** delivered by the Slack work (envelope retains `tool_use.input`; per-def `getClaudeNormalizer` registry under `bindings/claude/`). Mirror that implementation; do not fork it.
+6. **`cli/src/core/references/bindings/claude/ZoomDocNormalize.ts`** — defensively parses `{ file_name, file_content }` + merges `fileId` from `toolInput`, builds `url`, returns `{ fileId, title, content, url }`; unparseable / missing `fileId` → returns a shape that voids (never throws). Register in the `getClaudeNormalizer` map (`zoom-doc → zoomDocNormalize`).
+7. **`cli/src/core/references/sources/definitions/zoom-doc.ts`** — `path`-only DSL over the canonical shape; `acceptSuffix: "hub_get_file_content"`; `render: { wrapperTag: "zoom-docs", itemTag: "doc", bodyTag: "content", maxCharsPerReference: 30000, maxTotalChars: 60000 }`.
+8. **VS Code `SOURCE_META`** gains `"zoom-doc": { label: "Zoom Doc", letter: "Z", icon: "file", color: "#2D8CFF" }`.
+
+Everything downstream (`ReferenceStore`, `plans.json.references`, orphan snapshot, `assembleReferenceBlocks`, `Regenerator`, folder storage) is already generic and needs **no change**.
+
+---
+
+## 5. Rendering / injection
+
+No engine change — the existing slot vocabulary covers both:
+
+```jsonc
+// zoom-meeting
+"render": { "wrapperTag": "zoom-meetings", "itemTag": "meeting", "bodyTag": "summary",
+            "maxCharsPerReference": 20000, "maxTotalChars": 40000 }
+// zoom-doc
+"render": { "wrapperTag": "zoom-docs", "itemTag": "doc", "bodyTag": "content",
+            "maxCharsPerReference": 30000, "maxTotalChars": 60000 }
+```
+
+Injection reuses `assembleReferenceBlocks` (bucketed by source, `registry.all()` order).
+
+---
+
+## 6. Observed Reality (real payloads captured 2026-07-08)
+
+Captured live via the `claude.ai` Zoom for Claude connector. These are the pinned fixtures.
+
+### `recordings_list` — **empty in practice**
+
+`{ "total_records": 0, "meetings": [] }`. This org does not use Zoom **cloud recordings**; meeting knowledge lives entirely in **AI summaries + transcripts**. Any design keyed on "recording" artifacts would find nothing. (This is the exact class of at-rest assumption the integrating-external-systems skill warns about.)
+
+### `get_meeting_assets` (input `meetingId = "JZVQEJPDSOefJZ2Yzmtp9w=="`)
+
+Key shape (trimmed):
+
+```jsonc
+{
+  "meeting_summary": {
+    "summary_markdown": "## Quick recap\n…\n## Next steps\n…",
+    "summary_plain_text": "…",
+    "has_permission": true,
+    "has_summary": true,
+    "summary_doc_url": "https://docs.zoom.us/doc/y_sTD3ZsQv-o-f2pw3IQCA"
+  },
+  "meeting_transcript": {
+    "transcript_items": [ { "start": "00:00:50.000", "text": "…", "end": "00:00:52.000" }, … ],
+    "primary_language": "en"
+  },
+  "my_notes": { "has_my_notes": false },
+  "meeting_type": 4,
+  "meeting_number": 4456640966,
+  "deep_url": "https://jolli.zoom.us/launch/edl?muid=…",
+  "start_time": "2026-06-16T02:19:12Z",
+  "end_time": "2026-06-16T02:26:41Z",
+  "meeting_uuid": "25955010-93C3-48E7-9F25-9D98CE6B69F7",
+  "topic": "Flyer Li's Personal Meeting Room",
+  "meeting_category": "history"
+}
+```
+
+Pitfalls captured:
+- **Two ID forms coexist.** The input `meetingId` is the base64 form (`JZVQEJPDSOefJZ2Yzmtp9w==`); the result's `meeting_uuid` is the canonical `25955010-…`. `nativeId` uses the **result's `meeting_uuid`** (self-contained, no input needed).
+- **`transcript_items` is an object array** — not DSL-joinable (drives the "summary only" decision).
+- **`summary_doc_url` is present only when `has_summary`**; `deep_url` is always present → `url` coalesces the two.
+- **Permission is per-field.** `has_summary_permission` / `has_transcript_permission` vary per meeting (see `search_meetings`); `meeting_summary.has_permission` gates summary access. The guard (`has_summary`) already voids no-summary payloads.
+
+### `hub_get_file_content` (input `fileId = "y_sTD3ZsQv-o-f2pw3IQCA"`, `format = "markdown"`)
+
+```jsonc
+{ "file_name": "Flyer Li's Personal Meeting Room",
+  "file_content": "## Quick recap\n…" }
+```
+
+Pitfall captured: **the result contains no `fileId`.** `fileId` exists only in the tool-call **input** → `zoom-doc` requires the shared input-threading seam, and `url` is built as `https://docs.zoom.us/doc/<fileId>`. Doc content is bounded at 100 KB by the tool itself.
+
+### `search_meetings` / `search_zoom` (reference only, not v1 triggers)
+
+`search_meetings` returns a meeting list with `meeting_uuid`, `topic`, `attendees[{user_name}]`, `has_summary`, `has_transcript`, `has_summary_permission`, `next_page_token`. `search_zoom` (zoom_doc) returns `{ file_id, title, link, file_type, ancestors[], create_time, modify_time }`. Recorded for completeness; not consumed in v1.
+
+---
+
+## 7. Testing (real fixtures, defensive parsing)
+
+1. **Pinned real fixtures**: the two payloads in §6. `zoom-meeting` — a GoldenParity-style test asserts the final `Reference` + rendered `<zoom-meetings>` block. `zoom-doc` — a `ZoomDocNormalize` unit test asserts the canonical object, then the `Reference` + `<zoom-docs>` block.
+2. **Guard matrix (`zoom-meeting`)**: `has_summary: false` (the empty PMI instance) → voids, no reference produced.
+3. **URL coalesce (`zoom-meeting`)**: `summary_doc_url` present → used; absent (no summary but reference forced) → falls back to `deep_url`. (Guard normally prevents the no-summary case; test the coalesce directly.)
+4. **Envelope test (`zoom-doc`, Phase 2)**: `tool_use.input.fileId` is threaded through to `normalize`; url built correctly.
+5. **Defensive parsing (`zoom-doc`)**: missing `fileId` in input, or missing `file_name`/`file_content` → `normalize` returns a voiding shape, never throws.
+6. **Coverage**: hold 97/96/97/97; batch `npm run all` + a single DCO-signed commit at the end of each phase.
+
+---
+
+## 8. Pre-implementation verification gates
+
+Confirm against real data **before** writing the plan:
+
+1. ✅ **Real `get_meeting_assets` payload shape** — captured 2026-07-08; pinned.
+2. ✅ **Real `hub_get_file_content` payload shape** — captured 2026-07-08; pinned (`fileId` confirmed absent from result).
+3. ⚠️ **Large-result truncation** — the `get_meeting_assets` result (full transcript inline) can be large; confirm a real **Claude Code transcript JSONL** records the full tool_result and does not truncate it below the summary. If Claude Code truncates large tool results, `summary_markdown` may still be intact (it precedes the transcript in the object) but this must be checked on a real transcript.
+4. ⚠️ **tool_use input keys (`zoom-doc`)** — confirm a real Claude Code transcript records the input under `input` with key `fileId` (exact casing) for `hub_get_file_content`.
+5. ⏳ **Slack shared seam** — Phase 2 is blocked until the Slack work merges the envelope input-threading + `getClaudeNormalizer` registry. Rebase onto it and mirror, do not fork.
+
+---
+
+## 9. Out of scope (future)
+
+- Meeting transcript / participants / whiteboards / agenda capture.
+- `search_meetings` / `search_zoom` as reference triggers (would produce candidate lists, not single entities).
+- `get_recording_resource` capture (org uses AI summaries, not cloud recordings — see §6).
+- Codex parity for the Zoom tool namespace.
+- IntelliJ panel parity.

--- a/vscode/src/views/NextMemoryScriptBuilder.test.ts
+++ b/vscode/src/views/NextMemoryScriptBuilder.test.ts
@@ -41,6 +41,15 @@ describe("buildNextMemoryScript", () => {
 		expect(js).toContain("mem-ctx-badge");
 	});
 
+	it("derives the reference badge from referenceHover.source, not the codicon iconKey", () => {
+		// Regression: passing item.iconKey (e.g. 'device-camera-video' for a
+		// zoom-meeting) into ctxBadge misses SOURCE_META and falls back to a
+		// neutral 'D' badge; the sidebar keys off referenceHover.source ('Z').
+		const js = buildNextMemoryScript();
+		expect(js).toContain("item.referenceHover ? item.referenceHover.source");
+		expect(js).not.toContain("ctxBadge(item.contextValue, item.iconKey)");
+	});
+
 	it("renders file rows with the git-status letter", () => {
 		const js = buildNextMemoryScript();
 		expect(js).toContain("'gs gs-' + item.gitStatus");

--- a/vscode/src/views/NextMemoryScriptBuilder.ts
+++ b/vscode/src/views/NextMemoryScriptBuilder.ts
@@ -319,7 +319,13 @@ export function buildNextMemoryScript(): string {
     const aiExcluded = !!(rel && rel.autoExclude);
     // Main row: identity (badge + title) + hover-overlay actions only.
     const row = el('div', { className: 'row', 'data-id': item.id });
-    row.appendChild(ctxBadge(item.contextValue, item.iconKey));
+    // A reference badge's letter/hue keys off the SOURCE id (forwarded via
+    // referenceHover.source), NOT item.iconKey. iconKey is the codicon id (e.g.
+    // 'device-camera-video' for zoom-meeting), which misses SOURCE_META and
+    // falls back to a neutral 'D' badge. Mirrors the sidebar's renderPlanRow so
+    // both surfaces show the identical per-source square (e.g. 'Z' for Zoom).
+    const badgeSource = item.contextValue === 'reference' && item.referenceHover ? item.referenceHover.source : '';
+    row.appendChild(ctxBadge(item.contextValue, badgeSource));
     row.appendChild(el('div', { className: 'r-main' }, [el('div', { className: 'r-title', text: item.label })]));
     let toggleMsg;
     let removeCmd;

--- a/vscode/src/views/SourceLabels.test.ts
+++ b/vscode/src/views/SourceLabels.test.ts
@@ -34,4 +34,14 @@ describe("getSourceMeta", () => {
 			expect(meta.icon).toBe("link");
 		}
 	});
+
+	it("has bespoke Zoom Meeting badge metadata", () => {
+		const m = getSourceMeta("zoom-meeting");
+		expect(m).toEqual({ label: "Zoom Meeting", letter: "Z", icon: "device-camera-video", color: "#2D8CFF" });
+	});
+
+	it("has bespoke Zoom Doc badge metadata", () => {
+		const m = getSourceMeta("zoom-doc");
+		expect(m).toEqual({ label: "Zoom Doc", letter: "Z", icon: "file", color: "#2D8CFF" });
+	});
 });

--- a/vscode/src/views/SourceLabels.ts
+++ b/vscode/src/views/SourceLabels.ts
@@ -28,7 +28,7 @@ export interface SourceMeta {
 }
 
 /**
- * Metadata for the five built-in sources. Colors match the prior per-file
+ * Metadata for the seven built-in sources. Colors match the prior per-file
  * `.mem-ctx-badge--<source>` CSS rules byte-for-byte; letters match the prior
  * per-file switch statements, with one intentional normalization: the
  * hover-card badge previously showed 'GH' for GitHub while every other call
@@ -43,6 +43,8 @@ export const SOURCE_META: Record<KnownSourceId, SourceMeta> = {
 	github: { label: "GitHub", letter: "G", icon: "issues", color: "#6e7681" },
 	notion: { label: "Notion", letter: "N", icon: "file-text", color: "#787774" },
 	slack: { label: "Slack", letter: "S", icon: "comment-discussion", color: "#4a154b" },
+	"zoom-meeting": { label: "Zoom Meeting", letter: "Z", icon: "device-camera-video", color: "#2D8CFF" },
+	"zoom-doc": { label: "Zoom Doc", letter: "Z", icon: "file", color: "#2D8CFF" },
 };
 
 /** Neutral badge color for a source outside {@link SOURCE_META} (matches the prior `.mem-ctx-badge--reference` fallback hue). */


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer added Zoom meeting summaries and Hub documents as new reference sources that flow into the working memory context and persist alongside existing Linear, Jira, GitHub, and Notion references. Zoom meetings are captured with their UUID, topic, AI-generated summary, and a link to the summary document or meeting deep link using a pure DSL definition. Zoom Hub documents are captured with their file ID, title, content, and a public document URL, with a dedicated normalizer that merges file metadata from the API result with the file ID from the tool input. Both sources appear in the VS Code sidebar with distinct visual identity: blue color, camera icon for meetings, and file icon for documents.

A critical fix was added to recover oversized Zoom meeting payloads that Claude Code offloads to disk when they exceed the output limit. The envelope parser now detects the "Output has been saved to <path>" pointer pattern, validates the file path against a strict allowlist to prevent traversal attacks, reads the offloaded JSON from disk, and parses it. If recovery fails at any step, the parser safely falls back to dropping the result as before. This fix is transparent to downstream layers—once recovered, the payload flows through the existing reference extraction and storage unchanged.

The implementation reuses Slack's normalize pattern for consistency and refactored context-aware reference normalization from hardcoded branches into a data-driven registry, eliminating the ripple effect of adding new context-aware sources in the future. A secondary fix unified reference badge rendering across the sidebar and Next Memory preview page by ensuring both surfaces read the source ID from the serialized reference object rather than deriving it from the codicon icon, guaranteeing consistent badge appearance.

---

## Topics (8)
<details>
<summary><strong>01 · Recover oversized Zoom meeting summaries from offloaded tool results</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When Zoom meeting summaries exceed Claude Code's output size limit, the transcript contains only a file pointer instead of the JSON payload, causing the parser to silently drop the reference and lose meeting context from the knowledge system.

**💡 Decisions Behind the Code**

- **Recovery at the envelope layer**: The payload is not in the transcript at all—only the pointer is—so recovery must happen before DSL extraction. Asking the model to call a lighter-weight tool would not work because tool selection is not controllable. Placing recovery in the envelope parser keeps the fix localized and preserves the existing architecture where the parser is already Claude-Code-specific.
- **Incremental recovery over structural redesign**: Rather than redesigning how Claude Code offloads or how the parser buffers results, the fix detects the offload pointer in the existing error path and recovers the payload from disk. This keeps the change minimal and non-invasive—the parser's drop behavior for all other failures remains unchanged, and the recovery is purely additive.
- **Defensive path validation over trust**: The transcript content is untrusted, so a malicious or corrupted transcript could otherwise trick the parser into reading arbitrary files on disk. Validation requires absolute path, `tool-results/` segment presence, no `..` traversal, file not directory, and a 10 MB size cap.

**✅ What Was Implemented**

- Added `recoverOffloadedPayload()` function to detect the "Output has been saved to <path>" pointer pattern in the transcript, validate the file path (must be absolute, contain `tool-results/` as immediate parent, have no traversal attempts, be a regular file under 10MB), read the offloaded JSON from disk, and re-parse it. If recovery fails at any step, the parser safely falls back to dropping the result as before.
- Hardened containment checks by replacing `statSync` with `lstatSync` to reject symlinked files and tightening the `tool-results` segment check from "anywhere in path" to "must be the immediate parent directory" to prevent crafted pointers from accessing unrelated files.
- Added 12 targeted test cases covering the happy path, symlink rejection, nested directory rejection, oversized files, missing files, malformed JSON, and successful recovery of real meeting payloads.
- The recovery is transparent to downstream layers: once the payload is recovered and parsed, it flows through the existing reference extraction and storage unchanged.

**📋 Future Enhancements**

Investigate whether Claude Code ever performs inline truncation (leaving a half-parsed JSON in the transcript with no file pointer). If so, add detection for that case and either recover it or emit a more diagnostic warning than the current silent drop.

**📁 FILES**
- `cli/src/core/references/ClaudeEnvelopeParser.ts`
- `cli/src/core/references/ClaudeEnvelopeParser.test.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Add zoom-meeting reference source for Zoom meeting assets</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Zoom meeting summaries that an AI agent reads during a Claude Code session needed to be captured as references and persisted alongside existing Linear, Jira, GitHub, and Notion references.

**💡 Decisions Behind the Code**

- **Pure-DSL implementation without normalization**: All required fields (meeting_uuid, topic, summary_doc_url, deep_url) are already present in the get_meeting_assets result, so no normalize function is needed. This avoids unnecessary indirection and keeps the implementation lightweight.
- **Guard on summary_markdown ensures data quality**: Meetings without AI-generated summaries produce no reference rather than an empty-bodied one, maintaining data quality in the reference store.
- **URL preference for summary_doc_url over deep_url**: Prioritizes the AI-generated summary document when available, improving user experience by linking to richer context.
- **Suffix gate for precision**: The zoom-meeting source uses a suffix gate (matching only `get_meeting_assets`) rather than a broader pattern to avoid false positives with other Zoom tools in the MCP namespace. Only the specific tool Claude needs is registered, reducing the risk of accidentally capturing unrelated Zoom functionality.
- **Fail-fast validation**: Tightening the nativeId pattern upfront ensures invalid data is rejected at the source before it can propagate through the system and cause cryptic failures in unrelated code paths. Real UUIDs never trigger the looser pattern, so the stricter constraint has no impact on legitimate use cases while eliminating a class of latent bugs.

**✅ What Was Implemented**

- Created `zoom-meeting.ts` definition using pure DSL (no normalize function or tool_use.input needed). The definition extracts meeting UUID, topic, summary markdown, and URLs directly from the `get_meeting_assets` payload, with a guard requiring non-empty summary_markdown to avoid voiding meetings without AI summaries.
- Registered `zoomMeetingDefinition` in the builtin definitions index, making the zoom-meeting source available to the resolver alongside linear, jira, github, and notion sources.
- Added Zoom Meeting badge metadata to `SourceLabels.ts` with label "Zoom Meeting", letter "Z", icon "device-camera-video", and color "#2D8CFF" (matching Zoom's brand blue).
- Updated the `KnownSourceId` type in `cli/src/Types.ts` to include `"zoom-meeting"` alongside the existing four built-in sources.
- Tightened the `nativeId` validation pattern from `.+` (any non-empty string) to `^[\w-]+$` (word characters and hyphens only), matching the documented UUID shape and ensuring invalid IDs are caught at validation time rather than throwing errors downstream.
- Implemented `zoom-meeting.test.ts` with four test cases covering real payload extraction, URL fallback from summary_doc_url to deep_url, guard enforcement for missing summaries, and XML block rendering with the zoom-meetings wrapper tag.
- Added two resolver tests verifying that the `get_meeting_assets` tool resolves to the zoom-meeting source and that other Zoom tools do not match, validating the suffix-gate filtering logic.

**📁 FILES**
- `cli/src/core/references/sources/definitions/zoom-meeting.ts`
- `cli/src/Types.ts`
- `vscode/src/views/SourceLabels.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Add zoom-doc reference source for Zoom Hub documents</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Zoom Hub documents that an agent reads during a Claude Code session needed to be captured as references and persisted alongside existing Linear, Jira, GitHub, and Notion references.

**💡 Decisions Behind the Code**

- **Deduplication of tool prefixes is a genuine improvement**: The prefix list feeds a `.some()` pre-filter that only checks for substring presence; a repeated needle is redundant rather than incorrect. Deduplicating keeps the prefix set clean and avoids pointless duplicate checks on every line, while allowing two definitions to safely share the same MCP prefix and disambiguate later via `acceptSuffix`.
- **Shared MCP prefix with suffix-based disambiguation**: Both zoom-meeting and zoom-doc live under `mcp__claude_ai_Zoom_for_Claude__` but are distinguished by their `acceptSuffix` values (`get_meeting_assets` vs. `hub_get_file_content`). This mirrors the real Claude MCP tool structure and avoids artificial prefix duplication in the source definitions themselves.

**✅ What Was Implemented**

- Created `zoom-doc.ts` source definition that matches the Claude MCP tool `hub_get_file_content` under the shared Zoom prefix, extracting fileId as the native identifier and mapping title, content, and URL fields from the normalized canonical shape. The definition renders references in a `<zoom-docs>` wrapper with `<doc>` items and `<content>` body tags, supporting up to 30,000 characters per reference and 60,000 total.
- Added `zoom-doc` to the `KnownSourceId` type union and appended it to the `BUILTIN_DEFINITIONS` array in stable order after `zoom-meeting`, ensuring it appears in the registry's `.all()` list and is discoverable by the matching system.
- Updated the `CLAUDE_TOOL_PREFIXES` derivation to deduplicate prefixes via a `Set`, since both `zoom-meeting` and `zoom-doc` declare the same Claude MCP prefix. Without deduplication, registering zoom-doc would have added a duplicate substring to the pre-filter.
- Created `zoom-doc.test.ts` with three test cases: extraction of a Reference from the canonical shape, voiding when fileId is missing, and rendering a `<zoom-docs>` block with content tags.
- Added zoom-doc metadata to `SourceLabels.ts` with label "Zoom Doc", letter "Z", file icon, and the Zoom brand color (#2D8CFF), matching the visual treatment of zoom-meeting.

**📁 FILES**
- `cli/src/core/references/sources/definitions/zoom-doc.ts`
- `cli/src/Types.ts`
- `vscode/src/views/SourceLabels.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Wire zoom-doc normalization into Claude envelope parser</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The zoom-doc source was registered but inert—its normalization logic existed in isolation and was never called when processing Claude tool results.

**💡 Decisions Behind the Code**

- **Hardcoded branch pattern over registry (initial approach)**: Slack's implementation uses explicit `if (def.id === "slack")` branches in the envelope parser rather than a generic `getClaudeNormalizer` registry. Zoom-doc mirrors this pattern for consistency and simplicity—adding a second hardcoded branch is lower complexity than building a registry abstraction that would only serve two sources.
- **Closed-registry context normalizers (evolved approach)**: The commit refactored the hardcoded branches into a data-driven `CONTEXT_NORMALIZERS` registry to eliminate the ripple effect of adding new context-aware sources. Future sources only require a new registry entry, not a new code branch. This evolution preserves the simplicity of the initial approach while scaling to multiple sources without code duplication.
- **Null return for voiding**: The normalizer returns null when the result lacks required fields, and the envelope parser skips creating a Reference entry when null is returned. This is safer than returning a partial shape—it prevents incomplete references from entering the ledger and avoids silent data loss if the MCP result is malformed.
- **Context threading over input preservation**: Rather than passing the raw tool_use input object to the normalizer, the envelope parser extracts the fileId into a typed context object before calling the normalizer. This reduces the normalizer's defensive burden and makes the contract explicit.

**✅ What Was Implemented**

- Relocated `ZoomDocNormalize` from `bindings/claude/` to `sources/` alongside `SlackNormalize.ts`, aligning it with the actual wiring pattern used by Slack. Renamed the export to `normalizeZoomDoc` and changed its signature from `(result, toolInput)` to `(rawResult, ctx)` to match Slack's interface contract.
- Extended `ClaudeEnvelopeParser.collectToolResults()` to detect zoom-doc tool results and invoke `normalizeZoomDoc()` with the fileId extracted from the tool_use input, mirroring the existing Slack branch. The normalizer returns a canonical object or null; null results void the reference.
- Updated `PendingEntry.toolInput` documentation and the conditional that retains tool_use input to include zoom-doc alongside Slack, since both sources need out-of-payload context that the tool result itself does not carry.
- Added integration test verifying that a zoom-doc tool_use with fileId input and a file_content result produces a canonical payload with fileId, title, url, and content fields correctly merged.
- Refactored context-aware reference normalization (Slack and zoom-doc) from two separate code branches into a single data-driven `CONTEXT_NORMALIZERS` registry. This eliminates the ripple effect of adding new context-aware sources in the future: each new source requires only a registry entry, not a new `if (def.id === ...)` block. Membership is checked through a `Set` of own keys, mirroring the existing `SourceEngine` pattern to prevent prototype-chain ids from resolving a normalizer.

**📁 FILES**
- `cli/src/core/references/ClaudeEnvelopeParser.ts`
- `cli/src/core/references/sources/ZoomDocNormalize.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Create canonical-shape builder for Zoom document references</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The zoom-doc reference source needed to merge file metadata from the hub API result with the file ID from the tool input and construct the public document URL.

**💡 Decisions Behind the Code**

The function accepts both result and toolInput as parameters rather than extracting them from a larger context object. This keeps the normalizer stateless and testable in isolation, and allows it to be composed into larger reference-binding pipelines without coupling to any specific tool or envelope format. The defensive null-checking and type guards ensure the function never throws, shifting the responsibility for voiding incomplete records to the zoom-doc definition's `require` field, which is the appropriate layer for that decision.

**✅ What Was Implemented**

- Created `ZoomDocNormalize.ts` with a pure function that accepts the hub API result and tool input, merges the fileId from input with file_name and file_content from result, and constructs the Zoom docs URL (`https://docs.zoom.us/doc/{fileId}`). The function is defensive: it returns a shape without fileId/url when input is malformed, allowing the zoom-doc definition's `require` field to void incomplete records.
- Added comprehensive test coverage with four test cases: happy path (valid result and input merge correctly), missing fileId (returns voided shape), empty-string fileId (treated as missing), and robustness (does not throw on non-object inputs).

**📁 FILES**
- `cli/src/core/references/sources/ZoomDocNormalize.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Unify reference badge rendering across sidebar and Next Memory preview</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Next Memory review page showed a neutral "D" badge for Zoom meetings while the sidebar showed the correct blue "Z" badge for the same reference. The root cause was that Next Memory was passing the codicon icon ID instead of the source ID to the badge renderer.

**💡 Decisions Behind the Code**

**Single source of truth for badge identity**: The fix ensures both webviews read the same field (`referenceHover.source`) rather than each inventing its own path to the badge. This prevents future divergence and makes the badge identity decision a property of the serialized reference object, not the rendering code.

**✅ What Was Implemented**

- Modified `NextMemoryScriptBuilder.renderContextRow()` to read `item.referenceHover.source` (the semantic source identifier) instead of `item.iconKey` (the presentational codicon). This mirrors the sidebar's `renderPlanRow()` which already uses the correct field.
- The badge now correctly resolves to `SOURCE_META["zoom-meeting"]` yielding the letter "Z" and the blue color `#2D8CFF`, instead of falling back to `SOURCE_META["device-camera-video"]` (which does not exist) and producing a neutral "D".
- Added a regression test asserting that the badge source derives from `referenceHover.source`, not `iconKey`.

**📁 FILES**
- `vscode/src/views/NextMemoryScriptBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Update test expectations for new Zoom source definitions</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Adding zoom-meeting and zoom-doc as new source definitions broke existing tests that hard-assert the exact list of registered sources and the expected Claude tool prefixes.

**💡 Decisions Behind the Code**

The test assertions needed to be updated to match the new registry state rather than modifying the registry itself, because the tests document a contract: the stable order of definitions is a load-bearing constraint for downstream consumers like tool prefix mappings. Updating the tests ensures the contract remains explicit and verifiable.

**✅ What Was Implemented**

- Updated the stable-order test in `SourceDefinitionRegistry.test.ts` to expect the new zoom-meeting and zoom-doc definitions in the registry list, changing the assertion from `["linear", "jira", "github", "notion"]` to `["linear", "jira", "github", "notion", "zoom-meeting", "zoom-doc"]`.
- Updated the comment in the definitions index file to document that zoom-meeting and zoom-doc are appended after the four migrated definitions, clarifying the intentional ordering for consumers that depend on definition order.
- Updated the test description and expected array in `cli/src/core/references/bindings/claude/index.test.ts` to include the Zoom for Claude prefix (`mcp__claude_ai_Zoom_for_Claude__`) in the expected vendor prefix list.
- Added a dedicated test case verifying that `hub_get_file_content` resolves to the zoom-doc definition.

**📁 FILES**
- `cli/src/core/references/SourceDefinitionRegistry.test.ts`
- `cli/src/core/references/bindings/claude/index.test.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Design Zoom meeting and document context capture architecture</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team needed to capture Zoom meeting summaries and Hub documents that an AI agent reads during a Claude Code session, turning them into references that flow into the working memory context and persist alongside existing Linear, Jira, GitHub, and Notion references.

**💡 Decisions Behind the Code**

- **Two independent sources instead of one unified "Zoom" source**: `get_meeting_assets` and `hub_get_file_content` produce heterogeneous payloads with different render buckets and dependencies. Splitting them keeps `zoom-meeting` decoupled from the Slack seam and allows Phase 1 to ship independently, mirroring the single-tool `acceptSuffix` pattern already proven in `notion.ts`.
- **Meeting body is AI summary only, not full transcript**: The transcript is an object array (`transcript_items[{start,text,end}]`) that the DSL cannot join into text, forcing a `normalize` onto an otherwise pure-DSL source. Full transcript also balloons context size and risks JSONL truncation. The AI summary already carries the distilled, high-value content (Quick recap + Next steps), making it the optimal payload.
- **Construct doc URL from input `fileId` without config**: Unlike Slack (which needs a configured workspace URL), Zoom's doc URL is a pure function of `fileId` (`https://docs.zoom.us/doc/<fileId>`). This eliminates the need for a config schema, optional-url engine change, or VS Code config-needed hint—Zoom reuses only Slack's input-threading seam, not its full complexity.
- **Two-phase split with Phase 1 independent**: `zoom-meeting` requires no engine changes and no external dependencies, so it can ship immediately. `zoom-doc` is implementable now but its final envelope wiring must wait for the Slack work to land the shared normalize seam. This avoids blocking Phase 1 and lets the team parallelize work across branches.

**✅ What Was Implemented**

- Created a comprehensive design specification (`docs/superpowers/specs/2026-07-08-zoom-context-capture-design.md`) that defines two independent reference sources: `zoom-meeting` (capturing AI-generated meeting summaries via `get_meeting_assets`) and `zoom-doc` (capturing Hub documents via `hub_get_file_content`). The spec includes real payload fixtures captured from the Zoom for Claude MCP connector, pinned to prevent assumption drift.
- Established a two-phase implementation roadmap: Phase 1 delivers `zoom-meeting` as a pure-DSL `SourceDefinition` with zero engine changes (independent, ships immediately); Phase 2 delivers `zoom-doc` after the Slack integration work lands its shared Claude-MCP input-threading seam (which `zoom-doc` depends on to access the `fileId` from tool-call input).
- Documented the architectural fit: Zoom sources consume the existing reference pipeline (envelope → SourceEngine → ReferenceStore → assembleReferenceBlocks), requiring no changes to downstream storage, folder persistence, or orphan-branch snapshots. The design explicitly excludes meeting transcripts, participants, and recordings (out of scope) and clarifies why `zoom-meeting` captures only the AI summary, not the full transcript (DSL cannot join object arrays; full transcript balloons token cost and risks JSONL truncation).
- Created a detailed implementation plan (`docs/superpowers/plans/2026-07-08-zoom-context-capture.md`) split into Phase 1 (independent `zoom-meeting` implementation with 4 tasks: definition, registration, badge metadata, and verification) and Phase 2 (implementable `zoom-doc` definition and normalizer with Task 7 blocked on the parallel Slack work delivering the shared Claude-MCP normalize seam). Each task includes exact file paths, test fixtures, and step-by-step instructions grounded in the real codebase structure.

**📁 FILES**
- `docs/superpowers/specs/2026-07-08-zoom-context-capture-design.md`
- `docs/superpowers/plans/2026-07-08-zoom-context-capture.md`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 10, 2026 at 12:19 AM · via Anthropic*
<!-- jollimemory-summary-end -->