### PR TITLE
Add multilabel kind classification to graph knowledge units

### DIFF
--- a/cli/src/core/PromptTemplates.ts
+++ b/cli/src/core/PromptTemplates.ts
@@ -759,7 +759,7 @@ Output ONLY a JSON object -- no prose, no markdown fences:
 {"categories":[{"id":"<kebab-id>","shortTitle":"<<=5 words>","summary":"<one sentence>"}],"topics":[{"slug":"<unchanged>","title":"<unchanged>","shortTitle":"<<=5 words>","summary":"<one sentence>","categoryId":"<category id>"}]}
 Include EVERY input topic exactly once. Use [] for empty arrays.`;
 
-const GRAPH_UNITS = `You are distilling ONE wiki topic into its atomic knowledge units. A unit is a single decision, mechanism, or fix that a future contributor must know -- project-specific knowledge, not generic engineering facts.
+const GRAPH_UNITS = `You are distilling ONE wiki topic into its atomic knowledge units. A unit is a single piece of project-specific knowledge a future contributor must know -- not a generic engineering fact.
 
 ## Topic
 {{topicTitle}}
@@ -767,16 +767,34 @@ const GRAPH_UNITS = `You are distilling ONE wiki topic into its atomic knowledge
 ## Page content
 {{content}}
 
+## Kinds
+Each unit carries 1-3 kinds, most salient first. Pick from:
+- decision: a deliberate choice made between options (we chose X over Y).
+- mechanism: how some part of the system works (neutral "how it works").
+- fix: a bug/problem that was resolved and closed (there was a fix action).
+- constraint: a hard rule/invariant that MUST hold; violating it breaks correctness (crash, data loss, broken invariant).
+- gotcha: a non-obvious pitfall or surprising behavior to watch out for (may or may not be fixed; it is a live warning).
+- non-goal: something deliberately NOT done, removed, rejected, or forbidden (the inverse of a decision).
+- convention: an established style/pattern the project always follows; violating it is only an inconsistency, not a correctness bug.
+
+Boundary rules (assign multiple kinds when a unit genuinely spans them):
+- decision vs non-goal: doing X = decision; not doing / removing / rejecting X = non-goal (a "chose X, so dropped Y" unit is [decision, non-goal]).
+- constraint vs convention: correctness red-line = constraint; style/consistency preference = convention.
+- decision + constraint: a choice that also establishes a hard invariant is [decision, constraint] (the choice is the decision; the resulting must-hold rule is the constraint).
+- fix vs gotcha: closed problem with a fix = fix; live warning about a trap = gotcha (a "fixed the trap and left a warning" unit is [fix, gotcha]).
+- mechanism is the fallback: use it only for neutral "how it works". If the unit says WHY it was chosen -> decision; if it says something MUST hold -> constraint.
+- rationale belongs INSIDE a decision's summary ("chose X because Y"), never a separate unit.
+
 ## Task
-- Extract 1-8 units. Each is exactly one decision / mechanism / fix.
-- kind is one of: decision (a deliberate trade-off), mechanism (how something works), fix (a bug or gotcha resolved).
+- Extract 1-8 units.
+- kinds: an array of 1-3 values from the list above, most important first (kinds[0] drives its colour). No duplicates.
 - id: a short kebab-case slug unique within THIS topic (the caller namespaces it globally).
 - shortTitle <= 5 words; summary one sentence.
 - anchors.files: source file paths named in the content (verbatim). anchors.commits: commit hashes named in the content. Use [] when none.
 
 ## Output
 Output ONLY a JSON object -- no prose, no markdown fences:
-{"units":[{"id":"<kebab>","kind":"decision|mechanism|fix","shortTitle":"<<=5 words>","summary":"<one sentence>","anchors":{"files":[],"commits":[]}}]}
+{"units":[{"id":"<kebab>","kinds":["decision","non-goal"],"shortTitle":"<<=5 words>","summary":"<one sentence>","anchors":{"files":[],"commits":[]}}]}
 Use [] for empty arrays.`;
 
 const GRAPH_EDGES = `You are finding typed relationships between knowledge units in a software project's wiki. You are given a flat list of units (id, topic, short title, summary).
@@ -941,7 +959,7 @@ export const TEMPLATES: ReadonlyMap<string, PromptTemplate> = new Map<string, Pr
 	// template's own version bump, not the schema version.
 	["graph-categories", { action: "graph-categories", version: 1, template: GRAPH_CATEGORIES }],
 	["graph-categories-delta", { action: "graph-categories-delta", version: 1, template: GRAPH_CATEGORIES_DELTA }],
-	["graph-units", { action: "graph-units", version: 1, template: GRAPH_UNITS }],
+	["graph-units", { action: "graph-units", version: 2, template: GRAPH_UNITS }],
 	["graph-edges", { action: "graph-edges", version: 1, template: GRAPH_EDGES }],
 	["rank-context", { action: "rank-context", version: 3, template: RANK_CONTEXT }],
 ]);

