### PR TITLE
Add synchronous batch push support to pre-push sync

### DIFF
--- a/cli/src/Api.test.ts
+++ b/cli/src/Api.test.ts
@@ -142,6 +142,10 @@ vi.mock("./auth/Login.js", () => ({
 	browserLogin: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("./hooks/PushCompensation.js", () => ({
+	triggerPendingPushRetry: vi.fn().mockResolvedValue(undefined),
+}));
+
 // Mock all dependencies
 vi.mock("./install/Installer.js", () => ({
 	install: vi.fn().mockResolvedValue({
@@ -302,6 +306,26 @@ vi.mock("./core/TopicIndexStore.js", () => ({
 }));
 vi.mock("./core/TopicPageStore.js", () => ({
 	purgeTopicPagesExcept: vi.fn(async () => []),
+}));
+
+vi.mock("./sync/VaultWriteLock.js", () => {
+	class VaultWriteBusyError extends Error {}
+	return {
+		DEFAULT_VAULT_WRITE_WAIT_MS: 0,
+		VaultWriteBusyError,
+		withVaultWriteLock: vi.fn(async (_root: string, _mode: unknown, body: () => Promise<unknown>) => ({
+			ran: true,
+			value: await body(),
+		})),
+	};
+});
+
+vi.mock("./sync/SyncBootstrap.js", () => ({
+	deriveMemoryBankRoot: vi.fn(() => "/mock/vault"),
+}));
+
+vi.mock("./hooks/QueueWorker.js", () => ({
+	launchWorker: vi.fn(),
 }));
 
 vi.mock("./core/StorageFactory.js", () => ({
@@ -729,8 +753,10 @@ describe("CLI", () => {
 
 	describe("enable command", () => {
 		it("should call install", async () => {
+			const { triggerPendingPushRetry } = await import("./hooks/PushCompensation.js");
 			await main(["enable"]);
 			expect(install).toHaveBeenCalled();
+			expect(triggerPendingPushRetry).toHaveBeenCalledWith("/mock/project", "cli-enable");
 		});
 
 		it("should set exit code on failure", async () => {
@@ -5102,8 +5128,9 @@ describe("CLI", () => {
 			}
 		});
 
-		it("should call browserLogin on auth login", async () => {
+		it("should log in and trigger pending push compensation", async () => {
 			const { browserLogin } = await import("./auth/Login.js");
+			const { triggerPendingPushRetry } = await import("./hooks/PushCompensation.js");
 			vi.mocked(browserLogin).mockResolvedValueOnce(undefined);
 
 			await main(["auth", "login"]);
@@ -5112,6 +5139,7 @@ describe("CLI", () => {
 			// it appends `/login` and the cli_callback params internally.
 			expect(browserLogin).toHaveBeenCalledTimes(1);
 			expect(browserLogin).toHaveBeenCalledWith(expect.stringMatching(/^https:\/\/[^/]+$/));
+			expect(triggerPendingPushRetry).toHaveBeenCalledWith("/mock/project", "cli-auth-login");
 		});
 
 		it("should report Jolli API Key saved when login yields jolliApiKey", async () => {
@@ -5130,6 +5158,7 @@ describe("CLI", () => {
 
 		it("should handle login failure gracefully", async () => {
 			const { browserLogin } = await import("./auth/Login.js");
+			const { triggerPendingPushRetry } = await import("./hooks/PushCompensation.js");
 			vi.mocked(browserLogin).mockRejectedValueOnce(new Error("Connection refused"));
 			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -5138,6 +5167,7 @@ describe("CLI", () => {
 
 				expect(errorSpy).toHaveBeenCalledWith("\n  Login failed:", "Connection refused");
 				expect(process.exitCode).toBe(1);
+				expect(triggerPendingPushRetry).not.toHaveBeenCalled();
 			} finally {
 				errorSpy.mockRestore();
 			}

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -501,7 +501,7 @@ export interface CommitSummary {
 	readonly orphanedDocIds?: ReadonlyArray<number>;
 	/**
 	 * Commit hashes whose summaries had no `jolliDocId` at squash/merge time
-	 * (race: PrePushWorker hadn't written back the ID yet). Consumed at push
+	 * (race: the pre-push sync hadn't written back the ID yet). Consumed at push
 	 * time: re-read each hash, promote any now-present docId into
 	 * `orphanedDocIds` for cleanup, retain hashes still present in the shared
 	 * push-pending queue, and discard only hashes known not to be in flight.
@@ -1124,9 +1124,11 @@ export interface JolliMemoryConfig {
 	/**
 	 * Auto-push memory to Jolli Space on every `git push`. `undefined` = enabled
 	 * (default when logged in); `false` = disabled. The pre-push hook records
-	 * pushed commits into `.jolli/jollimemory/push-pending.json` and a detached
-	 * PrePushWorker syncs them to the bound Space. Complementary to the
-	 * PR-level `push_memory` flow — same idempotent server path, no duplicates.
+	 * pushed commits into `.jolli/jollimemory/push-pending.json` and syncs the
+	 * ones with generated memory to the bound Space synchronously (budget-bound
+	 * batch request); the rest follow via the compensation channels.
+	 * Complementary to the PR-level `push_memory` flow — same idempotent server
+	 * path, no duplicates.
 	 */
 	readonly syncOnPush?: boolean;
 	/**

--- a/cli/src/commands/AuthCommand.ts
+++ b/cli/src/commands/AuthCommand.ts
@@ -8,6 +8,8 @@ import { clearAuthCredentials, getJolliUrl, loadAuthToken } from "../auth/AuthCo
 import { browserLogin } from "../auth/Login.js";
 import { loadConfig } from "../core/SessionTracker.js";
 import { track } from "../core/Telemetry.js";
+import { triggerPendingPushRetry } from "../hooks/PushCompensation.js";
+import { resolveProjectDir } from "./CliUtils.js";
 
 export function registerAuthCommands(program: Command): void {
 	const auth = program
@@ -22,6 +24,7 @@ export function registerAuthCommands(program: Command): void {
 			try {
 				await browserLogin(getJolliUrl());
 				const config = await loadConfig();
+				triggerPendingPushRetry(resolveProjectDir(), "cli-auth-login");
 				console.log("\n  Signed in successfully!");
 				console.log("  Auth token:        saved ✓");
 				if (config.jolliApiKey) {

--- a/cli/src/commands/EnableCommand.ts
+++ b/cli/src/commands/EnableCommand.ts
@@ -204,7 +204,7 @@ export function registerEnableCommand(program: Command): void {
 				// integrations-only mode (IntelliJ manages its own hook/worker). Fully
 				// guarded — never throws, no-ops when nothing is pending or not signed in.
 				if (!options.integrationsOnly) {
-					void triggerPendingPushRetry(options.cwd);
+					triggerPendingPushRetry(options.cwd, "cli-enable");
 				}
 
 				// Historical back-fill is no longer kicked off automatically at enable

--- a/cli/src/commands/GuidedFrontDoor.test.ts
+++ b/cli/src/commands/GuidedFrontDoor.test.ts
@@ -120,7 +120,7 @@ describe("GuidedFrontDoor", () => {
 		await runGuidedFrontDoor();
 
 		expect(h.install).not.toHaveBeenCalled();
-		expect(h.triggerPendingPushRetry).toHaveBeenCalledWith("/repo");
+		expect(h.triggerPendingPushRetry).toHaveBeenCalledWith("/repo", "cli-front-door");
 		expect(h.runSpaceSyncStep).toHaveBeenCalledWith("/repo");
 		expect(out()).toContain("signed in · acme.jolli.ai");
 		expect(out()).toContain("3 memories");
@@ -143,7 +143,7 @@ describe("GuidedFrontDoor", () => {
 		completeSpaceSync();
 		await frontDoor;
 
-		expect(h.triggerPendingPushRetry).toHaveBeenCalledWith("/repo");
+		expect(h.triggerPendingPushRetry).toHaveBeenCalledWith("/repo", "cli-front-door");
 	});
 
 	it("first-run copy when summaryCount is 0", async () => {
@@ -221,7 +221,7 @@ describe("GuidedFrontDoor", () => {
 
 		expect(h.install).toHaveBeenCalledWith("/repo", { source: "cli" });
 		expect(h.track).toHaveBeenCalledWith("surface_enabled", { trigger: "cli" });
-		expect(h.triggerPendingPushRetry).toHaveBeenCalledWith("/repo");
+		expect(h.triggerPendingPushRetry).toHaveBeenCalledWith("/repo", "cli-front-door");
 		expect(h.runSpaceSyncStep).toHaveBeenCalledWith("/repo");
 		expect(out()).toContain("5 memories");
 		expect(out()).toContain("signed in");
@@ -303,7 +303,7 @@ describe("GuidedFrontDoor", () => {
 		expect(h.promptSetup).toHaveBeenCalledTimes(1);
 		expect(out()).toContain("signed in");
 		expect(out()).toContain("Jolli is listening");
-		expect(h.triggerPendingPushRetry).toHaveBeenCalledWith("/repo");
+		expect(h.triggerPendingPushRetry).toHaveBeenCalledWith("/repo", "cli-front-door");
 	});
 
 	// ── Rung 2: optional sign-in nudge (local key, cannot sync) ──

--- a/cli/src/commands/GuidedFrontDoor.ts
+++ b/cli/src/commands/GuidedFrontDoor.ts
@@ -165,7 +165,7 @@ export async function runGuidedFrontDoor(): Promise<void> {
 	// Space first (runSpaceSyncStep), then push the backlog to it —
 	// triggerPendingPushRetry is idempotent and no-ops when not signed in. ──
 	await runSpaceSyncStep(cwd);
-	void triggerPendingPushRetry(cwd);
+	triggerPendingPushRetry(cwd, "cli-front-door");
 
 	// ── Closing confirmation: only promise "listening" when generation works. ──
 	if (canGenerate) {

--- a/cli/src/core/JolliMemoryPushClient.test.ts
+++ b/cli/src/core/JolliMemoryPushClient.test.ts
@@ -7,11 +7,14 @@ const loadConfigMock = vi.fn(async () => ({ jolliApiKey: "sk-jol-cfg" }) as { jo
 vi.mock("./SessionTracker.js", () => ({ loadConfig: () => loadConfigMock() }));
 
 import {
+	type BatchPushPayload,
+	BatchUnsupportedError,
 	BindingAlreadyExistsError,
 	BindingRequiredError,
 	ClientOutdatedError,
 	JolliMemoryPushClient,
 	NotAuthenticatedError,
+	PermissionDeniedError,
 	type PlatformToolManifestEntry,
 } from "./JolliMemoryPushClient.js";
 
@@ -375,6 +378,16 @@ describe("push", () => {
 		await expect(
 			c.push({ title: "t", content: "c", commitHash: "abc1234", docType: "summary" }),
 		).rejects.toBeInstanceOf(BindingAlreadyExistsError);
+	});
+	it("maps 401 to NotAuthenticatedError and 403 to PermissionDeniedError", async () => {
+		const unauthorized = client(async () => jsonResponse(401, { error: "unauthorized" }));
+		await expect(
+			unauthorized.push({ title: "t", content: "c", commitHash: "abc1234", docType: "summary" }),
+		).rejects.toBeInstanceOf(NotAuthenticatedError);
+		const forbidden = client(async () => jsonResponse(403, { error: "Insufficient space permissions" }));
+		await expect(
+			forbidden.push({ title: "t", content: "c", commitHash: "abc1234", docType: "summary" }),
+		).rejects.toBeInstanceOf(PermissionDeniedError);
 	});
 	it("throws a plain Error on a generic non-2xx", async () => {
 		const c = client(async () => jsonResponse(500, { error: "boom" }));
@@ -952,5 +965,137 @@ describe("invokePlatformTool", () => {
 		expect(capturedMethod).toBe("POST");
 		expect(capturedUrl).toBe("https://jolli.ai/api/mcp/tools/list_tickets");
 		expect(capturedBody).toBe(JSON.stringify({ status: "open" }));
+	});
+});
+
+describe("pushBatch", () => {
+	const payload: BatchPushPayload = {
+		repoUrl: "https://github.com/acme/repo",
+		items: [
+			{
+				commitHash: "a".repeat(40),
+				branch: "main",
+				summary: { title: "feat: one", content: "# body" },
+				attachments: [],
+			},
+		],
+	};
+
+	it("returns validated per-item results on 200", async () => {
+		const c = client(async () =>
+			jsonResponse(200, {
+				results: [
+					{
+						commitHash: "a".repeat(40),
+						ok: true,
+						summary: { docId: 9, url: "/articles/one-9", jrn: "jrn:9", created: true },
+						attachments: [{ clientKey: "plan-0", ok: true, docId: 10, url: "/articles/p-10" }],
+					},
+				],
+			}),
+		);
+		const r = await c.pushBatch(payload);
+		expect(r.results).toHaveLength(1);
+		expect(r.results[0]).toMatchObject({ commitHash: "a".repeat(40), ok: true });
+		expect(r.results[0].summary).toEqual({ docId: 9, url: "/articles/one-9", jrn: "jrn:9", created: true });
+		expect(r.results[0].attachments[0]).toMatchObject({ clientKey: "plan-0", ok: true, docId: 10 });
+	});
+
+	it("downgrades an ok:true attachment without docId/url to a failure (contract drift guard)", async () => {
+		const c = client(async () =>
+			jsonResponse(200, {
+				results: [
+					{
+						commitHash: "a".repeat(40),
+						ok: true,
+						summary: { docId: 9, url: "/articles/one-9", jrn: "jrn:9", created: true },
+						attachments: [
+							{ clientKey: "plan-0", ok: true },
+							{ clientKey: "note-0", ok: true, docId: 12 },
+						],
+					},
+				],
+			}),
+		);
+		const r = await c.pushBatch(payload);
+		expect(r.results[0].attachments).toEqual([
+			{ clientKey: "plan-0", ok: false, error: "Batch attachment result was missing docId/url" },
+			{ clientKey: "note-0", ok: false, error: "Batch attachment result was missing docId/url" },
+		]);
+	});
+
+	it("maps 404 to BatchUnsupportedError (server predates the endpoint)", async () => {
+		const c = client(async () => jsonResponse(404, { error: "Not found" }));
+		await expect(c.pushBatch(payload)).rejects.toBeInstanceOf(BatchUnsupportedError);
+	});
+
+	it("maps 426 to ClientOutdatedError", async () => {
+		const c = client(async () => jsonResponse(426, { error: "client_outdated" }));
+		await expect(c.pushBatch(payload)).rejects.toBeInstanceOf(ClientOutdatedError);
+	});
+
+	it("maps 412 binding_required to BindingRequiredError carrying the repoUrl", async () => {
+		const c = client(async () =>
+			jsonResponse(412, { error: "binding_required", repoUrl: "https://github.com/acme/repo" }),
+		);
+		await expect(c.pushBatch(payload)).rejects.toBeInstanceOf(BindingRequiredError);
+	});
+
+	it("maps 401 to NotAuthenticatedError", async () => {
+		const c = client(async () => jsonResponse(401, { error: "unauthorized" }));
+		await expect(c.pushBatch(payload)).rejects.toBeInstanceOf(NotAuthenticatedError);
+	});
+
+	it("maps 403 to PermissionDeniedError (signed in, but no space permission)", async () => {
+		const c = client(async () =>
+			jsonResponse(403, { error: "Insufficient space permissions", requiredPermission: "articles.edit" }),
+		);
+		await expect(c.pushBatch(payload)).rejects.toBeInstanceOf(PermissionDeniedError);
+	});
+
+	it("throws on a generic non-2xx with the server message", async () => {
+		const c = client(async () => jsonResponse(500, { error: "Batch push failed" }));
+		await expect(c.pushBatch(payload)).rejects.toThrow("Batch push failed");
+	});
+
+	it("rejects a 2xx whose body has no results array (gateway/HTML body)", async () => {
+		const c = client(async () => textResponse(200, "<html>gateway</html>"));
+		await expect(c.pushBatch(payload)).rejects.toThrow(/missing results/);
+	});
+
+	it("rejects a garbage result entry outright", async () => {
+		const c = client(async () => jsonResponse(200, { results: [42] }));
+		await expect(c.pushBatch(payload)).rejects.toThrow(/malformed/);
+	});
+
+	it("downgrades an ok item with unusable summary fields to a failure (never delete blind)", async () => {
+		const c = client(async () =>
+			jsonResponse(200, {
+				results: [{ commitHash: "a".repeat(40), ok: true, summary: { docId: "nope" }, attachments: [] }],
+			}),
+		);
+		const r = await c.pushBatch(payload);
+		expect(r.results[0].ok).toBe(false);
+		expect(r.results[0].errorCode).toBe("malformed_response");
+	});
+
+	it("keeps failed items with their error/errorCode and filters malformed attachments", async () => {
+		const c = client(async () =>
+			jsonResponse(200, {
+				results: [
+					{
+						commitHash: "a".repeat(40),
+						ok: false,
+						error: "boom",
+						errorCode: "push_failed",
+						attachments: [{ clientKey: "k", ok: false, error: "att boom" }, { bogus: true }],
+					},
+				],
+			}),
+		);
+		const r = await c.pushBatch(payload);
+		expect(r.results[0]).toMatchObject({ ok: false, error: "boom", errorCode: "push_failed" });
+		expect(r.results[0].attachments).toHaveLength(1);
+		expect(r.results[0].attachments[0]).toMatchObject({ clientKey: "k", ok: false, error: "att boom" });
 	});
 });

--- a/cli/src/core/JolliMemoryPushClient.ts
+++ b/cli/src/core/JolliMemoryPushClient.ts
@@ -16,10 +16,13 @@
  * VS Code `BindingInfo` type suggesting one.
  */
 
+import { createLogger } from "../Logger.js";
 import { JOLLI_CLIENT_HEADER } from "./ClientHeader.js";
 import { deriveJolliEnvKey, type JolliApiKeyMeta, parseBaseUrl, parseJolliApiKey } from "./JolliApiUtils.js";
 import { loadConfig } from "./SessionTracker.js";
 import { currentTraceHeader, newTraceHeader, TRACE_HEADER_NAME } from "./TraceContext.js";
+
+const log = createLogger("JolliMemoryPushClient");
 
 /** No `jolliApiKey` configured, or no Jolli URL could be resolved from it. */
 export class NotAuthenticatedError extends Error {
@@ -64,6 +67,32 @@ export class BindingRequiredError extends Error {
 		super(message ?? "binding_required");
 		this.name = "BindingRequiredError";
 		this.repoUrl = repoUrl;
+	}
+}
+
+/**
+ * `POST /api/push/jollimemory/batch` returned 404 — the server predates the
+ * batch endpoint. Callers leave their pending entries untouched (no retry
+ * burn) so a later server deploy picks them up.
+ */
+export class BatchUnsupportedError extends Error {
+	constructor(message?: string) {
+		super(message ?? "Jolli server does not support batch push yet");
+		this.name = "BatchUnsupportedError";
+	}
+}
+
+/**
+ * Server returned 403 — the API key is valid but lacks permission to write
+ * (no `articles.edit` on the bound Space, or a key scope restriction).
+ * Distinct from {@link NotAuthenticatedError} so user-facing surfaces (the
+ * pre-push result list) don't mislabel a permission problem as "not signed
+ * in". Config-class: retrying without a permission change cannot succeed.
+ */
+export class PermissionDeniedError extends Error {
+	constructor(message?: string) {
+		super(message ?? "No permission to write to the bound Jolli Space.");
+		this.name = "PermissionDeniedError";
 	}
 }
 
@@ -222,6 +251,96 @@ interface PushResponseBody {
 	readonly repoUrl?: string;
 }
 
+// ─── Batch push (POST /api/push/jollimemory/batch) ──────────────────────────
+
+/**
+ * Max commits per batch request. MUST stay in lockstep with the server's
+ * `BATCH_MAX_ITEMS` (`backend/src/router/PushRouter.ts`) — the server rejects
+ * larger payloads with 400.
+ */
+export const BATCH_MAX_ITEMS = 30;
+
+/**
+ * Remaining batch request limits. These MUST stay in lockstep with
+ * `BatchPushRequestSchema` in the server's `PushRouter.ts`.
+ */
+export const BATCH_MAX_ATTACHMENTS_PER_ITEM = 50;
+export const BATCH_MAX_CONTENT_CHARS = 2_000_000;
+export const BATCH_MAX_TOTAL_CONTENT_CHARS = 8_000_000;
+
+/** One attachment (plan/note/reference) inside a batch item. */
+export interface BatchPushAttachment {
+	readonly clientKey: string;
+	readonly docType: "plan" | "note" | "reference";
+	readonly title: string;
+	readonly content: string;
+	readonly relativePath?: string;
+	readonly docId?: number;
+}
+
+/** One commit's summary + owned attachments inside a batch payload. */
+export interface BatchPushItem {
+	readonly commitHash: string;
+	readonly branch?: string;
+	readonly summary: {
+		readonly title: string;
+		readonly content: string;
+		readonly relativePath?: string;
+		readonly docId?: number;
+		readonly summaryJson?: string;
+	};
+	readonly attachments: ReadonlyArray<BatchPushAttachment>;
+}
+
+/** Payload for `POST /api/push/jollimemory/batch`. */
+export interface BatchPushPayload {
+	readonly repoUrl?: string;
+	readonly items: ReadonlyArray<BatchPushItem>;
+}
+
+/** Per-attachment entry in a batch item result. */
+export interface BatchAttachmentResult {
+	readonly clientKey: string;
+	readonly ok: boolean;
+	readonly docId?: number;
+	readonly url?: string;
+	readonly jrn?: string;
+	readonly created?: boolean;
+	readonly error?: string;
+}
+
+/** Doc fields reported for a successfully pushed batch summary. */
+export interface BatchDocResult {
+	readonly docId: number;
+	readonly url: string;
+	readonly jrn: string;
+	readonly created: boolean;
+	readonly summaryJsonDocId?: number;
+}
+
+/** Per-item (= per-commit) entry of the batch response, in request order. */
+export interface BatchItemResult {
+	readonly commitHash: string;
+	readonly ok: boolean;
+	readonly summary?: BatchDocResult;
+	readonly attachments: ReadonlyArray<BatchAttachmentResult>;
+	readonly error?: string;
+	readonly errorCode?: string;
+}
+
+/** Validated response of `POST /api/push/jollimemory/batch`. */
+export interface BatchPushResult {
+	readonly results: ReadonlyArray<BatchItemResult>;
+}
+
+/** Raw shape of `POST /api/push/jollimemory/batch` — validated entry-by-entry. */
+interface BatchPushResponseBody {
+	readonly results?: unknown;
+	readonly error?: string;
+	readonly message?: string;
+	readonly repoUrl?: string;
+}
+
 export class JolliMemoryPushClient {
 	private readonly fetchImpl: typeof fetch;
 	private readonly baseUrlOverride?: string;
@@ -348,8 +467,11 @@ export class JolliMemoryPushClient {
 		if (status === 409 && json.error === "binding_already_exists") {
 			throw new BindingAlreadyExistsError(json.message ?? "binding_already_exists");
 		}
-		if (status === 401 || status === 403) {
+		if (status === 401) {
 			throw new NotAuthenticatedError();
+		}
+		if (status === 403) {
+			throw new PermissionDeniedError(errorMessage(json));
 		}
 		if (status < 200 || status >= 300) {
 			// Read `message ?? error` like listSpaces/createBinding (and the vscode
@@ -370,6 +492,59 @@ export class JolliMemoryPushClient {
 			created: json.created,
 			summaryJsonDocId: json.summaryJsonDocId,
 		};
+	}
+
+	/**
+	 * Pushes up to {@link BATCH_MAX_ITEMS} commits (one summary + its owned
+	 * plans/notes/references each) in a single `POST /api/push/jollimemory/batch`
+	 * request. Whole-request error taxonomy mirrors {@link push}; 404 maps to
+	 * {@link BatchUnsupportedError} so the pre-push flow can leave its entries
+	 * pending instead of burning retries against a server that predates the
+	 * endpoint. Per-item success/failure is reported in `results` (request
+	 * order), HTTP 200 even on partial failure.
+	 */
+	async pushBatch(payload: BatchPushPayload): Promise<BatchPushResult> {
+		const { status, json } = await this.call<BatchPushResponseBody>("POST", "/api/push/jollimemory/batch", payload);
+		if (status === 404) {
+			throw new BatchUnsupportedError();
+		}
+		if (status === 426) {
+			throw new ClientOutdatedError(errorMessage(json) ?? "Client outdated — update the CLI/extension.");
+		}
+		if (status === 412 && json.error === "binding_required") {
+			throw new BindingRequiredError(json.repoUrl ?? payload.repoUrl ?? "", json.message);
+		}
+		if (status === 401) {
+			throw new NotAuthenticatedError();
+		}
+		if (status === 403) {
+			throw new PermissionDeniedError(errorMessage(json));
+		}
+		if (status < 200 || status >= 300) {
+			throw new Error(errorMessage(json) ?? `HTTP ${status}`);
+		}
+		if (!Array.isArray(json.results)) {
+			// Same rationale as push(): a 2xx with a gateway/HTML body must not be
+			// mistaken for "everything pushed" — the caller would delete pending
+			// entries it never actually synced.
+			throw new Error(`Batch push returned HTTP ${status} but the response was missing results`);
+		}
+		const results: BatchItemResult[] = [];
+		for (const entry of json.results) {
+			const item = toBatchItemResult(entry);
+			if (!item) {
+				throw new Error(`Batch push returned HTTP ${status} but a result entry was malformed`);
+			}
+			results.push(item);
+		}
+		const okCount = results.filter((r) => r.ok).length;
+		log.debug(
+			"pushBatch: %d item(s) sent — ok=%d failed=%d",
+			payload.items.length,
+			okCount,
+			results.length - okCount,
+		);
+		return { results };
 	}
 
 	/**
@@ -553,6 +728,123 @@ export class JolliMemoryPushClient {
 			clearTimeout(timer);
 		}
 	}
+}
+
+/** Field-by-field validation of one batch summary doc result; undefined on shape mismatch. */
+function toBatchDocResult(value: unknown): BatchDocResult | undefined {
+	if (typeof value !== "object" || value === null) {
+		return undefined;
+	}
+	const raw = value as {
+		docId?: unknown;
+		url?: unknown;
+		jrn?: unknown;
+		created?: unknown;
+		summaryJsonDocId?: unknown;
+	};
+	if (typeof raw.docId !== "number" || typeof raw.url !== "string" || typeof raw.jrn !== "string") {
+		return undefined;
+	}
+	return {
+		docId: raw.docId,
+		url: raw.url,
+		jrn: raw.jrn,
+		created: raw.created === true,
+		...(typeof raw.summaryJsonDocId === "number" && { summaryJsonDocId: raw.summaryJsonDocId }),
+	};
+}
+
+/**
+ * Field-by-field validation of one batch attachment result; undefined on shape
+ * mismatch. An `ok: true` entry without a usable docId/url is DOWNGRADED to a
+ * failure — same rationale as {@link toBatchItemResult}'s summary downgrade: a
+ * malformed success would silently skip the write-back and re-CREATE the
+ * attachment on the next push.
+ */
+function toBatchAttachmentResult(value: unknown): BatchAttachmentResult | undefined {
+	if (typeof value !== "object" || value === null) {
+		return undefined;
+	}
+	const raw = value as {
+		clientKey?: unknown;
+		ok?: unknown;
+		docId?: unknown;
+		url?: unknown;
+		jrn?: unknown;
+		created?: unknown;
+		error?: unknown;
+	};
+	if (typeof raw.clientKey !== "string" || typeof raw.ok !== "boolean") {
+		return undefined;
+	}
+	if (raw.ok && (typeof raw.docId !== "number" || typeof raw.url !== "string")) {
+		return {
+			clientKey: raw.clientKey,
+			ok: false,
+			error: "Batch attachment result was missing docId/url",
+		};
+	}
+	return {
+		clientKey: raw.clientKey,
+		ok: raw.ok,
+		...(typeof raw.docId === "number" && { docId: raw.docId }),
+		...(typeof raw.url === "string" && { url: raw.url }),
+		...(typeof raw.jrn === "string" && { jrn: raw.jrn }),
+		...(typeof raw.created === "boolean" && { created: raw.created }),
+		...(typeof raw.error === "string" && { error: raw.error }),
+	};
+}
+
+/**
+ * Field-by-field validation of one batch item result. An `ok: true` entry whose
+ * summary fields are unusable is DOWNGRADED to a failure (not dropped): the
+ * caller must keep that commit pending rather than delete it blind on a
+ * malformed success. Returns undefined only when the entry itself is garbage.
+ */
+function toBatchItemResult(value: unknown): BatchItemResult | undefined {
+	if (typeof value !== "object" || value === null) {
+		return undefined;
+	}
+	const raw = value as {
+		commitHash?: unknown;
+		ok?: unknown;
+		summary?: unknown;
+		attachments?: unknown;
+		error?: unknown;
+		errorCode?: unknown;
+	};
+	if (typeof raw.commitHash !== "string" || typeof raw.ok !== "boolean") {
+		return undefined;
+	}
+	const attachments: BatchAttachmentResult[] = [];
+	if (Array.isArray(raw.attachments)) {
+		for (const entry of raw.attachments) {
+			const attachment = toBatchAttachmentResult(entry);
+			if (attachment) {
+				attachments.push(attachment);
+			}
+		}
+	}
+	if (raw.ok) {
+		const summary = toBatchDocResult(raw.summary);
+		if (!summary) {
+			return {
+				commitHash: raw.commitHash,
+				ok: false,
+				attachments,
+				errorCode: "malformed_response",
+				error: "Batch item result was missing docId/url",
+			};
+		}
+		return { commitHash: raw.commitHash, ok: true, summary, attachments };
+	}
+	return {
+		commitHash: raw.commitHash,
+		ok: false,
+		attachments,
+		...(typeof raw.error === "string" && { error: raw.error }),
+		...(typeof raw.errorCode === "string" && { errorCode: raw.errorCode }),
+	};
 }
 
 function isErrorBody(value: unknown): value is ErrorResponseBody {

--- a/cli/src/core/JolliMemoryPushOrchestrator.test.ts
+++ b/cli/src/core/JolliMemoryPushOrchestrator.test.ts
@@ -21,6 +21,8 @@ vi.mock("./GitRemoteUtils.js", async (importOriginal) => {
 import { getDefaultBranch } from "./GitOps.js";
 import { buildBranchRelativePath, getCanonicalRepoUrl } from "./GitRemoteUtils.js";
 import {
+	BATCH_MAX_ATTACHMENTS_PER_ITEM,
+	type BatchItemResult,
 	BindingAlreadyExistsError,
 	BindingRequiredError,
 	ClientOutdatedError,
@@ -30,12 +32,15 @@ import {
 	type PushResult,
 } from "./JolliMemoryPushClient.js";
 import {
+	applyBatchResult,
 	applyNoteUrls,
 	applyPlanUrls,
 	applyReferenceUrls,
 	assignOwnedAttachments,
+	buildBatchItems,
 	buildPushMarkdown,
 	canReuseDocId,
+	docUrlPlaceholder,
 	latestPlanPerName,
 	type PushContext,
 	pushBranchToJolli,
@@ -1593,5 +1598,399 @@ describe("pushBranchToJolli", () => {
 		vi.mocked(getCanonicalRepoUrl).mockRejectedValue(new Error("stop before any network call"));
 		const result = await pushBranchToJolli({ cwd: "/repo" });
 		expect(result.type).toBe("error");
+	});
+});
+
+// ─── Batch push helpers ──────────────────────────────────────────────────────
+
+describe("docUrlPlaceholder", () => {
+	it("builds the lockstep placeholder shape", () => {
+		expect(docUrlPlaceholder("plan-0")).toBe("{{jolli:doc:plan-0}}");
+	});
+});
+
+describe("buildBatchItems", () => {
+	beforeEach(() => {
+		vi.mocked(readPlanFromBranch).mockReset().mockResolvedValue(null);
+		vi.mocked(readNoteFromBranch).mockReset().mockResolvedValue(null);
+		vi.mocked(readReferenceFromBranch).mockReset().mockResolvedValue(null);
+	});
+
+	function owned(overrides: {
+		plans?: Map<string, ReadonlyArray<PlanReference>>;
+		notes?: Map<string, ReadonlyArray<NoteReference>>;
+		references?: Map<string, ReadonlyArray<ReferenceCommitRef>>;
+	}) {
+		return {
+			ownedPlans: overrides.plans ?? new Map(),
+			ownedNotes: overrides.notes ?? new Map(),
+			ownedReferences: overrides.references ?? new Map(),
+		};
+	}
+
+	it("builds one item per summary with placeholder-woven markdown and attachment keys", async () => {
+		const summary = leaf({ plans: [plan()] });
+		vi.mocked(readPlanFromBranch).mockResolvedValue("# Plan body");
+		const ctx = baseCtx(fakeClient());
+
+		const built = await buildBatchItems(
+			[summary],
+			owned({ plans: new Map([[summary.commitHash, [plan()]]]) }),
+			ctx,
+		);
+
+		expect(built).toHaveLength(1);
+		const item = built[0].item;
+		expect(item.commitHash).toBe(summary.commitHash);
+		expect(item.branch).toBe(summary.branch);
+		expect(item.attachments).toHaveLength(1);
+		expect(item.attachments[0]).toMatchObject({ clientKey: "plan-0", docType: "plan", content: "# Plan body" });
+		// The placeholder is woven into the summary markdown where the plan URL goes.
+		expect(item.summary.content).toContain(docUrlPlaceholder("plan-0"));
+		// Write-back bookkeeping maps the clientKey to the plan's slug.
+		expect(built[0].attachmentKeys.get("plan-0")).toEqual({ kind: "plan", key: "p1" });
+		expect(built[0].batchContentChars).toBe(
+			item.summary.content.length + (item.summary.summaryJson?.length ?? 0) + item.attachments[0].content.length,
+		);
+		expect(built[0].batchIneligibleReason).toBeUndefined();
+	});
+
+	it("marks an item with too many attachments for the per-commit fallback", async () => {
+		const plans = Array.from({ length: BATCH_MAX_ATTACHMENTS_PER_ITEM + 1 }, (_, index) =>
+			plan({ slug: `p-${index}` }),
+		);
+		const summary = leaf({ plans });
+		vi.mocked(readPlanFromBranch).mockResolvedValue("# Plan body");
+
+		const built = await buildBatchItems(
+			[summary],
+			owned({ plans: new Map([[summary.commitHash, plans]]) }),
+			baseCtx(fakeClient()),
+		);
+
+		expect(built[0].item.attachments).toHaveLength(BATCH_MAX_ATTACHMENTS_PER_ITEM + 1);
+		expect(built[0].batchIneligibleReason).toBe("attachment count exceeds the batch limit");
+	});
+
+	it("skips a plan whose content is unreadable (no attachment, no placeholder)", async () => {
+		const summary = leaf({ plans: [plan()] });
+		vi.mocked(readPlanFromBranch).mockResolvedValue(null);
+		const ctx = baseCtx(fakeClient());
+
+		const built = await buildBatchItems(
+			[summary],
+			owned({ plans: new Map([[summary.commitHash, [plan()]]]) }),
+			ctx,
+		);
+
+		expect(built[0].item.attachments).toHaveLength(0);
+		expect(built[0].item.summary.content).not.toContain("{{jolli:doc:");
+	});
+
+	it("carries a reusable docId when the stored doc URL matches the push env", async () => {
+		const summary = leaf({ plans: [plan()] });
+		vi.mocked(readPlanFromBranch).mockResolvedValue("# Plan body");
+		const reusable = plan({ jolliPlanDocId: 42, jolliPlanDocUrl: `${BASE}/articles/p-42` });
+		const ctx = baseCtx(fakeClient());
+
+		const built = await buildBatchItems(
+			[summary],
+			owned({ plans: new Map([[summary.commitHash, [reusable]]]) }),
+			ctx,
+		);
+
+		expect(built[0].item.attachments[0].docId).toBe(42);
+	});
+
+	it("drops a docId minted on a different backend (env mismatch)", async () => {
+		const summary = leaf({ plans: [plan()] });
+		vi.mocked(readPlanFromBranch).mockResolvedValue("# Plan body");
+		const foreign = plan({ jolliPlanDocId: 42, jolliPlanDocUrl: "https://other.jolli.dev/articles/p-42" });
+		const ctx = baseCtx(fakeClient());
+
+		const built = await buildBatchItems(
+			[summary],
+			owned({ plans: new Map([[summary.commitHash, [foreign]]]) }),
+			ctx,
+		);
+
+		expect(built[0].item.attachments[0].docId).toBeUndefined();
+	});
+
+	it("carries the summary's own reusable docId and summaryJson", async () => {
+		const summary = leaf({ jolliDocId: 7, jolliDocUrl: `${BASE}/articles/s-7` });
+		const ctx = baseCtx(fakeClient());
+
+		const built = await buildBatchItems([summary], owned({}), ctx);
+
+		expect(built[0].item.summary.docId).toBe(7);
+		expect(built[0].item.summary.summaryJson).toBeDefined();
+	});
+
+	it("reads note bodies from the inline content field without hitting storage", async () => {
+		const summary = leaf({ notes: [note({ content: "inline note body" })] });
+		const ctx = baseCtx(fakeClient());
+
+		const built = await buildBatchItems(
+			[summary],
+			owned({ notes: new Map([[summary.commitHash, [note({ content: "inline note body" })]]]) }),
+			ctx,
+		);
+
+		expect(built[0].item.attachments[0]).toMatchObject({
+			clientKey: "note-0",
+			docType: "note",
+			content: "inline note body",
+		});
+		expect(readNoteFromBranch).not.toHaveBeenCalled();
+	});
+});
+
+describe("applyBatchResult", () => {
+	beforeEach(() => {
+		vi.mocked(storeSummary).mockReset().mockResolvedValue(undefined);
+		vi.mocked(getIndexEntryMap).mockReset().mockResolvedValue(new Map());
+		vi.mocked(getSummary).mockReset().mockResolvedValue(null);
+		vi.mocked(loadPushPending).mockReset().mockResolvedValue({ version: 1, entries: {} });
+		vi.mocked(readPlanFromBranch).mockReset().mockResolvedValue("# Plan body");
+		vi.mocked(readNoteFromBranch).mockReset().mockResolvedValue(null);
+		vi.mocked(readReferenceFromBranch).mockReset().mockResolvedValue(null);
+	});
+
+	async function buildOne(summary: CommitSummary, plans: ReadonlyArray<PlanReference> = []) {
+		const ctx = baseCtx(fakeClient());
+		const built = await buildBatchItems(
+			[summary],
+			{
+				ownedPlans: new Map(plans.length > 0 ? [[summary.commitHash, plans]] : []),
+				ownedNotes: new Map(),
+				ownedReferences: new Map(),
+			},
+			ctx,
+		);
+		return { ctx, built };
+	}
+
+	function okResult(summary: CommitSummary, attachments: BatchItemResult["attachments"] = []): BatchItemResult {
+		return {
+			commitHash: summary.commitHash,
+			ok: true,
+			summary: { docId: 9, url: "/articles/s-9", jrn: "jrn:9", created: true },
+			attachments,
+		};
+	}
+
+	it("writes back the summary docId/url and woven attachment URLs on success", async () => {
+		const summary = leaf({ plans: [plan()] });
+		const { ctx, built } = await buildOne(summary, [plan()]);
+
+		const outcome = await applyBatchResult(
+			built,
+			[okResult(summary, [{ clientKey: "plan-0", ok: true, docId: 11, url: "/articles/p-11" }])],
+			ctx,
+		);
+
+		expect(outcome).toEqual({ writtenBack: 1, childSkipped: 0 });
+		expect(storeSummary).toHaveBeenCalledTimes(1);
+		const stored = vi.mocked(storeSummary).mock.calls[0][0] as CommitSummary;
+		expect(stored.jolliDocId).toBe(9);
+		expect(stored.jolliDocUrl).toBe(`${BASE}/articles/s-9`);
+		expect(stored.plans?.[0]).toMatchObject({ jolliPlanDocId: 11, jolliPlanDocUrl: `${BASE}/articles/p-11` });
+	});
+
+	it("deletes the freshly-pushed article and skips write-back when the commit became a child mid-push", async () => {
+		const summary = leaf();
+		const { ctx, built } = await buildOne(summary);
+		vi.mocked(getIndexEntryMap).mockResolvedValue(
+			new Map([
+				[
+					summary.commitHash,
+					{
+						commitHash: summary.commitHash,
+						parentCommitHash: "def4567890",
+						commitMessage: "",
+						commitDate: "",
+						branch: summary.branch,
+						generatedAt: "",
+					},
+				],
+			]),
+		);
+
+		const outcome = await applyBatchResult(built, [okResult(summary)], ctx);
+
+		expect(outcome).toEqual({ writtenBack: 0, childSkipped: 1 });
+		expect(ctx.client.deleteDoc).toHaveBeenCalledWith(9);
+		expect(storeSummary).not.toHaveBeenCalled();
+	});
+
+	it("deletes only the CREATEd attachments alongside the article on the mid-push child guard", async () => {
+		const summary = leaf();
+		const { ctx, built } = await buildOne(summary);
+		vi.mocked(getIndexEntryMap).mockResolvedValue(
+			new Map([
+				[
+					summary.commitHash,
+					{
+						commitHash: summary.commitHash,
+						parentCommitHash: "def4567890",
+						commitMessage: "",
+						commitDate: "",
+						branch: summary.branch,
+						generatedAt: "",
+					},
+				],
+			]),
+		);
+
+		const outcome = await applyBatchResult(
+			built,
+			[
+				okResult(summary, [
+					{ clientKey: "plan-0", ok: true, docId: 11, url: "/articles/p-11", created: true },
+					{ clientKey: "note-0", ok: true, docId: 12, url: "/articles/n-12", created: false },
+					{ clientKey: "note-1", ok: true, created: true },
+					{ clientKey: "ref-0", ok: false, error: "boom" },
+				]),
+			],
+			ctx,
+		);
+
+		expect(outcome).toEqual({ writtenBack: 0, childSkipped: 1 });
+		expect(ctx.client.deleteDoc).toHaveBeenCalledWith(9);
+		expect(ctx.client.deleteDoc).toHaveBeenCalledWith(11);
+		expect(ctx.client.deleteDoc).toHaveBeenCalledTimes(2);
+		expect(storeSummary).not.toHaveBeenCalled();
+	});
+
+	it("tolerates a best-effort delete failure on the mid-push child guard", async () => {
+		const summary = leaf();
+		const ctx = baseCtx(fakeClient({ deleteDoc: async () => Promise.reject(new Error("network")) }));
+		const built = await buildBatchItems(
+			[summary],
+			{ ownedPlans: new Map(), ownedNotes: new Map(), ownedReferences: new Map() },
+			ctx,
+		);
+		vi.mocked(getIndexEntryMap).mockResolvedValue(
+			new Map([
+				[
+					summary.commitHash,
+					{
+						commitHash: summary.commitHash,
+						parentCommitHash: "def4567890",
+						commitMessage: "",
+						commitDate: "",
+						branch: summary.branch,
+						generatedAt: "",
+					},
+				],
+			]),
+		);
+
+		// The created attachment's delete fails too — both stay best-effort.
+		await expect(
+			applyBatchResult(
+				built,
+				[
+					okResult(summary, [
+						{ clientKey: "plan-0", ok: true, docId: 11, url: "/articles/p-11", created: true },
+					]),
+				],
+				ctx,
+			),
+		).resolves.toEqual({
+			writtenBack: 0,
+			childSkipped: 1,
+		});
+	});
+
+	it("skips failed items and items with no matching built entry", async () => {
+		const summary = leaf();
+		const { ctx, built } = await buildOne(summary);
+
+		const outcome = await applyBatchResult(
+			built,
+			[
+				{ commitHash: summary.commitHash, ok: false, attachments: [], error: "boom" },
+				{ ...okResult(summary), commitHash: "f".repeat(40) },
+			],
+			ctx,
+		);
+
+		expect(outcome).toEqual({ writtenBack: 0, childSkipped: 0 });
+		expect(storeSummary).not.toHaveBeenCalled();
+	});
+
+	it("reports a per-item write-back failure with the minted ids (article is already published)", async () => {
+		const summary = leaf();
+		const { ctx, built } = await buildOne(summary);
+		vi.mocked(storeSummary).mockRejectedValue(new Error("disk full"));
+
+		const outcome = await applyBatchResult(built, [okResult(summary)], ctx);
+
+		expect(outcome).toEqual({
+			writtenBack: 0,
+			childSkipped: 0,
+			writeBackFailures: [{ commitHash: summary.commitHash, docId: 9, url: `${BASE}/articles/s-9` }],
+		});
+	});
+
+	it("treats every commit as a root when the summary index cannot be read", async () => {
+		const summary = leaf();
+		const { ctx, built } = await buildOne(summary);
+		vi.mocked(getIndexEntryMap).mockRejectedValue(new Error("index unavailable"));
+
+		const outcome = await applyBatchResult(built, [okResult(summary)], ctx);
+
+		expect(outcome).toEqual({ writtenBack: 1, childSkipped: 0 });
+		expect(ctx.client.deleteDoc).not.toHaveBeenCalled();
+		expect(storeSummary).toHaveBeenCalledTimes(1);
+	});
+
+	it("deletes orphaned articles when cleanupOrphans is set (compensation path)", async () => {
+		const summary = leaf({ orphanedDocIds: [42] });
+		const { ctx, built } = await buildOne(summary);
+
+		const outcome = await applyBatchResult(built, [okResult(summary)], ctx, { cleanupOrphans: true });
+
+		expect(outcome).toEqual({ writtenBack: 1, childSkipped: 0 });
+		expect(ctx.client.deleteDoc).toHaveBeenCalledWith(42);
+		// Two persists: the docId/url write-back, then the cleaned orphan list.
+		expect(storeSummary).toHaveBeenCalledTimes(2);
+	});
+
+	it("skips orphan cleanup by default (budget-bound inline pre-push path)", async () => {
+		const summary = leaf({ orphanedDocIds: [42] });
+		const { ctx, built } = await buildOne(summary);
+
+		const outcome = await applyBatchResult(built, [okResult(summary)], ctx);
+
+		expect(ctx.client.deleteDoc).not.toHaveBeenCalled();
+		expect(outcome).toEqual({ writtenBack: 1, childSkipped: 0, cleanupPendingHashes: [summary.commitHash] });
+	});
+
+	it("keeps the write-back result when orphan cleanup itself fails", async () => {
+		const summary = leaf({ orphanedDocIds: [42] });
+		const ctx = baseCtx(fakeClient({ deleteDoc: async () => Promise.reject(new Error("network")) }));
+		const built = await buildBatchItems(
+			[summary],
+			{ ownedPlans: new Map(), ownedNotes: new Map(), ownedReferences: new Map() },
+			ctx,
+		);
+
+		const outcome = await applyBatchResult(built, [okResult(summary)], ctx, { cleanupOrphans: true });
+
+		expect(outcome).toEqual({ writtenBack: 1, childSkipped: 0, cleanupPendingHashes: [summary.commitHash] });
+	});
+
+	it("resolves orphan hashes before cleanup on the compensation batch path", async () => {
+		const summary = leaf({ unresolvedOrphanHashes: ["child1hash"] });
+		const { ctx, built } = await buildOne(summary);
+		vi.mocked(getSummary).mockResolvedValueOnce(leaf({ commitHash: "child1hash", jolliDocId: 201 }));
+
+		const outcome = await applyBatchResult(built, [okResult(summary)], ctx, { cleanupOrphans: true });
+
+		expect(ctx.client.deleteDoc).toHaveBeenCalledWith(201);
+		expect(outcome).toEqual({ writtenBack: 1, childSkipped: 0 });
 	});
 });

--- a/cli/src/core/JolliMemoryPushOrchestrator.ts
+++ b/cli/src/core/JolliMemoryPushOrchestrator.ts
@@ -15,6 +15,12 @@ import { getDefaultBranch } from "./GitOps.js";
 import { buildBranchRelativePath, deriveRepoNameFromUrl, getCanonicalRepoUrl } from "./GitRemoteUtils.js";
 import { deriveJolliEnvKey, resolveArticleUrl } from "./JolliApiUtils.js";
 import {
+	BATCH_MAX_ATTACHMENTS_PER_ITEM,
+	BATCH_MAX_CONTENT_CHARS,
+	BATCH_MAX_TOTAL_CONTENT_CHARS,
+	type BatchItemResult,
+	type BatchPushAttachment,
+	type BatchPushItem,
 	BindingAlreadyExistsError,
 	BindingRequiredError,
 	ClientOutdatedError,
@@ -402,6 +408,423 @@ export function buildPushMarkdown(summary: CommitSummary): string {
 	return lines.join("\n");
 }
 
+// ── Batch push helpers ───────────────────────────────────────────────────────
+
+/**
+ * Builds the article-URL placeholder embedded in batch summary content where an
+ * attachment's final URL will go. The server substitutes the real URLs after
+ * minting the doc ids — in a single-request protocol the client cannot know
+ * them up front.
+ *
+ * MUST stay byte-for-byte in lockstep with the server's `docUrlPlaceholder`
+ * (`backend/src/router/PushRouter.ts`) — same spirit as the `parseJolliApiKey`
+ * lockstep rule.
+ */
+export function docUrlPlaceholder(clientKey: string): string {
+	return `{{jolli:doc:${clientKey}}}`;
+}
+
+/** Identity of one batch attachment for the post-push URL write-back. */
+export interface BatchAttachmentKey {
+	readonly kind: "plan" | "note" | "reference";
+	/** Plan slug / note id / reference archivedKey. */
+	readonly key: string;
+}
+
+/** One built batch item plus the bookkeeping `applyBatchResult` needs. */
+export interface BuiltBatchItem {
+	readonly item: BatchPushItem;
+	readonly summary: CommitSummary;
+	readonly attachmentKeys: ReadonlyMap<string, BatchAttachmentKey>;
+	/** Character count used by the server's batch-wide content limit. */
+	readonly batchContentChars: number;
+	/** Set when this item must use the legacy per-commit push path. */
+	readonly batchIneligibleReason?: string;
+}
+
+/** Owner-assigned attachments per commit hash (see {@link assignOwnedAttachments}). */
+export interface OwnedAttachmentMaps {
+	readonly ownedPlans: ReadonlyMap<string, ReadonlyArray<PlanReference>>;
+	readonly ownedNotes: ReadonlyMap<string, ReadonlyArray<NoteReference>>;
+	readonly ownedReferences: ReadonlyMap<string, ReadonlyArray<ReferenceCommitRef>>;
+}
+
+/**
+ * Builds one `BatchPushItem` per summary for `pushBatch`: reads attachment
+ * bodies, assigns per-item clientKeys, weaves placeholder URLs into the
+ * summary markdown (+ summaryJson), and carries existing docIds (env-gated by
+ * {@link canReuseDocId}) so the server updates instead of creating.
+ *
+ * Only URL fields carry placeholders — attachment docId fields inside the
+ * summaryJson stay numeric/absent (a placeholder string there would break the
+ * sidecar schema); the local write-back (`applyBatchResult`) records the real
+ * ids for the next push.
+ *
+ * Unreadable/empty attachment bodies are skipped like `pushPlanList` — their
+ * placeholder is never minted, so the woven copy keeps whatever URL state the
+ * reference already had.
+ */
+export async function buildBatchItems(
+	summaries: ReadonlyArray<CommitSummary>,
+	owned: OwnedAttachmentMaps,
+	ctx: PushContext,
+): Promise<Array<BuiltBatchItem>> {
+	const envKey = await ctx.client.resolveEnvKey();
+	const built: Array<BuiltBatchItem> = [];
+	for (const summary of summaries) {
+		built.push(await buildOneBatchItem(summary, owned, ctx, envKey));
+	}
+	const attachmentCount = built.reduce((sum, item) => sum + item.item.attachments.length, 0);
+	const fallbackCount = built.filter((item) => item.batchIneligibleReason !== undefined).length;
+	log.debug(
+		"buildBatchItems: built %d item(s) with %d attachment(s), individualFallback=%d",
+		built.length,
+		attachmentCount,
+		fallbackCount,
+	);
+	return built;
+}
+
+/** Mirrors the server's batch content accounting exactly. */
+function countBatchContentChars(item: BatchPushItem): number {
+	let total = item.summary.content.length + (item.summary.summaryJson?.length ?? 0);
+	for (const attachment of item.attachments) total += attachment.content.length;
+	return total;
+}
+
+/** Returns why an item cannot pass the server's batch schema, if any. */
+function getBatchIneligibleReason(item: BatchPushItem, contentChars: number): string | undefined {
+	if (item.summary.content.length > BATCH_MAX_CONTENT_CHARS) return "summary content exceeds the batch limit";
+	if ((item.summary.summaryJson?.length ?? 0) > BATCH_MAX_CONTENT_CHARS)
+		return "summary JSON exceeds the batch limit";
+	if (item.attachments.length > BATCH_MAX_ATTACHMENTS_PER_ITEM) return "attachment count exceeds the batch limit";
+	if (item.attachments.some((attachment) => attachment.content.length > BATCH_MAX_CONTENT_CHARS))
+		return "attachment content exceeds the batch limit";
+	if (contentChars > BATCH_MAX_TOTAL_CONTENT_CHARS) return "item content exceeds the batch total limit";
+	return undefined;
+}
+
+async function buildOneBatchItem(
+	summary: CommitSummary,
+	owned: OwnedAttachmentMaps,
+	ctx: PushContext,
+	envKey: string,
+): Promise<BuiltBatchItem> {
+	const attachments: Array<BatchPushAttachment> = [];
+	const attachmentKeys = new Map<string, BatchAttachmentKey>();
+	const relativePath = buildBranchRelativePath(summary.branch);
+	const placeholderBySlug = new Map<string, string>();
+	const placeholderByNoteId = new Map<string, string>();
+	const placeholderByArchivedKey = new Map<string, string>();
+
+	const plans = owned.ownedPlans.get(summary.commitHash) ?? [];
+	for (const [index, plan] of plans.entries()) {
+		const content = (await readPlanFromBranch(plan.slug, ctx.cwd, ctx.storage)) ?? "";
+		if (!content) {
+			log.info("Plan %s: no content found, skipping", plan.slug);
+			continue;
+		}
+		const clientKey = `plan-${index}`;
+		attachments.push({
+			clientKey,
+			docType: "plan",
+			title: buildPlanPushTitle(summary, plan.title),
+			content,
+			relativePath,
+			...(plan.jolliPlanDocId !== undefined &&
+				canReuseDocId(plan.jolliPlanDocUrl, envKey) && { docId: plan.jolliPlanDocId }),
+		});
+		attachmentKeys.set(clientKey, { kind: "plan", key: plan.slug });
+		placeholderBySlug.set(plan.slug, docUrlPlaceholder(clientKey));
+	}
+
+	const notes = owned.ownedNotes.get(summary.commitHash) ?? [];
+	for (const [index, note] of notes.entries()) {
+		const content = note.content ?? (await readNoteFromBranch(note.id, ctx.cwd, ctx.storage)) ?? "";
+		if (!content) {
+			log.info("Note %s: no content found, skipping", note.id);
+			continue;
+		}
+		const clientKey = `note-${index}`;
+		attachments.push({
+			clientKey,
+			docType: "note",
+			title: buildNotePushTitle(summary, note.title),
+			content,
+			relativePath,
+			...(note.jolliNoteDocId !== undefined &&
+				canReuseDocId(note.jolliNoteDocUrl, envKey) && { docId: note.jolliNoteDocId }),
+		});
+		attachmentKeys.set(clientKey, { kind: "note", key: note.id });
+		placeholderByNoteId.set(note.id, docUrlPlaceholder(clientKey));
+	}
+
+	const references = owned.ownedReferences.get(summary.commitHash) ?? [];
+	for (const [index, ref] of references.entries()) {
+		const storedMd = await readReferenceFromBranch(ref.source, ref.archivedKey, ctx.cwd, ctx.storage);
+		const description = storedMd
+			? (readReferenceMarkdownFromString(storedMd)?.description ?? undefined)
+			: undefined;
+		const clientKey = `ref-${index}`;
+		attachments.push({
+			clientKey,
+			docType: "reference",
+			title: buildReferencePushTitle(ref),
+			content: buildReferencePushMarkdown(ref, description),
+			relativePath,
+			...(ref.jolliReferenceDocId !== undefined &&
+				canReuseDocId(ref.jolliReferenceDocUrl, envKey) && { docId: ref.jolliReferenceDocId }),
+		});
+		attachmentKeys.set(clientKey, { kind: "reference", key: ref.archivedKey });
+		placeholderByArchivedKey.set(ref.archivedKey, docUrlPlaceholder(clientKey));
+	}
+
+	// Weave placeholder URLs into the enriched copy the markdown + summaryJson
+	// are built from — mirrors pushSummary's real-URL weave, minus docIds.
+	const dedupedPlans = latestPlanPerName(summary.plans ?? []);
+	const plansWithUrls = dedupedPlans.map((p) => {
+		const placeholder = placeholderBySlug.get(p.slug);
+		return placeholder ? { ...p, jolliPlanDocUrl: placeholder } : p;
+	});
+	const notesWithUrls = summary.notes?.map((n) => {
+		const placeholder = placeholderByNoteId.get(n.id);
+		return placeholder ? { ...n, jolliNoteDocUrl: placeholder } : n;
+	});
+	const referencesWithUrls = summary.references?.map((r) => {
+		const placeholder = placeholderByArchivedKey.get(r.archivedKey);
+		return placeholder ? { ...r, jolliReferenceDocUrl: placeholder } : r;
+	});
+	const summaryForMarkdown: CommitSummary = {
+		...summary,
+		plans: plansWithUrls,
+		...(notesWithUrls !== undefined && { notes: notesWithUrls }),
+		...(referencesWithUrls !== undefined && { references: referencesWithUrls }),
+	};
+	const markdown = buildPushMarkdown(summaryForMarkdown);
+	const summaryJson = serializeSummaryJson(summaryForMarkdown);
+
+	const item: BatchPushItem = {
+		commitHash: summary.commitHash,
+		branch: summary.branch,
+		summary: {
+			title: buildPushTitle(summary),
+			content: markdown,
+			relativePath,
+			...(summary.jolliDocId !== undefined &&
+				canReuseDocId(summary.jolliDocUrl, envKey) && { docId: summary.jolliDocId }),
+			...(summaryJson && { summaryJson }),
+		},
+		attachments,
+	};
+	const batchContentChars = countBatchContentChars(item);
+	const batchIneligibleReason = getBatchIneligibleReason(item, batchContentChars);
+	return {
+		summary,
+		attachmentKeys,
+		item,
+		batchContentChars,
+		...(batchIneligibleReason !== undefined && { batchIneligibleReason }),
+	};
+}
+
+/**
+ * A pushed item whose local docId/url write-back failed. Carries the minted
+ * ids so the caller can persist them in the pending entry — the next drain
+ * then retries as an UPDATE of the same article instead of a duplicate CREATE.
+ */
+export interface BatchWriteBackFailure {
+	readonly commitHash: string;
+	readonly docId: number;
+	readonly url: string;
+}
+
+/** Outcome counts of {@link applyBatchResult}, for the caller's logging. */
+export interface ApplyBatchResultOutcome {
+	readonly writtenBack: number;
+	readonly childSkipped: number;
+	/** Successful items that still need confirmed post-push orphan cleanup. */
+	readonly cleanupPendingHashes?: ReadonlyArray<string>;
+	/** Successful items whose write-back failed — keep pending with the minted ids recorded. */
+	readonly writeBackFailures?: ReadonlyArray<BatchWriteBackFailure>;
+}
+
+/**
+ * Post-batch write-back: for every `ok` item, resolves the final article URL,
+ * weaves attachment URLs/docIds into the stored summary and persists it so the
+ * next push updates instead of creating. Mirrors `pushSummary`'s write-back
+ * including its mid-push child guard: a commit that became a child (squash)
+ * while the request was on the network gets its freshly-minted article deleted
+ * best-effort instead of a force-store that would resurrect a zombie root —
+ * along with any attachments this same batch item CREATEd (attachments that
+ * UPDATEd a pre-existing doc keep their article).
+ * Best-effort per item — a failed write-back is logged and never fails the
+ * caller (the article is already published). Each failed item is reported in
+ * `writeBackFailures` with its minted docId/url so the caller can keep the
+ * pending entry and retry as an UPDATE instead of a duplicate CREATE.
+ *
+ * `opts.cleanupOrphans` additionally resolves `unresolvedOrphanHashes` and
+ * deletes the orphaned articles recorded on each written-back summary. The
+ * compensation drain opts in; the budget-bound pre-push flow leaves it off and
+ * receives `cleanupPendingHashes` so those pending entries are preserved.
+ */
+export async function applyBatchResult(
+	built: ReadonlyArray<BuiltBatchItem>,
+	results: ReadonlyArray<BatchItemResult>,
+	ctx: PushContext,
+	opts?: { readonly cleanupOrphans?: boolean },
+): Promise<ApplyBatchResultOutcome> {
+	const displayBase = ctx.baseUrl.replace(/\/+$/, "");
+	const builtByHash = new Map(built.map((b) => [b.item.commitHash, b]));
+	const postPushIndex = await getIndexEntryMap(ctx.cwd, ctx.storage).catch((err: unknown) => {
+		// Degrading to "no commit is a child" keeps parity with pushSummary, but
+		// it also disarms the mid-push child guard below — say so in the log.
+		log.warn(
+			"Could not read the summary index for the mid-push child guard — treating every commit as a root: %s",
+			err instanceof Error ? err.message : String(err),
+		);
+		return new Map<string, unknown>();
+	});
+	let writtenBack = 0;
+	let childSkipped = 0;
+	const cleanupPendingHashes: string[] = [];
+	const writeBackFailures: BatchWriteBackFailure[] = [];
+	for (const result of results) {
+		const summaryDoc = result.ok ? result.summary : undefined;
+		if (!summaryDoc) continue;
+		const entry = builtByHash.get(result.commitHash);
+		if (!entry) continue;
+		const indexEntry = postPushIndex.get(result.commitHash) as
+			| { readonly parentCommitHash?: string | null }
+			| undefined;
+		if (indexEntry?.parentCommitHash != null) {
+			childSkipped++;
+			log.warn(
+				"Commit %s became a child mid-push (parent=%s); deleting freshly-pushed article %d and skipping write-back",
+				result.commitHash.substring(0, 8),
+				indexEntry.parentCommitHash.substring(0, 8),
+				summaryDoc.docId,
+			);
+			try {
+				await ctx.client.deleteDoc(summaryDoc.docId);
+			} catch (err) {
+				log.warn(
+					"Best-effort delete of newly-orphaned article %d failed: %s",
+					summaryDoc.docId,
+					err instanceof Error ? err.message : String(err),
+				);
+			}
+			// Attachments this same batch item CREATEd must go too, or they leak
+			// as stray docs of a commit that no longer exists as a root. Only the
+			// created ones: an attachment that UPDATEd a pre-existing doc keeps
+			// its article — that doc predates this push and is cleaned up by the
+			// squash consolidation's own orphan machinery.
+			for (const att of result.attachments) {
+				if (!att.ok || att.created !== true || att.docId === undefined) continue;
+				try {
+					await ctx.client.deleteDoc(att.docId);
+				} catch (err) {
+					log.warn(
+						"Best-effort delete of newly-orphaned attachment %d failed: %s",
+						att.docId,
+						err instanceof Error ? err.message : String(err),
+					);
+				}
+			}
+			continue;
+		}
+		try {
+			const updated = await writeBackBatchItem(entry, result, displayBase, ctx);
+			writtenBack++;
+			let finalUpdated = updated;
+			if (opts?.cleanupOrphans && finalUpdated && hasPendingOrphanCleanup(finalUpdated)) {
+				try {
+					finalUpdated = await resolveUnresolvedOrphanHashes(finalUpdated, ctx);
+					const cleaned = await cleanupOrphanedDocs(finalUpdated, finalUpdated, ctx);
+					if (cleaned) finalUpdated = cleaned;
+				} catch (err) {
+					log.warn(
+						"Orphan cleanup after batch push failed for %s: %s",
+						result.commitHash.substring(0, 8),
+						err instanceof Error ? err.message : String(err),
+					);
+				}
+			}
+			if (finalUpdated && hasPendingOrphanCleanup(finalUpdated)) {
+				cleanupPendingHashes.push(result.commitHash);
+			}
+		} catch (err) {
+			// The article exists server-side but its id never reached local
+			// storage — report the minted ids so the caller keeps the pending
+			// entry and the retry UPDATEs instead of CREATEing a duplicate.
+			writeBackFailures.push({
+				commitHash: result.commitHash,
+				docId: summaryDoc.docId,
+				url: resolveArticleUrl(displayBase, summaryDoc.url, summaryDoc.docId),
+			});
+			log.warn(
+				"Write-back after batch push failed for %s: %s",
+				result.commitHash.substring(0, 8),
+				err instanceof Error ? err.message : String(err),
+			);
+		}
+	}
+	log.debug(
+		"applyBatchResult: writtenBack=%d childSkipped=%d cleanupPending=%d writeBackFailed=%d cleanupOrphans=%s",
+		writtenBack,
+		childSkipped,
+		cleanupPendingHashes.length,
+		writeBackFailures.length,
+		opts?.cleanupOrphans === true,
+	);
+	return {
+		writtenBack,
+		childSkipped,
+		...(cleanupPendingHashes.length > 0 && { cleanupPendingHashes }),
+		...(writeBackFailures.length > 0 && { writeBackFailures }),
+	};
+}
+
+async function writeBackBatchItem(
+	entry: BuiltBatchItem,
+	result: BatchItemResult,
+	displayBase: string,
+	ctx: PushContext,
+): Promise<CommitSummary | undefined> {
+	const summaryDoc = result.summary;
+	/* v8 ignore next -- callers only pass ok results, which always carry summary */
+	if (!summaryDoc) return undefined;
+	const summaryUrl = resolveArticleUrl(displayBase, summaryDoc.url, summaryDoc.docId);
+	const planUrls: Array<{ slug: string; url: string; docId: number }> = [];
+	const noteUrls: Array<{ id: string; url: string; docId: number }> = [];
+	const referenceUrls: Array<{ archivedKey: string; url: string; docId: number }> = [];
+	for (const att of result.attachments) {
+		if (!att.ok || att.docId === undefined || att.url === undefined) continue;
+		const identity = entry.attachmentKeys.get(att.clientKey);
+		if (!identity) continue;
+		const url = resolveArticleUrl(displayBase, att.url, att.docId);
+		if (identity.kind === "plan") {
+			planUrls.push({ slug: identity.key, url, docId: att.docId });
+		} else if (identity.kind === "note") {
+			noteUrls.push({ id: identity.key, url, docId: att.docId });
+		} else {
+			referenceUrls.push({ archivedKey: identity.key, url, docId: att.docId });
+		}
+	}
+	const summary = entry.summary;
+	const updatedSummary: CommitSummary = {
+		...summary,
+		jolliDocUrl: summaryUrl,
+		jolliDocId: summaryDoc.docId,
+		...(planUrls.length > 0 ? { plans: applyPlanUrls(summary.plans, planUrls) } : {}),
+		...(noteUrls.length > 0 && summary.notes ? { notes: applyNoteUrls(summary.notes, noteUrls) } : {}),
+		...(referenceUrls.length > 0 && summary.references
+			? { references: applyReferenceUrls(summary.references, referenceUrls) }
+			: {}),
+	};
+	await storeSummary(updatedSummary, ctx.cwd, true, undefined, ctx.storage);
+	return updatedSummary;
+}
+
 // ── Push orchestration (network I/O) ─────────────────────────────────────────
 
 /**
@@ -553,65 +976,7 @@ export async function pushSummary(
 	};
 	await storeSummary(updatedSummary, ctx.cwd, true, undefined, ctx.storage);
 
-	// Resolve unresolvedOrphanHashes: re-read each hash's summary from the
-	// orphan branch. If PrePushWorker has since written back a jolliDocId,
-	// promote it into orphanedDocIds for cleanup.
-	//
-	// Retention is gated by the shared push-pending queue:
-	//   * hash present in pending → retain (a worker is still in flight and
-	//     may yet resolve it)
-	//   * hash absent from pending → discard (it was never pushed, or the
-	//     worker already finished without producing a docId — either way the
-	//     hash has no Space article to clean up)
-	//
-	// When `loadPushPending` itself fails (lock unavailable, transient IO
-	// error) we fall back to conservative retention: keep every unresolved
-	// hash so a crashed worker's article can still be cleaned up on the next
-	// push.
-	let summaryForCleanup = updatedSummary;
-	if (summary.unresolvedOrphanHashes && summary.unresolvedOrphanHashes.length > 0) {
-		const pending = await loadPushPending(ctx.cwd).catch((err: unknown) => {
-			log.warn(
-				"Could not read push-pending state while resolving orphan hashes: %s",
-				err instanceof Error ? err.message : String(err),
-			);
-			return undefined;
-		});
-		const resolvedDocIds: number[] = [];
-		const remainingHashes: string[] = [];
-		let stillInFlight = 0;
-		for (const hash of summary.unresolvedOrphanHashes) {
-			const fresh = await getSummary(hash, ctx.cwd, ctx.storage);
-			// Guard against tree-hash fallback: if the child's own summary
-			// file was cleaned, getSummary may resolve to the merged summary
-			// (same tree) — whose jolliDocId is the article we just pushed.
-			// Without this check we'd delete our own freshly-published article.
-			if (fresh?.jolliDocId && fresh.commitHash === hash) {
-				resolvedDocIds.push(fresh.jolliDocId);
-			} else if (pending === undefined) {
-				remainingHashes.push(hash);
-			} else if (pending.entries[hash]) {
-				remainingHashes.push(hash);
-				stillInFlight++;
-			}
-		}
-		if (resolvedDocIds.length > 0 || remainingHashes.length !== summary.unresolvedOrphanHashes.length) {
-			if (resolvedDocIds.length > 0)
-				log.info(
-					"Resolved %d orphan hashes → docIds for cleanup (%d retained, %d still in-flight)",
-					resolvedDocIds.length,
-					remainingHashes.length,
-					stillInFlight,
-				);
-			const mergedOrphanIds = [...new Set([...(updatedSummary.orphanedDocIds ?? []), ...resolvedDocIds])];
-			summaryForCleanup = {
-				...updatedSummary,
-				orphanedDocIds: mergedOrphanIds.length > 0 ? mergedOrphanIds : undefined,
-				unresolvedOrphanHashes: remainingHashes.length > 0 ? [...new Set(remainingHashes)] : undefined,
-			};
-			await storeSummary(summaryForCleanup, ctx.cwd, true, undefined, ctx.storage);
-		}
-	}
+	const summaryForCleanup = await resolveUnresolvedOrphanHashes(updatedSummary, ctx);
 
 	// Clean up orphaned articles, then persist which ones were actually deleted.
 	// Best-effort: the summary + jolliDocId are already pushed and stored above, so a
@@ -769,6 +1134,64 @@ async function pushReferenceList(
 		});
 	}
 	return results;
+}
+
+function hasPendingOrphanCleanup(summary: CommitSummary): boolean {
+	return (summary.orphanedDocIds?.length ?? 0) > 0 || (summary.unresolvedOrphanHashes?.length ?? 0) > 0;
+}
+
+/**
+ * Resolves hashes recorded during a squash/push race into article ids that can
+ * be deleted. Shared by single and batch push paths so batch-first compensation
+ * preserves the same cleanup behavior as `pushSummary`.
+ */
+async function resolveUnresolvedOrphanHashes(summary: CommitSummary, ctx: PushContext): Promise<CommitSummary> {
+	const unresolved = summary.unresolvedOrphanHashes;
+	if (!unresolved || unresolved.length === 0) return summary;
+
+	// Retain hashes still present in push-pending because another worker may yet
+	// write back their docId. If the pending file cannot be read, retain every
+	// unresolved hash conservatively instead of risking an orphan leak.
+	const pending = await loadPushPending(ctx.cwd).catch((err: unknown) => {
+		log.warn(
+			"Could not read push-pending state while resolving orphan hashes: %s",
+			err instanceof Error ? err.message : String(err),
+		);
+		return undefined;
+	});
+	const resolvedDocIds: number[] = [];
+	const remainingHashes: string[] = [];
+	let stillInFlight = 0;
+	for (const hash of unresolved) {
+		const fresh = await getSummary(hash, ctx.cwd, ctx.storage);
+		// Guard against tree-hash fallback resolving to the merged summary itself.
+		if (fresh?.jolliDocId && fresh.commitHash === hash) {
+			resolvedDocIds.push(fresh.jolliDocId);
+		} else if (pending === undefined) {
+			remainingHashes.push(hash);
+		} else if (pending.entries[hash]) {
+			remainingHashes.push(hash);
+			stillInFlight++;
+		}
+	}
+
+	if (resolvedDocIds.length === 0 && remainingHashes.length === unresolved.length) return summary;
+	if (resolvedDocIds.length > 0) {
+		log.info(
+			"Resolved %d orphan hashes → docIds for cleanup (%d retained, %d still in-flight)",
+			resolvedDocIds.length,
+			remainingHashes.length,
+			stillInFlight,
+		);
+	}
+	const mergedOrphanIds = [...new Set([...(summary.orphanedDocIds ?? []), ...resolvedDocIds])];
+	const resolvedSummary: CommitSummary = {
+		...summary,
+		orphanedDocIds: mergedOrphanIds.length > 0 ? mergedOrphanIds : undefined,
+		unresolvedOrphanHashes: remainingHashes.length > 0 ? [...new Set(remainingHashes)] : undefined,
+	};
+	await storeSummary(resolvedSummary, ctx.cwd, true, undefined, ctx.storage);
+	return resolvedSummary;
 }
 
 /**

--- a/cli/src/core/PushExecutor.test.ts
+++ b/cli/src/core/PushExecutor.test.ts
@@ -2,10 +2,26 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CommitSummary } from "../Types.js";
 import { execGit, getCurrentBranch, getDefaultBranch } from "./GitOps.js";
 import { getCanonicalRepoUrl } from "./GitRemoteUtils.js";
-import { BindingRequiredError, ClientOutdatedError, NotAuthenticatedError } from "./JolliMemoryPushClient.js";
-import { assignOwnedAttachments, pushSummary } from "./JolliMemoryPushOrchestrator.js";
+import {
+	BATCH_MAX_ITEMS,
+	BATCH_MAX_TOTAL_CONTENT_CHARS,
+	type BatchPushPayload,
+	type BatchPushResult,
+	BatchUnsupportedError,
+	BindingRequiredError,
+	ClientOutdatedError,
+	NotAuthenticatedError,
+	PermissionDeniedError,
+} from "./JolliMemoryPushClient.js";
+import {
+	applyBatchResult,
+	assignOwnedAttachments,
+	type BuiltBatchItem,
+	buildBatchItems,
+	pushSummary,
+} from "./JolliMemoryPushOrchestrator.js";
 import { loadBranchSummaries } from "./PrDescription.js";
-import { classifyError, processPushPending, triggerPushForNewSummaries } from "./PushExecutor.js";
+import { classifyError, processPrePushInline, processPushPending, triggerPushForNewSummaries } from "./PushExecutor.js";
 import { claimForPush, loadPushPending, type PushPendingEntry, updateBatch } from "./PushPendingStore.js";
 import { loadConfig } from "./SessionTracker.js";
 import { createStorage } from "./StorageFactory.js";
@@ -28,7 +44,13 @@ vi.mock("./PushPendingStore.js", async (importOriginal) => {
 });
 vi.mock("./JolliMemoryPushOrchestrator.js", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("./JolliMemoryPushOrchestrator.js")>();
-	return { ...actual, pushSummary: vi.fn(), assignOwnedAttachments: vi.fn() };
+	return {
+		...actual,
+		pushSummary: vi.fn(),
+		assignOwnedAttachments: vi.fn(),
+		buildBatchItems: vi.fn(),
+		applyBatchResult: vi.fn(),
+	};
 });
 
 const CWD = "/repo";
@@ -44,8 +66,66 @@ function summary(hash: string, branch = "feature/x"): CommitSummary {
 	} as CommitSummary;
 }
 
-function fakeClient() {
-	return { resolveBaseUrl: vi.fn(async () => "https://acme.jolli.ai") } as never;
+/** pushBatch mock that succeeds for every item in the payload, per-item docIds 100+. */
+function okPushBatch() {
+	return vi.fn(async (payload: { items: Array<{ commitHash: string }> }) => ({
+		results: payload.items.map((item, index) => ({
+			commitHash: item.commitHash,
+			ok: true,
+			summary: {
+				docId: 100 + index,
+				url: `/articles/doc-${100 + index}`,
+				jrn: `jrn:${index}`,
+				created: true,
+			},
+			attachments: [],
+		})),
+	}));
+}
+
+/**
+ * Client stub for processPushPending tests. The default pushBatch succeeds for
+ * every item; pass an explicit mock to drive failures or capture payloads.
+ */
+function fakeClient(pushBatch?: ReturnType<typeof vi.fn>) {
+	return {
+		resolveBaseUrl: vi.fn(async () => "https://acme.jolli.ai"),
+		pushBatch: pushBatch ?? okPushBatch(),
+	} as never;
+}
+
+/** Client stub for the inline batch path — `pushBatch` is injectable per test. */
+function fakeBatchClient(pushBatch: ReturnType<typeof vi.fn>) {
+	return {
+		resolveBaseUrl: vi.fn(async () => "https://acme.jolli.ai"),
+		pushBatch,
+	} as never;
+}
+
+/** Minimal BuiltBatchItem for one summary — mirrors what buildBatchItems produces. */
+function builtItem(hash: string, branch = "feature/x"): BuiltBatchItem {
+	return {
+		item: {
+			commitHash: hash,
+			branch,
+			summary: { title: `t-${hash.substring(0, 4)}`, content: "# body" },
+			attachments: [],
+		},
+		summary: summary(hash, branch),
+		attachmentKeys: new Map(),
+		batchContentChars: 6,
+	};
+}
+
+function okBatchResult(...hashes: string[]): BatchPushResult {
+	return {
+		results: hashes.map((hash, index) => ({
+			commitHash: hash,
+			ok: true,
+			summary: { docId: 100 + index, url: `/articles/doc-${100 + index}`, jrn: `jrn:${index}`, created: true },
+			attachments: [],
+		})),
+	};
 }
 
 function entry(retryCount = 0, overrides: Partial<PushPendingEntry> = {}): PushPendingEntry {
@@ -77,6 +157,8 @@ beforeEach(() => {
 	});
 	vi.mocked(pushSummary).mockResolvedValue({ summary: summary(HASH_A), summaryUrl: "https://acme.jolli.ai/a" });
 	vi.mocked(updateBatch).mockResolvedValue(undefined);
+	vi.mocked(buildBatchItems).mockImplementation(async (summaries) => summaries.map((s) => builtItem(s.commitHash)));
+	vi.mocked(applyBatchResult).mockResolvedValue({ writtenBack: 0, childSkipped: 0 });
 	// Default: every candidate is claimed successfully, and the returned
 	// `entries` mirror whatever the current `loadPushPending` mock has been
 	// set up to return — so tests that seed a specific retryCount into
@@ -100,8 +182,13 @@ afterEach(() => {
 describe("classifyError", () => {
 	it("does not increment retry for config/permanent failures", () => {
 		expect(classifyError(new NotAuthenticatedError()).increment).toBe(false);
+		expect(classifyError(new PermissionDeniedError()).increment).toBe(false);
 		expect(classifyError(new BindingRequiredError("r")).increment).toBe(false);
 		expect(classifyError(new ClientOutdatedError()).increment).toBe(false);
+	});
+	it("labels a permission failure distinctly from not-signed-in", () => {
+		expect(classifyError(new PermissionDeniedError()).message).toBe("permission-denied");
+		expect(classifyError(new NotAuthenticatedError()).message).toBe("not-authenticated");
 	});
 	it("increments retry for operational failures", () => {
 		const c = classifyError(new Error("ECONNRESET"));
@@ -113,7 +200,7 @@ describe("classifyError", () => {
 describe("processPushPending", () => {
 	it("no-ops with no pending entries", async () => {
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: {} });
-		const r = await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
 		expect(r.note).toBe("no pending entries");
 		expect(pushSummary).not.toHaveBeenCalled();
 	});
@@ -128,7 +215,7 @@ describe("processPushPending", () => {
 
 	it("skips entries that exhausted the retry budget", async () => {
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(3) } });
-		const r = await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
 		expect(r.skippedRetryExhausted).toBe(1);
 		expect(pushSummary).not.toHaveBeenCalled();
 	});
@@ -138,14 +225,21 @@ describe("processPushPending", () => {
 			version: 1,
 			entries: { [HASH_A]: entry(), [HASH_B]: entry() },
 		});
-		await processPushPending(CWD, { source: "post-queue", hashFilter: new Set([HASH_A]), client: fakeClient() });
-		expect(pushSummary).toHaveBeenCalledTimes(1);
+		const pushBatch = okPushBatch();
+		await processPushPending(CWD, {
+			source: "post-queue",
+			hashFilter: new Set([HASH_A]),
+			client: fakeClient(pushBatch),
+		});
+		expect(pushBatch).toHaveBeenCalledTimes(1);
+		const payload = pushBatch.mock.calls[0][0] as { items: Array<{ commitHash: string }> };
+		expect(payload.items.map((item) => item.commitHash)).toEqual([HASH_A]);
 	});
 
 	it("skips candidates whose memory isn't generated yet and releases the claim so the post-queue trigger can re-claim", async () => {
 		vi.mocked(getSummary).mockResolvedValue(null);
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const r = await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
 		expect(r.skippedNoMemory).toBe(1);
 		expect(pushSummary).not.toHaveBeenCalled();
 		// Empty patch releases claimedAt so QueueWorker's post-drain trigger
@@ -158,7 +252,7 @@ describe("processPushPending", () => {
 	it("skips tree-hash-resolved summaries (commitHash mismatch) to avoid pushing stale pre-squash content, releasing the claim so the post-queue trigger can re-claim", async () => {
 		vi.mocked(getSummary).mockResolvedValue(summary(HASH_B));
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const r = await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
 		expect(r.skippedNoMemory).toBe(1);
 		expect(pushSummary).not.toHaveBeenCalled();
 		// Empty patch releases claimedAt — same mechanism as the missing-summary
@@ -169,11 +263,148 @@ describe("processPushPending", () => {
 		expect(batch.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
 	});
 
-	it("pushes a candidate with memory and deletes it on success", async () => {
+	it("pushes a candidate with memory in one batch request and deletes it on success", async () => {
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const r = await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		const pushBatch = okPushBatch();
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
+		expect(r.pushed).toBe(1);
+		expect(pushBatch).toHaveBeenCalledTimes(1);
+		expect(pushSummary).not.toHaveBeenCalled();
+		const batch = vi.mocked(updateBatch).mock.calls[0][1];
+		expect(batch.get(HASH_A)).toEqual({ kind: "delete" });
+		// Compensation opts into orphan cleanup during write-back.
+		expect(applyBatchResult).toHaveBeenCalledWith(expect.any(Array), expect.any(Array), expect.any(Object), {
+			cleanupOrphans: true,
+		});
+	});
+
+	it("keeps a pushed entry pending with the minted ids when its write-back fails", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		vi.mocked(applyBatchResult).mockResolvedValueOnce({
+			writtenBack: 0,
+			childSkipped: 0,
+			writeBackFailures: [{ commitHash: HASH_A, docId: 100, url: "https://acme.jolli.ai/articles/doc-100" }],
+		});
+
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
+
+		expect(r.pushed).toBe(1);
+		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
+		expect(batch?.get(HASH_A)).toEqual({
+			kind: "patch",
+			patch: {
+				lastAttemptAt: expect.any(String),
+				lastError: "pushed, but persisting the article id locally failed — will retry the write-back",
+				pushedDocId: 100,
+				pushedUrl: "https://acme.jolli.ai/articles/doc-100",
+			},
+		});
+	});
+
+	it("grafts the recovered docId/url into the individual fallback push", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({
+			version: 1,
+			entries: { [HASH_A]: entry(0, { pushedDocId: 55, pushedUrl: "https://acme.jolli.ai/articles/doc-55" }) },
+		});
+		vi.mocked(buildBatchItems).mockImplementation(async (summaries) =>
+			summaries.map((s) => ({ ...builtItem(s.commitHash), batchIneligibleReason: "attachment too large" })),
+		);
+
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
+
 		expect(r.pushed).toBe(1);
 		expect(pushSummary).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(pushSummary).mock.calls[0][0]).toMatchObject({
+			jolliDocId: 55,
+			jolliDocUrl: "https://acme.jolli.ai/articles/doc-55",
+		});
+	});
+
+	it("chunks more than BATCH_MAX_ITEMS commits into multiple batch requests", async () => {
+		const entries: Record<string, PushPendingEntry> = {};
+		for (let i = 0; i < BATCH_MAX_ITEMS + 1; i++) {
+			entries[`h-${String(i).padStart(3, "0")}`] = entry();
+		}
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries });
+		const pushBatch = okPushBatch();
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
+		expect(pushBatch).toHaveBeenCalledTimes(2);
+		expect(r.pushed).toBe(BATCH_MAX_ITEMS + 1);
+	});
+
+	it("splits batch requests before their combined content exceeds the server limit", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({
+			version: 1,
+			entries: { [HASH_A]: entry(), [HASH_B]: entry() },
+		});
+		const charsPerItem = Math.floor(BATCH_MAX_TOTAL_CONTENT_CHARS / 2) + 1;
+		vi.mocked(buildBatchItems).mockResolvedValueOnce([
+			{ ...builtItem(HASH_A), batchContentChars: charsPerItem },
+			{ ...builtItem(HASH_B), batchContentChars: charsPerItem },
+		]);
+		const pushBatch = okPushBatch();
+
+		const result = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
+
+		expect(result.pushed).toBe(2);
+		expect(pushBatch).toHaveBeenCalledTimes(2);
+		expect(pushBatch.mock.calls[0][0].items).toHaveLength(1);
+		expect(pushBatch.mock.calls[1][0].items).toHaveLength(1);
+	});
+
+	it("uses the per-commit path for an item that cannot pass the batch schema", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		vi.mocked(buildBatchItems).mockResolvedValueOnce([
+			{ ...builtItem(HASH_A), batchIneligibleReason: "attachment count exceeds the batch limit" },
+		]);
+		const pushBatch = okPushBatch();
+
+		const result = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
+
+		expect(result.pushed).toBe(1);
+		expect(pushBatch).not.toHaveBeenCalled();
+		expect(pushSummary).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls back to per-commit pushSummary when the server lacks batch support", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		const pushBatch = vi.fn(async () => {
+			throw new BatchUnsupportedError();
+		});
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
+		expect(pushSummary).toHaveBeenCalledTimes(1);
+		expect(r.pushed).toBe(1);
+		const batch = vi.mocked(updateBatch).mock.calls[0][1];
+		expect(batch.get(HASH_A)).toEqual({ kind: "delete" });
+	});
+
+	it("keeps a successful compensation entry pending while orphan cleanup remains", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		vi.mocked(applyBatchResult).mockResolvedValueOnce({
+			writtenBack: 1,
+			childSkipped: 0,
+			cleanupPendingHashes: [HASH_A],
+		});
+
+		const result = await processPushPending(CWD, { source: "activation", client: fakeClient() });
+
+		expect(result.pushed).toBe(1);
+		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
+		expect(batch?.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
+	});
+
+	it("keeps the raced-away guard on the per-commit fallback path", async () => {
+		vi.mocked(loadBranchSummaries).mockResolvedValue({ summaries: [], missingCount: 0 });
+		vi.mocked(getSummary)
+			.mockResolvedValueOnce(summary(HASH_A)) // memory check
+			.mockResolvedValueOnce(null); // fallback pushOne re-read
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		const pushBatch = vi.fn(async () => {
+			throw new BatchUnsupportedError();
+		});
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
+		expect(r.failed).toBe(1);
+		expect(pushSummary).not.toHaveBeenCalled();
 		const batch = vi.mocked(updateBatch).mock.calls[0][1];
 		expect(batch.get(HASH_A)).toEqual({ kind: "delete" });
 	});
@@ -192,11 +423,12 @@ describe("processPushPending", () => {
 			},
 		});
 
-		const result = await processPushPending(CWD, { source: "activation", client: fakeClient() });
+		const pushBatch = okPushBatch();
+		const result = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
 
 		expect(result.pushed).toBe(1);
 		expect(execGit).toHaveBeenCalledWith(["ls-remote", "--refs", pushUrl, remoteRef], CWD);
-		expect(pushSummary).toHaveBeenCalledTimes(1);
+		expect(pushBatch).toHaveBeenCalledTimes(1);
 	});
 
 	it("keeps the entry when the remote ref does not contain the pushed SHA", async () => {
@@ -257,7 +489,7 @@ describe("processPushPending", () => {
 		expect(pushSummary).not.toHaveBeenCalled();
 	});
 
-	it("passes owned attachments to pushSummary (cross-commit dedup)", async () => {
+	it("passes owned attachments into the batch build (cross-commit dedup)", async () => {
 		vi.mocked(assignOwnedAttachments).mockReturnValue({
 			ownedPlans: new Map([[HASH_A, [{ slug: "p-1234abcd" }]]]) as never,
 			ownedNotes: new Map(),
@@ -267,9 +499,9 @@ describe("processPushPending", () => {
 			seedReferenceDocIds: new Map(),
 		});
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
-		const attachments = vi.mocked(pushSummary).mock.calls[0][2];
-		expect(attachments?.plans).toHaveLength(1);
+		await processPushPending(CWD, { source: "activation", client: fakeClient() });
+		const ownership = vi.mocked(buildBatchItems).mock.calls[0][1];
+		expect(ownership.ownedPlans.get(HASH_A)).toHaveLength(1);
 	});
 
 	it("builds attachment ownership from an off-current branch context", async () => {
@@ -307,13 +539,16 @@ describe("processPushPending", () => {
 		await processPushPending(CWD, { source: "activation", client: fakeClient() });
 
 		expect(assignOwnedAttachments).toHaveBeenCalledWith([offSummary]);
-		expect(vi.mocked(pushSummary).mock.calls[0][2]?.plans).toHaveLength(1);
+		const ownership = vi.mocked(buildBatchItems).mock.calls[0][1];
+		expect(ownership.ownedPlans.get(HASH_A)).toHaveLength(1);
 	});
 
-	it("increments retryCount on an operational failure", async () => {
-		vi.mocked(pushSummary).mockRejectedValue(new Error("network down"));
+	it("increments retryCount when the batch request fails operationally", async () => {
+		const pushBatch = vi.fn(async () => {
+			throw new Error("network down");
+		});
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(1) } });
-		const r = await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
 		expect(r.failed).toBe(1);
 		const batch = vi.mocked(updateBatch).mock.calls[0][1];
 		const update = batch.get(HASH_A);
@@ -325,9 +560,11 @@ describe("processPushPending", () => {
 	});
 
 	it("does NOT increment retryCount on NotAuthenticated mid-push", async () => {
-		vi.mocked(pushSummary).mockRejectedValue(new NotAuthenticatedError());
+		const pushBatch = vi.fn(async () => {
+			throw new NotAuthenticatedError();
+		});
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(1) } });
-		await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
 		const batch = vi.mocked(updateBatch).mock.calls[0][1];
 		const update = batch.get(HASH_A);
 		if (update?.kind === "patch") {
@@ -336,26 +573,25 @@ describe("processPushPending", () => {
 		}
 	});
 
-	it("drops a candidate that raced away (summary gone by push time)", async () => {
-		// Passes the memory check (truthy first) but the pushOne fallback getSummary
-		// returns null (deleted meanwhile). loadBranchSummaries empty → byHash miss
-		// forces the fallback lookup.
-		vi.mocked(loadBranchSummaries).mockResolvedValue({ summaries: [], missingCount: 0 });
-		vi.mocked(getSummary)
-			.mockResolvedValueOnce(summary(HASH_A)) // memory check
-			.mockResolvedValueOnce(null); // pushOne fallback
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const r = await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+	it("records a per-item batch failure with a counted retry", async () => {
+		const pushBatch = vi.fn(async () => ({
+			results: [{ commitHash: HASH_A, ok: false, attachments: [], error: "boom", errorCode: "push_failed" }],
+		}));
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(1) } });
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
 		expect(r.failed).toBe(1);
-		expect(pushSummary).not.toHaveBeenCalled();
 		const batch = vi.mocked(updateBatch).mock.calls[0][1];
-		expect(batch.get(HASH_A)).toEqual({ kind: "delete" });
+		const update = batch.get(HASH_A);
+		if (update?.kind === "patch") {
+			expect(update.patch.retryCount).toBe(2);
+			expect(update.patch.lastError).toBe("boom");
+		}
 	});
 
 	it("creates storage when none is active", async () => {
 		vi.mocked(getActiveStorage).mockReturnValue(undefined);
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		await processPushPending(CWD, { source: "activation", client: fakeClient() });
 		expect(createStorage).toHaveBeenCalledWith(CWD, CWD);
 		expect(setActiveStorage).toHaveBeenCalled();
 	});
@@ -386,7 +622,7 @@ describe("processPushPending", () => {
 				],
 			]),
 		);
-		const r = await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
 		expect(pushSummary).not.toHaveBeenCalled();
 		const batch = vi.mocked(updateBatch).mock.calls[0][1];
 		expect(batch.get(HASH_A)).toEqual({ kind: "delete" });
@@ -404,21 +640,480 @@ describe("processPushPending", () => {
 			claimed: new Set([HASH_B]),
 			entries: { [HASH_B]: entry() },
 		});
-		await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
-		expect(pushSummary).toHaveBeenCalledTimes(1);
-		expect(pushSummary).toHaveBeenCalledWith(
-			expect.objectContaining({ commitHash: HASH_B }),
-			expect.any(Object),
-			expect.any(Object),
-		);
+		const pushBatch = okPushBatch();
+		await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
+		expect(pushBatch).toHaveBeenCalledTimes(1);
+		const payload = pushBatch.mock.calls[0][0] as { items: Array<{ commitHash: string }> };
+		expect(payload.items.map((item) => item.commitHash)).toEqual([HASH_B]);
 	});
 
 	it("returns early when every candidate was already claimed by another process", async () => {
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
 		vi.mocked(claimForPush).mockResolvedValue({ claimed: new Set(), entries: {} });
-		const r = await processPushPending(CWD, { source: "pre-push", client: fakeClient() });
+		const pushBatch = okPushBatch();
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
 		expect(r.note).toBe("all entries claimed by another process");
-		expect(pushSummary).not.toHaveBeenCalled();
+		expect(pushBatch).not.toHaveBeenCalled();
+	});
+});
+
+describe("processPrePushInline", () => {
+	const farDeadline = () => Date.now() + 60_000;
+
+	it("no-ops with no pending entries", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: {} });
+		const r = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(vi.fn()),
+		});
+		expect(r.note).toBe("no pending entries");
+		expect(claimForPush).not.toHaveBeenCalled();
+	});
+
+	it("keeps entries untouched when syncOnPush is disabled", async () => {
+		vi.mocked(loadConfig).mockResolvedValue({ jolliApiKey: "sk-jol-x", syncOnPush: false });
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		const r = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(vi.fn()),
+		});
+		expect(r.note).toBe("syncOnPush disabled");
+		expect(updateBatch).not.toHaveBeenCalled();
+	});
+
+	it("keeps entries untouched when not signed in", async () => {
+		vi.mocked(loadConfig).mockResolvedValue({});
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		const r = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(vi.fn()),
+		});
+		expect(r.note).toBe("not signed in");
+		expect(updateBatch).not.toHaveBeenCalled();
+	});
+
+	it("marks retry-exhausted entries as failed in the result list", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(3) } });
+		const r = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(vi.fn()),
+		});
+		expect(r.skippedRetryExhausted).toBe(1);
+		expect(r.note).toBe("no eligible entries");
+		expect(r.commits).toEqual([{ hash: HASH_A, status: "failed", reason: "failed repeatedly — giving up" }]);
+	});
+
+	it("claims ONLY this push's commits — leftover entries stay for the compensation channels", async () => {
+		const leftover = "c".repeat(40);
+		vi.mocked(loadPushPending).mockResolvedValue({
+			version: 1,
+			entries: { [leftover]: entry(), [HASH_A]: entry() },
+		});
+		const pushBatch = vi.fn(async () => okBatchResult(HASH_A));
+		const r = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(pushBatch),
+		});
+		expect(claimForPush).toHaveBeenCalledWith(CWD, [HASH_A]);
+		expect(r.commits.map((c) => c.hash)).toEqual([HASH_A]);
+	});
+
+	it("caps the candidate list at BATCH_MAX_ITEMS and defers the overflow", async () => {
+		const hashes = Array.from({ length: BATCH_MAX_ITEMS + 5 }, (_, i) => `hash-${String(i).padStart(3, "0")}`);
+		const entries: Record<string, PushPendingEntry> = {};
+		for (const hash of hashes) entries[hash] = entry();
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries });
+		const pushBatch = vi.fn(async () => ({ results: [] }));
+		const r = await processPrePushInline(CWD, {
+			priorityHashes: hashes,
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(pushBatch),
+		});
+		const candidates = vi.mocked(claimForPush).mock.calls[0][1];
+		expect(candidates).toHaveLength(BATCH_MAX_ITEMS);
+		expect(r.commits.filter((c) => c.status === "deferred")).toHaveLength(5);
+	});
+
+	it("returns early when every candidate was already claimed by another process", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		vi.mocked(claimForPush).mockResolvedValue({ claimed: new Set(), entries: {} });
+		const r = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(vi.fn()),
+		});
+		expect(r.note).toBe("all entries claimed by another process");
+	});
+
+	it("releases claims and reports notAttempted when the budget is already exhausted", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		const pushBatch = vi.fn();
+		const r = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A],
+			deadlineAt: Date.now() - 1,
+			client: fakeBatchClient(pushBatch),
+		});
+		expect(r.notAttempted).toBe(1);
+		expect(r.note).toBe("budget exhausted");
+		expect(pushBatch).not.toHaveBeenCalled();
+		expect(r.commits).toEqual([{ hash: HASH_A, status: "deferred", reason: "timed out — will sync later" }]);
+		const batch = vi.mocked(updateBatch).mock.calls[0][1];
+		expect(batch.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
+	});
+
+	it("releases no-memory candidates and deletes merged children before the batch", async () => {
+		const child = "e".repeat(40);
+		vi.mocked(loadPushPending).mockResolvedValue({
+			version: 1,
+			entries: { [HASH_A]: entry(), [child]: entry() },
+		});
+		vi.mocked(getIndexEntryMap).mockResolvedValue(
+			new Map([
+				[
+					child,
+					{
+						commitHash: child,
+						parentCommitHash: HASH_B,
+						commitMessage: "",
+						commitDate: "",
+						branch: "feature/x",
+						generatedAt: "",
+					},
+				],
+			]),
+		);
+		vi.mocked(getSummary).mockResolvedValue(null);
+		const r = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A, child],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(vi.fn()),
+		});
+		expect(r.skippedNoMemory).toBe(1);
+		expect(r.deletedChildren).toBe(1);
+		expect(r.note).toBe("no candidates with memory");
+		expect(r.commits).toEqual([
+			{ hash: HASH_A, status: "generating", reason: "memory still generating — will sync later" },
+			{ hash: child, status: "merged", reason: "merged into another commit's memory" },
+		]);
+		const batch = vi.mocked(updateBatch).mock.calls[0][1];
+		expect(batch.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
+		expect(batch.get(child)).toEqual({ kind: "delete" });
+	});
+
+	it("pushes with-memory candidates in one batch, deletes successes, and writes back", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({
+			version: 1,
+			entries: { [HASH_A]: entry(), [HASH_B]: entry() },
+		});
+		const pushBatch = vi.fn(async (_payload: unknown) => okBatchResult(HASH_A, HASH_B));
+		const r = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A, HASH_B],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(pushBatch),
+		});
+		expect(r.pushed).toBe(2);
+		expect(r.failed).toBe(0);
+		expect(pushBatch).toHaveBeenCalledTimes(1);
+		const payload = pushBatch.mock.calls[0][0] as { repoUrl?: string; items: Array<{ commitHash: string }> };
+		expect(payload.repoUrl).toBe("https://github.com/acme/repo");
+		expect(payload.items.map((i) => i.commitHash).sort()).toEqual([HASH_A, HASH_B]);
+		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
+		expect(batch?.get(HASH_A)).toEqual({ kind: "delete" });
+		expect(batch?.get(HASH_B)).toEqual({ kind: "delete" });
+		expect(applyBatchResult).toHaveBeenCalledTimes(1);
+		// Per-commit outcomes carry the resolved absolute article URLs, in push order.
+		expect(r.commits).toEqual([
+			{ hash: HASH_A, status: "pushed", url: "https://acme.jolli.ai/articles/doc-100" },
+			{ hash: HASH_B, status: "pushed", url: "https://acme.jolli.ai/articles/doc-101" },
+		]);
+	});
+
+	it("defers inline overflow beyond the server's total-content limit", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({
+			version: 1,
+			entries: { [HASH_A]: entry(), [HASH_B]: entry() },
+		});
+		vi.mocked(buildBatchItems).mockResolvedValueOnce([
+			{ ...builtItem(HASH_A), batchContentChars: BATCH_MAX_TOTAL_CONTENT_CHARS - 1 },
+			builtItem(HASH_B),
+		]);
+		const pushBatch = vi.fn(async (_payload: BatchPushPayload) => okBatchResult(HASH_A));
+
+		const result = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A, HASH_B],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(pushBatch),
+		});
+
+		expect(result.pushed).toBe(1);
+		expect(result.notAttempted).toBe(1);
+		expect(pushBatch).toHaveBeenCalledTimes(1);
+		expect(pushBatch.mock.calls[0][0].items.map((item: { commitHash: string }) => item.commitHash)).toEqual([
+			HASH_A,
+		]);
+		const updateCalls = vi.mocked(updateBatch).mock.calls;
+		expect(updateCalls.at(-1)?.[1].get(HASH_A)).toEqual({ kind: "delete" });
+		const releasedOverflow = updateCalls.find((call) => call[1].has(HASH_B))?.[1];
+		expect(releasedOverflow?.get(HASH_B)).toEqual({ kind: "patch", patch: {} });
+		expect(result.commits[1]).toEqual({
+			hash: HASH_B,
+			status: "deferred",
+			reason: "batch content limit reached — will sync later",
+		});
+	});
+
+	it("keeps an inline success pending when confirmed orphan cleanup is still required", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		vi.mocked(applyBatchResult).mockResolvedValueOnce({
+			writtenBack: 1,
+			childSkipped: 0,
+			cleanupPendingHashes: [HASH_A],
+		});
+
+		const result = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(vi.fn(async () => okBatchResult(HASH_A))),
+		});
+
+		expect(result.pushed).toBe(1);
+		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
+		expect(batch?.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
+	});
+
+	it("keeps an inline success pending with the minted ids when its write-back fails", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		vi.mocked(applyBatchResult).mockResolvedValueOnce({
+			writtenBack: 0,
+			childSkipped: 0,
+			writeBackFailures: [{ commitHash: HASH_A, docId: 100, url: "https://acme.jolli.ai/articles/doc-100" }],
+		});
+
+		const result = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(vi.fn(async () => okBatchResult(HASH_A))),
+		});
+
+		// The push itself succeeded — the commit still reports as pushed.
+		expect(result.pushed).toBe(1);
+		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
+		expect(batch?.get(HASH_A)).toEqual({
+			kind: "patch",
+			patch: {
+				lastAttemptAt: expect.any(String),
+				lastError: "pushed, but persisting the article id locally failed — will retry the write-back",
+				pushedDocId: 100,
+				pushedUrl: "https://acme.jolli.ai/articles/doc-100",
+			},
+		});
+	});
+
+	it("grafts the recovered docId/url from the pending entry into the batch build", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({
+			version: 1,
+			entries: { [HASH_A]: entry(0, { pushedDocId: 55, pushedUrl: "https://acme.jolli.ai/articles/doc-55" }) },
+		});
+
+		await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(vi.fn(async () => okBatchResult(HASH_A))),
+		});
+
+		const builtSummaries = vi.mocked(buildBatchItems).mock.calls[0][0];
+		expect(builtSummaries[0]).toMatchObject({
+			jolliDocId: 55,
+			jolliDocUrl: "https://acme.jolli.ai/articles/doc-55",
+		});
+	});
+
+	it("never overrides a summary's own docId with the recovered one", async () => {
+		vi.mocked(getSummary).mockImplementation(async (hash: string) => ({
+			...summary(hash),
+			jolliDocId: 7,
+			jolliDocUrl: "https://acme.jolli.ai/articles/doc-7",
+		}));
+		vi.mocked(loadPushPending).mockResolvedValue({
+			version: 1,
+			entries: { [HASH_A]: entry(0, { pushedDocId: 55, pushedUrl: "https://acme.jolli.ai/articles/doc-55" }) },
+		});
+
+		await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(vi.fn(async () => okBatchResult(HASH_A))),
+		});
+
+		const builtSummaries = vi.mocked(buildBatchItems).mock.calls[0][0];
+		expect(builtSummaries[0]).toMatchObject({ jolliDocId: 7, jolliDocUrl: "https://acme.jolli.ai/articles/doc-7" });
+	});
+
+	it("records a per-item failure with a counted retry while the rest succeed", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({
+			version: 1,
+			entries: { [HASH_A]: entry(1), [HASH_B]: entry() },
+		});
+		const pushBatch = vi.fn(async () => ({
+			results: [
+				{ commitHash: HASH_A, ok: false, attachments: [], error: "boom", errorCode: "push_failed" },
+				...okBatchResult(HASH_B).results,
+			],
+		}));
+		const r = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A, HASH_B],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(pushBatch),
+		});
+		expect(r.pushed).toBe(1);
+		expect(r.failed).toBe(1);
+		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
+		const update = batch?.get(HASH_A);
+		expect(update).toMatchObject({ kind: "patch" });
+		if (update?.kind === "patch") {
+			expect(update.patch.retryCount).toBe(2);
+			expect(update.patch.lastError).toBe("boom");
+		}
+		expect(batch?.get(HASH_B)).toEqual({ kind: "delete" });
+		expect(r.commits).toEqual([
+			{ hash: HASH_A, status: "failed", reason: "boom" },
+			{ hash: HASH_B, status: "pushed", url: "https://acme.jolli.ai/articles/doc-100" },
+		]);
+	});
+
+	it("marks a hash missing from the response as failed", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		const pushBatch = vi.fn(async () => ({ results: [] }));
+		const r = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(pushBatch),
+		});
+		expect(r.failed).toBe(1);
+		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
+		const update = batch?.get(HASH_A);
+		if (update?.kind === "patch") {
+			expect(update.patch.lastError).toBe("missing batch result");
+		}
+		expect(r.commits).toEqual([{ hash: HASH_A, status: "failed", reason: "missing batch result" }]);
+	});
+
+	it("counts the retry on a whole-request operational failure", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(1) } });
+		const pushBatch = vi.fn(async () => {
+			throw new Error("network down");
+		});
+		const r = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(pushBatch),
+		});
+		expect(r.failed).toBe(1);
+		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
+		const update = batch?.get(HASH_A);
+		if (update?.kind === "patch") {
+			expect(update.patch.retryCount).toBe(2);
+			expect(update.patch.lastError).toContain("network down");
+		}
+		expect(r.commits).toEqual([{ hash: HASH_A, status: "failed", reason: "network down" }]);
+	});
+
+	it("holds the retry count on a whole-request config failure (not signed in mid-flight)", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(1) } });
+		const pushBatch = vi.fn(async () => {
+			throw new NotAuthenticatedError();
+		});
+		const r = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(pushBatch),
+		});
+		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
+		const update = batch?.get(HASH_A);
+		if (update?.kind === "patch") {
+			expect(update.patch.retryCount).toBeUndefined();
+			expect(update.patch.lastError).toBe("not-authenticated");
+		}
+		// The result list shows the friendly wording, not the raw error code.
+		expect(r.commits).toEqual([{ hash: HASH_A, status: "failed", reason: "not signed in to Jolli" }]);
+	});
+
+	it("labels a space-permission failure distinctly in the result list (no retry burn)", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(1) } });
+		const pushBatch = vi.fn(async () => {
+			throw new PermissionDeniedError("Insufficient space permissions");
+		});
+		const r = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(pushBatch),
+		});
+		expect(r.commits).toEqual([
+			{ hash: HASH_A, status: "failed", reason: "no permission to write to the bound Jolli Space" },
+		]);
+		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
+		const update = batch?.get(HASH_A);
+		if (update?.kind === "patch") {
+			expect(update.patch.retryCount).toBeUndefined();
+			expect(update.patch.lastError).toBe("permission-denied");
+		}
+	});
+
+	it("releases claims without retry burn when the server lacks batch support", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		const pushBatch = vi.fn(async () => {
+			throw new BatchUnsupportedError();
+		});
+		const r = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(pushBatch),
+		});
+		expect(r.notAttempted).toBe(1);
+		expect(r.note).toBe("server lacks batch support");
+		expect(r.commits).toEqual([
+			{ hash: HASH_A, status: "deferred", reason: "server does not support batch push yet" },
+		]);
+		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
+		expect(batch?.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
+	});
+
+	it("releases claims without retry burn when the request aborts at the deadline", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		const abortError = new Error("This operation was aborted");
+		abortError.name = "AbortError";
+		const pushBatch = vi.fn(async () => {
+			throw abortError;
+		});
+		const r = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(pushBatch),
+		});
+		expect(r.notAttempted).toBe(1);
+		expect(r.note).toBe("deadline exceeded");
+		expect(r.commits).toEqual([{ hash: HASH_A, status: "deferred", reason: "timed out — will sync later" }]);
+		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
+		expect(batch?.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
+	});
+
+	it("marks entries claimed by a concurrent process as deferred in the result list", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		vi.mocked(claimForPush).mockResolvedValue({ claimed: new Set(), entries: {} });
+		const r = await processPrePushInline(CWD, {
+			priorityHashes: [HASH_A],
+			deadlineAt: farDeadline(),
+			client: fakeBatchClient(vi.fn()),
+		});
+		expect(r.note).toBe("all entries claimed by another process");
+		expect(r.commits).toEqual([
+			{ hash: HASH_A, status: "deferred", reason: "another sync is already handling this commit" },
+		]);
 	});
 });
 

