### PR TITLE
Add host-side local workflow-run orchestration

### DIFF
--- a/cli/src/Api.ts
+++ b/cli/src/Api.ts
@@ -22,6 +22,7 @@ import { runGuidedFrontDoor } from "./commands/GuidedFrontDoor.js";
 import { registerHealFolderCommand } from "./commands/HealFolderCommand.js";
 import { getHelpGroup } from "./commands/HelpGroups.js";
 import { registerBindCommand, registerPushCommand, registerSpacesCommand } from "./commands/JolliCloudCommands.js";
+import { registerLocalRunOfferCommand } from "./commands/LocalRunOfferCommand.js";
 import { registerMcpCommand } from "./commands/McpCommand.js";
 import { registerMigrateCommand } from "./commands/MigrateCommand.js";
 import { registerPrDescriptionCommand } from "./commands/PrDescriptionCommand.js";
@@ -166,6 +167,7 @@ const MEMORY_COMMAND_NAMES = new Set([
 	"backfill",
 	"pr-description",
 	"queue-status",
+	"local-run-workflows",
 	"compile",
 	"graph",
 	"export",
@@ -351,6 +353,7 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 	registerSpacesCommand(program);
 	registerBindCommand(program);
 	registerQueueStatusCommand(program);
+	registerLocalRunOfferCommand(program);
 	registerCompileCommand(program);
 	registerGraphCommand(program);
 	registerMigrateCommand(program);

--- a/cli/src/commands/LocalRunOfferCommand.test.ts
+++ b/cli/src/commands/LocalRunOfferCommand.test.ts
@@ -1,0 +1,119 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerLocalRunOfferCommand } from "./LocalRunOfferCommand.js";
+
+const { listWorkflowsMock, execFileMock } = vi.hoisted(() => ({
+	listWorkflowsMock: vi.fn(),
+	execFileMock: vi.fn(),
+}));
+
+// The command constructs `new JolliMemoryPushClient()` and calls `.listWorkflows()`,
+// and spawns the clones read through `execFileAsyncHidden`. Mock both leaves so the
+// command's own wiring (offer resolve, clones parse, JSON print, exit codes) runs
+// for real without a live backend or a real space-cli.
+vi.mock("../core/JolliMemoryPushClient.js", () => ({
+	JolliMemoryPushClient: class {
+		listWorkflows = listWorkflowsMock;
+	},
+}));
+vi.mock("../util/Subprocess.js", () => ({ execFileAsyncHidden: execFileMock }));
+
+const JRN = "jrn:/global:spaces:space/impact-1783452586552";
+
+function wfEntry(id: string | number, syncProtocol: string, autoApply: boolean, jrn: string) {
+	return { id, destination: { syncProtocol, autoApply, jrn } };
+}
+
+async function run(): Promise<string> {
+	const logs: string[] = [];
+	vi.spyOn(console, "log").mockImplementation((m?: unknown) => void logs.push(String(m)));
+	const program = new Command();
+	registerLocalRunOfferCommand(program);
+	await program.parseAsync(["node", "jolli", "local-run-workflows"]);
+	return logs.join("\n");
+}
+
+beforeEach(() => {
+	process.exitCode = 0;
+	listWorkflowsMock.mockReset();
+	execFileMock.mockReset();
+});
+afterEach(() => {
+	vi.restoreAllMocks();
+	process.exitCode = 0;
+});
+
+describe("local-run-workflows command", () => {
+	it("prints only the runnable workflows (git-backed + cloned) with their autoMerges signal", async () => {
+		listWorkflowsMock.mockResolvedValue([
+			wfEntry(7, "git", true, JRN),
+			wfEntry(9, "git", false, "jrn:/global:spaces:space/uncloned"),
+			wfEntry(5, "db", true, JRN),
+		]);
+		execFileMock.mockResolvedValue({ stdout: JSON.stringify([{ jrn: JRN }]), stderr: "" });
+
+		const out = await run();
+		expect(JSON.parse(out)).toEqual({
+			type: "workflows",
+			workflows: [{ id: 7, autoMerges: true }],
+		});
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("includes each runnable workflow's display name in the printed offer when the backend supplied one", async () => {
+		listWorkflowsMock.mockResolvedValue([
+			{ id: 7, name: "Impact Analysis", destination: { syncProtocol: "git", autoApply: true, jrn: JRN } },
+		]);
+		execFileMock.mockResolvedValue({ stdout: JSON.stringify([{ jrn: JRN }]), stderr: "" });
+
+		const out = await run();
+		expect(JSON.parse(out)).toEqual({
+			type: "workflows",
+			workflows: [{ id: 7, name: "Impact Analysis", autoMerges: true }],
+		});
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("spawns the clones read via the run-cli indirection (never a bare `jolli` on PATH)", async () => {
+		listWorkflowsMock.mockResolvedValue([wfEntry(7, "git", true, JRN)]);
+		execFileMock.mockResolvedValue({ stdout: "[]", stderr: "" });
+
+		await run();
+		expect(execFileMock).toHaveBeenCalledTimes(1);
+		const [command, args] = execFileMock.mock.calls[0];
+		expect(command).not.toBe("jolli");
+		expect(command === "node" || String(command).endsWith("run-cli")).toBe(true);
+		expect(args).toEqual(["space", "clones", "--json"]);
+	});
+
+	it("prints the space_cli_required install prompt when the clones spawn fails (space-cli missing)", async () => {
+		listWorkflowsMock.mockResolvedValue([wfEntry(7, "git", true, JRN)]);
+		execFileMock.mockRejectedValue(new Error("spawn jolli ENOENT"));
+
+		const out = await run();
+		expect(JSON.parse(out)).toEqual({
+			type: "space_cli_required",
+			message: expect.stringContaining("space-cli"),
+			install: "npm i -g @jolli.ai/cli @jolli.ai/space-cli",
+		});
+		// A needs-input result is NOT a failure.
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("prints an empty list (without spawning clones) when the workflow list degrades to empty", async () => {
+		listWorkflowsMock.mockResolvedValue([]);
+
+		const out = await run();
+		expect(JSON.parse(out)).toEqual({ type: "workflows", workflows: [] });
+		expect(execFileMock).not.toHaveBeenCalled();
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("prints a type:error result and exits non-zero on an unexpected failure", async () => {
+		listWorkflowsMock.mockRejectedValue(new Error("boom"));
+
+		const out = await run();
+		expect(JSON.parse(out)).toEqual({ type: "error", message: "boom" });
+		expect(process.exitCode).toBe(1);
+	});
+});

--- a/cli/src/commands/LocalRunOfferCommand.ts
+++ b/cli/src/commands/LocalRunOfferCommand.ts
@@ -1,0 +1,66 @@
+/**
+ * `local-run-workflows` — prints, as JSON, the workflows that can be run locally
+ * right now (git-backed + cloned destination). Agent/recipe consumption: the
+ * `jolli-local-run` recipe shells this one command to obtain the offerable set
+ * instead of orchestrating the manifest fetch + clones read itself.
+ *
+ * This is a normal CLI process (not the MCP stdio server), so it can freely spawn
+ * `jolli space clones --json` without any risk of corrupting a JSON-RPC channel.
+ *
+ * Output (always JSON on stdout):
+ *   - `{ type: "workflows", workflows: [{ id, name?, autoMerges }] }` — the offerable
+ *     set (possibly empty; an empty list is a normal "nothing to offer" state).
+ *     `name` is present only when the backend supplied one (advisory display). Exit 0.
+ *   - `{ type: "space_cli_required", message, install }` — needs-input: space-cli
+ *     must be installed first. Exit 0 (not a failure — mirrors `binding_required`).
+ *   - `{ type: "error", message }` — an unexpected failure. Exit 1.
+ */
+
+import type { Command } from "commander";
+import { JolliMemoryPushClient } from "../core/JolliMemoryPushClient.js";
+import { parseClonedSpaceKeys, resolveLocalRunOffer } from "../core/LocalRunOffer.js";
+import { resolveCliInvocation } from "../install/McpRegistration.js";
+import { execFileAsyncHidden } from "../util/Subprocess.js";
+
+/**
+ * Reads the cloned-space keys (space JRNs / slugs) on this machine by spawning
+ * `jolli space clones --json` through the run-cli indirection (never a bare
+ * `jolli` on PATH). Returns `null` when space-cli is unavailable — the spawn
+ * errors, or the `space` command stub prints its install hint and exits non-zero
+ * — which the offer resolver surfaces as `space_cli_required`. A spawn that
+ * succeeds but emits an unreadable body degrades to an empty set (no clones)
+ * rather than an error.
+ */
+async function readClonedSpaceKeys(): Promise<Set<string> | null> {
+	const { command, args } = resolveCliInvocation(["space", "clones", "--json"]);
+	let stdout: string;
+	try {
+		({ stdout } = await execFileAsyncHidden(command, args));
+	} catch {
+		return null;
+	}
+	return parseClonedSpaceKeys(stdout);
+}
+
+/** Registers the `local-run-workflows` command on the given Commander program. */
+export function registerLocalRunOfferCommand(program: Command): void {
+	program
+		.command("local-run-workflows")
+		.description(
+			"List the workflows runnable locally (git-backed + cloned destination) as JSON (agent/recipe consumption)",
+		)
+		.action(async () => {
+			try {
+				const client = new JolliMemoryPushClient();
+				const result = await resolveLocalRunOffer({
+					listWorkflows: () => client.listWorkflows(),
+					readClonedSpaceKeys,
+				});
+				console.log(JSON.stringify(result));
+			} catch (error: unknown) {
+				const message = error instanceof Error ? error.message : String(error);
+				console.log(JSON.stringify({ type: "error", message }));
+				process.exitCode = 1;
+			}
+		});
+}

--- a/cli/src/commands/SpaceCommandStubs.test.ts
+++ b/cli/src/commands/SpaceCommandStubs.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for SpaceCommandStubs — fallback stub commanders registered when the
+ * `@jolli.ai/space-cli` plugin is not installed.
+ *
+ * Covers:
+ *   - registration adds all Space stub commands (including `docs`) to a bare program
+ *   - each stub is tagged with the "space" help group
+ *   - invoking a stub (`docs`) prints the install hint and exits non-zero
+ *   - `jolli docs pull --branch x` / `jolli docs publish --foo` forward the
+ *     subcommand + unknown flags to the action (no parser error) via
+ *     allowUnknownOption + [args...]
+ *   - the collision-tolerant guard: a stub whose name is already occupied
+ *     (by command name or by alias) is skipped rather than throwing
+ */
+
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getHelpGroup } from "./HelpGroups.js";
+import { registerSpaceCommandStubs } from "./SpaceCommandStubs.js";
+
+// ─── Constants mirrored from the source under test ───────────────────────────
+
+/** The Space command names the stubs register, in declaration order. */
+const SPACE_NAMES = ["init", "space", "source", "impact", "sync", "docs", "agent"];
+
+const INSTALL_COMMAND = "npm install -g @jolli.ai/space-cli";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+interface StubRun {
+	/** Joined console.error output captured during the invocation. */
+	output: string;
+	/** The exit code the stub passed to process.exit, or undefined if it never exited. */
+	exitCode: number | undefined;
+}
+
+/**
+ * Invokes the named stub via Commander. `process.exit` is stubbed to throw so
+ * execution halts at the stub's exit call; the thrown sentinel is swallowed
+ * here. Returns the captured console.error output and the requested exit code.
+ */
+async function runStub(program: Command, name: string, extraArgs: string[] = []): Promise<StubRun> {
+	const errLines: string[] = [];
+	let exitCode: number | undefined;
+	const errSpy = vi.spyOn(console, "error").mockImplementation((...a: unknown[]) => {
+		errLines.push(a.map(String).join(" "));
+	});
+	const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+		exitCode = code;
+		throw new Error("__exit__");
+	}) as never);
+	try {
+		await program.parseAsync([name, ...extraArgs], { from: "user" });
+	} catch (err) {
+		// Re-throw anything that isn't our exit sentinel (e.g. a parser error,
+		// which would indicate the stub failed to swallow unknown options).
+		if (!(err instanceof Error) || err.message !== "__exit__") throw err;
+	} finally {
+		errSpy.mockRestore();
+		exitSpy.mockRestore();
+	}
+	return { output: errLines.join("\n"), exitCode };
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("registerSpaceCommandStubs", () => {
+	it("registers all Space stub commands (including docs) on a bare program", () => {
+		const program = new Command();
+		registerSpaceCommandStubs(program);
+		expect(program.commands.map((c) => c.name())).toEqual(SPACE_NAMES);
+	});
+
+	it("tags every registered stub with the 'space' help group", () => {
+		const program = new Command();
+		registerSpaceCommandStubs(program);
+		for (const cmd of program.commands) {
+			expect(getHelpGroup(cmd)).toBe("space");
+		}
+	});
+
+	it("appends the (requires @jolli.ai/space-cli) suffix to each description", () => {
+		const program = new Command();
+		registerSpaceCommandStubs(program);
+		for (const cmd of program.commands) {
+			expect(cmd.description()).toMatch(/\(requires @jolli\.ai\/space-cli\)$/);
+		}
+	});
+
+	it("prints the install hint and exits non-zero when the docs stub is invoked", async () => {
+		const program = new Command();
+		registerSpaceCommandStubs(program);
+
+		const { output, exitCode } = await runStub(program, "docs");
+		expect(exitCode).toBe(1);
+		expect(output).toContain("Space command `docs` requires the @jolli.ai/space-cli plugin.");
+		expect(output).toContain(INSTALL_COMMAND);
+		expect(output).toContain("Then re-run: jolli docs ...");
+	});
+
+	it("forwards `docs pull --branch x` to the action without a parser error", async () => {
+		const program = new Command();
+		registerSpaceCommandStubs(program);
+
+		// The subcommand token + the unknown --branch flag must reach the action
+		// (install-hint exit), NOT raise Commander's "unknown option" error.
+		const { exitCode } = await runStub(program, "docs", ["pull", "--branch", "jolli/run-123"]);
+		expect(exitCode).toBe(1);
+	});
+
+	it("forwards `docs publish --foo` to the action without a parser error", async () => {
+		const program = new Command();
+		registerSpaceCommandStubs(program);
+
+		const { exitCode } = await runStub(program, "docs", ["publish", "--foo"]);
+		expect(exitCode).toBe(1);
+	});
+
+	it("skips a stub whose name is already occupied by an existing command", () => {
+		const program = new Command();
+		// Pre-register a command named "docs" that the stub must not clobber.
+		program.command("docs").description("pre-existing docs command");
+		registerSpaceCommandStubs(program);
+
+		const docsCommands = program.commands.filter((c) => c.name() === "docs");
+		expect(docsCommands).toHaveLength(1);
+		expect(docsCommands[0].description()).toBe("pre-existing docs command");
+		expect(getHelpGroup(docsCommands[0])).toBeUndefined();
+		// The pre-existing `docs` plus the other six stubs (docs skipped).
+		expect(program.commands.map((c) => c.name())).toEqual(["docs", ...SPACE_NAMES.filter((n) => n !== "docs")]);
+	});
+
+	it("skips a stub whose name collides with an existing command's alias", () => {
+		const program = new Command();
+		// An existing command aliased "docs" must block the docs stub.
+		program.command("documents").alias("docs").description("pre-existing documents command");
+		registerSpaceCommandStubs(program);
+
+		// No second command literally named "docs" should be added.
+		expect(program.commands.filter((c) => c.name() === "docs")).toHaveLength(0);
+		const stubNames = program.commands.map((c) => c.name()).filter((n) => SPACE_NAMES.includes(n));
+		expect(stubNames).toEqual(SPACE_NAMES.filter((n) => n !== "docs"));
+	});
+});

--- a/cli/src/commands/SpaceCommandStubs.ts
+++ b/cli/src/commands/SpaceCommandStubs.ts
@@ -5,13 +5,13 @@
  * Why this exists
  * ----------------
  *
- * The space / sync / source / impact / agent commands live in the
+ * The space / sync / source / impact / docs / agent commands live in the
  * `@jolli.ai/space-cli` plugin package. The host CLI discovers it through
  * `PluginLoader` (allow-listed by `jolliPluginId`, not by name). When the
  * plugin is installed alongside the host CLI, its `register()` adds the real
- * `init` / `space` / `source` / `impact` / `sync` / `agent` commands. When it
- * isn't installed, `PluginLoader` falls back to registering the stubs in this
- * file so:
+ * `init` / `space` / `source` / `impact` / `sync` / `docs` / `agent` commands.
+ * When it isn't installed, `PluginLoader` falls back to registering the stubs
+ * in this file so:
  *
  *   - `jolli --help` still shows the Space commands under the "Jolli Space"
  *     section, so users discover the feature exists.
@@ -50,6 +50,7 @@ const SPACE_COMMAND_STUBS: ReadonlyArray<StubSpec> = [
 	{ name: "source", description: "Manage source repositories for impact analysis" },
 	{ name: "impact", description: "Documentation impact analysis tools" },
 	{ name: "sync", description: "Sync markdown files with the server" },
+	{ name: "docs", description: "Pull and publish documents for a git-backed space" },
 	{ name: "agent", description: "Interactive LLM agent with local tool execution" },
 ];
 

--- a/cli/src/core/JolliMemoryPushClient.test.ts
+++ b/cli/src/core/JolliMemoryPushClient.test.ts
@@ -1234,3 +1234,189 @@ describe("pushBatch", () => {
 		expect(r.results[0].attachments[0]).toMatchObject({ clientKey: "k", ok: false, error: "att boom" });
 	});
 });
+
+describe("listWorkflows", () => {
+	const LIST_WF_ENTRY = {
+		name: "list_workflows",
+		description: "List runnable workflows",
+		inputSchema: { type: "object", properties: {} },
+	};
+	// The REAL backend `list_workflows` entry shape (captured live): numeric `id`,
+	// a human-readable `name`, `destination.syncProtocol` (not backingType), and a
+	// JRN identity (no numeric spaceId). `name` is carried through for display;
+	// other extra fields (type, …) are ignored by the parser.
+	const WF_JRN = "jrn:/global:spaces:space/impact-1783452586552";
+	const WF = {
+		id: 7,
+		name: "Impact Analysis",
+		destination: { type: "space", jrn: WF_JRN, syncProtocol: "git", autoApply: true },
+	};
+
+	/**
+	 * Routes the two round-trips listWorkflows makes: the manifest fetch
+	 * (`GET /api/mcp/manifest`) and the tool invocation
+	 * (`POST /api/mcp/tools/list_workflows`, the conventional endpoint since the
+	 * entry carries no binding). `invoke` omitted ⇒ the invocation must not fire.
+	 */
+	function routed(manifest: () => Response, invoke?: () => Response): typeof fetch {
+		return (async (url: string | URL | Request) => {
+			const u = String(url);
+			if (u.endsWith("/api/mcp/manifest")) {
+				return manifest();
+			}
+			if (u.includes("/api/mcp/tools/list_workflows")) {
+				if (!invoke) {
+					throw new Error(`unexpected invocation of ${u}`);
+				}
+				return invoke();
+			}
+			throw new Error(`unexpected url ${u}`);
+		}) as typeof fetch;
+	}
+
+	it("returns the parsed workflows from a { workflows: [...] } invocation body", async () => {
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [LIST_WF_ENTRY] }),
+				() => jsonResponse(200, { workflows: [WF] }),
+			),
+		);
+		const workflows = await c.listWorkflows();
+		expect(workflows).toEqual([
+			{ id: 7, name: "Impact Analysis", destination: { syncProtocol: "git", autoApply: true, jrn: WF_JRN } },
+		]);
+		// The numeric id is preserved as a number (start_local_run's schema wants an integer).
+		expect(typeof workflows[0].id).toBe("number");
+	});
+
+	it("carries a non-empty string `name` for display, and omits it when absent, blank, or non-string", async () => {
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [LIST_WF_ENTRY] }),
+				() =>
+					jsonResponse(200, {
+						workflows: [
+							WF,
+							{ id: 8, name: "  ", destination: { syncProtocol: "git", autoApply: true, jrn: WF_JRN } },
+							{ id: 9, name: 42, destination: { syncProtocol: "git", autoApply: true, jrn: WF_JRN } },
+							{ id: 10, destination: { syncProtocol: "git", autoApply: true, jrn: WF_JRN } },
+						],
+					}),
+			),
+		);
+		const workflows = await c.listWorkflows();
+		expect(workflows.map((w) => w.name)).toEqual(["Impact Analysis", undefined, undefined, undefined]);
+	});
+
+	it("accepts a bare top-level array invocation body", async () => {
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [LIST_WF_ENTRY] }),
+				() => jsonResponse(200, [WF]),
+			),
+		);
+		const workflows = await c.listWorkflows();
+		expect(workflows.map((w) => w.id)).toEqual([7]);
+	});
+
+	it("returns [] (without invoking) when `list_workflows` is absent from the manifest", async () => {
+		const other = { name: "other_tool", description: "d", inputSchema: { type: "object", properties: {} } };
+		const c = client(routed(() => jsonResponse(200, { tools: [other] })));
+		await expect(c.listWorkflows()).resolves.toEqual([]);
+	});
+
+	it("returns [] when platform tools are off / the manifest is empty", async () => {
+		const c = client(routed(() => jsonResponse(200, {})));
+		await expect(c.listWorkflows()).resolves.toEqual([]);
+	});
+
+	it("returns [] when the manifest fetch itself fails (404 surface disabled)", async () => {
+		const c = client(routed(() => jsonResponse(404, { error: "not_found" })));
+		await expect(c.listWorkflows()).resolves.toEqual([]);
+	});
+
+	it("returns [] when the invocation is a non-2xx", async () => {
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [LIST_WF_ENTRY] }),
+				() => jsonResponse(500, { error: "boom" }),
+			),
+		);
+		await expect(c.listWorkflows()).resolves.toEqual([]);
+	});
+
+	it("returns [] when the invocation fetch rejects (network error / abort / timeout)", async () => {
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [LIST_WF_ENTRY] }),
+				() => {
+					throw new Error("network down");
+				},
+			),
+		);
+		await expect(c.listWorkflows()).resolves.toEqual([]);
+	});
+
+	it("returns [] when the invocation body isn't JSON (proxy page)", async () => {
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [LIST_WF_ENTRY] }),
+				() => textResponse(200, "<html>OK</html>"),
+			),
+		);
+		await expect(c.listWorkflows()).resolves.toEqual([]);
+	});
+
+	it("drops malformed workflow entries but keeps the valid ones", async () => {
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [LIST_WF_ENTRY] }),
+				() =>
+					jsonResponse(200, {
+						workflows: [
+							WF,
+							"not-an-object",
+							{ id: "", destination: { syncProtocol: "git", autoApply: true, jrn: "jrn:x" } }, // empty id, no slug
+							{ id: 8, name: "no_dest" },
+							{ id: 8, destination: null },
+							{ id: 8, destination: [] },
+							{ id: 8, destination: { syncProtocol: 1, autoApply: true, jrn: "jrn:x" } }, // bad syncProtocol
+							{ id: 8, destination: { syncProtocol: "git", autoApply: "yes", jrn: "jrn:x" } }, // bad autoApply
+							{ id: 8, destination: { syncProtocol: "git", autoApply: true, jrn: "" } }, // empty jrn
+							{ id: 8, destination: { syncProtocol: "git", autoApply: true } }, // missing jrn
+						],
+					}),
+			),
+		);
+		const workflows = await c.listWorkflows();
+		expect(workflows.map((w) => w.id)).toEqual([7]);
+	});
+
+	it("reads the identifier from `slug` when `id` is absent", async () => {
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [LIST_WF_ENTRY] }),
+				() =>
+					jsonResponse(200, {
+						workflows: [
+							{
+								slug: "wf-slug",
+								destination: {
+									syncProtocol: "git",
+									autoApply: false,
+									jrn: "jrn:/global:spaces:space/s2",
+								},
+							},
+						],
+					}),
+			),
+		);
+		const workflows = await c.listWorkflows();
+		expect(workflows).toEqual([
+			{
+				id: "wf-slug",
+				destination: { syncProtocol: "git", autoApply: false, jrn: "jrn:/global:spaces:space/s2" },
+			},
+		]);
+	});
+});

