### PR TITLE
Add guided front door for bare `jolli` command on TTY

### DIFF
--- a/cli/src/Api.test.ts
+++ b/cli/src/Api.test.ts
@@ -31,6 +31,10 @@ const { mockQuestion } = vi.hoisted(() => ({
 	mockQuestion: vi.fn((_q: string, cb: (a: string) => void) => cb("")),
 }));
 
+const { mockRunGuidedFrontDoor } = vi.hoisted(() => ({
+	mockRunGuidedFrontDoor: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("node:child_process", () => ({
 	execFileSync: mockExecFileSync,
 }));
@@ -42,6 +46,10 @@ vi.mock("node:fs", async (importOriginal) => {
 
 vi.mock("node:readline", () => ({
 	createInterface: mockCreateInterface,
+}));
+
+vi.mock("./commands/GuidedFrontDoor.js", () => ({
+	runGuidedFrontDoor: mockRunGuidedFrontDoor,
 }));
 
 vi.mock("./core/SessionTracker.js", () => ({
@@ -333,6 +341,80 @@ describe("CLI", () => {
 		mockCreateInterface.mockReturnValue({
 			question: mockQuestion,
 			close: vi.fn(),
+		});
+	});
+
+	describe("bare `jolli` guided front door", () => {
+		const setTty = (stdin: boolean, stdout: boolean): void => {
+			Object.defineProperty(process.stdin, "isTTY", { value: stdin, configurable: true });
+			Object.defineProperty(process.stdout, "isTTY", { value: stdout, configurable: true });
+		};
+		let priorIn: unknown;
+		let priorOut: unknown;
+
+		beforeEach(() => {
+			priorIn = process.stdin.isTTY;
+			priorOut = process.stdout.isTTY;
+		});
+
+		afterEach(() => {
+			Object.defineProperty(process.stdin, "isTTY", { value: priorIn, configurable: true });
+			Object.defineProperty(process.stdout, "isTTY", { value: priorOut, configurable: true });
+		});
+
+		it("runs the front door with no args when stdin+stdout are TTY", async () => {
+			setTty(true, true);
+			await main([]);
+			expect(mockRunGuidedFrontDoor).toHaveBeenCalledTimes(1);
+		});
+
+		it("does NOT run the front door when stdin is not a TTY", async () => {
+			setTty(false, true);
+			const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+				throw new Error("process.exit");
+			}) as never);
+			try {
+				await main([]);
+			} catch {
+				// bare + non-TTY falls through to parseAsync → grouped help → exit(1)
+			} finally {
+				// It must NOT enter the front door, and it MUST fall through to
+				// parseAsync's help-and-exit path (positive proof of the fallback).
+				expect(mockRunGuidedFrontDoor).not.toHaveBeenCalled();
+				expect(exitSpy).toHaveBeenCalled();
+				exitSpy.mockRestore();
+			}
+		});
+
+		it("does NOT run the front door when stdout is piped (not a TTY)", async () => {
+			setTty(true, false);
+			const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+				throw new Error("process.exit");
+			}) as never);
+			try {
+				await main([]);
+			} catch {
+				// piped stdout falls through to parseAsync → grouped help
+			} finally {
+				expect(mockRunGuidedFrontDoor).not.toHaveBeenCalled();
+				expect(exitSpy).toHaveBeenCalled();
+				exitSpy.mockRestore();
+			}
+		});
+
+		it("does NOT run the front door when a subcommand is given, even on a full TTY", async () => {
+			setTty(true, true);
+			const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+				throw new Error("process.exit");
+			}) as never);
+			try {
+				await main(["--version"]);
+			} catch {
+				// --version prints and exits via commander; never enters the front door
+			} finally {
+				expect(mockRunGuidedFrontDoor).not.toHaveBeenCalled();
+				exitSpy.mockRestore();
+			}
 		});
 	});
 

--- a/cli/src/Api.ts
+++ b/cli/src/Api.ts
@@ -18,6 +18,7 @@ import { registerDoctorCommand } from "./commands/DoctorCommand.js";
 import { registerDisableCommand, registerEnableCommand } from "./commands/EnableCommand.js";
 import { registerExportCommand, registerExportPromptCommand } from "./commands/ExportCommand.js";
 import { registerGraphCommand } from "./commands/GraphCommand.js";
+import { runGuidedFrontDoor } from "./commands/GuidedFrontDoor.js";
 import { registerHealFolderCommand } from "./commands/HealFolderCommand.js";
 import { getHelpGroup } from "./commands/HelpGroups.js";
 import { registerBindCommand, registerPushCommand, registerSpacesCommand } from "./commands/JolliCloudCommands.js";
@@ -385,7 +386,17 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 	// check doesn't trigger a second discovery walk on the startup hot path.
 	await checkVersionMismatch({ pluginDiagnostics });
 
+	// Bare `jolli` (no subcommand) on an interactive terminal becomes the guided
+	// front door instead of a help wall. Requires BOTH stdin and stdout to be a
+	// TTY: piped (`jolli | cat`) or CI runs fall through to `parseAsync`, which
+	// prints the grouped help and never blocks or prompts.
+	const userArgs = args ?? process.argv.slice(2);
+	if (userArgs.length === 0 && process.stdin.isTTY === true && process.stdout.isTTY === true) {
+		await runGuidedFrontDoor();
+		return;
+	}
+
 	/* v8 ignore start - process.argv branch only used when running as script, not in tests */
-	await program.parseAsync(args ? ["node", "jolli", ...args] : process.argv);
+	await program.parseAsync(args !== undefined ? ["node", "jolli", ...args] : process.argv);
 	/* v8 ignore stop */
 }

