### PR TITLE
Add sign-in nudge flow and UserProfile decline tracking to GuidedFrontDoor

### DIFF
--- a/cli/src/commands/GuidedFrontDoor.test.ts
+++ b/cli/src/commands/GuidedFrontDoor.test.ts
@@ -2,6 +2,9 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vites
 
 const h = vi.hoisted(() => ({
 	loadAuthToken: vi.fn(),
+	getJolliUrl: vi.fn(),
+	browserLogin: vi.fn(),
+	validateJolliApiKey: vi.fn(),
 	loadConfig: vi.fn(),
 	getSummaryCount: vi.fn(),
 	track: vi.fn(),
@@ -16,9 +19,13 @@ const h = vi.hoisted(() => ({
 	setActiveStorage: vi.fn(),
 	saveConfigScoped: vi.fn(),
 	getGlobalConfigDir: vi.fn(),
+	loadUserProfile: vi.fn(),
+	saveUserProfile: vi.fn(),
 }));
 
-vi.mock("../auth/AuthConfig.js", () => ({ loadAuthToken: h.loadAuthToken }));
+vi.mock("../auth/AuthConfig.js", () => ({ loadAuthToken: h.loadAuthToken, getJolliUrl: h.getJolliUrl }));
+vi.mock("../auth/Login.js", () => ({ browserLogin: h.browserLogin }));
+vi.mock("../core/JolliApiUtils.js", () => ({ validateJolliApiKey: h.validateJolliApiKey }));
 vi.mock("../core/SessionTracker.js", () => ({
 	loadConfig: h.loadConfig,
 	saveConfigScoped: h.saveConfigScoped,
@@ -30,6 +37,10 @@ vi.mock("../core/SummaryStore.js", () => ({
 	setActiveStorage: h.setActiveStorage,
 }));
 vi.mock("../core/Telemetry.js", () => ({ track: h.track }));
+vi.mock("../core/UserProfile.js", () => ({
+	loadUserProfile: h.loadUserProfile,
+	saveUserProfile: h.saveUserProfile,
+}));
 vi.mock("../hooks/PushCompensation.js", () => ({ triggerPendingPushRetry: h.triggerPendingPushRetry }));
 vi.mock("../install/GitHookInstaller.js", () => ({ isGitHookInstalled: h.isGitHookInstalled }));
 vi.mock("../install/Installer.js", () => ({ install: h.install }));
@@ -69,11 +80,14 @@ describe("GuidedFrontDoor", () => {
 			warns.push(a.map(String).join(" "));
 		});
 
-		// Defaults: signed in via OAuth, enabled, no memories yet.
+		// Defaults: signed in via OAuth, enabled, no memories yet, no prior decline.
 		h.resolveProjectDir.mockReturnValue("/repo");
 		h.createStorage.mockResolvedValue({});
 		h.getGlobalConfigDir.mockReturnValue("/global/config");
 		h.saveConfigScoped.mockResolvedValue(undefined);
+		h.getJolliUrl.mockReturnValue("https://acme.jolli.ai");
+		h.browserLogin.mockResolvedValue(undefined);
+		h.validateJolliApiKey.mockReturnValue(undefined);
 		h.loadAuthToken.mockResolvedValue("oauth-token");
 		h.loadConfig.mockResolvedValue({ jolliUrl: "https://acme.jolli.ai", jolliApiKey: "sk-jol-default" });
 		h.isGitHookInstalled.mockResolvedValue(true);
@@ -83,6 +97,8 @@ describe("GuidedFrontDoor", () => {
 		h.triggerPendingPushRetry.mockResolvedValue(undefined);
 		h.runSpaceSyncStep.mockResolvedValue(undefined);
 		h.promptSetup.mockResolvedValue(undefined);
+		h.loadUserProfile.mockResolvedValue({});
+		h.saveUserProfile.mockResolvedValue(undefined);
 	});
 
 	afterEach(() => {
@@ -97,6 +113,8 @@ describe("GuidedFrontDoor", () => {
 
 	const out = (): string => logs.join("\n");
 
+	// ── Steady state / status line ──
+
 	it("returning user (signed in + enabled): status line + delegates, no install", async () => {
 		h.getSummaryCount.mockResolvedValue(3);
 		await runGuidedFrontDoor();
@@ -109,7 +127,7 @@ describe("GuidedFrontDoor", () => {
 		expect(out()).toContain("last memory saved");
 	});
 
-	it("waits for Space sync before retrying pending pushes", async () => {
+	it("binds the Space before retrying pending pushes", async () => {
 		let completeSpaceSync!: () => void;
 		h.runSpaceSyncStep.mockImplementationOnce(
 			() =>
@@ -128,22 +146,33 @@ describe("GuidedFrontDoor", () => {
 		expect(h.triggerPendingPushRetry).toHaveBeenCalledWith("/repo");
 	});
 
-	it("no credential → runs promptSetup", async () => {
-		h.loadAuthToken.mockResolvedValue(undefined);
-		h.loadConfig.mockResolvedValue({});
+	it("first-run copy when summaryCount is 0", async () => {
+		h.getSummaryCount.mockResolvedValue(0);
 		await runGuidedFrontDoor();
-		expect(h.promptSetup).toHaveBeenCalledTimes(1);
+		expect(out()).toContain("your next commit is your first memory");
 	});
 
-	it("still no credential after promptSetup → no success/listening line", async () => {
-		h.loadAuthToken.mockResolvedValue(undefined);
-		h.loadConfig.mockResolvedValue({});
+	it("singular 'memory' when summaryCount is 1", async () => {
+		h.getSummaryCount.mockResolvedValue(1);
 		await runGuidedFrontDoor();
-		expect(out()).toContain("not signed in");
-		expect(out()).not.toContain("Jolli is listening");
+		expect(out()).toContain("1 memory");
+		expect(out()).not.toContain("1 memories");
 	});
 
-	it("manual jolliApiKey (no OAuth) → shows 'configured', not 'signed in'", async () => {
+	it("invalid jolliUrl → plain 'signed in' without a host", async () => {
+		h.loadConfig.mockResolvedValue({ jolliUrl: "not a url", jolliApiKey: "sk-jol-x" });
+		await runGuidedFrontDoor();
+		expect(out()).toContain("signed in");
+		expect(out()).not.toContain("signed in ·");
+	});
+
+	it("missing jolliUrl → plain 'signed in'", async () => {
+		h.loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-x" });
+		await runGuidedFrontDoor();
+		expect(out()).not.toContain("signed in ·");
+	});
+
+	it("manual jolliApiKey (no OAuth) → 'Jolli API key set', can already sync so no nudge", async () => {
 		h.loadAuthToken.mockResolvedValue(undefined);
 		h.loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-x" });
 		await runGuidedFrontDoor();
@@ -151,13 +180,14 @@ describe("GuidedFrontDoor", () => {
 		expect(out()).toContain("Jolli API key set (not signed in to Jolli)");
 		expect(out()).not.toContain("signed in ·");
 		expect(out()).toContain("Jolli is listening");
-		// Has a jolliApiKey (can already sync) → must NOT nudge sign-in.
-		expect(out()).not.toContain("sync memories to a Space");
+		expect(h.browserLogin).not.toHaveBeenCalled();
+		expect(h.promptText).not.toHaveBeenCalledWith(expect.stringContaining("Sign in now to sync"));
 	});
 
-	it("ANTHROPIC_API_KEY env counts as a credential", async () => {
+	it("ANTHROPIC_API_KEY env counts as a credential (status line names Anthropic)", async () => {
 		h.loadAuthToken.mockResolvedValue(undefined);
 		h.loadConfig.mockResolvedValue({});
+		h.loadUserProfile.mockResolvedValue({ signInPromptDeclined: true }); // suppress the nudge
 		process.env.ANTHROPIC_API_KEY = "sk-ant-x";
 		try {
 			await runGuidedFrontDoor();
@@ -167,6 +197,21 @@ describe("GuidedFrontDoor", () => {
 			delete process.env.ANTHROPIC_API_KEY;
 		}
 	});
+
+	it("both keys, not signed in, provider=anthropic → Anthropic label, no nudge", async () => {
+		// The status-line label follows credSource (the key that would actually be
+		// used), so it names Anthropic even though a jolliApiKey is also present;
+		// and canSync is true via that jolliApiKey, so no sign-in nudge fires.
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig.mockResolvedValue({ apiKey: "sk-ant-x", jolliApiKey: "sk-jol-x", aiProvider: "anthropic" });
+		await runGuidedFrontDoor();
+		expect(out()).toContain("Anthropic API key set (not signed in to Jolli)");
+		expect(h.promptText).not.toHaveBeenCalledWith(expect.stringContaining("Sign in now to sync"));
+		expect(h.browserLogin).not.toHaveBeenCalled();
+		expect(out()).toContain("Jolli is listening");
+	});
+
+	// ── Enable axis ──
 
 	it("not enabled + [Y/n]=y → install + track + push retry + delegate", async () => {
 		h.isGitHookInstalled.mockResolvedValue(false);
@@ -186,11 +231,17 @@ describe("GuidedFrontDoor", () => {
 	it("just enabled a fresh repo (no memories yet) → 0 memories", async () => {
 		h.isGitHookInstalled.mockResolvedValue(false);
 		h.promptText.mockResolvedValue("y");
-		h.getSummaryCount.mockResolvedValue(0); // fresh repo, empty index
+		h.getSummaryCount.mockResolvedValue(0);
 		await runGuidedFrontDoor();
 		expect(h.install).toHaveBeenCalled();
-		expect(h.getSummaryCount).toHaveBeenCalled();
 		expect(out()).toContain("0 memories");
+	});
+
+	it("not enabled + empty answer (Enter) defaults to Yes → installs", async () => {
+		h.isGitHookInstalled.mockResolvedValue(false);
+		h.promptText.mockResolvedValue("");
+		await runGuidedFrontDoor();
+		expect(h.install).toHaveBeenCalledWith("/repo", { source: "cli" });
 	});
 
 	it("not enabled + [Y/n]=n → no install, early return", async () => {
@@ -224,35 +275,27 @@ describe("GuidedFrontDoor", () => {
 		expect(warns.join("\n")).toContain("heads up");
 	});
 
-	it("first-run copy when summaryCount is 0", async () => {
-		h.getSummaryCount.mockResolvedValue(0);
-		await runGuidedFrontDoor();
-		expect(out()).toContain("your next commit is your first memory");
-	});
+	// ── Fresh onboarding (promptSetup) ──
 
-	it("singular 'memory' when summaryCount is 1", async () => {
-		h.getSummaryCount.mockResolvedValue(1);
-		await runGuidedFrontDoor();
-		expect(out()).toContain("1 memory");
-		expect(out()).not.toContain("1 memories");
-	});
-
-	it("invalid jolliUrl → plain 'signed in' without a host", async () => {
-		h.loadConfig.mockResolvedValue({ jolliUrl: "not a url" });
-		await runGuidedFrontDoor();
-		expect(out()).toContain("signed in");
-		expect(out()).not.toContain("signed in ·");
-	});
-
-	it("missing jolliUrl → plain 'signed in'", async () => {
+	it("no credential → runs promptSetup", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
 		h.loadConfig.mockResolvedValue({});
 		await runGuidedFrontDoor();
-		expect(out()).not.toContain("signed in ·");
+		expect(h.promptSetup).toHaveBeenCalledTimes(1);
+	});
+
+	it("skipped setup (still nothing) → 'not signed in', no listening, no re-ask", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig.mockResolvedValue({});
+		await runGuidedFrontDoor();
+		expect(out()).toContain("not signed in");
+		expect(out()).not.toContain("Jolli is listening");
+		// Fresh user with nothing must not be re-prompted by the repair rung.
+		expect(out()).not.toContain("no Anthropic key is available");
+		expect(h.saveConfigScoped).not.toHaveBeenCalled();
 	});
 
 	it("promptSetup turns no-credential into signed in + listening, and pushes backlog", async () => {
-		// Enabled returning repo, but the user has no credential until they sign in
-		// now. The enable branch is skipped, yet backlog catch-up must still fire.
 		h.loadAuthToken.mockResolvedValueOnce(undefined).mockResolvedValueOnce("new-token");
 		h.loadConfig.mockResolvedValueOnce({}).mockResolvedValueOnce({ jolliApiKey: "sk-jol-new" });
 		await runGuidedFrontDoor();
@@ -263,74 +306,132 @@ describe("GuidedFrontDoor", () => {
 		expect(h.triggerPendingPushRetry).toHaveBeenCalledWith("/repo");
 	});
 
-	it("config.apiKey alone (no Jolli credential) → generates locally + nudges sign-in", async () => {
+	// ── Rung 2: optional sign-in nudge (local key, cannot sync) ──
+
+	it("local Anthropic key, Enter (default Yes) → browser login, sync confirmation, listening", async () => {
 		h.loadAuthToken.mockResolvedValue(undefined);
 		h.loadConfig.mockResolvedValue({ apiKey: "sk-ant-x" });
+		h.getSummaryCount.mockResolvedValue(2);
+		h.promptText.mockResolvedValue(""); // Enter → default Yes
 		await runGuidedFrontDoor();
-		expect(h.promptSetup).not.toHaveBeenCalled();
+
 		expect(out()).toContain("Anthropic API key set (not signed in to Jolli)");
-		expect(out()).toContain("Jolli is listening");
-		// Pure-Anthropic user with no Jolli credential — soft nudge to sign in.
-		expect(out()).toContain("sync memories to a Space");
+		expect(h.promptText).toHaveBeenCalledWith(expect.stringContaining("Sign in now to sync memories to a Space"));
+		expect(h.browserLogin).toHaveBeenCalledWith("https://acme.jolli.ai");
+		expect(out()).toContain("memories will sync to your Space");
+		expect(h.saveUserProfile).not.toHaveBeenCalled();
+		expect(out()).toContain("last memory saved");
 	});
 
-	it("not enabled + empty answer (Enter) defaults to Yes → installs", async () => {
-		h.isGitHookInstalled.mockResolvedValue(false);
-		h.promptText.mockResolvedValue("");
+	it("local Anthropic key, answer 'n' → records the decline, no login, still listening", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig.mockResolvedValue({ apiKey: "sk-ant-x" });
+		h.promptText.mockResolvedValue("n");
 		await runGuidedFrontDoor();
-		expect(h.install).toHaveBeenCalledWith("/repo", { source: "cli" });
+
+		expect(h.browserLogin).not.toHaveBeenCalled();
+		expect(h.saveUserProfile).toHaveBeenCalledWith({ signInPromptDeclined: true });
+		expect(out()).toContain("You can sign in anytime");
+		expect(out()).toContain("Jolli is listening");
 	});
 
-	it("signed in but no usable key → offers a fix, no false 'listening'", async () => {
+	it("local Anthropic key, login fails → error, no decline recorded, still listening", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig.mockResolvedValue({ apiKey: "sk-ant-x" });
+		h.promptText.mockResolvedValue(""); // Enter → Yes → browserLogin
+		h.browserLogin.mockRejectedValue(new Error("network down"));
+		await runGuidedFrontDoor();
+
+		expect(errors.join("\n")).toContain("network down");
+		expect(out()).toContain("try again with");
+		expect(h.saveUserProfile).not.toHaveBeenCalled();
+		expect(out()).toContain("Jolli is listening");
+	});
+
+	it("local Anthropic key, decline but persisting the flag fails → swallowed, front door still finishes", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig.mockResolvedValue({ apiKey: "sk-ant-x" });
+		h.promptText.mockResolvedValue("n");
+		h.saveUserProfile.mockRejectedValue(new Error("EACCES: read-only home"));
+		await runGuidedFrontDoor();
+
+		expect(h.saveUserProfile).toHaveBeenCalledWith({ signInPromptDeclined: true });
+		expect(out()).toContain("You can sign in anytime");
+		expect(out()).toContain("Jolli is listening");
+	});
+
+	it("local Anthropic key, login rejects with a non-Error value → still reported", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig.mockResolvedValue({ apiKey: "sk-ant-x" });
+		h.promptText.mockResolvedValue("");
+		h.browserLogin.mockRejectedValue("odd failure");
+		await runGuidedFrontDoor();
+
+		expect(errors.join("\n")).toContain("odd failure");
+		expect(out()).toContain("try again with");
+	});
+
+	it("local Anthropic key but sign-in previously declined → nudge suppressed", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig.mockResolvedValue({ apiKey: "sk-ant-x" });
+		h.loadUserProfile.mockResolvedValue({ signInPromptDeclined: true });
+		await runGuidedFrontDoor();
+
+		expect(h.promptText).not.toHaveBeenCalledWith(expect.stringContaining("Sign in now to sync"));
+		expect(h.browserLogin).not.toHaveBeenCalled();
+		expect(h.saveUserProfile).not.toHaveBeenCalled();
+		expect(out()).toContain("Jolli is listening");
+	});
+
+	// ── Rung 1: provider/key mismatch repair ──
+
+	it("signed in but no usable key → repair menu, no false 'listening' when skipped", async () => {
 		h.loadAuthToken.mockResolvedValue("oauth-token");
 		h.loadConfig.mockResolvedValue({ jolliUrl: "https://acme.jolli.ai" }); // no key at all
 		h.promptText.mockResolvedValue(""); // menu default → enter key → empty → skip
 		await runGuidedFrontDoor();
 		expect(out()).toContain("signed in");
+		expect(out()).toContain("no Anthropic key is available");
 		expect(out()).not.toContain("Jolli is listening");
-		expect(out()).toContain("no usable key");
 	});
 
-	it("choose 'switch to Jolli' → saves aiProvider jolli; listening reflects existing memory count", async () => {
+	it("provider=anthropic + jolliApiKey, choose 'switch to Jolli' → saves aiProvider, listening reflects count", async () => {
 		h.loadAuthToken.mockResolvedValue("oauth-token");
-		h.loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-x", aiProvider: "anthropic" });
-		h.getSummaryCount.mockResolvedValue(163); // returning repo with history
-		h.promptText.mockResolvedValue("2");
+		h.loadConfig.mockResolvedValue({
+			jolliApiKey: "sk-jol-x",
+			aiProvider: "anthropic",
+			jolliUrl: "https://acme.jolli.ai",
+		});
+		h.getSummaryCount.mockResolvedValue(163);
+		h.promptText.mockResolvedValue("1");
 		await runGuidedFrontDoor();
 		expect(h.saveConfigScoped).toHaveBeenCalledWith({ aiProvider: "jolli" }, "/global/config");
 		expect(out()).toContain("switched to Jolli");
-		// Must NOT claim "first memory" when the repo already has memories.
 		expect(out()).toContain("last memory saved");
 		expect(out()).not.toContain("first memory");
 	});
 
-	it("choose 'enter Anthropic key' → saves apiKey + provider anthropic; listening reflects memory count", async () => {
+	it("provider=anthropic + jolliApiKey, Enter at menu → defaults to 'switch to Jolli'", async () => {
 		h.loadAuthToken.mockResolvedValue("oauth-token");
 		h.loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-x", aiProvider: "anthropic" });
-		h.getSummaryCount.mockResolvedValue(163);
-		h.promptText.mockResolvedValueOnce("1").mockResolvedValueOnce("sk-ant-new");
+		h.promptText.mockResolvedValue(""); // Enter → default [1] = switch
+		await runGuidedFrontDoor();
+		expect(h.saveConfigScoped).toHaveBeenCalledWith({ aiProvider: "jolli" }, "/global/config");
+	});
+
+	it("provider=anthropic + jolliApiKey, choose 'enter Anthropic key' → saves apiKey + provider", async () => {
+		h.loadAuthToken.mockResolvedValue("oauth-token");
+		h.loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-x", aiProvider: "anthropic" });
+		h.promptText.mockResolvedValueOnce("2").mockResolvedValueOnce("sk-ant-new");
 		await runGuidedFrontDoor();
 		expect(h.saveConfigScoped).toHaveBeenCalledWith(
 			{ apiKey: "sk-ant-new", aiProvider: "anthropic" },
 			"/global/config",
 		);
 		expect(out()).toContain("Anthropic key saved");
-		expect(out()).toContain("last memory saved");
-		expect(out()).not.toContain("first memory");
 	});
 
-	it("provider=anthropic + jolliApiKey, press Enter at menu → defaults to entering an Anthropic key", async () => {
-		h.loadAuthToken.mockResolvedValue("oauth-token");
-		h.loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-x", aiProvider: "anthropic" });
-		h.promptText.mockResolvedValueOnce("").mockResolvedValueOnce("sk-ant-y");
-		await runGuidedFrontDoor();
-		expect(h.saveConfigScoped).toHaveBeenCalledWith(
-			{ apiKey: "sk-ant-y", aiProvider: "anthropic" },
-			"/global/config",
-		);
-	});
-
-	it("provider=anthropic + jolliApiKey, choose 'skip' → no config change", async () => {
+	it("provider=anthropic + jolliApiKey, choose 'skip' → no config change, no listening", async () => {
 		h.loadAuthToken.mockResolvedValue("oauth-token");
 		h.loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-x", aiProvider: "anthropic" });
 		h.promptText.mockResolvedValue("3");
@@ -339,9 +440,9 @@ describe("GuidedFrontDoor", () => {
 		expect(out()).not.toContain("Jolli is listening");
 	});
 
-	it("no jolliApiKey path: enter Anthropic key → saved", async () => {
+	it("provider=anthropic, no other key: enter Anthropic key → saved", async () => {
 		h.loadAuthToken.mockResolvedValue("oauth-token");
-		h.loadConfig.mockResolvedValue({ aiProvider: "anthropic" }); // no jolliApiKey
+		h.loadConfig.mockResolvedValue({ aiProvider: "anthropic", jolliUrl: "https://acme.jolli.ai" });
 		h.promptText.mockResolvedValueOnce("1").mockResolvedValueOnce("sk-ant-x");
 		await runGuidedFrontDoor();
 		expect(h.saveConfigScoped).toHaveBeenCalledWith(
@@ -350,19 +451,74 @@ describe("GuidedFrontDoor", () => {
 		);
 	});
 
-	it("no jolliApiKey path: skip → no change", async () => {
+	it("provider=anthropic, no other key: skip → no change", async () => {
 		h.loadAuthToken.mockResolvedValue("oauth-token");
-		h.loadConfig.mockResolvedValue({ aiProvider: "anthropic" });
-		h.promptText.mockResolvedValue("2"); // skip in the no-Jolli menu
+		h.loadConfig.mockResolvedValue({ aiProvider: "anthropic", jolliUrl: "https://acme.jolli.ai" });
+		h.promptText.mockResolvedValue("2"); // skip in the 2-option menu
 		await runGuidedFrontDoor();
 		expect(h.saveConfigScoped).not.toHaveBeenCalled();
 	});
 
 	it("enter Anthropic key but press Enter (empty) → skipped, no save", async () => {
 		h.loadAuthToken.mockResolvedValue("oauth-token");
-		h.loadConfig.mockResolvedValue({ aiProvider: "anthropic" });
+		h.loadConfig.mockResolvedValue({ aiProvider: "anthropic", jolliUrl: "https://acme.jolli.ai" });
 		h.promptText.mockResolvedValueOnce("1").mockResolvedValueOnce("");
 		await runGuidedFrontDoor();
+		expect(h.saveConfigScoped).not.toHaveBeenCalled();
+	});
+
+	it("provider=jolli, only an Anthropic key → 'switch to Anthropic', then offers sign-in", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		// Second load reflects the just-written aiProvider switch (rung 1 reloads config).
+		h.loadConfig
+			.mockResolvedValueOnce({ apiKey: "sk-ant-x", aiProvider: "jolli" })
+			.mockResolvedValueOnce({ apiKey: "sk-ant-x", aiProvider: "anthropic" });
+		h.getSummaryCount.mockResolvedValue(3);
+		h.promptText.mockResolvedValueOnce("1").mockResolvedValueOnce("n"); // switch, then decline login
+		await runGuidedFrontDoor();
+		expect(out()).toContain("no Jolli key is available");
+		expect(h.saveConfigScoped).toHaveBeenCalledWith({ aiProvider: "anthropic" }, "/global/config");
+		expect(out()).toContain("switched to Anthropic");
+		expect(h.saveUserProfile).toHaveBeenCalledWith({ signInPromptDeclined: true });
+		expect(out()).toContain("last memory saved");
+	});
+
+	it("provider=jolli, only an Anthropic key, choose 'enter a Jolli key' → validated + saved", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig
+			.mockResolvedValueOnce({ apiKey: "sk-ant-x", aiProvider: "jolli" })
+			.mockResolvedValueOnce({ apiKey: "sk-ant-x", jolliApiKey: "sk-jol-new", aiProvider: "jolli" });
+		h.promptText.mockResolvedValueOnce("2").mockResolvedValueOnce("sk-jol-new");
+		await runGuidedFrontDoor();
+		expect(h.validateJolliApiKey).toHaveBeenCalledWith("sk-jol-new");
+		expect(h.saveConfigScoped).toHaveBeenCalledWith(
+			{ jolliApiKey: "sk-jol-new", aiProvider: "jolli" },
+			"/global/config",
+		);
+		expect(out()).toContain("Jolli key saved");
+		// jolliApiKey now present → can sync → no sign-in nudge.
+		expect(h.browserLogin).not.toHaveBeenCalled();
+	});
+
+	it("enter a Jolli key that fails validation → error, no save, no listening", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig.mockResolvedValue({ apiKey: "sk-ant-x", aiProvider: "jolli" });
+		h.promptText.mockResolvedValueOnce("2").mockResolvedValueOnce("bad-key");
+		h.validateJolliApiKey.mockImplementation(() => {
+			throw new Error("invalid key");
+		});
+		await runGuidedFrontDoor();
+		expect(errors.join("\n")).toContain("invalid key");
+		expect(h.saveConfigScoped).not.toHaveBeenCalled();
+		expect(out()).not.toContain("Jolli is listening");
+	});
+
+	it("enter a Jolli key but press Enter (empty) → skipped, no save", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig.mockResolvedValue({ apiKey: "sk-ant-x", aiProvider: "jolli" });
+		h.promptText.mockResolvedValueOnce("2").mockResolvedValueOnce("");
+		await runGuidedFrontDoor();
+		expect(h.validateJolliApiKey).not.toHaveBeenCalled();
 		expect(h.saveConfigScoped).not.toHaveBeenCalled();
 	});
 
@@ -375,8 +531,6 @@ describe("GuidedFrontDoor", () => {
 		});
 
 		it("folder-only repo with no orphan branch still reports its memories", async () => {
-			// Regression: previously gated on orphanBranchExists, so folder-mode
-			// repos (memories on disk, no orphan branch) wrongly reported 0.
 			h.isGitHookInstalled.mockResolvedValue(true);
 			h.getSummaryCount.mockResolvedValue(4);
 			const status = await getGuidedFrontDoorStatus("/repo");

--- a/cli/src/commands/GuidedFrontDoor.ts
+++ b/cli/src/commands/GuidedFrontDoor.ts
@@ -1,30 +1,40 @@
 /**
  * The guided front door — what bare `jolli` (no args, interactive TTY) runs.
  *
- * It reads two axes of state — auth (global sign-in / credentials) and enable
- * (per-repo hooks) — and offers the next step: sign in, enable the repo, then
- * confirm "Jolli is listening". It replaces having to run `auth login`, `auth
- * status`, `enable`, and `status` by hand, without removing those commands.
+ * It reads two orthogonal capabilities and guides the next step:
+ *   - can generate — is there a usable LLM key (`resolveLlmCredentialSource`)?
+ *   - can sync     — is there any Jolli credential (OAuth token or jolliApiKey)
+ *                    to push memories to a Space?
+ * `signedIn` (an OAuth token) is display-only — it decides the status-line
+ * wording, never the control flow.
  *
- * Everything about the cloud side (pushing memories to a Jolli Space, binding,
- * sync prompts) is delegated to `runSpaceSyncStep` — the front door only calls
- * it once the repo is enabled and prints nothing about push/sync itself.
+ * Flow: opening status line → capability ladder (fix generation if broken, then
+ * offer sign-in if memories can't sync) → cloud side-effects with the settled
+ * credentials → a closing "Jolli is listening" when generation works. It
+ * replaces running `auth login`, `auth status`, `enable`, and `status` by hand
+ * without removing those commands. Everything about the cloud side (pushing to a
+ * Space, binding, sync prompts) is delegated to `runSpaceSyncStep`.
  */
 
-import { loadAuthToken } from "../auth/AuthConfig.js";
+import { getJolliUrl, loadAuthToken } from "../auth/AuthConfig.js";
+import { browserLogin } from "../auth/Login.js";
+import { validateJolliApiKey } from "../core/JolliApiUtils.js";
 import { resolveLlmCredentialSource } from "../core/LlmClient.js";
 import { getGlobalConfigDir, loadConfig, saveConfigScoped } from "../core/SessionTracker.js";
 import { createStorage } from "../core/StorageFactory.js";
 import { getSummaryCount, setActiveStorage } from "../core/SummaryStore.js";
 import { track } from "../core/Telemetry.js";
+import { loadUserProfile, saveUserProfile } from "../core/UserProfile.js";
 import { triggerPendingPushRetry } from "../hooks/PushCompensation.js";
 import { isGitHookInstalled } from "../install/GitHookInstaller.js";
 import { install } from "../install/Installer.js";
-import { setLogDir } from "../Logger.js";
+import { createLogger, setLogDir } from "../Logger.js";
 import type { JolliMemoryConfig } from "../Types.js";
 import { isAffirmative, promptText, resolveProjectDir } from "./CliUtils.js";
 import { promptSetup } from "./EnableCommand.js";
 import { runSpaceSyncStep } from "./SpaceSyncStep.js";
+
+const log = createLogger("GuidedFrontDoor");
 
 /** Lightweight front-door status. Deliberately avoids the heavy `getStatus()`. */
 export interface GuidedFrontDoorStatus {
@@ -75,6 +85,7 @@ export async function runGuidedFrontDoor(): Promise<void> {
 	// Any of these counts as "has some credential" and skips the sign-in guide.
 	const hasCredential = (): boolean =>
 		Boolean(token || config.jolliApiKey || config.apiKey || process.env.ANTHROPIC_API_KEY);
+
 	// ── Auth axis: no credential at all → run the existing sign-in / config guide ──
 	if (!hasCredential()) {
 		await promptSetup();
@@ -108,11 +119,12 @@ export async function runGuidedFrontDoor(): Promise<void> {
 		summaryCount = await getSummaryCount(cwd);
 	}
 
-	// ── Status line: reflect the real credential state, never a blanket sign-in ──
-	// `credSource` uses the authoritative resolver (honours the chosen aiProvider),
-	// so it can name the actual key in play and also gates "listening" below. A
-	// bare OAuth token alone is not an LLM credential, hence null → "not signed in".
+	// ── Two orthogonal capabilities. `signedIn` (a token) is display-only. ──
 	const credSource = resolveLlmCredentialSource(config);
+	let canGenerate = credSource !== null;
+	let canSync = Boolean(token || config.jolliApiKey);
+
+	// ── Status line (opening snapshot; the token picks the wording only) ──
 	if (token) {
 		const site = siteHost(config.jolliUrl);
 		console.log(site ? `\n  ✓ signed in · ${site}` : "\n  ✓ signed in");
@@ -124,80 +136,99 @@ export async function runGuidedFrontDoor(): Promise<void> {
 	}
 	console.log(`  ✓ enabled · ${summaryCount} ${summaryCount === 1 ? "memory" : "memories"}`);
 
-	// ── Cloud sync + push catch-up: whenever enabled. Resolve or create the repo
-	// binding before retrying pending pushes so the first retry cannot race ahead
-	// and fail with `binding_required`. The retry remains fire-and-forget after
-	// setup and no-ops when not signed in. ──
-	if (enabled) {
-		await runSpaceSyncStep(cwd);
-		void triggerPendingPushRetry(cwd);
+	// ── Rung 1 (blocking): a credential exists but the chosen provider can't use
+	// it → repair the provider/key mismatch. `hasCredential()` excludes the fresh
+	// user who just skipped setup (nothing to repair — don't re-ask). ──
+	if (!canGenerate && hasCredential()) {
+		canGenerate = await promptGenerationFix(config);
+		// A key entered / provider switched above may now allow sync too.
+		config = await loadConfig();
+		canSync = Boolean(token || config.jolliApiKey);
 	}
 
-	// ── Confirmation: only promise "listening" when memories can be generated ──
-	let generatable = credSource !== null;
-	if (!generatable && token) {
-		// Signed in, but the chosen provider has no usable key. Offer an in-place
-		// fix; it returns whether we can generate now (a key was set / provider switched).
-		generatable = await promptGenerationFix(config);
-		// NOTE: promptGenerationFix may have persisted config changes (via
-		// saveConfigScoped); the in-memory `config` / `credSource` are now stale.
-		// Nothing below re-reads them — re-read config if you add logic that does.
+	// ── Rung 2 (non-blocking): generation works, but memories can't leave the
+	// machine → offer sign-in once, defaulting to Yes. A prior decline (persisted
+	// in profile.json) suppresses it. Read the profile lazily — only here. ──
+	if (canGenerate && !canSync) {
+		const profile = await loadUserProfile();
+		if (!profile.signInPromptDeclined) {
+			await promptOptionalLogin();
+			token = await loadAuthToken();
+			config = await loadConfig();
+			canSync = Boolean(token || config.jolliApiKey);
+		}
 	}
-	if (generatable) {
+
+	// ── Cloud side-effects: only after credentials are settled, so a sign-in or
+	// key established above is picked up this run. We are always enabled by here
+	// (the enable axis above either enabled the repo or returned early). Bind the
+	// Space first (runSpaceSyncStep), then push the backlog to it —
+	// triggerPendingPushRetry is idempotent and no-ops when not signed in. ──
+	await runSpaceSyncStep(cwd);
+	void triggerPendingPushRetry(cwd);
+
+	// ── Closing confirmation: only promise "listening" when generation works. ──
+	if (canGenerate) {
 		const listening =
 			summaryCount === 0
 				? "Jolli is listening — your next commit is your first memory"
 				: "Jolli is listening — last memory saved.";
-		// Generating locally via an Anthropic key but with no Jolli credential at
-		// all — nudge (never force) sign-in so memories can sync to a Space.
-		const nudge =
-			!token && !config.jolliApiKey
-				? "\n  Not signed in to Jolli — run `jolli auth login` to sync memories to a Space."
-				: "";
-		console.log(`\n  ${listening}${nudge}\n`);
+		console.log(`\n  ${listening}\n`);
 	}
 }
 
 /**
- * Signed in, but the active provider has no usable key. Offer to fix it in place:
- * enter an Anthropic key, or — when the user already has a Jolli sign-in key —
- * switch to the Jolli provider. The provider is only ever changed by an explicit
- * choice here, never silently. Each choice writes `aiProvider` so the saved
- * credential and the chosen provider can't drift out of sync.
+ * Reached only when generation is broken while a credential exists: the chosen
+ * `aiProvider` has no usable key. Offer the zero-typing fix first — switch to
+ * whichever provider a key already exists for — then entering the missing key,
+ * then skip. The provider is only ever changed by an explicit choice here.
+ * Returns whether generation can now proceed (a key was set / provider switched).
  */
 async function promptGenerationFix(config: JolliMemoryConfig): Promise<boolean> {
 	const configDir = getGlobalConfigDir();
-	// Reaching here means canGenerate() was false. If a jolliApiKey exists the
-	// provider cannot be "jolli" (that would already generate), so offering to
-	// switch to Jolli is always safe when a jolliApiKey is present.
-	const canUseJolli = Boolean(config.jolliApiKey);
+	const provider = config.aiProvider === "jolli" ? "jolli" : "anthropic";
+	const providerName = provider === "jolli" ? "Jolli" : "Anthropic";
+	const hasJolliKey = Boolean(config.jolliApiKey);
+	const hasAnthropicKey = Boolean(config.apiKey || process.env.ANTHROPIC_API_KEY);
+	// The *other* provider already has a key → switching to it fixes generation
+	// with no typing. Symmetric: covers both provider directions.
+	const otherHasKey = provider === "anthropic" ? hasJolliKey : hasAnthropicKey;
+	const otherProvider = provider === "anthropic" ? "jolli" : "anthropic";
+	const otherName = otherProvider === "jolli" ? "Jolli" : "Anthropic";
+	const enterKeyLabel = provider === "anthropic" ? "an Anthropic key" : "a Jolli key";
+	const enterMissingKey = (): Promise<boolean> =>
+		provider === "anthropic" ? promptAndSaveAnthropicKey(configDir) : promptAndSaveJolliKey(configDir);
 
-	console.log("\n  Signed in, but the current AI provider has no usable key — memories won't be generated.\n");
-	if (canUseJolli) {
-		console.log("    1. Enter an Anthropic API key          (keeps Anthropic)");
-		console.log("    2. Switch to Jolli (use your sign-in)");
+	console.log(
+		`\n  AI provider is set to ${providerName} but no ${providerName} key is available — memories won't be generated.\n`,
+	);
+
+	if (otherHasKey) {
+		const switchHint = otherProvider === "jolli" ? "use your sign-in" : "use existing key";
+		console.log(`    1. Switch to ${otherName} (${switchHint})`);
+		console.log(`    2. Enter ${enterKeyLabel}`);
 		console.log("    3. Skip for now");
 		const choice = (await promptText("\n  Choice [1]: ")) || "1";
 		if (choice === "3") {
 			console.log("\n  Skipped. Set a key in settings or run `jolli configure` later.\n");
 			return false;
 		}
-		if (choice === "2") {
-			await saveConfigScoped({ aiProvider: "jolli" }, configDir);
-			console.log("\n  ✓ switched to Jolli");
+		if (choice === "1") {
+			await saveConfigScoped({ aiProvider: otherProvider }, configDir);
+			console.log(`\n  ✓ switched to ${otherName}`);
 			return true;
 		}
-		return promptAndSaveAnthropicKey(configDir);
+		return enterMissingKey();
 	}
 
-	console.log("    1. Enter an Anthropic API key");
+	console.log(`    1. Enter ${enterKeyLabel}`);
 	console.log("    2. Skip for now");
 	const choice = (await promptText("\n  Choice [1]: ")) || "1";
 	if (choice === "2") {
 		console.log("\n  Skipped. Set a key in settings or run `jolli configure` later.\n");
 		return false;
 	}
-	return promptAndSaveAnthropicKey(configDir);
+	return enterMissingKey();
 }
 
 /** Prompts for an Anthropic API key, saves it, and pins the provider to Anthropic. Returns whether a key was saved. */
@@ -210,4 +241,51 @@ async function promptAndSaveAnthropicKey(configDir: string): Promise<boolean> {
 	await saveConfigScoped({ apiKey: key, aiProvider: "anthropic" }, configDir);
 	console.log("\n  ✓ Anthropic key saved");
 	return true;
+}
+
+/** Prompts for a Jolli API key, validates + saves it, and pins the provider to Jolli. Returns whether a key was saved. */
+async function promptAndSaveJolliKey(configDir: string): Promise<boolean> {
+	const key = await promptText("\n  Jolli API Key (press Enter to skip): ");
+	if (!key) {
+		console.log("  Skipped. Set a key in settings or run `jolli configure` later.\n");
+		return false;
+	}
+	try {
+		validateJolliApiKey(key);
+	} catch (err) {
+		console.error(`\n  Error: ${(err as Error).message}\n`);
+		return false;
+	}
+	await saveConfigScoped({ jolliApiKey: key, aiProvider: "jolli" }, configDir);
+	console.log("\n  ✓ Jolli key saved");
+	return true;
+}
+
+/**
+ * Generation works locally, but there's no Jolli credential to sync memories to
+ * a Space. Offer to sign in — default Yes, asked once. On an explicit "no" we
+ * persist the decline (profile.json) so this never reappears; a login failure is
+ * NOT a decline, so it stays unrecorded and the next run can offer again.
+ */
+async function promptOptionalLogin(): Promise<void> {
+	const answer = await promptText("\n  Not signed in to Jolli. Sign in now to sync memories to a Space? [Y/n] ");
+	if (!isAffirmative(answer)) {
+		// Persisting the decline is best-effort: a cosmetic "don't ask again" flag
+		// must never abort the front door if the profile dir isn't writable — we
+		// just offer again next run.
+		try {
+			await saveUserProfile({ signInPromptDeclined: true });
+		} catch {
+			log.debug("Could not persist the sign-in decline; will offer again next run");
+		}
+		console.log("  You can sign in anytime with `jolli auth login`.\n");
+		return;
+	}
+	try {
+		await browserLogin(getJolliUrl());
+		console.log("\n  ✓ signed in — memories will sync to your Space.\n");
+	} catch (err) {
+		console.error(`\n  Login failed: ${err instanceof Error ? err.message : String(err)}`);
+		console.log("  You can try again with `jolli auth login`.\n");
+	}
 }

--- a/cli/src/core/UserProfile.test.ts
+++ b/cli/src/core/UserProfile.test.ts
@@ -1,0 +1,62 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Point getGlobalConfigDir at a throwaway temp dir; everything else (atomicWrite,
+// fs) runs for real so the load/save round-trip is genuinely exercised.
+const h = vi.hoisted(() => ({ dir: "" }));
+vi.mock("./SessionTracker.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("./SessionTracker.js")>()),
+	getGlobalConfigDir: () => h.dir,
+}));
+
+import { loadUserProfile, saveUserProfile } from "./UserProfile.js";
+
+describe("UserProfile", () => {
+	let dir: string;
+
+	beforeEach(async () => {
+		dir = await mkdtemp(join(tmpdir(), "jolli-profile-"));
+		h.dir = dir;
+	});
+
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("returns an empty profile when the file is missing", async () => {
+		expect(await loadUserProfile()).toEqual({});
+	});
+
+	it("returns an empty profile on unparseable JSON", async () => {
+		await writeFile(join(dir, "profile.json"), "{ not json", "utf-8");
+		expect(await loadUserProfile()).toEqual({});
+	});
+
+	it("returns an empty profile on well-formed but non-object JSON", async () => {
+		// External tampering could leave a bare number / array / null; none of these
+		// is a valid profile, so we fall back to {} rather than let it leak through.
+		for (const junk of ["42", "null", "[]", '"nope"']) {
+			await writeFile(join(dir, "profile.json"), junk, "utf-8");
+			expect(await loadUserProfile()).toEqual({});
+		}
+	});
+
+	it("saves then loads a flag round-trip", async () => {
+		await saveUserProfile({ signInPromptDeclined: true });
+		expect(await loadUserProfile()).toEqual({ signInPromptDeclined: true });
+	});
+
+	it("shallow-merges updates, preserving existing fields", async () => {
+		await saveUserProfile({ email: "joe@acme.dev" });
+		await saveUserProfile({ signInPromptDeclined: true });
+		expect(await loadUserProfile()).toEqual({ email: "joe@acme.dev", signInPromptDeclined: true });
+	});
+
+	it("creates the config directory when it does not exist yet", async () => {
+		h.dir = join(dir, "nested", "config");
+		await saveUserProfile({ signInPromptDeclined: true });
+		expect(await loadUserProfile()).toEqual({ signInPromptDeclined: true });
+	});
+});

--- a/cli/src/core/UserProfile.ts
+++ b/cli/src/core/UserProfile.ts
@@ -1,0 +1,56 @@
+/**
+ * User profile — machine-global, non-credential state that Jolli observes or
+ * remembers about the user, kept separate from `config.json`.
+ *
+ * `config.json` holds credentials and settings the user actively sets (auth
+ * token, API keys, chosen AI provider). `profile.json` holds things Jolli
+ * derives or remembers on the user's behalf: a captured sign-in email (future),
+ * and small UX flags such as whether the user has declined the optional
+ * sign-in nudge. The two never overwrite each other.
+ *
+ * Lives at `<globalConfigDir>/profile.json`. Mirrors SessionTracker's config
+ * load/save idiom: read errors fall back to defaults; writes merge with the
+ * existing file and land atomically so a partial write can't corrupt it.
+ */
+
+import { mkdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createLogger } from "../Logger.js";
+import { atomicWriteFile } from "./AtomicWrite.js";
+import { getGlobalConfigDir } from "./SessionTracker.js";
+
+const log = createLogger("UserProfile");
+const PROFILE_FILE = "profile.json";
+
+export interface UserProfile {
+	/** Sign-in email captured after OAuth (reserved for future use). */
+	readonly email?: string;
+	/** The user explicitly declined the optional sign-in nudge; don't ask again. */
+	readonly signInPromptDeclined?: boolean;
+}
+
+/**
+ * Reads the global profile.json. Returns an empty profile on any error (missing
+ * file, bad JSON) and on well-formed but non-object JSON (e.g. `42`, `null`,
+ * `[]`) — the latter can only arise from external tampering, but guarding it
+ * keeps the "always an object" contract that callers spread and read from.
+ */
+export async function loadUserProfile(): Promise<UserProfile> {
+	const filePath = join(getGlobalConfigDir(), PROFILE_FILE);
+	try {
+		const parsed = JSON.parse(await readFile(filePath, "utf-8")) as unknown;
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as UserProfile) : {};
+	} catch {
+		log.debug("No profile file at %s, using defaults", filePath);
+		return {};
+	}
+}
+
+/** Merges a partial update into the global profile.json and writes it atomically. */
+export async function saveUserProfile(update: Partial<UserProfile>): Promise<void> {
+	const dir = getGlobalConfigDir();
+	await mkdir(dir, { recursive: true });
+	const merged = { ...(await loadUserProfile()), ...update };
+	await atomicWriteFile(join(dir, PROFILE_FILE), JSON.stringify(merged, null, "\t"));
+	log.debug("Profile saved to %s", dir);
+}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The tool's startup flow gained a proper interactive sign-in prompt for users who can generate memories locally but have no way to sync them to a Space. Previously, these users saw a single passive line of text suggesting they run a separate command. Now the tool asks directly, defaults to yes, and opens the browser OAuth flow on acceptance. A deliberate refusal is recorded permanently so the question never reappears; a login failure is not recorded, giving the user another opportunity on the next run.

The repair path for mismatched AI provider settings was also made symmetric. Previously, only one direction of mismatch was handled — a user who had selected the Jolli provider but only possessed an Anthropic key would reach a dead end with no actionable option. The updated flow detects which key is already available and offers a zero-typing "switch to that provider" option as the first choice in both directions. The trigger for this repair was also broadened to fire for any user with a credential but a misconfigured provider, not only those with an active sign-in session.

---

## Topics (3)
<details>
<summary><strong>01 · Sign-in nudge flow added to guide users without cloud sync</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users running the tool with only a local AI key (such as an Anthropic key) could generate memories but had no way to sync them to a Space. The existing experience only printed a passive one-line hint to run a separate command. The developer wanted this to become an interactive prompt that asks once, defaults to yes, and never asks again after a deliberate refusal.

**💡 Decisions Behind the Code**

- **Persisting the decline separately from credentials**: Storing the "don't ask again" flag in a dedicated profile file rather than the main credentials config keeps the two concerns cleanly separated — credentials are things the user actively sets, while the profile holds things the tool observes or remembers. This also makes the file a natural home for future identity data such as a captured sign-in email, without polluting the credentials file.
- **Default Yes with a permanent decline, not a recurring passive hint**: Making the prompt default to Yes and recording an explicit No permanently means the tool asks assertively once and then respects the answer forever. A login failure is deliberately not recorded as a decline, so a network outage cannot silence the nudge permanently — the user gets another chance next run. This is more respectful of user intent than either always showing the hint or requiring the user to find a separate command.
- **Capability axes over sign-in state as the control variable**: Earlier designs used the OAuth token as the primary branching condition, which caused the "has a Jolli API key but no OAuth token" case to be misclassified as needing a sign-in nudge even though that user can already sync. Switching to "can generate" and "can sync" as the two independent axes made every scenario fall into the correct branch without special-case patches, and reduced the number of terminal states from five to three.

**✅ What Was Implemented**

- `GuidedFrontDoor.ts` was restructured around two orthogonal capability axes — whether the user can generate memories (has a usable AI key) and whether memories can leave the machine (has any Jolli credential). The old `signedIn` flag was demoted to a display-only variable that controls status-line wording but never drives control flow. A new `promptOptionalLogin` function presents the sign-in question with a default-Yes prompt, calls the browser OAuth flow on acceptance, and swallows write errors on decline so a non-writable home directory cannot abort the front door.
- The ordering of cloud side-effects was corrected: the Space binding step and the push-backlog retry now run after all interactive credential prompts complete, so a sign-in or key entered during the session is picked up in the same run rather than the next one. Config is reloaded and capabilities recomputed after each interactive rung.
- `cli/src/core/UserProfile.ts` was introduced as a new module that reads and writes `~/.jolli/jollimemory/profile.json` — a machine-global file separate from the credentials config. It stores the user's explicit decline of the sign-in nudge (and reserves space for a future sign-in email field). Writes are atomic and merge with existing content so unknown fields survive updates.

**📁 FILES**
- `cli/src/commands/GuidedFrontDoor.ts`
- `cli/src/core/UserProfile.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Provider and key mismatch repair made symmetric for both AI providers</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The existing repair menu only handled the case where the user had chosen Anthropic as their provider but was missing an Anthropic key. If the user had chosen the Jolli provider but only had an Anthropic key available, the menu offered no useful path and could not suggest switching to the provider whose key was already present.

**💡 Decisions Behind the Code**

- **Zero-typing switch option shown first**: When the user already has a working key for the other provider, offering "switch to that provider" as the first and default choice means most mismatch repairs require a single keypress. Entering a new key is offered as a secondary option. This ordering reflects that the common case is a misconfigured provider setting, not a genuinely missing key.
- **Widening the trigger to not require OAuth**: The old guard required an active OAuth session before showing the repair menu, which left users with a key but no OAuth token stuck at a dead-end status screen with no actionable path. Removing that restriction means the repair menu fires for any user who has some credential but the wrong provider selected, regardless of sign-in state.

**✅ What Was Implemented**

- `promptGenerationFix` in `GuidedFrontDoor.ts` was rewritten to detect which provider is active and which key is already available, then offer a zero-typing "switch to the other provider" option first when a key for that provider already exists. The logic is symmetric: it works in both directions (Anthropic→Jolli and Jolli→Anthropic) rather than only one.
- A new `promptAndSaveJolliKey` function was added alongside the existing Anthropic key entry path, so users can also enter a Jolli API key inline with validation. The repair menu trigger was also widened to fire whenever a credential exists but the chosen provider has no key, removing a prior restriction that required an OAuth token to be present.

**📁 FILES**
- `cli/src/commands/GuidedFrontDoor.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · User profile storage module introduced for machine-global non-credential state</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The sign-in decline flag needed a persistent home that was separate from the credentials file and designed to grow with future identity data. No such module existed.

**💡 Decisions Behind the Code**

Validating that the parsed JSON value is a plain object before returning it closes a gap between the documented contract ("always returns an object") and the actual behavior: `JSON.parse` succeeds for valid but non-object inputs, and spreading a `null` result would throw rather than degrade. The fix was identified by an adversarial review agent and confirmed as zero-risk — the writer always produces an object, so the guard only fires on externally corrupted files, and the safe fallback is to re-prompt the user once rather than crash.

**✅ What Was Implemented**

`cli/src/core/UserProfile.ts` provides `loadUserProfile` and `saveUserProfile`. Loading returns an empty profile on any error including missing file, unparseable JSON, and well-formed but non-object JSON values such as `null` or bare arrays — the last case was identified during adversarial review as the one path that could throw rather than degrade gracefully. Saves shallow-merge the update with the existing file content and write atomically, preserving any fields added by future versions.

**📁 FILES**
- `cli/src/core/UserProfile.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 14, 2026 at 4:47 PM · via Anthropic*
<!-- jollimemory-summary-end -->