### PR TITLE
Add monday.com item reference source integration

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -781,7 +781,8 @@ export type KnownSourceId =
 	| "slack"
 	| "zoom-meeting"
 	| "zoom-doc"
-	| "asana";
+	| "asana"
+	| "monday";
 
 /**
  * ReferenceField — one displayable field produced by a `SourceDefinition`'s `fields` pipes.

--- a/cli/src/core/references/ClaudeEnvelopeParser.test.ts
+++ b/cli/src/core/references/ClaudeEnvelopeParser.test.ts
@@ -269,3 +269,57 @@ describe("ClaudeEnvelopeParser oversized/offloaded tool result", () => {
 		expect(claudeEnvelopeParser.parse(meetingResultLines(offloadPointer(badJson)), {}).results).toHaveLength(0);
 	});
 });
+
+describe("ClaudeEnvelopeParser monday", () => {
+	const PAYLOAD = {
+		board: { id: "18421599187", name: "Tasks" },
+		items: [
+			{
+				id: "12511130115",
+				name: "Add monday MCP integration",
+				url: "https://jolli-squad.monday.com/boards/18421599187/pulses/12511130115",
+				created_at: "2026-07-12T11:05:25Z",
+				updated_at: "2026-07-14T08:30:22Z",
+				item_description: {
+					blocks: [{ content: '{"deltaFormat":[{"insert":"Use MCP to get monday task info."}]}' }],
+				},
+			},
+		],
+		pagination: { count: 1 },
+	};
+	const TOOL = "mcp__claude_ai_monday_com__get_board_items_page";
+
+	function mondayLines(input: Record<string, unknown>): string[] {
+		return [
+			JSON.stringify({
+				message: {
+					role: "assistant",
+					content: [{ type: "tool_use", id: "m1", name: TOOL, input }],
+				},
+			}),
+			JSON.stringify({
+				message: {
+					role: "user",
+					content: [{ type: "tool_result", tool_use_id: "m1", content: JSON.stringify(PAYLOAD) }],
+				},
+			}),
+		];
+	}
+
+	it("normalizes a targeted itemIds fetch into the { items } wrapper", () => {
+		const { results } = claudeEnvelopeParser.parse(
+			mondayLines({ boardId: 18421599187, itemIds: [12511130115] }),
+			{},
+		);
+		expect(results).toHaveLength(1);
+		expect(results[0].def.id).toBe("monday");
+		const p = results[0].payload as { items: Array<{ id: string; description?: string }> };
+		expect(p.items[0].id).toBe("12511130115");
+		expect(p.items[0].description).toBe("Use MCP to get monday task info.");
+	});
+
+	it("produces nothing for a board browse (no itemIds)", () => {
+		const { results } = claudeEnvelopeParser.parse(mondayLines({ boardId: 18421599187 }), {});
+		expect(results.filter((r) => r.def.id === "monday")).toHaveLength(0);
+	});
+});

--- a/cli/src/core/references/ClaudeEnvelopeParser.ts
+++ b/cli/src/core/references/ClaudeEnvelopeParser.ts
@@ -33,6 +33,7 @@ import { scanUserPermalinks } from "./SlackPermalink.js";
 import type { SourceDefinition } from "./SourceDefinition.js";
 import { getRegistry } from "./SourceDefinitionRegistry.js";
 import { normalizeConfluence } from "./sources/ConfluenceNormalize.js";
+import { normalizeMonday, readItemIds } from "./sources/MondayNormalize.js";
 import { normalizeSlackThread } from "./sources/SlackNormalize.js";
 import { normalizeZoomDoc } from "./sources/ZoomDocNormalize.js";
 import type {
@@ -295,6 +296,7 @@ const CONTEXT_NORMALIZERS: Record<
 		return normalizeZoomDoc(payload, { fileId: zoomInput.fileId });
 	},
 	confluence: (payload) => normalizeConfluence(payload),
+	monday: (payload, toolInput) => normalizeMonday(payload, { itemIds: readItemIds(toolInput) }),
 };
 
 /**

--- a/cli/src/core/references/CodexEnvelopeParser.test.ts
+++ b/cli/src/core/references/CodexEnvelopeParser.test.ts
@@ -59,15 +59,22 @@ function fnOutputRaw(callId: string, output: string): string {
 	});
 }
 
-/** mcp_tool_call_end event row. `inner` is the business object (single-stringed). */
-function toolCallEnd(tool: string, callId: string, inner: unknown): string {
+/** mcp_tool_call_end event row. `inner` is the business object (single-stringed).
+ *  `invocationArgs` is the pre-parsed request object real codex_apps events carry
+ *  on `invocation.arguments` (present in exec/apps mode where there is no paired
+ *  function_call row); omitted when absent. */
+function toolCallEnd(tool: string, callId: string, inner: unknown, invocationArgs?: unknown): string {
 	return jsonl({
 		type: "event_msg",
 		timestamp: TS,
 		payload: {
 			type: "mcp_tool_call_end",
 			call_id: callId,
-			invocation: { server: "codex_apps", tool },
+			invocation: {
+				server: "codex_apps",
+				tool,
+				...(invocationArgs !== undefined ? { arguments: invocationArgs } : {}),
+			},
 			result: { Ok: { content: [{ type: "text", text: JSON.stringify(inner) }] } },
 		},
 	});
@@ -1022,5 +1029,95 @@ describe("CodexEnvelopeParser end-to-end — shell gh issue view (state lowercas
 		expect(gh).toHaveLength(1);
 		expect(gh[0].fields?.find((f) => f.key === "status")?.value).toBe("closed");
 		expect(gh[0].fields?.some((f) => f.key === "labels")).toBe(true);
+	});
+});
+
+describe("CodexEnvelopeParser.parse — monday (itemIds gate from event or function_call arguments)", () => {
+	const MONDAY = {
+		board: { id: "18421599187", name: "Tasks" },
+		items: [
+			{
+				id: "12511130115",
+				name: "Add monday MCP integration",
+				url: "https://jolli-squad.monday.com/boards/18421599187/pulses/12511130115",
+				created_at: "2026-07-12T11:05:25Z",
+				updated_at: "2026-07-14T08:30:22Z",
+				item_description: {
+					blocks: [{ content: '{"deltaFormat":[{"insert":"Use MCP to get monday task info."}]}' }],
+				},
+			},
+		],
+		pagination: { count: 1 },
+	};
+	// Real 2026-07-14 rollout arguments for a targeted fetch.
+	const ARGS_TARGETED = '{"boardId":18421599187,"itemIds":[12511130115],"includeItemDescription":true,"limit":1}';
+	const ARGS_BROWSE = '{"boardId":18421599187,"limit":25}';
+
+	it("PRIMARY path: function_call(arguments.itemIds) + function_call_output → monday reference", () => {
+		const lines = [
+			fnCall("mcp__codex_apps__monday_com", "_get_board_items_page", "c_mon", ARGS_TARGETED),
+			fnOutput("c_mon", MONDAY, { wrap: "bare", prefix: true }),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results.map((r) => r.def.id)).toEqual(["monday"]);
+		const p = results[0].payload as { items: Array<{ id: string; description?: string }> };
+		expect(p.items[0].id).toBe("12511130115");
+		expect(p.items[0].description).toBe("Use MCP to get monday task info.");
+		expect(results[0].toolName).toBe("mcp__claude_ai_monday_com__get_board_items_page");
+	});
+
+	it("FALLBACK path: mcp_tool_call_end still gates on the paired request's itemIds", () => {
+		const lines = [
+			fnCall("mcp__codex_apps__monday_com", "_get_board_items_page", "c_mon2", ARGS_TARGETED),
+			toolCallEnd("monday_com.get_board_items_page", "c_mon2", MONDAY),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results.map((r) => r.def.id)).toEqual(["monday"]);
+		expect((results[0].payload as { items: Array<{ id: string }> }).items[0].id).toBe("12511130115");
+	});
+
+	it("captures nothing for a board browse (arguments without itemIds), PRIMARY path", () => {
+		const lines = [
+			fnCall("mcp__codex_apps__monday_com", "_get_board_items_page", "c_mon3", ARGS_BROWSE),
+			fnOutput("c_mon3", MONDAY, { wrap: "bare", prefix: true }),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results.filter((r) => r.def.id === "monday")).toHaveLength(0);
+	});
+
+	it("captures nothing for a board browse (arguments without itemIds), FALLBACK path", () => {
+		const lines = [
+			fnCall("mcp__codex_apps__monday_com", "_get_board_items_page", "c_mon4", ARGS_BROWSE),
+			toolCallEnd("monday_com.get_board_items_page", "c_mon4", MONDAY),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results.filter((r) => r.def.id === "monday")).toHaveLength(0);
+	});
+
+	// exec/apps sandbox mode: the codex_apps connector routes the MCP call so that
+	// the rollout carries ONLY an mcp_tool_call_end event — no paired function_call
+	// row — with itemIds pre-parsed on `invocation.arguments`. Grounded on the real
+	// 2026-07-14 rollout event shape (invocation.arguments is an object, itemIds are
+	// numbers). Before the gate read the event's own arguments, this voided → the
+	// monday reference silently vanished from the sidebar.
+	it("FALLBACK exec/apps mode: mcp_tool_call_end alone (no function_call) gates on invocation.arguments.itemIds", () => {
+		const lines = [
+			toolCallEnd("monday_com.get_board_items_page", "c_exec", MONDAY, {
+				boardId: 18421599187,
+				itemIds: [12511130115],
+				limit: 1,
+			}),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results.map((r) => r.def.id)).toEqual(["monday"]);
+		expect((results[0].payload as { items: Array<{ id: string }> }).items[0].id).toBe("12511130115");
+	});
+
+	it("FALLBACK exec/apps mode: board browse event (invocation.arguments without itemIds) voids", () => {
+		const lines = [
+			toolCallEnd("monday_com.get_board_items_page", "c_exec2", MONDAY, { boardId: 18421599187, limit: 25 }),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results.filter((r) => r.def.id === "monday")).toHaveLength(0);
 	});
 });

--- a/cli/src/core/references/CodexEnvelopeParser.ts
+++ b/cli/src/core/references/CodexEnvelopeParser.ts
@@ -60,6 +60,9 @@ interface FunctionCallRow {
 	/** 0-based line index of the request — used to hold the cursor before an
 	 *  in-flight (output-not-yet-written) fetch call so the next poll re-reads it. */
 	readonly lineIndex: number;
+	/** Raw JSON-string `arguments` from the request, threaded to a gating
+	 *  normalizer (monday's `itemIds`); undefined when absent. */
+	readonly arguments?: string;
 }
 interface FunctionOutputRow {
 	readonly output: string;
@@ -70,6 +73,11 @@ interface ToolCallEndRow {
 	readonly callId: string | undefined;
 	readonly tool: string;
 	readonly text: string;
+	/** The event's own `invocation.arguments` (real codex_apps events carry the
+	 *  request pre-parsed as an object). In the exec/apps sandbox mode there is NO
+	 *  paired function_call row, so this is the ONLY place a gating normalizer can
+	 *  read itemIds; undefined when absent. */
+	readonly arguments?: unknown;
 	readonly lineNumber: number;
 	readonly referencedAt: string;
 }
@@ -160,7 +168,7 @@ class CodexEnvelopeParser implements TranscriptEnvelopeParser {
 						break;
 					}
 					if (callId !== undefined && namespace !== undefined && name !== undefined) {
-						calls.set(callId, { namespace, name, lineIndex: i });
+						calls.set(callId, { namespace, name, lineIndex: i, arguments: readString(payload.arguments) });
 					}
 					break;
 				}
@@ -184,7 +192,8 @@ class CodexEnvelopeParser implements TranscriptEnvelopeParser {
 					const tool = readInvocationTool(payload.invocation);
 					const text = readToolCallEndText(payload.result);
 					if (tool !== undefined && text !== undefined) {
-						events.push({ callId, tool, text, lineNumber: i + 1, referencedAt });
+						const args = readInvocationArguments(payload.invocation);
+						events.push({ callId, tool, text, arguments: args, lineNumber: i + 1, referencedAt });
 					}
 					break;
 				}
@@ -208,14 +217,20 @@ class CodexEnvelopeParser implements TranscriptEnvelopeParser {
 			/* v8 ignore start -- every registry codex definition has a matching CodexBinding; guarded for totality. */
 			if (normalizer === undefined) continue;
 			/* v8 ignore stop */
+			emitted.add(callId);
+			// A gating normalizer (monday's itemIds gate) returns null to void — skip
+			// it rather than push a null payload, mirroring the Claude envelope's
+			// context-normalizer null handling. The call is still marked emitted so
+			// the FALLBACK never re-processes it.
+			const payload = normalizer.normalize(business, parseArguments(call.arguments));
+			if (payload === null) continue;
 			results.push({
 				def,
 				toolName: normalizer.canonicalToolName,
-				payload: normalizer.normalize(business),
+				payload,
 				lineNumber: out.lineNumber,
 				referencedAt: out.referencedAt,
 			});
-			emitted.add(callId);
 		}
 
 		// PRIMARY (CLI): shell_command + function_call_output pairs. Gated on
@@ -265,10 +280,23 @@ class CodexEnvelopeParser implements TranscriptEnvelopeParser {
 					if (stitched !== null) business = stitched;
 				}
 			}
+			// Gating normalizers (monday) read the call's `arguments` to tell a
+			// targeted `itemIds` fetch from a 500-item board browse. Prefer the event's
+			// OWN `invocation.arguments`: in the codex_apps exec/apps sandbox mode the
+			// rollout carries ONLY this event — there is NO paired function_call row —
+			// so reading solely from `calls` there yielded undefined, failed the gate
+			// CLOSED, and silently dropped every exec-mode monday reference. Fall back to
+			// the paired request's arguments for older events that lack their own (and
+			// when the request landed but its output failed to parse). Still fails closed
+			// when NEITHER is present — dropping is safer than flooding a whole board.
+			const toolInput =
+				ev.arguments ?? (ev.callId !== undefined ? parseArguments(calls.get(ev.callId)?.arguments) : undefined);
+			const payload = normalizer.normalize(business, toolInput);
+			if (payload === null) continue;
 			results.push({
 				def,
 				toolName: normalizer.canonicalToolName,
-				payload: normalizer.normalize(business),
+				payload,
 				lineNumber: ev.lineNumber,
 				referencedAt: ev.referencedAt,
 			});
