### PR TITLE
release: intellij 0.99.8

### DIFF
--- a/intellij/CHANGELOG.md
+++ b/intellij/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.99.8
+
+### New Features
+
+- **Slack thread references** — Slack threads read through the Slack MCP server in your AI conversations are now captured as a fifth reference source, right alongside Linear, Jira, GitHub, and Notion, and shown in the committed-memory and working-memory views. A pasted thread permalink is picked up with zero configuration (including from plain-text messages); without one, a `slack.workspaceUrl` configured in Settings reconstructs the link — the URL is validated (HTTPS, `slack.com` host) when you save it.
+- **Smarter about what goes into a memory** — plans, notes, and references are now ranked for relevance against your change in one batched AI call before summarizing. Items judged clearly unrelated are left out of the summary and kept in the working area for a later commit; excluded items stay visible in the memory detail view and the folder Markdown for traceability. If the ranking call fails, summarization proceeds with the full set — it never blocks a commit.
+- **Agent guidance is now opt-in** — Jolli only teaches your AI agents to prefer it (via a managed block in `~/.claude/CLAUDE.md`, `~/.gemini/GEMINI.md`, and `~/.codex/AGENTS.md`) once you turn it on under **Settings → Agents**. The decision is stored in the shared config, so the CLI, VS Code, and IntelliJ all honor the same choice. All three skills (`jolli-recall`, `jolli-search`, `jolli-pr`) are now installed with the current MCP-preferring content.
+- **Token usage travels with pushed memories** — the article pushed to your Jolli Space now carries the same **Task usage** line as the CLI and VS Code (token total, estimated cost, input/output/cached split), and the raw token figures are sent along with the push.
+
+### Fixes & Improvements
+
+- Auto-sync on push can now sync the queued summaries synchronously in one batch during `git push`, instead of only handing them to the background worker
+- Reference discovery no longer drops tool calls split across a scan boundary, so references near chunk edges are reliably captured
+- The CLI, VS Code, and IntelliJ stopped rewriting each other's installed skill files — skill updates are now guarded by a shared revision number instead of per-tool version strings
+- More reliable anonymous usage telemetry (still content-free): events carry deduplication ids, are batched and flushed in the background and at exit, benign no-op ingests are no longer reported as errors, and new or upgraded installs and key panel actions are counted
+
 ## 0.99.7
 
 ### New Features

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "ai.jolli"
-version = "0.99.7"
+version = "0.99.8"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Bump the IntelliJ plugin version to 0.99.8 and add its changelog entry.

The entry documents only what the plugin actually received since the 0.99.7 release:

- **Slack thread references** — fifth reference source alongside Linear, Jira, GitHub, and Notion; permalink-anchored, with an optional `slack.workspaceUrl` fallback validated in Settings
- **AI relevance filtering** — plans, notes, and references are ranked against the change in one batched AI call before summarizing; clearly unrelated items are soft-excluded and kept for a later commit (fail-open, never blocks a commit)
- **Opt-in agent guidance** — global skill instructions are applied only when enabled under Settings → Agents; the decision is stored in the shared config so CLI / VS Code / IntelliJ honor the same choice
- **Token usage on pushed memories** — the Task usage line and raw token figures now travel with memories pushed to a Jolli Space
- Fixes & improvements: synchronous batch push on pre-push sync, scan-boundary reference-discovery fix, revision-based skill idempotency across the three surfaces, telemetry reliability

CLI / VS Code 0.99.8 features that the IntelliJ plugin does not have yet are intentionally omitted from the changelog.
