### PR TITLE
Update CHANGELOG.md for version 0.99.7 release

### DIFF
--- a/intellij/CHANGELOG.md
+++ b/intellij/CHANGELOG.md
@@ -1,14 +1,22 @@
 # Changelog
 
-## 0.99.6
+## 0.99.7
 
 ### New Features
 
 - **Auto-sync on push** — `git push` now automatically syncs the pushed commits' summaries to your Jolli Space in the background. The pre-push hook is lightweight (config read, stdin parse, one JSON write, spawn) and never blocks the push; the actual network sync runs in a detached worker. Failed syncs are retried on the next push, after the queue worker finishes a post-commit drain, and each time the IDE or CLI activates — so nothing is lost even if the network is flaky. Opt out with `syncOnPush: false` in config.
+- **More accurate cost estimates** — each memory is now priced by the model that actually generated it (Opus / Sonnet / Haiku) instead of a flat Sonnet rate.
 
 ### Fixes & Improvements
 
+- Safer pushing — the pre-push step now tidies up leftover memory data and retries the sync if a push races with it, so nothing gets left behind
 - Stale push-pending entries are pruned automatically after 7 days, keeping the state directory clean between pushes
+
+## 0.99.6
+
+### Fixes & Improvements
+
+- Bug fixes
 
 ## 0.99.5
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Topic (1)
<details>
<summary><strong>01 · Fix IntelliJ changelog to reflect actual 0.99.7 feature set</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The IntelliJ plugin's "What's New" dialog was displaying version 0.99.6 release notes even though the build version had been bumped to 0.99.7. The changelog file was missing the 0.99.7 entry entirely, while CLI and VS Code changelogs had already been updated.

**💡 Decisions Behind the Code**

The developer reviewed the IntelliJ source code to verify which features were actually implemented before writing the changelog. Slack & Zoom reference extraction and relevance filtering exist only in the CLI codebase (with TypeScript implementations like `ContextRelevance.ts` and Slack/Zoom adapters); the IntelliJ plugin's `SourceId` enum supports only Linear, Jira, GitHub, and Notion. Per-model cost estimation was confirmed to be fully implemented in IntelliJ via `ModelPricing.kt`. This verification step prevented shipping inaccurate marketing claims in the release notes.

**✅ What Was Implemented**

- Updated `intellij/CHANGELOG.md` to add a new `## 0.99.7` section at the top with accurate feature descriptions. Moved "Auto-sync on push" from 0.99.6 to 0.99.7 and added "More accurate cost estimates" (per-model pricing). Removed two features that were not actually implemented in IntelliJ: Slack & Zoom references and relevance filtering.
- Simplified the 0.99.6 section to a generic "Bug fixes" entry, matching the pattern used in other platform changelogs.

**📁 FILES**
- `intellij/CHANGELOG.md`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 10, 2026 at 10:29 PM · via Anthropic*
<!-- jollimemory-summary-end -->