### PR TITLE
chore(deps): bump js-yaml 4.2.0 -> 4.3.0 to sync lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4213,9 +4213,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"dev": true,
 			"funding": [
 				{


### PR DESCRIPTION
## What

Bumps `js-yaml` `4.2.0` → `4.3.0` in `package-lock.json` (lockfile-only change).

`js-yaml` is a transitive **dev** dependency:
`@vscode/vsce` → `@secretlint/node` → `rc-config-loader` → `js-yaml`.

## Why

Dependabot's security update for `js-yaml` was failing with `security_update_not_possible` ([run](https://github.com/jolliai/jolliai/actions/runs/29977214214/job/89111460955)). The committed lockfile pinned `4.2.0`, below the advisory's lowest non-vulnerable version `4.3.0`, even though `rc-config-loader` allows `^4.1.1` — nothing actually constrained the upgrade, the lockfile was just stale. `npm update js-yaml` resolves it to `4.3.0`.

This clears the Dependabot failure for `js-yaml`.

## Not included

The separate `@hono/node-server` advisory is **not** addressed here — it's pinned by `@modelcontextprotocol/sdk@1.29.0` (`^1.19.9`), so no update path to the fixed `2.0.10` exists until the MCP SDK loosens that constraint. Left untouched intentionally.

## Verification

- Only `package-lock.json` changed (3 lines: version + resolved + integrity for `js-yaml`).
- `npm run all` passes (build, lint, 8281 tests). The 2 `GitClient.test.ts` push/non-FF failures are pre-existing local-environment flakes (`safe.bareRepository`), unrelated to this change — they pass 135/135 with the documented `safe.bareRepository=all` git config.