### PR TITLE
Refactor AI relevance layer from exclude list to full ranking with tiers

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -567,9 +567,36 @@ export interface CommitSummary {
 	 * CONTEXT items the AI relevance ranker judged unrelated to this commit and
 	 * soft-excluded — kept OUT of the summary prompt but recorded here for
 	 * traceability (CLI / sidebar can show "AI excluded N items + why"). Distinct
-	 * from user manual excludes, which are hard-discarded and never stored.
+	 * from user manual excludes, which are skipped from association but never
+	 * recorded on the summary.
 	 */
 	readonly excludedContext?: ReadonlyArray<ExcludedContextItem>;
+	/**
+	 * AI relevance tier + one-line reason for every KEPT context item, keyed by
+	 * (kind, key) onto `plans` / `notes` / `references`. Complements
+	 * `excludedContext` (the soft-excluded items): together they preserve the
+	 * full relevance picture the pre-commit panel showed. Absent on summaries
+	 * generated without a relevance ranking (no context, fail-open, or a
+	 * fingerprint-reuse from a selection file that predates this field) — the
+	 * display layers then fall back to plain title rows. Per-node like
+	 * `excludedContext` (each commit states its own judgment; NOT a
+	 * Consolidate-Hoist field).
+	 */
+	readonly contextRelevance?: ReadonlyArray<ContextRelevanceRef>;
+}
+
+/**
+ * AI relevance verdict for one KEPT context item on a commit summary. `key`
+ * matches the working-area identity: plan slug / note id / reference
+ * `<source>:<nativeId>` mapKey (NOT the shortHash-suffixed archivedKey —
+ * renderers match references via `${source}:${nativeId}`).
+ */
+export interface ContextRelevanceRef {
+	readonly kind: "plan" | "note" | "reference";
+	readonly key: string;
+	readonly tier: "high" | "mid" | "low";
+	/** One-line AI note on how the item relates to this change. */
+	readonly reason: string;
 }
 
 /**

--- a/cli/src/core/CommitSelectionStore.test.ts
+++ b/cli/src/core/CommitSelectionStore.test.ts
@@ -4,14 +4,15 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { JOLLI_DIR, JOLLIMEMORY_DIR } from "../Logger.js";
 import {
-	type AiExclusion,
+	type AiRelevanceEntry,
 	type CommitExclusions,
 	clearAiSelection,
 	conversationKey,
 	deleteSelectionFile,
+	dismissAiExclusion,
+	isEffectivelyExcluded,
 	readAiSelection,
 	readExclusions,
-	removeAiExclusion,
 	setAllExcluded,
 	setExcluded,
 	writeAiSelection,
@@ -262,50 +263,86 @@ describe("CommitSelectionStore", () => {
 });
 
 describe("CommitSelectionStore — AI relevance layer", () => {
+	const entry = (over: Partial<AiRelevanceEntry> = {}): AiRelevanceEntry => ({
+		kind: "plans",
+		key: "p1",
+		tier: "low",
+		reason: "unrelated",
+		excluded: true,
+		...over,
+	});
+
 	it("readAiSelection returns an empty layer when the file is missing", async () => {
 		const ai = await readAiSelection(cwd);
-		expect(ai.aiExcluded).toEqual([]);
+		expect(ai.aiRelevance).toEqual([]);
 		expect(ai.changeFingerprint).toBeUndefined();
 	});
 
-	it("writeAiSelection persists suggestions + fingerprint, readable via readAiSelection", async () => {
-		const ex: AiExclusion = { kind: "plans", key: "p1", reason: "unrelated" };
-		await writeAiSelection(cwd, [ex], "fp-abc");
+	it("writeAiSelection persists the full ranking + fingerprint, readable via readAiSelection", async () => {
+		const entries = [
+			entry({ kind: "plans", key: "p1", tier: "high", reason: "plan lists changed files", excluded: false }),
+			entry({
+				kind: "references",
+				key: "linear:X-1",
+				tier: "low",
+				reason: "different subsystem",
+				excluded: true,
+			}),
+		];
+		await writeAiSelection(cwd, entries, "fp-abc");
 		const ai = await readAiSelection(cwd);
-		expect(ai.aiExcluded).toEqual([ex]);
+		expect(ai.aiRelevance).toEqual(entries);
 		expect(ai.changeFingerprint).toBe("fp-abc");
 	});
 
 	it("writeAiSelection does not disturb the user manual exclude set", async () => {
 		await setExcluded(cwd, "plans", "manual", true);
-		await writeAiSelection(cwd, [{ kind: "notes", key: "n1", reason: "x" }], "fp");
+		await writeAiSelection(cwd, [entry({ kind: "notes", key: "n1" })], "fp");
 		const ex = await readExclusions(cwd);
 		expect(ex.plans.has("manual")).toBe(true);
-		expect((await readAiSelection(cwd)).aiExcluded).toHaveLength(1);
+		expect((await readAiSelection(cwd)).aiRelevance).toHaveLength(1);
 	});
 
-	it("removeAiExclusion drops one AI suggestion, preserving the rest + fingerprint", async () => {
+	it("dismissAiExclusion sets the dismissed flag IN PLACE — the AI's verdict survives", async () => {
 		await writeAiSelection(
 			cwd,
-			[
-				{ kind: "references", key: "linear:X-1", reason: "unrelated" },
-				{ kind: "plans", key: "p1", reason: "unrelated" },
-			],
+			[entry({ kind: "references", key: "linear:X-1" }), entry({ kind: "plans", key: "p1" })],
 			"fp-1",
 		);
-		await removeAiExclusion(cwd, "references", "linear:X-1");
+		await dismissAiExclusion(cwd, "references", "linear:X-1");
 		const ai = await readAiSelection(cwd);
-		expect(ai.aiExcluded).toEqual([{ kind: "plans", key: "p1", reason: "unrelated" }]);
+		// The entry is still there with its original tier + reason + excluded
+		// judgment; only the user's veto was added. The other entry + the
+		// fingerprint are untouched.
+		expect(ai.aiRelevance).toEqual([
+			entry({ kind: "references", key: "linear:X-1", dismissed: true }),
+			entry({ kind: "plans", key: "p1" }),
+		]);
 		expect(ai.changeFingerprint).toBe("fp-1");
+		expect(isEffectivelyExcluded(ai.aiRelevance[0])).toBe(false);
+		expect(isEffectivelyExcluded(ai.aiRelevance[1])).toBe(true);
+	});
+
+	it("dismissAiExclusion is idempotent and a harmless no-op for unknown keys / empty layer", async () => {
+		await setExcluded(cwd, "plans", "manual", true);
+		await dismissAiExclusion(cwd, "plans", "ghost");
+		expect((await readAiSelection(cwd)).aiRelevance).toEqual([]);
+		await writeAiSelection(cwd, [entry()], "fp");
+		await dismissAiExclusion(cwd, "plans", "p1");
+		await dismissAiExclusion(cwd, "plans", "p1");
+		expect((await readAiSelection(cwd)).aiRelevance).toEqual([entry({ dismissed: true })]);
+		expect((await readExclusions(cwd)).plans.has("manual")).toBe(true);
 	});
 
 	it("clearAiSelection wipes the AI layer but keeps the user manual excludes", async () => {
 		await setExcluded(cwd, "plans", "kept-exclude", true);
-		await writeAiSelection(cwd, [{ kind: "plans", key: "p1", reason: "unrelated" }], "fp-1");
+		await writeAiSelection(cwd, [entry()], "fp-1");
 		await clearAiSelection(cwd);
 		const ai = await readAiSelection(cwd);
-		expect(ai.aiExcluded).toEqual([]);
+		expect(ai.aiRelevance).toEqual([]);
 		expect(ai.changeFingerprint).toBeUndefined();
+		const raw = JSON.parse(await readFile(filePath(), "utf8"));
+		expect(raw.aiRelevance).toBeUndefined();
 		// The user's manual exclude survives — clearAiSelection only touches the AI layer.
 		expect((await readExclusions(cwd)).plans.has("kept-exclude")).toBe(true);
 	});
@@ -317,7 +354,13 @@ describe("CommitSelectionStore — AI relevance layer", () => {
 		expect(Object.keys(raw).sort()).toEqual(["conversations", "notes", "plans", "references", "version"]);
 	});
 
-	it("drops malformed aiSuggestedExclude entries on read", async () => {
+	it("writeAiSelection without a fingerprint clears any previously stored one", async () => {
+		await writeAiSelection(cwd, [entry()], "fp-old");
+		await writeAiSelection(cwd, [entry()]);
+		expect((await readAiSelection(cwd)).changeFingerprint).toBeUndefined();
+	});
+
+	it("coerces a non-array aiRelevance to empty on read", async () => {
 		await writeFile(
 			filePath(),
 			JSON.stringify({
@@ -326,21 +369,43 @@ describe("CommitSelectionStore — AI relevance layer", () => {
 				plans: [],
 				notes: [],
 				references: [],
-				aiSuggestedExclude: [
-					{ kind: "plans", key: "ok", score: 0.5, reason: "r" },
-					{ bad: true },
-					{ kind: "bogus", key: "x", score: 1, reason: "" },
+				aiRelevance: "garbage",
+			}),
+			"utf8",
+		);
+		expect((await readAiSelection(cwd)).aiRelevance).toEqual([]);
+	});
+
+	it("drops malformed aiRelevance entries on read (bad kind / tier / missing fields); a stray dismissed value coerces to absent", async () => {
+		await writeFile(
+			filePath(),
+			JSON.stringify({
+				version: 2,
+				conversations: [],
+				plans: [],
+				notes: [],
+				references: [],
+				aiRelevance: [
+					{ kind: "plans", key: "ok", tier: "high", reason: "r", excluded: false },
+					{ kind: "plans", key: "ok2", tier: "low", reason: "r", excluded: true, dismissed: true },
+					{ kind: "plans", key: "ok3", tier: "low", reason: "r", excluded: true, dismissed: "yes" },
+					{ kind: "bogus", key: "x", tier: "high", reason: "r", excluded: true },
+					{ kind: "notes", key: "n", tier: "extreme", reason: "r", excluded: true },
+					{ kind: "notes", key: "n2", tier: "low", reason: "r" },
+					"garbage",
+					null,
 				],
 			}),
 			"utf8",
 		);
-		expect((await readAiSelection(cwd)).aiExcluded).toEqual([
-			// A legacy `score` in the file is dropped on read (only kind/key/reason kept).
-			{ kind: "plans", key: "ok", reason: "r" },
+		expect((await readAiSelection(cwd)).aiRelevance).toEqual([
+			{ kind: "plans", key: "ok", tier: "high", reason: "r", excluded: false },
+			{ kind: "plans", key: "ok2", tier: "low", reason: "r", excluded: true, dismissed: true },
+			{ kind: "plans", key: "ok3", tier: "low", reason: "r", excluded: true },
 		]);
 	});
 
-	it("forward-compat: a v2 file with extra AI keys still yields the exclude sets; a legacy userIncluded key is ignored", async () => {
+	it("forward-compat: legacy userIncluded / aiSuggestedExclude / aiRelevanceResults keys are ignored", async () => {
 		await writeFile(
 			filePath(),
 			JSON.stringify({
@@ -350,7 +415,8 @@ describe("CommitSelectionStore — AI relevance layer", () => {
 				notes: [],
 				references: [],
 				userIncluded: { plans: ["kept"] },
-				aiSuggestedExclude: [{ kind: "plans", key: "p1", score: 0.1, reason: "x" }],
+				aiSuggestedExclude: [{ kind: "plans", key: "p1", reason: "x" }],
+				aiRelevanceResults: [{ kind: "plans", key: "p1", tier: "low", reason: "x" }],
 				changeFingerprint: "fp",
 			}),
 			"utf8",
@@ -358,10 +424,10 @@ describe("CommitSelectionStore — AI relevance layer", () => {
 		const ex = await readExclusions(cwd);
 		expect(ex.conversations.has("c1")).toBe(true);
 		expect(ex.plans.has("p1")).toBe(true);
-		// The legacy userIncluded key is dropped from the model (dismiss edits
-		// aiSuggestedExclude directly); readAiSelection surfaces only ai + fingerprint.
+		// The legacy two-list keys are dropped from the model — the AI layer reads
+		// empty (one fallback re-rank), while the fingerprint passes through.
 		const ai = await readAiSelection(cwd);
-		expect(ai.aiExcluded).toHaveLength(1);
+		expect(ai.aiRelevance).toEqual([]);
 		expect(ai.changeFingerprint).toBe("fp");
 	});
 });

--- a/cli/src/core/CommitSelectionStore.ts
+++ b/cli/src/core/CommitSelectionStore.ts
@@ -11,14 +11,16 @@
  *      (QueueWorker, PlansTreeProvider, SelectAllSelection) treat it as
  *      "user unchecked these" — do not change what it returns.
  *
- *   2. AI suggestion (`aiSuggestedExclude` + `changeFingerprint`) — the
- *      relevance ranker's soft-exclude list with a per-item reason, written
- *      by the pre-commit Review panel so the post-commit QueueWorker can reuse
- *      it when the fingerprint matches (otherwise QueueWorker recomputes). The
- *      user dismisses a single AI suggestion via `removeAiExclusion` (drops that
- *      entry so the item lands normally). There is NO separate "user include"
- *      layer — dismissing edits this list directly, so a dismiss is a per-change
- *      (non-persistent across a re-rank) override, which is the intended model.
+ *   2. AI relevance layer (`aiRelevance` + `changeFingerprint`) — the relevance
+ *      ranker's FULL per-item verdict list (tier + reason + the AI's exclude
+ *      decision, one entry per ranked item), written by the pre-commit Review
+ *      panel so the post-commit QueueWorker can reuse it when the fingerprint
+ *      matches (otherwise QueueWorker recomputes). The user vetoes a single AI
+ *      exclusion via `dismissAiExclusion`, which sets that entry's `dismissed`
+ *      flag — the AI's original judgment is never rewritten, so nothing is
+ *      lost. There is NO separate "user include" layer; a dismiss is a
+ *      per-change (non-persistent across a re-rank) override, which is the
+ *      intended model.
  *
  * Version stays at 2 ON PURPOSE. Bumping to 3 would make an older CLI/extension
  * reader (which hard-rejects unknown versions and returns an empty set) silently
@@ -28,17 +30,19 @@
  * fields are written only when non-empty so the file shape is unchanged for
  * users who never touch the AI-relevance feature.
  *
- * Sticky semantics: entries persist until explicitly changed by the user. The
- * QueueWorker only READS this file; it never writes AI results back here (it
- * writes the audit trail to CommitSummary.excludedContext instead), which keeps
- * a cross-process file lock unnecessary.
+ * Sticky semantics: entries persist until explicitly changed by the user (or
+ * consumed: the QueueWorker clears the AI layer post-commit via
+ * clearAiSelection; all writes serialize under withCommitSelectionLock).
  *
  * Schema versions (all read at version 2):
  *   - v1: { conversations, plans, notes } (references migrates to empty)
  *   - v2: + references
- *   - v2+ (this file): + optional aiSuggestedExclude / changeFingerprint.
- *         Transparent to older readers. (A legacy `userIncluded` key from an
- *         earlier build is ignored on read and dropped on the next write.)
+ *   - v2+ (this file): + optional aiRelevance / changeFingerprint.
+ *         Transparent to older readers. (Legacy `userIncluded` /
+ *         `aiSuggestedExclude` / `aiRelevanceResults` keys from earlier builds
+ *         of this in-development feature are ignored on read and dropped on the
+ *         next write — this file is a short-lived local relay, so the sole cost
+ *         is one fallback re-rank.)
  */
 
 import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
@@ -62,19 +66,46 @@ export interface CommitExclusions {
 	readonly references: ReadonlySet<string>;
 }
 