--- a/cli/src/core/JolliMemoryPushClient.ts
+++ b/cli/src/core/JolliMemoryPushClient.ts
@@ -19,6 +19,7 @@
 import { createLogger } from "../Logger.js";
 import { JOLLI_CLIENT_HEADER } from "./ClientHeader.js";
 import { deriveJolliEnvKey, type JolliApiKeyMeta, parseBaseUrl, parseJolliApiKey } from "./JolliApiUtils.js";
+import type { WorkflowSummary } from "./LocalRunEligibility.js";
 import { loadConfig } from "./SessionTracker.js";
 import { currentTraceHeader, newTraceHeader, TRACE_HEADER_NAME } from "./TraceContext.js";
 
@@ -725,6 +726,45 @@ export class JolliMemoryPushClient {
 		return json;
 	}
 
+	/**
+	 * Fetches the candidate local-run workflows by invoking the backend-defined
+	 * `list_workflows` platform tool through the manifest path (there is no bespoke
+	 * REST endpoint). Best-effort by contract, mirroring {@link fetchManifest}'s
+	 * posture: EVERY degrade — platform tools disabled or the tool absent from the
+	 * manifest (both yield an empty manifest so the tool is not found), a failed
+	 * invocation (non-2xx, network / abort / timeout, a non-JSON body, or an
+	 * outdated client), or a malformed workflow body — resolves to `[]` and NEVER
+	 * throws. Because it rides the platform-tool path, an empty result is the
+	 * normal state when the surface is off or the backend does not yet serve the
+	 * tool. Individual malformed workflow entries are dropped rather than failing
+	 * the whole list. Accepts either a `{ workflows: [...] }` envelope or a bare
+	 * array.
+	 *
+	 * Deliberately asymmetric to {@link invokePlatformTool} (which throws on a
+	 * failed invocation): the eligibility path treats "can't list workflows" as
+	 * "nothing to offer", never as an error, so the try/catch here swallows the
+	 * invocation throw.
+	 */
+	async listWorkflows(): Promise<WorkflowSummary[]> {
+		// fetchManifest is itself best-effort ([] on every failure, never throws),
+		// so an unauthenticated / disabled / unreachable backend simply yields no
+		// `list_workflows` entry here.
+		const manifest = await this.fetchManifest();
+		const tool = manifest.find((entry) => entry.name === LIST_WORKFLOWS_TOOL_NAME);
+		if (!tool) {
+			return [];
+		}
+		try {
+			const raw = await this.invokePlatformTool(tool, {});
+			return parseWorkflowList(raw);
+		} catch {
+			// A failed invocation (non-2xx / network / abort / malformed body /
+			// ClientOutdated) degrades to "no workflows" — unlike a direct platform
+			// tool call, the eligibility path must never surface an error.
+			return [];
+		}
+	}
+
 	private async resolveAuth(): Promise<{
 		apiKey: string;
 		baseUrl: string;
@@ -971,6 +1011,96 @@ function resolveToolEndpoint(tool: PlatformToolManifestEntry, origin: string): {
 	} catch {
 		return fallback;
 	}
+}
+
+/** Backend tool name that lists the candidate local-run workflows. */
+const LIST_WORKFLOWS_TOOL_NAME = "list_workflows";
+
+/**
+ * Parses the `list_workflows` invocation body into validated {@link WorkflowSummary}
+ * entries, mirroring the defensive manifest parse: a `{ workflows: [...] }`
+ * envelope or a bare array is accepted, and any entry that is not a well-formed
+ * workflow (no usable `id`/`slug`, or a `destination` lacking a string
+ * `syncProtocol`, a boolean `autoApply`, or a non-empty string `jrn`) is dropped
+ * rather than failing the whole list.
+ */
+function parseWorkflowList(json: unknown): WorkflowSummary[] {
+	return extractWorkflowArray(json)
+		.map(toWorkflowSummary)
+		.filter((workflow): workflow is WorkflowSummary => workflow !== null);
+}
+
+/** Pulls the workflow array out of the body — `{ workflows: [...] }` or a bare array. */
+function extractWorkflowArray(json: unknown): unknown[] {
+	if (Array.isArray(json)) {
+		return json;
+	}
+	if (json !== null && typeof json === "object") {
+		const workflows = (json as { workflows?: unknown }).workflows;
+		if (Array.isArray(workflows)) {
+			return workflows;
+		}
+	}
+	return [];
+}
+
+/**
+ * Validates one raw workflow entry into a {@link WorkflowSummary}, or `null` if it
+ * is malformed. The identifier is read from `id` (a finite number — the backend's
+ * shape — or a non-empty string), falling back to a non-empty `slug`; the
+ * `destination` must carry a string `syncProtocol`, a boolean `autoApply`, and a
+ * non-empty string `jrn`. A non-empty string `name` is carried through for display
+ * (advisory only); any other extra fields (type, sources, …) are ignored.
+ */
+function toWorkflowSummary(value: unknown): WorkflowSummary | null {
+	if (typeof value !== "object" || value === null) {
+		return null;
+	}
+	const { id, slug, name, destination } = value as {
+		id?: unknown;
+		slug?: unknown;
+		name?: unknown;
+		destination?: unknown;
+	};
+	const identifier = resolveWorkflowId(id, slug);
+	if (identifier === null) {
+		return null;
+	}
+	if (typeof destination !== "object" || destination === null || Array.isArray(destination)) {
+		return null;
+	}
+	const { syncProtocol, autoApply, jrn } = destination as {
+		syncProtocol?: unknown;
+		autoApply?: unknown;
+		jrn?: unknown;
+	};
+	if (typeof syncProtocol !== "string" || typeof autoApply !== "boolean") {
+		return null;
+	}
+	if (typeof jrn !== "string" || jrn.trim() === "") {
+		return null;
+	}
+	const displayName = typeof name === "string" && name.trim() !== "" ? name : undefined;
+	return { id: identifier, name: displayName, destination: { syncProtocol, autoApply, jrn } };
+}
+
+/**
+ * The workflow identifier for `start_local_run`: a finite numeric `id` (the
+ * backend's shape — carried as a number so it stays usable as the integer the
+ * tool expects), else a non-empty string `id`, else a non-empty `slug`, else
+ * `null` (malformed).
+ */
+function resolveWorkflowId(id: unknown, slug: unknown): string | number | null {
+	if (typeof id === "number" && Number.isFinite(id)) {
+		return id;
+	}
+	if (typeof id === "string" && id.trim() !== "") {
+		return id;
+	}
+	if (typeof slug === "string" && slug.trim() !== "") {
+		return slug;
+	}
+	return null;
 }
 
 /** Pulls the tool array out of a manifest body — `{ tools: [...] }` or a bare array. */