@@ -360,6 +388,13 @@ function parseFunctionCallOutput(output: string): unknown {
 	return unwrapTextEnvelope(parsed);
 }
 
+/** Parse a function_call's JSON-string `arguments` to an object, or undefined. */
+function parseArguments(args: string | undefined): unknown {
+	if (args === undefined) return undefined;
+	const parsed = tryParse(args);
+	return parsed === null ? undefined : parsed;
+}
+
 /** Parse the `command` field from a shell `function_call`'s JSON-string `arguments`. */
 function readShellCommand(args: unknown): string | undefined {
 	if (typeof args !== "string") return undefined;
@@ -419,6 +454,19 @@ function readString(v: unknown): string | undefined {
 function readInvocationTool(invocation: unknown): string | undefined {
 	if (!isObject(invocation)) return undefined;
 	return readString(invocation.tool);
+}
+
+/**
+ * The `invocation.arguments` an `mcp_tool_call_end` event carries — the request
+ * object a gating normalizer (monday's `itemIds`) reads. Real codex_apps events
+ * carry it pre-parsed as an object; a JSON-string variant is parsed too (that is
+ * how the sibling `function_call` serializes its `arguments`), so both shapes
+ * yield the same object downstream. Returns undefined when absent/unparsable.
+ */
+function readInvocationArguments(invocation: unknown): unknown {
+	if (!isObject(invocation)) return undefined;
+	const args = invocation.arguments;
+	return typeof args === "string" ? parseArguments(args) : args;
 }
 
 /** Extract `result.Ok.content[0].text` (the business JSON string) defensively. */

--- a/cli/src/core/references/SourceDefinitionRegistry.test.ts
+++ b/cli/src/core/references/SourceDefinitionRegistry.test.ts
@@ -43,12 +43,23 @@ describe("SourceDefinitionRegistry", () => {
 		expect(r.match("codex", "linear.get_issue")?.id).toBe("linear"); // invocation-tool path (no namespace)
 	});
 
-	it("all() is stable order linear,confluence,jira,github,notion,slack,zoom-meeting,zoom-doc,asana", () => {
+	it("all() is stable order linear,confluence,jira,github,notion,slack,zoom-meeting,zoom-doc,asana,monday", () => {
 		expect(
 			getRegistry()
 				.all()
 				.map((d) => d.id),
-		).toEqual(["linear", "confluence", "jira", "github", "notion", "slack", "zoom-meeting", "zoom-doc", "asana"]);
+		).toEqual([
+			"linear",
+			"confluence",
+			"jira",
+			"github",
+			"notion",
+			"slack",
+			"zoom-meeting",
+			"zoom-doc",
+			"asana",
+			"monday",
+		]);
 	});
 
 	it("routes getConfluencePage to confluence and getJiraIssue to jira", () => {
@@ -361,6 +372,24 @@ describe("SourceDefinitionRegistry", () => {
 			expect(r.match("codex", "_get_my_tasks", "asana")).toBeUndefined();
 			expect(r.match("codex", "_search_tasks", "asana")).toBeUndefined();
 			expect(r.match("codex", "asana_get_task")).toBeUndefined(); // underscore, not the real dotted tool
+		});
+	});
+
+	describe("monday registration", () => {
+		it("resolves the Claude item-fetch tool", () => {
+			expect(getRegistry().match("claude", "mcp__claude_ai_monday_com__get_board_items_page")?.id).toBe("monday");
+		});
+		it("resolves both Codex match paths", () => {
+			const r = getRegistry();
+			expect(r.match("codex", "_get_board_items_page", "monday_com")?.id).toBe("monday"); // function_call path
+			expect(r.match("codex", "monday_com.get_board_items_page")?.id).toBe("monday"); // invocation-tool path
+		});
+		it("does NOT match monday write/enumeration/other tools", () => {
+			const r = getRegistry();
+			expect(r.match("claude", "mcp__claude_ai_monday_com__create_item")).toBeUndefined();
+			expect(r.match("claude", "mcp__claude_ai_monday_com__get_board_info")).toBeUndefined();
+			expect(r.match("claude", "mcp__claude_ai_monday_com__get_updates")).toBeUndefined();
+			expect(r.match("codex", "_get_board_info", "monday_com")).toBeUndefined();
 		});
 	});
 });

--- a/cli/src/core/references/bindings/claude/index.test.ts
+++ b/cli/src/core/references/bindings/claude/index.test.ts
@@ -5,7 +5,7 @@ describe("Claude producer binding", () => {
 	describe("CLAUDE_TOOL_PREFIXES", () => {
 		it("lists every vendor prefix for the envelope pre-filter, de-duplicated (both Linear prefixes included; Zoom prefix appears once even though zoom-meeting and zoom-doc both declare it)", () => {
 			// Order follows BUILTIN_DEFINITIONS (linear, jira, github, notion, slack,
-			// zoom-meeting, zoom-doc, asana) — derived from the SourceDefinitionRegistry.
+			// zoom-meeting, zoom-doc, asana, monday) — derived from the SourceDefinitionRegistry.
 			// zoom-meeting and zoom-doc share the same Claude MCP prefix, so
 			// CLAUDE_TOOL_PREFIXES de-dupes via a Set; the shared prefix still
 			// appears exactly once here. Order is not semantically significant
@@ -21,6 +21,7 @@ describe("Claude producer binding", () => {
 				"mcp__claude_ai_Slack__",
 				"mcp__claude_ai_Zoom_for_Claude__",
 				"mcp__claude_ai_Asana__",
+				"mcp__claude_ai_monday_com__",
 			]);
 		});
 	});

--- a/cli/src/core/references/bindings/codex/CodexBinding.ts
+++ b/cli/src/core/references/bindings/codex/CodexBinding.ts
@@ -29,10 +29,13 @@ export interface CodexNormalizer {
 	readonly canonicalToolName: string;
 	/**
 	 * Normalize the connector business payload — a single entity OR a search/list
-	 * collection — into the shape the shared definition reads. Implementations use
-	 * {@link normalizeEntities} so both shapes are handled uniformly.
+	 * collection — into the shape the shared definition reads. `toolInput` is the
+	 * parsed `function_call` `arguments` (undefined when absent); only sources that
+	 * gate on their input read it (monday's `itemIds`). Every other binding ignores
+	 * it. Implementations use {@link normalizeEntities} so both shapes are handled
+	 * uniformly.
 	 */
-	normalize(business: unknown): unknown;
+	normalize(business: unknown, toolInput?: unknown): unknown;
 
 	/**
 	 * OPTIONAL recovery — **not** the main path. The normal path is: parse the

--- a/cli/src/core/references/bindings/codex/CodexMondayBinding.ts
+++ b/cli/src/core/references/bindings/codex/CodexMondayBinding.ts
@@ -1,0 +1,20 @@
+/**
+ * CodexMondayBinding — monday.com `codex_apps` connector normalizer.
+ *
+ * Reached through `_get_board_items_page` (namespace `mcp__codex_apps__monday_com`)
+ * or the `monday_com.get_board_items_page` invocation — match identity lives in
+ * `mondayDefinition.match.codex`. The connector's `function_call_output` unwraps to
+ * the SAME `{ board, items, pagination }` payload as the Claude monday MCP, so this
+ * binding shares `normalizeMonday` with the Claude path. It reads the `itemIds` gate
+ * from the request `arguments` (threaded by CodexEnvelopeParser) — a Codex board
+ * browse with no `itemIds` voids, exactly like the Claude side.
+ */
+
+import { normalizeMonday, readItemIds } from "../../sources/MondayNormalize.js";
+import type { CodexNormalizer } from "./CodexBinding.js";
+
+export const mondayCodexBinding: CodexNormalizer = {
+	id: "monday",
+	canonicalToolName: "mcp__claude_ai_monday_com__get_board_items_page",
+	normalize: (business, toolInput) => normalizeMonday(business, { itemIds: readItemIds(toolInput) }),
+};

--- a/cli/src/core/references/bindings/codex/index.test.ts
+++ b/cli/src/core/references/bindings/codex/index.test.ts
@@ -15,6 +15,9 @@ describe("Codex producer normalizer registry", () => {
 				"mcp__claude_ai_Atlassian__getConfluencePage",
 			);
 			expect(getCodexNormalizer("asana")?.canonicalToolName).toBe("mcp__claude_ai_Asana__get_task");
+			expect(getCodexNormalizer("monday")?.canonicalToolName).toBe(
+				"mcp__claude_ai_monday_com__get_board_items_page",
+			);
 		});
 
 		it("returns undefined for an id with no registered normalizer", () => {
@@ -48,6 +51,34 @@ describe("Codex producer normalizer registry", () => {
 			expect(out.pageId).toBe("131076");
 			expect(out.title).toBe("P");
 			expect(out.url).toBe("https://x.atlassian.net/wiki/p/131076");
+		});
+
+		it("monday normalizer gates on itemIds from the threaded tool input", () => {
+			const business = {
+				board: { name: "Tasks" },
+				items: [
+					{
+						id: "9",
+						name: "T",
+						url: "https://x.monday.com/boards/1/pulses/9",
+						created_at: "t",
+						updated_at: "t",
+					},
+				],
+			};
+			const out = getCodexNormalizer("monday")?.normalize(business, { itemIds: [9] }) as {
+				items: Array<Record<string, unknown>>;
+			};
+			expect(out.items[0]).toEqual({
+				id: "9",
+				name: "T",
+				url: "https://x.monday.com/boards/1/pulses/9",
+				board: "Tasks",
+			});
+		});
+
+		it("monday normalizer voids (null) a board browse with no itemIds", () => {
+			expect(getCodexNormalizer("monday")?.normalize({ items: [] }, {})).toBeNull();
 		});
 	});
 });

--- a/cli/src/core/references/bindings/codex/index.ts
+++ b/cli/src/core/references/bindings/codex/index.ts
@@ -16,6 +16,7 @@ import { confluenceCodexBinding } from "./CodexConfluenceBinding.js";
 import { githubCodexBinding } from "./CodexGitHubBinding.js";
 import { jiraCodexBinding } from "./CodexJiraBinding.js";
 import { linearCodexBinding } from "./CodexLinearBinding.js";
+import { mondayCodexBinding } from "./CodexMondayBinding.js";
 import { notionCodexBinding } from "./CodexNotionBinding.js";
 import { zoomMeetingCodexBinding } from "./CodexZoomMeetingBinding.js";
 
@@ -30,6 +31,7 @@ const CODEX_NORMALIZERS: readonly CodexNormalizer[] = [
 	zoomMeetingCodexBinding,
 	confluenceCodexBinding,
 	asanaCodexBinding,
+	mondayCodexBinding,
 ];
 
 const BY_ID: ReadonlyMap<SourceId, CodexNormalizer> = new Map(CODEX_NORMALIZERS.map((n) => [n.id, n]));

--- a/cli/src/core/references/sources/MondayNormalize.test.ts
+++ b/cli/src/core/references/sources/MondayNormalize.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import { normalizeMonday, readItemIds } from "./MondayNormalize.js";
+
+const ITEM_A = {
+	id: "12511130115",
+	name: "Add monday MCP integration",
+	url: "https://jolli-squad.monday.com/boards/18421599187/pulses/12511130115",
+	created_at: "2026-07-12T11:05:25Z",
+	updated_at: "2026-07-14T08:30:22Z",
+	column_values: { task_status: "In Progress" },
+	item_description: {
+		id: "44442382",
+		blocks: [
+			{
+				id: "c5d5",
+				type: "normal text",
+				content:
+					'{"direction":"ltr","deltaFormat":[{"insert":"Use MCP to get monday task info in Agents (Claude Code, Codex, etc), Jolli Memory will capture the context in sessions, and show as context reference in working memory."}]}',
+			},
+		],
+	},
+};
+const PAYLOAD_A = { board: { id: "18421599187", name: "Tasks" }, items: [ITEM_A], pagination: { count: 1 } };
+
+const ITEM_B_NO_DESC = {
+	id: "12526313713",
+	name: "Claude Code Support",
+	url: "https://jolli-squad.monday.com/boards/18421888353/pulses/12526313713",
+	created_at: "2026-07-14T09:15:22Z",
+	updated_at: "2026-07-14T09:15:22Z",
+	column_values: { person: null },
+};
+const PAYLOAD_B = { board: { id: "18421888353", name: "Subitems of Tasks" }, items: [ITEM_B_NO_DESC] };
+
+describe("readItemIds", () => {
+	it("returns the numeric ids when present", () => {
+		expect(readItemIds({ boardId: 1, itemIds: [12511130115] })).toEqual([12511130115]);
+	});
+	it("returns undefined when itemIds is absent (board browse)", () => {
+		expect(readItemIds({ boardId: 1 })).toBeUndefined();
+	});
+	it("returns undefined for an empty itemIds array", () => {
+		expect(readItemIds({ itemIds: [] })).toBeUndefined();
+	});
+	it("accepts numeric-string ids (monday serializes large ids as strings)", () => {
+		expect(readItemIds({ itemIds: ["12511130115"] })).toEqual([12511130115]);
+		expect(readItemIds({ itemIds: [12511130115, "12526313713"] })).toEqual([12511130115, 12526313713]);
+	});
+	it("ignores non-numeric-string entries but keeps a valid one", () => {
+		expect(readItemIds({ itemIds: ["abc"] })).toBeUndefined();
+		expect(readItemIds({ itemIds: ["abc", "9"] })).toEqual([9]);
+	});
+	it("returns undefined for a non-object input", () => {
+		expect(readItemIds(undefined)).toBeUndefined();
+		expect(readItemIds("nope")).toBeUndefined();
+	});
+});
+
+describe("normalizeMonday", () => {
+	it("voids (null) when itemIds is undefined — a board browse produces no reference", () => {
+		expect(normalizeMonday(PAYLOAD_A, { itemIds: undefined })).toBeNull();
+	});
+	it("voids (null) when itemIds is empty", () => {
+		expect(normalizeMonday(PAYLOAD_A, { itemIds: [] })).toBeNull();
+	});
+	it("voids (null) for a non-object payload", () => {
+		expect(normalizeMonday("nope", { itemIds: [1] })).toBeNull();
+	});
+	it("flattens a targeted item with its delta-format description + board name", () => {
+		const out = normalizeMonday(PAYLOAD_A, { itemIds: [12511130115] });
+		expect(out).toEqual({
+			items: [
+				{
+					id: "12511130115",
+					name: "Add monday MCP integration",
+					url: "https://jolli-squad.monday.com/boards/18421599187/pulses/12511130115",
+					board: "Tasks",
+					description:
+						"Use MCP to get monday task info in Agents (Claude Code, Codex, etc), Jolli Memory will capture the context in sessions, and show as context reference in working memory.",
+				},
+			],
+		});
+	});
+	it("omits description when item_description is absent (subitem)", () => {
+		const out = normalizeMonday(PAYLOAD_B, { itemIds: [12526313713] });
+		expect(out?.items[0]).toEqual({
+			id: "12526313713",
+			name: "Claude Code Support",
+			url: "https://jolli-squad.monday.com/boards/18421888353/pulses/12526313713",
+			board: "Subitems of Tasks",
+		});
+	});
+	it("concatenates multiple blocks and multiple inserts", () => {
+		const multi = {
+			items: [
+				{
+					id: "9",
+					name: "Multi",
+					url: "https://x.monday.com/boards/1/pulses/9",
+					created_at: "t",
+					updated_at: "t",
+					item_description: {
+						blocks: [
+							{ content: '{"deltaFormat":[{"insert":"Line one "},{"insert":"still one"}]}' },
+							{ content: '{"deltaFormat":[{"insert":"Line two"}]}' },
+						],
+					},
+				},
+			],
+		};
+		expect(normalizeMonday(multi, { itemIds: [9] })?.items[0].description).toBe("Line one still one\nLine two");
+	});
+	it("keeps a non-JSON block as plain text and concatenates the deltaFormat block", () => {
+		const bad = {
+			items: [
+				{
+					id: "9",
+					name: "Bad",
+					url: "https://x.monday.com/boards/1/pulses/9",
+					created_at: "t",
+					updated_at: "t",
+					item_description: {
+						blocks: [{ content: "plain text line" }, { content: '{"deltaFormat":[{"insert":"ok"}]}' }],
+					},
+				},
+			],
+		};
+		expect(normalizeMonday(bad, { itemIds: [9] })?.items[0].description).toBe("plain text line\nok");
+	});
+	it("skips a JSON-shaped but malformed/deltaFormat-less block without throwing", () => {
+		const bad = {
+			items: [
+				{
+					id: "9",
+					name: "Bad",
+					url: "https://x.monday.com/boards/1/pulses/9",
+					created_at: "t",
+					updated_at: "t",
+					item_description: {
+						// first: truncated JSON blob (JSON-shaped, unparseable); second: valid JSON, no deltaFormat.
+						blocks: [{ content: '{"deltaFormat":[{"insert":' }, { content: '{"other":1}' }],
+					},
+				},
+			],
+		};
+		expect(normalizeMonday(bad, { itemIds: [9] })?.items[0].description).toBeUndefined();
+	});
+	it("drops an item missing id/name/url", () => {
+		const p = { board: { name: "B" }, items: [{ id: "1", name: "no-url" }] };
+		expect(normalizeMonday(p, { itemIds: [1] })).toEqual({ items: [] });
+	});
+	it("omits board when the board name is absent", () => {
+		const p = { items: [ITEM_B_NO_DESC] };
+		expect(normalizeMonday(p, { itemIds: [1] })?.items[0].board).toBeUndefined();
+	});
+});

--- a/cli/src/core/references/sources/MondayNormalize.ts
+++ b/cli/src/core/references/sources/MondayNormalize.ts
@@ -1,0 +1,125 @@
+/**
+ * MondayNormalize — canonical-shape builder for the monday.com item source.
+ *
+ * monday has no single-item getter: `get_board_items_page` serves BOTH a
+ * targeted `itemIds` fetch AND a whole-board browse (up to 500 items). Tool-name
+ * matching cannot tell them apart, so the reference gate is on the tool INPUT — a
+ * reference is produced ONLY when the call carried a non-empty `itemIds` (a
+ * targeted lookup); a board browse yields null. This mirrors Slack/zoom-doc
+ * reading tool_use input.
+ *
+ * It also flattens the item body: `item_description.blocks[].content` is a JSON
+ * string holding a Quill `deltaFormat`, which the DSL's dotted `readPath` (no
+ * array indexing, no embedded-JSON parse) cannot express — the same reason
+ * Confluence's ADF flattening lives in a normalizer.
+ *
+ * The `mondayDefinition` is pure `path` DSL over this function's `{ items: [...] }`
+ * output. Used by BOTH hosts: the Claude envelope's CONTEXT_NORMALIZERS entry and
+ * the Codex `mondayCodexBinding`, each passing the itemIds read from its host's
+ * own tool input.
+ */
+
+import { isObject } from "../guards.js";
+
+/** Flattened, host-agnostic monday item the `mondayDefinition` reads via `path`. */
+export interface MondayItem {
+	readonly id: string;
+	readonly name: string;
+	readonly url: string;
+	readonly board?: string;
+	readonly description?: string;
+}
+
+function readString(v: unknown): string | undefined {
+	return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+/**
+ * The `itemIds` a `get_board_items_page` call carried, or undefined when absent /
+ * empty / malformed — the gate then voids (a board browse has no `itemIds`). Only
+ * presence matters downstream; the values are not cross-referenced.
+ *
+ * monday item ids are large integers that this ecosystem serializes both ways —
+ * the tool_result body carries them as strings (`id: "12511130115"`) even though
+ * the request schema takes numbers — so a numeric string in `itemIds` is accepted
+ * too, otherwise a real targeted fetch would silently produce no reference. The
+ * coerced value is never used beyond presence, so >2^53 precision loss is moot.
+ */
+export function readItemIds(toolInput: unknown): readonly number[] | undefined {
+	if (!isObject(toolInput)) return undefined;
+	const ids = toolInput.itemIds;
+	if (!Array.isArray(ids)) return undefined;
+	const nums = ids
+		.map((x) => (typeof x === "number" ? x : typeof x === "string" && /^\d+$/.test(x) ? Number(x) : undefined))
+		.filter((x): x is number => x !== undefined);
+	return nums.length > 0 ? nums : undefined;
+}
+
+/**
+ * Flatten a monday `item_description` into plain text. Each block's `content` is a
+ * JSON string `{"deltaFormat":[{"insert":"…"}]}`; concat every `insert` across all
+ * blocks, blocks joined by "\n". Returns undefined when absent or empty.
+ *
+ * A block whose `content` is not JSON-shaped (does not start with `{`/`[`) is
+ * treated as plain text and kept verbatim, so a non-deltaFormat body is preserved
+ * rather than dropped. Content that IS JSON-shaped but fails to parse (e.g. a
+ * truncated blob) or parses without a `deltaFormat` array is skipped — never
+ * surfacing broken JSON as text, and never throwing.
+ */
+function flattenDescription(itemDescription: unknown): string | undefined {
+	if (!isObject(itemDescription)) return undefined;
+	const blocks = itemDescription.blocks;
+	if (!Array.isArray(blocks)) return undefined;
+	const lines: string[] = [];
+	for (const block of blocks) {
+		if (!isObject(block) || typeof block.content !== "string") continue;
+		const trimmed = block.content.trim();
+		if (trimmed.length === 0) continue;
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(block.content);
+		} catch {
+			// Not deltaFormat JSON. Keep genuine plain text; skip a malformed
+			// JSON-shaped blob so we never emit broken JSON as a description.
+			if (trimmed[0] !== "{" && trimmed[0] !== "[") lines.push(trimmed);
+			continue;
+		}
+		if (!isObject(parsed) || !Array.isArray(parsed.deltaFormat)) continue;
+		const text = parsed.deltaFormat
+			.map((seg) => (isObject(seg) && typeof seg.insert === "string" ? seg.insert : ""))
+			.join("");
+		if (text.length > 0) lines.push(text);
+	}
+	return lines.length > 0 ? lines.join("\n") : undefined;
+}
+
+/**
+ * Build the `{ items }` wrapper the `mondayDefinition` reads, or null to void the
+ * whole result. Gates on `itemIds`; flattens each item's description.
+ */
+export function normalizeMonday(
+	payload: unknown,
+	ctx: { readonly itemIds: readonly number[] | undefined },
+): { items: MondayItem[] } | null {
+	if (ctx.itemIds === undefined || ctx.itemIds.length === 0) return null;
+	if (!isObject(payload)) return null;
+	const board = isObject(payload.board) ? readString(payload.board.name) : undefined;
+	const rawItems = Array.isArray(payload.items) ? payload.items : [];
+	const items: MondayItem[] = [];
+	for (const raw of rawItems) {
+		if (!isObject(raw)) continue;
+		const id = readString(raw.id);
+		const name = readString(raw.name);
+		const url = readString(raw.url);
+		if (id === undefined || name === undefined || url === undefined) continue;
+		const description = flattenDescription(raw.item_description);
+		items.push({
+			id,
+			name,
+			url,
+			...(board !== undefined ? { board } : {}),
+			...(description !== undefined ? { description } : {}),
+		});
+	}
+	return { items };
+}

--- a/cli/src/core/references/sources/definitions/index.ts
+++ b/cli/src/core/references/sources/definitions/index.ts
@@ -18,6 +18,7 @@ import { confluenceDefinition } from "./confluence.js";
 import { githubDefinition } from "./github.js";
 import { jiraDefinition } from "./jira.js";
 import { linearDefinition } from "./linear.js";
+import { mondayDefinition } from "./monday.js";
 import { notionDefinition } from "./notion.js";
 import { slackDefinition } from "./slack.js";
 import { zoomDocDefinition } from "./zoom-doc.js";
@@ -33,4 +34,5 @@ export const BUILTIN_DEFINITIONS = [
 	zoomMeetingDefinition,
 	zoomDocDefinition,
 	asanaDefinition,
+	mondayDefinition,
 ] as const;

--- a/cli/src/core/references/sources/definitions/monday.test.ts
+++ b/cli/src/core/references/sources/definitions/monday.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { extractRef, renderBlock } from "../../SourceEngine.js";
+import { mondayDefinition as def } from "./monday.js";
+
+// The definition runs over ONE normalized item (after wrapperKeys:["items"] unwrap).
+const ITEM = {
+	id: "12511130115",
+	name: "Add monday MCP integration",
+	url: "https://jolli-squad.monday.com/boards/18421599187/pulses/12511130115",
+	board: "Tasks",
+	description: "Use MCP to get monday task info in Agents.",
+};
+const TOOL = "mcp__claude_ai_monday_com__get_board_items_page";
+const AT = "2026-07-14T00:00:00Z";
+
+describe("monday definition", () => {
+	it("extracts a Reference from a normalized item", () => {
+		const ref = extractRef(def, ITEM, TOOL, AT);
+		expect(ref?.source).toBe("monday");
+		expect(ref?.nativeId).toBe("12511130115");
+		expect(ref?.title).toBe("Add monday MCP integration");
+		expect(ref?.url).toBe(ITEM.url);
+		expect(ref?.description).toBe("Use MCP to get monday task info in Agents.");
+		expect(ref?.fields).toEqual([
+			{ key: "entity-type", label: "Type", icon: "symbol-class", value: "item" },
+			{ key: "board", label: "Board", icon: "project", value: "Tasks" },
+		]);
+	});
+	it("drops the description when absent (subitem)", () => {
+		const { description: _description, ...noDesc } = ITEM;
+		const ref = extractRef(def, noDesc, TOOL, AT);
+		expect(ref?.description).toBeUndefined();
+	});
+	it("drops the board field when the board name is absent", () => {
+		const { board: _board, ...noBoard } = ITEM;
+		const ref = extractRef(def, noBoard, TOOL, AT);
+		expect(ref?.fields).toEqual([{ key: "entity-type", label: "Type", icon: "symbol-class", value: "item" }]);
+	});
+	it("voids when id (nativeId) is missing", () => {
+		expect(extractRef(def, { ...ITEM, id: undefined }, TOOL, AT)).toBeNull();
+	});
+	it("voids when the url is not a monday host", () => {
+		expect(extractRef(def, { ...ITEM, url: "https://evil.example/x" }, TOOL, AT)).toBeNull();
+	});
+	it("accepts a mixed-case monday host (URL hosts are case-insensitive)", () => {
+		const url = "https://Jolli-Squad.Monday.com/boards/1/pulses/9";
+		expect(extractRef(def, { ...ITEM, url }, TOOL, AT)?.url).toBe(url);
+	});
+	it("accepts a multi-label monday sub-domain", () => {
+		const url = "https://a.b.monday.com/boards/1/pulses/9";
+		expect(extractRef(def, { ...ITEM, url }, TOOL, AT)?.url).toBe(url);
+	});
+	it("still rejects a look-alike host that only ends in monday.com", () => {
+		expect(extractRef(def, { ...ITEM, url: "https://x.monday.com.evil.example/x" }, TOOL, AT)).toBeNull();
+		expect(extractRef(def, { ...ITEM, url: "https://evilmonday.com/x" }, TOOL, AT)).toBeNull();
+	});
+	it("renders a <monday-items> block", () => {
+		const ref = extractRef(def, ITEM, TOOL, AT);
+		if (ref === null) throw new Error("expected ref");
+		const block = renderBlock(def, [ref]);
+		expect(block).toContain("<monday-items>");
+		expect(block).toContain("<item ");
+		expect(block).toContain("<description>");
+	});
+});

--- a/cli/src/core/references/sources/definitions/monday.ts
+++ b/cli/src/core/references/sources/definitions/monday.ts
@@ -1,0 +1,60 @@
+/**
+ * monday.com built-in source — pure `path` DSL over the MondayNormalize
+ * canonical shape ({ id, name, url, created_at, updated_at, board?, description? }).
+ *
+ * The messy work — the itemIds anti-flood gate and the delta-format body flatten
+ * — lives in `sources/MondayNormalize.normalizeMonday`, wired into BOTH envelope
+ * parsers (Claude via CONTEXT_NORMALIZERS, Codex via CodexMondayBinding). This
+ * definition only selects fields, exactly like zoom-doc.
+ *
+ * `match.claude` allows only `get_board_items_page` (the item fetch); every
+ * write/enumeration/doc/dashboard tool is excluded by the allowlist. `match.codex`
+ * targets the `codex_apps__monday_com` connector (function_call `_get_board_items_page`,
+ * invocation `monday_com.get_board_items_page`) — both transcribed from a real
+ * 2026-07-14 rollout, not guessed.
+ *
+ * `column_values` are deliberately NOT surfaced as fields: their keys are
+ * board-defined and vary per board (Tasks uses `task_status`; the Subitems board
+ * uses `person`/`status`/`date0`), so only stable top-level fields are used.
+ */
+
+import type { SourceDefinition } from "../../SourceDefinition.js";
+
+export const mondayDefinition: SourceDefinition = {
+	id: "monday",
+	label: "monday.com",
+	icon: "table",
+	match: {
+		claude: { prefixes: ["mcp__claude_ai_monday_com__"], acceptSuffix: "get_board_items_page" },
+		codex: {
+			namespaceSuffix: "monday_com",
+			functionCallNames: ["_get_board_items_page"],
+			invocationTools: ["monday_com.get_board_items_page"],
+		},
+	},
+	wrapperKeys: ["items"],
+	reference: {
+		nativeId: { pipe: [{ op: "path", path: "id" }], require: "^\\d+$" },
+		title: { pipe: [{ op: "path", path: "name" }], require: ".+" },
+		url: {
+			pipe: [{ op: "path", path: "url" }],
+			// Host must be monday.com or a sub-domain of it (one or more labels),
+			// anchored so a spoofed `url` field can't point the reference elsewhere.
+			require: "^https://([\\w-]+\\.)*monday\\.com/",
+			requireFlags: "i",
+		},
+		description: { pipe: [{ op: "path", path: "description" }], optional: true },
+	},
+	fields: [
+		{ key: "entity-type", label: "Type", icon: "symbol-class", pipe: [{ op: "const", value: "item" }] },
+		{ key: "board", label: "Board", icon: "project", pipe: [{ op: "path", path: "board" }] },
+	],
+	storage: { nativeIdPathSafe: true },
+	render: {
+		wrapperTag: "monday-items",
+		itemTag: "item",
+		bodyTag: "description",
+		maxCharsPerReference: 4000,
+		maxTotalChars: 30000,
+	},
+};

--- a/docs/superpowers/plans/2026-07-14-monday-reference-source.md
+++ b/docs/superpowers/plans/2026-07-14-monday-reference-source.md
@@ -1,0 +1,925 @@
+# monday.com Reference Source Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture a referenced monday.com item (title, description, URL) as a Jolli reference whenever a Claude Code or Codex session fetches it by id via `get_board_items_page`.
+
+**Architecture:** monday joins the *context-normalizer tier* (like Slack / zoom-doc / Confluence): a small `normalizeMonday(payload, { itemIds })` (a) gates on the tool input — a reference is produced ONLY for a targeted `itemIds` fetch, never a board browse — and (b) flattens the item's `deltaFormat` body into plain text. A pure-DSL `mondayDefinition` reads its `{ items: [...] }` output. Claude threads `itemIds` from the tool_use input (existing machinery); the Codex envelope parser is extended to thread the `function_call` `arguments` to the normalizer.
+
+**Tech Stack:** TypeScript (ESM), Vitest, Biome. Data-only `SourceDefinition` DSL evaluated by `SourceEngine`.
+
+## Global Constraints
+
+Copied verbatim from repo `CLAUDE.md` — every task's requirements include these:
+
+- **`npm run all` must pass before commit** (clean → build → lint → test). This is the gate — NOT `typecheck` (the repo carries a known typecheck baseline debt in existing test fixtures; ignore it — only ensure new code is error-free under build/lint/test).
+- **CLI coverage floor** (`cli/vite.config.ts`): 97% statements / 96% branches / 97% functions / 97% lines. New CLI code must be fully exercised by tests. Where a defensive branch is genuinely unreachable, exempt it with a `/* v8 ignore start */` … `/* v8 ignore stop */` block — the single-line `/* v8 ignore next */` form does NOT work in this repo.
+- **DCO sign-off on the commit** — `git commit -s`. **No `Co-Authored-By: Claude …` trailer, no `🤖 Generated with …` footer.** Human-authored message; only `Signed-off-by:` belongs there.
+- **Use `toForwardSlash` for `\`→`/`** — not needed here (no path work), but never inline `path.replace(/\\/g,"/")`.
+- **Three-impl lockstep** (`parseJolliApiKey`) — not touched here.
+- **Tests use REAL fixtures.** Both monday payloads below were captured live from the real connector this session; the Codex `function_call_output` is byte-identical after prefix strip. Do NOT invent payload shapes.
+
+### Execution note (user workflow preference — overrides the skill's default cadence)
+
+Per standing user guidance: **do NOT run tests or commit per task.** Each task writes only test code + implementation code. `npm run all` and a **single** consolidated commit happen once, in the final task. Tasks may leave the tree in an intermediate (non-building) state between them; only the final state must be green.
+
+### The two real fixtures (referenced by several tasks)
+
+**Fixture A — Tasks item WITH description** (`saved: scratchpad/monday-real-payload.json`):
+
+```json
+{ "board": { "id": "18421599187", "name": "Tasks" },
+  "items": [ {
+    "id": "12511130115",
+    "name": "Add monday MCP integration",
+    "url": "https://jolli-squad.monday.com/boards/18421599187/pulses/12511130115",
+    "created_at": "2026-07-12T11:05:25Z",
+    "updated_at": "2026-07-14T08:30:22Z",
+    "column_values": { "task_status": "In Progress", "task_type": "Feature", "item_id": "TJOL-001" },
+    "item_description": { "id": "44442382", "blocks": [
+      { "id": "c5d5", "type": "normal text",
+        "content": "{\"direction\":\"ltr\",\"deltaFormat\":[{\"insert\":\"Use MCP to get monday task info in Agents (Claude Code, Codex, etc), Jolli Memory will capture the context in sessions, and show as context reference in working memory.\"}]}" } ] } } ],
+  "pagination": { "has_more": false, "nextCursor": null, "count": 1 } }
+```
+
+**Fixture B — Subitem, NO `item_description`** (`board 18421888353` / item `12526313713`):
+
+```json
+{ "board": { "id": "18421888353", "name": "Subitems of Tasks" },
+  "items": [ {
+    "id": "12526313713",
+    "name": "Claude Code Support",
+    "url": "https://jolli-squad.monday.com/boards/18421888353/pulses/12526313713",
+    "created_at": "2026-07-14T09:15:22Z",
+    "updated_at": "2026-07-14T09:15:22Z",
+    "column_values": { "person": null, "status": null, "date0": null } } ],
+  "pagination": { "has_more": false, "nextCursor": null, "count": 1 } }
+```
+
+**Codex rollout arguments** (`_get_board_items_page` request), used in Task 4:
+`{"boardId":18421599187,"itemIds":[12511130115],"includeColumns":true,"includeItemDescription":true,"includeSubItems":true,"subItemLimit":50,"limit":1}`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `cli/src/core/references/sources/MondayNormalize.ts` | **NEW** — `normalizeMonday` (itemIds gate + delta flatten) + `readItemIds`; the only non-data logic |
+| `cli/src/core/references/sources/definitions/monday.ts` | **NEW** — `mondayDefinition` (pure DSL over the normalized shape; both `match.claude` + `match.codex`) |
+| `cli/src/core/references/sources/definitions/index.ts` | Register `mondayDefinition` in `BUILTIN_DEFINITIONS` |
+| `cli/src/Types.ts` | `"monday"` in `KnownSourceId` |
+| `vscode/src/views/SourceLabels.ts` | `monday` row in `SOURCE_META` (TS-forced by `KnownSourceId`) |
+| `cli/src/core/references/ClaudeEnvelopeParser.ts` | `monday` entry in `CONTEXT_NORMALIZERS` |
+| `cli/src/core/references/bindings/codex/CodexBinding.ts` | `normalize(business, toolInput?)` — optional 2nd param on the interface |
+| `cli/src/core/references/CodexEnvelopeParser.ts` | Retain `arguments` on `FunctionCallRow`; thread parsed args to `normalize` in both emit loops |
+| `cli/src/core/references/bindings/codex/CodexMondayBinding.ts` | **NEW** — `mondayCodexBinding` |
+| `cli/src/core/references/bindings/codex/index.ts` | Register `mondayCodexBinding` in `CODEX_NORMALIZERS` |
+| `*.test.ts` (5 files) | Real-fixture tests per task |
+
+**Not touched (verified):** `CLAUDE_TOOL_PREFIXES` (auto-derived from registry), `SourceEngine.ts` / `SourceDefinition.ts` (no new DSL op), `referencesBySourceOrder` (both copies derive order from `getRegistry().all()`), `ReferenceExtractor.ts`.
+
+---
+
+## Task 1: `normalizeMonday` + `readItemIds`
+
+**Files:**
+- Create: `cli/src/core/references/sources/MondayNormalize.ts`
+- Test: `cli/src/core/references/sources/MondayNormalize.test.ts`
+
+**Interfaces:**
+- Consumes: `isObject` from `../guards.js`.
+- Produces:
+  - `interface MondayItem { readonly id: string; readonly name: string; readonly url: string; readonly created_at: string; readonly updated_at: string; readonly board?: string; readonly description?: string }`
+  - `function readItemIds(toolInput: unknown): readonly number[] | undefined`
+  - `function normalizeMonday(payload: unknown, ctx: { readonly itemIds: readonly number[] | undefined }): { items: MondayItem[] } | null`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// cli/src/core/references/sources/MondayNormalize.test.ts
+import { describe, expect, it } from "vitest";
+import { normalizeMonday, readItemIds } from "./MondayNormalize.js";
+
+const ITEM_A = {
+	id: "12511130115",
+	name: "Add monday MCP integration",
+	url: "https://jolli-squad.monday.com/boards/18421599187/pulses/12511130115",
+	created_at: "2026-07-12T11:05:25Z",
+	updated_at: "2026-07-14T08:30:22Z",
+	column_values: { task_status: "In Progress" },
+	item_description: {
+		id: "44442382",
+		blocks: [
+			{
+				id: "c5d5",
+				type: "normal text",
+				content:
+					'{"direction":"ltr","deltaFormat":[{"insert":"Use MCP to get monday task info in Agents (Claude Code, Codex, etc), Jolli Memory will capture the context in sessions, and show as context reference in working memory."}]}',
+			},
+		],
+	},
+};
+const PAYLOAD_A = { board: { id: "18421599187", name: "Tasks" }, items: [ITEM_A], pagination: { count: 1 } };
+
+const ITEM_B_NO_DESC = {
+	id: "12526313713",
+	name: "Claude Code Support",
+	url: "https://jolli-squad.monday.com/boards/18421888353/pulses/12526313713",
+	created_at: "2026-07-14T09:15:22Z",
+	updated_at: "2026-07-14T09:15:22Z",
+	column_values: { person: null },
+};
+const PAYLOAD_B = { board: { id: "18421888353", name: "Subitems of Tasks" }, items: [ITEM_B_NO_DESC] };
+
+describe("readItemIds", () => {
+	it("returns the numeric ids when present", () => {
+		expect(readItemIds({ boardId: 1, itemIds: [12511130115] })).toEqual([12511130115]);
+	});
+	it("returns undefined when itemIds is absent (board browse)", () => {
+		expect(readItemIds({ boardId: 1 })).toBeUndefined();
+	});
+	it("returns undefined for an empty itemIds array", () => {
+		expect(readItemIds({ itemIds: [] })).toBeUndefined();
+	});
+	it("returns undefined for a non-object input", () => {
+		expect(readItemIds(undefined)).toBeUndefined();
+		expect(readItemIds("nope")).toBeUndefined();
+	});
+});
+
+describe("normalizeMonday", () => {
+	it("voids (null) when itemIds is undefined — a board browse produces no reference", () => {
+		expect(normalizeMonday(PAYLOAD_A, { itemIds: undefined })).toBeNull();
+	});
+	it("voids (null) when itemIds is empty", () => {
+		expect(normalizeMonday(PAYLOAD_A, { itemIds: [] })).toBeNull();
+	});
+	it("voids (null) for a non-object payload", () => {
+		expect(normalizeMonday("nope", { itemIds: [1] })).toBeNull();
+	});
+	it("flattens a targeted item with its delta-format description + board name", () => {
+		const out = normalizeMonday(PAYLOAD_A, { itemIds: [12511130115] });
+		expect(out).toEqual({
+			items: [
+				{
+					id: "12511130115",
+					name: "Add monday MCP integration",
+					url: "https://jolli-squad.monday.com/boards/18421599187/pulses/12511130115",
+					created_at: "2026-07-12T11:05:25Z",
+					updated_at: "2026-07-14T08:30:22Z",
+					board: "Tasks",
+					description:
+						"Use MCP to get monday task info in Agents (Claude Code, Codex, etc), Jolli Memory will capture the context in sessions, and show as context reference in working memory.",
+				},
+			],
+		});
+	});
+	it("omits description when item_description is absent (subitem)", () => {
+		const out = normalizeMonday(PAYLOAD_B, { itemIds: [12526313713] });
+		expect(out?.items[0]).toEqual({
+			id: "12526313713",
+			name: "Claude Code Support",
+			url: "https://jolli-squad.monday.com/boards/18421888353/pulses/12526313713",
+			created_at: "2026-07-14T09:15:22Z",
+			updated_at: "2026-07-14T09:15:22Z",
+			board: "Subitems of Tasks",
+		});
+	});
+	it("concatenates multiple blocks and multiple inserts", () => {
+		const multi = {
+			items: [
+				{
+					id: "9",
+					name: "Multi",
+					url: "https://x.monday.com/boards/1/pulses/9",
+					created_at: "t",
+					updated_at: "t",
+					item_description: {
+						blocks: [
+							{ content: '{"deltaFormat":[{"insert":"Line one "},{"insert":"still one"}]}' },
+							{ content: '{"deltaFormat":[{"insert":"Line two"}]}' },
+						],
+					},
+				},
+			],
+		};
+		expect(normalizeMonday(multi, { itemIds: [9] })?.items[0].description).toBe("Line one still one\nLine two");
+	});
+	it("skips a block whose content is not valid JSON without throwing", () => {
+		const bad = {
+			items: [
+				{
+					id: "9",
+					name: "Bad",
+					url: "https://x.monday.com/boards/1/pulses/9",
+					created_at: "t",
+					updated_at: "t",
+					item_description: { blocks: [{ content: "not json" }, { content: '{"deltaFormat":[{"insert":"ok"}]}' }] },
+				},
+			],
+		};
+		expect(normalizeMonday(bad, { itemIds: [9] })?.items[0].description).toBe("ok");
+	});
+	it("drops an item missing id/name/url", () => {
+		const p = { board: { name: "B" }, items: [{ id: "1", name: "no-url" }] };
+		expect(normalizeMonday(p, { itemIds: [1] })).toEqual({ items: [] });
+	});
+});
+```
+
+- [ ] **Step 2: Write the implementation**
+
+```ts
+// cli/src/core/references/sources/MondayNormalize.ts
+/**
+ * MondayNormalize — canonical-shape builder for the monday.com item source.
+ *
+ * monday has no single-item getter: `get_board_items_page` serves BOTH a
+ * targeted `itemIds` fetch AND a whole-board browse (up to 500 items). Tool-name
+ * matching cannot tell them apart, so the reference gate is on the tool INPUT — a
+ * reference is produced ONLY when the call carried a non-empty `itemIds` (a
+ * targeted lookup); a board browse yields null. This mirrors Slack/zoom-doc
+ * reading tool_use input.
+ *
+ * It also flattens the item body: `item_description.blocks[].content` is a JSON
+ * string holding a Quill `deltaFormat`, which the DSL's dotted `readPath` (no
+ * array indexing, no embedded-JSON parse) cannot express — the same reason
+ * Confluence's ADF flattening lives in a normalizer.
+ *
+ * The `mondayDefinition` is pure `path` DSL over this function's `{ items: [...] }`
+ * output. Used by BOTH hosts: the Claude envelope's CONTEXT_NORMALIZERS entry and
+ * the Codex `mondayCodexBinding`, each passing the itemIds read from its host's
+ * own tool input.
+ */
+
+import { isObject } from "../guards.js";
+
+/** Flattened, host-agnostic monday item the `mondayDefinition` reads via `path`. */
+export interface MondayItem {
+	readonly id: string;
+	readonly name: string;
+	readonly url: string;
+	readonly created_at: string;
+	readonly updated_at: string;
+	readonly board?: string;
+	readonly description?: string;
+}
+
+function readString(v: unknown): string | undefined {
+	return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+/**
+ * The `itemIds` a `get_board_items_page` call carried, or undefined when absent /
+ * empty / malformed — the gate then voids (a board browse has no `itemIds`). Only
+ * presence matters downstream; the values are not cross-referenced.
+ */
+export function readItemIds(toolInput: unknown): readonly number[] | undefined {
+	if (!isObject(toolInput)) return undefined;
+	const ids = toolInput.itemIds;
+	if (!Array.isArray(ids)) return undefined;
+	const nums = ids.filter((x): x is number => typeof x === "number");
+	return nums.length > 0 ? nums : undefined;
+}
+
+/**
+ * Flatten a monday `item_description` into plain text. Each block's `content` is a
+ * JSON string `{"deltaFormat":[{"insert":"…"}]}`; concat every `insert` across all
+ * blocks, blocks joined by "\n". Returns undefined when absent or empty. A block
+ * whose content is not valid JSON / lacks a deltaFormat is skipped (never throws).
+ */
+function flattenDescription(itemDescription: unknown): string | undefined {
+	if (!isObject(itemDescription)) return undefined;
+	const blocks = itemDescription.blocks;
+	if (!Array.isArray(blocks)) return undefined;
+	const lines: string[] = [];
+	for (const block of blocks) {
+		if (!isObject(block) || typeof block.content !== "string") continue;
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(block.content);
+		} catch {
+			continue;
+		}
+		if (!isObject(parsed) || !Array.isArray(parsed.deltaFormat)) continue;
+		const text = parsed.deltaFormat
+			.map((seg) => (isObject(seg) && typeof seg.insert === "string" ? seg.insert : ""))
+			.join("");
+		if (text.length > 0) lines.push(text);
+	}
+	return lines.length > 0 ? lines.join("\n") : undefined;
+}
+
+/**
+ * Build the `{ items }` wrapper the `mondayDefinition` reads, or null to void the
+ * whole result. Gates on `itemIds`; flattens each item's description.
+ */
+export function normalizeMonday(
+	payload: unknown,
+	ctx: { readonly itemIds: readonly number[] | undefined },
+): { items: MondayItem[] } | null {
+	if (ctx.itemIds === undefined || ctx.itemIds.length === 0) return null;
+	if (!isObject(payload)) return null;
+	const board = isObject(payload.board) ? readString(payload.board.name) : undefined;
+	const rawItems = Array.isArray(payload.items) ? payload.items : [];
+	const items: MondayItem[] = [];
+	for (const raw of rawItems) {
+		if (!isObject(raw)) continue;
+		const id = readString(raw.id);
+		const name = readString(raw.name);
+		const url = readString(raw.url);
+		if (id === undefined || name === undefined || url === undefined) continue;
+		const description = flattenDescription(raw.item_description);
+		items.push({
+			id,
+			name,
+			url,
+			created_at: readString(raw.created_at) ?? "",
+			updated_at: readString(raw.updated_at) ?? "",
+			...(board !== undefined ? { board } : {}),
+			...(description !== undefined ? { description } : {}),
+		});
+	}
+	return { items };
+}
+```
+
+---
+
+## Task 2: `mondayDefinition` + registration + display metadata
+
+**Files:**
+- Create: `cli/src/core/references/sources/definitions/monday.ts`
+- Modify: `cli/src/core/references/sources/definitions/index.ts`
+- Modify: `cli/src/Types.ts` (`KnownSourceId` union, ~line 775)
+- Modify: `vscode/src/views/SourceLabels.ts` (`SOURCE_META`)
+- Test: `cli/src/core/references/sources/definitions/monday.test.ts`
+- Test: `cli/src/core/references/SourceDefinitionRegistry.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `SourceDefinition` type; the normalized `{ items: [MondayItem] }` shape from Task 1 (the def reads flat `id`/`name`/`url`/`description`/`board`).
+- Produces: `export const mondayDefinition: SourceDefinition` (id `"monday"`). `match.codex` is present but INERT until Task 4 wires the binding — `getCodexNormalizer("monday")` returns undefined until then, and the parser skips it.
+
+- [ ] **Step 1: Write the failing definition test**
+
+```ts
+// cli/src/core/references/sources/definitions/monday.test.ts
+import { describe, expect, it } from "vitest";
+import { extractRef, renderBlock } from "../../SourceEngine.js";
+import { mondayDefinition as def } from "./monday.js";
+
+// The definition runs over ONE normalized item (after wrapperKeys:["items"] unwrap).
+const ITEM = {
+	id: "12511130115",
+	name: "Add monday MCP integration",
+	url: "https://jolli-squad.monday.com/boards/18421599187/pulses/12511130115",
+	created_at: "2026-07-12T11:05:25Z",
+	updated_at: "2026-07-14T08:30:22Z",
+	board: "Tasks",
+	description: "Use MCP to get monday task info in Agents.",
+};
+const TOOL = "mcp__claude_ai_monday_com__get_board_items_page";
+const AT = "2026-07-14T00:00:00Z";
+
+describe("monday definition", () => {
+	it("extracts a Reference from a normalized item", () => {
+		const ref = extractRef(def, ITEM, TOOL, AT);
+		expect(ref?.source).toBe("monday");
+		expect(ref?.nativeId).toBe("12511130115");
+		expect(ref?.title).toBe("Add monday MCP integration");
+		expect(ref?.url).toBe(ITEM.url);
+		expect(ref?.description).toBe("Use MCP to get monday task info in Agents.");
+		expect(ref?.fields).toEqual([
+			{ key: "entity-type", label: "Type", icon: "symbol-class", value: "item" },
+			{ key: "board", label: "Board", icon: "project", value: "Tasks" },
+		]);
+	});
+	it("drops the description when absent (subitem)", () => {
+		const { description, ...noDesc } = ITEM;
+		const ref = extractRef(def, noDesc, TOOL, AT);
+		expect(ref?.description).toBeUndefined();
+	});
+	it("voids when id (nativeId) is missing", () => {
+		expect(extractRef(def, { ...ITEM, id: undefined }, TOOL, AT)).toBeNull();
+	});
+	it("voids when the url is not a monday host", () => {
+		expect(extractRef(def, { ...ITEM, url: "https://evil.example/x" }, TOOL, AT)).toBeNull();
+	});
+	it("accepts a mixed-case monday host", () => {
+		const url = "https://Jolli-Squad.Monday.com/boards/1/pulses/9";
+		expect(extractRef(def, { ...ITEM, url }, TOOL, AT)?.url).toBe(url);
+	});
+	it("renders a <monday-items> block", () => {
+		const ref = extractRef(def, ITEM, TOOL, AT);
+		if (ref === null) throw new Error("expected ref");
+		const block = renderBlock(def, [ref]);
+		expect(block).toContain("<monday-items>");
+		expect(block).toContain("<item ");
+		expect(block).toContain("<description>");
+	});
+});
+```
+
+- [ ] **Step 2: Create the definition**
+
+```ts
+// cli/src/core/references/sources/definitions/monday.ts
+/**
+ * monday.com built-in source — pure `path` DSL over the MondayNormalize
+ * canonical shape ({ id, name, url, created_at, updated_at, board?, description? }).
+ *
+ * The messy work — the itemIds anti-flood gate and the delta-format body flatten
+ * — lives in `sources/MondayNormalize.normalizeMonday`, wired into BOTH envelope
+ * parsers (Claude via CONTEXT_NORMALIZERS, Codex via CodexMondayBinding). This
+ * definition only selects fields, exactly like zoom-doc.
+ *
+ * `match.claude` allows only `get_board_items_page` (the item fetch); every
+ * write/enumeration/doc/dashboard tool is excluded by the allowlist. `match.codex`
+ * targets the `codex_apps__monday_com` connector (function_call `_get_board_items_page`,
+ * invocation `monday_com.get_board_items_page`) — both transcribed from a real
+ * 2026-07-14 rollout, not guessed.
+ *
+ * `column_values` are deliberately NOT surfaced as fields: their keys are
+ * board-defined and vary per board (Tasks uses `task_status`; the Subitems board
+ * uses `person`/`status`/`date0`), so only stable top-level fields are used.
+ */
+
+import type { SourceDefinition } from "../../SourceDefinition.js";
+
+export const mondayDefinition: SourceDefinition = {
+	id: "monday",
+	label: "monday.com",
+	icon: "table",
+	match: {
+		claude: { prefixes: ["mcp__claude_ai_monday_com__"], acceptSuffix: "get_board_items_page" },
+		codex: {
+			namespaceSuffix: "monday_com",
+			functionCallNames: ["_get_board_items_page"],
+			invocationTools: ["monday_com.get_board_items_page"],
+		},
+	},
+	wrapperKeys: ["items"],
+	reference: {
+		nativeId: { pipe: [{ op: "path", path: "id" }], require: "^\\d+$" },
+		title: { pipe: [{ op: "path", path: "name" }], require: ".+" },
+		url: { pipe: [{ op: "path", path: "url" }], require: "^https://[\\w-]+\\.monday\\.com/", requireFlags: "i" },
+		description: { pipe: [{ op: "path", path: "description" }], optional: true },
+	},
+	fields: [
+		{ key: "entity-type", label: "Type", icon: "symbol-class", pipe: [{ op: "const", value: "item" }] },
+		{ key: "board", label: "Board", icon: "project", pipe: [{ op: "path", path: "board" }] },
+	],
+	storage: { nativeIdPathSafe: true },
+	render: {
+		wrapperTag: "monday-items",
+		itemTag: "item",
+		bodyTag: "description",
+		maxCharsPerReference: 4000,
+		maxTotalChars: 30000,
+	},
+};
+```
+
+- [ ] **Step 3: Register in `BUILTIN_DEFINITIONS`**
+
+In `cli/src/core/references/sources/definitions/index.ts` add the import (alphabetical-ish with the others) and append to the array:
+
+```ts
+import { mondayDefinition } from "./monday.js";
+```
+
+```ts
+export const BUILTIN_DEFINITIONS = [
+	linearDefinition,
+	confluenceDefinition,
+	jiraDefinition,
+	githubDefinition,
+	notionDefinition,
+	slackDefinition,
+	zoomMeetingDefinition,
+	zoomDocDefinition,
+	asanaDefinition,
+	mondayDefinition,
+] as const;
+```
+
+- [ ] **Step 4: Add `"monday"` to `KnownSourceId`**
+
+In `cli/src/Types.ts` (the `KnownSourceId` union, ~line 775) append:
+
+```ts
+export type KnownSourceId =
+	| "linear"
+	| "confluence"
+	| "jira"
+	| "github"
+	| "notion"
+	| "slack"
+	| "zoom-meeting"
+	| "zoom-doc"
+	| "asana"
+	| "monday";
+```
+
+- [ ] **Step 5: Add the `SOURCE_META` row (TS-forced by Step 4)**
+
+In `vscode/src/views/SourceLabels.ts`, add to the `SOURCE_META` object literal:
+
+```ts
+	monday: { label: "monday.com", letter: "M", icon: "table", color: "#ff3d57" },
+```
+
+(`Record<KnownSourceId, SourceMeta>` makes this a compile error until added. `#ff3d57` is monday's brand red; `table` matches the CLI def icon.)
+
+- [ ] **Step 6: Extend the registry test**
+
+In `cli/src/core/references/SourceDefinitionRegistry.test.ts`:
+
+(a) Append `"monday"` to the `all()` stable-order id-list assertion (find the array that currently ends `…, "asana"` and add `"monday"`).
+
+(b) Add a registration describe block:
+
+```ts
+describe("monday registration", () => {
+	it("resolves the Claude item-fetch tool", () => {
+		expect(getRegistry().match("claude", "mcp__claude_ai_monday_com__get_board_items_page")?.id).toBe("monday");
+	});
+	it("resolves both Codex match paths", () => {
+		expect(getRegistry().match("codex", "_get_board_items_page", "monday_com")?.id).toBe("monday");
+		expect(getRegistry().match("codex", "monday_com.get_board_items_page")?.id).toBe("monday");
+	});
+	it("does NOT resolve monday write/enumeration/other tools", () => {
+		const r = getRegistry();
+		expect(r.match("claude", "mcp__claude_ai_monday_com__create_item")).toBeUndefined();
+		expect(r.match("claude", "mcp__claude_ai_monday_com__get_board_info")).toBeUndefined();
+		expect(r.match("claude", "mcp__claude_ai_monday_com__get_updates")).toBeUndefined();
+		expect(r.match("codex", "_get_board_info", "monday_com")).toBeUndefined();
+	});
+});
+```
+
+(Match the file's existing import of `getRegistry` — reuse whatever helper the sibling describes use; if they call a `getRegistry()` fresh each time, do the same.)
+
+---
+
+## Task 3: Claude envelope wiring (itemIds gate on the Claude path)
+
+**Files:**
+- Modify: `cli/src/core/references/ClaudeEnvelopeParser.ts` (`CONTEXT_NORMALIZERS`)
+- Test: `cli/src/core/references/ClaudeEnvelopeParser.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `normalizeMonday`, `readItemIds` (Task 1); `mondayDefinition` registered (Task 2).
+- Produces: monday added to `CONTEXT_NORMALIZERS` → `CONTEXT_NORMALIZER_IDS` (auto-derived) now includes `"monday"`, so `collectToolUses` retains the tool_use `input` for monday calls and `collectToolResults` runs the normalizer.
+
+- [ ] **Step 1: Write the failing end-to-end test**
+
+Add to `cli/src/core/references/ClaudeEnvelopeParser.test.ts` (mirror the existing zoom-doc/slack e2e style in that file — build a two-line transcript: an assistant `tool_use`, then a user `tool_result`, and run the file's existing extraction entrypoint). Real payload:
+
+```ts
+describe("monday (Claude)", () => {
+	const PAYLOAD = {
+		board: { id: "18421599187", name: "Tasks" },
+		items: [
+			{
+				id: "12511130115",
+				name: "Add monday MCP integration",
+				url: "https://jolli-squad.monday.com/boards/18421599187/pulses/12511130115",
+				created_at: "2026-07-12T11:05:25Z",
+				updated_at: "2026-07-14T08:30:22Z",
+				item_description: {
+					blocks: [{ content: '{"deltaFormat":[{"insert":"Use MCP to get monday task info."}]}' }],
+				},
+			},
+		],
+		pagination: { count: 1 },
+	};
+	const TOOL = "mcp__claude_ai_monday_com__get_board_items_page";
+
+	it("captures a targeted itemIds fetch as a monday reference", () => {
+		const lines = buildTranscript(TOOL, { boardId: 18421599187, itemIds: [12511130115] }, PAYLOAD);
+		const refs = extractFromLines(lines); // use the file's existing helper / entrypoint
+		const monday = refs.find((r) => r.source === "monday");
+		expect(monday?.nativeId).toBe("12511130115");
+		expect(monday?.title).toBe("Add monday MCP integration");
+		expect(monday?.description).toBe("Use MCP to get monday task info.");
+	});
+
+	it("captures nothing for a board browse (no itemIds)", () => {
+		const lines = buildTranscript(TOOL, { boardId: 18421599187 }, PAYLOAD);
+		const refs = extractFromLines(lines);
+		expect(refs.find((r) => r.source === "monday")).toBeUndefined();
+	});
+});
+```
+
+> **Note for implementer:** `buildTranscript(toolName, input, payload)` and `extractFromLines`/entrypoint are placeholders for whatever the sibling monday-less tests in this file already use to assemble a Claude JSONL transcript and run extraction. Reuse the existing helpers verbatim — do not invent a new harness. The tool_use block must carry `"input": <input>` and the tool_result must carry the JSON-stringified `payload` under a `{type:"text",text:"…"}` content block, matching the existing slack/zoom-doc cases.
+
+- [ ] **Step 2: Add the `monday` context-normalizer**
+
+In `cli/src/core/references/ClaudeEnvelopeParser.ts`:
+
+Add the import near the other `sources/*Normalize` imports:
+
+```ts
+import { normalizeMonday, readItemIds } from "./sources/MondayNormalize.js";
+```
+
+Add an entry to the `CONTEXT_NORMALIZERS` record (alongside `slack` / `zoom-doc` / `confluence`):
+
+```ts
+	monday: (payload, toolInput) => normalizeMonday(payload, { itemIds: readItemIds(toolInput) }),
+```
+
+No other change: `CONTEXT_NORMALIZER_IDS` is `new Set(Object.keys(CONTEXT_NORMALIZERS))`, so `"monday"` is auto-added; `collectToolUses` then retains `b.input` for monday tool_uses, and `collectToolResults` invokes the normalizer (returning `null` from the gate voids the result, exactly like slack's `null` path).
+
+---
+
+## Task 4: Codex parser extension + `mondayCodexBinding`
+
+**Files:**
+- Modify: `cli/src/core/references/bindings/codex/CodexBinding.ts` (interface signature)
+- Modify: `cli/src/core/references/CodexEnvelopeParser.ts` (retain + thread `arguments`)
+- Create: `cli/src/core/references/bindings/codex/CodexMondayBinding.ts`
+- Modify: `cli/src/core/references/bindings/codex/index.ts` (register)
+- Test: `cli/src/core/references/CodexEnvelopeParser.test.ts` (extend)
+- Test: `cli/src/core/references/bindings/codex/index.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `normalizeMonday`, `readItemIds` (Task 1); `mondayDefinition.match.codex` (Task 2).
+- Produces: `CodexNormalizer.normalize(business, toolInput?)`; `mondayCodexBinding` in `CODEX_NORMALIZERS`.
+
+- [ ] **Step 1: Widen the `CodexNormalizer.normalize` signature**
+
+In `cli/src/core/references/bindings/codex/CodexBinding.ts`, change the interface method (and its doc) to accept the optional tool input. Existing bindings (`(business) => …`) stay assignable — a function of fewer params satisfies the wider type.
+
+```ts
+	/**
+	 * Normalize the connector business payload — a single entity OR a search/list
+	 * collection — into the shape the shared definition reads. `toolInput` is the
+	 * parsed `function_call` `arguments` (undefined when absent); only sources that
+	 * gate on their input read it (monday's `itemIds`). Implementations use
+	 * {@link normalizeEntities} so both shapes are handled uniformly.
+	 */
+	normalize(business: unknown, toolInput?: unknown): unknown;
+```
+
+- [ ] **Step 2: Retain and thread `arguments` in the Codex parser**
+
+In `cli/src/core/references/CodexEnvelopeParser.ts`:
+
+(a) Add `arguments` to `FunctionCallRow`:
+
+```ts
+interface FunctionCallRow {
+	readonly namespace: string;
+	readonly name: string;
+	readonly lineIndex: number;
+	/** Raw JSON-string `arguments` from the request, threaded to a gating
+	 *  normalizer (monday's `itemIds`); undefined when absent. */
+	readonly arguments?: string;
+}
+```
+
+(b) In the `function_call` case, store the arguments when setting the namespaced call:
+
+```ts
+if (callId !== undefined && namespace !== undefined && name !== undefined) {
+	calls.set(callId, { namespace, name, lineIndex: i, arguments: readString(payload.arguments) });
+}
+```
+
+(c) Add a small parse helper near `parseFunctionCallOutput`:
+
+```ts
+/** Parse a function_call's JSON-string `arguments` to an object, or undefined. */
+function parseArguments(args: string | undefined): unknown {
+	if (args === undefined) return undefined;
+	const parsed = tryParse(args);
+	return parsed === null ? undefined : parsed;
+}
+```
+
+(d) In the PRIMARY loop, pass the parsed arguments to `normalize`:
+
+```ts
+results.push({
+	def,
+	toolName: normalizer.canonicalToolName,
+	payload: normalizer.normalize(business, parseArguments(call.arguments)),
+	lineNumber: out.lineNumber,
+	referencedAt: out.referencedAt,
+});
+```
+
+(e) In the FALLBACK (`mcp_tool_call_end`) loop, look up the paired request's arguments by `call_id` and pass them:
+
+```ts
+const toolInput = ev.callId !== undefined ? parseArguments(calls.get(ev.callId)?.arguments) : undefined;
+results.push({
+	def,
+	toolName: normalizer.canonicalToolName,
+	payload: normalizer.normalize(business, toolInput),
+	lineNumber: ev.lineNumber,
+	referencedAt: ev.referencedAt,
+});
+```
+
+(The shell-CLI loop's `shell.binding.normalize(business, shell.command)` is a different `CliBinding` interface — leave it unchanged.)
+
+- [ ] **Step 3: Create `CodexMondayBinding`**
+
+```ts
+// cli/src/core/references/bindings/codex/CodexMondayBinding.ts
+/**
+ * CodexMondayBinding — monday.com `codex_apps` connector normalizer.
+ *
+ * Reached through `_get_board_items_page` (namespace `mcp__codex_apps__monday_com`)
+ * or the `monday_com.get_board_items_page` invocation — match identity lives in
+ * `mondayDefinition.match.codex`. The connector's `function_call_output` unwraps to
+ * the SAME `{ board, items, pagination }` payload as the Claude monday MCP, so this
+ * binding shares `normalizeMonday` with the Claude path. It reads the `itemIds` gate
+ * from the request `arguments` (threaded by CodexEnvelopeParser) — a Codex board
+ * browse with no `itemIds` voids, exactly like the Claude side.
+ */
+
+import { normalizeMonday, readItemIds } from "../../sources/MondayNormalize.js";
+import type { CodexNormalizer } from "./CodexBinding.js";
+
+export const mondayCodexBinding: CodexNormalizer = {
+	id: "monday",
+	canonicalToolName: "mcp__claude_ai_monday_com__get_board_items_page",
+	normalize: (business, toolInput) => normalizeMonday(business, { itemIds: readItemIds(toolInput) }),
+};
+```
+
+- [ ] **Step 4: Register in `CODEX_NORMALIZERS`**
+
+In `cli/src/core/references/bindings/codex/index.ts` add the import and append to the array:
+
+```ts
+import { mondayCodexBinding } from "./CodexMondayBinding.js";
+```
+
+```ts
+const CODEX_NORMALIZERS: readonly CodexNormalizer[] = [
+	linearCodexBinding,
+	notionCodexBinding,
+	githubCodexBinding,
+	jiraCodexBinding,
+	zoomMeetingCodexBinding,
+	confluenceCodexBinding,
+	asanaCodexBinding,
+	mondayCodexBinding,
+];
+```
+
+- [ ] **Step 5: Write the binding unit test**
+
+Add to `cli/src/core/references/bindings/codex/index.test.ts` (mirror the `asana`/`zoom-meeting` binding cases):
+
+```ts
+describe("mondayCodexBinding", () => {
+	it("has the canonical Claude tool name", () => {
+		expect(getCodexNormalizer("monday")?.canonicalToolName).toBe(
+			"mcp__claude_ai_monday_com__get_board_items_page",
+		);
+	});
+	it("normalizes a targeted fetch (itemIds present) into the { items } wrapper", () => {
+		const business = {
+			board: { name: "Tasks" },
+			items: [
+				{
+					id: "9",
+					name: "T",
+					url: "https://x.monday.com/boards/1/pulses/9",
+					created_at: "t",
+					updated_at: "t",
+				},
+			],
+		};
+		const out = getCodexNormalizer("monday")?.normalize(business, { itemIds: [9] });
+		expect(out).toEqual({ items: [{ id: "9", name: "T", url: "https://x.monday.com/boards/1/pulses/9", created_at: "t", updated_at: "t", board: "Tasks" }] });
+	});
+	it("voids (null) a board browse (no itemIds)", () => {
+		expect(getCodexNormalizer("monday")?.normalize({ items: [] }, {})).toBeNull();
+	});
+});
+```
+
+(Reuse the file's existing `getCodexNormalizer` import.)
+
+- [ ] **Step 6: Write the Codex envelope end-to-end test**
+
+Add to `cli/src/core/references/CodexEnvelopeParser.test.ts` (mirror the existing `asana`/`jira` Codex cases — build the three-line-type rollout). Use the REAL arguments + output:
+
+```ts
+describe("monday (Codex)", () => {
+	const OUTPUT_JSON = JSON.stringify({
+		board: { id: "18421599187", name: "Tasks" },
+		items: [
+			{
+				id: "12511130115",
+				name: "Add monday MCP integration",
+				url: "https://jolli-squad.monday.com/boards/18421599187/pulses/12511130115",
+				created_at: "2026-07-12T11:05:25Z",
+				updated_at: "2026-07-14T08:30:22Z",
+				item_description: { blocks: [{ content: '{"deltaFormat":[{"insert":"Use MCP to get monday task info."}]}' }] },
+			},
+		],
+		pagination: { count: 1 },
+	});
+	const ARGS = '{"boardId":18421599187,"itemIds":[12511130115],"includeItemDescription":true,"limit":1}';
+	const ARGS_BROWSE = '{"boardId":18421599187,"limit":25}';
+
+	it("PRIMARY path: function_call(arguments.itemIds) + function_call_output → monday ref", () => {
+		// buildCodexRollout(namespace, name, callId, argsJson, outputBody) — reuse the file's helper.
+		const lines = buildCodexRollout(
+			"mcp__codex_apps__monday_com",
+			"_get_board_items_page",
+			"call_1",
+			ARGS,
+			`Wall time: 1s\nOutput:\n${OUTPUT_JSON}`,
+		);
+		const refs = extractFromCodexLines(lines); // reuse the file's entrypoint
+		const monday = refs.find((r) => r.source === "monday");
+		expect(monday?.nativeId).toBe("12511130115");
+		expect(monday?.description).toBe("Use MCP to get monday task info.");
+	});
+
+	it("FALLBACK path: mcp_tool_call_end (no output) still gates on the request's itemIds", () => {
+		const lines = buildCodexRolloutEventOnly(
+			"mcp__codex_apps__monday_com",
+			"_get_board_items_page",
+			"monday_com.get_board_items_page",
+			"call_2",
+			ARGS,
+			OUTPUT_JSON,
+		);
+		const refs = extractFromCodexLines(lines);
+		expect(refs.find((r) => r.source === "monday")?.nativeId).toBe("12511130115");
+	});
+
+	it("captures nothing for a Codex board browse (arguments without itemIds)", () => {
+		const lines = buildCodexRollout(
+			"mcp__codex_apps__monday_com",
+			"_get_board_items_page",
+			"call_3",
+			ARGS_BROWSE,
+			`Wall time: 1s\nOutput:\n${OUTPUT_JSON}`,
+		);
+		const refs = extractFromCodexLines(lines);
+		expect(refs.find((r) => r.source === "monday")).toBeUndefined();
+	});
+});
+```
+
+> **Note for implementer:** `buildCodexRollout` / `buildCodexRolloutEventOnly` / `extractFromCodexLines` are placeholders for the assembly + extraction helpers the sibling Codex tests in this file already use. Reuse them verbatim; the request line must include `"arguments": <argsJson>`. If the FALLBACK helper doesn't already exist, model the event-only line on the file's existing `mcp_tool_call_end` fixtures (`payload.type:"mcp_tool_call_end"`, `invocation.tool`, `result.Ok.content[0].text`) plus the paired `function_call` request that carries the arguments.
+
+---
+
+## Task 5: Verify & commit (single consolidated pass)
+
+**Files:** none (verification + commit only).
+
+- [ ] **Step 1: Run the full gate**
+
+```bash
+cd /Users/flyer/jolli/code/jollimemory && npm run all
+```
+
+Expected: clean → build → lint → test all PASS, including CLI coverage ≥ 97/96/97/97. If coverage falls short on `MondayNormalize.ts`, add the missing branch case to `MondayNormalize.test.ts` (do not lower the threshold, do not add `v8 ignore` to a reachable branch).
+
+- [ ] **Step 2: Commit everything with DCO sign-off (no AI co-author trailer)**
+
+```bash
+git add -A
+git commit -s -m "feat(references): add monday.com item reference source
+
+Capture a monday.com item (title, delta-format body, url) as a reference
+when a Claude Code or Codex session fetches it by itemIds via
+get_board_items_page. Gates on itemIds so board browses don't flood
+working memory; extends the Codex envelope parser to thread function_call
+arguments to the normalizer."
+```
+
+Verify the commit message has a `Signed-off-by:` line and NO `Co-Authored-By: Claude` / `🤖 Generated with` footer.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Item entity via `get_board_items_page` → Task 2 (`match.claude`/`match.codex` allowlist). ✓
+- itemIds anti-flood gate → Task 1 (`normalizeMonday` gate) + Task 3 (Claude) + Task 4 (Codex). ✓
+- Delta-format description flatten + absent-description case → Task 1 (`flattenDescription`, Fixtures A & B). ✓
+- `column_values` NOT surfaced → Task 2 (fields = entity-type + board only). ✓
+- Codex byte-identical payload / no reshape → Task 4 (`mondayCodexBinding` shares `normalizeMonday`). ✓
+- Codex parser input-threading → Task 4 Steps 1–2. ✓
+- `KnownSourceId` + `SOURCE_META` + registry stable-order → Task 2 Steps 4–6. ✓
+- Both `referencesBySourceOrder` copies auto-derive order → no task needed (verified). ✓
+
+**Placeholder scan:** The only non-literal items are the test-harness helper names in Tasks 3 & 4 (`buildTranscript`, `extractFromLines`, `buildCodexRollout`, …), explicitly flagged as "reuse the sibling tests' existing helpers verbatim" — this is intentional (the harness already exists in those test files; inventing a parallel one would be wrong). All production code is complete and literal.
+
+**Type consistency:** `readItemIds(unknown): readonly number[] | undefined` and `normalizeMonday(payload, { itemIds })` are used identically in Tasks 1, 3, 4. `CodexNormalizer.normalize(business, toolInput?)` (Task 4 Step 1) matches the call sites (Task 4 Step 2 d/e) and the `mondayCodexBinding` implementation (Step 3). `mondayDefinition` field/render tags (`monday-items`/`item`/`description`) match the definition test assertions.

--- a/docs/superpowers/specs/2026-07-14-monday-reference-source-design.md
+++ b/docs/superpowers/specs/2026-07-14-monday-reference-source-design.md
@@ -1,0 +1,287 @@
+# monday.com reference source — design
+
+**Date:** 2026-07-14
+**Task:** monday — "Add monday MCP integration" (Jolli Memory project)
+**Status:** Approved, ready for implementation plan
+
+## Summary
+
+Add monday.com as a built-in reference-extraction source so that when a user's
+Claude Code **or Codex** session fetches a monday item, the referenced item
+(title, description, URL) is captured as a Jolli reference — like the existing
+Linear / Jira / GitHub / Notion / Slack / Zoom / Asana sources.
+
+Unlike Asana (a pure-DSL, self-contained source), monday lands in the
+**context-normalizer tier** (alongside Slack / zoom-doc / Confluence) because its
+data shape forces it there on **two** independent counts:
+
+1. **No single-item getter tool exists.** monday's `get_board_items_page` serves
+   *both* "fetch specific items by id" *and* "list/browse a whole board"
+   (up to 500 items). Tool-name matching (`acceptSuffix` / `denySuffixes`) cannot
+   tell them apart. The only reliable discriminator is the **tool input**: a
+   targeted fetch passes `itemIds`; a board browse does not. Reading tool input
+   is exactly what the context-normalizer tier is for (Slack's `channel_id`,
+   zoom-doc's `fileId`).
+2. **The description is doubly-encoded inside an array.** An item's body lives at
+   `item_description.blocks[].content`, where each `content` is a **JSON string**
+   holding a Quill-style `deltaFormat`. The DSL's dotted `readPath` cannot index
+   arrays (`isObject` rejects arrays) nor parse embedded JSON — the same
+   limitation that put Confluence's ADF flattening in a normalizer.
+
+Both counts are satisfied by one small `normalizeMonday(payload, { itemIds })`
+function; the `mondayDefinition` is then pure-DSL over its clean output.
+
+**One architectural extension is required** (approved): the Codex envelope parser
+must thread the `function_call` `arguments` to the normalizer so the `itemIds`
+gate works on Codex too. See "Codex support".
+
+## Scope decisions
+
+1. **Item entity only, via `get_board_items_page`.** Boards, docs, updates,
+   users, dashboards, widgets, etc. are out of scope. A monday *subitem* is just
+   an item on a "Subitems of …" board (same shape, same `/pulses/` URL) — it needs
+   no special handling and is covered for free.
+2. **Anti-flood gate on `itemIds` (approved).** A reference is produced **only**
+   when the tool call carried a non-empty `itemIds` argument (a targeted lookup).
+   A board browse (no `itemIds`, N items) is voided — this is monday's equivalent
+   of Linear/Jira's enumeration exclusion, and the only anti-flood signal
+   available given no single-item tool exists.
+3. **Both hosts now (approved).** Claude and Codex. The Codex half is grounded in
+   a real on-disk rollout (below), not guessed — honoring the JOLLI-1921 / GitHub
+   precedent that forbids a hallucinated `match.codex`.
+4. **`column_values` are NOT surfaced as fields.** Their keys are **board-defined**
+   and vary per board (proven: the Tasks board uses `task_status`/`task_type`; the
+   Subitems board uses `person`/`status`/`date0`). A static DSL path into them
+   would work on one board and silently fail on the next. Only stable top-level
+   API fields are used.
+
+## Truth source (two real fixtures)
+
+Both captured live this session from the monday MCP connector (Claude side); the
+Codex `function_call_output` for the identical call is **byte-identical** after
+prefix-strip (verified — see Codex support). Saved:
+`scratchpad/monday-real-payload.json`.
+
+**Fixture A — Tasks item, WITH description** (`board 18421599187` / item `12511130115`):
+
+```json
+{ "board": { "id": "18421599187", "name": "Tasks" },
+  "items": [ {
+    "id": "12511130115",
+    "name": "Add monday MCP integration",
+    "url": "https://jolli-squad.monday.com/boards/18421599187/pulses/12511130115",
+    "created_at": "2026-07-12T11:05:25Z",
+    "updated_at": "2026-07-14T08:30:22Z",
+    "column_values": { "task_status": "In Progress", "task_type": "Feature", "item_id": "TJOL-001", "...": "..." },
+    "item_description": { "id": "44442382", "blocks": [
+      { "id": "c5d5…", "type": "normal text",
+        "content": "{\"direction\":\"ltr\",\"deltaFormat\":[{\"insert\":\"Use MCP to get monday task info in Agents (Claude Code, Codex, etc), Jolli Memory will capture the context in sessions, and show as context reference in working memory.\"}]}" } ] } } ],
+  "pagination": { "has_more": false, "nextCursor": null, "count": 1 } }
+```
+
+**Fixture B — Subitem, NO description** (`board 18421888353` / item `12526313713`):
+
+```json
+{ "board": { "id": "18421888353", "name": "Subitems of Tasks" },
+  "items": [ {
+    "id": "12526313713",
+    "name": "Claude Code Support",
+    "url": "https://jolli-squad.monday.com/boards/18421888353/pulses/12526313713",
+    "created_at": "2026-07-14T09:15:22Z",
+    "updated_at": "2026-07-14T09:15:22Z",
+    "column_values": { "person": null, "status": null, "date0": null } } ],
+  "pagination": { "has_more": false, "nextCursor": null, "count": 1 } }
+```
+
+Fixture B pins two contracts: `item_description` may be **entirely absent**
+(→ no description, not an error), and `column_values` keys differ per board.
+
+## `normalizeMonday` (new — `cli/src/core/references/sources/MondayNormalize.ts`)
+
+Signature (mirrors `normalizeZoomDoc` / `normalizeConfluence`):
+
+```
+normalizeMonday(payload: unknown, ctx: { itemIds: readonly number[] | undefined }): { items: MondayItem[] } | null
+```
+
+Behavior:
+
+1. **Gate:** if `ctx.itemIds` is `undefined` or empty → return `null` (voids the
+   whole result — a board browse produces no reference).
+2. Read `payload.board?.name` once (carried onto every item as `board`).
+3. For each entry in `payload.items` (array), emit a flat canonical item:
+   ```
+   { id, name, url, created_at, updated_at, board, description? }
+   ```
+   - `id` / `name` / `url` / `created_at` / `updated_at` copied verbatim.
+   - `board` = the board name (may be undefined → dropped downstream).
+   - `description` = flattened from `item_description.blocks[]`: for each block,
+     `JSON.parse(content)` and concat every `deltaFormat[].insert` string; join
+     blocks with `\n`. If `item_description` is absent, no block parses, or the
+     result is empty → **omit** `description`. Defensive: any block whose
+     `content` is not valid JSON, or lacks `deltaFormat`, is skipped (never
+     throws). **Fixture note:** only the single-block / single-insert shape is
+     pinned by a real fixture (A); the multi-block/multi-insert concat is written
+     defensively and covered by a synthetic test, and flagged as such.
+4. Return `{ items }` — even when `items` is empty (extraction then yields nothing,
+   which is correct; a non-null empty-items wrapper is fine).
+
+The messy work lives here; the definition below is pure `path` DSL over the
+`{ items: [...] }` output — exactly the zoom-doc pattern.
+
+## The `mondayDefinition` (new — `.../sources/definitions/monday.ts`)
+
+```
+id:      "monday"
+label:   "monday.com"
+icon:    "table"                 // codicon; finalize in TDD
+match.claude: { prefixes: ["mcp__claude_ai_monday_com__"], acceptSuffix: "get_board_items_page" }
+match.codex:  { namespaceSuffix: "monday_com",
+                functionCallNames: ["_get_board_items_page"],
+                invocationTools:   ["monday_com.get_board_items_page"] }
+wrapperKeys: ["items"]           // walkPayload voids at the {items,...} wrapper, descends items[]
+reference:
+  nativeId:    path "id"          require ^\d+$
+  title:       path "name"        require .+
+  url:         path "url"         require ^https://[\w-]+\.monday\.com/   flags i
+  description: path "description" optional            // already flattened by normalize
+fields:
+  { key: "entity-type", const: "item" }
+  { key: "board",       path "board" }                // drops when board name absent
+storage: { nativeIdPathSafe: true }   // monday ids are numeric → identity path
+render:  { wrapperTag: "monday-items", itemTag: "item", bodyTag: "description",
+           maxCharsPerReference: 4000, maxTotalChars: 30000 }
+```
+
+### Why these choices
+
+- **`acceptSuffix: "get_board_items_page"`** (single-tool allowlist, like
+  Notion/Asana) — monday's tool surface is ~100 tools; an allowlist is the safe
+  default. All write/enumeration/doc/dashboard tools are excluded automatically.
+- **`wrapperKeys: ["items"]`** — `normalizeMonday` returns `{ items: [...] }`;
+  `walkPayload` voids `extractRef` at the wrapper (no `id`), then descends `items`
+  and extracts each flattened item.
+- **`url` host allowlist `^https://[\w-]+\.monday\.com/` (case-insensitive)** —
+  accepts any account subdomain (`jolli-squad.monday.com`), rejects arbitrary
+  hosts. `flags: "i"` because URL hosts are case-insensitive (mirrors Asana).
+- **Minimal, honest `fields`** — only `entity-type` (const) and `board` (a stable
+  top-level value carried down by normalize). `column_values` deliberately omitted
+  (board-specific keys; see scope decision 4).
+
+## Codex support
+
+### Observed reality (real rollout — authoritative, not guessed)
+
+Tool catalog `~/.codex/cache/codex_apps_tools/*.json` (authoritative for tool
+existence/names): connector `Monday.com`, `tool_namespace: codex_apps__monday_com`,
+`tool.name: monday_com.get_board_items_page`, input schema includes `itemIds`.
+
+Real rollout
+`~/.codex/sessions/2026/07/14/rollout-…T17-10-35-019f5fe4….jsonl` — the user had
+Codex fetch item `12511130115`. The three `codex_apps` line types:
+
+- **`function_call`** (request): `namespace: "mcp__codex_apps__monday_com"`,
+  `name: "_get_board_items_page"`,
+  `arguments: {"boardId":18421599187,"itemIds":[12511130115],"includeColumns":true,"includeItemDescription":true,"includeSubItems":true,"subItemLimit":50,"limit":1}`
+  — **`itemIds` is present in `arguments`** (the LLM naturally set it, plus `limit:1`).
+- **`mcp_tool_call_end`** (event): `invocation.tool: "monday_com.get_board_items_page"`.
+- **`function_call_output`** (result): `"Wall time: …\nOutput:\n{board,items,pagination}"`
+  — after prefix strip, **byte-identical to the Claude MCP payload** (Fixture A).
+
+Because the result payload matches the Claude shape, `normalizeMonday` consumes it
+unchanged — **no reshaping**. The only Codex-specific problem is that `itemIds`
+lives in `arguments`, a *different* line from the result, and the current parser
+discards it.
+
+### Parser extension (approved deviation from "add a source, don't touch the parser")
+
+Slack / zoom-doc — the existing input-dependent sources — are **Claude-only**
+precisely because the Codex path never exposed tool input to normalizers. monday
+needs `itemIds`, so we add that capability, minimally and symmetrically with
+Claude's existing `toolInput` threading:
+
+1. **`CodexEnvelopeParser`** — `FunctionCallRow` gains `arguments?: string` (the
+   raw JSON string, already read for the shell path). Store `payload.arguments` on
+   the row in the `function_call` case.
+2. In **both** emit loops (PRIMARY `function_call_output` pairs, and the
+   `mcp_tool_call_end` FALLBACK), look up the paired request by `call_id`, parse
+   its `arguments`, and pass them to `normalize`.
+3. **`CodexNormalizer.normalize`** signature gains an optional second param:
+   `normalize(business, toolInput?)`. Every existing binding ignores it (identity /
+   collection logic unchanged); only monday reads `toolInput.itemIds`.
+4. **`CodexMondayBinding.ts`** — `mondayCodexBinding`:
+   `normalize: (business, toolInput) => normalizeMonday(business, { itemIds: readItemIds(toolInput) })`,
+   `canonicalToolName: "mcp__claude_ai_monday_com__get_board_items_page"` (a
+   Codex-sourced monday ref persists the same synthetic tool name as the Claude
+   one). Registered in `bindings/codex/index.ts` `CODEX_NORMALIZERS` (appended).
+
+`readItemIds` reads a `number[]` `itemIds` off the parsed arguments object,
+returning `undefined` when absent/malformed → the gate then voids (correct: a
+Codex board browse has no `itemIds`).
+
+### Claude side
+
+`CONTEXT_NORMALIZERS.monday` in `ClaudeEnvelopeParser.ts`:
+`(payload, toolInput) => normalizeMonday(payload, { itemIds: readItemIds(toolInput) })`,
+where `toolInput` is the `get_board_items_page` tool_use `input` (already threaded
+for sources in `CONTEXT_NORMALIZER_IDS`). `monday` is added to that set — the
+existing `CONTEXT_NORMALIZER_IDS.has(def.id)` machinery does the rest.
+
+## Touch list
+
+Verified against the current subsystem. Downstream ordering
+(`CLAUDE_TOOL_PREFIXES`, `referencesBySourceOrder`) derives from
+`getRegistry().all()`, so appending to `BUILTIN_DEFINITIONS` is the only
+functional registration.
+
+| # | File | Edit |
+|---|------|------|
+| 1 | `cli/src/core/references/sources/MondayNormalize.ts` | **NEW** — `normalizeMonday` + `readItemIds` (delta flatten, itemIds gate) |
+| 2 | `cli/src/core/references/sources/definitions/monday.ts` | **NEW** — `mondayDefinition` (above) |
+| 3 | `cli/src/core/references/sources/definitions/index.ts` | Import + append `mondayDefinition` to `BUILTIN_DEFINITIONS` |
+| 4 | `cli/src/Types.ts` (~775) | Add `"monday"` to `KnownSourceId` union |
+| 5 | `cli/src/core/references/ClaudeEnvelopeParser.ts` | Add `monday` entry to `CONTEXT_NORMALIZERS` (reads tool_use `input.itemIds`) |
+| 6 | `cli/src/core/references/bindings/codex/CodexBinding.ts` | `normalize(business, toolInput?)` — add optional 2nd param to the interface |
+| 7 | `cli/src/core/references/CodexEnvelopeParser.ts` | Keep `arguments` on `FunctionCallRow`; join by `call_id` and pass parsed args to `normalize` in both emit loops |
+| 8 | `cli/src/core/references/bindings/codex/CodexMondayBinding.ts` | **NEW** — `mondayCodexBinding` (normalize via `normalizeMonday`, canonicalToolName) |
+| 9 | `cli/src/core/references/bindings/codex/index.ts` | Import + append `mondayCodexBinding` to `CODEX_NORMALIZERS` |
+| 10 | `vscode/src/views/SourceLabels.ts` | Add `monday` row to `SOURCE_META` (TS-forced by #4): `{ label:"monday.com", letter:"M", icon:"table", color:"#ff3d57" }` (color = monday brand; confirm when editing) |
+| 11 | `.../definitions/monday.test.ts` | **NEW** — definition test over both fixtures (with/without description, void cases, render) |
+| 12 | `.../sources/MondayNormalize.test.ts` | **NEW** — gate (no itemIds → null), delta flatten (single + synthetic multi-block), missing description |
+| 13 | `cli/src/core/references/SourceDefinitionRegistry.test.ts` | Extend `all()` stable-order (append `"monday"`); add a `monday registration` describe (claude `get_board_items_page` resolves; both codex paths resolve; enumeration/write tools do not) |
+| 14 | `cli/src/core/references/ClaudeEnvelopeParser.test.ts` | monday end-to-end: tool_use(input.itemIds)+tool_result → `monday:<id>`; board-browse (no itemIds) → nothing |
+| 15 | `cli/src/core/references/CodexEnvelopeParser.test.ts` | monday PRIMARY + FALLBACK paths using the real rollout arguments+output; no-itemIds → nothing |
+| 16 | `cli/src/core/references/bindings/codex/index.test.ts` | `mondayCodexBinding` canonicalToolName + normalize-with-toolInput |
+| 17 *(optional)* | `vscode/src/views/SummaryHtmlBuilder.ts` | Append `"monday"` to `HTML_REFERENCE_SOURCE_ORDER` if that list is exhaustive |
+
+**No edit needed:** `CLAUDE_TOOL_PREFIXES` (auto-derived), `SourceEngine.ts`,
+`SourceDefinition.ts` (no new op — delta flattening is in `normalizeMonday`, not
+the DSL), `ReferenceExtractor.ts`.
+
+## Testing
+
+- **`MondayNormalize.test.ts`**: itemIds gate (undefined/empty → null; present →
+  wrapper); delta flatten for Fixture A's single block; a synthetic multi-block /
+  multi-insert case; missing `item_description` (Fixture B) → no `description`; a
+  malformed-`content` block is skipped without throwing.
+- **`monday.test.ts`**: feed the normalized shape through `extractRef` +
+  `renderBlock` — assert source/nativeId/title/url/description/fields for A;
+  description-absent for B; void cases (missing `id`, non-monday host); render
+  `<monday-items><item …>`.
+- **Registry test**: stable-order list includes `"monday"`; claude
+  `get_board_items_page` and both codex match paths resolve to monday; write/
+  enumeration tools (`create_item`, `get_updates`, `get_board_info`, …) do not.
+- **Envelope tests** (Claude + Codex): end-to-end with real
+  arguments/output; the no-`itemIds` browse yields nothing on both hosts.
+- `npm run all` must pass (CLI 97% coverage floor). The parser change is the only
+  non-data code — covered by the two envelope tests (PRIMARY + FALLBACK, gated and
+  ungated).
+
+## Non-goals
+
+- monday boards, docs, updates, users, dashboards, widgets, or any non-item entity.
+- Surfacing `column_values` (status/owner/type/…) — board-specific keys.
+- monday write/enumeration/search tools.
+- Any change to the DSL op vocabulary or storage/render common layers.
+- Retroactive Codex input-threading for Slack / zoom-doc (out of scope; they stay
+  Claude-only unless separately revisited).

--- a/vscode/src/views/SourceLabels.ts
+++ b/vscode/src/views/SourceLabels.ts
@@ -47,6 +47,7 @@ export const SOURCE_META: Record<KnownSourceId, SourceMeta> = {
 	"zoom-meeting": { label: "Zoom Meeting", letter: "Z", icon: "device-camera-video", color: "#2D8CFF" },
 	"zoom-doc": { label: "Zoom Doc", letter: "Z", icon: "file", color: "#2D8CFF" },
 	asana: { label: "Asana", letter: "A", icon: "checklist", color: "#f06a6a" },
+	monday: { label: "monday.com", letter: "M", icon: "table", color: "#ff3d57" },
 };
 
 /** Neutral badge color for a source outside {@link SOURCE_META} (matches the prior `.mem-ctx-badge--reference` fallback hue). */


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Context (2)

- monday.com Reference Source Implementation Plan
- monday.com reference source — design

## Quick recap

The developer added monday.com as a reference source for Jolli Memory, enabling Claude Code and Codex sessions to capture monday items as working memory references when they are fetched by ID. The integration carefully gates reference extraction on the presence of `itemIds` in the tool input, preventing the API's 500-item page limit from flooding the reference system during board browse operations. Item descriptions are flattened from monday's nested Quill delta JSON format into plain text, and the system handles real-world data quirks like numeric-string id inconsistencies and plain-text description blocks alongside JSON-encoded content.

The implementation extends the Codex envelope parser to thread tool call arguments to normalizers, establishing a reusable pattern for future input-dependent sources on both Claude and Codex. A shared normalizer function ensures consistent behavior across both hosts, avoiding duplication and maintenance burden. The design was grounded in two real monday workspace fixtures rather than API documentation alone, ensuring the normalizer handles actual edge cases and prevents silent failures across different monday boards with varying column schemas.

---

## Topics (2)
<details>
<summary><strong>01 · Monday.com item reference source integration with input gating</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team needed to add monday.com as a reference source so that when Claude Code or Codex sessions fetch monday items by ID, those items are automatically captured as references in Jolli Memory, matching the existing behavior for Linear, Jira, GitHub, and other platforms.

**💡 Decisions Behind the Code**

- **Context-normalizer tier, not pure DSL**: monday's `get_board_items_page` tool serves both targeted `itemIds` fetches and whole-board browses (up to 500 items). Tool-name matching alone cannot distinguish them, so the reference gate must read the tool input (`itemIds`). This mirrors Slack and zoom-doc, which also depend on input context. The alternative (pure DSL with no input awareness) would flood working memory on board browses.
- **Input-level gating over tool-level filtering**: The gate is placed on the normalizer's inspection of `itemIds` in the request rather than on the tool name itself. This allows the same `get_board_items_page` tool to serve both targeted fetches and exploratory board browsing, while the normalizer silently voids the latter. The alternative — blocking the tool entirely or post-processing all results — would either lose legitimate targeted queries or require expensive filtering downstream.
- **Codex parser extension to thread arguments**: Codex's envelope parser was extended to capture and pass tool call arguments to normalizers, enabling the same `itemIds` gate on both Claude and Codex paths. This required threading `arguments` through `FunctionCallRow` and joining by `call_id`, but ensures monday works symmetrically on both hosts and establishes a pattern for future input-dependent sources on Codex.
- **Shared normalizer across both hosts**: The same `normalizeMonday()` function is used by both Claude and Codex envelope parsers, with each host reading `itemIds` from its own tool input format and passing it to the normalizer. This avoids duplication and ensures consistent behavior across hosts.
- **Delta-format flattening in the normalizer, not the DSL**: monday's `item_description.blocks[].content` is a JSON string holding Quill delta format, which the DSL's dotted path syntax cannot parse. Following the Confluence precedent, the flatten logic lives in the normalizer so the definition remains pure DSL, keeping the two concerns separate and testable.

**✅ What Was Implemented**

- Created `MondayNormalize.ts` with `normalizeMonday()` and `readItemIds()` functions that gate reference capture on targeted item fetches (non-empty `itemIds` in tool input) and flatten Quill delta-format descriptions into plain text. Board browse calls without `itemIds` produce no reference, preventing flood from large result sets.
- Implemented `mondayDefinition` as a pure DSL definition that extracts monday item fields (id, name, url, description, board) and renders them as references with stable fields (entity type and board name). The definition matches both Claude (`mcp__claude_ai_monday_com__get_board_items_page`) and Codex (`_get_board_items_page` under `monday_com` namespace) tool invocations.
- Wired the normalizer into both envelope parsers: Claude's `CONTEXT_NORMALIZERS` registry and a new `CodexMondayBinding` in the Codex normalizer registry. Extended `CodexEnvelopeParser` to retain and thread `function_call` `arguments` to gating normalizers, allowing Codex to read `itemIds` from request parameters just as Claude does.
- Hardened the implementation against real-world edge cases: item ids are accepted as both numbers and numeric strings (since the API serializes them inconsistently), plain-text description blocks are preserved rather than dropped, and the URL host regex was widened to accept multi-label subdomains. All changes are covered by new test cases.

**📁 FILES**
- `cli/src/core/references/sources/MondayNormalize.ts`
- `cli/src/core/references/sources/definitions/monday.ts`
- `cli/src/core/references/CodexEnvelopeParser.ts`
- `cli/src/core/references/ClaudeEnvelopeParser.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Design specification and implementation plan for monday reference extraction</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team needed a comprehensive design specification and implementation plan to guide the monday.com integration, grounded in real monday workspace fixtures and covering the full touch list of files, test coverage strategy, and architectural decisions.

**💡 Decisions Behind the Code**

- **Fixture-driven design over guessed shapes**: Rather than inferring monday's data structure from documentation, the specification was grounded in two real captured payloads from the monday MCP connector and Codex rollout. This ensures the normalizer handles actual edge cases (missing `item_description`, board-specific `column_values` keys) and prevents silent failures when deployed to different monday boards with different column schemas.
- **Minimal, honest field surface**: Only stable top-level API fields (`id`, `name`, `url`, `created_at`, `updated_at`, `board`) are surfaced as reference metadata. Board-specific `column_values` (status, owner, type, etc.) are deliberately excluded because their keys vary per board and a static DSL path would work on one board and silently fail on the next, violating the principle that references should be reliable across all instances of a source.

**✅ What Was Implemented**

- Created a comprehensive design specification (`docs/superpowers/specs/2026-07-14-monday-reference-source-design.md`) that establishes monday as a context-normalizer source (not pure DSL) because it lacks a single-item getter tool and encodes descriptions as doubly-nested JSON. The specification introduces an anti-flood gate that extracts references only from targeted item fetches, not board browsing operations.
- Designed an architectural extension that threads tool call arguments through the Codex envelope parser, enabling the `itemIds` gate to work on Codex in addition to Claude and establishing a reusable pattern for future input-dependent sources.
- Produced a detailed implementation plan (`docs/superpowers/plans/2026-07-14-monday-reference-source.md`) with five concrete tasks: normalizer + itemIds gate, definition + registration, Claude envelope wiring, Codex parser extension, and final verification. Each task includes failing tests, implementation code, and integration points.
- Pinned two real fixtures from an actual monday workspace (Tasks board item with description, Subitems board item without description) to serve as authoritative truth sources for the implementation, ensuring the normalizer handles both the happy path and edge cases like missing `item_description` fields.
- Specified comprehensive test coverage across 6 test files covering itemIds gating, delta flattening, missing descriptions, definition extraction and rendering, registry ordering, and end-to-end envelope tests for both Claude and Codex with real arguments and outputs.

**📁 FILES**
- `docs/superpowers/specs/2026-07-14-monday-reference-source-design.md`
- `docs/superpowers/plans/2026-07-14-monday-reference-source.md`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 14, 2026 at 10:44 PM · via Anthropic*
<!-- jollimemory-summary-end -->
