### PR TITLE
Support discovering sessions in project subdirectories

### DIFF
--- a/cli/src/core/AntigravitySessionDiscoverer.test.ts
+++ b/cli/src/core/AntigravitySessionDiscoverer.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, realpathSync, utimesSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -124,6 +124,37 @@ sqliteOnly("AntigravitySessionDiscoverer", () => {
 		// ...discovered while running from the sibling WORKTREE.
 		const sessions = await discoverAntigravitySessions(wt, home);
 		expect(sessions.map((s) => s.sessionId)).toEqual(["cross-wt"]);
+	});
+
+	// JOLLI-2015: a conversation recorded in a subdirectory of the project (the IDE
+	// opened on a subpackage, or a CLI variant run from `cd packages/foo`) IS
+	// attributed to the repo via prefix/containment matching — shared with the other
+	// hookless sources.
+	it("discovers a conversation recorded in a subdirectory of the project (prefix match)", async () => {
+		const home = freshDir("agy-home-");
+		const ws = freshDir("repo-");
+		createAntigravityConvo(home, {
+			convId: "in-subdir",
+			workspacePath: join(ws, "packages", "foo"),
+			transcriptLines: REAL_TRANSCRIPT_FULL,
+		});
+		const sessions = await discoverAntigravitySessions(ws, home);
+		expect(sessions.map((s) => s.sessionId)).toEqual(["in-subdir"]);
+	});
+
+	// A conversation living in a NESTED git repo / submodule inside the worktree
+	// belongs to the inner repo, not this one — an intervening `.git` excludes it.
+	it("skips a conversation inside a nested git repo under the project", async () => {
+		const home = freshDir("agy-home-");
+		const ws = realpathSync(freshDir("repo-"));
+		const nested = join(ws, "vendor", "lib");
+		mkdirSync(join(nested, ".git"), { recursive: true });
+		createAntigravityConvo(home, {
+			convId: "nested",
+			workspacePath: nested,
+			transcriptLines: REAL_TRANSCRIPT_FULL,
+		});
+		expect(await discoverAntigravitySessions(ws, home)).toHaveLength(0);
 	});
 
 	it("de-duplicates a conversation present under multiple variants, keeping the newest", async () => {

--- a/cli/src/core/AntigravitySessionDiscoverer.ts
+++ b/cli/src/core/AntigravitySessionDiscoverer.ts
@@ -23,7 +23,7 @@ import type { SessionInfo } from "../Types.js";
 import { getAntigravityVariants } from "./AntigravityDetector.js";
 import { unwrapUserRequest } from "./AntigravityTranscriptReader.js";
 import { listWorktrees } from "./GitOps.js";
-import { normalizePathForCompare } from "./PathUtils.js";
+import { sessionDirBelongsToRepo } from "./SessionDirMatch.js";
 import { classifyScanError, hasNodeSqliteSupport, type SqliteScanError, withSqliteDb } from "./SqliteHelpers.js";
 
 const log = createLogger("AntigravityDiscoverer");
@@ -123,19 +123,22 @@ async function readTitle(transcriptPath: string): Promise<string | undefined> {
 }
 
 /**
- * Resolves the normalized set of worktree roots for the repo containing
- * `projectDir`. Antigravity records the checkout the IDE was opened in, which is
- * frequently a *different* worktree than the one committing (e.g. the IDE sits
- * on the main checkout while commits happen from a linked feature worktree), so
- * a plain `workspacePath === projectDir` match drops the conversation. Matching
- * against every worktree root attributes the conversation to the same repo
- * regardless of which worktree runs the hook. Falls back to exact-match on
- * `projectDir` when git is unavailable or the dir is not inside a repo.
+ * Resolves the set of worktree roots (raw, unnormalized paths) for the repo
+ * containing `projectDir`. Antigravity records the checkout the IDE was opened
+ * in, which is frequently a *different* worktree than the one committing (e.g.
+ * the IDE sits on the main checkout while commits happen from a linked feature
+ * worktree), so matching against every worktree root attributes the conversation
+ * to the same repo regardless of which worktree runs the hook. Falls back to
+ * just `projectDir` when git is unavailable or the dir is not inside a repo.
+ *
+ * Paths are kept raw (not `normalizePathForCompare`d) because the caller feeds
+ * them to `sessionDirBelongsToRepo`, whose nested-repo `.git` walk needs the
+ * real on-disk path; that helper does the separator/case folding itself.
  */
 async function resolveWorktreeRoots(projectDir: string): Promise<ReadonlySet<string>> {
-	const roots = new Set<string>([normalizePathForCompare(projectDir)]);
+	const roots = new Set<string>([projectDir]);
 	try {
-		for (const wt of await listWorktrees(projectDir)) roots.add(normalizePathForCompare(wt));
+		for (const wt of await listWorktrees(projectDir)) roots.add(wt);
 	} catch (err) {
 		log.debug("listWorktrees failed for %s (falling back to exact match): %s", projectDir, errMsg(err));
 	}
@@ -207,7 +210,12 @@ export async function scanAntigravitySessions(projectDir: string, home?: string)
 				continue;
 			}
 
-			if (!workspacePath || !worktreeRoots.has(normalizePathForCompare(workspacePath))) continue;
+			// Prefix/containment match (shared `sessionDirBelongsToRepo`, like the
+			// other hookless sources): a workspace recorded in a *subdirectory* of a
+			// worktree still belongs to the repo (JOLLI-2015), while a nested git
+			// repo / submodule inside it is excluded via the helper's `.git` walk.
+			if (!workspacePath || ![...worktreeRoots].some((root) => sessionDirBelongsToRepo(workspacePath, root)))
+				continue;
 
 			const transcriptPath = join(variant.brainDir, convId, ...TRANSCRIPT_RELPATH);
 			if (!existsSync(transcriptPath)) {

--- a/cli/src/core/CodexSessionDiscoverer.test.ts
+++ b/cli/src/core/CodexSessionDiscoverer.test.ts
@@ -31,6 +31,14 @@ vi.mock("node:os", async (importOriginal) => {
 	return { ...original, homedir: () => mockHomeDir(), platform: () => mockPlatform() };
 });
 
+// The cwd match now runs through `normalizePathForCompare`, which reads
+// `process.platform` directly (not os.platform()). Override it per-test so the
+// case-sensitivity branch is deterministic regardless of host OS; restore in afterEach.
+const savedPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+function setPlatform(os: NodeJS.Platform): void {
+	Object.defineProperty(process, "platform", { value: os, configurable: true });
+}
+
 import { discoverCodexSessions, isCodexInstalled } from "./CodexSessionDiscoverer.js";
 
 let tempDir: string;
@@ -43,6 +51,8 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+	/* v8 ignore next -- the platform descriptor is always present on supported runtimes */
+	if (savedPlatform) Object.defineProperty(process, "platform", savedPlatform);
 	await rm(tempDir, { recursive: true, force: true });
 });
 
@@ -98,6 +108,45 @@ describe("discoverCodexSessions", () => {
 
 		const sessions = await discoverCodexSessions("/my/project");
 		expect(sessions).toHaveLength(0);
+	});
+
+	// JOLLI-2015: a session run from a subdirectory of the project (common in a
+	// monorepo, `cd packages/foo && codex`) IS attributed to the repo via
+	// prefix/containment matching — semantics shared with Devin/OpenCode/Copilot.
+	it("discovers a session run in a subdirectory of the project (prefix match)", async () => {
+		const now = new Date();
+		const year = String(now.getFullYear());
+		const month = String(now.getMonth() + 1).padStart(2, "0");
+		const day = String(now.getDate()).padStart(2, "0");
+		const dayDir = join(tempDir, ".codex", "sessions", year, month, day);
+
+		await createCodexSession(dayDir, "rollout-sub.jsonl", "/my/project/packages/foo", "sess-sub");
+
+		const sessions = await discoverCodexSessions("/my/project");
+		expect(sessions.map((s) => s.sessionId)).toEqual(["sess-sub"]);
+	});
+
+	// A session living in a NESTED git repo / submodule inside the worktree belongs
+	// to the inner repo's own post-commit, not this one — an intervening `.git`
+	// excludes it. Uses a real temp dir so `.git` can exist on disk.
+	it("does NOT discover a session inside a nested git repo under the project", async () => {
+		const now = new Date();
+		const year = String(now.getFullYear());
+		const month = String(now.getMonth() + 1).padStart(2, "0");
+		const day = String(now.getDate()).padStart(2, "0");
+		const dayDir = join(tempDir, ".codex", "sessions", year, month, day);
+
+		const realRepo = await mkdtemp(join(realTmpdir(), "codex-nested-"));
+		try {
+			const nested = join(realRepo, "vendor", "lib");
+			await mkdir(join(nested, ".git"), { recursive: true });
+			await createCodexSession(dayDir, "rollout-nested.jsonl", nested, "sess-nested");
+
+			const sessions = await discoverCodexSessions(realRepo);
+			expect(sessions).toHaveLength(0);
+		} finally {
+			await rm(realRepo, { recursive: true, force: true });
+		}
 	});
 
 	it("returns empty array when sessions directory does not exist", async () => {
@@ -346,7 +395,7 @@ describe("discoverCodexSessions", () => {
 
 describe("Windows path case-insensitive matching", () => {
 	it("matches cwd with different drive letter case on Windows", async () => {
-		mockPlatform.mockReturnValue("win32");
+		setPlatform("win32");
 
 		const now = new Date();
 		const year = String(now.getFullYear());
@@ -365,7 +414,7 @@ describe("Windows path case-insensitive matching", () => {
 	});
 
 	it("does not match different paths case-insensitively on non-Windows", async () => {
-		mockPlatform.mockReturnValue("linux");
+		setPlatform("linux");
 
 		const now = new Date();
 		const year = String(now.getFullYear());

--- a/cli/src/core/CodexSessionDiscoverer.ts
+++ b/cli/src/core/CodexSessionDiscoverer.ts
@@ -13,7 +13,8 @@
  * Algorithm:
  *   1. Scan ~/.codex/sessions/YYYY/MM/DD/ for recent JSONL files
  *   2. Read only line 1 of each file (session_meta) to extract cwd
- *   3. Match cwd against the current project directory
+ *   3. Match cwd against the project dir via sessionDirBelongsToRepo (prefix/
+ *      containment + nested-repo exclusion, shared with Devin/OpenCode/Copilot)
  *   4. Also scan ~/.codex/archived_sessions/ for recently archived sessions
  *   5. Return matching sessions as SessionInfo[] with source="codex"
  *
@@ -23,11 +24,12 @@
 
 import { createReadStream } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
-import { homedir, platform } from "node:os";
+import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { createLogger } from "../Logger.js";
 import type { SessionInfo } from "../Types.js";
+import { sessionDirBelongsToRepo } from "./SessionDirMatch.js";
 
 const log = createLogger("CodexDiscoverer");
 
@@ -207,14 +209,13 @@ async function tryParseSessionMeta(filePath: string, resolvedProject: string): P
 			return null;
 		}
 
-		// Match cwd against the project directory
-		// On Windows, drive letter case may differ (e.g. Codex stores "e:\foo" vs "E:\foo")
-		const resolvedCwd = resolve(cwd);
-		const cwdMatch =
-			platform() === "win32"
-				? resolvedCwd.toLowerCase() === resolvedProject.toLowerCase()
-				: resolvedCwd === resolvedProject;
-		if (!cwdMatch) {
+		// Match cwd against the project directory via `sessionDirBelongsToRepo`
+		// (shared with Devin/OpenCode/Copilot): prefix/containment with separator +
+		// case folding (handling the Windows "e:\foo" vs "E:\foo" drive-letter drift)
+		// plus the nested-repo exclusion. It replaced the exact `resolvedCwd ===
+		// resolvedProject` match, which silently dropped every session run from a
+		// subdirectory of the repo (JOLLI-2015).
+		if (!sessionDirBelongsToRepo(resolve(cwd), resolvedProject)) {
 			return null;
 		}
 

--- a/cli/src/core/CopilotSessionDiscoverer.test.ts
+++ b/cli/src/core/CopilotSessionDiscoverer.test.ts
@@ -35,7 +35,9 @@ const SCHEMA_STATEMENTS = [
 
 interface SeedSession {
 	id: string;
-	cwd: string;
+	// `null` seeds a SQL NULL cwd — Copilot CLI stores this for sessions started
+	// outside any project (see the null-cwd regression test below).
+	cwd: string | null;
 	updated_at: string;
 	// Optional override for the sessions.summary column. `undefined` (default)
 	// inserts SQL NULL — matches the historical fixture shape so existing tests
@@ -95,14 +97,43 @@ describe("scanCopilotSessions", () => {
 		expect(sessions[0].transcriptPath).toMatch(/session-store\.db#a$/);
 	});
 
-	it("returns multiple matching sessions ordered by updated_at DESC", async () => {
+	// JOLLI-2015: a session run from a subdirectory of the project (common in a
+	// monorepo, `cd packages/foo && copilot`) IS attributed to the repo via
+	// prefix/containment matching — semantics shared with Devin/OpenCode.
+	it("returns a session run in a subdirectory of the project (prefix match)", async () => {
+		await withFixture([
+			{ id: "sub", cwd: platformPath("/Users/x/project/packages/foo"), updated_at: isoFromNow() },
+		]);
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions } = await scanCopilotSessions(platformPath("/Users/x/project"));
+		expect(sessions.map((s) => s.sessionId)).toEqual(["sub"]);
+	});
+
+	// A session living in a NESTED git repo / submodule inside the worktree belongs
+	// to the inner repo's own post-commit, not this one — an intervening `.git`
+	// excludes it. Uses a real temp dir so `.git` can exist on disk.
+	it("does NOT return a session inside a nested git repo under the project", async () => {
+		const { mkdir } = await import("node:fs/promises");
+		const realRepo = await mkdtemp(join(tmpdir(), "copilot-nested-"));
+		cleanups.push(() => rm(realRepo, { recursive: true, force: true }));
+		const nested = join(realRepo, "vendor", "lib");
+		await mkdir(join(nested, ".git"), { recursive: true });
+		await withFixture([{ id: "nested", cwd: resolve(nested), updated_at: isoFromNow() }]);
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions } = await scanCopilotSessions(resolve(realRepo));
+		expect(sessions).toEqual([]);
+	});
+
+	it("returns every matching session (order is not part of the contract)", async () => {
+		// The query has no ORDER BY — all rows passing the directory + staleness filters
+		// are kept regardless of order — so assert on set membership, not order.
 		await withFixture([
 			{ id: "older", cwd: platformPath("/p"), updated_at: isoFromNow(2_000) },
 			{ id: "newer", cwd: platformPath("/p"), updated_at: isoFromNow(1_000) },
 		]);
 		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
 		const { sessions } = await scanCopilotSessions(platformPath("/p"));
-		expect(sessions.map((s) => s.sessionId)).toEqual(["newer", "older"]);
+		expect(sessions.map((s) => s.sessionId).sort()).toEqual(["newer", "older"]);
 	});
 
 	it("normalizes trailing slashes on the projectDir", async () => {
@@ -168,6 +199,23 @@ describe("scanCopilotSessions", () => {
 		const { sessions, error } = await scanCopilotSessions(platformPath("/Users/x/project"));
 		expect(sessions).toEqual([]);
 		expect(error?.kind).toBe("corrupt");
+	});
+
+	// Regression: Copilot CLI stores cwd = NULL for a session started outside any
+	// project. The scan maps `sessionDirBelongsToRepo` over every row in one
+	// flatMap, so a null-cwd row must be skipped rather than throwing — otherwise
+	// that single poison row aborts the whole scan and drops every session (the
+	// "Copilot capture stopped working" bug: one null row → source flagged
+	// unavailable, zero sessions summarized).
+	it("skips a null-cwd row without poisoning the rest of the scan", async () => {
+		await withFixture([
+			{ id: "null-cwd", cwd: null, updated_at: isoFromNow(1_000) },
+			{ id: "good", cwd: platformPath("/p"), updated_at: isoFromNow(2_000) },
+		]);
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+		const { sessions, error } = await scanCopilotSessions(platformPath("/p"));
+		expect(error).toBeUndefined();
+		expect(sessions.map((s) => s.sessionId)).toEqual(["good"]);
 	});
 
 	it("skips a row whose updated_at is non-finite", async () => {

--- a/cli/src/core/CopilotSessionDiscoverer.ts
+++ b/cli/src/core/CopilotSessionDiscoverer.ts
@@ -2,7 +2,9 @@
  * GitHub Copilot CLI session discoverer.
  *
  * Copilot stores every session in ~/.copilot/session-store.db. Each session row
- * carries its own `cwd`, so workspace attribution is exact. Sessions older than
+ * carries its own `cwd`; attribution is prefix/containment via
+ * `sessionDirBelongsToRepo` (shared with Devin/OpenCode), so a session run from a
+ * subdirectory of the repo is still captured (JOLLI-2015). Sessions older than
  * 48 hours are excluded — matches the OpenCode / Cursor / Codex convention so a
  * user enabling Copilot for the first time doesn't pull months of history into
  * the next commit summary. Synthetic transcript path: "<dbPath>#<sessionId>".
@@ -13,6 +15,7 @@ import { resolve } from "node:path";
 import { createLogger } from "../Logger.js";
 import type { SessionInfo } from "../Types.js";
 import { getCopilotDbPath } from "./CopilotDetector.js";
+import { sessionDirBelongsToRepo } from "./SessionDirMatch.js";
 import { classifyScanError, type SqliteScanError, withSqliteDb } from "./SqliteHelpers.js";
 
 const log = createLogger("CopilotDiscoverer");
@@ -54,17 +57,26 @@ export async function scanCopilotSessions(projectDir: string): Promise<CopilotSc
 
 	try {
 		const sessions = await withSqliteDb(dbPath, (db) => {
-			const caseInsensitive = process.platform === "win32" || process.platform === "darwin";
-			const cwdMatch = caseInsensitive ? "LOWER(cwd) = LOWER(:cwd)" : "cwd = :cwd";
+			// The directory match runs in JS via `sessionDirBelongsToRepo` (shared with
+			// Devin/OpenCode): prefix/containment with separator + case folding plus the
+			// nested-repo exclusion. It replaced the SQL `cwd = :cwd` (and its win32/darwin
+			// LOWER() variant), which silently dropped every session run from a
+			// subdirectory of the repo (JOLLI-2015). updated_at is TEXT with no clean SQL
+			// cutoff, so the staleness filter is already JS-side below — the directory
+			// filter joins it there.
 			const rows = db
 				.prepare(
+					// No ORDER BY: every row passing the directory + staleness filters below is
+					// kept regardless of order, so sorting would only add a full-table sort on
+					// top of an already-unavoidable full scan (updated_at is TEXT — see above).
 					`SELECT id, cwd, repository, branch, host_type, summary, created_at, updated_at
-					 FROM sessions
-					 WHERE ${cwdMatch}
-					 ORDER BY updated_at DESC`,
+					 FROM sessions`,
 				)
-				.all({ cwd: normalized }) as ReadonlyArray<{ id: string; updated_at: string; summary: unknown }>;
+				.all() as ReadonlyArray<{ id: string; cwd: string; updated_at: string; summary: unknown }>;
 			return rows.flatMap((row): SessionInfo[] => {
+				if (!sessionDirBelongsToRepo(row.cwd, normalized)) {
+					return [];
+				}
 				const ms = Date.parse(row.updated_at);
 				if (!Number.isFinite(ms)) {
 					log.warn("Skipping Copilot session %s: non-finite updated_at", row.id);

--- a/cli/src/core/DevinSessionDiscoverer.test.ts
+++ b/cli/src/core/DevinSessionDiscoverer.test.ts
@@ -324,15 +324,13 @@ describe("DevinSessionDiscoverer", () => {
 			expect(await discoverDevinSessions(projectDir)).toEqual([]);
 		});
 
-		// Contract, not a limitation to "fix" silently: matching is intentionally
-		// an exact repo-root equality (see sessionMatchesDir docstring), so a
-		// session started from a *subdirectory* of the project — common in a
-		// monorepo (`cd packages/foo && devin …`) — is NOT attributed to the repo.
-		// Capture requires running Devin at the repo root (or attaching the root as
-		// a workspace_dir). If this ever needs to change, it is a deliberate
-		// semantics decision across all hookless directory-scoped sources, not a
-		// spot edit here — flipping this test guards against an accidental change.
-		it("does NOT match a session started in a subdirectory of the project (exact-match contract)", async () => {
+		// JOLLI-2015: a session started from a *subdirectory* of the project —
+		// common in a monorepo (`cd packages/foo && devin …`) — IS attributed to
+		// the repo. Matching is prefix/containment (see sessionMatchesDir docstring
+		// → sessionDirBelongsToRepo), so the child path resolves to the repo root.
+		// This replaced the previous exact-equality contract that silently dropped
+		// every subdirectory session.
+		it("matches a session started in a subdirectory of the project (prefix match)", async () => {
 			const dbDir = join(fakeDataHome, "devin", "cli");
 			const nowSec = Math.floor(Date.now() / 1000);
 			await createDevinDb(dbDir, [
@@ -343,7 +341,28 @@ describe("DevinSessionDiscoverer", () => {
 				},
 			]);
 
-			expect(await discoverDevinSessions(projectDir)).toEqual([]);
+			const sessions = await discoverDevinSessions(projectDir);
+			expect(sessions.map((s) => s.sessionId)).toEqual(["in-subdir"]);
+		});
+
+		// The prefix match must not swallow a session that lives in a NESTED git
+		// repo / submodule inside the worktree — that session belongs to the inner
+		// repo's own post-commit. An intervening `.git` between the session dir and
+		// the repo root excludes it (see sessionDirBelongsToRepo). Uses a real temp
+		// dir so `.git` can exist on disk.
+		it("does NOT match a session inside a nested git repo under the project", async () => {
+			const dbDir = join(fakeDataHome, "devin", "cli");
+			const nowSec = Math.floor(Date.now() / 1000);
+			const realRepo = await mkdtemp(join(tmpdir(), "devin-nested-"));
+			try {
+				const nested = join(realRepo, "vendor", "lib");
+				await mkdir(join(nested, ".git"), { recursive: true });
+				await createDevinDb(dbDir, [{ id: "nested", workingDirectory: nested, lastActivityAt: nowSec - 100 }]);
+
+				expect(await discoverDevinSessions(realRepo)).toEqual([]);
+			} finally {
+				await rm(realRepo, { recursive: true, force: true });
+			}
 		});
 
 		it.each([

--- a/cli/src/core/DevinSessionDiscoverer.ts
+++ b/cli/src/core/DevinSessionDiscoverer.ts
@@ -18,7 +18,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { createLogger } from "../Logger.js";
 import type { SessionInfo } from "../Types.js";
-import { normalizePathForCompare } from "./PathUtils.js";
+import { sessionDirBelongsToRepo } from "./SessionDirMatch.js";
 import { classifyScanError, hasNodeSqliteSupport, type SqliteScanError, withSqliteDb } from "./SqliteHelpers.js";
 
 const log = createLogger("DevinDiscoverer");
@@ -50,30 +50,28 @@ function parseWorkspaceDirs(raw: string | null): string[] {
 }
 
 /**
- * A Devin session belongs to `wantDir` when its primary `working_directory` OR
- * any of its additional `workspace_dirs` normalizes to the same path. Sessions
+ * A Devin session belongs to `repoRoot` when its primary `working_directory` OR
+ * any of its additional `workspace_dirs` is inside the repo worktree. Sessions
  * started from an attached workspace/worktree surface only through
  * `workspace_dirs`, so matching on `working_directory` alone silently drops them.
- * `wantDir` must already be `normalizePathForCompare`-normalized.
  *
- * Matching is exact path *equality*, not a prefix/containment test. This mirrors
- * the other hookless directory-scoped source (OpenCode's `directory = :projectDir`)
- * and has a deliberate consequence: a session started from a *subdirectory* of the
- * repo — common in a monorepo, e.g. `cd packages/foo && devin …` — is NOT
- * attributed to the repo, because `wantDir` is the git repo root and the child
- * path is not equal to it. Hook-backed sources (Claude/Gemini) don't have this gap:
- * their hook resolves the git root at record time, so a subdirectory session still
- * lands under the repo. For hookless sources the only capture path is running Devin
- * at the repo root (or attaching the root via `workspace_dirs`). This is a known,
- * intentional limitation — see the "subdirectory of the project" contract test in
- * DevinSessionDiscoverer.test.ts. Widening it to prefix/containment matching is a
- * cross-source semantics decision, not a Devin-local tweak.
+ * Matching is prefix/containment via {@link sessionDirBelongsToRepo}, shared with
+ * the other hookless directory-scoped sources (OpenCode, Copilot): a session
+ * started from a *subdirectory* of the repo — common in a monorepo, e.g.
+ * `cd packages/foo && devin …` — IS attributed to the repo (JOLLI-2015).
+ * Sessions living in a nested git repo / submodule inside the worktree are
+ * excluded so they aren't double-captured by both repos — the helper's docstring
+ * has the full rationale.
  */
-function sessionMatchesDir(workingDirectory: string | null, workspaceDirsRaw: string | null, wantDir: string): boolean {
-	if (typeof workingDirectory === "string" && normalizePathForCompare(workingDirectory) === wantDir) {
+function sessionMatchesDir(
+	workingDirectory: string | null,
+	workspaceDirsRaw: string | null,
+	repoRoot: string,
+): boolean {
+	if (typeof workingDirectory === "string" && sessionDirBelongsToRepo(workingDirectory, repoRoot)) {
 		return true;
 	}
-	return parseWorkspaceDirs(workspaceDirsRaw).some((dir) => normalizePathForCompare(dir) === wantDir);
+	return parseWorkspaceDirs(workspaceDirsRaw).some((dir) => sessionDirBelongsToRepo(dir, repoRoot));
 }
 
 function getDevinCliDir(home?: string): string {
@@ -173,19 +171,19 @@ export async function scanDevinSessionsAt(dbPath: string, projectDir: string): P
 			// last_activity_at is epoch SECONDS → compare against cutoff in seconds.
 			const cutoffSec = Math.floor(cutoffMs / 1000);
 
-			// The directory match is done in JS rather than SQL so it can go
-			// through `normalizePathForCompare` — folding `\`↔`/`, trailing
-			// slashes, and (only on win32/darwin) case, matching the rest of the
-			// codebase. A raw `working_directory = :projectDir` silently missed
-			// sessions when Devin persisted a trailing slash or a `\`-separated path.
-			const wantDir = normalizePathForCompare(projectDir);
+			// The directory match runs in JS (not SQL) via `sessionDirBelongsToRepo`,
+			// which does prefix/containment matching with separator/case folding plus
+			// the nested-repo exclusion. The old exact `working_directory = :projectDir`
+			// both missed subdirectory sessions and mishandled trailing-slash / backslash
+			// paths.
 			const rows = db
 				.prepare(
+					// No ORDER BY: every row passing the SQL filters and the JS directory match is
+					// kept regardless of order, so sorting the result set would buy nothing.
 					`SELECT id, title, last_activity_at, working_directory, workspace_dirs
 					 FROM sessions
 					 WHERE hidden = 0
-					   AND last_activity_at > :cutoff
-					 ORDER BY last_activity_at DESC`,
+					   AND last_activity_at > :cutoff`,
 				)
 				.all({ cutoff: cutoffSec }) as ReadonlyArray<{
 				id: string;
@@ -196,7 +194,7 @@ export async function scanDevinSessionsAt(dbPath: string, projectDir: string): P
 			}>;
 
 			return rows.flatMap((row): SessionInfo[] => {
-				if (!sessionMatchesDir(row.working_directory, row.workspace_dirs, wantDir)) {
+				if (!sessionMatchesDir(row.working_directory, row.workspace_dirs, projectDir)) {
 					return [];
 				}
 				if (!Number.isFinite(row.last_activity_at)) {

--- a/cli/src/core/OpenCodeSessionDiscoverer.test.ts
+++ b/cli/src/core/OpenCodeSessionDiscoverer.test.ts
@@ -10,14 +10,21 @@ vi.spyOn(console, "warn").mockImplementation(() => {});
 vi.spyOn(console, "error").mockImplementation(() => {});
 
 // Mock homedir so tests don't depend on real home directory
-const { mockHomedir, mockPlatform } = vi.hoisted(() => ({
+const { mockHomedir } = vi.hoisted(() => ({
 	mockHomedir: vi.fn().mockReturnValue(""),
-	mockPlatform: vi.fn().mockReturnValue("darwin"),
 }));
 vi.mock("node:os", async (importOriginal) => {
 	const original = await importOriginal<typeof import("node:os")>();
-	return { ...original, homedir: mockHomedir, platform: mockPlatform };
+	return { ...original, homedir: mockHomedir };
 });
+
+// The directory match runs through `normalizePathForCompare`, which reads
+// `process.platform` directly. Override it per-test so the case-sensitivity
+// branch is deterministic regardless of host OS, and restore in afterEach.
+const savedPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+function setPlatform(os: NodeJS.Platform): void {
+	Object.defineProperty(process, "platform", { value: os, configurable: true });
+}
 
 import {
 	discoverOpenCodeSessions,
@@ -134,6 +141,8 @@ describe("OpenCodeSessionDiscoverer", () => {
 		// Restore XDG_DATA_HOME to avoid leaking between tests
 		if (savedXdgDataHome === undefined) delete process.env.XDG_DATA_HOME;
 		else process.env.XDG_DATA_HOME = savedXdgDataHome;
+		/* v8 ignore next -- the platform descriptor is always present on supported runtimes */
+		if (savedPlatform) Object.defineProperty(process, "platform", savedPlatform);
 		await rm(tempDir, { recursive: true, force: true });
 		await rm(fakeHome, { recursive: true, force: true });
 	});
@@ -202,11 +211,13 @@ describe("OpenCodeSessionDiscoverer", () => {
 
 			const sessions = await discoverOpenCodeSessions(projectDir);
 
+			// The query has no ORDER BY — all matching rows are kept regardless of order —
+			// so assert on set membership rather than a specific ordering.
 			expect(sessions).toHaveLength(2);
-			expect(sessions[0].sessionId).toBe("s2");
-			expect(sessions[1].sessionId).toBe("s1");
-			expect(sessions[0].source).toBe("opencode");
-			expect(sessions[0].transcriptPath).toContain("#s2");
+			const byId = new Map(sessions.map((s) => [s.sessionId, s]));
+			expect([...byId.keys()].sort()).toEqual(["s1", "s2"]);
+			expect(byId.get("s2")?.source).toBe("opencode");
+			expect(byId.get("s2")?.transcriptPath).toContain("#s2");
 		});
 
 		it("filters out sessions from other projects", async () => {
@@ -226,6 +237,45 @@ describe("OpenCodeSessionDiscoverer", () => {
 
 			expect(sessions).toHaveLength(1);
 			expect(sessions[0].sessionId).toBe("mine");
+		});
+
+		// JOLLI-2015: a session run from a subdirectory of the project (common in a
+		// monorepo, `cd packages/foo && opencode`) IS attributed to the repo via
+		// prefix/containment matching — semantics shared with Devin.
+		it("discovers a session run in a subdirectory of the project (prefix match)", async () => {
+			const now = Date.now();
+			const dbDir = join(fakeHome, ".local", "share", "opencode");
+			await createOpenCodeDb(dbDir, [
+				{
+					id: "in-subdir",
+					directory: join(projectDir, "packages", "foo"),
+					time_created: now - 1000,
+					time_updated: now - 100,
+				},
+			]);
+
+			const sessions = await discoverOpenCodeSessions(projectDir);
+			expect(sessions.map((s) => s.sessionId)).toEqual(["in-subdir"]);
+		});
+
+		// A session living in a NESTED git repo / submodule inside the worktree
+		// belongs to the inner repo's own post-commit, not this one — an intervening
+		// `.git` excludes it. Uses a real temp dir so `.git` can exist on disk.
+		it("does NOT discover a session inside a nested git repo under the project", async () => {
+			const now = Date.now();
+			const dbDir = join(fakeHome, ".local", "share", "opencode");
+			const realRepo = await mkdtemp(join(tmpdir(), "opencode-nested-"));
+			try {
+				const nested = join(realRepo, "vendor", "lib");
+				await mkdir(join(nested, ".git"), { recursive: true });
+				await createOpenCodeDb(dbDir, [
+					{ id: "nested", directory: nested, time_created: now - 1000, time_updated: now - 100 },
+				]);
+
+				expect(await discoverOpenCodeSessions(realRepo)).toHaveLength(0);
+			} finally {
+				await rm(realRepo, { recursive: true, force: true });
+			}
 		});
 
 		it("filters out stale sessions older than 48 hours", async () => {
@@ -340,9 +390,11 @@ describe("OpenCodeSessionDiscoverer", () => {
 				//   worker pipeline spawned with cwd "E:\\jollimemory-3" → stored by OpenCode
 				//   extension status reported projectDir "e:\\jollimemory-3" → exact-match missed
 				// Both describe the same directory on a case-insensitive filesystem, so the
-				// SQL must match regardless of drive-letter casing on Windows / macOS.
+				// match must hold regardless of drive-letter casing on Windows / macOS.
+				// `sessionDirBelongsToRepo` folds case via `normalizePathForCompare`, which
+				// reads `process.platform` — so drive the platform there, not the node:os mock.
 				// Linux's case-sensitive behaviour is asserted by the next test.
-				mockPlatform.mockReturnValue(osName);
+				setPlatform(osName);
 				const now = Date.now();
 				const dbDir = join(fakeHome, ".local", "share", "opencode");
 				const storedDir = "E:\\jollimemory-3";
@@ -359,9 +411,9 @@ describe("OpenCodeSessionDiscoverer", () => {
 
 		it("matches directory exactly (case-sensitive) on linux", async () => {
 			// Linux filesystems are case-sensitive, so a casing mismatch must NOT
-			// resolve to the same session. This exercises the `directory = :projectDir`
-			// branch of the case-insensitive ternary that darwin/win32 hosts skip.
-			mockPlatform.mockReturnValue("linux");
+			// resolve to the same session. This exercises the case-sensitive branch of
+			// `normalizePathForCompare` (no lowercasing) that darwin/win32 hosts skip.
+			setPlatform("linux");
 			const now = Date.now();
 			const dbDir = join(fakeHome, ".local", "share", "opencode");
 			const storedDir = "/home/flyer/Project";

--- a/cli/src/core/OpenCodeSessionDiscoverer.ts
+++ b/cli/src/core/OpenCodeSessionDiscoverer.ts
@@ -8,7 +8,9 @@
  * Algorithm:
  *   1. Check if the global DB file exists at ~/.local/share/opencode/opencode.db
  *   2. Open the DB read-only using node:sqlite (built-in SQLite with WAL support)
- *   3. Query the session table for recent top-level sessions matching projectDir
+ *   3. Query the session table for recent sessions (time cutoff in SQL), then keep
+ *      those whose `directory` is inside projectDir via `sessionDirBelongsToRepo`
+ *      (prefix/containment + nested-repo exclusion, shared with Devin/Copilot)
  *   4. Return matching sessions as SessionInfo[] with source="opencode"
  *
  * Cursor design: All sessions share one DB file. To give each session its own
@@ -16,10 +18,11 @@
  */
 
 import { stat } from "node:fs/promises";
-import { homedir, platform } from "node:os";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { createLogger } from "../Logger.js";
 import type { SessionInfo } from "../Types.js";
+import { sessionDirBelongsToRepo } from "./SessionDirMatch.js";
 import {
 	classifyScanError as classifySqliteScanError,
 	hasNodeSqliteSupport as hasNodeSqliteSupportFromHelpers,
@@ -152,33 +155,33 @@ export async function scanOpenCodeSessions(projectDir: string): Promise<OpenCode
 			// Auto-compact creates child sessions (parent_id != NULL) that carry on the conversation,
 			// so filtering to parent_id IS NULL would miss active sessions after compaction.
 			//
-			// Windows and macOS have case-insensitive filesystems: OpenCode may store
-			// directory as "E:\\proj" while Jolli's projectDir arrives lowercased
-			// (e.g. VS Code URIs lowercase the drive letter). Compare case-insensitively
-			// on those platforms. Linux filesystems are case-sensitive, so exact match
-			// is correct there.
-			const os = platform();
-			const caseInsensitive = os === "win32" || os === "darwin";
-			const directoryMatch = caseInsensitive
-				? "LOWER(directory) = LOWER(:projectDir)"
-				: "directory = :projectDir";
-
+			// The directory match runs in JS via `sessionDirBelongsToRepo` (shared with
+			// Devin/Copilot): prefix/containment with separator + case folding (handling
+			// the "E:\\proj" vs "e:\\proj" Windows drive-letter drift and case-sensitive
+			// Linux) plus the nested-repo exclusion. It replaced the SQL `directory =
+			// :projectDir` (and the win32/darwin LOWER() variant), which silently dropped
+			// every session run from a subdirectory of the repo (JOLLI-2015). Rows are
+			// still narrowed by the time cutoff in SQL; the directory filter is JS-side.
 			const rows = db
 				.prepare(
-					`SELECT id, title, time_created, time_updated
+					// No ORDER BY: every row passing the SQL cutoff and the JS directory filter is
+					// kept regardless of order, so sorting the result set would buy nothing.
+					`SELECT id, title, time_created, time_updated, directory
 					 FROM session
-					 WHERE ${directoryMatch}
-					   AND time_updated > :cutoff
-					 ORDER BY time_updated DESC`,
+					 WHERE time_updated > :cutoff`,
 				)
-				.all({ projectDir, cutoff: cutoffMs }) as ReadonlyArray<{
+				.all({ cutoff: cutoffMs }) as ReadonlyArray<{
 				id: string;
 				title: string;
 				time_created: number;
 				time_updated: number;
+				directory: string;
 			}>;
 
 			return rows.flatMap((row): SessionInfo[] => {
+				if (!sessionDirBelongsToRepo(row.directory, projectDir)) {
+					return [];
+				}
 				// Guard against schema drift: SQL's `time_updated > :cutoff` already
 				// filters NULL, but a non-numeric value would make new Date().toISOString()
 				// throw RangeError and bubble up as a spurious "unknown" scan error.

--- a/cli/src/core/SessionDirMatch.test.ts
+++ b/cli/src/core/SessionDirMatch.test.ts
@@ -1,0 +1,107 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sessionDirBelongsToRepo } from "./SessionDirMatch.js";
+
+describe("sessionDirBelongsToRepo", () => {
+	it("matches a session run at the repo root exactly", () => {
+		expect(sessionDirBelongsToRepo("/Users/x/repo", "/Users/x/repo")).toBe(true);
+	});
+
+	it("matches a session run in a subdirectory of the repo (the JOLLI-2015 case)", () => {
+		expect(sessionDirBelongsToRepo("/Users/x/repo/packages/foo", "/Users/x/repo")).toBe(true);
+	});
+
+	it("does not match a session run outside the repo", () => {
+		expect(sessionDirBelongsToRepo("/Users/x/other", "/Users/x/repo")).toBe(false);
+	});
+
+	it("returns false for a null/empty sessionDir instead of throwing", () => {
+		// SQLite-backed sources (Copilot CLI, OpenCode) have a nullable cwd column:
+		// a session started outside any project stores cwd = NULL. Such a row must
+		// not be attributed to the repo — and crucially must not throw, or a single
+		// null row poisons the whole discoverer scan (JOLLI: Copilot capture broke
+		// when one null-cwd session tripped `.replace()` on null).
+		expect(sessionDirBelongsToRepo(null as unknown as string, "/Users/x/repo")).toBe(false);
+		expect(sessionDirBelongsToRepo("" as string, "/Users/x/repo")).toBe(false);
+		expect(sessionDirBelongsToRepo(undefined as unknown as string, "/Users/x/repo")).toBe(false);
+	});
+
+	it("does not match a sibling whose path only shares a prefix string", () => {
+		// /Users/x/repo2 starts with the string "/Users/x/repo" but is not inside it.
+		expect(sessionDirBelongsToRepo("/Users/x/repo2", "/Users/x/repo")).toBe(false);
+	});
+
+	it("keeps a subdirectory session when the directory no longer exists (best-effort)", () => {
+		// Non-existent paths: no `.git` can be found, so the session is attributed
+		// to the repo that matched by path.
+		expect(sessionDirBelongsToRepo("/nonexistent/repo/sub/dir", "/nonexistent/repo")).toBe(true);
+	});
+
+	describe("nested git repo / submodule exclusion (real filesystem)", () => {
+		let root: string;
+
+		beforeEach(async () => {
+			root = await mkdtemp(join(tmpdir(), "sessiondirmatch-"));
+		});
+
+		afterEach(async () => {
+			await rm(root, { recursive: true, force: true });
+		});
+
+		it("excludes a session inside a nested git repo (.git directory)", async () => {
+			const nested = join(root, "vendor", "lib");
+			await mkdir(join(nested, ".git"), { recursive: true });
+			expect(sessionDirBelongsToRepo(nested, root)).toBe(false);
+		});
+
+		it("excludes a session inside a submodule (.git file)", async () => {
+			const sub = join(root, "modules", "sdk");
+			await mkdir(sub, { recursive: true });
+			await writeFile(join(sub, ".git"), "gitdir: ../../.git/modules/sdk\n");
+			expect(sessionDirBelongsToRepo(sub, root)).toBe(false);
+		});
+
+		it("excludes a session in a deeper directory of a nested repo", async () => {
+			const nestedRoot = join(root, "vendor", "lib");
+			await mkdir(join(nestedRoot, ".git"), { recursive: true });
+			const deep = join(nestedRoot, "src", "core");
+			await mkdir(deep, { recursive: true });
+			expect(sessionDirBelongsToRepo(deep, root)).toBe(false);
+		});
+
+		it("keeps a subdirectory session when only the repo root has a .git (normal repo)", async () => {
+			await mkdir(join(root, ".git"), { recursive: true });
+			const sub = join(root, "packages", "foo");
+			await mkdir(sub, { recursive: true });
+			// The repo root's own .git must NOT trigger exclusion.
+			expect(sessionDirBelongsToRepo(sub, root)).toBe(true);
+		});
+
+		// A linked worktree (`git worktree add .worktrees/foo`) has a `.git` FILE at
+		// its root. Excluding its sessions from a PARENT/sibling worktree's scan is
+		// intentional, not a gap (P2): the worktree is its own working context on its
+		// own branch and captures its sessions via its OWN post-commit (next test).
+		it("excludes a linked-worktree session from a parent worktree's scan (.git file at worktree root)", async () => {
+			await mkdir(join(root, ".git"), { recursive: true });
+			const worktree = join(root, ".worktrees", "foo");
+			const worktreeSub = join(worktree, "packages", "bar");
+			await mkdir(worktreeSub, { recursive: true });
+			// The linked worktree's root carries a `.git` FILE pointing into the main repo.
+			await writeFile(join(worktree, ".git"), "gitdir: ../../.git/worktrees/foo\n");
+			// Scanned against the PARENT repo root: the intervening `.git` file excludes it.
+			expect(sessionDirBelongsToRepo(worktreeSub, root)).toBe(false);
+		});
+
+		it("keeps that same linked-worktree session when scanned against the worktree's own root", async () => {
+			const worktree = join(root, ".worktrees", "foo");
+			const worktreeSub = join(worktree, "packages", "bar");
+			await mkdir(worktreeSub, { recursive: true });
+			await writeFile(join(worktree, ".git"), "gitdir: ../../.git/worktrees/foo\n");
+			// repoRoot IS the worktree root, so its own `.git` file is never inspected and
+			// the walk to `worktreeSub` finds nothing between them — the session is kept.
+			expect(sessionDirBelongsToRepo(worktreeSub, worktree)).toBe(true);
+		});
+	});
+});

--- a/cli/src/core/SessionDirMatch.ts
+++ b/cli/src/core/SessionDirMatch.ts
@@ -1,0 +1,85 @@
+/**
+ * Directory-based session attribution for hookless sources.
+ *
+ * Devin, OpenCode, and Copilot have no agent hook: at post-commit time the
+ * discoverer reads a global session DB and must map each session's recorded
+ * working directory back to the committing repo itself. Hook-backed sources
+ * (Claude/Gemini) don't need this — their hook resolves the git root when the
+ * session ends and records against it directly.
+ */
+
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { isPathInside, normalizePathForCompare } from "./PathUtils.js";
+
+/**
+ * Decides whether an agent session whose working directory is `sessionDir`
+ * should be attributed to the git worktree rooted at `repoRoot`.
+ *
+ * The match is prefix/containment (see {@link isPathInside}): a session run
+ * from a subdirectory of the worktree — common in a monorepo, e.g.
+ * `cd packages/foo && devin …` — still belongs to the repo. This replaced the
+ * previous exact-equality match, which silently dropped every subdirectory
+ * session (JOLLI-2015).
+ *
+ * Containment alone would double-capture a session that actually lives in a
+ * NESTED git repo or submodule inside the worktree: it would be attributed to
+ * BOTH the inner repo (its own post-commit) and this outer one. To prevent
+ * that, a strict-subdirectory match is rejected when any directory between
+ * `sessionDir` and `repoRoot` (including `sessionDir`, excluding `repoRoot`)
+ * carries its own `.git` — a directory for a nested clone, a file for a
+ * submodule/linked worktree. This deliberately also excludes a linked worktree
+ * created inside the tree (e.g. `git worktree add .worktrees/foo`, whose root
+ * carries a `.git` file): that worktree is its own working context on its own
+ * branch, so its sessions are attributed by *its* post-commit — where its root
+ * is `repoRoot` and the intervening-`.git` walk never fires — not swept up by a
+ * sibling/parent worktree's commit, which would be cross-context bleed. The
+ * check is filesystem `existsSync` only (no `git` subprocess) and runs solely
+ * for the strict-subdirectory case; an exact `sessionDir === repoRoot` match
+ * skips it. `repoRoot`'s own `.git` is never inspected, so a normal repo's
+ * subdirectory sessions are always kept. If an
+ * intermediate directory no longer exists, no `.git` is found and the session
+ * is kept (best-effort: the recorded dir is gone, so attribute it to the repo
+ * that matched by path).
+ *
+ * Both paths are absolute; comparison folds separators and (on Windows/macOS)
+ * case via {@link normalizePathForCompare}.
+ */
+export function sessionDirBelongsToRepo(sessionDir: string, repoRoot: string): boolean {
+	// SQLite-backed sources (Copilot CLI, OpenCode) expose a nullable working-dir
+	// column: a session started outside any project stores it as NULL. Such a
+	// session can't be attributed to a repo, and — critically — must not throw:
+	// the discoverer maps this over every row in one flatMap, so a single null
+	// row would otherwise poison the whole scan and drop every session (the
+	// Copilot capture regression). Guard before the path helpers, which call
+	// `.replace()` and would blow up on a falsy value.
+	if (!sessionDir) {
+		return false;
+	}
+	if (!isPathInside(sessionDir, repoRoot)) {
+		return false;
+	}
+	const repoNorm = normalizePathForCompare(repoRoot);
+	// Exact match is unambiguous — skip the nested-repo walk.
+	if (normalizePathForCompare(sessionDir) === repoNorm) {
+		return true;
+	}
+	// Strict subdirectory: reject if an intervening `.git` marks a nested repo.
+	let current = sessionDir;
+	while (normalizePathForCompare(current) !== repoNorm) {
+		if (existsSync(join(current, ".git"))) {
+			return false;
+		}
+		const parent = dirname(current);
+		/* v8 ignore start -- defensive: isPathInside already guaranteed containment, so
+		   walking up via dirname always meets repoRoot before the filesystem root. This
+		   only trips on an exotic path shape; it prevents an infinite loop rather than
+		   encoding reachable behavior. */
+		if (parent === current) {
+			break;
+		}
+		/* v8 ignore stop */
+		current = parent;
+	}
+	return true;
+}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer updated session discovery across five hookless sources (Devin, OpenCode, Copilot, Codex CLI, and Antigravity) for sessions started in monorepo subdirectories. Sessions run from subdirectories like `packages/foo` are now correctly attributed to the repository root. The fix introduces a shared helper for directory matching using prefix-based logic with lightweight `.git` traversal. When matching a session to a repository, the helper ascends through parent directories; sessions located within nested repositories or submodules are excluded. All five discoverers use this unified logic, providing consistent semantics. Tests confirm both subdirectory capture and nested-repository exclusion.

---

## Topic (1)
<details>
<summary><strong>01 · Support session discovery in monorepo subdirectories across all hookless sources</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Hookless session sources (Devin, OpenCode, Copilot, Codex CLI, Antigravity) used exact directory matching, which silently dropped sessions started in monorepo subdirectories (e.g., `cd packages/foo && devin`). Sessions were attributed only when run at the repository root.

**💡 Decisions Behind the Code**

- **Centralized shared helper**: Implemented one helper that all five discoverers share, consolidating directory-matching logic. This ensures consistent rules across Devin, OpenCode, Copilot, Codex, and Antigravity, simplifies future refinements, and prevents divergent handling of subdirectory and nested-repository cases.

- **File-based nested-repository detection**: Implemented via `existsSync` checks on parent directories. This approach is simpler, avoids subprocess overhead, and remains correct: any nested repository carries a `.git` file or directory. The check runs only in the subdirectory case; exact-match sessions skip the walk entirely.

**✅ What Was Implemented**

- Created new `SessionDirMatch.ts` module with `sessionDirBelongsToRepo()` helper implementing prefix/containment matching. The helper detects nested repositories and submodules via lightweight `.git` directory checks (no git subprocess), returning false when an intervening `.git` marks an inner repository.

- Updated all 5 discoverers (Devin, OpenCode, Copilot, Codex, Antigravity) to call the shared helper instead of exact directory matching. Removed SQL-side directory filters in OpenCode/Copilot/Codex discoverers, moving all matching logic to JavaScript.

- Updated discoverer tests to reflect the new semantics. Flipped the subdirectory contract test from "should NOT match" to "should match", and added nested-repository exclusion tests using real temp directories with `.git` present.

**📁 FILES**
- `cli/src/core/SessionDirMatch.ts`
- `cli/src/core/DevinSessionDiscoverer.ts`
- `cli/src/core/OpenCodeSessionDiscoverer.ts`
- `cli/src/core/CopilotSessionDiscoverer.ts`
- `cli/src/core/CodexSessionDiscoverer.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 22, 2026 at 6:22 PM · via Local agent*
<!-- jollimemory-summary-end -->