--- a/cli/src/core/LocalRunEligibility.test.ts
+++ b/cli/src/core/LocalRunEligibility.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+	evaluateLocalRunEligibility,
+	isGitBackedSyncProtocol,
+	spaceSlugFromJrn,
+	type WorkflowSummary,
+} from "./LocalRunEligibility.js";
+
+const JRN = "jrn:/global:spaces:space/impact-1783452586552";
+const SLUG = "impact-1783452586552";
+
+function wf(id: string | number, syncProtocol: string, autoApply: boolean, jrn: string): WorkflowSummary {
+	return { id, destination: { syncProtocol, autoApply, jrn } };
+}
+
+describe("isGitBackedSyncProtocol", () => {
+	it("treats `git` as git-backed and everything else as not", () => {
+		expect(isGitBackedSyncProtocol("git")).toBe(true);
+		expect(isGitBackedSyncProtocol("db")).toBe(false);
+		expect(isGitBackedSyncProtocol("")).toBe(false);
+		expect(isGitBackedSyncProtocol("Git")).toBe(false); // exact match; backend canonical is lowercase
+		expect(isGitBackedSyncProtocol("github")).toBe(false);
+	});
+});
+
+describe("spaceSlugFromJrn", () => {
+	it("extracts the slug segment after the final slash", () => {
+		expect(spaceSlugFromJrn(JRN)).toBe(SLUG);
+		expect(spaceSlugFromJrn("jrn:/global:spaces:space/eng")).toBe("eng");
+	});
+
+	it("returns null when the JRN has no slug segment", () => {
+		expect(spaceSlugFromJrn("jrn:no-slash")).toBeNull();
+		expect(spaceSlugFromJrn("jrn:/global:spaces:space/")).toBeNull(); // trailing slash → empty slug
+	});
+});
+
+describe("evaluateLocalRunEligibility", () => {
+	it("git-backed + cloned (by JRN) + autoApply → runnable with autoMerges:true", () => {
+		const [verdict] = evaluateLocalRunEligibility([wf(7, "git", true, JRN)], new Set([JRN]));
+		expect(verdict).toEqual({ id: 7, runnable: true, autoMerges: true });
+	});
+
+	it("git-backed + cloned + no autoApply → runnable with autoMerges:false (review-first)", () => {
+		const [verdict] = evaluateLocalRunEligibility([wf(8, "git", false, JRN)], new Set([JRN]));
+		expect(verdict).toEqual({ id: 8, runnable: true, autoMerges: false });
+	});
+
+	it("echoes the workflow's display name on the verdict when the backend supplied one", () => {
+		const named: WorkflowSummary = {
+			id: 7,
+			name: "Impact Analysis",
+			destination: { syncProtocol: "git", autoApply: true, jrn: JRN },
+		};
+		const [verdict] = evaluateLocalRunEligibility([named], new Set([JRN]));
+		expect(verdict).toEqual({ id: 7, name: "Impact Analysis", runnable: true, autoMerges: true });
+	});
+
+	it("matches a clone recorded by SLUG when the destination is given by JRN", () => {
+		const [verdict] = evaluateLocalRunEligibility([wf(9, "git", true, JRN)], new Set([SLUG]));
+		expect(verdict.runnable).toBe(true);
+	});
+
+	it("git-backed + NOT cloned → not runnable, reason names the JRN, autoMerges still echoes autoApply", () => {
+		const [verdict] = evaluateLocalRunEligibility([wf(10, "git", true, JRN)], new Set(["jrn:/other/space/x"]));
+		expect(verdict.runnable).toBe(false);
+		expect(verdict.autoMerges).toBe(true);
+		expect(verdict.reason).toContain("not cloned");
+		expect(verdict.reason).toContain(JRN);
+	});
+
+	it("NON-git-backed + cloned → not runnable, reason names the syncProtocol, autoMerges still echoes autoApply", () => {
+		const [verdict] = evaluateLocalRunEligibility([wf(11, "db", true, JRN)], new Set([JRN]));
+		expect(verdict.runnable).toBe(false);
+		expect(verdict.autoMerges).toBe(true);
+		expect(verdict.reason).toContain("not git-backed");
+		expect(verdict.reason).toContain("db");
+	});
+
+	it("empty workflow list → empty verdict list", () => {
+		expect(evaluateLocalRunEligibility([], new Set([JRN]))).toEqual([]);
+	});
+
+	it("empty clones list → every git-backed workflow is not runnable", () => {
+		const verdicts = evaluateLocalRunEligibility(
+			[wf("a", "git", true, JRN), wf("b", "git", false, "jrn:/global:spaces:space/other")],
+			new Set(),
+		);
+		expect(verdicts.every((v) => v.runnable === false)).toBe(true);
+		expect(verdicts.map((v) => v.id)).toEqual(["a", "b"]);
+	});
+
+	it("preserves input order across a mix of verdicts", () => {
+		const verdicts = evaluateLocalRunEligibility(
+			[
+				wf("runnable", "git", true, JRN),
+				wf("not-cloned", "git", false, "jrn:/global:spaces:space/nope"),
+				wf("not-git", "db", true, JRN),
+			],
+			new Set([JRN]),
+		);
+		expect(verdicts.map((v) => ({ id: v.id, runnable: v.runnable }))).toEqual([
+			{ id: "runnable", runnable: true },
+			{ id: "not-cloned", runnable: false },
+			{ id: "not-git", runnable: false },
+		]);
+	});
+});

