### PR TITLE
Track context7 library documentation lookups as references

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -807,7 +807,8 @@ export type KnownSourceId =
 	| "zoom-meeting"
 	| "zoom-doc"
 	| "asana"
-	| "monday";
+	| "monday"
+	| "context7";
 
 /**
  * ReferenceField — one displayable field produced by a `SourceDefinition`'s `fields` pipes.

--- a/cli/src/core/Regenerator.test.ts
+++ b/cli/src/core/Regenerator.test.ts
@@ -1598,5 +1598,74 @@ describe("regenerateSummary", () => {
 			// Only one block, leading with `<linear-issues>`.
 			expect(params.referenceBlocks?.startsWith("<linear-issues>")).toBe(true);
 		});
+
+		it("excludes the track-only context7 block while keeping the linear block", async () => {
+			// context7 refs are still read + grouped into bySource (readReferenceFromBranch
+			// is still called for it below), but the block-emit loop skips it — only the
+			// LLM-facing referenceBlocks output is filtered.
+			const mixed: CommitSummary = {
+				...baseSummary,
+				references: [
+					{
+						archivedKey: "linear:PROJ-1-abc12345",
+						source: "linear",
+						nativeId: "PROJ-1",
+						title: "L1",
+						url: "https://linear.app/x",
+						referencedAt: "2026-05-22T00:00:00Z",
+						sourceToolName: "mcp__linear__get_issue",
+					},
+					{
+						archivedKey: "context7:/vercel/next.js-deadbeef",
+						source: "context7",
+						nativeId: "/vercel/next.js",
+						title: "vercel/next.js",
+						url: "https://context7.com/vercel/next.js",
+						referencedAt: "2026-05-22T00:00:00Z",
+						sourceToolName: "mcp__context7__query-docs",
+					},
+				],
+			} as CommitSummary;
+			vi.mocked(SummaryStore.readReferenceFromBranch)
+				.mockResolvedValueOnce(
+					[
+						"---",
+						'source: "linear"',
+						'nativeId: "PROJ-1"',
+						'title: "L1"',
+						'url: "https://linear.app/x"',
+						'referencedAt: "2026-05-22T00:00:00Z"',
+						'sourceToolName: "mcp__linear__get_issue"',
+						"---",
+						"L1 body",
+					].join("\n"),
+				)
+				.mockResolvedValueOnce(
+					[
+						"---",
+						'source: "context7"',
+						'nativeId: "/vercel/next.js"',
+						'title: "vercel/next.js"',
+						'url: "https://context7.com/vercel/next.js"',
+						'referencedAt: "2026-05-22T00:00:00Z"',
+						'sourceToolName: "mcp__context7__query-docs"',
+						"---",
+						"context7 body",
+					].join("\n"),
+				);
+
+			await regenerateSummary(mixed, "/repo", config);
+
+			// Still read (archival/grouping is untouched by the LLM-block filter).
+			expect(SummaryStore.readReferenceFromBranch).toHaveBeenCalledWith(
+				"context7",
+				"context7:/vercel/next.js-deadbeef",
+				"/repo",
+				undefined,
+			);
+			const params = vi.mocked(Summarizer.generateSummary).mock.calls[0][0];
+			expect(params.referenceBlocks).toContain("<linear-issues>");
+			expect(params.referenceBlocks).not.toContain("context7-libraries");
+		});
 	});
 });

--- a/cli/src/core/Regenerator.ts
+++ b/cli/src/core/Regenerator.ts
@@ -277,6 +277,7 @@ async function rebuildReferenceBlocks(
 
 	const blocks: string[] = [];
 	for (const def of getRegistry().all()) {
+		if (def.trackOnly === true) continue; // track-only sources never reach the regeneration LLM
 		const sourceRefs = bySource.get(def.id);
 		if (!sourceRefs || sourceRefs.length === 0) continue;
 		const block = renderBlock(def, sourceRefs);

--- a/cli/src/core/references/ClaudeEnvelopeParser.test.ts
+++ b/cli/src/core/references/ClaudeEnvelopeParser.test.ts
@@ -323,3 +323,87 @@ describe("ClaudeEnvelopeParser monday", () => {
 		expect(results.filter((r) => r.def.id === "monday")).toHaveLength(0);
 	});
 });
+
+describe("ClaudeEnvelopeParser context7 (arguments-derived, prose result)", () => {
+	function context7Lines(toolName: string, id: string, input: Record<string, unknown>, resultText: string): string[] {
+		return [
+			JSON.stringify({
+				message: {
+					role: "assistant",
+					content: [{ type: "tool_use", id, name: toolName, input }],
+				},
+			}),
+			JSON.stringify({
+				message: {
+					role: "user",
+					content: [{ type: "tool_result", tool_use_id: id, content: resultText }],
+				},
+			}),
+		];
+	}
+
+	it("extracts one reference from a query-docs call whose result is markdown", () => {
+		const lines = context7Lines(
+			"mcp__context7__query-docs",
+			"c7a",
+			{ libraryId: "/vercel/next.js", query: "how does middleware work in the app router" },
+			"### Real-world middleware example\n\nSource: https://github.com/vercel/next.js/blob/canary/examples/i18n-routing/middleware.ts\n\nA complete middleware.ts example…",
+		);
+		const { results } = claudeEnvelopeParser.parse(lines, {});
+		expect(results).toHaveLength(1);
+		expect(results[0].def.id).toBe("context7");
+		expect(results[0].payload).toEqual({
+			libraryId: "/vercel/next.js",
+			query: "how does middleware work in the app router",
+		});
+	});
+
+	it("ignores resolve-library-id calls", () => {
+		const lines = context7Lines(
+			"mcp__context7__resolve-library-id",
+			"c7r",
+			{ libraryName: "Next.js", query: "middleware" },
+			"Available Libraries:\n- /vercel/next.js",
+		);
+		expect(claudeEnvelopeParser.parse(lines, {}).results).toHaveLength(0);
+	});
+});
+
+describe("ClaudeEnvelopeParser tail-rewind with an earlier abandoned call", () => {
+	// Regression: a resultless call left behind EARLIER in the transcript (aborted
+	// / errored) must not drag the tail-rewind target back below lastResultLineIndex
+	// and thereby suppress the rewind of a genuinely-incomplete TAIL call. Before
+	// the fix the rewind used the earliest pending tool_use ANYWHERE; the abandoned
+	// call's low line index failed the `> lastResultLineIndex` guard, so the cursor
+	// stayed at EOF and the tail context7 reference was stranded forever once its
+	// result finally landed on a later scan.
+	function assistantToolUse(id: string, input: Record<string, unknown>): string {
+		return JSON.stringify({
+			message: {
+				role: "assistant",
+				content: [{ type: "tool_use", id, name: "mcp__context7__query-docs", input }],
+			},
+		});
+	}
+	function userToolResult(id: string, text: string): string {
+		return JSON.stringify({
+			message: { role: "user", content: [{ type: "tool_result", tool_use_id: id, content: text }] },
+		});
+	}
+
+	it("rewinds to the trailing incomplete call, not the earlier abandoned one", () => {
+		const transcript = [
+			assistantToolUse("old-abandoned", { libraryId: "/a/aborted", query: "never answered" }), // line 0, no result
+			assistantToolUse("mid-paired", { libraryId: "/b/paired", query: "answered inline" }), // line 1
+			userToolResult("mid-paired", "### docs\nSource: https://example.test/b"), // line 2 → lastResultLineIndex = 2
+			assistantToolUse("tail-incomplete", { libraryId: "/c/tail", query: "result not flushed yet" }), // line 3
+		];
+		const { results, lastLineNumberScanned } = claudeEnvelopeParser.parse(transcript, {});
+		// Only the mid pair produced a reference this scan.
+		expect(results).toHaveLength(1);
+		expect(results[0].payload).toEqual({ libraryId: "/b/paired", query: "answered inline" });
+		// Cursor must rewind to the tail tool_use (line index 3) so the next scan
+		// re-pairs it — NOT sit at EOF (4), which strands it forever.
+		expect(lastLineNumberScanned).toBe(3);
+	});
+});

--- a/cli/src/core/references/ClaudeEnvelopeParser.ts
+++ b/cli/src/core/references/ClaudeEnvelopeParser.ts
@@ -33,6 +33,7 @@ import { scanUserPermalinks } from "./SlackPermalink.js";
 import type { SourceDefinition } from "./SourceDefinition.js";
 import { getRegistry } from "./SourceDefinitionRegistry.js";
 import { normalizeConfluence } from "./sources/ConfluenceNormalize.js";
+import { normalizeContext7 } from "./sources/Context7Normalize.js";
 import { normalizeMonday, readItemIds } from "./sources/MondayNormalize.js";
 import { normalizeSlackThread } from "./sources/SlackNormalize.js";
 import { normalizeZoomDoc } from "./sources/ZoomDocNormalize.js";
@@ -80,6 +81,13 @@ interface PendingEntry {
 	 * looks at this field.
 	 */
 	readonly toolInput?: unknown;
