### PR TITLE
Exclude Linear enumeration tools from reference extraction

### DIFF
--- a/cli/src/core/references/ReferenceExtractor.test.ts
+++ b/cli/src/core/references/ReferenceExtractor.test.ts
@@ -126,7 +126,7 @@ describe("extractReferencesFromTranscript", () => {
 		expect(lastLineNumberScanned).toBe(2);
 	});
 
-	it("extracts all issues from a list_issues array result, preserving order", async () => {
+	it("captures zero references from a list_issues enumeration result", async () => {
 		const jsonl = makeJsonl(
 			toolUseLine({
 				toolUseId: "toolu_2",
@@ -144,31 +144,30 @@ describe("extractReferencesFromTranscript", () => {
 
 		const { references } = await extractReferencesFromTranscript("/fake.jsonl");
 
-		expect(references.map((i) => i.nativeId)).toEqual(["PROJ-1528", "PROJ-1404"]);
-		expect(references.every((i) => i.toolName === "mcp__linear__list_issues")).toBe(true);
+		expect(references).toEqual([]);
 	});
 
-	it("dedupes same nativeId across multiple references, keeping the latest referencedAt", async () => {
+	it("dedupes same nativeId across two get_issue results, keeping the latest referencedAt", async () => {
 		const jsonl = makeJsonl(
-			// First: list result (no description)
+			// First: sparse get_issue (old title, no description), earlier timestamp
 			toolUseLine({
-				toolUseId: "toolu_list",
-				toolName: "mcp__linear__list_issues",
+				toolUseId: "toolu_get1",
+				toolName: "mcp__linear__get_issue",
 				timestamp: "2026-05-14T06:00:00.000Z",
 			}),
 			toolResultLine({
-				toolUseId: "toolu_list",
+				toolUseId: "toolu_get1",
 				timestamp: "2026-05-14T06:00:01.000Z",
-				payload: [{ id: "PROJ-1528", title: "old title", url: SAMPLE_ISSUE_PAYLOAD.url }],
+				payload: { id: "PROJ-1528", title: "old title", url: SAMPLE_ISSUE_PAYLOAD.url },
 			}),
-			// Then: get_issue with full description, later timestamp
+			// Then: full get_issue, later timestamp
 			toolUseLine({
-				toolUseId: "toolu_get",
+				toolUseId: "toolu_get2",
 				toolName: "mcp__linear__get_issue",
 				timestamp: "2026-05-14T07:00:00.000Z",
 			}),
 			toolResultLine({
-				toolUseId: "toolu_get",
+				toolUseId: "toolu_get2",
 				timestamp: "2026-05-14T07:00:01.000Z",
 				payload: SAMPLE_ISSUE_PAYLOAD,
 			}),
@@ -448,7 +447,7 @@ describe("extractReferencesFromTranscript", () => {
 		const jsonl = makeJsonl(
 			toolUseLine({
 				toolUseId: "toolu_w",
-				toolName: "mcp__linear__list_issues",
+				toolName: "mcp__linear__get_issue",
 				timestamp: "2026-05-14T06:00:00.000Z",
 			}),
 			toolResultLine({
@@ -474,7 +473,7 @@ describe("extractReferencesFromTranscript", () => {
 		const jsonl = makeJsonl(
 			toolUseLine({
 				toolUseId: "toolu_obj",
-				toolName: "mcp__linear__list_issues",
+				toolName: "mcp__linear__get_issue",
 				timestamp: "2026-05-14T06:00:00.000Z",
 			}),
 			toolResultLine({

--- a/cli/src/core/references/SourceDefinition.ts
+++ b/cli/src/core/references/SourceDefinition.ts
@@ -36,6 +36,13 @@ export interface MatchClaude {
 	readonly prefixes: ReadonlyArray<string>;
 	/** Optional suffix accept (e.g. Notion "notion-fetch"). */
 	readonly acceptSuffix?: string;
+	/**
+	 * After a prefix match (and any `acceptSuffix`), reject if the tool name ends
+	 * with any of these. Enumeration tools (`list_issues` / `search_issues`)
+	 * bulk-capture their whole result array — one reference per element — flooding
+	 * Working Memory → Context, so they are excluded from reference extraction.
+	 */
+	readonly denySuffixes?: ReadonlyArray<string>;
 }
 export interface MatchCodex {
 	readonly namespaceSuffix: string;

--- a/cli/src/core/references/SourceDefinitionRegistry.test.ts
+++ b/cli/src/core/references/SourceDefinitionRegistry.test.ts
@@ -15,6 +15,27 @@ describe("SourceDefinitionRegistry", () => {
 		expect(r.match("claude", "mcp__claude_ai_Notion__notion-search")).toBeUndefined(); // acceptSuffix gate
 	});
 
+	it("match rejects Claude enumeration tools via denySuffixes, keeps single-entity fetches", () => {
+		const r = getRegistry();
+		// Enumeration tools are excluded (bulk-capture guard):
+		expect(r.match("claude", "mcp__linear__list_issues")).toBeUndefined();
+		expect(r.match("claude", "mcp__linear__search_issues")).toBeUndefined();
+		expect(r.match("claude", "mcp__claude_ai_Linear__list_issues")).toBeUndefined();
+		// Single-entity fetches still resolve:
+		expect(r.match("claude", "mcp__linear__get_issue")?.id).toBe("linear");
+	});
+
+	it("no longer matches Codex Linear enumeration tools", () => {
+		const r = getRegistry();
+		expect(r.match("codex", "_list_issues", "linear")).toBeUndefined();
+		expect(r.match("codex", "_search", "linear")).toBeUndefined();
+		expect(r.match("codex", "linear.list_issues")).toBeUndefined();
+		expect(r.match("codex", "linear.search")).toBeUndefined();
+		// Single-entity Codex Linear tools still resolve:
+		expect(r.match("codex", "_get_issue", "linear")?.id).toBe("linear");
+		expect(r.match("codex", "linear.get_issue")?.id).toBe("linear");
+	});
+
 	it("match resolves Codex by namespaceSuffix + name, and by invocation tool", () => {
 		const r = getRegistry();
 		expect(r.match("codex", "_fetch", "linear")?.id).toBe("linear"); // function_call path

--- a/cli/src/core/references/SourceDefinitionRegistry.ts
+++ b/cli/src/core/references/SourceDefinitionRegistry.ts
@@ -8,7 +8,9 @@
  *   - claude: first definition whose `match.claude.prefixes` has a prefix the
  *     tool name starts with; if that definition also declares `acceptSuffix`,
  *     the tool name must end with it too (Notion's "notion-fetch" gate — a
- *     prefix match with the wrong suffix is not a match at all).
+ *     prefix match with the wrong suffix is not a match at all); and if it
+ *     declares `denySuffixes`, a tool name ending in any of them is rejected
+ *     (enumeration tools like `list_issues` that would bulk-capture results).
  *   - codex, with a namespace (function_call path): first definition whose
  *     `match.codex.namespaceSuffix` equals the namespace AND whose
  *     `functionCallNames` includes the tool name (disambiguates names like
@@ -182,7 +184,7 @@ export class SourceDefinitionRegistry {
 
 	/**
 	 * Resolves the definition that owns a tool invocation.
-	 * - `agent === "claude"`: prefix + optional `acceptSuffix` match.
+	 * - `agent === "claude"`: prefix + optional `acceptSuffix` accept + optional `denySuffixes` reject.
 	 * - `agent === "codex"` with `namespace`: `namespaceSuffix` + `functionCallNames` match.
 	 * - `agent === "codex"` without `namespace`: `invocationTools` match.
 	 */
@@ -191,7 +193,9 @@ export class SourceDefinitionRegistry {
 			return this.definitions.find((d) => {
 				const m = d.match.claude;
 				if (m === undefined || !m.prefixes.some((prefix) => toolName.startsWith(prefix))) return false;
-				return m.acceptSuffix === undefined || toolName.endsWith(m.acceptSuffix);
+				if (m.acceptSuffix !== undefined && !toolName.endsWith(m.acceptSuffix)) return false;
+				if (m.denySuffixes?.some((suffix) => toolName.endsWith(suffix))) return false;
+				return true;
 			});
 		}
 

--- a/cli/src/core/references/bindings/codex/CodexLinearBinding.ts
+++ b/cli/src/core/references/bindings/codex/CodexLinearBinding.ts
@@ -1,21 +1,19 @@
 /**
  * CodexLinearBinding — Linear `codex_apps` connector normalizer.
  *
- * Reached through the read tools that return issue-shaped payloads: `_fetch` /
- * `linear_fetch` (the original standalone-MCP names) and `_get_issue` /
- * `_list_issues` / `_search` (and their dotted `linear.*` invocation forms,
- * emitted by the OpenAI-curated Codex Linear connector) — match identity for all
- * of these lives in the registry. Verified live for `_get_issue` /
- * `linear.get_issue` (payload is a normal Linear issue object: the ticket id is
- * in `id` (e.g. `ABC-123`) and the URL is `linear.app/…`, read directly by the
- * linear `SourceDefinition`; no reshaping → identity normalize). List/search are
- * added on the same recognition but their payload shape is NOT yet verified
- * live; the expectation is that entries wrap under a key in the definition's
- * wrapper keys (`issues` / `results`) so the driver unwraps them and `extractRef`
- * validates each — if that guess is wrong they simply yield nothing (never
- * crash). Write tools (e.g. `_create_attachment`, `_delete_comment`) are
- * intentionally not recognized: they don't return an issue, so they'd be dropped
- * anyway.
+ * Reached through the single-entity read tools that return an issue-shaped
+ * payload: `_fetch` / `linear_fetch` (the original standalone-MCP names) and
+ * `_get_issue` / `linear.get_issue` (the OpenAI-curated Codex Linear connector) —
+ * match identity for these lives in the registry. Verified live for `_get_issue` /
+ * `linear.get_issue` (payload is a normal Linear issue object: the ticket id is in
+ * `id` (e.g. `ABC-123`) and the URL is `linear.app/…`, read directly by the linear
+ * `SourceDefinition`; no reshaping → identity normalize).
+ *
+ * Enumeration tools (`_list_issues` / `_search` and their dotted `linear.*`
+ * forms) are intentionally NOT recognized: a list/search result carries many
+ * issues the user is not working on, and capturing each one floods Working
+ * Memory → Context (JOLLI-1921). Write tools (e.g. `_create_attachment`,
+ * `_delete_comment`) are likewise not recognized — they don't return an issue.
  */
 
 import type { CodexNormalizer } from "./CodexBinding.js";

--- a/cli/src/core/references/sources/definitions/linear.ts
+++ b/cli/src/core/references/sources/definitions/linear.ts
@@ -25,11 +25,15 @@ export const linearDefinition: SourceDefinition = {
 	label: "Linear",
 	icon: "issues",
 	match: {
-		claude: { prefixes: ["mcp__linear__", "mcp__claude_ai_Linear__"] },
+		claude: {
+			prefixes: ["mcp__linear__", "mcp__claude_ai_Linear__"],
+			// Enumeration tools bulk-capture every returned issue; exclude them.
+			denySuffixes: ["list_issues", "search_issues"],
+		},
 		codex: {
 			namespaceSuffix: "linear",
-			functionCallNames: ["_fetch", "_get_issue", "_list_issues", "_search"],
-			invocationTools: ["linear_fetch", "linear.get_issue", "linear.list_issues", "linear.search"],
+			functionCallNames: ["_fetch", "_get_issue"],
+			invocationTools: ["linear_fetch", "linear.get_issue"],
 		},
 	},
 	wrapperKeys: ["items", "issues", "nodes", "results"],

--- a/docs/superpowers/plans/2026-07-10-exclude-enumeration-references.md
+++ b/docs/superpowers/plans/2026-07-10-exclude-enumeration-references.md
@@ -1,0 +1,426 @@
+# Exclude Enumeration Tools From Reference Extraction — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Post-review amendment (2026-07-10):** the final whole-branch review found GitHub's Claude-path MCP tool names are unverified in the codebase (canonical is `mcp__github__issue_read`; `list_issues`/`search_issues` existed only in new test code) and that GitHub PR enumeration would flood too. Per the repo's real-fixture rule, **GitHub was descoped** — Tasks 3 and the GitHub half of Task 4 were reverted; only the Linear fix + the `denySuffixes` mechanism shipped. See the spec's "Follow-up (deferred)" section. The task text below is retained as originally written.
+
+**Goal:** Stop MCP enumeration tools (`list_issues` / `search_issues`) from bulk-capturing every returned issue as a reference into Working Memory → Context.
+
+**Architecture:** Add a `denySuffixes` gate to the Claude match layer (mirror of the existing `acceptSuffix`), so enumeration tool calls resolve to no `SourceDefinition` and are never walked. Apply it to the Linear and GitHub definitions, and remove Linear's speculative Codex `_list_issues`/`_search` recognition. Codex GitHub `_search_issues` (verified discovery+dedupe) is left intact.
+
+**Tech Stack:** TypeScript (ESM, Node 22.5+), Vitest, Biome. Declarative `SourceDefinition` DSL under `cli/src/core/references/`.
+
+## Global Constraints
+
+- Biome: tabs, 4-wide, 120 columns. `noExplicitAny: error`, `noUnusedImports/Variables: error`. CI runs `biome check --error-on-warnings` (warnings fail).
+- CLI coverage floor: 97% statements / 96% branches / 97% functions / 97% lines. New branches must be tested.
+- DCO sign-off on the commit (`git commit -s`). No `Co-Authored-By: Claude …` / no "🤖 Generated with …". Only `Signed-off-by:`.
+- `npm run all` must pass before commit (clean → build → lint → test).
+- Keep the three API-key-parser impls in lockstep — **not touched here** (this change is confined to the references subsystem).
+- Use `toForwardSlash` for any `\`→`/` normalization — **N/A here** (no path work).
+
+**Commit/verify policy for this plan (project convention overrides the skill default):** do NOT commit or run `npm run all` per task. Tasks 1–4 only write code (tests + implementation). Task 5 runs `npm run all` once and makes a single commit.
+
+---
+
+### Task 1: Add `denySuffixes` primitive to the Claude match layer
+
+**Files:**
+- Modify: `cli/src/core/references/SourceDefinition.ts` (the `MatchClaude` interface)
+- Modify: `cli/src/core/references/SourceDefinitionRegistry.ts:190-196` (the `agent === "claude"` branch of `match()`)
+- Test: `cli/src/core/references/SourceDefinitionRegistry.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `MatchClaude.denySuffixes?: ReadonlyArray<string>` — when a Claude tool name matches a definition's `prefixes` (and passes `acceptSuffix`), the definition is rejected if the tool name `endsWith` any listed suffix. Later tasks set this field on `linearDefinition` and `githubDefinition`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `cli/src/core/references/SourceDefinitionRegistry.test.ts`, inside the top-level `describe("SourceDefinitionRegistry", …)` block (after the existing `"match resolves Claude by prefix, honoring acceptSuffix"` test, ~line 16):
+
+```ts
+	it("match rejects Claude enumeration tools via denySuffixes, keeps single-entity fetches", () => {
+		const r = getRegistry();
+		// Enumeration tools are excluded (bulk-capture guard):
+		expect(r.match("claude", "mcp__linear__list_issues")).toBeUndefined();
+		expect(r.match("claude", "mcp__linear__search_issues")).toBeUndefined();
+		expect(r.match("claude", "mcp__claude_ai_Linear__list_issues")).toBeUndefined();
+		expect(r.match("claude", "mcp__github__list_issues")).toBeUndefined();
+		expect(r.match("claude", "mcp__github__search_issues")).toBeUndefined();
+		// Single-entity fetches still resolve:
+		expect(r.match("claude", "mcp__linear__get_issue")?.id).toBe("linear");
+		expect(r.match("claude", "mcp__github__get_issue")?.id).toBe("github");
+	});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/references/SourceDefinitionRegistry.test.ts -t "denySuffixes"`
+Expected: FAIL — the four `list_issues`/`search_issues` assertions currently return the matching definition (not `undefined`) because Task 2/3 haven't added `denySuffixes` yet, and the match layer doesn't honor it.
+
+Note: this test also proves Task 2/3 wired the field. It will fully pass only after Tasks 2–3. That is expected; leave it failing until then.
+
+- [ ] **Step 3: Add the `denySuffixes` field to `MatchClaude`**
+
+In `cli/src/core/references/SourceDefinition.ts`, replace the `MatchClaude` interface:
+
+```ts
+export interface MatchClaude {
+	readonly prefixes: ReadonlyArray<string>;
+	/** Optional suffix accept (e.g. Notion "notion-fetch"). */
+	readonly acceptSuffix?: string;
+	/**
+	 * After a prefix match (and any `acceptSuffix`), reject if the tool name ends
+	 * with any of these. Enumeration tools (`list_issues` / `search_issues`)
+	 * bulk-capture their whole result array — one reference per element — flooding
+	 * Working Memory → Context, so they are excluded from reference extraction.
+	 */
+	readonly denySuffixes?: ReadonlyArray<string>;
+}
+```
+
+- [ ] **Step 4: Implement the deny gate in `match()`**
+
+In `cli/src/core/references/SourceDefinitionRegistry.ts`, replace the `agent === "claude"` branch inside `match()`:
+
+```ts
+		if (agent === "claude") {
+			return this.definitions.find((d) => {
+				const m = d.match.claude;
+				if (m === undefined || !m.prefixes.some((prefix) => toolName.startsWith(prefix))) return false;
+				if (m.acceptSuffix !== undefined && !toolName.endsWith(m.acceptSuffix)) return false;
+				if (m.denySuffixes?.some((suffix) => toolName.endsWith(suffix))) return false;
+				return true;
+			});
+		}
+```
+
+- [ ] **Step 5: Run test to confirm the mechanism compiles and single-entity assertions pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/references/SourceDefinitionRegistry.test.ts -t "denySuffixes"`
+Expected: the two single-entity assertions PASS. The five enumeration assertions still FAIL until Tasks 2–3 set `denySuffixes` on the definitions. (No commit — see the plan's commit policy.)
+
+---
+
+### Task 2: Exclude enumeration on Linear (Claude deny + Codex removal)
+
+**Files:**
+- Modify: `cli/src/core/references/sources/definitions/linear.ts:27-34` (the `match` block)
+- Modify: `cli/src/core/references/bindings/codex/CodexLinearBinding.ts:1-19` (header doc)
+- Test: `cli/src/core/references/ReferenceExtractor.test.ts`, `cli/src/core/references/SourceDefinitionRegistry.test.ts`
+
+**Interfaces:**
+- Consumes: `MatchClaude.denySuffixes` (Task 1).
+- Produces: Linear no longer matches Claude `list_issues`/`search_issues` nor Codex `_list_issues`/`_search`.
+
+- [ ] **Step 1: Write the failing extractor test (Linear list_issues → 0 refs)**
+
+In `cli/src/core/references/ReferenceExtractor.test.ts`, REPLACE the existing test `"extracts all issues from a list_issues array result, preserving order"` (currently ~lines 129-149) with:
+
+```ts
+	it("captures zero references from a list_issues enumeration result", async () => {
+		const jsonl = makeJsonl(
+			toolUseLine({
+				toolUseId: "toolu_2",
+				toolName: "mcp__linear__list_issues",
+				timestamp: "2026-05-14T06:00:00.000Z",
+				inputJson: '{"team":"Jolli"}',
+			}),
+			toolResultLine({
+				toolUseId: "toolu_2",
+				timestamp: "2026-05-14T06:00:01.000Z",
+				payload: [SAMPLE_ISSUE_PAYLOAD, SAMPLE_ISSUE_PAYLOAD_2],
+			}),
+		);
+		mockReadFile.mockResolvedValue(jsonl);
+
+		const { references } = await extractReferencesFromTranscript("/fake.jsonl");
+
+		expect(references).toEqual([]);
+	});
+```
+
+- [ ] **Step 2: Repurpose the dedupe test to two single-entity fetches**
+
+In the same file, REPLACE the test `"dedupes same nativeId across multiple references, keeping the latest referencedAt"` (currently ~lines 151-184) — the old version relied on a `list_issues` line contributing the stale copy, which no longer happens. Use two `get_issue` calls instead:
+
+```ts
+	it("dedupes same nativeId across two get_issue results, keeping the latest referencedAt", async () => {
+		const jsonl = makeJsonl(
+			// First: sparse get_issue (old title, no description), earlier timestamp
+			toolUseLine({
+				toolUseId: "toolu_get1",
+				toolName: "mcp__linear__get_issue",
+				timestamp: "2026-05-14T06:00:00.000Z",
+			}),
+			toolResultLine({
+				toolUseId: "toolu_get1",
+				timestamp: "2026-05-14T06:00:01.000Z",
+				payload: { id: "PROJ-1528", title: "old title", url: SAMPLE_ISSUE_PAYLOAD.url },
+			}),
+			// Then: full get_issue, later timestamp
+			toolUseLine({
+				toolUseId: "toolu_get2",
+				toolName: "mcp__linear__get_issue",
+				timestamp: "2026-05-14T07:00:00.000Z",
+			}),
+			toolResultLine({
+				toolUseId: "toolu_get2",
+				timestamp: "2026-05-14T07:00:01.000Z",
+				payload: SAMPLE_ISSUE_PAYLOAD,
+			}),
+		);
+		mockReadFile.mockResolvedValue(jsonl);
+
+		const { references } = await extractReferencesFromTranscript("/fake.jsonl");
+
+		expect(references).toHaveLength(1);
+		expect(references[0].title).toBe(SAMPLE_ISSUE_PAYLOAD.title);
+		expect(references[0].referencedAt).toBe("2026-05-14T07:00:01.000Z");
+		expect(references[0].description).toContain("Linear issues are high-density");
+	});
+```
+
+- [ ] **Step 3: Add Codex-level registry assertions for Linear**
+
+In `cli/src/core/references/SourceDefinitionRegistry.test.ts`, add after the `denySuffixes` test from Task 1:
+
+```ts
+	it("no longer matches Codex Linear enumeration tools", () => {
+		const r = getRegistry();
+		expect(r.match("codex", "_list_issues", "linear")).toBeUndefined();
+		expect(r.match("codex", "_search", "linear")).toBeUndefined();
+		expect(r.match("codex", "linear.list_issues")).toBeUndefined();
+		expect(r.match("codex", "linear.search")).toBeUndefined();
+		// Single-entity Codex Linear tools still resolve:
+		expect(r.match("codex", "_get_issue", "linear")?.id).toBe("linear");
+		expect(r.match("codex", "linear.get_issue")?.id).toBe("linear");
+	});
+```
+
+- [ ] **Step 4: Run the new/changed tests to verify they fail**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/references/ReferenceExtractor.test.ts src/core/references/SourceDefinitionRegistry.test.ts`
+Expected: the three tests above FAIL (Linear still matches enumeration tools on both paths).
+
+- [ ] **Step 5: Edit `linear.ts` match block**
+
+In `cli/src/core/references/sources/definitions/linear.ts`, replace the `match` block:
+
+```ts
+	match: {
+		claude: {
+			prefixes: ["mcp__linear__", "mcp__claude_ai_Linear__"],
+			// Enumeration tools bulk-capture every returned issue; exclude them.
+			denySuffixes: ["list_issues", "search_issues"],
+		},
+		codex: {
+			namespaceSuffix: "linear",
+			functionCallNames: ["_fetch", "_get_issue"],
+			invocationTools: ["linear_fetch", "linear.get_issue"],
+		},
+	},
+```
+
+- [ ] **Step 6: Update the `CodexLinearBinding.ts` header doc**
+
+In `cli/src/core/references/bindings/codex/CodexLinearBinding.ts`, replace the header comment body so it no longer claims `_list_issues`/`_search` are recognized:
+
+```ts
+/**
+ * CodexLinearBinding — Linear `codex_apps` connector normalizer.
+ *
+ * Reached through the single-entity read tools that return an issue-shaped
+ * payload: `_fetch` / `linear_fetch` (the original standalone-MCP names) and
+ * `_get_issue` / `linear.get_issue` (the OpenAI-curated Codex Linear connector) —
+ * match identity for these lives in the registry. Verified live for `_get_issue` /
+ * `linear.get_issue` (payload is a normal Linear issue object: the ticket id is in
+ * `id` (e.g. `ABC-123`) and the URL is `linear.app/…`, read directly by the linear
+ * `SourceDefinition`; no reshaping → identity normalize).
+ *
+ * Enumeration tools (`_list_issues` / `_search` and their dotted `linear.*`
+ * forms) are intentionally NOT recognized: a list/search result carries many
+ * issues the user is not working on, and capturing each one floods Working
+ * Memory → Context (JOLLI-1921). Write tools (e.g. `_create_attachment`,
+ * `_delete_comment`) are likewise not recognized — they don't return an issue.
+ */
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/references/ReferenceExtractor.test.ts src/core/references/SourceDefinitionRegistry.test.ts`
+Expected: the Linear enumeration extractor test, the repurposed dedupe test, and the Codex Linear registry test all PASS. (The Task 1 `denySuffixes` test now passes its Linear assertions; GitHub assertions pass after Task 3.)
+
+---
+
+### Task 3: Exclude enumeration on GitHub (Claude deny only)
+
+**Files:**
+- Modify: `cli/src/core/references/sources/definitions/github.ts:41-48` (the `match` block)
+- Test: `cli/src/core/references/ReferenceExtractor.test.ts`
+
+**Interfaces:**
+- Consumes: `MatchClaude.denySuffixes` (Task 1).
+- Produces: GitHub no longer matches Claude `list_issues`/`search_issues`. Codex GitHub `_search_issues` is unchanged.
+
+- [ ] **Step 1: Write the failing extractor test (GitHub search_issues → 0 refs)**
+
+In `cli/src/core/references/ReferenceExtractor.test.ts`, add inside `describe("extractReferencesFromTranscript", …)`, after the Linear enumeration test from Task 2:
+
+```ts
+	it("captures zero references from a GitHub search_issues enumeration result", async () => {
+		const jsonl = makeJsonl(
+			toolUseLine({
+				toolUseId: "toolu_gh",
+				toolName: "mcp__github__search_issues",
+				timestamp: "2026-05-14T06:00:00.000Z",
+				inputJson: '{"q":"is:open"}',
+			}),
+			toolResultLine({
+				toolUseId: "toolu_gh",
+				timestamp: "2026-05-14T06:00:01.000Z",
+				payload: {
+					issues: [
+						{
+							number: 12,
+							title: "First hit",
+							html_url: "https://github.com/jolliai/jolliai/issues/12",
+							repository: { full_name: "jolliai/jolliai" },
+						},
+						{
+							number: 34,
+							title: "Second hit",
+							html_url: "https://github.com/jolliai/jolliai/issues/34",
+							repository: { full_name: "jolliai/jolliai" },
+						},
+					],
+				},
+			}),
+		);
+		mockReadFile.mockResolvedValue(jsonl);
+
+		const { references } = await extractReferencesFromTranscript("/fake.jsonl");
+
+		expect(references).toEqual([]);
+	});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/references/ReferenceExtractor.test.ts -t "GitHub search_issues"`
+Expected: FAIL — currently returns two references (`jolliai/jolliai#12`, `#34`).
+
+- [ ] **Step 3: Edit `github.ts` Claude match**
+
+In `cli/src/core/references/sources/definitions/github.ts`, replace the `match` block:
+
+```ts
+	match: {
+		claude: {
+			prefixes: ["mcp__github__"],
+			// Enumeration tools bulk-capture every returned issue; exclude them.
+			denySuffixes: ["list_issues", "search_issues"],
+		},
+		codex: {
+			namespaceSuffix: "github",
+			functionCallNames: ["_fetch_issue", "_search_issues"],
+			invocationTools: ["github_fetch_issue", "github_search_issues"],
+		},
+	},
+```
+
+Note: the Codex arrays are intentionally unchanged — `_search_issues` is the verified single-entity discovery path (search → `gh` backfill → dedupe).
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/references/ReferenceExtractor.test.ts -t "GitHub search_issues"`
+Expected: PASS (0 references). The Task 1 `denySuffixes` test now passes its GitHub assertions too.
+
+---
+
+### Task 4: Verify Codex GitHub discovery is untouched (guard test)
+
+**Files:**
+- Test: `cli/src/core/references/SourceDefinitionRegistry.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: an explicit regression guard proving the intentionally-preserved Codex GitHub `_search_issues` path still resolves.
+
+- [ ] **Step 1: Write the guard test**
+
+In `cli/src/core/references/SourceDefinitionRegistry.test.ts`, add after the Codex Linear test from Task 2:
+
+```ts
+	it("keeps Codex GitHub _search_issues discovery (intentionally not excluded)", () => {
+		const r = getRegistry();
+		expect(r.match("codex", "_search_issues", "github")?.id).toBe("github");
+		expect(r.match("codex", "github_search_issues")?.id).toBe("github");
+	});
+```
+
+- [ ] **Step 2: Run it to verify it passes immediately**
+
+Run: `npm run test -w @jolli.ai/cli -- src/core/references/SourceDefinitionRegistry.test.ts -t "Codex GitHub"`
+Expected: PASS with no source change (this behavior was deliberately preserved). If it FAILS, a prior task over-reached into GitHub's Codex arrays — revert that.
+
+---
+
+### Task 5: Full verification and single commit
+
+**Files:** none (verification + commit only).
+
+- [ ] **Step 1: Run the full gate**
+
+Run: `cd /Users/flyer/jolli/code/jollimemory-worktrees/feature-wt1 && npm run all`
+Expected: clean → build → lint → test all pass; CLI coverage stays ≥ 97/96/97/97.
+
+If the git-op tests fail for environment reasons (known local flake), re-run the CLI tests with the isolation prefix from project memory:
+`GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all npm run test:cli`
+
+- [ ] **Step 2: Stage the change set**
+
+```bash
+git add cli/src/core/references/SourceDefinition.ts \
+        cli/src/core/references/SourceDefinitionRegistry.ts \
+        cli/src/core/references/SourceDefinitionRegistry.test.ts \
+        cli/src/core/references/ReferenceExtractor.test.ts \
+        cli/src/core/references/sources/definitions/linear.ts \
+        cli/src/core/references/sources/definitions/github.ts \
+        cli/src/core/references/bindings/codex/CodexLinearBinding.ts \
+        docs/superpowers/specs/2026-07-10-exclude-enumeration-references-design.md \
+        docs/superpowers/plans/2026-07-10-exclude-enumeration-references.md
+```
+
+- [ ] **Step 3: Commit (DCO sign-off, no AI co-author)**
+
+```bash
+git commit -s -m "Exclude enumeration tools from reference extraction
+
+Linear/GitHub list_issues and search_issues bulk-captured every returned
+issue as a reference, flooding Working Memory > Context. Add a denySuffixes
+gate to the Claude match layer and drop Linear's speculative Codex
+_list_issues/_search recognition. Codex GitHub _search_issues (verified
+discovery + dedupe) is left intact.
+
+Fixes JOLLI-1921"
+```
+
+Expected: commit succeeds with a `Signed-off-by:` trailer and no `Co-Authored-By: Claude` / no "🤖 Generated with" footer.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- `denySuffixes` primitive → Task 1. ✓
+- linear.ts Claude deny + Codex removal → Task 2 (steps 5–6). ✓
+- github.ts Claude deny, Codex untouched → Task 3. ✓
+- CodexLinearBinding doc lockstep → Task 2 step 6. ✓
+- "NOT changed" — Codex GitHub `_search_issues` → guarded in Task 4; Jira/Notion → no task (correctly, they need no change). ✓
+- Tests: invert list_issues test, repurpose dedupe test, add Linear+GitHub 0-ref tests, registry deny assertions → Tasks 1–4. ✓
+- Behavior "single-entity fetch unchanged" → asserted in Task 1 (registry) and preserved by the existing `get_issue` test at ReferenceExtractor.test.ts:97. ✓
+
+**2. Placeholder scan:** No TBD/TODO/"handle edge cases"/"similar to Task N". All steps carry concrete code or exact commands. ✓
+
+**3. Type consistency:** `denySuffixes: ReadonlyArray<string>` is used identically in `SourceDefinition.ts`, `match()`, and both definitions. `match()` signature unchanged. Test helpers (`makeJsonl`, `toolUseLine`, `toolResultLine`, `SAMPLE_ISSUE_PAYLOAD`, `SAMPLE_ISSUE_PAYLOAD_2`, `getRegistry`) all exist in the target files. ✓

--- a/docs/superpowers/specs/2026-07-10-exclude-enumeration-references-design.md
+++ b/docs/superpowers/specs/2026-07-10-exclude-enumeration-references-design.md
@@ -1,0 +1,150 @@
+# Exclude enumeration tools from reference extraction — design
+
+**Issue:** JOLLI-1921 — Linear `list_issues` / `search_issues` results are bulk-captured
+as references into Working Memory → Context.
+
+**Date:** 2026-07-10
+
+## Problem
+
+When an agent calls an MCP enumeration tool (`list_issues` / `search_issues`), the
+reference extractor walks the whole tool result and captures **every** returned
+issue as a reference. A single call floods the sidebar's **Working Memory →
+Context** with dozens of issues the user is not working on. A list/search
+enumeration is not the same as the user actively working on those entities.
+
+Two independent paths cause this:
+
+- **Claude path** — `SourceDefinitionRegistry.match("claude", …)` matches by
+  tool-name **prefix only**, so `mcp__…_Linear__list_issues` resolves to the
+  Linear definition exactly like `get_issue`. `walkPayload` (ReferenceExtractor)
+  then descends into the definition's `wrapperKeys` (`issues` / `results` / …)
+  and emits one `Reference` per array element.
+- **Codex Linear** — `linear.ts` declares `_list_issues` / `_search` (and their
+  dotted `linear.*` invocation forms) in `match.codex`. Per `CodexLinearBinding`,
+  these were added speculatively and their payload shape is **not verified live**.
+
+## Scope
+
+Fixed:
+
+- **Claude path** enumeration exclusion for **Linear** (the confirmed, reported
+  bug — real `linear.app` URLs; `list_issues` is a live connector tool this very
+  session). Linear matches by prefix and unwraps `issues`/`results`.
+- **Codex Linear** speculative `_list_issues` / `_search` recognition removed.
+
+Intentionally **not** changed:
+
+- **GitHub** — deferred to a fixture-first follow-up (same reasoning as Jira).
+  The final review surfaced that GitHub's Claude-path MCP tool names are **not
+  verified** anywhere in the codebase: the established canonical is
+  `mcp__github__issue_read` (13 uses), while `get_issue` / `list_issues` /
+  `search_issues` appeared only in newly-written test code. GitHub MCP matching
+  has always been prefix-only, so no real GitHub tool name was ever pinned, and
+  the GitHub definition also captures **pull requests** (`nativeId` regex matches
+  `(?:issues|pull)/\d+`), so `list_pull_requests` / `search_pull_requests` /
+  `list_sub_issues` would flood too. Shipping guessed deny suffixes risks being
+  a no-op (wrong names) or incomplete (PRs). Per the repo's real-fixture rule,
+  GitHub is deferred until a real GitHub MCP transcript confirms the actual tool
+  surface (issues **and** PRs).
+- **Codex GitHub `_search_issues`** — a verified, tested single-entity discovery
+  flow (search → `gh` shell backfill → dedupe into one rich reference; see
+  `CodexEnvelopeParser.test.ts` and the `CodexBinding` header). Left intact.
+- **Jira** — codex path is already single-entity-only (`_getjiraissue`). Its
+  Claude-path JQL-search tool name is not verified against a real transcript, so
+  no deny suffix is invented here (repo rule: real fixtures, not guesses). Left
+  as a follow-up once the tool name is confirmed.
+- **Notion** — already gated: `match.claude.acceptSuffix: "notion-fetch"` plus a
+  `metadata.type === "page"` guard. Enumeration (`notion-search`) never matches.
+
+## Design
+
+### 1. New schema primitive: `denySuffixes` on `MatchClaude`
+
+The Claude path matches by prefix, so exclusion cannot be expressed by "removing
+a name" (unlike Codex, which lists explicit tool names). Add a symmetric deny
+gate — the mirror of the existing `acceptSuffix`:
+
+```ts
+export interface MatchClaude {
+    readonly prefixes: ReadonlyArray<string>;
+    readonly acceptSuffix?: string;
+    /** After a prefix match, reject if the tool name ends with any of these.
+     *  Enumeration tools (list_issues / search_issues) bulk-capture their whole
+     *  result array, so they are excluded from reference extraction. */
+    readonly denySuffixes?: ReadonlyArray<string>;
+}
+```
+
+`SourceDefinitionRegistry.match("claude", toolName)` — after the prefix and
+`acceptSuffix` checks pass — additionally rejects when
+`denySuffixes.some((s) => toolName.endsWith(s))`. Matching by `endsWith` is
+consistent with `acceptSuffix`; false positives (a non-enumeration tool literally
+ending in `list_issues`) are not a concern for these connectors.
+
+`validateDefinition` does not deep-validate `match` today (per its own doc
+comment — `match`/`storage`/`render` are internal wiring for built-ins), so no
+validator change is required.
+
+### 2. `linear.ts`
+
+- Claude: `denySuffixes: ["list_issues", "search_issues"]`.
+- Codex: drop `_list_issues` / `_search` from `functionCallNames`; drop
+  `linear.list_issues` / `linear.search` from `invocationTools`. Leaves the
+  single-entity `_fetch` / `_get_issue` (and their invocation forms).
+
+### 3. `github.ts` — deferred
+
+Not changed (see Scope). GitHub enumeration exclusion is a follow-up that must
+start by capturing a real GitHub MCP transcript to verify the actual tool names
+(issues and PRs) before any deny suffix is added.
+
+### 4. Doc lockstep: `CodexLinearBinding.ts`
+
+Its header currently documents `_list_issues` / `_search` as recognized. Update
+it to state they are intentionally excluded to prevent Working Memory → Context
+flooding, so code and comment stay in lockstep.
+
+## Behavior after fix
+
+- Claude `mcp__…_Linear__list_issues` / `search_issues` → `match()` returns
+  `undefined` → `walkPayload` never runs → **0 references**.
+- Claude Linear `get_issue` → unchanged (1 reference).
+- Codex Linear `_list_issues` / `_search` → no longer match → 0 references.
+- Codex GitHub `_search_issues` → unchanged (discovery + dedupe intact).
+- GitHub Claude path → unchanged in this PR (deferred).
+
+Note: excluding list/search on the Claude path removes no *new* references beyond
+what single-entity fetches already produce — dedupe already merged a
+list-and-then-`get_issue` pair by `mapKey`. What it removes is the flood of
+*un-fetched* enumeration entries.
+
+## Testing
+
+- **Invert** the two current buggy-behavior tests in `ReferenceExtractor.test.ts`:
+  - `"extracts all issues from a list_issues array result…"` → now asserts 0
+    references.
+  - The list-then-`get_issue` dedupe test → repurpose to two `get_issue` calls
+    (the list line no longer contributes), keeping the "latest referencedAt wins"
+    assertion meaningful.
+- **Add** (ReferenceExtractor level): Claude Linear `list_issues` → 0 references;
+  `get_issue` still yields its reference (regression guard).
+- **`SourceDefinitionRegistry.test.ts`**: `match("claude", …_Linear__list_issues)`
+  / `…__search_issues` → `undefined`; Linear `…__get_issue` still resolves; codex
+  Linear `_list_issues` / `_search` no longer match.
+- Run the **whole** affected test files (no `-t` filter) — the source-definition
+  id ordering and match tables are exhaustive; a filtered run can mask a ripple.
+
+## Risks
+
+- Low. The change narrows matching; it cannot produce new references. The only
+  behavioral removal is the intended one (enumeration flooding). Codex GitHub
+  discovery and all single-entity fetches are preserved.
+- CLI coverage floor (97%) — the new `denySuffixes` branch and the Linear source
+  edit are covered by the added registry + extractor tests.
+
+## Follow-up (deferred)
+
+- **GitHub enumeration exclusion.** Capture a real GitHub MCP transcript to
+  confirm the actual Claude-path tool names for both issue and PR enumeration,
+  then apply the same `denySuffixes` gate. Do not guess the names.


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer fixed a reference-extraction bug where Linear's enumeration tools were bulk-capturing every returned issue into the Working Memory sidebar. A single tool call could flood the sidebar with dozens of unrelated issues the user was not actively working on. The fix adds a `denySuffixes` gate to the Claude match layer, allowing enumeration tools to be excluded from reference extraction while preserving single-entity fetches like `get_issue`. The change is confined to the reference-extraction subsystem and includes comprehensive test coverage verifying that enumeration tools now yield zero references while single-entity fetches continue to work. GitHub enumeration exclusion was deferred to a follow-up that must verify actual tool names against a real transcript first, following the repository's real-fixture rule.

---

## Topic (1)
<details>
<summary><strong>01 · Exclude Linear enumeration tools from reference extraction</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Linear's `list_issues` and `search_issues` tools were bulk-capturing every returned issue as a reference into the Working Memory sidebar, flooding it with dozens of unrelated issues the user was not actively working on. A single tool call could add 20+ references that had nothing to do with the user's current work.

**💡 Decisions Behind the Code**

- **Deny suffixes over allowlists**: The `denySuffixes` approach mirrors the existing `acceptSuffix` pattern and requires only a small, explicit list of enumeration tool names. An allowlist of single-entity tools would be fragile and harder to maintain as new tools are added to the MCP ecosystem.
- **Full exclusion rather than corroboration**: Single-entity fetch corroboration would be observably equivalent to full exclusion because dedupe already merges list-and-then-get pairs. Adding user-mention corroboration would require surfacing user text through the parser pipeline — a larger change. Full exclusion is the simplest, cleanest approach and removes the exact noise the issue describes.
- **Linear-only scope in this batch**: GitHub's Claude-path MCP tool names appeared only in newly-written test code and were never verified against a real GitHub transcript. GitHub also captures pull requests, so excluding only `list_issues` and `search_issues` would be incomplete. Per the repository's real-fixture rule, GitHub enumeration exclusion was descoped to a follow-up that must start with a real GitHub MCP transcript to confirm the actual tool surface before any deny suffix is added.

**✅ What Was Implemented**

- Added a `denySuffixes` field to the Claude match layer in `SourceDefinitionRegistry.ts`, allowing tool names to be rejected after prefix matching. The deny gate mirrors the existing `acceptSuffix` mechanism and is evaluated after prefix and accept-suffix checks pass.
- Updated `linear.ts` to exclude `list_issues` and `search_issues` on the Claude path via `denySuffixes`, while preserving single-entity tools like `_fetch` and `_get_issue`.
- Removed speculative Codex Linear `_list_issues` and `_search` recognition from `CodexLinearBinding.ts`, leaving only verified single-entity paths.
- Inverted two existing tests in `ReferenceExtractor.test.ts`: the `list_issues` test now asserts zero references instead of bulk-capture, and the dedupe test was repurposed to use two `get_issue` calls instead of list-then-get.

**📋 Future Enhancements**

Capture a real GitHub MCP transcript to confirm the actual Claude-path tool names for both issue and pull request enumeration, then apply the same `denySuffixes` gate to GitHub. Do not guess the names.

**📁 FILES**
- `cli/src/core/references/SourceDefinitionRegistry.ts`
- `cli/src/core/references/sources/definitions/linear.ts`
- `cli/src/core/references/sources/definitions/CodexLinearBinding.ts`
- `cli/src/core/references/ReferenceExtractor.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 10, 2026 at 6:27 PM · via Anthropic*
<!-- jollimemory-summary-end -->
