### PR TITLE
Keep platform-tool internal metadata off tools/list and degrade a bad binding

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -1053,6 +1053,16 @@ export interface JolliMemoryConfig {
 	readonly compileExcludeFolders?: ReadonlyArray<string>;
 	/** Jolli Space API key for pushing summaries and proxy LLM calls (sk-jol-...) */
 	readonly jolliApiKey?: string;
+	/**
+	 * Opt-in gate for the manifest-driven Jolli-platform MCP tools. When `true`,
+	 * the `jolli mcp` server also registers the backend-defined platform tools
+	 * (fetched from the tenant's tool manifest at startup) alongside the built-in
+	 * git-memory tools. Off by default — when absent or `false`, the server stays
+	 * git-memory-only and never contacts the backend for a manifest. Opt-in
+	 * polarity, unlike the `*Enabled` source-discovery flags below which default
+	 * to on. The `JOLLI_MCP_PLATFORM_TOOLS=1` env var overrides it at read time.
+	 */
+	readonly mcpPlatformToolsEnabled?: boolean;
 	/** Enable Codex CLI session discovery at post-commit time (default: auto-detect) */
 	readonly codexEnabled?: boolean;
 	/** Enable Gemini CLI session tracking via AfterAgent hook (default: auto-detect) */

--- a/cli/src/commands/ConfigureCommand.test.ts
+++ b/cli/src/commands/ConfigureCommand.test.ts
@@ -448,4 +448,40 @@ describe("ConfigureCommand — settable keys", () => {
 			await expectSetRejected("-30", /positive integer/);
 		});
 	});
+
+	describe("mcpPlatformToolsEnabled boolean coercion via --set", () => {
+		it("accepts true/false/yes/no/1/0 forms", async () => {
+			for (const truthy of ["true", "yes", "1"]) {
+				mockSaveConfig.mockClear();
+				await runConfigure(["--set", `mcpPlatformToolsEnabled=${truthy}`]);
+				expect(mockSaveConfig).toHaveBeenCalledWith(expect.objectContaining({ mcpPlatformToolsEnabled: true }));
+			}
+			for (const falsy of ["false", "no", "0"]) {
+				mockSaveConfig.mockClear();
+				await runConfigure(["--set", `mcpPlatformToolsEnabled=${falsy}`]);
+				expect(mockSaveConfig).toHaveBeenCalledWith(
+					expect.objectContaining({ mcpPlatformToolsEnabled: false }),
+				);
+			}
+		});
+
+		it("rejects garbage boolean values", async () => {
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const prev = process.exitCode;
+			try {
+				await runConfigure(["--set", "mcpPlatformToolsEnabled=maybe"]);
+				expect(errorSpy).toHaveBeenCalledWith(expect.stringMatching(/true\/false/));
+				expect(process.exitCode).toBe(1);
+				expect(mockSaveConfig).not.toHaveBeenCalled();
+			} finally {
+				errorSpy.mockRestore();
+				process.exitCode = prev;
+			}
+		});
+
+		it("lists mcpPlatformToolsEnabled in --list-keys output", async () => {
+			const help = await runConfigureHelp();
+			expect(help).toContain("mcpPlatformToolsEnabled");
+		});
+	});
 });

