### PR TITLE
Add Asana task reference capture and display

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -780,7 +780,8 @@ export type KnownSourceId =
 	| "notion"
 	| "slack"
 	| "zoom-meeting"
-	| "zoom-doc";
+	| "zoom-doc"
+	| "asana";
 
 /**
  * ReferenceField — one displayable field produced by a `SourceDefinition`'s `fields` pipes.

--- a/cli/src/core/references/CodexEnvelopeParser.test.ts
+++ b/cli/src/core/references/CodexEnvelopeParser.test.ts
@@ -210,6 +210,23 @@ const ROVO_JIRA_REST = {
 		labels: [],
 	},
 };
+// Real `codex_apps` Asana `get_task` output (2026-07-12 rollout, trimmed to the
+// fields the asana def reads plus a couple of the extra keys that ride along):
+// the connector wraps the task in a top-level `data` key — byte-identical to the
+// Claude Asana MCP shape — so it is fed BARE (no text-envelope) and consumed via
+// the def's own `wrapperKeys:["data"]`. `assignee` is null here (verbatim from the
+// rollout); the assignee-present branch is covered by asana.test.ts.
+const ASANA = {
+	data: {
+		gid: "1216474542361983",
+		name: "Add Asana MCP integration",
+		notes: "Add Asana MCP integration for Claude Code and Codex",
+		permalink_url: "https://app.asana.com/1/1216474500374769/project/1216474339608643/task/1216474542361983",
+		assignee: null,
+		completed: false,
+		resource_type: "task",
+	},
+};
 
 describe("CodexEnvelopeParser.parse", () => {
 	it("emits one NormalizedToolResult per source via the PRIMARY function_call pair, with canonical toolName + matched adapter", () => {
@@ -332,6 +349,40 @@ describe("CodexEnvelopeParser.parse", () => {
 		const lines = [
 			fnCall("mcp__codex_apps__linear", "_list_teams", "c_list"),
 			fnOutput("c_list", { teams: [] }, { wrap: "array", prefix: true }),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results).toHaveLength(0);
+	});
+
+	it("resolves the codex Asana get_task pair (PRIMARY path) to the asana def with canonical toolName", () => {
+		// Real rollout shape: name `_get_task` under namespace `mcp__codex_apps__asana`,
+		// bare `{data:{…}}` output behind the `Wall time:` prefix.
+		const lines = [
+			fnCall("mcp__codex_apps__asana", "_get_task", "c_asana"),
+			fnOutput("c_asana", ASANA, { wrap: "bare", prefix: true }),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results).toHaveLength(1);
+		expect(results[0].def.id).toBe("asana");
+		expect(results[0].toolName).toBe("mcp__claude_ai_Asana__get_task");
+		// normalize is identity — the `{data:{…}}` wrapper is preserved for the def's wrapperKeys.
+		expect((results[0].payload as { data?: { gid?: string } }).data?.gid).toBe("1216474542361983");
+	});
+
+	it("falls back to the mcp_tool_call_end event for Asana via the dotted invocation tool", () => {
+		const lines = [
+			fnCall("mcp__codex_apps__asana", "_get_task", "c_asana_evt"),
+			toolCallEnd("asana.get_task", "c_asana_evt", ASANA),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results).toHaveLength(1);
+		expect(results[0].def.id).toBe("asana");
+	});
+
+	it("ignores an Asana enumeration call (get_my_tasks) even under the asana namespace", () => {
+		const lines = [
+			fnCall("mcp__codex_apps__asana", "_get_my_tasks", "c_asana_list"),
+			fnOutput("c_asana_list", { data: [] }, { wrap: "bare", prefix: true }),
 		];
 		const { results } = codexEnvelopeParser.parse(lines, {});
 		expect(results).toHaveLength(0);
@@ -664,12 +715,14 @@ describe("CodexEnvelopeParser end-to-end via extractReferencesFromTranscript (so
 			// A dedicated getJiraIssue with only `self` (no webUrl), via the real
 			// `atlassian_rovo.getJiraIssue` event — captured with self mapped to url.
 			toolCallEnd("atlassian_rovo.getJiraIssue", "c_jira_nourl", JIRA_BARE_NO_URL),
+			fnCall("mcp__codex_apps__asana", "_get_task", "c_asana"),
+			fnOutput("c_asana", ASANA, { wrap: "bare", prefix: true }),
 		];
 		writeFileSync(file, `${lines.join("\n")}\n`, "utf-8");
 	});
 	afterAll(() => rmSync(dir, { recursive: true, force: true }));
 
-	it("extracts correct refs for all four sources through the unchanged adapters", async () => {
+	it("extracts correct refs for all five sources through the unchanged adapters", async () => {
 		const { references } = await extractReferencesFromTranscript(file, { source: "codex" });
 		const byKey = new Map(references.map((r) => [r.mapKey, r]));
 
@@ -689,6 +742,12 @@ describe("CodexEnvelopeParser end-to-end via extractReferencesFromTranscript (so
 		// The getJiraIssue with only `self` is now captured, with `self` as its url
 		// (the api.atlassian.com endpoint — no browsable link is available).
 		expect(byKey.get("jira:KAN-9")?.url).toBe("https://api.atlassian.com/ex/jira/29e34fb0/rest/api/3/issue/10099");
+
+		// Asana: the `{data:{…}}` output flows through the identity binding and the
+		// def's wrapperKeys to a task ref with title/url/nativeId from gid.
+		const asana = byKey.get("asana:1216474542361983");
+		expect(asana?.title).toBe("Add Asana MCP integration");
+		expect(asana?.url).toBe(ASANA.data.permalink_url);
 	});
 });
 

--- a/cli/src/core/references/SourceDefinitionRegistry.test.ts
+++ b/cli/src/core/references/SourceDefinitionRegistry.test.ts
@@ -48,17 +48,7 @@ describe("SourceDefinitionRegistry", () => {
 			getRegistry()
 				.all()
 				.map((d) => d.id),
-		).toEqual([
-			"linear",
-			"confluence",
-			"jira",
-			"github",
-			"notion",
-			"slack",
-			"zoom-meeting",
-			"zoom-doc",
-			"asana",
-		]);
+		).toEqual(["linear", "confluence", "jira", "github", "notion", "slack", "zoom-meeting", "zoom-doc", "asana"]);
 	});
 
 	it("routes getConfluencePage to confluence and getJiraIssue to jira", () => {
@@ -359,6 +349,18 @@ describe("SourceDefinitionRegistry", () => {
 			expect(r.match("claude", "mcp__claude_ai_Asana__get_my_tasks")).toBeUndefined();
 			expect(r.match("claude", "mcp__claude_ai_Asana__search_tasks")).toBeUndefined();
 			expect(r.match("claude", "mcp__claude_ai_Asana__create_task_confirm")).toBeUndefined();
+		});
+		it("resolves the codex get_task via both the function_call and invocation paths", () => {
+			const r = getRegistry();
+			expect(r.match("codex", "_get_task", "asana")?.id).toBe("asana"); // function_call path
+			expect(r.match("codex", "asana.get_task")?.id).toBe("asana"); // invocation-tool path (dotted, verbatim)
+		});
+		it("does NOT match codex enumeration/write tools or a mistyped invocation name", () => {
+			const r = getRegistry();
+			expect(r.match("codex", "_get_tasks", "asana")).toBeUndefined();
+			expect(r.match("codex", "_get_my_tasks", "asana")).toBeUndefined();
+			expect(r.match("codex", "_search_tasks", "asana")).toBeUndefined();
+			expect(r.match("codex", "asana_get_task")).toBeUndefined(); // underscore, not the real dotted tool
 		});
 	});
 });

--- a/cli/src/core/references/SourceDefinitionRegistry.test.ts
+++ b/cli/src/core/references/SourceDefinitionRegistry.test.ts
@@ -43,12 +43,22 @@ describe("SourceDefinitionRegistry", () => {
 		expect(r.match("codex", "linear.get_issue")?.id).toBe("linear"); // invocation-tool path (no namespace)
 	});
 
-	it("all() is stable order linear,confluence,jira,github,notion,slack,zoom-meeting,zoom-doc", () => {
+	it("all() is stable order linear,confluence,jira,github,notion,slack,zoom-meeting,zoom-doc,asana", () => {
 		expect(
 			getRegistry()
 				.all()
 				.map((d) => d.id),
-		).toEqual(["linear", "confluence", "jira", "github", "notion", "slack", "zoom-meeting", "zoom-doc"]);
+		).toEqual([
+			"linear",
+			"confluence",
+			"jira",
+			"github",
+			"notion",
+			"slack",
+			"zoom-meeting",
+			"zoom-doc",
+			"asana",
+		]);
 	});
 
 	it("routes getConfluencePage to confluence and getJiraIssue to jira", () => {
@@ -336,6 +346,19 @@ describe("SourceDefinitionRegistry", () => {
 		it("resolves hub_get_file_content to zoom-doc", () => {
 			const def = getRegistry().match("claude", "mcp__claude_ai_Zoom_for_Claude__hub_get_file_content");
 			expect(def?.id).toBe("zoom-doc");
+		});
+	});
+
+	describe("asana registration", () => {
+		it("resolves get_task to asana", () => {
+			expect(getRegistry().match("claude", "mcp__claude_ai_Asana__get_task")?.id).toBe("asana");
+		});
+		it("does NOT match enumeration or write tools (suffix gate)", () => {
+			const r = getRegistry();
+			expect(r.match("claude", "mcp__claude_ai_Asana__get_tasks")).toBeUndefined();
+			expect(r.match("claude", "mcp__claude_ai_Asana__get_my_tasks")).toBeUndefined();
+			expect(r.match("claude", "mcp__claude_ai_Asana__search_tasks")).toBeUndefined();
+			expect(r.match("claude", "mcp__claude_ai_Asana__create_task_confirm")).toBeUndefined();
 		});
 	});
 });

--- a/cli/src/core/references/bindings/claude/index.test.ts
+++ b/cli/src/core/references/bindings/claude/index.test.ts
@@ -5,7 +5,7 @@ describe("Claude producer binding", () => {
 	describe("CLAUDE_TOOL_PREFIXES", () => {
 		it("lists every vendor prefix for the envelope pre-filter, de-duplicated (both Linear prefixes included; Zoom prefix appears once even though zoom-meeting and zoom-doc both declare it)", () => {
 			// Order follows BUILTIN_DEFINITIONS (linear, jira, github, notion, slack,
-			// zoom-meeting, zoom-doc) — derived from the SourceDefinitionRegistry.
+			// zoom-meeting, zoom-doc, asana) — derived from the SourceDefinitionRegistry.
 			// zoom-meeting and zoom-doc share the same Claude MCP prefix, so
 			// CLAUDE_TOOL_PREFIXES de-dupes via a Set; the shared prefix still
 			// appears exactly once here. Order is not semantically significant
@@ -20,6 +20,7 @@ describe("Claude producer binding", () => {
 				"mcp__claude_ai_Notion__",
 				"mcp__claude_ai_Slack__",
 				"mcp__claude_ai_Zoom_for_Claude__",
+				"mcp__claude_ai_Asana__",
 			]);
 		});
 	});

--- a/cli/src/core/references/bindings/codex/CodexAsanaBinding.ts
+++ b/cli/src/core/references/bindings/codex/CodexAsanaBinding.ts
@@ -1,0 +1,21 @@
+/**
+ * CodexAsanaBinding — Asana `codex_apps` connector normalizer.
+ *
+ * Reached through `_get_task` (namespace `mcp__codex_apps__asana`), or the
+ * `asana.get_task` invocation on the fallback path — match identity lives in
+ * `asanaDefinition.match.codex`. The connector's `function_call_output` unwraps
+ * to `{ data: { …task… } }`, byte-identical to the Claude Asana MCP payload the
+ * asana `SourceDefinition` already reads (`wrapperKeys:["data"]`), so there is no
+ * reshaping — `normalize` is identity, exactly like `CodexNotionBinding`. Only
+ * `get_task` is recognized; enumeration/search/write tools never reach extraction.
+ * When an Asana search/list shape is observed, add its tool name + a collection
+ * key here, mirroring CodexGitHubBinding.
+ */
+
+import type { CodexNormalizer } from "./CodexBinding.js";
+
+export const asanaCodexBinding: CodexNormalizer = {
+	id: "asana",
+	canonicalToolName: "mcp__claude_ai_Asana__get_task",
+	normalize: (business) => business,
+};

