### PR TITLE
Add cold-start back-fill offer to the bare jolli front door

### DIFF
--- a/cli/src/backfill/BackfillEngine.test.ts
+++ b/cli/src/backfill/BackfillEngine.test.ts
@@ -157,6 +157,84 @@ describe("runBackfill", () => {
 		expect(vi.mocked(launchWorker)).not.toHaveBeenCalled();
 	});
 
+	it("fires onCommitStart before generating each commit (index is 1-based, carries the subject)", async () => {
+		const { buildCommitTargetIndex } = await import("./CommitTargetIndex.js");
+		vi.mocked(buildCommitTargetIndex).mockResolvedValue({
+			commitMeta: new Map([["c1", { ts: 1, subject: "First subject" }]]),
+			commitFiles: new Map(),
+			fileToCommits: new Map(),
+			baseToCommits: new Map(),
+		} as never);
+		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map([["c1", attrFor("c1")]]), skipped: [] });
+		const starts: Array<[number, number, string, string | undefined]> = [];
+		let startedBeforeGenerate = false;
+		vi.mocked(generateSummary).mockImplementation(async () => {
+			startedBeforeGenerate = starts.length === 1; // onCommitStart ran before the LLM call
+			return summaryResult as never;
+		});
+
+		await runBackfill({
+			cwd: CWD,
+			hashes: ["c1"],
+			onCommitStart: (index, total, hash, subject) => starts.push([index, total, hash, subject]),
+		});
+
+		expect(starts).toEqual([[1, 1, "c1", "First subject"]]);
+		expect(startedBeforeGenerate).toBe(true);
+	});
+
+	it("does not fire onCommitStart in dry-run (no generation to wait on)", async () => {
+		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map([["c1", attrFor("c1")]]), skipped: [] });
+		const onCommitStart = vi.fn();
+		await runBackfill({ cwd: CWD, hashes: ["c1"], dryRun: true, onCommitStart });
+		expect(onCommitStart).not.toHaveBeenCalled();
+	});
+
+	it("an already-aborted signal stops before any commit is generated", async () => {
+		vi.mocked(attributeCommits).mockReturnValue({
+			attributed: new Map([
+				["c1", attrFor("c1")],
+				["c2", attrFor("c2")],
+			]),
+			skipped: [],
+		});
+		const controller = new AbortController();
+		controller.abort();
+
+		const report = await runBackfill({ cwd: CWD, hashes: ["c1", "c2"], signal: controller.signal });
+
+		expect(report.generated).toBe(0);
+		expect(vi.mocked(generateSummary)).not.toHaveBeenCalled();
+		// Nothing generated → no ingest for the batch.
+		expect(vi.mocked(enqueueIngestOperation)).not.toHaveBeenCalled();
+		expect(vi.mocked(launchWorker)).not.toHaveBeenCalled();
+	});
+
+	it("aborting after a commit stops at the boundary (rest skipped) and still ingests what was built", async () => {
+		vi.mocked(attributeCommits).mockReturnValue({
+			attributed: new Map([
+				["c1", attrFor("c1")],
+				["c2", attrFor("c2")],
+			]),
+			skipped: [],
+		});
+		const controller = new AbortController();
+		// Abort as soon as the first commit completes — the boundary check then
+		// stops the loop before the second commit starts.
+		const report = await runBackfill({
+			cwd: CWD,
+			hashes: ["c1", "c2"],
+			signal: controller.signal,
+			onProgress: () => controller.abort(),
+		});
+
+		expect(report.generated).toBe(1);
+		expect(vi.mocked(generateSummary)).toHaveBeenCalledTimes(1);
+		// The one generated commit still triggers exactly one repo-wide ingest.
+		expect(vi.mocked(enqueueIngestOperation)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(launchWorker)).toHaveBeenCalledTimes(1);
+	});
+
 	it("skips commits that already have a summary", async () => {
 		vi.mocked(getIndexEntryMap).mockResolvedValue(new Map([["c1", {} as never]]));
 		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map(), skipped: [] });

--- a/cli/src/backfill/BackfillEngine.ts
+++ b/cli/src/backfill/BackfillEngine.ts
@@ -114,6 +114,23 @@ export interface BackfillOptions {
 	readonly projectsRoot?: string;
 	/** Progress callback fired after each commit is processed. */
 	readonly onProgress?: (done: number, total: number, outcome: BackfillOutcome) => void;
+	/**
+	 * Fired right BEFORE a commit's summary is generated (before its LLM call),
+	 * unlike `onProgress` which fires after. Lets a UI show "now working on commit
+	 * N/total" the instant that commit's (potentially slow) generation starts,
+	 * instead of leaving the screen frozen until the first commit completes.
+	 * `index` is 1-based over the commits that lack a summary.
+	 */
+	readonly onCommitStart?: (index: number, total: number, hash: string, subject?: string) => void;
+	/**
+	 * Cooperative cancellation. Checked at each commit boundary (before starting a
+	 * commit's LLM call), so an abort stops the loop cleanly between commits — the
+	 * commit in flight always finishes and stores, and the loop never leaves a
+	 * half-written summary. Already-generated commits stay on the orphan branch, so
+	 * a re-run resumes with only the still-missing commits. Used by the guided front
+	 * door's Ctrl-C handler to make a long back-fill interruptible + resumable.
+	 */
+	readonly signal?: AbortSignal;
 }
 
 /** Returns the repo's worktree roots (for scoping transcripts by cwd). */