+	/**
+	 * 0-based transcript line index of the originating tool_use. Retained so a
+	 * scan that ends with this entry still unpaired can rewind its cursor to this
+	 * line, letting the next scan re-pair it once the tool_result has landed. See
+	 * the tail-rewind logic in {@link ClaudeEnvelopeParser.parse}.
+	 */
+	readonly toolUseLineIndex: number;
 }
 
 class ClaudeEnvelopeParser implements TranscriptEnvelopeParser {
@@ -88,6 +96,11 @@ class ClaudeEnvelopeParser implements TranscriptEnvelopeParser {
 		const pending = new Map<string, PendingEntry>();
 		const results: NormalizedToolResult[] = [];
 		let lastConsumed = fromLine;
+		// 0-based index of the last line that paired a tool_result to a pending
+		// tool_use. Used by the tail-rewind below to tell a flush-race incomplete
+		// tail (only unpaired tool_uses after the last result → rewind) apart from a
+		// genuinely resultless call left behind mid-stream (do not pin the cursor).
+		let lastResultLineIndex = fromLine - 1;
 		// Slack's normalize needs a url no MCP payload carries; the pasted
 		// permalink (if any) is the only place it lives. Scanned once up front so
 		// every user text line is visited exactly once regardless of how many
@@ -124,12 +137,39 @@ class ClaudeEnvelopeParser implements TranscriptEnvelopeParser {
 			if (role === undefined || blocks === undefined) continue;
 
 			if (role === "assistant") {
-				collectToolUses(blocks, timestamp, opts.beforeTimestamp, pending);
+				collectToolUses(blocks, i, timestamp, opts.beforeTimestamp, pending);
 				/* v8 ignore start -- readRole returns only "assistant" | "user" | undefined; undefined is filtered above, so the else-if's false branch is unreachable. */
 			} else if (role === "user") {
 				/* v8 ignore stop */
+				const resultsBefore = results.length;
 				collectToolResults(blocks, i + 1, timestamp, opts.beforeTimestamp, pending, results, permalinks, opts);
+				if (results.length > resultsBefore) lastResultLineIndex = i;
 			}
+		}
+
+		// Tail rewind: a matched tool_use left unpaired in the trailing suffix (after
+		// the last paired result) is an INCOMPLETE tail — the tool_result has not
+		// been flushed to disk yet, or a concurrent StopHook fire advanced the cursor
+		// mid-pair. Rewind the cursor to the earliest such tail tool_use so the next
+		// scan re-reads from there and can pair it. Without this, an `argumentsDerived`
+		// reference (context7 — built from the tool_use input, emitted only when its
+		// result is seen in the SAME scan) is lost for good, since the cursor never
+		// moves backward. Re-scanning the tail is idempotent.
+		//
+		// The rewind target MUST be scoped to the trailing suffix (`> lastResultLineIndex`
+		// PER ENTRY), not the earliest pending entry overall: a genuinely resultless
+		// call left behind EARLIER (aborted/errored, then later calls paired fine)
+		// sits before lastResultLineIndex, and must neither become the rewind target
+		// nor — the bug this replaced — suppress the rewind of a newer incomplete tail
+		// by dragging the global minimum below the threshold.
+		if (pending.size > 0) {
+			let earliestTailPending = Number.POSITIVE_INFINITY;
+			for (const entry of pending.values()) {
+				if (entry.toolUseLineIndex > lastResultLineIndex && entry.toolUseLineIndex < earliestTailPending) {
+					earliestTailPending = entry.toolUseLineIndex;
+				}
+			}
+			if (earliestTailPending !== Number.POSITIVE_INFINITY) lastConsumed = earliestTailPending;
 		}
 
 		return { results, lastLineNumberScanned: lastConsumed };
@@ -171,6 +211,7 @@ function readCommand(input: unknown): string | undefined {
 
 function collectToolUses(
 	blocks: readonly unknown[],
+	lineIndex: number,
 	timestamp: string | undefined,
 	beforeTimestamp: string | undefined,
 	pending: Map<string, PendingEntry>,
@@ -195,6 +236,7 @@ function collectToolUses(
 				def: mcpDef,
 				normalize: identity,
 				requireSuccess: false,
+				toolUseLineIndex: lineIndex,
 				// Only sources with a registered context-normalizer read the
 				// tool_use input (Slack's channel_id/message_ts, zoom-doc's
 				// fileId); every other source's `normalize` is `identity` and
@@ -222,6 +264,7 @@ function collectToolUses(
 				normalize: cli.normalize,
 				command,
 				requireSuccess: true,
+				toolUseLineIndex: lineIndex,
 			});
 		}
 	}
@@ -297,6 +340,7 @@ const CONTEXT_NORMALIZERS: Record<
 	},
 	confluence: (payload) => normalizeConfluence(payload),
 	monday: (payload, toolInput) => normalizeMonday(payload, { itemIds: readItemIds(toolInput) }),
+	context7: (_payload, toolInput) => normalizeContext7(toolInput),
 };
 
 /**
@@ -352,23 +396,31 @@ function collectToolResults(
 			// whose bundled transcript routinely blows the cap).
 			const recovered = recoverOffloadedPayload(payloadText);
 			if (recovered === undefined) {
-				log.warn(
-					"Dropping tool_result for %s (%s): payload JSON.parse failed: %s | preview=%s",
+				// An arguments-derived source (context7) returns prose, not JSON — its
+				// reference is built from the retained toolInput, so an unparseable result
+				// is expected. Give the normalizer an empty payload instead of dropping.
+				if (pendingEntry.def.argumentsDerived === true) {
+					parsedPayload = {};
+				} else {
+					log.warn(
+						"Dropping tool_result for %s (%s): payload JSON.parse failed: %s | preview=%s",
+						b.tool_use_id,
+						pendingEntry.toolName,
+						(err as Error).message,
+						payloadText.slice(0, 200),
+					);
+					pending.delete(b.tool_use_id);
+					continue;
+				}
+			} else {
+				log.info(
+					"Recovered offloaded tool_result for %s (%s) from %s",
 					b.tool_use_id,
 					pendingEntry.toolName,
-					(err as Error).message,
-					payloadText.slice(0, 200),
+					recovered.path,
 				);
-				pending.delete(b.tool_use_id);
-				continue;
+				parsedPayload = recovered.payload;
 			}
-			log.info(
-				"Recovered offloaded tool_result for %s (%s) from %s",
-				b.tool_use_id,
-				pendingEntry.toolName,
-				recovered.path,
-			);
-			parsedPayload = recovered.payload;
 		}
 
 		// A source whose canonical shape the identity path cannot produce runs

--- a/cli/src/core/references/CodexEnvelopeParser.test.ts
+++ b/cli/src/core/references/CodexEnvelopeParser.test.ts
@@ -1272,3 +1272,85 @@ describe("CodexEnvelopeParser end-to-end — Slack thread via extractReferencesF
 		expect(ref?.title?.startsWith("Consolidate")).toBe(true);
 	});
 });
+
+// ─── context7 (local MCP, argumentsDerived fallback) ─────────────────────────
+// Real 2026-07 rollout shape: context7 runs as a LOCAL MCP server (not a
+// codex_apps connector), so it never carries the `mcp__codex_apps__` namespace
+// and is matched ONLY via the FALLBACK path on `mcp_tool_call_end`, using
+// `invocation.tool`/`invocation.arguments`. `result.Ok.content[0].text` is
+// markdown prose, not JSON — this is the argumentsDerived case the FALLBACK
+// loop must special-case rather than drop.
+
+describe("context7 local MCP (fallback path, prose result)", () => {
+	it("extracts one reference from a query-docs mcp_tool_call_end event", () => {
+		const lines = [
+			JSON.stringify({
+				timestamp: "2026-07-22T08:18:30.000Z",
+				type: "event_msg",
+				payload: {
+					type: "mcp_tool_call_end",
+					call_id: "callc7",
+					invocation: {
+						server: "context7",
+						tool: "query-docs",
+						arguments: { libraryId: "/vercel/next.js", query: "middleware in the app router" },
+					},
+					result: {
+						Ok: {
+							content: [
+								{ type: "text", text: "### Middleware\n\nSource: https://github.com/vercel/next.js/…" },
+							],
+						},
+					},
+				},
+			}),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results).toHaveLength(1);
+		expect(results[0].def.id).toBe("context7");
+		expect(results[0].payload).toEqual({ libraryId: "/vercel/next.js", query: "middleware in the app router" });
+	});
+
+	it("ignores resolve-library-id events", () => {
+		const lines = [
+			JSON.stringify({
+				timestamp: "2026-07-22T08:18:29.000Z",
+				type: "event_msg",
+				payload: {
+					type: "mcp_tool_call_end",
+					call_id: "callr",
+					invocation: {
+						server: "context7",
+						tool: "resolve-library-id",
+						arguments: { libraryName: "Next.js" },
+					},
+					result: { Ok: { content: [{ type: "text", text: "Available Libraries:\n- /vercel/next.js" }] } },
+				},
+			}),
+		];
+		expect(codexEnvelopeParser.parse(lines, {}).results).toHaveLength(0);
+	});
+});
+
+// ─── context7 (codex_apps connector, PRIMARY path, argumentsDerived) ─────────
+// A `codex_apps` connector build of context7 (as opposed to the local-MCP build
+// exercised above) would carry the `mcp__codex_apps__` namespace and match via
+// PRIMARY (function_call + function_call_output), not FALLBACK. This shape is
+// catalog-derived (inferred from the codex_apps connector convention shared by
+// asana/monday/etc. above), NOT captured from a real rollout — no live context7
+// connector transcript was available. Its prose result (non-JSON output) is the
+// case the PRIMARY loop must special-case via `argumentsDerived` rather than drop
+// (mirroring the FALLBACK loop's existing null-business guard).
+describe("context7 codex_apps connector (PRIMARY path, prose result)", () => {
+	it("extracts one reference from a _query_docs function_call/output pair", () => {
+		const args = JSON.stringify({ libraryId: "/vercel/next.js", query: "middleware in the app router" });
+		const lines = [
+			fnCall("mcp__codex_apps__context7", "_query_docs", "c_context7", args),
+			fnOutputRaw("c_context7", "### Middleware\n\nSource: https://github.com/vercel/next.js/…"),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results).toHaveLength(1);
+		expect(results[0].def.id).toBe("context7");
+		expect(results[0].payload).toEqual({ libraryId: "/vercel/next.js", query: "middleware in the app router" });
+	});
+});

--- a/cli/src/core/references/CodexEnvelopeParser.ts
+++ b/cli/src/core/references/CodexEnvelopeParser.ts
@@ -222,8 +222,15 @@ class CodexEnvelopeParser implements TranscriptEnvelopeParser {
 			if (call === undefined) continue;
 			const def = resolveCodexDef(registry, call.namespace, call.name);
 			if (def === undefined) continue;
-			const business = parseFunctionCallOutput(out.output);
-			if (business === null) continue;
+			let business = parseFunctionCallOutput(out.output);
+			if (business === null) {
+				// An arguments-derived source (context7) returns prose, not JSON. Its
+				// reference is built from invocation.arguments below, so an unparseable
+				// output is expected — give the normalizer an empty business object
+				// instead of dropping the call. Every JSON-result source is unaffected.
+				if (def.argumentsDerived !== true) continue;
+				business = {};
+			}
 			const normalizer = getCodexNormalizer(def.id);
 			/* v8 ignore start -- every registry codex definition has a matching CodexBinding; guarded for totality. */
 			if (normalizer === undefined) continue;
@@ -281,7 +288,14 @@ class CodexEnvelopeParser implements TranscriptEnvelopeParser {
 			if (normalizer === undefined) continue;
 			/* v8 ignore stop */
 			let business = tryParse(ev.text);
-			if (business === null) continue;
+			if (business === null) {
+				// An arguments-derived source (context7) returns prose, not JSON. Its
+				// reference is built from invocation.arguments below, so an unparseable
+				// event text is expected — give the normalizer an empty business object
+				// instead of dropping the event. Every JSON-result source is unaffected.
+				if (def.argumentsDerived !== true) continue;
+				business = {};
+			}
 			// Recovery (NOT the main path): reaching the fallback for a call_id that
 			// ALSO has a function_call output means that output either failed to parse
 			// or normalized to null (a successful, non-null normalize would have marked

--- a/cli/src/core/references/ReferenceExtractor.test.ts
+++ b/cli/src/core/references/ReferenceExtractor.test.ts
@@ -1305,3 +1305,86 @@ describe("extractReferencesFromTranscript — Claude Bash gh issue view CLI fall
 		expect(references[0].mapKey).toBe("github:jolliai/jolli#959");
 	});
 });
+
+// ─── Regression: incremental cursor must not split an argumentsDerived pair ───
+//
+// REPRO for the observed data loss: a Claude StopHook context7 (`query-docs`)
+// lookup was never persisted, while the exact same lookup extracts cleanly from
+// the full transcript. Root cause: incremental discovery advances a forward-only
+// cursor, and `context7` is `argumentsDerived` — its reference is built from the
+// tool_use `input`, emitted only when the paired tool_result is seen IN THE SAME
+// scan. If the cursor boundary lands between the tool_use and its tool_result
+// (double StopHook fire racing the cursor, or the result simply not flushed to
+// disk yet when the first scan runs), pass 1 sees a tool_use with no result (no
+// emit) and advances the cursor past it; pass 2 sees a result with no pending
+// tool_use (no emit). The reference is lost forever because the cursor never
+// rewinds.
+//
+// This pins the fix-agnostic invariant: across the full lifetime of incremental
+// discovery, an argumentsDerived reference is captured even when a scan boundary
+// splits its tool_use/tool_result pair. Any chosen fix (carry pending across
+// scans, hold the cursor before an unpaired tool_use, or dedupe the double fire)
+// must make this pass. It currently FAILS (union is empty).
+describe("extractReferencesFromTranscript incremental argumentsDerived pairing", () => {
+	const c7ToolUse = toolUseLine({
+		toolUseId: "c7_1",
+		toolName: "mcp__context7__query-docs",
+		timestamp: "2026-07-22T14:59:52.000Z",
+		inputJson: JSON.stringify({ libraryId: "/thedotmack/claude-mem", query: "what is claude-mem" }),
+	});
+	// context7 returns markdown prose, not JSON — the argumentsDerived path.
+	const c7Result = toolResultLine({
+		toolUseId: "c7_1",
+		timestamp: "2026-07-22T14:59:53.000Z",
+		payload: "### Claude-Mem\n\nClaude-Mem is a persistent memory compression system for Claude Code…",
+	});
+
+	it("control: a single full scan captures the context7 reference", async () => {
+		mockReadFile.mockResolvedValue(makeJsonl(c7ToolUse, c7Result));
+		const { references } = await extractReferencesFromTranscript("/fake.jsonl");
+		expect(references.map((r) => r.mapKey)).toContain("context7:/thedotmack/claude-mem");
+	});
+
+	it("does not lose the reference when the cursor boundary splits the tool_use/tool_result pair", async () => {
+		// Pass 1: the tool_result has not been flushed yet — only the tool_use is
+		// on disk. No reference is emitted, and the cursor advances past it.
+		mockReadFile.mockResolvedValueOnce(makeJsonl(c7ToolUse));
+		const pass1 = await extractReferencesFromTranscript("/fake.jsonl");
+
+		// Pass 2: the result is now flushed. Discovery resumes from the persisted
+		// cursor, so it starts AFTER the tool_use line.
+		mockReadFile.mockResolvedValueOnce(makeJsonl(c7ToolUse, c7Result));
+		const pass2 = await extractReferencesFromTranscript("/fake.jsonl", {
+			fromLineNumber: pass1.lastLineNumberScanned,
+		});
+
+		const captured = [...pass1.references, ...pass2.references].map((r) => r.mapKey);
+		expect(captured).toContain("context7:/thedotmack/claude-mem");
+	});
+
+	it("does NOT rewind past a genuinely resultless tool_use that a later result followed", async () => {
+		// c7_1 never gets a result (aborted/errored call). A completed linear
+		// lookup follows it. The unpaired tool_use sits BEFORE the last paired
+		// result, so the tail is not "incomplete" — rewinding here would pin the
+		// cursor on a call that will never pair. The cursor must advance to EOF.
+		const jsonl = makeJsonl(
+			c7ToolUse, // line index 0 — stays unpaired
+			toolUseLine({
+				toolUseId: "toolu_lin",
+				toolName: "mcp__linear__get_issue",
+				timestamp: "2026-07-22T15:00:00.000Z",
+			}),
+			toolResultLine({
+				toolUseId: "toolu_lin",
+				timestamp: "2026-07-22T15:00:01.000Z",
+				payload: SAMPLE_ISSUE_PAYLOAD,
+			}),
+		);
+		mockReadFile.mockResolvedValue(jsonl);
+
+		const { references, lastLineNumberScanned } = await extractReferencesFromTranscript("/fake.jsonl");
+
+		expect(lastLineNumberScanned).toBe(3); // advanced to EOF, not rewound to line 0
+		expect(references.map((r) => r.mapKey)).toEqual(["linear:PROJ-1528"]);
+	});
+});