--- a/cli/src/core/PushExecutor.ts
+++ b/cli/src/core/PushExecutor.ts
@@ -1,22 +1,31 @@
 /**
  * PushExecutor — the shared "drain push-pending.json to Jolli Space" core.
  *
- * Called by all three consumers of the pre-push sync flow:
- *   - PrePushWorker            (detached, source="pre-push")
- *   - QueueWorker post-drain   (in-process, source="post-queue", hashFilter set)
- *   - plugin/CLI activation    (source="activation")
+ * Two drain flavors share the triage/claim/accounting machinery:
+ *   - `processPushPending`   — compensation drain, called by QueueWorker
+ *     post-drain (source="post-queue", hashFilter set) and plugin/CLI
+ *     activation (source="activation"). Publishes only after the remote ref
+ *     confirms the git push landed. Batch-first (chunks of BATCH_MAX_ITEMS
+ *     through `pushBatch`, orphan cleanup included); falls back to the legacy
+ *     per-commit `pushSummary` loop when the server predates the endpoint.
+ *   - `processPrePushInline` — called synchronously INSIDE the pre-push hook,
+ *     before git transfers objects. Pushes every with-memory candidate in ONE
+ *     `pushBatch` HTTP request under a hard wall-clock budget, deliberately
+ *     WITHOUT push confirmation (waiting for the remote ref inside the hook
+ *     would deadlock — git waits for the hook to exit before transferring).
  *
- * Reuses the existing push_memory path verbatim — `pushSummary` for the
- * per-commit upload and `assignOwnedAttachments` for cross-commit plan/note
- * dedup — so nothing about the Jolli Space contract is re-implemented here
- * (JOLLI-1900 requirement 3). `pushBranchToJolli` is intentionally NOT used:
- * it pushes the whole branch as one unit with no per-commit retry state, which
- * is what the pending-file model provides.
+ * Both reuse the existing push_memory building blocks — `pushSummary` /
+ * `buildBatchItems` + `applyBatchResult` for uploads and
+ * `assignOwnedAttachments` for cross-commit plan/note dedup — so nothing about
+ * the Jolli Space contract is re-implemented here (JOLLI-1900 requirement 3).
+ * `pushBranchToJolli` is intentionally NOT used: it pushes the whole branch as
+ * one unit with no per-commit retry state, which is what the pending-file
+ * model provides.
  *
  * Cross-commit dedup requires the full branch context. The current branch uses
  * `base..HEAD`; off-current branches are reconstructed from root summaries in
  * the summary index. Every pending commit therefore gets the plans/notes it
- * owns even when the user checked out another branch before the worker ran.
+ * owns even when the user checked out another branch before the drain runs.
  */
 
 import { createLogger, errMsg } from "../Logger.js";