-/** One AI-suggested soft-exclusion with its reason (panel reuse by the worker). No
- *  score: the LLM's numeric score lives only in the panel's in-process relevanceCache
- *  (surfaced as the tier); the worker only needs kind/key/reason to reconstruct the
- *  exclude set, so persisting a score here was dead weight (always written as 0). */
-export interface AiExclusion {
+/**
+ * One ranked item's full AI relevance verdict — tier + one-line reason + the
+ * AI's soft-exclude decision. ONE list carries the whole ranking (kept and
+ * excluded alike), which removes the alignment/lifecycle drift an earlier
+ * two-list shape (separate exclude list + verdict list) suffered from. This is
+ * what lets the QueueWorker's fingerprint-reuse path rebuild the full decision
+ * — effective exclude set AND kept items' tier/reason for
+ * `CommitSummary.contextRelevance` — without re-running the LLM.
+ *
+ * Two independent facts, two fields, each with a single writer:
+ * - `excluded` — the AI's ORIGINAL judgment. Written once by the ranking,
+ *   never rewritten (a dismiss must not erase what the AI concluded).
+ * - `dismissed` — the user's veto of that exclusion (the panel/sidebar
+ *   "Include" / "+" action). Only meaningful when `excluded` is true.
+ * The effective exclude decision is `isEffectivelyExcluded` (excluded &&
+ * !dismissed). Nothing is ever lost: the AI's tier + reason survive a dismiss,
+ * and "AI suggested excluding this but the user kept it" stays reconstructable.
+ *
+ * No score: the LLM's numeric score is uncalibrated display noise; the
+ * rank-derived tier is the surfaced signal.
+ */
+export interface AiRelevanceEntry {
 	readonly kind: ExclusionKind;
 	readonly key: string;
+	readonly tier: "high" | "mid" | "low";
 	readonly reason: string;
+	/** The AI's original soft-exclude judgment — never rewritten. */
+	readonly excluded: boolean;
+	/** User veto of the exclusion (Include / "+"). Absent = false. */
+	readonly dismissed?: boolean;
+}
+
+/** The effective exclude decision: AI excluded it AND the user has not vetoed. */
+export function isEffectivelyExcluded(e: AiRelevanceEntry): boolean {
+	return e.excluded && e.dismissed !== true;
 }
 
 /** The AI-relevance layer read back for reuse by the QueueWorker / panel. */
 export interface AiSelection {
-	readonly aiExcluded: ReadonlyArray<AiExclusion>;
+	readonly aiRelevance: ReadonlyArray<AiRelevanceEntry>;
 	readonly changeFingerprint?: string;
 }
 
@@ -84,7 +115,7 @@ interface PersistedShape {
 	readonly notes: readonly string[];
 	readonly plans: readonly string[];
 	readonly references: readonly string[];
-	readonly aiSuggestedExclude?: readonly AiExclusion[];
+	readonly aiRelevance?: readonly AiRelevanceEntry[];
 	readonly changeFingerprint?: string;
 }
 
@@ -105,10 +136,11 @@ function asStringArray(v: unknown): readonly string[] {
 	return v.filter((x): x is string => typeof x === "string");
 }
 
-function asAiExclusions(v: unknown): readonly AiExclusion[] {
+function asAiRelevanceEntries(v: unknown): readonly AiRelevanceEntry[] {
 	if (!Array.isArray(v)) return [];
 	const kinds = new Set<ExclusionKind>(["conversations", "plans", "notes", "references"]);
-	const out: AiExclusion[] = [];
+	const tiers = new Set(["high", "mid", "low"]);
+	const out: AiRelevanceEntry[] = [];
 	for (const x of v) {
 		if (x === null || typeof x !== "object") continue;
 		const o = x as Record<string, unknown>;
@@ -116,10 +148,19 @@ function asAiExclusions(v: unknown): readonly AiExclusion[] {
 			typeof o.kind === "string" &&
 			kinds.has(o.kind as ExclusionKind) &&
 			typeof o.key === "string" &&
-			typeof o.reason === "string"
+			typeof o.tier === "string" &&
+			tiers.has(o.tier) &&
+			typeof o.reason === "string" &&
+			typeof o.excluded === "boolean"
 		) {
-			// Extract only kind/key/reason — a legacy `score` from an older file is dropped.
-			out.push({ kind: o.kind as ExclusionKind, key: o.key, reason: o.reason });
+			out.push({
+				kind: o.kind as ExclusionKind,
+				key: o.key,
+				tier: o.tier as AiRelevanceEntry["tier"],
+				reason: o.reason,
+				excluded: o.excluded,
+				...(o.dismissed === true ? { dismissed: true } : {}),
+			});
 		}
 	}
 	return out;
@@ -157,16 +198,18 @@ async function readPersisted(projectDir: string): Promise<PersistedShape> {
 		log.warn("readPersisted version mismatch (got %s) — ignoring file", String(parsed.version));
 		return empty;
 	}
-	// A legacy `userIncluded` key (from an earlier build) is intentionally not read
-	// — the dismiss model edits aiSuggestedExclude directly, so it's simply dropped
-	// on the next write.
+	// Legacy keys from earlier builds of this in-development feature —
+	// `userIncluded`, `aiSuggestedExclude`, `aiRelevanceResults` — are
+	// intentionally not read: this file is a short-lived local relay (cleared by
+	// the worker after each commit), so the sole cost is one fingerprint miss →
+	// one fallback re-rank. They're simply dropped on the next write.
 	return {
 		version: SELECTION_VERSION,
 		conversations: asStringArray(parsed.conversations),
 		notes: asStringArray(parsed.notes),
 		plans: asStringArray(parsed.plans),
 		references: asStringArray(parsed.references),
-		...(parsed.aiSuggestedExclude ? { aiSuggestedExclude: asAiExclusions(parsed.aiSuggestedExclude) } : {}),
+		...(parsed.aiRelevance ? { aiRelevance: asAiRelevanceEntries(parsed.aiRelevance) } : {}),
 		...(typeof parsed.changeFingerprint === "string" ? { changeFingerprint: parsed.changeFingerprint } : {}),
 	};
 }
@@ -182,11 +225,11 @@ export async function readExclusions(projectDir: string): Promise<CommitExclusio
 	};
 }
 
-/** Reads the AI-relevance layer (AI exclude suggestions + change fingerprint). */
+/** Reads the AI-relevance layer (the full per-item ranking + change fingerprint). */
 export async function readAiSelection(projectDir: string): Promise<AiSelection> {
 	const p = await readPersisted(projectDir);
 	return {
-		aiExcluded: p.aiSuggestedExclude ?? [],
+		aiRelevance: p.aiRelevance ?? [],
 		...(p.changeFingerprint !== undefined ? { changeFingerprint: p.changeFingerprint } : {}),
 	};
 }
@@ -200,9 +243,7 @@ function serializePersisted(p: PersistedShape): PersistedShape {
 		plans: p.plans,
 		notes: p.notes,
 		references: p.references,
-		...(p.aiSuggestedExclude && p.aiSuggestedExclude.length > 0
-			? { aiSuggestedExclude: p.aiSuggestedExclude }
-			: {}),
+		...(p.aiRelevance && p.aiRelevance.length > 0 ? { aiRelevance: p.aiRelevance } : {}),
 		...(p.changeFingerprint ? { changeFingerprint: p.changeFingerprint } : {}),
 	};
 }
@@ -280,52 +321,65 @@ export async function setAllExcluded(
 }
 
 /**
- * Dismisses one AI soft-exclude suggestion: removes the matching (kind, key) entry
- * from `aiSuggestedExclude` so the item lands normally in the summary. This is the
- * whole "user overrides the AI" mechanism — there is no separate persistent include
- * layer; the user edits the AI list directly. Preserves the rest of the list + the
- * change fingerprint so the QueueWorker's fingerprint reuse still holds.
+ * Records the user's veto of one AI soft-exclusion (the panel/sidebar "Include" /
+ * "+" action): sets `dismissed: true` on the matching (kind, key) entry so it is
+ * no longer EFFECTIVELY excluded, while the AI's original judgment — `excluded`,
+ * tier, reason — stays intact (nothing is lost; the item lands in the summary
+ * with its original verdict attached). There is no separate persistent include
+ * layer; the veto is a flag on the ranking itself. Idempotent; preserves the
+ * rest of the list + the change fingerprint so the QueueWorker's fingerprint
+ * reuse still holds.
  */
-export async function removeAiExclusion(projectDir: string, kind: ExclusionKind, key: string): Promise<void> {
+export async function dismissAiExclusion(projectDir: string, kind: ExclusionKind, key: string): Promise<void> {
 	return serialize(projectDir, async () => {
 		const p = await readPersisted(projectDir);
-		const filtered = (p.aiSuggestedExclude ?? []).filter((e) => !(e.kind === kind && e.key === key));
-		await writePersisted(projectDir, { ...p, aiSuggestedExclude: filtered });
+		const updated = (p.aiRelevance ?? []).map((e) =>
+			e.kind === kind && e.key === key ? { ...e, dismissed: true } : e,
+		);
+		await writePersisted(projectDir, { ...p, aiRelevance: updated });
 	});
 }
 
 /**
- * Writes the AI suggestion layer (soft-exclude list + change fingerprint) for the
- * QueueWorker to reuse when its fingerprint matches. Called by the pre-commit panel.
- * (The worker doesn't call THIS one, but it DOES clear the layer post-consume via
- * clearAiSelection — both go through withCommitSelectionLock.) Passing an empty list
- * and no fingerprint clears the layer.
+ * Writes the AI-relevance layer (the full per-item ranking + change fingerprint)
+ * for the QueueWorker to reuse when its fingerprint matches. Called by the
+ * pre-commit panel. (The worker doesn't call THIS one, but it DOES clear the
+ * layer post-consume via clearAiSelection — both go through
+ * withCommitSelectionLock.) Passing an empty list and no fingerprint clears the
+ * layer. Entries carry EVERY ranked item's tier + reason + exclude decision —
+ * the single source for both the effective exclude set and
+ * CommitSummary.contextRelevance on the reuse path.
  */
 export async function writeAiSelection(
 	projectDir: string,
-	aiExcluded: readonly AiExclusion[],
+	aiRelevance: readonly AiRelevanceEntry[],
 	changeFingerprint?: string,
 ): Promise<void> {
 	return serialize(projectDir, async () => {
 		const p = await readPersisted(projectDir);
 		await writePersisted(projectDir, {
 			...p,
-			aiSuggestedExclude: aiExcluded,
+			aiRelevance,
 			...(changeFingerprint !== undefined ? { changeFingerprint } : { changeFingerprint: undefined }),
 		});
 	});
 }
 
 /**
- * Clears the AI-relevance layer (aiSuggestedExclude + changeFingerprint) while keeping
- * the user manual exclude set. Called by the QueueWorker AFTER it consumes the ranking
- * for a commit, so a later commit over the SAME file set can't reuse a stale fingerprint
- * / exclude decision. Runs under withCommitSelectionLock via serialize.
+ * Clears the AI-relevance layer (aiRelevance + changeFingerprint) while keeping
+ * the user manual exclude set. Called by the QueueWorker AFTER it consumes the
+ * ranking for a commit, so a later commit over the SAME file set can't reuse a
+ * stale fingerprint / exclude decision. Runs under withCommitSelectionLock via
+ * serialize.
  */
 export async function clearAiSelection(projectDir: string): Promise<void> {
 	return serialize(projectDir, async () => {
 		const p = await readPersisted(projectDir);
-		await writePersisted(projectDir, { ...p, aiSuggestedExclude: [], changeFingerprint: undefined });
+		await writePersisted(projectDir, {
+			...p,
+			aiRelevance: [],
+			changeFingerprint: undefined,
+		});
 	});
 }
 

--- a/cli/src/core/ContextRelevance.test.ts
+++ b/cli/src/core/ContextRelevance.test.ts
@@ -11,12 +11,13 @@ import {
 	assessContextRelevance,
 	buildChangeBlock,
 	buildChangeSignal,
-	buildDecisionFromAiExcluded,
+	buildDecisionFromAiRelevance,
 	buildItemsBlock,
 	type ContextItem,
 	computeChangeFingerprint,
 	extractCandidateRepr,
 	extractSymbols,
+	keptContextRelevanceRefs,
 	parseRankContextResponse,
 	rankContextRelevance,
 	stripFrontmatter,
@@ -390,6 +391,80 @@ describe("assessContextRelevance", () => {
 		expect(decision.results).toEqual([]);
 		expect(decision.excludedContext).toEqual([]);
 	});
+
+	it("ranks notes and references too: kept ones land in their kind arrays with full results", async () => {
+		mockCallLlm.mockResolvedValue(
+			llmText(
+				[
+					"===ITEM===",
+					"index: 1",
+					"relevant: yes",
+					"score: 0.9",
+					"reason: note matches",
+					"===ITEM===",
+					"index: 2",
+					"relevant: yes",
+					"score: 0.8",
+					"reason: ref matches",
+				].join("\n"),
+			),
+		);
+		const note = {
+			id: "n1",
+			title: "N1",
+			format: "markdown",
+			sourcePath: "/x/n1.md",
+			addedAt: "",
+			updatedAt: "",
+			commitHash: null,
+		} as never;
+		const ref = { source: "linear", nativeId: "X-1", title: "Ref", sourcePath: "/x/r.md" } as never;
+		const decision = await assessContextRelevance(
+			{ plans: [], notes: [note], references: [ref] },
+			{ commitMessage: "m", changedFiles: ["a.ts"], symbols: [] },
+			config,
+		);
+		expect(decision.notes).toEqual([note]);
+		expect(decision.references).toEqual([ref]);
+		expect(decision.results.map((r) => `${r.kind}:${r.id}`)).toEqual(["note:n1", "reference:linear:X-1"]);
+	});
+
+	it("soft-excludes a bottom-ranked note into excludedContext with its note title", async () => {
+		mockCallLlm.mockResolvedValue(rankTwo());
+		const note = {
+			id: "n1",
+			title: "N1",
+			format: "markdown",
+			sourcePath: "/x/n1.md",
+			addedAt: "",
+			updatedAt: "",
+			commitHash: null,
+		} as never;
+		const decision = await assessContextRelevance(
+			{ plans: [planEntry("p1", "P1")], notes: [note], references: [] },
+			{ commitMessage: "m", changedFiles: ["a.ts"], symbols: [] },
+			config,
+		);
+		expect(decision.notes).toEqual([]);
+		expect(decision.excludedContext).toEqual([
+			{ kind: "note", key: "n1", title: "N1", reason: "unrelated", tier: "low" },
+		]);
+	});
+
+	it("soft-excludes a bottom-ranked reference with the nativeId-lead audit title", async () => {
+		mockCallLlm.mockResolvedValue(rankTwo());
+		const ref = { source: "linear", nativeId: "X-1", title: "Ref", sourcePath: "/x/r.md" } as never;
+		const decision = await assessContextRelevance(
+			{ plans: [planEntry("p1", "P1")], notes: [], references: [ref] },
+			{ commitMessage: "m", changedFiles: ["a.ts"], symbols: [] },
+			config,
+		);
+		expect(decision.references).toEqual([]);
+		expect(decision.excludedContext).toEqual([
+			// The reference's audit title carries the nativeId lead (sidebar label parity).
+			{ kind: "reference", key: "linear:X-1", title: "X-1 — Ref", reason: "unrelated", tier: "low" },
+		]);
+	});
 });
 
 describe("computeChangeFingerprint", () => {
@@ -410,15 +485,76 @@ describe("computeChangeFingerprint", () => {
 	});
 });
 