--- a/cli/src/commands/GuidedFrontDoor.test.ts
+++ b/cli/src/commands/GuidedFrontDoor.test.ts
@@ -1,0 +1,272 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+	loadAuthToken: vi.fn(),
+	loadConfig: vi.fn(),
+	orphanBranchExists: vi.fn(),
+	getSummaryCount: vi.fn(),
+	track: vi.fn(),
+	triggerPendingPushRetry: vi.fn(),
+	isGitHookInstalled: vi.fn(),
+	install: vi.fn(),
+	promptText: vi.fn(),
+	resolveProjectDir: vi.fn(),
+	promptSetup: vi.fn(),
+	runSpaceSyncStep: vi.fn(),
+	createStorage: vi.fn(),
+	setActiveStorage: vi.fn(),
+}));
+
+vi.mock("../auth/AuthConfig.js", () => ({ loadAuthToken: h.loadAuthToken }));
+vi.mock("../core/SessionTracker.js", () => ({ loadConfig: h.loadConfig }));
+vi.mock("../core/GitOps.js", () => ({ orphanBranchExists: h.orphanBranchExists }));
+vi.mock("../core/StorageFactory.js", () => ({ createStorage: h.createStorage }));
+vi.mock("../core/SummaryStore.js", () => ({
+	getSummaryCount: h.getSummaryCount,
+	setActiveStorage: h.setActiveStorage,
+}));
+vi.mock("../core/Telemetry.js", () => ({ track: h.track }));
+vi.mock("../hooks/PushCompensation.js", () => ({ triggerPendingPushRetry: h.triggerPendingPushRetry }));
+vi.mock("../install/GitHookInstaller.js", () => ({ isGitHookInstalled: h.isGitHookInstalled }));
+vi.mock("../install/Installer.js", () => ({ install: h.install }));
+vi.mock("./EnableCommand.js", () => ({ promptSetup: h.promptSetup }));
+vi.mock("./SpaceSyncStep.js", () => ({ runSpaceSyncStep: h.runSpaceSyncStep }));
+vi.mock("./CliUtils.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./CliUtils.js")>();
+	return { ...actual, promptText: h.promptText, resolveProjectDir: h.resolveProjectDir };
+});
+
+import { getGuidedFrontDoorStatus, runGuidedFrontDoor } from "./GuidedFrontDoor.js";
+
+const PRIOR_ANTHROPIC = process.env.ANTHROPIC_API_KEY;
+
+describe("GuidedFrontDoor", () => {
+	let logs: string[];
+	let errors: string[];
+	let warns: string[];
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		process.exitCode = undefined;
+		// The host env may set ANTHROPIC_API_KEY, which would count as a credential
+		// and skip the sign-in guide. Remove it so "no credential" cases are honest.
+		delete process.env.ANTHROPIC_API_KEY;
+
+		logs = [];
+		errors = [];
+		warns = [];
+		vi.spyOn(console, "log").mockImplementation((...a: unknown[]) => {
+			logs.push(a.map(String).join(" "));
+		});
+		vi.spyOn(console, "error").mockImplementation((...a: unknown[]) => {
+			errors.push(a.map(String).join(" "));
+		});
+		vi.spyOn(console, "warn").mockImplementation((...a: unknown[]) => {
+			warns.push(a.map(String).join(" "));
+		});
+
+		// Defaults: signed in via OAuth, enabled, no memories yet.
+		h.resolveProjectDir.mockReturnValue("/repo");
+		h.createStorage.mockResolvedValue({});
+		h.loadAuthToken.mockResolvedValue("oauth-token");
+		h.loadConfig.mockResolvedValue({ jolliUrl: "https://acme.jolli.ai", jolliApiKey: "sk-jol-default" });
+		h.isGitHookInstalled.mockResolvedValue(true);
+		h.orphanBranchExists.mockResolvedValue(true);
+		h.getSummaryCount.mockResolvedValue(0);
+		h.install.mockResolvedValue({ success: true, warnings: [] });
+		h.promptText.mockResolvedValue("");
+		h.triggerPendingPushRetry.mockResolvedValue(undefined);
+		h.runSpaceSyncStep.mockResolvedValue(undefined);
+		h.promptSetup.mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		process.exitCode = undefined;
+	});
+
+	afterAll(() => {
+		if (PRIOR_ANTHROPIC === undefined) delete process.env.ANTHROPIC_API_KEY;
+		else process.env.ANTHROPIC_API_KEY = PRIOR_ANTHROPIC;
+	});
+
+	const out = (): string => logs.join("\n");
+
+	it("returning user (signed in + enabled): status line + delegates, no install", async () => {
+		h.getSummaryCount.mockResolvedValue(3);
+		await runGuidedFrontDoor();
+
+		expect(h.install).not.toHaveBeenCalled();
+		expect(h.triggerPendingPushRetry).toHaveBeenCalledWith("/repo");
+		expect(h.runSpaceSyncStep).toHaveBeenCalledWith("/repo");
+		expect(out()).toContain("signed in · acme.jolli.ai");
+		expect(out()).toContain("3 memories");
+		expect(out()).toContain("last memory saved");
+	});
+
+	it("no credential → runs promptSetup", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig.mockResolvedValue({});
+		await runGuidedFrontDoor();
+		expect(h.promptSetup).toHaveBeenCalledTimes(1);
+	});
+
+	it("still no credential after promptSetup → no success/listening line", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig.mockResolvedValue({});
+		await runGuidedFrontDoor();
+		expect(out()).toContain("not signed in");
+		expect(out()).not.toContain("Jolli is listening");
+	});
+
+	it("manual jolliApiKey (no OAuth) → shows 'configured', not 'signed in'", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-x" });
+		await runGuidedFrontDoor();
+		expect(h.promptSetup).not.toHaveBeenCalled();
+		expect(out()).toContain("configured (not signed in via OAuth)");
+		expect(out()).not.toContain("signed in ·");
+		expect(out()).toContain("Jolli is listening");
+	});
+
+	it("ANTHROPIC_API_KEY env counts as a credential", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig.mockResolvedValue({});
+		process.env.ANTHROPIC_API_KEY = "sk-ant-x";
+		try {
+			await runGuidedFrontDoor();
+			expect(h.promptSetup).not.toHaveBeenCalled();
+			expect(out()).toContain("configured (not signed in via OAuth)");
+		} finally {
+			delete process.env.ANTHROPIC_API_KEY;
+		}
+	});
+
+	it("not enabled + [Y/n]=y → install + track + push retry + delegate", async () => {
+		h.isGitHookInstalled.mockResolvedValue(false);
+		h.promptText.mockResolvedValue("y");
+		h.getSummaryCount.mockResolvedValue(5);
+		await runGuidedFrontDoor();
+
+		expect(h.install).toHaveBeenCalledWith("/repo", { source: "cli" });
+		expect(h.track).toHaveBeenCalledWith("surface_enabled", { trigger: "cli" });
+		expect(h.triggerPendingPushRetry).toHaveBeenCalledWith("/repo");
+		expect(h.runSpaceSyncStep).toHaveBeenCalledWith("/repo");
+		expect(out()).toContain("5 memories");
+		expect(out()).toContain("signed in");
+		expect(out()).toContain("Restart your AI agent session");
+	});
+
+	it("not enabled + [Y/n]=n → no install, early return", async () => {
+		h.isGitHookInstalled.mockResolvedValue(false);
+		h.promptText.mockResolvedValue("n");
+		await runGuidedFrontDoor();
+
+		expect(h.install).not.toHaveBeenCalled();
+		expect(h.runSpaceSyncStep).not.toHaveBeenCalled();
+		expect(out()).toContain("Not enabled");
+	});
+
+	it("install failure → error + exitCode 1 + no track + no delegate", async () => {
+		h.isGitHookInstalled.mockResolvedValue(false);
+		h.promptText.mockResolvedValue("y");
+		h.install.mockResolvedValue({ success: false, message: "boom", warnings: ["w1"] });
+		await runGuidedFrontDoor();
+
+		expect(errors.join("\n")).toContain("boom");
+		expect(warns.join("\n")).toContain("w1");
+		expect(h.track).not.toHaveBeenCalled();
+		expect(h.runSpaceSyncStep).not.toHaveBeenCalled();
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("install success with warnings → warnings printed", async () => {
+		h.isGitHookInstalled.mockResolvedValue(false);
+		h.promptText.mockResolvedValue("y");
+		h.install.mockResolvedValue({ success: true, warnings: ["heads up"] });
+		await runGuidedFrontDoor();
+		expect(warns.join("\n")).toContain("heads up");
+	});
+
+	it("first-run copy when summaryCount is 0", async () => {
+		h.getSummaryCount.mockResolvedValue(0);
+		await runGuidedFrontDoor();
+		expect(out()).toContain("your next commit is your first memory");
+	});
+
+	it("singular 'memory' when summaryCount is 1", async () => {
+		h.getSummaryCount.mockResolvedValue(1);
+		await runGuidedFrontDoor();
+		expect(out()).toContain("1 memory");
+		expect(out()).not.toContain("1 memories");
+	});
+
+	it("invalid jolliUrl → plain 'signed in' without a host", async () => {
+		h.loadConfig.mockResolvedValue({ jolliUrl: "not a url" });
+		await runGuidedFrontDoor();
+		expect(out()).toContain("signed in");
+		expect(out()).not.toContain("signed in ·");
+	});
+
+	it("missing jolliUrl → plain 'signed in'", async () => {
+		h.loadConfig.mockResolvedValue({});
+		await runGuidedFrontDoor();
+		expect(out()).not.toContain("signed in ·");
+	});
+
+	it("promptSetup turns no-credential into signed in + listening, and pushes backlog", async () => {
+		// Enabled returning repo, but the user has no credential until they sign in
+		// now. The enable branch is skipped, yet backlog catch-up must still fire.
+		h.loadAuthToken.mockResolvedValueOnce(undefined).mockResolvedValueOnce("new-token");
+		h.loadConfig.mockResolvedValueOnce({}).mockResolvedValueOnce({ jolliApiKey: "sk-jol-new" });
+		await runGuidedFrontDoor();
+
+		expect(h.promptSetup).toHaveBeenCalledTimes(1);
+		expect(out()).toContain("signed in");
+		expect(out()).toContain("Jolli is listening");
+		expect(h.triggerPendingPushRetry).toHaveBeenCalledWith("/repo");
+	});
+
+	it("config.apiKey alone counts as a credential", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig.mockResolvedValue({ apiKey: "sk-ant-x" });
+		await runGuidedFrontDoor();
+		expect(h.promptSetup).not.toHaveBeenCalled();
+		expect(out()).toContain("configured (not signed in via OAuth)");
+		expect(out()).toContain("Jolli is listening");
+	});
+
+	it("not enabled + empty answer (Enter) defaults to Yes → installs", async () => {
+		h.isGitHookInstalled.mockResolvedValue(false);
+		h.promptText.mockResolvedValue("");
+		await runGuidedFrontDoor();
+		expect(h.install).toHaveBeenCalledWith("/repo", { source: "cli" });
+	});
+
+	it("signed in via OAuth but no LLM credential → no 'listening', prompts to configure a key", async () => {
+		h.loadAuthToken.mockResolvedValue("oauth-token");
+		h.loadConfig.mockResolvedValue({ jolliUrl: "https://acme.jolli.ai" }); // no jolliApiKey / apiKey
+		await runGuidedFrontDoor();
+		expect(out()).toContain("signed in");
+		expect(out()).not.toContain("Jolli is listening");
+		expect(out()).toContain("Configure an API key");
+	});
+
+	describe("getGuidedFrontDoorStatus", () => {
+		it("no orphan branch → summaryCount 0, does not call getSummaryCount", async () => {
+			h.isGitHookInstalled.mockResolvedValue(true);
+			h.orphanBranchExists.mockResolvedValue(false);
+			const status = await getGuidedFrontDoorStatus("/repo");
+			expect(status).toEqual({ enabled: true, summaryCount: 0 });
+			expect(h.getSummaryCount).not.toHaveBeenCalled();
+		});
+
+		it("orphan branch exists → counts summaries", async () => {
+			h.isGitHookInstalled.mockResolvedValue(false);
+			h.orphanBranchExists.mockResolvedValue(true);
+			h.getSummaryCount.mockResolvedValue(7);
+			const status = await getGuidedFrontDoorStatus("/repo");
+			expect(status).toEqual({ enabled: false, summaryCount: 7 });
+		});
+	});
+});

