### PR TITLE
Part of JOLLI-1900: Add pre-push hook for auto-syncing commits to Jolli Space

### DIFF
--- a/cli/src/Api.test.ts
+++ b/cli/src/Api.test.ts
@@ -765,7 +765,7 @@ describe("CLI", () => {
 				calls.some(
 					(s) =>
 						s.includes("Hooks:") &&
-						s.includes("3 Git") &&
+						s.includes("4 Git") &&
 						s.includes("2 Claude") &&
 						s.includes("1 Gemini CLI"),
 				),

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -494,6 +494,14 @@ export interface CommitSummary {
 	 * Plan articles are never orphaned — plan slugs include commit hashes and are all kept.
 	 */
 	readonly orphanedDocIds?: ReadonlyArray<number>;
+	/**
+	 * Commit hashes whose summaries had no `jolliDocId` at squash/merge time
+	 * (race: PrePushWorker hadn't written back the ID yet). Consumed at push
+	 * time: re-read each hash, promote any now-present docId into
+	 * `orphanedDocIds` for cleanup, retain hashes still present in the shared
+	 * push-pending queue, and discard only hashes known not to be in flight.
+	 */
+	readonly unresolvedOrphanHashes?: ReadonlyArray<string>;
 	/** Git tree hash for this commit; used for cross-branch summary matching */
 	readonly treeHash?: string;
 	/** On-demand E2E test scenarios for PR reviewers (generated via SummaryWebviewPanel) */
@@ -1058,6 +1066,14 @@ export interface JolliMemoryConfig {
 	 */
 	readonly dcoSignoff?: boolean;
 	/**
+	 * Auto-push memory to Jolli Space on every `git push`. `undefined` = enabled
+	 * (default when logged in); `false` = disabled. The pre-push hook records
+	 * pushed commits into `.jolli/jollimemory/push-pending.json` and a detached
+	 * PrePushWorker syncs them to the bound Space. Complementary to the
+	 * PR-level `push_memory` flow — same idempotent server path, no duplicates.
+	 */
+	readonly syncOnPush?: boolean;
+	/**
 	 * Whether to **auto-sync** Memory Bank to the user's private Personal
 	 * Space vault on a recurring schedule. Plan §0.7 made manual sync the
 	 * always-available default (the "Sync to Personal Space Now" button +
@@ -1179,6 +1195,8 @@ export interface InstallResult {
 	readonly prepareMsgHookPath?: string;
 	/** Absolute path to the git post-merge hook file (set on successful install) */
 	readonly postMergeHookPath?: string;
+	/** Absolute path to the git pre-push hook file (set on successful install) */
+	readonly prePushHookPath?: string;
 	/** Absolute path to the Gemini CLI settings file (set on successful install when Gemini detected) */
 	readonly geminiSettingsPath?: string;
 }
@@ -1200,6 +1218,8 @@ export interface StatusInfo {
 	readonly enabled: boolean;
 	readonly claudeHookInstalled: boolean;
 	readonly gitHookInstalled: boolean;
+	/** Whether the pre-push hook section is installed (additive, not required for `enabled`) */
+	readonly prePushHookInstalled?: boolean;
 	/** Whether the Gemini AfterAgent hook is installed in .gemini/settings.json */
 	readonly geminiHookInstalled: boolean;
 	/**

--- a/cli/src/commands/ConfigureCommand.test.ts
+++ b/cli/src/commands/ConfigureCommand.test.ts
@@ -106,6 +106,16 @@ describe("ConfigureCommand — settable keys", () => {
 		expect((await loadConfig()).copilotEnabled).toBe(false);
 	});
 
+	it("accepts syncOnPush as a boolean key", async () => {
+		await runConfigure(["--set", "syncOnPush=false"]);
+		expect(mockSaveConfig).toHaveBeenCalledWith(expect.objectContaining({ syncOnPush: false }));
+		expect((await loadConfig()).syncOnPush).toBe(false);
+
+		await runConfigure(["--set", "syncOnPush=true"]);
+		expect(mockSaveConfig).toHaveBeenCalledWith(expect.objectContaining({ syncOnPush: true }));
+		expect((await loadConfig()).syncOnPush).toBe(true);
+	});
+
 	it("accepts localFolder as a string path key", async () => {
 		// CLI-only setups (no VS Code Settings panel) need a way to point Memory
 		// Bank at a folder; without this key the only option was hand-editing

--- a/cli/src/commands/ConfigureCommand.ts
+++ b/cli/src/commands/ConfigureCommand.ts
@@ -57,6 +57,7 @@ const VALID_CONFIG_KEYS = [
 	"aiProvider",
 	"syncTranscripts",
 	"syncPollIntervalSec",
+	"syncOnPush",
 	"slack.workspaceUrl",
 ] as const satisfies ReadonlyArray<keyof JolliMemoryConfig | "slack.workspaceUrl">;
 
@@ -121,7 +122,8 @@ function coerceConfigValue(key: ConfigKey, raw: string): string | number | boole
 		key === "openCodeEnabled" ||
 		key === "cursorEnabled" ||
 		key === "copilotEnabled" ||
-		key === "syncTranscripts"
+		key === "syncTranscripts" ||
+		key === "syncOnPush"
 	) {
 		const lower = raw.toLowerCase();
 		if (lower === "true" || lower === "1" || lower === "yes") return true;
@@ -222,6 +224,11 @@ const CONFIG_KEY_INFO: ReadonlyArray<{ key: ConfigKey; type: string; description
 		key: "syncTranscripts",
 		type: "boolean",
 		description: "Include raw AI conversation transcripts in cloud sync (default: false)",
+	},
+	{
+		key: "syncOnPush",
+		type: "boolean",
+		description: "Auto-sync pushed commits' memory to Jolli Space on every git push (default: true when signed in)",
 	},
 	{
 		key: "syncPollIntervalSec",

--- a/cli/src/commands/EnableCommand.ts
+++ b/cli/src/commands/EnableCommand.ts
@@ -12,6 +12,7 @@ import { browserLogin } from "../auth/Login.js";
 import { validateJolliApiKey } from "../core/JolliApiUtils.js";
 import { getGlobalConfigDir, loadConfigFromDir, saveConfigScoped } from "../core/SessionTracker.js";
 import { track } from "../core/Telemetry.js";
+import { triggerPendingPushRetry } from "../hooks/PushCompensation.js";
 import { install, uninstall } from "../install/Installer.js";
 import { createLogger, setLogDir } from "../Logger.js";
 import type { JolliMemoryConfig } from "../Types.js";
@@ -161,6 +162,8 @@ export function registerEnableCommand(program: Command): void {
 					console.log(
 						`    - Git prepare-commit-msg hook (${result.prepareMsgHookPath ?? ".git/hooks/prepare-commit-msg"})`,
 					);
+					console.log(`    - Git post-merge hook (${result.postMergeHookPath ?? ".git/hooks/post-merge"})`);
+					console.log(`    - Git pre-push hook (${result.prePushHookPath ?? ".git/hooks/pre-push"})`);
 					console.log(
 						`    - Claude Code hooks (${result.claudeSettingsPath ?? ".claude/settings.local.json"})`,
 					);
@@ -193,6 +196,15 @@ export function registerEnableCommand(program: Command): void {
 					console.log("\n  Configure API keys to enable summarization:");
 					console.log(`    Edit: ${join(configDir, "config.json")}`);
 					console.log('    Set "apiKey" (Anthropic) and/or "jolliApiKey" (Jolli Space)\n');
+				}
+
+				// Pre-push sync catch-up (JOLLI-1900): retry any commits left in
+				// push-pending.json from a previous session. Runs after promptSetup so a
+				// user who just signed in gets their backlog pushed. Skipped in
+				// integrations-only mode (IntelliJ manages its own hook/worker). Fully
+				// guarded — never throws, no-ops when nothing is pending or not signed in.
+				if (!options.integrationsOnly) {
+					void triggerPendingPushRetry(options.cwd);
 				}
 
 				// Historical back-fill is no longer kicked off automatically at enable

--- a/cli/src/commands/StatusCommand.ts
+++ b/cli/src/commands/StatusCommand.ts
@@ -96,7 +96,7 @@ export function registerStatusCommand(program: Command): void {
 
 			// Build hooks description matching VSCode STATUS panel format
 			const hookParts: string[] = [];
-			if (status.gitHookInstalled) hookParts.push("3 Git");
+			if (status.gitHookInstalled) hookParts.push(`${status.prePushHookInstalled ? 5 : 4} Git`);
 			if (status.claudeHookInstalled) hookParts.push("2 Claude");
 			if (status.geminiHookInstalled) hookParts.push("1 Gemini CLI");
 			const hooksDesc = hookParts.length > 0 ? hookParts.join(" + ") : "none installed";

--- a/cli/src/core/JolliMemoryPushClient.ts
+++ b/cli/src/core/JolliMemoryPushClient.ts
@@ -223,6 +223,9 @@ export class JolliMemoryPushClient {
 		if (status === 409 && json.error === "binding_already_exists") {
 			throw new BindingAlreadyExistsError(json.message ?? "binding_already_exists");
 		}
+		if (status === 401 || status === 403) {
+			throw new NotAuthenticatedError();
+		}
 		if (status < 200 || status >= 300) {
 			// Read `message ?? error` like listSpaces/createBinding (and the vscode
 			// parent) — the server may carry the human-readable reason in `message`.
@@ -251,6 +254,9 @@ export class JolliMemoryPushClient {
 	 */
 	async deleteDoc(docId: number): Promise<void> {
 		const { status } = await this.call("DELETE", `/api/push/jollimemory/${docId}`);
+		if (status === 401 || status === 403) {
+			throw new NotAuthenticatedError();
+		}
 		if (status < 200 || status >= 300) {
 			throw new Error(`delete failed: HTTP ${status}`);
 		}

--- a/cli/src/core/JolliMemoryPushOrchestrator.test.ts
+++ b/cli/src/core/JolliMemoryPushOrchestrator.test.ts
@@ -3,8 +3,11 @@ import type { CommitSummary, NoteReference, PlanReference } from "../Types.js";
 
 vi.mock("./GitOps.js", () => ({ getDefaultBranch: vi.fn() }));
 vi.mock("./PrDescription.js", () => ({ loadBranchSummaries: vi.fn() }));
+vi.mock("./PushPendingStore.js", () => ({ loadPushPending: vi.fn() }));
 vi.mock("./SummaryStore.js", () => ({
 	getActiveStorage: vi.fn(),
+	getIndexEntryMap: vi.fn(async () => new Map()),
+	getSummary: vi.fn(),
 	readNoteFromBranch: vi.fn(),
 	readPlanFromBranch: vi.fn(),
 	storeSummary: vi.fn(),
@@ -38,8 +41,16 @@ import {
 	serializeSummaryJson,
 } from "./JolliMemoryPushOrchestrator.js";
 import { loadBranchSummaries } from "./PrDescription.js";
+import { loadPushPending } from "./PushPendingStore.js";
 import { buildPushTitle } from "./SummaryFormat.js";
-import { getActiveStorage, readNoteFromBranch, readPlanFromBranch, storeSummary } from "./SummaryStore.js";
+import {
+	getActiveStorage,
+	getIndexEntryMap,
+	getSummary,
+	readNoteFromBranch,
+	readPlanFromBranch,
+	storeSummary,
+} from "./SummaryStore.js";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -93,11 +104,18 @@ function note(overrides: Partial<NoteReference> = {}): NoteReference {
 
 describe("serializeSummaryJson", () => {
 	it("strips push-state fields", () => {
-		const s = { commitHash: "a", jolliDocId: 5, jolliDocUrl: "u", orphanedDocIds: [1] } as unknown as CommitSummary;
+		const s = {
+			commitHash: "a",
+			jolliDocId: 5,
+			jolliDocUrl: "u",
+			orphanedDocIds: [1],
+			unresolvedOrphanHashes: ["old-hash"],
+		} as unknown as CommitSummary;
 		const json = JSON.parse(serializeSummaryJson(s) ?? "{}");
 		expect(json.jolliDocId).toBeUndefined();
 		expect(json.jolliDocUrl).toBeUndefined();
 		expect(json.orphanedDocIds).toBeUndefined();
+		expect(json.unresolvedOrphanHashes).toBeUndefined();
 		expect(json.commitHash).toBe("a");
 	});
 
@@ -588,6 +606,79 @@ describe("pushSummary", () => {
 		vi.mocked(storeSummary).mockReset().mockResolvedValue(undefined);
 		vi.mocked(readPlanFromBranch).mockReset().mockResolvedValue(null);
 		vi.mocked(readNoteFromBranch).mockReset().mockResolvedValue(null);
+		vi.mocked(loadPushPending).mockReset().mockResolvedValue({ version: 1, entries: {} });
+		vi.mocked(getIndexEntryMap).mockReset().mockResolvedValue(new Map());
+	});
+
+	it("deletes the freshly-pushed article and skips force-store when the commit became a child mid-push", async () => {
+		const client = fakeClient();
+		const summary = leaf();
+		vi.mocked(getIndexEntryMap).mockResolvedValue(
+			new Map<
+				string,
+				{
+					readonly commitHash: string;
+					readonly parentCommitHash: string | null;
+					readonly commitMessage: string;
+					readonly commitDate: string;
+					readonly branch: string;
+					readonly generatedAt: string;
+				}
+			>([
+				[
+					summary.commitHash,
+					{
+						commitHash: summary.commitHash,
+						parentCommitHash: "def4567890",
+						commitMessage: "",
+						commitDate: "",
+						branch: summary.branch,
+						generatedAt: "",
+					},
+				],
+			]),
+		);
+
+		await pushSummary(summary, baseCtx(client));
+
+		expect(client.push).toHaveBeenCalledTimes(1);
+		expect(client.deleteDoc).toHaveBeenCalledWith(42);
+		expect(storeSummary).not.toHaveBeenCalled();
+	});
+
+	it("tolerates a best-effort deleteDoc failure when unwinding a mid-push re-parent", async () => {
+		const client = fakeClient({ deleteDoc: async () => Promise.reject(new Error("network")) });
+		const summary = leaf();
+		vi.mocked(getIndexEntryMap).mockResolvedValue(
+			new Map<
+				string,
+				{
+					readonly commitHash: string;
+					readonly parentCommitHash: string | null;
+					readonly commitMessage: string;
+					readonly commitDate: string;
+					readonly branch: string;
+					readonly generatedAt: string;
+				}
+			>([
+				[
+					summary.commitHash,
+					{
+						commitHash: summary.commitHash,
+						parentCommitHash: "def4567890",
+						commitMessage: "",
+						commitDate: "",
+						branch: summary.branch,
+						generatedAt: "",
+					},
+				],
+			]),
+		);
+
+		await expect(pushSummary(summary, baseCtx(client))).resolves.toEqual(
+			expect.objectContaining({ summaryUrl: `${BASE}/articles?doc=42` }),
+		);
+		expect(storeSummary).not.toHaveBeenCalled();
 	});
 
 	it("pushes the summary payload and writes the docId/docUrl back via storeSummary(force=true)", async () => {
@@ -915,6 +1006,84 @@ describe("pushSummary", () => {
 
 		const { summaryUrl } = await pushSummary(summary, baseCtx(client));
 		expect(summaryUrl).toBe(`${BASE}/articles?doc=42`);
+	});
+
+	it("resolves unresolvedOrphanHashes into orphanedDocIds for cleanup", async () => {
+		const client = fakeClient();
+		const summary = leaf({ unresolvedOrphanHashes: ["child1hash", "child2hash"] });
+		vi.mocked(getSummary)
+			.mockResolvedValueOnce(leaf({ commitHash: "child1hash", jolliDocId: 201 }))
+			.mockResolvedValueOnce(leaf({ commitHash: "child2hash", jolliDocId: 202 }));
+
+		await pushSummary(summary, baseCtx(client));
+
+		expect(client.deleteDoc).toHaveBeenCalledWith(201);
+		expect(client.deleteDoc).toHaveBeenCalledWith(202);
+		const resolveStoreCall = vi.mocked(storeSummary).mock.calls[1];
+		expect(resolveStoreCall?.[0].unresolvedOrphanHashes).toBeUndefined();
+		expect(resolveStoreCall?.[0].orphanedDocIds).toEqual([201, 202]);
+	});
+
+	it("discards unresolvedOrphanHashes that still have no jolliDocId (never pushed)", async () => {
+		const client = fakeClient();
+		const summary = leaf({ unresolvedOrphanHashes: ["child1hash", "child2hash"] });
+		vi.mocked(getSummary)
+			.mockResolvedValueOnce(leaf({ commitHash: "child1hash" }))
+			.mockResolvedValueOnce(null);
+
+		await pushSummary(summary, baseCtx(client));
+
+		expect(client.deleteDoc).not.toHaveBeenCalled();
+		const resolveStoreCall = vi.mocked(storeSummary).mock.calls[1];
+		expect(resolveStoreCall?.[0].unresolvedOrphanHashes).toBeUndefined();
+		expect(resolveStoreCall?.[0].orphanedDocIds).toBeUndefined();
+	});
+
+	it("retains an unresolved hash while its pre-push worker is still pending", async () => {
+		const client = fakeClient();
+		const summary = leaf({ unresolvedOrphanHashes: ["child1hash", "child2hash"] });
+		vi.mocked(loadPushPending).mockResolvedValue({
+			version: 1,
+			entries: {
+				child1hash: {
+					branch: "feature/x",
+					enqueuedAt: "2026-01-01T00:00:00.000Z",
+					retryCount: 0,
+				},
+			},
+		});
+		vi.mocked(getSummary).mockResolvedValue(null);
+
+		await pushSummary(summary, baseCtx(client));
+
+		const resolveStoreCall = vi.mocked(storeSummary).mock.calls[1];
+		expect(resolveStoreCall?.[0].unresolvedOrphanHashes).toEqual(["child1hash"]);
+	});
+
+	it("conservatively retains unresolved hashes when the pending file cannot be read", async () => {
+		const client = fakeClient();
+		const summary = leaf({ unresolvedOrphanHashes: ["child1hash"] });
+		vi.mocked(loadPushPending).mockRejectedValue(new Error("lock unavailable"));
+		vi.mocked(getSummary).mockResolvedValue(null);
+
+		const result = await pushSummary(summary, baseCtx(client));
+
+		expect(result.summary.unresolvedOrphanHashes).toEqual(["child1hash"]);
+		expect(storeSummary).toHaveBeenCalledTimes(1);
+	});
+
+	it("merges resolved orphan hashes with existing orphanedDocIds", async () => {
+		const client = fakeClient();
+		const summary = leaf({
+			orphanedDocIds: [100],
+			unresolvedOrphanHashes: ["child1hash"],
+		});
+		vi.mocked(getSummary).mockResolvedValueOnce(leaf({ commitHash: "child1hash", jolliDocId: 201 }));
+
+		await pushSummary(summary, baseCtx(client));
+
+		expect(client.deleteDoc).toHaveBeenCalledWith(100);
+		expect(client.deleteDoc).toHaveBeenCalledWith(201);
 	});
 });
 

--- a/cli/src/core/JolliMemoryPushOrchestrator.ts
+++ b/cli/src/core/JolliMemoryPushOrchestrator.ts
@@ -22,6 +22,7 @@ import {
 	NotAuthenticatedError,
 } from "./JolliMemoryPushClient.js";
 import { loadBranchSummaries } from "./PrDescription.js";
+import { loadPushPending } from "./PushPendingStore.js";
 import type { StorageProvider } from "./StorageProvider.js";
 import { buildNotePushTitle, buildPlanPushTitle, buildPushTitle, collectSortedTopics } from "./SummaryFormat.js";
 import {
@@ -34,7 +35,14 @@ import {
 	pushTopicBody,
 	pushTopicsSection,
 } from "./SummaryMarkdownBuilder.js";
-import { getActiveStorage, readNoteFromBranch, readPlanFromBranch, storeSummary } from "./SummaryStore.js";
+import {
+	getActiveStorage,
+	getIndexEntryMap,
+	getSummary,
+	readNoteFromBranch,
+	readPlanFromBranch,
+	storeSummary,
+} from "./SummaryStore.js";
 
 const log = createLogger("JolliMemoryPushOrchestrator");
 
@@ -49,15 +57,22 @@ const MAX_SUMMARY_JSON_BYTES = 1_572_864;
 /**
  * Serializes a summary for the `summaryJson` push field: the enriched
  * `summaryForMarkdown` copy (plan/note URLs woven in) minus the client push-state
- * fields — `jolliDocId`/`jolliDocUrl` churn per push and `orphanedDocIds` is
- * cleanup bookkeeping, none of which is commit content the share page should see
+ * fields — `jolliDocId`/`jolliDocUrl` churn per push, while `orphanedDocIds`
+ * and `unresolvedOrphanHashes` are cleanup bookkeeping. None of them are
+ * commit content the share page should see
  * (stripping them also keeps the top-level fields of a re-push byte-identical for
  * unchanged content, so the server upsert can no-op — per-plan/note `jolliPlan*`/
  * `jolliNote*` ids nested inside `plans[]`/`notes[]` are untouched and can still
  * churn). Returns undefined above {@link MAX_SUMMARY_JSON_BYTES}.
  */
 export function serializeSummaryJson(summary: CommitSummary): string | undefined {
-	const { jolliDocId: _docId, jolliDocUrl: _docUrl, orphanedDocIds: _orphaned, ...content } = summary;
+	const {
+		jolliDocId: _docId,
+		jolliDocUrl: _docUrl,
+		orphanedDocIds: _orphaned,
+		unresolvedOrphanHashes: _unresolved,
+		...content
+	} = summary;
 	const json = JSON.stringify(content);
 	if (Buffer.byteLength(json, "utf-8") > MAX_SUMMARY_JSON_BYTES) {
 		log.warn(
@@ -374,6 +389,36 @@ export async function pushSummary(
 
 	const summaryUrl = `${displayBase}/articles?doc=${result.docId}`;
 
+	// Post-push race check: `processPushPending` already skipped hashes that
+	// were children at claim time, but the user could have amend/squashed this
+	// commit while we were on the network. Force-writing a child back as a root
+	// (storeSummary force=true below) would create a zombie index entry that
+	// duplicates the merged root's content. Instead, best-effort delete the
+	// freshly-published article and return — the merged root remains the sole
+	// authority for this commit's memory.
+	const postPushIndex = await getIndexEntryMap(ctx.cwd, ctx.storage).catch(() => new Map<string, unknown>());
+	const currentIndexEntry = postPushIndex.get(summary.commitHash) as
+		| { readonly parentCommitHash?: string | null }
+		| undefined;
+	if (currentIndexEntry?.parentCommitHash != null) {
+		log.warn(
+			"Commit %s became a child mid-push (parent=%s); deleting freshly-pushed article %d and skipping force-store",
+			summary.commitHash.substring(0, 8),
+			currentIndexEntry.parentCommitHash.substring(0, 8),
+			result.docId,
+		);
+		try {
+			await ctx.client.deleteDoc(result.docId);
+		} catch (err) {
+			log.warn(
+				"Best-effort delete of newly-orphaned article %d failed: %s",
+				result.docId,
+				err instanceof Error ? err.message : String(err),
+			);
+		}
+		return { summary, summaryUrl };
+	}
+
 	const updatedSummary: CommitSummary = {
 		...summary,
 		jolliDocUrl: summaryUrl,
@@ -383,12 +428,72 @@ export async function pushSummary(
 	};
 	await storeSummary(updatedSummary, ctx.cwd, true, undefined, ctx.storage);
 
+	// Resolve unresolvedOrphanHashes: re-read each hash's summary from the
+	// orphan branch. If PrePushWorker has since written back a jolliDocId,
+	// promote it into orphanedDocIds for cleanup.
+	//
+	// Retention is gated by the shared push-pending queue:
+	//   * hash present in pending → retain (a worker is still in flight and
+	//     may yet resolve it)
+	//   * hash absent from pending → discard (it was never pushed, or the
+	//     worker already finished without producing a docId — either way the
+	//     hash has no Space article to clean up)
+	//
+	// When `loadPushPending` itself fails (lock unavailable, transient IO
+	// error) we fall back to conservative retention: keep every unresolved
+	// hash so a crashed worker's article can still be cleaned up on the next
+	// push.
+	let summaryForCleanup = updatedSummary;
+	if (summary.unresolvedOrphanHashes && summary.unresolvedOrphanHashes.length > 0) {
+		const pending = await loadPushPending(ctx.cwd).catch((err: unknown) => {
+			log.warn(
+				"Could not read push-pending state while resolving orphan hashes: %s",
+				err instanceof Error ? err.message : String(err),
+			);
+			return undefined;
+		});
+		const resolvedDocIds: number[] = [];
+		const remainingHashes: string[] = [];
+		let stillInFlight = 0;
+		for (const hash of summary.unresolvedOrphanHashes) {
+			const fresh = await getSummary(hash, ctx.cwd, ctx.storage);
+			// Guard against tree-hash fallback: if the child's own summary
+			// file was cleaned, getSummary may resolve to the merged summary
+			// (same tree) — whose jolliDocId is the article we just pushed.
+			// Without this check we'd delete our own freshly-published article.
+			if (fresh?.jolliDocId && fresh.commitHash === hash) {
+				resolvedDocIds.push(fresh.jolliDocId);
+			} else if (pending === undefined) {
+				remainingHashes.push(hash);
+			} else if (pending.entries[hash]) {
+				remainingHashes.push(hash);
+				stillInFlight++;
+			}
+		}
+		if (resolvedDocIds.length > 0 || remainingHashes.length !== summary.unresolvedOrphanHashes.length) {
+			if (resolvedDocIds.length > 0)
+				log.info(
+					"Resolved %d orphan hashes → docIds for cleanup (%d retained, %d still in-flight)",
+					resolvedDocIds.length,
+					remainingHashes.length,
+					stillInFlight,
+				);
+			const mergedOrphanIds = [...new Set([...(updatedSummary.orphanedDocIds ?? []), ...resolvedDocIds])];
+			summaryForCleanup = {
+				...updatedSummary,
+				orphanedDocIds: mergedOrphanIds.length > 0 ? mergedOrphanIds : undefined,
+				unresolvedOrphanHashes: remainingHashes.length > 0 ? [...new Set(remainingHashes)] : undefined,
+			};
+			await storeSummary(summaryForCleanup, ctx.cwd, true, undefined, ctx.storage);
+		}
+	}
+
 	// Clean up orphaned articles, then persist which ones were actually deleted.
 	// Best-effort: the summary + jolliDocId are already pushed and stored above, so a
 	// cleanup/bookkeeping failure must not surface to the caller as a failed push.
-	let finalSummary = updatedSummary;
+	let finalSummary = summaryForCleanup;
 	try {
-		const cleaned = await cleanupOrphanedDocs(summary, updatedSummary, ctx);
+		const cleaned = await cleanupOrphanedDocs(summaryForCleanup, summaryForCleanup, ctx);
 		if (cleaned) finalSummary = cleaned;
 	} catch (err) {
 		log.warn("Orphan cleanup failed after a successful push: %s", err instanceof Error ? err.message : String(err));

--- a/cli/src/core/Locks.test.ts
+++ b/cli/src/core/Locks.test.ts
@@ -37,6 +37,7 @@ import {
 	LOCK_TIMEOUT_MS,
 	ORPHAN_WRITE_LOCK_FILE,
 	PLANS_LOCK_FILE,
+	PUSH_PENDING_LOCK_FILE,
 	refreshIngestLockMtime,
 	refreshWorkerLockMtime,
 	releaseIngestLock,
@@ -44,6 +45,7 @@ import {
 	releaseWorkerLock,
 	WORKER_LOCK_FILE,
 	withPlansLock,
+	withPushPendingLock,
 } from "./Locks.js";
 
 /**
@@ -66,6 +68,11 @@ function orphanWriteLockPath(tempDir: string): string {
 /** plans.lock dir = per-worktree (`<cwd>/.jolli/jollimemory/`), like worker.lock. */
 function plansLockPath(tempDir: string): string {
 	return join(tempDir, ".jolli", "jollimemory", PLANS_LOCK_FILE);
+}
+
+/** push-pending.lock dir = per-worktree (`<cwd>/.jolli/jollimemory/`), like worker.lock. */
+function pushPendingLockPath(tempDir: string): string {
+	return join(tempDir, ".jolli", "jollimemory", PUSH_PENDING_LOCK_FILE);
 }
 
 describe("Locks", () => {
@@ -584,6 +591,55 @@ describe("Locks", () => {
 			expect(result).toBe("best-effort");
 			// The foreign-owned lock is untouched.
 			await expect(stat(plansLockPath(tempDir))).resolves.toBeDefined();
+		});
+	});
+
+	describe("withPushPendingLock — per-worktree push-pending.json RMW serialisation", () => {
+		it("acquires, runs the body, returns its value, then releases the lock", async () => {
+			let lockHeldDuringBody = false;
+			const result = await withPushPendingLock(tempDir, async () => {
+				lockHeldDuringBody = await stat(pushPendingLockPath(tempDir)).then(
+					() => true,
+					() => false,
+				);
+				return 7;
+			});
+			expect(result).toBe(7);
+			expect(lockHeldDuringBody).toBe(true);
+			await expect(stat(pushPendingLockPath(tempDir))).rejects.toThrow();
+		});
+
+		it("releases the lock even when the body throws", async () => {
+			await expect(
+				withPushPendingLock(tempDir, async () => {
+					throw new Error("boom");
+				}),
+			).rejects.toThrow("boom");
+			await expect(stat(pushPendingLockPath(tempDir))).rejects.toThrow();
+		});
+
+		it("serialises two overlapping holders", async () => {
+			const order: string[] = [];
+			let releaseFirst: () => void = () => {};
+			const firstBodyEntered = new Promise<void>((resolve) => {
+				void withPushPendingLock(tempDir, async () => {
+					order.push("first-enter");
+					resolve();
+					await new Promise<void>((r) => {
+						releaseFirst = r;
+					});
+					order.push("first-exit");
+				});
+			});
+			await firstBodyEntered;
+			const second = withPushPendingLock(tempDir, async () => {
+				order.push("second-enter");
+			});
+			await new Promise((r) => setTimeout(r, 60));
+			expect(order).toEqual(["first-enter"]);
+			releaseFirst();
+			await second;
+			expect(order).toEqual(["first-enter", "first-exit", "second-enter"]);
 		});
 	});
 

--- a/cli/src/core/Locks.ts
+++ b/cli/src/core/Locks.ts
@@ -119,6 +119,7 @@ export const ORPHAN_WRITE_LOCK_FILE = "orphan-write.lock";
 export const SYNC_LOCK_FILE = "sync.lock";
 export const PLANS_LOCK_FILE = "plans.lock";
 export const COMMIT_SELECTION_LOCK_FILE = "commit-selection.lock";
+export const PUSH_PENDING_LOCK_FILE = "push-pending.lock";
 
 /** Default wait budget for `acquireOrphanWriteLock` (background callers). */
 export const DEFAULT_ORPHAN_WRITE_TIMEOUT_MS = 1000;
@@ -135,6 +136,16 @@ export const DEFAULT_PLANS_LOCK_TIMEOUT_MS = 5000;
 
 /** Default poll interval while waiting for `plans.lock`. */
 export const DEFAULT_PLANS_LOCK_POLL_MS = 25;
+
+/**
+ * Default wait budget for `withPushPendingLock`. Same rationale as
+ * `withPlansLock`: the guarded section is a sub-millisecond read-modify-write of
+ * `push-pending.json`, so a peer holder clears almost instantly.
+ */
+export const DEFAULT_PUSH_PENDING_LOCK_TIMEOUT_MS = 5000;
+
+/** Default poll interval while waiting for `push-pending.lock`. */
+export const DEFAULT_PUSH_PENDING_LOCK_POLL_MS = 25;
 
 /** Optional knobs for `acquireOrphanWriteLock`. */
 export interface OrphanWriteLockOpts {
@@ -444,5 +455,36 @@ export async function withCommitSelectionLock<T>(
 		return await fn();
 	} finally {
 		if (acquired) await releaseIfOwned(lockPath, COMMIT_SELECTION_LOCK_FILE);
+	}
+}
+
+/**
+ * Guards a read-modify-write of `push-pending.json`. Same shape as
+ * `withPlansLock`: per-worktree; best-effort fallback so writes that MUST land
+ * (pre-push enqueue, worker success/failure accounting) are never silently
+ * dropped. Callers re-read inside `fn` so a lost-update is avoided even under
+ * the best-effort fallback. MUST NOT be nested.
+ */
+export async function withPushPendingLock<T>(
+	cwd: string | undefined,
+	fn: () => Promise<T>,
+	opts: OrphanWriteLockOpts = {},
+): Promise<T> {
+	const timeoutMs = opts.timeoutMs ?? DEFAULT_PUSH_PENDING_LOCK_TIMEOUT_MS;
+	const pollMs = opts.pollMs ?? DEFAULT_PUSH_PENDING_LOCK_POLL_MS;
+	const dir = await ensureWorktreeLockDir(cwd);
+	const lockPath = join(dir, PUSH_PENDING_LOCK_FILE);
+	const acquired = await acquireWithPoll(lockPath, { timeoutMs, pollMs });
+	if (!acquired) {
+		log.warn(
+			"withPushPendingLock: could not acquire %s within %d ms — proceeding best-effort",
+			PUSH_PENDING_LOCK_FILE,
+			timeoutMs,
+		);
+	}
+	try {
+		return await fn();
+	} finally {
+		if (acquired) await releaseIfOwned(lockPath, PUSH_PENDING_LOCK_FILE);
 	}
 }

--- a/cli/src/core/PushExecutor.test.ts
+++ b/cli/src/core/PushExecutor.test.ts
@@ -1,0 +1,434 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommitSummary } from "../Types.js";
+import { execGit, getCurrentBranch, getDefaultBranch } from "./GitOps.js";
+import { getCanonicalRepoUrl } from "./GitRemoteUtils.js";
+import { BindingRequiredError, ClientOutdatedError, NotAuthenticatedError } from "./JolliMemoryPushClient.js";
+import { assignOwnedAttachments, pushSummary } from "./JolliMemoryPushOrchestrator.js";
+import { loadBranchSummaries } from "./PrDescription.js";
+import { classifyError, processPushPending, triggerPushForNewSummaries } from "./PushExecutor.js";
+import { claimForPush, loadPushPending, type PushPendingEntry, updateBatch } from "./PushPendingStore.js";
+import { loadConfig } from "./SessionTracker.js";
+import { createStorage } from "./StorageFactory.js";
+import { getActiveStorage, getIndexEntryMap, getSummary, setActiveStorage } from "./SummaryStore.js";
+
+vi.mock("./SessionTracker.js", () => ({ loadConfig: vi.fn() }));
+vi.mock("./SummaryStore.js", () => ({
+	getSummary: vi.fn(),
+	getIndexEntryMap: vi.fn(),
+	getActiveStorage: vi.fn(),
+	setActiveStorage: vi.fn(),
+}));
+vi.mock("./StorageFactory.js", () => ({ createStorage: vi.fn() }));
+vi.mock("./GitOps.js", () => ({ execGit: vi.fn(), getCurrentBranch: vi.fn(), getDefaultBranch: vi.fn() }));
+vi.mock("./GitRemoteUtils.js", () => ({ getCanonicalRepoUrl: vi.fn() }));
+vi.mock("./PrDescription.js", () => ({ loadBranchSummaries: vi.fn() }));
+vi.mock("./PushPendingStore.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./PushPendingStore.js")>();
+	return { ...actual, loadPushPending: vi.fn(), updateBatch: vi.fn(), claimForPush: vi.fn() };
+});
+vi.mock("./JolliMemoryPushOrchestrator.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./JolliMemoryPushOrchestrator.js")>();
+	return { ...actual, pushSummary: vi.fn(), assignOwnedAttachments: vi.fn() };
+});
+
+const CWD = "/repo";
+const HASH_A = "a".repeat(40);
+const HASH_B = "b".repeat(40);
+const FAKE_STORAGE = { id: "fake" } as never;
+
+function summary(hash: string, branch = "feature/x"): CommitSummary {
+	return {
+		commitHash: hash,
+		branch,
+		generatedAt: "2026-01-01T00:00:00.000Z",
+	} as CommitSummary;
+}
+
+function fakeClient() {
+	return { resolveBaseUrl: vi.fn(async () => "https://acme.jolli.ai") } as never;
+}
+
+function entry(retryCount = 0, overrides: Partial<PushPendingEntry> = {}): PushPendingEntry {
+	return { branch: "feature/x", enqueuedAt: new Date().toISOString(), retryCount, ...overrides };
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(loadConfig).mockResolvedValue({ jolliApiKey: "sk-jol-x" });
+	vi.mocked(getActiveStorage).mockReturnValue(FAKE_STORAGE);
+	vi.mocked(createStorage).mockResolvedValue(FAKE_STORAGE);
+	vi.mocked(getCurrentBranch).mockResolvedValue("feature/x");
+	vi.mocked(getDefaultBranch).mockResolvedValue("main");
+	vi.mocked(getIndexEntryMap).mockResolvedValue(new Map());
+	vi.mocked(execGit).mockResolvedValue({ stdout: "", stderr: "", exitCode: 1 });
+	vi.mocked(getCanonicalRepoUrl).mockResolvedValue("https://github.com/acme/repo");
+	vi.mocked(getSummary).mockImplementation(async (hash: string) => summary(hash));
+	vi.mocked(loadBranchSummaries).mockResolvedValue({
+		summaries: [summary(HASH_A), summary(HASH_B)],
+		missingCount: 0,
+	});
+	vi.mocked(assignOwnedAttachments).mockReturnValue({
+		ownedPlans: new Map(),
+		ownedNotes: new Map(),
+		seedPlanDocIds: new Map(),
+		seedNoteDocIds: new Map(),
+	});
+	vi.mocked(pushSummary).mockResolvedValue({ summary: summary(HASH_A), summaryUrl: "https://acme.jolli.ai/a" });
+	vi.mocked(updateBatch).mockResolvedValue(undefined);
+	// Default: every candidate is claimed successfully, and the returned
+	// `entries` mirror whatever the current `loadPushPending` mock has been
+	// set up to return — so tests that seed a specific retryCount into
+	// loadPushPending see the same value on the failure path. Tests that
+	// exercise concurrent-claim races override this to return an empty /
+	// partial set.
+	vi.mocked(claimForPush).mockImplementation(async (cwd, candidates) => {
+		const pendingResult = await vi.mocked(loadPushPending)(cwd);
+		const pendingEntries = pendingResult.entries;
+		return {
+			claimed: new Set(candidates),
+			entries: Object.fromEntries(candidates.map((h) => [h, pendingEntries[h] ?? entry()])),
+		};
+	});
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("classifyError", () => {
+	it("does not increment retry for config/permanent failures", () => {
+		expect(classifyError(new NotAuthenticatedError()).increment).toBe(false);
+		expect(classifyError(new BindingRequiredError("r")).increment).toBe(false);
+		expect(classifyError(new ClientOutdatedError()).increment).toBe(false);
+	});
+	it("increments retry for operational failures", () => {
+		const c = classifyError(new Error("ECONNRESET"));
+		expect(c.increment).toBe(true);
+		expect(c.message).toContain("ECONNRESET");
+	});
+});
+
+describe("processPushPending", () => {
+	it("no-ops with no pending entries", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: {} });
+		const r = await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		expect(r.note).toBe("no pending entries");
+		expect(pushSummary).not.toHaveBeenCalled();
+	});
+
+	it("keeps entries and no-ops when not signed in", async () => {
+		vi.mocked(loadConfig).mockResolvedValue({});
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
+		expect(r.note).toBe("not signed in");
+		expect(updateBatch).not.toHaveBeenCalled();
+	});
+
+	it("skips entries that exhausted the retry budget", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(3) } });
+		const r = await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		expect(r.skippedRetryExhausted).toBe(1);
+		expect(pushSummary).not.toHaveBeenCalled();
+	});
+
+	it("honors the hashFilter (post-queue path)", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({
+			version: 1,
+			entries: { [HASH_A]: entry(), [HASH_B]: entry() },
+		});
+		await processPushPending(CWD, { source: "post-queue", hashFilter: new Set([HASH_A]), client: fakeClient() });
+		expect(pushSummary).toHaveBeenCalledTimes(1);
+	});
+
+	it("skips candidates whose memory isn't generated yet and releases the claim so the post-queue trigger can re-claim", async () => {
+		vi.mocked(getSummary).mockResolvedValue(null);
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		const r = await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		expect(r.skippedNoMemory).toBe(1);
+		expect(pushSummary).not.toHaveBeenCalled();
+		// Empty patch releases claimedAt so QueueWorker's post-drain trigger
+		// (triggerPushForNewSummaries) can re-claim once the summary lands.
+		expect(updateBatch).toHaveBeenCalledTimes(1);
+		const batch = vi.mocked(updateBatch).mock.calls[0][1];
+		expect(batch.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
+	});
+
+	it("skips tree-hash-resolved summaries (commitHash mismatch) to avoid pushing stale pre-squash content, releasing the claim so the post-queue trigger can re-claim", async () => {
+		vi.mocked(getSummary).mockResolvedValue(summary(HASH_B));
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		const r = await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		expect(r.skippedNoMemory).toBe(1);
+		expect(pushSummary).not.toHaveBeenCalled();
+		// Empty patch releases claimedAt — same mechanism as the missing-summary
+		// case above. Without it, the immediate post-queue push would be blocked
+		// by the still-fresh claimedAt for up to CLAIM_STALE_MS (5 min).
+		expect(updateBatch).toHaveBeenCalledTimes(1);
+		const batch = vi.mocked(updateBatch).mock.calls[0][1];
+		expect(batch.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
+	});
+
+	it("pushes a candidate with memory and deletes it on success", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		const r = await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		expect(r.pushed).toBe(1);
+		expect(pushSummary).toHaveBeenCalledTimes(1);
+		const batch = vi.mocked(updateBatch).mock.calls[0][1];
+		expect(batch.get(HASH_A)).toEqual({ kind: "delete" });
+	});
+
+	it("waits for remote confirmation before publishing a newly pushed commit", async () => {
+		const remoteRef = "refs/heads/feature/x";
+		const pushUrl = "ssh://git@example.com/acme/repo.git";
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			if (args[0] === "remote") return { stdout: `${pushUrl}\n`, stderr: "", exitCode: 0 };
+			return { stdout: `${HASH_A}\t${remoteRef}\n`, stderr: "", exitCode: 0 };
+		});
+		vi.mocked(loadPushPending).mockResolvedValue({
+			version: 1,
+			entries: {
+				[HASH_A]: entry(0, { pushTargets: [{ remote: "origin", remoteRef, localSha: HASH_A }] }),
+			},
+		});
+
+		const result = await processPushPending(CWD, { source: "activation", client: fakeClient() });
+
+		expect(result.pushed).toBe(1);
+		expect(execGit).toHaveBeenCalledWith(["ls-remote", "--refs", pushUrl, remoteRef], CWD);
+		expect(pushSummary).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps the entry when the remote ref does not contain the pushed SHA", async () => {
+		const remoteRef = "refs/heads/feature/x";
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			if (args[0] === "remote") return { stdout: "origin\n", stderr: "", exitCode: 0 };
+			if (args[0] === "ls-remote") return { stdout: `${HASH_B}\t${remoteRef}\n`, stderr: "", exitCode: 0 };
+			return { stdout: "", stderr: "", exitCode: 1 };
+		});
+		vi.mocked(loadPushPending).mockResolvedValue({
+			version: 1,
+			entries: {
+				[HASH_A]: entry(0, { pushTargets: [{ remote: "origin", remoteRef, localSha: HASH_A }] }),
+			},
+		});
+
+		const result = await processPushPending(CWD, { source: "activation", client: fakeClient() });
+
+		expect(result.note).toBe("push not confirmed");
+		expect(pushSummary).not.toHaveBeenCalled();
+		expect(updateBatch).not.toHaveBeenCalled();
+	});
+
+	it("accepts a pushed SHA that is an ancestor of a later remote tip", async () => {
+		const remoteRef = "refs/heads/feature/x";
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			if (args[0] === "remote") return { stdout: "", stderr: "unknown remote", exitCode: 2 };
+			if (args[0] === "ls-remote") return { stdout: `${HASH_B}\t${remoteRef}\n`, stderr: "", exitCode: 0 };
+			return { stdout: "", stderr: "", exitCode: 0 };
+		});
+		vi.mocked(loadPushPending).mockResolvedValue({
+			version: 1,
+			entries: {
+				[HASH_A]: entry(0, { pushTargets: [{ remote: "origin", remoteRef, localSha: HASH_A }] }),
+			},
+		});
+
+		const result = await processPushPending(CWD, { source: "activation", client: fakeClient() });
+
+		expect(result.pushed).toBe(1);
+		expect(execGit).toHaveBeenCalledWith(["ls-remote", "--refs", "origin", remoteRef], CWD);
+		expect(execGit).toHaveBeenCalledWith(["merge-base", "--is-ancestor", HASH_A, HASH_B], CWD);
+	});
+
+	it("keeps the entry when the remote ref cannot be queried", async () => {
+		const remoteRef = "refs/heads/feature/x";
+		vi.mocked(execGit).mockResolvedValue({ stdout: "", stderr: "offline", exitCode: 1 });
+		vi.mocked(loadPushPending).mockResolvedValue({
+			version: 1,
+			entries: {
+				[HASH_A]: entry(0, { pushTargets: [{ remote: "origin", remoteRef, localSha: HASH_A }] }),
+			},
+		});
+
+		const result = await processPushPending(CWD, { source: "activation", client: fakeClient() });
+
+		expect(result.note).toBe("push not confirmed");
+		expect(pushSummary).not.toHaveBeenCalled();
+	});
+
+	it("passes owned attachments to pushSummary (cross-commit dedup)", async () => {
+		vi.mocked(assignOwnedAttachments).mockReturnValue({
+			ownedPlans: new Map([[HASH_A, [{ slug: "p-1234abcd" }]]]) as never,
+			ownedNotes: new Map(),
+			seedPlanDocIds: new Map(),
+			seedNoteDocIds: new Map(),
+		});
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		const attachments = vi.mocked(pushSummary).mock.calls[0][2];
+		expect(attachments?.plans).toHaveLength(1);
+	});
+
+	it("builds attachment ownership from an off-current branch context", async () => {
+		const offBranch = "feature/off-current";
+		const offSummary = summary(HASH_A, offBranch);
+		vi.mocked(getSummary).mockResolvedValue(offSummary);
+		vi.mocked(getIndexEntryMap).mockResolvedValue(
+			new Map([
+				[
+					HASH_A,
+					{
+						commitHash: HASH_A,
+						parentCommitHash: null,
+						branch: offBranch,
+						commitMessage: "off branch",
+						commitDate: "2026-01-01T00:00:00.000Z",
+						generatedAt: "2026-01-01T00:00:00.000Z",
+					},
+				],
+			]),
+		);
+		vi.mocked(assignOwnedAttachments).mockReturnValue({
+			ownedPlans: new Map([[HASH_A, [{ slug: "off-plan" }]]]) as never,
+			ownedNotes: new Map(),
+			seedPlanDocIds: new Map(),
+			seedNoteDocIds: new Map(),
+		});
+		vi.mocked(loadPushPending).mockResolvedValue({
+			version: 1,
+			entries: { [HASH_A]: entry(0, { branch: offBranch }) },
+		});
+
+		await processPushPending(CWD, { source: "activation", client: fakeClient() });
+
+		expect(assignOwnedAttachments).toHaveBeenCalledWith([offSummary]);
+		expect(vi.mocked(pushSummary).mock.calls[0][2]?.plans).toHaveLength(1);
+	});
+
+	it("increments retryCount on an operational failure", async () => {
+		vi.mocked(pushSummary).mockRejectedValue(new Error("network down"));
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(1) } });
+		const r = await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		expect(r.failed).toBe(1);
+		const batch = vi.mocked(updateBatch).mock.calls[0][1];
+		const update = batch.get(HASH_A);
+		expect(update).toMatchObject({ kind: "patch" });
+		if (update?.kind === "patch") {
+			expect(update.patch.retryCount).toBe(2);
+			expect(update.patch.lastError).toContain("network down");
+		}
+	});
+
+	it("does NOT increment retryCount on NotAuthenticated mid-push", async () => {
+		vi.mocked(pushSummary).mockRejectedValue(new NotAuthenticatedError());
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(1) } });
+		await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		const batch = vi.mocked(updateBatch).mock.calls[0][1];
+		const update = batch.get(HASH_A);
+		if (update?.kind === "patch") {
+			expect(update.patch.retryCount).toBeUndefined();
+			expect(update.patch.lastError).toBe("not-authenticated");
+		}
+	});
+
+	it("drops a candidate that raced away (summary gone by push time)", async () => {
+		// Passes the memory check (truthy first) but the pushOne fallback getSummary
+		// returns null (deleted meanwhile). loadBranchSummaries empty → byHash miss
+		// forces the fallback lookup.
+		vi.mocked(loadBranchSummaries).mockResolvedValue({ summaries: [], missingCount: 0 });
+		vi.mocked(getSummary)
+			.mockResolvedValueOnce(summary(HASH_A)) // memory check
+			.mockResolvedValueOnce(null); // pushOne fallback
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		const r = await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		expect(r.failed).toBe(1);
+		expect(pushSummary).not.toHaveBeenCalled();
+		const batch = vi.mocked(updateBatch).mock.calls[0][1];
+		expect(batch.get(HASH_A)).toEqual({ kind: "delete" });
+	});
+
+	it("creates storage when none is active", async () => {
+		vi.mocked(getActiveStorage).mockReturnValue(undefined);
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		expect(createStorage).toHaveBeenCalledWith(CWD, CWD);
+		expect(setActiveStorage).toHaveBeenCalled();
+	});
+
+	it("skips all entries when syncOnPush is disabled (not just the pre-push hook path)", async () => {
+		vi.mocked(loadConfig).mockResolvedValue({ jolliApiKey: "sk-jol-x", syncOnPush: false });
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
+		expect(r.note).toBe("syncOnPush disabled");
+		expect(pushSummary).not.toHaveBeenCalled();
+		expect(updateBatch).not.toHaveBeenCalled();
+	});
+
+	it("deletes (does not push) a pending entry whose commit is now a child in the index", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		vi.mocked(getIndexEntryMap).mockResolvedValue(
+			new Map([
+				[
+					HASH_A,
+					{
+						commitHash: HASH_A,
+						parentCommitHash: HASH_B,
+						commitMessage: "",
+						commitDate: "",
+						branch: "feature/x",
+						generatedAt: "",
+					},
+				],
+			]),
+		);
+		const r = await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		expect(pushSummary).not.toHaveBeenCalled();
+		const batch = vi.mocked(updateBatch).mock.calls[0][1];
+		expect(batch.get(HASH_A)).toEqual({ kind: "delete" });
+		expect(r.note).toBe("all candidates were merged children");
+		expect(r.deletedChildren).toBe(1);
+	});
+
+	it("skips entries a concurrent process already claimed", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({
+			version: 1,
+			entries: { [HASH_A]: entry(), [HASH_B]: entry() },
+		});
+		// Concurrent process already claimed HASH_A; we only get HASH_B.
+		vi.mocked(claimForPush).mockResolvedValue({
+			claimed: new Set([HASH_B]),
+			entries: { [HASH_B]: entry() },
+		});
+		await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		expect(pushSummary).toHaveBeenCalledTimes(1);
+		expect(pushSummary).toHaveBeenCalledWith(
+			expect.objectContaining({ commitHash: HASH_B }),
+			expect.any(Object),
+			expect.any(Object),
+		);
+	});
+
+	it("returns early when every candidate was already claimed by another process", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		vi.mocked(claimForPush).mockResolvedValue({ claimed: new Set(), entries: {} });
+		const r = await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		expect(r.note).toBe("all entries claimed by another process");
+		expect(pushSummary).not.toHaveBeenCalled();
+	});
+});
+
+describe("triggerPushForNewSummaries", () => {
+	it("no-ops on an empty hash list", () => {
+		triggerPushForNewSummaries(CWD, []);
+		// nothing scheduled — loadPushPending never called
+		expect(loadPushPending).not.toHaveBeenCalled();
+	});
+
+	it("schedules a post-queue drain filtered to the given hashes", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		triggerPushForNewSummaries(CWD, [HASH_A]);
+		// setImmediate → wait a tick
+		await new Promise((r) => setImmediate(r));
+		await new Promise((r) => setImmediate(r));
+		expect(loadPushPending).toHaveBeenCalled();
+	});
+});