--- a/cli/src/commands/ConfigureCommand.ts
+++ b/cli/src/commands/ConfigureCommand.ts
@@ -50,6 +50,7 @@ const VALID_CONFIG_KEYS = [
 	"openCodeEnabled",
 	"cursorEnabled",
 	"copilotEnabled",
+	"mcpPlatformToolsEnabled",
 	"globalInstructions",
 	"logLevel",
 	"excludePatterns",
@@ -122,6 +123,7 @@ function coerceConfigValue(key: ConfigKey, raw: string): string | number | boole
 		key === "openCodeEnabled" ||
 		key === "cursorEnabled" ||
 		key === "copilotEnabled" ||
+		key === "mcpPlatformToolsEnabled" ||
 		key === "syncTranscripts" ||
 		key === "syncOnPush"
 	) {
@@ -201,6 +203,11 @@ const CONFIG_KEY_INFO: ReadonlyArray<{ key: ConfigKey; type: string; description
 		key: "copilotEnabled",
 		type: "boolean",
 		description: "Enable Copilot CLI session discovery (true/false; requires Node 22.5+ at runtime)",
+	},
+	{
+		key: "mcpPlatformToolsEnabled",
+		type: "boolean",
+		description: "Register backend-defined Jolli-platform tools in the MCP server (true/false; off by default)",
 	},
 	{ key: "logLevel", type: "enum", description: "Log level: debug | info | warn | error" },
 	{ key: "excludePatterns", type: "string[]", description: "Glob patterns for file exclusion (comma-separated)" },

--- a/cli/src/core/JolliMemoryPushClient.test.ts
+++ b/cli/src/core/JolliMemoryPushClient.test.ts
@@ -586,12 +586,6 @@ describe("fetchManifest", () => {
 						description: "required has non-string members",
 						inputSchema: { type: "object", properties: {}, required: [123] },
 					},
-					{
-						name: "bad_binding",
-						description: "binding missing path",
-						inputSchema: { type: "object", properties: {} },
-						binding: { method: "POST" },
-					},
 					"not-an-object",
 					TOOL_B,
 				],
@@ -652,6 +646,57 @@ describe("fetchManifest", () => {
 		expect(tool.binding).toEqual({ method: "POST", path: "/api/mcp/tools/list_workflow_definitions" });
 	});
 
+	it("drops a malformed binding WITHOUT dropping the tool (like menu)", async () => {
+		// `binding` is internal routing metadata, never advertised, so a bad one can
+		// never poison tools/list — drop only the binding and keep the tool callable
+		// (the generic executor then falls back to POST /api/mcp/tools/<name>).
+		const c = client(async () =>
+			jsonResponse(200, {
+				tools: [
+					{
+						name: "not_object",
+						description: "d",
+						inputSchema: { type: "object", properties: {} },
+						binding: "nope",
+					},
+					{
+						name: "arr_binding",
+						description: "d",
+						inputSchema: { type: "object", properties: {} },
+						binding: [],
+					},
+					{
+						name: "no_path",
+						description: "d",
+						inputSchema: { type: "object", properties: {} },
+						binding: { method: "POST" },
+					},
+					{
+						name: "no_method",
+						description: "d",
+						inputSchema: { type: "object", properties: {} },
+						binding: { path: "/api/mcp/tools/x" },
+					},
+					{
+						name: "non_string_method",
+						description: "d",
+						inputSchema: { type: "object", properties: {} },
+						binding: { method: 1, path: "/api/mcp/tools/x" },
+					},
+				],
+			}),
+		);
+		const tools = await c.fetchManifest();
+		expect(tools.map((t) => t.name)).toEqual([
+			"not_object",
+			"arr_binding",
+			"no_path",
+			"no_method",
+			"non_string_method",
+		]);
+		expect(tools.every((t) => t.binding === undefined)).toBe(true);
+	});
+
 	it("preserves a valid menu block on a fetched entry", async () => {
 		const withMenu = {
 			name: "create_ticket",
@@ -681,7 +726,7 @@ describe("fetchManifest", () => {
 		expect(tool.menu).toEqual({ label: "Just a label" });
 	});
 
-	it("drops a malformed menu block WITHOUT dropping the tool (unlike binding)", async () => {
+	it("drops a malformed menu block WITHOUT dropping the tool (like binding)", async () => {
 		// Each of these entries has a bad menu but must remain a usable tool with no
 		// menu — a partially-rolled-out backend must never lose a working tool.
 		const c = client(async () =>

--- a/cli/src/core/JolliMemoryPushClient.test.ts
+++ b/cli/src/core/JolliMemoryPushClient.test.ts
@@ -12,6 +12,7 @@ import {
 	ClientOutdatedError,
 	JolliMemoryPushClient,
 	NotAuthenticatedError,
+	type PlatformToolManifestEntry,
 } from "./JolliMemoryPushClient.js";
 
 const KEY = "sk-jol-test"; // parseJolliApiKey may return null for a plain key → baseUrlOverride supplies the URL
@@ -493,5 +494,317 @@ describe("constructor defaults", () => {
 		);
 		const r = await c.listSpaces();
 		expect(r).toEqual({ spaces: [], defaultSpaceId: null });
+	});
+});
+
+const TOOL_A = {
+	name: "create_ticket",
+	description: "Create a ticket",
+	inputSchema: { type: "object", properties: { title: { type: "string" } }, required: ["title"] },
+};
+const TOOL_B = {
+	name: "list_projects",
+	description: "List projects",
+	inputSchema: { type: "object", properties: {} },
+};
+
+describe("fetchManifest", () => {
+	it("returns the validated tools from a { tools: [...] } envelope", async () => {
+		const c = client(async () => jsonResponse(200, { tools: [TOOL_A, TOOL_B] }));
+		const tools = await c.fetchManifest();
+		expect(tools.map((t) => t.name)).toEqual(["create_ticket", "list_projects"]);
+	});
+
+	it("accepts a bare top-level array manifest", async () => {
+		const c = client(async () => jsonResponse(200, [TOOL_A]));
+		const tools = await c.fetchManifest();
+		expect(tools.map((t) => t.name)).toEqual(["create_ticket"]);
+	});
+
+	it("returns [] on an empty manifest ({} or { tools: [] })", async () => {
+		expect(await client(async () => jsonResponse(200, {})).fetchManifest()).toEqual([]);
+		expect(await client(async () => jsonResponse(200, { tools: [] })).fetchManifest()).toEqual([]);
+	});
+
+	it("returns [] on 404 (surface disabled) without throwing", async () => {
+		const c = client(async () => jsonResponse(404, { error: "not_found" }));
+		await expect(c.fetchManifest()).resolves.toEqual([]);
+	});
+
+	it("returns [] on 403 (key lacks the invoke scope) without throwing", async () => {
+		const c = client(async () => jsonResponse(403, { error: "forbidden" }));
+		await expect(c.fetchManifest()).resolves.toEqual([]);
+	});
+
+	it("returns [] on a generic non-2xx without throwing", async () => {
+		const c = client(async () => jsonResponse(500, { error: "boom" }));
+		await expect(c.fetchManifest()).resolves.toEqual([]);
+	});
+
+	it("returns [] on a non-JSON 200 body (parse failure)", async () => {
+		const c = client(async () => textResponse(200, "<html>200 OK</html>"));
+		await expect(c.fetchManifest()).resolves.toEqual([]);
+	});
+
+	it("returns [] when the fetch rejects (network error / abort)", async () => {
+		const c = client(async () => {
+			throw new Error("network down");
+		});
+		await expect(c.fetchManifest()).resolves.toEqual([]);
+	});
+
+	it("returns [] (not a throw) when no api key is configured", async () => {
+		const c = new JolliMemoryPushClient({
+			fetchImpl: async () => jsonResponse(200, { tools: [TOOL_A] }),
+			apiKeyProvider: async () => undefined,
+		});
+		await expect(c.fetchManifest()).resolves.toEqual([]);
+	});
+
+	it("drops malformed entries but keeps the valid ones", async () => {
+		const c = client(async () =>
+			jsonResponse(200, {
+				tools: [
+					TOOL_A,
+					{ name: "", description: "empty name", inputSchema: { type: "object", properties: {} } },
+					{ name: "bad_desc", description: 123, inputSchema: { type: "object", properties: {} } },
+					{ description: "no name", inputSchema: { type: "object", properties: {} } },
+					{ name: "no_schema", description: "missing schema" },
+					{ name: "bad_schema", description: "wrong type", inputSchema: { type: "array", properties: {} } },
+					{
+						name: "arr_props",
+						description: "properties is an array",
+						inputSchema: { type: "object", properties: [] },
+					},
+					{
+						name: "bad_required",
+						description: "required is not an array",
+						inputSchema: { type: "object", properties: {}, required: "title" },
+					},
+					{
+						name: "bad_required_elems",
+						description: "required has non-string members",
+						inputSchema: { type: "object", properties: {}, required: [123] },
+					},
+					{
+						name: "bad_binding",
+						description: "binding missing path",
+						inputSchema: { type: "object", properties: {} },
+						binding: { method: "POST" },
+					},
+					"not-an-object",
+					TOOL_B,
+				],
+			}),
+		);
+		const tools = await c.fetchManifest();
+		expect(tools.map((t) => t.name)).toEqual(["create_ticket", "list_projects"]);
+	});
+
+	it("accepts a zero-arg tool with no `properties` and defaults it to {}", async () => {
+		// MCP treats `{ type: "object" }` (no properties) as a valid no-arg schema;
+		// the validator must keep it and normalize the advertised schema.
+		const c = client(async () =>
+			jsonResponse(200, {
+				tools: [{ name: "ping", description: "no-arg tool", inputSchema: { type: "object" } }],
+			}),
+		);
+		const [tool] = await c.fetchManifest();
+		expect(tool.name).toBe("ping");
+		expect(tool.inputSchema).toEqual({ type: "object", properties: {} });
+	});
+
+	it("preserves extra JSON-Schema keywords on inputSchema", async () => {
+		const c = client(async () =>
+			jsonResponse(200, {
+				tools: [
+					{
+						name: "t",
+						description: "d",
+						inputSchema: {
+							type: "object",
+							properties: { x: { type: "string" } },
+							required: ["x"],
+							additionalProperties: false,
+						},
+					},
+				],
+			}),
+		);
+		const [tool] = await c.fetchManifest();
+		expect(tool.inputSchema).toMatchObject({
+			type: "object",
+			properties: { x: { type: "string" } },
+			required: ["x"],
+			additionalProperties: false,
+		});
+	});
+
+	it("preserves a valid binding on a fetched entry", async () => {
+		const withBinding = {
+			name: "list_workflow_definitions",
+			description: "List workflow definitions",
+			inputSchema: { type: "object", properties: {} },
+			binding: { method: "POST", path: "/api/mcp/tools/list_workflow_definitions" },
+		};
+		const c = client(async () => jsonResponse(200, { tools: [withBinding] }));
+		const [tool] = await c.fetchManifest();
+		expect(tool.binding).toEqual({ method: "POST", path: "/api/mcp/tools/list_workflow_definitions" });
+	});
+
+	it("sends Bearer auth to /api/mcp/manifest", async () => {
+		let capturedUrl: string | undefined;
+		let capturedHeaders: Record<string, string> = {};
+		const c = client(async (url, init) => {
+			capturedUrl = String(url);
+			capturedHeaders = init?.headers as Record<string, string>;
+			return jsonResponse(200, { tools: [] });
+		});
+		await c.fetchManifest();
+		expect(capturedUrl).toBe("https://jolli.ai/api/mcp/manifest");
+		expect(capturedHeaders.Authorization).toBe(`Bearer ${KEY}`);
+	});
+});
+
+describe("invokePlatformTool", () => {
+	function entry(name: string, binding?: { method: string; path: string }): PlatformToolManifestEntry {
+		return {
+			name,
+			description: "d",
+			inputSchema: { type: "object", properties: {} },
+			...(binding ? { binding } : {}),
+		};
+	}
+
+	it("returns a 2xx JSON body verbatim", async () => {
+		const c = client(async () => jsonResponse(200, { type: "ok", result: 42 }));
+		await expect(c.invokePlatformTool(entry("create_ticket"), { title: "x" })).resolves.toEqual({
+			type: "ok",
+			result: 42,
+		});
+	});
+
+	it("returns a backend {type:'error'} body as-is (does NOT throw — the server flags it)", async () => {
+		const c = client(async () => jsonResponse(200, { type: "error", message: "bad args" }));
+		await expect(c.invokePlatformTool(entry("create_ticket"), {})).resolves.toEqual({
+			type: "error",
+			message: "bad args",
+		});
+	});
+
+	it("throws on a non-2xx status so the server surfaces it", async () => {
+		const c = client(async () => jsonResponse(500, { error: "boom" }));
+		await expect(c.invokePlatformTool(entry("create_ticket"), {})).rejects.toThrow("boom");
+	});
+
+	it("falls back to `HTTP <status>` when a non-2xx body carries no message", async () => {
+		const c = client(async () => jsonResponse(400, {}));
+		await expect(c.invokePlatformTool(entry("create_ticket"), {})).rejects.toThrow("HTTP 400");
+	});
+
+	it("maps 426 to ClientOutdatedError", async () => {
+		const c = client(async () => jsonResponse(426, { error: "client_outdated" }));
+		await expect(c.invokePlatformTool(entry("create_ticket"), {})).rejects.toBeInstanceOf(ClientOutdatedError);
+	});
+
+	it("throws on a 2xx body that isn't JSON (proxy page)", async () => {
+		const c = client(async () => textResponse(200, "<html>OK</html>"));
+		await expect(c.invokePlatformTool(entry("create_ticket"), {})).rejects.toThrow(/Malformed/);
+	});
+
+	it("falls back to POST /api/mcp/tools/<name> (URL-encoded) with the args as the JSON body when no binding", async () => {
+		let capturedUrl: string | undefined;
+		let capturedBody: string | undefined;
+		let capturedMethod: string | undefined;
+		let capturedHeaders: Record<string, string> = {};
+		const c = client(async (url, init) => {
+			capturedUrl = String(url);
+			capturedBody = init?.body as string;
+			capturedMethod = init?.method;
+			capturedHeaders = init?.headers as Record<string, string>;
+			return jsonResponse(200, { ok: true });
+		});
+		await c.invokePlatformTool(entry("weird/name space"), { a: 1 });
+		expect(capturedMethod).toBe("POST");
+		expect(capturedUrl).toBe("https://jolli.ai/api/mcp/tools/weird%2Fname%20space");
+		expect(capturedBody).toBe(JSON.stringify({ a: 1 }));
+		expect(capturedHeaders.Authorization).toBe(`Bearer ${KEY}`);
+		expect(capturedHeaders["Content-Type"]).toBe("application/json");
+	});
+
+	it("honors the manifest binding's method and path when present", async () => {
+		let capturedUrl: string | undefined;
+		let capturedMethod: string | undefined;
+		const c = client(async (url, init) => {
+			capturedUrl = String(url);
+			capturedMethod = init?.method;
+			return jsonResponse(200, { ok: true });
+		});
+		await c.invokePlatformTool(
+			entry("list_workflow_definitions", { method: "POST", path: "/api/mcp/tools/list_workflow_definitions" }),
+			{},
+		);
+		expect(capturedMethod).toBe("POST");
+		expect(capturedUrl).toBe("https://jolli.ai/api/mcp/tools/list_workflow_definitions");
+	});
+
+	it("ignores an off-origin binding path (including URL-parser bypass vectors) and falls back", async () => {
+		// A manifest must never redirect the bearer token off-origin. A raw string
+		// prefix check is not enough: the WHATWG URL parser rewrites `\` to `/` and
+		// strips embedded tab/CR/LF, so each of these normalizes to an off-origin
+		// host. The guard must compare the RESOLVED origin, not the raw string.
+		const vectors = [
+			"https://evil.example/steal",
+			"//evil.example/steal",
+			"/\\evil.example/steal",
+			"/\t/evil.example",
+			"/\r/evil.example",
+			"/\n/evil.example",
+		];
+		for (const evil of vectors) {
+			let capturedUrl: string | undefined;
+			const c = client(async (url) => {
+				capturedUrl = String(url);
+				return jsonResponse(200, { ok: true });
+			});
+			await c.invokePlatformTool(entry("create_ticket", { method: "POST", path: evil }), {});
+			expect(capturedUrl).toBe("https://jolli.ai/api/mcp/tools/create_ticket");
+		}
+	});
+
+	it("honors a same-origin binding supplied as an absolute URL", async () => {
+		let capturedUrl: string | undefined;
+		const c = client(async (url) => {
+			capturedUrl = String(url);
+			return jsonResponse(200, { ok: true });
+		});
+		await c.invokePlatformTool(
+			entry("create_ticket", { method: "POST", path: "https://jolli.ai/api/mcp/tools/custom" }),
+			{},
+		);
+		expect(capturedUrl).toBe("https://jolli.ai/api/mcp/tools/custom");
+	});
+
+	it("honors a valid non-POST method case-insensitively on a same-origin binding", async () => {
+		let capturedMethod: string | undefined;
+		const c = client(async (_url, init) => {
+			capturedMethod = init?.method;
+			return jsonResponse(200, { ok: true });
+		});
+		await c.invokePlatformTool(entry("create_ticket", { method: "put", path: "/api/mcp/tools/create_ticket" }), {});
+		expect(capturedMethod).toBe("PUT");
+	});
+
+	it("falls back to the conventional POST endpoint when the binding method is not a known HTTP method", async () => {
+		let capturedUrl: string | undefined;
+		let capturedMethod: string | undefined;
+		const c = client(async (url, init) => {
+			capturedUrl = String(url);
+			capturedMethod = init?.method;
+			return jsonResponse(200, { ok: true });
+		});
+		await c.invokePlatformTool(entry("create_ticket", { method: "FETCH", path: "/api/mcp/tools/x" }), {});
+		expect(capturedMethod).toBe("POST");
+		expect(capturedUrl).toBe("https://jolli.ai/api/mcp/tools/create_ticket");
 	});
 });

--- a/cli/src/core/JolliMemoryPushClient.test.ts
+++ b/cli/src/core/JolliMemoryPushClient.test.ts
@@ -931,4 +931,26 @@ describe("invokePlatformTool", () => {
 		expect(capturedMethod).toBe("POST");
 		expect(capturedUrl).toBe("https://jolli.ai/api/mcp/tools/create_ticket");
 	});
+
+	it("falls back to POST for a GET binding — GET cannot carry the args body", async () => {
+		// The invocation contract always relays `args` as a JSON body, and a real
+		// `fetch` throws `Request with GET/HEAD method cannot have body`. GET is
+		// therefore not an allowed binding method: a GET-natured tool routes through
+		// the conventional POST endpoint (with the args body) instead of throwing.
+		let capturedMethod: string | undefined;
+		let capturedUrl: string | undefined;
+		let capturedBody: unknown;
+		const c = client(async (url, init) => {
+			capturedUrl = String(url);
+			capturedMethod = init?.method;
+			capturedBody = init?.body;
+			return jsonResponse(200, { ok: true });
+		});
+		await c.invokePlatformTool(entry("list_tickets", { method: "GET", path: "/api/mcp/tools/list_tickets" }), {
+			status: "open",
+		});
+		expect(capturedMethod).toBe("POST");
+		expect(capturedUrl).toBe("https://jolli.ai/api/mcp/tools/list_tickets");
+		expect(capturedBody).toBe(JSON.stringify({ status: "open" }));
+	});
 });

--- a/cli/src/core/JolliMemoryPushClient.test.ts
+++ b/cli/src/core/JolliMemoryPushClient.test.ts
@@ -652,6 +652,85 @@ describe("fetchManifest", () => {
 		expect(tool.binding).toEqual({ method: "POST", path: "/api/mcp/tools/list_workflow_definitions" });
 	});
 
+	it("preserves a valid menu block on a fetched entry", async () => {
+		const withMenu = {
+			name: "create_ticket",
+			description: "Create a ticket",
+			inputSchema: { type: "object", properties: {} },
+			menu: { label: "Create ticket", description: "Open a new ticket", order: 2 },
+		};
+		const c = client(async () => jsonResponse(200, { tools: [withMenu] }));
+		const [tool] = await c.fetchManifest();
+		expect(tool.menu).toEqual({ label: "Create ticket", description: "Open a new ticket", order: 2 });
+	});
+
+	it("keeps only the label when a menu block omits description/order", async () => {
+		const c = client(async () =>
+			jsonResponse(200, {
+				tools: [
+					{
+						name: "t",
+						description: "d",
+						inputSchema: { type: "object", properties: {} },
+						menu: { label: "Just a label" },
+					},
+				],
+			}),
+		);
+		const [tool] = await c.fetchManifest();
+		expect(tool.menu).toEqual({ label: "Just a label" });
+	});
+
+	it("drops a malformed menu block WITHOUT dropping the tool (unlike binding)", async () => {
+		// Each of these entries has a bad menu but must remain a usable tool with no
+		// menu — a partially-rolled-out backend must never lose a working tool.
+		const c = client(async () =>
+			jsonResponse(200, {
+				tools: [
+					{
+						name: "not_object",
+						description: "d",
+						inputSchema: { type: "object", properties: {} },
+						menu: "nope",
+					},
+					{ name: "menu_array", description: "d", inputSchema: { type: "object", properties: {} }, menu: [] },
+					{
+						name: "no_label",
+						description: "d",
+						inputSchema: { type: "object", properties: {} },
+						menu: { description: "no label here" },
+					},
+					{
+						name: "blank_label",
+						description: "d",
+						inputSchema: { type: "object", properties: {} },
+						menu: { label: "   " },
+					},
+				],
+			}),
+		);
+		const tools = await c.fetchManifest();
+		expect(tools.map((t) => t.name)).toEqual(["not_object", "menu_array", "no_label", "blank_label"]);
+		expect(tools.every((t) => t.menu === undefined)).toBe(true);
+	});
+
+	it("drops only the malformed description/order fields, keeping the label", async () => {
+		const c = client(async () =>
+			jsonResponse(200, {
+				tools: [
+					{
+						name: "t",
+						description: "d",
+						inputSchema: { type: "object", properties: {} },
+						menu: { label: "Keep me", description: 123, order: "high" },
+					},
+				],
+			}),
+		);
+		const [tool] = await c.fetchManifest();
+		expect(tool.menu).toEqual({ label: "Keep me" });
+	});
+
 	it("sends Bearer auth to /api/mcp/manifest", async () => {
 		let capturedUrl: string | undefined;
 		let capturedHeaders: Record<string, string> = {};

--- a/cli/src/core/JolliMemoryPushClient.ts
+++ b/cli/src/core/JolliMemoryPushClient.ts
@@ -96,6 +96,28 @@ export type FrontDoorResult =
 	  }
 	| { readonly status: "no_spaces" };
 
+/** How to reach a platform tool's backend endpoint, as advertised by the manifest. */
+export interface PlatformToolBinding {
+	readonly method: string;
+	readonly path: string;
+}
+
+/**
+ * A backend-defined Jolli-platform tool as advertised by `GET /api/mcp/manifest`.
+ * The `name` / `description` / `inputSchema` triple structurally matches the MCP
+ * server's tool definition so the server can splice these straight into its tool
+ * registry (the extra `binding` field is internal routing metadata, not part of
+ * the advertised tool schema). Declared here — with no MCP-SDK coupling — because
+ * this client owns the fetch, field validation, and the generic executor.
+ */
+export interface PlatformToolManifestEntry {
+	readonly name: string;
+	readonly description: string;
+	readonly inputSchema: { type: "object"; properties: Record<string, unknown>; required?: string[] };
+	/** REST binding the generic executor calls. Falls back to POST /api/mcp/tools/<name> when absent. */
+	readonly binding?: PlatformToolBinding;
+}
+
 /** Test seam — swap in a stub `fetch` / api key / base URL to drive unit tests deterministically. */
 export interface JolliMemoryPushClientOpts {
 	readonly fetchImpl?: typeof fetch;
@@ -108,6 +130,14 @@ export interface JolliMemoryPushClientOpts {
 }
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Manifest fetch runs at MCP-server startup, so it uses a much tighter timeout
+ * than a normal request: a reachable-but-slow backend must not stall server
+ * startup for the full default window. A timeout collapses to "no platform
+ * tools" like any other manifest failure.
+ */
+const MANIFEST_TIMEOUT_MS = 5_000;
 
 /** Raw shape of `GET /api/jolli-memory/spaces` — validated field-by-field at parse time. */
 interface ListSpacesResponseBody {
@@ -365,6 +395,68 @@ export class JolliMemoryPushClient {
 		return deriveJolliEnvKey(baseUrl) ?? "";
 	}
 
+	/**
+	 * Fetches the tenant's backend-defined Jolli-platform tool manifest
+	 * (`GET /api/mcp/manifest`). Best-effort by contract: EVERY failure mode —
+	 * a non-2xx status (including 404 when the surface is off and 403 when the
+	 * key lacks permission to invoke it), no api key configured, a network /
+	 * abort / timeout error, a non-JSON body, or a missing / empty tool array —
+	 * resolves to `[]` and NEVER throws, so a disabled or older backend silently
+	 * degrades to "no platform tools" instead of breaking MCP-server startup.
+	 * Malformed individual entries are dropped rather than failing the whole
+	 * manifest. Accepts either a `{ tools: [...] }` envelope or a bare array.
+	 */
+	async fetchManifest(): Promise<PlatformToolManifestEntry[]> {
+		try {
+			const { status, json, parseFailed } = await this.call<unknown>(
+				"GET",
+				"/api/mcp/manifest",
+				undefined,
+				MANIFEST_TIMEOUT_MS,
+			);
+			if (status < 200 || status >= 300 || parseFailed) {
+				return [];
+			}
+			return extractManifestTools(json)
+				.map(toPlatformToolEntry)
+				.filter((entry): entry is PlatformToolManifestEntry => entry !== null);
+		} catch {
+			// NotAuthenticatedError (no key / no resolvable URL), a rejected fetch,
+			// or an abort — all collapse to "no platform tools".
+			return [];
+		}
+	}
+
+	/**
+	 * Relays a Jolli-platform tool call to the endpoint the manifest advertised
+	 * for it (its `binding`), falling back to `POST /api/mcp/tools/<name>` when no
+	 * binding is present. Args are forwarded as-is — the backend validates them
+	 * against the tool's manifest schema, so the CLI does not re-validate.
+	 * Deliberately asymmetric to {@link fetchManifest}: a failed INVOCATION must
+	 * surface, so this THROWS on a non-2xx status or a 2xx body that isn't JSON
+	 * (the loud-fail pattern `push` / `listSpaces` use), letting the MCP server's
+	 * existing catch wrap it as an error response. A 2xx JSON body is returned
+	 * verbatim so the server's own envelope rules (a `type: "error"` result is an
+	 * error; a "needs input" result is not) apply to the backend's response shape
+	 * unchanged.
+	 */
+	async invokePlatformTool(tool: PlatformToolManifestEntry, args: Record<string, unknown>): Promise<unknown> {
+		const { baseUrl } = await this.resolveAuth();
+		const { origin } = parseBaseUrl(baseUrl);
+		const { method, path } = resolveToolEndpoint(tool, origin);
+		const { status, json, parseFailed } = await this.call<unknown>(method, path, args);
+		if (status === 426) {
+			throw new ClientOutdatedError(errorMessage(json));
+		}
+		if (status < 200 || status >= 300) {
+			throw new Error(errorMessage(json) ?? `HTTP ${status}`);
+		}
+		if (parseFailed) {
+			throw new Error(`Malformed (non-JSON) response from ${path} (HTTP ${status})`);
+		}
+		return json;
+	}
+
 	private async resolveAuth(): Promise<{
 		apiKey: string;
 		baseUrl: string;
@@ -410,14 +502,15 @@ export class JolliMemoryPushClient {
 	}
 
 	private async call<T>(
-		method: "GET" | "POST" | "DELETE",
+		method: string,
 		path: string,
 		body?: unknown,
+		timeoutMs: number = this.timeoutMs,
 	): Promise<{ status: number; json: T; parseFailed: boolean }> {
 		const { apiKey, baseUrl, keyMeta, tenantSlug } = await this.resolveAuth();
 		const { origin } = parseBaseUrl(baseUrl);
 		const controller = new AbortController();
-		const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+		const timer = setTimeout(() => controller.abort(), timeoutMs);
 		try {
 			const res = await this.fetchImpl(new URL(path, origin).toString(), {
 				method,
@@ -449,6 +542,126 @@ export class JolliMemoryPushClient {
 
 function isErrorBody(value: unknown): value is ErrorResponseBody {
 	return typeof value === "object" && value !== null;
+}
+
+/** HTTP methods a platform tool binding may use; anything else falls back to the conventional endpoint. */
+const ALLOWED_TOOL_METHODS: ReadonlySet<string> = new Set(["GET", "POST", "PUT", "PATCH", "DELETE"]);
+
+/**
+ * Resolves the endpoint for a platform tool call. Honors the manifest-advertised
+ * `binding` only when, after full WHATWG URL normalization against the tenant
+ * origin, it stays same-origin AND its method is a known HTTP method — otherwise
+ * it falls back to the conventional `POST /api/mcp/tools/<name>`. Comparing the
+ * *resolved* origin (not the raw string) is essential: a prefix check is defeated
+ * by inputs the URL parser rewrites — e.g. `/\host` (backslash becomes `/`) or a
+ * path with an embedded tab/CR/LF — which would otherwise smuggle an off-origin
+ * host and leak the bearer token. Mirrors the origin-allowlist comparison done at
+ * key-save time.
+ */
+function resolveToolEndpoint(tool: PlatformToolManifestEntry, origin: string): { method: string; path: string } {
+	const fallback = { method: "POST", path: `/api/mcp/tools/${encodeURIComponent(tool.name)}` };
+	const binding = tool.binding;
+	if (!binding) {
+		return fallback;
+	}
+	const method = binding.method.toUpperCase();
+	if (!ALLOWED_TOOL_METHODS.has(method)) {
+		return fallback;
+	}
+	try {
+		const resolved = new URL(binding.path, origin);
+		if (resolved.origin !== origin) {
+			return fallback;
+		}
+		return { method, path: resolved.pathname + resolved.search };
+	} catch {
+		return fallback;
+	}
+}
+
+/** Pulls the tool array out of a manifest body — `{ tools: [...] }` or a bare array. */
+function extractManifestTools(json: unknown): unknown[] {
+	if (Array.isArray(json)) {
+		return json;
+	}
+	if (json !== null && typeof json === "object") {
+		const tools = (json as { tools?: unknown }).tools;
+		if (Array.isArray(tools)) {
+			return tools;
+		}
+	}
+	return [];
+}
+
+/**
+ * Validates and normalizes one raw manifest entry, mirroring the MCP tool-input
+ * schema contract. Requires a non-empty string `name`, a string `description`,
+ * and an `inputSchema` object whose `type` is `"object"`. `properties` is
+ * OPTIONAL (a zero-arg tool omits it) and is defaulted to `{}` so the advertised
+ * schema always carries one; when present it must be a plain (non-array) object.
+ * `required`, when present, must be an array of strings. An optional `binding`
+ * must be a `{ method, path }` string pair. Any other shape is rejected (returns
+ * `null`) so a single malformed tool can neither survive into the advertised
+ * registry — where it could make the whole `tools/list` response fail a client's
+ * schema validation — nor drop a valid neighbor. Other JSON-Schema keywords on
+ * `inputSchema` are preserved.
+ */
+function toPlatformToolEntry(value: unknown): PlatformToolManifestEntry | null {
+	if (typeof value !== "object" || value === null) {
+		return null;
+	}
+	const { name, description, inputSchema, binding } = value as {
+		name?: unknown;
+		description?: unknown;
+		inputSchema?: unknown;
+		binding?: unknown;
+	};
+	if (typeof name !== "string" || name.trim() === "" || typeof description !== "string") {
+		return null;
+	}
+	if (typeof inputSchema !== "object" || inputSchema === null || Array.isArray(inputSchema)) {
+		return null;
+	}
+	const schema = inputSchema as Record<string, unknown>;
+	if (schema.type !== "object") {
+		return null;
+	}
+	// `properties` is optional; when present it must be a plain object, not an array.
+	if (
+		schema.properties !== undefined &&
+		(typeof schema.properties !== "object" || schema.properties === null || Array.isArray(schema.properties))
+	) {
+		return null;
+	}
+	// `required`, when present, must be an array of strings.
+	if (
+		schema.required !== undefined &&
+		(!Array.isArray(schema.required) || (schema.required as unknown[]).some((item) => typeof item !== "string"))
+	) {
+		return null;
+	}
+	let normalizedBinding: PlatformToolBinding | undefined;
+	if (binding !== undefined) {
+		if (typeof binding !== "object" || binding === null) {
+			return null;
+		}
+		const { method, path } = binding as { method?: unknown; path?: unknown };
+		if (typeof method !== "string" || typeof path !== "string") {
+			return null;
+		}
+		normalizedBinding = { method, path };
+	}
+	// A zero-arg tool omits `properties`; default it to `{}` without dropping any
+	// other schema keywords the backend supplied.
+	const inputSchemaOut = (
+		schema.properties === undefined ? { ...schema, properties: {} } : schema
+	) as PlatformToolManifestEntry["inputSchema"];
+	return {
+		name,
+		description,
+		inputSchema: inputSchemaOut,
+		...(normalizedBinding ? { binding: normalizedBinding } : {}),
+	};
 }
 
 function errorMessage(body: unknown): string | undefined {

--- a/cli/src/core/JolliMemoryPushClient.ts
+++ b/cli/src/core/JolliMemoryPushClient.ts
@@ -559,14 +559,23 @@ function isErrorBody(value: unknown): value is ErrorResponseBody {
 	return typeof value === "object" && value !== null;
 }
 
-/** HTTP methods a platform tool binding may use; anything else falls back to the conventional endpoint. */
-const ALLOWED_TOOL_METHODS: ReadonlySet<string> = new Set(["GET", "POST", "PUT", "PATCH", "DELETE"]);
+/**
+ * HTTP methods a platform-tool binding may use; anything else falls back to the
+ * conventional endpoint. GET (and HEAD) are deliberately excluded: the tool-call
+ * contract always relays the invocation's `args` as a JSON request body, and those
+ * methods cannot carry one (Node's `fetch` throws `Request with GET/HEAD method
+ * cannot have body`). A GET/HEAD-natured binding therefore falls back to the
+ * conventional `POST /api/mcp/tools/<name>` endpoint that every tool supports,
+ * rather than advertising a method that would throw before reaching the network.
+ */
+const ALLOWED_TOOL_METHODS: ReadonlySet<string> = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 /**
  * Resolves the endpoint for a platform tool call. Honors the manifest-advertised
  * `binding` only when, after full WHATWG URL normalization against the tenant
- * origin, it stays same-origin AND its method is a known HTTP method — otherwise
- * it falls back to the conventional `POST /api/mcp/tools/<name>`. Comparing the
+ * origin, it stays same-origin AND its method is a body-carrying HTTP method
+ * (POST/PUT/PATCH/DELETE) — otherwise it falls back to the conventional
+ * `POST /api/mcp/tools/<name>` (see {@link ALLOWED_TOOL_METHODS}). Comparing the
  * *resolved* origin (not the raw string) is essential: a prefix check is defeated
  * by inputs the URL parser rewrites — e.g. `/\host` (backslash becomes `/`) or a
  * path with an embedded tab/CR/LF — which would otherwise smuggle an off-origin

--- a/cli/src/core/JolliMemoryPushClient.ts
+++ b/cli/src/core/JolliMemoryPushClient.ts
@@ -614,18 +614,22 @@ function extractManifestTools(json: unknown): unknown[] {
  * and an `inputSchema` object whose `type` is `"object"`. `properties` is
  * OPTIONAL (a zero-arg tool omits it) and is defaulted to `{}` so the advertised
  * schema always carries one; when present it must be a plain (non-array) object.
- * `required`, when present, must be an array of strings. An optional `binding`
- * must be a `{ method, path }` string pair. Any other shape is rejected (returns
+ * `required`, when present, must be an array of strings. A malformed *advertised
+ * schema* field — a missing/blank name, a non-string description, or an
+ * `inputSchema` that is not an object schema — rejects the whole entry (returns
  * `null`) so a single malformed tool can neither survive into the advertised
  * registry — where it could make the whole `tools/list` response fail a client's
  * schema validation — nor drop a valid neighbor. Other JSON-Schema keywords on
  * `inputSchema` are preserved.
  *
- * An optional `menu` block is validated at FIELD granularity (see
- * `toPlatformMenuEntry`): unlike `binding`, a malformed `menu` never drops the
- * whole entry — the tool stays callable, it just doesn't appear in the `/jolli`
- * menu. This lets a partially-rolled-out backend add menu metadata without any
- * risk of dropping a working tool.
+ * The optional `binding` and `menu` blocks are internal routing / curation
+ * metadata, never part of the advertised tool schema, so — unlike the schema
+ * fields above — a malformed one degrades at FIELD granularity and never drops
+ * the tool (see `toPlatformBinding` / `toPlatformMenuEntry`): a bad `binding` is
+ * discarded and the generic executor falls back to the conventional
+ * `POST /api/mcp/tools/<name>` endpoint; a bad `menu` just leaves the tool absent
+ * from the `/jolli` menu. This lets a partially-rolled-out backend ship either
+ * without any risk of dropping a working tool.
  */
 function toPlatformToolEntry(value: unknown): PlatformToolManifestEntry | null {
 	if (typeof value !== "object" || value === null) {
@@ -662,22 +666,12 @@ function toPlatformToolEntry(value: unknown): PlatformToolManifestEntry | null {
 	) {
 		return null;
 	}
-	let normalizedBinding: PlatformToolBinding | undefined;
-	if (binding !== undefined) {
-		if (typeof binding !== "object" || binding === null) {
-			return null;
-		}
-		const { method, path } = binding as { method?: unknown; path?: unknown };
-		if (typeof method !== "string" || typeof path !== "string") {
-			return null;
-		}
-		normalizedBinding = { method, path };
-	}
 	// A zero-arg tool omits `properties`; default it to `{}` without dropping any
 	// other schema keywords the backend supplied.
 	const inputSchemaOut = (
 		schema.properties === undefined ? { ...schema, properties: {} } : schema
 	) as PlatformToolManifestEntry["inputSchema"];
+	const normalizedBinding = toPlatformBinding(binding);
 	const normalizedMenu = toPlatformMenuEntry(menu);
 	return {
 		name,
@@ -686,6 +680,27 @@ function toPlatformToolEntry(value: unknown): PlatformToolManifestEntry | null {
 		...(normalizedBinding ? { binding: normalizedBinding } : {}),
 		...(normalizedMenu ? { menu: normalizedMenu } : {}),
 	};
+}
+
+/**
+ * Normalizes an optional `binding` block. Like `menu`, a malformed binding never
+ * drops the parent tool: `binding` is internal routing metadata, never part of the
+ * advertised tool schema, so a bad one can't poison `tools/list`. A missing,
+ * non-object, or array `binding`, or one whose `method`/`path` are not both
+ * strings, yields `undefined` — the tool stays callable and the generic executor
+ * falls back to the conventional `POST /api/mcp/tools/<name>` endpoint (which is
+ * also where a structurally-valid but off-origin/unknown-method binding lands at
+ * call time), so a working tool is never lost to a broken binding.
+ */
+function toPlatformBinding(value: unknown): PlatformToolBinding | undefined {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		return undefined;
+	}
+	const { method, path } = value as { method?: unknown; path?: unknown };
+	if (typeof method !== "string" || typeof path !== "string") {
+		return undefined;
+	}
+	return { method, path };
 }
 
 /**

--- a/cli/src/core/JolliMemoryPushClient.ts
+++ b/cli/src/core/JolliMemoryPushClient.ts
@@ -103,6 +103,19 @@ export interface PlatformToolBinding {
 }
 
 /**
+ * Opt-in metadata that surfaces a platform tool in the curated `/jolli` menu
+ * prompt. The backend flags a tool for the menu by attaching this block; an entry
+ * without it is a normal, directly-callable tool that simply never appears in the
+ * menu. `label` is the human-facing menu entry, `description` overrides the tool's
+ * own description in the menu, and `order` is an optional sort hint.
+ */
+export interface PlatformToolMenuEntry {
+	readonly label: string;
+	readonly description?: string;
+	readonly order?: number;
+}
+
+/**
  * A backend-defined Jolli-platform tool as advertised by `GET /api/mcp/manifest`.
  * The `name` / `description` / `inputSchema` triple structurally matches the MCP
  * server's tool definition so the server can splice these straight into its tool
@@ -116,6 +129,8 @@ export interface PlatformToolManifestEntry {
 	readonly inputSchema: { type: "object"; properties: Record<string, unknown>; required?: string[] };
 	/** REST binding the generic executor calls. Falls back to POST /api/mcp/tools/<name> when absent. */
 	readonly binding?: PlatformToolBinding;
+	/** Present only when the backend flags this tool for the curated `/jolli` menu. */
+	readonly menu?: PlatformToolMenuEntry;
 }
 
 /** Test seam — swap in a stub `fetch` / api key / base URL to drive unit tests deterministically. */
@@ -605,16 +620,23 @@ function extractManifestTools(json: unknown): unknown[] {
  * registry — where it could make the whole `tools/list` response fail a client's
  * schema validation — nor drop a valid neighbor. Other JSON-Schema keywords on
  * `inputSchema` are preserved.
+ *
+ * An optional `menu` block is validated at FIELD granularity (see
+ * `toPlatformMenuEntry`): unlike `binding`, a malformed `menu` never drops the
+ * whole entry — the tool stays callable, it just doesn't appear in the `/jolli`
+ * menu. This lets a partially-rolled-out backend add menu metadata without any
+ * risk of dropping a working tool.
  */
 function toPlatformToolEntry(value: unknown): PlatformToolManifestEntry | null {
 	if (typeof value !== "object" || value === null) {
 		return null;
 	}
-	const { name, description, inputSchema, binding } = value as {
+	const { name, description, inputSchema, binding, menu } = value as {
 		name?: unknown;
 		description?: unknown;
 		inputSchema?: unknown;
 		binding?: unknown;
+		menu?: unknown;
 	};
 	if (typeof name !== "string" || name.trim() === "" || typeof description !== "string") {
 		return null;
@@ -656,11 +678,37 @@ function toPlatformToolEntry(value: unknown): PlatformToolManifestEntry | null {
 	const inputSchemaOut = (
 		schema.properties === undefined ? { ...schema, properties: {} } : schema
 	) as PlatformToolManifestEntry["inputSchema"];
+	const normalizedMenu = toPlatformMenuEntry(menu);
 	return {
 		name,
 		description,
 		inputSchema: inputSchemaOut,
 		...(normalizedBinding ? { binding: normalizedBinding } : {}),
+		...(normalizedMenu ? { menu: normalizedMenu } : {}),
+	};
+}
+
+/**
+ * Normalizes an optional `menu` block, degrading at field granularity so a bad
+ * block never drops the parent tool. A missing/non-object `menu`, or one without a
+ * non-empty string `label`, yields `undefined` (the tool is simply absent from the
+ * menu). A valid `label` with a malformed `description` / `order` keeps the label
+ * and drops only the offending field.
+ */
+function toPlatformMenuEntry(value: unknown): PlatformToolMenuEntry | undefined {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		return undefined;
+	}
+	const { label, description, order } = value as { label?: unknown; description?: unknown; order?: unknown };
+	if (typeof label !== "string" || label.trim() === "") {
+		return undefined;
+	}
+	const validDescription = typeof description === "string" ? description : undefined;
+	const validOrder = typeof order === "number" && Number.isFinite(order) ? order : undefined;
+	return {
+		label,
+		...(validDescription !== undefined ? { description: validDescription } : {}),
+		...(validOrder !== undefined ? { order: validOrder } : {}),
 	};
 }
 

--- a/cli/src/install/SkillInstaller.test.ts
+++ b/cli/src/install/SkillInstaller.test.ts
@@ -57,17 +57,24 @@ function readPr(target: "claude" | "agents" = "claude"): string {
 	return readFileSync(join(tempDir, dir, "SKILL.md"), "utf-8");
 }
 
+function readJolli(target: "claude" | "agents" = "claude"): string {
+	const dir = target === "claude" ? ".claude/skills/jolli" : ".agents/skills/jolli";
+	return readFileSync(join(tempDir, dir, "SKILL.md"), "utf-8");
+}
+
 // ─── Dual-target write ──────────────────────────────────────────────────────
 
 describe("updateSkillsIfNeeded — target dimension", () => {
-	it("writes all three skills into both .claude/skills/ and .agents/skills/", async () => {
+	it("writes all four skills into both .claude/skills/ and .agents/skills/", async () => {
 		await updateSkillsIfNeeded(tempDir);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli-pr/SKILL.md"))).toBe(true);
+		expect(existsSync(join(tempDir, ".claude/skills/jolli/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-recall/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-search/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-pr/SKILL.md"))).toBe(true);
+		expect(existsSync(join(tempDir, ".agents/skills/jolli/SKILL.md"))).toBe(true);
 	});
 
 	it("writes byte-identical SKILL.md to .claude/skills/ and .agents/skills/", async () => {
@@ -75,6 +82,7 @@ describe("updateSkillsIfNeeded — target dimension", () => {
 		expect(readRecall("claude")).toBe(readRecall("agents"));
 		expect(readSearch("claude")).toBe(readSearch("agents"));
 		expect(readPr("claude")).toBe(readPr("agents"));
+		expect(readJolli("claude")).toBe(readJolli("agents"));
 	});
 
 	it("with claudeEnabled=false, skips .claude/skills/ but still writes .agents/skills/", async () => {
@@ -82,9 +90,11 @@ describe("updateSkillsIfNeeded — target dimension", () => {
 		expect(existsSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"))).toBe(false);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"))).toBe(false);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli-pr/SKILL.md"))).toBe(false);
+		expect(existsSync(join(tempDir, ".claude/skills/jolli/SKILL.md"))).toBe(false);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-recall/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-search/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-pr/SKILL.md"))).toBe(true);
+		expect(existsSync(join(tempDir, ".agents/skills/jolli/SKILL.md"))).toBe(true);
 	});
 
 	it("with claudeEnabled=undefined (default), writes both targets for all skills", async () => {
@@ -95,14 +105,16 @@ describe("updateSkillsIfNeeded — target dimension", () => {
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-pr/SKILL.md"))).toBe(true);
 	});
 
-	it("exports the 6 git-exclude paths for the three skills × two targets", () => {
+	it("exports the 8 git-exclude paths for the four skills × two targets", () => {
 		expect(SKILL_GIT_EXCLUDE_PATHS).toEqual([
 			"/.claude/skills/jolli-recall/",
 			"/.claude/skills/jolli-search/",
 			"/.claude/skills/jolli-pr/",
+			"/.claude/skills/jolli/",
 			"/.agents/skills/jolli-recall/",
 			"/.agents/skills/jolli-search/",
 			"/.agents/skills/jolli-pr/",
+			"/.agents/skills/jolli/",
 		]);
 	});
 });
@@ -173,6 +185,36 @@ describe("pr template frontmatter", () => {
 		expect(pr).not.toMatch(/^argument-hint:/m);
 		expect(pr).not.toMatch(/^user-invocable:/m);
 		expect(pr).not.toMatch(/^disable-model-invocation:/m);
+	});
+});
+
+describe("jolli menu template frontmatter", () => {
+	it("uses spec-compliant fields only — name, description, metadata.version, metadata.vendor", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const jolli = readJolli();
+		expect(jolli).toMatch(/^---\nname: jolli\n/);
+		expect(jolli).toMatch(/description: The Jolli action menu/);
+		expect(jolli).toMatch(/metadata:\n {2}version: "[^"]+"\n {2}vendor: "jolli\.ai"/);
+	});
+
+	it("does NOT contain Claude-private top-level frontmatter fields", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const jolli = readJolli();
+		expect(jolli).not.toMatch(/^argument-hint:/m);
+		expect(jolli).not.toMatch(/^user-invocable:/m);
+		expect(jolli).not.toMatch(/^disable-model-invocation:/m);
+	});
+
+	it("routes to the sibling skills and the Jolli MCP tools without re-deriving backend curation", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const jolli = readJolli();
+		// Static local-skill menu entries.
+		expect(jolli).toMatch(/jolli-recall/);
+		expect(jolli).toMatch(/jolli-search/);
+		expect(jolli).toMatch(/jolli-pr/);
+		// Surfaces session-registered MCP tools, not a hardcoded manifest fetch.
+		expect(jolli).toMatch(/mcp__jollimemory__/);
+		expect(jolli).toMatch(/AskUserQuestion/);
 	});
 });
 

--- a/cli/src/install/SkillInstaller.ts
+++ b/cli/src/install/SkillInstaller.ts
@@ -102,11 +102,12 @@ const SKILLS: ReadonlyArray<SkillRegistration> = [
 	{ name: "jolli-recall", build: buildRecallSkillTemplate },
 	{ name: "jolli-search", build: buildSearchSkillTemplate },
 	{ name: "jolli-pr", build: buildPrSkillTemplate },
+	{ name: "jolli", build: buildJolliMenuSkillTemplate },
 ];
 
 /**
  * Skill paths recorded in `.git/info/exclude` so they don't pollute
- * `git status` in user repositories. Always 6 entries: 3 skills × 2 targets.
+ * `git status` in user repositories. Always 8 entries: 4 skills × 2 targets.
  * Path format follows git's gitignore syntax — leading `/` anchors to the
  * repo root, trailing `/` matches the directory and its contents.
  */
@@ -930,5 +931,90 @@ hit you have:
 
 **Empty hits** → tell the user nothing matched; suggest broader keywords or a
 different phrasing. Do NOT mention BM25 or index internals.
+`;
+}
+
+/**
+ * The `jolli` umbrella-menu skill — surfaces as a bare `/jolli` and acts as the
+ * single friendly front door over the sibling Jolli skills plus whatever
+ * `mcp__jollimemory__*` tools are registered in the session. It only steers the
+ * agent to invoke an already-existing skill or tool; it is never a second
+ * execution path for any action, and it does NOT re-derive the backend's curated
+ * `menu` metadata (a static SKILL.md cannot fetch the manifest — curation of which
+ * platform tools belong in the menu stays authoritative in the server-side MCP
+ * `jolli` prompt). Byte-identical across every {@link SKILL_TARGETS} entry, with
+ * spec-compliant frontmatter only.
+ *
+ * The menu-interaction contract mirrors the MCP `jolli` prompt (see
+ * `cli/src/mcp/JolliMenu.ts`): argument provided → match to one action and invoke
+ * it directly, asking only when ambiguous or unmatched; argument absent → present
+ * the menu via an interactive single-select tool where the host provides one (e.g.
+ * Claude Code's AskUserQuestion), otherwise a plain-text list, then invoke the
+ * chosen action. Host-agnostic by design — the AskUserQuestion mention is only an
+ * example and the text-list fallback keeps `/jolli` usable on every host.
+ */
+export function buildJolliMenuSkillTemplate(): string {
+	return `---
+name: jolli
+description: The Jolli action menu — a single front door that lists the Jolli skills (recall, search, pr) plus the Jolli MCP tools registered in this session, then routes your choice to the right one. Use when the user types /jolli or asks for the Jolli menu.
+metadata:
+  version: "${SKILL_VERSION}"
+  vendor: "jolli.ai"
+---
+
+# Jolli
+
+The single umbrella action menu for Jolli. It ties together the standalone Jolli
+skills and whatever Jolli MCP tools are registered in this session, and routes the
+user's choice to the right one. It is a friendly front door — it **never**
+re-implements any action, it only invokes an existing skill or an existing MCP
+tool. The standalone \`/jolli-recall\`, \`/jolli-search\`, \`/jolli-pr\` commands and
+the \`/mcp__jollimemory__jolli\` prompt all keep working unchanged; this is layered
+on top of them, not a replacement.
+
+## Step 1 — build the unified menu
+
+Assemble ONE combined list of actions from two sources.
+
+### Local Jolli skills (always present)
+
+- **jolli-recall** — Recall prior development context for the current branch.
+  Route by invoking the \`jolli-recall\` skill.
+- **jolli-search** — Search structured commit memories across branches
+  (decisions, topics, files). Route by invoking the \`jolli-search\` skill.
+- **jolli-pr** — Create or update a pull request using a Jolli Memory-generated
+  description. Route by invoking the \`jolli-pr\` skill.
+
+Route a local choice by invoking that skill through your host's skill-invocation
+mechanism (for example, the Skill tool in Claude Code).
+
+### Jolli MCP tools (whatever is registered this session)
+
+Surface every tool whose name starts with \`mcp__jollimemory__\` that is available
+in the current session — for example \`recall\`, \`search\`, \`get_pr_description\`,
+\`queue_status\`, and any manifest-driven platform tools (workflow, space, article,
+and the like). Route a choice by calling the matching \`mcp__jollimemory__*\` tool.
+
+Do NOT assume a fixed list — enumerate the Jolli MCP tools that are actually
+registered right now. Do NOT try to fetch or re-derive any backend "menu"
+curation; a skill cannot read the manifest, so simply surface the Jolli MCP tools
+present in the session. If no Jolli MCP tools are registered, present just the
+local skills above.
+
+## Step 2 — route the request
+
+This skill takes one optional free-text argument.
+
+- **Argument provided** → match it to exactly one menu action and invoke that
+  action directly (invoke the skill, or call the MCP tool). Only ask the user to
+  choose if the request is ambiguous or matches no menu action.
+- **Argument absent** → present the unified menu and let the user pick one, using
+  an interactive single-select tool if your host provides one (for example
+  AskUserQuestion in Claude Code); otherwise list the options as plain text and
+  ask the user to choose. After the user selects, invoke the corresponding skill
+  or MCP tool.
+
+Host-agnostic by design: the AskUserQuestion mention is only an example; the
+text-list fallback keeps \`/jolli\` usable on every host that loads skills.
 `;
 }

--- a/cli/src/mcp/JolliMenu.test.ts
+++ b/cli/src/mcp/JolliMenu.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import type { PlatformToolManifestEntry } from "../core/JolliMemoryPushClient.js";
+import {
+	type BuiltInToolInfo,
+	buildJolliMenu,
+	buildJolliPromptText,
+	JOLLI_PROMPT_ARGUMENT,
+	JOLLI_PROMPT_NAME,
+	LOCAL_MENU_TOOL_NAMES,
+} from "./JolliMenu.js";
+
+function platformTool(overrides: Partial<PlatformToolManifestEntry> & { name: string }): PlatformToolManifestEntry {
+	return {
+		description: `desc for ${overrides.name}`,
+		inputSchema: { type: "object", properties: {} },
+		...overrides,
+	};
+}
+
+const BUILT_INS: BuiltInToolInfo[] = [
+	{ name: "search", description: "Search memories" },
+	{ name: "recall", description: "Recall branch context" },
+];
+
+describe("JolliMenu constants", () => {
+	it("names the prompt and its single argument", () => {
+		expect(JOLLI_PROMPT_NAME).toBe("jolli");
+		expect(JOLLI_PROMPT_ARGUMENT).toBe("request");
+	});
+
+	it("ships an empty local inclusion list", () => {
+		expect(LOCAL_MENU_TOOL_NAMES).toEqual([]);
+	});
+});
+
+describe("buildJolliMenu", () => {
+	it("includes only menu-flagged platform tools", () => {
+		const menu = buildJolliMenu(
+			[
+				platformTool({ name: "create_ticket", menu: { label: "Create ticket" } }),
+				platformTool({ name: "unflagged" }),
+			],
+			BUILT_INS,
+		);
+		expect(menu).toEqual([
+			{ toolName: "create_ticket", label: "Create ticket", description: "desc for create_ticket" },
+		]);
+	});
+
+	it("prefers the menu description over the tool description when provided", () => {
+		const menu = buildJolliMenu(
+			[
+				platformTool({
+					name: "create_ticket",
+					menu: { label: "Create ticket", description: "Open a new ticket" },
+				}),
+			],
+			BUILT_INS,
+		);
+		expect(menu[0]).toMatchObject({ description: "Open a new ticket" });
+	});
+
+	it("resolves local tool names against the built-in registry", () => {
+		const menu = buildJolliMenu([], BUILT_INS, ["recall"]);
+		expect(menu).toEqual([{ toolName: "recall", label: "recall", description: "Recall branch context" }]);
+	});
+
+	it("skips local names that do not match a built-in tool", () => {
+		const menu = buildJolliMenu([], BUILT_INS, ["does_not_exist"]);
+		expect(menu).toEqual([]);
+	});
+
+	it("defaults to the empty local inclusion list", () => {
+		const menu = buildJolliMenu([platformTool({ name: "a", menu: { label: "A" } })], BUILT_INS);
+		expect(menu.map((m) => m.toolName)).toEqual(["a"]);
+	});
+
+	it("sorts by order ascending, then label, then tool name", () => {
+		const menu = buildJolliMenu(
+			[
+				platformTool({ name: "third", menu: { label: "Zeta" } }), // no order → last
+				platformTool({ name: "first", menu: { label: "Alpha", order: 1 } }),
+				platformTool({ name: "second", menu: { label: "Beta", order: 2 } }),
+				platformTool({ name: "second_tie", menu: { label: "Beta", order: 2 } }),
+			],
+			BUILT_INS,
+		);
+		expect(menu.map((m) => m.toolName)).toEqual(["first", "second", "second_tie", "third"]);
+	});
+
+	it("combines platform and local items", () => {
+		const menu = buildJolliMenu(
+			[platformTool({ name: "create_ticket", menu: { label: "Create ticket" } })],
+			BUILT_INS,
+			["search"],
+		);
+		expect(menu.map((m) => m.toolName).sort()).toEqual(["create_ticket", "search"]);
+	});
+});
+
+describe("buildJolliPromptText", () => {
+	const menu = buildJolliMenu(
+		[
+			platformTool({ name: "create_ticket", menu: { label: "Create ticket", description: "Open a ticket" } }),
+			platformTool({ name: "plain", menu: { label: "Plain" }, description: "" }),
+		],
+		BUILT_INS,
+	);
+
+	it("renders each item with label, description, and the tool to call", () => {
+		const text = buildJolliPromptText(menu);
+		expect(text).toContain("- Create ticket — Open a ticket (call tool `create_ticket`)");
+		// An item with no description omits the em-dash clause.
+		expect(text).toContain("- Plain (call tool `plain`)");
+	});
+
+	it("with a request: instructs the agent to match and invoke directly", () => {
+		const text = buildJolliPromptText(menu, "  make me a ticket  ");
+		expect(text).toContain('with this request: "make me a ticket"');
+		expect(text).toContain("invoke its MCP tool directly");
+		expect(text).not.toContain("without a specific request");
+	});
+
+	it("without a request: instructs the agent to present a picker with a text fallback", () => {
+		const text = buildJolliPromptText(menu);
+		expect(text).toContain("without a specific request");
+		expect(text).toContain("AskUserQuestion");
+		expect(text).toContain("plain text");
+	});
+
+	it("treats a blank/whitespace request as absent", () => {
+		expect(buildJolliPromptText(menu, "   ")).toContain("without a specific request");
+	});
+});

--- a/cli/src/mcp/JolliMenu.ts
+++ b/cli/src/mcp/JolliMenu.ts
@@ -1,0 +1,128 @@
+/**
+ * The curated `/jolli` menu (JOLLI-1925).
+ *
+ * The host `jolli mcp` server registers a single MCP prompt, `jolli` (surfaced in
+ * Claude Code as `/mcp__jollimemory__jolli`), that presents a curated menu of
+ * actions and steers the agent to invoke the corresponding — already registered —
+ * MCP tool. The menu is the union of:
+ *   - backend manifest platform tools flagged with a `menu` block, and
+ *   - a CLI-side inclusion list of built-in tool names (`LOCAL_MENU_TOOL_NAMES`).
+ *
+ * The prompt only steers; every menu item is an already-registered tool, so the
+ * prompt is never a second execution path. When the menu is empty the server does
+ * not register the prompt at all (see `startMcpServer`), so this module is inert
+ * until the backend flags a tool or a local tool is added to the list.
+ */
+
+import type { PlatformToolManifestEntry } from "../core/JolliMemoryPushClient.js";
+
+/** The MCP prompt name and its single optional free-text argument. */
+export const JOLLI_PROMPT_NAME = "jolli";
+export const JOLLI_PROMPT_ARGUMENT = "request";
+
+/**
+ * Built-in (local) tool names to surface in the `/jolli` menu. Intentionally EMPTY
+ * for now — an extension point for later. A name here must match a built-in tool in
+ * `TOOL_DEFINITIONS`; unknown names are ignored by `buildJolliMenu`.
+ */
+export const LOCAL_MENU_TOOL_NAMES: readonly string[] = [];
+
+/** One resolved menu entry: which tool to call and how to present it. */
+export interface JolliMenuItem {
+	readonly toolName: string;
+	readonly label: string;
+	readonly description?: string;
+	readonly order?: number;
+}
+
+/** Minimal built-in tool shape needed to resolve a local menu entry. */
+export interface BuiltInToolInfo {
+	readonly name: string;
+	readonly description: string;
+}
+
+/**
+ * Builds the curated menu from the menu-flagged platform tools and the local
+ * inclusion list. Platform items take their label/order from the manifest `menu`
+ * block and fall back to the tool's own description when the menu block omits one.
+ * Local items resolve their description from the built-in registry; a local name
+ * with no matching built-in is skipped. The two groups never overlap (surviving
+ * platform tools can never share a name with a built-in), so no dedupe is needed.
+ * The result is sorted by `order` ascending (unordered items last), then by label,
+ * then by tool name for a stable order.
+ */
+export function buildJolliMenu(
+	platformTools: readonly PlatformToolManifestEntry[],
+	builtIns: readonly BuiltInToolInfo[],
+	localNames: readonly string[] = LOCAL_MENU_TOOL_NAMES,
+): JolliMenuItem[] {
+	const items: JolliMenuItem[] = [];
+	for (const tool of platformTools) {
+		if (tool.menu) {
+			items.push({
+				toolName: tool.name,
+				label: tool.menu.label,
+				description: tool.menu.description ?? tool.description,
+				...(tool.menu.order !== undefined ? { order: tool.menu.order } : {}),
+			});
+		}
+	}
+	const builtInByName = new Map(builtIns.map((t) => [t.name, t] as const));
+	for (const name of localNames) {
+		const info = builtInByName.get(name);
+		if (info) {
+			items.push({ toolName: info.name, label: info.name, description: info.description });
+		}
+	}
+	return sortMenu(items);
+}
+
+function sortMenu(items: JolliMenuItem[]): JolliMenuItem[] {
+	return [...items].sort((a, b) => {
+		const ao = a.order ?? Number.POSITIVE_INFINITY;
+		const bo = b.order ?? Number.POSITIVE_INFINITY;
+		if (ao !== bo) {
+			return ao - bo;
+		}
+		const byLabel = a.label.localeCompare(b.label);
+		return byLabel !== 0 ? byLabel : a.toolName.localeCompare(b.toolName);
+	});
+}
+
+/**
+ * Builds the steering message the `jolli` prompt returns. MCP prompts return
+ * messages, not a native picker, so this text tells the agent how to render the
+ * menu and which tool each choice maps to:
+ *   - `request` provided → match it to one menu item and invoke that tool directly,
+ *     asking only if the intent is ambiguous or matches nothing;
+ *   - `request` absent → present the menu via an interactive single-select tool
+ *     where the host provides one (e.g. Claude Code's `AskUserQuestion`), otherwise
+ *     enumerate the options as text, then invoke the chosen tool.
+ * Host-agnostic by design: the `AskUserQuestion` mention is only an example and the
+ * text-list fallback keeps the prompt usable in any MCP host.
+ */
+export function buildJolliPromptText(menu: readonly JolliMenuItem[], request?: string): string {
+	const lines = menu.map((item) => {
+		const desc = item.description ? ` — ${item.description}` : "";
+		return `- ${item.label}${desc} (call tool \`${item.toolName}\`)`;
+	});
+	const trimmed = request?.trim();
+	if (trimmed) {
+		return [
+			`The user opened the Jolli action menu with this request: "${trimmed}".`,
+			"Match the request to exactly one menu item below and invoke its MCP tool directly.",
+			"Only ask the user to choose if the request is ambiguous or matches no menu item.",
+			"",
+			"Menu:",
+			...lines,
+		].join("\n");
+	}
+	return [
+		"The user opened the Jolli action menu without a specific request.",
+		"Present these options and let the user pick one, using an interactive single-select tool if your host provides one (for example AskUserQuestion in Claude Code); otherwise list them as plain text and ask the user to choose.",
+		"After the user selects an option, invoke the corresponding MCP tool.",
+		"",
+		"Menu:",
+		...lines,
+	].join("\n");
+}

--- a/cli/src/mcp/McpServer.test.ts
+++ b/cli/src/mcp/McpServer.test.ts
@@ -45,10 +45,33 @@ vi.mock("@modelcontextprotocol/sdk/types.js", () => ({
 	CallToolRequestSchema: { kind: "call" },
 }));
 
+// Gate the platform-tool path deterministically: default to "disabled" so the
+// pre-existing tests exercise the dormant (git-memory-only) path without reading
+// a real config off disk. Preserve every other SessionTracker export.
+const { loadConfigMock } = vi.hoisted(() => ({ loadConfigMock: vi.fn() }));
+vi.mock("../core/SessionTracker.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../core/SessionTracker.js")>();
+	return { ...actual, loadConfig: loadConfigMock };
+});
+
+// Stub the backend client so the default `new JolliMemoryPushClient()` factory
+// used when no createPlatformClient dep is supplied never opens a real socket.
+const { fetchManifestMock, invokePlatformToolMock } = vi.hoisted(() => ({
+	fetchManifestMock: vi.fn(),
+	invokePlatformToolMock: vi.fn(),
+}));
+vi.mock("../core/JolliMemoryPushClient.js", () => ({
+	JolliMemoryPushClient: class {
+		fetchManifest = fetchManifestMock;
+		invokePlatformTool = invokePlatformToolMock;
+	},
+}));
+
 import { VERSION } from "../commands/CliUtils.js";
+import type { PlatformToolManifestEntry } from "../core/JolliMemoryPushClient.js";
 import { createStorage } from "../core/StorageFactory.js";
 import { setActiveStorage } from "../core/SummaryStore.js";
-import { dispatchTool, startMcpServer, TOOL_DEFINITIONS } from "./McpServer.js";
+import { dispatchTool, type PlatformToolClient, startMcpServer, TOOL_DEFINITIONS } from "./McpServer.js";
 import {
 	runBindSpace,
 	runDecisionTimeline,
@@ -146,6 +169,9 @@ describe("startMcpServer", () => {
 	beforeEach(() => {
 		capturedHandlers.length = 0;
 		connectMock.mockClear();
+		loadConfigMock.mockReset().mockResolvedValue({});
+		fetchManifestMock.mockReset();
+		invokePlatformToolMock.mockReset();
 	});
 
 	it("connects the stdio transport and registers two request handlers", async () => {
@@ -247,5 +273,160 @@ describe("startMcpServer", () => {
 	it("names the server with the package version, not a hardcoded string", async () => {
 		await startMcpServer("/repo");
 		expect(serverInfo).toMatchObject({ name: "jollimemory", version: VERSION });
+	});
+});
+
+describe("startMcpServer — platform tools", () => {
+	const platA: PlatformToolManifestEntry = {
+		name: "create_ticket",
+		description: "Create a ticket",
+		inputSchema: { type: "object", properties: {} },
+	};
+	const platB: PlatformToolManifestEntry = {
+		name: "list_projects",
+		description: "List projects",
+		inputSchema: { type: "object", properties: {} },
+	};
+
+	function stubClient(tools: PlatformToolManifestEntry[]): PlatformToolClient {
+		return { fetchManifest: async () => tools, invokePlatformTool: invokePlatformToolMock };
+	}
+
+	beforeEach(() => {
+		capturedHandlers.length = 0;
+		connectMock.mockClear();
+		loadConfigMock.mockReset().mockResolvedValue({});
+		fetchManifestMock.mockReset();
+		invokePlatformToolMock.mockReset();
+		vi.mocked(runSearch).mockClear();
+	});
+
+	it("dormant by default: advertises exactly 9 tools and never constructs a client", async () => {
+		const createPlatformClient = vi.fn();
+		await startMcpServer("/repo", { loadConfig: async () => ({}), createPlatformClient });
+		const list = (await capturedHandlers[0]({ params: { name: "" } })) as { tools: unknown[] };
+		expect(list.tools).toBe(TOOL_DEFINITIONS);
+		expect(list.tools).toHaveLength(9);
+		expect(createPlatformClient).not.toHaveBeenCalled();
+		// A built-in still dispatches through the local table.
+		await capturedHandlers[1]({ params: { name: "search", arguments: { query: "x" } } });
+		expect(runSearch).toHaveBeenCalledWith("/repo", { query: "x" });
+	});
+
+	it("enabled: advertises the built-ins plus the manifest's platform tools", async () => {
+		await startMcpServer("/repo", {
+			loadConfig: async () => ({ mcpPlatformToolsEnabled: true }),
+			createPlatformClient: () => stubClient([platA, platB]),
+		});
+		const list = (await capturedHandlers[0]({ params: { name: "" } })) as { tools: { name: string }[] };
+		expect(list.tools).toHaveLength(11);
+		expect(list.tools.map((t) => t.name)).toEqual(
+			expect.arrayContaining(["create_ticket", "list_projects", "search"]),
+		);
+	});
+
+	it("enabled: routes a platform tool call through the generic executor and wraps the result", async () => {
+		invokePlatformToolMock.mockResolvedValue({ ok: true });
+		await startMcpServer("/repo", {
+			loadConfig: async () => ({ mcpPlatformToolsEnabled: true }),
+			createPlatformClient: () => stubClient([platA]),
+		});
+		const result = (await capturedHandlers[1]({
+			params: { name: "create_ticket", arguments: { title: "x" } },
+		})) as { content: { text: string }[]; isError?: boolean };
+		expect(invokePlatformToolMock).toHaveBeenCalledWith(platA, { title: "x" });
+		expect(result.isError).toBeUndefined();
+		expect(JSON.parse(result.content[0].text)).toEqual({ ok: true });
+	});
+
+	it("enabled: flags a platform tool's {type:'error'} result as isError", async () => {
+		invokePlatformToolMock.mockResolvedValue({ type: "error", message: "bad args" });
+		await startMcpServer("/repo", {
+			loadConfig: async () => ({ mcpPlatformToolsEnabled: true }),
+			createPlatformClient: () => stubClient([platA]),
+		});
+		const result = (await capturedHandlers[1]({ params: { name: "create_ticket", arguments: {} } })) as {
+			content: { text: string }[];
+			isError?: boolean;
+		};
+		expect(result.isError).toBe(true);
+		expect(JSON.parse(result.content[0].text)).toEqual({ type: "error", message: "bad args" });
+	});
+
+	it("enabled: wraps a thrown platform tool error as an isError response", async () => {
+		invokePlatformToolMock.mockRejectedValue(new Error("relay failed"));
+		await startMcpServer("/repo", {
+			loadConfig: async () => ({ mcpPlatformToolsEnabled: true }),
+			createPlatformClient: () => stubClient([platA]),
+		});
+		const result = (await capturedHandlers[1]({ params: { name: "create_ticket", arguments: {} } })) as {
+			content: { text: string }[];
+			isError?: boolean;
+		};
+		expect(result.isError).toBe(true);
+		expect(JSON.parse(result.content[0].text)).toEqual({ error: "relay failed" });
+	});
+
+	it("enabled but empty/failed manifest: falls back to exactly the 9 built-ins and still connects", async () => {
+		await startMcpServer("/repo", {
+			loadConfig: async () => ({ mcpPlatformToolsEnabled: true }),
+			createPlatformClient: () => stubClient([]),
+		});
+		const list = (await capturedHandlers[0]({ params: { name: "" } })) as { tools: unknown[] };
+		expect(list.tools).toBe(TOOL_DEFINITIONS);
+		expect(list.tools).toHaveLength(9);
+		expect(connectMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("enabled: drops a platform tool that collides with a built-in name; the built-in stays reachable", async () => {
+		const collide: PlatformToolManifestEntry = {
+			name: "search",
+			description: "backend search",
+			inputSchema: { type: "object", properties: {} },
+		};
+		await startMcpServer("/repo", {
+			loadConfig: async () => ({ mcpPlatformToolsEnabled: true }),
+			createPlatformClient: () => stubClient([collide, platA]),
+		});
+		const list = (await capturedHandlers[0]({ params: { name: "" } })) as { tools: { name: string }[] };
+		expect(list.tools).toHaveLength(10);
+		expect(list.tools.filter((t) => t.name === "search")).toHaveLength(1);
+		// "search" hits the built-in handler, not the generic executor.
+		await capturedHandlers[1]({ params: { name: "search", arguments: { query: "x" } } });
+		expect(runSearch).toHaveBeenCalledWith("/repo", { query: "x" });
+		expect(invokePlatformToolMock).not.toHaveBeenCalled();
+	});
+
+	it("enabled: dedupes duplicate platform tool names (first wins in both list and dispatch)", async () => {
+		const first: PlatformToolManifestEntry = {
+			name: "create_ticket",
+			description: "first",
+			inputSchema: { type: "object", properties: {} },
+		};
+		const second: PlatformToolManifestEntry = {
+			name: "create_ticket",
+			description: "second (duplicate)",
+			inputSchema: { type: "object", properties: {} },
+		};
+		invokePlatformToolMock.mockResolvedValue({ ok: true });
+		await startMcpServer("/repo", {
+			loadConfig: async () => ({ mcpPlatformToolsEnabled: true }),
+			createPlatformClient: () => stubClient([first, second]),
+		});
+		const list = (await capturedHandlers[0]({ params: { name: "" } })) as { tools: { name: string }[] };
+		// Exactly one create_ticket advertised (9 built-ins + 1) — no duplicate in tools/list.
+		expect(list.tools).toHaveLength(10);
+		expect(list.tools.filter((t) => t.name === "create_ticket")).toHaveLength(1);
+		// tools/call runs the FIRST entry, matching what a client sees in tools/list.
+		await capturedHandlers[1]({ params: { name: "create_ticket", arguments: {} } });
+		expect(invokePlatformToolMock).toHaveBeenCalledWith(first, {});
+	});
+
+	it("enabled without a client dep: uses the default real-client factory to fetch the manifest", async () => {
+		fetchManifestMock.mockResolvedValue([platA]);
+		await startMcpServer("/repo", { loadConfig: async () => ({ mcpPlatformToolsEnabled: true }) });
+		const list = (await capturedHandlers[0]({ params: { name: "" } })) as { tools: unknown[] };
+		expect(fetchManifestMock).toHaveBeenCalled();
+		expect(list.tools).toHaveLength(10);
 	});
 });

--- a/cli/src/mcp/McpServer.test.ts
+++ b/cli/src/mcp/McpServer.test.ts
@@ -347,6 +347,35 @@ describe("startMcpServer — platform tools", () => {
 		);
 	});
 
+	it("enabled: advertises only the public schema — never the internal binding/menu metadata", async () => {
+		const withMeta: PlatformToolManifestEntry = {
+			name: "create_ticket",
+			description: "Create a ticket",
+			inputSchema: { type: "object", properties: {} },
+			binding: { method: "POST", path: "/api/mcp/tools/create_ticket" },
+			menu: { label: "Create ticket", description: "Open a new ticket", order: 1 },
+		};
+		invokePlatformToolMock.mockResolvedValue({ ok: true });
+		await startMcpServer("/repo", {
+			loadConfig: async () => ({ mcpPlatformToolsEnabled: true }),
+			createPlatformClient: () => stubClient([withMeta]),
+		});
+		const list = (await capturedHandlers[0]({ params: { name: "" } })) as {
+			tools: Record<string, unknown>[];
+		};
+		const advertised = list.tools.find((t) => t.name === "create_ticket");
+		expect(advertised).toEqual({
+			name: "create_ticket",
+			description: "Create a ticket",
+			inputSchema: { type: "object", properties: {} },
+		});
+		expect(advertised).not.toHaveProperty("binding");
+		expect(advertised).not.toHaveProperty("menu");
+		// Dispatch still uses the FULL entry (with binding) — routing is unaffected.
+		await capturedHandlers[1]({ params: { name: "create_ticket", arguments: { title: "x" } } });
+		expect(invokePlatformToolMock).toHaveBeenCalledWith(withMeta, { title: "x" });
+	});
+
 	it("enabled: routes a platform tool call through the generic executor and wraps the result", async () => {
 		invokePlatformToolMock.mockResolvedValue({ ok: true });
 		await startMcpServer("/repo", {

--- a/cli/src/mcp/McpServer.test.ts
+++ b/cli/src/mcp/McpServer.test.ts
@@ -19,16 +19,27 @@ vi.mock("../core/SummaryStore.js", () => ({ setActiveStorage: vi.fn() }));
 // Capture the request handlers the server registers so the test can invoke them directly.
 type RequestHandler = (req: { params: { name: string; arguments?: Record<string, unknown> } }) => Promise<unknown>;
 const capturedHandlers: RequestHandler[] = [];
+// Parallel to capturedHandlers: the (mocked) schema marker each handler was registered with.
+const capturedSchemas: Array<{ kind: string }> = [];
 const connectMock = vi.fn().mockResolvedValue(undefined);
-// Capture the Server constructor's first arg so the test can assert name/version.
+// Capture the Server constructor's args so the test can assert name/version + capabilities.
 let serverInfo: { name: string; version: string } | undefined;
+let serverCapabilities: { tools?: unknown; prompts?: unknown } | undefined;
+
+// Find the handler registered for a given schema marker kind (e.g. "listPrompts").
+function handlerForKind(kind: string): RequestHandler | undefined {
+	const idx = capturedSchemas.findIndex((s) => s?.kind === kind);
+	return idx >= 0 ? capturedHandlers[idx] : undefined;
+}
 
 vi.mock("@modelcontextprotocol/sdk/server/index.js", () => ({
 	Server: class {
-		constructor(info: { name: string; version: string }) {
+		constructor(info: { name: string; version: string }, options?: { capabilities?: typeof serverCapabilities }) {
 			serverInfo = info;
+			serverCapabilities = options?.capabilities;
 		}
-		setRequestHandler(_schema: unknown, handler: RequestHandler) {
+		setRequestHandler(schema: { kind: string }, handler: RequestHandler) {
+			capturedSchemas.push(schema);
 			capturedHandlers.push(handler);
 		}
 		connect = connectMock;
@@ -43,6 +54,8 @@ vi.mock("@modelcontextprotocol/sdk/server/stdio.js", () => ({
 vi.mock("@modelcontextprotocol/sdk/types.js", () => ({
 	ListToolsRequestSchema: { kind: "list" },
 	CallToolRequestSchema: { kind: "call" },
+	ListPromptsRequestSchema: { kind: "listPrompts" },
+	GetPromptRequestSchema: { kind: "getPrompt" },
 }));
 
 // Gate the platform-tool path deterministically: default to "disabled" so the
@@ -168,6 +181,8 @@ describe("dispatchTool", () => {
 describe("startMcpServer", () => {
 	beforeEach(() => {
 		capturedHandlers.length = 0;
+		capturedSchemas.length = 0;
+		serverCapabilities = undefined;
 		connectMock.mockClear();
 		loadConfigMock.mockReset().mockResolvedValue({});
 		fetchManifestMock.mockReset();
@@ -178,6 +193,11 @@ describe("startMcpServer", () => {
 		await startMcpServer("/repo");
 		expect(connectMock).toHaveBeenCalledTimes(1);
 		expect(capturedHandlers).toHaveLength(2);
+	});
+
+	it("advertises the tools capability only when no menu is active", async () => {
+		await startMcpServer("/repo");
+		expect(serverCapabilities).toEqual({ tools: {} });
 	});
 
 	it("ListTools handler returns the tool definitions", async () => {
@@ -294,6 +314,8 @@ describe("startMcpServer — platform tools", () => {
 
 	beforeEach(() => {
 		capturedHandlers.length = 0;
+		capturedSchemas.length = 0;
+		serverCapabilities = undefined;
 		connectMock.mockClear();
 		loadConfigMock.mockReset().mockResolvedValue({});
 		fetchManifestMock.mockReset();
@@ -337,6 +359,16 @@ describe("startMcpServer — platform tools", () => {
 		expect(invokePlatformToolMock).toHaveBeenCalledWith(platA, { title: "x" });
 		expect(result.isError).toBeUndefined();
 		expect(JSON.parse(result.content[0].text)).toEqual({ ok: true });
+	});
+
+	it("enabled: a platform tool call with no arguments defaults to {}", async () => {
+		invokePlatformToolMock.mockResolvedValue({ ok: true });
+		await startMcpServer("/repo", {
+			loadConfig: async () => ({ mcpPlatformToolsEnabled: true }),
+			createPlatformClient: () => stubClient([platA]),
+		});
+		await capturedHandlers[1]({ params: { name: "create_ticket" } });
+		expect(invokePlatformToolMock).toHaveBeenCalledWith(platA, {});
 	});
 
 	it("enabled: flags a platform tool's {type:'error'} result as isError", async () => {
@@ -428,5 +460,85 @@ describe("startMcpServer — platform tools", () => {
 		const list = (await capturedHandlers[0]({ params: { name: "" } })) as { tools: unknown[] };
 		expect(fetchManifestMock).toHaveBeenCalled();
 		expect(list.tools).toHaveLength(10);
+	});
+
+	// --- /jolli menu prompt (JOLLI-1925) ---
+
+	const platMenu: PlatformToolManifestEntry = {
+		name: "create_ticket",
+		description: "Create a ticket",
+		inputSchema: { type: "object", properties: {} },
+		menu: { label: "Create ticket", description: "Open a new ticket" },
+	};
+
+	it("enabled + a menu-flagged tool: advertises the prompts capability and lists exactly [jolli]", async () => {
+		await startMcpServer("/repo", {
+			loadConfig: async () => ({ mcpPlatformToolsEnabled: true }),
+			createPlatformClient: () => stubClient([platMenu, platB]),
+		});
+		expect(serverCapabilities).toEqual({ tools: {}, prompts: {} });
+		const listPrompts = handlerForKind("listPrompts");
+		expect(listPrompts).toBeDefined();
+		const result = (await listPrompts?.({ params: { name: "" } })) as {
+			prompts: { name: string; arguments: { name: string; required?: boolean }[] }[];
+		};
+		expect(result.prompts).toHaveLength(1);
+		expect(result.prompts[0].name).toBe("jolli");
+		expect(result.prompts[0].arguments).toEqual([expect.objectContaining({ name: "request", required: false })]);
+	});
+
+	it("GetPrompt with no request: returns a picker steering message listing the menu", async () => {
+		await startMcpServer("/repo", {
+			loadConfig: async () => ({ mcpPlatformToolsEnabled: true }),
+			createPlatformClient: () => stubClient([platMenu]),
+		});
+		const getPrompt = handlerForKind("getPrompt");
+		const result = (await getPrompt?.({ params: { name: "jolli" } })) as {
+			messages: { role: string; content: { type: string; text: string } }[];
+		};
+		const text = result.messages[0].content.text;
+		expect(result.messages[0].role).toBe("user");
+		expect(text).toContain("without a specific request");
+		expect(text).toContain("Create ticket — Open a new ticket (call tool `create_ticket`)");
+	});
+
+	it("GetPrompt with a request: returns a direct-invoke steering message", async () => {
+		await startMcpServer("/repo", {
+			loadConfig: async () => ({ mcpPlatformToolsEnabled: true }),
+			createPlatformClient: () => stubClient([platMenu]),
+		});
+		const getPrompt = handlerForKind("getPrompt");
+		const result = (await getPrompt?.({
+			params: { name: "jolli", arguments: { request: "make a ticket" } },
+		})) as { messages: { content: { text: string } }[] };
+		expect(result.messages[0].content.text).toContain('with this request: "make a ticket"');
+		expect(result.messages[0].content.text).toContain("invoke its MCP tool directly");
+	});
+
+	it("GetPrompt rejects an unknown prompt name", async () => {
+		await startMcpServer("/repo", {
+			loadConfig: async () => ({ mcpPlatformToolsEnabled: true }),
+			createPlatformClient: () => stubClient([platMenu]),
+		});
+		const getPrompt = handlerForKind("getPrompt");
+		await expect(getPrompt?.({ params: { name: "nope" } })).rejects.toThrow(/unknown prompt/i);
+	});
+
+	it("enabled but no menu-flagged tools: no prompts capability and no prompt handlers", async () => {
+		await startMcpServer("/repo", {
+			loadConfig: async () => ({ mcpPlatformToolsEnabled: true }),
+			createPlatformClient: () => stubClient([platA, platB]),
+		});
+		expect(serverCapabilities).toEqual({ tools: {} });
+		expect(handlerForKind("listPrompts")).toBeUndefined();
+		expect(handlerForKind("getPrompt")).toBeUndefined();
+		expect(capturedHandlers).toHaveLength(2);
+	});
+
+	it("gate off: no prompts capability even if a manifest tool would be menu-flagged", async () => {
+		const createPlatformClient = vi.fn();
+		await startMcpServer("/repo", { loadConfig: async () => ({}), createPlatformClient });
+		expect(serverCapabilities).toEqual({ tools: {} });
+		expect(handlerForKind("getPrompt")).toBeUndefined();
 	});
 });

--- a/cli/src/mcp/McpServer.ts
+++ b/cli/src/mcp/McpServer.ts
@@ -254,9 +254,18 @@ export async function startMcpServer(cwd: string, deps: StartMcpServerDeps = {})
 	const platformByName = new Map(platformTools.map((t) => [t.name, t] as const));
 	// Advertise the built-ins plus any platform tools. Build the list locally and
 	// leave the static built-in registry untouched; with no platform tools the
-	// static array is returned directly.
+	// static array is returned directly. Project each platform tool down to the
+	// public tool schema (name / description / inputSchema): a manifest entry also
+	// carries `binding` (backend routing) and `menu` (curation) metadata that are
+	// internal-only and must never reach a client's `tools/list`. Dispatch still
+	// uses the full entries via `platformByName`, so routing is unaffected.
+	const advertisedPlatformTools: ToolDefinition[] = platformTools.map(({ name, description, inputSchema }) => ({
+		name,
+		description,
+		inputSchema,
+	}));
 	const toolDefinitions: ToolDefinition[] =
-		platformTools.length > 0 ? [...TOOL_DEFINITIONS, ...platformTools] : TOOL_DEFINITIONS;
+		advertisedPlatformTools.length > 0 ? [...TOOL_DEFINITIONS, ...advertisedPlatformTools] : TOOL_DEFINITIONS;
 
 	// Advertise the `prompts` capability only when the menu is non-empty. With an
 	// empty menu (gate off, empty manifest, or no menu-flagged tools) the server is

--- a/cli/src/mcp/McpServer.ts
+++ b/cli/src/mcp/McpServer.ts
@@ -8,9 +8,12 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { VERSION } from "../commands/CliUtils.js";
+import { JolliMemoryPushClient, type PlatformToolManifestEntry } from "../core/JolliMemoryPushClient.js";
+import { loadConfig } from "../core/SessionTracker.js";
 import { createStorage } from "../core/StorageFactory.js";
 import { setActiveStorage } from "../core/SummaryStore.js";
 import { createLogger } from "../Logger.js";
+import type { JolliMemoryConfig } from "../Types.js";
 import {
 	runBindSpace,
 	runDecisionTimeline,
@@ -22,6 +25,7 @@ import {
 	runRecall,
 	runSearch,
 } from "./McpTools.js";
+import { isPlatformToolsEnabled } from "./PlatformTools.js";
 
 const log = createLogger("McpServer");
 
@@ -173,25 +177,85 @@ export async function dispatchTool(cwd: string, name: string, args: Record<strin
 	}
 }
 
+/**
+ * The slice of the backend client the platform-tool path uses. Declared as an
+ * interface so tests can inject a fake without constructing a live HTTP client.
+ */
+export interface PlatformToolClient {
+	fetchManifest(): Promise<PlatformToolManifestEntry[]>;
+	invokePlatformTool(tool: PlatformToolManifestEntry, args: Record<string, unknown>): Promise<unknown>;
+}
+
+/** Injectable dependencies for {@link startMcpServer}; the defaults wire the real implementations. */
+export interface StartMcpServerDeps {
+	/** Loads the config that gates platform-tool registration. Defaults to the machine-global config loader. */
+	readonly loadConfig?: () => Promise<Pick<JolliMemoryConfig, "mcpPlatformToolsEnabled">>;
+	/** Builds the backend client that fetches the manifest and relays tool calls. Defaults to a real client. */
+	readonly createPlatformClient?: () => PlatformToolClient;
+}
+
 /** Start the stdio MCP server. Resolves when the transport closes. */
-export async function startMcpServer(cwd: string): Promise<void> {
+export async function startMcpServer(cwd: string, deps: StartMcpServerDeps = {}): Promise<void> {
 	// Establish the configured storage backend up front. The tool handlers read
 	// through the store APIs without threading `storage`, so without this they'd
 	// fall through resolveStorage to the orphan branch — wrong for folder-mode
 	// users and a per-read WARN in this long-lived process.
 	setActiveStorage(await createStorage(cwd, cwd));
 
+	// Optionally register the backend-defined platform tools alongside the
+	// built-in git-memory tools. Opt-in and off by default: when the gate is
+	// closed we never construct a client or touch the network, so the server
+	// behaves exactly as a git-memory-only server.
+	const config = await (deps.loadConfig ?? loadConfig)();
+	let platformClient: PlatformToolClient | undefined;
+	let platformTools: PlatformToolManifestEntry[] = [];
+	if (isPlatformToolsEnabled(config)) {
+		platformClient = (deps.createPlatformClient ?? (() => new JolliMemoryPushClient()))();
+		const builtInNames = new Set(TOOL_DEFINITIONS.map((t) => t.name));
+		const seenNames = new Set<string>();
+		platformTools = (await platformClient.fetchManifest()).filter((tool) => {
+			if (builtInNames.has(tool.name)) {
+				// A built-in tool always wins a name collision: drop the backend tool
+				// so the built-in handler stays reachable and its wire contract is
+				// never shadowed by a same-named backend tool.
+				log.warn("Ignoring platform tool whose name collides with a built-in tool: %s", tool.name);
+				return false;
+			}
+			if (seenNames.has(tool.name)) {
+				// Keep only the first entry per name so the advertised list and the
+				// dispatch map agree — otherwise `tools/list` would show a duplicate a
+				// client could select while `tools/call` always ran a different one.
+				log.warn("Ignoring duplicate platform tool name from the manifest: %s", tool.name);
+				return false;
+			}
+			seenNames.add(tool.name);
+			return true;
+		});
+	}
+	const platformByName = new Map(platformTools.map((t) => [t.name, t] as const));
+	// Advertise the built-ins plus any platform tools. Build the list locally and
+	// leave the static built-in registry untouched; with no platform tools the
+	// static array is returned directly.
+	const toolDefinitions: ToolDefinition[] =
+		platformTools.length > 0 ? [...TOOL_DEFINITIONS, ...platformTools] : TOOL_DEFINITIONS;
+
 	const server = new Server({ name: "jollimemory", version: VERSION }, { capabilities: { tools: {} } });
 
-	server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOL_DEFINITIONS }));
+	server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: toolDefinitions }));
 
 	server.setRequestHandler(CallToolRequestSchema, async (req) => {
 		const { name, arguments: args } = req.params;
 		try {
-			const result = await dispatchTool(cwd, name, args ?? {});
-			// Unify the error contract across tools. `push_memory` reports failure
-			// as a structured `{ type: "error" }` result (its CLI caller branches on
-			// that) rather than throwing, so flag it `isError` here to match the
+			// Route backend-defined tools through the generic executor; everything
+			// else is a built-in handled by the local dispatch table.
+			const platformTool = platformByName.get(name);
+			const result =
+				platformClient && platformTool
+					? await platformClient.invokePlatformTool(platformTool, args ?? {})
+					: await dispatchTool(cwd, name, args ?? {});
+			// Unify the error contract across tools. `push_memory` (and any backend
+			// platform tool) reports failure as a structured `{ type: "error" }`
+			// result rather than throwing, so flag it `isError` here to match the
 			// thrown-error path that `list_spaces` / `bind_space` take. A
 			// `binding_required` result is a legitimate "needs input" outcome, not
 			// an error, so it stays a normal result.

--- a/cli/src/mcp/McpServer.ts
+++ b/cli/src/mcp/McpServer.ts
@@ -6,7 +6,13 @@
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+	CallToolRequestSchema,
+	GetPromptRequestSchema,
+	ListPromptsRequestSchema,
+	ListToolsRequestSchema,
+	type Prompt,
+} from "@modelcontextprotocol/sdk/types.js";
 import { VERSION } from "../commands/CliUtils.js";
 import { JolliMemoryPushClient, type PlatformToolManifestEntry } from "../core/JolliMemoryPushClient.js";
 import { loadConfig } from "../core/SessionTracker.js";
@@ -14,6 +20,13 @@ import { createStorage } from "../core/StorageFactory.js";
 import { setActiveStorage } from "../core/SummaryStore.js";
 import { createLogger } from "../Logger.js";
 import type { JolliMemoryConfig } from "../Types.js";
+import {
+	buildJolliMenu,
+	buildJolliPromptText,
+	JOLLI_PROMPT_ARGUMENT,
+	JOLLI_PROMPT_NAME,
+	type JolliMenuItem,
+} from "./JolliMenu.js";
 import {
 	runBindSpace,
 	runDecisionTimeline,
@@ -209,6 +222,9 @@ export async function startMcpServer(cwd: string, deps: StartMcpServerDeps = {})
 	const config = await (deps.loadConfig ?? loadConfig)();
 	let platformClient: PlatformToolClient | undefined;
 	let platformTools: PlatformToolManifestEntry[] = [];
+	// The curated `/jolli` menu is computed only inside the platform-tools gate, so
+	// with the gate closed it stays empty and no prompt is ever registered.
+	let menu: JolliMenuItem[] = [];
 	if (isPlatformToolsEnabled(config)) {
 		platformClient = (deps.createPlatformClient ?? (() => new JolliMemoryPushClient()))();
 		const builtInNames = new Set(TOOL_DEFINITIONS.map((t) => t.name));
@@ -231,6 +247,9 @@ export async function startMcpServer(cwd: string, deps: StartMcpServerDeps = {})
 			seenNames.add(tool.name);
 			return true;
 		});
+		// Menu = menu-flagged platform tools ∪ the local-tools inclusion list
+		// (empty for now). Every item is one of the tools advertised below.
+		menu = buildJolliMenu(platformTools, TOOL_DEFINITIONS);
 	}
 	const platformByName = new Map(platformTools.map((t) => [t.name, t] as const));
 	// Advertise the built-ins plus any platform tools. Build the list locally and
@@ -239,7 +258,14 @@ export async function startMcpServer(cwd: string, deps: StartMcpServerDeps = {})
 	const toolDefinitions: ToolDefinition[] =
 		platformTools.length > 0 ? [...TOOL_DEFINITIONS, ...platformTools] : TOOL_DEFINITIONS;
 
-	const server = new Server({ name: "jollimemory", version: VERSION }, { capabilities: { tools: {} } });
+	// Advertise the `prompts` capability only when the menu is non-empty. With an
+	// empty menu (gate off, empty manifest, or no menu-flagged tools) the server is
+	// byte-identical to a tools-only server: no capability, no handlers, no prompt.
+	const promptsEnabled = menu.length > 0;
+	const server = new Server(
+		{ name: "jollimemory", version: VERSION },
+		{ capabilities: promptsEnabled ? { tools: {}, prompts: {} } : { tools: {} } },
+	);
 
 	server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: toolDefinitions }));
 
@@ -268,6 +294,38 @@ export async function startMcpServer(cwd: string, deps: StartMcpServerDeps = {})
 			return { content: [{ type: "text", text: JSON.stringify({ error: message }) }], isError: true };
 		}
 	});
+
+	if (promptsEnabled) {
+		// One prompt, `jolli`, that steers the agent to the curated menu. `ListPrompts`
+		// returns exactly this prompt; `GetPrompt` returns a steering message built
+		// from the menu. The menu items are already-registered tools, so the prompt is
+		// not a second execution path — it only tells the agent which tool to call.
+		const jolliPrompt: Prompt = {
+			name: JOLLI_PROMPT_NAME,
+			description: "Browse and run Jolli actions from a curated menu.",
+			arguments: [
+				{
+					name: JOLLI_PROMPT_ARGUMENT,
+					description:
+						"Optional free-text request; matched against a menu item so the agent can invoke it directly.",
+					required: false,
+				},
+			],
+		};
+		server.setRequestHandler(ListPromptsRequestSchema, async () => ({ prompts: [jolliPrompt] }));
+		server.setRequestHandler(GetPromptRequestSchema, async (req) => {
+			const { name, arguments: promptArgs } = req.params;
+			if (name !== JOLLI_PROMPT_NAME) {
+				throw new Error(`Unknown prompt: ${name}`);
+			}
+			const rawRequest = promptArgs?.[JOLLI_PROMPT_ARGUMENT];
+			const request = typeof rawRequest === "string" ? rawRequest : undefined;
+			return {
+				description: "Curated Jolli action menu.",
+				messages: [{ role: "user", content: { type: "text", text: buildJolliPromptText(menu, request) } }],
+			};
+		});
+	}
 
 	const transport = new StdioServerTransport();
 	await server.connect(transport);

--- a/cli/src/mcp/PlatformTools.test.ts
+++ b/cli/src/mcp/PlatformTools.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { isPlatformToolsEnabled, PLATFORM_TOOLS_ENV_FLAG } from "./PlatformTools.js";
+
+describe("isPlatformToolsEnabled", () => {
+	it("is true when the config flag is explicitly true", () => {
+		expect(isPlatformToolsEnabled({ mcpPlatformToolsEnabled: true }, {})).toBe(true);
+	});
+
+	it("is true when the env flag is exactly '1', regardless of config", () => {
+		expect(isPlatformToolsEnabled({}, { [PLATFORM_TOOLS_ENV_FLAG]: "1" })).toBe(true);
+		expect(isPlatformToolsEnabled({ mcpPlatformToolsEnabled: false }, { [PLATFORM_TOOLS_ENV_FLAG]: "1" })).toBe(
+			true,
+		);
+	});
+
+	it("is false when both the config flag and env flag are absent (off by default)", () => {
+		expect(isPlatformToolsEnabled({}, {})).toBe(false);
+	});
+
+	it("is false when the config flag is explicitly false and the env flag is unset", () => {
+		expect(isPlatformToolsEnabled({ mcpPlatformToolsEnabled: false }, {})).toBe(false);
+	});
+
+	it("does not treat a truthy-but-non-'1' env value as enabled (strict === '1')", () => {
+		expect(isPlatformToolsEnabled({}, { [PLATFORM_TOOLS_ENV_FLAG]: "true" })).toBe(false);
+		expect(isPlatformToolsEnabled({}, { [PLATFORM_TOOLS_ENV_FLAG]: "0" })).toBe(false);
+		expect(isPlatformToolsEnabled({}, { [PLATFORM_TOOLS_ENV_FLAG]: "" })).toBe(false);
+	});
+});

--- a/cli/src/mcp/PlatformTools.ts
+++ b/cli/src/mcp/PlatformTools.ts
@@ -1,0 +1,29 @@
+/**
+ * Activation gate for the manifest-driven Jolli-platform MCP tools.
+ *
+ * The `jolli mcp` server registers backend-defined platform tools only when
+ * this gate is open; otherwise it stays git-memory-only and never contacts the
+ * backend for a tool manifest. The feature is opt-in (off by default): the
+ * config flag `mcpPlatformToolsEnabled` must be explicitly `true`, OR the
+ * escape-hatch env var `JOLLI_MCP_PLATFORM_TOOLS` must be exactly `"1"` (for
+ * CI / debugging without touching config.json — same strict `=== "1"` shape as
+ * the other CLI env gates).
+ */
+
+import type { JolliMemoryConfig } from "../Types.js";
+
+/** Env var that force-enables the platform tools without a config write. */
+export const PLATFORM_TOOLS_ENV_FLAG = "JOLLI_MCP_PLATFORM_TOOLS";
+
+/**
+ * Returns true when the manifest-driven Jolli-platform tools should be
+ * registered. Opt-in: the config flag must be `true`, or the env flag must be
+ * the literal `"1"`. `env` is injectable so the decision is unit-testable
+ * without mutating `process.env`.
+ */
+export function isPlatformToolsEnabled(
+	config: Pick<JolliMemoryConfig, "mcpPlatformToolsEnabled">,
+	env: Record<string, string | undefined> = process.env,
+): boolean {
+	return config.mcpPlatformToolsEnabled === true || env[PLATFORM_TOOLS_ENV_FLAG] === "1";
+}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (4)

1. Add manifest-driven Jolli-platform tools to the jolli mcp server (`42e7e74`)
2. Add the jolli menu prompt to the jolli mcp server (`cd48de5`)
3. Add a /jolli umbrella-menu skill over the Jolli skills and MCP tools (`c4c1a22`)
4. Keep platform-tool internal metadata off tools/list and degrade a bad binding (`27ac1e5`)

---

*Generated by Jolli Memory · July 12, 2026 at 11:39 AM*
<!-- jollimemory-summary-end -->
