### PR TITLE
Explain minimal content on track-only and arguments-derived references

### DIFF
--- a/cli/src/core/references/ReferenceStore.test.ts
+++ b/cli/src/core/references/ReferenceStore.test.ts
@@ -56,6 +56,20 @@ function githubRef(overrides: Partial<Reference> = {}): Reference {
 	};
 }
 
+function context7Ref(overrides: Partial<Reference> = {}): Reference {
+	return {
+		mapKey: "context7:/websites/api_jquery",
+		source: "context7",
+		nativeId: "/websites/api_jquery",
+		title: "websites/api_jquery",
+		url: "https://context7.com/websites/api_jquery",
+		description: "how to use jQuery.ajax() function: options, success/error callbacks",
+		referencedAt: "2026-07-23T03:31:06.464Z",
+		toolName: "mcp__context7__query-docs",
+		...overrides,
+	};
+}
+
 describe("ReferenceStore", () => {
 	let tempDir: string;
 
@@ -582,6 +596,49 @@ describe("ReferenceStore", () => {
 			const back = await readReferenceMarkdown(sourcePath);
 			expect(back).not.toBeNull();
 			expect(hashReferenceContent(back as Reference)).toBe(contentHash);
+		});
+	});
+
+	describe("track-only / arguments-derived auto-note", () => {
+		it("appends a human note explaining why a track-only reference stores so little", async () => {
+			const { sourcePath } = await writeReferenceMarkdown(context7Ref(), tempDir);
+			const content = await readFile(sourcePath, "utf-8");
+			// argumentsDerived → "full response not saved"; trackOnly → "not used ... summaries".
+			expect(content).toContain("bookmark, not a full copy");
+			expect(content).toContain("intentionally not saved");
+			expect(content).toContain("Track-only");
+			expect(content).toContain("not** used as a source when generating memory summaries");
+			// The user-facing body (the query) still renders above the note.
+			expect(content).toContain("how to use jQuery.ajax()");
+		});
+
+		it("does not append a note to ordinary (non-track-only) references", async () => {
+			const { sourcePath } = await writeReferenceMarkdown(linearRef({ description: "Issue body" }), tempDir);
+			const content = await readFile(sourcePath, "utf-8");
+			expect(content).not.toContain("bookmark, not a full copy");
+			expect(content).not.toContain("Track-only");
+		});
+
+		it("strips the note on read so it never folds into the stored description", async () => {
+			const { sourcePath } = await writeReferenceMarkdown(context7Ref(), tempDir);
+			const back = await readReferenceMarkdown(sourcePath);
+			expect(back).not.toBeNull();
+			expect((back as Reference).description).toBe(context7Ref().description);
+			expect((back as Reference).description).not.toContain("bookmark");
+		});
+
+		it("keeps the guard hash stable across a render→parse→render round-trip (no re-upsert loop)", async () => {
+			const { sourcePath, contentHash } = await writeReferenceMarkdown(context7Ref(), tempDir);
+			const back = await readReferenceMarkdown(sourcePath);
+			expect(back).not.toBeNull();
+			// Archive-side hash of the parsed-back ref must equal the upsert-side hash,
+			// or the reference re-surfaces as uncommitted on every re-extraction.
+			expect(hashReferenceContent(back as Reference)).toBe(contentHash);
+
+			// A second round-trip must not accumulate the note into the body.
+			const { sourcePath: sp2 } = await writeReferenceMarkdown(back as Reference, tempDir);
+			const back2 = await readReferenceMarkdown(sp2);
+			expect((back2 as Reference).description).toBe(context7Ref().description);
 		});
 	});
 });

--- a/cli/src/core/references/ReferenceStore.ts
+++ b/cli/src/core/references/ReferenceStore.ts
@@ -34,6 +34,7 @@ import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { createLogger, getJolliMemoryDir } from "../../Logger.js";
 import type { Reference, ReferenceField, SourceId } from "../../Types.js";
+import type { SourceDefinition } from "./SourceDefinition.js";
 import { getRegistry } from "./SourceDefinitionRegistry.js";
 
 const log = createLogger("ReferenceStore");
