### PR TITLE
Report workflow-run results (remote + local) with links, open-in-browser, and run history

### DIFF
--- a/cli/src/Api.ts
+++ b/cli/src/Api.ts
@@ -25,6 +25,7 @@ import { registerBindCommand, registerPushCommand, registerSpacesCommand } from 
 import { registerLocalRunOfferCommand } from "./commands/LocalRunOfferCommand.js";
 import { registerMcpCommand } from "./commands/McpCommand.js";
 import { registerMigrateCommand } from "./commands/MigrateCommand.js";
+import { registerOpenUrlCommand } from "./commands/OpenUrlCommand.js";
 import { registerPrDescriptionCommand } from "./commands/PrDescriptionCommand.js";
 import { registerQueueStatusCommand } from "./commands/QueueStatusCommand.js";
 import { registerRecallCommand } from "./commands/RecallCommand.js";
@@ -34,6 +35,8 @@ import { registerSyncCommand } from "./commands/SyncCommand.js";
 import { registerTelemetryCommand } from "./commands/TelemetryCommand.js";
 import { registerUninstallCommand } from "./commands/UninstallCommand.js";
 import { registerViewCommand } from "./commands/ViewCommand.js";
+import { registerWorkflowRunStatusCommand } from "./commands/WorkflowRunStatusCommand.js";
+import { registerWorkflowRunsCommand } from "./commands/WorkflowRunsCommand.js";
 // _parseJolliApiKey / _parseBaseUrl: re-exposed at the bottom of this file.
 // See the `parseJolliApiKey` export for the rationale (Vite tree-shaker drops
 // pure re-exports from the entry bundle when nothing inside the entry
@@ -168,6 +171,9 @@ const MEMORY_COMMAND_NAMES = new Set([
 	"pr-description",
 	"queue-status",
 	"local-run-workflows",
+	"open-url",
+	"workflow-run-status",
+	"workflow-runs",
 	"compile",
 	"graph",
 	"export",
@@ -354,6 +360,9 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 	registerBindCommand(program);
 	registerQueueStatusCommand(program);
 	registerLocalRunOfferCommand(program);
+	registerOpenUrlCommand(program);
+	registerWorkflowRunStatusCommand(program);
+	registerWorkflowRunsCommand(program);
 	registerCompileCommand(program);
 	registerGraphCommand(program);
 	registerMigrateCommand(program);

--- a/cli/src/Api.ts
+++ b/cli/src/Api.ts
@@ -34,6 +34,7 @@ import { registerStatusCommand } from "./commands/StatusCommand.js";
 import { registerSyncCommand } from "./commands/SyncCommand.js";
 import { registerTelemetryCommand } from "./commands/TelemetryCommand.js";
 import { registerUninstallCommand } from "./commands/UninstallCommand.js";
+import { registerVerifyPublishBranchCommand } from "./commands/VerifyPublishBranchCommand.js";
 import { registerViewCommand } from "./commands/ViewCommand.js";
 import { registerWorkflowRunStatusCommand } from "./commands/WorkflowRunStatusCommand.js";
 import { registerWorkflowRunsCommand } from "./commands/WorkflowRunsCommand.js";
@@ -172,6 +173,7 @@ const MEMORY_COMMAND_NAMES = new Set([
 	"queue-status",
 	"local-run-workflows",
 	"open-url",
+	"verify-publish-branch",
 	"workflow-run-status",
 	"workflow-runs",
 	"compile",
@@ -361,6 +363,7 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 	registerQueueStatusCommand(program);
 	registerLocalRunOfferCommand(program);
 	registerOpenUrlCommand(program);
+	registerVerifyPublishBranchCommand(program);
 	registerWorkflowRunStatusCommand(program);
 	registerWorkflowRunsCommand(program);
 	registerCompileCommand(program);

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -1083,6 +1083,19 @@ export interface JolliMemoryConfig {
 	 * to on. The `JOLLI_MCP_PLATFORM_TOOLS=1` env var overrides it at read time.
 	 */
 	readonly mcpPlatformToolsEnabled?: boolean;
+	/**
+	 * Opt-in extra origins that `jolli open-url` may auto-launch, on top of its
+	 * built-in jolli-origin and known-git-host allowlist tiers. A **local-development
+	 * affordance** for tunnel/dev deployments whose deep-links come from a public base
+	 * host (e.g. an ngrok host) that is neither a jolli origin nor a known git host.
+	 * Each entry is a bare host (`x.ngrok-free.dev`) or a full `https://…` origin,
+	 * normalized to a host and matched with the same suffix-boundary rule as the other
+	 * tiers. Empty/absent by default ⇒ the gate is identical to the two-tier default
+	 * (production/normal users unaffected). The `JOLLI_OPEN_URL_ALLOWED_ORIGINS` env var
+	 * (comma-separated) is **merged with** these — env adds to config, it does not
+	 * replace it. The URL opened is still `https`-only regardless of this list.
+	 */
+	readonly openUrlAllowedOrigins?: ReadonlyArray<string>;
 	/** Enable Codex CLI session discovery at post-commit time (default: auto-detect) */
 	readonly codexEnabled?: boolean;
 	/** Enable Gemini CLI session tracking via AfterAgent hook (default: auto-detect) */

--- a/cli/src/commands/OpenUrlCommand.test.ts
+++ b/cli/src/commands/OpenUrlCommand.test.ts
@@ -7,6 +7,10 @@ import { registerOpenUrlCommand } from "./OpenUrlCommand.js";
 const { openUrlOrPrintMock } = vi.hoisted(() => ({ openUrlOrPrintMock: vi.fn() }));
 vi.mock("../core/OpenUrl.js", () => ({ openUrlOrPrint: openUrlOrPrintMock }));
 
+// The command loads the persisted opt-in dev origins and passes them through.
+const { loadConfigMock } = vi.hoisted(() => ({ loadConfigMock: vi.fn() }));
+vi.mock("../core/SessionTracker.js", () => ({ loadConfig: loadConfigMock }));
+
 const URL_HTTPS = "https://jolli.ai/w/7/runs/abc";
 
 async function run(url: string): Promise<string> {
@@ -21,6 +25,8 @@ async function run(url: string): Promise<string> {
 beforeEach(() => {
 	process.exitCode = 0;
 	openUrlOrPrintMock.mockReset();
+	loadConfigMock.mockReset();
+	loadConfigMock.mockResolvedValue({});
 });
 afterEach(() => {
 	vi.restoreAllMocks();
@@ -32,9 +38,19 @@ describe("open-url command", () => {
 		openUrlOrPrintMock.mockResolvedValue({ opened: true, url: URL_HTTPS });
 
 		const out = await run(URL_HTTPS);
-		expect(openUrlOrPrintMock).toHaveBeenCalledWith(URL_HTTPS);
+		expect(openUrlOrPrintMock).toHaveBeenCalledWith(URL_HTTPS, { configOrigins: undefined });
 		expect(JSON.parse(out)).toEqual({ opened: true, url: URL_HTTPS });
 		expect(process.exitCode).toBe(0);
+	});
+
+	it("passes the persisted openUrlAllowedOrigins config through to openUrlOrPrint", async () => {
+		loadConfigMock.mockResolvedValue({ openUrlAllowedOrigins: ["abc123.ngrok-free.dev"] });
+		openUrlOrPrintMock.mockResolvedValue({ opened: true, url: URL_HTTPS });
+
+		await run(URL_HTTPS);
+		expect(openUrlOrPrintMock).toHaveBeenCalledWith(URL_HTTPS, {
+			configOrigins: ["abc123.ngrok-free.dev"],
+		});
 	});
 
 	it("prints { opened: false, url } and exits 0 when it fell back to printing (headless)", async () => {
@@ -42,6 +58,20 @@ describe("open-url command", () => {
 
 		const out = await run(URL_HTTPS);
 		expect(JSON.parse(out)).toEqual({ opened: false, url: URL_HTTPS });
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("passes through a refused (off-allowlist) result verbatim and exits 0", async () => {
+		const refused = {
+			opened: false,
+			url: "https://evil.example/x",
+			refused: true,
+			reason: "origin-not-allowlisted",
+		};
+		openUrlOrPrintMock.mockResolvedValue(refused);
+
+		const out = await run("https://evil.example/x");
+		expect(JSON.parse(out)).toEqual(refused);
 		expect(process.exitCode).toBe(0);
 	});
 

--- a/cli/src/commands/OpenUrlCommand.test.ts
+++ b/cli/src/commands/OpenUrlCommand.test.ts
@@ -1,0 +1,66 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerOpenUrlCommand } from "./OpenUrlCommand.js";
+
+// The command is thin wiring over `openUrlOrPrint`; mock that leaf so the
+// command's own wiring (JSON print, exit codes) runs for real.
+const { openUrlOrPrintMock } = vi.hoisted(() => ({ openUrlOrPrintMock: vi.fn() }));
+vi.mock("../core/OpenUrl.js", () => ({ openUrlOrPrint: openUrlOrPrintMock }));
+
+const URL_HTTPS = "https://jolli.ai/w/7/runs/abc";
+
+async function run(url: string): Promise<string> {
+	const logs: string[] = [];
+	vi.spyOn(console, "log").mockImplementation((m?: unknown) => void logs.push(String(m)));
+	const program = new Command();
+	registerOpenUrlCommand(program);
+	await program.parseAsync(["node", "jolli", "open-url", url]);
+	return logs.join("\n");
+}
+
+beforeEach(() => {
+	process.exitCode = 0;
+	openUrlOrPrintMock.mockReset();
+});
+afterEach(() => {
+	vi.restoreAllMocks();
+	process.exitCode = 0;
+});
+
+describe("open-url command", () => {
+	it("prints { opened: true, url } and exits 0 when the browser launched", async () => {
+		openUrlOrPrintMock.mockResolvedValue({ opened: true, url: URL_HTTPS });
+
+		const out = await run(URL_HTTPS);
+		expect(openUrlOrPrintMock).toHaveBeenCalledWith(URL_HTTPS);
+		expect(JSON.parse(out)).toEqual({ opened: true, url: URL_HTTPS });
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("prints { opened: false, url } and exits 0 when it fell back to printing (headless)", async () => {
+		openUrlOrPrintMock.mockResolvedValue({ opened: false, url: URL_HTTPS });
+
+		const out = await run(URL_HTTPS);
+		expect(JSON.parse(out)).toEqual({ opened: false, url: URL_HTTPS });
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("prints a type:error result and exits 1 for a non-https URL", async () => {
+		openUrlOrPrintMock.mockRejectedValue(new Error("open-url only opens https URLs, got scheme: http:"));
+
+		const out = await run("http://jolli.ai/x");
+		expect(JSON.parse(out)).toEqual({
+			type: "error",
+			message: "open-url only opens https URLs, got scheme: http:",
+		});
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("stringifies a non-Error rejection", async () => {
+		openUrlOrPrintMock.mockRejectedValue("weird");
+
+		const out = await run(URL_HTTPS);
+		expect(JSON.parse(out)).toEqual({ type: "error", message: "weird" });
+		expect(process.exitCode).toBe(1);
+	});
+});

--- a/cli/src/commands/OpenUrlCommand.ts
+++ b/cli/src/commands/OpenUrlCommand.ts
@@ -8,12 +8,17 @@
  *   - `{ opened: boolean, url }` — `opened:true` when the browser launched,
  *     `opened:false` when it fell back to printing the URL (headless / launch
  *     failure). Exit 0.
+ *   - `{ opened: false, url, refused: true, reason: "origin-not-allowlisted" }` —
+ *     an off-allowlist origin: refused (never launched), still printed. Exit 0 —
+ *     a refusal is a safe outcome, indistinguishable to the recipe from a headless
+ *     print except for the `refused` flag.
  *   - `{ type: "error", message }` — a non-`https` or missing/unparseable URL.
  *     Exit 1.
  */
 
 import type { Command } from "commander";
 import { openUrlOrPrint } from "../core/OpenUrl.js";
+import { loadConfig } from "../core/SessionTracker.js";
 
 /** Registers the `open-url` command on the given Commander program. */
 export function registerOpenUrlCommand(program: Command): void {
@@ -24,7 +29,10 @@ export function registerOpenUrlCommand(program: Command): void {
 		)
 		.action(async (url: string) => {
 			try {
-				const result = await openUrlOrPrint(url);
+				// Load the persisted opt-in dev origins (merged with the env var inside
+				// openUrlOrPrint). loadConfig never throws — a missing file yields {}.
+				const { openUrlAllowedOrigins } = await loadConfig();
+				const result = await openUrlOrPrint(url, { configOrigins: openUrlAllowedOrigins });
 				console.log(JSON.stringify(result));
 			} catch (error: unknown) {
 				const message = error instanceof Error ? error.message : String(error);

--- a/cli/src/commands/OpenUrlCommand.ts
+++ b/cli/src/commands/OpenUrlCommand.ts
@@ -1,0 +1,35 @@
+/**
+ * `open-url <url>` — open one backend-supplied `https` URL in the developer's
+ * default browser, or print it (headless / no browser / launch failure). The
+ * workflow-run recipes shell this per URL the user chooses to open; it never
+ * throws for a launch problem and never blocks.
+ *
+ * Output (always JSON on stdout, one line):
+ *   - `{ opened: boolean, url }` — `opened:true` when the browser launched,
+ *     `opened:false` when it fell back to printing the URL (headless / launch
+ *     failure). Exit 0.
+ *   - `{ type: "error", message }` — a non-`https` or missing/unparseable URL.
+ *     Exit 1.
+ */
+
+import type { Command } from "commander";
+import { openUrlOrPrint } from "../core/OpenUrl.js";
+
+/** Registers the `open-url` command on the given Commander program. */
+export function registerOpenUrlCommand(program: Command): void {
+	program
+		.command("open-url <url>")
+		.description(
+			"Open one https URL in the default browser (or print it when headless); prints { opened, url } as JSON",
+		)
+		.action(async (url: string) => {
+			try {
+				const result = await openUrlOrPrint(url);
+				console.log(JSON.stringify(result));
+			} catch (error: unknown) {
+				const message = error instanceof Error ? error.message : String(error);
+				console.log(JSON.stringify({ type: "error", message }));
+				process.exitCode = 1;
+			}
+		});
+}

--- a/cli/src/commands/VerifyPublishBranchCommand.test.ts
+++ b/cli/src/commands/VerifyPublishBranchCommand.test.ts
@@ -1,0 +1,50 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerVerifyPublishBranchCommand } from "./VerifyPublishBranchCommand.js";
+
+// Thin wiring over the pure `checkPublishBranch`; drive the real command so its
+// JSON print + exit-code wiring runs for real.
+async function run(args: string[]): Promise<string> {
+	const logs: string[] = [];
+	vi.spyOn(console, "log").mockImplementation((m?: unknown) => void logs.push(String(m)));
+	const program = new Command();
+	registerVerifyPublishBranchCommand(program);
+	await program.parseAsync(["node", "jolli", "verify-publish-branch", ...args]);
+	return logs.join("\n");
+}
+
+beforeEach(() => {
+	process.exitCode = 0;
+});
+afterEach(() => {
+	vi.restoreAllMocks();
+	process.exitCode = 0;
+});
+
+describe("verify-publish-branch command", () => {
+	it("prints { match: true } and exits 0 when the branches match", async () => {
+		const out = await run(["jolli-agent-8226c9abc576", "jolli-agent-8226c9abc576"]);
+		expect(JSON.parse(out)).toEqual({
+			match: true,
+			expected: "jolli-agent-8226c9abc576",
+			actual: "jolli-agent-8226c9abc576",
+		});
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("prints { match: false } and exits 1 when the publish landed on a different branch", async () => {
+		const out = await run(["jolli-agent-8226c9abc576", "jolli-6e3a72e55c22"]);
+		expect(JSON.parse(out)).toEqual({
+			match: false,
+			expected: "jolli-agent-8226c9abc576",
+			actual: "jolli-6e3a72e55c22",
+		});
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("exits 1 when headBranch is omitted (unverifiable publish)", async () => {
+		const out = await run(["jolli-agent-8226c9abc576"]);
+		expect(JSON.parse(out)).toEqual({ match: false, expected: "jolli-agent-8226c9abc576", actual: "" });
+		expect(process.exitCode).toBe(1);
+	});
+});

--- a/cli/src/commands/VerifyPublishBranchCommand.ts
+++ b/cli/src/commands/VerifyPublishBranchCommand.ts
@@ -1,0 +1,32 @@
+/**
+ * `verify-publish-branch <expected> [actual]` — deterministically confirm a
+ * local-run publish landed on the server-derived work branch. `<expected>` is the
+ * run's `writeTarget.workBranch`; `[actual]` is the `headBranch` that `docs publish
+ * --json` reported (the branch the PR was actually opened on). The `jolli-local-run`
+ * recipe shells this between publish and complete so the branch comparison does not
+ * rely on the LLM — the same actor whose dropped branch causes the mismatch.
+ *
+ * Output (always JSON on stdout, one line): `{ match, expected, actual }`.
+ * Exit 0 when the branches match; exit 1 when they differ (or `headBranch` is
+ * missing/empty — an unverifiable publish is treated as a mismatch, never a
+ * silent success).
+ */
+
+import type { Command } from "commander";
+import { checkPublishBranch } from "../core/WorkBranchCheck.js";
+
+/** Registers the `verify-publish-branch` command on the given Commander program. */
+export function registerVerifyPublishBranchCommand(program: Command): void {
+	program
+		.command("verify-publish-branch <expected> [actual]")
+		.description(
+			"Verify a local-run publish landed on the server work branch (compares expected workBranch to the published headBranch); prints { match, expected, actual }, exits non-zero on mismatch",
+		)
+		.action((expected: string, actual?: string) => {
+			const result = checkPublishBranch(expected, actual ?? "");
+			console.log(JSON.stringify(result));
+			if (!result.match) {
+				process.exitCode = 1;
+			}
+		});
+}

--- a/cli/src/commands/WorkflowRunStatusCommand.test.ts
+++ b/cli/src/commands/WorkflowRunStatusCommand.test.ts
@@ -1,0 +1,78 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerWorkflowRunStatusCommand } from "./WorkflowRunStatusCommand.js";
+
+const { monitorRunMock, realSleepMock, getRunStatusMock } = vi.hoisted(() => ({
+	monitorRunMock: vi.fn(),
+	realSleepMock: vi.fn().mockResolvedValue(undefined),
+	getRunStatusMock: vi.fn(),
+}));
+
+// The command constructs `new JolliMemoryPushClient()` and drives `monitorRun`.
+// Mock both leaves so the command's own wiring (deps assembly, JSON print, exit
+// codes) runs for real without a live backend or real timers.
+vi.mock("../core/WorkflowRunMonitor.js", () => ({ monitorRun: monitorRunMock, realSleep: realSleepMock }));
+vi.mock("../core/JolliMemoryPushClient.js", () => ({
+	JolliMemoryPushClient: class {
+		getRunStatus = getRunStatusMock;
+	},
+}));
+
+async function run(): Promise<string> {
+	const logs: string[] = [];
+	vi.spyOn(console, "log").mockImplementation((m?: unknown) => void logs.push(String(m)));
+	const program = new Command();
+	registerWorkflowRunStatusCommand(program);
+	await program.parseAsync(["node", "jolli", "workflow-run-status", "run_42"]);
+	return logs.join("\n");
+}
+
+beforeEach(() => {
+	process.exitCode = 0;
+	monitorRunMock.mockReset();
+	getRunStatusMock.mockReset();
+});
+afterEach(() => {
+	vi.restoreAllMocks();
+	process.exitCode = 0;
+});
+
+describe("workflow-run-status command", () => {
+	it("prints the monitor's report as JSON and wires the real client + sleep", async () => {
+		const report = {
+			status: "succeeded",
+			openableUrls: [{ kind: "workflow", url: "https://jolli.ai/w/1" }],
+		};
+		monitorRunMock.mockResolvedValue(report);
+
+		const out = await run();
+
+		expect(JSON.parse(out)).toEqual(report);
+		expect(process.exitCode).toBe(0);
+		expect(monitorRunMock).toHaveBeenCalledTimes(1);
+		const [deps, runId] = monitorRunMock.mock.calls[0];
+		expect(runId).toBe("run_42");
+		expect(deps.sleep).toBe(realSleepMock);
+		// The injected getRunStatus forwards to the client's method.
+		await deps.getRunStatus("run_42");
+		expect(getRunStatusMock).toHaveBeenCalledWith("run_42");
+	});
+
+	it("prints a type:error result and exits non-zero when the monitor rejects", async () => {
+		monitorRunMock.mockRejectedValue(new Error("platform tools off"));
+
+		const out = await run();
+
+		expect(JSON.parse(out)).toEqual({ type: "error", message: "platform tools off" });
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("stringifies a non-Error rejection", async () => {
+		monitorRunMock.mockRejectedValue("boom");
+
+		const out = await run();
+
+		expect(JSON.parse(out)).toEqual({ type: "error", message: "boom" });
+		expect(process.exitCode).toBe(1);
+	});
+});

--- a/cli/src/commands/WorkflowRunStatusCommand.ts
+++ b/cli/src/commands/WorkflowRunStatusCommand.ts
@@ -1,0 +1,43 @@
+/**
+ * `workflow-run-status <runId>` — monitor a remote workflow run to a terminal
+ * state and print its report as JSON. The `jolli-remote-run` recipe shells this
+ * once (after `run_remote_workflow` returns a run id) instead of driving the poll
+ * loop itself; the monitor owns backoff, terminal detection, and the timeout.
+ *
+ * Output (always JSON on stdout, one line):
+ *   - the `RunReport` shape (`{ status, openableUrls, cancel?, troubleshooting? }`)
+ *     with an added `timedOut?: boolean` when the attempt cap was hit while still
+ *     running. Exit 0.
+ *   - `{ type: "error", message }` — a persistent fetch failure / platform tools
+ *     off. Exit 1.
+ *
+ * This command never opens a browser itself — the recipe offers `jolli open-url`
+ * per URL the user chooses.
+ */
+
+import type { Command } from "commander";
+import { JolliMemoryPushClient } from "../core/JolliMemoryPushClient.js";
+import { monitorRun, realSleep } from "../core/WorkflowRunMonitor.js";
+
+/** Registers the `workflow-run-status` command on the given Commander program. */
+export function registerWorkflowRunStatusCommand(program: Command): void {
+	program
+		.command("workflow-run-status <runId>")
+		.description(
+			"Monitor a remote workflow run to a terminal state and print its report as JSON (agent/recipe consumption)",
+		)
+		.action(async (runId: string) => {
+			try {
+				const client = new JolliMemoryPushClient();
+				const report = await monitorRun(
+					{ getRunStatus: (id) => client.getRunStatus(id), sleep: realSleep },
+					runId,
+				);
+				console.log(JSON.stringify(report));
+			} catch (error: unknown) {
+				const message = error instanceof Error ? error.message : String(error);
+				console.log(JSON.stringify({ type: "error", message }));
+				process.exitCode = 1;
+			}
+		});
+}

--- a/cli/src/commands/WorkflowRunsCommand.test.ts
+++ b/cli/src/commands/WorkflowRunsCommand.test.ts
@@ -1,0 +1,110 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkflowRunPayload } from "../core/WorkflowRunReport.js";
+import { registerWorkflowRunsCommand } from "./WorkflowRunsCommand.js";
+
+const { listWorkflowRunsMock } = vi.hoisted(() => ({ listWorkflowRunsMock: vi.fn() }));
+
+// The command constructs `new JolliMemoryPushClient()` and drives
+// `listWorkflowRuns`. Mock the client leaf so the command's own wiring (id
+// coercion, per-run projection via the real `shapeRunHistoryEntry`, JSON print,
+// degrade-on-throw) runs for real without a live backend.
+vi.mock("../core/JolliMemoryPushClient.js", () => ({
+	JolliMemoryPushClient: class {
+		listWorkflowRuns = listWorkflowRunsMock;
+	},
+}));
+
+async function run(arg: string): Promise<string> {
+	const logs: string[] = [];
+	vi.spyOn(console, "log").mockImplementation((m?: unknown) => void logs.push(String(m)));
+	const program = new Command();
+	registerWorkflowRunsCommand(program);
+	await program.parseAsync(["node", "jolli", "workflow-runs", arg]);
+	return logs.join("\n");
+}
+
+beforeEach(() => {
+	process.exitCode = 0;
+	listWorkflowRunsMock.mockReset();
+});
+afterEach(() => {
+	vi.restoreAllMocks();
+	process.exitCode = 0;
+});
+
+describe("workflow-runs command", () => {
+	it("projects a mixed history (git-backed PR, jolli-git withheld, failed, cancelled) into per-run rows", async () => {
+		const runs: WorkflowRunPayload[] = [
+			{
+				id: "r4",
+				status: "completed",
+				createdAt: "2026-07-17T10:00:00Z",
+				workflowUrl: "https://jolli.ai/w/7",
+				runUrl: "https://jolli.ai/w/7/r/r4",
+				pullRequest: { number: 5, url: "https://gh/pr/5", state: "open" },
+			},
+			{
+				id: "r3",
+				status: "completed",
+				createdAt: "2026-07-17T09:00:00Z",
+				writtenArticles: [{ operation: "edited", path: "a.md", url: "https://jolli.ai/a", active: true }],
+			},
+			{ id: "r2", status: "failed", createdAt: "2026-07-17T08:00:00Z", error: "code=TIMEOUT: x" },
+			{ id: "r1", status: "cancelled", createdAt: "2026-07-17T07:00:00Z", canceledBy: "Dev" },
+		];
+		listWorkflowRunsMock.mockResolvedValue(runs);
+
+		const out = await run("7");
+
+		expect(JSON.parse(out)).toEqual({
+			type: "runs",
+			runs: [
+				{
+					runId: "r4",
+					status: "succeeded",
+					timestamp: "2026-07-17T10:00:00Z",
+					workflowUrl: "https://jolli.ai/w/7",
+					runUrl: "https://jolli.ai/w/7/r/r4",
+					prUrl: "https://gh/pr/5",
+					articleUrls: [],
+				},
+				{
+					runId: "r3",
+					status: "succeeded",
+					timestamp: "2026-07-17T09:00:00Z",
+					articleUrls: ["https://jolli.ai/a"],
+				},
+				{ runId: "r2", status: "failed", timestamp: "2026-07-17T08:00:00Z", articleUrls: [] },
+				{ runId: "r1", status: "cancelled", timestamp: "2026-07-17T07:00:00Z", articleUrls: [] },
+			],
+		});
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("coerces a numeric workflow id to a number before calling the client", async () => {
+		listWorkflowRunsMock.mockResolvedValue([]);
+		await run("42");
+		expect(listWorkflowRunsMock).toHaveBeenCalledWith(42);
+	});
+
+	it("passes a non-numeric workflow id verbatim (for the backend to reject)", async () => {
+		listWorkflowRunsMock.mockResolvedValue([]);
+		await run("wf-abc");
+		expect(listWorkflowRunsMock).toHaveBeenCalledWith("wf-abc");
+	});
+
+	it("prints an empty list for a workflow with no run history", async () => {
+		listWorkflowRunsMock.mockResolvedValue([]);
+		const out = await run("7");
+		expect(JSON.parse(out)).toEqual({ type: "runs", runs: [] });
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("degrades to an empty list (exit 0) when the history is unavailable (loud-fail from the client)", async () => {
+		listWorkflowRunsMock.mockRejectedValue(new Error("platform tools off"));
+		const out = await run("7");
+		expect(JSON.parse(out)).toEqual({ type: "runs", runs: [] });
+		expect(process.exitCode).toBe(0);
+	});
+});

--- a/cli/src/commands/WorkflowRunsCommand.ts
+++ b/cli/src/commands/WorkflowRunsCommand.ts
@@ -1,0 +1,43 @@
+/**
+ * `workflow-runs <workflowId>` — list a workflow's run history (newest first) as
+ * JSON. The `/jolli` menu's "Workflow history" action and the run recipes shell
+ * this to enumerate past runs and offer to open any listed URL via
+ * `jolli open-url`; it never opens a browser itself.
+ *
+ * Output (always JSON on stdout, one line):
+ *   - `{ type: "runs", runs: RunHistoryEntry[] }` — one row per run (status,
+ *     timestamp, workflow/run deep-links, the PR URL when the payload carried one,
+ *     and the active article URLs), each projected through `shapeRunHistoryEntry`.
+ *     Exit 0.
+ *   - `{ type: "runs", runs: [] }` — degraded: platform tools off / tool absent
+ *     from the manifest / transport failure. `listWorkflowRuns` fails loudly and
+ *     this command catches it, so an unavailable history is a normal empty
+ *     outcome, never a crash. Exit 0.
+ *
+ * The argument is the workflow's numeric id; a numeric positional is coerced to a
+ * number to honor the `list_workflow_runs({ id: number })` contract (a
+ * non-numeric value is passed verbatim for the backend to reject).
+ */
+
+import type { Command } from "commander";
+import { JolliMemoryPushClient } from "../core/JolliMemoryPushClient.js";
+import { shapeRunHistoryEntry } from "../core/WorkflowRunReport.js";
+
+/** Registers the `workflow-runs` command on the given Commander program. */
+export function registerWorkflowRunsCommand(program: Command): void {
+	program
+		.command("workflow-runs <workflowId>")
+		.description(
+			"List a workflow's run history (status, timestamps, deep-links, article/PR URLs) as JSON (agent/recipe consumption)",
+		)
+		.action(async (workflowId: string) => {
+			const id = /^\d+$/.test(workflowId) ? Number(workflowId) : workflowId;
+			const client = new JolliMemoryPushClient();
+			try {
+				const runs = await client.listWorkflowRuns(id);
+				console.log(JSON.stringify({ type: "runs", runs: runs.map(shapeRunHistoryEntry) }));
+			} catch {
+				console.log(JSON.stringify({ type: "runs", runs: [] }));
+			}
+		});
+}

--- a/cli/src/commands/WorkflowRunsCommand.ts
+++ b/cli/src/commands/WorkflowRunsCommand.ts
@@ -22,6 +22,9 @@
 import type { Command } from "commander";
 import { JolliMemoryPushClient } from "../core/JolliMemoryPushClient.js";
 import { shapeRunHistoryEntry } from "../core/WorkflowRunReport.js";
+import { createLogger } from "../Logger.js";
+
+const log = createLogger("WorkflowRunsCommand");
 
 /** Registers the `workflow-runs` command on the given Commander program. */
 export function registerWorkflowRunsCommand(program: Command): void {
@@ -36,7 +39,12 @@ export function registerWorkflowRunsCommand(program: Command): void {
 			try {
 				const runs = await client.listWorkflowRuns(id);
 				console.log(JSON.stringify({ type: "runs", runs: runs.map(shapeRunHistoryEntry) }));
-			} catch {
+			} catch (error: unknown) {
+				// The empty-list degrade is deliberate (an unavailable history is a normal
+				// "no history yet" outcome for the agent, never a crash), but log the
+				// swallowed cause at debug so a genuine fault stays diagnosable rather than
+				// silently looking identical to a truly empty history.
+				log.debug("workflow-runs: listWorkflowRuns failed, degrading to empty list — %s", String(error));
 				console.log(JSON.stringify({ type: "runs", runs: [] }));
 			}
 		});

--- a/cli/src/core/JolliMemoryPushClient.test.ts
+++ b/cli/src/core/JolliMemoryPushClient.test.ts
@@ -1420,3 +1420,395 @@ describe("listWorkflows", () => {
 		]);
 	});
 });
+
+describe("getRunStatus", () => {
+	const GET_RUN_STATUS_ENTRY = {
+		name: "get_run_status",
+		description: "Get one run's status",
+		inputSchema: { type: "object", properties: { runId: { type: "string" } }, required: ["runId"] },
+	};
+	const RUN = {
+		id: "run-1",
+		workflowId: 7,
+		createdAt: "2026-07-16T00:00:00Z",
+		status: "completed",
+		triggeredBy: "manual",
+		executionMode: "server",
+		workflowUrl: "https://jolli.ai/w/7",
+		runUrl: "https://jolli.ai/w/7/r/run-1",
+	};
+
+	/** Routes the manifest fetch and the get_run_status invocation. */
+	function routed(manifest: () => Response, invoke?: (body: unknown) => Response): typeof fetch {
+		return (async (url: string | URL | Request, init?: RequestInit) => {
+			const u = String(url);
+			if (u.endsWith("/api/mcp/manifest")) {
+				return manifest();
+			}
+			if (u.includes("/api/mcp/tools/get_run_status")) {
+				if (!invoke) {
+					throw new Error(`unexpected invocation of ${u}`);
+				}
+				return invoke(init?.body ? JSON.parse(String(init.body)) : undefined);
+			}
+			throw new Error(`unexpected url ${u}`);
+		}) as typeof fetch;
+	}
+
+	it("unwraps the { run } envelope and returns the parsed run, sending { runId }", async () => {
+		let sentBody: unknown;
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [GET_RUN_STATUS_ENTRY] }),
+				(body) => {
+					sentBody = body;
+					return jsonResponse(200, { run: RUN });
+				},
+			),
+		);
+		const run = await c.getRunStatus("run-1");
+		expect(sentBody).toEqual({ runId: "run-1" });
+		expect(run).toEqual({
+			id: "run-1",
+			workflowId: 7,
+			createdAt: "2026-07-16T00:00:00Z",
+			status: "completed",
+			triggeredBy: "manual",
+			executionMode: "server",
+			workflowUrl: "https://jolli.ai/w/7",
+			runUrl: "https://jolli.ai/w/7/r/run-1",
+		});
+	});
+
+	it("tolerates a bare run object (no { run } envelope)", async () => {
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [GET_RUN_STATUS_ENTRY] }),
+				() => jsonResponse(200, RUN),
+			),
+		);
+		const run = await c.getRunStatus("run-1");
+		expect(run.id).toBe("run-1");
+		expect(run.status).toBe("completed");
+	});
+
+	it("throws when get_run_status is absent from the manifest (platform tools off)", async () => {
+		const c = client(routed(() => jsonResponse(200, {})));
+		await expect(c.getRunStatus("run-1")).rejects.toThrow(/get_run_status.*unavailable/);
+	});
+
+	it("throws when the manifest fetch itself fails (404 surface disabled)", async () => {
+		const c = client(routed(() => jsonResponse(404, { error: "not_found" })));
+		await expect(c.getRunStatus("run-1")).rejects.toThrow(/get_run_status.*unavailable/);
+	});
+
+	it("throws (loud) on a non-2xx invocation", async () => {
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [GET_RUN_STATUS_ENTRY] }),
+				() => jsonResponse(500, { error: "boom" }),
+			),
+		);
+		await expect(c.getRunStatus("run-1")).rejects.toThrow("boom");
+	});
+
+	it("throws ClientOutdatedError on a 426 invocation", async () => {
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [GET_RUN_STATUS_ENTRY] }),
+				() => jsonResponse(426, { error: "too old" }),
+			),
+		);
+		await expect(c.getRunStatus("run-1")).rejects.toBeInstanceOf(ClientOutdatedError);
+	});
+
+	it("throws on a non-JSON invocation body (proxy page)", async () => {
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [GET_RUN_STATUS_ENTRY] }),
+				() => textResponse(200, "<html>OK</html>"),
+			),
+		);
+		await expect(c.getRunStatus("run-1")).rejects.toThrow(/Malformed/);
+	});
+
+	it("throws on a malformed run payload (empty envelope, bad id, or unknown status)", async () => {
+		const empty = client(
+			routed(
+				() => jsonResponse(200, { tools: [GET_RUN_STATUS_ENTRY] }),
+				() => jsonResponse(200, {}),
+			),
+		);
+		await expect(empty.getRunStatus("run-1")).rejects.toThrow(/malformed run payload/);
+
+		const badStatus = client(
+			routed(
+				() => jsonResponse(200, { tools: [GET_RUN_STATUS_ENTRY] }),
+				() => jsonResponse(200, { run: { id: "run-1", status: "bogus" } }),
+			),
+		);
+		await expect(badStatus.getRunStatus("run-1")).rejects.toThrow(/malformed run payload/);
+	});
+});
+
+describe("listWorkflowRuns", () => {
+	const LIST_RUNS_ENTRY = {
+		name: "list_workflow_runs",
+		description: "List a workflow's runs",
+		inputSchema: { type: "object", properties: { id: { type: "number" } }, required: ["id"] },
+	};
+
+	/** Routes the manifest fetch and the list_workflow_runs invocation. */
+	function routed(manifest: () => Response, invoke?: (body: unknown) => Response): typeof fetch {
+		return (async (url: string | URL | Request, init?: RequestInit) => {
+			const u = String(url);
+			if (u.endsWith("/api/mcp/manifest")) {
+				return manifest();
+			}
+			if (u.includes("/api/mcp/tools/list_workflow_runs")) {
+				if (!invoke) {
+					throw new Error(`unexpected invocation of ${u}`);
+				}
+				return invoke(init?.body ? JSON.parse(String(init.body)) : undefined);
+			}
+			throw new Error(`unexpected url ${u}`);
+		}) as typeof fetch;
+	}
+
+	it("parses the { runs: [...] } envelope and sends the numeric workflow id as { id }", async () => {
+		let sentBody: unknown;
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [LIST_RUNS_ENTRY] }),
+				(body) => {
+					sentBody = body;
+					return jsonResponse(200, {
+						runs: [
+							{ id: "r2", status: "active" },
+							{ id: "r1", status: "completed" },
+						],
+					});
+				},
+			),
+		);
+		const runs = await c.listWorkflowRuns(7);
+		expect(sentBody).toEqual({ id: 7 });
+		expect(runs.map((r) => r.id)).toEqual(["r2", "r1"]);
+	});
+
+	it("accepts a bare top-level array invocation body and passes a string id verbatim", async () => {
+		let sentBody: unknown;
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [LIST_RUNS_ENTRY] }),
+				(body) => {
+					sentBody = body;
+					return jsonResponse(200, [{ id: "r1", status: "queued" }]);
+				},
+			),
+		);
+		const runs = await c.listWorkflowRuns("42");
+		expect(sentBody).toEqual({ id: "42" });
+		expect(runs.map((r) => r.id)).toEqual(["r1"]);
+	});
+
+	it("carries every host-consumed field through when well-typed", async () => {
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [LIST_RUNS_ENTRY] }),
+				() =>
+					jsonResponse(200, {
+						runs: [
+							{
+								id: "r1",
+								workflowId: 7,
+								createdAt: "2026-07-16T00:00:00Z",
+								status: "completed",
+								triggeredBy: "schedule",
+								executionMode: "local",
+								startedAt: "2026-07-16T00:00:01Z",
+								completedAt: "2026-07-16T00:00:09Z",
+								completionInfo: { message: "done", extra: "ignored" },
+								writtenArticles: [
+									{
+										operation: "created",
+										path: "a.md",
+										url: "https://jolli.ai/a",
+										active: true,
+										docId: 3,
+										title: "A",
+									},
+									{ operation: "deleted", path: "b.md", url: null, active: false },
+								],
+								pullRequest: { number: 5, url: "https://gh/pr/5", state: "open" },
+								workflowUrl: "https://jolli.ai/w/7",
+								runUrl: "https://jolli.ai/w/7/r/r1",
+								canceledBy: "Dev",
+								canceledAt: "2026-07-16T00:00:05Z",
+								outputSummary: "never read",
+								stats: { prNumber: 9 },
+							},
+						],
+					}),
+			),
+		);
+		const [run] = await c.listWorkflowRuns(7);
+		expect(run).toEqual({
+			id: "r1",
+			workflowId: 7,
+			createdAt: "2026-07-16T00:00:00Z",
+			status: "completed",
+			triggeredBy: "schedule",
+			executionMode: "local",
+			startedAt: "2026-07-16T00:00:01Z",
+			completedAt: "2026-07-16T00:00:09Z",
+			completionInfo: { message: "done" },
+			writtenArticles: [
+				{ operation: "created", path: "a.md", url: "https://jolli.ai/a", active: true, docId: 3, title: "A" },
+				{ operation: "deleted", path: "b.md", url: null, active: false },
+			],
+			pullRequest: { number: 5, url: "https://gh/pr/5", state: "open" },
+			workflowUrl: "https://jolli.ai/w/7",
+			runUrl: "https://jolli.ai/w/7/r/r1",
+			canceledBy: "Dev",
+			canceledAt: "2026-07-16T00:00:05Z",
+		});
+		// outputSummary/stats are never modeled.
+		expect("outputSummary" in run).toBe(false);
+		expect("stats" in run).toBe(false);
+	});
+
+	it("drops ill-typed optional fields at field granularity (keeps the run)", async () => {
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [LIST_RUNS_ENTRY] }),
+				() =>
+					jsonResponse(200, {
+						runs: [
+							{
+								id: "r1",
+								status: "failed",
+								workflowId: "7", // not a number → dropped
+								createdAt: 123, // not a string → dropped
+								triggeredBy: "bogus", // unknown trigger → dropped
+								executionMode: "cloud", // unknown mode → dropped
+								error: "code=X: boom",
+								completionInfo: { message: 5 }, // non-string message → dropped
+								writtenArticles: "nope", // non-array → field absent
+								pullRequest: { number: 5, url: "https://gh/pr/5", state: "weird" }, // bad state → absent
+								workflowUrl: 9, // not a string → dropped
+							},
+						],
+					}),
+			),
+		);
+		const [run] = await c.listWorkflowRuns(7);
+		expect(run).toEqual({ id: "r1", status: "failed", error: "code=X: boom" });
+	});
+
+	it("drops malformed run entries but keeps the valid ones", async () => {
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [LIST_RUNS_ENTRY] }),
+				() =>
+					jsonResponse(200, {
+						runs: [
+							{ id: "ok", status: "completed" },
+							"not-an-object",
+							null,
+							[],
+							{ id: "", status: "completed" }, // empty id
+							{ id: "no-status" }, // missing status
+							{ id: "bad-status", status: "running" }, // "running" is a report status, not a wire status
+							{ status: "completed" }, // missing id
+						],
+					}),
+			),
+		);
+		const runs = await c.listWorkflowRuns(7);
+		expect(runs.map((r) => r.id)).toEqual(["ok"]);
+	});
+
+	it("drops malformed article entries within a run's manifest", async () => {
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [LIST_RUNS_ENTRY] }),
+				() =>
+					jsonResponse(200, {
+						runs: [
+							{
+								id: "r1",
+								status: "completed",
+								writtenArticles: [
+									{ operation: "created", path: "keep.md", url: "https://jolli.ai/a", active: true },
+									{ operation: "moved", path: "bad-op.md", url: null, active: true }, // bad op
+									{ operation: "edited", url: null, active: true }, // missing path
+									{ operation: "edited", path: "no-active.md", url: null }, // missing active
+									"not-an-object",
+									{ operation: "edited", path: "coerced.md", active: false }, // url missing → null
+								],
+							},
+						],
+					}),
+			),
+		);
+		const [run] = await c.listWorkflowRuns(7);
+		expect(run.writtenArticles).toEqual([
+			{ operation: "created", path: "keep.md", url: "https://jolli.ai/a", active: true },
+			{ operation: "edited", path: "coerced.md", url: null, active: false },
+		]);
+	});
+
+	it("drops a pullRequest whose number is not numeric (field-granular, keeps the run)", async () => {
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [LIST_RUNS_ENTRY] }),
+				() =>
+					jsonResponse(200, {
+						runs: [
+							{
+								id: "r1",
+								status: "completed",
+								pullRequest: { number: "5", url: "https://gh/pr/5", state: "open" },
+							},
+						],
+					}),
+			),
+		);
+		const [run] = await c.listWorkflowRuns(7);
+		expect(run).toEqual({ id: "r1", status: "completed" });
+	});
+
+	it("returns [] when the invocation body has no runs array", async () => {
+		const emptyObj = client(
+			routed(
+				() => jsonResponse(200, { tools: [LIST_RUNS_ENTRY] }),
+				() => jsonResponse(200, {}),
+			),
+		);
+		await expect(emptyObj.listWorkflowRuns(7)).resolves.toEqual([]);
+
+		const nonArrayRuns = client(
+			routed(
+				() => jsonResponse(200, { tools: [LIST_RUNS_ENTRY] }),
+				() => jsonResponse(200, { runs: "nope" }),
+			),
+		);
+		await expect(nonArrayRuns.listWorkflowRuns(7)).resolves.toEqual([]);
+	});
+
+	it("throws when list_workflow_runs is absent from the manifest", async () => {
+		const c = client(routed(() => jsonResponse(200, {})));
+		await expect(c.listWorkflowRuns(7)).rejects.toThrow(/list_workflow_runs.*unavailable/);
+	});
+
+	it("throws (loud) on a non-2xx invocation so the command can degrade", async () => {
+		const c = client(
+			routed(
+				() => jsonResponse(200, { tools: [LIST_RUNS_ENTRY] }),
+				() => jsonResponse(500, { error: "boom" }),
+			),
+		);
+		await expect(c.listWorkflowRuns(7)).rejects.toThrow("boom");
+	});
+});

