### PR TITLE
Add Codex zoom-meeting connector binding and normalizer

### DIFF
--- a/cli/src/core/references/CodexEnvelopeParser.test.ts
+++ b/cli/src/core/references/CodexEnvelopeParser.test.ts
@@ -134,6 +134,31 @@ const GITHUB_SEARCH = {
 		},
 	],
 };
+// Real `codex_apps/zoom._get_meeting_assets` shape (2026-07-13 rollout): the
+// business payload is a single meeting object identical to the Claude
+// get_meeting_assets result, read directly by the zoom-meeting definition.
+const ZOOM_MEETING = {
+	from_server: true,
+	meeting_uuid: "CB9D57D1-D6B0-4ECC-A6C2-E00449DF9B8D",
+	meeting_number: 98668434129,
+	topic: "US/China sync meeting",
+	start_time: "2026-07-09T01:30:00Z",
+	end_time: "2026-07-09T02:00:00Z",
+	deep_url: "https://jolli.zoom.us/launch/edl?muid=b69e8f55-b001-420f-a02d-ba19b3bc9416",
+	meeting_category: "history",
+	meeting_summary: {
+		summary_plain_text: "Quick recap ...",
+		summary_markdown: "## Quick recap\n\nThe team reviewed the 1.0 release plan.",
+		summary_doc_url: "https://docs.zoom.us/doc/BL6P4Z-qRv-5Tpj3svUONw",
+		has_permission: true,
+		has_summary: true,
+	},
+	meeting_transcript: {
+		primary_language: "en",
+		transcript_items: [{ start: "00:01:58.000", text: "Hi", end: "00:01:59.000" }],
+	},
+	my_notes: { has_my_notes: false },
+};
 
 describe("CodexEnvelopeParser.parse", () => {
 	it("emits one NormalizedToolResult per source via the PRIMARY function_call pair, with canonical toolName + matched adapter", () => {
@@ -558,6 +583,69 @@ describe("CodexEnvelopeParser end-to-end via extractReferencesFromTranscript (so
 
 		// The webUrl-less jira event produced no ref.
 		expect(byKey.has("jira:KAN-9")).toBe(false);
+	});
+});
+
+describe("CodexEnvelopeParser — Zoom meeting connector", () => {
+	it("emits a zoom-meeting ref via the PRIMARY function_call pair (identity normalize)", () => {
+		const lines = [
+			fnCall("mcp__codex_apps__zoom", "_get_meeting_assets", "c_zoom"),
+			fnOutput("c_zoom", ZOOM_MEETING, { wrap: "bare", prefix: true }),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results).toHaveLength(1);
+		expect(results[0].def.id).toBe("zoom-meeting");
+		expect(results[0].toolName).toBe("mcp__claude_ai_Zoom_for_Claude__get_meeting_assets");
+	});
+
+	it("recovers a zoom-meeting ref from the mcp_tool_call_end event when the output is malformed", () => {
+		// Real 2026-07-13 case: on a long meeting the function_call_output is invalid
+		// JSON (a bad escape mid-transcript), but the paired event carries a complete,
+		// valid copy that already includes the URLs — no `recover` hook is needed.
+		const lines = [
+			fnCall("mcp__codex_apps__zoom", "_get_meeting_assets", "c_zoom_bad"),
+			fnOutputRaw("c_zoom_bad", `Wall time: 10.06s\nOutput:\n{"topic":"US/China sync",bad json`),
+			toolCallEnd("zoom.get_meeting_assets", "c_zoom_bad", ZOOM_MEETING),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results).toHaveLength(1);
+		expect(results[0].def.id).toBe("zoom-meeting");
+	});
+
+	it("ignores zoom enumeration / recording-resource connector calls", () => {
+		const lines = [
+			fnCall("mcp__codex_apps__zoom", "_search_meetings", "c_zsearch"),
+			fnOutput("c_zsearch", { meetings: [] }, { wrap: "bare", prefix: true }),
+			fnCall("mcp__codex_apps__zoom", "_get_recording_resource", "c_zrec"),
+			fnOutput("c_zrec", { recording: {} }, { wrap: "bare", prefix: true }),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results).toHaveLength(0);
+	});
+});
+
+describe("CodexEnvelopeParser end-to-end — Zoom meeting fallback path via extractReferencesFromTranscript", () => {
+	let dir: string;
+	let file: string;
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), "codex-zoom-"));
+		file = join(dir, "rollout.jsonl");
+		const lines = [
+			fnCall("mcp__codex_apps__zoom", "_get_meeting_assets", "c_zoom_e2e"),
+			fnOutputRaw("c_zoom_e2e", `Wall time: 10.06s\nOutput:\n{"topic":"US/China sync",bad json`),
+			toolCallEnd("zoom.get_meeting_assets", "c_zoom_e2e", ZOOM_MEETING),
+		];
+		writeFileSync(file, `${lines.join("\n")}\n`, "utf-8");
+	});
+	afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+	it("extracts the meeting ref (title, summary-doc url, mapKey) through the unchanged definition", async () => {
+		const { references } = await extractReferencesFromTranscript(file, { source: "codex" });
+		const zoom = references.find((r) => r.mapKey === "zoom-meeting:CB9D57D1-D6B0-4ECC-A6C2-E00449DF9B8D");
+		expect(zoom).toBeDefined();
+		expect(zoom?.title).toBe("US/China sync meeting");
+		expect(zoom?.url).toBe("https://docs.zoom.us/doc/BL6P4Z-qRv-5Tpj3svUONw");
+		expect(zoom?.description).toContain("Quick recap");
 	});
 });
 

