### PR TITLE
Telemetry: delivery reliability, instrumentation fixes, and VS Code UI engagement events

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -74,7 +74,7 @@ disk **before** they are sent.
 | `sync_completed` | A memory-bank sync round finished. Props: outcome (discriminator), duration_ms. |
 | `toolwindow_opened` | The memory tool window was opened. Props: view. |
 | `view_switched` | Tool window view switched (current/bank/knowledge). Props: view (discriminator). |
-| `memory_committed` | User committed a memory via the Commit button. Props: none. |
+| `memory_committed` | User committed a memory via the Commit button. Props: files_bucket (bucketed changed-file count), has_conversations (bool), context_bucket (bucketed plans/context count). |
 | `memory_expanded` | A committed memory's details were expanded. Props: expanded. |
 | `memory_item_opened` | An item inside a memory was opened. Props: item_type (discriminator: conversation/file/context/shipped). |
 | `session_resumed` | A conversation session was resumed in a terminal. Props: source (discriminator). |

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -81,6 +81,11 @@ disk **before** they are sent.
 | `recall_prompt_copied` | A recall prompt was copied to the clipboard. Props: none. |
 | `memory_pinned` | An item was pinned. Props: kind (discriminator). |
 | `memory_unpinned` | An item was unpinned. Props: kind (discriminator). |
+| `repo_switched` | User switched the active repo in the tool window's breadcrumb. Props: is_foreign (bool). |
+| `branch_switched` | User switched the active branch in the tool window's breadcrumb. Props: is_foreign (bool). |
+| `squash_performed` | User squashed commits. Props: count_bucket (bucketed number of commits squashed). |
+| `pr_created` | User created or updated a PR from the tool window. Props: action (discriminator: created/updated). |
+| `memory_shared` | User invoked Share for a branch's memories (read-only share link). Props: none. |
 | `key_rejected` | The server rejected the API key (401/403). Props: retried, where. |
 | `reauth_completed` | Re-authentication after a rejected key finished. Props: outcome. |
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -52,37 +52,37 @@ disk **before** they are sent.
 
 | Event | Description |
 | -- | -- |
-| `app_installed` | First run after install; installId minted (once per machine). |
+| `app_installed` | First run after install; installId minted (once per machine). Props: none — count distinct install_id. |
 | `client_activated` | A GUI surface activated (VS Code activate / IntelliJ project open), carrying `surface_version`. First-seen (install_id, surface_version) ≈ new + upgrade installs that launched. GUI-only — CLI new/upgrade is read from any event's surface_version. |
-| `surface_enabled` | A surface was enabled in a repo. |
-| `surface_disabled` | A surface was disabled / opted out. |
-| `signin_started` | User initiated OAuth sign-in. |
-| `signin_completed` | jolliApiKey minted — the conversion event. |
-| `signed_out` | User logged out. |
-| `ai_provider_selected` | User chose jolli vs anthropic for LLM. |
-| `memory_bank_migrated` | Migrate-to-Memory-Bank run. |
-| `command_invoked` | Any CLI command ran (auto-emitted). MCP tool calls carry a `tool` property and are emitted per call (not per session); the session-level `command:"mcp"` event is suppressed. |
-| `recall_performed` | A recall was run. |
-| `search_performed` | A search was run. |
-| `memory_pushed` | Memories pushed. |
-| `export_performed` | Export run. |
-| `ai_source_detected` | A new AI source transcript was detected. |
-| `settings_opened` | Settings UI opened (vscode/intellij). |
-| `ingest_completed` | A drainIngest run finished. Carries `idle:true` for a no-op drain (ingested=0); filter those out for real-ingest latency/health metrics. |
+| `surface_enabled` | A surface was enabled in a repo. Props: trigger. |
+| `surface_disabled` | A surface was disabled / opted out. Props: trigger, reason. |
+| `signin_started` | User initiated OAuth sign-in. Props: trigger. |
+| `signin_completed` | jolliApiKey minted — the conversion event. Props: api_key_minted. |
+| `signed_out` | User logged out. Props: none. |
+| `ai_provider_selected` | User chose jolli vs anthropic for LLM. Props: provider (discriminator). |
+| `memory_bank_migrated` | Migrate-to-Memory-Bank run. Props: outcome, repos, entries_bucket. |
+| `command_invoked` | Any CLI command ran (auto-emitted). Props: command (discriminator), ok, duration_ms. MCP tool calls carry a `tool` property and are emitted per call (not per session); the session-level `command:"mcp"` event is suppressed. |
+| `recall_performed` | A recall was run. Props: hit, result_count_bucket. |
+| `search_performed` | A search was run. Props: query_len_bucket, result_count_bucket. |
+| `memory_pushed` | Memories pushed to a Space. Props: kind, created, plans_bucket. |
+| `export_performed` | Export run. Props: format (discriminator). |
+| `ai_source_detected` | A new AI source transcript was detected. Props: source (discriminator: claude/codex/cursor/…). |
+| `settings_opened` | Settings UI opened (vscode/intellij). Props: tab (discriminator). |
+| `ingest_completed` | A drainIngest run finished. Props: outcome, ingested, idle (no-op when ingested=0), batches, route_calls, reconcile_calls, touched_slugs, topic_failures, duration_ms. Filter idle=true out for real-ingest latency/health metrics. |
 | `error_occurred` | A structured error was raised. Content-free schema: { where (stage/subsystem), code (enumerated), source? , retryable? }. Emitted via trackError(); never carries a message/stack/path. |
-| `queue_drained` | QueueWorker finished a drain. |
-| `sync_completed` | A memory-bank sync round finished. |
-| `toolwindow_opened` | The memory tool window was opened. |
-| `view_switched` | Tool window view switched (current/bank/knowledge). |
-| `memory_committed` | User committed a memory via the Commit button. |
-| `memory_expanded` | A committed memory's details were expanded. |
-| `memory_item_opened` | An item inside a memory was opened (conversation/file/context/shipped). |
-| `session_resumed` | A conversation session was resumed in a terminal. |
-| `recall_prompt_copied` | A recall prompt was copied to the clipboard. |
-| `memory_pinned` | An item was pinned. |
-| `memory_unpinned` | An item was unpinned. |
-| `key_rejected` | The server rejected the API key (401/403). |
-| `reauth_completed` | Re-authentication after a rejected key finished. |
+| `queue_drained` | QueueWorker finished a drain. Props: ops, duration_ms. |
+| `sync_completed` | A memory-bank sync round finished. Props: outcome (discriminator), duration_ms. |
+| `toolwindow_opened` | The memory tool window was opened. Props: view. |
+| `view_switched` | Tool window view switched (current/bank/knowledge). Props: view (discriminator). |
+| `memory_committed` | User committed a memory via the Commit button. Props: none. |
+| `memory_expanded` | A committed memory's details were expanded. Props: expanded. |
+| `memory_item_opened` | An item inside a memory was opened. Props: item_type (discriminator: conversation/file/context/shipped). |
+| `session_resumed` | A conversation session was resumed in a terminal. Props: source (discriminator). |
+| `recall_prompt_copied` | A recall prompt was copied to the clipboard. Props: none. |
+| `memory_pinned` | An item was pinned. Props: kind (discriminator). |
+| `memory_unpinned` | An item was unpinned. Props: kind (discriminator). |
+| `key_rejected` | The server rejected the API key (401/403). Props: retried, where. |
+| `reauth_completed` | Re-authentication after a rejected key finished. Props: outcome. |
 
 ---
 *Generated from `cli/src/core/TelemetryEvents.ts`. The IntelliJ plugin is an

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -76,7 +76,7 @@ disk **before** they are sent.
 | `view_switched` | Tool window view switched (current/bank/knowledge). Props: view (discriminator). |
 | `memory_committed` | User committed a memory via the Commit button. Props: files_bucket (bucketed changed-file count), has_conversations (bool), context_bucket (bucketed plans/context count). |
 | `memory_expanded` | A committed memory's details were expanded. Props: expanded. |
-| `memory_item_opened` | An item inside a memory was opened. Props: item_type (discriminator: conversation/file/context/shipped). |
+| `memory_item_opened` | An item inside a memory was opened. Props: item_type (discriminator: conversation/file/plan/note/reference/shipped). |
 | `session_resumed` | A conversation session was resumed in a terminal. Props: source (discriminator). |
 | `recall_prompt_copied` | A recall prompt was copied to the clipboard. Props: none. |
 | `memory_pinned` | An item was pinned. Props: kind (discriminator). |

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -69,7 +69,7 @@ disk **before** they are sent.
 | `ai_source_detected` | A new AI source transcript was detected. |
 | `settings_opened` | Settings UI opened (vscode/intellij). |
 | `ingest_completed` | A drainIngest run finished. |
-| `error_occurred` | A structured error code was raised. |
+| `error_occurred` | A structured error was raised. Content-free schema: { where (stage/subsystem), code (enumerated), source? , retryable? }. Emitted via trackError(); never carries a message/stack/path. |
 | `queue_drained` | QueueWorker finished a drain. |
 | `sync_completed` | A memory-bank sync round finished. |
 | `toolwindow_opened` | The memory tool window was opened. |

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -53,6 +53,7 @@ disk **before** they are sent.
 | Event | Description |
 | -- | -- |
 | `app_installed` | First run after install; installId minted (once per machine). |
+| `client_activated` | A GUI surface activated (VS Code activate / IntelliJ project open), carrying `surface_version`. First-seen (install_id, surface_version) ≈ new + upgrade installs that launched. GUI-only — CLI new/upgrade is read from any event's surface_version. |
 | `surface_enabled` | A surface was enabled in a repo. |
 | `surface_disabled` | A surface was disabled / opted out. |
 | `signin_started` | User initiated OAuth sign-in. |

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -60,7 +60,7 @@ disk **before** they are sent.
 | `signed_out` | User logged out. |
 | `ai_provider_selected` | User chose jolli vs anthropic for LLM. |
 | `memory_bank_migrated` | Migrate-to-Memory-Bank run. |
-| `command_invoked` | Any CLI command ran (auto-emitted). |
+| `command_invoked` | Any CLI command ran (auto-emitted). MCP tool calls carry a `tool` property and are emitted per call (not per session); the session-level `command:"mcp"` event is suppressed. |
 | `recall_performed` | A recall was run. |
 | `search_performed` | A search was run. |
 | `memory_pushed` | Memories pushed. |

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -68,7 +68,7 @@ disk **before** they are sent.
 | `export_performed` | Export run. |
 | `ai_source_detected` | A new AI source transcript was detected. |
 | `settings_opened` | Settings UI opened (vscode/intellij). |
-| `ingest_completed` | A drainIngest run finished. |
+| `ingest_completed` | A drainIngest run finished. Carries `idle:true` for a no-op drain (ingested=0); filter those out for real-ingest latency/health metrics. |
 | `error_occurred` | A structured error was raised. Content-free schema: { where (stage/subsystem), code (enumerated), source? , retryable? }. Emitted via trackError(); never carries a message/stack/path. |
 | `queue_drained` | QueueWorker finished a drain. |
 | `sync_completed` | A memory-bank sync round finished. |

--- a/cli/src/Cli.ts
+++ b/cli/src/Cli.ts
@@ -8,6 +8,7 @@
  */
 
 import { main } from "./Api.js";
+import { trackCommandFailureIfPending } from "./core/TelemetryCommandHook.js";
 import { bootstrapTelemetry, flushTelemetryNow, maybeShowCliTelemetryNotice } from "./core/TelemetryStartup.js";
 import { runWithTrace, traceIdFromEnv } from "./core/TraceContext.js";
 import { setSilentConsole } from "./Logger.js";
@@ -36,20 +37,26 @@ if (!process.env.VITEST) {
 			// auto-emit and any in-command track() calls have a live context. Never
 			// throws; the VITEST guard keeps it (and its installId mint) out of tests.
 			await bootstrapTelemetry({ cwd: process.cwd() });
+			let failed = false;
 			try {
 				await main();
 			} catch (error: unknown) {
+				failed = true;
 				console.error("Fatal error:", error);
-				process.exit(1);
+				// JOLLI-1960: commander skips its postAction on a thrown action, so the
+				// only place a failed command is recorded is here.
+				trackCommandFailureIfPending();
 			}
 			// JOLLI-1955: drain the shared telemetry buffer on command exit so CLI
-			// usage that never commits or runs an agent still uploads. Skip the
-			// `telemetry` command group — `off` clears the buffer and `inspect` must
-			// not send. Bounded timeout (not the flusher's 10s default) so a slow
+			// usage that never commits or runs an agent still uploads (and, on the
+			// failure path, so the ok:false event above is sent before we exit). Skip
+			// the `telemetry` command group — `off` clears the buffer and `inspect`
+			// must not send. Bounded timeout (not the flusher's 10s default) so a slow
 			// network can't stall the prompt; best-effort and never throws.
 			if (process.argv[2] !== "telemetry") {
 				await flushTelemetryNow(process.cwd(), { timeoutMs: 2_000 });
 			}
+			if (failed) process.exit(1);
 		})(),
 	);
 }

--- a/cli/src/Cli.ts
+++ b/cli/src/Cli.ts
@@ -8,7 +8,7 @@
  */
 
 import { main } from "./Api.js";
-import { bootstrapTelemetry, maybeShowCliTelemetryNotice } from "./core/TelemetryStartup.js";
+import { bootstrapTelemetry, flushTelemetryNow, maybeShowCliTelemetryNotice } from "./core/TelemetryStartup.js";
 import { runWithTrace, traceIdFromEnv } from "./core/TraceContext.js";
 import { setSilentConsole } from "./Logger.js";
 
@@ -41,6 +41,14 @@ if (!process.env.VITEST) {
 			} catch (error: unknown) {
 				console.error("Fatal error:", error);
 				process.exit(1);
+			}
+			// JOLLI-1955: drain the shared telemetry buffer on command exit so CLI
+			// usage that never commits or runs an agent still uploads. Skip the
+			// `telemetry` command group — `off` clears the buffer and `inspect` must
+			// not send. Bounded timeout (not the flusher's 10s default) so a slow
+			// network can't stall the prompt; best-effort and never throws.
+			if (process.argv[2] !== "telemetry") {
+				await flushTelemetryNow(process.cwd(), { timeoutMs: 2_000 });
 			}
 		})(),
 	);

--- a/cli/src/commands/TelemetryCommand.test.ts
+++ b/cli/src/commands/TelemetryCommand.test.ts
@@ -33,6 +33,7 @@ const run = async (...argv: string[]): Promise<void> => {
 
 const env = (over: Partial<TelemetryEnvelope> = {}): TelemetryEnvelope => ({
 	schemaVersion: 1,
+	eventId: "44444444-4444-4444-8444-444444444444",
 	eventName: "recall_performed",
 	surface: "cli",
 	surfaceVersion: "1.0.0",

--- a/cli/src/core/IngestErrors.ts
+++ b/cli/src/core/IngestErrors.ts
@@ -37,3 +37,29 @@ export const INGEST_CODES = {
 } as const;
 
 export type IngestCode = (typeof INGEST_CODES)[keyof typeof INGEST_CODES];
+
+/**
+ * Ingest outcomes that are NOT pipeline errors and therefore must NOT raise an
+ * `error_occurred` telemetry event (JOLLI-1962). `ingest_completed` still records
+ * the outcome for all of them; they just aren't double-counted as errors.
+ *
+ *   - `OK` / `NO_PENDING` — success / nothing pending.
+ *   - `CREDENTIAL_MISSING` — the user isn't signed in, so the drain can't run yet.
+ *     An expected "can't run" state, not a failure — it dominated (~87%) the old
+ *     apparent ingest error rate.
+ *   - `NO_SOURCE_CONTENT` — the batch's sources vanished / were empty; nothing to
+ *     fold in.
+ *   - `PAGE_WRITE_CONFLICT` — a benign, self-resolving concurrent-write hold (see
+ *     its code doc above); sources are just retried on the next drain.
+ *
+ * Genuine failures (`ROUTE_FAILED`, `RECONCILE_TRUNCATED`, `RECONCILE_PARSE_FAILED`,
+ * `RECONCILE_CALL_FAILED`, `ITERATION_GUARD`, `PAGE_WRITE_ERROR`) are absent here,
+ * so they still surface as `error_occurred`.
+ */
+export const INGEST_NON_ERROR_OUTCOMES: ReadonlySet<string> = new Set([
+	INGEST_CODES.OK,
+	INGEST_CODES.NO_PENDING,
+	INGEST_CODES.CREDENTIAL_MISSING,
+	INGEST_CODES.NO_SOURCE_CONTENT,
+	INGEST_CODES.PAGE_WRITE_CONFLICT,
+]);

--- a/cli/src/core/IngestRunStore.test.ts
+++ b/cli/src/core/IngestRunStore.test.ts
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getJolliMemoryDir } from "../Logger.js";
 import { INGEST_CODES } from "./IngestErrors.js";
 import { appendCredentialMissingRun, appendIngestRun, type IngestRunRecord, readIngestRuns } from "./IngestRunStore.js";
+import { initTelemetry, shutdownTelemetry } from "./Telemetry.js";
+import { readTelemetryEvents } from "./TelemetryBuffer.js";
 
 let cwd: string;
 const rec = (over: Partial<IngestRunRecord> = {}): IngestRunRecord => ({
@@ -76,5 +78,48 @@ describe("IngestRunStore", () => {
 		expect(runs[0].outcome).toBe(INGEST_CODES.CREDENTIAL_MISSING);
 		expect(runs[0].triggeredBy).toBe("post-merge");
 		expect(runs[0].batches).toBe(0);
+	});
+});
+
+describe("IngestRunStore telemetry — error_occurred gating (JOLLI-1962)", () => {
+	beforeEach(() => {
+		initTelemetry({
+			cwd,
+			installId: "11111111-1111-4111-8111-111111111111",
+			origin: "https://jolli.ai",
+			config: {},
+		});
+	});
+	afterEach(() => shutdownTelemetry());
+
+	const eventsOfType = async (name: string) => (await readTelemetryEvents(cwd)).filter((e) => e.eventName === name);
+
+	it("does NOT raise error_occurred for success or benign/expected outcomes", async () => {
+		const benign = [
+			INGEST_CODES.OK,
+			INGEST_CODES.NO_PENDING,
+			INGEST_CODES.CREDENTIAL_MISSING,
+			INGEST_CODES.NO_SOURCE_CONTENT,
+			INGEST_CODES.PAGE_WRITE_CONFLICT,
+		];
+		for (const outcome of benign) await appendIngestRun(cwd, rec({ outcome }));
+		// Every run still records a completion event; none is counted as an error.
+		expect(await eventsOfType("ingest_completed")).toHaveLength(benign.length);
+		expect(await eventsOfType("error_occurred")).toEqual([]);
+	});
+
+	it("raises one error_occurred(where=ingest) per genuine failure outcome", async () => {
+		const failures = [
+			INGEST_CODES.ROUTE_FAILED,
+			INGEST_CODES.RECONCILE_TRUNCATED,
+			INGEST_CODES.RECONCILE_PARSE_FAILED,
+			INGEST_CODES.RECONCILE_CALL_FAILED,
+			INGEST_CODES.ITERATION_GUARD,
+			INGEST_CODES.PAGE_WRITE_ERROR,
+		];
+		for (const outcome of failures) await appendIngestRun(cwd, rec({ outcome }));
+		const errs = await eventsOfType("error_occurred");
+		expect(errs).toHaveLength(failures.length);
+		expect(errs.every((e) => (e.properties as { where?: string }).where === "ingest")).toBe(true);
 	});
 });

--- a/cli/src/core/IngestRunStore.test.ts
+++ b/cli/src/core/IngestRunStore.test.ts
@@ -122,4 +122,11 @@ describe("IngestRunStore telemetry — error_occurred gating (JOLLI-1962)", () =
 		expect(errs).toHaveLength(failures.length);
 		expect(errs.every((e) => (e.properties as { where?: string }).where === "ingest")).toBe(true);
 	});
+
+	it("flags idle (ingested=0) vs real ingests on ingest_completed (JOLLI-1964)", async () => {
+		await appendIngestRun(cwd, rec({ outcome: INGEST_CODES.NO_PENDING, ingested: 0 }));
+		await appendIngestRun(cwd, rec({ outcome: INGEST_CODES.OK, ingested: 3 }));
+		const completed = await eventsOfType("ingest_completed");
+		expect(completed.map((e) => (e.properties as { idle?: boolean }).idle)).toEqual([true, false]);
+	});
 });

--- a/cli/src/core/IngestRunStore.ts
+++ b/cli/src/core/IngestRunStore.ts
@@ -11,7 +11,7 @@ import { getJolliMemoryDir } from "../Logger.js";
 import type { IngestOperation } from "../Types.js";
 import { atomicWriteFile } from "./AtomicWrite.js";
 import { INGEST_CODES, INGEST_NON_ERROR_OUTCOMES, type IngestCode } from "./IngestErrors.js";
-import { track } from "./Telemetry.js";
+import { track, trackError } from "./Telemetry.js";
 
 const RUNS_FILE = "ingest-runs.json";
 const MAX_RUNS = 20;