--- a/cli/src/core/JolliMemoryPushClient.test.ts
+++ b/cli/src/core/JolliMemoryPushClient.test.ts
@@ -17,6 +17,7 @@ import {
 	PermissionDeniedError,
 	type PlatformToolManifestEntry,
 } from "./JolliMemoryPushClient.js";
+import { PlatformToolUnavailableError } from "./WorkflowRunReport.js";
 
 const KEY = "sk-jol-test"; // parseJolliApiKey may return null for a plain key → baseUrlOverride supplies the URL
 function client(fetchImpl: typeof fetch) {
@@ -1492,9 +1493,11 @@ describe("getRunStatus", () => {
 		expect(run.status).toBe("completed");
 	});
 
-	it("throws when get_run_status is absent from the manifest (platform tools off)", async () => {
+	it("throws a PlatformToolUnavailableError when get_run_status is absent from the manifest (platform tools off)", async () => {
 		const c = client(routed(() => jsonResponse(200, {})));
 		await expect(c.getRunStatus("run-1")).rejects.toThrow(/get_run_status.*unavailable/);
+		// Typed so the monitor can fail fast on it instead of retrying a permanent error.
+		await expect(c.getRunStatus("run-1")).rejects.toBeInstanceOf(PlatformToolUnavailableError);
 	});
 
 	it("throws when the manifest fetch itself fails (404 surface disabled)", async () => {
@@ -1797,9 +1800,10 @@ describe("listWorkflowRuns", () => {
 		await expect(nonArrayRuns.listWorkflowRuns(7)).resolves.toEqual([]);
 	});
 
-	it("throws when list_workflow_runs is absent from the manifest", async () => {
+	it("throws a PlatformToolUnavailableError when list_workflow_runs is absent from the manifest", async () => {
 		const c = client(routed(() => jsonResponse(200, {})));
 		await expect(c.listWorkflowRuns(7)).rejects.toThrow(/list_workflow_runs.*unavailable/);
+		await expect(c.listWorkflowRuns(7)).rejects.toBeInstanceOf(PlatformToolUnavailableError);
 	});
 
 	it("throws (loud) on a non-2xx invocation so the command can degrade", async () => {

--- a/cli/src/core/JolliMemoryPushClient.ts
+++ b/cli/src/core/JolliMemoryPushClient.ts
@@ -28,6 +28,7 @@ import type {
 	WorkflowRunPullRequest,
 	WorkflowRunWrittenArticle,
 } from "./WorkflowRunReport.js";
+import { PlatformToolUnavailableError } from "./WorkflowRunReport.js";
 
 const log = createLogger("JolliMemoryPushClient");
 
@@ -786,7 +787,7 @@ export class JolliMemoryPushClient {
 		const manifest = await this.fetchManifest();
 		const tool = manifest.find((entry) => entry.name === GET_RUN_STATUS_TOOL_NAME);
 		if (!tool) {
-			throw new Error(
+			throw new PlatformToolUnavailableError(
 				`Platform tool "${GET_RUN_STATUS_TOOL_NAME}" is unavailable (platform tools off or backend too old).`,
 			);
 		}
@@ -813,7 +814,7 @@ export class JolliMemoryPushClient {
 		const manifest = await this.fetchManifest();
 		const tool = manifest.find((entry) => entry.name === LIST_WORKFLOW_RUNS_TOOL_NAME);
 		if (!tool) {
-			throw new Error(
+			throw new PlatformToolUnavailableError(
 				`Platform tool "${LIST_WORKFLOW_RUNS_TOOL_NAME}" is unavailable (platform tools off or backend too old).`,
 			);
 		}

--- a/cli/src/core/JolliMemoryPushClient.ts
+++ b/cli/src/core/JolliMemoryPushClient.ts
@@ -22,6 +22,12 @@ import { deriveJolliEnvKey, type JolliApiKeyMeta, parseBaseUrl, parseJolliApiKey
 import type { WorkflowSummary } from "./LocalRunEligibility.js";
 import { loadConfig } from "./SessionTracker.js";
 import { currentTraceHeader, newTraceHeader, TRACE_HEADER_NAME } from "./TraceContext.js";
+import type {
+	JobStatus,
+	WorkflowRunPayload,
+	WorkflowRunPullRequest,
+	WorkflowRunWrittenArticle,
+} from "./WorkflowRunReport.js";
 
 const log = createLogger("JolliMemoryPushClient");
 
@@ -765,6 +771,56 @@ export class JolliMemoryPushClient {
 		}
 	}
 
+	/**
+	 * Fetches one workflow run's enriched status by invoking the backend-defined
+	 * `get_run_status` platform tool through the manifest path, unwrapping the
+	 * `{ run }` envelope (a bare run object is tolerated defensively).
+	 *
+	 * Deliberately LOUD-FAIL (unlike {@link listWorkflows}): every failure — the
+	 * tool absent from the manifest (platform tools off / older backend), a failed
+	 * invocation (non-2xx / 426 / network / abort / non-JSON body), or a
+	 * malformed run payload — THROWS, so the remote-run monitor can distinguish
+	 * "still running" from "fetch failed" and own retry/terminal/degrade itself.
+	 */
+	async getRunStatus(runId: string): Promise<WorkflowRunPayload> {
+		const manifest = await this.fetchManifest();
+		const tool = manifest.find((entry) => entry.name === GET_RUN_STATUS_TOOL_NAME);
+		if (!tool) {
+			throw new Error(
+				`Platform tool "${GET_RUN_STATUS_TOOL_NAME}" is unavailable (platform tools off or backend too old).`,
+			);
+		}
+		const raw = await this.invokePlatformTool(tool, { runId });
+		const run = toWorkflowRun(unwrapRun(raw));
+		if (!run) {
+			throw new Error(`"${GET_RUN_STATUS_TOOL_NAME}" returned a malformed run payload.`);
+		}
+		return run;
+	}
+
+	/**
+	 * Lists a workflow's run history (newest first) by invoking the backend-defined
+	 * `list_workflow_runs` platform tool through the manifest path, parsing the
+	 * `{ runs: [...] }` envelope (a bare array is tolerated defensively) and
+	 * dropping malformed entries, mirroring {@link parseWorkflowList}.
+	 *
+	 * The tool takes the workflow's numeric `id` (NOT a `workflowId` key). LOUD-FAIL
+	 * like {@link getRunStatus}: the tool absent from the manifest or a failed
+	 * invocation THROWS, and the history command catches and degrades to an empty
+	 * list — the failure posture lives in the command, not here.
+	 */
+	async listWorkflowRuns(workflowId: string | number): Promise<WorkflowRunPayload[]> {
+		const manifest = await this.fetchManifest();
+		const tool = manifest.find((entry) => entry.name === LIST_WORKFLOW_RUNS_TOOL_NAME);
+		if (!tool) {
+			throw new Error(
+				`Platform tool "${LIST_WORKFLOW_RUNS_TOOL_NAME}" is unavailable (platform tools off or backend too old).`,
+			);
+		}
+		const raw = await this.invokePlatformTool(tool, { id: workflowId });
+		return parseRunList(raw);
+	}
+
 	private async resolveAuth(): Promise<{
 		apiKey: string;
 		baseUrl: string;
@@ -1015,6 +1071,172 @@ function resolveToolEndpoint(tool: PlatformToolManifestEntry, origin: string): {
 
 /** Backend tool name that lists the candidate local-run workflows. */
 const LIST_WORKFLOWS_TOOL_NAME = "list_workflows";
+
+/** Backend tool name that returns one run's enriched status (an `{ run }` envelope). */
+const GET_RUN_STATUS_TOOL_NAME = "get_run_status";
+
+/** Backend tool name that lists a workflow's runs (a `{ runs }` envelope, newest first). */
+const LIST_WORKFLOW_RUNS_TOOL_NAME = "list_workflow_runs";
+
+/** The frozen set of valid wire run statuses; anything else rejects the run entry. */
+const RUN_STATUSES: ReadonlySet<string> = new Set<JobStatus>(["queued", "active", "completed", "failed", "cancelled"]);
+
+/** The frozen set of valid run triggers; an unrecognized value is dropped (field-granular). */
+const RUN_TRIGGERS: ReadonlySet<string> = new Set(["manual", "schedule", "event"]);
+
+/** The frozen set of valid execution modes; an unrecognized value is dropped (field-granular). */
+const RUN_EXECUTION_MODES: ReadonlySet<string> = new Set(["server", "local"]);
+
+/** The frozen set of valid article operations; an unrecognized op drops the article entry. */
+const ARTICLE_OPERATIONS: ReadonlySet<string> = new Set(["created", "edited", "deleted"]);
+
+/** The frozen set of valid PR states; an unrecognized state drops the (field-granular) PR. */
+const PR_STATES: ReadonlySet<string> = new Set(["open", "merged", "closed"]);
+
+/** Unwraps a `get_run_status` body's `{ run }` envelope; a bare run object is tolerated. */
+function unwrapRun(json: unknown): unknown {
+	if (json !== null && typeof json === "object" && !Array.isArray(json)) {
+		const run = (json as { run?: unknown }).run;
+		if (run !== undefined) {
+			return run;
+		}
+	}
+	return json;
+}
+
+/**
+ * Parses a `list_workflow_runs` invocation body into validated
+ * {@link WorkflowRunPayload} entries, mirroring {@link parseWorkflowList}: a
+ * `{ runs: [...] }` envelope or a bare array is accepted, and any entry that is
+ * not a well-formed run (no usable string `id`, or an unrecognized `status`) is
+ * dropped rather than failing the whole list.
+ */
+function parseRunList(json: unknown): WorkflowRunPayload[] {
+	return extractRunArray(json)
+		.map(toWorkflowRun)
+		.filter((run): run is WorkflowRunPayload => run !== null);
+}
+
+/** Pulls the run array out of the body — `{ runs: [...] }` or a bare array. */
+function extractRunArray(json: unknown): unknown[] {
+	if (Array.isArray(json)) {
+		return json;
+	}
+	if (json !== null && typeof json === "object") {
+		const runs = (json as { runs?: unknown }).runs;
+		if (Array.isArray(runs)) {
+			return runs;
+		}
+	}
+	return [];
+}
+
+/**
+ * Validates one raw run entry into a {@link WorkflowRunPayload}, or `null` if it is
+ * malformed. The two load-bearing fields are required: a non-empty string `id` and
+ * a `status` in the frozen vocabulary (an unclassifiable status can't be shaped).
+ * Every other field is carried through at FIELD granularity — a bad optional value
+ * is simply dropped, never failing the whole run — and the never-consumed wire
+ * fields (`outputSummary`, `stats`) are ignored. Nested `writtenArticles` entries
+ * and the `pullRequest` are each validated the same way (a malformed article is
+ * dropped from the manifest; a malformed PR leaves the field absent).
+ */
+function toWorkflowRun(value: unknown): WorkflowRunPayload | null {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		return null;
+	}
+	const raw = value as Record<string, unknown>;
+	if (typeof raw.id !== "string" || raw.id.trim() === "") {
+		return null;
+	}
+	if (typeof raw.status !== "string" || !RUN_STATUSES.has(raw.status)) {
+		return null;
+	}
+	const completionInfo = toCompletionInfo(raw.completionInfo);
+	const pullRequest = toPullRequest(raw.pullRequest);
+	return {
+		id: raw.id,
+		status: raw.status as JobStatus,
+		...(typeof raw.workflowId === "number" && Number.isFinite(raw.workflowId) && { workflowId: raw.workflowId }),
+		...(typeof raw.createdAt === "string" && { createdAt: raw.createdAt }),
+		...(typeof raw.triggeredBy === "string" &&
+			RUN_TRIGGERS.has(raw.triggeredBy) && { triggeredBy: raw.triggeredBy as WorkflowRunPayload["triggeredBy"] }),
+		...(typeof raw.executionMode === "string" &&
+			RUN_EXECUTION_MODES.has(raw.executionMode) && {
+				executionMode: raw.executionMode as WorkflowRunPayload["executionMode"],
+			}),
+		...(typeof raw.startedAt === "string" && { startedAt: raw.startedAt }),
+		...(typeof raw.completedAt === "string" && { completedAt: raw.completedAt }),
+		...(typeof raw.error === "string" && { error: raw.error }),
+		...(completionInfo !== undefined && { completionInfo }),
+		...(Array.isArray(raw.writtenArticles) && { writtenArticles: toWrittenArticles(raw.writtenArticles) }),
+		...(pullRequest !== undefined && { pullRequest }),
+		...(typeof raw.workflowUrl === "string" && { workflowUrl: raw.workflowUrl }),
+		...(typeof raw.runUrl === "string" && { runUrl: raw.runUrl }),
+		...(typeof raw.canceledBy === "string" && { canceledBy: raw.canceledBy }),
+		...(typeof raw.canceledAt === "string" && { canceledAt: raw.canceledAt }),
+	};
+}
+
+/** Validates the success-only `completionInfo` — an object with a string `message` — else undefined. */
+function toCompletionInfo(value: unknown): { message: string } | undefined {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		return undefined;
+	}
+	const message = (value as { message?: unknown }).message;
+	return typeof message === "string" ? { message } : undefined;
+}
+
+/** Maps a raw `writtenArticles` array to validated entries, dropping malformed ones. */
+function toWrittenArticles(value: unknown[]): WorkflowRunWrittenArticle[] {
+	return value.map(toWrittenArticle).filter((article): article is WorkflowRunWrittenArticle => article !== null);
+}
+
+/**
+ * Validates one raw `writtenArticles` entry, or `null` if malformed. Requires a
+ * valid `operation`, a string `path`, and a boolean `active`; `url` must be a
+ * string or `null` (an absent/other value is normalized to `null` — not-yet-
+ * openable). `docId` / `title` are carried through only when well-typed.
+ */
+function toWrittenArticle(value: unknown): WorkflowRunWrittenArticle | null {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		return null;
+	}
+	const raw = value as Record<string, unknown>;
+	if (typeof raw.operation !== "string" || !ARTICLE_OPERATIONS.has(raw.operation)) {
+		return null;
+	}
+	if (typeof raw.path !== "string" || typeof raw.active !== "boolean") {
+		return null;
+	}
+	return {
+		operation: raw.operation as WorkflowRunWrittenArticle["operation"],
+		path: raw.path,
+		active: raw.active,
+		url: typeof raw.url === "string" ? raw.url : null,
+		...(typeof raw.docId === "number" && Number.isFinite(raw.docId) && { docId: raw.docId }),
+		...(typeof raw.title === "string" && { title: raw.title }),
+	};
+}
+
+/**
+ * Validates the `pullRequest` reference, or undefined when absent/malformed (a
+ * withheld or no-PR run — normal, never an error). Requires a numeric `number`, a
+ * string `url`, and a `state` in the frozen set.
+ */
+function toPullRequest(value: unknown): WorkflowRunPullRequest | undefined {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		return undefined;
+	}
+	const raw = value as Record<string, unknown>;
+	if (typeof raw.number !== "number" || !Number.isFinite(raw.number)) {
+		return undefined;
+	}
+	if (typeof raw.url !== "string" || typeof raw.state !== "string" || !PR_STATES.has(raw.state)) {
+		return undefined;
+	}
+	return { number: raw.number, url: raw.url, state: raw.state as WorkflowRunPullRequest["state"] };
+}
 
 /**
  * Parses the `list_workflows` invocation body into validated {@link WorkflowSummary}

--- a/cli/src/core/OpenUrl.test.ts
+++ b/cli/src/core/OpenUrl.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { openUrlOrPrint } from "./OpenUrl.js";
+import { ORIGIN_NOT_ALLOWLISTED, openUrlOrPrint } from "./OpenUrl.js";
 
 // The default launch seam lazy-imports the `open` package; mock it so exercising
 // the default path never spawns a real browser.
@@ -8,8 +8,8 @@ vi.mock("open", () => ({ default: openMock }));
 
 const URL_HTTPS = "https://jolli.ai/w/7/runs/abc";
 
-/** Snapshot + override the env keys and platform that `defaultIsHeadless` reads. */
-const ENV_KEYS = ["CI", "DISPLAY", "WAYLAND_DISPLAY"] as const;
+/** Snapshot + override the env keys and platform that `defaultIsHeadless` / the dev-origins tier read. */
+const ENV_KEYS = ["CI", "DISPLAY", "WAYLAND_DISPLAY", "JOLLI_OPEN_URL_ALLOWED_ORIGINS"] as const;
 let savedEnv: Record<string, string | undefined>;
 let savedPlatform: PropertyDescriptor | undefined;
 
@@ -88,6 +88,200 @@ describe("openUrlOrPrint — injected seams", () => {
 		expect(result).toEqual({ opened: false, url: URL_HTTPS });
 		expect(launch).not.toHaveBeenCalled();
 		expect(print).toHaveBeenCalledWith(URL_HTTPS);
+	});
+});
+
+describe("openUrlOrPrint — origin allowlist gate", () => {
+	// Jolli-origin tier (tier 1) and git-host tier (tier 2) both launch; everything
+	// else is refused-and-printed without ever calling launch.
+	const allowlisted = [
+		["a jolli apex origin", "https://jolli.ai/w/7/runs/abc"],
+		["a jolli subdomain origin", "https://tenant.jolli.ai/w/7"],
+		["a jolli-local.me origin", "https://jolli-local.me/jollidougs/w/7"],
+		["a jolli.dev origin", "https://x.jolli.dev/w/1"],
+		["a github.com PR URL", "https://github.com/acme/repo/pull/12"],
+		["a github subdomain", "https://gist.github.com/acme/deadbeef"],
+		["a gitlab.com PR URL", "https://gitlab.com/acme/repo/-/merge_requests/3"],
+		["a bitbucket.org PR URL", "https://bitbucket.org/acme/repo/pull-requests/4"],
+	] as const;
+
+	for (const [label, url] of allowlisted) {
+		it(`launches ${label}`, async () => {
+			const launch = vi.fn().mockResolvedValue({ unref: vi.fn() });
+			const print = vi.fn();
+
+			const result = await openUrlOrPrint(url, { launch, isHeadless: () => false, print });
+
+			expect(result).toEqual({ opened: true, url });
+			expect(launch).toHaveBeenCalledWith(url);
+			expect(print).not.toHaveBeenCalled();
+		});
+	}
+
+	const refused = [
+		["an off-allowlist host", "https://evil.example/pull/1"],
+		["a jolli-lookalike suffix", "https://jolli.ai.evil.com/w/7"],
+		["a git-host-lookalike suffix", "https://github.com.evil.com/acme/repo/pull/1"],
+		["a self-hosted git host", "https://git.enterprise.internal/acme/repo/pull/1"],
+	] as const;
+
+	for (const [label, url] of refused) {
+		it(`refuses ${label}: prints, never launches, opened:false + refused`, async () => {
+			const launch = vi.fn();
+			const print = vi.fn();
+
+			const result = await openUrlOrPrint(url, { launch, isHeadless: () => false, print });
+
+			expect(result).toEqual({ opened: false, url, refused: true, reason: ORIGIN_NOT_ALLOWLISTED });
+			expect(launch).not.toHaveBeenCalled();
+			expect(print).toHaveBeenCalledWith(url);
+		});
+	}
+
+	it("refuses off-allowlist even on a headless host (the gate precedes the headless check)", async () => {
+		const launch = vi.fn();
+		const print = vi.fn();
+
+		const result = await openUrlOrPrint("https://evil.example/x", { launch, isHeadless: () => true, print });
+
+		expect(result).toEqual({
+			opened: false,
+			url: "https://evil.example/x",
+			refused: true,
+			reason: ORIGIN_NOT_ALLOWLISTED,
+		});
+		expect(launch).not.toHaveBeenCalled();
+	});
+});
+
+describe("openUrlOrPrint — opt-in dev-origins tier (JOLLI_OPEN_URL_ALLOWED_ORIGINS)", () => {
+	const NGROK_URL = "https://abc123.ngrok-free.dev/jollidougs/w/7/runs/5c60505";
+
+	it("refuses a tunnel deep-link when the env is unset (Step 8 behavior preserved)", async () => {
+		const launch = vi.fn();
+		const print = vi.fn();
+
+		const result = await openUrlOrPrint(NGROK_URL, { launch, isHeadless: () => false, print });
+
+		expect(result).toEqual({ opened: false, url: NGROK_URL, refused: true, reason: ORIGIN_NOT_ALLOWLISTED });
+		expect(launch).not.toHaveBeenCalled();
+		expect(print).toHaveBeenCalledWith(NGROK_URL);
+	});
+
+	it("launches a tunnel deep-link when its exact host is listed", async () => {
+		process.env.JOLLI_OPEN_URL_ALLOWED_ORIGINS = "abc123.ngrok-free.dev";
+		const launch = vi.fn().mockResolvedValue({ unref: vi.fn() });
+		const print = vi.fn();
+
+		const result = await openUrlOrPrint(NGROK_URL, { launch, isHeadless: () => false, print });
+
+		expect(result).toEqual({ opened: true, url: NGROK_URL });
+		expect(launch).toHaveBeenCalledWith(NGROK_URL);
+		expect(print).not.toHaveBeenCalled();
+	});
+
+	it("normalizes a full-origin entry (https://…) to its host", async () => {
+		process.env.JOLLI_OPEN_URL_ALLOWED_ORIGINS = "https://abc123.ngrok-free.dev";
+		const launch = vi.fn().mockResolvedValue({ unref: vi.fn() });
+
+		const result = await openUrlOrPrint(NGROK_URL, { launch, isHeadless: () => false, print: vi.fn() });
+
+		expect(result).toEqual({ opened: true, url: NGROK_URL });
+		expect(launch).toHaveBeenCalledWith(NGROK_URL);
+	});
+
+	it("matches subdomains of a listed apex (suffix-boundary)", async () => {
+		process.env.JOLLI_OPEN_URL_ALLOWED_ORIGINS = "ngrok-free.dev";
+		const launch = vi.fn().mockResolvedValue({ unref: vi.fn() });
+
+		const result = await openUrlOrPrint(NGROK_URL, { launch, isHeadless: () => false, print: vi.fn() });
+
+		expect(result).toEqual({ opened: true, url: NGROK_URL });
+		expect(launch).toHaveBeenCalledWith(NGROK_URL);
+	});
+
+	it("does not match a lookalike host that only shares a suffix without the dot boundary", async () => {
+		process.env.JOLLI_OPEN_URL_ALLOWED_ORIGINS = "ngrok-free.dev";
+		const launch = vi.fn();
+		const print = vi.fn();
+		const url = "https://notngrok-free.dev/x";
+
+		const result = await openUrlOrPrint(url, { launch, isHeadless: () => false, print });
+
+		expect(result).toEqual({ opened: false, url, refused: true, reason: ORIGIN_NOT_ALLOWLISTED });
+		expect(launch).not.toHaveBeenCalled();
+	});
+
+	it("still refuses a different off-list host even when the env lists one origin", async () => {
+		process.env.JOLLI_OPEN_URL_ALLOWED_ORIGINS = "abc123.ngrok-free.dev";
+		const launch = vi.fn();
+		const url = "https://evil.example/x";
+
+		const result = await openUrlOrPrint(url, { launch, isHeadless: () => false, print: vi.fn() });
+
+		expect(result).toEqual({ opened: false, url, refused: true, reason: ORIGIN_NOT_ALLOWLISTED });
+		expect(launch).not.toHaveBeenCalled();
+	});
+
+	it("still rejects an http:// URL to a listed dev host (never-launch-non-https invariant)", async () => {
+		process.env.JOLLI_OPEN_URL_ALLOWED_ORIGINS = "abc123.ngrok-free.dev";
+		await expect(
+			openUrlOrPrint("http://abc123.ngrok-free.dev/x", { launch: vi.fn(), isHeadless: () => false }),
+		).rejects.toThrow(/only opens https URLs/);
+	});
+
+	it("honors multiple comma-separated origins and ignores blank / malformed entries", async () => {
+		process.env.JOLLI_OPEN_URL_ALLOWED_ORIGINS = " , https://other.example , abc123.ngrok-free.dev , bad host ";
+		const launch = vi.fn().mockResolvedValue({ unref: vi.fn() });
+
+		const ngrok = await openUrlOrPrint(NGROK_URL, { launch, isHeadless: () => false, print: vi.fn() });
+		expect(ngrok).toEqual({ opened: true, url: NGROK_URL });
+
+		const other = "https://other.example/x";
+		const otherResult = await openUrlOrPrint(other, { launch, isHeadless: () => false, print: vi.fn() });
+		expect(otherResult).toEqual({ opened: true, url: other });
+	});
+
+	it("launches a host listed only in the persisted config (configOrigins), env unset", async () => {
+		const launch = vi.fn().mockResolvedValue({ unref: vi.fn() });
+
+		const result = await openUrlOrPrint(NGROK_URL, {
+			launch,
+			isHeadless: () => false,
+			print: vi.fn(),
+			configOrigins: ["https://abc123.ngrok-free.dev"],
+		});
+
+		expect(result).toEqual({ opened: true, url: NGROK_URL });
+		expect(launch).toHaveBeenCalledWith(NGROK_URL);
+	});
+
+	it("merges config origins with the env var (env adds to config, both launch)", async () => {
+		process.env.JOLLI_OPEN_URL_ALLOWED_ORIGINS = "env-only.example";
+		const launch = vi.fn().mockResolvedValue({ unref: vi.fn() });
+		const configOrigins = ["abc123.ngrok-free.dev"];
+
+		const fromConfig = await openUrlOrPrint(NGROK_URL, { launch, isHeadless: () => false, configOrigins });
+		expect(fromConfig).toEqual({ opened: true, url: NGROK_URL });
+
+		const envUrl = "https://env-only.example/x";
+		const fromEnv = await openUrlOrPrint(envUrl, { launch, isHeadless: () => false, configOrigins });
+		expect(fromEnv).toEqual({ opened: true, url: envUrl });
+	});
+
+	it("still refuses an off-list host even when config lists other origins", async () => {
+		const launch = vi.fn();
+		const url = "https://evil.example/x";
+
+		const result = await openUrlOrPrint(url, {
+			launch,
+			isHeadless: () => false,
+			print: vi.fn(),
+			configOrigins: ["abc123.ngrok-free.dev"],
+		});
+
+		expect(result).toEqual({ opened: false, url, refused: true, reason: ORIGIN_NOT_ALLOWLISTED });
+		expect(launch).not.toHaveBeenCalled();
 	});
 });
 

--- a/cli/src/core/OpenUrl.test.ts
+++ b/cli/src/core/OpenUrl.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { openUrlOrPrint } from "./OpenUrl.js";
+
+// The default launch seam lazy-imports the `open` package; mock it so exercising
+// the default path never spawns a real browser.
+const { openMock } = vi.hoisted(() => ({ openMock: vi.fn() }));
+vi.mock("open", () => ({ default: openMock }));
+
+const URL_HTTPS = "https://jolli.ai/w/7/runs/abc";
+
+/** Snapshot + override the env keys and platform that `defaultIsHeadless` reads. */
+const ENV_KEYS = ["CI", "DISPLAY", "WAYLAND_DISPLAY"] as const;
+let savedEnv: Record<string, string | undefined>;
+let savedPlatform: PropertyDescriptor | undefined;
+
+function setPlatform(value: NodeJS.Platform): void {
+	Object.defineProperty(process, "platform", { value, configurable: true });
+}
+
+beforeEach(() => {
+	openMock.mockReset();
+	savedEnv = {};
+	for (const key of ENV_KEYS) {
+		savedEnv[key] = process.env[key];
+		delete process.env[key];
+	}
+	savedPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+});
+
+afterEach(() => {
+	for (const key of ENV_KEYS) {
+		if (savedEnv[key] === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = savedEnv[key];
+		}
+	}
+	if (savedPlatform) {
+		Object.defineProperty(process, "platform", savedPlatform);
+	}
+	vi.restoreAllMocks();
+});
+
+describe("openUrlOrPrint — input validation", () => {
+	it("rejects a non-https scheme with a typed error", async () => {
+		await expect(openUrlOrPrint("http://jolli.ai/x")).rejects.toThrow(/only opens https URLs/);
+	});
+
+	it("rejects a non-http(s) scheme (e.g. javascript:) with a typed error", async () => {
+		await expect(openUrlOrPrint("javascript:alert(1)")).rejects.toThrow(/only opens https URLs/);
+	});
+
+	it("rejects an unparseable URL with a typed error", async () => {
+		await expect(openUrlOrPrint("not a url")).rejects.toThrow(/valid https URL/);
+	});
+});
+
+describe("openUrlOrPrint — injected seams", () => {
+	it("launches the browser and detaches the child on success", async () => {
+		const unref = vi.fn();
+		const launch = vi.fn().mockResolvedValue({ unref });
+		const print = vi.fn();
+
+		const result = await openUrlOrPrint(URL_HTTPS, { launch, isHeadless: () => false, print });
+
+		expect(result).toEqual({ opened: true, url: URL_HTTPS });
+		expect(launch).toHaveBeenCalledWith(URL_HTTPS);
+		expect(unref).toHaveBeenCalledTimes(1);
+		expect(print).not.toHaveBeenCalled();
+	});
+
+	it("prints the URL and reports opened:false when the launch throws", async () => {
+		const launch = vi.fn().mockRejectedValue(new Error("no browser"));
+		const print = vi.fn();
+
+		const result = await openUrlOrPrint(URL_HTTPS, { launch, isHeadless: () => false, print });
+
+		expect(result).toEqual({ opened: false, url: URL_HTTPS });
+		expect(print).toHaveBeenCalledWith(URL_HTTPS);
+	});
+
+	it("skips the launch entirely and prints when headless", async () => {
+		const launch = vi.fn();
+		const print = vi.fn();
+
+		const result = await openUrlOrPrint(URL_HTTPS, { launch, isHeadless: () => true, print });
+
+		expect(result).toEqual({ opened: false, url: URL_HTTPS });
+		expect(launch).not.toHaveBeenCalled();
+		expect(print).toHaveBeenCalledWith(URL_HTTPS);
+	});
+});
+
+describe("openUrlOrPrint — default seams", () => {
+	it("uses the lazy-imported `open` package by default on a non-headless host", async () => {
+		setPlatform("darwin"); // no CI, non-linux ⇒ not headless
+		const unref = vi.fn();
+		openMock.mockResolvedValue({ unref });
+
+		const result = await openUrlOrPrint(URL_HTTPS, { print: vi.fn() });
+
+		expect(result).toEqual({ opened: true, url: URL_HTTPS });
+		expect(openMock).toHaveBeenCalledWith(URL_HTTPS);
+		expect(unref).toHaveBeenCalledTimes(1);
+	});
+
+	it("prints to stderr by default when the default launch fails", async () => {
+		setPlatform("darwin");
+		openMock.mockRejectedValue(new Error("open failed"));
+		const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+		const result = await openUrlOrPrint(URL_HTTPS);
+
+		expect(result).toEqual({ opened: false, url: URL_HTTPS });
+		expect(stderr).toHaveBeenCalledWith(`${URL_HTTPS}\n`);
+	});
+
+	it("treats a CI environment as headless on any platform", async () => {
+		setPlatform("darwin");
+		process.env.CI = "1";
+		const launch = vi.fn();
+
+		const result = await openUrlOrPrint(URL_HTTPS, { launch, print: vi.fn() });
+
+		expect(result).toEqual({ opened: false, url: URL_HTTPS });
+		expect(launch).not.toHaveBeenCalled();
+	});
+
+	it("treats Linux with no display server as headless", async () => {
+		setPlatform("linux"); // no DISPLAY / WAYLAND_DISPLAY / CI set
+		const launch = vi.fn();
+
+		const result = await openUrlOrPrint(URL_HTTPS, { launch, print: vi.fn() });
+
+		expect(result).toEqual({ opened: false, url: URL_HTTPS });
+		expect(launch).not.toHaveBeenCalled();
+	});
+
+	it("treats Linux with a display server as non-headless (launches)", async () => {
+		setPlatform("linux");
+		process.env.DISPLAY = ":0";
+		const launch = vi.fn().mockResolvedValue({ unref: vi.fn() });
+
+		const result = await openUrlOrPrint(URL_HTTPS, { launch, print: vi.fn() });
+
+		expect(result).toEqual({ opened: true, url: URL_HTTPS });
+		expect(launch).toHaveBeenCalledWith(URL_HTTPS);
+	});
+});

--- a/cli/src/core/OpenUrl.ts
+++ b/cli/src/core/OpenUrl.ts
@@ -1,0 +1,109 @@
+/**
+ * The CLI's single browser-open primitive: open one backend-supplied `https`
+ * URL in the developer's default browser, or fall back to printing it (headless
+ * / no browser / launch failure). It NEVER throws for a launch problem and NEVER
+ * blocks — the only thrown error is for invalid input (a non-`https` or
+ * unparseable URL), which the calling command turns into a `{ type: "error" }`
+ * result. The URL is opened verbatim; this primitive constructs nothing.
+ *
+ * Contract:
+ *   - non-`https:` scheme (or an unparseable URL) ⇒ throws a typed Error (the
+ *     caller surfaces `{ type: "error", message }`, exit 1). Deliberately stricter
+ *     than the VS Code reference sink (which allows `http`+`https`) because every
+ *     URL this feature opens is a backend-supplied `https` deep-link.
+ *   - headless (a CI marker, or Linux with no `DISPLAY`/`WAYLAND_DISPLAY`) ⇒ skip
+ *     the launch, print the URL, return `{ opened: false, url }`.
+ *   - `open()` failure ⇒ print the URL, return `{ opened: false, url }`.
+ *   - success ⇒ detach the browser child (`unref()`), return `{ opened: true, url }`.
+ *
+ * The fallback print goes to stderr so the command's single stdout JSON line
+ * (`{ opened, url }`) stays clean for the agent/recipe that consumes it.
+ */
+
+/** The one capability {@link openUrlOrPrint} needs from a launched browser process. */
+interface DetachableChild {
+	unref(): void;
+}
+
+/** Injectable seams for {@link openUrlOrPrint}; the defaults hit the real environment. */
+export interface OpenUrlDeps {
+	/** Launch the URL in the default browser, resolving to a detachable child process. */
+	launch: (url: string) => Promise<DetachableChild>;
+	/** Whether the environment cannot show a browser (⇒ print instead of launching). */
+	isHeadless: () => boolean;
+	/** Emit the URL as a human-readable fallback (defaults to stderr). */
+	print: (url: string) => void;
+}
+
+/** Result of {@link openUrlOrPrint}: whether the browser launched, and the URL acted on. */
+export interface OpenUrlResult {
+	opened: boolean;
+	url: string;
+}
+
+/**
+ * Lazy-import the already-declared `open` package (kept out of the hot path, and
+ * injectable in tests) and launch the URL. Mirrors the `GraphCommand`/`Login`
+ * usage: `open(url)` resolves to a child process we detach with `unref()`.
+ */
+async function defaultLaunch(url: string): Promise<DetachableChild> {
+	const open = (await import("open")).default;
+	return open(url);
+}
+
+/**
+ * True when we should not attempt a browser launch: a CI environment (any
+ * platform), or Linux with no display server (`DISPLAY`/`WAYLAND_DISPLAY` unset).
+ */
+function defaultIsHeadless(): boolean {
+	if (process.env.CI) {
+		return true;
+	}
+	if (process.platform === "linux") {
+		return !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY;
+	}
+	return false;
+}
+
+/** Print the URL to stderr, keeping stdout reserved for the command's JSON line. */
+function defaultPrint(url: string): void {
+	process.stderr.write(`${url}\n`);
+}
+
+/** Throws a typed Error unless `url` parses and uses the `https:` scheme. */
+function assertHttpsUrl(url: string): void {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		throw new Error(`open-url requires a valid https URL, got: ${url}`);
+	}
+	if (parsed.protocol !== "https:") {
+		throw new Error(`open-url only opens https URLs, got scheme: ${parsed.protocol}`);
+	}
+}
+
+/**
+ * Open `url` in the default browser, or print it as a fallback. See the file
+ * header for the full contract. Rejects only for invalid input; a launch failure
+ * or a headless environment resolves to `{ opened: false, url }`.
+ */
+export async function openUrlOrPrint(url: string, deps: Partial<OpenUrlDeps> = {}): Promise<OpenUrlResult> {
+	assertHttpsUrl(url);
+	const launch = deps.launch ?? defaultLaunch;
+	const isHeadless = deps.isHeadless ?? defaultIsHeadless;
+	const print = deps.print ?? defaultPrint;
+
+	if (isHeadless()) {
+		print(url);
+		return { opened: false, url };
+	}
+	try {
+		const child = await launch(url);
+		child.unref();
+		return { opened: true, url };
+	} catch {
+		print(url);
+		return { opened: false, url };
+	}
+}

--- a/cli/src/core/OpenUrl.ts
+++ b/cli/src/core/OpenUrl.ts
@@ -11,6 +11,18 @@
  *     caller surfaces `{ type: "error", message }`, exit 1). Deliberately stricter
  *     than the VS Code reference sink (which allows `http`+`https`) because every
  *     URL this feature opens is a backend-supplied `https` deep-link.
+ *   - off-allowlist origin ⇒ **refused, not launched**: print the URL, return
+ *     `{ opened: false, url, refused: true, reason: "origin-not-allowlisted" }`
+ *     (exit 0). A buggy or compromised payload can therefore never turn this into
+ *     an arbitrary-launch / open-redirect primitive. The allowlist has three tiers:
+ *     the canonical jolli-origin allowlist (workflow / run / article deep-links,
+ *     via `assertJolliOriginAllowed`, reused verbatim — a 3-impl lockstep artifact,
+ *     never forked here), a small known-git-host set (PR links), and an **opt-in
+ *     dev-origins tier that is empty by default** — a local-development affordance for
+ *     tunnel deep-links, sourced from the `openUrlAllowedOrigins` config key and the
+ *     `JOLLI_OPEN_URL_ALLOWED_ORIGINS` env var (merged; see {@link resolveDevOriginHosts}).
+ *     With neither set, the gate is identical to the two-tier default (production/normal
+ *     users unaffected).
  *   - headless (a CI marker, or Linux with no `DISPLAY`/`WAYLAND_DISPLAY`) ⇒ skip
  *     the launch, print the URL, return `{ opened: false, url }`.
  *   - `open()` failure ⇒ print the URL, return `{ opened: false, url }`.
@@ -19,6 +31,8 @@
  * The fallback print goes to stderr so the command's single stdout JSON line
  * (`{ opened, url }`) stays clean for the agent/recipe that consumes it.
  */
+
+import { assertJolliOriginAllowed } from "./JolliApiUtils.js";
 
 /** The one capability {@link openUrlOrPrint} needs from a launched browser process. */
 interface DetachableChild {
@@ -33,12 +47,120 @@ export interface OpenUrlDeps {
 	isHeadless: () => boolean;
 	/** Emit the URL as a human-readable fallback (defaults to stderr). */
 	print: (url: string) => void;
+	/**
+	 * Extra opt-in dev origins from persisted config (`openUrlAllowedOrigins`), merged
+	 * with the `JOLLI_OPEN_URL_ALLOWED_ORIGINS` env var to form tier 3. The caller
+	 * (the command) loads config and passes it — mirroring how `isPlatformToolsEnabled`
+	 * takes an injected config rather than reading the file itself. Defaults to none.
+	 */
+	configOrigins: readonly string[];
 }
 
 /** Result of {@link openUrlOrPrint}: whether the browser launched, and the URL acted on. */
 export interface OpenUrlResult {
 	opened: boolean;
 	url: string;
+	/** `true` only when the URL was refused for being off the origin allowlist (never launched, still printed). */
+	refused?: boolean;
+	/** Machine-readable refusal reason; present only alongside `refused: true`. */
+	reason?: string;
+}
+
+/** Machine-readable `reason` on an off-allowlist refusal — stable for recipe/menu consumers. */
+export const ORIGIN_NOT_ALLOWLISTED = "origin-not-allowlisted";
+
+/**
+ * Known external git hosts whose PR URLs `open-url` may auto-launch. PR links point
+ * at a git host (not a jolli origin) and are withheld entirely for private
+ * `jolli-git` destinations, so this is a small, explicit set matched with the same
+ * https + suffix-boundary rule as {@link assertJolliOriginAllowed}. A self-hosted
+ * git PR URL (e.g. GitHub Enterprise on a custom domain) falls outside it and
+ * degrades to print-only. Kept here — NOT in `JolliApiUtils.ts`, which stays
+ * jolli-only and unforked (its three implementations are kept in lockstep).
+ */
+const ALLOWED_GIT_HOSTS: readonly string[] = ["github.com", "gitlab.com", "bitbucket.org"];
+
+/**
+ * Env var naming the opt-in dev-origins allowlist (tier 3): a comma-separated list of
+ * tunnel hosts a local dev explicitly trusts. Empty / unset by default — see
+ * {@link parseDevOriginHosts}.
+ */
+const DEV_ORIGINS_ENV = "JOLLI_OPEN_URL_ALLOWED_ORIGINS";
+
+/** Shared host match used by every non-jolli tier: exact host, or a dotted subdomain of it. */
+function hostMatches(host: string, allowed: string): boolean {
+	return host === allowed || host.endsWith(`.${allowed}`);
+}
+
+/**
+ * Normalize one dev-origins entry to a lowercase host, or `undefined` if it is
+ * unparseable. Accepts a bare host (`x.ngrok-free.dev`) or a full origin
+ * (`https://x.ngrok-free.dev`) — both resolve to the host. A malformed entry is
+ * dropped rather than thrown so a bad env value can never crash `open-url`.
+ */
+function devOriginToHost(entry: string): string | undefined {
+	const withScheme = entry.includes("://") ? entry : `https://${entry}`;
+	try {
+		return new URL(withScheme).hostname.toLowerCase();
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Resolve the opt-in dev-origins allowlist (tier 3) as normalized hosts, merging the
+ * persisted `openUrlAllowedOrigins` config (passed by the caller) with the
+ * `JOLLI_OPEN_URL_ALLOWED_ORIGINS` env var (comma-separated) — **env adds to config,
+ * it does not replace it**. A **local-development affordance**: in a tunnel/dev
+ * deployment the backend renders absolute deep-links from its configured public base
+ * URL (e.g. an ngrok host), which is neither a jolli origin nor a known git host, so
+ * tiers 1–2 correctly refuse them. A dev names their tunnel origin(s) here to let those
+ * `https` deep-links launch; everything else stays refused-and-printed. Both sources
+ * empty ⇒ no dev origins (the gate is then byte-identical to the two-tier default, so
+ * production is unaffected). Each entry is normalized to a host and matched with the
+ * same suffix-boundary rule as the other tiers; the URL being opened is still
+ * `https`-only (enforced upstream).
+ */
+function resolveDevOriginHosts(configOrigins: readonly string[]): string[] {
+	const entries = [...configOrigins];
+	const envRaw = process.env[DEV_ORIGINS_ENV];
+	if (envRaw) {
+		entries.push(...envRaw.split(","));
+	}
+	const hosts: string[] = [];
+	for (const entry of entries) {
+		const trimmed = entry.trim();
+		if (!trimmed) {
+			continue;
+		}
+		const host = devOriginToHost(trimmed);
+		if (host) {
+			hosts.push(host);
+		}
+	}
+	return hosts;
+}
+
+/**
+ * Whether `parsed`'s origin is on the open-url allowlist: tier 1 = the canonical
+ * jolli-origin allowlist (reused verbatim from `JolliApiUtils`, no fork); tier 2 =
+ * the known external git-host set for PR links; tier 3 = the opt-in dev-origins set
+ * (`devHosts`, empty by default). `parsed` is already a valid `https` URL by the time
+ * this runs (see {@link assertHttpsUrl}), so tiers 2–3 only need a suffix-boundary host
+ * match. Any other origin is off-allowlist.
+ */
+function isOriginAllowlisted(parsed: URL, devHosts: readonly string[]): boolean {
+	try {
+		assertJolliOriginAllowed(parsed.href);
+		return true;
+	} catch {
+		// Not a jolli origin — fall through to the git-host + dev-origin tiers.
+	}
+	const host = parsed.hostname.toLowerCase();
+	if (ALLOWED_GIT_HOSTS.some((h) => hostMatches(host, h))) {
+		return true;
+	}
+	return devHosts.some((h) => hostMatches(host, h));
 }
 
 /**
@@ -70,8 +192,8 @@ function defaultPrint(url: string): void {
 	process.stderr.write(`${url}\n`);
 }
 
-/** Throws a typed Error unless `url` parses and uses the `https:` scheme. */
-function assertHttpsUrl(url: string): void {
+/** Returns the parsed URL, throwing a typed Error unless `url` parses and uses the `https:` scheme. */
+function assertHttpsUrl(url: string): URL {
 	let parsed: URL;
 	try {
 		parsed = new URL(url);
@@ -81,6 +203,7 @@ function assertHttpsUrl(url: string): void {
 	if (parsed.protocol !== "https:") {
 		throw new Error(`open-url only opens https URLs, got scheme: ${parsed.protocol}`);
 	}
+	return parsed;
 }
 
 /**
@@ -89,10 +212,19 @@ function assertHttpsUrl(url: string): void {
  * or a headless environment resolves to `{ opened: false, url }`.
  */
 export async function openUrlOrPrint(url: string, deps: Partial<OpenUrlDeps> = {}): Promise<OpenUrlResult> {
-	assertHttpsUrl(url);
+	const parsed = assertHttpsUrl(url);
 	const launch = deps.launch ?? defaultLaunch;
 	const isHeadless = deps.isHeadless ?? defaultIsHeadless;
 	const print = deps.print ?? defaultPrint;
+	const devHosts = resolveDevOriginHosts(deps.configOrigins ?? []);
+
+	// Refuse (never launch) an off-allowlist origin — the last-line guard against a
+	// crafted payload turning open-url into an arbitrary-launch primitive. Still
+	// print the URL so the user can open it manually; a refusal is a safe outcome.
+	if (!isOriginAllowlisted(parsed, devHosts)) {
+		print(url);
+		return { opened: false, url, refused: true, reason: ORIGIN_NOT_ALLOWLISTED };
+	}
 
 	if (isHeadless()) {
 		print(url);

--- a/cli/src/core/WorkBranchCheck.test.ts
+++ b/cli/src/core/WorkBranchCheck.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { checkPublishBranch } from "./WorkBranchCheck.js";
+
+describe("checkPublishBranch", () => {
+	it("matches identical branches", () => {
+		expect(checkPublishBranch("jolli-agent-8226c9abc576", "jolli-agent-8226c9abc576")).toEqual({
+			match: true,
+			expected: "jolli-agent-8226c9abc576",
+			actual: "jolli-agent-8226c9abc576",
+		});
+	});
+
+	it("does NOT match when space-cli published on its own generated branch (the silent-failure case)", () => {
+		expect(checkPublishBranch("jolli-agent-8226c9abc576", "jolli-6e3a72e55c22")).toEqual({
+			match: false,
+			expected: "jolli-agent-8226c9abc576",
+			actual: "jolli-6e3a72e55c22",
+		});
+	});
+
+	it("treats a missing/empty headBranch as an unverifiable non-match", () => {
+		expect(checkPublishBranch("jolli-agent-8226c9abc576", "")).toEqual({
+			match: false,
+			expected: "jolli-agent-8226c9abc576",
+			actual: "",
+		});
+	});
+
+	it("treats an empty expected work branch as a non-match", () => {
+		expect(checkPublishBranch("", "jolli-agent-8226c9abc576")).toEqual({
+			match: false,
+			expected: "",
+			actual: "jolli-agent-8226c9abc576",
+		});
+	});
+
+	it("trims surrounding whitespace before comparing", () => {
+		expect(checkPublishBranch("  jolli-agent-abc  ", "jolli-agent-abc\n")).toEqual({
+			match: true,
+			expected: "jolli-agent-abc",
+			actual: "jolli-agent-abc",
+		});
+	});
+
+	it("does not match two blank inputs", () => {
+		expect(checkPublishBranch("   ", "")).toEqual({ match: false, expected: "", actual: "" });
+	});
+});

--- a/cli/src/core/WorkBranchCheck.ts
+++ b/cli/src/core/WorkBranchCheck.ts
@@ -1,0 +1,36 @@
+/**
+ * Deterministic work-branch cross-check for the local-run publish step.
+ *
+ * A local run's file writes must be published on the *server-derived* work branch
+ * (`writeTarget.workBranch` from `start_local_run`) so the backend can link the run
+ * to the pull request and auto-merge/apply it. If the host LLM drops the branch when
+ * it runs `docs pull --branch <workBranch>`, space-cli falls back to generating its
+ * own `jolli-<hex>` branch and opens the PR there instead — the run→PR link silently
+ * breaks (nothing merges, articles never publish), yet the run can still report
+ * success. `docs publish --json` returns the branch the PR was actually opened on as
+ * `headBranch` (present on both the public and the private/withheld paths), so the
+ * host can catch the mismatch deterministically by comparing two strings it already
+ * holds — instead of asking the same LLM that dropped the branch to compare them.
+ */
+
+/** Result of comparing the expected server work branch to the published head branch. */
+export interface WorkBranchCheckResult {
+	/** True only when both branches are non-empty and equal (after trimming). */
+	readonly match: boolean;
+	/** The expected server-derived work branch (`writeTarget.workBranch`), trimmed. */
+	readonly expected: string;
+	/** The branch the PR was actually opened on (`headBranch`), trimmed. */
+	readonly actual: string;
+}
+
+/**
+ * Compares the expected server work branch to the branch the publish landed on.
+ * A missing/empty `actual` (no `headBranch` reported) can NOT be verified as correct,
+ * so it is treated as a non-match — the caller stops rather than assuming success.
+ */
+export function checkPublishBranch(expected: string, actual: string): WorkBranchCheckResult {
+	const trimmedExpected = expected.trim();
+	const trimmedActual = actual.trim();
+	const match = trimmedExpected.length > 0 && trimmedActual.length > 0 && trimmedExpected === trimmedActual;
+	return { match, expected: trimmedExpected, actual: trimmedActual };
+}

--- a/cli/src/core/WorkflowRunMonitor.test.ts
+++ b/cli/src/core/WorkflowRunMonitor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { monitorRun, realSleep } from "./WorkflowRunMonitor.js";
-import type { WorkflowRunPayload } from "./WorkflowRunReport.js";
+import { PlatformToolUnavailableError, type WorkflowRunPayload } from "./WorkflowRunReport.js";
 
 /** A minimal running (`active`) payload carrying a workflow deep-link. */
 function running(overrides: Partial<WorkflowRunPayload> = {}): WorkflowRunPayload {
@@ -85,6 +85,47 @@ describe("monitorRun", () => {
 		expect(report.status).toBe("running");
 		expect(report.timedOut).toBe(true);
 		expect(report.openableUrls).toEqual([]);
+	});
+
+	it("includes the run deep-link (not just the workflow URL) in a timedOut report when the payload carried one", async () => {
+		const getRunStatus = vi.fn().mockResolvedValue(running({ runUrl: "https://jolli.ai/w/1/r/run_1" }));
+		const sleep = vi.fn().mockResolvedValue(undefined);
+
+		const report = await monitorRun({ getRunStatus, sleep }, "run_1", FAST);
+
+		expect(report.status).toBe("running");
+		expect(report.timedOut).toBe(true);
+		// The run URL points straight at the still-in-progress run for the user to watch.
+		expect(report.openableUrls).toEqual([
+			{ kind: "workflow", url: "https://jolli.ai/w/1" },
+			{ kind: "run", url: "https://jolli.ai/w/1/r/run_1" },
+		]);
+	});
+
+	it("does not sleep after the final attempt (the trailing backoff would poll nothing)", async () => {
+		const getRunStatus = vi.fn().mockResolvedValue(running());
+		const sleep = vi.fn().mockResolvedValue(undefined);
+
+		await monitorRun({ getRunStatus, sleep }, "run_1", FAST);
+
+		// maxAttempts=5 non-terminal polls ⇒ a sleep between each of the first four,
+		// but NOT after the fifth (the loop exits straight into the timedOut report).
+		expect(getRunStatus).toHaveBeenCalledTimes(5);
+		expect(sleep).toHaveBeenCalledTimes(4);
+	});
+
+	it("re-throws a PlatformToolUnavailableError immediately without retrying or sleeping", async () => {
+		const getRunStatus = vi
+			.fn()
+			.mockRejectedValue(new PlatformToolUnavailableError('Platform tool "get_run_status" is unavailable.'));
+		const sleep = vi.fn().mockResolvedValue(undefined);
+
+		await expect(monitorRun({ getRunStatus, sleep }, "run_1", FAST)).rejects.toBeInstanceOf(
+			PlatformToolUnavailableError,
+		);
+		// Permanent error ⇒ fail fast: one call, no transient retries, no backoff.
+		expect(getRunStatus).toHaveBeenCalledTimes(1);
+		expect(sleep).not.toHaveBeenCalled();
 	});
 
 	it("retries a transient throw then succeeds", async () => {

--- a/cli/src/core/WorkflowRunMonitor.test.ts
+++ b/cli/src/core/WorkflowRunMonitor.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import { monitorRun, realSleep } from "./WorkflowRunMonitor.js";
+import type { WorkflowRunPayload } from "./WorkflowRunReport.js";
+
+/** A minimal running (`active`) payload carrying a workflow deep-link. */
+function running(overrides: Partial<WorkflowRunPayload> = {}): WorkflowRunPayload {
+	return { id: "run_1", status: "active", workflowUrl: "https://jolli.ai/w/1", ...overrides };
+}
+
+/** Fast opts so the timeout/backoff branches run without real waits or 40 iterations. */
+const FAST = { maxAttempts: 5, maxTransientRetries: 2, baseDelayMs: 1, maxDelayMs: 4 } as const;
+
+describe("monitorRun", () => {
+	it("polls until terminal and returns the succeeded report (no trailing sleep on terminal)", async () => {
+		const getRunStatus = vi
+			.fn()
+			.mockResolvedValueOnce(running())
+			.mockResolvedValueOnce(running())
+			.mockResolvedValueOnce(
+				running({
+					status: "completed",
+					writtenArticles: [{ operation: "created", path: "a.md", url: "https://jolli.ai/a", active: true }],
+				}),
+			);
+		const sleep = vi.fn().mockResolvedValue(undefined);
+
+		const report = await monitorRun({ getRunStatus, sleep }, "run_1", FAST);
+
+		expect(report.status).toBe("succeeded");
+		expect(report.timedOut).toBeUndefined();
+		expect(report.openableUrls).toEqual([
+			{ kind: "workflow", url: "https://jolli.ai/w/1" },
+			{ kind: "article", url: "https://jolli.ai/a", label: "a.md" },
+		]);
+		expect(getRunStatus).toHaveBeenCalledTimes(3);
+		// Slept once between each of the two non-terminal polls; not after the terminal poll.
+		expect(sleep).toHaveBeenCalledTimes(2);
+	});
+
+	it("returns a failed report with troubleshooting on an immediate failed status", async () => {
+		const getRunStatus = vi
+			.fn()
+			.mockResolvedValue(running({ status: "failed", error: "code=TIMEOUT: agent stalled" }));
+		const sleep = vi.fn().mockResolvedValue(undefined);
+
+		const report = await monitorRun({ getRunStatus, sleep }, "run_1", FAST);
+
+		expect(report.status).toBe("failed");
+		expect(report.troubleshooting).toBe("code=TIMEOUT: agent stalled");
+		expect(sleep).not.toHaveBeenCalled();
+	});
+
+	it("returns cancel attribution on a cancelled status", async () => {
+		const getRunStatus = vi
+			.fn()
+			.mockResolvedValue(
+				running({ status: "cancelled", canceledBy: "Doug", canceledAt: "2026-07-17T00:00:00Z" }),
+			);
+		const sleep = vi.fn().mockResolvedValue(undefined);
+
+		const report = await monitorRun({ getRunStatus, sleep }, "run_1", FAST);
+
+		expect(report.status).toBe("cancelled");
+		expect(report.cancel).toEqual({ by: "Doug", at: "2026-07-17T00:00:00Z" });
+	});
+
+	it("returns a timedOut running report (with the last workflow URL) when the attempt cap is hit", async () => {
+		const getRunStatus = vi.fn().mockResolvedValue(running());
+		const sleep = vi.fn().mockResolvedValue(undefined);
+
+		const report = await monitorRun({ getRunStatus, sleep }, "run_1", FAST);
+
+		expect(report.status).toBe("running");
+		expect(report.timedOut).toBe(true);
+		expect(report.openableUrls).toEqual([{ kind: "workflow", url: "https://jolli.ai/w/1" }]);
+		expect(getRunStatus).toHaveBeenCalledTimes(5);
+	});
+
+	it("returns a timedOut report with no openable URLs when no payload carried a workflow URL", async () => {
+		const getRunStatus = vi.fn().mockResolvedValue(running({ workflowUrl: undefined }));
+		const sleep = vi.fn().mockResolvedValue(undefined);
+
+		const report = await monitorRun({ getRunStatus, sleep }, "run_1", FAST);
+
+		expect(report.status).toBe("running");
+		expect(report.timedOut).toBe(true);
+		expect(report.openableUrls).toEqual([]);
+	});
+
+	it("retries a transient throw then succeeds", async () => {
+		const getRunStatus = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("network blip"))
+			.mockResolvedValueOnce(running({ status: "completed" }));
+		const sleep = vi.fn().mockResolvedValue(undefined);
+
+		const report = await monitorRun({ getRunStatus, sleep }, "run_1", FAST);
+
+		expect(report.status).toBe("succeeded");
+		expect(getRunStatus).toHaveBeenCalledTimes(2);
+		expect(sleep).toHaveBeenCalledTimes(1);
+	});
+
+	it("re-throws a persistent getRunStatus failure past the transient-retry budget", async () => {
+		const getRunStatus = vi.fn().mockRejectedValue(new Error("platform tools off"));
+		const sleep = vi.fn().mockResolvedValue(undefined);
+
+		await expect(monitorRun({ getRunStatus, sleep }, "run_1", FAST)).rejects.toThrow("platform tools off");
+		// maxTransientRetries=2 ⇒ failures at count 1,2 retried, count 3 (>2) re-throws.
+		expect(getRunStatus).toHaveBeenCalledTimes(3);
+	});
+
+	it("uses default bounds/backoff (cap applied on later attempts) when no opts are given", async () => {
+		// Six non-terminal polls then completed exercises the maxDelayMs cap
+		// (base 2000·2^attempt exceeds 15000 by attempt 3) under default options.
+		const getRunStatus = vi.fn();
+		for (let i = 0; i < 6; i++) {
+			getRunStatus.mockResolvedValueOnce(running());
+		}
+		getRunStatus.mockResolvedValueOnce(running({ status: "completed" }));
+		const sleep = vi.fn().mockResolvedValue(undefined);
+
+		const report = await monitorRun({ getRunStatus, sleep }, "run_1");
+
+		expect(report.status).toBe("succeeded");
+		expect(getRunStatus).toHaveBeenCalledTimes(7);
+		// The delay ceiling (15000) was reached on the later attempts.
+		expect(Math.max(...sleep.mock.calls.map((c) => c[0] as number))).toBe(15000);
+	});
+
+	it("realSleep resolves after the given delay", async () => {
+		await expect(realSleep(0)).resolves.toBeUndefined();
+	});
+});

--- a/cli/src/core/WorkflowRunMonitor.ts
+++ b/cli/src/core/WorkflowRunMonitor.ts
@@ -1,0 +1,108 @@
+/**
+ * The deterministic poll-to-terminal monitor for a remote workflow run. The
+ * remote-run recipe shells `jolli workflow-run-status <runId>` once instead of
+ * driving a poll loop in the agent: this core polls `getRunStatus(runId)` with
+ * exponential backoff until the wire status is terminal, then returns the pure
+ * {@link shapeRunReport} projection of the final payload.
+ *
+ * It is pure-ish — every side-effecting seam is injected ({@link MonitorDeps}):
+ * the run-status read-method and a `sleep` clock — so tests drive it with a fake
+ * sleep and need no real timers. The monitor NEVER hangs and NEVER throws for a
+ * still-running run: on the attempt cap it returns a still-running report tagged
+ * `timedOut: true` (the run continues server-side). The ONLY throw it propagates
+ * is a PERSISTENT `getRunStatus` failure — a small number of consecutive
+ * transient throws are retried first; only a run of failures past that budget is
+ * re-thrown, which the command turns into a `{ type: "error" }` result.
+ */
+
+import { isTerminalStatus, type RunReport, shapeRunReport, type WorkflowRunPayload } from "./WorkflowRunReport.js";
+
+/** The side-effecting seams {@link monitorRun} needs; the command wires real impls. */
+export interface MonitorDeps {
+	/** Fetch one run's enriched status; LOUD-FAIL (throws on transport/tool-absent). */
+	getRunStatus: (runId: string) => Promise<WorkflowRunPayload>;
+	/** Wait `ms` milliseconds (injected so tests need no real timers). */
+	sleep: (ms: number) => Promise<void>;
+}
+
+/** Bounds and backoff shape for {@link monitorRun}; each field defaults when omitted. */
+export interface MonitorOptions {
+	/** Max poll attempts before returning a `timedOut` report (default 40). */
+	readonly maxAttempts?: number;
+	/** Consecutive transient `getRunStatus` throws tolerated before re-throwing (default 3). */
+	readonly maxTransientRetries?: number;
+	/** First backoff delay in ms; doubles each attempt up to {@link maxDelayMs} (default 2000). */
+	readonly baseDelayMs?: number;
+	/** Backoff ceiling in ms (default 15000). */
+	readonly maxDelayMs?: number;
+}
+
+/** A {@link RunReport} plus the monitor-only `timedOut` flag (set only on the cap). */
+export interface MonitorResult extends RunReport {
+	/** True when the attempt cap was hit while the run was still non-terminal. */
+	readonly timedOut?: boolean;
+}
+
+const DEFAULT_MAX_ATTEMPTS = 40;
+const DEFAULT_MAX_TRANSIENT_RETRIES = 3;
+const DEFAULT_BASE_DELAY_MS = 2000;
+const DEFAULT_MAX_DELAY_MS = 15000;
+
+/** A real `sleep` seam for production wiring (the command injects this). */
+export function realSleep(ms: number): Promise<void> {
+	return new Promise((resolve) => {
+		setTimeout(resolve, ms);
+	});
+}
+
+/** Exponential backoff for `attempt` (0-based), doubling `base` and capped at `max`. */
+function backoffDelay(attempt: number, baseDelayMs: number, maxDelayMs: number): number {
+	return Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
+}
+
+/**
+ * Poll `runId` to a terminal state and return its shaped report. See the file
+ * header for the full contract:
+ * - terminal (`completed`/`failed`/`cancelled`) ⇒ the shaped report, returned as
+ *   soon as it is observed (no trailing sleep).
+ * - attempt cap hit while non-terminal ⇒ `{ status: "running", timedOut: true,
+ *   openableUrls: [workflow URL if the last payload carried one] }`.
+ * - a persistent `getRunStatus` throw (past `maxTransientRetries` consecutive
+ *   failures) ⇒ re-thrown for the command to report; a successful poll resets the
+ *   transient counter.
+ */
+export async function monitorRun(deps: MonitorDeps, runId: string, opts: MonitorOptions = {}): Promise<MonitorResult> {
+	const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+	const maxTransientRetries = opts.maxTransientRetries ?? DEFAULT_MAX_TRANSIENT_RETRIES;
+	const baseDelayMs = opts.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+	const maxDelayMs = opts.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+
+	let lastWorkflowUrl: string | undefined;
+	let consecutiveFailures = 0;
+
+	for (let attempt = 0; attempt < maxAttempts; attempt++) {
+		let run: WorkflowRunPayload;
+		try {
+			run = await deps.getRunStatus(runId);
+		} catch (error) {
+			consecutiveFailures++;
+			if (consecutiveFailures > maxTransientRetries) {
+				throw error;
+			}
+			await deps.sleep(backoffDelay(attempt, baseDelayMs, maxDelayMs));
+			continue;
+		}
+		consecutiveFailures = 0;
+		lastWorkflowUrl = run.workflowUrl ?? lastWorkflowUrl;
+		if (isTerminalStatus(run.status)) {
+			return shapeRunReport(run);
+		}
+		await deps.sleep(backoffDelay(attempt, baseDelayMs, maxDelayMs));
+	}
+
+	return {
+		status: "running",
+		openableUrls: lastWorkflowUrl !== undefined ? [{ kind: "workflow", url: lastWorkflowUrl }] : [],
+		timedOut: true,
+	};
+}

--- a/cli/src/core/WorkflowRunMonitor.ts
+++ b/cli/src/core/WorkflowRunMonitor.ts
@@ -9,13 +9,27 @@
  * the run-status read-method and a `sleep` clock — so tests drive it with a fake
  * sleep and need no real timers. The monitor NEVER hangs and NEVER throws for a
  * still-running run: on the attempt cap it returns a still-running report tagged
- * `timedOut: true` (the run continues server-side). The ONLY throw it propagates
- * is a PERSISTENT `getRunStatus` failure — a small number of consecutive
- * transient throws are retried first; only a run of failures past that budget is
- * re-thrown, which the command turns into a `{ type: "error" }` result.
+ * `timedOut: true` (the run continues server-side). The default cap is sized to a
+ * few minutes of wall-clock (see {@link DEFAULT_MAX_ATTEMPTS}) so the single
+ * foreground `jolli workflow-run-status` call the recipe shells stays inside a
+ * typical agent shell-tool timeout — the graceful `timedOut` report is only useful
+ * if it actually reaches the agent rather than the host killing the call first.
+ *
+ * The ONLY throw it propagates is a `getRunStatus` failure that is not recoverable
+ * by waiting: a {@link PlatformToolUnavailableError} (platform tools off / backend
+ * too old) is structurally permanent and re-thrown immediately, and a run of
+ * consecutive transient throws past `maxTransientRetries` is re-thrown too. The
+ * command turns either into a `{ type: "error" }` result.
  */
 
-import { isTerminalStatus, type RunReport, shapeRunReport, type WorkflowRunPayload } from "./WorkflowRunReport.js";
+import {
+	isTerminalStatus,
+	type OpenableUrl,
+	PlatformToolUnavailableError,
+	type RunReport,
+	shapeRunReport,
+	type WorkflowRunPayload,
+} from "./WorkflowRunReport.js";
 
 /** The side-effecting seams {@link monitorRun} needs; the command wires real impls. */
 export interface MonitorDeps {
@@ -27,7 +41,7 @@ export interface MonitorDeps {
 
 /** Bounds and backoff shape for {@link monitorRun}; each field defaults when omitted. */
 export interface MonitorOptions {
-	/** Max poll attempts before returning a `timedOut` report (default 40). */
+	/** Max poll attempts before returning a `timedOut` report (default {@link DEFAULT_MAX_ATTEMPTS}). */
 	readonly maxAttempts?: number;
 	/** Consecutive transient `getRunStatus` throws tolerated before re-throwing (default 3). */
 	readonly maxTransientRetries?: number;
@@ -43,7 +57,14 @@ export interface MonitorResult extends RunReport {
 	readonly timedOut?: boolean;
 }
 
-const DEFAULT_MAX_ATTEMPTS = 40;
+/**
+ * Poll-attempt cap. With the default backoff (2s → 4s → 8s → 15s ceiling), 15
+ * attempts is ~3 min of wall-clock — a few minutes, bounded well under a typical
+ * agent shell-tool timeout so the graceful `timedOut` report reaches the agent
+ * instead of the host killing the foreground call. A still-running run is not lost:
+ * the recipe re-runs `workflow-run-status <runId>` to pick it back up.
+ */
+const DEFAULT_MAX_ATTEMPTS = 15;
 const DEFAULT_MAX_TRANSIENT_RETRIES = 3;
 const DEFAULT_BASE_DELAY_MS = 2000;
 const DEFAULT_MAX_DELAY_MS = 15000;
@@ -66,10 +87,13 @@ function backoffDelay(attempt: number, baseDelayMs: number, maxDelayMs: number):
  * - terminal (`completed`/`failed`/`cancelled`) ⇒ the shaped report, returned as
  *   soon as it is observed (no trailing sleep).
  * - attempt cap hit while non-terminal ⇒ `{ status: "running", timedOut: true,
- *   openableUrls: [workflow URL if the last payload carried one] }`.
- * - a persistent `getRunStatus` throw (past `maxTransientRetries` consecutive
- *   failures) ⇒ re-thrown for the command to report; a successful poll resets the
- *   transient counter.
+ *   openableUrls: [workflow and run deep-links the last payload carried] }` — the
+ *   run URL points straight at the still-in-progress run for the user to watch.
+ * - a {@link PlatformToolUnavailableError} ⇒ re-thrown immediately (structurally
+ *   permanent — retrying cannot make the tool appear).
+ * - a persistent transient `getRunStatus` throw (past `maxTransientRetries`
+ *   consecutive failures) ⇒ re-thrown for the command to report; a successful poll
+ *   resets the transient counter.
  */
 export async function monitorRun(deps: MonitorDeps, runId: string, opts: MonitorOptions = {}): Promise<MonitorResult> {
 	const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
@@ -78,6 +102,7 @@ export async function monitorRun(deps: MonitorDeps, runId: string, opts: Monitor
 	const maxDelayMs = opts.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
 
 	let lastWorkflowUrl: string | undefined;
+	let lastRunUrl: string | undefined;
 	let consecutiveFailures = 0;
 
 	for (let attempt = 0; attempt < maxAttempts; attempt++) {
@@ -85,6 +110,11 @@ export async function monitorRun(deps: MonitorDeps, runId: string, opts: Monitor
 		try {
 			run = await deps.getRunStatus(runId);
 		} catch (error) {
+			// A tool-absent failure is permanent — waiting cannot fix it, so surface
+			// it now rather than burning the transient budget + backoff on retries.
+			if (error instanceof PlatformToolUnavailableError) {
+				throw error;
+			}
 			consecutiveFailures++;
 			if (consecutiveFailures > maxTransientRetries) {
 				throw error;
@@ -94,15 +124,23 @@ export async function monitorRun(deps: MonitorDeps, runId: string, opts: Monitor
 		}
 		consecutiveFailures = 0;
 		lastWorkflowUrl = run.workflowUrl ?? lastWorkflowUrl;
+		lastRunUrl = run.runUrl ?? lastRunUrl;
 		if (isTerminalStatus(run.status)) {
 			return shapeRunReport(run);
 		}
-		await deps.sleep(backoffDelay(attempt, baseDelayMs, maxDelayMs));
+		// Skip the backoff wait after the final attempt — the loop is about to exit
+		// and return the `timedOut` report, so that last sleep would poll nothing.
+		if (attempt < maxAttempts - 1) {
+			await deps.sleep(backoffDelay(attempt, baseDelayMs, maxDelayMs));
+		}
 	}
 
-	return {
-		status: "running",
-		openableUrls: lastWorkflowUrl !== undefined ? [{ kind: "workflow", url: lastWorkflowUrl }] : [],
-		timedOut: true,
-	};
+	const openableUrls: OpenableUrl[] = [];
+	if (lastWorkflowUrl !== undefined) {
+		openableUrls.push({ kind: "workflow", url: lastWorkflowUrl });
+	}
+	if (lastRunUrl !== undefined) {
+		openableUrls.push({ kind: "run", url: lastRunUrl });
+	}
+	return { status: "running", openableUrls, timedOut: true };
 }

--- a/cli/src/core/WorkflowRunReport.test.ts
+++ b/cli/src/core/WorkflowRunReport.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+import {
+	isTerminalStatus,
+	type JobStatus,
+	shapeRunHistoryEntry,
+	shapeRunReport,
+	toReportStatus,
+	type WorkflowRunPayload,
+} from "./WorkflowRunReport.js";
+
+/** A minimal valid run; spread over per-case overrides. */
+function run(overrides: Partial<WorkflowRunPayload> = {}): WorkflowRunPayload {
+	return { id: "run-1", status: "completed", ...overrides };
+}
+
+describe("isTerminalStatus", () => {
+	it.each<[JobStatus, boolean]>([
+		["completed", true],
+		["failed", true],
+		["cancelled", true],
+		["queued", false],
+		["active", false],
+	])("%s → %s", (status, terminal) => {
+		expect(isTerminalStatus(status)).toBe(terminal);
+	});
+});
+
+describe("toReportStatus", () => {
+	it.each<[JobStatus, string]>([
+		["completed", "succeeded"],
+		["failed", "failed"],
+		["cancelled", "cancelled"],
+		["queued", "running"],
+		["active", "running"],
+	])("%s → %s", (wire, report) => {
+		expect(toReportStatus(wire)).toBe(report);
+	});
+});
+
+describe("shapeRunReport", () => {
+	it("succeeded: 2 active + 1 created(url:null) + 1 deleted article ⇒ 2 article URLs + workflow/run URLs", () => {
+		const report = shapeRunReport(
+			run({
+				status: "completed",
+				workflowUrl: "https://jolli.ai/w/7",
+				runUrl: "https://jolli.ai/w/7/r/run-1",
+				writtenArticles: [
+					{ operation: "edited", path: "a.md", title: "Alpha", url: "https://jolli.ai/a", active: true },
+					{ operation: "edited", path: "b.md", url: "https://jolli.ai/b", active: true },
+					{ operation: "created", path: "c.md", url: null, active: false }, // freshly created, not yet reindexed
+					{ operation: "deleted", path: "d.md", url: null, active: false },
+				],
+			}),
+		);
+		expect(report.status).toBe("succeeded");
+		expect(report.openableUrls).toEqual([
+			{ kind: "workflow", url: "https://jolli.ai/w/7" },
+			{ kind: "run", url: "https://jolli.ai/w/7/r/run-1" },
+			{ kind: "article", url: "https://jolli.ai/a", label: "Alpha" }, // label from title
+			{ kind: "article", url: "https://jolli.ai/b", label: "b.md" }, // label falls back to path
+		]);
+		expect(report.cancel).toBeUndefined();
+		expect(report.troubleshooting).toBeUndefined();
+	});
+
+	it("excludes an article that is active but has a null url", () => {
+		const report = shapeRunReport(
+			run({ writtenArticles: [{ operation: "created", path: "x.md", url: null, active: true }] }),
+		);
+		expect(report.openableUrls).toEqual([]);
+	});
+
+	it("git-backed succeeded with a pullRequest ⇒ PR URL included", () => {
+		const report = shapeRunReport(
+			run({
+				workflowUrl: "https://jolli.ai/w/7",
+				pullRequest: { number: 5, url: "https://gh/pr/5", state: "open" },
+			}),
+		);
+		expect(report.openableUrls).toEqual([
+			{ kind: "workflow", url: "https://jolli.ai/w/7" },
+			{ kind: "pr", url: "https://gh/pr/5" },
+		]);
+	});
+
+	it("private jolli-git withheld (no pullRequest) ⇒ article URLs only, never a PR", () => {
+		const report = shapeRunReport(
+			run({
+				workflowUrl: "https://jolli.ai/w/7",
+				writtenArticles: [{ operation: "edited", path: "a.md", url: "https://jolli.ai/a", active: true }],
+			}),
+		);
+		expect(report.openableUrls.some((u) => u.kind === "pr")).toBe(false);
+		expect(report.openableUrls).toEqual([
+			{ kind: "workflow", url: "https://jolli.ai/w/7" },
+			{ kind: "article", url: "https://jolli.ai/a", label: "a.md" },
+		]);
+	});
+
+	it("failed ⇒ troubleshooting from error + workflow URL, no run/article/pr", () => {
+		const report = shapeRunReport(
+			run({ status: "failed", error: "code=TIMEOUT: run exceeded budget", workflowUrl: "https://jolli.ai/w/7" }),
+		);
+		expect(report.status).toBe("failed");
+		expect(report.troubleshooting).toBe("code=TIMEOUT: run exceeded budget");
+		expect(report.openableUrls).toEqual([{ kind: "workflow", url: "https://jolli.ai/w/7" }]);
+	});
+
+	it("failed without an error string ⇒ no troubleshooting field", () => {
+		const report = shapeRunReport(run({ status: "failed" }));
+		expect(report.status).toBe("failed");
+		expect(report.troubleshooting).toBeUndefined();
+	});
+
+	it("does not surface troubleshooting for a non-failed run even if error is present", () => {
+		const report = shapeRunReport(run({ status: "completed", error: "stray error" }));
+		expect(report.status).toBe("succeeded");
+		expect(report.troubleshooting).toBeUndefined();
+	});
+
+	it("cancelled ⇒ cancel { by, at } + workflow URL", () => {
+		const report = shapeRunReport(
+			run({
+				status: "cancelled",
+				canceledBy: "Dev",
+				canceledAt: "2026-07-16T00:00:05Z",
+				workflowUrl: "https://jolli.ai/w/7",
+			}),
+		);
+		expect(report.status).toBe("cancelled");
+		expect(report.cancel).toEqual({ by: "Dev", at: "2026-07-16T00:00:05Z" });
+	});
+
+	it("cancel is populated from canceledBy alone", () => {
+		expect(shapeRunReport(run({ status: "cancelled", canceledBy: "Dev" })).cancel).toEqual({ by: "Dev" });
+	});
+
+	it("cancel is populated from canceledAt alone", () => {
+		expect(shapeRunReport(run({ status: "cancelled", canceledAt: "2026-07-16T00:00:05Z" })).cancel).toEqual({
+			at: "2026-07-16T00:00:05Z",
+		});
+	});
+
+	it("running ⇒ status running; a sparse payload yields no openable URLs and never throws", () => {
+		const report = shapeRunReport(run({ status: "active" }));
+		expect(report.status).toBe("running");
+		expect(report.openableUrls).toEqual([]);
+		expect(report.cancel).toBeUndefined();
+		expect(report.troubleshooting).toBeUndefined();
+	});
+
+	it("emits a run URL without a workflow URL when only runUrl is present", () => {
+		const report = shapeRunReport(run({ status: "queued", runUrl: "https://jolli.ai/w/7/r/run-1" }));
+		expect(report.openableUrls).toEqual([{ kind: "run", url: "https://jolli.ai/w/7/r/run-1" }]);
+	});
+});
+
+describe("shapeRunHistoryEntry", () => {
+	it("succeeded git-backed run ⇒ status, timestamp, workflow/run/PR URLs, and active article URLs", () => {
+		const entry = shapeRunHistoryEntry(
+			run({
+				id: "r7",
+				status: "completed",
+				createdAt: "2026-07-17T10:00:00Z",
+				workflowUrl: "https://jolli.ai/w/7",
+				runUrl: "https://jolli.ai/w/7/r/r7",
+				pullRequest: { number: 5, url: "https://gh/pr/5", state: "open" },
+				writtenArticles: [
+					{ operation: "edited", path: "a.md", title: "Alpha", url: "https://jolli.ai/a", active: true },
+					{ operation: "created", path: "b.md", url: null, active: false }, // not yet reindexed
+				],
+			}),
+		);
+		expect(entry).toEqual({
+			runId: "r7",
+			status: "succeeded",
+			timestamp: "2026-07-17T10:00:00Z",
+			workflowUrl: "https://jolli.ai/w/7",
+			runUrl: "https://jolli.ai/w/7/r/r7",
+			prUrl: "https://gh/pr/5",
+			articleUrls: ["https://jolli.ai/a"],
+		});
+	});
+
+	it("private jolli-git withheld run ⇒ article URLs only, never a prUrl", () => {
+		const entry = shapeRunHistoryEntry(
+			run({
+				id: "r8",
+				status: "completed",
+				createdAt: "2026-07-17T11:00:00Z",
+				workflowUrl: "https://jolli.ai/w/7",
+				writtenArticles: [{ operation: "edited", path: "a.md", url: "https://jolli.ai/a", active: true }],
+			}),
+		);
+		expect(entry.prUrl).toBeUndefined();
+		expect(entry).toEqual({
+			runId: "r8",
+			status: "succeeded",
+			timestamp: "2026-07-17T11:00:00Z",
+			workflowUrl: "https://jolli.ai/w/7",
+			articleUrls: ["https://jolli.ai/a"],
+		});
+	});
+
+	it("failed run ⇒ failed status with no article/PR URLs", () => {
+		const entry = shapeRunHistoryEntry(
+			run({ id: "r9", status: "failed", createdAt: "2026-07-17T12:00:00Z", error: "code=TIMEOUT: x" }),
+		);
+		expect(entry).toEqual({ runId: "r9", status: "failed", timestamp: "2026-07-17T12:00:00Z", articleUrls: [] });
+	});
+
+	it("cancelled run ⇒ cancelled status (cancel attribution is not part of the history row)", () => {
+		const entry = shapeRunHistoryEntry(
+			run({ id: "r10", status: "cancelled", createdAt: "2026-07-17T13:00:00Z", canceledBy: "Dev" }),
+		);
+		expect(entry).toEqual({
+			runId: "r10",
+			status: "cancelled",
+			timestamp: "2026-07-17T13:00:00Z",
+			articleUrls: [],
+		});
+	});
+
+	it("omits timestamp when the payload lacked createdAt; sparse running row has an empty articleUrls", () => {
+		const entry = shapeRunHistoryEntry(run({ id: "r11", status: "active" }));
+		expect(entry).toEqual({ runId: "r11", status: "running", articleUrls: [] });
+		expect(entry.timestamp).toBeUndefined();
+	});
+});

--- a/cli/src/core/WorkflowRunReport.ts
+++ b/cli/src/core/WorkflowRunReport.ts
@@ -18,6 +18,20 @@
  */
 
 /**
+ * Thrown by the run read-methods (`getRunStatus` / `listWorkflowRuns`) when the
+ * backing platform tool is absent from the manifest (platform tools off / backend
+ * too old). Structurally PERMANENT — unlike a transient transport blip, retrying
+ * will not make the tool appear — so the run monitor fails fast on it instead of
+ * burning its transient-retry budget and the ~29s of backoff that costs.
+ */
+export class PlatformToolUnavailableError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "PlatformToolUnavailableError";
+	}
+}
+
+/**
  * The run's lifecycle status on the wire. Terminal values are `completed` /
  * `failed` / `cancelled`; `queued` / `active` are in-progress. NB the success
  * value is `completed`, NOT `succeeded` (`succeeded` is the shaper's presentation

--- a/cli/src/core/WorkflowRunReport.ts
+++ b/cli/src/core/WorkflowRunReport.ts
@@ -1,0 +1,249 @@
+/**
+ * The enriched per-run workflow read model the host consumes off the run tools
+ * (`get_run_status` / `list_workflow_runs`), plus a PURE shaper that turns one
+ * run payload into a report-ready shape.
+ *
+ * The host constructs NO URL of its own: every openable URL is read verbatim off
+ * the payload and the shaper opens exactly what the backend supplied. The shaper
+ * is deliberately I/O-free — a payload in, a report out, no fetching, no spawning
+ * — and never throws on a well-formed-but-sparse payload (a missing optional
+ * field simply yields fewer openable URLs). The client's loud-fail read-methods
+ * (which import these types type-only) own the transport/validation asymmetry.
+ *
+ * Openability is frozen: an article is openable ONLY when `active === true &&
+ * url != null`. A freshly-created article resolves to `active:false, url:null`
+ * until the backend reindexes; a deleted article is `active:false, url:null`.
+ * The typed pull request is deliberately withheld for private Jolli-managed
+ * destinations, so an absent PR is NORMAL — never an error, never fabricated.
+ */
+
+/**
+ * The run's lifecycle status on the wire. Terminal values are `completed` /
+ * `failed` / `cancelled`; `queued` / `active` are in-progress. NB the success
+ * value is `completed`, NOT `succeeded` (`succeeded` is the shaper's presentation
+ * label — see {@link shapeRunReport}); a terminal check keyed off `succeeded`
+ * would silently never terminate.
+ */
+export type JobStatus = "queued" | "active" | "completed" | "failed" | "cancelled";
+
+/** How a run was initiated. */
+export type RunTrigger = "manual" | "schedule" | "event";
+
+/** Where the run executed. An absent legacy value surfaces as `"server"`. */
+export type RunExecutionMode = "server" | "local";
+
+/** One entry per file a run wrote — the article-write manifest. */
+export interface WorkflowRunWrittenArticle {
+	/** The changeset op. */
+	readonly operation: "created" | "edited" | "deleted";
+	/** The document row id, present only when resolved. */
+	readonly docId?: number;
+	/** Cosmetic title, used as the openable-URL label when present. */
+	readonly title?: string;
+	/** Server/repo-relative path; always present. */
+	readonly path: string;
+	/**
+	 * The share URL, populated ONLY for a still-active, docId-bearing article. A
+	 * freshly-created (not-yet-reindexed) or deleted article is `null`. The host
+	 * treats `null` as "not yet openable" and never fabricates one.
+	 */
+	readonly url: string | null;
+	/** Whether the article currently exists. */
+	readonly active: boolean;
+}
+
+/**
+ * A typed pull-request reference. Present ONLY for a git-backed run that opened a
+ * verified PR whose destination is NOT a private Jolli-managed repo — for those,
+ * the field is omitted entirely (an absent PR is normal, never an error).
+ */
+export interface WorkflowRunPullRequest {
+	readonly number: number;
+	readonly url: string;
+	readonly state: "open" | "merged" | "closed";
+}
+
+/**
+ * The enriched per-run read model. `get_run_status` and `list_workflow_runs`
+ * return this identical shape (the list is not a reduced subset). Only the fields
+ * the host consumes are modeled: the wire additionally carries `outputSummary`
+ * (declared but never populated — deliberately NOT modeled) and a `stats` object
+ * (whose PR fields are stripped for private destinations — the host reads
+ * `pullRequest`, not `stats`, so it is not modeled either).
+ */
+export interface WorkflowRunPayload {
+	/** The run id. */
+	readonly id: string;
+	/** The parent workflow's numeric id. */
+	readonly workflowId?: number;
+	/** Run creation time (ISO) — the history timestamp. */
+	readonly createdAt?: string;
+	/** The lifecycle status. */
+	readonly status: JobStatus;
+	/** What initiated the run. */
+	readonly triggeredBy?: RunTrigger;
+	/** Where the run executed. */
+	readonly executionMode?: RunExecutionMode;
+	/** Lifecycle timestamps (ISO). */
+	readonly startedAt?: string;
+	readonly completedAt?: string;
+	/**
+	 * Failure only; format `code=<code>: <detail>` — the troubleshooting narrative
+	 * for a failed run. The shaper reads this (NOT `outputSummary`) for a failed
+	 * run's `troubleshooting`.
+	 */
+	readonly error?: string;
+	/** Success only; `message` is the success narrative. Not populated on failure. */
+	readonly completionInfo?: { readonly message: string };
+	/** The article-write manifest. */
+	readonly writtenArticles?: WorkflowRunWrittenArticle[];
+	/** The typed PR reference (withheld for private Jolli-managed destinations). */
+	readonly pullRequest?: WorkflowRunPullRequest;
+	/** Absolute per-tenant deep-link to the workflow; omitted when the destination space is unresolvable. */
+	readonly workflowUrl?: string;
+	/** Absolute per-tenant deep-link to this run; omitted alongside `workflowUrl`. */
+	readonly runUrl?: string;
+	/** Resolved display name of the canceller; best-effort, absent unless a user cancelled. */
+	readonly canceledBy?: string;
+	/** When the run was cancelled (ISO). */
+	readonly canceledAt?: string;
+}
+
+/** The report status presented to the developer (mapped from the wire {@link JobStatus}). */
+export type ReportStatus = "succeeded" | "failed" | "cancelled" | "running";
+
+/** One openable URL read verbatim off the payload. */
+export interface OpenableUrl {
+	readonly kind: "workflow" | "run" | "article" | "pr";
+	readonly url: string;
+	/** Optional human label (an article's title/path). */
+	readonly label?: string;
+}
+
+/** The report-ready shape a run payload is projected into. */
+export interface RunReport {
+	readonly status: ReportStatus;
+	readonly openableUrls: OpenableUrl[];
+	/** Populated when a cancel attribution (`by` and/or `at`) is present. */
+	readonly cancel?: { readonly by?: string; readonly at?: string };
+	/** The `error` narrative for a failed run. */
+	readonly troubleshooting?: string;
+}
+
+/**
+ * The per-run history row printed by `jolli workflow-runs` — one flat,
+ * agent-friendly projection per run. Derived entirely from {@link shapeRunReport}
+ * (no re-derivation of URL selection): the report `status`, the workflow/run/PR
+ * URLs re-bucketed by kind, and `articleUrls` = the active article URLs.
+ * `prUrl` appears ONLY when the payload carried a `pullRequest` (never fabricated
+ * for a withheld private Jolli-managed destination).
+ */
+export interface RunHistoryEntry {
+	readonly runId: string;
+	readonly status: ReportStatus;
+	/** The run's `createdAt` (ISO) — the history timestamp; omitted when the payload lacked it. */
+	readonly timestamp?: string;
+	readonly workflowUrl?: string;
+	readonly runUrl?: string;
+	readonly prUrl?: string;
+	readonly articleUrls: string[];
+}
+
+/**
+ * Projects one enriched run payload into a flat {@link RunHistoryEntry} for the
+ * history list. Reuses {@link shapeRunReport} for openable-URL selection (active-
+ * only articles, withheld-PR handling) and merely re-buckets the result by `kind`
+ * — it never re-implements which URLs are openable. Pure and total.
+ */
+export function shapeRunHistoryEntry(run: WorkflowRunPayload): RunHistoryEntry {
+	const { status, openableUrls } = shapeRunReport(run);
+	const urlOfKind = (kind: OpenableUrl["kind"]): string | undefined =>
+		openableUrls.find((entry) => entry.kind === kind)?.url;
+	const workflowUrl = urlOfKind("workflow");
+	const runUrl = urlOfKind("run");
+	const prUrl = urlOfKind("pr");
+	const articleUrls = openableUrls.filter((entry) => entry.kind === "article").map((entry) => entry.url);
+	return {
+		runId: run.id,
+		status,
+		...(run.createdAt !== undefined && { timestamp: run.createdAt }),
+		...(workflowUrl !== undefined && { workflowUrl }),
+		...(runUrl !== undefined && { runUrl }),
+		...(prUrl !== undefined && { prUrl }),
+		articleUrls,
+	};
+}
+
+/** Whether a wire status is terminal (`completed` / `failed` / `cancelled`). */
+export function isTerminalStatus(status: JobStatus): boolean {
+	return status === "completed" || status === "failed" || status === "cancelled";
+}
+
+/**
+ * Maps the wire {@link JobStatus} to the presentation {@link ReportStatus}:
+ * `completed → succeeded`, `failed → failed`, `cancelled → cancelled`, and both
+ * in-progress values (`queued` / `active`) → `running`.
+ */
+export function toReportStatus(status: JobStatus): ReportStatus {
+	switch (status) {
+		case "completed":
+			return "succeeded";
+		case "failed":
+			return "failed";
+		case "cancelled":
+			return "cancelled";
+		default:
+			return "running";
+	}
+}
+
+/**
+ * Projects one enriched run payload into a report-ready shape. Pure: no fetching,
+ * no spawning, and never throws on a well-formed-but-sparse payload.
+ *
+ * openableUrls composition (order: workflow, run, articles, pr):
+ * - `workflowUrl` / `runUrl` — each only when present.
+ * - one `article` URL per manifest entry ONLY when `active === true && url != null`
+ *   (labelled by the entry's `title`, falling back to its `path`).
+ * - `pullRequest.url` ONLY when `pullRequest` is present (never fabricated).
+ *
+ * `cancel` is populated when either `canceledBy` or `canceledAt` is present.
+ * `troubleshooting` is the `error` string for a `failed` run.
+ */
+export function shapeRunReport(run: WorkflowRunPayload): RunReport {
+	const status = toReportStatus(run.status);
+	const openableUrls: OpenableUrl[] = [];
+	if (run.workflowUrl !== undefined) {
+		openableUrls.push({ kind: "workflow", url: run.workflowUrl });
+	}
+	if (run.runUrl !== undefined) {
+		openableUrls.push({ kind: "run", url: run.runUrl });
+	}
+	for (const article of run.writtenArticles ?? []) {
+		if (article.active && article.url != null) {
+			openableUrls.push({ kind: "article", url: article.url, label: article.title ?? article.path });
+		}
+	}
+	if (run.pullRequest !== undefined) {
+		openableUrls.push({ kind: "pr", url: run.pullRequest.url });
+	}
+	const report: RunReport = { status, openableUrls };
+	const cancel = shapeCancel(run);
+	const troubleshooting = status === "failed" ? run.error : undefined;
+	return {
+		...report,
+		...(cancel !== undefined && { cancel }),
+		...(troubleshooting !== undefined && { troubleshooting }),
+	};
+}
+
+/** The cancel attribution when either `canceledBy` or `canceledAt` is present, else undefined. */
+function shapeCancel(run: WorkflowRunPayload): { by?: string; at?: string } | undefined {
+	if (run.canceledBy === undefined && run.canceledAt === undefined) {
+		return undefined;
+	}
+	return {
+		...(run.canceledBy !== undefined && { by: run.canceledBy }),
+		...(run.canceledAt !== undefined && { at: run.canceledAt }),
+	};
+}

--- a/cli/src/install/SkillInstaller.test.ts
+++ b/cli/src/install/SkillInstaller.test.ts
@@ -368,6 +368,18 @@ describe("jolli-local-run template", () => {
 		expect(t).toContain("prUrl");
 	});
 
+	it("cross-checks the published headBranch against writeTarget.workBranch and stops on mismatch", () => {
+		const t = buildLocalRunSkillTemplate();
+		// Deterministic branch check via the CLI, not an LLM string comparison.
+		expect(t).toContain(
+			'"$HOME/.jolli/jollimemory/run-cli" verify-publish-branch <writeTarget.workBranch> <headBranch>',
+		);
+		expect(t).toContain("headBranch");
+		// On mismatch the recipe must fail loudly and NOT complete the run as success.
+		expect(t).toMatch(/run-to-PR link is broken/);
+		expect(t).toMatch(/do NOT call `complete_local_run` as if the run succeeded/);
+	});
+
 	it("completes a private Jolli-managed destination WITHOUT a PR reference", () => {
 		const t = buildLocalRunSkillTemplate();
 		// The publish JSON withholds prNumber/prUrl for private destinations

--- a/cli/src/install/SkillInstaller.test.ts
+++ b/cli/src/install/SkillInstaller.test.ts
@@ -18,6 +18,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+	buildJolliMenuSkillTemplate,
 	buildLocalRunSkillTemplate,
 	buildRecallSkillTemplate,
 	buildRemoteRunSkillTemplate,
@@ -531,6 +532,18 @@ describe("jolli-remote-run template", () => {
 		expect(t).toContain('"$HOME/.jolli/jollimemory/run-cli" open-url <url>');
 		expect(t).toMatch(/headless/);
 		expect(t).toContain("Only `https` URLs are accepted");
+	});
+
+	it("every open-url recipe/menu notes that an off-allowlist URL is refused-and-printed (Step 8)", () => {
+		// The open-url origin-allowlist gate refuses (never launches) an off-allowlist
+		// URL and prints it with `refused: true`; each template that shells open-url must
+		// tell the agent to surface such a URL for manual opening, not treat it as an error.
+		for (const build of [buildLocalRunSkillTemplate, buildRemoteRunSkillTemplate, buildJolliMenuSkillTemplate]) {
+			const t = build();
+			expect(t).toMatch(/off Jolli's allowlist is refused/);
+			expect(t).toContain('"refused": true');
+			expect(t).toMatch(/open manually/);
+		}
 	});
 
 	it("notes that an in-flight remote run can be cancelled via cancel_remote_workflow", () => {

--- a/cli/src/install/SkillInstaller.test.ts
+++ b/cli/src/install/SkillInstaller.test.ts
@@ -20,6 +20,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	buildLocalRunSkillTemplate,
 	buildRecallSkillTemplate,
+	buildRemoteRunSkillTemplate,
 	buildSearchSkillTemplate,
 	SKILL_GIT_EXCLUDE_PATHS,
 	updateSkillIfNeeded,
@@ -68,20 +69,27 @@ function readLocalRun(target: "claude" | "agents" = "claude"): string {
 	return readFileSync(join(tempDir, dir, "SKILL.md"), "utf-8");
 }
 
+function readRemoteRun(target: "claude" | "agents" = "claude"): string {
+	const dir = target === "claude" ? ".claude/skills/jolli-remote-run" : ".agents/skills/jolli-remote-run";
+	return readFileSync(join(tempDir, dir, "SKILL.md"), "utf-8");
+}
+
 // ─── Dual-target write ──────────────────────────────────────────────────────
 
 describe("updateSkillsIfNeeded — target dimension", () => {
-	it("writes all five skills into both .claude/skills/ and .agents/skills/", async () => {
+	it("writes all six skills into both .claude/skills/ and .agents/skills/", async () => {
 		await updateSkillsIfNeeded(tempDir);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli-recall/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli-pr/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli-local-run/SKILL.md"))).toBe(true);
+		expect(existsSync(join(tempDir, ".claude/skills/jolli-remote-run/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-recall/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-search/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-pr/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-local-run/SKILL.md"))).toBe(true);
+		expect(existsSync(join(tempDir, ".agents/skills/jolli-remote-run/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli/SKILL.md"))).toBe(true);
 	});
 
@@ -91,6 +99,7 @@ describe("updateSkillsIfNeeded — target dimension", () => {
 		expect(readSearch("claude")).toBe(readSearch("agents"));
 		expect(readPr("claude")).toBe(readPr("agents"));
 		expect(readLocalRun("claude")).toBe(readLocalRun("agents"));
+		expect(readRemoteRun("claude")).toBe(readRemoteRun("agents"));
 		expect(readJolli("claude")).toBe(readJolli("agents"));
 	});
 
@@ -100,11 +109,13 @@ describe("updateSkillsIfNeeded — target dimension", () => {
 		expect(existsSync(join(tempDir, ".claude/skills/jolli-search/SKILL.md"))).toBe(false);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli-pr/SKILL.md"))).toBe(false);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli-local-run/SKILL.md"))).toBe(false);
+		expect(existsSync(join(tempDir, ".claude/skills/jolli-remote-run/SKILL.md"))).toBe(false);
 		expect(existsSync(join(tempDir, ".claude/skills/jolli/SKILL.md"))).toBe(false);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-recall/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-search/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-pr/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-local-run/SKILL.md"))).toBe(true);
+		expect(existsSync(join(tempDir, ".agents/skills/jolli-remote-run/SKILL.md"))).toBe(true);
 		expect(existsSync(join(tempDir, ".agents/skills/jolli/SKILL.md"))).toBe(true);
 	});
 
@@ -116,19 +127,34 @@ describe("updateSkillsIfNeeded — target dimension", () => {
 		expect(existsSync(join(tempDir, ".agents/skills/jolli-pr/SKILL.md"))).toBe(true);
 	});
 
-	it("exports the 10 git-exclude paths for the five skills × two targets", () => {
+	it("exports the 12 git-exclude paths for the six skills × two targets", () => {
 		expect(SKILL_GIT_EXCLUDE_PATHS).toEqual([
 			"/.claude/skills/jolli-recall/",
 			"/.claude/skills/jolli-search/",
 			"/.claude/skills/jolli-pr/",
 			"/.claude/skills/jolli-local-run/",
+			"/.claude/skills/jolli-remote-run/",
 			"/.claude/skills/jolli/",
 			"/.agents/skills/jolli-recall/",
 			"/.agents/skills/jolli-search/",
 			"/.agents/skills/jolli-pr/",
 			"/.agents/skills/jolli-local-run/",
+			"/.agents/skills/jolli-remote-run/",
 			"/.agents/skills/jolli/",
 		]);
+	});
+
+	it("renders a parseable metadata.revision for every installed skill", async () => {
+		// A skill whose template omits `revision` parses as PREHISTORIC_REVISION (-1),
+		// so the upsert guard (existing >= mine) freezes it after first install and a
+		// later body fix never reaches existing installs. Every SKILLS template must
+		// therefore carry a real, parseable revision.
+		await updateSkillsIfNeeded(tempDir);
+		const revisionLine = /\n {2}revision: \d+\n/;
+		for (const read of [readRecall, readSearch, readPr, readLocalRun, readRemoteRun, readJolli]) {
+			expect(read("claude")).toMatch(revisionLine);
+			expect(read("agents")).toMatch(revisionLine);
+		}
 	});
 });
 
@@ -226,21 +252,39 @@ describe("jolli menu template frontmatter", () => {
 		expect(jolli).toMatch(/jolli-search/);
 		expect(jolli).toMatch(/jolli-pr/);
 		expect(jolli).toMatch(/jolli-local-run/);
+		expect(jolli).toMatch(/jolli-remote-run/);
 		// Surfaces session-registered MCP tools, not a hardcoded manifest fetch.
 		expect(jolli).toMatch(/mcp__jollimemory__/);
 		expect(jolli).toMatch(/AskUserQuestion/);
 	});
 
-	it("run-a-workflow action asks local vs remote, defaulting to local", async () => {
+	it("run-a-workflow action asks local vs remote, defaulting to local, routing both to recipe skills", async () => {
 		await updateSkillsIfNeeded(tempDir);
 		const jolli = readJolli();
 		expect(jolli).toMatch(/Run a workflow/);
 		expect(jolli).toMatch(/local vs remote/i);
 		// Default is local.
 		expect(jolli).toMatch(/default.*local|local.*default/i);
-		// Local routes to the jolli-local-run skill; remote to the renamed MCP tool.
+		// Both paths route to a recipe skill — local to jolli-local-run, remote to
+		// jolli-remote-run (which drives run_remote_workflow), not the raw tool.
 		expect(jolli).toContain("jolli-local-run");
+		expect(jolli).toContain("jolli-remote-run");
 		expect(jolli).toContain("run_remote_workflow");
+		expect(jolli).toMatch(/not by calling the raw tool/);
+	});
+
+	it("adds a Workflow history action that shells workflow-runs and offers open-url", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		const jolli = readJolli();
+		expect(jolli).toMatch(/Workflow history/);
+		expect(jolli).toContain('"$HOME/.jolli/jollimemory/run-cli" workflow-runs <workflowId>');
+		expect(jolli).toContain('"type": "runs"');
+		// An empty history is a normal outcome, not an error.
+		expect(jolli).toMatch(/no history yet/);
+		// Offers to open any listed URL via the open-url helper.
+		expect(jolli).toContain('"$HOME/.jolli/jollimemory/run-cli" open-url <url>');
+		// The history action shells run-cli, so the menu carries the shell prerequisite.
+		expect(jolli).toContain("### Shell prerequisite");
 	});
 
 	it("mentions canceling an in-flight remote run via cancel_remote_workflow", async () => {
@@ -274,7 +318,9 @@ describe("jolli-local-run template", () => {
 		const t = buildLocalRunSkillTemplate();
 		expect(t).toMatch(/^---\nname: jolli-local-run\n/);
 		expect(t).toMatch(/description: Run a Jolli workflow locally/);
-		expect(t).toMatch(/metadata:\n {2}version: "[^"]+"\n {2}vendor: "jolli\.ai"/);
+		// Carries a parseable metadata.revision so a corrected body reaches existing
+		// installs (a revision-less template is frozen at PREHISTORIC forever).
+		expect(t).toMatch(/metadata:\n {2}version: "[^"]+"\n {2}revision: \d+\n {2}vendor: "jolli\.ai"/);
 		expect(t).not.toMatch(/^argument-hint:/m);
 		expect(t).not.toMatch(/^user-invocable:/m);
 	});
@@ -332,6 +378,48 @@ describe("jolli-local-run template", () => {
 		expect(t).toContain("willAutoMerge");
 	});
 
+	it("Step 6 surfaces the completion result URLs and offers to open each via open-url", () => {
+		const t = buildLocalRunSkillTemplate();
+		// Auto-apply ON reports the article URLs (writtenArticles); OFF reports the PR URL.
+		expect(t).toContain("writtenArticles");
+		expect(t).toMatch(/article URLs/);
+		// `willAutoMerge: true` is framed as the destination's INTENT, not a confirmation the
+		// merge completed — the recipe must not flatly claim the PR auto-merged (it can't
+		// verify it, and for a private jolli-git dest the merge can silently not happen).
+		expect(t).toMatch(/set to auto-merge/);
+		expect(t).toMatch(/not a\s+confirmation/i);
+		expect(t).toMatch(/PR left open for team review/);
+		// Both the workflow and run deep-links are surfaced, read verbatim off the result.
+		expect(t).toContain("workflowUrl");
+		expect(t).toContain("runUrl");
+		// Offers to open each reported URL via the open-url helper (Step 3 of JOLLI-1947).
+		expect(t).toMatch(/open any reported URL/);
+		expect(t).toContain('"$HOME/.jolli/jollimemory/run-cli" open-url <url>');
+	});
+
+	it("only offers an article URL when still openable (active + non-null url) and never fabricates one", () => {
+		const t = buildLocalRunSkillTemplate();
+		expect(t).toMatch(/active: true/);
+		expect(t).toMatch(/non-null/);
+		expect(t).toMatch(/not yet available/);
+		expect(t).toMatch(/never invent a URL/);
+	});
+
+	it("for a private Jolli-managed destination surfaces article URLs only, never a repo/PR link", () => {
+		const t = buildLocalRunSkillTemplate();
+		expect(t).toMatch(/article URLs only/);
+		expect(t).toContain("never surface a repo or PR link the result did not carry");
+	});
+
+	it("describes the destination by Space name/folder and never narrates the backing repo owner/name or work branch as the write target", () => {
+		const t = buildLocalRunSkillTemplate();
+		expect(t).toContain("Space name / folder");
+		expect(t).toContain("Do **not** announce a backing repo");
+		expect(t).toContain('do **not** present the `workBranch` as "the write target"');
+		// An empty writeTarget.repo (private destinations) is normal, never an error.
+		expect(t).toMatch(/may be\s+\*\*empty\*\* for a private Jolli-managed destination/);
+	});
+
 	it("surfaces the combined space-cli install hint when the plugin is missing", () => {
 		const t = buildLocalRunSkillTemplate();
 		expect(t).toContain("npm i -g @jolli.ai/cli @jolli.ai/space-cli");
@@ -360,6 +448,93 @@ describe("jolli-local-run template", () => {
 
 	it("carries the Windows Git Bash shell prerequisite (its run-cli bash steps hit %USERPROFILE%)", () => {
 		const t = buildLocalRunSkillTemplate();
+		expect(t).toContain("### Shell prerequisite");
+		expect(t).toMatch(/Git Bash/);
+		expect(t).toContain("%USERPROFILE%");
+	});
+});
+
+describe("jolli-remote-run template", () => {
+	it("uses spec-compliant frontmatter (name/description/metadata, with a parseable revision)", () => {
+		const t = buildRemoteRunSkillTemplate();
+		expect(t).toMatch(/^---\nname: jolli-remote-run\n/);
+		expect(t).toMatch(/description: Run a Jolli workflow remotely/);
+		// Carries a parseable metadata.revision so a corrected body reaches existing
+		// installs (a revision-less template is frozen at PREHISTORIC forever).
+		expect(t).toMatch(/metadata:\n {2}version: "[^"]+"\n {2}revision: \d+\n {2}vendor: "jolli\.ai"/);
+		expect(t).not.toMatch(/^argument-hint:/m);
+		expect(t).not.toMatch(/^user-invocable:/m);
+	});
+
+	it("triggers the remote run via run_remote_workflow and captures the runId", () => {
+		const t = buildRemoteRunSkillTemplate();
+		expect(t).toContain("run_remote_workflow");
+		expect(t).toContain("mcp__jollimemory__run_remote_workflow");
+		expect(t).toContain("runId");
+		// The workflow id is an unquoted number, matching the frozen tool contract.
+		expect(t).toContain('{ "id": <workflow id> }');
+	});
+
+	it("offers workflow discovery via list_workflows when it is registered", () => {
+		const t = buildRemoteRunSkillTemplate();
+		expect(t).toContain("list_workflows");
+		expect(t).toContain("mcp__jollimemory__list_workflows");
+	});
+
+	it("shells the deterministic workflow-run-status monitor with the runId", () => {
+		const t = buildRemoteRunSkillTemplate();
+		expect(t).toContain('"$HOME/.jolli/jollimemory/run-cli" workflow-run-status <runId>');
+		// Documents the report shape the recipe parses.
+		expect(t).toContain("openableUrls");
+		expect(t).toMatch(/"succeeded"/);
+		expect(t).toMatch(/"failed"/);
+		expect(t).toMatch(/"cancelled"/);
+	});
+
+	it("reports failed, cancelled, succeeded, and still-running outcomes", () => {
+		const t = buildRemoteRunSkillTemplate();
+		expect(t).toMatch(/troubleshooting/);
+		expect(t).toMatch(/cancel\.by/);
+		expect(t).toMatch(/article/);
+		// A timed-out poll means the run is still progressing server-side, not failed.
+		expect(t).toContain("timedOut");
+		expect(t).toMatch(/still\s+running server-side/);
+	});
+
+	it("degrades cleanly when the monitor cannot reach the run", () => {
+		const t = buildRemoteRunSkillTemplate();
+		expect(t).toContain('{ "type": "error", "message": "..." }');
+		expect(t).toMatch(/degraded outcome, not a\s+crash/);
+	});
+
+	it("never fabricates a withheld link and reads every URL verbatim off the report", () => {
+		const t = buildRemoteRunSkillTemplate();
+		expect(t).toMatch(/verbatim/);
+		expect(t).toMatch(/never construct, guess, or\s+look/);
+		expect(t).toMatch(/withheld/);
+	});
+
+	it("offers to open any reported URL via open-url with a headless-safe fallback", () => {
+		const t = buildRemoteRunSkillTemplate();
+		expect(t).toContain('"$HOME/.jolli/jollimemory/run-cli" open-url <url>');
+		expect(t).toMatch(/headless/);
+		expect(t).toContain("Only `https` URLs are accepted");
+	});
+
+	it("notes that an in-flight remote run can be cancelled via cancel_remote_workflow", () => {
+		const t = buildRemoteRunSkillTemplate();
+		expect(t).toContain("cancel_remote_workflow");
+		expect(t).toContain("mcp__jollimemory__cancel_remote_workflow");
+	});
+
+	it("prefers the MCP run tools but shells the jolli CLI (run-cli) for the monitor and open", () => {
+		const t = buildRemoteRunSkillTemplate();
+		expect(t).toMatch(/no CLI\s+mirror/);
+		expect(t).toContain("$HOME/.jolli/jollimemory/run-cli");
+	});
+
+	it("carries the Windows Git Bash shell prerequisite (its run-cli bash steps hit %USERPROFILE%)", () => {
+		const t = buildRemoteRunSkillTemplate();
 		expect(t).toContain("### Shell prerequisite");
 		expect(t).toMatch(/Git Bash/);
 		expect(t).toContain("%USERPROFILE%");
@@ -887,6 +1062,11 @@ describe("English-only", () => {
 	it("local-run template contains no CJK characters", async () => {
 		await updateSkillsIfNeeded(tempDir);
 		expect(readLocalRun()).not.toMatch(CJK_AND_OTHER_NON_LATIN);
+	});
+
+	it("remote-run template contains no CJK characters", async () => {
+		await updateSkillsIfNeeded(tempDir);
+		expect(readRemoteRun()).not.toMatch(CJK_AND_OTHER_NON_LATIN);
 	});
 });
 

--- a/cli/src/install/SkillInstaller.ts
+++ b/cli/src/install/SkillInstaller.ts
@@ -120,12 +120,13 @@ const SKILLS: ReadonlyArray<SkillRegistration> = [
 	{ name: "jolli-search", build: buildSearchSkillTemplate },
 	{ name: "jolli-pr", build: buildPrSkillTemplate },
 	{ name: "jolli-local-run", build: buildLocalRunSkillTemplate },
+	{ name: "jolli-remote-run", build: buildRemoteRunSkillTemplate },
 	{ name: "jolli", build: buildJolliMenuSkillTemplate },
 ];
 
 /**
  * Skill paths recorded in `.git/info/exclude` so they don't pollute
- * `git status` in user repositories. Always 8 entries: 4 skills × 2 targets.
+ * `git status` in user repositories. Always 12 entries: 6 skills × 2 targets.
  * Path format follows git's gitignore syntax — leading `/` anchors to the
  * repo root, trailing `/` matches the directory and its contents.
  */
@@ -997,6 +998,7 @@ name: jolli-local-run
 description: Run a Jolli workflow locally — your own agent executes the workflow's recipe (no Jolli LLM budget) and its file writes land in a git-backed Jolli Space via a branch and pull request that space-cli opens on this machine. Use when the user wants to run a Jolli workflow locally.
 metadata:
   version: "${SKILL_VERSION}"
+  revision: 2
   vendor: "jolli.ai"
 ---
 
@@ -1057,7 +1059,14 @@ Capture from its result:
 - \`runId\` — the run handle for every later call.
 - \`plan\` — the recipe steps your agent will execute.
 - \`writeTarget\` — carries the server-derived \`workBranch\`, the destination Space,
-  and the destination folder.
+  and the destination folder. Refer to the destination in user-facing prose by its
+  **Space name / folder** only. Do **not** announce a backing repo \`owner/name\`, and
+  do **not** present the \`workBranch\` as "the write target" — those are internal
+  plumbing, not the destination's identity. The \`workBranch\` is passed verbatim to
+  \`docs pull --branch\` in Step 3, but keep it framed as an internal detail. Do not
+  inspect the clone's git remotes to name the destination. \`writeTarget.repo\` may be
+  **empty** for a private Jolli-managed destination — that is normal, never an error,
+  and never something to look up or narrate.
 
 ## Step 3 — check out the agent branch
 
@@ -1117,9 +1126,42 @@ fresh across the wait.
    - **Nothing published** (\`"pushed": false\`, e.g. \`"reason": "no-changes"\`): no PR
      was opened, so there is nothing to complete — tell the user the workflow produced
      no changes and release the run with \`abandon_local_run\` (Step 7).
-3. Read \`willAutoMerge\` from \`complete_local_run\`'s result and tell the user which
-   happened: **"PR auto-merged"** (\`willAutoMerge: true\`) or **"PR left open for team
-   review"** (\`willAutoMerge: false\`).
+3. Read the outcome and its links off \`complete_local_run\`'s result and report them.
+   Every URL is read **verbatim** off the result — never construct, guess, or look up
+   one. The result carries \`willAutoMerge\`, \`workflowUrl\`, \`runUrl\`, and (auto-apply
+   ON only) a \`writtenArticles\` list of \`{ operation, path, url, active, ... }\`.
+   - **Auto-apply on** (\`willAutoMerge: true\`): the destination auto-applies, so the PR
+     is **set to auto-merge** and — once it does — the created/edited **articles are the
+     artifact**. Treat \`willAutoMerge: true\` as the destination's *intent*, NOT a
+     confirmation that the merge already completed — so do **not** flatly tell the user
+     "PR auto-merged". Report what actually published, judged by each article's own state:
+     for every \`writtenArticles\` entry that is still openable (\`active: true\` **and** a
+     non-null \`url\`), present its URL as a published article. If an article is
+     \`active: false\` or has \`url: null\`, publishing has **not** completed yet (the
+     auto-merge and reindex may still be in progress) — tell the user that article is
+     **not yet available**, never invent a URL, and note they can re-check shortly via the
+     run URL or by re-running \`workflow-run-status <runId>\`. Then present the workflow URL
+     (\`workflowUrl\`) and the run URL (\`runUrl\`).
+   - **PR left open for team review** (\`willAutoMerge: false\` — auto-apply off): the
+     open **PR is the artifact**. Tell the user "PR left open for team review" and
+     present the PR URL (\`prUrl\`), the workflow URL (\`workflowUrl\`), and the run URL
+     (\`runUrl\`).
+   - **Private Jolli-managed destination** (the result carries no \`prUrl\`): present the
+     **article URLs only** (same \`active: true\` + non-null \`url\` rule) plus the workflow
+     URL and run URL — never surface a repo or PR link the result did not carry. As with
+     any auto-apply run, an article that is not yet \`active\` / lacks a \`url\` is **not yet
+     available** (publishing still completing), not an error — say it will appear once
+     published and offer the run URL to re-check.
+4. Offer to open any reported URL in the user's default browser. For each URL the user
+   chooses, shell:
+
+   \`\`\`bash
+   "$HOME/.jolli/jollimemory/run-cli" open-url <url>
+   \`\`\`
+
+   It prints one JSON line \`{ "opened": true|false, "url": "..." }\`. When \`opened\` is
+   \`false\` (headless / no browser available) the URL is printed for the user to copy
+   instead — that is normal, not a failure. Only \`https\` URLs are accepted.
 
 ## Step 7 — on cancel: abandon
 
@@ -1136,6 +1178,134 @@ user to install it and stop:
 \`\`\`bash
 npm i -g @jolli.ai/cli @jolli.ai/space-cli
 \`\`\`
+`;
+}
+
+/**
+ * Remote-workflow-run recipe skill — walks the calling agent through running a
+ * Jolli workflow on the Jolli backend: identify the workflow, trigger the run via
+ * the `run_remote_workflow` platform tool, then shell the deterministic
+ * `workflow-run-status` monitor (host code polls to a terminal state) and report
+ * the outcome — failed (troubleshooting + workflow URL), cancelled (who/when +
+ * workflow URL), or succeeded (still-active article URLs + workflow URL) — and
+ * offer to open any reported URL. Prefers the Jolli MCP platform tools for the run
+ * lifecycle (there is no CLI mirror for them); the monitor and the browser-open
+ * primitive go through the `jolli` CLI (run-cli entry script). Byte-identical
+ * across every {@link SKILL_TARGETS} entry, spec-compliant frontmatter only.
+ */
+export function buildRemoteRunSkillTemplate(): string {
+	return `---
+name: jolli-remote-run
+description: Run a Jolli workflow remotely — the Jolli backend executes the workflow server-side; this recipe triggers the run, monitors it to completion, reports the outcome (failed / cancelled / succeeded) with its article, PR, and workflow links, and offers to open any in your browser. Use when the user wants to run a Jolli workflow remotely (on the Jolli backend).
+metadata:
+  version: "${SKILL_VERSION}"
+  revision: 1
+  vendor: "jolli.ai"
+---
+
+# Jolli Remote Run
+
+Run a Jolli **workflow** remotely: the Jolli backend executes the workflow
+server-side (it spends Jolli LLM budget, unlike a local run), and this recipe
+triggers the run, monitors it to a terminal state, and reports what it produced —
+the still-active article URLs, the pull-request URL when the destination is
+git-backed, and the workflow/run deep-links — then offers to open any of them.
+
+Drive the steps below in order. Prefer the Jolli MCP tools for the run lifecycle —
+the run tools (\`run_remote_workflow\`, \`cancel_remote_workflow\`) have **no CLI
+mirror** — and shell the \`jolli\` CLI (via the run-cli entry script the sibling
+skills also use) only for the deterministic monitor and the browser-open helper.
+
+Every URL is read **verbatim** off the run report — never construct, guess, or
+look one up. A link that is not in the report was withheld on purpose (for
+example, a private Jolli-managed destination omits the PR link but keeps the
+article URLs); treat its absence as normal, never an error.
+
+${SHELL_PREREQUISITE_BLOCK}
+
+## Step 1 — identify the workflow to run
+
+Determine which workflow the user wants to run and keep its numeric \`id\`.
+
+- If the \`list_workflows\` tool is registered this session (on Claude Code
+  \`mcp__jollimemory__list_workflows\`), call it to list the available workflows and
+  present them to the user by \`name\` (use your host's interactive single-select
+  tool if it has one — e.g. AskUserQuestion on Claude Code — otherwise list them as
+  text). Keep the chosen workflow's \`id\`.
+- Otherwise, ask the user which workflow to run and get its numeric \`id\`.
+
+## Step 2 — trigger the remote run
+
+Call the \`run_remote_workflow\` tool (on Claude Code
+\`mcp__jollimemory__run_remote_workflow\`) with the chosen workflow's id, passed as
+an **unquoted number**: \`{ "id": <workflow id> }\` (add \`templateVariables\` only if
+the workflow needs them). Capture \`runId\` from its result (\`{ "runId": "..." }\`) —
+that handle drives the monitor in Step 3.
+
+## Step 3 — monitor the run to completion
+
+Shell the deterministic monitor with the captured \`runId\`:
+
+\`\`\`bash
+"$HOME/.jolli/jollimemory/run-cli" workflow-run-status <runId>
+\`\`\`
+
+It polls the run to a terminal state (with backoff, so you do not drive the poll
+loop yourself) and prints exactly one JSON line — the run report. Parse it:
+
+- \`status\` — one of \`"succeeded"\`, \`"failed"\`, \`"cancelled"\`, \`"running"\`.
+- \`openableUrls\` — an array of \`{ "kind": "workflow" | "run" | "article" | "pr", "url": "...", "label": "..." }\`.
+  Only openable URLs appear here (active articles with a non-null url, a PR only
+  when the payload carried one) — present exactly these, nothing more.
+- \`cancel\` (cancelled runs) — \`{ "by": "...", "at": "..." }\` when known.
+- \`troubleshooting\` (failed runs) — the actionable error detail.
+- \`timedOut\` — \`true\` when the monitor stopped polling before the run reached a
+  terminal state (see the "still running" case below).
+
+If the command instead prints \`{ "type": "error", "message": "..." }\` (the run
+could not be reached — platform tools off, or a transport failure), tell the user
+the run status could not be retrieved and stop. That is a degraded outcome, not a
+crash — the run may still be progressing server-side.
+
+## Step 4 — report the outcome
+
+Report based on \`status\`:
+
+- **succeeded** (\`status: "succeeded"\`): the run finished. Present the \`article\`
+  URLs from \`openableUrls\` (each by its \`label\`), the \`pr\` URL if one is present,
+  and the \`workflow\` and \`run\` deep-links. Never surface a link that is not in
+  \`openableUrls\` — a missing PR link means the destination withheld it (a private
+  Jolli-managed destination), which is normal.
+- **failed** (\`status: "failed"\`): the run failed. Present the \`troubleshooting\`
+  detail (the actionable error) and the \`workflow\` URL.
+- **cancelled** (\`status: "cancelled"\`): the run was cancelled. Report who
+  (\`cancel.by\`) and when (\`cancel.at\`) when present, plus the \`workflow\` URL.
+- **still running** (\`status: "running"\` with \`timedOut: true\`): the monitor
+  stopped polling before the run reached a terminal state — the run is **still
+  running server-side**, not failed. Tell the user it is still in progress, present
+  the \`workflow\` URL so they can watch it, and note they can re-check later by
+  re-running \`workflow-run-status <runId>\`.
+
+## Step 5 — offer to open any reported URL
+
+Offer to open any URL from the report in the user's default browser. For each URL
+the user chooses, shell:
+
+\`\`\`bash
+"$HOME/.jolli/jollimemory/run-cli" open-url <url>
+\`\`\`
+
+It prints one JSON line \`{ "opened": true|false, "url": "..." }\`. When \`opened\` is
+\`false\` (headless / no browser available) the URL is printed for the user to copy
+instead — that is normal, not a failure. Only \`https\` URLs are accepted.
+
+## Cancelling an in-flight run
+
+While a remote run is still in progress, the user can stop it: call
+\`cancel_remote_workflow\` (on Claude Code
+\`mcp__jollimemory__cancel_remote_workflow\`) with the workflow's numeric id —
+\`{ "id": <workflow id> }\`. After cancelling, re-run \`workflow-run-status <runId>\`
+to report the cancelled outcome (who/when + workflow URL).
 `;
 }
 
@@ -1161,10 +1331,10 @@ npm i -g @jolli.ai/cli @jolli.ai/space-cli
 export function buildJolliMenuSkillTemplate(): string {
 	return `---
 name: jolli
-description: The Jolli action menu — a single front door that lists the Jolli skills (recall, search, pr, run a workflow local or remote) plus the Jolli MCP tools registered in this session, then routes your choice to the right one. Use when the user types /jolli or asks for the Jolli menu.
+description: The Jolli action menu — a single front door that lists the Jolli skills (recall, search, pr, run a workflow local or remote, workflow history) plus the Jolli MCP tools registered in this session, then routes your choice to the right one. Use when the user types /jolli or asks for the Jolli menu.
 metadata:
   version: "${SKILL_VERSION}"
-  revision: 1
+  revision: 2
   vendor: "jolli.ai"
 ---
 
@@ -1177,6 +1347,11 @@ re-implements any action, it only invokes an existing skill or an existing MCP
 tool. The standalone \`/jolli-recall\`, \`/jolli-search\`, \`/jolli-pr\` commands and
 the \`/mcp__jollimemory__jolli\` prompt all keep working unchanged; this is layered
 on top of them, not a replacement.
+
+The **Workflow history** action below shells the \`jolli\` CLI (via the run-cli
+entry script), so the shell prerequisite applies when that action is used.
+
+${SHELL_PREREQUISITE_BLOCK}
 
 ## Step 1 — build the unified menu
 
@@ -1195,16 +1370,38 @@ Assemble ONE combined list of actions from two sources.
   - **local (default)** — your agent executes the workflow's recipe on this
     machine (no Jolli LLM budget); the writes land in a git-backed Space via a
     branch + PR. Route by invoking the \`jolli-local-run\` skill.
-  - **remote** — the Jolli backend executes the workflow server-side. Route by
-    calling the \`run_remote_workflow\` MCP tool
-    (\`mcp__jollimemory__run_remote_workflow\`).
+  - **remote** — the Jolli backend executes the workflow server-side, and the run
+    is monitored to completion and its result reported. Route by invoking the
+    \`jolli-remote-run\` skill (which drives the \`run_remote_workflow\` tool for
+    you) — not by calling the raw tool.
 
   A running **remote** run can be canceled with the \`cancel_remote_workflow\` MCP
   tool (\`mcp__jollimemory__cancel_remote_workflow\`) — offer this if the user
   wants to stop an in-flight remote run.
+- **Workflow history** — Show a workflow's past runs. When the user picks this,
+  identify the workflow's numeric id (if the \`list_workflows\` tool is registered
+  this session, use it to let the user pick one by name; otherwise ask for the
+  id), then shell:
 
-Route a local choice by invoking that skill through your host's skill-invocation
-mechanism (for example, the Skill tool in Claude Code).
+  \`\`\`bash
+  "$HOME/.jolli/jollimemory/run-cli" workflow-runs <workflowId>
+  \`\`\`
+
+  It prints \`{ "type": "runs", "runs": [ ... ] }\` — one entry per run with its
+  \`status\`, \`timestamp\`, and any \`workflowUrl\` / \`runUrl\` / \`prUrl\` /
+  \`articleUrls\`. An empty \`runs\` list is the normal "no history yet" outcome, not
+  an error. Offer to open any listed URL via the \`open-url\` helper:
+
+  \`\`\`bash
+  "$HOME/.jolli/jollimemory/run-cli" open-url <url>
+  \`\`\`
+
+  (\`{ "opened": true|false, "url": "..." }\`; \`opened: false\` on a headless host
+  just prints the URL — normal, not a failure. Only \`https\` URLs are accepted.)
+
+Route a local, remote, or history choice by invoking that skill through your
+host's skill-invocation mechanism (for example, the Skill tool in Claude Code);
+the Workflow history action runs its \`run-cli\` commands directly as shown above.
 
 ### Jolli MCP tools (whatever is registered this session)
 

--- a/cli/src/install/SkillInstaller.ts
+++ b/cli/src/install/SkillInstaller.ts
@@ -998,7 +998,7 @@ name: jolli-local-run
 description: Run a Jolli workflow locally — your own agent executes the workflow's recipe (no Jolli LLM budget) and its file writes land in a git-backed Jolli Space via a branch and pull request that space-cli opens on this machine. Use when the user wants to run a Jolli workflow locally.
 metadata:
   version: "${SKILL_VERSION}"
-  revision: 2
+  revision: 3
   vendor: "jolli.ai"
 ---
 
@@ -1113,7 +1113,27 @@ fresh across the wait.
 
    \`--json\` prints exactly one JSON object on stdout (all human-readable progress
    goes to stderr) — parse that object; never scrape the human log for a PR number.
-2. Call \`complete_local_run\` (on Claude Code
+2. Verify the pull request landed on the server-derived work branch. \`docs publish\`
+   reports the branch the PR was actually opened on as \`headBranch\` (present on both
+   the public and the private/withheld paths); the run's server work branch is
+   \`writeTarget.workBranch\` from Step 2. **When \`pushed\` is true, cross-check them
+   deterministically** — do not eyeball it yourself:
+
+   \`\`\`bash
+   "$HOME/.jolli/jollimemory/run-cli" verify-publish-branch <writeTarget.workBranch> <headBranch>
+   \`\`\`
+
+   It prints \`{ "match": true|false, "expected": "...", "actual": "..." }\` and exits
+   non-zero when the branches differ or \`headBranch\` is missing. **If \`match\` is
+   false, STOP** — the PR was opened on the wrong branch (usually because \`docs pull
+   --branch <workBranch>\` in Step 3 was skipped, so space-cli generated its own
+   \`jolli-<hex>\` branch). The backend cannot link the run to that PR, so it will
+   **not** auto-merge and the articles will **never** publish. Tell the user the
+   run-to-PR link is broken (published on \`<actual>\` instead of the expected
+   \`<expected>\`) and **do NOT call \`complete_local_run\` as if the run succeeded** —
+   release the run with \`abandon_local_run\` (Step 7) or ask the user how to proceed.
+   Skip this check only when \`pushed\` is false (nothing was published).
+3. Call \`complete_local_run\` (on Claude Code
    \`mcp__jollimemory__complete_local_run\`), branching on what the publish JSON
    contained:
    - **PR refs present** (the JSON has a \`prNumber\` — a user-accessible
@@ -1126,7 +1146,7 @@ fresh across the wait.
    - **Nothing published** (\`"pushed": false\`, e.g. \`"reason": "no-changes"\`): no PR
      was opened, so there is nothing to complete — tell the user the workflow produced
      no changes and release the run with \`abandon_local_run\` (Step 7).
-3. Read the outcome and its links off \`complete_local_run\`'s result and report them.
+4. Read the outcome and its links off \`complete_local_run\`'s result and report them.
    Every URL is read **verbatim** off the result — never construct, guess, or look up
    one. The result carries \`willAutoMerge\`, \`workflowUrl\`, \`runUrl\`, and (auto-apply
    ON only) a \`writtenArticles\` list of \`{ operation, path, url, active, ... }\`.
@@ -1152,7 +1172,7 @@ fresh across the wait.
      any auto-apply run, an article that is not yet \`active\` / lacks a \`url\` is **not yet
      available** (publishing still completing), not an error — say it will appear once
      published and offer the run URL to re-check.
-4. Offer to open any reported URL in the user's default browser. For each URL the user
+5. Offer to open any reported URL in the user's default browser. For each URL the user
    chooses, shell:
 
    \`\`\`bash

--- a/cli/src/install/SkillInstaller.ts
+++ b/cli/src/install/SkillInstaller.ts
@@ -998,7 +998,7 @@ name: jolli-local-run
 description: Run a Jolli workflow locally — your own agent executes the workflow's recipe (no Jolli LLM budget) and its file writes land in a git-backed Jolli Space via a branch and pull request that space-cli opens on this machine. Use when the user wants to run a Jolli workflow locally.
 metadata:
   version: "${SKILL_VERSION}"
-  revision: 3
+  revision: 4
   vendor: "jolli.ai"
 ---
 
@@ -1181,7 +1181,10 @@ fresh across the wait.
 
    It prints one JSON line \`{ "opened": true|false, "url": "..." }\`. When \`opened\` is
    \`false\` (headless / no browser available) the URL is printed for the user to copy
-   instead — that is normal, not a failure. Only \`https\` URLs are accepted.
+   instead — that is normal, not a failure. Only \`https\` URLs are accepted. A URL
+   whose origin is off Jolli's allowlist is refused (never launched) and printed
+   instead — the result carries \`"refused": true\`; surface that URL for the user to
+   open manually, not as an error.
 
 ## Step 7 — on cancel: abandon
 
@@ -1219,7 +1222,7 @@ name: jolli-remote-run
 description: Run a Jolli workflow remotely — the Jolli backend executes the workflow server-side; this recipe triggers the run, monitors it to completion, reports the outcome (failed / cancelled / succeeded) with its article, PR, and workflow links, and offers to open any in your browser. Use when the user wants to run a Jolli workflow remotely (on the Jolli backend).
 metadata:
   version: "${SKILL_VERSION}"
-  revision: 1
+  revision: 2
   vendor: "jolli.ai"
 ---
 
@@ -1317,7 +1320,10 @@ the user chooses, shell:
 
 It prints one JSON line \`{ "opened": true|false, "url": "..." }\`. When \`opened\` is
 \`false\` (headless / no browser available) the URL is printed for the user to copy
-instead — that is normal, not a failure. Only \`https\` URLs are accepted.
+instead — that is normal, not a failure. Only \`https\` URLs are accepted. A URL whose
+origin is off Jolli's allowlist is refused (never launched) and printed instead — the
+result carries \`"refused": true\`; surface that URL for the user to open manually, not
+as an error.
 
 ## Cancelling an in-flight run
 
@@ -1354,7 +1360,7 @@ name: jolli
 description: The Jolli action menu — a single front door that lists the Jolli skills (recall, search, pr, run a workflow local or remote, workflow history) plus the Jolli MCP tools registered in this session, then routes your choice to the right one. Use when the user types /jolli or asks for the Jolli menu.
 metadata:
   version: "${SKILL_VERSION}"
-  revision: 2
+  revision: 3
   vendor: "jolli.ai"
 ---
 
@@ -1417,7 +1423,9 @@ Assemble ONE combined list of actions from two sources.
   \`\`\`
 
   (\`{ "opened": true|false, "url": "..." }\`; \`opened: false\` on a headless host
-  just prints the URL — normal, not a failure. Only \`https\` URLs are accepted.)
+  just prints the URL — normal, not a failure. Only \`https\` URLs are accepted. A URL
+  whose origin is off Jolli's allowlist is refused (never launched) and printed — the
+  result carries \`"refused": true\`; surface it for the user to open manually.)
 
 Route a local, remote, or history choice by invoking that skill through your
 host's skill-invocation mechanism (for example, the Skill tool in Claude Code);

--- a/cli/src/install/SkillInstaller.ts
+++ b/cli/src/install/SkillInstaller.ts
@@ -126,7 +126,8 @@ const SKILLS: ReadonlyArray<SkillRegistration> = [
 
 /**
  * Skill paths recorded in `.git/info/exclude` so they don't pollute
- * `git status` in user repositories. Always 12 entries: 6 skills × 2 targets.
+ * `git status` in user repositories. Derived as {@link SKILLS} × {@link SKILL_TARGETS},
+ * so the count tracks those two lists automatically (one entry per skill per target).
  * Path format follows git's gitignore syntax — leading `/` anchors to the
  * repo root, trailing `/` matches the directory and its contents.
  */


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (5)

1. Report workflow-run results with links, open-in-browser, and run history (`47c0f78`) — [Memory](https://jolli-local.me/jollidougs/o/default/articles/report-workflow-run-results-with-links-open-in-browser-and-run-history-568)
2. Guard local-run publish against a work-branch mismatch (`16bfd8e`) — [Memory](https://jolli-local.me/jollidougs/o/default/articles/guard-local-run-publish-against-a-work-branch-mismatch-575)
3. Gate open-url browser launches behind an origin allowlist (`6776037`) — [Memory](https://jolli-local.me/jollidougs/o/default/articles/gate-open-url-browser-launches-behind-an-origin-allowlist-572)
4. Harden the remote workflow-run monitor against timeouts and permanent errors (`100ede4`) — [Memory](https://jolli.ai/very/o/default/articles/harden-the-remote-workflow-run-monitor-against-timeouts-and-permanent-errors-8630)
5. Keep the workflow-runs degrade diagnosable and de-hardcode the skill-exclude count (`95b4f1e`) — [Memory](https://jolli.ai/very/o/default/articles/keep-the-workflow-runs-degrade-diagnosable-and-de-hardcode-the-skill-exclude-count-8629)

## Context (4)

- [273. Local Workflow-Run Orchestration (host side)](https://jolli-local.me/jollidougs/o/default/articles/273-local-workflow-run-orchestration-host-side-563)
- [JOLLI-1947: Host CLI — report workflow-run results (remote + local) with article/PR/workflow URLs, open-in-browser, and a workflow-history view](https://jolli-local.me/jollidougs/o/default/articles/jolli-1947-host-cli-report-workflow-run-results-remote-local-with-article-pr-workflow-urls-open-in-browser-and-a-workflow-history-view-564)
- [274. Workflow-Run Result Reporting (remote + local), Open-in-Browser, and Run History](https://jolli-local.me/jollidougs/o/default/articles/274-workflow-run-result-reporting-remote-local-open-in-browser-and-run-history-565)
- [272 — `jolli` Menu Skill Content](https://jolli-local.me/jollidougs/o/default/articles/272-jolli-menu-skill-content-566)

## Quick recap (4)

### Commit 1 of 5: Report workflow-run results with links, open-in-browser, and run history (`47c0f78`)

This work delivered end-to-end reporting for Jolli workflow runs, whether they execute on the Jolli backend or on the developer's own machine. After triggering a workflow remotely, the command line can now watch the run until it finishes and report whether it succeeded, failed, or was cancelled, along with links to the resulting articles, any pull request, and the workflow and run pages themselves — with a safe option to open any of those links directly in the browser, or print them when no browser is available. A new guided recipe walks an assisting agent through choosing a workflow, starting the run, and reporting these results, and the main workflow menu now routes remote runs through this recipe and adds a new option for browsing a workflow's run history.

Locally-run workflows gained matching treatment: once a run completes, the developer is now shown either the created and edited article links or the open pull-request link, along with workflow and run pages, with an offer to open them. For destinations that are kept private, only article links are shown and no internal repository or pull-request information is revealed, and the destination is now described by its user-facing name rather than internal repository details.

During testing, a defect was found and fixed where two of the newly added recipes could never receive future corrected updates once installed, due to a missing internal version marker; both recipes were given a proper version number and a new safeguard test was added so this type of gap is caught automatically going forward. Separately, the underlying data shapes used throughout this feature were checked directly against the real backend rather than assumed, catching several mismatches — such as the true wording of a successful run's status — before they could cause silent failures.

### Commit 2 of 5: Guard local-run publish against a work-branch mismatch (`16bfd8e`)

The developer added a safeguard for local Jolli workflow runs so a publish can no longer silently complete on the wrong branch. A new verification step now compares the branch a run was supposed to publish to against the branch the pull request actually landed on, and reports the result as a clear pass or fail. The local-run recipe was updated so that when this check fails, the run is stopped and released instead of being reported as finished, preventing the previous silent-failure scenario where a workflow appeared to succeed but its changes never actually merged or published.

### Commit 3 of 5: Gate open-url browser launches behind an origin allowlist (`6776037`)

The browser-open safeguard used by workflow-related commands gained a way to safely handle local development setups that use temporary public tunnel addresses (such as ngrok) to preview work. Previously, any link on such a tunnel address was refused and only printed for manual copying, even when it was a completely legitimate workflow or article link produced by the developer's own local backend. Developers can now explicitly name trusted tunnel addresses either through an environment variable for a quick one-off session or by saving them in their personal configuration file for a lasting setup; the two lists combine, so both a saved list and an on-the-fly addition work together. With neither of these set, behavior for everyone else remains completely unchanged — links are still checked against the standard allowed set of Jolli and known code-hosting sites, and only secure links are ever opened.

A follow-up conversation clarified that this new trusted-origins setting cannot yet be adjusted through the standard configuration command, since that command only recognizes a fixed set of setting names and this addition was deliberately left out of it as a developer-only convenience. Two manual ways to set it were shared instead: a one-line environment variable export, or directly editing the configuration file. Both changes were verified with an expanded automated test suite and combined into a single change that was reviewed, tested end-to-end, and pushed to the shared project branch.

### Commit 4 of 5: Harden the remote workflow-run monitor against timeouts and permanent errors (`100ede4`)

The workflow-run monitor was hardened against two failure modes: unrecoverable tool-availability errors and long-running polls that risked being cut off before finishing. When platform tools are disabled or a backend is too old, the monitor now recognizes that condition and stops immediately, reporting the problem right away instead of retrying a check that could never succeed.

Polling for an in-progress workflow run is now capped at a shorter window, keeping the total wait comfortably inside the time limits enforced by the tools that call it. A still-running result now reliably reaches the requester within that window. When a run is still in progress at the end of the window, the report includes a direct link to the specific run in addition to the workflow page, making it easier for users to jump straight to what they were watching.

## Topics (13)
<details>
<summary><strong>01 · [47c0f78] Report and open results after running a Jolli workflow remotely or locally</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Running a Jolli workflow from the command line, whether executed on the Jolli backend or locally by the developer's own agent, previously gave no report of what happened or links to the resulting article, pull request, or workflow page. The goal was to have the tool monitor a run to completion, describe the outcome, and let the developer open any produced link in a browser.

**💡 Decisions Behind the Code**

- **Verified real backend behavior instead of trusting written specs**: earlier assumptions about field names and status values (like assuming a successful run reports "succeeded") were checked directly against the backend's actual source code, uncovering that the real wire value is "completed," that status lookups return wrapped results, and that the workflow's numeric identifier — not its name — is what several tools expect. This deliberate verification step avoided shipping code built on wrong assumptions, a mistake that had happened in an earlier related feature.
- **Kept the reporting logic separate from the interactive parts**: the polling, link-safety checks, and browser-opening are handled by fast, testable command-line code, while deciding what to say to the user and which links to offer stays with the assisting agent following written instructions. This kept the reliable "never hang, never crash" behavior in code while leaving natural-language reporting flexible.
- **Chose to always show article links but withhold pull-request links for certain private destinations**: when a workflow writes to a privately-managed destination, the underlying repository details are never revealed, but the resulting articles remain visible and linkable. This preserves the useful case for the developer (seeing what was written) while avoiding leaking details about internal infrastructure.

**✅ What Was Implemented**

- Added a client method that polls a single run's status and unwraps its enriched result, plus a companion method that lists a workflow's past runs, both built to fail loudly on any transport problem so callers can tell "still running" apart from "unreachable."
- Added a pure shaping function that turns a raw run result into a report-ready structure: which links are safe to open (workflow, run, article, or pull-request pages), cancellation details when relevant, and troubleshooting text for failures — never inventing a link that wasn't actually returned.
- Added three new command-line helpers: one that opens a link in the browser (or safely prints it when no browser is available), one that watches a remote run until it finishes and prints the outcome, and one that lists a workflow's run history — all producing simple, predictable output for an assisting agent to read and relay to the user.

**📁 FILES**
- `cli/src/core/WorkflowRunReport.ts`
- `cli/src/core/JolliMemoryPushClient.ts`
- `cli/src/core/WorkflowRunMonitor.ts`
- `cli/src/core/OpenUrl.ts`
- `cli/src/commands/OpenUrlCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [47c0f78] List a workflow's run history from the command line</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Developers wanted a way to see the past runs of a given workflow — their outcomes, timestamps, and any produced links — instead of having to look them up elsewhere.

**💡 Decisions Behind the Code**

The history listing reuses the same link-safety logic used for single-run reporting rather than re-implementing which links are safe to show, keeping that rule in exactly one place so it can't drift out of sync between the two features. An unavailable history was deliberately treated as a normal "no history yet" outcome rather than an error, since the command is expected to be used defensively by assisting agents that shouldn't crash a conversation over a missing feature flag.

**✅ What Was Implemented**

Added a new command-line helper that prints a workflow's run history as a simple list, each entry showing its status, when it ran, links to the workflow and run pages, a pull-request link when one exists, and any still-valid article links. The command safely returns an empty list rather than an error when the history can't be fetched (for example, if the relevant feature is turned off), and it accepts either a numeric workflow identifier or a raw value passed straight through.

**📁 FILES**
- `cli/src/commands/WorkflowRunsCommand.ts`
- `cli/src/core/WorkflowRunReport.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [47c0f78] Add a guided recipe for running workflows remotely and reporting results</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

There was no standard step-by-step guide for an assisting agent to follow when a developer wants to run a workflow on the Jolli backend (rather than locally) — from picking the workflow, to triggering it, to reporting what happened and offering to open the results.

**💡 Decisions Behind the Code**

Routing the remote-run menu choice through the new recipe (rather than calling the trigger tool directly) ensures every remote run gets consistent completion reporting and link-opening, matching how local runs already behave — so developers get the same experience regardless of where the workflow executes.

**✅ What Was Implemented**

Added a new installable recipe ("run a workflow remotely") that walks an assisting agent through choosing a workflow, triggering the run, invoking the new run-monitoring helper, and reporting success, failure, or cancellation with the right links — then offering to open any of them. The main menu skill was updated so the "run a workflow" choice for a remote run now goes through this recipe instead of calling the underlying tool directly, and a new "workflow history" menu option was added that lists past runs and offers to open their links.

**📁 FILES**
- `cli/src/install/SkillInstaller.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [47c0f78] Report completed local run results and hide private destination details</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After a locally-run workflow finished, the recipe guiding the process didn't tell the developer what was produced (article links or a pull request link) or offer to open them, and it risked revealing internal repository details for privately-managed destinations.

**💡 Decisions Behind the Code**

This closes a gap where the recipe would have silently no-showed useful results information after a successful run, aligning local-run reporting with the same reporting standard being built for remote runs so both paths feel consistent to the developer.

**✅ What Was Implemented**

- Extended the local-run recipe so that after completion it reads the result and reports either the created/edited article links (when changes were applied automatically) or the pull-request link (when left open for review), plus workflow and run links — offering to open any of them, and only showing an article link when it's confirmed still valid.
- For privately-managed destinations, the recipe now shows article links only and never mentions a repository or pull-request link, since those aren't part of the response for such destinations.
- Updated the guidance about naming the write destination so it's described by its user-facing space and folder name rather than by internal repository ownership or branch details, and clarified that an empty internal repository value for private destinations is expected, not an error.

**📁 FILES**
- `cli/src/install/SkillInstaller.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [47c0f78] Fix installed recipes that could never receive future corrected updates</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A tester verifying the feature discovered that two of the newly-added recipes would never update on a developer's machine even if a later version fixed a bug in them, because they were missing an internal version marker that the installer relies on to know whether to overwrite an existing file.

**💡 Decisions Behind the Code**

- **Fixed immediately rather than deferring**: because the defect meant any future correction to either recipe would silently fail to reach machines that already had it installed, it was judged worth fixing before this work was finalized rather than shipping now and patching later.
- **Chose a version number that safely applies to existing installs**: since previously-installed copies had no version marker at all, assigning the new recipes a starting version number ensures those existing installs get upgraded exactly once and then remain stable — avoiding a scenario where every install kept resetting itself repeatedly.

**✅ What Was Implemented**

Added a real version marker to both new recipe templates so the installer's existing upgrade check can detect and apply future corrections, and added a broader safety-net test that checks every installable recipe carries a valid version marker (so this specific gap can't reappear unnoticed).

**📁 FILES**
- `cli/src/install/SkillInstaller.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · [16bfd8e] Guard against local-run publishes landing on the wrong branch</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a local Jolli workflow run publishes its changes, the coding agent driving it is supposed to push to a specific branch tied to that run. If the agent skips that step, the publish tool silently opens the pull request on a different, self-generated branch instead — breaking the connection between the run and its pull request so nothing ever merges or publishes, even though the run can still report success.

**💡 Decisions Behind the Code**

- **Deterministic check instead of LLM judgment**: the branch comparison was moved into a small CLI command rather than left as something the agent inspects itself, because the agent's own mistake (dropping the target branch) is exactly what causes the mismatch — the same actor can't be trusted to reliably catch its own error, so the check needed to be an external, code-level guarantee.
- **Missing data treated as failure, not success**: when the publish step doesn't report a branch at all, the check is designed to fail closed (reported as a non-match) rather than assume everything went fine, since an unverifiable publish should never be treated the same as a confirmed success.

**✅ What Was Implemented**

- Added a new command, `verify-publish-branch`, backed by a pure comparison function (`checkPublishBranch` in `cli/src/core/WorkBranchCheck.ts`) that trims and compares the expected server-derived work branch against the branch a publish actually landed on, printing a JSON result and exiting non-zero on any mismatch.
- Wired the command into the CLI's command registry (`cli/src/Api.ts`) so it can be shelled out to as a standalone step.
- Updated the `jolli-local-run` skill recipe in `cli/src/install/SkillInstaller.ts` (template revision bumped to 3) to insert this verification between the publish and completion steps, instructing the agent to stop and abandon the run rather than report success when the branches don't match.

**📁 FILES**
- `cli/src/core/WorkBranchCheck.ts`
- `cli/src/commands/VerifyPublishBranchCommand.ts`
- `cli/src/install/SkillInstaller.ts`
- `cli/src/Api.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · [6776037] Add opt-in allowlist tier so local devs can open tunnel/ngrok links safely</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Live testing revealed that on tunnel-based local deployments, the backend renders workflow/run/article links on a public tunnel host (ngrok) rather than a Jolli domain, so the newly built origin-checking safeguard correctly but unhelpfully refused to open them, always falling back to printing the link instead of launching a browser.

**💡 Decisions Behind the Code**

An environment-variable opt-in was chosen over a broader always-on trust of the backend's own configured public address, because it is self-contained, requires no new cross-system coupling, and keeps the safety boundary explicit and auditable per developer machine rather than implicit and automatic.

**✅ What Was Implemented**

- Added a third, opt-in allowlist tier to the browser-open safeguard (`cli/src/core/OpenUrl.ts`), sourced from a comma-separated environment variable naming specific tunnel hosts a developer explicitly trusts; entries can be a bare host or a full web address and are normalized and matched using the same subdomain-boundary rule as the existing tiers.
- Left the tier empty/unset by default so production and every normal user see byte-identical behavior to before this change; only a developer who explicitly opts in gets tunnel links to auto-launch, and the browser-open action still only ever opens secure (https) links.
- Updated the governing specification document and the automated test suite (new scenarios for exact-host match, full-address normalization, subdomain matching, lookalike-host rejection, and malformed/blank entries) to reflect and lock in the new tier; full verification passed with coverage above the required floor.

**📁 FILES**
- `cli/src/core/OpenUrl.ts`
- `cli/src/core/OpenUrl.test.ts`
- `specs/274-workflow-run-result-reporting.md`

</blockquote>
</details>
<details>
<summary><strong>08 · [6776037] Let developers persist their trusted tunnel origins in a config file</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After adding the environment-variable opt-in, the user asked whether a config setting already existed so they wouldn't have to re-export the environment variable every session.

**💡 Decisions Behind the Code**

The two trust sources were merged rather than having one override the other, because a persisted list and a temporary session addition serve different, complementary needs — a developer working across multiple tunnels benefits from adding one without losing the other, whereas an override model (used elsewhere in this codebase) would force a choice between the two.

**✅ What Was Implemented**

- Added a new configuration key to the CLI's config file that accepts a list of trusted origins, mirroring how an existing toggle setting is read from config with an environment-variable override.
- Wired the browser-open command to load this configuration and pass it into the safeguard alongside the environment variable, so both sources are checked; the core browser-open logic itself does no file reading, keeping that concern in the command layer.
- Chose to combine (rather than replace) the two sources, so a developer can keep a standing list in their config file while still layering on a one-off origin via the environment variable for a single session; verified with new tests covering config-only, config-plus-environment merging, and refusal of anything not on either list.

**📁 FILES**
- `cli/src/Types.ts`
- `cli/src/core/OpenUrl.ts`
- `cli/src/commands/OpenUrlCommand.ts`
- `cli/src/core/OpenUrl.test.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · [6776037] Clarify that the configuration command cannot set the new trusted-origins setting</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The user asked whether the standard configuration-setting command could be used to set the new trusted-origins value, and requested a ready-to-use example call.

**💡 Decisions Behind the Code**

Extending the configuration-setting command to support this key was considered and then explicitly deferred once the user clarified the setting is dev-only — avoiding unnecessary expansion of a general-purpose, user-facing command surface for a narrow, opt-in developer convenience.

**✅ What Was Implemented**

The configuration-setting command only accepts a fixed, explicit list of known setting names, and the new trusted-origins setting was not (and, per the user's follow-up "since this is dev-only," was deliberately not) added to that list. Two working alternatives were provided instead: exporting the environment variable directly, or manually editing the config file (with an example command sequence) to add the specific tunnel address the user needed.

</blockquote>
</details>
<details>
<summary><strong>10 · [6776037] Combine and push the origin-safeguard and config-key changes as one commit</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The user asked to bundle the tunnel-allowlist environment-variable feature and the new persisted-config-key feature into a single commit and push it to the shared branch.

**💡 Decisions Behind the Code**

The two features were committed together as a single "origin-allowlist gate" unit rather than split, since both build on and are inseparable from the same underlying safeguard code introduced earlier in the same uncommitted working state.

**✅ What Was Implemented**

- Verified exactly which tracked source files carried the two entangled changes (seven files total, since the two features were built on the same underlying safeguard code) and confirmed untracked planning/specification files were intentionally excluded from the commit, matching prior practice on this branch.
- Re-ran the full verification suite before committing; one unrelated test failed under load (a known flaky concurrency test in an unrelated module) but passed cleanly in isolation and on a second full run, confirming no regression from these changes.
- Committed with proper sign-off and pushed to the shared branch.

</blockquote>
</details>
<details>
<summary><strong>11 · [100ede4] Fail fast when the workflow-run status tool is permanently unavailable</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When platform tools were turned off or a backend was too old, checking on a workflow run's status could not succeed no matter how many times it was retried, but the run monitor was still spending time retrying it as if the failure might be temporary.

**💡 Decisions Behind the Code**

Distinguishing a permanently-unavailable tool from a merely flaky one with its own error type lets the monitor fail immediately in the permanent case instead of burning its retry budget and the accompanying backoff wait, since no amount of waiting can make a disabled or missing tool reappear. This keeps the failure visible to the caller quickly rather than masking it behind a full round of pointless retries.

**✅ What Was Implemented**

- Added a dedicated error type in `cli/src/core/WorkflowRunReport.ts` (`PlatformToolUnavailableError`) to distinguish "this tool is structurally absent" from an ordinary transient failure.
- Updated `getRunStatus` and `listWorkflowRuns` in `cli/src/core/JolliMemoryPushClient.ts` to throw this typed error instead of a generic `Error` when the tool is missing from the manifest.
- Updated the polling loop in `cli/src/core/WorkflowRunMonitor.ts` to recognize the typed error and re-throw it on the first occurrence, bypassing the transient-retry counter and the backoff delay entirely.

**📁 FILES**
- `cli/src/core/WorkflowRunReport.ts`
- `cli/src/core/JolliMemoryPushClient.ts`
- `cli/src/core/WorkflowRunMonitor.ts`

</blockquote>
</details>
<details>
<summary><strong>12 · [100ede4] Bound workflow-run polling to shell-tool timeouts and surface the run link</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Monitoring a still-running workflow could poll for up to several minutes, long enough to risk being force-killed by the host's own timeout before the graceful "still running" result could ever be delivered back to the caller, and the resulting message only pointed to the general workflow page instead of the specific run.

**💡 Decisions Behind the Code**

- **Shorter attempt cap**: Cutting the maximum monitoring window to about 3 minutes trades the ability to wait out very long runs for reliably getting the "still running" report back to the caller before an external timeout intervenes; a still-running run isn't lost since it can be re-checked on demand.
- **Dropping the final sleep**: The wait after the last attempt was pure dead time since the loop was about to exit into a report regardless of whether it slept, so removing it is a straightforward efficiency fix with no behavior trade-off.
- **Including the run link on timeout**: Adding the specific run's link next to the general workflow link gives users a direct path to the exact in-progress run they were watching, rather than a two-hop path through the workflow overview.

**✅ What Was Implemented**

- Reduced the default poll-attempt cap in `cli/src/core/WorkflowRunMonitor.ts` from 40 to 15, bringing worst-case wall-clock time down to roughly 3 minutes with the existing backoff schedule.
- Removed the trailing wait after the final poll attempt, since the loop was sleeping once more even though it was about to exit into a timed-out result anyway.
- Extended the timed-out report to include the specific run's direct link alongside the workflow-level link, when the last poll response carried one.

**📁 FILES**
- `cli/src/core/WorkflowRunMonitor.ts`

</blockquote>
</details>
<details>
<summary><strong>13 · [95b4f1e] Log swallowed workflow-runs list failures without changing the empty-list fallback</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When fetching workflow run history failed, the CLI silently returned an empty list with no trace of the underlying cause, making it hard to tell a genuine failure apart from a repo that simply has no history yet.

**💡 Decisions Behind the Code**

The empty-list fallback was kept as-is because an unavailable run history is treated as a normal, expected outcome for the calling agent rather than an error condition. Debug-level logging was added specifically so a real underlying fault leaves a trace that developers can inspect later, instead of looking identical to a genuinely empty history with no way to tell the two apart.

**✅ What Was Implemented**

- Added a logger to `WorkflowRunsCommand.ts` via `createLogger("WorkflowRunsCommand")` and changed the catch block to capture the thrown error.
- On failure, the handler now logs the caught error at debug level before still emitting the same `{ type: "runs", runs: [] }` JSON payload, so callers see no behavioral difference.

**📁 FILES**
- `cli/src/commands/WorkflowRunsCommand.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 18, 2026 at 4:11 PM · via Jolli proxy*
<!-- jollimemory-summary-end -->