--- a/cli/src/core/references/SourceDefinition.ts
+++ b/cli/src/core/references/SourceDefinition.ts
@@ -74,6 +74,20 @@ export interface SourceDefinition {
 	readonly id: string;
 	readonly label: string;
 	readonly icon: string;
+	/**
+	 * Track-only: the reference is captured, archived into CommitSummary.references,
+	 * and shown in every reference listing (detail page, PR, push, timeline), but is
+	 * EXCLUDED from the {{references}} block fed to the memory-decision LLM. Absent
+	 * (falsy) for every existing source.
+	 */
+	readonly trackOnly?: boolean;
+	/**
+	 * Arguments-derived: the reference is built from the tool-call arguments, not the
+	 * result, so a non-JSON (prose) result is expected. Both transcript parsers pass an
+	 * empty payload to this source's normalizer on JSON-parse failure instead of
+	 * dropping the call. Absent (falsy) for every existing (JSON-result) source.
+	 */
+	readonly argumentsDerived?: boolean;
 	readonly match: SourceMatch;
 	readonly wrapperKeys: ReadonlyArray<string>;
 	readonly reference: {

--- a/cli/src/core/references/SourceDefinitionRegistry.test.ts
+++ b/cli/src/core/references/SourceDefinitionRegistry.test.ts
@@ -43,7 +43,7 @@ describe("SourceDefinitionRegistry", () => {
 		expect(r.match("codex", "linear.get_issue")?.id).toBe("linear"); // invocation-tool path (no namespace)
 	});
 
-	it("all() is stable order linear,confluence,jira,github,notion,slack,zoom-meeting,zoom-doc,asana,monday", () => {
+	it("all() is stable order linear,confluence,jira,github,notion,slack,zoom-meeting,zoom-doc,asana,monday,context7", () => {
 		expect(
 			getRegistry()
 				.all()
@@ -59,6 +59,7 @@ describe("SourceDefinitionRegistry", () => {
 			"zoom-doc",
 			"asana",
 			"monday",
+			"context7",
 		]);
 	});
 

--- a/cli/src/core/references/bindings/claude/index.test.ts
+++ b/cli/src/core/references/bindings/claude/index.test.ts
@@ -22,6 +22,7 @@ describe("Claude producer binding", () => {
 				"mcp__claude_ai_Zoom_for_Claude__",
 				"mcp__claude_ai_Asana__",
 				"mcp__claude_ai_monday_com__",
+				"mcp__context7__",
 			]);
 		});
 	});

--- a/cli/src/core/references/bindings/codex/CodexContext7Binding.ts
+++ b/cli/src/core/references/bindings/codex/CodexContext7Binding.ts
@@ -1,0 +1,14 @@
+import { normalizeContext7 } from "../../sources/Context7Normalize.js";
+import type { CodexNormalizer } from "./CodexBinding.js";
+
+/**
+ * Local-MCP context7 calls match via the FALLBACK path (mcp_tool_call_end,
+ * invocation.tool = "query-docs", invocation.arguments carries libraryId); the
+ * codex_apps connector variant matches via PRIMARY. Either way the business
+ * payload is ignored — the reference is built from the arguments.
+ */
+export const context7CodexBinding: CodexNormalizer = {
+	id: "context7",
+	canonicalToolName: "mcp__context7__query-docs",
+	normalize: (_business, toolInput) => normalizeContext7(toolInput),
+};

--- a/cli/src/core/references/bindings/codex/index.ts
+++ b/cli/src/core/references/bindings/codex/index.ts
@@ -13,6 +13,7 @@ import type { SourceId } from "../../../../Types.js";
 import { asanaCodexBinding } from "./CodexAsanaBinding.js";
 import type { CodexNormalizer } from "./CodexBinding.js";
 import { confluenceCodexBinding } from "./CodexConfluenceBinding.js";
+import { context7CodexBinding } from "./CodexContext7Binding.js";
 import { githubCodexBinding } from "./CodexGitHubBinding.js";
 import { jiraCodexBinding } from "./CodexJiraBinding.js";
 import { linearCodexBinding } from "./CodexLinearBinding.js";
@@ -34,6 +35,7 @@ const CODEX_NORMALIZERS: readonly CodexNormalizer[] = [
 	asanaCodexBinding,
 	mondayCodexBinding,
 	slackCodexBinding,
+	context7CodexBinding,
 ];
 
 const BY_ID: ReadonlyMap<SourceId, CodexNormalizer> = new Map(CODEX_NORMALIZERS.map((n) => [n.id, n]));

--- a/cli/src/core/references/sources/Context7Normalize.test.ts
+++ b/cli/src/core/references/sources/Context7Normalize.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { normalizeContext7 } from "./Context7Normalize.js";
+
+describe("normalizeContext7", () => {
+	it("builds { libraryId, query } from the query-docs arguments", () => {
+		expect(normalizeContext7({ libraryId: "/vercel/next.js", query: "middleware" })).toEqual({
+			libraryId: "/vercel/next.js",
+			query: "middleware",
+		});
+	});
+
+	it("omits query when absent or empty", () => {
+		expect(normalizeContext7({ libraryId: "/vercel/next.js" })).toEqual({ libraryId: "/vercel/next.js" });
+		expect(normalizeContext7({ libraryId: "/vercel/next.js", query: "" })).toEqual({
+			libraryId: "/vercel/next.js",
+		});
+	});
+
+	it("returns null when libraryId is missing or non-string", () => {
+		expect(normalizeContext7({ query: "middleware" })).toBeNull();
+		expect(normalizeContext7({ libraryId: 42 })).toBeNull();
+		expect(normalizeContext7("not-an-object")).toBeNull();
+		expect(normalizeContext7(undefined)).toBeNull();
+	});
+});

--- a/cli/src/core/references/sources/Context7Normalize.ts
+++ b/cli/src/core/references/sources/Context7Normalize.ts
@@ -1,0 +1,23 @@
+/**
+ * context7 is an arguments-derived source: the referenced library (`libraryId`,
+ * e.g. `/vercel/next.js`) and the topic (`query`) live in the `query-docs` tool
+ * ARGUMENTS. The result is markdown prose and is ignored. This reshaper turns the
+ * tool input into the flat object the `context7Definition` reads via `path` ops,
+ * and is shared by both the Claude context-normalizer and the Codex binding.
+ */
+import { isObject } from "../guards.js";
+
+function readString(v: unknown): string | undefined {
+	return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+/** Build the context7 reference shape from the query-docs arguments. Returns null
+ *  (voiding the reference) when `libraryId` is absent/non-string. A malformed-but-
+ *  present id is left for the definition's `require` regex to void. */
+export function normalizeContext7(toolInput: unknown): { libraryId: string; query?: string } | null {
+	if (!isObject(toolInput)) return null;
+	const libraryId = readString(toolInput.libraryId);
+	if (libraryId === undefined) return null;
+	const query = readString(toolInput.query);
+	return { libraryId, ...(query !== undefined ? { query } : {}) };
+}

--- a/cli/src/core/references/sources/definitions/context7.test.ts
+++ b/cli/src/core/references/sources/definitions/context7.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { extractRef } from "../../SourceEngine.js";
+import { context7Definition } from "./context7.js";
+
+const AT = "2026-07-22T08:00:00.000Z";
+
+describe("context7Definition", () => {
+	it("is track-only and arguments-derived", () => {
+		expect(context7Definition.trackOnly).toBe(true);
+		expect(context7Definition.argumentsDerived).toBe(true);
+	});
+
+	it("extracts a per-library reference from the normalized arguments payload", () => {
+		const ref = extractRef(
+			context7Definition,
+			{ libraryId: "/vercel/next.js", query: "how does middleware work" },
+			"mcp__context7__query-docs",
+			AT,
+		);
+		expect(ref).not.toBeNull();
+		expect(ref?.source).toBe("context7");
+		expect(ref?.nativeId).toBe("/vercel/next.js");
+		expect(ref?.title).toBe("vercel/next.js");
+		expect(ref?.url).toBe("https://context7.com/vercel/next.js");
+		expect(ref?.description).toBe("how does middleware work");
+		expect(ref?.mapKey).toBe("context7:/vercel/next.js");
+	});
+
+	it("voids the reference when libraryId is not org/project shaped", () => {
+		expect(extractRef(context7Definition, { libraryId: "next.js" }, "mcp__context7__query-docs", AT)).toBeNull();
+		expect(extractRef(context7Definition, { libraryId: "/vercel" }, "mcp__context7__query-docs", AT)).toBeNull();
+	});
+
+	it("keeps the reference when query is absent (description optional)", () => {
+		const ref = extractRef(context7Definition, { libraryId: "/mongodb/docs" }, "mcp__context7__query-docs", AT);
+		expect(ref?.nativeId).toBe("/mongodb/docs");
+		expect(ref?.description).toBeUndefined();
+	});
+});

--- a/cli/src/core/references/sources/definitions/context7.ts
+++ b/cli/src/core/references/sources/definitions/context7.ts
@@ -1,0 +1,58 @@
+import type { SourceDefinition } from "../../SourceDefinition.js";
+
+// A Context7-compatible library id is `/org/project` (optionally `/org/project/version`).
+const LIBRARY_ID = "^/[^/\\s]+/[^/\\s]+";
+
+/**
+ * context7 (`@upstash/context7-mcp`) — track-only documentation references.
+ * Only the current `query-docs` tool is matched (legacy `get-library-docs` uses a
+ * different arg name and is out of scope). The reference is built from the ARGUMENTS
+ * (`libraryId`, `query`) via `Context7Normalize`; the markdown result is ignored,
+ * which is why `argumentsDerived` is set. `trackOnly` keeps it out of the LLM block.
+ */
+export const context7Definition: SourceDefinition = {
+	id: "context7",
+	label: "Context7",
+	icon: "book",
+	trackOnly: true,
+	argumentsDerived: true,
+	match: {
+		claude: { prefixes: ["mcp__context7__"], acceptSuffix: "query-docs" },
+		codex: {
+			namespaceSuffix: "context7",
+			functionCallNames: ["_query_docs"],
+			invocationTools: ["query-docs", "context7.query-docs"],
+		},
+	},
+	wrapperKeys: [],
+	reference: {
+		nativeId: { pipe: [{ op: "path", path: "libraryId" }], require: LIBRARY_ID },
+		title: {
+			pipe: [
+				{ op: "path", path: "libraryId" },
+				{ op: "regex", pattern: "^/(.+)$", extract: "$1" },
+			],
+			require: ".+",
+		},
+		url: {
+			pipe: [
+				{
+					op: "template",
+					template: "https://context7.com{id}",
+					from: { id: [{ op: "path", path: "libraryId" }] },
+				},
+			],
+			require: "^https://context7\\.com/",
+		},
+		description: { pipe: [{ op: "path", path: "query" }], optional: true },
+	},
+	fields: [],
+	storage: { nativeIdPathSafe: false },
+	render: {
+		wrapperTag: "context7-libraries",
+		itemTag: "library",
+		bodyTag: "content",
+		maxCharsPerReference: 2000,
+		maxTotalChars: 8000,
+	},
+};

--- a/cli/src/core/references/sources/definitions/index.ts
+++ b/cli/src/core/references/sources/definitions/index.ts
@@ -15,6 +15,7 @@
 
 import { asanaDefinition } from "./asana.js";
 import { confluenceDefinition } from "./confluence.js";
+import { context7Definition } from "./context7.js";
 import { githubDefinition } from "./github.js";
 import { jiraDefinition } from "./jira.js";
 import { linearDefinition } from "./linear.js";
@@ -35,4 +36,5 @@ export const BUILTIN_DEFINITIONS = [
 	zoomDocDefinition,
 	asanaDefinition,
 	mondayDefinition,
+	context7Definition,
 ] as const;

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -1465,6 +1465,216 @@ describe("QueueWorker", () => {
 		});
 	});
 
