### PR TITLE
Fix clear-text logging of errors in hook handlers

### DIFF
--- a/cli/src/hooks/GeminiAfterAgentHook.ts
+++ b/cli/src/hooks/GeminiAfterAgentHook.ts
@@ -119,8 +119,12 @@ function isMainScript(): boolean {
 }
 
 if (isMainScript()) {
-	handleGeminiAfterAgentHook().catch((error: unknown) => {
-		console.error("[GeminiAfterAgentHook] Fatal error:", error);
+	handleGeminiAfterAgentHook().catch((_error: unknown) => {
+		// Log a static message only — never anything derived from the error.
+		// In the flush/sync chain an error can carry a jolliApiKey (e.g. in
+		// request headers), so nothing error-derived may reach the log sink
+		// (CodeQL js/clear-text-logging).
+		console.error("[GeminiAfterAgentHook] Fatal error: after-agent handler failed.");
 		process.exit(1);
 	});
 }

--- a/cli/src/hooks/StopHook.ts
+++ b/cli/src/hooks/StopHook.ts
@@ -195,8 +195,12 @@ function isMainScript(): boolean {
 }
 
 if (isMainScript()) {
-	handleStopHook().catch((error: unknown) => {
-		console.error("[StopHook] Fatal error:", error);
+	handleStopHook().catch((_error: unknown) => {
+		// Log a static message only — never anything derived from the error.
+		// In the flush/sync chain an error can carry a jolliApiKey (e.g. in
+		// request headers), so nothing error-derived may reach the log sink
+		// (CodeQL js/clear-text-logging).
+		console.error("[StopHook] Fatal error: stop-hook handler failed.");
 		process.exit(1);
 	});
 }


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Quick recap

This commit closed two high-severity security findings related to sensitive data leaking into application logs. When background hooks that report agent status encountered a fatal error, the failure handler previously logged the entire error object, which could include an API key if the error originated from a failed telemetry network request. Both affected hook error handlers now log only a fixed, generic failure message, ensuring no error-derived data ever reaches the logs.

The developer verified that two other hooks with similarly structured error handlers were not actually exposed to this risk, since they never interact with the telemetry system that carries the key, and left them unmodified. The fix mirrors an existing safe-logging pattern already established elsewhere in the codebase, keeping the handling of this type of error consistent across the application going forward.

https://github.com/jolliai/jolliai/security/code-scanning/54
https://github.com/jolliai/jolliai/security/code-scanning/53


---

## Topic (1)
<details>
<summary><strong>01 · Prevent API keys from leaking into logs via hook error handlers</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Automated security scanning flagged two high-severity findings showing that a secret API key could end up written to logs in plain text when certain background hooks failed with an error.

**💡 Decisions Behind the Code**

The fix followed an existing pattern already used elsewhere in the codebase (in `QueueWorker.ts`) for the same class of scanner finding, rather than inventing a new redaction or masking approach. Reusing the established static-message pattern keeps all affected files consistent and lets reviewers recognize the fix instantly, instead of introducing a new helper function that would need separate review and testing. The team also chose to strip the error object out of the log entirely rather than attempt to sanitize or redact only the sensitive part of it, since fully removing any error-derived data is a simpler and more reliable way to guarantee no sensitive value can slip through the log sink.

**✅ What Was Implemented**

- Investigated both flagged code paths and traced how the app secret key travels from telemetry components into hook error handlers, confirming that a failed network request during telemetry flushing could carry the key in its request details, and that this error object was then being logged directly.
- Fixed `cli/src/hooks/StopHook.ts` (line ~199) and `cli/src/hooks/GeminiAfterAgentHook.ts` (line ~123) by changing the top-level failure handlers to log a fixed, static message instead of the raw error object, so nothing derived from the error can reach the log output.
- Confirmed two other hooks with similar error-handling code (`PrepareMsgHook.ts`, `PostRewriteHook.ts`) never touch telemetry and therefore cannot carry the key, explaining why the scanner did not flag them, and left those files unchanged.

**📁 FILES**
- `cli/src/hooks/StopHook.ts`
- `cli/src/hooks/GeminiAfterAgentHook.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 17, 2026 at 6:07 PM · via Jolli proxy*
<!-- jollimemory-summary-end -->