--- a/cli/src/core/PushExecutor.ts
+++ b/cli/src/core/PushExecutor.ts
@@ -1,0 +1,461 @@
+/**
+ * PushExecutor — the shared "drain push-pending.json to Jolli Space" core.
+ *
+ * Called by all three consumers of the pre-push sync flow:
+ *   - PrePushWorker            (detached, source="pre-push")
+ *   - QueueWorker post-drain   (in-process, source="post-queue", hashFilter set)
+ *   - plugin/CLI activation    (source="activation")
+ *
+ * Reuses the existing push_memory path verbatim — `pushSummary` for the
+ * per-commit upload and `assignOwnedAttachments` for cross-commit plan/note
+ * dedup — so nothing about the Jolli Space contract is re-implemented here
+ * (JOLLI-1900 requirement 3). `pushBranchToJolli` is intentionally NOT used:
+ * it pushes the whole branch as one unit with no per-commit retry state, which
+ * is what the pending-file model provides.
+ *
+ * Cross-commit dedup requires the full branch context. The current branch uses
+ * `base..HEAD`; off-current branches are reconstructed from root summaries in
+ * the summary index. Every pending commit therefore gets the plans/notes it
+ * owns even when the user checked out another branch before the worker ran.
+ */
+
+import { createLogger, errMsg } from "../Logger.js";
+import type { CommitSummary } from "../Types.js";
+import { mapWithConcurrency } from "./Concurrency.js";
+import { execGit, getCurrentBranch, getDefaultBranch } from "./GitOps.js";
+import { getCanonicalRepoUrl } from "./GitRemoteUtils.js";
+import {
+	BindingRequiredError,
+	ClientOutdatedError,
+	JolliMemoryPushClient,
+	NotAuthenticatedError,
+} from "./JolliMemoryPushClient.js";
+import {
+	type AttachmentSelection,
+	assignOwnedAttachments,
+	type PushContext,
+	pushSummary,
+} from "./JolliMemoryPushOrchestrator.js";
+import { loadBranchSummaries } from "./PrDescription.js";
+import {
+	type BatchUpdate,
+	claimForPush,
+	loadPushPending,
+	MAX_RETRY_COUNT,
+	PUSH_CONCURRENCY,
+	type PushPendingEntry,
+	type PushTarget,
+	updateBatch,
+} from "./PushPendingStore.js";
+import { loadConfig } from "./SessionTracker.js";
+import { createStorage } from "./StorageFactory.js";
+import type { StorageProvider } from "./StorageProvider.js";
+import { getActiveStorage, getIndexEntryMap, getSummary, setActiveStorage } from "./SummaryStore.js";
+
+const log = createLogger("PushExecutor");
+
+const PUSH_CONFIRM_POLL_ATTEMPTS = 60;
+const PUSH_CONFIRM_POLL_INTERVAL_MS = 1_000;
+
+/** Where a `processPushPending` call originated — used only for logging. */
+export type PushSource = "pre-push" | "post-queue" | "activation";
+
+export interface ProcessPushPendingOptions {
+	readonly source: PushSource;
+	/** When set, only these hashes are considered (QueueWorker post-drain path). */
+	readonly hashFilter?: ReadonlySet<string>;
+	/** Test seam — defaults to a real client. */
+	readonly client?: JolliMemoryPushClient;
+}
+
+export interface ProcessPushPendingResult {
+	readonly attempted: number;
+	readonly pushed: number;
+	readonly failed: number;
+	readonly skippedNoMemory: number;
+	readonly skippedRetryExhausted: number;
+	/**
+	 * Count of pending entries dropped this run because the commit is now a
+	 * child in the summary index (squash/amend after the entry was enqueued).
+	 * Reported separately from `pushed`/`failed` — no network was attempted.
+	 */
+	readonly deletedChildren: number;
+	/** Set when the whole run short-circuited (no work / not signed in). */
+	readonly note?: string;
+}
+
+/**
+ * Classifies a push failure into whether it should count against the retry
+ * budget. Configuration / environment failures (not signed in, no binding,
+ * client too old) require an explicit user action to fix, so retrying every
+ * push forever would burn the retry budget for nothing — they record the error
+ * but do NOT increment `retryCount`. Everything else (network, 5xx, 4xx,
+ * unknown) is operational and increments so it eventually gives up.
+ */
+export function classifyError(err: unknown): { readonly increment: boolean; readonly message: string } {
+	if (err instanceof NotAuthenticatedError) return { increment: false, message: "not-authenticated" };
+	if (err instanceof BindingRequiredError) return { increment: false, message: "binding-required" };
+	if (err instanceof ClientOutdatedError) return { increment: false, message: "client-outdated" };
+	return { increment: true, message: errMsg(err) };
+}
+
+/**
+ * Ensures a StorageProvider is active for this process. PrePushWorker starts
+ * fresh (no active storage) and must create one; the QueueWorker post-drain
+ * path already has storage set by the drain, so we reuse it.
+ */
+async function ensureStorage(cwd: string): Promise<StorageProvider> {
+	const active = getActiveStorage();
+	if (active) return active;
+	const storage = await createStorage(cwd, cwd);
+	setActiveStorage(storage);
+	return storage;
+}
+
+function pushTargetKey(target: PushTarget): string {
+	return `${target.remote}\0${target.remoteRef}\0${target.localSha}`;
+}
+
+async function resolvePushRemote(cwd: string, remote: string): Promise<string> {
+	const result = await execGit(["remote", "get-url", "--push", remote], cwd);
+	return result.exitCode === 0 && result.stdout.trim() ? result.stdout.trim().split("\n")[0] : remote;
+}
+
+async function isPushTargetConfirmed(cwd: string, target: PushTarget, remote: string): Promise<boolean> {
+	const result = await execGit(["ls-remote", "--refs", remote, target.remoteRef], cwd);
+	if (result.exitCode !== 0) return false;
+	const remoteSha = result.stdout
+		.split("\n")
+		.map((line) => line.trim().split(/\s+/, 2))
+		.find((parts) => parts[1] === target.remoteRef)?.[0];
+	if (!remoteSha) return false;
+	if (remoteSha === target.localSha) return true;
+
+	// A later push may already have advanced the remote ref. When the newer tip
+	// exists locally, ancestry still proves that this push reached the remote.
+	const ancestor = await execGit(["merge-base", "--is-ancestor", target.localSha, remoteSha], cwd);
+	return ancestor.exitCode === 0;
+}
+
+async function waitForConfirmedPushes(
+	cwd: string,
+	hashes: ReadonlyArray<string>,
+	entries: Readonly<Record<string, PushPendingEntry>>,
+	source: PushSource,
+): Promise<string[]> {
+	const targets = new Map<string, PushTarget>();
+	for (const hash of hashes) {
+		for (const target of entries[hash].pushTargets ?? []) targets.set(pushTargetKey(target), target);
+	}
+	if (targets.size === 0) return [...hashes]; // Backward compatibility for legacy pending files.
+
+	const confirmedTargets = new Set<string>();
+	const pushRemotes = new Map<string, string>();
+	for (const target of targets.values()) {
+		if (!pushRemotes.has(target.remote))
+			pushRemotes.set(target.remote, await resolvePushRemote(cwd, target.remote));
+	}
+	const attempts = source === "pre-push" ? PUSH_CONFIRM_POLL_ATTEMPTS : 1;
+	for (let attempt = 0; attempt < attempts; attempt++) {
+		await Promise.all(
+			[...targets].map(async ([key, target]) => {
+				if (
+					!confirmedTargets.has(key) &&
+					(await isPushTargetConfirmed(cwd, target, pushRemotes.get(target.remote) ?? target.remote))
+				)
+					confirmedTargets.add(key);
+			}),
+		);
+		const confirmedHashes = hashes.filter((hash) => {
+			const entryTargets = entries[hash].pushTargets;
+			return !entryTargets?.length || entryTargets.some((target) => confirmedTargets.has(pushTargetKey(target)));
+		});
+		if (confirmedHashes.length === hashes.length || attempt === attempts - 1) return confirmedHashes;
+		await new Promise<void>((resolve) => setTimeout(resolve, PUSH_CONFIRM_POLL_INTERVAL_MS));
+	}
+	return [];
+}
+
+async function buildAttachmentOwnership(
+	cwd: string,
+	storage: StorageProvider,
+	pendingEntries: Readonly<Record<string, PushPendingEntry>>,
+	hashes: ReadonlyArray<string>,
+	candidates: ReadonlyMap<string, CommitSummary>,
+): Promise<{
+	ownedPlans: Map<string, NonNullable<CommitSummary["plans"]>>;
+	ownedNotes: Map<string, NonNullable<CommitSummary["notes"]>>;
+}> {
+	const branches = new Set(hashes.map((hash) => pendingEntries[hash].branch));
+	const contexts = new Map<string, Map<string, CommitSummary>>();
+	for (const branch of branches) contexts.set(branch, new Map());
+
+	const currentBranch = await getCurrentBranch(cwd);
+	if (branches.has(currentBranch)) {
+		const base = await getDefaultBranch(cwd);
+		const { summaries } = await loadBranchSummaries(cwd, base);
+		const context = contexts.get(currentBranch);
+		for (const summary of summaries) context?.set(summary.commitHash, summary);
+	}
+
+	const offCurrentBranches = new Set([...branches].filter((branch) => branch !== currentBranch));
+	if (offCurrentBranches.size > 0) {
+		const indexEntries = await getIndexEntryMap(cwd, storage);
+		const rootHashes = new Set<string>();
+		for (const entry of indexEntries.values()) {
+			if (entry.parentCommitHash == null && offCurrentBranches.has(entry.branch))
+				rootHashes.add(entry.commitHash);
+		}
+		for (const hash of rootHashes) {
+			const summary = candidates.get(hash) ?? (await getSummary(hash, cwd, storage));
+			if (summary?.commitHash === hash) contexts.get(summary.branch)?.set(hash, summary);
+		}
+	}
+
+	for (const hash of hashes) {
+		const summary = candidates.get(hash);
+		if (summary) contexts.get(pendingEntries[hash].branch)?.set(hash, summary);
+	}
+
+	const ownedPlans = new Map<string, NonNullable<CommitSummary["plans"]>>();
+	const ownedNotes = new Map<string, NonNullable<CommitSummary["notes"]>>();
+	for (const context of contexts.values()) {
+		const summaries = [...context.values()].sort((a, b) => a.generatedAt.localeCompare(b.generatedAt));
+		const owned = assignOwnedAttachments(summaries);
+		for (const [hash, plans] of owned.ownedPlans) ownedPlans.set(hash, plans);
+		for (const [hash, notes] of owned.ownedNotes) ownedNotes.set(hash, notes);
+	}
+	return { ownedPlans, ownedNotes };
+}
+
+/**
+ * Drains eligible entries from `push-pending.json` to the bound Jolli Space.
+ * Idempotent and safe to call concurrently across processes — every state
+ * mutation goes through `updateBatch` (locked + re-read).
+ */
+export async function processPushPending(
+	cwd: string,
+	options: ProcessPushPendingOptions,
+): Promise<ProcessPushPendingResult> {
+	const empty: ProcessPushPendingResult = {
+		attempted: 0,
+		pushed: 0,
+		failed: 0,
+		skippedNoMemory: 0,
+		skippedRetryExhausted: 0,
+		deletedChildren: 0,
+	};
+
+	// Unlocked pre-flight read: cheap scan for eligible candidates. The actual
+	// commitment to process specific hashes happens via `claimForPush` below,
+	// which atomically stamps `claimedAt` under the file lock so concurrent
+	// processes never double-push the same entry.
+	const pending = await loadPushPending(cwd);
+	const allHashes = Object.keys(pending.entries);
+	if (allHashes.length === 0) return { ...empty, note: "no pending entries" };
+
+	const config = await loadConfig();
+
+	// Opt-out gate: syncOnPush=false means the user explicitly disabled
+	// push-to-Space sync. Keep the entries (re-enabling should catch up)
+	// but do not upload anything — applies to ALL callers (activation,
+	// post-queue, pre-push), not just the pre-push hook.
+	if (config.syncOnPush === false) {
+		log.info("processPushPending(%s): syncOnPush disabled — skipping %d entries", options.source, allHashes.length);
+		return { ...empty, note: "syncOnPush disabled" };
+	}
+
+	// Auth gate: without a jolliApiKey there is nothing to push to. Keep the
+	// entries (the user may sign in later) and return without marking failures.
+	if (!config.jolliApiKey) {
+		log.info(
+			"processPushPending(%s): not signed in — keeping %d entries for later",
+			options.source,
+			allHashes.length,
+		);
+		return { ...empty, note: "not signed in" };
+	}
+
+	// Eligible = under the retry ceiling, and (when a filter is set) in the filter.
+	let skippedRetryExhausted = 0;
+	const eligible: string[] = [];
+	for (const hash of allHashes) {
+		if (options.hashFilter && !options.hashFilter.has(hash)) continue;
+		const entry = pending.entries[hash];
+		if (entry.retryCount >= MAX_RETRY_COUNT) {
+			skippedRetryExhausted++;
+			continue;
+		}
+		eligible.push(hash);
+	}
+	if (eligible.length === 0) return { ...empty, skippedRetryExhausted, note: "no eligible entries" };
+
+	// The hook runs before Git transfers objects, so the detached worker can start
+	// while the push is still in flight. Do not publish until the remote ref proves
+	// that the push succeeded. Failed/rejected pushes remain pending for a retry.
+	const confirmed = await waitForConfirmedPushes(cwd, eligible, pending.entries, options.source);
+	if (confirmed.length === 0) return { ...empty, skippedRetryExhausted, note: "push not confirmed" };
+
+	// Atomic claim: stamp `claimedAt` on every confirmed hash under the file
+	// lock. A concurrent `processPushPending` that races us will see a fresh
+	// `claimedAt` and skip the entry, preventing duplicate Space articles.
+	const { claimed, entries: claimedEntries } = await claimForPush(cwd, confirmed);
+	if (claimed.size === 0) return { ...empty, skippedRetryExhausted, note: "all entries claimed by another process" };
+	const claimedHashes = confirmed.filter((h) => claimed.has(h));
+
+	const storage = await ensureStorage(cwd);
+
+	// Only push commits whose memory has actually been generated. Entries whose
+	// summary isn't in storage yet stay pending (QueueWorker's post-drain trigger
+	// picks them up once the summary lands).
+	//
+	// Also skip hashes that are now children in the index (squashed/merged into
+	// another root). Pushing a child standalone would call storeSummary(force=true)
+	// which re-creates its index entry as a root — a zombie that duplicates the
+	// merged root's content and whose Space article gets orphaned on the next
+	// cleanup pass.
+	const indexEntries = await getIndexEntryMap(cwd, storage);
+	const withMemory: string[] = [];
+	const candidateSummaries = new Map<string, CommitSummary>();
+	let skippedNoMemory = 0;
+	let deletedChildren = 0;
+	// Pre-flight updates cover hashes we decided NOT to push in this pass:
+	//   - Merged children               → { kind: "delete" }
+	//   - Missing / mismatched summary  → { kind: "patch", patch: {} }
+	// The empty patch is load-bearing: `updateBatch` writes
+	// `claimedAt: undefined` on every patch, which releases the claim
+	// stamped by `claimForPush` above. Without this release, QueueWorker's
+	// post-drain `triggerPushForNewSummaries` would hit the still-fresh
+	// `claimedAt` and skip the push, defeating the "push arrived before
+	// memory" compensation path this feature was built for.
+	const preFlightUpdates = new Map<string, BatchUpdate>();
+	for (const hash of claimedHashes) {
+		const indexEntry = indexEntries.get(hash);
+		if (indexEntry && indexEntry.parentCommitHash != null) {
+			preFlightUpdates.set(hash, { kind: "delete" });
+			deletedChildren++;
+			log.info(
+				"Skipping child entry %s (parent=%s) — already merged",
+				hash.substring(0, 8),
+				indexEntry.parentCommitHash.substring(0, 8),
+			);
+			continue;
+		}
+		const summary = await getSummary(hash, cwd, storage);
+		// Reject tree-hash-resolved summaries (commitHash mismatch): the real
+		// summary for this commit hasn't been generated yet — leave the entry
+		// pending so QueueWorker's triggerPushForNewSummaries picks it up once
+		// the proper summary lands. Without this, a squash+push races the
+		// merge worker and pushes a stale pre-squash summary via tree fallback.
+		if (summary && summary.commitHash === hash) {
+			withMemory.push(hash);
+			candidateSummaries.set(hash, summary);
+		} else {
+			preFlightUpdates.set(hash, { kind: "patch", patch: {} });
+			skippedNoMemory++;
+		}
+	}
+	if (preFlightUpdates.size > 0) {
+		await updateBatch(cwd, preFlightUpdates);
+	}
+	if (withMemory.length === 0) {
+		const note =
+			deletedChildren > 0 && skippedNoMemory === 0
+				? "all candidates were merged children"
+				: "no candidates with memory";
+		return { ...empty, skippedNoMemory, skippedRetryExhausted, deletedChildren, note };
+	}
+
+	const { ownedPlans, ownedNotes } = await buildAttachmentOwnership(
+		cwd,
+		storage,
+		claimedEntries,
+		withMemory,
+		candidateSummaries,
+	);
+
+	const client = options.client ?? new JolliMemoryPushClient();
+	const repoUrl = await getCanonicalRepoUrl(cwd);
+	const baseUrl = await client.resolveBaseUrl();
+	const ctx: PushContext = { cwd, baseUrl, repoUrl, client, storage };
+
+	log.info("processPushPending(%s): pushing %d commit(s)", options.source, withMemory.length);
+
+	const updates = new Map<string, BatchUpdate>();
+	const nowIso = new Date().toISOString();
+
+	const results = await mapWithConcurrency(
+		withMemory,
+		PUSH_CONCURRENCY,
+		async (hash): Promise<"pushed" | "failed"> => {
+			// Re-read immediately before the network call so a concurrent rewrite or
+			// cleanup cannot make us publish a stale summary captured above.
+			const summary = await getSummary(hash, cwd, storage);
+			if (!summary || summary.commitHash !== hash) {
+				// Raced away (deleted between the memory check and here), or
+				// tree-hash fallback resolved to another commit's summary. Drop it.
+				updates.set(hash, { kind: "delete" });
+				return "failed";
+			}
+			const attachments: AttachmentSelection = {
+				plans: ownedPlans.get(hash) ?? [],
+				notes: ownedNotes.get(hash) ?? [],
+			};
+			try {
+				await pushSummary(summary, ctx, attachments);
+				updates.set(hash, { kind: "delete" });
+				return "pushed";
+			} catch (err) {
+				const { increment, message } = classifyError(err);
+				const entry = claimedEntries[hash];
+				updates.set(hash, {
+					kind: "patch",
+					patch: {
+						lastAttemptAt: nowIso,
+						lastError: message,
+						...(increment ? { retryCount: entry.retryCount + 1 } : {}),
+					},
+				});
+				log.warn(
+					"Push failed for %s: %s (retry %s)",
+					hash.substring(0, 8),
+					message,
+					increment ? "counted" : "held",
+				);
+				return "failed";
+			}
+		},
+	);
+
+	await updateBatch(cwd, updates);
+
+	const pushed = results.filter((r) => r === "pushed").length;
+	const failed = results.filter((r) => r === "failed").length;
+	log.info("processPushPending(%s): pushed=%d failed=%d", options.source, pushed, failed);
+
+	return {
+		attempted: withMemory.length,
+		pushed,
+		failed,
+		skippedNoMemory,
+		skippedRetryExhausted,
+		deletedChildren,
+	};
+}
+
+/**
+ * Fire-and-forget trigger for the QueueWorker post-drain path. Runs on the next
+ * tick so the caller (the worker's drain loop) never awaits a network round-trip
+ * — a slow or offline push must not extend the worker's lock hold or delay the
+ * ingest phase. Failures are swallowed to debug: the entries survive in
+ * push-pending.json and the next push / activation retries them.
+ */
+export function triggerPushForNewSummaries(cwd: string, hashes: ReadonlyArray<string>): void {
+	if (hashes.length === 0) return;
+	const filter = new Set(hashes);
+	setImmediate(() => {
+		processPushPending(cwd, { source: "post-queue", hashFilter: filter }).catch((err) => {
+			log.debug("post-queue push trigger failed (will retry later): %s", errMsg(err));
+		});
+	});
+}

