### PR TITLE
Part of JOLLI-1937: Implement Space binding flow

### DIFF
--- a/cli/src/commands/GuidedFrontDoor.test.ts
+++ b/cli/src/commands/GuidedFrontDoor.test.ts
@@ -109,6 +109,25 @@ describe("GuidedFrontDoor", () => {
 		expect(out()).toContain("last memory saved");
 	});
 
+	it("waits for Space sync before retrying pending pushes", async () => {
+		let completeSpaceSync!: () => void;
+		h.runSpaceSyncStep.mockImplementationOnce(
+			() =>
+				new Promise<void>((resolve) => {
+					completeSpaceSync = resolve;
+				}),
+		);
+
+		const frontDoor = runGuidedFrontDoor();
+		await vi.waitFor(() => expect(h.runSpaceSyncStep).toHaveBeenCalledWith("/repo"));
+		expect(h.triggerPendingPushRetry).not.toHaveBeenCalled();
+
+		completeSpaceSync();
+		await frontDoor;
+
+		expect(h.triggerPendingPushRetry).toHaveBeenCalledWith("/repo");
+	});
+
 	it("no credential → runs promptSetup", async () => {
 		h.loadAuthToken.mockResolvedValue(undefined);
 		h.loadConfig.mockResolvedValue({});

--- a/cli/src/commands/GuidedFrontDoor.ts
+++ b/cli/src/commands/GuidedFrontDoor.ts
@@ -124,12 +124,13 @@ export async function runGuidedFrontDoor(): Promise<void> {
 	}
 	console.log(`  ✓ enabled · ${summaryCount} ${summaryCount === 1 ? "memory" : "memories"}`);
 
-	// ── Cloud sync + push catch-up: whenever enabled. triggerPendingPushRetry is
-	// idempotent and no-ops when not signed in, so a returning user who just
-	// signed in still gets their backlog pushed (matches `jolli enable`). ──
+	// ── Cloud sync + push catch-up: whenever enabled. Resolve or create the repo
+	// binding before retrying pending pushes so the first retry cannot race ahead
+	// and fail with `binding_required`. The retry remains fire-and-forget after
+	// setup and no-ops when not signed in. ──
 	if (enabled) {
-		void triggerPendingPushRetry(cwd);
 		await runSpaceSyncStep(cwd);
+		void triggerPendingPushRetry(cwd);
 	}
 
 	// ── Confirmation: only promise "listening" when memories can be generated ──

--- a/cli/src/commands/SpaceSyncStep.test.ts
+++ b/cli/src/commands/SpaceSyncStep.test.ts
@@ -1,29 +1,348 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	BindingAlreadyExistsError,
+	type JolliMemoryPushClient,
+	NotAuthenticatedError,
+} from "../core/JolliMemoryPushClient.js";
 import { runSpaceSyncStep } from "./SpaceSyncStep.js";
 
-describe("runSpaceSyncStep (stub)", () => {
+const h = vi.hoisted(() => ({
+	loadConfig: vi.fn(),
+	getCanonicalRepoUrl: vi.fn(),
+	deriveRepoNameFromUrl: vi.fn(),
+	parseJolliApiKey: vi.fn(),
+	promptText: vi.fn(),
+}));
+
+vi.mock("../core/SessionTracker.js", () => ({ loadConfig: h.loadConfig }));
+vi.mock("../core/GitRemoteUtils.js", () => ({
+	getCanonicalRepoUrl: h.getCanonicalRepoUrl,
+	deriveRepoNameFromUrl: h.deriveRepoNameFromUrl,
+}));
+// JolliMemoryPushClient (imported un-mocked above for its error classes) pulls
+// parseBaseUrl/deriveJolliEnvKey from the same module, so stub those too.
+vi.mock("../core/JolliApiUtils.js", () => ({
+	parseJolliApiKey: h.parseJolliApiKey,
+	parseBaseUrl: vi.fn(),
+	deriveJolliEnvKey: vi.fn(),
+}));
+vi.mock("./CliUtils.js", () => ({ promptText: h.promptText }));
+
+const spaceA = { id: 1, name: "Acme Core", slug: "acme-core" };
+const spaceB = { id: 2, name: "Sandbox", slug: "sandbox" };
+
+interface ClientStubs {
+	frontDoor?: ReturnType<typeof vi.fn>;
+	createBinding?: ReturnType<typeof vi.fn>;
+}
+
+function makeClient(stubs: ClientStubs = {}): {
+	client: JolliMemoryPushClient;
+	frontDoor: ReturnType<typeof vi.fn>;
+	createBinding: ReturnType<typeof vi.fn>;
+} {
+	const frontDoor = stubs.frontDoor ?? vi.fn();
+	const createBinding = stubs.createBinding ?? vi.fn();
+	return { client: { frontDoor, createBinding } as unknown as JolliMemoryPushClient, frontDoor, createBinding };
+}
+
+describe("runSpaceSyncStep", () => {
 	let logSpy: ReturnType<typeof vi.spyOn>;
-	const PRIOR_DEV = process.env.JOLLI_DEV;
 
 	beforeEach(() => {
+		vi.clearAllMocks();
 		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-		delete process.env.JOLLI_DEV;
+		h.loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-test" });
+		h.getCanonicalRepoUrl.mockResolvedValue("https://github.com/acme/widgets");
+		h.deriveRepoNameFromUrl.mockReturnValue("widgets");
+		h.parseJolliApiKey.mockReturnValue({ u: "https://acme.jolli.ai" });
 	});
 
 	afterEach(() => {
 		logSpy.mockRestore();
-		if (PRIOR_DEV === undefined) delete process.env.JOLLI_DEV;
-		else process.env.JOLLI_DEV = PRIOR_DEV;
 	});
 
-	it("stays silent for end users (no JOLLI_DEV) — placeholder must not leak in a release", async () => {
-		await runSpaceSyncStep("/repo");
+	it("returns quietly when no jolliApiKey is configured", async () => {
+		h.loadConfig.mockResolvedValue({});
+		const { client, frontDoor } = makeClient();
+
+		await runSpaceSyncStep("/repo", { client });
+
+		expect(frontDoor).not.toHaveBeenCalled();
+		expect(h.getCanonicalRepoUrl).not.toHaveBeenCalled();
 		expect(logSpy).not.toHaveBeenCalled();
 	});
 
-	it("prints the dev placeholder when JOLLI_DEV is set", async () => {
-		process.env.JOLLI_DEV = "1";
-		await runSpaceSyncStep("/repo");
-		expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("[space-sync]"));
+	it("prints the bound Space name when the repo is already bound", async () => {
+		const { client, frontDoor, createBinding } = makeClient({
+			frontDoor: vi.fn().mockResolvedValue({
+				status: "bound",
+				binding: { jmSpaceId: spaceA.id, spaceName: spaceA.name },
+			}),
+		});
+
+		await runSpaceSyncStep("/repo", { client });
+
+		expect(frontDoor).toHaveBeenCalledWith({ repoUrl: "https://github.com/acme/widgets", repoName: "widgets" });
+		expect(logSpy).toHaveBeenCalledWith("  ✓ syncing to Acme Core");
+		expect(createBinding).not.toHaveBeenCalled();
+		expect(h.promptText).not.toHaveBeenCalled();
+	});
+
+	it("prints a generic label when the server withholds the bound Space name", async () => {
+		const { client } = makeClient({
+			frontDoor: vi.fn().mockResolvedValue({ status: "bound", binding: { jmSpaceId: 7, spaceName: null } }),
+		});
+
+		await runSpaceSyncStep("/repo", { client });
+
+		expect(logSpy).toHaveBeenCalledWith("  ✓ syncing to your Jolli Space");
+	});
+
+	it("prints the tenant site in the no-Spaces hint", async () => {
+		const { client } = makeClient({ frontDoor: vi.fn().mockResolvedValue({ status: "no_spaces" }) });
+
+		await runSpaceSyncStep("/repo", { client });
+
+		expect(logSpy).toHaveBeenCalledWith("  No Jolli Spaces available yet — create one at acme.jolli.ai");
+	});
+
+	it("falls back to a generic no-Spaces hint when the api key encodes no site URL", async () => {
+		h.parseJolliApiKey.mockReturnValue(null);
+		const { client } = makeClient({ frontDoor: vi.fn().mockResolvedValue({ status: "no_spaces" }) });
+
+		await runSpaceSyncStep("/repo", { client });
+
+		expect(logSpy).toHaveBeenCalledWith("  No Jolli Spaces available yet — create one in the Jolli web app");
+	});
+
+	it("falls back to a generic no-Spaces hint when the api key site URL is unparseable", async () => {
+		h.parseJolliApiKey.mockReturnValue({ u: "not a url" });
+		const { client } = makeClient({ frontDoor: vi.fn().mockResolvedValue({ status: "no_spaces" }) });
+
+		await runSpaceSyncStep("/repo", { client });
+
+		expect(logSpy).toHaveBeenCalledWith("  No Jolli Spaces available yet — create one in the Jolli web app");
+	});
+
+	it("treats an unbound response with an empty Space list as no Spaces", async () => {
+		// Contract drift: the server answers no_spaces when nothing is bindable,
+		// so an empty unbound list must not reach the zero-option prompt.
+		const { client, createBinding } = makeClient({
+			frontDoor: vi.fn().mockResolvedValue({ status: "unbound", spaces: [], defaultSpaceId: null }),
+		});
+
+		await runSpaceSyncStep("/repo", { client });
+
+		expect(logSpy).toHaveBeenCalledWith("  No Jolli Spaces available yet — create one at acme.jolli.ai");
+		expect(h.promptText).not.toHaveBeenCalled();
+		expect(createBinding).not.toHaveBeenCalled();
+	});
+
+	it("auto-binds without prompting when the unbound list has exactly one Space", async () => {
+		// Contract drift: the server auto-binds the single-Space case itself, so
+		// a one-entry list is taken as-is instead of prompting with one option.
+		const { client, createBinding } = makeClient({
+			frontDoor: vi.fn().mockResolvedValue({ status: "unbound", spaces: [spaceA], defaultSpaceId: null }),
+			createBinding: vi.fn().mockResolvedValue({ bindingId: 9, jmSpaceId: spaceA.id, repoName: "widgets" }),
+		});
+
+		await runSpaceSyncStep("/repo", { client });
+
+		expect(h.promptText).not.toHaveBeenCalled();
+		expect(createBinding).toHaveBeenCalledWith({
+			repoUrl: "https://github.com/acme/widgets",
+			repoName: "widgets",
+			jmSpaceId: spaceA.id,
+		});
+		expect(logSpy).toHaveBeenCalledWith("  ✓ syncing to Acme Core");
+	});
+
+	it("prompts, binds the picked Space, and prints it when several Spaces are bindable", async () => {
+		const { client, createBinding } = makeClient({
+			frontDoor: vi.fn().mockResolvedValue({
+				status: "unbound",
+				spaces: [spaceA, spaceB],
+				defaultSpaceId: spaceA.id,
+			}),
+			createBinding: vi.fn().mockResolvedValue({ bindingId: 9, jmSpaceId: spaceB.id, repoName: "widgets" }),
+		});
+		h.promptText.mockResolvedValue("2");
+
+		await runSpaceSyncStep("/repo", { client });
+
+		expect(logSpy).toHaveBeenCalledWith("\n  2 Spaces on your tenant. Which Space should this repo sync to?");
+		expect(logSpy).toHaveBeenCalledWith("    1) Acme Core (default)");
+		expect(logSpy).toHaveBeenCalledWith("    2) Sandbox");
+		expect(h.promptText).toHaveBeenCalledWith("\n  Choice [1]: ");
+		expect(createBinding).toHaveBeenCalledWith({
+			repoUrl: "https://github.com/acme/widgets",
+			repoName: "widgets",
+			jmSpaceId: spaceB.id,
+		});
+		expect(logSpy).toHaveBeenCalledWith("  ✓ syncing to Sandbox");
+	});
+
+	it("defaults to the tenant default Space on empty input", async () => {
+		const { client, createBinding } = makeClient({
+			frontDoor: vi.fn().mockResolvedValue({
+				status: "unbound",
+				spaces: [spaceA, spaceB],
+				defaultSpaceId: spaceB.id,
+			}),
+			createBinding: vi.fn().mockResolvedValue({ bindingId: 9, jmSpaceId: spaceB.id, repoName: "widgets" }),
+		});
+		h.promptText.mockResolvedValue("");
+
+		await runSpaceSyncStep("/repo", { client });
+
+		expect(h.promptText).toHaveBeenCalledWith("\n  Choice [2]: ");
+		expect(createBinding).toHaveBeenCalledWith(expect.objectContaining({ jmSpaceId: spaceB.id }));
+		expect(logSpy).toHaveBeenCalledWith("  ✓ syncing to Sandbox");
+	});
+
+	it("defaults to the first Space when the tenant has no default", async () => {
+		const { client, createBinding } = makeClient({
+			frontDoor: vi.fn().mockResolvedValue({
+				status: "unbound",
+				spaces: [spaceA, spaceB],
+				defaultSpaceId: null,
+			}),
+			createBinding: vi.fn().mockResolvedValue({ bindingId: 9, jmSpaceId: spaceA.id, repoName: "widgets" }),
+		});
+		h.promptText.mockResolvedValue("");
+
+		await runSpaceSyncStep("/repo", { client });
+
+		expect(h.promptText).toHaveBeenCalledWith("\n  Choice [1]: ");
+		expect(createBinding).toHaveBeenCalledWith(expect.objectContaining({ jmSpaceId: spaceA.id }));
+	});
+
+	it("falls back to the default choice on unparseable input", async () => {
+		const { client, createBinding } = makeClient({
+			frontDoor: vi.fn().mockResolvedValue({
+				status: "unbound",
+				spaces: [spaceA, spaceB],
+				defaultSpaceId: spaceA.id,
+			}),
+			createBinding: vi.fn().mockResolvedValue({ bindingId: 9, jmSpaceId: spaceA.id, repoName: "widgets" }),
+		});
+		h.promptText.mockResolvedValue("nope");
+
+		await runSpaceSyncStep("/repo", { client });
+
+		expect(createBinding).toHaveBeenCalledWith(expect.objectContaining({ jmSpaceId: spaceA.id }));
+	});
+
+	it("falls back to the default choice on an out-of-range pick", async () => {
+		const { client, createBinding } = makeClient({
+			frontDoor: vi.fn().mockResolvedValue({
+				status: "unbound",
+				spaces: [spaceA, spaceB],
+				defaultSpaceId: spaceA.id,
+			}),
+			createBinding: vi.fn().mockResolvedValue({ bindingId: 9, jmSpaceId: spaceA.id, repoName: "widgets" }),
+		});
+		h.promptText.mockResolvedValue("9");
+
+		await runSpaceSyncStep("/repo", { client });
+
+		expect(createBinding).toHaveBeenCalledWith(expect.objectContaining({ jmSpaceId: spaceA.id }));
+	});
+
+	it("treats a 409 whose existing binding matches the pick as success", async () => {
+		const { client } = makeClient({
+			frontDoor: vi.fn().mockResolvedValue({
+				status: "unbound",
+				spaces: [spaceA, spaceB],
+				defaultSpaceId: null,
+			}),
+			createBinding: vi.fn().mockRejectedValue(new BindingAlreadyExistsError("exists", spaceB.id)),
+		});
+		h.promptText.mockResolvedValue("2");
+
+		await runSpaceSyncStep("/repo", { client });
+
+		expect(logSpy).toHaveBeenCalledWith("  ✓ syncing to Sandbox");
+	});
+
+	it("fails closed when the 409 existing binding differs from the pick", async () => {
+		const { client } = makeClient({
+			frontDoor: vi.fn().mockResolvedValue({
+				status: "unbound",
+				spaces: [spaceA, spaceB],
+				defaultSpaceId: null,
+			}),
+			createBinding: vi.fn().mockRejectedValue(new BindingAlreadyExistsError("exists", spaceA.id)),
+		});
+		h.promptText.mockResolvedValue("2");
+
+		await runSpaceSyncStep("/repo", { client });
+
+		expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("already bound to a different Jolli Space"));
+		expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining("✓ syncing to"));
+	});
+
+	it("fails closed when the 409 carries no existing space id", async () => {
+		const { client } = makeClient({
+			frontDoor: vi.fn().mockResolvedValue({
+				status: "unbound",
+				spaces: [spaceA, spaceB],
+				defaultSpaceId: null,
+			}),
+			createBinding: vi.fn().mockRejectedValue(new BindingAlreadyExistsError("exists")),
+		});
+		h.promptText.mockResolvedValue("2");
+
+		await runSpaceSyncStep("/repo", { client });
+
+		expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("already bound to a different Jolli Space"));
+		expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining("✓ syncing to"));
+	});
+
+	it("stays silent when the front-door call fails", async () => {
+		const { client } = makeClient({
+			frontDoor: vi.fn().mockRejectedValue(new NotAuthenticatedError()),
+		});
+
+		await runSpaceSyncStep("/repo", { client });
+
+		expect(logSpy).not.toHaveBeenCalled();
+	});
+
+	it("stays silent when the binding call fails with an unexpected error", async () => {
+		const { client } = makeClient({
+			frontDoor: vi.fn().mockResolvedValue({
+				status: "unbound",
+				spaces: [spaceA, spaceB],
+				defaultSpaceId: null,
+			}),
+			createBinding: vi.fn().mockRejectedValue(new Error("boom")),
+		});
+		h.promptText.mockResolvedValue("1");
+
+		await expect(runSpaceSyncStep("/repo", { client })).resolves.toBeUndefined();
+
+		expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining("✓ syncing to"));
+	});
+
+	it("swallows non-Error throwables without crashing the front door", async () => {
+		const { client } = makeClient({
+			frontDoor: vi.fn().mockRejectedValue("string failure"),
+		});
+
+		await expect(runSpaceSyncStep("/repo", { client })).resolves.toBeUndefined();
+
+		expect(logSpy).not.toHaveBeenCalled();
+	});
+
+	it("constructs a real client reusing the loaded config key and stays silent when it fails", async () => {
+		// No injected client → the default JolliMemoryPushClient is built with an
+		// apiKeyProvider over the already-loaded config. The stubbed parseBaseUrl
+		// returns undefined, so auth resolution throws before any network I/O —
+		// exercising the default-client path end-to-end without a fetch.
+		await expect(runSpaceSyncStep("/repo")).resolves.toBeUndefined();
+
+		expect(logSpy).not.toHaveBeenCalled();
 	});
 });

--- a/cli/src/commands/SpaceSyncStep.ts
+++ b/cli/src/commands/SpaceSyncStep.ts
@@ -2,36 +2,151 @@
  * Cloud sync / Space-binding step delegated by the guided front door.
  *
  * The guided front door (`runGuidedFrontDoor`) owns the auth + enable axes and
- * calls this once whenever the repo is in the enabled state. Everything about
- * getting memories into a Jolli Space — unbound detection, single/multi Space
- * binding, and every sync-related user prompt — belongs here, not in the front
- * door. Kept in its own module so the front door's tests can mock it.
+ * calls this once whenever the repo is in the enabled state (interactive TTY
+ * guaranteed by the front door). Everything about getting memories into a
+ * Jolli Space — binding-state discovery, single/multi Space binding, and every
+ * sync-related user prompt — lives here, not in the front door. Kept in its
+ * own module so the front door's tests can mock it.
  *
- * Contract for the implementer:
- *   - Called only on an interactive TTY (the front door guards this) and only
- *     when the repo is enabled. Whether the user is signed in / has a Jolli API
- *     key is this function's own concern — return quietly when there is none.
- *   - Called on EVERY bare `jolli` that reaches the enabled state, so this owns
- *     the setup-if-needed decision: return fast and silently once the repo is
- *     bound and synced; do not hit the network every time.
- *   - A 409 "binding already exists" must be handled fail-closed: treat it as
- *     success only when the existing space id matches the requested one;
- *     otherwise surface an error and stop, never silently pushing memories to
- *     the wrong Space (mirror pushBranchToJolli's existing behaviour).
- *   - Push catch-up is already triggered by the front door whenever the repo is
- *     enabled; re-trigger here only if needed (it is idempotent).
+ * One network round-trip on the common path: `POST /api/jolli-memory/front-door`
+ * resolves "already bound", "auto-bound to the only Space", "several Spaces —
+ * ask", and "no Spaces" in a single call (JOLLI-1937). Only the several-Spaces
+ * first run needs a second call (`createBinding` with the user's pick). There
+ * is deliberately no local binding cache — the server owns binding state
+ * (mirroring the VS Code extension), so a re-bind or unbind done elsewhere is
+ * picked up on the next `jolli`.
  *
- * Currently a stub: prints a development-only placeholder so the front door's
- * call site and timing can be exercised end-to-end. Replace the body with the
- * real push / sync / Space orchestration.
+ * Failure posture: best-effort. The front door must never be blocked by cloud
+ * state, so every error (not signed in, outdated client, network) is logged at
+ * debug level and swallowed — except a fail-closed mismatch on the 409
+ * "binding already exists" race, which is surfaced so memories are never
+ * silently confirmed for the wrong Space (mirrors pushBranchToJolli).
  */
-export async function runSpaceSyncStep(cwd: string): Promise<void> {
-	void cwd;
-	// Development-only placeholder so the front door's call site / timing can be
-	// exercised by hand (`JOLLI_DEV=1 jolli`). Gated behind JOLLI_DEV so it never
-	// reaches end users if a release ships before the real sync/binding replaces
-	// this stub. Remove the whole guard when implementing the real logic.
-	if (process.env.JOLLI_DEV) {
-		console.log("\n  [space-sync] cloud sync / Space binding placeholder — not yet implemented");
+
+import { deriveRepoNameFromUrl, getCanonicalRepoUrl } from "../core/GitRemoteUtils.js";
+import { parseJolliApiKey } from "../core/JolliApiUtils.js";
+import {
+	BindingAlreadyExistsError,
+	JolliMemoryPushClient,
+	type JolliMemorySpace,
+} from "../core/JolliMemoryPushClient.js";
+import { loadConfig } from "../core/SessionTracker.js";
+import { createLogger } from "../Logger.js";
+import { promptText } from "./CliUtils.js";
+
+const log = createLogger("SpaceSyncStep");
+
+/** Test seam — defaults to a real `JolliMemoryPushClient` (mirrors `PushBranchOpts.client`). */
+export interface SpaceSyncStepOpts {
+	readonly client?: JolliMemoryPushClient;
+}
+
+/** Runs the Space-binding axis of the guided front door. See the module docstring for the contract. */
+export async function runSpaceSyncStep(cwd: string, opts: SpaceSyncStepOpts = {}): Promise<void> {
+	const config = await loadConfig();
+	// No Jolli credential → nothing to sync to. The front door's status line
+	// already tells the user how to sign in; stay quiet here.
+	if (!config.jolliApiKey) {
+		return;
+	}
+	try {
+		// Reuse the config snapshot read above — one config read per run, and the
+		// key check and the requests can never observe different keys.
+		const client = opts.client ?? new JolliMemoryPushClient({ apiKeyProvider: async () => config.jolliApiKey });
+		const repoUrl = await getCanonicalRepoUrl(cwd);
+		const repoName = deriveRepoNameFromUrl(repoUrl);
+		const result = await client.frontDoor({ repoUrl, repoName });
+
+		if (result.status === "bound") {
+			printSyncingTo(result.binding.spaceName);
+			return;
+		}
+		// An `unbound` whose list came back empty is contract drift (the server
+		// answers `no_spaces` when nothing is bindable) — prompting would offer
+		// zero choices, so fold it into the same hint.
+		if (result.status === "no_spaces" || result.spaces.length === 0) {
+			const site = siteFromApiKey(config.jolliApiKey);
+			console.log(
+				`  No Jolli Spaces available yet — create one${site ? ` at ${site}` : " in the Jolli web app"}`,
+			);
+			return;
+		}
+
+		// Several bindable Spaces — ask which one, then bind via the same
+		// endpoint the VS Code chooser uses. A single-entry list is contract
+		// drift too (the server auto-binds that case) — take it without a
+		// pointless one-option prompt.
+		const chosen =
+			result.spaces.length === 1
+				? result.spaces[0]
+				: await promptSpaceChoice(result.spaces, result.defaultSpaceId);
+		try {
+			await client.createBinding({ repoUrl, repoName, jmSpaceId: chosen.id });
+		} catch (err) {
+			if (!(err instanceof BindingAlreadyExistsError)) {
+				throw err;
+			}
+			// Fail closed on the concurrent-bind race: only treat the 409 as
+			// success when the existing binding provably matches the user's pick
+			// (mirrors pushBranchToJolli). An undefined existingSpaceId cannot be
+			// confirmed, so it is a mismatch too.
+			if (err.existingSpaceId !== chosen.id) {
+				console.log(
+					"  ⚠ this repo is already bound to a different Jolli Space — your pick was not applied. Re-run `jolli` to see the active binding.",
+				);
+				return;
+			}
+		}
+		printSyncingTo(chosen.name);
+	} catch (error) {
+		// Best-effort: never block or noise up the front door over cloud state
+		// (offline, revoked key, outdated client, server hiccup).
+		log.debug(`space sync step skipped: ${error instanceof Error ? error.message : String(error)}`);
+	}
+}
+
+/** Prints the one-line sync confirmation. `spaceName` is null when the server withheld it (no `spaces.view`). */
+function printSyncingTo(spaceName: string | null): void {
+	console.log(`  ✓ syncing to ${spaceName ?? "your Jolli Space"}`);
+}
+
+/**
+ * Numbered pick-from-list prompt for the several-Spaces case (JOLLI-1937).
+ * Only called with two or more entries — the caller resolves empty and
+ * single-entry lists without prompting. Empty or unparseable input falls back
+ * to the default choice — the tenant's default Space when it is in the list,
+ * the first entry otherwise (same "anything else means the default"
+ * convention as the front door's own prompts).
+ */
+async function promptSpaceChoice(
+	spaces: ReadonlyArray<JolliMemorySpace>,
+	defaultSpaceId: number | null,
+): Promise<JolliMemorySpace> {
+	const defaultIndex = Math.max(
+		0,
+		spaces.findIndex((s) => s.id === defaultSpaceId),
+	);
+	console.log(`\n  ${spaces.length} Spaces on your tenant. Which Space should this repo sync to?`);
+	spaces.forEach((space, i) => {
+		console.log(`    ${i + 1}) ${space.name}${space.id === defaultSpaceId ? " (default)" : ""}`);
+	});
+	const answer = await promptText(`\n  Choice [${defaultIndex + 1}]: `);
+	const picked = Number.parseInt(answer, 10);
+	if (Number.isInteger(picked) && picked >= 1 && picked <= spaces.length) {
+		return spaces[picked - 1];
+	}
+	return spaces[defaultIndex];
+}
+
+/** Host of the tenant site encoded in the Jolli API key, for the no-Spaces hint. */
+function siteFromApiKey(apiKey: string): string | undefined {
+	const url = parseJolliApiKey(apiKey)?.u;
+	if (!url) {
+		return undefined;
+	}
+	try {
+		return new URL(url).host;
+	} catch {
+		return undefined;
 	}
 }

--- a/cli/src/core/JolliMemoryPushClient.test.ts
+++ b/cli/src/core/JolliMemoryPushClient.test.ts
@@ -143,6 +143,104 @@ describe("createBinding", () => {
 	});
 });
 
+describe("frontDoor", () => {
+	const args = { repoUrl: "https://github.com/o/r", repoName: "r" };
+
+	it("POSTs the repo identity to /api/jolli-memory/front-door", async () => {
+		let capturedUrl: string | undefined;
+		let capturedInit: RequestInit | undefined;
+		const c = client(async (url, init) => {
+			capturedUrl = String(url);
+			capturedInit = init;
+			return jsonResponse(200, { status: "no_spaces" });
+		});
+		await c.frontDoor(args);
+		expect(capturedUrl).toBe("https://jolli.ai/api/jolli-memory/front-door");
+		expect(capturedInit?.method).toBe("POST");
+		expect(JSON.parse(String(capturedInit?.body))).toEqual(args);
+	});
+	it("returns bound with the space name", async () => {
+		const c = client(async () =>
+			jsonResponse(200, { status: "bound", binding: { jmSpaceId: 7, spaceName: "Eng" } }),
+		);
+		await expect(c.frontDoor(args)).resolves.toEqual({
+			status: "bound",
+			binding: { jmSpaceId: 7, spaceName: "Eng" },
+		});
+	});
+	it("coalesces missing bound Space details to null", async () => {
+		const c = client(async () => jsonResponse(200, { status: "bound", binding: {} }));
+		await expect(c.frontDoor(args)).resolves.toEqual({
+			status: "bound",
+			binding: { jmSpaceId: null, spaceName: null },
+		});
+	});
+	it("accepts explicit null Space details on a bound response", async () => {
+		const c = client(async () =>
+			jsonResponse(200, { status: "bound", binding: { jmSpaceId: null, spaceName: null } }),
+		);
+		await expect(c.frontDoor(args)).resolves.toEqual({
+			status: "bound",
+			binding: { jmSpaceId: null, spaceName: null },
+		});
+	});
+	it("coalesces a missing spaceName to null when the Space id is visible", async () => {
+		const c = client(async () => jsonResponse(200, { status: "bound", binding: { jmSpaceId: 7 } }));
+		await expect(c.frontDoor(args)).resolves.toEqual({
+			status: "bound",
+			binding: { jmSpaceId: 7, spaceName: null },
+		});
+	});
+	it("returns unbound with the space list and defaultSpaceId", async () => {
+		const c = client(async () =>
+			jsonResponse(200, {
+				status: "unbound",
+				spaces: [{ id: 1, name: "Eng", slug: "eng" }],
+				defaultSpaceId: 1,
+			}),
+		);
+		await expect(c.frontDoor(args)).resolves.toEqual({
+			status: "unbound",
+			spaces: [{ id: 1, name: "Eng", slug: "eng" }],
+			defaultSpaceId: 1,
+		});
+	});
+	it("defaults spaces to [] and defaultSpaceId to null on a sparse unbound body", async () => {
+		const c = client(async () => jsonResponse(200, { status: "unbound" }));
+		await expect(c.frontDoor(args)).resolves.toEqual({ status: "unbound", spaces: [], defaultSpaceId: null });
+	});
+	it("returns no_spaces", async () => {
+		const c = client(async () => jsonResponse(200, { status: "no_spaces" }));
+		await expect(c.frontDoor(args)).resolves.toEqual({ status: "no_spaces" });
+	});
+	it("maps 426 to ClientOutdatedError", async () => {
+		const c = client(async () => jsonResponse(426, { error: "client_outdated" }));
+		await expect(c.frontDoor(args)).rejects.toBeInstanceOf(ClientOutdatedError);
+	});
+	it("maps 401/403 to NotAuthenticatedError", async () => {
+		const c401 = client(async () => jsonResponse(401, { error: "unauthorized" }));
+		await expect(c401.frontDoor(args)).rejects.toBeInstanceOf(NotAuthenticatedError);
+		const c403 = client(async () => jsonResponse(403, { error: "forbidden" }));
+		await expect(c403.frontDoor(args)).rejects.toBeInstanceOf(NotAuthenticatedError);
+	});
+	it("throws a plain Error on a generic non-2xx", async () => {
+		const c = client(async () => jsonResponse(500, { error: "boom" }));
+		await expect(c.frontDoor(args)).rejects.toThrow("boom");
+	});
+	it("throws on a 2xx response with a non-JSON body instead of misreading the repo state", async () => {
+		const c = client(async () => textResponse(200, "<html>200 OK</html>"));
+		await expect(c.frontDoor(args)).rejects.toThrow(/Malformed/);
+	});
+	it("throws on a 2xx body with an unrecognized status", async () => {
+		const c = client(async () => jsonResponse(200, { status: "??" }));
+		await expect(c.frontDoor(args)).rejects.toThrow(/Unexpected front-door response shape/);
+	});
+	it("throws on a bound body whose binding object is missing", async () => {
+		const c = client(async () => jsonResponse(200, { status: "bound" }));
+		await expect(c.frontDoor(args)).rejects.toThrow(/Unexpected front-door response shape/);
+	});
+});
+
 describe("header plumbing", () => {
 	it("sends Bearer auth, x-jolli-client, x-org-slug, and resolves base URL from keyMeta.u", async () => {
 		// Realistic key: meta segment base64url-decodes to JSON {t,u,o}; secret segment after the dot.

--- a/cli/src/core/JolliMemoryPushClient.ts
+++ b/cli/src/core/JolliMemoryPushClient.ts
@@ -74,6 +74,28 @@ export interface JolliMemorySpace {
 	readonly slug: string;
 }
 
+/**
+ * Outcome of `POST /api/jolli-memory/front-door` — the single round-trip
+ * "binding status + setup-if-needed" call the guided front door makes on every
+ * bare `jolli`. `bound` covers both a pre-existing binding and the server-side
+ * auto-bind when exactly one Space is bindable. `jmSpaceId` and `spaceName` are
+ * `null` when the caller lacks `spaces.view` on the bound Space; the server
+ * withholds the Space details but not the bound-ness. `unbound` means several
+ * Spaces are bindable and the caller should prompt, then bind via
+ * {@link JolliMemoryPushClient.createBinding}.
+ */
+export type FrontDoorResult =
+	| {
+			readonly status: "bound";
+			readonly binding: { readonly jmSpaceId: number | null; readonly spaceName: string | null };
+	  }
+	| {
+			readonly status: "unbound";
+			readonly spaces: JolliMemorySpace[];
+			readonly defaultSpaceId: number | null;
+	  }
+	| { readonly status: "no_spaces" };
+
 /** Test seam — swap in a stub `fetch` / api key / base URL to drive unit tests deterministically. */
 export interface JolliMemoryPushClientOpts {
 	readonly fetchImpl?: typeof fetch;
@@ -97,6 +119,14 @@ interface ListSpacesResponseBody {
 interface CreateBindingResponseBody {
 	readonly binding?: { readonly id: number; readonly jmSpaceId: number; readonly repoName: string };
 	readonly repoFolder?: unknown;
+}
+
+/** Raw shape of `POST /api/jolli-memory/front-door` — validated field-by-field at parse time. */
+interface FrontDoorResponseBody {
+	readonly status?: "bound" | "unbound" | "no_spaces";
+	readonly binding?: { readonly jmSpaceId?: number | null; readonly spaceName?: string | null };
+	readonly spaces?: ReadonlyArray<{ readonly id: number; readonly name: string; readonly slug: string }>;
+	readonly defaultSpaceId?: number | null;
 }
 
 /** Generic error-shaped JSON body: `{ error?: string; message?: string }`. */
@@ -181,6 +211,56 @@ export class JolliMemoryPushClient {
 		}
 		const spaces = (json.spaces ?? []).map((s) => ({ id: s.id, name: s.name, slug: s.slug }));
 		return { spaces, defaultSpaceId: json.defaultSpaceId ?? null };
+	}
+
+	/**
+	 * Resolves the repo's Space-binding state in one round-trip (see
+	 * {@link FrontDoorResult}). The server auto-binds when exactly one Space is
+	 * bindable, so callers only ever follow up with `createBinding` after an
+	 * `unbound` (several Spaces → user picked one).
+	 */
+	async frontDoor(args: { repoUrl: string; repoName: string }): Promise<FrontDoorResult> {
+		const { status, json, parseFailed } = await this.call<FrontDoorResponseBody>(
+			"POST",
+			"/api/jolli-memory/front-door",
+			args,
+		);
+		if (status === 426) {
+			throw new ClientOutdatedError(errorMessage(json));
+		}
+		if (status === 401 || status === 403) {
+			throw new NotAuthenticatedError();
+		}
+		if (status < 200 || status >= 300) {
+			throw new Error(errorMessage(json) ?? `HTTP ${status}`);
+		}
+		if (parseFailed) {
+			// Same rationale as listSpaces: a 2xx with an HTML/plain-text body
+			// (proxy/gateway) must fail loudly, not read as an empty/unknown state.
+			throw new Error(`Malformed (non-JSON) response from /api/jolli-memory/front-door (HTTP ${status})`);
+		}
+		if (
+			json.status === "bound" &&
+			json.binding &&
+			(json.binding.jmSpaceId === undefined ||
+				json.binding.jmSpaceId === null ||
+				typeof json.binding.jmSpaceId === "number")
+		) {
+			return {
+				status: "bound",
+				binding: { jmSpaceId: json.binding.jmSpaceId ?? null, spaceName: json.binding.spaceName ?? null },
+			};
+		}
+		if (json.status === "unbound") {
+			const spaces = (json.spaces ?? []).map((s) => ({ id: s.id, name: s.name, slug: s.slug }));
+			return { status: "unbound", spaces, defaultSpaceId: json.defaultSpaceId ?? null };
+		}
+		if (json.status === "no_spaces") {
+			return { status: "no_spaces" };
+		}
+		// A 2xx whose body carries no recognizable status (field renamed, contract
+		// drift) — fail loudly rather than have the caller misread the repo state.
+		throw new Error(`Unexpected front-door response shape (HTTP ${status})`);
 	}
 
 	/** Binds a repo to a Jolli Memory space. Server response has no `jmSpaceName` — only `{ binding, repoFolder }`. */


### PR DESCRIPTION
## Summary

Part of JOLLI-1937 — implements the real Space-binding flow behind the guided front door, replacing the previous development-only stub in `runSpaceSyncStep`.

### What changed

- **`SpaceSyncStep.ts`** — the Space-binding axis of the guided front door, resolved in a single network round-trip on the common path via `POST /api/jolli-memory/front-door`:
  - `bound` (pre-existing binding, or server-side auto-bind when exactly one Space is bindable) → prints a one-line `✓ syncing to <Space>` confirmation.
  - `no_spaces` (and the contract-drift case of an `unbound` result with an empty list) → prints a hint to create a Space, with the tenant site host derived from the Jolli API key.
  - `unbound` with several Spaces → numbered pick-from-list prompt with the tenant's default Space pre-selected, then binds via `createBinding`. A single-entry list is taken without a pointless one-option prompt.
  - The 409 "binding already exists" race is handled fail-closed: it only counts as success when the existing space id provably matches the user's pick; otherwise a warning is surfaced and nothing is confirmed (mirrors `pushBranchToJolli`).
  - Best-effort posture everywhere else: not signed in, offline, revoked key, outdated client, or server errors are logged at debug level and never block the front door.
  - Deliberately no local binding cache — the server owns binding state (mirroring the VS Code extension), so a re-bind or unbind done elsewhere is picked up on the next `jolli` run.
- **`JolliMemoryPushClient.ts`** — new `frontDoor()` method and `FrontDoorResult` discriminated union. Responses are validated field-by-field; a 2xx with a non-JSON body or an unrecognized shape fails loudly instead of being misread as an empty state, and 426/401/403 map to the existing typed errors (`ClientOutdatedError`, `NotAuthenticatedError`).
- **`GuidedFrontDoor.ts`** — runs the Space-binding step *before* `triggerPendingPushRetry`, so the first push retry cannot race ahead of binding setup and fail with `binding_required`.

### Testing

Unit tests cover the new flow end-to-end: `SpaceSyncStep.test.ts` (binding states, prompt fallbacks, 409 race, best-effort error handling), `JolliMemoryPushClient.test.ts` (`frontDoor()` response parsing and error mapping), and `GuidedFrontDoor.test.ts` (step ordering).