@@ -216,7 +233,16 @@ async function generateAndStore(
  * failure — per-commit errors become `error` outcomes so a batch always finishes.
  */
 export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport> {
-	const { cwd, hashes, dryRun = false, minTier = DEFAULT_BACKFILL_TIER, projectsRoot, onProgress } = opts;
+	const {
+		cwd,
+		hashes,
+		dryRun = false,
+		minTier = DEFAULT_BACKFILL_TIER,
+		projectsRoot,
+		onProgress,
+		onCommitStart,
+		signal,
+	} = opts;
 	const outcomes: BackfillOutcome[] = [];
 
 	log.info("Back-fill start: cwd=%s candidates=%d dryRun=%s minTier=%s", cwd, hashes.length, dryRun, minTier);
@@ -273,14 +299,25 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
 
 	let done = 0;
 	for (const hash of missing) {
+		// Cooperative cancellation at the commit boundary: never mid-LLM. The commit
+		// already generated is stored; we simply stop before starting the next one.
+		// A re-run drops already-summarized commits (step 1) and resumes the rest.
+		if (signal?.aborted) {
+			log.info("Back-fill aborted at %d/%d commits (signal)", done, missing.length);
+			break;
+		}
 		// `null` attribution → diff-only summary (no conversation confidently found),
-		// mirroring the live pipeline's no-session path. 宁缺毋滥 only blocks *attaching*
-		// an unsure conversation; every own-commit still gets at least a diff summary.
+		// mirroring the live pipeline's no-session path. The "better none than a wrong
+		// one" rule only blocks *attaching* an unsure conversation; every own-commit
+		// still gets at least a diff summary.
 		const attr = attributed.get(hash) ?? null;
 		const method = attr?.method ?? "diff-only";
 		// Subject is already in the target index (no extra git call) — carry it so
 		// progress UIs can show the commit's one-line message instead of a bare hash.
 		const subject = index.commitMeta.get(hash)?.subject;
+		// Announce the commit BEFORE its (slow) generation so a UI isn't frozen during
+		// the first commit's LLM call. Skipped on dry-run (no generation to wait on).
+		if (!dryRun) onCommitStart?.(done + 1, missing.length, hash, subject);
 		let outcome: BackfillOutcome;
 		if (dryRun) {
 			outcome = {

--- a/cli/src/backfill/ColdStart.ts
+++ b/cli/src/backfill/ColdStart.ts
@@ -1,0 +1,25 @@
+/**
+ * Cold-start scope constants — the single source of truth for "which historical
+ * commits does the cold-start back-fill offer".
+ *
+ * Shared by every surface that computes cold-start signals or renders the offer:
+ * the CLI guided front door (`BackfillFrontDoorStep`), the VS Code sidebar card,
+ * and the Settings panel all import these so the window + cap can never drift
+ * between them. Lives in `cli/src/backfill/` (not the VS Code layer) because the
+ * CLI front door is now a first-class consumer; the VS Code `BackfillListRenderer`
+ * re-exports them for its existing importers.
+ */
+
+/**
+ * Time window (ms) for the cold-start offer: only own commits authored within this
+ * span of the newest own commit are offered. 30 days — recent enough that the user
+ * still remembers the work, short enough to keep the list and the LLM cost bounded.
+ */
+export const COLD_START_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Max commits the cold-start offer lists. A larger local backlog is not shown in
+ * the guided front door / sidebar card — the surplus is reached via `jolli backfill`
+ * (CLI) or the Settings "manage all" link (VS Code).
+ */
+export const COLD_START_CAP = 10;

--- a/cli/src/commands/BackfillFrontDoorStep.test.ts
+++ b/cli/src/commands/BackfillFrontDoorStep.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BackfillReport, MissingCommitInfo } from "../backfill/BackfillEngine.js";
+import { runBackfillFrontDoorStep } from "./BackfillFrontDoorStep.js";
+
+const h = vi.hoisted(() => ({
+	loadConfig: vi.fn(),
+	resolveLlmCredentialSource: vi.fn(),
+	readRepoProfile: vi.fn(),
+	updateRepoProfile: vi.fn(),
+	listMissingCommits: vi.fn(),
+	repoHasAnyMemory: vi.fn(),
+	runBackfill: vi.fn(),
+	promptText: vi.fn(),
+}));
+
+vi.mock("../core/SessionTracker.js", () => ({ loadConfig: h.loadConfig }));
+vi.mock("../core/LlmClient.js", () => ({ resolveLlmCredentialSource: h.resolveLlmCredentialSource }));
+vi.mock("../core/RepoProfile.js", () => ({
+	readRepoProfile: h.readRepoProfile,
+	updateRepoProfile: h.updateRepoProfile,
+}));
+vi.mock("../backfill/BackfillEngine.js", () => ({
+	listMissingCommits: h.listMissingCommits,
+	repoHasAnyMemory: h.repoHasAnyMemory,
+	runBackfill: h.runBackfill,
+}));
+vi.mock("./CliUtils.js", () => ({ promptText: h.promptText }));
+
+const CWD = "/repo";
+
+function commit(hash: string, subject: string, ts = 0): MissingCommitInfo {
+	return { commitHash: hash, subject, ts };
+}
+
+function report(over: Partial<BackfillReport> = {}): BackfillReport {
+	return { total: 0, generated: 0, skipped: 0, errors: 0, outcomes: [], ...over };
+}
+
+describe("runBackfillFrontDoorStep", () => {
+	let logSpy: ReturnType<typeof vi.spyOn>;
+	let stdoutSpy: ReturnType<typeof vi.spyOn>;
+	let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+	const loggedText = (): string => logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+		// Defaults for the happy path; individual tests override.
+		h.loadConfig.mockResolvedValue({ apiKey: "sk-ant" });
+		h.resolveLlmCredentialSource.mockReturnValue("anthropic");
+		h.readRepoProfile.mockResolvedValue({});
+		h.repoHasAnyMemory.mockResolvedValue(true);
+		h.listMissingCommits.mockResolvedValue([commit("a1b2c3d4", "Add branch-match tier")]);
+		h.runBackfill.mockResolvedValue(report({ total: 1, generated: 1 }));
+		h.promptText.mockResolvedValue(""); // Enter → yes
+	});
+
+	afterEach(() => {
+		logSpy.mockRestore();
+		stdoutSpy.mockRestore();
+		stderrSpy.mockRestore();
+	});
+
+	it("stays silent and offers nothing when there is no LLM credential", async () => {
+		h.resolveLlmCredentialSource.mockReturnValue(null);
+		await runBackfillFrontDoorStep(CWD);
+		expect(h.listMissingCommits).not.toHaveBeenCalled();
+		expect(h.promptText).not.toHaveBeenCalled();
+	});
+
+	it("does not offer when the repo was permanently dismissed", async () => {
+		h.readRepoProfile.mockResolvedValue({ backfillDismissed: true });
+		await runBackfillFrontDoorStep(CWD);
+		expect(h.listMissingCommits).not.toHaveBeenCalled();
+		expect(h.promptText).not.toHaveBeenCalled();
+	});
+
+	it("does not prompt when there are no missing commits", async () => {
+		h.listMissingCommits.mockResolvedValue([]);
+		await runBackfillFrontDoorStep(CWD);
+		expect(h.repoHasAnyMemory).not.toHaveBeenCalled();
+		expect(h.promptText).not.toHaveBeenCalled();
+	});
+
+	it("shows the empty-repo headline and the commit list", async () => {
+		h.repoHasAnyMemory.mockResolvedValue(false);
+		h.listMissingCommits.mockResolvedValue([commit("a1b2c3d4", "Add tier"), commit("e5f6a7b8", "Fix worker")]);
+		h.promptText.mockResolvedValue("n"); // don't actually build
+		await runBackfillFrontDoorStep(CWD);
+		const out = loggedText();
+		expect(out).toContain("no memories yet");
+		expect(out).toContain("a1b2c3d");
+		expect(out).toContain("Add tier");
+		expect(out).toContain("e5f6a7b");
+	});
+
+	it("shows the gaps headline with the missing count", async () => {
+		h.repoHasAnyMemory.mockResolvedValue(true);
+		h.listMissingCommits.mockResolvedValue([commit("a1b2c3d4", "One"), commit("e5f6a7b8", "Two")]);
+		h.promptText.mockResolvedValue("n");
+		await runBackfillFrontDoorStep(CWD);
+		const out = loggedText();
+		expect(out).toContain("2 commits from the last month don't have a memory yet");
+	});
+
+	it("uses singular wording in the gaps headline for a single missing commit", async () => {
+		h.repoHasAnyMemory.mockResolvedValue(true);
+		h.listMissingCommits.mockResolvedValue([commit("a1b2c3d4", "Only one")]);
+		h.promptText.mockResolvedValue("n");
+		await runBackfillFrontDoorStep(CWD);
+		expect(loggedText()).toContain("1 commit from the last month doesn't have a memory yet");
+	});
+
+	it("appends a cap note when the list is capped at COLD_START_CAP", async () => {
+		h.listMissingCommits.mockResolvedValue(Array.from({ length: 10 }, (_, i) => commit(`hash${i}xxx`, `s${i}`)));
+		h.promptText.mockResolvedValue("n");
+		await runBackfillFrontDoorStep(CWD);
+		expect(loggedText()).toContain("showing the 10 most recent");
+	});
+
+	it("builds with progress and reports success when the user accepts", async () => {
+		h.listMissingCommits.mockResolvedValue([commit("a1b2c3d4", "Add tier"), commit("e5f6a7b8", "Fix worker")]);
+		h.promptText.mockResolvedValue("y");
+		h.runBackfill.mockImplementation(async (opts) => {
+			opts.onCommitStart?.(1, 2, "a1b2c3d4", "Add tier");
+			opts.onCommitStart?.(2, 2, "e5f6a7b8", "Fix worker");
+			return report({ total: 2, generated: 2 });
+		});
+		await runBackfillFrontDoorStep(CWD);
+		expect(h.runBackfill).toHaveBeenCalledTimes(1);
+		expect(h.runBackfill.mock.calls[0][0].hashes).toEqual(["a1b2c3d4", "e5f6a7b8"]);
+		// The AbortSignal must actually be threaded into the engine — otherwise Ctrl-C
+		// could not cancel a real run even though the local handler fires.
+		expect(h.runBackfill.mock.calls[0][0].signal).toBeInstanceOf(AbortSignal);
+		// Each commit is its own persistent line (not an in-place rewrite): both survive.
+		expect(loggedText()).toContain("1/2  Add tier");
+		expect(loggedText()).toContain("2/2  Fix worker");
+		expect(loggedText()).toContain("Built 2 memories from your history");
+	});
+
+	it("renders progress with a truncated long subject and falls back to the hash when a subject is missing", async () => {
+		h.promptText.mockResolvedValue("y");
+		const longSubject = "x".repeat(120);
+		h.runBackfill.mockImplementation(async (opts) => {
+			opts.onCommitStart?.(1, 2, "a1b2c3d4", longSubject);
+			opts.onCommitStart?.(2, 2, "e5f6a7b8ffff", undefined); // no subject → hash
+			return report({ total: 2, generated: 2 });
+		});
+		await runBackfillFrontDoorStep(CWD);
+		const out = loggedText();
+		expect(out).toContain("…"); // long subject was truncated
+		expect(out).toContain("e5f6a7b"); // missing subject → short hash
+	});
+
+	it("reports a friendly failure when the back-fill run rejects with a non-Error value", async () => {
+		h.promptText.mockResolvedValue("y");
+		h.runBackfill.mockRejectedValue("stringly-typed failure");
+		await runBackfillFrontDoorStep(CWD);
+		expect(loggedText()).toContain("Couldn't build memories right now");
+	});
+
+	it("uses singular wording for a single built memory", async () => {
+		h.promptText.mockResolvedValue("");
+		h.runBackfill.mockResolvedValue(report({ total: 1, generated: 1 }));
+		await runBackfillFrontDoorStep(CWD);
+		expect(loggedText()).toContain("Built 1 memory from your history");
+	});
+
+	it("skips without building or dismissing on 'not now'", async () => {
+		h.promptText.mockResolvedValue("n");
+		await runBackfillFrontDoorStep(CWD);
+		expect(h.runBackfill).not.toHaveBeenCalled();
+		expect(h.updateRepoProfile).not.toHaveBeenCalled();
+		expect(loggedText()).toContain("run `jolli` again anytime");
+	});
+
+	it("records a sticky dismiss on 'don't ask again'", async () => {
+		h.promptText.mockResolvedValue("d");
+		await runBackfillFrontDoorStep(CWD);
+		expect(h.updateRepoProfile).toHaveBeenCalledWith(CWD, { backfillDismissed: true });
+		expect(h.runBackfill).not.toHaveBeenCalled();
+		expect(loggedText()).toContain("won't ask again");
+	});
+
+	it("treats an unrecognized answer as 'not now' (no build, no dismiss)", async () => {
+		h.promptText.mockResolvedValue("maybe later");
+		await runBackfillFrontDoorStep(CWD);
+		expect(h.runBackfill).not.toHaveBeenCalled();
+		expect(h.updateRepoProfile).not.toHaveBeenCalled();
+	});
+
+	it("swallows a cold-start detection failure without prompting", async () => {
+		h.listMissingCommits.mockRejectedValue(new Error("git blew up"));
+		await expect(runBackfillFrontDoorStep(CWD)).resolves.toBeUndefined();
+		expect(h.promptText).not.toHaveBeenCalled();
+	});
+
+	it("reports a Ctrl-C interruption as stopped-and-resumable", async () => {
+		h.promptText.mockResolvedValue("y");
+		let seenSignal: AbortSignal | undefined;
+		h.runBackfill.mockImplementation(async (opts) => {
+			// Simulate the user pressing Ctrl-C mid-run: the step's SIGINT handler is
+			// registered by now, so this aborts the controller it passed in.
+			seenSignal = opts.signal;
+			process.emit("SIGINT");
+			return report({ total: 3, generated: 1 });
+		});
+		await runBackfillFrontDoorStep(CWD);
+		// The real handler must have aborted the very signal handed to the engine.
+		expect(seenSignal?.aborted).toBe(true);
+		expect(loggedText()).toContain("Stopped — 1 memory built and saved");
+	});
+
+	it("still confirms the dismiss even if persisting the flag fails", async () => {
+		h.promptText.mockResolvedValue("d");
+		h.updateRepoProfile.mockRejectedValue(new Error("disk full"));
+		await expect(runBackfillFrontDoorStep(CWD)).resolves.toBeUndefined();
+		expect(loggedText()).toContain("won't ask again");
+	});
+
+	it("a second Ctrl-C forces a hard exit (code 130)", async () => {
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+		h.promptText.mockResolvedValue("y");
+		h.runBackfill.mockImplementation(async () => {
+			process.emit("SIGINT"); // 1st → cooperative abort
+			process.emit("SIGINT"); // 2nd → hard exit
+			return report({ total: 3, generated: 1 });
+		});
+		await runBackfillFrontDoorStep(CWD);
+		expect(exitSpy).toHaveBeenCalledWith(130);
+		exitSpy.mockRestore();
+	});
+
+	it("reports a friendly failure when the back-fill run throws", async () => {
+		h.promptText.mockResolvedValue("y");
+		h.runBackfill.mockRejectedValue(new Error("storage down"));
+		await runBackfillFrontDoorStep(CWD);
+		expect(loggedText()).toContain("Couldn't build memories right now");
+	});
+
+	it("tolerates a repo-profile read failure and still offers", async () => {
+		h.readRepoProfile.mockRejectedValue(new Error("fs error"));
+		h.promptText.mockResolvedValue("n");
+		await runBackfillFrontDoorStep(CWD);
+		// Read failed → treated as not-dismissed → still detects + prompts.
+		expect(h.promptText).toHaveBeenCalled();
+	});
+});

--- a/cli/src/commands/BackfillFrontDoorStep.ts
+++ b/cli/src/commands/BackfillFrontDoorStep.ts
@@ -1,0 +1,202 @@
+/**
+ * Cold-start back-fill step delegated by the guided front door.
+ *
+ * When the repo is in cold start — no memories yet, or the local user's own recent
+ * commits (last {@link COLD_START_WINDOW_MS}) lack a summary — this offers to build
+ * memories from those commits by reusing the shared {@link runBackfill} engine (one
+ * LLM call per commit, locally). It is the CLI counterpart of the VS Code sidebar's
+ * cold-start card, and shares the engine, the cold-start scope constants, and the
+ * repo-wide dismiss flag ({@link RepoProfile}) with it.
+ *
+ * Contract (mirrors SpaceSyncStep): the front door calls this once, only when the
+ * repo is enabled and memories can be generated. Everything cold-start lives here.
+ * It NEVER throws into the front door — detection failures are logged at debug and
+ * swallowed; the run itself only fails the offer, never the whole `jolli`.
+ *
+ * Three-way prompt: `[Y] yes` builds now (blocking, live progress, Ctrl-C aware),
+ * `[n] not now` skips this run WITHOUT recording anything (so the next `jolli` asks
+ * again), and `[d] don't ask again` records a sticky, permanent opt-out in the
+ * repo profile. Any unrecognized answer is treated as `not now` — the safe
+ * non-action, so a typo never spends LLM budget or permanently silences the offer.
+ *
+ * Blocking, not backgrounded: the front door is inherently synchronous (the user is
+ * at the TTY), the offer is bounded to {@link COLD_START_CAP} commits, and each
+ * commit's summary is stored immediately — so Ctrl-C is always safe and a re-run
+ * resumes with only the still-missing commits. Large / scripted back-fills stay in
+ * the standalone `jolli backfill` command.
+ */
+
+import {
+	listMissingCommits,
+	type MissingCommitInfo,
+	repoHasAnyMemory,
+	runBackfill,
+} from "../backfill/BackfillEngine.js";
+import { COLD_START_CAP, COLD_START_WINDOW_MS } from "../backfill/ColdStart.js";
+import { resolveLlmCredentialSource } from "../core/LlmClient.js";
+import { readRepoProfile, updateRepoProfile } from "../core/RepoProfile.js";
+import { loadConfig } from "../core/SessionTracker.js";
+import { createLogger } from "../Logger.js";
+import { promptText } from "./CliUtils.js";
+
+const log = createLogger("BackfillFrontDoorStep");
+
+/**
+ * Max chars of a commit subject, used identically for the offer list and the
+ * progress line. Git subjects are conventionally ≤72, so 100 shows them in full;
+ * the rare longer one is clipped the same way in both places.
+ */
+const SUBJECT_MAX = 100;
+
+type Choice = "yes" | "no" | "dismiss";
+
+/** Runs the cold-start back-fill axis of the guided front door. See the module docstring. */
+export async function runBackfillFrontDoorStep(cwd: string): Promise<void> {
+	// 1. No LLM credential → the front door can't build memories; stay silent.
+	//    Read config fresh: an in-place key fix earlier in the front door may have
+	//    just made generation possible, and the caller's snapshot is stale.
+	if (resolveLlmCredentialSource(await loadConfig()) === null) return;
+
+	// 2. Sticky, explicit opt-out → never offer again.
+	let dismissed = false;
+	try {
+		dismissed = (await readRepoProfile(cwd)).backfillDismissed === true;
+	} catch (err) {
+		log.debug(`repo profile read failed: ${errMsg(err)}`);
+	}
+	if (dismissed) return;
+
+	// 3. Cold-start detection (cheap — git log + orphan-branch index, no transcript
+	//    scan / LLM). Any failure is best-effort: skip the offer, never block.
+	let missing: MissingCommitInfo[];
+	let hasMemory: boolean;
+	try {
+		missing = await listMissingCommits(cwd, COLD_START_WINDOW_MS, COLD_START_CAP);
+		if (missing.length === 0) return; // nothing to build (fresh repo with no commits, or no gaps)
+		hasMemory = await repoHasAnyMemory(cwd);
+	} catch (err) {
+		log.debug(`cold-start detection skipped: ${errMsg(err)}`);
+		return;
+	}
+
+	// 4. Show the offer + the concrete commit list (subjects are free from git log).
+	printOffer(hasMemory ? "gaps" : "empty", missing);
+
+	// 5. Three-way prompt.
+	const choice = parseChoice(await promptText("\n  Build them now?  [Y] yes  [n] not now  [d] don't ask again: "));
+	if (choice === "no") {
+		console.log("\n  No problem — run `jolli` again anytime to build them.\n");
+		return;
+	}
+	if (choice === "dismiss") {
+		try {
+			await updateRepoProfile(cwd, { backfillDismissed: true });
+		} catch (err) {
+			log.debug(`repo profile write failed: ${errMsg(err)}`);
+		}
+		console.log("\n  Got it — I won't ask again in this repo. Run `jolli backfill` anytime to build them.\n");
+		return;
+	}
+
+	// 6. Build (choice === "yes").
+	await buildWithProgress(
+		cwd,
+		missing.map((m) => m.commitHash),
+	);
+}
+
+/** Prints the cold-start offer headline plus the concrete commit list. */
+function printOffer(variant: "empty" | "gaps", missing: ReadonlyArray<MissingCommitInfo>): void {
+	if (variant === "empty") {
+		console.log("\n  ✨ This repo has no memories yet. These recent commits can become memories:\n");
+	} else {
+		const n = missing.length;
+		console.log(
+			`\n  ✨ ${n} commit${n === 1 ? "" : "s"} from the last month ${n === 1 ? "doesn't" : "don't"} have a memory yet:\n`,
+		);
+	}
+	for (const m of missing) {
+		console.log(`     ${m.commitHash.slice(0, 7)}  ${truncate(m.subject, SUBJECT_MAX)}`);
+	}
+	// `>= cap` is the standard "list was capped, there may be more" heuristic (an
+	// uncapped count isn't computed). The wording is true either way.
+	if (missing.length >= COLD_START_CAP) {
+		console.log(`\n     (showing the ${COLD_START_CAP} most recent — run \`jolli backfill\` for the rest)`);
+	}
+}
+
+/**
+ * Maps a prompt answer to a choice. Enter / y / yes → build; d / don't / never →
+ * permanent dismiss; everything else (including n / no and any typo) → not now,
+ * the safe non-action.
+ */
+function parseChoice(answer: string): Choice {
+	const a = answer.trim().toLowerCase();
+	if (a === "" || a === "y" || a === "yes") return "yes";
+	if (a === "d" || a === "dont" || a === "don't" || a === "never") return "dismiss";
+	return "no";
+}
+
+/**
+ * Runs `runBackfill` blocking, with a single-line live progress readout and a
+ * Ctrl-C handler. First Ctrl-C aborts cooperatively at the next commit boundary
+ * (the in-flight commit finishes + stores); a second forces a hard exit. Either
+ * way already-built memories are saved and a re-run resumes the rest.
+ */
+async function buildWithProgress(cwd: string, hashes: string[]): Promise<void> {
+	const controller = new AbortController();
+	let interrupts = 0;
+	const onSigint = (): void => {
+		interrupts++;
+		if (interrupts === 1) {
+			controller.abort();
+			process.stderr.write("\n  Stopping… (finishing the current commit, or press Ctrl-C again to force quit)\n");
+		} else {
+			process.off("SIGINT", onSigint);
+			process.exit(130);
+		}
+	};
+	process.on("SIGINT", onSigint);
+	try {
+		console.log("\n  Building memories… one AI call per commit, locally. This may take a while.");
+		console.log("  Press Ctrl-C anytime to stop — progress is saved and you can resume later.\n");
+		let generated: number;
+		try {
+			const report = await runBackfill({
+				cwd,
+				hashes,
+				signal: controller.signal,
+				// Fires BEFORE each commit's generation, so a line appears as work starts
+				// (not after it finishes) — the first commit's slow LLM call is no longer
+				// silent. One permanent line per commit (no in-place rewrite) so the run
+				// leaves a readable log. `index` is 1-based over the commits being built.
+				onCommitStart: (index, total, hash, subject) => {
+					const label = subject ? truncate(subject, SUBJECT_MAX) : hash.slice(0, 7);
+					console.log(`  Building memories… ${index}/${total}  ${label}`);
+				},
+			});
+			generated = report.generated;
+		} catch (err) {
+			log.debug(`back-fill run failed: ${errMsg(err)}`);
+			console.log("\n  Couldn't build memories right now — run `jolli backfill` to try again.\n");
+			return;
+		}
+		const memories = `${generated} ${generated === 1 ? "memory" : "memories"}`;
+		if (controller.signal.aborted) {
+			console.log(`\n  Stopped — ${memories} built and saved. Run \`jolli\` again to build the rest.\n`);
+		} else {
+			console.log(`\n  ✓ Built ${memories} from your history.\n`);
+		}
+	} finally {
+		process.off("SIGINT", onSigint);
+	}
+}
+
+/** Truncates to `max` chars with a trailing ellipsis. */
+function truncate(text: string, max: number): string {
+	return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+function errMsg(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}

--- a/cli/src/commands/GuidedFrontDoor.test.ts
+++ b/cli/src/commands/GuidedFrontDoor.test.ts
@@ -15,6 +15,7 @@ const h = vi.hoisted(() => ({
 	resolveProjectDir: vi.fn(),
 	promptSetup: vi.fn(),
 	runSpaceSyncStep: vi.fn(),
+	runBackfillFrontDoorStep: vi.fn(),
 	createStorage: vi.fn(),
 	setActiveStorage: vi.fn(),
 	saveConfigScoped: vi.fn(),
@@ -46,6 +47,7 @@ vi.mock("../install/GitHookInstaller.js", () => ({ isGitHookInstalled: h.isGitHo
 vi.mock("../install/Installer.js", () => ({ install: h.install }));
 vi.mock("./EnableCommand.js", () => ({ promptSetup: h.promptSetup }));
 vi.mock("./SpaceSyncStep.js", () => ({ runSpaceSyncStep: h.runSpaceSyncStep }));
+vi.mock("./BackfillFrontDoorStep.js", () => ({ runBackfillFrontDoorStep: h.runBackfillFrontDoorStep }));
 vi.mock("./CliUtils.js", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("./CliUtils.js")>();
 	return { ...actual, promptText: h.promptText, resolveProjectDir: h.resolveProjectDir };
@@ -96,6 +98,7 @@ describe("GuidedFrontDoor", () => {
 		h.promptText.mockResolvedValue("");
 		h.triggerPendingPushRetry.mockResolvedValue(undefined);
 		h.runSpaceSyncStep.mockResolvedValue(undefined);
+		h.runBackfillFrontDoorStep.mockResolvedValue(undefined);
 		h.promptSetup.mockResolvedValue(undefined);
 		h.loadUserProfile.mockResolvedValue({});
 		h.saveUserProfile.mockResolvedValue(undefined);
@@ -122,9 +125,20 @@ describe("GuidedFrontDoor", () => {
 		expect(h.install).not.toHaveBeenCalled();
 		expect(h.triggerPendingPushRetry).toHaveBeenCalledWith("/repo", "cli-front-door");
 		expect(h.runSpaceSyncStep).toHaveBeenCalledWith("/repo");
+		expect(h.runBackfillFrontDoorStep).toHaveBeenCalledWith("/repo");
 		expect(out()).toContain("signed in · acme.jolli.ai");
 		expect(out()).toContain("3 memories");
 		expect(out()).toContain("last memory saved");
+	});
+
+	it("offers cold-start back-fill then re-reads the count so 'listening' reflects new memories", async () => {
+		// Status line reads 0 memories; the back-fill step builds some; the re-read
+		// after it returns 2, so the listening line no longer says "first memory".
+		h.getSummaryCount.mockResolvedValueOnce(0).mockResolvedValue(2);
+		await runGuidedFrontDoor();
+		expect(h.runBackfillFrontDoorStep).toHaveBeenCalledWith("/repo");
+		expect(out()).toContain("last memory saved");
+		expect(out()).not.toContain("first memory");
 	});
 
 	it("binds the Space before retrying pending pushes", async () => {
@@ -393,6 +407,8 @@ describe("GuidedFrontDoor", () => {
 		expect(out()).toContain("signed in");
 		expect(out()).toContain("no Anthropic key is available");
 		expect(out()).not.toContain("Jolli is listening");
+		// Not generatable (fix declined) → the back-fill offer is skipped this run.
+		expect(h.runBackfillFrontDoorStep).not.toHaveBeenCalled();
 	});
 
 	it("provider=anthropic + jolliApiKey, choose 'switch to Jolli' → saves aiProvider, listening reflects count", async () => {

--- a/cli/src/commands/GuidedFrontDoor.ts
+++ b/cli/src/commands/GuidedFrontDoor.ts
@@ -30,6 +30,7 @@ import { isGitHookInstalled } from "../install/GitHookInstaller.js";
 import { install } from "../install/Installer.js";
 import { createLogger, setLogDir } from "../Logger.js";
 import type { JolliMemoryConfig } from "../Types.js";
+import { runBackfillFrontDoorStep } from "./BackfillFrontDoorStep.js";
 import { isAffirmative, promptText, resolveProjectDir } from "./CliUtils.js";
 import { promptSetup } from "./EnableCommand.js";
 import { runSpaceSyncStep } from "./SpaceSyncStep.js";
@@ -158,7 +159,6 @@ export async function runGuidedFrontDoor(): Promise<void> {
 			canSync = Boolean(token || config.jolliApiKey);
 		}
 	}
-
 	// ── Cloud side-effects: only after credentials are settled, so a sign-in or
 	// key established above is picked up this run. We are always enabled by here
 	// (the enable axis above either enabled the repo or returned early). Bind the
@@ -169,6 +169,12 @@ export async function runGuidedFrontDoor(): Promise<void> {
 
 	// ── Closing confirmation: only promise "listening" when generation works. ──
 	if (canGenerate) {
+		// Cold-start back-fill offer. Runs after the capability ladder + cloud
+		// side-effects (so it benefits from any key/sign-in just established) and
+		// re-reads the count so the "listening" line reflects memories just built.
+		// Best-effort — the step never throws into the front door. See BackfillFrontDoorStep.
+		await runBackfillFrontDoorStep(cwd);
+		summaryCount = await getSummaryCount(cwd);
 		const listening =
 			summaryCount === 0
 				? "Jolli is listening — your next commit is your first memory"

--- a/cli/src/core/RepoProfile.test.ts
+++ b/cli/src/core/RepoProfile.test.ts
@@ -1,0 +1,125 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readRepoProfile, updateRepoProfile } from "./RepoProfile.js";
+
+const GIT_ENV = {
+	...process.env,
+	GIT_AUTHOR_NAME: "t",
+	GIT_AUTHOR_EMAIL: "t@t",
+	GIT_COMMITTER_NAME: "t",
+	GIT_COMMITTER_EMAIL: "t@t",
+};
+
+describe("RepoProfile", () => {
+	let cwd: string;
+
+	beforeEach(() => {
+		cwd = mkdtempSync(join(tmpdir(), "jolli-repoprofile-"));
+		execFileSync("git", ["init", "-q"], { cwd });
+	});
+	afterEach(() => {
+		rmSync(cwd, { recursive: true, force: true });
+	});
+
+	const profilePath = (root: string) => join(root, ".jolli", "jollimemory", "profile.json");
+
+	it("returns an empty profile when no file exists", async () => {
+		expect(await readRepoProfile(cwd)).toEqual({});
+	});
+
+	it("persists a field to <main-root>/.jolli/jollimemory/profile.json and reads it back", async () => {
+		await updateRepoProfile(cwd, { backfillDismissed: true });
+		expect(await readRepoProfile(cwd)).toEqual({ backfillDismissed: true });
+		expect(existsSync(profilePath(cwd))).toBe(true);
+	});
+
+	it("merges patches instead of overwriting the whole profile", async () => {
+		await updateRepoProfile(cwd, { backfillDismissed: true });
+		await updateRepoProfile(cwd, {});
+		expect(await readRepoProfile(cwd)).toEqual({ backfillDismissed: true });
+		await updateRepoProfile(cwd, { backfillDismissed: false });
+		expect(await readRepoProfile(cwd)).toEqual({ backfillDismissed: false });
+	});
+
+	it("tolerates a corrupt profile.json (returns empty)", async () => {
+		mkdirSync(join(cwd, ".jolli", "jollimemory"), { recursive: true });
+		writeFileSync(profilePath(cwd), "{ not json");
+		expect(await readRepoProfile(cwd)).toEqual({});
+	});
+
+	it("treats valid-but-non-object JSON as empty", async () => {
+		mkdirSync(join(cwd, ".jolli", "jollimemory"), { recursive: true });
+		writeFileSync(profilePath(cwd), "null");
+		expect(await readRepoProfile(cwd)).toEqual({});
+	});
+
+	it("migrates the legacy backfill-card-dismissed marker on read and persists it (read-once)", async () => {
+		// Legacy location: <git-common-dir>/jollimemory/backfill-card-dismissed.
+		const legacyMarker = join(cwd, ".git", "jollimemory", "backfill-card-dismissed");
+		mkdirSync(join(cwd, ".git", "jollimemory"), { recursive: true });
+		writeFileSync(legacyMarker, new Date(0).toISOString());
+
+		expect(await readRepoProfile(cwd)).toEqual({ backfillDismissed: true });
+		expect(existsSync(profilePath(cwd))).toBe(true);
+
+		// Prove the value was PERSISTED, not merely re-derived: remove the legacy
+		// marker and read again — the dismiss must survive from profile.json alone.
+		rmSync(legacyMarker);
+		expect(await readRepoProfile(cwd)).toEqual({ backfillDismissed: true });
+	});
+
+	it("still returns the migrated value when persisting the migration fails", async () => {
+		// Make writeProfile fail deterministically: put a DIRECTORY where profile.json
+		// should be, so the best-effort persist throws (EISDIR/EPERM) but read recovers.
+		mkdirSync(profilePath(cwd), { recursive: true });
+		const legacyDir = join(cwd, ".git", "jollimemory");
+		mkdirSync(legacyDir, { recursive: true });
+		writeFileSync(join(legacyDir, "backfill-card-dismissed"), new Date(0).toISOString());
+		// Precondition guard: profile.json must be an (unwritable/unreadable) directory,
+		// so the persist genuinely throws and the .catch is genuinely exercised. If a
+		// platform ever let the write through, this asserts the setup is still valid.
+		expect(statSync(profilePath(cwd)).isDirectory()).toBe(true);
+
+		expect(await readRepoProfile(cwd)).toEqual({ backfillDismissed: true });
+		// Persist failed → profile.json is still the directory (never became a file).
+		expect(statSync(profilePath(cwd)).isDirectory()).toBe(true);
+	});
+
+	it("does NOT let the legacy marker override an explicit profile value", async () => {
+		const legacyDir = join(cwd, ".git", "jollimemory");
+		mkdirSync(legacyDir, { recursive: true });
+		writeFileSync(join(legacyDir, "backfill-card-dismissed"), new Date(0).toISOString());
+		// Explicit false in the profile wins over the legacy "dismissed" marker.
+		await updateRepoProfile(cwd, { backfillDismissed: false });
+		expect(await readRepoProfile(cwd)).toEqual({ backfillDismissed: false });
+	});
+
+	it("falls back to the per-project .jolli dir when not a git repo", async () => {
+		const nonGit = mkdtempSync(join(tmpdir(), "jolli-repoprofile-nogit-"));
+		try {
+			expect(await readRepoProfile(nonGit)).toEqual({});
+			await updateRepoProfile(nonGit, { backfillDismissed: true });
+			expect(await readRepoProfile(nonGit)).toEqual({ backfillDismissed: true });
+			expect(existsSync(profilePath(nonGit))).toBe(true);
+			expect(existsSync(join(nonGit, ".git"))).toBe(false);
+		} finally {
+			rmSync(nonGit, { recursive: true, force: true });
+		}
+	});
+
+	it("is shared across worktrees of the same repo (repo-wide, not per-worktree)", async () => {
+		execFileSync("git", ["commit", "--allow-empty", "-m", "init", "-q"], { cwd, env: GIT_ENV });
+		await updateRepoProfile(cwd, { backfillDismissed: true });
+		const wt = mkdtempSync(join(tmpdir(), "jolli-repoprofile-wt-"));
+		try {
+			execFileSync("git", ["worktree", "add", "-q", wt, "HEAD"], { cwd });
+			// Linked worktree resolves to the MAIN worktree's profile.json.
+			expect(await readRepoProfile(wt)).toEqual({ backfillDismissed: true });
+		} finally {
+			rmSync(wt, { recursive: true, force: true });
+		}
+	});
+});

--- a/cli/src/core/RepoProfile.ts
+++ b/cli/src/core/RepoProfile.ts
@@ -1,0 +1,125 @@
+/**
+ * RepoProfile — per-repo, machine-local front-door preferences.
+ *
+ * Stored as JSON at `<main-worktree-root>/.jolli/jollimemory/profile.json`. This
+ * is the repo-level sibling of the user-level `~/.jolli/jollimemory/profile.json`
+ * (the machine-global `UserProfile`): same filename, different scope.
+ *
+ * Deliberately **repo-wide, not per-worktree**. The cold-start decision it gates
+ * (`repoHasAnyMemory` reads the shared orphan branch) is itself repo-wide, so a
+ * "don't ask again" chosen in one worktree must hold in every worktree. We anchor
+ * to the MAIN worktree root (derived from `git rev-parse --git-common-dir`) rather
+ * than the current `cwd`, so all linked worktrees resolve to the same file. The
+ * `.jolli/jollimemory/` dir is gitignored, so this never gets committed.
+ *
+ * This replaces the earlier `backfill-card-dismissed` marker that lived inside the
+ * shared `.git` common dir. Reads transparently migrate that old marker (see
+ * {@link readRepoProfile}), so users who dismissed the card before this change are
+ * not re-prompted.
+ */
+
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join } from "node:path";
+import { getJolliMemoryDir } from "../Logger.js";
+import { execGit } from "./GitOps.js";
+
+const PROFILE_FILE = "profile.json";
+/** Legacy marker (pre-RepoProfile): `<git-common-dir>/jollimemory/backfill-card-dismissed`. */
+const LEGACY_DISMISS_DIR = "jollimemory";
+const LEGACY_DISMISS_FILE = "backfill-card-dismissed";
+
+export interface RepoProfile {
+	/**
+	 * The user chose "don't ask again" for the back-fill cold-start offer in this
+	 * repo. STICKY: once set, nothing clears it automatically — it is an explicit,
+	 * permanent opt-out (contrast the earlier behavior, which auto-cleared it after
+	 * any generation). Only an explicit re-set to false would undo it.
+	 */
+	backfillDismissed?: boolean;
+}
+
+/** Resolved paths for a repo's profile, plus the legacy marker to migrate from. */
+interface ProfilePaths {
+	readonly profilePath: string;
+	/** Legacy marker path, or null when not in a git repo (nothing to migrate). */
+	readonly legacyMarkerPath: string | null;
+}
+
+/**
+ * Resolves the profile path, anchored to the MAIN worktree root so the file is
+ * shared across all worktrees of the repo. Falls back to the current-dir
+ * `.jolli/jollimemory/` only when `cwd` is not a git repo — the front door never
+ * offers back-fill there, so the fallback is inert.
+ */
+async function resolvePaths(cwd: string): Promise<ProfilePaths> {
+	const res = await execGit(["rev-parse", "--git-common-dir"], cwd);
+	const raw = res.exitCode === 0 ? res.stdout.trim() : "";
+	if (!raw) {
+		return { profilePath: join(getJolliMemoryDir(cwd), PROFILE_FILE), legacyMarkerPath: null };
+	}
+	const commonDir = isAbsolute(raw) ? raw : join(cwd, raw);
+	// The main worktree root is the parent of the common `.git` dir. Linked
+	// worktrees still report the main repo's common dir, so they resolve here too
+	// — this shared common dir is exactly why we use it rather than
+	// `--show-toplevel` (which returns the CURRENT worktree, breaking sharing).
+	// Edge case: inside a git submodule the common dir is `<super>/.git/modules/<name>`,
+	// so the profile lands under `.git/` rather than a working-tree root. That is
+	// harmless and self-consistent (reads/writes resolve identically, and it matches
+	// where the pre-RepoProfile marker already lived), just not the out-of-`.git` ideal.
+	const mainRoot = dirname(commonDir);
+	return {
+		profilePath: join(getJolliMemoryDir(mainRoot), PROFILE_FILE),
+		legacyMarkerPath: join(commonDir, LEGACY_DISMISS_DIR, LEGACY_DISMISS_FILE),
+	};
+}
+
+/** Parses profile.json; returns `{}` on any error (missing file, corrupt JSON). */
+async function readRaw(profilePath: string): Promise<RepoProfile> {
+	try {
+		const text = await readFile(profilePath, "utf-8");
+		const parsed = JSON.parse(text);
+		return parsed && typeof parsed === "object" ? (parsed as RepoProfile) : {};
+	} catch {
+		return {};
+	}
+}
+
+async function fileExists(path: string): Promise<boolean> {
+	try {
+		await stat(path);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function writeProfile(profilePath: string, profile: RepoProfile): Promise<void> {
+	await mkdir(dirname(profilePath), { recursive: true });
+	await writeFile(profilePath, `${JSON.stringify(profile, null, "\t")}\n`);
+}
+
+/**
+ * Reads the repo's profile. If the profile has no `backfillDismissed` field but the
+ * legacy `<git-common-dir>/jollimemory/backfill-card-dismissed` marker exists, the
+ * dismiss is treated as `true` and persisted into the new profile (best-effort —
+ * a persist failure still returns the migrated value). Returns `{}` when nothing
+ * has been set.
+ */
+export async function readRepoProfile(cwd: string): Promise<RepoProfile> {
+	const { profilePath, legacyMarkerPath } = await resolvePaths(cwd);
+	const profile = await readRaw(profilePath);
+	if (profile.backfillDismissed === undefined && legacyMarkerPath && (await fileExists(legacyMarkerPath))) {
+		const migrated: RepoProfile = { ...profile, backfillDismissed: true };
+		// Best-effort persist so the legacy marker only needs to be read once.
+		await writeProfile(profilePath, migrated).catch(() => {});
+		return migrated;
+	}
+	return profile;
+}
+
+/** Merges `patch` into the repo's profile and persists it. */
+export async function updateRepoProfile(cwd: string, patch: Partial<RepoProfile>): Promise<void> {
+	const { profilePath } = await resolvePaths(cwd);
+	const current = await readRaw(profilePath);
+	await writeProfile(profilePath, { ...current, ...patch });
+}

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -7604,7 +7604,7 @@ describe("Extension", () => {
 			expect(res.items).toEqual([]);
 		});
 
-		it("run streams progress, returns result rows, and clears the dismiss marker on success", async () => {
+		it("run streams progress, returns result rows, and does NOT clear the sticky dismiss flag on success", async () => {
 			const { runBackfill } = await import("../../cli/src/backfill/BackfillEngine.js");
 			const { writeBackfillDismissFlag } = await import("./services/BackfillDismissFlag.js");
 			vi.mocked(runBackfill).mockImplementation(async (opts) => {
@@ -7623,7 +7623,9 @@ describe("Extension", () => {
 			expect(progress).toEqual([1]);
 			expect(res.generated).toBe(1);
 			expect(res.rows).toEqual([{ commitHash: "h1", subject: "fix a", sessions: 2, topics: 3, status: "generated" }]);
-			expect(vi.mocked(writeBackfillDismissFlag)).toHaveBeenCalledWith("/test/workspace", false);
+			// Dismiss is a sticky, explicit opt-out — generating a memory must never touch it
+			// (neither clear it nor, worse, set it). The success path writes the flag not at all.
+			expect(vi.mocked(writeBackfillDismissFlag)).not.toHaveBeenCalled();
 		});
 
 		it("run maps an errored outcome to a failed result row", async () => {
@@ -7656,7 +7658,7 @@ describe("Extension", () => {
 			expect(state.backfillDismissed).toBe(true);
 		});
 
-		it("the Settings full-scope command also leaves cold start (clears the dismiss marker on generated>0)", async () => {
+		it("the Settings full-scope command runs back-fill but does NOT clear the sticky dismiss flag", async () => {
 			const { recentCommitHashes, runBackfill } = await import("../../cli/src/backfill/BackfillEngine.js");
 			const { writeBackfillDismissFlag } = await import("./services/BackfillDismissFlag.js");
 			vi.mocked(recentCommitHashes).mockResolvedValue(["h1"]);
@@ -7673,9 +7675,9 @@ describe("Extension", () => {
 			expect(handler).toBeDefined();
 			await handler?.();
 			expect(vi.mocked(runBackfill)).toHaveBeenCalled();
-			// Regression: the cold-start state update lives in runBackfillJob so BOTH
-			// entry points (card + Settings) clear the dismiss marker on generated>0.
-			expect(vi.mocked(writeBackfillDismissFlag)).toHaveBeenCalledWith("/test/workspace", false);
+			// Regression: neither entry point (card nor Settings) touches the sticky
+			// dismiss flag on generated>0 — dismiss is a permanent, explicit opt-out.
+			expect(vi.mocked(writeBackfillDismissFlag)).not.toHaveBeenCalled();
 		});
 
 		it("tolerates a failure resolving the cold-start signals (activate still completes)", async () => {

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -951,10 +951,12 @@ export function activate(context: vscode.ExtensionContext): void {
 		// Cold-start bookkeeping is done HERE (not in the sidebar `run` dep) so BOTH
 		// entry points — the cold-start card AND the Settings "Generate Missing
 		// Summaries" button — leave cold start consistently: once any back-fill
-		// produces a memory, the repo is no longer empty, and the per-repo dismiss
-		// marker is cleared so a future fresh-empty transition re-shows the card.
+		// produces a memory, the repo is no longer empty.
 		// (An already-open sidebar card flips to its own done view via `backfill:done`;
 		// this only fixes the host-side state a later sidebar reload reads.)
+		// NOTE: the per-repo dismiss flag is deliberately NOT cleared here — dismiss is
+		// now a sticky, explicit opt-out (shared with the CLI front door). Generating a
+		// memory must not resurrect a card the user permanently dismissed.
 		if (report.generated > 0) {
 			currentRepoHasMemories = true;
 			// Optimistically clear the card variant: the user just acted, so don't
@@ -964,7 +966,6 @@ export function activate(context: vscode.ExtensionContext): void {
 			// will re-surface 'gaps' if a partial back-fill left recent gaps.
 			currentColdStartVariant = null;
 			currentRecentMissingCount = 0;
-			void writeBackfillDismissFlag(workspaceRoot, false).catch(handleError("backfill.clearDismiss"));
 		}
 		// Card result list shows only the commits acted on (generated / errored);
 		// already-summarized neighbors in a full-scope run are not interesting rows.
@@ -1110,8 +1111,9 @@ export function activate(context: vscode.ExtensionContext): void {
 			},
 			// Real generation for the selected hashes. Streams per-commit progress
 			// to the card AND to the native notification (via runBackfillJob).
-			// Cold-start host state (repoHasMemories / dismiss marker) is updated
-			// inside runBackfillJob so this path and the Settings command agree.
+			// Cold-start host state (repoHasMemories) is updated inside runBackfillJob
+			// so this path and the Settings command agree. The dismiss flag is sticky
+			// and intentionally never cleared by a generation.
 			run: async (hashes, onProgress) => {
 				const r = await runBackfillJob(hashes, onProgress);
 				return { rows: r.rows, generated: r.generated, skipped: r.skipped, errors: r.errors };

--- a/vscode/src/services/BackfillDismissFlag.test.ts
+++ b/vscode/src/services/BackfillDismissFlag.test.ts
@@ -1,77 +1,40 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { readBackfillDismissFlag, writeBackfillDismissFlag } from "./BackfillDismissFlag.js";
 
+// These wrappers now forward to the shared RepoProfile (profile.json). The
+// exhaustive path-resolution / migration / worktree-sharing coverage lives in
+// cli/src/core/RepoProfile.test.ts; here we only assert the boolean forwarding
+// and the new storage location.
 describe("BackfillDismissFlag", () => {
 	let cwd: string;
 
 	beforeEach(() => {
 		cwd = mkdtempSync(join(tmpdir(), "jolli-bf-dismiss-"));
-		// The marker lives under the shared git common dir, so the repo must be a
-		// git repo for `git rev-parse --git-common-dir` to resolve it.
 		execFileSync("git", ["init", "-q"], { cwd });
 	});
 	afterEach(() => {
 		rmSync(cwd, { recursive: true, force: true });
 	});
 
-	it("reads false when no marker exists", async () => {
+	it("reads false when nothing is set", async () => {
 		expect(await readBackfillDismissFlag(cwd)).toBe(false);
 	});
 
-	it("writes the marker under the shared .git common dir and reads back true", async () => {
+	it("writes to <main-root>/.jolli/jollimemory/profile.json and reads back true", async () => {
 		await writeBackfillDismissFlag(cwd, true);
 		expect(await readBackfillDismissFlag(cwd)).toBe(true);
-		// Repo-wide location: <git-common-dir>/jollimemory/backfill-card-dismissed.
-		const markerPath = join(cwd, ".git", "jollimemory", "backfill-card-dismissed");
-		expect(existsSync(markerPath)).toBe(true);
-		// Body is an ISO timestamp (human-debug only) — existence is the boolean.
-		expect(readFileSync(markerPath, "utf8").trim()).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+		// New repo-wide location: the shared RepoProfile, not the old .git marker.
+		expect(existsSync(join(cwd, ".jolli", "jollimemory", "profile.json"))).toBe(true);
+		expect(existsSync(join(cwd, ".git", "jollimemory", "backfill-card-dismissed"))).toBe(false);
 	});
 
-	it("clears the marker and reads back false", async () => {
+	it("clears back to false", async () => {
 		await writeBackfillDismissFlag(cwd, true);
 		await writeBackfillDismissFlag(cwd, false);
 		expect(await readBackfillDismissFlag(cwd)).toBe(false);
-	});
-
-	it("clearing an already-absent marker is a no-op (no throw)", async () => {
-		await expect(writeBackfillDismissFlag(cwd, false)).resolves.toBeUndefined();
-		expect(await readBackfillDismissFlag(cwd)).toBe(false);
-	});
-
-	it("falls back to the per-project .jolli dir when the dir is not a git repo", async () => {
-		// A non-git temp dir: `git rev-parse --git-common-dir` fails → markerDir()
-		// falls back to <cwd>/.jolli/jollimemory (inert, since the card never shows there).
-		const nonGit = mkdtempSync(join(tmpdir(), "jolli-bf-nogit-"));
-		try {
-			expect(await readBackfillDismissFlag(nonGit)).toBe(false);
-			await writeBackfillDismissFlag(nonGit, true);
-			expect(await readBackfillDismissFlag(nonGit)).toBe(true);
-			expect(existsSync(join(nonGit, ".jolli", "jollimemory", "backfill-card-dismissed"))).toBe(true);
-			expect(existsSync(join(nonGit, ".git"))).toBe(false); // never created a bogus .git
-		} finally {
-			rmSync(nonGit, { recursive: true, force: true });
-		}
-	});
-
-	it("is shared across worktrees of the same repo (linked worktree resolves to the same marker)", async () => {
-		// Dismiss from the main worktree, then add a linked worktree and confirm the
-		// marker is visible there too (git-common-dir is shared) — the repo-wide contract.
-		execFileSync("git", ["commit", "--allow-empty", "-m", "init", "-q"], {
-			cwd,
-			env: { ...process.env, GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t" },
-		});
-		await writeBackfillDismissFlag(cwd, true);
-		const wt = mkdtempSync(join(tmpdir(), "jolli-bf-wt-"));
-		try {
-			execFileSync("git", ["worktree", "add", "-q", wt, "HEAD"], { cwd });
-			expect(await readBackfillDismissFlag(wt)).toBe(true);
-		} finally {
-			rmSync(wt, { recursive: true, force: true });
-		}
 	});
 });

--- a/vscode/src/services/BackfillDismissFlag.ts
+++ b/vscode/src/services/BackfillDismissFlag.ts
@@ -1,72 +1,30 @@
 /**
- * BackfillDismissFlag — repo-wide marker for "user dismissed the back-fill
- * cold-start card in this repository."
+ * BackfillDismissFlag — repo-wide "user dismissed the back-fill cold-start card".
  *
- * Stored under the **shared git common dir** (`git rev-parse --git-common-dir`,
- * i.e. the one `.git` every worktree of a repo points at) at
- * `<git-common-dir>/jollimemory/backfill-card-dismissed`. This is deliberately
- * REPO-WIDE, not per-worktree: the cold-start decision itself is repo-wide
- * (`repoHasAnyMemory` reads the shared orphan branch), so dismissing the card in
- * one worktree must suppress it in every worktree of the same repo. It is also
- * inherently local + untracked (nothing under `.git` is committed).
+ * Thin forwarder over the shared {@link RepoProfile} (`profile.json`), which is the
+ * single source of truth used by BOTH surfaces (this VS Code card and the CLI
+ * guided front door). The dismiss state moved out of the `.git` common dir and into
+ * `<main-worktree-root>/.jolli/jollimemory/profile.json`; RepoProfile keeps the
+ * repo-wide (not per-worktree) semantics and transparently migrates the old
+ * `<git-common-dir>/jollimemory/backfill-card-dismissed` marker.
  *
- * (Note: the sibling `disabled-by-user` marker (ManualDisableFlag) is still
- * per-worktree — a pre-existing storage choice with migration implications, left
- * as-is. The two markers mean different things: disable is a per-workspace
- * on/off switch; dismiss acknowledges a repo-wide backlog.)
+ * Semantics change (aligned with the CLI front door's three-way prompt): dismiss is
+ * now STICKY — it is an explicit, permanent opt-out and is never auto-cleared after
+ * a generation. The former "clear the marker once a back-fill produced a memory"
+ * behavior has been removed at the call site.
  *
- * Marker semantics: the file's *existence* is the boolean. The card only ever
- * shows in cold start (repo has zero memories or a recent-month backlog), so
- * once a back-fill generates a memory the marker is cleared (either entry point,
- * via `runBackfillJob`). The body holds an ISO timestamp for human debugging.
+ * These wrappers are kept (rather than inlining RepoProfile) so the existing
+ * Extension.ts call sites and their tests stay unchanged.
  */
 
-import { mkdir, stat, unlink, writeFile } from "node:fs/promises";
-import { dirname, isAbsolute, join } from "node:path";
-import { execGit } from "../../../cli/src/core/GitOps.js";
-import { getJolliMemoryDir } from "../../../cli/src/Logger.js";
+import { readRepoProfile, updateRepoProfile } from "../../../cli/src/core/RepoProfile.js";
 
-const FILE_NAME = "backfill-card-dismissed";
-
-/**
- * Directory holding the marker: `<git-common-dir>/jollimemory`. The common dir
- * is shared by all worktrees of a repo, so the marker is repo-wide. Falls back
- * to the per-project `.jolli/jollimemory/` only when the common dir can't be
- * resolved (not a git repo) — the card never shows there anyway, so it's inert.
- */
-async function markerDir(cwd: string): Promise<string> {
-	const res = await execGit(["rev-parse", "--git-common-dir"], cwd);
-	const raw = res.exitCode === 0 ? res.stdout.trim() : "";
-	if (raw) return join(isAbsolute(raw) ? raw : join(cwd, raw), "jollimemory");
-	return getJolliMemoryDir(cwd);
-}
-
-/** Returns true iff the dismiss marker exists for this repo. */
+/** Returns true iff the user has dismissed the cold-start card for this repo. */
 export async function readBackfillDismissFlag(cwd: string): Promise<boolean> {
-	try {
-		await stat(join(await markerDir(cwd), FILE_NAME));
-		return true;
-	} catch {
-		return false;
-	}
+	return (await readRepoProfile(cwd)).backfillDismissed === true;
 }
 
-/**
- * Sets the marker. `dismissed=true` writes the file (creating the directory if
- * needed); `dismissed=false` removes it (no-op if already absent).
- */
+/** Sets (`true`) or clears (`false`) the repo-wide dismiss flag. */
 export async function writeBackfillDismissFlag(cwd: string, dismissed: boolean): Promise<void> {
-	const path = join(await markerDir(cwd), FILE_NAME);
-	if (dismissed) {
-		await mkdir(dirname(path), { recursive: true });
-		await writeFile(path, `${new Date().toISOString()}\n`);
-		return;
-	}
-	try {
-		await unlink(path);
-	} catch (err) {
-		if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-			throw err;
-		}
-	}
+	await updateRepoProfile(cwd, { backfillDismissed: dismissed });
 }

--- a/vscode/src/views/BackfillListRenderer.ts
+++ b/vscode/src/views/BackfillListRenderer.ts
@@ -19,18 +19,17 @@
  * commit with no attributed conversation shows "Code change only".
  */
 
+import { COLD_START_CAP, COLD_START_WINDOW_MS } from "../../../cli/src/backfill/ColdStart.js";
+
 const s = (n: number): string => (n === 1 ? "" : "s");
 
 /**
- * Cold-start scope, shared by the host (Extension.ts: `listMissingCommits` window
- * + cap) and the note copy below, so a single change stays consistent everywhere.
- * `COLD_START_CAP` is the max commits the cold-start card lists (the rest go to
- * Settings via the card's "manage all" link). NOTE: temporarily lowered to 1 for
- * manual testing of the capped / "N more in Settings" flow — restore to 10 for
- * release.
+ * Cold-start scope constants now live in the CLI (`cli/src/backfill/ColdStart.ts`)
+ * so the guided front door and this VS Code renderer share one source of truth.
+ * Re-exported here so existing VS Code importers (Extension.ts, SidebarScriptBuilder)
+ * keep resolving them from this module.
  */
-export const COLD_START_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
-export const COLD_START_CAP = 10;
+export { COLD_START_CAP, COLD_START_WINDOW_MS };
 
 /** Candidate-row meta: "3 sessions · 12 turns", or "Code change only" when diff-only. */
 export function formatBackfillMeta(sessions: number, conversationTurns: number): string {


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The bare `jolli` command now offers to rebuild memories from recent historical commits when a repository is new or has gaps in its memory coverage. Users see a list of the specific commits that would be processed, then choose to build them immediately, skip for now, or permanently opt out. When building, the terminal shows a live progress line for each commit — appearing the instant work begins on that commit rather than only after it completes — giving users a readable log of everything built and eliminating the long silent pause that previously made the program appear frozen.

The back-fill process gained cooperative cancellation support. A first Ctrl-C stops the loop cleanly between commits rather than mid-call, and a second forces an immediate exit. Every memory written before the interruption is fully stored, and a re-run automatically skips those commits and resumes from where it left off.

The preference for opting out of the offer is now stored permanently in the project's own configuration folder and shared between the VS Code extension and the CLI. Dismissing the card or choosing "don't ask again" in either tool permanently silences the offer in both. Generating new memories no longer resets that choice, so a user's stated preference is always honored regardless of which tool they used to set it.

---

## Topics (6)
<details>
<summary><strong>01 · Silent freeze fixed: progress lines now appear as each memory build starts</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

During real-world testing, users saw a long blank pause after the startup message before any progress appeared, making the program look frozen or crashed.

**💡 Decisions Behind the Code**

- **Show activity at commit start, not commit end**: The first commit's language model call can take 10–30 seconds, and the original design produced no output during that entire window. Firing the notification the instant work begins on each commit eliminates the frozen-screen experience without requiring polling or background threads.
- **Permanent lines over in-place rewrite**: A carriage-return overwrite kept the terminal tidy but destroyed the history of what had been built and risked leaving visible remnants of longer prior lines. One permanent line per commit gives a readable build log. The tradeoff of slightly more terminal output is acceptable for an interactive session.
- **Remove the "preparing…" intermediate line**: The preamble already printed a "building memories" message immediately before the engine started, making the intermediate line a third repetition of the same information. The new start-of-commit callback now provides the first meaningful status update as soon as the engine actually begins work.

**✅ What Was Implemented**

- Added an `onCommitStart` callback to `BackfillEngine.ts` (in `BackfillOptions` and `runBackfill`). This callback fires immediately before each commit's language model call begins, carrying a 1-based index, total count, commit hash, and subject line — unlike the existing `onProgress` callback which fires only after completion.
- Rewrote the progress display in `BackfillFrontDoorStep.ts` to emit one permanent `console.log` line per commit (`1/4 <title>`, `2/4 <title>`, …) rather than an in-place carriage-return overwrite. Removed the `CLEAR_EOL` constant and the redundant `preparing…` intermediate line.
- Unified subject truncation to a single `SUBJECT_MAX = 100` constant used identically in both the offer list and the progress lines, replacing a prior split of 60 chars for progress and a separate value for the list.

**📁 FILES**
- `cli/src/backfill/BackfillEngine.ts`
- `cli/src/commands/BackfillFrontDoorStep.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Cold-start back-fill offer added to the bare jolli command</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

CLI users without the VS Code extension had no way to rebuild memories from historical commits when starting fresh in a repository. The guided front door needed a way to detect this cold-start condition and offer to fill the gap interactively.

**💡 Decisions Behind the Code**

- **Blocking execution over background worker**: The front door is an interactive, synchronous session where the user is already waiting at the terminal. A background worker would require a detached process, a progress state file, and polling — infrastructure designed for automated post-commit hooks, not a one-time user-initiated action. Blocking with a live progress display and a safe Ctrl-C exit matches the mental model of tools like package installers.
- **Three-way prompt over two**: A simple yes/no would conflate two meaningfully different user intentions — skipping this run versus permanently opting out. Treating every "no" as a permanent dismiss would re-prompt users who genuinely want to build memories later; never recording a dismiss would re-prompt users who have decided the feature is not for them. The third option makes the distinction explicit and only records a flag when the user clearly intends it.
- **Sticky dismiss shared across CLI and VS Code**: The previous VS Code behavior auto-cleared the dismiss flag whenever any back-fill generated a memory, making the card reappear after the user had explicitly closed it. Aligning both surfaces to a permanent opt-out removes that surprise and lets the two front-ends share a single flag in the same file without conflicting semantics.

**✅ What Was Implemented**

- `cli/src/commands/BackfillFrontDoorStep.ts` was created as the core of the feature. It detects whether the repo is in a cold-start state (no memories, or recent commits without summaries), prints the list of affected commits with their titles, presents a three-way prompt (build now / skip / don't ask again), and then runs the back-fill engine blocking with a live single-line-per-commit progress readout and a two-level Ctrl-C handler. Detection failures are swallowed at debug level and never throw into the front door.
- `cli/src/commands/GuidedFrontDoor.ts` was updated to call the new step after the cloud sync phase and before the final "Jolli is listening" confirmation, then re-reads the memory count so the closing line reflects any memories just built.
- `cli/src/core/RepoProfile.ts` was created to store the repo-wide dismiss preference in `<main-worktree-root>/.jolli/jollimemory/profile.json`, anchored to the main worktree via `git rev-parse --git-common-dir` so all linked worktrees share one file. It transparently migrates the legacy marker from inside the `.git` directory on first read.

**📋 Future Enhancements**

The IntelliJ plugin still reads the old dismiss marker location and still auto-clears it after generation. Users who dismiss via CLI or VS Code will see the card reappear in IntelliJ. Three options were identified: migrate IntelliJ to the shared profile file, add a bridge write, or defer with a corrected comment. No decision was made — needs a follow-up ticket or discussion.

**📁 FILES**
- `cli/src/commands/BackfillFrontDoorStep.ts`
- `cli/src/commands/GuidedFrontDoor.ts`
- `cli/src/core/RepoProfile.ts`
- `vscode/src/services/BackfillDismissFlag.ts`
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Back-fill engine made interruptible with cooperative cancellation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Running a back-fill over many commits could take several minutes with no way to stop cleanly mid-run. Users needed to be able to interrupt the process and resume later without losing progress or ending up with incomplete data.

**💡 Decisions Behind the Code**

Cancellation was placed at commit boundaries rather than inside the network call to the language model. Interrupting mid-call would require the underlying HTTP client to support cancellation signals, which was not confirmed. Boundary-level cancellation guarantees that every stored summary is complete and that a re-run picks up exactly where the previous one left off, with no partial or duplicate entries.

**✅ What Was Implemented**

- `cli/src/backfill/BackfillEngine.ts` gained an optional cancellation signal on its options type. The main commit loop checks the signal at the start of each iteration, stopping cleanly between commits. The commit currently being processed always finishes and stores before the loop exits, and already-generated summaries trigger one final graph ingest pass.
- Two new tests cover the abort paths: one verifies that a pre-aborted signal produces zero generations and no ingest, and another verifies that aborting after the first commit's progress callback stops the loop at the boundary while still ingesting the one built summary.

**📁 FILES**
- `cli/src/backfill/BackfillEngine.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Dismiss flag storage moved out of the git directory into the project folder</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The flag recording that a user had dismissed the back-fill card was stored inside the hidden git directory, which is an unconventional location for application preferences and made it impossible to share the flag cleanly between the VS Code extension and the new CLI front door.

**💡 Decisions Behind the Code**

- **Permanent opt-out over soft dismiss**: The previous behavior treated the dismiss as temporary — generating any memory would silently restore the card. This conflicted with the new three-way prompt where "don't ask again" is an explicit, permanent choice. Making the flag sticky across both surfaces means the user's stated preference is always honored regardless of which tool they used to set it.
- **Thin forwarder over inline migration**: Rather than updating every VS Code call site to use the new storage module directly, the existing wrapper functions were kept and made to delegate internally. This kept the change surface in the VS Code extension minimal while still unifying the underlying storage.

**✅ What Was Implemented**

- `vscode/src/services/BackfillDismissFlag.ts` was rewritten as a thin forwarder over the new `RepoProfile` module. The file-existence-as-boolean approach was replaced with a keyed JSON field, and the storage location moved from inside the git directory to the project's `.jolli` folder.
- `vscode/src/Extension.ts` had the call that auto-cleared the dismiss flag after a successful generation removed. Two test cases in `vscode/src/Extension.test.ts` were updated to assert that the flag is never touched by a generation event.

**📁 FILES**
- `vscode/src/services/BackfillDismissFlag.ts`
- `vscode/src/Extension.ts`
- `cli/src/core/RepoProfile.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Cold-start scope constants moved to a shared location</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The time window and commit cap that define the cold-start offer were defined only in the VS Code layer, making them unavailable to the new CLI front door without duplication.

**💡 Decisions Behind the Code**

Placing the constants in the CLI layer rather than a shared package reflects where the primary new consumer lives. The VS Code module re-exports them under the same names so all existing VS Code importers continue to resolve them from the same module path without any call-site changes.

**✅ What Was Implemented**

`cli/src/backfill/ColdStart.ts` was created as the single source of truth for the 30-day window and 10-commit cap. The VS Code renderer was updated to import and re-export these values rather than defining its own, and a stale comment incorrectly describing the cap as temporarily lowered to 1 was removed.

**📁 FILES**
- `cli/src/backfill/ColdStart.ts`
- `vscode/src/views/BackfillListRenderer.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Implementation verified against plan document; plan updated with as-built deviations</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After end-to-end testing passed, the developer wanted to verify that the implementation matched the written plan and catch any bugs before committing.

**💡 Decisions Behind the Code**

Because all three agents agreed there were no code defects and end-to-end tests had already passed, no code changes were made. The only action taken was updating the plan document to reflect reality, which carries zero risk of breaking the working implementation.

**✅ What Was Implemented**

Three independent agents reviewed the code against the plan document and independently concluded there were no code bugs — every discrepancy was the plan document being out of date relative to the already-shipped implementation. The plan document (`docs/208`) was updated by appending a new "As-built changes" section recording nine deviations, including the progress rendering change, unified truncation constant, removal of the dependency-injection seam in favour of module-level mocking, detection order optimisation, input parsing fallback behaviour, error handling additions, and notes on path normalisation and submodule edge cases.

**📁 FILES**
- `docs/208`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 15, 2026 at 4:09 PM · via Anthropic*
<!-- jollimemory-summary-end -->