@@ -24,15 +33,25 @@ import type { CommitSummary } from "../Types.js";
 import { mapWithConcurrency } from "./Concurrency.js";
 import { execGit, getCurrentBranch, getDefaultBranch } from "./GitOps.js";
 import { getCanonicalRepoUrl } from "./GitRemoteUtils.js";
+import { resolveArticleUrl } from "./JolliApiUtils.js";
 import {
+	BATCH_MAX_ITEMS,
+	BATCH_MAX_TOTAL_CONTENT_CHARS,
+	type BatchPushResult,
+	BatchUnsupportedError,
 	BindingRequiredError,
 	ClientOutdatedError,
 	JolliMemoryPushClient,
 	NotAuthenticatedError,
+	PermissionDeniedError,
 } from "./JolliMemoryPushClient.js";
 import {
 	type AttachmentSelection,
+	applyBatchResult,
 	assignOwnedAttachments,
+	type BatchWriteBackFailure,
+	type BuiltBatchItem,
+	buildBatchItems,
 	type PushContext,
 	pushSummary,
 } from "./JolliMemoryPushOrchestrator.js";
@@ -54,11 +73,15 @@ import { getActiveStorage, getIndexEntryMap, getSummary, setActiveStorage } from
 
 const log = createLogger("PushExecutor");
 
