### PR TITLE
Fix DOM-XSS sink in graph error handler by using textContent

### DIFF
--- a/cli/src/graph/assets/js/main.js
+++ b/cli/src/graph/assets/js/main.js
@@ -131,8 +131,16 @@
     try {
       await window.WikiDataLoader.load();
     } catch (err) {
-      document.getElementById("board").innerHTML =
-        `<div style="padding:40px;color:#c66">Failed to load the knowledge graph data — ${err.message}.</div>`;
+      // Render the error as a text node, not innerHTML: err.message can carry
+      // host-supplied / exception text (see host-bridge.js requestGraph, which
+      // rejects with String(data.error) from a postMessage), so interpolating it
+      // into HTML would be a DOM-XSS sink. textContent escapes it inertly.
+      const board = document.getElementById("board");
+      board.textContent = "";
+      const div = document.createElement("div");
+      div.style.cssText = "padding:40px;color:#c66";
+      div.textContent = `Failed to load the knowledge graph data — ${err.message}.`;
+      board.appendChild(div);
       return;
     }
     // Track last nav to know when a full re-render is needed vs panel-only.


### PR DESCRIPTION
## Summary

Fix a DOM-XSS sink in the knowledge-graph viewer's data-load error handler: the failure message is now rendered as a text node via `textContent` instead of being interpolated into an `innerHTML` string.

## Motivation

In `cli/src/graph/assets/js/main.js`, when `WikiDataLoader.load()` rejects, `err.message` was interpolated directly into an `innerHTML` assignment. `err.message` can carry host-supplied / exception text — `host-bridge.js`'s `requestGraph` rejects with `String(data.error)` sourced from a `postMessage` — so interpolating it into HTML is an untrusted-input → HTML injection sink (flagged by code scanning).

## Changes

- Replace the `innerHTML` interpolation in the graph load-error branch with safe DOM construction: clear `#board`, create a `<div>`, set its style via `cssText`, set the message via `textContent`, and append it. The user-visible error text is unchanged; the HTML-injection path is removed.