--- a/cli/src/core/references/bindings/codex/index.test.ts
+++ b/cli/src/core/references/bindings/codex/index.test.ts
@@ -14,6 +14,7 @@ describe("Codex producer normalizer registry", () => {
 			expect(getCodexNormalizer("confluence")?.canonicalToolName).toBe(
 				"mcp__claude_ai_Atlassian__getConfluencePage",
 			);
+			expect(getCodexNormalizer("asana")?.canonicalToolName).toBe("mcp__claude_ai_Asana__get_task");
 		});
 
 		it("returns undefined for an id with no registered normalizer", () => {
@@ -31,12 +32,13 @@ describe("Codex producer normalizer registry", () => {
 			expect(out.issues[0].html_url).toBe("https://github.com/o/r/issues/959");
 		});
 
-		it("linear/notion/jira/zoom-meeting normalizers pass payloads through unchanged", () => {
+		it("linear/notion/jira/zoom-meeting/asana normalizers pass payloads through unchanged", () => {
 			const payload = { id: "JOLLI-1", title: "x" };
 			expect(getCodexNormalizer("linear")?.normalize(payload)).toBe(payload);
 			expect(getCodexNormalizer("notion")?.normalize(payload)).toBe(payload);
 			expect(getCodexNormalizer("jira")?.normalize(payload)).toBe(payload);
 			expect(getCodexNormalizer("zoom-meeting")?.normalize(payload)).toBe(payload);
+			expect(getCodexNormalizer("asana")?.normalize(payload)).toBe(payload);
 		});
 
 		it("confluence normalizer reshapes the {content:{nodes}} page into the canonical shape", () => {

--- a/cli/src/core/references/bindings/codex/index.ts
+++ b/cli/src/core/references/bindings/codex/index.ts
@@ -10,6 +10,7 @@
  */
 
 import type { SourceId } from "../../../../Types.js";
+import { asanaCodexBinding } from "./CodexAsanaBinding.js";
 import type { CodexNormalizer } from "./CodexBinding.js";
 import { confluenceCodexBinding } from "./CodexConfluenceBinding.js";
 import { githubCodexBinding } from "./CodexGitHubBinding.js";
@@ -28,6 +29,7 @@ const CODEX_NORMALIZERS: readonly CodexNormalizer[] = [
 	jiraCodexBinding,
 	zoomMeetingCodexBinding,
 	confluenceCodexBinding,
+	asanaCodexBinding,
 ];
 
 const BY_ID: ReadonlyMap<SourceId, CodexNormalizer> = new Map(CODEX_NORMALIZERS.map((n) => [n.id, n]));

--- a/cli/src/core/references/sources/definitions/asana.test.ts
+++ b/cli/src/core/references/sources/definitions/asana.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { extractRef, renderBlock } from "../../SourceEngine.js";
+import { asanaDefinition as def } from "./asana.js";
+
+// The definition runs over the task object after wrapperKeys:["data"] unwrap.
+const CANONICAL = {
+	gid: "1216474542361983",
+	name: "Add Asana MCP integration",
+	notes: "Add Asana MCP integration for Claude Code and Codex",
+	permalink_url: "https://app.asana.com/1/1216474500374769/project/1216474339608643/task/1216474542361983",
+	assignee: { gid: "42", name: "Flyer Li" },
+};
+const TOOL = "mcp__claude_ai_Asana__get_task";
+const AT = "2026-07-12T00:00:00Z";
+
+describe("asana definition", () => {
+	it("extracts a Reference from the canonical shape", () => {
+		const ref = extractRef(def, CANONICAL, TOOL, AT);
+		expect(ref?.source).toBe("asana");
+		expect(ref?.nativeId).toBe("1216474542361983");
+		expect(ref?.title).toBe("Add Asana MCP integration");
+		expect(ref?.url).toBe(CANONICAL.permalink_url);
+		expect(ref?.description).toContain("Add Asana MCP integration for Claude Code and Codex");
+		expect(ref?.fields).toEqual([
+			{ key: "entity-type", label: "Type", icon: "symbol-class", value: "task" },
+			{ key: "assignee", label: "Assignee", icon: "person", value: "Flyer Li" },
+		]);
+	});
+
+	it("drops the assignee field when the task is unassigned", () => {
+		const ref = extractRef(def, { ...CANONICAL, assignee: null }, TOOL, AT);
+		expect(ref?.fields).toEqual([{ key: "entity-type", label: "Type", icon: "symbol-class", value: "task" }]);
+	});
+
+	it("voids when gid (nativeId) is missing", () => {
+		expect(extractRef(def, { ...CANONICAL, gid: undefined }, TOOL, AT)).toBeNull();
+	});
+
+	it("voids when the url is not an Asana host", () => {
+		expect(extractRef(def, { ...CANONICAL, permalink_url: "https://evil.example/task/1" }, TOOL, AT)).toBeNull();
+	});
+
+	it("renders an <asana-tasks> block", () => {
+		const ref = extractRef(def, CANONICAL, TOOL, AT);
+		if (ref === null) throw new Error("expected ref");
+		const block = renderBlock(def, [ref]);
+		expect(block).toContain("<asana-tasks>");
+		expect(block).toContain("<task");
+		expect(block).toContain("<description>");
+	});
+});

--- a/cli/src/core/references/sources/definitions/asana.test.ts
+++ b/cli/src/core/references/sources/definitions/asana.test.ts
@@ -40,6 +40,11 @@ describe("asana definition", () => {
 		expect(extractRef(def, { ...CANONICAL, permalink_url: "https://evil.example/task/1" }, TOOL, AT)).toBeNull();
 	});
 
+	it("accepts a mixed-case Asana host (URL hosts are case-insensitive)", () => {
+		const url = "https://App.Asana.com/1/1216474500374769/task/1216474542361983";
+		expect(extractRef(def, { ...CANONICAL, permalink_url: url }, TOOL, AT)?.url).toBe(url);
+	});
+
 	it("renders an <asana-tasks> block", () => {
 		const ref = extractRef(def, CANONICAL, TOOL, AT);
 		if (ref === null) throw new Error("expected ref");

--- a/cli/src/core/references/sources/definitions/asana.ts
+++ b/cli/src/core/references/sources/definitions/asana.ts
@@ -1,0 +1,50 @@
+/**
+ * Asana built-in source definition — pure-DSL over the get_task result.
+ *
+ * The Asana MCP connector's get_task returns `{ data: { …task… } }`, so
+ * wrapperKeys is `["data"]`: walkPayload voids at the top level (gid/name live
+ * under `data`), then descends into `data` and extracts the task. The same key
+ * also iterates a `{ data: [ … ] }` array shape, though only get_task is
+ * accepted for extraction (acceptSuffix).
+ *
+ * Fields are deliberately minimal. Asana section/project live under array paths
+ * (`memberships[0].section.name` / `projects[0].name`) that the DSL's dotted
+ * `readPath` cannot index, and `completed` is a boolean that `toScalar` drops —
+ * so only a constant entity-type and the assignee's name (an object subpath)
+ * are surfaced.
+ *
+ * Claude-only: no Codex connector exposes Asana today, so no `match.codex`.
+ */
+
+import type { SourceDefinition } from "../../SourceDefinition.js";
+
+/** Asana web host — task permalinks are always under app.asana.com. */
+const ASANA_URL = "^https://app\\.asana\\.com/";
+
+export const asanaDefinition: SourceDefinition = {
+	id: "asana",
+	label: "Asana",
+	icon: "checklist",
+	match: {
+		claude: { prefixes: ["mcp__claude_ai_Asana__"], acceptSuffix: "get_task" },
+	},
+	wrapperKeys: ["data"],
+	reference: {
+		nativeId: { pipe: [{ op: "path", path: "gid" }], require: "^\\d+$" },
+		title: { pipe: [{ op: "path", path: "name" }], require: ".+" },
+		url: { pipe: [{ op: "path", path: "permalink_url" }], require: ASANA_URL },
+		description: { pipe: [{ op: "path", path: "notes" }], optional: true },
+	},
+	fields: [
+		{ key: "entity-type", label: "Type", icon: "symbol-class", pipe: [{ op: "const", value: "task" }] },
+		{ key: "assignee", label: "Assignee", icon: "person", pipe: [{ op: "path", path: "assignee.name" }] },
+	],
+	storage: { nativeIdPathSafe: true },
+	render: {
+		wrapperTag: "asana-tasks",
+		itemTag: "task",
+		bodyTag: "description",
+		maxCharsPerReference: 4000,
+		maxTotalChars: 30000,
+	},
+};

--- a/cli/src/core/references/sources/definitions/asana.ts
+++ b/cli/src/core/references/sources/definitions/asana.ts
@@ -13,12 +13,22 @@
  * so only a constant entity-type and the assignee's name (an object subpath)
  * are surfaced.
  *
- * Claude-only: no Codex connector exposes Asana today, so no `match.codex`.
+ * Codex: the `codex_apps` Asana connector's `get_task` produces the SAME
+ * `{ data: { …task… } }` shape (verified against a real rollout — function_call
+ * `name="_get_task"` under namespace `mcp__codex_apps__asana`; invocation
+ * `asana.get_task`; the `function_call_output` unwraps to the identical task
+ * object), so no reshaping is needed — see `CodexAsanaBinding` (identity
+ * normalize). `match.codex` mirrors `notion.ts`: the dotted `invocationTool`
+ * value (`asana.get_task`) is taken verbatim from the rollout, not guessed.
  */
 
 import type { SourceDefinition } from "../../SourceDefinition.js";
 
-/** Asana web host — task permalinks are always under app.asana.com. */
+/**
+ * Asana web host — task permalinks are always under app.asana.com. Matched
+ * case-insensitively (`requireFlags: "i"`, mirroring `notion.ts`): URL hosts are
+ * case-insensitive, so a mixed-case host must not silently void the reference.
+ */
 const ASANA_URL = "^https://app\\.asana\\.com/";
 
 export const asanaDefinition: SourceDefinition = {
@@ -27,12 +37,13 @@ export const asanaDefinition: SourceDefinition = {
 	icon: "checklist",
 	match: {
 		claude: { prefixes: ["mcp__claude_ai_Asana__"], acceptSuffix: "get_task" },
+		codex: { namespaceSuffix: "asana", functionCallNames: ["_get_task"], invocationTools: ["asana.get_task"] },
 	},
 	wrapperKeys: ["data"],
 	reference: {
 		nativeId: { pipe: [{ op: "path", path: "gid" }], require: "^\\d+$" },
 		title: { pipe: [{ op: "path", path: "name" }], require: ".+" },
-		url: { pipe: [{ op: "path", path: "permalink_url" }], require: ASANA_URL },
+		url: { pipe: [{ op: "path", path: "permalink_url" }], require: ASANA_URL, requireFlags: "i" },
 		description: { pipe: [{ op: "path", path: "notes" }], optional: true },
 	},
 	fields: [

--- a/cli/src/core/references/sources/definitions/index.ts
+++ b/cli/src/core/references/sources/definitions/index.ts
@@ -13,6 +13,7 @@
  * Confluence tool call would silently resolve to jira.
  */
 
+import { asanaDefinition } from "./asana.js";
 import { confluenceDefinition } from "./confluence.js";
 import { githubDefinition } from "./github.js";
 import { jiraDefinition } from "./jira.js";
@@ -31,4 +32,5 @@ export const BUILTIN_DEFINITIONS = [
 	slackDefinition,
 	zoomMeetingDefinition,
 	zoomDocDefinition,
+	asanaDefinition,
 ] as const;

--- a/docs/superpowers/plans/2026-07-12-asana-reference-source.md
+++ b/docs/superpowers/plans/2026-07-12-asana-reference-source.md
@@ -1,0 +1,305 @@
+# Asana Reference Source Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture Asana tasks as Jolli references when a Claude Code session calls the Asana MCP `get_task` tool.
+
+**Architecture:** Add one declarative `SourceDefinition` (`asanaDefinition`) to the reference-extraction registry, register its display metadata in the VS Code `SOURCE_META` table, and cover it with a definition test (over the real `get_task` payload) plus a registry-resolution test. No `SourceEngine`, envelope-parser, or DSL changes. Codex is out of scope (no Asana connector exists in Codex today).
+
+**Tech Stack:** TypeScript (ESM), Vitest, Biome. CLI workspace `@jolli.ai/cli`; VS Code workspace `vscode`.
+
+## Global Constraints
+
+- **DCO sign-off on the commit** — `git commit -s`. No `Co-Authored-By: Claude` / `🤖 Generated` trailers.
+- **`npm run all` must pass before commit** (clean → build → lint → test).
+- **CLI coverage floor**: 97% statements / 96% branches / 97% functions / 97% lines under `cli/src/`.
+- **Biome**: tabs (4-wide), 120-column limit, `noExplicitAny`, `noUnusedImports`.
+- **Verification + commit are consolidated in the final task** (single `npm run all`, single commit) — earlier tasks write source + tests only, they do not run partial builds or commit. This is because Task 2 (`KnownSourceId` extension) makes the `vscode` typecheck fail until the `SOURCE_META` row is added, so the tree only type-checks once all edits are in place.
+- **Real fixture rule**: the definition test uses the actual Asana `get_task` payload shape (below), not an invented one.
+
+The canonical Asana `get_task` payload (truth source):
+
+```json
+{ "data": {
+    "gid": "1216474542361983",
+    "name": "Add Asana MCP integration",
+    "notes": "Add Asana MCP integration for Claude Code and Codex",
+    "permalink_url": "https://app.asana.com/1/1216474500374769/project/1216474339608643/task/1216474542361983",
+    "assignee": null
+} }
+```
+
+Note: the Asana MCP tool result is JSON-parsed by `ClaudeEnvelopeParser` into this `{ data: { … } }` object before it reaches the engine. `wrapperKeys: ["data"]` unwraps it. The definition test feeds the **unwrapped task object** directly to `extractRef` (matching how `zoom-doc.test.ts` feeds its post-unwrap canonical shape).
+
+---
+
+### Task 1: Asana SourceDefinition + CLI registration + CLI tests
+
+**Files:**
+- Create: `cli/src/core/references/sources/definitions/asana.ts`
+- Modify: `cli/src/core/references/sources/definitions/index.ts`
+- Modify: `cli/src/Types.ts` (`KnownSourceId`, ~line 775)
+- Create (test): `cli/src/core/references/sources/definitions/asana.test.ts`
+- Modify (test): `cli/src/core/references/SourceDefinitionRegistry.test.ts` (stable-order assertion ~line 46; new describe block after line 322)
+
+**Interfaces:**
+- Consumes: `SourceDefinition` type from `../../SourceDefinition.js`; `extractRef`, `renderBlock` from `../../SourceEngine.js`; `getRegistry` from `../SourceDefinitionRegistry.js` (via existing test imports).
+- Produces: `export const asanaDefinition: SourceDefinition` (id `"asana"`); appended to `BUILTIN_DEFINITIONS`; `"asana"` added to the `KnownSourceId` union.
+
+- [ ] **Step 1: Write the definition file**
+
+Create `cli/src/core/references/sources/definitions/asana.ts`:
+
+```ts
+/**
+ * Asana built-in source definition — pure-DSL over the get_task result.
+ *
+ * The Asana MCP connector's get_task returns `{ data: { …task… } }`, so
+ * wrapperKeys is `["data"]`: walkPayload voids at the top level (gid/name live
+ * under `data`), then descends into `data` and extracts the task. The same key
+ * also iterates a `{ data: [ … ] }` array shape, though only get_task is
+ * accepted for extraction (acceptSuffix).
+ *
+ * Fields are deliberately minimal. Asana section/project live under array paths
+ * (`memberships[0].section.name` / `projects[0].name`) that the DSL's dotted
+ * `readPath` cannot index, and `completed` is a boolean that `toScalar` drops —
+ * so only a constant entity-type and the assignee's name (an object subpath)
+ * are surfaced.
+ *
+ * Claude-only: no Codex connector exposes Asana today, so no `match.codex`.
+ */
+
+import type { SourceDefinition } from "../../SourceDefinition.js";
+
+/** Asana web host — task permalinks are always under app.asana.com. */
+const ASANA_URL = "^https://app\\.asana\\.com/";
+
+export const asanaDefinition: SourceDefinition = {
+	id: "asana",
+	label: "Asana",
+	icon: "checklist",
+	match: {
+		claude: { prefixes: ["mcp__claude_ai_Asana__"], acceptSuffix: "get_task" },
+	},
+	wrapperKeys: ["data"],
+	reference: {
+		nativeId: { pipe: [{ op: "path", path: "gid" }], require: "^\\d+$" },
+		title: { pipe: [{ op: "path", path: "name" }], require: ".+" },
+		url: { pipe: [{ op: "path", path: "permalink_url" }], require: ASANA_URL },
+		description: { pipe: [{ op: "path", path: "notes" }], optional: true },
+	},
+	fields: [
+		{ key: "entity-type", label: "Type", icon: "symbol-class", pipe: [{ op: "const", value: "task" }] },
+		{ key: "assignee", label: "Assignee", icon: "person", pipe: [{ op: "path", path: "assignee.name" }] },
+	],
+	storage: { nativeIdPathSafe: true },
+	render: {
+		wrapperTag: "asana-tasks",
+		itemTag: "task",
+		bodyTag: "description",
+		maxCharsPerReference: 4000,
+		maxTotalChars: 30000,
+	},
+};
+```
+
+- [ ] **Step 2: Register the definition**
+
+Modify `cli/src/core/references/sources/definitions/index.ts`. Add the import (alphabetical among the imports) and append `asanaDefinition` to `BUILTIN_DEFINITIONS` **at the end** (append-only preserves the stable order that downstream consumers pin):
+
+```ts
+import { asanaDefinition } from "./asana.js";
+import { githubDefinition } from "./github.js";
+import { jiraDefinition } from "./jira.js";
+import { linearDefinition } from "./linear.js";
+import { notionDefinition } from "./notion.js";
+import { slackDefinition } from "./slack.js";
+import { zoomDocDefinition } from "./zoom-doc.js";
+import { zoomMeetingDefinition } from "./zoom-meeting.js";
+
+export const BUILTIN_DEFINITIONS = [
+	linearDefinition,
+	jiraDefinition,
+	githubDefinition,
+	notionDefinition,
+	slackDefinition,
+	zoomMeetingDefinition,
+	zoomDocDefinition,
+	asanaDefinition,
+] as const;
+```
+
+- [ ] **Step 3: Extend the `KnownSourceId` union**
+
+Modify `cli/src/Types.ts` line ~775. Add `"asana"` at the end:
+
+```ts
+export type KnownSourceId = "linear" | "jira" | "github" | "notion" | "slack" | "zoom-meeting" | "zoom-doc" | "asana";
+```
+
+- [ ] **Step 4: Write the definition test**
+
+Create `cli/src/core/references/sources/definitions/asana.test.ts` (mirrors `zoom-doc.test.ts`; the canonical shape is the unwrapped task object):
+
+```ts
+import { describe, expect, it } from "vitest";
+import { extractRef, renderBlock } from "../../SourceEngine.js";
+import { asanaDefinition as def } from "./asana.js";
+
+// The definition runs over the task object after wrapperKeys:["data"] unwrap.
+const CANONICAL = {
+	gid: "1216474542361983",
+	name: "Add Asana MCP integration",
+	notes: "Add Asana MCP integration for Claude Code and Codex",
+	permalink_url: "https://app.asana.com/1/1216474500374769/project/1216474339608643/task/1216474542361983",
+	assignee: { gid: "42", name: "Flyer Li" },
+};
+const TOOL = "mcp__claude_ai_Asana__get_task";
+const AT = "2026-07-12T00:00:00Z";
+
+describe("asana definition", () => {
+	it("extracts a Reference from the canonical shape", () => {
+		const ref = extractRef(def, CANONICAL, TOOL, AT);
+		expect(ref?.source).toBe("asana");
+		expect(ref?.nativeId).toBe("1216474542361983");
+		expect(ref?.title).toBe("Add Asana MCP integration");
+		expect(ref?.url).toBe(CANONICAL.permalink_url);
+		expect(ref?.description).toContain("Add Asana MCP integration for Claude Code and Codex");
+		expect(ref?.fields).toEqual([
+			{ key: "entity-type", label: "Type", icon: "symbol-class", value: "task" },
+			{ key: "assignee", label: "Assignee", icon: "person", value: "Flyer Li" },
+		]);
+	});
+
+	it("drops the assignee field when the task is unassigned", () => {
+		const ref = extractRef(def, { ...CANONICAL, assignee: null }, TOOL, AT);
+		expect(ref?.fields).toEqual([{ key: "entity-type", label: "Type", icon: "symbol-class", value: "task" }]);
+	});
+
+	it("voids when gid (nativeId) is missing", () => {
+		expect(extractRef(def, { ...CANONICAL, gid: undefined }, TOOL, AT)).toBeNull();
+	});
+
+	it("voids when the url is not an Asana host", () => {
+		expect(extractRef(def, { ...CANONICAL, permalink_url: "https://evil.example/task/1" }, TOOL, AT)).toBeNull();
+	});
+
+	it("renders an <asana-tasks> block", () => {
+		const ref = extractRef(def, CANONICAL, TOOL, AT);
+		if (ref === null) throw new Error("expected ref");
+		const block = renderBlock(def, [ref]);
+		expect(block).toContain("<asana-tasks>");
+		expect(block).toContain("<task");
+		expect(block).toContain("<description>");
+	});
+});
+```
+
+- [ ] **Step 5: Extend the registry stable-order assertion**
+
+Modify `cli/src/core/references/SourceDefinitionRegistry.test.ts` line ~46. Update the test name and expected array to include `"asana"` at the end:
+
+```ts
+	it("all() is stable order linear,jira,github,notion,slack,zoom-meeting,zoom-doc,asana", () => {
+		expect(
+			getRegistry()
+				.all()
+				.map((d) => d.id),
+		).toEqual(["linear", "jira", "github", "notion", "slack", "zoom-meeting", "zoom-doc", "asana"]);
+	});
+```
+
+- [ ] **Step 6: Add the asana registration test block**
+
+In the same file, add after the `zoom-doc registration` describe (after line ~322, before the closing `});` of the outer describe):
+
+```ts
+	describe("asana registration", () => {
+		it("resolves get_task to asana", () => {
+			expect(getRegistry().match("claude", "mcp__claude_ai_Asana__get_task")?.id).toBe("asana");
+		});
+		it("does NOT match enumeration or write tools (suffix gate)", () => {
+			const r = getRegistry();
+			expect(r.match("claude", "mcp__claude_ai_Asana__get_tasks")).toBeUndefined();
+			expect(r.match("claude", "mcp__claude_ai_Asana__get_my_tasks")).toBeUndefined();
+			expect(r.match("claude", "mcp__claude_ai_Asana__search_tasks")).toBeUndefined();
+			expect(r.match("claude", "mcp__claude_ai_Asana__create_task_confirm")).toBeUndefined();
+		});
+	});
+```
+
+---
+
+### Task 2: VS Code source display metadata
+
+**Files:**
+- Modify: `vscode/src/views/SourceLabels.ts` (`SOURCE_META`, ~line 40-48)
+
+**Interfaces:**
+- Consumes: the `"asana"` member of `KnownSourceId` (from Task 1, Step 3) — `SOURCE_META` is typed `Record<KnownSourceId, SourceMeta>`, so TypeScript **requires** this row once Task 1 lands.
+- Produces: `SOURCE_META.asana` (and, derived automatically, `SOURCE_TITLES.asana`).
+
+- [ ] **Step 1: Add the asana row to `SOURCE_META`**
+
+Modify `vscode/src/views/SourceLabels.ts`. Append the `asana` entry to the `SOURCE_META` object (Asana's brand coral `#f06a6a`; `checklist` codicon matching `asanaDefinition.icon`):
+
+```ts
+export const SOURCE_META: Record<KnownSourceId, SourceMeta> = {
+	linear: { label: "Linear", letter: "L", icon: "issues", color: "#5e6ad2" },
+	jira: { label: "Jira", letter: "J", icon: "issues", color: "#0052cc" },
+	github: { label: "GitHub", letter: "G", icon: "issues", color: "#6e7681" },
+	notion: { label: "Notion", letter: "N", icon: "file-text", color: "#787774" },
+	slack: { label: "Slack", letter: "S", icon: "comment-discussion", color: "#4a154b" },
+	"zoom-meeting": { label: "Zoom Meeting", letter: "Z", icon: "device-camera-video", color: "#2D8CFF" },
+	"zoom-doc": { label: "Zoom Doc", letter: "Z", icon: "file", color: "#2D8CFF" },
+	asana: { label: "Asana", letter: "A", icon: "checklist", color: "#f06a6a" },
+};
+```
+
+Note: `HTML_REFERENCE_SOURCE_ORDER` in `SummaryHtmlBuilder.ts` is intentionally **not** modified — it already omits the zoom sources, so Asana follows the same first-seen-order fallback as zoom for consistency.
+
+---
+
+### Task 3: Verify and commit
+
+**Files:** none (verification + commit only).
+
+- [ ] **Step 1: Run the full gate**
+
+Run: `npm run all`
+Expected: clean → build → lint → test all PASS; CLI coverage stays ≥ the 97/96/97/97 floor. The new definition test exercises every `require`/field branch of `asanaDefinition`, so the added code is fully covered.
+
+If lint reports formatting, run `npm run lint:fix` and re-run `npm run all`.
+
+- [ ] **Step 2: Stage and commit (single DCO-signed commit)**
+
+```bash
+git add cli/src/core/references/sources/definitions/asana.ts \
+        cli/src/core/references/sources/definitions/index.ts \
+        cli/src/Types.ts \
+        cli/src/core/references/sources/definitions/asana.test.ts \
+        cli/src/core/references/SourceDefinitionRegistry.test.ts \
+        vscode/src/views/SourceLabels.ts
+git commit -s -m "feat: capture Asana tasks as references from Claude get_task"
+```
+
+Expected: commit succeeds with a `Signed-off-by:` trailer and no AI co-author trailer.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Asana `SourceDefinition` (Claude, task-only, `acceptSuffix: "get_task"`) → Task 1 Step 1. ✓
+- `wrapperKeys: ["data"]`, `nativeId`/`title`/`url`/`description` mapping → Task 1 Step 1 + test Step 4. ✓
+- Minimal fields (entity-type const + assignee subpath; no boolean/array fields) → Task 1 Step 1 + the "drops the assignee field" test. ✓
+- Registration in `BUILTIN_DEFINITIONS` → Task 1 Step 2. ✓
+- `KnownSourceId` + `SOURCE_META` → Task 1 Step 3, Task 2 Step 1. ✓
+- Definition test over real fixture + registry resolver test → Task 1 Steps 4–6. ✓
+- Codex deferred (no `match.codex`, no binding) → documented in `asana.ts` header comment; no task adds it. ✓
+- `npm run all` gate + DCO commit → Task 3. ✓
+- Optional `HTML_REFERENCE_SOURCE_ORDER` → explicitly skipped (matches zoom precedent), noted in Task 2. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. ✓
+
+**Type consistency:** `asanaDefinition` (id `"asana"`) used identically in index.ts, both tests, and SOURCE_META key. Field output shape `{ key, label, icon, value }` matches `extractRef`'s builder (`SourceEngine.ts:214`) and the zoom-doc test precedent. `acceptSuffix` semantics (`toolName.endsWith`) verified against `SourceDefinitionRegistry.ts:196`. ✓

--- a/docs/superpowers/plans/2026-07-12-asana-report.md
+++ b/docs/superpowers/plans/2026-07-12-asana-report.md
@@ -1,0 +1,74 @@
+# Asana Reference Source — Implementation Report
+
+Plan executed: `docs/superpowers/plans/2026-07-12-asana-reference-source.md` (all three tasks, single commit).
+
+## Files created
+
+- `cli/src/core/references/sources/definitions/asana.ts` — `asanaDefinition` `SourceDefinition`, transcribed verbatim from plan Task 1 Step 1.
+- `cli/src/core/references/sources/definitions/asana.test.ts` — definition test over the real (unwrapped) `get_task` payload, transcribed verbatim from plan Task 1 Step 4.
+
+## Files modified
+
+- `cli/src/core/references/sources/definitions/index.ts` — added `asanaDefinition` import (alphabetical) and appended it to `BUILTIN_DEFINITIONS` (append-only, preserves stable order).
+- `cli/src/Types.ts` (~line 775) — `KnownSourceId` union extended with `"asana"` at the end.
+- `cli/src/core/references/SourceDefinitionRegistry.test.ts` — stable-order assertion updated to include `"asana"`; new `describe("asana registration", …)` block added after the `zoom-doc registration` block (Task 1 Steps 5–6).
+- `vscode/src/views/SourceLabels.ts` — `SOURCE_META.asana` row added (`{ label: "Asana", letter: "A", icon: "checklist", color: "#f06a6a" }`), transcribed verbatim from plan Task 2 Step 1.
+- `cli/src/core/references/bindings/claude/index.test.ts` — **deviation, see below.**
+
+## Deviation from the plan
+
+The plan's file list for Task 1 did not include `cli/src/core/references/bindings/claude/index.test.ts`, but the first `npm run all` run failed one test there:
+
+```
+FAIL src/core/references/bindings/claude/index.test.ts > Claude producer binding > CLAUDE_TOOL_PREFIXES
+  > lists every vendor prefix for the envelope pre-filter, de-duplicated …
+AssertionError: expected [ 'mcp__linear__', …(7) ] to deeply equal [ 'mcp__linear__', …(6) ]
++ "mcp__claude_ai_Asana__"
+```
+
+`CLAUDE_TOOL_PREFIXES` is derived automatically from `BUILTIN_DEFINITIONS` (registry-driven, de-duplicated), so adding `asanaDefinition` to the registry mechanically adds its Claude prefix to this list — a known ripple effect (see project memory note "新增 SourceDefinition 的 ripple 坑": adding a source definition breaks the stable-order id-list *and* `CLAUDE_TOOL_PREFIXES`). This is exactly the "test assertion that doesn't match actual engine output" case the task instructions call out: I corrected the test's expected array to append `"mcp__claude_ai_Asana__"` (with the accompanying comment updated to mention `asana` in the BUILTIN_DEFINITIONS order list), re-ran, and it passed. No production code was touched to make this test pass — only the pinned expectation was extended to match the new (correct) registry-driven output.
+
+No other ripple effects were found. Checked `ClaudeEnvelopeParser.test.ts`, `vscode/src/views/SourceLabels.test.ts`, and other files referencing `"zoom-doc"`/`"zoom-meeting"` for exhaustive-enumeration assertions — none needed changes.
+
+No other deviations. `asanaDefinition`, the `KnownSourceId` union, and `SOURCE_META.asana` all match the plan's code blocks byte-for-byte. `HTML_REFERENCE_SOURCE_ORDER`, `match.codex`, and bindings were intentionally left untouched per the plan's explicit exclusions.
+
+## `npm run all` result
+
+**PASS** — clean → build → typecheck → lint → test, full chain green.
+
+- CLI lint: `Checked 552 files in 261ms. No fixes applied.`
+- VS Code lint: `Checked 217 files in 121ms. No fixes applied.`
+- CLI unit tests: `Test Files 264 passed (264)` / `Tests 6913 passed | 1 todo (6914)`
+- CLI acceptance tests: `Test Files 5 passed (5)` / `Tests 9 passed (9)`
+- VS Code tests: `Test Files 106 passed (106)` / `Tests 4197 passed | 8 skipped (4205)`
+
+CLI coverage (floor: 97% stmts / 96% branch / 97% funcs / 97% lines):
+
+```
+Statements   : 99.58% ( 18688/18765 )
+Branches     : 98.21% ( 10526/10717 )
+Functions    : 99.61% ( 2611/2621 )
+Lines        : 99.76% ( 16967/17007 )
+```
+
+All four metrics comfortably above the floor. New `asana.ts` / `asana.test.ts` files show no uncovered lines in the coverage report (`src/core/references/sources` and `sources/definitions` groups report at/near 100%).
+
+VS Code coverage (informational, no enforced floor for this workspace):
+
+```
+Statements   : 99.31% ( 8593/8652 )
+Branches     : 98.18% ( 5017/5110 )
+Functions    : 99.14% ( 1393/1405 )
+Lines        : 99.51% ( 8165/8205 )
+```
+
+## Commit
+
+```
+commit 11734a5c215047ffc70cb425e69ae520f3a01ee3
+feat: capture Asana tasks as references from Claude get_task
+
+Signed-off-by: Flyer Li <flyer.li@jolli.ai>
+```
+
+Branch: `feature/asana-mcp-integration`. 7 files changed (122 insertions, 4 deletions) — the 6 files listed in the plan's Task 3 Step 2, plus the one ripple-fix test file noted above. No `Co-Authored-By:` or `Generated with` trailer present.

--- a/docs/superpowers/specs/2026-07-12-asana-reference-source-design.md
+++ b/docs/superpowers/specs/2026-07-12-asana-reference-source-design.md
@@ -7,33 +7,29 @@
 ## Summary
 
 Add Asana as a built-in reference-extraction source so that when a user's Claude
-Code session calls the Asana MCP connector's `get_task` tool, the referenced task
-(title, notes, URL) is captured as a Jolli reference — exactly like the existing
-Linear / Jira / GitHub / Notion / Zoom sources.
+Code **or Codex** session calls the Asana connector's `get_task` tool, the
+referenced task (title, notes, URL) is captured as a Jolli reference — exactly
+like the existing Linear / Jira / GitHub / Notion / Zoom sources.
 
-This is a **declarative `SourceDefinition`** addition. It follows the
-`zoom-doc` template (the most recently added source) end-to-end. No changes to
+This is a **declarative `SourceDefinition`** addition. The Claude half follows the
+`zoom-doc` template end-to-end; the Codex half adds a `match.codex` block plus an
+identity `CodexAsanaBinding` (mirroring `CodexNotionBinding`). No changes to
 `SourceEngine`, the envelope parsers, or the DSL vocabulary are required.
 
 ## Scope decisions
 
-Two scope questions were resolved with the requester before design:
+1. **Claude Code first, then Codex (both now shipped).**
+   The task text names "Claude Code and Codex". The Claude half shipped first
+   (commit 11734a5c). Codex was **initially deferred** because at design time no
+   Asana connector existed on disk and the prior precedent (the Codex Rovo Jira
+   matcher was hallucinated and never matched; JOLLI-1921 shipped only the
+   verified Linear half) forbids shipping a guessed `match.codex` block.
 
-1. **Claude Code only this round; Codex deferred.**
-   The task text names "Claude Code and Codex", but the Codex half has **no
-   truth source** and cannot get one right now:
-   - `~/.codex/config.toml` has no Asana MCP server.
-   - The real Codex MCP tools observed in on-disk rollouts are `codex_apps` →
-     `atlassian_rovo.*` and `notion.fetch` — **no Asana**.
-   - Codex itself, in a rollout, stated it had no Asana connection capability.
-
-   Per prior precedent (the Codex Rovo Jira matcher was hallucinated and never
-   matched; JOLLI-1921 shipped only the verified Linear half), we do **not**
-   ship an unverified `match.codex` block. Shipping a guessed Codex matcher
-   produces dead code, not working coverage.
-
-   **Codex is recorded as a follow-up** (see "Deferred: Codex" below) with an
-   explicit precondition: a real `codex_apps` Asana rollout captured on disk.
+   **That precondition is now met.** The machine has the `openai-curated-remote`
+   Asana plugin (`~/.codex/plugins/cache/.../asana/7.0.0/`) installed, and a real
+   rollout captured a live `get_task` call. The Codex half is implemented against
+   that real rollout — see "Codex support" below. No value in `match.codex` is
+   guessed; every field is transcribed from the on-disk envelope.
 
 2. **Task entity only (`get_task`).**
    Asana projects and other entities are out of scope. Only single-task fetches
@@ -69,6 +65,7 @@ id:      "asana"
 label:   "Asana"
 icon:    "checklist"           // codicon; finalize in TDD
 match.claude: { prefixes: ["mcp__claude_ai_Asana__"], acceptSuffix: "get_task" }
+match.codex:  { namespaceSuffix: "asana", functionCallNames: ["_get_task"], invocationTools: ["asana.get_task"] }
 wrapperKeys: ["data"]          // descends {data:{task}}; also iterates {data:[...]}
 reference:
   nativeId:    path "gid"            require ^\d+$
@@ -142,21 +139,68 @@ Verified against the current subsystem. Ordering downstream (`CLAUDE_TOOL_PREFIX
 - `npm run all` must pass (CLI 97% coverage floor). New code is a data literal +
   tests, so coverage is met by the definition test exercising every field/require.
 
-## Deferred: Codex
+## Codex support
 
-Not implemented this round. Preconditions to add it later:
+### Observed Reality (real rollout, not a fixture)
 
-1. A real Codex rollout on disk showing an Asana call under the `codex_apps`
-   server — the exact `server`/`tool` naming (e.g. `asana.get_task` vs
-   `asana.fetch`) must be read from that rollout, not guessed.
-2. Then add a `match.codex` block to `asanaDefinition` and a
-   `CodexAsanaBinding` (identity normalize, mirroring `CodexNotionBinding.ts`),
-   registered in `bindings/codex/index.ts` `CODEX_NORMALIZERS`, plus a
-   `CodexEnvelopeParser.test.ts` case built from the real rollout JSONL.
+Captured from `~/.codex/sessions/2026/07/12/rollout-…T20-21-42-…019f5646….jsonl`,
+where the user asked Codex to capture an Asana task URL and it called `get_task`.
+The connector spans the standard three `codex_apps` line types:
+
+- **`function_call`** (request): `name: "_get_task"`,
+  `namespace: "mcp__codex_apps__asana"`, `arguments` a JSON string.
+- **`mcp_tool_call_end`** (event): `invocation.server: "codex_apps"`,
+  `invocation.tool: "asana.get_task"` — **dotted**, taken verbatim (contrast the
+  Notion connector's underscore `notion_fetch`; the tool name is the connector's
+  own, not a normalized form). `result.Ok.content[0].text` and
+  `result.Ok.structuredContent.data` both carry the task.
+- **`function_call_output`** (result): `output` is
+  `"Wall time: …\nOutput:\n{\"data\":{…}}"`. After the parser strips the prefix
+  the payload is `{ data: { gid, name, notes, permalink_url, assignee, … } }` —
+  **byte-identical to the Claude Asana MCP shape.**
+
+The full Asana Codex tool surface (namespace `codex_apps__asana`, `tool_name`
+with a leading underscore / `tool.name` prefixed `asana.`) lives in
+`~/.codex/cache/codex_apps_tools/*.json`; `_get_task` / `asana.get_task` is the
+single-task fetch, alongside `_get_my_tasks`, `_search_tasks`, `_create_tasks`,
+etc. (all excluded).
+
+Because the result payload matches the Claude shape, the existing
+`wrapperKeys:["data"]` + reference DSL consume it unchanged — **no reshaping**.
+
+### Implementation
+
+1. **`asanaDefinition.match.codex`** (mirrors `notion.ts`):
+   ```
+   codex: { namespaceSuffix: "asana", functionCallNames: ["_get_task"], invocationTools: ["asana.get_task"] }
+   ```
+   - `namespaceSuffix: "asana"` + `functionCallNames: ["_get_task"]` — the
+     PRIMARY (function_call) match path; `registry.match` strips the shared
+     `mcp__codex_apps__` prefix before comparing the suffix.
+   - `invocationTools: ["asana.get_task"]` — the FALLBACK (`mcp_tool_call_end`)
+     match path, compared against the raw dotted `invocation.tool`.
+2. **`CodexAsanaBinding.ts`** — `asanaCodexBinding` with identity `normalize`
+   (the payload already matches the def) and
+   `canonicalToolName: "mcp__claude_ai_Asana__get_task"` (so a Codex-sourced
+   Asana ref persists the same synthetic tool name as the Claude one).
+   Registered in `bindings/codex/index.ts` `CODEX_NORMALIZERS` (appended).
+3. **Tests**:
+   - `CodexEnvelopeParser.test.ts`: an `ASANA` fixture (the real `{data:{…}}`
+     output), a PRIMARY-path test, a FALLBACK-path (dotted invocation) test, an
+     enumeration-guard test (`_get_my_tasks` yields nothing), and an end-to-end
+     `extractReferencesFromTranscript` assertion (`asana:<gid>` → title + url).
+   - `SourceDefinitionRegistry.test.ts` `asana registration`: both codex match
+     paths resolve; enumeration/write tools and an underscore invocation name do
+     not.
+   - `bindings/codex/index.test.ts`: `canonicalToolName` + identity `normalize`.
+
+**No edit needed** beyond the above: `SourceEngine`, `CodexEnvelopeParser`, the
+DSL vocabulary, and storage/render are untouched — the payload is self-contained,
+so no `CONTEXT_NORMALIZERS` / `recover` hook is required (unlike Jira).
 
 ## Non-goals
 
 - Asana projects, portfolios, users, or any non-task entity.
-- Codex support (deferred, above).
+- Codex Asana enumeration/search/write tools (only `get_task` is extracted).
 - Any change to the DSL vocabulary, the envelope parsers, or storage/render
   common layers.

--- a/docs/superpowers/specs/2026-07-12-asana-reference-source-design.md
+++ b/docs/superpowers/specs/2026-07-12-asana-reference-source-design.md
@@ -1,0 +1,162 @@
+# Asana reference source — design
+
+**Date:** 2026-07-12
+**Task:** Asana — "Add Asana MCP integration for Claude Code and Codex" (Jolli Memory project)
+**Status:** Approved, ready for implementation plan
+
+## Summary
+
+Add Asana as a built-in reference-extraction source so that when a user's Claude
+Code session calls the Asana MCP connector's `get_task` tool, the referenced task
+(title, notes, URL) is captured as a Jolli reference — exactly like the existing
+Linear / Jira / GitHub / Notion / Zoom sources.
+
+This is a **declarative `SourceDefinition`** addition. It follows the
+`zoom-doc` template (the most recently added source) end-to-end. No changes to
+`SourceEngine`, the envelope parsers, or the DSL vocabulary are required.
+
+## Scope decisions
+
+Two scope questions were resolved with the requester before design:
+
+1. **Claude Code only this round; Codex deferred.**
+   The task text names "Claude Code and Codex", but the Codex half has **no
+   truth source** and cannot get one right now:
+   - `~/.codex/config.toml` has no Asana MCP server.
+   - The real Codex MCP tools observed in on-disk rollouts are `codex_apps` →
+     `atlassian_rovo.*` and `notion.fetch` — **no Asana**.
+   - Codex itself, in a rollout, stated it had no Asana connection capability.
+
+   Per prior precedent (the Codex Rovo Jira matcher was hallucinated and never
+   matched; JOLLI-1921 shipped only the verified Linear half), we do **not**
+   ship an unverified `match.codex` block. Shipping a guessed Codex matcher
+   produces dead code, not working coverage.
+
+   **Codex is recorded as a follow-up** (see "Deferred: Codex" below) with an
+   explicit precondition: a real `codex_apps` Asana rollout captured on disk.
+
+2. **Task entity only (`get_task`).**
+   Asana projects and other entities are out of scope. Only single-task fetches
+   are extracted. Bulk enumeration/search tools are excluded (they flood Working
+   Memory, the same rationale as Linear's `denySuffixes`).
+
+## Truth source (fixture)
+
+A **real** Claude-side Asana `get_task` payload was captured (from the Asana MCP
+connector during this session) and is the fixture of record. Shape:
+
+```json
+{ "data": {
+    "gid": "1216474542361983",
+    "name": "Add Asana MCP integration",
+    "notes": "Add Asana MCP integration for Claude Code and Codex",
+    "permalink_url": "https://app.asana.com/1/.../project/.../task/1216474542361983",
+    "assignee": null,
+    "completed": false,
+    "projects": [ { "gid": "...", "name": "Jolli Memory" } ],
+    "memberships": [ { "section": { "name": "Shipped" } } ]
+} }
+```
+
+The task object is wrapped in a top-level `data` key.
+
+## The `asanaDefinition`
+
+New file: `cli/src/core/references/sources/definitions/asana.ts`.
+
+```
+id:      "asana"
+label:   "Asana"
+icon:    "checklist"           // codicon; finalize in TDD
+match.claude: { prefixes: ["mcp__claude_ai_Asana__"], acceptSuffix: "get_task" }
+wrapperKeys: ["data"]          // descends {data:{task}}; also iterates {data:[...]}
+reference:
+  nativeId:    path "gid"            require ^\d+$
+  title:       path "name"          require .+
+  url:         path "permalink_url" require ^https://app\.asana\.com/
+  description: path "notes"         optional
+fields:
+  { key: "entity-type", const: "task" }
+  { key: "assignee",    path "assignee.name" }   // object subpath; drops when null
+storage: { nativeIdPathSafe: true }   // gid is numeric → identity path
+render:  { wrapperTag: "asana-tasks", itemTag: "task", bodyTag: "description",
+           maxCharsPerReference: 4000, maxTotalChars: 30000 }
+```
+
+### Why these choices
+
+- **`acceptSuffix: "get_task"`** (single-tool allowlist, mirrors Notion's
+  `notion-fetch`) rather than `denySuffixes` (blacklist, Linear). Asana's tool
+  surface is large; an allowlist is the safer default. `endsWith("get_task")`
+  precisely matches `mcp__claude_ai_Asana__get_task` and excludes `get_tasks`,
+  `get_my_tasks`, `search_tasks`, `create_task_confirm`, and all write tools.
+- **`wrapperKeys: ["data"]`** unwraps the `{data:{...}}` envelope; `walkPayload`
+  first tries `extractRef` at the top level (voids — `gid`/`name` live under
+  `data`), then descends `data` and matches the task object.
+- **`nativeId` from `gid`, `nativeIdPathSafe: true`**: Asana gids are numeric,
+  opaque, path-safe strings (like Linear/Notion ids), so the on-disk reference
+  path uses the id directly — no sha8 hashing (contrast GitHub's slashed keys).
+- **`url` host allowlist `^https://app\.asana\.com/`**: mirrors Notion's
+  allow-listed-host approach; rejects arbitrary URLs.
+- **Minimal, honest `fields`.** Two DSL constraints (both verified against
+  `SourceEngine`) shape this:
+  - `readPath` splits on `.` and descends via `isObject` only — it does **not**
+    support array indexing, so `projects.0.name` / `memberships.0.section.name`
+    cannot be read. Section and project are therefore **not** shown.
+  - `toScalar` returns `undefined` for booleans, so `completed` cannot render as
+    a field.
+
+  We use a constant `entity-type` (pattern from Notion/Zoom) and `assignee.name`
+  (a plain object subpath that cleanly drops when the assignee is null). The
+  exact field set is locked against the real fixture during TDD.
+
+## Touch list
+
+Verified against the current subsystem. Ordering downstream (`CLAUDE_TOOL_PREFIXES`,
+`referencesBySourceOrder`) derives from `getRegistry().all()`, so appending to
+`BUILTIN_DEFINITIONS` is the only functional registration.
+
+| # | File | Edit |
+|---|------|------|
+| 1 | `cli/src/core/references/sources/definitions/asana.ts` | **NEW** — `asanaDefinition` (above) |
+| 2 | `cli/src/core/references/sources/definitions/index.ts` | Import + append `asanaDefinition` to `BUILTIN_DEFINITIONS` |
+| 3 | `cli/src/Types.ts` (~775) | Add `"asana"` to `KnownSourceId` union |
+| 4 | `vscode/src/views/SourceLabels.ts` | Add `asana` row to `SOURCE_META` (TS-forced by #3): `{ label:"Asana", letter:"A", icon:"checklist", color:"#f06a6a" }` (icon/color match existing `SourceMeta` shape; confirm shape when editing) |
+| 5 | `cli/src/core/references/sources/definitions/asana.test.ts` | **NEW** — definition test, mirror `zoom-doc.test.ts`, using the real fixture (canonical case, void case, render case) |
+| 6 | `cli/src/core/references/SourceDefinitionRegistry.test.ts` | Extend the `all()` stable-order assertion (append `"asana"`) + add an `asana registration` describe: `match("claude","mcp__claude_ai_Asana__get_task")?.id === "asana"`, and assert enumeration/write tools are rejected |
+| 7 *(optional)* | `vscode/src/views/SummaryHtmlBuilder.ts` | Append `"asana"` to `HTML_REFERENCE_SOURCE_ORDER` (committed-memory HTML panel ordering) |
+
+**No edit needed:** `CLAUDE_TOOL_PREFIXES` (auto-derived), `SourceEngine.ts`,
+`SourceDefinition.ts`, `ClaudeEnvelopeParser.ts` / `CodexEnvelopeParser.ts`
+(Asana payloads are self-contained — no `CONTEXT_NORMALIZERS` entry),
+`ReferenceExtractor.ts`.
+
+## Testing
+
+- **Definition test** (`asana.test.ts`): feed the real fixture through
+  `extractRef` + `renderBlock`; assert `source`/`nativeId`/`title`/`url`/
+  `description`/`fields`; a void case (missing `gid` or non-Asana host); a render
+  case (`<asana-tasks><task …>`).
+- **Registry test**: stable-order list includes `"asana"`; `get_task` resolves to
+  the asana def; `search_tasks` / `get_my_tasks` / `create_task_confirm` do not.
+- `npm run all` must pass (CLI 97% coverage floor). New code is a data literal +
+  tests, so coverage is met by the definition test exercising every field/require.
+
+## Deferred: Codex
+
+Not implemented this round. Preconditions to add it later:
+
+1. A real Codex rollout on disk showing an Asana call under the `codex_apps`
+   server — the exact `server`/`tool` naming (e.g. `asana.get_task` vs
+   `asana.fetch`) must be read from that rollout, not guessed.
+2. Then add a `match.codex` block to `asanaDefinition` and a
+   `CodexAsanaBinding` (identity normalize, mirroring `CodexNotionBinding.ts`),
+   registered in `bindings/codex/index.ts` `CODEX_NORMALIZERS`, plus a
+   `CodexEnvelopeParser.test.ts` case built from the real rollout JSONL.
+
+## Non-goals
+
+- Asana projects, portfolios, users, or any non-task entity.
+- Codex support (deferred, above).
+- Any change to the DSL vocabulary, the envelope parsers, or storage/render
+  common layers.

--- a/vscode/src/views/SourceLabels.ts
+++ b/vscode/src/views/SourceLabels.ts
@@ -46,6 +46,7 @@ export const SOURCE_META: Record<KnownSourceId, SourceMeta> = {
 	slack: { label: "Slack", letter: "S", icon: "comment-discussion", color: "#4a154b" },
 	"zoom-meeting": { label: "Zoom Meeting", letter: "Z", icon: "device-camera-video", color: "#2D8CFF" },
 	"zoom-doc": { label: "Zoom Doc", letter: "Z", icon: "file", color: "#2D8CFF" },
+	asana: { label: "Asana", letter: "A", icon: "checklist", color: "#f06a6a" },
 };
 
 /** Neutral badge color for a source outside {@link SOURCE_META} (matches the prior `.mem-ctx-badge--reference` fallback hue). */

--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -639,11 +639,12 @@ describe("SummaryHtmlBuilder", () => {
 
 		// `SourceId` is now `string`, so `getSourceMeta` will hand back the raw id
 		// as the label for an unknown source. That raw id never reaches the DOM
-		// here because `referencesBySourceOrder` renders only the four known
-		// sources — the source-allowlist, not escaping, is what keeps a crafted
-		// source string (from a tampered orphan branch / shared Memory Bank) out
-		// of the webview. Pin that invariant so a future refactor that drops the
-		// allowlist can't silently turn the bare source label into an injection.
+		// here because `referencesBySourceOrder` renders only sources in the
+		// built-in `SourceDefinition` registry — the source-allowlist, not
+		// escaping, is what keeps a crafted source string (from a tampered orphan
+		// branch / shared Memory Bank) out of the webview. Pin that invariant so a
+		// future refactor that drops the allowlist can't silently turn the bare
+		// source label into an injection.
 		it("drops an unknown reference source from the HTML view (source allowlist)", () => {
 			const html = buildHtml(
 				makeSummary({
@@ -654,6 +655,29 @@ describe("SummaryHtmlBuilder", () => {
 			// the row would render; the source label is escaped, but "onerror"
 			// itself has no escapable chars, so it would still surface as text.)
 			expect(html).not.toContain("onerror");
+		});
+
+		// Counterpart to the allowlist test above: a source that IS a registered
+		// built-in but was NOT in the original hardcoded five (asana, zoom-*) must
+		// render. Pins that the allowlist is derived from the registry, so a new
+		// source appears here the moment it joins BUILTIN_DEFINITIONS.
+		it("renders a reference whose source is a registered built-in beyond the original hardcoded set (asana)", () => {
+			const html = buildHtml(
+				makeSummary({
+					references: [
+						{
+							source: "asana",
+							title: "Add Asana MCP integration",
+							url: "https://app.asana.com/1/1216474500374769/task/1216474542361983",
+							referencedAt: "2026-07-12T10:00:00Z",
+							sourceToolName: "mcp__claude_ai_Asana__get_task",
+							archivedKey: "asana:1216474542361983",
+							nativeId: "1216474542361983",
+						},
+					],
+				}),
+			);
+			expect(html).toContain("Add Asana MCP integration");
 		});
 
 		it('shows "No topics available" message when topics are empty', () => {

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -10,6 +10,7 @@
  */
 
 import { labelLeadsWithNativeId, referenceDisplayTitle } from "../../../cli/src/core/references/ReferenceDisplay.js";
+import { getRegistry } from "../../../cli/src/core/references/SourceDefinitionRegistry.js";
 import { isSummaryError } from "../../../cli/src/core/SummaryErrorMarker.js";
 import {
 	aggregateConversationTokenBreakdown,
@@ -1206,12 +1207,22 @@ export function buildFilesPanelShell(): string {
 </div>`;
 }
 
-const HTML_REFERENCE_SOURCE_ORDER: ReadonlyArray<SourceId> = ["linear", "jira", "github", "notion", "slack"];
-
 /**
- * Returns references ordered by source (linear → jira → github → notion),
- * preserving within-source order. Mirrors `referencesBySourceOrder` in
- * SummaryMarkdownBuilder so the HTML and Markdown views agree on item order.
+ * Orders references by source for the webview, using the built-in
+ * `SourceDefinition` registry as the render allowlist: only sources that ship
+ * as a built-in definition are rendered, in registry order (linear → jira →
+ * github → notion → slack → zoom-meeting → zoom-doc → asana → …), preserving
+ * within-source order.
+ *
+ * Deriving the allowlist from `getRegistry()` — rather than a hand-maintained
+ * subset — keeps every registered source visible (a new source appears here the
+ * moment it joins `BUILTIN_DEFINITIONS`, no second edit) while preserving the
+ * security property the previous hardcoded list provided: a `source` that is
+ * NOT a registered built-in (e.g. a crafted string from a tampered orphan
+ * branch / shared Memory Bank) is dropped, never rendered into the webview DOM.
+ * Unlike `SummaryMarkdownBuilder.referencesBySourceOrder` (LLM-prompt path,
+ * which appends unknown sources), this webview path deliberately does not append
+ * leftovers.
  */
 function referencesBySourceOrder(
 	references: ReadonlyArray<ReferenceCommitRef>,
@@ -1223,8 +1234,8 @@ function referencesBySourceOrder(
 		bySource.set(e.source, arr);
 	}
 	const out: Array<ReferenceCommitRef> = [];
-	for (const source of HTML_REFERENCE_SOURCE_ORDER) {
-		const arr = bySource.get(source);
+	for (const def of getRegistry().all()) {
+		const arr = bySource.get(def.id);
 		if (arr) out.push(...arr);
 	}
 	return out;


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (2)

1. Add Asana task reference capture and display (`865fcc5`) 
2. Add Asana MCP integration to reference extraction for Codex (`f2da6f1`)

## Quick recap (2)

### Commit 1 of 2: Add Asana task reference capture and display (`865fcc5`)

The developer added Asana task capture to the reference system, bringing it to feature parity with Linear, Jira, GitHub, Notion, Slack, and Zoom. When Claude calls the Asana `get_task` tool, the task is now automatically recorded into the working memory with its title, URL, description, and assignee. The implementation uses a registry-driven architecture so that future task sources can be added in one place and automatically cascade through all dependent systems — the CLI prompt path, the webview rendering, and the envelope pre-filter.

A related fix corrected the VS Code summary panel, which was silently dropping Asana and Zoom references even though they were correctly captured. The panel now renders all registered sources in order, derived from the same registry that defines the capture rules. The security property is preserved: only sources that ship as built-in definitions are rendered; crafted source strings from tampered memory are still dropped.

### Commit 2 of 2: Add Asana MCP integration to reference extraction for Codex (`f2da6f1`)

The developer completed the Codex half of Asana task reference extraction. The original design deferred this work because no Asana connector existed in Codex at the time; the machine now has the plugin installed and a real rollout captured a live get_task call. Every matcher value in the Codex integration was transcribed directly from that rollout data rather than guessed, following the principle that external system integrations must lock to observed reality. The Codex connector's output payload matches the Claude MCP shape exactly, so the binding uses identity normalization and reuses the existing reference extraction logic. Comprehensive tests verify both the PRIMARY match path (function_call with namespace and function name) and the FALLBACK path (mcp_tool_call_end with dotted invocation tool), plus enumeration-guard tests to ensure search and list tools are rejected. The design documentation was updated to describe the implemented Codex support and remove the deferral language.

## Topics (6)
<details>
<summary><strong>01 · [865fcc5] Capture Asana tasks as references from Claude get_task calls</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The codebase already captures task references from Linear, Jira, GitHub, Notion, Slack, and Zoom when Claude calls their respective tools. Asana was missing from this reference-capture system, so tasks retrieved via Claude's Asana connector were not being recorded into the working memory.

**💡 Decisions Behind the Code**

- **Suffix gate on get_task over enumeration tools**: The definition uses `acceptSuffix: "get_task"` to reject enumeration tools (`get_tasks`, `get_my_tasks`, `search_tasks`) and write operations (`create_task_confirm`). This ensures only single-task results are captured, preventing noise from bulk operations or confirmation dialogs.
- **Minimal field surface (entity-type and assignee only)**: Asana's section and project metadata live under array paths that the declarative DSL's dotted `readPath` cannot index, and boolean fields like `completed` are dropped by the scalar converter. Keeping fields minimal ensures clean, reliable output rather than attempting DSL extensions that would expand scope and risk.
- **Claude-only, no Codex**: The definition includes only a Claude MCP match, not Codex, because no Codex connector exposes Asana today. This avoids dead code and makes the scope explicit; Codex support can be added later if the connector is built.
- **Registry-driven cascading over manual ripple fixes**: The new source is added once to `BUILTIN_DEFINITIONS` and the registry automatically propagates it to all dependent systems (CLI prompt rendering, envelope pre-filter). This eliminates the risk of future sources being silently omitted from one or more paths.

**✅ What Was Implemented**

- Added a declarative `SourceDefinition` for Asana that extracts task metadata (ID, name, notes, permalink, assignee) from the MCP tool result, with `wrapperKeys: ["data"]` to unwrap the nested response structure and `acceptSuffix: "get_task"` to match only the read operation.
- Extended the reference-extraction registry by appending the Asana definition to `BUILTIN_DEFINITIONS`, added `"asana"` to the `KnownSourceId` union type, and registered display metadata (label, icon, brand color) in the VS Code source labels configuration.
- Validated the definition against a live `get_task` call to confirm the assumed envelope shape and field structure match production exactly.

**📁 FILES**
- `cli/src/core/references/sources/definitions/asana.ts`
- `cli/src/core/references/sources/definitions/index.ts`
- `cli/src/Types.ts`
- `vscode/src/views/SourceLabels.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [865fcc5] Fix webview reference rendering to include all registered sources</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The VS Code summary panel had a hardcoded allowlist of five sources for rendering references. Asana and Zoom references were being silently dropped from the webview even though they were correctly captured and stored, creating a discrepancy between what the CLI showed and what the user saw in the editor.

**💡 Decisions Behind the Code**

**Registry-derived allowlist over hardcoded subset**: The original hardcoded list served a dual purpose: render order and security allowlist. Deriving the allowlist from the registry preserves the security property while eliminating the maintenance burden and the risk of new sources being invisible in the webview.

**✅ What Was Implemented**

- Replaced the hardcoded source order array in the webview builder with a registry-derived loop that renders all sources registered in `BUILTIN_DEFINITIONS`, in registry order. The allowlist semantics are preserved — unknown or crafted source strings are still dropped for security — but the allowlist is now complete and auto-updates when new sources are added.
- Updated the function's documentation to clarify the distinction from the CLI's reference builder, which appends unknown sources (safe for LLM prompts) versus the webview path which deliberately does not (safe for DOM rendering).

**📁 FILES**
- `vscode/src/views/SummaryHtmlBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [865fcc5] Design specification for Asana task reference extraction</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A user requested adding Asana as a reference source so that when Claude Code calls the Asana MCP connector's task-fetch tool, the referenced task is captured as a Jolli reference alongside existing sources.

**💡 Decisions Behind the Code**

- **Claude-only scope with explicit Codex deferral**: Investigation revealed the local Codex environment has no Asana MCP server configured and no real Asana tool calls in on-disk rollouts. Shipping an unverified Codex matcher would produce dead code. The spec records Codex as a follow-up with a hard precondition: a real `codex_apps` Asana rollout captured on disk. This trades short-term completeness for long-term correctness and maintainability.
- **Single-tool allowlist over blacklist**: An allowlist is safer than a blacklist because it explicitly names the one tool to extract, whereas a blacklist requires guessing which tools to exclude and risks missing new ones. This mirrors Notion's approach and avoids the Linear enumeration-flooding problem.

**✅ What Was Implemented**

- Created a design specification document that defines the complete Asana reference source as a declarative `SourceDefinition`, including the real Asana API payload fixture, field mappings, Claude-side tool matching rules, and a seven-point implementation touch list.
- Scoped the work to Claude Code only (Codex deferred due to lack of real truth source in the local Codex environment) and to single-task fetches via `get_task` (excluding bulk enumeration tools to prevent Working Memory flooding).
- Documented DSL constraints discovered during design: `readPath` does not support array indexing (so project and section fields cannot be extracted) and `toScalar` returns undefined for booleans (so task completion status cannot be rendered). The spec records Codex as a follow-up with explicit preconditions.

**📁 FILES**
- `docs/superpowers/specs/2026-07-12-asana-reference-source-design.md`

</blockquote>
</details>
<details>
<summary><strong>04 · [865fcc5] Implementation plan for Asana reference source</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team needed a concrete implementation plan to guide the capture and display of Asana tasks when Claude Code sessions call the Asana MCP `get_task` tool.

**💡 Decisions Behind the Code**

- **Minimal field surface**: Only entity-type (constant) and assignee name are exposed as fields. Asana section and project metadata live under array paths that the DSL's dotted `readPath` cannot index, and the `completed` boolean is dropped by the `toScalar` operator, so attempting to surface these would either fail silently or require DSL changes outside the scope.
- **Claude-only, no Codex**: The definition includes no `match.codex` binding because no Asana connector exists in Codex today. This decision is documented in the source code comment and deferred explicitly rather than left ambiguous, preventing future confusion.
- **Suffix-based tool matching over prefix-only**: The `acceptSuffix: "get_task"` gate ensures the definition matches only the read operation and rejects `get_tasks`, `get_my_tasks`, `search_tasks`, and `create_task_confirm`, preventing accidental extraction from enumeration or write-confirmation tools.

**✅ What Was Implemented**

- Created a declarative `SourceDefinition` for Asana that extracts task metadata from the MCP tool result, with `wrapperKeys: ["data"]` to unwrap the nested response structure and `acceptSuffix: "get_task"` to match only the read operation.
- Extended the reference-extraction registry by appending the Asana definition to `BUILTIN_DEFINITIONS`, added `"asana"` to the `KnownSourceId` union, and registered display metadata (label, icon, brand color) in VS Code.
- Covered the definition with a comprehensive test suite validating extraction from the canonical task shape, field rendering, null-assignee handling, validation failures, and suffix-based tool matching to prevent false positives.

**📁 FILES**
- `cli/src/core/references/sources/definitions/asana.ts`
- `cli/src/core/references/sources/definitions/index.ts`
- `cli/src/Types.ts`
- `cli/src/core/references/sources/definitions/asana.test.ts`
- `cli/src/core/references/SourceDefinitionRegistry.test.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [f2da6f1] Add Asana task reference capture for Codex sessions</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The original design deferred Codex support for Asana task extraction because no Asana connector existed in Codex at the time. The machine now has the Asana plugin installed and a real rollout shows Codex calling the get_task tool, making it possible to implement the deferred Codex half.

**💡 Decisions Behind the Code**

- **Verify against real rollout data, not design assumptions**: The original design document stated "no Asana connector exists in Codex", but the machine had the plugin installed and a real rollout captured a live `get_task` call. Every value in `match.codex` (namespace suffix, function names, invocation tool format) was transcribed directly from that rollout rather than guessed, following the principle that external system integrations must be locked to observed reality to avoid hallucinated matchers that never match in production.
- **Identity normalization for payload compatibility**: The Codex connector wraps the task in `{data:{...}}` — exactly matching the Claude MCP shape. Rather than adding a custom normalizer, the binding uses identity normalization (payload passes through unchanged) and relies on the existing `wrapperKeys:["data"]` in the definition to unwrap it. This reuses proven extraction logic and avoids duplicating the reference DSL.
- **Allowlist enumeration/search/write tools**: The definition uses `functionCallNames:["_get_task"]` and `invocationTools:["asana.get_task"]` as an allowlist rather than excluding enumeration tools by name. This is safer than a blacklist when the tool surface is large and growing, and mirrors the Claude-side `acceptSuffix` approach.

**✅ What Was Implemented**

- Added `match.codex` block to `asanaDefinition` with namespace suffix, function call names, and invocation tool matchers transcribed directly from the real rollout data (namespace `mcp__codex_apps__asana`, function name `_get_task`, invocation tool `asana.get_task`).
- Created `CodexAsanaBinding.ts` with identity normalization, since the Codex connector's output payload (`{data:{...}}`) is byte-identical to the Claude MCP shape and requires no reshaping.
- Registered the binding in `bindings/codex/index.ts` and added comprehensive test coverage: PRIMARY and FALLBACK match paths in `CodexEnvelopeParser.test.ts`, enumeration-guard tests to reject `_get_my_tasks`, and end-to-end extraction tests verifying title and URL are correctly captured.

**📁 FILES**
- `cli/src/core/references/sources/definitions/asana.ts`
- `cli/src/core/references/bindings/codex/CodexAsanaBinding.ts`
- `cli/src/core/references/bindings/codex/index.ts`
- `cli/src/core/references/CodexEnvelopeParser.test.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · [f2da6f1] Update design documentation to reflect implemented Codex support</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The design spec marked Codex support as deferred pending a real rollout. Now that the feature is implemented, the documentation needs to be updated to describe the actual Codex integration and remove the deferral language.

**💡 Decisions Behind the Code**

The documentation captures the real rollout data as the source of truth for the Codex implementation. This prevents future confusion about whether the matcher values are guessed or verified, and provides a concrete reference for anyone maintaining or extending the integration.

**✅ What Was Implemented**

- Replaced the "Deferred: Codex" section with a complete "Codex support" section documenting the observed reality (real rollout data showing function_call, mcp_tool_call_end, and function_call_output shapes), the implementation approach (match.codex block and CodexAsanaBinding), and test coverage.
- Updated the summary and scope sections to reflect that both Claude and Codex are now shipped, removing the "Claude-only" language from the definition file header comment.

**📁 FILES**
- `docs/superpowers/specs/2026-07-12-asana-reference-source-design.md`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 13, 2026 at 3:31 PM · via Anthropic*
<!-- jollimemory-summary-end -->
