### PR TITLE
Add Confluence as first-class reference source; fix jira for codex

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -772,7 +772,15 @@ export interface NoteReference {
 export type SourceId = string;
 
 /** The source ids that ship as built-in `SourceDefinition`s. Docs/reference only — not an exhaustive runtime set. */
-export type KnownSourceId = "linear" | "jira" | "github" | "notion" | "slack" | "zoom-meeting" | "zoom-doc";
+export type KnownSourceId =
+	| "linear"
+	| "confluence"
+	| "jira"
+	| "github"
+	| "notion"
+	| "slack"
+	| "zoom-meeting"
+	| "zoom-doc";
 
 /**
  * ReferenceField — one displayable field produced by a `SourceDefinition`'s `fields` pipes.

--- a/cli/src/core/references/ClaudeEnvelopeParser.ts
+++ b/cli/src/core/references/ClaudeEnvelopeParser.ts
@@ -32,6 +32,7 @@ import { isObject } from "./guards.js";
 import { scanUserPermalinks } from "./SlackPermalink.js";
 import type { SourceDefinition } from "./SourceDefinition.js";
 import { getRegistry } from "./SourceDefinitionRegistry.js";
+import { normalizeConfluence } from "./sources/ConfluenceNormalize.js";
 import { normalizeSlackThread } from "./sources/SlackNormalize.js";
 import { normalizeZoomDoc } from "./sources/ZoomDocNormalize.js";
 import type {
@@ -258,10 +259,13 @@ interface ContextNormalizeEnv {
 
 /**
  * Closed registry of context-aware normalizers, keyed by source id. A source
- * belongs here IFF its canonical shape needs out-of-payload context — the
- * originating tool_use `input`, and/or parse-scoped state (permalink map,
- * workspace url) — that the default `identity` path cannot supply. Every other
- * MCP source's `normalize` is `identity` and never appears here.
+ * belongs here IFF the default `identity` path cannot produce its canonical
+ * shape — either because that shape needs out-of-payload context (the
+ * originating tool_use `input`, and/or parse-scoped state like the permalink
+ * map / workspace url), OR because it requires a payload-internal shape
+ * coercion the DSL cannot express (e.g. Confluence's ADF-object → string body
+ * flattening). Every other MCP source's `normalize` is `identity` and never
+ * appears here.
  *
  * Returning null voids the reference. Adding a fourth such source is one entry
  * here, not a new `def.id === …` branch in `collectToolResults`.
@@ -290,6 +294,7 @@ const CONTEXT_NORMALIZERS: Record<
 		/* v8 ignore stop */
 		return normalizeZoomDoc(payload, { fileId: zoomInput.fileId });
 	},
+	confluence: (payload) => normalizeConfluence(payload),
 };
 
 /**
@@ -364,11 +369,14 @@ function collectToolResults(
 			parsedPayload = recovered.payload;
 		}
 
-		// A source whose canonical shape needs out-of-payload context (the
-		// tool_use input, and/or parse-scoped state like the permalink map /
-		// workspace url) runs its registered context-normalizer here instead of
-		// the identity path — a single data-driven branch rather than one
-		// `def.id === …` block per such source. Membership goes through
+		// A source whose canonical shape the identity path cannot produce runs
+		// its registered context-normalizer here — either because that shape
+		// needs out-of-payload context (the tool_use input, and/or parse-scoped
+		// state like the permalink map / workspace url), or because it needs a
+		// payload-internal shape coercion the DSL cannot express (e.g.
+		// Confluence's ADF-object → string body flattening). A single
+		// data-driven branch rather than one `def.id === …` block per such
+		// source. Membership goes through
 		// CONTEXT_NORMALIZER_IDS (own keys only) so a prototype-chain id can
 		// never resolve a function, and every other source's `normalize` stays a
 		// pure `(payload, command) => payload` hook.

--- a/cli/src/core/references/CodexEnvelopeParser.test.ts
+++ b/cli/src/core/references/CodexEnvelopeParser.test.ts
@@ -159,6 +159,41 @@ const ZOOM_MEETING = {
 	},
 	my_notes: { has_my_notes: false },
 };
+// Real Codex built-in "Atlassian Rovo" app shapes, captured from a live rollout
+// (2026-07-12). Rovo has NO `_getjiraissue`: Confluence uses a dedicated
+// `_getconfluencepage` whose output is the SAME `{content:{nodes}}` shape as
+// Claude's getConfluencePage, while Jira comes through the generic `_fetch`
+// returning the `{id,title,text,url,type,metadata}` entity envelope (NOT the
+// `{key,fields,webUrl}` shape the older fabricated fixtures assumed).
+const ROVO_CONFLUENCE = {
+	content: {
+		totalCount: 1,
+		nodes: [
+			{
+				id: "131076",
+				type: "page",
+				title: "数据库访问架构变更设计：Per-Provider 连接池",
+				space: { key: "KAN", name: "My Kanban Space" },
+				author: { displayName: "Flyer Li" },
+				body: "## TL;DR\n\n1. 现状：per-(tenant, org) 连接池。",
+				webUrl: "https://lichengbin2008.atlassian.net/wiki/spaces/KAN/pages/131076/Per-Provider",
+			},
+		],
+	},
+};
+const ROVO_JIRA_FETCH = {
+	id: "ari:cloud:jira:e8d56e41-d65c-44d9-822d-96fb42c56007:issue/KAN-1",
+	title: "Trace Log",
+	text: "1. Background\n\nThe backend uses pino for logging.",
+	url: "https://api.atlassian.com/ex/jira/e8d56e41-d65c-44d9-822d-96fb42c56007/rest/api/3/issue/10000",
+	type: "jira-issue",
+	metadata: {
+		cloudId: "e8d56e41-d65c-44d9-822d-96fb42c56007",
+		status: "To Do",
+		priority: "Medium",
+		issueType: "Task",
+	},
+};
 
 describe("CodexEnvelopeParser.parse", () => {
 	it("emits one NormalizedToolResult per source via the PRIMARY function_call pair, with canonical toolName + matched adapter", () => {
@@ -177,6 +212,29 @@ describe("CodexEnvelopeParser.parse", () => {
 		expect(results.map((r) => r.def.id).sort()).toEqual(["github", "jira", "linear", "notion"]);
 		const jira = results.find((r) => r.def.id === "jira");
 		expect(jira?.toolName).toContain("mcp__claude_ai_Atlassian__");
+	});
+
+	it("extracts a Confluence reference from the real Rovo _getconfluencepage function_call", () => {
+		const lines = [
+			fnCall("mcp__codex_apps__atlassian_rovo", "_getconfluencepage", "c_conf"),
+			fnOutput("c_conf", ROVO_CONFLUENCE, { wrap: "bare", prefix: true }),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results.map((r) => r.def.id)).toEqual(["confluence"]);
+		expect((results[0].payload as { pageId?: string }).pageId).toBe("131076");
+		expect(results[0].toolName).toBe("mcp__claude_ai_Atlassian__getConfluencePage");
+	});
+
+	it("extracts a Jira reference from the real Rovo generic _fetch entity envelope", () => {
+		const lines = [
+			fnCall("mcp__codex_apps__atlassian_rovo", "_fetch", "c_jf"),
+			fnOutput("c_jf", ROVO_JIRA_FETCH, { wrap: "bare", prefix: true }),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results.map((r) => r.def.id)).toEqual(["jira"]);
+		const payload = results[0].payload as { key?: string; fields?: { summary?: string } };
+		expect(payload.key).toBe("KAN-1");
+		expect(payload.fields?.summary).toBe("Trace Log");
 	});
 
 	it("unwraps the object-envelope function_call_output ({content:[{text}]}) — newer Linear _get_issue connector", () => {

--- a/cli/src/core/references/CodexEnvelopeParser.test.ts
+++ b/cli/src/core/references/CodexEnvelopeParser.test.ts
@@ -159,27 +159,27 @@ const ZOOM_MEETING = {
 	},
 	my_notes: { has_my_notes: false },
 };
-// Real Codex built-in "Atlassian Rovo" app shapes, captured from a live rollout
-// (2026-07-12). Rovo has NO `_getjiraissue`: Confluence uses a dedicated
-// `_getconfluencepage` whose output is the SAME `{content:{nodes}}` shape as
-// Claude's getConfluencePage, while Jira comes through the generic `_fetch`
-// returning the `{id,title,text,url,type,metadata}` entity envelope (NOT the
-// `{key,fields,webUrl}` shape the older fabricated fixtures assumed).
+// Real Codex built-in "Atlassian Rovo" app shapes, captured from live rollouts
+// (2026-07). Confluence uses a dedicated `_getconfluencepage`; Jira is reachable
+// BOTH through the generic `_fetch` (`{id,title,text,url,type,metadata}` entity
+// envelope) AND a dedicated `_getjiraissue` (standard REST issue — see
+// ROVO_JIRA_REST). The older fixtures fabricated a `{key,fields,webUrl}` _fetch
+// shape and a mis-spelled `_getjiraissue` name, neither matching reality.
+//
+// Rovo's `_getconfluencepage` `content[0].text` — the string the Codex envelope
+// layer extracts — is a FLAT page node, NOT Claude's `{content:{nodes:[…]}}`
+// wrapper (that wrapped twin lives only in the discarded `structuredContent`).
+// The flat node carries `spaceId`/`authorId` IDs, NO `space`/`author` objects.
 const ROVO_CONFLUENCE = {
-	content: {
-		totalCount: 1,
-		nodes: [
-			{
-				id: "131076",
-				type: "page",
-				title: "数据库访问架构变更设计：Per-Provider 连接池",
-				space: { key: "KAN", name: "My Kanban Space" },
-				author: { displayName: "Flyer Li" },
-				body: "## TL;DR\n\n1. 现状：per-(tenant, org) 连接池。",
-				webUrl: "https://lichengbin2008.atlassian.net/wiki/spaces/KAN/pages/131076/Per-Provider",
-			},
-		],
-	},
+	id: "131076",
+	type: "page",
+	status: "current",
+	title: "数据库访问架构变更设计：Per-Provider 连接池",
+	spaceId: 98307,
+	parentId: "98415",
+	authorId: "712020:bb39bcb3-833a-4d6e-8605-5cfaad3e2172",
+	body: "## TL;DR\n\n1. 现状：per-(tenant, org) 连接池。",
+	webUrl: "https://lichengbin2008.atlassian.net/wiki/spaces/KAN/pages/131076/Per-Provider",
 };
 const ROVO_JIRA_FETCH = {
 	id: "ari:cloud:jira:e8d56e41-d65c-44d9-822d-96fb42c56007:issue/KAN-1",
@@ -192,6 +192,22 @@ const ROVO_JIRA_FETCH = {
 		status: "To Do",
 		priority: "Medium",
 		issueType: "Task",
+	},
+};
+// Real dedicated `atlassian_rovo.getJiraIssue` content[0].text (2026-07-13): the
+// standard Jira REST v3 issue — `{key, fields:{summary,…}, self}` with NO webUrl.
+const ROVO_JIRA_REST = {
+	expand: "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+	id: "10000",
+	self: "https://api.atlassian.com/ex/jira/e8d56e41-d65c-44d9-822d-96fb42c56007/rest/api/3/issue/10000",
+	key: "KAN-1",
+	fields: {
+		summary: "Trace Log",
+		status: { name: "To Do", statusCategory: { name: "To Do" } },
+		priority: { name: "Medium" },
+		issuetype: { name: "Task" },
+		description: "1. Background\n\nThe backend uses pino for logging.",
+		labels: [],
 	},
 };
 
@@ -214,14 +230,22 @@ describe("CodexEnvelopeParser.parse", () => {
 		expect(jira?.toolName).toContain("mcp__claude_ai_Atlassian__");
 	});
 
-	it("extracts a Confluence reference from the real Rovo _getconfluencepage function_call", () => {
+	it("extracts a Confluence reference from the real Rovo _getconfluencepage (flat content[0].text via mcp_tool_call_end)", () => {
+		// Faithful to the live rollout: the page fetch produced only a
+		// mcp_tool_call_end event (no function_call_output), and its
+		// `result.Ok.content[0].text` is the FLAT node — the shape that used to
+		// slip past normalizeConfluence's `content.nodes` gate and get dropped.
 		const lines = [
 			fnCall("mcp__codex_apps__atlassian_rovo", "_getconfluencepage", "c_conf"),
-			fnOutput("c_conf", ROVO_CONFLUENCE, { wrap: "bare", prefix: true }),
+			toolCallEnd("atlassian_rovo.getConfluencePage", "c_conf", ROVO_CONFLUENCE),
 		];
 		const { results } = codexEnvelopeParser.parse(lines, {});
 		expect(results.map((r) => r.def.id)).toEqual(["confluence"]);
-		expect((results[0].payload as { pageId?: string }).pageId).toBe("131076");
+		const payload = results[0].payload as { pageId?: string; space?: string; author?: string };
+		expect(payload.pageId).toBe("131076");
+		// Flat node has only spaceId/authorId → these display fields stay undefined.
+		expect(payload.space).toBeUndefined();
+		expect(payload.author).toBeUndefined();
 		expect(results[0].toolName).toBe("mcp__claude_ai_Atlassian__getConfluencePage");
 	});
 
@@ -235,6 +259,28 @@ describe("CodexEnvelopeParser.parse", () => {
 		const payload = results[0].payload as { key?: string; fields?: { summary?: string } };
 		expect(payload.key).toBe("KAN-1");
 		expect(payload.fields?.summary).toBe("Trace Log");
+	});
+
+	it("extracts a Jira reference from the real Rovo dedicated getJiraIssue (REST issue via mcp_tool_call_end)", () => {
+		// Faithful to the live rollout: the dedicated tool fires a `_getjiraissue`
+		// function_call and an `atlassian_rovo.getJiraIssue` event whose
+		// content[0].text is the standard Jira REST issue — `{key,fields,self}`, NO
+		// webUrl. Before the fix the event name did not match and, even if it had, the
+		// missing webUrl voided the ref.
+		const lines = [
+			fnCall("mcp__codex_apps__atlassian_rovo", "_getjiraissue", "c_gji"),
+			toolCallEnd("atlassian_rovo.getJiraIssue", "c_gji", ROVO_JIRA_REST),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results.map((r) => r.def.id)).toEqual(["jira"]);
+		const payload = results[0].payload as { key?: string; webUrl?: string; fields?: { summary?: string } };
+		expect(payload.key).toBe("KAN-1");
+		expect(payload.fields?.summary).toBe("Trace Log");
+		// self mapped to webUrl (no browsable url from Rovo).
+		expect(payload.webUrl).toBe(
+			"https://api.atlassian.com/ex/jira/e8d56e41-d65c-44d9-822d-96fb42c56007/rest/api/3/issue/10000",
+		);
+		expect(results[0].toolName).toBe("mcp__claude_ai_Atlassian__getJiraIssue");
 	});
 
 	it("unwraps the object-envelope function_call_output ({content:[{text}]}) — newer Linear _get_issue connector", () => {
@@ -615,8 +661,9 @@ describe("CodexEnvelopeParser end-to-end via extractReferencesFromTranscript (so
 			fnOutput("c_gh", GITHUB, { wrap: "bare", prefix: true }),
 			fnCall("mcp__codex_apps__atlassian_rovo", "_getjiraissue", "c_jira"),
 			fnOutput("c_jira", JIRA_WRAPPED, { wrap: "bare", prefix: false }),
-			// A jira call with no webUrl (bare, via event) must NOT yield a ref.
-			toolCallEnd("atlassian rovo_getjiraissue", "c_jira_nourl", JIRA_BARE_NO_URL),
+			// A dedicated getJiraIssue with only `self` (no webUrl), via the real
+			// `atlassian_rovo.getJiraIssue` event — captured with self mapped to url.
+			toolCallEnd("atlassian_rovo.getJiraIssue", "c_jira_nourl", JIRA_BARE_NO_URL),
 		];
 		writeFileSync(file, `${lines.join("\n")}\n`, "utf-8");
 	});
@@ -639,8 +686,9 @@ describe("CodexEnvelopeParser end-to-end via extractReferencesFromTranscript (so
 		expect(jira?.url).toBe("https://jolli-team-kr0v9z0x.atlassian.net/browse/KAN-4");
 		expect(jira?.title).toBe("My Jira task");
 
-		// The webUrl-less jira event produced no ref.
-		expect(byKey.has("jira:KAN-9")).toBe(false);
+		// The getJiraIssue with only `self` is now captured, with `self` as its url
+		// (the api.atlassian.com endpoint — no browsable link is available).
+		expect(byKey.get("jira:KAN-9")?.url).toBe("https://api.atlassian.com/ex/jira/29e34fb0/rest/api/3/issue/10099");
 	});
 });
 
@@ -747,7 +795,7 @@ describe("CodexEnvelopeParser end-to-end — Jira malformed-output recovery", ()
 		const lines = [
 			fnCall("mcp__codex_apps__atlassian_rovo", "_getjiraissue", "j1"),
 			fnOutputRaw("j1", malformedOutput),
-			toolCallEnd("atlassian rovo_getjiraissue", "j1", {
+			toolCallEnd("atlassian_rovo.getJiraIssue", "j1", {
 				key: "KAN-7",
 				self: "https://api.atlassian.com/ex/jira/x/rest/api/3/issue/10099",
 				versionedRepresentations: { summary: { "1": "Recovered jira summary" } },

--- a/cli/src/core/references/SourceDefinitionRegistry.test.ts
+++ b/cli/src/core/references/SourceDefinitionRegistry.test.ts
@@ -43,12 +43,18 @@ describe("SourceDefinitionRegistry", () => {
 		expect(r.match("codex", "linear.get_issue")?.id).toBe("linear"); // invocation-tool path (no namespace)
 	});
 
-	it("all() is stable order linear,jira,github,notion,slack,zoom-meeting,zoom-doc", () => {
+	it("all() is stable order linear,confluence,jira,github,notion,slack,zoom-meeting,zoom-doc", () => {
 		expect(
 			getRegistry()
 				.all()
 				.map((d) => d.id),
-		).toEqual(["linear", "jira", "github", "notion", "slack", "zoom-meeting", "zoom-doc"]);
+		).toEqual(["linear", "confluence", "jira", "github", "notion", "slack", "zoom-meeting", "zoom-doc"]);
+	});
+
+	it("routes getConfluencePage to confluence and getJiraIssue to jira", () => {
+		const r = getRegistry();
+		expect(r.match("claude", "mcp__claude_ai_Atlassian__getConfluencePage")?.id).toBe("confluence");
+		expect(r.match("claude", "mcp__claude_ai_Atlassian__getJiraIssue")?.id).toBe("jira");
 	});
 
 	it("byId() finds a known definition and returns undefined for unknown ids", () => {

--- a/cli/src/core/references/bindings/codex/CodexConfluenceBinding.ts
+++ b/cli/src/core/references/bindings/codex/CodexConfluenceBinding.ts
@@ -3,12 +3,15 @@
  * through the "Atlassian Rovo" app's `_getconfluencepage` tool; match identity
  * lives in `confluence`'s `SourceDefinition.match.codex`).
  *
- * Verified from a live rollout (2026-07-12): Rovo's `_getconfluencepage` output
- * is byte-identical in shape to Claude's `getConfluencePage` — the same
- * `{ content: { nodes: [ node ] } }` wrapper with `id` / `title` / `webUrl` /
- * `space` / `author` / `body`. So `normalize` is just `normalizeConfluence`, the
- * exact function the Claude path already runs (see `ClaudeEnvelopeParser`'s
- * context-normalizer registry); no Rovo-specific reshaping is needed.
+ * Verified from live rollouts (2026-07): Rovo's `_getconfluencepage` result is
+ * the full MCP CallToolResult, and the Codex envelope layer extracts its
+ * `content[0].text` — which is a FLAT page node (`id` / `title` / `webUrl` /
+ * `body` / `spaceId` / `authorId`), NOT Claude's `{ content: { nodes: [ node ] } }`
+ * wrapper. That wrapped twin exists only in the sibling `structuredContent`, which
+ * the envelope discards. `normalizeConfluence` now accepts BOTH shapes, so this
+ * binding still reuses it verbatim — but the two paths are NOT byte-identical, and
+ * the flat node has no `space` / `author` objects (only IDs), so those fields come
+ * back undefined here.
  */
 
 import { normalizeConfluence } from "../../sources/ConfluenceNormalize.js";