@@ -72,7 +72,7 @@ function emitIngestTelemetry(record: IngestRunRecord): void {
 	// "not signed in" and benign-retry noise (JOLLI-1962). The outcome is still
 	// recorded on `ingest_completed`; only real failures raise the error event.
 	if (!INGEST_NON_ERROR_OUTCOMES.has(record.outcome)) {
-		track("error_occurred", { code: record.outcome, where: "ingest" });
+		trackError("ingest", record.outcome);
 	}
 }
 

--- a/cli/src/core/IngestRunStore.ts
+++ b/cli/src/core/IngestRunStore.ts
@@ -10,7 +10,7 @@ import { join } from "node:path";
 import { getJolliMemoryDir } from "../Logger.js";
 import type { IngestOperation } from "../Types.js";
 import { atomicWriteFile } from "./AtomicWrite.js";
-import { INGEST_CODES, type IngestCode } from "./IngestErrors.js";
+import { INGEST_CODES, INGEST_NON_ERROR_OUTCOMES, type IngestCode } from "./IngestErrors.js";
 import { track } from "./Telemetry.js";
 
 const RUNS_FILE = "ingest-runs.json";
@@ -65,9 +65,13 @@ function emitIngestTelemetry(record: IngestRunRecord): void {
 		reconcile_calls: record.reconcileCalls,
 		topic_failures: record.topicFailures.length,
 	});
-	// A genuine failure outcome also raises a structured error event. OK and
-	// NO_PENDING are normal terminal states, not errors.
-	if (record.outcome !== INGEST_CODES.OK && record.outcome !== INGEST_CODES.NO_PENDING) {
+	// A genuine failure outcome also raises a structured error event. Success and
+	// benign/expected terminal states (OK, NO_PENDING, CREDENTIAL_MISSING,
+	// NO_SOURCE_CONTENT, PAGE_WRITE_CONFLICT) are NOT errors — raising
+	// `error_occurred` for them inflated the apparent ingest error rate with
+	// "not signed in" and benign-retry noise (JOLLI-1962). The outcome is still
+	// recorded on `ingest_completed`; only real failures raise the error event.
+	if (!INGEST_NON_ERROR_OUTCOMES.has(record.outcome)) {
 		track("error_occurred", { code: record.outcome, where: "ingest" });
 	}
 }

