### PR TITLE
Add Cline session sources (CLI and VS Code)

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -4,6 +4,7 @@
  * Central type definitions for all modules in the Jolli Memory tool.
  */
 
+import type { ClineScanError } from "./core/ClineTranscriptShared.js";
 import type { CopilotChatScanError } from "./core/CopilotChatTranscriptReader.js";
 import type { SqliteScanError } from "./core/SqliteHelpers.js";
 
@@ -22,6 +23,8 @@ export const TRANSCRIPT_SOURCES = [
 	"cursor",
 	"copilot",
 	"copilot-chat",
+	"cline",
+	"cline-cli",
 ] as const;
 
 /** Which AI coding agent produced the transcript. Derived from the runtime allowlist. */
@@ -1086,6 +1089,8 @@ export interface JolliMemoryConfig {
 	readonly cursorEnabled?: boolean;
 	/** Enable GitHub Copilot CLI session discovery at post-commit time (default: auto-detect) */
 	readonly copilotEnabled?: boolean;
+	/** Enable Cline (VS Code extension + CLI) session discovery at post-commit time (default: auto-detect) */
+	readonly clineEnabled?: boolean;
 	/** Global minimum log level written to debug.log (default: "info") */
 	readonly logLevel?: LogLevel;
 	/** Per-module log level overrides (e.g. { "GitOps": "debug" }) */
@@ -1368,6 +1373,16 @@ export interface StatusInfo {
 	readonly copilotChatDetected?: boolean;
 	/** Copilot Chat scan failed with a real (non-ENOENT) error: parse / fs / schema. */
 	readonly copilotChatScanError?: CopilotChatScanError;
+	/** Whether any Cline surface (VS Code extension globalStorage or ~/.cline CLI) was detected */
+	readonly clineDetected?: boolean;
+	/** Whether the Cline CLI (~/.cline/data/sessions) was detected */
+	readonly clineCliDetected?: boolean;
+	/** Whether the Cline VS Code extension globalStorage was detected */
+	readonly clineVscodeDetected?: boolean;
+	/** Whether Cline session discovery is enabled in config (undefined = auto-detect) */
+	readonly clineEnabled?: boolean;
+	/** Cline scan failed with a real error (non-ENOENT): parse / fs / schema. */
+	readonly clineScanError?: ClineScanError;
 	/**
 	 * v5 schema migration state — surfaced in `jolli status` and the VSCode
 	 * Hooks tooltip so users can see whether their on-disk data has been

--- a/cli/src/commands/ConfigureCommand.test.ts
+++ b/cli/src/commands/ConfigureCommand.test.ts
@@ -106,6 +106,30 @@ describe("ConfigureCommand — settable keys", () => {
 		expect((await loadConfig()).copilotEnabled).toBe(false);
 	});
 
+	it("accepts clineEnabled as a boolean key", async () => {
+		await runConfigure(["--set", "clineEnabled=true"]);
+		expect(mockSaveConfig).toHaveBeenCalledWith(expect.objectContaining({ clineEnabled: true }));
+		expect((await loadConfig()).clineEnabled).toBe(true);
+
+		await runConfigure(["--set", "clineEnabled=false"]);
+		expect(mockSaveConfig).toHaveBeenCalledWith(expect.objectContaining({ clineEnabled: false }));
+		expect((await loadConfig()).clineEnabled).toBe(false);
+	});
+
+	it("rejects a non-boolean value for clineEnabled", async () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const prev = process.exitCode;
+		try {
+			await runConfigure(["--set", "clineEnabled=maybe"]);
+			expect(errorSpy).toHaveBeenCalledWith(expect.stringMatching(/true\/false/));
+			expect(process.exitCode).toBe(1);
+			expect(mockSaveConfig).not.toHaveBeenCalled();
+		} finally {
+			errorSpy.mockRestore();
+			process.exitCode = prev;
+		}
+	});
+
 	it("accepts syncOnPush as a boolean key", async () => {
 		await runConfigure(["--set", "syncOnPush=false"]);
 		expect(mockSaveConfig).toHaveBeenCalledWith(expect.objectContaining({ syncOnPush: false }));
@@ -231,6 +255,11 @@ describe("ConfigureCommand — settable keys", () => {
 		expect(help).toContain("localFolder");
 		expect(help).toContain("aiProvider");
 		expect(help).toContain("globalInstructions");
+	});
+
+	it("lists clineEnabled in help/description output", async () => {
+		const help = await runConfigureHelp();
+		expect(help).toContain("clineEnabled");
 	});
 
 	describe("slack.workspaceUrl validation", () => {

--- a/cli/src/commands/ConfigureCommand.ts
+++ b/cli/src/commands/ConfigureCommand.ts
@@ -57,6 +57,7 @@ const VALID_CONFIG_KEYS = [
 	"openCodeEnabled",
 	"cursorEnabled",
 	"copilotEnabled",
+	"clineEnabled",
 	"mcpPlatformToolsEnabled",
 	"globalInstructions",
 	"logLevel",
@@ -132,6 +133,7 @@ function coerceConfigValue(key: ConfigKey, raw: string): string | number | boole
 		key === "openCodeEnabled" ||
 		key === "cursorEnabled" ||
 		key === "copilotEnabled" ||
+		key === "clineEnabled" ||
 		key === "mcpPlatformToolsEnabled" ||
 		key === "syncTranscripts" ||
 		key === "syncOnPush"
@@ -218,6 +220,11 @@ const CONFIG_KEY_INFO: ReadonlyArray<{ key: ConfigKey; type: string; description
 		key: "copilotEnabled",
 		type: "boolean",
 		description: "Enable Copilot CLI session discovery (true/false; requires Node 22.5+ at runtime)",
+	},
+	{
+		key: "clineEnabled",
+		type: "boolean",
+		description: "Enable Cline (VS Code extension + CLI) session discovery (true/false)",
 	},
 	{
 		key: "mcpPlatformToolsEnabled",

--- a/cli/src/commands/StatusCommand.test.ts
+++ b/cli/src/commands/StatusCommand.test.ts
@@ -204,6 +204,94 @@ describe("StatusCommand — Copilot integration row", () => {
 	});
 });
 
+describe("StatusCommand — Cline integration row", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockLoadConfigFromDir.mockResolvedValue({});
+		mockLoadAuthToken.mockResolvedValue(null);
+		mockFrontDoor.mockResolvedValue({ status: "no_spaces" });
+		mockTenantOrigin.mockReturnValue(null);
+		mockLoadCache.mockResolvedValue(null);
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("does not render Cline row when Cline not detected", async () => {
+		const out = await renderStatus({
+			...baseStatus,
+			// clineDetected unset (undefined) -> default state
+		});
+		expect(out).not.toContain("Cline:");
+	});
+
+	it("renders Cline row with merged extension + CLI session count", async () => {
+		const out = await renderStatus({
+			...baseStatus,
+			clineDetected: true,
+			clineEnabled: true,
+			sessionsBySource: { cline: 2, "cline-cli": 3 },
+		});
+		expect(out).toContain("Cline");
+		expect(out).toMatch(/5\s*sessions/);
+	});
+
+	it("renders Cline row as unavailable on scan error", async () => {
+		const out = await renderStatus({
+			...baseStatus,
+			clineDetected: true,
+			clineScanError: { kind: "parse", message: "bad task json" },
+		});
+		expect(out).toContain("Cline");
+		expect(out).toContain("unavailable");
+		expect(out).toContain("parse");
+	});
+
+	it("renders Cline row as disabled when detected but clineEnabled is false", async () => {
+		const out = await renderStatus({
+			...baseStatus,
+			clineDetected: true,
+			clineEnabled: false,
+		});
+		expect(out).toContain("Cline");
+		expect(out).toContain("detected but disabled");
+	});
+
+	it("Cline row shows CLI/VS Code breakdown when only the CLI is detected", async () => {
+		const out = await renderStatus({
+			...baseStatus,
+			clineDetected: true,
+			clineCliDetected: true,
+			clineVscodeDetected: false,
+			clineEnabled: true,
+		});
+		expect(out).toContain("CLI: ✓");
+		expect(out).toContain("VS Code: ✗");
+	});
+
+	it("renders the Copilot CLI/Chat sub-line under Copilot, not under Cline", async () => {
+		// Regression: the Copilot sub-line was emitted after the whole integration
+		// loop, so it visually attached to the last row (Cline). It must print
+		// directly beneath Copilot — i.e. before the Cline row.
+		const out = await renderStatus({
+			...baseStatus,
+			copilotDetected: true,
+			copilotChatDetected: true,
+			copilotEnabled: true,
+			clineDetected: true,
+			clineCliDetected: true,
+			clineVscodeDetected: true,
+			clineEnabled: true,
+		});
+		const chatIdx = out.indexOf("Chat: ✓");
+		const clineRowIdx = out.indexOf("Cline:");
+		expect(chatIdx).toBeGreaterThan(-1);
+		expect(clineRowIdx).toBeGreaterThan(-1);
+		expect(chatIdx).toBeLessThan(clineRowIdx);
+	});
+});
+
 describe("StatusCommand — Jolli Site display", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();

--- a/cli/src/commands/StatusCommand.ts
+++ b/cli/src/commands/StatusCommand.ts
@@ -8,6 +8,7 @@
 
 import type { Command } from "commander";
 import { loadAuthToken } from "../auth/AuthConfig.js";
+import type { ClineScanError } from "../core/ClineTranscriptShared.js";
 import { deriveRepoNameFromUrl, getCanonicalRepoUrl } from "../core/GitRemoteUtils.js";
 import {
 	ClientOutdatedError,
@@ -22,6 +23,7 @@ import {
 	saveSpaceBindingCache,
 	tenantOriginForKey,
 } from "../core/SpaceBindingCache.js";
+import type { SqliteScanError } from "../core/SqliteHelpers.js";
 import { getStatus } from "../install/Installer.js";
 import { createLogger, setLogDir } from "../Logger.js";
 import type { StatusInfo } from "../Types.js";
@@ -222,8 +224,13 @@ interface IntegrationStatusInputs {
 	/** undefined = this integration has no hook concept (Codex, OpenCode). */
 	readonly hookInstalled: boolean | undefined;
 	readonly sessionCount: number | undefined;
-	/** DB existed but scan failed (corrupt/locked/schema/etc). Used by OpenCode and Copilot integrations. */
-	readonly scanError?: StatusInfo["openCodeScanError"];
+	/**
+	 * DB/file scan failed (corrupt/locked/schema/parse/etc). Used by OpenCode,
+	 * Cursor, Copilot, and Cline integrations. Union preserves literal-kind safety
+	 * for both SqliteScanError (corrupt|locked|permission|schema|unknown) and
+	 * ClineScanError (parse|fs|schema|unknown).
+	 */
+	readonly scanError?: SqliteScanError | ClineScanError;
 }
 
 /**
@@ -326,8 +333,39 @@ export function registerStatusCommand(program: Command): void {
 			// the VSCode STATUS panel). Claude's enabled flag lives in config, not
 			// StatusInfo, so read it from the already-loaded `config`.
 			const counts = status.sessionsBySource ?? {};
+			const subIndent = "".padEnd(18);
+			const mark = (detected: boolean | undefined): string => (detected ? "✓" : "✗");
+
+			// Copilot and Cline are dual-variant sources (terminal CLI + editor). Each
+			// prints an indented breakdown sub-line beneath its main row. These are
+			// attached to the row tuple (not emitted after the loop) so they render
+			// directly under their own row rather than the last integration row.
+			const copilotSubLines: string[] = [];
+			const anyCopilotDetected = (status.copilotDetected ?? false) || (status.copilotChatDetected ?? false);
+			if (anyCopilotDetected) {
+				copilotSubLines.push(
+					`  ${subIndent}↳ CLI: ${mark(status.copilotDetected)}, Chat: ${mark(status.copilotChatDetected)}`,
+				);
+				if (status.copilotChatScanError) {
+					copilotSubLines.push(
+						`  ${subIndent}↳ Chat scan failed (${status.copilotChatScanError.kind}): ${status.copilotChatScanError.message}`,
+					);
+				}
+			}
+			const clineSubLines: string[] = [];
+			if (status.clineDetected) {
+				clineSubLines.push(
+					`  ${subIndent}↳ CLI: ${mark(status.clineCliDetected)}, VS Code: ${mark(status.clineVscodeDetected)}`,
+				);
+			}
+
 			const integrationRows: ReadonlyArray<
-				readonly [label: string, detected: boolean | undefined, inputs: IntegrationStatusInputs]
+				readonly [
+					label: string,
+					detected: boolean | undefined,
+					inputs: IntegrationStatusInputs,
+					subLines?: readonly string[],
+				]
 			> = [
 				[
 					"Claude:",
@@ -378,7 +416,7 @@ export function registerStatusCommand(program: Command): void {
 				],
 				[
 					"Copilot:",
-					(status.copilotDetected ?? false) || (status.copilotChatDetected ?? false),
+					anyCopilotDetected,
 					{
 						enabled: status.copilotEnabled !== false,
 						hookInstalled: undefined,
@@ -386,21 +424,25 @@ export function registerStatusCommand(program: Command): void {
 						// CLI scan error renders on the main row; Chat scan error renders as a sub-line below.
 						scanError: status.copilotScanError,
 					},
+					copilotSubLines,
+				],
+				[
+					"Cline:",
+					status.clineDetected ?? false,
+					{
+						enabled: status.clineEnabled !== false,
+						hookInstalled: undefined,
+						sessionCount: (counts.cline ?? 0) + (counts["cline-cli"] ?? 0),
+						scanError: status.clineScanError,
+					},
+					clineSubLines,
 				],
 			];
-			for (const [label, detected, inputs] of integrationRows) {
+			for (const [label, detected, inputs, subLines] of integrationRows) {
 				if (!detected) continue;
 				console.log(`  ${label.padEnd(18)}${describeIntegrationStatus(inputs)}`);
-			}
-			const anyCopilotDetected = (status.copilotDetected ?? false) || (status.copilotChatDetected ?? false);
-			if (anyCopilotDetected) {
-				const cliMark = status.copilotDetected ? "✓" : "✗";
-				const chatMark = status.copilotChatDetected ? "✓" : "✗";
-				console.log(`  ${"".padEnd(18)}↳ CLI: ${cliMark}, Chat: ${chatMark}`);
-				if (status.copilotChatScanError) {
-					console.log(
-						`  ${"".padEnd(18)}↳ Chat scan failed (${status.copilotChatScanError.kind}): ${status.copilotChatScanError.message}`,
-					);
+				for (const line of subLines ?? []) {
+					console.log(line);
 				}
 			}
 

--- a/cli/src/core/ActiveSessionAggregator.test.ts
+++ b/cli/src/core/ActiveSessionAggregator.test.ts
@@ -6,6 +6,8 @@ vi.mock("./CodexSessionDiscoverer.js", () => ({ discoverCodexSessions: vi.fn() }
 vi.mock("./OpenCodeSessionDiscoverer.js", () => ({ scanOpenCodeSessions: vi.fn() }));
 vi.mock("./CopilotSessionDiscoverer.js", () => ({ scanCopilotSessions: vi.fn() }));
 vi.mock("./CopilotChatSessionDiscoverer.js", () => ({ scanCopilotChatSessions: vi.fn() }));
+vi.mock("./ClineSessionDiscoverer.js", () => ({ scanClineSessions: vi.fn() }));
+vi.mock("./ClineCliSessionDiscoverer.js", () => ({ scanClineCliSessions: vi.fn() }));
 vi.mock("./SessionTracker.js", () => ({ loadAllSessions: vi.fn().mockResolvedValue([]) }));
 vi.mock("./SessionTitleResolver.js", () => ({
 	resolveSessionTitle: vi.fn().mockImplementation(async (s) => s.title ?? `resolved:${s.sessionId}`),
@@ -19,6 +21,8 @@ vi.mock("./TranscriptMessageCounter.js", () => ({
 }));
 
 import { listActiveConversations } from "./ActiveSessionAggregator.js";
+import { scanClineCliSessions } from "./ClineCliSessionDiscoverer.js";
+import { scanClineSessions } from "./ClineSessionDiscoverer.js";
 import { discoverCodexSessions } from "./CodexSessionDiscoverer.js";
 import { conversationKey, setExcluded } from "./CommitSelectionStore.js";
 import { scanCopilotChatSessions } from "./CopilotChatSessionDiscoverer.js";
@@ -48,6 +52,8 @@ beforeEach(() => {
 	vi.mocked(scanOpenCodeSessions).mockReset().mockResolvedValue(scan([]));
 	vi.mocked(scanCopilotSessions).mockReset().mockResolvedValue(scan([]));
 	vi.mocked(scanCopilotChatSessions).mockReset().mockResolvedValue(scan([]));
+	vi.mocked(scanClineSessions).mockReset().mockResolvedValue(scan([]));
+	vi.mocked(scanClineCliSessions).mockReset().mockResolvedValue(scan([]));
 	vi.mocked(discoverCodexSessions).mockReset().mockResolvedValue([]);
 	vi.mocked(loadMergedTranscript)
 		.mockReset()
@@ -135,10 +141,36 @@ describe("listActiveConversations", () => {
 		vi.mocked(scanOpenCodeSessions).mockRejectedValueOnce(new Error("opencode fail"));
 		vi.mocked(scanCopilotSessions).mockRejectedValueOnce(new Error("copilot fail"));
 		vi.mocked(scanCopilotChatSessions).mockRejectedValueOnce(new Error("cc fail"));
+		vi.mocked(scanClineSessions).mockRejectedValueOnce(new Error("cline fail"));
+		vi.mocked(scanClineCliSessions).mockRejectedValueOnce(new Error("cline-cli fail"));
 		vi.mocked(discoverCodexSessions).mockRejectedValueOnce(new Error("codex fail"));
 
 		const items = await listActiveConversations({ cwd: "/proj", windowMs: 2 * DAY });
 		expect(items).toEqual([]);
+	});
+
+	it("includes Cline (VS Code) and Cline CLI sessions from their discoverers", async () => {
+		vi.mocked(scanClineSessions).mockResolvedValueOnce(
+			scan([
+				{ sessionId: "cl1", transcriptPath: "/", updatedAt: iso(-HOUR), source: "cline", title: "Cline task" },
+			]),
+		);
+		vi.mocked(scanClineCliSessions).mockResolvedValueOnce(
+			scan([{ sessionId: "clc1", transcriptPath: "/", updatedAt: iso(-HOUR), source: "cline-cli" }]),
+		);
+
+		const items = await listActiveConversations({ cwd: "/proj", windowMs: 2 * DAY });
+		expect(items.map((i) => i.sessionId).sort()).toEqual(["cl1", "clc1"]);
+	});
+
+	it("continues when Cline discoverer throws (source-level isolation)", async () => {
+		vi.mocked(scanClineSessions).mockRejectedValueOnce(new Error("cline scan fail"));
+		vi.mocked(scanOpenCodeSessions).mockResolvedValueOnce(
+			scan([{ sessionId: "ok", transcriptPath: "/", updatedAt: iso(-HOUR), source: "opencode" }]),
+		);
+
+		const items = await listActiveConversations({ cwd: "/proj", windowMs: 2 * DAY });
+		expect(items.map((i) => i.sessionId)).toEqual(["ok"]);
 	});
 
 	it("loadClaudeAndGemini swallows SessionTracker errors", async () => {

--- a/cli/src/core/ActiveSessionAggregator.ts
+++ b/cli/src/core/ActiveSessionAggregator.ts
@@ -222,6 +222,8 @@ async function collectFromAllSources(cwd: string): Promise<CollectResult> {
 		loadOpenCode(cwd),
 		loadCopilot(cwd),
 		loadCopilotChat(cwd),
+		loadCline(cwd),
+		loadClineCli(cwd),
 	]);
 	const sessions: SessionInfo[] = [];
 	const failedSources: TranscriptSource[] = [];
@@ -325,5 +327,35 @@ async function loadCopilotChat(cwd: string): Promise<LoaderResult> {
 	} catch (err) {
 		log.warn("scanCopilotChatSessions threw: %s", errMsg(err));
 		return { sessions: [], failed: ["copilot-chat"] };
+	}
+}
+
+async function loadCline(cwd: string): Promise<LoaderResult> {
+	try {
+		const { scanClineSessions } = await import("./ClineSessionDiscoverer.js");
+		const r = await scanClineSessions(cwd);
+		if (r.error) {
+			log.warn("scanClineSessions reported %s: %s", r.error.kind, r.error.message);
+			return { sessions: r.sessions, failed: ["cline"] };
+		}
+		return { sessions: r.sessions, failed: [] };
+	} catch (err) {
+		log.warn("scanClineSessions threw: %s", errMsg(err));
+		return { sessions: [], failed: ["cline"] };
+	}
+}
+
+async function loadClineCli(cwd: string): Promise<LoaderResult> {
+	try {
+		const { scanClineCliSessions } = await import("./ClineCliSessionDiscoverer.js");
+		const r = await scanClineCliSessions(cwd);
+		if (r.error) {
+			log.warn("scanClineCliSessions reported %s: %s", r.error.kind, r.error.message);
+			return { sessions: r.sessions, failed: ["cline-cli"] };
+		}
+		return { sessions: r.sessions, failed: [] };
+	} catch (err) {
+		log.warn("scanClineCliSessions threw: %s", errMsg(err));
+		return { sessions: [], failed: ["cline-cli"] };
 	}
 }

--- a/cli/src/core/ClineCliDetector.test.ts
+++ b/cli/src/core/ClineCliDetector.test.ts
@@ -1,0 +1,29 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getClineCliDataDir, getClineCliSessionsDir, isClineCliInstalled } from "./ClineCliDetector.js";
+
+describe("ClineCliDetector", () => {
+	let home: string;
+	beforeEach(async () => {
+		home = await mkdtemp(join(tmpdir(), "cline-cli-det-"));
+	});
+	afterEach(async () => {
+		await rm(home, { recursive: true, force: true });
+	});
+
+	it("derives data + sessions dirs from home", () => {
+		expect(getClineCliDataDir(home)).toBe(join(home, ".cline", "data"));
+		expect(getClineCliSessionsDir(home)).toBe(join(home, ".cline", "data", "sessions"));
+	});
+
+	it("returns false when sessions dir is absent", async () => {
+		expect(await isClineCliInstalled(home)).toBe(false);
+	});
+
+	it("returns true once sessions dir exists", async () => {
+		await mkdir(getClineCliSessionsDir(home), { recursive: true });
+		expect(await isClineCliInstalled(home)).toBe(true);
+	});
+});

--- a/cli/src/core/ClineCliDetector.ts
+++ b/cli/src/core/ClineCliDetector.ts
@@ -1,0 +1,26 @@
+import { access } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Cline CLI data root: <home>/.cline/data (home-relative on all platforms). */
+export function getClineCliDataDir(home: string = homedir()): string {
+	return join(home, ".cline", "data");
+}
+
+/** Per-session directory root: <dataDir>/sessions. */
+export function getClineCliSessionsDir(home: string = homedir()): string {
+	return join(getClineCliDataDir(home), "sessions");
+}
+
+/**
+ * Detected when the sessions/ dir exists. No node:sqlite gate — the CLI
+ * discoverer reads plain JSON sidecars, never the WAL-mode sessions.db.
+ */
+export async function isClineCliInstalled(home: string = homedir()): Promise<boolean> {
+	try {
+		await access(getClineCliSessionsDir(home));
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/cli/src/core/ClineCliSessionDiscoverer.test.ts
+++ b/cli/src/core/ClineCliSessionDiscoverer.test.ts
@@ -1,0 +1,112 @@
+import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { discoverClineCliSessions, scanClineCliSessions } from "./ClineCliSessionDiscoverer.js";
+
+async function writeSession(sessionsDir: string, id: string, sidecar: object): Promise<void> {
+	const dir = join(sessionsDir, id);
+	await mkdir(dir, { recursive: true });
+	await writeFile(join(dir, `${id}.json`), JSON.stringify(sidecar), "utf8");
+	await writeFile(join(dir, `${id}.messages.json`), JSON.stringify({ messages: [] }), "utf8");
+}
+
+describe("scanClineCliSessions", () => {
+	let sessionsDir: string;
+	const project = "/tmp/proj-a";
+	beforeEach(async () => {
+		sessionsDir = await mkdtemp(join(tmpdir(), "cline-cli-disc-"));
+	});
+	afterEach(async () => {
+		await rm(sessionsDir, { recursive: true, force: true });
+	});
+
+	it("returns empty (no error) when sessions dir absent", async () => {
+		const r = await scanClineCliSessions(project, join(sessionsDir, "nope"));
+		expect(r).toEqual({ sessions: [] });
+	});
+
+	it("attributes by workspace_root, sets source/title, uses messages.json mtime", async () => {
+		await writeSession(sessionsDir, "s1", {
+			session_id: "s1",
+			workspace_root: project,
+			messages_path: join(sessionsDir, "s1", "s1.messages.json"),
+			metadata: { title: "fix bug" },
+		});
+		await writeSession(sessionsDir, "s2", { session_id: "s2", workspace_root: "/tmp/other" });
+		const r = await scanClineCliSessions(project, sessionsDir);
+		expect(r.sessions).toHaveLength(1);
+		expect(r.sessions[0]).toMatchObject({ sessionId: "s1", source: "cline-cli", title: "fix bug" });
+		expect(r.sessions[0].transcriptPath).toContain("s1.messages.json");
+	});
+
+	it("falls back to the canonical messages path when messages_path is relative", async () => {
+		await writeSession(sessionsDir, "sRel", {
+			workspace_root: project,
+			messages_path: "sRel.messages.json", // relative — must not be trusted verbatim
+		});
+		const r = await scanClineCliSessions(project, sessionsDir);
+		expect(r.sessions.map((s) => s.sessionId)).toContain("sRel");
+		expect(r.sessions.find((s) => s.sessionId === "sRel")?.transcriptPath).toBe(
+			join(sessionsDir, "sRel", "sRel.messages.json"),
+		);
+	});
+
+	it("falls back to cwd when workspace_root missing; skips corrupt sidecar", async () => {
+		await writeSession(sessionsDir, "s3", { session_id: "s3", cwd: project });
+		await mkdir(join(sessionsDir, "s4"), { recursive: true });
+		await writeFile(join(sessionsDir, "s4", "s4.json"), "{ not json", "utf8");
+		const r = await scanClineCliSessions(project, sessionsDir);
+		expect(r.sessions.map((s) => s.sessionId)).toEqual(["s3"]);
+	});
+
+	it("discoverClineCliSessions strips error channel", async () => {
+		const sessions = await discoverClineCliSessions(project);
+		expect(Array.isArray(sessions)).toBe(true);
+	});
+
+	it("skips sessions with missing or stale messages file", async () => {
+		// Session with no messages file
+		await mkdir(join(sessionsDir, "s5"), { recursive: true });
+		await writeFile(join(sessionsDir, "s5", "s5.json"), JSON.stringify({ workspace_root: project }), "utf8");
+		// Session with stale messages file (mtime before cutoff)
+		await writeSession(sessionsDir, "sOld", { workspace_root: project });
+		const oldTime = new Date(Date.now() - 49 * 60 * 60 * 1000); // 49 hours ago
+		await utimes(join(sessionsDir, "sOld", "sOld.messages.json"), oldTime, oldTime);
+		// Session with fresh messages file
+		await writeSession(sessionsDir, "sFresh", { workspace_root: project });
+		const r = await scanClineCliSessions(project, sessionsDir);
+		// sFresh should be included (fresh mtime)
+		expect(r.sessions.map((s) => s.sessionId)).toContain("sFresh");
+		// sOld should be skipped (stale mtime)
+		expect(r.sessions.map((s) => s.sessionId)).not.toContain("sOld");
+		// s5 should be skipped (no messages file)
+		expect(r.sessions.map((s) => s.sessionId)).not.toContain("s5");
+	});
+
+	it("skips sessions from different workspace_root/cwd", async () => {
+		await writeSession(sessionsDir, "s7", { workspace_root: "/other/project" });
+		await writeSession(sessionsDir, "s8", { cwd: "/yet/another" });
+		const r = await scanClineCliSessions(project, sessionsDir);
+		expect(r.sessions.length).toBe(0);
+	});
+
+	it("returns filesystem error when non-ENOENT error occurs", async () => {
+		// Simulate an error by passing a path that is a file, not a directory
+		const filePath = join(sessionsDir, "not-a-dir");
+		await writeFile(filePath, "test", "utf8");
+		const r = await scanClineCliSessions(project, filePath);
+		expect(r.error).toBeDefined();
+		expect(r.error?.kind).toBe("fs");
+	});
+
+	it("discoverClineCliSessions returns empty array on fs error (logs warn)", async () => {
+		// Pass a file path instead of directory to trigger fs error
+		const filePath = join(sessionsDir, "not-a-dir");
+		await writeFile(filePath, "test", "utf8");
+		const sessions = await discoverClineCliSessions(project);
+		// Should return array (not error) despite fs error
+		expect(Array.isArray(sessions)).toBe(true);
+		expect(sessions).toHaveLength(0);
+	});
+});

--- a/cli/src/core/ClineCliSessionDiscoverer.ts
+++ b/cli/src/core/ClineCliSessionDiscoverer.ts
@@ -1,0 +1,86 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import { isAbsolute, join } from "node:path";
+import { createLogger } from "../Logger.js";
+import type { SessionInfo } from "../Types.js";
+import { getClineCliSessionsDir } from "./ClineCliDetector.js";
+import type { ClineScanError } from "./ClineTranscriptShared.js";
+import { normalizePathForCompare } from "./PathUtils.js";
+
+const log = createLogger("ClineCliDiscoverer");
+const SESSION_STALE_MS = 48 * 60 * 60 * 1000;
+
+export type { ClineScanError };
+
+export interface ClineCliScanResult {
+	readonly sessions: ReadonlyArray<SessionInfo>;
+	readonly error?: ClineScanError;
+}
+
+interface ClineCliSidecar {
+	readonly session_id?: string;
+	readonly cwd?: string;
+	readonly workspace_root?: string;
+	readonly messages_path?: string;
+	readonly metadata?: { readonly title?: string };
+}
+
+export async function scanClineCliSessions(
+	projectDir: string,
+	sessionsDir: string = getClineCliSessionsDir(),
+): Promise<ClineCliScanResult> {
+	let ids: string[];
+	try {
+		ids = await readdir(sessionsDir);
+	} catch (error: unknown) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT") return { sessions: [] };
+		return { sessions: [], error: { kind: "fs", message: (error as Error).message } };
+	}
+
+	const cutoffMs = Date.now() - SESSION_STALE_MS;
+	const target = normalizePathForCompare(projectDir);
+	const sessions: SessionInfo[] = [];
+
+	for (const id of ids) {
+		const sidecarPath = join(sessionsDir, id, `${id}.json`);
+		let meta: ClineCliSidecar;
+		try {
+			meta = JSON.parse(await readFile(sidecarPath, "utf8")) as ClineCliSidecar;
+		} catch (error: unknown) {
+			log.debug("Skipping %s: sidecar read/parse failed (%s)", id, (error as Error).message);
+			continue;
+		}
+		const root = meta.workspace_root ?? meta.cwd;
+		if (typeof root !== "string" || normalizePathForCompare(root) !== target) continue;
+		// Trust the sidecar's messages_path only when absolute — a relative value
+		// (or one synced from another machine) would stat against process.cwd() and
+		// silently drop a live session. Fall back to the canonical per-session path.
+		const messagesPath =
+			typeof meta.messages_path === "string" && isAbsolute(meta.messages_path)
+				? meta.messages_path
+				: join(sessionsDir, id, `${id}.messages.json`);
+		let mtimeMs: number;
+		try {
+			mtimeMs = (await stat(messagesPath)).mtimeMs;
+		} catch {
+			continue;
+		}
+		if (mtimeMs < cutoffMs) continue;
+		const title = meta.metadata?.title?.trim();
+		sessions.push({
+			sessionId: meta.session_id ?? id,
+			transcriptPath: messagesPath,
+			updatedAt: new Date(mtimeMs).toISOString(),
+			source: "cline-cli",
+			...(title ? { title } : {}),
+		});
+	}
+	return { sessions };
+}
+
+/** QueueWorker wrapper — strips the error channel. */
+export async function discoverClineCliSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
+	const { sessions, error } = await scanClineCliSessions(projectDir);
+	if (error) log.warn("Cline CLI scan error (%s): %s", error.kind, error.message);
+	return sessions;
+}

--- a/cli/src/core/ClineCliTranscriptReader.test.ts
+++ b/cli/src/core/ClineCliTranscriptReader.test.ts
@@ -1,0 +1,113 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readClineCliTranscript } from "./ClineCliTranscriptReader.js";
+
+const FIXTURE = {
+	version: 1,
+	messages: [
+		{
+			id: "m1",
+			role: "user",
+			content: [{ type: "text", text: '<user_input mode="act">hi</user_input>' }],
+			ts: 1000,
+		},
+		{
+			id: "m2",
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "planning" },
+				{ type: "text", text: "Hi! How can I help?" },
+			],
+			ts: 2000,
+		},
+		{
+			id: "m3",
+			role: "assistant",
+			content: [
+				{ type: "text", text: "Running check" },
+				{ type: "tool_use", id: "c1", name: "run_commands", input: { commands: ["git branch"] } },
+			],
+			ts: 3000,
+		},
+		{
+			id: "m4",
+			role: "user",
+			content: [{ type: "tool_result", tool_use_id: "c1", name: "run_commands", content: [{ result: "main" }] }],
+			ts: 4000,
+		},
+		{ id: "m5", role: "assistant", content: [{ type: "text", text: "Branch is main" }], ts: 5000 },
+	],
+};
+
+describe("readClineCliTranscript", () => {
+	let dir: string;
+	let path: string;
+	beforeEach(async () => {
+		dir = await mkdtemp(join(tmpdir(), "cline-cli-rd-"));
+		path = join(dir, "m.messages.json");
+		await writeFile(path, JSON.stringify(FIXTURE), "utf8");
+	});
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("extracts text blocks, strips <user_input>, drops thinking/tool blocks, merges same-role", async () => {
+		const r = await readClineCliTranscript(path);
+		// m1 human "hi"; m2+m3+m5 all consecutive assistant entries merge; m4 (empty tool_result) skipped
+		expect(r.entries).toEqual([
+			{ role: "human", content: "hi", timestamp: new Date(1000).toISOString() },
+			{
+				role: "assistant",
+				content: "Hi! How can I help?\n\nRunning check\n\nBranch is main",
+				timestamp: new Date(2000).toISOString(),
+			},
+		]);
+		expect(r.newCursor.lineNumber).toBe(5);
+		expect(r.totalLinesRead).toBe(5);
+	});
+
+	it("resumes from cursor.lineNumber (starting at m5)", async () => {
+		const r = await readClineCliTranscript(path, { transcriptPath: path, lineNumber: 4, updatedAt: "" });
+		// m5 is at index 4
+		expect(r.entries).toEqual([
+			{ role: "assistant", content: "Branch is main", timestamp: new Date(5000).toISOString() },
+		]);
+		expect(r.totalLinesRead).toBe(1);
+	});
+
+	it("honors beforeTimestamp (stops at first message past cutoff, advances cursor to consumed)", async () => {
+		const r = await readClineCliTranscript(path, null, new Date(3000).toISOString());
+		expect(r.entries.map((e) => e.role)).toEqual(["human", "assistant"]);
+		expect(r.newCursor.lineNumber).toBe(3); // m1,m2,m3 consumed; m4 (ts 4000) > cutoff → break
+	});
+
+	it("returns empty result on unreadable file", async () => {
+		const r = await readClineCliTranscript(join(dir, "missing.json"));
+		expect(r.entries).toEqual([]);
+		expect(r.totalLinesRead).toBe(0);
+	});
+
+	it("handles messages without content array gracefully", async () => {
+		const noContentFixture = {
+			messages: [
+				{ id: "m1", role: "assistant" },
+				{ id: "m2", role: "user" },
+			],
+		};
+		await writeFile(path, JSON.stringify(noContentFixture), "utf8");
+		const r = await readClineCliTranscript(path);
+		// Both messages have no content, so both get empty text → skipped
+		expect(r.entries).toEqual([]);
+		expect(r.totalLinesRead).toBe(2);
+	});
+
+	it("handles undefined parsed.messages gracefully", async () => {
+		const noMessagesFixture = { version: 1 }; // no messages field
+		await writeFile(path, JSON.stringify(noMessagesFixture), "utf8");
+		const r = await readClineCliTranscript(path);
+		expect(r.entries).toEqual([]);
+		expect(r.totalLinesRead).toBe(0);
+	});
+});