+	describe("assembleReferenceBlocks — track-only source filtering", () => {
+		it("omits track-only (context7) references from the LLM block while keeping notion", async () => {
+			const { readReferenceMarkdown } = await import("../core/references/ReferenceStore.js");
+			vi.mocked(readReferenceMarkdown).mockImplementation(async (path: string) => {
+				if (path.includes("notion")) {
+					return {
+						mapKey: "notion:abcdef0123456789abcdef0123456789",
+						source: "notion",
+						nativeId: "abcdef0123456789abcdef0123456789",
+						title: "Notion page",
+						url: "https://www.notion.so/Notion-page-abcdef0123456789abcdef0123456789",
+						toolName: "notion-fetch",
+						referencedAt: "2026-05-14T06:06:01.123Z",
+					};
+				}
+				if (path.includes("context7")) {
+					return {
+						mapKey: "context7:/vercel/next.js",
+						source: "context7",
+						nativeId: "/vercel/next.js",
+						title: "vercel/next.js",
+						url: "https://context7.com/vercel/next.js",
+						toolName: "mcp__context7__query-docs",
+						referencedAt: "2026-05-14T06:06:02.123Z",
+					};
+				}
+				return null;
+			});
+
+			const block = await __test__.assembleReferenceBlocks([
+				{
+					source: "notion",
+					nativeId: "abcdef0123456789abcdef0123456789",
+					title: "Notion page",
+					url: "https://www.notion.so/Notion-page-abcdef0123456789abcdef0123456789",
+					sourcePath: "/test/cwd/.jolli/jollimemory/references/notion/abcdef.md",
+					addedAt: "x",
+					updatedAt: "x",
+					sourceToolName: "notion-fetch",
+				},
+				{
+					source: "context7",
+					nativeId: "/vercel/next.js",
+					title: "vercel/next.js",
+					url: "https://context7.com/vercel/next.js",
+					sourcePath: "/test/cwd/.jolli/jollimemory/references/context7/vercel-next-js.md",
+					addedAt: "x",
+					updatedAt: "x",
+					sourceToolName: "mcp__context7__query-docs",
+				},
+			]);
+
+			expect(block).toContain("notion-pages");
+			expect(block).not.toContain("context7-libraries");
+		});
+	});
+
+	describe("trackOnly references and relevance", () => {
+		// Shared arrange: two active references — a track-only context7 library and a
+		// normal Linear issue — plus the archival rescan seeing both. `excludedContext`
+		// is what the pipeline treats as excluded; each test supplies its own verdict.
+		async function arrangeTwoRefs(excludedContext: ExcludedContextItem[]): Promise<void> {
+			const op = makeCommitOp({ commitHash: "abc12345def67890" });
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/li.json" }])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+			setupPipelineMocks("abc12345def67890");
+
+			const { readReferenceMarkdown } = await import("../core/references/ReferenceStore.js");
+			vi.mocked(readReferenceMarkdown).mockImplementation(async (path: string) => {
+				if (path.includes("context7")) {
+					return {
+						mapKey: "context7:/vercel/next.js",
+						source: "context7",
+						nativeId: "/vercel/next.js",
+						title: "vercel/next.js",
+						url: "https://context7.com/vercel/next.js",
+						toolName: "mcp__context7__query-docs",
+						referencedAt: "2026-05-14T06:06:01.123Z",
+					};
+				}
+				if (path.includes("linear")) {
+					return {
+						mapKey: "linear:PROJ-1",
+						source: "linear",
+						nativeId: "PROJ-1",
+						title: "Linear issue",
+						url: "https://linear.app/x/PROJ-1",
+						toolName: "mcp__linear__get_issue",
+						referencedAt: "2026-05-14T06:06:02.123Z",
+					};
+				}
+				return null;
+			});
+
+			vi.mocked(getReferenceEntriesForBranch).mockResolvedValue([
+				{
+					source: "context7",
+					nativeId: "/vercel/next.js",
+					title: "vercel/next.js",
+					url: "https://context7.com/vercel/next.js",
+					sourcePath: "/test/cwd/.jolli/jollimemory/references/context7/vercel-next-js.md",
+					addedAt: "x",
+					updatedAt: "x",
+					sourceToolName: "mcp__context7__query-docs",
+				},
+				{
+					source: "linear",
+					nativeId: "PROJ-1",
+					title: "Linear issue",
+					url: "https://linear.app/x/PROJ-1",
+					sourcePath: "/test/cwd/.jolli/jollimemory/references/linear/PROJ-1.md",
+					addedAt: "x",
+					updatedAt: "x",
+					sourceToolName: "mcp__linear__get_issue",
+				},
+			]);
+
+			vi.mocked(assessContextRelevance).mockResolvedValueOnce({
+				plans: [],
+				notes: [],
+				references: [],
+				excludedContext,
+				results: [],
+			});
+
+			// Archival is a separate registry rescan — both refs are still active.
+			vi.mocked(detectUncommittedReferenceIds).mockResolvedValue([
+				{
+					mapKey: "context7:/vercel/next.js",
+					source: "context7",
+					sourcePath: "/test/cwd/.jolli/jollimemory/references/context7/vercel-next-js.md",
+				},
+				{
+					mapKey: "linear:PROJ-1",
+					source: "linear",
+					sourcePath: "/test/cwd/.jolli/jollimemory/references/linear/PROJ-1.md",
+				},
+			]);
+			vi.mocked(loadPlansRegistry).mockResolvedValue({
+				version: 1,
+				plans: {},
+				references: {
+					"context7:/vercel/next.js": {
+						source: "context7",
+						nativeId: "/vercel/next.js",
+						title: "vercel/next.js",
+						url: "https://context7.com/vercel/next.js",
+						sourcePath: "/test/cwd/.jolli/jollimemory/references/context7/vercel-next-js.md",
+						addedAt: "2026-04-01T00:00:00Z",
+						updatedAt: "2026-04-01T00:00:00Z",
+						sourceToolName: "mcp__context7__query-docs",
+					},
+					"linear:PROJ-1": {
+						source: "linear",
+						nativeId: "PROJ-1",
+						title: "Linear issue",
+						url: "https://linear.app/x/PROJ-1",
+						sourcePath: "/test/cwd/.jolli/jollimemory/references/linear/PROJ-1.md",
+						addedAt: "2026-04-01T00:00:00Z",
+						updatedAt: "2026-04-01T00:00:00Z",
+						sourceToolName: "mcp__linear__get_issue",
+					},
+				},
+			});
+		}
+
+		it("keeps a track-only (context7) reference out of the relevance input and always archived", async () => {
+			// Realistic verdict: the LLM can only exclude what it was given (linear).
+			await arrangeTwoRefs([
+				{ kind: "reference", key: "linear:PROJ-1", title: "Linear issue", reason: "unrelated", tier: "low" },
+			]);
+
+			await runWorker("/test/cwd");
+
+			// Input-split: context7 never reaches the relevance LLM (only linear does),
+			// so a relevance verdict can never auto-exclude it.
+			expect(assessContextRelevance).toHaveBeenCalledTimes(1);
+			const rawArg = vi.mocked(assessContextRelevance).mock.calls[0][0];
+			expect(rawArg.references).toEqual([expect.objectContaining({ source: "linear", nativeId: "PROJ-1" })]);
+
+			const savedSummary = vi.mocked(storeSummary).mock.calls[0][0];
+			const archivedSources = savedSummary.references?.map((r) => r.source) ?? [];
+			expect(archivedSources).toContain("context7"); // always archived
+			expect(archivedSources).not.toContain("linear"); // the LLM's linear exclusion is honored
+		});
+
+		it("still honors an EXPLICIT exclusion of a track-only reference (dropped from archival)", async () => {
+			// An explicit/persisted decision that lands context7 in excludedContext must
+			// be honored — a deliberately-excluded reference is not archived, even track-only.
+			await arrangeTwoRefs([
+				{
+					kind: "reference",
+					key: "context7:/vercel/next.js",
+					title: "vercel/next.js",
+					reason: "user excluded",
+					tier: "low",
+				},
+			]);
+
+			await runWorker("/test/cwd");
+
+			const savedSummary = vi.mocked(storeSummary).mock.calls[0][0];
+			const archivedSources = savedSummary.references?.map((r) => r.source) ?? [];
+			expect(archivedSources).not.toContain("context7"); // explicit exclusion honored
+			expect(archivedSources).toContain("linear"); // linear had no exclusion → archived
+		});
+	});
+
 	describe("Cursor integration", () => {
 		it("should include discovered Cursor sessions in the pipeline when enabled", async () => {
 			const op = makeCommitOp();

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -1530,6 +1530,7 @@ async function assembleReferenceBlocks(activeReferenceEntries: ReadonlyArray<Ref
 	}
 	const parts: string[] = [];
 	for (const def of getRegistry().all()) {
+		if (def.trackOnly === true) continue; // track-only sources never reach the memory-decision LLM
 		const refs = refsBySource.get(def.id) ?? [];
 		const block = renderBlock(def, refs);
 		if (block.length > 0) parts.push(block);
@@ -1590,7 +1591,15 @@ async function consumeWorkspaceContext(args: {
 		note: new Set<string>(),
 		reference: new Set<string>(),
 	};
-	for (const e of excludedContext) aiExcludedKeys[e.kind].add(e.key);
+	for (const e of excludedContext) {
+		// An explicit exclusion — whether a relevance verdict or a reused/persisted
+		// aiSelection decision — is always honored, including for track-only sources
+		// (context7): a reference the user deliberately excluded must not be archived
+		// with the commit memory. Track-only refs are kept OUT of the relevance LLM's
+		// input upstream, so a relevance verdict can never auto-exclude them here; any
+		// track-only key that does appear in `excludedContext` is a deliberate choice.
+		aiExcludedKeys[e.kind].add(e.key);
+	}
 
 	const planSlugs = await detectPlanSlugsFromRegistry(cwd, branch);
 	for (const excludedSlug of exclusions.plans) planSlugs.delete(excludedSlug);
@@ -1764,6 +1773,16 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 	const userKeptReferences = rawActiveReferenceEntries.filter(
 		(e) => !exclusions.references.has(`${e.source}:${e.nativeId}`),
 	);
+	// Track-only sources (e.g. context7) must be unconditionally tracked — never
+	// fed to the relevance LLM, so a verdict can never land them in excludedContext
+	// and get them dropped from archival. Split them out of the relevance input;
+	// they're spliced back into activeReferenceEntries below (both on success and
+	// on the fail-open catch, since `activeReferenceEntries` defaults to the full
+	// `userKeptReferences`, which already includes them).
+	const trackOnlyReferences = userKeptReferences.filter((e) => getRegistry().byId(e.source)?.trackOnly === true);
+	const relevanceCandidateReferences = userKeptReferences.filter(
+		(e) => getRegistry().byId(e.source)?.trackOnly !== true,
+	);
 
 	// AI relevance: rank the user-kept context against this change and soft-exclude
 	// clearly-unrelated items. Wrapped so ANY failure (git / content-read / LLM /
@@ -1779,7 +1798,7 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 	let contextRelevance: ReadonlyArray<ContextRelevanceRef> = [];
 	try {
 		const changeSignal = await buildChangeSignal(commitInfo.message, `${op.commitHash}~1`, op.commitHash, cwd);
-		const raw = { plans: userKeptPlans, notes: userKeptNotes, references: userKeptReferences };
+		const raw = { plans: userKeptPlans, notes: userKeptNotes, references: relevanceCandidateReferences };
 		// Reuse the pre-commit panel's full-text ranking when its change fingerprint
 		// matches (so the excluded set the user saw is exactly what lands, and we skip
 		// a redundant LLM call). Otherwise — panel not opened, or the change moved
@@ -1792,7 +1811,7 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 				: await assessContextRelevance(raw, changeSignal, config);
 		activePlanEntries = [...relevance.plans];
 		activeNoteEntries = [...relevance.notes];
-		activeReferenceEntries = [...relevance.references];
+		activeReferenceEntries = [...relevance.references, ...trackOnlyReferences];
 		excludedContext = relevance.excludedContext;
 		// Kept items' tier+reason for the summary artifact (a user-dismissed
 		// exclusion lands here with its ORIGINAL verdict attached). Empty when the
@@ -2879,6 +2898,13 @@ async function handleAmendPipeline(
 	const userKeptAmendRefs = rawAmendReferenceEntries.filter(
 		(e) => !amendExclusions.references.has(`${e.source}:${e.nativeId}`),
 	);
+	// Track-only sources (e.g. context7) must be unconditionally tracked — never fed
+	// to the relevance LLM, so a verdict can never land them in amendExcludedContext
+	// and get them dropped from archival. Mirrors executePipeline's split above.
+	const trackOnlyAmendRefs = userKeptAmendRefs.filter((e) => getRegistry().byId(e.source)?.trackOnly === true);
+	const relevanceCandidateAmendRefs = userKeptAmendRefs.filter(
+		(e) => getRegistry().byId(e.source)?.trackOnly !== true,
+	);
 	// AI relevance filtering, mirroring executePipeline's Stage 2 (wrapped so any
 	// git / content-read / LLM / parse failure falls back to the full user-kept set).
 	// assessContextRelevance is fail-open and unit-tested; this call site is amend-only,
@@ -2902,13 +2928,13 @@ async function handleAmendPipeline(
 			cwd,
 		);
 		const amendRelevance = await assessContextRelevance(
-			{ plans: userKeptAmendPlans, notes: userKeptAmendNotes, references: userKeptAmendRefs },
+			{ plans: userKeptAmendPlans, notes: userKeptAmendNotes, references: relevanceCandidateAmendRefs },
 			amendChangeSignal,
 			amendConfig,
 		);
 		amendPlanEntries = [...amendRelevance.plans];
 		amendNoteEntries = [...amendRelevance.notes];
-		amendReferenceEntries = [...amendRelevance.references];
+		amendReferenceEntries = [...amendRelevance.references, ...trackOnlyAmendRefs];
 		amendExcludedContext = amendRelevance.excludedContext;
 		// Kept items' tier+reason for the amend summary artifact (amend always
 		// re-ranks fresh, so results are always populated on success).
@@ -3746,6 +3772,7 @@ export const __test__ = {
 	buildHoistedAmendRoot,
 	consumeWorkspaceContext,
 	associatePlansWithCommit,
+	assembleReferenceBlocks,
 	finalizeReferenceArchive,
 	executePipeline,
 	handleAmendPipeline,

--- a/cli/src/hooks/StopHook.test.ts
+++ b/cli/src/hooks/StopHook.test.ts
@@ -12,6 +12,9 @@ vi.mock("../core/SessionTracker.js", () => ({
 	loadPlansRegistry: vi.fn().mockResolvedValue({ version: 1, plans: {} }),
 	savePlansRegistry: vi.fn().mockResolvedValue(undefined),
 	upsertReferenceEntry: vi.fn().mockResolvedValue(undefined),
+	// The discovery-ownership gate resolves the global run-hook launcher path via
+	// getGlobalConfigDir to check that the CLI hook it would defer to can run.
+	getGlobalConfigDir: vi.fn().mockReturnValue("/home/user/.jolli/jollimemory"),
 }));
 
 // Mock ReferenceExtractor — pure-function module called from StopHook.
@@ -30,6 +33,13 @@ vi.mock("../core/TelemetryStartup.js", () => ({
 // plans.json RMW body inline; the lock contract is covered in Locks.test.ts.
 vi.mock("../core/Locks.js", () => ({
 	withPlansLock: (_cwd: string | undefined, fn: () => Promise<unknown>) => fn(),
+}));
+
+// Mock ClaudeHookInstaller — the discovery-ownership gate calls
+// isClaudeHookInstalled to decide whether to defer transcript discovery to the
+// CLI/settings Stop hook when this process is the claude-plugin's Stop hook.
+vi.mock("../install/ClaudeHookInstaller.js", () => ({
+	isClaudeHookInstalled: vi.fn().mockResolvedValue(false),
 }));
 
 // Mock node:fs so we can control existsSync / readFileSync / createReadStream
@@ -76,12 +86,14 @@ import {
 	loadConfig,
 	loadDiscoveryCursor,
 	loadPlansRegistry,
+	migrateDiscoveryCursors,
 	saveDiscoveryCursor,
 	savePlansRegistry,
 	saveSession,
 	upsertReferenceEntry,
 } from "../core/SessionTracker.js";
 import { flushTelemetryNow } from "../core/TelemetryStartup.js";
+import { isClaudeHookInstalled } from "../install/ClaudeHookInstaller.js";
 import type { PlanEntry } from "../Types.js";
 import { withPlatform } from "../testUtils/withPlatform.js";
 import { handleStopHook } from "./StopHook.js";
@@ -204,6 +216,10 @@ describe("StopHook", () => {
 		vi.clearAllMocks();
 		process.env = { ...originalEnv };
 		process.env.CLAUDE_PROJECT_DIR = undefined;
+		// Default: not a plugin invocation, so the single-owner gate never probes the
+		// run-hook launcher — keeps plan tests that queue existsSync via
+		// mockReturnValueOnce deterministic. Gate tests set this explicitly.
+		process.env.CLAUDE_PLUGIN_ROOT = undefined;
 		// Default: transcript file does not exist → plan discovery exits early
 		vi.mocked(existsSync).mockReturnValue(false);
 		// Default: loadPlansRegistry returns empty registry
@@ -214,6 +230,88 @@ describe("StopHook", () => {
 
 	afterEach(() => {
 		process.env = originalEnv;
+	});
+
+	describe("plugin/CLI discovery ownership (single-owner gate)", () => {
+		// Both surfaces (the CLI/settings Stop hook and the claude-plugin Stop
+		// hook) fire on the same Stop event and share ONE merged
+		// discovery-cursors.json. The plugin hook is pinned to its bundled dist,
+		// while the CLI hook resolves the newest dist across every source
+		// (run-hook → resolve-dist-path). If the (potentially older) plugin hook
+		// runs discovery and advances the cursor past a tool_use it does not
+		// recognize — e.g. a source added after the plugin build, like context7 —
+		// the newer CLI hook, starting from that advanced cursor, never sees it
+		// and the reference is lost for good. So the plugin hook defers discovery
+		// to the CLI hook whenever one is installed. `migrateDiscoveryCursors` is
+		// the first call inside the discovery pass, so its (non-)invocation is the
+		// authoritative "discovery ran" signal.
+		it("defers discovery when invoked as the plugin hook AND the CLI Stop hook is installed", async () => {
+			vi.mocked(existsSync).mockReturnValue(true);
+			vi.mocked(isClaudeHookInstalled).mockResolvedValue(true);
+			process.env.CLAUDE_PLUGIN_ROOT = "/plugins/jolli";
+
+			mockStdin(hookJson());
+			await handleStopHook();
+
+			expect(migrateDiscoveryCursors).not.toHaveBeenCalled();
+			expect(extractReferencesFromTranscript).not.toHaveBeenCalled();
+			// session save + telemetry flush are surface-independent and still run
+			expect(saveSession).toHaveBeenCalled();
+			expect(flushTelemetryNow).toHaveBeenCalled();
+		});
+
+		it("runs discovery as the plugin hook when NO CLI Stop hook is installed (plugin-only install)", async () => {
+			vi.mocked(existsSync).mockReturnValue(true);
+			vi.mocked(isClaudeHookInstalled).mockResolvedValue(false);
+			process.env.CLAUDE_PLUGIN_ROOT = "/plugins/jolli";
+
+			mockStdin(hookJson());
+			await handleStopHook();
+
+			expect(migrateDiscoveryCursors).toHaveBeenCalled();
+		});
+
+		it("runs discovery for the CLI hook (CLAUDE_PLUGIN_ROOT unset) even when a CLI Stop hook is installed", async () => {
+			vi.mocked(existsSync).mockReturnValue(true);
+			vi.mocked(isClaudeHookInstalled).mockResolvedValue(true);
+			process.env.CLAUDE_PLUGIN_ROOT = undefined;
+
+			mockStdin(hookJson());
+			await handleStopHook();
+
+			expect(migrateDiscoveryCursors).toHaveBeenCalled();
+		});
+
+		it("runs discovery (does NOT defer) when the settings hook is stale but the run-hook launcher is missing", async () => {
+			// A stale `.claude/settings*.json` Stop hook entry can outlive the global
+			// `~/.jolli/jollimemory/run-hook` launcher it invokes (CLI uninstalled,
+			// folder wiped). Deferring to a launcher that no longer runs would leave
+			// NOBODY doing discovery — the exact stranding the gate exists to prevent.
+			// So when the launcher is absent, the plugin hook stays the fallback owner.
+			vi.mocked(isClaudeHookInstalled).mockResolvedValue(true);
+			process.env.CLAUDE_PLUGIN_ROOT = "/plugins/jolli";
+			// Transcript exists (discovery can proceed) but the run-hook launcher does not.
+			vi.mocked(existsSync).mockImplementation((p) => !String(p).includes("run-hook"));
+
+			mockStdin(hookJson());
+			await handleStopHook();
+
+			expect(migrateDiscoveryCursors).toHaveBeenCalled();
+		});
+
+		it("treats an empty CLAUDE_PLUGIN_ROOT as NOT a plugin invocation (runs discovery)", async () => {
+			// A truthy check, not `!== undefined`: an empty value is not a real
+			// plugin root, so the hook must still own discovery rather than defer
+			// to a CLI hook that may not exist.
+			vi.mocked(existsSync).mockReturnValue(true);
+			vi.mocked(isClaudeHookInstalled).mockResolvedValue(true);
+			process.env.CLAUDE_PLUGIN_ROOT = "";
+
+			mockStdin(hookJson());
+			await handleStopHook();
+
+			expect(migrateDiscoveryCursors).toHaveBeenCalled();
+		});
 	});
 
 	it("should no-op when spawned by the local-agent backend (re-entry guard)", async () => {

--- a/cli/src/hooks/StopHook.ts
+++ b/cli/src/hooks/StopHook.ts
@@ -26,12 +26,13 @@
  */
 
 import { existsSync } from "node:fs";
-import { resolve as pathResolve } from "node:path";
+import { join, resolve as pathResolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isLocalAgentChild } from "../core/AgentReentry.js";
 import { scanPlansFrom } from "../core/plans/TranscriptPlanDiscovery.js";
 import { scanReferencesFrom } from "../core/references/TranscriptReferenceDiscovery.js";
 import {
+	getGlobalConfigDir,
 	loadConfig,
 	loadDiscoveryCursor,
 	migrateDiscoveryCursors,
@@ -39,6 +40,7 @@ import {
 	saveSession,
 } from "../core/SessionTracker.js";
 import { flushTelemetryNow } from "../core/TelemetryStartup.js";
+import { isClaudeHookInstalled } from "../install/ClaudeHookInstaller.js";
 import { createLogger, setLogDir } from "../Logger.js";
 import type { ClaudeHookInput, SessionInfo } from "../Types.js";
 import { readStdin } from "./HookUtils.js";
@@ -135,7 +137,63 @@ export async function handleStopHook(): Promise<void> {
 	// one discovery-cursors.json line per transcript. Each inner scan swallows
 	// its own errors so one failing discovery never blocks the other or the
 	// cursor advance.
-	await discoverFromTranscript(sessionInfo, projectDir);
+	//
+	// Single-owner gate. When both the CLI/settings Stop hook and the
+	// claude-plugin Stop hook are enabled on a repo, Claude Code fires BOTH on
+	// every Stop event and they share ONE merged discovery-cursors.json. The
+	// plugin hook is pinned to its bundled `${CLAUDE_PLUGIN_ROOT}/dist`, while the
+	// CLI hook resolves the newest dist across every source (run-hook →
+	// resolve-dist-path). If the (possibly older) plugin hook wins the race and
+	// advances the cursor past a tool_use it doesn't recognize — a source added
+	// after the plugin build, e.g. context7 — the newer CLI hook starts from that
+	// advanced cursor, never re-reads those lines (the cursor only moves forward),
+	// and the reference is lost for good. So the plugin-invoked hook defers
+	// discovery to the CLI hook whenever one is installed; a plugin-only install
+	// (no CLI Stop hook) still runs discovery itself. Session save + telemetry
+	// flush are surface-independent and always run.
+	//
+	// Discriminator — CLAUDE_PLUGIN_ROOT: Claude Code sets it in the environment
+	// of a plugin-provided hook's process, and ONLY there (it is not
+	// session-global — verified: absent from the parent Claude Code process env).
+	// That scoping is what makes the gate safe from a zero-runner deadlock: the
+	// CLI/settings hook never sees the var, so it never defers, so at least one
+	// hook always runs discovery. A truthy check (not `!== undefined`) so an empty
+	// value is never mistaken for a plugin invocation, matching how `envProjectDir`
+	// is tested above.
+	//
+	// `isClaudeHookInstalled` reads the repo's `.claude/settings*.json`. The plugin
+	// registers its own Stop hook in the plugin package's `hooks/hooks.json`, never
+	// in repo settings, so it can't false-positive here as "the CLI hook". (It
+	// matches both the `run-hook` and legacy `StopHook` command markers — both are
+	// CLI-install forms.) And this gate degrades gracefully: even if the
+	// discriminator ever failed and both hooks ran, the rebuilt plugin dist now
+	// understands every source, so a double scan would still extract correctly
+	// rather than strand a reference — the gate removes the wasted work and the
+	// cross-version race, it is not the sole line of defense.
+	//
+	// Runner liveness: the settings entry alone is NOT proof that the CLI hook can
+	// actually run. A stale `.claude/settings*.json` hook can outlive the global
+	// `~/.jolli/jollimemory/run-hook` launcher it invokes (CLI uninstalled, folder
+	// wiped) — every CLI-install Stop hook, current or legacy, shells out through
+	// that one launcher. Deferring to a launcher that no longer exists would leave
+	// NOBODY running discovery, silently stopping plan/reference updates. So we only
+	// defer when the launcher is present on disk; if it is gone, the plugin stays the
+	// fallback owner and runs discovery itself. (Running when we could have deferred
+	// is safe — at worst a redundant idempotent scan; deferring to a dead runner is
+	// not.)
+	const isPluginInvocation = Boolean(process.env.CLAUDE_PLUGIN_ROOT);
+	// Short-circuit order matters: cheap env check → sync launcher probe → async
+	// settings read. Only a plugin invocation ever probes the launcher, so a
+	// normal CLI-hook run pays nothing extra.
+	const deferToCliHook =
+		isPluginInvocation &&
+		existsSync(join(getGlobalConfigDir(), "run-hook")) &&
+		(await isClaudeHookInstalled(projectDir));
+	if (deferToCliHook) {
+		log.info("Plugin Stop hook: a CLI Stop hook owns transcript discovery — deferring to it");
+	} else {
+		await discoverFromTranscript(sessionInfo, projectDir);
+	}
 
 	// JOLLI-1954: the Stop hook fires on every agent turn end — far more often
 	// than commits — so piggyback it to drain the shared telemetry buffer. Covers

--- a/docs/superpowers/plans/2026-07-22-context7-tracking.md
+++ b/docs/superpowers/plans/2026-07-22-context7-tracking.md
@@ -1,0 +1,665 @@
+# context7 reference tracking (track-only) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add context7 as a track-only reference source so jollimemory records which libraries were consulted (`query-docs libraryId`) per commit, surfaced in every reference listing but never fed to the memory-decision LLM.
+
+**Architecture:** context7 becomes the 11th `SourceDefinition` in the reference-extraction subsystem. It is *arguments-derived* (its reference is built from the tool-call arguments; the result is markdown prose, so both transcript parsers gain one guarded `argumentsDerived` branch) and *track-only* (a new `SourceDefinition.trackOnly` flag; the two functions that build the `{{references}}` LLM block skip such sources). Everything else — discovery, `plans.json` registry, archival into `CommitSummary.references`, detail-page/PR/push/timeline rendering — treats it as an ordinary reference.
+
+**Tech Stack:** TypeScript (ESM, Node 22.5+), Vitest, Biome. CLI workspace `@jolli.ai/cli`.
+
+## Global Constraints
+
+- DCO sign-off on the final commit: `git commit -s`. No `Co-Authored-By: Claude` / `🤖 Generated with` trailers.
+- `npm run all` must pass before the (single) commit — clean → build → lint → test.
+- CLI coverage floor: 97% statements / 96% branches / 97% functions / 97% lines (`cli/vite.config.ts`). New code must not regress it.
+- Biome: tabs, 4-wide, 120 columns; `noExplicitAny: error`, `noUnusedImports/Variables: error`. `npm run lint` runs `biome check --error-on-warnings`.
+- Use `toForwardSlash` for any `\`→`/` normalization (not relevant here, but never inline the replace).
+- **Project workflow override (per user preference):** do NOT commit or run `npm run all` per task. Each task writes test + implementation code only. The FINAL task runs `npm run all` once and makes one commit.
+- Keep the three API-key parser implementations in lockstep — not touched by this plan.
+
+## File Structure
+
+**New files (cli):**
+- `cli/src/core/references/sources/definitions/context7.ts` — the `SourceDefinition`.
+- `cli/src/core/references/sources/definitions/context7.test.ts` — definition + `extractRef` behavior.
+- `cli/src/core/references/sources/Context7Normalize.ts` — arguments→`{libraryId, query}` reshaper.
+- `cli/src/core/references/sources/Context7Normalize.test.ts` — normalizer unit tests.
+- `cli/src/core/references/bindings/codex/CodexContext7Binding.ts` — Codex binding.
+
+**Modified files (cli):**
+- `cli/src/core/references/SourceDefinition.ts` — add `trackOnly?` + `argumentsDerived?`.
+- `cli/src/core/references/sources/definitions/index.ts` — register in `BUILTIN_DEFINITIONS`.
+- `cli/src/core/references/ClaudeEnvelopeParser.ts` — register normalizer + `argumentsDerived` parse-fail branch.
+- `cli/src/core/references/CodexEnvelopeParser.ts` — `argumentsDerived` fallback branch.
+- `cli/src/core/references/bindings/codex/index.ts` — register `context7CodexBinding`.
+- `cli/src/Types.ts` — add `"context7"` to `KnownSourceId`.
+- `cli/src/hooks/QueueWorker.ts` — `assembleReferenceBlocks` skips track-only defs.
+- `cli/src/core/Regenerator.ts` — `rebuildReferenceBlocks` skips track-only defs.
+- `cli/src/core/references/SourceDefinitionRegistry.test.ts` — update stable-order id list.
+- `cli/src/core/references/ClaudeEnvelopeParser.test.ts` — real Claude fixture.
+- `cli/src/core/references/CodexEnvelopeParser.test.ts` — real Codex fixture.
+
+**Modified files (vscode):**
+- `vscode/src/views/SourceLabels.ts` — `SOURCE_META` entry.
+
+**Design decision — no `isTrackOnlySource` helper.** Both filter points iterate `getRegistry().all()` and already hold the `def`, so an inline `def.trackOnly === true` check is used. This supersedes the spec's mention of a registry helper (YAGNI — no call site has only a source-id string).
+
+---
+
+### Task 1: Add `trackOnly` + `argumentsDerived` flags to SourceDefinition
+
+**Files:**
+- Modify: `cli/src/core/references/SourceDefinition.ts` (interface `SourceDefinition`, lines 73-95)
+
+**Interfaces:**
+- Produces: `SourceDefinition.trackOnly?: boolean` and `SourceDefinition.argumentsDerived?: boolean` — read by the parsers (Tasks 3, 4) and the block-builder filters (Task 5).
+
+- [ ] **Step 1: Add the two optional fields to the `SourceDefinition` interface**
+
+In `cli/src/core/references/SourceDefinition.ts`, inside `export interface SourceDefinition`, after the `icon: string;` line, add:
+
+```ts
+	/**
+	 * Track-only: the reference is captured, archived into CommitSummary.references,
+	 * and shown in every reference listing (detail page, PR, push, timeline), but is
+	 * EXCLUDED from the {{references}} block fed to the memory-decision LLM. Absent
+	 * (falsy) for every existing source.
+	 */
+	readonly trackOnly?: boolean;
+	/**
+	 * Arguments-derived: the reference is built from the tool-call arguments, not the
+	 * result, so a non-JSON (prose) result is expected. Both transcript parsers pass an
+	 * empty payload to this source's normalizer on JSON-parse failure instead of
+	 * dropping the call. Absent (falsy) for every existing (JSON-result) source.
+	 */
+	readonly argumentsDerived?: boolean;
+```
+
+No test in this task — the flags are exercised by Tasks 2-5. `validateDefinition` accepts unknown/extra fields, so no validator change is needed.
+
+---
+
+### Task 2: context7 SourceDefinition + normalizer + all registrations
+
+**Files:**
+- Create: `cli/src/core/references/sources/Context7Normalize.ts`
+- Create: `cli/src/core/references/sources/Context7Normalize.test.ts`
+- Create: `cli/src/core/references/sources/definitions/context7.ts`
+- Create: `cli/src/core/references/sources/definitions/context7.test.ts`
+- Modify: `cli/src/core/references/sources/definitions/index.ts`
+- Modify: `cli/src/Types.ts` (`KnownSourceId`, lines 799-809)
+- Modify: `vscode/src/views/SourceLabels.ts` (`SOURCE_META`, lines 40-51)
+- Modify: `cli/src/core/references/SourceDefinitionRegistry.test.ts` (stable-order test, lines 46-63)
+
+**Interfaces:**
+- Consumes: `SourceDefinition`, `trackOnly`/`argumentsDerived` (Task 1).
+- Produces: `context7Definition: SourceDefinition`; `normalizeContext7(toolInput: unknown): { libraryId: string; query?: string } | null`.
+
+- [ ] **Step 1: Write the normalizer unit test**
+
+Create `cli/src/core/references/sources/Context7Normalize.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { normalizeContext7 } from "./Context7Normalize.js";
+
+describe("normalizeContext7", () => {
+	it("builds { libraryId, query } from the query-docs arguments", () => {
+		expect(normalizeContext7({ libraryId: "/vercel/next.js", query: "middleware" })).toEqual({
+			libraryId: "/vercel/next.js",
+			query: "middleware",
+		});
+	});
+
+	it("omits query when absent or empty", () => {
+		expect(normalizeContext7({ libraryId: "/vercel/next.js" })).toEqual({ libraryId: "/vercel/next.js" });
+		expect(normalizeContext7({ libraryId: "/vercel/next.js", query: "" })).toEqual({ libraryId: "/vercel/next.js" });
+	});
+
+	it("returns null when libraryId is missing or non-string", () => {
+		expect(normalizeContext7({ query: "middleware" })).toBeNull();
+		expect(normalizeContext7({ libraryId: 42 })).toBeNull();
+		expect(normalizeContext7("not-an-object")).toBeNull();
+		expect(normalizeContext7(undefined)).toBeNull();
+	});
+});
+```
+
+- [ ] **Step 2: Write the normalizer implementation**
+
+Create `cli/src/core/references/sources/Context7Normalize.ts`:
+
+```ts
+/**
+ * context7 is an arguments-derived source: the referenced library (`libraryId`,
+ * e.g. `/vercel/next.js`) and the topic (`query`) live in the `query-docs` tool
+ * ARGUMENTS. The result is markdown prose and is ignored. This reshaper turns the
+ * tool input into the flat object the `context7Definition` reads via `path` ops,
+ * and is shared by both the Claude context-normalizer and the Codex binding.
+ */
+import { isObject } from "../guards.js";
+
+function readString(v: unknown): string | undefined {
+	return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+/** Build the context7 reference shape from the query-docs arguments. Returns null
+ *  (voiding the reference) when `libraryId` is absent/non-string. A malformed-but-
+ *  present id is left for the definition's `require` regex to void. */
+export function normalizeContext7(toolInput: unknown): { libraryId: string; query?: string } | null {
+	if (!isObject(toolInput)) return null;
+	const libraryId = readString(toolInput.libraryId);
+	if (libraryId === undefined) return null;
+	const query = readString(toolInput.query);
+	return { libraryId, ...(query !== undefined ? { query } : {}) };
+}
+```
+
+- [ ] **Step 3: Write the definition test**
+
+Create `cli/src/core/references/sources/definitions/context7.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { extractRef } from "../../SourceEngine.js";
+import { context7Definition } from "./context7.js";
+
+const AT = "2026-07-22T08:00:00.000Z";
+
+describe("context7Definition", () => {
+	it("is track-only and arguments-derived", () => {
+		expect(context7Definition.trackOnly).toBe(true);
+		expect(context7Definition.argumentsDerived).toBe(true);
+	});
+
+	it("extracts a per-library reference from the normalized arguments payload", () => {
+		const ref = extractRef(
+			context7Definition,
+			{ libraryId: "/vercel/next.js", query: "how does middleware work" },
+			"mcp__context7__query-docs",
+			AT,
+		);
+		expect(ref).not.toBeNull();
+		expect(ref?.source).toBe("context7");
+		expect(ref?.nativeId).toBe("/vercel/next.js");
+		expect(ref?.title).toBe("vercel/next.js");
+		expect(ref?.url).toBe("https://context7.com/vercel/next.js");
+		expect(ref?.description).toBe("how does middleware work");
+		expect(ref?.mapKey).toBe("context7:/vercel/next.js");
+	});
+
+	it("voids the reference when libraryId is not org/project shaped", () => {
+		expect(extractRef(context7Definition, { libraryId: "next.js" }, "mcp__context7__query-docs", AT)).toBeNull();
+		expect(extractRef(context7Definition, { libraryId: "/vercel" }, "mcp__context7__query-docs", AT)).toBeNull();
+	});
+
+	it("keeps the reference when query is absent (description optional)", () => {
+		const ref = extractRef(context7Definition, { libraryId: "/mongodb/docs" }, "mcp__context7__query-docs", AT);
+		expect(ref?.nativeId).toBe("/mongodb/docs");
+		expect(ref?.description).toBeUndefined();
+	});
+});
+```
+
+- [ ] **Step 4: Write the definition**
+
+Create `cli/src/core/references/sources/definitions/context7.ts`:
+
+```ts
+import type { SourceDefinition } from "../../SourceDefinition.js";
+
+// A Context7-compatible library id is `/org/project` (optionally `/org/project/version`).
+const LIBRARY_ID = "^/[^/\\s]+/[^/\\s]+";
+
+/**
+ * context7 (`@upstash/context7-mcp`) — track-only documentation references.
+ * Only the current `query-docs` tool is matched (legacy `get-library-docs` uses a
+ * different arg name and is out of scope). The reference is built from the ARGUMENTS
+ * (`libraryId`, `query`) via `Context7Normalize`; the markdown result is ignored,
+ * which is why `argumentsDerived` is set. `trackOnly` keeps it out of the LLM block.
+ */
+export const context7Definition: SourceDefinition = {
+	id: "context7",
+	label: "Context7",
+	icon: "book",
+	trackOnly: true,
+	argumentsDerived: true,
+	match: {
+		claude: { prefixes: ["mcp__context7__"], acceptSuffix: "query-docs" },
+		codex: {
+			namespaceSuffix: "context7",
+			functionCallNames: ["_query_docs"],
+			invocationTools: ["query-docs", "context7.query-docs"],
+		},
+	},
+	wrapperKeys: [],
+	reference: {
+		nativeId: { pipe: [{ op: "path", path: "libraryId" }], require: LIBRARY_ID },
+		title: {
+			pipe: [
+				{ op: "path", path: "libraryId" },
+				{ op: "regex", pattern: "^/(.+)$", extract: "$1" },
+			],
+			require: ".+",
+		},
+		url: {
+			pipe: [
+				{
+					op: "template",
+					template: "https://context7.com{id}",
+					from: { id: [{ op: "path", path: "libraryId" }] },
+				},
+			],
+			require: "^https://context7\\.com/",
+		},
+		description: { pipe: [{ op: "path", path: "query" }], optional: true },
+	},
+	fields: [],
+	storage: { nativeIdPathSafe: false },
+	render: {
+		wrapperTag: "context7-libraries",
+		itemTag: "library",
+		bodyTag: "content",
+		maxCharsPerReference: 2000,
+		maxTotalChars: 8000,
+	},
+};
+```
+
+- [ ] **Step 5: Register in `BUILTIN_DEFINITIONS`**
+
+In `cli/src/core/references/sources/definitions/index.ts`, add the import (alphabetical with the others) and append to the array (order is unconstrained — the `mcp__context7__` prefix is unique):
+
+```ts
+import { context7Definition } from "./context7.js";
+```
+
+Then add `context7Definition,` as the last entry of the `BUILTIN_DEFINITIONS` array (after `mondayDefinition,`).
+
+- [ ] **Step 6: Add `"context7"` to `KnownSourceId`**
+
+In `cli/src/Types.ts`, in the `KnownSourceId` union (lines 799-809), add `| "context7"` as the last member (after `| "monday"`).
+
+- [ ] **Step 7: Add the `SOURCE_META` entry**
+
+In `vscode/src/views/SourceLabels.ts`, add to the `SOURCE_META` object (it is typed `Record<KnownSourceId, SourceMeta>`, so this is required to compile after Step 6):
+
+```ts
+	context7: { label: "Context7", letter: "7", icon: "book", color: "#0b7285" },
+```
+
+- [ ] **Step 8: Update the stable-order test**
+
+In `cli/src/core/references/SourceDefinitionRegistry.test.ts`, update the `it("all() is stable order …")` test: append `"context7"` to the expected array (after `"monday"`) and update the test title to include `,context7`.
+
+---
+
+### Task 3: Claude parser — register normalizer + argumentsDerived branch
+
+**Files:**
+- Modify: `cli/src/core/references/ClaudeEnvelopeParser.ts` (CONTEXT_NORMALIZERS ~274-300; parse-fail catch ~344-372)
+- Test: `cli/src/core/references/ClaudeEnvelopeParser.test.ts`
+
+**Interfaces:**
+- Consumes: `normalizeContext7` (Task 2), `SourceDefinition.argumentsDerived` (Task 1).
+
+- [ ] **Step 1: Write the Claude parser fixture test**
+
+Add to `cli/src/core/references/ClaudeEnvelopeParser.test.ts` (follow the existing `tool_use`/`tool_result` builder style in that file; the `text` below is a trimmed slice of the real captured `query-docs` markdown result — prose, NOT JSON):
+
+```ts
+describe("context7 (arguments-derived, prose result)", () => {
+	it("extracts one reference from a query-docs call whose result is markdown", () => {
+		const lines = [
+			JSON.stringify({
+				type: "assistant",
+				message: {
+					role: "assistant",
+					content: [
+						{
+							type: "tool_use",
+							id: "c7a",
+							name: "mcp__context7__query-docs",
+							input: { libraryId: "/vercel/next.js", query: "how does middleware work in the app router" },
+						},
+					],
+				},
+			}),
+			JSON.stringify({
+				type: "user",
+				message: {
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "c7a",
+							content: "### Real-world middleware example\n\nSource: https://github.com/vercel/next.js/blob/canary/examples/i18n-routing/middleware.ts\n\nA complete middleware.ts example…",
+						},
+					],
+				},
+			}),
+		];
+		const { results } = claudeEnvelopeParser.parse(lines, {});
+		expect(results).toHaveLength(1);
+		expect(results[0].def.id).toBe("context7");
+		expect(results[0].payload).toEqual({
+			libraryId: "/vercel/next.js",
+			query: "how does middleware work in the app router",
+		});
+	});
+
+	it("ignores resolve-library-id calls", () => {
+		const lines = [
+			JSON.stringify({
+				type: "assistant",
+				message: {
+					role: "assistant",
+					content: [
+						{
+							type: "tool_use",
+							id: "c7r",
+							name: "mcp__context7__resolve-library-id",
+							input: { libraryName: "Next.js", query: "middleware" },
+						},
+					],
+				},
+			}),
+			JSON.stringify({
+				type: "user",
+				message: {
+					role: "user",
+					content: [{ type: "tool_result", tool_use_id: "c7r", content: "Available Libraries:\n- /vercel/next.js" }],
+				},
+			}),
+		];
+		expect(claudeEnvelopeParser.parse(lines, {}).results).toHaveLength(0);
+	});
+});
+```
+
+(If the file's builders differ in envelope key names, match the file's existing helpers exactly — the two message shapes above mirror the real Claude transcript: an `assistant` message with a `tool_use` block and a `user` message with a `tool_result` block paired by `tool_use_id`.)
+
+- [ ] **Step 2: Register the context7 context-normalizer**
+
+In `cli/src/core/references/ClaudeEnvelopeParser.ts`, add the import near the other `sources/*Normalize` imports:
+
+```ts
+import { normalizeContext7 } from "./sources/Context7Normalize.js";
+```
+
+Then add an entry to the `CONTEXT_NORMALIZERS` object (it ignores the prose `payload` and reads the retained `toolInput`):
+
+```ts
+	context7: (_payload, toolInput) => normalizeContext7(toolInput),
+```
+
+(`CONTEXT_NORMALIZER_IDS` is derived from `Object.keys(CONTEXT_NORMALIZERS)`, so context7's `toolInput` is automatically retained at the tool_use collection site.)
+
+- [ ] **Step 3: Add the argumentsDerived parse-fail branch**
+
+In `cli/src/core/references/ClaudeEnvelopeParser.ts`, the JSON-parse catch currently drops the entry when offload-recovery fails. Change the `if (recovered === undefined) { … }` block (≈ lines 353-371) to keep arguments-derived sources alive with an empty payload:
+
+```ts
+			const recovered = recoverOffloadedPayload(payloadText);
+			if (recovered === undefined) {
+				// An arguments-derived source (context7) returns prose, not JSON — its
+				// reference is built from the retained toolInput, so an unparseable result
+				// is expected. Give the normalizer an empty payload instead of dropping.
+				if (pendingEntry.def.argumentsDerived === true) {
+					parsedPayload = {};
+				} else {
+					log.warn(
+						"Dropping tool_result for %s (%s): payload JSON.parse failed: %s | preview=%s",
+						b.tool_use_id,
+						pendingEntry.toolName,
+						(err as Error).message,
+						payloadText.slice(0, 200),
+					);
+					pending.delete(b.tool_use_id);
+					continue;
+				}
+			} else {
+				log.info(
+					"Recovered offloaded tool_result for %s (%s) from %s",
+					b.tool_use_id,
+					pendingEntry.toolName,
+					recovered.path,
+				);
+				parsedPayload = recovered.payload;
+			}
+```
+
+(This replaces the existing early-`continue` shape; the `log.info` + `parsedPayload = recovered.payload` move into the `else`. Behavior for every non-arguments-derived source is byte-identical.)
+
+---
+
+### Task 4: Codex binding + parser argumentsDerived fallback branch
+
+**Files:**
+- Create: `cli/src/core/references/bindings/codex/CodexContext7Binding.ts`
+- Modify: `cli/src/core/references/bindings/codex/index.ts`
+- Modify: `cli/src/core/references/CodexEnvelopeParser.ts` (fallback ~283-284)
+- Test: `cli/src/core/references/CodexEnvelopeParser.test.ts`
+
+**Interfaces:**
+- Consumes: `normalizeContext7` (Task 2), `CodexNormalizer` interface, `SourceDefinition.argumentsDerived` (Task 1).
+- Produces: `context7CodexBinding: CodexNormalizer`.
+
+- [ ] **Step 1: Write the Codex binding**
+
+Create `cli/src/core/references/bindings/codex/CodexContext7Binding.ts`:
+
+```ts
+import { normalizeContext7 } from "../../sources/Context7Normalize.js";
+import type { CodexNormalizer } from "./CodexBinding.js";
+
+/**
+ * Local-MCP context7 calls match via the FALLBACK path (mcp_tool_call_end,
+ * invocation.tool = "query-docs", invocation.arguments carries libraryId); the
+ * codex_apps connector variant matches via PRIMARY. Either way the business
+ * payload is ignored — the reference is built from the arguments.
+ */
+export const context7CodexBinding: CodexNormalizer = {
+	id: "context7",
+	canonicalToolName: "mcp__context7__query-docs",
+	normalize: (_business, toolInput) => normalizeContext7(toolInput),
+};
+```
+
+- [ ] **Step 2: Register the binding**
+
+In `cli/src/core/references/bindings/codex/index.ts`, add the import and append `context7CodexBinding,` to the `CODEX_NORMALIZERS` array:
+
+```ts
+import { context7CodexBinding } from "./CodexContext7Binding.js";
+```
+
+- [ ] **Step 3: Write the Codex parser fixture test**
+
+Add to `cli/src/core/references/CodexEnvelopeParser.test.ts` (mirrors the real local-MCP rollout: no `mcp__codex_apps__` namespace, so the `mcp_tool_call_end` event drives the match; `result.Ok.content[0].text` is prose, `invocation.arguments` carries `libraryId`):
+
+```ts
+describe("context7 local MCP (fallback path, prose result)", () => {
+	it("extracts one reference from a query-docs mcp_tool_call_end event", () => {
+		const lines = [
+			JSON.stringify({
+				timestamp: "2026-07-22T08:18:30.000Z",
+				type: "event_msg",
+				payload: {
+					type: "mcp_tool_call_end",
+					call_id: "callc7",
+					invocation: {
+						server: "context7",
+						tool: "query-docs",
+						arguments: { libraryId: "/vercel/next.js", query: "middleware in the app router" },
+					},
+					result: { Ok: { content: [{ type: "text", text: "### Middleware\n\nSource: https://github.com/vercel/next.js/…" }] } },
+				},
+			}),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results).toHaveLength(1);
+		expect(results[0].def.id).toBe("context7");
+		expect(results[0].payload).toEqual({ libraryId: "/vercel/next.js", query: "middleware in the app router" });
+	});
+
+	it("ignores resolve-library-id events", () => {
+		const lines = [
+			JSON.stringify({
+				timestamp: "2026-07-22T08:18:29.000Z",
+				type: "event_msg",
+				payload: {
+					type: "mcp_tool_call_end",
+					call_id: "callr",
+					invocation: { server: "context7", tool: "resolve-library-id", arguments: { libraryName: "Next.js" } },
+					result: { Ok: { content: [{ type: "text", text: "Available Libraries:\n- /vercel/next.js" }] } },
+				},
+			}),
+		];
+		expect(codexEnvelopeParser.parse(lines, {}).results).toHaveLength(0);
+	});
+});
+```
+
+- [ ] **Step 4: Add the argumentsDerived fallback branch**
+
+In `cli/src/core/references/CodexEnvelopeParser.ts`, the FALLBACK loop currently drops any event whose `ev.text` is not JSON. Change (≈ lines 283-284):
+
+```ts
+			let business = tryParse(ev.text);
+			if (business === null) continue;
+```
+
+to:
+
+```ts
+			let business = tryParse(ev.text);
+			if (business === null) {
+				// An arguments-derived source (context7) returns prose, not JSON. Its
+				// reference is built from invocation.arguments below, so an unparseable
+				// event text is expected — give the normalizer an empty business object
+				// instead of dropping the event. Every JSON-result source is unaffected.
+				if (def.argumentsDerived !== true) continue;
+				business = {};
+			}
+```
+
+`def` is already in scope (from `registry.match("codex", ev.tool)` above). The `recover` step is skipped for context7 (no `recover` on its binding), and `toolInput` resolves to `ev.arguments` (which carries `libraryId`).
+
+---
+
+### Task 5: Exclude track-only sources from the LLM reference block
+
+**Files:**
+- Modify: `cli/src/hooks/QueueWorker.ts` (`assembleReferenceBlocks`, ~1518-1536)
+- Modify: `cli/src/core/Regenerator.ts` (`rebuildReferenceBlocks`, `for (const def of getRegistry().all())` loop)
+- Test: add to an existing suite for each (`QueueWorker.*.test.ts` and `Regenerator.test.ts`) — see steps.
+
+**Interfaces:**
+- Consumes: `SourceDefinition.trackOnly` (Task 1), `context7Definition` (Task 2).
+
+- [ ] **Step 1: Write the live-pipeline filter test**
+
+Add a test near the existing `assembleReferenceBlocks` coverage (same test file that already imports it, or a new `QueueWorker.references.test.ts` following that file's setup). Assert that a context7 registry entry is excluded from the assembled block while a non-track-only source is included. Use the exported `assembleReferenceBlocks` (export it if it is currently module-private — see Step 3) and the reference-markdown writer the other tests use. Minimal shape:
+
+```ts
+it("omits track-only (context7) references from the LLM block", async () => {
+	// Arrange: write a context7 reference markdown + a notion reference markdown to
+	// a temp plans dir, build ReferenceEntry rows for both (reuse the file's helper).
+	// Act:
+	const block = await assembleReferenceBlocks([notionEntry, context7Entry]);
+	// Assert:
+	expect(block).toContain("notion-pages"); // non-track-only present
+	expect(block).not.toContain("context7-libraries"); // track-only excluded
+});
+```
+
+(Model the entry/markdown setup on the existing reference tests in that file. The assertion that matters is `not.toContain` the context7 wrapper tag.)
+
+- [ ] **Step 2: Write the regeneration filter test**
+
+Add to `cli/src/core/Regenerator.test.ts` a case where a `CommitSummary.references` array contains a context7 `ReferenceCommitRef` plus a non-track-only one, and assert the rebuilt reference block excludes the context7 wrapper tag but includes the other. Follow the file's existing `rebuildReferenceBlocks`/regeneration harness.
+
+- [ ] **Step 3: Filter in `assembleReferenceBlocks`**
+
+In `cli/src/hooks/QueueWorker.ts`, inside `assembleReferenceBlocks`, add the guard as the first line of the `for (const def of getRegistry().all())` loop:
+
+```ts
+	for (const def of getRegistry().all()) {
+		if (def.trackOnly === true) continue; // track-only sources never reach the memory-decision LLM
+		const refs = refsBySource.get(def.id) ?? [];
+		const block = renderBlock(def, refs);
+		if (block.length > 0) parts.push(block);
+	}
+```
+
+If `assembleReferenceBlocks` is not currently exported, add `export` so the Step 1 test can import it (it is a module-level `async function` in QueueWorker.ts).
+
+- [ ] **Step 4: Filter in `rebuildReferenceBlocks`**
+
+In `cli/src/core/Regenerator.ts`, inside `rebuildReferenceBlocks`, add the same guard as the first line of its `for (const def of getRegistry().all())` loop:
+
+```ts
+	for (const def of getRegistry().all()) {
+		if (def.trackOnly === true) continue; // track-only sources never reach the regeneration LLM
+		const sourceRefs = bySource.get(def.id);
+		if (!sourceRefs || sourceRefs.length === 0) continue;
+		const block = renderBlock(def, sourceRefs);
+		// … existing block-push logic unchanged …
+	}
+```
+
+Note: context7 refs are still read and grouped into `bySource` (so archival/other reads are untouched); only the LLM block-emit loop skips them.
+
+---
+
+### Task 6: Verify and commit (single, final)
+
+- [ ] **Step 1: Run the full gate**
+
+Run: `npm run all`
+Expected: clean → build → lint → test all pass; CLI coverage ≥ 97/96/97/97. Fix any coverage gaps by extending the Task 2-5 tests (e.g. ensure both parser `argumentsDerived` branches and both `trackOnly` filter branches are hit).
+
+- [ ] **Step 2: Replace the scratchpad fixtures with in-repo ones (if not already inlined)**
+
+The real captured envelopes live in the session scratchpad (`context7-fixtures/`). Confirm the Task 3/4 tests inline the real shapes (they do); no scratchpad file is referenced by committed code. Scrub check: `git grep -n "ctx7sk-"` must return nothing.
+
+Run: `git grep -n "ctx7sk-" -- 'cli/**' 'vscode/**'`
+Expected: no output (no API key committed).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A cli/src vscode/src
+git commit -s -m "feat(references): track context7 library lookups (track-only)
+
+Add context7 as an arguments-derived, track-only reference source. It
+records which libraries were consulted via query-docs (libraryId) per
+commit and surfaces them in every reference listing, but is excluded
+from the memory-decision LLM. Both transcript parsers gain a guarded
+argumentsDerived branch so context7's prose result reaches the
+arguments-only normalizer; local-MCP context7 on Codex matches via the
+mcp_tool_call_end fallback path."
+```
+
+(If the worktree index is clobbered by a plugin — `invalid object … Error building trees` — run `git read-tree HEAD`, then re-`git add`, then commit. Do not run destructive git in a pipeline.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- query-docs-only matching → Task 2 (`acceptSuffix: "query-docs"`, codex names) + Task 3/4 "ignores resolve-library-id" tests. ✓
+- arguments-derived / prose result → Task 1 flag + Task 3/4 parser branches + tests. ✓
+- per-library dedup, metadata-only, url/title/description/nativeId → Task 2 definition + test. ✓
+- trackOnly (archived + listed everywhere, excluded from LLM only) → Task 1 flag + Task 5 filters + tests; archival path deliberately untouched. ✓
+- Claude + Codex hosts → Task 3 (Claude) + Task 4 (Codex, local fallback + connector match). ✓
+- ripple (index, KnownSourceId, SOURCE_META, stable-order test) → Task 2 Steps 5-8. ✓
+
+**Placeholder scan:** No TBD/TODO. Task 5 Step 1/2 reference "the file's existing helper" for reference-markdown setup rather than inlining unknown harness code — this is a deliberate pointer to a concrete existing pattern, and the load-bearing assertions (`not.toContain` the wrapper tag) are given explicitly. All production code is shown in full.
+
+**Type consistency:** `normalizeContext7(toolInput): { libraryId: string; query?: string } | null` used identically in Task 2 (def test), Task 3 (Claude), Task 4 (Codex). `def.trackOnly === true` / `def.argumentsDerived === true` checks match the Task 1 field names. `context7Definition` / `context7CodexBinding` names consistent across tasks.
+
+## Known residual (flag during review)
+- The **codex_apps connector** variant of context7 is matched by `match.codex` (functionCallNames/invocationTools) but tested only with the **local-MCP** real fixture (no live connector rollout was captured). The connector PRIMARY path reuses the same normalizer, so risk is low, but a connector fixture is a good follow-up if a user reports it.

--- a/docs/superpowers/specs/2026-07-22-context7-tracking-design.md
+++ b/docs/superpowers/specs/2026-07-22-context7-tracking-design.md
@@ -1,0 +1,148 @@
+# context7 reference tracking (track-only) — design
+
+**Date:** 2026-07-22
+**Status:** approved for planning
+**Scope:** Add context7 as a new *reference source* in the reference-extraction subsystem, purely for tracking which libraries were referenced during work on a commit. Track-only: it is attached to the commit and shown wherever references are listed, but it never feeds the LLM that generates memory decisions.
+
+## Goal
+
+context7 (`@upstash/context7-mcp`) is a third-party MCP server that serves up-to-date library documentation. When an AI agent uses it, we want to record **when context7 was used and which libraries it referenced**, associated with the commit — so a reader can later see "while working on this commit, docs for `/vercel/next.js` were consulted." Nothing more: we do not summarize the docs, and the reference must not influence generated memory content.
+
+## Non-goals (YAGNI)
+
+- Tracking `resolve-library-id` searches (fuzzy intent). Only confirmed `query-docs` fetches count.
+- Storing the returned documentation body.
+- Per-call history (references dedupe per library).
+- Registering the context7 MCP server. context7 is installed by the user; we only *observe* its calls in transcripts.
+- IntelliJ surfacing.
+
+## Ground truth (captured live 2026-07-22)
+
+All shapes below were captured from real runs, not inferred. Raw MCP payloads captured by driving `npx @upstash/context7-mcp` over stdio; the real Codex envelope captured from a live `codex-cli 0.145` rollout. Fixtures were scrubbed of the user's API key.
+
+### context7 tool surface (server v3.2.4)
+
+Two tools:
+
+| Tool | Args | Returns |
+|------|------|---------|
+| `resolve-library-id` | `{ query, libraryName }` | markdown text: candidate library IDs (`- Context7-compatible library ID: /vercel/next.js`) |
+| `query-docs` | `{ libraryId, query }` | markdown text: aggregated doc snippets |
+
+Critical facts:
+
+- The **current** doc-fetch tool is `query-docs`, **not** `get-library-docs` — the older name returns `MCP error -32602: Tool ... not found` on v3.2.4. We still accept the legacy name for older installs.
+- The **referenced library lives in the tool-call arguments** (`query-docs.libraryId`), not in the result. The result is prose. context7 is therefore an *input-dependent* source (same category as `monday`, which reads `itemIds` from arguments).
+- **The result is markdown prose, not JSON — and both core parsers assume JSON.** `ClaudeEnvelopeParser` does `JSON.parse(payloadText)` (`:346`) and drops the entry if it throws; `CodexEnvelopeParser`'s fallback does `tryParse(ev.text); if (null) continue` (`:283`). context7's markdown fails both, dropping the call *before* the arguments-only normalizer runs. context7 is the first prose-result source (monday is input-dependent but its result is JSON). This is why the design adds `argumentsDerived` and a guarded parse-fail branch to both parsers.
+- Results carry no single "doc page URL"; each snippet has its own `Source:` GitHub link. There is no per-query doc URL to store.
+- The library-level browsable page `https://context7.com/<libraryId>` **does** resolve (verified for `/vercel/next.js`) — this is the correct URL for the reference (the entity is the library, not a doc).
+
+### Host envelope shapes
+
+**Claude** (local MCP): `tool_use.name = "mcp__context7__query-docs"`, `input = { libraryId, query }`; paired `tool_result.content` = the doc text (JSON-stringified or string).
+
+**Codex** — two real shapes exist:
+
+1. Local MCP server (this machine's `[mcp_servers.context7]`): `function_call.name = "query_docs"`, `namespace = "mcp__context7"`; `mcp_tool_call_end.invocation = { server: "context7", tool: "query-docs" }`.
+2. `codex_apps` connector (tool catalog): `function_call.name = "_query_docs"`, `namespace = "codex_apps__context7"`; `invocation.tool = "context7.query-docs"`.
+
+On this machine context7 is a **local** MCP server (`[mcp_servers.context7]`), so its calls appear as shape 1 — `namespace = "mcp__context7"`, which does **not** start with `mcp__codex_apps__`. The Codex parser's PRIMARY path (`resolveCodexDef`) therefore rejects it; local-MCP context7 matches only via the **FALLBACK** path on the `mcp_tool_call_end` event, where `invocation = {server:"context7", tool:"query-docs"}` and `invocation.arguments` carries `{libraryId, query}` (both verified in the capture). The `codex_apps` connector variant (shape 2) matches via PRIMARY. `match.codex.invocationTools` must include both `"query-docs"` (local) and `"context7.query-docs"` (connector). Codex 0.145 lazy-loads MCP tools (a `tool_search_call` precedes first use), and a "call it exactly" prompt makes it refuse before loading — a natural "use context7 to…" prompt is required to capture a real call.
+
+## Design
+
+### Two new `SourceDefinition` flags
+
+The reference subsystem has neither a "tracking-only" notion nor a "non-JSON result" notion today. We add two optional flags, both defaulting to absent/false, both leaving every existing source byte-for-byte unchanged. `validateDefinition` accepts unknown extra fields (no exhaustiveness check), so neither flag needs validator changes.
+
+**1. `trackOnly?: boolean`** — with registry helper `isTrackOnlySource(source: string): boolean`. A track-only reference behaves **identically** to any other reference (discovered, upserted to `plans.json.references`, archived into `CommitSummary.references`, shown in the detail-page Context section, PR description, Push-to-Space, and decision timeline) — with a **single** exception: it is excluded from the two functions that build the `{{references}}` block fed to the LLM.
+
+**2. `argumentsDerived?: boolean`** — marks a source whose reference is built entirely from the tool-call *arguments*, so a non-JSON (prose) result is expected, not a parse failure. Both parsers, in their parse-fail branch, pass an **empty payload** (`{}`) to the normalizer instead of dropping the call — but only when `def.argumentsDerived === true`. Existing sources have the flag absent and continue to drop on parse failure exactly as before.
+
+Both flags are read directly off the resolved `SourceDefinition` (`pendingEntry.def` in Claude; `def` in Codex), so no change to the `CodexNormalizer` interface is required.
+
+### Data model (one Reference per library ID)
+
+Dedup key `context7:<libraryId>`, so a library queried N times is one row whose `referencedAt` reflects the latest use.
+
+| field | value | source |
+|-------|-------|--------|
+| `source` | `context7` | — |
+| `nativeId` | `/vercel/next.js` | arg `libraryId`, guarded `^/[^/\s]+/[^/\s]+` |
+| `title` | `vercel/next.js` | derived from `libraryId` (leading `/` stripped) |
+| `url` | `https://context7.com/vercel/next.js` | constructed `https://context7.com` + `libraryId` (optional) |
+| `description` | the `query` topic | arg `query` |
+| `referencedAt` | tool-call timestamp | envelope |
+
+No doc body stored; small `render` budget. `storage.nativeIdPathSafe: false` (nativeId contains `/`).
+
+### Matching (query-docs only)
+
+Only the current `query-docs` tool is matched. Legacy `get-library-docs` is out of scope — it uses a different argument name (`context7CompatibleLibraryID`) and we have no real fixture for it.
+
+- Claude: `match.claude = { prefixes: ["mcp__context7__"], acceptSuffix: "query-docs" }`. `acceptSuffix` is a single string; `mcp__context7__query-docs` ends with it, while `resolve-library-id` and `get-library-docs` do not — so the resolver and the legacy tool are excluded without needing `denySuffixes`.
+- Codex: `match.codex = { namespaceSuffix: "context7", functionCallNames: ["_query_docs"], invocationTools: ["query-docs", "context7.query-docs"] }`. `functionCallNames` serves the connector PRIMARY path; `invocationTools` serves both the local-MCP FALLBACK (`query-docs`) and the connector FALLBACK (`context7.query-docs`). `resolve-library-id` matches none of these and is ignored.
+
+### Input-dependent normalizer
+
+context7's reference data is in the arguments, so a normalizer reshapes `toolInput` (`{ libraryId, query }`) into the object the DSL reads, ignoring the (prose) result. It returns `null` (voiding the reference) only when `libraryId` is absent or malformed. There is **no** isError guard: an errored fetch still means that library was consulted, which is what tracking records. Registered per host:
+
+- Claude: `CONTEXT_NORMALIZERS.context7` → new `sources/Context7Normalize.ts`.
+- Codex: `CODEX_NORMALIZERS` entry → new `bindings/codex/CodexContext7Binding.ts`.
+
+Because the result is prose, the normalizer is reached only after the parsers' `argumentsDerived` branch supplies an empty payload (see below); the normalizer never inspects that payload.
+
+### The track-only seam (where generation is blocked)
+
+References reach the LLM through exactly two block builders. Both must skip track-only sources; nothing else changes.
+
+| Path | Function / location | track-only handling |
+|------|--------------------|--------------------|
+| Live summarizer | `assembleReferenceBlocks` (input assembled at `QueueWorker.ts:1762`/`1813`, amend twin `:2878`) | filter out track-only sources |
+| Regeneration | `rebuildReferenceBlocks` (`Regenerator.ts:112`/`137`, reads `summary.references` at `:209`) | filter out track-only sources |
+
+The archive path (`consumeWorkspaceContext` → `associateReferencesWithCommit`, `QueueWorker.ts:1607-1615`) is **not** filtered, so context7 lands in `CommitSummary.references` and surfaces everywhere references are listed.
+
+Regeneration must be filtered explicitly: because context7 *is* present in `summary.references`, `rebuildReferenceBlocks` would otherwise re-feed it into the regen prompt.
+
+### The argumentsDerived seam (prose-result survival)
+
+Because context7's result is markdown, both parsers must not drop it on JSON-parse failure. Each gets one guarded branch, gated on `def.argumentsDerived === true`:
+
+| Parser | Location | Change |
+|--------|----------|--------|
+| Claude | `ClaudeEnvelopeParser.ts` ~`:346-363` (the `JSON.parse` catch, after `recoverOffloadedPayload` returns `undefined`) | if `pendingEntry.def.argumentsDerived`, set `parsedPayload = {}` and proceed to the normalizer instead of dropping |
+| Codex | `CodexEnvelopeParser.ts` ~`:283-284` (fallback `business = tryParse(ev.text)`) | if `business === null`: `continue` unless `def.argumentsDerived`, in which case set `business = {}` and proceed |
+
+Existing sources have `argumentsDerived` absent, so both branches are inert for them — no behavior change, verified by the untouched JSON-source fixtures.
+
+## Change set (ripple)
+
+1. `cli/src/core/references/SourceDefinition.ts` — add optional `trackOnly?: boolean` and `argumentsDerived?: boolean`.
+2. `cli/src/core/references/SourceDefinitionRegistry.ts` — add `isTrackOnlySource` helper.
+3. `cli/src/core/references/ClaudeEnvelopeParser.ts` — `argumentsDerived` parse-fail branch; register `context7` in `CONTEXT_NORMALIZERS`.
+4. `cli/src/core/references/CodexEnvelopeParser.ts` — `argumentsDerived` fallback branch.
+5. **new** `cli/src/core/references/sources/definitions/context7.ts` (+ `.test.ts`) — the definition; add to `BUILTIN_DEFINITIONS` in `definitions/index.ts`.
+6. **new** `cli/src/core/references/sources/Context7Normalize.ts` (+ `.test.ts`).
+7. **new** `cli/src/core/references/bindings/codex/CodexContext7Binding.ts` — register in `CODEX_NORMALIZERS` (`bindings/codex/index.ts`).
+8. `cli/src/Types.ts` — add `"context7"` to `KnownSourceId`.
+9. `vscode/src/views/SourceLabels.ts` — add a `SOURCE_META` entry (label "Context7", icon `book`).
+10. LLM filter — `assembleReferenceBlocks` (`QueueWorker.ts`) and `rebuildReferenceBlocks` (`Regenerator.ts`) skip `isTrackOnlySource` inside their `getRegistry().all()` loop.
+11. Tests — update the hardcoded stable-order id list in `SourceDefinitionRegistry.test.ts`; add real captured envelopes as inline fixtures in `ClaudeEnvelopeParser.test.ts` and `CodexEnvelopeParser.test.ts`; add a regression test asserting a track-only reference **is** present in `CommitSummary.references` (and PR/push output) but **absent** from the assembled/rebuilt reference blocks.
+
+`CLAUDE_TOOL_PREFIXES` is auto-derived from the registry, so no manual edit there.
+
+## Testing strategy
+
+- Parser fixtures come from the pinned real envelopes (Claude raw payload + established wrapping; real Codex local-MCP rollout + catalog-confirmed connector names), API key scrubbed.
+- `argumentsDerived`: a prose (non-JSON) result still yields a reference on both hosts; an existing JSON source is unaffected (regression fixture).
+- Guard behavior: a malformed/absent `libraryId` produces no reference.
+- Dedup: two `query-docs` calls to the same `libraryId` produce one reference with the later `referencedAt` and latest `query` as description.
+- Track-only invariant (the load-bearing test): a committed context7 reference appears in `summary.references` / PR / push output but never in the LLM reference block from either builder.
+- Coverage stays at or above the CLI floor (97/96/97/97).
+
+## Resolved during planning
+
+- `MatchClaude.acceptSuffix` is a single string; `acceptSuffix: "query-docs"` alone excludes `resolve-library-id` and legacy `get-library-docs` (query-docs scope).
+- The Codex parser strips only the `mcp__codex_apps__` prefix, so the local `mcp__context7` shape matches via the FALLBACK `invocationTools` path, not PRIMARY. `match.codex` covers both shapes.
+- `url` kept: `https://context7.com/<libraryId>` verified to resolve.
+- Both parsers assume JSON results → the `argumentsDerived` flag + guarded parse-fail branch is required (not optional) for context7 on either host.

--- a/vscode/src/views/SourceLabels.ts
+++ b/vscode/src/views/SourceLabels.ts
@@ -48,6 +48,7 @@ export const SOURCE_META: Record<KnownSourceId, SourceMeta> = {
 	"zoom-doc": { label: "Zoom Doc", letter: "Z", icon: "file", color: "#2D8CFF" },
 	asana: { label: "Asana", letter: "A", icon: "checklist", color: "#f06a6a" },
 	monday: { label: "monday.com", letter: "M", icon: "table", color: "#ff3d57" },
+	context7: { label: "Context7", letter: "7", icon: "book", color: "#0b7285" },
 };
 
 /** Neutral badge color for a source outside {@link SOURCE_META} (matches the prior `.mem-ctx-badge--reference` fallback hue). */


### PR DESCRIPTION
## Summary

Adds **context7 as a track-only reference source**, so `mcp__context7__query-docs` / `resolve-library-id` calls surface the referenced library (e.g. `context7:/thedotmack/claude-mem`) alongside Linear / Jira / GitHub / Notion references. context7 is *arguments-derived*: the library id lives in the tool-use **arguments**, not the result payload (which is markdown prose), so the envelope parsers thread the tool-use input through normalization and treat an unparseable prose result as an empty payload rather than dropping the reference.

Wired for **both hosts**: Claude (`ClaudeEnvelopeParser` context-normalizer) and Codex (`CodexContext7Binding`), through the shared `Context7Normalize` reshaper.

## What's included

- **Source definition + normalizer** — `sources/definitions/context7.ts`, `sources/Context7Normalize.ts`, registered in the definitions registry and `SourceLabels`.
- **Host bindings** — Claude context-normalizer entry + `bindings/codex/CodexContext7Binding.ts`.
- **Arguments-derived handling** — envelope parsers keep the tool-use `input` for context7 and, when the prose result fails `JSON.parse`, fall back to an empty payload so the arguments-derived reference is still emitted.
- **Cursor tail-rewind** (`ClaudeEnvelopeParser`) — when a scan ends with a matched tool-use still unpaired *and* it sits after the last paired result, the cursor rewinds to that tool-use so the next scan re-pairs it once the result has flushed, instead of stranding the reference behind a monotonic cursor.
- **StopHook single-owner discovery gate** — when both the CLI/settings Stop hook and the claude-plugin Stop hook are enabled, Claude Code fires both on every Stop event and they share one merged `discovery-cursors.json`. The plugin hook is pinned to its bundled dist while the CLI hook resolves the newest dist across sources; a stale plugin hook could advance the cursor past a source it doesn't recognize (e.g. context7) and permanently blind the newer CLI hook. The plugin-invoked hook now defers discovery to the CLI hook when one is installed (`CLAUDE_PLUGIN_ROOT` + `isClaudeHookInstalled`); a plugin-only install still runs discovery itself. Degrades gracefully — with an up-to-date plugin dist a double scan would still extract correctly.

## Testing

- New unit tests for the context7 definition, normalizer, both envelope parsers, `Regenerator`, `QueueWorker`, and the StopHook ownership gate (deferral, plugin-only run, CLI-hook run, empty-`CLAUDE_PLUGIN_ROOT` run).
- Full `npm run all` gate: build + lint (biome, `--error-on-warnings`) + typecheck + vitest with the 97% coverage floor. The only failures observed locally are the two known `GitClient` push/pullRebase tests, which time out due to the local `safe.bareRepository` + worktree-concurrency environment and are unrelated to this change.