--- a/cli/src/core/IngestRunStore.ts
+++ b/cli/src/core/IngestRunStore.ts
@@ -60,6 +60,10 @@ function emitIngestTelemetry(record: IngestRunRecord): void {
 		duration_ms: record.durationMs,
 		batches: record.batches,
 		ingested: record.ingested,
+		// JOLLI-1964: explicit idle flag so latency/health dashboards can drop no-op
+		// drains (nothing pending → p50 ~ms) without knowing the `ingested` semantics.
+		// ~27% of runs are idle and would otherwise dilute real-ingest metrics.
+		idle: record.ingested === 0,
 		touched_slugs: record.touchedSlugs,
 		route_calls: record.routeCalls,
 		reconcile_calls: record.reconcileCalls,

--- a/cli/src/core/Telemetry.test.ts
+++ b/cli/src/core/Telemetry.test.ts
@@ -178,6 +178,7 @@ describe("track / initTelemetry", () => {
 		expect(e.os).toBe(process.platform);
 		expect(e.runtimeVersion).toBe(`node-${process.versions.node}`);
 		expect(e.tsIso).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+		expect(e.eventId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
 	});
 
 	it("omits sessionId when none is provided", async () => {
@@ -185,6 +186,18 @@ describe("track / initTelemetry", () => {
 		track("search_performed");
 		const [e] = await readTelemetryEvents(cwd);
 		expect(e).not.toHaveProperty("sessionId");
+	});
+
+	it("mints a distinct eventId per event (idempotency key)", async () => {
+		initTelemetry(baseInit());
+		track("search_performed");
+		track("search_performed");
+		const events = await readTelemetryEvents(cwd);
+		expect(events).toHaveLength(2);
+		expect(events[0].eventId).not.toBe(events[1].eventId);
+		for (const e of events) {
+			expect(e.eventId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+		}
 	});
 
 	it("does not emit when consent is off (config)", async () => {

--- a/cli/src/core/Telemetry.test.ts
+++ b/cli/src/core/Telemetry.test.ts
@@ -12,6 +12,7 @@ import {
 	scrubProperties,
 	shutdownTelemetry,
 	track,
+	trackError,
 } from "./Telemetry.js";
 import { readTelemetryEvents } from "./TelemetryBuffer.js";
 
@@ -232,5 +233,31 @@ describe("track / initTelemetry", () => {
 		expect(getTelemetryContext()).toBeNull();
 		track("recall_performed");
 		expect(await readTelemetryEvents(cwd)).toEqual([]);
+	});
+});
+
+describe("trackError (JOLLI-1961)", () => {
+	const baseInit = () => ({ cwd, installId: "install-1", origin: "https://acme.jolli.ai", config: {} });
+
+	it("emits error_occurred with the full content-free schema", async () => {
+		initTelemetry(baseInit());
+		trackError("ingest", "ROUTE_FAILED", { source: "claude", retryable: true });
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.eventName).toBe("error_occurred");
+		expect(e.properties).toEqual({ where: "ingest", code: "ROUTE_FAILED", source: "claude", retryable: true });
+	});
+
+	it("omits absent optional fields (where + code only)", async () => {
+		initTelemetry(baseInit());
+		trackError("push", "push_failed");
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.properties).toEqual({ where: "push", code: "push_failed" });
+	});
+
+	it("includes retryable:false when explicitly false", async () => {
+		initTelemetry(baseInit());
+		trackError("sync", "conflict", { retryable: false });
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.properties).toEqual({ where: "sync", code: "conflict", retryable: false });
 	});
 });

--- a/cli/src/core/Telemetry.ts
+++ b/cli/src/core/Telemetry.ts
@@ -135,6 +135,30 @@ export function track(eventName: TelemetryEventName, properties: Readonly<Record
 	}
 }
 
+/**
+ * Emit a structured, content-free `error_occurred` (JOLLI-1961). The one schema
+ * every surface uses is `{ where, code, source?, retryable? }`:
+ *   - `where`      — the pipeline stage / subsystem (e.g. "ingest", "push", "sync").
+ *   - `code`       — a stable, enumerated error code — NEVER a message, stack, or path.
+ *   - `source?`    — the source/subsystem enum, when relevant (content-free).
+ *   - `retryable?` — whether a retry may succeed, when known.
+ * All values must be fixed identifiers from our own code, never user content.
+ * Routing every error through here keeps the shape consistent (in particular it
+ * avoids a property literally named `name`, which the backend scrubber drops).
+ */
+export function trackError(
+	where: string,
+	code: string,
+	opts?: { readonly source?: string; readonly retryable?: boolean },
+): void {
+	track("error_occurred", {
+		where,
+		code,
+		...(opts?.source !== undefined ? { source: opts.source } : {}),
+		...(opts?.retryable !== undefined ? { retryable: opts.retryable } : {}),
+	});
+}
+
 // ─────────────────────────── helpers ───────────────────────────
 
 /** Map a raw count to a coarse bucket. Non-positive / non-finite → "0". */

--- a/cli/src/core/Telemetry.ts
+++ b/cli/src/core/Telemetry.ts
@@ -22,7 +22,7 @@
  * The Kotlin port (`Telemetry.kt`, Phase 3) mirrors this module — keep them in
  * lockstep.
  */
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { JOLLI_CLIENT_HEADER } from "./ClientHeader.js";
 import { appendTelemetryEvent, type TelemetryEnvelope } from "./TelemetryBuffer.js";
 import { resolveTelemetryConsent } from "./TelemetryConsent.js";
@@ -110,6 +110,10 @@ export function track(eventName: TelemetryEventName, properties: Readonly<Record
 	try {
 		const envelope: TelemetryEnvelope = {
 			schemaVersion: SCHEMA_VERSION,
+			// Idempotency key minted once here, at buffer time. Written to disk and
+			// re-read verbatim on flush, so a re-sent event keeps the same id and the
+			// backend dedups on (event_id, ts) — see TelemetryEnvelope (JOLLI-1966).
+			eventId: randomUUID(),
 			eventName,
 			surface: ctx.surface,
 			surfaceVersion: ctx.surfaceVersion,

--- a/cli/src/core/TelemetryBuffer.test.ts
+++ b/cli/src/core/TelemetryBuffer.test.ts
@@ -44,6 +44,31 @@ afterEach(async () => {
 });
 
 describe("TelemetryBuffer", () => {
+	// JOLLI-1957 — the cwd IS the buffer identity: `join(cwd, .jolli/jollimemory,
+	// telemetry-queue.ndjson)` with no git-root normalization. Two cwds are two
+	// separate buffers, so a writer and a flusher for the same project must pass
+	// the same cwd or events are stranded. Lock that invariant here.
+	it("keeps buffers isolated per cwd — a different cwd is a different buffer", async () => {
+		const otherCwd = await mkdtemp(join(tmpdir(), "telemetry-buffer-other-"));
+		try {
+			appendTelemetryEvent(cwd, env({ installId: "in-a" }));
+			appendTelemetryEvent(otherCwd, env({ installId: "in-b" }));
+
+			// Each cwd sees only its own events (distinct files, distinct content).
+			expect((await readTelemetryEvents(cwd)).map((e) => e.installId)).toEqual(["in-a"]);
+			expect((await readTelemetryEvents(otherCwd)).map((e) => e.installId)).toEqual(["in-b"]);
+			expect(queueFile(cwd)).not.toBe(queueFile(otherCwd));
+
+			// Draining/clearing one cwd must not touch the other's buffer — this is
+			// what guarantees a mismatched-cwd flush can't strand the other's events.
+			await clearTelemetryBuffer(cwd);
+			expect(await readTelemetryEvents(cwd)).toEqual([]);
+			expect((await readTelemetryEvents(otherCwd)).map((e) => e.installId)).toEqual(["in-b"]);
+		} finally {
+			await rm(otherCwd, { recursive: true, force: true });
+		}
+	});
+
 	it("round-trips appended events (missing file starts empty)", async () => {
 		expect(await readTelemetryEvents(cwd)).toEqual([]);
 		appendTelemetryEvent(cwd, env({ properties: { hit: true } }));

--- a/cli/src/core/TelemetryBuffer.test.ts
+++ b/cli/src/core/TelemetryBuffer.test.ts
@@ -18,6 +18,7 @@ let cwd: string;
 
 const env = (over: Partial<TelemetryEnvelope> = {}): TelemetryEnvelope => ({
 	schemaVersion: 1,
+	eventId: "22222222-2222-4222-8222-222222222222",
 	eventName: "recall_performed",
 	surface: "cli",
 	surfaceVersion: "1.2.0",

--- a/cli/src/core/TelemetryBuffer.ts
+++ b/cli/src/core/TelemetryBuffer.ts
@@ -33,6 +33,7 @@
  * other surfaces write to). Do not introduce a flush call site that resolves cwd
  * differently from where the events were written.
  */
+import { createHash } from "node:crypto";
 import { appendFileSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { mkdir, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
@@ -41,6 +42,7 @@ import { atomicWriteFile } from "./AtomicWrite.js";
 import type { TelemetryEventName } from "./TelemetryEvents.js";
 
 const QUEUE_FILE = "telemetry-queue.ndjson";
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 /**
  * Hard ceiling on buffered events. At the cap, the oldest events are dropped
@@ -99,6 +101,28 @@ function queuePath(cwd: string): string {
 	return join(getJolliMemoryDir(cwd), QUEUE_FILE);
 }
 
+function hasUsableEventId(eventId: unknown): eventId is string {
+	return typeof eventId === "string" && UUID_RE.test(eventId);
+}
+
+/**
+ * Backfill a stable UUID for telemetry lines buffered by older clients before
+ * `eventId` existed. The id is deterministic from the exact stored line, so a
+ * failed flush/retry keeps the same id even though the legacy file is unchanged.
+ */
+function legacyEventId(rawLine: string): string {
+	const hex = createHash("sha256").update(rawLine).digest("hex");
+	const variant = ((Number.parseInt(hex.slice(16, 18), 16) & 0x3f) | 0x80).toString(16).padStart(2, "0");
+	return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-5${hex.slice(13, 16)}-${variant}${hex.slice(18, 20)}-${hex.slice(20, 32)}`;
+}
+
+function normalizeTelemetryEnvelope(parsed: unknown, rawLine: string): TelemetryEnvelope | null {
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+	const event = parsed as Record<string, unknown>;
+	if (hasUsableEventId(event.eventId)) return event as unknown as TelemetryEnvelope;
+	return { ...event, eventId: legacyEventId(rawLine) } as unknown as TelemetryEnvelope;
+}
+
 /**
  * Synchronously append one event as an NDJSON line. Creates the directory if
  * needed. Designed to be called from the synchronous `track()` choke-point;
@@ -142,7 +166,8 @@ export async function readTelemetryEvents(cwd: string): Promise<TelemetryEnvelop
 		const trimmed = line.trim();
 		if (trimmed.length === 0) continue;
 		try {
-			events.push(JSON.parse(trimmed) as TelemetryEnvelope);
+			const event = normalizeTelemetryEnvelope(JSON.parse(trimmed), trimmed);
+			if (event) events.push(event);
 		} catch {
 			// Skip a torn/corrupt line; the rest of the buffer is still good.
 		}

--- a/cli/src/core/TelemetryBuffer.ts
+++ b/cli/src/core/TelemetryBuffer.ts
@@ -48,6 +48,15 @@ export const MAX_BYTES = 1_000_000;
  */
 export interface TelemetryEnvelope {
 	readonly schemaVersion: number;
+	/**
+	 * Client-generated idempotency key (UUID), minted once when the event is
+	 * buffered and preserved verbatim across re-sends. Telemetry delivery is
+	 * at-least-once (a lost ack after a successful insert, or overlapping flush
+	 * triggers, re-sends buffered events), so the backend dedups on
+	 * `(event_id, ts)` — `INSERT … ON CONFLICT DO NOTHING` — to keep a retry from
+	 * creating a duplicate row (JOLLI-1966). Must NOT be regenerated on re-send.
+	 */
+	readonly eventId: string;
 	readonly eventName: TelemetryEventName;
 	readonly surface: string;
 	readonly surfaceVersion: string;

--- a/cli/src/core/TelemetryBuffer.ts
+++ b/cli/src/core/TelemetryBuffer.ts
@@ -16,6 +16,22 @@
  *
  * Resilience: a corrupt line is skipped, not fatal — the rest of the buffer is
  * still readable (line-level, unlike IngestRunStore's whole-file fallback).
+ *
+ * Cwd contract (JOLLI-1957 — read this before adding a writer or a flusher):
+ * the buffer path is `join(cwd, ".jolli/jollimemory", QUEUE_FILE)` — a LITERAL
+ * `cwd`, with no git-root normalization (see `getJolliMemoryDir`). So the `cwd`
+ * IS the buffer identity: two different `cwd` strings (a repo root vs one of its
+ * subdirectories, or two surfaces resolving the root differently) are two
+ * SEPARATE buffers. Therefore every writer (`track()` via `initTelemetry`'s
+ * cwd) and every flusher (`flushTelemetryNow`) for a given project MUST pass the
+ * SAME cwd — the project/workspace root — or events written under one cwd are
+ * stranded in a buffer no trigger for the other cwd will ever drain. Current
+ * surfaces satisfy this by construction: CLI (`Cli.ts`) uses `process.cwd()` for
+ * both bootstrap and the exit flush; the git-hook QueueWorker uses one `cwd` for
+ * both; VS Code uses `workspaceRoot`; IntelliJ uses `project.basePath`; the AI
+ * Stop hooks flush `CLAUDE_PROJECT_DIR ?? hookData.cwd` (the same repo root the
+ * other surfaces write to). Do not introduce a flush call site that resolves cwd
+ * differently from where the events were written.
  */
 import { appendFileSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { mkdir, readFile, rm } from "node:fs/promises";

--- a/cli/src/core/TelemetryCommandHook.test.ts
+++ b/cli/src/core/TelemetryCommandHook.test.ts
@@ -5,7 +5,7 @@ import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { initTelemetry, shutdownTelemetry } from "./Telemetry.js";
 import { readTelemetryEvents } from "./TelemetryBuffer.js";
-import { commandPath, installCommandTelemetryHooks } from "./TelemetryCommandHook.js";
+import { commandPath, installCommandTelemetryHooks, trackCommandFailureIfPending } from "./TelemetryCommandHook.js";
 
 let cwd: string;
 
@@ -70,6 +70,39 @@ describe("installCommandTelemetryHooks", () => {
 	it("skips the session-level command_invoked for `mcp` (JOLLI-1959 — the MCP server emits per-tool events)", async () => {
 		const program = programWith(() => {});
 		await program.parseAsync(["node", "jolli", "mcp"]);
+		expect(await readTelemetryEvents(cwd)).toEqual([]);
+	});
+
+	it("trackCommandFailureIfPending records command_invoked{ok:false} after a thrown action (JOLLI-1960)", async () => {
+		const program = programWith(() => {
+			throw new Error("boom");
+		});
+		await expect(program.parseAsync(["node", "jolli", "recall"])).rejects.toThrow("boom");
+		// postAction was skipped, so nothing is buffered yet…
+		expect(await readTelemetryEvents(cwd)).toEqual([]);
+		// …until the CLI's top-level catch records the failure.
+		trackCommandFailureIfPending();
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.eventName).toBe("command_invoked");
+		expect(e.properties).toMatchObject({ command: "recall", ok: false });
+		expect(typeof e.properties.duration_ms).toBe("number");
+	});
+
+	it("trackCommandFailureIfPending is a no-op after a successful command", async () => {
+		const program = programWith(() => {});
+		await program.parseAsync(["node", "jolli", "recall"]);
+		trackCommandFailureIfPending();
+		const events = await readTelemetryEvents(cwd);
+		expect(events).toHaveLength(1); // only the success event, no extra failure row
+		expect(events[0].properties.ok).toBe(true);
+	});
+
+	it("trackCommandFailureIfPending skips a failed `mcp` (per-tool events come from the MCP server)", async () => {
+		const program = programWith(() => {
+			throw new Error("boom");
+		});
+		await expect(program.parseAsync(["node", "jolli", "mcp"])).rejects.toThrow("boom");
+		trackCommandFailureIfPending();
 		expect(await readTelemetryEvents(cwd)).toEqual([]);
 	});
 });

--- a/cli/src/core/TelemetryCommandHook.test.ts
+++ b/cli/src/core/TelemetryCommandHook.test.ts
@@ -25,6 +25,7 @@ function programWith(action: () => void | Promise<void>): Command {
 	program.command("recall").action(async () => action());
 	const auth = program.command("auth");
 	auth.command("login").action(async () => action());
+	program.command("mcp").action(async () => action());
 	return program;
 }
 
@@ -63,6 +64,12 @@ describe("installCommandTelemetryHooks", () => {
 			throw new Error("boom");
 		});
 		await expect(program.parseAsync(["node", "jolli", "recall"])).rejects.toThrow("boom");
+		expect(await readTelemetryEvents(cwd)).toEqual([]);
+	});
+
+	it("skips the session-level command_invoked for `mcp` (JOLLI-1959 — the MCP server emits per-tool events)", async () => {
+		const program = programWith(() => {});
+		await program.parseAsync(["node", "jolli", "mcp"]);
 		expect(await readTelemetryEvents(cwd)).toEqual([]);
 	});
 });

--- a/cli/src/core/TelemetryCommandHook.ts
+++ b/cli/src/core/TelemetryCommandHook.ts
@@ -44,6 +44,11 @@ export function installCommandTelemetryHooks(program: Command): void {
 		starts.set(actionCommand, Date.now());
 	});
 	program.hook("postAction", (_thisCommand, actionCommand) => {
+		// `mcp` is emitted per tool call by the MCP server's CallTool handler
+		// (JOLLI-1959, tagged with `tool`). The generic session-level event here
+		// would be a coarse duplicate (`command:"mcp"` with no tool, once at stdio
+		// disconnect), so skip it — the CallTool handler is the source of truth.
+		if (commandPath(actionCommand) === "mcp") return;
 		const start = starts.get(actionCommand);
 		track("command_invoked", {
 			command: commandPath(actionCommand),

--- a/cli/src/core/TelemetryCommandHook.ts
+++ b/cli/src/core/TelemetryCommandHook.ts
@@ -37,23 +37,48 @@ export function commandPath(cmd: Command): string {
 	return parts.join(" ");
 }
 
+/**
+ * The command that started but hasn't completed. `preAction` sets it; the
+ * `postAction` success path clears it. Commander skips `postAction` when the
+ * action throws, so a still-set `pending` after `parseAsync` rejects means the
+ * command FAILED — `trackCommandFailureIfPending()` records that. A CLI runs one
+ * command per process, so a single slot suffices.
+ */
+let pending: { readonly command: string; readonly start: number } | null = null;
+
 /** Register the `command_invoked` auto-emit hooks on the root program. */
 export function installCommandTelemetryHooks(program: Command): void {
-	const starts = new WeakMap<Command, number>();
 	program.hook("preAction", (_thisCommand, actionCommand) => {
-		starts.set(actionCommand, Date.now());
+		pending = { command: commandPath(actionCommand), start: Date.now() };
 	});
 	program.hook("postAction", (_thisCommand, actionCommand) => {
+		const start = pending?.start;
+		pending = null; // success — recorded below (or intentionally skipped for mcp)
 		// `mcp` is emitted per tool call by the MCP server's CallTool handler
 		// (JOLLI-1959, tagged with `tool`). The generic session-level event here
 		// would be a coarse duplicate (`command:"mcp"` with no tool, once at stdio
 		// disconnect), so skip it — the CallTool handler is the source of truth.
 		if (commandPath(actionCommand) === "mcp") return;
-		const start = starts.get(actionCommand);
 		track("command_invoked", {
 			command: commandPath(actionCommand),
 			duration_ms: start === undefined ? undefined : Date.now() - start,
 			ok: true,
 		});
 	});
+}
+
+/**
+ * Emit a failed `command_invoked{ ok: false }` when an action started but never
+ * completed. Commander skips `postAction` on a thrown action, so this is the
+ * only place a command *failure* is recorded (JOLLI-1960) — otherwise every
+ * `command_invoked` would report `ok: true` and the failure would be invisible.
+ * Call from the CLI's top-level catch. No-op when the last command succeeded,
+ * none ran, or it was `mcp` (tracked per tool call by the MCP server). Never
+ * throws — telemetry must not mask the original command error.
+ */
+export function trackCommandFailureIfPending(): void {
+	const p = pending;
+	pending = null;
+	if (!p || p.command === "mcp") return;
+	track("command_invoked", { command: p.command, duration_ms: Date.now() - p.start, ok: false });
 }

--- a/cli/src/core/TelemetryEvents.ts
+++ b/cli/src/core/TelemetryEvents.ts
@@ -60,7 +60,7 @@ export const TELEMETRY_EVENTS = {
 		"User committed a memory via the Commit button. Props: files_bucket (bucketed changed-file count), has_conversations (bool), context_bucket (bucketed plans/context count).",
 	memory_expanded: "A committed memory's details were expanded. Props: expanded.",
 	memory_item_opened:
-		"An item inside a memory was opened. Props: item_type (discriminator: conversation/file/context/shipped).",
+		"An item inside a memory was opened. Props: item_type (discriminator: conversation/file/plan/note/reference/shipped).",
 	session_resumed: "A conversation session was resumed in a terminal. Props: source (discriminator).",
 	recall_prompt_copied: "A recall prompt was copied to the clipboard. Props: none.",
 	memory_pinned: "An item was pinned. Props: kind (discriminator).",

--- a/cli/src/core/TelemetryEvents.ts
+++ b/cli/src/core/TelemetryEvents.ts
@@ -25,44 +25,47 @@
  */
 export const TELEMETRY_EVENTS = {
 	// ── lifecycle & conversion funnel (the primary goal) ──
-	app_installed: "First run after install; installId minted (once per machine).",
+	app_installed:
+		"First run after install; installId minted (once per machine). Props: none — count distinct install_id.",
 	client_activated:
 		"A GUI surface activated (VS Code activate / IntelliJ project open), carrying `surface_version`. First-seen (install_id, surface_version) ≈ new + upgrade installs that launched. GUI-only — CLI new/upgrade is read from any event's surface_version.",
-	surface_enabled: "A surface was enabled in a repo.",
-	surface_disabled: "A surface was disabled / opted out.",
-	signin_started: "User initiated OAuth sign-in.",
-	signin_completed: "jolliApiKey minted — the conversion event.",
-	signed_out: "User logged out.",
-	ai_provider_selected: "User chose jolli vs anthropic for LLM.",
-	memory_bank_migrated: "Migrate-to-Memory-Bank run.",
+	surface_enabled: "A surface was enabled in a repo. Props: trigger.",
+	surface_disabled: "A surface was disabled / opted out. Props: trigger, reason.",
+	signin_started: "User initiated OAuth sign-in. Props: trigger.",
+	signin_completed: "jolliApiKey minted — the conversion event. Props: api_key_minted.",
+	signed_out: "User logged out. Props: none.",
+	ai_provider_selected: "User chose jolli vs anthropic for LLM. Props: provider (discriminator).",
+	memory_bank_migrated: "Migrate-to-Memory-Bank run. Props: outcome, repos, entries_bucket.",
 	// ── feature usage / adoption ──
 	command_invoked:
-		'Any CLI command ran (auto-emitted). MCP tool calls carry a `tool` property and are emitted per call (not per session); the session-level `command:"mcp"` event is suppressed.',
-	recall_performed: "A recall was run.",
-	search_performed: "A search was run.",
-	memory_pushed: "Memories pushed.",
-	export_performed: "Export run.",
-	ai_source_detected: "A new AI source transcript was detected.",
-	settings_opened: "Settings UI opened (vscode/intellij).",
+		'Any CLI command ran (auto-emitted). Props: command (discriminator), ok, duration_ms. MCP tool calls carry a `tool` property and are emitted per call (not per session); the session-level `command:"mcp"` event is suppressed.',
+	recall_performed: "A recall was run. Props: hit, result_count_bucket.",
+	search_performed: "A search was run. Props: query_len_bucket, result_count_bucket.",
+	memory_pushed: "Memories pushed to a Space. Props: kind, created, plans_bucket.",
+	export_performed: "Export run. Props: format (discriminator).",
+	ai_source_detected:
+		"A new AI source transcript was detected. Props: source (discriminator: claude/codex/cursor/…).",
+	settings_opened: "Settings UI opened (vscode/intellij). Props: tab (discriminator).",
 	// ── pipeline health ──
 	ingest_completed:
-		"A drainIngest run finished. Carries `idle:true` for a no-op drain (ingested=0); filter those out for real-ingest latency/health metrics.",
+		"A drainIngest run finished. Props: outcome, ingested, idle (no-op when ingested=0), batches, route_calls, reconcile_calls, touched_slugs, topic_failures, duration_ms. Filter idle=true out for real-ingest latency/health metrics.",
 	error_occurred:
 		"A structured error was raised. Content-free schema: { where (stage/subsystem), code (enumerated), source? , retryable? }. Emitted via trackError(); never carries a message/stack/path.",
-	queue_drained: "QueueWorker finished a drain.",
-	sync_completed: "A memory-bank sync round finished.",
+	queue_drained: "QueueWorker finished a drain. Props: ops, duration_ms.",
+	sync_completed: "A memory-bank sync round finished. Props: outcome (discriminator), duration_ms.",
 	// ── IDE tool-window UI / engagement (IntelliJ, VS Code) ──
-	toolwindow_opened: "The memory tool window was opened.",
-	view_switched: "Tool window view switched (current/bank/knowledge).",
-	memory_committed: "User committed a memory via the Commit button.",
-	memory_expanded: "A committed memory's details were expanded.",
-	memory_item_opened: "An item inside a memory was opened (conversation/file/context/shipped).",
-	session_resumed: "A conversation session was resumed in a terminal.",
-	recall_prompt_copied: "A recall prompt was copied to the clipboard.",
-	memory_pinned: "An item was pinned.",
-	memory_unpinned: "An item was unpinned.",
-	key_rejected: "The server rejected the API key (401/403).",
-	reauth_completed: "Re-authentication after a rejected key finished.",
+	toolwindow_opened: "The memory tool window was opened. Props: view.",
+	view_switched: "Tool window view switched (current/bank/knowledge). Props: view (discriminator).",
+	memory_committed: "User committed a memory via the Commit button. Props: none.",
+	memory_expanded: "A committed memory's details were expanded. Props: expanded.",
+	memory_item_opened:
+		"An item inside a memory was opened. Props: item_type (discriminator: conversation/file/context/shipped).",
+	session_resumed: "A conversation session was resumed in a terminal. Props: source (discriminator).",
+	recall_prompt_copied: "A recall prompt was copied to the clipboard. Props: none.",
+	memory_pinned: "An item was pinned. Props: kind (discriminator).",
+	memory_unpinned: "An item was unpinned. Props: kind (discriminator).",
+	key_rejected: "The server rejected the API key (401/403). Props: retried, where.",
+	reauth_completed: "Re-authentication after a rejected key finished. Props: outcome.",
 } as const;
 
 /** Union of every registered event name. */

--- a/cli/src/core/TelemetryEvents.ts
+++ b/cli/src/core/TelemetryEvents.ts
@@ -46,7 +46,8 @@ export const TELEMETRY_EVENTS = {
 	settings_opened: "Settings UI opened (vscode/intellij).",
 	// ── pipeline health ──
 	ingest_completed: "A drainIngest run finished.",
-	error_occurred: "A structured error code was raised.",
+	error_occurred:
+		"A structured error was raised. Content-free schema: { where (stage/subsystem), code (enumerated), source? , retryable? }. Emitted via trackError(); never carries a message/stack/path.",
 	queue_drained: "QueueWorker finished a drain.",
 	sync_completed: "A memory-bank sync round finished.",
 	// ── IDE tool-window UI / engagement (IntelliJ, VS Code) ──

--- a/cli/src/core/TelemetryEvents.ts
+++ b/cli/src/core/TelemetryEvents.ts
@@ -56,7 +56,8 @@ export const TELEMETRY_EVENTS = {
 	// ── IDE tool-window UI / engagement (IntelliJ, VS Code) ──
 	toolwindow_opened: "The memory tool window was opened. Props: view.",
 	view_switched: "Tool window view switched (current/bank/knowledge). Props: view (discriminator).",
-	memory_committed: "User committed a memory via the Commit button. Props: none.",
+	memory_committed:
+		"User committed a memory via the Commit button. Props: files_bucket (bucketed changed-file count), has_conversations (bool), context_bucket (bucketed plans/context count).",
 	memory_expanded: "A committed memory's details were expanded. Props: expanded.",
 	memory_item_opened:
 		"An item inside a memory was opened. Props: item_type (discriminator: conversation/file/context/shipped).",

--- a/cli/src/core/TelemetryEvents.ts
+++ b/cli/src/core/TelemetryEvents.ts
@@ -65,6 +65,11 @@ export const TELEMETRY_EVENTS = {
 	recall_prompt_copied: "A recall prompt was copied to the clipboard. Props: none.",
 	memory_pinned: "An item was pinned. Props: kind (discriminator).",
 	memory_unpinned: "An item was unpinned. Props: kind (discriminator).",
+	repo_switched: "User switched the active repo in the tool window's breadcrumb. Props: is_foreign (bool).",
+	branch_switched: "User switched the active branch in the tool window's breadcrumb. Props: is_foreign (bool).",
+	squash_performed: "User squashed commits. Props: count_bucket (bucketed number of commits squashed).",
+	pr_created: "User created or updated a PR from the tool window. Props: action (discriminator: created/updated).",
+	memory_shared: "User invoked Share for a branch's memories (read-only share link). Props: none.",
 	key_rejected: "The server rejected the API key (401/403). Props: retried, where.",
 	reauth_completed: "Re-authentication after a rejected key finished. Props: outcome.",
 } as const;

--- a/cli/src/core/TelemetryEvents.ts
+++ b/cli/src/core/TelemetryEvents.ts
@@ -26,6 +26,8 @@
 export const TELEMETRY_EVENTS = {
 	// ── lifecycle & conversion funnel (the primary goal) ──
 	app_installed: "First run after install; installId minted (once per machine).",
+	client_activated:
+		"A GUI surface activated (VS Code activate / IntelliJ project open), carrying `surface_version`. First-seen (install_id, surface_version) ≈ new + upgrade installs that launched. GUI-only — CLI new/upgrade is read from any event's surface_version.",
 	surface_enabled: "A surface was enabled in a repo.",
 	surface_disabled: "A surface was disabled / opted out.",
 	signin_started: "User initiated OAuth sign-in.",

--- a/cli/src/core/TelemetryEvents.ts
+++ b/cli/src/core/TelemetryEvents.ts
@@ -45,7 +45,8 @@ export const TELEMETRY_EVENTS = {
 	ai_source_detected: "A new AI source transcript was detected.",
 	settings_opened: "Settings UI opened (vscode/intellij).",
 	// ── pipeline health ──
-	ingest_completed: "A drainIngest run finished.",
+	ingest_completed:
+		"A drainIngest run finished. Carries `idle:true` for a no-op drain (ingested=0); filter those out for real-ingest latency/health metrics.",
 	error_occurred:
 		"A structured error was raised. Content-free schema: { where (stage/subsystem), code (enumerated), source? , retryable? }. Emitted via trackError(); never carries a message/stack/path.",
 	queue_drained: "QueueWorker finished a drain.",

--- a/cli/src/core/TelemetryEvents.ts
+++ b/cli/src/core/TelemetryEvents.ts
@@ -34,7 +34,8 @@ export const TELEMETRY_EVENTS = {
 	ai_provider_selected: "User chose jolli vs anthropic for LLM.",
 	memory_bank_migrated: "Migrate-to-Memory-Bank run.",
 	// ── feature usage / adoption ──
-	command_invoked: "Any CLI command ran (auto-emitted).",
+	command_invoked:
+		'Any CLI command ran (auto-emitted). MCP tool calls carry a `tool` property and are emitted per call (not per session); the session-level `command:"mcp"` event is suppressed.',
 	recall_performed: "A recall was run.",
 	search_performed: "A search was run.",
 	memory_pushed: "Memories pushed.",

--- a/cli/src/core/TelemetryFlusher.test.ts
+++ b/cli/src/core/TelemetryFlusher.test.ts
@@ -31,9 +31,12 @@ function makeKey(u: string): string {
 }
 
 const okFetch = () => vi.fn<typeof fetch>(async () => ({ ok: true }) as Response);
-const seed = (n: number) => {
-	for (let i = 0; i < n; i++) appendTelemetryEvent(cwd, env({ installId: `i-${i}` }));
+// Seed n events under ONE install_id (so they form a single batch group), each
+// tagged with a distinct `seq` so identity-based assertions stay unambiguous.
+const seed = (n: number, installId = "install-1") => {
+	for (let i = 0; i < n; i++) appendTelemetryEvent(cwd, env({ installId, properties: { seq: i } }));
 };
+const seqOf = (e: TelemetryEnvelope) => (e.properties as { seq: number }).seq;
 
 beforeEach(async () => {
 	cwd = await mkdtemp(join(tmpdir(), "telemetry-flush-"));
@@ -139,7 +142,7 @@ describe("flushTelemetry", () => {
 		const result = await flushTelemetry({ cwd, origin: "https://jolli.ai", fetchImpl, maxBatch: 2 });
 		expect(result).toEqual({ sent: 2, remaining: 3 });
 		const kept = await readTelemetryEvents(cwd);
-		expect(kept.map((e) => e.installId)).toEqual(["i-2", "i-3", "i-4"]);
+		expect(kept.map(seqOf)).toEqual([2, 3, 4]);
 	});
 
 	it("treats a network throw as failure and leaves the buffer intact", async () => {
@@ -147,6 +150,24 @@ describe("flushTelemetry", () => {
 		const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(new Error("ECONNREFUSED"));
 		expect(await flushTelemetry({ cwd, origin: "https://jolli.ai", fetchImpl })).toEqual({ sent: 0, remaining: 2 });
 		expect(await readTelemetryEvents(cwd)).toHaveLength(2);
+	});
+
+	it("backfills a stable eventId for legacy buffered events across retries", async () => {
+		appendTelemetryEvent(cwd, { ...env({ installId: "legacy" }), eventId: undefined as never });
+		const fetchImpl = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce({ ok: false } as Response)
+			.mockResolvedValueOnce({ ok: true } as Response);
+
+		expect(await flushTelemetry({ cwd, origin: "https://jolli.ai", fetchImpl })).toEqual({ sent: 0, remaining: 1 });
+		const firstBody = JSON.parse(fetchImpl.mock.calls[0]?.[1]?.body as string);
+		const firstEventId = firstBody.events[0].eventId;
+		expect(firstEventId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+
+		expect(await flushTelemetry({ cwd, origin: "https://jolli.ai", fetchImpl })).toEqual({ sent: 1, remaining: 0 });
+		const secondBody = JSON.parse(fetchImpl.mock.calls[1]?.[1]?.body as string);
+		expect(secondBody.events[0].eventId).toBe(firstEventId);
+		expect(await readTelemetryEvents(cwd)).toEqual([]);
 	});
 
 	it("preserves events appended concurrently during the flush", async () => {
@@ -160,6 +181,41 @@ describe("flushTelemetry", () => {
 		expect(result.sent).toBe(3);
 		const kept = await readTelemetryEvents(cwd);
 		expect(kept.map((e) => e.installId)).toEqual(["late"]);
+	});
+
+	it("groups by install_id so every POST batch carries exactly one install_id", async () => {
+		appendTelemetryEvent(cwd, env({ installId: "A", properties: { seq: 0 } }));
+		appendTelemetryEvent(cwd, env({ installId: "B", properties: { seq: 1 } }));
+		appendTelemetryEvent(cwd, env({ installId: "A", properties: { seq: 2 } }));
+		const fetchImpl = okFetch();
+		const result = await flushTelemetry({ cwd, origin: "https://jolli.ai", fetchImpl });
+		expect(result).toEqual({ sent: 3, remaining: 0 });
+		// One batch per install_id group (A has 2, B has 1) — never a mixed batch.
+		expect(fetchImpl).toHaveBeenCalledTimes(2);
+		for (const call of fetchImpl.mock.calls) {
+			const body = JSON.parse((call[1] as RequestInit).body as string) as { events: TelemetryEnvelope[] };
+			expect(new Set(body.events.map((e) => e.installId)).size).toBe(1);
+		}
+		expect(await readTelemetryEvents(cwd)).toEqual([]);
+	});
+
+	it("a stray install_id that 400s does not block delivery of the others", async () => {
+		// Reproduces the JOLLI ibe jam: one stray event from a prior install sits at
+		// the buffer head; the backend 400s any batch that includes it. Grouping must
+		// isolate it so the current install's events still deliver.
+		appendTelemetryEvent(cwd, env({ installId: "stray", properties: { seq: 0 } }));
+		appendTelemetryEvent(cwd, env({ installId: "current", properties: { seq: 1 } }));
+		appendTelemetryEvent(cwd, env({ installId: "current", properties: { seq: 2 } }));
+		// Server rejects the stray group (mixed-install 400 analogue), accepts the rest.
+		const fetchImpl = vi.fn<typeof fetch>(async (_url, init) => {
+			const body = JSON.parse((init as RequestInit).body as string) as { events: TelemetryEnvelope[] };
+			return { ok: body.events[0].installId !== "stray" } as Response;
+		});
+		const result = await flushTelemetry({ cwd, origin: "https://jolli.ai", fetchImpl });
+		expect(result).toEqual({ sent: 2, remaining: 1 });
+		// Only the poisoned stray event remains; the current install's events delivered.
+		const kept = await readTelemetryEvents(cwd);
+		expect(kept.map((e) => e.installId)).toEqual(["stray"]);
 	});
 
 	it("returns remaining without sending when the origin is unparseable", async () => {

--- a/cli/src/core/TelemetryFlusher.test.ts
+++ b/cli/src/core/TelemetryFlusher.test.ts
@@ -9,6 +9,7 @@ let cwd: string;
 
 const env = (over: Partial<TelemetryEnvelope> = {}): TelemetryEnvelope => ({
 	schemaVersion: 1,
+	eventId: "11111111-1111-4111-8111-111111111111",
 	eventName: "recall_performed",
 	surface: "cli",
 	surfaceVersion: "1.0.0",

--- a/cli/src/core/TelemetryFlusher.ts
+++ b/cli/src/core/TelemetryFlusher.ts
@@ -2,9 +2,10 @@
  * TelemetryFlusher — drains the on-disk telemetry buffer to the jolli backend
  * (JOLLI-1785 Phase 2). Batched, fire-and-forget, and best-effort:
  *
- *   - POSTs to `<origin>/api/telemetry/events` in chunks of at most
- *     `maxBatch` (the backend enforces its own `TELEMETRY_MAX_BATCH` cap, so
- *     we chunk below it). HTTP scaffolding mirrors `sync/BackendClient.ts`:
+ *   - POSTs to `<origin>/api/telemetry/events` grouped by `install_id` (the
+ *     backend rejects mixed-install_id batches) and chunked at most `maxBatch`
+ *     within each group (the backend enforces its own `TELEMETRY_MAX_BATCH` cap,
+ *     so we chunk below it). HTTP scaffolding mirrors `sync/BackendClient.ts`:
  *     `x-jolli-client` header, injected `fetchImpl` test seam, `AbortController`
  *     timeout.
  *   - **Anonymous vs signed-in**: when a `jolliApiKey` is supplied it is sent
@@ -93,25 +94,43 @@ export async function flushTelemetry(opts: FlushOptions): Promise<FlushResult> {
 		return { sent: 0, remaining: events.length };
 	}
 
-	let sent = 0;
-	for (let i = 0; i < events.length; i += maxBatch) {
-		const batch = events.slice(i, i + maxBatch);
-		const ok = await postBatch(url, batch, authKey, fetchImpl, timeoutMs);
-		if (!ok) break;
-		sent += batch.length;
+	// Group by install_id before batching: the backend rejects a batch that
+	// mixes install_ids with 400 ("batch must carry a single install_id"). If the
+	// buffer ever holds >1 install_id — e.g. after an install_id rotation leaves a
+	// stray event from a prior install — a count-only batching scheme puts both in
+	// one batch and that 400 permanently jams delivery for EVERY event. Grouping
+	// keeps each batch homogeneous, and a failing group is skipped without blocking
+	// the others, so one poisoned install_id can't strand the rest.
+	const groups = new Map<string, TelemetryEnvelope[]>();
+	for (const e of events) {
+		const arr = groups.get(e.installId);
+		if (arr) arr.push(e);
+		else groups.set(e.installId, [e]);
 	}
 
-	if (sent === 0) return { sent: 0, remaining: events.length };
+	const acked: TelemetryEnvelope[] = [];
+	for (const group of groups.values()) {
+		for (let i = 0; i < group.length; i += maxBatch) {
+			const batch = group.slice(i, i + maxBatch);
+			// A failed batch stops THIS install_id's remaining batches (the next
+			// would fail the same way) but not the other groups' — continue the loop.
+			if (!(await postBatch(url, batch, authKey, fetchImpl, timeoutMs))) break;
+			acked.push(...batch);
+		}
+	}
+
+	if (acked.length === 0) return { sent: 0, remaining: events.length };
 
 	// Re-read so events appended during the flush survive, then remove the exact
 	// envelopes we acked by identity rather than by count: under the ring cap a
-	// concurrent append can trim the buffer head, so a positional `slice(sent)`
-	// would discard the wrong (newest) events. Identity removal is correct
-	// regardless of trimming and tolerant of acked events already dropped by the cap.
+	// concurrent append can trim the buffer head, and grouping means acked events
+	// are no longer a contiguous prefix, so a positional slice would drop the wrong
+	// events. Identity removal is correct regardless of order/trimming and tolerant
+	// of acked events already dropped by the cap.
 	const current = await readTelemetryEvents(opts.cwd);
-	const remaining = removeAcked(current, events.slice(0, sent));
+	const remaining = removeAcked(current, acked);
 	await replaceTelemetryEvents(opts.cwd, remaining);
-	return { sent, remaining: remaining.length };
+	return { sent: acked.length, remaining: remaining.length };
 }
 
 /**

--- a/cli/src/core/TelemetryStartup.test.ts
+++ b/cli/src/core/TelemetryStartup.test.ts
@@ -104,6 +104,7 @@ describe("bootstrapTelemetry", () => {
 describe("flushTelemetryNow", () => {
 	const ev = (over: Partial<TelemetryEnvelope> = {}): TelemetryEnvelope => ({
 		schemaVersion: 1,
+		eventId: "33333333-3333-4333-8333-333333333333",
 		eventName: "app_installed",
 		surface: "cli",
 		surfaceVersion: "1.0.0",

--- a/cli/src/core/TelemetryStartup.ts
+++ b/cli/src/core/TelemetryStartup.ts
@@ -133,6 +133,12 @@ export interface FlushNowDeps {
 	readonly platformDisabled?: boolean;
 	/** Env for the `DO_NOT_TRACK` check. Defaults to `process.env`. */
 	readonly env?: NodeJS.ProcessEnv;
+	/**
+	 * Per-POST timeout override, forwarded to `flushTelemetry`. Latency-sensitive
+	 * callers (the CLI command-exit flush, JOLLI-1955) pass a short cap so a slow
+	 * network can't stall the process; omit to use the flusher's default (10s).
+	 */
+	readonly timeoutMs?: number;
 }
 
 /**
@@ -156,7 +162,13 @@ export async function flushTelemetryNow(cwd: string, deps?: FlushNowDeps): Promi
 			return;
 		}
 		const origin = resolveTelemetryOrigin(config, getJolliUrl);
-		await flushTelemetry({ cwd, origin, jolliApiKey: config.jolliApiKey, fetchImpl: deps?.fetchImpl });
+		await flushTelemetry({
+			cwd,
+			origin,
+			jolliApiKey: config.jolliApiKey,
+			fetchImpl: deps?.fetchImpl,
+			timeoutMs: deps?.timeoutMs,
+		});
 	} catch {
 		// Flush is best-effort — never propagate into the worker / exit path.
 	}

--- a/cli/src/hooks/GeminiAfterAgentHook.test.ts
+++ b/cli/src/hooks/GeminiAfterAgentHook.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock SessionTracker
+// Mock SessionTracker (loadConfig is reached transitively via the JOLLI-1954
+// telemetry flush at the end of the hook; return an empty config so consent
+// resolves on and the flush no-ops against the empty test buffer).
 vi.mock("../core/SessionTracker.js", () => ({
 	saveSession: vi.fn(),
+	loadConfig: vi.fn().mockResolvedValue({}),
 }));
 
 // Suppress console output

--- a/cli/src/hooks/GeminiAfterAgentHook.ts
+++ b/cli/src/hooks/GeminiAfterAgentHook.ts
@@ -21,6 +21,7 @@
 import { resolve as pathResolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { saveSession } from "../core/SessionTracker.js";
+import { flushTelemetryNow } from "../core/TelemetryStartup.js";
 import { createLogger, setLogDir } from "../Logger.js";
 import type { ClaudeHookInput, SessionInfo } from "../Types.js";
 import { readStdin } from "./HookUtils.js";
@@ -99,6 +100,11 @@ export async function handleGeminiAfterAgentHook(): Promise<void> {
 	} catch (error: unknown) {
 		log.error("Failed to save session: %s", (error as Error).message);
 	}
+
+	// JOLLI-1954: flush the shared telemetry buffer on every agent turn end
+	// (mirrors the Claude Stop hook). Awaited so the short-lived hook process
+	// doesn't exit before the POST; best-effort, re-gates consent, never throws.
+	await flushTelemetryNow(projectDir);
 
 	// Always write JSON response — Gemini CLI requires it
 	writeStdout();

--- a/cli/src/hooks/StopHook.ts
+++ b/cli/src/hooks/StopHook.ts
@@ -37,6 +37,7 @@ import {
 	saveDiscoveryCursor,
 	saveSession,
 } from "../core/SessionTracker.js";
+import { flushTelemetryNow } from "../core/TelemetryStartup.js";
 import { createLogger, setLogDir } from "../Logger.js";
 import type { ClaudeHookInput, SessionInfo } from "../Types.js";
 import { readStdin } from "./HookUtils.js";
@@ -127,6 +128,15 @@ export async function handleStopHook(): Promise<void> {
 	// its own errors so one failing discovery never blocks the other or the
 	// cursor advance.
 	await discoverFromTranscript(sessionInfo, projectDir);
+
+	// JOLLI-1954: the Stop hook fires on every agent turn end — far more often
+	// than commits — so piggyback it to drain the shared telemetry buffer. Covers
+	// the "using the agent but not committing" case that the post-commit flush
+	// misses. Awaited (not fire-and-forget) so the short-lived hook process does
+	// not exit before the POST completes; the hook runs `async: true`, so this
+	// never blocks the agent. `flushTelemetryNow` re-gates consent, has its own
+	// timeout, no-ops on an empty buffer, and never throws.
+	await flushTelemetryNow(projectDir);
 }
 
 // ─── Discovery orchestration ────────────────────────────────────────────────

--- a/cli/src/mcp/McpServer.test.ts
+++ b/cli/src/mcp/McpServer.test.ts
@@ -15,6 +15,8 @@ vi.mock("./McpTools.js", () => ({
 const { mockStorage } = vi.hoisted(() => ({ mockStorage: { kind: "mock-storage" } }));
 vi.mock("../core/StorageFactory.js", () => ({ createStorage: vi.fn().mockResolvedValue(mockStorage) }));
 vi.mock("../core/SummaryStore.js", () => ({ setActiveStorage: vi.fn() }));
+// JOLLI-1959: the CallTool handler emits per-tool telemetry; spy on track().
+vi.mock("../core/Telemetry.js", () => ({ track: vi.fn() }));
 
 // Capture the request handlers the server registers so the test can invoke them directly.
 type RequestHandler = (req: { params: { name: string; arguments?: Record<string, unknown> } }) => Promise<unknown>;
@@ -84,6 +86,7 @@ import { VERSION } from "../commands/CliUtils.js";
 import type { PlatformToolManifestEntry } from "../core/JolliMemoryPushClient.js";
 import { createStorage } from "../core/StorageFactory.js";
 import { setActiveStorage } from "../core/SummaryStore.js";
+import { track } from "../core/Telemetry.js";
 import { dispatchTool, type PlatformToolClient, startMcpServer, TOOL_DEFINITIONS } from "./McpServer.js";
 import {
 	runBindSpace,
@@ -187,6 +190,7 @@ describe("startMcpServer", () => {
 		loadConfigMock.mockReset().mockResolvedValue({});
 		fetchManifestMock.mockReset();
 		invokePlatformToolMock.mockReset();
+		vi.mocked(track).mockClear();
 	});
 
 	it("connects the stdio transport and registers two request handlers", async () => {
@@ -244,6 +248,40 @@ describe("startMcpServer", () => {
 		};
 		expect(result.isError).toBe(true);
 		expect(JSON.parse(result.content[0].text)).toEqual({ type: "error", message: "Not signed in" });
+	});
+
+	it("CallTool emits per-tool telemetry (tool name + ok=true), never the arguments (JOLLI-1959)", async () => {
+		await startMcpServer("/repo");
+		await capturedHandlers[1]({ params: { name: "search", arguments: { query: "acme-secret/repo/path" } } });
+		expect(track).toHaveBeenCalledWith(
+			"command_invoked",
+			expect.objectContaining({ command: "mcp", tool: "search", ok: true }),
+		);
+		const props = vi.mocked(track).mock.calls[0][1] as Record<string, unknown>;
+		expect(typeof props.duration_ms).toBe("number");
+		// The tool's arguments must never reach telemetry (they may carry user content).
+		expect(props).not.toHaveProperty("arguments");
+		expect(JSON.stringify(props)).not.toContain("acme-secret");
+	});
+
+	it("CallTool telemetry reports ok=false when the tool throws (JOLLI-1959)", async () => {
+		vi.mocked(runSearch).mockRejectedValueOnce(new Error("boom"));
+		await startMcpServer("/repo");
+		await capturedHandlers[1]({ params: { name: "search", arguments: {} } });
+		expect(track).toHaveBeenCalledWith(
+			"command_invoked",
+			expect.objectContaining({ command: "mcp", tool: "search", ok: false }),
+		);
+	});
+
+	it("CallTool telemetry reports ok=false for a structured {type:'error'} result (JOLLI-1959)", async () => {
+		vi.mocked(runPushMemory).mockResolvedValueOnce({ type: "error", message: "Not signed in" });
+		await startMcpServer("/repo");
+		await capturedHandlers[1]({ params: { name: "push_memory", arguments: {} } });
+		expect(track).toHaveBeenCalledWith(
+			"command_invoked",
+			expect.objectContaining({ command: "mcp", tool: "push_memory", ok: false }),
+		);
 	});
 
 	it("CallTool handler does NOT flag a binding_required result as isError (it's a needs-input outcome)", async () => {

--- a/cli/src/mcp/McpServer.ts
+++ b/cli/src/mcp/McpServer.ts
@@ -18,6 +18,7 @@ import { JolliMemoryPushClient, type PlatformToolManifestEntry } from "../core/J
 import { loadConfig } from "../core/SessionTracker.js";
 import { createStorage } from "../core/StorageFactory.js";
 import { setActiveStorage } from "../core/SummaryStore.js";
+import { track } from "../core/Telemetry.js";
 import { createLogger } from "../Logger.js";
 import type { JolliMemoryConfig } from "../Types.js";
 import {
@@ -280,6 +281,7 @@ export async function startMcpServer(cwd: string, deps: StartMcpServerDeps = {})
 
 	server.setRequestHandler(CallToolRequestSchema, async (req) => {
 		const { name, arguments: args } = req.params;
+		const start = Date.now();
 		try {
 			// Route backend-defined tools through the generic executor; everything
 			// else is a built-in handled by the local dispatch table.
@@ -296,8 +298,17 @@ export async function startMcpServer(cwd: string, deps: StartMcpServerDeps = {})
 			// an error, so it stays a normal result.
 			const isError =
 				typeof result === "object" && result !== null && (result as { type?: unknown }).type === "error";
+			// Per-tool-call telemetry (JOLLI-1959). The session-level `command:"mcp"`
+			// event (fired once at stdio disconnect) can't tell which tool the AI used;
+			// emit one event per call, tagged with the tool `name`. NEVER include
+			// `arguments` — they may carry user content. `ok` folds in push_memory's
+			// structured `{type:"error"}` result, not just thrown errors. The
+			// session-level mcp event is suppressed in TelemetryCommandHook so this
+			// does not double-count.
+			track("command_invoked", { command: "mcp", tool: name, duration_ms: Date.now() - start, ok: !isError });
 			return { content: [{ type: "text", text: JSON.stringify(result) }], ...(isError ? { isError: true } : {}) };
 		} catch (err) {
+			track("command_invoked", { command: "mcp", tool: name, duration_ms: Date.now() - start, ok: false });
 			const message = err instanceof Error ? err.message : String(err);
 			log.warn("Tool %s failed: %s", name, message);
 			return { content: [{ type: "text", text: JSON.stringify({ error: message }) }], isError: true };

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/SquashAction.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/actions/SquashAction.kt
@@ -136,6 +136,12 @@ class SquashAction : AnAction() {
                         val shouldPush = dialog.shouldPush()
                         if (edited.isBlank()) return@invokeLater
 
+                        // User confirmed a squash of `commits.size` commits (count bucketed for privacy).
+                        ai.jolli.jollimemory.core.telemetry.Telemetry.track(
+                            "squash_performed",
+                            mapOf("count_bucket" to ai.jolli.jollimemory.core.telemetry.Telemetry.bucket(commits.size)),
+                        )
+
                         ApplicationManager.getApplication().executeOnPooledThread {
                             indicator.text = "Squashing commits..."
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/IngestPipeline.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/IngestPipeline.kt
@@ -279,7 +279,7 @@ object IngestPipeline {
         // (JOLLI-1962). Mirrors cli INGEST_NON_ERROR_OUTCOMES — IntelliJ's enum lacks
         // CREDENTIAL_MISSING / PAGE_WRITE_CONFLICT, so its benign set is just these.
         if (outcome !in setOf(IngestCode.OK, IngestCode.NO_PENDING, IngestCode.NO_SOURCE_CONTENT)) {
-            ai.jolli.jollimemory.core.telemetry.Telemetry.track("error_occurred", mapOf("code" to outcome.name, "where" to "ingest"))
+            ai.jolli.jollimemory.core.telemetry.Telemetry.trackError("ingest", outcome.name)
         }
         return DrainResult(batches, ingested, outcome, topicFailures)
     }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/IngestPipeline.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/IngestPipeline.kt
@@ -274,7 +274,11 @@ object IngestPipeline {
             "ingest_completed",
             mapOf("outcome" to outcome.name, "batches" to batches, "ingested" to ingested, "topic_failures" to topicFailures.size),
         )
-        if (outcome != IngestCode.OK && outcome != IngestCode.NO_PENDING) {
+        // Only genuine failures raise error_occurred. Success and benign/expected
+        // terminal states are excluded so they don't inflate the ingest error rate
+        // (JOLLI-1962). Mirrors cli INGEST_NON_ERROR_OUTCOMES — IntelliJ's enum lacks
+        // CREDENTIAL_MISSING / PAGE_WRITE_CONFLICT, so its benign set is just these.
+        if (outcome !in setOf(IngestCode.OK, IngestCode.NO_PENDING, IngestCode.NO_SOURCE_CONTENT)) {
             ai.jolli.jollimemory.core.telemetry.Telemetry.track("error_occurred", mapOf("code" to outcome.name, "where" to "ingest"))
         }
         return DrainResult(batches, ingested, outcome, topicFailures)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/IngestPipeline.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/IngestPipeline.kt
@@ -272,7 +272,9 @@ object IngestPipeline {
         // JOLLI-1785: pipeline-health telemetry (no-op until telemetry is bootstrapped).
         ai.jolli.jollimemory.core.telemetry.Telemetry.track(
             "ingest_completed",
-            mapOf("outcome" to outcome.name, "batches" to batches, "ingested" to ingested, "topic_failures" to topicFailures.size),
+            // JOLLI-1964: `idle` flags a no-op drain (nothing pending) so dashboards
+            // can drop them from latency/health metrics. Mirrors cli.
+            mapOf("outcome" to outcome.name, "batches" to batches, "ingested" to ingested, "idle" to (ingested == 0), "topic_failures" to topicFailures.size),
         )
         // Only genuine failures raise error_occurred. Success and benign/expected
         // terminal states are excluded so they don't inflate the ingest error rate

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/Telemetry.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/Telemetry.kt
@@ -3,6 +3,7 @@ package ai.jolli.jollimemory.core.telemetry
 import java.net.URI
 import java.security.MessageDigest
 import java.time.Instant
+import java.util.UUID
 
 /**
  * Telemetry — the single `track()` choke-point for the IntelliJ plugin
@@ -94,6 +95,10 @@ object Telemetry {
             val envelope =
                 TelemetryEnvelope(
                     schemaVersion = SCHEMA_VERSION,
+                    // Idempotency key minted once here, at buffer time. Written to disk
+                    // and re-read verbatim on flush, so a re-sent event keeps the same id
+                    // and the backend dedups on (event_id, ts) — see TelemetryEnvelope.
+                    eventId = UUID.randomUUID().toString(),
                     eventName = eventName,
                     surface = "intellij",
                     surfaceVersion = ctx.surfaceVersion,

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/Telemetry.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/Telemetry.kt
@@ -120,6 +120,22 @@ object Telemetry {
         }
     }
 
+    /**
+     * Emit a structured, content-free `error_occurred` (JOLLI-1961). One schema
+     * across every surface: `{ where, code, source?, retryable? }` — `where` is the
+     * stage/subsystem, `code` an enumerated error code (never a message/stack/path),
+     * `source?`/`retryable?` optional content-free extras. Mirrors cli trackError().
+     */
+    fun trackError(where: String, code: String, source: String? = null, retryable: Boolean? = null) {
+        val props = buildMap<String, Any?> {
+            put("where", where)
+            put("code", code)
+            if (source != null) put("source", source)
+            if (retryable != null) put("retryable", retryable)
+        }
+        track("error_occurred", props)
+    }
+
     // ─────────────────────────── helpers ───────────────────────────
 
     enum class Bucket(val label: String) {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryActivation.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryActivation.kt
@@ -79,8 +79,11 @@ object TelemetryActivation {
             }
             val jolliApiKey = SessionTracker.loadConfig().jolliApiKey
             TelemetryFlusher.flush(cwd, origin = resolveOrigin(jolliApiKey), jolliApiKey = jolliApiKey)
-        } catch (_: Exception) {
-            // best-effort
+        } catch (e: Exception) {
+            // best-effort — but log it (JOLLI-1966): a silently-swallowed flush
+            // failure made a delivery outage impossible to diagnose.
+            ai.jolli.jollimemory.core.JmLogger.create("TelemetryActivation")
+                .warn("flushNow failed: ${e.javaClass.simpleName}: ${e.message}")
         }
     }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryBuffer.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryBuffer.kt
@@ -15,6 +15,14 @@ import java.nio.file.StandardCopyOption
  */
 data class TelemetryEnvelope(
     val schemaVersion: Int,
+    /**
+     * Client-generated idempotency key (UUID), minted once when the event is
+     * buffered and preserved verbatim across re-sends. Delivery is at-least-once,
+     * so the backend dedups on `(event_id, ts)` — `INSERT … ON CONFLICT DO NOTHING`
+     * — to keep a retry from creating a duplicate row (JOLLI-1966). Must NOT be
+     * regenerated on re-send. Mirrors cli/src/core/TelemetryBuffer.ts.
+     */
+    val eventId: String,
     val eventName: String,
     val surface: String,
     val surfaceVersion: String,

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryBuffer.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryBuffer.kt
@@ -51,6 +51,13 @@ data class TelemetryEnvelope(
  *
  * Append is synchronous and append-only so it never blocks the <5ms hooks; the
  * ring cap (`MAX_EVENTS`, drop-oldest) is enforced lazily on read/replace.
+ *
+ * Cwd contract (JOLLI-1957): the path uses a LITERAL cwd (no git-root
+ * normalization), so the cwd is the buffer identity — a writer and a flusher for
+ * the same project must pass the same cwd or events are stranded. IntelliJ
+ * satisfies this by always using `project.basePath` (bootstrap, the startup +
+ * background flush, the tool-window tick, and the Stop/Gemini hooks' resolved
+ * cwd). See the TS TelemetryBuffer header for the full contract.
  */
 object TelemetryBuffer {
     const val MAX_EVENTS = 500

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
@@ -56,6 +56,11 @@ object TelemetryEvents {
             "recall_prompt_copied" to "A recall prompt was copied to the clipboard. Props: none.",
             "memory_pinned" to "An item was pinned. Props: kind (discriminator).",
             "memory_unpinned" to "An item was unpinned. Props: kind (discriminator).",
+            "repo_switched" to "User switched the active repo in the tool window's breadcrumb. Props: is_foreign (bool).",
+            "branch_switched" to "User switched the active branch in the tool window's breadcrumb. Props: is_foreign (bool).",
+            "squash_performed" to "User squashed commits. Props: count_bucket (bucketed number of commits squashed).",
+            "pr_created" to "User created or updated a PR from the tool window. Props: action (discriminator: created/updated).",
+            "memory_shared" to "User invoked Share for a branch's memories (read-only share link). Props: none.",
             "key_rejected" to "The server rejected the API key (401/403). Props: retried, where.",
             "reauth_completed" to "Re-authentication after a rejected key finished. Props: outcome.",
         )

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
@@ -36,7 +36,9 @@ object TelemetryEvents {
             "ai_source_detected" to "A new AI source transcript was detected.",
             "settings_opened" to "Settings UI opened (vscode/intellij).",
             // ── pipeline health ──
-            "ingest_completed" to "A drainIngest run finished.",
+            "ingest_completed" to
+                "A drainIngest run finished. Carries `idle:true` for a no-op drain (ingested=0); " +
+                "filter those out for real-ingest latency/health metrics.",
             "error_occurred" to
                 "A structured error was raised. Content-free schema: { where, code, source?, retryable? }. " +
                 "Emitted via Telemetry.trackError(); never carries a message/stack/path.",

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
@@ -17,6 +17,9 @@ object TelemetryEvents {
         linkedMapOf(
             // ── lifecycle & conversion funnel (the primary goal) ──
             "app_installed" to "First run after install; installId minted (once per machine).",
+            "client_activated" to
+                "A GUI surface activated (VS Code activate / IntelliJ project open), carrying `surface_version`. " +
+                "First-seen (install_id, surface_version) ≈ new + upgrade installs that launched.",
             "surface_enabled" to "A surface was enabled in a repo.",
             "surface_disabled" to "A surface was disabled / opted out.",
             "signin_started" to "User initiated OAuth sign-in.",

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
@@ -37,7 +37,9 @@ object TelemetryEvents {
             "settings_opened" to "Settings UI opened (vscode/intellij).",
             // ── pipeline health ──
             "ingest_completed" to "A drainIngest run finished.",
-            "error_occurred" to "A structured error code was raised.",
+            "error_occurred" to
+                "A structured error was raised. Content-free schema: { where, code, source?, retryable? }. " +
+                "Emitted via Telemetry.trackError(); never carries a message/stack/path.",
             "queue_drained" to "QueueWorker finished a drain.",
             "sync_completed" to "A memory-bank sync round finished.",
             // ── IDE tool-window UI / engagement (IntelliJ, VS Code) ──

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
@@ -47,7 +47,9 @@ object TelemetryEvents {
             // ── IDE tool-window UI / engagement (IntelliJ, VS Code) ──
             "toolwindow_opened" to "The memory tool window was opened. Props: view.",
             "view_switched" to "Tool window view switched (current/bank/knowledge). Props: view (discriminator).",
-            "memory_committed" to "User committed a memory via the Commit button. Props: none.",
+            "memory_committed" to
+                "User committed a memory via the Commit button. Props: files_bucket (bucketed changed-file count), " +
+                "has_conversations (bool), context_bucket (bucketed plans/context count).",
             "memory_expanded" to "A committed memory's details were expanded. Props: expanded.",
             "memory_item_opened" to "An item inside a memory was opened. Props: item_type (discriminator).",
             "session_resumed" to "A conversation session was resumed in a terminal. Props: source (discriminator).",

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
@@ -16,46 +16,46 @@ object TelemetryEvents {
     val TELEMETRY_EVENTS: Map<String, String> =
         linkedMapOf(
             // ── lifecycle & conversion funnel (the primary goal) ──
-            "app_installed" to "First run after install; installId minted (once per machine).",
+            "app_installed" to "First run after install; installId minted (once per machine). Props: none — count distinct install_id.",
             "client_activated" to
                 "A GUI surface activated (VS Code activate / IntelliJ project open), carrying `surface_version`. " +
                 "First-seen (install_id, surface_version) ≈ new + upgrade installs that launched.",
-            "surface_enabled" to "A surface was enabled in a repo.",
-            "surface_disabled" to "A surface was disabled / opted out.",
-            "signin_started" to "User initiated OAuth sign-in.",
-            "signin_completed" to "jolliApiKey minted — the conversion event.",
-            "signed_out" to "User logged out.",
-            "ai_provider_selected" to "User chose jolli vs anthropic for LLM.",
-            "memory_bank_migrated" to "Migrate-to-Memory-Bank run.",
+            "surface_enabled" to "A surface was enabled in a repo. Props: trigger.",
+            "surface_disabled" to "A surface was disabled / opted out. Props: trigger, reason.",
+            "signin_started" to "User initiated OAuth sign-in. Props: trigger.",
+            "signin_completed" to "jolliApiKey minted — the conversion event. Props: api_key_minted.",
+            "signed_out" to "User logged out. Props: none.",
+            "ai_provider_selected" to "User chose jolli vs anthropic for LLM. Props: provider (discriminator).",
+            "memory_bank_migrated" to "Migrate-to-Memory-Bank run. Props: outcome, repos, entries_bucket.",
             // ── feature usage / adoption ──
-            "command_invoked" to "Any CLI command ran (auto-emitted).",
-            "recall_performed" to "A recall was run.",
-            "search_performed" to "A search was run.",
-            "memory_pushed" to "Memories pushed.",
-            "export_performed" to "Export run.",
-            "ai_source_detected" to "A new AI source transcript was detected.",
-            "settings_opened" to "Settings UI opened (vscode/intellij).",
+            "command_invoked" to "Any CLI command ran (auto-emitted). Props: command (discriminator), ok, duration_ms.",
+            "recall_performed" to "A recall was run. Props: hit, result_count_bucket.",
+            "search_performed" to "A search was run. Props: query_len_bucket, result_count_bucket.",
+            "memory_pushed" to "Memories pushed to a Space. Props: kind, created, plans_bucket.",
+            "export_performed" to "Export run. Props: format (discriminator).",
+            "ai_source_detected" to "A new AI source transcript was detected. Props: source (discriminator).",
+            "settings_opened" to "Settings UI opened (vscode/intellij). Props: tab (discriminator).",
             // ── pipeline health ──
             "ingest_completed" to
-                "A drainIngest run finished. Carries `idle:true` for a no-op drain (ingested=0); " +
-                "filter those out for real-ingest latency/health metrics.",
+                "A drainIngest run finished. Props: outcome, ingested, idle (no-op when ingested=0), batches, " +
+                "route_calls, reconcile_calls, touched_slugs, topic_failures, duration_ms. Filter idle=true out for real-ingest metrics.",
             "error_occurred" to
                 "A structured error was raised. Content-free schema: { where, code, source?, retryable? }. " +
                 "Emitted via Telemetry.trackError(); never carries a message/stack/path.",
-            "queue_drained" to "QueueWorker finished a drain.",
-            "sync_completed" to "A memory-bank sync round finished.",
+            "queue_drained" to "QueueWorker finished a drain. Props: ops, duration_ms.",
+            "sync_completed" to "A memory-bank sync round finished. Props: outcome (discriminator), duration_ms.",
             // ── IDE tool-window UI / engagement (IntelliJ, VS Code) ──
-            "toolwindow_opened" to "The memory tool window was opened.",
-            "view_switched" to "Tool window view switched (current/bank/knowledge).",
-            "memory_committed" to "User committed a memory via the Commit button.",
-            "memory_expanded" to "A committed memory's details were expanded.",
-            "memory_item_opened" to "An item inside a memory was opened (conversation/file/context/shipped).",
-            "session_resumed" to "A conversation session was resumed in a terminal.",
-            "recall_prompt_copied" to "A recall prompt was copied to the clipboard.",
-            "memory_pinned" to "An item was pinned.",
-            "memory_unpinned" to "An item was unpinned.",
-            "key_rejected" to "The server rejected the API key (401/403).",
-            "reauth_completed" to "Re-authentication after a rejected key finished.",
+            "toolwindow_opened" to "The memory tool window was opened. Props: view.",
+            "view_switched" to "Tool window view switched (current/bank/knowledge). Props: view (discriminator).",
+            "memory_committed" to "User committed a memory via the Commit button. Props: none.",
+            "memory_expanded" to "A committed memory's details were expanded. Props: expanded.",
+            "memory_item_opened" to "An item inside a memory was opened. Props: item_type (discriminator).",
+            "session_resumed" to "A conversation session was resumed in a terminal. Props: source (discriminator).",
+            "recall_prompt_copied" to "A recall prompt was copied to the clipboard. Props: none.",
+            "memory_pinned" to "An item was pinned. Props: kind (discriminator).",
+            "memory_unpinned" to "An item was unpinned. Props: kind (discriminator).",
+            "key_rejected" to "The server rejected the API key (401/403). Props: retried, where.",
+            "reauth_completed" to "Re-authentication after a rejected key finished. Props: outcome.",
         )
 
     /** `object_action`: lowercase snake_case with at least two words. */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryFlusher.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryFlusher.kt
@@ -1,10 +1,12 @@
 package ai.jolli.jollimemory.core.telemetry
 
 import ai.jolli.jollimemory.services.JolliApiClient
+import com.google.gson.JsonParser
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.security.MessageDigest
 import java.time.Duration
 
 /**
@@ -30,6 +32,11 @@ object TelemetryFlusher {
     const val DEFAULT_MAX_BATCH = 100
     private const val TELEMETRY_PATH = "/api/telemetry/events"
     private val TIMEOUT: Duration = Duration.ofSeconds(10)
+    private val UUID_RE = Regex("^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", RegexOption.IGNORE_CASE)
+
+    // JOLLI-1966 diagnostics: the flush path is otherwise silent, so a delivery
+    // outage is invisible. Log the resolved target + per-batch HTTP status.
+    private val log = ai.jolli.jollimemory.core.JmLogger.create("TelemetryFlusher")
 
     data class FlushResult(val sent: Int, val remaining: Int)
 
@@ -52,8 +59,11 @@ object TelemetryFlusher {
                         .POST(HttpRequest.BodyPublishers.ofString(body))
                 if (bearer != null) builder.header("Authorization", "Bearer $bearer")
                 val response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.discarding())
-                response.statusCode() in 200..299
-            } catch (_: Exception) {
+                val ok = response.statusCode() in 200..299
+                log.info("telemetry POST $url -> HTTP ${response.statusCode()} (bearer=${bearer != null}, ok=$ok)")
+                ok
+            } catch (e: Exception) {
+                log.warn("telemetry POST $url threw ${e.javaClass.simpleName}: ${e.message}")
                 false
             }
         }
@@ -77,16 +87,21 @@ object TelemetryFlusher {
             }
         }
 
-        val lines = TelemetryBuffer.readLines(cwd)
+        val lines = TelemetryBuffer.readLines(cwd).map { ensureEventIdLine(it) }
         if (lines.isEmpty()) return FlushResult(0, 0)
-        if (resolvedOrigin.isNullOrEmpty()) return FlushResult(0, lines.size)
+        log.info("telemetry flush: ${lines.size} buffered, resolvedOrigin=$resolvedOrigin, bearer=${bearer != null}")
+        if (resolvedOrigin.isNullOrEmpty()) {
+            log.warn("telemetry flush: no origin resolved — ${lines.size} events stranded")
+            return FlushResult(0, lines.size)
+        }
 
         // Defense-in-depth: never POST telemetry (or a Bearer key) to a non-Jolli
         // host. The flusher re-derives origin from raw config, so re-assert the
         // HTTPS + allowlist boundary here (parity with the CLI flusher).
         try {
             ai.jolli.jollimemory.auth.JolliAuthUtils.assertJolliOriginAllowed(resolvedOrigin)
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            log.warn("telemetry flush: origin rejected by allowlist ($resolvedOrigin): ${e.message}")
             return FlushResult(0, lines.size)
         }
 
@@ -99,28 +114,89 @@ object TelemetryFlusher {
                 return FlushResult(0, lines.size)
             }
 
+        // Group by install_id before batching: the backend rejects a batch that
+        // mixes install_ids with 400 ("batch must carry a single install_id"). If
+        // the buffer holds >1 install_id — e.g. after an install_id rotation leaves
+        // a stray event from a prior install — count-only batching puts both in one
+        // batch and that 400 permanently jams delivery for EVERY event. Grouping
+        // keeps each batch homogeneous; a failing group is skipped without blocking
+        // the others, so one poisoned install_id can't strand the rest.
+        val groups = LinkedHashMap<String, MutableList<String>>()
+        for (line in lines) groups.getOrPut(installIdOf(line)) { mutableListOf() }.add(line)
+
         val batchSize = maxOf(1, maxBatch)
-        var sent = 0
-        var i = 0
-        while (i < lines.size) {
-            val batch = lines.subList(i, minOf(i + batchSize, lines.size))
-            val body = """{"events":[${batch.joinToString(",")}]}"""
-            if (!sender.send(url, body, bearer)) break
-            sent += batch.size
-            i += batchSize
+        val acked = ArrayList<String>()
+        for (group in groups.values) {
+            var i = 0
+            while (i < group.size) {
+                val batch = group.subList(i, minOf(i + batchSize, group.size))
+                val body = """{"events":[${batch.joinToString(",")}]}"""
+                // A failed batch stops THIS install_id's remaining batches (the next
+                // would fail the same way) but not the other groups' — break inner only.
+                if (!sender.send(url, body, bearer)) break
+                acked.addAll(batch)
+                i += batchSize
+            }
         }
 
-        if (sent == 0) return FlushResult(0, lines.size)
+        if (acked.isEmpty()) {
+            log.warn("telemetry flush: all batches failed — ${lines.size} events remain buffered (url=$url)")
+            return FlushResult(0, lines.size)
+        }
+        log.info("telemetry flush: sent ${acked.size}/${lines.size} event(s) to $url")
 
         // Re-read so events appended during the flush survive, then remove the
         // acked lines by identity rather than by count: under the ring cap a
-        // concurrent append can trim the buffer head, so a positional sublist
-        // would drop the wrong (newest) lines. Identity removal is correct
-        // regardless of trimming (lines are stored verbatim, so equality is exact).
-        val current = TelemetryBuffer.readLines(cwd)
-        val remaining = removeAcked(current, lines.subList(0, sent))
+        // concurrent append can trim the buffer head, and grouping means acked
+        // lines are no longer a contiguous prefix, so a positional sublist would
+        // drop the wrong lines. Identity removal is correct regardless of
+        // order/trimming (lines are stored verbatim, so equality is exact).
+        val current = TelemetryBuffer.readLines(cwd).map { ensureEventIdLine(it) }
+        val remaining = removeAcked(current, acked)
         TelemetryBuffer.replaceLines(cwd, remaining)
-        return FlushResult(sent, remaining.size)
+        return FlushResult(acked.size, remaining.size)
+    }
+
+    /** The `installId` of a buffered line, for batch grouping; "" when absent/unparseable. */
+    private fun installIdOf(line: String): String =
+        try {
+            JsonParser.parseString(line).asJsonObject.get("installId")?.asString ?: ""
+        } catch (_: Exception) {
+            ""
+        }
+
+    /**
+     * Backfill a stable UUID for telemetry lines buffered by older clients before
+     * `eventId` existed. The id is deterministic from the exact stored line, so a
+     * failed flush/retry keeps the same id even though the legacy file is unchanged.
+     */
+    private fun ensureEventIdLine(line: String): String {
+        return try {
+            val obj = JsonParser.parseString(line).asJsonObject
+            val hasEventId = obj.has("eventId")
+            val eventId = runCatching { obj.get("eventId")?.asString }.getOrNull()
+            if (eventId != null && UUID_RE.matches(eventId)) {
+                line
+            } else {
+                val trimmed = line.trim()
+                if (!hasEventId && trimmed.startsWith("{")) {
+                    """{"eventId":"${legacyEventId(trimmed)}",${trimmed.substring(1)}"""
+                } else {
+                    obj.addProperty("eventId", legacyEventId(trimmed))
+                    obj.toString()
+                }
+            }
+        } catch (_: Exception) {
+            line
+        }
+    }
+
+    private fun legacyEventId(rawLine: String): String {
+        val hex = MessageDigest.getInstance("SHA-256").digest(rawLine.toByteArray(Charsets.UTF_8)).joinToString("") {
+            "%02x".format(it)
+        }
+        val variant = ((hex.substring(16, 18).toInt(16) and 0x3f) or 0x80).toString(16).padStart(2, '0')
+        return "${hex.substring(0, 8)}-${hex.substring(8, 12)}-5${hex.substring(13, 16)}-$variant${hex.substring(18, 20)}-${hex.substring(20, 32)}"
     }
 
     /**

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/GeminiAfterAgentHook.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/GeminiAfterAgentHook.kt
@@ -51,5 +51,9 @@ object GeminiAfterAgentHook {
 
         SessionTracker.saveSession(sessionInfo, cwd)
         log.info("Gemini session saved: %s", hookInput.session_id)
+
+        // JOLLI-1954: flush the shared telemetry buffer on every agent turn end
+        // (mirrors the Claude Stop hook). flushNow re-gates consent, never throws.
+        ai.jolli.jollimemory.core.telemetry.TelemetryActivation.flushNow(cwd)
     }
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/StopHook.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/hooks/StopHook.kt
@@ -68,6 +68,12 @@ object StopHook {
         } catch (t: Throwable) {
             log.error("discoverFromTranscript crashed: %s: %s", t.javaClass.name, t.message)
         }
+
+        // JOLLI-1954: the Stop hook fires on every agent turn end — far more often
+        // than commits — so drain the shared telemetry buffer here too. Covers the
+        // "using the agent but not committing" case. flushNow re-gates consent and
+        // never throws. Mirrors cli/src/hooks/StopHook.ts.
+        ai.jolli.jollimemory.core.telemetry.TelemetryActivation.flushNow(cwd)
     }
 
     /**

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryStartupActivity.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryStartupActivity.kt
@@ -70,6 +70,12 @@ class JolliMemoryStartupActivity : ProjectActivity {
         // by prior sessions/hooks, and show the loud first-run notice once.
         try {
             val showNotice = ai.jolli.jollimemory.core.telemetry.TelemetryActivation.bootstrap(basePath)
+            // JOLLI-1963: count new + upgrade installs. Fires once per project open
+            // (a real session), carrying surface_version; first-seen (install_id,
+            // surface_version) ≈ new + upgrade installs. Emitted here (not in
+            // TelemetryActivation.bootstrap, which the git hooks also call) so hook
+            // runs don't flood it. No-op when telemetry is off.
+            ai.jolli.jollimemory.core.telemetry.Telemetry.track("client_activated")
             ai.jolli.jollimemory.core.telemetry.TelemetryActivation.flushNow(basePath)
             if (showNotice) {
                 ai.jolli.jollimemory.core.telemetry.TelemetrySharedConfig.markNoticeShown()

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryStartupActivity.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryStartupActivity.kt
@@ -5,8 +5,12 @@ import com.intellij.ide.BrowserUtil
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
+import com.intellij.openapi.util.Disposer
+import com.intellij.util.concurrency.AppExecutorUtil
+import java.util.concurrent.TimeUnit
 
 /**
  * Runs after project opens — initializes the JolliMemory service
@@ -89,6 +93,25 @@ class JolliMemoryStartupActivity : ProjectActivity {
             }
         } catch (e: Exception) {
             log.warn("Telemetry bootstrap failed (ignored): ${e.message}")
+        }
+
+        // JOLLI-1956: periodic telemetry flush, decoupled from the tool window's
+        // visibility. The Active Conversations 60s tick only flushes while that
+        // panel is showing, so a user who keeps the tool window closed would never
+        // drain the shared buffer. Schedule a background flush tied to the project
+        // lifecycle (cancelled on project close). Runs off the EDT — flushNow does
+        // blocking HTTP — and is best-effort (flushNow re-gates consent, never throws).
+        try {
+            val flushFuture =
+                AppExecutorUtil.getAppScheduledExecutorService().scheduleWithFixedDelay(
+                    { ai.jolli.jollimemory.core.telemetry.TelemetryActivation.flushNow(basePath) },
+                    60L,
+                    60L,
+                    TimeUnit.SECONDS,
+                )
+            Disposer.register(project, Disposable { flushFuture.cancel(false) })
+        } catch (e: Exception) {
+            log.warn("Telemetry flush scheduling failed (ignored): ${e.message}")
         }
 
         log.info("JolliMemory: startup complete for project at $basePath")

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActionBarPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActionBarPanel.kt
@@ -88,6 +88,7 @@ class ActionBarPanel(
 		}
 		val prompt = "Invoke the \"jolli-recall\" skill with args \"$branch\"."
 		Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(prompt), null)
+		ai.jolli.jollimemory.core.telemetry.Telemetry.track("recall_prompt_copied")
 		Messages.showInfoMessage(
 			project,
 			"Recall prompt copied — paste it into your AI coding tool.",
@@ -186,6 +187,7 @@ class ActionBarPanel(
 					)
 					return@invokeLater
 				}
+				ai.jolli.jollimemory.core.telemetry.Telemetry.track("memory_shared")
 				val vFile = SummaryVirtualFile(newest)
 				val editors = com.intellij.openapi.fileEditor.FileEditorManager.getInstance(project)
 					.openFile(vFile, true)

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActiveConversationsPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/ActiveConversationsPanel.kt
@@ -201,6 +201,10 @@ class ActiveConversationsPanel(
 		val cwd = service.mainRepoRoot ?: project.basePath ?: return
 		val key = CommitSelectionStore.conversationKey(item.source, item.sessionId)
 		val title = item.title.ifBlank { "${item.source.name} conversation" }
+		// Pinning a conversation mirrors PlansPanel/CommitsPanel pins (memory_pinned);
+		// without this, conversation pins were the one pin path with no telemetry
+		// (unpin was already tracked in PinnedPanel — this restores the symmetry).
+		ai.jolli.jollimemory.core.telemetry.Telemetry.track("memory_pinned", mapOf("kind" to "conversations"))
 		ApplicationManager.getApplication().executeOnPooledThread {
 			ai.jolli.jollimemory.core.PinStore.pin(cwd, "conversations", key, title, item.source.name)
 			SwingUtilities.invokeLater { service.panelRegistry?.pinnedPanel?.refresh() }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BreadcrumbHeaderPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/BreadcrumbHeaderPanel.kt
@@ -132,6 +132,10 @@ class BreadcrumbHeaderPanel(
 	}
 
 	private fun onRepoSelected() {
+		// User picked a repo in the breadcrumb (setSelectedSilently doesn't fire onPick,
+		// so this is genuinely user-driven). is_foreign = not the workspace's own repo.
+		val isForeign = repos.find { it.repoName == repoPicker.selected }?.isCurrentRepo != true
+		ai.jolli.jollimemory.core.telemetry.Telemetry.track("repo_switched", mapOf("is_foreign" to isForeign))
 		refreshBranches()
 	}
 
@@ -158,17 +162,24 @@ class BreadcrumbHeaderPanel(
 				} else {
 					branchPicker.setSelectedSilently(branches.firstOrNull())
 				}
-				onBranchSelected()
+				// Cascade from a repo switch — repo_switched already fired, so don't
+				// also emit branch_switched (would double-count one user action).
+				onBranchSelected(trackSwitch = false)
 			}
 		}
 	}
 
-	private fun onBranchSelected() {
+	private fun onBranchSelected(trackSwitch: Boolean = true) {
 		val selectedRepo = repoPicker.selected ?: return
 		val selectedBranch = branchPicker.selected ?: return
 		val isCurrentRepo = repos.find { it.repoName == selectedRepo }?.isCurrentRepo == true
 		val isForeign = !isCurrentRepo || selectedBranch != currentBranch
 
+		// Only a genuine branch pick emits branch_switched; the repo-cascade path
+		// passes trackSwitch=false (see refreshBranches).
+		if (trackSwitch) {
+			ai.jolli.jollimemory.core.telemetry.Telemetry.track("branch_switched", mapOf("is_foreign" to isForeign))
+		}
 		onSelectionChanged(
 			if (isForeign) selectedRepo else null,
 			if (isForeign) selectedBranch else null,

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CreatePrPanel.kt
@@ -245,10 +245,13 @@ class CreatePrPanel(
                         // wrapWithMarkers would delete that custom text (mirrors SummaryPanel.handleUpdatePr).
                         val mergedBody = PrService.replaceSummaryInBody(lookup.pr.body, rawBody)
                         PrService.updatePr(lookup.pr.number, title, mergedBody, cwd)
+                        ai.jolli.jollimemory.core.telemetry.Telemetry.track("pr_created", mapOf("action" to "updated"))
                         lookup.pr.url
                     } else {
                         // Create: no existing body to preserve — wrap the summary in markers.
-                        PrService.createPr(title, PrService.wrapWithMarkers(rawBody), cwd)
+                        val created = PrService.createPr(title, PrService.wrapWithMarkers(rawBody), cwd)
+                        ai.jolli.jollimemory.core.telemetry.Telemetry.track("pr_created", mapOf("action" to "created"))
+                        created
                     }
 
                     // One-click share: when signed in, push the included memories to Jolli.

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
@@ -605,7 +605,7 @@ class SummaryPanel(
                         if (choice == Messages.YES) reauthenticateAndRetry()
                     }
                 } catch (e: Exception) {
-                    ai.jolli.jollimemory.core.telemetry.Telemetry.track("error_occurred", mapOf("code" to "push_failed", "where" to "push"))
+                    ai.jolli.jollimemory.core.telemetry.Telemetry.trackError("push", "push_failed")
                     ApplicationManager.getApplication().invokeLater {
                         postToWebview("pushFailed")
                         Messages.showErrorDialog(project, "Push failed: ${e.message}", "Push Error")

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryBufferTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryBufferTest.kt
@@ -18,6 +18,7 @@ class TelemetryBufferTest {
         properties: Map<String, Any?> = mapOf("hit" to true),
     ) = TelemetryEnvelope(
         schemaVersion = 1,
+        eventId = "22222222-2222-4222-8222-222222222222",
         eventName = eventName,
         surface = "intellij",
         surfaceVersion = "1.0.0",

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryFlusherTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryFlusherTest.kt
@@ -27,7 +27,7 @@ class TelemetryFlusherTest {
         }
     }
 
-    private fun env(installId: String) =
+    private fun env(installId: String, seq: Int? = null) =
         TelemetryEnvelope(
             schemaVersion = 1,
             eventId = "33333333-3333-4333-8333-333333333333",
@@ -41,11 +41,13 @@ class TelemetryFlusherTest {
             env = "local",
             tsIso = "2026-06-20T00:00:00.000Z",
             accountId = null,
-            properties = emptyMap(),
+            properties = if (seq != null) mapOf("seq" to seq.toString()) else emptyMap(),
         )
 
-    private fun seed(n: Int) {
-        for (i in 0 until n) TelemetryBuffer.append(cwd, env("i-$i"))
+    // Seed n events under ONE install_id (so they form a single batch group), each
+    // tagged with a distinct `seq` so identity-based assertions stay unambiguous.
+    private fun seed(n: Int, installId: String = "install-1") {
+        for (i in 0 until n) TelemetryBuffer.append(cwd, env(installId, seq = i))
     }
 
     private fun makeKey(u: String): String {
@@ -143,7 +145,7 @@ class TelemetryFlusherTest {
             }
         val result = TelemetryFlusher.flush(cwd, origin = "https://jolli.ai", maxBatch = 2, sender = sender)
         result shouldBe TelemetryFlusher.FlushResult(2, 3)
-        TelemetryBuffer.read(cwd).map { it.installId } shouldBe listOf("i-2", "i-3", "i-4")
+        TelemetryBuffer.read(cwd).map { it.properties["seq"] } shouldBe listOf("2", "3", "4")
     }
 
     @Test
@@ -153,5 +155,70 @@ class TelemetryFlusherTest {
         val result = TelemetryFlusher.flush(cwd, origin = "https://jolli.ai", maxBatch = 10, sender = sender)
         result.sent shouldBe 3
         TelemetryBuffer.read(cwd).map { it.installId } shouldBe listOf("late")
+    }
+
+    @Test
+    fun `backfills a stable eventId for legacy buffered events across retries`() {
+        val queue = File("$cwd/.jolli/jollimemory/telemetry-queue.ndjson")
+        queue.parentFile.mkdirs()
+        queue.writeText(
+            """{"schemaVersion":1,"eventName":"app_installed","surface":"intellij","surfaceVersion":"1.0.0","installId":"legacy","os":"mac","arch":"arm64","runtimeVersion":"jvm-21","env":"local","tsIso":"2026-06-20T00:00:00.000Z","accountId":null,"properties":{}}""" + "\n",
+            Charsets.UTF_8,
+        )
+        val sender =
+            object : TelemetryFlusher.Sender {
+                val calls = mutableListOf<String>()
+
+                override fun send(url: String, body: String, bearer: String?): Boolean {
+                    calls.add(body)
+                    return calls.size == 2
+                }
+            }
+
+        TelemetryFlusher.flush(cwd, origin = "https://jolli.ai", sender = sender) shouldBe TelemetryFlusher.FlushResult(0, 1)
+        val firstEventId = Regex(""""eventId":"([^"]+)"""").find(sender.calls[0])!!.groupValues[1]
+        Regex("""^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$""", RegexOption.IGNORE_CASE).matches(firstEventId) shouldBe true
+
+        TelemetryFlusher.flush(cwd, origin = "https://jolli.ai", sender = sender) shouldBe TelemetryFlusher.FlushResult(1, 0)
+        val secondEventId = Regex(""""eventId":"([^"]+)"""").find(sender.calls[1])!!.groupValues[1]
+        secondEventId shouldBe firstEventId
+        TelemetryBuffer.readLines(cwd) shouldHaveSize 0
+    }
+
+    @Test
+    fun `groups by install_id so every batch carries a single install_id`() {
+        TelemetryBuffer.append(cwd, env("A", seq = 0))
+        TelemetryBuffer.append(cwd, env("B", seq = 1))
+        TelemetryBuffer.append(cwd, env("A", seq = 2))
+        val sender = CapturingSender(ok = true)
+        val result = TelemetryFlusher.flush(cwd, origin = "https://jolli.ai", sender = sender)
+        result shouldBe TelemetryFlusher.FlushResult(3, 0)
+        // One batch per install_id group (A has 2, B has 1) — never a mixed batch.
+        sender.calls shouldHaveSize 2
+        for (call in sender.calls) {
+            val ids = Regex(""""installId":"([^"]+)"""").findAll(call.body).map { it.groupValues[1] }.toSet()
+            ids shouldHaveSize 1
+        }
+        TelemetryBuffer.readLines(cwd) shouldHaveSize 0
+    }
+
+    @Test
+    fun `a stray install_id that fails does not block delivery of the others`() {
+        // Reproduces the ibe jam: one stray event from a prior install sits at the
+        // buffer head; the backend 400s any batch containing it. Grouping must
+        // isolate it so the current install's events still deliver.
+        TelemetryBuffer.append(cwd, env("stray", seq = 0))
+        TelemetryBuffer.append(cwd, env("current", seq = 1))
+        TelemetryBuffer.append(cwd, env("current", seq = 2))
+        val sender =
+            object : TelemetryFlusher.Sender {
+                override fun send(url: String, body: String, bearer: String?): Boolean =
+                    // reject the stray group (mixed-install 400 analogue), accept the rest
+                    !body.contains(""""installId":"stray"""")
+            }
+        val result = TelemetryFlusher.flush(cwd, origin = "https://jolli.ai", sender = sender)
+        result shouldBe TelemetryFlusher.FlushResult(2, 1)
+        // Only the poisoned stray event remains; the current install's events delivered.
+        TelemetryBuffer.read(cwd).map { it.installId } shouldBe listOf("stray")
     }
 }

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryFlusherTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryFlusherTest.kt
@@ -30,6 +30,7 @@ class TelemetryFlusherTest {
     private fun env(installId: String) =
         TelemetryEnvelope(
             schemaVersion = 1,
+            eventId = "33333333-3333-4333-8333-333333333333",
             eventName = "app_installed",
             surface = "intellij",
             surfaceVersion = "1.0.0",

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -1000,6 +1000,8 @@ vi.mock("./views/NoteEditorWebviewPanel.js", () => ({
 vi.mock("./TelemetryActivation.js", () => ({
 	activateExtensionTelemetry: vi.fn().mockResolvedValue(undefined),
 	reinitExtensionTelemetry: vi.fn().mockResolvedValue(undefined),
+	// JOLLI-1956: activate() flushes once immediately and on a background interval.
+	flushExtensionTelemetry: vi.fn(),
 }));
 
 // Branch-recall command bodies live in their own module (tested directly in

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -28,7 +28,7 @@ import { assertJolliOriginAllowed } from "../../cli/src/core/JolliApiUtils.js";
 import { triggerPendingPushRetry } from "../../cli/src/hooks/PushCompensation.js";
 import { exportSharedBranch } from "./services/JolliShareService.js";
 import { importSharedBranchForDisplay } from "./services/SharedBranchImporter.js";
-import { activateExtensionTelemetry, reinitExtensionTelemetry } from "./TelemetryActivation.js";
+import { activateExtensionTelemetry, flushExtensionTelemetry, reinitExtensionTelemetry } from "./TelemetryActivation.js";
 import {
 	getGlobalConfigDir,
 	loadConfig,
@@ -466,6 +466,16 @@ export function activate(context: vscode.ExtensionContext): void {
 			void reinitExtensionTelemetry(workspaceRoot, !enabled);
 		}),
 	);
+	// JOLLI-1956: UI-decoupled background telemetry flush. The sidebar's 60s tick
+	// only drains the shared buffer while the panel is visible, so a user who keeps
+	// it closed would never upload. Flush once now (drains anything a prior session
+	// left buffered) and then on a fixed interval, regardless of panel state.
+	// Best-effort — `flushExtensionTelemetry` re-gates consent and never throws;
+	// the live platform opt-out is passed each call so a mid-session toggle wins.
+	const flushTelemetry = (): void => flushExtensionTelemetry(workspaceRoot, !vscode.env.isTelemetryEnabled);
+	flushTelemetry();
+	const telemetryFlushTimer = setInterval(flushTelemetry, 60_000);
+	context.subscriptions.push({ dispose: () => clearInterval(telemetryFlushTimer) });
 
 	// ── Core bridge ──────────────────────────────────────────────────────────
 	// Bridge now calls Installer functions directly — no CLI subprocess needed.

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -3540,6 +3540,8 @@ export function activate(context: vscode.ExtensionContext): void {
 				);
 				return;
 			}
+			// JOLLI-1904: user invoked branch Share (mirrors IntelliJ ActionBarPanel.handleShare).
+			track("memory_shared");
 			const readStorageResult = await bridge.createReadStorageForCurrentRepo();
 			await SummaryWebviewPanel.showWithShareModal(
 				newest,

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -30,6 +30,7 @@ import { exportSharedBranch } from "./services/JolliShareService.js";
 import { importSharedBranchForDisplay } from "./services/SharedBranchImporter.js";
 import { track } from "../../cli/src/core/Telemetry.js";
 import { activateExtensionTelemetry, flushExtensionTelemetry, reinitExtensionTelemetry } from "./TelemetryActivation.js";
+import { trackMemoryCommitted } from "./telemetry/UiTelemetry.js";
 import {
 	getGlobalConfigDir,
 	loadConfig,
@@ -2373,6 +2374,13 @@ export function activate(context: vscode.ExtensionContext): void {
 
 		vscode.commands.registerCommand("jollimemory.commitAI", () => {
 			log.info("cmd", "commitAI invoked");
+			// JOLLI-1904: memory_committed engagement event (mirrors IntelliJ). Gather
+			// the counts off the click path so telemetry never delays the commit.
+			void trackMemoryCommitted({
+				getFilesCount: () => filesStore.getSnapshot().files.length,
+				getContextCount: () => plansStore.getSnapshot().plans.length,
+				listConversations: () => activeSessionsProvider.list(),
+			});
 			commitCommand.execute().catch(handleError("commitAI"));
 		}),
 

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -28,6 +28,7 @@ import { assertJolliOriginAllowed } from "../../cli/src/core/JolliApiUtils.js";
 import { triggerPendingPushRetry } from "../../cli/src/hooks/PushCompensation.js";
 import { exportSharedBranch } from "./services/JolliShareService.js";
 import { importSharedBranchForDisplay } from "./services/SharedBranchImporter.js";
+import { track } from "../../cli/src/core/Telemetry.js";
 import { activateExtensionTelemetry, flushExtensionTelemetry, reinitExtensionTelemetry } from "./TelemetryActivation.js";
 import {
 	getGlobalConfigDir,
@@ -2225,6 +2226,9 @@ export function activate(context: vscode.ExtensionContext): void {
 					// usual. Done only on success — a failed install means the
 					// previous (manuallyDisabled) state is still the user's intent.
 					await writeManualDisableFlag(workspaceRoot, false);
+					// JOLLI-1904 (funnel): surface enabled. Mirrors IntelliJ
+					// surface_enabled { trigger }; surface=vscode auto-injected.
+					track("surface_enabled", { trigger: "command" });
 					log.info("cmd", "enable succeeded — refreshing all panels");
 					// ORDER MATTERS:
 					//   1. refreshStatusBar flips every store's enabled flag
@@ -2290,6 +2294,9 @@ export function activate(context: vscode.ExtensionContext): void {
 					log.error("cmd", "disable failed", { message: result.message });
 					vscode.window.showErrorMessage(`Jolli Memory: ${result.message}`);
 				} else {
+					// JOLLI-1904 (funnel): surface disabled. Mirrors IntelliJ
+					// surface_disabled { trigger }; surface=vscode auto-injected.
+					track("surface_disabled", { trigger: "command" });
 					log.info("cmd", "disable succeeded");
 					await statusStore.refresh();
 					const status = await refreshStatusBar(

--- a/vscode/src/TelemetryActivation.test.ts
+++ b/vscode/src/TelemetryActivation.test.ts
@@ -6,6 +6,7 @@ const loadConfig = vi.fn(async () => ({}) as Record<string, unknown>);
 const saveConfig = vi.fn(async () => {});
 const shouldShowTelemetryNotice = vi.fn(() => false);
 const shutdownTelemetry = vi.fn();
+const track = vi.fn();
 
 vi.mock("../../cli/src/core/TelemetryStartup.js", () => ({
 	bootstrapTelemetry: (...args: unknown[]) => bootstrapTelemetry(...(args as [])),
@@ -16,6 +17,7 @@ vi.mock("../../cli/src/core/TelemetryConsent.js", () => ({
 }));
 vi.mock("../../cli/src/core/Telemetry.js", () => ({
 	shutdownTelemetry: (...args: unknown[]) => shutdownTelemetry(...(args as [])),
+	track: (...args: unknown[]) => track(...(args as [])),
 }));
 vi.mock("../../cli/src/core/SessionTracker.js", () => ({
 	loadConfig: (...args: unknown[]) => loadConfig(...(args as [])),
@@ -52,6 +54,12 @@ beforeEach(() => {
 });
 
 describe("activateExtensionTelemetry", () => {
+	it("emits client_activated once on activation (JOLLI-1963)", async () => {
+		const { deps } = makeDeps();
+		await activateExtensionTelemetry("/repo", deps);
+		expect(track).toHaveBeenCalledWith("client_activated");
+	});
+
 	it("bootstraps with the platform opt-out signal", async () => {
 		const { deps } = makeDeps({ platformDisabled: true });
 		await activateExtensionTelemetry("/repo", deps);

--- a/vscode/src/TelemetryActivation.ts
+++ b/vscode/src/TelemetryActivation.ts
@@ -14,7 +14,7 @@
  * CLI core functions are imported from the bundled `cli/src/**`.
  */
 import { loadConfig, saveConfig } from "../../cli/src/core/SessionTracker.js";
-import { shutdownTelemetry } from "../../cli/src/core/Telemetry.js";
+import { shutdownTelemetry, track } from "../../cli/src/core/Telemetry.js";
 import { shouldShowTelemetryNotice } from "../../cli/src/core/TelemetryConsent.js";
 import { bootstrapTelemetry, flushTelemetryNow } from "../../cli/src/core/TelemetryStartup.js";
 
@@ -37,6 +37,11 @@ export interface TelemetryActivationDeps {
 /** Bootstrap telemetry for the extension and show the first-run notice once. Never throws. */
 export async function activateExtensionTelemetry(cwd: string, deps: TelemetryActivationDeps): Promise<void> {
 	await bootstrapTelemetry({ cwd, platformDisabled: deps.platformDisabled });
+	// JOLLI-1963: count new + upgrade installs. Fires once per extension activation
+	// (a real session), carrying `surface_version` in the envelope; the metric dedups
+	// on first-seen (install_id, surface_version). No-op when telemetry is off — track
+	// re-gates consent. Unlike `app_installed` (once per machine), this catches upgrades.
+	track("client_activated");
 	try {
 		const config = await loadConfig();
 		if (shouldShowTelemetryNotice({ config, platformDisabled: deps.platformDisabled })) {

--- a/vscode/src/commands/BranchRecallCommands.test.ts
+++ b/vscode/src/commands/BranchRecallCommands.test.ts
@@ -24,6 +24,9 @@ vi.mock("../views/BranchRecall.js", () => ({
 	buildBranchRecallPrompt,
 }));
 
+const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+vi.mock("../../../cli/src/core/Telemetry.js", () => ({ track }));
+
 import type { JolliMemoryBridge } from "../JolliMemoryBridge.js";
 import { runCopyBranchRecallPrompt, runRecallInClaudeCode } from "./BranchRecallCommands.js";
 
@@ -90,6 +93,8 @@ describe("runCopyBranchRecallPrompt — detached HEAD guard", () => {
 
 		expect(buildBranchRecallPrompt).toHaveBeenCalledWith("/repo", "main");
 		expect(writeText).toHaveBeenCalledWith("RECALL");
+		// JOLLI-1904: emits recall_prompt_copied after a successful copy.
+		expect(track).toHaveBeenCalledWith("recall_prompt_copied");
 	});
 
 	it("shows the empty message (not the detached message) when a real branch has no records", async () => {

--- a/vscode/src/commands/BranchRecallCommands.ts
+++ b/vscode/src/commands/BranchRecallCommands.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { track } from "../../../cli/src/core/Telemetry.js";
 import type { JolliMemoryBridge } from "../JolliMemoryBridge.js";
 import { buildBranchRecallPrompt } from "../views/BranchRecall.js";
 
@@ -48,5 +49,7 @@ export async function runCopyBranchRecallPrompt(bridge: JolliMemoryBridge, cwd: 
 		return;
 	}
 	await vscode.env.clipboard.writeText(prompt);
+	// JOLLI-1904: recall prompt copied to clipboard (mirrors IntelliJ; no props).
+	track("recall_prompt_copied");
 	await vscode.window.showInformationMessage("Recall prompt copied — paste it into Codex, Cursor, or any AI tool.");
 }

--- a/vscode/src/commands/SquashCommand.test.ts
+++ b/vscode/src/commands/SquashCommand.test.ts
@@ -11,6 +11,13 @@ const { info, warn, error, debug } = vi.hoisted(() => ({
 	debug: vi.fn(),
 }));
 
+// Spy on track() but keep the real bucket() so we assert on real bucket labels.
+const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+vi.mock("../../../cli/src/core/Telemetry.js", async (importActual) => ({
+	...(await importActual<typeof import("../../../cli/src/core/Telemetry.js")>()),
+	track,
+}));
+
 type QuickPickController = {
 	qp: {
 		value: string;
@@ -165,6 +172,31 @@ describe("SquashCommand", () => {
 		warn.mockClear();
 		error.mockClear();
 		debug.mockClear();
+	});
+
+	it("emits squash_performed{count_bucket} once the QuickPick is confirmed (JOLLI-1904)", async () => {
+		// 2 commits (makeDeps default) → bucket = "1-5". Worker turns busy right after
+		// the QuickPick, aborting before the real git work — but squash_performed fires
+		// at confirmation (before the re-check), so it's already recorded.
+		const deps = makeDeps();
+		const command = new SquashCommand(
+			deps.bridge as never,
+			deps.commitsStore as never,
+			deps.filesStore as never,
+			deps.statusStore as never,
+			deps.statusBar as never,
+			"/repo",
+		);
+		vi.spyOn(command as never, "showSquashQuickPick").mockResolvedValue({
+			item: { label: "$(git-merge) Squash" },
+			message: "feat: squash",
+		});
+		isWorkerBusy.mockReset().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+		track.mockClear();
+
+		await command.execute();
+
+		expect(track).toHaveBeenCalledWith("squash_performed", { count_bucket: "1-5" });
 	});
 
 	it("blocks while the worker is busy", async () => {

--- a/vscode/src/commands/SquashCommand.ts
+++ b/vscode/src/commands/SquashCommand.ts
@@ -15,6 +15,7 @@
  */
 
 import * as vscode from "vscode";
+import { bucket, track } from "../../../cli/src/core/Telemetry.js";
 import type { JolliMemoryBridge } from "../JolliMemoryBridge.js";
 import type { CommitsStore } from "../stores/CommitsStore.js";
 import type { FilesStore } from "../stores/FilesStore.js";
@@ -133,6 +134,10 @@ export class SquashCommand {
 			log.info("squash", "QuickPick cancelled by user");
 			return;
 		}
+
+		// JOLLI-1904: user confirmed a squash (mirrors IntelliJ SquashAction — fires at
+		// confirm, count bucketed for privacy). surface=vscode auto-injected.
+		track("squash_performed", { count_bucket: bucket(orderedHashes.length) });
 
 		// Re-check the worker gate: the click-time check at the top goes stale
 		// during LLM message generation + QuickPick review (seconds to minutes).

--- a/vscode/src/services/AuthService.test.ts
+++ b/vscode/src/services/AuthService.test.ts
@@ -25,6 +25,8 @@ const { getDeviceLabel } = vi.hoisted(() => ({
 	getDeviceLabel: vi.fn(),
 }));
 
+const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+
 const {
 	executeCommand,
 	openExternal,
@@ -129,6 +131,8 @@ vi.mock("../../../cli/src/core/SessionTracker.js", () => ({
 	loadConfig,
 }));
 
+vi.mock("../../../cli/src/core/Telemetry.js", () => ({ track }));
+
 vi.mock("../util/Logger.js", () => ({
 	log: { info, warn, error: logError },
 }));
@@ -206,11 +210,24 @@ describe("AuthService", () => {
 				jolliApiKey: "sk-jol-test",
 			});
 			expect(saveAuthCredentials).toHaveBeenCalledTimes(1);
+			// JOLLI-1904 funnel: conversion event, api_key_minted=true.
+			expect(track).toHaveBeenCalledWith("signin_completed", { api_key_minted: true });
 			expect(executeCommand).toHaveBeenCalledWith(
 				"setContext",
 				"jollimemory.signedIn",
 				true,
 			);
+		});
+
+		it("emits signin_completed with api_key_minted=false when no key is provisioned", async () => {
+			exchangeCliCode.mockResolvedValueOnce({ token: "test-token" });
+			const state = await primeStateViaSignIn(service);
+			const uri = makeUri("/auth-callback", `code=abc123&state=${state}`);
+
+			const result = await service.handleAuthCallback(uri as never);
+
+			expect(result).toEqual({ success: true });
+			expect(track).toHaveBeenCalledWith("signin_completed", { api_key_minted: false });
 		});
 
 		it("persists the minted key's tenant as jolliUrl, not the sign-in origin", async () => {
@@ -731,6 +748,8 @@ describe("AuthService", () => {
 			// clearAuthCredentials removes authToken AND jolliApiKey in a single write.
 			expect(clearAuthCredentials).toHaveBeenCalledTimes(1);
 			expect(saveAuthCredentials).not.toHaveBeenCalled();
+			// JOLLI-1904 funnel.
+			expect(track).toHaveBeenCalledWith("signed_out");
 		});
 
 		it("should set signedIn context key to false", async () => {
@@ -750,6 +769,8 @@ describe("AuthService", () => {
 		it("should open browser with correct login URL", async () => {
 			await service.openSignInPage();
 
+			// JOLLI-1904 funnel: sign-in initiated.
+			expect(track).toHaveBeenCalledWith("signin_started", { trigger: "vscode" });
 			expect(openExternal).toHaveBeenCalledTimes(1);
 			expect(uriParse).toHaveBeenCalledTimes(1);
 			const parsed = uriParse.mock.calls[0]?.[0];

--- a/vscode/src/services/AuthService.ts
+++ b/vscode/src/services/AuthService.ts
@@ -25,6 +25,7 @@ import {
 import { exchangeCliCode } from "../../../cli/src/auth/CliExchange.js";
 import { getDeviceLabel } from "../../../cli/src/auth/DeviceLabel.js";
 import { loadConfig } from "../../../cli/src/core/SessionTracker.js";
+import { track } from "../../../cli/src/core/Telemetry.js";
 import type { JolliMemoryConfig } from "../../../cli/src/Types.js";
 import { log } from "../util/Logger.js";
 import { EXTENSION_ID, resolveUriScheme } from "../util/UriSchemeResolver.js";
@@ -278,6 +279,10 @@ export class AuthService {
 		} catch (err: unknown) {
 			log.warn("AuthService", "Failed to update signedIn context key: %s", err);
 		}
+		// JOLLI-1904 (funnel): the conversion event. `api_key_minted` mirrors
+		// IntelliJ — whether this sign-in provisioned a jolliApiKey. surface=vscode
+		// is auto-injected. No-op if telemetry is off.
+		track("signin_completed", { api_key_minted: credentials.jolliApiKey != null });
 		log.info("AuthService", "Sign-in successful");
 		return { success: true };
 	}
@@ -296,11 +301,15 @@ export class AuthService {
 			"jollimemory.signedIn",
 			false,
 		);
+		track("signed_out");
 		log.info("AuthService", "Signed out");
 	}
 
 	/** Opens the browser to the Jolli login page with a VSCode callback URI. */
 	async openSignInPage(): Promise<void> {
+		// JOLLI-1904 (funnel): sign-in initiated. `trigger` mirrors IntelliJ's
+		// surface-tagged value; surface=vscode is auto-injected. No-op if off.
+		track("signin_started", { trigger: "vscode" });
 		// Derive the callback scheme from the host IDE. `vscode.env.uriScheme`
 		// is unreliable here — most forks inherit upstream's "vscode" default
 		// for that API even though they register their own scheme at the OS

--- a/vscode/src/telemetry/UiTelemetry.test.ts
+++ b/vscode/src/telemetry/UiTelemetry.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Spy on track() but keep the real bucket() so we assert on real bucket labels.
+const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+vi.mock("../../../cli/src/core/Telemetry.js", async (importActual) => ({
+	...(await importActual<typeof import("../../../cli/src/core/Telemetry.js")>()),
+	track,
+}));
+
+import { trackMemoryCommitted } from "./UiTelemetry.js";
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("trackMemoryCommitted", () => {
+	it("emits memory_committed with bucketed counts + has_conversations=true", async () => {
+		await trackMemoryCommitted({
+			getFilesCount: () => 3,
+			getContextCount: () => 0,
+			listConversations: async () => [{}, {}],
+		});
+		expect(track).toHaveBeenCalledWith("memory_committed", {
+			files_bucket: "1-5",
+			has_conversations: true,
+			context_bucket: "0",
+		});
+	});
+
+	it("reports has_conversations=false when there are none", async () => {
+		await trackMemoryCommitted({
+			getFilesCount: () => 0,
+			getContextCount: () => 25,
+			listConversations: async () => [],
+		});
+		expect(track).toHaveBeenCalledWith("memory_committed", {
+			files_bucket: "0",
+			has_conversations: false,
+			context_bucket: "21-100",
+		});
+	});
+
+	it("never throws and does not emit when gathering fails", async () => {
+		await expect(
+			trackMemoryCommitted({
+				getFilesCount: () => {
+					throw new Error("snapshot unavailable");
+				},
+				getContextCount: () => 1,
+				listConversations: async () => [],
+			}),
+		).resolves.toBeUndefined();
+		expect(track).not.toHaveBeenCalled();
+	});
+});

--- a/vscode/src/telemetry/UiTelemetry.ts
+++ b/vscode/src/telemetry/UiTelemetry.ts
@@ -1,0 +1,40 @@
+/**
+ * UiTelemetry — thin, unit-testable helpers for VS Code click-layer telemetry
+ * (JOLLI-1904). The UI runs in-process (not via commander), so button clicks get
+ * no `command_invoked` fallback and must `track()` explicitly. Event names +
+ * prop shapes mirror the IntelliJ implementation so both surfaces aggregate
+ * together (`surface` is auto-injected at build time).
+ *
+ * Only emits that need real logic (async gathering, bucketing) live here; a
+ * trivial `track("name")` at a call site doesn't need a wrapper.
+ */
+import { bucket, track } from "../../../cli/src/core/Telemetry.js";
+
+/**
+ * `memory_committed` — the user committed a memory via the Commit button.
+ * Mirrors IntelliJ CurrentMemoryPanel: bucketed changed-file count, whether any
+ * active conversations exist, and bucketed context (plans) count. Counts go
+ * through `bucket()` (never raw, for privacy). Best-effort and never throws —
+ * telemetry must not disturb the commit. Gather the (async) conversation count
+ * off the click path so this never delays committing.
+ */
+export async function trackMemoryCommitted(deps: {
+	readonly getFilesCount: () => number;
+	readonly getContextCount: () => number;
+	readonly listConversations: () => Promise<readonly unknown[]>;
+}): Promise<void> {
+	try {
+		// All reads happen inside the try so a store snapshot / conversation read
+		// that throws degrades to "no event", never an error in the commit flow.
+		const files = deps.getFilesCount();
+		const context = deps.getContextCount();
+		const conversations = (await deps.listConversations()).length;
+		track("memory_committed", {
+			files_bucket: bucket(files),
+			has_conversations: conversations > 0,
+			context_bucket: bucket(context),
+		});
+	} catch {
+		// telemetry is best-effort — never surface an error into the commit flow
+	}
+}

--- a/vscode/src/views/CreatePrWebviewPanel.test.ts
+++ b/vscode/src/views/CreatePrWebviewPanel.test.ts
@@ -128,6 +128,12 @@ vi.mock("./BindingChooserWebviewPanel.js", () => ({
 	BindingChooserWebviewPanel: { openAndAwait: mocks.openAndAwait, dispose: vi.fn() },
 }));
 
+const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+vi.mock("../../../cli/src/core/Telemetry.js", async (importActual) => ({
+	...(await importActual<typeof import("../../../cli/src/core/Telemetry.js")>()),
+	track,
+}));
+
 import { CreatePrWebviewPanel } from "./CreatePrWebviewPanel.js";
 
 const uri = { fsPath: "/ext" } as never;
@@ -172,6 +178,14 @@ describe("CreatePrWebviewPanel", () => {
 		expect(mocks.handleCreatePr.mock.calls[0][0]).toBe("feat: x"); // title
 		expect(mocks.handleCreatePr.mock.calls[0][1]).toContain("B"); // wrapped body contains drafted bodyMarkdown
 		expect(mocks.handleCreatePr.mock.calls[0][4]).toBe("feature/x"); // branch arg
+	});
+
+	it("emits pr_created{action:'created'} on a successful create submit (JOLLI-1904)", async () => {
+		await CreatePrWebviewPanel.show({ fsPath: "/ext" } as never, resolve("/repo"), bridge, "main");
+		track.mockClear();
+		created[0].onMsg({ command: "createPr" });
+		await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+		expect(track).toHaveBeenCalledWith("pr_created", { action: "created" });
 	});
 
 	it("createPr: the post callback passed to handleCreatePr forwards messages to the webview", async () => {

--- a/vscode/src/views/CreatePrWebviewPanel.ts
+++ b/vscode/src/views/CreatePrWebviewPanel.ts
@@ -22,6 +22,7 @@ import * as nodePath from "node:path";
 import * as vscode from "vscode";
 import { isPathInside } from "../../../cli/src/core/PathUtils.js";
 import { wrapWithMarkers } from "../../../cli/src/core/PrDescription.js";
+import { track } from "../../../cli/src/core/Telemetry.js";
 import type { JolliMemoryBridge } from "../JolliMemoryBridge.js";
 import { pushBranchMemoriesToSpace } from "../services/LiveShareController.js";
 import { ShareBindingError } from "../services/JolliPushOrchestrator.js";
@@ -275,6 +276,8 @@ export class CreatePrWebviewPanel {
 					// Same webview message for both modes; the host is the source of
 					// truth for whether an open PR exists. Update pushes + syncs the
 					// draft into the existing PR; otherwise create a fresh one.
+					// Capture create-vs-update before the call (the vm may be rebuilt after).
+					const prAction = this.vm.existingPr ? "updated" : "created";
 					const outcome = this.vm.existingPr
 						? await handleUpdatePrWithPush(title, body, this.workspaceRoot, post, this.vm.branch)
 						: await handleCreatePr(title, body, this.workspaceRoot, post, this.vm.branch);
@@ -282,6 +285,8 @@ export class CreatePrWebviewPanel {
 					// prCreateBlockedCrossBranch — the webview has re-enabled its buttons
 					// and stays put (edit form kept open for a retry). Nothing more to do.
 					if (outcome === "succeeded") {
+						// JOLLI-1904: mirrors IntelliJ CreatePrPanel — pr_created{action}.
+						track("pr_created", { action: prAction });
 						// The full operation isn't done at PR-live: when signed in we then
 						// share the branch's memories to the user's Jolli Space (the pane's
 						// share notice promises this). The handler's mid-flight prStatus is

--- a/vscode/src/views/SettingsWebviewPanel.ts
+++ b/vscode/src/views/SettingsWebviewPanel.ts
@@ -635,6 +635,13 @@ export class SettingsWebviewPanel {
 
 		await saveConfigScoped(update, configDir);
 
+		// JOLLI-1904 (funnel): record an explicit AI-provider change, not every
+		// settings save. Mirrors IntelliJ ai_provider_selected { provider };
+		// surface=vscode is auto-injected.
+		if (settings.aiProvider !== this.resolveProvider(currentConfig)) {
+			track("ai_provider_selected", { provider: settings.aiProvider });
+		}
+
 		// Act on a global-instructions transition in EITHER direction: the
 		// undecided/disabled -> enabled transition writes the block; the
 		// enabled -> off transition removes it (the checkbox's "off" must

--- a/vscode/src/views/SidebarMessages.ts
+++ b/vscode/src/views/SidebarMessages.ts
@@ -550,7 +550,7 @@ export interface RepoChoice {
 
 export type SidebarOutboundMsg =
 	| { readonly type: "ready" }
-	| { readonly type: "tab:switched"; readonly tab: SidebarTab }
+	| { readonly type: "tab:switched"; readonly tab: SidebarTab; readonly userInitiated?: boolean }
 	| {
 			/**
 			 * Webview asks the host to materialize the breadcrumb selection
@@ -578,6 +578,7 @@ export type SidebarOutboundMsg =
 	| { readonly type: "kb:openFile"; readonly path: string }
 	| { readonly type: "kb:openMemory"; readonly commitHash: string }
 	| { readonly type: "kb:expandMemory"; readonly commitHash: string }
+	| { readonly type: "kb:memoryToggled"; readonly expanded: boolean }
 	| { readonly type: "kb:loadMore" }
 	| { readonly type: "kb:search"; readonly query: string }
 	| { readonly type: "kb:clearSearch" }

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -356,7 +356,7 @@ export function buildSidebarScript(): string {
   // "JOLLI MEMORY" title-bar Status icon (jollimemory.toggleStatus → the
   // 'status:toggle' inbound message) toggles the Status overlay open and
   // collapses back to Branch on a second click.
-  function switchTab(tab) {
+  function switchTab(tab, userInitiated) {
     if (state.activeTab === tab) return;
     const outgoing = tabContents[state.activeTab];
     if (outgoing) state.scrollTops[state.activeTab] = outgoing.scrollTop;
@@ -390,7 +390,11 @@ export function buildSidebarScript(): string {
         renderMemories();
       }
     }
-    vscode.postMessage({ type: 'tab:switched', tab: tab });
+    // userInitiated distinguishes a real view-switcher click (→ view_switched
+    // telemetry, matching IntelliJ's applyView) from the programmatic switches
+    // (init-restore, onboarding auto-land, breadcrumb context change) that must
+    // not emit. Only branch/kb map to an IntelliJ view; status has no analog.
+    vscode.postMessage({ type: 'tab:switched', tab: tab, userInitiated: !!userInitiated });
     // switchTab unconditionally reveals the target tab content. If the cold-start
     // card should own the viewport (e.g. init posts activeTab:'branch' after the
     // card was shown, or onboarding lands on 'status'), re-assert it so the card
@@ -415,7 +419,7 @@ export function buildSidebarScript(): string {
   // collapse — that behavior is reserved for the Status overlay).
   document.querySelectorAll('.view-tab[data-tab]').forEach(function(elBtn) {
     elBtn.addEventListener('click', function() {
-      switchTab(elBtn.getAttribute('data-tab'));
+      switchTab(elBtn.getAttribute('data-tab'), true);
     });
   });
 
@@ -1551,7 +1555,9 @@ export function buildSidebarScript(): string {
       state.backfillMode = 'offer';
       persist();
       applyBackfillCard();
-      switchTab('kb');
+      // User-driven (mirrors IntelliJ's "Open your Memory Bank" → applyView(BANK)),
+      // so this counts as a view_switched to the bank.
+      switchTab('kb', true);
     });
     return [
       bfHeader(r.generated + ' memor' + (r.generated === 1 ? 'y' : 'ies') + ' built from your history', null),
@@ -3407,6 +3413,10 @@ export function buildSidebarScript(): string {
       const toggleHash = memToggle.getAttribute('data-memory-toggle');
       state.memoriesExpanded[toggleHash] = !state.memoriesExpanded[toggleHash];
       persist();
+      // Report both directions (matches IntelliJ memory_expanded{expanded}). This
+      // is the user toggle; kb:expandMemory is only a lazy evidence fetch and
+      // can't stand in for it (it never fires on collapse or on a cache hit).
+      vscode.postMessage({ type: 'kb:memoryToggled', expanded: state.memoriesExpanded[toggleHash] });
       renderMemories();
       e.stopPropagation();
       return;

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
 	SidebarInboundMsg,
 	SidebarOutboundMsg,
@@ -64,6 +64,16 @@ vi.mock("vscode", () => ({
 			return mockWorkspaceFolders.length > 0 ? mockWorkspaceFolders : undefined;
 		},
 	},
+}));
+
+// Spy on track() (funnel telemetry, JOLLI-1904) but keep every other real
+// export — transitive code paths still call bucket()/flush helpers. Mocking
+// here also keeps `handleReady`'s toolwindow_opened emit from touching disk in
+// the many "ready" tests below.
+const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+vi.mock("../../../cli/src/core/Telemetry.js", async (importActual) => ({
+	...(await importActual<typeof import("../../../cli/src/core/Telemetry.js")>()),
+	track,
 }));
 
 // Stub ConversationDetailsPanel.show so happy-path branch:openConversation
@@ -135,6 +145,7 @@ describe("SidebarWebviewProvider", () => {
 	let executeCommand: ReturnType<typeof vi.fn>;
 
 	beforeEach(() => {
+		track.mockClear();
 		executeCommand = vi.fn().mockResolvedValue(undefined);
 		provider = new SidebarWebviewProvider({
 			executeCommand: executeCommand as never,
@@ -190,6 +201,160 @@ describe("SidebarWebviewProvider", () => {
 			command: "jollimemory.openSettings",
 		});
 		expect(executeCommand).toHaveBeenCalledWith("jollimemory.openSettings");
+	});
+
+	// ── JOLLI-1904 funnel telemetry (mirrors IntelliJ event names + props) ──
+
+	it("emits toolwindow_opened {view:'current'} once per ready cycle", async () => {
+		const view = makeMockView();
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({ type: "ready" });
+		await flushReady();
+		expect(track).toHaveBeenCalledWith("toolwindow_opened", { view: "current" });
+	});
+
+	it("maps a user tab switch to view_switched: branch→current, kb→bank", () => {
+		const view = makeMockView();
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({ type: "tab:switched", tab: "branch", userInitiated: true });
+		expect(track).toHaveBeenCalledWith("view_switched", { view: "current" });
+		track.mockClear();
+		view.webview.triggerMessage({ type: "tab:switched", tab: "kb", userInitiated: true });
+		expect(track).toHaveBeenCalledWith("view_switched", { view: "bank" });
+	});
+
+	it("never emits view_switched for programmatic switches or the Status overlay", () => {
+		const view = makeMockView();
+		provider.resolveWebviewView(view as unknown as never);
+		// Programmatic switch (init-restore, breadcrumb, onboarding) — no flag.
+		view.webview.triggerMessage({ type: "tab:switched", tab: "kb" });
+		// Status overlay has no IntelliJ view, even when user-initiated.
+		view.webview.triggerMessage({ type: "tab:switched", tab: "status", userInitiated: true });
+		expect(track).not.toHaveBeenCalledWith("view_switched", expect.anything());
+	});
+
+	it("emits memory_expanded with the toggled state in both directions", () => {
+		const view = makeMockView();
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({ type: "kb:memoryToggled", expanded: true });
+		expect(track).toHaveBeenCalledWith("memory_expanded", { expanded: true });
+		track.mockClear();
+		view.webview.triggerMessage({ type: "kb:memoryToggled", expanded: false });
+		expect(track).toHaveBeenCalledWith("memory_expanded", { expanded: false });
+	});
+
+	// ── Phase 4: memory_item_opened (committed-memory evidence rows) ──
+	// item_type values match IntelliJ's CommitsPanel.trackItemOpened verbatim.
+
+	it.each([
+		[
+			"kb:openEvidenceNote",
+			{ noteId: "n1", title: "N", sourceRepoName: "r", sourceRemoteUrl: null },
+			{ item_type: "note" },
+		],
+		[
+			"kb:openEvidencePlan",
+			{ planId: "p1", title: "P", sourceRepoName: "r", sourceRemoteUrl: null },
+			{ item_type: "plan" },
+		],
+		[
+			"kb:openEvidenceReference",
+			{ archivedKey: "linear:X-1-ab12cd34", source: "linear", sourceRepoName: null, sourceRemoteUrl: null },
+			{ item_type: "reference" },
+		],
+	])("emits memory_item_opened from %s", (type, fields, expected) => {
+		const view = makeMockView();
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({ type, ...fields } as never);
+		expect(track).toHaveBeenCalledWith("memory_item_opened", expected);
+	});
+
+	it("emits memory_item_opened{conversation, render:stored, source} for evidence conversations", () => {
+		const view = makeMockView();
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({
+			type: "kb:openEvidenceConversation",
+			commitHash: "c1",
+			sessionId: "s1",
+			source: "claude",
+			title: "Chat",
+		});
+		expect(track).toHaveBeenCalledWith("memory_item_opened", {
+			item_type: "conversation",
+			render: "stored",
+			source: "claude",
+		});
+	});
+
+	it("does NOT emit memory_item_opened when an evidence reference source is rejected", () => {
+		const view = makeMockView();
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({
+			type: "kb:openEvidenceReference",
+			archivedKey: "bogus:1",
+			source: "not-a-source",
+			sourceRepoName: null,
+			sourceRemoteUrl: null,
+		} as never);
+		expect(track).not.toHaveBeenCalledWith("memory_item_opened", expect.anything());
+	});
+
+	// ── Phase 4: memory_pinned / memory_unpinned (kind → IntelliJ plural) ──
+
+	describe("pin/unpin telemetry", () => {
+		beforeEach(() => {
+			mockWorkspaceFolders.length = 0;
+			mockWorkspaceFolders.push({ uri: { fsPath: "/abs/proj" } });
+		});
+		afterEach(() => {
+			mockWorkspaceFolders.length = 0;
+		});
+
+		function makePinProvider(): SidebarWebviewProvider {
+			return new SidebarWebviewProvider({
+				executeCommand: vi.fn().mockResolvedValue(undefined) as never,
+				getInitialState: () => ({
+					enabled: true,
+					authenticated: false,
+					activeTab: "branch",
+					kbMode: "folders",
+					branchName: "main",
+					detached: false,
+					currentRepoName: "myrepo",
+				}),
+				extensionUri: mockExtensionUri as unknown as never,
+				pinStore: {
+					addPin: vi.fn().mockResolvedValue(undefined),
+					removePin: vi.fn().mockResolvedValue(undefined),
+					listPins: vi.fn().mockResolvedValue([]),
+				} as never,
+			});
+		}
+
+		it("maps a conversation pin to memory_pinned{kind:'conversations'}", () => {
+			const p = makePinProvider();
+			const view = makeMockView();
+			p.resolveWebviewView(view as unknown as never);
+			view.webview.triggerMessage({ type: "branch:pin", kind: "conversation", id: "s1", title: "T" });
+			expect(track).toHaveBeenCalledWith("memory_pinned", { kind: "conversations" });
+		});
+
+		it("maps a memory unpin to memory_unpinned{kind:'memories'}", () => {
+			const p = makePinProvider();
+			const view = makeMockView();
+			p.resolveWebviewView(view as unknown as never);
+			view.webview.triggerMessage({ type: "branch:unpin", kind: "memory", id: "abc123" });
+			expect(track).toHaveBeenCalledWith("memory_unpinned", { kind: "memories" });
+		});
+
+		it("does not emit when the pin store is absent (no projectDir/repo/store guard)", () => {
+			// The default `provider` has no pinStore — the guard must skip both the
+			// write and the telemetry so we never claim a pin that never happened.
+			const view = makeMockView();
+			provider.resolveWebviewView(view as unknown as never);
+			view.webview.triggerMessage({ type: "branch:pin", kind: "plan", id: "p1", title: "T" });
+			expect(track).not.toHaveBeenCalledWith("memory_pinned", expect.anything());
+		});
 	});
 
 	it("pushContextRelevanceToSidebar posts to the sidebar view ONLY — never to broadcast targets", () => {

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -3055,6 +3055,36 @@ describe("SidebarWebviewProvider", () => {
 		});
 	}
 
+	it("emits repo_switched{is_foreign} on a breadcrumb repo pick (JOLLI-1904)", () => {
+		const view = makeMockView();
+		const provider = makeSelectionProvider({
+			listRepos: vi.fn().mockReturnValue([
+				{ repoName: "workspace-repo", isCurrent: true },
+				{ repoName: "other-repo", isCurrent: false, remoteUrl: "git@x:y" },
+			]),
+			listBranches: vi.fn().mockReturnValue(["main"]),
+			currentRepoName: "workspace-repo",
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		track.mockClear();
+		view.webview.triggerMessage({ type: "selection:request", repoName: "other-repo" });
+		expect(track).toHaveBeenCalledWith("repo_switched", { is_foreign: true });
+	});
+
+	it("emits branch_switched{is_foreign} on a breadcrumb branch pick (JOLLI-1904)", () => {
+		const view = makeMockView();
+		const provider = makeSelectionProvider({
+			listRepos: vi.fn().mockReturnValue([{ repoName: "workspace-repo", isCurrent: true }]),
+			listBranches: vi.fn().mockReturnValue(["main", "feature-x"]),
+			currentRepoName: "workspace-repo",
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		track.mockClear();
+		// Different from the workspace HEAD ("main") → foreign.
+		view.webview.triggerMessage({ type: "selection:request", branchName: "feature-x" });
+		expect(track).toHaveBeenCalledWith("branch_switched", { is_foreign: true });
+	});
+
 	it("pushes selection:repos and selection:branches for the current repo on ready", async () => {
 		const view = makeMockView();
 		const listRepos = vi.fn().mockReturnValue([

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -23,6 +23,7 @@ import { isTranscriptSource } from "../../../cli/src/Types.js";
 import type { ActiveConversationItem } from "../../../cli/src/core/ActiveSessionAggregator.js";
 import type { ActiveSessionsProvider } from "../services/ActiveSessionsProvider.js";
 import type { CommitFileInfo } from "../Types.js";
+import { track } from "../../../cli/src/core/Telemetry.js";
 import { flushExtensionTelemetry } from "../TelemetryActivation.js";
 import type { IngestPhase } from "../stores/StatusStore.js";
 import { log } from "../util/Logger.js";
@@ -59,6 +60,21 @@ import { sliceStartTime } from "./TranscriptSliceOrder.js";
  * committed-reference rows become un-openable.
  */
 const REFERENCE_SOURCE_IDS: ReadonlySet<string> = new Set<string>(Object.keys(SOURCE_META));
+
+/**
+ * JOLLI-1904 memory_pinned/memory_unpinned `kind` alignment. VS Code's PinStore
+ * uses singular kinds; IntelliJ's uses the plural form of the same five. Both
+ * surfaces must emit the SAME `kind` value or the cross-surface metric can't be
+ * joined, so we translate to IntelliJ's plural vocabulary at the telemetry edge
+ * (the on-disk PinStore keys are untouched).
+ */
+const PIN_KIND_TELEMETRY: Readonly<Record<PinKind, string>> = {
+	conversation: "conversations",
+	plan: "plans",
+	note: "notes",
+	memory: "memories",
+	reference: "references",
+};
 
 /**
  * Built-in VS Code commands the sidebar webview is allowed to dispatch, in
@@ -693,6 +709,12 @@ export class SidebarWebviewProvider
 			// fall through
 		}
 		this.postMessage({ type: "init", state: this.deps.getInitialState() });
+		// JOLLI-1904 (VS Code funnel telemetry). Hidden webview views reload — and
+		// re-post `ready` — each time the sidebar is revealed, so this fires once
+		// per open, matching IntelliJ's createFullContent → toolwindow_opened. The
+		// view is hardcoded "current" to mirror IntelliJ verbatim (it always opens
+		// on the Current view); `view_switched` reports later user navigation.
+		track("toolwindow_opened", { view: "current" });
 		// Trigger lazy-loaded data sources on first visibility. Idempotent —
 		// `firstVisibleFired` guards against re-firing on view re-resolves
 		// (e.g. user collapses + reopens the sidebar).
@@ -734,6 +756,22 @@ export class SidebarWebviewProvider
 		switch (msg.type) {
 			case "ready":
 				void this.handleReady();
+				return;
+			case "tab:switched": {
+				// JOLLI-1904 view_switched: only a real view-switcher click emits
+				// (userInitiated), matching IntelliJ's applyView. VS Code's two
+				// memory views map to IntelliJ's discriminator values: Current
+				// Branch → "current", Memory Bank → "bank". The Status overlay has
+				// no IntelliJ analog, so it is deliberately not reported.
+				if (msg.userInitiated) {
+					const view = msg.tab === "branch" ? "current" : msg.tab === "kb" ? "bank" : undefined;
+					if (view) track("view_switched", { view });
+				}
+				return;
+			}
+			case "kb:memoryToggled":
+				// JOLLI-1904 memory_expanded — both directions, mirroring IntelliJ.
+				track("memory_expanded", { expanded: msg.expanded });
 				return;
 			case "command":
 				// Defense-in-depth (confused-deputy): the webview can only ask the
@@ -791,6 +829,10 @@ export class SidebarWebviewProvider
 				void this.pushMemoryEvidence(msg.commitHash);
 				return;
 			case "kb:openEvidenceNote":
+				// JOLLI-1904 memory_item_opened — an item inside a committed memory
+				// (mirrors IntelliJ CommitsPanel.trackItemOpened). item_type matches
+				// IntelliJ's singular vocabulary verbatim.
+				track("memory_item_opened", { item_type: "note" });
 				// Committed-memory note evidence row. Routes to the orphan-only
 				// previewNote (the same command the detail panel uses for committed
 				// notes), passing the memory's provenance so a foreign-repo note
@@ -805,6 +847,7 @@ export class SidebarWebviewProvider
 				);
 				return;
 			case "kb:openEvidencePlan":
+				track("memory_item_opened", { item_type: "plan" });
 				// Foreign-repo committed-memory plan evidence row. Routes to
 				// previewCommittedPlan, passing the memory's provenance so the plan
 				// body reads from the owning repo's FolderStorage. The live
@@ -830,6 +873,7 @@ export class SidebarWebviewProvider
 					});
 					return;
 				}
+				track("memory_item_opened", { item_type: "reference" });
 				void this.deps.executeCommand(
 					"jollimemory.previewCommittedReference",
 					msg.archivedKey,
@@ -991,6 +1035,11 @@ export class SidebarWebviewProvider
 					);
 					return;
 				}
+				// JOLLI-1904 memory_item_opened. Committed evidence is always the
+				// archived snapshot, so render is "stored" (mirrors IntelliJ's
+				// stored-conversation branch, which also carries render + source).
+				// TranscriptSource ids are already lowercase, matching IntelliJ.
+				track("memory_item_opened", { item_type: "conversation", render: "stored", source: msg.source });
 				void this.openEvidenceConversation(msg.commitHash, msg.sessionId, msg.source, msg.title);
 				return;
 			case "branch:discardFile":
@@ -1074,6 +1123,10 @@ export class SidebarWebviewProvider
 					this.selectedBranchName ?? this.deps.branchWatcher?.current().name ?? state.branchName;
 				const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 				if (projectDir && repo && this.deps.pinStore) {
+					// JOLLI-1904: fire at the pin action (matches IntelliJ PlansPanel /
+					// CommitsPanel, which track before the async persist). kind is
+					// translated to IntelliJ's plural vocabulary for cross-surface joins.
+					track("memory_pinned", { kind: PIN_KIND_TELEMETRY[msg.kind] });
 					void this.deps.pinStore
 						.addPin(projectDir, repo, branch, {
 							kind: msg.kind,
@@ -1113,6 +1166,9 @@ export class SidebarWebviewProvider
 					this.selectedBranchName ?? this.deps.branchWatcher?.current().name ?? state.branchName;
 				const projectDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 				if (projectDir && repo && this.deps.pinStore) {
+					// JOLLI-1904: mirror IntelliJ PinnedPanel — track the unpin action,
+					// kind translated to the shared plural vocabulary.
+					track("memory_unpinned", { kind: PIN_KIND_TELEMETRY[msg.kind] });
 					void this.deps.pinStore
 						.removePin(projectDir, repo, branch, msg.kind, msg.id)
 						.then(() => this.pushPins())

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -1296,6 +1296,9 @@ export class SidebarWebviewProvider
 			const target = repos.find((r) => r.repoName === repoName);
 			if (!target) return;
 			this.selectedRepoName = target.repoName;
+			// JOLLI-1904: user switched repo in the breadcrumb (mirrors IntelliJ
+			// BreadcrumbHeaderPanel.onRepoSelected). is_foreign = not the workspace repo.
+			track("repo_switched", { is_foreign: !target.isCurrent });
 			const branches = this.deps.selection.listBranches(target.repoName);
 			this.selectedBranchName = branches[0];
 			this.postMessage({
@@ -1313,6 +1316,12 @@ export class SidebarWebviewProvider
 		}
 		if (branchName) {
 			this.selectedBranchName = branchName;
+			// JOLLI-1904: user switched branch in the breadcrumb (mirrors IntelliJ
+			// onBranchSelected). is_foreign = foreign repo, or a branch other than HEAD.
+			const state = this.deps.getInitialState();
+			const repoForeign = this.selectedRepoName != null && this.selectedRepoName !== state.currentRepoName;
+			const currentBranch = this.deps.branchWatcher?.current().name ?? state.branchName;
+			track("branch_switched", { is_foreign: repoForeign || branchName !== currentBranch });
 			this.postMessage({
 				type: "selection:set",
 				repoName: this.selectedRepoName,


### PR DESCRIPTION
## Summary

Telemetry hardening across all three surfaces (CLI, VS Code, IntelliJ). Production dashboards showed a set of registered events sitting at **0** — some because events were being dropped before delivery, some because the instrumentation was never written on a given surface, and some because the events were semantically wrong (spurious errors, missing failure signals). This branch fixes delivery reliability, corrects the instrumentation, and ports the IntelliJ tool-window engagement events to VS Code.

All event names stay on the append-only allowlist and remain in lockstep between `cli/src/core/TelemetryEvents.ts` and the IntelliJ Kotlin port. `surface` is the only discriminator between IDEs — reused event names, not per-surface names.

## What changed

### Delivery reliability (events were being lost)
- **JOLLI-1966** — every event carries a client-minted `event_id` (idempotency key) so retried/duplicated deliveries can be de-duped downstream.
- **JOLLI-1954 / 1955 / 1956** — flush the buffered NDJSON queue at the points where the process was exiting before it drained: the AI-agent Stop hook, CLI command exit, and a UI-decoupled background flush in VS Code + IntelliJ.
- **JOLLI-1957** — document and lock the telemetry-buffer `cwd` contract so buffered events always resolve to the right per-repo queue.

### Instrumentation quality (events were wrong or missing)
- **JOLLI-1959** — per-tool MCP telemetry: `command_invoked` now records which MCP tool the AI actually called.
- **JOLLI-1960** — emit `command_invoked{ok:false}` on command failure (previously only successes were recorded).
- **JOLLI-1962** — stop raising `error_occurred` for benign ingest outcomes (CREDENTIAL_MISSING, NO_PENDING, etc.); these are reclassified as non-errors.
- **JOLLI-1961** — standardize `error_occurred` on a typed, content-free schema `{ where, code, source?, retryable? }` (never a message/stack/path).
- **JOLLI-1964** — flag idle no-op ingests (`idle:true` when `ingested==0`) so real-ingest metrics can filter them out.
- **JOLLI-1963** — `client_activated` counts new + upgrade installs that actually launched.
- **JOLLI-1958** — document each event's discriminator + metric properties in the registry (and regenerate TELEMETRY.md).

### VS Code UI engagement telemetry (JOLLI-1904 — was never implemented on VS Code)
The IDE tool-window engagement events existed only in IntelliJ. VS Code UI runs in-process (not through commander), so button clicks get **no `command_invoked` fallback** and must `track()` explicitly. Ported in four phases, reusing IntelliJ's event names + prop shapes verbatim:
- **Funnel:** `signin_started` / `signin_completed` / `signed_out`, `ai_provider_selected`, `surface_enabled` / `surface_disabled`.
- **Engagement:** `recall_prompt_copied`, `memory_committed` (bucketed file/context counts + `has_conversations`), `toolwindow_opened`, `view_switched` (branch→`current`, kb→`bank`), `memory_expanded` (both directions), `memory_item_opened` (evidence rows), `memory_pinned` / `memory_unpinned` (VS Code's singular `PinKind` mapped to IntelliJ's plural `kind` vocabulary for cross-surface joins).
- **`session_resumed` intentionally skipped** — VS Code has no terminal-based conversation-resume feature (IntelliJ's `TerminalUtils.resumeSession`), so there is no honest interaction to map it onto.

## Reviewer notes
- No registry additions — all event names were already registered; this branch only wires up emitters and fixes emit conditions.
- `memory_committed`'s registry description was corrected (it does carry props, not "none") on both the TS and Kotlin sides.
- `npm run all` passes (build → lint → test, CLI coverage floor held). New VS Code telemetry paths have unit tests asserting exact event names + props.
