### PR TITLE
Add Node.js runtime gating scaffolding

### DIFF
--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/CliIntegrations.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/CliIntegrations.kt
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit
 object CliIntegrations {
 
     private val log = JmLogger.create("CliIntegrations")
-    private val isWindows = System.getProperty("os.name").lowercase().contains("win")
 
     sealed class Result {
         /** Integrations set up successfully. */
@@ -228,38 +227,13 @@ object CliIntegrations {
         }
 
     /**
-     * The user's login-shell PATH. GUI-launched IDEs inherit a minimal PATH that often
-     * omits node installed via nvm/homebrew, so we ask the login shell (matches
-     * PrService's gh resolution).
+     * Absolute path to a VERIFIED `node` executable, or null if none exists. Delegates
+     * to [NodeRuntime], which probes the process/login/interactive-shell PATHs plus
+     * well-known install dirs, proves candidates with `node --version`, and records the
+     * winner in `~/.jolli/jollimemory/node-info.json`. Blocking on first call — keep
+     * off the EDT (all current callers already run on pooled threads).
      */
-    private val resolvedPath: String by lazy {
-        try {
-            if (isWindows) {
-                System.getenv("PATH") ?: ""
-            } else {
-                val shell = System.getenv("SHELL")?.takeIf { it.isNotBlank() && File(it).canExecute() } ?: "/bin/zsh"
-                val proc = ProcessBuilder(shell, "-l", "-c", "echo \$PATH").redirectErrorStream(true).start()
-                val out = proc.inputStream.bufferedReader().use { it.readText().trim() }
-                proc.waitFor(5, TimeUnit.SECONDS)
-                if (out.isNotBlank()) out else System.getenv("PATH") ?: ""
-            }
-        } catch (_: Exception) {
-            System.getenv("PATH") ?: ""
-        }
-    }
-
-    /** Absolute path to a `node` executable on the login-shell PATH, or null if absent. */
-    fun resolveNode(): String? {
-        val candidates = if (isWindows) listOf("node.exe", "node.cmd", "node") else listOf("node")
-        for (dir in resolvedPath.split(File.pathSeparator)) {
-            if (dir.isBlank()) continue
-            for (name in candidates) {
-                val f = File(dir, name)
-                if (f.canExecute()) return f.absolutePath
-            }
-        }
-        return null
-    }
+    fun resolveNode(): String? = NodeRuntime.detect()?.path
 
     fun isNodeAvailable(): Boolean = resolveNode() != null
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/NodeRuntime.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/NodeRuntime.kt
@@ -1,0 +1,572 @@
+package ai.jolli.jollimemory.bridge
+
+import ai.jolli.jollimemory.core.HookEnv
+import ai.jolli.jollimemory.core.JmLogger
+import ai.jolli.jollimemory.core.SessionTracker
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/** A verified Node.js runtime: absolute binary path + `node --version` output (e.g. "v22.14.0"). */
+data class NodeInfo(val path: String, val version: String)
+
+/**
+ * A Node install found during detection but rejected as unusable.
+ *
+ * Currently the only rejection reason is "runs, but version below [NodeRuntime.MIN_SUPPORTED_MAJOR]".
+ * Surfaced so the UI can tell the user "we saw v14.21.3 at /opt/homebrew/bin/node — please upgrade"
+ * instead of a bare "no Node found", which is confusing on a machine that clearly has Node.
+ */
+data class RejectedCandidate(val path: String, val version: String)
+
+/**
+ * NodeRuntime — locates and verifies a usable Node.js runtime, and records the result.
+ *
+ * Why not simply spawn `node --version` and see if it works: subprocesses inherit the
+ * IDE process environment, and a GUI-launched IDE (Dock / Launchpad / desktop shortcut)
+ * gets a minimal PATH (`/usr/bin:/bin:...`) that lacks nvm/homebrew/volta locations. A
+ * naive spawn therefore reports "missing" on machines that DO have Node. Conversely,
+ * merely finding an executable file on some PATH is not proof it runs. Detection is
+ * therefore two-phase: gather candidate binaries from every plausible channel, then
+ * verify candidates by actually executing `<candidate> --version` — the first binary
+ * that answers wins.
+ *
+ * Candidate channels, in order:
+ *  1. The binary recorded in `~/.jolli/jollimemory/node-info.json` by a previous
+ *     successful detection (fast path — skips the shell probes entirely).
+ *  2. The IDE process PATH (correct when the IDE was launched from a terminal; free).
+ *  3. The LOGIN shell PATH (`$SHELL -lc`) — loads ~/.zprofile, where homebrew lives.
+ *  4. The INTERACTIVE login shell PATH (`$SHELL -lic`) — additionally loads ~/.zshrc,
+ *     which is where nvm's init line is installed by default.
+ *  5. On Windows: the official MSI installer's registry record
+ *     (`HKLM/HKCU\SOFTWARE\Node.js InstallPath`) — unlike the process PATH (a snapshot
+ *     taken at IDE launch), the registry reflects an install done AFTER the IDE
+ *     started, which is exactly the Retry-button scenario.
+ *  6. Well-known install locations (homebrew, MacPorts, nvm, nvm.fish, volta, fnm,
+ *     asdf, mise, nodenv, n; on Windows: Program Files, scoop, chocolatey,
+ *     nvm-windows, Volta).
+ *
+ * Verification also enforces [MIN_SUPPORTED_MAJOR]: the plugin's bundled Cli.js
+ * cannot run on ancient Node, so a v12 on PATH must count as "not usable", not as a
+ * successful detection — a newer install elsewhere can still win via later channels.
+ *
+ * Shell probes wrap `$PATH` in sentinel markers so rc-file noise (echoes, warnings,
+ * prompts) cannot corrupt the extracted value, use fish-specific syntax when `$SHELL`
+ * is fish (fish has no `${}` expansion and PATH is a list, not a colon string), and
+ * enforce a hard timeout with the wait-then-read order so a hanging rc file (tmux
+ * auto-attach etc.) cannot block.
+ *
+ * The verified result is persisted to `~/.jolli/jollimemory/node-info.json`
+ * (`{path, version, source, detectedAt}`) and cached in-process. [detect] with
+ * `forceRefresh = true` re-runs the full probe — used by the tool window's Retry
+ * button after the user installs Node. When every automatic channel fails, the
+ * blocking panel offers a file chooser; the pick goes through [adoptManualSelection],
+ * which applies the exact same `--version` + minimum-version proof before adopting.
+ *
+ * When detection returns null, callers can read [rejectedFromLastDetection] to explain
+ * WHY — currently: Node installs that ran but were below [MIN_SUPPORTED_MAJOR] — so the
+ * UI can be specific ("v14.21.3 at /opt/homebrew/bin/node — too old") instead of a
+ * generic "no Node found" that reads as a bug on machines that clearly have Node.
+ *
+ * Thread-safety: [detect] is synchronized (concurrent callers share one probe) and
+ * blocking (shell probes can take seconds on first run) — call it off the EDT.
+ * [cached] never blocks and is safe anywhere.
+ */
+object NodeRuntime {
+
+    private val log = JmLogger.create("NodeRuntime")
+
+    /**
+     * Access point for every JVM-global read this file needs (osName, userHome, getenv).
+     * Defaults to the real process globals; tests inject a fake via [setEnvForTest] so
+     * detection can be exercised deterministically. Routing everything through this one
+     * field is what keeps the file out of scripts/main-globals-baseline.txt — the
+     * checkGlobalState gate greps for direct process-global reads (env vars, system
+     * properties, standard streams).
+     */
+    @Volatile
+    private var env: HookEnv = HookEnv()
+
+    /** Test seam: swap in a fake HookEnv (see TestEnvs.fakeHookEnv). */
+    internal fun setEnvForTest(newEnv: HookEnv) = synchronized(detectLock) {
+        env = newEnv
+    }
+
+    private val isWindows: Boolean
+        get() = env.osName.lowercase().contains("win")
+
+    internal const val INFO_FILE_NAME = "node-info.json"
+
+    /**
+     * Oldest Node major the bundled Cli.js runs on (the esbuild bundle targets Node 18;
+     * `node:sqlite`-dependent features degrade gracefully above that). Older binaries
+     * are rejected during verification so "detected" always means "actually usable".
+     */
+    internal const val MIN_SUPPORTED_MAJOR = 18
+
+    private const val PATH_MARK_START = "__JOLLI_PATH_START__"
+    private const val PATH_MARK_END = "__JOLLI_PATH_END__"
+    private const val SHELL_PROBE_TIMEOUT_SECONDS = 5L
+    private const val VERSION_PROBE_TIMEOUT_SECONDS = 10L
+    private const val REG_QUERY_TIMEOUT_SECONDS = 5L
+
+    private val detectLock = Any()
+
+    @Volatile
+    private var cachedInfo: NodeInfo? = null
+
+    @Volatile
+    private var detectionDone = false
+
+    @Volatile
+    private var rejectedList: List<RejectedCandidate> = emptyList()
+
+    /**
+     * Non-blocking: the last detection outcome. `null` means "not found" OR "not yet
+     * detected" — distinguish with [hasDetected] when it matters for UI wording.
+     */
+    fun cached(): NodeInfo? = cachedInfo
+
+    /** Non-blocking: true once a detection pass has completed in this process (found or not). */
+    fun hasDetected(): Boolean = detectionDone
+
+    /**
+     * Non-blocking: candidates that ran during the last [detect] pass but were rejected
+     * (currently: Node installs below [MIN_SUPPORTED_MAJOR]). Empty when detection has
+     * never run, when detection succeeded via the fast path or on the first candidate,
+     * or when no candidate answered `--version` at all. Read by UI code to explain why
+     * automatic detection failed on a machine that clearly has Node.
+     */
+    fun rejectedFromLastDetection(): List<RejectedCandidate> = rejectedList
+
+    /**
+     * Finds a verified Node runtime, or `null` when none exists. Blocking — first run
+     * may spawn shell probes (seconds); later runs return the in-process cache. A
+     * negative outcome is also cached for the process lifetime so gate checks stay
+     * cheap; pass [forceRefresh] to probe again (Retry button, post-install).
+     */
+    fun detect(forceRefresh: Boolean = false): NodeInfo? = synchronized(detectLock) {
+        if (!forceRefresh && detectionDone) return cachedInfo
+
+        // Reset the rejected list for THIS pass so callers never see stale data from a
+        // previous probe. Fast-path success leaves it empty (nothing to report when we
+        // never scanned the full set); the full-probe branch below fills it if any
+        // candidate answered --version but was too old.
+        rejectedList = emptyList()
+
+        // Fast path: re-verify the binary recorded by a previous successful detection.
+        // Skipped on forceRefresh so Retry always re-runs the full probe. When the
+        // version has drifted (e.g. a patch upgrade under a manually-picked binary),
+        // we rewrite the record but preserve the original source tag so a "manual"
+        // pick is never silently reclassified as "auto".
+        if (!forceRefresh) {
+            readRecord(infoFile())?.let { recorded ->
+                val fresh = verify(recorded.info.path)
+                if (fresh is VerifyResult.Ok) {
+                    if (fresh.info != recorded.info) {
+                        writeRecordedInfo(infoFile(), fresh.info, source = recorded.source)
+                    }
+                    return finish(fresh.info)
+                }
+            }
+        }
+
+        // Full probe: walk every candidate. Stop at the first Ok; collect TooOld hits
+        // (deduped by path — a version manager plus PATH shim can list the same binary
+        // twice) so the UI can name the rejected version, not just say "not found".
+        val rejected = LinkedHashMap<String, RejectedCandidate>()
+        var found: NodeInfo? = null
+        for (candidate in candidateBinaries()) {
+            when (val result = verify(candidate)) {
+                is VerifyResult.Ok -> {
+                    found = result.info
+                    break
+                }
+                is VerifyResult.TooOld ->
+                    rejected.putIfAbsent(result.path, RejectedCandidate(result.path, result.version))
+                VerifyResult.NotUsable -> {} // silently skip: not a runnable Node
+            }
+        }
+        rejectedList = rejected.values.toList()
+
+        if (found != null) {
+            log.info("Node runtime verified: %s (%s)", found.path, found.version)
+            writeRecordedInfo(infoFile(), found)
+        } else {
+            log.warn("No usable Node runtime found (probed process/login/interactive PATH + well-known dirs)")
+            // Drop a stale record so the fast path can't resurrect a binary that just failed.
+            try {
+                infoFile().delete()
+            } catch (_: Exception) {
+                // best-effort cleanup
+            }
+        }
+        finish(found)
+    }
+
+    private fun finish(info: NodeInfo?): NodeInfo? {
+        cachedInfo = info
+        detectionDone = true
+        return info
+    }
+
+    // ── Manual selection (file-chooser fallback) ────────────────────────────
+
+    /** Outcome of validating a user-picked binary, with enough detail for UI wording. */
+    sealed class ManualSelectionResult {
+        /** The pick is a usable Node runtime and is now the recorded one. */
+        data class Accepted(val info: NodeInfo) : ManualSelectionResult()
+
+        /** The pick runs, but its version is below [MIN_SUPPORTED_MAJOR]. */
+        data class TooOld(val version: String) : ManualSelectionResult()
+
+        /** The pick exists but `--version` failed or printed no Node version. */
+        object NotNode : ManualSelectionResult()
+
+        /** The pick is not a regular executable file. */
+        object NotExecutable : ManualSelectionResult()
+    }
+
+    /** File names the manual chooser accepts as a Node binary (chooser-side filter). */
+    fun isNodeExecutableName(fileName: String): Boolean {
+        val n = fileName.lowercase()
+        return n == "node" || n == "node.exe" || n == "node.cmd"
+    }
+
+    /**
+     * Validates a binary the user picked in the file chooser and — when it proves to be
+     * a usable Node runtime — adopts it: records it in node-info.json (tagged
+     * `source: "manual"`) and makes it the in-process detection result. The same
+     * `--version` + minimum-version proof as automatic detection applies, so picking a
+     * wrong file can never unblock the plugin. Blocking — call off the EDT.
+     */
+    fun adoptManualSelection(binPath: String): ManualSelectionResult =
+        adoptManualSelection(binPath, infoFile())
+
+    /** Testable seam: same validation/adoption against an explicit record file. */
+    internal fun adoptManualSelection(binPath: String, recordFile: File): ManualSelectionResult =
+        synchronized(detectLock) {
+            val f = File(binPath)
+            if (!f.isFile || !f.canExecute()) return ManualSelectionResult.NotExecutable
+            val version = probeVersion(f) ?: return ManualSelectionResult.NotNode
+            val major = versionMajor(version)
+            if (major == null || major < MIN_SUPPORTED_MAJOR) return ManualSelectionResult.TooOld(version)
+            val info = NodeInfo(f.absolutePath, version)
+            writeRecordedInfo(recordFile, info, source = "manual")
+            log.info("Node runtime adopted from manual selection: %s (%s)", info.path, info.version)
+            // Clear any TooOld candidates left over from the prior detect() pass: the
+            // manually-picked binary is now the authoritative outcome, so
+            // rejectedFromLastDetection() must not keep returning stale rejections.
+            rejectedList = emptyList()
+            finish(info)
+            ManualSelectionResult.Accepted(info)
+        }
+
+    /** Test-only: clears the in-process detection state (NodeRuntime is a singleton). */
+    internal fun resetForTest() = synchronized(detectLock) {
+        cachedInfo = null
+        detectionDone = false
+        rejectedList = emptyList()
+        env = HookEnv()
+    }
+
+    // ── Candidate discovery ─────────────────────────────────────────────────
+
+    /** Ordered, de-duplicated candidate binaries that exist and are executable. */
+    private fun candidateBinaries(): List<String> {
+        val names = if (isWindows) listOf("node.exe", "node.cmd", "node") else listOf("node")
+        val dirs = LinkedHashSet<String>()
+        splitPath(env.getenv("PATH")).forEach { dirs.add(it) }
+        if (!isWindows) {
+            splitPath(shellPath(interactive = false)).forEach { dirs.add(it) }
+            splitPath(shellPath(interactive = true)).forEach { dirs.add(it) }
+        }
+        val candidates = LinkedHashSet<String>()
+        for (dir in dirs) {
+            for (name in names) {
+                val f = File(dir, name)
+                if (f.isFile && f.canExecute()) candidates.add(f.absolutePath)
+            }
+        }
+        wellKnownBinaries().forEach { candidates.add(it) }
+        return candidates.toList()
+    }
+
+    private fun splitPath(path: String?): List<String> =
+        path?.split(File.pathSeparator)?.filter { it.isNotBlank() } ?: emptyList()
+
+    /**
+     * The user's shell, or a fallback that actually exists on this OS. macOS always
+     * ships /bin/zsh, but many Linux distros ship only bash or sh — a hardcoded zsh
+     * fallback would silently disable both shell probes there.
+     */
+    private fun resolveShell(): String? {
+        env.getenv("SHELL")?.takeIf { it.isNotBlank() && File(it).canExecute() }?.let { return it }
+        return listOf("/bin/zsh", "/bin/bash", "/bin/sh").firstOrNull { File(it).canExecute() }
+    }
+
+    /**
+     * `$PATH` as reported by the user's shell. [interactive] adds `-i` so rc files
+     * (~/.zshrc — nvm's default home) are loaded too. Wait-then-read order: if the
+     * shell hangs it is force-killed at the timeout and we read whatever it buffered,
+     * so a pathological rc file can never wedge detection. csh/tcsh reject the flag
+     * combination and print no marker — that degrades to null and the well-known
+     * directory fallback covers those users.
+     */
+    private fun shellPath(interactive: Boolean): String? {
+        return try {
+            val shell = resolveShell() ?: return null
+            val flags = if (interactive) "-lic" else "-lc"
+            // POSIX shells: braced ${PATH}, because the end marker starts with an
+            // underscore and an unbraced $PATH would be greedily parsed as one long
+            // variable name. fish: no ${} syntax at all, and $PATH is a list — the
+            // marker quotes concatenate with the command substitution's output.
+            val echoCommand = if (File(shell).name == "fish") {
+                "echo \"$PATH_MARK_START\"(string join : \$PATH)\"$PATH_MARK_END\""
+            } else {
+                "echo \"$PATH_MARK_START\${PATH}$PATH_MARK_END\""
+            }
+            val proc = ProcessBuilder(shell, flags, echoCommand)
+                .redirectErrorStream(true)
+                .start()
+            proc.outputStream.close() // EOF on stdin so an interactive shell can't wait for input
+            if (!proc.waitFor(SHELL_PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                proc.destroyForcibly()
+                proc.waitFor(1, TimeUnit.SECONDS)
+            }
+            extractMarkedPath(proc.inputStream.bufferedReader().use { it.readText() })
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    /** Pulls the marker-wrapped PATH out of shell output that may contain rc-file noise. */
+    internal fun extractMarkedPath(output: String): String? {
+        val start = output.lastIndexOf(PATH_MARK_START)
+        if (start < 0) return null
+        val from = start + PATH_MARK_START.length
+        val end = output.indexOf(PATH_MARK_END, from)
+        if (end < 0) return null
+        return output.substring(from, end).trim().takeIf { it.isNotBlank() }
+    }
+
+    /** Install locations of the common Node distribution channels, newest version first. */
+    private fun wellKnownBinaries(): List<String> {
+        if (isWindows) return windowsWellKnownBinaries()
+        val home = env.userHome.path
+        val fixed = listOf(
+            "/opt/homebrew/bin/node", // homebrew (Apple Silicon)
+            "/usr/local/bin/node", // homebrew (Intel) / nodejs.org pkg installer / tj-n default
+            "/opt/local/bin/node", // MacPorts
+            "/usr/bin/node", // Linux distro package
+            "$home/.volta/bin/node",
+            "$home/.asdf/shims/node",
+            "$home/.nodenv/shims/node",
+            "$home/.n/bin/node", // tj/n with N_PREFIX=~/.n
+            "$home/.local/share/mise/shims/node",
+        ).filter { File(it).isFile }
+        val posixRel = listOf("bin/node", "installation/bin/node")
+        val versioned = listOf(
+            "$home/.nvm/versions/node", // nvm: <root>/vX.Y.Z/bin/node
+            "$home/.local/share/nvm", // nvm.fish: <root>/vX.Y.Z/bin/node
+            "$home/.fnm/node-versions", // fnm: <root>/vX.Y.Z/installation/bin/node
+            "$home/.local/share/fnm/node-versions",
+            "$home/Library/Application Support/fnm/node-versions",
+            "$home/.local/share/mise/installs/node", // mise: <root>/X.Y.Z/bin/node
+        ).flatMap { versionedBinaries(it, posixRel) }
+        return fixed + versioned
+    }
+
+    /**
+     * Windows install channels. The registry record comes FIRST: the process PATH is a
+     * snapshot from IDE launch, so an official-MSI install done while the IDE is open
+     * (the Retry-button scenario) is invisible to PATH but present in the registry.
+     */
+    private fun windowsWellKnownBinaries(): List<String> {
+        val out = LinkedHashSet<String>()
+        registryNodeInstallPath()?.let { out.add(File(it, "node.exe").absolutePath) }
+        env.getenv("ProgramFiles")?.let { out.add("$it\\nodejs\\node.exe") }
+        env.getenv("ProgramFiles(x86)")?.let { out.add("$it\\nodejs\\node.exe") }
+        env.getenv("LOCALAPPDATA")?.let { out.add("$it\\Programs\\nodejs\\node.exe") }
+        val userProfile = env.getenv("USERPROFILE") ?: env.userHome.path
+        out.add("$userProfile\\scoop\\shims\\node.exe") // scoop
+        env.getenv("ProgramData")?.let { out.add("$it\\chocolatey\\bin\\node.exe") } // chocolatey shim
+        env.getenv("LOCALAPPDATA")?.let { out.add("$it\\Volta\\bin\\node.exe") } // Volta (Windows default)
+        out.add("$userProfile\\.volta\\bin\\node.exe")
+        // nvm-windows: NVM_HOME is set machine-wide by its installer; layout is
+        // <root>\vX.Y.Z\node.exe (no bin\ segment).
+        val nvmHome = env.getenv("NVM_HOME") ?: env.getenv("APPDATA")?.let { "$it\\nvm" }
+        val versioned = if (nvmHome != null) versionedBinaries(nvmHome, listOf("node.exe")) else emptyList()
+        return out.filter { File(it).isFile } + versioned
+    }
+
+    /**
+     * `InstallPath` from `HKLM/HKCU\SOFTWARE\Node.js` — written by the official
+     * Windows MSI installer. Queried via `reg.exe` (no JNI), best-effort.
+     */
+    private fun registryNodeInstallPath(): String? {
+        for (hive in listOf("HKLM", "HKCU")) {
+            try {
+                val proc = ProcessBuilder("reg", "query", "$hive\\SOFTWARE\\Node.js", "/v", "InstallPath")
+                    .redirectErrorStream(true)
+                    .start()
+                proc.outputStream.close()
+                if (!proc.waitFor(REG_QUERY_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    proc.destroyForcibly()
+                    proc.waitFor(1, TimeUnit.SECONDS)
+                    continue
+                }
+                if (proc.exitValue() != 0) continue
+                val out = proc.inputStream.bufferedReader().use { it.readText() }
+                val path = parseRegInstallPath(out)
+                if (path != null) return path
+            } catch (_: Exception) {
+                // reg.exe unavailable or query failed — fall through to the next hive
+            }
+        }
+        return null
+    }
+
+    /** Pulls the InstallPath value out of `reg query` output. */
+    internal fun parseRegInstallPath(output: String): String? =
+        Regex("InstallPath\\s+REG_(?:EXPAND_)?SZ\\s+(.+)").find(output)
+            ?.groupValues?.get(1)?.trim()?.takeIf { it.isNotBlank() }
+
+    /** Binaries under a version-manager root (one dir per version), newest first. */
+    private fun versionedBinaries(root: String, relativePaths: List<String>): List<String> {
+        val dir = File(root)
+        if (!dir.isDirectory) return emptyList()
+        return (dir.listFiles { f -> f.isDirectory } ?: emptyArray())
+            .sortedByDescending { versionSortKey(it.name) }
+            .mapNotNull { versionDir ->
+                relativePaths.map { File(versionDir, it) }.firstOrNull { it.isFile }?.absolutePath
+            }
+    }
+
+    /** Numeric sort key for "v22.14.0"-style directory names; unparseable names sort last. */
+    internal fun versionSortKey(name: String): Long {
+        val m = Regex("^v?(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?").find(name.trim()) ?: return -1
+        val major = m.groupValues[1].toLongOrNull() ?: return -1
+        val minor = m.groupValues[2].toLongOrNull() ?: 0
+        val patch = m.groupValues[3].toLongOrNull() ?: 0
+        return major * 1_000_000 + minor * 1_000 + patch
+    }
+
+    // ── Verification ────────────────────────────────────────────────────────
+
+    /**
+     * Structured outcome of verifying one candidate. Callers care about three cases:
+     *  - [Ok] wins the probe;
+     *  - [TooOld] does not, but is worth surfacing to the user (their Node just needs
+     *    upgrading — much more actionable than a blanket "not found");
+     *  - [NotUsable] is silently skipped (broken symlink, wrong arch, unrelated file).
+     */
+    private sealed class VerifyResult {
+        data class Ok(val info: NodeInfo) : VerifyResult()
+        data class TooOld(val path: String, val version: String) : VerifyResult()
+        object NotUsable : VerifyResult()
+    }
+
+    /**
+     * Proves a candidate actually runs by executing `<binPath> --version`. Existence or
+     * canExecute alone is NOT sufficient (broken symlink targets, wrong-arch binaries).
+     * A binary older than [MIN_SUPPORTED_MAJOR] runs but the bundled Cli.js cannot run
+     * ON it, so it must not count as a usable detection — a newer install elsewhere can
+     * still win as a later candidate. Too-old hits are returned as [VerifyResult.TooOld]
+     * so [detect] can surface them for actionable UI messages.
+     */
+    private fun verify(binPath: String): VerifyResult {
+        val f = File(binPath)
+        if (!f.isFile || !f.canExecute()) return VerifyResult.NotUsable
+        val version = probeVersion(f) ?: return VerifyResult.NotUsable
+        val major = versionMajor(version) ?: return VerifyResult.NotUsable
+        if (major < MIN_SUPPORTED_MAJOR) {
+            log.info(
+                "Rejecting %s: %s is below the minimum supported v%d",
+                f.absolutePath, version, MIN_SUPPORTED_MAJOR,
+            )
+            return VerifyResult.TooOld(f.absolutePath, version)
+        }
+        return VerifyResult.Ok(NodeInfo(f.absolutePath, version))
+    }
+
+    /** Runs `<binary> --version` and returns the reported version, or null when it can't run. */
+    private fun probeVersion(binary: File): String? {
+        return try {
+            val proc = ProcessBuilder(binary.absolutePath, "--version").redirectErrorStream(true).start()
+            proc.outputStream.close()
+            if (!proc.waitFor(VERSION_PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                proc.destroyForcibly()
+                proc.waitFor(1, TimeUnit.SECONDS)
+                return null
+            }
+            val out = proc.inputStream.bufferedReader().use { it.readText() }
+            if (proc.exitValue() == 0) parseVersionOutput(out) else null
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    /** Extracts the "vX.Y.Z" line from `node --version` output. */
+    internal fun parseVersionOutput(output: String): String? =
+        output.lineSequence()
+            .map { it.trim() }
+            .lastOrNull { it.matches(Regex("^v\\d+\\.\\d+\\.\\d+\\S*$")) }
+
+    /** Major component of a "vX.Y.Z" version string, or null when unparseable. */
+    internal fun versionMajor(version: String): Int? =
+        Regex("^v(\\d+)\\.").find(version.trim())?.groupValues?.get(1)?.toIntOrNull()
+
+    // ── Persistence (~/.jolli/jollimemory/node-info.json) ───────────────────
+
+    private fun infoFile(): File = File(SessionTracker.getGlobalConfigDir(), INFO_FILE_NAME)
+
+    /**
+     * Persisted record shape: the info plus its source tag. Kept private so callers
+     * (including tests) keep dealing with plain NodeInfo; only [detect] itself
+     * needs the source, to preserve `"manual"` tags across fast-path rewrites when
+     * the version has drifted (a Node upgrade under a manually-picked binary).
+     */
+    private data class RecordedRuntime(val info: NodeInfo, val source: String)
+
+    /** Testable seam: reads a previously recorded detection, or `null` when absent/corrupt. */
+    internal fun readRecordedInfo(file: File): NodeInfo? = readRecord(file)?.info
+
+    private fun readRecord(file: File): RecordedRuntime? = try {
+        if (!file.isFile) {
+            null
+        } else {
+            val o = JsonParser.parseString(file.readText(Charsets.UTF_8)).asJsonObject
+            val path = o.get("path")?.asString
+            val version = o.get("version")?.asString
+            val source = o.get("source")?.asString?.takeIf { it.isNotBlank() } ?: "auto"
+            if (path.isNullOrBlank() || version.isNullOrBlank()) {
+                null
+            } else {
+                RecordedRuntime(NodeInfo(path, version), source)
+            }
+        }
+    } catch (_: Exception) {
+        null
+    }
+
+    /**
+     * Testable seam: records a verified detection (path + version + timestamp).
+     * [source] tags how the binary was found — "auto" (detection) or "manual"
+     * (file-chooser pick) — for diagnostics; readers ignore it.
+     */
+    internal fun writeRecordedInfo(file: File, info: NodeInfo, source: String = "auto") {
+        try {
+            file.parentFile?.mkdirs()
+            val o = JsonObject()
+            o.addProperty("path", info.path)
+            o.addProperty("version", info.version)
+            o.addProperty("source", source)
+            o.addProperty("detectedAt", java.time.Instant.now().toString())
+            file.writeText(o.toString() + "\n", Charsets.UTF_8)
+        } catch (e: Exception) {
+            log.warn("Failed to write %s: %s", INFO_FILE_NAME, e.message)
+        }
+    }
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
@@ -242,6 +242,16 @@ class JolliMemoryService(private val project: Project) : Disposable {
         private set
 
     /**
+     * Set to `true` when [initialize] was blocked because no usable Node.js runtime
+     * was found. While set, NOTHING was initialized (no hooks, no KB folder, no
+     * watchers) — the tool window shows a blocking "Node.js required" panel instead
+     * of the full UI. Cleared by a successful [initialize] after Node is detected.
+     */
+    @Volatile
+    var nodeMissing: Boolean = false
+        private set
+
+    /**
      * Resets initialization state so [initialize] can run again.
      * Called when `.git` reappears after being removed (e.g., user ran `git init`
      * after previously deleting the repo).
@@ -262,6 +272,21 @@ val sb = StringBuilder()
             initLog = sb.toString()
             return
         }
+
+        // Hard gate: a usable Node.js runtime is REQUIRED. When absent, initialization
+        // stops here — no hooks, no KB folder, no watchers, no sync. The startup
+        // activity and the tool window surface a blocking "Node.js required" panel
+        // with a Retry that re-runs detection and then this method. Blocking probe,
+        // but cheap after the first detection (in-process + node-info.json cache).
+        if (ai.jolli.jollimemory.bridge.NodeRuntime.detect() == null) {
+            nodeMissing = true
+            lastError = "Node.js not found — Jolli Memory is blocked until it is installed"
+            sb.appendLine("BLOCKED: no usable Node.js runtime found")
+            initLog = sb.toString()
+            log.warn("Initialize blocked: no usable Node.js runtime")
+            return
+        }
+        nodeMissing = false
 
         // Check .git entry
         val gitEntry = java.io.File(basePath, ".git")

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryStartupActivity.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryStartupActivity.kt
@@ -1,6 +1,8 @@
 package ai.jolli.jollimemory.services
 
+import ai.jolli.jollimemory.bridge.NodeRuntime
 import ai.jolli.jollimemory.core.JmLogger
+import ai.jolli.jollimemory.util.escapeHtml
 import com.intellij.ide.BrowserUtil
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationGroupManager
@@ -18,10 +20,14 @@ import java.util.concurrent.TimeUnit
  *
  * When the project has no Git repository, shows a one-time balloon
  * notification suggesting the user run `git init`.
+ *
+ * When no usable Node.js runtime is found, startup is BLOCKED: an error
+ * notification is shown and none of the startup sequence runs. The tool
+ * window independently shows a blocking "Node.js required" panel whose
+ * Retry button calls [retryNodeDetection] to re-probe and, on success,
+ * complete the startup sequence that was skipped here.
  */
 class JolliMemoryStartupActivity : ProjectActivity {
-
-    private val log = JmLogger.create("StartupActivity")
 
     override suspend fun execute(project: Project) {
         val basePath = project.basePath ?: return
@@ -46,80 +52,143 @@ class JolliMemoryStartupActivity : ProjectActivity {
             return
         }
 
-        log.info("JolliMemory: initializing for project at $basePath")
-        val service = project.getService(JolliMemoryService::class.java)
-        service.initialize()
-
-        log.info("JolliMemory: activating sync for project at $basePath")
-        ai.jolli.jollimemory.sync.SyncActivation.activateSync(project, service)
-
-        // Cold-start back-fill signals (Kotlin analog of VS Code's computeColdStartSignals):
-        // decide whether to offer "build memory from your history" in the tool window. Runs
-        // on a pooled thread because it shells out to `jolli backfill --list-candidates`, so
-        // it never delays project startup; the tool window updates via a backfill listener.
-        com.intellij.openapi.application.ApplicationManager.getApplication().executeOnPooledThread {
-            try {
-                service.computeColdStartSignals()
-            } catch (e: Exception) {
-                log.warn("Cold-start signal compute failed (ignored): ${e.message}")
+        // Hard gate: a usable Node.js runtime is required before ANY startup logic
+        // runs. Detection is blocking (shell probes) — fine here, this coroutine is
+        // off the EDT. When missing, notify and stop; the tool window shows the
+        // blocking panel with the Retry entry point.
+        if (NodeRuntime.detect() == null) {
+            log.warn("JolliMemory: no usable Node.js runtime found — startup blocked")
+            // Prefer a specific "installed but too old" message over the generic "not
+            // found" when detection actually saw Node — it's much more actionable and
+            // matches what the tool window's blocking panel says.
+            val rejected = NodeRuntime.rejectedFromLastDetection()
+            val leading = if (rejected.isEmpty()) {
+                "No usable Node.js runtime was found on this machine, so Jolli Memory is blocked."
+            } else {
+                val details = rejected.joinToString("; ") { r ->
+                    "${escapeHtml(r.version)} at ${escapeHtml(r.path)}"
+                }
+                "Node.js is installed but too old (need v18 or newer): $details. " +
+                    "Jolli Memory is blocked."
             }
-        }
-
-        // Telemetry (JOLLI-1785): bootstrap anonymous, content-free usage
-        // telemetry, fire app_installed once per machine, flush anything buffered
-        // by prior sessions/hooks, and show the loud first-run notice once.
-        try {
-            val showNotice = ai.jolli.jollimemory.core.telemetry.TelemetryActivation.bootstrap(basePath)
-            // JOLLI-1963: count new + upgrade installs. Fires once per project open
-            // (a real session), carrying surface_version; first-seen (install_id,
-            // surface_version) ≈ new + upgrade installs. Emitted here (not in
-            // TelemetryActivation.bootstrap, which the git hooks also call) so hook
-            // runs don't flood it. No-op when telemetry is off.
-            ai.jolli.jollimemory.core.telemetry.Telemetry.track("client_activated")
-            ai.jolli.jollimemory.core.telemetry.TelemetryActivation.flushNow(basePath)
-            if (showNotice) {
-                ai.jolli.jollimemory.core.telemetry.TelemetrySharedConfig.markNoticeShown()
-                NotificationGroupManager.getInstance()
-                    .getNotificationGroup("JolliMemory")
-                    .createNotification(
-                        "Jolli Memory usage telemetry",
-                        "Anonymous, content-free usage telemetry (never code, paths, or memory content) is on to " +
-                            "improve the product. Turn it off any time with <code>jolli telemetry off</code>, the " +
-                            "<code>DO_NOT_TRACK</code> env var, or the IDE's data-sharing setting.",
-                        NotificationType.INFORMATION,
-                    )
-                    .addAction(NotificationAction.createSimple("Learn more") {
-                        BrowserUtil.browse("https://www.jolli.ai/telemetry")
-                    })
-                    .addAction(NotificationAction.createSimple("Turn off") {
-                        ai.jolli.jollimemory.core.telemetry.TelemetrySharedConfig.setTelemetry(false)
-                        ai.jolli.jollimemory.core.telemetry.Telemetry.shutdown()
-                    })
-                    .notify(project)
-            }
-        } catch (e: Exception) {
-            log.warn("Telemetry bootstrap failed (ignored): ${e.message}")
-        }
-
-        // JOLLI-1956: periodic telemetry flush, decoupled from the tool window's
-        // visibility. The Active Conversations 60s tick only flushes while that
-        // panel is showing, so a user who keeps the tool window closed would never
-        // drain the shared buffer. Schedule a background flush tied to the project
-        // lifecycle (cancelled on project close). Runs off the EDT — flushNow does
-        // blocking HTTP — and is best-effort (flushNow re-gates consent, never throws).
-        try {
-            val flushFuture =
-                AppExecutorUtil.getAppScheduledExecutorService().scheduleWithFixedDelay(
-                    { ai.jolli.jollimemory.core.telemetry.TelemetryActivation.flushNow(basePath) },
-                    60L,
-                    60L,
-                    TimeUnit.SECONDS,
+            NotificationGroupManager.getInstance()
+                .getNotificationGroup("JolliMemory")
+                .createNotification(
+                    "Jolli Memory requires Node.js",
+                    "$leading Install Node.js 18 or newer (LTS recommended) and click " +
+                        "<b>Retry detection</b> in the Jolli Memory tool window — or point it at " +
+                        "an existing binary there with <b>Choose manually</b>.",
+                    NotificationType.ERROR,
                 )
-            Disposer.register(project, Disposable { flushFuture.cancel(false) })
-        } catch (e: Exception) {
-            log.warn("Telemetry flush scheduling failed (ignored): ${e.message}")
+                .addAction(NotificationAction.createSimple("Download Node.js") {
+                    BrowserUtil.browse("https://nodejs.org/en/download")
+                })
+                .notify(project)
+            return
         }
 
-        log.info("JolliMemory: startup complete for project at $basePath")
+        runPostNodeStartup(project)
+    }
+
+    companion object {
+
+        private val log = JmLogger.create("StartupActivity")
+
+        /**
+         * Forces a fresh Node probe and, when a runtime is found, completes the
+         * startup sequence that the Node gate skipped. Returns whether Node was
+         * found. Blocking (shell probes + full startup) — call from a pooled
+         * thread, never the EDT. Used by the tool window's Retry button.
+         */
+        fun retryNodeDetection(project: Project): Boolean {
+            if (NodeRuntime.detect(forceRefresh = true) == null) return false
+            runPostNodeStartup(project)
+            return true
+        }
+
+        /**
+         * The startup sequence that runs once the Node gate has passed: service
+         * initialization, sync activation, cold-start back-fill signals, and
+         * telemetry bootstrap/flush scheduling.
+         */
+        internal fun runPostNodeStartup(project: Project) {
+            val basePath = project.basePath ?: return
+
+            log.info("JolliMemory: initializing for project at $basePath")
+            val service = project.getService(JolliMemoryService::class.java)
+            service.initialize()
+
+            log.info("JolliMemory: activating sync for project at $basePath")
+            ai.jolli.jollimemory.sync.SyncActivation.activateSync(project, service)
+
+            // Cold-start back-fill signals (Kotlin analog of VS Code's computeColdStartSignals):
+            // decide whether to offer "build memory from your history" in the tool window. Runs
+            // on a pooled thread because it shells out to `jolli backfill --list-candidates`, so
+            // it never delays project startup; the tool window updates via a backfill listener.
+            com.intellij.openapi.application.ApplicationManager.getApplication().executeOnPooledThread {
+                try {
+                    service.computeColdStartSignals()
+                } catch (e: Exception) {
+                    log.warn("Cold-start signal compute failed (ignored): ${e.message}")
+                }
+            }
+
+            // Telemetry (JOLLI-1785): bootstrap anonymous, content-free usage
+            // telemetry, fire app_installed once per machine, flush anything buffered
+            // by prior sessions/hooks, and show the loud first-run notice once.
+            try {
+                val showNotice = ai.jolli.jollimemory.core.telemetry.TelemetryActivation.bootstrap(basePath)
+                // JOLLI-1963: count new + upgrade installs. Fires once per project open
+                // (a real session), carrying surface_version; first-seen (install_id,
+                // surface_version) ≈ new + upgrade installs. Emitted here (not in
+                // TelemetryActivation.bootstrap, which the git hooks also call) so hook
+                // runs don't flood it. No-op when telemetry is off.
+                ai.jolli.jollimemory.core.telemetry.Telemetry.track("client_activated")
+                ai.jolli.jollimemory.core.telemetry.TelemetryActivation.flushNow(basePath)
+                if (showNotice) {
+                    ai.jolli.jollimemory.core.telemetry.TelemetrySharedConfig.markNoticeShown()
+                    NotificationGroupManager.getInstance()
+                        .getNotificationGroup("JolliMemory")
+                        .createNotification(
+                            "Jolli Memory usage telemetry",
+                            "Anonymous, content-free usage telemetry (never code, paths, or memory content) is on to " +
+                                "improve the product. Turn it off any time with <code>jolli telemetry off</code>, the " +
+                                "<code>DO_NOT_TRACK</code> env var, or the IDE's data-sharing setting.",
+                            NotificationType.INFORMATION,
+                        )
+                        .addAction(NotificationAction.createSimple("Learn more") {
+                            BrowserUtil.browse("https://www.jolli.ai/telemetry")
+                        })
+                        .addAction(NotificationAction.createSimple("Turn off") {
+                            ai.jolli.jollimemory.core.telemetry.TelemetrySharedConfig.setTelemetry(false)
+                            ai.jolli.jollimemory.core.telemetry.Telemetry.shutdown()
+                        })
+                        .notify(project)
+                }
+            } catch (e: Exception) {
+                log.warn("Telemetry bootstrap failed (ignored): ${e.message}")
+            }
+
+            // JOLLI-1956: periodic telemetry flush, decoupled from the tool window's
+            // visibility. The Active Conversations 60s tick only flushes while that
+            // panel is showing, so a user who keeps the tool window closed would never
+            // drain the shared buffer. Schedule a background flush tied to the project
+            // lifecycle (cancelled on project close). Runs off the EDT — flushNow does
+            // blocking HTTP — and is best-effort (flushNow re-gates consent, never throws).
+            try {
+                val flushFuture =
+                    AppExecutorUtil.getAppScheduledExecutorService().scheduleWithFixedDelay(
+                        { ai.jolli.jollimemory.core.telemetry.TelemetryActivation.flushNow(basePath) },
+                        60L,
+                        60L,
+                        TimeUnit.SECONDS,
+                    )
+                Disposer.register(project, Disposable { flushFuture.cancel(false) })
+            } catch (e: Exception) {
+                log.warn("Telemetry flush scheduling failed (ignored): ${e.message}")
+            }
+
+            log.info("JolliMemory: startup complete for project at $basePath")
+        }
     }
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/JolliMemoryToolWindowFactory.kt
@@ -7,6 +7,7 @@ import ai.jolli.jollimemory.core.SessionTracker
 import ai.jolli.jollimemory.services.JolliApiClient
 import ai.jolli.jollimemory.services.JolliAuthService
 import ai.jolli.jollimemory.services.JolliMemoryService
+import ai.jolli.jollimemory.util.escapeHtml
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.DefaultActionGroup
@@ -16,6 +17,8 @@ import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vcs.ProjectLevelVcsManager
+import com.intellij.openapi.fileChooser.FileChooser
+import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.vcs.VcsListener
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
@@ -73,7 +76,158 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
             return
         }
 
-        createFullContent(project, toolWindow)
+        createGatedContent(project, toolWindow)
+    }
+
+    /**
+     * Node.js gate in front of the full UI. When a verified Node runtime is already
+     * known (in-process cache, non-blocking check — safe on the EDT) the full content
+     * is built; otherwise the blocking "Node.js required" panel is shown, which probes
+     * in the background and swaps in the full UI only once Node is found.
+     */
+    private fun createGatedContent(project: Project, toolWindow: ToolWindow) {
+        if (ai.jolli.jollimemory.bridge.NodeRuntime.cached() != null) {
+            createFullContent(project, toolWindow)
+        } else {
+            showNodeMissingContent(project, toolWindow)
+        }
+    }
+
+    /**
+     * Blocking panel shown while no verified Node.js runtime is known. Nothing else of
+     * the plugin UI is reachable behind it (and JolliMemoryService.initialize() is
+     * gated on the same check, so no plugin logic runs either).
+     *
+     * On construction it immediately re-probes in the background WITHOUT forcing, so a
+     * detection already running in the startup activity is shared, and a tool window
+     * that opened before that first probe finished self-heals into the full UI. The
+     * Retry button forces a fresh probe and, via
+     * [ai.jolli.jollimemory.services.JolliMemoryStartupActivity.retryNodeDetection],
+     * completes the startup sequence the gate skipped.
+     */
+    private fun showNodeMissingContent(project: Project, toolWindow: ToolWindow) {
+        val statusLabel = JBLabel("Checking for Node.js...")
+        val retryButton = javax.swing.JButton("Retry detection").apply { isEnabled = false }
+        val chooseButton = javax.swing.JButton("Choose manually...").apply { isEnabled = false }
+        val downloadButton = javax.swing.JButton("Download Node.js")
+
+        val messagePanel = JPanel(BorderLayout()).apply {
+            border = JBUI.Borders.empty(12)
+            val box = Box.createVerticalBox()
+            box.add(JBLabel(
+                "<html>" +
+                    "<b>Node.js is required</b><br/><br/>" +
+                    "Jolli Memory needs a Node.js runtime and is blocked until one is found.<br/>" +
+                    "Install Node.js 18 or newer (LTS recommended), then click <b>Retry detection</b> — " +
+                    "or point Jolli Memory at an existing binary with <b>Choose manually</b>." +
+                    "</html>",
+            ).apply { alignmentX = Component.LEFT_ALIGNMENT })
+            box.add(Box.createVerticalStrut(12))
+            box.add(statusLabel.apply { alignmentX = Component.LEFT_ALIGNMENT })
+            box.add(Box.createVerticalStrut(12))
+            box.add(JPanel(java.awt.FlowLayout(java.awt.FlowLayout.LEFT, 8, 0)).apply {
+                alignmentX = Component.LEFT_ALIGNMENT
+                isOpaque = false
+                add(retryButton)
+                add(chooseButton)
+                add(downloadButton)
+            })
+            add(box, BorderLayout.NORTH)
+        }
+        val content = ContentFactory.getInstance().createContent(messagePanel, "", false)
+        toolWindow.contentManager.addContent(content)
+
+        downloadButton.addActionListener {
+            com.intellij.ide.BrowserUtil.browse("https://nodejs.org/en/download")
+        }
+
+        fun setBusy(text: String) {
+            statusLabel.text = text
+            retryButton.isEnabled = false
+            chooseButton.isEnabled = false
+        }
+
+        fun setIdle(text: String) {
+            statusLabel.text = text
+            retryButton.isEnabled = true
+            chooseButton.isEnabled = true
+        }
+
+        val unblock = {
+            SwingUtilities.invokeLater {
+                toolWindow.contentManager.removeAllContents(true)
+                createFullContent(project, toolWindow)
+            }
+        }
+
+        val onProbeDone = { found: Boolean ->
+            if (found) {
+                unblock()
+            } else {
+                // If detection ran candidates and rejected every one only because they were too
+                // old, tell the user exactly that — with concrete versions and paths — instead
+                // of a bare "not found" which reads as a bug on a machine that clearly has Node.
+                val rejected = ai.jolli.jollimemory.bridge.NodeRuntime.rejectedFromLastDetection()
+                val msg = if (rejected.isEmpty()) {
+                    "No usable Node.js (18 or newer) was found on this machine."
+                } else {
+                    val items = rejected.joinToString("<br/>") { r ->
+                        "• <b>${escapeHtml(r.version)}</b> at ${escapeHtml(r.path)} — too old"
+                    }
+                    "<html>Node.js is installed but too old (need v18 or newer):<br/>$items</html>"
+                }
+                SwingUtilities.invokeLater { setIdle(msg) }
+            }
+        }
+
+        // Initial background probe (non-forced — shares a probe already running in the
+        // startup activity instead of repeating it).
+        com.intellij.openapi.application.ApplicationManager.getApplication().executeOnPooledThread {
+            onProbeDone(ai.jolli.jollimemory.bridge.NodeRuntime.detect() != null)
+        }
+
+        retryButton.addActionListener {
+            setBusy("Checking for Node.js...")
+            com.intellij.openapi.application.ApplicationManager.getApplication().executeOnPooledThread {
+                onProbeDone(
+                    ai.jolli.jollimemory.services.JolliMemoryStartupActivity.retryNodeDetection(project),
+                )
+            }
+        }
+
+        // Manual fallback for installs the automatic channels can't see (fully custom
+        // locations, exotic shells). The chooser only lets an actual node binary be
+        // picked, and the pick still goes through the same --version + minimum-version
+        // proof as automatic detection — a wrong file can never unblock the plugin.
+        chooseButton.addActionListener {
+            val descriptor = FileChooserDescriptor(true, false, false, false, false, false)
+                .withTitle("Select Node.js Executable")
+                .withDescription("Pick the node binary itself (node / node.exe), not a folder")
+                .withShowHiddenFiles(true) // node usually lives in dot-dirs (~/.nvm, ~/.volta)
+                .withFileFilter { ai.jolli.jollimemory.bridge.NodeRuntime.isNodeExecutableName(it.name) }
+            FileChooser.chooseFile(descriptor, project, null) { picked ->
+                setBusy("Verifying ${picked.name}...")
+                com.intellij.openapi.application.ApplicationManager.getApplication().executeOnPooledThread {
+                    val result = ai.jolli.jollimemory.bridge.NodeRuntime.adoptManualSelection(picked.path)
+                    if (result is ai.jolli.jollimemory.bridge.NodeRuntime.ManualSelectionResult.Accepted) {
+                        // Same pooled thread: complete the startup sequence the gate
+                        // skipped, then swap in the full UI.
+                        ai.jolli.jollimemory.services.JolliMemoryStartupActivity.runPostNodeStartup(project)
+                        unblock()
+                    } else {
+                        val message = when (result) {
+                            is ai.jolli.jollimemory.bridge.NodeRuntime.ManualSelectionResult.TooOld ->
+                                "That Node.js is ${result.version} — version 18 or newer is required."
+                            is ai.jolli.jollimemory.bridge.NodeRuntime.ManualSelectionResult.NotNode ->
+                                "The selected file did not answer node --version — pick the actual Node.js binary."
+                            else ->
+                                "The selected file is not an executable."
+                        }
+                        SwingUtilities.invokeLater { setIdle(message) }
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -98,7 +252,7 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
         val content = ContentFactory.getInstance().createContent(messagePanel, "", false)
         toolWindow.contentManager.addContent(content)
 
-        // Listen for VCS changes — when .git appears, rebuild with full UI
+        // Listen for VCS changes — when .git appears, rebuild (behind the Node gate)
         val connection = project.messageBus.connect()
         connection.subscribe(
             ProjectLevelVcsManager.VCS_CONFIGURATION_CHANGED,
@@ -107,7 +261,7 @@ class JolliMemoryToolWindowFactory : ToolWindowFactory, DumbAware {
                     connection.disconnect()
                     SwingUtilities.invokeLater {
                         toolWindow.contentManager.removeAllContents(true)
-                        createFullContent(project, toolWindow)
+                        createGatedContent(project, toolWindow)
                     }
                 }
             },

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/util/HtmlEscape.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/util/HtmlEscape.kt
@@ -1,0 +1,16 @@
+package ai.jolli.jollimemory.util
+
+/**
+ * Minimal HTML escape for user-supplied text embedded in JBLabel HTML content or
+ * IntelliJ Notification body (paths and version strings from
+ * [ai.jolli.jollimemory.bridge.RejectedCandidate], status messages, etc.). Only
+ * the four characters that can break out of text context are escaped — enough
+ * for the non-strict HTML renderer used in both places. Kept as a single shared
+ * helper so the tool window's "Node.js required" panel and the startup error
+ * notification cannot drift out of sync on their escape rules.
+ */
+internal fun escapeHtml(text: String): String =
+	text.replace("&", "&amp;")
+		.replace("<", "&lt;")
+		.replace(">", "&gt;")
+		.replace("\"", "&quot;")

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/NodeRuntimeTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/NodeRuntimeTest.kt
@@ -1,0 +1,246 @@
+package ai.jolli.jollimemory.bridge
+
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.api.parallel.Isolated
+import java.io.File
+
+/**
+ * Tests for the pure/deterministic parts of [NodeRuntime]: shell-output PATH
+ * extraction, version parsing/sorting, and the node-info.json record round-trip.
+ * The live probes (shell spawning, binary verification) depend on the host
+ * environment and are exercised implicitly by the callers' graceful-degradation
+ * tests (see CliIntegrationsTest).
+ *
+ * `@Isolated`: NodeRuntime is a process-wide singleton (cachedInfo /
+ * detectionDone / rejectedList / env). This suite's @AfterEach calls
+ * `resetForTest()` to null those fields, which would race any concurrent
+ * test class that indirectly reaches NodeRuntime.detect() (e.g. via
+ * `CliIntegrations.resolveNode()`). Running this class alone against the
+ * rest of the suite is the least-invasive fix until the singleton is
+ * refactored behind an injected instance.
+ */
+@Isolated
+class NodeRuntimeTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    @AfterEach
+    fun resetSingletonState() {
+        // adoptManualSelection mutates the NodeRuntime singleton's in-process cache;
+        // clear it so other tests in this JVM see a fresh detector.
+        NodeRuntime.resetForTest()
+    }
+
+    private val isWindows = System.getProperty("os.name").lowercase().contains("win")
+
+    /** Writes an executable fake `node` script that prints [version] for --version. */
+    private fun fakeNode(version: String): File {
+        val script = File(tempDir, "node")
+        script.writeText("#!/bin/sh\necho $version\n")
+        script.setExecutable(true)
+        return script
+    }
+
+    // ── extractMarkedPath — sentinel extraction survives rc-file noise ──────
+
+    @Test
+    fun `extractMarkedPath returns the marked PATH`() {
+        NodeRuntime.extractMarkedPath("__JOLLI_PATH_START__/usr/bin:/bin__JOLLI_PATH_END__") shouldBe
+            "/usr/bin:/bin"
+    }
+
+    @Test
+    fun `extractMarkedPath ignores rc-file noise around the markers`() {
+        val out = "Welcome banner\nnvm warning: something\n" +
+            "__JOLLI_PATH_START__/opt/homebrew/bin:/usr/bin__JOLLI_PATH_END__\ntrailing prompt"
+        NodeRuntime.extractMarkedPath(out) shouldBe "/opt/homebrew/bin:/usr/bin"
+    }
+
+    @Test
+    fun `extractMarkedPath uses the LAST start marker (rc file echoed the command)`() {
+        val out = "echo __JOLLI_PATH_START__ noise\n" +
+            "__JOLLI_PATH_START__/real/path__JOLLI_PATH_END__"
+        NodeRuntime.extractMarkedPath(out) shouldBe "/real/path"
+    }
+
+    @Test
+    fun `extractMarkedPath is null when markers are missing or empty`() {
+        NodeRuntime.extractMarkedPath("no markers at all").shouldBeNull()
+        NodeRuntime.extractMarkedPath("__JOLLI_PATH_START__/no/end/marker").shouldBeNull()
+        NodeRuntime.extractMarkedPath("__JOLLI_PATH_START____JOLLI_PATH_END__").shouldBeNull()
+    }
+
+    // ── parseVersionOutput — `node --version` output shapes ────────────────
+
+    @Test
+    fun `parseVersionOutput reads a plain version line`() {
+        NodeRuntime.parseVersionOutput("v22.14.0\n") shouldBe "v22.14.0"
+    }
+
+    @Test
+    fun `parseVersionOutput ignores surrounding noise lines`() {
+        NodeRuntime.parseVersionOutput("some warning\nv18.19.1\n") shouldBe "v18.19.1"
+    }
+
+    @Test
+    fun `parseVersionOutput is null for non-version output`() {
+        NodeRuntime.parseVersionOutput("command not found").shouldBeNull()
+        NodeRuntime.parseVersionOutput("").shouldBeNull()
+    }
+
+    // ── versionMajor — minimum-version gate input ───────────────────────────
+
+    @Test
+    fun `versionMajor parses the major component`() {
+        NodeRuntime.versionMajor("v22.14.0") shouldBe 22
+        NodeRuntime.versionMajor("v8.17.0") shouldBe 8
+        NodeRuntime.versionMajor("v18.0.0-nightly") shouldBe 18
+    }
+
+    @Test
+    fun `versionMajor is null for unparseable input`() {
+        NodeRuntime.versionMajor("garbage").shouldBeNull()
+        NodeRuntime.versionMajor("22.14.0").shouldBeNull()
+        NodeRuntime.versionMajor("").shouldBeNull()
+    }
+
+    // ── parseRegInstallPath — Windows MSI registry record ───────────────────
+
+    @Test
+    fun `parseRegInstallPath reads the InstallPath value from reg query output`() {
+        val out = "\r\nHKEY_LOCAL_MACHINE\\SOFTWARE\\Node.js\r\n" +
+            "    InstallPath    REG_SZ    C:\\Program Files\\nodejs\\\r\n\r\n"
+        NodeRuntime.parseRegInstallPath(out) shouldBe "C:\\Program Files\\nodejs\\"
+    }
+
+    @Test
+    fun `parseRegInstallPath handles REG_EXPAND_SZ and is null when absent`() {
+        val expand = "    InstallPath    REG_EXPAND_SZ    D:\\tools\\node\r\n"
+        NodeRuntime.parseRegInstallPath(expand) shouldBe "D:\\tools\\node"
+        NodeRuntime.parseRegInstallPath("ERROR: The system was unable to find the specified registry key.")
+            .shouldBeNull()
+    }
+
+    // ── versionSortKey — newest-first ordering of version-manager dirs ─────
+
+    @Test
+    fun `versionSortKey orders semver directory names numerically`() {
+        val sorted = listOf("v8.17.0", "v22.14.0", "v10.24.1", "v22.9.0")
+            .sortedByDescending { NodeRuntime.versionSortKey(it) }
+        sorted shouldBe listOf("v22.14.0", "v22.9.0", "v10.24.1", "v8.17.0")
+    }
+
+    @Test
+    fun `versionSortKey sorts unparseable names last`() {
+        val sorted = listOf("alias", "v20.1.0").sortedByDescending { NodeRuntime.versionSortKey(it) }
+        sorted shouldBe listOf("v20.1.0", "alias")
+    }
+
+    @Test
+    fun `versionSortKey accepts unprefixed version names (mise layout)`() {
+        val sorted = listOf("20.11.1", "22.14.0").sortedByDescending { NodeRuntime.versionSortKey(it) }
+        sorted shouldBe listOf("22.14.0", "20.11.1")
+    }
+
+    // ── node-info.json record round-trip ────────────────────────────────────
+
+    @Test
+    fun `write then read round-trips path and version`() {
+        val file = File(tempDir, "node-info.json")
+        val info = NodeInfo("/opt/homebrew/bin/node", "v22.14.0")
+        NodeRuntime.writeRecordedInfo(file, info)
+        NodeRuntime.readRecordedInfo(file) shouldBe info
+    }
+
+    @Test
+    fun `write creates missing parent directories`() {
+        val file = File(tempDir, "nested/dir/node-info.json")
+        NodeRuntime.writeRecordedInfo(file, NodeInfo("/usr/local/bin/node", "v20.11.0"))
+        NodeRuntime.readRecordedInfo(file) shouldBe NodeInfo("/usr/local/bin/node", "v20.11.0")
+    }
+
+    @Test
+    fun `read is null for a missing file`() {
+        NodeRuntime.readRecordedInfo(File(tempDir, "absent.json")).shouldBeNull()
+    }
+
+    // ── isNodeExecutableName — the chooser-side filename filter ─────────────
+
+    @Test
+    fun `isNodeExecutableName accepts only node binaries (case-insensitive)`() {
+        NodeRuntime.isNodeExecutableName("node") shouldBe true
+        NodeRuntime.isNodeExecutableName("node.exe") shouldBe true
+        NodeRuntime.isNodeExecutableName("Node.EXE") shouldBe true
+        NodeRuntime.isNodeExecutableName("node.cmd") shouldBe true
+        NodeRuntime.isNodeExecutableName("nodemon") shouldBe false
+        NodeRuntime.isNodeExecutableName("node.txt") shouldBe false
+        NodeRuntime.isNodeExecutableName("npm") shouldBe false
+    }
+
+    // ── adoptManualSelection — user-picked binaries get the same proof ──────
+
+    @Test
+    fun `adoptManualSelection rejects a missing or non-executable pick`() {
+        val record = File(tempDir, "record.json")
+        NodeRuntime.adoptManualSelection(File(tempDir, "absent").absolutePath, record)
+            .shouldBeInstanceOf<NodeRuntime.ManualSelectionResult.NotExecutable>()
+        record.exists() shouldBe false
+    }
+
+    @Test
+    fun `adoptManualSelection rejects a file that is not node`() {
+        Assumptions.assumeTrue(!isWindows) // fake executable is a POSIX shell script
+        val notNode = File(tempDir, "node").apply {
+            writeText("#!/bin/sh\necho command not found\nexit 1\n")
+            setExecutable(true)
+        }
+        val record = File(tempDir, "record.json")
+        NodeRuntime.adoptManualSelection(notNode.absolutePath, record)
+            .shouldBeInstanceOf<NodeRuntime.ManualSelectionResult.NotNode>()
+        record.exists() shouldBe false
+    }
+
+    @Test
+    fun `adoptManualSelection rejects a node below the minimum version`() {
+        Assumptions.assumeTrue(!isWindows)
+        val record = File(tempDir, "record.json")
+        val result = NodeRuntime.adoptManualSelection(fakeNode("v12.22.0").absolutePath, record)
+        result.shouldBeInstanceOf<NodeRuntime.ManualSelectionResult.TooOld>()
+        result.version shouldBe "v12.22.0"
+        record.exists() shouldBe false
+    }
+
+    @Test
+    fun `adoptManualSelection accepts a usable pick and records it as manual`() {
+        Assumptions.assumeTrue(!isWindows)
+        val record = File(tempDir, "record.json")
+        val bin = fakeNode("v22.14.0")
+        val result = NodeRuntime.adoptManualSelection(bin.absolutePath, record)
+        result.shouldBeInstanceOf<NodeRuntime.ManualSelectionResult.Accepted>()
+        result.info shouldBe NodeInfo(bin.absolutePath, "v22.14.0")
+        // Persisted, tagged as a manual pick, and now the in-process detection result.
+        NodeRuntime.readRecordedInfo(record) shouldBe result.info
+        record.readText() shouldContain "\"source\":\"manual\""
+        NodeRuntime.cached() shouldBe result.info
+    }
+
+    @Test
+    fun `read is null for corrupt or incomplete records`() {
+        val corrupt = File(tempDir, "corrupt.json").apply { writeText("not json at all") }
+        NodeRuntime.readRecordedInfo(corrupt).shouldBeNull()
+
+        val missingVersion = File(tempDir, "partial.json").apply { writeText("""{"path":"/usr/bin/node"}""") }
+        NodeRuntime.readRecordedInfo(missingVersion).shouldBeNull()
+
+        val blankPath = File(tempDir, "blank.json").apply { writeText("""{"path":"","version":"v20.0.0"}""") }
+        NodeRuntime.readRecordedInfo(blankPath).shouldBeNull()
+    }
+}


### PR DESCRIPTION
Detect and verify a usable Node.js runtime (>= v18) before the plugin's startup activity runs. Detection walks the IDE PATH, login and interactive shell PATH, the Windows MSI registry record, and well-known install locations, and proves each candidate by actually executing --version. The verified result is persisted to
~/.jolli/jollimemory/node-info.json.

The tool window shows a blocking "Node.js required" panel with Retry and Choose manually... buttons; the manual pick applies the same --version + minimum-version proof and cannot be used to bypass the minimum version.

When automatic detection rejects candidates only because they are too old, surface those installs to the blocking panel and startup error notification with the concrete version and path, so the user sees "v14.21.3 at /opt/homebrew/bin/node - too old" instead of a generic "no Node found" that reads as a bug on a machine that clearly has Node.

## Summary

<!-- What does this PR do? Keep it to 1-3 sentences. -->

## Motivation

<!-- Why is this change needed? Link to any related issue with #123. -->

## Testing

<!-- How did you verify this works? -->
- [ ] Added/updated unit tests
- [ ] Ran `./gradlew test` locally
- [ ] Tested in sandbox IDE via `./gradlew runIde`
- [ ] Tested on: (e.g. macOS + IntelliJ 2025.1)

## Screenshots / Recordings

<!-- For UI changes, attach before/after screenshots. Delete section if not applicable. -->

## Checklist

- [ ] Code follows the existing style
- [ ] Documentation updated (README / CHANGELOG) if user-facing
- [ ] No new warnings from Plugin Verifier