--- a/cli/src/commands/GuidedFrontDoor.test.ts
+++ b/cli/src/commands/GuidedFrontDoor.test.ts
@@ -3,7 +3,6 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vites
 const h = vi.hoisted(() => ({
 	loadAuthToken: vi.fn(),
 	loadConfig: vi.fn(),
-	orphanBranchExists: vi.fn(),
 	getSummaryCount: vi.fn(),
 	track: vi.fn(),
 	triggerPendingPushRetry: vi.fn(),
@@ -15,11 +14,16 @@ const h = vi.hoisted(() => ({
 	runSpaceSyncStep: vi.fn(),
 	createStorage: vi.fn(),
 	setActiveStorage: vi.fn(),
+	saveConfigScoped: vi.fn(),
+	getGlobalConfigDir: vi.fn(),
 }));
 
 vi.mock("../auth/AuthConfig.js", () => ({ loadAuthToken: h.loadAuthToken }));
-vi.mock("../core/SessionTracker.js", () => ({ loadConfig: h.loadConfig }));
-vi.mock("../core/GitOps.js", () => ({ orphanBranchExists: h.orphanBranchExists }));
+vi.mock("../core/SessionTracker.js", () => ({
+	loadConfig: h.loadConfig,
+	saveConfigScoped: h.saveConfigScoped,
+	getGlobalConfigDir: h.getGlobalConfigDir,
+}));
 vi.mock("../core/StorageFactory.js", () => ({ createStorage: h.createStorage }));
 vi.mock("../core/SummaryStore.js", () => ({
 	getSummaryCount: h.getSummaryCount,
@@ -68,10 +72,11 @@ describe("GuidedFrontDoor", () => {
 		// Defaults: signed in via OAuth, enabled, no memories yet.
 		h.resolveProjectDir.mockReturnValue("/repo");
 		h.createStorage.mockResolvedValue({});
+		h.getGlobalConfigDir.mockReturnValue("/global/config");
+		h.saveConfigScoped.mockResolvedValue(undefined);
 		h.loadAuthToken.mockResolvedValue("oauth-token");
 		h.loadConfig.mockResolvedValue({ jolliUrl: "https://acme.jolli.ai", jolliApiKey: "sk-jol-default" });
 		h.isGitHookInstalled.mockResolvedValue(true);
-		h.orphanBranchExists.mockResolvedValue(true);
 		h.getSummaryCount.mockResolvedValue(0);
 		h.install.mockResolvedValue({ success: true, warnings: [] });
 		h.promptText.mockResolvedValue("");
@@ -124,9 +129,11 @@ describe("GuidedFrontDoor", () => {
 		h.loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-x" });
 		await runGuidedFrontDoor();
 		expect(h.promptSetup).not.toHaveBeenCalled();
-		expect(out()).toContain("configured (not signed in via OAuth)");
+		expect(out()).toContain("Jolli API key set (not signed in to Jolli)");
 		expect(out()).not.toContain("signed in ·");
 		expect(out()).toContain("Jolli is listening");
+		// Has a jolliApiKey (can already sync) → must NOT nudge sign-in.
+		expect(out()).not.toContain("sync memories to a Space");
 	});
 
 	it("ANTHROPIC_API_KEY env counts as a credential", async () => {
@@ -136,7 +143,7 @@ describe("GuidedFrontDoor", () => {
 		try {
 			await runGuidedFrontDoor();
 			expect(h.promptSetup).not.toHaveBeenCalled();
-			expect(out()).toContain("configured (not signed in via OAuth)");
+			expect(out()).toContain("Anthropic API key set (not signed in to Jolli)");
 		} finally {
 			delete process.env.ANTHROPIC_API_KEY;
 		}
@@ -155,6 +162,16 @@ describe("GuidedFrontDoor", () => {
 		expect(out()).toContain("5 memories");
 		expect(out()).toContain("signed in");
 		expect(out()).toContain("Restart your AI agent session");
+	});
+
+	it("just enabled a fresh repo (no memories yet) → 0 memories", async () => {
+		h.isGitHookInstalled.mockResolvedValue(false);
+		h.promptText.mockResolvedValue("y");
+		h.getSummaryCount.mockResolvedValue(0); // fresh repo, empty index
+		await runGuidedFrontDoor();
+		expect(h.install).toHaveBeenCalled();
+		expect(h.getSummaryCount).toHaveBeenCalled();
+		expect(out()).toContain("0 memories");
 	});
 
 	it("not enabled + [Y/n]=n → no install, early return", async () => {
@@ -227,13 +244,15 @@ describe("GuidedFrontDoor", () => {
 		expect(h.triggerPendingPushRetry).toHaveBeenCalledWith("/repo");
 	});
 
-	it("config.apiKey alone counts as a credential", async () => {
+	it("config.apiKey alone (no Jolli credential) → generates locally + nudges sign-in", async () => {
 		h.loadAuthToken.mockResolvedValue(undefined);
 		h.loadConfig.mockResolvedValue({ apiKey: "sk-ant-x" });
 		await runGuidedFrontDoor();
 		expect(h.promptSetup).not.toHaveBeenCalled();
-		expect(out()).toContain("configured (not signed in via OAuth)");
+		expect(out()).toContain("Anthropic API key set (not signed in to Jolli)");
 		expect(out()).toContain("Jolli is listening");
+		// Pure-Anthropic user with no Jolli credential — soft nudge to sign in.
+		expect(out()).toContain("sync memories to a Space");
 	});
 
 	it("not enabled + empty answer (Enter) defaults to Yes → installs", async () => {
@@ -243,30 +262,113 @@ describe("GuidedFrontDoor", () => {
 		expect(h.install).toHaveBeenCalledWith("/repo", { source: "cli" });
 	});
 
-	it("signed in via OAuth but no LLM credential → no 'listening', prompts to configure a key", async () => {
+	it("signed in but no usable key → offers a fix, no false 'listening'", async () => {
 		h.loadAuthToken.mockResolvedValue("oauth-token");
-		h.loadConfig.mockResolvedValue({ jolliUrl: "https://acme.jolli.ai" }); // no jolliApiKey / apiKey
+		h.loadConfig.mockResolvedValue({ jolliUrl: "https://acme.jolli.ai" }); // no key at all
+		h.promptText.mockResolvedValue(""); // menu default → enter key → empty → skip
 		await runGuidedFrontDoor();
 		expect(out()).toContain("signed in");
 		expect(out()).not.toContain("Jolli is listening");
-		expect(out()).toContain("Configure an API key");
+		expect(out()).toContain("no usable key");
+	});
+
+	it("choose 'switch to Jolli' → saves aiProvider jolli; listening reflects existing memory count", async () => {
+		h.loadAuthToken.mockResolvedValue("oauth-token");
+		h.loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-x", aiProvider: "anthropic" });
+		h.getSummaryCount.mockResolvedValue(163); // returning repo with history
+		h.promptText.mockResolvedValue("2");
+		await runGuidedFrontDoor();
+		expect(h.saveConfigScoped).toHaveBeenCalledWith({ aiProvider: "jolli" }, "/global/config");
+		expect(out()).toContain("switched to Jolli");
+		// Must NOT claim "first memory" when the repo already has memories.
+		expect(out()).toContain("last memory saved");
+		expect(out()).not.toContain("first memory");
+	});
+
+	it("choose 'enter Anthropic key' → saves apiKey + provider anthropic; listening reflects memory count", async () => {
+		h.loadAuthToken.mockResolvedValue("oauth-token");
+		h.loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-x", aiProvider: "anthropic" });
+		h.getSummaryCount.mockResolvedValue(163);
+		h.promptText.mockResolvedValueOnce("1").mockResolvedValueOnce("sk-ant-new");
+		await runGuidedFrontDoor();
+		expect(h.saveConfigScoped).toHaveBeenCalledWith(
+			{ apiKey: "sk-ant-new", aiProvider: "anthropic" },
+			"/global/config",
+		);
+		expect(out()).toContain("Anthropic key saved");
+		expect(out()).toContain("last memory saved");
+		expect(out()).not.toContain("first memory");
+	});
+
+	it("provider=anthropic + jolliApiKey, press Enter at menu → defaults to entering an Anthropic key", async () => {
+		h.loadAuthToken.mockResolvedValue("oauth-token");
+		h.loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-x", aiProvider: "anthropic" });
+		h.promptText.mockResolvedValueOnce("").mockResolvedValueOnce("sk-ant-y");
+		await runGuidedFrontDoor();
+		expect(h.saveConfigScoped).toHaveBeenCalledWith(
+			{ apiKey: "sk-ant-y", aiProvider: "anthropic" },
+			"/global/config",
+		);
+	});
+
+	it("provider=anthropic + jolliApiKey, choose 'skip' → no config change", async () => {
+		h.loadAuthToken.mockResolvedValue("oauth-token");
+		h.loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-x", aiProvider: "anthropic" });
+		h.promptText.mockResolvedValue("3");
+		await runGuidedFrontDoor();
+		expect(h.saveConfigScoped).not.toHaveBeenCalled();
+		expect(out()).not.toContain("Jolli is listening");
+	});
+
+	it("no jolliApiKey path: enter Anthropic key → saved", async () => {
+		h.loadAuthToken.mockResolvedValue("oauth-token");
+		h.loadConfig.mockResolvedValue({ aiProvider: "anthropic" }); // no jolliApiKey
+		h.promptText.mockResolvedValueOnce("1").mockResolvedValueOnce("sk-ant-x");
+		await runGuidedFrontDoor();
+		expect(h.saveConfigScoped).toHaveBeenCalledWith(
+			{ apiKey: "sk-ant-x", aiProvider: "anthropic" },
+			"/global/config",
+		);
+	});
+
+	it("no jolliApiKey path: skip → no change", async () => {
+		h.loadAuthToken.mockResolvedValue("oauth-token");
+		h.loadConfig.mockResolvedValue({ aiProvider: "anthropic" });
+		h.promptText.mockResolvedValue("2"); // skip in the no-Jolli menu
+		await runGuidedFrontDoor();
+		expect(h.saveConfigScoped).not.toHaveBeenCalled();
+	});
+
+	it("enter Anthropic key but press Enter (empty) → skipped, no save", async () => {
+		h.loadAuthToken.mockResolvedValue("oauth-token");
+		h.loadConfig.mockResolvedValue({ aiProvider: "anthropic" });
+		h.promptText.mockResolvedValueOnce("1").mockResolvedValueOnce("");
+		await runGuidedFrontDoor();
+		expect(h.saveConfigScoped).not.toHaveBeenCalled();
 	});
 
 	describe("getGuidedFrontDoorStatus", () => {
-		it("no orphan branch → summaryCount 0, does not call getSummaryCount", async () => {
-			h.isGitHookInstalled.mockResolvedValue(true);
-			h.orphanBranchExists.mockResolvedValue(false);
-			const status = await getGuidedFrontDoorStatus("/repo");
-			expect(status).toEqual({ enabled: true, summaryCount: 0 });
-			expect(h.getSummaryCount).not.toHaveBeenCalled();
-		});
-
-		it("orphan branch exists → counts summaries", async () => {
+		it("counts summaries from the active storage", async () => {
 			h.isGitHookInstalled.mockResolvedValue(false);
-			h.orphanBranchExists.mockResolvedValue(true);
 			h.getSummaryCount.mockResolvedValue(7);
 			const status = await getGuidedFrontDoorStatus("/repo");
 			expect(status).toEqual({ enabled: false, summaryCount: 7 });
+		});
+
+		it("folder-only repo with no orphan branch still reports its memories", async () => {
+			// Regression: previously gated on orphanBranchExists, so folder-mode
+			// repos (memories on disk, no orphan branch) wrongly reported 0.
+			h.isGitHookInstalled.mockResolvedValue(true);
+			h.getSummaryCount.mockResolvedValue(4);
+			const status = await getGuidedFrontDoorStatus("/repo");
+			expect(status).toEqual({ enabled: true, summaryCount: 4 });
+		});
+
+		it("empty index → 0 memories", async () => {
+			h.isGitHookInstalled.mockResolvedValue(true);
+			h.getSummaryCount.mockResolvedValue(0);
+			const status = await getGuidedFrontDoorStatus("/repo");
+			expect(status).toEqual({ enabled: true, summaryCount: 0 });
 		});
 	});
 });

--- a/cli/src/commands/GuidedFrontDoor.ts
+++ b/cli/src/commands/GuidedFrontDoor.ts
@@ -1,0 +1,144 @@
+/**
+ * The guided front door — what bare `jolli` (no args, interactive TTY) runs.
+ *
+ * It reads two axes of state — auth (global sign-in / credentials) and enable
+ * (per-repo hooks) — and offers the next step: sign in, enable the repo, then
+ * confirm "Jolli is listening". It replaces having to run `auth login`, `auth
+ * status`, `enable`, and `status` by hand, without removing those commands.
+ *
+ * Everything about the cloud side (pushing memories to a Jolli Space, binding,
+ * sync prompts) is delegated to `runSpaceSyncStep` — the front door only calls
+ * it once the repo is enabled and prints nothing about push/sync itself.
+ */
+
+import { loadAuthToken } from "../auth/AuthConfig.js";
+import { orphanBranchExists } from "../core/GitOps.js";
+import { resolveLlmCredentialSource } from "../core/LlmClient.js";
+import { loadConfig } from "../core/SessionTracker.js";
+import { createStorage } from "../core/StorageFactory.js";
+import { getSummaryCount, setActiveStorage } from "../core/SummaryStore.js";
+import { track } from "../core/Telemetry.js";
+import { triggerPendingPushRetry } from "../hooks/PushCompensation.js";
+import { isGitHookInstalled } from "../install/GitHookInstaller.js";
+import { install } from "../install/Installer.js";
+import { ORPHAN_BRANCH, setLogDir } from "../Logger.js";
+import { isAffirmative, promptText, resolveProjectDir } from "./CliUtils.js";
+import { promptSetup } from "./EnableCommand.js";
+import { runSpaceSyncStep } from "./SpaceSyncStep.js";
+
+/** Lightweight front-door status. Deliberately avoids the heavy `getStatus()`. */
+export interface GuidedFrontDoorStatus {
+	readonly enabled: boolean;
+	readonly summaryCount: number;
+}
+
+/**
+ * Reads only what the front door needs: whether the git hook is installed and
+ * how many memories exist. Unlike `getStatus()`, this does not probe every AI
+ * host, scan Codex / OpenCode sessions, or enumerate worktrees.
+ */
+export async function getGuidedFrontDoorStatus(cwd: string): Promise<GuidedFrontDoorStatus> {
+	const enabled = await isGitHookInstalled(cwd);
+	const summaryCount = (await orphanBranchExists(ORPHAN_BRANCH, cwd)) ? await getSummaryCount(cwd) : 0;
+	return { enabled, summaryCount };
+}
+
+/** Extracts the host from a saved Jolli site URL, if any, for the status line. */
+function siteHost(jolliUrl: string | undefined): string | undefined {
+	if (!jolliUrl) return undefined;
+	try {
+		return new URL(jolliUrl).host;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Runs the guided front door. Assumes the caller (Api.ts) has already confirmed
+ * an interactive TTY on both stdin and stdout — this never guards for that.
+ */
+export async function runGuidedFrontDoor(): Promise<void> {
+	const cwd = resolveProjectDir();
+	// Initialise storage the way every other memory-reading command does, so
+	// folder-mode users read from their Memory Bank rather than the orphan-branch
+	// fallback (which also logs a resolveStorage warning).
+	setActiveStorage(await createStorage(cwd, cwd));
+	let token = await loadAuthToken();
+	let config = await loadConfig();
+	let { enabled, summaryCount } = await getGuidedFrontDoorStatus(cwd);
+
+	// Any of these counts as "has some credential" and skips the sign-in guide.
+	const hasCredential = (): boolean =>
+		Boolean(token || config.jolliApiKey || config.apiKey || process.env.ANTHROPIC_API_KEY);
+	// Whether summaries can actually be generated. Uses the authoritative resolver
+	// so it honours the chosen aiProvider — e.g. provider "anthropic" with only a
+	// jolliApiKey (and no Anthropic key) cannot generate. "Jolli is listening" is
+	// a capability promise, so it is gated on this, not on being signed in.
+	const canGenerate = (): boolean => resolveLlmCredentialSource(config) !== null;
+
+	// ── Auth axis: no credential at all → run the existing sign-in / config guide ──
+	if (!hasCredential()) {
+		await promptSetup();
+		token = await loadAuthToken();
+		config = await loadConfig();
+	}
+
+	// ── Enable axis: not enabled → offer to enable ──
+	if (!enabled) {
+		const answer = await promptText("\n  Enable Jolli in this repo? [Y/n] ");
+		if (!isAffirmative(answer)) {
+			console.log("\n  Not enabled. Run `jolli` or `jolli enable` anytime.\n");
+			return;
+		}
+		setLogDir(cwd);
+		const result = await install(cwd, { source: "cli" });
+		if (!result.success) {
+			console.error(`\n  Error: ${result.message}\n`);
+			for (const warning of result.warnings) console.warn(`  Warning: ${warning}`);
+			process.exitCode = 1;
+			return;
+		}
+		track("surface_enabled", { trigger: "cli" });
+		for (const warning of result.warnings) console.warn(`  Warning: ${warning}`);
+		// Git hooks record commits immediately, but the AI-agent session hooks
+		// (Claude, Gemini) only attach on a fresh session — say so once here.
+		console.log("\n  Restart your AI agent session so it records that session too.");
+		enabled = true;
+		summaryCount = (await getGuidedFrontDoorStatus(cwd)).summaryCount;
+	}
+
+	// ── Status line: reflect the real credential state, never a blanket sign-in ──
+	if (token) {
+		const site = siteHost(config.jolliUrl);
+		console.log(site ? `\n  ✓ signed in · ${site}` : "\n  ✓ signed in");
+	} else if (canGenerate()) {
+		console.log("\n  ✓ configured (not signed in via OAuth)");
+	} else {
+		console.log("\n  ✗ not signed in — run `jolli auth login` to start generating memories");
+	}
+	console.log(`  ✓ enabled · ${summaryCount} ${summaryCount === 1 ? "memory" : "memories"}`);
+
+	// ── Cloud sync + push catch-up: whenever enabled. triggerPendingPushRetry is
+	// idempotent and no-ops when not signed in, so a returning user who just
+	// signed in still gets their backlog pushed (matches `jolli enable`). ──
+	if (enabled) {
+		void triggerPendingPushRetry(cwd);
+		await runSpaceSyncStep(cwd);
+	}
+
+	// ── Confirmation: only promise "listening" when memories can be generated ──
+	if (canGenerate()) {
+		console.log(
+			summaryCount === 0
+				? "\n  Jolli is listening — your next commit is your first memory\n"
+				: "\n  Jolli is listening — last memory saved.\n",
+		);
+	} else if (token) {
+		// Signed in, but the chosen provider has no usable key (e.g. provider is
+		// Anthropic but its key is unset). Be honest and point at the fix — don't
+		// suggest `auth login`, which only helps the Jolli provider.
+		console.log(
+			"\n  Signed in, but the current AI provider has no usable key — memories won't be generated.\n  Set one in Jolli Memory settings or run `jolli configure`.\n",
+		);
+	}
+}

--- a/cli/src/commands/GuidedFrontDoor.ts
+++ b/cli/src/commands/GuidedFrontDoor.ts
@@ -12,16 +12,16 @@
  */
 
 import { loadAuthToken } from "../auth/AuthConfig.js";
-import { orphanBranchExists } from "../core/GitOps.js";
 import { resolveLlmCredentialSource } from "../core/LlmClient.js";
-import { loadConfig } from "../core/SessionTracker.js";
+import { getGlobalConfigDir, loadConfig, saveConfigScoped } from "../core/SessionTracker.js";
 import { createStorage } from "../core/StorageFactory.js";
 import { getSummaryCount, setActiveStorage } from "../core/SummaryStore.js";
 import { track } from "../core/Telemetry.js";
 import { triggerPendingPushRetry } from "../hooks/PushCompensation.js";
 import { isGitHookInstalled } from "../install/GitHookInstaller.js";
 import { install } from "../install/Installer.js";
-import { ORPHAN_BRANCH, setLogDir } from "../Logger.js";
+import { setLogDir } from "../Logger.js";
+import type { JolliMemoryConfig } from "../Types.js";
 import { isAffirmative, promptText, resolveProjectDir } from "./CliUtils.js";
 import { promptSetup } from "./EnableCommand.js";
 import { runSpaceSyncStep } from "./SpaceSyncStep.js";
@@ -39,7 +39,12 @@ export interface GuidedFrontDoorStatus {
  */
 export async function getGuidedFrontDoorStatus(cwd: string): Promise<GuidedFrontDoorStatus> {
 	const enabled = await isGitHookInstalled(cwd);
-	const summaryCount = (await orphanBranchExists(ORPHAN_BRANCH, cwd)) ? await getSummaryCount(cwd) : 0;
+	// Read the count straight from the active storage (set by runGuidedFrontDoor
+	// before calling this). getSummaryCount returns 0 when no index exists, so
+	// this covers the fresh-repo case without gating on the orphan branch —
+	// gating on it would report 0 for folder-only repos that have memories but
+	// no orphan branch.
+	const summaryCount = await getSummaryCount(cwd);
 	return { enabled, summaryCount };
 }
 
@@ -70,12 +75,6 @@ export async function runGuidedFrontDoor(): Promise<void> {
 	// Any of these counts as "has some credential" and skips the sign-in guide.
 	const hasCredential = (): boolean =>
 		Boolean(token || config.jolliApiKey || config.apiKey || process.env.ANTHROPIC_API_KEY);
-	// Whether summaries can actually be generated. Uses the authoritative resolver
-	// so it honours the chosen aiProvider — e.g. provider "anthropic" with only a
-	// jolliApiKey (and no Anthropic key) cannot generate. "Jolli is listening" is
-	// a capability promise, so it is gated on this, not on being signed in.
-	const canGenerate = (): boolean => resolveLlmCredentialSource(config) !== null;
-
 	// ── Auth axis: no credential at all → run the existing sign-in / config guide ──
 	if (!hasCredential()) {
 		await promptSetup();
@@ -104,15 +103,22 @@ export async function runGuidedFrontDoor(): Promise<void> {
 		// (Claude, Gemini) only attach on a fresh session — say so once here.
 		console.log("\n  Restart your AI agent session so it records that session too.");
 		enabled = true;
-		summaryCount = (await getGuidedFrontDoorStatus(cwd)).summaryCount;
+		// enabled is now known true, so only the count can have changed — read it
+		// directly instead of re-running the whole lightweight status.
+		summaryCount = await getSummaryCount(cwd);
 	}
 
 	// ── Status line: reflect the real credential state, never a blanket sign-in ──
+	// `credSource` uses the authoritative resolver (honours the chosen aiProvider),
+	// so it can name the actual key in play and also gates "listening" below. A
+	// bare OAuth token alone is not an LLM credential, hence null → "not signed in".
+	const credSource = resolveLlmCredentialSource(config);
 	if (token) {
 		const site = siteHost(config.jolliUrl);
 		console.log(site ? `\n  ✓ signed in · ${site}` : "\n  ✓ signed in");
-	} else if (canGenerate()) {
-		console.log("\n  ✓ configured (not signed in via OAuth)");
+	} else if (credSource) {
+		const keyLabel = credSource === "jolli-proxy" ? "Jolli API key" : "Anthropic API key";
+		console.log(`\n  ✓ ${keyLabel} set (not signed in to Jolli)`);
 	} else {
 		console.log("\n  ✗ not signed in — run `jolli auth login` to start generating memories");
 	}
@@ -127,18 +133,80 @@ export async function runGuidedFrontDoor(): Promise<void> {
 	}
 
 	// ── Confirmation: only promise "listening" when memories can be generated ──
-	if (canGenerate()) {
-		console.log(
-			summaryCount === 0
-				? "\n  Jolli is listening — your next commit is your first memory\n"
-				: "\n  Jolli is listening — last memory saved.\n",
-		);
-	} else if (token) {
-		// Signed in, but the chosen provider has no usable key (e.g. provider is
-		// Anthropic but its key is unset). Be honest and point at the fix — don't
-		// suggest `auth login`, which only helps the Jolli provider.
-		console.log(
-			"\n  Signed in, but the current AI provider has no usable key — memories won't be generated.\n  Set one in Jolli Memory settings or run `jolli configure`.\n",
-		);
+	let generatable = credSource !== null;
+	if (!generatable && token) {
+		// Signed in, but the chosen provider has no usable key. Offer an in-place
+		// fix; it returns whether we can generate now (a key was set / provider switched).
+		generatable = await promptGenerationFix(config);
+		// NOTE: promptGenerationFix may have persisted config changes (via
+		// saveConfigScoped); the in-memory `config` / `credSource` are now stale.
+		// Nothing below re-reads them — re-read config if you add logic that does.
 	}
+	if (generatable) {
+		const listening =
+			summaryCount === 0
+				? "Jolli is listening — your next commit is your first memory"
+				: "Jolli is listening — last memory saved.";
+		// Generating locally via an Anthropic key but with no Jolli credential at
+		// all — nudge (never force) sign-in so memories can sync to a Space.
+		const nudge =
+			!token && !config.jolliApiKey
+				? "\n  Not signed in to Jolli — run `jolli auth login` to sync memories to a Space."
+				: "";
+		console.log(`\n  ${listening}${nudge}\n`);
+	}
+}
+
+/**
+ * Signed in, but the active provider has no usable key. Offer to fix it in place:
+ * enter an Anthropic key, or — when the user already has a Jolli sign-in key —
+ * switch to the Jolli provider. The provider is only ever changed by an explicit
+ * choice here, never silently. Each choice writes `aiProvider` so the saved
+ * credential and the chosen provider can't drift out of sync.
+ */
+async function promptGenerationFix(config: JolliMemoryConfig): Promise<boolean> {
+	const configDir = getGlobalConfigDir();
+	// Reaching here means canGenerate() was false. If a jolliApiKey exists the
+	// provider cannot be "jolli" (that would already generate), so offering to
+	// switch to Jolli is always safe when a jolliApiKey is present.
+	const canUseJolli = Boolean(config.jolliApiKey);
+
+	console.log("\n  Signed in, but the current AI provider has no usable key — memories won't be generated.\n");
+	if (canUseJolli) {
+		console.log("    1. Enter an Anthropic API key          (keeps Anthropic)");
+		console.log("    2. Switch to Jolli (use your sign-in)");
+		console.log("    3. Skip for now");
+		const choice = (await promptText("\n  Choice [1]: ")) || "1";
+		if (choice === "3") {
+			console.log("\n  Skipped. Set a key in settings or run `jolli configure` later.\n");
+			return false;
+		}
+		if (choice === "2") {
+			await saveConfigScoped({ aiProvider: "jolli" }, configDir);
+			console.log("\n  ✓ switched to Jolli");
+			return true;
+		}
+		return promptAndSaveAnthropicKey(configDir);
+	}
+
+	console.log("    1. Enter an Anthropic API key");
+	console.log("    2. Skip for now");
+	const choice = (await promptText("\n  Choice [1]: ")) || "1";
+	if (choice === "2") {
+		console.log("\n  Skipped. Set a key in settings or run `jolli configure` later.\n");
+		return false;
+	}
+	return promptAndSaveAnthropicKey(configDir);
+}
+
+/** Prompts for an Anthropic API key, saves it, and pins the provider to Anthropic. Returns whether a key was saved. */
+async function promptAndSaveAnthropicKey(configDir: string): Promise<boolean> {
+	const key = await promptText("\n  Anthropic API Key (press Enter to skip): ");
+	if (!key) {
+		console.log("  Skipped. Set a key in settings or run `jolli configure` later.\n");
+		return false;
+	}
+	await saveConfigScoped({ apiKey: key, aiProvider: "anthropic" }, configDir);
+	console.log("\n  ✓ Anthropic key saved");
+	return true;
 }

--- a/cli/src/commands/SpaceSyncStep.test.ts
+++ b/cli/src/commands/SpaceSyncStep.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runSpaceSyncStep } from "./SpaceSyncStep.js";
+
+describe("runSpaceSyncStep (stub)", () => {
+	let logSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		logSpy.mockRestore();
+	});
+
+	it("prints the development placeholder", async () => {
+		await runSpaceSyncStep("/repo");
+		expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("[space-sync]"));
+	});
+});

--- a/cli/src/commands/SpaceSyncStep.test.ts
+++ b/cli/src/commands/SpaceSyncStep.test.ts
@@ -3,16 +3,26 @@ import { runSpaceSyncStep } from "./SpaceSyncStep.js";
 
 describe("runSpaceSyncStep (stub)", () => {
 	let logSpy: ReturnType<typeof vi.spyOn>;
+	const PRIOR_DEV = process.env.JOLLI_DEV;
 
 	beforeEach(() => {
 		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		delete process.env.JOLLI_DEV;
 	});
 
 	afterEach(() => {
 		logSpy.mockRestore();
+		if (PRIOR_DEV === undefined) delete process.env.JOLLI_DEV;
+		else process.env.JOLLI_DEV = PRIOR_DEV;
 	});
 
-	it("prints the development placeholder", async () => {
+	it("stays silent for end users (no JOLLI_DEV) — placeholder must not leak in a release", async () => {
+		await runSpaceSyncStep("/repo");
+		expect(logSpy).not.toHaveBeenCalled();
+	});
+
+	it("prints the dev placeholder when JOLLI_DEV is set", async () => {
+		process.env.JOLLI_DEV = "1";
 		await runSpaceSyncStep("/repo");
 		expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("[space-sync]"));
 	});

--- a/cli/src/commands/SpaceSyncStep.ts
+++ b/cli/src/commands/SpaceSyncStep.ts
@@ -1,0 +1,32 @@
+/**
+ * Cloud sync / Space-binding step delegated by the guided front door.
+ *
+ * The guided front door (`runGuidedFrontDoor`) owns the auth + enable axes and
+ * calls this once whenever the repo is in the enabled state. Everything about
+ * getting memories into a Jolli Space — unbound detection, single/multi Space
+ * binding, and every sync-related user prompt — belongs here, not in the front
+ * door. Kept in its own module so the front door's tests can mock it.
+ *
+ * Contract for the implementer:
+ *   - Called only on an interactive TTY (the front door guards this) and only
+ *     when the repo is enabled. Whether the user is signed in / has a Jolli API
+ *     key is this function's own concern — return quietly when there is none.
+ *   - Called on EVERY bare `jolli` that reaches the enabled state, so this owns
+ *     the setup-if-needed decision: return fast and silently once the repo is
+ *     bound and synced; do not hit the network every time.
+ *   - A 409 "binding already exists" must be handled fail-closed: treat it as
+ *     success only when the existing space id matches the requested one;
+ *     otherwise surface an error and stop, never silently pushing memories to
+ *     the wrong Space (mirror pushBranchToJolli's existing behaviour).
+ *   - Push catch-up is already triggered by the front door whenever the repo is
+ *     enabled; re-trigger here only if needed (it is idempotent).
+ *
+ * Currently a stub: prints a development-only placeholder so the front door's
+ * call site and timing can be exercised end-to-end. Replace the body with the
+ * real push / sync / Space orchestration.
+ */
+export async function runSpaceSyncStep(cwd: string): Promise<void> {
+	void cwd;
+	// Development placeholder — remove when the real sync / binding lands.
+	console.log("\n  [space-sync] cloud sync / Space binding placeholder — not yet implemented");
+}

--- a/cli/src/commands/SpaceSyncStep.ts
+++ b/cli/src/commands/SpaceSyncStep.ts
@@ -27,6 +27,11 @@
  */
 export async function runSpaceSyncStep(cwd: string): Promise<void> {
 	void cwd;
-	// Development placeholder — remove when the real sync / binding lands.
-	console.log("\n  [space-sync] cloud sync / Space binding placeholder — not yet implemented");
+	// Development-only placeholder so the front door's call site / timing can be
+	// exercised by hand (`JOLLI_DEV=1 jolli`). Gated behind JOLLI_DEV so it never
+	// reaches end users if a release ships before the real sync/binding replaces
+	// this stub. Remove the whole guard when implementing the real logic.
+	if (process.env.JOLLI_DEV) {
+		console.log("\n  [space-sync] cloud sync / Space binding placeholder — not yet implemented");
+	}
 }


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Jolli Memory

## Quick recap

The bare `jolli` command now acts as a guided setup experience for new and returning users. On an interactive terminal with no subcommand given, the tool reads whether the user is signed in and whether the current repository has Jolli Memory enabled, then walks through whichever steps remain: signing in, enabling the repo, and confirming the tool is active. Piped and automated environments see the existing help output and are never blocked by prompts.

The confirmation that Jolli is actively recording commits is now honest about what will actually happen. A user who is signed in but whose AI provider has no key configured sees an explanation and a pointer to settings rather than a false "listening" message. The status line also distinguishes between a full browser sign-in and a manually entered key, giving users an accurate picture of their setup state.

Push catch-up — the process of syncing memories that were generated locally but never uploaded — now fires whenever a user visits the front door and their repo is enabled, not only during the first-time setup flow. A returning user who signs in for the first time on an already-enabled repo gets their backlog flushed in the same session, matching the behavior of the manual enable command.

---

## Topics (5)
<details>
<summary><strong>01 · Bare jolli command becomes interactive guided setup for new users</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

New users running the CLI tool with no arguments were met with a help wall and an error exit code, forcing them to discover and run several separate commands to sign in, enable the tool in their repo, and understand what it does. The product team wanted the bare command to act as a smart front door that guides users through setup automatically.

**💡 Decisions Behind the Code**

- **Dual-TTY gate instead of input-only check**: The interception requires both the input and output streams to be connected to a real terminal, not just the input stream. A piped command like `jolli | cat` keeps the input connected to the terminal but redirects output, and earlier analysis confirmed that checking only the input stream would cause the interactive prompts to fire in scripting contexts where no human is present to answer them.
- **Lightweight status read instead of reusing the existing full scan**: The existing status function probes every AI tool integration, scans local databases, and enumerates worktrees — work that is irrelevant to the two questions the front door needs answered. A dedicated lightweight reader was introduced that checks only whether the git hook is installed and how many memories exist, keeping the front door fast and focused.
- **Cloud sync delegated entirely to a separate module**: All logic about pushing memories to a Jolli Space — detecting whether a repo is bound, handling single vs. multiple Spaces, and every related user prompt — was placed in a separate file rather than inline in the front door. This keeps the front door's scope limited to auth and enable, makes the boundary between the two collaborators' work explicit, and allows the front door's tests to replace the sync step cleanly.

**✅ What Was Implemented**

- `cli/src/commands/GuidedFrontDoor.ts` was created as the main entry point for the guided experience. It reads two axes of state — whether the user has credentials and whether the current repo has the tool enabled — then offers the appropriate next step: sign in, enable the repo, or confirm the tool is active. A lightweight status reader was introduced to avoid the performance cost of the full status scan used elsewhere in the codebase.
- `cli/src/Api.ts` was updated to intercept bare invocations on interactive terminals before handing off to the normal command parser. The interception requires both input and output to be connected to a real terminal, so piped and automated environments fall through to the existing help output without blocking.
- `cli/src/commands/SpaceSyncStep.ts` was created as a stub module that the front door delegates cloud sync and Space binding work to once the repo is enabled. It prints a visible development placeholder and is designed to be replaced by a collaborator implementing the Space binding feature, with a documented contract covering idempotency, error handling, and timing.

**📋 Future Enhancements**

- `runSpaceSyncStep` is a stub with a visible placeholder message. A collaborator is responsible for replacing the body with real Space binding and push catch-up logic. The contract (idempotent fast-return when already synced, fail-closed on conflicting bindings, quiet return when no credentials) is documented in the stub file.

**📁 FILES**
- `cli/src/commands/GuidedFrontDoor.ts`
- `cli/src/commands/SpaceSyncStep.ts`
- `cli/src/Api.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Push catch-up fires for returning users who sign in, not only on first enable</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A returning user whose repo was already set up but who had never signed in would open the front door, sign in for the first time, and leave without their backlog of unsynced memories being pushed. The existing enable command always triggered a catch-up push after sign-in, but the front door's initial implementation only triggered it during the first-time enable flow.

**💡 Decisions Behind the Code**

The existing enable command deliberately places the catch-up call after the sign-in prompt so that a user who just authenticated gets their backlog flushed immediately. The front door needed to match this behavior for the case where sign-in happens on a repo that was already enabled, which the enable-only placement missed entirely.

**✅ What Was Implemented**

The push catch-up call was moved out of the enable-only branch and into the block that runs whenever the repo is in the enabled state, so it fires on every front door visit where the repo is active. The call is idempotent and silently no-ops when there is nothing to push or when the user has no credentials, so the change adds no cost for users who are already fully synced.

**📁 FILES**
- `cli/src/commands/GuidedFrontDoor.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Listening confirmation gated on whether memories can actually be generated</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A user who had signed in via the browser but whose chosen AI provider had no usable key configured would see a "Jolli is listening" confirmation, implying their next commit would produce a memory. In practice the commit would fail silently because the provider lacked credentials, making the confirmation a false promise.

**💡 Decisions Behind the Code**

- **Use the authoritative provider resolver rather than a simpler credential check**: An earlier version checked only whether any credential existed at all, which produced false positives when a user had signed in via the browser but their explicit provider choice (for example, Anthropic) had no key set. Using the same resolver the generation path uses means the front door's promise matches what will actually happen on the next commit.
- **Honest status line over a unified signed-in message**: Rather than collapsing all credential states into a single "signed in" line, the front door shows distinct text for OAuth sign-in, manual key configuration, and no credentials. This was chosen after discussion confirmed that showing "signed in" to a user who only has a manually entered key is misleading about what they can do and what the sign-in flow would add.

**✅ What Was Implemented**

The "Jolli is listening" message is now gated on whether the currently configured AI provider has a usable key, using the same credential resolver that the memory generation path itself uses. When a user is signed in but their provider has no key, the front door instead prints a message explaining that memories will not be generated and pointing to the settings where the key can be added. The status line also distinguishes between a full OAuth sign-in and a manually configured key, showing different text for each state.

**📁 FILES**
- `cli/src/commands/GuidedFrontDoor.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Storage backend initialized in front door to prevent memory-read warnings</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Running the bare command on a real machine produced a warning in the debug log indicating that the memory storage system had fallen back to a default mode because the caller had not initialized it. Users with a Memory Bank folder configured would have their memory count read from the wrong location.

**💡 Decisions Behind the Code**

The warning was not caught by the automated tests because those tests mock the storage layer entirely, so the misconfiguration only surfaced on a real machine. The fix follows the existing convention used by every other command that reads memories rather than introducing a new pattern, keeping the initialization consistent across the codebase.

**✅ What Was Implemented**

The front door now initializes the storage backend at startup using the same pattern every other memory-reading command in the codebase uses. The warning no longer appears, and users with folder-based memory storage see the correct count rather than the orphan-branch fallback value.

**📁 FILES**
- `cli/src/commands/GuidedFrontDoor.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Agent session restart reminder added after enabling the tool</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user enabled the tool through the front door, they saw a "Jolli is listening" confirmation but no indication that their current AI agent session would not be recorded. Git commit hooks take effect immediately, but the hooks that capture AI agent sessions require the session to be restarted first.

**💡 Decisions Behind the Code**

The existing enable command prints a detailed list of installed hooks and a restart reminder. The front door uses a shorter single-line version to stay consistent with its minimal, guided tone while still communicating the one action the user must take for the tool to capture their current session.

**✅ What Was Implemented**

A one-line reminder to restart the AI agent session is printed immediately after a successful enable, before the status summary. The message is absent for returning users whose repo was already enabled, since they have already been through this step.

**📁 FILES**
- `cli/src/commands/GuidedFrontDoor.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 13, 2026 at 2:05 PM · via Anthropic*
<!-- jollimemory-summary-end -->