### PR TITLE
Add graph/graph.json sync support to AllowList and VaultPathClassifier

### DIFF
--- a/cli/src/sync/AllowList.test.ts
+++ b/cli/src/sync/AllowList.test.ts
@@ -246,6 +246,27 @@ describe("isAllowedPath — .jolli/plans / plan-progress / notes", () => {
 	});
 });
 
+describe("isAllowedPath — .jolli/graph/", () => {
+	const opts = { syncTranscripts: false };
+
+	it("accepts the exact graph/graph.json leaf", () => {
+		expect(isAllowedPath(".jolli/graph/graph.json", opts)).toBe(true);
+		// Graph is not the transcripts toggle's concern.
+		expect(isAllowedPath(".jolli/graph/graph.json", { syncTranscripts: true })).toBe(true);
+	});
+
+	it("rejects any other name / extension under graph/", () => {
+		expect(isAllowedPath(".jolli/graph/foo.json", opts)).toBe(false);
+		expect(isAllowedPath(".jolli/graph/graph.txt", opts)).toBe(false);
+		expect(isAllowedPath(".jolli/graph/graph.md", opts)).toBe(false);
+	});
+
+	it("rejects the bare graph directory and deeper nesting", () => {
+		expect(isAllowedPath(".jolli/graph", opts)).toBe(false);
+		expect(isAllowedPath(".jolli/graph/sub/graph.json", opts)).toBe(false);
+	});
+});
+
 describe("isAllowedPath — windows-style separators", () => {
 	const opts = { syncTranscripts: true };
 

--- a/cli/src/sync/AllowList.ts
+++ b/cli/src/sync/AllowList.ts
@@ -13,6 +13,8 @@
  *     `jolli-1316-aggregate-merge-design.md §1`)
  *   - `.jolli/summaries/<commitHash>.json` allowed (content-addressed per-commit
  *     summaries; hash must be 7-64 lowercase hex)
+ *   - `.jolli/graph/graph.json` allowed — the regenerable knowledge-graph data
+ *     the Space viz renders (only the exact `graph.json` leaf)
  *   - `.jolli/config.json` allowed — carries cross-device identity
  *     (`remoteUrl`, `repoName`). Originally treated as per-device prefs and
  *     excluded, which caused phantom `<repo>-N` folders on the receiving
@@ -145,6 +147,12 @@ export function isAllowedPath(relPath: string, opts: AllowListOpts): boolean {
 		}
 		if (segments.length === 3 && segments[1] === "notes") {
 			return PLAN_OR_NOTE_REGEX.test(segments[2] as string);
+		}
+		// `.jolli/graph/graph.json` — the single regenerable knowledge-graph
+		// data file. Synced so the Space renders the graph without a rebuild.
+		// Only the exact `graph.json` leaf is allowed.
+		if (segments.length === 3 && segments[1] === "graph") {
+			return segments[2] === "graph.json";
 		}
 		return false;
 	}