--- a/cli/src/graph/GraphArtifactStore.test.ts
+++ b/cli/src/graph/GraphArtifactStore.test.ts
@@ -14,7 +14,7 @@ function tinyDistill(): DistilledGraph {
 			{
 				id: "t1::u1",
 				topicSlug: "t1",
-				kind: "decision",
+				kinds: ["decision"],
 				shortTitle: "U1",
 				summary: "Unit one.",
 				anchors: { files: [], commits: [] },
@@ -68,7 +68,7 @@ describe("readGraph", () => {
 		await writeGraphArtifacts(root, written);
 
 		const got = await readGraph(root);
-		expect(got?.schemaVersion).toBe(2);
+		expect(got?.schemaVersion).toBe(3);
 		expect(got?.topicFingerprints).toEqual({ t1: "fp" });
 		expect(got?.units).toHaveLength(1);
 	});

--- a/cli/src/graph/GraphBuilder.test.ts
+++ b/cli/src/graph/GraphBuilder.test.ts
@@ -16,6 +16,7 @@ vi.mock("./GraphDistiller.js", () => ({ distillGraph, distillGraphIncremental })
 vi.mock("./GraphArtifactStore.js", () => ({ writeGraphArtifacts, readGraph }));
 
 import { buildKnowledgeGraph, topicFingerprint, topicMetaFingerprint } from "./GraphBuilder.js";
+import { GRAPH_SCHEMA_VERSION } from "./GraphSchema.js";
 
 const ISO = "2026-06-15T00:00:00.000Z";
 const CONFIG = { apiKey: "k" };
@@ -29,7 +30,7 @@ const validDistill = {
 		{
 			id: "t1::u1",
 			topicSlug: "t1",
-			kind: "decision",
+			kinds: ["decision"],
 			shortTitle: "U1",
 			summary: "s",
 			anchors: { files: [], commits: [] },
@@ -251,7 +252,7 @@ describe("buildKnowledgeGraph", () => {
 		topicMetaFingerprints: Record<string, string> = {},
 	) {
 		return {
-			schemaVersion: 2,
+			schemaVersion: GRAPH_SCHEMA_VERSION,
 			generatedAt: "x",
 			source: "x",
 			topicFingerprints,
@@ -281,7 +282,7 @@ describe("buildKnowledgeGraph", () => {
 				{
 					id: "t1::u1",
 					topicSlug: "t1",
-					kind: "decision",
+					kinds: ["decision"],
 					shortTitle: "U1",
 					summary: "s",
 					anchors: { files: [], commits: [] },
@@ -494,5 +495,32 @@ describe("buildKnowledgeGraph", () => {
 		expect(graphArg.topics).toEqual([]);
 		expect(graphArg.units).toEqual([]);
 		expect(graphArg.categories).toEqual([]);
+	});
+
+	it("writes an empty graph on bump + empty index (stale-schema baseline is not stranded)", async () => {
+		readTopicIndex.mockResolvedValue({ schemaVersion: 1, topics: [] }); // all topics gone
+		// Prior graph exists but its schemaVersion no longer matches (a bump happened),
+		// so prevDistill is null. The empty-write gate must key off the RAW prevGraph
+		// (still non-empty) — otherwise this stale old-schema file would be stranded.
+		readGraph.mockResolvedValue({ ...richBaseline({ t1: fpOf("Topic1", "s1", "") }, {}), schemaVersion: 1 });
+
+		const r = await buildKnowledgeGraph("/cwd", folderStorage, CONFIG, { nowIso: ISO });
+
+		expect(r.built).toBe(true);
+		expect(r).toMatchObject({ topics: 0, units: 0, edges: 0 });
+		expect(distillGraph).not.toHaveBeenCalled();
+		expect(distillGraphIncremental).not.toHaveBeenCalled();
+		const [, graphArg] = writeGraphArtifacts.mock.calls[0];
+		expect(graphArg.topics).toEqual([]);
+		expect(graphArg.schemaVersion).toBe(GRAPH_SCHEMA_VERSION); // re-stamped to current
+	});
+
+	it("skips (no write) on empty index when there is no prior graph at all", async () => {
+		readTopicIndex.mockResolvedValue({ schemaVersion: 1, topics: [] });
+		readGraph.mockResolvedValue(null);
+		const r = await buildKnowledgeGraph("/cwd", folderStorage, CONFIG, { nowIso: ISO });
+		expect(r.built).toBe(false);
+		expect(r.reason).toBe("no topics");
+		expect(writeGraphArtifacts).not.toHaveBeenCalled();
 	});
 });

--- a/cli/src/graph/GraphBuilder.ts
+++ b/cli/src/graph/GraphBuilder.ts
@@ -169,10 +169,22 @@ export async function buildKnowledgeGraph(
 		// All topics deleted → the deletion case, taken to zero topics. Overwrite the
 		// stale graph.json with an empty (referentially-trivial) graph so the viz stops
 		// showing phantom topics — NO LLM. A bare skip here would leave the last good
-		// graph on disk forever. Nothing-ever-built (no usable baseline, or a baseline
-		// that is already empty) still skips.
-		if (prevDistill && prevDistill.topics.length > 0) {
-			log.info("All topics deleted (was %d) -- writing empty knowledge graph", prevDistill.topics.length);
+		// graph on disk forever. Nothing-ever-built (no prior graph, or one already
+		// empty) still skips.
+		//
+		// Gate on the RAW prevGraph, NOT prevDistill: after a GRAPH_SCHEMA_VERSION bump
+		// prevDistill is null (schema-mismatch gate above) even though a non-empty
+		// old-schema graph.json is still on disk. Using prevDistill here would let the
+		// "bump + empty index" case fall through to skip and strand that stale
+		// old-schema file (phantom topics) indefinitely. Any non-empty prior graph →
+		// write the fresh empty graph, which also re-stamps the current schemaVersion.
+		const prevTopicCount = prevGraph?.topics?.length ?? 0;
+		const prevUnitCount = prevGraph?.units?.length ?? 0;
+		if (prevTopicCount > 0 || prevUnitCount > 0) {
+			log.info(
+				"All topics deleted (prior graph had %d topic(s)) -- writing empty knowledge graph",
+				prevTopicCount,
+			);
 			const empty = assembleGraph({ categories: [], topics: [], units: [], edges: [] }, new Map(), now, repoName);
 			opts?.onProgress?.("writing graph.json");
 			const { graphJsonPath } = await writeGraphArtifacts(kbRoot, empty);

--- a/cli/src/graph/GraphDistiller.test.ts
+++ b/cli/src/graph/GraphDistiller.test.ts
@@ -379,7 +379,7 @@ describe("distillGraphIncremental", () => {
 				{
 					id: "t1::u1",
 					topicSlug: "t1",
-					kind: "decision",
+					kinds: ["decision"],
 					shortTitle: "U1",
 					summary: "s",
 					anchors: { files: [], commits: [] },
@@ -387,7 +387,7 @@ describe("distillGraphIncremental", () => {
 				{
 					id: "t2::uOld",
 					topicSlug: "t2",
-					kind: "fix",
+					kinds: ["fix"],
 					shortTitle: "old",
 					summary: "s",
 					anchors: { files: [], commits: [] },
@@ -702,5 +702,121 @@ describe("distillGraphIncremental", () => {
 		await expect(distillGraphIncremental(input, baseline(), diff, CONFIG)).rejects.toThrow(
 			/graph-edges returned no edges array/,
 		);
+	});
+});
+
+describe("kinds multi-label handling", () => {
+	const oneTopic = { topics: [{ slug: "t1", title: "Topic1", summary: "s", content: "b" }] };
+	const cats = JSON.stringify({
+		categories: [{ id: "c", shortTitle: "C", summary: "c" }],
+		topics: [{ slug: "t1", title: "Topic1", shortTitle: "T1", summary: "s", categoryId: "c" }],
+	});
+
+	it("preserves a canonical kinds[] and dedupes + caps at three, order preserved", async () => {
+		setup({
+			categories: cats,
+			units: {
+				Topic1: JSON.stringify({
+					units: [
+						{
+							id: "u1",
+							kinds: ["fix", "fix", "gotcha", "decision", "constraint"],
+							shortTitle: "U1",
+							summary: "s",
+						},
+					],
+				}),
+			},
+		});
+		const g = await distillGraph(oneTopic, CONFIG);
+		expect(g.units.find((u) => u.id === "t1::u1")?.kinds).toEqual(["fix", "gotcha", "decision"]);
+	});
+
+	it("coerces a legacy scalar kind into a single-element kinds[]", async () => {
+		setup({
+			categories: cats,
+			units: {
+				Topic1: JSON.stringify({ units: [{ id: "u1", kind: "mechanism", shortTitle: "U", summary: "s" }] }),
+			},
+		});
+		const g = await distillGraph(oneTopic, CONFIG);
+		expect(g.units.find((u) => u.id === "t1::u1")?.kinds).toEqual(["mechanism"]);
+	});
+
+	it("full path drops a unit with no valid kind but keeps its valid siblings", async () => {
+		setup({
+			categories: cats,
+			units: {
+				Topic1: JSON.stringify({
+					units: [
+						{ id: "bad", kinds: ["bogus"], shortTitle: "B", summary: "s" },
+						{ id: "ok", kinds: ["decision", "non-goal"], shortTitle: "OK", summary: "s" },
+					],
+				}),
+			},
+		});
+		const g = await distillGraph(oneTopic, CONFIG);
+		expect(g.units.map((u) => u.id)).toEqual(["t1::ok"]);
+		expect(g.units[0].kinds).toEqual(["decision", "non-goal"]);
+	});
+
+	it("incremental (strict) throws when a dirty topic's units are ALL invalid-kind (fail closed)", async () => {
+		callLlm.mockImplementation(async (opts: { action: string }) => {
+			if (opts.action === "graph-categories-delta")
+				return {
+					text: JSON.stringify({
+						newCategories: [],
+						topics: [{ slug: "t1", shortTitle: "T1", summary: "s", categoryId: "c" }],
+					}),
+				};
+			if (opts.action === "graph-units")
+				return {
+					text: JSON.stringify({ units: [{ id: "u1", kinds: ["bogus"], shortTitle: "U", summary: "s" }] }),
+				};
+			return { text: '{"edges":[]}', stopReason: null };
+		});
+		const prev: DistilledGraph = {
+			categories: [{ id: "c", shortTitle: "C", summary: "s" }],
+			topics: [],
+			units: [],
+			edges: [],
+		};
+		const diff: TopicDiff = { clean: [], dirty: ["t1"], added: [], deleted: [] };
+		await expect(distillGraphIncremental(oneTopic, prev, diff, CONFIG)).rejects.toThrow(
+			/none had a valid id \+ kinds/,
+		);
+	});
+
+	it("full path degrades an all-invalid topic to [] (onError) without aborting the build", async () => {
+		callLlm.mockImplementation(async (opts: { action: string; params: Record<string, string> }) => {
+			if (opts.action === "graph-categories")
+				return {
+					text: JSON.stringify({
+						categories: [{ id: "c", shortTitle: "C", summary: "c" }],
+						topics: TWO_TOPICS.topics.map((t) => ({
+							slug: t.slug,
+							title: t.title,
+							shortTitle: t.slug,
+							summary: t.summary,
+							categoryId: "c",
+						})),
+					}),
+				};
+			if (opts.action === "graph-units") {
+				if (opts.params.topicTitle === "Topic1")
+					return {
+						text: JSON.stringify({
+							units: [{ id: "u1", kinds: ["bogus"], shortTitle: "U", summary: "s" }],
+						}),
+					};
+				return {
+					text: JSON.stringify({ units: [{ id: "u9", kinds: ["fix"], shortTitle: "U9", summary: "s" }] }),
+				};
+			}
+			return { text: '{"edges":[]}', stopReason: null };
+		});
+		const g = await distillGraph(TWO_TOPICS, CONFIG);
+		// Topic1 threw (all-invalid) → swallowed to []; Topic2 survives.
+		expect(g.units.map((u) => u.id)).toEqual(["t2::u9"]);
 	});
 });

--- a/cli/src/graph/GraphDistiller.ts
+++ b/cli/src/graph/GraphDistiller.ts
@@ -27,10 +27,9 @@ import {
 	type EdgeType,
 	type GraphEdge,
 	mergeCategoryLayer,
+	normalizeKinds,
 	type TopicDiff,
 	UNCATEGORIZED_CATEGORY_ID,
-	UNIT_KINDS,
-	type UnitKind,
 } from "./GraphSchema.js";
 
 const log = createLogger("GraphDistiller");
@@ -119,6 +118,9 @@ interface CategoriesResponse {
 }
 interface RawUnit {
 	id?: unknown;
+	/** Canonical multi-label form. */
+	kinds?: unknown;
+	/** Legacy scalar; still accepted at ingestion and coerced to `[kind]`. */
 	kind?: unknown;
 	shortTitle?: unknown;
 	summary?: unknown;
@@ -243,15 +245,18 @@ async function distillUnitsForTopic(
 	// `{}` / `{"foo":1}` parse fine but would degrade to zero units and overwrite a
 	// dirty topic's baseline units — so a missing/non-array field fails the round too.
 	// `{"units":[]}` (array present, empty) is a legitimate "no units" and does not throw.
-	if (opts?.strict && !Array.isArray(parsed?.units)) {
+	const rawUnits = parsed?.units;
+	if (opts?.strict && !Array.isArray(rawUnits)) {
 		throw new Error(`graph-units returned no units array for topic ${topic.slug}`);
 	}
 	const units: DistilledUnit[] = [];
 	const seenLocal = new Set<string>();
-	for (const u of parsed?.units ?? []) {
+	for (const u of rawUnits ?? []) {
 		const localId = asString(u.id).trim();
-		const kind = asString(u.kind) as UnitKind;
-		if (!localId || !UNIT_KINDS.includes(kind)) continue;
+		// Canonical `kinds[]` (deduped, ≤3); also coerces a legacy scalar `kind`.
+		// A unit with no valid id or no valid kind is unusable → skip it.
+		const kinds = normalizeKinds(u);
+		if (!localId || kinds.length === 0) continue;
 		// Namespace per topic to guarantee global uniqueness; suffix on collision.
 		let local = localId;
 		let n = 2;
@@ -263,11 +268,22 @@ async function distillUnitsForTopic(
 		units.push({
 			id: `${topic.slug}::${local}`,
 			topicSlug: topic.slug,
-			kind,
+			kinds,
 			shortTitle,
 			summary: asNonBlank(u.summary, shortTitle),
 			anchors: { files: asStringArray(u.anchors?.files), commits: asStringArray(u.anchors?.commits) },
 		});
+	}
+	// Fail closed: the LLM returned a NON-EMPTY units array but every entry was
+	// unusable (no id, or no recognizable kind). That is a malformed round, not a
+	// legitimate "no units" (which is an empty `{units:[]}` and is left untouched
+	// above). Throwing keeps the incremental path on its prior good graph; on the
+	// full path the caller's onError degrades this one topic to [] with a warning
+	// instead of silently emitting a topic that lost all its units.
+	if (Array.isArray(rawUnits) && rawUnits.length > 0 && units.length === 0) {
+		throw new Error(
+			`graph-units for topic ${topic.slug}: ${rawUnits.length} raw unit(s) but none had a valid id + kinds`,
+		);
 	}
 	return units;
 }

--- a/cli/src/graph/GraphSchema.test.ts
+++ b/cli/src/graph/GraphSchema.test.ts
@@ -8,13 +8,17 @@ import {
 	diffTopics,
 	dropSubsumedRelatedTo,
 	type GraphEdge,
+	isCanonicalKinds,
 	isFingerprintMap,
+	MAX_UNIT_KINDS,
 	mergeCategoryLayer,
+	normalizeKinds,
 	normalizeSymmetricEdges,
 	SYMMETRIC_EDGE_TYPES,
 	type TopicSourceMeta,
 	toDistilled,
 	UNCATEGORIZED_CATEGORY_ID,
+	UNIT_KINDS,
 	validateDistilledGraph,
 } from "./GraphSchema.js";
 
@@ -32,7 +36,7 @@ function validGraph(): DistilledGraph {
 			{
 				id: "t1::u1",
 				topicSlug: "t1",
-				kind: "decision",
+				kinds: ["decision"],
 				shortTitle: "U1",
 				summary: "Unit 1.",
 				anchors: { files: [], commits: [] },
@@ -40,7 +44,7 @@ function validGraph(): DistilledGraph {
 			{
 				id: "t1::u2",
 				topicSlug: "t1",
-				kind: "mechanism",
+				kinds: ["mechanism", "constraint"],
 				shortTitle: "U2",
 				summary: "Unit 2.",
 				anchors: { files: [], commits: [] },
@@ -48,7 +52,7 @@ function validGraph(): DistilledGraph {
 			{
 				id: "t2::u3",
 				topicSlug: "t2",
-				kind: "fix",
+				kinds: ["fix"],
 				shortTitle: "U3",
 				summary: "Unit 3.",
 				anchors: { files: [], commits: [] },
@@ -84,11 +88,17 @@ describe("validateDistilledGraph", () => {
 		expect(validateDistilledGraph(g)).toContain("unit t1::u1: unknown topicSlug ghost");
 	});
 
-	it("flags an invalid unit kind", () => {
+	it("flags invalid unit kinds", () => {
 		const g = validGraph();
 		// biome-ignore lint/suspicious/noExplicitAny: deliberately bad data
-		g.units[0] = { ...g.units[0], kind: "bogus" as any };
-		expect(validateDistilledGraph(g)).toContain("unit t1::u1: invalid kind bogus");
+		g.units[0] = { ...g.units[0], kinds: ["bogus"] as any };
+		expect(validateDistilledGraph(g)).toContain('unit t1::u1: invalid kinds ["bogus"]');
+	});
+
+	it("flags an empty kinds array", () => {
+		const g = validGraph();
+		g.units[0] = { ...g.units[0], kinds: [] };
+		expect(validateDistilledGraph(g)).toContain("unit t1::u1: invalid kinds []");
 	});
 
 	it("flags dangling edge endpoints", () => {
@@ -253,7 +263,7 @@ describe("assembleGraph", () => {
 		const graph = assembleGraph(validGraph(), sources, "2026-06-15T00:00:00.000Z", "");
 
 		expect(graph.generatedAt).toBe("2026-06-15T00:00:00.000Z");
-		expect(graph.schemaVersion).toBe(2);
+		expect(graph.schemaVersion).toBe(3);
 
 		const t1 = graph.topics.find((t) => t.slug === "t1");
 		expect(t1?.sourceBranches).toEqual(["main", "feature/x"]);
@@ -296,7 +306,7 @@ describe("assembleGraph", () => {
 				{
 					id: "t1::u1",
 					topicSlug: "t1",
-					kind: "decision",
+					kinds: ["decision"],
 					shortTitle: "U1",
 					summary: "s",
 					anchors: { files: [], commits: [] },
@@ -304,7 +314,7 @@ describe("assembleGraph", () => {
 				{
 					id: "t2::u2",
 					topicSlug: "t2",
-					kind: "fix",
+					kinds: ["fix"],
 					shortTitle: "U2",
 					summary: "s",
 					anchors: { files: [], commits: [] },
@@ -455,10 +465,10 @@ describe("toDistilled", () => {
 
 	it("returns null on a unit missing a field, a bad kind, or bad anchors", () => {
 		const g = priorGraph() as Record<string, unknown>;
-		const baseUnit = { id: "x::u", topicSlug: "x", kind: "decision", shortTitle: "U", summary: "s" };
+		const baseUnit = { id: "x::u", topicSlug: "x", kinds: ["decision"], shortTitle: "U", summary: "s" };
 		expect(toDistilled({ ...g, units: [{ ...baseUnit /* no anchors */ }] })).toBeNull();
 		expect(
-			toDistilled({ ...g, units: [{ ...baseUnit, kind: "bogus", anchors: { files: [], commits: [] } }] }),
+			toDistilled({ ...g, units: [{ ...baseUnit, kinds: ["bogus"], anchors: { files: [], commits: [] } }] }),
 		).toBeNull();
 		expect(toDistilled({ ...g, units: [{ ...baseUnit, anchors: { files: "no", commits: [] } }] })).toBeNull();
 		expect(toDistilled({ ...g, units: [{ ...baseUnit, anchors: null }] })).toBeNull();
@@ -614,5 +624,83 @@ describe("mergeCategoryLayer", () => {
 		);
 		expect(categories.filter((c) => c.id === "x")).toHaveLength(1);
 		expect(categories.find((c) => c.id === "x")?.shortTitle).toBe("First");
+	});
+});
+
+describe("normalizeKinds", () => {
+	it("keeps a valid kinds array in order", () => {
+		expect(normalizeKinds({ kinds: ["mechanism", "constraint"] })).toEqual(["mechanism", "constraint"]);
+	});
+
+	it("coerces a legacy scalar kind to a single-element array", () => {
+		expect(normalizeKinds({ kind: "fix" })).toEqual(["fix"]);
+	});
+
+	it("prefers kinds[] over a legacy scalar when both are present", () => {
+		expect(normalizeKinds({ kinds: ["decision"], kind: "fix" })).toEqual(["decision"]);
+	});
+
+	it("dedupes preserving first-seen order (primary stays first)", () => {
+		expect(normalizeKinds({ kinds: ["fix", "fix", "decision"] })).toEqual(["fix", "decision"]);
+	});
+
+	it("caps at MAX_UNIT_KINDS", () => {
+		const many = ["decision", "mechanism", "fix", "constraint", "gotcha"];
+		expect(normalizeKinds({ kinds: many })).toHaveLength(MAX_UNIT_KINDS);
+		expect(normalizeKinds({ kinds: many })).toEqual(["decision", "mechanism", "fix"]);
+	});
+
+	it("filters out unknown and non-string members", () => {
+		expect(normalizeKinds({ kinds: ["decision", "bogus", 7, null, "gotcha"] })).toEqual(["decision", "gotcha"]);
+	});
+
+	it("returns [] when nothing valid survives", () => {
+		expect(normalizeKinds({ kinds: ["bogus", 5] })).toEqual([]);
+		expect(normalizeKinds({ kind: "nope" })).toEqual([]);
+		expect(normalizeKinds({})).toEqual([]);
+		expect(normalizeKinds({ kinds: "bogus" })).toEqual([]); // scalar kinds, but not a known kind
+	});
+
+	it("coerces a stray scalar kinds into a single-element array", () => {
+		expect(normalizeKinds({ kinds: "decision" })).toEqual(["decision"]);
+		// a scalar kinds still wins over a legacy scalar kind
+		expect(normalizeKinds({ kinds: "gotcha", kind: "fix" })).toEqual(["gotcha"]);
+	});
+
+	it("accepts all seven kinds", () => {
+		for (const k of ["decision", "mechanism", "fix", "constraint", "gotcha", "non-goal", "convention"]) {
+			expect(normalizeKinds({ kind: k })).toEqual([k]);
+		}
+	});
+
+	it("pins UNIT_KINDS to exactly the seven-member closed vocabulary", () => {
+		// The closed vocabulary is a red line (a stray add/remove would silently
+		// break cross-build tag consistency): assert set identity, not just membership.
+		expect([...UNIT_KINDS]).toEqual([
+			"decision",
+			"mechanism",
+			"fix",
+			"constraint",
+			"gotcha",
+			"non-goal",
+			"convention",
+		]);
+	});
+});
+
+describe("isCanonicalKinds", () => {
+	it("accepts a non-empty deduped array of valid kinds", () => {
+		expect(isCanonicalKinds(["decision"])).toBe(true);
+		expect(isCanonicalKinds(["decision", "constraint", "gotcha"])).toBe(true);
+	});
+
+	it("rejects empty, over-long, duplicated, non-array, or invalid-member values", () => {
+		expect(isCanonicalKinds([])).toBe(false);
+		expect(isCanonicalKinds(["decision", "mechanism", "fix", "constraint"])).toBe(false); // > MAX
+		expect(isCanonicalKinds(["fix", "fix"])).toBe(false); // dupes
+		expect(isCanonicalKinds(["decision", "bogus"])).toBe(false);
+		expect(isCanonicalKinds("decision")).toBe(false);
+		expect(isCanonicalKinds(undefined)).toBe(false);
+		expect(isCanonicalKinds([1, 2])).toBe(false);
 	});
 });

--- a/cli/src/graph/GraphSchema.ts
+++ b/cli/src/graph/GraphSchema.ts
@@ -26,9 +26,63 @@ export type EdgeType = (typeof EDGE_TYPES)[number];
  */
 export const SYMMETRIC_EDGE_TYPES: ReadonlySet<EdgeType> = new Set<EdgeType>(["related-to", "contradicts"]);
 
-/** The kinds a knowledge unit can take. */
-export const UNIT_KINDS = ["decision", "mechanism", "fix"] as const;
+/**
+ * The kinds a knowledge unit can take. A unit carries 1–3 of these as an ordered
+ * `kinds[]` (see {@link DistilledUnit}); the first is the PRIMARY, driving the
+ * node's colour in the viz. The four kinds beyond the original trio
+ * (decision/mechanism/fix) were added to stop over-loading `decision` as a
+ * catch-all — see docs/graph-unit-*.md for the definitions and boundary rules.
+ */
+export const UNIT_KINDS = ["decision", "mechanism", "fix", "constraint", "gotcha", "non-goal", "convention"] as const;
 export type UnitKind = (typeof UNIT_KINDS)[number];
+
+/** Max number of kinds a single unit may carry (primary + up to two secondary). */
+export const MAX_UNIT_KINDS = 3;
+
+/**
+ * Coerce raw LLM/JSON input into a canonical `kinds[]`: accept a `kinds` array, a
+ * stray scalar `kinds`, or a legacy scalar `kind` string, keep only members of
+ * {@link UNIT_KINDS},
+ * dedupe preserving first-seen order (so `kinds[0]` stays the primary), and cap at
+ * {@link MAX_UNIT_KINDS}. Returns `[]` when nothing valid survives — callers decide
+ * whether an empty result means "drop this unit" (full path) or "fail the round"
+ * (strict path); see {@link GraphDistiller}. The legacy-scalar branch is a
+ * transitional robustness net for LLM responses only — persisted graph.json always
+ * stores canonical `kinds[]`.
+ */
+export function normalizeKinds(raw: { kinds?: unknown; kind?: unknown }): UnitKind[] {
+	const candidates: unknown[] = Array.isArray(raw.kinds)
+		? raw.kinds
+		: raw.kinds !== undefined
+			? [raw.kinds]
+			: raw.kind !== undefined
+				? [raw.kind]
+				: [];
+	const out: UnitKind[] = [];
+	for (const c of candidates) {
+		if (typeof c !== "string") continue;
+		const k = c as UnitKind;
+		if (UNIT_KINDS.includes(k) && !out.includes(k)) out.push(k);
+		if (out.length >= MAX_UNIT_KINDS) break;
+	}
+	return out;
+}
+
+/**
+ * Validates a persisted/canonical `kinds` value: a non-empty, deduped array of
+ * length ≤ {@link MAX_UNIT_KINDS} whose every member is a known {@link UnitKind}.
+ * Unlike {@link normalizeKinds} this does NOT coerce or accept a legacy scalar —
+ * it is the strict gate for graph.json (`validUnit` / `validateDistilledGraph`).
+ */
+export function isCanonicalKinds(v: unknown): v is UnitKind[] {
+	return (
+		Array.isArray(v) &&
+		v.length > 0 &&
+		v.length <= MAX_UNIT_KINDS &&
+		new Set(v).size === v.length &&
+		v.every((k) => typeof k === "string" && UNIT_KINDS.includes(k as UnitKind))
+	);
+}
 
 /**
  * Schema version stamped onto the emitted graph; bump on a breaking shape change.
@@ -50,8 +104,10 @@ export type UnitKind = (typeof UNIT_KINDS)[number];
  * `categories`/`topics`/`units`/`edges`, so these baseline-only fields are inert
  * to them. A FUTURE change to either field's shape, or any new top-level field,
  * is a breaking shape change and must bump this constant again.
+ * Bumped 2→3 when `DistilledUnit.kind: UnitKind` became `kinds: UnitKind[]`
+ * (multi-label) and four new kinds were added — an output-shape change on `units`.
  */
-export const GRAPH_SCHEMA_VERSION = 2;
+export const GRAPH_SCHEMA_VERSION = 3;
 
 /** Category id for topics not grouped into any real category. Shared by the full
  * distiller (backfill) and the incremental merge so both bucket the same way. */
@@ -81,11 +137,12 @@ export interface UnitAnchors {
 	readonly commits: string[];
 }
 
-/** A single distilled knowledge unit (one decision / mechanism / fix). */
+/** A single distilled knowledge unit (one decision / mechanism / fix / …). */
 export interface DistilledUnit {
 	readonly id: string;
 	readonly topicSlug: string;
-	readonly kind: UnitKind;
+	/** 1–3 kinds, ordered by salience; `kinds[0]` is the primary (drives colour). */
+	readonly kinds: UnitKind[];
 	readonly shortTitle: string;
 	readonly summary: string;
 	readonly anchors: UnitAnchors;
@@ -211,7 +268,7 @@ export function validateDistilledGraph(graph: DistilledGraph): string[] {
 		if (unitIds.has(u.id)) errors.push(`duplicate unit id ${u.id}`);
 		unitIds.add(u.id);
 		if (!topicSlugs.has(u.topicSlug)) errors.push(`unit ${u.id}: unknown topicSlug ${u.topicSlug}`);
-		if (!UNIT_KINDS.includes(u.kind)) errors.push(`unit ${u.id}: invalid kind ${u.kind}`);
+		if (!isCanonicalKinds(u.kinds)) errors.push(`unit ${u.id}: invalid kinds ${JSON.stringify(u.kinds)}`);
 	}
 
 	const edgePairSeen = new Set<string>();
@@ -474,7 +531,7 @@ function validUnit(u: unknown): boolean {
 	) {
 		return false;
 	}
-	if (!UNIT_KINDS.includes(r.kind as UnitKind)) return false;
+	if (!isCanonicalKinds(r.kinds)) return false;
 	if (typeof r.anchors !== "object" || r.anchors === null) return false;
 	const a = r.anchors as Record<string, unknown>;
 	return isStringArray(a.files) && isStringArray(a.commits);
@@ -539,7 +596,7 @@ export function toDistilled(graph: unknown): DistilledGraph | null {
 		units: us.map((u) => ({
 			id: u.id,
 			topicSlug: u.topicSlug,
-			kind: u.kind,
+			kinds: [...u.kinds],
 			shortTitle: u.shortTitle,
 			summary: u.summary,
 			anchors: { files: [...u.anchors.files], commits: [...u.anchors.commits] },

--- a/cli/src/graph/KindBadgesAsset.test.ts
+++ b/cli/src/graph/KindBadgesAsset.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+// The viz assets under assets/js/ are plain JavaScript, bundled verbatim into the
+// webview / standalone export — tsc never type-checks them, so a `u.kind` ->
+// `u.kinds` slip would render `undefined` at runtime with no compile-time signal.
+// This smoke test evaluates the real data.js IIFE (its `window.WikiRender.kindBadges`
+// is the shared chip renderer used by views.js and panel.js) and asserts its output.
+// data.js only *defines* load() (which uses fetch) — it never calls it at eval time —
+// so a bare stub window is enough.
+function loadKindBadges(): (kinds: unknown) => string {
+	const src = readFileSync(new URL("./assets/js/data.js", import.meta.url), "utf8");
+	const win: { WikiRender?: { kindBadges: (kinds: unknown) => string } } = {};
+	new Function("window", src)(win);
+	if (!win.WikiRender) throw new Error("data.js did not expose window.WikiRender");
+	return win.WikiRender.kindBadges;
+}
+
+describe("kindBadges (assets/js/data.js runtime smoke)", () => {
+	const kindBadges = loadKindBadges();
+
+	it("renders a single primary chip", () => {
+		const html = kindBadges(["decision"]);
+		expect(html).toBe('<span class="u-kind decision">decision</span>');
+		expect(html).not.toContain("undefined");
+	});
+
+	it("renders the primary chip plus smaller secondary badges", () => {
+		const html = kindBadges(["fix", "gotcha", "constraint"]);
+		expect(html).toContain('<span class="u-kind fix">fix</span>');
+		expect(html).toContain('<span class="u-kind u-kind--sec gotcha">gotcha</span>');
+		expect(html).toContain('<span class="u-kind u-kind--sec constraint">constraint</span>');
+		expect(html).not.toContain("undefined");
+	});
+
+	it("renders a clean out-of-vocabulary kind without crashing or leaking 'undefined'", () => {
+		// A value outside the 7-word vocabulary (e.g. from a tampered graph.json) still
+		// renders a chip -- unstyled, since no CSS rule matches -- but must not crash
+		// or emit the literal "undefined".
+		const html = kindBadges(["banana", "gotcha"]);
+		expect(html).toContain('<span class="u-kind banana">banana</span>');
+		expect(html).toContain('<span class="u-kind u-kind--sec gotcha">gotcha</span>');
+		expect(html).not.toContain("undefined");
+	});
+
+	it("returns an empty string (never the literal 'undefined') for empty or missing kinds", () => {
+		expect(kindBadges([])).toBe("");
+		expect(kindBadges(undefined)).toBe("");
+		expect(kindBadges(null)).toBe("");
+	});
+
+	it("escapes HTML metacharacters defensively", () => {
+		const html = kindBadges(["<x>"]);
+		expect(html).not.toContain("<x>");
+		expect(html).toContain("&lt;x&gt;");
+	});
+});

--- a/cli/src/graph/assets/js/data.js
+++ b/cli/src/graph/assets/js/data.js
@@ -125,5 +125,27 @@
     return window.WikiData;
   }
 
+  // Shared unit-kind chip renderer. A unit carries `kinds[]` (1-3, primary first);
+  // the primary drives the colour, the rest render as smaller secondary badges.
+  // Centralised here (loaded first) so views.js and panel.js never drift. Kind
+  // values come from a closed vocabulary in validated graph.json, but escape
+  // defensively anyway. Callers that need spacing around the whole cluster wrap
+  // the return value (see the panel's `.p-kinds`) rather than styling one chip.
+  const kindEsc = (s) =>
+    String(s ?? "").replace(
+      /[&<>"']/g,
+      (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c],
+    );
+  function kindBadges(kinds) {
+    const list = Array.isArray(kinds) ? kinds : [];
+    if (!list.length) return "";
+    let html = `<span class="u-kind ${kindEsc(list[0])}">${kindEsc(list[0])}</span>`;
+    for (let i = 1; i < list.length; i++) {
+      html += `<span class="u-kind u-kind--sec ${kindEsc(list[i])}">${kindEsc(list[i])}</span>`;
+    }
+    return html;
+  }
+  window.WikiRender = { kindBadges };
+
   window.WikiDataLoader = { load };
 })();

--- a/cli/src/graph/assets/js/panel.js
+++ b/cli/src/graph/assets/js/panel.js
@@ -64,7 +64,7 @@
     const topic = D.topicsBySlug.get(u.topicSlug);
     let html = "";
     html += `<h2>${esc(u.shortTitle)}</h2>`;
-    html += `<div class="p-meta"><span class="u-kind ${esc(u.kind)}" style="margin-right:8px">${esc(u.kind)}</span>` +
+    html += `<div class="p-meta"><span class="p-kinds">${window.WikiRender.kindBadges(u.kinds)}</span>` +
       `in <code>${esc(topic.shortTitle)}</code></div>`;
     html += `<p class="summary">${esc(u.summary)}</p>`;
 
@@ -113,8 +113,8 @@
       html += `<h6>Units in this topic — ${units.length}</h6>`;
       for (const u of units) {
         html += `<div class="rel-item" data-goto-unit="${esc(u.id)}">` +
-          `<div class="rel-head"><span class="u-kind ${esc(u.kind)}">${esc(u.kind)}</span>` +
-          `<span class="rel-title">${esc(u.shortTitle)}</span></div>` +
+          `<div class="rel-head"><span class="rel-title">${esc(u.shortTitle)}</span></div>` +
+          window.WikiRender.kindBadges(u.kinds) +
           `<div class="rel-evidence">${esc(u.summary)}</div></div>`;
       }
     }

--- a/cli/src/graph/assets/js/views.js
+++ b/cli/src/graph/assets/js/views.js
@@ -200,9 +200,20 @@
       html += `<div class="collapsed-hint">${units.length} unit${units.length === 1 ? "" : "s"} hidden — click to expand</div>`;
       html += `<div class="unit-grid">`;
       for (const u of units) {
-        html += `<div class="unit-card${u.id === selectedUnitId ? " selected" : ""}" data-unit="${esc(u.id)}">`;
-        html += `<span class="u-kind ${esc(u.kind)}">${esc(u.kind)}</span>`;
+        // Colour the card by its PRIMARY kind: a left accent bar for at-a-glance
+        // scanning, and `--ukind` so the SELECTED outline uses the kind colour too
+        // (units highlight by kind; topics still highlight by category via --tcolor).
+        // Escape defensively (mirrors kindBadges) and fall back to --accent so an
+        // unknown/tampered kind degrades gracefully instead of emitting an invalid
+        // var() that drops the whole declaration.
+        const primaryKind = Array.isArray(u.kinds) && u.kinds.length ? esc(u.kinds[0]) : "";
+        const accent = primaryKind
+          ? ` style="--ukind:var(--kind-${primaryKind}, var(--accent));border-left-color:var(--kind-${primaryKind}, var(--accent))"`
+          : "";
+        html += `<div class="unit-card${primaryKind ? " kind-accent" : ""}${u.id === selectedUnitId ? " selected" : ""}"${accent} data-unit="${esc(u.id)}">`;
+        // Order mirrors the side panel: title → kinds → summary.
         html += `<h5>${esc(u.shortTitle)}</h5>`;
+        html += window.WikiRender.kindBadges(u.kinds);
         html += `<p>${esc(u.summary)}</p>`;
         html += `</div>`;
       }
@@ -304,9 +315,19 @@
       layoutCategory(board, categoryId)
         .catch((err) => {
           console.error("[wiki] layoutCategory failed, falling back to masonry", err);
-          layoutMasonry(board);
+          try {
+            layoutMasonry(board);
+          } catch (err2) {
+            console.error("[wiki] masonry fallback also failed", err2);
+          }
         })
         .then(() => {
+          // Failsafe: the board is visibility:hidden until `.laid-out`. If BOTH
+          // layout paths bailed (an early return on an empty/edge-case group set,
+          // or a throw in the fallback), the cards would be stranded invisible —
+          // a blank page. Force the class on so content is never stuck hidden.
+          const detail = board.querySelector(".category-detail.masonry");
+          if (detail) detail.classList.add("laid-out");
           drawCategoryEdges(categoryId);
           refreshSpotlight();
           settleCamera();

--- a/cli/src/graph/assets/styles/main.css
+++ b/cli/src/graph/assets/styles/main.css
@@ -43,7 +43,10 @@
   --kind-decision: #6eaaef;
   --kind-mechanism: #4ece8d;
   --kind-fix: #e0ac2b;
-  --kind-migration: #b494f0;
+  --kind-constraint: #f47067;
+  --kind-gotcha: #b494f0;
+  --kind-non-goal: #8a94a6;
+  --kind-convention: #56b6c2;
 
   /* Topic-box fill — OPAQUE (unlike the translucent --surface) so the back edge
      layer is occluded where a cross edge passes over a box. Mapped onto the
@@ -68,7 +71,10 @@ body.vscode-light {
   --kind-decision: #1f5a91;
   --kind-mechanism: #1b6340;
   --kind-fix: #96680e;
-  --kind-migration: #5c35a0;
+  --kind-constraint: #c0392b;
+  --kind-gotcha: #5c35a0;
+  --kind-non-goal: #5a6472;
+  --kind-convention: #1a7f8e;
 }
 
 * { box-sizing: border-box; }
@@ -296,20 +302,43 @@ body {
 .unit-card, .category-card, .portal, .topic-group { cursor: grab; }
 .wiki-dragging { cursor: grabbing !important; z-index: 50 !important; }
 .wiki-dragging.unit-card { transform: none; }
+/* A selected UNIT highlights in its PRIMARY-KIND colour (--ukind, set inline per
+   card); topics still highlight by category (--tcolor, see .topic-group.selected).
+   Falls back to category/accent for a unit with no kind. */
 .unit-card.selected {
-  border-color: var(--tcolor, var(--accent));
-  box-shadow: 0 0 0 1px var(--tcolor, var(--accent)) inset;
+  border-color: var(--ukind, var(--tcolor, var(--accent)));
+  box-shadow: 0 0 0 1px var(--ukind, var(--tcolor, var(--accent))) inset;
 }
 .unit-card.dimmed { opacity: .3; }
-.unit-card .u-kind {
+/* Primary-kind accent bar on the left edge (colour set inline per card). The 3px
+   border replaces the base 1px on the left; trim left padding by 2px so the text
+   column doesn't shift. */
+.unit-card.kind-accent { border-left-width: 3px; padding-left: 9px; }
+/* Chip shape/typography — global (not scoped to .unit-card) so the same pill
+   renders in the panel (p-meta / rel-head) as on board cards, now that a unit
+   can show a primary + secondary kind badges in both places. */
+.u-kind {
   display: inline-block; font-size: 9px; font-weight: 700; letter-spacing: .1em;
-  text-transform: uppercase; padding: 2px 7px; border-radius: 3px; margin-bottom: 7px;
+  text-transform: uppercase; padding: 2px 7px; border-radius: 3px;
   font-family: Consolas, monospace;
 }
-.u-kind.decision   { background: rgba(136,192,216,.16); color: var(--kind-decision); }
-.u-kind.mechanism  { background: rgba(163,181,119,.16); color: var(--kind-mechanism); }
-.u-kind.fix        { background: rgba(204,136,86,.18);  color: var(--kind-fix); }
-.u-kind.migration  { background: rgba(169,149,207,.16); color: var(--kind-migration); }
+/* Chips sit directly under the title (title → kinds → summary), mirroring the
+   side panel. The title's own bottom margin gives the gap above; the chips add a
+   gap below, before the summary. Same in the panel's per-topic unit list rows. */
+.unit-card .u-kind { margin-bottom: 7px; }
+.rel-item .u-kind { margin-bottom: 6px; }
+.u-kind.decision   { background: rgba(110,170,239,.16); color: var(--kind-decision); }
+.u-kind.mechanism  { background: rgba(78,206,141,.16);  color: var(--kind-mechanism); }
+.u-kind.fix        { background: rgba(224,172,43,.18);  color: var(--kind-fix); }
+.u-kind.constraint { background: rgba(244,112,103,.16); color: var(--kind-constraint); }
+.u-kind.gotcha     { background: rgba(180,148,240,.16); color: var(--kind-gotcha); }
+.u-kind.non-goal   { background: rgba(138,148,166,.16); color: var(--kind-non-goal); }
+.u-kind.convention { background: rgba(86,182,194,.16);  color: var(--kind-convention); }
+/* Secondary kinds (kinds[1..]) render smaller and dimmer next to the primary. */
+.u-kind.u-kind--sec { font-size: 8px; opacity: .8; margin-left: 4px; }
+/* Panel header: gap between the whole kind cluster and the trailing "in <topic>"
+   (the margin sits on the cluster, not one chip, so multi-kind units space right). */
+.p-meta .p-kinds { margin-right: 8px; }
 .unit-card h5 { margin: 0 0 5px; font-size: 13.5px; line-height: 1.35; }
 .unit-card p {
   margin: 0; font-size: 11.5px; color: var(--prose); line-height: 1.5;


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Graph knowledge units can now be tagged with up to three classification labels drawn from a seven-kind vocabulary: decision, mechanism, fix, constraint, gotcha, non-goal, and convention. Within that list, the first label determines the colour the unit shows in the graph; any additional labels appear as smaller badges alongside it. The vocabulary was grounded in an analysis of hundreds of real units across two repositories, and label handling was made resilient against minor formatting variations in generated output.

Kind labels are now consistently visible across both the board view and the detail panel. Selected unit cards glow in their primary kind's colour, and any card with a known kind gains a coloured left-edge accent bar that persists at rest, providing an at-a-glance kind indicator. Badge clusters in the detail panel carry a gap after all labels, and adjacent text begins cleanly after the last badge. All seven kinds received distinct colour schemes in both the dark and light editor themes, and badge chips look identical whether they appear on a board card or inside the detail panel.

The prompting guidance for kind label assignment was also updated. The output example now demonstrates a two-label unit alongside written boundary rules, and the fourth label-overlap case was integrated into the main guidance table, completing coverage for all documented co-occurrence scenarios. Knowledge units generated after this change will reflect more accurate multi-label classification, supported by both a concrete output example and explicit co-occurrence rules.

---

## Topics (5)
<details>
<summary><strong>01 · Graph knowledge units now support multiple ordered classification labels</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The three existing unit kinds (decision, mechanism, fix) were too narrow, causing the "decision" category to absorb 41% of all units as a catch-all. The team wanted richer, more precise classification without abandoning a controlled vocabulary.

**💡 Decisions Behind the Code**

- **Closed vocabulary with multiple labels over open tags**: The graph is assembled by many parallel AI calls, one per topic. Free-form tagging would produce the same concept under different labels across runs (e.g. "gotcha", "pitfall", and "caveat" in different calls), making filtering unreliable. A fixed vocabulary keeps labels consistent across incremental rebuilds while still allowing a unit to span more than one category.
- **Ordered labels with a designated primary over an unordered set**: The graph can only display one colour per node, so the first label drives the chip colour. Having the AI rank labels by importance and place the most significant first makes the primary label semantically meaningful rather than an implementation artifact that requires arbitrary tie-breaking later.
- **Per-topic guard over a build-level abort**: A build-level guard was prototyped and removed because it conflicted with a tested contract that full rebuilds tolerate empty topic output gracefully. The narrower guard — which only triggers when the AI returned units but every one was unrecognisable — preserves that contract while still protecting incremental updates from silent data loss.
- **Data-driven vocabulary selection**: The seven final kinds were chosen by examining 537 real units across two repositories and identifying which concepts were being force-fitted into the wrong category. Keyword analysis of the over-loaded "decision" bucket revealed the four missing kinds, grounding the vocabulary in real output rather than speculation.
- **Permissive coercion for scalar kind values**: The plain-string rescue was an intentional reversal of an earlier explicit rejection — consistency with how the legacy single-label format has always been handled justified the change. The tradeoff is slightly more permissive input handling in exchange for symmetric behaviour across both input formats.

**✅ What Was Implemented**

- `GraphSchema.ts` expanded the closed vocabulary from 3 to 7 kinds (adding constraint, gotcha, non-goal, convention), replaced the single `kind` field on `DistilledUnit` with an ordered `kinds[]` array (1–3 entries, first is primary), and introduced `normalizeKinds` for coercion and `isCanonicalKinds` for strict persistence validation. The schema version was bumped from 2 to 3, and `MAX_UNIT_KINDS = 3` was exported as a named constant. `normalizeKinds` was subsequently extended to treat a scalar (non-array) kinds field as a single-element list before filtering, so units where the field arrives as a plain string are rescued rather than silently dropped.
- `GraphDistiller.ts` was updated to run all parsed unit output through `normalizeKinds`, replacing the previous single-kind filter. A fail-closed guard was added: when the LLM returns a non-empty units array but every entry normalizes to zero valid kinds, the incremental path throws to preserve the prior graph, while the full-rebuild path degrades that topic to an empty list with a warning.
- The frontend rendering pipeline was unified: a shared `kindBadges(kinds, opts)` helper was added to `data.js` and called from all three render sites in `views.js` and `panel.js`. The CSS chip rule was promoted from a board-card-scoped selector to a bare `.u-kind` rule so panel contexts receive the same pill shape, and all seven kinds received colour variables in both dark and light VS Code themes. The stale `migration` kind colour was removed.

**📋 Future Enhancements**

Secondary kind badges in the panel render without consistent padding and uppercase styling when units appear outside a board card context. Visual consistency across all panel contexts should be verified once real multi-kind units appear in production graphs.

**📁 FILES**
- `cli/src/graph/GraphSchema.ts`
- `cli/src/graph/GraphDistiller.ts`
- `cli/src/graph/GraphBuilder.ts`
- `cli/src/graph/assets/js/data.js`

</blockquote>
</details>
<details>
<summary><strong>02 · Kind badge visibility unified across board cards and detail panel</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a unit card belonged to multiple kinds, the selection highlight and left-edge accent bar used the topic category colour rather than the unit's own primary kind colour, making it hard to distinguish kind at a glance on the board.

**💡 Decisions Behind the Code**

- **Three-level colour priority over a code branch**: The card's selected colour is determined by a cascade — kind colour, then topic category, then a global default — keeping the logic entirely in the stylesheet. Cards without a kind assigned automatically degrade to the existing behaviour with no extra logic required.
- **Padding compensation on the accent bar**: Widening only the left border would push card content rightward. Trimming left padding by exactly the extra 2px keeps the text column visually stable, avoiding a layout shift noticeable when the accent class is toggled dynamically.
- **Cluster-level gap over individual badge spacing**: Adding spacing to the container around the full badge cluster is more robust than spacing only the first badge. For a single-label unit both approaches look identical, but for multi-label units the old approach left the last badge colliding with the following text.
- **Defence in depth for the accent bar colour**: The accent bar styling normally uses validated data, so the escaping and colour fallback rarely activate. A manually edited or corrupted file could inject unexpected content; both protections ensure the worst-case outcome is a card with the default colour rather than a broken style declaration.

**✅ What Was Implemented**

- In `main.css`, the selected-card border and inset box-shadow were updated to use a new `--ukind` CSS custom property (set inline per card) as the first fallback before the existing category and global accent colours. A new `.unit-card.kind-accent` utility class was added that widens the left border to 3px and trims left padding by 2px to compensate, giving cards with a known primary kind a persistent coloured left-edge accent bar without shifting the text column.
- In `panel.js`, the badge cluster was wrapped in a container element and given an 8px right margin (in `main.css`), so the spacing gap appears after the full cluster of badges rather than only after the first. The per-chip inline spacing option was removed from the shared badge renderer in `data.js`.
- In `views.js`, HTML escaping was applied to the primary label value used to construct the board card's accent bar, and a CSS colour fallback was added so an unrecognised value degrades to the default accent colour instead of emitting a broken style declaration.

**📁 FILES**
- `cli/src/graph/assets/styles/main.css`
- `cli/src/graph/assets/js/views.js`
- `cli/src/graph/assets/js/panel.js`
- `cli/src/graph/assets/js/data.js`

</blockquote>
</details>
<details>
<summary><strong>03 · Prompt updated to demonstrate multi-label kind outputs and complete overlap rules</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The prompt's output example showed only a single kind label, which could anchor the AI toward always choosing one label per unit even though the feature supports up to three. One of the four label-overlap boundary rules was also missing from the main guidance.

**💡 Decisions Behind the Code**

- **Example over instruction**: Using a multi-label output example gives the AI more reliable guidance than written rules alone. The AI tends to anchor heavily on the concrete output example in the prompt; a single-label example would undercut the multi-label feature regardless of how clearly the accompanying text explained it.
- **Complete the boundary rule set**: Three of the four label overlap cases already had explicit co-occurrence guidance, but the fourth appeared only in a supplementary note outside the main table. Integrating it inline ensures the AI has equal coverage for all four overlap scenarios.

**✅ What Was Implemented**

- Changed the JSON output example in `cli/src/core/PromptTemplates.ts` from a single-kind `["decision"]` to a two-kind `["decision","non-goal"]`, giving the model a direct illustration of multi-label output.
- Added the missing boundary rule for the decision-plus-constraint overlap case: when a choice also establishes a permanent hard invariant, both labels apply. Three of the four co-occurrence pairs were already documented inline; this completed the set.

**📁 FILES**
- `cli/src/core/PromptTemplates.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Tests added for exact kind vocabulary membership and out-of-vocabulary badge rendering</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The closed seven-label vocabulary was tested to confirm each label was accepted, but no test verified the set was exactly those seven labels, so a future accidental addition or removal would pass silently. The badge renderer also had no test for what happens when a label outside the vocabulary appears.

**💡 Decisions Behind the Code**

Checking for exact set identity — both contents and order — rather than membership alone was deliberate. A membership-only check catches only one failure direction (a valid label being incorrectly rejected), while an exact-set check also catches labels being quietly added or removed. The cost is that the test must be updated whenever the vocabulary is intentionally changed, making any such change explicit and visible in the review process.

**✅ What Was Implemented**

- Added a set-identity assertion in `cli/src/graph/GraphSchema.test.ts` checking that the vocabulary array equals exactly the seven expected members in order, catching both accidental additions and accidental removals.
- Added an out-of-vocabulary test case in `cli/src/graph/KindBadgesAsset.test.ts` confirming that an unrecognised label value still renders a chip without crashing or leaking the literal "undefined" into the output. Removed the now-obsolete test for the per-chip spacing option that was eliminated from the badge renderer.

**📁 FILES**
- `cli/src/graph/GraphSchema.test.ts`
- `cli/src/graph/KindBadgesAsset.test.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Schema version bump no longer strands stale graph file when topic index is empty</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After a schema version bump, if all topics had been deleted, the old graph file could be left on disk indefinitely rather than being replaced with a fresh empty graph, causing phantom topics to persist in the visualization.

**💡 Decisions Behind the Code**

The gate was moved to the raw prior graph rather than implementing a full v2→v3 legacy migration path. A migration path would require rewriting schema-mismatch logic, adding coercion code, and updating tests that lock the "schema mismatch means full rebuild" behaviour. Accepting one full rebuild on upgrade is consistent with how the v1→v2 transition was handled and avoids a migration code path for a one-time event.

**✅ What Was Implemented**

`GraphBuilder.ts` was updated to gate the empty-graph write on the raw prior graph object rather than the parsed-and-validated distilled graph. The distilled graph is null after a schema mismatch, so the old gate would fall through to a skip and strand the stale file. The new gate reads topic and unit counts directly from the raw JSON, ensuring any non-empty prior graph triggers an overwrite that re-stamps the current schema version.

**📁 FILES**
- `cli/src/graph/GraphBuilder.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 20, 2026 at 5:01 PM · via mixed: Local agent, Anthropic*
<!-- jollimemory-summary-end -->