### PR TITLE
Exclude agent scratch markdown from external plan discovery

### DIFF
--- a/cli/src/core/plans/TranscriptPlanDiscovery.ts
+++ b/cli/src/core/plans/TranscriptPlanDiscovery.ts
@@ -11,7 +11,7 @@
 
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { createLogger } from "../../Logger.js";
 import type { PlanEntry, TranscriptSource } from "../../Types.js";
@@ -44,18 +44,63 @@ const EXTERNAL_EXCLUDE_BASENAMES = new Set([
 ]);
 
 /**
- * Decide whether an external .md path is a plan candidate. Excludes any path
- * under `.claude/`, `node_modules/`, or `.github/`, plus common non-plan
- * filenames (README.md, CLAUDE.md, etc.) at any depth.
+ * Basename suffix patterns for transient agent scratch artifacts that are not
+ * plans — PR review scratch files (`pr320-review.md`, `code-review.md`) and
+ * task/status report dumps (`task-report.md`, `task_report.md`, `report.md`).
+ * Applied to the already-lowercased basename, so no `i` flag is needed. The
+ * `[-_]` separator alternative covers both dash- and underscore-delimited
+ * naming; `(?:^|…)` also matches the bare `review.md` / `report.md`. This
+ * complements the exact-basename denylist above — see JOLLI-1918.
  */