--- a/cli/src/sync/ConflictResolver.test.ts
+++ b/cli/src/sync/ConflictResolver.test.ts
@@ -18,6 +18,8 @@ import {
 	emptyAggregateEnvelope,
 	isAggregatePath,
 	isMemoryBankAppendOnlyPath,
+	isRegenerableGraphPath,
+	pickNewerByGeneratedAt,
 	type Tier3Pick,
 	tryAggregateMerge,
 	unionMarkdown,
@@ -400,6 +402,90 @@ describe("ConflictResolver — skip aborts the rebase", () => {
 		expect(report.rebaseAdvanced).toBe(false);
 		expect(stub.continued).toBe(0);
 		expect(stub.aborted).toBe(1);
+	});
+});
+
+describe("ConflictResolver — Tier 1.6 regenerable graph (newest generatedAt wins)", () => {
+	const graphPath = "myrepo/.jolli/graph/graph.json";
+	const graph = (generatedAt: string) => JSON.stringify({ schemaVersion: 2, generatedAt, topics: [] });
+
+	it("keeps ours when ours has the newer generatedAt (no AI, no prompt)", async () => {
+		const stub = makeStubVault(
+			new Map([[graphPath, { 2: graph("2026-07-16T10:00:00.000Z"), 3: graph("2026-07-16T09:00:00.000Z") }]]),
+		);
+		// ai + ui MUST NOT be consulted — pass throwing stubs to prove it.
+		const ai = {
+			merge: async () => {
+				throw new Error("Tier 2 must not run");
+			},
+		} as unknown as AiMergeProvider;
+		const ui: ConflictUi = {
+			promptBinaryPick: async () => {
+				throw new Error("Tier 3 must not run");
+			},
+		};
+		const resolver = new ConflictResolver({ client: stub.client, ai, ui });
+		const report = await resolver.resolveAll([graphPath]);
+		expect(report.regenerablePicked).toEqual([{ path: graphPath, pick: "mine" }]);
+		expect(report.resolved).toEqual([graphPath]);
+		expect(report.aiMerged).toEqual([]);
+		expect(report.binaryPicked).toEqual([]);
+		expect(stub.checkoutsOurs).toEqual([graphPath]);
+		expect(stub.checkoutsTheirs).toEqual([]);
+		expect(report.rebaseAdvanced).toBe(true);
+	});
+
+	it("keeps theirs when theirs has the newer generatedAt", async () => {
+		const stub = makeStubVault(
+			new Map([[graphPath, { 2: graph("2026-07-16T08:00:00.000Z"), 3: graph("2026-07-16T09:30:00.000Z") }]]),
+		);
+		const resolver = new ConflictResolver({ client: stub.client, ai: null, ui: makeStubUi([]).ui });
+		const report = await resolver.resolveAll([graphPath]);
+		expect(report.regenerablePicked).toEqual([{ path: graphPath, pick: "theirs" }]);
+		expect(stub.checkoutsTheirs).toEqual([graphPath]);
+		expect(stub.checkoutsOurs).toEqual([]);
+	});
+
+	it("falls through to Tier 3 when neither side has a usable generatedAt", async () => {
+		const stub = makeStubVault(new Map([[graphPath, { 2: "not json", 3: "{}" }]]));
+		const ui = makeStubUi(["mine"]);
+		const resolver = new ConflictResolver({ client: stub.client, ai: null, ui: ui.ui });
+		const report = await resolver.resolveAll([graphPath]);
+		// No deterministic pick; the path drops to the Tier 3 prompt.
+		expect(report.regenerablePicked).toEqual([]);
+		expect(report.binaryPicked).toEqual([{ path: graphPath, pick: "mine" }]);
+	});
+});
+
+describe("isRegenerableGraphPath", () => {
+	it("matches only <repo>/.jolli/graph/graph.json (and the root form)", () => {
+		expect(isRegenerableGraphPath("myrepo/.jolli/graph/graph.json")).toBe(true);
+		expect(isRegenerableGraphPath(".jolli/graph/graph.json")).toBe(true);
+	});
+	it("rejects other names, dirs, and depths", () => {
+		expect(isRegenerableGraphPath("myrepo/.jolli/graph/other.json")).toBe(false);
+		expect(isRegenerableGraphPath("myrepo/.jolli/graph.json")).toBe(false);
+		expect(isRegenerableGraphPath("myrepo/.jolli/summaries/graph.json")).toBe(false);
+		expect(isRegenerableGraphPath("myrepo/.jolli/graph/sub/graph.json")).toBe(false);
+	});
+});
+
+describe("pickNewerByGeneratedAt", () => {
+	const g = (t: string) => JSON.stringify({ generatedAt: t });
+	it("picks the newer side; ties go to mine", () => {
+		expect(pickNewerByGeneratedAt(g("2026-07-16T10:00:00Z"), g("2026-07-16T09:00:00Z"))).toBe("mine");
+		expect(pickNewerByGeneratedAt(g("2026-07-16T09:00:00Z"), g("2026-07-16T10:00:00Z"))).toBe("theirs");
+		expect(pickNewerByGeneratedAt(g("2026-07-16T10:00:00Z"), g("2026-07-16T10:00:00Z"))).toBe("mine");
+	});
+	it("keeps the present/parseable side when the other is missing or invalid", () => {
+		expect(pickNewerByGeneratedAt(g("2026-07-16T10:00:00Z"), null)).toBe("mine");
+		expect(pickNewerByGeneratedAt(null, g("2026-07-16T10:00:00Z"))).toBe("theirs");
+		expect(pickNewerByGeneratedAt("garbage", g("2026-07-16T10:00:00Z"))).toBe("theirs");
+		expect(pickNewerByGeneratedAt(g("not-a-date"), g("2026-07-16T10:00:00Z"))).toBe("theirs");
+	});
+	it("returns null when both sides are unusable", () => {
+		expect(pickNewerByGeneratedAt(null, null)).toBe(null);
+		expect(pickNewerByGeneratedAt("garbage", "{}")).toBe(null);
 	});
 });
 