--- a/cli/src/core/ClineCliTranscriptReader.ts
+++ b/cli/src/core/ClineCliTranscriptReader.ts
@@ -1,0 +1,59 @@
+import { readFile } from "node:fs/promises";
+import { createLogger } from "../Logger.js";
+import type { TranscriptCursor, TranscriptReadResult } from "../Types.js";
+import {
+	buildClineReadResult,
+	emptyClineReadResult,
+	mapClineRole,
+	type NormalizedMessage,
+} from "./ClineTranscriptShared.js";
+
+const log = createLogger("ClineCliReader");
+
+interface ClineCliBlock {
+	readonly type: string;
+	readonly text?: string;
+}
+interface ClineCliMessage {
+	readonly role?: string;
+	readonly content?: ReadonlyArray<ClineCliBlock>;
+	readonly ts?: number;
+}
+interface ClineCliFile {
+	readonly messages?: ReadonlyArray<ClineCliMessage>;
+}
+
+const USER_INPUT_RE = /<user_input\b[^>]*>([\s\S]*?)<\/user_input>/i;
+
+function unwrapUserInput(text: string): string {
+	const m = USER_INPUT_RE.exec(text);
+	return (m ? m[1] : text).trim();
+}
+
+function extractText(msg: ClineCliMessage): string {
+	const parts: string[] = [];
+	for (const block of msg.content ?? []) {
+		if (block.type === "text" && typeof block.text === "string") parts.push(block.text);
+	}
+	return parts.join("\n").trim();
+}
+
+export async function readClineCliTranscript(
+	transcriptPath: string,
+	cursor?: TranscriptCursor | null,
+	beforeTimestamp?: string,
+): Promise<TranscriptReadResult> {
+	let parsed: ClineCliFile;
+	try {
+		parsed = JSON.parse(await readFile(transcriptPath, "utf8")) as ClineCliFile;
+	} catch (error: unknown) {
+		log.error("Failed to read Cline CLI transcript %s: %s", transcriptPath, (error as Error).message);
+		return emptyClineReadResult(transcriptPath, cursor);
+	}
+	const messages: NormalizedMessage[] = (Array.isArray(parsed.messages) ? parsed.messages : []).map((msg) => {
+		const role = mapClineRole(msg.role);
+		const raw = extractText(msg);
+		return { role, content: role === "human" ? unwrapUserInput(raw) : raw, ts: msg.ts };
+	});
+	return buildClineReadResult(transcriptPath, messages, cursor, beforeTimestamp);
+}

--- a/cli/src/core/ClineDetector.test.ts
+++ b/cli/src/core/ClineDetector.test.ts
@@ -1,0 +1,43 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getClineStorageDirs, isClineInstalled } from "./ClineDetector.js";
+
+describe("ClineDetector", () => {
+	let home: string;
+	let prevAppData: string | undefined;
+	beforeEach(async () => {
+		home = await mkdtemp(join(tmpdir(), "cline-ext-det-"));
+		// On win32, getVscodeUserDataDir resolves via %APPDATA% and ignores the
+		// `home` argument, so a real machine's APPDATA would leak in (reading — and
+		// in the "true" case writing — the real user profile). Point it inside the
+		// temp dir so all three cases stay isolated. No-op on darwin/linux, which
+		// honour `home` directly.
+		prevAppData = process.env.APPDATA;
+		process.env.APPDATA = join(home, "AppData", "Roaming");
+	});
+	afterEach(async () => {
+		if (prevAppData === undefined) delete process.env.APPDATA;
+		else process.env.APPDATA = prevAppData;
+		await rm(home, { recursive: true, force: true });
+	});
+
+	it("returns one storage dir per flavor", () => {
+		const dirs = getClineStorageDirs(home);
+		expect(dirs.length).toBeGreaterThanOrEqual(5);
+		expect(dirs.some((d) => d.includes("saoudrizwan.claude-dev"))).toBe(true);
+	});
+
+	it("false when no flavor has taskHistory.json", async () => {
+		expect(await isClineInstalled(home)).toBe(false);
+	});
+
+	it("true when any flavor has taskHistory.json", async () => {
+		// darwin layout: <home>/Library/Application Support/Code/User/globalStorage/<ext>/state/
+		const stateDir = join(getClineStorageDirs(home)[0], "state");
+		await mkdir(stateDir, { recursive: true });
+		await writeFile(join(stateDir, "taskHistory.json"), "[]", "utf8");
+		expect(await isClineInstalled(home)).toBe(true);
+	});
+});

--- a/cli/src/core/ClineDetector.ts
+++ b/cli/src/core/ClineDetector.ts
@@ -1,0 +1,28 @@
+import { access } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { ALL_VSCODE_FLAVORS, getVscodeUserDataDir } from "./VscodeWorkspaceLocator.js";
+
+const EXTENSION_ID = "saoudrizwan.claude-dev";
+
+/** globalStorage dir for the Cline extension under one VS Code flavor. */
+function flavorStorageDir(flavor: (typeof ALL_VSCODE_FLAVORS)[number], home: string): string {
+	return join(getVscodeUserDataDir(flavor, home), "User", "globalStorage", EXTENSION_ID);
+}
+
+/** Existing-or-not, one entry per flavor (caller filters). */
+export function getClineStorageDirs(home: string = homedir()): string[] {
+	return ALL_VSCODE_FLAVORS.map((f) => flavorStorageDir(f, home));
+}
+
+export async function isClineInstalled(home: string = homedir()): Promise<boolean> {
+	for (const dir of getClineStorageDirs(home)) {
+		try {
+			await access(join(dir, "state", "taskHistory.json"));
+			return true;
+		} catch {
+			// try next flavor
+		}
+	}
+	return false;
+}

--- a/cli/src/core/ClineSessionDiscoverer.test.ts
+++ b/cli/src/core/ClineSessionDiscoverer.test.ts
@@ -1,0 +1,78 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { discoverClineSessions, scanClineSessions } from "./ClineSessionDiscoverer.js";
+
+async function writeHistory(storageDir: string, entries: object[]): Promise<void> {
+	const stateDir = join(storageDir, "state");
+	await mkdir(stateDir, { recursive: true });
+	await writeFile(join(stateDir, "taskHistory.json"), JSON.stringify(entries), "utf8");
+}
+
+describe("scanClineSessions", () => {
+	let sd: string;
+	const project = "/tmp/proj-a";
+	beforeEach(async () => {
+		sd = await mkdtemp(join(tmpdir(), "cline-ext-disc-"));
+	});
+	afterEach(async () => {
+		await rm(sd, { recursive: true, force: true });
+	});
+
+	it("empty when no flavor has history (ENOENT ignored, no error)", async () => {
+		const r = await scanClineSessions(project, [join(sd, "flavorX")]);
+		expect(r).toEqual({ sessions: [] });
+	});
+
+	it("attributes by cwdOnTaskInitialization, sets source/title/transcriptPath", async () => {
+		await writeHistory(sd, [
+			{ id: "t1", ts: Date.now(), task: "查看分支", cwdOnTaskInitialization: project },
+			{ id: "t2", ts: Date.now(), task: "other", cwdOnTaskInitialization: "/tmp/other" },
+		]);
+		const r = await scanClineSessions(project, [sd]);
+		expect(r.sessions).toHaveLength(1);
+		expect(r.sessions[0]).toMatchObject({ sessionId: "t1", source: "cline", title: "查看分支" });
+		expect(r.sessions[0].transcriptPath).toBe(join(sd, "tasks", "t1", "api_conversation_history.json"));
+	});
+
+	it("merges across flavors; reports error on corrupt history", async () => {
+		await writeHistory(sd, [{ id: "t1", ts: Date.now(), cwdOnTaskInitialization: project }]);
+		const bad = await mkdtemp(join(tmpdir(), "cline-bad-"));
+		await mkdir(join(bad, "state"), { recursive: true });
+		await writeFile(join(bad, "state", "taskHistory.json"), "{ not array", "utf8");
+		const r = await scanClineSessions(project, [sd, bad]);
+		expect(r.sessions.map((s) => s.sessionId)).toEqual(["t1"]);
+		expect(r.error?.kind).toBe("parse");
+		await rm(bad, { recursive: true, force: true });
+	});
+
+	it("discoverClineSessions strips error channel", async () => {
+		expect(Array.isArray(await discoverClineSessions(project))).toBe(true);
+	});
+
+	it("skips sessions older than 48h, and entries lacking a numeric ts", async () => {
+		const now = Date.now();
+		const oldTs = now - 49 * 60 * 60 * 1000; // 49 hours ago
+		const recentTs = now - 24 * 60 * 60 * 1000; // 24 hours ago
+		await writeHistory(sd, [
+			{ id: "t1", ts: oldTs, task: "old", cwdOnTaskInitialization: project },
+			{ id: "t2", ts: recentTs, task: "recent", cwdOnTaskInitialization: project },
+			{ id: "t3", task: "no-ts", cwdOnTaskInitialization: project }, // missing ts → treated as stale
+		]);
+		const r = await scanClineSessions(project, [sd]);
+		expect(r.sessions.map((s) => s.sessionId)).toEqual(["t2"]);
+	});
+
+	it("reports a fs-kind error (not parse) when the history path is unreadable", async () => {
+		// Make taskHistory.json a directory so readFile fails with EISDIR on every
+		// platform — a filesystem error, not a JSON SyntaxError. (Making `state` a
+		// file instead yields ENOTDIR on POSIX but ENOENT on Windows, and ENOENT is
+		// treated as "no history" — so that shape can't assert an fs error
+		// cross-platform.)
+		await mkdir(join(sd, "state", "taskHistory.json"), { recursive: true });
+		const r = await scanClineSessions(project, [sd]);
+		expect(r.sessions).toEqual([]);
+		expect(r.error?.kind).toBe("fs");
+	});
+});

--- a/cli/src/core/ClineSessionDiscoverer.ts
+++ b/cli/src/core/ClineSessionDiscoverer.ts
@@ -1,0 +1,83 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createLogger } from "../Logger.js";
+import type { SessionInfo } from "../Types.js";
+import { getClineStorageDirs } from "./ClineDetector.js";
+import type { ClineScanError } from "./ClineTranscriptShared.js";
+import { normalizePathForCompare } from "./PathUtils.js";
+
+const log = createLogger("ClineDiscoverer");
+const SESSION_STALE_MS = 48 * 60 * 60 * 1000;
+
+export type { ClineScanError };
+
+export interface ClineScanResult {
+	readonly sessions: ReadonlyArray<SessionInfo>;
+	readonly error?: ClineScanError;
+}
+
+interface TaskHistoryEntry {
+	readonly id?: string;
+	readonly ts?: number;
+	readonly task?: string;
+	readonly cwdOnTaskInitialization?: string;
+}
+
+async function scanFlavor(storageDir: string, target: string, cutoffMs: number): Promise<SessionInfo[]> {
+	const historyPath = join(storageDir, "state", "taskHistory.json");
+	let entries: TaskHistoryEntry[];
+	try {
+		const parsed = JSON.parse(await readFile(historyPath, "utf8")) as unknown;
+		entries = Array.isArray(parsed) ? (parsed as TaskHistoryEntry[]) : [];
+	} catch (error: unknown) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+		throw error;
+	}
+	const out: SessionInfo[] = [];
+	for (const e of entries) {
+		if (typeof e.id !== "string" || typeof e.cwdOnTaskInitialization !== "string") continue;
+		if (normalizePathForCompare(e.cwdOnTaskInitialization) !== target) continue;
+		// `ts` is the task's updatedAt (always present in real taskHistory). Require
+		// it: an entry without a numeric ts has no basis to be judged fresh, so treat
+		// it as stale rather than surfacing it with a fabricated `Date.now()` stamp.
+		if (typeof e.ts !== "number" || e.ts < cutoffMs) continue;
+		const title = e.task?.trim();
+		out.push({
+			sessionId: e.id,
+			transcriptPath: join(storageDir, "tasks", e.id, "api_conversation_history.json"),
+			updatedAt: new Date(e.ts).toISOString(),
+			source: "cline",
+			...(title ? { title } : {}),
+		});
+	}
+	return out;
+}
+
+export async function scanClineSessions(
+	projectDir: string,
+	storageDirs: string[] = getClineStorageDirs(),
+): Promise<ClineScanResult> {
+	const target = normalizePathForCompare(projectDir);
+	const cutoffMs = Date.now() - SESSION_STALE_MS;
+	const sessions: SessionInfo[] = [];
+	let error: ClineScanError | undefined;
+	for (const dir of storageDirs) {
+		try {
+			sessions.push(...(await scanFlavor(dir, target, cutoffMs)));
+		} catch (err: unknown) {
+			log.warn("Cline flavor scan failed at %s: %s", dir, (err as Error).message);
+			// Malformed taskHistory.json throws a SyntaxError (parse); anything else
+			// reaching here is a filesystem error (e.g. EACCES) — don't mislabel it.
+			const kind = err instanceof SyntaxError ? "parse" : "fs";
+			error = error ?? { kind, message: (err as Error).message };
+		}
+	}
+	return error ? { sessions, error } : { sessions };
+}
+
+/** QueueWorker wrapper — strips the error channel. */
+export async function discoverClineSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
+	const { sessions, error } = await scanClineSessions(projectDir);
+	if (error) log.warn("Cline scan error (%s): %s", error.kind, error.message);
+	return sessions;
+}

--- a/cli/src/core/ClineTranscriptReader.test.ts
+++ b/cli/src/core/ClineTranscriptReader.test.ts
@@ -1,0 +1,141 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readClineTranscript } from "./ClineTranscriptReader.js";
+
+// Block structure captured from a real Cline VS Code extension task on
+// 2026-07-18 (api_conversation_history.json); paths/timestamps sanitized.
+// role:"user" turns carry a <task>/<feedback> wrapper plus Cline-injected
+// scaffolding (# task_progress boilerplate, <environment_details>, and tool
+// results echoed as plain text) that must NOT be attributed to the human.
+const FIXTURE = [
+	{
+		role: "user",
+		content: [
+			{ type: "text", text: "<task>\n查看当前分支\n</task>" },
+			{ type: "text", text: "# task_progress RECOMMENDED\n\nWhen starting a new task, include a todo list…" },
+			{
+				type: "text",
+				text: "<environment_details>\n# VS Code Open Tabs\nsrc/app.ts\n\n# Current Time\n2026/7/18\n</environment_details>",
+			},
+		],
+		ts: 1000,
+	},
+	{
+		role: "assistant",
+		content: [
+			{ type: "thinking", text: "" },
+			{
+				type: "text",
+				text: "<execute_command>\n<command>git branch --show-current</command>\n</execute_command>",
+			},
+		],
+		ts: 2000,
+	},
+	{
+		role: "user",
+		content: [
+			{
+				type: "text",
+				text: "[execute_command for 'git branch --show-current'] Result:\nCommand executed.\nOutput:\nmain",
+			},
+			{ type: "text", text: "<environment_details>\n# Current Time\n2026/7/18\n</environment_details>" },
+		],
+		ts: 3000,
+	},
+	{
+		role: "assistant",
+		content: [{ type: "text", text: "当前分支是 `main`" }],
+		ts: 4000,
+	},
+];
+
+describe("readClineTranscript", () => {
+	let dir: string;
+	let path: string;
+	beforeEach(async () => {
+		dir = await mkdtemp(join(tmpdir(), "cline-ext-rd-"));
+		path = join(dir, "api_conversation_history.json");
+		await writeFile(path, JSON.stringify(FIXTURE), "utf8");
+	});
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("unwraps <task>, strips env/boilerplate, drops tool-result-as-user, merges assistant", async () => {
+		const r = await readClineTranscript(path);
+		// msg0 → "查看当前分支" (task unwrapped, boilerplate + env dropped);
+		// msg2 → "" (tool-result echo + env) → dropped;
+		// msg1 + msg3 assistant collapse into one merged entry.
+		expect(r.entries).toEqual([
+			{ role: "human", content: "查看当前分支", timestamp: new Date(1000).toISOString() },
+			{
+				role: "assistant",
+				content:
+					"<execute_command>\n<command>git branch --show-current</command>\n</execute_command>\n\n当前分支是 `main`",
+				timestamp: new Date(2000).toISOString(),
+			},
+		]);
+		expect(r.newCursor.lineNumber).toBe(4);
+	});
+
+	it("drops native tool_use / tool_result blocks (Anthropic-family models)", async () => {
+		// Anthropic-family models emit native tool_use/tool_result blocks instead
+		// of XML-in-text; tool output lands under role "user" as a tool_result
+		// block. textBlocks keeps only `text`, so neither surfaces as an entry —
+		// only the human prose and the assistant's own text remain.
+		const native = [
+			{ role: "user", content: [{ type: "text", text: "<task>\nlist files\n</task>" }], ts: 1000 },
+			{
+				role: "assistant",
+				content: [
+					{ type: "text", text: "Listing now" },
+					{ type: "tool_use", id: "c1", name: "run_commands", input: { commands: ["ls"] } },
+				],
+				ts: 2000,
+			},
+			{
+				role: "user",
+				content: [{ type: "tool_result", tool_use_id: "c1", content: [{ type: "text", text: "a.ts\nb.ts" }] }],
+				ts: 3000,
+			},
+			{ role: "assistant", content: [{ type: "text", text: "Two files." }], ts: 4000 },
+		];
+		await writeFile(path, JSON.stringify(native), "utf8");
+		const r = await readClineTranscript(path);
+		// tool_use (msg1) + tool_result (msg2) blocks dropped; assistant msg1+msg3
+		// collapse (the empty tool_result turn is skipped, not a role boundary).
+		expect(r.entries).toEqual([
+			{ role: "human", content: "list files", timestamp: new Date(1000).toISOString() },
+			{ role: "assistant", content: "Listing now\n\nTwo files.", timestamp: new Date(2000).toISOString() },
+		]);
+	});
+
+	it("unwraps <feedback> and keeps plain human text as-is", async () => {
+		const fb = [
+			{ role: "user", content: [{ type: "text", text: "<feedback>\ntry again\n</feedback>" }], ts: 1000 },
+			{ role: "user", content: [{ type: "text", text: "plain follow-up" }], ts: 2000 },
+		];
+		await writeFile(path, JSON.stringify(fb), "utf8");
+		const r = await readClineTranscript(path);
+		expect(r.entries).toEqual([
+			{ role: "human", content: "try again\n\nplain follow-up", timestamp: new Date(1000).toISOString() },
+		]);
+	});
+
+	it("honors cursor + beforeTimestamp", async () => {
+		const r = await readClineTranscript(path, { transcriptPath: path, lineNumber: 3, updatedAt: "" });
+		expect(r.entries).toEqual([
+			{ role: "assistant", content: "当前分支是 `main`", timestamp: new Date(4000).toISOString() },
+		]);
+		const cut = await readClineTranscript(path, null, new Date(1500).toISOString());
+		expect(cut.entries.map((e) => e.role)).toEqual(["human"]);
+		expect(cut.newCursor.lineNumber).toBe(1);
+	});
+
+	it("empty on bad file", async () => {
+		const r = await readClineTranscript(join(dir, "nope.json"));
+		expect(r.entries).toEqual([]);
+	});
+});

--- a/cli/src/core/ClineTranscriptReader.ts
+++ b/cli/src/core/ClineTranscriptReader.ts
@@ -1,0 +1,86 @@
+import { readFile } from "node:fs/promises";
+import { createLogger } from "../Logger.js";
+import type { TranscriptCursor, TranscriptReadResult } from "../Types.js";
+import {
+	buildClineReadResult,
+	emptyClineReadResult,
+	mapClineRole,
+	type NormalizedMessage,
+} from "./ClineTranscriptShared.js";
+
+const log = createLogger("ClineReader");
+
+interface AnthropicBlock {
+	readonly type: string;
+	readonly text?: string;
+}
+interface ExtMessage {
+	readonly role?: string;
+	readonly content?: ReadonlyArray<AnthropicBlock> | string;
+	readonly ts?: number;
+}
+
+// Cline injects non-human scaffolding into `role:"user"` messages of
+// api_conversation_history.json (verified against real captured data 2026-07-18):
+//   - a `<environment_details>…</environment_details>` block (open tabs, file
+//     tree, timestamps) — pure context, multi-KB, never human-authored;
+//   - a `# task_progress RECOMMENDED …` boilerplate block on the first turn;
+//   - tool results echoed as plain text blocks like `[execute_command …] Result:`
+//     (Cline replays the API conversation, so tool output lands under role "user").
+// Real human text is wrapped in `<task>…</task>` (first turn) or `<feedback>…</feedback>`.
+// Without stripping, the ~6-char task drowns in ~7 KB of scaffolding and tool
+// output is mis-attributed as human speech. Assistant text is kept raw (it may
+// carry XML-in-text tool calls from non-Anthropic providers — degrade gracefully).
+const ENV_DETAILS_RE = /<environment_details>[\s\S]*?<\/environment_details>/gi;
+const TASK_RE = /<task>([\s\S]*?)<\/task>/i;
+const FEEDBACK_RE = /<feedback>([\s\S]*?)<\/feedback>/i;
+const TASK_PROGRESS_BOILERPLATE_RE = /^#\s*task_progress\b/i;
+const TOOL_RESULT_RE = /^\[[^\]\n]+\]\s+Result:/;
+
+/** Reduce one raw text block from a user turn to its human-authored content ("" = drop). */
+function normalizeUserBlock(text: string): string {
+	const stripped = text.replace(ENV_DETAILS_RE, "").trim();
+	if (stripped.length === 0) return "";
+	if (TASK_PROGRESS_BOILERPLATE_RE.test(stripped) || TOOL_RESULT_RE.test(stripped)) return "";
+	const task = TASK_RE.exec(stripped);
+	if (task) return task[1].trim();
+	const feedback = FEEDBACK_RE.exec(stripped);
+	if (feedback) return feedback[1].trim();
+	return stripped;
+}
+
+/** Collect the `text` blocks of a message (string content counts as a single block). */
+function textBlocks(content: ExtMessage["content"]): string[] {
+	if (typeof content === "string") return [content];
+	const parts: string[] = [];
+	for (const block of content ?? []) {
+		if (block.type === "text" && typeof block.text === "string") parts.push(block.text);
+	}
+	return parts;
+}
+
+function extractText(msg: ExtMessage, role: NormalizedMessage["role"]): string {
+	const blocks = textBlocks(msg.content);
+	const kept = role === "human" ? blocks.map(normalizeUserBlock).filter((t) => t.length > 0) : blocks;
+	return kept.join("\n").trim();
+}
+
+export async function readClineTranscript(
+	transcriptPath: string,
+	cursor?: TranscriptCursor | null,
+	beforeTimestamp?: string,
+): Promise<TranscriptReadResult> {
+	let raw: ExtMessage[];
+	try {
+		const parsed = JSON.parse(await readFile(transcriptPath, "utf8")) as unknown;
+		raw = Array.isArray(parsed) ? (parsed as ExtMessage[]) : [];
+	} catch (error: unknown) {
+		log.error("Failed to read Cline transcript %s: %s", transcriptPath, (error as Error).message);
+		return emptyClineReadResult(transcriptPath, cursor);
+	}
+	const messages: NormalizedMessage[] = raw.map((msg) => {
+		const role = mapClineRole(msg.role);
+		return { role, content: extractText(msg, role), ts: msg.ts };
+	});
+	return buildClineReadResult(transcriptPath, messages, cursor, beforeTimestamp);
+}