--- a/cli/src/core/references/bindings/codex/CodexConfluenceBinding.ts
+++ b/cli/src/core/references/bindings/codex/CodexConfluenceBinding.ts
@@ -1,0 +1,23 @@
+/**
+ * CodexConfluenceBinding — Confluence `codex_apps` connector normalizer (reached
+ * through the "Atlassian Rovo" app's `_getconfluencepage` tool; match identity
+ * lives in `confluence`'s `SourceDefinition.match.codex`).
+ *
+ * Verified from a live rollout (2026-07-12): Rovo's `_getconfluencepage` output
+ * is byte-identical in shape to Claude's `getConfluencePage` — the same
+ * `{ content: { nodes: [ node ] } }` wrapper with `id` / `title` / `webUrl` /
+ * `space` / `author` / `body`. So `normalize` is just `normalizeConfluence`, the
+ * exact function the Claude path already runs (see `ClaudeEnvelopeParser`'s
+ * context-normalizer registry); no Rovo-specific reshaping is needed.
+ */
+
+import { normalizeConfluence } from "../../sources/ConfluenceNormalize.js";
+import type { CodexNormalizer } from "./CodexBinding.js";
+
+export const confluenceCodexBinding: CodexNormalizer = {
+	id: "confluence",
+	canonicalToolName: "mcp__claude_ai_Atlassian__getConfluencePage",
+	// normalizeConfluence returns null on structurally unparseable input; the
+	// definition's `require` regexes void the reference either way.
+	normalize: (business) => normalizeConfluence(business),
+};

--- a/cli/src/core/references/bindings/codex/CodexJiraBinding.test.ts
+++ b/cli/src/core/references/bindings/codex/CodexJiraBinding.test.ts
@@ -82,6 +82,61 @@ describe("jiraCodexBinding.normalize (derive fields.summary from versionedRepres
 	});
 });
 
+describe("jiraCodexBinding.normalize — generic _fetch entity envelope (type:'jira-issue')", () => {
+	// Real Rovo `_fetch` output shape (2026-07-12): flat, no `fields`/`key`.
+	const ENVELOPE = {
+		id: "ari:cloud:jira:e8d56e41:issue/KAN-1",
+		title: "Trace Log",
+		text: "1. Background\n\nThe backend uses pino.",
+		url: "https://api.atlassian.com/ex/jira/e8d56e41/rest/api/3/issue/10000",
+		type: "jira-issue",
+		metadata: { status: "To Do", priority: "Medium", issueType: "Task" },
+	};
+
+	it("maps id/title/text/url/metadata into the canonical {key, fields, webUrl}", () => {
+		const out = normalize(ENVELOPE) as {
+			key: string;
+			webUrl: string;
+			fields: { summary: string; description: string; status: string; priority: string };
+		};
+		expect(out.key).toBe("KAN-1");
+		expect(out.webUrl).toBe("https://api.atlassian.com/ex/jira/e8d56e41/rest/api/3/issue/10000");
+		expect(out.fields.summary).toBe("Trace Log");
+		expect(out.fields.description).toBe("1. Background\n\nThe backend uses pino.");
+		expect(out.fields.status).toBe("To Do");
+		expect(out.fields.priority).toBe("Medium");
+	});
+
+	it("omits every optional field when the envelope carries only type + id", () => {
+		const out = normalize({ type: "jira-issue", id: "ari:cloud:jira:x:issue/KAN-2" }) as {
+			key: string;
+			webUrl?: string;
+			fields: Record<string, unknown>;
+		};
+		expect(out.key).toBe("KAN-2");
+		expect(out.webUrl).toBeUndefined();
+		expect(out.fields).toEqual({});
+	});
+
+	it("omits key when the id has no path segment, and drops whitespace-only text", () => {
+		const noSlash = normalize({ type: "jira-issue", id: "notanari", text: "   " }) as {
+			key?: string;
+			fields: { description?: string };
+		};
+		expect(noSlash.key).toBeUndefined(); // lastIndexOf('/') === -1 → no key
+		expect(noSlash.fields.description).toBeUndefined();
+	});
+
+	it("omits key and coerces non-object metadata to empty when the id is absent", () => {
+		const noId = normalize({ type: "jira-issue", metadata: 42 }) as {
+			key?: string;
+			fields: Record<string, unknown>;
+		};
+		expect(noId.key).toBeUndefined();
+		expect(noId.fields).toEqual({});
+	});
+});
+
 describe("jiraCodexBinding.normalize — description (ADF → markdown)", () => {
 	const withDescription = (description: unknown) =>
 		normalize({ key: "KAN-4", versionedRepresentations: { summary: { "1": "S" }, description } }) as {

--- a/cli/src/core/references/bindings/codex/CodexJiraBinding.test.ts
+++ b/cli/src/core/references/bindings/codex/CodexJiraBinding.test.ts
@@ -137,6 +137,51 @@ describe("jiraCodexBinding.normalize — generic _fetch entity envelope (type:'j
 	});
 });
 