-const PUSH_CONFIRM_POLL_ATTEMPTS = 60;
-const PUSH_CONFIRM_POLL_INTERVAL_MS = 1_000;
+/**
+ * Minimum wall-clock budget worth spending on the inline batch HTTP request.
+ * Below this, `processPrePushInline` releases its claims instead of firing a
+ * request that would almost certainly be aborted mid-flight.
+ */
+export const INLINE_MIN_HTTP_BUDGET_MS = 500;
 
 /** Where a `processPushPending` call originated — used only for logging. */
-export type PushSource = "pre-push" | "post-queue" | "activation";
+export type PushSource = "post-queue" | "activation";
 
 export interface ProcessPushPendingOptions {
 	readonly source: PushSource;
@@ -94,15 +117,16 @@ export interface ProcessPushPendingResult {
  */
 export function classifyError(err: unknown): { readonly increment: boolean; readonly message: string } {
 	if (err instanceof NotAuthenticatedError) return { increment: false, message: "not-authenticated" };
+	if (err instanceof PermissionDeniedError) return { increment: false, message: "permission-denied" };
 	if (err instanceof BindingRequiredError) return { increment: false, message: "binding-required" };
 	if (err instanceof ClientOutdatedError) return { increment: false, message: "client-outdated" };
 	return { increment: true, message: errMsg(err) };
 }
 
 /**
- * Ensures a StorageProvider is active for this process. PrePushWorker starts
- * fresh (no active storage) and must create one; the QueueWorker post-drain
- * path already has storage set by the drain, so we reuse it.
+ * Ensures a StorageProvider is active for this process. The pre-push hook
+ * process starts fresh (no active storage) and must create one; the QueueWorker
+ * post-drain path already has storage set by the drain, so we reuse it.
  */
 async function ensureStorage(cwd: string): Promise<StorageProvider> {
 	const active = getActiveStorage();
@@ -141,7 +165,6 @@ async function waitForConfirmedPushes(
 	cwd: string,
 	hashes: ReadonlyArray<string>,
 	entries: Readonly<Record<string, PushPendingEntry>>,
-	source: PushSource,
 ): Promise<string[]> {
 	const targets = new Map<string, PushTarget>();
 	for (const hash of hashes) {
@@ -155,25 +178,19 @@ async function waitForConfirmedPushes(
 		if (!pushRemotes.has(target.remote))
 			pushRemotes.set(target.remote, await resolvePushRemote(cwd, target.remote));
 	}
-	const attempts = source === "pre-push" ? PUSH_CONFIRM_POLL_ATTEMPTS : 1;
-	for (let attempt = 0; attempt < attempts; attempt++) {
-		await Promise.all(
-			[...targets].map(async ([key, target]) => {
-				if (
-					!confirmedTargets.has(key) &&
-					(await isPushTargetConfirmed(cwd, target, pushRemotes.get(target.remote) ?? target.remote))
-				)
-					confirmedTargets.add(key);
-			}),
-		);
-		const confirmedHashes = hashes.filter((hash) => {
-			const entryTargets = entries[hash].pushTargets;
-			return !entryTargets?.length || entryTargets.some((target) => confirmedTargets.has(pushTargetKey(target)));
-		});
-		if (confirmedHashes.length === hashes.length || attempt === attempts - 1) return confirmedHashes;
-		await new Promise<void>((resolve) => setTimeout(resolve, PUSH_CONFIRM_POLL_INTERVAL_MS));
-	}
-	return [];
+	// Single pass: both remaining callers (post-queue, activation) run after any
+	// git push has already finished, so there is nothing to poll for — the old
+	// 60x1s pre-push polling went away with the detached PrePushWorker.
+	await Promise.all(
+		[...targets].map(async ([key, target]) => {
+			if (await isPushTargetConfirmed(cwd, target, pushRemotes.get(target.remote) ?? target.remote))
+				confirmedTargets.add(key);
+		}),
+	);
+	return hashes.filter((hash) => {
+		const entryTargets = entries[hash].pushTargets;
+		return !entryTargets?.length || entryTargets.some((target) => confirmedTargets.has(pushTargetKey(target)));
+	});
 }
 
 async function buildAttachmentOwnership(
@@ -231,6 +248,76 @@ async function buildAttachmentOwnership(
 	return { ownedPlans, ownedNotes, ownedReferences };
 }
 
+/** Partitions batch-eligible items by both item count and total content size. */
+function partitionBatchItems(items: ReadonlyArray<BuiltBatchItem>): BuiltBatchItem[][] {
+	const batches: BuiltBatchItem[][] = [];
+	let current: BuiltBatchItem[] = [];
+	let currentChars = 0;
+	for (const item of items) {
+		if (
+			current.length > 0 &&
+			(current.length >= BATCH_MAX_ITEMS || currentChars + item.batchContentChars > BATCH_MAX_TOTAL_CONTENT_CHARS)
+		) {
+			batches.push(current);
+			current = [];
+			currentChars = 0;
+		}
+		current.push(item);
+		currentChars += item.batchContentChars;
+	}
+	if (current.length > 0) batches.push(current);
+	return batches;
+}
+
+/** Keeps successful entries queued when their orphan cleanup is not finished. */
+function preserveCleanupPending(
+	updates: Map<string, BatchUpdate>,
+	cleanupPendingHashes: ReadonlyArray<string> | undefined,
+): void {
+	for (const hash of cleanupPendingHashes ?? []) {
+		if (updates.get(hash)?.kind === "delete") updates.set(hash, { kind: "patch", patch: {} });
+	}
+}
+
+/**
+ * Keeps entries whose article was pushed but whose local docId write-back
+ * failed: the patch records the minted docId/url so the next drain retries as
+ * an UPDATE of the same article (never a duplicate CREATE) and the write-back
+ * gets another chance. `retryCount` is deliberately untouched — the push
+ * itself succeeded, so the operational retry budget must not shrink.
+ */
+function preserveWriteBackFailures(
+	updates: Map<string, BatchUpdate>,
+	failures: ReadonlyArray<BatchWriteBackFailure> | undefined,
+	attemptedAtIso: string,
+): void {
+	for (const failure of failures ?? []) {
+		if (updates.get(failure.commitHash)?.kind !== "delete") continue;
+		updates.set(failure.commitHash, {
+			kind: "patch",
+			patch: {
+				lastAttemptAt: attemptedAtIso,
+				lastError: "pushed, but persisting the article id locally failed — will retry the write-back",
+				pushedDocId: failure.docId,
+				pushedUrl: failure.url,
+			},
+		});
+	}
+}
+
+/**
+ * Grafts the docId/url a previous push minted — but failed to persist locally
+ * (see `PushPendingEntry.pushedDocId`) — onto a summary that lacks one, so the
+ * retry UPDATEs the existing article instead of CREATEing a duplicate. The
+ * tenant gate stays where it always was: `buildBatchItems`/`pushSummary` only
+ * reuse the id when `canReuseDocId` accepts the grafted url.
+ */
+function withRecoveredDocId(summary: CommitSummary, entry: PushPendingEntry | undefined): CommitSummary {
+	if (summary.jolliDocId !== undefined) return summary;
+	if (entry?.pushedDocId === undefined || entry.pushedUrl === undefined) return summary;
+	return { ...summary, jolliDocId: entry.pushedDocId, jolliDocUrl: entry.pushedUrl };
+}
+
 /**
  * Drains eligible entries from `push-pending.json` to the bound Jolli Space.
  * Idempotent and safe to call concurrently across processes — every state
@@ -255,7 +342,16 @@ export async function processPushPending(
 	// processes never double-push the same entry.
 	const pending = await loadPushPending(cwd);
 	const allHashes = Object.keys(pending.entries);
-	if (allHashes.length === 0) return { ...empty, note: "no pending entries" };
+	if (allHashes.length === 0) {
+		log.debug("processPushPending(%s): no pending entries", options.source);
+		return { ...empty, note: "no pending entries" };
+	}
+	log.info(
+		"processPushPending(%s): %d pending entr(ies)%s",
+		options.source,
+		allHashes.length,
+		options.hashFilter ? ` (filtered to ${options.hashFilter.size} hash(es))` : "",
+	);
 
 	const config = await loadConfig();
 
@@ -293,18 +389,39 @@ export async function processPushPending(
 	}
 	if (eligible.length === 0) return { ...empty, skippedRetryExhausted, note: "no eligible entries" };
 
-	// The hook runs before Git transfers objects, so the detached worker can start
-	// while the push is still in flight. Do not publish until the remote ref proves
-	// that the push succeeded. Failed/rejected pushes remain pending for a retry.
-	const confirmed = await waitForConfirmedPushes(cwd, eligible, pending.entries, options.source);
-	if (confirmed.length === 0) return { ...empty, skippedRetryExhausted, note: "push not confirmed" };
+	// Do not publish until the remote ref proves that the push succeeded.
+	// Failed/rejected pushes remain pending for a retry.
+	const confirmed = await waitForConfirmedPushes(cwd, eligible, pending.entries);
+	if (confirmed.length === 0) {
+		log.info(
+			"processPushPending(%s): no candidate confirmed on the remote yet — keeping %d entr(ies)",
+			options.source,
+			eligible.length,
+		);
+		return { ...empty, skippedRetryExhausted, note: "push not confirmed" };
+	}
+	log.debug(
+		"processPushPending(%s): %d/%d candidate(s) confirmed on the remote",
+		options.source,
+		confirmed.length,
+		eligible.length,
+	);
 
 	// Atomic claim: stamp `claimedAt` on every confirmed hash under the file
 	// lock. A concurrent `processPushPending` that races us will see a fresh
 	// `claimedAt` and skip the entry, preventing duplicate Space articles.
 	const { claimed, entries: claimedEntries } = await claimForPush(cwd, confirmed);
-	if (claimed.size === 0) return { ...empty, skippedRetryExhausted, note: "all entries claimed by another process" };
+	if (claimed.size === 0) {
+		log.info("processPushPending(%s): all candidates already claimed by another process", options.source);
+		return { ...empty, skippedRetryExhausted, note: "all entries claimed by another process" };
+	}
 	const claimedHashes = confirmed.filter((h) => claimed.has(h));
+	log.info(
+		"processPushPending(%s): claimed %d/%d candidate(s)",
+		options.source,
+		claimedHashes.length,
+		confirmed.length,
+	);
 
 	const storage = await ensureStorage(cwd);
 
@@ -352,7 +469,7 @@ export async function processPushPending(
 		// merge worker and pushes a stale pre-squash summary via tree fallback.
 		if (summary && summary.commitHash === hash) {
 			withMemory.push(hash);
-			candidateSummaries.set(hash, summary);
+			candidateSummaries.set(hash, withRecoveredDocId(summary, claimedEntries[hash]));
 		} else {
 			preFlightUpdates.set(hash, { kind: "patch", patch: {} });
 			skippedNoMemory++;
@@ -361,6 +478,13 @@ export async function processPushPending(
 	if (preFlightUpdates.size > 0) {
 		await updateBatch(cwd, preFlightUpdates);
 	}
+	log.info(
+		"processPushPending(%s): triage — withMemory=%d noMemory=%d mergedChildren=%d",
+		options.source,
+		withMemory.length,
+		skippedNoMemory,
+		deletedChildren,
+	);
 	if (withMemory.length === 0) {
 		const note =
 			deletedChildren > 0 && skippedNoMemory === 0
@@ -369,13 +493,7 @@ export async function processPushPending(
 		return { ...empty, skippedNoMemory, skippedRetryExhausted, deletedChildren, note };
 	}
 
-	const { ownedPlans, ownedNotes, ownedReferences } = await buildAttachmentOwnership(
-		cwd,
-		storage,
-		claimedEntries,
-		withMemory,
-		candidateSummaries,
-	);
+	const ownership = await buildAttachmentOwnership(cwd, storage, claimedEntries, withMemory, candidateSummaries);
 
 	const client = options.client ?? new JolliMemoryPushClient();
 	const repoUrl = await getCanonicalRepoUrl(cwd);
@@ -385,65 +503,738 @@ export async function processPushPending(
 	log.info("processPushPending(%s): pushing %d commit(s)", options.source, withMemory.length);
 
 	const updates = new Map<string, BatchUpdate>();
-	const nowIso = new Date().toISOString();
+	const counters = { pushed: 0, failed: 0 };
 
-	const results = await mapWithConcurrency(
-		withMemory,
-		PUSH_CONCURRENCY,
-		async (hash): Promise<"pushed" | "failed"> => {
-			// Re-read immediately before the network call so a concurrent rewrite or
-			// cleanup cannot make us publish a stale summary captured above.
-			const summary = await getSummary(hash, cwd, storage);
-			if (!summary || summary.commitHash !== hash) {
-				// Raced away (deleted between the memory check and here), or
-				// tree-hash fallback resolved to another commit's summary. Drop it.
-				updates.set(hash, { kind: "delete" });
-				return "failed";
+	// Batch-first: candidate windows are capped by item count, then split again
+	// by the server's total-content limit. Items that cannot pass the batch schema
+	// use the legacy per-commit path so one oversized memory cannot reject every
+	// otherwise-valid item in its batch.
+	let index = 0;
+	batchLoop: while (index < withMemory.length) {
+		const chunkHashes = withMemory.slice(index, index + BATCH_MAX_ITEMS);
+		index += chunkHashes.length;
+		const chunkSummaries: CommitSummary[] = [];
+		for (const hash of chunkHashes) {
+			const summary = candidateSummaries.get(hash);
+			if (summary) chunkSummaries.push(summary);
+		}
+		const built = await buildBatchItems(chunkSummaries, ownership, ctx);
+		const individualFallbackHashes = built
+			.filter((item) => item.batchIneligibleReason !== undefined)
+			.map((item) => item.item.commitHash);
+		for (const item of built) {
+			if (item.batchIneligibleReason) {
+				log.info(
+					"Commit %s requires individual push: %s",
+					item.item.commitHash.substring(0, 8),
+					item.batchIneligibleReason,
+				);
 			}
-			const attachments: AttachmentSelection = {
-				plans: ownedPlans.get(hash) ?? [],
-				notes: ownedNotes.get(hash) ?? [],
-				references: ownedReferences.get(hash) ?? [],
-			};
+		}
+		const batchGroups = partitionBatchItems(built.filter((item) => item.batchIneligibleReason === undefined));
+
+		for (let groupIndex = 0; groupIndex < batchGroups.length; groupIndex++) {
+			const batchBuilt = batchGroups[groupIndex];
+			const batchHashes = batchBuilt.map((item) => item.item.commitHash);
+			let batchResult: BatchPushResult;
 			try {
-				await pushSummary(summary, ctx, attachments);
-				updates.set(hash, { kind: "delete" });
-				return "pushed";
+				batchResult = await client.pushBatch({ repoUrl, items: batchBuilt.map((item) => item.item) });
 			} catch (err) {
+				if (err instanceof BatchUnsupportedError) {
+					log.info(
+						"processPushPending(%s): server lacks batch support — falling back to per-commit pushes",
+						options.source,
+					);
+					const fallbackHashes = [
+						...batchGroups.slice(groupIndex).flatMap((group) => group.map((item) => item.item.commitHash)),
+						...individualFallbackHashes,
+						...withMemory.slice(index),
+					];
+					await pushCandidatesIndividually({
+						cwd,
+						storage,
+						hashes: fallbackHashes,
+						ownership,
+						claimedEntries,
+						ctx,
+						updates,
+						counters,
+					});
+					break batchLoop;
+				}
 				const { increment, message } = classifyError(err);
-				const entry = claimedEntries[hash];
+				const failedAtIso = new Date().toISOString();
+				// Config failures affect every unsent item identically, so release all
+				// remaining claims without wasting more network requests.
+				const affected = increment
+					? batchHashes
+					: [
+							...batchHashes,
+							...batchGroups
+								.slice(groupIndex + 1)
+								.flatMap((group) => group.map((item) => item.item.commitHash)),
+							...individualFallbackHashes,
+							...withMemory.slice(index),
+						];
+				for (const hash of affected) {
+					updates.set(hash, {
+						kind: "patch",
+						patch: {
+							lastAttemptAt: failedAtIso,
+							lastError: message,
+							...(increment ? { retryCount: claimedEntries[hash].retryCount + 1 } : {}),
+						},
+					});
+				}
+				counters.failed += affected.length;
+				log.warn(
+					"processPushPending(%s): batch request failed for %d commit(s): %s (retry %s)",
+					options.source,
+					affected.length,
+					message,
+					increment ? "counted" : "held",
+				);
+				if (!increment) break batchLoop;
+				continue;
+			}
+
+			const resultByHash = new Map(batchResult.results.map((result) => [result.commitHash, result]));
+			const nowIso = new Date().toISOString();
+			for (const hash of batchHashes) {
+				const result = resultByHash.get(hash);
+				if (result?.ok) {
+					updates.set(hash, { kind: "delete" });
+					counters.pushed++;
+					continue;
+				}
+				counters.failed++;
+				const message = result?.error ?? result?.errorCode ?? "missing batch result";
 				updates.set(hash, {
 					kind: "patch",
 					patch: {
 						lastAttemptAt: nowIso,
 						lastError: message,
-						...(increment ? { retryCount: entry.retryCount + 1 } : {}),
+						retryCount: claimedEntries[hash].retryCount + 1,
 					},
 				});
-				log.warn(
-					"Push failed for %s: %s (retry %s)",
-					hash.substring(0, 8),
-					message,
-					increment ? "counted" : "held",
-				);
-				return "failed";
+				log.warn("Batch push failed for %s: %s", hash.substring(0, 8), message);
 			}
-		},
-	);
+
+			// Compensation has no wall-clock budget, so it resolves delayed orphan
+			// hashes and deletes known orphaned articles after each successful batch.
+			try {
+				const writeBack = await applyBatchResult(batchBuilt, batchResult.results, ctx, {
+					cleanupOrphans: true,
+				});
+				preserveCleanupPending(updates, writeBack.cleanupPendingHashes);
+				preserveWriteBackFailures(updates, writeBack.writeBackFailures, nowIso);
+				log.info(
+					"processPushPending(%s): write-back — writtenBack=%d childSkipped=%d cleanupPending=%d writeBackFailed=%d",
+					options.source,
+					writeBack.writtenBack,
+					writeBack.childSkipped,
+					writeBack.cleanupPendingHashes?.length ?? 0,
+					writeBack.writeBackFailures?.length ?? 0,
+				);
+			} catch (err) {
+				log.warn("processPushPending(%s): write-back failed: %s", options.source, errMsg(err));
+			}
+		}
+
+		if (individualFallbackHashes.length > 0) {
+			await pushCandidatesIndividually({
+				cwd,
+				storage,
+				hashes: individualFallbackHashes,
+				ownership,
+				claimedEntries,
+				ctx,
+				updates,
+				counters,
+			});
+		}
+	}
 
 	await updateBatch(cwd, updates);
-
-	const pushed = results.filter((r) => r === "pushed").length;
-	const failed = results.filter((r) => r === "failed").length;
-	log.info("processPushPending(%s): pushed=%d failed=%d", options.source, pushed, failed);
+	log.info("processPushPending(%s): pushed=%d failed=%d", options.source, counters.pushed, counters.failed);
 
 	return {
 		attempted: withMemory.length,
-		pushed,
-		failed,
+		pushed: counters.pushed,
+		failed: counters.failed,
 		skippedNoMemory,
 		skippedRetryExhausted,
 		deletedChildren,
+	};
+}
+
+/**
+ * Legacy per-commit push loop — retained as the fallback for servers that
+ * predate the batch endpoint. Identical semantics to the pre-batch drain:
+ * re-reads each summary right before the network call (stale-summary race
+ * guard), pushes via `pushSummary` (orphan cleanup included), and fills
+ * `updates`/`counters` in place.
+ */
+async function pushCandidatesIndividually(args: {
+	readonly cwd: string;
+	readonly storage: StorageProvider;
+	readonly hashes: ReadonlyArray<string>;
+	readonly ownership: {
+		readonly ownedPlans: ReadonlyMap<string, NonNullable<CommitSummary["plans"]>>;
+		readonly ownedNotes: ReadonlyMap<string, NonNullable<CommitSummary["notes"]>>;
+		readonly ownedReferences: ReadonlyMap<string, NonNullable<CommitSummary["references"]>>;
+	};
+	readonly claimedEntries: Readonly<Record<string, PushPendingEntry>>;
+	readonly ctx: PushContext;
+	readonly updates: Map<string, BatchUpdate>;
+	readonly counters: { pushed: number; failed: number };
+}): Promise<void> {
+	const { cwd, storage, hashes, ownership, claimedEntries, ctx, updates, counters } = args;
+	const nowIso = new Date().toISOString();
+	const results = await mapWithConcurrency(hashes, PUSH_CONCURRENCY, async (hash): Promise<"pushed" | "failed"> => {
+		// Re-read immediately before the network call so a concurrent rewrite or
+		// cleanup cannot make us publish a stale summary captured earlier.
+		const freshSummary = await getSummary(hash, cwd, storage);
+		if (!freshSummary || freshSummary.commitHash !== hash) {
+			// Raced away (deleted between the memory check and here), or
+			// tree-hash fallback resolved to another commit's summary. Drop it.
+			updates.set(hash, { kind: "delete" });
+			return "failed";
+		}
+		const summary = withRecoveredDocId(freshSummary, claimedEntries[hash]);
+		const attachments: AttachmentSelection = {
+			plans: ownership.ownedPlans.get(hash) ?? [],
+			notes: ownership.ownedNotes.get(hash) ?? [],
+			references: ownership.ownedReferences.get(hash) ?? [],
+		};
+		try {
+			await pushSummary(summary, ctx, attachments);
+			updates.set(hash, { kind: "delete" });
+			return "pushed";
+		} catch (err) {
+			const { increment, message } = classifyError(err);
+			const entry = claimedEntries[hash];
+			updates.set(hash, {
+				kind: "patch",
+				patch: {
+					lastAttemptAt: nowIso,
+					lastError: message,
+					...(increment ? { retryCount: entry.retryCount + 1 } : {}),
+				},
+			});
+			log.warn(
+				"Push failed for %s: %s (retry %s)",
+				hash.substring(0, 8),
+				message,
+				increment ? "counted" : "held",
+			);
+			return "failed";
+		}
+	});
+	for (const result of results) {
+		if (result === "pushed") counters.pushed++;
+		else counters.failed++;
+	}
+}
+
+// ─── Inline pre-push drain (synchronous, budget-bound, single batch request) ─
+
+export interface ProcessPrePushInlineOptions {
+	/** Commits of the current push — the ONLY entries this drain considers, in push order. */
+	readonly priorityHashes: ReadonlyArray<string>;
+	/** Absolute epoch-ms deadline for the WHOLE inline phase (local reads + HTTP). */
+	readonly deadlineAt: number;
+	/** Test seam — defaults to a real client whose timeout is the remaining budget. */
+	readonly client?: JolliMemoryPushClient;
+}
+
+/** Display status of one commit in the inline pre-push sync result list. */
+export type InlineCommitStatus = "pushed" | "generating" | "failed" | "deferred" | "merged";
+
+/** Per-commit outcome, in push order — feeds the hook's `git push` result list. */
+export interface InlineCommitOutcome {
+	readonly hash: string;
+	readonly status: InlineCommitStatus;
+	/** Absolute article URL — set only for "pushed". */
+	readonly url?: string;
+	/** Short human-readable reason — set for every non-"pushed" status. */
+	readonly reason?: string;
+}
+
+export interface ProcessPrePushInlineResult {
+	readonly attempted: number;
+	readonly pushed: number;
+	readonly failed: number;
+	readonly skippedNoMemory: number;
+	readonly skippedRetryExhausted: number;
+	readonly deletedChildren: number;
+	/** Claimed candidates released untouched — budget/limit deferral, deadline abort, or no batch support. */
+	readonly notAttempted: number;
+	/** Per-commit outcomes of THIS push's commits, in push order. */
+	readonly commits: ReadonlyArray<InlineCommitOutcome>;
+	/** Set when the run short-circuited or the batch request failed as a whole. */
+	readonly note?: string;
+}
+
+const EMPTY_INLINE_RESULT: ProcessPrePushInlineResult = {
+	attempted: 0,
+	pushed: 0,
+	failed: 0,
+	skippedNoMemory: 0,
+	skippedRetryExhausted: 0,
+	deletedChildren: 0,
+	notAttempted: 0,
+	commits: [],
+};
+
+/** Orders the collected outcomes by the push's own commit order. */
+function commitsInPushOrder(
+	priorityHashes: ReadonlyArray<string>,
+	outcomes: ReadonlyMap<string, InlineCommitOutcome>,
+): InlineCommitOutcome[] {
+	const commits: InlineCommitOutcome[] = [];
+	for (const hash of priorityHashes) {
+		const outcome = outcomes.get(hash);
+		if (outcome) commits.push(outcome);
+	}
+	return commits;
+}
+
+/** Short, user-facing reason for a failed push — printed verbatim in the hook's result list. */
+function friendlyPushFailure(message: string): string {
+	if (message === "not-authenticated") return "not signed in to Jolli";
+	if (message === "permission-denied") return "no permission to write to the bound Jolli Space";
+	if (message === "binding-required") return "repo is not bound to a Jolli Space";
+	if (message === "client-outdated") return "Jolli client is outdated — please update";
+	const compact = message.trim().replace(/\s+/g, " ");
+	return compact.length > 60 ? `${compact.substring(0, 59)}…` : compact;
+}
+
+/** True for a fetch aborted by the client's own deadline timer — not a server failure. */
+function isAbortError(err: unknown): boolean {
+	return err instanceof Error && err.name === "AbortError";
+}
+
+/**
+ * Releases claims without recording an attempt: an empty patch clears
+ * `claimedAt` only, so any later drain (post-queue, activation, next push)
+ * can pick the entry up immediately instead of waiting out the claim TTL.
+ */
+async function releaseClaims(cwd: string, hashes: ReadonlyArray<string>): Promise<void> {
+	if (hashes.length === 0) return;
+	const updates = new Map<string, BatchUpdate>();
+	for (const hash of hashes) updates.set(hash, { kind: "patch", patch: {} });
+	await updateBatch(cwd, updates);
+}
+
+/**
+ * Synchronous pre-push drain, called INSIDE the git pre-push hook while git is
+ * waiting for the hook to exit. Key differences from {@link processPushPending}:
+ *
+ * - **No push confirmation.** The hook runs before git transfers objects, so
+ *   waiting for the remote ref would deadlock (git waits for the hook; the
+ *   hook would wait for the push). Publishing is optimistic by design — a
+ *   rejected push can briefly leave Space articles for commits that never
+ *   reached the remote; the user's retry converges them via docId reuse.
+ * - **At most one HTTP request.** Batch-eligible memories that fit the server's
+ *   total-content limit go out in one `pushBatch` call. Oversized or overflow
+ *   items stay pending for the compensation path.
+ * - **Hard wall-clock budget.** Every phase checks `deadlineAt`; when the
+ *   budget runs out, unprocessed candidates release their claims and stay
+ *   pending. The HTTP call's own timeout is the remaining budget, so a hung
+ *   connection cannot keep the hook process (and therefore `git push`) alive.
+ * - **This push only.** Only the commits of the current push are considered;
+ *   leftover entries from earlier pushes stay for the compensation channels
+ *   (QueueWorker post-drain, activation retry) so the blocking window stays
+ *   proportional to the push at hand. Every considered commit gets a per-hash
+ *   entry in `commits` for the hook's result list.
+ */
+export async function processPrePushInline(
+	cwd: string,
+	options: ProcessPrePushInlineOptions,
+): Promise<ProcessPrePushInlineResult> {
+	const remainingMs = (): number => options.deadlineAt - Date.now();
+
+	const pending = await loadPushPending(cwd);
+	const allHashes = Object.keys(pending.entries);
+	log.info(
+		"processPrePushInline: %d commit(s) in this push, %d pending entr(ies) on disk",
+		options.priorityHashes.length,
+		allHashes.length,
+	);
+	if (allHashes.length === 0) return { ...EMPTY_INLINE_RESULT, note: "no pending entries" };
+
+	// Same gates as processPushPending — the hook checks these before calling,
+	// but the gates stay here so any future caller inherits them.
+	const config = await loadConfig();
+	if (config.syncOnPush === false) {
+		log.info("processPrePushInline: syncOnPush disabled — skipping %d entries", allHashes.length);
+		return { ...EMPTY_INLINE_RESULT, note: "syncOnPush disabled" };
+	}
+	if (!config.jolliApiKey) {
+		log.info("processPrePushInline: not signed in — keeping %d entries for later", allHashes.length);
+		return { ...EMPTY_INLINE_RESULT, note: "not signed in" };
+	}
+
+	// Scope: ONLY this push's commits, in push order, capped to the server's
+	// batch limit. Leftover entries from earlier pushes are deliberately left
+	// for the compensation channels.
+	const outcomes = new Map<string, InlineCommitOutcome>();
+	let skippedRetryExhausted = 0;
+	const candidates: string[] = [];
+	for (const hash of options.priorityHashes) {
+		const entry = pending.entries[hash];
+		if (!entry) continue; // not recorded (pruned/raced away) — nothing to report
+		if (entry.retryCount >= MAX_RETRY_COUNT) {
+			skippedRetryExhausted++;
+			outcomes.set(hash, { hash, status: "failed", reason: "failed repeatedly — giving up" });
+			continue;
+		}
+		if (candidates.length < BATCH_MAX_ITEMS) {
+			candidates.push(hash);
+		} else {
+			outcomes.set(hash, { hash, status: "deferred", reason: "over the batch limit — will sync later" });
+		}
+	}
+	if (candidates.length === 0) {
+		log.info("processPrePushInline: no eligible candidates (%d retry-exhausted)", skippedRetryExhausted);
+		return {
+			...EMPTY_INLINE_RESULT,
+			skippedRetryExhausted,
+			commits: commitsInPushOrder(options.priorityHashes, outcomes),
+			note: "no eligible entries",
+		};
+	}
+
+	// Atomic claim — identical race protection to processPushPending.
+	const { claimed, entries: claimedEntries } = await claimForPush(cwd, candidates);
+	const claimedHashes: string[] = [];
+	for (const hash of candidates) {
+		if (claimed.has(hash)) {
+			claimedHashes.push(hash);
+		} else {
+			outcomes.set(hash, { hash, status: "deferred", reason: "another sync is already handling this commit" });
+		}
+	}
+	log.info("processPrePushInline: claimed %d/%d candidate(s)", claimedHashes.length, candidates.length);
+	if (claimedHashes.length === 0) {
+		return {
+			...EMPTY_INLINE_RESULT,
+			skippedRetryExhausted,
+			commits: commitsInPushOrder(options.priorityHashes, outcomes),
+			note: "all entries claimed by another process",
+		};
+	}
+
+	const deferAll = (hashes: ReadonlyArray<string>, reason: string): void => {
+		for (const hash of hashes) outcomes.set(hash, { hash, status: "deferred", reason });
+	};
+
+	if (remainingMs() <= 0) {
+		log.warn("processPrePushInline: budget exhausted before triage — deferring %d commit(s)", claimedHashes.length);
+		await releaseClaims(cwd, claimedHashes);
+		deferAll(claimedHashes, "timed out — will sync later");
+		return {
+			...EMPTY_INLINE_RESULT,
+			skippedRetryExhausted,
+			notAttempted: claimedHashes.length,
+			commits: commitsInPushOrder(options.priorityHashes, outcomes),
+			note: "budget exhausted",
+		};
+	}
+
+	const storage = await ensureStorage(cwd);
+
+	// Triage — same rules as processPushPending: merged children drop out, and
+	// only commits whose own summary exists go into the batch.
+	const indexEntries = await getIndexEntryMap(cwd, storage);
+	const withMemory: string[] = [];
+	const candidateSummaries = new Map<string, CommitSummary>();
+	let skippedNoMemory = 0;
+	let deletedChildren = 0;
+	const preFlightUpdates = new Map<string, BatchUpdate>();
+	for (const hash of claimedHashes) {
+		const indexEntry = indexEntries.get(hash);
+		if (indexEntry && indexEntry.parentCommitHash != null) {
+			preFlightUpdates.set(hash, { kind: "delete" });
+			deletedChildren++;
+			outcomes.set(hash, { hash, status: "merged", reason: "merged into another commit's memory" });
+			log.info(
+				"Skipping child entry %s (parent=%s) — already merged",
+				hash.substring(0, 8),
+				indexEntry.parentCommitHash.substring(0, 8),
+			);
+			continue;
+		}
+		const summary = await getSummary(hash, cwd, storage);
+		if (summary && summary.commitHash === hash) {
+			withMemory.push(hash);
+			candidateSummaries.set(hash, withRecoveredDocId(summary, claimedEntries[hash]));
+		} else {
+			// The empty patch releases the claim so QueueWorker's post-drain
+			// trigger can push the commit the moment its summary lands.
+			preFlightUpdates.set(hash, { kind: "patch", patch: {} });
+			skippedNoMemory++;
+			outcomes.set(hash, { hash, status: "generating", reason: "memory still generating — will sync later" });
+		}
+	}
+	if (preFlightUpdates.size > 0) {
+		await updateBatch(cwd, preFlightUpdates);
+	}
+	log.info(
+		"processPrePushInline: triage — withMemory=%d generating=%d mergedChildren=%d",
+		withMemory.length,
+		skippedNoMemory,
+		deletedChildren,
+	);
+	const baseResult: ProcessPrePushInlineResult = {
+		...EMPTY_INLINE_RESULT,
+		skippedNoMemory,
+		skippedRetryExhausted,
+		deletedChildren,
+	};
+	if (withMemory.length === 0) {
+		const note =
+			deletedChildren > 0 && skippedNoMemory === 0
+				? "all candidates were merged children"
+				: "no candidates with memory";
+		return { ...baseResult, commits: commitsInPushOrder(options.priorityHashes, outcomes), note };
+	}
+
+	if (remainingMs() <= INLINE_MIN_HTTP_BUDGET_MS) {
+		log.warn(
+			"processPrePushInline: budget exhausted before the batch request — deferring %d commit(s)",
+			withMemory.length,
+		);
+		await releaseClaims(cwd, withMemory);
+		deferAll(withMemory, "timed out — will sync later");
+		return {
+			...baseResult,
+			notAttempted: withMemory.length,
+			commits: commitsInPushOrder(options.priorityHashes, outcomes),
+			note: "budget exhausted",
+		};
+	}
+
+	// Payload preparation needs auth/env helpers but performs no network request.
+	// A fresh deadline-bound client is created immediately before pushBatch below,
+	// after git reads and attachment loading have consumed their share of the budget.
+	const preparationClient = options.client ?? new JolliMemoryPushClient();
+	const repoUrl = await getCanonicalRepoUrl(cwd);
+	const baseUrl = await preparationClient.resolveBaseUrl();
+	const displayBase = baseUrl.replace(/\/+$/, "");
+	const preparationCtx: PushContext = { cwd, baseUrl, repoUrl, client: preparationClient, storage };
+
+	const summaries: CommitSummary[] = [];
+	for (const hash of withMemory) {
+		const summary = candidateSummaries.get(hash);
+		if (summary) summaries.push(summary);
+	}
+	const ownership = await buildAttachmentOwnership(cwd, storage, claimedEntries, withMemory, candidateSummaries);
+	const built = await buildBatchItems(summaries, ownership, preparationCtx);
+
+	if (remainingMs() <= INLINE_MIN_HTTP_BUDGET_MS) {
+		log.warn(
+			"processPrePushInline: budget exhausted after payload build — deferring %d commit(s)",
+			withMemory.length,
+		);
+		await releaseClaims(cwd, withMemory);
+		deferAll(withMemory, "timed out — will sync later");
+		return {
+			...baseResult,
+			notAttempted: withMemory.length,
+			commits: commitsInPushOrder(options.priorityHashes, outcomes),
+			note: "budget exhausted",
+		};
+	}
+
+	// Inline mode is intentionally one request. Fill it greedily within the
+	// server's total-content cap; invalid/overflow items release their claims and
+	// stay pending for the confirmed compensation path, which can split batches or
+	// fall back to individual pushes without blocking git.
+	const batchBuilt: BuiltBatchItem[] = [];
+	const deferredByBatchLimit: string[] = [];
+	let batchContentChars = 0;
+	for (const item of built) {
+		const hash = item.item.commitHash;
+		if (item.batchIneligibleReason) {
+			deferredByBatchLimit.push(hash);
+			outcomes.set(hash, {
+				hash,
+				status: "deferred",
+				reason: `${item.batchIneligibleReason} — will sync separately`,
+			});
+			continue;
+		}
+		if (batchContentChars + item.batchContentChars > BATCH_MAX_TOTAL_CONTENT_CHARS) {
+			deferredByBatchLimit.push(hash);
+			outcomes.set(hash, {
+				hash,
+				status: "deferred",
+				reason: "batch content limit reached — will sync later",
+			});
+			continue;
+		}
+		batchBuilt.push(item);
+		batchContentChars += item.batchContentChars;
+	}
+	if (deferredByBatchLimit.length > 0) {
+		await releaseClaims(cwd, deferredByBatchLimit);
+		log.info(
+			"processPrePushInline: deferred %d commit(s) that exceed inline batch limits",
+			deferredByBatchLimit.length,
+		);
+	}
+	if (batchBuilt.length === 0) {
+		return {
+			...baseResult,
+			notAttempted: deferredByBatchLimit.length,
+			commits: commitsInPushOrder(options.priorityHashes, outcomes),
+			note: "batch limits require compensation",
+		};
+	}
+
+	const batchHashes = batchBuilt.map((item) => item.item.commitHash);
+	if (remainingMs() <= INLINE_MIN_HTTP_BUDGET_MS) {
+		log.warn(
+			"processPrePushInline: budget exhausted before the batch request — deferring %d commit(s)",
+			batchHashes.length,
+		);
+		await releaseClaims(cwd, batchHashes);
+		deferAll(batchHashes, "timed out — will sync later");
+		return {
+			...baseResult,
+			notAttempted: deferredByBatchLimit.length + batchHashes.length,
+			commits: commitsInPushOrder(options.priorityHashes, outcomes),
+			note: "budget exhausted",
+		};
+	}
+
+	// Capture the latest remaining budget immediately before the network call.
+	const requestClient = options.client ?? new JolliMemoryPushClient({ timeoutMs: remainingMs() });
+	const requestCtx: PushContext = { ...preparationCtx, client: requestClient };
+	log.info("processPrePushInline: pushing %d commit(s) in one batch request", batchBuilt.length);
+	let batchResult: BatchPushResult;
+	try {
+		batchResult = await requestClient.pushBatch({ repoUrl, items: batchBuilt.map((item) => item.item) });
+	} catch (err) {
+		if (err instanceof BatchUnsupportedError) {
+			// Server predates the endpoint — leave everything pending without
+			// burning retries; a later server deploy (or the pushSummary-based
+			// compensation paths) picks the entries up.
+			log.warn("processPrePushInline: %s", err.message);
+			await releaseClaims(cwd, batchHashes);
+			deferAll(batchHashes, "server does not support batch push yet");
+			return {
+				...baseResult,
+				notAttempted: deferredByBatchLimit.length + batchHashes.length,
+				commits: commitsInPushOrder(options.priorityHashes, outcomes),
+				note: "server lacks batch support",
+			};
+		}
+		if (isAbortError(err)) {
+			// Our own deadline abort — not a server failure, so no retry burn.
+			log.warn("processPrePushInline: batch request aborted at the deadline");
+			await releaseClaims(cwd, batchHashes);
+			deferAll(batchHashes, "timed out — will sync later");
+			return {
+				...baseResult,
+				notAttempted: deferredByBatchLimit.length + batchHashes.length,
+				commits: commitsInPushOrder(options.priorityHashes, outcomes),
+				note: "deadline exceeded",
+			};
+		}
+		const { increment, message } = classifyError(err);
+		const failureUpdates = new Map<string, BatchUpdate>();
+		const failedAtIso = new Date().toISOString();
+		const reason = friendlyPushFailure(message);
+		for (const hash of batchHashes) {
+			failureUpdates.set(hash, {
+				kind: "patch",
+				patch: {
+					lastAttemptAt: failedAtIso,
+					lastError: message,
+					...(increment ? { retryCount: claimedEntries[hash].retryCount + 1 } : {}),
+				},
+			});
+			outcomes.set(hash, { hash, status: "failed", reason });
+		}
+		await updateBatch(cwd, failureUpdates);
+		log.warn(
+			"processPrePushInline: batch request failed for %d commit(s): %s (retry %s)",
+			batchHashes.length,
+			message,
+			increment ? "counted" : "held",
+		);
+		return {
+			...baseResult,
+			attempted: batchHashes.length,
+			failed: batchHashes.length,
+			notAttempted: deferredByBatchLimit.length,
+			commits: commitsInPushOrder(options.priorityHashes, outcomes),
+			note: message,
+		};
+	}
+
+	// Per-item accounting: ok → entry gone; failed → error + retry counted.
+	const updates = new Map<string, BatchUpdate>();
+	const nowIso = new Date().toISOString();
+	const resultByHash = new Map(batchResult.results.map((r) => [r.commitHash, r]));
+	let pushed = 0;
+	let failed = 0;
+	for (const hash of batchHashes) {
+		const result = resultByHash.get(hash);
+		if (result?.ok) {
+			updates.set(hash, { kind: "delete" });
+			pushed++;
+			const url = result.summary
+				? resolveArticleUrl(displayBase, result.summary.url, result.summary.docId)
+				: undefined;
+			outcomes.set(hash, { hash, status: "pushed", ...(url !== undefined && { url }) });
+			continue;
+		}
+		failed++;
+		const message = result?.error ?? result?.errorCode ?? "missing batch result";
+		updates.set(hash, {
+			kind: "patch",
+			patch: {
+				lastAttemptAt: nowIso,
+				lastError: message,
+				retryCount: claimedEntries[hash].retryCount + 1,
+			},
+		});
+		outcomes.set(hash, { hash, status: "failed", reason: friendlyPushFailure(message) });
+		log.warn("Batch push failed for %s: %s", hash.substring(0, 8), message);
+	}
+
+	// Local write-back (docId/url → stored summary) so the next push updates
+	// instead of creating. Keep successful entries pending when confirmed orphan
+	// cleanup still remains; the inline hook cannot safely delete old articles
+	// before git confirms that the push itself succeeded.
+	try {
+		const writeBack = await applyBatchResult(batchBuilt, batchResult.results, requestCtx);
+		preserveCleanupPending(updates, writeBack.cleanupPendingHashes);
+		preserveWriteBackFailures(updates, writeBack.writeBackFailures, nowIso);
+		log.debug(
+			"processPrePushInline: write-back — writtenBack=%d childSkipped=%d cleanupPending=%d writeBackFailed=%d",
+			writeBack.writtenBack,
+			writeBack.childSkipped,
+			writeBack.cleanupPendingHashes?.length ?? 0,
+			writeBack.writeBackFailures?.length ?? 0,
+		);
+	} catch (err) {
+		log.warn("processPrePushInline: write-back failed: %s", errMsg(err));
+	}
+	await updateBatch(cwd, updates);
+
+	log.info("processPrePushInline: pushed=%d failed=%d", pushed, failed);
+	return {
+		...baseResult,
+		attempted: batchHashes.length,
+		pushed,
+		failed,
+		notAttempted: deferredByBatchLimit.length,
+		commits: commitsInPushOrder(options.priorityHashes, outcomes),
 	};
 }
 
@@ -457,6 +1248,7 @@ export async function processPushPending(
 export function triggerPushForNewSummaries(cwd: string, hashes: ReadonlyArray<string>): void {
 	if (hashes.length === 0) return;
 	const filter = new Set(hashes);
+	log.info("Post-queue push trigger: scheduling drain for %d newly generated summar(ies)", filter.size);
 	setImmediate(() => {
 		processPushPending(cwd, { source: "post-queue", hashFilter: filter }).catch((err) => {
 			log.debug("post-queue push trigger failed (will retry later): %s", errMsg(err));

--- a/cli/src/core/PushPendingStore.test.ts
+++ b/cli/src/core/PushPendingStore.test.ts
@@ -241,6 +241,22 @@ describe("updateBatch / updateEntry / deleteEntry", () => {
 		expect(file.entries[HASH_A].lastError).toBeUndefined();
 	});
 
+	it("records pushedDocId/pushedUrl and preserves them across later patches", async () => {
+		await updateEntry(cwd, HASH_A, {
+			pushedDocId: 123,
+			pushedUrl: "https://acme.jolli.ai/articles?doc=123",
+		});
+		await updateEntry(cwd, HASH_A, { retryCount: 1, lastError: "boom" });
+
+		const file = await loadPushPending(cwd);
+		expect(file.entries[HASH_A]).toMatchObject({
+			pushedDocId: 123,
+			pushedUrl: "https://acme.jolli.ai/articles?doc=123",
+			retryCount: 1,
+			lastError: "boom",
+		});
+	});
+
 	it("ignores updates for hashes no longer present", async () => {
 		await deleteEntry(cwd, HASH_A);
 		await updateEntry(cwd, HASH_A, { retryCount: 5 }); // gone — no-op

--- a/cli/src/core/PushPendingStore.ts
+++ b/cli/src/core/PushPendingStore.ts
@@ -13,6 +13,8 @@
  *         "lastAttemptAt": "ISO-8601"?,   // set on every push attempt (success or fail)
  *         "retryCount": number,           // increments only on "operational" failure
  *         "lastError": "string"?,         // truncated to PUSH_ERROR_MSG_MAX_LEN chars
+ *         "pushedDocId": number?,         // article id minted by a push whose local write-back failed
+ *         "pushedUrl": "string"?,         // article url matching pushedDocId (carries the tenant gate)
  *         "pushTargets": [{                // remote refs that can confirm the push succeeded
  *           "remote": "origin",
  *           "remoteRef": "refs/heads/feature/xxx",
@@ -89,6 +91,16 @@ export interface PushPendingEntry {
 	readonly lastAttemptAt?: string;
 	readonly retryCount: number;
 	readonly lastError?: string;
+	/**
+	 * Article docId/url minted by a successful push whose local write-back
+	 * failed. The next drain reuses them as the update target, so the retry
+	 * UPDATEs the already-created article instead of CREATEing a duplicate,
+	 * and the write-back gets another chance. Cleared implicitly — a
+	 * successful write-back deletes the whole entry.
+	 */
+	readonly pushedDocId?: number;
+	/** Article url matching {@link pushedDocId}; carries the tenant gate (`canReuseDocId`). */
+	readonly pushedUrl?: string;
 	/** Successful confirmation of any target proves this commit reached the remote. */
 	readonly pushTargets?: ReadonlyArray<PushTarget>;
 	/**
@@ -114,6 +126,8 @@ export interface PushPendingEntryPatch {
 	readonly lastAttemptAt?: string;
 	readonly retryCount?: number;
 	readonly lastError?: string | null;
+	readonly pushedDocId?: number;
+	readonly pushedUrl?: string;
 }
 
 export type BatchUpdate =
@@ -385,6 +399,8 @@ export async function updateBatch(cwd: string, updates: ReadonlyMap<string, Batc
 						: patch.lastError !== undefined
 							? truncateError(patch.lastError)
 							: existing.lastError,
+				pushedDocId: patch.pushedDocId ?? existing.pushedDocId,
+				pushedUrl: patch.pushedUrl ?? existing.pushedUrl,
 				// Explicit: clear the claim on every patch so the entry can be
 				// retried by any process. Written as `undefined` (not omitted) so
 				// this stays load-bearing under future field additions — a new

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -1070,7 +1070,7 @@ async function mergeManyToOneLocked(
 	const allOrphanedDocIds = [...jolliMeta.orphanedDocIds, ...inheritedOrphanIds];
 
 	// Children without jolliDocId may have been pushed to Space by a
-	// concurrent PrePushWorker that hasn't written back the docId yet (race).
+	// concurrent pre-push sync that hasn't written back the docId yet (race).
 	// Record their hashes so pushSummary can resolve them at push time and
 	// clean up the orphaned Space articles.
 	const unresolvedOrphanHashes = Array.from(

--- a/cli/src/hooks/PrePushHook.test.ts
+++ b/cli/src/hooks/PrePushHook.test.ts
@@ -1,13 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type ProcessPrePushInlineResult, processPrePushInline } from "../core/PushExecutor.js";
 import { mergeEntries } from "../core/PushPendingStore.js";
 import { loadConfig } from "../core/SessionTracker.js";
+import { createStorage } from "../core/StorageFactory.js";
+import { getIndexEntryMap, getSummary } from "../core/SummaryStore.js";
 import { execFileAsyncHidden } from "../util/Subprocess.js";
-import { parsePushRefs, prePushEntry } from "./PrePushHook.js";
-import { launchPrePushWorker } from "./PrePushWorker.js";
+import { PRE_PUSH_SYNC_BUDGET_MS, parsePushRefs, prePushEntry } from "./PrePushHook.js";
 
 vi.mock("../core/SessionTracker.js", () => ({ loadConfig: vi.fn() }));
 vi.mock("../core/PushPendingStore.js", () => ({ mergeEntries: vi.fn() }));
-vi.mock("./PrePushWorker.js", () => ({ launchPrePushWorker: vi.fn() }));
+vi.mock("../core/PushExecutor.js", () => ({ processPrePushInline: vi.fn() }));
+vi.mock("../core/StorageFactory.js", () => ({ createStorage: vi.fn() }));
+vi.mock("../core/SummaryStore.js", () => ({ getIndexEntryMap: vi.fn(), getSummary: vi.fn() }));
 vi.mock("../util/Subprocess.js", () => ({ execFileAsyncHidden: vi.fn() }));
 
 const CWD = "/repo";
@@ -16,10 +20,25 @@ const LOCAL = "1".repeat(40);
 const REMOTE = "2".repeat(40);
 const REMOTE_NAME = "origin";
 
+const EMPTY_RESULT: ProcessPrePushInlineResult = {
+	attempted: 0,
+	pushed: 0,
+	failed: 0,
+	skippedNoMemory: 0,
+	skippedRetryExhausted: 0,
+	deletedChildren: 0,
+	notAttempted: 0,
+	commits: [],
+};
+
 beforeEach(() => {
 	vi.clearAllMocks();
 	vi.mocked(loadConfig).mockResolvedValue({ jolliApiKey: "sk-jol-x" });
 	vi.mocked(mergeEntries).mockResolvedValue(undefined);
+	vi.mocked(processPrePushInline).mockResolvedValue(EMPTY_RESULT);
+	vi.mocked(createStorage).mockResolvedValue({} as never);
+	vi.mocked(getIndexEntryMap).mockResolvedValue(new Map());
+	vi.mocked(getSummary).mockResolvedValue(null);
 	vi.mocked(execFileAsyncHidden).mockResolvedValue({ stdout: "c1\nc2\n", stderr: "" });
 });
 
@@ -37,14 +56,14 @@ describe("parsePushRefs", () => {
 });
 
 describe("prePushEntry", () => {
-	it("no-ops entirely when syncOnPush is false (no file write, no worker)", async () => {
+	it("no-ops entirely when syncOnPush is false (no file write, no inline sync)", async () => {
 		vi.mocked(loadConfig).mockResolvedValue({ jolliApiKey: "sk-jol-x", syncOnPush: false });
 		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
 		expect(mergeEntries).not.toHaveBeenCalled();
-		expect(launchPrePushWorker).not.toHaveBeenCalled();
+		expect(processPrePushInline).not.toHaveBeenCalled();
 	});
 
-	it("records commits but does NOT spawn the worker when not signed in", async () => {
+	it("records commits but does NOT sync inline when not signed in", async () => {
 		vi.mocked(loadConfig).mockResolvedValue({});
 		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
 		expect(mergeEntries).toHaveBeenCalledWith(CWD, ["c1", "c2"], "x", {
@@ -52,23 +71,241 @@ describe("prePushEntry", () => {
 			remoteRef: "refs/heads/x",
 			localSha: LOCAL,
 		});
-		expect(launchPrePushWorker).not.toHaveBeenCalled();
+		expect(processPrePushInline).not.toHaveBeenCalled();
 	});
 
-	it("records commits and spawns the worker when signed in", async () => {
-		await prePushEntry(CWD, `refs/heads/feature/y ${LOCAL} refs/heads/feature/y ${REMOTE}\n`, REMOTE_NAME);
+	it("lists at most three exact root memories when not signed in", async () => {
+		const hashes = ["1", "2", "3", "4", "5", "6"].map((digit) => digit.repeat(40));
+		vi.mocked(loadConfig).mockResolvedValue({});
+		vi.mocked(execFileAsyncHidden).mockImplementation(async (_file, args) => {
+			if (args?.[0] === "show") {
+				return {
+					stdout: [
+						`${hashes[0]}\tFirst memory`,
+						`${hashes[1]}\t${"a".repeat(80)}`,
+						`${hashes[4]}\tThird memory`,
+						`${hashes[5]}\tFourth memory`,
+					].join("\n"),
+					stderr: "",
+				};
+			}
+			return { stdout: `${hashes.join("\n")}\n`, stderr: "" };
+		});
+		vi.mocked(getIndexEntryMap).mockResolvedValue(
+			new Map([
+				[hashes[0], { commitHash: hashes[0], parentCommitHash: null } as never],
+				[hashes[1], { commitHash: hashes[1], parentCommitHash: null } as never],
+				[hashes[2], { commitHash: hashes[2], parentCommitHash: null } as never],
+				[hashes[3], { commitHash: hashes[3], parentCommitHash: hashes[0] } as never],
+				[hashes[4], { commitHash: hashes[4], parentCommitHash: null } as never],
+				[hashes[5], { commitHash: hashes[5], parentCommitHash: null } as never],
+			]),
+		);
+		vi.mocked(getSummary).mockImplementation(async (hash) => {
+			if (hash === hashes[2]) return { commitHash: hashes[0] } as never;
+			return { commitHash: hash } as never;
+		});
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+
+		const output = String(stderrSpy.mock.calls[0][0]);
+		expect(output).toContain("jollimemory: not signed in");
+		expect(output).toContain(`${hashes[0].substring(0, 8)} First memory`);
+		expect(output).toContain(`${hashes[1].substring(0, 8)} ${"a".repeat(49)}…`);
+		expect(output).toContain(`${hashes[4].substring(0, 8)} Third memory`);
+		expect(output).not.toContain(hashes[3].substring(0, 8));
+		expect(output).not.toContain("Fourth memory");
+		expect(output).toContain("  ...");
+		expect(output).toContain("Run `jolli auth login` to sign in");
+		expect(processPrePushInline).not.toHaveBeenCalled();
+	});
+
+	it("omits the signed-out notice when this push has no generated memories", async () => {
+		vi.mocked(loadConfig).mockResolvedValue({});
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+
+		expect(stderrSpy).not.toHaveBeenCalled();
+		expect(getSummary).not.toHaveBeenCalled();
+	});
+
+	it("prints no ellipsis when three or fewer signed-out memories are pending", async () => {
+		const hash = "7".repeat(40);
+		vi.mocked(loadConfig).mockResolvedValue({});
+		vi.mocked(execFileAsyncHidden).mockImplementation(async (_file, args) => {
+			if (args?.[0] === "show") return { stdout: `${hash}\tOne memory\n`, stderr: "" };
+			return { stdout: `${hash}\n`, stderr: "" };
+		});
+		vi.mocked(getIndexEntryMap).mockResolvedValue(
+			new Map([[hash, { commitHash: hash, parentCommitHash: null } as never]]),
+		);
+		vi.mocked(getSummary).mockResolvedValue({ commitHash: hash } as never);
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+
+		const output = String(stderrSpy.mock.calls[0][0]);
+		expect(output).toContain("One memory");
+		expect(output).not.toContain("  ...");
+	});
+
+	it("swallows signed-out notice failures so the push is never blocked", async () => {
+		vi.mocked(loadConfig).mockResolvedValue({});
+		vi.mocked(createStorage).mockRejectedValue(new Error("storage unavailable"));
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+		await expect(
+			prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME),
+		).resolves.toBeUndefined();
+		expect(stderrSpy).not.toHaveBeenCalled();
+		expect(processPrePushInline).not.toHaveBeenCalled();
+	});
+
+	it("stops the signed-out preview scan at the deadline instead of reading storage per commit", async () => {
+		vi.mocked(loadConfig).mockResolvedValue({});
+		vi.mocked(getIndexEntryMap).mockResolvedValue(
+			new Map([["c1", { commitHash: "c1", parentCommitHash: null } as never]]),
+		);
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+		// Anchor the budget in the past so the preview deadline is already over.
+		const expiredStart = Date.now() - PRE_PUSH_SYNC_BUDGET_MS - 1;
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME, expiredStart);
+
+		expect(getSummary).not.toHaveBeenCalled();
+		expect(stderrSpy).not.toHaveBeenCalled();
+	});
+
+	it("records commits and runs the inline sync when signed in", async () => {
+		const startedAtMs = 1_000_000;
+		await prePushEntry(
+			CWD,
+			`refs/heads/feature/y ${LOCAL} refs/heads/feature/y ${REMOTE}\n`,
+			REMOTE_NAME,
+			startedAtMs,
+		);
 		expect(mergeEntries).toHaveBeenCalledWith(CWD, ["c1", "c2"], "feature/y", {
 			remote: REMOTE_NAME,
 			remoteRef: "refs/heads/feature/y",
 			localSha: LOCAL,
 		});
-		expect(launchPrePushWorker).toHaveBeenCalledWith(CWD);
+		expect(processPrePushInline).toHaveBeenCalledWith(CWD, {
+			priorityHashes: ["c1", "c2"],
+			deadlineAt: startedAtMs + PRE_PUSH_SYNC_BUDGET_MS,
+		});
+	});
+
+	it("records entries BEFORE the inline sync runs (write-first crash safety)", async () => {
+		const order: string[] = [];
+		vi.mocked(mergeEntries).mockImplementation(async () => {
+			order.push("merge");
+		});
+		vi.mocked(processPrePushInline).mockImplementation(async () => {
+			order.push("sync");
+			return EMPTY_RESULT;
+		});
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+		expect(order).toEqual(["merge", "sync"]);
+	});
+
+	it("swallows inline sync failures so the push is never blocked", async () => {
+		vi.mocked(processPrePushInline).mockRejectedValue(new Error("network down"));
+		await expect(
+			prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME),
+		).resolves.toBeUndefined();
+	});
+
+	it("prints a per-commit result list to stderr (URL for pushed, reason for pending)", async () => {
+		vi.mocked(execFileAsyncHidden).mockImplementation(async (_file, args) => {
+			if (args?.[0] === "show") {
+				return { stdout: "c1\tfix login bug\nc2\tadd retry logic\n", stderr: "" };
+			}
+			return { stdout: "c1\nc2\n", stderr: "" };
+		});
+		vi.mocked(processPrePushInline).mockResolvedValue({
+			...EMPTY_RESULT,
+			attempted: 1,
+			pushed: 1,
+			skippedNoMemory: 1,
+			commits: [
+				{ hash: "c1", status: "pushed", url: "https://jolli.ai/articles/fix-login-bug-9" },
+				{ hash: "c2", status: "generating", reason: "memory still generating — will sync later" },
+			],
+		});
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+		const output = String(stderrSpy.mock.calls[0][0]);
+		expect(output).toContain("jollimemory: push to Jolli Space");
+		expect(output).toContain("✓ c1");
+		expect(output).toContain("fix login bug");
+		expect(output).toContain("https://jolli.ai/articles/fix-login-bug-9");
+		expect(output).toContain("… c2");
+		expect(output).toContain("memory still generating — will sync later");
+	});
+
+	it("prints a short failure reason for failed commits", async () => {
+		vi.mocked(processPrePushInline).mockResolvedValue({
+			...EMPTY_RESULT,
+			attempted: 1,
+			failed: 1,
+			commits: [{ hash: "c1", status: "failed", reason: "network timeout" }],
+		});
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+		const output = String(stderrSpy.mock.calls[0][0]);
+		expect(output).toContain("✗ c1");
+		expect(output).toContain("network timeout");
+	});
+
+	it("truncates over-long commit subjects in the result list", async () => {
+		const longSubject = "a".repeat(80);
+		vi.mocked(execFileAsyncHidden).mockImplementation(async (_file, args) => {
+			if (args?.[0] === "show") return { stdout: `c1\t${longSubject}\n`, stderr: "" };
+			return { stdout: "c1\n", stderr: "" };
+		});
+		vi.mocked(processPrePushInline).mockResolvedValue({
+			...EMPTY_RESULT,
+			attempted: 1,
+			pushed: 1,
+			commits: [{ hash: "c1", status: "pushed", url: "https://jolli.ai/a" }],
+		});
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+		const output = String(stderrSpy.mock.calls[0][0]);
+		expect(output).toContain(`${"a".repeat(49)}…`);
+		expect(output).not.toContain("a".repeat(60));
+	});
+
+	it("renders the list even when commit subjects cannot be resolved", async () => {
+		vi.mocked(execFileAsyncHidden).mockImplementation(async (_file, args) => {
+			if (args?.[0] === "show") throw new Error("git boom");
+			return { stdout: "c1\n", stderr: "" };
+		});
+		vi.mocked(processPrePushInline).mockResolvedValue({
+			...EMPTY_RESULT,
+			attempted: 1,
+			pushed: 1,
+			commits: [{ hash: "c1", status: "pushed", url: "https://jolli.ai/a" }],
+		});
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+		const output = String(stderrSpy.mock.calls[0][0]);
+		expect(output).toContain("✓ c1");
+		expect(output).toContain("https://jolli.ai/a");
+	});
+
+	it("stays silent on stderr when there was nothing to sync", async () => {
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+		expect(stderrSpy).not.toHaveBeenCalled();
 	});
 
 	it("skips delete pushes (all-zero local sha)", async () => {
 		await prePushEntry(CWD, `(delete) ${ZERO} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
 		expect(mergeEntries).not.toHaveBeenCalled();
-		expect(launchPrePushWorker).not.toHaveBeenCalled();
+		expect(processPrePushInline).not.toHaveBeenCalled();
 	});
 
 	it("uses --not --remotes for a brand-new remote branch (zero remote sha)", async () => {
@@ -87,7 +324,7 @@ describe("prePushEntry", () => {
 		vi.mocked(execFileAsyncHidden).mockResolvedValue({ stdout: "\n", stderr: "" });
 		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
 		expect(mergeEntries).not.toHaveBeenCalled();
-		expect(launchPrePushWorker).not.toHaveBeenCalled();
+		expect(processPrePushInline).not.toHaveBeenCalled();
 	});
 
 	it("tolerates a git rev-list failure (logs, skips that ref)", async () => {

--- a/cli/src/hooks/PrePushHook.ts
+++ b/cli/src/hooks/PrePushHook.ts
@@ -3,11 +3,23 @@
  * PrePushHook — Git pre-push Event Handler.
  *
  * Invoked by git's pre-push hook before objects are transferred. Records the
- * commits being pushed into `push-pending.json` and spawns a detached
- * PrePushWorker to sync their Memory Bank summaries to Jolli Space. The
- * synchronous portion is minimal (config read, stdin parse, `git rev-list`,
- * one JSON write, spawn) so the push is never blocked; the network sync happens
- * in the background worker.
+ * commits being pushed into `push-pending.json`, then SYNCHRONOUSLY pushes the
+ * batch-eligible memories that fit one request to Jolli Space
+ * (`processPrePushInline`) — deliberately blocking the push, but never for
+ * longer than {@link PRE_PUSH_SYNC_BUDGET_MS}. Commits without memory, items
+ * beyond batch limits, and failed pushes stay in `push-pending.json` for the
+ * compensation channels (QueueWorker post-drain, activation retry, the next
+ * push).
+ *
+ * Publishing here is optimistic: it happens BEFORE git transfers objects, so a
+ * subsequently rejected push can briefly leave Space articles for commits that
+ * never reached the remote — accepted by design (the retry converges via docId
+ * reuse). Waiting for push confirmation inside the hook would deadlock: git
+ * waits for the hook to exit before transferring.
+ *
+ * Failure policy: every error is caught, the exit code is always 0, and a
+ * hard-exit timer (budget + grace) guarantees the hook can never hold
+ * `git push` hostage even if something wedges.
  *
  * stdin format (one line per ref being pushed):
  *   <local-ref> <local-sha> <remote-ref> <remote-sha>
@@ -15,15 +27,35 @@
 
 import { basename, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+	type InlineCommitStatus,
+	type ProcessPrePushInlineResult,
+	processPrePushInline,
+} from "../core/PushExecutor.js";
 import { mergeEntries, type PushTarget } from "../core/PushPendingStore.js";
 import { loadConfig } from "../core/SessionTracker.js";
+import { createStorage } from "../core/StorageFactory.js";
+import { getIndexEntryMap, getSummary } from "../core/SummaryStore.js";
 import { runWithTrace, traceIdFromEnv } from "../core/TraceContext.js";
 import { createLogger, errMsg } from "../Logger.js";
 import { execFileAsyncHidden } from "../util/Subprocess.js";
 import { readStdin } from "./HookUtils.js";
-import { launchPrePushWorker } from "./PrePushWorker.js";
 
 const log = createLogger("PrePushHook");
+
+/**
+ * Total wall-clock budget for the synchronous portion of the hook — local git
+ * reads, the pending-file write, and the single batch HTTP request all share
+ * it. Anchored at process start.
+ */
+export const PRE_PUSH_SYNC_BUDGET_MS = 3_000;
+
+/**
+ * Grace on top of the budget before the hard-exit timer force-terminates the
+ * process. Last-resort guard: cooperative deadline checks and the HTTP abort
+ * normally end the hook well before this fires.
+ */
+export const PRE_PUSH_HARD_EXIT_GRACE_MS = 1_000;
 
 /** Git's all-zero SHA — signals a branch deletion (local side) or a new ref (remote side). */
 const ZERO_SHA = "0000000000000000000000000000000000000000";
@@ -77,22 +109,165 @@ async function listCommitsForRef(cwd: string, ref: PushRef): Promise<string[]> {
 	}
 }
 
+/** Display width for the commit-subject column of the result list. */
+const COMMIT_SUBJECT_DISPLAY_WIDTH = 50;
+
+/** Truncates a commit subject and pads it so the result column aligns. */
+function formatSubject(subject: string): string {
+	const clean = subject.trim();
+	const truncated =
+		clean.length > COMMIT_SUBJECT_DISPLAY_WIDTH
+			? `${clean.substring(0, COMMIT_SUBJECT_DISPLAY_WIDTH - 1)}…`
+			: clean;
+	return truncated.padEnd(COMMIT_SUBJECT_DISPLAY_WIDTH);
+}
+
+/**
+ * Best-effort commit-subject lookup for the result list (one `git show -s`
+ * over all hashes). Failures just leave subjects blank — the list still
+ * renders with hashes.
+ */
+async function loadCommitSubjects(cwd: string, hashes: ReadonlyArray<string>): Promise<Map<string, string>> {
+	const subjects = new Map<string, string>();
+	if (hashes.length === 0) return subjects;
+	try {
+		const { stdout } = await execFileAsyncHidden("git", ["show", "-s", "--format=%H%x09%s", ...hashes], { cwd });
+		for (const line of stdout.split("\n")) {
+			const tab = line.indexOf("\t");
+			if (tab > 0) subjects.set(line.substring(0, tab).trim(), line.substring(tab + 1).trim());
+		}
+	} catch (err) {
+		log.debug("Could not resolve commit subjects for the result list: %s", errMsg(err));
+	}
+	return subjects;
+}
+
+/** One marker per status: pushed / still coming / merged away / failed. */
+const STATUS_MARKERS: Record<InlineCommitStatus, string> = {
+	pushed: "✓",
+	generating: "…",
+	deferred: "…",
+	merged: "–",
+	failed: "✗",
+};
+
+/**
+ * Prints the per-commit sync results to stderr — git forwards hook stderr, so
+ * the list shows up inline in the user's `git push` output. One line per
+ * commit of this push: marker, short hash, truncated subject, then the article
+ * URL (pushed) or a short reason (everything else).
+ */
+async function printSyncResults(cwd: string, result: ProcessPrePushInlineResult): Promise<void> {
+	if (result.commits.length === 0) return;
+	const subjects = await loadCommitSubjects(
+		cwd,
+		result.commits.map((commit) => commit.hash),
+	);
+	const lines = ["jollimemory: push to Jolli Space"];
+	for (const commit of result.commits) {
+		const marker = STATUS_MARKERS[commit.status];
+		const shortHash = commit.hash.substring(0, 8);
+		const subject = formatSubject(subjects.get(commit.hash) ?? "");
+		const tail = commit.status === "pushed" ? (commit.url ?? "") : (commit.reason ?? "");
+		lines.push(`  ${marker} ${shortHash} ${subject} ${tail}`);
+	}
+	process.stderr.write(`${lines.join("\n")}\n`);
+}
+
+/** Maximum number of already-generated memories shown while signed out. */
+const SIGNED_OUT_MEMORY_DISPLAY_LIMIT = 3;
+
+interface SignedOutMemoryPreview {
+	readonly hashes: ReadonlyArray<string>;
+	readonly hasMore: boolean;
+}
+
+/**
+ * Finds the first independently pushable memories from this push using local
+ * storage only. The same eligibility rules as the real push path apply:
+ * merged children are excluded, and the summary must belong to the exact hash
+ * rather than resolving through an alias or equal-tree fallback.
+ *
+ * Deadline-bound like the signed-in path: each root costs a storage read, and
+ * a first push of a large branch can carry thousands of memory-less hashes —
+ * without the check the scan would grind on until the hard-exit timer kills
+ * the process. On deadline the preview returns what it has, flagged hasMore.
+ */
+async function loadSignedOutMemoryPreview(
+	cwd: string,
+	hashes: ReadonlyArray<string>,
+	deadlineAt: number,
+): Promise<SignedOutMemoryPreview> {
+	const storage = await createStorage(cwd, cwd);
+	const indexEntries = await getIndexEntryMap(cwd, storage);
+	const preview: string[] = [];
+
+	for (const hash of hashes) {
+		if (Date.now() >= deadlineAt) {
+			log.debug("Signed-out memory preview stopped at the deadline (%d shown)", preview.length);
+			return { hashes: preview, hasMore: true };
+		}
+		const indexEntry = indexEntries.get(hash);
+		if (!indexEntry || indexEntry.parentCommitHash != null) continue;
+		const summary = await getSummary(hash, cwd, storage);
+		if (!summary || summary.commitHash !== hash) continue;
+		if (preview.length >= SIGNED_OUT_MEMORY_DISPLAY_LIMIT) {
+			return { hashes: preview, hasMore: true };
+		}
+		preview.push(hash);
+	}
+
+	return { hashes: preview, hasMore: false };
+}
+
+/**
+ * Prints a best-effort signed-out notice without ever affecting the Git push.
+ * Any local storage or display failure is kept in debug.log and swallowed.
+ */
+async function printSignedOutMemoryNotice(
+	cwd: string,
+	hashes: ReadonlyArray<string>,
+	deadlineAt: number,
+): Promise<void> {
+	try {
+		const preview = await loadSignedOutMemoryPreview(cwd, hashes, deadlineAt);
+		if (preview.hashes.length === 0) return;
+		const subjects = await loadCommitSubjects(cwd, preview.hashes);
+		const lines = ["jollimemory: not signed in — these memories were not pushed to Jolli"];
+		for (const hash of preview.hashes) {
+			lines.push(`  ${hash.substring(0, 8)} ${formatSubject(subjects.get(hash) ?? "")}`);
+		}
+		if (preview.hasMore) lines.push("  ...");
+		lines.push(
+			"",
+			"Run `jolli auth login` to sign in. Pending memories will be pushed automatically after sign-in.",
+		);
+		process.stderr.write(`${lines.join("\n")}\n`);
+	} catch (error) {
+		log.debug("Could not render the signed-out memory notice: %s", errMsg(error));
+	}
+}
+
 /**
  * Core pre-push logic. Records pushed commits into push-pending.json and (when
- * signed in) spawns the background sync worker.
+ * signed in) synchronously batch-pushes the ones that already have memory,
+ * within the remaining wall-clock budget. `startedAtMs` anchors the budget at
+ * process start; it defaults to "now" for callers that don't track it.
  */
-export async function prePushEntry(cwd: string, stdin: string, remote?: string): Promise<void> {
+export async function prePushEntry(cwd: string, stdin: string, remote?: string, startedAtMs?: number): Promise<void> {
+	const deadlineAt = (startedAtMs ?? Date.now()) + PRE_PUSH_SYNC_BUDGET_MS;
+	log.info("pre-push hook: remote=%s budget=%dms", remote ?? "(none)", PRE_PUSH_SYNC_BUDGET_MS);
 	const config = await loadConfig();
 
-	// Explicit opt-out: do nothing at all (no file write, no worker).
+	// Explicit opt-out: do nothing at all (no file write, no sync).
 	if (config.syncOnPush === false) {
 		log.debug("syncOnPush is disabled — skipping");
 		return;
 	}
 
 	// Not signed in: still record intent (so a later login can catch up) but
-	// don't spawn the worker — there's nowhere to push to yet.
-	const skipWorker = !config.jolliApiKey;
+	// skip the synchronous sync — there's nowhere to push to yet.
+	const skipSync = !config.jolliApiKey;
 
 	const refs = parsePushRefs(stdin);
 	const allHashes = new Set<string>();
@@ -113,13 +288,34 @@ export async function prePushEntry(cwd: string, stdin: string, remote?: string):
 		log.debug("No commits to sync on this push");
 		return;
 	}
+	log.info("pre-push: recorded %d commit(s) across %d pushed ref(s)", total, refs.length);
 
-	if (skipWorker) {
+	if (skipSync) {
 		log.info("Recorded %d commit(s) for later sync — not signed in to Jolli", total);
+		await printSignedOutMemoryNotice(cwd, [...allHashes], deadlineAt);
 		return;
 	}
 
-	launchPrePushWorker(cwd);
+	// Synchronous inline sync — scoped to THIS push's commits only (leftover
+	// entries belong to the compensation channels). Entries are already
+	// recorded above (write-first), so any failure here just leaves them for
+	// those channels — never block or fail the push on sync problems.
+	try {
+		log.info("pre-push: starting inline sync — %dms of budget remaining", deadlineAt - Date.now());
+		const result = await processPrePushInline(cwd, { priorityHashes: [...allHashes], deadlineAt });
+		log.info(
+			"pre-push: inline sync done — pushed=%d failed=%d noMemory=%d notAttempted=%d children=%d%s",
+			result.pushed,
+			result.failed,
+			result.skippedNoMemory,
+			result.notAttempted,
+			result.deletedChildren,
+			result.note ? ` (${result.note})` : "",
+		);
+		await printSyncResults(cwd, result);
+	} catch (error: unknown) {
+		log.error("Inline pre-push sync failed: %s", errMsg(error));
+	}
 }
 
 // --- Script entry point (only when run directly, not when imported) ---
@@ -138,10 +334,16 @@ function isMainScript(): boolean {
 
 if (isMainScript()) {
 	const cwd = process.cwd();
+	const startedAtMs = Date.now();
+	// Hard ceiling: whatever happens (hung request, stuck IO), this process must
+	// never hold `git push` beyond budget + grace. unref() keeps the timer from
+	// holding an otherwise-finished process alive; atomic pending-file writes
+	// (temp + rename) make a force-exit lose at most one unrecorded entry.
+	setTimeout(() => process.exit(0), PRE_PUSH_SYNC_BUDGET_MS + PRE_PUSH_HARD_EXIT_GRACE_MS).unref();
 	// Adopt a parent-supplied trace id if present, else mint one.
 	runWithTrace(traceIdFromEnv(), () =>
 		readStdin()
-			.then((stdin) => prePushEntry(cwd, stdin, process.argv[2]))
+			.then((stdin) => prePushEntry(cwd, stdin, process.argv[2], startedAtMs))
 			.catch((error: unknown) => {
 				// Never block or fail the push on our account — exit 0 always.
 				log.error("PrePushHook error: %s", error instanceof Error ? error.message : String(error));

--- a/cli/src/hooks/PrePushWorker.test.ts
+++ b/cli/src/hooks/PrePushWorker.test.ts
@@ -1,28 +1,22 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { processPushPending } from "../core/PushExecutor.js";
+import { describe, expect, it, vi } from "vitest";
+import { type ProcessPushPendingResult, processPushPending } from "../core/PushExecutor.js";
 import { runPushWorker } from "./PrePushWorker.js";
 
 vi.mock("../core/PushExecutor.js", () => ({ processPushPending: vi.fn() }));
 
-beforeEach(() => {
-	vi.clearAllMocks();
-	vi.mocked(processPushPending).mockResolvedValue({
-		attempted: 0,
-		pushed: 0,
-		failed: 0,
-		skippedNoMemory: 0,
-		skippedRetryExhausted: 0,
-		deletedChildren: 0,
-	});
-});
-
-afterEach(() => {
-	vi.restoreAllMocks();
-});
+const EMPTY_RESULT: ProcessPushPendingResult = {
+	attempted: 0,
+	pushed: 0,
+	failed: 0,
+	skippedNoMemory: 0,
+	skippedRetryExhausted: 0,
+	deletedChildren: 0,
+};
 
 describe("runPushWorker", () => {
-	it("drains push-pending with the pre-push source", async () => {
-		await runPushWorker("/repo");
-		expect(processPushPending).toHaveBeenCalledWith("/repo", { source: "pre-push" });
+	it("drains push-pending.json via the activation compensation path", async () => {
+		vi.mocked(processPushPending).mockResolvedValue(EMPTY_RESULT);
+		await runPushWorker("/repo", "cli-auth-login");
+		expect(processPushPending).toHaveBeenCalledWith("/repo", { source: "activation" });
 	});
 });

--- a/cli/src/hooks/PrePushWorker.ts
+++ b/cli/src/hooks/PrePushWorker.ts
@@ -1,59 +1,40 @@
 #!/usr/bin/env node
 /**
- * PrePushWorker — detached background process spawned by PrePushHook.
+ * PrePushWorker — standalone drain of `push-pending.json` to Jolli Space.
  *
- * Runs the actual network sync (`processPushPending`) so a slow or offline
- * Jolli Space never delays or fails the user's `git push`. Mirrors the
- * QueueWorker launch/spawn pattern: `spawnHidden` + `detached` + `stdio:
- * "ignore"` + `child.unref()`.
+ * The pre-push hook itself syncs inline (`processPrePushInline`, one
+ * budget-bound batch request scoped to the current push). This entry point is
+ * the cross-process compensation drain used by CLI and VS Code activation /
+ * sign-in triggers, as well as the IntelliJ plugin's Kotlin integration.
+ * External orchestrators can use it the same way:
+ * `node PrePushWorker.js --cwd <repo>`.
+ *
+ * Behavior matches the activation compensation path: eligible entries use the
+ * batch endpoint first and fall back to per-commit `pushSummary` calls when an
+ * item exceeds batch limits or the server predates batch support. Publishing
+ * starts only after the remote ref confirms the git push actually landed.
  */
 
-import { existsSync } from "node:fs";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { processPushPending } from "../core/PushExecutor.js";
-import { getCurrentTraceId, runWithTrace, TRACE_ID_ENV, traceIdFromEnv } from "../core/TraceContext.js";
+import { runWithTrace, traceIdFromEnv } from "../core/TraceContext.js";
 import { createLogger } from "../Logger.js";
-import { spawnHidden } from "../util/Subprocess.js";
 
 const log = createLogger("PrePushWorker");
 
-/** Drains push-pending.json to Jolli Space. Entry point for the detached run. */
-export async function runPushWorker(cwd: string): Promise<void> {
-	await processPushPending(cwd, { source: "pre-push" });
-}
-
-/**
- * Spawns a detached PrePushWorker process. Locates `PrePushWorker.js` by
- * `dirname(import.meta.url) + basename` — NOT by `import.meta.url` alone —
- * because esbuild inlines this function into the PrePushHook bundle, where
- * `import.meta.url` would resolve to PrePushHook.js. Both scripts are siblings
- * in the same dist dir (guaranteed by the vite/esbuild entries), so resolving
- * by directory + explicit filename always finds the right script (same trick as
- * QueueWorker.launchWorker).
- */
-/* v8 ignore start -- spawns a real detached child; not exercised in unit tests */
-export function launchPrePushWorker(cwd: string): void {
-	const dir = dirname(fileURLToPath(import.meta.url));
-	const scriptPath = join(dir, "PrePushWorker.js");
-	if (!existsSync(scriptPath)) {
-		log.error("PrePushWorker.js not found at %s — skipping push sync spawn", scriptPath);
-		return;
-	}
-
-	// No Node flags before scriptPath (same rationale as launchWorker: the hook
-	// runs under a bare `node`, possibly older than our engines floor). Propagate
-	// the ambient trace id so the detached worker's logs share it.
-	const traceId = getCurrentTraceId();
-	const child = spawnHidden(process.execPath, [scriptPath, "--cwd", cwd], {
-		detached: true,
-		stdio: "ignore",
-		cwd,
-		...(traceId ? { env: { ...process.env, [TRACE_ID_ENV]: traceId } } : {}),
-	});
-	child.unref();
-	log.info("PrePushWorker spawned (PID: %d)", child.pid ?? -1);
-	/* v8 ignore stop */
+/** Drains push-pending.json to Jolli Space. Entry point for the standalone run. */
+export async function runPushWorker(cwd: string, trigger = "activation"): Promise<void> {
+	log.info("PrePushWorker(%s): spawned compensation drain starting", trigger);
+	const result = await processPushPending(cwd, { source: "activation" });
+	log.info(
+		"PrePushWorker(%s): drain done — attempted=%d pushed=%d failed=%d%s",
+		trigger,
+		result.attempted,
+		result.pushed,
+		result.failed,
+		result.note ? ` (${result.note})` : "",
+	);
 }
 
 // --- Script entry point (only when run directly, not when imported) ---
@@ -66,11 +47,11 @@ function isMainScript(): boolean {
 	const resolvedScript = resolve(fileURLToPath(import.meta.url));
 	if (resolvedArgv !== resolvedScript) return false;
 
-	// Only auto-run when the entrypoint itself is PrePushWorker.
-	// esbuild (CJS, no code splitting) inlines this module into PrePushHook.js,
-	// where import.meta.url is aliased to the same __jmImportMetaUrl — without
-	// the basename check both guards fire and PushExecutor runs in-process,
-	// blocking git push. Same pattern as QueueWorker/PostCommitHook.
+	// Only auto-run when the entrypoint itself is PrePushWorker. esbuild (CJS,
+	// no code splitting) can inline this module into sibling bundles, where
+	// import.meta.url is aliased to the same __jmImportMetaUrl — without the
+	// basename check the guard would fire inside those bundles too. Same
+	// pattern as QueueWorker/PostCommitHook.
 	const entryName = basename(resolvedArgv).toLowerCase();
 	return entryName === "prepushworker.js" || entryName === "prepushworker.ts";
 }
@@ -79,9 +60,11 @@ if (isMainScript()) {
 	const args = process.argv.slice(2);
 	const cwdIndex = args.indexOf("--cwd");
 	const cwd = cwdIndex >= 0 && args[cwdIndex + 1] ? args[cwdIndex + 1] : process.cwd();
+	const triggerIndex = args.indexOf("--trigger");
+	const trigger = triggerIndex >= 0 && args[triggerIndex + 1] ? args[triggerIndex + 1] : "activation";
 
 	runWithTrace(traceIdFromEnv(), () =>
-		runPushWorker(cwd).catch((error: unknown) => {
+		runPushWorker(cwd, trigger).catch((error: unknown) => {
 			log.error("PrePushWorker fatal error: %s", error instanceof Error ? error.message : String(error));
 			process.exit(0); // never signal failure — this is a background sync
 		}),

--- a/cli/src/hooks/PushCompensation.test.ts
+++ b/cli/src/hooks/PushCompensation.test.ts
@@ -1,33 +1,137 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { processPushPending } from "../core/PushExecutor.js";
+import { resolve } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toForwardSlash } from "../core/PathUtils.js";
 import { triggerPendingPushRetry } from "./PushCompensation.js";
 
-vi.mock("../core/PushExecutor.js", () => ({ processPushPending: vi.fn() }));
+const CWD = resolve("/repo");
+
+const h = vi.hoisted(() => {
+	const child = {
+		once: vi.fn(),
+		unref: vi.fn(),
+	};
+	return {
+		child,
+		existsSync: vi.fn(),
+		getCurrentTraceId: vi.fn(),
+		spawnHidden: vi.fn(),
+		debug: vi.fn(),
+		error: vi.fn(),
+	};
+});
+
+vi.mock("node:fs", () => ({ existsSync: h.existsSync }));
+vi.mock("../core/PushPendingStore.js", () => ({ PUSH_PENDING_FILE: "push-pending.json" }));
+vi.mock("../core/TraceContext.js", () => ({
+	getCurrentTraceId: h.getCurrentTraceId,
+	TRACE_ID_ENV: "JOLLI_TRACE_ID",
+}));
+vi.mock("../Logger.js", () => ({
+	createLogger: vi.fn(() => ({ debug: h.debug, error: h.error })),
+	errMsg: vi.fn((error: unknown) => (error instanceof Error ? error.message : String(error))),
+	getJolliMemoryDir: vi.fn((cwd: string) => `${cwd}/.jolli/jollimemory`),
+}));
+vi.mock("../util/Subprocess.js", () => ({ spawnHidden: h.spawnHidden }));
+
+function pathEndsWith(path: unknown, suffix: string): boolean {
+	return toForwardSlash(String(path)).endsWith(suffix);
+}
 
 beforeEach(() => {
 	vi.clearAllMocks();
-});
-
-afterEach(() => {
-	vi.restoreAllMocks();
+	h.existsSync.mockImplementation(
+		(path) => pathEndsWith(path, "/push-pending.json") || pathEndsWith(path, "/PrePushWorker.js"),
+	);
+	h.getCurrentTraceId.mockReturnValue(undefined);
+	h.spawnHidden.mockReturnValue(h.child);
 });
 
 describe("triggerPendingPushRetry", () => {
-	it("drains push-pending with the activation source", async () => {
-		vi.mocked(processPushPending).mockResolvedValue({
-			attempted: 2,
-			pushed: 2,
-			failed: 0,
-			skippedNoMemory: 0,
-			skippedRetryExhausted: 0,
-			deletedChildren: 0,
-		});
-		await triggerPendingPushRetry("/repo");
-		expect(processPushPending).toHaveBeenCalledWith("/repo", { source: "activation" });
+	it("returns without spawning when there is no pending backlog", () => {
+		h.existsSync.mockReturnValue(false);
+
+		triggerPendingPushRetry(CWD, "cli-front-door");
+
+		expect(h.spawnHidden).not.toHaveBeenCalled();
+		expect(h.debug).toHaveBeenCalledWith("Push compensation (%s): no push-pending backlog", "cli-front-door");
 	});
 
-	it("never throws when the drain fails", async () => {
-		vi.mocked(processPushPending).mockRejectedValue(new Error("boom"));
-		await expect(triggerPendingPushRetry("/repo")).resolves.toBeUndefined();
+	it("spawns and unreferences the built worker with trace propagation", () => {
+		h.getCurrentTraceId.mockReturnValue("0123456789abcdef0123456789abcdef");
+
+		triggerPendingPushRetry(CWD, "cli-auth-login");
+
+		expect(h.spawnHidden).toHaveBeenCalledWith(
+			process.execPath,
+			[expect.stringMatching(/PrePushWorker\.js$/), "--cwd", CWD, "--trigger", "cli-auth-login"],
+			expect.objectContaining({
+				detached: true,
+				stdio: "ignore",
+				cwd: CWD,
+				env: expect.objectContaining({ JOLLI_TRACE_ID: "0123456789abcdef0123456789abcdef" }),
+			}),
+		);
+		expect(h.child.once).toHaveBeenCalledWith("error", expect.any(Function));
+		expect(h.child.unref).toHaveBeenCalledTimes(1);
+	});
+
+	it("omits the environment override when there is no ambient trace", () => {
+		triggerPendingPushRetry(CWD);
+
+		const options = h.spawnHidden.mock.calls[0]?.[2];
+		expect(options).not.toHaveProperty("env");
+	});
+
+	it("uses the tsx loader arguments for the source worker in development", () => {
+		h.existsSync.mockImplementation((path) => {
+			if (pathEndsWith(path, "/push-pending.json")) return true;
+			return pathEndsWith(path, "/PrePushWorker.ts");
+		});
+
+		triggerPendingPushRetry(CWD);
+
+		const args = h.spawnHidden.mock.calls[0]?.[1] as ReadonlyArray<string>;
+		expect(args.slice(-5)).toEqual([
+			expect.stringMatching(/PrePushWorker\.ts$/),
+			"--cwd",
+			CWD,
+			"--trigger",
+			"activation",
+		]);
+		expect(args.slice(0, -5)).toEqual(process.execArgv);
+	});
+
+	it("leaves the backlog for later when no worker entry exists", () => {
+		h.existsSync.mockImplementation((path) => pathEndsWith(path, "/push-pending.json"));
+
+		triggerPendingPushRetry(CWD, "cli-enable");
+
+		expect(h.spawnHidden).not.toHaveBeenCalled();
+		expect(h.error).toHaveBeenCalledWith("Push compensation (%s): PrePushWorker entry not found", "cli-enable");
+	});
+
+	it("swallows synchronous spawn failures", () => {
+		h.spawnHidden.mockImplementation(() => {
+			throw new Error("spawn failed");
+		});
+
+		expect(() => triggerPendingPushRetry(CWD, "vscode-activation")).not.toThrow();
+		expect(h.debug).toHaveBeenCalledWith(
+			"Push compensation (%s) trigger failed: %s",
+			"vscode-activation",
+			"spawn failed",
+		);
+	});
+
+	it("swallows asynchronous worker startup failures", () => {
+		triggerPendingPushRetry(CWD, "vscode-sign-in");
+		const errorHandler = h.child.once.mock.calls[0]?.[1] as (error: Error) => void;
+
+		expect(() => errorHandler(new Error("worker failed"))).not.toThrow();
+		expect(h.debug).toHaveBeenCalledWith(
+			"Push compensation (%s) worker failed to start: %s",
+			"vscode-sign-in",
+			"worker failed",
+		);
 	});
 });

--- a/cli/src/hooks/PushCompensation.ts
+++ b/cli/src/hooks/PushCompensation.ts
@@ -1,38 +1,84 @@
 /**
- * PushCompensation — the "retry pending pushes on startup" entry point shared by
- * the three surfaces that activate Jolli Memory:
- *   - VS Code   `Extension.activate()`
- *   - IntelliJ  `JolliMemoryService.initialize()` (via the Kotlin port)
- *   - CLI       `jolli enable`
+ * PushCompensation — detached retry entry point shared by the TypeScript
+ * surfaces that activate Jolli Memory:
+ *   - VS Code   activation and successful sign-in
+ *   - CLI       `jolli enable`, `jolli auth login`, and the guided front door
  *
- * Fire-and-forget: retries every under-the-ceiling entry in push-pending.json
- * (no hash filter). Fully guarded — a non-git directory, missing state file, or
- * network error must never surface to the caller or block activation.
- * `processPushPending` itself no-ops cleanly when there are no pending entries
- * or the user isn't signed in, so no pre-checks are needed here.
+ * The caller only checks local state and starts PrePushWorker as a detached
+ * child. Network work and push-pending processing never run in the caller's
+ * process, so CLI commands and VS Code activation do not wait for compensation.
  */
 
-import { processPushPending } from "../core/PushExecutor.js";
-import { createLogger, errMsg } from "../Logger.js";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PUSH_PENDING_FILE } from "../core/PushPendingStore.js";
+import { getCurrentTraceId, TRACE_ID_ENV } from "../core/TraceContext.js";
+import { createLogger, errMsg, getJolliMemoryDir } from "../Logger.js";
+import { spawnHidden } from "../util/Subprocess.js";
 
 const log = createLogger("PushCompensation");
 
+interface WorkerInvocation {
+	readonly scriptPath: string;
+	readonly nodeArgs: ReadonlyArray<string>;
+}
+
+/** Resolves the built worker, with a tsx-compatible source fallback for development. */
+function resolveWorkerInvocation(): WorkerInvocation | undefined {
+	const dir = dirname(fileURLToPath(import.meta.url));
+	const builtWorker = join(dir, "PrePushWorker.js");
+	if (existsSync(builtWorker)) {
+		return { scriptPath: builtWorker, nodeArgs: [] };
+	}
+
+	// `npm run cli` executes the source through tsx. Reuse that process's Node
+	// loader arguments so development also keeps the compensation process
+	// boundary instead of falling back to in-process work.
+	const sourceWorker = join(dir, "PrePushWorker.ts");
+	if (existsSync(sourceWorker)) {
+		return { scriptPath: sourceWorker, nodeArgs: process.execArgv };
+	}
+
+	return undefined;
+}
+
 /**
- * Retries all pending pushes for `cwd`. Never throws — failures are logged at
- * debug and left in push-pending.json for the next trigger.
+ * Starts an independent compensation drain when push-pending.json exists.
+ * The detached child owns every network request and never inherits stdio.
+ * Spawn failures are logged and left for the next trigger.
  */
-export async function triggerPendingPushRetry(cwd: string): Promise<void> {
+export function triggerPendingPushRetry(cwd: string, trigger = "activation"): void {
 	try {
-		const result = await processPushPending(cwd, { source: "activation" });
-		if (result.attempted > 0) {
-			log.info(
-				"Activation push retry: attempted=%d pushed=%d failed=%d",
-				result.attempted,
-				result.pushed,
-				result.failed,
-			);
+		const projectDir = resolve(cwd);
+		const pendingPath = join(getJolliMemoryDir(projectDir), PUSH_PENDING_FILE);
+		if (!existsSync(pendingPath)) {
+			log.debug("Push compensation (%s): no push-pending backlog", trigger);
+			return;
 		}
-	} catch (err) {
-		log.debug("Activation push retry failed (will retry later): %s", errMsg(err));
+
+		const invocation = resolveWorkerInvocation();
+		if (!invocation) {
+			log.error("Push compensation (%s): PrePushWorker entry not found", trigger);
+			return;
+		}
+
+		const traceId = getCurrentTraceId();
+		const child = spawnHidden(
+			process.execPath,
+			[...invocation.nodeArgs, invocation.scriptPath, "--cwd", projectDir, "--trigger", trigger],
+			{
+				detached: true,
+				stdio: "ignore",
+				cwd: projectDir,
+				...(traceId ? { env: { ...process.env, [TRACE_ID_ENV]: traceId } } : {}),
+			},
+		);
+		child.once("error", (error) => {
+			log.debug("Push compensation (%s) worker failed to start: %s", trigger, errMsg(error));
+		});
+		child.unref();
+	} catch (error) {
+		log.debug("Push compensation (%s) trigger failed: %s", trigger, errMsg(error));
 	}
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/HookInstaller.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/HookInstaller.kt
@@ -673,8 +673,11 @@ class HookInstaller(private val projectDir: String, private val mainRepoRoot: St
      * it reuses the SAME shared `run-hook` dispatcher the CLI and VS Code install
      * (written by [CliIntegrations.enableIntegrations] → the bundled `jolli enable
      * --integrations-only`), so IntelliJ gets byte-identical per-push behaviour via
-     * the same `PrePushHook.js` + `PrePushWorker.js` (JOLLI-1900 requirement 3 —
-     * reuse the existing push path, don't re-implement it).
+     * the same `PrePushHook.js` (JOLLI-1900 requirement 3 — reuse the existing
+     * push path, don't re-implement it). The hook itself syncs inline with a
+     * budget-bound batch request and spawns no worker; the bundled
+     * `PrePushWorker.js` remains only as the standalone compensation drain
+     * [CliIntegrations.retryPendingPushes] spawns.
      *
      * The absolute `run-hook` path is baked at install time (same convention as the
      * `java -jar <jar>` paths in the other scripts). Guarded two ways so a missing

--- a/vscode/esbuild.config.mjs
+++ b/vscode/esbuild.config.mjs
@@ -87,6 +87,9 @@ const cliOptions = {
 		{ in: `${jmSrc}/hooks/PostRewriteHook.ts`,         out: "PostRewriteHook" },
 		{ in: `${jmSrc}/hooks/PrepareMsgHook.ts`,          out: "PrepareMsgHook" },
 		{ in: `${jmSrc}/hooks/PrePushHook.ts`,             out: "PrePushHook" },
+		// NOT spawned by PrePushHook anymore (inline batch sync). Kept as the
+		// detached pending-push compensation drain used by the bundled CLI, the
+		// extension, and IntelliJ's CliIntegrations.retryPendingPushes.
 		{ in: `${jmSrc}/hooks/PrePushWorker.ts`,           out: "PrePushWorker" },
 		{ in: `${jmSrc}/hooks/GeminiAfterAgentHook.ts`,   out: "GeminiAfterAgentHook" },
 		{ in: `${jmSrc}/hooks/SessionStartHook.ts`,       out: "SessionStartHook" },

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -28,6 +28,10 @@ const { mockNotifyApiKeySaveError } = vi.hoisted(() => ({
 	mockNotifyApiKeySaveError: vi.fn(),
 }));
 
+const { triggerPendingPushRetry } = vi.hoisted(() => ({
+	triggerPendingPushRetry: vi.fn(),
+}));
+
 const { mockRefreshConversationsPanel } = vi.hoisted(() => ({
 	mockRefreshConversationsPanel: vi.fn(() => Promise.resolve()),
 }));
@@ -736,6 +740,10 @@ vi.mock("../../cli/src/Logger.js", () => ({
 	isEnoent: vi.fn((err: unknown) => (err as NodeJS.ErrnoException)?.code === "ENOENT"),
 }));
 
+vi.mock("../../cli/src/hooks/PushCompensation.js", () => ({
+	triggerPendingPushRetry,
+}));
+
 vi.mock("../../cli/src/backfill/BackfillEngine.js", () => ({
 	recentCommitHashes: vi.fn(),
 	runBackfill: vi.fn(),
@@ -1348,6 +1356,17 @@ describe("Extension", () => {
 	// ── activate: normal activation ───────────────────────────────────────
 
 	describe("activate — normal activation", () => {
+		it("starts detached push compensation after storage initialization", async () => {
+			activate(makeContext());
+
+			await vi.waitFor(() => {
+				expect(triggerPendingPushRetry).toHaveBeenCalledWith(
+					"/test/workspace",
+					"vscode-activation",
+				);
+			});
+		});
+
 		it("creates providers and pushes disposables to context.subscriptions", () => {
 			const ctx = makeContext();
 
@@ -7068,6 +7087,10 @@ describe("Extension", () => {
 				"Signed in to Jolli successfully.",
 			);
 			expect(mockStatusStore.refresh).toHaveBeenCalled();
+			expect(triggerPendingPushRetry).toHaveBeenCalledWith(
+				"/test/workspace",
+				"vscode-sign-in",
+			);
 		});
 
 		it("shows error message on failed auth callback", async () => {
@@ -7097,6 +7120,10 @@ describe("Extension", () => {
 
 			expect(showErrorMessage).toHaveBeenCalledWith(
 				"Jolli sign-in failed: No authorization code received",
+			);
+			expect(triggerPendingPushRetry).not.toHaveBeenCalledWith(
+				"/test/workspace",
+				"vscode-sign-in",
 			);
 		});
 

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1723,7 +1723,7 @@ export function activate(context: vscode.ExtensionContext): void {
 		// push-pending.json from a previous session, now that storage is
 		// initialized. Fire-and-forget; fully guarded (never throws, no-ops when
 		// nothing is pending or the user isn't signed in).
-		void triggerPendingPushRetry(workspaceRoot);
+		triggerPendingPushRetry(workspaceRoot, "vscode-activation");
 	});
 
 	// ── sessions.json watcher ─────────────────────────────────────────────────
@@ -3776,7 +3776,7 @@ export function activate(context: vscode.ExtensionContext): void {
 							.catch(handleError("uriHandler.reconcileAutoSync"));
 						// Pre-push sync catch-up: drain any commits left in
 						// push-pending.json from pushes made while signed out.
-						void triggerPendingPushRetry(workspaceRoot);
+						triggerPendingPushRetry(workspaceRoot, "vscode-sign-in");
 					} else {
 						vscode.window.showErrorMessage(
 							`Jolli sign-in failed: ${result.error}`,


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

This work improved how the tool behaves when a user is signed out of Jolli and pushes code, and how push compensation runs across the CLI and VS Code extension. When someone pushes commits while signed out, the terminal now prints a clear notice listing up to three of the affected commits — their short hash and message — for any commits in that push whose memories already exist and would otherwise go unsynced, along with a prompt to sign in. Commits that were merged into another commit's memory, or whose memory hasn't finished generating, are left out of the list so the count accurately reflects what will actually sync after sign-in. The check only reads local git and memory data, adds no network calls, and any failure building the message is silently ignored so the push itself is never slowed down or blocked.

Separately, the mechanism that retries any pending pushes after signing in, enabling the tool, or activating the VS Code extension now runs as a fully independent background process rather than inside the same process as the command that triggered it. Previously this retry logic ran inline, which could leave the CLI or extension waiting on network activity before finishing. Now, CLI login, CLI enable, the guided setup flow, and both VS Code activation and sign-in all hand this work off to a detached background process and return control immediately, giving users a snappier experience across every entry point that triggers this retry.

---

## Topics (2)
<details>
<summary><strong>01 · Push compensation now runs in a detached background process instead of blocking the CLI or extension</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The user asked whether the "retry pending pushes" logic that runs after login, enable, and other triggers spawns a separate process or just runs inline without waiting — worried it could delay the CLI or VS Code extension from finishing its work. After confirming it was running inline (using unnetworked promises that don't actually free up the process), the user asked to convert it to a truly independent background process and to check every other place that triggers the same compensation logic.

**💡 Decisions Behind the Code**

- **Detached process over in-process fire-and-forget**: Running the drain in a spawned, detached child guarantees the CLI command or extension activation can finish and return control immediately, without waiting on network calls or file I/O — matching how the IntelliJ plugin already isolates this work in its own process.
- **Centralize the fix in one shared module**: Rather than adding spawn logic separately to each of the five trigger points, the fix was made once in the shared compensation entry point so every caller inherits the same non-blocking behavior automatically and stays consistent going forward.
- **Leave already-isolated paths untouched**: The summary-generation retry path (already running in its own detached worker) and the pre-push hook's own time-boxed sync were confirmed safe and intentionally left unchanged, keeping the scope of the fix limited to genuinely blocking call sites.

**✅ What Was Implemented**

- Rewrote the shared push-compensation entry point so it now spawns a fully detached child process running the standalone worker script, instead of performing the pending-push drain directly inside the caller's process; the parent only does a quick local existence check on the pending-push file before deciding whether to spawn.
- Updated all five call sites — CLI auth login, CLI enable, the guided CLI front door, VS Code activation, and VS Code sign-in — to call the compensation trigger directly instead of wrapping it in a fire-and-forget promise, since the function itself no longer returns one.
- Added a trigger-name argument to the standalone worker so its logs can be traced back to which entry point started it, and updated the extension's build config comments to reflect the new usage.

**📁 FILES**
- `cli/src/hooks/PushCompensation.ts`
- `cli/src/hooks/PrePushWorker.ts`
- `cli/src/commands/AuthCommand.ts`
- `cli/src/commands/EnableCommand.ts`
- `cli/src/commands/GuidedFrontDoor.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Friendly signed-out notice lists which commits' memories were not pushed to Jolli</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The user wanted a specific improvement: when someone is signed out and runs a normal git push, the push itself should still succeed without delay, but the terminal should clearly tell the user that memories for certain commits were not sent to Jolli and prompt them to sign in, listing up to three affected commits.

**💡 Decisions Behind the Code**

- **Exclude merged child commits from the list**: Since commits that were squashed or rebased into another commit's memory are never pushed independently, showing them in the notice would mislead users into expecting more memories to sync than actually will, so only the independently pushable "root" memories are shown.
- **Cap the list at three with an ellipsis**: Keeping the notice short avoids overwhelming users during large pushes while still giving them a concrete sense of what's affected, reusing the existing message-truncation convention for consistency with other output.
- **Fail silently and never block the push**: Because the overriding requirement was that git push must never be slowed down or blocked by Jolli, any error while building the notice (local read errors, missing storage, etc.) is caught and only logged at debug level rather than surfaced or retried.

**✅ What Was Implemented**

- Added logic in the pre-push hook that, when the user is not signed in, checks only the commits included in the current push and looks up which of them already have a generated, independently pushable memory (excluding commits that were merged as children into another commit's memory, and any commit whose memory doesn't exactly match that hash).
- Displays up to three matching commits with their short hash and the same truncated commit message format used elsewhere in the tool, followed by an ellipsis if more exist, printed to standard error alongside instructions to sign in and a note that pending memories will push automatically afterward.
- The lookup only reads local git and memory data (no network calls), and the whole notice-building step is wrapped so that any failure is silently logged and never affects or delays the actual git push.

**📁 FILES**
- `cli/src/hooks/PrePushHook.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 15, 2026 at 10:52 AM*
<!-- jollimemory-summary-end -->