--- a/cli/src/core/LocalRunEligibility.ts
+++ b/cli/src/core/LocalRunEligibility.ts
@@ -1,0 +1,145 @@
+/**
+ * Pure eligibility logic for running a Jolli workflow LOCALLY (the calling
+ * client's own agent executes the recipe; Jolli supplies the recipe and tracks
+ * the run). A workflow is offered as locally-runnable ONLY when its destination
+ * space is git-backed AND that space is already cloned on this machine — so the
+ * workflow's writes can land through a branch + PR that space-cli commits and
+ * pushes locally.
+ *
+ * This module is deliberately I/O-free: it takes the raw candidate workflow list
+ * (fetched elsewhere via the manifest-served `list_workflows` platform tool) and
+ * the set of space keys cloned on this machine (read elsewhere from
+ * `jolli space clones --json`), and returns a verdict per workflow. No fetching,
+ * no spawning, no config reads — every input is passed in, every verdict comes
+ * out, which makes the whole rule exhaustively unit-testable.
+ *
+ * The destination identity is the space **JRN** (the backend keys spaces by JRN,
+ * not by a numeric id): a workflow is cloned-locally when its destination JRN —
+ * or the space slug encoded in that JRN — is among the machine's cloned-space
+ * keys.
+ */
+
+/** The destination-space facts an eligibility decision depends on. */
+export interface WorkflowDestination {
+	/**
+	 * The destination space's sync protocol. Only `git` is git-backed and
+	 * therefore locally-runnable (a PR needs a git remote to open against); other
+	 * values (e.g. `db`) are not runnable locally.
+	 */
+	readonly syncProtocol: string;
+	/**
+	 * Whether the destination auto-applies (auto-merges) an approved PR. Read
+	 * ONLY to tell the user up front whether the resulting PR auto-merges (`true`)
+	 * or opens for team review (`false`) — it is NEVER an eligibility input.
+	 */
+	readonly autoApply: boolean;
+	/**
+	 * The destination space's JRN (e.g. `jrn:/global:spaces:space/impact-1783452586552`).
+	 * Matched against the machine's cloned-space keys, by full JRN or by the space
+	 * slug encoded in it (see {@link spaceSlugFromJrn}).
+	 */
+	readonly jrn: string;
+}
+
+/** One candidate workflow as surfaced by the `list_workflows` platform tool. */
+export interface WorkflowSummary {
+	/**
+	 * Workflow identifier passed to `start_local_run`. The backend emits a numeric
+	 * id; it is carried as-is (not coerced to a string) so it stays usable as the
+	 * integer the `start_local_run` tool expects. A string id/slug is also accepted.
+	 */
+	readonly id: string | number;
+	/**
+	 * Human-readable workflow name (e.g. "Impact Analysis"), carried for display
+	 * ONLY so the recipe can present a chosen-from list by name rather than by an
+	 * opaque id. Advisory: absent when the backend omits it, and NEVER an
+	 * eligibility input.
+	 */
+	readonly name?: string;
+	readonly destination: WorkflowDestination;
+}
+
+/** The eligibility verdict for a single workflow. */
+export interface EligibilityVerdict {
+	readonly id: string | number;
+	/** The workflow's human-readable name, echoed for display when the backend supplied one. Never an eligibility input. */
+	readonly name?: string;
+	/** `true` iff the destination is git-backed AND its space is cloned locally. */
+	readonly runnable: boolean;
+	/** `destination.autoApply` — whether an approved PR auto-merges. Always populated, never an eligibility input. */
+	readonly autoMerges: boolean;
+	/** Present only when `runnable` is `false`; a short human-readable explanation. */
+	readonly reason?: string;
+}
+
+/**
+ * Sync protocols that are git-backed and therefore locally-runnable. Only `git`
+ * qualifies today (the backend's `destination.syncProtocol` value); add any
+ * future git-backed protocols here.
+ */
+const GIT_BACKED_SYNC_PROTOCOLS: ReadonlySet<string> = new Set(["git"]);
+
+/** Whether a destination sync protocol is git-backed (and so eligible for a local run). */
+export function isGitBackedSyncProtocol(syncProtocol: string): boolean {
+	return GIT_BACKED_SYNC_PROTOCOLS.has(syncProtocol);
+}
+
+/**
+ * The space slug encoded in a space JRN — the segment after the final `/` — or
+ * `null` when the JRN carries no slug segment. Example:
+ * `jrn:/global:spaces:space/impact-1783452586552` → `impact-1783452586552`.
+ */
+export function spaceSlugFromJrn(jrn: string): string | null {
+	const slash = jrn.lastIndexOf("/");
+	if (slash < 0 || slash === jrn.length - 1) {
+		return null;
+	}
+	return jrn.slice(slash + 1);
+}
+
+/**
+ * Computes the runnable verdict for every candidate workflow. Preserves input
+ * order. A workflow is `runnable` iff its destination is git-backed AND its
+ * destination space (by JRN, or by the slug encoded in the JRN) is in
+ * `clonedSpaceKeys`; `autoMerges` always echoes `destination.autoApply`; a
+ * `runnable: false` verdict carries a `reason`.
+ */
+export function evaluateLocalRunEligibility(
+	workflows: readonly WorkflowSummary[],
+	clonedSpaceKeys: ReadonlySet<string>,
+): EligibilityVerdict[] {
+	return workflows.map((workflow) => evaluateOne(workflow, clonedSpaceKeys));
+}
+
+function evaluateOne(workflow: WorkflowSummary, clonedSpaceKeys: ReadonlySet<string>): EligibilityVerdict {
+	const { id, name, destination } = workflow;
+	const autoMerges = destination.autoApply;
+	if (!isGitBackedSyncProtocol(destination.syncProtocol)) {
+		return {
+			id,
+			name,
+			runnable: false,
+			autoMerges,
+			reason: `Destination is not git-backed (syncProtocol="${destination.syncProtocol}"); local runs require a git-backed space.`,
+		};
+	}
+	if (!isCloned(destination.jrn, clonedSpaceKeys)) {
+		return {
+			id,
+			name,
+			runnable: false,
+			autoMerges,
+			reason: `Destination space ${destination.jrn} is not cloned on this machine.`,
+		};
+	}
+	return { id, name, runnable: true, autoMerges };
+}
+
+/** Whether the destination space — by full JRN or by its encoded slug — is among the machine's cloned-space keys. */
+function isCloned(jrn: string, clonedSpaceKeys: ReadonlySet<string>): boolean {
+	if (clonedSpaceKeys.has(jrn)) {
+		return true;
+	}
+	const slug = spaceSlugFromJrn(jrn);
+	return slug !== null && clonedSpaceKeys.has(slug);
+}

