### PR TITLE
Add `jolli uninstall` command for machine-wide cleanup (JOLLI-1928)

### DIFF
--- a/cli/src/Api.ts
+++ b/cli/src/Api.ts
@@ -31,6 +31,7 @@ import { registerSearchCommand } from "./commands/SearchCommand.js";
 import { registerStatusCommand } from "./commands/StatusCommand.js";
 import { registerSyncCommand } from "./commands/SyncCommand.js";
 import { registerTelemetryCommand } from "./commands/TelemetryCommand.js";
+import { registerUninstallCommand } from "./commands/UninstallCommand.js";
 import { registerViewCommand } from "./commands/ViewCommand.js";
 // _parseJolliApiKey / _parseBaseUrl: re-exposed at the bottom of this file.
 // See the `parseJolliApiKey` export for the rationale (Vite tree-shaker drops
@@ -154,6 +155,7 @@ function isHiddenCommand(c: Command): boolean {
 const MEMORY_COMMAND_NAMES = new Set([
 	"enable",
 	"disable",
+	"uninstall",
 	"status",
 	"configure",
 	"clean",
@@ -335,6 +337,7 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 
 	registerEnableCommand(program);
 	registerDisableCommand(program);
+	registerUninstallCommand(program);
 	registerStatusCommand(program);
 	registerConfigureCommand(program);
 	registerCleanCommand(program);

--- a/cli/src/commands/UninstallCommand.test.ts
+++ b/cli/src/commands/UninstallCommand.test.ts
@@ -1,0 +1,306 @@
+/**
+ * UninstallCommand tests.
+ *
+ * The scan, hook-strip (`uninstall`), and filesystem `rm` are all mocked so the
+ * command's own logic — scope filtering, inventory rendering, interactive
+ * selection, confirmation gates, and per-item outcome reporting — is exercised
+ * deterministically without touching the real machine.
+ */
+
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RemovableItem, UninstallInventory } from "../install/UninstallScan.js";
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockScan, mockPrune, mockUninstall, mockRm, mockIsInteractive, mockPromptText, mockTrack } = vi.hoisted(() => ({
+	mockScan: vi.fn(),
+	mockPrune: vi.fn(),
+	mockUninstall: vi.fn(),
+	mockRm: vi.fn(),
+	mockIsInteractive: vi.fn(),
+	mockPromptText: vi.fn(),
+	mockTrack: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({ rm: mockRm }));
+
+vi.mock("../install/UninstallScan.js", () => ({
+	scanUninstallInventory: mockScan,
+	pruneVscodeExtensionManifest: mockPrune,
+}));
+
+vi.mock("../install/Installer.js", () => ({ uninstall: mockUninstall }));
+
+vi.mock("../core/Telemetry.js", () => ({ track: mockTrack }));
+
+vi.mock("./CliUtils.js", () => ({
+	isInteractive: mockIsInteractive,
+	promptText: mockPromptText,
+	resolveProjectDir: () => "/repo",
+}));
+
+import { parseSelection, registerUninstallCommand } from "./UninstallCommand.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function item(over: Partial<RemovableItem>): RemovableItem {
+	return {
+		surface: "global-config",
+		label: "Item",
+		path: "/tmp/item",
+		kind: "dir",
+		...over,
+	};
+}
+
+function inventory(items: RemovableItem[]): UninstallInventory {
+	return { items, preserved: ["orphan branch", "Memory Bank"] };
+}
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+/** Runs `jolli uninstall <args>` and returns captured stdout+stderr. */
+async function run(args: string[]): Promise<{ out: string; err: string }> {
+	const program = new Command();
+	program.exitOverride();
+	registerUninstallCommand(program);
+	await program.parseAsync(["node", "jolli", "uninstall", ...args]);
+	const out = logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+	const err = errSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+	return { out, err };
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	process.exitCode = undefined;
+	logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+	errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	mockRm.mockResolvedValue(undefined);
+	mockPrune.mockResolvedValue(undefined);
+	mockUninstall.mockResolvedValue({ success: true, message: "ok", warnings: [] });
+	mockIsInteractive.mockReturnValue(true);
+});
+
+afterEach(() => {
+	logSpy.mockRestore();
+	errSpy.mockRestore();
+	process.exitCode = undefined;
+});
+
+// ─── parseSelection ───────────────────────────────────────────────────────────
+
+describe("parseSelection", () => {
+	it("returns null for an empty answer", () => {
+		expect(parseSelection("", 3)).toBeNull();
+		expect(parseSelection("   ", 3)).toBeNull();
+	});
+
+	it("selects everything for 'a' or 'all'", () => {
+		expect(parseSelection("a", 3)).toEqual(new Set([1, 2, 3]));
+		expect(parseSelection("all", 2)).toEqual(new Set([1, 2]));
+	});
+
+	it("parses comma- and space-separated indices", () => {
+		expect(parseSelection("1, 3", 3)).toEqual(new Set([1, 3]));
+		expect(parseSelection("2 3", 3)).toEqual(new Set([2, 3]));
+	});
+
+	it("skips empty tokens from a leading separator", () => {
+		expect(parseSelection(",1", 3)).toEqual(new Set([1]));
+	});
+
+	it("ignores out-of-range and non-numeric tokens", () => {
+		expect(parseSelection("0 2 9 foo", 3)).toEqual(new Set([2]));
+	});
+
+	it("returns null when no valid index is present", () => {
+		expect(parseSelection("0 9 foo", 3)).toBeNull();
+	});
+});
+
+// ─── empty inventory ──────────────────────────────────────────────────────────
+
+describe("uninstall — nothing found", () => {
+	it("reports an empty scope and removes nothing", async () => {
+		mockScan.mockResolvedValue(inventory([]));
+		const { out } = await run(["--yes"]);
+		expect(out).toContain("No Jolli installation or configuration found");
+		expect(mockRm).not.toHaveBeenCalled();
+	});
+});
+
+// ─── dry-run ──────────────────────────────────────────────────────────────────
+
+describe("uninstall — dry run", () => {
+	it("lists items with and without detail but deletes nothing", async () => {
+		mockScan.mockResolvedValue(
+			inventory([
+				item({ surface: "vscode-extension", label: "Ext", path: "/e", detail: "v1" }),
+				item({ surface: "global-config", label: "Cfg", path: "/c" }),
+			]),
+		);
+		const { out } = await run(["--dry-run"]);
+		expect(out).toContain("(v1)");
+		expect(out).toContain("[dry-run] Would remove 2 items");
+		expect(mockRm).not.toHaveBeenCalled();
+	});
+});
+
+// ─── scope filtering ──────────────────────────────────────────────────────────
+
+describe("uninstall — scope", () => {
+	const mixed = () =>
+		inventory([
+			item({ surface: "vscode-extension", label: "Ext", path: "/e" }),
+			item({ surface: "project-config", label: "Proj", path: "/p" }),
+		]);
+
+	it("shows only global surfaces with --scope global", async () => {
+		mockScan.mockResolvedValue(mixed());
+		const { out } = await run(["--scope", "global", "--dry-run"]);
+		expect(out).toContain("Ext");
+		expect(out).not.toContain("Proj");
+		expect(out).toContain("Would remove 1 item");
+	});
+
+	it("shows only project surfaces with --scope project", async () => {
+		mockScan.mockResolvedValue(mixed());
+		const { out } = await run(["--scope", "project", "--dry-run"]);
+		expect(out).toContain("Proj");
+		expect(out).not.toContain("Ext");
+	});
+
+	it("rejects an invalid scope", async () => {
+		mockScan.mockResolvedValue(mixed());
+		const { err } = await run(["--scope", "bogus"]);
+		expect(err).toContain("Invalid --scope");
+		expect(process.exitCode).toBe(1);
+		expect(mockScan).not.toHaveBeenCalled();
+	});
+});
+
+// ─── non-interactive guard ────────────────────────────────────────────────────
+
+describe("uninstall — non-interactive", () => {
+	it("refuses to delete without --yes when stdin is not a TTY", async () => {
+		mockIsInteractive.mockReturnValue(false);
+		mockScan.mockResolvedValue(inventory([item({ path: "/x" })]));
+		const { err } = await run([]);
+		expect(err).toContain("Refusing to delete in non-interactive mode");
+		expect(process.exitCode).toBe(1);
+		expect(mockRm).not.toHaveBeenCalled();
+	});
+});
+
+// ─── --yes removes everything ─────────────────────────────────────────────────
+
+describe("uninstall — --yes", () => {
+	it("removes all items and dispatches hooks to uninstall()", async () => {
+		mockScan.mockResolvedValue(
+			inventory([
+				item({ surface: "global-config", label: "Cfg", path: "/c", kind: "dir" }),
+				item({ surface: "repo-hooks", label: "Hooks", path: "/repo", kind: "hooks" }),
+			]),
+		);
+		const { out } = await run(["--yes"]);
+		expect(mockRm).toHaveBeenCalledWith("/c", { recursive: true, force: true });
+		expect(mockUninstall).toHaveBeenCalledWith("/repo");
+		expect(out).toContain("Removed 2 items");
+		expect(mockTrack).toHaveBeenCalledWith("surface_disabled", { reason: "uninstall" });
+		// Removing the global config warns that other repos' hooks will break.
+		expect(out).toContain("global config was removed");
+		// Non-extension items must not trigger manifest reconciliation.
+		expect(mockPrune).not.toHaveBeenCalled();
+	});
+
+	it("notes Windows self-deletion when the global CLI is removed on win32", async () => {
+		const originalPlatform = process.platform;
+		Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+		try {
+			mockScan.mockResolvedValue(
+				inventory([item({ surface: "cli-global", label: "CLI", path: "/cli", kind: "dir" })]),
+			);
+			const { out } = await run(["--yes"]);
+			expect(out).toContain("global CLI removed itself");
+		} finally {
+			Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+		}
+	});
+
+	it("reconciles the VS Code manifest after deleting an extension folder", async () => {
+		mockScan.mockResolvedValue(
+			inventory([item({ surface: "vscode-extension", label: "Ext", path: "/ext/jolli.x-1.0.0", kind: "dir" })]),
+		);
+		const { out } = await run(["--yes"]);
+		expect(mockRm).toHaveBeenCalledWith("/ext/jolli.x-1.0.0", { recursive: true, force: true });
+		expect(mockPrune).toHaveBeenCalledWith("/ext/jolli.x-1.0.0");
+		expect(out).toContain("restart any open VS Code");
+	});
+});
+
+// ─── interactive selection ────────────────────────────────────────────────────
+
+describe("uninstall — interactive", () => {
+	beforeEach(() => {
+		mockScan.mockResolvedValue(
+			inventory([item({ label: "One", path: "/one" }), item({ label: "Two", path: "/two" })]),
+		);
+	});
+
+	it("removes only the selected item after confirmation", async () => {
+		mockPromptText.mockResolvedValueOnce("1").mockResolvedValueOnce("y");
+		const { out } = await run([]);
+		expect(mockRm).toHaveBeenCalledTimes(1);
+		expect(mockRm).toHaveBeenCalledWith("/one", expect.anything());
+		expect(out).toContain("Removed 1 item");
+	});
+
+	it("cancels when the selection answer is empty", async () => {
+		mockPromptText.mockResolvedValueOnce("");
+		const { out } = await run([]);
+		expect(out).toContain("Cancelled. Nothing was removed");
+		expect(mockRm).not.toHaveBeenCalled();
+	});
+
+	it("aborts when the confirmation is declined", async () => {
+		mockPromptText.mockResolvedValueOnce("a").mockResolvedValueOnce("n");
+		const { out } = await run([]);
+		expect(out).toContain("Aborted. Nothing was removed");
+		expect(mockRm).not.toHaveBeenCalled();
+	});
+});
+
+// ─── failure reporting ────────────────────────────────────────────────────────
+
+describe("uninstall — failures", () => {
+	it("reports a filesystem removal error and sets a non-zero exit code", async () => {
+		mockScan.mockResolvedValue(inventory([item({ label: "Bad", path: "/bad" })]));
+		mockRm.mockRejectedValueOnce(new Error("EACCES: permission denied"));
+		const { err } = await run(["--yes"]);
+		expect(err).toContain("could not be removed");
+		expect(err).toContain("EACCES");
+		expect(process.exitCode).toBe(1);
+		// Nothing was actually removed — no disable event should be recorded.
+		expect(mockTrack).not.toHaveBeenCalled();
+	});
+
+	it("pluralizes when more than one item fails", async () => {
+		mockScan.mockResolvedValue(inventory([item({ label: "A", path: "/a" }), item({ label: "B", path: "/b" })]));
+		mockRm.mockRejectedValue(new Error("EACCES"));
+		const { err } = await run(["--yes"]);
+		expect(err).toContain("2 items could not be removed");
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("reports a failed hook strip via uninstall()", async () => {
+		mockScan.mockResolvedValue(
+			inventory([item({ surface: "repo-hooks", label: "Hooks", path: "/repo", kind: "hooks" })]),
+		);
+		mockUninstall.mockResolvedValueOnce({ success: false, message: "hook removal failed", warnings: [] });
+		const { err } = await run(["--yes"]);
+		expect(err).toContain("hook removal failed");
+		expect(process.exitCode).toBe(1);
+	});
+});

--- a/cli/src/commands/UninstallCommand.ts
+++ b/cli/src/commands/UninstallCommand.ts
@@ -1,0 +1,255 @@
+/**
+ * UninstallCommand — `jolli uninstall`.
+ *
+ * Machine-wide detection and selective removal of every Jolli Memory
+ * installation and configuration artifact: VS Code / IntelliJ editor
+ * integrations, the global `@jolli.ai/cli` package, the global + per-project
+ * `.jolli/jollimemory/` state directories, and the current repo's hooks.
+ *
+ * User memory is NEVER touched — the orphan branch and Memory Bank content are
+ * out of scope by construction (see UninstallScan). This command removes
+ * installation + configuration only.
+ *
+ * Flags mirror `clean`: `--dry-run` previews, `--yes` skips the prompt (and is
+ * required in non-interactive contexts), `--scope` narrows to machine-global or
+ * project-local surfaces.
+ */
+
+import { rm } from "node:fs/promises";
+import type { Command } from "commander";
+import { track } from "../core/Telemetry.js";
+import { uninstall } from "../install/Installer.js";
+import {
+	pruneVscodeExtensionManifest,
+	type RemovableItem,
+	scanUninstallInventory,
+	type UninstallInventory,
+	type UninstallSurface,
+} from "../install/UninstallScan.js";
+import { createLogger, setLogDir } from "../Logger.js";
+import { isInteractive, promptText, resolveProjectDir } from "./CliUtils.js";
+
+const log = createLogger("uninstall");
+
+/** Removal scope selected via `--scope`. */
+type Scope = "all" | "global" | "project";
+
+/** Ordered surface metadata: section heading + which scope each belongs to. */
+const SURFACE_META: ReadonlyArray<{ surface: UninstallSurface; heading: string; scope: Exclude<Scope, "all"> }> = [
+	{ surface: "vscode-extension", heading: "VS Code editors", scope: "global" },
+	{ surface: "intellij-plugin", heading: "JetBrains IDEs", scope: "global" },
+	{ surface: "cli-global", heading: "Command-line tool", scope: "global" },
+	{ surface: "global-config", heading: "Global configuration", scope: "global" },
+	{ surface: "project-config", heading: "Project state (current repo)", scope: "project" },
+	{ surface: "repo-hooks", heading: "Hooks & MCP (current repo)", scope: "project" },
+];
+
+/** True when `item` belongs to the requested `scope`. */
+function inScope(item: RemovableItem, scope: Scope): boolean {
+	if (scope === "all") return true;
+	const meta = SURFACE_META.find((m) => m.surface === item.surface);
+	/* v8 ignore next -- every surface has a SURFACE_META entry; guards a future gap */
+	return meta?.scope === scope;
+}
+
+/** Prints the grouped inventory. Returns the flat list of in-scope items. */
+function printInventory(inventory: UninstallInventory, scope: Scope): RemovableItem[] {
+	const items = inventory.items.filter((i) => inScope(i, scope));
+
+	console.log("\n  Jolli Memory — Uninstall");
+	console.log("  ────────────────────────────────────────────");
+
+	if (items.length === 0) {
+		console.log("\n  No Jolli installation or configuration found for the selected scope.\n");
+		return items;
+	}
+
+	let index = 0;
+	for (const { surface, heading } of SURFACE_META) {
+		const group = items.filter((i) => i.surface === surface);
+		if (group.length === 0) continue;
+		console.log(`\n  ${heading}:`);
+		for (const item of group) {
+			index++;
+			const detail = item.detail ? ` (${item.detail})` : "";
+			console.log(`    ${String(index).padStart(2)}. ${item.label}${detail}`);
+			console.log(`        ${item.path}`);
+		}
+	}
+
+	console.log("\n  Preserved (never removed):");
+	for (const note of inventory.preserved) {
+		console.log(`    · ${note}`);
+	}
+
+	return items;
+}
+
+/**
+ * Parses a selection answer into a set of 1-based indices. Accepts comma- or
+ * space-separated numbers, or "a"/"all" for everything. Returns null when the
+ * answer is empty (treated as "cancel") or contains no valid index.
+ */
+export function parseSelection(answer: string, count: number): Set<number> | null {
+	const trimmed = answer.trim().toLowerCase();
+	if (trimmed === "") return null;
+	if (trimmed === "a" || trimmed === "all") {
+		return new Set(Array.from({ length: count }, (_, i) => i + 1));
+	}
+	const selected = new Set<number>();
+	for (const token of trimmed.split(/[\s,]+/)) {
+		if (token === "") continue;
+		const n = Number(token);
+		if (Number.isInteger(n) && n >= 1 && n <= count) {
+			selected.add(n);
+		}
+	}
+	return selected.size > 0 ? selected : null;
+}
+
+/**
+ * Removes a single item. Filesystem items are deleted with `rm -rf`; the
+ * `repo-hooks` pseudo-item dispatches to the marker-aware `uninstall()` so hook
+ * sections are stripped without clobbering unrelated user hooks. Returns an
+ * error message on failure, or null on success.
+ */
+async function removeItem(item: RemovableItem): Promise<string | null> {
+	try {
+		if (item.kind === "hooks") {
+			const result = await uninstall(item.path);
+			return result.success ? null : result.message;
+		}
+		await rm(item.path, { recursive: true, force: true });
+		// A VS Code-family editor tracks installs in extensions.json; deleting the
+		// folder alone leaves a dangling entry that shows a "corrupt extension"
+		// warning on reopen. Reconcile the manifest so the uninstall reads clean.
+		if (item.surface === "vscode-extension") {
+			await pruneVscodeExtensionManifest(item.path);
+		}
+		return null;
+	} catch (err) {
+		return (err as Error).message;
+	}
+}
+
+/** Core flow: scan, print, select, confirm, remove. */
+async function runUninstall(cwd: string, scope: Scope, dryRun: boolean, skipPrompt: boolean): Promise<void> {
+	const inventory = await scanUninstallInventory({ projectDir: cwd });
+	const items = printInventory(inventory, scope);
+
+	if (items.length === 0) return;
+
+	if (dryRun) {
+		console.log(`\n  [dry-run] Would remove ${items.length} item${items.length === 1 ? "" : "s"}.\n`);
+		return;
+	}
+
+	// Decide which items to remove.
+	let targets: RemovableItem[];
+	if (skipPrompt) {
+		targets = items;
+	} else {
+		if (!isInteractive()) {
+			console.error(
+				"\n  Refusing to delete in non-interactive mode. Pass --yes to remove everything listed, or --dry-run to preview.\n",
+			);
+			process.exitCode = 1;
+			return;
+		}
+		const answer = await promptText(
+			"\n  Enter item numbers to remove (comma/space separated), 'a' for all, or Enter to cancel: ",
+		);
+		const selection = parseSelection(answer, items.length);
+		if (selection === null) {
+			console.log("\n  Cancelled. Nothing was removed.\n");
+			return;
+		}
+		targets = items.filter((_, i) => selection.has(i + 1));
+
+		// Second confirmation for irreversible deletion.
+		const confirm = await promptText(
+			`\n  Remove ${targets.length} selected item${targets.length === 1 ? "" : "s"}? [y/N]: `,
+		);
+		const lower = confirm.trim().toLowerCase();
+		if (lower !== "y" && lower !== "yes") {
+			console.log("\n  Aborted. Nothing was removed.\n");
+			return;
+		}
+	}
+
+	// Apply removals; report per-item outcome.
+	let removed = 0;
+	let removedExtension = false;
+	let removedGlobalConfig = false;
+	let removedCliGlobal = false;
+	const failures: string[] = [];
+	for (const item of targets) {
+		const error = await removeItem(item);
+		if (error === null) {
+			removed++;
+			if (item.surface === "vscode-extension") removedExtension = true;
+			if (item.surface === "global-config") removedGlobalConfig = true;
+			if (item.surface === "cli-global") removedCliGlobal = true;
+			console.log(`  ✓ ${item.label}`);
+		} else {
+			failures.push(`${item.label}: ${error}`);
+			console.error(`  ✗ ${item.label} — ${error}`);
+		}
+	}
+
+	// Only record the disable event when something was actually removed — a run
+	// where every item failed (or nothing was selected) is not a disable.
+	if (removed > 0) {
+		track("surface_disabled", { reason: "uninstall" });
+	}
+
+	console.log(`\n  Removed ${removed} item${removed === 1 ? "" : "s"}.`);
+	if (failures.length > 0) {
+		console.error(`  ${failures.length} item${failures.length === 1 ? "" : "s"} could not be removed:`);
+		for (const f of failures) console.error(`    - ${f}`);
+		process.exitCode = 1;
+	}
+	if (removedGlobalConfig) {
+		// The global config dir holds the shared hook entry scripts (resolve-dist-path,
+		// run-hook) that EVERY repo's git hooks invoke. Removing it here does not touch
+		// hooks in other repos, so those will error on their next commit until Jolli is
+		// re-enabled or fully removed there.
+		console.log("\n  Note: global config was removed. Jolli hooks in OTHER repos will error on their next");
+		console.log("  commit until you run `jolli disable` (or `jolli uninstall`) in each of them.");
+	}
+	if (removedExtension) {
+		// A running editor may rewrite extensions.json on exit, re-adding the entry
+		// we just pruned. Restarting lets it reconcile against the deleted folder.
+		console.log("\n  Note: restart any open VS Code / Cursor / fork window so the uninstall takes effect.");
+	}
+	if (removedCliGlobal && process.platform === "win32") {
+		// On Windows the running executable's files can't be deleted while in use, so
+		// some may linger until this process exits.
+		console.log("\n  Note: the global CLI removed itself; some files may remain until this process exits.");
+	}
+	console.log("");
+}
+
+/** Registers the `uninstall` command on the given Commander program. */
+export function registerUninstallCommand(program: Command): void {
+	program
+		.command("uninstall")
+		.description("Detect and remove all Jolli installation & config (never your memories)")
+		.option("--dry-run", "Show what would be removed without deleting anything")
+		.option("-y, --yes", "Remove everything detected without prompting (required in non-interactive shells)")
+		.option("--scope <scope>", "Limit to 'global', 'project', or 'all' surfaces (default: all)", "all")
+		.option("--cwd <dir>", "Project directory (default: git repo root)", resolveProjectDir())
+		.action(async (options: { cwd: string; dryRun?: boolean; yes?: boolean; scope?: string }) => {
+			setLogDir(options.cwd);
+			log.info("Running 'uninstall' command");
+
+			const scope = options.scope;
+			if (scope !== "all" && scope !== "global" && scope !== "project") {
+				console.error(`\n  Invalid --scope '${scope}'. Use 'all', 'global', or 'project'.\n`);
+				process.exitCode = 1;
+				return;
+			}
+
+			await runUninstall(options.cwd, scope, options.dryRun === true, options.yes === true);
+		});
+}

--- a/cli/src/install/UninstallScan.test.ts
+++ b/cli/src/install/UninstallScan.test.ts
@@ -1,0 +1,493 @@
+/**
+ * UninstallScan tests.
+ *
+ * Uses real temp directories for the filesystem-facing scanners (VS Code,
+ * IntelliJ, CLI-global, config dirs) so readdir/stat/lstat branches are
+ * exercised end-to-end. Only three seams are mocked: `getStatus` (repo-hooks
+ * probe), `getGlobalConfigDir` (redirected into a temp dir), and
+ * `execFileAsyncHidden` (the `npm root -g` spawn).
+ */
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockGetStatus, mockExecFile } = vi.hoisted(() => ({
+	mockGetStatus: vi.fn(),
+	mockExecFile: vi.fn(),
+}));
+
+let mockGlobalConfigDir = "/nonexistent/global/config";
+
+vi.mock("./Installer.js", () => ({
+	getStatus: mockGetStatus,
+}));
+
+vi.mock("../core/SessionTracker.js", () => ({
+	getGlobalConfigDir: () => mockGlobalConfigDir,
+}));
+
+vi.mock("../util/Subprocess.js", () => ({
+	execFileAsyncHidden: mockExecFile,
+}));
+
+import {
+	getJetBrainsRoot,
+	pruneVscodeExtensionManifest,
+	resolveNpmGlobalRoots,
+	scanCliGlobal,
+	scanGlobalConfig,
+	scanIntellijPlugins,
+	scanProjectConfig,
+	scanRepoHooks,
+	scanUninstallInventory,
+	scanVscodeExtensions,
+	staticNpmGlobalRoots,
+} from "./UninstallScan.js";
+
+let tempDir: string;
+
+beforeEach(() => {
+	tempDir = mkdtempSync(join(tmpdir(), "jolli-uninstall-scan-"));
+	mockGlobalConfigDir = "/nonexistent/global/config";
+	vi.clearAllMocks();
+	mockGetStatus.mockResolvedValue({
+		gitHookInstalled: false,
+		claudeHookInstalled: false,
+		geminiHookInstalled: false,
+	});
+});
+
+afterEach(() => {
+	rmSync(tempDir, { recursive: true, force: true });
+});
+
+// ─── scanVscodeExtensions ─────────────────────────────────────────────────────
+
+describe("scanVscodeExtensions", () => {
+	it("finds the extension across editors and forks and parses the version", async () => {
+		mkdirSync(join(tempDir, ".vscode", "extensions", "jolli.jollimemory-vscode-0.99.7"), { recursive: true });
+		mkdirSync(join(tempDir, ".vscode", "extensions", "ms-python.python-2024.1"), { recursive: true });
+		mkdirSync(join(tempDir, ".cursor", "extensions", "jolli.jollimemory-vscode-1.0.0"), { recursive: true });
+		// Antigravity's real data dir is `.antigravity-ide`, not `.antigravity`.
+		mkdirSync(join(tempDir, ".antigravity-ide", "extensions", "jolli.jollimemory-vscode-1.0.0"), {
+			recursive: true,
+		});
+		mkdirSync(join(tempDir, ".kiro", "extensions", "jolli.jollimemory-vscode-1.0.0"), { recursive: true });
+		mkdirSync(join(tempDir, ".devin", "extensions", "jolli.jollimemory-vscode-1.0.0"), { recursive: true });
+
+		const items = await scanVscodeExtensions(tempDir);
+
+		expect(items).toHaveLength(5);
+		const vscode = items.find((i) => i.label.includes("VS Code"));
+		expect(vscode?.detail).toBe("v0.99.7");
+		expect(vscode?.kind).toBe("dir");
+		expect(items.some((i) => i.label.includes("Cursor") && i.detail === "v1.0.0")).toBe(true);
+		expect(items.some((i) => i.label.includes("Antigravity"))).toBe(true);
+		expect(items.some((i) => i.label.includes("Kiro"))).toBe(true);
+		expect(items.some((i) => i.label.includes("Devin"))).toBe(true);
+	});
+
+	it("leaves detail undefined when the folder has no version suffix", async () => {
+		mkdirSync(join(tempDir, ".vscode", "extensions", "jolli.jollimemory-vscode"), { recursive: true });
+
+		const items = await scanVscodeExtensions(tempDir);
+
+		expect(items).toHaveLength(1);
+		expect(items[0].detail).toBeUndefined();
+	});
+
+	it("returns nothing when no editor extensions dir exists", async () => {
+		const items = await scanVscodeExtensions(tempDir);
+		expect(items).toEqual([]);
+	});
+});
+
+// ─── pruneVscodeExtensionManifest ─────────────────────────────────────────────
+
+describe("pruneVscodeExtensionManifest", () => {
+	/** Writes an extensions.json in `extDir` and returns its path. */
+	function writeManifest(extDir: string, entries: unknown[]): string {
+		mkdirSync(extDir, { recursive: true });
+		const p = join(extDir, "extensions.json");
+		writeFileSync(p, JSON.stringify(entries));
+		return p;
+	}
+
+	it("removes the entry whose relativeLocation matches the deleted folder", async () => {
+		const extDir = join(tempDir, "extensions");
+		const manifest = writeManifest(extDir, [
+			{ identifier: { id: "jolli.jollimemory-vscode" }, relativeLocation: "jolli.jollimemory-vscode-1.0.0" },
+			{ identifier: { id: "ms-python.python" }, relativeLocation: "ms-python.python-2024.1" },
+		]);
+
+		await pruneVscodeExtensionManifest(join(extDir, "jolli.jollimemory-vscode-1.0.0"));
+
+		const remaining = JSON.parse(readFileSync(manifest, "utf8")) as Array<{ relativeLocation: string }>;
+		expect(remaining).toHaveLength(1);
+		expect(remaining[0].relativeLocation).toBe("ms-python.python-2024.1");
+	});
+
+	it("leaves the manifest untouched when nothing matches", async () => {
+		const extDir = join(tempDir, "extensions");
+		const entries = [{ relativeLocation: "other.ext-1.0.0" }];
+		const manifest = writeManifest(extDir, entries);
+		const before = readFileSync(manifest, "utf8");
+
+		await pruneVscodeExtensionManifest(join(extDir, "jolli.jollimemory-vscode-1.0.0"));
+
+		expect(readFileSync(manifest, "utf8")).toBe(before);
+	});
+
+	it("does nothing when the manifest is absent", async () => {
+		// No extensions.json created — must not throw.
+		await expect(
+			pruneVscodeExtensionManifest(join(tempDir, "extensions", "jolli.jollimemory-vscode-1.0.0")),
+		).resolves.toBeUndefined();
+	});
+
+	it("swallows a malformed manifest", async () => {
+		const extDir = join(tempDir, "extensions");
+		mkdirSync(extDir, { recursive: true });
+		writeFileSync(join(extDir, "extensions.json"), "{ not json");
+
+		await expect(
+			pruneVscodeExtensionManifest(join(extDir, "jolli.jollimemory-vscode-1.0.0")),
+		).resolves.toBeUndefined();
+	});
+
+	it("ignores a manifest that is not a JSON array", async () => {
+		const extDir = join(tempDir, "extensions");
+		mkdirSync(extDir, { recursive: true });
+		writeFileSync(join(extDir, "extensions.json"), JSON.stringify({ not: "an array" }));
+
+		await expect(
+			pruneVscodeExtensionManifest(join(extDir, "jolli.jollimemory-vscode-1.0.0")),
+		).resolves.toBeUndefined();
+	});
+});
+
+// ─── getJetBrainsRoot ─────────────────────────────────────────────────────────
+
+describe("getJetBrainsRoot", () => {
+	it("resolves the macOS path", () => {
+		expect(getJetBrainsRoot("/home/u", "darwin")).toBe("/home/u/Library/Application Support/JetBrains");
+	});
+
+	it("resolves the Linux path", () => {
+		expect(getJetBrainsRoot("/home/u", "linux")).toBe("/home/u/.local/share/JetBrains");
+	});
+
+	it("resolves the Windows path from APPDATA", () => {
+		vi.stubEnv("APPDATA", "C:\\Users\\u\\AppData\\Roaming");
+		expect(getJetBrainsRoot("C:\\Users\\u", "win32")).toContain("JetBrains");
+	});
+
+	it("falls back to a home-relative path on Windows without APPDATA", () => {
+		vi.stubEnv("APPDATA", undefined);
+		const result = getJetBrainsRoot("C:\\Users\\u", "win32");
+		expect(result).toContain("JetBrains");
+	});
+});
+
+// ─── scanIntellijPlugins ──────────────────────────────────────────────────────
+
+describe("scanIntellijPlugins", () => {
+	function jetbrainsBase(home: string): string {
+		return join(home, ".local", "share", "JetBrains");
+	}
+
+	it("finds jolli plugins across product dirs and skips non-jolli ones", async () => {
+		const base = jetbrainsBase(tempDir);
+		mkdirSync(join(base, "IntelliJIdea2024.1", "plugins", "jollimemory-intellij"), { recursive: true });
+		mkdirSync(join(base, "IntelliJIdea2024.1", "plugins", "some-other-plugin"), { recursive: true });
+		mkdirSync(join(base, "WebStorm2023.3", "plugins", "jollimemory-intellij"), { recursive: true });
+
+		const items = await scanIntellijPlugins(tempDir, "linux");
+
+		expect(items).toHaveLength(2);
+		expect(items.every((i) => i.surface === "intellij-plugin")).toBe(true);
+		expect(items.some((i) => i.label.includes("WebStorm2023.3"))).toBe(true);
+	});
+
+	it("returns nothing when the JetBrains root is absent", async () => {
+		const items = await scanIntellijPlugins(tempDir, "linux");
+		expect(items).toEqual([]);
+	});
+
+	it("skips product entries that have no plugins subdirectory", async () => {
+		const base = jetbrainsBase(tempDir);
+		mkdirSync(base, { recursive: true });
+		writeFileSync(join(base, "stray-file"), "x");
+
+		const items = await scanIntellijPlugins(tempDir, "linux");
+		expect(items).toEqual([]);
+	});
+
+	it("finds Android Studio under Google, ignoring unrelated Google apps", async () => {
+		const googleBase = join(tempDir, ".local", "share", "Google");
+		mkdirSync(join(googleBase, "AndroidStudio2024.1", "plugins", "jollimemory-intellij"), { recursive: true });
+		// A non-AndroidStudio app under Google/ must be skipped even if it somehow
+		// contains a jolli-named folder — the productPrefix filter excludes it.
+		mkdirSync(join(googleBase, "Chrome", "plugins", "jollimemory-intellij"), { recursive: true });
+
+		const items = await scanIntellijPlugins(tempDir, "linux");
+
+		expect(items).toHaveLength(1);
+		expect(items[0].surface).toBe("intellij-plugin");
+		expect(items[0].label).toContain("AndroidStudio2024.1");
+	});
+});
+
+// ─── resolveNpmGlobalRoots ────────────────────────────────────────────────────
+
+describe("resolveNpmGlobalRoots", () => {
+	it("returns the trimmed root from `npm root -g`, passing a timeout", async () => {
+		mockExecFile.mockResolvedValueOnce({ stdout: "/usr/local/lib/node_modules\n", stderr: "" });
+		expect(await resolveNpmGlobalRoots()).toEqual(["/usr/local/lib/node_modules"]);
+		expect(mockExecFile).toHaveBeenCalledWith("npm", ["root", "-g"], { timeout: 5000 });
+	});
+
+	it("returns [] when npm prints empty output", async () => {
+		mockExecFile.mockResolvedValueOnce({ stdout: "  \n", stderr: "" });
+		expect(await resolveNpmGlobalRoots()).toEqual([]);
+	});
+
+	it("returns [] when npm is missing or errors", async () => {
+		mockExecFile.mockRejectedValueOnce(new Error("spawn npm ENOENT"));
+		expect(await resolveNpmGlobalRoots()).toEqual([]);
+	});
+});
+
+// ─── staticNpmGlobalRoots ─────────────────────────────────────────────────────
+
+describe("staticNpmGlobalRoots", () => {
+	it("includes the Homebrew path on darwin", () => {
+		const roots = staticNpmGlobalRoots("/Users/u", "darwin");
+		expect(roots).toContain("/opt/homebrew/lib/node_modules");
+		expect(roots).toContain("/usr/local/lib/node_modules");
+	});
+
+	it("omits the Homebrew path on plain linux", () => {
+		const roots = staticNpmGlobalRoots("/home/u", "linux");
+		expect(roots).not.toContain("/opt/homebrew/lib/node_modules");
+	});
+
+	it("returns the APPDATA npm path on win32", () => {
+		vi.stubEnv("APPDATA", "C:\\Users\\u\\AppData\\Roaming");
+		const roots = staticNpmGlobalRoots("C:\\Users\\u", "win32");
+		expect(roots.some((r) => r.includes("npm"))).toBe(true);
+	});
+
+	it("falls back to a home-relative npm path on win32 without APPDATA", () => {
+		vi.stubEnv("APPDATA", undefined);
+		const roots = staticNpmGlobalRoots("C:\\Users\\u", "win32");
+		expect(roots).toHaveLength(1);
+	});
+});
+
+// ─── scanCliGlobal ────────────────────────────────────────────────────────────
+
+describe("scanCliGlobal", () => {
+	it("finds the package dir and the POSIX bin shim, de-duplicating roots", async () => {
+		const root = join(tempDir, "lib", "node_modules");
+		mkdirSync(join(root, "@jolli.ai", "cli"), { recursive: true });
+		mkdirSync(join(tempDir, "bin"), { recursive: true });
+		symlinkSync(join(root, "@jolli.ai", "cli", "dist", "Cli.js"), join(tempDir, "bin", "jolli"));
+
+		// Pass the same root twice to exercise de-duplication.
+		const items = await scanCliGlobal(tempDir, "linux", [root, root]);
+
+		expect(items.filter((i) => i.kind === "dir")).toHaveLength(1);
+		expect(items.filter((i) => i.kind === "file")).toHaveLength(1);
+		expect(items[0].surface).toBe("cli-global");
+	});
+
+	it("returns only the package dir when no bin shim exists", async () => {
+		const root = join(tempDir, "lib", "node_modules");
+		mkdirSync(join(root, "@jolli.ai", "cli"), { recursive: true });
+
+		const items = await scanCliGlobal(tempDir, "linux", [root]);
+
+		expect(items).toHaveLength(1);
+		expect(items[0].kind).toBe("dir");
+	});
+
+	it("returns nothing when the package is not installed at any root", async () => {
+		const items = await scanCliGlobal(tempDir, "linux", [join(tempDir, "empty")]);
+		expect(items).toEqual([]);
+	});
+
+	it("handles a global root that does not end in node_modules", async () => {
+		const root = join(tempDir, "globalroot");
+		mkdirSync(join(root, "@jolli.ai", "cli"), { recursive: true });
+		mkdirSync(join(root, "bin"), { recursive: true });
+		writeFileSync(join(root, "bin", "jolli"), "#!/bin/sh");
+
+		const items = await scanCliGlobal(tempDir, "linux", [root]);
+
+		expect(items.filter((i) => i.kind === "dir")).toHaveLength(1);
+		expect(items.filter((i) => i.kind === "file")).toHaveLength(1);
+	});
+
+	it("de-duplicates a bin shim shared by two roots with the same prefix", async () => {
+		const libRoot = join(tempDir, "lib", "node_modules");
+		const plainRoot = join(tempDir, "node_modules");
+		mkdirSync(join(libRoot, "@jolli.ai", "cli"), { recursive: true });
+		mkdirSync(join(plainRoot, "@jolli.ai", "cli"), { recursive: true });
+		mkdirSync(join(tempDir, "bin"), { recursive: true });
+		writeFileSync(join(tempDir, "bin", "jolli"), "#!/bin/sh");
+
+		const items = await scanCliGlobal(tempDir, "linux", [libRoot, plainRoot]);
+
+		// Two distinct package dirs, but the shared bin shim is listed once.
+		expect(items.filter((i) => i.kind === "dir")).toHaveLength(2);
+		expect(items.filter((i) => i.kind === "file")).toHaveLength(1);
+	});
+
+	it("locates the Windows shim beside the prefix", async () => {
+		const root = join(tempDir, "npm", "node_modules");
+		mkdirSync(join(root, "@jolli.ai", "cli"), { recursive: true });
+		writeFileSync(join(tempDir, "npm", "jolli.cmd"), "@echo off");
+
+		const items = await scanCliGlobal(tempDir, "win32", [root]);
+
+		expect(items.some((i) => i.kind === "file" && i.path.endsWith("jolli.cmd"))).toBe(true);
+	});
+});
+
+// ─── scanGlobalConfig ─────────────────────────────────────────────────────────
+
+describe("scanGlobalConfig", () => {
+	it("returns the dir item when the global config dir exists", async () => {
+		mockGlobalConfigDir = join(tempDir, "globalcfg");
+		mkdirSync(mockGlobalConfigDir, { recursive: true });
+
+		const items = await scanGlobalConfig();
+		expect(items).toHaveLength(1);
+		expect(items[0].surface).toBe("global-config");
+	});
+
+	it("returns nothing when the dir is missing", async () => {
+		mockGlobalConfigDir = join(tempDir, "missing");
+		expect(await scanGlobalConfig()).toEqual([]);
+	});
+
+	it("returns nothing when the path is a file, not a dir", async () => {
+		mockGlobalConfigDir = join(tempDir, "cfgfile");
+		writeFileSync(mockGlobalConfigDir, "x");
+		expect(await scanGlobalConfig()).toEqual([]);
+	});
+});
+
+// ─── scanProjectConfig ────────────────────────────────────────────────────────
+
+describe("scanProjectConfig", () => {
+	it("returns the dir item when the project state dir exists", async () => {
+		mkdirSync(join(tempDir, ".jolli", "jollimemory"), { recursive: true });
+
+		const items = await scanProjectConfig(tempDir);
+		expect(items).toHaveLength(1);
+		expect(items[0].surface).toBe("project-config");
+	});
+
+	it("returns nothing when the project state dir is missing", async () => {
+		expect(await scanProjectConfig(tempDir)).toEqual([]);
+	});
+
+	it("returns nothing when the state path is a file", async () => {
+		mkdirSync(join(tempDir, ".jolli"), { recursive: true });
+		writeFileSync(join(tempDir, ".jolli", "jollimemory"), "x");
+		expect(await scanProjectConfig(tempDir)).toEqual([]);
+	});
+});
+
+// ─── scanRepoHooks ────────────────────────────────────────────────────────────
+
+describe("scanRepoHooks", () => {
+	it("emits a hooks pseudo-item when any hook is installed", async () => {
+		mockGetStatus.mockResolvedValueOnce({
+			gitHookInstalled: true,
+			claudeHookInstalled: false,
+			geminiHookInstalled: false,
+		});
+
+		const items = await scanRepoHooks(tempDir);
+		expect(items).toHaveLength(1);
+		expect(items[0].kind).toBe("hooks");
+		expect(items[0].surface).toBe("repo-hooks");
+	});
+
+	it("returns nothing when no hooks are installed", async () => {
+		const items = await scanRepoHooks(tempDir);
+		expect(items).toEqual([]);
+	});
+
+	it("returns nothing (non-fatal) when getStatus throws", async () => {
+		mockGetStatus.mockRejectedValueOnce(new Error("not a git repo"));
+		const items = await scanRepoHooks(tempDir);
+		expect(items).toEqual([]);
+	});
+});
+
+// ─── scanUninstallInventory ───────────────────────────────────────────────────
+
+describe("scanUninstallInventory", () => {
+	it("aggregates every surface and lists preserved notes", async () => {
+		// VS Code extension
+		mkdirSync(join(tempDir, ".vscode", "extensions", "jolli.jollimemory-vscode-0.99.7"), { recursive: true });
+		// IntelliJ plugin
+		mkdirSync(join(tempDir, ".local", "share", "JetBrains", "IdeaIC2024.1", "plugins", "jollimemory-intellij"), {
+			recursive: true,
+		});
+		// Global CLI
+		const npmRoot = join(tempDir, "lib", "node_modules");
+		mkdirSync(join(npmRoot, "@jolli.ai", "cli"), { recursive: true });
+		// Global config
+		mockGlobalConfigDir = join(tempDir, "globalcfg");
+		mkdirSync(mockGlobalConfigDir, { recursive: true });
+		// Project config
+		const projectDir = join(tempDir, "proj");
+		mkdirSync(join(projectDir, ".jolli", "jollimemory"), { recursive: true });
+		// Repo hooks
+		mockGetStatus.mockResolvedValue({
+			gitHookInstalled: true,
+			claudeHookInstalled: false,
+			geminiHookInstalled: false,
+		});
+
+		const inventory = await scanUninstallInventory({
+			home: tempDir,
+			platform: "linux",
+			projectDir,
+			npmGlobalRoots: [npmRoot],
+		});
+
+		const surfaces = new Set(inventory.items.map((i) => i.surface));
+		expect(surfaces).toEqual(
+			new Set([
+				"vscode-extension",
+				"intellij-plugin",
+				"cli-global",
+				"global-config",
+				"project-config",
+				"repo-hooks",
+			]),
+		);
+		expect(inventory.preserved.length).toBeGreaterThanOrEqual(2);
+		expect(inventory.preserved.join(" ")).toMatch(/orphan branch/i);
+	});
+
+	it("falls back to npm root -g and process defaults when options are omitted", async () => {
+		mockExecFile.mockResolvedValue({ stdout: "", stderr: "" });
+
+		const inventory = await scanUninstallInventory();
+
+		expect(mockExecFile).toHaveBeenCalledWith("npm", ["root", "-g"], { timeout: 5000 });
+		expect(Array.isArray(inventory.items)).toBe(true);
+		expect(inventory.preserved).toHaveLength(2);
+	});
+});

--- a/cli/src/install/UninstallScan.ts
+++ b/cli/src/install/UninstallScan.ts
@@ -1,0 +1,498 @@
+/**
+ * UninstallScan — machine-wide discovery of every Jolli Memory installation and
+ * configuration artifact, for the `jolli uninstall` command.
+ *
+ * Scope (vs `disable`): `disable` strips the CURRENT repo's hook sections and
+ * repo-scoped MCP entries. `uninstall` is machine-wide: it also finds the VS
+ * Code / IntelliJ editor artifacts, the globally-installed CLI package, and the
+ * global + per-project `.jolli/jollimemory/` state directories.
+ *
+ * HARD EXCLUSION — user memory is never in the inventory:
+ *   - the `jollimemory/summaries/v3` git orphan branch (system of record), and
+ *   - the Memory Bank folder (default `~/Documents/jolli/`, or the configured
+ *     `localFolder`) which holds summary/transcript/plan/note content.
+ * Only *installation and configuration* is removable. The global config dir
+ * (`~/.jolli/jollimemory/`) is config/state only — API keys, dist-paths, hook
+ * entry scripts — and lives on a different path than the Memory Bank, so
+ * removing it never touches memory content.
+ *
+ * Every path input is injectable (`home`, `platform`, `projectDir`,
+ * `npmGlobalRoots`) so the scan is deterministic and fully unit-testable
+ * without touching the real machine.
+ */
+
+import { lstat, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { homedir, platform as osPlatform } from "node:os";
+import { basename, dirname, join, sep } from "node:path";
+import { getGlobalConfigDir } from "../core/SessionTracker.js";
+import { createLogger, getJolliMemoryDir } from "../Logger.js";
+import { execFileAsyncHidden } from "../util/Subprocess.js";
+import { getStatus } from "./Installer.js";
+
+const log = createLogger("UninstallScan");
+
+/** The distinct surfaces a Jolli install can occupy. */
+export type UninstallSurface =
+	| "vscode-extension"
+	| "intellij-plugin"
+	| "cli-global"
+	| "global-config"
+	| "project-config"
+	| "repo-hooks";
+
+/** How the command removes an item. */
+export type RemovableKind = "file" | "dir" | "hooks";
+
+/** A single removable artifact discovered on disk (or a pseudo-item for hooks). */
+export interface RemovableItem {
+	readonly surface: UninstallSurface;
+	/** Human-readable one-line label shown in the inventory. */
+	readonly label: string;
+	/** Absolute path. For `hooks`, the repo dir the hook-strip operates on. */
+	readonly path: string;
+	readonly kind: RemovableKind;
+	/** Optional extra context (version, editor name). */
+	readonly detail?: string;
+}
+
+/** Result of a full scan: removable items plus notes on what is preserved. */
+export interface UninstallInventory {
+	readonly items: readonly RemovableItem[];
+	/** Human-readable notes about data the command deliberately never removes. */
+	readonly preserved: readonly string[];
+}
+
+/** Options for {@link scanUninstallInventory} and the per-surface scanners. */
+export interface ScanOptions {
+	/** Home directory (defaults to `os.homedir()`). */
+	readonly home?: string;
+	/** Platform override (defaults to `os.platform()`). */
+	readonly platform?: NodeJS.Platform;
+	/** Project directory used for the project-config + repo-hooks surfaces. */
+	readonly projectDir?: string;
+	/**
+	 * Global `node_modules` roots to probe for `@jolli.ai/cli`. When omitted,
+	 * {@link resolveNpmGlobalRoots} is invoked (spawns `npm root -g`). Passed
+	 * explicitly by tests to avoid spawning.
+	 */
+	readonly npmGlobalRoots?: readonly string[];
+}
+
+// ─── VS Code family ──────────────────────────────────────────────────────────
+
+/**
+ * VS Code-family extension roots, all under `$HOME` on every platform (VS Code
+ * stores extensions in `~/.vscode/extensions` regardless of OS). Keyed by the
+ * home-relative directory holding the `extensions/` folder; value is the label
+ * shown to the user.
+ *
+ * Covers the VS Code forks Jolli installs into: Cursor, Windsurf, Antigravity
+ * (ships two data dirs — `.antigravity` and the current `.antigravity-ide`),
+ * VSCodium, Positron, Kiro, Devin's desktop editor, and the stock VS Code /
+ * Insiders / remote-server dirs. The data-folder names were verified against
+ * real installs — a fork's dir name is not always its brand name (Antigravity →
+ * `.antigravity-ide`), so entries here are observed, not guessed. Absent editors
+ * are skipped by readdir.
+ */
+const VSCODE_EXTENSION_ROOTS: ReadonlyArray<readonly [string, string]> = [
+	[".vscode", "VS Code"],
+	[".vscode-insiders", "VS Code Insiders"],
+	[".vscode-oss", "VSCodium"],
+	[".vscode-server", "VS Code Server (remote)"],
+	[".cursor", "Cursor"],
+	[".windsurf", "Windsurf"],
+	[".antigravity", "Antigravity"],
+	[".antigravity-ide", "Antigravity"],
+	[".kiro", "Kiro"],
+	[".positron", "Positron"],
+	[".devin", "Devin"],
+];
+
+/** Extension folder prefix: `<publisher>.<name>` = `jolli.jollimemory-vscode`. */
+const VSCODE_EXTENSION_PREFIX = "jolli.jollimemory-vscode";
+
+/**
+ * Finds the installed Jolli Memory extension folder(s) across all detected VS
+ * Code-family editors. Extension dirs are named `<publisher>.<name>-<version>`.
+ */
+export async function scanVscodeExtensions(home: string): Promise<RemovableItem[]> {
+	const items: RemovableItem[] = [];
+	for (const [rootName, editorLabel] of VSCODE_EXTENSION_ROOTS) {
+		const extDir = join(home, rootName, "extensions");
+		let entries: string[];
+		try {
+			entries = await readdir(extDir);
+		} catch {
+			// Editor not installed / no extensions dir — skip silently.
+			continue;
+		}
+		for (const entry of entries) {
+			if (!entry.startsWith(VSCODE_EXTENSION_PREFIX)) continue;
+			const version = entry.slice(VSCODE_EXTENSION_PREFIX.length + 1) || undefined;
+			items.push({
+				surface: "vscode-extension",
+				label: `Jolli Memory extension — ${editorLabel}`,
+				path: join(extDir, entry),
+				kind: "dir",
+				detail: version ? `v${version}` : undefined,
+			});
+		}
+	}
+	return items;
+}
+
+/**
+ * Reconciles a VS Code-family editor's `extensions/extensions.json` manifest
+ * after the extension folder has been deleted.
+ *
+ * VS Code (and every fork) treats `<extensionsDir>/extensions.json` as the
+ * source of truth for what is installed. Deleting only the extension folder
+ * leaves a dangling manifest entry, so on next launch the editor lists the
+ * extension in its UI with a "cannot find / corrupt" warning (and may try to
+ * reinstall it). Removing the manifest entry whose `relativeLocation` matches
+ * the deleted folder makes the editor see a clean uninstall.
+ *
+ * Best-effort and never throws: a missing manifest (older editors), malformed
+ * JSON, or a write failure is logged and swallowed — the folder deletion is the
+ * primary action and its success is reported independently by the caller.
+ *
+ * @param extensionDir Absolute path to the deleted extension folder
+ *   (`<extensionsDir>/<publisher>.<name>-<version>`).
+ */
+export async function pruneVscodeExtensionManifest(extensionDir: string): Promise<void> {
+	const manifestPath = join(dirname(extensionDir), "extensions.json");
+	const folderName = basename(extensionDir);
+
+	let raw: string;
+	try {
+		raw = await readFile(manifestPath, "utf8");
+	} catch {
+		// No manifest (older VS Code, or fork without one) — nothing to reconcile.
+		return;
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (err) {
+		log.warn("extensions.json at %s is not valid JSON — skipping prune: %s", manifestPath, (err as Error).message);
+		return;
+	}
+	if (!Array.isArray(parsed)) return;
+
+	const filtered = parsed.filter(
+		(entry) => (entry as { relativeLocation?: unknown })?.relativeLocation !== folderName,
+	);
+	// Nothing matched — leave the file byte-for-byte untouched.
+	if (filtered.length === parsed.length) return;
+
+	try {
+		await writeFile(manifestPath, JSON.stringify(filtered), "utf8");
+	} catch (err) {
+		/* v8 ignore next -- defensive: manifest write failure (EPERM/read-only) is rare */
+		log.warn("Failed to update extensions.json at %s: %s", manifestPath, (err as Error).message);
+	}
+}
+
+// ─── IntelliJ / JetBrains family ──────────────────────────────────────────────
+
+/** Per-platform config root for a JetBrains-platform vendor (`JetBrains`, `Google`). */
+export function getVendorConfigRoot(vendor: string, home: string, platform: NodeJS.Platform): string {
+	switch (platform) {
+		case "darwin":
+			return join(home, "Library", "Application Support", vendor);
+		case "win32":
+			return join(process.env.APPDATA ?? join(home, "AppData", "Roaming"), vendor);
+		default:
+			return join(home, ".local", "share", vendor);
+	}
+}
+
+/** Per-platform JetBrains config root holding `<Product><Version>/` dirs. */
+export function getJetBrainsRoot(home: string, platform: NodeJS.Platform): string {
+	return getVendorConfigRoot("JetBrains", home, platform);
+}
+
+/**
+ * Android Studio config root. Android Studio is IntelliJ-platform-based but
+ * stores its per-version config under `Google/AndroidStudio<Version>/` rather
+ * than `JetBrains/`, so it needs a separate root.
+ */
+export function getAndroidStudioRoot(home: string, platform: NodeJS.Platform): string {
+	return getVendorConfigRoot("Google", home, platform);
+}
+
+/**
+ * Scans one vendor config root for Jolli plugin folders. The plugin folder
+ * (`jollimemory-intellij`) lives under `<root>/<Product><Version>/plugins/`.
+ * Matches any entry containing "jolli" (case-insensitive) to tolerate future
+ * artifact renames. Returns [] if the root is absent.
+ *
+ * `productPrefix` narrows which product dirs are considered — the `Google/`
+ * vendor root holds unrelated apps (Chrome, …), so Android Studio passes
+ * `"AndroidStudio"` to avoid probing them; the JetBrains root passes nothing
+ * (every product dir is a JetBrains IDE).
+ */
+async function scanPluginRoot(root: string, productPrefix?: string): Promise<RemovableItem[]> {
+	let products: string[];
+	try {
+		products = await readdir(root);
+	} catch {
+		return [];
+	}
+
+	const items: RemovableItem[] = [];
+	for (const product of products) {
+		if (productPrefix && !product.startsWith(productPrefix)) continue;
+		const pluginsDir = join(root, product, "plugins");
+		let plugins: string[];
+		try {
+			plugins = await readdir(pluginsDir);
+		} catch {
+			// `<product>` has no plugins dir (e.g. a stray file / non-IDE dir) — skip.
+			continue;
+		}
+		for (const plugin of plugins) {
+			if (!plugin.toLowerCase().includes("jolli")) continue;
+			items.push({
+				surface: "intellij-plugin",
+				label: `Jolli Memory plugin — ${product}`,
+				path: join(pluginsDir, plugin),
+				kind: "dir",
+			});
+		}
+	}
+	return items;
+}
+
+/**
+ * Finds the installed Jolli Memory plugin across all IntelliJ-platform IDEs —
+ * every JetBrains product (IDEA, WebStorm, PyCharm, GoLand, Rider, …) plus
+ * Android Studio (under `Google/`). Absent vendor roots are skipped.
+ */
+export async function scanIntellijPlugins(home: string, platform: NodeJS.Platform): Promise<RemovableItem[]> {
+	const [jetbrains, androidStudio] = await Promise.all([
+		scanPluginRoot(getJetBrainsRoot(home, platform)),
+		scanPluginRoot(getAndroidStudioRoot(home, platform), "AndroidStudio"),
+	]);
+	return [...jetbrains, ...androidStudio];
+}
+
+// ─── Global CLI (@jolli.ai/cli) ───────────────────────────────────────────────
+
+/** The npm-scoped package name of the CLI. */
+const CLI_PACKAGE = "@jolli.ai/cli";
+
+/** Hard cap on the `npm root -g` probe so a hung npm can't wedge the scan. */
+const NPM_ROOT_TIMEOUT_MS = 5000;
+
+/**
+ * Resolves the global `node_modules` root via `npm root -g`. Returns an empty
+ * array on any failure (npm missing, non-zero exit, empty output, or the 5s
+ * timeout) — the caller merges this with static candidate roots, so a failed
+ * probe just narrows the search rather than breaking the scan. The timeout
+ * matters because this is awaited even for `--dry-run`, so a misconfigured or
+ * hung npm would otherwise hang the whole command indefinitely.
+ */
+export async function resolveNpmGlobalRoots(): Promise<string[]> {
+	try {
+		const { stdout } = await execFileAsyncHidden("npm", ["root", "-g"], { timeout: NPM_ROOT_TIMEOUT_MS });
+		const root = stdout.trim();
+		return root ? [root] : [];
+	} catch (err) {
+		log.info("npm root -g failed (non-fatal): %s", (err as Error).message);
+		return [];
+	}
+}
+
+/**
+ * Static, no-spawn candidate global `node_modules` roots derived from home +
+ * platform. Merged with the `npm root -g` result so custom prefixes and the
+ * common package-manager defaults are both covered.
+ */
+export function staticNpmGlobalRoots(home: string, platform: NodeJS.Platform): string[] {
+	if (platform === "win32") {
+		const appData = process.env.APPDATA ?? join(home, "AppData", "Roaming");
+		return [join(appData, "npm", "node_modules")];
+	}
+	const roots = [
+		"/usr/local/lib/node_modules",
+		"/usr/lib/node_modules",
+		join(home, ".npm-global", "lib", "node_modules"),
+		join(home, ".node_modules", "lib", "node_modules"),
+	];
+	if (platform === "darwin") {
+		roots.push("/opt/homebrew/lib/node_modules");
+	}
+	return roots;
+}
+
+/**
+ * Derives the executable-shim candidates for a global install rooted at
+ * `nodeModulesRoot`. npm lays the package under `<prefix>/lib/node_modules` (or
+ * `<prefix>/node_modules`) and the `jolli` shim under `<prefix>/bin` (POSIX) or
+ * directly under `<prefix>` (Windows: `jolli`, `jolli.cmd`, `jolli.ps1`).
+ */
+function binCandidates(nodeModulesRoot: string, platform: NodeJS.Platform): string[] {
+	// Strip trailing node_modules (and an optional lib segment) to get <prefix>.
+	// Reconstruct with the host separator so the derived paths match real files
+	// on whichever OS we're running; `platform` only chooses the shim filenames.
+	const parts = nodeModulesRoot.split(/[\\/]/);
+	if (parts[parts.length - 1] === "node_modules") parts.pop();
+	if (parts[parts.length - 1] === "lib") parts.pop();
+	const prefix = parts.join(sep);
+	if (platform === "win32") {
+		return [join(prefix, "jolli"), join(prefix, "jolli.cmd"), join(prefix, "jolli.ps1")];
+	}
+	return [join(prefix, "bin", "jolli")];
+}
+
+/**
+ * Finds the globally-installed `@jolli.ai/cli` package directory and its `jolli`
+ * executable shim. Probes every candidate root; de-duplicates by path so a root
+ * reported by both `npm root -g` and the static list yields one item.
+ */
+export async function scanCliGlobal(
+	home: string,
+	platform: NodeJS.Platform,
+	npmGlobalRoots: readonly string[],
+): Promise<RemovableItem[]> {
+	const roots = [...new Set([...npmGlobalRoots, ...staticNpmGlobalRoots(home, platform)])];
+	const items: RemovableItem[] = [];
+	const seen = new Set<string>();
+
+	for (const root of roots) {
+		const pkgDir = join(root, CLI_PACKAGE);
+		let isPkg = false;
+		try {
+			isPkg = (await stat(pkgDir)).isDirectory();
+		} catch {
+			// Not installed at this root.
+		}
+		if (!isPkg || seen.has(pkgDir)) continue;
+		seen.add(pkgDir);
+		items.push({
+			surface: "cli-global",
+			label: `Global CLI package (${CLI_PACKAGE})`,
+			path: pkgDir,
+			kind: "dir",
+		});
+
+		// The executable shim(s) live next to the prefix, not under the package.
+		for (const bin of binCandidates(root, platform)) {
+			if (seen.has(bin)) continue;
+			try {
+				// lstat: the shim is usually a symlink into the package on POSIX;
+				// we want to remove the link itself, not its target.
+				await lstat(bin);
+			} catch {
+				continue;
+			}
+			seen.add(bin);
+			items.push({
+				surface: "cli-global",
+				label: "Global `jolli` executable",
+				path: bin,
+				kind: "file",
+			});
+		}
+	}
+	return items;
+}
+
+// ─── Config / state directories ───────────────────────────────────────────────
+
+/** The machine-global `~/.jolli/jollimemory/` config+state directory, if present. */
+export async function scanGlobalConfig(): Promise<RemovableItem[]> {
+	const dir = getGlobalConfigDir();
+	try {
+		if (!(await stat(dir)).isDirectory()) return [];
+	} catch {
+		return [];
+	}
+	return [
+		{
+			surface: "global-config",
+			label: "Global config & state (API keys, dist-paths, hook scripts)",
+			path: dir,
+			kind: "dir",
+		},
+	];
+}
+
+/** The per-project `<projectDir>/.jolli/jollimemory/` state directory, if present. */
+export async function scanProjectConfig(projectDir: string): Promise<RemovableItem[]> {
+	const dir = getJolliMemoryDir(projectDir);
+	try {
+		if (!(await stat(dir)).isDirectory()) return [];
+	} catch {
+		return [];
+	}
+	return [
+		{
+			surface: "project-config",
+			label: "Project state (sessions, cursors, queue, notes, plans)",
+			path: dir,
+			kind: "dir",
+		},
+	];
+}
+
+/**
+ * Detects whether the current repo has any Jolli hooks or repo-scoped MCP
+ * registration installed. If so, emits a single `repo-hooks` pseudo-item whose
+ * removal is dispatched to `Installer.uninstall(projectDir)` (marker-aware hook
+ * stripping — never a blind file delete). Never throws: `getStatus` resolves
+ * gracefully outside a git repo, in which case no item is emitted.
+ */
+export async function scanRepoHooks(projectDir: string): Promise<RemovableItem[]> {
+	let hasHooks = false;
+	try {
+		const status = await getStatus(projectDir);
+		hasHooks = status.gitHookInstalled || status.claudeHookInstalled || status.geminiHookInstalled;
+	} catch (err) {
+		log.info("getStatus failed during repo-hooks scan (non-fatal): %s", (err as Error).message);
+		return [];
+	}
+	if (!hasHooks) return [];
+	return [
+		{
+			surface: "repo-hooks",
+			label: "Git & AI-agent hooks + repo MCP registration (current repo)",
+			path: projectDir,
+			kind: "hooks",
+		},
+	];
+}
+
+// ─── Orchestration ─────────────────────────────────────────────────────────────
+
+/**
+ * Runs every surface scan and assembles the full inventory. Each surface is
+ * isolated — a failure in one never aborts the others (individual scanners
+ * already swallow their own fs errors, so this is belt-and-suspenders).
+ */
+export async function scanUninstallInventory(options: ScanOptions = {}): Promise<UninstallInventory> {
+	const home = options.home ?? homedir();
+	const platform = options.platform ?? osPlatform();
+	const projectDir = options.projectDir ?? process.cwd();
+	const npmGlobalRoots = options.npmGlobalRoots ?? (await resolveNpmGlobalRoots());
+
+	const [vscode, intellij, cli, globalConfig, projectConfig, repoHooks] = await Promise.all([
+		scanVscodeExtensions(home),
+		scanIntellijPlugins(home, platform),
+		scanCliGlobal(home, platform, npmGlobalRoots),
+		scanGlobalConfig(),
+		scanProjectConfig(projectDir),
+		scanRepoHooks(projectDir),
+	]);
+
+	const items = [...vscode, ...intellij, ...cli, ...globalConfig, ...projectConfig, ...repoHooks];
+
+	const preserved = [
+		"Git orphan branch 'jollimemory/summaries/v3' (your commit memories)",
+		"Memory Bank folder content (default ~/Documents/jolli/, or your configured localFolder)",
+	];
+
+	return { items, preserved };
+}


### PR DESCRIPTION
Adds a `jolli uninstall` CLI command that detects and selectively removes **every** Jolli Memory installation and configuration artifact on a machine — without ever touching user memory.

Closes JOLLI-1928.

## What it detects

- **VS Code family extensions** — stock VS Code / Insiders / remote-server plus the forks Jolli installs into: Cursor, Windsurf, VSCodium, Positron, Kiro, Antigravity, and Devin's desktop editor. Data-folder names are **verified against real installs, not guessed** (e.g. Antigravity uses `.antigravity-ide`). Removal also prunes the editor's `extensions.json` manifest so a reopened editor doesn't show a dangling "corrupt extension" warning.
- **JetBrains + Android Studio plugins** — wildcard scan of the `JetBrains/` and `Google/` config roots; covers every IntelliJ-platform IDE (IDEA, WebStorm, PyCharm, GoLand, Rider, …) plus Android Studio, with no hardcoded product list.
- **Global `@jolli.ai/cli`** — package dir + `jolli` shim, via `npm root -g` plus static candidate roots.
- **Config/state dirs** — machine-global `~/.jolli/jollimemory/` and per-project `.jolli/jollimemory/`.
- **Current-repo hooks + repo MCP** — dispatched to the existing marker-aware `uninstall()` (never a blind delete).

## Hard exclusion

User memory is never in the inventory: the `jollimemory/summaries/v3` orphan branch and Memory Bank folder content (default `~/Documents/jolli/`) are excluded by construction. The command removes installation + configuration only.

## UX / flags

Prints a grouped inventory, then an interactive checklist. Flags: `--dry-run` (preview), `--yes` (remove all, required in non-interactive shells), `--scope global|project|all`. Reports per-item outcomes and hints to restart the editor after removing an extension.

## Implementation

- `cli/src/install/UninstallScan.ts` — detection; all paths injectable (home/platform/projectDir/npmGlobalRoots) so the scan is fully unit-tested without touching the real machine.
- `cli/src/commands/UninstallCommand.ts` — command + removal + manifest reconciliation.
- Wired into `Api.ts` (registered + added to `MEMORY_COMMAND_NAMES`).

## Test plan

- New unit tests for both modules (real temp-dir fixtures for the fs scanners; mocked seams for the command).
- `npm run all` passes clean (build → lint → test, both workspaces); no coverage regression.
- Verified end-to-end via `--dry-run` on a real machine: all 8 installed editors + JetBrains plugin + global CLI + config dirs + repo hooks detected; memory data correctly excluded.

## Known caveat

The VS Code editor list and JetBrains vendor roots are **observed allowlists** — a fork using a data-folder name / vendor root not yet seen would be missed until added. Detection never touches memory data regardless.