--- a/cli/src/core/ClineTranscriptShared.test.ts
+++ b/cli/src/core/ClineTranscriptShared.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildClineReadResult,
+	emptyClineReadResult,
+	mapClineRole,
+	type NormalizedMessage,
+} from "./ClineTranscriptShared.js";
+
+const N = (role: string | undefined, content: string, ts?: number): NormalizedMessage => ({
+	role: mapClineRole(role),
+	content,
+	ts,
+});
+
+describe("mapClineRole", () => {
+	it("maps user→human, assistant→assistant, else undefined", () => {
+		expect(mapClineRole("user")).toBe("human");
+		expect(mapClineRole("assistant")).toBe("assistant");
+		expect(mapClineRole("system")).toBeUndefined();
+		expect(mapClineRole(undefined)).toBeUndefined();
+	});
+});
+
+describe("buildClineReadResult", () => {
+	const msgs = [N("user", "hi", 1000), N("assistant", "a", 2000), N("assistant", "b", 3000), N("system", "x", 4000)];
+
+	it("merges same-role, drops empty/unknown, advances cursor to end without beforeTimestamp", () => {
+		const r = buildClineReadResult("p", msgs, null, undefined);
+		expect(r.entries).toEqual([
+			{ role: "human", content: "hi", timestamp: new Date(1000).toISOString() },
+			{ role: "assistant", content: "a\n\nb", timestamp: new Date(2000).toISOString() },
+		]);
+		expect(r.newCursor.lineNumber).toBe(4);
+		expect(r.totalLinesRead).toBe(4);
+	});
+
+	it("resumes from cursor index", () => {
+		const r = buildClineReadResult("p", msgs, { transcriptPath: "p", lineNumber: 2, updatedAt: "" }, undefined);
+		expect(r.entries).toEqual([{ role: "assistant", content: "b", timestamp: new Date(3000).toISOString() }]);
+		expect(r.totalLinesRead).toBe(2);
+	});
+
+	it("beforeTimestamp stops at cutoff, cursor = last consumed", () => {
+		const r = buildClineReadResult("p", msgs, null, new Date(2000).toISOString());
+		expect(r.entries.map((e) => e.role)).toEqual(["human", "assistant"]);
+		expect(r.newCursor.lineNumber).toBe(2); // msg[2] ts 3000 > cutoff → break
+	});
+
+	it("skips empty content but still advances consumed index", () => {
+		const r = buildClineReadResult("p", [N("user", "", 1000), N("assistant", "hi", 2000)], null, undefined);
+		expect(r.entries).toEqual([{ role: "assistant", content: "hi", timestamp: new Date(2000).toISOString() }]);
+		expect(r.newCursor.lineNumber).toBe(2);
+	});
+
+	it("omits timestamp field when ts is undefined", () => {
+		const r = buildClineReadResult("p", [N("user", "no ts", undefined)], null, undefined);
+		expect(r.entries).toHaveLength(1);
+		// Should have no timestamp field
+		expect(r.entries[0]).toEqual({ role: "human", content: "no ts" });
+		expect("timestamp" in r.entries[0]).toBe(false);
+	});
+});
+
+describe("emptyClineReadResult", () => {
+	it("preserves cursor index", () => {
+		const r = emptyClineReadResult("p", { transcriptPath: "p", lineNumber: 7, updatedAt: "" });
+		expect(r).toMatchObject({ entries: [], totalLinesRead: 0, newCursor: { lineNumber: 7 } });
+	});
+});

--- a/cli/src/core/ClineTranscriptShared.ts
+++ b/cli/src/core/ClineTranscriptShared.ts
@@ -1,0 +1,69 @@
+import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
+import { mergeConsecutiveEntries } from "./TranscriptReader.js";
+
+/** Structured scan error shared by the Cline CLI + extension sources (non-SQLite). */
+export interface ClineScanError {
+	readonly kind: "parse" | "fs" | "schema" | "unknown";
+	readonly message: string;
+}
+
+/** A source message after file-shape + text extraction has been normalized away. */
+export interface NormalizedMessage {
+	readonly role: "human" | "assistant" | undefined;
+	readonly content: string;
+	readonly ts?: number;
+}
+
+/** Map a raw Cline role string to a TranscriptEntry role (unknown → undefined → dropped). */
+export function mapClineRole(role: string | undefined): "human" | "assistant" | undefined {
+	if (role === "assistant") return "assistant";
+	if (role === "user") return "human";
+	return undefined;
+}
+
+/**
+ * Shared read logic for both Cline sources. `messages` are already normalized
+ * (role mapped, text extracted, `<user_input>` unwrapped by the caller as needed).
+ * Cursor.lineNumber is repurposed as a message index. When `beforeTimestamp` is
+ * set, stops at the first message past the cutoff and advances the cursor only to
+ * the last consumed index (commit-attribution mode); otherwise advances to end.
+ */
+export function buildClineReadResult(
+	transcriptPath: string,
+	messages: ReadonlyArray<NormalizedMessage>,
+	cursor: TranscriptCursor | null | undefined,
+	beforeTimestamp: string | undefined,
+): TranscriptReadResult {
+	const startIndex = cursor?.lineNumber ?? 0;
+	const beforeMs = beforeTimestamp ? Date.parse(beforeTimestamp) : undefined;
+
+	const rawEntries: TranscriptEntry[] = [];
+	let lastConsumedIndex = startIndex;
+	for (let i = startIndex; i < messages.length; i++) {
+		const msg = messages[i];
+		if (beforeMs !== undefined && typeof msg.ts === "number" && msg.ts > beforeMs) break;
+		lastConsumedIndex = i + 1;
+		if (msg.role === undefined || msg.content.length === 0) continue;
+		const timestamp = typeof msg.ts === "number" ? new Date(msg.ts).toISOString() : undefined;
+		rawEntries.push(
+			timestamp ? { role: msg.role, content: msg.content, timestamp } : { role: msg.role, content: msg.content },
+		);
+	}
+
+	const entries = mergeConsecutiveEntries(rawEntries);
+	const newCursor: TranscriptCursor = {
+		transcriptPath,
+		lineNumber: beforeTimestamp ? lastConsumedIndex : messages.length,
+		updatedAt: new Date().toISOString(),
+	};
+	return { entries, newCursor, totalLinesRead: lastConsumedIndex - startIndex };
+}
+
+/** Empty result preserving the caller's cursor index (used on unreadable file). */
+export function emptyClineReadResult(transcriptPath: string, cursor?: TranscriptCursor | null): TranscriptReadResult {
+	return {
+		entries: [],
+		newCursor: { transcriptPath, lineNumber: cursor?.lineNumber ?? 0, updatedAt: new Date().toISOString() },
+		totalLinesRead: 0,
+	};
+}

--- a/cli/src/core/SessionTitleResolver.test.ts
+++ b/cli/src/core/SessionTitleResolver.test.ts
@@ -21,8 +21,8 @@ describe("resolveSessionTitle", () => {
 		vi.mocked(readFirstUserMessageTitle).mockReset();
 	});
 