--- a/cli/src/core/LocalRunOffer.test.ts
+++ b/cli/src/core/LocalRunOffer.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import type { WorkflowSummary } from "./LocalRunEligibility.js";
+import { parseClonedSpaceKeys, resolveLocalRunOffer, SPACE_CLI_INSTALL_HINT } from "./LocalRunOffer.js";
+
+const JRN = "jrn:/global:spaces:space/impact-1783452586552";
+const SLUG = "impact-1783452586552";
+
+function wf(id: string | number, syncProtocol: string, autoApply: boolean, jrn: string): WorkflowSummary {
+	return { id, destination: { syncProtocol, autoApply, jrn } };
+}
+
+describe("resolveLocalRunOffer", () => {
+	it("returns an empty offer WITHOUT reading clones when there are no candidate workflows", async () => {
+		const readClonedSpaceKeys = vi.fn(async () => new Set<string>());
+		const result = await resolveLocalRunOffer({ listWorkflows: async () => [], readClonedSpaceKeys });
+		expect(result).toEqual({ type: "workflows", workflows: [] });
+		expect(readClonedSpaceKeys).not.toHaveBeenCalled();
+	});
+
+	it("returns space_cli_required (with the combined install hint) when candidates exist but clones are unavailable", async () => {
+		const result = await resolveLocalRunOffer({
+			listWorkflows: async () => [wf(7, "git", true, JRN)],
+			readClonedSpaceKeys: async () => null,
+		});
+		expect(result).toEqual({
+			type: "space_cli_required",
+			message: expect.stringContaining("space-cli"),
+			install: SPACE_CLI_INSTALL_HINT,
+		});
+		expect(SPACE_CLI_INSTALL_HINT).toBe("npm i -g @jolli.ai/cli @jolli.ai/space-cli");
+	});
+
+	it("offers only the runnable workflows, each carrying its autoMerges signal", async () => {
+		const result = await resolveLocalRunOffer({
+			listWorkflows: async () => [
+				wf(1, "git", true, JRN),
+				wf(2, "git", false, "jrn:/global:spaces:space/eng"),
+				wf(3, "git", true, "jrn:/global:spaces:space/uncloned"),
+				wf(4, "db", true, JRN),
+			],
+			readClonedSpaceKeys: async () => new Set([JRN, "eng"]),
+		});
+		expect(result).toEqual({
+			type: "workflows",
+			workflows: [
+				{ id: 1, autoMerges: true },
+				{ id: 2, autoMerges: false },
+			],
+		});
+	});
+
+	it("carries each runnable workflow's display name through the offer when the backend supplied one", async () => {
+		const result = await resolveLocalRunOffer({
+			listWorkflows: async () => [
+				{ id: 7, name: "Impact Analysis", destination: { syncProtocol: "git", autoApply: true, jrn: JRN } },
+				{ id: 8, destination: { syncProtocol: "git", autoApply: false, jrn: JRN } },
+			],
+			readClonedSpaceKeys: async () => new Set([JRN]),
+		});
+		expect(result).toEqual({
+			type: "workflows",
+			workflows: [
+				{ id: 7, name: "Impact Analysis", autoMerges: true },
+				{ id: 8, autoMerges: false },
+			],
+		});
+	});
+
+	it("returns an empty offer when candidates exist but none are runnable", async () => {
+		const result = await resolveLocalRunOffer({
+			listWorkflows: async () => [
+				wf(1, "git", true, "jrn:/global:spaces:space/uncloned"),
+				wf(2, "db", true, JRN),
+			],
+			readClonedSpaceKeys: async () => new Set([JRN]),
+		});
+		expect(result).toEqual({ type: "workflows", workflows: [] });
+	});
+});
+
+describe("parseClonedSpaceKeys", () => {
+	it("reads space JRNs from a bare array", () => {
+		expect(parseClonedSpaceKeys(JSON.stringify([{ jrn: JRN }, { jrn: "jrn:/x/space/y" }]))).toEqual(
+			new Set([JRN, "jrn:/x/space/y"]),
+		);
+	});
+
+	it("reads keys from a { clones: [...] } envelope", () => {
+		expect(parseClonedSpaceKeys(JSON.stringify({ clones: [{ jrn: JRN }] }))).toEqual(new Set([JRN]));
+	});
+
+	it("collects both `jrn` and `slug` when an entry exposes them", () => {
+		expect(parseClonedSpaceKeys(JSON.stringify([{ jrn: JRN, slug: SLUG }]))).toEqual(new Set([JRN, SLUG]));
+	});
+
+	it("reads a slug-only entry", () => {
+		expect(parseClonedSpaceKeys(JSON.stringify([{ slug: SLUG }]))).toEqual(new Set([SLUG]));
+	});
+
+	it("skips entries with no usable string key", () => {
+		const body = JSON.stringify([{ jrn: JRN }, { jrn: 5 }, { jrn: "" }, { slug: "  " }, {}, "not-an-object", null]);
+		expect(parseClonedSpaceKeys(body)).toEqual(new Set([JRN]));
+	});
+
+	it("returns an empty set on a non-JSON body", () => {
+		expect(parseClonedSpaceKeys("<html>oops</html>")).toEqual(new Set());
+	});
+
+	it("returns an empty set on a JSON body that is neither an array nor a { clones } envelope", () => {
+		expect(parseClonedSpaceKeys(JSON.stringify({ other: 1 }))).toEqual(new Set());
+		expect(parseClonedSpaceKeys(JSON.stringify(5))).toEqual(new Set());
+	});
+});

--- a/cli/src/core/LocalRunOffer.ts
+++ b/cli/src/core/LocalRunOffer.ts
@@ -1,0 +1,123 @@
+/**
+ * Combines the candidate workflow list, the machine's cloned-space ids, and the
+ * pure {@link evaluateLocalRunEligibility} rule into the offer the local-run
+ * recipe consumes: the set of workflows that can be run locally right now.
+ *
+ * The I/O is injected ({@link LocalRunOfferDeps}) so the branching is fully
+ * unit-testable without a live backend or a real space-cli spawn. The command
+ * surface (`local-run-workflows`) wires the real deps and prints the result.
+ */
+
+import { evaluateLocalRunEligibility, type WorkflowSummary } from "./LocalRunEligibility.js";
+
+/** The combined install hint surfaced when space-cli is required but absent. */
+export const SPACE_CLI_INSTALL_HINT = "npm i -g @jolli.ai/cli @jolli.ai/space-cli";
+
+/** One offerable workflow: the id the recipe passes to `start_local_run`, plus its advisory auto-merge signal. */
+export interface OfferableWorkflow {
+	/** Carried verbatim from the backend (a numeric id) so it stays usable as the integer `start_local_run` expects. */
+	readonly id: string | number;
+	/**
+	 * The workflow's human-readable name, when the backend supplied one, so the
+	 * recipe can present a multi-workflow choice by name instead of an opaque id.
+	 * Advisory display only — never a factor in what is offered.
+	 */
+	readonly name?: string;
+	/** Whether an approved PR will auto-merge (`true`) or open for team review (`false`). */
+	readonly autoMerges: boolean;
+}
+
+/**
+ * Type-tagged offer outcome. `workflows` (possibly empty) is the normal success —
+ * an empty list is a legitimate "nothing to offer" state (platform tools off, or
+ * no eligible workflow), never an error. `space_cli_required` is a "needs input"
+ * result (mirrors the `binding_required` idiom): space-cli must be installed
+ * before eligibility can be computed.
+ */
+export type LocalRunOfferResult =
+	| { readonly type: "workflows"; readonly workflows: OfferableWorkflow[] }
+	| { readonly type: "space_cli_required"; readonly message: string; readonly install: string };
+
+export interface LocalRunOfferDeps {
+	/** Best-effort candidate workflow list (empty on any degrade; never throws). */
+	readonly listWorkflows: () => Promise<WorkflowSummary[]>;
+	/** The cloned-space keys (JRNs and/or slugs) on this machine, or `null` when space-cli is unavailable. */
+	readonly readClonedSpaceKeys: () => Promise<Set<string> | null>;
+}
+
+/**
+ * Resolves the offer. When there are no candidate workflows the result is an
+ * empty offer WITHOUT consulting the clones — the blocker there is the absent
+ * workflow list (platform tools off / none served), not space-cli, so surfacing
+ * an install prompt would mislead. Only when candidates exist does a missing
+ * space-cli become the `space_cli_required` needs-input result.
+ */
+export async function resolveLocalRunOffer(deps: LocalRunOfferDeps): Promise<LocalRunOfferResult> {
+	const workflows = await deps.listWorkflows();
+	if (workflows.length === 0) {
+		return { type: "workflows", workflows: [] };
+	}
+	const clonedSpaceKeys = await deps.readClonedSpaceKeys();
+	if (clonedSpaceKeys === null) {
+		return {
+			type: "space_cli_required",
+			message: "Running a workflow locally needs the Jolli space-cli plugin. Install it with:",
+			install: SPACE_CLI_INSTALL_HINT,
+		};
+	}
+	const offerable = evaluateLocalRunEligibility(workflows, clonedSpaceKeys)
+		.filter((verdict) => verdict.runnable)
+		.map((verdict) => ({ id: verdict.id, name: verdict.name, autoMerges: verdict.autoMerges }));
+	return { type: "workflows", workflows: offerable };
+}
+
+/**
+ * Parses the cloned-space keys from `jolli space clones --json` output. Accepts a
+ * bare array or a `{ clones: [...] }` envelope; each entry contributes its space
+ * `jrn` and/or `slug` (whichever it exposes) as a string key, matched against a
+ * workflow destination's JRN or its encoded slug. Defensive by contract: a
+ * non-JSON body (a broken space-cli, a proxy page) yields an empty set — treated
+ * as "no clones" (nothing runnable) rather than an error — and entries with no
+ * usable string key are skipped.
+ *
+ * NOTE: the exact `jolli space clones --json` output shape is owned by
+ * `@jolli.ai/space-cli` (a separate package). This parser keys on the space
+ * identity the backend actually emits (JRN / slug), never a numeric id the
+ * backend does not produce; a clones command that exposes neither yields no
+ * matches (and must gain a JRN/slug key for local runs to be offerable).
+ */
+export function parseClonedSpaceKeys(stdout: string): Set<string> {
+	const keys = new Set<string>();
+	let json: unknown;
+	try {
+		json = JSON.parse(stdout);
+	} catch {
+		return keys;
+	}
+	for (const entry of extractCloneArray(json)) {
+		if (entry !== null && typeof entry === "object") {
+			const { jrn, slug } = entry as { jrn?: unknown; slug?: unknown };
+			if (typeof jrn === "string" && jrn.trim() !== "") {
+				keys.add(jrn);
+			}
+			if (typeof slug === "string" && slug.trim() !== "") {
+				keys.add(slug);
+			}
+		}
+	}
+	return keys;
+}
+
+/** Pulls the clone array out of the body — a bare array or a `{ clones: [...] }` envelope. */
+function extractCloneArray(json: unknown): unknown[] {
+	if (Array.isArray(json)) {
+		return json;
+	}
+	if (json !== null && typeof json === "object") {
+		const clones = (json as { clones?: unknown }).clones;
+		if (Array.isArray(clones)) {
+			return clones;
+		}
+	}
+	return [];
+}