-describe("buildDecisionFromAiExcluded (worker reuse of the panel ranking)", () => {
+describe("buildDecisionFromAiRelevance (worker reuse of the panel ranking)", () => {
 	const pe = (slug: string, title: string) =>
 		({ slug, title, sourcePath: "", addedAt: "", updatedAt: "", commitHash: null }) as never;
+	const ne = (id: string, title: string) =>
+		({ id, title, format: "markdown", addedAt: "", updatedAt: "", commitHash: null }) as never;
 
-	it("excludes the AI-suggested keys and keeps the rest in registry order", () => {
+	it("routes items by the entries' exclude decision, keeping registry order", () => {
 		const raw = { plans: [pe("p1", "P1"), pe("p2", "P2")], notes: [], references: [] };
-		const decision = buildDecisionFromAiExcluded(raw, [{ kind: "plans", key: "p2", reason: "unrelated" }]);
+		const decision = buildDecisionFromAiRelevance(raw, [
+			{ kind: "plans", key: "p1", tier: "high", reason: "direct hit", excluded: false },
+			{ kind: "plans", key: "p2", tier: "low", reason: "unrelated", excluded: true },
+		]);
 		expect(decision.plans.map((p) => p.slug)).toEqual(["p1"]);
 		expect(decision.excludedContext).toEqual([{ kind: "plan", key: "p2", title: "P2", reason: "unrelated" }]);
+		expect(decision.results).toEqual([
+			{
+				id: "p1",
+				kind: "plan",
+				relevant: true,
+				score: 0,
+				tier: "high",
+				reason: "direct hit",
+				rank: 1,
+				autoExclude: false,
+			},
+			{
+				id: "p2",
+				kind: "plan",
+				relevant: false,
+				score: 0,
+				tier: "low",
+				reason: "unrelated",
+				rank: 2,
+				autoExclude: true,
+			},
+		]);
+	});
+
+	it("a dismissed exclusion lands KEPT with its ORIGINAL tier + reason (user veto, verdict preserved)", () => {
+		const raw = { plans: [], notes: [ne("n1", "N1")], references: [] };
+		const decision = buildDecisionFromAiRelevance(raw, [
+			{ kind: "notes", key: "n1", tier: "low", reason: "different subsystem", excluded: true, dismissed: true },
+		]);
+		// Not excluded (the veto wins) …
+		expect(decision.notes).toHaveLength(1);
+		expect(decision.excludedContext).toEqual([]);
+		// … and the AI's original verdict rides along, so the summary shows
+		// "Low · different subsystem" on the kept item (nothing is lost).
+		expect(decision.results).toEqual([
+			{
+				id: "n1",
+				kind: "note",
+				relevant: true,
+				score: 0,
+				tier: "low",
+				reason: "different subsystem",
+				rank: 1,
+				autoExclude: false,
+			},
+		]);
+		expect(keptContextRelevanceRefs(decision)).toEqual([
+			{ kind: "note", key: "n1", tier: "low", reason: "different subsystem" },
+		]);
+	});
+
+	it("items with no persisted entry are kept plain (no result entry)", () => {
+		const raw = { plans: [pe("p1", "P1")], notes: [], references: [] };
+		const decision = buildDecisionFromAiRelevance(raw, []);
+		expect(decision.plans).toHaveLength(1);
+		expect(decision.excludedContext).toEqual([]);
 		expect(decision.results).toEqual([]);
 	});
 
@@ -430,8 +566,8 @@ describe("buildDecisionFromAiExcluded (worker reuse of the panel ranking)", () =
 			sourcePath: "",
 		} as never;
 		const raw = { plans: [], notes: [], references: [ref] };
-		const decision = buildDecisionFromAiExcluded(raw, [
-			{ kind: "references", key: "linear:JOLLI-776", reason: "unrelated" },
+		const decision = buildDecisionFromAiRelevance(raw, [
+			{ kind: "references", key: "linear:JOLLI-776", tier: "low", reason: "unrelated", excluded: true },
 		]);
 		expect(decision.excludedContext).toEqual([
 			{
@@ -440,6 +576,20 @@ describe("buildDecisionFromAiExcluded (worker reuse of the panel ranking)", () =
 				title: "JOLLI-776 — JolliMemory: array-based",
 				reason: "unrelated",
 			},
+		]);
+		expect(decision.references).toEqual([]);
+	});
+
+	it("keptContextRelevanceRefs projects kept results only and drops empty-reason entries", () => {
+		const raw = { plans: [pe("p1", "P1"), pe("p2", "P2")], notes: [ne("n1", "N1")], references: [] };
+		const decision = buildDecisionFromAiRelevance(raw, [
+			{ kind: "plans", key: "p1", tier: "high", reason: "direct hit", excluded: false },
+			{ kind: "plans", key: "p2", tier: "low", reason: "unrelated", excluded: true },
+			// Fabricated fail-open shape (empty reason) must not reach the artifact.
+			{ kind: "notes", key: "n1", tier: "high", reason: "", excluded: false },
+		]);
+		expect(keptContextRelevanceRefs(decision)).toEqual([
+			{ kind: "plan", key: "p1", tier: "high", reason: "direct hit" },
 		]);
 	});
 });

--- a/cli/src/core/ContextRelevance.ts
+++ b/cli/src/core/ContextRelevance.ts
@@ -25,8 +25,15 @@
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { createLogger } from "../Logger.js";
-import type { ExcludedContextItem, LlmConfig, NoteEntry, PlanEntry, ReferenceEntry } from "../Types.js";
-import type { AiExclusion } from "./CommitSelectionStore.js";
+import type {
+	ContextRelevanceRef,
+	ExcludedContextItem,
+	LlmConfig,
+	NoteEntry,
+	PlanEntry,
+	ReferenceEntry,
+} from "../Types.js";
+import { type AiRelevanceEntry, isEffectivelyExcluded } from "./CommitSelectionStore.js";
 import { execGit, getDiffContent } from "./GitOps.js";
 import { callLlm } from "./LlmClient.js";
 import { toForwardSlash } from "./PathUtils.js";
@@ -562,10 +569,10 @@ async function readEntryContent(sourcePath: string | undefined, fallback: string
  * returns kept entries in relevance order plus the soft-excluded items for the
  * summary's `excludedContext`.
  *
- * Always recomputes: the panel's persisted aiSuggestedExclude drives pre-commit
- * display; fingerprint-based reuse here is a later optimization ("recompute is
- * the common case"). Never throws — rankContextRelevance fails open, so any
- * failure yields "keep everything, exclude nothing".
+ * Always recomputes: fingerprint-based reuse of the panel's persisted
+ * aiRelevance list lives in buildDecisionFromAiRelevance, not here. Never
+ * throws — rankContextRelevance fails open, so any failure yields "keep
+ * everything, exclude nothing".
  */
 export async function assessContextRelevance(
 	raw: RawContextEntries,
@@ -644,50 +651,96 @@ export async function assessContextRelevance(
 }
 
 /**
- * Reconstructs a decision from a previously-persisted AI suggestion. The pre-commit
- * panel writes `aiSuggestedExclude` + a change fingerprint (full-text ranking); the
- * QueueWorker reuses it here when the fingerprint matches, INSTEAD of re-running the
- * LLM — so the excluded set the user saw in the panel is exactly what lands, and the
- * common path costs only one LLM call. Registry order is kept (no re-ranking: the
- * authoritative match is the exclude SET; top-N ordering is secondary). A user who
- * dismissed an AI suggestion already had it removed from `aiExcluded` (the panel edits
- * that list directly), so there's no separate include set to apply here. Pure — no I/O.
+ * Projects a decision's per-item results into the summary-artifact shape: one
+ * `{kind, key, tier, reason}` entry per KEPT item (excluded items live on
+ * `excludedContext` instead — no duplication). This is what lands on
+ * `CommitSummary.contextRelevance`. Works for both ranking sources: a fresh
+ * `assessContextRelevance` (full results) and a fingerprint-reuse
+ * `buildDecisionFromAiRelevance` (results rebuilt from the persisted
+ * aiRelevance list; empty on legacy selection files → returns []).
+ *
+ * Empty-reason entries are dropped: the fail-open `keepAll` fallback fabricates
+ * `tier:"high", reason:""` for EVERY item when the ranking LLM fails, and a
+ * per-item LLM omission defaults to `reason:""` too — neither is a real
+ * verdict, and persisting them would stamp "all High" onto the artifact
+ * (contradicting the field's "absent on fail-open" contract) and render
+ * dangling `· ` separators.
  */
-export function buildDecisionFromAiExcluded(
+export function keptContextRelevanceRefs(decision: ContextRelevanceDecision): ContextRelevanceRef[] {
+	return decision.results
+		.filter((r) => !r.autoExclude && r.reason !== "")
+		.map((r) => ({ kind: r.kind, key: r.id, tier: r.tier, reason: r.reason }));
+}
+
+/**
+ * Reconstructs a decision from the previously-persisted AI ranking. The pre-commit
+ * panel writes the full per-item `aiRelevance` list + a change fingerprint
+ * (full-text ranking); the QueueWorker reuses it here when the fingerprint
+ * matches, INSTEAD of re-running the LLM — so what the user saw in the panel is
+ * exactly what lands, and the common path costs only one LLM call. Registry order
+ * is kept (no re-ranking: the authoritative data is the per-item entries; top-N
+ * ordering is secondary).
+ *
+ * Membership comes from `isEffectivelyExcluded`: the AI's original `excluded`
+ * judgment minus the user's `dismissed` veto. A dismissed entry therefore lands
+ * as a KEPT item carrying its ORIGINAL tier + reason (nothing the AI concluded
+ * is lost — display layers decide what to show). Items with no persisted entry
+ * (legacy file, or added after the ranking) get no result entry — the display
+ * layers fall back to plain title rows. Pure — no I/O.
+ */
+export function buildDecisionFromAiRelevance(
 	raw: RawContextEntries,
-	aiExcluded: readonly AiExclusion[],
+	aiRelevance: readonly AiRelevanceEntry[],
 ): ContextRelevanceDecision {
-	const reasonByKind = {
-		plans: new Map<string, string>(),
-		notes: new Map<string, string>(),
-		references: new Map<string, string>(),
+	const entryByKind = {
+		plans: new Map<string, AiRelevanceEntry>(),
+		notes: new Map<string, AiRelevanceEntry>(),
+		references: new Map<string, AiRelevanceEntry>(),
 	};
-	for (const e of aiExcluded) {
-		if (e.kind === "plans" || e.kind === "notes" || e.kind === "references")
-			reasonByKind[e.kind].set(e.key, e.reason);
+	for (const e of aiRelevance) {
+		if (e.kind === "plans" || e.kind === "notes" || e.kind === "references") entryByKind[e.kind].set(e.key, e);
 	}
 	const keptPlans: PlanEntry[] = [];
 	const keptNotes: NoteEntry[] = [];
 	const keptRefs: ReferenceEntry[] = [];
 	const excludedContext: ExcludedContextItem[] = [];
+	const results: ContextRelevanceResult[] = [];
+	// Reconstructed results carry no meaningful score/rank (those never persist);
+	// rank re-numbers in registry order purely to keep the field monotonic.
+	// Returns whether the item is EFFECTIVELY excluded so the caller can route it.
+	const pushResult = (kind: ContextKind, id: string, entry: AiRelevanceEntry | undefined): boolean => {
+		if (!entry) return false; // no persisted verdict for this item → kept, plain
+		const excluded = isEffectivelyExcluded(entry);
+		results.push({
+			id,
+			kind,
+			relevant: !excluded,
+			score: 0,
+			tier: entry.tier,
+			reason: entry.reason,
+			rank: results.length + 1,
+			autoExclude: excluded,
+		});
+		return excluded;
+	};
 	for (const p of raw.plans) {
-		const reason = reasonByKind.plans.get(p.slug);
-		if (reason !== undefined) {
-			excludedContext.push({ kind: "plan", key: p.slug, title: p.title, reason });
+		const entry = entryByKind.plans.get(p.slug);
+		if (pushResult("plan", p.slug, entry)) {
+			excludedContext.push({ kind: "plan", key: p.slug, title: p.title, reason: entry?.reason ?? "" });
 		} else keptPlans.push(p);
 	}
 	for (const n of raw.notes) {
-		const reason = reasonByKind.notes.get(n.id);
-		if (reason !== undefined) {
-			excludedContext.push({ kind: "note", key: n.id, title: n.title, reason });
+		const entry = entryByKind.notes.get(n.id);
+		if (pushResult("note", n.id, entry)) {
+			excludedContext.push({ kind: "note", key: n.id, title: n.title, reason: entry?.reason ?? "" });
 		} else keptNotes.push(n);
 	}
 	for (const r of raw.references) {
 		const key = referenceKey(r);
-		const reason = reasonByKind.references.get(key);
-		if (reason !== undefined) {
-			excludedContext.push({ kind: "reference", key, title: referenceLabel(r), reason });
+		const entry = entryByKind.references.get(key);
+		if (pushResult("reference", key, entry)) {
+			excludedContext.push({ kind: "reference", key, title: referenceLabel(r), reason: entry?.reason ?? "" });
 		} else keptRefs.push(r);
 	}
-	return { plans: keptPlans, notes: keptNotes, references: keptRefs, excludedContext, results: [] };
+	return { plans: keptPlans, notes: keptNotes, references: keptRefs, excludedContext, results };
 }

--- a/cli/src/core/JolliMemoryPushOrchestrator.ts
+++ b/cli/src/core/JolliMemoryPushOrchestrator.ts
@@ -388,7 +388,11 @@ export function buildPushMarkdown(summary: CommitSummary): string {
 	const lines: Array<string> = [];
 
 	pushPropertiesSection(lines, summary);
-	pushPlansAndNotesSection(lines, summary, { includeReferences: true });
+	// withRelevance: the pushed Jolli Space article shows the same relevance
+	// picture as every other summary surface (webview, clipboard, Memory Bank
+	// .md) — only PR bodies stay relevance-free. Without it the cli and vscode
+	// push paths would also diverge from each other.
+	pushPlansAndNotesSection(lines, summary, { includeReferences: true, withRelevance: true });
 	pushRecapSection(lines, summary);
 	pushE2eTestSection(lines, summary.e2eTestGuide);
 	pushSourceCommitsSection(lines, sourceNodes);

--- a/cli/src/core/MarkdownEscape.test.ts
+++ b/cli/src/core/MarkdownEscape.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { escHtml, escMdLinkText, escMdUrl } from "./MarkdownEscape.js";
+import { escHtml, escMdLinkText, escMdStrikeText, escMdUrl } from "./MarkdownEscape.js";
 
 describe("escHtml", () => {
 	it('escapes &, <, >, "', () => {
@@ -10,6 +10,17 @@ describe("escHtml", () => {
 describe("escMdLinkText", () => {
 	it("backslash-escapes brackets and folds newlines", () => {
 		expect(escMdLinkText("x](y)\nz")).toBe("x\\](y) z");
+	});
+});
+
+describe("escMdStrikeText", () => {
+	it("escapes tildes on top of the link-text set so `~~` can't close a strikethrough span", () => {
+		expect(escMdStrikeText("weird ~~title~~ [x]\ny")).toBe("weird \\~\\~title\\~\\~ \\[x\\] y");
+	});
+	it("escapes pre-existing backslashes in the same pass, so `\\~` input can't forge an escape", () => {
+		// Input `\~`: the backslash becomes `\\` and the tilde `\~` — the tilde's
+		// escaping backslash is always the one WE added, never attacker-supplied.
+		expect(escMdStrikeText("a\\~b")).toBe("a\\\\\\~b");
 	});
 });
 

--- a/cli/src/core/MarkdownEscape.ts
+++ b/cli/src/core/MarkdownEscape.ts
@@ -20,6 +20,20 @@ export function escMdLinkText(str: string): string {
 }
 
 /**
+ * Escapes text for safe use INSIDE a `~~…~~` strikethrough span: everything
+ * escMdLinkText covers PLUS `~`, so a literal `~~` in the text cannot close
+ * the span early. One single-pass character class with the backslash included
+ * — escaping `\` in the same pass as the characters we prefix with it is what
+ * keeps a pre-existing backslash from combining with an added `\~` into an
+ * ambiguous sequence. Kept separate from escMdLinkText on purpose: adding `~`
+ * there would change the output bytes of every existing consumer (PR bodies
+ * must stay byte-identical).
+ */
+export function escMdStrikeText(str: string): string {
+	return str.replace(/[\\[\]~]/g, "\\$&").replace(/[\r\n]+/g, " ");
+}
+
+/**
  * Escapes an untrusted URL for safe use inside a Markdown link target `(…)`.
  * Percent-encodes the structure-breaking characters (parens, whitespace,
  * angle brackets, quote) so a crafted URL cannot close the link early or be

--- a/cli/src/core/SummaryMarkdownBuilder.test.ts
+++ b/cli/src/core/SummaryMarkdownBuilder.test.ts
@@ -3,7 +3,6 @@ import type { CommitSummary, ReferenceCommitRef } from "../Types.js";
 import {
 	buildMarkdown,
 	buildReferencePushMarkdown,
-	pushExcludedContextSection,
 	pushFooter,
 	pushPlansAndNotesSection,
 	referencesBySourceOrder,
@@ -513,39 +512,113 @@ describe("pushPlansAndNotesSection references gating", () => {
 	});
 });
 
-describe("pushExcludedContextSection", () => {
-	it("renders nothing when there is no excluded context", () => {
+describe("pushPlansAndNotesSection withRelevance", () => {
+	const relevanceSummary = () =>
+		leaf({
+			plans: [
+				{
+					slug: "graph-plan-ab12cd34",
+					title: "Graph Plan",
+					addedAt: "2026-03-01T09:00:00.000Z",
+					updatedAt: "2026-03-01T09:30:00.000Z",
+				},
+			],
+			notes: [
+				{
+					id: "n1",
+					title: "Cursor Support",
+					format: "markdown",
+					addedAt: "2026-03-01T09:00:00.000Z",
+					updatedAt: "2026-03-01T09:30:00.000Z",
+				},
+			],
+			contextRelevance: [
+				// Working-area key (no archive hash suffix) — must still match the
+				// archived plan slug via the stripped-suffix fallback.
+				{ kind: "plan", key: "graph-plan", tier: "high", reason: "plan lists the changed files" },
+				{ kind: "note", key: "n1", tier: "mid", reason: "note touches adjacent module" },
+			],
+			excludedContext: [
+				{ kind: "note", key: "n2", title: "Unrelated Note", reason: "different subsystem" },
+				{ kind: "plan", key: "p9", title: "Old Plan", reason: "" },
+			],
+		});
+
+	it("adds tier + reason suffixes to kept rows (archive-suffix keys resolve)", () => {
 		const lines: string[] = [];
-		pushExcludedContextSection(lines, leaf());
-		expect(lines).toEqual([]);
+		pushPlansAndNotesSection(lines, relevanceSummary(), { withRelevance: true });
+		const out = lines.join("\n");
+		expect(out).toContain("- Graph Plan — High · plan lists the changed files");
+		expect(out).toContain("- Cursor Support — Med · note touches adjacent module");
 	});
-	it("renders a collapsed details block with items and reasons", () => {
+
+	it("inlines excluded items as struck-through read-only rows (reason optional)", () => {
 		const lines: string[] = [];
-		pushExcludedContextSection(
+		pushPlansAndNotesSection(lines, relevanceSummary(), { withRelevance: true });
+		const out = lines.join("\n");
+		expect(out).toContain("- ~~Unrelated Note~~ — Excluded · different subsystem");
+		expect(out).toContain("- ~~Old Plan~~ — Excluded");
+		expect(out).not.toContain("<details>");
+	});
+
+	it("renders the Context section for an excluded-only summary", () => {
+		const lines: string[] = [];
+		pushPlansAndNotesSection(
 			lines,
-			leaf({
-				excludedContext: [
-					{
-						kind: "note",
-						key: "n1",
-						title: "Cursor Support",
-						reason: "unrelated to graph change",
-					},
-					{ kind: "plan", key: "p1", title: "Backfill Plan", reason: "" },
-				],
-			}),
+			leaf({ excludedContext: [{ kind: "note", key: "n1", title: "T", reason: "r" }] }),
+			{ withRelevance: true },
 		);
 		const out = lines.join("\n");
-		expect(out).toContain("<details>");
-		expect(out).toContain("AI judged 2 context item(s) unrelated");
-		expect(out).toContain("- Cursor Support");
-		expect(out).toContain("— unrelated to graph change");
-		expect(out).toContain("- Backfill Plan");
-		expect(out).toContain("</details>");
+		expect(out).toContain("## Context");
+		expect(out).toContain("- ~~T~~ — Excluded · r");
 	});
-	it("buildMarkdown includes the excluded-context details block", () => {
-		const md = buildMarkdown(leaf({ excludedContext: [{ kind: "note", key: "n1", title: "T", reason: "r" }] }));
-		expect(md).toContain("AI judged 1 context item(s) unrelated");
+
+	it("omits relevance + excluded rows without the flag (PR-builder parity)", () => {
+		const lines: string[] = [];
+		pushPlansAndNotesSection(lines, relevanceSummary());
+		const out = lines.join("\n");
+		expect(out).toContain("- Graph Plan");
+		expect(out).not.toContain("High ·");
+		expect(out).not.toContain("Excluded");
+	});
+
+	it("kept rows without a persisted verdict render plain (legacy summaries)", () => {
+		const lines: string[] = [];
+		pushPlansAndNotesSection(lines, leaf({ notes: relevanceSummary().notes }), { withRelevance: true });
+		expect(lines.join("\n")).toContain("- Cursor Support");
+		expect(lines.join("\n")).not.toContain("·");
+	});
+
+	it("an empty-reason verdict renders no suffix (no dangling 'High · ')", () => {
+		const lines: string[] = [];
+		pushPlansAndNotesSection(
+			lines,
+			leaf({
+				notes: relevanceSummary().notes,
+				contextRelevance: [{ kind: "note", key: "n1", tier: "high", reason: "" }],
+			}),
+			{ withRelevance: true },
+		);
+		const out = lines.join("\n");
+		expect(out).toContain("- Cursor Support");
+		expect(out).not.toContain("High");
+		expect(out).not.toContain("·");
+	});
+
+	it("escapes tildes in an excluded title so `~~` inside it can't break the strikethrough", () => {
+		const lines: string[] = [];
+		pushPlansAndNotesSection(
+			lines,
+			leaf({ excludedContext: [{ kind: "note", key: "n1", title: "weird ~~title~~", reason: "r" }] }),
+			{ withRelevance: true },
+		);
+		expect(lines.join("\n")).toContain("- ~~weird \\~\\~title\\~\\~~~ — Excluded · r");
+	});
+
+	it("buildMarkdown shows the relevance picture (kept tiers + inlined excluded)", () => {
+		const md = buildMarkdown(relevanceSummary());
+		expect(md).toContain("- Graph Plan — High · plan lists the changed files");
+		expect(md).toContain("- ~~Unrelated Note~~ — Excluded · different subsystem");
 	});
 });
 

--- a/cli/src/core/SummaryMarkdownBuilder.ts
+++ b/cli/src/core/SummaryMarkdownBuilder.ts
@@ -7,7 +7,7 @@
  */
 
 import type { CommitSummary, E2eTestScenario, ReferenceCommitRef, SourceId } from "../Types.js";
-import { escMdLinkText, escMdUrl } from "./MarkdownEscape.js";
+import { escMdLinkText, escMdStrikeText, escMdUrl } from "./MarkdownEscape.js";
 import { referenceDisplayTitle } from "./references/ReferenceDisplay.js";
 import { getRegistry } from "./references/SourceDefinitionRegistry.js";
 import {
@@ -43,8 +43,11 @@ export function buildMarkdown(summary: CommitSummary): string {
 	const lines: Array<string> = [];
 
 	pushPropertiesSection(lines, summary);
-	pushPlansAndNotesSection(lines, summary);
-	pushExcludedContextSection(lines, summary);
+	// withRelevance: the memory/summary export shows the AI relevance picture —
+	// per-item tier+reason on kept rows plus the AI-excluded items inlined as
+	// read-only rows. PR builders call pushPlansAndNotesSection WITHOUT the flag
+	// so PR bodies keep their original, relevance-free Context section.
+	pushPlansAndNotesSection(lines, summary, { withRelevance: true });
 	pushRecapSection(lines, summary);
 	pushE2eTestSection(lines, summary.e2eTestGuide);
 	pushSourceCommitsSection(lines, sourceNodes);
@@ -150,6 +153,32 @@ export function referencesBySourceOrder(
 	return out;
 }
 
+/** Archive suffix on committed plan slugs / note ids (`slug-<hash8>`). Relevance
+ *  keys are working-area identities (pre-archive), so lookups try the exact key
+ *  first and then this stripped form. Mirrors QueueWorker's REF_HASH_SUFFIX. */
+const ARCHIVE_HASH_SUFFIX = /-[0-9a-f]{8}$/;
+
+/** Relevance lookup for one archived ref: exact key first (covers unarchived or
+ *  naturally-hex-ending working keys), then the archive-suffix-stripped base. */
+function lookupRelevance(
+	map: ReadonlyMap<string, { tier: "high" | "mid" | "low"; reason: string }>,
+	kind: "plan" | "note" | "reference",
+	key: string,
+): { tier: "high" | "mid" | "low"; reason: string } | undefined {
+	return map.get(`${kind}:${key}`) ?? map.get(`${kind}:${key.replace(ARCHIVE_HASH_SUFFIX, "")}`);
+}
+
+const TIER_LABEL = { high: "High", mid: "Med", low: "Low" } as const;
+
+/** ` — High · reason` suffix for a kept row; empty when the item has no verdict
+ *  (legacy summaries, fail-open runs). An empty reason (fabricated fail-open
+ *  verdict that slipped into an artifact) renders no suffix rather than a
+ *  dangling `High · `. */
+function relevanceSuffix(rel: { tier: "high" | "mid" | "low"; reason: string } | undefined): string {
+	if (!rel || rel.reason === "") return "";
+	return ` — ${TIER_LABEL[rel.tier]} · ${escMdLinkText(rel.reason)}`;
+}
+
 /**
  * Appends a combined Plans & Notes section — title + URL for each item.
  * External references (Linear/Jira/GitHub/Notion) are rendered only when
@@ -157,17 +186,32 @@ export function referencesBySourceOrder(
  * path leaves it off, so the *references* output is the only part that differs
  * between the two paths (plan/note titles are escaped on both). Exported so PR
  * builders reuse it.
+ *
+ * `opts.withRelevance` (memory/summary export only — PR builders leave it off)
+ * additionally renders the AI relevance picture: each kept row gains a
+ * ` — High/Med/Low · reason` suffix from `summary.contextRelevance`, and the
+ * AI-excluded items (`summary.excludedContext`) are inlined as read-only rows
+ * at the end (struck-through title + `Excluded` tag + reason, no links). This
+ * replaced the old collapsed `<details>` block so kept and excluded items read
+ * as one list.
  */
 export function pushPlansAndNotesSection(
 	lines: Array<string>,
 	summary: CommitSummary,
-	opts?: { includeReferences?: boolean },
+	opts?: { includeReferences?: boolean; withRelevance?: boolean },
 ): void {
 	const plans = summary.plans ?? [];
 	const notes = summary.notes ?? [];
 	const references: ReadonlyArray<ReferenceCommitRef> = opts?.includeReferences ? (summary.references ?? []) : [];
+	const excluded = opts?.withRelevance ? (summary.excludedContext ?? []) : [];
+	const relevanceMap = new Map<string, { tier: "high" | "mid" | "low"; reason: string }>();
+	if (opts?.withRelevance) {
+		for (const r of summary.contextRelevance ?? []) {
+			relevanceMap.set(`${r.kind}:${r.key}`, { tier: r.tier, reason: r.reason });
+		}
+	}
 	const totalCount = plans.length + notes.length + references.length;
-	if (totalCount === 0) {
+	if (totalCount === 0 && excluded.length === 0) {
 		return;
 	}
 	const countLabel = totalCount > 1 ? ` (${totalCount})` : "";
@@ -175,15 +219,19 @@ export function pushPlansAndNotesSection(
 
 	for (const plan of plans) {
 		const planUrl = plan.jolliPlanDocUrl;
+		const suffix = relevanceSuffix(lookupRelevance(relevanceMap, "plan", plan.slug));
 		lines.push(
-			planUrl ? `- [${escMdLinkText(plan.title)}](${escMdUrl(planUrl)})` : `- ${escMdLinkText(plan.title)}`,
+			(planUrl ? `- [${escMdLinkText(plan.title)}](${escMdUrl(planUrl)})` : `- ${escMdLinkText(plan.title)}`) +
+				suffix,
 		);
 	}
 
 	for (const note of notes) {
 		const noteUrl = note.jolliNoteDocUrl;
+		const suffix = relevanceSuffix(lookupRelevance(relevanceMap, "note", note.id));
 		lines.push(
-			noteUrl ? `- [${escMdLinkText(note.title)}](${escMdUrl(noteUrl)})` : `- ${escMdLinkText(note.title)}`,
+			(noteUrl ? `- [${escMdLinkText(note.title)}](${escMdUrl(noteUrl)})` : `- ${escMdLinkText(note.title)}`) +
+				suffix,
 		);
 	}
 
@@ -192,30 +240,18 @@ export function pushPlansAndNotesSection(
 		// reference hasn't been pushed (or the push failed) so the row is never dead.
 		const label = escMdLinkText(referenceDisplayTitle(e));
 		const target = e.jolliReferenceDocUrl ?? e.url;
-		lines.push(target ? `- [${label}](${escMdUrl(target)})` : `- ${label}`);
+		const suffix = relevanceSuffix(lookupRelevance(relevanceMap, "reference", `${e.source}:${e.nativeId}`));
+		lines.push((target ? `- [${label}](${escMdUrl(target)})` : `- ${label}`) + suffix);
 	}
-}
 
-/**
- * Appends the AI-excluded context as a collapsed <details> block: the CONTEXT
- * items the relevance ranker judged unrelated to this commit, each with its
- * reason. Renders nothing when there are no soft-excluded items. Kept separate
- * from the Context section so it still shows when the Context section is empty.
- */
-export function pushExcludedContextSection(lines: Array<string>, summary: CommitSummary): void {
-	const excluded = summary.excludedContext ?? [];
-	if (excluded.length === 0) return;
-	lines.push(
-		"",
-		"<details>",
-		`<summary>AI judged ${excluded.length} context item(s) unrelated (not included)</summary>`,
-		"",
-	);
+	// AI-excluded items, inlined read-only after the kept rows: struck-through
+	// title, an `Excluded` tag in place of a tier, and the AI's reason. No links
+	// — a soft-excluded item was never archived into this commit, so there is
+	// nothing to open. escMdStrikeText additionally escapes tildes so a literal
+	// `~~` inside the title can't close the strikethrough early.
 	for (const e of excluded) {
-		lines.push(`- ${escMdLinkText(e.title)}`);
-		if (e.reason) lines.push(`  — ${escMdLinkText(e.reason)}`);
+		lines.push(`- ~~${escMdStrikeText(e.title)}~~ — Excluded${e.reason ? ` · ${escMdLinkText(e.reason)}` : ""}`);
 	}
-	lines.push("", "</details>");
 }
 
 /**

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -535,7 +535,7 @@ describe("QueueWorker", () => {
 			topics: [{ title: "Test topic", trigger: "test", response: "done", decisions: "none" }],
 		});
 		vi.mocked(storeSummary).mockResolvedValue(undefined);
-		vi.mocked(readAiSelection).mockResolvedValue({ aiExcluded: [] });
+		vi.mocked(readAiSelection).mockResolvedValue({ aiRelevance: [] });
 		vi.mocked(clearAiSelection).mockResolvedValue(undefined);
 		vi.mocked(existsSync).mockReturnValue(false);
 		vi.mocked(readFileSync).mockReturnValue("");
@@ -2494,7 +2494,7 @@ describe("QueueWorker", () => {
 			// Persisted fingerprint matches this change → executePipeline takes the
 			// buildDecisionFromAiExcluded reuse arm and skips assessContextRelevance.
 			vi.mocked(readAiSelection).mockResolvedValueOnce({
-				aiExcluded: [],
+				aiRelevance: [],
 				changeFingerprint: computeChangeFingerprint(signal),
 			});
 			vi.mocked(assessContextRelevance).mockClear();
@@ -3684,6 +3684,120 @@ describe("QueueWorker", () => {
 			expect(storeSummary).toHaveBeenCalledTimes(1);
 			expect(vi.mocked(storeSummary).mock.calls[0][0].excludedContext).toEqual([
 				{ kind: "note", key: "n-x", title: "N", reason: "unrelated", tier: "low" },
+			]);
+		});
+
+		it("normal commit writes contextRelevance (kept items' tier+reason) onto the summary", async () => {
+			const op = makeCommitOp();
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/entry.json" }])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+			setupPipelineMocks();
+			vi.mocked(assessContextRelevance).mockResolvedValueOnce({
+				plans: [],
+				notes: [],
+				references: [],
+				excludedContext: [],
+				results: [
+					{
+						id: "p-kept",
+						kind: "plan",
+						relevant: true,
+						score: 0.9,
+						tier: "high",
+						reason: "plan covers the change",
+						rank: 1,
+						autoExclude: false,
+					},
+					{
+						id: "n-dropped",
+						kind: "note",
+						relevant: false,
+						score: 0.1,
+						tier: "low",
+						reason: "unrelated",
+						rank: 2,
+						autoExclude: true,
+					},
+				],
+			});
+
+			await runWorker("/test/cwd");
+
+			expect(storeSummary).toHaveBeenCalledTimes(1);
+			// Only the KEPT item's verdict lands on contextRelevance (excluded ones
+			// live on excludedContext instead).
+			expect(vi.mocked(storeSummary).mock.calls[0][0].contextRelevance).toEqual([
+				{ kind: "plan", key: "p-kept", tier: "high", reason: "plan covers the change" },
+			]);
+		});
+
+		it("fingerprint reuse writes contextRelevance from the persisted aiRelevanceResults (no LLM)", async () => {
+			const op = makeCommitOp();
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/entry.json" }])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+			setupPipelineMocks();
+			const signal = { commitMessage: "", changedFiles: ["src/file.ts"], symbols: [] as string[] };
+			vi.mocked(buildChangeSignal).mockResolvedValueOnce(signal);
+			// Matching fingerprint → the reuse arm runs (no LLM). This suite's
+			// default mocks detect no plans/notes/refs, so the meaningful assertion
+			// is the legacy-file shape: empty persisted results must yield NO
+			// contextRelevance field (not an empty array).
+			vi.mocked(readAiSelection).mockResolvedValueOnce({
+				aiRelevance: [],
+				changeFingerprint: computeChangeFingerprint(signal),
+			});
+			vi.mocked(assessContextRelevance).mockClear();
+
+			await runWorker("/test/cwd");
+
+			expect(storeSummary).toHaveBeenCalledTimes(1);
+			expect(assessContextRelevance).not.toHaveBeenCalled();
+			// Empty persisted results (legacy selection file) → no contextRelevance
+			// on the summary rather than a bogus empty array.
+			expect(vi.mocked(storeSummary).mock.calls[0][0].contextRelevance).toBeUndefined();
+		});
+
+		it("fingerprint reuse threads a persisted kept-item verdict onto summary.contextRelevance", async () => {
+			const op = makeCommitOp();
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/entry.json" }])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+			setupPipelineMocks();
+			// One detected working note; the panel's persisted layer carries its verdict.
+			vi.mocked(detectActiveNotesForBranch).mockResolvedValue([
+				{
+					id: "n-kept",
+					title: "Kept",
+					format: "snippet",
+					sourcePath: "/x/kept.md",
+					addedAt: "2026-04-01T00:00:00Z",
+					updatedAt: "2026-04-01T00:00:00Z",
+					commitHash: null,
+				} as never,
+			]);
+			const signal = { commitMessage: "", changedFiles: ["src/file.ts"], symbols: [] as string[] };
+			vi.mocked(buildChangeSignal).mockResolvedValueOnce(signal);
+			vi.mocked(readAiSelection).mockResolvedValueOnce({
+				aiRelevance: [
+					{ kind: "notes", key: "n-kept", tier: "high", reason: "note covers the change", excluded: false },
+				],
+				changeFingerprint: computeChangeFingerprint(signal),
+			});
+			vi.mocked(assessContextRelevance).mockClear();
+
+			await runWorker("/test/cwd");
+
+			expect(storeSummary).toHaveBeenCalledTimes(1);
+			expect(assessContextRelevance).not.toHaveBeenCalled();
+			// The panel's persisted verdict rides through buildDecisionFromAiExcluded
+			// onto the artifact — the reuse path's whole point.
+			expect(vi.mocked(storeSummary).mock.calls[0][0].contextRelevance).toEqual([
+				{ kind: "note", key: "n-kept", tier: "high", reason: "note covers the change" },
 			]);
 		});
 

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -25,8 +25,9 @@ import { clearAiSelection, conversationKey, readAiSelection, readExclusions } fr
 import {
 	assessContextRelevance,
 	buildChangeSignal,
-	buildDecisionFromAiExcluded,
+	buildDecisionFromAiRelevance,
 	computeChangeFingerprint,
+	keptContextRelevanceRefs,
 } from "../core/ContextRelevance.js";
 import { applyOverlaysToSessions, pruneConsumedOverlayRules } from "../core/ConversationOverlayStore.js";
 import { isCopilotChatInstalled } from "../core/CopilotChatDetector.js";
@@ -132,6 +133,7 @@ import {
 	type CommitSource,
 	type CommitSummary,
 	type CommitType,
+	type ContextRelevanceRef,
 	type ConversationTokenBreakdown,
 	CURRENT_SCHEMA_VERSION,
 	type DiffStats,
@@ -1718,6 +1720,7 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 	let activeNoteEntries = userKeptNotes;
 	let activeReferenceEntries = userKeptReferences;
 	let excludedContext: ReadonlyArray<ExcludedContextItem> = [];
+	let contextRelevance: ReadonlyArray<ContextRelevanceRef> = [];
 	try {
 		const changeSignal = await buildChangeSignal(commitInfo.message, `${op.commitHash}~1`, op.commitHash, cwd);
 		const raw = { plans: userKeptPlans, notes: userKeptNotes, references: userKeptReferences };
@@ -1729,12 +1732,17 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 		const fingerprint = computeChangeFingerprint(changeSignal);
 		const relevance =
 			aiSel.changeFingerprint === fingerprint
-				? buildDecisionFromAiExcluded(raw, aiSel.aiExcluded)
+				? buildDecisionFromAiRelevance(raw, aiSel.aiRelevance)
 				: await assessContextRelevance(raw, changeSignal, config);
 		activePlanEntries = [...relevance.plans];
 		activeNoteEntries = [...relevance.notes];
 		activeReferenceEntries = [...relevance.references];
 		excludedContext = relevance.excludedContext;
+		// Kept items' tier+reason for the summary artifact (a user-dismissed
+		// exclusion lands here with its ORIGINAL verdict attached). Empty when the
+		// reuse path read a legacy selection file with no aiRelevance — the summary
+		// then simply has no per-item relevance (display falls back).
+		contextRelevance = keptContextRelevanceRefs(relevance);
 	} catch (err) {
 		log.warn("Context relevance assessment failed (%s) — using all user-kept context", (err as Error).message);
 	}
@@ -1923,6 +1931,7 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 		...(noteRefs.length > 0 ? { notes: noteRefs } : {}),
 		...(referenceRefs.length > 0 ? { references: referenceRefs } : {}),
 		...(excludedContext.length > 0 ? { excludedContext } : {}),
+		...(contextRelevance.length > 0 ? { contextRelevance } : {}),
 		// v5 contract: `transcripts` is always present on a v5 root (empty array
 		// when no AI sessions were captured). Omitting the field would route the
 		// `getTranscriptIds` fast-path back through `collectAllTranscriptHashes`,
@@ -2368,6 +2377,10 @@ function mergeRefsNewWins<T>(
  * `excludedContext` is the AI soft-exclude audit, written only on the paths
  * that generate a new summary (full path / fresh leaf), mirroring the normal
  * commit pipeline; the short-circuit paths pass `[]`.
+ * `contextRelevance` is the kept items' tier+reason (same summary-generating
+ * paths; `[]` on short-circuit). Its keys are working-area identities (plan
+ * slug / note id without the archive hash suffix) — display layers match
+ * archived refs by exact key first, then by stripping REF_HASH_SUFFIX.
  */
 function buildHoistedAmendRoot(
 	// All three call sites are gated on `if (oldSummary)` so a non-undefined
@@ -2391,6 +2404,7 @@ function buildHoistedAmendRoot(
 		readonly references?: ReadonlyArray<ReferenceCommitRef>;
 	},
 	excludedContext?: ReadonlyArray<ExcludedContextItem>,
+	contextRelevance?: ReadonlyArray<ContextRelevanceRef>,
 ): CommitSummary {
 	// Old (hoisted) refs ∪ new refs, deduped by base key with new winning.
 	const hoistedMeta = hoistMetadataFromOldSummary(oldSummary);
@@ -2448,6 +2462,7 @@ function buildHoistedAmendRoot(
 		...(mergedNotes.length > 0 ? { notes: mergedNotes } : {}),
 		...(mergedReferences.length > 0 ? { references: mergedReferences } : {}),
 		...(auditedExclusions.length > 0 ? { excludedContext: auditedExclusions } : {}),
+		...((contextRelevance ?? []).length > 0 ? { contextRelevance } : {}),
 		topics: hoisted.topics,
 		/* v8 ignore next */
 		...(hoisted.recap && { recap: hoisted.recap }),
@@ -2782,6 +2797,7 @@ async function handleAmendPipeline(
 	let amendNoteEntries = userKeptAmendNotes;
 	let amendReferenceEntries = userKeptAmendRefs;
 	let amendExcludedContext: ReadonlyArray<ExcludedContextItem> = [];
+	let amendContextRelevance: ReadonlyArray<ContextRelevanceRef> = [];
 	try {
 		const amendChangeSignal = await buildChangeSignal(
 			commitInfo.message,
@@ -2798,6 +2814,9 @@ async function handleAmendPipeline(
 		amendNoteEntries = [...amendRelevance.notes];
 		amendReferenceEntries = [...amendRelevance.references];
 		amendExcludedContext = amendRelevance.excludedContext;
+		// Kept items' tier+reason for the amend summary artifact (amend always
+		// re-ranks fresh, so results are always populated on success).
+		amendContextRelevance = keptContextRelevanceRefs(amendRelevance);
 	} catch (err) {
 		log.warn("Amend context relevance failed (%s) — using all user-kept context", (err as Error).message);
 	}
@@ -3012,6 +3031,7 @@ async function handleAmendPipeline(
 			},
 			{ plans: consumed.planAssociation.refs, notes: consumed.noteRefs, references: consumed.referenceRefs },
 			amendExcludedContext,
+			amendContextRelevance,
 		);
 		await storeSummary(
 			root,
@@ -3077,6 +3097,7 @@ async function handleAmendPipeline(
 		// AI soft-exclude audit, mirroring the normal commit pipeline: this path
 		// generated a new summary, so record what the relevance layer set aside.
 		...(amendExcludedContext.length > 0 ? { excludedContext: amendExcludedContext } : {}),
+		...(amendContextRelevance.length > 0 ? { contextRelevance: amendContextRelevance } : {}),
 		// v5 contract: always present, even if empty. Fresh leaf has no
 		// inherited IDs; only the new delta (if any).
 		transcripts: amendDeltaTranscriptId !== undefined ? [amendDeltaTranscriptId] : [],

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -11,7 +11,7 @@ import { clearTimeout, setTimeout } from "node:timers";
 import * as vscode from "vscode";
 import {
 	conversationKey,
-	removeAiExclusion,
+	dismissAiExclusion,
 	setExcluded,
 } from "../../cli/src/core/CommitSelectionStore.js";
 import { discoverCodexConversations } from "../../cli/src/core/CodexDiscovery.js";
@@ -1252,14 +1252,24 @@ export function activate(context: vscode.ExtensionContext): void {
 			await plansProvider.refreshExclusions();
 		},
 		applyDismissAiExclude: async (kind, key) => {
-			// Map the single-form context kind to the plural ExclusionKind, then drop this
-			// entry from aiSuggestedExclude so the item lands normally (the worker's
-			// fingerprint reuse then honours the dismiss).
+			// Map the single-form context kind to the plural ExclusionKind, then set the
+			// entry's `dismissed` flag so it is no longer effectively excluded — the AI's
+			// original tier + reason stay intact and ride onto the summary with the kept
+			// item (the worker's fingerprint reuse honours the veto).
 			const k = kind === "plan" ? "plans" : kind === "note" ? "notes" : "references";
-			await removeAiExclusion(workspaceRoot, k, key);
+			await dismissAiExclusion(workspaceRoot, k, key);
 			// Reflect the dismiss in the memoized ranking (rather than invalidating it), so
 			// reopening the panel keeps the item included without a re-rank / "Analyzing…".
 			NextMemoryPreviewPanel.dismissInRelevanceCache(key);
+			// Mirror the post-dismiss overlay to BOTH surfaces. A dismiss can originate
+			// from either the Review panel or the sidebar, and only the originator
+			// updates itself optimistically — without this push the OTHER surface keeps
+			// its stale Excluded strikethrough indefinitely (no code path re-derives the
+			// overlay until the file selection changes or the panel reopens). The
+			// broadcast fan-out is safe here precisely because the panel does NOT post
+			// its own copy for dismisses: each surface receives exactly one update.
+			const items = NextMemoryPreviewPanel.getRelevanceCacheItems();
+			if (items) sidebarProvider.postMessage({ type: "context:relevance", items });
 			await plansProvider.refreshExclusions();
 		},
 		// Active Conversations source for the Branch tab (hoisted above so

--- a/vscode/src/views/NextMemoryPreviewPanel.test.ts
+++ b/vscode/src/views/NextMemoryPreviewPanel.test.ts
@@ -68,6 +68,7 @@ function makeSidebarProvider(overrides: Record<string, unknown> = {}) {
 		getPlansSnapshot: vi.fn().mockReturnValue([]),
 		getFilesSnapshot: vi.fn().mockReturnValue([]),
 		getConversationsSnapshot: vi.fn().mockResolvedValue([]),
+		pushContextRelevanceToSidebar: vi.fn(),
 		...overrides,
 	};
 }
@@ -450,16 +451,84 @@ describe("NextMemoryPreviewPanel — context relevance overlay", () => {
 			),
 		);
 		expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: "context:analyzing", analyzing: true }));
-		// Persisted for the post-commit worker to reuse.
-		expect(writeAiMock).toHaveBeenCalled();
+		// Persisted for the post-commit worker to reuse — ONE list carrying every
+		// item's full verdict (tier + reason + the AI's exclude decision).
+		expect(writeAiMock).toHaveBeenCalledWith(
+			"/repo",
+			[{ kind: "plans", key: "p1", tier: "low", reason: "unrelated", excluded: true }],
+			"fp",
+		);
+		// The overlay is mirrored to the sidebar (view-only push) so its CONTEXT
+		// rows strike through in sync.
+		expect(sidebar.pushContextRelevanceToSidebar).toHaveBeenCalledWith([
+			expect.objectContaining({ id: "p1", autoExclude: true }),
+		]);
+	});
+
+	it("does not persist fabricated empty-reason verdicts (fail-open keepAll)", async () => {
+		postMessage.mockClear();
+		writeAiMock.mockClear();
+		detectPlansMock.mockResolvedValue([{ slug: "p1", title: "P1" }]);
+		// keepAll shape: every item tier:"high", reason:"" — not a real verdict.
+		assessMock.mockResolvedValue({
+			plans: [{ slug: "p1", title: "P1" }],
+			notes: [],
+			references: [],
+			excludedContext: [],
+			results: [
+				{ id: "p1", kind: "plan", relevant: true, score: 0, tier: "high", reason: "", rank: 1, autoExclude: false },
+			],
+		});
+		const sidebar = makeSidebarProvider({
+			getFilesSnapshot: vi.fn().mockReturnValue([{ id: "f1", description: "src/a.ts", isSelected: true }]),
+		});
+		await openAndReady(makeBridge(), sidebar);
+		await vi.waitFor(() => expect(writeAiMock).toHaveBeenCalled());
+		// The fabricated empty-reason entries are filtered to nothing — the reuse
+		// path must not stamp "all High" onto the artifact.
+		expect(writeAiMock).toHaveBeenCalledWith("/repo", [], "fp");
+	});
+
+	it("getRelevanceCacheItems exposes the cached ranking; dismiss updates it in place", async () => {
+		postMessage.mockClear();
+		detectPlansMock.mockResolvedValue([{ slug: "p1", title: "P1" }]);
+		assessMock.mockResolvedValue({
+			plans: [],
+			notes: [],
+			references: [],
+			excludedContext: [{ kind: "plan", key: "p1", title: "P1", reason: "unrelated" }],
+			results: [
+				{ id: "p1", kind: "plan", relevant: false, score: 0.1, tier: "low", reason: "unrelated", rank: 1, autoExclude: true },
+			],
+		});
+		const sidebar = makeSidebarProvider({
+			getFilesSnapshot: vi.fn().mockReturnValue([{ id: "f1", description: "src/a.ts", isSelected: true }]),
+		});
+		await openAndReady(makeBridge(), sidebar);
+		await vi.waitFor(() =>
+			expect(NextMemoryPreviewPanel.getRelevanceCacheItems()).toEqual([
+				expect.objectContaining({ id: "p1", autoExclude: true }),
+			]),
+		);
+		// The host's dismiss handler reads this to re-push the post-dismiss
+		// overlay to both surfaces — it must reflect the dismissal immediately,
+		// with the AI's ORIGINAL tier + reason preserved (a dismiss vetoes only
+		// the exclude action, never the verdict).
+		NextMemoryPreviewPanel.dismissInRelevanceCache("p1");
+		expect(NextMemoryPreviewPanel.getRelevanceCacheItems()).toEqual([
+			{ id: "p1", tier: "low", reason: "unrelated", autoExclude: false },
+		]);
 	});
 
 	it("posts an empty context:relevance (no LLM) when no files are selected", async () => {
 		postMessage.mockClear();
 		assessMock.mockClear();
-		await openAndReady(makeBridge(), makeSidebarProvider());
+		const sidebar = makeSidebarProvider();
+		await openAndReady(makeBridge(), sidebar);
 		await vi.waitFor(() => expect(postMessage).toHaveBeenCalledWith({ type: "context:relevance", items: [] }));
 		expect(assessMock).not.toHaveBeenCalled();
+		// The sidebar overlay is cleared too.
+		expect(sidebar.pushContextRelevanceToSidebar).toHaveBeenCalledWith([]);
 	});
 
 	it("reuses the cached ranking on reopen (same files + items) — no second LLM call", async () => {
@@ -494,6 +563,11 @@ describe("NextMemoryPreviewPanel — context relevance overlay", () => {
 		);
 		expect(assessMock).not.toHaveBeenCalled();
 		expect(postMessage).not.toHaveBeenCalledWith(expect.objectContaining({ type: "context:analyzing", analyzing: true }));
+		// The cache-hit path mirrors to the sidebar too — a reopened panel must not
+		// leave the sidebar's strikethroughs stale.
+		expect(sidebar.pushContextRelevanceToSidebar).toHaveBeenCalledWith([
+			expect.objectContaining({ id: "p1", tier: "high" }),
+		]);
 	});
 
 	it("dismiss updates the cached ranking in place — reopen keeps it dismissed, no re-rank", async () => {

--- a/vscode/src/views/NextMemoryPreviewPanel.ts
+++ b/vscode/src/views/NextMemoryPreviewPanel.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 import type { ActiveConversationItem } from "../../../cli/src/core/ActiveSessionAggregator.js";
 import { sumConversationTokens } from "../../../cli/src/core/ConversationTokenTotals.js";
 import { assessContextRelevance, computeChangeFingerprint } from "../../../cli/src/core/ContextRelevance.js";
-import { type AiExclusion, readExclusions, writeAiSelection } from "../../../cli/src/core/CommitSelectionStore.js";
+import { type AiRelevanceEntry, readExclusions, writeAiSelection } from "../../../cli/src/core/CommitSelectionStore.js";
 import { getWorkingTreeDiffStats } from "../../../cli/src/core/GitOps.js";
 import {
 	detectActiveNotesForBranch,
@@ -27,6 +27,14 @@ interface SidebarBroadcastHost {
 	getPlansSnapshot(): ReadonlyArray<SerializedTreeItem>;
 	getFilesSnapshot(): ReadonlyArray<SerializedTreeItem>;
 	getConversationsSnapshot(): Promise<ReadonlyArray<ActiveConversationItem>>;
+	/**
+	 * Mirror the relevance overlay onto the sidebar's own view (NOT the broadcast
+	 * fan-out, which would echo it back to this panel). Keeps the sidebar's
+	 * CONTEXT strikethroughs in sync with the panel's Excluded rows.
+	 */
+	pushContextRelevanceToSidebar(
+		items: ReadonlyArray<{ readonly id: string; readonly autoExclude: boolean; readonly reason?: string }>,
+	): void;
 }
 
 let currentPanel: vscode.WebviewPanel | undefined;
@@ -380,11 +388,12 @@ export class NextMemoryPreviewPanel {
 	/**
 	 * Ranks CONTEXT relevance against the selected-file change set and pushes per-item
 	 * {tier, reason, autoExclude} for the overlay. AUTHORITATIVE: it reads full registry
-	 * content (like the QueueWorker) and PERSISTS the result (aiSuggestedExclude + a
-	 * file-based change fingerprint) so the post-commit worker reuses it verbatim when
-	 * the fingerprint matches — one ranking, panel == final. Best-effort: any failure
-	 * posts an empty overlay. No selected files → no change signal → empty (avoids
-	 * ranking against an empty signal, which would spuriously exclude everything).
+	 * content (like the QueueWorker) and PERSISTS the result (the full aiRelevance list
+	 * + a file-based change fingerprint) so the post-commit worker reuses it verbatim
+	 * when the fingerprint matches — one ranking, panel == final. Best-effort: any
+	 * failure posts an empty overlay. No selected files → no change signal → empty
+	 * (avoids ranking against an empty signal, which would spuriously exclude
+	 * everything).
 	 */
 	private static async pushContextRelevance(
 		webview: vscode.Webview,
@@ -403,6 +412,7 @@ export class NextMemoryPreviewPanel {
 			// overlay; leaving the stale cache is harmless (a different file set has a
 			// different key → miss → re-rank anyway).
 			void webview.postMessage({ type: "context:relevance", items: [] });
+			sidebarProvider.pushContextRelevanceToSidebar([]);
 			return;
 		}
 		try {
@@ -440,7 +450,10 @@ export class NextMemoryPreviewPanel {
 				].sort(),
 			].join("|");
 			if (relevanceCache && relevanceCache.key === itemsKey) {
-				if (!isStale()) void webview.postMessage({ type: "context:relevance", items: relevanceCache.items });
+				if (!isStale()) {
+					void webview.postMessage({ type: "context:relevance", items: relevanceCache.items });
+					sidebarProvider.pushContextRelevanceToSidebar(relevanceCache.items);
+				}
 				return;
 			}
 			// A newer refresh started while we read the registry — let it own the
@@ -451,16 +464,29 @@ export class NextMemoryPreviewPanel {
 			// Superseded during the (up-to-45s) LLM call → discard, so this stale file
 			// set's ranking can't clobber the newer result's cache/overlay/fingerprint.
 			if (isStale()) return;
-			const aiExcluded: AiExclusion[] = decision.excludedContext.map((e) => ({
-				kind: e.kind === "plan" ? "plans" : e.kind === "note" ? "notes" : "references",
-				key: e.key,
-				reason: e.reason,
-			}));
-			await writeAiSelection(workspaceRoot, aiExcluded, fingerprint);
+			// Persist EVERY item's full verdict (tier + reason + the AI's exclude
+			// decision) as ONE list: the post-commit worker's fingerprint-reuse path
+			// rebuilds both the effective exclude set and the kept items' relevance
+			// (CommitSummary.contextRelevance) from it without an LLM call.
+			// Empty-reason entries are NOT verdicts — the fail-open keepAll fallback
+			// fabricates tier:"high", reason:"" for every item — so they're dropped,
+			// mirroring keptContextRelevanceRefs, or the reuse path would stamp the
+			// fabricated "all High" onto the artifact. A fresh ranking carries no
+			// user veto — `dismissed` only ever appears via dismissAiExclusion.
+			const aiEntries: AiRelevanceEntry[] = decision.results
+				.filter((r) => r.reason !== "")
+				.map((r) => ({
+					kind: r.kind === "plan" ? "plans" : r.kind === "note" ? "notes" : "references",
+					key: r.id,
+					tier: r.tier,
+					reason: r.reason,
+					excluded: r.autoExclude,
+				}));
+			await writeAiSelection(workspaceRoot, aiEntries, fingerprint);
 			// autoExclude reflects the final exclude set (excludedContext). There's no
-			// persistent "kept" state: a dismiss just drops the item from that set
-			// (optimistically in the panel + persisted via removeAiExclusion), so it
-			// falls back to showing its normal tier.
+			// persistent "kept" state: a dismiss vetoes the exclusion (optimistically
+			// in the panel + persisted as a `dismissed` flag via dismissAiExclusion),
+			// so the item falls back to showing its original tier + note.
 			const excludedKeys = new Set(decision.excludedContext.map((e) => `${e.kind}:${e.key}`));
 			const items: ContextRelevancePreviewItem[] = decision.results.map((r) => ({
 				id: r.id,
@@ -475,8 +501,12 @@ export class NextMemoryPreviewPanel {
 			if (isStale()) return;
 			relevanceCache = { key: itemsKey, items };
 			void webview.postMessage({ type: "context:relevance", items });
+			sidebarProvider.pushContextRelevanceToSidebar(items);
 		} catch {
-			if (!isStale()) void webview.postMessage({ type: "context:relevance", items: [] });
+			if (!isStale()) {
+				void webview.postMessage({ type: "context:relevance", items: [] });
+				sidebarProvider.pushContextRelevanceToSidebar([]);
+			}
 		}
 	}
 
@@ -495,6 +525,12 @@ export class NextMemoryPreviewPanel {
 	 * dismissed item to non-excluded in place. Reopening the panel then hits the cache
 	 * (no re-rank, no "Analyzing…") AND preserves the dismiss, rather than re-ranking and
 	 * letting the AI re-exclude it.
+	 *
+	 * The tier + reason are deliberately KEPT: a dismiss vetoes only the exclude
+	 * action, not the AI's judgment — the item falls back to showing its original
+	 * tier + note (mirroring the persisted layer, where dismissAiExclusion sets a
+	 * flag and leaves the verdict intact, and the summary artifact, which records
+	 * the original verdict on the kept item).
 	 */
 	static dismissInRelevanceCache(key: string): void {
 		if (!relevanceCache) return;
@@ -502,5 +538,16 @@ export class NextMemoryPreviewPanel {
 			key: relevanceCache.key,
 			items: relevanceCache.items.map((it) => (it.id === key ? { ...it, autoExclude: false } : it)),
 		};
+	}
+
+	/**
+	 * Current cached ranking items (undefined when no ranking ran this session).
+	 * Used by the host's dismiss handler to re-push the post-dismiss overlay to
+	 * BOTH surfaces — without it, a dismiss from one surface leaves the other
+	 * showing the stale Excluded strikethrough indefinitely (neither webview
+	 * re-derives the overlay on its own; only a `context:relevance` push does).
+	 */
+	static getRelevanceCacheItems(): ReadonlyArray<ContextRelevancePreviewItem> | undefined {
+		return relevanceCache?.items;
 	}
 }

--- a/vscode/src/views/NextMemoryScriptBuilder.ts
+++ b/vscode/src/views/NextMemoryScriptBuilder.ts
@@ -344,16 +344,18 @@ export function buildNextMemoryScript(): string {
     // "+ Include" button — no 🗑 (removing an item the AI already dropped is
     // pointless) and no ✕ (the item is already out of the summary, so toggling it
     // changes nothing). Clicking Include dismisses the AI's exclude suggestion and
-    // brings the item back to its normal tier. A normal row keeps 🗑 + the ✕ exclude
-    // toggle. All sit in the hover overlay.
+    // brings the item back to its original tier + note. A normal row keeps 🗑 + the
+    // ✕ exclude toggle. All sit in the hover overlay.
     let actions;
     if (aiExcluded) {
       actions = [
         rowLabeledButton('codicon-add', 'Include', "Dismiss the AI's exclude suggestion", function() {
           vscode.postMessage({ type: 'branch:dismissAiExclude', kind: item.contextValue, key: item.id });
-          // Optimistic: drop it from the AI-excluded set so it immediately falls back
-          // to its normal tier — no persistent state. The host removes it from
-          // aiSuggestedExclude so the worker's fingerprint reuse honours the dismiss.
+          // Optimistic: a dismiss vetoes only the EXCLUDE ACTION, not the AI's
+          // judgment — the row falls back to its original tier + ✨ note (nothing
+          // the AI concluded is lost). The host persists the same veto as a
+          // dismissed-flag (dismissAiExclusion), keeps the verdict, and
+          // re-pushes context:relevance to both surfaces.
           relevanceById[item.id] = Object.assign({}, rel, { autoExclude: false });
           renderContext();
         }),

--- a/vscode/src/views/SidebarCssBuilder.ts
+++ b/vscode/src/views/SidebarCssBuilder.ts
@@ -1067,10 +1067,14 @@ export function buildSidebarCss(): string {
      Discard icon stacked over it, making it unclickable). */
   /* Excluded row: struck through + dimmed so "left out of this memory" reads
      at a glance. The label carries the line-through; the whole row dims. The
-     hover action overlay is exempted so its icons stay legible. */
-  .tree-node.excluded .label { text-decoration: line-through; }
-  .tree-node.excluded { opacity: 0.6; }
-  .tree-node.excluded:hover { opacity: 1; }
+     hover action overlay is exempted so its icons stay legible.
+     .ai-excluded is the AI soft-exclude axis (Review-panel relevance ranking),
+     deliberately identical in look — both mean "won't go into the next memory"
+     — but an independent class: it must never flow through isSelected /
+     .excluded, whose axis is the user's manual exclude. */
+  .tree-node.excluded .label, .tree-node.ai-excluded .label { text-decoration: line-through; }
+  .tree-node.excluded, .tree-node.ai-excluded { opacity: 0.6; }
+  .tree-node.excluded:hover, .tree-node.ai-excluded:hover { opacity: 1; }
   /* Twirl chevron that toggles evidence expansion — sits at the very left
      of the memory row (before the M icon). Vertically centered; cursor pointer
      since it is a toggle target, not a full-row action. */

--- a/vscode/src/views/SidebarMessages.ts
+++ b/vscode/src/views/SidebarMessages.ts
@@ -1053,6 +1053,24 @@ export type SidebarInboundMsg =
 	  }
 	| {
 			/**
+			 * AI context-relevance overlay for the Working Memory CONTEXT rows.
+			 * Pushed by the Review panel's relevance ranking (via the host) so the
+			 * sidebar strikes through AI soft-excluded items in sync with the
+			 * panel. In-memory only: it exists while the panel has ranked this
+			 * session; an empty `items` clears the overlay. `id` is the plan slug /
+			 * note id / reference mapKey (same key the row's data-id carries);
+			 * `reason` feeds the row's native tooltip. Extra fields the panel
+			 * includes for its own overlay (tier etc.) are ignored here.
+			 */
+			readonly type: "context:relevance";
+			readonly items: ReadonlyArray<{
+				readonly id: string;
+				readonly autoExclude: boolean;
+				readonly reason?: string;
+			}>;
+	  }
+	| {
+			/**
 			 * Aggregated LLM token usage across all committed summaries on the current
 			 * branch. Posted alongside `branch:commitsData` when at least one summary
 			 * carries token metadata. Drives the horizontal token-usage bar rendered

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -2449,10 +2449,11 @@ describe("SidebarScriptBuilder", () => {
 			const fnEnd = js.indexOf("function gitStatusToCodicon", fnStart);
 			const body = js.slice(fnStart, fnEnd);
 			// Plan / note / entity rows all route through the shared hover-card
-			// mouseover handler now, so the native title attribute is
-			// universally nulled — keeping it would surface a duplicate
-			// tooltip on an independent timer.
-			expect(body).toContain("title: null");
+			// mouseover handler now, so the native title attribute is nulled —
+			// keeping it would surface a duplicate tooltip on an independent
+			// timer. Sole exception (A+): an AI-excluded row carries the AI's
+			// one-line reason as its native tooltip; normal rows stay null.
+			expect(body).toContain("title: aiEx ? (aiReasonById[item.id] || null) : null");
 			expect(body).not.toContain("title: item.tooltip");
 		});
 
@@ -3375,6 +3376,51 @@ describe("SidebarScriptBuilder", () => {
 			// conditional child was null → replaceChildren stringified it to "null".
 			const js = buildSidebarScript();
 			expect(js).toMatch(/function mountIn\(container, nodes\)[\s\S]*?\.filter\(function\(n\)\s*\{\s*return n != null;/);
+		});
+	});
+
+	// AI context-relevance sync (Review panel → sidebar CONTEXT rows). The
+	// stateful bits live in the emitted script string; these pin the wiring so a
+	// regression (dropping the handler, conflating the AI axis with isSelected,
+	// or losing the stale-overlay clear) fails a test.
+	describe("AI relevance overlay wiring (source assertions)", () => {
+		it("handles context:relevance by rebuilding the AI-excluded id set (autoExclude only)", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("case 'context:relevance':");
+			expect(js).toContain("aiExcludedIds = new Set()");
+			expect(js).toContain("if (r.autoExclude)");
+			expect(js).toContain("aiExcludedIds.add(r.id)");
+		});
+		it("renderPlanRow strikes AI-excluded rows via an independent class + reason tooltip", () => {
+			const js = buildSidebarScript();
+			// The AI axis must NOT flow through isSelected — it's its own class...
+			expect(js).toContain("aiExcludedIds.has(item.id)");
+			expect(js).toContain("(aiEx ? ' ai-excluded' : '')");
+			// ...and the A+ tooltip carries the AI's one-line reason on struck rows only.
+			expect(js).toContain("title: aiEx ? (aiReasonById[item.id] || null) : null");
+		});
+		it("exclude toggle unifies both axes: struck rows offer +, clearing user AND AI excludes", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("row.classList.contains('ai-excluded')");
+			// Add-back dismisses the AI suggestion through the same round-trip the
+			// Review panel uses, so the worker's fingerprint reuse honors it.
+			expect(js).toContain("type: 'branch:dismissAiExclude'");
+			expect(js).toContain("kind: row.getAttribute('data-context')");
+			// The toggle's initial glyph reads both axes.
+			expect(js).toContain("excludeToggle(!!item.isSelected && !aiEx)");
+		});
+		it("clears the AI overlay when the file selection changes (stale-ranking guard)", () => {
+			const js = buildSidebarScript();
+			expect(js).toMatch(/branch:toggleFileSelection[\s\S]{0,900}?aiExcludedIds = new Set\(\)/);
+		});
+		it("clears the AI overlay when a summary run starts (worker consumed the ranking)", () => {
+			const js = buildSidebarScript();
+			expect(js).toMatch(/case 'worker:busy':[\s\S]{0,900}?aiExcludedIds = new Set\(\)/);
+		});
+		it("reason lookup uses a prototype-less object (a 'constructor' slug must not hit Object internals)", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("aiReasonById = Object.create(null)");
+			expect(js).not.toContain("aiReasonById = {}");
 		});
 	});
 });

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -822,6 +822,15 @@ export function buildSidebarScript(): string {
         // Memory "Summarizing <hash>…" row can name the commit being summarized.
         const nextHash = next ? (msg.commit || null) : null;
         if (state.workerBusy === next && state.summarizingHash === nextHash) break;
+        // A summary run starting means the QueueWorker is consuming (and then
+        // clearing) the persisted AI ranking — the overlay's verdicts are spent.
+        // Clear the strikethroughs so they don't linger on the still-working
+        // items after the commit (with the Review panel open, its post-commit
+        // refresh re-ranks and re-pushes a fresh overlay).
+        if (next && aiExcludedIds.size > 0) {
+          aiExcludedIds = new Set();
+          aiReasonById = Object.create(null);
+        }
         state.workerBusy = next;
         state.summarizingHash = nextHash;
         // Only the Branch tab reacts to workerBusy: the toolbar shows the
@@ -1044,6 +1053,20 @@ export function buildSidebarScript(): string {
       }
       case 'branch:plansData':
         branchData.plans = msg.items.slice();
+        if (state.activeTab === 'branch') renderBranch();
+        break;
+      case 'context:relevance':
+        // Wholesale replace: each push is a complete ranking for the current
+        // file set (an empty items list clears the overlay). Only autoExclude
+        // rows matter here — kept items' tiers are panel-only UI.
+        aiExcludedIds = new Set();
+        aiReasonById = Object.create(null);
+        (msg.items || []).forEach(function(r) {
+          if (r.autoExclude) {
+            aiExcludedIds.add(r.id);
+            if (r.reason) aiReasonById[r.id] = r.reason;
+          }
+        });
         if (state.activeTab === 'branch') renderBranch();
         break;
       case 'branch:changesData':
@@ -3397,6 +3420,18 @@ export function buildSidebarScript(): string {
 
   // ---- Branch tab renderer ----
   let branchData = { plans: [], changes: [], commits: [], commitsMode: 'empty', conversations: [], conversationsFailedSources: [] };
+  // AI context-relevance overlay (in-memory, session-scoped). Populated by the
+  // Review panel's ranking via the host's 'context:relevance' push; ids are the
+  // CONTEXT rows' data-id keys (plan slug / note id / reference mapKey). Rows in
+  // aiExcludedIds render struck-through + dimmed (same look as user excludes but
+  // an independent axis — user excludes live on item.isSelected). aiReasonById
+  // feeds the row's native tooltip. Cleared when the file selection changes (the
+  // ranking was computed against the old file set) and replaced wholesale on
+  // each push. A window reload drops it — the panel re-ranks on next open.
+  // Object.create(null): a plan slug like "constructor" must not hit a
+  // prototype-chain key and surface Object internals as a tooltip.
+  let aiExcludedIds = new Set();
+  let aiReasonById = Object.create(null);
   // How many committed memories are currently shown. Grows by COMMITS_PAGE each
   // time "Show N more" is clicked; reset to the page size whenever the commit
   // sequence changes (new branch / new commit) so a fresh list starts collapsed.
@@ -4266,19 +4301,29 @@ export function buildSidebarScript(): string {
     // Strikethrough-exclude toggle joins the hover action cluster (after the
     // trash Remove). Distinct from Remove: exclude just leaves the item out of
     // the next memory (reversible), Remove deletes the note/plan/reference.
-    planActions.push(excludeToggle(!!item.isSelected));
+    // The toggle's initial glyph reads BOTH strike axes (user exclude via
+    // isSelected, AI soft-exclude via aiExcludedIds): any struck row shows "+"
+    // (add back); only a fully-normal row shows the "✕" leave-out.
+    const aiEx = aiExcludedIds.has(item.id);
+    planActions.push(excludeToggle(!!item.isSelected && !aiEx));
     kids.push(el('span', { className: 'inline-actions' }, planActions));
     // Suppress the native title= on every row type that drives the .hover-card
     // popover (plan / note / reference — see the tabContents.branch mouseover
     // handler). A title= would surface a duplicate native tooltip showing the
     // MarkdownString-source plain text, and worse it would trigger on a
     // different timer than the card so the two tooltips would compete.
+    // Exception: an AI-excluded row carries the AI's one-line reason as its
+    // native tooltip — the sidebar shows no tier chips / inline notes, so this
+    // is the only place the "why" surfaces. The row is dimmed and struck, so the
+    // occasional overlap with the hover-card reads acceptably.
     return el('div', {
-      className: 'tree-node tree-node--hover-actions' + (item.isSelected ? '' : ' excluded'),
+      className: 'tree-node tree-node--hover-actions'
+        + (item.isSelected ? '' : ' excluded')
+        + (aiEx ? ' ai-excluded' : ''),
       'data-indent': String(depth),
       'data-context': item.contextValue || '',
       'data-id': item.id,
-      title: null,
+      title: aiEx ? (aiReasonById[item.id] || null) : null,
     }, kids);
   }
 
@@ -5564,18 +5609,55 @@ export function buildSidebarScript(): string {
     e.stopPropagation();
     const row = toggle.closest('.tree-node');
     if (!row) return;
-    const nowExcluded = row.classList.toggle('excluded');
-    const cb = row.querySelector('input[data-checkbox="1"]');
-    if (cb) {
-      cb.checked = !nowExcluded;
-      cb.dispatchEvent(new Event('change', { bubbles: true }));
+    // Unified two-axis semantics: a row struck by EITHER axis (user exclude via
+    // .excluded / AI soft-exclude via .ai-excluded) offers "+" = add back, which
+    // clears BOTH axes at once — the user's intent is "make this item normal
+    // again", not "flip one internal layer". An unstruck row offers "✕" = user
+    // leave-out (unchanged behavior; AI exclusion is never set from here).
+    const wasUser = row.classList.contains('excluded');
+    const wasAi = row.classList.contains('ai-excluded');
+    const struck = wasUser || wasAi;
+    if (struck) {
+      if (wasUser) {
+        // Restore the user axis through the hidden checkbox so the existing
+        // per-kind change handler posts the same toggle*Selection message.
+        row.classList.remove('excluded');
+        const cb = row.querySelector('input[data-checkbox="1"]');
+        if (cb) {
+          cb.checked = true;
+          cb.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+      }
+      if (wasAi) {
+        // Dismiss the AI suggestion: optimistic local clear + the same
+        // branch:dismissAiExclude round-trip the Review panel uses (host sets the
+        // entry's dismissed-flag via dismissAiExclusion — the AI's verdict is
+        // kept — so the worker's fingerprint reuse honors the veto).
+        row.classList.remove('ai-excluded');
+        row.removeAttribute('title');
+        const id = row.getAttribute('data-id');
+        aiExcludedIds.delete(id);
+        delete aiReasonById[id];
+        vscode.postMessage({
+          type: 'branch:dismissAiExclude',
+          kind: row.getAttribute('data-context'),
+          key: id,
+        });
+      }
+    } else {
+      row.classList.add('excluded');
+      const cb = row.querySelector('input[data-checkbox="1"]');
+      if (cb) {
+        cb.checked = false;
+        cb.dispatchEvent(new Event('change', { bubbles: true }));
+      }
     }
     const ic = toggle.querySelector('.codicon');
     if (ic) {
-      ic.classList.toggle('codicon-close', !nowExcluded);
-      ic.classList.toggle('codicon-add', nowExcluded);
+      ic.classList.toggle('codicon-close', struck);
+      ic.classList.toggle('codicon-add', !struck);
     }
-    toggle.setAttribute('aria-label', nowExcluded ? 'Add back to this memory' : 'Leave out of this memory');
+    toggle.setAttribute('aria-label', struck ? 'Leave out of this memory' : 'Add back to this memory');
   });
 
   // Squash confirm-bar actions (Select-all / Squash / Cancel). The bar lives in
@@ -5669,6 +5751,16 @@ export function buildSidebarScript(): string {
         filePath: filePath,
         selected: !!cb.checked,
       });
+      // The AI relevance overlay was ranked against the OLD file selection —
+      // clear it so no stale strikethrough lingers. With the Review panel open
+      // its debounced refresh re-ranks and re-pushes within ~400ms; with the
+      // panel closed the overlay stays cleared (correct: no ranking exists for
+      // the new file set).
+      if (aiExcludedIds.size > 0) {
+        aiExcludedIds = new Set();
+        aiReasonById = Object.create(null);
+        if (state.activeTab === 'branch') renderBranch();
+      }
     }
   });
 

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -192,6 +192,39 @@ describe("SidebarWebviewProvider", () => {
 		expect(executeCommand).toHaveBeenCalledWith("jollimemory.openSettings");
 	});
 
+	it("pushContextRelevanceToSidebar posts to the sidebar view ONLY — never to broadcast targets", () => {
+		const view = makeMockView();
+		provider.resolveWebviewView(view as unknown as never);
+		// A registered broadcast target (the Review panel) must NOT receive this
+		// push — the panel already posts context:relevance to its own webview, so
+		// fanning out would deliver a duplicate.
+		const target = { postMessage: vi.fn() };
+		provider.registerBroadcastTarget(target as never);
+		const items = [{ id: "p1", autoExclude: true, reason: "unrelated" }];
+		provider.pushContextRelevanceToSidebar(items);
+		expect(view.webview.postMessage).toHaveBeenCalledWith({ type: "context:relevance", items });
+		expect(target.postMessage).not.toHaveBeenCalled();
+	});
+
+	it("pushContextRelevanceToSidebar is a no-op before the view resolves", () => {
+		// No resolveWebviewView — must not throw.
+		expect(() => provider.pushContextRelevanceToSidebar([])).not.toThrow();
+	});
+
+	it("pushContextRelevanceToSidebar swallows a disposed view's webview-getter throw", () => {
+		// VS Code disposes hidden sidebar views; their `webview` getter then
+		// throws synchronously. That throw must not escape into the Review
+		// panel's relevance catch (which would wipe the panel's own overlay).
+		const view = makeMockView();
+		provider.resolveWebviewView(view as unknown as never);
+		Object.defineProperty(view, "webview", {
+			get() {
+				throw new Error("Webview is disposed");
+			},
+		});
+		expect(() => provider.pushContextRelevanceToSidebar([{ id: "p1", autoExclude: true }])).not.toThrow();
+	});
+
 	it("blocks a `command` message whose command is not a jollimemory.* command", () => {
 		const view = makeMockView();
 		provider.resolveWebviewView(view as unknown as never);

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -306,9 +306,10 @@ export interface SidebarWebviewDeps {
 		selected: boolean,
 	) => void | Promise<void>;
 	/**
-	 * Dismiss one AI soft-exclude suggestion — removes it from aiSuggestedExclude so
-	 * the item lands normally. `kind` is the single-form context kind; the handler
-	 * maps it to the plural ExclusionKind for removeAiExclusion.
+	 * Dismiss one AI soft-exclude suggestion — sets the entry's `dismissed` flag so
+	 * the item lands normally while the AI's original tier + reason survive. `kind`
+	 * is the single-form context kind; the handler maps it to the plural
+	 * ExclusionKind for dismissAiExclusion.
 	 */
 	applyDismissAiExclude?: (kind: "plan" | "note" | "reference", key: string) => void | Promise<void>;
 	/**
@@ -616,6 +617,31 @@ export class SidebarWebviewProvider
 		if (this.view) void this.view.webview.postMessage(msg);
 		for (const target of this.broadcastTargets) {
 			void target.postMessage(msg);
+		}
+	}
+
+	/**
+	 * Push the AI context-relevance overlay to the sidebar view ONLY — deliberately
+	 * NOT `postMessage`, whose broadcast fan-out would echo a second copy back to
+	 * the Review panel (the panel already posts `context:relevance` to its own
+	 * webview). Called by the panel after each ranking so the sidebar's CONTEXT
+	 * rows strike through AI soft-excluded items in sync. Empty `items` clears
+	 * the sidebar overlay.
+	 *
+	 * Best-effort by contract: `this.view` is never cleared on dispose, and a
+	 * hidden/disposed sidebar view's `webview` getter THROWS synchronously. The
+	 * try keeps that throw from escaping into the panel's relevance catch block,
+	 * which would wrongly post an empty overlay and wipe the panel's own
+	 * freshly-rendered chips.
+	 */
+	pushContextRelevanceToSidebar(
+		items: ReadonlyArray<{ readonly id: string; readonly autoExclude: boolean; readonly reason?: string }>,
+	): void {
+		try {
+			if (this.view) void this.view.webview.postMessage({ type: "context:relevance", items });
+		} catch {
+			// Disposed view — the sidebar will simply have no overlay until the
+			// panel's next push after the view re-resolves.
 		}
 	}
 

--- a/vscode/src/views/SummaryCssBuilder.ts
+++ b/vscode/src/views/SummaryCssBuilder.ts
@@ -399,11 +399,23 @@ export function buildCss(): string {
   .e2e-scenario .callout.steps .callout-label { color: var(--callout-response-label); }
   .e2e-scenario .callout.expectedResults { background: var(--callout-decisions-bg); }
   .e2e-scenario .callout.expectedResults .callout-label { color: var(--callout-decisions-label); }
-  .ai-excluded { margin: 6px 0 2px; }
-  .ai-excluded-summary { cursor: pointer; font-size: 12px; color: #8a63d2; user-select: none; padding: 4px 0; }
-  .ai-ex-list { margin: 4px 0 8px; padding-left: 18px; list-style: none; }
-  .ai-ex-item { font-size: 12.5px; color: var(--vscode-foreground); margin: 3px 0; }
-  .ai-ex-reason { color: var(--vscode-descriptionForeground); }
+  /* AI relevance meta line under a kept context row: tier chip + ✨ reason.
+     Chip colors mirror the Review panel's ctx-tier--* (green/amber/neutral),
+     restated with theme-safe rgba/vscode vars for this webview. */
+  .ctx-rel { display: flex; align-items: baseline; gap: 6px; margin-top: 2px; min-width: 0; }
+  .ctx-tier { flex-shrink: 0; font-size: 10px; font-weight: 650; letter-spacing: 0.02em; padding: 1px 7px; border-radius: 10px; }
+  .ctx-tier--high { background: rgba(27,138,79,0.16); color: var(--vscode-charts-green, #1b8a4f); }
+  .ctx-tier--mid { background: rgba(150,104,14,0.16); color: var(--vscode-charts-yellow, #96680e); }
+  .ctx-tier--low { background: var(--vscode-toolbar-hoverBackground); color: var(--vscode-descriptionForeground); }
+  .ctx-tier--ex { background: var(--vscode-toolbar-hoverBackground); color: var(--vscode-disabledForeground, var(--vscode-descriptionForeground)); }
+  .ai-say { flex: 1; min-width: 0; font-size: 11px; color: #8a63d2; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+  body.vscode-dark .ai-say, body.vscode-high-contrast .ai-say { color: #a99cf0; }
+  /* AI soft-excluded context item, inlined read-only after the kept rows:
+     dimmed + struck-through title, no hover actions (nothing to open — the
+     item was never archived into this commit). */
+  .ai-ex-row { opacity: 0.55; }
+  .ai-ex-row:hover { opacity: 1; }
+  .ai-ex-row .ai-ex-title { text-decoration: line-through; }
   .e2e-scenario .callout ol {
     margin: 0; padding-left: 1.4em;
   }

--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -1296,7 +1296,7 @@ describe("SummaryHtmlBuilder", () => {
 				expect(html).not.toContain('id="sourceCard"');
 			});
 
-			it("renders the AI-excluded context details when excludedContext is present", () => {
+			it("inlines an AI-excluded item as a read-only row (Excluded chip + reason, no actions)", () => {
 				const html = buildContextPanel(
 					makeSummary({
 						excludedContext: [
@@ -1304,14 +1304,71 @@ describe("SummaryHtmlBuilder", () => {
 						],
 					}),
 				);
-				expect(html).toContain("AI excluded 1 unrelated context item(s)");
+				// Inline row replaces the old collapsed "AI excluded N" details block.
+				expect(html).not.toContain("AI excluded 1 unrelated context item(s)");
+				expect(html).toContain('class="row plan-item ai-ex-row"');
 				expect(html).toContain("Cursor Support");
 				expect(html).toContain("unrelated to graph change");
+				expect(html).toContain('class="ctx-tier ctx-tier--ex"');
+				// Read-only: no preview link, no edit/remove actions on the row.
+				const row = html.slice(html.indexOf("ai-ex-row"), html.indexOf("snippet-form"));
+				expect(row).not.toContain("data-action=");
 			});
 
-			it("omits the AI-excluded details when there is no excludedContext", () => {
+			it("renders the Context section for an excluded-only summary (no kept rows)", () => {
+				const html = buildContextPanel(
+					makeSummary({
+						excludedContext: [{ kind: "plan", key: "p1", title: "Old Plan", reason: "different subsystem" }],
+					}),
+				);
+				expect(html).toContain("ai-ex-row");
+				expect(html).not.toContain("No plans or notes associated with this commit yet");
+			});
+
+			it("excluded reference rows derive their badge letter from the key's source segment", () => {
+				const html = buildContextPanel(
+					makeSummary({
+						excludedContext: [
+							{ kind: "reference", key: "linear:ENG-1", title: "ENG-1 — Fix", reason: "unrelated" },
+						],
+					}),
+				);
+				expect(html).toContain('class="kb-tag t-ref"');
+			});
+
+			it("omits AI rows entirely when there is no excludedContext", () => {
 				const html = buildContextPanel(makeSummary({ plans: [makePlan()] }));
-				expect(html).not.toContain("AI excluded");
+				expect(html).not.toContain("ai-ex-row");
+			});
+
+			it("kept rows show a tier chip + reason from contextRelevance (archive-suffix keys resolve)", () => {
+				const html = buildContextPanel(
+					makeSummary({
+						plans: [makePlan({ slug: "graph-plan-ab12cd34" })],
+						contextRelevance: [
+							// Working-area key (no archive suffix) still matches the archived slug.
+							{ kind: "plan", key: "graph-plan", tier: "high", reason: "plan lists the changed files" },
+						],
+					}),
+				);
+				expect(html).toContain('class="ctx-tier ctx-tier--high"');
+				expect(html).toContain("plan lists the changed files");
+			});
+
+			it("kept rows without a persisted verdict render no relevance line (legacy summaries)", () => {
+				const html = buildContextPanel(makeSummary({ plans: [makePlan()] }));
+				expect(html).not.toContain("ctx-rel");
+			});
+
+			it("an empty-reason verdict renders no relevance line (fabricated fail-open entry)", () => {
+				const html = buildContextPanel(
+					makeSummary({
+						plans: [makePlan()],
+						contextRelevance: [{ kind: "plan", key: "test-plan", tier: "high", reason: "" }],
+					}),
+				);
+				expect(html).not.toContain("ctx-rel");
+				expect(html).not.toContain("ctx-tier--high");
 			});
 		});
 

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -18,6 +18,7 @@ import {
 } from "../../../cli/src/core/SummaryTree.js";
 import type {
 	CommitSummary,
+	ContextRelevanceRef,
 	ConversationTokenBreakdown,
 	E2eTestScenario,
 	ExcludedContextItem,
@@ -743,25 +744,76 @@ export function contextChipCount(summary: CommitSummary): number {
  * affordance while dispatching through the same `data-action="toggleAddMenu"`
  * delegated handler (SummaryScriptBuilder) \u2014 no new script wiring needed.
  */
+/** Per-item AI relevance data threaded into buildPlansAndNotesSection: kept
+ *  items' tier+reason (`refs`) plus the soft-excluded items rendered as inline
+ *  read-only rows (`excluded`). Both optional — legacy summaries render plain
+ *  title rows. */
+export interface ContextRelevanceDisplay {
+	readonly refs?: ReadonlyArray<ContextRelevanceRef>;
+	readonly excluded?: ReadonlyArray<ExcludedContextItem>;
+}
+
+/** Archive suffix on committed plan slugs / note ids (`slug-<hash8>`). Relevance
+ *  keys are working-area identities (pre-archive), so lookups try the exact key
+ *  first, then this stripped form. Mirrors QueueWorker's REF_HASH_SUFFIX. */
+const ARCHIVE_HASH_SUFFIX = /-[0-9a-f]{8}$/;
+
+const TIER_LABEL = { high: "High", mid: "Med", low: "Low" } as const;
+const TIER_TIP = {
+	high: "High relevance to this change",
+	mid: "Medium relevance to this change",
+	low: "Low relevance to this change",
+} as const;
+
+function buildRelevanceLookup(refs: ReadonlyArray<ContextRelevanceRef> | undefined): Map<string, ContextRelevanceRef> {
+	const map = new Map<string, ContextRelevanceRef>();
+	for (const r of refs ?? []) map.set(`${r.kind}:${r.key}`, r);
+	return map;
+}
+
+function lookupRelevance(
+	map: ReadonlyMap<string, ContextRelevanceRef>,
+	kind: "plan" | "note" | "reference",
+	key: string,
+): ContextRelevanceRef | undefined {
+	return map.get(`${kind}:${key}`) ?? map.get(`${kind}:${key.replace(ARCHIVE_HASH_SUFFIX, "")}`);
+}
+
+/** Second meta line under a kept row's title: tier chip + the AI's one-line
+ *  reason. Empty string when the item has no persisted verdict — or when the
+ *  verdict carries an empty reason (a fabricated fail-open entry that slipped
+ *  into an artifact), which would otherwise render a chip + dangling ✨. */
+function buildRelevanceLine(rel: ContextRelevanceRef | undefined): string {
+	if (!rel || rel.reason === "") return "";
+	return `
+      <div class="ctx-rel"><span class="ctx-tier ctx-tier--${rel.tier}" title="${escAttr(TIER_TIP[rel.tier])}">${TIER_LABEL[rel.tier]}</span><span class="ai-say">&#x2728; ${escHtml(rel.reason)}</span></div>`;
+}
+
 /**
- * Renders the AI-excluded context as a native <details> disclosure (collapsed by
- * default; native <details> needs no script and is CSP-safe). Lists the CONTEXT
- * items the relevance ranker judged unrelated, each with its reason. Empty -> "".
+ * One inline READ-ONLY row for an AI soft-excluded context item: badge +
+ * struck-through title + `Excluded` chip + reason. Deliberately no preview /
+ * edit / remove actions and no title link — a soft-excluded item was never
+ * archived into this commit, so there is no snapshot to open. Rendered after
+ * the kept rows (replaces the old collapsed "AI excluded N" details block).
  */
-function buildExcludedContextSection(excluded: ReadonlyArray<ExcludedContextItem>): string {
-	if (excluded.length === 0) return "";
-	const items = excluded
-		.map((e) => {
-			const reason = e.reason ? ` <span class="ai-ex-reason">&mdash; ${escHtml(e.reason)}</span>` : "";
-			return `<li class="ai-ex-item"><span class="ai-ex-title">${escHtml(e.title)}</span>${reason}</li>`;
-		})
-		.join("\n");
-	return `<details class="ai-excluded">
-  <summary class="ai-excluded-summary">&#x2728; AI excluded ${excluded.length} unrelated context item(s)</summary>
-  <ul class="ai-ex-list">
-${items}
-  </ul>
-</details>`;
+function buildExcludedRow(e: ExcludedContextItem): string {
+	let tag = `<span class="kb-tag t-plan">P</span>`;
+	if (e.kind === "note") tag = `<span class="kb-tag t-note">N</span>`;
+	else if (e.kind === "reference") {
+		const source = e.key.includes(":") ? e.key.slice(0, e.key.indexOf(":")) : e.key;
+		tag = `<span class="kb-tag t-ref">${escHtml(getSourceMeta(source).letter)}</span>`;
+	}
+	const reason = e.reason
+		? `
+      <div class="ctx-rel"><span class="ctx-tier ctx-tier--ex" title="AI marked unrelated &mdash; excluded from the summary">Excluded</span><span class="ai-say">&#x2728; ${escHtml(e.reason)}</span></div>`
+		: "";
+	return `
+  <div class="row plan-item ai-ex-row">
+    ${tag}
+    <div class="r-main">
+      <span class="r-title ai-ex-title">${escHtml(e.title)}</span>${reason}
+    </div>
+  </div>`;
 }
 
 export function buildContextPanel(
@@ -777,6 +829,7 @@ export function buildContextPanel(
 		planTranslateSet,
 		noteTranslateSet,
 		referenceTranslateSet,
+		{ refs: summary.contextRelevance, excluded: summary.excludedContext },
 	);
 	const contextCount = contextChipCount(summary);
 	return `
@@ -794,7 +847,6 @@ export function buildContextPanel(
     </div>
   </div>
   ${plansAndNotesBody}
-  ${buildExcludedContextSection(summary.excludedContext ?? [])}
   <div class="snippet-form hidden" id="snippetForm">
     <div class="snippet-field">
       <label for="snippetTitle">Title</label>
@@ -991,6 +1043,7 @@ export function buildPlansAndNotesSection(
 	planTranslateSet?: ReadonlySet<string>,
 	noteTranslateSet?: ReadonlySet<string>,
 	referenceTranslateSet?: ReadonlySet<string>,
+	relevance?: ContextRelevanceDisplay,
 ): string {
 	const planList = plans ?? [];
 	const noteList = notes ?? [];
@@ -1000,6 +1053,8 @@ export function buildPlansAndNotesSection(
 	// practice.
 	/* v8 ignore next -- references is always defined by the buildHtml caller (see L139). */
 	const referenceList = references ?? [];
+	const relevanceMap = buildRelevanceLookup(relevance?.refs);
+	const excludedList = relevance?.excluded ?? [];
 	const totalCount = planList.length + noteList.length + referenceList.length;
 
 	const planItems = annotatePlans(planList)
@@ -1024,7 +1079,7 @@ export function buildPlansAndNotesSection(
     <span class="kb-tag t-plan">P</span>
     <div class="r-main">
       <a class="r-title plan-title plan-title-link" href="#" title="Click to preview" data-action="previewPlan" data-plan-slug="${key}" data-plan-title="${escAttr(p.title)}">${escHtml(p.title)}</a>${latestBadge}
-      <div class="plan-meta">${escHtml(key)}.md${jolliLink}</div>
+      <div class="plan-meta">${escHtml(key)}.md${jolliLink}</div>${buildRelevanceLine(lookupRelevance(relevanceMap, "plan", key))}
     </div>
     <span class="r-actions plan-header-actions">
       ${dateBadge}${translateBtn}<button class="icon-btn topic-action-btn plan-edit-btn" title="Edit Plan" data-plan-slug="${key}" data-action="loadPlanContent">&#x270E;</button>
@@ -1056,7 +1111,7 @@ export function buildPlansAndNotesSection(
     <span class="kb-tag t-note">N</span>
     <div class="r-main">
       <a class="r-title plan-title plan-title-link" href="#" title="Click to preview" data-action="previewNote" data-note-id="${escAttr(n.id)}" data-note-title="${escAttr(n.title)}">${escHtml(n.title)}</a>
-      ${noteMeta}
+      ${noteMeta}${buildRelevanceLine(lookupRelevance(relevanceMap, "note", n.id))}
     </div>
     <span class="r-actions plan-header-actions">
       ${noteTranslateBtn}<button class="icon-btn topic-action-btn plan-edit-btn" title="Edit Note" data-note-id="${escAttr(n.id)}" data-note-title="${escAttr(n.title)}" data-note-format="${n.format}" data-action="loadNoteContent">&#x270E;</button>
@@ -1080,10 +1135,17 @@ export function buildPlansAndNotesSection(
 	// commit. All sources share the same `*Reference` data-action names; the
 	// host dispatches by `data-reference-source`.
 	const referenceItems = referencesBySourceOrder(referenceList)
-		.map((e) => buildReferenceRow(e, referenceTranslateSet))
+		.map((e) =>
+			buildReferenceRow(e, referenceTranslateSet, lookupRelevance(relevanceMap, "reference", `${e.source}:${e.nativeId}`)),
+		)
 		.join("\n");
 
-	const allItems = planItems + noteItems + referenceItems;
+	// AI soft-excluded items, inlined read-only after the kept rows (the old
+	// collapsed "AI excluded N" details block is gone — one unified list).
+	const excludedItems = excludedList.map((e) => buildExcludedRow(e)).join("\n");
+
+	const allItems = planItems + noteItems + referenceItems + excludedItems;
+	const hasAnyRow = totalCount > 0 || excludedList.length > 0;
 	const countBadge =
 		totalCount > 1 ? ` <span class="section-count">${totalCount}</span>` : "";
 
@@ -1100,7 +1162,7 @@ export function buildPlansAndNotesSection(
   <div class="section-header">
     <div class="section-title">&#x1F4CB; CONTEXT${countBadge}</div>
   </div>
-  ${totalCount > 0 ? allItems : '<p class="e2e-placeholder">No plans or notes associated with this commit yet.</p>'}
+  ${hasAnyRow ? allItems : '<p class="e2e-placeholder">No plans or notes associated with this commit yet.</p>'}
 </div>
 <hr class="separator" />
 `;
@@ -1203,6 +1265,7 @@ function stripSourcePrefix(archivedKey: string, source: SourceId): string {
 function buildReferenceRow(
 	e: ReferenceCommitRef,
 	referenceTranslateSet?: ReadonlySet<string>,
+	relevance?: ContextRelevanceRef,
 ): string {
 	const sourceMeta = getSourceMeta(e.source);
 	const sourceLabel = sourceMeta.label;
@@ -1230,7 +1293,7 @@ function buildReferenceRow(
   <div class="row plan-item" id="reference-${escAttr(e.source)}-${escAttr(domKey)}">
     <span class="kb-tag t-ref">${escHtml(sourceLetter)}</span>
     <div class="r-main">
-      <a class="r-title plan-title plan-title-link" href="#" title="Click to preview" data-action="previewReference" data-reference-key="${escAttr(e.archivedKey)}" data-reference-source="${escAttr(e.source)}" data-reference-native-id="${escAttr(e.nativeId)}" data-reference-title="${escAttr(e.title)}">${escHtml(referenceDisplayTitle(e))}</a>${subLine}
+      <a class="r-title plan-title plan-title-link" href="#" title="Click to preview" data-action="previewReference" data-reference-key="${escAttr(e.archivedKey)}" data-reference-source="${escAttr(e.source)}" data-reference-native-id="${escAttr(e.nativeId)}" data-reference-title="${escAttr(e.title)}">${escHtml(referenceDisplayTitle(e))}</a>${subLine}${buildRelevanceLine(relevance)}
     </div>
     <span class="r-actions plan-header-actions">
       <button class="icon-btn topic-action-btn" title="Open in ${escAttr(sourceLabel)}" data-reference-key="${escAttr(e.archivedKey)}" data-reference-source="${escAttr(e.source)}" data-reference-url="${escAttr(e.url ?? "")}" data-action="openReferenceExternal">&#x1F30D;</button>

--- a/vscode/src/views/SummaryMarkdownBuilder.ts
+++ b/vscode/src/views/SummaryMarkdownBuilder.ts
@@ -51,7 +51,10 @@ export function buildMarkdown(summary: CommitSummary): string {
 	const lines: Array<string> = [];
 
 	pushPropertiesSection(lines, summary);
-	pushPlansAndNotesSection(lines, summary, { includeReferences: true });
+	// withRelevance keeps the exported markdown consistent with what the summary
+	// webview SHOWS (tier chips + inlined AI-excluded rows) — "what you copy is
+	// what you saw". PR bodies stay relevance-free via their own builders.
+	pushPlansAndNotesSection(lines, summary, { includeReferences: true, withRelevance: true });
 	pushRecapSection(lines, summary);
 	pushE2eTestSection(lines, summary.e2eTestGuide);
 	pushSourceCommitsSection(lines, sourceNodes);

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -1487,6 +1487,10 @@ export class SummaryWebviewPanel {
 				this.planTranslateSet,
 				this.noteTranslateSet,
 				this.referenceTranslateSet,
+				// Keep the AI relevance rows across in-place section refreshes —
+				// without this the tier chips + inlined excluded rows would vanish
+				// after any plan/note/reference mutation re-render.
+				{ refs: summary.contextRelevance, excluded: summary.excludedContext },
 			),
 			// The visible "CONTEXT N" chip lives in #contextPanel's panel-header
 			// (buildContextPanel), OUTSIDE the #plansAndNotesSection HTML above —


### PR DESCRIPTION
<!-- jollimemory-summary-start -->


## Quick recap

The commit introduced two interconnected features that together give users a complete picture of the AI's context relevance judgment — both in the Review panel and in the persistent commit summary record.

The sidebar's context list now reflects the Review panel's AI analysis in real time. When the Review panel marks a context item as unrelated to the current change, the corresponding row in the sidebar immediately gains a strikethrough and a tooltip explaining the AI's reasoning. Users can restore any struck item directly from the sidebar using the same "+" button that was already there, and the action propagates back to the Review panel without requiring a panel switch. The overlay clears automatically when the file selection changes or when a commit starts, preventing stale judgments from lingering.

Commit summaries now record the AI's full relevance verdict for every context item. Kept items display a tier rating (High, Medium, or Low) and a one-line explanation alongside their title. Items the AI considered unrelated appear as inline read-only rows in the same context list rather than being hidden in a collapsed section, giving a unified view of what was included and what was set aside. This information is written into the persistent summary record and survives across sessions, so the AI's reasoning is available whenever the summary is reviewed later. The underlying storage layer was also redesigned so that when a user overrides the AI's exclusion judgment, the AI's original tier and reason are preserved in the record rather than erased.

---

## Topics (3)
<details>
<summary><strong>01 · AI relevance ranking refactored from exclude-only list to full per-item verdict storage</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The existing storage layer only saved which items the AI had excluded, discarding tier and reason data for kept items. This made it impossible to show relevance information on kept context items in commit summaries, and caused the "user include" dismiss action to lose the AI's original judgment entirely.

**💡 Decisions Behind the Code**

- **Single list over two parallel lists**: An earlier design used separate `aiSuggestedExclude` and `aiRelevanceResults` lists that had to stay aligned by `(kind, key)`. Keeping them in sync across dismiss operations and lifecycle events (clear, reuse, partial updates) was identified as the root cause of data-loss bugs. Merging into one list with two independent boolean fields (`excluded`, `dismissed`) eliminates the alignment problem entirely and makes the dismiss operation idempotent with zero data loss.
- **Preserve AI verdict on user dismiss**: The user debated whether dismissing an item should erase the AI's tier and reason (cleaner display) or keep them (zero data loss, future display flexibility). Keeping the verdict was chosen: the summary artifact records "AI judged this Low but the user kept it," which is more informative than a blank row, and display layers can always choose not to show the verdict later without needing to re-run the LLM.
- **Legacy key compatibility via silent fallback**: The old `aiSuggestedExclude` and `aiRelevanceResults` keys are silently dropped on read rather than migrated, because the selection file is a short-lived local relay cleared after each commit. The only cost of an unreadable legacy file is one extra LLM call on the next commit, which was judged acceptable over the complexity of a migration path.

**✅ What Was Implemented**

- `CommitSelectionStore` was redesigned around a single `AiRelevanceEntry` list replacing the old two-list shape (`aiSuggestedExclude` + a separate results list). Each entry now carries `tier`, `reason`, `excluded` (the AI's original judgment, never rewritten), and an optional `dismissed` flag (the user's veto). The `dismissAiExclusion` function sets the flag in place rather than deleting the entry, so the AI's verdict survives a user "Include" action. `isEffectivelyExcluded` encapsulates the combined decision.
- `buildDecisionFromAiExcluded` was renamed `buildDecisionFromAiRelevance` and rewritten to accept the unified list. It now populates `results` (previously always `[]`) by reconstructing per-item `ContextRelevanceResult` entries from the persisted verdicts, including dismissed items as kept rows carrying their original tier and reason. A new `keptContextRelevanceRefs` helper projects kept results into the `ContextRelevanceRef` shape for the summary artifact.
- `QueueWorker` was updated on both the normal commit and amend paths to stop discarding `relevance.results`, instead calling `keptContextRelevanceRefs` and writing the output to a new `CommitSummary.contextRelevance` field. The Review panel (`NextMemoryPreviewPanel`) now persists the full ranked list via `writeAiSelection` instead of only the excluded subset.

**📋 Future Enhancements**

- Sidebar webview single-reload overlay loss: if only the sidebar webview reloads (not the full window), the in-memory overlay is lost and won't return until the Review panel re-ranks. Fixing this requires lifting relevance state to the host layer, deferred as a follow-up.
- Sidebar file-selection change during an in-flight LLM ranking: the old ranking can complete and overwrite the just-cleared overlay. Fixing this requires the panel to detect sidebar file-selection changes mid-flight, noted as a narrow-window UX issue.

**📁 FILES**
- `cli/src/core/CommitSelectionStore.ts`
- `cli/src/core/ContextRelevance.ts`
- `cli/src/hooks/QueueWorker.ts`
- `vscode/src/views/NextMemoryPreviewPanel.ts`
- `cli/src/Types.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · AI relevance results persisted to commit summaries and displayed per context item</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Commit summaries showed context items as plain title rows with no indication of why the AI considered each one relevant or irrelevant. Users wanted to see the AI's tier rating and one-line explanation alongside each kept item, and wanted excluded items shown inline rather than hidden in a collapsed section.

**💡 Decisions Behind the Code**

- **Top-level array field over embedding tier/reason in existing reference types**: Adding `tier` and `reason` directly to `PlanReference`, `NoteReference`, and `ReferenceCommitRef` would have required three parallel type changes plus three parallel serialization and display changes. A single top-level `contextRelevance` array keyed by `(kind, key)` achieves the same result with one type, one write point, and display-layer lookups — and matches the existing `excludedContext` pattern already in the schema.
- **Inline excluded rows replacing the collapsed details block**: The old design hid excluded items behind a `&lt;details&gt;` disclosure, making them invisible by default. Inlining them as read-only rows in the same list as kept items gives a unified view of the AI's full judgment at a glance. The rows are deliberately non-interactive (no links, no edit/remove actions) because soft-excluded items were never archived into the commit and have no snapshot to open.
- **Archive-suffix key matching via stripped fallback**: Relevance keys are working-area identities (e.g. `graph-plan`) while archived plan slugs carry a commit-hash suffix (e.g. `graph-plan-ab12cd34`). Rather than normalizing keys at write time, display layers try the exact key first and then the suffix-stripped form, keeping the storage layer simple and avoiding a write-time dependency on the archive hash.

**✅ What Was Implemented**

- A new `contextRelevance` field was added to `CommitSummary` holding one `ContextRelevanceRef` entry per kept context item (plan, note, or reference), each carrying `kind`, `key`, `tier`, and `reason`. The field is optional and absent on legacy summaries or fail-open ranking runs, so display layers fall back to plain title rows. It is serialized as part of the existing whole-object JSON write with no schema version change.
- The VS Code summary webview (`SummaryHtmlBuilder`) was updated to render a tier chip and AI reason line under each kept context row, and to replace the old collapsed "AI excluded N items" details block with inline read-only rows for excluded items (struck-through title, "Excluded" chip, reason). New CSS classes (`ctx-rel`, `ctx-tier--*`, `ai-say`, `ai-ex-row`) were added to `SummaryCssBuilder`.
- The CLI markdown builder (`SummaryMarkdownBuilder`) was updated symmetrically: kept rows gain a ` — High/Med/Low · reason` suffix, and excluded items are inlined as struck-through read-only lines. The `pushExcludedContextSection` function (which emitted the old `&lt;details&gt;` block) was removed and its behavior merged into `pushPlansAndNotesSection` behind a `withRelevance` flag. PR markdown builders omit the flag to keep PR bodies relevance-free.

**📁 FILES**
- `cli/src/Types.ts`
- `cli/src/core/SummaryMarkdownBuilder.ts`
- `vscode/src/views/SummaryHtmlBuilder.ts`
- `vscode/src/views/SummaryCssBuilder.ts`
- `vscode/src/views/SummaryWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · AI excluded items synced to sidebar context panel with strikethrough and tooltip</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When the Review panel analyzed context relevance and marked items as excluded, the left sidebar's context list had no awareness of this — items appeared normal there even though they were struck through in the Review panel. Users wanted the sidebar to reflect the AI's judgment visually so they could see and act on it without switching panels.

**💡 Decisions Behind the Code**

- **Independent CSS class, not reusing the existing user-exclude class**: The AI soft-exclude and user manual exclude have different semantics — one is reversible AI judgment, the other is a deliberate user choice. Sharing a class would have required routing AI excludes through the user-exclude state, which would have corrupted the user's manual exclude list and triggered hard-discard behavior. Using a separate class with identical visual styling keeps the two axes cleanly separated while looking the same to the user.
- **View-only push method over broadcast fan-out**: The existing broadcast mechanism sends messages to the sidebar and all registered targets (including the Review panel itself). Using it for the relevance overlay would have delivered a second copy of `context:relevance` to the Review panel on every ranking, potentially causing double-renders. A dedicated sidebar-only method avoids this with minimal added surface area.
- **Unified "add back" clears both axes at once**: An earlier design left the AI-exclude axis as read-only in the sidebar, requiring users to go to the Review panel to dismiss AI suggestions. The unified toggle was chosen so users can restore any struck item from wherever they see it, with the dismiss round-trip handled transparently. The AI's original verdict is preserved on the server side regardless.

**✅ What Was Implemented**

- `SidebarWebviewProvider` gained a `pushContextRelevanceToSidebar` method that posts a `context:relevance` message directly to the sidebar's own webview view, deliberately bypassing the broadcast fan-out that would echo a duplicate back to the Review panel. `NextMemoryPreviewPanel` calls this method at all four points where it posts its own overlay (new ranking, cache hit, empty/no-files, and error).
- The sidebar script was updated to maintain two in-memory state objects (`aiExcludedIds` and `aiReasonById`, the latter using `Object.create(null)` to prevent prototype-chain collisions) populated from incoming `context:relevance` messages. `renderPlanRow` adds an `ai-excluded` CSS class and a native `title` tooltip carrying the AI's reason to any row whose id appears in the set. The class is independent of the existing `excluded` class driven by user manual excludes.
- The exclude toggle button was unified across both axes: any row struck by either user exclusion or AI exclusion shows a "+" (add back) icon, and clicking it clears both axes simultaneously — removing the user exclude and sending a `branch:dismissAiExclude` message for the AI axis. The overlay is cleared when the file selection changes (stale ranking guard) and when a summary run starts (the worker has consumed the ranking).

**📁 FILES**
- `vscode/src/views/SidebarScriptBuilder.ts`
- `vscode/src/views/SidebarWebviewProvider.ts`
- `vscode/src/views/SidebarMessages.ts`
- `vscode/src/views/SidebarCssBuilder.ts`
- `vscode/src/Extension.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 10, 2026 at 6:50 PM · via Anthropic*
<!-- jollimemory-summary-end -->