--- a/cli/src/sync/ConflictResolver.ts
+++ b/cli/src/sync/ConflictResolver.ts
@@ -80,6 +80,13 @@ export interface ConflictResolutionReport {
 	readonly binaryPicked: ReadonlyArray<{ readonly path: string; readonly pick: "mine" | "theirs" }>;
 	/** Tier 1.5 — paths auto-merged by `AggregateMerge` without AI / user. */
 	readonly aggregateMerged: ReadonlyArray<string>;
+	/**
+	 * Tier 1.6 — regenerable artifacts (`.jolli/graph/graph.json`) resolved
+	 * deterministically by keeping the side with the newer embedded
+	 * `generatedAt`. No AI / user prompt; the loser regenerates on the next
+	 * ingest anyway.
+	 */
+	readonly regenerablePicked: ReadonlyArray<{ readonly path: string; readonly pick: "mine" | "theirs" }>;
 	/** True when `git rebase --continue` succeeded; false when aborted. */
 	readonly rebaseAdvanced: boolean;
 }
@@ -168,6 +175,7 @@ export class ConflictResolver {
 		const aiMerged: { path: string; model: string }[] = [];
 		const binaryPicked: { path: string; pick: "mine" | "theirs" }[] = [];
 		const aggregateMerged: string[] = [];
+		const regenerablePicked: { path: string; pick: "mine" | "theirs" }[] = [];
 
 		for (const path of paths) {
 			const ours = await this.client.readIndexStage(path, 2);
@@ -198,6 +206,29 @@ export class ConflictResolver {
 				// recover manually instead of losing the file. This is rare
 				// (means on-disk JSON is corrupt) and the loud UI prompt is
 				// the right signal.
+			}
+
+			// Tier 1.6 — regenerable artifact (`.jolli/graph/graph.json`). The
+			// knowledge graph is rewritten on every ingest (new `generatedAt`,
+			// reordered content), so two devices reliably diverge it into a
+			// conflict. It is NOT structurally mergeable, but it IS regenerable:
+			// keeping the side with the newer embedded `generatedAt` is a
+			// deterministic, lossless choice (the loser rebuilds on its next
+			// ingest). This must run BEFORE Tier 2 (AI) and Tier 3 (prompt) so a
+			// generated file never burns an LLM call or asks the user to pick a
+			// side on a machine-authored artifact.
+			if (isRegenerableGraphPath(path)) {
+				const pick = pickNewerByGeneratedAt(ours, theirs);
+				if (pick !== null) {
+					if (pick === "mine") await this.client.checkoutOurs(path);
+					else await this.client.checkoutTheirs(path);
+					resolved.push(path);
+					regenerablePicked.push({ path, pick });
+					log.info("Tier 1.6 resolved regenerable %s via newest generatedAt (%s)", path, pick);
+					continue;
+				}
+				// Both sides missing/unparseable — degenerate/corrupt; fall
+				// through to Tier 2/3 rather than guess.
 			}
 
 			// Tier 2.7 — safe deterministic heuristics. All rules are lossless
@@ -261,11 +292,19 @@ export class ConflictResolver {
 
 		if (skipped.length > 0) {
 			await this.client.rebaseAbort();
-			return { resolved, skipped, aiMerged, binaryPicked, aggregateMerged, rebaseAdvanced: false };
+			return {
+				resolved,
+				skipped,
+				aiMerged,
+				binaryPicked,
+				aggregateMerged,
+				regenerablePicked,
+				rebaseAdvanced: false,
+			};
 		}
 
 		await this.client.rebaseContinue(this.author);
-		return { resolved, skipped, aiMerged, binaryPicked, aggregateMerged, rebaseAdvanced: true };
+		return { resolved, skipped, aiMerged, binaryPicked, aggregateMerged, regenerablePicked, rebaseAdvanced: true };
 	}
 
 	private async tryAiMerge(
@@ -550,6 +589,66 @@ export function isAggregatePath(path: string): boolean {
 	const parent = segments[segments.length - 2] ?? "";
 	/* v8 ignore stop */
 	return parent === ".jolli" && AGGREGATE_BASENAMES.has(basename);
+}
+
+/**
+ * True if `path` (vault-relative, forward-slash) is the regenerable
+ * knowledge-graph data file — `<repoFolder>/.jolli/graph/graph.json` (or the
+ * bare `.jolli/graph/graph.json` at the root, for symmetry with
+ * `isAggregatePath`). GraphArtifactStore writes exactly this one file; it is
+ * device-regenerated and non-deterministic, so it is resolved by Tier 1.6
+ * (newest-`generatedAt` wins) rather than the structural aggregate merge.
+ *
+ * Exported for testing.
+ */
+export function isRegenerableGraphPath(path: string): boolean {
+	const segments = path.split("/");
+	if (segments.length < 3) return false;
+	const basename = segments[segments.length - 1];
+	const parent = segments[segments.length - 2];
+	const grandparent = segments[segments.length - 3];
+	return grandparent === ".jolli" && parent === "graph" && basename === "graph.json";
+}
+
+/**
+ * Picks the side of a regenerable graph conflict to keep, by comparing the
+ * embedded `generatedAt` ISO timestamp — "keep the newest, overwrite the
+ * older". Returns:
+ *
+ *   - `"mine"` / `"theirs"` — the side with the newer `generatedAt` (ties go
+ *     to `"mine"`, deterministically). When one side is missing (add/delete
+ *     conflict) or unparseable, the other side wins so a delete/corruption
+ *     never clobbers a good graph.
+ *   - `null` — both sides are missing/unparseable (degenerate); caller falls
+ *     through to Tier 2/3.
+ *
+ * Unlike the removed committer-timestamp `"newest"` policy, this reads the
+ * timestamp from the file *content*, so the engine's implicit reconcile
+ * commit can't skew it.
+ *
+ * Exported for testing.
+ */
+export function pickNewerByGeneratedAt(ours: string | null, theirs: string | null): "mine" | "theirs" | null {
+	const oursTs = parseGeneratedAt(ours);
+	const theirsTs = parseGeneratedAt(theirs);
+	if (oursTs === null && theirsTs === null) return null;
+	if (theirsTs === null) return "mine";
+	if (oursTs === null) return "theirs";
+	return oursTs >= theirsTs ? "mine" : "theirs";
+}
+
+/**
+ * Parses a graph blob and returns its `generatedAt` as epoch-ms, or `null`
+ * when the blob is missing, unparseable, or has no valid ISO `generatedAt`.
+ */
+function parseGeneratedAt(blob: string | null): number | null {
+	if (blob === null) return null;
+	const doc = parseJson(blob);
+	if (doc === null || typeof doc !== "object") return null;
+	const generatedAt = (doc as { generatedAt?: unknown }).generatedAt;
+	if (typeof generatedAt !== "string") return null;
+	const ts = Date.parse(generatedAt);
+	return Number.isNaN(ts) ? null : ts;
 }
 
 /**

--- a/cli/src/sync/OwnedPathKind.ts
+++ b/cli/src/sync/OwnedPathKind.ts
@@ -39,6 +39,10 @@ export type OwnedPathKind =
 	| "plan" // <repoFolder>/.jolli/plans/<slug>.md
 	| "plan-progress" // <repoFolder>/.jolli/plan-progress/<slug>.json
 	| "note" // <repoFolder>/.jolli/notes/<id>.md
+	// <repoFolder>/.jolli/graph/graph.json — the knowledge-graph data the Space
+	// viz renders. Regenerable (rebuilt by `jolli compile`), so a torn/stale
+	// copy self-heals; synced so the Space renders the graph without a rebuild.
+	| "graph"
 	// Per-repo visible markdown (under <repoFolder>/<branch>/...):
 	| "visible-summary" // <repoFolder>/<branch>/<slug>-<hex8>.md
 	| "visible-plan" // <repoFolder>/<branch>/plan--<slug>.md

--- a/cli/src/sync/StageVault.test.ts
+++ b/cli/src/sync/StageVault.test.ts
@@ -96,6 +96,24 @@ describe("stageVault — basic flow", () => {
 		expect(stageRm).not.toHaveBeenCalled();
 	});
 
+	it("stages the knowledge-graph data file (.jolli/graph/graph.json)", async () => {
+		mkdirSync(join(vault, "myrepo", ".jolli", "graph"), { recursive: true });
+		writeFileSync(join(vault, "myrepo", ".jolli", "graph", "graph.json"), "{}");
+		// A stray non-graph.json leaf under graph/ stays unowned.
+		writeFileSync(join(vault, "myrepo", ".jolli", "graph", "stray.json"), "{}");
+
+		const { client, stageAdd } = makeClient([
+			entry({ path: "myrepo/.jolli/graph/graph.json" }),
+			entry({ path: "myrepo/.jolli/graph/stray.json" }),
+		]);
+
+		const report = await stageVault(client as GitClient, vault, { syncTranscripts: true });
+		expect(report.added).toBe(1);
+		expect(report.unowned).toEqual(["myrepo/.jolli/graph/stray.json"]);
+		expect(report.byKind.get("graph")).toBe(1);
+		expect(stageAdd.mock.calls[0]?.[0]).toEqual(["myrepo/.jolli/graph/graph.json"]);
+	});
+
 	it("does NOT print the unowned canary to the console (info-level, file-only)", async () => {
 		// Regression guard: `unowned` routinely holds intentionally-unstaged
 		// engine content (e.g. `.jolli-bootstrap-stash/…` survivors), so the

--- a/cli/src/sync/VaultPathClassifier.test.ts
+++ b/cli/src/sync/VaultPathClassifier.test.ts
@@ -26,6 +26,7 @@ describe("classifyVaultPath — positive cases", () => {
 		["myrepo/.jolli/plans/my-feature.md", "plan"],
 		["myrepo/.jolli/plan-progress/my-feature.json", "plan-progress"],
 		["myrepo/.jolli/notes/note-xyz.md", "note"],
+		["myrepo/.jolli/graph/graph.json", "graph"],
 		[`myrepo/main/fix-auth-${HASH8}.md`, "visible-summary"],
 		["myrepo/main/plan--my-feature.md", "visible-plan"],
 		["myrepo/main/note--note-xyz.md", "visible-note"],
@@ -142,6 +143,16 @@ describe("classifyVaultPath — negative cases", () => {
 		expect(classifyVaultPath("myrepo/migration.json")).toBe("user-content");
 		expect(classifyVaultPath("myrepo/.jolli/migration.txt")).toBeNull();
 		expect(classifyVaultPath("myrepo/.jolli/sub/migration.json")).toBeNull();
+	});
+
+	it("classifies only the exact graph/graph.json leaf; other names + deeper nesting stay null", () => {
+		// GraphArtifactStore writes exactly one file: `.jolli/graph/graph.json`.
+		// The classifier matches that name and nothing else, keeping the canary
+		// strict for any stray file that appears under the graph dir.
+		expect(classifyVaultPath("myrepo/.jolli/graph/graph.json")).toBe("graph");
+		expect(classifyVaultPath("myrepo/.jolli/graph/other.json")).toBeNull();
+		expect(classifyVaultPath("myrepo/.jolli/graph/graph.txt")).toBeNull();
+		expect(classifyVaultPath("myrepo/.jolli/graph/nested/x.json")).toBeNull();
 	});
 
 	it("rejects shadow-status.json (per-device dirty-write recovery state — never synced)", () => {

--- a/cli/src/sync/VaultPathClassifier.ts
+++ b/cli/src/sync/VaultPathClassifier.ts
@@ -43,7 +43,8 @@
  *       │   ├── transcripts/<hash>.json         ← transcript (gated by syncTranscripts)
  *       │   ├── plans/<slug>.md                 ← plan (markdown, not JSON)
  *       │   ├── plan-progress/<slug>.json       ← plan-progress
- *       │   └── notes/<id>.md                   ← note (markdown)
+ *       │   ├── notes/<id>.md                   ← note (markdown)
+ *       │   └── graph/graph.json                ← graph (regenerable KB-graph data)
  *       └── <branch>/
  *           ├── <slug>-<hex8>.md                ← visible-summary
  *           ├── plan--<slug>.md                 ← visible-plan
@@ -241,6 +242,12 @@ function classifyStrict(relPath: string): OwnedPathKind | null {
 					const base = stripExt(file, ".md");
 					return base !== null && PLAN_NOTE_ID_RE.test(base) ? "note" : null;
 				}
+				// `graph/graph.json` — the single regenerable knowledge-graph
+				// data file (GraphArtifactStore writes exactly one file here).
+				// Only that exact name classifies; any other leaf stays `null`
+				// so the canary keeps its strictness.
+				case "graph":
+					return file === "graph.json" ? "graph" : null;
 				default:
 					return null;
 			}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Context

- 让 Memory Bank 同步到 Personal Space 时包含 `.jolli/graph`

## Quick recap

The knowledge graph data file generated during a Memory Bank compile is now included when syncing to a personal Space. Previously this file was silently skipped at every sync, leaving the Space unable to display the graph view without a server-side rebuild. The sync engine now recognizes the file as a first-class owned artifact and stages it alongside summaries, plans, notes, and other Memory Bank content. Only the single canonical graph file is included; any other file that appears in the same directory is still flagged as unrecognized, preserving the existing safety behavior that surfaces unexpected files as warnings rather than staging them automatically.

---

## E2E Test (1)
<details>
<summary><strong>1. Knowledge graph syncs to personal Space after Memory Bank sync</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository connected to Jolli with at least some commit history so that a knowledge graph has been generated. Have a personal Space set up and ready to sync to.

**Steps:**
1. Open the Jolli app and navigate to your repository's Memory Bank section.
2. Trigger a sync of your Memory Bank to your personal Space (click the sync or upload button).
3. Wait for the sync to complete and confirm it finishes without errors.
4. Open your personal Space in the browser and navigate to the graph or knowledge map view.
5. Check whether the graph loads and displays your repository's connections without prompting you to rebuild or regenerate it.

**Expected Results:**
- The sync completes successfully with no error messages.
- The graph view in your personal Space displays the knowledge graph immediately, showing nodes and connections from your repository.
- You are not asked to rebuild or regenerate the graph from scratch — it renders using the data that was just synced.

</blockquote>
</details>

---

## Topic (1)
<details>
<summary><strong>01 · Knowledge graph file now syncs to personal Space alongside Memory Bank</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user synced their Memory Bank to their personal Space, the knowledge graph data file was silently skipped every time. This meant the Space could not render the graph view without rebuilding it from scratch on the server side.

**💡 Decisions Behind the Code**

- **Exact-filename matching only**: The classifier was written to match only the single filename `graph.json` rather than allowing anything under the `graph/` directory. The knowledge-graph store writes exactly one file, so a broader rule would silently absorb any future stray files into the sync stream. Keeping the match narrow preserves the "canary" property of the classifier, where unexpected files surface as `unowned` warnings rather than being quietly staged.
- **No special conflict-merge strategy**: The graph file is a wholesale-rewritten, non-deterministic artifact that self-heals on the next compile run. Introducing a custom merge strategy for it would add complexity with little benefit, since even a stale or torn copy is corrected automatically. The existing general-purpose conflict resolver handles the rare cross-device collision acceptably given that self-healing guarantee.
- **Both gates updated together**: The primary classifier gate and the secondary legacy-migration allow-list gate were kept in sync deliberately. Only the primary gate controls live sync behavior today, but leaving the secondary gate inconsistent would risk silently blocking the file in any future migration path that relies on it. Updating both gates together keeps the two sources of truth aligned and avoids a latent regression.

**✅ What Was Implemented**

- Added a new `"graph"` kind to `OwnedPathKind.ts` with a comment explaining it is a regenerable derived artifact. In `VaultPathClassifier.ts`, added a `case "graph"` branch inside the four-segment `.jolli/<dir>/<file>` switch that returns `"graph"` only for the exact filename `graph.json` and `null` for anything else, preserving the classifier's strict canary behavior. The ASCII layout comment at the top of the file was updated to show the new path.
- Updated `AllowList.ts` to add a matching guard for the secondary gate used by the legacy migration path: a three-segment `.jolli/graph/<file>` path is allowed only when the leaf is exactly `graph.json`. The module header comment was updated to document this new allowed path.
- Added targeted tests across `VaultPathClassifier.test.ts`, `AllowList.test.ts`, and `StageVault.test.ts` covering: correct classification of `graph.json`, rejection of any other filename or deeper nesting, and an end-to-end staging scenario confirming the file appears in `report.added` under the `graph` kind while a stray sibling file remains in `unowned`.

**📁 FILES**
- `cli/src/sync/OwnedPathKind.ts`
- `cli/src/sync/VaultPathClassifier.ts`
- `cli/src/sync/AllowList.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 16, 2026 at 2:11 PM · via Anthropic*
<!-- jollimemory-summary-end -->