-	it("uses SessionInfo.title when present (opencode/cursor/copilot)", async () => {
-		for (const source of ["opencode", "cursor", "copilot"] as const) {
+	it("uses SessionInfo.title when present (opencode/cursor/copilot/cline/cline-cli)", async () => {
+		for (const source of ["opencode", "cursor", "copilot", "cline", "cline-cli"] as const) {
 			const result = await resolveSessionTitle({
 				sessionId: "s1",
 				transcriptPath: "/tmp/x",

--- a/cli/src/core/SessionTitleResolver.ts
+++ b/cli/src/core/SessionTitleResolver.ts
@@ -32,6 +32,8 @@ const PARSE_LINE: Record<TranscriptSource, (line: string) => string | undefined>
 	cursor: parseCursorUserLine,
 	copilot: parseCopilotUserLine,
 	"copilot-chat": parseCopilotChatUserLine,
+	cline: parseClineUserLine,
+	"cline-cli": parseClineCliUserLine,
 };
 
 /**
@@ -191,6 +193,16 @@ function parseCopilotChatUserLine(line: string): string | undefined {
 		}
 	}
 
+	return undefined;
+}
+
+function parseClineUserLine(_line: string): string | undefined {
+	// Cline extension sessions carry SessionInfo.title from taskHistory.task.
+	return undefined;
+}
+
+function parseClineCliUserLine(_line: string): string | undefined {
+	// Cline CLI sessions carry SessionInfo.title from sidecar metadata.title.
 	return undefined;
 }
 

--- a/cli/src/core/SessionTracker.test.ts
+++ b/cli/src/core/SessionTracker.test.ts
@@ -1607,6 +1607,25 @@ describe("SessionTracker", () => {
 			const filtered = filterSessionsByEnabledIntegrations(sessions, {});
 			expect(filtered.map((s) => s.sessionId)).toEqual(["b"]);
 		});
+
+		it("clineEnabled:false drops cline + cline-cli", () => {
+			const sessions: ReadonlyArray<SessionInfo> = [
+				{ sessionId: "a", transcriptPath: "/a", updatedAt: "2026-05-06T00:00:00Z", source: "cline" },
+				{ sessionId: "b", transcriptPath: "/b", updatedAt: "2026-05-06T00:00:00Z", source: "cline-cli" },
+				{ sessionId: "c", transcriptPath: "/c", updatedAt: "2026-05-06T00:00:00Z", source: "claude" },
+			];
+			const filtered = filterSessionsByEnabledIntegrations(sessions, { clineEnabled: false });
+			expect(filtered.map((s) => s.source)).toEqual(["claude"]);
+		});
+
+		it("includes cline + cline-cli sessions when clineEnabled is unset (auto-detect)", () => {
+			const sessions: ReadonlyArray<SessionInfo> = [
+				{ sessionId: "a", transcriptPath: "/a", updatedAt: "2026-05-06T00:00:00Z", source: "cline" },
+				{ sessionId: "b", transcriptPath: "/b", updatedAt: "2026-05-06T00:00:00Z", source: "cline-cli" },
+			];
+			const filtered = filterSessionsByEnabledIntegrations(sessions, {});
+			expect(filtered.map((s) => s.sessionId)).toEqual(["a", "b"]);
+		});
 	});
 
 	// ── git operation queue ────────────────────────────────────────────────

--- a/cli/src/core/SessionTracker.ts
+++ b/cli/src/core/SessionTracker.ts
@@ -182,6 +182,9 @@ export function filterSessionsByEnabledIntegrations(
 	if (config.copilotEnabled === false) {
 		filtered = filtered.filter((s) => s.source !== "copilot" && s.source !== "copilot-chat");
 	}
+	if (config.clineEnabled === false) {
+		filtered = filtered.filter((s) => s.source !== "cline" && s.source !== "cline-cli");
+	}
 	return filtered;
 }
 

--- a/cli/src/core/TranscriptLoader.test.ts
+++ b/cli/src/core/TranscriptLoader.test.ts
@@ -17,7 +17,15 @@ vi.mock("./CursorTranscriptReader.js", () => ({
 vi.mock("./CopilotTranscriptReader.js", () => ({
 	readCopilotTranscript: vi.fn(),
 }));
+vi.mock("./ClineTranscriptReader.js", () => ({
+	readClineTranscript: vi.fn(),
+}));
+vi.mock("./ClineCliTranscriptReader.js", () => ({
+	readClineCliTranscript: vi.fn(),
+}));
 
+import { readClineCliTranscript } from "./ClineCliTranscriptReader.js";
+import { readClineTranscript } from "./ClineTranscriptReader.js";
 import { readCopilotTranscript } from "./CopilotTranscriptReader.js";
 import { readCursorTranscript } from "./CursorTranscriptReader.js";
 import { readOpenCodeTranscript } from "./OpenCodeTranscriptReader.js";
@@ -30,6 +38,8 @@ describe("loadTranscript", () => {
 		vi.mocked(readOpenCodeTranscript).mockReset();
 		vi.mocked(readCursorTranscript).mockReset();
 		vi.mocked(readCopilotTranscript).mockReset();
+		vi.mocked(readClineTranscript).mockReset();
+		vi.mocked(readClineCliTranscript).mockReset();
 	});
 	afterEach(() => {
 		rmSync(dir, { recursive: true, force: true });
@@ -186,6 +196,36 @@ describe("loadTranscript", () => {
 		expect(result).toEqual([{ role: "assistant", content: "copilot reply" }]);
 	});
 
+	it("dispatches cline source to readClineTranscript with the synthetic path", async () => {
+		vi.mocked(readClineTranscript).mockResolvedValueOnce({
+			entries: [{ role: "human", content: "cline hi" }],
+			newCursor: {
+				transcriptPath: "/cline/task-1/ui_messages.json",
+				lineNumber: 1,
+				updatedAt: "2026-05-17T00:00:00Z",
+			},
+			totalLinesRead: 1,
+		});
+		const result = await loadTranscript({ source: "cline", transcriptPath: "/cline/task-1/ui_messages.json" });
+		expect(readClineTranscript).toHaveBeenCalledWith("/cline/task-1/ui_messages.json");
+		expect(result).toEqual([{ role: "human", content: "cline hi" }]);
+	});
+
+	it("dispatches cline-cli source to readClineCliTranscript with the synthetic path", async () => {
+		vi.mocked(readClineCliTranscript).mockResolvedValueOnce({
+			entries: [{ role: "assistant", content: "cline-cli reply" }],
+			newCursor: {
+				transcriptPath: "/cline-cli/session-1.json",
+				lineNumber: 1,
+				updatedAt: "2026-05-17T00:00:00Z",
+			},
+			totalLinesRead: 1,
+		});
+		const result = await loadTranscript({ source: "cline-cli", transcriptPath: "/cline-cli/session-1.json" });
+		expect(readClineCliTranscript).toHaveBeenCalledWith("/cline-cli/session-1.json");
+		expect(result).toEqual([{ role: "assistant", content: "cline-cli reply" }]);
+	});
+
 	// Each sqlite-backed reader's catch branch — proves loader errors degrade
 	// to "" instead of bubbling out to the panel.
 	it("returns [] when readOpenCodeTranscript throws", async () => {
@@ -203,6 +243,18 @@ describe("loadTranscript", () => {
 	it("returns [] when readCopilotTranscript throws", async () => {
 		vi.mocked(readCopilotTranscript).mockRejectedValueOnce(new Error("schema drift"));
 		const result = await loadTranscript({ source: "copilot", transcriptPath: "/session-store.db#x" });
+		expect(result).toEqual([]);
+	});
+
+	it("returns [] when readClineTranscript throws", async () => {
+		vi.mocked(readClineTranscript).mockRejectedValueOnce(new Error("parse error"));
+		const result = await loadTranscript({ source: "cline", transcriptPath: "/cline/task-x/ui_messages.json" });
+		expect(result).toEqual([]);
+	});
+
+	it("returns [] when readClineCliTranscript throws", async () => {
+		vi.mocked(readClineCliTranscript).mockRejectedValueOnce(new Error("parse error"));
+		const result = await loadTranscript({ source: "cline-cli", transcriptPath: "/cline-cli/session-x.json" });
 		expect(result).toEqual([]);
 	});
 
@@ -232,6 +284,18 @@ describe("loadTranscript", () => {
 	it("returns [] silently when readCopilotTranscript throws ENOENT (no warn branch)", async () => {
 		vi.mocked(readCopilotTranscript).mockRejectedValueOnce(enoent("/missing.db"));
 		const result = await loadTranscript({ source: "copilot", transcriptPath: "/missing.db#x" });
+		expect(result).toEqual([]);
+	});
+
+	it("returns [] silently when readClineTranscript throws ENOENT (no warn branch)", async () => {
+		vi.mocked(readClineTranscript).mockRejectedValueOnce(enoent("/missing/ui_messages.json"));
+		const result = await loadTranscript({ source: "cline", transcriptPath: "/missing/ui_messages.json" });
+		expect(result).toEqual([]);
+	});
+
+	it("returns [] silently when readClineCliTranscript throws ENOENT (no warn branch)", async () => {
+		vi.mocked(readClineCliTranscript).mockRejectedValueOnce(enoent("/missing/session-x.json"));
+		const result = await loadTranscript({ source: "cline-cli", transcriptPath: "/missing/session-x.json" });
 		expect(result).toEqual([]);
 	});
 

--- a/cli/src/core/TranscriptLoader.ts
+++ b/cli/src/core/TranscriptLoader.ts
@@ -85,6 +85,25 @@ export async function loadTranscript(opts: LoadOptions): Promise<TranscriptEntry
 			return [];
 		}
 	}
+	if (opts.source === "cline") {
+		try {
+			const { readClineTranscript } = await import("./ClineTranscriptReader.js");
+			return [...(await readClineTranscript(opts.transcriptPath)).entries];
+		} catch (err) {
+			if (!isEnoent(err)) log.warn("loadTranscript (cline) failed for %s: %s", opts.transcriptPath, errMsg(err));
+			return [];
+		}
+	}
+	if (opts.source === "cline-cli") {
+		try {
+			const { readClineCliTranscript } = await import("./ClineCliTranscriptReader.js");
+			return [...(await readClineCliTranscript(opts.transcriptPath)).entries];
+		} catch (err) {
+			if (!isEnoent(err))
+				log.warn("loadTranscript (cline-cli) failed for %s: %s", opts.transcriptPath, errMsg(err));
+			return [];
+		}
+	}
 	const entries: TranscriptEntry[] = [];
 	let parseSkipped = 0;
 	try {
@@ -130,11 +149,12 @@ export async function loadTranscript(opts: LoadOptions): Promise<TranscriptEntry
 
 /**
  * Per-line JSONL parsers. Sources that own a dedicated single-artifact
- * reader (`gemini` JSON file; `opencode` / `cursor` / `copilot` SQLite DBs)
- * are intentionally absent — those are dispatched at the top of
- * `loadTranscript` before this table is consulted.
+ * reader (`gemini` JSON file; `opencode` / `cursor` / `copilot` SQLite DBs;
+ * `cline` / `cline-cli` plain-JSON files) are intentionally absent — those
+ * are dispatched at the top of `loadTranscript` before this table is
+ * consulted.
  */
-type JsonlSource = Exclude<TranscriptSource, "gemini" | "opencode" | "cursor" | "copilot">;
+type JsonlSource = Exclude<TranscriptSource, "gemini" | "opencode" | "cursor" | "copilot" | "cline" | "cline-cli">;
 const PARSERS: Record<JsonlSource, (line: string) => TranscriptEntry | undefined> = {
 	claude: parseClaude,
 	codex: parseCodex,

--- a/cli/src/core/TranscriptMessageCounter.dispatch.test.ts
+++ b/cli/src/core/TranscriptMessageCounter.dispatch.test.ts
@@ -51,6 +51,20 @@ vi.mock("./CopilotChatTranscriptReader.js", () => ({
 		totalLinesRead: 1,
 	}),
 }));
+vi.mock("./ClineTranscriptReader.js", () => ({
+	readClineTranscript: vi.fn().mockResolvedValue({
+		entries: [{ role: "human", content: "cline-payload" }],
+		newCursor: null,
+		totalLinesRead: 1,
+	}),
+}));
+vi.mock("./ClineCliTranscriptReader.js", () => ({
+	readClineCliTranscript: vi.fn().mockResolvedValue({
+		entries: [{ role: "human", content: "cline-cli-payload" }],
+		newCursor: null,
+		totalLinesRead: 1,
+	}),
+}));
 // Mock the codex path's reader so we don't need a real JSONL file for it.
 vi.mock("./TranscriptReader.js", () => ({
 	readTranscript: vi.fn().mockResolvedValue({
@@ -60,6 +74,8 @@ vi.mock("./TranscriptReader.js", () => ({
 	}),
 }));
 
+import { readClineCliTranscript } from "./ClineCliTranscriptReader.js";
+import { readClineTranscript } from "./ClineTranscriptReader.js";
 import { readCopilotChatTranscript } from "./CopilotChatTranscriptReader.js";
 import { readCopilotTranscript } from "./CopilotTranscriptReader.js";
 import { readCursorTranscript } from "./CursorTranscriptReader.js";
@@ -76,6 +92,8 @@ describe("loadUnreadMergedTranscript per-source dispatch", () => {
 		vi.mocked(readCursorTranscript).mockClear();
 		vi.mocked(readCopilotTranscript).mockClear();
 		vi.mocked(readCopilotChatTranscript).mockClear();
+		vi.mocked(readClineTranscript).mockClear();
+		vi.mocked(readClineCliTranscript).mockClear();
 		vi.mocked(readTranscript).mockClear();
 	});
 
@@ -178,6 +196,34 @@ describe("loadUnreadMergedTranscript per-source dispatch", () => {
 		// Cursor was non-null → `cursor ?? undefined` returned the cursor
 		// itself, not undefined.
 		expect(vi.mocked(readCopilotChatTranscript).mock.calls[0][1]).toBeTruthy();
+	});
+
+	it("dispatches to Cline reader for source=cline", async () => {
+		const entries = await loadUnreadMergedTranscript(
+			{
+				sessionId: "s",
+				transcriptPath: "/synthetic/cline.json",
+				updatedAt: "2026-05-15T00:00:00Z",
+				source: "cline",
+			},
+			projectDir,
+		);
+		expect(readClineTranscript).toHaveBeenCalledTimes(1);
+		expect(entries).toEqual([{ role: "human", content: "cline-payload" }]);
+	});
+
+	it("dispatches to Cline CLI reader for source=cline-cli", async () => {
+		const entries = await loadUnreadMergedTranscript(
+			{
+				sessionId: "s",
+				transcriptPath: "/synthetic/cline-cli.json",
+				updatedAt: "2026-05-15T00:00:00Z",
+				source: "cline-cli",
+			},
+			projectDir,
+		);
+		expect(readClineCliTranscript).toHaveBeenCalledTimes(1);
+		expect(entries).toEqual([{ role: "human", content: "cline-cli-payload" }]);
 	});
 
 	it("dispatches to the JSONL reader for source=codex", async () => {

--- a/cli/src/core/TranscriptMessageCounter.ts
+++ b/cli/src/core/TranscriptMessageCounter.ts
@@ -24,6 +24,8 @@
 
 import { createLogger, errMsg } from "../Logger.js";
 import type { SessionInfo, TranscriptEntry, TranscriptReadResult, TranscriptSource } from "../Types.js";
+import { readClineCliTranscript } from "./ClineCliTranscriptReader.js";
+import { readClineTranscript } from "./ClineTranscriptReader.js";
 import { applyOverlay, loadOverlay } from "./ConversationOverlayStore.js";
 import { readCopilotChatTranscript } from "./CopilotChatTranscriptReader.js";
 import { readCopilotTranscript } from "./CopilotTranscriptReader.js";
@@ -130,6 +132,10 @@ async function readUnreadTranscript(
 			return readCopilotTranscript(transcriptPath, cursor);
 		case "copilot-chat":
 			return readCopilotChatTranscript(transcriptPath, cursor ?? undefined);
+		case "cline":
+			return readClineTranscript(transcriptPath, cursor);
+		case "cline-cli":
+			return readClineCliTranscript(transcriptPath, cursor);
 		case "codex":
 			return readTranscript(transcriptPath, cursor, getParserForSource("codex"));
 		default:

--- a/cli/src/core/TranscriptSourceLabel.test.ts
+++ b/cli/src/core/TranscriptSourceLabel.test.ts
@@ -12,6 +12,8 @@ describe("transcriptSourceLabel", () => {
 		expect(transcriptSourceLabel("copilot-chat")).toBe("Copilot Chat");
 		expect(transcriptSourceLabel("gemini")).toBe("Gemini");
 		expect(transcriptSourceLabel("opencode")).toBe("OpenCode");
+		expect(transcriptSourceLabel("cline")).toBe("Cline (VS Code)");
+		expect(transcriptSourceLabel("cline-cli")).toBe("Cline CLI");
 	});
 
 	it("falls back to 'Claude' for unknown sources (matches the current webview behavior)", () => {

--- a/cli/src/core/TranscriptSourceLabel.ts
+++ b/cli/src/core/TranscriptSourceLabel.ts
@@ -21,6 +21,8 @@ export const TRANSCRIPT_SOURCE_LABELS: Readonly<Record<TranscriptSource, string>
 	"copilot-chat": "Copilot Chat",
 	gemini: "Gemini",
 	opencode: "OpenCode",
+	cline: "Cline (VS Code)",
+	"cline-cli": "Cline CLI",
 };
 
 export function transcriptSourceLabel(source: TranscriptSource | undefined): string {

--- a/cli/src/core/VscodeWorkspaceLocator.test.ts
+++ b/cli/src/core/VscodeWorkspaceLocator.test.ts
@@ -220,3 +220,11 @@ describe("findVscodeWorkspaceHash", () => {
 		expect(await findVscodeWorkspaceHash("Cursor", toNativePath("/Users/test/myproject"))).toBe("cursor1");
 	});
 });
+
+describe("ALL_VSCODE_FLAVORS", () => {
+	it("includes all supported flavors", async () => {
+		const { ALL_VSCODE_FLAVORS } = await import("./VscodeWorkspaceLocator.js");
+		expect(ALL_VSCODE_FLAVORS).toEqual(["Code", "Code - Insiders", "Cursor", "VSCodium", "Windsurf"]);
+		expect(ALL_VSCODE_FLAVORS.length).toBeGreaterThanOrEqual(5);
+	});
+});

--- a/cli/src/core/VscodeWorkspaceLocator.ts
+++ b/cli/src/core/VscodeWorkspaceLocator.ts
@@ -21,7 +21,16 @@ import { createLogger } from "../Logger.js";
 
 const log = createLogger("VscodeWorkspaceLocator");
 
-export type VscodeFlavor = "Cursor" | "Code";
+export type VscodeFlavor = "Cursor" | "Code" | "Code - Insiders" | "VSCodium" | "Windsurf";
+
+/** All VS Code-family flavors Jolli scans for extension data. Directory name == flavor string. */
+export const ALL_VSCODE_FLAVORS: ReadonlyArray<VscodeFlavor> = [
+	"Code",
+	"Code - Insiders",
+	"Cursor",
+	"VSCodium",
+	"Windsurf",
+];
 
 /**
  * Returns the VS Code-family user-data root for the current platform.

--- a/cli/src/hooks/PostCommitHook.helpers.test.ts
+++ b/cli/src/hooks/PostCommitHook.helpers.test.ts
@@ -98,6 +98,10 @@ vi.mock("node:fs", () => ({
 
 vi.mock("node:os", () => ({
 	homedir: mockHomedir,
+	// Cline detection (wired into loadSessionTranscripts) resolves VS Code flavor
+	// dirs via os.platform(); the mocked homedir points at a temp dir with no
+	// globalStorage, so isClineInstalled() returns false regardless of platform.
+	platform: () => process.platform,
 }));
 
 vi.mock("node:readline", () => ({

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -199,6 +199,43 @@ vi.mock("../core/CopilotDetector.js", () => ({
 	getCopilotDbPath: vi.fn().mockReturnValue("/mock/.copilot/session-store.db"),
 }));
 
+// Cline detectors are wired into loadSessionTranscripts; neutralize them so the
+// hook tests stay hermetic (otherwise they do real fs I/O against the dev machine
+// under fake timers and hang). Mirrors the Copilot mocks above.
+vi.mock("../core/ClineDetector.js", () => ({
+	isClineInstalled: vi.fn().mockResolvedValue(false),
+	getClineStorageDirs: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock("../core/ClineCliDetector.js", () => ({
+	isClineCliInstalled: vi.fn().mockResolvedValue(false),
+	getClineCliSessionsDir: vi.fn().mockReturnValue("/mock/.cline/data/sessions"),
+}));
+
+vi.mock("../core/ClineSessionDiscoverer.js", () => ({
+	discoverClineSessions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../core/ClineCliSessionDiscoverer.js", () => ({
+	discoverClineCliSessions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../core/ClineTranscriptReader.js", () => ({
+	readClineTranscript: vi.fn().mockResolvedValue({
+		entries: [],
+		newCursor: { transcriptPath: "", lineNumber: 0, updatedAt: "" },
+		totalLinesRead: 0,
+	}),
+}));
+
+vi.mock("../core/ClineCliTranscriptReader.js", () => ({
+	readClineCliTranscript: vi.fn().mockResolvedValue({
+		entries: [],
+		newCursor: { transcriptPath: "", lineNumber: 0, updatedAt: "" },
+		totalLinesRead: 0,
+	}),
+}));
+
 vi.mock("../core/CopilotSessionDiscoverer.js", () => ({
 	discoverCopilotSessions: vi.fn().mockResolvedValue([]),
 }));

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -338,6 +338,38 @@ vi.mock("../core/CursorTranscriptReader.js", () => ({
 	}),
 }));
 
+vi.mock("../core/ClineDetector.js", () => ({
+	isClineInstalled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../core/ClineSessionDiscoverer.js", () => ({
+	discoverClineSessions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../core/ClineTranscriptReader.js", () => ({
+	readClineTranscript: vi.fn().mockResolvedValue({
+		entries: [],
+		newCursor: { transcriptPath: "", lineNumber: 0, updatedAt: "" },
+		totalLinesRead: 0,
+	}),
+}));
+
+vi.mock("../core/ClineCliDetector.js", () => ({
+	isClineCliInstalled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../core/ClineCliSessionDiscoverer.js", () => ({
+	discoverClineCliSessions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../core/ClineCliTranscriptReader.js", () => ({
+	readClineCliTranscript: vi.fn().mockResolvedValue({
+		entries: [],
+		newCursor: { transcriptPath: "", lineNumber: 0, updatedAt: "" },
+		totalLinesRead: 0,
+	}),
+}));
+
 vi.mock("../core/CopilotDetector.js", () => ({
 	isCopilotInstalled: vi.fn().mockResolvedValue(false),
 }));
@@ -411,6 +443,12 @@ import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { isClineCliInstalled } from "../core/ClineCliDetector.js";
+import { discoverClineCliSessions } from "../core/ClineCliSessionDiscoverer.js";
+import { readClineCliTranscript } from "../core/ClineCliTranscriptReader.js";
+import { isClineInstalled } from "../core/ClineDetector.js";
+import { discoverClineSessions } from "../core/ClineSessionDiscoverer.js";
+import { readClineTranscript } from "../core/ClineTranscriptReader.js";
 import { isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
 import { clearAiSelection, readAiSelection } from "../core/CommitSelectionStore.js";
 import { assessContextRelevance, buildChangeSignal, computeChangeFingerprint } from "../core/ContextRelevance.js";
@@ -526,6 +564,10 @@ describe("QueueWorker", () => {
 		vi.mocked(isCopilotInstalled).mockResolvedValue(false);
 		vi.mocked(isCopilotChatInstalled).mockResolvedValue(false);
 		vi.mocked(discoverCopilotChatSessions).mockResolvedValue([]);
+		vi.mocked(isClineInstalled).mockResolvedValue(false);
+		vi.mocked(discoverClineSessions).mockResolvedValue([]);
+		vi.mocked(isClineCliInstalled).mockResolvedValue(false);
+		vi.mocked(discoverClineCliSessions).mockResolvedValue([]);
 		vi.mocked(buildMultiSessionContext).mockReturnValue("");
 		vi.mocked(generateSummary).mockResolvedValue({
 			transcriptEntries: 0,
@@ -1439,6 +1481,119 @@ describe("QueueWorker", () => {
 		});
 	});
 
+	describe("Cline integration", () => {
+		it("should include discovered Cline (VS Code) sessions in the pipeline when enabled", async () => {
+			const op = makeCommitOp();
+			const queueEntry = { op, filePath: "/tmp/queue/cline.json" };
+
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([queueEntry])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+
+			setupPipelineMocks();
+			vi.mocked(loadConfig).mockResolvedValue({} as Awaited<ReturnType<typeof loadConfig>>);
+			vi.mocked(isClineInstalled).mockResolvedValue(true);
+			vi.mocked(discoverClineSessions).mockResolvedValue([
+				{
+					sessionId: "cline-1",
+					transcriptPath: "/tmp/cline/task-1/ui_messages.json",
+					updatedAt: "2026-04-01T12:00:00.000Z",
+					source: "cline",
+				},
+			]);
+			vi.mocked(readClineTranscript).mockResolvedValue({
+				entries: [{ role: "human", content: "Cline context", timestamp: "2026-04-01T12:00:00.000Z" }],
+				newCursor: {
+					transcriptPath: "/tmp/cline/task-1/ui_messages.json",
+					lineNumber: 1,
+					updatedAt: "2026-04-01T12:00:00.000Z",
+				},
+				totalLinesRead: 1,
+			});
+
+			await runWorker("/test/cwd");
+
+			expect(discoverClineSessions).toHaveBeenCalledWith("/test/cwd");
+			expect(readClineTranscript).toHaveBeenCalledWith(
+				"/tmp/cline/task-1/ui_messages.json",
+				null,
+				"2026-04-01T12:00:00.000Z",
+			);
+			expect(saveCursor).toHaveBeenCalledWith(
+				expect.objectContaining({ transcriptPath: "/tmp/cline/task-1/ui_messages.json", lineNumber: 1 }),
+				"/test/cwd",
+			);
+		});
+
+		it("should include discovered Cline CLI sessions in the pipeline when enabled", async () => {
+			const op = makeCommitOp();
+			const queueEntry = { op, filePath: "/tmp/queue/cline-cli.json" };
+
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([queueEntry])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+
+			setupPipelineMocks();
+			vi.mocked(loadConfig).mockResolvedValue({} as Awaited<ReturnType<typeof loadConfig>>);
+			vi.mocked(isClineCliInstalled).mockResolvedValue(true);
+			vi.mocked(discoverClineCliSessions).mockResolvedValue([
+				{
+					sessionId: "cline-cli-1",
+					transcriptPath: "/tmp/cline-cli/session-1.json",
+					updatedAt: "2026-04-01T12:00:00.000Z",
+					source: "cline-cli",
+				},
+			]);
+			vi.mocked(readClineCliTranscript).mockResolvedValue({
+				entries: [{ role: "human", content: "Cline CLI context", timestamp: "2026-04-01T12:00:00.000Z" }],
+				newCursor: {
+					transcriptPath: "/tmp/cline-cli/session-1.json",
+					lineNumber: 1,
+					updatedAt: "2026-04-01T12:00:00.000Z",
+				},
+				totalLinesRead: 1,
+			});
+
+			await runWorker("/test/cwd");
+
+			expect(discoverClineCliSessions).toHaveBeenCalledWith("/test/cwd");
+			expect(readClineCliTranscript).toHaveBeenCalledWith(
+				"/tmp/cline-cli/session-1.json",
+				null,
+				"2026-04-01T12:00:00.000Z",
+			);
+			expect(saveCursor).toHaveBeenCalledWith(
+				expect.objectContaining({ transcriptPath: "/tmp/cline-cli/session-1.json", lineNumber: 1 }),
+				"/test/cwd",
+			);
+		});
+
+		it("skips discovery for both Cline sources when clineEnabled is explicitly false", async () => {
+			const op = makeCommitOp();
+			const queueEntry = { op, filePath: "/tmp/queue/cline-disabled.json" };
+
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([queueEntry])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+
+			setupPipelineMocks();
+			vi.mocked(loadConfig).mockResolvedValue({ clineEnabled: false } as Awaited<ReturnType<typeof loadConfig>>);
+			vi.mocked(isClineInstalled).mockResolvedValue(true);
+			vi.mocked(isClineCliInstalled).mockResolvedValue(true);
+
+			await runWorker("/test/cwd");
+
+			// clineEnabled=false short-circuits before isClineInstalled/isClineCliInstalled are consulted
+			expect(isClineInstalled).not.toHaveBeenCalled();
+			expect(discoverClineSessions).not.toHaveBeenCalled();
+			expect(isClineCliInstalled).not.toHaveBeenCalled();
+			expect(discoverClineCliSessions).not.toHaveBeenCalled();
+		});
+	});
+
 	describe("OpenCode integration", () => {
 		it("should include discovered OpenCode sessions in the pipeline when enabled", async () => {
 			const op = makeCommitOp();
@@ -1967,6 +2122,81 @@ describe("QueueWorker", () => {
 
 			expect(isCopilotChatInstalled).not.toHaveBeenCalled();
 			expect(discoverCopilotChatSessions).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("Cline integration — read failure", () => {
+		it("skips a Cline session whose transcript read throws and continues with the rest of the pipeline", async () => {
+			const op = makeCommitOp();
+			const queueEntry = { op, filePath: "/tmp/queue/cline-throws.json" };
+
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([queueEntry])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+
+			setupPipelineMocks();
+			vi.mocked(loadConfig).mockResolvedValue({} as Awaited<ReturnType<typeof loadConfig>>);
+			vi.mocked(isClineInstalled).mockResolvedValue(true);
+			vi.mocked(discoverClineSessions).mockResolvedValue([
+				{
+					sessionId: "cline-broken",
+					transcriptPath: "/cline/task-broken/ui_messages.json",
+					updatedAt: "2026-04-01T12:00:00.000Z",
+					source: "cline",
+				},
+			]);
+			vi.mocked(readClineTranscript).mockRejectedValue(new Error("Cannot read Cline session: cline-broken"));
+
+			await runWorker("/test/cwd");
+
+			expect(readClineTranscript).toHaveBeenCalledWith(
+				"/cline/task-broken/ui_messages.json",
+				null,
+				"2026-04-01T12:00:00.000Z",
+			);
+			// Pipeline still completes — the broken session was skipped, not fatal
+			expect(storeSummary).toHaveBeenCalled();
+			expect(saveCursor).not.toHaveBeenCalledWith(
+				expect.objectContaining({ transcriptPath: "/cline/task-broken/ui_messages.json" }),
+				"/test/cwd",
+			);
+		});
+
+		it("skips a Cline CLI session whose transcript read throws and continues with the rest of the pipeline", async () => {
+			const op = makeCommitOp();
+			const queueEntry = { op, filePath: "/tmp/queue/cline-cli-throws.json" };
+
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([queueEntry])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+
+			setupPipelineMocks();
+			vi.mocked(loadConfig).mockResolvedValue({} as Awaited<ReturnType<typeof loadConfig>>);
+			vi.mocked(isClineCliInstalled).mockResolvedValue(true);
+			vi.mocked(discoverClineCliSessions).mockResolvedValue([
+				{
+					sessionId: "cline-cli-broken",
+					transcriptPath: "/cline-cli/session-broken.json",
+					updatedAt: "2026-04-01T12:00:00.000Z",
+					source: "cline-cli",
+				},
+			]);
+			vi.mocked(readClineCliTranscript).mockRejectedValue(new Error("Cannot read Cline CLI session: broken"));
+
+			await runWorker("/test/cwd");
+
+			expect(readClineCliTranscript).toHaveBeenCalledWith(
+				"/cline-cli/session-broken.json",
+				null,
+				"2026-04-01T12:00:00.000Z",
+			);
+			expect(storeSummary).toHaveBeenCalled();
+			expect(saveCursor).not.toHaveBeenCalledWith(
+				expect.objectContaining({ transcriptPath: "/cline-cli/session-broken.json" }),
+				"/test/cwd",
+			);
 		});
 	});
 

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -20,6 +20,12 @@ import { createHash } from "node:crypto";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { isClineCliInstalled } from "../core/ClineCliDetector.js";
+import { discoverClineCliSessions } from "../core/ClineCliSessionDiscoverer.js";
+import { readClineCliTranscript } from "../core/ClineCliTranscriptReader.js";
+import { isClineInstalled } from "../core/ClineDetector.js";
+import { discoverClineSessions } from "../core/ClineSessionDiscoverer.js";
+import { readClineTranscript } from "../core/ClineTranscriptReader.js";
 import { discoverCodexSessions, isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
 import { clearAiSelection, conversationKey, readAiSelection, readExclusions } from "../core/CommitSelectionStore.js";
 import {
@@ -3195,6 +3201,23 @@ async function loadSessionTranscripts(
 		/* v8 ignore stop */
 	}
 
+	// Discover Cline VS Code extension sessions (plain-JSON scan across VS Code flavors).
+	if (config.clineEnabled !== false && (await isClineInstalled())) {
+		const clineSessions = await discoverClineSessions(cwd);
+		if (clineSessions.length > 0) {
+			allSessions = [...allSessions, ...clineSessions];
+			log.info("Discovered %d Cline (VS Code) session(s)", clineSessions.length);
+		}
+	}
+	// Discover Cline CLI sessions (plain-JSON scan of ~/.cline/data/sessions).
+	if (config.clineEnabled !== false && (await isClineCliInstalled())) {
+		const clineCliSessions = await discoverClineCliSessions(cwd);
+		if (clineCliSessions.length > 0) {
+			allSessions = [...allSessions, ...clineCliSessions];
+			log.info("Discovered %d Cline CLI session(s)", clineCliSessions.length);
+		}
+	}
+
 	if (allSessions.length === 0) {
 		log.info("No active sessions found — will infer topics from diff if available");
 	}
@@ -3411,7 +3434,7 @@ async function readAllTranscripts(
 			track("ai_source_detected", { source });
 		}
 
-		// Gemini, OpenCode, Cursor, and Copilot use dedicated readers (not JSONL line-based parsing).
+		// Gemini, OpenCode, Cursor, Copilot, and Cline use dedicated readers (not JSONL line-based parsing).
 		// Every reader is wrapped in try/catch + `continue` so one bad session never abandons the
 		// rest of the batch. SQLite-backed readers (opencode/cursor/copilot) fail on transient
 		// lock, corruption, schema drift, or DB disappearing between scan and read. The JSONL
@@ -3454,6 +3477,20 @@ async function readAllTranscripts(
 				result = await readCopilotChatTranscript(session.transcriptPath, cursor ?? undefined, beforeTimestamp);
 			} catch (error: unknown) {
 				log.error("Skipping Copilot Chat session %s: %s", session.sessionId, (error as Error).message);
+				continue;
+			}
+		} else if (source === "cline") {
+			try {
+				result = await readClineTranscript(session.transcriptPath, cursor, beforeTimestamp);
+			} catch (error: unknown) {
+				log.error("Skipping Cline session %s: %s", session.sessionId, (error as Error).message);
+				continue;
+			}
+		} else if (source === "cline-cli") {
+			try {
+				result = await readClineCliTranscript(session.transcriptPath, cursor, beforeTimestamp);
+			} catch (error: unknown) {
+				log.error("Skipping Cline CLI session %s: %s", session.sessionId, (error as Error).message);
 				continue;
 			}
 		} else {

--- a/cli/src/install/Installer.test.ts
+++ b/cli/src/install/Installer.test.ts
@@ -99,6 +99,28 @@ vi.mock("../core/CopilotChatSessionDiscoverer.js", () => ({
 	discoverCopilotChatSessions: vi.fn().mockResolvedValue([]),
 }));
 
+// Mock ClineDetector for status/install checks
+vi.mock("../core/ClineDetector.js", () => ({
+	isClineInstalled: vi.fn().mockResolvedValue(false),
+}));
+
+// Mock ClineCliDetector for status/install checks
+vi.mock("../core/ClineCliDetector.js", () => ({
+	isClineCliInstalled: vi.fn().mockResolvedValue(false),
+}));
+
+// Mock ClineSessionDiscoverer for status/install checks
+vi.mock("../core/ClineSessionDiscoverer.js", () => ({
+	scanClineSessions: vi.fn().mockResolvedValue({ sessions: [] }),
+	discoverClineSessions: vi.fn().mockResolvedValue([]),
+}));
+
+// Mock ClineCliSessionDiscoverer for status/install checks
+vi.mock("../core/ClineCliSessionDiscoverer.js", () => ({
+	scanClineCliSessions: vi.fn().mockResolvedValue({ sessions: [] }),
+	discoverClineCliSessions: vi.fn().mockResolvedValue([]),
+}));
+
 // Mock SchemaV5Migration so install() doesn't spawn real git fast-import on
 // every test. `install()` both statically imports `readSchemaV5State` (for
 // status) and dynamically imports `migrateSchemaToV5` (for the auto-upgrade
@@ -213,6 +235,14 @@ describe("Installer", () => {
 		const { scanCopilotChatSessions } = await import("../core/CopilotChatSessionDiscoverer.js");
 		vi.mocked(isCopilotChatInstalled).mockResolvedValue(false);
 		vi.mocked(scanCopilotChatSessions).mockResolvedValue({ sessions: [] });
+		const { isClineInstalled } = await import("../core/ClineDetector.js");
+		const { scanClineSessions } = await import("../core/ClineSessionDiscoverer.js");
+		vi.mocked(isClineInstalled).mockResolvedValue(false);
+		vi.mocked(scanClineSessions).mockResolvedValue({ sessions: [] });
+		const { isClineCliInstalled } = await import("../core/ClineCliDetector.js");
+		const { scanClineCliSessions } = await import("../core/ClineCliSessionDiscoverer.js");
+		vi.mocked(isClineCliInstalled).mockResolvedValue(false);
+		vi.mocked(scanClineCliSessions).mockResolvedValue({ sessions: [] });
 	});
 
 	afterEach(async () => {
@@ -429,6 +459,55 @@ describe("Installer", () => {
 
 			const globalConfig = await loadConfigFromDir(getGlobalConfigDir());
 			expect(globalConfig.copilotEnabled).toBeUndefined();
+		});
+
+		it("auto-enables clineEnabled when the Cline VS Code extension is detected", async () => {
+			const { isClineInstalled } = await import("../core/ClineDetector.js");
+			vi.mocked(isClineInstalled).mockResolvedValueOnce(true);
+
+			const result = await install(tempDir);
+
+			expect(result.success).toBe(true);
+			const globalConfig = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
+			expect(globalConfig.clineEnabled).toBe(true);
+		});
+
+		it("auto-enables clineEnabled when only the Cline CLI is detected", async () => {
+			const { isClineInstalled } = await import("../core/ClineDetector.js");
+			const { isClineCliInstalled } = await import("../core/ClineCliDetector.js");
+			vi.mocked(isClineInstalled).mockResolvedValueOnce(false);
+			vi.mocked(isClineCliInstalled).mockResolvedValueOnce(true);
+
+			const result = await install(tempDir);
+
+			expect(result.success).toBe(true);
+			const globalConfig = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
+			expect(globalConfig.clineEnabled).toBe(true);
+		});
+
+		it("does not overwrite clineEnabled when explicitly set", async () => {
+			const { isClineInstalled } = await import("../core/ClineDetector.js");
+			vi.mocked(isClineInstalled).mockResolvedValueOnce(true);
+			await writeFile(join(emptyGlobalDir, "config.json"), JSON.stringify({ clineEnabled: false }), "utf-8");
+
+			const result = await install(tempDir);
+
+			expect(result.success).toBe(true);
+			const globalConfig = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
+			expect(globalConfig.clineEnabled).toBe(false);
+		});
+
+		it("does not auto-enable clineEnabled when neither Cline form is present", async () => {
+			const { isClineInstalled } = await import("../core/ClineDetector.js");
+			const { isClineCliInstalled } = await import("../core/ClineCliDetector.js");
+			vi.mocked(isClineInstalled).mockResolvedValueOnce(false);
+			vi.mocked(isClineCliInstalled).mockResolvedValueOnce(false);
+
+			await install(tempDir);
+
+			const { loadConfigFromDir, getGlobalConfigDir } = await import("../core/SessionTracker.js");
+			const globalConfig = await loadConfigFromDir(getGlobalConfigDir());
+			expect(globalConfig.clineEnabled).toBeUndefined();
 		});
 
 		it("should use process.cwd() when install is called without cwd", async () => {
@@ -2518,6 +2597,78 @@ describe("Installer", () => {
 			expect(status.activeSessions).toBeGreaterThanOrEqual(1);
 			expect(status.sessionsBySource?.copilot).toBe(1);
 			expect(status.copilotScanError).toBeUndefined();
+		});
+
+		it("includes clineDetected/clineEnabled in status when either Cline surface is present", async () => {
+			const { isClineInstalled } = await import("../core/ClineDetector.js");
+			const { saveConfigScoped } = await import("../core/SessionTracker.js");
+			vi.mocked(isClineInstalled).mockResolvedValue(true);
+			await saveConfigScoped({ clineEnabled: true }, emptyGlobalDir);
+			const status = await getStatus(tempDir);
+			expect(status.clineDetected).toBe(true);
+			expect(status.clineEnabled).toBe(true);
+		});
+
+		it("reports Cline CLI and VS Code variants separately in status", async () => {
+			const { isClineInstalled } = await import("../core/ClineDetector.js");
+			const { isClineCliInstalled } = await import("../core/ClineCliDetector.js");
+			const { saveConfigScoped } = await import("../core/SessionTracker.js");
+			vi.mocked(isClineInstalled).mockResolvedValue(false);
+			vi.mocked(isClineCliInstalled).mockResolvedValue(true);
+			await saveConfigScoped({ clineEnabled: true }, emptyGlobalDir);
+			const status = await getStatus(tempDir);
+			expect(status.clineCliDetected).toBe(true);
+			expect(status.clineVscodeDetected).toBe(false);
+			expect(status.clineDetected).toBe(true);
+		});
+
+		it("surfaces clineScanError from the extension or CLI scan", async () => {
+			const { isClineInstalled } = await import("../core/ClineDetector.js");
+			const { scanClineSessions } = await import("../core/ClineSessionDiscoverer.js");
+			const { saveConfigScoped } = await import("../core/SessionTracker.js");
+			vi.mocked(isClineInstalled).mockResolvedValue(true);
+			vi.mocked(scanClineSessions).mockResolvedValue({
+				sessions: [],
+				error: { kind: "parse", message: "unexpected token" },
+			});
+			await saveConfigScoped({ clineEnabled: true }, emptyGlobalDir);
+			const status = await getStatus(tempDir);
+			expect(status.clineScanError).toEqual({ kind: "parse", message: "unexpected token" });
+		});
+
+		it("merges Cline extension and CLI sessions into the active session count", async () => {
+			const { isClineInstalled } = await import("../core/ClineDetector.js");
+			const { scanClineSessions } = await import("../core/ClineSessionDiscoverer.js");
+			const { scanClineCliSessions } = await import("../core/ClineCliSessionDiscoverer.js");
+			const { saveConfigScoped } = await import("../core/SessionTracker.js");
+			vi.mocked(isClineInstalled).mockResolvedValue(true);
+			vi.mocked(scanClineSessions).mockResolvedValue({
+				sessions: [
+					{
+						sessionId: "cline-ext-1",
+						transcriptPath: "/fake/globalStorage/saoudrizwan.claude-dev/tasks/cline-ext-1",
+						updatedAt: new Date().toISOString(),
+						source: "cline",
+					},
+				],
+			});
+			vi.mocked(scanClineCliSessions).mockResolvedValue({
+				sessions: [
+					{
+						sessionId: "cline-cli-1",
+						transcriptPath: "/fake/.cline/data/sessions/cline-cli-1",
+						updatedAt: new Date().toISOString(),
+						source: "cline-cli",
+					},
+				],
+			});
+			await saveConfigScoped({ clineEnabled: true }, emptyGlobalDir);
+
+			const status = await getStatus(tempDir);
+
+			expect(status.sessionsBySource?.cline).toBe(1);
+			expect(status.sessionsBySource?.["cline-cli"]).toBe(1);
+			expect(status.clineScanError).toBeUndefined();
 		});
 
 		it("should count legacy sessions without a source as Claude sessions", async () => {

--- a/cli/src/install/Installer.ts
+++ b/cli/src/install/Installer.ts
@@ -18,6 +18,11 @@ import { stat, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isClaudeInstalled } from "../core/ClaudeDetector.js";
+import { isClineCliInstalled } from "../core/ClineCliDetector.js";
+import { scanClineCliSessions } from "../core/ClineCliSessionDiscoverer.js";
+import { isClineInstalled } from "../core/ClineDetector.js";
+import { scanClineSessions } from "../core/ClineSessionDiscoverer.js";
+import type { ClineScanError } from "../core/ClineTranscriptShared.js";
 import { discoverCodexSessions, isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
 import { isCopilotChatInstalled } from "../core/CopilotChatDetector.js";
 import { scanCopilotChatSessions } from "../core/CopilotChatSessionDiscoverer.js";
@@ -266,6 +271,7 @@ export async function install(
 		const opencodeDetectedOnce = await isOpenCodeInstalled();
 		const copilotDetectedOnce = await isCopilotInstalled();
 		const copilotChatDetectedOnce = await isCopilotChatInstalled();
+		const clineDetectedOnce = (await isClineInstalled()) || (await isClineCliInstalled());
 
 		// Install .jolli/jollimemory/ state dir (always) and Claude Code hook (if enabled)
 		let claudeResult: HookOpResult = {};
@@ -479,6 +485,12 @@ export async function install(
 				copilotDetected,
 				copilotChatDetected,
 			);
+		}
+
+		// Auto-detect Cline (extension or CLI) and enable session discovery
+		if (clineDetectedOnce && config.clineEnabled === undefined) {
+			await saveConfig({ clineEnabled: true });
+			log.info("Cline detected — enabled Cline session discovery");
 		}
 
 		// Migrate any existing worktree-level API keys to the global config dir.
@@ -786,6 +798,9 @@ export async function getStatus(cwd?: string, storage?: StorageProvider): Promis
 	const cursorDetected = await isCursorInstalled();
 	const copilotDetected = await isCopilotInstalled();
 	const copilotChatDetected = await isCopilotChatInstalled();
+	const clineVscodeDetected = await isClineInstalled();
+	const clineCliDetected = await isClineCliInstalled();
+	const clineDetected = clineVscodeDetected || clineCliDetected;
 
 	// Check if we can enumerate worktrees; falls back gracefully if not a git repo
 	let enabledWorktrees: number | undefined;
@@ -855,6 +870,16 @@ export async function getStatus(cwd?: string, storage?: StorageProvider): Promis
 			allEnabledSessions = [...allEnabledSessions, ...scan.sessions];
 		}
 		copilotChatScanError = scan.error;
+	}
+
+	// Discover Cline sessions on-demand (extension + CLI), merged under one row.
+	let clineScanError: ClineScanError | undefined;
+	if (config.clineEnabled !== false && clineDetected) {
+		const ext = await scanClineSessions(projectDir);
+		const cli = await scanClineCliSessions(projectDir);
+		const merged = [...ext.sessions, ...cli.sessions];
+		if (merged.length > 0) allEnabledSessions = [...allEnabledSessions, ...merged];
+		clineScanError = ext.error ?? cli.error;
 	}
 
 	// Compute per-source session counts for integration status rows
@@ -955,6 +980,11 @@ export async function getStatus(cwd?: string, storage?: StorageProvider): Promis
 		copilotScanError,
 		copilotChatDetected,
 		copilotChatScanError,
+		clineDetected,
+		clineCliDetected,
+		clineVscodeDetected,
+		clineEnabled: config.clineEnabled,
+		clineScanError,
 		globalConfigDir,
 		worktreeStatePath,
 		enabledWorktrees,
@@ -967,7 +997,7 @@ export async function getStatus(cwd?: string, storage?: StorageProvider): Promis
 	};
 
 	log.info(
-		"Status: enabled=%s, claude=%s, git=%s, geminiHook=%s, worktreeHooks=%s, sessions=%d, summaries=%d, codex=%s/%s, gemini=%s/%s, enabledWorktrees=%s, opencode=%s/%s, cursor=%s/%s, copilot=%s/%s, copilotChat=%s",
+		"Status: enabled=%s, claude=%s, git=%s, geminiHook=%s, worktreeHooks=%s, sessions=%d, summaries=%d, codex=%s/%s, gemini=%s/%s, enabledWorktrees=%s, opencode=%s/%s, cursor=%s/%s, copilot=%s/%s, copilotChat=%s, cline=%s/%s",
 		status.enabled,
 		status.claudeHookInstalled,
 		status.gitHookInstalled,
@@ -987,6 +1017,8 @@ export async function getStatus(cwd?: string, storage?: StorageProvider): Promis
 		status.copilotDetected,
 		status.copilotEnabled,
 		status.copilotChatDetected,
+		status.clineDetected,
+		status.clineEnabled,
 	);
 
 	return status;

--- a/docs/superpowers/plans/2026-07-18-cline-sources.md
+++ b/docs/superpowers/plans/2026-07-18-cline-sources.md
@@ -1,0 +1,1306 @@
+# Cline 会话源(扩展 + CLI)实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 jollimemory 在 post-commit 时捕获 Cline 两种形态(VS Code 扩展 `cline` / CLI `cline-cli`)的会话并生成 commit summary。
+
+**Architecture:** 两套"无 hook"明文文件源三件套(detector + session discoverer + transcript reader),仿 CopilotChat 而非 Cursor(明文、非 SQLite)。共用单个 `clineEnabled` config flag(仿 Copilot CLI/Chat)。发现层不读 SQLite(CLI 扫明文目录规避 WAL 陷阱;扩展本无 DB)。两 reader 复用 `cursor.lineNumber` 作 message 下标游标,只抽 `text` block 映射为 `TranscriptEntry`。
+
+**Tech Stack:** TypeScript(ESM,Node 22.5+)、Vitest、Biome(tab 缩进,120 列)。
+
+## Global Constraints
+
+> 每个 task 隐含遵守以下(逐字取自 spec / CLAUDE.md / 用户偏好):
+
+- **提交纪律(用户裁决)**:每个 task **写代码 + 用 `git commit -s` 提交**(供 SDD 逐-task review 与 ledger 恢复);**但不每 task 跑 `npm run all`**——per-task 只跑本 task 自己的测试文件(如 `npm run test -w @jolli.ai/cli -- src/core/ClineCliDetector.test.ts`)。昂贵的全量 `npm run all` 门只在 Task 5 跑一次。PR 阶段可 squash。
+- DCO:最终 commit 用 `git commit -s`。**禁止** `Co-Authored-By: Claude` / `🤖 Generated with` footer。
+- 覆盖率红线(`cli/vite.config.ts`):statements 97 / branches 96 / functions 97 / lines 97。`cli/src/Types.ts` 免测。新三件套 + 每个新分支需覆盖。单行覆盖率豁免只认 `/* v8 ignore start/stop */` 块。
+- 路径归一化用 `normalizePathForCompare`(`cli/src/core/PathUtils.ts`) / `normalizePathForMatch`(`VscodeWorkspaceLocator.ts`);禁止内联 `replace(/\\/g,"/")`(域助手内除外)。Windows/darwin 大小写不敏感。
+- Biome:tab 缩进,120 列,`noExplicitAny: error`,`noUnusedImports: error`,`useImportType`。
+- 源 id 命名:裸名 `cline` = VS Code 扩展,`cline-cli` = CLI。Label:`Cline (VS Code)` / `Cline CLI`。文件前缀:扩展 `Cline*`、CLI `ClineCli*`。
+
+## 关键既有类型(逐字,供所有 task 引用)
+
+```ts
+// cli/src/Types.ts
+export interface SessionInfo {
+	readonly sessionId: string;
+	readonly transcriptPath: string;
+	readonly updatedAt: string; // ISO 8601
+	readonly source?: TranscriptSource;
+	readonly title?: string;
+}
+export interface TranscriptCursor {
+	readonly transcriptPath: string;
+	readonly lineNumber: number;
+	readonly updatedAt: string; // ISO 8601
+}
+export interface TranscriptEntry {
+	readonly role: "human" | "assistant";
+	readonly content: string;
+	readonly timestamp?: string;
+}
+export interface TranscriptReadResult {
+	readonly entries: ReadonlyArray<TranscriptEntry>;
+	readonly newCursor: TranscriptCursor;
+	readonly totalLinesRead: number;
+	// usage* 字段可选,Cline reader 不填
+}
+```
+
+```ts
+// cli/src/core/TranscriptReader.ts
+export function mergeConsecutiveEntries(entries: ReadonlyArray<TranscriptEntry>): TranscriptEntry[]
+```
+
+## 文件结构
+
+**新建(共享 helper + 6 个三件套 + 测试):**
+
+- `cli/src/core/ClineTranscriptShared.ts`(+ `.test.ts`)——`ClineScanError` 类型 + `mapClineRole` + `buildClineReadResult`(游标/beforeTimestamp/合并/newCursor 的共享逻辑,两 reader 复用)
+- `cli/src/core/ClineCliDetector.ts` / `ClineCliSessionDiscoverer.ts` / `ClineCliTranscriptReader.ts`(+ 各 `.test.ts`)
+- `cli/src/core/ClineDetector.ts` / `ClineSessionDiscoverer.ts` / `ClineTranscriptReader.ts`(+ 各 `.test.ts`)
+
+**修改(共享工具 + 12 处接线):**
+
+- `cli/src/core/VscodeWorkspaceLocator.ts`(扩 `VscodeFlavor` + `ALL_VSCODE_FLAVORS`)
+- `cli/src/Types.ts`(`TRANSCRIPT_SOURCES` / `JolliMemoryConfig` / `StatusInfo`)
+- `cli/src/core/TranscriptSourceLabel.ts`、`cli/src/hooks/QueueWorker.ts`、`cli/src/core/TranscriptMessageCounter.ts`、`cli/src/core/TranscriptLoader.ts`、`cli/src/core/ActiveSessionAggregator.ts`、`cli/src/core/SessionTracker.ts`、`cli/src/core/SessionTitleResolver.ts`
+- `cli/src/install/Installer.ts`、`cli/src/commands/StatusCommand.ts`、`cli/src/commands/ConfigureCommand.ts`
+
+> **两 reader 抽共享 helper(用户裁决)**:游标/beforeTimestamp/合并/newCursor 逻辑放 `ClineTranscriptShared.ts` 的 `buildClineReadResult`;两 reader 各自只做「读文件 + 归一化(文件形状 + `<user_input>` 剥壳)成 `NormalizedMessage[]`」再调共享逻辑。`ClineScanError` 也定义在此共享模块。
+
+---
+
+## Task 1: Cline CLI 三件套(source id `cline-cli`)
+
+**Files:**
+- Create: `cli/src/core/ClineCliDetector.ts`
+- Create: `cli/src/core/ClineCliSessionDiscoverer.ts`
+- Create: `cli/src/core/ClineCliTranscriptReader.ts`
+- Test: `cli/src/core/ClineCliDetector.test.ts` / `ClineCliSessionDiscoverer.test.ts` / `ClineCliTranscriptReader.test.ts`
+
+**Interfaces:**
+- Produces（供 Task 3 wiring 消费):
+  - `isClineCliInstalled(home?: string): Promise<boolean>`
+  - `getClineCliDataDir(home?: string): string`、`getClineCliSessionsDir(home?: string): string`
+  - `interface ClineCliScanResult { readonly sessions: ReadonlyArray<SessionInfo>; readonly error?: ClineScanError }`
+  - `scanClineCliSessions(projectDir: string, sessionsDir?: string): Promise<ClineCliScanResult>`
+  - `discoverClineCliSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>>`
+  - `readClineCliTranscript(transcriptPath: string, cursor?: TranscriptCursor | null, beforeTimestamp?: string): Promise<TranscriptReadResult>`
+- 本 task 先建 `ClineTranscriptShared.ts`(见 Step 1),其中定义 `ClineScanError`、`mapClineRole`、`buildClineReadResult`、`NormalizedMessage`;CLI/扩展 discoverer、Types.ts、Installer 均从此模块 import `ClineScanError`。
+
+- [ ] **Step 1: 写 `ClineCliDetector.ts`**
+
+```ts
+import { access } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Cline CLI data root: <home>/.cline/data (home-relative on all platforms). */
+export function getClineCliDataDir(home: string = homedir()): string {
+	return join(home, ".cline", "data");
+}
+
+/** Per-session directory root: <dataDir>/sessions. */
+export function getClineCliSessionsDir(home: string = homedir()): string {
+	return join(getClineCliDataDir(home), "sessions");
+}
+
+/**
+ * Detected when the sessions/ dir exists. No node:sqlite gate — the CLI
+ * discoverer reads plain JSON sidecars, never the WAL-mode sessions.db.
+ */
+export async function isClineCliInstalled(home: string = homedir()): Promise<boolean> {
+	try {
+		await access(getClineCliSessionsDir(home));
+		return true;
+	} catch {
+		return false;
+	}
+}
+```
+
+- [ ] **Step 2: 写 `ClineCliDetector.test.ts`**
+
+```ts
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getClineCliDataDir, getClineCliSessionsDir, isClineCliInstalled } from "./ClineCliDetector.js";
+
+describe("ClineCliDetector", () => {
+	let home: string;
+	beforeEach(async () => {
+		home = await mkdtemp(join(tmpdir(), "cline-cli-det-"));
+	});
+	afterEach(async () => {
+		await rm(home, { recursive: true, force: true });
+	});
+
+	it("derives data + sessions dirs from home", () => {
+		expect(getClineCliDataDir(home)).toBe(join(home, ".cline", "data"));
+		expect(getClineCliSessionsDir(home)).toBe(join(home, ".cline", "data", "sessions"));
+	});
+
+	it("returns false when sessions dir is absent", async () => {
+		expect(await isClineCliInstalled(home)).toBe(false);
+	});
+
+	it("returns true once sessions dir exists", async () => {
+		await mkdir(getClineCliSessionsDir(home), { recursive: true });
+		expect(await isClineCliInstalled(home)).toBe(true);
+	});
+});
+```
+
+- [ ] **Step 3a: 写共享模块 `ClineTranscriptShared.ts`**
+
+> 承载两 reader 共用的:`ClineScanError` 类型、role 映射、以及 `NormalizedMessage[] → TranscriptReadResult` 的游标/beforeTimestamp/合并/newCursor 逻辑。两 reader 各自只负责「读文件 + 抽 text + 归一化」。
+
+```ts
+import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
+import { mergeConsecutiveEntries } from "./TranscriptReader.js";
+
+/** Structured scan error shared by the Cline CLI + extension sources (non-SQLite). */
+export interface ClineScanError {
+	readonly kind: "parse" | "fs" | "schema" | "unknown";
+	readonly message: string;
+}
+
+/** A source message after file-shape + text extraction has been normalized away. */
+export interface NormalizedMessage {
+	readonly role: "human" | "assistant" | undefined;
+	readonly content: string;
+	readonly ts?: number;
+}
+
+/** Map a raw Cline role string to a TranscriptEntry role (unknown → undefined → dropped). */
+export function mapClineRole(role: string | undefined): "human" | "assistant" | undefined {
+	if (role === "assistant") return "assistant";
+	if (role === "user") return "human";
+	return undefined;
+}
+
+/**
+ * Shared read logic for both Cline sources. `messages` are already normalized
+ * (role mapped, text extracted, `<user_input>` unwrapped by the caller as needed).
+ * Cursor.lineNumber is repurposed as a message index. When `beforeTimestamp` is
+ * set, stops at the first message past the cutoff and advances the cursor only to
+ * the last consumed index (commit-attribution mode); otherwise advances to end.
+ */
+export function buildClineReadResult(
+	transcriptPath: string,
+	messages: ReadonlyArray<NormalizedMessage>,
+	cursor: TranscriptCursor | null | undefined,
+	beforeTimestamp: string | undefined,
+): TranscriptReadResult {
+	const startIndex = cursor?.lineNumber ?? 0;
+	const beforeMs = beforeTimestamp ? Date.parse(beforeTimestamp) : undefined;
+
+	const rawEntries: TranscriptEntry[] = [];
+	let lastConsumedIndex = startIndex;
+	for (let i = startIndex; i < messages.length; i++) {
+		const msg = messages[i];
+		if (beforeMs !== undefined && typeof msg.ts === "number" && msg.ts > beforeMs) break;
+		lastConsumedIndex = i + 1;
+		if (msg.role === undefined || msg.content.length === 0) continue;
+		const timestamp = typeof msg.ts === "number" ? new Date(msg.ts).toISOString() : undefined;
+		rawEntries.push(timestamp ? { role: msg.role, content: msg.content, timestamp } : { role: msg.role, content: msg.content });
+	}
+
+	const entries = mergeConsecutiveEntries(rawEntries);
+	const newCursor: TranscriptCursor = {
+		transcriptPath,
+		lineNumber: beforeTimestamp ? lastConsumedIndex : messages.length,
+		updatedAt: new Date().toISOString(),
+	};
+	return { entries, newCursor, totalLinesRead: lastConsumedIndex - startIndex };
+}
+
+/** Empty result preserving the caller's cursor index (used on unreadable file). */
+export function emptyClineReadResult(transcriptPath: string, cursor?: TranscriptCursor | null): TranscriptReadResult {
+	return {
+		entries: [],
+		newCursor: { transcriptPath, lineNumber: cursor?.lineNumber ?? 0, updatedAt: new Date().toISOString() },
+		totalLinesRead: 0,
+	};
+}
+```
+
+- [ ] **Step 3b: 写共享模块测试 `ClineTranscriptShared.test.ts`**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { buildClineReadResult, emptyClineReadResult, mapClineRole, type NormalizedMessage } from "./ClineTranscriptShared.js";
+
+const N = (role: string | undefined, content: string, ts?: number): NormalizedMessage => ({
+	role: mapClineRole(role),
+	content,
+	ts,
+});
+
+describe("mapClineRole", () => {
+	it("maps user→human, assistant→assistant, else undefined", () => {
+		expect(mapClineRole("user")).toBe("human");
+		expect(mapClineRole("assistant")).toBe("assistant");
+		expect(mapClineRole("system")).toBeUndefined();
+		expect(mapClineRole(undefined)).toBeUndefined();
+	});
+});
+
+describe("buildClineReadResult", () => {
+	const msgs = [N("user", "hi", 1000), N("assistant", "a", 2000), N("assistant", "b", 3000), N("system", "x", 4000)];
+
+	it("merges same-role, drops empty/unknown, advances cursor to end without beforeTimestamp", () => {
+		const r = buildClineReadResult("p", msgs, null, undefined);
+		expect(r.entries).toEqual([
+			{ role: "human", content: "hi", timestamp: new Date(1000).toISOString() },
+			{ role: "assistant", content: "a\n\nb", timestamp: new Date(2000).toISOString() },
+		]);
+		expect(r.newCursor.lineNumber).toBe(4);
+		expect(r.totalLinesRead).toBe(4);
+	});
+
+	it("resumes from cursor index", () => {
+		const r = buildClineReadResult("p", msgs, { transcriptPath: "p", lineNumber: 2, updatedAt: "" }, undefined);
+		expect(r.entries).toEqual([{ role: "assistant", content: "b", timestamp: new Date(3000).toISOString() }]);
+		expect(r.totalLinesRead).toBe(2);
+	});
+
+	it("beforeTimestamp stops at cutoff, cursor = last consumed", () => {
+		const r = buildClineReadResult("p", msgs, null, new Date(2000).toISOString());
+		expect(r.entries.map((e) => e.role)).toEqual(["human", "assistant"]);
+		expect(r.newCursor.lineNumber).toBe(2); // msg[2] ts 3000 > cutoff → break
+	});
+
+	it("skips empty content but still advances consumed index", () => {
+		const r = buildClineReadResult("p", [N("user", "", 1000), N("assistant", "hi", 2000)], null, undefined);
+		expect(r.entries).toEqual([{ role: "assistant", content: "hi", timestamp: new Date(2000).toISOString() }]);
+		expect(r.newCursor.lineNumber).toBe(2);
+	});
+});
+
+describe("emptyClineReadResult", () => {
+	it("preserves cursor index", () => {
+		const r = emptyClineReadResult("p", { transcriptPath: "p", lineNumber: 7, updatedAt: "" });
+		expect(r).toMatchObject({ entries: [], totalLinesRead: 0, newCursor: { lineNumber: 7 } });
+	});
+});
+```
+
+- [ ] **Step 3c: 写 `ClineCliTranscriptReader.ts`(薄:读文件 + 抽 text + 剥 `<user_input>` + 调共享)**
+
+> CLI transcript = 单对象 `{messages:[{role, content:[{type,text?}], ts}]}`,user 文本包 `<user_input mode="...">…</user_input>`。
+
+```ts
+import { readFile } from "node:fs/promises";
+import { createLogger } from "../Logger.js";
+import type { TranscriptCursor, TranscriptReadResult } from "../Types.js";
+import { buildClineReadResult, emptyClineReadResult, mapClineRole, type NormalizedMessage } from "./ClineTranscriptShared.js";
+
+const log = createLogger("ClineCliReader");
+
+interface ClineCliBlock {
+	readonly type: string;
+	readonly text?: string;
+}
+interface ClineCliMessage {
+	readonly role?: string;
+	readonly content?: ReadonlyArray<ClineCliBlock>;
+	readonly ts?: number;
+}
+interface ClineCliFile {
+	readonly messages?: ReadonlyArray<ClineCliMessage>;
+}
+
+const USER_INPUT_RE = /<user_input\b[^>]*>([\s\S]*?)<\/user_input>/i;
+
+function unwrapUserInput(text: string): string {
+	const m = USER_INPUT_RE.exec(text);
+	return (m ? m[1] : text).trim();
+}
+
+function extractText(msg: ClineCliMessage): string {
+	const parts: string[] = [];
+	for (const block of msg.content ?? []) {
+		if (block.type === "text" && typeof block.text === "string") parts.push(block.text);
+	}
+	return parts.join("\n").trim();
+}
+
+export async function readClineCliTranscript(
+	transcriptPath: string,
+	cursor?: TranscriptCursor | null,
+	beforeTimestamp?: string,
+): Promise<TranscriptReadResult> {
+	let parsed: ClineCliFile;
+	try {
+		parsed = JSON.parse(await readFile(transcriptPath, "utf8")) as ClineCliFile;
+	} catch (error: unknown) {
+		log.error("Failed to read Cline CLI transcript %s: %s", transcriptPath, (error as Error).message);
+		return emptyClineReadResult(transcriptPath, cursor);
+	}
+	const messages: NormalizedMessage[] = (Array.isArray(parsed.messages) ? parsed.messages : []).map((msg) => {
+		const role = mapClineRole(msg.role);
+		const raw = extractText(msg);
+		return { role, content: role === "human" ? unwrapUserInput(raw) : raw, ts: msg.ts };
+	});
+	return buildClineReadResult(transcriptPath, messages, cursor, beforeTimestamp);
+}
+```
+
+- [ ] **Step 4: 写 `ClineCliTranscriptReader.test.ts`**
+
+> Fixture 内联写入临时文件(脱敏:占位路径)。覆盖 text/thinking/tool_use/tool_result 全类型、`<user_input>` 剥壳、下标游标、beforeTimestamp、损坏文件。
+
+```ts
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readClineCliTranscript } from "./ClineCliTranscriptReader.js";
+
+const FIXTURE = {
+	version: 1,
+	messages: [
+		{ id: "m1", role: "user", content: [{ type: "text", text: '<user_input mode="act">hi</user_input>' }], ts: 1000 },
+		{
+			id: "m2",
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "planning" },
+				{ type: "text", text: "Hi! How can I help?" },
+			],
+			ts: 2000,
+		},
+		{
+			id: "m3",
+			role: "assistant",
+			content: [
+				{ type: "text", text: "Running check" },
+				{ type: "tool_use", id: "c1", name: "run_commands", input: { commands: ["git branch"] } },
+			],
+			ts: 3000,
+		},
+		{
+			id: "m4",
+			role: "user",
+			content: [{ type: "tool_result", tool_use_id: "c1", name: "run_commands", content: [{ result: "main" }] }],
+			ts: 4000,
+		},
+		{ id: "m5", role: "assistant", content: [{ type: "text", text: "Branch is main" }], ts: 5000 },
+	],
+};
+
+describe("readClineCliTranscript", () => {
+	let dir: string;
+	let path: string;
+	beforeEach(async () => {
+		dir = await mkdtemp(join(tmpdir(), "cline-cli-rd-"));
+		path = join(dir, "m.messages.json");
+		await writeFile(path, JSON.stringify(FIXTURE), "utf8");
+	});
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("extracts text blocks, strips <user_input>, drops thinking/tool blocks, merges same-role", async () => {
+		const r = await readClineCliTranscript(path);
+		// m1 human "hi"; m2+m3 assistant merged (thinking/tool_use dropped); m4 tool_result → empty → dropped; m5 assistant
+		expect(r.entries).toEqual([
+			{ role: "human", content: "hi", timestamp: new Date(1000).toISOString() },
+			{
+				role: "assistant",
+				content: "Hi! How can I help?\n\nRunning check",
+				timestamp: new Date(2000).toISOString(),
+			},
+			{ role: "assistant", content: "Branch is main", timestamp: new Date(5000).toISOString() },
+		]);
+		expect(r.newCursor.lineNumber).toBe(5);
+		expect(r.totalLinesRead).toBe(5);
+	});
+
+	it("resumes from cursor.lineNumber", async () => {
+		const r = await readClineCliTranscript(path, { transcriptPath: path, lineNumber: 4, updatedAt: "" });
+		expect(r.entries).toEqual([
+			{ role: "assistant", content: "Branch is main", timestamp: new Date(5000).toISOString() },
+		]);
+		expect(r.totalLinesRead).toBe(1);
+	});
+
+	it("honors beforeTimestamp (stops at first message past cutoff, advances cursor to consumed)", async () => {
+		const r = await readClineCliTranscript(path, null, new Date(3000).toISOString());
+		expect(r.entries.map((e) => e.role)).toEqual(["human", "assistant"]);
+		expect(r.newCursor.lineNumber).toBe(3); // m1,m2,m3 consumed; m4 (ts 4000) > cutoff → break
+	});
+
+	it("returns empty result on unreadable file", async () => {
+		const r = await readClineCliTranscript(join(dir, "missing.json"));
+		expect(r.entries).toEqual([]);
+		expect(r.totalLinesRead).toBe(0);
+	});
+});
+```
+
+- [ ] **Step 5: 写 `ClineCliSessionDiscoverer.ts`**
+
+> 扫 `sessions/*/`,读 `<id>.json` sidecar,按 `workspace_root`(回退 `cwd`)归属;`updatedAt` = `<id>.messages.json` mtime;`transcriptPath` = sidecar `messages_path`;`title` = `metadata.title`;48h stale。
+
+```ts
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { createLogger } from "../Logger.js";
+import type { SessionInfo } from "../Types.js";
+import { getClineCliSessionsDir } from "./ClineCliDetector.js";
+import type { ClineScanError } from "./ClineTranscriptShared.js";
+import { normalizePathForCompare } from "./PathUtils.js";
+
+const log = createLogger("ClineCliDiscoverer");
+const SESSION_STALE_MS = 48 * 60 * 60 * 1000;
+
+export type { ClineScanError };
+
+export interface ClineCliScanResult {
+	readonly sessions: ReadonlyArray<SessionInfo>;
+	readonly error?: ClineScanError;
+}
+
+interface ClineCliSidecar {
+	readonly session_id?: string;
+	readonly cwd?: string;
+	readonly workspace_root?: string;
+	readonly messages_path?: string;
+	readonly metadata?: { readonly title?: string };
+}
+
+export async function scanClineCliSessions(
+	projectDir: string,
+	sessionsDir: string = getClineCliSessionsDir(),
+): Promise<ClineCliScanResult> {
+	let ids: string[];
+	try {
+		ids = await readdir(sessionsDir);
+	} catch (error: unknown) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT") return { sessions: [] };
+		return { sessions: [], error: { kind: "fs", message: (error as Error).message } };
+	}
+
+	const cutoffMs = Date.now() - SESSION_STALE_MS;
+	const target = normalizePathForCompare(projectDir);
+	const sessions: SessionInfo[] = [];
+
+	for (const id of ids) {
+		const sidecarPath = join(sessionsDir, id, `${id}.json`);
+		let meta: ClineCliSidecar;
+		try {
+			meta = JSON.parse(await readFile(sidecarPath, "utf8")) as ClineCliSidecar;
+		} catch (error: unknown) {
+			log.debug("Skipping %s: sidecar read/parse failed (%s)", id, (error as Error).message);
+			continue;
+		}
+		const root = meta.workspace_root ?? meta.cwd;
+		if (typeof root !== "string" || normalizePathForCompare(root) !== target) continue;
+		const messagesPath = meta.messages_path ?? join(sessionsDir, id, `${id}.messages.json`);
+		let mtimeMs: number;
+		try {
+			mtimeMs = (await stat(messagesPath)).mtimeMs;
+		} catch {
+			continue;
+		}
+		if (mtimeMs < cutoffMs) continue;
+		const title = meta.metadata?.title?.trim();
+		sessions.push({
+			sessionId: meta.session_id ?? id,
+			transcriptPath: messagesPath,
+			updatedAt: new Date(mtimeMs).toISOString(),
+			source: "cline-cli",
+			...(title ? { title } : {}),
+		});
+	}
+	return { sessions };
+}
+
+/** QueueWorker wrapper — strips the error channel. */
+export async function discoverClineCliSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
+	const { sessions, error } = await scanClineCliSessions(projectDir);
+	if (error) log.warn("Cline CLI scan error (%s): %s", error.kind, error.message);
+	return sessions;
+}
+```
+
+- [ ] **Step 6: 写 `ClineCliSessionDiscoverer.test.ts`**
+
+```ts
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { discoverClineCliSessions, scanClineCliSessions } from "./ClineCliSessionDiscoverer.js";
+
+async function writeSession(sessionsDir: string, id: string, sidecar: object): Promise<void> {
+	const dir = join(sessionsDir, id);
+	await mkdir(dir, { recursive: true });
+	await writeFile(join(dir, `${id}.json`), JSON.stringify(sidecar), "utf8");
+	await writeFile(join(dir, `${id}.messages.json`), JSON.stringify({ messages: [] }), "utf8");
+}
+
+describe("scanClineCliSessions", () => {
+	let sessionsDir: string;
+	const project = "/tmp/proj-a";
+	beforeEach(async () => {
+		sessionsDir = await mkdtemp(join(tmpdir(), "cline-cli-disc-"));
+	});
+	afterEach(async () => {
+		await rm(sessionsDir, { recursive: true, force: true });
+	});
+
+	it("returns empty (no error) when sessions dir absent", async () => {
+		const r = await scanClineCliSessions(project, join(sessionsDir, "nope"));
+		expect(r).toEqual({ sessions: [] });
+	});
+
+	it("attributes by workspace_root, sets source/title, uses messages.json mtime", async () => {
+		await writeSession(sessionsDir, "s1", {
+			session_id: "s1",
+			workspace_root: project,
+			messages_path: join(sessionsDir, "s1", "s1.messages.json"),
+			metadata: { title: "fix bug" },
+		});
+		await writeSession(sessionsDir, "s2", { session_id: "s2", workspace_root: "/tmp/other" });
+		const r = await scanClineCliSessions(project, sessionsDir);
+		expect(r.sessions).toHaveLength(1);
+		expect(r.sessions[0]).toMatchObject({ sessionId: "s1", source: "cline-cli", title: "fix bug" });
+		expect(r.sessions[0].transcriptPath).toContain("s1.messages.json");
+	});
+
+	it("falls back to cwd when workspace_root missing; skips corrupt sidecar", async () => {
+		await writeSession(sessionsDir, "s3", { session_id: "s3", cwd: project });
+		await mkdir(join(sessionsDir, "s4"), { recursive: true });
+		await writeFile(join(sessionsDir, "s4", "s4.json"), "{ not json", "utf8");
+		const r = await scanClineCliSessions(project, sessionsDir);
+		expect(r.sessions.map((s) => s.sessionId)).toEqual(["s3"]);
+	});
+
+	it("discoverClineCliSessions strips error channel", async () => {
+		const sessions = await discoverClineCliSessions(project);
+		expect(Array.isArray(sessions)).toBe(true);
+	});
+});
+```
+
+---
+
+## Task 2: Cline 扩展三件套(source id `cline`,跨 VS Code flavor)
+
+**Files:**
+- Modify: `cli/src/core/VscodeWorkspaceLocator.ts:24`(扩 `VscodeFlavor` + 新增 `ALL_VSCODE_FLAVORS`)
+- Create: `cli/src/core/ClineDetector.ts` / `ClineSessionDiscoverer.ts` / `ClineTranscriptReader.ts`
+- Test: 各 `.test.ts` + `VscodeWorkspaceLocator.test.ts`(补 `ALL_VSCODE_FLAVORS` 断言,若该测试文件存在)
+
+**Interfaces:**
+- Consumes:`buildClineReadResult` / `mapClineRole` / `emptyClineReadResult` / `NormalizedMessage` / `ClineScanError`(from `ClineTranscriptShared.ts`,Task 1)、`getVscodeUserDataDir(flavor, home?)`
+- Produces（供 Task 3):
+  - `export const ALL_VSCODE_FLAVORS: ReadonlyArray<VscodeFlavor>`（VscodeWorkspaceLocator.ts)
+  - `isClineInstalled(home?: string): Promise<boolean>`、`getClineStorageDirs(home?: string): string[]`
+  - `interface ClineScanResult { readonly sessions: ReadonlyArray<SessionInfo>; readonly error?: ClineScanError }`
+  - `scanClineSessions(projectDir: string, storageDirs?: string[]): Promise<ClineScanResult>`
+  - `discoverClineSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>>`
+  - `readClineTranscript(transcriptPath: string, cursor?: TranscriptCursor | null, beforeTimestamp?: string): Promise<TranscriptReadResult>`
+
+- [ ] **Step 1: 扩 `VscodeWorkspaceLocator.ts` 的 `VscodeFlavor` union + 导出 `ALL_VSCODE_FLAVORS`**
+
+改 line 24:
+
+```ts
+export type VscodeFlavor = "Cursor" | "Code" | "Code - Insiders" | "VSCodium" | "Windsurf";
+
+/** All VS Code-family flavors Jolli scans for extension data. Directory name == flavor string. */
+export const ALL_VSCODE_FLAVORS: ReadonlyArray<VscodeFlavor> = [
+	"Code",
+	"Code - Insiders",
+	"Cursor",
+	"VSCodium",
+	"Windsurf",
+];
+```
+
+> `getVscodeUserDataDir` 用 `join(..., flavor)`,flavor 字符串即目录名,新增成员无需改其 body。现有 `"Cursor"`/`"Code"` 字面量调用点(Cursor/CopilotChat)不受 union 变宽影响。
+
+- [ ] **Step 2: 写 `ClineDetector.ts`**
+
+```ts
+import { access } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { ALL_VSCODE_FLAVORS, getVscodeUserDataDir } from "./VscodeWorkspaceLocator.js";
+
+const EXTENSION_ID = "saoudrizwan.claude-dev";
+
+/** globalStorage dir for the Cline extension under one VS Code flavor. */
+function flavorStorageDir(flavor: (typeof ALL_VSCODE_FLAVORS)[number], home: string): string {
+	return join(getVscodeUserDataDir(flavor, home), "User", "globalStorage", EXTENSION_ID);
+}
+
+/** Existing-or-not, one entry per flavor (caller filters). */
+export function getClineStorageDirs(home: string = homedir()): string[] {
+	return ALL_VSCODE_FLAVORS.map((f) => flavorStorageDir(f, home));
+}
+
+export async function isClineInstalled(home: string = homedir()): Promise<boolean> {
+	for (const dir of getClineStorageDirs(home)) {
+		try {
+			await access(join(dir, "state", "taskHistory.json"));
+			return true;
+		} catch {
+			// try next flavor
+		}
+	}
+	return false;
+}
+```
+
+- [ ] **Step 3: 写 `ClineDetector.test.ts`**
+
+```ts
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getClineStorageDirs, isClineInstalled } from "./ClineDetector.js";
+
+describe("ClineDetector", () => {
+	let home: string;
+	beforeEach(async () => {
+		home = await mkdtemp(join(tmpdir(), "cline-ext-det-"));
+	});
+	afterEach(async () => {
+		await rm(home, { recursive: true, force: true });
+	});
+
+	it("returns one storage dir per flavor", () => {
+		const dirs = getClineStorageDirs(home);
+		expect(dirs.length).toBeGreaterThanOrEqual(5);
+		expect(dirs.some((d) => d.includes("saoudrizwan.claude-dev"))).toBe(true);
+	});
+
+	it("false when no flavor has taskHistory.json", async () => {
+		expect(await isClineInstalled(home)).toBe(false);
+	});
+
+	it("true when any flavor has taskHistory.json", async () => {
+		// darwin layout: <home>/Library/Application Support/Code/User/globalStorage/<ext>/state/
+		const stateDir = join(getClineStorageDirs(home)[0], "state");
+		await mkdir(stateDir, { recursive: true });
+		await writeFile(join(stateDir, "taskHistory.json"), "[]", "utf8");
+		expect(await isClineInstalled(home)).toBe(true);
+	});
+});
+```
+
+> 注:`getClineStorageDirs(home)[0]` 对应 `ALL_VSCODE_FLAVORS[0] = "Code"`。测试用真实平台布局(`getVscodeUserDataDir` 已按 platform 分支),无需 mock。
+
+- [ ] **Step 4: 写 `ClineTranscriptReader.ts`**
+
+> 扩展 transcript = `api_conversation_history.json`,**顶层数组** `[{role, content:[Anthropic blocks], ts}]`,无 `<user_input>` 壳。薄:读文件 + 抽 text + 归一化 + 调 Task 1 的 `buildClineReadResult`。
+
+```ts
+import { readFile } from "node:fs/promises";
+import { createLogger } from "../Logger.js";
+import type { TranscriptCursor, TranscriptReadResult } from "../Types.js";
+import { buildClineReadResult, emptyClineReadResult, mapClineRole, type NormalizedMessage } from "./ClineTranscriptShared.js";
+
+const log = createLogger("ClineReader");
+
+interface AnthropicBlock {
+	readonly type: string;
+	readonly text?: string;
+}
+interface ExtMessage {
+	readonly role?: string;
+	readonly content?: ReadonlyArray<AnthropicBlock> | string;
+	readonly ts?: number;
+}
+
+function extractText(msg: ExtMessage): string {
+	if (typeof msg.content === "string") return msg.content.trim();
+	const parts: string[] = [];
+	for (const block of msg.content ?? []) {
+		if (block.type === "text" && typeof block.text === "string") parts.push(block.text);
+	}
+	return parts.join("\n").trim();
+}
+
+export async function readClineTranscript(
+	transcriptPath: string,
+	cursor?: TranscriptCursor | null,
+	beforeTimestamp?: string,
+): Promise<TranscriptReadResult> {
+	let raw: ExtMessage[];
+	try {
+		const parsed = JSON.parse(await readFile(transcriptPath, "utf8")) as unknown;
+		raw = Array.isArray(parsed) ? (parsed as ExtMessage[]) : [];
+	} catch (error: unknown) {
+		log.error("Failed to read Cline transcript %s: %s", transcriptPath, (error as Error).message);
+		return emptyClineReadResult(transcriptPath, cursor);
+	}
+	const messages: NormalizedMessage[] = raw.map((msg) => ({
+		role: mapClineRole(msg.role),
+		content: extractText(msg),
+		ts: msg.ts,
+	}));
+	return buildClineReadResult(transcriptPath, messages, cursor, beforeTimestamp);
+}
+```
+
+- [ ] **Step 5: 写 `ClineTranscriptReader.test.ts`**
+
+```ts
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readClineTranscript } from "./ClineTranscriptReader.js";
+
+const FIXTURE = [
+	{ role: "user", content: [{ type: "text", text: "env" }, { type: "text", text: "查看当前分支" }], ts: 1000 },
+	{ role: "assistant", content: [{ type: "thinking", text: "plan" }, { type: "text", text: "分支是 main" }], ts: 2000 },
+	{ role: "assistant", content: [{ type: "text", text: "done" }], ts: 3000 },
+];
+
+describe("readClineTranscript", () => {
+	let dir: string;
+	let path: string;
+	beforeEach(async () => {
+		dir = await mkdtemp(join(tmpdir(), "cline-ext-rd-"));
+		path = join(dir, "api_conversation_history.json");
+		await writeFile(path, JSON.stringify(FIXTURE), "utf8");
+	});
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("joins text blocks, drops thinking, merges same-role, no <user_input> stripping", async () => {
+		const r = await readClineTranscript(path);
+		expect(r.entries).toEqual([
+			{ role: "human", content: "env\n查看当前分支", timestamp: new Date(1000).toISOString() },
+			{ role: "assistant", content: "分支是 main\n\ndone", timestamp: new Date(2000).toISOString() },
+		]);
+		expect(r.newCursor.lineNumber).toBe(3);
+	});
+
+	it("honors cursor + beforeTimestamp", async () => {
+		const r = await readClineTranscript(path, { transcriptPath: path, lineNumber: 2, updatedAt: "" });
+		expect(r.entries).toEqual([{ role: "assistant", content: "done", timestamp: new Date(3000).toISOString() }]);
+		const cut = await readClineTranscript(path, null, new Date(1500).toISOString());
+		expect(cut.entries.map((e) => e.role)).toEqual(["human"]);
+		expect(cut.newCursor.lineNumber).toBe(1);
+	});
+
+	it("empty on bad file", async () => {
+		const r = await readClineTranscript(join(dir, "nope.json"));
+		expect(r.entries).toEqual([]);
+	});
+});
+```
+
+- [ ] **Step 6: 写 `ClineSessionDiscoverer.ts`**
+
+> 遍历各 flavor 的 `state/taskHistory.json`(数组),按 `cwdOnTaskInitialization` 归属;`updatedAt` = 条目 `ts`;`transcriptPath` = 该 flavor `tasks/<id>/api_conversation_history.json`;`title` = `task`;48h stale。
+
+```ts
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createLogger } from "../Logger.js";
+import type { SessionInfo } from "../Types.js";
+import { getClineStorageDirs } from "./ClineDetector.js";
+import type { ClineScanError } from "./ClineTranscriptShared.js";
+import { normalizePathForCompare } from "./PathUtils.js";
+
+const log = createLogger("ClineDiscoverer");
+const SESSION_STALE_MS = 48 * 60 * 60 * 1000;
+
+export type { ClineScanError };
+
+export interface ClineScanResult {
+	readonly sessions: ReadonlyArray<SessionInfo>;
+	readonly error?: ClineScanError;
+}
+
+interface TaskHistoryEntry {
+	readonly id?: string;
+	readonly ts?: number;
+	readonly task?: string;
+	readonly cwdOnTaskInitialization?: string;
+}
+
+async function scanFlavor(storageDir: string, target: string, cutoffMs: number): Promise<SessionInfo[]> {
+	const historyPath = join(storageDir, "state", "taskHistory.json");
+	let entries: TaskHistoryEntry[];
+	try {
+		const parsed = JSON.parse(await readFile(historyPath, "utf8")) as unknown;
+		entries = Array.isArray(parsed) ? (parsed as TaskHistoryEntry[]) : [];
+	} catch (error: unknown) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+		throw error;
+	}
+	const out: SessionInfo[] = [];
+	for (const e of entries) {
+		if (typeof e.id !== "string" || typeof e.cwdOnTaskInitialization !== "string") continue;
+		if (normalizePathForCompare(e.cwdOnTaskInitialization) !== target) continue;
+		if (typeof e.ts === "number" && e.ts < cutoffMs) continue;
+		const title = e.task?.trim();
+		out.push({
+			sessionId: e.id,
+			transcriptPath: join(storageDir, "tasks", e.id, "api_conversation_history.json"),
+			updatedAt: new Date(typeof e.ts === "number" ? e.ts : Date.now()).toISOString(),
+			source: "cline",
+			...(title ? { title } : {}),
+		});
+	}
+	return out;
+}
+
+export async function scanClineSessions(
+	projectDir: string,
+	storageDirs: string[] = getClineStorageDirs(),
+): Promise<ClineScanResult> {
+	const target = normalizePathForCompare(projectDir);
+	const cutoffMs = Date.now() - SESSION_STALE_MS;
+	const sessions: SessionInfo[] = [];
+	let error: ClineScanError | undefined;
+	for (const dir of storageDirs) {
+		try {
+			sessions.push(...(await scanFlavor(dir, target, cutoffMs)));
+		} catch (err: unknown) {
+			log.warn("Cline flavor scan failed at %s: %s", dir, (err as Error).message);
+			error = error ?? { kind: "parse", message: (err as Error).message };
+		}
+	}
+	return error ? { sessions, error } : { sessions };
+}
+
+/** QueueWorker wrapper — strips the error channel. */
+export async function discoverClineSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
+	const { sessions, error } = await scanClineSessions(projectDir);
+	if (error) log.warn("Cline scan error (%s): %s", error.kind, error.message);
+	return sessions;
+}
+```
+
+- [ ] **Step 7: 写 `ClineSessionDiscoverer.test.ts`**
+
+```ts
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { discoverClineSessions, scanClineSessions } from "./ClineSessionDiscoverer.js";
+
+async function writeHistory(storageDir: string, entries: object[]): Promise<void> {
+	const stateDir = join(storageDir, "state");
+	await mkdir(stateDir, { recursive: true });
+	await writeFile(join(stateDir, "taskHistory.json"), JSON.stringify(entries), "utf8");
+}
+
+describe("scanClineSessions", () => {
+	let sd: string;
+	const project = "/tmp/proj-a";
+	beforeEach(async () => {
+		sd = await mkdtemp(join(tmpdir(), "cline-ext-disc-"));
+	});
+	afterEach(async () => {
+		await rm(sd, { recursive: true, force: true });
+	});
+
+	it("empty when no flavor has history (ENOENT ignored, no error)", async () => {
+		const r = await scanClineSessions(project, [join(sd, "flavorX")]);
+		expect(r).toEqual({ sessions: [] });
+	});
+
+	it("attributes by cwdOnTaskInitialization, sets source/title/transcriptPath", async () => {
+		await writeHistory(sd, [
+			{ id: "t1", ts: Date.now(), task: "查看分支", cwdOnTaskInitialization: project },
+			{ id: "t2", ts: Date.now(), task: "other", cwdOnTaskInitialization: "/tmp/other" },
+		]);
+		const r = await scanClineSessions(project, [sd]);
+		expect(r.sessions).toHaveLength(1);
+		expect(r.sessions[0]).toMatchObject({ sessionId: "t1", source: "cline", title: "查看分支" });
+		expect(r.sessions[0].transcriptPath).toBe(join(sd, "tasks", "t1", "api_conversation_history.json"));
+	});
+
+	it("merges across flavors; reports error on corrupt history", async () => {
+		await writeHistory(sd, [{ id: "t1", ts: Date.now(), cwdOnTaskInitialization: project }]);
+		const bad = await mkdtemp(join(tmpdir(), "cline-bad-"));
+		await mkdir(join(bad, "state"), { recursive: true });
+		await writeFile(join(bad, "state", "taskHistory.json"), "{ not array", "utf8");
+		const r = await scanClineSessions(project, [sd, bad]);
+		expect(r.sessions.map((s) => s.sessionId)).toEqual(["t1"]);
+		expect(r.error?.kind).toBe("parse");
+		await rm(bad, { recursive: true, force: true });
+	});
+
+	it("discoverClineSessions strips error channel", async () => {
+		expect(Array.isArray(await discoverClineSessions(project))).toBe(true);
+	});
+});
+```
+
+---
+
+## Task 3: 注册 + dispatch 接线(让两源流入 summary 管线)
+
+**Files（均 Modify,锚点为当前行号,实现时以 grep 确认）:**
+- `cli/src/Types.ts`(TRANSCRIPT_SOURCES:17 / import:7-8 / JolliMemoryConfig:~1088 / StatusInfo:~1317)
+- `cli/src/core/TranscriptSourceLabel.ts`、`QueueWorker.ts`、`TranscriptMessageCounter.ts`、`TranscriptLoader.ts`、`ActiveSessionAggregator.ts`、`SessionTracker.ts`、`SessionTitleResolver.ts`
+
+**Interfaces:** Consumes Task 1/2 的全部导出。
+
+- [ ] **Step 1: `Types.ts` — 加两源 id + 复用 ClineScanError import + config flag + StatusInfo 合并字段**
+
+`TRANSCRIPT_SOURCES`(line 17 数组末尾)加:
+```ts
+	"cline",
+	"cline-cli",
+```
+import 区(line 7-8 附近)加:
+```ts
+import type { ClineScanError } from "./core/ClineTranscriptShared.js";
+```
+`JolliMemoryConfig` 在 `copilotEnabled` 后加:
+```ts
+	/** Enable Cline (VS Code extension + CLI) session discovery at post-commit time (default: auto-detect) */
+	readonly clineEnabled?: boolean;
+```
+`StatusInfo` 在 copilotChat 字段后加(**合并单组**):
+```ts
+	/** Whether any Cline surface (VS Code extension globalStorage or ~/.cline CLI) was detected */
+	readonly clineDetected?: boolean;
+	/** Whether Cline session discovery is enabled in config (undefined = auto-detect) */
+	readonly clineEnabled?: boolean;
+	/** Cline scan failed with a real error (non-ENOENT): parse / fs / schema. */
+	readonly clineScanError?: ClineScanError;
+```
+
+- [ ] **Step 2: `TranscriptSourceLabel.ts` — 加两 label(`TRANSCRIPT_SOURCE_LABELS` 是 `Record<TranscriptSource,string>`,不加不编译)**
+
+```ts
+	cline: "Cline (VS Code)",
+	"cline-cli": "Cline CLI",
+```
+
+- [ ] **Step 3: `SessionTitleResolver.ts` — `PARSE_LINE` 加两 stub(两源 discoverer 均带 title,仿 `parseCursorUserLine`)**
+
+map(line 27-35)加:
+```ts
+	cline: parseClineUserLine,
+	"cline-cli": parseClineCliUserLine,
+```
+新增两函数:
+```ts
+function parseClineUserLine(_line: string): string | undefined {
+	// Cline extension sessions carry SessionInfo.title from taskHistory.task.
+	return undefined;
+}
+function parseClineCliUserLine(_line: string): string | undefined {
+	// Cline CLI sessions carry SessionInfo.title from sidecar metadata.title.
+	return undefined;
+}
+```
+
+- [ ] **Step 4: `TranscriptLoader.ts` — 两个 single-artifact 分支 + `JsonlSource` exclude**
+
+在 cursor 分支(line 64-75)后加:
+```ts
+	if (opts.source === "cline") {
+		try {
+			const { readClineTranscript } = await import("./ClineTranscriptReader.js");
+			return [...(await readClineTranscript(opts.transcriptPath)).entries];
+		} catch (err) {
+			if (!isEnoent(err)) log.warn("loadTranscript (cline) failed for %s: %s", opts.transcriptPath, errMsg(err));
+			return [];
+		}
+	}
+	if (opts.source === "cline-cli") {
+		try {
+			const { readClineCliTranscript } = await import("./ClineCliTranscriptReader.js");
+			return [...(await readClineCliTranscript(opts.transcriptPath)).entries];
+		} catch (err) {
+			if (!isEnoent(err)) log.warn("loadTranscript (cline-cli) failed for %s: %s", opts.transcriptPath, errMsg(err));
+			return [];
+		}
+	}
+```
+`JsonlSource`(line 137)加两 exclude:
+```ts
+type JsonlSource = Exclude<TranscriptSource, "gemini" | "opencode" | "cursor" | "copilot" | "cline" | "cline-cli">;
+```
+
+- [ ] **Step 5: `TranscriptMessageCounter.ts` — imports + switch 两 case**
+
+import 区加:
+```ts
+import { readClineTranscript } from "./ClineTranscriptReader.js";
+import { readClineCliTranscript } from "./ClineCliTranscriptReader.js";
+```
+switch(line 122-140)在 `case "copilot-chat"` 后加:
+```ts
+		case "cline":
+			return readClineTranscript(transcriptPath, cursor);
+		case "cline-cli":
+			return readClineCliTranscript(transcriptPath, cursor);
+```
+
+- [ ] **Step 6: `QueueWorker.ts` — imports + 发现循环两块 + reader dispatch 两 arm**
+
+import 区(line 39-41 附近)加:
+```ts
+import { isClineInstalled } from "../core/ClineDetector.js";
+import { discoverClineSessions } from "../core/ClineSessionDiscoverer.js";
+import { readClineTranscript } from "../core/ClineTranscriptReader.js";
+import { isClineCliInstalled } from "../core/ClineCliDetector.js";
+import { discoverClineCliSessions } from "../core/ClineCliSessionDiscoverer.js";
+import { readClineCliTranscript } from "../core/ClineCliTranscriptReader.js";
+```
+发现循环(cursor 块 line 3168-3175 后)加:
+```ts
+		// Discover Cline VS Code extension sessions (plain-JSON scan across VS Code flavors).
+		if (config.clineEnabled !== false && (await isClineInstalled())) {
+			const clineSessions = await discoverClineSessions(cwd);
+			if (clineSessions.length > 0) {
+				allSessions = [...allSessions, ...clineSessions];
+				log.info("Discovered %d Cline (VS Code) session(s)", clineSessions.length);
+			}
+		}
+		// Discover Cline CLI sessions (plain-JSON scan of ~/.cline/data/sessions).
+		if (config.clineEnabled !== false && (await isClineCliInstalled())) {
+			const clineCliSessions = await discoverClineCliSessions(cwd);
+			if (clineCliSessions.length > 0) {
+				allSessions = [...allSessions, ...clineCliSessions];
+				log.info("Discovered %d Cline CLI session(s)", clineCliSessions.length);
+			}
+		}
+```
+reader dispatch(copilot-chat arm line 3452-3458 后)加:
+```ts
+		} else if (source === "cline") {
+			try {
+				result = await readClineTranscript(session.transcriptPath, cursor, beforeTimestamp);
+			} catch (error: unknown) {
+				log.error("Skipping Cline session %s: %s", session.sessionId, (error as Error).message);
+				continue;
+			}
+		} else if (source === "cline-cli") {
+			try {
+				result = await readClineCliTranscript(session.transcriptPath, cursor, beforeTimestamp);
+			} catch (error: unknown) {
+				log.error("Skipping Cline CLI session %s: %s", session.sessionId, (error as Error).message);
+				continue;
+			}
+```
+
+- [ ] **Step 7: `SessionTracker.ts` — `filterSessionsByEnabledIntegrations` 加合并过滤(copilot 双源单开关模型)**
+
+在 copilot 过滤(line 182-184)后加:
+```ts
+	if (config.clineEnabled === false) {
+		filtered = filtered.filter((s) => s.source !== "cline" && s.source !== "cline-cli");
+	}
+```
+
+- [ ] **Step 8: `ActiveSessionAggregator.ts` — Promise.all 加两 loader + 两函数(仿 `loadCursor`)**
+
+`Promise.all`(line 218-225)加:
+```ts
+		loadCline(cwd),
+		loadClineCli(cwd),
+```
+新增两函数(仿 `loadCursor` 261-274):
+```ts
+async function loadCline(cwd: string): Promise<LoaderResult> {
+	try {
+		const { scanClineSessions } = await import("./ClineSessionDiscoverer.js");
+		const r = await scanClineSessions(cwd);
+		if (r.error) {
+			log.warn("scanClineSessions reported %s: %s", r.error.kind, r.error.message);
+			return { sessions: r.sessions, failed: ["cline"] };
+		}
+		return { sessions: r.sessions, failed: [] };
+	} catch (err) {
+		log.warn("scanClineSessions threw: %s", errMsg(err));
+		return { sessions: [], failed: ["cline"] };
+	}
+}
+async function loadClineCli(cwd: string): Promise<LoaderResult> {
+	try {
+		const { scanClineCliSessions } = await import("./ClineCliSessionDiscoverer.js");
+		const r = await scanClineCliSessions(cwd);
+		if (r.error) {
+			log.warn("scanClineCliSessions reported %s: %s", r.error.kind, r.error.message);
+			return { sessions: r.sessions, failed: ["cline-cli"] };
+		}
+		return { sessions: r.sessions, failed: [] };
+	} catch (err) {
+		log.warn("scanClineCliSessions threw: %s", errMsg(err));
+		return { sessions: [], failed: ["cline-cli"] };
+	}
+}
+```
+
+> 若 `LoaderResult.failed` 是 `TranscriptSource[]` 之外的枚举,`"cline"/"cline-cli"` 已在 union 内(Task 3 Step 1),类型安全。
+
+- [ ] **Step 9: 更新共享 dispatch 测试**
+
+为 `TranscriptMessageCounter.test.ts`(+`.dispatch.test.ts` 若存在)、`TranscriptLoader.test.ts`、`ActiveSessionAggregator.test.ts`、`SessionTracker.test.ts`、`SessionTitleResolver.test.ts`、`TranscriptSourceLabel.test.ts`、`QueueWorker.test.ts` 各补 `cline` / `cline-cli` 分支断言,镜像现有 `cursor` / `copilot-chat` 用例。示例(SessionTracker):
+
+```ts
+it("clineEnabled:false drops cline + cline-cli", () => {
+	const sessions = [
+		{ sessionId: "a", transcriptPath: "", updatedAt: "", source: "cline" as const },
+		{ sessionId: "b", transcriptPath: "", updatedAt: "", source: "cline-cli" as const },
+		{ sessionId: "c", transcriptPath: "", updatedAt: "", source: "claude" as const },
+	];
+	const out = filterSessionsByEnabledIntegrations(sessions, { clineEnabled: false });
+	expect(out.map((s) => s.source)).toEqual(["claude"]);
+});
+```
+
+示例(TranscriptSourceLabel):
+```ts
+expect(TRANSCRIPT_SOURCE_LABELS.cline).toBe("Cline (VS Code)");
+expect(TRANSCRIPT_SOURCE_LABELS["cline-cli"]).toBe("Cline CLI");
+```
+
+---
+
+## Task 4: Install / Status / Configure 表面(合并展示单开关)
+
+**Files:** `cli/src/install/Installer.ts`、`cli/src/commands/StatusCommand.ts`、`cli/src/commands/ConfigureCommand.ts` + 对应 `.test.ts`
+
+- [ ] **Step 1: `Installer.ts` — detector import + 合并检测 + auto-enable + status scan + status 对象 + 日志**
+
+import(line 27-28 附近):
+```ts
+import { isClineInstalled } from "../core/ClineDetector.js";
+import { scanClineSessions } from "../core/ClineSessionDiscoverer.js";
+import { isClineCliInstalled } from "../core/ClineCliDetector.js";
+import { scanClineCliSessions } from "../core/ClineCliSessionDiscoverer.js";
+```
+once-before-loop(line 263-268 后)加:
+```ts
+			const clineDetectedOnce = (await isClineInstalled()) || (await isClineCliInstalled());
+```
+auto-enable(cursor 块 line 461-468 后)加:
+```ts
+			// Auto-detect Cline (extension or CLI) and enable session discovery
+			if (clineDetectedOnce && config.clineEnabled === undefined) {
+				await saveConfig({ clineEnabled: true });
+				log.info("Cline detected — enabled Cline session discovery");
+			}
+```
+`getStatus` 检测(line 782-788 后)加:
+```ts
+	const clineDetected = (await isClineInstalled()) || (await isClineCliInstalled());
+```
+on-demand scan(cursor scan line 830-838 后)加(**合并两源 session + 合并 error**):
+```ts
+	// Discover Cline sessions on-demand (extension + CLI), merged under one row.
+	let clineScanError: ClineScanError | undefined;
+	if (config.clineEnabled !== false && clineDetected) {
+		const ext = await scanClineSessions(projectDir);
+		const cli = await scanClineCliSessions(projectDir);
+		const merged = [...ext.sessions, ...cli.sessions];
+		if (merged.length > 0) allEnabledSessions = [...allEnabledSessions, ...merged];
+		clineScanError = ext.error ?? cli.error;
+	}
+```
+> `ClineScanError` 从 `../core/ClineTranscriptShared.js` import type(与 Types.ts 同源)。
+status 对象(line 950-957 内)加:
+```ts
+		clineDetected,
+		clineEnabled: config.clineEnabled,
+		clineScanError,
+```
+status 日志(line 969-990):在格式串末尾加 `, cline=%s/%s`,并在参数列表末尾(`status.copilotChatDetected` 后)加 `status.clineDetected, status.clineEnabled`。
+
+- [ ] **Step 2: `StatusCommand.ts` — `integrationRows` 合并单行 "Cline"(仿 Copilot 双源行 379-389)**
+
+在 Copilot 行后加:
+```ts
+				[
+					"Cline:",
+					status.clineDetected ?? false,
+					{
+						enabled: status.clineEnabled !== false,
+						hookInstalled: undefined,
+						sessionCount: (counts.cline ?? 0) + (counts["cline-cli"] ?? 0),
+						scanError: status.clineScanError,
+					},
+				],
+```
+
+- [ ] **Step 3: `ConfigureCommand.ts` — `clineEnabled` 三处(keys / boolean guard / descriptions)**
+
+`VALID_CONFIG_KEYS`(line 58-59 后)加 `"clineEnabled",`。
+`coerceConfigValue` boolean guard(line 128-138)在 `key === "copilotEnabled" ||` 后加 `key === "clineEnabled" ||`。
+`CONFIG_KEY_INFO`(copilot entry 217-221 后)加:
+```ts
+	{
+		key: "clineEnabled",
+		type: "boolean",
+		description: "Enable Cline (VS Code extension + CLI) session discovery (true/false)",
+	},
+```
+
+- [ ] **Step 4: 更新 `Installer.test.ts` / `StatusCommand.test.ts` / `ConfigureCommand.test.ts`**
+
+镜像 cursor/copilot 断言,补:Installer auto-enable 在检测到 Cline 时写 `clineEnabled:true`;StatusCommand 渲染 "Cline:" 行且 sessionCount 合并两源;ConfigureCommand 接受 `clineEnabled=true/false` 且拒非布尔。示例(ConfigureCommand):
+```ts
+it("coerces clineEnabled", () => {
+	expect(coerceConfigValue("clineEnabled", "true")).toBe(true);
+	expect(() => coerceConfigValue("clineEnabled", "maybe")).toThrow();
+});
+```
+
+---
+
+## Task 5: 集中验证 + 单次提交(用户偏好:全程唯一 run + commit)
+
+- [ ] **Step 1: 全量校验**
+
+```bash
+cd /Users/flyer/jolli/code/jollimemory && npm run all
+```
+Expected: clean → build → lint → test 全绿;CLI 覆盖率 ≥ 97/96/97/97。若某新分支未覆盖,回到对应 task 补测试(仍不单独 commit)。
+
+- [ ] **Step 2: grep 自检两源已在所有穷举点**
+
+```bash
+cd /Users/flyer/jolli/code/jollimemory/cli && \
+grep -rn '"cline-cli"\|"cline"' src/core/TranscriptSourceLabel.ts src/core/SessionTitleResolver.ts src/core/TranscriptLoader.ts && \
+grep -rn 'clineEnabled' src/Types.ts src/commands/ConfigureCommand.ts src/core/SessionTracker.ts
+```
+Expected: 每处均命中。
+
+- [ ] **Step 3: 补英文版 spec(仓库约定 `.en.md`)**
+
+将 `docs/superpowers/specs/2026-07-18-cline-cli-source-design.md` 译为 `2026-07-18-cline-cli-source-design.en.md`(英文,内容对齐)。
+
+- [ ] **Step 4: 单次提交(DCO,无 Claude 署名)**
+
+```bash
+cd /Users/flyer/jolli/code/jollimemory && git add -A && git commit -s -m "feat: add Cline VS Code extension + CLI session sources"
+```
+
+---
+
+## Self-Review(spec 覆盖对照)
+
+- ✅ 两独立源三件套(Task 1/2)、单 `clineEnabled` flag(Task 3.1 / 3.7 / 4)、跨 flavor 扫描(Task 2.1)、Status 合并(Task 4.2)、发现层不读 SQLite(Task 1/2 均明文)、真实字节形状(fixture 内联脱敏,源自本机 capture)。
+- ✅ 无 tool-block 表示 → 两 reader 只抽 text(Task 1.3 / 2.4),与 `TranscriptEntry` 约束一致。
+- ✅ 每处穷举点(TRANSCRIPT_SOURCES 驱动的 `Record<TranscriptSource,…>`:TranscriptSourceLabel、SessionTitleResolver)均在 Task 3 覆盖。
+- ✅ 提交纪律(用户裁决):每 task commit(-s,无 Claude 署名)但不每 task 跑 `npm run all`;全量门只在 Task 5。
+- ✅ reader 去重(用户裁决):游标/合并/beforeTimestamp 逻辑抽入 `ClineTranscriptShared.buildClineReadResult`,两 reader 只留文件解析 + 归一化,消除逐字重复。
+- 待实现期确认(spec 未决项,非阻塞):`CLINE_DIR`/XDG 覆盖;补一份扩展"原生 tool_use" fixture(当前 fixture 已含 text/thinking,tool_use 被丢弃故不影响正确性);`metadata.git.branch` 增强归属(YAGNI,未纳入)。

--- a/docs/superpowers/specs/2026-07-18-cline-cli-source-design.en.md
+++ b/docs/superpowers/specs/2026-07-18-cline-cli-source-design.en.md
@@ -1,0 +1,152 @@
+# Cline Session Source Integration Design (CLI + VS Code Extension)
+
+> Date: 2026-07-18
+> Scope: the summary triplet (session capture → memory), for **two independent sources**: Cline CLI + Cline VS Code extension. Excludes MCP registration and references extraction.
+
+## Goal
+
+Let jollimemory capture sessions produced by **both forms of Cline**, reading their transcripts at post-commit time and generating commit summaries, consistent with existing "hook-less sources" like Cursor / Copilot Chat / OpenCode:
+
+1. **Cline CLI** — `~/.cline/`, a terminal TUI, the `cline` binary.
+2. **Cline VS Code extension** — `saoudrizwan.claude-dev`, data under VS Code globalStorage.
+
+The two have **completely different storage locations, file names, and message schemas** (see Observed Reality), so each is implemented as an **independent triplet**, but per the CLAUDE.md rule (Copilot CLI + Copilot Chat, same product, share one `copilotEnabled`) they **share a single `clineEnabled` config flag**.
+
+**Explicitly out of scope (this round):** MCP registration (Cline supports it via `cline_mcp_settings.json` — separate PR), references extraction (`ClineEnvelopeParser` — separate PR), git-hook install changes (Cline is hook-less).
+
+## Source ids and naming
+
+Following the Copilot precedent (bare-name file = bare-name source id). **The extension is Cline's flagship form (far more users than the CLI), so it takes the bare name:**
+
+| Form | `TranscriptSource` id | Label | Triplet file prefix |
+|---|---|---|---|
+| VS Code extension | `"cline"` | `Cline (VS Code)` | `Cline*` (`ClineDetector.ts`, …) |
+| CLI | `"cline-cli"` | `Cline CLI` | `ClineCli*` |
+
+## Observed Reality (verified on a real machine, 2026-07-18)
+
+> This section is mandated by integrating-external-systems: every conclusion comes from real runtime bytes on this machine, not documentation or an imagined fixture. Both forms were driven through a real task on this machine and captured.
+
+### A. Cline CLI
+
+- Data root: `~/.cline/data/` = `<home>/.cline/data`, **home-relative and consistent cross-platform** (Windows `%USERPROFILE%\.cline\data`, Linux `$HOME/.cline/data`); confirm during the plan whether a `CLINE_DIR`/XDG env override exists and, if so, prefer it.
+- Layout:
+
+```
+~/.cline/data/
+├── db/sessions.db(+.db-wal/.db-shm)   ← SQLite, journal_mode=WAL
+├── sessions/<id>/<id>.json            ← metadata sidecar (plain JSON)
+└── sessions/<id>/<id>.messages.json   ← transcript (plain JSON, single object)
+```
+
+- **WAL trap — reproduced live:** the `sessions.db` main file is only **4096 bytes (empty)**; the single session row lives entirely in `sessions.db-wal` (~99 KB). The system `sqlite3` (native, WAL-aware) reads it; `sql.js` (pure JS/WASM, the same one from OpenCode PR #834) reads only the main file → **0 sessions**. **Therefore the CLI discovery layer does not read SQLite; it scans the plain `sessions/<id>/` directory tree.**
+- Sidecar `<id>.json` top-level: `session_id, source("cli"), started_at, status, provider, model, cwd, workspace_root, prompt, metadata{git.{url,branch}, checkpoint, title, usage}, messages_path`. **No `updated_at`** → use the mtime of `<id>.messages.json`.
+- Transcript `<id>.messages.json`: **a single JSON object** `{version, updated_at, agent, sessionId, messages[], system_prompt}`. Each message: `{id, role:"user"|"assistant", content:[blocks], ts:epochMs, modelInfo?, metrics?}`.
+- Four block types: `text{text}` / `thinking{thinking}` / `tool_use{id,name,input}` / `tool_result{tool_use_id,name,content:[{query,result,success}]}`.
+- **Special case:** user text is wrapped in `<user_input mode="act|plan|yolo">…</user_input>`; the reader/title parser must unwrap it.
+- The transcript is **rewritten whole** (top-level `updated_at`), not JSONL → the cursor is a message index.
+
+### B. Cline VS Code extension
+
+- Data root: `<vscodeUserDataDir>/User/globalStorage/saoudrizwan.claude-dev/`. **Scanned across all VS Code flavors** (`Code` / `Code - Insiders` / `Cursor` / `Windsurf` / `VSCodium`).
+  - **Verified current state:** `VscodeWorkspaceLocator.ts:24`'s `VscodeFlavor` currently has only `"Cursor" | "Code"`; CopilotChat does **not** iterate multiple flavors (no existing precedent to copy).
+  - This source therefore needs: (a) **extending the `VscodeFlavor` union** to add Insiders/Windsurf/VSCodium (the file header comment already states "only requires extending the union", with each flavor's `getVscodeUserDataDir` path mapping); (b) a new `ALL_VSCODE_FLAVORS` list iterated in the detector/discoverer. When several flavors hit, sessions are merged.
+- Layout:
+
+```
+globalStorage/saoudrizwan.claude-dev/
+├── state/taskHistory.json          ← discovery index (plain JSON array)
+├── tasks/<taskId>/
+│   ├── api_conversation_history.json   ← transcript (Anthropic-native array)
+│   ├── ui_messages.json                ← UI event stream (has ts, command, … — unused here)
+│   ├── task_metadata.json              ← files_in_context / model_usage / env
+│   └── focus_chain_taskid_*.md
+├── settings/cline_mcp_settings.json    ← MCP (unused here)
+└── checkpoints/  cache/
+```
+
+- **No transcript database, no WAL trap** — all plain JSON.
+- Index `state/taskHistory.json`: an **array** `[{id, ulid, ts:epochMs, task, tokensIn/Out, totalCost, size, cwdOnTaskInitialization, isFavorited, modelId}]`. **Project attribution uses `cwdOnTaskInitialization`**; `ts` is updatedAt; `task` is the title.
+- Transcript `tasks/<id>/api_conversation_history.json`: an **Anthropic-native array** `[{role, content:[blocks], ts:epochMs}]`. **Each message carries `ts`** (keys=`content,role,ts`) → `beforeTimestamp` attribution can use `ts` directly, with no need to correlate `ui_messages.json`.
+- Blocks: `text` / `thinking` / Anthropic-native `tool_use` / `tool_result`. Only `text` blocks carry prose — `thinking`/`tool_use`/`tool_result` blocks are dropped by the reader.
+- **User-turn shape (differs from the CLI's `<user_input>`):** a `role:"user"` turn is **not** bare human text. Cline injects, as sibling `text` blocks: a `# task_progress RECOMMENDED …` boilerplate block (first turn), an `<environment_details>…</environment_details>` scaffolding block (open tabs / file tree / clock, multi-KB), and — because Cline replays the API conversation — tool results echoed as plain `[<tool> …] Result:` text **under role `user`** (not assistant). The real human prose is wrapped in `<task>…</task>` (first turn) or `<feedback>…</feedback>` (later turns). The reader must unwrap task/feedback and drop the boilerplate + scaffolding + tool-result echoes, else the ~6-char task drowns in ~7 KB of noise and tool output is mis-attributed as human speech.
+- **Provider-dependent pitfall (observed):** the captured fixture used deepseek-v4-flash, whose tool **calls** land as **XML-in-text** (e.g. `<execute_command>…`) inside a `text` block rather than a native `tool_use` block; Anthropic-family models use native blocks. The reader keeps assistant text raw (so XML-in-text tool calls survive verbatim — degrade gracefully) and drops native `tool_use`/`tool_result` blocks (only `text` is extracted). Both representations are covered by `ClineTranscriptReader.test.ts`.
+
+## Architecture
+
+Two triplets (`cli/src/core/`), each shedding the complexity it doesn't need. Both readers share their cursor/merge/`beforeTimestamp` logic via a small helper module `ClineTranscriptShared.ts` (`ClineScanError`, `mapClineRole`, `buildClineReadResult`, `emptyClineReadResult`, `NormalizedMessage`); each reader only parses its file shape and normalizes messages before delegating.
+
+### A. Cline CLI triplet (scans plain directories, bypassing WAL)
+
+- **`ClineCliDetector.ts`**: `getClineCliDataDir(home?)` → `<home>/.cline/data`; `getClineCliSessionsDir(home?)`; `isClineCliInstalled()` → the `sessions/` dir exists (**no `node:sqlite` gate**, no SQLite reads).
+- **`ClineCliSessionDiscoverer.ts`**: `ClineCliScanResult = {sessions, error?}`; `scanClineCliSessions(projectDir, sessionsDir?)` walks `sessions/*/` reading sidecars, attributing by `workspace_root` (falling back to `cwd`) via `normalizePathForCompare`; `updatedAt` = messages.json mtime; `transcriptPath = messages_path`; 48h stale window. `discoverClineCliSessions(projectDir)` is a thin wrapper.
+- **`ClineCliTranscriptReader.ts`**: `readClineCliTranscript(path, cursor?, beforeTimestamp?)` reads the whole JSON → `messages[]`; **index cursor** (reuses `TranscriptCursor.lineNumber` as consumed count); `ts` filter; blocks → `TranscriptEntry` (unwrapping the user's `<user_input>` wrapper); `mergeConsecutiveEntries` at the end.
+
+### B. Cline extension triplet (source id `cline`, scans globalStorage, all plain JSON)
+
+- **`ClineDetector.ts`**: `getClineStorageDirs()` → iterates `ALL_VSCODE_FLAVORS` (the extended `VscodeFlavor`), each `getVscodeUserDataDir(flavor)` + `User/globalStorage/saoudrizwan.claude-dev`, returning the **existing** flavor dirs; `isClineInstalled()` → any flavor has `state/taskHistory.json` or `tasks/`.
+- **`ClineSessionDiscoverer.ts`**: `scanClineSessions(projectDir, storageDirs?)` reads each hit flavor's `state/taskHistory.json` array and merges, attributing by `cwdOnTaskInitialization`; `updatedAt` = entry `ts`; `transcriptPath` = that flavor's `tasks/<id>/api_conversation_history.json`; `title` = `task`; 48h stale. `discoverClineSessions` is a thin wrapper.
+- **`ClineTranscriptReader.ts`**: `readClineTranscript(path, cursor?, beforeTimestamp?)` reads the whole Anthropic-native array; **index cursor**; `ts` filter; extracts `text` blocks only (native `tool_use`/`tool_result`/`thinking` dropped); for user turns unwraps `<task>`/`<feedback>` and drops `# task_progress` boilerplate / `<environment_details>` / `[…] Result:` tool-result echoes, while assistant text is kept raw; `mergeConsecutiveEntries`.
+
+## Wiring points (ripple map, one branch per source)
+
+> A background Explore agent verified the anchors; each site below needs **one branch each for `cline` (extension) and `cline-cli` (CLI)**.
+
+1. `cli/src/Types.ts`: add `"cline"`, `"cline-cli"` to `TRANSCRIPT_SOURCES`; add `clineEnabled?` to `JolliMemoryConfig` (**one flag governs both**); `StatusInfo` **merged display**: add one group `clineDetected?` (true if extension OR CLI detected) / `clineEnabled?` / `clineScanError?` — not a separate group per source.
+2. `TranscriptSourceLabel.ts`: `cline:"Cline (VS Code)"`, `cline-cli:"Cline CLI"`.
+2b. `cli/src/core/VscodeWorkspaceLocator.ts`: **extend the `VscodeFlavor` union** (`"Cursor" | "Code"` → add `"Code - Insiders" | "Windsurf" | "VSCodium"`), and export a new `ALL_VSCODE_FLAVORS`. (`getVscodeUserDataDir` uses `join(..., flavor)`, so the flavor string is the directory name — no mapping table needed. Existing `"Cursor"`/`"Code"` literal callers are unaffected by widening the union.)
+3. `QueueWorker.ts`: two discovery blocks (`clineEnabled!==false && isClineInstalled()` / `…isClineCliInstalled()`); two reader-dispatch arms.
+4. `TranscriptMessageCounter.ts`: two dispatch cases.
+5. `TranscriptLoader.ts`: two JSON-file branches; add `"cline" | "cline-cli"` to the `JsonlSource` `Exclude<…>`.
+6. `ActiveSessionAggregator.ts`: add `loadCline` (extension) + `loadClineCli` (CLI) to `Promise.all`.
+7. `SessionTracker.ts`: `clineEnabled === false` filters both sources.
+8. `SessionTitleResolver.ts`: `PARSE_LINE` gains `cline` + `cline-cli` (both stub parsers — sources carry `SessionInfo.title` from their discoverers).
+9. `Installer.ts`: detect both, auto-enable (`clineEnabled === undefined` → `true`), status/scan for both.
+10. `StatusCommand.ts`: **one merged "Cline" row** (shows the combined detected/enabled of extension + CLI), not a row per source.
+11. `ConfigureCommand.ts`: `clineEnabled` in keys / boolean guard / descriptions (one flag).
+
+**Untouched:** `references/**`, git-hook installer, `SkillInstaller`, MCP `HostRegistrars`, any SQLite dependency.
+
+## Data flow
+
+```
+post-commit → QueueWorker.loadSessionTranscripts
+  ├─ [cline-cli] clineEnabled!==false && isClineCliInstalled()
+  │    → discoverClineCliSessions(cwd)  // scan ~/.cline/data/sessions/*/, by workspace_root
+  │    → readClineCliTranscript(messages_path, cursor, beforeTs)
+  └─ [cline]     clineEnabled!==false && isClineInstalled()
+       → discoverClineSessions(cwd)     // read taskHistory.json, by cwdOnTaskInitialization
+       → readClineTranscript(api_conversation_history.json, cursor, beforeTs)
+  → feeds the existing summary pipeline (no difference from other sources)
+```
+
+## Error handling
+
+- Root dir / index missing → the corresponding `isXInstalled()` returns `false`, the source is silently skipped.
+- A single session/task failing to read or corrupt JSON → recorded as the corresponding `ScanError`, does not affect others, not thrown.
+- Transcript parse failure → the reader returns empty entries + the original cursor (no advance).
+- Missing CLI `<user_input>` wrapper / extension XML-in-text tools → lenient matching, degrades to raw text.
+
+## Test strategy
+
+- Six new triplet test files (`ClineCli*` ×3 = CLI, `Cline*` ×3 = extension), plus a shared-helper test.
+- **Fixtures (block structure captured from this machine 2026-07-18, inlined into the reader tests with a provenance comment; paths/timestamps sanitized):**
+  - CLI (`ClineCliTranscriptReader.test.ts`): covers text/thinking/native `tool_use`/`tool_result` + the `<user_input>` wrapper.
+  - Extension (`ClineTranscriptReader.test.ts`): covers `<task>`/`<feedback>` unwrap, `# task_progress` boilerplate + `<environment_details>` strip, `[…] Result:` tool-result-as-user drop, **XML-in-text** tools (deepseek-family), and a dedicated **native `tool_use`/`tool_result`** case.
+- Update shared dispatch tests to add both source branches: `TranscriptMessageCounter(.dispatch).test.ts`, `TranscriptLoader.test.ts`, `ActiveSessionAggregator.test.ts`, `SessionTracker.test.ts`, `SessionTitleResolver.test.ts`, `TranscriptSourceLabel.test.ts`, `QueueWorker.test.ts`, `Installer.test.ts`, `StatusCommand.test.ts`, `ConfigureCommand.test.ts`.
+- Coverage floor: `cli/vite.config.ts` 97/96/97/97 (`Types.ts` exempt).
+
+## Resolved decisions
+
+- Source ids: bare `cline` = VS Code extension (flagship), `cline-cli` = CLI.
+- CLI and extension share a single `clineEnabled` flag (Copilot precedent).
+- Extension scanned across all VS Code flavors (Code/Insiders/Cursor/Windsurf/VSCodium).
+- Status merged into one "Cline" row (not a row/field-group per source).
+- Neither discovery layer reads SQLite (CLI scans plain dirs to bypass WAL; the extension has no DB).
+- The two readers share cursor/merge/`beforeTimestamp` logic via `ClineTranscriptShared.ts` (deduplication chosen over self-contained readers).
+
+## Open items (confirm during implementation)
+
+- `TranscriptEntry` carries only role/content/timestamp — tool_use/tool_result/thinking blocks are intentionally dropped, keeping only `text` (matches every existing reader).
+- Confirm whether the CLI honors a `CLINE_DIR`/XDG env override for the data root.
+- Whether `metadata.git.branch` (CLI) / checkpoint should enrich attribution (default YAGNI; stays with `beforeTimestamp`).

--- a/docs/superpowers/specs/2026-07-18-cline-cli-source-design.md
+++ b/docs/superpowers/specs/2026-07-18-cline-cli-source-design.md
@@ -1,0 +1,154 @@
+# Cline 会话源接入设计（CLI + VS Code 扩展）
+
+> 日期：2026-07-18
+> 范围：summary 三件套（会话捕获 → memory），**两个独立源**：Cline CLI + Cline VS Code 扩展。不含 MCP 注册、不含 references 提取。
+
+## 目标
+
+让 jollimemory 能捕获 **Cline** 两种形态产生的会话，在 post-commit 时读取 transcript 并生成 commit summary，与现有 Cursor / Copilot Chat / OpenCode 等"无 hook 源"一致：
+
+1. **Cline CLI** — `~/.cline/`，终端 TUI，`cline` 二进制。
+2. **Cline VS Code 扩展** — `saoudrizwan.claude-dev`，数据在 VS Code globalStorage。
+
+两者**存储位置、文件名、message schema 完全不同**（见 Observed Reality），因此实现为**两个独立三件套**，但按 CLAUDE.md 规则（Copilot CLI + Copilot Chat 同产品共用一个 `copilotEnabled`）**共用一个 `clineEnabled` config flag**。
+
+**明确不做（本次）**：MCP 注册（Cline 支持，读 `cline_mcp_settings.json`，另开 PR）、references 提取（`ClineEnvelopeParser`，另开 PR）、git-hook 安装改动（Cline 无 hook）。
+
+## 源 id 与命名
+
+沿用 Copilot 先例（裸名文件 = 裸名 source id）。**扩展是 Cline 旗舰形态（用户远多于 CLI），占用裸名**：
+
+| 形态 | `TranscriptSource` id | Label | 三件套文件前缀 |
+|---|---|---|---|
+| VS Code 扩展 | `"cline"` | `Cline (VS Code)` | `Cline*`（`ClineDetector.ts` 等） |
+| CLI | `"cline-cli"` | `Cline CLI` | `ClineCli*` |
+
+## Observed Reality（真机实测，2026-07-18）
+
+> 本节由 integrating-external-systems 强制要求：所有结论来自本机真实运行态字节，非文档、非脑补 fixture。两种形态均已在本机跑真实任务并抓取。
+
+### A. Cline CLI
+
+- 数据根：`~/.cline/data/` = `<home>/.cline/data`，**home-relative，跨平台一致**（Windows `%USERPROFILE%\.cline\data`、Linux `$HOME/.cline/data`）；plan 阶段确认是否有 `CLINE_DIR`/XDG 环境变量覆盖，有则优先。
+- 布局：
+
+```
+~/.cline/data/
+├── db/sessions.db(+.db-wal/.db-shm)   ← SQLite, journal_mode=WAL
+├── sessions/<id>/<id>.json            ← 元数据 sidecar（明文）
+└── sessions/<id>/<id>.messages.json   ← transcript（明文，单 JSON 对象）
+```
+
+- **WAL 陷阱 — live 复现**：`sessions.db` 主库仅 **4096 字节（空）**，那 1 行 session 数据全在 `sessions.db-wal`（~99KB）。系统 `sqlite3`（native, WAL-aware）能读；`sql.js`（纯 JS/WASM，OpenCode PR #834 同款）只读主库 → **0 session**。**故 CLI 发现层不读 SQLite，扫明文 `sessions/<id>/` 目录树。**
+- sidecar `<id>.json` 顶层：`session_id, source("cli"), started_at, status, provider, model, cwd, workspace_root, prompt, metadata{git.{url,branch}, checkpoint, title, usage}, messages_path`。**缺 `updated_at`** → 用 `<id>.messages.json` 的 mtime。
+- transcript `<id>.messages.json`：**单 JSON 对象** `{version, updated_at, agent, sessionId, messages[], system_prompt}`。message：`{id, role:"user"|"assistant", content:[blocks], ts:epochMs, modelInfo?, metrics?}`。
+- block 四类：`text{text}` / `thinking{thinking}` / `tool_use{id,name,input}` / `tool_result{tool_use_id,name,content:[{query,result,success}]}`。
+- **特例**：user 文本包 `<user_input mode="act|plan|yolo">…</user_input>`，reader/title 需剥壳。
+- transcript 为**整文件覆盖写**（顶层 `updated_at`），非 JSONL → 游标按 message 下标。
+
+### B. Cline VS Code 扩展
+
+- 数据根：`<vscodeUserDataDir>/User/globalStorage/saoudrizwan.claude-dev/`。**跨所有 VS Code flavor 扫描**（`Code` / `Code - Insiders` / `Cursor` / `Windsurf` / `VSCodium`）。
+  - **实测现状**：`VscodeWorkspaceLocator.ts:24` 的 `VscodeFlavor` 当前只有 `"Cursor" | "Code"` 两个成员；CopilotChat **未**遍历多 flavor（无现成先例可仿）。
+  - 因此本源需：(a) **扩展 `VscodeFlavor` union** 加入 Insiders/Windsurf/VSCodium（文件头注释已说明"只需扩 union"，含各自 `getVscodeUserDataDir` 路径映射）；(b) 新增一个 `ALL_VSCODE_FLAVORS` 列表并在 detector/discoverer 中遍历。多个 flavor 命中则合并会话。
+- 布局：
+
+```
+globalStorage/saoudrizwan.claude-dev/
+├── state/taskHistory.json          ← 发现索引（明文数组）
+├── tasks/<taskId>/
+│   ├── api_conversation_history.json   ← transcript（Anthropic 原生数组）
+│   ├── ui_messages.json                ← UI 事件流（含 ts、command 等，本次不用）
+│   ├── task_metadata.json              ← files_in_context / model_usage / env
+│   └── focus_chain_taskid_*.md
+├── settings/cline_mcp_settings.json    ← MCP（本次不用）
+└── checkpoints/  cache/
+```
+
+- **无 transcript 数据库、无 WAL 陷阱**，全明文 JSON。
+- 索引 `state/taskHistory.json`：**数组** `[{id, ulid, ts:epochMs, task, tokensIn/Out, totalCost, size, cwdOnTaskInitialization, isFavorited, modelId}]`。**项目归属用 `cwdOnTaskInitialization`**；`ts` 作 updatedAt；`task` 作 title。
+- transcript `tasks/<id>/api_conversation_history.json`：**Anthropic 原生数组** `[{role, content:[blocks], ts:epochMs}]`。**每条带 `ts`**（keys=`content,role,ts`）→ `beforeTimestamp` 归属可直接用 `ts`，无需 correlate `ui_messages.json`。
+- block：`text` / `thinking` / Anthropic 原生 `tool_use` / `tool_result`。仅 `text` 块承载文本 —— `thinking`/`tool_use`/`tool_result` 块被 reader 丢弃。
+- **user turn 形状（与 CLI 的 `<user_input>` 不同）**：`role:"user"` turn **不是**裸人类文本。Cline 以平级 `text` 块注入：`# task_progress RECOMMENDED …` boilerplate（首轮）、`<environment_details>…</environment_details>` scaffolding（开着的 tab / 文件树 / 时钟，数 KB），以及因 Cline 重放 API 会话而把工具结果回显成的 `[<tool> …] Result:` 纯文本 —— 且这些回显挂在 **`user` 角色下（非 assistant）**。真正的人类文本包在 `<task>…</task>`（首轮）或 `<feedback>…</feedback>`（后续）里。reader 必须解 task/feedback 壳并丢弃 boilerplate + scaffolding + 工具结果回显，否则 ~6 字符的 task 会淹没在 ~7 KB 噪声里、工具输出被误当成人类发言。
+- **provider 相关坑（实测）**：本次 fixture 用 deepseek-v4-flash，其工具**调用**以 **XML-in-text**（如 `<execute_command>…`）落在 `text` block，而非原生 `tool_use` block；Anthropic 系模型则用原生 block。reader 对 assistant 文本保持原样（XML-in-text 工具调用逐字保留 —— degrade gracefully），并丢弃原生 `tool_use`/`tool_result` 块（只取 `text`）。两种表示均由 `ClineTranscriptReader.test.ts` 覆盖。
+
+## 架构
+
+两套三件套（`cli/src/core/`），各自去掉不需要的复杂度：
+
+### A. Cline CLI 三件套（扫明文目录，绕开 WAL）
+
+- **`ClineCliDetector.ts`**：`getClineDataDir(home?)` → `<home>/.cline/data`；`getClineSessionsDir(home?)`；`isClineCliInstalled()` → `sessions/` 目录存在（**不加 `node:sqlite` gate**，不读 SQLite）。
+- **`ClineCliSessionDiscoverer.ts`**：`ClineCliScanResult = {sessions, error?}`（导出 `ClineCliScanError`）；`scanClineCliSessions(projectDir)` 遍历 `sessions/*/` 读 sidecar，按 `workspace_root`（回退 `cwd`）用 `normalizePathForCompare` 归属；`updatedAt` = messages.json mtime；`transcriptPath = messages_path`；48h stale。`discoverClineCliSessions(projectDir)` 薄封装。
+- **`ClineCliTranscriptReader.ts`**：`readClineCliTranscript(path, cursor?, beforeTimestamp?)` 整读 JSON→`messages[]`；**下标游标**（复用 `TranscriptCursor.lineNumber` 存已消费条数）；`ts` 过滤；block→`TranscriptEntry`（user 剥 `<user_input>` 壳）；末尾 `mergeConsecutiveEntries`。
+
+### B. Cline 扩展三件套（source id `cline`，扫 globalStorage，全明文）
+
+- **`ClineDetector.ts`**：`getClineStorageDirs()` → 遍历 `ALL_VSCODE_FLAVORS`（扩展后的 `VscodeFlavor`）各自的 `getVscodeUserDataDir(flavor)` + `User/globalStorage/saoudrizwan.claude-dev`，返回**存在的** flavor 目录列表；`isClineInstalled()` → 任一 flavor 有 `state/taskHistory.json` 或 `tasks/`。
+- **`ClineSessionDiscoverer.ts`**：`scanClineSessions(projectDir)` **对每个命中 flavor** 读其 `state/taskHistory.json` 数组并合并，按 `cwdOnTaskInitialization` 归属；`updatedAt` = 条目 `ts`；`transcriptPath` = 该 flavor 下 `tasks/<id>/api_conversation_history.json`；`title` = `task`；48h stale。`discoverClineSessions` 薄封装。
+- **`ClineTranscriptReader.ts`**：`readClineTranscript(path, cursor?, beforeTimestamp?)` 整读 Anthropic 原生数组；**下标游标**；`ts` 过滤；仅取 `text` 块（原生 `tool_use`/`tool_result`/`thinking` 丢弃）；user turn 解 `<task>`/`<feedback>` 壳并丢弃 `# task_progress` boilerplate / `<environment_details>` / `[…] Result:` 工具结果回显，assistant 文本保持原样；`mergeConsecutiveEntries`。
+
+> 两个 reader 都是"整读 JSON 数组 + 下标游标"，可考虑抽一个共享 helper（如 `readJsonArrayTranscript`），plan 阶段按去重收益决定；但**两源的 block→Entry 映射不同**（envelope 形状 + 剥壳差异），映射逻辑不共享。
+
+## 接线点（ripple map，两源各加一条）
+
+> 后台 Explore agent 已核对锚点；下列每处需为 **`cline`（扩展）与 `cline-cli`（CLI）各加一个分支**。
+
+1. `cli/src/Types.ts`：`TRANSCRIPT_SOURCES` 加 `"cline"`, `"cline-cli"`；`JolliMemoryConfig` 加 `clineEnabled?`（**单 flag 管两源**）；`StatusInfo` **合并展示**：加单组 `clineDetected?`（扩展或 CLI 任一命中即 true）/ `clineEnabled?` / `clineScanError?`（两源错误取其一或合并信息）——不为两源各开一组字段。
+2. `TranscriptSourceLabel.ts`：`cline:"Cline (VS Code)"`, `cline-cli:"Cline CLI"`。
+2b. `cli/src/core/VscodeWorkspaceLocator.ts`：**扩展 `VscodeFlavor` union**（`"Cursor" | "Code"` → 加 `"Code - Insiders" | "Windsurf" | "VSCodium"`），并在 `getVscodeUserDataDir` 里补各 flavor 的目录名映射；新增导出 `ALL_VSCODE_FLAVORS`。（注意：这是共享工具，改动会影响所有用 `VscodeFlavor` 的源；plan 阶段确认现有 Cursor/CopilotChat 调用点不受影响——它们传字面量，union 变宽是安全的。）
+3. `QueueWorker.ts`：发现循环两块（`clineEnabled!==false && isClineInstalled()` / `…isClineCliInstalled()`）；reader dispatch switch 两 arm。
+4. `TranscriptMessageCounter.ts`：dispatch 两 case。
+5. `TranscriptLoader.ts`：两个 JSON-file 分支；`JsonlSource` 的 `Exclude<…>` 补 `"cline" | "cline-cli"`。
+6. `ActiveSessionAggregator.ts`：`Promise.all` 加 `loadCline`（扩展）+ `loadClineCli`（CLI）。
+7. `SessionTracker.ts`：`clineEnabled === false` 过滤两源。
+8. `SessionTitleResolver.ts`：`PARSE_LINE` 加 `cline`（扩展，裸 task 文本）+ `cline-cli`（CLI，剥 `<user_input>` 壳）。
+9. `Installer.ts`：detect 两个、auto-enable（`clineEnabled === undefined` → `true`）、status/scan 两组。
+10. `StatusCommand.ts`：**合并为单行 "Cline"**（展示扩展 + CLI 合并后的 detected/enabled 状态，如"Cline: enabled (VS Code + CLI)"），不为两源各占一行。
+11. `ConfigureCommand.ts`：`clineEnabled` 入 keys / boolean guard / descriptions（单 flag）。
+
+**不动**：`references/**`、git-hook installer、`SkillInstaller`、MCP `HostRegistrars`、SQLite 依赖。
+
+## 数据流
+
+```
+post-commit → QueueWorker.loadSessionTranscripts
+  ├─ [cline-cli] clineEnabled!==false && isClineCliInstalled()
+  │    → discoverClineCliSessions(cwd)  // 扫 ~/.cline/data/sessions/*/，按 workspace_root
+  │    → readClineCliTranscript(messages_path, cursor, beforeTs)
+  └─ [cline]     clineEnabled!==false && isClineInstalled()
+       → discoverClineSessions(cwd)     // 读 taskHistory.json，按 cwdOnTaskInitialization
+       → readClineTranscript(api_conversation_history.json, cursor, beforeTs)
+  → 汇入既有 summary 管线（与其它源无差异）
+```
+
+## 错误处理
+
+- 根目录/索引不存在 → 对应 `isXInstalled()` 返 `false`，该源静默跳过。
+- 单 session/task 读失败或 JSON 损坏 → 计入对应 `ScanError`，不影响其它、不抛。
+- transcript 解析失败 → reader 返回空 entries + 原 cursor（不推进）。
+- CLI `<user_input>` 壳缺失 / 扩展 XML-in-text 工具 → 宽容匹配，退化为裸文本。
+
+## 测试策略
+
+- 新增 6 个 triplet 测试文件（`ClineCli*` ×3 = CLI、`Cline*` ×3 = 扩展）。
+- **fixture（block 结构本机真机抓取 2026-07-18，内联进 reader 测试并带 provenance 注释；路径/时间戳已脱敏）**：
+  - CLI（`ClineCliTranscriptReader.test.ts`）：覆盖 text/thinking/原生 `tool_use`/`tool_result` + `<user_input>` 壳。
+  - 扩展（`ClineTranscriptReader.test.ts`）：覆盖 `<task>`/`<feedback>` 解壳、`# task_progress` boilerplate + `<environment_details>` 剥离、`[…] Result:` 工具结果回显（user 角色）丢弃、**XML-in-text** 工具（deepseek 系），以及一条专门的**原生 `tool_use`/`tool_result`** 用例。
+- 更新共享 dispatch 测试补两个源分支：`TranscriptMessageCounter(.dispatch).test.ts`、`TranscriptLoader.test.ts`、`ActiveSessionAggregator.test.ts`、`SessionTracker.test.ts`、`SessionTitleResolver.test.ts`、`TranscriptSourceLabel.test.ts`、`QueueWorker.test.ts`、`Installer.test.ts`、`StatusCommand.test.ts`、`ConfigureCommand.test.ts`。
+- 覆盖率红线：`cli/vite.config.ts` 97/96/97/97（`Types.ts` 免测）。
+
+## 未决 / plan 阶段确认
+
+- 两 reader 是否抽共享 `readJsonArrayTranscript` helper（去重 vs 边界清晰）。
+- `TranscriptEntry` 对 tool_use/tool_result/thinking 的承载字段（对齐现有 reader）；扩展 XML-in-text 工具的解析策略。
+- 确认 CLI 是否有 `CLINE_DIR`/XDG 环境变量覆盖数据根。
+- `metadata.git.branch`（CLI）/ checkpoint 是否用于增强归属（默认 YAGNI，走 `beforeTimestamp`）。
+
+## 已定案（历史决策记录）
+
+- 源 id：裸名 `cline` = VS Code 扩展（旗舰），`cline-cli` = CLI。
+- CLI 与扩展共用单个 `clineEnabled` flag（仿 Copilot）。
+- 扩展跨所有 VS Code flavor 扫描（Code/Insiders/Cursor/Windsurf/VSCodium）。
+- Status 合并为单行 "Cline"（不为两源各占一行/各开字段组）。
+- 发现层均不读 SQLite（CLI 扫明文目录规避 WAL；扩展本无 DB）。

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/WorkingMemoryHtmlBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/WorkingMemoryHtmlBuilder.kt
@@ -239,7 +239,13 @@ object WorkingMemoryHtmlBuilder {
     }
 
     private fun sourceIconSvg(source: String, isDark: Boolean): String {
-        val name = if (source == "copilot-chat") "copilot" else source
+        // copilot-chat and cline-cli reuse their sibling's brand mark (Copilot,
+        // Cline) rather than shipping a duplicate source-*.svg resource.
+        val name = when (source) {
+            "copilot-chat" -> "copilot"
+            "cline-cli" -> "cline"
+            else -> source
+        }
         val base = "/icons/source-$name"
         val svg = (if (isDark) readResource("${base}_dark.svg") else null)
             ?: readResource("$base.svg")
@@ -300,6 +306,8 @@ object WorkingMemoryHtmlBuilder {
         "copilot" -> "Copilot"
         "copilot-chat" -> "Copilot Chat"
         "opencode" -> "OpenCode"
+        "cline" -> "Cline (VS Code)"
+        "cline-cli" -> "Cline CLI"
         else -> source.replaceFirstChar { it.uppercase() }
     }
 

--- a/intellij/src/main/resources/icons/source-cline.svg
+++ b/intellij/src/main/resources/icons/source-cline.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <circle cx="8" cy="2.1" r="1.05" fill="#4A4A4A"/>
+  <g fill="none" stroke="#4A4A4A" stroke-width="1.3" stroke-linejoin="round" stroke-linecap="round">
+    <line x1="8" y1="3.15" x2="8" y2="4.7"/>
+    <path d="M5.1 4.7h5.8a2.9 2.9 0 0 1 2.9 2.9v.5l1 1.7-1 1.7v.5a2.9 2.9 0 0 1-2.9 2.9H5.1a2.9 2.9 0 0 1-2.9-2.9v-.5l-1-1.7 1-1.7v-.5A2.9 2.9 0 0 1 5.1 4.7Z"/>
+  </g>
+  <g fill="#4A4A4A">
+    <rect x="5.5" y="7.6" width="1.5" height="3.5" rx="0.75"/>
+    <rect x="9" y="7.6" width="1.5" height="3.5" rx="0.75"/>
+  </g>
+</svg>

--- a/intellij/src/main/resources/icons/source-cline_dark.svg
+++ b/intellij/src/main/resources/icons/source-cline_dark.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <circle cx="8" cy="2.1" r="1.05" fill="#C8C8C8"/>
+  <g fill="none" stroke="#C8C8C8" stroke-width="1.3" stroke-linejoin="round" stroke-linecap="round">
+    <line x1="8" y1="3.15" x2="8" y2="4.7"/>
+    <path d="M5.1 4.7h5.8a2.9 2.9 0 0 1 2.9 2.9v.5l1 1.7-1 1.7v.5a2.9 2.9 0 0 1-2.9 2.9H5.1a2.9 2.9 0 0 1-2.9-2.9v-.5l-1-1.7 1-1.7v-.5A2.9 2.9 0 0 1 5.1 4.7Z"/>
+  </g>
+  <g fill="#C8C8C8">
+    <rect x="5.5" y="7.6" width="1.5" height="3.5" rx="0.75"/>
+    <rect x="9" y="7.6" width="1.5" height="3.5" rx="0.75"/>
+  </g>
+</svg>

--- a/vscode/src/providers/StatusTreeProvider.test.ts
+++ b/vscode/src/providers/StatusTreeProvider.test.ts
@@ -916,6 +916,75 @@ describe("StatusTreeProvider", () => {
 		expect(String(integration?.tooltip)).toContain("Chat: ✓");
 	});
 
+	// ── Cline integration ─────────────────────────────────────────────────
+
+	it("shows Cline Integration row when detected and enabled", async () => {
+		const bridge = {
+			cwd: "/repo",
+			getStatus: vi.fn(async () =>
+				makeStatus({
+					clineDetected: true,
+					clineEnabled: true,
+					sessionsBySource: { cline: 2, "cline-cli": 3 },
+				}),
+			),
+		};
+		loadConfigFromDir.mockResolvedValue({ apiKey: "key" });
+
+		const provider = makeStatusProvider(bridge as never);
+		await provider.refresh();
+
+		const items = provider.getChildren();
+		const item = items.find((i) => i.label === "Cline Integration");
+		expect(item).toBeDefined();
+		expect(item?.description).toContain("5");
+	});
+
+	it("Cline row tooltip distinguishes CLI / VS Code detection", async () => {
+		const bridge = {
+			cwd: "/repo",
+			getStatus: vi.fn(async () =>
+				makeStatus({
+					clineDetected: true,
+					clineCliDetected: true,
+					clineVscodeDetected: false,
+					clineEnabled: true,
+				}),
+			),
+		};
+		loadConfigFromDir.mockResolvedValue({ apiKey: "key" });
+
+		const provider = makeStatusProvider(bridge as never);
+		await provider.refresh();
+
+		const items = provider.getChildren();
+		const clineItem = items.find((i) => i.label === "Cline Integration");
+		expect(String(clineItem?.tooltip)).toContain("CLI: ✓");
+		expect(String(clineItem?.tooltip)).toContain("VS Code: ✗");
+	});
+
+	it("shows Cline Integration as unavailable when scan errors", async () => {
+		const bridge = {
+			cwd: "/repo",
+			getStatus: vi.fn(async () =>
+				makeStatus({
+					clineDetected: true,
+					clineEnabled: true,
+					clineScanError: { kind: "parse", message: "bad task json" },
+				}),
+			),
+		};
+		loadConfigFromDir.mockResolvedValue({ apiKey: "key" });
+
+		const provider = makeStatusProvider(bridge as never);
+		await provider.refresh();
+
+		const items = provider.getChildren();
+		const item = items.find((i) => i.label === "Cline Integration");
+		expect(item?.description).toContain("parse");
+		expect(String(item?.tooltip)).toContain("Cline scan failed");
+	});
+
 	// ── Auth-aware status rows ────────────────────────────────────────────
 
 	it("shows Jolli Account connected when authToken is present", async () => {

--- a/vscode/src/providers/StatusTreeProvider.ts
+++ b/vscode/src/providers/StatusTreeProvider.ts
@@ -241,7 +241,7 @@ function buildFullStatusItems(
 		items.push(accountItem);
 	}
 
-	// Integration status rows (Claude, Codex, Gemini, OpenCode, Cursor)
+	// Integration status rows (Claude, Codex, Gemini, OpenCode, Cursor, Copilot, Cline)
 	const counts = s.sessionsBySource ?? {};
 	pushIntegrationItem(
 		items,
@@ -364,6 +364,35 @@ function buildFullStatusItems(
 		undefined,
 		copilotSessions,
 	);
+
+	// Cline integration: shared `clineEnabled` toggle for the terminal CLI and the
+	// VS Code extension. Like Cursor/OpenCode, a scan error replaces the main row
+	// with a dedicated warn row (single scan channel, unlike Copilot's two).
+	if (s.clineScanError) {
+		items.push(
+			new StatusItem(
+				"Cline Integration",
+				`unavailable — ${s.clineScanError.kind}`,
+				ICON_WARN,
+				`Cline scan failed (${s.clineScanError.kind}): ${s.clineScanError.message}`,
+			),
+		);
+	} else {
+		const clineCliMark = s.clineCliDetected ? "✓" : "✗";
+		const clineVscodeMark = s.clineVscodeDetected ? "✓" : "✗";
+		const clineSessions = (counts.cline ?? 0) + (counts["cline-cli"] ?? 0);
+		pushIntegrationItem(
+			items,
+			s.clineDetected ?? false,
+			s.clineEnabled !== false,
+			undefined,
+			"Cline Integration",
+			`Cline detected (CLI: ${clineCliMark}, VS Code: ${clineVscodeMark}) — session discovery is enabled`,
+			`Cline detected (CLI: ${clineCliMark}, VS Code: ${clineVscodeMark}) but session discovery is disabled in config`,
+			undefined,
+			clineSessions,
+		);
+	}
 
 	if (extensionOutdated) {
 		items.push(

--- a/vscode/src/services/ActiveSessionsProvider.test.ts
+++ b/vscode/src/services/ActiveSessionsProvider.test.ts
@@ -101,6 +101,8 @@ describe("ActiveSessionsProvider", () => {
 		expect(result.items).toEqual([]);
 		expect([...result.failedSources].sort()).toEqual([
 			"claude",
+			"cline",
+			"cline-cli",
 			"codex",
 			"copilot",
 			"copilot-chat",

--- a/vscode/src/views/NextMemoryScriptBuilder.ts
+++ b/vscode/src/views/NextMemoryScriptBuilder.ts
@@ -132,6 +132,8 @@ export function buildNextMemoryScript(): string {
       case 'opencode': return 'OpenCode';
       case 'copilot': return 'Copilot';
       case 'copilot-chat': return 'Copilot Chat';
+      case 'cline': return 'Cline (VS Code)';
+      case 'cline-cli': return 'Cline CLI';
       default: return source;
     }
   }
@@ -173,8 +175,18 @@ export function buildNextMemoryScript(): string {
       '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">' +
       '<g fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">' +
       '<path d="M3.5 5 7 8l-3.5 3"/><line x1="8.5" y1="11.5" x2="13" y2="11.5"/></g></svg>',
+    cline:
+      '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">' +
+      '<circle cx="8" cy="2.1" r="1.05" fill="currentColor"/>' +
+      '<g fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round" stroke-linecap="round">' +
+      '<line x1="8" y1="3.15" x2="8" y2="4.7"/>' +
+      '<path d="M5.1 4.7h5.8a2.9 2.9 0 0 1 2.9 2.9v.5l1 1.7-1 1.7v.5a2.9 2.9 0 0 1-2.9 2.9H5.1a2.9 2.9 0 0 1-2.9-2.9v-.5l-1-1.7 1-1.7v-.5A2.9 2.9 0 0 1 5.1 4.7Z"/></g>' +
+      '<g fill="currentColor"><rect x="5.5" y="7.6" width="1.5" height="3.5" rx="0.75"/><rect x="9" y="7.6" width="1.5" height="3.5" rx="0.75"/></g></svg>',
   };
   SOURCE_ICON_SVG['copilot-chat'] = SOURCE_ICON_SVG.copilot;
+  // Cline's VS Code extension + terminal CLI share the same robot-head mark,
+  // as copilot / copilot-chat do above.
+  SOURCE_ICON_SVG['cline-cli'] = SOURCE_ICON_SVG.cline;
 
   function convSourceIcon(source) {
     var markup = SOURCE_ICON_SVG[source];

--- a/vscode/src/views/SettingsHtmlBuilder.test.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.test.ts
@@ -58,13 +58,19 @@ describe("SettingsHtmlBuilder", () => {
 
 	// ── AI Agents tab ──
 
-	it("AI Agents tab lists all six per-source toggles", () => {
+	it("AI Agents tab lists all seven per-source toggles", () => {
 		expect(html).toContain('id="claudeEnabled"');
 		expect(html).toContain('id="codexEnabled"');
 		expect(html).toContain('id="geminiEnabled"');
 		expect(html).toContain('id="openCodeEnabled"');
 		expect(html).toContain('id="cursorEnabled"');
 		expect(html).toContain('id="copilotEnabled"');
+		expect(html).toContain('id="clineEnabled"');
+	});
+
+	it("Cline toggle description mentions both CLI and VS Code sources", () => {
+		expect(html).toContain("Cline CLI");
+		expect(html).toContain("VS Code");
 	});
 
 	it("Copilot toggle description mentions both CLI and Chat sources", () => {

--- a/vscode/src/views/SettingsHtmlBuilder.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.ts
@@ -6,7 +6,7 @@
  * intentionally omitted from this surface):
  *
  *   1. AI Agents     — per-source toggles (Claude / Codex / Gemini /
- *                      OpenCode / Cursor / Copilot)
+ *                      OpenCode / Cursor / Copilot / Cline)
  *   2. AI Summary    — Provider dropdown + Anthropic card (key/model/maxTokens)
  *                      or Jolli card (signed-in / no-key / signed-out)
  *   3. Sync to Jolli — sign-in or signed-in state for cloud push
@@ -55,6 +55,7 @@ export function buildSettingsHtml(nonce: string): string {
       ${buildToggleRow("openCodeEnabled", "OpenCode", "Session discovery via ~/.local/share/opencode/opencode.db")}
       ${buildToggleRow("cursorEnabled", "Cursor", "Session discovery via Cursor's local SQLite store")}
       ${buildToggleRow("copilotEnabled", "Copilot", "Session discovery for GitHub Copilot CLI (~/.copilot/session-store.db) and VS Code Copilot Chat (workspace storage)")}
+      ${buildToggleRow("clineEnabled", "Cline", "Session discovery for the Cline CLI (~/.cline/data/sessions) and the Cline VS Code extension (globalStorage)")}
       <div class="error-message" id="integrations-error"></div>
       <p class="section-hint">Global preferences</p>
       ${buildToggleRow("globalInstructions", "Global Instructions", GLOBAL_INSTRUCTIONS_PROMPT)}

--- a/vscode/src/views/SettingsScriptBuilder.test.ts
+++ b/vscode/src/views/SettingsScriptBuilder.test.ts
@@ -92,6 +92,24 @@ describe("SettingsScriptBuilder", () => {
 		);
 	});
 
+	it("references the clineEnabled DOM input", () => {
+		expect(script).toContain("getElementById('clineEnabled')");
+	});
+
+	it("includes clineEnabled in validation guard", () => {
+		expect(script).toMatch(/!clineEnabledInput\.checked/);
+	});
+
+	it("ships clineEnabled in save payload", () => {
+		expect(script).toContain("clineEnabled: clineEnabledInput.checked");
+	});
+
+	it("loads clineEnabled from host message", () => {
+		expect(script).toContain(
+			"clineEnabledInput.checked = msg.settings.clineEnabled",
+		);
+	});
+
 	// ── DCO sign-off toggle ──
 
 	it("references the dcoSignoff DOM input", () => {

--- a/vscode/src/views/SettingsScriptBuilder.ts
+++ b/vscode/src/views/SettingsScriptBuilder.ts
@@ -38,6 +38,7 @@ export function buildSettingsScript(): string {
   const openCodeEnabledInput = document.getElementById('openCodeEnabled');
   const cursorEnabledInput = document.getElementById('cursorEnabled');
   const copilotEnabledInput = document.getElementById('copilotEnabled');
+  const clineEnabledInput = document.getElementById('clineEnabled');
   const globalInstructionsInput = document.getElementById('globalInstructions');
   const localFolderInput = document.getElementById('localFolder');
   const browseLocalFolderBtn = document.getElementById('browseLocalFolderBtn');
@@ -262,7 +263,7 @@ export function buildSettingsScript(): string {
     }) && valid;
     // At least one integration must be enabled
     var intError = document.getElementById('integrations-error');
-    if (!claudeEnabledInput.checked && !codexEnabledInput.checked && !geminiEnabledInput.checked && !openCodeEnabledInput.checked && !cursorEnabledInput.checked && !copilotEnabledInput.checked) {
+    if (!claudeEnabledInput.checked && !codexEnabledInput.checked && !geminiEnabledInput.checked && !openCodeEnabledInput.checked && !cursorEnabledInput.checked && !copilotEnabledInput.checked && !clineEnabledInput.checked) {
       intError.textContent = 'At least one integration must be enabled';
       valid = false;
     } else {
@@ -337,6 +338,7 @@ export function buildSettingsScript(): string {
       openCodeEnabled: openCodeEnabledInput.checked,
       cursorEnabled: cursorEnabledInput.checked,
       copilotEnabled: copilotEnabledInput.checked,
+      clineEnabled: clineEnabledInput.checked,
       globalInstructions: globalInstructionsInput.checked,
       localFolder: localFolderInput.value,
       excludePatterns: excludePatternsInput.value,
@@ -363,6 +365,7 @@ export function buildSettingsScript(): string {
       openCodeEnabledInput.checked !== initialState.openCodeEnabled ||
       cursorEnabledInput.checked !== initialState.cursorEnabled ||
       copilotEnabledInput.checked !== initialState.copilotEnabled ||
+      clineEnabledInput.checked !== initialState.clineEnabled ||
       globalInstructionsInput.checked !== initialState.globalInstructions ||
       localFolderInput.value !== initialState.localFolder ||
       excludePatternsInput.value !== initialState.excludePatterns ||
@@ -427,7 +430,7 @@ export function buildSettingsScript(): string {
   aiProviderSelect.addEventListener('change', function() {
     checkDirty(); clearSaveFeedback(); syncProviderCard();
   });
-  [claudeEnabledInput, codexEnabledInput, geminiEnabledInput, openCodeEnabledInput, cursorEnabledInput, copilotEnabledInput, globalInstructionsInput].forEach(function(input) {
+  [claudeEnabledInput, codexEnabledInput, geminiEnabledInput, openCodeEnabledInput, cursorEnabledInput, copilotEnabledInput, clineEnabledInput, globalInstructionsInput].forEach(function(input) {
     input.addEventListener('change', function() { validateAll(); checkDirty(); clearSaveFeedback(); });
   });
   dcoSignoffInput.addEventListener('change', function() { checkDirty(); clearSaveFeedback(); });
@@ -462,6 +465,7 @@ export function buildSettingsScript(): string {
         openCodeEnabled: openCodeEnabledInput.checked,
         cursorEnabled: cursorEnabledInput.checked,
         copilotEnabled: copilotEnabledInput.checked,
+        clineEnabled: clineEnabledInput.checked,
         globalInstructions: globalInstructionsInput.checked,
         localFolder: localFolderInput.value.trim(),
         excludePatterns: excludePatternsInput.value,
@@ -576,6 +580,7 @@ export function buildSettingsScript(): string {
         openCodeEnabledInput.checked = msg.settings.openCodeEnabled;
         cursorEnabledInput.checked = msg.settings.cursorEnabled;
         copilotEnabledInput.checked = msg.settings.copilotEnabled;
+        clineEnabledInput.checked = msg.settings.clineEnabled;
         globalInstructionsInput.checked = !!msg.settings.globalInstructions;
         localFolderInput.value = msg.settings.localFolder || '';
         excludePatternsInput.value = msg.settings.excludePatterns;

--- a/vscode/src/views/SettingsWebviewPanel.test.ts
+++ b/vscode/src/views/SettingsWebviewPanel.test.ts
@@ -1511,6 +1511,73 @@ describe("SettingsWebviewPanel", () => {
 			);
 		});
 
+		it("loads clineEnabled from config (default true)", async () => {
+			const dispatch = await setupWithLoadedConfig({ clineEnabled: false });
+			dispatch({ command: "loadSettings" });
+			await flushPromises();
+
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: "settingsLoaded",
+					settings: expect.objectContaining({ clineEnabled: false }),
+				}),
+			);
+
+			postMessage.mockClear();
+			SettingsWebviewPanel.dispose();
+			mockLoadConfigFromDir.mockResolvedValue({
+				apiKey: undefined,
+				model: "sonnet",
+				maxTokens: null,
+				jolliApiKey: undefined,
+				claudeEnabled: true,
+				codexEnabled: true,
+				geminiEnabled: true,
+				// clineEnabled intentionally absent
+				excludePatterns: [],
+			});
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch2 = captureMessageHandler();
+			dispatch2({ command: "loadSettings" });
+			await flushPromises();
+
+			expect(postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					command: "settingsLoaded",
+					settings: expect.objectContaining({ clineEnabled: true }),
+				}),
+			);
+		});
+
+		it("persists clineEnabled when the user submits", async () => {
+			const dispatch = await setupWithLoadedConfig({ clineEnabled: true });
+
+			dispatch({
+				command: "applySettings",
+				maskedApiKey: "",
+				maskedJolliApiKey: "",
+				settings: {
+					apiKey: "",
+					model: "sonnet",
+					maxTokens: null,
+					jolliApiKey: "",
+					claudeEnabled: true,
+					codexEnabled: true,
+					geminiEnabled: true,
+					openCodeEnabled: true,
+					copilotEnabled: true,
+					clineEnabled: false,
+					excludePatterns: "",
+				},
+			});
+			await flushPromises();
+
+			expect(mockSaveConfigScoped).toHaveBeenCalledWith(
+				expect.objectContaining({ clineEnabled: false }),
+				expect.any(String),
+			);
+		});
+
 		it("removes Claude and Gemini hooks when disabled", async () => {
 			const dispatch = await setupWithLoadedConfig();
 

--- a/vscode/src/views/SettingsWebviewPanel.ts
+++ b/vscode/src/views/SettingsWebviewPanel.ts
@@ -55,6 +55,7 @@ interface SettingsPayload {
 	readonly openCodeEnabled: boolean;
 	readonly cursorEnabled: boolean;
 	readonly copilotEnabled: boolean;
+	readonly clineEnabled: boolean;
 	/** Tri-state config switch (undecided | "enabled" | "disabled") flattened to a checkbox; see handleApplySettings for the enable/disable/preserve-undecided persistence rules. */
 	readonly globalInstructions: boolean;
 	readonly localFolder: string;
@@ -462,6 +463,7 @@ export class SettingsWebviewPanel {
 			openCodeEnabled: config.openCodeEnabled !== false,
 			cursorEnabled: config.cursorEnabled !== false,
 			copilotEnabled: config.copilotEnabled !== false,
+			clineEnabled: config.clineEnabled !== false,
 			globalInstructions: config.globalInstructions === "enabled",
 			localFolder: config.localFolder ?? "",
 			excludePatterns: config.excludePatterns
@@ -610,6 +612,7 @@ export class SettingsWebviewPanel {
 			openCodeEnabled: settings.openCodeEnabled,
 			cursorEnabled: settings.cursorEnabled,
 			copilotEnabled: settings.copilotEnabled,
+			clineEnabled: settings.clineEnabled,
 			...giUpdate,
 			localFolder:
 				settings.localFolder && settings.localFolder.length > 0

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -166,11 +166,12 @@ describe("SidebarScriptBuilder", () => {
 	it("defines a per-source brand-icon map covering every provider", () => {
 		const js = buildSidebarScript();
 		expect(js).toContain("var SOURCE_ICON_SVG = {");
-		for (const src of ["claude", "codex", "gemini", "cursor", "copilot", "opencode"]) {
+		for (const src of ["claude", "codex", "gemini", "cursor", "copilot", "opencode", "cline"]) {
 			expect(js).toContain(`${src}:`);
 		}
-		// copilot-chat reuses the Copilot mark.
+		// copilot-chat reuses the Copilot mark; cline-cli reuses the Cline mark.
 		expect(js).toContain("SOURCE_ICON_SVG['copilot-chat'] = SOURCE_ICON_SVG.copilot");
+		expect(js).toContain("SOURCE_ICON_SVG['cline-cli'] = SOURCE_ICON_SVG.cline");
 		// Parsed as a trusted constant via DOMParser, not innerHTML.
 		expect(js).toContain("new DOMParser().parseFromString(markup, 'image/svg+xml')");
 		expect(js).not.toContain(".innerHTML = markup");

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -4538,6 +4538,8 @@ export function buildSidebarScript(): string {
       case 'opencode':     return 'OpenCode';
       case 'copilot':      return 'Copilot';
       case 'copilot-chat': return 'Copilot Chat';
+      case 'cline':        return 'Cline (VS Code)';
+      case 'cline-cli':    return 'Cline CLI';
       default:             return source;
     }
   }
@@ -4583,8 +4585,18 @@ export function buildSidebarScript(): string {
       '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">' +
       '<g fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">' +
       '<path d="M3.5 5 7 8l-3.5 3"/><line x1="8.5" y1="11.5" x2="13" y2="11.5"/></g></svg>',
+    cline:
+      '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">' +
+      '<circle cx="8" cy="2.1" r="1.05" fill="currentColor"/>' +
+      '<g fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round" stroke-linecap="round">' +
+      '<line x1="8" y1="3.15" x2="8" y2="4.7"/>' +
+      '<path d="M5.1 4.7h5.8a2.9 2.9 0 0 1 2.9 2.9v.5l1 1.7-1 1.7v.5a2.9 2.9 0 0 1-2.9 2.9H5.1a2.9 2.9 0 0 1-2.9-2.9v-.5l-1-1.7 1-1.7v-.5A2.9 2.9 0 0 1 5.1 4.7Z"/></g>' +
+      '<g fill="currentColor"><rect x="5.5" y="7.6" width="1.5" height="3.5" rx="0.75"/><rect x="9" y="7.6" width="1.5" height="3.5" rx="0.75"/></g></svg>',
   };
   SOURCE_ICON_SVG['copilot-chat'] = SOURCE_ICON_SVG.copilot;
+  // Cline ships two transcript sources (VS Code extension + terminal CLI); both
+  // wear the same robot-head mark, mirroring the copilot / copilot-chat pairing.
+  SOURCE_ICON_SVG['cline-cli'] = SOURCE_ICON_SVG.cline;
 
   // Build the leading source glyph for a conversation row. Parses the trusted
   // constant via DOMParser (NOT innerHTML-for-content; CSP also forbids <img>

--- a/vscode/src/views/SummaryScriptBuilder.test.ts
+++ b/vscode/src/views/SummaryScriptBuilder.test.ts
@@ -246,6 +246,15 @@ describe("SummaryScriptBuilder", () => {
 		expect(script).toMatch(/'copilot',\s*'copilot-chat'/);
 	});
 
+	it("defines a Cline brand glyph and aliases cline-cli to it", () => {
+		expect(script).toContain("cline:");
+		expect(script).toContain("SOURCE_ICON_SVG['cline-cli'] = SOURCE_ICON_SVG.cline");
+	});
+
+	it("includes both Cline sources in sourceOrder", () => {
+		expect(script).toMatch(/'copilot-chat',\s*'cline',\s*'cline-cli'/);
+	});
+
 	describe("Regenerate summary re-render wiring", () => {
 		// The emitted JS runs in the webview iframe and is not unit-testable
 		// at runtime in vitest. These string-contain assertions pin the

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -2146,8 +2146,18 @@ export function buildScript(options: SummaryScriptOptions = {}): string {
       '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">' +
       '<g fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">' +
       '<path d="M3.5 5 7 8l-3.5 3"/><line x1="8.5" y1="11.5" x2="13" y2="11.5"/></g></svg>',
+    cline:
+      '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">' +
+      '<circle cx="8" cy="2.1" r="1.05" fill="currentColor"/>' +
+      '<g fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round" stroke-linecap="round">' +
+      '<line x1="8" y1="3.15" x2="8" y2="4.7"/>' +
+      '<path d="M5.1 4.7h5.8a2.9 2.9 0 0 1 2.9 2.9v.5l1 1.7-1 1.7v.5a2.9 2.9 0 0 1-2.9 2.9H5.1a2.9 2.9 0 0 1-2.9-2.9v-.5l-1-1.7 1-1.7v-.5A2.9 2.9 0 0 1 5.1 4.7Z"/></g>' +
+      '<g fill="currentColor"><rect x="5.5" y="7.6" width="1.5" height="3.5" rx="0.75"/><rect x="9" y="7.6" width="1.5" height="3.5" rx="0.75"/></g></svg>',
   };
   SOURCE_ICON_SVG['copilot-chat'] = SOURCE_ICON_SVG.copilot;
+  // Cline's VS Code extension + terminal CLI share one robot-head mark, as
+  // copilot / copilot-chat do above.
+  SOURCE_ICON_SVG['cline-cli'] = SOURCE_ICON_SVG.cline;
 
   // Render inline conversation rows from the host's conversationsData payload.
   // Interpolated host-supplied strings (title/source/ids) go through esc(),
@@ -2348,7 +2358,7 @@ ${buildSourceLabelScript()}
       if (conversationsStats) {
         var sessionCounts = msg.sessionCounts || {};
         var parts = [];
-        var sourceOrder = ['claude', 'codex', 'gemini', 'opencode', 'cursor', 'copilot', 'copilot-chat'];
+        var sourceOrder = ['claude', 'codex', 'gemini', 'opencode', 'cursor', 'copilot', 'copilot-chat', 'cline', 'cline-cli'];
         for (var i = 0; i < sourceOrder.length; i++) {
           var source = sourceOrder[i];
           var count = sessionCounts[source] || 0;


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer added Cline session source integration to jollimemory, enabling the post-commit hook to automatically capture sessions from both the Cline CLI tool and the Cline VS Code extension. Users running either form of Cline now have their AI-assisted coding conversations automatically documented and indexed alongside other agent sessions, bringing Cline into parity with other supported agents like Copilot and Cursor. The integration works seamlessly across multiple VS Code variants including Code, Insiders, Cursor, Windsurf, and VSCodium.

Cline sessions now display a distinctive robot-head brand icon across conversation views in both VSCode and IntelliJ, providing instant visual identity. Both the VS Code extension and CLI entry points display the same robot-head icon, positioning Cline as a unified agent presence across all entry points. Conversation counts in the summary view break down Cline sessions by source, improving visibility into how different AI agents have been used. The icon adapts automatically to the user's light or dark theme in both IDEs.

---

## Topics (2)
<details>
<summary><strong>01 · Add Cline brand icon across session views and sources</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Cline agent was integrated as a session source for both CLI and VS Code entry points but lacked a distinctive brand icon, falling back to generic glyphs.

**💡 Decisions Behind the Code**

- **Monochrome glyph from hand-authored primitives**: Agent brand marks in this app are hand-drawn glyphs tuned for legibility in tree rows, not exact-replica logos. The Cline robot head (antenna, eye bars, ear-tabs) renders clearly and recognizably in this minimal style, following the pattern used for all other agents.
- **Platform-specific color handling**: VSCode allows the icon to adapt to the user's theme (light or dark) automatically; IntelliJ displays require hard-coded colors that match both themes. The two platforms have different rendering constraints, but both approaches produce the same visual result: the icon always matches the user's theme.
- **Unified Cline brand across entry points**: Both the VS Code extension and CLI source display the same robot-head icon, positioning Cline as a single unified brand. This mirrors how other multi-source agents like Copilot are branded, avoiding confusion from multiple visually distinct icons for the same agent.

**✅ What Was Implemented**

- Added Cline robot-head brand glyph (16px monochrome SVG) to the SOURCE_ICON_SVG maps in SidebarScriptBuilder, SummaryScriptBuilder, and NextMemoryScriptBuilder, so conversation rows now display the distinctive Cline logo instead of a generic icon.
- Created light and dark IntelliJ resource SVG files (source-cline.svg and source-cline_dark.svg) and wired them through WorkingMemoryHtmlBuilder.sourceIconSvg(), ensuring consistent branding across IDEs.
- Added both cline and cline-cli sources to the sourceOrder array in SummaryScriptBuilder, so conversation counts now break down by Cline agent separately.

**📁 FILES**
- `vscode/src/views/SidebarScriptBuilder.ts`
- `vscode/src/views/SummaryScriptBuilder.ts`
- `vscode/src/views/NextMemoryScriptBuilder.ts`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/WorkingMemoryHtmlBuilder.kt`
- `intellij/src/main/resources/icons/source-cline.svg`

</blockquote>
</details>
<details>
<summary><strong>02 · Add Cline session source capture for CLI and VS Code extension</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Cline exists in two independent forms (a CLI tool and a VS Code extension) with completely different storage layouts and message schemas, and jollimemory needed to capture sessions from both.

**💡 Decisions Behind the Code**

- **Plain-file discovery for CLI instead of SQLite**: The Cline CLI stores sessions in a WAL-mode SQLite database where the main file is empty and all data lives in the .db-wal sidecar. Reading this with pure-JavaScript parsers fails silently, a trap that claimed the OpenCode integration. Scanning plain JSON sidecars instead avoids the WAL hazard entirely while simplifying the dependency graph—no node:sqlite gate needed and more resilient to database migrations.
- **Real machine fixture grounding**: Rather than writing test fixtures from documentation or imagination, the developer captured actual Cline data from the development machine and embedded it into test cases. This prevents the self-consistent-but-completely-wrong closure that affected Codex and Gemini integrations in past PRs, where fixtures matched the parser but mismatched reality.
- **Merged config flag and status display**: Although CLI and extension are separate sources with different storage, both are governed by a single clineEnabled flag and shown as a merged status row with an indented per-form breakdown. This matches the Copilot CLI/Chat precedent, simplifies the user-facing configuration surface, and still allows per-form detection and error reporting.

**✅ What Was Implemented**

- Implemented the Cline CLI source triplet to scan plain JSON sidecars in ~/.cline/data/sessions/ instead of the WAL-mode SQLite database, avoiding the silent data-loss trap that affected earlier integrations. The detector, discoverer, and transcript reader follow the existing pattern but operate entirely on plain files.
- Implemented the Cline VS Code extension source triplet with cross-VS Code-flavor support by extending VscodeFlavor to include Code, Insiders, Cursor, Windsurf, and VSCodium. The discoverer scans each flavor's globalStorage directory and merges results, ensuring users get Cline session capture regardless of which VS Code variant they run.
- Wired both sources into the existing transcript pipeline across config, detection, discovery, reading, and status display. Both sources are governed by a single clineEnabled flag (following the Copilot CLI/Chat precedent) and shown as a merged status row with a per-form breakdown.

**📁 FILES**
- `cli/src/core/ClineTranscriptShared.ts`
- `cli/src/core/ClineCliSessionDiscoverer.ts`
- `cli/src/core/ClineCliTranscriptReader.ts`
- `cli/src/core/ClineSessionDiscoverer.ts`
- `cli/src/Types.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 19, 2026 at 3:20 PM · via Local agent*
<!-- jollimemory-summary-end -->
