### PR TITLE
Handle partial/full backfill errors with retry hints in front-door step

### DIFF
--- a/cli/src/commands/BackfillFrontDoorStep.test.ts
+++ b/cli/src/commands/BackfillFrontDoorStep.test.ts
@@ -169,6 +169,26 @@ describe("runBackfillFrontDoorStep", () => {
 		expect(loggedText()).toContain("Built 1 memory from your history");
 	});
 
+	it("does not claim success when every commit failed", async () => {
+		h.promptText.mockResolvedValue("y");
+		h.runBackfill.mockResolvedValue(report({ total: 2, generated: 0, errors: 2 }));
+		await runBackfillFrontDoorStep(CWD);
+		const text = loggedText();
+		expect(text).not.toContain("✓");
+		expect(text).toContain("all 2 failed");
+		expect(text).toContain("jolli backfill");
+	});
+
+	it("reports partial success with a retry hint when some commits failed", async () => {
+		h.promptText.mockResolvedValue("y");
+		h.runBackfill.mockResolvedValue(report({ total: 3, generated: 2, errors: 1 }));
+		await runBackfillFrontDoorStep(CWD);
+		const text = loggedText();
+		expect(text).toContain("✓ Built 2 memories from your history");
+		expect(text).toContain("1 failed");
+		expect(text).toContain("jolli backfill");
+	});
+
 	it("skips without building or dismissing on 'not now'", async () => {
 		h.promptText.mockResolvedValue("n");
 		await runBackfillFrontDoorStep(CWD);

--- a/cli/src/commands/BackfillFrontDoorStep.ts
+++ b/cli/src/commands/BackfillFrontDoorStep.ts
@@ -161,6 +161,7 @@ async function buildWithProgress(cwd: string, hashes: string[]): Promise<void> {
 		console.log("\n  Building memories… one AI call per commit, locally. This may take a while.");
 		console.log("  Press Ctrl-C anytime to stop — progress is saved and you can resume later.\n");
 		let generated: number;
+		let errors: number;
 		try {
 			const report = await runBackfill({
 				cwd,
@@ -176,6 +177,7 @@ async function buildWithProgress(cwd: string, hashes: string[]): Promise<void> {
 				},
 			});
 			generated = report.generated;
+			errors = report.errors;
 		} catch (err) {
 			log.debug(`back-fill run failed: ${errMsg(err)}`);
 			console.log("\n  Couldn't build memories right now — run `jolli backfill` to try again.\n");
@@ -184,6 +186,14 @@ async function buildWithProgress(cwd: string, hashes: string[]): Promise<void> {
 		const memories = `${generated} ${generated === 1 ? "memory" : "memories"}`;
 		if (controller.signal.aborted) {
 			console.log(`\n  Stopped — ${memories} built and saved. Run \`jolli\` again to build the rest.\n`);
+		} else if (generated === 0 && errors > 0) {
+			// Every candidate failed (e.g. an API or storage outage) — don't wear a
+			// success check; point the user at a retry instead.
+			console.log(`\n  Couldn't build memories — all ${errors} failed. Run \`jolli backfill\` to retry.\n`);
+		} else if (errors > 0) {
+			console.log(
+				`\n  ✓ Built ${memories} from your history — ${errors} failed. Run \`jolli backfill\` to retry.\n`,
+			);
 		} else {
 			console.log(`\n  ✓ Built ${memories} from your history.\n`);
 		}

--- a/cli/src/core/RepoProfile.ts
+++ b/cli/src/core/RepoProfile.ts
@@ -63,9 +63,13 @@ async function resolvePaths(cwd: string): Promise<ProfilePaths> {
 	// — this shared common dir is exactly why we use it rather than
 	// `--show-toplevel` (which returns the CURRENT worktree, breaking sharing).
 	// Edge case: inside a git submodule the common dir is `<super>/.git/modules/<name>`,
-	// so the profile lands under `.git/` rather than a working-tree root. That is
-	// harmless and self-consistent (reads/writes resolve identically, and it matches
-	// where the pre-RepoProfile marker already lived), just not the out-of-`.git` ideal.
+	// and dirname drops the `<name>` segment, so the profile lands at
+	// `<super>/.git/modules/.jolli/...`, shared by every submodule of that super-repo.
+	// Reads/writes stay self-consistent, but sibling submodules then share one profile,
+	// so a dismiss in one submodule suppresses the offer in the others. Known,
+	// low-severity limitation (no data loss); git submodules are rare enough that a
+	// per-submodule special-case isn't worth it. Note the legacy marker below is anchored
+	// at the full commonDir (with `<name>`), so it was per-submodule.
 	const mainRoot = dirname(commonDir);
 	return {
 		profilePath: join(getJolliMemoryDir(mainRoot), PROFILE_FILE),


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (2)

1. Add cold-start back-fill offer to the bare jolli front door (`345876b`) — [Memory](https://jolli.ai/very/o/default/articles/add-cold-start-back-fill-offer-to-the-bare-jolli-front-door-8013)
2. Handle partial/full backfill errors with retry hints in front-door step (`3d4d62f`)

## Quick recap (2)

### Commit 1 of 2: Add cold-start back-fill offer to the bare jolli front door (`345876b`)

The bare `jolli` command now offers to rebuild memories from recent historical commits when a repository is new or has gaps in its memory coverage. Users see a list of the specific commits that would be processed, then choose to build them immediately, skip for now, or permanently opt out. When building, the terminal shows a live progress line for each commit — appearing the instant work begins on that commit rather than only after it completes — giving users a readable log of everything built and eliminating the long silent pause that previously made the program appear frozen.

The back-fill process gained cooperative cancellation support. A first Ctrl-C stops the loop cleanly between commits rather than mid-call, and a second forces an immediate exit. Every memory written before the interruption is fully stored, and a re-run automatically skips those commits and resumes from where it left off.

The preference for opting out of the offer is now stored permanently in the project's own configuration folder and shared between the VS Code extension and the CLI. Dismissing the card or choosing "don't ask again" in either tool permanently silences the offer in both. Generating new memories no longer resets that choice, so a user's stated preference is always honored regardless of which tool they used to set it.

### Commit 2 of 2: Handle partial/full backfill errors with retry hints in front-door step (`3d4d62f`)

When a backfill run encounters errors on every commit — for example during an API outage — the tool previously displayed a green checkmark and reported zero memories built, giving users no indication that anything had gone wrong. The completion message now distinguishes between full failure, partial failure, and full success: a fully-failed run shows an explicit failure notice and directs the user to a retry command, while a partially-failed run shows the success count alongside the number of failures and the same retry hint. The backfill engine's existing design — where per-commit failures are recorded as data rather than thrown as exceptions — was preserved unchanged; the fix lives entirely in how results are presented after the run completes.

## Topics (8)
<details>
<summary><strong>01 · [345876b] Silent freeze fixed: progress lines now appear as each memory build starts</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

During real-world testing, users saw a long blank pause after the startup message before any progress appeared, making the program look frozen or crashed.

**💡 Decisions Behind the Code**

- **Show activity at commit start, not commit end**: The first commit's language model call can take 10–30 seconds, and the original design produced no output during that entire window. Firing the notification the instant work begins on each commit eliminates the frozen-screen experience without requiring polling or background threads.
- **Permanent lines over in-place rewrite**: A carriage-return overwrite kept the terminal tidy but destroyed the history of what had been built and risked leaving visible remnants of longer prior lines. One permanent line per commit gives a readable build log. The tradeoff of slightly more terminal output is acceptable for an interactive session.
- **Remove the "preparing…" intermediate line**: The preamble already printed a "building memories" message immediately before the engine started, making the intermediate line a third repetition of the same information. The new start-of-commit callback now provides the first meaningful status update as soon as the engine actually begins work.

**✅ What Was Implemented**

- Added an `onCommitStart` callback to `BackfillEngine.ts` (in `BackfillOptions` and `runBackfill`). This callback fires immediately before each commit's language model call begins, carrying a 1-based index, total count, commit hash, and subject line — unlike the existing `onProgress` callback which fires only after completion.
- Rewrote the progress display in `BackfillFrontDoorStep.ts` to emit one permanent `console.log` line per commit (`1/4 <title>`, `2/4 <title>`, …) rather than an in-place carriage-return overwrite. Removed the `CLEAR_EOL` constant and the redundant `preparing…` intermediate line.
- Unified subject truncation to a single `SUBJECT_MAX = 100` constant used identically in both the offer list and the progress lines, replacing a prior split of 60 chars for progress and a separate value for the list.

**📁 FILES**
- `cli/src/backfill/BackfillEngine.ts`
- `cli/src/commands/BackfillFrontDoorStep.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [345876b] Cold-start back-fill offer added to the bare jolli command</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

CLI users without the VS Code extension had no way to rebuild memories from historical commits when starting fresh in a repository. The guided front door needed a way to detect this cold-start condition and offer to fill the gap interactively.

**💡 Decisions Behind the Code**

- **Blocking execution over background worker**: The front door is an interactive, synchronous session where the user is already waiting at the terminal. A background worker would require a detached process, a progress state file, and polling — infrastructure designed for automated post-commit hooks, not a one-time user-initiated action. Blocking with a live progress display and a safe Ctrl-C exit matches the mental model of tools like package installers.
- **Three-way prompt over two**: A simple yes/no would conflate two meaningfully different user intentions — skipping this run versus permanently opting out. Treating every "no" as a permanent dismiss would re-prompt users who genuinely want to build memories later; never recording a dismiss would re-prompt users who have decided the feature is not for them. The third option makes the distinction explicit and only records a flag when the user clearly intends it.
- **Sticky dismiss shared across CLI and VS Code**: The previous VS Code behavior auto-cleared the dismiss flag whenever any back-fill generated a memory, making the card reappear after the user had explicitly closed it. Aligning both surfaces to a permanent opt-out removes that surprise and lets the two front-ends share a single flag in the same file without conflicting semantics.

**✅ What Was Implemented**

- `cli/src/commands/BackfillFrontDoorStep.ts` was created as the core of the feature. It detects whether the repo is in a cold-start state (no memories, or recent commits without summaries), prints the list of affected commits with their titles, presents a three-way prompt (build now / skip / don't ask again), and then runs the back-fill engine blocking with a live single-line-per-commit progress readout and a two-level Ctrl-C handler. Detection failures are swallowed at debug level and never throw into the front door.
- `cli/src/commands/GuidedFrontDoor.ts` was updated to call the new step after the cloud sync phase and before the final "Jolli is listening" confirmation, then re-reads the memory count so the closing line reflects any memories just built.
- `cli/src/core/RepoProfile.ts` was created to store the repo-wide dismiss preference in `<main-worktree-root>/.jolli/jollimemory/profile.json`, anchored to the main worktree via `git rev-parse --git-common-dir` so all linked worktrees share one file. It transparently migrates the legacy marker from inside the `.git` directory on first read.

**📋 Future Enhancements**

The IntelliJ plugin still reads the old dismiss marker location and still auto-clears it after generation. Users who dismiss via CLI or VS Code will see the card reappear in IntelliJ. Three options were identified: migrate IntelliJ to the shared profile file, add a bridge write, or defer with a corrected comment. No decision was made — needs a follow-up ticket or discussion.

**📁 FILES**
- `cli/src/commands/BackfillFrontDoorStep.ts`
- `cli/src/commands/GuidedFrontDoor.ts`
- `cli/src/core/RepoProfile.ts`
- `vscode/src/services/BackfillDismissFlag.ts`
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [345876b] Back-fill engine made interruptible with cooperative cancellation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Running a back-fill over many commits could take several minutes with no way to stop cleanly mid-run. Users needed to be able to interrupt the process and resume later without losing progress or ending up with incomplete data.

**💡 Decisions Behind the Code**

Cancellation was placed at commit boundaries rather than inside the network call to the language model. Interrupting mid-call would require the underlying HTTP client to support cancellation signals, which was not confirmed. Boundary-level cancellation guarantees that every stored summary is complete and that a re-run picks up exactly where the previous one left off, with no partial or duplicate entries.

**✅ What Was Implemented**

- `cli/src/backfill/BackfillEngine.ts` gained an optional cancellation signal on its options type. The main commit loop checks the signal at the start of each iteration, stopping cleanly between commits. The commit currently being processed always finishes and stores before the loop exits, and already-generated summaries trigger one final graph ingest pass.
- Two new tests cover the abort paths: one verifies that a pre-aborted signal produces zero generations and no ingest, and another verifies that aborting after the first commit's progress callback stops the loop at the boundary while still ingesting the one built summary.

**📁 FILES**
- `cli/src/backfill/BackfillEngine.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [345876b] Dismiss flag storage moved out of the git directory into the project folder</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The flag recording that a user had dismissed the back-fill card was stored inside the hidden git directory, which is an unconventional location for application preferences and made it impossible to share the flag cleanly between the VS Code extension and the new CLI front door.

**💡 Decisions Behind the Code**

- **Permanent opt-out over soft dismiss**: The previous behavior treated the dismiss as temporary — generating any memory would silently restore the card. This conflicted with the new three-way prompt where "don't ask again" is an explicit, permanent choice. Making the flag sticky across both surfaces means the user's stated preference is always honored regardless of which tool they used to set it.
- **Thin forwarder over inline migration**: Rather than updating every VS Code call site to use the new storage module directly, the existing wrapper functions were kept and made to delegate internally. This kept the change surface in the VS Code extension minimal while still unifying the underlying storage.

**✅ What Was Implemented**

- `vscode/src/services/BackfillDismissFlag.ts` was rewritten as a thin forwarder over the new `RepoProfile` module. The file-existence-as-boolean approach was replaced with a keyed JSON field, and the storage location moved from inside the git directory to the project's `.jolli` folder.
- `vscode/src/Extension.ts` had the call that auto-cleared the dismiss flag after a successful generation removed. Two test cases in `vscode/src/Extension.test.ts` were updated to assert that the flag is never touched by a generation event.

**📁 FILES**
- `vscode/src/services/BackfillDismissFlag.ts`
- `vscode/src/Extension.ts`
- `cli/src/core/RepoProfile.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [345876b] Cold-start scope constants moved to a shared location</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The time window and commit cap that define the cold-start offer were defined only in the VS Code layer, making them unavailable to the new CLI front door without duplication.

**💡 Decisions Behind the Code**

Placing the constants in the CLI layer rather than a shared package reflects where the primary new consumer lives. The VS Code module re-exports them under the same names so all existing VS Code importers continue to resolve them from the same module path without any call-site changes.

**✅ What Was Implemented**

`cli/src/backfill/ColdStart.ts` was created as the single source of truth for the 30-day window and 10-commit cap. The VS Code renderer was updated to import and re-export these values rather than defining its own, and a stale comment incorrectly describing the cap as temporarily lowered to 1 was removed.

**📁 FILES**
- `cli/src/backfill/ColdStart.ts`
- `vscode/src/views/BackfillListRenderer.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · [345876b] Implementation verified against plan document; plan updated with as-built deviations</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After end-to-end testing passed, the developer wanted to verify that the implementation matched the written plan and catch any bugs before committing.

**💡 Decisions Behind the Code**

Because all three agents agreed there were no code defects and end-to-end tests had already passed, no code changes were made. The only action taken was updating the plan document to reflect reality, which carries zero risk of breaking the working implementation.

**✅ What Was Implemented**

Three independent agents reviewed the code against the plan document and independently concluded there were no code bugs — every discrepancy was the plan document being out of date relative to the already-shipped implementation. The plan document (`docs/208`) was updated by appending a new "As-built changes" section recording nine deviations, including the progress rendering change, unified truncation constant, removal of the dependency-injection seam in favour of module-level mocking, detection order optimisation, input parsing fallback behaviour, error handling additions, and notes on path normalisation and submodule edge cases.

**📁 FILES**
- `docs/208`

</blockquote>
</details>
<details>
<summary><strong>07 · [3d4d62f] Fix backfill reporting success when all commits failed</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code reviewer found that when every commit in a backfill run fails (for example, due to an API or storage outage), the tool still displays a green checkmark and "Built 0 memories from your history" — giving users no indication that anything went wrong and no prompt to retry.

**💡 Decisions Behind the Code**

- **Errors as data, not exceptions**: The backfill engine was deliberately designed so per-commit failures are recorded in the report rather than thrown as exceptions — this lets one bad commit fail without aborting the whole batch. The fix was applied entirely in the presentation layer, leaving the engine design untouched. This keeps the engine's resilience intact while making failures visible to the user.
- **Retry hint over silent count**: Rather than simply showing "Built 0 memories", the failure message explicitly names the retry command. This was chosen because a user seeing a zero count with no guidance has no clear next step, whereas naming the command makes recovery self-evident without requiring the user to consult documentation.

**✅ What Was Implemented**

- `BackfillFrontDoorStep.ts` (`buildWithProgress`): captured the `errors` count from the backfill report alongside the existing `generated` count, then added two new branches to the completion message. A fully-failed run (zero generated, one or more errors) now prints a failure message without a checkmark and directs the user to run `jolli backfill` to retry. A partially-failed run prints the success count with a checkmark followed by the failure count and the same retry hint.
- `BackfillFrontDoorStep.test.ts`: added two new test cases covering the fully-failed and partially-failed paths, asserting the absence of a checkmark in the all-errors case and the presence of retry hint text in both cases. Coverage for the affected file remains at 100%.

**📁 FILES**
- `cli/src/commands/BackfillFrontDoorStep.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · [3d4d62f] Correct misleading comment about submodule profile path behavior</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code reviewer pointed out that the existing comment in the repository profile path logic incorrectly claimed the new profile location matched where the old marker file lived. In reality, the old marker was stored per-submodule while the new profile is shared across sibling submodules — the comment was actively misleading about both the behavior and the comparison to the legacy path.

**💡 Decisions Behind the Code**

The decision was made to fix only the comment rather than the underlying path behavior. The submodule sharing issue requires a rare combination of circumstances to manifest and causes no data loss — only a suppressed prompt. Implementing a correct per-submodule fix would require special-casing the submodule directory shape without breaking the common-repo and worktree cases, adding complexity for a scenario the team considers out of scope for now.

**✅ What Was Implemented**

Updated the comment in `RepoProfile.ts` to accurately describe the submodule edge case: the path calculation drops the submodule name segment, causing sibling submodules to share one profile file, which means dismissing the backfill offer in one submodule suppresses it in others. The comment now explicitly notes this is a known low-severity limitation, explains why a per-submodule fix was not pursued, and correctly states that the legacy marker did include the submodule name (making it per-submodule). No path logic was changed.

**📋 Future Enhancements**

If submodule support becomes a priority, the path resolution in `RepoProfile.ts` needs a special case for the `.git/modules/<name>` directory shape to restore per-submodule isolation.

**📁 FILES**
- `cli/src/core/RepoProfile.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 15, 2026 at 9:06 PM · via Anthropic*
<!-- jollimemory-summary-end -->