@@ -187,6 +188,62 @@ function stripBodyEdges(body: string): string {
 	return body.replace(/^\n+/, "").replace(/\n+$/, "");
 }
 
+/**
+ * Drop the auto-generated note (everything from {@link REFERENCE_NOTE_SENTINEL} onward)
+ * so it never round-trips into the stored `description`. Keyed on the sentinel's presence
+ * in the text — not on the source definition — so a reference whose source was later
+ * removed from the registry still parses back to the same body.
+ *
+ * LOCKSTEP: the VS Code-side reader (`vscode/src/core/ReferenceService.ts` `readFrontmatter`)
+ * strips the same sentinel before building its 200-char description snippet — keep both in sync.
+ */
+function stripReferenceNote(body: string): string {
+	const idx = body.indexOf(REFERENCE_NOTE_SENTINEL);
+	return idx === -1 ? body : body.slice(0, idx);
+}
+
+/**
+ * Sentinel opening the auto-generated human note for track-only / arguments-derived
+ * references. It's an HTML comment (invisible in rendered markdown) that acts as the
+ * cut point for the render↔parse round-trip: {@link renderMarkdown} appends everything
+ * from this line onward, {@link parseMarkdown} strips it back off before assigning
+ * `description`. Without the strip the note would fold into the stored body, get
+ * re-appended on the next render, and drift the {@link hashReferenceContent} guard —
+ * re-upserting + re-archiving the reference on every commit forever.
+ */
+const REFERENCE_NOTE_SENTINEL = "<!-- jolli:auto-note -->";
+
+/**
+ * Deterministic footer explaining why a track-only / arguments-derived reference stores
+ * so little content — a recurring point of user confusion ("why is the Context7 content
+ * so short — is it broken?"). `argumentsDerived` sources build the reference from the
+ * call arguments and discard the (prose) tool result, so the body is only the query;
+ * `trackOnly` sources are kept as context but never fed to the summary LLM. Returns "" for
+ * ordinary sources so their markdown is untouched.
+ *
+ * The note is emitted from the source definition alone (not from stored body text), so it
+ * is byte-identical across renders of the same source — the property the round-trip relies
+ * on. See {@link REFERENCE_NOTE_SENTINEL}.
+ */
+function referenceNote(def: SourceDefinition | undefined): string {
+	if (def === undefined || (def.argumentsDerived !== true && def.trackOnly !== true)) return "";
+	// One blockquote paragraph per relevant flag, joined with a `>` continuation line so
+	// they read as a single quote block. Built via an array (not conditional separators)
+	// so there is no separator branch to leave uncovered.
+	const paragraphs: string[] = [];
+	if (def.argumentsDerived === true) {
+		paragraphs.push(
+			`> ℹ️ **This is a bookmark, not a full copy.** Only the query and the ${def.label} link are recorded here — ${def.label}'s full response is intentionally not saved. This is expected behaviour, not a bug.`,
+		);
+	}
+	if (def.trackOnly === true) {
+		paragraphs.push(
+			"> _Track-only_ — this reference is kept as background context but is **not** used as a source when generating memory summaries.",
+		);
+	}
+	return [REFERENCE_NOTE_SENTINEL, "", "---", "", paragraphs.join("\n>\n")].join("\n");
+}
+
 function renderMarkdown(ref: Reference): string {
 	const lines: string[] = ["---"];
 	lines.push(`source: ${JSON.stringify(ref.source)}`);
@@ -210,6 +267,10 @@ function renderMarkdown(ref: Reference): string {
 	if (ref.description !== undefined) {
 		const body = stripBodyEdges(ref.description);
 		if (body.length > 0) lines.push(body);
+	}
+	const note = referenceNote(getRegistry().byId(ref.source));
+	if (note.length > 0) {
+		lines.push("", note);
 	}
 	return `${lines.join("\n")}\n`;
 }
@@ -239,7 +300,10 @@ function parseMarkdown(content: string): Reference | null {
 	if (closingIdx === -1) return null;
 
 	const frontmatter = lines.slice(1, closingIdx);
-	const body = stripBodyEdges(lines.slice(closingIdx + 1).join("\n"));
+	// Cut the auto-generated note (if any) before it can fold into `description`.
+	// renderMarkdown re-derives the note from the source definition on every render,
+	// so stripping it here keeps render→parse→render idempotent. See REFERENCE_NOTE_SENTINEL.
+	const body = stripBodyEdges(stripReferenceNote(lines.slice(closingIdx + 1).join("\n")));
 
 	const scalars: Record<string, string> = {};
 	const refFields: ReferenceField[] = [];

--- a/vscode/src/core/ReferenceService.test.ts
+++ b/vscode/src/core/ReferenceService.test.ts
@@ -365,6 +365,34 @@ describe("detectReferences", () => {
 		expect(result[0].description).toBe("body");
 	});
 
+	it("strips the auto-generated track-only note from the description snippet", async () => {
+		mockLoadPlansRegistry.mockResolvedValue({
+			version: 1,
+			plans: {},
+			references: { "linear:PROJ-1528": makeEntry() },
+		});
+		mockReadFileSync.mockReturnValue(
+			[
+				"---",
+				'source: "context7"',
+				"---",
+				"how to use jQuery.ajax()",
+				"",
+				"<!-- jolli:auto-note -->",
+				"",
+				"---",
+				"",
+				"> ℹ️ **This is a bookmark, not a full copy.** Context7's full response is intentionally not saved.",
+				"",
+			].join("\n"),
+		);
+		const result = await detectReferences("/repo");
+		// Only the query survives — the sentinel and note text must not leak into the snippet.
+		expect(result[0].description).toBe("how to use jQuery.ajax()");
+		expect(result[0].description).not.toContain("jolli:auto-note");
+		expect(result[0].description).not.toContain("bookmark");
+	});
+
 	it("skips a bad-shape fields list item (valid JSON, missing key/label/value)", async () => {
 		mockLoadPlansRegistry.mockResolvedValue({
 			version: 1,

--- a/vscode/src/core/ReferenceService.ts
+++ b/vscode/src/core/ReferenceService.ts
@@ -246,11 +246,12 @@ function readFrontmatter(sourcePath: string): ParsedFrontmatter {
 	if (closingIdx === -1) return {};
 
 	const fmLines = lines.slice(1, closingIdx);
-	const body = lines
-		.slice(closingIdx + 1)
-		.join("\n")
-		.replace(/^\n+/, "")
-		.replace(/\n+$/, "");
+	const rawBody = lines.slice(closingIdx + 1).join("\n");
+	// LOCKSTEP with ReferenceStore.stripReferenceNote (cli): drop the auto-generated
+	// track-only note (everything from the "<!-- jolli:auto-note -->" sentinel onward)
+	// so it never leaks into the 200-char description snippet shown in the sidebar / hover.
+	const noteIdx = rawBody.indexOf("<!-- jolli:auto-note -->");
+	const body = (noteIdx === -1 ? rawBody : rawBody.slice(0, noteIdx)).replace(/^\n+/, "").replace(/\n+$/, "");
 
 	const out: {
 		-readonly [K in keyof ParsedFrontmatter]: ParsedFrontmatter[K];


### PR DESCRIPTION
## What

Arguments-derived sources (e.g. Context7) record only the query and the source link; track-only sources are kept as context but never fed to the summary LLM. Both store so little body text that users reasonably ask whether the reference is broken.

This appends a deterministic, human-readable note block to the rendered markdown for these sources explaining that the minimal content is expected, not a bug.

## How

- `renderMarkdown` derives the note from the source definition alone and appends it after a `<!-- jolli:auto-note -->` HTML-comment sentinel (invisible in rendered markdown).
- `parseMarkdown` cuts everything from the sentinel onward before assigning `description`, so render→parse stays idempotent and the content hash never drifts (otherwise the reference would re-upsert and re-archive on every commit).
- VS Code `ReferenceService.readFrontmatter` strips the same sentinel **in lockstep**, so the note never leaks into the sidebar/hover description snippet.

## Testing

- `ReferenceStore.test.ts`: 45 passed (adds coverage for the note render/strip round-trip)
- `ReferenceService.test.ts`: 34 passed (adds VS Code strip test)
- Full `npm run all` green except the two known environmental `GitClient.test.ts` flakes, which pass 135/135 under the `safe.bareRepository` isolation prefix.