--- a/cli/src/install/McpRegistration.test.ts
+++ b/cli/src/install/McpRegistration.test.ts
@@ -2,7 +2,14 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mcpServerEntry, registerMcpInClaude, removeMcpFromClaude, resolveCliJs } from "./McpRegistration.js";
+import {
+	cliInvocation,
+	mcpServerEntry,
+	registerMcpInClaude,
+	removeMcpFromClaude,
+	resolveCliInvocation,
+	resolveCliJs,
+} from "./McpRegistration.js";
 
 let dir: string;
 beforeEach(async () => {
@@ -82,6 +89,59 @@ describe("mcpServerEntry", () => {
 		// path (installDistPath runs, and aborts on failure, before registration),
 		// and re-registration replaces it with `node Cli.js` once a dist is known.
 		expect(mcpServerEntry("win32", runCli, undefined)).toEqual({ command: runCli, args: ["mcp"] });
+	});
+});
+
+describe("cliInvocation", () => {
+	const runCli = "/home/u/.jolli/jollimemory/run-cli";
+	const cliJs = "/abs/dist/Cli.js";
+
+	it("spawns the run-cli wrapper with the given args on POSIX", () => {
+		expect(cliInvocation("darwin", runCli, cliJs, ["space", "clones", "--json"])).toEqual({
+			command: runCli,
+			args: ["space", "clones", "--json"],
+		});
+		expect(cliInvocation("linux", runCli, cliJs, ["mcp"])).toEqual({ command: runCli, args: ["mcp"] });
+	});
+
+	it("spawns node on the resolved Cli.js with the given args on Windows", () => {
+		expect(cliInvocation("win32", runCli, cliJs, ["space", "clones", "--json"])).toEqual({
+			command: "node",
+			args: [cliJs, "space", "clones", "--json"],
+		});
+	});
+
+	it("falls back to the run-cli last resort on Windows when Cli.js can't be resolved", () => {
+		expect(cliInvocation("win32", runCli, undefined, ["mcp"])).toEqual({ command: runCli, args: ["mcp"] });
+	});
+});
+
+describe("resolveCliInvocation", () => {
+	it("resolves the run-cli indirection (never a bare `jolli`) with the given args on the host platform", () => {
+		const globalDir = "/home/u/.jolli/jollimemory";
+		const entry = resolveCliInvocation(["space", "clones", "--json"], globalDir);
+		expect(entry.args).toEqual(["space", "clones", "--json"]);
+		expect(entry.command).not.toBe("jolli");
+		// On POSIX hosts the run-cli wrapper is spawned directly; on win32 CI it is
+		// `node <Cli.js>` (or the run-cli last resort with no dist).
+		expect(entry.command === "node" || entry.command.endsWith("run-cli")).toBe(true);
+	});
+
+	it("consults resolveCliJs on Windows (no dist ⇒ run-cli last resort)", async () => {
+		const globalDir = await mkdtemp(join(tmpdir(), "jolli-global-"));
+		const original = process.platform;
+		Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+		try {
+			// No dist-paths dir under globalDir ⇒ resolveCliJs returns undefined ⇒ the
+			// win32 branch falls back to the run-cli path (exercises the win32 ternary).
+			expect(resolveCliInvocation(["mcp"], globalDir)).toEqual({
+				command: join(globalDir, "run-cli"),
+				args: ["mcp"],
+			});
+		} finally {
+			Object.defineProperty(process, "platform", { value: original, configurable: true });
+			await rm(globalDir, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/cli/src/install/McpRegistration.ts
+++ b/cli/src/install/McpRegistration.ts
@@ -20,30 +20,51 @@ interface McpServerEntry {
 }
 
 /**
- * The `command`/`args` an MCP host should spawn to start the server.
- *
- * The MCP host spawns `command` DIRECTLY (no shell), so the platform matters:
+ * The platform-correct `{ command, args }` to launch the jolli CLI with the given
+ * subcommand `args`. The launcher spawns `command` DIRECTLY (no shell), so the
+ * platform matters:
  * - POSIX: the `run-cli` dispatch script has a `#!/bin/bash` shebang and is +x,
  *   so a direct spawn honors it — and we keep the dist-path indirection (a
  *   version bump that moves the dist still resolves at spawn time).
  * - Windows: `run-cli` is an extension-less bash script; a direct spawn is
  *   ENOENT (no shebang support, not on PATHEXT). So we spawn `node` (already a
  *   hard requirement for the hooks, hence on PATH) on the resolved `Cli.js`.
- *   This bakes in an absolute path, but `registerMcpInClaude` re-runs on every
- *   install/activate, so a moved dist is re-resolved then.
+ *   This bakes in an absolute path, but callers re-run on every install/activate,
+ *   so a moved dist is re-resolved then.
  *
  *   If the dist can't be resolved yet on Windows there is no launchable command:
  *   `run-cli` is returned only as a last resort and is itself NOT launchable on
  *   win32 (same ENOENT) — i.e. it does NOT "avoid a broken entry", it just defers
- *   the breakage. This branch is effectively unreachable on the normal install
- *   path: `Installer.install()` writes this source's dist-path entry (and aborts
- *   on failure) BEFORE any MCP registration runs, so `resolveCliJs` resolves by
- *   then. If it were ever hit, the host would surface a spawn error (not silent)
- *   and the next install/activate would re-register with the real `node Cli.js`.
+ *   the breakage. On the normal install path `Installer.install()` writes this
+ *   source's dist-path entry (aborting on failure) BEFORE any registration runs,
+ *   so `resolveCliJs` resolves by then.
  */
+export function cliInvocation(
+	platform: NodeJS.Platform,
+	runCli: string,
+	cliJs: string | undefined,
+	args: string[],
+): McpServerEntry {
+	if (platform === "win32" && cliJs) return { command: "node", args: [cliJs, ...args] };
+	return { command: runCli, args: [...args] };
+}
+
+/** The `command`/`args` an MCP host should spawn to start the server (`<cli> mcp`). */
 export function mcpServerEntry(platform: NodeJS.Platform, runCli: string, cliJs: string | undefined): McpServerEntry {
-	if (platform === "win32" && cliJs) return { command: "node", args: [cliJs, "mcp"] };
-	return { command: runCli, args: ["mcp"] };
+	return cliInvocation(platform, runCli, cliJs, ["mcp"]);
+}
+
+/**
+ * Resolves the `{ command, args }` to spawn the jolli CLI with `args`, via the
+ * machine-global `run-cli` indirection host registration already writes (POSIX)
+ * or `node <Cli.js>` (win32). Deliberately NEVER a bare `jolli` on PATH — under
+ * GUI-launched hosts and the VS Code bundle (which by design needs no global CLI
+ * install) a bare-PATH spawn misfires. `globalDir` is injectable for tests.
+ */
+export function resolveCliInvocation(args: string[], globalDir: string = getGlobalConfigDir()): McpServerEntry {
+	const runCli = join(globalDir, "run-cli");
+	const cliJs = process.platform === "win32" ? resolveCliJs(globalDir) : undefined;
+	return cliInvocation(process.platform, runCli, cliJs, args);
 }
 
 /**

--- a/cli/src/install/SkillInstaller.test.ts
+++ b/cli/src/install/SkillInstaller.test.ts
@@ -18,6 +18,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+	buildLocalRunSkillTemplate,
 	buildRecallSkillTemplate,
 	buildSearchSkillTemplate,
 	SKILL_GIT_EXCLUDE_PATHS,
@@ -62,18 +63,25 @@ function readJolli(target: "claude" | "agents" = "claude"): string {
 	return readFileSync(join(tempDir, dir, "SKILL.md"), "utf-8");
 }
 
+function readLocalRun(target: "claude" | "agents" = "claude"): string {
+	const dir = target === "claude" ? ".claude/skills/jolli-local-run" : ".agents/skills/jolli-local-run";
+	return readFileSync(join(tempDir, dir, "SKILL.md"), "utf-8");
+}
+
 // ─── Dual-target write ──────────────────────────────────────────────────────
 
 describe("updateSkillsIfNeeded — target dimension", () => {
-	it("writes all four skills into both .claude/skills/ and .agents/skills/", async () => {
+	it("writes all five skills into both .claude/skills/ and .agents/skills/", async () => {
 		await updateSkillsIfNeeded(tempDir);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli-pr/SKILL.md"))).toBe(true);
+		expect(existsSync(join(tempDir, ".claude/skills/jolli-local-run/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-recall/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-search/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-pr/SKILL.md"))).toBe(true);
+		expect(existsSync(join(tempDir, ".agents/skills/jolli-local-run/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli/SKILL.md"))).toBe(true);
 	});
 
@@ -82,6 +90,7 @@ describe("updateSkillsIfNeeded — target dimension", () => {
 		expect(readRecall("claude")).toBe(readRecall("agents"));
 		expect(readSearch("claude")).toBe(readSearch("agents"));
 		expect(readPr("claude")).toBe(readPr("agents"));
+		expect(readLocalRun("claude")).toBe(readLocalRun("agents"));
 		expect(readJolli("claude")).toBe(readJolli("agents"));
 	});
 
@@ -90,10 +99,12 @@ describe("updateSkillsIfNeeded — target dimension", () => {
 		expect(existsSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"))).toBe(false);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"))).toBe(false);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli-pr/SKILL.md"))).toBe(false);
+		expect(existsSync(join(tempDir, ".claude/skills/jolli-local-run/SKILL.md"))).toBe(false);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli/SKILL.md"))).toBe(false);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-recall/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-search/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-pr/SKILL.md"))).toBe(true);
+		expect(existsSync(join(tempDir, ".agents/skills/jolli-local-run/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli/SKILL.md"))).toBe(true);
 	});
 
@@ -105,15 +116,17 @@ describe("updateSkillsIfNeeded — target dimension", () => {
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-pr/SKILL.md"))).toBe(true);
 	});
 
-	it("exports the 8 git-exclude paths for the four skills × two targets", () => {
+	it("exports the 10 git-exclude paths for the five skills × two targets", () => {
 		expect(SKILL_GIT_EXCLUDE_PATHS).toEqual([
 			"/.claude/skills/jolli-recall/",
 			"/.claude/skills/jolli-search/",
 			"/.claude/skills/jolli-pr/",
+			"/.claude/skills/jolli-local-run/",
 			"/.claude/skills/jolli/",
 			"/.agents/skills/jolli-recall/",
 			"/.agents/skills/jolli-search/",
 			"/.agents/skills/jolli-pr/",
+			"/.agents/skills/jolli-local-run/",
 			"/.agents/skills/jolli/",
 		]);
 	});
@@ -212,9 +225,97 @@ describe("jolli menu template frontmatter", () => {
 		expect(jolli).toMatch(/jolli-recall/);
 		expect(jolli).toMatch(/jolli-search/);
 		expect(jolli).toMatch(/jolli-pr/);
+		expect(jolli).toMatch(/jolli-local-run/);
 		// Surfaces session-registered MCP tools, not a hardcoded manifest fetch.
 		expect(jolli).toMatch(/mcp__jollimemory__/);
 		expect(jolli).toMatch(/AskUserQuestion/);
+	});
+});
+
+describe("jolli-local-run template", () => {
+	it("uses spec-compliant frontmatter (name/description/metadata only)", () => {
+		const t = buildLocalRunSkillTemplate();
+		expect(t).toMatch(/^---\nname: jolli-local-run\n/);
+		expect(t).toMatch(/description: Run a Jolli workflow locally/);
+		expect(t).toMatch(/metadata:\n {2}version: "[^"]+"\n {2}vendor: "jolli\.ai"/);
+		expect(t).not.toMatch(/^argument-hint:/m);
+		expect(t).not.toMatch(/^user-invocable:/m);
+	});
+
+	it("drives the run lifecycle tools", () => {
+		const t = buildLocalRunSkillTemplate();
+		expect(t).toContain("start_local_run");
+		expect(t).toContain("report_local_run_progress");
+		expect(t).toContain("complete_local_run");
+		expect(t).toContain("abandon_local_run");
+	});
+
+	it("uses the eligibility helper and offers only runnable workflows, announcing auto-merge vs team review", () => {
+		const t = buildLocalRunSkillTemplate();
+		expect(t).toContain("local-run-workflows");
+		expect(t).toMatch(/auto-merge/i);
+		expect(t).toMatch(/team review/i);
+	});
+
+	it("pins docs pull to --branch and explicitly forbids the destructive --agent", () => {
+		const t = buildLocalRunSkillTemplate();
+		expect(t).toContain("docs pull --branch");
+		expect(t).toContain("--agent");
+		expect(t).toMatch(/NEVER `--agent`/);
+		expect(t).toContain("git clean -fdx");
+	});
+
+	it("does NOT instruct the agent to call fetchSpaceBacking (docs pull fetches the token internally)", () => {
+		const t = buildLocalRunSkillTemplate();
+		expect(t).not.toContain("fetchSpaceBacking");
+		expect(t).toMatch(/fetches the destination write token internally/);
+	});
+
+	it("brackets the blocking review with heartbeats (before and after, not during)", () => {
+		const t = buildLocalRunSkillTemplate();
+		expect(t).toMatch(/immediately before/);
+		expect(t).toMatch(/immediately after/);
+		expect(t).toMatch(/explicitly approve/);
+	});
+
+	it("captures the docs publish {prNumber, prUrl} and passes them to complete_local_run", () => {
+		const t = buildLocalRunSkillTemplate();
+		expect(t).toContain("docs publish --json");
+		expect(t).toContain("prNumber");
+		expect(t).toContain("prUrl");
+	});
+
+	it("surfaces the combined space-cli install hint when the plugin is missing", () => {
+		const t = buildLocalRunSkillTemplate();
+		expect(t).toContain("npm i -g @jolli.ai/cli @jolli.ai/space-cli");
+	});
+
+	it("prefers MCP tools but shells the jolli CLI (run-cli) for the helper and git ops", () => {
+		const t = buildLocalRunSkillTemplate();
+		expect(t).toContain("mcp__jollimemory__start_local_run");
+		expect(t).toContain("$HOME/.jolli/jollimemory/run-cli");
+	});
+
+	it("shows the start_local_run id verbatim as an unquoted number (not a misleading quoted string)", () => {
+		const t = buildLocalRunSkillTemplate();
+		expect(t).toContain('{ "id": <workflow id> }');
+		expect(t).not.toContain('{ "id": "<workflow id>" }');
+		expect(t).toMatch(/exactly as the helper returned it/);
+	});
+
+	it("presents workflows by name and shows the real numeric id shape in the Step 1 example", () => {
+		const t = buildLocalRunSkillTemplate();
+		expect(t).toContain('"id": 7');
+		expect(t).toContain('"name": "Impact Analysis"');
+		expect(t).toMatch(/by its `name`/);
+		expect(t).not.toContain('"id": "..."');
+	});
+
+	it("carries the Windows Git Bash shell prerequisite (its run-cli bash steps hit %USERPROFILE%)", () => {
+		const t = buildLocalRunSkillTemplate();
+		expect(t).toContain("### Shell prerequisite");
+		expect(t).toMatch(/Git Bash/);
+		expect(t).toContain("%USERPROFILE%");
 	});
 });
 
@@ -734,6 +835,11 @@ describe("English-only", () => {
 	it("pr template contains no CJK characters", async () => {
 		await updateSkillsIfNeeded(tempDir);
 		expect(readPr()).not.toMatch(CJK_AND_OTHER_NON_LATIN);
+	});
+
+	it("local-run template contains no CJK characters", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		expect(readLocalRun()).not.toMatch(CJK_AND_OTHER_NON_LATIN);
 	});
 });
 

--- a/cli/src/install/SkillInstaller.ts
+++ b/cli/src/install/SkillInstaller.ts
@@ -119,6 +119,7 @@ const SKILLS: ReadonlyArray<SkillRegistration> = [
 	{ name: "jolli-recall", build: buildRecallSkillTemplate },
 	{ name: "jolli-search", build: buildSearchSkillTemplate },
 	{ name: "jolli-pr", build: buildPrSkillTemplate },
+	{ name: "jolli-local-run", build: buildLocalRunSkillTemplate },
 	{ name: "jolli", build: buildJolliMenuSkillTemplate },
 ];
 
@@ -241,6 +242,32 @@ async function upsertSkill(skillsDir: string, name: string, content: string): Pr
 // ─── Skill Templates ────────────────────────────────────────────────────────
 
 /**
+ * The Windows shell-prerequisite block shared by every shell-backed skill. It
+ * pins Git Bash on Windows because the `run-cli` entry script is written via
+ * Windows Node's `os.homedir()` to `%USERPROFILE%\\.jolli\\jollimemory\\run-cli`,
+ * and only Git Bash's `$HOME` aligns with `%USERPROFILE%` — PowerShell / WSL bash
+ * see a different home and won't find the script. Reused verbatim by both the
+ * arg-carrying here-doc skills ({@link heredocInvocation}) and the local-run
+ * recipe (fixed `run-cli` subcommands, no here-doc), so the guidance lives in one
+ * place instead of drifting per skill.
+ */
+const SHELL_PREREQUISITE_BLOCK = `### Shell prerequisite
+
+This block requires a POSIX bash shell. On Linux/macOS the system bash works.
+**On Windows, use Git Bash** (the bash bundled with Git for Windows). Other
+Windows "bash" options — \`C:\\Windows\\System32\\bash.exe\`, the WindowsApps
+alias, or any WSL bash — see a separate Linux home directory and will not
+find the Jolli entry script that lives under \`%USERPROFILE%\`.
+
+If Git Bash is not available on Windows, STOP and tell the user:
+"Jolli skill needs Git Bash on Windows. Install Git for Windows from
+https://git-scm.com/download/win and retry."
+
+Do NOT fall back to \`npm run\`, \`npx\`, \`node\` directly, PowerShell-native
+commands, WSL bash, or any workspace-local script — those bypass the
+security recipe and the dist resolver and will not produce valid output.`;
+
+/**
  * Shared Step-1 preamble — instructs the LLM to invoke the CLI via a here-doc
  * with a freshly-generated 16-char hex delimiter, and to STOP if the host
  * can't support that recipe rather than fall back to an `argv` interpolation
@@ -257,21 +284,7 @@ async function upsertSkill(skillsDir: string, name: string, content: string): Pr
  * prompt-injection payloads useless.
  */
 function heredocInvocation(subcommand: "recall" | "search" | "pr-description", flagSuffix: string): string {
-	return `### Shell prerequisite
-
-This block requires a POSIX bash shell. On Linux/macOS the system bash works.
-**On Windows, use Git Bash** (the bash bundled with Git for Windows). Other
-Windows "bash" options — \`C:\\Windows\\System32\\bash.exe\`, the WindowsApps
-alias, or any WSL bash — see a separate Linux home directory and will not
-find the Jolli entry script that lives under \`%USERPROFILE%\`.
-
-If Git Bash is not available on Windows, STOP and tell the user:
-"Jolli skill needs Git Bash on Windows. Install Git for Windows from
-https://git-scm.com/download/win and retry."
-
-Do NOT fall back to \`npm run\`, \`npx\`, \`node\` directly, PowerShell-native
-commands, WSL bash, or any workspace-local script — those bypass the
-security recipe and the dist resolver and will not produce valid output.
+	return `${SHELL_PREREQUISITE_BLOCK}
 
 ### Invocation
 
@@ -968,6 +981,154 @@ different phrasing. Do NOT mention BM25 or index internals.
 }
 
 /**
+ * Local-workflow-run recipe skill — walks the calling agent through running a
+ * Jolli workflow locally: discover the runnable workflows via the eligibility CLI
+ * helper, start the run and drive the destination clone through the `docs`
+ * (space-cli) commands, gate on a human review with lease heartbeats bracketing
+ * the blocking approval, then publish + complete (or abandon). Prefers the Jolli
+ * MCP platform tools for the run lifecycle; the eligibility check and the git
+ * operations go through the `jolli` CLI (run-cli entry script), matching the
+ * sibling skills. Byte-identical across every {@link SKILL_TARGETS} entry,
+ * spec-compliant frontmatter only.
+ */
+export function buildLocalRunSkillTemplate(): string {
+	return `---
+name: jolli-local-run
+description: Run a Jolli workflow locally — your own agent executes the workflow's recipe (no Jolli LLM budget) and its file writes land in a git-backed Jolli Space via a branch and pull request that space-cli opens on this machine. Use when the user wants to run a Jolli workflow locally.
+metadata:
+  version: "${SKILL_VERSION}"
+  vendor: "jolli.ai"
+---
+
+# Jolli Local Run
+
+Run a Jolli **workflow** locally: *your* agent executes the workflow's recipe on
+this machine (so it spends no Jolli LLM budget), Jolli supplies the recipe and
+tracks the run, and the workflow's file writes are published to a git-backed
+Jolli Space through an agent branch + pull request that space-cli commits and
+pushes locally.
+
+A workflow can be run locally only when its destination Space is **git-backed**
+AND already **cloned** on this machine. Before starting, the user is told whether
+the resulting PR will **auto-merge** or **open for team review**.
+
+Drive the steps below in order. Prefer the Jolli MCP tools for the run lifecycle;
+the eligibility check and the git operations go through the \`jolli\` CLI (via the
+run-cli entry script the sibling skills also use).
+
+${SHELL_PREREQUISITE_BLOCK}
+
+## Step 1 — discover the runnable workflows
+
+Run the eligibility helper and read its JSON:
+
+\`\`\`bash
+"$HOME/.jolli/jollimemory/run-cli" local-run-workflows
+\`\`\`
+
+- \`{ "type": "workflows", "workflows": [ { "id": 7, "name": "Impact Analysis", "autoMerges": true|false }, ... ] }\`
+  — the workflows runnable right now. **Offer only these.** Present each one to
+  the user by its \`name\` (fall back to the \`id\` when \`name\` is absent), and tell
+  them up front whether it will **auto-merge** the PR (\`autoMerges: true\`) or
+  **open the PR for team review** (\`autoMerges: false\`). If the array is empty,
+  tell the user there are no locally-runnable workflows (a workflow's destination
+  must be a git-backed, already-cloned Space) and stop.
+- \`{ "type": "space_cli_required", ... }\` — the space-cli plugin is missing. Tell
+  the user to install it and stop:
+
+  \`\`\`bash
+  npm i -g @jolli.ai/cli @jolli.ai/space-cli
+  \`\`\`
+
+- \`{ "type": "error", "message": "..." }\` — report the message and stop.
+
+Have the user pick one workflow — list them by \`name\` (use your host's
+interactive single-select tool if it has one — e.g. AskUserQuestion on Claude
+Code — otherwise list them as text). Keep the chosen workflow's \`id\` for Step 2.
+
+## Step 2 — start the run
+
+Call the \`start_local_run\` tool (on Claude Code
+\`mcp__jollimemory__start_local_run\`) with the chosen workflow's id, passed
+**exactly as the helper returned it** — the backend's id is a number, so it stays
+an unquoted number: \`{ "id": <workflow id> }\` (a string id/slug stays quoted).
+Capture from its result:
+
+- \`runId\` — the run handle for every later call.
+- \`plan\` — the recipe steps your agent will execute.
+- \`writeTarget\` — carries the server-derived \`workBranch\`, the destination Space,
+  and the destination folder.
+
+## Step 3 — check out the agent branch
+
+Pull the destination clone onto the server-derived work branch:
+
+\`\`\`bash
+"$HOME/.jolli/jollimemory/run-cli" docs pull --branch <writeTarget.workBranch>
+\`\`\`
+
+**Always \`--branch\`. NEVER \`--agent\`.** The \`--agent\` mode runs a destructive
+\`git clean -fdx\` that wipes untracked files; \`--branch\` checks out the
+server-derived branch without cleaning. Do not substitute \`--agent\` under any
+circumstances. \`docs pull\` fetches the destination write token internally — you
+do **not** fetch or handle any token yourself.
+
+## Step 4 — write the workflow's output
+
+Execute the workflow's \`plan\` from Step 2, writing the output files under the
+destination folder from \`writeTarget\`, inside the checked-out clone.
+
+## Step 5 — local review gate (with heartbeats)
+
+Nothing is committed or pushed until the human explicitly approves.
+
+1. Send a heartbeat so the run's lease stays alive while the human reviews: call
+   \`report_local_run_progress\` (on Claude Code
+   \`mcp__jollimemory__report_local_run_progress\`) with \`{ "runId": "<runId>" }\`.
+2. Show the working-tree diff of what the workflow wrote, and ask the user to
+   review, edit if needed, and **explicitly approve** (or cancel).
+3. When the user answers, send \`report_local_run_progress\` again.
+
+Send the heartbeat **immediately before** asking and **immediately after** the
+answer. Your turn is blocked while you wait for the human, so you cannot
+heartbeat *during* the review — bracketing the approval prompt keeps the lease
+fresh across the wait.
+
+## Step 6 — on approval: publish and complete
+
+1. Publish the branch as a pull request and capture the machine-readable result:
+
+   \`\`\`bash
+   "$HOME/.jolli/jollimemory/run-cli" docs publish --json
+   \`\`\`
+
+   Read \`prNumber\` and \`prUrl\` from its JSON output.
+2. Call \`complete_local_run\` (on Claude Code
+   \`mcp__jollimemory__complete_local_run\`) with
+   \`{ "runId": "<runId>", "prNumber": <prNumber>, "prUrl": "<prUrl>" }\`.
+3. Read \`autoMerges\` from its result and tell the user which happened: **"PR
+   auto-merged"** (\`autoMerges: true\`) or **"PR left open for team review"**
+   (\`autoMerges: false\`).
+
+## Step 7 — on cancel: abandon
+
+If the user cancels at the review gate (or you must abort), release the run: call
+\`abandon_local_run\` (on Claude Code \`mcp__jollimemory__abandon_local_run\`) with
+\`{ "runId": "<runId>" }\`.
+
+## If space-cli is missing at any point
+
+Any \`docs\` command that prints an install hint (or the eligibility helper's
+\`space_cli_required\` result) means the space-cli plugin is not installed. Tell the
+user to install it and stop:
+
+\`\`\`bash
+npm i -g @jolli.ai/cli @jolli.ai/space-cli
+\`\`\`
+`;
+}
+
+/**
  * The `jolli` umbrella-menu skill — surfaces as a bare `/jolli` and acts as the
  * single friendly front door over the sibling Jolli skills plus whatever
  * `mcp__jollimemory__*` tools are registered in the session. It only steers the
@@ -989,7 +1150,7 @@ different phrasing. Do NOT mention BM25 or index internals.
 export function buildJolliMenuSkillTemplate(): string {
 	return `---
 name: jolli
-description: The Jolli action menu — a single front door that lists the Jolli skills (recall, search, pr) plus the Jolli MCP tools registered in this session, then routes your choice to the right one. Use when the user types /jolli or asks for the Jolli menu.
+description: The Jolli action menu — a single front door that lists the Jolli skills (recall, search, pr, local-run) plus the Jolli MCP tools registered in this session, then routes your choice to the right one. Use when the user types /jolli or asks for the Jolli menu.
 metadata:
   version: "${SKILL_VERSION}"
   revision: 1
@@ -1018,6 +1179,9 @@ Assemble ONE combined list of actions from two sources.
   (decisions, topics, files). Route by invoking the \`jolli-search\` skill.
 - **jolli-pr** — Create or update a pull request using a Jolli Memory-generated
   description. Route by invoking the \`jolli-pr\` skill.
+- **jolli-local-run** — Run a Jolli workflow locally (your agent executes the
+  recipe; the writes land in a git-backed Space via a branch + PR). Route by
+  invoking the \`jolli-local-run\` skill.
 
 Route a local choice by invoking that skill through your host's skill-invocation
 mechanism (for example, the Skill tool in Claude Code).


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

This change lands the host side of running a Jolli workflow locally: a person's
own AI client runs the workflow's recipe on their machine (no Jolli LLM budget),
and the output is published to a git-backed destination space as a branch and
pull request that space-cli opens locally. A helper command reports which
workflows are eligible to run locally, a stub prints an install prompt when the
companion space-cli plugin is missing, and a new guided skill walks an assistant
through starting a run, checking out the right branch, pausing for a human's
review and approval, then publishing the result as a PR that either auto-merges
or waits for team review.

The eligibility parsing was also aligned to the backend's real response shape —
a numeric workflow id and a JRN-based destination identity — after an earlier
assumed shape caused the workflow list to always come back empty. Live
end-to-end against a real backend and space-cli is out of scope here.

---

## Topics (4)
<details>
<summary><strong>01 · Align local workflow-run eligibility to the backend's real response shape</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The "run a workflow locally" helper always reported zero available workflows
even when an eligible one existed, because the parser assumed a response format
the backend doesn't actually send.

**💡 Decisions Behind the Code**

- **Reconcile the CLI to the backend's real, already-shipped shape** rather than
  asking the backend to add fields it doesn't have — the live response is
  treated as ground truth, confirmed against the running system.
- **Fold the correction directly into the still-unreleased code** instead of
  layering a separate patch on top, keeping the history clean.
- **Degrade gracefully where a companion tool isn't ready yet** rather than
  fabricating a workaround — report "nothing runnable" or "install required"
  until that tool catches up.

**✅ What Was Implemented**

- Rewrote the workflow-list parsing to accept a numeric workflow id (carried
  as-is instead of forced to text), and to read the destination's sync protocol
  and JRN from the fields the backend actually returns.
- Re-keyed the eligibility and offer logic off the space JRN (or the slug
  encoded in it) — the backend emits no numeric space id — matching the full
  identifier or the short name against the machine's cloned spaces.
- Rewrote the affected tests against the real captured response shape,
  preserving every malformed-data and failure-mode case.

**📁 FILES**
- `cli/src/core/JolliMemoryPushClient.ts`
- `cli/src/core/LocalRunEligibility.ts`
- `cli/src/core/LocalRunOffer.ts`
- `cli/src/commands/LocalRunOfferCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Build the host eligibility helper command</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Expose the eligibility check to the guiding recipe as a single command an AI
client can call to learn which workflows are runnable locally right now.

**💡 Decisions Behind the Code**

- **A CLI helper the recipe shells, not a built-in platform tool** — the
  tool-dispatch path had no clean way to inject the network client, and spawning
  a subprocess from inside the stdio server risks corrupting its JSON-RPC
  channel.
- **Short-circuit to an empty offer before reading clones** when there are no
  candidate workflows at all, so the install prompt appears only when workflows
  actually exist.

**✅ What Was Implemented**

- A pure eligibility function that marks a workflow runnable only when its
  destination is git-backed and already cloned locally, echoing whether the
  resulting PR would auto-merge as an informational signal (never a factor in
  runnability itself).
- A best-effort workflow-list fetch that fails safe to an empty list under any
  error condition (feature disabled, tool missing, transport failure) rather
  than throwing.
- A `jolli local-run-workflows` command that reads the machine's cloned spaces
  and prints the offerable set as JSON; the clones read spawns through the
  run-cli indirection (or node on the resolved `Cli.js` on Windows) rather than
  a bare `jolli` on `PATH`, which matters for sandboxed and GUI-launched
  environments.

**📁 FILES**
- `cli/src/core/LocalRunEligibility.ts`
- `cli/src/core/LocalRunOffer.ts`
- `cli/src/commands/LocalRunOfferCommand.ts`
- `cli/src/install/McpRegistration.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Add a docs command stub for the space-cli plugin</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Local runs depend on a `docs` command from the companion space-cli plugin to
pull and publish files; without the plugin installed, the command previously
failed with a confusing generic error instead of a helpful install prompt.

**💡 Decisions Behind the Code**

- **Reuse the existing generic stub mechanism** rather than bespoke handling —
  it already provides argument forwarding, help-menu grouping, and
  collision-tolerant registration for the other space-related stubs.

**✅ What Was Implemented**

- Added a `docs` stub alongside the existing space-related command stubs so
  that, when the plugin isn't installed, `jolli docs pull --branch <b>` and
  `jolli docs publish` print a clear install instruction and exit non-zero
  instead of a Commander "unknown command/option" error.

**📁 FILES**
- `cli/src/commands/SpaceCommandStubs.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Add the guided skill that walks an assistant through a local run</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

With the eligibility check and command groundwork in place, the final piece is
step-by-step guidance an AI assistant can follow to carry out a local workflow
run from start to finish.

**💡 Decisions Behind the Code**

- **Guide an existing assistant through the steps rather than build a fully
  automated command** — writing arbitrary workflow output requires genuine
  reasoning ability that only an assistant already capable of writing code and
  files has; a plain command can't generate that content itself.
- **Send status pings only right before and right after the human review, not
  throughout** — an assistant's turn is fully paused while awaiting a person, so
  periodic pings during the wait aren't possible; the design relies on the wait
  window being generous enough to cover typical review time.

**✅ What Was Implemented**

- Authored a new installable skill that walks an assistant through the full
  sequence: check which workflows can run locally, announce whether the result
  will auto-merge or need review, start the run, check out the correct branch,
  write the output, pause for human approval with status pings before and after
  (not during) the wait, then publish and complete the run.
- Explicitly warned against a destructive branch-checkout mode that wipes
  uncommitted files, and clarified that the file-pull step handles
  authentication internally so the assistant never fetches or handles any access
  token itself.
- Listed the new skill in the umbrella `/jolli` menu alongside the existing
  recall, search, and pull-request skills.

**📁 FILES**
- `cli/src/install/SkillInstaller.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 14, 2026 at 11:13 PM · via Jolli proxy*
<!-- jollimemory-summary-end -->
