### PR TITLE
Establish storage backend before uninstall scan to silence spurious warning

### DIFF
--- a/cli/src/commands/UninstallCommand.test.ts
+++ b/cli/src/commands/UninstallCommand.test.ts
@@ -13,7 +13,17 @@ import type { RemovableItem, UninstallInventory } from "../install/UninstallScan
 
 // ─── Hoisted mocks ────────────────────────────────────────────────────────────
 
-const { mockScan, mockPrune, mockUninstall, mockRm, mockIsInteractive, mockPromptText, mockTrack } = vi.hoisted(() => ({
+const {
+	mockScan,
+	mockPrune,
+	mockUninstall,
+	mockRm,
+	mockIsInteractive,
+	mockPromptText,
+	mockTrack,
+	mockCreateStorage,
+	mockSetActiveStorage,
+} = vi.hoisted(() => ({
 	mockScan: vi.fn(),
 	mockPrune: vi.fn(),
 	mockUninstall: vi.fn(),
@@ -21,9 +31,15 @@ const { mockScan, mockPrune, mockUninstall, mockRm, mockIsInteractive, mockPromp
 	mockIsInteractive: vi.fn(),
 	mockPromptText: vi.fn(),
 	mockTrack: vi.fn(),
+	mockCreateStorage: vi.fn(),
+	mockSetActiveStorage: vi.fn(),
 }));
 
 vi.mock("node:fs/promises", () => ({ rm: mockRm }));
+
+vi.mock("../core/StorageFactory.js", () => ({ createStorage: mockCreateStorage }));
+
+vi.mock("../core/SummaryStore.js", () => ({ setActiveStorage: mockSetActiveStorage }));
 
 vi.mock("../install/UninstallScan.js", () => ({
 	scanUninstallInventory: mockScan,
@@ -81,6 +97,7 @@ beforeEach(() => {
 	mockPrune.mockResolvedValue(undefined);
 	mockUninstall.mockResolvedValue({ success: true, message: "ok", warnings: [] });
 	mockIsInteractive.mockReturnValue(true);
+	mockCreateStorage.mockResolvedValue({ tag: "fake-storage" });
 });
 
 afterEach(() => {
@@ -117,6 +134,30 @@ describe("parseSelection", () => {
 
 	it("returns null when no valid index is present", () => {
 		expect(parseSelection("0 9 foo", 3)).toBeNull();
+	});
+});
+
+// ─── storage backend ──────────────────────────────────────────────────────────
+
+describe("uninstall — storage backend", () => {
+	it("establishes the configured backend before scanning", async () => {
+		mockScan.mockResolvedValue(inventory([]));
+		await run(["--yes"]);
+		// Backend must be set before the scan reads the summary count, else the read
+		// falls through to the orphan-branch fallback and logs a spurious warning.
+		expect(mockCreateStorage).toHaveBeenCalledWith("/repo", "/repo");
+		expect(mockSetActiveStorage).toHaveBeenCalledWith({ tag: "fake-storage" });
+		const setOrder = mockSetActiveStorage.mock.invocationCallOrder[0];
+		const scanOrder = mockScan.mock.invocationCallOrder[0];
+		expect(setOrder).toBeLessThan(scanOrder);
+	});
+
+	it("proceeds when the backend cannot be established (non-fatal)", async () => {
+		mockCreateStorage.mockRejectedValue(new Error("no repo"));
+		mockScan.mockResolvedValue(inventory([]));
+		const { out } = await run(["--yes"]);
+		expect(mockSetActiveStorage).not.toHaveBeenCalled();
+		expect(out).toContain("No Jolli installation or configuration found");
 	});
 });
 

--- a/cli/src/commands/UninstallCommand.ts
+++ b/cli/src/commands/UninstallCommand.ts
@@ -17,6 +17,8 @@
 
 import { rm } from "node:fs/promises";
 import type { Command } from "commander";
+import { createStorage } from "../core/StorageFactory.js";
+import { setActiveStorage } from "../core/SummaryStore.js";
 import { track } from "../core/Telemetry.js";
 import { uninstall } from "../install/Installer.js";
 import {
@@ -242,6 +244,19 @@ export function registerUninstallCommand(program: Command): void {
 		.action(async (options: { cwd: string; dryRun?: boolean; yes?: boolean; scope?: string }) => {
 			setLogDir(options.cwd);
 			log.info("Running 'uninstall' command");
+
+			// Establish the configured storage backend before the scan — same as the
+			// read commands (SearchCommand/RecallCommand). The scan reaches getStatus →
+			// getSummaryCount, a read that otherwise falls through resolveStorage to the
+			// orphan-branch fallback and logs a spurious "folder-mode users will miss
+			// this write" warning (misleading: the scan only reads, never writes).
+			// Guarded because uninstall may run in a half-configured or non-repo state;
+			// on failure the read still succeeds via the fallback.
+			try {
+				setActiveStorage(await createStorage(options.cwd, options.cwd));
+			} catch (err) {
+				log.info("Could not establish storage backend before scan (non-fatal): %s", (err as Error).message);
+			}
 
 			const scope = options.scope;
 			if (scope !== "all" && scope !== "global" && scope !== "project") {


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Topic (1)
<details>
<summary><strong>01 · Fix misleading warning shown during uninstall scan</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Running the uninstall command was printing a confusing warning about "folder-mode users will miss this write" even though uninstall only reads existing data and never writes anything, making users think something was going wrong.

**💡 Decisions Behind the Code**

The fix establishes the storage backend proactively before scanning rather than suppressing or rewording the warning message itself, since the warning was accurate for its original purpose (flagging writes that could be lost in folder-mode) but simply misfired here because uninstall never writes. Making the read path resolve the backend correctly, the same way other read-only commands already do, fixes the root cause rather than papering over the symptom. The backend setup was made non-fatal by design, since uninstall must still work in situations where the repo or configuration is incomplete or missing, and failing the whole command over a cosmetic warning would be worse than tolerating the fallback.

**✅ What Was Implemented**

- Updated the uninstall command flow in `cli/src/commands/UninstallCommand.ts` to establish the configured storage backend (via `createStorage` and `setActiveStorage`) immediately after logging start, before the inventory scan runs.
- This mirrors what the read-oriented `SearchCommand`/`RecallCommand` already do, ensuring the scan's internal status/count read resolves through the proper backend instead of falling through to an orphan-branch fallback that logged the spurious warning.
- The backend setup is wrapped in a try/catch so that if it fails (e.g. uninstall run outside a configured repo), the error is logged at info level and the scan still proceeds via the existing fallback path.
- Added tests in `cli/src/commands/UninstallCommand.test.ts` verifying the backend is created and set before the scan runs, and that scanning still succeeds gracefully if backend setup fails.

**📁 FILES**
- `cli/src/commands/UninstallCommand.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 21, 2026 at 6:05 PM · via Jolli proxy*
<!-- jollimemory-summary-end -->
