### PR TITLE
Default MCP platform tools on; handle local and remote workflow runs

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jolli.ai/cli",
-	"version": "0.99.7",
+	"version": "0.99.8",
 	"description": "AI development process auto-documentation tool - generates structured commit summaries from Claude Code, Codex, Gemini, OpenCode, Cursor, and Copilot sessions",
 	"main": "./dist/Api.js",
 	"types": "./dist/Api.d.ts",

--- a/cli/src/commands/ConfigureCommand.ts
+++ b/cli/src/commands/ConfigureCommand.ts
@@ -207,7 +207,7 @@ const CONFIG_KEY_INFO: ReadonlyArray<{ key: ConfigKey; type: string; description
 	{
 		key: "mcpPlatformToolsEnabled",
 		type: "boolean",
-		description: "Register backend-defined Jolli-platform tools in the MCP server (true/false; off by default)",
+		description: "Register backend-defined Jolli-platform tools in the MCP server (true/false; on by default)",
 	},
 	{ key: "logLevel", type: "enum", description: "Log level: debug | info | warn | error" },
 	{ key: "excludePatterns", type: "string[]", description: "Glob patterns for file exclusion (comma-separated)" },

--- a/cli/src/install/SkillInstaller.test.ts
+++ b/cli/src/install/SkillInstaller.test.ts
@@ -230,6 +230,43 @@ describe("jolli menu template frontmatter", () => {
 		expect(jolli).toMatch(/mcp__jollimemory__/);
 		expect(jolli).toMatch(/AskUserQuestion/);
 	});
+
+	it("run-a-workflow action asks local vs remote, defaulting to local", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const jolli = readJolli();
+		expect(jolli).toMatch(/Run a workflow/);
+		expect(jolli).toMatch(/local vs remote/i);
+		// Default is local.
+		expect(jolli).toMatch(/default.*local|local.*default/i);
+		// Local routes to the jolli-local-run skill; remote to the renamed MCP tool.
+		expect(jolli).toContain("jolli-local-run");
+		expect(jolli).toContain("run_remote_workflow");
+	});
+
+	it("mentions canceling an in-flight remote run via cancel_remote_workflow", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const jolli = readJolli();
+		expect(jolli).toContain("cancel_remote_workflow");
+		expect(jolli).toMatch(/cancel/i);
+	});
+
+	it("hides list_workflow_definitions and does not list the remote workflow tools raw", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const jolli = readJolli();
+		// list_workflow_definitions is plumbing — never a standalone menu item.
+		expect(jolli).toContain("list_workflow_definitions");
+		expect(jolli).toMatch(/Exclusions/);
+		// The exclusion instruction must name it as excluded, not surface it.
+		expect(jolli).toMatch(/do NOT surface/i);
+	});
+
+	it("uses the renamed remote_* backend tool names, not the old pre-rename names", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const jolli = readJolli();
+		// No lingering old names in the menu template body.
+		expect(jolli).not.toMatch(/\brun_workflow\b/);
+		expect(jolli).not.toMatch(/`run_workflow`/);
+	});
 });
 
 describe("jolli-local-run template", () => {
@@ -283,6 +320,16 @@ describe("jolli-local-run template", () => {
 		expect(t).toContain("docs publish --json");
 		expect(t).toContain("prNumber");
 		expect(t).toContain("prUrl");
+	});
+
+	it("completes a private Jolli-managed destination WITHOUT a PR reference", () => {
+		const t = buildLocalRunSkillTemplate();
+		// The publish JSON withholds prNumber/prUrl for private destinations
+		// (`private: true`); the run must still complete, just without a PR ref.
+		expect(t).toContain('"private": true');
+		expect(t).toContain("WITHOUT a PR reference");
+		// And it reads the completion result's `willAutoMerge` (not the offer's `autoMerges`).
+		expect(t).toContain("willAutoMerge");
 	});
 
 	it("surfaces the combined space-cli install hint when the plugin is missing", () => {

--- a/cli/src/install/SkillInstaller.ts
+++ b/cli/src/install/SkillInstaller.ts
@@ -1102,13 +1102,24 @@ fresh across the wait.
    "$HOME/.jolli/jollimemory/run-cli" docs publish --json
    \`\`\`
 
-   Read \`prNumber\` and \`prUrl\` from its JSON output.
+   \`--json\` prints exactly one JSON object on stdout (all human-readable progress
+   goes to stderr) — parse that object; never scrape the human log for a PR number.
 2. Call \`complete_local_run\` (on Claude Code
-   \`mcp__jollimemory__complete_local_run\`) with
-   \`{ "runId": "<runId>", "prNumber": <prNumber>, "prUrl": "<prUrl>" }\`.
-3. Read \`autoMerges\` from its result and tell the user which happened: **"PR
-   auto-merged"** (\`autoMerges: true\`) or **"PR left open for team review"**
-   (\`autoMerges: false\`).
+   \`mcp__jollimemory__complete_local_run\`), branching on what the publish JSON
+   contained:
+   - **PR refs present** (the JSON has a \`prNumber\` — a user-accessible
+     destination): pass them through —
+     \`{ "runId": "<runId>", "prNumber": <prNumber>, "prUrl": "<prUrl>" }\`.
+   - **PR refs withheld** (the JSON is \`"private": true\` with no \`prNumber\` — a
+     private Jolli-managed destination whose backing repo the user cannot access):
+     complete WITHOUT a PR reference — \`{ "runId": "<runId>" }\`. Do not invent,
+     guess, or look up a \`prNumber\`; the run already knows its destination is private.
+   - **Nothing published** (\`"pushed": false\`, e.g. \`"reason": "no-changes"\`): no PR
+     was opened, so there is nothing to complete — tell the user the workflow produced
+     no changes and release the run with \`abandon_local_run\` (Step 7).
+3. Read \`willAutoMerge\` from \`complete_local_run\`'s result and tell the user which
+   happened: **"PR auto-merged"** (\`willAutoMerge: true\`) or **"PR left open for team
+   review"** (\`willAutoMerge: false\`).
 
 ## Step 7 — on cancel: abandon
 
@@ -1150,7 +1161,7 @@ npm i -g @jolli.ai/cli @jolli.ai/space-cli
 export function buildJolliMenuSkillTemplate(): string {
 	return `---
 name: jolli
-description: The Jolli action menu — a single front door that lists the Jolli skills (recall, search, pr, local-run) plus the Jolli MCP tools registered in this session, then routes your choice to the right one. Use when the user types /jolli or asks for the Jolli menu.
+description: The Jolli action menu — a single front door that lists the Jolli skills (recall, search, pr, run a workflow local or remote) plus the Jolli MCP tools registered in this session, then routes your choice to the right one. Use when the user types /jolli or asks for the Jolli menu.
 metadata:
   version: "${SKILL_VERSION}"
   revision: 1
@@ -1179,9 +1190,18 @@ Assemble ONE combined list of actions from two sources.
   (decisions, topics, files). Route by invoking the \`jolli-search\` skill.
 - **jolli-pr** — Create or update a pull request using a Jolli Memory-generated
   description. Route by invoking the \`jolli-pr\` skill.
-- **jolli-local-run** — Run a Jolli workflow locally (your agent executes the
-  recipe; the writes land in a git-backed Space via a branch + PR). Route by
-  invoking the \`jolli-local-run\` skill.
+- **Run a workflow** — Run a Jolli workflow. When the user picks this, ask them
+  **local vs remote**, defaulting to **local**:
+  - **local (default)** — your agent executes the workflow's recipe on this
+    machine (no Jolli LLM budget); the writes land in a git-backed Space via a
+    branch + PR. Route by invoking the \`jolli-local-run\` skill.
+  - **remote** — the Jolli backend executes the workflow server-side. Route by
+    calling the \`run_remote_workflow\` MCP tool
+    (\`mcp__jollimemory__run_remote_workflow\`).
+
+  A running **remote** run can be canceled with the \`cancel_remote_workflow\` MCP
+  tool (\`mcp__jollimemory__cancel_remote_workflow\`) — offer this if the user
+  wants to stop an in-flight remote run.
 
 Route a local choice by invoking that skill through your host's skill-invocation
 mechanism (for example, the Skill tool in Claude Code).
@@ -1190,14 +1210,21 @@ mechanism (for example, the Skill tool in Claude Code).
 
 Surface every tool whose name starts with \`mcp__jollimemory__\` that is available
 in the current session — for example \`recall\`, \`search\`, \`get_pr_description\`,
-\`queue_status\`, and any manifest-driven platform tools (workflow, space, article,
-and the like). Route a choice by calling the matching \`mcp__jollimemory__*\` tool.
+\`queue_status\`, and any manifest-driven platform tools (space, article, and the
+like). Route a choice by calling the matching \`mcp__jollimemory__*\` tool.
+
+**Exclusions — do NOT surface these as standalone menu items:**
+
+- \`list_workflow_definitions\` — discovery/plumbing, not a human quick-action.
+- \`run_remote_workflow\` and \`cancel_remote_workflow\` — these are already covered
+  by the **Run a workflow** action above (its *remote* path and its cancellation
+  option); don't list them again as raw tools.
 
 Do NOT assume a fixed list — enumerate the Jolli MCP tools that are actually
-registered right now. Do NOT try to fetch or re-derive any backend "menu"
-curation; a skill cannot read the manifest, so simply surface the Jolli MCP tools
-present in the session. If no Jolli MCP tools are registered, present just the
-local skills above.
+registered right now, minus the exclusions above. Do NOT try to fetch or
+re-derive any backend "menu" curation; a skill cannot read the manifest, so
+simply surface the Jolli MCP tools present in the session. If no Jolli MCP tools
+are registered, present just the local skills above.
 
 ## Step 2 — route the request
 

--- a/cli/src/mcp/McpServer.test.ts
+++ b/cli/src/mcp/McpServer.test.ts
@@ -187,7 +187,10 @@ describe("startMcpServer", () => {
 		capturedSchemas.length = 0;
 		serverCapabilities = undefined;
 		connectMock.mockClear();
-		loadConfigMock.mockReset().mockResolvedValue({});
+		// Platform tools are on by default, so pin these built-in-only tests to the
+		// dormant (git-memory-only) path with an explicit opt-out; otherwise the
+		// default-on gate would open and hit the unstubbed manifest fetch.
+		loadConfigMock.mockReset().mockResolvedValue({ mcpPlatformToolsEnabled: false });
 		fetchManifestMock.mockReset();
 		invokePlatformToolMock.mockReset();
 		vi.mocked(track).mockClear();
@@ -361,9 +364,12 @@ describe("startMcpServer — platform tools", () => {
 		vi.mocked(runSearch).mockClear();
 	});
 
-	it("dormant by default: advertises exactly 9 tools and never constructs a client", async () => {
+	it("explicit opt-out: advertises exactly 9 tools and never constructs a client", async () => {
 		const createPlatformClient = vi.fn();
-		await startMcpServer("/repo", { loadConfig: async () => ({}), createPlatformClient });
+		await startMcpServer("/repo", {
+			loadConfig: async () => ({ mcpPlatformToolsEnabled: false }),
+			createPlatformClient,
+		});
 		const list = (await capturedHandlers[0]({ params: { name: "" } })) as { tools: unknown[] };
 		expect(list.tools).toBe(TOOL_DEFINITIONS);
 		expect(list.tools).toHaveLength(9);
@@ -371,6 +377,15 @@ describe("startMcpServer — platform tools", () => {
 		// A built-in still dispatches through the local table.
 		await capturedHandlers[1]({ params: { name: "search", arguments: { query: "x" } } });
 		expect(runSearch).toHaveBeenCalledWith("/repo", { query: "x" });
+	});
+
+	it("on by default: an unset config flag opens the gate and fetches the manifest", async () => {
+		const createPlatformClient = vi.fn(() => stubClient([platA]));
+		await startMcpServer("/repo", { loadConfig: async () => ({}), createPlatformClient });
+		expect(createPlatformClient).toHaveBeenCalledTimes(1);
+		const list = (await capturedHandlers[0]({ params: { name: "" } })) as { tools: { name: string }[] };
+		expect(list.tools).toHaveLength(10);
+		expect(list.tools.map((t) => t.name)).toContain("create_ticket");
 	});
 
 	it("enabled: advertises the built-ins plus the manifest's platform tools", async () => {
@@ -602,9 +617,12 @@ describe("startMcpServer — platform tools", () => {
 		expect(capturedHandlers).toHaveLength(2);
 	});
 
-	it("gate off: no prompts capability even if a manifest tool would be menu-flagged", async () => {
+	it("gate off (explicit opt-out): no prompts capability even if a manifest tool would be menu-flagged", async () => {
 		const createPlatformClient = vi.fn();
-		await startMcpServer("/repo", { loadConfig: async () => ({}), createPlatformClient });
+		await startMcpServer("/repo", {
+			loadConfig: async () => ({ mcpPlatformToolsEnabled: false }),
+			createPlatformClient,
+		});
 		expect(serverCapabilities).toEqual({ tools: {} });
 		expect(handlerForKind("getPrompt")).toBeUndefined();
 	});

--- a/cli/src/mcp/PlatformTools.test.ts
+++ b/cli/src/mcp/PlatformTools.test.ts
@@ -6,24 +6,31 @@ describe("isPlatformToolsEnabled", () => {
 		expect(isPlatformToolsEnabled({ mcpPlatformToolsEnabled: true }, {})).toBe(true);
 	});
 
-	it("is true when the env flag is exactly '1', regardless of config", () => {
+	it("is true when both the config flag and env flag are absent (on by default)", () => {
+		expect(isPlatformToolsEnabled({}, {})).toBe(true);
+	});
+
+	it("is true when the env flag is exactly '1', even when config opts out", () => {
 		expect(isPlatformToolsEnabled({}, { [PLATFORM_TOOLS_ENV_FLAG]: "1" })).toBe(true);
+		// The env escape hatch force-enables even over an explicit `false`.
 		expect(isPlatformToolsEnabled({ mcpPlatformToolsEnabled: false }, { [PLATFORM_TOOLS_ENV_FLAG]: "1" })).toBe(
 			true,
 		);
 	});
 
-	it("is false when both the config flag and env flag are absent (off by default)", () => {
-		expect(isPlatformToolsEnabled({}, {})).toBe(false);
-	});
-
-	it("is false when the config flag is explicitly false and the env flag is unset", () => {
+	it("is false only when the config flag is explicitly false and the env flag is unset", () => {
 		expect(isPlatformToolsEnabled({ mcpPlatformToolsEnabled: false }, {})).toBe(false);
 	});
 
-	it("does not treat a truthy-but-non-'1' env value as enabled (strict === '1')", () => {
-		expect(isPlatformToolsEnabled({}, { [PLATFORM_TOOLS_ENV_FLAG]: "true" })).toBe(false);
-		expect(isPlatformToolsEnabled({}, { [PLATFORM_TOOLS_ENV_FLAG]: "0" })).toBe(false);
-		expect(isPlatformToolsEnabled({}, { [PLATFORM_TOOLS_ENV_FLAG]: "" })).toBe(false);
+	it("does not treat a truthy-but-non-'1' env value as enabling when config opts out (strict === '1')", () => {
+		expect(isPlatformToolsEnabled({ mcpPlatformToolsEnabled: false }, { [PLATFORM_TOOLS_ENV_FLAG]: "true" })).toBe(
+			false,
+		);
+		expect(isPlatformToolsEnabled({ mcpPlatformToolsEnabled: false }, { [PLATFORM_TOOLS_ENV_FLAG]: "0" })).toBe(
+			false,
+		);
+		expect(isPlatformToolsEnabled({ mcpPlatformToolsEnabled: false }, { [PLATFORM_TOOLS_ENV_FLAG]: "" })).toBe(
+			false,
+		);
 	});
 });

--- a/cli/src/mcp/PlatformTools.ts
+++ b/cli/src/mcp/PlatformTools.ts
@@ -3,11 +3,14 @@
  *
  * The `jolli mcp` server registers backend-defined platform tools only when
  * this gate is open; otherwise it stays git-memory-only and never contacts the
- * backend for a tool manifest. The feature is opt-in (off by default): the
- * config flag `mcpPlatformToolsEnabled` must be explicitly `true`, OR the
- * escape-hatch env var `JOLLI_MCP_PLATFORM_TOOLS` must be exactly `"1"` (for
+ * backend for a tool manifest. The feature is **on by default** (matching the
+ * other `*Enabled` config keys): an unset config flag counts as enabled, so the
+ * gate is open unless the config flag `mcpPlatformToolsEnabled` is explicitly
+ * `false`, OR — regardless of the config value — the escape-hatch env var
+ * `JOLLI_MCP_PLATFORM_TOOLS` is exactly `"1"` (which still force-enables for
  * CI / debugging without touching config.json — same strict `=== "1"` shape as
- * the other CLI env gates).
+ * the other CLI env gates). The manifest fetch is best-effort, so defaulting on
+ * degrades silently to "no platform tools" when no key is configured.
  */
 
 import type { JolliMemoryConfig } from "../Types.js";
@@ -17,13 +20,14 @@ export const PLATFORM_TOOLS_ENV_FLAG = "JOLLI_MCP_PLATFORM_TOOLS";
 
 /**
  * Returns true when the manifest-driven Jolli-platform tools should be
- * registered. Opt-in: the config flag must be `true`, or the env flag must be
- * the literal `"1"`. `env` is injectable so the decision is unit-testable
- * without mutating `process.env`.
+ * registered. On by default: enabled unless the config flag is explicitly
+ * `false`, or force-enabled when the env flag is the literal `"1"` (the env
+ * flag wins even over an explicit `false`). `env` is injectable so the decision
+ * is unit-testable without mutating `process.env`.
  */
 export function isPlatformToolsEnabled(
 	config: Pick<JolliMemoryConfig, "mcpPlatformToolsEnabled">,
 	env: Record<string, string | undefined> = process.env,
 ): boolean {
-	return config.mcpPlatformToolsEnabled === true || env[PLATFORM_TOOLS_ENV_FLAG] === "1";
+	return config.mcpPlatformToolsEnabled !== false || env[PLATFORM_TOOLS_ENV_FLAG] === "1";
 }


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Jolli Memory

[https://jolli.ai/very/o/default/articles/default-mcp-platform-tools-on-handle-local-and-remote-workflow-runs-8179](https://jolli.ai/very/o/default/articles/default-mcp-platform-tools-on-handle-local-and-remote-workflow-runs-8179)

## Context (3)

- [148. MCP server — tool surface](https://jolli.ai/very/o/default/articles/148-mcp-server-tool-surface-8180)
- [272 — `jolli` Menu Skill Content](https://jolli.ai/very/o/default/articles/272-jolli-menu-skill-content-8176)
- [62. `jolli configure` — Manage configuration values](https://jolli.ai/very/o/default/articles/62-jolli-configure-manage-configuration-values-8177)

## Quick recap

The Jolli MCP server now registers the backend-defined platform tools by default instead of requiring opt-in. The `mcpPlatformToolsEnabled` gate is treated as enabled unless it is explicitly set to `false`, and the `JOLLI_MCP_PLATFORM_TOOLS=1` environment escape hatch still force-enables even over an explicit `false`. The workflow, space, and article tools are therefore available out of the box, and the `jolli configure` key description was updated to reflect the new default.

The `/jolli` menu skill's workflow entry was reworked from a single local-run item into one "Run a workflow" action that asks the user local versus remote (defaulting to local): local runs route to the `jolli-local-run` skill, remote runs to the `run_remote_workflow` MCP tool. Pure discovery and plumbing tools — `list_workflow_definitions` and the raw `run_remote_workflow`/`cancel_remote_workflow` — are excluded from the surfaced tool list so they no longer appear as standalone menu items.

The `jolli-local-run` skill's publish step now branches on the `docs publish --json` result rather than assuming a pull-request reference is always present. It passes `prNumber`/`prUrl` through for user-accessible destinations and completes the run without a PR reference for private Jolli-managed destinations, whose PR and repository references are deliberately withheld. It also reads `willAutoMerge` from the completion result, correcting an earlier read of the offer's `autoMerges` field that the completion result does not carry.

---

*Generated by Jolli Memory · July 16, 2026 at 5:30 PM*
<!-- jollimemory-summary-end -->
