### PR TITLE
fix(mcp): no-op startMcpServer for local-agent child processes

### DIFF
--- a/cli/src/mcp/McpServer.test.ts
+++ b/cli/src/mcp/McpServer.test.ts
@@ -357,6 +357,26 @@ describe("startMcpServer", () => {
 		await startMcpServer("/repo");
 		expect(serverInfo).toMatchObject({ name: "jollimemory", version: VERSION });
 	});
+
+	it("no-ops entirely when running as a local-agent child (JOLLI-2033)", async () => {
+		// The local-agent backend spawns `claude` in a throwaway temp cwd marked
+		// JOLLI_LOCAL_AGENT_CHILD=1; a globally-installed jolli plugin then spawns
+		// `jolli mcp` there. Without this guard, createStorage roots a FolderStorage
+		// at <localFolder>/<tempDirName>/, claiming a spurious Memory Bank "repo" per
+		// summary call. The child denies all tools, so no MCP tool is ever invoked —
+		// the whole server must no-op, mirroring the SessionStart/Stop/enable guards.
+		vi.mocked(createStorage).mockClear();
+		vi.mocked(setActiveStorage).mockClear();
+		process.env.JOLLI_LOCAL_AGENT_CHILD = "1";
+		try {
+			await startMcpServer("/tmp/jolli-localagent-abc123");
+		} finally {
+			delete process.env.JOLLI_LOCAL_AGENT_CHILD;
+		}
+		expect(createStorage).not.toHaveBeenCalled();
+		expect(setActiveStorage).not.toHaveBeenCalled();
+		expect(connectMock).not.toHaveBeenCalled();
+	});
 });
 
 describe("startMcpServer — platform tools", () => {

--- a/cli/src/mcp/McpServer.ts
+++ b/cli/src/mcp/McpServer.ts
@@ -14,6 +14,7 @@ import {
 	type Prompt,
 } from "@modelcontextprotocol/sdk/types.js";
 import { VERSION } from "../commands/CliUtils.js";
+import { isLocalAgentChild } from "../core/AgentReentry.js";
 import { JolliMemoryPushClient, type PlatformToolManifestEntry } from "../core/JolliMemoryPushClient.js";
 import { loadConfig } from "../core/SessionTracker.js";
 import { createStorage } from "../core/StorageFactory.js";
@@ -219,6 +220,20 @@ export interface StartMcpServerDeps {
 
 /** Start the stdio MCP server. Resolves when the transport closes. */
 export async function startMcpServer(cwd: string, deps: StartMcpServerDeps = {}): Promise<void> {
+	// Re-entrancy guard (JOLLI-2033): the local-agent backend spawns `claude` in a
+	// throwaway temp cwd marked JOLLI_LOCAL_AGENT_CHILD=1. When the jolli plugin is
+	// globally installed, that nested `claude` spawns `jolli mcp` here — inheriting
+	// the marker. Without this no-op, the storage init below roots a FolderStorage
+	// at <localFolder>/<tempDirName>/, claiming a spurious Memory Bank "repo" per
+	// summary call (the temp dir basename becomes the repoName). The child runs
+	// `--tools ""` (all tools denied) so it never invokes an MCP tool; no-op the
+	// whole server. Mirrors the SessionStartHook/StopHook/EnableCommand guards and
+	// honors the "MCP storage init no-ops" contract stated in AgentReentry.
+	if (isLocalAgentChild()) {
+		log.info("Local-agent child detected; skipping MCP server startup to avoid a spurious Memory Bank repo");
+		return;
+	}
+
 	// Establish the configured storage backend up front. The tool handlers read
 	// through the store APIs without threading `storage`, so without this they'd
 	// fall through resolveStorage to the orphan branch — wrong for folder-mode


### PR DESCRIPTION
## Problem

Running the local-agent LLM provider left a growing pile of junk "repos" in the Memory Bank folder / VS Code sidebar — `jolli-localagent-<random>` (one per summary call), plus `tmp` and `unknown`. Each held only empty scaffolding (`.jolli/config.json`, `branches.json`, empty `manifest.json`), no actual memory.

## Root cause

The local-agent backend (`ClaudeCodeBackend.buildInvocation`) spawns `claude` in a throwaway `mkdtemp` cwd named `jolli-localagent-XXXXXX`, marking the child with `JOLLI_LOCAL_AGENT_CHILD=1`. The re-entrancy guard (`isLocalAgentChild()`) was checked in `SessionStartHook`, `StopHook`, and `EnableCommand` — but **not** in the MCP server.

With the jolli plugin installed globally, the nested `claude` spawns `jolli mcp` in that temp cwd. `startMcpServer` called `setActiveStorage(await createStorage(cwd, cwd))` unconditionally → in dual-write mode `createFolderStorage` resolved `extractRepoName(tempCwd)` to the temp dir basename → `MetadataManager.ensure()` wrote a spurious Memory Bank repo at `<localFolder>/jolli-localagent-XXXXXX/`.

This violated the contract already documented in `AgentReentry.ts` and `ClaudeCodeBackend.ts`, both of which list "MCP storage init" as a path that no-ops for local-agent children.

## Fix

Early-return from `startMcpServer` when `isLocalAgentChild()` is true, mirroring the three existing guarded entry points. Safe because local-agent children run `--tools ""` (all tools denied) and never invoke an MCP tool, so the whole server can no-op.

## Testing

- New regression test `no-ops entirely when running as a local-agent child` (RED before the guard, GREEN after).
- Full CLI suite green; coverage 99.35% stmts / 97.58% branches / 99.47% funcs / 99.56% lines (above the 97/96/97/97 floor). `typecheck:cli` clean.