+describe("jiraCodexBinding.normalize — dedicated getJiraIssue REST issue (self → webUrl)", () => {
+	// Real Rovo `atlassian_rovo.getJiraIssue` content[0].text (captured 2026-07-13):
+	// the standard Jira REST v3 issue — `{ key, fields:{summary,…}, self }` with NO
+	// top-level `webUrl`, only the api.atlassian.com REST endpoint under `self`.
+	const REST_ISSUE = {
+		expand: "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+		id: "10000",
+		self: "https://api.atlassian.com/ex/jira/e8d56e41-d65c-44d9-822d-96fb42c56007/rest/api/3/issue/10000",
+		key: "KAN-1",
+		fields: {
+			summary: "Trace Log",
+			status: { name: "To Do", statusCategory: { name: "To Do" } },
+			priority: { name: "Medium" },
+			issuetype: { name: "Task" },
+			description: "1. Background\n\nThe backend uses pino for logging.",
+			labels: [],
+		},
+	};
+
+	it("maps self → webUrl so the issue is captured (Rovo returns no browsable url)", () => {
+		const out = normalize(REST_ISSUE) as {
+			key: string;
+			webUrl?: string;
+			fields: { summary: string; status: { name: string } };
+		};
+		expect(out.key).toBe("KAN-1");
+		expect(out.fields.summary).toBe("Trace Log");
+		expect(out.fields.status.name).toBe("To Do");
+		// self kept as-is (api endpoint) — the tenant site for a /browse/ link is absent.
+		expect(out.webUrl).toBe(
+			"https://api.atlassian.com/ex/jira/e8d56e41-d65c-44d9-822d-96fb42c56007/rest/api/3/issue/10000",
+		);
+	});
+
+	it("does not overwrite an existing webUrl with self", () => {
+		const out = normalize({
+			key: "KAN-4",
+			self: "https://api.atlassian.com/ex/jira/x/rest/api/3/issue/10013",
+			webUrl: "https://acme.atlassian.net/browse/KAN-4",
+			fields: { summary: "S" },
+		}) as { webUrl: string };
+		expect(out.webUrl).toBe("https://acme.atlassian.net/browse/KAN-4");
+	});
+});
+
 describe("jiraCodexBinding.normalize — description (ADF → markdown)", () => {
 	const withDescription = (description: unknown) =>
 		normalize({ key: "KAN-4", versionedRepresentations: { summary: { "1": "S" }, description } }) as {

--- a/cli/src/core/references/bindings/codex/CodexJiraBinding.ts
+++ b/cli/src/core/references/bindings/codex/CodexJiraBinding.ts
@@ -1,18 +1,31 @@
 /**
- * CodexJiraBinding — Jira `codex_apps` connector normalizer (reached through
- * `_getjiraissue` / invocation `atlassian rovo_getjiraissue` — note the space;
- * match identity lives in the registry).
+ * CodexJiraBinding — Jira `codex_apps` connector normalizer (match identity lives
+ * in `jira`'s `SourceDefinition.match.codex`).
  *
- * Codex's `_getjiraissue` payload is `{ issues: { nodes: [ node ] } }`, and each
- * node — unlike Claude's Atlassian MCP — has **NO `fields` object**: `key` +
- * gateway `self` + tenant `webUrl` are top-level, and the field VALUES live under
- * `versionedRepresentations` (`{ "<version>": <value> }`), where `summary` is a
- * string and `description` is an ADF document. So:
- *   - `normalize` (main path) reshapes each node, deriving `fields.summary` and
- *     `fields.description` (ADF → markdown) so the jira `SourceDefinition` accepts it.
- *   - `recover` (NOT the main path) handles the malformed-output edge — see below.
+ * Two payload shapes are handled, both reshaped into the `{ key, fields, webUrl }`
+ * the jira `SourceDefinition` reads:
+ *
+ *   1. Generic `_fetch` entity envelope (VERIFIED from a live "Atlassian Rovo"
+ *      rollout, 2026-07-12): a FLAT object
+ *      `{ id: "ari:cloud:jira:…:issue/<KEY>", title, text, url, type:"jira-issue",
+ *      metadata:{ status, priority, … } }`. The issue key is the ARI's trailing
+ *      `issue/<KEY>` segment; `title`→`fields.summary`, `text`→`fields.description`,
+ *      `metadata.status`/`priority`→`fields.*`, `url`→`webUrl`. Note `url` is the
+ *      `api.atlassian.com/.../rest/api/3/issue/<id>` REST endpoint — NOT a
+ *      human-browsable `/browse/<KEY>` link. It is the only URL Rovo returns, and
+ *      the tenant site name needed to build a browse link is absent from the
+ *      envelope (only `cloudId` is present), so it is kept as-is rather than
+ *      voiding the otherwise-useful reference. `type:"jira-issue"` gates this branch.
+ *
+ *   2. `{ issues: { nodes: [ node ] } }` with per-node field VALUES under
+ *      `versionedRepresentations` (`{ "<version>": <value> }`; `summary` a string,
+ *      `description` an ADF document). UNVERIFIED legacy shape retained pending a
+ *      real transcript — `normalize` derives `fields.summary`/`description` (ADF →
+ *      markdown), and `recover` (NOT the main path) handles its malformed-output
+ *      edge (see below).
  */
 
+import { adfToText } from "../../sources/AdfToText.js";
 import { isObject } from "../shared.js";
 import type { CodexNormalizer } from "./CodexBinding.js";
 
@@ -41,44 +54,46 @@ function latestRepresentation(versioned: unknown, field: string): unknown {
 	return best;
 }
 
-/**
- * Minimal ADF (Atlassian Document Format) → markdown-ish plain text. Handles the
- * node types Jira descriptions actually use (heading/paragraph/list/blockquote/
- * codeBlock/text); unknown nodes just concatenate their children. Good enough for
- * a reference body; the adapter truncates it.
- */
-function adfToText(node: unknown): string {
-	if (!isObject(node)) return "";
-	if (node.type === "text") return typeof node.text === "string" ? node.text : "";
-	const children = Array.isArray(node.content) ? node.content : [];
-	const inline = children.map(adfToText).join("");
-	switch (node.type) {
-		case "heading": {
-			const level = isObject(node.attrs) && typeof node.attrs.level === "number" ? node.attrs.level : 1;
-			return `${"#".repeat(Math.min(Math.max(level, 1), 6))} ${inline}`;
-		}
-		case "paragraph":
-		case "codeBlock":
-			return inline;
-		case "blockquote":
-			return children.map((c) => `> ${adfToText(c)}`).join("\n");
-		case "bulletList":
-			return children.map((c) => `- ${adfToText(c)}`).join("\n");
-		case "orderedList":
-			return children.map((c, i) => `${i + 1}. ${adfToText(c)}`).join("\n");
-		case "doc":
-			return children.map(adfToText).join("\n\n");
-		default:
-			return inline;
-	}
-}
-
 /** Derive a plain-text description from `versionedRepresentations.description` (a string or ADF doc). */
 function descriptionFromVersionedRepresentations(versioned: unknown): string | undefined {
 	const value = latestRepresentation(versioned, "description");
 	const text = typeof value === "string" ? value : adfToText(value);
 	const trimmed = text.trim();
 	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Issue key from a Jira ARI's trailing `issue/<KEY>` segment
+ * (`ari:cloud:jira:<cloudId>:issue/KAN-1` → `KAN-1`). Returns undefined when
+ * `id` is absent or has no path segment; a non-key trailing value (e.g. a
+ * numeric id) simply fails the def's `JIRA_KEY_REGEX` require and voids.
+ */
+function issueKeyFromAri(id: unknown): string | undefined {
+	if (typeof id !== "string") return undefined;
+	const slash = id.lastIndexOf("/");
+	return slash >= 0 ? id.slice(slash + 1) : undefined;
+}
+
+/**
+ * Reshape the generic `_fetch` entity envelope (`type:"jira-issue"`) into the
+ * canonical `{ key, fields, webUrl }`. Fields absent from the envelope are simply
+ * omitted (the def treats each as optional except the required `summary`/`key`).
+ */
+function reshapeFetchEnvelope(env: { [key: string]: unknown }): unknown {
+	const metadata = isObject(env.metadata) ? env.metadata : {};
+	const key = issueKeyFromAri(env.id);
+	const description = typeof env.text === "string" && env.text.trim().length > 0 ? env.text : undefined;
+	const fields = {
+		...(typeof env.title === "string" ? { summary: env.title } : {}),
+		...(description !== undefined ? { description } : {}),
+		...(typeof metadata.status === "string" ? { status: metadata.status } : {}),
+		...(typeof metadata.priority === "string" ? { priority: metadata.priority } : {}),
+	};
+	return {
+		...(key !== undefined ? { key } : {}),
+		...(typeof env.url === "string" ? { webUrl: env.url } : {}),
+		fields,
+	};
 }
 
 /** Reshape one Jira node so the adapter's `fields.summary` (+ description) is present. */
@@ -105,6 +120,11 @@ function reshapeJiraNode(node: unknown): unknown {
  */
 function normalizeJira(business: unknown): unknown {
 	if (!isObject(business)) return business;
+	// Generic `_fetch` entity envelope — the real Rovo shape. Gated on
+	// `type:"jira-issue"` so a non-Jira `_fetch` (e.g. a Confluence entity fetched
+	// through the same generic tool) passes through unreshaped and voids on the
+	// def's `key`/`summary` requires rather than being mis-attributed to Jira.
+	if (business.type === "jira-issue") return reshapeFetchEnvelope(business);
 	const issues = business.issues;
 	if (isObject(issues) && Array.isArray(issues.nodes)) {
 		return { ...business, issues: { ...issues, nodes: issues.nodes.map(reshapeJiraNode) } };

--- a/cli/src/core/references/bindings/codex/CodexJiraBinding.ts
+++ b/cli/src/core/references/bindings/codex/CodexJiraBinding.ts
@@ -2,7 +2,7 @@
  * CodexJiraBinding — Jira `codex_apps` connector normalizer (match identity lives
  * in `jira`'s `SourceDefinition.match.codex`).
  *
- * Two payload shapes are handled, both reshaped into the `{ key, fields, webUrl }`
+ * Three payload shapes are handled, all reshaped into the `{ key, fields, webUrl }`
  * the jira `SourceDefinition` reads:
  *
  *   1. Generic `_fetch` entity envelope (VERIFIED from a live "Atlassian Rovo"
@@ -17,12 +17,20 @@
  *      envelope (only `cloudId` is present), so it is kept as-is rather than
  *      voiding the otherwise-useful reference. `type:"jira-issue"` gates this branch.
  *
- *   2. `{ issues: { nodes: [ node ] } }` with per-node field VALUES under
+ *   2. Dedicated `getJiraIssue` REST issue (VERIFIED from a live rollout,
+ *      2026-07-13): the standard Jira REST v3 object `{ id, self, key, fields:{
+ *      summary, status:{name}, priority:{name}, description, labels, … } }`. It is
+ *      already `{key, fields}`-shaped, so `reshapeJiraNode` leaves fields alone —
+ *      but it has NO top-level `webUrl`, only `self` (the api.atlassian.com REST
+ *      endpoint), so {@link withWebUrlFromSelf} maps `self`→`webUrl` (same api-URL
+ *      tradeoff as shape 1). Without that the whole reference voided on the def's
+ *      `url` require — the bug this binding was extended to fix.
+ *
+ *   3. `{ issues: { nodes: [ node ] } }` with per-node field VALUES under
  *      `versionedRepresentations` (`{ "<version>": <value> }`; `summary` a string,
- *      `description` an ADF document). UNVERIFIED legacy shape retained pending a
- *      real transcript — `normalize` derives `fields.summary`/`description` (ADF →
- *      markdown), and `recover` (NOT the main path) handles its malformed-output
- *      edge (see below).
+ *      `description` an ADF document). Retained for the heavy-`expand` variant —
+ *      `normalize` derives `fields.summary`/`description` (ADF → markdown), and
+ *      `recover` (NOT the main path) handles its malformed-output edge (see below).
  */
 
 import { adfToText } from "../../sources/AdfToText.js";
@@ -96,9 +104,26 @@ function reshapeFetchEnvelope(env: { [key: string]: unknown }): unknown {
 	};
 }
 
+/**
+ * Ensure a `webUrl` for the def's `url` require. The dedicated `getJiraIssue`
+ * returns the standard Jira REST issue with NO top-level `webUrl` — only `self`,
+ * the `api.atlassian.com/…/rest/api/3/issue/<id>` endpoint (verified from a live
+ * Rovo rollout, 2026-07-13). Fall back `self` → `webUrl` so the issue is captured
+ * rather than voided; like the generic `_fetch` path this keeps the non-browsable
+ * api URL, since the tenant site name needed for a `/browse/<KEY>` link is absent
+ * from the payload. Returns the input unchanged when a `webUrl` is already present
+ * (so a real browse link always wins) or when there is no `self` to borrow.
+ */
+function withWebUrlFromSelf(node: { [key: string]: unknown }): { [key: string]: unknown } {
+	if (typeof node.webUrl === "string" && node.webUrl.length > 0) return node;
+	if (typeof node.self === "string" && node.self.length > 0) return { ...node, webUrl: node.self };
+	return node;
+}
+
 /** Reshape one Jira node so the adapter's `fields.summary` (+ description) is present. */
-function reshapeJiraNode(node: unknown): unknown {
-	if (!isObject(node)) return node;
+function reshapeJiraNode(rawNode: unknown): unknown {
+	if (!isObject(rawNode)) return rawNode;
+	const node = withWebUrlFromSelf(rawNode);
 	const existing = isObject(node.fields) ? node.fields : undefined;
 	// Already adapter-shaped (Claude / a future fields-bearing payload): leave it.
 	if (existing !== undefined && typeof existing.summary === "string" && existing.summary.length > 0) return node;

--- a/cli/src/core/references/bindings/codex/index.test.ts
+++ b/cli/src/core/references/bindings/codex/index.test.ts
@@ -11,6 +11,9 @@ describe("Codex producer normalizer registry", () => {
 			expect(getCodexNormalizer("zoom-meeting")?.canonicalToolName).toBe(
 				"mcp__claude_ai_Zoom_for_Claude__get_meeting_assets",
 			);
+			expect(getCodexNormalizer("confluence")?.canonicalToolName).toBe(
+				"mcp__claude_ai_Atlassian__getConfluencePage",
+			);
 		});
 
 		it("returns undefined for an id with no registered normalizer", () => {
@@ -34,6 +37,15 @@ describe("Codex producer normalizer registry", () => {
 			expect(getCodexNormalizer("notion")?.normalize(payload)).toBe(payload);
 			expect(getCodexNormalizer("jira")?.normalize(payload)).toBe(payload);
 			expect(getCodexNormalizer("zoom-meeting")?.normalize(payload)).toBe(payload);
+		});
+
+		it("confluence normalizer reshapes the {content:{nodes}} page into the canonical shape", () => {
+			const out = getCodexNormalizer("confluence")?.normalize({
+				content: { nodes: [{ id: "131076", title: "P", webUrl: "https://x.atlassian.net/wiki/p/131076" }] },
+			}) as { pageId?: string; title?: string; url?: string };
+			expect(out.pageId).toBe("131076");
+			expect(out.title).toBe("P");
+			expect(out.url).toBe("https://x.atlassian.net/wiki/p/131076");
 		});
 	});
 });

--- a/cli/src/core/references/bindings/codex/index.ts
+++ b/cli/src/core/references/bindings/codex/index.ts
@@ -11,6 +11,7 @@
 
 import type { SourceId } from "../../../../Types.js";
 import type { CodexNormalizer } from "./CodexBinding.js";
+import { confluenceCodexBinding } from "./CodexConfluenceBinding.js";
 import { githubCodexBinding } from "./CodexGitHubBinding.js";
 import { jiraCodexBinding } from "./CodexJiraBinding.js";
 import { linearCodexBinding } from "./CodexLinearBinding.js";
@@ -26,6 +27,7 @@ const CODEX_NORMALIZERS: readonly CodexNormalizer[] = [
 	githubCodexBinding,
 	jiraCodexBinding,
 	zoomMeetingCodexBinding,
+	confluenceCodexBinding,
 ];
 
 const BY_ID: ReadonlyMap<SourceId, CodexNormalizer> = new Map(CODEX_NORMALIZERS.map((n) => [n.id, n]));

--- a/cli/src/core/references/sources/AdfToText.ts
+++ b/cli/src/core/references/sources/AdfToText.ts
@@ -1,0 +1,38 @@
+/**
+ * Minimal ADF (Atlassian Document Format) → markdown-ish plain text.
+ *
+ * Agent- and source-agnostic: both the Codex Jira binding (issue descriptions)
+ * and the Confluence normalizer (page bodies) receive ADF documents and need a
+ * plain-text rendering for a reference body. Handles the node types those
+ * payloads actually use (heading/paragraph/list/blockquote/codeBlock/text);
+ * unknown nodes just concatenate their children. Good enough for a reference
+ * body; the consumer truncates it.
+ */
+
+import { isObject } from "../guards.js";
+
+export function adfToText(node: unknown): string {
+	if (!isObject(node)) return "";
+	if (node.type === "text") return typeof node.text === "string" ? node.text : "";
+	const children = Array.isArray(node.content) ? node.content : [];
+	const inline = children.map(adfToText).join("");
+	switch (node.type) {
+		case "heading": {
+			const level = isObject(node.attrs) && typeof node.attrs.level === "number" ? node.attrs.level : 1;
+			return `${"#".repeat(Math.min(Math.max(level, 1), 6))} ${inline}`;
+		}
+		case "paragraph":
+		case "codeBlock":
+			return inline;
+		case "blockquote":
+			return children.map((c) => `> ${adfToText(c)}`).join("\n");
+		case "bulletList":
+			return children.map((c) => `- ${adfToText(c)}`).join("\n");
+		case "orderedList":
+			return children.map((c, i) => `${i + 1}. ${adfToText(c)}`).join("\n");
+		case "doc":
+			return children.map(adfToText).join("\n\n");
+		default:
+			return inline;
+	}
+}

--- a/cli/src/core/references/sources/ConfluenceNormalize.test.ts
+++ b/cli/src/core/references/sources/ConfluenceNormalize.test.ts
@@ -64,7 +64,64 @@ const ADF_BODY = {
 	},
 };
 
+// Real Codex "Atlassian Rovo" `_getconfluencepage` result (captured 2026-07-13):
+// the MCP CallToolResult's `content[0].text` — the shape the Codex envelope layer
+// actually extracts — is a FLAT page node, NOT the `{content:{nodes:[…]}}` wrapper
+// Claude's `getConfluencePage` structuredContent carries. There is no `space`/`author`
+// object here, only `spaceId`/`authorId`.
+const ROVO_FLAT_PAGE = {
+	id: "8388609",
+	type: "page",
+	status: "current",
+	title: "My second page - 002",
+	spaceId: 196611,
+	parentId: "98415",
+	authorId: "712020:11111111-2222-3333-4444-555555555555",
+	body: "## Overview\n\nSecond page body text.",
+	webUrl: "https://lichengbin2008.atlassian.net/wiki/spaces/KAN/pages/8388609/My+second+page",
+};
+
 describe("normalizeConfluence", () => {
+	it("captures a flat page node (Codex Rovo shape) without the content.nodes wrapper", () => {
+		const out = normalizeConfluence(ROVO_FLAT_PAGE);
+		expect(out).not.toBeNull();
+		expect(out?.pageId).toBe("8388609");
+		expect(out?.title).toBe("My second page - 002");
+		expect(out?.url).toBe("https://lichengbin2008.atlassian.net/wiki/spaces/KAN/pages/8388609/My+second+page");
+		expect(out?.body).toBe("## Overview\n\nSecond page body text.");
+		expect(out?.entityType).toBe("page");
+		// The flat node has only spaceId/authorId (opaque IDs), no space/author
+		// objects — those display fields stay undefined rather than surfacing IDs.
+		expect(out?.space).toBeUndefined();
+		expect(out?.author).toBeUndefined();
+	});
+
+	it("flattens an ADF body on a flat page node too (Codex adf contentFormat)", () => {
+		const out = normalizeConfluence({
+			id: "131076",
+			type: "page",
+			title: "adf flat page",
+			webUrl: "https://x.atlassian.net/wiki/spaces/KAN/pages/131076/p",
+			body: {
+				type: "doc",
+				content: [{ type: "heading", attrs: { level: 2 }, content: [{ type: "text", text: "TL;DR" }] }],
+			},
+		});
+		expect(out?.body).toBe("## TL;DR");
+	});
+
+	it("identifies a flat node by webUrl when title is absent", () => {
+		const out = normalizeConfluence({ id: "42", webUrl: "https://x.atlassian.net/wiki/p/42" });
+		expect(out).not.toBeNull();
+		expect(out?.pageId).toBe("42");
+		expect(out?.title).toBeUndefined();
+	});
+
+	it("returns null for a top-level object with an id but neither title nor webUrl", () => {
+		// Not the wrapper (no `content`) and not page-node-shaped enough to trust.
+		expect(normalizeConfluence({ id: "1" })).toBeNull();
+	});
+
 	it("passes a string body through unchanged", () => {
 		const out = normalizeConfluence(STRING_BODY);
 		expect(out).not.toBeNull();

--- a/cli/src/core/references/sources/ConfluenceNormalize.test.ts
+++ b/cli/src/core/references/sources/ConfluenceNormalize.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { normalizeConfluence } from "./ConfluenceNormalize.js";
+
+// Real getConfluencePage capture (default/markdown contentFormat): body is a string.
+const STRING_BODY = {
+	content: {
+		totalCount: 1,
+		nodes: [
+			{
+				id: "557292",
+				type: "page",
+				status: "current",
+				title: "数据库访问架构变更设计：Per-Provider 连接池",
+				summary: "TL;DR…",
+				space: { key: "Engineerin", name: "Engineering" },
+				author: { displayName: "Flyer Li", avatarUrls: { "48x48": "https://…/aa-avatar/…" } },
+				_links: { webui: "/spaces/Engineerin/pages/557292/Per-Provider" },
+				lastModified: "17 minutes ago",
+				body: "## TL;DR\n\n1. 现状：per-(tenant, org) 连接池。",
+				webUrl: "https://jolli-team-zod7kvo1.atlassian.net/wiki/spaces/Engineerin/pages/557292/Per-Provider",
+			},
+		],
+	},
+};
+
+// Real getConfluencePage capture (adf contentFormat): body is an ADF document object.
+const ADF_BODY = {
+	content: {
+		totalCount: 1,
+		nodes: [
+			{
+				id: "557292",
+				title: "数据库访问架构变更设计：Per-Provider 连接池",
+				space: { key: "Engineerin", name: "Engineering" },
+				author: { displayName: "Flyer Li" },
+				body: {
+					type: "doc",
+					version: 1,
+					content: [
+						{ type: "heading", attrs: { level: 2 }, content: [{ type: "text", text: "TL;DR" }] },
+						{
+							type: "orderedList",
+							content: [
+								{
+									type: "listItem",
+									content: [
+										{
+											type: "paragraph",
+											content: [
+												{ type: "text", text: "现状：每个 org 的 " },
+												{ type: "text", text: "poolMax", marks: [{ type: "code" }] },
+												{ type: "text", text: " 配得越小。" },
+											],
+										},
+									],
+								},
+							],
+						},
+					],
+				},
+				webUrl: "https://jolli-team-zod7kvo1.atlassian.net/wiki/spaces/Engineerin/pages/557292/Per-Provider",
+			},
+		],
+	},
+};
+
+describe("normalizeConfluence", () => {
+	it("passes a string body through unchanged", () => {
+		const out = normalizeConfluence(STRING_BODY);
+		expect(out).not.toBeNull();
+		expect(out?.pageId).toBe("557292");
+		expect(out?.title).toBe("数据库访问架构变更设计：Per-Provider 连接池");
+		expect(out?.url).toBe(
+			"https://jolli-team-zod7kvo1.atlassian.net/wiki/spaces/Engineerin/pages/557292/Per-Provider",
+		);
+		expect(out?.body).toBe("## TL;DR\n\n1. 现状：per-(tenant, org) 连接池。");
+		expect(out?.space).toBe("Engineering");
+		expect(out?.author).toBe("Flyer Li");
+		expect(out?.entityType).toBe("page");
+	});
+
+	it("carries a non-page content type (blogpost) through, and omits it when absent", () => {
+		const blogpost = normalizeConfluence({
+			content: { nodes: [{ id: "1", type: "blogpost", title: "t", webUrl: "https://x.atlassian.net/wiki/p/1" }] },
+		});
+		expect(blogpost?.entityType).toBe("blogpost");
+		const noType = normalizeConfluence({
+			content: { nodes: [{ id: "1", title: "t", webUrl: "https://x.atlassian.net/wiki/p/1" }] },
+		});
+		expect(noType?.entityType).toBeUndefined();
+	});
+
+	it("flattens an ADF body to plain text", () => {
+		const out = normalizeConfluence(ADF_BODY);
+		expect(out?.body).toBe("## TL;DR\n\n1. 现状：每个 org 的 poolMax 配得越小。");
+	});
+
+	it("omits body when it is neither string nor flattenable", () => {
+		const out = normalizeConfluence({ content: { nodes: [{ id: "1", title: "t", webUrl: "u", body: 42 }] } });
+		expect(out?.body).toBeUndefined();
+	});
+
+	it("returns null when content is missing", () => {
+		expect(normalizeConfluence({})).toBeNull();
+		expect(normalizeConfluence({ content: {} })).toBeNull();
+		expect(normalizeConfluence({ content: { nodes: [] } })).toBeNull();
+		expect(normalizeConfluence({ content: { nodes: [42] } })).toBeNull();
+		expect(normalizeConfluence(null)).toBeNull();
+	});
+
+	it("does not null-check title/url (leaves them undefined for the definition to void)", () => {
+		const out = normalizeConfluence({ content: { nodes: [{ id: "1" }] } });
+		expect(out).not.toBeNull();
+		expect(out?.pageId).toBe("1");
+		expect(out?.title).toBeUndefined();
+		expect(out?.url).toBeUndefined();
+	});
+
+	it("leaves pageId undefined when the node has no id", () => {
+		const out = normalizeConfluence({
+			content: { nodes: [{ title: "t", webUrl: "https://x.atlassian.net/wiki/p/1" }] },
+		});
+		expect(out).not.toBeNull();
+		expect(out?.pageId).toBeUndefined();
+		expect(out?.title).toBe("t");
+	});
+});

--- a/cli/src/core/references/sources/ConfluenceNormalize.ts
+++ b/cli/src/core/references/sources/ConfluenceNormalize.ts
@@ -2,11 +2,22 @@
  * ConfluenceNormalize — reshape a `getConfluencePage` MCP result into a canonical
  * object the `confluence` SourceDefinition reads with plain `path` ops.
  *
- * The raw payload is `{ content: { nodes: [ node ] } }`; a single-page fetch
- * yields exactly one node. The only field the DSL cannot handle itself is `body`,
- * which is a markdown STRING under the default/"markdown" contentFormat but an
- * ADF document OBJECT under "adf" — so this flattens ADF to text (the DSL's
- * `path`/`transform` cannot: `transform` fns are `(string) => string`).
+ * TWO envelope shapes reach this layer, both carrying the same logical page:
+ *   - WRAPPED `{ content: { nodes: [ node ] } }` — Claude's `getConfluencePage`
+ *     tool result body (and a single-page fetch yields exactly one node). The
+ *     node carries `space:{name}` / `author:{displayName}` objects.
+ *   - FLAT `{ id, title, webUrl, body, spaceId, authorId, … }` — Codex's Rovo
+ *     `_getconfluencepage`, whose `content[0].text` (the string the Codex envelope
+ *     layer extracts) is the page node itself, NOT the wrapper. Its wrapped twin
+ *     lives in the connector's `structuredContent`, which the envelope discards
+ *     (verified against live 2026-07 rollouts). The flat node has NO `space` /
+ *     `author` objects — only `spaceId` / `authorId` IDs — so those display fields
+ *     are deliberately left undefined rather than surfaced as opaque IDs.
+ * {@link resolveNode} accepts either. The only field the DSL cannot handle itself
+ * is `body`, which is a markdown STRING under the default/"markdown" contentFormat
+ * but an ADF document OBJECT under "adf" (true in BOTH shapes) — so this flattens
+ * ADF to text (the DSL's `path`/`transform` cannot: `transform` fns are
+ * `(string) => string`).
  *
  * "Normalize only normalizes": missing `title`/`url` are left undefined so the
  * definition's `require` regexes void the reference — this layer only returns
@@ -33,14 +44,35 @@ function bodyToString(body: unknown): string | undefined {
 	return trimmed.length > 0 ? text : undefined;
 }
 
+/**
+ * Extract the page node from either envelope shape. A top-level `content` key is
+ * the unambiguous marker of the WRAPPED shape (a flat page node keeps its body
+ * under `body`, never a top-level `content`), so once `content` is an object we
+ * commit to `content.nodes[0]` and never fall through. Otherwise, a top-level
+ * object that looks like a page node (`id` plus a `title` or `webUrl`) is treated
+ * as the FLAT Codex shape. Anything else is unparseable.
+ */
+function resolveNode(rawResult: { [k: string]: unknown }): { [k: string]: unknown } | null {
+	const content = rawResult.content;
+	if (isObject(content)) {
+		const nodes = content.nodes;
+		if (!Array.isArray(nodes) || nodes.length === 0) return null;
+		const node = nodes[0];
+		return isObject(node) ? node : null;
+	}
+	if (
+		typeof rawResult.id === "string" &&
+		(typeof rawResult.title === "string" || typeof rawResult.webUrl === "string")
+	) {
+		return rawResult;
+	}
+	return null;
+}
+
 export function normalizeConfluence(rawResult: unknown): ConfluenceCanonical | null {
 	if (!isObject(rawResult)) return null;
-	const content = rawResult.content;
-	if (!isObject(content)) return null;
-	const nodes = content.nodes;
-	if (!Array.isArray(nodes) || nodes.length === 0) return null;
-	const node = nodes[0];
-	if (!isObject(node)) return null;
+	const node = resolveNode(rawResult);
+	if (node === null) return null;
 
 	const pageId = typeof node.id === "string" ? node.id : undefined;
 	const title = typeof node.title === "string" ? node.title : undefined;

--- a/cli/src/core/references/sources/ConfluenceNormalize.ts
+++ b/cli/src/core/references/sources/ConfluenceNormalize.ts
@@ -1,0 +1,63 @@
+/**
+ * ConfluenceNormalize — reshape a `getConfluencePage` MCP result into a canonical
+ * object the `confluence` SourceDefinition reads with plain `path` ops.
+ *
+ * The raw payload is `{ content: { nodes: [ node ] } }`; a single-page fetch
+ * yields exactly one node. The only field the DSL cannot handle itself is `body`,
+ * which is a markdown STRING under the default/"markdown" contentFormat but an
+ * ADF document OBJECT under "adf" — so this flattens ADF to text (the DSL's
+ * `path`/`transform` cannot: `transform` fns are `(string) => string`).
+ *
+ * "Normalize only normalizes": missing `title`/`url` are left undefined so the
+ * definition's `require` regexes void the reference — this layer only returns
+ * null for structurally unparseable input, and never throws.
+ */
+
+import { isObject } from "../guards.js";
+import { adfToText } from "./AdfToText.js";
+
+export interface ConfluenceCanonical {
+	readonly pageId?: string;
+	readonly title?: string;
+	readonly url?: string;
+	readonly body?: string;
+	readonly space?: string;
+	readonly author?: string;
+	/** Confluence content type — "page", "blogpost", etc. Undefined when absent. */
+	readonly entityType?: string;
+}
+
+function bodyToString(body: unknown): string | undefined {
+	const text = typeof body === "string" ? body : adfToText(body);
+	const trimmed = text.trim();
+	return trimmed.length > 0 ? text : undefined;
+}
+
+export function normalizeConfluence(rawResult: unknown): ConfluenceCanonical | null {
+	if (!isObject(rawResult)) return null;
+	const content = rawResult.content;
+	if (!isObject(content)) return null;
+	const nodes = content.nodes;
+	if (!Array.isArray(nodes) || nodes.length === 0) return null;
+	const node = nodes[0];
+	if (!isObject(node)) return null;
+
+	const pageId = typeof node.id === "string" ? node.id : undefined;
+	const title = typeof node.title === "string" ? node.title : undefined;
+	const url = typeof node.webUrl === "string" ? node.webUrl : undefined;
+	const body = bodyToString(node.body);
+	const space = isObject(node.space) && typeof node.space.name === "string" ? node.space.name : undefined;
+	const author =
+		isObject(node.author) && typeof node.author.displayName === "string" ? node.author.displayName : undefined;
+	const entityType = typeof node.type === "string" ? node.type : undefined;
+
+	return {
+		...(pageId !== undefined ? { pageId } : {}),
+		...(title !== undefined ? { title } : {}),
+		...(url !== undefined ? { url } : {}),
+		...(body !== undefined ? { body } : {}),
+		...(space !== undefined ? { space } : {}),
+		...(author !== undefined ? { author } : {}),
+		...(entityType !== undefined ? { entityType } : {}),
+	};
+}

--- a/cli/src/core/references/sources/definitions/confluence.test.ts
+++ b/cli/src/core/references/sources/definitions/confluence.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { extractRef, renderBlock } from "../../SourceEngine.js";
+import { confluenceDefinition as def } from "./confluence.js";
+
+// The definition runs over the POST-normalize canonical shape (ConfluenceNormalize output).
+const CANONICAL = {
+	pageId: "557292",
+	title: "数据库访问架构变更设计：Per-Provider 连接池",
+	url: "https://jolli-team-zod7kvo1.atlassian.net/wiki/spaces/Engineerin/pages/557292/Per-Provider",
+	body: "## TL;DR\n\n1. 现状：per-(tenant, org) 连接池。",
+	space: "Engineering",
+	author: "Flyer Li",
+};
+const TOOL = "mcp__claude_ai_Atlassian__getConfluencePage";
+const AT = "2026-07-11T00:00:00Z";
+
+describe("confluence definition", () => {
+	it("extracts a Reference from the canonical shape", () => {
+		const ref = extractRef(def, CANONICAL, TOOL, AT);
+		expect(ref?.source).toBe("confluence");
+		expect(ref?.nativeId).toBe("557292");
+		expect(ref?.title).toBe("数据库访问架构变更设计：Per-Provider 连接池");
+		expect(ref?.url).toBe(CANONICAL.url);
+		expect(ref?.description).toContain("TL;DR");
+		expect(ref?.fields).toEqual([
+			{ key: "space", label: "Space", icon: "symbol-namespace", value: "Engineering" },
+			{ key: "author", label: "Author", icon: "account", value: "Flyer Li" },
+			{ key: "entity-type", label: "Type", icon: "symbol-class", value: "page" },
+		]);
+	});
+
+	it("reflects a non-page entityType (blogpost) in the Type field", () => {
+		const ref = extractRef(def, { ...CANONICAL, entityType: "blogpost" }, TOOL, AT);
+		expect(ref?.fields).toContainEqual({
+			key: "entity-type",
+			label: "Type",
+			icon: "symbol-class",
+			value: "blogpost",
+		});
+	});
+
+	it("voids when pageId (nativeId) is non-numeric", () => {
+		expect(extractRef(def, { ...CANONICAL, pageId: "abc" }, TOOL, AT)).toBeNull();
+	});
+
+	it("voids when the URL is not a wiki URL", () => {
+		expect(extractRef(def, { ...CANONICAL, url: "https://example.com/not-wiki" }, TOOL, AT)).toBeNull();
+	});
+
+	it("still extracts when body/space/author are absent (title+url suffice)", () => {
+		const ref = extractRef(def, { pageId: "1", title: "t", url: "https://x.atlassian.net/wiki/p/1" }, TOOL, AT);
+		expect(ref?.nativeId).toBe("1");
+		expect(ref?.description).toBeUndefined();
+	});
+
+	it("renders a <confluence-pages> block", () => {
+		const ref = extractRef(def, CANONICAL, TOOL, AT);
+		if (ref === null) throw new Error("expected ref");
+		const block = renderBlock(def, [ref]);
+		expect(block).toContain("<confluence-pages>");
+		expect(block).toContain("<content>");
+	});
+});

--- a/cli/src/core/references/sources/definitions/confluence.ts
+++ b/cli/src/core/references/sources/definitions/confluence.ts
@@ -30,8 +30,9 @@ export const confluenceDefinition: SourceDefinition = {
 		// Codex's built-in "Atlassian Rovo" app fetches a page through a dedicated
 		// `_getconfluencepage` tool (namespace `mcp__codex_apps__atlassian_rovo`,
 		// invocation `atlassian_rovo.getConfluencePage`) — verified from a live
-		// rollout. Its output is the SAME `{content:{nodes}}` shape as the Claude
-		// tool, so `CodexConfluenceBinding` reuses `normalizeConfluence` verbatim.
+		// rollout. Its extracted `content[0].text` is a FLAT page node, NOT the
+		// Claude tool's `{content:{nodes}}` wrapper (see CodexConfluenceBinding);
+		// `normalizeConfluence` accepts both, so the binding reuses it verbatim.
 		// This def ONLY claims the dedicated `_getconfluencepage`; a page fetched via
 		// the generic `_fetch` routes to the jira def and is dropped (see the KNOWN
 		// GAP note in jira.ts). Jira's `_fetch` therefore never collides with this def.

--- a/cli/src/core/references/sources/definitions/confluence.ts
+++ b/cli/src/core/references/sources/definitions/confluence.ts
@@ -1,0 +1,71 @@
+/**
+ * Confluence built-in source definition — captures the result of
+ * `mcp__claude_ai_Atlassian__getConfluencePage`.
+ *
+ * Runs over the canonical shape produced by `normalizeConfluence`
+ * (`{ pageId, title, url, body?, space?, author? }`), NOT the raw MCP payload:
+ * the normalizer flattens the ADF-vs-markdown `body` variance the DSL cannot
+ * express, so this reads plain `path` ops and needs no `wrapperKeys`.
+ *
+ * Ordering: jira's `match.claude` is prefix-only (`mcp__claude_ai_Atlassian__`)
+ * and matches every Atlassian tool. This def's `acceptSuffix: "getConfluencePage"`
+ * plus its position BEFORE jira in `BUILTIN_DEFINITIONS` routes page reads here
+ * and lets `getJiraIssue` fall through to jira.
+ */
+
+import type { SourceDefinition } from "../../SourceDefinition.js";
+
+// Any HTTPS host with a /wiki/ path. Stricter than jira's bare `^https?://`
+// (confirms a Cloud wiki link), looser than hard-coding atlassian.net (tolerates
+// Cloud custom domains, which keep the /wiki/ prefix). The claude.ai connector is
+// Cloud-only; Data Center's /display/ URL layout is intentionally out of scope.
+const WIKI_URL = "^https://[^/]+/wiki/";
+
+export const confluenceDefinition: SourceDefinition = {
+	id: "confluence",
+	label: "Confluence",
+	icon: "book",
+	match: {
+		claude: { prefixes: ["mcp__claude_ai_Atlassian__"], acceptSuffix: "getConfluencePage" },
+		// Codex's built-in "Atlassian Rovo" app fetches a page through a dedicated
+		// `_getconfluencepage` tool (namespace `mcp__codex_apps__atlassian_rovo`,
+		// invocation `atlassian_rovo.getConfluencePage`) — verified from a live
+		// rollout. Its output is the SAME `{content:{nodes}}` shape as the Claude
+		// tool, so `CodexConfluenceBinding` reuses `normalizeConfluence` verbatim.
+		// This def ONLY claims the dedicated `_getconfluencepage`; a page fetched via
+		// the generic `_fetch` routes to the jira def and is dropped (see the KNOWN
+		// GAP note in jira.ts). Jira's `_fetch` therefore never collides with this def.
+		codex: {
+			namespaceSuffix: "atlassian_rovo",
+			functionCallNames: ["_getconfluencepage"],
+			invocationTools: ["atlassian_rovo.getConfluencePage"],
+		},
+	},
+	wrapperKeys: [],
+	reference: {
+		nativeId: { pipe: [{ op: "path", path: "pageId" }], require: "^\\d+$" },
+		title: { pipe: [{ op: "path", path: "title" }], require: ".+" },
+		url: { pipe: [{ op: "path", path: "url" }], require: WIKI_URL },
+		description: { pipe: [{ op: "path", path: "body" }], optional: true },
+	},
+	fields: [
+		{ key: "space", label: "Space", icon: "symbol-namespace", pipe: [{ op: "path", path: "space" }] },
+		{ key: "author", label: "Author", icon: "account", pipe: [{ op: "path", path: "author" }] },
+		{
+			key: "entity-type",
+			label: "Type",
+			icon: "symbol-class",
+			// Prefer the page's real content type ("page" / "blogpost"); fall back to
+			// "page" when the payload omits it (older/leaner captures).
+			pipe: [{ op: "coalesce", of: [[{ op: "path", path: "entityType" }], [{ op: "const", value: "page" }]] }],
+		},
+	],
+	storage: { nativeIdPathSafe: true },
+	render: {
+		wrapperTag: "confluence-pages",
+		itemTag: "page",
+		bodyTag: "content",
+		maxCharsPerReference: 30000,
+		maxTotalChars: 60000,
+	},
+};

--- a/cli/src/core/references/sources/definitions/index.ts
+++ b/cli/src/core/references/sources/definitions/index.ts
@@ -5,8 +5,15 @@
  * github, notion) — preserved for continuity with `SourceDefinitionRegistry`
  * consumers that pin this order (e.g. `CLAUDE_TOOL_PREFIXES`). `slack`,
  * `zoom-meeting` and `zoom-doc` are appended after the migrated four.
+ *
+ * `confluence` is inserted BEFORE `jira` deliberately: both share the
+ * `mcp__claude_ai_Atlassian__` tool prefix, jira's `match.claude` is a
+ * prefix-only catch-all, and the registry returns the first array match — so
+ * confluence's narrower `acceptSuffix` must be checked first or every
+ * Confluence tool call would silently resolve to jira.
  */
 
+import { confluenceDefinition } from "./confluence.js";
 import { githubDefinition } from "./github.js";
 import { jiraDefinition } from "./jira.js";
 import { linearDefinition } from "./linear.js";
@@ -17,6 +24,7 @@ import { zoomMeetingDefinition } from "./zoom-meeting.js";
 
 export const BUILTIN_DEFINITIONS = [
 	linearDefinition,
+	confluenceDefinition,
 	jiraDefinition,
 	githubDefinition,
 	notionDefinition,

--- a/cli/src/core/references/sources/definitions/jira.ts
+++ b/cli/src/core/references/sources/definitions/jira.ts
@@ -30,23 +30,28 @@ export const jiraDefinition: SourceDefinition = {
 	icon: "issues",
 	match: {
 		claude: { prefixes: ["mcp__claude_ai_Atlassian__"] },
-		// Codex's built-in "Atlassian Rovo" app has NO dedicated Jira tool: an issue
-		// is fetched through the generic `_fetch` (namespace
-		// `mcp__codex_apps__atlassian_rovo`, invocation `atlassian_rovo.fetch`),
-		// returning a flat `{id,title,text,url,type:"jira-issue",metadata}` envelope
-		// that `CodexJiraBinding` reshapes into `{key,fields,webUrl}`. Verified from a
-		// live rollout (2026-07-12). Confluence's dedicated `_getconfluencepage` is
-		// owned by the confluence def, so that path never collides. KNOWN GAP: the
-		// generic `_fetch` can also fetch a Confluence page (a `confluence-page`
-		// entity); it routes here by tool name, passes through `normalizeJira`
-		// unreshaped (type !== "jira-issue"), and voids on the jira `key`/`summary`
-		// requires — i.e. such a page is DROPPED, not captured as confluence. Proper
-		// per-payload-`type` dispatch of the shared `_fetch` is deferred. `_getjiraissue`
-		// is retained as an UNVERIFIED legacy shape (no real transcript confirms it).
+		// Codex's built-in "Atlassian Rovo" app reaches a Jira issue TWO ways, both
+		// claimed here (namespace `mcp__codex_apps__atlassian_rovo`):
+		//   - Generic `_fetch` (invocation `atlassian_rovo.fetch`) → flat
+		//     `{id,title,text,url,type:"jira-issue",metadata}` envelope, `url`→`webUrl`.
+		//   - Dedicated `getJiraIssue` (function_call `_getjiraissue`, invocation
+		//     `atlassian_rovo.getJiraIssue`) → standard Jira REST issue
+		//     `{key,fields:{summary,…},self}` with NO webUrl (self→webUrl mapped in the
+		//     binding). Both VERIFIED from live rollouts (2026-07-12 / -13). The
+		//     invocation name MUST be the dotted `atlassian_rovo.getJiraIssue`; an
+		//     earlier `"atlassian rovo_getjiraissue"` was a fabricated guess that never
+		//     matched a real event, so getJiraIssue fetches were silently dropped.
+		// Confluence's dedicated `_getconfluencepage` is owned by the confluence def,
+		// so that path never collides. KNOWN GAP: the generic `_fetch` can also fetch a
+		// Confluence page (a `confluence-page` entity); it routes here by tool name,
+		// passes through `normalizeJira` unreshaped (type !== "jira-issue"), and voids
+		// on the jira `key`/`summary` requires — i.e. such a page is DROPPED, not
+		// captured as confluence. Proper per-payload-`type` dispatch of the shared
+		// `_fetch` is deferred.
 		codex: {
 			namespaceSuffix: "atlassian_rovo",
 			functionCallNames: ["_fetch", "_getjiraissue"],
-			invocationTools: ["atlassian_rovo.fetch", "atlassian rovo_getjiraissue"],
+			invocationTools: ["atlassian_rovo.fetch", "atlassian_rovo.getJiraIssue"],
 		},
 	},
 	wrapperKeys: ["nodes", "issues", "items", "results"],

--- a/cli/src/core/references/sources/definitions/jira.ts
+++ b/cli/src/core/references/sources/definitions/jira.ts
@@ -30,10 +30,23 @@ export const jiraDefinition: SourceDefinition = {
 	icon: "issues",
 	match: {
 		claude: { prefixes: ["mcp__claude_ai_Atlassian__"] },
+		// Codex's built-in "Atlassian Rovo" app has NO dedicated Jira tool: an issue
+		// is fetched through the generic `_fetch` (namespace
+		// `mcp__codex_apps__atlassian_rovo`, invocation `atlassian_rovo.fetch`),
+		// returning a flat `{id,title,text,url,type:"jira-issue",metadata}` envelope
+		// that `CodexJiraBinding` reshapes into `{key,fields,webUrl}`. Verified from a
+		// live rollout (2026-07-12). Confluence's dedicated `_getconfluencepage` is
+		// owned by the confluence def, so that path never collides. KNOWN GAP: the
+		// generic `_fetch` can also fetch a Confluence page (a `confluence-page`
+		// entity); it routes here by tool name, passes through `normalizeJira`
+		// unreshaped (type !== "jira-issue"), and voids on the jira `key`/`summary`
+		// requires — i.e. such a page is DROPPED, not captured as confluence. Proper
+		// per-payload-`type` dispatch of the shared `_fetch` is deferred. `_getjiraissue`
+		// is retained as an UNVERIFIED legacy shape (no real transcript confirms it).
 		codex: {
 			namespaceSuffix: "atlassian_rovo",
-			functionCallNames: ["_getjiraissue"],
-			invocationTools: ["atlassian rovo_getjiraissue"],
+			functionCallNames: ["_fetch", "_getjiraissue"],
+			invocationTools: ["atlassian_rovo.fetch", "atlassian rovo_getjiraissue"],
 		},
 	},
 	wrapperKeys: ["nodes", "issues", "items", "results"],

--- a/docs/superpowers/plans/2026-07-11-confluence-reference-source.md
+++ b/docs/superpowers/plans/2026-07-11-confluence-reference-source.md
@@ -1,0 +1,585 @@
+# Confluence reference source (Claude path) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Passively capture `mcp__claude_ai_Atlassian__getConfluencePage` results from Claude session transcripts and store each as a `Reference`, with page body normalized to a plain string (markdown pass-through, ADF flattened).
+
+**Architecture:** One new built-in `SourceDefinition` (`confluence`) + one normalizer (`ConfluenceNormalize`) that reshapes the raw MCP payload into a single canonical object (mirroring `zoom-doc`). The ADF→text helper is extracted from `CodexJiraBinding` into a shared module so both consumers use it. jollimemory never calls MCP — it reads the transcript the agent already produced.
+
+**Tech Stack:** TypeScript (ESM, Node 22.5+), Vitest, Biome. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-07-11-confluence-reference-source-design.md`
+
+## Global Constraints
+
+- DCO sign-off on every commit: `git commit -s`. (CI rejects PRs without `Signed-off-by:`.)
+- No `Co-Authored-By: Claude …` trailer / no `🤖 Generated with …` footer.
+- CLI coverage floor held: 97% statements / 96% branches / 97% functions / 97% lines (new code must add zero uncovered gaps).
+- Biome: tabs, 4-wide, 120 column limit; `noExplicitAny: error`, `noUnusedImports/Variables: error`. `npm run lint` = `biome check --error-on-warnings` (warnings fail).
+- Path normalization via `toForwardSlash` only — but this feature touches no path-building code.
+- **Commit/test cadence (user preference — overrides the skill's per-task-commit default):** each task below produces code only (failing test + implementation). Do NOT run `npm run all` or commit per task. Task 5 runs `npm run all` once and makes a single commit for the whole feature.
+- All external-data test fixtures must be real captures, never hand-authored. The three `getConfluencePage` captures (string body, ADF-object body) are pinned in this plan verbatim from live calls.
+
+---
+
+## File Structure
+
+**New**
+- `cli/src/core/references/sources/AdfToText.ts` — agent-agnostic ADF → plain-text (extracted from `CodexJiraBinding`).
+- `cli/src/core/references/sources/ConfluenceNormalize.ts` — raw MCP payload → `ConfluenceCanonical`.
+- `cli/src/core/references/sources/ConfluenceNormalize.test.ts`
+- `cli/src/core/references/sources/definitions/confluence.ts` — the `SourceDefinition`.
+- `cli/src/core/references/sources/definitions/confluence.test.ts`
+
+**Modified**
+- `cli/src/core/references/bindings/codex/CodexJiraBinding.ts` — delete local `adfToText`, import shared.
+- `cli/src/core/references/sources/definitions/index.ts` — register `confluence` before `jira`.
+- `cli/src/core/references/ClaudeEnvelopeParser.ts` — add `confluence` to `CONTEXT_NORMALIZERS`; broaden the registry docstring.
+- `cli/src/Types.ts:775` — add `"confluence"` to `KnownSourceId`.
+- `cli/src/core/references/SourceDefinitionRegistry.test.ts` — id-order assertion gains `"confluence"` before `"jira"`.
+
+---
+
+## Task 1: Extract `adfToText` into a shared module
+
+Pure move — no behavior change. The existing `CodexJiraBinding.test.ts` is the regression guard (it still exercises `adfToText` through `normalize`/`recover`).
+
+**Files:**
+- Create: `cli/src/core/references/sources/AdfToText.ts`
+- Modify: `cli/src/core/references/bindings/codex/CodexJiraBinding.ts:16,50-72` (remove local `adfToText`, add import)
+
+**Interfaces:**
+- Produces: `adfToText(node: unknown): string` — minimal ADF → markdown-ish plain text; handles `doc`/`heading`/`paragraph`/`bulletList`/`orderedList`/`listItem`/`blockquote`/`codeBlock`/`text`; unknown nodes concatenate children; non-object → `""`.
+- Consumes: `isObject` from `../guards.js`.
+
+- [ ] **Step 1: Create `AdfToText.ts` with the helper moved verbatim**
+
+```typescript
+/**
+ * Minimal ADF (Atlassian Document Format) → markdown-ish plain text.
+ *
+ * Agent- and source-agnostic: both the Codex Jira binding (issue descriptions)
+ * and the Confluence normalizer (page bodies) receive ADF documents and need a
+ * plain-text rendering for a reference body. Handles the node types those
+ * payloads actually use (heading/paragraph/list/blockquote/codeBlock/text);
+ * unknown nodes just concatenate their children. Good enough for a reference
+ * body; the consumer truncates it.
+ */
+
+import { isObject } from "../guards.js";
+
+export function adfToText(node: unknown): string {
+	if (!isObject(node)) return "";
+	if (node.type === "text") return typeof node.text === "string" ? node.text : "";
+	const children = Array.isArray(node.content) ? node.content : [];
+	const inline = children.map(adfToText).join("");
+	switch (node.type) {
+		case "heading": {
+			const level = isObject(node.attrs) && typeof node.attrs.level === "number" ? node.attrs.level : 1;
+			return `${"#".repeat(Math.min(Math.max(level, 1), 6))} ${inline}`;
+		}
+		case "paragraph":
+		case "codeBlock":
+			return inline;
+		case "blockquote":
+			return children.map((c) => `> ${adfToText(c)}`).join("\n");
+		case "bulletList":
+			return children.map((c) => `- ${adfToText(c)}`).join("\n");
+		case "orderedList":
+			return children.map((c, i) => `${i + 1}. ${adfToText(c)}`).join("\n");
+		case "doc":
+			return children.map(adfToText).join("\n\n");
+		default:
+			return inline;
+	}
+}
+```
+
+- [ ] **Step 2: In `CodexJiraBinding.ts`, delete the local `adfToText` function (lines ~50-72) and add the import**
+
+Add near the existing imports (after line 16 `import { isObject } from "../shared.js";`):
+
+```typescript
+import { adfToText } from "../../sources/AdfToText.js";
+```
+
+Then remove the entire local `function adfToText(node: unknown): string { … }` block. Leave every call site (`descriptionFromVersionedRepresentations` at line ~79, etc.) untouched — they now resolve to the imported symbol.
+
+Note: `CodexJiraBinding.ts` keeps importing `isObject` from `../shared.js` (unchanged); only `adfToText` moves. Biome's `noUnusedImports` will flag `isObject` only if it becomes unused — it is still used by other functions in the file, so leave it.
+
+- [ ] **Step 3 (verification deferred to Task 5):** no per-task run/commit. The move is covered by the existing `CodexJiraBinding.test.ts`, which Task 5's `npm run all` executes.
+
+---
+
+## Task 2: `ConfluenceNormalize` — raw MCP payload → canonical object
+
+**Files:**
+- Create: `cli/src/core/references/sources/ConfluenceNormalize.ts`
+- Test: `cli/src/core/references/sources/ConfluenceNormalize.test.ts`
+
+**Interfaces:**
+- Consumes: `isObject` from `../guards.js`; `adfToText` from `./AdfToText.js` (Task 1).
+- Produces:
+  - `interface ConfluenceCanonical { readonly pageId?: string; readonly title?: string; readonly url?: string; readonly body?: string; readonly space?: string; readonly author?: string }`
+  - `normalizeConfluence(rawResult: unknown): ConfluenceCanonical | null` — returns `null` on unparseable input (missing/non-object `content`, missing/empty `nodes`, non-object first node); never throws. Does NOT null-check `title`/`url` (the definition's `require` regexes void those downstream — "normalize only normalizes").
+
+- [ ] **Step 1: Write the failing test** (`ConfluenceNormalize.test.ts`)
+
+Fixtures are trimmed real captures of `getConfluencePage` (page 557292). `STRING_BODY` = default/`markdown` shape; `ADF_BODY` = `adf` shape.
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { normalizeConfluence } from "./ConfluenceNormalize.js";
+
+// Real getConfluencePage capture (default/markdown contentFormat): body is a string.
+const STRING_BODY = {
+	content: {
+		totalCount: 1,
+		nodes: [
+			{
+				id: "557292",
+				type: "page",
+				status: "current",
+				title: "数据库访问架构变更设计：Per-Provider 连接池",
+				summary: "TL;DR…",
+				space: { key: "Engineerin", name: "Engineering" },
+				author: { displayName: "Flyer Li", avatarUrls: { "48x48": "https://…/aa-avatar/…" } },
+				_links: { webui: "/spaces/Engineerin/pages/557292/Per-Provider" },
+				lastModified: "17 minutes ago",
+				body: "## TL;DR\n\n1. 现状：per-(tenant, org) 连接池。",
+				webUrl: "https://jolli-team-zod7kvo1.atlassian.net/wiki/spaces/Engineerin/pages/557292/Per-Provider",
+			},
+		],
+	},
+};
+
+// Real getConfluencePage capture (adf contentFormat): body is an ADF document object.
+const ADF_BODY = {
+	content: {
+		totalCount: 1,
+		nodes: [
+			{
+				id: "557292",
+				title: "数据库访问架构变更设计：Per-Provider 连接池",
+				space: { key: "Engineerin", name: "Engineering" },
+				author: { displayName: "Flyer Li" },
+				body: {
+					type: "doc",
+					version: 1,
+					content: [
+						{ type: "heading", attrs: { level: 2 }, content: [{ type: "text", text: "TL;DR" }] },
+						{
+							type: "orderedList",
+							content: [
+								{
+									type: "listItem",
+									content: [
+										{
+											type: "paragraph",
+											content: [
+												{ type: "text", text: "现状：每个 org 的 " },
+												{ type: "text", text: "poolMax", marks: [{ type: "code" }] },
+												{ type: "text", text: " 配得越小。" },
+											],
+										},
+									],
+								},
+							],
+						},
+					],
+				},
+				webUrl: "https://jolli-team-zod7kvo1.atlassian.net/wiki/spaces/Engineerin/pages/557292/Per-Provider",
+			},
+		],
+	},
+};
+
+describe("normalizeConfluence", () => {
+	it("passes a string body through unchanged", () => {
+		const out = normalizeConfluence(STRING_BODY);
+		expect(out).not.toBeNull();
+		expect(out?.pageId).toBe("557292");
+		expect(out?.title).toBe("数据库访问架构变更设计：Per-Provider 连接池");
+		expect(out?.url).toBe(
+			"https://jolli-team-zod7kvo1.atlassian.net/wiki/spaces/Engineerin/pages/557292/Per-Provider",
+		);
+		expect(out?.body).toBe("## TL;DR\n\n1. 现状：per-(tenant, org) 连接池。");
+		expect(out?.space).toBe("Engineering");
+		expect(out?.author).toBe("Flyer Li");
+	});
+
+	it("flattens an ADF body to plain text", () => {
+		const out = normalizeConfluence(ADF_BODY);
+		expect(out?.body).toBe("## TL;DR\n\n1. 现状：每个 org 的 poolMax 配得越小。");
+	});
+
+	it("omits body when it is neither string nor flattenable", () => {
+		const out = normalizeConfluence({ content: { nodes: [{ id: "1", title: "t", webUrl: "u", body: 42 }] } });
+		expect(out?.body).toBeUndefined();
+	});
+
+	it("returns null when content is missing", () => {
+		expect(normalizeConfluence({})).toBeNull();
+		expect(normalizeConfluence({ content: {} })).toBeNull();
+		expect(normalizeConfluence({ content: { nodes: [] } })).toBeNull();
+		expect(normalizeConfluence({ content: { nodes: [42] } })).toBeNull();
+		expect(normalizeConfluence(null)).toBeNull();
+	});
+
+	it("does not null-check title/url (leaves them undefined for the definition to void)", () => {
+		const out = normalizeConfluence({ content: { nodes: [{ id: "1" }] } });
+		expect(out).not.toBeNull();
+		expect(out?.pageId).toBe("1");
+		expect(out?.title).toBeUndefined();
+		expect(out?.url).toBeUndefined();
+	});
+});
+```
+
+- [ ] **Step 2: Write the implementation** (`ConfluenceNormalize.ts`)
+
+```typescript
+/**
+ * ConfluenceNormalize — reshape a `getConfluencePage` MCP result into a canonical
+ * object the `confluence` SourceDefinition reads with plain `path` ops.
+ *
+ * The raw payload is `{ content: { nodes: [ node ] } }`; a single-page fetch
+ * yields exactly one node. The only field the DSL cannot handle itself is `body`,
+ * which is a markdown STRING under the default/"markdown" contentFormat but an
+ * ADF document OBJECT under "adf" — so this flattens ADF to text (the DSL's
+ * `path`/`transform` cannot: `transform` fns are `(string) => string`).
+ *
+ * "Normalize only normalizes": missing `title`/`url` are left undefined so the
+ * definition's `require` regexes void the reference — this layer only returns
+ * null for structurally unparseable input, and never throws.
+ */
+
+import { isObject } from "../guards.js";
+import { adfToText } from "./AdfToText.js";
+
+export interface ConfluenceCanonical {
+	readonly pageId?: string;
+	readonly title?: string;
+	readonly url?: string;
+	readonly body?: string;
+	readonly space?: string;
+	readonly author?: string;
+}
+
+function bodyToString(body: unknown): string | undefined {
+	const text = typeof body === "string" ? body : adfToText(body);
+	const trimmed = text.trim();
+	return trimmed.length > 0 ? text : undefined;
+}
+
+export function normalizeConfluence(rawResult: unknown): ConfluenceCanonical | null {
+	if (!isObject(rawResult)) return null;
+	const content = rawResult.content;
+	if (!isObject(content)) return null;
+	const nodes = content.nodes;
+	if (!Array.isArray(nodes) || nodes.length === 0) return null;
+	const node = nodes[0];
+	if (!isObject(node)) return null;
+
+	const pageId = typeof node.id === "string" ? node.id : undefined;
+	const title = typeof node.title === "string" ? node.title : undefined;
+	const url = typeof node.webUrl === "string" ? node.webUrl : undefined;
+	const body = bodyToString(node.body);
+	const space = isObject(node.space) && typeof node.space.name === "string" ? node.space.name : undefined;
+	const author =
+		isObject(node.author) && typeof node.author.displayName === "string" ? node.author.displayName : undefined;
+
+	return {
+		...(pageId !== undefined ? { pageId } : {}),
+		...(title !== undefined ? { title } : {}),
+		...(url !== undefined ? { url } : {}),
+		...(body !== undefined ? { body } : {}),
+		...(space !== undefined ? { space } : {}),
+		...(author !== undefined ? { author } : {}),
+	};
+}
+```
+
+Note on `bodyToString`: it trims to decide emptiness but returns the **untrimmed** original string (fidelity — preserve the page's leading/trailing structure), returning `undefined` only when the content is entirely whitespace.
+
+---
+
+## Task 3: The `confluence` SourceDefinition
+
+**Files:**
+- Create: `cli/src/core/references/sources/definitions/confluence.ts`
+- Test: `cli/src/core/references/sources/definitions/confluence.test.ts`
+
+**Interfaces:**
+- Consumes: `SourceDefinition` type from `../../SourceDefinition.js`; `extractRef` / `renderBlock` from `../../SourceEngine.js` (test only). Runs over the `ConfluenceCanonical` shape from Task 2.
+- Produces: `export const confluenceDefinition: SourceDefinition` (id `"confluence"`), consumed by Task 4's registry.
+
+- [ ] **Step 1: Write the failing test** (`confluence.test.ts`, mirrors `zoom-doc.test.ts`)
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { extractRef, renderBlock } from "../../SourceEngine.js";
+import { confluenceDefinition as def } from "./confluence.js";
+
+// The definition runs over the POST-normalize canonical shape (ConfluenceNormalize output).
+const CANONICAL = {
+	pageId: "557292",
+	title: "数据库访问架构变更设计：Per-Provider 连接池",
+	url: "https://jolli-team-zod7kvo1.atlassian.net/wiki/spaces/Engineerin/pages/557292/Per-Provider",
+	body: "## TL;DR\n\n1. 现状：per-(tenant, org) 连接池。",
+	space: "Engineering",
+	author: "Flyer Li",
+};
+const TOOL = "mcp__claude_ai_Atlassian__getConfluencePage";
+const AT = "2026-07-11T00:00:00Z";
+
+describe("confluence definition", () => {
+	it("extracts a Reference from the canonical shape", () => {
+		const ref = extractRef(def, CANONICAL, TOOL, AT);
+		expect(ref?.source).toBe("confluence");
+		expect(ref?.nativeId).toBe("557292");
+		expect(ref?.title).toBe("数据库访问架构变更设计：Per-Provider 连接池");
+		expect(ref?.url).toBe(CANONICAL.url);
+		expect(ref?.description).toContain("TL;DR");
+		expect(ref?.fields).toEqual([
+			{ key: "space", label: "Space", icon: "symbol-namespace", value: "Engineering" },
+			{ key: "author", label: "Author", icon: "account", value: "Flyer Li" },
+			{ key: "entity-type", label: "Type", icon: "symbol-class", value: "page" },
+		]);
+	});
+
+	it("voids when pageId (nativeId) is non-numeric", () => {
+		expect(extractRef(def, { ...CANONICAL, pageId: "abc" }, TOOL, AT)).toBeNull();
+	});
+
+	it("voids when the URL is not a wiki URL", () => {
+		expect(extractRef(def, { ...CANONICAL, url: "https://example.com/not-wiki" }, TOOL, AT)).toBeNull();
+	});
+
+	it("still extracts when body/space/author are absent (title+url suffice)", () => {
+		const ref = extractRef(def, { pageId: "1", title: "t", url: "https://x.atlassian.net/wiki/p/1" }, TOOL, AT);
+		expect(ref?.nativeId).toBe("1");
+		expect(ref?.description).toBeUndefined();
+	});
+
+	it("renders a <confluence-pages> block", () => {
+		const ref = extractRef(def, CANONICAL, TOOL, AT);
+		if (ref === null) throw new Error("expected ref");
+		const block = renderBlock(def, [ref]);
+		expect(block).toContain("<confluence-pages>");
+		expect(block).toContain("<content>");
+	});
+});
+```
+
+- [ ] **Step 2: Write the implementation** (`confluence.ts`)
+
+```typescript
+/**
+ * Confluence built-in source definition — captures the result of
+ * `mcp__claude_ai_Atlassian__getConfluencePage`.
+ *
+ * Runs over the canonical shape produced by `normalizeConfluence`
+ * (`{ pageId, title, url, body?, space?, author? }`), NOT the raw MCP payload:
+ * the normalizer flattens the ADF-vs-markdown `body` variance the DSL cannot
+ * express, so this reads plain `path` ops and needs no `wrapperKeys`.
+ *
+ * Ordering: jira's `match.claude` is prefix-only (`mcp__claude_ai_Atlassian__`)
+ * and matches every Atlassian tool. This def's `acceptSuffix: "getConfluencePage"`
+ * plus its position BEFORE jira in `BUILTIN_DEFINITIONS` routes page reads here
+ * and lets `getJiraIssue` fall through to jira.
+ */
+
+import type { SourceDefinition } from "../../SourceDefinition.js";
+
+// Any HTTPS host with a /wiki/ path. Stricter than jira's bare `^https?://`
+// (confirms a wiki link), looser than hard-coding atlassian.net (tolerates
+// custom domains / Data Center). The claude.ai connector is Cloud-only today.
+const WIKI_URL = "^https://[^/]+/wiki/";
+
+export const confluenceDefinition: SourceDefinition = {
+	id: "confluence",
+	label: "Confluence",
+	icon: "book",
+	match: {
+		claude: { prefixes: ["mcp__claude_ai_Atlassian__"], acceptSuffix: "getConfluencePage" },
+	},
+	wrapperKeys: [],
+	reference: {
+		nativeId: { pipe: [{ op: "path", path: "pageId" }], require: "^\\d+$" },
+		title: { pipe: [{ op: "path", path: "title" }], require: ".+" },
+		url: { pipe: [{ op: "path", path: "url" }], require: WIKI_URL },
+		description: { pipe: [{ op: "path", path: "body" }], optional: true },
+	},
+	fields: [
+		{ key: "space", label: "Space", icon: "symbol-namespace", pipe: [{ op: "path", path: "space" }] },
+		{ key: "author", label: "Author", icon: "account", pipe: [{ op: "path", path: "author" }] },
+		{ key: "entity-type", label: "Type", icon: "symbol-class", pipe: [{ op: "const", value: "page" }] },
+	],
+	storage: { nativeIdPathSafe: true },
+	render: {
+		wrapperTag: "confluence-pages",
+		itemTag: "page",
+		bodyTag: "content",
+		maxCharsPerReference: 30000,
+		maxTotalChars: 60000,
+	},
+};
+```
+
+Note: confirm against `SourceDefinition.ts` that `RenderSpec` exposes `maxCharsPerReference`/`maxTotalChars` (it does — `zoom-doc.ts` uses both). If a `fields`-with-empty-value renders an empty attribute you don't want, check `zoom-doc`/`jira` behavior; the absent-field test above pins the acceptable outcome.
+
+---
+
+## Task 4: Register the source (definitions + normalizer + type + tests)
+
+**Files:**
+- Modify: `cli/src/core/references/sources/definitions/index.ts:10-26`
+- Modify: `cli/src/core/references/ClaudeEnvelopeParser.ts` (imports; `CONTEXT_NORMALIZERS` ~268-293; the docstring ~259-267)
+- Modify: `cli/src/Types.ts:775`
+- Modify: `cli/src/core/references/SourceDefinitionRegistry.test.ts` (id-order assertion)
+
+**Interfaces:**
+- Consumes: `confluenceDefinition` (Task 3), `normalizeConfluence` (Task 2).
+- Produces: `confluence` resolvable via `getRegistry().match("claude", "mcp__claude_ai_Atlassian__getConfluencePage")`.
+
+- [ ] **Step 1: Register the definition BEFORE jira in `index.ts`**
+
+Add the import (alphabetical among the others, before `githubDefinition`):
+
+```typescript
+import { confluenceDefinition } from "./confluence.js";
+```
+
+Insert `confluenceDefinition` into `BUILTIN_DEFINITIONS` immediately before `jiraDefinition`:
+
+```typescript
+export const BUILTIN_DEFINITIONS = [
+	linearDefinition,
+	confluenceDefinition,
+	jiraDefinition,
+	githubDefinition,
+	notionDefinition,
+	slackDefinition,
+	zoomMeetingDefinition,
+	zoomDocDefinition,
+] as const;
+```
+
+Also update the file's header comment (lines 4-7): note that `confluence` precedes `jira` deliberately so its `acceptSuffix` wins the shared `mcp__claude_ai_Atlassian__` prefix before jira's catch-all.
+
+- [ ] **Step 2: Register the normalizer in `ClaudeEnvelopeParser.ts`**
+
+Add the import alongside the existing `normalizeZoomDoc` import:
+
+```typescript
+import { normalizeConfluence } from "./sources/ConfluenceNormalize.js";
+```
+
+Add an entry to `CONTEXT_NORMALIZERS` (after the `"zoom-doc"` entry). Confluence needs neither `toolInput` nor `env`, so ignore both params:
+
+```typescript
+	confluence: (payload) => normalizeConfluence(payload),
+```
+
+Broaden the `CONTEXT_NORMALIZERS` docstring so it matches its actual residents. Change the sentence:
+
+> "A source belongs here IFF its canonical shape needs out-of-payload context — the originating tool_use `input`, and/or parse-scoped state (permalink map, workspace url) — that the default `identity` path cannot supply."
+
+to:
+
+> "A source belongs here IFF the default `identity` path cannot produce its canonical shape — either because that shape needs out-of-payload context (the originating tool_use `input`, and/or parse-scoped state like the permalink map / workspace url), OR because it requires a payload-internal shape coercion the DSL cannot express (e.g. Confluence's ADF-object → string body flattening)."
+
+- [ ] **Step 3: Add `"confluence"` to `KnownSourceId` in `Types.ts:775`**
+
+```typescript
+export type KnownSourceId =
+	| "linear"
+	| "confluence"
+	| "jira"
+	| "github"
+	| "notion"
+	| "slack"
+	| "zoom-meeting"
+	| "zoom-doc";
+```
+
+(Order cosmetic — match the `BUILTIN_DEFINITIONS` order for readability.)
+
+- [ ] **Step 4: Update the id-order assertion in `SourceDefinitionRegistry.test.ts`**
+
+Find the assertion pinning `all()` / registry id order (the array `["linear","jira","github","notion","slack","zoom-meeting","zoom-doc"]`) and insert `"confluence"` after `"linear"`:
+
+```typescript
+["linear", "confluence", "jira", "github", "notion", "slack", "zoom-meeting", "zoom-doc"]
+```
+
+Add two routing-regression assertions in the same file (near the existing Atlassian/`match` cases):
+
+```typescript
+it("routes getConfluencePage to confluence and getJiraIssue to jira", () => {
+	const r = getRegistry();
+	expect(r.match("claude", "mcp__claude_ai_Atlassian__getConfluencePage")?.id).toBe("confluence");
+	expect(r.match("claude", "mcp__claude_ai_Atlassian__getJiraIssue")?.id).toBe("jira");
+});
+```
+
+---
+
+## Task 5: Full verification + single commit
+
+Per the commit-cadence constraint, this is the only task that runs the full suite and commits.
+
+- [ ] **Step 1: Run the full gate**
+
+```bash
+cd /Users/flyer/jolli/code/jollimemory
+npm run all
+```
+
+Expected: clean → build → lint → test all PASS. In particular:
+- `ConfluenceNormalize.test.ts`, `confluence.test.ts` PASS.
+- `CodexJiraBinding.test.ts` PASS (proves the `adfToText` extraction was behavior-preserving).
+- `SourceDefinitionRegistry.test.ts` PASS with the new id-order + routing assertions.
+- `bindings/claude/index.test.ts` PASS unchanged (CLAUDE_TOOL_PREFIXES dedupes the reused `mcp__claude_ai_Atlassian__` prefix — array is unchanged).
+- Coverage thresholds (97/96/97/97) hold.
+
+If `bindings/claude/index.test.ts` fails on a prefix-count assertion, inspect whether it counts entries vs unique prefixes; the reused prefix should not change a deduped list — reconcile before proceeding.
+
+- [ ] **Step 2: Commit once, with DCO sign-off, no AI co-author**
+
+```bash
+git add cli/src/core/references/sources/AdfToText.ts \
+        cli/src/core/references/sources/ConfluenceNormalize.ts \
+        cli/src/core/references/sources/ConfluenceNormalize.test.ts \
+        cli/src/core/references/sources/definitions/confluence.ts \
+        cli/src/core/references/sources/definitions/confluence.test.ts \
+        cli/src/core/references/sources/definitions/index.ts \
+        cli/src/core/references/ClaudeEnvelopeParser.ts \
+        cli/src/core/references/bindings/codex/CodexJiraBinding.ts \
+        cli/src/Types.ts \
+        cli/src/core/references/SourceDefinitionRegistry.test.ts
+git commit -s -m "feat(references): capture Confluence pages via Atlassian MCP (Claude path)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Passive capture / no MCP client → architecture note in header + Task 2/3 (read canonical shape). ✓
+- Matching + ordering (confluence before jira, acceptSuffix) → Task 3 (def) + Task 4 Step 1/4. ✓
+- SourceDefinition fields/render/URL require → Task 3 code verbatim. ✓
+- Normalizer + ADF flattening → Task 2. ✓
+- `adfToText` shared extraction, no behavior change → Task 1, guarded by existing test in Task 5. ✓
+- CONTEXT_NORMALIZERS registration + docstring broadening → Task 4 Step 2. ✓
+- KnownSourceId → Task 4 Step 3. ✓
+- Registry id-order test + routing guard → Task 4 Step 4. ✓
+- Real fixtures (string + ADF body) → Task 2 Step 1. ✓
+- CLAUDE_TOOL_PREFIXES unchanged (verify only) → Task 5 Step 1. ✓
+- Coverage floor + single end commit → Task 5. ✓
+- Codex explicitly deferred → not implemented (spec §8); no task. ✓
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"/"similar to Task N". All code steps carry full code. ✓
+
+**Type consistency:** `ConfluenceCanonical` fields (`pageId`/`title`/`url`/`body`/`space`/`author`) used identically in Task 2 (produce), Task 2 test, Task 3 def `path`s, and Task 3 test `CANONICAL`. `normalizeConfluence` signature matches its call in Task 4 Step 2. `adfToText` signature matches Task 1 produce + Task 2 consume. Tool name `mcp__claude_ai_Atlassian__getConfluencePage` consistent across Task 3 test, Task 4 routing test. ✓

--- a/docs/superpowers/specs/2026-07-11-confluence-reference-source-design.md
+++ b/docs/superpowers/specs/2026-07-11-confluence-reference-source-design.md
@@ -1,0 +1,253 @@
+# Confluence reference source (Claude path) — design
+
+**Date:** 2026-07-11
+**Status:** Approved, ready for implementation plan
+**Branch:** `feature/confluence-mcp-integration`
+
+## Summary
+
+Add a built-in `SourceDefinition` (`confluence`) that passively captures the
+result of `mcp__claude_ai_Atlassian__getConfluencePage` calls made by the user's
+Claude sessions and turns each into a `Reference` stored in memory. Body content
+is normalized to a plain string (markdown passed through; ADF flattened to text).
+Claude path only this iteration; Codex is a deferred follow-up (no real fixture
+yet — see §8).
+
+## Motivation
+
+The reference subsystem already captures Linear / Jira / GitHub / Notion / Slack /
+Zoom entities that an agent touched during a session and folds them into the
+memory context. Confluence pages are a first-class source of design/spec context
+in this org but are not captured today. When a Claude session reads a Confluence
+page via the Atlassian MCP connector, that page's title, URL, space, author, and
+body should become a durable reference like any other.
+
+## Architecture: passive capture, zero new I/O
+
+**jollimemory never calls MCP.** The Atlassian MCP host and OAuth are owned by
+Claude Code (the `mcp__claude_ai_Atlassian__` connector). The agent calls
+`getConfluencePage` *during a session*; the call + its result land in the session
+transcript JSONL. jollimemory reads that transcript after the fact
+(`ReferenceExtractor.extractReferencesFromTranscript`) and reconstructs a
+`Reference` from the recorded `tool_use` / `tool_result` pair.
+
+Consequence: this feature adds **no MCP client, no auth, no network code**. It is
+one new `SourceDefinition`, one normalizer, and a shared-helper extraction. When
+the Atlassian connector is unauthorized, the agent's tool call fails, the result
+payload carries no usable fields, the required-field `require` regexes don't match,
+and the reference simply voids — no crash (same behavior as every other MCP
+source; MCP entries are `requireSuccess: false`).
+
+Storage is unchanged: references persist through the existing `ReferenceStore`
+(active markdown at `<jolliMemoryDir>/references/confluence/<pageId>.md`) and the
+`SummaryStore` orphan-branch snapshot. No storage-layer changes.
+
+## Matching and ordering (the critical ordering gotcha)
+
+`jira.match.claude` is `prefixes: ["mcp__claude_ai_Atlassian__"]` with **no
+`acceptSuffix`** — it is the catch-all for every Atlassian MCP tool.
+`SourceDefinitionRegistry.match()` returns the *first* definition in
+`BUILTIN_DEFINITIONS` order whose prefix (and optional suffix) matches.
+
+Therefore:
+
+- `confluence.match.claude = { prefixes: ["mcp__claude_ai_Atlassian__"], acceptSuffix: "getConfluencePage" }`
+- **`confluenceDefinition` must be placed BEFORE `jiraDefinition`** in
+  `sources/definitions/index.ts` → `BUILTIN_DEFINITIONS`.
+
+Result: `getConfluencePage` → confluence matches first (prefix + suffix);
+`getJiraIssue` → confluence's suffix fails, falls through to jira (prefix-only).
+
+## Observed payload (real captures, 3 formats)
+
+`getConfluencePage` returns (verified against a live page, all three
+`contentFormat` values):
+
+```
+{ content: { totalCount, nodes: [ {
+    id: "557292",                 // numeric page id (string)
+    type: "page", status: "current",
+    title: "…",
+    summary: "…",
+    space: { key, name },
+    author: { displayName, avatarUrls },
+    _links: { webui },
+    lastModified: "17 minutes ago",   // relative text, NOT a usable timestamp
+    body: <string | ADF-object>,      // markdown string (default / "markdown");
+                                       // ADF object ({type:"doc",content:[…]}) when "adf"
+    webUrl: "https://…/wiki/spaces/…" // absolute
+} ] } }
+```
+
+- **default (omitted) and `markdown`**: `body` is a markdown **string**.
+- **`adf`**: `body` is an **object** (Atlassian Document Format AST).
+
+Real captures of all three shapes become test fixtures (§7).
+
+## The `confluence` SourceDefinition
+
+The normalizer (below) reshapes the raw payload into a single canonical object,
+mirroring `zoom-doc`, so the definition reads plain `path` ops and needs no
+`wrapperKeys`:
+
+```
+id: "confluence"
+label: "Confluence"
+icon: "book"
+match: { claude: { prefixes: ["mcp__claude_ai_Atlassian__"], acceptSuffix: "getConfluencePage" } }
+wrapperKeys: []
+reference:
+  nativeId:    { pipe: [{ op: "path", path: "pageId" }], require: "^\\d+$" }
+  title:       { pipe: [{ op: "path", path: "title"  }], require: ".+" }
+  url:         { pipe: [{ op: "path", path: "url"    }], require: "^https://[^/]+/wiki/" }
+  description: { pipe: [{ op: "path", path: "body"   }], optional: true }
+fields:
+  - { key: "space",       label: "Space",  icon: "symbol-namespace", pipe: [{ op: "path", path: "space"  }] }
+  - { key: "author",      label: "Author", icon: "account",          pipe: [{ op: "path", path: "author" }] }
+  - { key: "entity-type", label: "Type",   icon: "symbol-class",     pipe: [{ op: "const", value: "page" }] }
+storage: { nativeIdPathSafe: true }          // numeric id is path-safe
+render:
+  wrapperTag: "confluence-pages"
+  itemTag: "page"
+  bodyTag: "content"
+  maxCharsPerReference: 30000                 // long-form, same tier as notion / zoom-doc
+  maxTotalChars: 60000
+```
+
+**URL `require` decision:** `^https://[^/]+/wiki/` — any HTTPS host with a `/wiki/`
+path. Stricter than jira's bare `^https?://` (confirms it is a wiki link), looser
+than hard-coding `atlassian.net` (does not exclude future custom domains / Data
+Center). May be tightened to `\\.atlassian\\.net/wiki/` later, since the claude.ai
+Atlassian connector is Cloud-only today.
+
+## Normalizer + shared `adfToText`
+
+### `sources/ConfluenceNormalize.ts` (new)
+
+Contract mirrors `ZoomDocNormalize` — returns `null` on anything unparseable (the
+caller voids the reference); never throws.
+
+```
+interface ConfluenceCanonical {
+  readonly pageId: string
+  readonly title: string
+  readonly url: string
+  readonly body?: string
+  readonly space?: string
+  readonly author?: string
+}
+
+normalizeConfluence(rawResult): ConfluenceCanonical | null
+  1. !isObject(rawResult)            → null
+  2. content = rawResult.content; !isObject(content) → null
+  3. nodes = content.nodes; !Array.isArray(nodes) || length === 0 → null
+  4. node = nodes[0]; !isObject(node) → null   // getConfluencePage(pageId) → exactly 1 node
+  5. pageId = node.id, title = node.title, url = node.webUrl
+     — do NOT null-check title/url here; let the definition's `require` void it
+       (keep "normalize only normalizes")
+  6. body = typeof node.body === "string" ? node.body : adfToText(node.body)
+     — empty/whitespace → undefined
+  7. space = node.space?.name, author = node.author?.displayName (optional)
+  return { pageId, title, url, body?, space?, author? }
+```
+
+### `sources/AdfToText.ts` (new — extracted, no behavior change)
+
+`adfToText` currently lives privately in
+`bindings/codex/CodexJiraBinding.ts`. It is agent-agnostic and body-format-generic
+(handles heading / paragraph / list / blockquote / codeBlock / text; unknown
+nodes concatenate children). Move it verbatim to `sources/AdfToText.ts`;
+`CodexJiraBinding.ts` imports it and deletes its local copy. **Pure move, zero
+behavior change** — the existing `CodexJiraBinding.test.ts` guards against
+regression.
+
+### Registration in `ClaudeEnvelopeParser.ts`
+
+Add to `CONTEXT_NORMALIZERS`:
+
+```
+"confluence": (payload) => normalizeConfluence(payload),   // ignores toolInput / env
+```
+
+`CONTEXT_NORMALIZER_IDS` is derived from `Object.keys(CONTEXT_NORMALIZERS)` — no
+manual edit.
+
+**Docstring honesty note:** `CONTEXT_NORMALIZERS` is documented as the home for
+sources whose canonical shape "needs out-of-payload context (the originating
+`tool_use` input, and/or parse-scoped state)". Confluence needs neither — it lives
+here purely for an ADF-object → string **type coercion** the DSL cannot express
+(`path` returns the object; `transform` fns are `(string) => string`). Broaden the
+docstring from "needs out-of-payload context" to "…**or a payload-internal shape
+coercion the DSL cannot express**", so the registry's stated boundary matches its
+actual residents.
+
+## Ripple list (every touched file)
+
+**New**
+
+- `cli/src/core/references/sources/definitions/confluence.ts`
+- `cli/src/core/references/sources/ConfluenceNormalize.ts`
+- `cli/src/core/references/sources/AdfToText.ts`
+- `cli/src/core/references/sources/definitions/confluence.test.ts`
+- `cli/src/core/references/sources/ConfluenceNormalize.test.ts`
+
+**Modified**
+
+- `cli/src/core/references/sources/definitions/index.ts` — import + insert into
+  `BUILTIN_DEFINITIONS` **before jira**
+- `cli/src/core/references/ClaudeEnvelopeParser.ts` — add confluence to
+  `CONTEXT_NORMALIZERS`; broaden the docstring
+- `cli/src/core/references/bindings/codex/CodexJiraBinding.ts` — delete local
+  `adfToText`, import from `AdfToText.ts`
+- `cli/src/Types.ts` — add `"confluence"` to `KnownSourceId` (cosmetic; runtime
+  uses the registry)
+- `cli/src/core/references/SourceDefinitionRegistry.test.ts` — add `"confluence"`
+  to the id-order assertion, positioned before `"jira"`
+
+**Verified NOT to require changes**
+
+- `CLAUDE_TOOL_PREFIXES` — reuses the existing `mcp__claude_ai_Atlassian__` prefix
+  (already contributed by jira); deduped array unchanged. Re-run
+  `bindings/claude/index.test.ts` to confirm.
+- Storage layer, MCP server tool set, folder layout.
+
+## Testing & fixtures
+
+- **Real fixtures**: the three live `getConfluencePage` captures (string body ×2,
+  ADF-object body ×1) pinned as fixtures (per the hard rule: external-data parsers
+  must be anchored to a real capture, never a hand-authored one).
+- `ConfluenceNormalize.test.ts`: string body passes through unchanged; ADF body
+  flattens to text preserving headings/list markers/inline `code`; malformed
+  shapes (`content` missing, empty `nodes`, non-object node) → `null`.
+- `confluence.test.ts`: fed a normalizer output, asserts
+  nativeId/title/url/description/fields; a non-wiki URL voids; a `getJiraIssue`
+  tool name does NOT get captured by confluence (ordering regression guard).
+- CLI coverage floor (97% statements / 96% branches / 97% functions / 97% lines)
+  held — new code must add zero uncovered gaps.
+- `npm run all` once at the end (clean → build → lint → test), not per-task.
+
+## Codex follow-up (explicitly NOT this iteration)
+
+Codex/Rovo Atlassian payloads are a completely different shape from Claude's
+(`{issues:{nodes:[…]}}`, field values under `versionedRepresentations`, `webUrl`
+top-level, ADF description) — the `CodexJiraBinding` shape was derived from a real
+Codex Jira capture. **No real Codex Confluence transcript exists in the repo**, and
+it is unconfirmed whether Codex's Rovo connector even exposes a Confluence-page-read
+tool. Building a Codex binding now would mean guessing the tool name, namespace, and
+payload shape — the exact self-consistent-but-wrong trap the real-fixture rule
+forbids.
+
+When a real Codex Confluence transcript (the `function_call_output` JSON) is
+available, add:
+
+- `confluence.match.codex` (namespace + function-call / invocation names from the
+  real capture)
+- `cli/src/core/references/bindings/codex/CodexConfluenceBinding.ts` (reusing the
+  now-shared `AdfToText.ts`)
+
+## Out of scope
+
+- Proactive fetching (jollimemory calling MCP/API itself) — rejected in favor of
+  passive capture, consistent with every existing source.
+- Confluence search / space-listing / comment tools — only `getConfluencePage`.
+- Codex support — deferred (above).

--- a/vscode/src/views/SourceLabels.ts
+++ b/vscode/src/views/SourceLabels.ts
@@ -39,6 +39,7 @@ export interface SourceMeta {
  */
 export const SOURCE_META: Record<KnownSourceId, SourceMeta> = {
 	linear: { label: "Linear", letter: "L", icon: "issues", color: "#5e6ad2" },
+	confluence: { label: "Confluence", letter: "C", icon: "book", color: "#1868DB" },
 	jira: { label: "Jira", letter: "J", icon: "issues", color: "#0052cc" },
 	github: { label: "GitHub", letter: "G", icon: "issues", color: "#6e7681" },
 	notion: { label: "Notion", letter: "N", icon: "file-text", color: "#787774" },


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (2)

1. Add Confluence as first-class reference source; fix jira for codex (`1303d3e`)
2. Support flat Confluence page nodes from Codex Rovo envelope (`a116c66`)

## Quick recap (2)

### Commit 1 of 2: Add Confluence as first-class reference source; fix jira for codex (`1303d3e`)

The developer added Confluence as a first-class reference source in the system, enabling passive capture of Confluence pages that Claude sessions read via the Atlassian MCP connector. Pages are now normalized from both markdown and Atlassian Document Format bodies into a canonical reference shape, with fields for space, author, content type, and page metadata. The integration reuses the existing passive transcript-reading pattern — no new network code or authentication required — and automatically extracts page title, URL, space, author, and body content into durable references.

The Codex integration for Atlassian Rovo was completed by adding bindings for both Confluence and Jira. Rovo's `_getconfluencepage` tool output flows through the same normalizer as Claude's path, while Jira issues arriving via Rovo's generic `_fetch` tool are reshaped into the canonical form the Jira definition expects. Both integrations were grounded in real Codex transcripts captured during a live rollout, replacing earlier unverified assumptions about tool names and payload shapes. The implementation includes comprehensive edge-case coverage and passes all reference tests with high coverage across the modified files.

A shared ADF-to-plaintext conversion helper was extracted and reused by both Jira and Confluence sources, eliminating code duplication and ensuring consistent rendering across both sources. The Jira reference URL issue was addressed by documenting that the REST API endpoint returned by Rovo is not human-browsable; the tenant site name needed to reconstruct a `/browse/` link is absent from the envelope, so the API URL is preserved as-is rather than voiding the reference. A known architectural gap was also documented: the generic `_fetch` tool can return Confluence pages, but the current name-based routing layer cannot dispatch by payload type, causing such pages to be dropped when fetched through that path. This gap is deferred to future work pending a deeper change to the shared tool dispatcher.

### Commit 2 of 2: Support flat Confluence page nodes from Codex Rovo envelope (`a116c66`)

The developer fixed a production bug where Codex's Confluence page captures were being silently dropped while Claude's identical logical data worked correctly. The root cause was a mismatch between two envelope shapes: Codex's Rovo integration returns a flat page object, but the normalizer only recognized the wrapped `{content:{nodes:[…]}}` structure that Claude uses. The normalizer now accepts both shapes, and the test fixture was updated to match the real flat shape captured from live rollouts rather than a self-consistent but incorrect wrapped shape. Confluence pages fetched through Codex now capture successfully, with space and author fields left undefined when the source provides only opaque IDs rather than human-readable names.

## Topics (6)
<details>
<summary><strong>01 · [1303d3e] Add Confluence as first-class reference source with passive MCP capture</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The reference subsystem captures entities from Linear, Jira, GitHub, Notion, Slack, and Zoom that agents interact with during sessions, but Confluence pages were not being captured despite being a primary source of design and specification context in the organization.

**💡 Decisions Behind the Code**

- **Passive capture over proactive fetching**: The design reuses the existing passive transcript-reading pattern (no new MCP client, no auth, no network code) rather than adding jollimemory's own API calls. This keeps the feature lightweight, consistent with every other reference source, and avoids duplicating the Atlassian OAuth and connector logic already owned by Claude Code.
- **Dedicated function claim over generic `_fetch`**: Confluence pages are claimed via the specific `_getconfluencepage` function rather than the shared `_fetch` tool. This avoids routing ambiguity — the generic `_fetch` can return either Jira or Confluence entities, and name-based matching cannot dispatch by payload type. Claiming the dedicated function guarantees Confluence pages are always captured.
- **Ordering-first matching strategy**: Confluence is placed before Jira in the definition registry and uses an `acceptSuffix` constraint to distinguish `getConfluencePage` from other Atlassian tools. This avoids a catch-all Jira matcher that would swallow Confluence results, and ensures the first-match-wins registry lookup returns the correct source without requiring a more complex matching algorithm.
- **Normalizer-level ADF coercion**: The normalizer handles the conversion from ADF objects to plain text via the shared `adfToText` helper rather than pushing that responsibility into the DSL. The DSL's `path` and `transform` operators cannot express object-to-string coercion, so the normalizer absorbs this shape mismatch, keeping the definition's field mappings simple and readable.
- **Content-type field with fallback**: The entity-type field reads the real content type from the payload (page, blogpost, etc.) and falls back to "page" when absent. This handles both current and older/leaner payload captures without breaking, and uses the codebase's standard `coalesce` DSL pattern rather than hardcoding the default in imperative code.

**✅ What Was Implemented**

- Designed and implemented a new built-in source definition for Confluence that passively captures results from `getConfluencePage` calls made by Claude sessions and converts them into stored references with pageId, title, url, body, space, and author metadata.
- Created a normalizer that reshapes raw MCP payloads into canonical form, handling both markdown string bodies and Atlassian Document Format (ADF) object bodies by flattening ADF to plain text.
- Extracted a shared `adfToText` helper into a standalone module for reuse across Confluence and Jira sources, eliminating code duplication and ensuring consistent ADF rendering.
- Registered Confluence in the reference pipeline before Jira in the source definition registry to ensure `getConfluencePage` tool calls match Confluence first while `getJiraIssue` falls through to Jira, avoiding a catch-all matcher that would swallow Confluence results.
- Added Confluence metadata to the VS Code source labels registry with label, icon, and color for consistent UI display alongside other supported sources.
- Extended the Confluence definition to carry content type (page, blogpost, etc.) through the normalizer and reflect it in reference fields, with a fallback to "page" for older payload captures that omit the type.

**📁 FILES**
- `cli/src/core/references/sources/AdfToText.ts`
- `cli/src/core/references/sources/ConfluenceNormalize.ts`
- `cli/src/core/references/sources/definitions/confluence.ts`
- `cli/src/core/references/bindings/codex/CodexConfluenceBinding.ts`
- `cli/src/Types.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [1303d3e] Add Confluence and Jira bindings for Atlassian Rovo codex integration</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Codex's built-in Atlassian Rovo app was producing tool calls for Confluence and Jira, but the reference extraction system had no matchers or normalizers to recognize and process them, leaving both sources unable to populate the context window.

**💡 Decisions Behind the Code**

- **Real transcript over fabricated fixtures**: Prior Jira matcher values were unverified assumptions that did not match actual Rovo app behavior. The developer captured true Codex output from a live rollout and used it as the source of truth for both matcher values and test cases, preventing the self-consistent-but-wrong pattern that had plagued earlier reference integrations.
- **Guard on entity type rather than tool name**: Rovo's generic `_fetch` tool can return multiple entity types (Jira issues, Confluence pages, etc.). Rather than try to disambiguate by tool name alone, the Jira binding gates its reshape logic on `type: "jira-issue"`, allowing non-Jira entities to pass through unreshaped and fail gracefully on the definition's required fields. This avoids misattributing Confluence entities fetched through `_fetch` to the Jira source.
- **Confluence reuses Claude normalizer**: Rovo's `_getconfluencepage` output is byte-identical to Claude's `getConfluencePage` response, so the Confluence binding simply delegates to the existing normalizer rather than duplicating logic. This reduces maintenance surface and confirms that the two paths are truly equivalent.
- **Retain unverified legacy paths**: The legacy `_getjiraissue` shape was retained rather than deleted because no real transcript has ever confirmed whether it exists in any Rovo version. Deleting it would risk breaking support if it does exist; keeping it costs nothing as a fallback path and documents the uncertainty explicitly via code comments.

**✅ What Was Implemented**

- Added a Confluence binding to normalize Rovo's `_getconfluencepage` output by reusing the existing `normalizeConfluence` function without modification, since Rovo's response shape matches Claude's exactly.
- Extended the Jira matcher to recognize Rovo's generic `_fetch` tool (in addition to the unverified legacy `_getjiraissue`) and added a Jira binding to reshape the flat `{id, title, text, url, type, metadata}` entity envelope into the canonical `{key, fields, webUrl}` form that the Jira definition expects.
- Registered both bindings in the Codex normalizer registry and added real-world test cases derived from a live Rovo rollout to verify end-to-end extraction.
- Added comprehensive edge-case coverage including minimal payloads with only type and id, missing key extraction, and metadata coercion scenarios, achieving 97%+ coverage across modified binding files.

**📁 FILES**
- `cli/src/core/references/bindings/codex/CodexConfluenceBinding.ts`
- `cli/src/core/references/bindings/codex/CodexJiraBinding.ts`
- `cli/src/core/references/sources/definitions/jira.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [1303d3e] Fix Jira reference URL and document Codex `_fetch` routing gap</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Codex Jira binding's `_fetch` path was producing REST API URLs instead of human-browsable issue links, and the generic `_fetch` tool can fetch Confluence pages but they were being silently dropped because the routing layer could not dispatch by payload type.

**💡 Decisions Behind the Code**

The decision to keep the non-browsable API URL and document the `_fetch` routing gap reflects a pragmatic trade-off between immediate utility and architectural cleanup. Removing the reference entirely would lose useful metadata (issue ID, title, description, status, priority); keeping the API URL preserves that value even though it is not directly clickable. The `_fetch` routing gap is a pre-existing architectural limitation (name-based matching cannot dispatch by payload type) that affects both Jira and Confluence — fixing it properly requires a deeper change to the shared tool dispatcher, which is deferred. Documenting both issues prevents future developers from assuming the gaps are already solved.

**✅ What Was Implemented**

- Clarified the Jira reference URL in the Codex binding with an explicit comment stating that the returned URL is the non-browsable REST endpoint, not a `/browse/<KEY>` link. The tenant site name needed to reconstruct a browse link is absent from the envelope (only `cloudId` is present), so the API URL is kept as-is rather than voiding the reference.
- Documented the known gap in both Jira and Confluence definitions: the generic `_fetch` tool can return Confluence pages, but they route to the Jira definition by tool name, fail the Jira-specific validation, and are dropped. Proper per-payload-`type` dispatch of the shared `_fetch` is deferred to future work.

**📋 Future Enhancements**

Implement per-payload-type dispatch for the shared `_fetch` tool to properly route Confluence pages fetched through Rovo's generic endpoint.

**📁 FILES**
- `cli/src/core/references/bindings/codex/CodexJiraBinding.ts`
- `cli/src/core/references/sources/definitions/jira.ts`
- `cli/src/core/references/sources/definitions/confluence.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [1303d3e] Broaden context-normalizer documentation to reflect payload coercion patterns</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The inline comment documenting context-normalizer use cases was too narrow and did not reflect the full range of reasons a source might need a context-normalizer, particularly payload-internal shape coercion that the DSL cannot express.

**💡 Decisions Behind the Code**

The comment was broadened rather than replaced entirely to preserve the existing explanation of out-of-payload context while adding the new dimension. This keeps the comment honest with the declaration docstring and ensures future maintainers understand both reasons a source might bypass the identity path, reducing the risk that a new source's normalizer would be misunderstood as purely context-driven when it actually performs DSL-inexpressible coercion.

**✅ What Was Implemented**

Updated the inline comment at `ClaudeEnvelopeParser.ts:372` to document both categories of context-normalizer use: sources needing out-of-payload context (tool_use input, parse-scoped state like permalink maps) AND sources needing payload-internal shape coercion that the DSL cannot express. Confluence's ADF-to-string body flattening is cited as a concrete example of the latter.

**📁 FILES**
- `cli/src/core/references/ClaudeEnvelopeParser.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [1303d3e] Correct Confluence URL pattern documentation and scope</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The comment on the Confluence URL regex claimed the pattern "tolerates Data Center," but Data Center uses a different URL layout, making the claim inaccurate.

**💡 Decisions Behind the Code**

Correcting the comment prevents future developers from assuming Data Center support exists or from attempting to extend the pattern to cover `/display/` URLs without understanding the architectural constraint. The Codex connector is Cloud-only by design, and the URL pattern should reflect that scope accurately.

**✅ What Was Implemented**

Updated the comment on the URL pattern to clarify that the pattern confirms a Cloud wiki link and tolerates Cloud custom domains (which keep the `/wiki/` prefix). Removed the false claim about Data Center support and explicitly stated that Data Center's `/display/` URL layout is intentionally out of scope, since the Codex connector is Cloud-only.

**📁 FILES**
- `cli/src/core/references/sources/definitions/confluence.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · [a116c66] Support flat Confluence page nodes from Codex Rovo envelope</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Codex's Atlassian Rovo integration was returning Confluence pages in a flat shape that the normalizer rejected, causing all Codex-sourced Confluence pages to be silently dropped. Meanwhile, Claude's Confluence tool returned the same logical data in a wrapped shape that worked correctly, creating an asymmetry where the two paths appeared identical in tests but failed in production.

**💡 Decisions Behind the Code**

- **Flat node identification by top-level `content` key**: The wrapped shape is unambiguously marked by a top-level `content` object (which flat nodes never have — they keep body under `body`), so the resolver commits to the wrapped path once it sees `content` and never falls through. This avoids false positives and keeps the logic simple.
- **Leave space/author undefined rather than surface opaque IDs**: Flat nodes from Rovo carry only `spaceId` and `authorId` (numeric and UUID strings), not the human-readable `space.name` and `author.displayName` objects that Claude provides. Rather than display raw IDs in the UI, these fields are left undefined, which the definition's `require` regexes already handle by voiding the reference if critical fields are missing.
- **Fixture must match real rollout shape, not self-consistent test shape**: The original fixture was wrapped and included `space`/`author` objects, making tests pass while real Codex output failed. By capturing the actual flat shape from live 2026-07 rollouts and updating the test to use the real `mcp_tool_call_end` event path, the test now guards against the exact failure mode that occurred in production.

**✅ What Was Implemented**

- Modified `ConfluenceNormalize.ts` to accept both envelope shapes: extracted the node-resolution logic into a new `resolveNode` function that recognizes either the wrapped `{content:{nodes:[…]}}` structure (Claude) or a flat page object with `id` plus `title`/`webUrl` (Codex). Field extraction logic remains unchanged, so flat nodes without `space`/`author` objects naturally yield undefined for those display fields rather than surfacing opaque IDs.
- Updated `CodexEnvelopeParser.test.ts` fixture `ROVO_CONFLUENCE` from the wrapped shape to the real flat shape captured from live 2026-07 rollouts, and changed the test to exercise the actual `mcp_tool_call_end` event path that Codex uses. Added assertions that `space` and `author` fields are undefined when the flat node carries only `spaceId`/`authorId` IDs.
- Added four new unit tests to `ConfluenceNormalize.test.ts` covering flat node capture, ADF body flattening on flat nodes, webUrl-only identification, and rejection of unparseable objects. These tests verify the normalizer handles both shapes correctly and that missing display objects do not cause failures.

**📁 FILES**
- `cli/src/core/references/sources/ConfluenceNormalize.ts`
- `cli/src/core/references/sources/ConfluenceNormalize.test.ts`
- `cli/src/core/references/CodexEnvelopeParser.test.ts`
- `cli/src/core/references/bindings/codex/CodexConfluenceBinding.ts`
- `cli/src/core/references/sources/definitions/confluence.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 13, 2026 at 5:06 PM · via Anthropic*
<!-- jollimemory-summary-end -->
