### PR TITLE
Add Slack thread connector for CodexEnvelopeParser

### DIFF
--- a/cli/src/core/references/CodexEnvelopeParser.test.ts
+++ b/cli/src/core/references/CodexEnvelopeParser.test.ts
@@ -1121,3 +1121,154 @@ describe("CodexEnvelopeParser.parse — monday (itemIds gate from event or funct
 		expect(results.filter((r) => r.def.id === "monday")).toHaveLength(0);
 	});
 });
+
+// ─── Slack thread (codex_apps slack connector) ───────────────────────────────
+// Real 2026-07-18 rollout shape: the pasted permalink lives in a user turn (two
+// line variants), the thread result arrives via mcp_tool_call_end ONLY (no
+// function_call_output), and neither the tool args nor the result carry a url.
+
+const SLACK_PERMALINK = "https://flyer-q4r7867.slack.com/archives/C0BFF9UHBD1/p1783413984700009";
+const SLACK_THREAD_BLOB = {
+	messages:
+		"=== THREAD PARENT MESSAGE ===\n" +
+		"From: Flyer Li <li@example.com> (U0BGFSM16DN)\n" +
+		"Time: 2026-07-07 16:46:24 CST\n" +
+		"Message TS: 1783413984.700009\n" +
+		"Consolidate the existing MCP reference integrations into one engine.\n\n" +
+		"=== THREAD REPLIES (2 total) ===\n\n" +
+		"--- Reply 1 of 2 ---\nMessage TS: 1783415917.422609\nConfig-driven MCP integration\n",
+};
+const SLACK_ARGS = JSON.stringify({ channel_id: "C0BFF9UHBD1", message_ts: "1783413984.700009", limit: 50 });
+
+/** Codex response_item `message` (role:user) with input_text blocks. */
+function codexUserMsg(text: string): string {
+	return jsonl({
+		type: "response_item",
+		timestamp: TS,
+		payload: { type: "message", role: "user", content: [{ type: "input_text", text }] },
+	});
+}
+
+/** Codex event `user_message` with a bare string message. */
+function codexUserMessageEvent(text: string): string {
+	return jsonl({ type: "event_msg", timestamp: TS, payload: { type: "user_message", message: text } });
+}
+
+describe("CodexEnvelopeParser — Slack thread connector", () => {
+	it("captures the thread via the mcp_tool_call_end event, url harvested from the pasted permalink", () => {
+		const lines = [
+			codexUserMsg(`[${SLACK_PERMALINK}](${SLACK_PERMALINK})\n`),
+			fnCall("mcp__codex_apps__slack", "_slack_read_thread", "c_slack", SLACK_ARGS),
+			toolCallEnd("slack.slack_read_thread", "c_slack", SLACK_THREAD_BLOB, {
+				channel_id: "C0BFF9UHBD1",
+				message_ts: "1783413984.700009",
+				limit: 50,
+			}),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results).toHaveLength(1);
+		expect(results[0].def.id).toBe("slack");
+		expect(results[0].toolName).toBe("mcp__claude_ai_Slack__slack_read_thread");
+		const p = results[0].payload as { channelId: string; parentTs: string; url?: string };
+		expect(p).toMatchObject({ channelId: "C0BFF9UHBD1", parentTs: "1783413984.700009", url: SLACK_PERMALINK });
+	});
+
+	it("harvests the permalink from the bare-string user_message event shape too", () => {
+		const lines = [
+			codexUserMessageEvent(`${SLACK_PERMALINK}\n`),
+			toolCallEnd("slack.slack_read_thread", "c_slack2", SLACK_THREAD_BLOB, {
+				channel_id: "C0BFF9UHBD1",
+				message_ts: "1783413984.700009",
+			}),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect((results[0].payload as { url?: string }).url).toBe(SLACK_PERMALINK);
+	});
+
+	it("reconstructs the url from slackWorkspaceUrl when no permalink was pasted", () => {
+		const lines = [
+			toolCallEnd("slack.slack_read_thread", "c_slack3", SLACK_THREAD_BLOB, {
+				channel_id: "C0BFF9UHBD1",
+				message_ts: "1783413984.700009",
+			}),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, { slackWorkspaceUrl: "https://flyer-q4r7867.slack.com" });
+		expect((results[0].payload as { url?: string }).url).toBe(SLACK_PERMALINK);
+	});
+
+	it("surfaces a urlless canonical when neither permalink nor workspace url is present (extractRef voids it downstream)", () => {
+		// The parser is a lower layer than extractRef: it still emits the canonical
+		// thread with no url. The slack definition marks url required, so
+		// `SourceEngine.extractRef` is where this urlless payload is voided — mirrors
+		// the Claude parser's equivalent test; nothing is stored end-to-end.
+		const lines = [
+			toolCallEnd("slack.slack_read_thread", "c_slack4", SLACK_THREAD_BLOB, {
+				channel_id: "C0BFF9UHBD1",
+				message_ts: "1783413984.700009",
+			}),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results).toHaveLength(1);
+		expect((results[0].payload as { url?: string }).url).toBeUndefined();
+	});
+
+	it("voids the thread when the event carries no request arguments (no channel/ts to read)", () => {
+		// exec/apps event with neither `invocation.arguments` nor a paired
+		// function_call → readSlackToolInput gets `undefined` → normalize voids.
+		const lines = [toolCallEnd("slack.slack_read_thread", "c_slack_noargs", SLACK_THREAD_BLOB)];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results.filter((r) => r.def.id === "slack")).toHaveLength(0);
+	});
+
+	it("voids the thread when request arguments lack channel_id/message_ts", () => {
+		const lines = [toolCallEnd("slack.slack_read_thread", "c_slack_badargs", SLACK_THREAD_BLOB, { limit: 50 })];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results.filter((r) => r.def.id === "slack")).toHaveLength(0);
+	});
+
+	it("recovers the thread from the event when the paired function_call_output blob is malformed", () => {
+		// Regression guard: a slack function_call_output that normalizes to null
+		// (no parent `Message TS:` in the blob) must NOT mark the call `emitted` and
+		// suppress the valid mcp_tool_call_end event — that would silently drop the
+		// reference. The FALLBACK recovers it from the good event.
+		const lines = [
+			codexUserMsg(`[${SLACK_PERMALINK}](${SLACK_PERMALINK})\n`),
+			fnCall("mcp__codex_apps__slack", "_slack_read_thread", "c_recover", SLACK_ARGS),
+			fnOutput("c_recover", { messages: "no parent ts here" }, { wrap: "envelope", prefix: true }),
+			toolCallEnd("slack.slack_read_thread", "c_recover", SLACK_THREAD_BLOB, {
+				channel_id: "C0BFF9UHBD1",
+				message_ts: "1783413984.700009",
+			}),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		const slack = results.filter((r) => r.def.id === "slack");
+		expect(slack).toHaveLength(1);
+		expect((slack[0].payload as { url?: string }).url).toBe(SLACK_PERMALINK);
+	});
+});
+
+describe("CodexEnvelopeParser end-to-end — Slack thread via extractReferencesFromTranscript", () => {
+	let dir: string;
+	let file: string;
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), "codex-slack-"));
+		file = join(dir, "rollout.jsonl");
+		const lines = [
+			codexUserMsg(`[${SLACK_PERMALINK}](${SLACK_PERMALINK})\n`),
+			fnCall("mcp__codex_apps__slack", "_slack_read_thread", "c_slack", SLACK_ARGS),
+			toolCallEnd("slack.slack_read_thread", "c_slack", SLACK_THREAD_BLOB, {
+				channel_id: "C0BFF9UHBD1",
+				message_ts: "1783413984.700009",
+			}),
+		];
+		writeFileSync(file, `${lines.join("\n")}\n`, "utf-8");
+	});
+	afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+	it("stores a slack reference with the harvested permalink url", async () => {
+		const { references } = await extractReferencesFromTranscript(file, { source: "codex" });
+		const ref = references.find((r) => r.mapKey === "slack:C0BFF9UHBD1-1783413984.700009");
+		expect(ref?.url).toBe(SLACK_PERMALINK);
+		expect(ref?.title?.startsWith("Consolidate")).toBe(true);
+	});
+});

