### PR TITLE
fix: stop merged jolli status rows masking a healthy variant (Copilot, Cline)

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -1457,8 +1457,15 @@ export interface StatusInfo {
 	readonly clineVscodeDetected?: boolean;
 	/** Whether Cline session discovery is enabled in config (undefined = auto-detect) */
 	readonly clineEnabled?: boolean;
-	/** Cline scan failed with a real error (non-ENOENT): parse / fs / schema. */
-	readonly clineScanError?: ClineScanError;
+	/**
+	 * Cline VS Code extension scan failed with a real error (non-ENOENT): parse /
+	 * fs / schema. Split from the CLI channel (was a single collapsed
+	 * `clineScanError`) so one broken channel never masks a healthy sibling on the
+	 * merged Cline row — see `buildIntegrationRows` in StatusCommand.ts.
+	 */
+	readonly clineVscodeScanError?: ClineScanError;
+	/** Cline CLI (~/.cline/data/sessions) scan failed with a real error. Same UI semantics as clineVscodeScanError. */
+	readonly clineCliScanError?: ClineScanError;
 	/**
 	 * v5 schema migration state — surfaced in `jolli status` and the VSCode
 	 * Hooks tooltip so users can see whether their on-disk data has been

--- a/cli/src/commands/StatusCommand.test.ts
+++ b/cli/src/commands/StatusCommand.test.ts
@@ -1,7 +1,9 @@
 /**
  * Tests for StatusCommand — `jolli status` integration rows.
  *
- * Covers the per-integration breakdown output, focused on the Copilot row.
+ * Covers the per-integration breakdown output, focused on the merged
+ * (two-channel) rows — Copilot (CLI + Chat), Cline (CLI + VS Code), Cursor
+ * (IDE + CLI) — where one channel failing must not mask a healthy sibling.
  */
 
 import { Command } from "commander";
@@ -154,15 +156,38 @@ describe("StatusCommand — Copilot integration row", () => {
 		expect(out).toContain("3");
 	});
 
-	it("renders Copilot row as unavailable on scan error", async () => {
+	it("does NOT mask a healthy Chat when the CLI DB scan fails", async () => {
+		// Regression (JOLLI-2034): a broken CLI DB used to feed the merged row's
+		// scanError, whose early return marked the WHOLE Copilot integration
+		// "unavailable" and hid the healthy Chat's session count. CLI-only failure
+		// must now render as a non-masking sub-line while the main row keeps the count.
 		const out = await renderStatus({
 			...baseStatus,
 			copilotDetected: true,
+			copilotChatDetected: true,
+			copilotEnabled: true,
 			copilotScanError: { kind: "locked", message: "database is locked" },
+			sessionsBySource: { "copilot-chat": 4 },
 		});
-		expect(out).toContain("Copilot");
-		expect(out).toContain("unavailable");
-		expect(out).toContain("locked");
+		expect(out).not.toContain("unavailable");
+		expect(out).toMatch(/4\s*sessions/);
+		expect(out).toContain("CLI scan failed (locked)");
+		expect(out).toContain("database is locked");
+	});
+
+	it("reads unavailable only when BOTH CLI and Chat scans fail", async () => {
+		const out = await renderStatus({
+			...baseStatus,
+			copilotDetected: true,
+			copilotChatDetected: true,
+			copilotEnabled: true,
+			copilotScanError: { kind: "locked", message: "database is locked" },
+			copilotChatScanError: { kind: "parse", message: "bad jsonl event at line 7" },
+		});
+		expect(out).toContain("Copilot:");
+		expect(out).toContain("unavailable — locked");
+		expect(out).toContain("CLI scan failed (locked)");
+		expect(out).toContain("Chat scan failed (parse)");
 	});
 
 	it("renders Copilot row as disabled when detected but copilotEnabled is false", async () => {
@@ -188,17 +213,20 @@ describe("StatusCommand — Copilot integration row", () => {
 		expect(out).toMatch(/2\s*sessions/);
 	});
 
-	it("emits a Chat scan-failed sub-line when copilotChatScanError is set", async () => {
-		// CLI scan error renders on the main row; Chat error is structurally
-		// different — it surfaces as an indented "↳ Chat scan failed" sub-line
-		// underneath the CLI/Chat breakdown so users can tell which form failed.
+	it("does NOT mask a healthy CLI when only the Chat scan fails", async () => {
+		// Symmetric to the CLI-failure case: a Chat-only error surfaces as an
+		// indented "↳ Chat scan failed" sub-line while the main row keeps the
+		// healthy CLI's session count (not "unavailable").
 		const out = await renderStatus({
 			...baseStatus,
 			copilotDetected: true,
 			copilotChatDetected: true,
 			copilotEnabled: true,
 			copilotChatScanError: { kind: "parse", message: "bad jsonl event at line 7" },
+			sessionsBySource: { copilot: 2 },
 		});
+		expect(out).not.toContain("unavailable");
+		expect(out).toMatch(/2\s*sessions/);
 		expect(out).toContain("Chat scan failed (parse)");
 		expect(out).toContain("bad jsonl event at line 7");
 	});
@@ -237,15 +265,56 @@ describe("StatusCommand — Cline integration row", () => {
 		expect(out).toMatch(/5\s*sessions/);
 	});
 
-	it("renders Cline row as unavailable on scan error", async () => {
+	it("does NOT mask a healthy CLI when the VS Code scan fails", async () => {
+		// Regression (JOLLI-2034): Cline collapsed both channels into one scanError
+		// field, so a broken VS Code extension scan marked the WHOLE row
+		// "unavailable" and hid the healthy CLI's session count. VS-Code-only
+		// failure must now render as a non-masking sub-line.
 		const out = await renderStatus({
 			...baseStatus,
 			clineDetected: true,
-			clineScanError: { kind: "parse", message: "bad task json" },
+			clineCliDetected: true,
+			clineVscodeDetected: true,
+			clineEnabled: true,
+			clineVscodeScanError: { kind: "parse", message: "bad task json" },
+			sessionsBySource: { "cline-cli": 3 },
 		});
-		expect(out).toContain("Cline");
-		expect(out).toContain("unavailable");
-		expect(out).toContain("parse");
+		expect(out).not.toContain("unavailable");
+		expect(out).toMatch(/3\s*sessions/);
+		expect(out).toContain("VS Code scan failed (parse)");
+		expect(out).toContain("bad task json");
+	});
+
+	it("renders a non-masking sub-line when only the CLI scan fails", async () => {
+		const out = await renderStatus({
+			...baseStatus,
+			clineDetected: true,
+			clineCliDetected: true,
+			clineVscodeDetected: true,
+			clineEnabled: true,
+			clineCliScanError: { kind: "fs", message: "EACCES on sessions/" },
+			sessionsBySource: { cline: 2 },
+		});
+		expect(out).not.toContain("unavailable");
+		expect(out).toMatch(/2\s*sessions/);
+		expect(out).toContain("CLI scan failed (fs)");
+		expect(out).toContain("EACCES on sessions/");
+	});
+
+	it("reads unavailable only when BOTH VS Code and CLI scans fail", async () => {
+		const out = await renderStatus({
+			...baseStatus,
+			clineDetected: true,
+			clineCliDetected: true,
+			clineVscodeDetected: true,
+			clineEnabled: true,
+			clineVscodeScanError: { kind: "parse", message: "bad task json" },
+			clineCliScanError: { kind: "fs", message: "EACCES on sessions/" },
+		});
+		expect(out).toContain("Cline:");
+		expect(out).toContain("unavailable — parse");
+		expect(out).toContain("VS Code scan failed (parse)");
+		expect(out).toContain("CLI scan failed (fs)");
 	});
 
 	it("renders Cline row as disabled when detected but clineEnabled is false", async () => {

--- a/cli/src/commands/StatusCommand.ts
+++ b/cli/src/commands/StatusCommand.ts
@@ -260,6 +260,49 @@ export function describeIntegrationStatus(x: IntegrationStatusInputs): string {
 	return `detected & enabled${suffix}`;
 }
 
+/** One channel-labelled scan failure inside a merged (dual-variant) integration. */
+export interface IntegrationScanError {
+	/** Human channel label, matching the CLI sub-line wording ("CLI", "Chat", "IDE", "VS Code"). */
+	readonly channel: string;
+	readonly kind: string;
+	readonly message: string;
+}
+
+/**
+ * Per-channel scan failures for the dual-variant integrations (Copilot, Cline,
+ * Cursor). Their merged {@link describeIntegrationStatus} row only reads
+ * "unavailable" when BOTH channels fail (see `buildIntegrationRows`' gated
+ * `scanError`), so a single broken channel beside a healthy sibling is invisible
+ * in the flat descriptor. The CLI renders these as `↳ … scan failed` sub-lines
+ * and the VS Code STATUS tree as per-channel warning nodes; this collects the
+ * same set so the flat MCP {@link StatusIntegration} can carry them too.
+ *
+ * Returns `[]` for single-channel sources (OpenCode, Devin, Antigravity, …):
+ * their scan failure is never masked — it already surfaces as `unavailable —
+ * <kind>` in the `status` descriptor.
+ */
+export function collectIntegrationScanErrors(status: StatusInfo, name: string): IntegrationScanError[] {
+	const errs: IntegrationScanError[] = [];
+	const push = (channel: string, e: { readonly kind: string; readonly message: string } | undefined): void => {
+		if (e) errs.push({ channel, kind: e.kind, message: e.message });
+	};
+	switch (name) {
+		case "Copilot":
+			push("CLI", status.copilotScanError);
+			push("Chat", status.copilotChatScanError);
+			break;
+		case "Cline":
+			push("VS Code", status.clineVscodeScanError);
+			push("CLI", status.clineCliScanError);
+			break;
+		case "Cursor":
+			push("IDE", status.cursorScanError);
+			push("CLI", status.cursorCliScanError);
+			break;
+	}
+	return errs;
+}
+
 /**
  * Whether Claude's agent hook is effectively active. The Claude Code plugin wires
  * its Stop/SessionStart hooks through its own manifest (hooks.json), NOT
@@ -368,7 +411,13 @@ export function buildIntegrationRows(
 					enabled: status.copilotEnabled !== false,
 					hookInstalled: undefined,
 					sessionCount: (counts.copilot ?? 0) + (counts["copilot-chat"] ?? 0),
-					scanError: status.copilotScanError,
+					// Merged CLI + Chat row: "unavailable" only when BOTH channels
+					// failed. A broken CLI DB beside a healthy Chat (or vice-versa) must
+					// not mask the working source via describeIntegrationStatus' early
+					// return — each failure renders as a sub-line below instead. Mirrors
+					// the Cursor entry above and the VS Code STATUS tree.
+					scanError:
+						status.copilotScanError && status.copilotChatScanError ? status.copilotScanError : undefined,
 				},
 			],
 			[
@@ -378,7 +427,12 @@ export function buildIntegrationRows(
 					enabled: status.clineEnabled !== false,
 					hookInstalled: undefined,
 					sessionCount: (counts.cline ?? 0) + (counts["cline-cli"] ?? 0),
-					scanError: status.clineScanError,
+					// Merged VS Code + CLI row: only "unavailable" when BOTH channels
+					// failed (same rule as Cursor/Copilot above).
+					scanError:
+						status.clineVscodeScanError && status.clineCliScanError
+							? status.clineVscodeScanError
+							: undefined,
 				},
 			],
 			[
@@ -485,6 +539,14 @@ export function registerStatusCommand(program: Command): void {
 					console.log(
 						`  ${subIndent}↳ CLI: ${mark(status.copilotDetected)}, Chat: ${mark(status.copilotChatDetected)}`,
 					);
+					// Both channels' scan errors render as non-masking sub-lines. The
+					// main row only reads "unavailable" when BOTH failed (see the row's
+					// scanError). Symmetric with Cursor's dual sub-lines.
+					if (status.copilotScanError) {
+						console.log(
+							`  ${subIndent}↳ CLI scan failed (${status.copilotScanError.kind}): ${status.copilotScanError.message}`,
+						);
+					}
 					if (status.copilotChatScanError) {
 						console.log(
 							`  ${subIndent}↳ Chat scan failed (${status.copilotChatScanError.kind}): ${status.copilotChatScanError.message}`,
@@ -494,6 +556,16 @@ export function registerStatusCommand(program: Command): void {
 					console.log(
 						`  ${subIndent}↳ CLI: ${mark(status.clineCliDetected)}, VS Code: ${mark(status.clineVscodeDetected)}`,
 					);
+					if (status.clineVscodeScanError) {
+						console.log(
+							`  ${subIndent}↳ VS Code scan failed (${status.clineVscodeScanError.kind}): ${status.clineVscodeScanError.message}`,
+						);
+					}
+					if (status.clineCliScanError) {
+						console.log(
+							`  ${subIndent}↳ CLI scan failed (${status.clineCliScanError.kind}): ${status.clineCliScanError.message}`,
+						);
+					}
 				} else if (name === "Cursor") {
 					console.log(
 						`  ${subIndent}↳ IDE: ${mark(status.cursorDetected)}, CLI: ${mark(status.cursorCliDetected)}`,

--- a/cli/src/install/Installer.test.ts
+++ b/cli/src/install/Installer.test.ts
@@ -2812,18 +2812,28 @@ describe("Installer", () => {
 			expect(status.clineDetected).toBe(true);
 		});
 
-		it("surfaces clineScanError from the extension or CLI scan", async () => {
+		it("surfaces the VS Code and CLI scan errors on separate fields (no collapse)", async () => {
+			// Regression (JOLLI-2034): the two channels previously collapsed into a
+			// single `clineScanError` via `ext.error ?? cli.error`, so a VS Code
+			// failure DROPPED a concurrent CLI failure. Each channel now populates
+			// its own field so neither masks nor loses the other.
 			const { isClineInstalled } = await import("../core/ClineDetector.js");
 			const { scanClineSessions } = await import("../core/ClineSessionDiscoverer.js");
+			const { scanClineCliSessions } = await import("../core/ClineCliSessionDiscoverer.js");
 			const { saveConfigScoped } = await import("../core/SessionTracker.js");
 			vi.mocked(isClineInstalled).mockResolvedValue(true);
 			vi.mocked(scanClineSessions).mockResolvedValue({
 				sessions: [],
 				error: { kind: "parse", message: "unexpected token" },
 			});
+			vi.mocked(scanClineCliSessions).mockResolvedValue({
+				sessions: [],
+				error: { kind: "fs", message: "EACCES on sessions/" },
+			});
 			await saveConfigScoped({ clineEnabled: true }, emptyGlobalDir);
 			const status = await getStatus(tempDir);
-			expect(status.clineScanError).toEqual({ kind: "parse", message: "unexpected token" });
+			expect(status.clineVscodeScanError).toEqual({ kind: "parse", message: "unexpected token" });
+			expect(status.clineCliScanError).toEqual({ kind: "fs", message: "EACCES on sessions/" });
 		});
 
 		it("merges Cline extension and CLI sessions into the active session count", async () => {
@@ -2858,7 +2868,8 @@ describe("Installer", () => {
 
 			expect(status.sessionsBySource?.cline).toBe(1);
 			expect(status.sessionsBySource?.["cline-cli"]).toBe(1);
-			expect(status.clineScanError).toBeUndefined();
+			expect(status.clineVscodeScanError).toBeUndefined();
+			expect(status.clineCliScanError).toBeUndefined();
 		});
 
 		it("should count legacy sessions without a source as Claude sessions", async () => {

--- a/cli/src/install/Installer.ts
+++ b/cli/src/install/Installer.ts
@@ -1059,13 +1059,18 @@ export async function getStatus(cwd?: string, storage?: StorageProvider): Promis
 	}
 
 	// Discover Cline sessions on-demand (extension + CLI), merged under one row.
-	let clineScanError: ClineScanError | undefined;
+	// Each channel keeps its OWN scan-error field — collapsing them (the old
+	// `ext.error ?? cli.error`) dropped a concurrent CLI failure and let one
+	// broken channel mask a healthy sibling on the merged row (JOLLI-2034).
+	let clineVscodeScanError: ClineScanError | undefined;
+	let clineCliScanError: ClineScanError | undefined;
 	if (config.clineEnabled !== false && clineDetected) {
 		const ext = await scanClineSessions(projectDir);
 		const cli = await scanClineCliSessions(projectDir);
 		const merged = [...ext.sessions, ...cli.sessions];
 		if (merged.length > 0) allEnabledSessions = [...allEnabledSessions, ...merged];
-		clineScanError = ext.error ?? cli.error;
+		clineVscodeScanError = ext.error;
+		clineCliScanError = cli.error;
 	}
 
 	// Discover Antigravity conversations on-demand (not stored in sessions.json).
@@ -1185,7 +1190,8 @@ export async function getStatus(cwd?: string, storage?: StorageProvider): Promis
 		clineCliDetected,
 		clineVscodeDetected,
 		clineEnabled: config.clineEnabled,
-		clineScanError,
+		clineVscodeScanError,
+		clineCliScanError,
 		antigravityDetected,
 		antigravityEnabled: config.antigravityEnabled,
 		antigravityScanError,

--- a/cli/src/mcp/McpTools.test.ts
+++ b/cli/src/mcp/McpTools.test.ts
@@ -541,6 +541,82 @@ describe("buildStatusSummary", () => {
 			{ name: "Copilot", detected: true, status: "detected & enabled (5 sessions)" },
 		]);
 	});
+
+	it("surfaces a merged integration's single broken channel via scanErrors while keeping the healthy status", () => {
+		// Copilot CLI DB is locked but Chat is healthy: the merged row must NOT read
+		// "unavailable" (its session count would vanish), so the partial failure has
+		// to travel in the structured scanErrors channel instead. Mirrors the CLI's
+		// non-masking `↳ CLI scan failed` sub-line and the VS Code per-channel warning.
+		const r = buildStatusSummary(
+			makeStatus({
+				copilotDetected: true,
+				copilotChatDetected: true,
+				copilotScanError: { kind: "locked", message: "db is locked" },
+				sessionsBySource: { "copilot-chat": 3 },
+			}),
+			{ version: "1", account, isClaudePlugin: false },
+		);
+		expect(r.integrations).toEqual([
+			{
+				name: "Copilot",
+				detected: true,
+				status: "detected & enabled (3 sessions)",
+				scanErrors: [{ channel: "CLI", kind: "locked", message: "db is locked" }],
+			},
+		]);
+	});
+
+	it("collects both channels in scanErrors for Cline and Cursor merged rows", () => {
+		// Cline: only the VS Code channel failed → row stays healthy, one scanError.
+		const cline = buildStatusSummary(
+			makeStatus({
+				clineDetected: true,
+				clineCliDetected: true,
+				clineVscodeScanError: { kind: "parse", message: "bad json" },
+				sessionsBySource: { "cline-cli": 2 },
+			}),
+			{ version: "1", account, isClaudePlugin: false },
+		);
+		expect(cline.integrations).toEqual([
+			{
+				name: "Cline",
+				detected: true,
+				status: "detected & enabled (2 sessions)",
+				scanErrors: [{ channel: "VS Code", kind: "parse", message: "bad json" }],
+			},
+		]);
+
+		// Cursor: BOTH channels failed → status reads "unavailable" AND scanErrors
+		// carries both, so a caller can still see each channel's kind/message.
+		const cursor = buildStatusSummary(
+			makeStatus({
+				cursorDetected: true,
+				cursorCliDetected: true,
+				cursorScanError: { kind: "corrupt", message: "ide db corrupt" },
+				cursorCliScanError: { kind: "fs", message: "cli read failed" },
+			}),
+			{ version: "1", account, isClaudePlugin: false },
+		);
+		expect(cursor.integrations).toEqual([
+			{
+				name: "Cursor",
+				detected: true,
+				status: "unavailable — corrupt",
+				scanErrors: [
+					{ channel: "IDE", kind: "corrupt", message: "ide db corrupt" },
+					{ channel: "CLI", kind: "fs", message: "cli read failed" },
+				],
+			},
+		]);
+	});
+
+	it("omits scanErrors entirely when a merged integration has no channel failures", () => {
+		const r = buildStatusSummary(
+			makeStatus({ copilotChatDetected: true, sessionsBySource: { "copilot-chat": 1 } }),
+			{ version: "1", account, isClaudePlugin: false },
+		);
+		expect(r.integrations).toEqual([{ name: "Copilot", detected: true, status: "detected & enabled (1 session)" }]);
+	});
 });
 
 describe("runStatus", () => {

--- a/cli/src/mcp/McpTools.ts
+++ b/cli/src/mcp/McpTools.ts
@@ -11,8 +11,10 @@ import {
 	buildHookRuntime,
 	buildHookSummary,
 	buildIntegrationRows,
+	collectIntegrationScanErrors,
 	describeIntegrationStatus,
 	describeSchemaV5Status,
+	type IntegrationScanError,
 	resolveClaudeHookActive,
 } from "../commands/StatusCommand.js";
 import { isClaudePluginBuild } from "../core/ClientHeader.js";
@@ -171,6 +173,17 @@ export interface StatusIntegration {
 	 * lives ONLY inside this string.
 	 */
 	readonly status: string;
+	/**
+	 * Per-channel scan failures for the dual-variant integrations (Copilot, Cline,
+	 * Cursor). Present ONLY when at least one channel failed. The merged `status`
+	 * descriptor stays healthy when just one channel is broken (so its session
+	 * count is not masked), so a single-channel failure would otherwise be
+	 * invisible to an MCP caller — it travels here instead. Mirrors the `jolli
+	 * status` `↳ … scan failed` sub-lines and the VS Code STATUS tree's per-channel
+	 * warning nodes. Single-channel sources never populate this: their failure
+	 * already reads as `unavailable — <kind>` in `status`.
+	 */
+	readonly scanErrors?: readonly IntegrationScanError[];
 }
 
 /** Curated installation & configuration health report — the `status` MCP tool result. */
@@ -263,11 +276,18 @@ export function buildStatusSummary(
 	const integrations: StatusIntegration[] = buildIntegrationRows(status, {
 		claudeEnabled: ctx.account.claudeEnabled,
 		claudeHookActive,
-	}).map(({ name, inputs }) => ({
-		name,
-		detected: true,
-		status: describeIntegrationStatus(inputs),
-	}));
+	}).map(({ name, inputs }) => {
+		// A merged row's `scanError` is gated on BOTH channels failing (so a
+		// healthy channel's session count survives), which means a single broken
+		// channel is invisible in `status`. Recover it into the structured field.
+		const scanErrors = collectIntegrationScanErrors(status, name);
+		return {
+			name,
+			detected: true,
+			status: describeIntegrationStatus(inputs),
+			...(scanErrors.length > 0 ? { scanErrors } : {}),
+		};
+	});
 
 	const site = ctx.account.site ? ctx.account.site.replace(/^https?:\/\//, "") : null;
 	const siteLabel = site ? (ctx.account.diskBacked ? "Jolli Site" : "Last signed-in site") : null;

--- a/vscode/src/providers/StatusTreeProvider.test.ts
+++ b/vscode/src/providers/StatusTreeProvider.test.ts
@@ -1135,14 +1135,20 @@ describe("StatusTreeProvider", () => {
 		expect(String(clineItem?.tooltip)).toContain("VS Code: ✗");
 	});
 
-	it("shows Cline Integration as unavailable when scan errors", async () => {
+	it("surfaces a VS Code scan error as a warn row without masking the healthy CLI", async () => {
+		// Regression (JOLLI-2034): a single collapsed clineScanError REPLACED the
+		// main Cline row, hiding the healthy CLI. The VS Code failure now surfaces
+		// as its own warn row while the merged "detected & enabled" row still shows.
 		const bridge = {
 			cwd: "/repo",
 			getStatus: vi.fn(async () =>
 				makeStatus({
 					clineDetected: true,
+					clineCliDetected: true,
+					clineVscodeDetected: true,
 					clineEnabled: true,
-					clineScanError: { kind: "parse", message: "bad task json" },
+					clineVscodeScanError: { kind: "parse", message: "bad task json" },
+					sessionsBySource: { "cline-cli": 3 },
 				}),
 			),
 		};
@@ -1152,9 +1158,46 @@ describe("StatusTreeProvider", () => {
 		await provider.refresh();
 
 		const items = provider.getChildren();
-		const item = items.find((i) => i.label === "Cline Integration");
-		expect(item?.description).toContain("parse");
-		expect(String(item?.tooltip)).toContain("Cline scan failed");
+		const warnRow = items.find(
+			(i) => i.label === "Cline Integration" && String(i.description).includes("unavailable"),
+		);
+		expect(warnRow?.description).toBe("unavailable — parse");
+		expect(String(warnRow?.tooltip)).toContain("Cline VS Code scan failed");
+		// The merged row still renders the healthy CLI's session count.
+		const healthyRow = items.find(
+			(i) => i.label === "Cline Integration" && String(i.tooltip).includes("CLI: ✓"),
+		);
+		expect(healthyRow?.description).toBe("detected & enabled (3 sessions)");
+	});
+
+	it("renders a separate 'Cline CLI' warn row when clineCliScanError is present", async () => {
+		const bridge = {
+			cwd: "/repo",
+			getStatus: vi.fn(async () =>
+				makeStatus({
+					clineDetected: true,
+					clineCliDetected: true,
+					clineVscodeDetected: true,
+					clineEnabled: true,
+					clineCliScanError: { kind: "fs", message: "permission denied" },
+					sessionsBySource: { cline: 2 },
+				}),
+			),
+		};
+		loadConfigFromDir.mockResolvedValue({ apiKey: "key" });
+
+		const provider = makeStatusProvider(bridge as never);
+		await provider.refresh();
+
+		const items = provider.getChildren();
+		const cliWarn = items.find((i) => i.label === "Cline CLI");
+		expect(cliWarn?.description).toBe("unavailable — fs");
+		expect(String(cliWarn?.tooltip)).toContain("permission denied");
+		// Main row unaffected.
+		const healthyRow = items.find(
+			(i) => i.label === "Cline Integration" && String(i.description).includes("detected & enabled"),
+		);
+		expect(healthyRow?.description).toBe("detected & enabled (2 sessions)");
 	});
 
 	// ── Auth-aware status rows ────────────────────────────────────────────

--- a/vscode/src/providers/StatusTreeProvider.ts
+++ b/vscode/src/providers/StatusTreeProvider.ts
@@ -405,33 +405,43 @@ function buildFullStatusItems(
 	);
 
 	// Cline integration: shared `clineEnabled` toggle for the terminal CLI and the
-	// VS Code extension. Like Cursor/OpenCode, a scan error replaces the main row
-	// with a dedicated warn row (single scan channel, unlike Copilot's two).
-	if (s.clineScanError) {
+	// VS Code extension. Each form has its own scan-error channel; each surfaces
+	// as a separate warn row while the merged row is ALWAYS shown, so a broken
+	// channel never masks a healthy sibling (mirrors Cursor/Copilot; JOLLI-2034).
+	if (s.clineVscodeScanError) {
 		items.push(
 			new StatusItem(
 				"Cline Integration",
-				`unavailable — ${s.clineScanError.kind}`,
+				`unavailable — ${s.clineVscodeScanError.kind}`,
 				ICON_WARN,
-				`Cline scan failed (${s.clineScanError.kind}): ${s.clineScanError.message}`,
+				`Cline VS Code scan failed (${s.clineVscodeScanError.kind}): ${s.clineVscodeScanError.message}`,
 			),
 		);
-	} else {
-		const clineCliMark = s.clineCliDetected ? "✓" : "✗";
-		const clineVscodeMark = s.clineVscodeDetected ? "✓" : "✗";
-		const clineSessions = (counts.cline ?? 0) + (counts["cline-cli"] ?? 0);
-		pushIntegrationItem(
-			items,
-			s.clineDetected ?? false,
-			s.clineEnabled !== false,
-			undefined,
-			"Cline Integration",
-			`Cline detected (CLI: ${clineCliMark}, VS Code: ${clineVscodeMark}) — session discovery is enabled`,
-			`Cline detected (CLI: ${clineCliMark}, VS Code: ${clineVscodeMark}) but session discovery is disabled in config`,
-			undefined,
-			clineSessions,
+	}
+	if (s.clineCliScanError) {
+		items.push(
+			new StatusItem(
+				"Cline CLI",
+				`unavailable — ${s.clineCliScanError.kind}`,
+				ICON_WARN,
+				`Cline CLI scan failed (${s.clineCliScanError.kind}): ${s.clineCliScanError.message}`,
+			),
 		);
 	}
+	const clineCliMark = s.clineCliDetected ? "✓" : "✗";
+	const clineVscodeMark = s.clineVscodeDetected ? "✓" : "✗";
+	const clineSessions = (counts.cline ?? 0) + (counts["cline-cli"] ?? 0);
+	pushIntegrationItem(
+		items,
+		s.clineDetected ?? false,
+		s.clineEnabled !== false,
+		undefined,
+		"Cline Integration",
+		`Cline detected (CLI: ${clineCliMark}, VS Code: ${clineVscodeMark}) — session discovery is enabled`,
+		`Cline detected (CLI: ${clineCliMark}, VS Code: ${clineVscodeMark}) but session discovery is disabled in config`,
+		undefined,
+		clineSessions,
+	);
 
 	// Antigravity: conversations via per-conversation SQLite + plaintext transcript
 	// (no agent hook — scan errors surface like OpenCode/Cursor).


### PR DESCRIPTION
## What & why

`jolli status`, the MCP `status` tool, and the VS Code STATUS tree render some integrations as a single **merged row** covering two independent data channels. `describeIntegrationStatus()` early-returns `unavailable` the moment its single `scanError` field is set — which is only correct for a merged integration when **both** channels have failed. Feeding one channel's error into it let a broken channel mask a perfectly healthy sibling, hiding the working channel's session count and reporting the whole integration as unavailable.

This is the exact defect fixed for **Cursor** in `f5ec76a2`. **Copilot** and **Cline** were not touched there — this PR brings them in line — and the MCP surface was left masking for **all three** (see below).

## Copilot (mirrors the Cursor fix)

- Gate the merged row's `scanError` on **both** `copilotScanError` (CLI) and `copilotChatScanError` (Chat).
- Add a non-masking `↳ CLI scan failed (…)` sub-line, symmetric with the existing Chat sub-line.

## Cline (was strictly worse — needed a field split)

Cline collapsed both channels into one field via `clineScanError = ext.error ?? cli.error`, which **masked** the healthy channel, **dropped** the CLI error whenever the extension also errored, and showed no per-channel failure detail.

- Split `clineScanError` into `clineVscodeScanError` + `clineCliScanError` on `StatusInfo` (`cli/src/Types.ts`); populate each separately in `Installer.ts` (no more `??` collapse).
- Gate the merged row on both being set; render each as its own `↳ VS Code scan failed (…)` / `↳ CLI scan failed (…)` sub-line.
- Fix the same single-field collapse in the VS Code `StatusTreeProvider` (main row was replaced by a warn row) → now emits an independent warn row per channel and **always** shows the merged row, matching Cursor/Copilot.

## MCP `status` tool — the flat-model gap (Copilot, Cline, **Cursor**)

The CLI and VS Code fixes above recover the partial-failure signal through an **extra render layer** (`↳ … scan failed` sub-lines / per-channel warn rows). The MCP `status` tool has no such layer: `buildStatusSummary` serializes each integration into a flat `StatusIntegration` (`name` / `detected` / `status`), so once the merged row's `scanError` is correctly gated on *both* channels, a single broken channel becomes **invisible** — the tool reports `detected & enabled` and AI hosts lose the partial-failure signal entirely. This masking applied to **Cursor** here too, since the render-layer fix never extended to MCP.

- Add a structured `scanErrors?: { channel; kind; message }[]` to `StatusIntegration`, present only when at least one channel failed.
- Collect it via a shared `collectIntegrationScanErrors(status, name)` helper in `StatusCommand.ts` whose channel labels/order mirror the CLI sub-lines verbatim (`CLI`/`Chat`, `VS Code`/`CLI`, `IDE`/`CLI`) — so all three surfaces say the same thing about the same failure.
- Populate it in `buildStatusSummary` for all three dual-variant integrations. The healthy session count stays in `status`; when **both** channels fail, `status` reads `unavailable` **and** `scanErrors` carries both.

Additive, backward-compatible field (the tool result is `JSON.stringify`d, not output-schema-constrained).

## Intentionally unchanged

- **Single-source rows** (Claude, Codex, Gemini, OpenCode, Devin, Antigravity) — each has exactly one channel, so their `scanError → "unavailable"` is correct on every surface, MCP included. `scanErrors` is deliberately **not** populated for them: their failure already surfaces unmasked as `unavailable — <kind>` in `status`.
- The Cline/Copilot/Cursor **detection breakdown** sub-lines (`↳ CLI: ✓, VS Code: ✓`) and session-count merging — unchanged; only scan-error handling changed.
- The MCP `status` **tool description / input schema** — the added output field needs no schema change.

## Tests

TDD (RED→GREEN) on every surface. CLI + VS Code (unchanged from the original PR): one channel broken + the other healthy → row is **not** `unavailable`, the healthy session count still shows, the broken channel's `scan failed` sub-line/warn row is present; both broken → `unavailable`. `Installer.test.ts` asserts the two Cline scan-error fields populate independently (no collapse).

MCP (this update): 4 new `McpTools.test.ts` cases — Copilot single-channel break exposes `scanErrors` while keeping the healthy `status`; Cline single-channel; Cursor **both** channels (`status: "unavailable — corrupt"` + both `scanErrors`); and no `scanErrors` field when a merged integration is fully healthy.

Local verification: `typecheck` + `lint` pass (both workspaces); the two changed files' suites are green (`StatusCommand.test.ts` + `McpTools.test.ts`, 89/89). Full CLI run: 8325 pass — the only failures are the pre-existing `GitClient` / `DaemonWatcher` timing flakes in this sandbox (both pass in isolation; no sync/daemon/git code was touched).