--- a/cli/src/core/PushPendingStore.test.ts
+++ b/cli/src/core/PushPendingStore.test.ts
@@ -1,0 +1,357 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { JOLLI_DIR, JOLLIMEMORY_DIR } from "../Logger.js";
+import { withPushPendingLock } from "./Locks.js";
+import {
+	__writeForTest,
+	claimForPush,
+	deleteEntry,
+	loadPushPending,
+	mergeEntries,
+	PUSH_ERROR_MSG_MAX_LEN,
+	PUSH_PENDING_STALE_MS,
+	type PushPendingFile,
+	truncateError,
+	updateBatch,
+	updateEntry,
+} from "./PushPendingStore.js";
+
+let cwd: string;
+
+beforeEach(async () => {
+	cwd = join(tmpdir(), `push-pending-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	await mkdir(join(cwd, JOLLI_DIR, JOLLIMEMORY_DIR), { recursive: true });
+});
+
+afterEach(async () => {
+	await rm(cwd, { recursive: true, force: true });
+});
+
+function filePath(): string {
+	return join(cwd, JOLLI_DIR, JOLLIMEMORY_DIR, "push-pending.json");
+}
+
+const HASH_A = "a".repeat(40);
+const HASH_B = "b".repeat(40);
+const TARGET = { remote: "origin", remoteRef: "refs/heads/feature/x", localSha: HASH_B } as const;
+
+describe("loadPushPending", () => {
+	it("returns empty when the file is missing", async () => {
+		const file = await loadPushPending(cwd);
+		expect(file.version).toBe(1);
+		expect(Object.keys(file.entries)).toHaveLength(0);
+	});
+
+	it("returns empty and does not throw on corrupt JSON", async () => {
+		await writeFile(filePath(), "not json {", "utf8");
+		const file = await loadPushPending(cwd);
+		expect(Object.keys(file.entries)).toHaveLength(0);
+	});
+
+	it("returns empty on an unexpected shape (wrong version)", async () => {
+		await writeFile(filePath(), JSON.stringify({ version: 99, entries: {} }), "utf8");
+		const file = await loadPushPending(cwd);
+		expect(Object.keys(file.entries)).toHaveLength(0);
+	});
+
+	it("reads back a valid file", async () => {
+		const now = new Date().toISOString();
+		await __writeForTest(cwd, {
+			version: 1,
+			entries: { [HASH_A]: { branch: "feature/x", enqueuedAt: now, retryCount: 0 } },
+		});
+		const file = await loadPushPending(cwd);
+		expect(file.entries[HASH_A]).toMatchObject({ branch: "feature/x", retryCount: 0 });
+	});
+
+	it("prunes an entry older than the stale window (by enqueuedAt) and unlinks when empty", async () => {
+		const old = new Date(Date.now() - PUSH_PENDING_STALE_MS - 1000).toISOString();
+		await __writeForTest(cwd, {
+			version: 1,
+			entries: { [HASH_A]: { branch: "b", enqueuedAt: old, retryCount: 0 } },
+		});
+		const file = await loadPushPending(cwd);
+		expect(Object.keys(file.entries)).toHaveLength(0);
+		// File unlinked once empty.
+		await expect(readFile(filePath(), "utf8")).rejects.toThrow();
+	});
+
+	it("uses lastAttemptAt over enqueuedAt for staleness (fresh attempt keeps an old entry)", async () => {
+		const oldEnqueue = new Date(Date.now() - PUSH_PENDING_STALE_MS - 1000).toISOString();
+		const recentAttempt = new Date(Date.now() - 1000).toISOString();
+		await __writeForTest(cwd, {
+			version: 1,
+			entries: {
+				[HASH_A]: { branch: "b", enqueuedAt: oldEnqueue, lastAttemptAt: recentAttempt, retryCount: 1 },
+			},
+		});
+		const file = await loadPushPending(cwd);
+		expect(file.entries[HASH_A]).toBeDefined();
+	});
+
+	it("keeps an entry with a malformed anchor (NaN treated as fresh)", async () => {
+		await __writeForTest(cwd, {
+			version: 1,
+			entries: { [HASH_A]: { branch: "b", enqueuedAt: "not-a-date", retryCount: 0 } },
+		});
+		const file = await loadPushPending(cwd);
+		expect(file.entries[HASH_A]).toBeDefined();
+	});
+
+	it("prunes only the stale entry, keeps the fresh one, and rewrites the file", async () => {
+		const old = new Date(Date.now() - PUSH_PENDING_STALE_MS - 1000).toISOString();
+		const fresh = new Date().toISOString();
+		await __writeForTest(cwd, {
+			version: 1,
+			entries: {
+				[HASH_A]: { branch: "b", enqueuedAt: old, retryCount: 0 },
+				[HASH_B]: { branch: "b", enqueuedAt: fresh, retryCount: 0 },
+			},
+		});
+		const file = await loadPushPending(cwd);
+		expect(Object.keys(file.entries)).toEqual([HASH_B]);
+		const onDisk = JSON.parse(await readFile(filePath(), "utf8")) as PushPendingFile;
+		expect(Object.keys(onDisk.entries)).toEqual([HASH_B]);
+	});
+
+	it("waits for push-pending.lock before persisting a stale prune", async () => {
+		const old = new Date(Date.now() - PUSH_PENDING_STALE_MS - 1000).toISOString();
+		await __writeForTest(cwd, {
+			version: 1,
+			entries: { [HASH_A]: { branch: "b", enqueuedAt: old, retryCount: 0 } },
+		});
+
+		let releaseHolder: () => void = () => {};
+		let markEntered: () => void = () => {};
+		const entered = new Promise<void>((resolve) => {
+			markEntered = resolve;
+		});
+		const holder = withPushPendingLock(cwd, async () => {
+			markEntered();
+			await new Promise<void>((resolve) => {
+				releaseHolder = resolve;
+			});
+		});
+		await entered;
+
+		const loading = loadPushPending(cwd);
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		await expect(readFile(filePath(), "utf8")).resolves.toContain(HASH_A);
+
+		releaseHolder();
+		await holder;
+		const file = await loading;
+		expect(Object.keys(file.entries)).toHaveLength(0);
+		await expect(readFile(filePath(), "utf8")).rejects.toThrow();
+	});
+});
+
+describe("mergeEntries", () => {
+	it("adds new hashes with retryCount 0", async () => {
+		await mergeEntries(cwd, [HASH_A, HASH_B], "feature/x");
+		const file = await loadPushPending(cwd);
+		expect(file.entries[HASH_A]).toMatchObject({ branch: "feature/x", retryCount: 0 });
+		expect(file.entries[HASH_B]).toMatchObject({ branch: "feature/x", retryCount: 0 });
+	});
+
+	it("stores the remote confirmation target on a new entry", async () => {
+		await mergeEntries(cwd, [HASH_A], "feature/x", TARGET);
+		const file = await loadPushPending(cwd);
+		expect(file.entries[HASH_A].pushTargets).toEqual([TARGET]);
+	});
+
+	it("preserves existing retry state for a hash already present", async () => {
+		await __writeForTest(cwd, {
+			version: 1,
+			entries: {
+				[HASH_A]: { branch: "b", enqueuedAt: new Date().toISOString(), retryCount: 2, lastError: "boom" },
+			},
+		});
+		await mergeEntries(cwd, [HASH_A], "feature/x");
+		const file = await loadPushPending(cwd);
+		expect(file.entries[HASH_A]).toMatchObject({ retryCount: 2, lastError: "boom", branch: "b" });
+	});
+
+	it("adds and deduplicates a remote confirmation target on existing entries", async () => {
+		await mergeEntries(cwd, [HASH_A], "feature/x");
+		await mergeEntries(cwd, [HASH_A], "feature/x", TARGET);
+		await mergeEntries(cwd, [HASH_A], "feature/x", TARGET);
+
+		const file = await loadPushPending(cwd);
+		expect(file.entries[HASH_A].pushTargets).toEqual([TARGET]);
+	});
+
+	it("no-ops on an empty hash list", async () => {
+		await mergeEntries(cwd, [], "feature/x");
+		await expect(readFile(filePath(), "utf8")).rejects.toThrow();
+	});
+
+	it("prunes stale entries inside the existing merge lock", async () => {
+		const old = new Date(Date.now() - PUSH_PENDING_STALE_MS - 1000).toISOString();
+		await __writeForTest(cwd, {
+			version: 1,
+			entries: { [HASH_A]: { branch: "b", enqueuedAt: old, retryCount: 0 } },
+		});
+
+		await mergeEntries(cwd, [HASH_B], "feature/x");
+
+		const onDisk = JSON.parse(await readFile(filePath(), "utf8")) as PushPendingFile;
+		expect(Object.keys(onDisk.entries)).toEqual([HASH_B]);
+	});
+});
+
+describe("updateBatch / updateEntry / deleteEntry", () => {
+	beforeEach(async () => {
+		await mergeEntries(cwd, [HASH_A, HASH_B], "feature/x");
+	});
+
+	it("deletes an entry", async () => {
+		await deleteEntry(cwd, HASH_A);
+		const file = await loadPushPending(cwd);
+		expect(file.entries[HASH_A]).toBeUndefined();
+		expect(file.entries[HASH_B]).toBeDefined();
+	});
+
+	it("patches retryCount + lastError (truncating the error)", async () => {
+		const longError = "x".repeat(PUSH_ERROR_MSG_MAX_LEN + 50);
+		await updateEntry(cwd, HASH_A, {
+			retryCount: 1,
+			lastError: longError,
+			lastAttemptAt: new Date().toISOString(),
+		});
+		const file = await loadPushPending(cwd);
+		expect(file.entries[HASH_A].retryCount).toBe(1);
+		expect(file.entries[HASH_A].lastError?.length).toBe(PUSH_ERROR_MSG_MAX_LEN);
+	});
+
+	it("preserves pushTargets while applying a retry patch", async () => {
+		await mergeEntries(cwd, [HASH_A], "feature/x", TARGET);
+		await updateEntry(cwd, HASH_A, { retryCount: 1 });
+
+		const file = await loadPushPending(cwd);
+		expect(file.entries[HASH_A].pushTargets).toEqual([TARGET]);
+	});
+
+	it("clears lastError when patched with null", async () => {
+		await updateEntry(cwd, HASH_A, { lastError: "boom" });
+		await updateEntry(cwd, HASH_A, { lastError: null });
+		const file = await loadPushPending(cwd);
+		expect(file.entries[HASH_A].lastError).toBeUndefined();
+	});
+
+	it("ignores updates for hashes no longer present", async () => {
+		await deleteEntry(cwd, HASH_A);
+		await updateEntry(cwd, HASH_A, { retryCount: 5 }); // gone — no-op
+		const file = await loadPushPending(cwd);
+		expect(file.entries[HASH_A]).toBeUndefined();
+	});
+
+	it("applies a mixed delete + patch batch and unlinks when all removed", async () => {
+		await updateBatch(
+			cwd,
+			new Map([
+				[HASH_A, { kind: "delete" }],
+				[HASH_B, { kind: "delete" }],
+			]),
+		);
+		await expect(readFile(filePath(), "utf8")).rejects.toThrow();
+	});
+
+	it("no-ops on an empty update map", async () => {
+		await updateBatch(cwd, new Map());
+		const file = await loadPushPending(cwd);
+		expect(Object.keys(file.entries)).toHaveLength(2);
+	});
+
+	it("survives concurrent mergeEntries without losing updates (lock + re-read)", async () => {
+		const hashes = Array.from({ length: 6 }, (_, i) => String(i).repeat(40).slice(0, 40));
+		await Promise.all(hashes.map((h) => mergeEntries(cwd, [h], "feature/x")));
+		const file = await loadPushPending(cwd);
+		// The two from beforeEach plus the six new = 8 distinct entries.
+		expect(Object.keys(file.entries).length).toBe(8);
+	});
+});
+
+describe("claimForPush", () => {
+	it("returns empty when there are no candidates", async () => {
+		const r = await claimForPush(cwd, []);
+		expect(r.claimed.size).toBe(0);
+	});
+
+	it("claims fresh entries and stamps claimedAt on disk", async () => {
+		const now = new Date().toISOString();
+		await __writeForTest(cwd, {
+			version: 1,
+			entries: { [HASH_A]: { branch: "feature/x", enqueuedAt: now, retryCount: 0 } },
+		});
+		const r = await claimForPush(cwd, [HASH_A]);
+		expect(r.claimed.has(HASH_A)).toBe(true);
+		const file = await loadPushPending(cwd);
+		expect(file.entries[HASH_A].claimedAt).toBeDefined();
+	});
+
+	it("skips an entry already claimed by another process within the stale window", async () => {
+		const now = new Date().toISOString();
+		await __writeForTest(cwd, {
+			version: 1,
+			entries: {
+				[HASH_A]: { branch: "feature/x", enqueuedAt: now, retryCount: 0, claimedAt: now },
+			},
+		});
+		const r = await claimForPush(cwd, [HASH_A]);
+		expect(r.claimed.has(HASH_A)).toBe(false);
+	});
+
+	it("reclaims an entry whose claim has gone stale (crashed process)", async () => {
+		const stale = new Date(Date.now() - 6 * 60 * 1000).toISOString(); // > 5 min stale window
+		const now = new Date().toISOString();
+		await __writeForTest(cwd, {
+			version: 1,
+			entries: {
+				[HASH_A]: { branch: "feature/x", enqueuedAt: now, retryCount: 0, claimedAt: stale },
+			},
+		});
+		const r = await claimForPush(cwd, [HASH_A]);
+		expect(r.claimed.has(HASH_A)).toBe(true);
+	});
+
+	it("only one of two concurrent claimForPush calls acquires a given hash", async () => {
+		const now = new Date().toISOString();
+		await __writeForTest(cwd, {
+			version: 1,
+			entries: { [HASH_A]: { branch: "feature/x", enqueuedAt: now, retryCount: 0 } },
+		});
+		const [r1, r2] = await Promise.all([claimForPush(cwd, [HASH_A]), claimForPush(cwd, [HASH_A])]);
+		expect(r1.claimed.has(HASH_A) !== r2.claimed.has(HASH_A)).toBe(true);
+	});
+
+	it("silently skips a hash that has no pending entry", async () => {
+		const r = await claimForPush(cwd, [HASH_A]);
+		expect(r.claimed.has(HASH_A)).toBe(false);
+	});
+
+	it("updateBatch clears claimedAt when patching an entry so retries are unblocked", async () => {
+		const now = new Date().toISOString();
+		await __writeForTest(cwd, {
+			version: 1,
+			entries: { [HASH_A]: { branch: "feature/x", enqueuedAt: now, retryCount: 0, claimedAt: now } },
+		});
+		await updateEntry(cwd, HASH_A, { retryCount: 1, lastError: "boom" });
+		const file = await loadPushPending(cwd);
+		expect(file.entries[HASH_A].claimedAt).toBeUndefined();
+		expect(file.entries[HASH_A].retryCount).toBe(1);
+	});
+});
+
+describe("truncateError", () => {
+	it("leaves short strings untouched", () => {
+		expect(truncateError("short")).toBe("short");
+	});
+	it("truncates and appends an ellipsis for long strings", () => {
+		const out = truncateError("y".repeat(PUSH_ERROR_MSG_MAX_LEN + 10));
+		expect(out.length).toBe(PUSH_ERROR_MSG_MAX_LEN);
+		expect(out.endsWith("…")).toBe(true);
+	});
+});

--- a/cli/src/core/PushPendingStore.ts
+++ b/cli/src/core/PushPendingStore.ts
@@ -1,0 +1,422 @@
+/**
+ * PushPendingStore — persistent record of commits whose Memory Bank summaries
+ * need to be synced to Jolli Space by the pre-push hook flow.
+ *
+ * File shape (`<projectDir>/.jolli/jollimemory/push-pending.json`):
+ *
+ *   {
+ *     "version": 1,
+ *     "entries": {
+ *       "<full 40-char commit hash>": {
+ *         "branch": "feature/xxx",
+ *         "enqueuedAt": "ISO-8601",
+ *         "lastAttemptAt": "ISO-8601"?,   // set on every push attempt (success or fail)
+ *         "retryCount": number,           // increments only on "operational" failure
+ *         "lastError": "string"?,         // truncated to PUSH_ERROR_MSG_MAX_LEN chars
+ *         "pushTargets": [{                // remote refs that can confirm the push succeeded
+ *           "remote": "origin",
+ *           "remoteRef": "refs/heads/feature/xxx",
+ *           "localSha": "<full 40-char commit hash>"
+ *         }]?
+ *       }
+ *     }
+ *   }
+ *
+ * Read-time stale prune (mirrors `SessionTracker.pruneStale`): each `load()`
+ * drops entries whose `lastAttemptAt ?? enqueuedAt` is older than
+ * PUSH_PENDING_STALE_MS. When the resulting entries object is empty the file
+ * is unlinked so the directory stays clean between pushes.
+ *
+ * Concurrency: three writers can race — the pre-push hook, the pre-push
+ * worker's success/failure accounting, and QueueWorker's post-drain follow-up.
+ * All mutation goes through `withPushPendingLock` (see Locks.ts) + re-read
+ * inside the lock so lost-update is avoided.
+ */
+
+import { readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { createLogger, errMsg, getJolliMemoryDir, isEnoent } from "../Logger.js";
+import { atomicWriteFile } from "./AtomicWrite.js";
+import { withPushPendingLock } from "./Locks.js";
+import { ensureJolliMemoryDir } from "./SessionTracker.js";
+
+const log = createLogger("PushPendingStore");
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+/** File name under `.jolli/jollimemory/`. */
+export const PUSH_PENDING_FILE = "push-pending.json";
+
+/**
+ * Entries whose `lastAttemptAt ?? enqueuedAt` is older than this are dropped
+ * on read. Aligned with `GIT_OP_QUEUE_STALE_MS` (7 days) — long enough for
+ * offline/rest-of-week workflows to catch up, short enough that abandoned
+ * failed entries don't accumulate forever. Retry-exhausted entries
+ * (`retryCount >= MAX_RETRY_COUNT`) rely on this to eventually clear.
+ */
+export const PUSH_PENDING_STALE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Max concurrent per-commit push calls inside `PushExecutor.processPushPending`.
+ * Chosen to match the small, IO-bound nature of `pushSummary` and stay well
+ * under any reasonable server rate limit.
+ */
+export const PUSH_CONCURRENCY = 3;
+
+/**
+ * Retry ceiling for "operational" failures (network / 5xx / 4xx / unknown).
+ * Configuration failures (`NotAuthenticatedError`, `BindingRequiredError`,
+ * `ClientOutdatedError`) do NOT increment `retryCount` — see PushExecutor.
+ */
+export const MAX_RETRY_COUNT = 3;
+
+/** Truncation length for `entry.lastError` — keep the file compact. */
+export const PUSH_ERROR_MSG_MAX_LEN = 200;
+
+const SCHEMA_VERSION = 1 as const;
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface PushTarget {
+	readonly remote: string;
+	readonly remoteRef: string;
+	readonly localSha: string;
+}
+
+export interface PushPendingEntry {
+	readonly branch: string;
+	readonly enqueuedAt: string;
+	readonly lastAttemptAt?: string;
+	readonly retryCount: number;
+	readonly lastError?: string;
+	/** Successful confirmation of any target proves this commit reached the remote. */
+	readonly pushTargets?: ReadonlyArray<PushTarget>;
+	/**
+	 * ISO-8601 timestamp set by `claimForPush` when a process begins pushing
+	 * this entry. Prevents concurrent processes from double-pushing the same
+	 * commit. Cleared on completion (delete or patch). Treated as stale after
+	 * `CLAIM_STALE_MS` so a crashed process doesn't lock an entry forever.
+	 */
+	readonly claimedAt?: string;
+}
+
+export interface PushPendingFile {
+	readonly version: typeof SCHEMA_VERSION;
+	readonly entries: Readonly<Record<string, PushPendingEntry>>;
+}
+
+/**
+ * Patch applied to a single entry by `updateBatch`. `lastError: null` clears the
+ * field; a string overwrites (and is truncated); omitting a key leaves it
+ * unchanged.
+ */
+export interface PushPendingEntryPatch {
+	readonly lastAttemptAt?: string;
+	readonly retryCount?: number;
+	readonly lastError?: string | null;
+}
+
+export type BatchUpdate =
+	| { readonly kind: "delete" }
+	| { readonly kind: "patch"; readonly patch: PushPendingEntryPatch };
+
+/**
+ * How long a claim is considered valid before another process can reclaim the
+ * entry. Sized for the worst-case push round: PUSH_CONCURRENCY * per-push
+ * timeout (30 s default) plus headroom for push-confirmation polling (60 s).
+ * A crashed process's claims expire after this, so entries are not stuck
+ * forever.
+ */
+const CLAIM_STALE_MS = 5 * 60 * 1000;
+
+// ─── Path helpers ───────────────────────────────────────────────────────────
+
+function pendingPath(cwd?: string): string {
+	return join(getJolliMemoryDir(cwd), PUSH_PENDING_FILE);
+}
+
+function emptyFile(): PushPendingFile {
+	return { version: SCHEMA_VERSION, entries: {} };
+}
+
+/** Truncate helper exported for PushExecutor + tests. */
+export function truncateError(msg: string): string {
+	if (msg.length <= PUSH_ERROR_MSG_MAX_LEN) return msg;
+	return `${msg.substring(0, PUSH_ERROR_MSG_MAX_LEN - 1)}…`;
+}
+
+// ─── Load (with locked stale prune) ─────────────────────────────────────────
+
+interface PushPendingSnapshot {
+	readonly file: PushPendingFile;
+	readonly prunedCount: number;
+}
+
+/**
+ * Reads and validates `push-pending.json`, then computes the surviving entries
+ * without writing. Callers that mutate the file use this inside
+ * `withPushPendingLock`; the public load path takes the same lock only when a
+ * stale-prune write is actually needed. Keeping the raw read side-effect free
+ * avoids a lock-free read→write race with `mergeEntries` / `updateBatch`.
+ */
+async function readPushPendingSnapshot(cwd?: string): Promise<PushPendingSnapshot> {
+	const path = pendingPath(cwd);
+	let raw: string;
+	try {
+		raw = await readFile(path, "utf-8");
+	} catch (err: unknown) {
+		if (isEnoent(err)) return { file: emptyFile(), prunedCount: 0 };
+		log.warn("Failed to read %s: %s", PUSH_PENDING_FILE, errMsg(err));
+		return { file: emptyFile(), prunedCount: 0 };
+	}
+
+	let parsed: PushPendingFile;
+	try {
+		const data = JSON.parse(raw) as unknown;
+		if (!isValidFile(data)) {
+			log.warn("push-pending.json has unexpected shape — treating as empty");
+			return { file: emptyFile(), prunedCount: 0 };
+		}
+		parsed = data;
+	} catch (err) {
+		log.warn("Failed to parse push-pending.json: %s — treating as empty", errMsg(err));
+		return { file: emptyFile(), prunedCount: 0 };
+	}
+
+	const now = Date.now();
+	const surviving: Record<string, PushPendingEntry> = {};
+	let prunedCount = 0;
+	for (const [hash, entry] of Object.entries(parsed.entries)) {
+		const anchor = entry.lastAttemptAt ?? entry.enqueuedAt;
+		const anchorMs = Date.parse(anchor);
+		// A malformed / missing anchor (NaN) is treated as fresh (keep it) —
+		// discarding entries on a parse error would silently drop legit work.
+		if (Number.isFinite(anchorMs) && now - anchorMs > PUSH_PENDING_STALE_MS) {
+			prunedCount++;
+			continue;
+		}
+		surviving[hash] = entry;
+	}
+
+	return { file: { version: SCHEMA_VERSION, entries: surviving }, prunedCount };
+}
+
+function logPrunedEntries(prunedCount: number): void {
+	if (prunedCount === 0) return;
+	log.info("Pruned %d stale push-pending entries (>%dh old)", prunedCount, PUSH_PENDING_STALE_MS / 3600000);
+}
+
+/**
+ * Reads `push-pending.json`, pruning stale entries in place when necessary, and
+ * returns the surviving entries. Missing file → empty result. Never throws on
+ * read/parse errors: a corrupt file is logged and treated as empty so a bad
+ * state file never blocks the pre-push flow.
+ */
+export async function loadPushPending(cwd?: string): Promise<PushPendingFile> {
+	const initial = await readPushPendingSnapshot(cwd);
+	if (initial.prunedCount === 0) return initial.file;
+
+	const path = pendingPath(cwd);
+	return withPushPendingLock(cwd, async () => {
+		// Re-read after acquiring the lock. A concurrent enqueue may have refreshed
+		// or replaced entries since the optimistic read above.
+		const current = await readPushPendingSnapshot(cwd);
+		if (current.prunedCount > 0) {
+			await writeOrUnlink(path, { ...current.file.entries });
+			logPrunedEntries(current.prunedCount);
+		}
+		return current.file;
+	});
+}
+
+function isValidFile(value: unknown): value is PushPendingFile {
+	if (typeof value !== "object" || value === null) return false;
+	const obj = value as { version?: unknown; entries?: unknown };
+	if (obj.version !== SCHEMA_VERSION) return false;
+	if (typeof obj.entries !== "object" || obj.entries === null) return false;
+	return true;
+}
+
+// ─── Write helpers ──────────────────────────────────────────────────────────
+
+async function writeOrUnlink(path: string, entries: Record<string, PushPendingEntry>): Promise<void> {
+	if (Object.keys(entries).length === 0) {
+		try {
+			await rm(path, { force: true });
+		} catch (err) {
+			log.warn("Failed to unlink %s: %s", PUSH_PENDING_FILE, errMsg(err));
+		}
+		return;
+	}
+	await atomicWriteFile(path, JSON.stringify({ version: SCHEMA_VERSION, entries }, null, "\t"));
+}
+
+// ─── Public mutation API (all locked) ───────────────────────────────────────
+
+/**
+ * Merges a batch of commit hashes into the pending file. Preserves existing
+ * entries' retry state (retryCount / lastError / lastAttemptAt) — only fills
+ * new keys. Called by the pre-push hook.
+ */
+export async function mergeEntries(
+	cwd: string,
+	hashes: ReadonlyArray<string>,
+	branch: string,
+	pushTarget?: PushTarget,
+): Promise<void> {
+	if (hashes.length === 0) return;
+	await ensureJolliMemoryDir(cwd);
+	const path = pendingPath(cwd);
+	const now = new Date().toISOString();
+	await withPushPendingLock(cwd, async () => {
+		// Re-read inside the lock: another writer may have modified the file
+		// between the caller's earlier read and this write.
+		const current = await readPushPendingSnapshot(cwd);
+		const next: Record<string, PushPendingEntry> = { ...current.file.entries };
+		let added = 0;
+		let targetsAdded = 0;
+		for (const hash of hashes) {
+			const existing = next[hash];
+			if (existing) {
+				if (!pushTarget) continue;
+				const targets = existing.pushTargets ?? [];
+				const alreadyTracked = targets.some(
+					(target) =>
+						target.remote === pushTarget.remote &&
+						target.remoteRef === pushTarget.remoteRef &&
+						target.localSha === pushTarget.localSha,
+				);
+				if (alreadyTracked) continue;
+				next[hash] = { ...existing, pushTargets: [...targets, pushTarget] };
+				targetsAdded++;
+				continue;
+			}
+			next[hash] = {
+				branch,
+				enqueuedAt: now,
+				retryCount: 0,
+				...(pushTarget && { pushTargets: [pushTarget] }),
+			};
+			added++;
+		}
+		if (added === 0 && targetsAdded === 0 && current.prunedCount === 0) return;
+		await writeOrUnlink(path, next);
+		logPrunedEntries(current.prunedCount);
+		if (added > 0) log.info("Enqueued %d new push-pending entries (branch=%s)", added, branch);
+		if (targetsAdded > 0) log.debug("Added push confirmation targets to %d existing entries", targetsAdded);
+	});
+}
+
+/**
+ * Atomically claims a set of hashes for push processing. Inside the file lock,
+ * reads the current entries and stamps `claimedAt` on every unclaimed (or
+ * stale-claimed) hash from `candidates`. Returns only the hashes that were
+ * successfully claimed — concurrent callers that lose the race get an empty set
+ * for the contested hashes.
+ *
+ * This closes the TOCTOU gap in `processPushPending`: previously the unlocked
+ * `loadPushPending` read let two processes both see the same entries and both
+ * push them, creating duplicate Space articles.
+ */
+export async function claimForPush(
+	cwd: string,
+	candidates: ReadonlyArray<string>,
+): Promise<{ claimed: ReadonlySet<string>; entries: Readonly<Record<string, PushPendingEntry>> }> {
+	if (candidates.length === 0) return { claimed: new Set(), entries: {} };
+	const path = pendingPath(cwd);
+	const candidateSet = new Set(candidates);
+	return withPushPendingLock(cwd, async () => {
+		const current = await readPushPendingSnapshot(cwd);
+		const next: Record<string, PushPendingEntry> = { ...current.file.entries };
+		const nowMs = Date.now();
+		const nowIso = new Date(nowMs).toISOString();
+		const claimed = new Set<string>();
+
+		for (const hash of candidateSet) {
+			const entry = next[hash];
+			if (!entry) continue;
+			if (entry.claimedAt) {
+				const claimAge = nowMs - Date.parse(entry.claimedAt);
+				if (Number.isFinite(claimAge) && claimAge < CLAIM_STALE_MS) continue;
+			}
+			next[hash] = { ...entry, claimedAt: nowIso };
+			claimed.add(hash);
+		}
+
+		if (claimed.size > 0 || current.prunedCount > 0) {
+			await writeOrUnlink(path, next);
+			logPrunedEntries(current.prunedCount);
+		}
+		return { claimed, entries: current.file.entries };
+	});
+}
+
+/**
+ * Applies a batch of updates atomically. Used by PushExecutor after a round of
+ * push attempts to persist per-commit success/failure state in one write.
+ * Silently ignores updates for hashes no longer present (pruned or updated by a
+ * concurrent worker).
+ */
+export async function updateBatch(cwd: string, updates: ReadonlyMap<string, BatchUpdate>): Promise<void> {
+	if (updates.size === 0) return;
+	const path = pendingPath(cwd);
+	await withPushPendingLock(cwd, async () => {
+		const current = await readPushPendingSnapshot(cwd);
+		const next: Record<string, PushPendingEntry> = { ...current.file.entries };
+		let changed = 0;
+		for (const [hash, update] of updates) {
+			const existing = next[hash];
+			if (!existing) continue;
+			if (update.kind === "delete") {
+				delete next[hash];
+				changed++;
+				continue;
+			}
+			const patch = update.patch;
+			const merged: PushPendingEntry = {
+				branch: existing.branch,
+				enqueuedAt: existing.enqueuedAt,
+				pushTargets: existing.pushTargets,
+				lastAttemptAt: patch.lastAttemptAt ?? existing.lastAttemptAt,
+				retryCount: patch.retryCount ?? existing.retryCount,
+				lastError:
+					patch.lastError === null
+						? undefined
+						: patch.lastError !== undefined
+							? truncateError(patch.lastError)
+							: existing.lastError,
+				// Explicit: clear the claim on every patch so the entry can be
+				// retried by any process. Written as `undefined` (not omitted) so
+				// this stays load-bearing under future field additions — a new
+				// PushPendingEntry field would trip TypeScript's exactOptional /
+				// exhaustive-check rather than silently inheriting `existing`'s
+				// value alongside `claimedAt`.
+				claimedAt: undefined,
+			};
+			next[hash] = merged;
+			changed++;
+		}
+		if (changed === 0 && current.prunedCount === 0) return;
+		await writeOrUnlink(path, next);
+		logPrunedEntries(current.prunedCount);
+	});
+}
+
+/**
+ * Convenience: apply a single patch. Prefer `updateBatch` when applying more
+ * than one update to avoid taking the lock repeatedly.
+ */
+export async function updateEntry(cwd: string, hash: string, patch: PushPendingEntryPatch): Promise<void> {
+	await updateBatch(cwd, new Map<string, BatchUpdate>([[hash, { kind: "patch", patch }]]));
+}
+
+/** Convenience: delete a single entry. */
+export async function deleteEntry(cwd: string, hash: string): Promise<void> {
+	await updateBatch(cwd, new Map<string, BatchUpdate>([[hash, { kind: "delete" }]]));
+}
+
+/** Test-only helper: overwrite the file (bypasses the lock/merge path). */
+export async function __writeForTest(cwd: string, file: PushPendingFile): Promise<void> {
+	await ensureJolliMemoryDir(cwd);
+	await writeOrUnlink(pendingPath(cwd), { ...file.entries });
+}

--- a/cli/src/core/Regenerator.ts
+++ b/cli/src/core/Regenerator.ts
@@ -39,7 +39,8 @@ export interface RegenerateResult {
  *                         conversationTurns, llm, generatedAt
  * Fields preserved:       ticketId, e2eTestGuide, plans, notes, references,
  *                         commitType, commitSource, jolliDocUrl, jolliDocId,
- *                         orphanedDocIds, everything else on root.
+ *                         orphanedDocIds, unresolvedOrphanHashes, everything
+ *                         else on root.
  *
  * The function opens by calling `normalizeToV4(summary)` — a pure helper
  * that collapses every v3-special-case into the v4 unified-Hoist invariant

--- a/cli/src/core/SchemaV5Migration.ts
+++ b/cli/src/core/SchemaV5Migration.ts
@@ -408,7 +408,8 @@ async function migrateSchemaToV5Locked(
  *
  * v3 → v4: delegated to `normalizeToV4`, now lossless (preserves topics,
  *          recap, plans, notes, linearIssues, e2eTestGuide, jolliDoc fields,
- *          orphanedDocIds, and migrates legacy `stats` to `diffStats`).
+ *          orphanedDocIds, unresolvedOrphanHashes, and migrates legacy
+ *          `stats` to `diffStats`).
  *
  * v4 → v5: stamp `version: 5` and compute the transcripts array. We
  *          enumerate every commit hash in the (already-v4) tree via

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -775,6 +775,21 @@ describe("SummaryStore", () => {
 	});
 
 	describe("migrateOneToOne", () => {
+		it("preserves unresolved orphan hashes on a one-to-one rewrite", async () => {
+			const oldSummary: CommitSummary = {
+				...createMockSummary("oldhash", "Old message"),
+				unresolvedOrphanHashes: ["pending-child"],
+			};
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(JSON.stringify(v3Index([])));
+
+			await migrateOneToOne(oldSummary, createMockCommitInfo("newhash", "New message"));
+
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const migrated = JSON.parse(files[0].content) as CommitSummary;
+			expect(migrated.unresolvedOrphanHashes).toEqual(["pending-child"]);
+			expect(migrated.children?.[0].unresolvedOrphanHashes).toBeUndefined();
+		});
+
 		it("hoists recap from a v3 squash root's children (recap not dropped on rebase-pick)", async () => {
 			// A v3 squash root keeps its recap on children, not the root. Reading
 			// oldSummary.recap directly would drop it; resolveEffectiveRecap picks
@@ -861,7 +876,7 @@ describe("SummaryStore", () => {
 			expect(newSummaryContent.topics).toEqual(oldSummary.topics);
 			expect(newSummaryContent.stats).toBeUndefined();
 			expect(newSummaryContent.diffStats).toEqual({ filesChanged: 1, insertions: 5, deletions: 2 });
-			// Old summary preserved as the sole child, with all 8 Hoist fields stripped.
+			// Old summary preserved as the sole child, with all Hoist fields stripped.
 			expect(newSummaryContent.children).toHaveLength(1);
 			expect(newSummaryContent.children?.[0].commitHash).toBe(oldHash);
 			// Topics are now stripped from the embedded child under the unified Hoist contract.
@@ -1911,6 +1926,57 @@ describe("SummaryStore", () => {
 			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
 			const merged = JSON.parse(files[0].content) as CommitSummary;
 			expect(merged.orphanedDocIds).toBeUndefined();
+		});
+
+		it("should record unresolvedOrphanHashes for children without jolliDocId", async () => {
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null);
+
+			await mergeManyToOne(
+				[createMockSummary("old1"), createMockSummary("old2")],
+				createMockCommitInfo("newhash"),
+			);
+
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const merged = JSON.parse(files[0].content) as CommitSummary;
+			expect(merged.unresolvedOrphanHashes).toEqual(["old1", "old2"]);
+		});
+
+		it("carries inherited unresolved orphan hashes through a later resquash", async () => {
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null);
+			const old1 = {
+				...createMockSummary("old1"),
+				jolliDocId: 101,
+				jolliDocUrl: "https://x.jolli.ai/articles?doc=101",
+				unresolvedOrphanHashes: ["pending-grandchild"],
+			};
+
+			await mergeManyToOne([old1, createMockSummary("old2")], createMockCommitInfo("newhash"));
+
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const merged = JSON.parse(files[0].content) as CommitSummary;
+			expect(merged.unresolvedOrphanHashes).toEqual(["old2", "pending-grandchild"]);
+			expect(merged.children?.[0].unresolvedOrphanHashes).toBeUndefined();
+		});
+
+		it("should not record unresolvedOrphanHashes for children that have jolliDocId", async () => {
+			const s1: CommitSummary = {
+				...createMockSummary("old1"),
+				jolliDocId: 101,
+				jolliDocUrl: "https://x.jolli.ai/articles?doc=101",
+			};
+			const s2: CommitSummary = {
+				...createMockSummary("old2"),
+				jolliDocId: 102,
+				jolliDocUrl: "https://x.jolli.ai/articles?doc=102",
+			};
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null);
+
+			await mergeManyToOne([s1, s2], createMockCommitInfo("newhash"));
+
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const merged = JSON.parse(files[0].content) as CommitSummary;
+			expect(merged.unresolvedOrphanHashes).toBeUndefined();
+			expect(merged.orphanedDocIds).toEqual([102]);
 		});
 
 		it("should keep the existing note when a duplicate appears with an older updatedAt", async () => {

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -398,9 +398,8 @@ async function migrateOneToOneLocked(
 	);
 
 	// Wrap the old summary as a child rather than replacing its hash.
-	// stripFunctionalMetadata strips all 9 Hoist fields (the original 8 plus
-	// the Linear-issues field added when that integration shipped) so the
-	// root is solely authoritative.
+	// stripFunctionalMetadata strips all 10 Hoist fields, including delayed
+	// orphan cleanup hashes, so the root is solely authoritative.
 	const strippedOld = stripFunctionalMetadata(oldSummary);
 	const docUrl = oldSummary.jolliDocUrl;
 
@@ -442,6 +441,7 @@ async function migrateOneToOneLocked(
 		...(oldSummary.jolliDocId && { jolliDocId: oldSummary.jolliDocId }),
 		...(docUrl && { jolliDocUrl: docUrl }),
 		...(oldSummary.orphanedDocIds && { orphanedDocIds: oldSummary.orphanedDocIds }),
+		...(oldSummary.unresolvedOrphanHashes && { unresolvedOrphanHashes: oldSummary.unresolvedOrphanHashes }),
 		...(oldSummary.plans && { plans: oldSummary.plans }),
 		...(oldSummary.notes && { notes: oldSummary.notes }),
 		// References — same Copy-Hoist treatment as plans / notes. Without this
@@ -630,7 +630,7 @@ export function collectChildReferences(nodes: ReadonlyArray<CommitSummary>): Rea
 
 /** Returns a deep copy of the summary tree with Jolli metadata stripped from all nodes. */
 function stripJolliMetadata(node: CommitSummary): CommitSummary {
-	const { jolliDocId: _d, jolliDocUrl: _u, orphanedDocIds: _o, ...rest } = node;
+	const { jolliDocId: _d, jolliDocUrl: _u, orphanedDocIds: _o, unresolvedOrphanHashes: _h, ...rest } = node;
 	if (!rest.children) return rest as CommitSummary;
 	return { ...rest, children: rest.children.map(stripJolliMetadata) } as CommitSummary;
 }
@@ -701,6 +701,16 @@ function collectDescendantOrphanedDocIds(children: ReadonlyArray<CommitSummary> 
 	return ids;
 }
 
+/** Recursively collects unresolved article hashes already queued on descendants. */
+function collectDescendantUnresolvedOrphanHashes(children: ReadonlyArray<CommitSummary> | undefined): string[] {
+	const hashes: string[] = [];
+	for (const child of children ?? []) {
+		if (child.unresolvedOrphanHashes) hashes.push(...child.unresolvedOrphanHashes);
+		hashes.push(...collectDescendantUnresolvedOrphanHashes(child.children));
+	}
+	return hashes;
+}
+
 /**
  * Pure in-memory v3 → v4 (unified Hoist) normalization. No I/O — caller
  * persists the result via storeSummary if it wants the migration to stick.
@@ -710,7 +720,7 @@ function collectDescendantOrphanedDocIds(children: ReadonlyArray<CommitSummary> 
  *   - version: 4
  *   - root holds the authoritative Copy-Hoist fields (plans / notes /
  *     references / e2eTestGuide / jolliDocId / jolliDocUrl /
- *     orphanedDocIds), unioned across the whole tree via the same
+ *     orphanedDocIds / unresolvedOrphanHashes), unioned across the whole tree via the same
  *     `collectChild*` helpers
  *   - root holds authoritative `topics` and `recap` collected from the
  *     entire tree via `resolveEffectiveTopics` / `resolveEffectiveRecap`
@@ -752,6 +762,12 @@ export function normalizeToV4(summary: CommitSummary): CommitSummary {
 			...jolliMeta.orphanedDocIds,
 			...(summary.orphanedDocIds ?? []),
 			...collectDescendantOrphanedDocIds(summary.children),
+		]),
+	);
+	const allUnresolvedOrphanHashes = Array.from(
+		new Set<string>([
+			...(summary.unresolvedOrphanHashes ?? []),
+			...collectDescendantUnresolvedOrphanHashes(summary.children),
 		]),
 	);
 
@@ -801,6 +817,7 @@ export function normalizeToV4(summary: CommitSummary): CommitSummary {
 				}
 			: {}),
 		...(allOrphanedDocIds.length > 0 ? { orphanedDocIds: allOrphanedDocIds } : {}),
+		...(allUnresolvedOrphanHashes.length > 0 ? { unresolvedOrphanHashes: allUnresolvedOrphanHashes } : {}),
 		...(summary.children !== undefined ? { children: summary.children.map(stripFunctionalMetadata) } : {}),
 	};
 }
@@ -951,11 +968,11 @@ export function expandSourcesForConsolidation(oldSummary: CommitSummary): Readon
 }
 
 /**
- * Strips all 9 Hoist-managed fields from a summary node and its descendants.
+ * Strips all 10 Hoist-managed fields from a summary node and its descendants.
  *
- * Hoist family (9 fields):
- *   - Copy-Hoist (7): jolliDocId, jolliDocUrl, orphanedDocIds, plans, notes,
- *                    references, e2eTestGuide
+ * Hoist family (10 fields):
+ *   - Copy-Hoist (8): jolliDocId, jolliDocUrl, orphanedDocIds,
+ *                    unresolvedOrphanHashes, plans, notes, references, e2eTestGuide
  *   - Consolidate-Hoist (2): topics, recap
  *
  * `version` is intentionally NOT stripped -- it's an identity field, like
@@ -1046,6 +1063,18 @@ async function mergeManyToOneLocked(
 	const jolliMeta = collectChildJolliMeta(children);
 	const inheritedOrphanIds = children.flatMap((c) => c.orphanedDocIds ?? []);
 	const allOrphanedDocIds = [...jolliMeta.orphanedDocIds, ...inheritedOrphanIds];
+
+	// Children without jolliDocId may have been pushed to Space by a
+	// concurrent PrePushWorker that hasn't written back the docId yet (race).
+	// Record their hashes so pushSummary can resolve them at push time and
+	// clean up the orphaned Space articles.
+	const unresolvedOrphanHashes = Array.from(
+		new Set<string>([
+			...children.filter((child) => !child.jolliDocId).map((child) => child.commitHash),
+			...collectDescendantUnresolvedOrphanHashes(children),
+		]),
+	);
+
 	const strippedChildren = children.map(stripFunctionalMetadata);
 
 	// Compute the real `git diff {squashHash}^..{squashHash}` for the persisted
@@ -1099,6 +1128,7 @@ async function mergeManyToOneLocked(
 		...(hoistedReferences.length > 0 && { references: hoistedReferences }),
 		...(jolliMeta.winner && { jolliDocId: jolliMeta.winner.jolliDocId, jolliDocUrl: jolliMeta.winner.jolliDocUrl }),
 		...(allOrphanedDocIds.length > 0 && { orphanedDocIds: allOrphanedDocIds }),
+		...(unresolvedOrphanHashes.length > 0 && { unresolvedOrphanHashes }),
 		topics: consolidatedTopics,
 		...(consolidatedRecap && { recap: consolidatedRecap }),
 		// v5 contract: always present, even if empty (see migrateOneToOne note).
@@ -1140,11 +1170,12 @@ async function mergeManyToOneLocked(
 	const store = resolveStorage(storage, cwd);
 	await store.writeFiles(files, `Merge summaries [${oldHashesStr}] → ${newCommitInfo.hash.substring(0, 8)}`);
 	log.info(
-		"Summaries merged: [%s] → %s (%d children, %d orphaned docs)",
+		"Summaries merged: [%s] → %s (%d children, %d orphaned docs, %d unresolved orphan hashes)",
 		oldHashesStr,
 		newCommitInfo.hash.substring(0, 8),
 		children.length,
 		allOrphanedDocIds.length,
+		unresolvedOrphanHashes.length,
 	);
 	return { orphanedDocIds: allOrphanedDocIds };
 }

--- a/cli/src/core/normalizeToV4.test.ts
+++ b/cli/src/core/normalizeToV4.test.ts
@@ -183,12 +183,14 @@ describe("normalizeToV4", () => {
 					commitHash: "c1",
 					version: 3,
 					orphanedDocIds: [2, 3],
+					unresolvedOrphanHashes: ["pending-child"],
 					children: [
 						{
 							...baseNode,
 							commitHash: "g1",
 							version: 3,
 							orphanedDocIds: [4],
+							unresolvedOrphanHashes: ["pending-grandchild"],
 						},
 					],
 				},
@@ -196,6 +198,8 @@ describe("normalizeToV4", () => {
 		} as CommitSummary;
 		const normalized = normalizeToV4(v3WithChildOrphans);
 		expect(new Set(normalized.orphanedDocIds ?? [])).toEqual(new Set([1, 2, 3, 4]));
+		expect(normalized.unresolvedOrphanHashes).toEqual(["pending-child", "pending-grandchild"]);
+		expect(normalized.children?.[0].unresolvedOrphanHashes).toBeUndefined();
 	});
 
 	it("dedups duplicated plans (by slug) by picking the newest updatedAt", () => {

--- a/cli/src/hooks/PrePushHook.test.ts
+++ b/cli/src/hooks/PrePushHook.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mergeEntries } from "../core/PushPendingStore.js";
+import { loadConfig } from "../core/SessionTracker.js";
+import { execFileAsyncHidden } from "../util/Subprocess.js";
+import { parsePushRefs, prePushEntry } from "./PrePushHook.js";
+import { launchPrePushWorker } from "./PrePushWorker.js";
+
+vi.mock("../core/SessionTracker.js", () => ({ loadConfig: vi.fn() }));
+vi.mock("../core/PushPendingStore.js", () => ({ mergeEntries: vi.fn() }));
+vi.mock("./PrePushWorker.js", () => ({ launchPrePushWorker: vi.fn() }));
+vi.mock("../util/Subprocess.js", () => ({ execFileAsyncHidden: vi.fn() }));
+
+const CWD = "/repo";
+const ZERO = "0".repeat(40);
+const LOCAL = "1".repeat(40);
+const REMOTE = "2".repeat(40);
+const REMOTE_NAME = "origin";
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(loadConfig).mockResolvedValue({ jolliApiKey: "sk-jol-x" });
+	vi.mocked(mergeEntries).mockResolvedValue(undefined);
+	vi.mocked(execFileAsyncHidden).mockResolvedValue({ stdout: "c1\nc2\n", stderr: "" });
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("parsePushRefs", () => {
+	it("parses well-formed lines and skips blanks/short lines", () => {
+		const stdin = `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n\nbad line\n`;
+		const refs = parsePushRefs(stdin);
+		expect(refs).toHaveLength(1);
+		expect(refs[0]).toMatchObject({ localRef: "refs/heads/x", localSha: LOCAL, remoteSha: REMOTE });
+	});
+});
+
+describe("prePushEntry", () => {
+	it("no-ops entirely when syncOnPush is false (no file write, no worker)", async () => {
+		vi.mocked(loadConfig).mockResolvedValue({ jolliApiKey: "sk-jol-x", syncOnPush: false });
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+		expect(mergeEntries).not.toHaveBeenCalled();
+		expect(launchPrePushWorker).not.toHaveBeenCalled();
+	});
+
+	it("records commits but does NOT spawn the worker when not signed in", async () => {
+		vi.mocked(loadConfig).mockResolvedValue({});
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+		expect(mergeEntries).toHaveBeenCalledWith(CWD, ["c1", "c2"], "x", {
+			remote: REMOTE_NAME,
+			remoteRef: "refs/heads/x",
+			localSha: LOCAL,
+		});
+		expect(launchPrePushWorker).not.toHaveBeenCalled();
+	});
+
+	it("records commits and spawns the worker when signed in", async () => {
+		await prePushEntry(CWD, `refs/heads/feature/y ${LOCAL} refs/heads/feature/y ${REMOTE}\n`, REMOTE_NAME);
+		expect(mergeEntries).toHaveBeenCalledWith(CWD, ["c1", "c2"], "feature/y", {
+			remote: REMOTE_NAME,
+			remoteRef: "refs/heads/feature/y",
+			localSha: LOCAL,
+		});
+		expect(launchPrePushWorker).toHaveBeenCalledWith(CWD);
+	});
+
+	it("skips delete pushes (all-zero local sha)", async () => {
+		await prePushEntry(CWD, `(delete) ${ZERO} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+		expect(mergeEntries).not.toHaveBeenCalled();
+		expect(launchPrePushWorker).not.toHaveBeenCalled();
+	});
+
+	it("uses --not --remotes for a brand-new remote branch (zero remote sha)", async () => {
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${ZERO}\n`, REMOTE_NAME);
+		const args = vi.mocked(execFileAsyncHidden).mock.calls[0][1];
+		expect(args).toEqual(["rev-list", "--reverse", LOCAL, "--not", "--remotes"]);
+	});
+
+	it("uses the remote..local range for an existing remote branch", async () => {
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+		const args = vi.mocked(execFileAsyncHidden).mock.calls[0][1];
+		expect(args).toEqual(["rev-list", "--reverse", `${REMOTE}..${LOCAL}`]);
+	});
+
+	it("no-ops when rev-list yields no commits", async () => {
+		vi.mocked(execFileAsyncHidden).mockResolvedValue({ stdout: "\n", stderr: "" });
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+		expect(mergeEntries).not.toHaveBeenCalled();
+		expect(launchPrePushWorker).not.toHaveBeenCalled();
+	});
+
+	it("tolerates a git rev-list failure (logs, skips that ref)", async () => {
+		vi.mocked(execFileAsyncHidden).mockRejectedValue(new Error("git boom"));
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+		expect(mergeEntries).not.toHaveBeenCalled();
+	});
+
+	it("keeps a non-heads ref name as-is (e.g. a tag push)", async () => {
+		await prePushEntry(CWD, `refs/tags/v1 ${LOCAL} refs/tags/v1 ${REMOTE}\n`, REMOTE_NAME);
+		expect(mergeEntries).toHaveBeenCalledWith(CWD, ["c1", "c2"], "refs/tags/v1", {
+			remote: REMOTE_NAME,
+			remoteRef: "refs/tags/v1",
+			localSha: LOCAL,
+		});
+	});
+
+	it("records a separate confirmation target for each pushed ref update", async () => {
+		const other = "3".repeat(40);
+		await prePushEntry(
+			CWD,
+			`refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\nrefs/heads/x ${other} refs/heads/x ${REMOTE}\n`,
+			REMOTE_NAME,
+		);
+		const branchCalls = vi.mocked(mergeEntries).mock.calls.filter((c) => c[2] === "x");
+		expect(branchCalls).toHaveLength(2);
+		expect(branchCalls.map((call) => call[3]?.localSha)).toEqual([LOCAL, other]);
+	});
+});

--- a/cli/src/hooks/PrePushHook.ts
+++ b/cli/src/hooks/PrePushHook.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * PrePushHook — Git pre-push Event Handler.
+ *
+ * Invoked by git's pre-push hook before objects are transferred. Records the
+ * commits being pushed into `push-pending.json` and spawns a detached
+ * PrePushWorker to sync their Memory Bank summaries to Jolli Space. The
+ * synchronous portion is minimal (config read, stdin parse, `git rev-list`,
+ * one JSON write, spawn) so the push is never blocked; the network sync happens
+ * in the background worker.
+ *
+ * stdin format (one line per ref being pushed):
+ *   <local-ref> <local-sha> <remote-ref> <remote-sha>
+ */
+
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mergeEntries, type PushTarget } from "../core/PushPendingStore.js";
+import { loadConfig } from "../core/SessionTracker.js";
+import { runWithTrace, traceIdFromEnv } from "../core/TraceContext.js";
+import { createLogger, errMsg } from "../Logger.js";
+import { execFileAsyncHidden } from "../util/Subprocess.js";
+import { readStdin } from "./HookUtils.js";
+import { launchPrePushWorker } from "./PrePushWorker.js";
+
+const log = createLogger("PrePushHook");
+
+/** Git's all-zero SHA — signals a branch deletion (local side) or a new ref (remote side). */
+const ZERO_SHA = "0000000000000000000000000000000000000000";
+
+interface PushRef {
+	readonly localRef: string;
+	readonly localSha: string;
+	readonly remoteRef: string;
+	readonly remoteSha: string;
+}
+
+/** Parses the pre-push stdin block into structured refs. */
+export function parsePushRefs(stdin: string): PushRef[] {
+	const refs: PushRef[] = [];
+	for (const line of stdin.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		const parts = trimmed.split(/\s+/);
+		if (parts.length < 4) continue;
+		const [localRef, localSha, remoteRef, remoteSha] = parts;
+		refs.push({ localRef, localSha, remoteRef, remoteSha });
+	}
+	return refs;
+}
+
+/** `refs/heads/feature/x` → `feature/x`; leaves other ref shapes untouched. */
+function branchFromRef(ref: string): string {
+	return ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : ref;
+}
+
+/**
+ * Lists the commits this ref update introduces, oldest-first. For a brand-new
+ * remote branch (`remote-sha` all-zero) there is no remote tip to diff against,
+ * so we take everything reachable from the local tip that isn't already on any
+ * remote (`--not --remotes`) — otherwise `rev-list <zero>..<local>` would error.
+ */
+async function listCommitsForRef(cwd: string, ref: PushRef): Promise<string[]> {
+	const args =
+		ref.remoteSha === ZERO_SHA
+			? ["rev-list", "--reverse", ref.localSha, "--not", "--remotes"]
+			: ["rev-list", "--reverse", `${ref.remoteSha}..${ref.localSha}`];
+	try {
+		const { stdout } = await execFileAsyncHidden("git", args, { cwd });
+		return stdout
+			.split("\n")
+			.map((l) => l.trim())
+			.filter((l) => l.length > 0);
+	} catch (err) {
+		log.warn("git rev-list failed for %s: %s", ref.localRef, errMsg(err));
+		return [];
+	}
+}
+
+/**
+ * Core pre-push logic. Records pushed commits into push-pending.json and (when
+ * signed in) spawns the background sync worker.
+ */
+export async function prePushEntry(cwd: string, stdin: string, remote?: string): Promise<void> {
+	const config = await loadConfig();
+
+	// Explicit opt-out: do nothing at all (no file write, no worker).
+	if (config.syncOnPush === false) {
+		log.debug("syncOnPush is disabled — skipping");
+		return;
+	}
+
+	// Not signed in: still record intent (so a later login can catch up) but
+	// don't spawn the worker — there's nowhere to push to yet.
+	const skipWorker = !config.jolliApiKey;
+
+	const refs = parsePushRefs(stdin);
+	const allHashes = new Set<string>();
+	for (const ref of refs) {
+		if (ref.localSha === ZERO_SHA) continue; // branch deletion — nothing to sync
+		const branch = branchFromRef(ref.localRef);
+		const hashes = await listCommitsForRef(cwd, ref);
+		if (hashes.length === 0) continue;
+		for (const hash of hashes) allHashes.add(hash);
+		const pushTarget: PushTarget | undefined = remote
+			? { remote, remoteRef: ref.remoteRef, localSha: ref.localSha }
+			: undefined;
+		await mergeEntries(cwd, hashes, branch, pushTarget);
+	}
+
+	const total = allHashes.size;
+	if (total === 0) {
+		log.debug("No commits to sync on this push");
+		return;
+	}
+
+	if (skipWorker) {
+		log.info("Recorded %d commit(s) for later sync — not signed in to Jolli", total);
+		return;
+	}
+
+	launchPrePushWorker(cwd);
+}
+
+// --- Script entry point (only when run directly, not when imported) ---
+/* v8 ignore start */
+function isMainScript(): boolean {
+	const argv1 = process.argv[1];
+	if (process.env.VITEST || !argv1) return false;
+	return resolve(argv1) === resolve(fileURLToPath(import.meta.url));
+}
+
+if (isMainScript()) {
+	const cwd = process.cwd();
+	// Adopt a parent-supplied trace id if present, else mint one.
+	runWithTrace(traceIdFromEnv(), () =>
+		readStdin()
+			.then((stdin) => prePushEntry(cwd, stdin, process.argv[2]))
+			.catch((error: unknown) => {
+				// Never block or fail the push on our account — exit 0 always.
+				log.error("PrePushHook error: %s", error instanceof Error ? error.message : String(error));
+			}),
+	);
+}
+/* v8 ignore stop */

--- a/cli/src/hooks/PrePushWorker.test.ts
+++ b/cli/src/hooks/PrePushWorker.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { processPushPending } from "../core/PushExecutor.js";
+import { runPushWorker } from "./PrePushWorker.js";
+
+vi.mock("../core/PushExecutor.js", () => ({ processPushPending: vi.fn() }));
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(processPushPending).mockResolvedValue({
+		attempted: 0,
+		pushed: 0,
+		failed: 0,
+		skippedNoMemory: 0,
+		skippedRetryExhausted: 0,
+		deletedChildren: 0,
+	});
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("runPushWorker", () => {
+	it("drains push-pending with the pre-push source", async () => {
+		await runPushWorker("/repo");
+		expect(processPushPending).toHaveBeenCalledWith("/repo", { source: "pre-push" });
+	});
+});

--- a/cli/src/hooks/PrePushWorker.ts
+++ b/cli/src/hooks/PrePushWorker.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * PrePushWorker — detached background process spawned by PrePushHook.
+ *
+ * Runs the actual network sync (`processPushPending`) so a slow or offline
+ * Jolli Space never delays or fails the user's `git push`. Mirrors the
+ * QueueWorker launch/spawn pattern: `spawnHidden` + `detached` + `stdio:
+ * "ignore"` + `child.unref()`.
+ */
+
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { processPushPending } from "../core/PushExecutor.js";
+import { getCurrentTraceId, runWithTrace, TRACE_ID_ENV, traceIdFromEnv } from "../core/TraceContext.js";
+import { createLogger } from "../Logger.js";
+import { spawnHidden } from "../util/Subprocess.js";
+
+const log = createLogger("PrePushWorker");
+
+/** Drains push-pending.json to Jolli Space. Entry point for the detached run. */
+export async function runPushWorker(cwd: string): Promise<void> {
+	await processPushPending(cwd, { source: "pre-push" });
+}
+
+/**
+ * Spawns a detached PrePushWorker process. Locates `PrePushWorker.js` by
+ * `dirname(import.meta.url) + basename` — NOT by `import.meta.url` alone —
+ * because esbuild inlines this function into the PrePushHook bundle, where
+ * `import.meta.url` would resolve to PrePushHook.js. Both scripts are siblings
+ * in the same dist dir (guaranteed by the vite/esbuild entries), so resolving
+ * by directory + explicit filename always finds the right script (same trick as
+ * QueueWorker.launchWorker).
+ */
+/* v8 ignore start -- spawns a real detached child; not exercised in unit tests */
+export function launchPrePushWorker(cwd: string): void {
+	const dir = dirname(fileURLToPath(import.meta.url));
+	const scriptPath = join(dir, "PrePushWorker.js");
+	if (!existsSync(scriptPath)) {
+		log.error("PrePushWorker.js not found at %s — skipping push sync spawn", scriptPath);
+		return;
+	}
+
+	// No Node flags before scriptPath (same rationale as launchWorker: the hook
+	// runs under a bare `node`, possibly older than our engines floor). Propagate
+	// the ambient trace id so the detached worker's logs share it.
+	const traceId = getCurrentTraceId();
+	const child = spawnHidden(process.execPath, [scriptPath, "--cwd", cwd], {
+		detached: true,
+		stdio: "ignore",
+		cwd,
+		...(traceId ? { env: { ...process.env, [TRACE_ID_ENV]: traceId } } : {}),
+	});
+	child.unref();
+	log.info("PrePushWorker spawned (PID: %d)", child.pid ?? -1);
+	/* v8 ignore stop */
+}
+
+// --- Script entry point (only when run directly, not when imported) ---
+/* v8 ignore start */
+function isMainScript(): boolean {
+	const argv1 = process.argv[1];
+	if (process.env.VITEST || !argv1) return false;
+	return resolve(argv1) === resolve(fileURLToPath(import.meta.url));
+}
+
+if (isMainScript()) {
+	const args = process.argv.slice(2);
+	const cwdIndex = args.indexOf("--cwd");
+	const cwd = cwdIndex >= 0 && args[cwdIndex + 1] ? args[cwdIndex + 1] : process.cwd();
+
+	runWithTrace(traceIdFromEnv(), () =>
+		runPushWorker(cwd).catch((error: unknown) => {
+			log.error("PrePushWorker fatal error: %s", error instanceof Error ? error.message : String(error));
+			process.exit(0); // never signal failure — this is a background sync
+		}),
+	);
+}
+/* v8 ignore stop */

--- a/cli/src/hooks/PushCompensation.test.ts
+++ b/cli/src/hooks/PushCompensation.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { processPushPending } from "../core/PushExecutor.js";
+import { triggerPendingPushRetry } from "./PushCompensation.js";
+
+vi.mock("../core/PushExecutor.js", () => ({ processPushPending: vi.fn() }));
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("triggerPendingPushRetry", () => {
+	it("drains push-pending with the activation source", async () => {
+		vi.mocked(processPushPending).mockResolvedValue({
+			attempted: 2,
+			pushed: 2,
+			failed: 0,
+			skippedNoMemory: 0,
+			skippedRetryExhausted: 0,
+			deletedChildren: 0,
+		});
+		await triggerPendingPushRetry("/repo");
+		expect(processPushPending).toHaveBeenCalledWith("/repo", { source: "activation" });
+	});
+
+	it("never throws when the drain fails", async () => {
+		vi.mocked(processPushPending).mockRejectedValue(new Error("boom"));
+		await expect(triggerPendingPushRetry("/repo")).resolves.toBeUndefined();
+	});
+});

--- a/cli/src/hooks/PushCompensation.ts
+++ b/cli/src/hooks/PushCompensation.ts
@@ -1,0 +1,38 @@
+/**
+ * PushCompensation — the "retry pending pushes on startup" entry point shared by
+ * the three surfaces that activate Jolli Memory:
+ *   - VS Code   `Extension.activate()`
+ *   - IntelliJ  `JolliMemoryService.initialize()` (via the Kotlin port)
+ *   - CLI       `jolli enable`
+ *
+ * Fire-and-forget: retries every under-the-ceiling entry in push-pending.json
+ * (no hash filter). Fully guarded — a non-git directory, missing state file, or
+ * network error must never surface to the caller or block activation.
+ * `processPushPending` itself no-ops cleanly when there are no pending entries
+ * or the user isn't signed in, so no pre-checks are needed here.
+ */
+
+import { processPushPending } from "../core/PushExecutor.js";
+import { createLogger, errMsg } from "../Logger.js";
+
+const log = createLogger("PushCompensation");
+
+/**
+ * Retries all pending pushes for `cwd`. Never throws — failures are logged at
+ * debug and left in push-pending.json for the next trigger.
+ */
+export async function triggerPendingPushRetry(cwd: string): Promise<void> {
+	try {
+		const result = await processPushPending(cwd, { source: "activation" });
+		if (result.attempted > 0) {
+			log.info(
+				"Activation push retry: attempted=%d pushed=%d failed=%d",
+				result.attempted,
+				result.pushed,
+				result.failed,
+			);
+		}
+	} catch (err) {
+		log.debug("Activation push retry failed (will retry later): %s", errMsg(err));
+	}
+}

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -1522,6 +1522,7 @@ describe("QueueWorker", () => {
 				jolliDocId: 42,
 				jolliDocUrl: "https://jolli.app/d/42",
 				orphanedDocIds: [1, 2],
+				unresolvedOrphanHashes: ["pending-child"],
 				plans: [{ slug: "p", title: "P", addedAt: "x", updatedAt: "y" }],
 				notes: [{ id: "n", title: "N", format: "markdown" as const, addedAt: "x", updatedAt: "y" }],
 				e2eTestGuide: [{ title: "T", steps: ["s"], expectedResults: ["r"] }],
@@ -1530,6 +1531,7 @@ describe("QueueWorker", () => {
 			expect(out.jolliDocId).toBe(42);
 			expect(out.jolliDocUrl).toBe("https://jolli.app/d/42");
 			expect(out.orphanedDocIds).toEqual([1, 2]);
+			expect(out.unresolvedOrphanHashes).toEqual(["pending-child"]);
 			expect(out.plans).toHaveLength(1);
 			expect(out.notes).toHaveLength(1);
 			expect(out.e2eTestGuide).toHaveLength(1);

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -57,6 +57,7 @@ import { readOpenCodeTranscript } from "../core/OpenCodeTranscriptReader.js";
 import { evaluatePlanProgress } from "../core/PlanProgressEvaluator.js";
 import { formatPlansBlock } from "../core/PlanPromptFormatter.js";
 import { estimateCostUsd, PRICES_AS_OF } from "../core/Pricing.js";
+import { triggerPushForNewSummaries } from "../core/PushExecutor.js";
 import { deleteReferenceMarkdown, readReferenceMarkdown } from "../core/references/ReferenceStore.js";
 import { getRegistry } from "../core/references/SourceDefinitionRegistry.js";
 import { renderBlock } from "../core/references/SourceEngine.js";
@@ -207,7 +208,8 @@ async function reassociateMetadata(
 /**
  * Extracts hoisted metadata fields from an old summary for inclusion in a new
  * summary root node. The full hoist set is: jolliDocId, jolliDocUrl,
- * orphanedDocIds, plans, notes, references, e2eTestGuide. Keep this list
+ * orphanedDocIds, unresolvedOrphanHashes, plans, notes, references,
+ * e2eTestGuide. Keep this list
  * synced with the spread block below — drift is the bug we're avoiding by
  * enumerating it here.
  *
@@ -221,6 +223,7 @@ function hoistMetadataFromOldSummary(oldSummary: CommitSummary | null | undefine
 		...(oldSummary.jolliDocId != null && { jolliDocId: oldSummary.jolliDocId }),
 		...(oldSummary.jolliDocUrl && { jolliDocUrl: oldSummary.jolliDocUrl }),
 		...(oldSummary.orphanedDocIds && { orphanedDocIds: oldSummary.orphanedDocIds }),
+		...(oldSummary.unresolvedOrphanHashes && { unresolvedOrphanHashes: oldSummary.unresolvedOrphanHashes }),
 		...(oldSummary.plans && { plans: oldSummary.plans }),
 		...(oldSummary.notes && { notes: oldSummary.notes }),
 		...(oldSummary.references && { references: oldSummary.references }),
@@ -499,6 +502,10 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 			// debounce-trigger a repo-wide topic-KB ingest after the drain (SP3).
 			// Ingest ops do NOT set it — that would self-perpetuate the trigger.
 			let committedThisRun = false;
+			// Commit hashes whose summary was (re)generated this drain. Fed to the
+			// pre-push sync trigger below so a `git push` that raced ahead of summary
+			// generation still gets its memory pushed once the summary lands.
+			const newlyGeneratedHashes = new Set<string>();
 			const MAX_ENTRIES_PER_RUN = 20; // Safety limit to prevent infinite loops
 
 			while (processedCount < MAX_ENTRIES_PER_RUN) {
@@ -533,6 +540,7 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 							processQueueEntry(op, cwd, activeStorage, force),
 						);
 						committedThisRun = true;
+						newlyGeneratedHashes.add(op.commitHash);
 					} catch (error: unknown) {
 						// Queue entries are deleted regardless of success or failure (fire-and-forget).
 						// Retry is intentionally not implemented: pipeline steps (transcript cursor
@@ -568,6 +576,15 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 			// a manual `jolli compile`, so commit-heavy workflows went stale.
 			if (committedThisRun) {
 				await enqueueIngestOperation(cwd, "post-commit");
+			}
+
+			// Pre-push sync follow-up (JOLLI-1900): if any of the commits summarized
+			// this drain are waiting in push-pending.json (a `git push` fired before
+			// their memory existed), push them now. Fire-and-forget on the next tick —
+			// it must never extend this worker's lock hold or delay the ingest phase,
+			// and a slow/offline push just leaves the entries for the next trigger.
+			if (newlyGeneratedHashes.size > 0) {
+				triggerPushForNewSummaries(cwd, [...newlyGeneratedHashes]);
 			}
 			/* v8 ignore start -- catch block only reached if dequeueAllGitOperations throws unexpectedly */
 		} catch (error: unknown) {

--- a/cli/src/install/DispatchScripts.ts
+++ b/cli/src/install/DispatchScripts.ts
@@ -148,6 +148,7 @@ case "$HOOK_TYPE" in
   post-merge)         exec node "$DIST/PostMergeHook.js" "$@" ;;
   post-rewrite)       exec node "$DIST/PostRewriteHook.js" "$@" ;;
   prepare-commit-msg) exec node "$DIST/PrepareMsgHook.js" "$@" ;;
+  pre-push)           exec node "$DIST/PrePushHook.js" "$@" ;;
   stop)               exec node "$DIST/StopHook.js" "$@" ;;
   session-start)      exec node "$DIST/SessionStartHook.js" "$@" ;;
   gemini-after-agent) exec node "$DIST/GeminiAfterAgentHook.js" "$@" ;;

--- a/cli/src/install/GitHookInstaller.test.ts
+++ b/cli/src/install/GitHookInstaller.test.ts
@@ -1,0 +1,79 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	installPrePushHook,
+	isHookSectionInstalled,
+	PRE_PUSH_MARKER_START,
+	removePrePushHook,
+} from "./GitHookInstaller.js";
+
+let cwd: string;
+
+beforeEach(async () => {
+	cwd = join(tmpdir(), `git-hook-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	await mkdir(join(cwd, ".git"), { recursive: true });
+});
+
+afterEach(async () => {
+	await rm(cwd, { recursive: true, force: true });
+});
+
+function hookPath(): string {
+	return join(cwd, ".git", "hooks", "pre-push");
+}
+
+describe("installPrePushHook / removePrePushHook", () => {
+	it("creates a pre-push hook with the Jolli marker and run-hook dispatch", async () => {
+		const result = await installPrePushHook(cwd);
+		expect(result.path).toBe(hookPath());
+		const content = await readFile(hookPath(), "utf-8");
+		expect(content).toContain(PRE_PUSH_MARKER_START);
+		expect(content).toContain("run-hook");
+		expect(content).toContain("pre-push");
+		// Forwards git's args + inherits stdin via exec.
+		expect(content).toContain('"$@"');
+		expect(content).toContain("__jolli_pre_push_previous_status=$?");
+		expect(content).toContain('(exit "$__jolli_pre_push_previous_status")');
+	});
+
+	it("is idempotent — installing twice leaves a single section", async () => {
+		await installPrePushHook(cwd);
+		await installPrePushHook(cwd);
+		const content = await readFile(hookPath(), "utf-8");
+		const occurrences = content.split(PRE_PUSH_MARKER_START).length - 1;
+		expect(occurrences).toBe(1);
+	});
+
+	it("appends to an existing pre-push hook without clobbering it", async () => {
+		await mkdir(join(cwd, ".git", "hooks"), { recursive: true });
+		await writeFile(hookPath(), "#!/bin/sh\necho existing\n", "utf-8");
+		const result = await installPrePushHook(cwd);
+		expect(result.warning).toMatch(/existing pre-push hook/i);
+		const content = await readFile(hookPath(), "utf-8");
+		expect(content).toContain("echo existing");
+		expect(content).toContain(PRE_PUSH_MARKER_START);
+	});
+
+	it("isHookSectionInstalled reports true after install, false after remove", async () => {
+		await installPrePushHook(cwd);
+		expect(await isHookSectionInstalled(cwd, "pre-push", PRE_PUSH_MARKER_START)).toBe(true);
+		await removePrePushHook(cwd);
+		expect(await isHookSectionInstalled(cwd, "pre-push", PRE_PUSH_MARKER_START)).toBe(false);
+	});
+
+	it("removePrePushHook removes only the Jolli section, leaving other hook content", async () => {
+		await mkdir(join(cwd, ".git", "hooks"), { recursive: true });
+		await writeFile(hookPath(), "#!/bin/sh\necho existing\n", "utf-8");
+		await installPrePushHook(cwd);
+		await removePrePushHook(cwd);
+		const content = await readFile(hookPath(), "utf-8");
+		expect(content).toContain("echo existing");
+		expect(content).not.toContain(PRE_PUSH_MARKER_START);
+	});
+
+	it("removePrePushHook is a no-op when the hook file is absent", async () => {
+		await expect(removePrePushHook(cwd)).resolves.toBeUndefined();
+	});
+});

--- a/cli/src/install/GitHookInstaller.ts
+++ b/cli/src/install/GitHookInstaller.ts
@@ -32,6 +32,9 @@ const PREPARE_MSG_MARKER_END = "# <<< JolliMemory prepare-commit-msg hook <<<";
 export const POST_MERGE_MARKER_START = "# >>> JolliMemory post-merge hook >>>";
 const POST_MERGE_MARKER_END = "# <<< JolliMemory post-merge hook <<<";
 
+export const PRE_PUSH_MARKER_START = "# >>> JolliMemory pre-push hook >>>";
+const PRE_PUSH_MARKER_END = "# <<< JolliMemory pre-push hook <<<";
+
 // ─── Install ────────────────────────────────────────────────────────────────
 
 /**
@@ -136,6 +139,32 @@ export async function installPostMergeHook(projectDir: string): Promise<HookOpRe
 	const hookSection = [POST_MERGE_MARKER_START, hookCommandLine, POST_MERGE_MARKER_END].join("\n");
 
 	return installGenericGitHook(projectDir, "post-merge", hookSection, hookCommandLine, POST_MERGE_MARKER_START);
+}
+
+/**
+ * Installs the git pre-push hook (auto-syncs pushed commits' memory to Jolli
+ * Space). If a hook already exists, appends Jolli Memory's section.
+ *
+ * pre-push receives `<remote-name> <url>` as $1/$2 and the ref lines on stdin;
+ * `"$@"` forwards the args and `exec` inherits stdin, so PrePushHook.js sees
+ * both.
+ */
+export async function installPrePushHook(projectDir: string): Promise<HookOpResult> {
+	// pre-push is the only hook where non-zero exit aborts the git operation.
+	// Guard with [ -x ] + || true so a missing run-hook or absent Node can
+	// NEVER block the user's push (aligned with IntelliJ's prePushScript).
+	// Preserve the status of the existing hook content: this section is appended,
+	// so letting our best-effort command become the script's final status would
+	// turn a preceding failure into success and incorrectly allow the push.
+	const runHook = '"$HOME/.jolli/jollimemory/run-hook"';
+	const hookCommandLine = [
+		"__jolli_pre_push_previous_status=$?",
+		`if [ -x ${runHook} ]; then ${runHook} pre-push "$@" || true; fi`,
+		'(exit "$__jolli_pre_push_previous_status")',
+	].join("\n");
+	const hookSection = [PRE_PUSH_MARKER_START, hookCommandLine, PRE_PUSH_MARKER_END].join("\n");
+
+	return installGenericGitHook(projectDir, "pre-push", hookSection, hookCommandLine, PRE_PUSH_MARKER_START);
 }
 
 /**
@@ -262,6 +291,13 @@ export async function removePrepareMsgHook(projectDir: string): Promise<void> {
  */
 export async function removePostMergeHook(projectDir: string): Promise<void> {
 	await removeGenericGitHook(projectDir, "post-merge", POST_MERGE_MARKER_START, POST_MERGE_MARKER_END);
+}
+
+/**
+ * Removes the Jolli Memory section from the git pre-push hook.
+ */
+export async function removePrePushHook(projectDir: string): Promise<void> {
+	await removeGenericGitHook(projectDir, "pre-push", PRE_PUSH_MARKER_START, PRE_PUSH_MARKER_END);
 }
 
 /**

--- a/cli/src/install/Installer.test.ts
+++ b/cli/src/install/Installer.test.ts
@@ -530,9 +530,10 @@ describe("Installer", () => {
 			// Override the mocks so they return the correct worktree-aware paths
 			const { getGitCommonDir, resolveGitHooksDir } = await import("../core/GitOps.js");
 			vi.mocked(getGitCommonDir).mockResolvedValueOnce(mainGitDir);
-			// install() calls resolveGitHooksDir 4× (post-commit, post-rewrite, prepare-commit-msg, post-merge)
+			// install() calls resolveGitHooksDir 5× (post-commit, post-rewrite, prepare-commit-msg, post-merge, pre-push)
 			const mainHooksDir = join(mainGitDir, "hooks");
 			vi.mocked(resolveGitHooksDir)
+				.mockResolvedValueOnce(mainHooksDir)
 				.mockResolvedValueOnce(mainHooksDir)
 				.mockResolvedValueOnce(mainHooksDir)
 				.mockResolvedValueOnce(mainHooksDir)
@@ -564,9 +565,10 @@ describe("Installer", () => {
 			const { getGitCommonDir, getProjectRootDir, resolveGitHooksDir } = await import("../core/GitOps.js");
 			vi.mocked(getGitCommonDir).mockResolvedValueOnce(gitDir);
 			vi.mocked(getProjectRootDir).mockResolvedValueOnce(tempDir);
-			// install() calls resolveGitHooksDir 4× (post-commit, post-rewrite, prepare-commit-msg, post-merge)
+			// install() calls resolveGitHooksDir 5× (post-commit, post-rewrite, prepare-commit-msg, post-merge, pre-push)
 			const gitHooksDir = join(gitDir, "hooks");
 			vi.mocked(resolveGitHooksDir)
+				.mockResolvedValueOnce(gitHooksDir)
 				.mockResolvedValueOnce(gitHooksDir)
 				.mockResolvedValueOnce(gitHooksDir)
 				.mockResolvedValueOnce(gitHooksDir)

--- a/cli/src/install/Installer.ts
+++ b/cli/src/install/Installer.ts
@@ -70,15 +70,18 @@ import {
 	installGitHook,
 	installPostMergeHook,
 	installPostRewriteHook,
+	installPrePushHook,
 	installPrepareMsgHook,
 	isGitHookInstalled,
 	isHookSectionInstalled,
 	POST_MERGE_MARKER_START,
 	POST_REWRITE_MARKER_START,
+	PRE_PUSH_MARKER_START,
 	PREPARE_MSG_MARKER_START,
 	removeGitHook,
 	removePostMergeHook,
 	removePostRewriteHook,
+	removePrePushHook,
 	removePrepareMsgHook,
 } from "./GitHookInstaller.js";
 import {
@@ -386,6 +389,7 @@ export async function install(
 		let postRewriteResult: HookOpResult = {};
 		let prepareMsgResult: HookOpResult = {};
 		let postMergeResult: HookOpResult = {};
+		let prePushResult: HookOpResult = {};
 		if (!integrationsOnly) {
 			gitResult = await installGitHook(projectDir);
 			if (gitResult.warning) {
@@ -408,6 +412,12 @@ export async function install(
 			postMergeResult = await installPostMergeHook(projectDir);
 			if (postMergeResult.warning) {
 				warnings.push(postMergeResult.warning);
+			}
+
+			// Install Git pre-push hook (auto-syncs pushed commits' memory to Jolli Space)
+			prePushResult = await installPrePushHook(projectDir);
+			if (prePushResult.warning) {
+				warnings.push(prePushResult.warning);
 			}
 		}
 
@@ -519,6 +529,7 @@ export async function install(
 			postRewriteHookPath: postRewriteResult.path,
 			prepareMsgHookPath: prepareMsgResult.path,
 			postMergeHookPath: postMergeResult.path,
+			prePushHookPath: prePushResult.path,
 			geminiSettingsPath,
 		};
 		/* v8 ignore start -- defensive: internal functions handle their own errors */
@@ -708,6 +719,7 @@ export async function uninstall(cwd?: string, options?: { integrationsOnly?: boo
 		await removePostRewriteHook(projectDir);
 		await removePrepareMsgHook(projectDir);
 		await removePostMergeHook(projectDir);
+		await removePrePushHook(projectDir);
 
 		// Conservative skill-cleanup policy: leave the generated SKILL.md files
 		// AND the `.git/info/exclude` block alone. Users sometimes ship their
@@ -762,6 +774,7 @@ export async function getStatus(cwd?: string, storage?: StorageProvider): Promis
 		(await isHookSectionInstalled(projectDir, "post-rewrite", POST_REWRITE_MARKER_START)) &&
 		(await isHookSectionInstalled(projectDir, "prepare-commit-msg", PREPARE_MSG_MARKER_START)) &&
 		(await isHookSectionInstalled(projectDir, "post-merge", POST_MERGE_MARKER_START));
+	const prePushHookInstalled = await isHookSectionInstalled(projectDir, "pre-push", PRE_PUSH_MARKER_START);
 	const sessions = await loadAllSessions(projectDir);
 	const branchExists = await orphanBranchExists(ORPHAN_BRANCH, projectDir);
 	const summaryCount = branchExists ? await getSummaryCount(projectDir, storage) : 0;
@@ -920,6 +933,7 @@ export async function getStatus(cwd?: string, storage?: StorageProvider): Promis
 		enabled: gitHookInstalled,
 		claudeHookInstalled,
 		gitHookInstalled,
+		prePushHookInstalled,
 		geminiHookInstalled,
 		worktreeHooksInstalled,
 		activeSessions: allEnabledSessions.length,

--- a/cli/vite.config.ts
+++ b/cli/vite.config.ts
@@ -35,6 +35,8 @@ export default defineConfig({
 				GeminiAfterAgentHook: resolve(__dirname, "src/hooks/GeminiAfterAgentHook.ts"),
 				SessionStartHook: resolve(__dirname, "src/hooks/SessionStartHook.ts"),
 				PostMergeHook: resolve(__dirname, "src/hooks/PostMergeHook.ts"),
+				PrePushHook: resolve(__dirname, "src/hooks/PrePushHook.ts"),
+				PrePushWorker: resolve(__dirname, "src/hooks/PrePushWorker.ts"),
 				QueueWorker: resolve(__dirname, "src/hooks/QueueWorker.ts"),
 			},
 			formats: ["es"],

--- a/intellij/CHANGELOG.md
+++ b/intellij/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.99.6
+
+### New Features
+
+- **Auto-sync on push** — `git push` now automatically syncs the pushed commits' summaries to your Jolli Space in the background. The pre-push hook is lightweight (config read, stdin parse, one JSON write, spawn) and never blocks the push; the actual network sync runs in a detached worker. Failed syncs are retried on the next push, after the queue worker finishes a post-commit drain, and each time the IDE or CLI activates — so nothing is lost even if the network is flaky. Opt out with `syncOnPush: false` in config.
+
+### Fixes & Improvements
+
+- Stale push-pending entries are pruned automatically after 7 days, keeping the state directory clean between pushes
+
 ## 0.99.5
 
 ### New Features

--- a/intellij/DEVELOPMENT.md
+++ b/intellij/DEVELOPMENT.md
@@ -78,6 +78,7 @@ These hooks track which AI sessions are active. They only record session metadat
 | **prepare-commit-msg** | Before commit | Detects squash/amend scenarios and writes pending files for the Worker |
 | **post-commit** | After commit | Spawns a background Worker that reads transcripts + diff, calls the LLM, and writes the summary to the orphan branch |
 | **post-rewrite** | After rebase/amend | Migrates existing summaries to match new commit hashes (1:1 hash remapping) |
+| **pre-push** | Before push | Syncs the pushed commits' memory to Jolli Space. **Does not use the Kotlin JAR**: the sync engine (`push-pending.json` queue + Space doc upload) lives only in the Node CLI, so this hook reuses the shared `run-hook pre-push` dispatcher (written by `enableIntegrations` → bundled `jolli enable --integrations-only`), guarded so a missing dispatcher / absent Node never aborts the push. `CliIntegrations.retryPendingPushes` drains any pending commits for catch-up — from both plugin startup (offline pushes) and the **post-commit drain's tail** (blocking), so a push that raced ahead of summary generation syncs once the summary lands, without a restart (the Kotlin QueueWorker's analog of the TS `triggerPushForNewSummaries`). |
 
 Summaries are stored in a git orphan branch (`jollimemory/summaries/v3`) using a v3 tree format.
 

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "ai.jolli"
-version = "0.99.5"
+version = "0.99.7"
 
 repositories {
     mavenCentral()

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/CliIntegrations.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/CliIntegrations.kt
@@ -303,6 +303,55 @@ object CliIntegrations {
     }
 
     /**
+     * Best-effort catch-up for the pre-push memory sync (JOLLI-1900). Spawns the
+     * bundled `PrePushWorker.js` to drain `push-pending.json` to Jolli Space. Two
+     * callers:
+     *   - plugin startup ([JolliMemoryService.initialize]) — fire-and-forget, for
+     *     commits left pending by an offline push in a previous session;
+     *   - the post-commit drain ([PostCommitHook.drainWorker], `waitForCompletion=true`)
+     *     — the IntelliJ analog of the TS `QueueWorker.triggerPushForNewSummaries`,
+     *     so a push that raced ahead of summary generation syncs as soon as the
+     *     summary lands, without waiting for the next plugin start.
+     *
+     * Cheap pre-check: returns immediately when there is no `push-pending.json`
+     * (`PushPendingStore` unlinks the file when it's empty), so the common commit —
+     * nothing pending — never pays a Node spawn.
+     *
+     * Never throws: a missing worker, absent Node, non-git dir, or offline network
+     * just leaves the pending entries for the next trigger. The worker self-no-ops
+     * when the user isn't signed in.
+     *
+     * @param waitForCompletion when true, block (bounded) until the drain worker
+     *   exits — safe here because the caller is already a detached background
+     *   process (git has returned); ensures the push finishes within the caller's
+     *   lifetime instead of orphaning the child when the JVM exits.
+     */
+    fun retryPendingPushes(projectDir: String, waitForCompletion: Boolean = false) {
+        try {
+            // Nothing pending → skip without spawning Node (the hot path for a
+            // normal commit). PushPendingStore removes the file when it's empty,
+            // so mere existence means there is at least one entry to try.
+            val pending = File(projectDir, ".jolli/jollimemory/push-pending.json")
+            if (!pending.exists() || pending.length() == 0L) return
+
+            val node = resolveNode() ?: return
+            val worker = File(distIntellijDir(), "PrePushWorker.js")
+            if (!worker.exists()) return
+            val proc = ProcessBuilder(node, worker.absolutePath, "--cwd", projectDir)
+                .directory(File(projectDir))
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
+                .start()
+            if (waitForCompletion) {
+                if (!proc.waitFor(120, TimeUnit.SECONDS)) proc.destroyForcibly()
+            }
+            log.info("Ran pre-push retry worker for %s (wait=%s)", projectDir, waitForCompletion)
+        } catch (e: Exception) {
+            log.warn("Pre-push retry spawn failed (non-fatal): %s", e.message)
+        }
+    }
+
+    /**
      * Tears down the MCP registration via `disable --integrations-only` (best-effort).
      * No-op when Node or the bundle is missing — nothing to undo that we could reach.
      */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/HookInstaller.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/HookInstaller.kt
@@ -14,9 +14,12 @@ import java.io.File
  *   2. Git post-commit hook in .git/hooks/post-commit
  *   3. Git post-rewrite hook in .git/hooks/post-rewrite
  *   4. Git prepare-commit-msg hook in .git/hooks/prepare-commit-msg
+ *   5. Git pre-push hook in .git/hooks/pre-push (JOLLI-1900)
  *
- * The hook scripts themselves call Node.js (for AI summarization), but the
- * INSTALLATION is pure file I/O — no Node.js needed on the plugin side.
+ * The git-hook INSTALLATION is pure file I/O — no Node.js needed on the plugin
+ * side. Hooks 2–4 run via the Kotlin fat JAR; the pre-push hook (5) is the one
+ * exception — it reuses the shared Node `run-hook` dispatcher (see
+ * [prePushScript]) because the Space-sync engine has no Kotlin port.
  */
 class HookInstaller(private val projectDir: String, private val mainRepoRoot: String = projectDir) {
 
@@ -76,6 +79,8 @@ class HookInstaller(private val projectDir: String, private val mainRepoRoot: St
         private const val POST_REWRITE_END = "# <<< JolliMemory post-rewrite hook <<<"
         private const val PREPARE_MSG_START = "# >>> JolliMemory prepare-commit-msg hook >>>"
         private const val PREPARE_MSG_END = "# <<< JolliMemory prepare-commit-msg hook <<<"
+        private const val PRE_PUSH_START = "# >>> JolliMemory pre-push hook >>>"
+        private const val PRE_PUSH_END = "# <<< JolliMemory pre-push hook <<<"
     }
 
     /** Check if Claude Code Stop hook is installed (checks main repo's .claude/). */
@@ -136,7 +141,8 @@ class HookInstaller(private val projectDir: String, private val mainRepoRoot: St
         return isClaudeHookInstalled() &&
             isGitHookInstalled("post-commit", POST_COMMIT_START) &&
             isGitHookInstalled("post-rewrite", POST_REWRITE_START) &&
-            isGitHookInstalled("prepare-commit-msg", PREPARE_MSG_START)
+            isGitHookInstalled("prepare-commit-msg", PREPARE_MSG_START) &&
+            isGitHookInstalled("pre-push", PRE_PUSH_START)
     }
 
     /**
@@ -184,6 +190,7 @@ class HookInstaller(private val projectDir: String, private val mainRepoRoot: St
             installGitHook("post-commit", POST_COMMIT_START, POST_COMMIT_END, postCommitScript())
             installGitHook("post-rewrite", POST_REWRITE_START, POST_REWRITE_END, postRewriteScript())
             installGitHook("prepare-commit-msg", PREPARE_MSG_START, PREPARE_MSG_END, prepareMsgScript())
+            installGitHook("pre-push", PRE_PUSH_START, PRE_PUSH_END, prePushScript())
             installLog.appendLine("Git hooks installed")
 
             // Install Claude Code skill file (.claude/skills/jolli-recall/SKILL.md)
@@ -263,6 +270,7 @@ class HookInstaller(private val projectDir: String, private val mainRepoRoot: St
             removeGitHookSection("post-commit", POST_COMMIT_START, POST_COMMIT_END)
             removeGitHookSection("post-rewrite", POST_REWRITE_START, POST_REWRITE_END)
             removeGitHookSection("prepare-commit-msg", PREPARE_MSG_START, PREPARE_MSG_END)
+            removeGitHookSection("pre-push", PRE_PUSH_START, PRE_PUSH_END)
             // Mirror of enable: tear down the MCP registration via the bundled CLI
             // (best-effort, node-only). Leaves hooks/skills/dist-paths per the CLI's
             // conservative uninstall policy. Never fails the disable over this.
@@ -654,6 +662,36 @@ class HookInstaller(private val projectDir: String, private val mainRepoRoot: St
         val jar = findHooksJar() ?: return "echo 'jollimemory-hooks.jar not found' >&2"
         val java = resolveJavaPath()
         return """"$java" -jar "$jar" prepare-commit-msg "$@""""
+    }
+
+    /**
+     * pre-push (JOLLI-1900): sync the pushed commits' memory to Jolli Space.
+     *
+     * Unlike every other IntelliJ hook, this does NOT go through the Kotlin fat
+     * JAR — the pre-push sync engine (the `push-pending.json` queue + the Jolli
+     * Space doc upload) lives only in the Node CLI, with no Kotlin port. Instead
+     * it reuses the SAME shared `run-hook` dispatcher the CLI and VS Code install
+     * (written by [CliIntegrations.enableIntegrations] → the bundled `jolli enable
+     * --integrations-only`), so IntelliJ gets byte-identical per-push behaviour via
+     * the same `PrePushHook.js` + `PrePushWorker.js` (JOLLI-1900 requirement 3 —
+     * reuse the existing push path, don't re-implement it).
+     *
+     * The absolute `run-hook` path is baked at install time (same convention as the
+     * `java -jar <jar>` paths in the other scripts). Guarded two ways so a missing
+     * dispatcher or absent Node can NEVER abort the push: the `[ -x … ]` test skips
+     * when `run-hook` isn't there (integrations not enabled / Node absent), and
+     * `|| true` swallows any non-zero exit from Jolli itself. Because this section is
+     * appended to an existing hook, it also captures the preceding command's status and
+     * restores it with a subshell exit: an existing validation failure must still abort
+     * the push, while the parent shell remains available to later appended sections.
+     */
+    private fun prePushScript(): String {
+        val runHook = File(System.getProperty("user.home"), ".jolli/jollimemory/run-hook").absolutePath
+        return """
+            __jolli_pre_push_previous_status=${'$'}?
+            if [ -x "$runHook" ]; then "$runHook" pre-push "$@" || true; fi
+            (exit "${'$'}__jolli_pre_push_previous_status")
+        """.trimIndent()
     }
 }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/PushPendingReader.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/PushPendingReader.kt
@@ -1,0 +1,25 @@
+package ai.jolli.jollimemory.core
+
+import com.google.gson.JsonParser
+import java.io.File
+
+/** Read-only view of the shared Node pre-push queue used by cleanup paths. */
+object PushPendingReader {
+
+    /**
+     * Returns queued commit hashes, an empty set when no queue exists, or null
+     * when the file cannot be parsed. Callers treat null conservatively as
+     * "possibly pending" so cleanup never drops an in-flight article reference.
+     */
+    fun loadHashes(cwd: String): Set<String>? {
+        val file = File(cwd, ".jolli/jollimemory/push-pending.json")
+        if (!file.exists()) return emptySet()
+        return try {
+            val root = JsonParser.parseString(file.readText()).asJsonObject
+            val entries = root.getAsJsonObject("entries") ?: return emptySet()
+            entries.keySet().toSet()
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SummaryStore.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SummaryStore.kt
@@ -186,8 +186,10 @@ class SummaryStore(private val cwd: String, private val git: GitOps, private val
             commitDate = newCommitInfo.date, branch = oldSummary.branch,
             generatedAt = Instant.now().toString(), commitType = CommitType.rebase,
             jolliDocId = oldSummary.jolliDocId, jolliDocUrl = oldSummary.jolliDocUrl,
+            orphanedDocIds = oldSummary.orphanedDocIds,
+            unresolvedOrphanHashes = oldSummary.unresolvedOrphanHashes,
             plans = oldSummary.plans, e2eTestGuide = oldSummary.e2eTestGuide, recap = oldSummary.recap,
-            children = listOf(oldSummary.copy(jolliDocId = null, jolliDocUrl = null, plans = null, e2eTestGuide = null, recap = null)),
+            children = listOf(stripMergedMetadata(oldSummary)),
         )
         storeSummary(newSummary, force = true)
     }
@@ -201,10 +203,22 @@ class SummaryStore(private val cwd: String, private val git: GitOps, private val
         aiProvider: String? = null,
     ) {
         val children = oldSummaries.sortedByDescending { it.commitDate }
-            .map { it.copy(jolliDocId = null, jolliDocUrl = null, plans = null, e2eTestGuide = null, recap = null) }
+            .map(::stripMergedMetadata)
         val allPlans = oldSummaries.flatMap { it.plans ?: emptyList() }
             .groupBy { it.slug }.mapNotNull { (_, p) -> p.maxByOrNull { it.updatedAt } }
         val allE2e = oldSummaries.flatMap { it.e2eTestGuide ?: emptyList() }
+        val jolliCandidates = collectJolliCandidates(oldSummaries)
+        val jolliWinner = jolliCandidates.maxWithOrNull(
+            compareBy<JolliCandidate> { it.generatedAt }.thenBy { it.commitDate },
+        )
+        val orphanedDocIds = (
+            jolliCandidates.filter { it !== jolliWinner }.map { it.docId } +
+                collectOrphanedDocIds(oldSummaries)
+            ).distinct().filter { it != jolliWinner?.docId }
+        val unresolvedOrphanHashes = (
+            oldSummaries.filter { it.jolliDocId == null }.map { it.commitHash } +
+                collectUnresolvedOrphanHashes(oldSummaries)
+            ).distinct()
 
         // Build consolidation sources from old summaries
         val sources = oldSummaries.map { s ->
@@ -296,6 +310,10 @@ class SummaryStore(private val cwd: String, private val git: GitOps, private val
             commitDate = newCommitInfo.date, branch = oldSummaries.firstOrNull()?.branch ?: "unknown",
             generatedAt = Instant.now().toString(), commitType = CommitType.squash,
             plans = allPlans.takeIf { it.isNotEmpty() }, e2eTestGuide = allE2e.takeIf { it.isNotEmpty() },
+            jolliDocId = jolliWinner?.docId,
+            jolliDocUrl = jolliWinner?.docUrl,
+            orphanedDocIds = orphanedDocIds.takeIf { it.isNotEmpty() },
+            unresolvedOrphanHashes = unresolvedOrphanHashes.takeIf { it.isNotEmpty() },
             topics = mergedTopics?.takeIf { it.isNotEmpty() },
             recap = mergedRecap,
             ticketId = mergedTicketId,
@@ -423,6 +441,41 @@ class SummaryStore(private val cwd: String, private val git: GitOps, private val
     }
 
     // ── Internal helpers ────────────────────────────────────────────────────
+
+    private data class JolliCandidate(
+        val docId: Int,
+        val docUrl: String,
+        val commitDate: String,
+        val generatedAt: String,
+    )
+
+    private fun collectJolliCandidates(nodes: List<CommitSummary>): List<JolliCandidate> = nodes.flatMap { node ->
+        val own = if (node.jolliDocId != null && node.jolliDocUrl != null) {
+            listOf(JolliCandidate(node.jolliDocId, node.jolliDocUrl, node.commitDate, node.generatedAt))
+        } else {
+            emptyList()
+        }
+        own + collectJolliCandidates(node.children ?: emptyList())
+    }
+
+    private fun collectOrphanedDocIds(nodes: List<CommitSummary>): List<Int> = nodes.flatMap { node ->
+        (node.orphanedDocIds ?: emptyList()) + collectOrphanedDocIds(node.children ?: emptyList())
+    }
+
+    private fun collectUnresolvedOrphanHashes(nodes: List<CommitSummary>): List<String> = nodes.flatMap { node ->
+        (node.unresolvedOrphanHashes ?: emptyList()) + collectUnresolvedOrphanHashes(node.children ?: emptyList())
+    }
+
+    private fun stripMergedMetadata(node: CommitSummary): CommitSummary = node.copy(
+        jolliDocId = null,
+        jolliDocUrl = null,
+        orphanedDocIds = null,
+        unresolvedOrphanHashes = null,
+        plans = null,
+        e2eTestGuide = null,
+        recap = null,
+        children = node.children?.map(::stripMergedMetadata),
+    )
 
     private fun flattenSummaryTree(node: CommitSummary, parentHash: String?): List<SummaryIndexEntry> {
         val treeHash = git.exec("cat-file", "-p", node.commitHash)?.let { output ->

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
@@ -299,6 +299,7 @@ data class CommitSummary(
     val jolliDocUrl: String? = null,
     val jolliDocId: Int? = null,
     val orphanedDocIds: List<Int>? = null,
+    val unresolvedOrphanHashes: List<String>? = null,
     val treeHash: String? = null,
     val recap: String? = null,
     val e2eTestGuide: List<E2eTestScenario>? = null,

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/PostCommitHook.kt
@@ -1,5 +1,6 @@
 package ai.jolli.jollimemory.hooks
 
+import ai.jolli.jollimemory.bridge.CliIntegrations
 import ai.jolli.jollimemory.bridge.GitOps
 import ai.jolli.jollimemory.core.*
 import ai.jolli.jollimemory.core.references.PromptRenderer
@@ -228,6 +229,19 @@ object PostCommitHook {
             }
             refresher.shutdownNow()
             SessionTracker.releaseLock(cwd)
+            // Pre-push sync catch-up (JOLLI-1900): a `git push` may have raced ahead
+            // of summary generation, leaving its commit in push-pending.json. Now that
+            // this drain has (re)generated summaries, drain the pending queue so those
+            // commits sync to Jolli Space without waiting for the next plugin startup —
+            // the IntelliJ analog of the TS QueueWorker's triggerPushForNewSummaries.
+            // Runs after releaseLock (never holds the drain lock over a network push;
+            // the push worker takes its own push-pending lock) and blocks (bounded)
+            // because this JVM is already a detached background process. Gated on
+            // `processed > 0` + the cheap no-pending short-circuit inside the callee,
+            // so a normal commit with nothing pending never spawns Node.
+            if (processed > 0) {
+                CliIntegrations.retryPendingPushes(cwd, waitForCompletion = true)
+            }
             ai.jolli.jollimemory.core.telemetry.Telemetry.track(
                 "queue_drained",
                 mapOf("ops" to processed, "duration_ms" to (System.currentTimeMillis() - drainStart)),

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/BranchShareModal.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/BranchShareModal.kt
@@ -85,6 +85,7 @@ object BranchShareModal {
         val storeSummary: (CommitSummary, Boolean) -> Unit,
         val readPlanFromBranch: (String) -> String?,
         val readNoteBody: (String) -> String?,
+        val readSummary: (String) -> CommitSummary? = { null },
         val resolveBinding: (String) -> JolliPushOrchestrator.BindingOutcome,
         val nowMs: Long? = null,
     )
@@ -97,6 +98,7 @@ object BranchShareModal {
             storeSummary = ctx.storeSummary,
             readPlanFromBranch = ctx.readPlanFromBranch,
             readNoteBody = ctx.readNoteBody,
+            readSummary = ctx.readSummary,
             resolveBinding = ctx.resolveBinding,
         )
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
@@ -1,5 +1,6 @@
 package ai.jolli.jollimemory.services
 
+import ai.jolli.jollimemory.bridge.CliIntegrations
 import ai.jolli.jollimemory.bridge.CommitSummaryBrief
 import ai.jolli.jollimemory.bridge.ConversationBrief
 import ai.jolli.jollimemory.bridge.GitOps
@@ -360,6 +361,15 @@ val sb = StringBuilder()
                     log.warn("Integrations catch-up failed (non-fatal): ${e.message}")
                 }
             }
+        }
+
+        // Pre-push sync catch-up (JOLLI-1900): retry any commits left in
+        // push-pending.json from a previous session — an offline push, or a push
+        // that raced ahead of summary generation. Off the EDT; fully guarded and
+        // fire-and-forget (no-ops when nothing is pending, Node is absent, or the
+        // user isn't signed in). Mirrors VS Code's Extension.activate retry.
+        com.intellij.openapi.application.ApplicationManager.getApplication().executeOnPooledThread {
+            CliIntegrations.retryPendingPushes(basePath)
         }
 
         isInitialized = true

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliPushOrchestrator.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliPushOrchestrator.kt
@@ -6,6 +6,7 @@ import ai.jolli.jollimemory.core.NoteFormat
 import ai.jolli.jollimemory.core.NoteReference
 import ai.jolli.jollimemory.core.PlanGrouping
 import ai.jolli.jollimemory.core.PlanReference
+import ai.jolli.jollimemory.core.PushPendingReader
 import ai.jolli.jollimemory.core.telemetry.Telemetry
 import ai.jolli.jollimemory.toolwindow.views.SummaryMarkdownBuilder
 import ai.jolli.jollimemory.toolwindow.views.SummaryUtils
@@ -79,6 +80,8 @@ object JolliPushOrchestrator {
         val readPlanFromBranch: (String) -> String?,
         /** Reads a note body from the orphan branch. */
         val readNoteBody: (String) -> String?,
+        /** Reads a summary by its original commit hash for delayed orphan cleanup. */
+        val readSummary: (String) -> CommitSummary? = { null },
         /** Opens the binding chooser and reports the outcome. */
         val resolveBinding: (String) -> BindingOutcome,
     )
@@ -141,9 +144,46 @@ object JolliPushOrchestrator {
             )
             ctx.storeSummary(updatedSummary, true)
 
+            var summaryForCleanup = updatedSummary
+            val unresolvedHashes = summary.unresolvedOrphanHashes ?: emptyList()
+            if (unresolvedHashes.isNotEmpty()) {
+                // Conservative retention: mirrors the TS port. Any hash that
+                // cannot be positively resolved to a docId is retained so a
+                // worker that crashed post-network-push does not leave an
+                // orphan Space article un-referenced. The push-pending file is
+                // consulted only for the in-flight log counter.
+                val pendingHashes = PushPendingReader.loadHashes(ctx.workspaceRoot)
+                val resolvedDocIds = ArrayList<Int>()
+                val remainingHashes = ArrayList<String>()
+                var stillInFlight = 0
+                for (hash in unresolvedHashes) {
+                    val fresh = ctx.readSummary(hash)
+                    if (fresh?.commitHash == hash && fresh.jolliDocId != null) {
+                        resolvedDocIds.add(fresh.jolliDocId)
+                    } else {
+                        remainingHashes.add(hash)
+                        if (pendingHashes != null && hash in pendingHashes) stillInFlight++
+                    }
+                }
+                if (resolvedDocIds.isNotEmpty() || remainingHashes.size != unresolvedHashes.size) {
+                    if (resolvedDocIds.isNotEmpty()) {
+                        log.info(
+                            "Resolved ${resolvedDocIds.size} orphan hashes → docIds for cleanup " +
+                                "(${remainingHashes.size} retained, $stillInFlight still in-flight)",
+                        )
+                    }
+                    summaryForCleanup = updatedSummary.copy(
+                        orphanedDocIds = ((updatedSummary.orphanedDocIds ?: emptyList()) + resolvedDocIds)
+                            .distinct().ifEmpty { null },
+                        unresolvedOrphanHashes = remainingHashes.distinct().ifEmpty { null },
+                    )
+                    ctx.storeSummary(summaryForCleanup, true)
+                }
+            }
+
             // Clean up orphaned articles (best-effort — never surfaces as a failed push).
             val cleanedSummary = try {
-                cleanupOrphanedDocs(summary, updatedSummary, displayBase, ctx)
+                cleanupOrphanedDocs(summaryForCleanup, summaryForCleanup, displayBase, ctx)
             } catch (e: Exception) {
                 log.warn("Orphan cleanup failed after a successful push: ${e.message}")
                 null
@@ -157,7 +197,7 @@ object JolliPushOrchestrator {
                     plans = planUrls,
                     notes = noteUrls,
                 ),
-                updatedSummary = cleanedSummary ?: updatedSummary,
+                updatedSummary = cleanedSummary ?: summaryForCleanup,
                 attachmentFailures = attachmentFailures,
                 isUpdate = isUpdate,
                 attachmentCount = planUrls.size + noteUrls.size,

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliShareService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliShareService.kt
@@ -3,6 +3,7 @@ package ai.jolli.jollimemory.services
 import ai.jolli.jollimemory.bridge.GitRemoteUtils
 import ai.jolli.jollimemory.core.CommitSummary
 import ai.jolli.jollimemory.core.JmLogger
+import ai.jolli.jollimemory.core.PushPendingReader
 import ai.jolli.jollimemory.core.SummaryStore
 import ai.jolli.jollimemory.core.telemetry.Telemetry
 import ai.jolli.jollimemory.toolwindow.views.SummaryMarkdownBuilder
@@ -106,7 +107,8 @@ object JolliShareService {
         val updatedSummary = summary.copy(jolliDocUrl = fullUrl, jolliDocId = result.docId, plans = plansWithUrls)
         store.storeSummary(updatedSummary, force = true)
 
-        val cleanedSummary = cleanupOrphanedDocs(store, summary, updatedSummary, baseUrl, apiKey) ?: updatedSummary
+        val resolvedSummary = resolveUnresolvedOrphans(store, updatedSummary, cwd)
+        val cleanedSummary = cleanupOrphanedDocs(store, resolvedSummary, resolvedSummary, baseUrl, apiKey) ?: resolvedSummary
 
         Telemetry.track(
             "memory_pushed",
@@ -118,6 +120,50 @@ object JolliShareService {
         )
 
         return ShareResult(cleanedSummary, result.created, planUrls.size)
+    }
+
+    /**
+     * Promotes delayed child article ids into the normal cleanup queue.
+     *
+     * Retention policy: any hash that cannot be positively resolved to a
+     * docId is retained. Dropping unresolved hashes purely because they are
+     * not in `push-pending.json` is unsafe — a worker that succeeded on the
+     * network but crashed before writing the docId back would have left an
+     * orphan Space article whose only local trace is this hash. The pending
+     * file is still read so we can log how many retained hashes look
+     * in-flight vs. abandoned; it does not gate retention.
+     */
+    private fun resolveUnresolvedOrphans(store: SummaryStore, summary: CommitSummary, cwd: String): CommitSummary {
+        val hashes = summary.unresolvedOrphanHashes ?: return summary
+        if (hashes.isEmpty()) return summary
+
+        val pendingHashes = PushPendingReader.loadHashes(cwd)
+        val resolvedDocIds = ArrayList<Int>()
+        val remainingHashes = ArrayList<String>()
+        var stillInFlight = 0
+        for (hash in hashes) {
+            val fresh = store.getSummary(hash)
+            if (fresh?.commitHash == hash && fresh.jolliDocId != null) {
+                resolvedDocIds.add(fresh.jolliDocId)
+            } else {
+                remainingHashes.add(hash)
+                if (pendingHashes != null && hash in pendingHashes) stillInFlight++
+            }
+        }
+        if (resolvedDocIds.isEmpty() && remainingHashes.size == hashes.size) return summary
+
+        if (resolvedDocIds.isNotEmpty()) {
+            log.info(
+                "Resolved ${resolvedDocIds.size} orphan hashes → docIds for cleanup " +
+                    "(${remainingHashes.size} retained, $stillInFlight still in-flight)",
+            )
+        }
+        val resolved = summary.copy(
+            orphanedDocIds = ((summary.orphanedDocIds ?: emptyList()) + resolvedDocIds).distinct().ifEmpty { null },
+            unresolvedOrphanHashes = remainingHashes.distinct().ifEmpty { null },
+        )
+        store.storeSummary(resolved, force = true)
+        return resolved
     }
 
     /**

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/LiveShareController.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/LiveShareController.kt
@@ -54,6 +54,7 @@ object LiveShareController {
         val storeSummary: (CommitSummary, Boolean) -> Unit,
         val readPlanFromBranch: (String) -> String?,
         val readNoteBody: (String) -> String?,
+        val readSummary: (String) -> CommitSummary? = { null },
         val resolveBinding: (String) -> JolliPushOrchestrator.BindingOutcome,
     )
 
@@ -222,6 +223,7 @@ object LiveShareController {
             storeSummary = deps.storeSummary,
             readPlanFromBranch = deps.readPlanFromBranch,
             readNoteBody = deps.readNoteBody,
+            readSummary = deps.readSummary,
             resolveBinding = deps.resolveBinding,
         )
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/settings/JolliMemoryConfigurable.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/settings/JolliMemoryConfigurable.kt
@@ -1,5 +1,6 @@
 package ai.jolli.jollimemory.settings
 
+import ai.jolli.jollimemory.bridge.CliIntegrations
 import ai.jolli.jollimemory.core.JolliMemoryConfig
 import ai.jolli.jollimemory.core.SessionTracker
 import ai.jolli.jollimemory.services.JolliAuthService
@@ -108,6 +109,18 @@ class JolliMemoryConfigurable(private val project: Project) : Configurable {
                         SwingUtilities.invokeLater {
                             loadFromConfig()
                             updateAccountUI()
+                        }
+                        // Pre-push sync catch-up (JOLLI-1900): drain any commits
+                        // left in push-pending.json from pushes made while signed
+                        // out. Mirrors VS Code's post-login retry in Extension.ts.
+                        val basePath = project.getService(
+                            ai.jolli.jollimemory.services.JolliMemoryService::class.java
+                        ).mainRepoRoot ?: project.basePath
+                        if (basePath != null) {
+                            com.intellij.openapi.application.ApplicationManager
+                                .getApplication().executeOnPooledThread {
+                                    CliIntegrations.retryPendingPushes(basePath)
+                                }
                         }
                     },
                     onError = { msg ->

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ShareContextFactory.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ShareContextFactory.kt
@@ -72,6 +72,7 @@ object ShareContextFactory {
             storeSummary = { s, _ -> store.storeSummary(s, force = true) },
             readPlanFromBranch = { slug -> store.readPlanFromBranch(slug) },
             readNoteBody = { id -> service?.readArchivedNote(id) },
+            readSummary = { hash -> store.getSummary(hash) },
             resolveBinding = { repoUrl -> resolveBindingViaChooser(project, repoUrl, keyMeta?.u, apiKey) },
             nowMs = System.currentTimeMillis(),
         )

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/CliIntegrationsTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/CliIntegrationsTest.kt
@@ -35,6 +35,25 @@ class CliIntegrationsTest {
         result.shouldBeInstanceOf<CliIntegrations.Result>()
     }
 
+    @Test
+    fun `retryPendingPushes no-ops (no throw) when there is nothing pending`() {
+        // No push-pending.json → the cheap pre-check returns before any Node work,
+        // so a normal commit never pays a spawn. Must not throw, either mode.
+        File(tempDir, ".jolli/jollimemory").mkdirs()
+        CliIntegrations.retryPendingPushes(tempDir.absolutePath)
+        CliIntegrations.retryPendingPushes(tempDir.absolutePath, waitForCompletion = true)
+    }
+
+    @Test
+    fun `retryPendingPushes degrades gracefully when a pending file exists but no node`() {
+        // With push-pending.json present the guard passes; with no node/bundle on the
+        // test classpath it still returns cleanly (never throws) rather than erroring.
+        File(tempDir, ".jolli/jollimemory").mkdirs()
+        File(tempDir, ".jolli/jollimemory/push-pending.json")
+            .writeText("""{"version":1,"entries":{"abc":{"branch":"x","enqueuedAt":"2026-01-01T00:00:00Z","retryCount":0}}}""")
+        CliIntegrations.retryPendingPushes(tempDir.absolutePath, waitForCompletion = true)
+    }
+
     // ── warningFor — every non-Ok result yields a user-facing message ──────
 
     @Test

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/HookInstallerTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/HookInstallerTest.kt
@@ -128,6 +128,14 @@ class HookInstallerTest {
             File(tempDir, ".git/hooks").mkdirs()
             HookInstaller(tempDir.absolutePath).isGitHookInstalled("post-commit", "marker") shouldBe false
         }
+
+        @Test
+        fun `detects the pre-push marker`(@TempDir tempDir: File) {
+            File(tempDir, ".git/hooks").mkdirs()
+            File(tempDir, ".git/hooks/pre-push").writeText(
+                "#!/bin/sh\n# >>> JolliMemory pre-push hook >>>\nscript\n# <<< JolliMemory pre-push hook <<<\n")
+            HookInstaller(tempDir.absolutePath).isGitHookInstalled("pre-push", "# >>> JolliMemory pre-push hook >>>") shouldBe true
+        }
     }
 
     // ── areAllHooksInstalled ────────────────────────────────────────────
@@ -135,6 +143,16 @@ class HookInstallerTest {
     @Test
     fun `areAllHooksInstalled returns false when no hooks`() {
         HookInstaller("/nonexistent/path").areAllHooksInstalled() shouldBe false
+    }
+
+    @Test
+    fun `pre-push script preserves the preceding hook status`() {
+        val method = HookInstaller::class.java.getDeclaredMethod("prePushScript")
+        method.isAccessible = true
+        val script = method.invoke(HookInstaller("/fake")) as String
+
+        script shouldContain "__jolli_pre_push_previous_status=${'$'}?"
+        script shouldContain """(exit "${'$'}__jolli_pre_push_previous_status")"""
     }
 
     // ── getDebugInfo ────────────────────────────────────────────────────
@@ -192,6 +210,20 @@ class HookInstallerTest {
 
             // Should either delete or clean the file
             val hookFile = File(tempDir, ".git/hooks/post-commit")
+            if (hookFile.exists()) {
+                hookFile.readText() shouldNotContain "JolliMemory"
+            }
+        }
+
+        @Test
+        fun `removes the pre-push hook section`(@TempDir tempDir: File) {
+            File(tempDir, ".git/hooks").mkdirs()
+            File(tempDir, ".git/hooks/pre-push").writeText(
+                "#!/bin/sh\n\n# >>> JolliMemory pre-push hook >>>\nsome script\n# <<< JolliMemory pre-push hook <<<\n")
+
+            HookInstaller(tempDir.absolutePath).uninstall()
+
+            val hookFile = File(tempDir, ".git/hooks/pre-push")
             if (hookFile.exists()) {
                 hookFile.readText() shouldNotContain "JolliMemory"
             }

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/PushPendingReaderTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/PushPendingReaderTest.kt
@@ -1,0 +1,31 @@
+package ai.jolli.jollimemory.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class PushPendingReaderTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    @Test
+    fun `returns queued commit hashes`() {
+        val queue = File(tempDir, ".jolli/jollimemory/push-pending.json")
+        queue.parentFile.mkdirs()
+        queue.writeText("""{"version":1,"entries":{"hash-a":{},"hash-b":{}}}""")
+
+        PushPendingReader.loadHashes(tempDir.absolutePath) shouldBe setOf("hash-a", "hash-b")
+    }
+
+    @Test
+    fun `returns empty when the queue is missing and null when it is corrupt`() {
+        PushPendingReader.loadHashes(tempDir.absolutePath) shouldBe emptySet()
+
+        val queue = File(tempDir, ".jolli/jollimemory/push-pending.json")
+        queue.parentFile.mkdirs()
+        queue.writeText("not json")
+        PushPendingReader.loadHashes(tempDir.absolutePath) shouldBe null
+    }
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/SummaryStoreTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/SummaryStoreTest.kt
@@ -35,6 +35,8 @@ class SummaryStoreTest {
         e2e: List<E2eTestScenario>? = null,
         jolliDocId: Int? = null,
         jolliDocUrl: String? = null,
+        orphanedDocIds: List<Int>? = null,
+        unresolvedOrphanHashes: List<String>? = null,
     ) = CommitSummary(
         commitHash = hash,
         commitMessage = "Test commit",
@@ -48,6 +50,8 @@ class SummaryStoreTest {
         e2eTestGuide = e2e,
         jolliDocId = jolliDocId,
         jolliDocUrl = jolliDocUrl,
+        orphanedDocIds = orphanedDocIds,
+        unresolvedOrphanHashes = unresolvedOrphanHashes,
     )
 
     private fun makeIndexEntry(hash: String, parent: String? = null, treeHash: String? = null) =
@@ -308,8 +312,13 @@ class SummaryStoreTest {
         fun `creates rebase summary with old as child`() {
             stubGitWritePipeline()
             every { git.readBranchFile(any(), "index.json") } returns null
+            val writtenBlobs = mutableListOf<String>()
+            every {
+                git.execWithStdin("hash-object", "-w", "--stdin", input = capture(writtenBlobs), timeoutSeconds = any())
+            } returns "blobhash123"
 
             val oldSummary = makeSummary("oldHash", jolliDocId = 42, jolliDocUrl = "https://jolli.ai/42",
+                orphanedDocIds = listOf(7), unresolvedOrphanHashes = listOf("pendingChild"),
                 plans = listOf(PlanReference("p1", "Plan", 1, "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z")),
                 e2e = listOf(E2eTestScenario("Test", steps = listOf("Step 1"), expectedResults = listOf("Result 1"))))
             val newInfo = CommitInfo("newHash", "New message", "Alice", "2026-01-16T10:00:00Z")
@@ -317,6 +326,14 @@ class SummaryStoreTest {
             store.migrateOneToOne(oldSummary, newInfo)
 
             verify { git.exec("rev-parse", match { it.startsWith("refs/heads/") }, timeoutSeconds = any()) }
+            val persisted = gson.fromJson(
+                writtenBlobs.first { it.contains("\"commitHash\": \"newHash\"") && it.contains("\"children\"") },
+                CommitSummary::class.java,
+            )
+            persisted.orphanedDocIds shouldBe listOf(7)
+            persisted.unresolvedOrphanHashes shouldBe listOf("pendingChild")
+            persisted.children!!.first().orphanedDocIds shouldBe null
+            persisted.children!!.first().unresolvedOrphanHashes shouldBe null
         }
     }
 
@@ -354,6 +371,40 @@ class SummaryStoreTest {
             // Verify commit was created
             // Verify a commit was created (writeFilesToBranch succeeded)
             verify { git.exec("rev-parse", match { it.startsWith("refs/heads/") }, timeoutSeconds = any()) }
+        }
+
+        @Test
+        fun `hoists jolli cleanup metadata while merging summaries`() {
+            stubGitWritePipeline()
+            every { git.readBranchFile(any(), "index.json") } returns null
+            val writtenBlobs = mutableListOf<String>()
+            every {
+                git.execWithStdin("hash-object", "-w", "--stdin", input = capture(writtenBlobs), timeoutSeconds = any())
+            } returns "blobhash123"
+
+            val older = makeSummary(
+                "s1", jolliDocId = 11, jolliDocUrl = "https://jolli.ai/11",
+                orphanedDocIds = listOf(7), unresolvedOrphanHashes = listOf("pendingChild"),
+                children = listOf(makeSummary("nested", unresolvedOrphanHashes = listOf("nestedPending"))),
+            ).copy(generatedAt = "2026-01-01T00:00:00Z")
+            val newer = makeSummary(
+                "s2", jolliDocId = 22, jolliDocUrl = "https://jolli.ai/22",
+            ).copy(generatedAt = "2026-01-02T00:00:00Z")
+
+            store.mergeManyToOne(
+                listOf(older, newer),
+                CommitInfo("squashHash", "Squash", "Bob", "2026-01-20T10:00:00Z"),
+            )
+
+            val persisted = gson.fromJson(
+                writtenBlobs.first { it.contains("\"commitHash\": \"squashHash\"") && it.contains("\"children\"") },
+                CommitSummary::class.java,
+            )
+            persisted.jolliDocId shouldBe 22
+            persisted.orphanedDocIds shouldBe listOf(11, 7)
+            persisted.unresolvedOrphanHashes shouldBe listOf("pendingChild", "nestedPending")
+            persisted.children!!.all { it.jolliDocId == null && it.unresolvedOrphanHashes == null } shouldBe true
+            persisted.children!!.first().children!!.first().unresolvedOrphanHashes shouldBe null
         }
     }
 

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliShareServiceTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliShareServiceTest.kt
@@ -2,6 +2,7 @@ package ai.jolli.jollimemory.services
 
 import ai.jolli.jollimemory.bridge.GitRemoteUtils
 import ai.jolli.jollimemory.core.CommitSummary
+import ai.jolli.jollimemory.core.PushPendingReader
 import ai.jolli.jollimemory.core.SummaryStore
 import ai.jolli.jollimemory.core.telemetry.Telemetry
 import io.kotest.matchers.shouldBe
@@ -21,10 +22,11 @@ class JolliShareServiceTest {
     private val baseUrl = "https://acme.jolli.ai"
     private val apiKey = "sk-jol-test"
 
-    private fun summary(orphaned: List<Int>? = null) = CommitSummary(
+    private fun summary(orphaned: List<Int>? = null, unresolved: List<String>? = null) = CommitSummary(
         commitHash = "abc12345", commitMessage = "feat: change", commitAuthor = "Dev",
         commitDate = "t", branch = "feature/x", generatedAt = "t",
         jolliDocId = null, orphanedDocIds = orphaned,
+        unresolvedOrphanHashes = unresolved,
     )
 
     @BeforeEach
@@ -34,11 +36,13 @@ class JolliShareServiceTest {
 
         mockkObject(JolliApiClient)
         mockkObject(GitRemoteUtils)
+        mockkObject(PushPendingReader)
         mockkObject(Telemetry)
         every { GitRemoteUtils.getCanonicalRepoUrl(any()) } returns "https://github.com/o/r"
         every { GitRemoteUtils.sanitizeBranchSlug(any()) } returns "feature-x"
         every { Telemetry.track(any(), any()) } returns Unit
         every { Telemetry.bucket(any()) } returns "0"
+        every { PushPendingReader.loadHashes(any()) } returns emptySet()
     }
 
     @AfterEach
@@ -69,6 +73,26 @@ class JolliShareServiceTest {
 
         verify { JolliApiClient.deleteFromJolli(baseUrl, apiKey, 7) }
         res.updatedSummary.orphanedDocIds shouldBe null
+    }
+
+    @Test
+    fun `resolves delayed child doc ids before orphan cleanup`() {
+        every { JolliApiClient.pushToJolli(any(), any(), any()) } returns
+            JolliApiClient.JolliPushResult(url = "ignored", docId = 5, jrn = "jrn:2", created = false)
+        every { JolliApiClient.deleteFromJolli(any(), any(), any()) } returns Unit
+        every { store.getSummary("childHash") } returns summary().copy(commitHash = "childHash", jolliDocId = 77)
+        every { PushPendingReader.loadHashes("/repo") } returns setOf("stillPending")
+
+        val res = JolliShareService.shareSummary(
+            store,
+            summary(unresolved = listOf("childHash", "stillPending")),
+            "/repo",
+            apiKey,
+            baseUrl,
+        )
+
+        verify { JolliApiClient.deleteFromJolli(baseUrl, apiKey, 77) }
+        res.updatedSummary.unresolvedOrphanHashes shouldBe listOf("stillPending")
     }
 
     @Test

--- a/vscode/esbuild.config.mjs
+++ b/vscode/esbuild.config.mjs
@@ -86,6 +86,8 @@ const cliOptions = {
 		{ in: `${jmSrc}/hooks/QueueWorker.ts`,             out: "QueueWorker" },
 		{ in: `${jmSrc}/hooks/PostRewriteHook.ts`,         out: "PostRewriteHook" },
 		{ in: `${jmSrc}/hooks/PrepareMsgHook.ts`,          out: "PrepareMsgHook" },
+		{ in: `${jmSrc}/hooks/PrePushHook.ts`,             out: "PrePushHook" },
+		{ in: `${jmSrc}/hooks/PrePushWorker.ts`,           out: "PrePushWorker" },
 		{ in: `${jmSrc}/hooks/GeminiAfterAgentHook.ts`,   out: "GeminiAfterAgentHook" },
 		{ in: `${jmSrc}/hooks/SessionStartHook.ts`,       out: "SessionStartHook" },
 	],

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -723,6 +723,8 @@ vi.mock("../../cli/src/core/MigrationEngine.js", () => ({
 
 vi.mock("../../cli/src/Logger.js", () => ({
 	ORPHAN_BRANCH: "jollimemory",
+	JOLLI_DIR: ".jolli",
+	JOLLIMEMORY_DIR: "jollimemory",
 	createLogger: vi.fn(() => ({
 		info: vi.fn(),
 		warn: vi.fn(),
@@ -730,6 +732,8 @@ vi.mock("../../cli/src/Logger.js", () => ({
 		debug: vi.fn(),
 	})),
 	getJolliMemoryDir: vi.fn((cwd: string) => `${cwd}/.jolli/jollimemory`),
+	errMsg: vi.fn((err: unknown) => (err instanceof Error ? err.message : String(err))),
+	isEnoent: vi.fn((err: unknown) => (err as NodeJS.ErrnoException)?.code === "ENOENT"),
 }));
 
 vi.mock("../../cli/src/backfill/BackfillEngine.js", () => ({

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -25,6 +25,7 @@ import {
 import type { ManifestEntry } from "../../cli/src/core/KBTypes.js";
 import { isPathInside, toForwardSlash } from "../../cli/src/core/PathUtils.js";
 import { assertJolliOriginAllowed } from "../../cli/src/core/JolliApiUtils.js";
+import { triggerPendingPushRetry } from "../../cli/src/hooks/PushCompensation.js";
 import { exportSharedBranch } from "./services/JolliShareService.js";
 import { importSharedBranchForDisplay } from "./services/SharedBranchImporter.js";
 import { activateExtensionTelemetry, reinitExtensionTelemetry } from "./TelemetryActivation.js";
@@ -1708,6 +1709,11 @@ export function activate(context: vscode.ExtensionContext): void {
 	initializeKB().finally(() => {
 		clearTimeout(kbInitWatchdog);
 		resolveKbInit();
+		// Pre-push sync catch-up (JOLLI-1900): retry any commits left in
+		// push-pending.json from a previous session, now that storage is
+		// initialized. Fire-and-forget; fully guarded (never throws, no-ops when
+		// nothing is pending or the user isn't signed in).
+		void triggerPendingPushRetry(workspaceRoot);
 	});
 
 	// ── sessions.json watcher ─────────────────────────────────────────────────
@@ -3758,6 +3764,9 @@ export function activate(context: vscode.ExtensionContext): void {
 						await activation?.runtime
 							.reconcileAutoSync()
 							.catch(handleError("uriHandler.reconcileAutoSync"));
+						// Pre-push sync catch-up: drain any commits left in
+						// push-pending.json from pushes made while signed out.
+						void triggerPendingPushRetry(workspaceRoot);
 					} else {
 						vscode.window.showErrorMessage(
 							`Jolli sign-in failed: ${result.error}`,

--- a/vscode/src/providers/StatusTreeProvider.test.ts
+++ b/vscode/src/providers/StatusTreeProvider.test.ts
@@ -207,7 +207,7 @@ describe("StatusTreeProvider", () => {
 			"Codex Integration",
 			"Gemini Integration",
 		]);
-		expect(items[0].description).toBe("3 Git + 2 Claude");
+		expect(items[0].description).toBe("4 Git + 2 Claude");
 		// Hooks icon is OK because gitHookInstalled is true
 		expect((items[0].iconPath as { id: string }).id).toBe("check");
 		// Provider row uses dispatcher's resolveLlmCredentialSource — config
@@ -414,7 +414,7 @@ describe("StatusTreeProvider", () => {
 
 		const items = provider.getChildren();
 		const hooksItem = items.find((item) => item.label === "Hooks");
-		expect(hooksItem?.description).toBe("3 Git + 2 Claude");
+		expect(hooksItem?.description).toBe("4 Git + 2 Claude");
 		// Hooks icon is OK because git hooks are installed (Gemini hook status doesn't affect it)
 		expect((hooksItem?.iconPath as { id: string }).id).toBe("check");
 	});
@@ -440,7 +440,7 @@ describe("StatusTreeProvider", () => {
 
 		const items = provider.getChildren();
 		const hooksItem = items.find((item) => item.label === "Hooks");
-		expect(hooksItem?.description).toBe("3 Git");
+		expect(hooksItem?.description).toBe("4 Git");
 
 		const sessionsItem = items.find((item) => item.label === "Sessions");
 		expect(sessionsItem?.description).toBe("1");
@@ -547,7 +547,7 @@ describe("StatusTreeProvider", () => {
 
 		const items = provider.getChildren();
 		const hooksItem = items.find((item) => item.label === "Hooks");
-		expect(hooksItem?.description).toBe("3 Git + 2 Claude + 1 Gemini CLI");
+		expect(hooksItem?.description).toBe("4 Git + 2 Claude + 1 Gemini CLI");
 	});
 
 	it("shows 'none installed' when no hooks are installed", async () => {

--- a/vscode/src/providers/StatusTreeProvider.ts
+++ b/vscode/src/providers/StatusTreeProvider.ts
@@ -118,7 +118,7 @@ function buildFullStatusItems(
 ): Array<StatusItem> {
 	const hookParts: Array<string> = [];
 	if (s.gitHookInstalled) {
-		hookParts.push("3 Git");
+		hookParts.push(`${s.prePushHookInstalled ? 5 : 4} Git`);
 	}
 	if (s.claudeHookInstalled) {
 		hookParts.push("2 Claude");
@@ -133,8 +133,10 @@ function buildFullStatusItems(
 		? `${s.hookSource}${s.hookVersion && s.hookVersion !== "unknown" ? `@${s.hookVersion}` : ""}`
 		: undefined;
 
+	const gitHookCount = s.gitHookInstalled ? (s.prePushHookInstalled ? 5 : 4) : 0;
+	const gitHookList = `post-commit, post-rewrite, prepare-commit-msg, post-merge${s.prePushHookInstalled ? ", pre-push" : ""}`;
 	const hooksTooltipLines = [
-		`Git hooks: ${s.gitHookInstalled ? "3 installed" : "not installed"} (post-commit, post-rewrite, prepare-commit-msg)`,
+		`Git hooks: ${gitHookCount > 0 ? `${gitHookCount} installed` : "not installed"} (${gitHookList})`,
 		`Claude Code hooks: ${s.claudeHookInstalled ? "2 installed" : "not installed"} (Stop, SessionStart)`,
 		`Gemini CLI hook: ${s.geminiHookInstalled ? "installed" : "not installed"} (AfterAgent)`,
 	];

--- a/vscode/src/services/data/StatusDataService.test.ts
+++ b/vscode/src/services/data/StatusDataService.test.ts
@@ -40,14 +40,14 @@ describe("StatusDataService.derive", () => {
 			geminiHookInstalled: true,
 		});
 		const derived = StatusDataService.derive(status, null);
-		expect(derived.hooksDescription).toBe("3 Git + 2 Claude + 1 Gemini CLI");
+		expect(derived.hooksDescription).toBe("4 Git + 2 Claude + 1 Gemini CLI");
 		expect(derived.allHooksInstalled).toBe(true);
 	});
 
 	it("reports only some hooks when partial", () => {
 		const status = makeStatus({ gitHookInstalled: true });
 		const derived = StatusDataService.derive(status, null);
-		expect(derived.hooksDescription).toBe("3 Git");
+		expect(derived.hooksDescription).toBe("4 Git");
 		expect(derived.allHooksInstalled).toBe(true);
 	});
 

--- a/vscode/src/services/data/StatusDataService.ts
+++ b/vscode/src/services/data/StatusDataService.ts
@@ -27,7 +27,7 @@ export class StatusDataService {
 	): StatusDerived {
 		const parts: Array<string> = [];
 		if (status?.gitHookInstalled) {
-			parts.push("3 Git");
+			parts.push(`${status.prePushHookInstalled ? 5 : 4} Git`);
 		}
 		if (status?.claudeHookInstalled) {
 			parts.push("2 Claude");


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Jolli Memory

## Quick recap

The developer implemented a complete pre-push hook auto-sync feature that enables memory to reach Jolli Space on every `git push` without waiting for PR creation. The synchronous portion of the hook (config check, stdin parse, rev-list, JSON write) completes in under 5ms and never blocks the push. The actual network sync runs in a detached background worker, so offline conditions or slow networks never impact the user's workflow.

Pending commits are recorded in a persistent state file with a retry budget of three attempts. Entries are retried automatically on the next push, when memory generation completes, and when plugins activate. This handles the common case where a push arrives before memory is ready, and ensures users don't lose work when they reconnect after being offline. Configuration failures (not signed in, no binding) do not count against the retry budget, so users can fix their setup and the pending work will naturally resume.

The executor reuses the existing cross-commit deduplication logic from the PR-level push path, loading the full branch context and running `assignOwnedAttachments` to determine which commit owns each plan or note. This prevents duplicate plan documents in Jolli Space when multiple commits reference the same logical plan. The feature is integrated into all three surfaces: CLI (via `jolli enable`), VS Code (via extension activation), and IntelliJ (via the Kotlin port's initialization). Comprehensive test coverage validates concurrent state mutations, error classification, and edge cases in git ref handling.

---

## Topics (3)
<details>
<summary><strong>01 · Pre-push hook auto-syncs memory to Jolli Space on every git push</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Memory synchronization to Jolli Space currently only happens at the PR level, requiring users to create a pull request before their work reaches the cloud. The feature request asks for automatic synchronization on every `git push` so memory reaches the cloud continuously during development without waiting for PR creation.

**💡 Decisions Behind the Code**

- **Detached async worker instead of blocking the push**: The synchronous portion of the hook (config check, stdin parse, rev-list, JSON write, spawn) stays under 5ms so git push returns immediately. The actual network sync happens in a background detached process that inherits the trace ID but never blocks or fails the push. This aligns with the existing post-commit hook pattern and ensures network latency or offline conditions never impact the user's workflow.
- **Persistent state file with retry budget instead of fire-and-forget**: Rather than attempting to push once and giving up, pending entries are recorded in `push-pending.json` with a retry count ceiling (3 attempts). Entries are retried on the next push, when QueueWorker finishes generating memory, and when plugins activate. This handles the common case where a push arrives before memory generation completes, and ensures offline users don't lose work when they reconnect.
- **Cross-commit dedup via full branch context**: The executor loads all summaries on the current branch and runs `assignOwnedAttachments` to determine which commit "owns" each plan/note across the entire branch. This prevents duplicate plan docs in Jolli Space when multiple commits reference the same logical plan. The cost (loading full branch summaries) is negligible compared to the network push, and it reuses the existing dedup logic from the PR-level push path.
- **Configuration failure vs. operational failure distinction**: `NotAuthenticatedError`, `BindingRequiredError`, and `ClientOutdatedError` do not increment the retry count because they require explicit user action (login, bind, upgrade) to fix. Retrying forever would waste the budget. Network errors, 5xx, and 4xx errors DO increment the count because they are transient and may resolve on the next attempt. This prevents users from hitting the retry ceiling due to temporary outages.

**✅ What Was Implemented**

- Added `PrePushHook.ts` as the synchronous entry point invoked by git's pre-push hook. It parses stdin to extract pushed commits, records them in `push-pending.json`, and spawns a detached worker only when the user is signed in. The hook itself completes in under 5ms, never blocking the push.
- Created `PushExecutor.ts` as the shared drain core called by three consumers: the detached PrePushWorker, QueueWorker's post-drain follow-up, and plugin activation retry. It loads pending entries, filters by retry budget and memory existence, loads the full branch context for cross-commit plan/note deduplication via `assignOwnedAttachments`, and pushes each commit's summary with its owned attachments to avoid duplicate plan docs in Jolli Space.
- Introduced `PushPendingStore.ts` to manage the persistent state file at `.jolli/jollimemory/push-pending.json`. It tracks each pending commit's branch, enqueue time, last attempt time, retry count, and error message. Stale entries (7 days without activity) are pruned on read. All mutations go through `withPushPendingLock` to prevent lost updates under concurrent access from the hook, worker, and activation retry paths.
- Extended `GitHookInstaller.ts` with `installPrePushHook` and `removePrePushHook` functions that manage the pre-push hook section idempotently, appending to existing hooks without clobbering them.
- Modified `Installer.ts` to call `installPrePushHook` during the standard install flow and `removePrePushHook` during uninstall. Added `prePushHookPath` to the `InstallResult` type.
- Updated `DispatchScripts.ts` to route `pre-push` hook invocations to `PrePushHook.js` via the `run-hook` dispatcher.
- Extended `QueueWorker.ts` to collect hashes of newly generated summaries and trigger `triggerPushForNewSummaries` on the next tick, so commits whose memory was generated during the drain get pushed even if the push arrived before memory generation completed.
- Modified `EnableCommand.ts` to call `triggerPendingPushRetry` after successful installation, catching up any commits recorded while the user was offline or unsigned in.
- Updated `Extension.ts` (VS Code) to call `triggerPendingPushRetry` after `initializeKB` completes, so the extension's activation retries any pending pushes.
- Added `syncOnPush?: boolean` field to `JolliMemoryConfig` in `Types.ts`, defaulting to enabled when undefined. Users can explicitly disable it via CLI configuration.

**📁 FILES**
- `cli/src/core/PushExecutor.ts`
- `cli/src/core/PushPendingStore.ts`
- `cli/src/hooks/PrePushHook.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Test coverage for pre-push sync flow across all modules</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The new pre-push sync feature spans multiple modules (state store, executor, hooks, installer) and involves concurrent access patterns (multiple writers to the same JSON file) and error handling (retry budgets, failure classification). Comprehensive tests are needed to ensure correctness and prevent regressions.

**💡 Decisions Behind the Code**

Test coverage prioritizes the three highest-risk areas: concurrent state mutations (the lock + re-read pattern in `PushPendingStore`), error classification and retry logic (the distinction between config and operational failures in `PushExecutor`), and the rev-list invocation edge cases (new branches vs. existing ones in `PrePushHook`). These are the areas most likely to cause silent data loss or incorrect behavior in production.

**✅ What Was Implemented**

- `PushPendingStore.test.ts` covers stale entry pruning (by `enqueuedAt` and `lastAttemptAt`), NaN-safe date parsing, concurrent `mergeEntries` calls without lost updates, batch updates with mixed deletes and patches, and graceful handling of corrupt or missing files.
- `PushExecutor.test.ts` tests the full drain flow: no-op when no pending entries or not signed in, skipping entries that exhausted the retry budget, honoring the `hashFilter` for post-queue path, skipping candidates without generated memory, pushing with owned attachments for cross-commit dedup, incrementing retry count only on operational failures, and handling race conditions where a summary disappears between the memory check and push time.
- `PrePushHook.test.ts` validates ref parsing, rev-list invocation with `--not --remotes` for new branches and `remote..local` for existing ones, skipping delete pushes, recording commits but not spawning the worker when unsigned in, and grouping multiple refs by branch.
- `GitHookInstaller.test.ts` confirms idempotent install (no duplicate sections on repeated calls), appending to existing hooks without clobbering, and clean removal that leaves other hook content intact.

**📁 FILES**
- `cli/src/core/PushPendingStore.test.ts`
- `cli/src/core/PushExecutor.test.ts`
- `cli/src/hooks/PrePushHook.test.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Build and packaging configuration for pre-push hook scripts</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The new PrePushHook and PrePushWorker scripts must be compiled and bundled into the CLI distribution and VS Code extension so they are available at runtime when the hook is invoked.

**💡 Decisions Behind the Code**

Both scripts are built as separate entry points (not bundled together) so they can be invoked independently: PrePushHook runs synchronously in the git hook context, and PrePushWorker runs as a detached child process. This separation allows PrePushWorker to locate itself by directory + filename (the same pattern used by QueueWorker) rather than relying on a shared bundle path, which is more robust when esbuild inlines the code into multiple distributions.

**✅ What Was Implemented**

- Updated `cli/vite.config.ts` to add `PrePushHook` and `PrePushWorker` as separate build entry points, producing `PrePushHook.js` and `PrePushWorker.js` in the dist directory.
- Updated `vscode/esbuild.config.mjs` to include both scripts in the CLI bundle that gets inlined into the VS Code extension, ensuring the extension can dispatch pre-push invocations to the bundled scripts.

**📁 FILES**
- `cli/vite.config.ts`
- `vscode/esbuild.config.mjs`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 10, 2026 at 1:07 AM · via Anthropic*
<!-- jollimemory-summary-end -->