--- a/cli/src/core/references/SourceDefinitionRegistry.test.ts
+++ b/cli/src/core/references/SourceDefinitionRegistry.test.ts
@@ -312,6 +312,18 @@ describe("SourceDefinitionRegistry", () => {
 		it("does NOT match other Zoom tools (suffix gate)", () => {
 			expect(getRegistry().match("claude", "mcp__claude_ai_Zoom_for_Claude__search_meetings")).toBeUndefined();
 		});
+		it("resolves the Codex zoom connector by namespace+name and by invocation tool", () => {
+			const r = getRegistry();
+			expect(r.match("codex", "_get_meeting_assets", "zoom")?.id).toBe("zoom-meeting"); // function_call path
+			expect(r.match("codex", "zoom.get_meeting_assets")?.id).toBe("zoom-meeting"); // invocation-tool path
+		});
+		it("does NOT match Codex zoom enumeration / recording-resource tools", () => {
+			const r = getRegistry();
+			expect(r.match("codex", "_search_meetings", "zoom")).toBeUndefined();
+			expect(r.match("codex", "_recordings_list", "zoom")).toBeUndefined();
+			expect(r.match("codex", "_get_recording_resource", "zoom")).toBeUndefined();
+			expect(r.match("codex", "zoom.search_meetings")).toBeUndefined();
+		});
 	});
 
 	describe("zoom-doc registration", () => {

--- a/cli/src/core/references/bindings/codex/CodexZoomMeetingBinding.ts
+++ b/cli/src/core/references/bindings/codex/CodexZoomMeetingBinding.ts
@@ -1,0 +1,29 @@
+/**
+ * CodexZoomMeetingBinding — Zoom `codex_apps` connector normalizer.
+ *
+ * Reached through `_get_meeting_assets` / `zoom.get_meeting_assets` (match
+ * identity lives in the registry). Verified live (2026-07-13 rollout): the
+ * business payload is a single meeting object with the SAME shape the Claude
+ * `get_meeting_assets` result has — `meeting_uuid`, `topic`, `start_time`,
+ * `meeting_number`, `deep_url`, and `meeting_summary.{summary_markdown,
+ * summary_doc_url}` — all read directly by the `zoom-meeting` SourceDefinition.
+ * No reshaping is required → identity normalize.
+ *
+ * The connector's `_search_meetings` / `_recordings_list` (enumeration) and
+ * `_get_recording_resource` tools are intentionally NOT recognized: a
+ * search/list result carries many meetings the user is not working on, and
+ * `_get_recording_resource` returns a recording asset, not a meeting object.
+ *
+ * No `recover`: on long meetings the `function_call_output` copy is often
+ * malformed JSON, but the paired `mcp_tool_call_end` event carries a complete,
+ * valid payload that already includes the URLs — so the parser's plain fallback
+ * suffices (contrast `CodexJiraBinding`, whose event lacks the tenant `webUrl`).
+ */
+
+import type { CodexNormalizer } from "./CodexBinding.js";
+
+export const zoomMeetingCodexBinding: CodexNormalizer = {
+	id: "zoom-meeting",
+	canonicalToolName: "mcp__claude_ai_Zoom_for_Claude__get_meeting_assets",
+	normalize: (business) => business,
+};

--- a/cli/src/core/references/bindings/codex/index.test.ts
+++ b/cli/src/core/references/bindings/codex/index.test.ts
@@ -8,6 +8,9 @@ describe("Codex producer normalizer registry", () => {
 			expect(getCodexNormalizer("jira")?.canonicalToolName).toBe("mcp__claude_ai_Atlassian__getJiraIssue");
 			expect(getCodexNormalizer("notion")?.canonicalToolName).toBe("mcp__claude_ai_Notion__notion-fetch");
 			expect(getCodexNormalizer("linear")?.canonicalToolName).toBe("mcp__linear__get_issue");
+			expect(getCodexNormalizer("zoom-meeting")?.canonicalToolName).toBe(
+				"mcp__claude_ai_Zoom_for_Claude__get_meeting_assets",
+			);
 		});
 
 		it("returns undefined for an id with no registered normalizer", () => {
@@ -25,11 +28,12 @@ describe("Codex producer normalizer registry", () => {
 			expect(out.issues[0].html_url).toBe("https://github.com/o/r/issues/959");
 		});
 
-		it("linear/notion/jira normalizers pass payloads through unchanged", () => {
+		it("linear/notion/jira/zoom-meeting normalizers pass payloads through unchanged", () => {
 			const payload = { id: "JOLLI-1", title: "x" };
 			expect(getCodexNormalizer("linear")?.normalize(payload)).toBe(payload);
 			expect(getCodexNormalizer("notion")?.normalize(payload)).toBe(payload);
 			expect(getCodexNormalizer("jira")?.normalize(payload)).toBe(payload);
+			expect(getCodexNormalizer("zoom-meeting")?.normalize(payload)).toBe(payload);
 		});
 	});
 });

--- a/cli/src/core/references/bindings/codex/index.ts
+++ b/cli/src/core/references/bindings/codex/index.ts
@@ -15,6 +15,7 @@ import { githubCodexBinding } from "./CodexGitHubBinding.js";
 import { jiraCodexBinding } from "./CodexJiraBinding.js";
 import { linearCodexBinding } from "./CodexLinearBinding.js";
 import { notionCodexBinding } from "./CodexNotionBinding.js";
+import { zoomMeetingCodexBinding } from "./CodexZoomMeetingBinding.js";
 
 /** `mcp__codex_apps__` — the shared connector namespace prefix for all sources. */
 export const CODEX_APPS_NAMESPACE_PREFIX = "mcp__codex_apps__";
@@ -24,6 +25,7 @@ const CODEX_NORMALIZERS: readonly CodexNormalizer[] = [
 	notionCodexBinding,
 	githubCodexBinding,
 	jiraCodexBinding,
+	zoomMeetingCodexBinding,
 ];
 
 const BY_ID: ReadonlyMap<SourceId, CodexNormalizer> = new Map(CODEX_NORMALIZERS.map((n) => [n.id, n]));

--- a/cli/src/core/references/sources/definitions/zoom-meeting.ts
+++ b/cli/src/core/references/sources/definitions/zoom-meeting.ts
@@ -9,6 +9,18 @@
  * Guard: require a non-empty meeting_summary.summary_markdown — a meeting with no
  * AI summary voids rather than producing an empty-bodied reference.
  * url: prefer the summary doc; fall back to the always-present deep_url.
+ *
+ * Codex: the `codex_apps/zoom` connector's `_get_meeting_assets` returns a payload
+ * with the identical shape (verified against a real 2026-07-13 rollout —
+ * meeting_uuid / topic / start_time / meeting_number / deep_url /
+ * meeting_summary.{summary_markdown,summary_doc_url} all present), so this same
+ * DSL reads it verbatim via an identity `CodexZoomMeetingBinding`. Enumeration
+ * tools (`_search_meetings`, `_recordings_list`) and `_get_recording_resource`
+ * are omitted from the match — allow-list semantics mean they never match. Note
+ * that the real `_get_meeting_assets` `function_call_output` is frequently
+ * malformed JSON (a bad escape mid-transcript on long meetings); extraction then
+ * succeeds through the parser's `mcp_tool_call_end` fallback, whose event carries
+ * a complete, valid copy (unlike Jira, it already holds the URL — no `recover`).
  */
 
 import type { SourceDefinition } from "../../SourceDefinition.js";
@@ -19,6 +31,11 @@ export const zoomMeetingDefinition: SourceDefinition = {
 	icon: "device-camera-video",
 	match: {
 		claude: { prefixes: ["mcp__claude_ai_Zoom_for_Claude__"], acceptSuffix: "get_meeting_assets" },
+		codex: {
+			namespaceSuffix: "zoom",
+			functionCallNames: ["_get_meeting_assets"],
+			invocationTools: ["zoom.get_meeting_assets"],
+		},
 	},
 	wrapperKeys: [],
 	reference: {


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

This commit added support for pulling Zoom meeting summaries into the reference system when working through the Codex coding assistant, matching a capability that already existed for Claude. Before implementing anything, the actual tool calls and data returned by Codex's Zoom connector were confirmed against real historical sessions, revealing that the returned meeting data has the same structure already handled for Claude — including the meeting title, timing, and summary document link. That discovery meant the existing extraction logic could be reused directly with no reshaping.

The work also uncovered a real-world quirk: on longer meetings, the primary copy of the summary data can arrive corrupted, but a secondary backup copy recorded alongside it reliably contains the complete, valid data including the summary link. Test coverage was added to confirm meeting summaries, links, and recap text extract correctly under both the normal case and this corrupted-then-recovered case, along with confirming that unrelated Zoom actions like searching or listing meetings are correctly ignored.

---

## Topic (1)
<details>
<summary><strong>01 · Add Codex connector support for retrieving Zoom meeting summaries</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The user asked to add support for the Codex coding assistant to read Zoom meeting data through the same connector pathway that already worked for Claude, so that meeting summaries and recaps captured via Codex sessions could be recognized and extracted the same way.

**💡 Decisions Behind the Code**

- **Verified the real tool behavior before writing any matching logic**: rather than guessing what Codex's Zoom connector calls would look like, actual historical session logs were mined to confirm the exact tool names and payload shapes in use. This avoids a known failure mode where invented assumptions produce matching rules that silently never activate in production.
- **Reused the existing Zoom data-reading logic unchanged**: because the real Codex payload turned out to have the same structure as the Claude one (same field names for meeting title, summary, and links), no custom reshaping code was needed — the new connector simply reads through the same rules.
- **Skipped adding a repair step for corrupted data**: some large meetings produce a malformed primary copy of the summary data, but investigation confirmed that a secondary backup copy recorded alongside it is always complete and already includes the needed links, so no extra recovery logic was necessary (unlike a similar past case with a different connector where the backup copy was missing key data).

**✅ What Was Implemented**

- Added a Codex matching rule to the existing Zoom meeting source definition, teaching the system to recognize the specific tool calls Codex's Zoom connector actually uses (verified against real usage logs rather than assumed).
- Created a new binding file that passes the Codex Zoom payload through unchanged, because the data shape it returns turned out to be identical to what the Claude connector already produces.
- Registered the new binding in the Codex normalizer registry and added test coverage across the binding registry, the source registry, and the end-to-end extraction path, including a scenario where the primary response is corrupted but a paired backup copy still contains the full data.

**📁 FILES**
- `cli/src/core/references/sources/definitions/zoom-meeting.ts`
- `cli/src/core/references/bindings/codex/CodexZoomMeetingBinding.ts`
- `cli/src/core/references/bindings/codex/index.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 13, 2026 at 3:46 PM · via Jolli proxy*
<!-- jollimemory-summary-end -->