-function isExternalPlanCandidate(absPath: string): boolean {
+const EXTERNAL_EXCLUDE_BASENAME_PATTERNS = [/(?:^|[-_])review\.md$/, /(?:^|[-_])report\.md$/];
+
+/**
+ * Temp roots whose contents are throwaway scratch output — an agent writing a
+ * `.md` into the OS temp dir or a session scratchpad is not authoring a plan.
+ * Normalized once at load. `tmpdir()` covers Windows `%TEMP%` and macOS
+ * `/var/folders/…`; the POSIX literals cover `/tmp` and `/private/tmp` (the
+ * macOS scratchpad root, which `tmpdir()` does NOT return).
+ */
+const EXTERNAL_EXCLUDE_TEMP_ROOTS = [tmpdir(), "/tmp", "/private/tmp", "/var/tmp"].map(normalizePathForCompare);
+
+/**
+ * True when `absPath` lives under `dir`. A plan candidate is always a `.md` file
+ * path and `dir` is the workspace root, so the two are never equal — only the
+ * strict-descendant (`dir/…`) case is meaningful here.
+ */
+function isWithinDir(absPath: string, dir: string): boolean {
+	return normalizePathForCompare(absPath).startsWith(`${normalizePathForCompare(dir)}/`);
+}
+
+/**
+ * True when `absPath` is a scratch temp file: under a known temp/scratchpad root
+ * AND outside the project workspace (`cwd`). The workspace caveat is essential —
+ * a project checkout can itself live under a temp root (test sandboxes via
+ * `mkdtemp`, or a repo cloned into `/tmp`), and files inside such a workspace are
+ * real project content, not scratch.
+ */
+function isScratchTempFile(absPath: string, cwd: string): boolean {
+	const norm = normalizePathForCompare(absPath);
+	if (!EXTERNAL_EXCLUDE_TEMP_ROOTS.some((root) => norm.startsWith(`${root}/`))) return false;
+	return !isWithinDir(absPath, cwd);
+}
+
+/**
+ * Decide whether an external .md path is a plan candidate. Excludes any path
+ * under `.claude/`, `node_modules/`, or `.github/`; scratch temp files outside
+ * the workspace; common non-plan filenames (README.md, CLAUDE.md, etc.); and
+ * transient scratch artifacts (`*-review.md`, `*-report.md`) at any depth.
+ */
+function isExternalPlanCandidate(absPath: string, cwd: string): boolean {
 	if (EXTERNAL_EXCLUDE_SEGMENTS.some((re) => re.test(absPath))) return false;
+	if (isScratchTempFile(absPath, cwd)) return false;
 	// `split` on a non-empty string always returns ≥1 element, so `pop()` is
 	// never undefined here. The non-null assertion drops the dead `?? ""`
 	// fallback that v8 otherwise counts as an uncovered branch arm.
 	// biome-ignore lint/style/noNonNullAssertion: split-then-pop is provably non-null
 	const base = absPath.split(/[/\\]/).pop()!.toLowerCase();
-	return !EXTERNAL_EXCLUDE_BASENAMES.has(base);
+	if (EXTERNAL_EXCLUDE_BASENAMES.has(base)) return false;
+	return !EXTERNAL_EXCLUDE_BASENAME_PATTERNS.some((re) => re.test(base));
 }
 
 /**
@@ -155,7 +200,7 @@ export async function scanPlansFrom(
 	// every source inherits the same README/AGENTS.md/etc. filter. Filter BEFORE
 	// the early-exit so "only excluded files were touched" still skips the registry
 	// read — byte-equivalent to the pre-refactor Claude behaviour.
-	const filteredExternal = new Set([...externalPlans].filter(isExternalPlanCandidate));
+	const filteredExternal = new Set([...externalPlans].filter((p) => isExternalPlanCandidate(p, cwd)));
 
 	if (slugs.size === 0 && filteredExternal.size === 0) {
 		return totalLines;

--- a/cli/src/hooks/StopHook.test.ts
+++ b/cli/src/hooks/StopHook.test.ts
@@ -1279,6 +1279,51 @@ describe("StopHook — plan discovery", () => {
 		expect(savePlansRegistry).not.toHaveBeenCalled();
 	});
 
+	it("should not register agent scratch review markdown (pr320-review.md / code-review.md / pr_review.md)", async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+
+		mockTranscriptWithLines([
+			'{"type":"tool_use","name":"Write","input":{"file_path":"/repo/pr320-review.md"}}',
+			'{"type":"tool_use","name":"Write","input":{"file_path":"/repo/docs/code-review.md"}}',
+			'{"type":"tool_use","name":"Edit","input":{"file_path":"/repo/pr_review.md"}}',
+			'{"type":"tool_use","name":"Write","input":{"file_path":"/repo/review.md"}}',
+		]);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		expect(savePlansRegistry).not.toHaveBeenCalled();
+	});
+
+	it("should not register agent scratch report markdown (task-report.md / task_report.md / report.md)", async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+
+		mockTranscriptWithLines([
+			'{"type":"tool_use","name":"Write","input":{"file_path":"/repo/task-report.md"}}',
+			'{"type":"tool_use","name":"Write","input":{"file_path":"/repo/docs/task_report.md"}}',
+			'{"type":"tool_use","name":"Edit","input":{"file_path":"/repo/report.md"}}',
+		]);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		expect(savePlansRegistry).not.toHaveBeenCalled();
+	});
+
+	it("should not register .md files written under temp dirs (/tmp, /private/tmp scratchpad)", async () => {
+		vi.mocked(existsSync).mockReturnValue(true);
+
+		mockTranscriptWithLines([
+			'{"type":"tool_use","name":"Write","input":{"file_path":"/tmp/scratch-plan.md"}}',
+			'{"type":"tool_use","name":"Write","input":{"file_path":"/private/tmp/claude-501/session/scratchpad/notes.md"}}',
+		]);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		expect(savePlansRegistry).not.toHaveBeenCalled();
+	});
+
 	it("should register an external .md edited multiple times as a single plan entry", async () => {
 		vi.mocked(existsSync)
 			.mockReturnValueOnce(true) // transcript file

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -110,8 +110,9 @@ const { getNotesDir } = vi.hoisted(() => ({
 	getNotesDir: vi.fn(() => "/test/workspace/.jolli/jollimemory/notes"),
 }));
 
-const { homedir } = vi.hoisted(() => ({
+const { homedir, tmpdir } = vi.hoisted(() => ({
 	homedir: vi.fn(() => "/home/user"),
+	tmpdir: vi.fn(() => "/tmp"),
 }));
 
 const { existsSync, readFileSync } = vi.hoisted(() => ({
@@ -1049,6 +1050,7 @@ vi.mock("./services/ManualDisableFlag.js", () => ({
 
 vi.mock("node:os", () => ({
 	homedir,
+	tmpdir,
 }));
 
 vi.mock("node:fs", () => ({


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The plan discovery system now filters out transient agent scratch artifacts that were previously being registered as plans. Review markdown files (such as PR review notes and code review summaries) and report files (task reports and status dumps) are excluded regardless of where they appear in the workspace. Additionally, markdown files written to temporary directories outside the project workspace are no longer treated as plans, preventing session scratchpads and throwaway notes from polluting the plan registry. The filtering preserves legitimate project content even when a workspace itself is located under a temporary directory, ensuring that real plans in sandboxed or temporary checkouts are still discovered correctly.

---

## Topic (1)
<details>
<summary><strong>01 · Exclude agent scratch markdown from external plan discovery</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Agent sessions were writing transient scratch files (PR reviews, task reports, temp directory artifacts) that were being incorrectly registered as plans. These files clutter the plan registry and do not represent actual project plans.

**💡 Decisions Behind the Code**

Temp directory exclusion was scoped to files OUTSIDE the workspace rather than excluding all temp-rooted paths unconditionally. This allows projects cloned into `/tmp` or test sandboxes created via `mkdtemp` to have their markdown files properly recognized as plans, since those files are genuine project content even though they live under a temp root. The workspace boundary acts as the semantic distinction between scratch artifacts and real project files.

**✅ What Was Implemented**

- Added basename pattern matching to filter out review and report markdown files (`*-review.md`, `*_review.md`, `review.md`, `*-report.md`, `*_report.md`, `report.md`) at any depth in the workspace. Patterns are applied to lowercased basenames and use regex alternation to match both dash and underscore delimiters.
- Implemented scratch temp file detection via `isScratchTempFile()` function that excludes markdown files written under known temporary directories (`/tmp`, `/private/tmp`, `/var/tmp`, and the OS temp root) when those files fall outside the project workspace. This preserves files in workspaces that themselves live under temp roots (e.g., test sandboxes).
- Updated `isExternalPlanCandidate()` to accept the workspace root (`cwd`) parameter and apply both the new pattern and temp-file checks before registering external markdown as a plan candidate.

**📁 FILES**
- `cli/src/core/plans/TranscriptPlanDiscovery.ts`
- `cli/src/hooks/StopHook.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 10, 2026 at 6:09 PM · via Anthropic*
<!-- jollimemory-summary-end -->