--- a/cli/src/core/references/CodexEnvelopeParser.ts
+++ b/cli/src/core/references/CodexEnvelopeParser.ts
@@ -39,8 +39,10 @@
 
 import { createLogger } from "../../Logger.js";
 import { type CliBinding, matchCliCommand } from "./bindings/cli/index.js";
+import type { CodexNormalizeEnv } from "./bindings/codex/CodexBinding.js";
 import { CODEX_APPS_NAMESPACE_PREFIX, getCodexNormalizer } from "./bindings/codex/index.js";
 import { isObject } from "./guards.js";
+import { scanCodexUserPermalinks } from "./SlackPermalink.js";
 import type { SourceDefinition } from "./SourceDefinition.js";
 import { getRegistry } from "./SourceDefinitionRegistry.js";
 import type {
@@ -95,6 +97,15 @@ class CodexEnvelopeParser implements TranscriptEnvelopeParser {
 	parse(lines: string[], opts: ExtractOptions): EnvelopeParseResult {
 		const fromLine = opts.fromLineNumber ?? 0;
 		const registry = getRegistry();
+		// Slack's url lives only in the pasted permalink (never the payload/args),
+		// so harvest it once per scan and thread it — plus the workspace-url
+		// fallback — into every normalize call, exactly as the Claude parser does.
+		// Scanning from line 0 (not `fromLine`) so a permalink pasted before the
+		// cursor still resolves a thread fetched after it.
+		const slackEnv: CodexNormalizeEnv = {
+			permalinks: scanCodexUserPermalinks(lines),
+			slackWorkspaceUrl: opts.slackWorkspaceUrl,
+		};
 
 		const calls = new Map<string, FunctionCallRow>();
 		const shellCalls = new Map<string, ShellCallRow>();
@@ -217,13 +228,17 @@ class CodexEnvelopeParser implements TranscriptEnvelopeParser {
 			/* v8 ignore start -- every registry codex definition has a matching CodexBinding; guarded for totality. */
 			if (normalizer === undefined) continue;
 			/* v8 ignore stop */
-			emitted.add(callId);
-			// A gating normalizer (monday's itemIds gate) returns null to void — skip
-			// it rather than push a null payload, mirroring the Claude envelope's
-			// context-normalizer null handling. The call is still marked emitted so
-			// the FALLBACK never re-processes it.
-			const payload = normalizer.normalize(business, parseArguments(call.arguments));
+			// A normalizer returns null to void — skip it rather than push a null
+			// payload, mirroring the Claude envelope's context-normalizer null
+			// handling. Crucially, only mark the call `emitted` on SUCCESS: a null
+			// here can mean the payload was malformed/blank (e.g. Slack's url-less
+			// blob), for which a paired `mcp_tool_call_end` event is a valid recovery
+			// source — leaving the call open lets the FALLBACK retry it. A re-gating
+			// normalizer (monday's itemIds gate) simply gates closed again in the
+			// fallback (see the board-browse FALLBACK tests), so this never floods.
+			const payload = normalizer.normalize(business, parseArguments(call.arguments), slackEnv);
 			if (payload === null) continue;
+			emitted.add(callId);
 			results.push({
 				def,
 				toolName: normalizer.canonicalToolName,
@@ -268,11 +283,12 @@ class CodexEnvelopeParser implements TranscriptEnvelopeParser {
 			let business = tryParse(ev.text);
 			if (business === null) continue;
 			// Recovery (NOT the main path): reaching the fallback for a call_id that
-			// ALSO has a function_call output means that output failed to parse (a
-			// successful parse would have emitted + marked it in PRIMARY). Some fields
-			// live ONLY on that malformed output (e.g. Jira's tenant webUrl), so let
-			// the binding stitch them onto this valid event payload. Bindings without
-			// this brittle edge leave `recover` unset.
+			// ALSO has a function_call output means that output either failed to parse
+			// or normalized to null (a successful, non-null normalize would have marked
+			// it `emitted` in PRIMARY). Some fields live ONLY on that malformed output
+			// (e.g. Jira's tenant webUrl), so let the binding stitch them onto this
+			// valid event payload. Bindings without this brittle edge leave `recover`
+			// unset.
 			if (normalizer.recover !== undefined && ev.callId !== undefined) {
 				const rawOutput = outputs.get(ev.callId)?.output;
 				if (rawOutput !== undefined) {
@@ -291,7 +307,7 @@ class CodexEnvelopeParser implements TranscriptEnvelopeParser {
 			// when NEITHER is present — dropping is safer than flooding a whole board.
 			const toolInput =
 				ev.arguments ?? (ev.callId !== undefined ? parseArguments(calls.get(ev.callId)?.arguments) : undefined);
-			const payload = normalizer.normalize(business, toolInput);
+			const payload = normalizer.normalize(business, toolInput, slackEnv);
 			if (payload === null) continue;
 			results.push({
 				def,

--- a/cli/src/core/references/SlackPermalink.test.ts
+++ b/cli/src/core/references/SlackPermalink.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseSlackPermalink, scanUserPermalinks } from "./SlackPermalink.js";
+import { parseSlackPermalink, scanCodexUserPermalinks, scanUserPermalinks } from "./SlackPermalink.js";
 
 const URL = "https://flyer-q4r7867.slack.com/archives/C0BFF9UHBD1/p1783413984700009";
 
@@ -104,5 +104,76 @@ describe("scanUserPermalinks", () => {
 	it("ignores lines missing the message key entirely", () => {
 		const lines = [JSON.stringify({ someOtherKey: "https://x.slack.com/archives/C1/p1" })];
 		expect(scanUserPermalinks(lines).size).toBe(0);
+	});
+});
+
+describe("scanCodexUserPermalinks", () => {
+	it("reads the codex `message` response_item (role:user, input_text blocks)", () => {
+		const lines = [
+			JSON.stringify({
+				payload: { type: "message", role: "user", content: [{ type: "input_text", text: `see ${URL}` }] },
+			}),
+		];
+		expect(scanCodexUserPermalinks(lines).get("C0BFF9UHBD1:1783413984.700009")).toBe(URL);
+	});
+	it("reads the codex `user_message` event (bare string message)", () => {
+		const lines = [JSON.stringify({ payload: { type: "user_message", message: `${URL}\n` } })];
+		expect(scanCodexUserPermalinks(lines).get("C0BFF9UHBD1:1783413984.700009")).toBe(URL);
+	});
+	it("dedupes the same thread appearing in both line shapes", () => {
+		const lines = [
+			JSON.stringify({
+				payload: { type: "message", role: "user", content: [{ type: "input_text", text: URL }] },
+			}),
+			JSON.stringify({ payload: { type: "user_message", message: URL } }),
+		];
+		expect(scanCodexUserPermalinks(lines).size).toBe(1);
+	});
+	it("ignores invalid JSON lines", () => {
+		const lines = ['{"payload": {"type": "user_message", "message": "https://x.slack.com/archives/C1/p1"'];
+		expect(scanCodexUserPermalinks(lines).size).toBe(0);
+	});
+	it("ignores lines without slack.com/archives/", () => {
+		const lines = [JSON.stringify({ payload: { type: "user_message", message: "https://example.com" } })];
+		expect(scanCodexUserPermalinks(lines).size).toBe(0);
+	});
+	it("ignores lines with a missing/null payload", () => {
+		const lines = [
+			JSON.stringify({ someKey: "https://x.slack.com/archives/C1/p1" }),
+			JSON.stringify({ payload: null, note: "https://x.slack.com/archives/C1/p1" }),
+		];
+		expect(scanCodexUserPermalinks(lines).size).toBe(0);
+	});
+	it("ignores an assistant `message` and a non-array content", () => {
+		const lines = [
+			JSON.stringify({
+				payload: { type: "message", role: "assistant", content: [{ type: "input_text", text: URL }] },
+			}),
+			JSON.stringify({ payload: { type: "message", role: "user", content: "not-array", note: URL } }),
+		];
+		expect(scanCodexUserPermalinks(lines).size).toBe(0);
+	});
+	it("ignores non-object blocks and non-input_text / non-string blocks", () => {
+		const lines = [
+			JSON.stringify({
+				payload: {
+					type: "message",
+					role: "user",
+					content: [null, "str", { type: "output_text", text: URL }, { type: "input_text", text: 123 }],
+					note: URL,
+				},
+			}),
+		];
+		expect(scanCodexUserPermalinks(lines).size).toBe(0);
+	});
+	it("ignores a user_message whose message is not a string", () => {
+		const lines = [JSON.stringify({ payload: { type: "user_message", message: 42, note: URL } })];
+		expect(scanCodexUserPermalinks(lines).size).toBe(0);
+	});
+	it("ignores an archives url that is not a full thread permalink (no p<ts>)", () => {
+		const lines = [
+			JSON.stringify({ payload: { type: "user_message", message: "https://x.slack.com/archives/C1" } }),
+		];
+		expect(scanCodexUserPermalinks(lines).size).toBe(0);
 	});
 });

--- a/cli/src/core/references/SlackPermalink.ts
+++ b/cli/src/core/references/SlackPermalink.ts
@@ -57,3 +57,48 @@ export function scanUserPermalinks(lines: string[]): Map<string, string> {
 	}
 	return out;
 }
+
+interface CodexUserLine {
+	payload?: { type?: unknown; role?: unknown; content?: unknown; message?: unknown };
+}
+
+/**
+ * Codex counterpart of {@link scanUserPermalinks}. A Codex rollout carries the
+ * user's pasted permalink in one of two `payload`-nested shapes (both observed
+ * in a real 2026-07-18 rollout):
+ *   - a `message` response_item (`role:"user"`) whose content blocks are
+ *     `{type:"input_text", text}` — NOT Claude's `text`; and
+ *   - a `user_message` event whose `message` is a bare string.
+ * Both are scanned; the `<channel>:<parentTs>` key dedupes the same thread that
+ * appears in both line types. Non-user lines (including the tool result blob,
+ * which never contains the permalink) are ignored so no thread is double-sourced.
+ */
+export function scanCodexUserPermalinks(lines: string[]): Map<string, string> {
+	const out = new Map<string, string>();
+	for (const line of lines) {
+		if (!line.includes(".slack.com/archives/")) continue;
+		let parsed: CodexUserLine;
+		try {
+			parsed = JSON.parse(line) as CodexUserLine;
+		} catch {
+			continue;
+		}
+		const p = parsed.payload;
+		if (p === undefined || p === null) continue;
+		const texts: string[] = [];
+		if (p.type === "message" && p.role === "user" && Array.isArray(p.content)) {
+			for (const block of p.content) {
+				if (typeof block !== "object" || block === null) continue;
+				const b = block as { type?: unknown; text?: unknown };
+				if (b.type === "input_text" && typeof b.text === "string") texts.push(b.text);
+			}
+		} else if (p.type === "user_message" && typeof p.message === "string") {
+			texts.push(p.message);
+		}
+		for (const text of texts) {
+			const link = parseSlackPermalink(text);
+			if (link !== null) out.set(`${link.channel}:${link.parentTs}`, link.url);
+		}
+	}
+	return out;
+}

--- a/cli/src/core/references/bindings/codex/CodexBinding.ts
+++ b/cli/src/core/references/bindings/codex/CodexBinding.ts
@@ -16,10 +16,27 @@
  *
  * Adding a newly-observed tool/shape = extend one binding file's `normalize`
  * (add a collection key, or a URL backfill) plus the registry's match identity;
- * never touch the parser.
+ * never touch the parser. The one standing exception is parse-scoped context
+ * collection — data that lives in neither the payload nor the args and can only
+ * be harvested by scanning the whole transcript (e.g. Slack's url, pasted as a
+ * permalink elsewhere in the rollout). That is inherently the parser's job; it
+ * gathers such context once and threads it in via {@link CodexNormalizeEnv},
+ * which the binding reads. Extending the env is expected, not a boundary breach.
  */
 
 import type { SourceId } from "../../../../Types.js";
+
+/**
+ * Parse-scoped context a Codex normalizer may read beyond the tool result
+ * payload and its request `arguments`. Today only Slack uses it: its url lives
+ * in neither the payload nor the args — only in the pasted permalink (harvested
+ * into `permalinks`) or the reconstructable `slackWorkspaceUrl` config. Mirrors
+ * the Claude parser's `ContextNormalizeEnv`; every other binding ignores it.
+ */
+export interface CodexNormalizeEnv {
+	readonly permalinks: Map<string, string>;
+	readonly slackWorkspaceUrl?: string;
+}
 
 export interface CodexNormalizer {
 	readonly id: SourceId;
@@ -33,9 +50,10 @@ export interface CodexNormalizer {
 	 * parsed `function_call` `arguments` (undefined when absent); only sources that
 	 * gate on their input read it (monday's `itemIds`). Every other binding ignores
 	 * it. Implementations use {@link normalizeEntities} so both shapes are handled
-	 * uniformly.
+	 * uniformly. `env` carries parse-scoped context (the pasted-permalink map,
+	 * workspace url) — only Slack reads it; every other binding omits the param.
 	 */
-	normalize(business: unknown, toolInput?: unknown): unknown;
+	normalize(business: unknown, toolInput?: unknown, env?: CodexNormalizeEnv): unknown;
 
 	/**
 	 * OPTIONAL recovery — **not** the main path. The normal path is: parse the

--- a/cli/src/core/references/bindings/codex/CodexSlackBinding.ts
+++ b/cli/src/core/references/bindings/codex/CodexSlackBinding.ts
@@ -1,0 +1,54 @@
+/**
+ * CodexSlackBinding — Slack `codex_apps` connector normalizer.
+ *
+ * Reached through `_slack_read_thread` (namespace `mcp__codex_apps__slack`), or
+ * the `slack.slack_read_thread` invocation on the fallback path — match identity
+ * lives in `slackDefinition.match.codex`. In practice the connector emits the
+ * thread ONLY via `mcp_tool_call_end` (no `function_call_output`), so this
+ * binding is normally reached on the FALLBACK path.
+ *
+ * Slack is the one source whose url is in neither the result blob nor the tool
+ * arguments — it lives only in the pasted permalink. So, exactly like the Claude
+ * slack path, this reads `{channel_id, message_ts}` from the request `arguments`
+ * and resolves the url from `env` (the harvested permalink map, else the
+ * reconstructable `slackWorkspaceUrl` config), then hands both to the shared
+ * `normalizeSlackThread`. A thread whose url cannot be resolved yields a urlless
+ * canonical that `SourceEngine.extractRef` voids downstream (url is required).
+ */
+
+import { isObject } from "../../guards.js";
+import { normalizeSlackThread } from "../../sources/SlackNormalize.js";
+import type { CodexNormalizer } from "./CodexBinding.js";
+
+/**
+ * `{channel_id, message_ts}` off a Slack `function_call`'s parsed arguments.
+ * Returns undefined when the request args are absent or malformed — the codex
+ * envelope can reach here with no arguments at all (an `mcp_tool_call_end`
+ * event that carries neither `invocation.arguments` nor a paired
+ * `function_call`), so both guards are live, not merely defensive.
+ */
+function readSlackToolInput(input: unknown): { channelId: string; messageTs: string } | undefined {
+	if (!isObject(input)) return undefined;
+	const channelId = (input as { channel_id?: unknown }).channel_id;
+	const messageTs = (input as { message_ts?: unknown }).message_ts;
+	if (typeof channelId !== "string" || typeof messageTs !== "string") return undefined;
+	return { channelId, messageTs };
+}
+
+export const slackCodexBinding: CodexNormalizer = {
+	id: "slack",
+	// Map to the Claude MCP tool name so both hosts persist the same
+	// `sourceToolName` (host-agnostic dedupe — see CodexAsanaBinding).
+	canonicalToolName: "mcp__claude_ai_Slack__slack_read_thread",
+	normalize: (business, toolInput, env) => {
+		const input = readSlackToolInput(toolInput);
+		if (input === undefined) return null;
+		const { channelId, messageTs } = input;
+		const url =
+			env?.permalinks.get(`${channelId}:${messageTs}`) ??
+			(env?.slackWorkspaceUrl !== undefined
+				? `${env.slackWorkspaceUrl}/archives/${channelId}/p${messageTs.replace(".", "")}`
+				: undefined);
+		return normalizeSlackThread(business, { channelId, url });
+	},
+};

--- a/cli/src/core/references/bindings/codex/index.ts
+++ b/cli/src/core/references/bindings/codex/index.ts
@@ -18,6 +18,7 @@ import { jiraCodexBinding } from "./CodexJiraBinding.js";
 import { linearCodexBinding } from "./CodexLinearBinding.js";
 import { mondayCodexBinding } from "./CodexMondayBinding.js";
 import { notionCodexBinding } from "./CodexNotionBinding.js";
+import { slackCodexBinding } from "./CodexSlackBinding.js";
 import { zoomMeetingCodexBinding } from "./CodexZoomMeetingBinding.js";
 
 /** `mcp__codex_apps__` — the shared connector namespace prefix for all sources. */
@@ -32,6 +33,7 @@ const CODEX_NORMALIZERS: readonly CodexNormalizer[] = [
 	confluenceCodexBinding,
 	asanaCodexBinding,
 	mondayCodexBinding,
+	slackCodexBinding,
 ];
 
 const BY_ID: ReadonlyMap<SourceId, CodexNormalizer> = new Map(CODEX_NORMALIZERS.map((n) => [n.id, n]));

--- a/cli/src/core/references/sources/definitions/slack.ts
+++ b/cli/src/core/references/sources/definitions/slack.ts
@@ -18,8 +18,12 @@ export const slackDefinition: SourceDefinition = {
 		claude: { prefixes: ["mcp__claude_ai_Slack__"], acceptSuffix: "slack_read_thread" },
 		codex: {
 			namespaceSuffix: "slack",
-			functionCallNames: ["_read_thread"],
-			invocationTools: ["slack_read_thread"],
+			// The connector's tool name repeats the app slug (`slack_read_thread`),
+			// unlike asana's `get_task` — so the `function_call` name is
+			// `_slack_read_thread` and the `mcp_tool_call_end` invocation is
+			// `slack.slack_read_thread`. Verified against a real 2026-07-18 rollout.
+			functionCallNames: ["_slack_read_thread"],
+			invocationTools: ["slack.slack_read_thread"],
 		},
 	},
 	wrapperKeys: [],


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Context

- [Consolidate the existing Linear / Jira / GitHub /…](https://flyer-q4r7867.slack.com/archives/C0BFF9UHBD1/p1783413984700009)

## Quick recap

The developer enabled Slack thread references in Codex, allowing users to paste Slack thread URLs in sessions and have them automatically captured in the context—matching the behavior that already existed in Claude. The implementation addressed three systematic gaps that had prevented the feature from working in Codex. Slack connector tool names were corrected to match Codex's output format, as the function call identifiers had been incorrectly shortened. A permalink extraction function was added to recognize Slack URLs across both message shapes that Codex uses: response items and bare-string events. A normalizer binding was introduced to resolve thread URLs from either user-pasted links or workspace configuration, enabling the feature to work even when users don't explicitly paste a link.

Additionally, a correctness improvement prevents silent reference loss when Slack messages are malformed: the system now attempts recovery from alternate event sources, allowing fallback processing to proceed. This approach increases reliability for edge cases while maintaining safety through downstream validation mechanisms.

---

## Topics (2)
<details>
<summary><strong>01 · Slack thread references now captured in Codex</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When users pasted Slack thread URLs in Codex, the URLs weren't being captured in the session context even though Codex was successfully invoking the Slack read tool. Investigation revealed three systemic gaps in the Codex implementation that prevented Slack reference capture, despite the feature working correctly in Claude.

**💡 Decisions Behind the Code**

- **Design for symmetry across hosts**: Rather than implementing Codex-specific Slack handling, the implementation mirrors the existing Claude implementation exactly — same permalink extraction logic, same context-threaded normalization interface, and same shared business logic. This guarantees Claude and Codex produce identical normalized references and consolidates maintenance to a single code path.
- **Single-pass context harvesting**: Slack permalinks are extracted once at parse startup and cached in a lookup map passed to every normalizer, improving parsing clarity and performance while enabling fallback chains. Workspace URL configuration serves as a fallback when users don't paste explicit links.
- **Defer completion marking to post-normalization**: The system marks a call as complete only after successful normalization, allowing fallback logic to attempt recovery using alternative event sources when the primary output is malformed. This increases reliability for edge cases while maintaining safety — downstream validation gates prevent unintended event flooding.

**✅ What Was Implemented**

- Fixed tool name matching in the Slack definition to match the actual Codex connector output. The declared function call names and invocation tool names are now `_slack_read_thread` and `slack.slack_read_thread` respectively.
- Added `scanCodexUserPermalinks()` function to recognize and extract Slack permalinks from both message shapes that Codex uses: response_item messages containing `input_text` blocks and bare-string `user_message` events, with deduplication for threads appearing in both shapes.
- Introduced `CodexNormalizeEnv` interface to thread parse-scoped context through the normalization pipeline, and created `CodexSlackBinding` normalizer that reads channel ID and timestamp from tool arguments, resolves the thread URL from either pasted permalink or workspace configuration, and delegates to shared business logic.
- Moved the `emitted.add(callId)` call in CodexEnvelopeParser to only execute after successful (non-null) normalization, preventing malformed outputs from blocking fallback recovery paths. Updated comments to clarify that null results leave the call open for fallback retry.

**📁 FILES**
- `cli/src/core/references/sources/definitions/slack.ts`
- `cli/src/core/references/SlackPermalink.ts`
- `cli/src/core/references/bindings/codex/CodexSlackBinding.ts`
- `cli/src/core/references/CodexEnvelopeParser.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Add test coverage for defensive Slack input validation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Code review found that safety checks in the Slack input validation were excluded from test coverage, even though they are reachable in production scenarios. This left edge case bugs undetected and vulnerable to causing issues in rare situations.

**💡 Decisions Behind the Code**

Rather than leaving defensive branches untested via coverage suppression, the code was properly tested because exec-mode scenarios legitimately produce events matching those defensive conditions. This improves test suite fidelity and ensures edge case bugs are caught.

**✅ What Was Implemented**

- Removed two `/* v8 ignore */` blocks from CodexSlackBinding.ts in the `readSlackToolInput` function that were suppressing coverage for defensive null checks on required input fields.
- Added two tests exercising the defensive paths: one where the event carries no request arguments at all, and another where arguments lack required channel_id/message_ts fields.
- Improved the `readSlackToolInput` function comment to explain that both defensive branches are genuinely reachable in exec-mode events lacking invocation.arguments or paired function_call.

**📁 FILES**
- `cli/src/core/references/bindings/codex/CodexSlackBinding.ts`
- `cli/src/core/references/CodexEnvelopeParser.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 19, 2026 at 3:20 PM · via Local agent*
<!-- jollimemory-summary-end -->
