### PR TITLE
Scope doc/plan/note IDs to env key to prevent cross-backend reuse

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -484,7 +484,12 @@ export interface CommitSummary {
 	 * - Normal commit: absent (leaf node)
 	 */
 	readonly children?: ReadonlyArray<CommitSummary>;
-	/** Full URL of the memory article on Jolli Space after pushing */
+	/**
+	 * Full URL of the memory article on Jolli Space after pushing. Its origin also
+	 * IS the env the `jolliDocId` was minted against: `jolliDocId` is reused as an
+	 * update target only when `deriveJolliEnvKey(jolliDocUrl)` matches the current
+	 * push env (see `canReuseDocId`), so an id from another backend is never reused.
+	 */
 	readonly jolliDocUrl?: string;
 	/** Server-side article ID for direct update on subsequent pushes (set after first push) */
 	readonly jolliDocId?: number;
@@ -604,7 +609,7 @@ export interface PlanReference {
 	readonly addedAt: string;
 	/** ISO 8601 — when this plan was last modified */
 	readonly updatedAt: string;
-	/** Full URL of the plan article on Jolli Space after pushing */
+	/** Full URL of the plan article on Jolli Space after pushing; its origin keys the reuse gate (see `CommitSummary.jolliDocUrl`). */
 	readonly jolliPlanDocUrl?: string;
 	/** Server-side article ID for direct plan update on subsequent pushes */
 	readonly jolliPlanDocId?: number;
@@ -719,7 +724,7 @@ export interface NoteReference {
 	readonly content?: string;
 	readonly addedAt: string;
 	readonly updatedAt: string;
-	/** Full URL of the note article on Jolli Space after pushing */
+	/** Full URL of the note article on Jolli Space after pushing; its origin keys the reuse gate (see `CommitSummary.jolliDocUrl`). */
 	readonly jolliNoteDocUrl?: string;
 	/** Server-side article ID for direct update on subsequent pushes */
 	readonly jolliNoteDocId?: number;
@@ -831,6 +836,10 @@ export interface ReferenceCommitRef {
 	readonly fields?: ReadonlyArray<ReferenceField>;
 	readonly referencedAt: string;
 	readonly sourceToolName: string;
+	/** Full URL of the reference article on Jolli Space after pushing (docType `reference`); its origin keys the reuse gate (see `CommitSummary.jolliDocUrl`). */
+	readonly jolliReferenceDocUrl?: string;
+	/** Server-side article ID for direct update on subsequent pushes of this reference. */
+	readonly jolliReferenceDocId?: number;
 }
 
 // ─── Knowledge Compilation types ────────────────────────────────────────────

--- a/cli/src/core/BranchShareStore.test.ts
+++ b/cli/src/core/BranchShareStore.test.ts
@@ -13,6 +13,13 @@ import {
 
 let cwd: string;
 
+// Backend key (`deriveJolliBackendKey` form — registrable domain) a record's
+// `shareUrl` resolves to. Fixtures' shareUrl lives on `acme.jolli.ai`, whose backend
+// is `https://jolli.ai`; reads pass ENV so they resolve. OTHER_ENV models a
+// since-swapped API key pointing at a different backend.
+const ENV = "https://jolli.ai";
+const OTHER_ENV = "https://jolli-local.me";
+
 beforeEach(async () => {
 	cwd = join(tmpdir(), `branch-share-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	await mkdir(join(cwd, JOLLI_DIR, JOLLIMEMORY_DIR), { recursive: true });
@@ -46,12 +53,12 @@ const MEMBER: BranchShareRecord = {
 
 describe("BranchShareStore", () => {
 	it("returns undefined for a missing file", async () => {
-		expect(await getShare(cwd, "feature/x")).toBeUndefined();
+		expect(await getShare(cwd, "feature/x", ENV)).toBeUndefined();
 	});
 
 	it("round-trips a public record", async () => {
 		await putBranchShare(cwd, "feature/x", PUB);
-		const got = await getShare(cwd, "feature/x");
+		const got = await getShare(cwd, "feature/x", ENV);
 		expect(got?.shareId).toBe("sh_pub");
 		expect(got?.visibility).toBe("public");
 	});
@@ -59,7 +66,7 @@ describe("BranchShareStore", () => {
 	it("single-slot: a re-put overwrites the subject's one record (flip public → member)", async () => {
 		await putBranchShare(cwd, "feature/x", PUB);
 		await putBranchShare(cwd, "feature/x", MEMBER);
-		const got = await getShare(cwd, "feature/x");
+		const got = await getShare(cwd, "feature/x", ENV);
 		expect(got?.shareId).toBe("sh_member");
 		expect(got?.visibility).toBe("org");
 		expect(got?.recipients).toEqual(["ada@example.com"]);
@@ -68,7 +75,7 @@ describe("BranchShareStore", () => {
 	it("flips the tier in place (org → people) without spawning a second record", async () => {
 		await putBranchShare(cwd, "feature/x", MEMBER); // org
 		await putBranchShare(cwd, "feature/x", { ...MEMBER, visibility: "people", recipients: ["tom@jolli.ai"] });
-		const got = await getShare(cwd, "feature/x");
+		const got = await getShare(cwd, "feature/x", ENV);
 		expect(got?.visibility).toBe("people");
 		expect(got?.recipients).toEqual(["tom@jolli.ai"]);
 	});
@@ -76,28 +83,28 @@ describe("BranchShareStore", () => {
 	it("keeps separate subjects per branch", async () => {
 		await putBranchShare(cwd, "feature/x", PUB);
 		await putBranchShare(cwd, "feature/y", { ...PUB, shareId: "sh_2" });
-		expect((await getShare(cwd, "feature/x"))?.shareId).toBe("sh_pub");
-		expect((await getShare(cwd, "feature/y"))?.shareId).toBe("sh_2");
+		expect((await getShare(cwd, "feature/x", ENV))?.shareId).toBe("sh_pub");
+		expect((await getShare(cwd, "feature/y", ENV))?.shareId).toBe("sh_2");
 	});
 
 	it("keeps a commit share separate from the branch share on the same branch", async () => {
 		const commitHash = "c".repeat(40);
 		await putBranchShare(cwd, "feature/x", PUB); // branch share
 		await putBranchShare(cwd, "feature/x", { ...PUB, shareId: "sh_commit" }, commitHash); // commit share
-		expect((await getShare(cwd, "feature/x"))?.shareId).toBe("sh_pub");
-		expect((await getShare(cwd, "feature/x", commitHash))?.shareId).toBe("sh_commit");
+		expect((await getShare(cwd, "feature/x", ENV))?.shareId).toBe("sh_pub");
+		expect((await getShare(cwd, "feature/x", ENV, commitHash))?.shareId).toBe("sh_commit");
 		// removing the commit share leaves the branch share intact
 		await removeShare(cwd, "feature/x", commitHash);
-		expect(await getShare(cwd, "feature/x", commitHash)).toBeUndefined();
-		expect((await getShare(cwd, "feature/x"))?.shareId).toBe("sh_pub");
+		expect(await getShare(cwd, "feature/x", ENV, commitHash)).toBeUndefined();
+		expect((await getShare(cwd, "feature/x", ENV))?.shareId).toBe("sh_pub");
 	});
 
 	it("removes a subject's record; idempotent for already-removed / never-shared", async () => {
 		await putBranchShare(cwd, "feature/x", PUB);
 		await putBranchShare(cwd, "feature/y", { ...PUB, shareId: "sh_y" });
 		await removeShare(cwd, "feature/x");
-		expect(await getShare(cwd, "feature/x")).toBeUndefined();
-		expect((await getShare(cwd, "feature/y"))?.shareId).toBe("sh_y"); // untouched
+		expect(await getShare(cwd, "feature/x", ENV)).toBeUndefined();
+		expect((await getShare(cwd, "feature/y", ENV))?.shareId).toBe("sh_y"); // untouched
 		// idempotent — already-removed and never-shared are both no-ops
 		await removeShare(cwd, "feature/x");
 		await removeShare(cwd, "never-shared");
@@ -120,10 +127,39 @@ describe("BranchShareStore", () => {
 			},
 		};
 		await putBranchShare(cwd, "feature/x", live);
-		const got = await getShare(cwd, "feature/x");
+		const got = await getShare(cwd, "feature/x", ENV);
 		expect(got?.visibility).toBe("org");
 		expect(got?.recipients).toEqual(["ada@example.com"]);
 		expect(got?.ref).toEqual(live.ref);
+	});
+
+	describe("env scoping", () => {
+		it("treats a record minted against a DIFFERENT backend as absent (foreign shareId never reused)", async () => {
+			await putBranchShare(cwd, "feature/x", PUB); // minted against ENV
+			// A since-swapped API key now targets OTHER_ENV — the cached ENV record is a
+			// cross-environment stale entry and must not surface (else its shareId 404s).
+			expect(await getShare(cwd, "feature/x", OTHER_ENV)).toBeUndefined();
+			// The original backend still resolves it.
+			expect((await getShare(cwd, "feature/x", ENV))?.shareId).toBe("sh_pub");
+		});
+
+		it("treats a record as absent when the current env key is undefined/blank (unknown backend)", async () => {
+			await putBranchShare(cwd, "feature/x", PUB);
+			expect(await getShare(cwd, "feature/x", undefined)).toBeUndefined();
+			expect(await getShare(cwd, "feature/x", "")).toBeUndefined();
+		});
+
+		it("does not seed a fresh subject from a stranded record on a different backend", async () => {
+			await putBranchShare(
+				cwd,
+				"feature/x",
+				{ ...MEMBER, shareId: "foreign", shareUrl: "https://jolli-local.me/share/x" },
+				"a".repeat(40),
+			);
+			const { record, seed } = await getShareWithBranchLatest(cwd, "feature/x", ENV, "b".repeat(40));
+			expect(record).toBeUndefined();
+			expect(seed).toBeUndefined(); // the stranded record belongs to another backend
+		});
 	});
 
 	it("persists a single record per subject on disk (no slot nesting)", async () => {
@@ -139,20 +175,36 @@ describe("BranchShareStore", () => {
 
 	it("treats a malformed file as empty", async () => {
 		await writeFile(filePath(), "{not json", "utf8");
-		expect(await getShare(cwd, "feature/x")).toBeUndefined();
+		expect(await getShare(cwd, "feature/x", ENV)).toBeUndefined();
 	});
 
 	it("ignores a file with an unrecognized version (no migration)", async () => {
-		// Older two-slot (v3) and single-record (v2) shapes were never released; any
+		// Only the dev-only shapes (v2/v3) are unrecognized; v4 is the current shape. A
 		// non-current version is ignored and re-created on the next share.
-		await writeFile(filePath(), JSON.stringify({ version: 3, subjects: { "feature/x": { public: PUB } } }), "utf8");
-		expect(await getShare(cwd, "feature/x")).toBeUndefined();
+		await writeFile(filePath(), JSON.stringify({ version: 3, subjects: { "feature/x": PUB } }), "utf8");
+		expect(await getShare(cwd, "feature/x", ENV)).toBeUndefined();
+	});
+
+	it("matches a record purely by its shareUrl backend (no separate env field)", async () => {
+		// An older record that also carried an `envKey` field still reads fine — the field
+		// is ignored and the backend is derived from shareUrl.
+		await writeFile(
+			filePath(),
+			JSON.stringify({
+				version: 4,
+				subjects: { "feature/x": { ...PUB, envKey: "https://stale.example" } },
+			}),
+			"utf8",
+		);
+		expect((await getShare(cwd, "feature/x", ENV))?.shareId).toBe("sh_pub");
+		// A since-swapped key on a different backend still reads it as foreign.
+		expect(await getShare(cwd, "feature/x", OTHER_ENV)).toBeUndefined();
 	});
 
 	it("ignores a file whose subjects field is not an object", async () => {
 		// Current version so it reaches the shape check (not short-circuited by version mismatch).
 		await writeFile(filePath(), JSON.stringify({ version: 4, subjects: "nope" }), "utf8");
-		expect(await getShare(cwd, "feature/x")).toBeUndefined();
+		expect(await getShare(cwd, "feature/x", ENV)).toBeUndefined();
 	});
 
 	it("cleans up and propagates when the atomic rename fails", async () => {
@@ -168,14 +220,14 @@ describe("BranchShareStore", () => {
 			putBranchShare(cwd, "b", { ...PUB, shareId: "b" }),
 			putBranchShare(cwd, "c", { ...PUB, shareId: "c" }),
 		]);
-		expect((await getShare(cwd, "a"))?.shareId).toBe("a");
-		expect((await getShare(cwd, "b"))?.shareId).toBe("b");
-		expect((await getShare(cwd, "c"))?.shareId).toBe("c");
+		expect((await getShare(cwd, "a", ENV))?.shareId).toBe("a");
+		expect((await getShare(cwd, "b", ENV))?.shareId).toBe("b");
+		expect((await getShare(cwd, "c", ENV))?.shareId).toBe("c");
 	});
 
 	describe("getShareWithBranchLatest", () => {
 		it("both undefined when the branch has no subjects at all", async () => {
-			const { record, seed } = await getShareWithBranchLatest(cwd, "feature/x");
+			const { record, seed } = await getShareWithBranchLatest(cwd, "feature/x", ENV);
 			expect(record).toBeUndefined();
 			expect(seed).toBeUndefined();
 		});
@@ -183,7 +235,7 @@ describe("BranchShareStore", () => {
 		it("returns a commit subject's own record and no seed when it's the only commit share", async () => {
 			const hash = "a".repeat(40);
 			await putBranchShare(cwd, "feature/x", { ...MEMBER, shareId: "own" }, hash);
-			const { record, seed } = await getShareWithBranchLatest(cwd, "feature/x", hash);
+			const { record, seed } = await getShareWithBranchLatest(cwd, "feature/x", ENV, hash);
 			expect(record?.shareId).toBe("own");
 			expect(seed).toBeUndefined(); // no OTHER commit share to seed from
 		});
@@ -202,7 +254,7 @@ describe("BranchShareStore", () => {
 				"b".repeat(40),
 			);
 			// Open a brand-new commit subject (no record): seed is the newest stranded commit share.
-			const { record, seed } = await getShareWithBranchLatest(cwd, "feature/x", "c".repeat(40));
+			const { record, seed } = await getShareWithBranchLatest(cwd, "feature/x", ENV, "c".repeat(40));
 			expect(record).toBeUndefined();
 			expect(seed?.shareId).toBe("new");
 			expect(seed?.recipients).toEqual(["tom@jolli.ai"]);
@@ -213,7 +265,7 @@ describe("BranchShareStore", () => {
 			// auto-staging its people would double-grant. A commit subject only seeds from
 			// other commit shares.
 			await putBranchShare(cwd, "feature/x", { ...MEMBER, shareId: "branch", recipients: ["ada@jolli.ai"] });
-			const { record, seed } = await getShareWithBranchLatest(cwd, "feature/x", "a".repeat(40));
+			const { record, seed } = await getShareWithBranchLatest(cwd, "feature/x", ENV, "a".repeat(40));
 			expect(record).toBeUndefined();
 			expect(seed).toBeUndefined(); // the branch share is not a seed source for a commit subject
 		});
@@ -221,7 +273,7 @@ describe("BranchShareStore", () => {
 		it("a branch subject never seeds (its key is stable, never stranded)", async () => {
 			await putBranchShare(cwd, "feature/x", { ...MEMBER, shareId: "branch" });
 			await putBranchShare(cwd, "feature/x", { ...MEMBER, shareId: "commit" }, "a".repeat(40));
-			const { record, seed } = await getShareWithBranchLatest(cwd, "feature/x");
+			const { record, seed } = await getShareWithBranchLatest(cwd, "feature/x", ENV);
 			expect(record?.shareId).toBe("branch"); // its own record
 			expect(seed).toBeUndefined(); // does not seed from the commit share (cross-kind)
 		});
@@ -241,14 +293,14 @@ describe("BranchShareStore", () => {
 			);
 			// Query the newer subject: its own record is returned; the seed is the OTHER one,
 			// even though the queried subject has a later expiry.
-			const { record, seed } = await getShareWithBranchLatest(cwd, "feature/x", "a".repeat(40));
+			const { record, seed } = await getShareWithBranchLatest(cwd, "feature/x", ENV, "a".repeat(40));
 			expect(record?.shareId).toBe("self");
 			expect(seed?.shareId).toBe("other");
 		});
 
 		it("does not match a branch whose name is a prefix of another (feat vs feature/x)", async () => {
 			await putBranchShare(cwd, "feature/x", PUB, "a".repeat(40));
-			const { seed } = await getShareWithBranchLatest(cwd, "feat", "b".repeat(40));
+			const { seed } = await getShareWithBranchLatest(cwd, "feat", ENV, "b".repeat(40));
 			expect(seed).toBeUndefined();
 		});
 	});

--- a/cli/src/core/BranchShareStore.ts
+++ b/cli/src/core/BranchShareStore.ts
@@ -28,15 +28,21 @@ import { mkdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createLogger, errMsg, isEnoent, JOLLI_DIR, JOLLIMEMORY_DIR } from "../Logger.js";
 import { atomicWriteFile } from "./AtomicWrite.js";
+import { deriveJolliBackendKey } from "./JolliApiUtils.js";
 
 const log = createLogger("BranchShare");
 
 const SHARES_FILE = "branch-shares.json";
-// One share record per subject (single-slot). Branch sharing never shipped with an
-// older on-disk shape (v2/v3 existed only on unreleased dev builds), so there is no
-// migration: a file whose `version` or shape doesn't match is ignored (treated as
-// empty) and re-created on the next share. The number stays MONOTONIC past the
-// dev-only v2/v3 so an older file is never mistaken for the current shape.
+// One share record per subject (single-slot). The on-disk shape is v4, shared with
+// the IntelliJ plugin, which reads/writes the SAME file (via Gson, which ignores
+// unknown fields). The backend a share was minted against is recovered from its
+// `shareUrl` origin (see `matchesEnv`), so no separate env field is stored; a v4 file
+// written by an older build that also carried an `envKey` field still reads fine (the
+// extra field is ignored). The version is deliberately NOT bumped for this: bumping
+// it would make the two tools discard each other's file and silently drop live
+// shares. A genuinely unrecognized version (the dev-only v2/v3) is still ignored
+// (treated as empty) and re-created on the next share; the number stays MONOTONIC
+// past those so an older file is never mistaken for the current shape.
 const SHARES_VERSION = 4 as const;
 
 /**
@@ -63,6 +69,18 @@ export type LiveRef =
 /** One share record (branch share or single-commit share). Every share is live. */
 export interface BranchShareRecord {
 	readonly shareId: string;
+	/**
+	 * Neutral base-domain share link (`https://<baseDomain>/share/<token>`). Its
+	 * origin also identifies the BACKEND the share was minted against: a record whose
+	 * `shareUrl` backend (`deriveJolliBackendKey`) doesn't match the current API key's
+	 * backend is a cross-environment stale entry (its `shareId` belongs to a server the
+	 * current key never talks to) and is treated as absent (see `matchesEnv`), so the
+	 * next Copy/Invite mints a fresh link instead of 404-ing (`share_not_found`) against
+	 * a foreign `shareId`. Mirrors the `jolliDocId` URL-origin reuse guard
+	 * (`canReuseDocId`), but at backend (registrable-domain) granularity because the
+	 * share link is tenant-free — a rare same-deployment cross-tenant switch is treated
+	 * as the same backend.
+	 */
 	readonly shareUrl: string;
 	/**
 	 * Access level: `public` (anyone-with-link bearer), `org` (auth-gated: any
@@ -114,6 +132,20 @@ const COMMIT_KEY_SEP = ":";
  */
 function subjectKey(branch: string, commitHash?: string): string {
 	return commitHash ? `${branch}${COMMIT_KEY_SEP}${commitHash}` : branch;
+}
+
+/**
+ * Whether a record belongs to the backend the current API key targets — decided by
+ * comparing the record's `shareUrl` backend (`deriveJolliBackendKey`) against
+ * `currentBackendKey` (the current API key's backend, same derivation). A record on a
+ * DIFFERENT backend stays foreign (its `shareId` would 404); a record read with a
+ * blank/undefined `currentBackendKey` (underivable backend) or a `shareUrl` that
+ * doesn't parse is not trusted. Backend (registrable-domain) granularity — see
+ * {@link BranchShareRecord.shareUrl}.
+ */
+function matchesEnv(rec: BranchShareRecord, currentBackendKey: string | undefined): boolean {
+	const recBackend = deriveJolliBackendKey(rec.shareUrl);
+	return Boolean(currentBackendKey) && recBackend === currentBackendKey;
 }
 
 interface PersistedShape {
@@ -179,15 +211,19 @@ function serialize<T>(projectDir: string, work: () => Promise<T>): Promise<T> {
 
 /**
  * Returns a subject's single share record, or undefined. Pass `commitHash` for a
- * commit share; omit it for a branch share.
+ * commit share; omit it for a branch share. `currentBackendKey` is the current API
+ * key's backend (`deriveJolliBackendKey`); a record on a different backend reads as
+ * absent (see {@link matchesEnv}).
  */
 export async function getShare(
 	projectDir: string,
 	branch: string,
+	currentBackendKey: string | undefined,
 	commitHash?: string,
 ): Promise<BranchShareRecord | undefined> {
 	const all = await readAll(projectDir);
-	return all.subjects[subjectKey(branch, commitHash)];
+	const rec = all.subjects[subjectKey(branch, commitHash)];
+	return rec && matchesEnv(rec, currentBackendKey) ? rec : undefined;
 }
 
 /**
@@ -221,19 +257,23 @@ export async function putBranchShare(
  * stable (never stranded), so it has no same-kind prior and gets no seed.
  *
  * Expiry is NOT filtered here (the store has no clock); the caller passes the result
- * through its liveness check so an intentionally-lapsed grant never seeds.
+ * through its liveness check so an intentionally-lapsed grant never seeds. Records
+ * minted against a different backend (`shareUrl` backend mismatch) are skipped — a
+ * foreign shareId must never seed a subject on the current server.
  */
 function pickSeedForSubject(
 	subjects: Readonly<Record<string, BranchShareRecord>>,
 	branch: string,
 	commitHash: string | undefined,
 	currentKey: string,
+	currentBackendKey: string | undefined,
 ): BranchShareRecord | undefined {
 	const wantCommit = commitHash !== undefined;
 	let seed: BranchShareRecord | undefined;
 	let seedAt = Number.NEGATIVE_INFINITY;
 	for (const [key, record] of Object.entries(subjects)) {
 		if (key === currentKey) continue; // never seed a subject from itself
+		if (!matchesEnv(record, currentBackendKey)) continue; // never seed from a foreign backend
 		const sameKind = wantCommit ? key.startsWith(branch + COMMIT_KEY_SEP) : key === branch;
 		if (!sameKind) continue;
 		const parsed = Date.parse(record.expiresAt);
@@ -257,13 +297,15 @@ function pickSeedForSubject(
 export async function getShareWithBranchLatest(
 	projectDir: string,
 	branch: string,
+	currentBackendKey: string | undefined,
 	commitHash?: string,
 ): Promise<{ record: BranchShareRecord | undefined; seed: BranchShareRecord | undefined }> {
 	const all = await readAll(projectDir);
 	const currentKey = subjectKey(branch, commitHash);
+	const own = all.subjects[currentKey];
 	return {
-		record: all.subjects[currentKey],
-		seed: pickSeedForSubject(all.subjects, branch, commitHash, currentKey),
+		record: own && matchesEnv(own, currentBackendKey) ? own : undefined,
+		seed: pickSeedForSubject(all.subjects, branch, commitHash, currentKey, currentBackendKey),
 	};
 }
 

--- a/cli/src/core/JolliApiUtils.test.ts
+++ b/cli/src/core/JolliApiUtils.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { assertJolliOriginAllowed, parseBaseUrl, parseJolliApiKey } from "./JolliApiUtils";
+import {
+	assertJolliOriginAllowed,
+	deriveJolliBackendKey,
+	deriveJolliBackendKeyFromApiKey,
+	deriveJolliEnvKey,
+	deriveJolliEnvKeyFromApiKey,
+	parseBaseUrl,
+	parseJolliApiKey,
+	resolveArticleUrl,
+} from "./JolliApiUtils";
 
 describe("JolliApiUtils", () => {
 	describe("parseBaseUrl", () => {
@@ -150,6 +159,94 @@ describe("JolliApiUtils", () => {
 
 		it("rejects credentials-in-url disguising attacker host", () => {
 			expect(() => assertJolliOriginAllowed("https://app.jolli.ai@evil.com")).toThrow(/evil\.com/);
+		});
+	});
+
+	describe("deriveJolliEnvKey", () => {
+		it("is the lowercased origin, ignoring any tenant path segment", () => {
+			expect(deriveJolliEnvKey("https://Tenant1.jolli.dev/acme")).toBe("https://tenant1.jolli.dev");
+		});
+
+		it("keys on origin so different backends differ but same-origin orgs collapse", () => {
+			expect(deriveJolliEnvKey("https://jolli-local.me")).toBe("https://jolli-local.me");
+			expect(deriveJolliEnvKey("https://jolli.ai")).toBe("https://jolli.ai");
+			// Same origin, different tenant path → same backend key (org/tenant intentionally ignored).
+			expect(deriveJolliEnvKey("https://jolli.ai/org-a")).toBe(deriveJolliEnvKey("https://jolli.ai/org-b"));
+		});
+
+		it("returns undefined when there is no base URL", () => {
+			expect(deriveJolliEnvKey(undefined)).toBeUndefined();
+		});
+	});
+
+	describe("deriveJolliEnvKeyFromApiKey", () => {
+		function keyWith(meta: Record<string, unknown>): string {
+			return `sk-jol-${Buffer.from(JSON.stringify(meta)).toString("base64url")}.secret`;
+		}
+
+		it("derives the env key from the key's embedded `.u` claim alone", () => {
+			const key = keyWith({ t: "t1", u: "https://tenant1.jolli.dev/acme", o: "engineering" });
+			expect(deriveJolliEnvKeyFromApiKey(key)).toBe("https://tenant1.jolli.dev");
+		});
+
+		it("returns undefined for an absent or undecodable key (no base URL to key on)", () => {
+			expect(deriveJolliEnvKeyFromApiKey(undefined)).toBeUndefined();
+			expect(deriveJolliEnvKeyFromApiKey("sk-jol-plain")).toBeUndefined();
+		});
+	});
+
+	describe("deriveJolliBackendKey", () => {
+		it("strips the tenant subdomain to the registrable domain (all tenants of a backend collapse)", () => {
+			expect(deriveJolliBackendKey("https://acme.jolli.ai")).toBe("https://jolli.ai");
+			expect(deriveJolliBackendKey("https://beta.jolli.ai/o/x/articles/y-5")).toBe("https://jolli.ai");
+			expect(deriveJolliBackendKey("https://acme.jolli.ai")).toBe(deriveJolliBackendKey("https://beta.jolli.ai"));
+		});
+
+		it("keeps a bare registrable domain, dot-less hosts, and IPv4 whole; preserves port", () => {
+			expect(deriveJolliBackendKey("https://jolli-local.me/7o423e4x/share/x")).toBe("https://jolli-local.me");
+			expect(deriveJolliBackendKey("http://localhost:8034/dev")).toBe("http://localhost:8034");
+			expect(deriveJolliBackendKey("https://192.168.0.1:9000/x")).toBe("https://192.168.0.1:9000");
+		});
+
+		it("returns undefined for a missing or unparseable input", () => {
+			expect(deriveJolliBackendKey(undefined)).toBeUndefined();
+			expect(deriveJolliBackendKey("not-a-url")).toBeUndefined();
+		});
+	});
+
+	describe("deriveJolliBackendKeyFromApiKey", () => {
+		it("derives the backend key from the key's embedded `.u` claim (subdomain stripped)", () => {
+			const key = `sk-jol-${Buffer.from(JSON.stringify({ t: "t1", u: "https://tenant1.jolli.dev/acme" })).toString("base64url")}.secret`;
+			expect(deriveJolliBackendKeyFromApiKey(key)).toBe("https://jolli.dev");
+		});
+
+		it("returns undefined for an absent or undecodable key", () => {
+			expect(deriveJolliBackendKeyFromApiKey(undefined)).toBeUndefined();
+			expect(deriveJolliBackendKeyFromApiKey("sk-jol-plain")).toBeUndefined();
+		});
+	});
+
+	describe("resolveArticleUrl", () => {
+		const base = "https://jolli-local.me/7o423e4x";
+
+		it("resolves the server-returned relative slug path against the display base (matches the web app)", () => {
+			expect(resolveArticleUrl(base, "/o/default/articles/my-summary-839", 839)).toBe(
+				"https://jolli-local.me/7o423e4x/o/default/articles/my-summary-839",
+			);
+			// org-less slug path (backend before it adds /o/<org>) still resolves.
+			expect(resolveArticleUrl(base, "/articles/my-summary-839", 839)).toBe(
+				"https://jolli-local.me/7o423e4x/articles/my-summary-839",
+			);
+		});
+
+		it("uses an already-absolute server url verbatim", () => {
+			expect(resolveArticleUrl(base, "https://jolli.ai/x/articles/s-5", 5)).toBe(
+				"https://jolli.ai/x/articles/s-5",
+			);
+		});
+
+		it("falls back to the ?doc=<id> deep-link when the server url is missing", () => {
+			expect(resolveArticleUrl(base, "", 839)).toBe("https://jolli-local.me/7o423e4x/articles?doc=839");
 		});
 	});
 });

--- a/cli/src/core/JolliApiUtils.ts
+++ b/cli/src/core/JolliApiUtils.ts
@@ -40,6 +40,21 @@ export function parseBaseUrl(baseUrl: string): ParsedBaseUrl {
 }
 
 /**
+ * Resolves the browsable article URL for a pushed doc.
+ *
+ * Prefers the server-returned `serverUrl` (absolute is used as-is; relative is
+ * prefixed with `displayBase`). Falls back to the `?doc=<id>` alias only when
+ * the server returned no URL. Shared by the CLI and VS Code push orchestrators
+ * so the stored/displayed URL matches the web app's canonical article path.
+ */
+export function resolveArticleUrl(displayBase: string, serverUrl: string | undefined, docId: number): string {
+	if (!serverUrl) return `${displayBase}/articles?doc=${docId}`;
+	return /^https?:\/\//i.test(serverUrl)
+		? serverUrl
+		: `${displayBase}${serverUrl.startsWith("/") ? "" : "/"}${serverUrl}`;
+}
+
+/**
  * Parses a Jolli API key (sk-jol-...) and extracts its metadata.
  * Returns null for old-format (no-dot) keys and for unrecognized shapes.
  *
@@ -78,6 +93,76 @@ export function parseJolliApiKey(key: string): JolliApiKeyMeta | null {
 		}
 	}
 	return null;
+}
+
+/**
+ * Derives a stable "environment key" identifying the BACKEND a push targets:
+ * the lowercased origin (e.g. `https://jolli.ai`). A server-minted id (`jolliDocId`,
+ * branch `shareId`) is only reused as an update/reopen target when the current
+ * push's env key matches the one it was minted against — otherwise the id belongs
+ * to a different backend and must not be sent.
+ *
+ * Origin only — deliberately NOT org/tenant. The id namespaces are per-backend
+ * (each of jolli-local.me / jolli.ai / jolli.cloud is its own database), so origin
+ * is what distinguishes them, and it's the only cross-environment switch that
+ * actually happens (local↔prod). The server still re-validates space/repo/owner on
+ * every push (`isValidJolliDoc`), so this key is a cleanliness optimization, never a
+ * correctness guard: the worst a mismatch can do is skip a reuse and let the server
+ * create a fresh doc. Keying on the mutable org/tenant slugs instead would only add
+ * rename-fragility (a renamed org would spuriously look like a new environment) for
+ * a same-origin org-switch case the server backstop already handles safely.
+ *
+ * Returns undefined when there is no base URL to key on; callers treat "no current
+ * env key" as "don't reuse a tagged id". Throws on an unparseable non-empty input
+ * (callers feeding stored/untrusted URLs — e.g. `canReuseDocId` — guard for it).
+ */
+export function deriveJolliEnvKey(baseUrl: string | undefined): string | undefined {
+	return baseUrl ? parseBaseUrl(baseUrl).origin.toLowerCase() : undefined;
+}
+
+/**
+ * Convenience over {@link deriveJolliEnvKey} for callers that hold only an API key:
+ * the key's embedded `.u` claim IS the base URL. Returns undefined when the key is
+ * absent or can't be decoded.
+ */
+export function deriveJolliEnvKeyFromApiKey(apiKey: string | undefined): string | undefined {
+	return deriveJolliEnvKey(apiKey ? parseJolliApiKey(apiKey)?.u : undefined);
+}
+
+/**
+ * Coarser sibling of {@link deriveJolliEnvKey}: the DEPLOYMENT backend key, reduced
+ * to the registrable domain so every tenant of a backend collapses to one key
+ * (`acme.jolli.ai` → `https://jolli.ai`, `jolli-local.me` → `https://jolli-local.me`).
+ *
+ * Used where the only URL available is the tenant-free base-domain form — the branch
+ * share `shareUrl` (built from the server's `BASE_DOMAIN`, never a tenant host). A
+ * share minted on any tenant of a backend must match the current key targeting that
+ * same backend, so the tenant subdomain is stripped. Trade-off vs the tenant-precise
+ * `deriveJolliEnvKey`: a same-deployment cross-tenant switch is treated as the same
+ * backend (an accepted, rare case). The allowlisted backends use a single-label public
+ * suffix, so the registrable domain is the last two labels; dot-less hosts (`localhost`)
+ * and IPv4 are kept whole; scheme and non-default port are preserved.
+ *
+ * Returns undefined for a missing/unparseable input.
+ */
+export function deriveJolliBackendKey(url: string | undefined): string | undefined {
+	if (!url) return undefined;
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return undefined;
+	}
+	const labels = parsed.hostname.split(".");
+	const isIpv4 = /^\d+$/.test(labels[labels.length - 1]);
+	const registrable = labels.length > 2 && !isIpv4 ? labels.slice(-2).join(".") : parsed.hostname;
+	const port = parsed.port ? `:${parsed.port}` : "";
+	return `${parsed.protocol}//${registrable}${port}`.toLowerCase();
+}
+
+/** Convenience over {@link deriveJolliBackendKey} for callers that hold only an API key. */
+export function deriveJolliBackendKeyFromApiKey(apiKey: string | undefined): string | undefined {
+	return deriveJolliBackendKey(apiKey ? parseJolliApiKey(apiKey)?.u : undefined);
 }
 
 /**

--- a/cli/src/core/JolliMemoryPushClient.test.ts
+++ b/cli/src/core/JolliMemoryPushClient.test.ts
@@ -340,6 +340,20 @@ describe("resolveBaseUrl", () => {
 	});
 });
 
+describe("resolveEnvKey", () => {
+	it("derives an env key from the resolved base URL + api key (no network)", async () => {
+		const c = client(async () => jsonResponse(200, {}));
+		await expect(c.resolveEnvKey()).resolves.toBe("https://jolli.ai");
+	});
+	it("throws NotAuthenticatedError when no api key is configured", async () => {
+		const c = new JolliMemoryPushClient({
+			fetchImpl: async () => jsonResponse(200, {}),
+			apiKeyProvider: async () => undefined,
+		});
+		await expect(c.resolveEnvKey()).rejects.toBeInstanceOf(NotAuthenticatedError);
+	});
+});
+
 describe("constructor defaults", () => {
 	it("falls back to the SessionTracker config loader when no apiKeyProvider is given", async () => {
 		let capturedHeaders: Record<string, string> = {};

--- a/cli/src/core/JolliMemoryPushClient.ts
+++ b/cli/src/core/JolliMemoryPushClient.ts
@@ -17,7 +17,7 @@
  */
 
 import { JOLLI_CLIENT_HEADER } from "./ClientHeader.js";
-import { type JolliApiKeyMeta, parseBaseUrl, parseJolliApiKey } from "./JolliApiUtils.js";
+import { deriveJolliEnvKey, type JolliApiKeyMeta, parseBaseUrl, parseJolliApiKey } from "./JolliApiUtils.js";
 import { loadConfig } from "./SessionTracker.js";
 import { currentTraceHeader, newTraceHeader, TRACE_HEADER_NAME } from "./TraceContext.js";
 
@@ -114,7 +114,7 @@ export interface PushPayload {
 	readonly title: string;
 	readonly content: string;
 	readonly commitHash: string;
-	readonly docType: "summary" | "plan" | "note";
+	readonly docType: "summary" | "plan" | "note" | "reference";
 	readonly branch?: string;
 	readonly docId?: number;
 	readonly repoUrl?: string;
@@ -271,6 +271,18 @@ export class JolliMemoryPushClient {
 	async resolveBaseUrl(): Promise<string> {
 		const { baseUrl } = await this.resolveAuth();
 		return baseUrl;
+	}
+
+	/**
+	 * Resolves the env key (`deriveJolliEnvKey`) of the tenant this client pushes
+	 * to — the orchestrator tags each minted `jolliDocId` with it and only reuses
+	 * an id as an update target when the tag matches. Same no-network auth resolve
+	 * as {@link resolveBaseUrl}; `resolveAuth` guarantees a base URL, so the key is
+	 * always defined here.
+	 */
+	async resolveEnvKey(): Promise<string> {
+		const { baseUrl } = await this.resolveAuth();
+		return deriveJolliEnvKey(baseUrl) ?? "";
 	}
 
 	private async resolveAuth(): Promise<{

--- a/cli/src/core/JolliMemoryPushOrchestrator.test.ts
+++ b/cli/src/core/JolliMemoryPushOrchestrator.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { CommitSummary, NoteReference, PlanReference } from "../Types.js";
+import type { CommitSummary, NoteReference, PlanReference, ReferenceCommitRef } from "../Types.js";
 
 vi.mock("./GitOps.js", () => ({ getDefaultBranch: vi.fn() }));
 vi.mock("./PrDescription.js", () => ({ loadBranchSummaries: vi.fn() }));
@@ -10,6 +10,7 @@ vi.mock("./SummaryStore.js", () => ({
 	getSummary: vi.fn(),
 	readNoteFromBranch: vi.fn(),
 	readPlanFromBranch: vi.fn(),
+	readReferenceFromBranch: vi.fn(),
 	storeSummary: vi.fn(),
 }));
 vi.mock("./GitRemoteUtils.js", async (importOriginal) => {
@@ -31,12 +32,15 @@ import {
 import {
 	applyNoteUrls,
 	applyPlanUrls,
+	applyReferenceUrls,
 	assignOwnedAttachments,
 	buildPushMarkdown,
+	canReuseDocId,
 	latestPlanPerName,
 	type PushContext,
 	pushBranchToJolli,
 	pushSummary,
+	referenceBaseKey,
 	resolveSpaceId,
 	serializeSummaryJson,
 } from "./JolliMemoryPushOrchestrator.js";
@@ -49,6 +53,7 @@ import {
 	getSummary,
 	readNoteFromBranch,
 	readPlanFromBranch,
+	readReferenceFromBranch,
 	storeSummary,
 } from "./SummaryStore.js";
 
@@ -89,6 +94,19 @@ function plan(overrides: Partial<PlanReference> = {}): PlanReference {
 	};
 }
 
+function reference(overrides: Partial<ReferenceCommitRef> = {}): ReferenceCommitRef {
+	return {
+		archivedKey: "linear:ENG-1-a1b2c3d4",
+		source: "linear",
+		nativeId: "ENG-1",
+		title: "Fix login bug",
+		url: "https://linear.app/acme/issue/ENG-1",
+		referencedAt: "2026-01-01T00:00:00.000Z",
+		sourceToolName: "Claude Code",
+		...overrides,
+	};
+}
+
 function note(overrides: Partial<NoteReference> = {}): NoteReference {
 	return {
 		id: "n1",
@@ -119,6 +137,20 @@ describe("serializeSummaryJson", () => {
 		expect(json.commitHash).toBe("a");
 	});
 
+	it("keeps nested plan/note/reference docId/url (needed for rendering the article links)", () => {
+		const s = {
+			commitHash: "a",
+			plans: [{ slug: "p1", jolliPlanDocId: 9, jolliPlanDocUrl: "pu" }],
+			notes: [{ id: "n1", jolliNoteDocId: 8, jolliNoteDocUrl: "nu" }],
+			references: [{ archivedKey: "linear:E-1-abcd1234", jolliReferenceDocId: 7, jolliReferenceDocUrl: "ru" }],
+		} as unknown as CommitSummary;
+		const json = JSON.parse(serializeSummaryJson(s) ?? "{}");
+		expect(json.plans[0].jolliPlanDocId).toBe(9);
+		expect(json.plans[0].jolliPlanDocUrl).toBe("pu");
+		expect(json.notes[0].jolliNoteDocUrl).toBe("nu");
+		expect(json.references[0].jolliReferenceDocUrl).toBe("ru");
+	});
+
 	it("returns undefined when serialized JSON exceeds the byte cap", () => {
 		const huge = "x".repeat(2_000_000);
 		const s = { commitHash: "a", commitMessage: huge } as unknown as CommitSummary;
@@ -129,7 +161,7 @@ describe("serializeSummaryJson", () => {
 // ─── applyPlanUrls / applyNoteUrls ──────────────────────────────────────────
 
 describe("applyPlanUrls", () => {
-	it("merges docId/url by slug", () => {
+	it("merges docId/url by slug (the URL's origin is the minting env)", () => {
 		const plans = [plan({ slug: "p1" })];
 		const out = applyPlanUrls(plans, [{ slug: "p1", url: "https://j/articles?doc=9", docId: 9 }]);
 		expect(out?.[0].jolliPlanDocId).toBe(9);
@@ -140,6 +172,7 @@ describe("applyPlanUrls", () => {
 		const plans = [plan({ slug: "p1" })];
 		const out = applyPlanUrls(plans, [{ slug: "other", url: "u", docId: 1 }]);
 		expect(out?.[0].jolliPlanDocId).toBeUndefined();
+		expect(out?.[0].jolliPlanDocUrl).toBeUndefined();
 	});
 
 	it("returns the input unchanged when plans is undefined or planUrls is empty", () => {
@@ -150,7 +183,7 @@ describe("applyPlanUrls", () => {
 });
 
 describe("applyNoteUrls", () => {
-	it("merges docId/url by id", () => {
+	it("merges docId/url by id (the URL's origin is the minting env)", () => {
 		const notes = [note({ id: "n1" })];
 		const out = applyNoteUrls(notes, [{ id: "n1", url: "https://j/articles?doc=3", docId: 3 }]);
 		expect(out[0].jolliNoteDocId).toBe(3);
@@ -161,6 +194,56 @@ describe("applyNoteUrls", () => {
 		const notes = [note({ id: "n1" })];
 		const out = applyNoteUrls(notes, [{ id: "other", url: "u", docId: 1 }]);
 		expect(out[0].jolliNoteDocId).toBeUndefined();
+		expect(out[0].jolliNoteDocUrl).toBeUndefined();
+	});
+});
+
+describe("applyReferenceUrls", () => {
+	it("merges docId/url by archivedKey (the URL's origin is the minting env)", () => {
+		const refs = [reference({ archivedKey: "linear:ENG-1-aaaa1111" })];
+		const out = applyReferenceUrls(refs, [
+			{ archivedKey: "linear:ENG-1-aaaa1111", url: "https://j/articles?doc=5", docId: 5 },
+		]);
+		expect(out[0].jolliReferenceDocId).toBe(5);
+		expect(out[0].jolliReferenceDocUrl).toBe("https://j/articles?doc=5");
+	});
+
+	it("leaves references unmatched by archivedKey untouched", () => {
+		const refs = [reference({ archivedKey: "linear:ENG-1-aaaa1111" })];
+		const out = applyReferenceUrls(refs, [{ archivedKey: "linear:ENG-9-zzzz9999", url: "u", docId: 1 }]);
+		expect(out[0].jolliReferenceDocId).toBeUndefined();
+		expect(out[0].jolliReferenceDocUrl).toBeUndefined();
+	});
+
+	it("returns the input unchanged when referenceUrls is empty", () => {
+		const refs = [reference()];
+		expect(applyReferenceUrls(refs, [])).toBe(refs);
+	});
+});
+
+describe("referenceBaseKey", () => {
+	it("keys on the stable <source>:<nativeId> (ignoring the per-commit archivedKey suffix)", () => {
+		expect(
+			referenceBaseKey(reference({ source: "linear", nativeId: "ENG-1", archivedKey: "linear:ENG-1-aaaa1111" })),
+		).toBe("linear:ENG-1");
+	});
+});
+
+describe("canReuseDocId", () => {
+	it("reuses when the stored doc URL's origin matches the current env", () => {
+		expect(canReuseDocId("https://jolli.ai/acme/o/eng/articles/x-5", "https://jolli.ai")).toBe(true);
+	});
+
+	it("does NOT reuse when the stored doc URL is from a different backend", () => {
+		expect(canReuseDocId("https://jolli-local.me/t/articles/x-5", "https://jolli.ai")).toBe(false);
+	});
+
+	it("reuses legacy (url-less) data so an upgrade doesn't orphan already-pushed docs", () => {
+		expect(canReuseDocId(undefined, "https://jolli.ai")).toBe(true);
+	});
+
+	it("treats an unparseable stored URL as env-agnostic rather than throwing", () => {
+		expect(canReuseDocId("not-a-url", "https://jolli.ai")).toBe(true);
 	});
 });
 
@@ -411,6 +494,57 @@ describe("assignOwnedAttachments", () => {
 		expect(ownedNotes.has("c2")).toBe(false);
 		expect(seedNoteDocIds.get("n1")).toBe(20);
 	});
+
+	it("dedupes a reference recurring across commits to ONE owner commit (latest referencedAt wins)", () => {
+		// Same ticket (ENG-1) referenced on two commits — different per-commit archivedKeys.
+		const older = leaf({
+			commitHash: "c1",
+			references: [reference({ archivedKey: "linear:ENG-1-c1", referencedAt: "2026-01-01T00:00:00.000Z" })],
+		});
+		const newer = leaf({
+			commitHash: "c2",
+			references: [reference({ archivedKey: "linear:ENG-1-c2", referencedAt: "2026-02-01T00:00:00.000Z" })],
+		});
+		const { ownedReferences } = assignOwnedAttachments([older, newer]);
+		// Only the newest-referencedAt commit owns the single push.
+		expect(ownedReferences.get("c2")?.[0].archivedKey).toBe("linear:ENG-1-c2");
+		expect(ownedReferences.has("c1")).toBe(false);
+	});
+
+	it("carries a prior commit's reference docId forward to the winner that lacks one (seeded)", () => {
+		const winner = leaf({
+			commitHash: "c1",
+			references: [reference({ archivedKey: "linear:ENG-1-c1", referencedAt: "2026-03-01T00:00:00.000Z" })],
+		});
+		const olderWithDocId = leaf({
+			commitHash: "c2",
+			references: [
+				reference({
+					archivedKey: "linear:ENG-1-c2",
+					referencedAt: "2026-02-01T00:00:00.000Z",
+					jolliReferenceDocId: 55,
+					jolliReferenceDocUrl: "https://jolli.ai/articles?doc=55",
+				}),
+			],
+		});
+		const { ownedReferences, seedReferenceDocIds } = assignOwnedAttachments([winner, olderWithDocId]);
+		expect(ownedReferences.get("c1")?.[0].jolliReferenceDocId).toBe(55);
+		// The seed URL rides with the seed docId so the woven URL matches the id it points at.
+		expect(ownedReferences.get("c1")?.[0].jolliReferenceDocUrl).toBe("https://jolli.ai/articles?doc=55");
+		expect(ownedReferences.has("c2")).toBe(false);
+		expect(seedReferenceDocIds.get("linear:ENG-1")).toBe(55);
+	});
+
+	it("keeps distinct references (different <source>:<nativeId>) as separate owned pushes", () => {
+		const summary = leaf({
+			references: [
+				reference({ source: "linear", nativeId: "ENG-1", archivedKey: "linear:ENG-1-c1" }),
+				reference({ source: "github", nativeId: "acme/repo#7", archivedKey: "github:acme/repo#7-c1" }),
+			],
+		});
+		const { ownedReferences } = assignOwnedAttachments([summary]);
+		expect(ownedReferences.get(summary.commitHash)).toHaveLength(2);
+	});
 });
 
 // ─── buildPushMarkdown ──────────────────────────────────────────────────────
@@ -474,6 +608,24 @@ describe("buildPushMarkdown", () => {
 		);
 		expect(md).toContain("## Context");
 		expect(md).toContain("PROJ-123");
+	});
+
+	it("links the Context reference row to the Space article when jolliReferenceDocUrl is set", () => {
+		const md = buildPushMarkdown(
+			leaf({
+				references: [
+					reference({
+						nativeId: "ENG-7",
+						title: "Ship it",
+						url: "https://linear.app/x",
+						jolliReferenceDocUrl: "https://jolli.ai/articles?doc=77",
+					}),
+				],
+			}),
+		);
+		// Points at the pushed Space article, not the external link.
+		expect(md).toContain("(https://jolli.ai/articles?doc=77)");
+		expect(md).not.toContain("(https://linear.app/x)");
 	});
 
 	it("renders the source commits section for multi-record summaries", () => {
@@ -566,9 +718,13 @@ describe("buildPushMarkdown", () => {
 // ─── pushSummary ────────────────────────────────────────────────────────────
 
 const BASE = "https://jolli.ai";
+const ENV_KEY = "https://jolli.ai";
 
+// `url: ""` (falsy) makes resolveArticleUrl fall back to the `?doc=<id>` form, which
+// keeps the URL-shape assertions below stable; the slug branch is covered directly
+// in the `resolveArticleUrl` describe. A test that needs the slug shape overrides `url`.
 function fakePushResult(overrides: Partial<PushResult> = {}): PushResult {
-	return { url: "unused", docId: 42, jrn: "jrn:1", created: true, ...overrides };
+	return { url: "", docId: 42, jrn: "jrn:1", created: true, ...overrides };
 }
 
 /** Builds a stub client — only the methods `pushSummary`/`pushBranchToJolli` call are ever invoked. */
@@ -586,6 +742,7 @@ function fakeClient(
 		}>;
 		deleteDoc: (docId: number) => Promise<void>;
 		resolveBaseUrl: () => Promise<string>;
+		resolveEnvKey: () => Promise<string>;
 	}> = {},
 ): JolliMemoryPushClient {
 	return {
@@ -594,6 +751,7 @@ function fakeClient(
 		createBinding: vi.fn(overrides.createBinding ?? (async () => ({ bindingId: 1, jmSpaceId: 1, repoName: "r" }))),
 		deleteDoc: vi.fn(overrides.deleteDoc ?? (async () => undefined)),
 		resolveBaseUrl: vi.fn(overrides.resolveBaseUrl ?? (async () => BASE)),
+		resolveEnvKey: vi.fn(overrides.resolveEnvKey ?? (async () => ENV_KEY)),
 	} as unknown as JolliMemoryPushClient;
 }
 
@@ -608,6 +766,7 @@ describe("pushSummary", () => {
 		vi.mocked(readNoteFromBranch).mockReset().mockResolvedValue(null);
 		vi.mocked(loadPushPending).mockReset().mockResolvedValue({ version: 1, entries: {} });
 		vi.mocked(getIndexEntryMap).mockReset().mockResolvedValue(new Map());
+		vi.mocked(readReferenceFromBranch).mockReset().mockResolvedValue(null);
 	});
 
 	it("deletes the freshly-pushed article and skips force-store when the commit became a child mid-push", async () => {
@@ -723,6 +882,36 @@ describe("pushSummary", () => {
 
 		const payload = vi.mocked(client.push).mock.calls[0][0];
 		expect(payload.docId).toBeUndefined();
+	});
+
+	it("writes back a doc URL whose origin keys to the current push env", async () => {
+		const client = fakeClient();
+		const { summary: pushed } = await pushSummary(leaf(), baseCtx(client));
+		// No separate env tag — the written-back URL's origin IS the env, so a
+		// same-env re-push would reuse this docId.
+		expect(canReuseDocId(pushed.jolliDocUrl, ENV_KEY)).toBe(true);
+	});
+
+	it("reuses the docId when the summary's stored URL origin matches the current env", async () => {
+		const client = fakeClient();
+		const summary = leaf({ jolliDocId: 7, jolliDocUrl: `${BASE}/articles?doc=7` });
+		await pushSummary(summary, baseCtx(client));
+		expect(client.push).toHaveBeenCalledWith(expect.objectContaining({ docId: 7 }));
+	});
+
+	it("does NOT reuse the docId when the summary was pushed to a different backend (creates fresh)", async () => {
+		const client = fakeClient();
+		const summary = leaf({
+			jolliDocId: 7,
+			jolliDocUrl: "https://jolli-local.me/t/articles?doc=7",
+		});
+		const { summary: pushed } = await pushSummary(summary, baseCtx(client));
+
+		const payload = vi.mocked(client.push).mock.calls[0][0];
+		expect(payload.docId).toBeUndefined();
+		// Write-back carries the freshly-created docId and a current-env URL.
+		expect(canReuseDocId(pushed.jolliDocUrl, ENV_KEY)).toBe(true);
+		expect(pushed.jolliDocId).toBe(42);
 	});
 
 	it("pushes an owned plan attachment once and writes its docId/url back onto the summary's plans", async () => {
@@ -1084,6 +1273,56 @@ describe("pushSummary", () => {
 
 		expect(client.deleteDoc).toHaveBeenCalledWith(100);
 		expect(client.deleteDoc).toHaveBeenCalledWith(201);
+	});
+
+	it("pushes a reference as a standalone `reference` article and writes its docId/url back", async () => {
+		const client = fakeClient({
+			push: async (payload) =>
+				payload.docType === "reference" ? fakePushResult({ docId: 77 }) : fakePushResult({ docId: 42 }),
+		});
+		const ref = reference({ archivedKey: "linear:ENG-1-a1b2c3d4" });
+		const summary = leaf({ references: [ref] });
+
+		const { summary: pushed } = await pushSummary(summary, baseCtx(client), {
+			plans: [],
+			notes: [],
+			references: [ref],
+		});
+
+		expect(client.push).toHaveBeenCalledWith(
+			expect.objectContaining({ docType: "reference", commitHash: summary.commitHash }),
+		);
+		expect(pushed.references?.[0].jolliReferenceDocId).toBe(77);
+		expect(pushed.references?.[0].jolliReferenceDocUrl).toBe(`${BASE}/articles?doc=77`);
+	});
+
+	it("reuses the reference docId when its stored URL origin matches the current env", async () => {
+		const client = fakeClient();
+		const ref = reference({ jolliReferenceDocId: 77, jolliReferenceDocUrl: `${BASE}/articles?doc=77` });
+		const summary = leaf({ references: [ref] });
+		await pushSummary(summary, baseCtx(client), { plans: [], notes: [], references: [ref] });
+
+		expect(client.push).toHaveBeenCalledWith(expect.objectContaining({ docType: "reference", docId: 77 }));
+	});
+
+	it("does NOT reuse the reference docId when it was minted against a different backend", async () => {
+		const client = fakeClient();
+		const ref = reference({
+			jolliReferenceDocId: 77,
+			jolliReferenceDocUrl: "https://jolli-local.me/t/articles?doc=77",
+		});
+		const summary = leaf({ references: [ref] });
+		await pushSummary(summary, baseCtx(client), { plans: [], notes: [], references: [ref] });
+
+		const refPayload = vi.mocked(client.push).mock.calls.find((c) => c[0].docType === "reference")?.[0];
+		expect(refPayload?.docId).toBeUndefined();
+	});
+
+	it("pushes the summary's own references when no attachment selection is given", async () => {
+		const client = fakeClient();
+		const summary = leaf({ references: [reference()] });
+		await pushSummary(summary, baseCtx(client));
+		expect(client.push).toHaveBeenCalledWith(expect.objectContaining({ docType: "reference" }));
 	});
 });
 

--- a/cli/src/core/JolliMemoryPushOrchestrator.ts
+++ b/cli/src/core/JolliMemoryPushOrchestrator.ts
@@ -10,9 +10,10 @@
  */
 
 import { createLogger } from "../Logger.js";
-import type { CommitSummary, NoteReference, PlanReference } from "../Types.js";
+import type { CommitSummary, NoteReference, PlanReference, ReferenceCommitRef } from "../Types.js";
 import { getDefaultBranch } from "./GitOps.js";
 import { buildBranchRelativePath, deriveRepoNameFromUrl, getCanonicalRepoUrl } from "./GitRemoteUtils.js";
+import { deriveJolliEnvKey, resolveArticleUrl } from "./JolliApiUtils.js";
 import {
 	BindingAlreadyExistsError,
 	BindingRequiredError,
@@ -23,9 +24,17 @@ import {
 } from "./JolliMemoryPushClient.js";
 import { loadBranchSummaries } from "./PrDescription.js";
 import { loadPushPending } from "./PushPendingStore.js";
+import { readReferenceMarkdownFromString } from "./references/ReferenceStore.js";
 import type { StorageProvider } from "./StorageProvider.js";
-import { buildNotePushTitle, buildPlanPushTitle, buildPushTitle, collectSortedTopics } from "./SummaryFormat.js";
 import {
+	buildNotePushTitle,
+	buildPlanPushTitle,
+	buildPushTitle,
+	buildReferencePushTitle,
+	collectSortedTopics,
+} from "./SummaryFormat.js";
+import {
+	buildReferencePushMarkdown,
 	pushE2eTestSection,
 	pushFooter,
 	pushPlansAndNotesSection,
@@ -41,6 +50,7 @@ import {
 	getSummary,
 	readNoteFromBranch,
 	readPlanFromBranch,
+	readReferenceFromBranch,
 	storeSummary,
 } from "./SummaryStore.js";
 
@@ -83,7 +93,27 @@ export function serializeSummaryJson(summary: CommitSummary): string | undefined
 	return json;
 }
 
-/** Merges published plan URLs/docIds into plan references (matched by exact slug). */
+/**
+ * A stored `jolliDocId` may be reused as an update target only when the article
+ * URL it was minted with points at the current push env. The env is NOT stored
+ * separately — the doc URL's origin already IS it, so `deriveJolliEnvKey(storedUrl)`
+ * recovers the backend the id belongs to. A URL from a different origin means the
+ * id lives on another backend, so we drop it and let the server create a fresh doc.
+ *
+ * A missing URL is legacy / never-pushed data (nothing to conflict with) →
+ * reuse allowed, preserving the pre-tagging always-reuse behavior. An unparseable
+ * URL is likewise treated as env-agnostic rather than throwing.
+ */
+export function canReuseDocId(storedDocUrl: string | undefined, currentEnv: string): boolean {
+	if (!storedDocUrl) return true;
+	try {
+		return deriveJolliEnvKey(storedDocUrl) === currentEnv;
+	} catch {
+		return true;
+	}
+}
+
+/** Merges published plan URLs/docIds into plan references (matched by exact slug). The URL's origin is the minting env — see {@link canReuseDocId}. */
 export function applyPlanUrls(
 	plans: ReadonlyArray<PlanReference> | undefined,
 	planUrls: ReadonlyArray<{ slug: string; url: string; docId: number }>,
@@ -96,7 +126,7 @@ export function applyPlanUrls(
 	});
 }
 
-/** Merges published note URLs/docIds into note references (matched by id). */
+/** Merges published note URLs/docIds into note references (matched by id). The URL's origin is the minting env — see {@link canReuseDocId}. */
 export function applyNoteUrls(
 	notes: ReadonlyArray<NoteReference>,
 	noteUrls: ReadonlyArray<{ id: string; url: string; docId: number }>,
@@ -105,6 +135,25 @@ export function applyNoteUrls(
 	return notes.map((n) => {
 		const pushed = urlMap.get(n.id);
 		return pushed ? { ...n, jolliNoteDocUrl: pushed.url, jolliNoteDocId: pushed.docId } : n;
+	});
+}
+
+/**
+ * Merges published reference URLs/docIds into commit references, matched by
+ * `archivedKey` — the exact per-commit array entry pointer
+ * (`<source>:<nativeId>-<shortHash>`), so a reference recurring across commits
+ * only weaves the URL into the entry that actually pushed. The URL's origin is
+ * the minting env — see {@link canReuseDocId}.
+ */
+export function applyReferenceUrls(
+	references: ReadonlyArray<ReferenceCommitRef>,
+	referenceUrls: ReadonlyArray<{ archivedKey: string; url: string; docId: number }>,
+): ReadonlyArray<ReferenceCommitRef> {
+	if (referenceUrls.length === 0) return references;
+	const urlMap = new Map(referenceUrls.map((r) => [r.archivedKey, r]));
+	return references.map((r) => {
+		const pushed = urlMap.get(r.archivedKey);
+		return pushed ? { ...r, jolliReferenceDocUrl: pushed.url, jolliReferenceDocId: pushed.docId } : r;
 	});
 }
 
@@ -142,7 +191,9 @@ function byUpdatedAtDesc(a: PlanReference, b: PlanReference): number {
  */
 export function latestPlanPerName(plans: ReadonlyArray<PlanReference>): ReadonlyArray<PlanReference> {
 	const sorted = [...plans].sort(byUpdatedAtDesc);
-	// Newest already-pushed docId/url per base name (first hit wins = newest).
+	// Newest already-pushed docId/url per base name (first hit wins = newest). The
+	// URL rides with the docId so the reuse gate downstream (`canReuseDocId`, which
+	// reads the URL's origin) can tell which backend the inherited id belongs to.
 	const pushedDoc = new Map<string, { docId: number; url: string | undefined }>();
 	for (const plan of sorted) {
 		const key = planBaseKey(plan.slug);
@@ -161,7 +212,11 @@ export function latestPlanPerName(plans: ReadonlyArray<PlanReference>): Readonly
 		if (plan.jolliPlanDocId === undefined) {
 			const inherited = pushedDoc.get(key);
 			if (inherited) {
-				result.push({ ...plan, jolliPlanDocId: inherited.docId, jolliPlanDocUrl: inherited.url });
+				result.push({
+					...plan,
+					jolliPlanDocId: inherited.docId,
+					jolliPlanDocUrl: inherited.url,
+				});
 				continue;
 			}
 		}
@@ -176,6 +231,8 @@ interface Winner<T> {
 	readonly ownerCommit: string;
 	/** A known docId for this plan/note (from any commit's prior push) so the push updates in place. */
 	readonly seedDocId?: number;
+	/** Article URL the `seedDocId` was minted with — rides with the id so the reuse gate (`canReuseDocId`, keyed on the URL's origin) can tell which backend it belongs to, and so the woven URL matches the id. */
+	readonly seedDocUrl?: string;
 }
 
 /**
@@ -191,11 +248,14 @@ interface Winner<T> {
 export function assignOwnedAttachments(subjectSummaries: ReadonlyArray<CommitSummary>): {
 	ownedPlans: Map<string, PlanReference[]>;
 	ownedNotes: Map<string, NoteReference[]>;
+	ownedReferences: Map<string, ReferenceCommitRef[]>;
 	seedPlanDocIds: Map<string, number>;
 	seedNoteDocIds: Map<string, number>;
+	seedReferenceDocIds: Map<string, number>;
 } {
 	const planWinners = new Map<string, Winner<PlanReference>>();
 	const noteWinners = new Map<string, Winner<NoteReference>>();
+	const referenceWinners = new Map<string, Winner<ReferenceCommitRef>>();
 	for (const summary of subjectSummaries) {
 		for (const plan of summary.plans ?? []) {
 			const key = planBaseKey(plan.slug);
@@ -208,15 +268,17 @@ export function assignOwnedAttachments(subjectSummaries: ReadonlyArray<CommitSum
 			if (!prev || byUpdatedAtDesc(plan, prev.ref) < 0) {
 				// This revision wins (or is the first seen). Its own docId is
 				// authoritative for the latest article; fall back to a docId a prior
-				// revision surfaced only when this one carries none.
+				// revision surfaced only when this one carries none. The URL tracks
+				// whichever revision actually supplied the docId.
 				const seedDocId = plan.jolliPlanDocId ?? prev?.seedDocId;
-				planWinners.set(key, { ref: plan, ownerCommit: summary.commitHash, seedDocId });
+				const seedDocUrl = plan.jolliPlanDocId !== undefined ? plan.jolliPlanDocUrl : prev?.seedDocUrl;
+				planWinners.set(key, { ref: plan, ownerCommit: summary.commitHash, seedDocId, seedDocUrl });
 			} else if (prev.seedDocId === undefined && plan.jolliPlanDocId !== undefined) {
 				// A losing (older) revision only fills in a docId the winner didn't
 				// already have. It must NEVER overwrite the winner's own docId —
 				// doing so would push the latest content to an older article and
 				// orphan (leak) the winner's real one.
-				planWinners.set(key, { ...prev, seedDocId: plan.jolliPlanDocId });
+				planWinners.set(key, { ...prev, seedDocId: plan.jolliPlanDocId, seedDocUrl: plan.jolliPlanDocUrl });
 			}
 		}
 		for (const note of summary.notes ?? []) {
@@ -226,33 +288,76 @@ export function assignOwnedAttachments(subjectSummaries: ReadonlyArray<CommitSum
 			// deterministic and NaN-free for a malformed/missing updatedAt.
 			if (!prev || note.updatedAt > prev.ref.updatedAt) {
 				const seedDocId = note.jolliNoteDocId ?? prev?.seedDocId;
-				noteWinners.set(note.id, { ref: note, ownerCommit: summary.commitHash, seedDocId });
+				const seedDocUrl = note.jolliNoteDocId !== undefined ? note.jolliNoteDocUrl : prev?.seedDocUrl;
+				noteWinners.set(note.id, { ref: note, ownerCommit: summary.commitHash, seedDocId, seedDocUrl });
 			} else if (prev.seedDocId === undefined && note.jolliNoteDocId !== undefined) {
-				noteWinners.set(note.id, { ...prev, seedDocId: note.jolliNoteDocId });
+				noteWinners.set(note.id, { ...prev, seedDocId: note.jolliNoteDocId, seedDocUrl: note.jolliNoteDocUrl });
+			}
+		}
+		for (const ref of summary.references ?? []) {
+			// A reference is identified across commits by its stable `<source>:<nativeId>`
+			// (Reference.mapKey), NOT its per-commit `archivedKey` — the same ticket
+			// referenced on two commits pushes to ONE Space article. Recency by
+			// `referencedAt` (string compare, newest wins, first-seen kept on a tie).
+			const key = referenceBaseKey(ref);
+			const prev = referenceWinners.get(key);
+			if (!prev || ref.referencedAt > prev.ref.referencedAt) {
+				const seedDocId = ref.jolliReferenceDocId ?? prev?.seedDocId;
+				const seedDocUrl = ref.jolliReferenceDocId !== undefined ? ref.jolliReferenceDocUrl : prev?.seedDocUrl;
+				referenceWinners.set(key, { ref, ownerCommit: summary.commitHash, seedDocId, seedDocUrl });
+			} else if (prev.seedDocId === undefined && ref.jolliReferenceDocId !== undefined) {
+				referenceWinners.set(key, {
+					...prev,
+					seedDocId: ref.jolliReferenceDocId,
+					seedDocUrl: ref.jolliReferenceDocUrl,
+				});
 			}
 		}
 	}
 
 	const ownedPlans = new Map<string, PlanReference[]>();
 	const ownedNotes = new Map<string, NoteReference[]>();
+	const ownedReferences = new Map<string, ReferenceCommitRef[]>();
 	const pushInto = <T>(map: Map<string, T[]>, commit: string, item: T): void => {
 		const arr = map.get(commit);
 		if (arr) arr.push(item);
 		else map.set(commit, [item]);
 	};
 	for (const w of planWinners.values()) {
-		pushInto(ownedPlans, w.ownerCommit, w.seedDocId ? { ...w.ref, jolliPlanDocId: w.seedDocId } : w.ref);
+		pushInto(
+			ownedPlans,
+			w.ownerCommit,
+			w.seedDocId ? { ...w.ref, jolliPlanDocId: w.seedDocId, jolliPlanDocUrl: w.seedDocUrl } : w.ref,
+		);
 	}
 	for (const w of noteWinners.values()) {
-		pushInto(ownedNotes, w.ownerCommit, w.seedDocId ? { ...w.ref, jolliNoteDocId: w.seedDocId } : w.ref);
+		pushInto(
+			ownedNotes,
+			w.ownerCommit,
+			w.seedDocId ? { ...w.ref, jolliNoteDocId: w.seedDocId, jolliNoteDocUrl: w.seedDocUrl } : w.ref,
+		);
+	}
+	for (const w of referenceWinners.values()) {
+		pushInto(
+			ownedReferences,
+			w.ownerCommit,
+			w.seedDocId ? { ...w.ref, jolliReferenceDocId: w.seedDocId, jolliReferenceDocUrl: w.seedDocUrl } : w.ref,
+		);
 	}
 
 	const seedPlanDocIds = new Map<string, number>();
 	const seedNoteDocIds = new Map<string, number>();
+	const seedReferenceDocIds = new Map<string, number>();
 	for (const w of planWinners.values()) if (w.seedDocId) seedPlanDocIds.set(planBaseKey(w.ref.slug), w.seedDocId);
 	for (const [id, w] of noteWinners) if (w.seedDocId) seedNoteDocIds.set(id, w.seedDocId);
+	for (const [key, w] of referenceWinners) if (w.seedDocId) seedReferenceDocIds.set(key, w.seedDocId);
 
-	return { ownedPlans, ownedNotes, seedPlanDocIds, seedNoteDocIds };
+	return { ownedPlans, ownedNotes, ownedReferences, seedPlanDocIds, seedNoteDocIds, seedReferenceDocIds };
+}
+
+/** Cross-commit dedup key for a reference: its stable `<source>:<nativeId>` (Reference.mapKey). */
+export function referenceBaseKey(ref: ReferenceCommitRef): string {
+	return `${ref.source}:${ref.nativeId}`;
 }
 
 // ── Push markdown ────────────────────────────────────────────────────────────
@@ -315,10 +420,12 @@ export interface PushContext {
 	readonly storage?: StorageProvider;
 }
 
-/** The plans/notes to push for a summary — caller-chosen, or the summary's own `latestPlanPerName` when omitted. */
+/** The plans/notes/references to push for a summary — caller-chosen, or the summary's own when omitted. */
 export interface AttachmentSelection {
 	readonly plans: ReadonlyArray<PlanReference>;
 	readonly notes: ReadonlyArray<NoteReference>;
+	/** Deduped (owner-commit) references; omit to push none for this summary (the branch path passes them explicitly). */
+	readonly references?: ReadonlyArray<ReferenceCommitRef>;
 }
 
 /** Result of pushing one summary: the persisted (write-back applied) summary, plus its article URL. */
@@ -348,11 +455,17 @@ export async function pushSummary(
 	attachments?: AttachmentSelection,
 ): Promise<PushSummaryResult> {
 	const displayBase = ctx.baseUrl.replace(/\/+$/, "");
+	// Env key of the tenant this push targets — every docId minted below is tagged
+	// with it, and an existing docId is reused as an update target only when its
+	// tag matches (see `canReuseDocId`). No network I/O.
+	const envKey = await ctx.client.resolveEnvKey();
 	const plansToPush = attachments ? attachments.plans : latestPlanPerName(summary.plans ?? []);
 	const notesToPush = attachments ? attachments.notes : (summary.notes ?? []);
+	const referencesToPush = attachments ? (attachments.references ?? []) : (summary.references ?? []);
 
-	const planUrls = await pushPlanList(plansToPush, summary, ctx, displayBase);
-	const noteUrls = await pushNoteList(notesToPush, summary, ctx, displayBase);
+	const planUrls = await pushPlanList(plansToPush, summary, ctx, displayBase, envKey);
+	const noteUrls = await pushNoteList(notesToPush, summary, ctx, displayBase, envKey);
+	const referenceUrls = await pushReferenceList(referencesToPush, summary, ctx, displayBase, envKey);
 
 	// Weave the published URLs into the summary markdown (so the article's Plans
 	// & Notes list links to the published docs). Dedupe same-named plan
@@ -365,10 +478,14 @@ export async function pushSummary(
 		applyPlanUrls(dedupedPlans, planUrls) ?? /* v8 ignore start -- unreachable: see comment above */ dedupedPlans;
 	/* v8 ignore stop */
 	const notesWithUrls = summary.notes ? applyNoteUrls(summary.notes, noteUrls) : summary.notes;
+	const referencesWithUrls = summary.references
+		? applyReferenceUrls(summary.references, referenceUrls)
+		: summary.references;
 	const summaryForMarkdown: CommitSummary = {
 		...summary,
 		plans: plansWithUrls,
 		...(notesWithUrls !== summary.notes && { notes: notesWithUrls }),
+		...(referencesWithUrls !== summary.references && { references: referencesWithUrls }),
 	};
 	const markdown = buildPushMarkdown(summaryForMarkdown);
 	// The structured twin of the markdown article, from the same enriched copy —
@@ -381,13 +498,14 @@ export async function pushSummary(
 		commitHash: summary.commitHash,
 		docType: "summary",
 		branch: summary.branch,
-		...(summary.jolliDocId !== undefined && { docId: summary.jolliDocId }),
+		...(summary.jolliDocId !== undefined &&
+			canReuseDocId(summary.jolliDocUrl, envKey) && { docId: summary.jolliDocId }),
 		repoUrl: ctx.repoUrl,
 		relativePath: buildBranchRelativePath(summary.branch),
 		...(summaryJson && { summaryJson }),
 	});
 
-	const summaryUrl = `${displayBase}/articles?doc=${result.docId}`;
+	const summaryUrl = resolveArticleUrl(displayBase, result.url, result.docId);
 
 	// Post-push race check: `processPushPending` already skipped hashes that
 	// were children at claim time, but the user could have amend/squashed this
@@ -425,6 +543,9 @@ export async function pushSummary(
 		jolliDocId: result.docId,
 		...(planUrls.length > 0 ? { plans: applyPlanUrls(summary.plans, planUrls) } : {}),
 		...(noteUrls.length > 0 && summary.notes ? { notes: applyNoteUrls(summary.notes, noteUrls) } : {}),
+		...(referenceUrls.length > 0 && summary.references
+			? { references: applyReferenceUrls(summary.references, referenceUrls) }
+			: {}),
 	};
 	await storeSummary(updatedSummary, ctx.cwd, true, undefined, ctx.storage);
 
@@ -513,6 +634,7 @@ async function pushPlanList(
 	summary: CommitSummary,
 	ctx: PushContext,
 	displayBase: string,
+	envKey: string,
 ): Promise<Array<{ slug: string; url: string; docId: number }>> {
 	const results: Array<{ slug: string; url: string; docId: number }> = [];
 	for (const plan of plans) {
@@ -529,7 +651,8 @@ async function pushPlanList(
 				commitHash: summary.commitHash,
 				docType: "plan",
 				branch: summary.branch,
-				...(plan.jolliPlanDocId !== undefined && { docId: plan.jolliPlanDocId }),
+				...(plan.jolliPlanDocId !== undefined &&
+					canReuseDocId(plan.jolliPlanDocUrl, envKey) && { docId: plan.jolliPlanDocId }),
 				repoUrl: ctx.repoUrl,
 				relativePath: buildBranchRelativePath(summary.branch),
 			});
@@ -540,7 +663,7 @@ async function pushPlanList(
 		}
 		results.push({
 			slug: plan.slug,
-			url: `${displayBase}/articles?doc=${planResult.docId}`,
+			url: resolveArticleUrl(displayBase, planResult.url, planResult.docId),
 			docId: planResult.docId,
 		});
 	}
@@ -553,6 +676,7 @@ async function pushNoteList(
 	summary: CommitSummary,
 	ctx: PushContext,
 	displayBase: string,
+	envKey: string,
 ): Promise<Array<{ id: string; url: string; docId: number }>> {
 	const results: Array<{ id: string; url: string; docId: number }> = [];
 	for (const note of notes) {
@@ -569,7 +693,8 @@ async function pushNoteList(
 				commitHash: summary.commitHash,
 				docType: "note",
 				branch: summary.branch,
-				...(note.jolliNoteDocId !== undefined && { docId: note.jolliNoteDocId }),
+				...(note.jolliNoteDocId !== undefined &&
+					canReuseDocId(note.jolliNoteDocUrl, envKey) && { docId: note.jolliNoteDocId }),
 				repoUrl: ctx.repoUrl,
 				relativePath: buildBranchRelativePath(summary.branch),
 			});
@@ -580,8 +705,63 @@ async function pushNoteList(
 		}
 		results.push({
 			id: note.id,
-			url: `${displayBase}/articles?doc=${noteResult.docId}`,
+			url: resolveArticleUrl(displayBase, noteResult.url, noteResult.docId),
 			docId: noteResult.docId,
+		});
+	}
+	return results;
+}
+
+/**
+ * Uploads the given archived references as standalone `reference` articles,
+ * returning their published URLs keyed by `archivedKey`. The body is synthesized
+ * from the value snapshot ({@link buildReferencePushMarkdown}) since a reference
+ * has no on-disk file. Like {@link pushPlanList}, a single transient failure is
+ * logged and skipped while `BindingRequiredError` / `ClientOutdatedError` propagate.
+ */
+async function pushReferenceList(
+	references: ReadonlyArray<ReferenceCommitRef>,
+	summary: CommitSummary,
+	ctx: PushContext,
+	displayBase: string,
+	envKey: string,
+): Promise<Array<{ archivedKey: string; url: string; docId: number }>> {
+	const results: Array<{ archivedKey: string; url: string; docId: number }> = [];
+	for (const ref of references) {
+		// Read the archived body from the orphan-branch snapshot so the pushed article
+		// carries the SAME content VS Code shows locally (the local `.md` is deleted at
+		// commit time; the orphan-branch snapshot is the system of record). Missing/
+		// unparseable → header-only, never a failed push.
+		const storedMd = await readReferenceFromBranch(ref.source, ref.archivedKey, ctx.cwd, ctx.storage);
+		const description = storedMd
+			? (readReferenceMarkdownFromString(storedMd)?.description ?? undefined)
+			: undefined;
+		let refResult: Awaited<ReturnType<JolliMemoryPushClient["push"]>>;
+		try {
+			refResult = await ctx.client.push({
+				title: buildReferencePushTitle(ref),
+				content: buildReferencePushMarkdown(ref, description),
+				commitHash: summary.commitHash,
+				docType: "reference",
+				branch: summary.branch,
+				...(ref.jolliReferenceDocId !== undefined &&
+					canReuseDocId(ref.jolliReferenceDocUrl, envKey) && { docId: ref.jolliReferenceDocId }),
+				repoUrl: ctx.repoUrl,
+				relativePath: buildBranchRelativePath(summary.branch),
+			});
+		} catch (err) {
+			if (err instanceof BindingRequiredError || err instanceof ClientOutdatedError) throw err;
+			log.error(
+				"Reference %s push FAILED: %s",
+				ref.archivedKey,
+				err instanceof Error ? err.message : String(err),
+			);
+			continue;
+		}
+		results.push({
+			archivedKey: ref.archivedKey,
+			url: resolveArticleUrl(displayBase, refResult.url, refResult.docId),
+			docId: refResult.docId,
 		});
 	}
 	return results;
@@ -702,12 +882,13 @@ export async function pushBranchToJolli(opts: PushBranchOpts): Promise<PushBranc
 		// then push oldest→newest passing each summary its OWNED (deduped) attachments.
 		// seedPlanDocIds/seedNoteDocIds are also returned (kept for vscode parity) but
 		// unused here — seeds are already applied to the owned plan/note refs.
-		const { ownedPlans, ownedNotes } = assignOwnedAttachments(summaries);
+		const { ownedPlans, ownedNotes, ownedReferences } = assignOwnedAttachments(summaries);
 		const urls: string[] = [];
 		for (const s of summaries) {
 			const attachments: AttachmentSelection = {
 				plans: ownedPlans.get(s.commitHash) ?? [],
 				notes: ownedNotes.get(s.commitHash) ?? [],
+				references: ownedReferences.get(s.commitHash) ?? [],
 			};
 			// BindingRequiredError propagates — fatal for the whole batch.
 			const { summaryUrl } = await pushSummary(s, ctx, attachments);

--- a/cli/src/core/PushExecutor.test.ts
+++ b/cli/src/core/PushExecutor.test.ts
@@ -70,8 +70,10 @@ beforeEach(() => {
 	vi.mocked(assignOwnedAttachments).mockReturnValue({
 		ownedPlans: new Map(),
 		ownedNotes: new Map(),
+		ownedReferences: new Map(),
 		seedPlanDocIds: new Map(),
 		seedNoteDocIds: new Map(),
+		seedReferenceDocIds: new Map(),
 	});
 	vi.mocked(pushSummary).mockResolvedValue({ summary: summary(HASH_A), summaryUrl: "https://acme.jolli.ai/a" });
 	vi.mocked(updateBatch).mockResolvedValue(undefined);
@@ -259,8 +261,10 @@ describe("processPushPending", () => {
 		vi.mocked(assignOwnedAttachments).mockReturnValue({
 			ownedPlans: new Map([[HASH_A, [{ slug: "p-1234abcd" }]]]) as never,
 			ownedNotes: new Map(),
+			ownedReferences: new Map(),
 			seedPlanDocIds: new Map(),
 			seedNoteDocIds: new Map(),
+			seedReferenceDocIds: new Map(),
 		});
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
 		await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
@@ -290,8 +294,10 @@ describe("processPushPending", () => {
 		vi.mocked(assignOwnedAttachments).mockReturnValue({
 			ownedPlans: new Map([[HASH_A, [{ slug: "off-plan" }]]]) as never,
 			ownedNotes: new Map(),
+			ownedReferences: new Map(),
 			seedPlanDocIds: new Map(),
 			seedNoteDocIds: new Map(),
+			seedReferenceDocIds: new Map(),
 		});
 		vi.mocked(loadPushPending).mockResolvedValue({
 			version: 1,

--- a/cli/src/core/PushExecutor.ts
+++ b/cli/src/core/PushExecutor.ts
@@ -185,6 +185,7 @@ async function buildAttachmentOwnership(
 ): Promise<{
 	ownedPlans: Map<string, NonNullable<CommitSummary["plans"]>>;
 	ownedNotes: Map<string, NonNullable<CommitSummary["notes"]>>;
+	ownedReferences: Map<string, NonNullable<CommitSummary["references"]>>;
 }> {
 	const branches = new Set(hashes.map((hash) => pendingEntries[hash].branch));
 	const contexts = new Map<string, Map<string, CommitSummary>>();
@@ -219,13 +220,15 @@ async function buildAttachmentOwnership(
 
 	const ownedPlans = new Map<string, NonNullable<CommitSummary["plans"]>>();
 	const ownedNotes = new Map<string, NonNullable<CommitSummary["notes"]>>();
+	const ownedReferences = new Map<string, NonNullable<CommitSummary["references"]>>();
 	for (const context of contexts.values()) {
 		const summaries = [...context.values()].sort((a, b) => a.generatedAt.localeCompare(b.generatedAt));
 		const owned = assignOwnedAttachments(summaries);
 		for (const [hash, plans] of owned.ownedPlans) ownedPlans.set(hash, plans);
 		for (const [hash, notes] of owned.ownedNotes) ownedNotes.set(hash, notes);
+		for (const [hash, references] of owned.ownedReferences) ownedReferences.set(hash, references);
 	}
-	return { ownedPlans, ownedNotes };
+	return { ownedPlans, ownedNotes, ownedReferences };
 }
 
 /**
@@ -366,7 +369,7 @@ export async function processPushPending(
 		return { ...empty, skippedNoMemory, skippedRetryExhausted, deletedChildren, note };
 	}
 
-	const { ownedPlans, ownedNotes } = await buildAttachmentOwnership(
+	const { ownedPlans, ownedNotes, ownedReferences } = await buildAttachmentOwnership(
 		cwd,
 		storage,
 		claimedEntries,
@@ -400,6 +403,7 @@ export async function processPushPending(
 			const attachments: AttachmentSelection = {
 				plans: ownedPlans.get(hash) ?? [],
 				notes: ownedNotes.get(hash) ?? [],
+				references: ownedReferences.get(hash) ?? [],
 			};
 			try {
 				await pushSummary(summary, ctx, attachments);

--- a/cli/src/core/SummaryFormat.test.ts
+++ b/cli/src/core/SummaryFormat.test.ts
@@ -5,6 +5,7 @@ import {
 	buildPanelTitle,
 	buildPlanPushTitle,
 	buildPushTitle,
+	buildReferencePushTitle,
 	collectAllNotes,
 	collectAllNotesWithHosts,
 	collectAllPlans,
@@ -243,6 +244,29 @@ describe("buildNotePushTitle", () => {
 	it("returns the note title without metadata prefix", () => {
 		const title = buildNotePushTitle(leaf(), "My Note");
 		expect(title).toBe("My Note");
+	});
+});
+
+describe("buildReferencePushTitle", () => {
+	it("leads with the source label + nativeId for tracker sources", () => {
+		expect(buildReferencePushTitle({ source: "linear", nativeId: "ENG-123", title: "Fix login bug" })).toBe(
+			"Linear · ENG-123 — Fix login bug",
+		);
+		expect(buildReferencePushTitle({ source: "github", nativeId: "owner/repo#42", title: "Bug" })).toBe(
+			// `/` in the nativeId is stripped by sanitizeTitle (path-unsafe), leaving a space.
+			"GitHub · owner repo#42 — Bug",
+		);
+	});
+
+	it("leads with the source label alone for machine-id sources (no ugly id prefix)", () => {
+		// Slack/Notion nativeIds are machine ids, so the display title is title-only;
+		// the source label still scopes the slug into a per-source namespace.
+		expect(buildReferencePushTitle({ source: "slack", nativeId: "C1-1700000000.1", title: "Deploy thread" })).toBe(
+			"Slack · Deploy thread",
+		);
+		expect(buildReferencePushTitle({ source: "notion", nativeId: "abcdef12", title: "Onboarding doc" })).toBe(
+			"Notion · Onboarding doc",
+		);
 	});
 });
 

--- a/cli/src/core/SummaryFormat.ts
+++ b/cli/src/core/SummaryFormat.ts
@@ -7,6 +7,11 @@
  */
 
 import type { CommitSummary, LlmCredentialSource, NoteReference, PlanReference } from "../Types.js";
+import {
+	type DisplayableReference,
+	referenceDisplayTitle,
+	referenceSourceLabel,
+} from "./references/ReferenceDisplay.js";
 import { collectDisplayTopics, collectSourceNodes, type TopicWithDate } from "./SummaryTree.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -209,6 +214,20 @@ export function buildPlanPushTitle(_summary: CommitSummary, planTitle: string): 
 /** Builds the note document title for pushing to Jolli Space. */
 export function buildNotePushTitle(_summary: CommitSummary, noteTitle: string): string {
 	return sanitizeTitle(noteTitle);
+}
+
+/**
+ * Builds the reference document title for pushing to Jolli Space. Leads with the
+ * human source label (`Linear: …`, `Slack: …`) followed by the unified display
+ * title ({@link referenceDisplayTitle} — which itself prefixes the nativeId for
+ * the trackers). The source prefix keeps the article recognizable in the Space
+ * tree AND scopes its generated slug into a per-source namespace, so a reference
+ * never collides with a plan/note/summary sharing the same base title.
+ */
+export function buildReferencePushTitle(ref: DisplayableReference): string {
+	// Middle-dot (not a colon — sanitizeTitle strips `:`) so the source label stays
+	// visually distinct from the ` — ` referenceDisplayTitle puts before the title.
+	return sanitizeTitle(`${referenceSourceLabel(ref.source)} · ${referenceDisplayTitle(ref)}`);
 }
 
 // ─── Topic collection ─────────────────────────────────────────────────────────

--- a/cli/src/core/SummaryMarkdownBuilder.test.ts
+++ b/cli/src/core/SummaryMarkdownBuilder.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
-import type { CommitSummary } from "../Types.js";
+import type { CommitSummary, ReferenceCommitRef } from "../Types.js";
 import {
 	buildMarkdown,
+	buildReferencePushMarkdown,
 	pushExcludedContextSection,
 	pushFooter,
 	pushPlansAndNotesSection,
@@ -492,6 +493,24 @@ describe("pushPlansAndNotesSection references gating", () => {
 		expect(out).not.toContain("C1-1700000000.1 —");
 		expect(out).not.toContain("abcdef12 —");
 	});
+	it("links to the pushed Space article when jolliReferenceDocUrl is present", () => {
+		const pushed = {
+			plans: [],
+			notes: [],
+			references: [
+				{
+					source: "linear",
+					nativeId: "ENG-1",
+					title: "Fix",
+					url: "https://l/ENG-1",
+					jolliReferenceDocUrl: "https://jolli.ai/articles?doc=9",
+				},
+			],
+		} as never;
+		const lines: string[] = [];
+		pushPlansAndNotesSection(lines, pushed, { includeReferences: true });
+		expect(lines.join("\n")).toContain("[ENG-1 — Fix](https://jolli.ai/articles?doc=9)");
+	});
 });
 
 describe("pushExcludedContextSection", () => {
@@ -527,6 +546,60 @@ describe("pushExcludedContextSection", () => {
 	it("buildMarkdown includes the excluded-context details block", () => {
 		const md = buildMarkdown(leaf({ excludedContext: [{ kind: "note", key: "n1", title: "T", reason: "r" }] }));
 		expect(md).toContain("AI judged 1 context item(s) unrelated");
+	});
+});
+
+// ─── buildReferencePushMarkdown ──────────────────────────────────────────────
+
+describe("buildReferencePushMarkdown", () => {
+	const ref: ReferenceCommitRef = {
+		archivedKey: "linear:ENG-1-a1b2c3d4",
+		source: "linear",
+		nativeId: "ENG-1",
+		title: "Fix login bug",
+		url: "https://linear.app/acme/issue/ENG-1",
+		referencedAt: "2026-01-01T00:00:00.000Z",
+		sourceToolName: "Claude Code",
+	};
+
+	it("renders the external link and source as an article body", () => {
+		const md = buildReferencePushMarkdown(ref);
+		expect(md).toContain("**Link:** [https://linear.app/acme/issue/ENG-1](https://linear.app/acme/issue/ENG-1)");
+		expect(md).toContain("**Source:** Claude Code");
+	});
+
+	it("renders source-specific fields as a table, escaping pipes/newlines", () => {
+		const withFields = {
+			...ref,
+			fields: [
+				{ key: "status", label: "Status", value: "In Progress" },
+				{ key: "assignee", label: "Assignee", value: "a | b\nnext" },
+				{ key: "path", label: "Path", value: "C:\\repo|x" },
+			],
+		} as never;
+		const md = buildReferencePushMarkdown(withFields);
+		expect(md).toContain("| Field | Value |");
+		expect(md).toContain("| Status | In Progress |");
+		// Pipe escaped, newline flattened so the row can't break the table.
+		expect(md).toContain("| Assignee | a \\| b next |");
+		// Backslash escaped BEFORE the pipe, so a trailing `\` can't revive the separator.
+		expect(md).toContain("| Path | C:\\\\repo\\|x |");
+	});
+
+	it("omits the table when there are no fields", () => {
+		expect(buildReferencePushMarkdown(ref)).not.toContain("| Field | Value |");
+	});
+
+	it("appends the stored description body (trimmed) below the header when provided", () => {
+		const md = buildReferencePushMarkdown(ref, "\n\nFull issue description.\nSecond line.\n\n");
+		expect(md).toContain("**Source:** Claude Code");
+		expect(md).toContain("Full issue description.\nSecond line.");
+		// Edge newlines trimmed so the render is stable.
+		expect(md.endsWith("Second line.")).toBe(true);
+	});
+
+	it("omits the body when the description is empty/absent (header only)", () => {
+		expect(buildReferencePushMarkdown(ref, "")).toBe(buildReferencePushMarkdown(ref));
 	});
 });
 

--- a/cli/src/core/SummaryMarkdownBuilder.ts
+++ b/cli/src/core/SummaryMarkdownBuilder.ts
@@ -188,8 +188,11 @@ export function pushPlansAndNotesSection(
 	}
 
 	for (const e of referencesBySourceOrder(references)) {
+		// Prefer the pushed Space article; fall back to the external link when the
+		// reference hasn't been pushed (or the push failed) so the row is never dead.
 		const label = escMdLinkText(referenceDisplayTitle(e));
-		lines.push(e.url ? `- [${label}](${escMdUrl(e.url)})` : `- ${label}`);
+		const target = e.jolliReferenceDocUrl ?? e.url;
+		lines.push(target ? `- [${label}](${escMdUrl(target)})` : `- ${label}`);
 	}
 }
 
@@ -213,6 +216,44 @@ export function pushExcludedContextSection(lines: Array<string>, summary: Commit
 		if (e.reason) lines.push(`  — ${escMdLinkText(e.reason)}`);
 	}
 	lines.push("", "</details>");
+}
+
+/**
+ * Builds the article body pushed for a single archived reference (docType
+ * `reference`). The header — the external link, the originating tool, and the
+ * source-specific `fields` as a table — is synthesized from the `ReferenceCommitRef`
+ * value snapshot (native id + title become the article TITLE, see
+ * `buildReferencePushTitle`, so they aren't repeated). `description` is the stored
+ * markdown body (the issue/PR/page content) that the caller reads back from the
+ * orphan-branch snapshot (`readReferenceFromBranch`) so the pushed article carries
+ * the SAME body VS Code shows locally, rather than a thinner card. Omitted (header
+ * only) when the snapshot has no body or can't be read.
+ */
+export function buildReferencePushMarkdown(ref: ReferenceCommitRef, description?: string): string {
+	const lines: Array<string> = [];
+	// `url` is optional (e.g. Slack references may carry none) — omit the row rather than emit a dead link.
+	if (ref.url) {
+		lines.push(`- **Link:** [${escMdLinkText(ref.url)}](${escMdUrl(ref.url)})`);
+	}
+	lines.push(`- **Source:** ${escMdLinkText(ref.sourceToolName)}`);
+	const fields = ref.fields ?? [];
+	if (fields.length > 0) {
+		lines.push("", "| Field | Value |", "| --- | --- |");
+		for (const f of fields) {
+			// Escape backslashes first, then pipes, and normalize newlines so a field
+			// value can't break the table layout (a trailing `\` must not turn the
+			// escaped `\|` back into a literal cell separator).
+			const cell = (s: string) => s.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+			lines.push(`| ${cell(f.label)} | ${cell(f.value)} |`);
+		}
+	}
+	// The stored body (source content) below the header, matching the local reference
+	// markdown VS Code renders. Trim edges so the render stays stable.
+	const body = description?.replace(/^\n+/, "").replace(/\n+$/, "");
+	if (body) {
+		lines.push("", body);
+	}
+	return lines.join("\n");
 }
 
 /** Appends the E2E test guide section (shared between clipboard and PR markdown). */

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -655,7 +655,12 @@ export interface JolliMetaHoistResult {
 
 /** Recursively collects jolliDocId/jolliDocUrl from children, picks newest as winner. */
 export function collectChildJolliMeta(nodes: ReadonlyArray<CommitSummary>): JolliMetaHoistResult {
-	const candidates: Array<{ jolliDocId: number; jolliDocUrl: string; commitDate: string; generatedAt: string }> = [];
+	const candidates: Array<{
+		jolliDocId: number;
+		jolliDocUrl: string;
+		commitDate: string;
+		generatedAt: string;
+	}> = [];
 	for (const node of nodes) {
 		const url = node.jolliDocUrl;
 		if (node.jolliDocId && url) {
@@ -1126,7 +1131,10 @@ async function mergeManyToOneLocked(
 		...(hoistedPlans.length > 0 && { plans: hoistedPlans }),
 		...(hoistedNotes.length > 0 && { notes: hoistedNotes }),
 		...(hoistedReferences.length > 0 && { references: hoistedReferences }),
-		...(jolliMeta.winner && { jolliDocId: jolliMeta.winner.jolliDocId, jolliDocUrl: jolliMeta.winner.jolliDocUrl }),
+		...(jolliMeta.winner && {
+			jolliDocId: jolliMeta.winner.jolliDocId,
+			jolliDocUrl: jolliMeta.winner.jolliDocUrl,
+		}),
 		...(allOrphanedDocIds.length > 0 && { orphanedDocIds: allOrphanedDocIds }),
 		...(unresolvedOrphanHashes.length > 0 && { unresolvedOrphanHashes }),
 		topics: consolidatedTopics,

--- a/cli/src/core/references/ReferenceDisplay.test.ts
+++ b/cli/src/core/references/ReferenceDisplay.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { labelLeadsWithNativeId, referenceDisplayTitle } from "./ReferenceDisplay.js";
+import { labelLeadsWithNativeId, referenceDisplayTitle, referenceSourceLabel } from "./ReferenceDisplay.js";
 
 describe("labelLeadsWithNativeId", () => {
 	it("leads with the nativeId for the issue trackers (recognizable keys)", () => {
@@ -19,5 +19,20 @@ describe("referenceDisplayTitle", () => {
 		expect(referenceDisplayTitle({ source: "slack", nativeId: "C1-1700000000.1", title: "Thread" })).toBe("Thread");
 		expect(referenceDisplayTitle({ source: "notion", nativeId: "abcdef12", title: "Page" })).toBe("Page");
 		expect(referenceDisplayTitle({ source: "zoom", nativeId: "z1", title: "Recording" })).toBe("Recording");
+	});
+});
+
+describe("referenceSourceLabel", () => {
+	it("returns the proper cased name for known sources", () => {
+		expect(referenceSourceLabel("linear")).toBe("Linear");
+		expect(referenceSourceLabel("jira")).toBe("Jira");
+		expect(referenceSourceLabel("github")).toBe("GitHub");
+		expect(referenceSourceLabel("slack")).toBe("Slack");
+		expect(referenceSourceLabel("notion")).toBe("Notion");
+	});
+	it("capitalizes an unknown/phase-2 source as a sensible fallback", () => {
+		expect(referenceSourceLabel("zoom")).toBe("Zoom");
+		expect(referenceSourceLabel("phase2-custom")).toBe("Phase2-custom");
+		expect(referenceSourceLabel("")).toBe("");
 	});
 });

--- a/cli/src/core/references/ReferenceDisplay.ts
+++ b/cli/src/core/references/ReferenceDisplay.ts
@@ -11,11 +11,29 @@
  * leads with the title alone. The default is title-only; the three trackers
  * opt in, so a new source needs no change here to render sensibly.
  */
+import { getRegistry } from "./SourceDefinitionRegistry.js";
+
 const NATIVE_ID_TRACKER_SOURCES: ReadonlySet<string> = new Set(["linear", "jira", "github"]);
 
 /** True when a reference label should lead with `<nativeId> — ` before its title. */
 export function labelLeadsWithNativeId(source: string): boolean {
 	return NATIVE_ID_TRACKER_SOURCES.has(source);
+}
+
+/**
+ * Human display name for a reference source (`Linear`, `GitHub`, …), read from
+ * the source's registered {@link SourceDefinition.label} — the single place the
+ * name is defined, so built-in and phase-2 config sources both resolve with no
+ * per-source code here. Used to prefix the pushed article title so it's
+ * recognizable in the Space tree AND its slug lands in a source-scoped
+ * namespace (a `reference` never collides with a same-titled plan/note/summary).
+ * Falls back to a capitalized `source` only for an unregistered id (defensive —
+ * stored references always carry a registered source).
+ */
+export function referenceSourceLabel(source: string): string {
+	const label = getRegistry().byId(source)?.label;
+	if (label !== undefined) return label;
+	return source ? source.charAt(0).toUpperCase() + source.slice(1) : source;
 }
 
 /** The minimal shape {@link referenceDisplayTitle} reads — satisfied by both the cli `Reference`/`ReferenceCommitRef` and the vscode `ReferenceInfo`. */

--- a/vscode/src/services/BranchShareController.test.ts
+++ b/vscode/src/services/BranchShareController.test.ts
@@ -36,15 +36,18 @@ describe("revokeShare", () => {
 		const commitHash = "c".repeat(40);
 		h.getShare.mockResolvedValue({ shareId: "sh_2" });
 		await revokeShare("/repo", "feature/x", "KEY", commitHash);
-		expect(h.getShare).toHaveBeenCalledWith("/repo", "feature/x", commitHash);
+		// "KEY" is not a decodable sk-jol- key, so the derived env key is undefined.
+		expect(h.getShare).toHaveBeenCalledWith("/repo", "feature/x", undefined, commitHash);
 		expect(h.removeShare).toHaveBeenCalledWith("/repo", "feature/x", commitHash);
 	});
 
-	it("skips the server call when there is no stored share (still clears locally)", async () => {
+	it("skips the server call AND the local delete when no matching share (foreign/absent record preserved)", async () => {
+		// getShare is env-scoped: a foreign-backend record reads as undefined. Deleting it
+		// locally would orphan a still-live link, so the record is left on disk.
 		h.getShare.mockResolvedValue(undefined);
 		await revokeShare("/repo", "feature/x", "KEY");
 		expect(h.revokeBranchShare).not.toHaveBeenCalled();
-		expect(h.removeShare).toHaveBeenCalledWith("/repo", "feature/x", undefined);
+		expect(h.removeShare).not.toHaveBeenCalled();
 	});
 });
 
@@ -174,7 +177,7 @@ describe("patchShareAudience", () => {
 		h.getShare.mockResolvedValue({ ...MEMBER, commitHash });
 		h.updateLiveShare.mockResolvedValue({ shareId: "sh_1", visibility: "people" });
 		await patchShareAudience("/repo", "feature/x", "KEY", { visibility: "people" }, commitHash);
-		expect(h.getShare).toHaveBeenCalledWith("/repo", "feature/x", commitHash);
+		expect(h.getShare).toHaveBeenCalledWith("/repo", "feature/x", undefined, commitHash);
 		expect(h.putBranchShare).toHaveBeenCalledWith("/repo", "feature/x", expect.any(Object), commitHash);
 	});
 });

--- a/vscode/src/services/BranchShareController.ts
+++ b/vscode/src/services/BranchShareController.ts
@@ -19,6 +19,7 @@ import {
 	putBranchShare,
 	removeShare,
 } from "../../../cli/src/core/BranchShareStore.js";
+import { deriveJolliBackendKeyFromApiKey } from "../../../cli/src/core/JolliApiUtils.js";
 import { revokeBranchShare, updateLiveShare } from "./JolliShareService.js";
 
 /** A subject's access change: the visibility tier and/or the invited-people allowlist. */
@@ -29,18 +30,31 @@ export interface ShareAudiencePatch {
 	readonly recipients?: ReadonlyArray<string>;
 }
 
-/** Revokes a subject's link (if present) and clears its record. Idempotent. */
+/**
+ * Revokes a subject's link (if present) and clears its record. Idempotent.
+ *
+ * Only touches the local record when it belongs to the CURRENT backend (the env-scoped
+ * `getShare` resolves it). A record minted against a DIFFERENT backend reads as absent
+ * here and is left on disk rather than deleted, so its still-live link stays revocable
+ * after switching the API key back — deleting it would orphan the link server-side.
+ */
 export async function revokeShare(
 	workspaceRoot: string,
 	branch: string,
 	apiKey: string,
 	commitHash?: string,
 ): Promise<void> {
-	const existing = await getShare(workspaceRoot, branch, commitHash);
+	const existing = await getShare(workspaceRoot, branch, deriveJolliBackendKeyFromApiKey(apiKey), commitHash);
 	if (existing?.shareId) {
 		await revokeBranchShare(undefined, apiKey, existing.shareId);
 	}
-	await removeShare(workspaceRoot, branch, commitHash);
+	// Clear the local record whenever it belongs to the CURRENT backend (getShare
+	// only returns current-backend records) — including a partial record that never
+	// got a shareId — so a stale entry never lingers. A foreign-backend record reads
+	// as absent (existing === undefined) and is deliberately left on disk.
+	if (existing) {
+		await removeShare(workspaceRoot, branch, commitHash);
+	}
 }
 
 /**
@@ -58,7 +72,7 @@ export async function patchShareAudience(
 	patch: ShareAudiencePatch,
 	commitHash?: string,
 ): Promise<BranchShareRecord | undefined> {
-	const existing = await getShare(workspaceRoot, branch, commitHash);
+	const existing = await getShare(workspaceRoot, branch, deriveJolliBackendKeyFromApiKey(apiKey), commitHash);
 	if (!existing?.shareId) return undefined;
 	const result = await updateLiveShare(undefined, apiKey, existing.shareId, {
 		...(patch.visibility && { visibility: patch.visibility }),

--- a/vscode/src/services/BranchShareModal.commitVsBranch.test.ts
+++ b/vscode/src/services/BranchShareModal.commitVsBranch.test.ts
@@ -46,6 +46,11 @@ vi.mock("../views/SummaryUtils.js", () => ({ buildBranchRelativePath: (b: string
 vi.mock("../../../cli/src/core/JolliApiUtils.js", () => ({
 	parseJolliApiKey: () => ({ u: "https://acme.jolli.ai" }),
 	assertJolliOriginAllowed: vi.fn(),
+	// Real store: matchesEnv derives the record's backend from its shareUrl and compares
+	// it to the current key's backend. A single constant for both keeps them in lockstep
+	// regardless of the actual shareUrl, so cached records resolve on read.
+	deriveJolliBackendKey: () => "https://acme.jolli.ai",
+	deriveJolliBackendKeyFromApiKey: () => "https://acme.jolli.ai",
 }));
 vi.mock("../util/Logger.js", () => ({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }));
 
@@ -53,6 +58,7 @@ import { getShare } from "../../../cli/src/core/BranchShareStore.js";
 import { copyShareLinkModal, openShareModal, type ShareModalContext, type ShareModalIO } from "./BranchShareModal.js";
 
 const BRANCH = "feature/x";
+const ENV = "https://acme.jolli.ai"; // matches the mocked deriveJolliEnvKey(FromApiKey)
 const TIP = "z".repeat(40);
 const OLDER = "x".repeat(40);
 const COMMIT_URL = "https://acme.jolli.ai/b/COMMIT";
@@ -99,7 +105,7 @@ beforeEach(async () => {
 	h.loadBranchSummaries.mockResolvedValue({ summaries: [summary(OLDER), summary(TIP)], missingCount: 0 });
 	h.push.mockImplementation((s: CommitSummary) =>
 		Promise.resolve({
-			pushedDoc: { commitHash: s.commitHash, summaryDocId: 100, plans: [], notes: [] },
+			pushedDoc: { commitHash: s.commitHash, summaryDocId: 100, plans: [], notes: [], references: [] },
 			updatedSummary: s,
 			attachmentFailures: [],
 			isUpdate: false,
@@ -131,8 +137,8 @@ describe("commit share then branch share (live)", () => {
 		expect(h.createLiveShare.mock.calls[1][2]).toMatchObject({ kind: "branch", headCommitHash: TIP });
 
 		// Distinct persisted records: commit-keyed vs branch-keyed, with distinct URLs.
-		expect((await getShare(cwd, BRANCH, OLDER))?.shareUrl).toBe(COMMIT_URL);
-		expect((await getShare(cwd, BRANCH))?.shareUrl).toBe(BRANCH_URL);
+		expect((await getShare(cwd, BRANCH, ENV, OLDER))?.shareUrl).toBe(COMMIT_URL);
+		expect((await getShare(cwd, BRANCH, ENV))?.shareUrl).toBe(BRANCH_URL);
 	});
 
 	it("reopening the branch share re-serves the BRANCH url (not the commit's)", async () => {

--- a/vscode/src/services/BranchShareModal.test.ts
+++ b/vscode/src/services/BranchShareModal.test.ts
@@ -42,6 +42,10 @@ vi.mock("./JolliPushOrchestrator.js", () => ({
 }));
 vi.mock("../../../cli/src/core/JolliApiUtils.js", () => ({
 	assertJolliOriginAllowed: h.assertJolliOriginAllowed,
+	// A truthy key resolves to a stable backend tag; the store reads are mocked, so
+	// the exact value only needs to be consistent across a test (real derivation is
+	// covered in JolliApiUtils.test.ts).
+	deriveJolliBackendKeyFromApiKey: vi.fn((apiKey?: string) => (apiKey ? "env-key" : undefined)),
 }));
 vi.mock("../util/Logger.js", () => ({
 	log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
@@ -121,10 +125,12 @@ beforeEach(() => {
 	// so existing setups keep driving it. `getLatestShareForBranch` here is a test double
 	// standing in for the store's subject-scoped seed pick (real filtering is covered in
 	// BranchShareStore.test.ts); the modal then applies its own expiry filter to it.
-	h.getShareWithBranchLatest.mockImplementation(async (cwd: string, branch: string, commit?: string) => ({
-		record: await h.getShare(cwd, branch, commit),
-		seed: await h.getLatestShareForBranch(cwd, branch),
-	}));
+	h.getShareWithBranchLatest.mockImplementation(
+		async (cwd: string, branch: string, envKey: string | undefined, commit?: string) => ({
+			record: await h.getShare(cwd, branch, envKey, commit),
+			seed: await h.getLatestShareForBranch(cwd, branch),
+		}),
+	);
 });
 
 describe("openShareModal", () => {

--- a/vscode/src/services/BranchShareModal.ts
+++ b/vscode/src/services/BranchShareModal.ts
@@ -27,7 +27,7 @@ import {
 	putBranchShare,
 	revokeShare,
 } from "./BranchShareController.js";
-import { assertJolliOriginAllowed } from "../../../cli/src/core/JolliApiUtils.js";
+import { assertJolliOriginAllowed, deriveJolliBackendKeyFromApiKey } from "../../../cli/src/core/JolliApiUtils.js";
 import type { BindingOutcome } from "./JolliPushOrchestrator.js";
 import type { BranchShareRecord } from "../../../cli/src/core/BranchShareStore.js";
 import { countSubjectDecisions, generateLiveShare, NothingToShareError, reconcileLiveShare } from "./LiveShareController.js";
@@ -152,7 +152,7 @@ export async function openShareModal(io: ShareModalIO, ctx: ShareModalContext): 
 		io.postState({ kind: "needsApiKey" });
 		return;
 	}
-	const existing = await getShare(ctx.workspaceRoot, ctx.branch, ctx.commitHash);
+	const existing = await getShare(ctx.workspaceRoot, ctx.branch, backendKeyOf(ctx), ctx.commitHash);
 	// Only reconcile a LIVE (unexpired) branch share — reconciling an expired one
 	// would re-push all content + PATCH a dead link (and could resurrect it), only
 	// for postReadyState to then render it as absent.
@@ -190,7 +190,7 @@ export async function copyShareLinkModal(io: ShareModalIO, ctx: ShareModalContex
 		io.postCopyResult({ ok: false });
 		return;
 	}
-	let record = await getShare(ctx.workspaceRoot, ctx.branch, ctx.commitHash);
+	let record = await getShare(ctx.workspaceRoot, ctx.branch, backendKeyOf(ctx), ctx.commitHash);
 	// Copying an EXISTING link must not repaint the pane (mockup: copy + flash only);
 	// only a lazy mint swaps to loading and needs the ready re-render afterwards.
 	let minted = false;
@@ -209,7 +209,7 @@ export async function copyShareLinkModal(io: ShareModalIO, ctx: ShareModalContex
 			return;
 		}
 		minted = true;
-		record = await getShare(ctx.workspaceRoot, ctx.branch, ctx.commitHash);
+		record = await getShare(ctx.workspaceRoot, ctx.branch, backendKeyOf(ctx), ctx.commitHash);
 	} else if (record.visibility !== visibility) {
 		if (visibility === "people" && (record.recipients ?? []).length === 0) {
 			io.notifyError("No one is invited yet — pick a teammate above first, or switch who can open the link.");
@@ -242,7 +242,7 @@ export async function setShareAccessModal(io: ShareModalIO, ctx: ShareModalConte
 		io.postState({ kind: "needsApiKey" });
 		return;
 	}
-	const existing = await getShare(ctx.workspaceRoot, ctx.branch, ctx.commitHash);
+	const existing = await getShare(ctx.workspaceRoot, ctx.branch, backendKeyOf(ctx), ctx.commitHash);
 	if (!existing?.shareId) {
 		// No link yet: `people` needs an invitee first (mint on Send invite); `public`
 		// and `org` mint immediately so the dropdown choice yields a copyable link.
@@ -302,7 +302,7 @@ export async function sendInviteModal(
 	// invitees layered on (grants union); anything else (people, or public — which
 	// can't carry an allowlist) resolves to a `people` link.
 	const targetTier: ShareVisibility = visibility === "org" ? "org" : "people";
-	let record = await getShare(ctx.workspaceRoot, ctx.branch, ctx.commitHash);
+	let record = await getShare(ctx.workspaceRoot, ctx.branch, backendKeyOf(ctx), ctx.commitHash);
 	let mintedForInvite = false;
 	let reTieredFrom: ShareVisibility | undefined;
 	if (!isLive(record, ctx.nowMs)) {
@@ -315,7 +315,7 @@ export async function sendInviteModal(
 			return;
 		}
 		mintedForInvite = true;
-		record = await getShare(ctx.workspaceRoot, ctx.branch, ctx.commitHash);
+		record = await getShare(ctx.workspaceRoot, ctx.branch, backendKeyOf(ctx), ctx.commitHash);
 	} else if (record.visibility !== targetTier) {
 		// The live link's tier differs from the one the invite targets — flip it in
 		// place FIRST so access matches the selection, not just the recipient list.
@@ -331,7 +331,7 @@ export async function sendInviteModal(
 			return;
 		}
 		reTieredFrom = from;
-		record = await getShare(ctx.workspaceRoot, ctx.branch, ctx.commitHash);
+		record = await getShare(ctx.workspaceRoot, ctx.branch, backendKeyOf(ctx), ctx.commitHash);
 	}
 	if (!record?.shareId) {
 		// Popover already closed (see above) — a toast is the only visible channel.
@@ -381,7 +381,7 @@ export async function removeRecipientModal(io: ShareModalIO, ctx: ShareModalCont
 		io.postState({ kind: "needsApiKey" });
 		return;
 	}
-	const record = await getShare(ctx.workspaceRoot, ctx.branch, ctx.commitHash);
+	const record = await getShare(ctx.workspaceRoot, ctx.branch, backendKeyOf(ctx), ctx.commitHash);
 	if (record?.shareId) {
 		const lower = email.trim().toLowerCase();
 		const next = (record.recipients ?? []).filter((r) => r.toLowerCase() !== lower);
@@ -475,6 +475,7 @@ async function postReadyState(io: ShareModalIO, ctx: ShareModalContext): Promise
 	const { record: rawRecord, seed: rawSeed } = await getShareWithBranchLatest(
 		ctx.workspaceRoot,
 		ctx.branch,
+		backendKeyOf(ctx),
 		ctx.commitHash,
 	);
 	const record = presentable(rawRecord, ctx.nowMs);
@@ -517,6 +518,15 @@ async function postReadyState(io: ShareModalIO, ctx: ShareModalContext): Promise
 		gitCollaborators: ctx.gitCollaborators,
 		owner: ctx.owner,
 	});
+}
+
+/**
+ * The current backend key (see {@link BranchShareRecord.shareUrl}) used to scope store
+ * reads: a cached share minted against a DIFFERENT backend (a since-swapped API key) is
+ * treated as absent, so its foreign `shareId` never reaches the current server.
+ */
+function backendKeyOf(ctx: ShareModalContext): string | undefined {
+	return deriveJolliBackendKeyFromApiKey(ctx.apiKey);
 }
 
 /** A record that is live (unexpired) — expired links are dead links and render as absent. */

--- a/vscode/src/services/JolliPushOrchestrator.test.ts
+++ b/vscode/src/services/JolliPushOrchestrator.test.ts
@@ -5,9 +5,10 @@ const { mockPushToJolli, mockDeleteFromJolli } = vi.hoisted(() => ({
 	mockPushToJolli: vi.fn(),
 	mockDeleteFromJolli: vi.fn(),
 }));
-const { mockReadPlan, mockReadNote } = vi.hoisted(() => ({
+const { mockReadPlan, mockReadNote, mockReadReference } = vi.hoisted(() => ({
 	mockReadPlan: vi.fn(),
 	mockReadNote: vi.fn(),
+	mockReadReference: vi.fn(),
 }));
 
 // Stub only the network functions; keep BindingRequiredError / PluginOutdatedError real (instanceof).
@@ -18,6 +19,7 @@ vi.mock("./JolliPushService.js", async (importActual) => {
 vi.mock("../../../cli/src/core/SummaryStore.js", () => ({
 	readPlanFromBranch: mockReadPlan,
 	readNoteFromBranch: mockReadNote,
+	readReferenceFromBranch: mockReadReference,
 }));
 vi.mock("../views/SummaryMarkdownBuilder.js", () => ({ buildMarkdown: () => "# markdown" }));
 vi.mock("../../../cli/src/core/Telemetry.js", () => ({ track: vi.fn() }));
@@ -62,6 +64,7 @@ beforeEach(() => {
 	vi.clearAllMocks();
 	mockReadPlan.mockResolvedValue("plan body");
 	mockReadNote.mockResolvedValue("note body");
+	mockReadReference.mockResolvedValue(null);
 });
 
 describe("pushSummaryWithAttachments", () => {
@@ -75,6 +78,36 @@ describe("pushSummaryWithAttachments", () => {
 		expect(result.isUpdate).toBe(false);
 		expect(result.attachmentCount).toBe(0);
 		expect(ctx.storeSummary).toHaveBeenCalledWith(expect.objectContaining({ jolliDocId: 100 }), true);
+	});
+
+	it("writes back a doc URL whose origin keys to the current push env", async () => {
+		mockPushToJolli.mockResolvedValue({ docId: 100 });
+		const ctx = makeContext();
+		await pushSummaryWithAttachments(makeSummary(), ctx);
+		// No separate env tag — the written-back URL's origin IS the env.
+		expect(ctx.storeSummary).toHaveBeenCalledWith(
+			expect.objectContaining({ jolliDocId: 100, jolliDocUrl: "https://acme.jolli.ai/articles?doc=100" }),
+			true,
+		);
+	});
+
+	it("reuses the docId when the summary's stored URL origin matches the current env", async () => {
+		mockPushToJolli.mockResolvedValue({ docId: 100 });
+		const summary = makeSummary({ jolliDocId: 7, jolliDocUrl: "https://acme.jolli.ai/articles?doc=7" });
+		await pushSummaryWithAttachments(summary, makeContext());
+		expect(mockPushToJolli).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.anything(),
+			expect.objectContaining({ docType: "summary", docId: 7 }),
+		);
+	});
+
+	it("does NOT reuse the docId when the summary was pushed to a different backend", async () => {
+		mockPushToJolli.mockResolvedValue({ docId: 100 });
+		const summary = makeSummary({ jolliDocId: 7, jolliDocUrl: "https://jolli-local.me/t/articles?doc=7" });
+		await pushSummaryWithAttachments(summary, makeContext());
+		const payload = mockPushToJolli.mock.calls[0][2] as { docId?: number };
+		expect(payload.docId).toBeUndefined();
 	});
 
 	it("pushes only the caller-chosen attachments (empty selection → no plan/note pushes)", async () => {
@@ -125,6 +158,85 @@ describe("pushSummaryWithAttachments", () => {
 		const result = await pushSummaryWithAttachments(makeSummary(), makeContext(), { plans: [], notes: [note] });
 		expect(result.pushedDoc.summaryDocId).toBe(100);
 		expect(result.attachmentFailures).toEqual([{ label: 'note "Note"', message: "note 500" }]);
+	});
+
+	it("pushes a reference as a standalone `reference` article and returns it keyed by archivedKey", async () => {
+		mockPushToJolli.mockImplementation((_b, _k, p: { docType: string }) =>
+			Promise.resolve({ docId: p.docType === "summary" ? 100 : 400 }),
+		);
+		const ref = {
+			archivedKey: "linear:ENG-1-a1b2c3d4",
+			source: "linear",
+			nativeId: "ENG-1",
+			title: "Fix bug",
+			url: "https://linear.app/x",
+			referencedAt: "t",
+			sourceToolName: "Claude Code",
+		};
+		const summary = makeSummary({ references: [ref] });
+		const result = await pushSummaryWithAttachments(summary, makeContext(), { plans: [], notes: [], references: [ref] });
+
+		expect(mockPushToJolli).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.anything(),
+			expect.objectContaining({ docType: "reference", title: "Linear · ENG-1 — Fix bug" }),
+		);
+		expect(result.pushedDoc.references).toEqual([
+			{ archivedKey: "linear:ENG-1-a1b2c3d4", baseKey: "linear:ENG-1", title: "Linear · ENG-1 — Fix bug", docId: 400, url: "https://acme.jolli.ai/articles?doc=400" },
+		]);
+		expect(result.updatedSummary.references?.[0].jolliReferenceDocId).toBe(400);
+		expect(result.attachmentCount).toBe(1);
+	});
+
+	it("reuses a reference docId only when its env tag matches the current env", async () => {
+		mockPushToJolli.mockImplementation((_b, _k, p: { docType: string }) =>
+			Promise.resolve({ docId: p.docType === "summary" ? 100 : 400 }),
+		);
+		const ref = {
+			archivedKey: "linear:ENG-1-a1b2c3d4",
+			source: "linear",
+			nativeId: "ENG-1",
+			title: "Fix bug",
+			url: "https://linear.app/x",
+			referencedAt: "t",
+			sourceToolName: "Claude Code",
+			jolliReferenceDocId: 400,
+			jolliReferenceDocUrl: "https://jolli-local.me/t/articles?doc=400", // different backend
+		};
+		await pushSummaryWithAttachments(makeSummary({ references: [ref] }), makeContext(), {
+			plans: [],
+			notes: [],
+			references: [ref],
+		});
+		const refCall = mockPushToJolli.mock.calls.find((c) => (c[2] as { docType: string }).docType === "reference");
+		expect((refCall?.[2] as { docId?: number }).docId).toBeUndefined();
+	});
+
+	it("treats a reference push failure as best-effort — skipped, NOT a fatal attachment failure", async () => {
+		mockPushToJolli.mockImplementation((_b, _k, p: { docType: string }) => {
+			if (p.docType === "reference") return Promise.reject(new Error("ref 500"));
+			return Promise.resolve({ docId: 100 });
+		});
+		const ref = {
+			archivedKey: "linear:ENG-1-a1b2c3d4",
+			source: "linear",
+			nativeId: "ENG-1",
+			title: "Fix bug",
+			url: "https://linear.app/x",
+			referencedAt: "t",
+			sourceToolName: "Claude Code",
+		};
+		const result = await pushSummaryWithAttachments(makeSummary({ references: [ref] }), makeContext(), {
+			plans: [],
+			notes: [],
+			references: [ref],
+		});
+		expect(result.pushedDoc.summaryDocId).toBe(100);
+		// The summary still succeeds; the failed reference is simply absent from the
+		// pushed set and does NOT enter attachmentFailures (which the strict branch-share
+		// path would turn into a fatal AttachmentPushError).
+		expect(result.pushedDoc.references).toEqual([]);
+		expect(result.attachmentFailures).toEqual([]);
 	});
 
 	it("skips a snippet note with no content and pushes a markdown note's body", async () => {
@@ -348,13 +460,33 @@ describe("pushSummaryWithAttachments", () => {
 describe("serializeSummaryJson", () => {
 	it("strips jolliDocId/jolliDocUrl/orphanedDocIds and keeps content fields", () => {
 		const json = serializeSummaryJson(
-			makeSummary({ jolliDocId: 55, jolliDocUrl: "https://x", orphanedDocIds: [1], recap: "did things" }),
+			makeSummary({
+				jolliDocId: 55,
+				jolliDocUrl: "https://x",
+				orphanedDocIds: [1],
+				recap: "did things",
+			}),
 		);
 		const parsed = JSON.parse(json ?? "");
 		expect(parsed).toEqual(expect.objectContaining({ commitHash: "abc123", recap: "did things" }));
 		expect(Object.keys(parsed)).not.toEqual(
 			expect.arrayContaining(["jolliDocId", "jolliDocUrl", "orphanedDocIds"]),
 		);
+	});
+
+	it("keeps nested plan/note/reference docId/url (needed to render the article links)", () => {
+		const json = serializeSummaryJson(
+			makeSummary({
+				plans: [{ slug: "p1", jolliPlanDocId: 9, jolliPlanDocUrl: "pu" }],
+				notes: [{ id: "n1", jolliNoteDocId: 8, jolliNoteDocUrl: "nu" }],
+				references: [{ archivedKey: "linear:E-1-abcd1234", jolliReferenceDocId: 7, jolliReferenceDocUrl: "ru" }],
+			} as unknown as Partial<CommitSummary>),
+		);
+		const parsed = JSON.parse(json ?? "");
+		expect(parsed.plans[0].jolliPlanDocId).toBe(9);
+		expect(parsed.plans[0].jolliPlanDocUrl).toBe("pu");
+		expect(parsed.notes[0].jolliNoteDocUrl).toBe("nu");
+		expect(parsed.references[0].jolliReferenceDocUrl).toBe("ru");
 	});
 
 	it("returns undefined for a summary that serializes over the byte cap", () => {

--- a/vscode/src/services/JolliPushOrchestrator.ts
+++ b/vscode/src/services/JolliPushOrchestrator.ts
@@ -21,12 +21,21 @@
  * the standalone button's existing behavior.
  */
 
-import type { CommitSummary, NoteReference, PlanReference } from "../../../cli/src/Types.js";
-import { readNoteFromBranch, readPlanFromBranch } from "../../../cli/src/core/SummaryStore.js";
+import type { CommitSummary, NoteReference, PlanReference, ReferenceCommitRef } from "../../../cli/src/Types.js";
+import { deriveJolliEnvKey, resolveArticleUrl } from "../../../cli/src/core/JolliApiUtils.js";
+import { buildReferencePushMarkdown } from "../../../cli/src/core/SummaryMarkdownBuilder.js";
+import { readReferenceMarkdownFromString } from "../../../cli/src/core/references/ReferenceStore.js";
+import { readNoteFromBranch, readPlanFromBranch, readReferenceFromBranch } from "../../../cli/src/core/SummaryStore.js";
 import { track } from "../../../cli/src/core/Telemetry.js";
 import { log } from "../util/Logger.js";
 import { latestPlanPerName } from "../util/PlanGrouping.js";
-import { buildBranchRelativePath, buildNotePushTitle, buildPlanPushTitle, buildPushTitle } from "../views/SummaryUtils.js";
+import {
+	buildBranchRelativePath,
+	buildNotePushTitle,
+	buildPlanPushTitle,
+	buildPushTitle,
+	buildReferencePushTitle,
+} from "../views/SummaryUtils.js";
 import { buildMarkdown } from "../views/SummaryMarkdownBuilder.js";
 import { BindingRequiredError, deleteFromJolli, PluginOutdatedError, pushToJolli } from "./JolliPushService.js";
 
@@ -110,6 +119,14 @@ export interface PushedNote {
 	readonly docId: number;
 	readonly url: string;
 }
+export interface PushedReference {
+	readonly archivedKey: string;
+	/** Stable cross-commit identity `<source>:<nativeId>` so `covered` resolves the shared article. */
+	readonly baseKey: string;
+	readonly title: string;
+	readonly docId: number;
+	readonly url: string;
+}
 
 /** The doc ids one summary push produced — feeds the live share's `covered` allowlist. */
 export interface PushedDoc {
@@ -118,6 +135,7 @@ export interface PushedDoc {
 	readonly summaryUrl: string;
 	readonly plans: ReadonlyArray<PushedPlan>;
 	readonly notes: ReadonlyArray<PushedNote>;
+	readonly references: ReadonlyArray<PushedReference>;
 }
 
 /** Result of pushing one summary; UI-renderable data only. */
@@ -132,10 +150,12 @@ export interface PushSummaryResult {
 	readonly attachmentCount: number;
 }
 
-/** The plans/notes to push for a summary — caller-chosen, or the summary's own when omitted. */
+/** The plans/notes/references to push for a summary — caller-chosen, or the summary's own when omitted. */
 export interface AttachmentSelection {
 	readonly plans: ReadonlyArray<PlanReference>;
 	readonly notes: ReadonlyArray<NoteReference>;
+	/** Deduped (owner-commit) references; omit to push none for this summary (the branch path passes them explicitly). */
+	readonly references?: ReadonlyArray<ReferenceCommitRef>;
 }
 
 export interface PushSummaryOptions {
@@ -159,8 +179,13 @@ export async function pushSummaryWithAttachments(
 	retried = false,
 ): Promise<PushSummaryResult> {
 	const displayBase = ctx.baseUrl.replace(/\/+$/, "");
+	// Env key of the tenant this push targets — every docId minted below is tagged
+	// with it, and an existing docId is reused as an update target only when its
+	// tag matches (see `canReuseDocId`).
+	const envKey = deriveJolliEnvKey(ctx.baseUrl) ?? "";
 	const plansToPush = attachments ? attachments.plans : latestPlanPerName(summary.plans ?? []);
 	const notesToPush = attachments ? attachments.notes : (summary.notes ?? []);
+	const referencesToPush = attachments ? (attachments.references ?? []) : (summary.references ?? []);
 
 	try {
 		// Step 1: upload plans + notes. Per-attachment failures are collected, not
@@ -171,6 +196,7 @@ export async function pushSummaryWithAttachments(
 			summary,
 			ctx,
 			displayBase,
+			envKey,
 			Boolean(options.strictAttachments),
 		);
 		const { results: noteUrls, failures: noteFailures } = await pushNoteList(
@@ -178,8 +204,28 @@ export async function pushSummaryWithAttachments(
 			summary,
 			ctx,
 			displayBase,
+			envKey,
 			Boolean(options.strictAttachments),
 		);
+		const { results: referenceUrls, failures: referenceFailures } = await pushReferenceList(
+			referencesToPush,
+			summary,
+			ctx,
+			displayBase,
+			envKey,
+		);
+		// References are auto-extracted context, not user-attached content, so their
+		// push is BEST-EFFORT: a failure is logged (in pushReferenceList) but must NOT
+		// join `attachmentFailures`, which the strict branch-share path turns into a
+		// fatal AttachmentPushError. Otherwise one reference the server rejects (e.g. a
+		// backend that doesn't yet accept docType:"reference") would abort the whole
+		// share — the CLI path already just logs+skips, so this keeps the two in step.
+		if (referenceFailures.length > 0) {
+			log.warn(
+				"PushOrchestrator",
+				`${referenceFailures.length} reference push(es) failed (non-fatal, skipped): ${referenceFailures.map((f) => f.label).join(", ")}`,
+			);
+		}
 		const attachmentFailures = [...planFailures, ...noteFailures];
 
 		// Step 2: weave the published URLs into the summary markdown (so the
@@ -190,10 +236,14 @@ export async function pushSummaryWithAttachments(
 		const plansWithUrls = applyPlanUrls(dedupedPlans, planUrls) ?? dedupedPlans;
 		/* v8 ignore stop */
 		const notesWithUrls = summary.notes ? applyNoteUrls(summary.notes, noteUrls) : summary.notes;
+		const referencesWithUrls = summary.references
+			? applyReferenceUrls(summary.references, referenceUrls)
+			: summary.references;
 		const summaryForMarkdown: CommitSummary = {
 			...summary,
 			plans: plansWithUrls,
 			...(notesWithUrls !== summary.notes && { notes: notesWithUrls }),
+			...(referencesWithUrls !== summary.references && { references: referencesWithUrls }),
 		};
 		const markdown = buildMarkdown(summaryForMarkdown);
 		// The structured twin of the markdown article, from the same enriched copy —
@@ -206,7 +256,7 @@ export async function pushSummaryWithAttachments(
 			commitHash: summary.commitHash,
 			docType: "summary",
 			branch: summary.branch,
-			...(summary.jolliDocId && { docId: summary.jolliDocId }),
+			...(summary.jolliDocId && canReuseDocId(summary.jolliDocUrl, envKey) && { docId: summary.jolliDocId }),
 			repoUrl: ctx.repoUrl,
 			relativePath: buildBranchRelativePath(summary.branch),
 			...(summaryJson && { summaryJson }),
@@ -214,7 +264,7 @@ export async function pushSummaryWithAttachments(
 
 		track("memory_pushed", { kind: "summary" });
 
-		const summaryUrl = `${displayBase}/articles?doc=${result.docId}`;
+		const summaryUrl = resolveArticleUrl(displayBase, result.url, result.docId);
 		const isUpdate = Boolean(summary.jolliDocUrl);
 
 		const updatedSummary: CommitSummary = {
@@ -223,6 +273,9 @@ export async function pushSummaryWithAttachments(
 			jolliDocId: result.docId,
 			...(planUrls.length > 0 ? { plans: applyPlanUrls(summary.plans, planUrls) } : {}),
 			...(noteUrls.length > 0 && summary.notes ? { notes: applyNoteUrls(summary.notes, noteUrls) } : {}),
+			...(referenceUrls.length > 0 && summary.references
+				? { references: applyReferenceUrls(summary.references, referenceUrls) }
+				: {}),
 		};
 		await ctx.storeSummary(updatedSummary, true);
 
@@ -246,11 +299,12 @@ export async function pushSummaryWithAttachments(
 				summaryUrl,
 				plans: planUrls,
 				notes: noteUrls,
+				references: referenceUrls,
 			},
 			updatedSummary: cleanedSummary ?? updatedSummary,
 			attachmentFailures,
 			isUpdate,
-			attachmentCount: planUrls.length + noteUrls.length,
+			attachmentCount: planUrls.length + noteUrls.length + referenceUrls.length,
 		};
 	} catch (err: unknown) {
 		if (err instanceof BindingRequiredError && !retried) {
@@ -274,6 +328,7 @@ async function pushPlanList(
 	summary: CommitSummary,
 	ctx: PushContext,
 	displayBase: string,
+	envKey: string,
 	strictAttachments: boolean,
 ): Promise<{ results: PushedPlan[]; failures: PushAttachmentFailure[] }> {
 	const failures: PushAttachmentFailure[] = [];
@@ -298,7 +353,7 @@ async function pushPlanList(
 				commitHash: summary.commitHash,
 				docType: "plan",
 				branch: summary.branch,
-				...(plan.jolliPlanDocId && { docId: plan.jolliPlanDocId }),
+				...(plan.jolliPlanDocId && canReuseDocId(plan.jolliPlanDocUrl, envKey) && { docId: plan.jolliPlanDocId }),
 				repoUrl: ctx.repoUrl,
 				relativePath: buildBranchRelativePath(summary.branch),
 			});
@@ -312,7 +367,7 @@ async function pushPlanList(
 		results.push({
 			slug: plan.slug,
 			title: plan.title,
-			url: `${displayBase}/articles?doc=${planResult.docId}`,
+			url: resolveArticleUrl(displayBase, planResult.url, planResult.docId),
 			docId: planResult.docId,
 		});
 	}
@@ -325,6 +380,7 @@ async function pushNoteList(
 	summary: CommitSummary,
 	ctx: PushContext,
 	displayBase: string,
+	envKey: string,
 	strictAttachments: boolean,
 ): Promise<{ results: PushedNote[]; failures: PushAttachmentFailure[] }> {
 	const failures: PushAttachmentFailure[] = [];
@@ -364,7 +420,7 @@ async function pushNoteList(
 				commitHash: summary.commitHash,
 				docType: "note",
 				branch: summary.branch,
-				...(note.jolliNoteDocId && { docId: note.jolliNoteDocId }),
+				...(note.jolliNoteDocId && canReuseDocId(note.jolliNoteDocUrl, envKey) && { docId: note.jolliNoteDocId }),
 				repoUrl: ctx.repoUrl,
 				relativePath: buildBranchRelativePath(summary.branch),
 			});
@@ -378,14 +434,85 @@ async function pushNoteList(
 		results.push({
 			id: note.id,
 			title: note.title,
-			url: `${displayBase}/articles?doc=${noteResult.docId}`,
+			url: resolveArticleUrl(displayBase, noteResult.url, noteResult.docId),
 			docId: noteResult.docId,
 		});
 	}
 	return { results, failures };
 }
 
-/** Merges published plan URLs/docIds into plan references (matched by exact slug). */
+/**
+ * Uploads the given archived references as standalone `reference` articles. The
+ * body is synthesized from the value snapshot ({@link buildReferencePushMarkdown})
+ * since a reference has no on-disk file. Like {@link pushPlanList}, a single
+ * transient failure is collected; fatal binding/plugin errors propagate.
+ */
+async function pushReferenceList(
+	references: ReadonlyArray<ReferenceCommitRef>,
+	summary: CommitSummary,
+	ctx: PushContext,
+	displayBase: string,
+	envKey: string,
+): Promise<{ results: PushedReference[]; failures: PushAttachmentFailure[] }> {
+	const failures: PushAttachmentFailure[] = [];
+	const results: PushedReference[] = [];
+	for (const ref of references) {
+		const title = buildReferencePushTitle(ref);
+		// Read the archived body from the orphan-branch snapshot so the pushed article
+		// carries the SAME content shown locally (the local `.md` is deleted at commit
+		// time). Missing/unparseable → header-only, never a failed push.
+		const storedMd = await readReferenceFromBranch(ref.source, ref.archivedKey, ctx.workspaceRoot);
+		const description = storedMd ? (readReferenceMarkdownFromString(storedMd)?.description ?? undefined) : undefined;
+		let refResult: Awaited<ReturnType<typeof pushToJolli>>;
+		try {
+			refResult = await pushToJolli(ctx.baseUrl, ctx.apiKey, {
+				title,
+				content: buildReferencePushMarkdown(ref, description),
+				commitHash: summary.commitHash,
+				docType: "reference",
+				branch: summary.branch,
+				...(ref.jolliReferenceDocId &&
+					canReuseDocId(ref.jolliReferenceDocUrl, envKey) && { docId: ref.jolliReferenceDocId }),
+				repoUrl: ctx.repoUrl,
+				relativePath: buildBranchRelativePath(summary.branch),
+			});
+		} catch (err) {
+			if (err instanceof BindingRequiredError || err instanceof PluginOutdatedError) throw err;
+			const msg = err instanceof Error ? err.message : String(err);
+			log.error("PushOrchestrator", `Reference ${ref.archivedKey} push FAILED: ${msg}`);
+			failures.push({ label: `reference "${title}"`, message: msg });
+			continue;
+		}
+		results.push({
+			archivedKey: ref.archivedKey,
+			baseKey: `${ref.source}:${ref.nativeId}`,
+			title,
+			url: resolveArticleUrl(displayBase, refResult.url, refResult.docId),
+			docId: refResult.docId,
+		});
+	}
+	return { results, failures };
+}
+
+/**
+ * A stored `jolliDocId` may be reused as an update target only when the article
+ * URL it was minted with points at the current push env — the URL's origin IS the
+ * env, so `deriveJolliEnvKey(storedDocUrl)` recovers the backend the id belongs to
+ * (no separate env tag is stored). A URL from a different origin means the id lives
+ * on another backend → drop it and let the server create a fresh doc. A missing URL
+ * is legacy / never-pushed (reuse allowed); an unparseable one is treated as
+ * env-agnostic rather than throwing. Mirror of the CLI `canReuseDocId`.
+ */
+export function canReuseDocId(storedDocUrl: string | undefined, currentEnv: string): boolean {
+	if (!storedDocUrl) return true;
+	try {
+		return deriveJolliEnvKey(storedDocUrl) === currentEnv;
+	} catch {
+		return true;
+	}
+}
+
+/** Merges published plan URLs/docIds into plan references (matched by exact slug). The URL's origin is the minting env — see {@link canReuseDocId}. */
 export function applyPlanUrls(
 	plans: ReadonlyArray<PlanReference> | undefined,
 	planUrls: ReadonlyArray<{ slug: string; url: string; docId: number }>,
@@ -398,7 +525,7 @@ export function applyPlanUrls(
 	});
 }
 
-/** Merges published note URLs/docIds into note references (matched by id). */
+/** Merges published note URLs/docIds into note references (matched by id). The URL's origin is the minting env — see {@link canReuseDocId}. */
 export function applyNoteUrls(
 	notes: ReadonlyArray<NoteReference>,
 	noteUrls: ReadonlyArray<{ id: string; url: string; docId: number }>,
@@ -407,6 +534,23 @@ export function applyNoteUrls(
 	return notes.map((n) => {
 		const pushed = urlMap.get(n.id);
 		return pushed ? { ...n, jolliNoteDocUrl: pushed.url, jolliNoteDocId: pushed.docId } : n;
+	});
+}
+
+/**
+ * Merges published reference URLs/docIds into commit references, matched by
+ * `archivedKey` (the exact per-commit entry). The URL's origin is the minting env —
+ * see {@link canReuseDocId}. Mirror of the CLI `applyReferenceUrls`.
+ */
+export function applyReferenceUrls(
+	references: ReadonlyArray<ReferenceCommitRef>,
+	referenceUrls: ReadonlyArray<{ archivedKey: string; url: string; docId: number }>,
+): ReadonlyArray<ReferenceCommitRef> {
+	if (referenceUrls.length === 0) return references;
+	const urlMap = new Map(referenceUrls.map((r) => [r.archivedKey, r]));
+	return references.map((r) => {
+		const pushed = urlMap.get(r.archivedKey);
+		return pushed ? { ...r, jolliReferenceDocUrl: pushed.url, jolliReferenceDocId: pushed.docId } : r;
 	});
 }
 

--- a/vscode/src/services/JolliPushService.ts
+++ b/vscode/src/services/JolliPushService.ts
@@ -20,7 +20,7 @@
  * - Sends `repoUrl` (canonical, normalized — see GitRemoteUtils) and
  *   `relativePath` (flat — `<branchSlug>` for all kinds) in the body so the
  *   server can place the doc under `repoFolder → branchSlug`.
- * - Sends `docType: "summary" | "plan" | "note"` in the body. With the flat
+ * - Sends `docType: "summary" | "plan" | "note" | "reference"` in the body. With the flat
  *   path layout this is the sole disambiguator the server uses to set
  *   `sourceMetadata.docType` and route TreeItem icons on the frontend.
  * - Maps `412 binding_required` → `BindingRequiredError` and
@@ -97,7 +97,7 @@ export interface JolliPushPayload {
 	 * server uses to set `sourceMetadata.docType` and to drive TreeItem icons.
 	 * Required: a missing value would silently mis-tag every push.
 	 */
-	readonly docType: "summary" | "plan" | "note";
+	readonly docType: "summary" | "plan" | "note" | "reference";
 	readonly branch?: string;
 	/** Server-side document ID for direct update on subsequent pushes. */
 	readonly docId?: number;

--- a/vscode/src/services/LiveShareController.test.ts
+++ b/vscode/src/services/LiveShareController.test.ts
@@ -31,7 +31,10 @@ vi.mock("../util/GitRemoteUtils.js", async (importActual) => ({
 	getCanonicalRepoUrl: vi.fn().mockResolvedValue("https://github.com/acme/repo"),
 }));
 vi.mock("../../../cli/src/core/KBPathResolver.js", () => ({ extractRepoName: () => "repo" }));
-vi.mock("../../../cli/src/core/JolliApiUtils.js", () => ({ parseJolliApiKey: mockParseKey }));
+vi.mock("../../../cli/src/core/JolliApiUtils.js", () => ({
+	parseJolliApiKey: mockParseKey,
+	deriveJolliBackendKeyFromApiKey: vi.fn(() => "https://jolli.ai"),
+}));
 vi.mock("../../../cli/src/core/SummaryStore.js", () => ({
 	resolveEffectiveTopics: (s: CommitSummary) => s.topics ?? [],
 	resolveEffectiveRecap: (s: CommitSummary) => s.recap,
@@ -112,7 +115,11 @@ beforeEach(() => {
 	mockGetShare.mockResolvedValue(undefined);
 	mockPutShare.mockResolvedValue(undefined);
 	// Default push: echo a docId for the chosen plan/note attachments; summary doc per commit.
-	type Att = { plans: PlanReference[]; notes: Array<{ id: string; title: string; jolliNoteDocId?: number }> };
+	type Att = {
+		plans: PlanReference[];
+		notes: Array<{ id: string; title: string; jolliNoteDocId?: number }>;
+		references?: Array<{ archivedKey: string; source: string; nativeId: string; jolliReferenceDocId?: number }>;
+	};
 	mockPush.mockImplementation((s: CommitSummary, _ctx: unknown, attachments?: Att) => {
 		const plans = (attachments?.plans ?? []).map((p) => ({
 			slug: p.slug,
@@ -126,17 +133,25 @@ beforeEach(() => {
 			docId: n.jolliNoteDocId ?? 8000 + n.id.length,
 			url: "u",
 		}));
+		const references = (attachments?.references ?? []).map((r) => ({
+			archivedKey: r.archivedKey,
+			baseKey: `${r.source}:${r.nativeId}`,
+			title: r.nativeId,
+			docId: r.jolliReferenceDocId ?? 7000 + r.archivedKey.length,
+			url: "u",
+		}));
 		return Promise.resolve({
 			pushedDoc: {
 				commitHash: s.commitHash,
 				summaryDocId: SUMMARY_DOC[s.commitHash as keyof typeof SUMMARY_DOC],
 				plans,
 				notes,
+				references,
 			},
 			updatedSummary: s,
 			attachmentFailures: [],
 			isUpdate: false,
-			attachmentCount: plans.length + notes.length,
+			attachmentCount: plans.length + notes.length + references.length,
 		});
 	});
 });
@@ -212,7 +227,7 @@ describe("generateLiveShare", () => {
 		// A (older) owns nothing; B (newer) owns the winner, pushed with the seed docId 500 so it updates in place.
 		const callA = mockPush.mock.calls.find((c) => c[0].commitHash === "A");
 		const callB = mockPush.mock.calls.find((c) => c[0].commitHash === "B");
-		expect(callA?.[2]).toEqual({ plans: [], notes: [] });
+		expect(callA?.[2]).toEqual({ plans: [], notes: [], references: [] });
 		expect(callB?.[2].plans).toEqual([
 			expect.objectContaining({ slug: "p-bbbbbbbb", jolliPlanDocId: 500 }),
 		]);
@@ -287,7 +302,7 @@ describe("generateLiveShare", () => {
 		mockPush.mockImplementation((s: CommitSummary, ctx: { storeSummary: (x: unknown, b: boolean) => Promise<void> }) => {
 			ctx.storeSummary(s, true); // exercise the buildPushContext passthrough
 			return Promise.resolve({
-				pushedDoc: { commitHash: s.commitHash, summaryDocId: 1, plans: [], notes: [] },
+				pushedDoc: { commitHash: s.commitHash, summaryDocId: 1, plans: [], notes: [], references: [] },
 				updatedSummary: s,
 				attachmentFailures: [],
 				isUpdate: false,
@@ -319,7 +334,7 @@ describe("generateLiveShare", () => {
 
 		await generateLiveShare({ ...deps(), branch: "feature/x", visibility: "public" });
 
-		expect(mockPush.mock.calls[0][2]).toEqual({ plans: [], notes: [] });
+		expect(mockPush.mock.calls[0][2]).toEqual({ plans: [], notes: [], references: [] });
 		const ref = mockCreate.mock.calls[0][2].ref;
 		expect(ref.covered).toEqual([{ commitHash: "A", summaryDocId: 1001, attachmentDocIds: [] }]);
 	});
@@ -338,7 +353,7 @@ describe("generateLiveShare", () => {
 		expect(callA?.[2].plans).toEqual([expect.objectContaining({ slug: "p-aaaaaaaa" })]);
 		expect(callA?.[2].plans[0].jolliPlanDocId).toBeUndefined();
 		expect(callA?.[2].notes[0].jolliNoteDocId).toBeUndefined();
-		expect(callB?.[2]).toEqual({ plans: [], notes: [] });
+		expect(callB?.[2]).toEqual({ plans: [], notes: [], references: [] });
 
 		// B's covered still references the docs pushed under A (same live docs).
 		const ref = mockCreate.mock.calls[0][2].ref;
@@ -365,7 +380,7 @@ describe("generateLiveShare", () => {
 		const a = summary("A", [plan("p-aaaaaaaa", "2026-01-01T00:00:00Z")], [note("n1", "2026-01-01T00:00:00Z")]);
 		mockLoad.mockResolvedValue({ summaries: [a], missingCount: 0 });
 		mockPush.mockResolvedValue({
-			pushedDoc: { commitHash: "A", summaryDocId: 1001, plans: [], notes: [] },
+			pushedDoc: { commitHash: "A", summaryDocId: 1001, plans: [], notes: [], references: [] },
 			updatedSummary: a,
 			attachmentFailures: [],
 			isUpdate: false,
@@ -382,7 +397,7 @@ describe("generateLiveShare", () => {
 		const a = summary("A", [plan("p-aaaaaaaa", "2026-01-01T00:00:00Z")], [note("n1", "2026-01-01T00:00:00Z")]);
 		mockLoad.mockResolvedValue({ summaries: [a], missingCount: 0 });
 		mockPush.mockResolvedValue({
-			pushedDoc: { commitHash: "A", summaryDocId: 1001, plans: [], notes: [] },
+			pushedDoc: { commitHash: "A", summaryDocId: 1001, plans: [], notes: [], references: [] },
 			updatedSummary: a,
 			attachmentFailures: [
 				{ label: 'plan "Plan"', message: "Network error: socket hang up" },
@@ -422,6 +437,8 @@ describe("generateLiveShare", () => {
 		const stored = mockPutShare.mock.calls[0][2];
 		expect(stored.visibility).toBe("people");
 		expect(stored.recipients).toEqual(["marta@jolli.ai"]);
+		// No separate env tag — the record's shareUrl origin identifies its backend.
+		expect(stored.shareUrl).toBe("https://acme.jolli.ai/b/x");
 	});
 
 	it("builds a commitDocs ref for a single-commit share", async () => {
@@ -596,7 +613,7 @@ describe("reconcileLiveShare", () => {
 		});
 		mockLoad.mockResolvedValue({ summaries: [a], missingCount: 0 });
 		mockPush.mockResolvedValue({
-			pushedDoc: { commitHash: "A", summaryDocId: 1001, plans: [], notes: [] },
+			pushedDoc: { commitHash: "A", summaryDocId: 1001, plans: [], notes: [], references: [] },
 			updatedSummary: a,
 			attachmentFailures: [{ label: 'plan "Plan"', message: "unauthorized (HTTP 401)" }],
 			isUpdate: false,

--- a/vscode/src/services/LiveShareController.ts
+++ b/vscode/src/services/LiveShareController.ts
@@ -26,10 +26,10 @@
  */
 
 import { createHash } from "node:crypto";
-import type { CommitSummary, PlanReference, NoteReference } from "../../../cli/src/Types.js";
+import type { CommitSummary, PlanReference, NoteReference, ReferenceCommitRef } from "../../../cli/src/Types.js";
 import { type LiveRef, getShare, putBranchShare } from "../../../cli/src/core/BranchShareStore.js";
 import { getDefaultBranch } from "../../../cli/src/core/GitOps.js";
-import { parseJolliApiKey } from "../../../cli/src/core/JolliApiUtils.js";
+import { deriveJolliBackendKeyFromApiKey, parseJolliApiKey } from "../../../cli/src/core/JolliApiUtils.js";
 import { extractRepoName } from "../../../cli/src/core/KBPathResolver.js";
 import { slugify } from "../../../cli/src/core/SummaryExporter.js";
 import { resolveEffectiveRecap, resolveEffectiveTopics } from "../../../cli/src/core/SummaryStore.js";
@@ -154,6 +154,8 @@ interface Winner<T> {
 	readonly ownerCommit: string;
 	/** A known docId for this plan/note (from any commit's prior push) so the push updates in place. */
 	readonly seedDocId?: number;
+	/** Article URL the `seedDocId` was minted with — rides with the id so the reuse gate (`canReuseDocId`, keyed on the URL's origin) can tell which backend it belongs to, and so the woven URL matches the id. */
+	readonly seedDocUrl?: string;
 }
 
 /**
@@ -169,11 +171,14 @@ interface Winner<T> {
 function assignOwnedAttachments(subjectSummaries: ReadonlyArray<CommitSummary>): {
 	ownedPlans: Map<string, PlanReference[]>;
 	ownedNotes: Map<string, NoteReference[]>;
+	ownedReferences: Map<string, ReferenceCommitRef[]>;
 	seedPlanDocIds: Map<string, number>;
 	seedNoteDocIds: Map<string, number>;
+	seedReferenceDocIds: Map<string, number>;
 } {
 	const planWinners = new Map<string, Winner<PlanReference>>();
 	const noteWinners = new Map<string, Winner<NoteReference>>();
+	const referenceWinners = new Map<string, Winner<ReferenceCommitRef>>();
 	for (const summary of subjectSummaries) {
 		for (const plan of summary.plans ?? []) {
 			const key = planBaseKey(plan.slug);
@@ -186,15 +191,17 @@ function assignOwnedAttachments(subjectSummaries: ReadonlyArray<CommitSummary>):
 			if (!prev || byUpdatedAtDesc(plan, prev.ref) < 0) {
 				// This revision wins (or is the first seen). Its own docId is
 				// authoritative for the latest article; fall back to a docId a prior
-				// revision surfaced only when this one carries none.
+				// revision surfaced only when this one carries none. The URL tracks
+				// whichever revision actually supplied the docId.
 				const seedDocId = plan.jolliPlanDocId ?? prev?.seedDocId;
-				planWinners.set(key, { ref: plan, ownerCommit: summary.commitHash, seedDocId });
+				const seedDocUrl = plan.jolliPlanDocId !== undefined ? plan.jolliPlanDocUrl : prev?.seedDocUrl;
+				planWinners.set(key, { ref: plan, ownerCommit: summary.commitHash, seedDocId, seedDocUrl });
 			} else if (prev.seedDocId === undefined && plan.jolliPlanDocId !== undefined) {
 				// A losing (older) revision only fills in a docId the winner didn't
 				// already have. It must NEVER overwrite the winner's own docId —
 				// doing so would push the latest content to an older article and
 				// orphan (leak) the winner's real one.
-				planWinners.set(key, { ...prev, seedDocId: plan.jolliPlanDocId });
+				planWinners.set(key, { ...prev, seedDocId: plan.jolliPlanDocId, seedDocUrl: plan.jolliPlanDocUrl });
 			}
 		}
 		for (const note of summary.notes ?? []) {
@@ -204,33 +211,70 @@ function assignOwnedAttachments(subjectSummaries: ReadonlyArray<CommitSummary>):
 			// deterministic and NaN-free for a malformed/missing updatedAt.
 			if (!prev || note.updatedAt > prev.ref.updatedAt) {
 				const seedDocId = note.jolliNoteDocId ?? prev?.seedDocId;
-				noteWinners.set(note.id, { ref: note, ownerCommit: summary.commitHash, seedDocId });
+				const seedDocUrl = note.jolliNoteDocId !== undefined ? note.jolliNoteDocUrl : prev?.seedDocUrl;
+				noteWinners.set(note.id, { ref: note, ownerCommit: summary.commitHash, seedDocId, seedDocUrl });
 			} else if (prev.seedDocId === undefined && note.jolliNoteDocId !== undefined) {
-				noteWinners.set(note.id, { ...prev, seedDocId: note.jolliNoteDocId });
+				noteWinners.set(note.id, { ...prev, seedDocId: note.jolliNoteDocId, seedDocUrl: note.jolliNoteDocUrl });
+			}
+		}
+		for (const ref of summary.references ?? []) {
+			// A reference is identified across commits by its stable `<source>:<nativeId>`,
+			// NOT its per-commit `archivedKey`, so the same ticket on two commits pushes to
+			// ONE Space article. Recency by `referencedAt` (newest wins, first-seen on tie).
+			const key = `${ref.source}:${ref.nativeId}`;
+			const prev = referenceWinners.get(key);
+			if (!prev || ref.referencedAt > prev.ref.referencedAt) {
+				const seedDocId = ref.jolliReferenceDocId ?? prev?.seedDocId;
+				const seedDocUrl = ref.jolliReferenceDocId !== undefined ? ref.jolliReferenceDocUrl : prev?.seedDocUrl;
+				referenceWinners.set(key, { ref, ownerCommit: summary.commitHash, seedDocId, seedDocUrl });
+			} else if (prev.seedDocId === undefined && ref.jolliReferenceDocId !== undefined) {
+				referenceWinners.set(key, {
+					...prev,
+					seedDocId: ref.jolliReferenceDocId,
+					seedDocUrl: ref.jolliReferenceDocUrl,
+				});
 			}
 		}
 	}
 
 	const ownedPlans = new Map<string, PlanReference[]>();
 	const ownedNotes = new Map<string, NoteReference[]>();
+	const ownedReferences = new Map<string, ReferenceCommitRef[]>();
 	const pushInto = <T>(map: Map<string, T[]>, commit: string, item: T): void => {
 		const arr = map.get(commit);
 		if (arr) arr.push(item);
 		else map.set(commit, [item]);
 	};
 	for (const w of planWinners.values()) {
-		pushInto(ownedPlans, w.ownerCommit, w.seedDocId ? { ...w.ref, jolliPlanDocId: w.seedDocId } : w.ref);
+		pushInto(
+			ownedPlans,
+			w.ownerCommit,
+			w.seedDocId ? { ...w.ref, jolliPlanDocId: w.seedDocId, jolliPlanDocUrl: w.seedDocUrl } : w.ref,
+		);
 	}
 	for (const w of noteWinners.values()) {
-		pushInto(ownedNotes, w.ownerCommit, w.seedDocId ? { ...w.ref, jolliNoteDocId: w.seedDocId } : w.ref);
+		pushInto(
+			ownedNotes,
+			w.ownerCommit,
+			w.seedDocId ? { ...w.ref, jolliNoteDocId: w.seedDocId, jolliNoteDocUrl: w.seedDocUrl } : w.ref,
+		);
+	}
+	for (const w of referenceWinners.values()) {
+		pushInto(
+			ownedReferences,
+			w.ownerCommit,
+			w.seedDocId ? { ...w.ref, jolliReferenceDocId: w.seedDocId, jolliReferenceDocUrl: w.seedDocUrl } : w.ref,
+		);
 	}
 
 	const seedPlanDocIds = new Map<string, number>();
 	const seedNoteDocIds = new Map<string, number>();
+	const seedReferenceDocIds = new Map<string, number>();
 	for (const w of planWinners.values()) if (w.seedDocId) seedPlanDocIds.set(planBaseKey(w.ref.slug), w.seedDocId);
 	for (const [id, w] of noteWinners) if (w.seedDocId) seedNoteDocIds.set(id, w.seedDocId);
+	for (const [key, w] of referenceWinners) if (w.seedDocId) seedReferenceDocIds.set(key, w.seedDocId);
 
-	return { ownedPlans, ownedNotes, seedPlanDocIds, seedNoteDocIds };
+	return { ownedPlans, ownedNotes, ownedReferences, seedPlanDocIds, seedNoteDocIds, seedReferenceDocIds };
 }
 
 /**
@@ -244,19 +288,22 @@ async function pushSubjectAndBuildRef(
 	ctx: PushContext,
 ): Promise<LiveRef> {
 	// 1–2. Cross-commit dedup: winners + owned attachments + seed docId maps.
-	const { ownedPlans, ownedNotes, seedPlanDocIds, seedNoteDocIds } = assignOwnedAttachments(subjectSummaries);
+	const { ownedPlans, ownedNotes, ownedReferences, seedPlanDocIds, seedNoteDocIds, seedReferenceDocIds } =
+		assignOwnedAttachments(subjectSummaries);
 
 	// 3. Push each summary oldest→newest with only its owned attachments. Capture the
 	//    pushed summary docId per commit and accumulate the branch-wide attachment map,
 	//    pre-seeded with any known docIds so a doc pushed under another commit still links.
 	const planDocIdByBase = new Map<string, number>(seedPlanDocIds);
 	const noteDocIdById = new Map<string, number>(seedNoteDocIds);
+	const referenceDocIdByBase = new Map<string, number>(seedReferenceDocIds);
 
 	const summaryDocIds: number[] = [];
 	for (const summary of subjectSummaries) {
 		const result = await pushSummaryWithAttachments(summary, ctx, {
 			plans: ownedPlans.get(summary.commitHash) ?? [],
 			notes: ownedNotes.get(summary.commitHash) ?? [],
+			references: ownedReferences.get(summary.commitHash) ?? [],
 		}, {
 			strictAttachments: true,
 		});
@@ -266,10 +313,12 @@ async function pushSubjectAndBuildRef(
 		summaryDocIds.push(result.pushedDoc.summaryDocId);
 		for (const p of result.pushedDoc.plans) planDocIdByBase.set(planBaseKey(p.slug), p.docId);
 		for (const n of result.pushedDoc.notes) noteDocIdById.set(n.id, n.docId);
+		for (const r of result.pushedDoc.references) referenceDocIdByBase.set(r.baseKey, r.docId);
 	}
 
-	// 4. Build covered: each commit references its OWN plans/notes' docids (resolved
-	//    via the shared map, so a doc pushed under a different commit is still linked).
+	// 4. Build covered: each commit references its OWN plans/notes/references' docids
+	//    (resolved via the shared maps, so a doc pushed under a different commit is
+	//    still linked — a reference keys on its stable `<source>:<nativeId>`).
 	const coveredFor = (summary: CommitSummary): number[] => {
 		const ids = new Set<number>();
 		for (const plan of summary.plans ?? []) {
@@ -278,6 +327,10 @@ async function pushSubjectAndBuildRef(
 		}
 		for (const note of summary.notes ?? []) {
 			const docId = noteDocIdById.get(note.id);
+			if (docId) ids.add(docId);
+		}
+		for (const ref of summary.references ?? []) {
+			const docId = referenceDocIdByBase.get(`${ref.source}:${ref.nativeId}`);
 			if (docId) ids.add(docId);
 		}
 		return [...ids];
@@ -344,6 +397,9 @@ export function subjectFingerprint(summaries: ReadonlyArray<CommitSummary>): str
 		r: resolveEffectiveRecap(s) ?? null,
 		p: (s.plans ?? []).map((pl) => [pl.slug, pl.updatedAt]),
 		n: (s.notes ?? []).map((nt) => [nt.id, nt.updatedAt]),
+		// References ride the share as first-class docs, so a new/updated reference
+		// (its `referencedAt` bumps) must move the hash and trigger a re-push.
+		f: (s.references ?? []).map((r) => [r.archivedKey, r.referencedAt]),
 	}));
 	return createHash("sha1").update(JSON.stringify(projection)).digest("hex").slice(0, 16);
 }
@@ -460,7 +516,8 @@ export function generateLiveShare(params: GenerateLiveShareParams): Promise<Live
  */
 export function reconcileLiveShare(deps: LiveShareDeps, branch: string): Promise<void> {
 	return withSubjectLock(deps.workspaceRoot, branch, async () => {
-		const existing = await getShare(deps.workspaceRoot, branch);
+		const backendKey = deriveJolliBackendKeyFromApiKey(deps.apiKey);
+		const existing = await getShare(deps.workspaceRoot, branch, backendKey);
 		// Only a branch (branchCollection) share reconciles here; commit shares are a fixed doc list.
 		if (!existing?.shareId || existing.ref?.kind !== "branchCollection") return;
 
@@ -548,7 +605,7 @@ export function pushBranchMemoriesToSpace(deps: LiveShareDeps, branch: string): 
 		if (subjectSummaries.length === 0) throw new NothingToShareError(branch);
 
 		const ctx = buildPushContext(deps, baseUrl, repoUrl);
-		const { ownedPlans, ownedNotes } = assignOwnedAttachments(subjectSummaries);
+		const { ownedPlans, ownedNotes, ownedReferences } = assignOwnedAttachments(subjectSummaries);
 
 		let pushedCount = 0;
 		let attachmentCount = 0;
@@ -559,6 +616,7 @@ export function pushBranchMemoriesToSpace(deps: LiveShareDeps, branch: string): 
 				const result = await pushSummaryWithAttachments(summary, ctx, {
 					plans: ownedPlans.get(summary.commitHash) ?? [],
 					notes: ownedNotes.get(summary.commitHash) ?? [],
+					references: ownedReferences.get(summary.commitHash) ?? [],
 				});
 				pushedCount += 1;
 				attachmentCount += result.attachmentCount;

--- a/vscode/src/util/PlanGrouping.ts
+++ b/vscode/src/util/PlanGrouping.ts
@@ -87,7 +87,9 @@ export function annotatePlans(plans: ReadonlyArray<PlanReference>): ReadonlyArra
  */
 export function latestPlanPerName(plans: ReadonlyArray<PlanReference>): ReadonlyArray<PlanReference> {
 	const sorted = [...plans].sort(byUpdatedAtDesc);
-	// Newest already-pushed docId/url per base name (first hit wins = newest).
+	// Newest already-pushed docId/url per base name (first hit wins = newest). The
+	// URL rides with the docId so the reuse gate downstream (`canReuseDocId`, keyed
+	// on the URL's origin) can tell which backend the inherited id belongs to.
 	const pushedDoc = new Map<string, { docId: number; url: string | undefined }>();
 	for (const plan of sorted) {
 		const key = planBaseKey(plan.slug);
@@ -106,7 +108,11 @@ export function latestPlanPerName(plans: ReadonlyArray<PlanReference>): Readonly
 		if (plan.jolliPlanDocId === undefined) {
 			const inherited = pushedDoc.get(key);
 			if (inherited) {
-				result.push({ ...plan, jolliPlanDocId: inherited.docId, jolliPlanDocUrl: inherited.url });
+				result.push({
+					...plan,
+					jolliPlanDocId: inherited.docId,
+					jolliPlanDocUrl: inherited.url,
+				});
 				continue;
 			}
 		}

--- a/vscode/src/views/SummaryCssBuilder.ts
+++ b/vscode/src/views/SummaryCssBuilder.ts
@@ -1533,10 +1533,6 @@ export function buildCss(): string {
   /* "What travels" banner */
   .share-travel-banner { display: flex; gap: 10px; align-items: flex-start; padding: 10px 12px; border-radius: 8px; background: var(--vscode-textBlockQuote-background, rgba(127,127,127,0.06)); font-size: 0.83em; line-height: 1.5; margin-bottom: 12px; }
   .share-travel-icon { flex: 0 0 auto; color: var(--vscode-textLink-foreground); font-size: 1.05em; }
-  /* Transcript opt-in (disabled mock) */
-  .share-transcript-opt { display: flex; align-items: center; gap: 8px; font-size: 0.85em; color: var(--text-secondary); cursor: not-allowed; }
-  .share-transcript-opt input { margin: 0; }
-  .share-optin-badge { font-size: 0.7em; font-weight: 700; letter-spacing: 0.04em; padding: 1px 6px; border-radius: 4px; background: rgba(127,127,127,0.16); color: var(--text-secondary); text-transform: uppercase; }
   /* Shared panes (loading / error / no-key) */
   .share-loading { display: flex; align-items: center; gap: 10px; color: var(--text-secondary); }
   .share-spinner { width: 14px; height: 14px; border: 2px solid var(--text-secondary); border-top-color: transparent; border-radius: 50%; animation: share-spin 0.8s linear infinite; }

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -233,8 +233,8 @@ const SHARE_ICON_SVG = `<svg class="share-icon" width="14" height="14" viewBox="
  * with a SINGLE link created lazily on first use. The main pane has a "General access"
  * select (public bearer / anyone-at-site / only invited people) that sets the one
  * link's tier — Copy mints it on first use and changing the select flips the same
- * link in place — plus the invited-people list, the "what travels" banner, and a
- * disabled transcript opt-in. A separate Send-invite pane stages people (grouped
+ * link in place — plus the invited-people list and the "what travels" banner. A
+ * separate Send-invite pane stages people (grouped
  * suggestions: jolli account members / git collaborators) with an optional note; the
  * server grants access AND emails in one step. The card is anchored under the Share
  * button by the client script (`getBoundingClientRect`); the overlay is a transparent
@@ -278,12 +278,6 @@ export function buildShareModal(): string {
         <span class="share-travel-icon" aria-hidden="true">&#x21C4;</span>
         <span>Summaries + decisions + linked refs travel.<br /><strong>Conversation transcripts stay on your machine.</strong></span>
       </div>
-
-      <label class="share-transcript-opt" title="Not available — transcripts stay on your machine.">
-        <input type="checkbox" disabled />
-        <span>Include conversation transcripts</span>
-        <span class="share-optin-badge">opt-in</span>
-      </label>
 
       <div class="share-modal-actions share-actions-main">
         <button class="action-btn primary" id="shareCopyBtn" title="Copy the link for the selected access level (created on first copy)">&#x1F4CB; Copy link</button>

--- a/vscode/src/views/SummaryUtils.ts
+++ b/vscode/src/views/SummaryUtils.ts
@@ -15,6 +15,7 @@ export {
 	buildPanelTitle,
 	buildPlanPushTitle,
 	buildPushTitle,
+	buildReferencePushTitle,
 	collectAllPlans,
 	collectLlmSources,
 	collectSortedTopics,


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

External tool references — Linear tickets, GitHub issues, Jira cards, Notion pages — now appear in Jolli Space as their own browsable articles alongside Plans and Notes. Each reference article contains the full issue description or page body, the external link, the originating tool, and any structured fields captured at archive time. The same ticket referenced across multiple commits produces exactly one Space article that is updated in place on each push, and the branch share page now lists references as first-class entries. Reference article titles lead with the source name followed by a middle-dot separator, keeping references visually distinct from plans and notes in the Space tree and preventing title collisions across sources. Slack and Notion references display clean, readable titles rather than raw machine identifiers.

Push operations now correctly handle switching between different backend environments. Each locally stored article ID is checked against the backend that originally minted it, and when a user switches their API key to a different server, the old ID is silently ignored and a fresh article is created on the new backend. This protection covers docs, plans, notes, and references uniformly. Backend identity is derived directly from the article URL already stored alongside each document ID, eliminating redundant tag fields entirely. The environment key uses only the server address, so renaming an org or tenant no longer causes the system to treat the same backend as a new environment.

The same environment-scoping protection was extended to the branch share cache: cached share records are now matched against the backend derived from the share link itself, and reads filter out any record that does not belong to the current deployment. A related bug was also closed: revoking a share while connected to a different backend no longer deletes the local record, so the original link remains fully manageable after switching back to the backend that created it.

The URLs stored by the plugin for pushed articles now more closely match the address shown in the browser. A single shared utility replaced eight separate hardcoded link constructions across the CLI and VS Code push flows, and the plugin now trusts the URL the server returns rather than reconstructing it from parts.

---

## Topics (6)
<details>
<summary><strong>01 · Branch share records identify their backend via share link URL</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user switched their API key from one backend to another, the locally cached share record minted on the old backend was still returned, causing operations like sending an invite to send a foreign share ID to the current backend and receive a 404.

**💡 Decisions Behind the Code**

- **URL-derived backend identity over a separate stored field, tried stored field first**: An earlier iteration added `envKey` as an optional field on `BranchShareRecord` and stamped untagged records on first read to freeze attribution. After doc records were updated to derive backend identity from the doc URL itself, the same pattern was applied to share records, eliminating the stored field entirely. The share URL already encodes which deployment minted the record, making the field redundant, and removing it also eliminated a class of subtle race conditions around concurrent writes during backfill.
- **Coarser deployment-level granularity is an accepted trade-off**: Doc URLs carry the full tenant origin, so doc records can distinguish `acme.jolli.ai` from `beta.jolli.ai` on the same deployment. Share URLs are intentionally tenant-free, so the only derivable key is the registrable domain. This means a same-deployment cross-tenant switch is treated as the same backend, and a cached share link from one tenant could be reused when switching to another tenant on the same server. The team judged this scenario rare enough that the occasional stale-link 404 is acceptable in exchange for eliminating the stored field.
- **Legacy backfill logic deleted rather than preserved**: With the URL-derived model there is nothing to stamp — the backend is always derived fresh from the URL — so the entire backfill path became dead code. Removing it reduces the read path to a single unconditional file read. Share records written by older builds that still carry the now-unused field continue to load correctly; the extra field is simply ignored.

**✅ What Was Implemented**

- Removed the `envKey` field from `BranchShareRecord` in `BranchShareStore.ts`. The `matchesEnv` function was rewritten to call the new `deriveJolliBackendKey` helper on the record's `shareUrl`, comparing the result against the current API key's backend key. The legacy `readAllForEnv` function, which stamped untagged records on first read, was deleted entirely, simplifying the read path to a plain `readAll` call.
- Added two new exported functions, `deriveJolliBackendKey` and `deriveJolliBackendKeyFromApiKey`, to `JolliApiUtils.ts`. These strip the tenant subdomain down to the registrable domain (e.g. `acme.jolli.ai` → `https://jolli.ai`), collapsing all tenants of a deployment to one key. This coarser granularity matches the tenant-free format of share URLs.
- All VS Code callers in `LiveShareController.ts`, `BranchShareModal.ts`, and `BranchShareController.ts` were updated to import and use `deriveJolliBackendKeyFromApiKey` in place of `deriveJolliEnvKeyFromApiKey`, and the `envKey` field was removed from every record construction site.

**📁 FILES**
- `cli/src/core/BranchShareStore.ts`
- `cli/src/core/JolliApiUtils.ts`
- `vscode/src/services/LiveShareController.ts`
- `vscode/src/services/BranchShareModal.ts`
- `vscode/src/services/BranchShareController.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Doc and plan IDs validated against backend origin to prevent cross-backend reuse</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a memory was pushed to one backend and the user then switched their API key to a different backend, the locally cached article ID from the first backend was silently sent to the second backend, risking unintended updates on the new server.

**💡 Decisions Behind the Code**

- **URL origin as implicit env key over explicit tag fields**: An earlier iteration stored a dedicated environment tag alongside every document ID. The article URL already encodes which backend minted each document ID, making the tag fields redundant overhead. Deriving backend identity from the URL origin eliminates those fields entirely with no loss of information, and a missing URL (legacy data) is treated as env-agnostic to preserve backward compatibility.
- **Origin only over full tenant identity**: The server re-validates space, repository, and owner on every push, so the client-side env key is purely a cleanliness optimization. Keying on mutable org and tenant slugs added rename-fragility for a same-origin org-switch scenario the server backstop already handles safely, so dropping those segments eliminates that fragility at no safety cost.
- **Per-document URL-based check over a single file-level marker**: Plans and references have independent lifetimes from the summary they appear in — a plan can be promoted across multiple commits, and a reference can be shared by several commits. A file-level key would cause the reuse check to treat a foreign-environment identifier as local. The URL-origin approach achieves per-document correctness automatically and requires no squash-time discard logic.
- **Graceful fallback for unparseable stored URLs**: The reuse gate wraps the URL parse in a try/catch and returns true (allow reuse) on failure, matching the existing behavior for absent URLs. This avoids a hard error on any legacy or hand-edited data while still correctly blocking cross-backend reuse for well-formed URLs.

**✅ What Was Implemented**

- Removed four dedicated environment tag fields (`jolliDocEnv`, `jolliPlanDocEnv`, `jolliNoteDocEnv`, `jolliReferenceDocEnv`) from `cli/src/Types.ts`. The reuse gate (`canReuseDocId`) was rewritten in both `cli/src/core/JolliMemoryPushOrchestrator.ts` and `vscode/src/services/JolliPushOrchestrator.ts` to derive backend identity by parsing the origin of the stored article URL via `deriveJolliEnvKey`, with a try/catch guard for malformed or absent legacy URLs that falls back to allowing reuse.
- The `applyPlanUrls`, `applyNoteUrls`, and `applyReferenceUrls` helpers in both orchestrators lost their `envKey` parameter entirely. The `stripEnvTags` JSON replacer function was deleted from both files, and `serializeSummaryJson` now uses a plain `JSON.stringify` call with no replacer.
- The `Winner` interface and `assignOwnedAttachments` / `latestPlanPerName` functions in the CLI orchestrator, VS Code `LiveShareController`, and `vscode/src/util/PlanGrouping.ts` were updated to carry `seedDocUrl` instead of `seedDocEnv`, so the article URL travels with the document ID through squash and hoist paths and the reuse gate always has the URL it needs.
- `deriveJolliEnvKey` and `deriveJolliEnvKeyFromApiKey` in `cli/src/core/JolliApiUtils.ts` were simplified to return only the lowercased server origin (e.g. `https://jolli.ai`) rather than a three-part `origin|org|tenant` string, eliminating fragility where renaming an org or tenant would cause the system to treat the same backend as a new environment.

**📁 FILES**
- `cli/src/Types.ts`
- `cli/src/core/JolliApiUtils.ts`
- `cli/src/core/JolliMemoryPushOrchestrator.ts`
- `vscode/src/services/JolliPushOrchestrator.ts`
- `vscode/src/services/LiveShareController.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · External tool references pushed to Jolli Space as standalone browsable articles</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

External tool references — Linear tickets, GitHub issues, Jira cards, Notion pages — only appeared as links embedded inside summary articles, making them invisible to Space search and browsing. Plans and Notes already had their own Space articles, but References had no equivalent.

**💡 Decisions Behind the Code**

- **Stable cross-commit identity key using permanent ticket identity**: References use `<source>:<nativeId>` as the deduplication key rather than the per-commit `archivedKey` (which includes a short commit hash suffix). This means a Linear ticket referenced across ten commits produces one Space article that gets updated, not ten duplicates, following the same pattern plans and notes already use.
- **Body synthesized from snapshot, not a file**: Unlike plans and notes, a reference has no on-disk markdown file after the commit lands. Rather than storing a separate body file or skipping the body entirely, the push renders the article content from the fields already captured in the archived orphan-branch snapshot, keeping the reference article useful and searchable without requiring new storage. If the snapshot is missing or unparseable, the push continues with a header-only article rather than failing.
- **Branch share controller extended to match CLI deduplication**: Without also updating the branch share controller's deduplication and `covered` allowlist, the same reference would be pushed once per commit on the share path and would not appear on the share page. The controller was updated to match the CLI's full deduplication logic so the feature works end-to-end on both push paths.

**✅ What Was Implemented**

- Added `jolliReferenceDocId`, `jolliReferenceDocUrl`, and `jolliReferenceDocEnv` fields to the reference data model in `cli/src/Types.ts`, mirroring the existing pattern for plans and notes. Added `"reference"` to the allowed document type union in both `cli/src/core/JolliMemoryPushClient.ts` and `vscode/src/services/JolliPushService.ts`.
- Implemented `pushReferenceList`, `applyReferenceUrls`, and `referenceBaseKey` in both `cli/src/core/JolliMemoryPushOrchestrator.ts` and `vscode/src/services/JolliPushOrchestrator.ts`. The push body is synthesized from the archived orphan-branch snapshot via `buildReferencePushMarkdown` in `cli/src/core/SummaryMarkdownBuilder.ts` (external link, source tool, and a fields table), since the on-disk reference file is deleted after commit. When a description is available, the trimmed body is appended below the header card.
- Extended `assignOwnedAttachments` in both the CLI orchestrator and `vscode/src/services/LiveShareController.ts` to deduplicate references across commits using the stable `<source>:<nativeId>` key, so the same ticket referenced on multiple commits pushes to exactly one Space article and updates it in place. The branch share page's `covered` allowlist and `subjectFingerprint` were also updated to include references.

**📁 FILES**
- `cli/src/Types.ts`
- `cli/src/core/JolliMemoryPushOrchestrator.ts`
- `vscode/src/services/JolliPushOrchestrator.ts`
- `cli/src/core/SummaryMarkdownBuilder.ts`
- `vscode/src/services/LiveShareController.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Reference article titles lead with source name to prevent collisions</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When references from different sources were pushed to the web backend, they shared the same title namespace as plans and notes, allowing a reference and a plan with similar titles to overwrite each other. Slack and Notion references were also receiving raw machine identifiers in their pushed titles instead of readable names.

**💡 Decisions Behind the Code**

- **Source label from registry, not a hardcoded map**: The source registry already carries a canonical label per source, including any future config-driven sources. Reading from it means new sources automatically get the correct label with no additional code changes, keeping a single authoritative definition across the codebase.
- **Middle-dot separator over colon or slash**: A colon is stripped silently by the title sanitizer, which would have made the prefix invisible in the generated slug. A slash is treated as a path separator in some contexts. The middle-dot survives sanitization and remains visually distinct from the separator the display-title already uses between the native ID and the article title.
- **Reuse display-title logic rather than re-implementing**: Tracker sources already lead with the native ID in their display title; Slack and Notion deliberately omit the machine ID. Composing on top of that existing function meant the push title automatically matched what users see locally in the editor, with no divergence to maintain.

**✅ What Was Implemented**

- Added `referenceSourceLabel()` to `cli/src/core/references/ReferenceDisplay.ts`, reading the human-readable source name from the source registry with a capitalized fallback for unregistered sources.
- Rewrote `buildReferencePushTitle()` in `cli/src/core/SummaryFormat.ts` to compose `<SourceLabel> · <referenceDisplayTitle>` using a middle-dot separator, reusing the existing display-title logic that already suppresses machine IDs for Slack and Notion.

**📁 FILES**
- `cli/src/core/references/ReferenceDisplay.ts`
- `cli/src/core/SummaryFormat.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Preserve live share links when revoking from a different backend</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user revoked a share while connected to a different backend than the one that originally created the link, the local record was deleted even though the server-side revoke was skipped, leaving the original link alive on the server with no way to manage or revoke it from the client.

**💡 Decisions Behind the Code**

- **Preserve foreign records rather than delete them**: When the current API key points at a different backend than the one that minted a share, the local record is intentionally left on disk. Deleting it would permanently orphan a still-live public link — the user could never revoke it again even after switching back. The small cost is a slightly larger local store, which is acceptable.
- **Gate delete on server call rather than adding a new env-aware delete path**: Rather than introducing a separate env-aware delete helper, the fix simply conditions the existing delete on whether the server call was made. This keeps the change minimal and avoids a new code path that could diverge from the lookup logic in the future.

**✅ What Was Implemented**

In `vscode/src/services/BranchShareController.ts`, the `removeShare` call was moved inside the block that only executes when a matching share ID exists for the current backend. Previously it ran unconditionally after the env-scoped lookup, so a foreign-backend record (which reads as absent) would still have its local pointer deleted. Now the local record is only removed when the server revoke actually fires.

**📁 FILES**
- `vscode/src/services/BranchShareController.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Article URLs stored by the plugin now match the web app address bar</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The URL shown in the VS Code plugin for a pushed article differed from the actual address in the browser. The plugin was storing a query-parameter form of the link while the web app displayed a structured path including the organization and a readable slug.

**💡 Decisions Behind the Code**

- **Single shared implementation over two mirrored copies**: An earlier draft placed `resolveArticleUrl` locally in both orchestrator files. The function was moved to the shared utility module instead, eliminating the drift risk that comes with keeping two copies in sync. The VS Code orchestrator already imported from that module, so the consolidation added no new dependency.
- **Server URL as the authority, with a fallback for absent values**: Rather than having the client reconstruct the canonical path from parts, the implementation trusts the URL the server returns and only falls back to the `?doc=` form when the server provides nothing. This keeps the client free of routing knowledge that belongs to the backend, and the fallback preserves backward compatibility with unit-test mocks that do not supply a URL.

**✅ What Was Implemented**

- Added `resolveArticleUrl(displayBase, serverUrl, docId)` to `cli/src/core/JolliApiUtils.ts` as the single shared implementation. The function uses the server-returned path (prefixing the display base if relative, using it verbatim if already absolute) and falls back to the legacy `?doc=<id>` form only when the server returns no URL.
- Updated `cli/src/core/JolliMemoryPushOrchestrator.ts` and `vscode/src/services/JolliPushOrchestrator.ts` — four URL construction sites each — to call `resolveArticleUrl` instead of building the query-parameter link locally. The VS Code orchestrator imports the function from the shared CLI utility alongside the existing `deriveJolliEnvKey` import.
- Moved `resolveArticleUrl` unit tests into `cli/src/core/JolliApiUtils.test.ts` covering relative slug, absolute, and fallback branches. Set `fakePushResult` default `url` to an empty string so existing `?doc=` assertions in orchestrator tests remain stable without modification.

**📋 Future Enhancements**

The backend still returns an org-less relative path (`/articles/<slug>`) instead of the full canonical path (`/o/<orgSlug>/articles/<slug>`). Until that is fixed, the URLs stored by the plugin will be closer to correct but still missing the `/o/<org>` segment in production. This is tracked as P1 backend work.

**📁 FILES**
- `cli/src/core/JolliApiUtils.ts`
- `cli/src/core/JolliMemoryPushOrchestrator.ts`
- `vscode/src/services/JolliPushOrchestrator.ts`

</blockquote>
</details>

---

<!-- jollimemory-summary-end -->