### PR TITLE
Add web embed support via host-bridge and repoName graph stamping

### DIFF
--- a/cli/src/graph/GraphArtifactStore.test.ts
+++ b/cli/src/graph/GraphArtifactStore.test.ts
@@ -40,7 +40,7 @@ async function freshDir(): Promise<string> {
 describe("writeGraphArtifacts", () => {
 	it("writes graph.json (the only artifact) under the hidden .jolli/graph layer", async () => {
 		const root = await freshDir();
-		const graph = assembleGraph(tinyDistill(), new Map(), ISO, { t1: "fp" });
+		const graph = assembleGraph(tinyDistill(), new Map(), ISO, "", { t1: "fp" });
 
 		const result = await writeGraphArtifacts(root, graph);
 
@@ -54,7 +54,7 @@ describe("writeGraphArtifacts", () => {
 
 	it("writes atomically, leaving no .tmp sibling behind", async () => {
 		const root = await freshDir();
-		await writeGraphArtifacts(root, assembleGraph(tinyDistill(), new Map(), ISO));
+		await writeGraphArtifacts(root, assembleGraph(tinyDistill(), new Map(), ISO, ""));
 
 		// atomicWriteFile renames tmp → final, so no half-written sibling lingers.
 		expect(existsSync(join(root, ".jolli", "graph", "graph.json.tmp"))).toBe(false);
@@ -64,7 +64,7 @@ describe("writeGraphArtifacts", () => {
 describe("readGraph", () => {
 	it("round-trips a written graph", async () => {
 		const root = await freshDir();
-		const written = assembleGraph(tinyDistill(), new Map(), ISO, { t1: "fp" });
+		const written = assembleGraph(tinyDistill(), new Map(), ISO, "", { t1: "fp" });
 		await writeGraphArtifacts(root, written);
 
 		const got = await readGraph(root);
@@ -81,7 +81,7 @@ describe("readGraph", () => {
 	it("returns null when graph.json is unparseable (corrupt → full rebuild)", async () => {
 		const root = await freshDir();
 		// Write a valid graph first so the .jolli/graph dir exists, then corrupt it.
-		await writeGraphArtifacts(root, assembleGraph(tinyDistill(), new Map(), ISO));
+		await writeGraphArtifacts(root, assembleGraph(tinyDistill(), new Map(), ISO, ""));
 		await writeFile(graphJsonPath(root), "{ not valid json", "utf8");
 		expect(await readGraph(root)).toBeNull();
 	});

--- a/cli/src/graph/GraphBuilder.test.ts
+++ b/cli/src/graph/GraphBuilder.test.ts
@@ -131,6 +131,8 @@ describe("buildKnowledgeGraph", () => {
 		// Source metadata is joined onto the assembled graph; artifacts go to kbRoot.
 		const [rootArg, graphArg] = writeGraphArtifacts.mock.calls[0];
 		expect(rootArg).toBe("/kb");
+		// The full-build exit stamps the repo name (breadcrumb root) — basename("/kb") === "kb".
+		expect(graphArg.repoName).toBe("kb");
 		const t1 = graphArg.topics.find((t: { slug: string }) => t.slug === "t1");
 		expect(t1.fullBody).toBe("page body\n\nsecond para");
 		expect(t1.overview).toBe("page body"); // first non-heading paragraph
@@ -300,13 +302,21 @@ describe("buildKnowledgeGraph", () => {
 		expect(r.mode).toBe("incremental");
 		expect(distillGraphIncremental).toHaveBeenCalled();
 		expect(distillGraph).not.toHaveBeenCalled();
+		// The incremental-LLM exit shares assembleGraph with the full path — it must stamp
+		// repoName too (basename("/kb") === "kb"), else a content change reverts the breadcrumb.
+		const [, graphArg] = writeGraphArtifacts.mock.calls[0];
+		expect(graphArg.repoName).toBe("kb");
 	});
 
 	it("skips entirely (no LLM, no write) when both content and metadata fingerprints are unchanged", async () => {
 		readTopicIndex.mockResolvedValue(ONE_TOPIC_INDEX);
 		readTopicPage.mockResolvedValue(null); // content = "", no branches/commits
-		// Baseline matches BOTH the content fingerprint and the (empty) metadata one.
-		readGraph.mockResolvedValue(baselineGraph({ t1: fpOf("Topic1", "s1", "") }, { t1: metaOf([], []) }));
+		// Baseline matches the content fingerprint, the (empty) metadata one, AND the
+		// build-stamped repoName — only then is it a true no-op. basename("/kb") === "kb".
+		readGraph.mockResolvedValue({
+			...baselineGraph({ t1: fpOf("Topic1", "s1", "") }, { t1: metaOf([], []) }),
+			repoName: "kb",
+		});
 
 		const r = await buildKnowledgeGraph("/cwd", folderStorage, CONFIG, { nowIso: ISO });
 
@@ -380,6 +390,28 @@ describe("buildKnowledgeGraph", () => {
 		expect(r.built).toBe(true);
 		expect(r.mode).toBe("incremental");
 		expect(writeGraphArtifacts).toHaveBeenCalled();
+	});
+
+	it("reassembles without LLM when content and metadata match but repoName is stale (heals repoName)", async () => {
+		readTopicIndex.mockResolvedValue(ONE_TOPIC_INDEX);
+		readTopicPage.mockResolvedValue(null); // content + metadata both unchanged
+		// Content AND metadata fingerprints match, so the only drift is the build-stamped
+		// repoName. Here it is stale ("old-name" from a rename); an absent field behaves the
+		// same. Either way a no-LLM reassemble must run and stamp the current basename("/kb").
+		readGraph.mockResolvedValue({
+			...richBaseline({ t1: fpOf("Topic1", "s1", "") }, { t1: metaOf([], []) }),
+			repoName: "old-name",
+		});
+
+		const r = await buildKnowledgeGraph("/cwd", folderStorage, CONFIG, { nowIso: ISO });
+
+		expect(r.built).toBe(true);
+		expect(r.mode).toBe("incremental");
+		expect(distillGraph).not.toHaveBeenCalled();
+		expect(distillGraphIncremental).not.toHaveBeenCalled();
+		expect(writeGraphArtifacts).toHaveBeenCalled();
+		const [, graphArg] = writeGraphArtifacts.mock.calls[0];
+		expect(graphArg.repoName).toBe("kb"); // refreshed to basename("/kb")
 	});
 
 	it("rebuilds fully when the baseline schemaVersion does not match", async () => {

--- a/cli/src/graph/GraphBuilder.ts
+++ b/cli/src/graph/GraphBuilder.ts
@@ -13,6 +13,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { basename } from "node:path";
 import { createFolderStorageAtRoot } from "../core/StorageFactory.js";
 import type { StorageProvider } from "../core/StorageProvider.js";
 import { readTopicIndex } from "../core/TopicIndexStore.js";
@@ -131,6 +132,8 @@ export async function buildKnowledgeGraph(
 	}
 
 	const kbRoot = storage.kbRoot ?? cwd;
+	// Repo display name stamped into graph.json → the viz breadcrumb root.
+	const repoName = basename(kbRoot);
 	const now = opts?.nowIso ?? new Date().toISOString();
 	const startedAt = performance.now();
 
@@ -170,7 +173,7 @@ export async function buildKnowledgeGraph(
 		// that is already empty) still skips.
 		if (prevDistill && prevDistill.topics.length > 0) {
 			log.info("All topics deleted (was %d) -- writing empty knowledge graph", prevDistill.topics.length);
-			const empty = assembleGraph({ categories: [], topics: [], units: [], edges: [] }, new Map(), now, {}, {});
+			const empty = assembleGraph({ categories: [], topics: [], units: [], edges: [] }, new Map(), now, repoName);
 			opts?.onProgress?.("writing graph.json");
 			const { graphJsonPath } = await writeGraphArtifacts(kbRoot, empty);
 			return { built: true, mode: "incremental", topics: 0, units: 0, edges: 0, graphJsonPath };
@@ -214,14 +217,14 @@ export async function buildKnowledgeGraph(
 			const prevMeta = isFingerprintMap(prevGraph?.topicMetaFingerprints)
 				? prevGraph.topicMetaFingerprints
 				: null;
-			if (prevMeta && sameFingerprints(prevMeta, metaFingerprints)) {
+			if (prevMeta && sameFingerprints(prevMeta, metaFingerprints) && prevGraph?.repoName === repoName) {
 				log.info("Knowledge graph unchanged (%d topics) -- skipping rebuild", index.topics.length);
 				return { built: false, reason: "no changes", topics: index.topics.length };
 			}
-			log.info("Knowledge graph content unchanged but source metadata drifted -- reassembling (no LLM)");
+			log.info("Knowledge graph content unchanged but source metadata/repoName drifted -- reassembling (no LLM)");
 			mode = "incremental";
 			distill = prevDistill;
-			const graph = assembleGraph(distill, sources, now, fingerprints, metaFingerprints);
+			const graph = assembleGraph(distill, sources, now, repoName, fingerprints, metaFingerprints);
 			opts?.onProgress?.("writing graph.json");
 			const { graphJsonPath } = await writeGraphArtifacts(kbRoot, graph);
 			log.info(
@@ -274,7 +277,7 @@ export async function buildKnowledgeGraph(
 		distill = await distillGraph({ topics: topicsInput }, config, opts?.onProgress);
 	}
 
-	const graph = assembleGraph(distill, sources, now, fingerprints, metaFingerprints);
+	const graph = assembleGraph(distill, sources, now, repoName, fingerprints, metaFingerprints);
 
 	opts?.onProgress?.("writing graph.json");
 	const { graphJsonPath } = await writeGraphArtifacts(kbRoot, graph);

--- a/cli/src/graph/GraphSchema.test.ts
+++ b/cli/src/graph/GraphSchema.test.ts
@@ -250,7 +250,7 @@ describe("assembleGraph", () => {
 	]);
 
 	it("joins source metadata, computes rollups + stats", () => {
-		const graph = assembleGraph(validGraph(), sources, "2026-06-15T00:00:00.000Z");
+		const graph = assembleGraph(validGraph(), sources, "2026-06-15T00:00:00.000Z", "");
 
 		expect(graph.generatedAt).toBe("2026-06-15T00:00:00.000Z");
 		expect(graph.schemaVersion).toBe(2);
@@ -312,7 +312,7 @@ describe("assembleGraph", () => {
 			],
 			edges: [{ from: "t1::u1", to: "t2::u2", type: "related-to", confidence: 0.7, evidence: "same cat" }],
 		};
-		const graph = assembleGraph(distill, new Map(), "2026-06-15T00:00:00.000Z");
+		const graph = assembleGraph(distill, new Map(), "2026-06-15T00:00:00.000Z", "");
 		expect(graph.stats.crossTopicEdges).toBe(1);
 		expect(graph.stats.crossCategoryEdges).toBe(0);
 		// t3 has no units — the `?? 0` rollup path.
@@ -325,7 +325,7 @@ describe("assembleGraph", () => {
 		// symmetric collapse is isolated from the related-to subsumption rule.
 		g.edges.push({ from: "t1::u2", to: "t2::u3", type: "related-to", confidence: 0.6, evidence: "fwd" });
 		g.edges.push({ from: "t2::u3", to: "t1::u2", type: "related-to", confidence: 0.9, evidence: "rev" });
-		const graph = assembleGraph(g, sources, "2026-06-15T00:00:00.000Z");
+		const graph = assembleGraph(g, sources, "2026-06-15T00:00:00.000Z", "");
 		// 2 original directed + 1 collapsed symmetric = 3 (not 4).
 		expect(graph.stats.edges).toBe(3);
 		expect(graph.edges).toHaveLength(3);
@@ -339,7 +339,7 @@ describe("assembleGraph", () => {
 		// Distiller also emitted a generic related-to for the same pair (reversed) at
 		// higher confidence — it must be dropped in favor of the specific extends.
 		g.edges.push({ from: "t1::u2", to: "t1::u1", type: "related-to", confidence: 0.95, evidence: "generic" });
-		const graph = assembleGraph(g, sources, "2026-06-15T00:00:00.000Z");
+		const graph = assembleGraph(g, sources, "2026-06-15T00:00:00.000Z", "");
 		// extends (t1) + caused-by (cross) survive; the related-to is subsumed.
 		expect(graph.stats.edges).toBe(2);
 		expect(graph.edges.some((x) => x.type === "related-to")).toBe(false);
@@ -349,7 +349,7 @@ describe("assembleGraph", () => {
 	it("throws on a graph that fails validation", () => {
 		const g = validGraph();
 		g.edges.push({ from: "ghost", to: "t1::u1", type: "extends", confidence: 0.6, evidence: "x" });
-		expect(() => assembleGraph(g, sources, "2026-06-15T00:00:00.000Z")).toThrow(/validation failed/);
+		expect(() => assembleGraph(g, sources, "2026-06-15T00:00:00.000Z", "")).toThrow(/validation failed/);
 	});
 
 	it("embeds the passed topicFingerprints / topicMetaFingerprints (and defaults both to {})", () => {
@@ -357,21 +357,30 @@ describe("assembleGraph", () => {
 			validGraph(),
 			sources,
 			"2026-06-15T00:00:00.000Z",
+			"",
 			{ t1: "a", t2: "b" },
 			{ t1: "m" },
 		);
 		expect(withFp.topicFingerprints).toEqual({ t1: "a", t2: "b" });
 		expect(withFp.topicMetaFingerprints).toEqual({ t1: "m" });
-		const withoutFp = assembleGraph(validGraph(), sources, "2026-06-15T00:00:00.000Z");
+		const withoutFp = assembleGraph(validGraph(), sources, "2026-06-15T00:00:00.000Z", "");
 		expect(withoutFp.topicFingerprints).toEqual({});
 		expect(withoutFp.topicMetaFingerprints).toEqual({});
+	});
+
+	it("stamps repoName when provided and omits the field for an empty name", () => {
+		const withRepo = assembleGraph(validGraph(), sources, "2026-06-15T00:00:00.000Z", "jolli");
+		expect(withRepo.repoName).toBe("jolli");
+		// Empty repo name (e.g. an unexpected root basename) omits the field rather than stamping "".
+		const withoutRepo = assembleGraph(validGraph(), sources, "2026-06-15T00:00:00.000Z", "");
+		expect(withoutRepo.repoName).toBeUndefined();
 	});
 
 	it("prunes a category that ends up with zero topics", () => {
 		const distill = validGraph();
 		// Add an extra category no topic references → must be pruned by assembleGraph.
 		distill.categories.push({ id: "orphan-cat", shortTitle: "Orphan", summary: "Nobody here." });
-		const graph = assembleGraph(distill, sources, "2026-06-15T00:00:00.000Z");
+		const graph = assembleGraph(distill, sources, "2026-06-15T00:00:00.000Z", "");
 		expect(graph.categories.map((c) => c.id).sort()).toEqual(["cat-a", "cat-b"]);
 		expect(graph.stats.categories).toBe(2);
 	});
@@ -414,7 +423,7 @@ describe("diffTopics", () => {
 describe("toDistilled", () => {
 	function priorGraph(): unknown {
 		// A real emitted KnowledgeGraph (the incremental baseline shape).
-		return assembleGraph(validGraph(), new Map(), "2026-06-15T00:00:00.000Z", { t1: "a", t2: "b" });
+		return assembleGraph(validGraph(), new Map(), "2026-06-15T00:00:00.000Z", "", { t1: "a", t2: "b" });
 	}
 
 	it("strips derived fields and restores the DistilledGraph subset", () => {

--- a/cli/src/graph/GraphSchema.ts
+++ b/cli/src/graph/GraphSchema.ts
@@ -157,6 +157,13 @@ export interface KnowledgeGraph {
 	readonly generatedAt: string;
 	readonly source: string;
 	/**
+	 * Repo/knowledge-base display name (the repo directory's basename), stamped at
+	 * build time. Consumed by the viz breadcrumb root (falls back to "Project" when
+	 * absent — e.g. graph.json built before this field existed). Optional so older
+	 * graph.json stays valid without a schema-version bump.
+	 */
+	readonly repoName?: string;
+	/**
 	 * Per-topic content fingerprint, keyed by `stableSlug`. The incremental
 	 * baseline: GraphBuilder diffs the previous graph.json's fingerprints against
 	 * the freshly-computed ones to find dirty/new/deleted topics. Empty `{}` on a
@@ -286,11 +293,18 @@ export function dropSubsumedRelatedTo(edges: ReadonlyArray<GraphEdge>): GraphEdg
  * rather than failing the compile).
  *
  * Topics absent from `sources` get empty source metadata (still rendered).
+ *
+ * `repoName` is required (the breadcrumb root, e.g. "jolli") and precedes the
+ * optional fingerprint maps so every caller must supply it — the stamp was
+ * previously an optional trailing arg that the full/incremental build paths
+ * silently dropped, reverting the breadcrumb to "Project". An empty string
+ * omits the field.
  */
 export function assembleGraph(
 	distill: DistilledGraph,
 	sources: ReadonlyMap<string, TopicSourceMeta>,
 	generatedAt: string,
+	repoName: string,
 	topicFingerprints: Record<string, string> = {},
 	topicMetaFingerprints: Record<string, string> = {},
 ): KnowledgeGraph {
@@ -384,6 +398,7 @@ export function assembleGraph(
 		schemaVersion: GRAPH_SCHEMA_VERSION,
 		generatedAt,
 		source: "topic KB distillation (LLM categories/topics/units/edges + computed joins)",
+		...(repoName ? { repoName } : {}),
 		topicFingerprints,
 		topicMetaFingerprints,
 		stats,

--- a/cli/src/graph/assets/index.html
+++ b/cli/src/graph/assets/index.html
@@ -9,10 +9,19 @@
 <body>
   <div class="app">
     <header class="topbar">
-      <div class="brand"><span class="brand-name">Jolli</span><span class="brand-sub">GRAPH</span></div>
+      <!-- Host-activated controls: hidden by default; a hosting page (the Jolli
+           web app) reveals them over the postMessage handshake (see host-bridge.js).
+           Standalone / VS Code webview never handshake, so they stay hidden. -->
+      <button type="button" class="host-btn" id="host-btn-expand-tree" title="Show sidebar" aria-label="Show sidebar" hidden>
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"></rect><path d="M9 3v18"></path></svg>
+      </button>
+      <div class="brand"><span class="brand-name">Graph</span></div>
       <nav class="breadcrumb" id="breadcrumb"></nav>
       <div class="topbar-spacer"></div>
       <input type="search" class="searchbox" id="searchbox" placeholder="Search topics & units…" autocomplete="off" />
+      <button type="button" class="host-btn" id="host-btn-close" title="Close graph" aria-label="Close graph" hidden>
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12"></path></svg>
+      </button>
     </header>
 
     <div class="layout">
@@ -46,6 +55,7 @@
   <script src="vendor/panzoom.min.js"></script>
   <script src="vendor/elk.bundled.js"></script>
   <script src="vendor/marked.min.js"></script>
+  <script src="js/host-bridge.js"></script>
   <script src="js/data.js"></script>
   <script src="js/state.js"></script>
   <script src="js/edges.js"></script>

--- a/cli/src/graph/assets/js/data.js
+++ b/cli/src/graph/assets/js/data.js
@@ -16,6 +16,9 @@
     let graph;
     if (window.__EMBEDDED_GRAPH__) {
       graph = window.__EMBEDDED_GRAPH__;
+    } else if (window.WikiHost && window.WikiHost.embedded) {
+      // Embedded in a host page (iframe): the host posts the graph (and theme) to us.
+      graph = await window.WikiHost.requestGraph();
     } else {
       const res = await fetch("../data/wiki-graph.json");
       if (!res.ok) throw new Error("wiki-graph.json: " + res.status);

--- a/cli/src/graph/assets/js/host-bridge.js
+++ b/cli/src/graph/assets/js/host-bridge.js
@@ -1,0 +1,178 @@
+// host-bridge.js — embed adapter.
+//
+// When the graph runs standalone (the VS Code webview export, or opened as a
+// plain file) it reads window.__EMBEDDED_GRAPH__ or fetches wiki-graph.json.
+// When it runs EMBEDDED in a host page (inside an <iframe>), that host instead
+// injects the graph data and the current theme over postMessage — the host
+// holds any auth / network access, so the iframe makes no requests of its own.
+//
+// Inert unless framed: window.WikiHost.embedded is false when not in an iframe,
+// and data.js only takes the handshake path when __EMBEDDED_GRAPH__ is absent,
+// so the VS Code webview / export (which set __EMBEDDED_GRAPH__) never touch it.
+//
+// Plain script (no modules); loaded before data.js; exposes window.WikiHost.
+(function () {
+  "use strict";
+
+  // True when this document is rendered inside another frame (a host page).
+  var embedded = window.parent && window.parent !== window;
+
+  // Apply host-provided CSS custom properties (already-resolved theme tokens,
+  // e.g. "--vscode-editor-background" -> "hsl(0 0% 8%)") onto :root, then flip
+  // the light/dark class the palette keys off. Edge strokes are computed from
+  // CSS vars at draw time (not live var() refs), so repaint after a change.
+  function applyTheme(theme, vars) {
+    if (vars && typeof vars === "object") {
+      var root = document.documentElement;
+      for (var name in vars) {
+        if (Object.prototype.hasOwnProperty.call(vars, name)) {
+          root.style.setProperty(name, vars[name]);
+        }
+      }
+    }
+    if (theme === "light") {
+      document.body.classList.add("vscode-light");
+    } else {
+      document.body.classList.remove("vscode-light");
+    }
+    // Repaint edges only once the graph data AND views are ready. On the initial
+    // data handshake WikiData isn't built yet (data.js is still resolving) — the
+    // first WikiViews.render() will draw themed edges, so skip here to avoid
+    // redrawEdges reading an undefined WikiData. Live theme changes (post-render)
+    // have WikiData set and do repaint.
+    if (window.WikiData && window.WikiViews && typeof window.WikiViews.redrawEdges === "function") {
+      window.WikiViews.redrawEdges();
+    }
+  }
+
+  // The host page's origin, captured from the first message it sends us. Unknown
+  // until then: the initial `jolli-graph-ready` ping must broadcast because the
+  // parent can be on any origin and we have no other way to reach it. Once
+  // captured we pin both inbound checks and outbound targets to it, so a frame on
+  // another origin can neither spoof messages to us nor observe the ones we send.
+  var hostOrigin = null;
+
+  // Only trust messages coming from our parent (host) frame. Source gating alone
+  // already excludes sibling frames; the origin pin (once known) additionally
+  // rejects a parent that has navigated to a different origin mid-session.
+  function fromHost(event) {
+    if (!embedded || event.source !== window.parent) return false;
+    return hostOrigin === null || event.origin === hostOrigin;
+  }
+
+  function postToHost(type) {
+    if (!embedded) return;
+    // An opaque parent origin (sandboxed iframe / file://) reports as "null",
+    // which is not a valid postMessage targetOrigin — broadcast in that case.
+    var target = hostOrigin && hostOrigin !== "null" ? hostOrigin : "*";
+    window.parent.postMessage({ type: type }, target);
+  }
+
+  // Host-activated topbar controls (progressive enhancement). The buttons live
+  // in index.html but start hidden; the hosting page reveals them via the
+  // handshake `host` config and can toggle them live with `jolli-graph-host`.
+  // Standalone / VS Code never send these, so the buttons stay hidden there.
+  function wireHostControls() {
+    var closeBtn = document.getElementById("host-btn-close");
+    var expandBtn = document.getElementById("host-btn-expand-tree");
+    if (closeBtn) {
+      closeBtn.addEventListener("click", function () {
+        postToHost("jolli-graph-close");
+      });
+    }
+    if (expandBtn) {
+      expandBtn.addEventListener("click", function () {
+        postToHost("jolli-graph-expand-tree");
+      });
+    }
+  }
+
+  function applyHostControls(host) {
+    if (!host || typeof host !== "object") return;
+    var closeBtn = document.getElementById("host-btn-close");
+    var expandBtn = document.getElementById("host-btn-expand-tree");
+    if (closeBtn && host.canClose === true) {
+      closeBtn.hidden = false;
+    }
+    // The expand-tree affordance only makes sense while the host's sidebar is
+    // collapsed; the host sends the current state and updates it live.
+    if (expandBtn && typeof host.treeCollapsed === "boolean") {
+      expandBtn.hidden = !host.treeCollapsed;
+    }
+    // The graph is per-repo; the host supplies the repo name so the breadcrumb
+    // root reads e.g. "jolli" instead of the generic "Project" (views.js reads
+    // window.WikiHost.rootLabel). Set on the initial data handshake, before the
+    // first render.
+    if (typeof host.repoName === "string" && host.repoName) {
+      window.WikiHost.rootLabel = host.repoName;
+    }
+  }
+
+  wireHostControls();
+
+  // Live updates after boot: theme toggles and host-control state changes.
+  window.addEventListener("message", function (event) {
+    if (!fromHost(event)) return;
+    var data = event.data;
+    if (!data) return;
+    if (data.type === "jolli-graph-theme") {
+      applyTheme(data.theme, data.vars);
+    } else if (data.type === "jolli-graph-host") {
+      applyHostControls(data.host);
+    }
+  });
+
+  // One-shot handshake: announce readiness to the host and resolve with the
+  // graph it posts back. Rejects if the host reports a load error, or if the host
+  // never replies within the timeout (otherwise data.js awaits forever and the
+  // graph is stuck on the loading state — boot() renders the rejection visibly).
+  var HANDSHAKE_TIMEOUT_MS = 15000;
+  function requestGraph() {
+    return new Promise(function (resolve, reject) {
+      var timer = null;
+      function cleanup() {
+        window.removeEventListener("message", onMessage);
+        if (timer !== null) {
+          clearTimeout(timer);
+          timer = null;
+        }
+      }
+      function onMessage(event) {
+        if (!fromHost(event)) return;
+        var data = event.data;
+        if (!data || data.type !== "jolli-graph-data") return;
+        hostOrigin = event.origin; // pin every later message to this host
+        cleanup();
+        applyTheme(data.theme, data.vars);
+        applyHostControls(data.host);
+        if (data.error) {
+          reject(new Error(String(data.error)));
+        } else {
+          resolve(data.graph);
+        }
+      }
+      window.addEventListener("message", onMessage);
+      timer = setTimeout(function () {
+        cleanup();
+        reject(new Error("host did not provide graph data within " + HANDSHAKE_TIMEOUT_MS / 1000 + "s"));
+      }, HANDSHAKE_TIMEOUT_MS);
+      postToHost("jolli-graph-ready");
+    });
+  }
+
+  // Announce to the host that the themed graph is on screen (so it can reveal the
+  // iframe). Routed here rather than posted inline so it targets the pinned host
+  // origin, not "*".
+  function notifyRendered() {
+    postToHost("jolli-graph-rendered");
+  }
+
+  // rootLabel: breadcrumb root override (repo name), set from the host handshake.
+  window.WikiHost = {
+    embedded: embedded,
+    requestGraph: requestGraph,
+    notifyRendered: notifyRendered,
+    applyTheme: applyTheme,
+    rootLabel: null,
+  };
+})();

--- a/cli/src/graph/assets/js/main.js
+++ b/cli/src/graph/assets/js/main.js
@@ -179,6 +179,14 @@
     wireSearch();
     wireCanvasClear();
     wireResize();
+
+    // Tell an embedding host the themed graph is on screen, so it can reveal the
+    // iframe (it keeps us hidden until now to avoid a dark→light flash while the
+    // vendor scripts load). Inert standalone / in the VS Code webview: only posts
+    // when framed, and the parent ignores unknown message types.
+    if (window.WikiHost && window.WikiHost.embedded) {
+      window.WikiHost.notifyRendered();
+    }
   }
 
   if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", boot);

--- a/cli/src/graph/assets/js/views.js
+++ b/cli/src/graph/assets/js/views.js
@@ -769,11 +769,16 @@
     const s = S.get();
     const bc = document.getElementById("breadcrumb");
     let html = "";
+    // Breadcrumb root: a host (the Jolli web app) can override with the repo name;
+    // otherwise use the repoName stamped into graph.json (works in the VS Code
+    // webview / standalone too); fall back to "Project" for graph.json built before
+    // that field existed.
+    const rootLabel = (window.WikiHost && window.WikiHost.rootLabel) || (D.graph && D.graph.repoName) || null;
     if (s.level === "overview") {
-      html = `<span class="crumb current">Project Overview</span>`;
+      html = `<span class="crumb current">${rootLabel ? esc(rootLabel) : "Project Overview"}</span>`;
     } else {
       const th = D.categoriesById.get(s.categoryId);
-      html = `<span class="crumb" data-nav="overview">Project</span>` +
+      html = `<span class="crumb" data-nav="overview">${rootLabel ? esc(rootLabel) : "Project"}</span>` +
         `<span class="sep">›</span>` +
         `<span class="crumb current">${esc(th ? th.shortTitle : s.categoryId)}</span>` +
         `<span class="esc-hint">(Esc to go back)</span>`;

--- a/cli/src/graph/assets/styles/main.css
+++ b/cli/src/graph/assets/styles/main.css
@@ -91,8 +91,7 @@ body {
   flex-shrink: 0;
 }
 .brand { display: flex; align-items: baseline; gap: 6px; }
-.brand-name { font-weight: 700; font-size: 17px; color: var(--accent); }
-.brand-sub { font-size: 11px; letter-spacing: 0.18em; color: var(--muted); }
+.brand-name { font-weight: 600; font-size: 13px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
 
 .breadcrumb { display: flex; align-items: center; gap: 8px; font-size: 13px; }
 .breadcrumb .crumb {
@@ -114,6 +113,17 @@ body {
 }
 .searchbox:focus { border-color: var(--accent-soft); width: 340px; }
 .searchbox::placeholder { color: var(--muted); }
+
+/* Host-activated topbar controls (see index.html / host-bridge.js). Hidden until
+   a hosting page reveals them; [hidden] must win over the inline-flex default. */
+.host-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 28px; height: 28px; padding: 0; flex-shrink: 0;
+  border: none; border-radius: 6px; background: transparent;
+  color: var(--muted); cursor: pointer; transition: background .15s, color .15s;
+}
+.host-btn:hover { background: var(--surface-hover); color: var(--ink); }
+.host-btn[hidden] { display: none; }
 
 /* ── Layout ─────────────────────────────────────────────── */
 .layout { display: flex; flex: 1; min-height: 0; }

--- a/cli/vite.config.ts
+++ b/cli/vite.config.ts
@@ -1,17 +1,62 @@
-import { cpSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { cpSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, extname, join, relative, resolve } from "node:path";
+import { transform } from "esbuild";
 import { defineConfig } from "vite";
 
 const pkg = JSON.parse(readFileSync(resolve(__dirname, "package.json"), "utf-8"));
 
 // The knowledge-graph viz runtime (HTML/CSS/JS/vendor) is read at runtime by
 // `jolli graph --export`, relative to the bundle. Copy it next to dist/ as
-// graph-assets/ so it ships in the published package. (The VS Code extension
-// has its own copy step; this one is CLI-only.)
+// graph-assets/ — this is the CANONICAL, compressed source of the viz: authored
+// JS/CSS are esbuild-minified here; vendor/ + index.html are copied verbatim
+// (index.html keeps its `<!-- scripts:start -->` / charset / stylesheet markers;
+// vendor is already in distributed form — elk is GWT-compiled and barely
+// minifies). Both this CLI (for `graph --export`) and downstream consumers (the
+// VS Code extension and the Jolli web app) copy FROM this output — no one
+// re-minifies, so compression lives in exactly one place (DRY).
+const graphAssetsSrc = resolve(__dirname, "src/graph/assets");
+const graphAssetsDest = resolve(__dirname, "dist/graph-assets");
+
+function walkGraphAssets(dir: string): Array<string> {
+	const out: Array<string> = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const abs = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			out.push(...walkGraphAssets(abs));
+		} else {
+			out.push(abs);
+		}
+	}
+	return out;
+}
+
+/** Minify the code we author (js/ + css); ship vendor/ + html verbatim. */
+function shouldMinifyGraphAsset(file: string): boolean {
+	if (file.replaceAll("\\", "/").includes("/vendor/")) {
+		return false;
+	}
+	const ext = extname(file);
+	return ext === ".css" || ext === ".js";
+}
+
 const copyGraphAssets = {
 	name: "copy-graph-assets",
-	closeBundle() {
-		cpSync(resolve(__dirname, "src/graph/assets"), resolve(__dirname, "dist/graph-assets"), { recursive: true });
+	async closeBundle() {
+		rmSync(graphAssetsDest, { recursive: true, force: true });
+		for (const abs of walkGraphAssets(graphAssetsSrc)) {
+			const out = join(graphAssetsDest, relative(graphAssetsSrc, abs));
+			mkdirSync(dirname(out), { recursive: true });
+			if (shouldMinifyGraphAsset(abs)) {
+				const { code } = await transform(readFileSync(abs, "utf8"), {
+					minify: true,
+					loader: extname(abs) === ".css" ? "css" : "js",
+					legalComments: "inline", // preserve @license / @preserve banners
+				});
+				writeFileSync(out, code, "utf8");
+			} else {
+				cpSync(abs, out);
+			}
+		}
 	},
 };
 

--- a/vscode/scripts/copy-graph-assets.mjs
+++ b/vscode/scripts/copy-graph-assets.mjs
@@ -1,64 +1,35 @@
-import { cpSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, extname, join, relative } from "node:path";
+import { cpSync, existsSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { transform } from "esbuild";
 
-// The knowledge-graph viz runtime (JS/CSS/HTML) lives in the CLI workspace (the
-// single, readable source of truth). Copy it into assets/graph/ so the webview
-// can load it via asWebviewUri. assets/ ships in the VSIX (not in .vscodeignore)
-// and is gitignored (regenerated on every build), mirroring assets/codicons/.
+// The knowledge-graph viz runtime is compiled ONCE by the CLI build into
+// cli/dist/graph-assets/ (authored JS/CSS minified there via esbuild; vendor/ +
+// index.html copied verbatim). The extension ships a copy under assets/graph/ so
+// the webview can load it via asWebviewUri — assets/ ships in the VSIX (not in
+// .vscodeignore) and is gitignored / regenerated each build, mirroring
+// assets/codicons/. We copy the CLI's compiled output VERBATIM (no re-minify),
+// so compression lives in exactly one place — the CLI build (DRY). index.html's
+// `<!-- scripts:start -->` / charset / stylesheet markers are preserved because
+// the CLI ships index.html verbatim; they survive for KnowledgeGraphPanel.renderGraphHtml.
 //
-// COMPRESSION: minify the code we author (app JS under js/, CSS under styles/);
-// copy vendor/ verbatim — it's already in distributed form (marked.min.js /
-// panzoom.min.js carry their license banners, and elk.bundled.js is GWT-compiled
-// so it barely minifies (~9%) while being the one file we can't easily verify
-// post-minify; the VSIX zip compresses it on the wire regardless). index.html is
-// copied verbatim so its `<!-- scripts:start -->` / charset / stylesheet markers
-// survive for KnowledgeGraphPanel.renderGraphHtml.
+// ORDER: the CLI must be built before this runs (the extension build depends on
+// the CLI). If cli/dist/graph-assets is missing, build the CLI first.
 const here = dirname(fileURLToPath(import.meta.url));
-const src = join(here, "..", "..", "cli", "src", "graph", "assets");
+const src = join(here, "..", "..", "cli", "dist", "graph-assets");
 const dest = join(here, "..", "assets", "graph");
 
-function walk(dir) {
-	const out = [];
-	for (const e of readdirSync(dir, { withFileTypes: true })) {
-		const p = join(dir, e.name);
-		if (e.isDirectory()) out.push(...walk(p));
-		else out.push(p);
-	}
-	return out;
+if (!existsSync(src)) {
+	console.error(
+		`[copy-graph-assets] ${src} not found — build the CLI first (npm run build in cli/) so its compiled graph assets exist.`,
+	);
+	process.exit(1);
 }
 
-/** Minify the code we author (js/ + styles/); copy vendor/ + html verbatim. */
-function shouldMinify(file) {
-	if (file.replaceAll("\\", "/").includes("/vendor/")) return false; // ship vendor as distributed
-	const ext = extname(file);
-	return ext === ".css" || ext === ".js";
-}
-
-async function build() {
+try {
 	rmSync(dest, { recursive: true, force: true });
-	let savedBytes = 0;
-	for (const abs of walk(src)) {
-		const out = join(dest, relative(src, abs));
-		mkdirSync(dirname(out), { recursive: true });
-		if (shouldMinify(abs)) {
-			const original = readFileSync(abs, "utf8");
-			const { code } = await transform(original, {
-				minify: true,
-				loader: extname(abs) === ".css" ? "css" : "js",
-				legalComments: "inline", // preserve @license / @preserve banners
-			});
-			writeFileSync(out, code, "utf8");
-			savedBytes += Buffer.byteLength(original) - Buffer.byteLength(code);
-		} else {
-			cpSync(abs, out);
-		}
-	}
-	console.log(`[copy-graph-assets] minified + copied to ${dest} (saved ${(savedBytes / 1024).toFixed(0)} KB)`);
-}
-
-build().catch((err) => {
+	cpSync(src, dest, { recursive: true });
+	console.log(`[copy-graph-assets] copied compiled CLI graph assets from ${src} → ${dest}`);
+} catch (err) {
 	console.error("[copy-graph-assets] failed:", err);
 	process.exit(1);
-});
+}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The graph viewer gained full support for running embedded inside a web application. A new bridge script handles the entire lifecycle of an embedded session: it detects the iframe context, performs a handshake with the parent page to receive graph data and the current color theme, and relays user actions (closing the panel, expanding a sidebar) back to the host. The iframe makes no network requests of its own — the host page supplies everything — and the bridge is completely inert when the graph runs standalone or inside the VS Code extension, so existing behavior is unchanged. Two new topbar buttons (close and expand-tree) live in the page from the start but stay hidden until a host page explicitly reveals them, keeping the standalone experience clean.

The graph breadcrumb now shows the actual repository name instead of the generic "Project" label. The name is stamped into the graph data file at build time using the knowledge-base directory's name, so it works in the VS Code extension and standalone viewer without any extra configuration. The web embed path lets a hosting page override the label with its own value. Older graph files without the stamped name fall back gracefully to the previous "Project" label. The incremental build was also updated to detect when a directory rename has made the stored name stale and heal it automatically on the next build, without invoking the language model.

---

## Topics (3)
<details>
<summary><strong>01 · Graph visualization can now run embedded inside a host web page</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The graph viewer was designed to run standalone or inside the VS Code extension, but there was no way to embed it inside a web application as an iframe. A hosting page needed a way to inject graph data, apply its own theme, and communicate user actions (like closing the panel or expanding a sidebar) without the iframe making its own network requests.

**💡 Decisions Behind the Code**

- **Inert-by-default design**: The bridge script is loaded on every page but activates only when the page is actually framed. Standalone use (VS Code webview, direct file open) is completely unaffected — no behavior changes, no extra network calls, no visible difference. This avoids the need for separate build outputs or conditional script loading, keeping the asset pipeline simple.
- **Host holds all data and auth**: Rather than having the iframe fetch graph data itself (which would require CORS headers, auth token forwarding, or a shared origin), the host page posts the graph payload over postMessage. This keeps the iframe stateless and auth-free, which is safer and simpler for the hosting web app to control.
- **Progressive enhancement for host controls**: The close and expand-tree buttons are present in the HTML from the start but hidden with the `hidden` attribute. The host reveals them selectively via the handshake config. This means the buttons never appear in standalone or VS Code contexts without any JavaScript branching in the render path.

**✅ What Was Implemented**

- `cli/src/graph/assets/js/host-bridge.js` was created as a new plain-script module that runs before the data loader. It detects whether the graph is running inside an iframe, performs a one-shot postMessage handshake with the parent page to receive graph data and theme tokens, applies CSS custom properties to the document root for theming, and exposes `window.WikiHost` for the rest of the app to consume. Live theme and host-control updates after initial render are handled via a persistent message listener.
- `cli/src/graph/assets/js/data.js` was updated to check for `window.WikiHost.embedded` as a new data-loading path: when embedded, it calls `WikiHost.requestGraph()` instead of fetching `wiki-graph.json`, keeping the iframe free of direct network requests.
- `cli/src/graph/assets/js/main.js` was updated to post a `jolli-graph-rendered` message to the parent once the graph is fully painted, giving the host a signal to reveal the iframe and avoid a flash of unstyled content during vendor script loading.

**📁 FILES**
- `cli/src/graph/assets/js/host-bridge.js`
- `cli/src/graph/assets/js/data.js`
- `cli/src/graph/assets/js/main.js`
- `cli/src/graph/assets/index.html`
- `cli/src/graph/assets/styles/main.css`

</blockquote>
</details>
<details>
<summary><strong>02 · Graph breadcrumb now shows the actual repository name instead of &quot;Project&quot;</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The graph viewer's navigation breadcrumb always showed the generic label "Project" or "Project Overview" regardless of which repository was being visualized. Users working with multiple repositories had no way to tell from the breadcrumb which codebase they were looking at.

**💡 Decisions Behind the Code**

- **Optional field over schema version bump**: Making `repoName` optional means graph files built before this change continue to load and display correctly, falling back to "Project". A schema version bump would have forced a full rebuild on every user's first run after upgrading, which is disruptive for large knowledge bases.
- **Basename of the KB root directory**: The repo name is derived from the directory name of the knowledge-base root rather than from git metadata or a config value. This requires no extra I/O, works offline, and matches what users already see in their file system — the trade-off is that renamed directories produce a stale value until the next build, which the incremental build logic now detects and heals automatically.
- **Stale repoName triggers a no-LLM reassemble**: The incremental skip condition was tightened to also require that the stored repo name matches the current one. A mismatch (e.g. after a directory rename) causes a cheap reassemble pass with no LLM calls, so the breadcrumb self-corrects on the next build without user intervention.

**✅ What Was Implemented**

- `cli/src/graph/GraphSchema.ts` adds an optional `repoName` field to the `KnowledgeGraph` interface and updates `assembleGraph()` to accept and stamp it into the output when provided. The field is optional so existing graph files without it remain valid without a schema version bump.
- `cli/src/graph/GraphBuilder.ts` derives `repoName` from the knowledge-base root directory's basename at build time and passes it through all `assembleGraph()` call sites, including the empty-graph and incremental-reassemble paths.
- `cli/src/graph/assets/js/views.js` reads the repo name for the breadcrumb from three sources in priority order: a host-page override (for the web embed case), the stamped field in the graph data (for VS Code and standalone), and finally the generic fallback for older graph files.

**📁 FILES**
- `cli/src/graph/GraphSchema.ts`
- `cli/src/graph/GraphBuilder.ts`
- `cli/src/graph/assets/js/views.js`

</blockquote>
</details>
<details>
<summary><strong>03 · Graph asset minification moved from VS Code extension build to CLI build</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The VS Code extension's build script was responsible for minifying the graph viewer's JavaScript and CSS using esbuild before copying the files into the extension package. This meant compression logic lived in the extension workspace rather than alongside the source files, and any other consumer (such as a web app) would need to re-implement or duplicate the minification step.

**💡 Decisions Behind the Code**

- **Single compression point (DRY)**: Minification now happens exactly once in the CLI build. The VS Code extension and any future consumer (the Jolli web app) copy the already-compressed output without re-processing it. Previously, each consumer had to independently minify the same source files, which risked inconsistency and made it harder to verify the output.
- **CLI must be built before the extension**: The extension build now has an explicit dependency on `cli/dist/graph-assets/` existing. The copy script exits with an error and a clear message if it is missing. This is a stricter build-order requirement than before, but it is the correct trade-off: it enforces the dependency explicitly rather than silently producing different output depending on build order.

**✅ What Was Implemented**

- `cli/vite.config.ts` was updated so the `copy-graph-assets` Vite plugin now walks the source assets, minifies authored JS and CSS via esbuild inline, and writes the compressed output to `cli/dist/graph-assets/`. Vendor files and HTML are copied verbatim. This makes the CLI build the single canonical source of compiled graph assets.
- `vscode/scripts/copy-graph-assets.mjs` was simplified from ~64 lines to ~35: it now just copies `cli/dist/graph-assets/` into the extension's `assets/graph/` directory verbatim, with an early-exit error if the CLI hasn't been built yet. All esbuild logic was removed from this script.

**📁 FILES**
- `cli/vite.config.ts`
- `vscode/scripts/copy-graph-assets.mjs`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 17, 2026 at 2:37 PM · via Anthropic*
<!-- jollimemory-summary-end -->