### PR TITLE
Extract repair ladder into GenerationFix and wire into EnableCommand

### DIFF
--- a/cli/src/Api.test.ts
+++ b/cli/src/Api.test.ts
@@ -151,6 +151,13 @@ vi.mock("./core/localagent/ClaudeExecutableResolver.js", async (importOriginal) 
 vi.mock("./commands/OptionalLogin.js", () => ({
 	offerOptionalJolliLogin: vi.fn().mockResolvedValue(undefined),
 }));
+vi.mock("./commands/GenerationFix.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./commands/GenerationFix.js")>();
+	// Keep the real `canGenerateNow` predicate the enable flow depends on; spy only
+	// the interactive repair ladder so tests can assert whether it ran. The
+	// ladder's own behavior is covered end-to-end in GuidedFrontDoor.test.ts.
+	return { ...actual, promptGenerationFix: vi.fn().mockResolvedValue(false) };
+});
 
 vi.mock("./hooks/PushCompensation.js", () => ({
 	triggerPendingPushRetry: vi.fn().mockResolvedValue(undefined),
@@ -3714,6 +3721,76 @@ describe("CLI", () => {
 				Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
 				vi.mocked(isClaudeCodeUsable).mockReturnValue(false);
 				vi.mocked(loadConfig).mockResolvedValue({});
+			}
+		});
+
+		it("enable repair: local-agent configured but claude broken → repair ladder only, no provider menu", async () => {
+			const { promptGenerationFix } = await import("./commands/GenerationFix.js");
+			const { loadConfig } = await import("./core/SessionTracker.js");
+			vi.mocked(promptGenerationFix).mockClear();
+			vi.mocked(console.log).mockClear();
+			// isClaudeCodeUsable stays false (module default) → local-agent can't generate,
+			// so this configured-but-broken state must go STRAIGHT to the repair ladder.
+			vi.mocked(loadConfig).mockResolvedValue({ aiProvider: "local-agent" });
+			mockUserInput();
+			mockExistsSync.mockReturnValue(false);
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+
+			try {
+				await main(["enable"]);
+				expect(promptGenerationFix).toHaveBeenCalled();
+				// Double-menu avoided: promptSetup is skipped, so its provider menu never
+				// prints — the user sees the repair ladder alone, not two menus.
+				const logs = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
+				expect(logs.some((l) => l.includes("How would you like to generate summaries"))).toBe(false);
+			} finally {
+				Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+				vi.mocked(loadConfig).mockResolvedValue({});
+			}
+		});
+
+		it("enable repair: provider set, no key but signed in → runs the repair ladder", async () => {
+			const { promptGenerationFix } = await import("./commands/GenerationFix.js");
+			const { loadConfig } = await import("./core/SessionTracker.js");
+			vi.mocked(promptGenerationFix).mockClear();
+			// aiProvider=anthropic with no key → can't generate; a stored authToken is a
+			// credential, so the ladder must run rather than finish silently broken.
+			// Clear ANTHROPIC_API_KEY so a var in the runner's env can't make
+			// canGenerateNow report "anthropic-env" and skip the ladder.
+			const origKey = process.env.ANTHROPIC_API_KEY;
+			delete process.env.ANTHROPIC_API_KEY;
+			vi.mocked(loadConfig).mockResolvedValue({ aiProvider: "anthropic", authToken: "tok" });
+			mockUserInput();
+			mockExistsSync.mockReturnValue(false);
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+
+			try {
+				await main(["enable"]);
+				expect(promptGenerationFix).toHaveBeenCalled();
+			} finally {
+				Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+				vi.mocked(loadConfig).mockResolvedValue({});
+				if (origKey !== undefined) process.env.ANTHROPIC_API_KEY = origKey;
+			}
+		});
+
+		it("enable repair: nothing configured (skipped setup) → ladder NOT run, no nudge", async () => {
+			const { promptGenerationFix } = await import("./commands/GenerationFix.js");
+			const { offerOptionalJolliLogin } = await import("./commands/OptionalLogin.js");
+			vi.mocked(promptGenerationFix).mockClear();
+			vi.mocked(offerOptionalJolliLogin).mockClear();
+			// loadConfig stays {} (default) → no credential and no engine: nothing to
+			// repair, and nothing to sync, so neither prompt fires.
+			mockUserInput("3");
+			mockExistsSync.mockReturnValue(false);
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+
+			try {
+				await main(["enable"]);
+				expect(promptGenerationFix).not.toHaveBeenCalled();
+				expect(offerOptionalJolliLogin).not.toHaveBeenCalled();
+			} finally {
+				Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
 			}
 		});
 

--- a/cli/src/Api.test.ts
+++ b/cli/src/Api.test.ts
@@ -142,6 +142,15 @@ vi.mock("open", () => ({
 vi.mock("./auth/Login.js", () => ({
 	browserLogin: vi.fn().mockResolvedValue(undefined),
 }));
+vi.mock("./core/localagent/ClaudeExecutableResolver.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./core/localagent/ClaudeExecutableResolver.js")>();
+	// Default: no local agent detected, so `promptSetup` shows the provider menu
+	// deterministically (never shells out to a real `claude` during tests).
+	return { ...actual, isClaudeCodeUsable: vi.fn(() => false) };
+});
+vi.mock("./commands/OptionalLogin.js", () => ({
+	offerOptionalJolliLogin: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock("./hooks/PushCompensation.js", () => ({
 	triggerPendingPushRetry: vi.fn().mockResolvedValue(undefined),
@@ -3452,29 +3461,25 @@ describe("CLI", () => {
 		});
 
 		it("should run promptSetup after install when interactive", async () => {
-			// Choose "4" (skip), then skip Anthropic key
-			mockUserInput("4", "");
+			// No local agent detected (mocked false) → the provider menu appears. Skip (3).
+			mockUserInput("3");
 			mockExistsSync.mockReturnValue(false);
 			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
 
 			try {
 				await main(["enable"]);
 
-				// promptSetup was reached — it printed the setup menu
 				const calls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
-				expect(calls.some((s) => s.includes("How would you like to use Jolli Memory"))).toBe(true);
+				expect(calls.some((s) => s.includes("How would you like to generate summaries"))).toBe(true);
 			} finally {
 				Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
 			}
 		});
 
-		it("should save API keys and print confirmation when keys are entered interactively", async () => {
+		it("should save an Anthropic key entered interactively (menu choice 2)", async () => {
 			const { saveConfigScoped } = await import("./core/SessionTracker.js");
-			// Construct an on-allowlist key so the new validateJolliApiKey gate passes.
-			const goodMeta = { t: "tenant1", u: "https://tenant1.jolli.ai" };
-			const goodJolliKey = `sk-jol-${Buffer.from(JSON.stringify(goodMeta)).toString("base64url")}.secret`;
-			// Choose "2" (manual Jolli API key), enter key, then enter Anthropic key
-			mockUserInput("2", goodJolliKey, "sk-ant-test-key");
+			// Choice "2" = enter an Anthropic key.
+			mockUserInput("2", "sk-ant-test-key");
 			mockExistsSync.mockReturnValue(false);
 			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
 
@@ -3482,10 +3487,12 @@ describe("CLI", () => {
 				await main(["enable"]);
 
 				const calls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
-				expect(calls.some((s) => s.includes("Jolli API Key:     saved"))).toBe(true);
 				expect(calls.some((s) => s.includes("Anthropic API Key: saved"))).toBe(true);
 				expect(calls.some((s) => s.includes("Configuration saved"))).toBe(true);
-				expect(saveConfigScoped).toHaveBeenCalled();
+				expect(saveConfigScoped).toHaveBeenCalledWith(
+					expect.objectContaining({ apiKey: "sk-ant-test-key", aiProvider: "anthropic" }),
+					expect.any(String),
+				);
 			} finally {
 				Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
 			}
@@ -3513,9 +3520,8 @@ describe("CLI", () => {
 			}
 		});
 
-		it("should display no-API-keys warning when setup is skipped", async () => {
-			// Choose "4" (skip), then skip Anthropic key
-			mockUserInput("4", "");
+		it("should print skip guidance when setup is skipped (menu choice 3)", async () => {
+			mockUserInput("3");
 			mockExistsSync.mockReturnValue(false);
 			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
 			const origKey = process.env.ANTHROPIC_API_KEY;
@@ -3532,12 +3538,12 @@ describe("CLI", () => {
 			}
 		});
 
-		it("should select the Local Agent provider on choice 3 (no key, no Anthropic prompt)", async () => {
+		it("should auto-select Local Agent when a working claude is detected (no menu)", async () => {
 			const { saveConfigScoped } = await import("./core/SessionTracker.js");
-			// Choose "3" (Local Agent). No further input — a fallthrough to the
-			// Anthropic prompt would hang on a missing second answer, so reaching the
-			// end proves the self-sufficient early return.
-			mockUserInput("3");
+			const { isClaudeCodeUsable } = await import("./core/localagent/ClaudeExecutableResolver.js");
+			vi.mocked(isClaudeCodeUsable).mockReturnValue(true);
+			// No menu input — detection auto-selects local agent and returns.
+			mockUserInput();
 			mockExistsSync.mockReturnValue(false);
 			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
 
@@ -3549,11 +3555,12 @@ describe("CLI", () => {
 					expect.any(String),
 				);
 				const calls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
-				expect(calls.some((s) => s.includes("Local Agent (Claude Code subscription)"))).toBe(true);
-				// Self-sufficient: the Anthropic-key prompt must NOT run.
-				expect(calls.some((s) => s.includes("Anthropic API Key"))).toBe(false);
+				expect(calls.some((s) => s.includes("Detected Claude Code"))).toBe(true);
+				// Auto-detected → the provider menu must NOT appear.
+				expect(calls.some((s) => s.includes("How would you like to generate summaries"))).toBe(false);
 			} finally {
 				Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+				vi.mocked(isClaudeCodeUsable).mockReturnValue(false);
 			}
 		});
 
@@ -3631,109 +3638,148 @@ describe("CLI", () => {
 			}
 		});
 
-		it("should show empty line when keys are saved after manual entry", async () => {
-			const { loadConfigFromDir } = await import("./core/SessionTracker.js");
-			// Construct an on-allowlist key so the new validateJolliApiKey gate passes.
-			const goodMeta = { t: "tenant1", u: "https://tenant1.jolli.ai" };
-			const goodJolliKey = `sk-jol-${Buffer.from(JSON.stringify(goodMeta)).toString("base64url")}.secret`;
-			// Choose "2" (manual), enter Jolli key, enter Anthropic key
-			mockUserInput("2", goodJolliKey, "sk-ant-test");
-			mockExistsSync.mockReturnValue(false);
-			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
-			// Mock the 3 calls to loadConfigFromDir:
-			// 1. initial check in promptSetup (empty, show menu)
-			// 2. after manual key entry, check for Anthropic key (has Jolli key now)
-			// 3. final state check in promptAnthropicKey (has both keys)
-			vi.mocked(loadConfigFromDir)
-				.mockResolvedValueOnce({})
-				.mockResolvedValueOnce({ jolliApiKey: goodJolliKey })
-				.mockResolvedValueOnce({ jolliApiKey: goodJolliKey, apiKey: "sk-ant-test" });
-
-			try {
-				await main(["enable"]);
-
-				const calls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
-				expect(calls.some((s) => s.includes("Jolli API Key:     saved"))).toBe(true);
-				expect(calls.some((s) => s.includes("Anthropic API Key: saved"))).toBe(true);
-			} finally {
-				Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
-			}
-		});
-
-		it("should error and set exit code when manual Jolli key fails validation", async () => {
+		it("menu choice 2 then empty Anthropic key → nothing saved for that provider", async () => {
 			const { saveConfigScoped } = await import("./core/SessionTracker.js");
 			vi.mocked(saveConfigScoped).mockClear();
-			// Choose "2" (manual), enter a key that parseJolliApiKey will reject (no sk-jol- prefix),
-			// then skip the Anthropic key prompt that follows.
-			mockUserInput("2", "bad-key", "");
+			mockUserInput("2", ""); // choose Anthropic, then press Enter (skip the key)
 			mockExistsSync.mockReturnValue(false);
 			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
-			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-			const origKey = process.env.ANTHROPIC_API_KEY;
-			delete process.env.ANTHROPIC_API_KEY;
 
 			try {
 				await main(["enable"]);
-
-				const errorCalls = errorSpy.mock.calls.map((c) => String(c[0]));
-				expect(errorCalls.some((s) => s.includes("Error:"))).toBe(true);
-				expect(process.exitCode).toBe(1);
-				// validateJolliApiKey threw before saveConfigScoped could persist the key.
-				expect(saveConfigScoped).not.toHaveBeenCalled();
+				expect(saveConfigScoped).not.toHaveBeenCalledWith(
+					expect.objectContaining({ aiProvider: "anthropic" }),
+					expect.any(String),
+				);
 			} finally {
 				Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
-				errorSpy.mockRestore();
-				if (origKey !== undefined) process.env.ANTHROPIC_API_KEY = origKey;
 			}
 		});
 
-		it("should show no-API-keys warning when manual key is skipped and no Anthropic key", async () => {
-			// Choose "2" (manual), skip Jolli API key, skip Anthropic key
-			mockUserInput("2", "", "");
+		it("enable nudge: Anthropic configured but not signed in → offers sign-in", async () => {
+			const { offerOptionalJolliLogin } = await import("./commands/OptionalLogin.js");
+			const { loadConfig } = await import("./core/SessionTracker.js");
+			vi.mocked(offerOptionalJolliLogin).mockClear();
+			// After promptSetup the config shows an Anthropic key and no Jolli credential.
+			vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-ant-x", aiProvider: "anthropic" });
+			mockUserInput("2", "sk-ant-x");
 			mockExistsSync.mockReturnValue(false);
 			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
-			const origKey = process.env.ANTHROPIC_API_KEY;
-			delete process.env.ANTHROPIC_API_KEY;
 
 			try {
 				await main(["enable"]);
-
-				const calls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
-				expect(calls.some((s) => s.includes("No API keys configured"))).toBe(true);
+				expect(offerOptionalJolliLogin).toHaveBeenCalled();
 			} finally {
 				Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
-				if (origKey !== undefined) process.env.ANTHROPIC_API_KEY = origKey;
+				// Restore the factory default so the persistent override doesn't bleed
+				// into later tests (beforeEach uses clearAllMocks, not resetAllMocks).
+				vi.mocked(loadConfig).mockResolvedValue({});
 			}
 		});
 
-		it("should show no-API-keys warning after browser login when only authToken is saved", async () => {
-			// Simulates the partial-setup case: OAuth succeeds and an authToken is
-			// saved, but backend key-generation fails so no jolliApiKey is set. The
-			// warning must still appear since authToken alone can't drive summaries.
-			const { loadConfigFromDir } = await import("./core/SessionTracker.js");
-			// Choose "1" (browser login), then skip Anthropic key
-			mockUserInput("1", "");
+		it("enable nudge: already can sync (Jolli key) → no sign-in offer", async () => {
+			const { offerOptionalJolliLogin } = await import("./commands/OptionalLogin.js");
+			const { loadConfig, loadConfigFromDir } = await import("./core/SessionTracker.js");
+			vi.mocked(offerOptionalJolliLogin).mockClear();
+			vi.mocked(loadConfigFromDir).mockResolvedValueOnce({ jolliApiKey: "sk-jol-x", apiKey: "sk-ant-x" });
+			vi.mocked(loadConfig).mockResolvedValue({ jolliApiKey: "sk-jol-x" });
+			mockUserInput();
 			mockExistsSync.mockReturnValue(false);
 			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
-			const origKey = process.env.ANTHROPIC_API_KEY;
-			delete process.env.ANTHROPIC_API_KEY;
-			// loadConfigFromDir calls: (1) initial in promptSetup — empty (show menu);
-			// (2) after browserLogin — authToken only; (3) after Jolli setup in
-			// promptSetup; (4) final state check in promptAnthropicKey.
-			vi.mocked(loadConfigFromDir)
-				.mockResolvedValueOnce({})
-				.mockResolvedValueOnce({ authToken: "tok" })
-				.mockResolvedValueOnce({ authToken: "tok" })
-				.mockResolvedValueOnce({ authToken: "tok" });
 
 			try {
 				await main(["enable"]);
+				expect(offerOptionalJolliLogin).not.toHaveBeenCalled();
+			} finally {
+				Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+				vi.mocked(loadConfig).mockResolvedValue({});
+			}
+		});
 
-				const calls = vi.mocked(console.log).mock.calls.map((c) => String(c[0]));
-				expect(calls.some((s) => s.includes("No API keys configured"))).toBe(true);
+		it("enable nudge: local-agent generation, not signed in → offers sign-in", async () => {
+			const { offerOptionalJolliLogin } = await import("./commands/OptionalLogin.js");
+			const { loadConfig } = await import("./core/SessionTracker.js");
+			const { isClaudeCodeUsable } = await import("./core/localagent/ClaudeExecutableResolver.js");
+			vi.mocked(offerOptionalJolliLogin).mockClear();
+			vi.mocked(isClaudeCodeUsable).mockReturnValue(true);
+			vi.mocked(loadConfig).mockResolvedValue({ aiProvider: "local-agent" });
+			mockUserInput();
+			mockExistsSync.mockReturnValue(false);
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+
+			try {
+				await main(["enable"]);
+				expect(offerOptionalJolliLogin).toHaveBeenCalled();
+			} finally {
+				Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+				vi.mocked(isClaudeCodeUsable).mockReturnValue(false);
+				vi.mocked(loadConfig).mockResolvedValue({});
+			}
+		});
+
+		it("jolliApiKey configured, no Anthropic → prompts and saves an Anthropic key", async () => {
+			const { saveConfigScoped, loadConfigFromDir } = await import("./core/SessionTracker.js");
+			vi.mocked(saveConfigScoped).mockClear();
+			vi.mocked(loadConfigFromDir).mockReset();
+			vi.mocked(loadConfigFromDir).mockResolvedValue({ jolliApiKey: "sk-jol-x" });
+			const origKey = process.env.ANTHROPIC_API_KEY;
+			delete process.env.ANTHROPIC_API_KEY;
+			mockUserInput("sk-ant-new");
+			mockExistsSync.mockReturnValue(false);
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+
+			try {
+				await main(["enable"]);
+				expect(saveConfigScoped).toHaveBeenCalledWith(
+					expect.objectContaining({ apiKey: "sk-ant-new" }),
+					expect.any(String),
+				);
 			} finally {
 				Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
 				if (origKey !== undefined) process.env.ANTHROPIC_API_KEY = origKey;
+				vi.mocked(loadConfigFromDir).mockReset();
+				vi.mocked(loadConfigFromDir).mockResolvedValue({});
+			}
+		});
+
+		it("jolliApiKey configured, empty Anthropic input → no Anthropic key saved", async () => {
+			const { saveConfigScoped, loadConfigFromDir } = await import("./core/SessionTracker.js");
+			vi.mocked(saveConfigScoped).mockClear();
+			vi.mocked(loadConfigFromDir).mockReset();
+			vi.mocked(loadConfigFromDir).mockResolvedValue({ jolliApiKey: "sk-jol-x" });
+			const origKey = process.env.ANTHROPIC_API_KEY;
+			delete process.env.ANTHROPIC_API_KEY;
+			mockUserInput(""); // press Enter → skip
+			mockExistsSync.mockReturnValue(false);
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+
+			try {
+				await main(["enable"]);
+				expect(saveConfigScoped).not.toHaveBeenCalledWith(
+					expect.objectContaining({ apiKey: expect.any(String) }),
+					expect.any(String),
+				);
+			} finally {
+				Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+				if (origKey !== undefined) process.env.ANTHROPIC_API_KEY = origKey;
+				vi.mocked(loadConfigFromDir).mockReset();
+				vi.mocked(loadConfigFromDir).mockResolvedValue({});
+			}
+		});
+
+		it("browser login (menu choice 1) completes the interactive enable", async () => {
+			const { browserLogin } = await import("./auth/Login.js");
+			// No local agent → menu → choice "1" = browser login. Terminal choice
+			// (no Anthropic fall-through), so a single answer is enough.
+			mockUserInput("1");
+			mockExistsSync.mockReturnValue(false);
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+
+			try {
+				await main(["enable"]);
+				expect(browserLogin).toHaveBeenCalled();
+			} finally {
+				Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
 			}
 		});
 	});
@@ -5901,12 +5947,22 @@ describe("CLI", () => {
 		});
 
 		it("should skip prompts for already-configured API keys", async () => {
-			vi.mocked(loadConfigFromDir).mockResolvedValueOnce({ jolliApiKey: "existing", apiKey: "existing" });
+			const { loadConfigFromDir } = await import("./core/SessionTracker.js");
+			// Hermetic: drain any leftover mockResolvedValueOnce from prior tests
+			// (the shared beforeEach uses clearAllMocks, which doesn't clear the
+			// once-queue) and return a fully-configured config for every read.
+			vi.mocked(loadConfigFromDir).mockReset();
+			vi.mocked(loadConfigFromDir).mockResolvedValue({ jolliApiKey: "existing", apiKey: "existing" });
 
-			await main(["enable", "--cwd", "/tmp/test-project"]);
+			try {
+				await main(["enable", "--cwd", "/tmp/test-project"]);
 
-			expect(console.log).toHaveBeenCalledWith(expect.stringContaining("configured"));
-			expect(mockQuestion).not.toHaveBeenCalled();
+				expect(console.log).toHaveBeenCalledWith(expect.stringContaining("configured"));
+				expect(mockQuestion).not.toHaveBeenCalled();
+			} finally {
+				vi.mocked(loadConfigFromDir).mockReset();
+				vi.mocked(loadConfigFromDir).mockResolvedValue({});
+			}
 		});
 	});
 

--- a/cli/src/commands/CliUtils.test.ts
+++ b/cli/src/commands/CliUtils.test.ts
@@ -502,4 +502,26 @@ describe("CliUtils", () => {
 			).toBe(false);
 		});
 	});
+
+	describe("isInsideGitWorkTree", () => {
+		it("true when `git rev-parse --is-inside-work-tree` prints 'true'", async () => {
+			mockExecFileSync.mockReturnValue("true\n");
+			const { isInsideGitWorkTree } = await import("./CliUtils.js");
+			expect(isInsideGitWorkTree("/repo")).toBe(true);
+		});
+
+		it("false when it prints 'false' (bare repo / inside .git, exit 0) — stdout, not exit code", async () => {
+			mockExecFileSync.mockReturnValue("false\n");
+			const { isInsideGitWorkTree } = await import("./CliUtils.js");
+			expect(isInsideGitWorkTree("/some/dir")).toBe(false);
+		});
+
+		it("false when git exits non-zero (not a git dir → throws)", async () => {
+			mockExecFileSync.mockImplementation(() => {
+				throw new Error("fatal: not a git repository");
+			});
+			const { isInsideGitWorkTree } = await import("./CliUtils.js");
+			expect(isInsideGitWorkTree("/tmp/x")).toBe(false);
+		});
+	});
 });

--- a/cli/src/commands/CliUtils.ts
+++ b/cli/src/commands/CliUtils.ts
@@ -163,6 +163,34 @@ export function resolveProjectDir(): string {
 	return _cachedProjectDir;
 }
 
+/**
+ * True when `cwd` is inside a git working tree.
+ *
+ * Uses `git rev-parse --is-inside-work-tree`, the canonical check, and tests the
+ * STDOUT (`"true"`) — NOT just the exit code. Inside a bare repo or the `.git`
+ * directory itself the command prints `"false"` yet still exits 0, so an
+ * exit-code-only check would misclassify those as a working tree. Any spawn
+ * failure (git missing, or a non-git dir → non-zero exit) resolves to false.
+ *
+ * The guided front door calls this before touching storage: Jolli attaches
+ * memory to commits, so a non-work-tree run is a dead end rather than something
+ * to configure.
+ */
+export function isInsideGitWorkTree(cwd: string): boolean {
+	try {
+		const out = execFileSyncHidden("git", ["rev-parse", "--is-inside-work-tree"], {
+			cwd,
+			encoding: "utf-8",
+			// Swallow git's own "fatal: not a git repository" so it never leaks to
+			// the user's terminal before jolli's own dead-end message.
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		return out.trim() === "true";
+	} catch {
+		return false;
+	}
+}
+
 /** Formats an ISO date string as "Mon DD" (e.g. "Apr 15"). Falls back to substring on invalid dates. */
 export function formatShortDate(iso: string): string {
 	const d = new Date(iso);

--- a/cli/src/commands/EnableCommand.ts
+++ b/cli/src/commands/EnableCommand.ts
@@ -10,7 +10,6 @@ import { type Command, Option } from "commander";
 import { getJolliUrl, loadAuthToken } from "../auth/AuthConfig.js";
 import { browserLogin } from "../auth/Login.js";
 import { isLocalAgentChild } from "../core/AgentReentry.js";
-import { resolveLlmCredentialSource } from "../core/LlmClient.js";
 import { isClaudeCodeUsable } from "../core/localagent/ClaudeExecutableResolver.js";
 import { getGlobalConfigDir, loadConfig, loadConfigFromDir, saveConfigScoped } from "../core/SessionTracker.js";
 import { track } from "../core/Telemetry.js";
@@ -21,6 +20,7 @@ import { install, uninstall } from "../install/Installer.js";
 import { createLogger, setLogDir } from "../Logger.js";
 import type { InstallResult, JolliMemoryConfig } from "../Types.js";
 import { isInteractive, promptText, resolveProjectDir } from "./CliUtils.js";
+import { canGenerateNow, promptGenerationFix } from "./GenerationFix.js";
 import { offerOptionalJolliLogin } from "./OptionalLogin.js";
 
 const log = createLogger("EnableCommand");
@@ -279,17 +279,45 @@ async function reportEnableResult(
 
 		// Step 2: Interactive provider configuration
 		if (isInteractive() && !options.yes) {
-			await promptSetup();
+			let cfg = await loadConfig();
+			let token = await loadAuthToken();
+			const hasCredential = (): boolean =>
+				Boolean(
+					token ||
+						cfg.jolliApiKey ||
+						cfg.apiKey ||
+						process.env.ANTHROPIC_API_KEY ||
+						cfg.aiProvider === "local-agent",
+				);
+			let canGenerate = canGenerateNow(cfg);
+			// Onboarding menu — EXCEPT when a provider is already configured but simply
+			// broken (has a credential yet can't generate). That case skips straight to
+			// the repair ladder below, so the user sees ONE menu (the fix), not two: the
+			// provider menu AND then the repair menu. Fresh users still onboard;
+			// configured-but-working users still get promptSetup (e.g. to add a second
+			// key). Mirrors the guided front door, which likewise repairs before asking.
+			if (!(hasCredential() && !canGenerate)) {
+				await promptSetup();
+				cfg = await loadConfig();
+				token = await loadAuthToken();
+				canGenerate = canGenerateNow(cfg);
+			}
+			// Repair ladder (parity with the guided front door's Rung 1): a provider
+			// that is configured but can't actually generate — a broken local `claude`,
+			// or an anthropic/jolli key mismatch — gets a one-step fix BEFORE the sync
+			// nudge, so `jolli enable` can't finish with generation silently broken.
+			// Skipped for the fresh user who just chose "Skip" (no credential to repair).
+			if (!canGenerate && hasCredential()) {
+				await promptGenerationFix(cfg);
+				cfg = await loadConfig();
+				token = await loadAuthToken();
+				canGenerate = canGenerateNow(cfg);
+			}
 			// Sign-in nudge (parity with the guided front door's Rung 2): a user
 			// who just configured local-agent / Anthropic generation but isn't
 			// signed in gets offered cloud sync once. Kept INSIDE the interactive
 			// guard so `-y` / non-interactive runs never open a browser login.
-			const cfg = await loadConfig();
-			const canGenerate =
-				cfg.aiProvider === "local-agent"
-					? isClaudeCodeUsable({ overridePath: cfg.localAgentPath })
-					: resolveLlmCredentialSource(cfg) !== null;
-			const canSync = Boolean((await loadAuthToken()) || cfg.jolliApiKey);
+			const canSync = Boolean(token || cfg.jolliApiKey);
 			if (canGenerate && !canSync) {
 				await offerOptionalJolliLogin();
 			}

--- a/cli/src/commands/EnableCommand.ts
+++ b/cli/src/commands/EnableCommand.ts
@@ -7,11 +7,12 @@
 
 import { join } from "node:path";
 import { type Command, Option } from "commander";
-import { getJolliUrl } from "../auth/AuthConfig.js";
+import { getJolliUrl, loadAuthToken } from "../auth/AuthConfig.js";
 import { browserLogin } from "../auth/Login.js";
 import { isLocalAgentChild } from "../core/AgentReentry.js";
-import { validateJolliApiKey } from "../core/JolliApiUtils.js";
-import { getGlobalConfigDir, loadConfigFromDir, saveConfigScoped } from "../core/SessionTracker.js";
+import { resolveLlmCredentialSource } from "../core/LlmClient.js";
+import { isClaudeCodeUsable } from "../core/localagent/ClaudeExecutableResolver.js";
+import { getGlobalConfigDir, loadConfig, loadConfigFromDir, saveConfigScoped } from "../core/SessionTracker.js";
 import { track } from "../core/Telemetry.js";
 import { markSkipExitFlush } from "../core/TelemetryCommandHook.js";
 import { triggerPendingPushRetry } from "../hooks/PushCompensation.js";
@@ -20,52 +21,70 @@ import { install, uninstall } from "../install/Installer.js";
 import { createLogger, setLogDir } from "../Logger.js";
 import type { InstallResult, JolliMemoryConfig } from "../Types.js";
 import { isInteractive, promptText, resolveProjectDir } from "./CliUtils.js";
+import { offerOptionalJolliLogin } from "./OptionalLogin.js";
 
 const log = createLogger("EnableCommand");
 
 /**
- * Interactive setup flow after hooks are installed.
- * Offers browser login (recommended), manual API key entry, or skip.
- * Always uses the global config directory.
+ * Interactive provider-setup flow after hooks are installed. When a fresh config
+ * meets a working local Claude Code CLI it auto-selects the local agent and
+ * returns; otherwise it offers browser sign-in (recommended), an Anthropic key,
+ * or skip. Always uses the global config directory. Shared by `jolli enable` and
+ * the bare-`jolli` guided front door.
  */
 export async function promptSetup(): Promise<void> {
 	const configDir = getGlobalConfigDir();
 	const config = await loadConfigFromDir(configDir);
 
-	// If jolliApiKey is already configured, skip the setup menu
+	// Already signed in / holding a Jolli key → skip the provider menu.
 	if (config.jolliApiKey) {
 		console.log("\n  Jolli API Key:     configured ✓");
 		await promptAnthropicKey(configDir, config);
 		return;
 	}
 
-	console.log("\n  How would you like to use Jolli Memory?\n");
-	console.log("    1. Sign up / Sign in to Jolli (recommended)");
-	console.log("    2. Enter Jolli API Key manually");
-	console.log("    3. Use a local agent CLI — Claude Code subscription, no API key");
-	console.log("    4. Skip for now (configure later)");
+	// Zero-friction default: when nothing is configured yet AND a working local
+	// Claude Code CLI is present, generate summaries through the user's own
+	// subscription (no API key, no sign-in) and skip the menu entirely. Probe
+	// ONLY on a truly fresh config so an existing Anthropic key or a deliberate
+	// provider choice is never second-guessed (and so an already-configured
+	// re-run never pays for the subprocess probe).
+	const fresh = !config.apiKey && !process.env.ANTHROPIC_API_KEY && config.aiProvider === undefined;
+	let noLocalAgent = false;
+	if (fresh) {
+		if (isClaudeCodeUsable({ overridePath: config.localAgentPath })) {
+			await handleLocalAgent(configDir);
+			return;
+		}
+		noLocalAgent = true;
+	}
+
+	// No local agent: the only ways to generate are the Jolli proxy (sign in) or
+	// a direct Anthropic key. "Skip" defers setup — hooks still install, nothing
+	// generates until configured. (Manual Jolli-key entry was retired; set one
+	// with `jolli configure` if needed.)
+	console.log(
+		noLocalAgent
+			? "\n  No local agent CLI found. How would you like to generate summaries?\n"
+			: "\n  How would you like to generate summaries?\n",
+	);
+	console.log("    1. Sign up / Sign in to Jolli (browser login)   [recommended]");
+	console.log("    2. Enter Anthropic API key (sk-ant-...)");
+	console.log("    3. Skip for now (configure later)");
 
 	const answer = await promptText("\n  Choice [1]: ");
 	const choice = answer.trim() || "1";
 
-	if (choice === "1") {
-		await handleBrowserLogin();
-	} else if (choice === "2") {
-		await handleManualApiKey(configDir);
+	// Each choice is terminal — no fall-through to the Anthropic-key prompt (that
+	// stays only on the "already have a Jolli key" path above).
+	if (choice === "2") {
+		await handleAnthropicKey(configDir);
 	} else if (choice === "3") {
-		await handleLocalAgent(configDir);
-		// Local Agent is self-sufficient (drives the tool's own login, holds no
-		// jollimemory key), so skip the Anthropic-key fallback below.
-		return;
-	} else {
-		console.log(`\n  Skipped. You can configure later with 'jolli auth login' or edit:`);
+		console.log("\n  Skipped. Configure later with 'jolli auth login' or 'jolli configure'.");
 		console.log(`    ${join(configDir, "config.json")}\n`);
-		return;
+	} else {
+		await handleBrowserLogin();
 	}
-
-	// After Jolli setup, offer Anthropic key if not configured
-	const updatedConfig = await loadConfigFromDir(configDir);
-	await promptAnthropicKey(configDir, updatedConfig);
 }
 
 /** Opens the browser for OAuth login/signup and saves credentials on callback. */
@@ -84,68 +103,49 @@ async function handleBrowserLogin(): Promise<void> {
 	}
 }
 
-/** Prompts for a Jolli API key and saves it to config. */
-async function handleManualApiKey(configDir: string): Promise<void> {
-	console.log("\n  API Key Configuration");
-	console.log("  ──────────────────────────────────────");
-
-	const key = await promptText("  Jolli API Key (press Enter to skip): ");
+/** Prompts for an Anthropic API key and pins the provider to Anthropic. */
+async function handleAnthropicKey(configDir: string): Promise<void> {
+	const key = await promptText("\n  Anthropic API Key (press Enter to skip): ");
 	if (key) {
-		try {
-			validateJolliApiKey(key);
-		} catch (err) {
-			console.error(`\n  Error: ${(err as Error).message}\n`);
-			process.exitCode = 1;
-			return;
-		}
-		await saveConfigScoped({ jolliApiKey: key } as Partial<JolliMemoryConfig>, configDir);
-		console.log("  Jolli API Key:     saved ✓");
+		await saveConfigScoped({ apiKey: key, aiProvider: "anthropic" } as Partial<JolliMemoryConfig>, configDir);
+		console.log("  Anthropic API Key: saved ✓");
 		console.log(`\n  Configuration saved to ${join(configDir, "config.json")}`);
 	}
 }
 
 /**
- * Selects the Local Agent provider: summaries are generated by driving a
- * locally-installed agent CLI (v1: Claude Code) through its own subscription
- * login, so no jollimemory-held API key is stored. Self-sufficient — the caller
- * does not fall through to the Anthropic-key prompt. Binary liveness is verified
- * by `jolli doctor`, which probes that `claude` is installed and accepts the
- * flags we pass.
+ * Auto-selects the Local Agent provider after a working Claude Code CLI is
+ * detected: summaries are generated by driving the local `claude` (v1) through
+ * the user's own subscription, so no jollimemory-held API key is stored. Reached
+ * only when {@link isClaudeCodeUsable} already returned true on a fresh config,
+ * so the message states the detection plainly and points at how to change it.
  */
 async function handleLocalAgent(configDir: string): Promise<void> {
 	await saveConfigScoped(
 		{ aiProvider: "local-agent", localAgentTool: "claude-code" } as Partial<JolliMemoryConfig>,
 		configDir,
 	);
-	console.log("\n  AI provider:       Local Agent (Claude Code subscription) ✓");
-	console.log("  No API key needed — summaries run through your local `claude` login.");
-	console.log("  Run 'jolli doctor' to verify the claude CLI is installed and signed in.");
+	console.log("\n  ✓ Detected Claude Code — using your subscription to generate summaries (claude -p), no API key.");
+	console.log("  Summaries run through your local `claude` login.");
+	console.log("  Change this anytime: 'jolli auth login', or 'jolli configure --set aiProvider=jolli'.");
 	console.log(`\n  Configuration saved to ${join(configDir, "config.json")}\n`);
 }
 
-/** Prompts for an Anthropic API key if not already configured. */
+/**
+ * Offers an Anthropic API key on the "already have a Jolli key" path (its only
+ * caller — a jolliApiKey is always present here, so summaries can already be
+ * generated; this just lets the user add a direct key on top).
+ */
 async function promptAnthropicKey(configDir: string, config: JolliMemoryConfig): Promise<void> {
 	if (config.apiKey || process.env.ANTHROPIC_API_KEY) {
 		console.log("  Anthropic API Key: configured ✓\n");
 		return;
 	}
-
 	const key = await promptText("  Anthropic API Key (press Enter to skip): ");
 	if (key) {
 		await saveConfigScoped({ apiKey: key } as Partial<JolliMemoryConfig>, configDir);
 		console.log("  Anthropic API Key: saved ✓");
 		console.log(`\n  Configuration saved to ${join(configDir, "config.json")}`);
-	}
-
-	// Check final state
-	const updatedConfig = await loadConfigFromDir(configDir);
-	const hasJolliKey = Boolean(updatedConfig.jolliApiKey);
-	const hasAnthropicKey = updatedConfig.apiKey || process.env.ANTHROPIC_API_KEY;
-
-	if (!hasJolliKey && !hasAnthropicKey) {
-		console.log("\n  Warning: No API keys configured. Jolli Memory summaries will not be generated.");
-		console.log("  Run 'jolli auth login' or 'jolli enable' again to configure, or edit config manually:");
-		console.log(`    ${join(configDir, "config.json")}\n`);
 	} else {
 		console.log("");
 	}
@@ -277,9 +277,22 @@ async function reportEnableResult(
 		console.log("  Jolli Memory (never your code, paths, or memory content). Turn it off with");
 		console.log("  'jolli telemetry off' (or DO_NOT_TRACK=1) · https://www.jolli.ai/telemetry");
 
-		// Step 2: Interactive API key configuration
+		// Step 2: Interactive provider configuration
 		if (isInteractive() && !options.yes) {
 			await promptSetup();
+			// Sign-in nudge (parity with the guided front door's Rung 2): a user
+			// who just configured local-agent / Anthropic generation but isn't
+			// signed in gets offered cloud sync once. Kept INSIDE the interactive
+			// guard so `-y` / non-interactive runs never open a browser login.
+			const cfg = await loadConfig();
+			const canGenerate =
+				cfg.aiProvider === "local-agent"
+					? isClaudeCodeUsable({ overridePath: cfg.localAgentPath })
+					: resolveLlmCredentialSource(cfg) !== null;
+			const canSync = Boolean((await loadAuthToken()) || cfg.jolliApiKey);
+			if (canGenerate && !canSync) {
+				await offerOptionalJolliLogin();
+			}
 		} else {
 			// Non-interactive: print manual config guide
 			const configDir = getGlobalConfigDir();

--- a/cli/src/commands/GenerationFix.ts
+++ b/cli/src/commands/GenerationFix.ts
@@ -1,0 +1,170 @@
+/**
+ * The provider/engine "repair ladder" plus the `canGenerateNow` predicate,
+ * shared by the guided front door (bare `jolli`) and `jolli enable`. When a
+ * credential or provider is configured but generation is still broken, this
+ * offers a one-step fix; both entry points run ONE implementation so their
+ * wording and behavior can't drift.
+ *
+ * Extracted to a neutral module (mirrors `OptionalLogin`) so neither command has
+ * to import the other — `GuidedFrontDoor` already imports `promptSetup` from
+ * `EnableCommand`, so routing the ladder through either would form an import
+ * cycle. This module depends only on `auth/*`, the core config + api-key
+ * helpers, the LLM credential resolver, and the local-agent probe — none of
+ * which import the command modules back.
+ */
+
+import { getJolliUrl } from "../auth/AuthConfig.js";
+import { browserLogin } from "../auth/Login.js";
+import { validateJolliApiKey } from "../core/JolliApiUtils.js";
+import { resolveLlmCredentialSource } from "../core/LlmClient.js";
+import { isClaudeCodeUsable } from "../core/localagent/ClaudeExecutableResolver.js";
+import { getGlobalConfigDir, saveConfigScoped } from "../core/SessionTracker.js";
+import type { JolliMemoryConfig } from "../Types.js";
+import { promptText } from "./CliUtils.js";
+
+/**
+ * True when the current config can actually generate summaries right now. For
+ * the local agent this PROBES the same `claude` binary the commit-time runtime
+ * would use (honoring an explicit `localAgentPath`) so it never disagrees with
+ * what actually generates; for every other provider it defers to
+ * {@link resolveLlmCredentialSource}. Shared verbatim by both the guided front
+ * door and `jolli enable` so the two paths agree on "can generate?".
+ */
+export function canGenerateNow(config: JolliMemoryConfig): boolean {
+	if (config.aiProvider === "local-agent") return isClaudeCodeUsable({ overridePath: config.localAgentPath });
+	return resolveLlmCredentialSource(config) !== null;
+}
+
+/**
+ * Reached only when generation is broken while a credential exists. Routes to the
+ * local-agent repair (R3) when the provider is the local agent, else the
+ * anthropic/jolli key-mismatch repair (R1/R2). Returns whether generation can now
+ * proceed. The provider is only ever changed by an explicit choice here.
+ */
+export async function promptGenerationFix(config: JolliMemoryConfig): Promise<boolean> {
+	const configDir = getGlobalConfigDir();
+
+	// R3: the local agent is configured but `claude` isn't runnable.
+	if (config.aiProvider === "local-agent") {
+		return promptLocalAgentFix(configDir, config.localAgentPath);
+	}
+
+	const provider = config.aiProvider === "jolli" ? "jolli" : "anthropic";
+	const providerName = provider === "jolli" ? "Jolli" : "Anthropic";
+	const hasJolliKey = Boolean(config.jolliApiKey);
+	const hasAnthropicKey = Boolean(config.apiKey || process.env.ANTHROPIC_API_KEY);
+	// The *other* provider already has a key → switching to it fixes generation
+	// with no typing. Symmetric: covers both provider directions.
+	const otherHasKey = provider === "anthropic" ? hasJolliKey : hasAnthropicKey;
+	const otherProvider = provider === "anthropic" ? "jolli" : "anthropic";
+	const otherName = otherProvider === "jolli" ? "Jolli" : "Anthropic";
+	const enterKeyLabel = provider === "anthropic" ? "an Anthropic key" : "a Jolli key";
+	const enterMissingKey = (): Promise<boolean> =>
+		provider === "anthropic" ? promptAndSaveAnthropicKey(configDir) : promptAndSaveJolliKey(configDir);
+
+	console.log(
+		`\n  AI provider is set to ${providerName} but no ${providerName} key is available — memories won't be generated.\n`,
+	);
+
+	if (otherHasKey) {
+		const switchHint = otherProvider === "jolli" ? "use your sign-in" : "use existing key";
+		console.log(`    1. Switch to ${otherName} (${switchHint})`);
+		console.log(`    2. Enter ${enterKeyLabel}`);
+		console.log("    3. Skip for now");
+		const choice = (await promptText("\n  Choice [1]: ")) || "1";
+		if (choice === "3") {
+			console.log("\n  Skipped. Set a key in settings or run `jolli configure` later.\n");
+			return false;
+		}
+		if (choice === "1") {
+			await saveConfigScoped({ aiProvider: otherProvider }, configDir);
+			console.log(`\n  ✓ switched to ${otherName}`);
+			return true;
+		}
+		return enterMissingKey();
+	}
+
+	console.log(`    1. Enter ${enterKeyLabel}`);
+	console.log("    2. Skip for now");
+	const choice = (await promptText("\n  Choice [1]: ")) || "1";
+	if (choice === "2") {
+		console.log("\n  Skipped. Set a key in settings or run `jolli configure` later.\n");
+		return false;
+	}
+	return enterMissingKey();
+}
+
+/**
+ * R3 repair: the provider is Local Agent but no usable `claude` was found.
+ * Offers a retry (re-probe once), or a switch to Jolli / Anthropic, or skip.
+ * Every branch terminates — no infinite retry loop. Returns whether generation
+ * can now proceed.
+ */
+async function promptLocalAgentFix(configDir: string, localAgentPath: string | undefined): Promise<boolean> {
+	console.log(
+		"\n  AI provider is set to Local Agent but no usable `claude` was found — memories won't be generated.\n",
+	);
+	console.log("    1. Retry (after install / upgrade, or `claude login`)");
+	console.log("    2. Switch to Jolli (sign in)");
+	console.log("    3. Enter an Anthropic key");
+	console.log("    4. Skip for now");
+	const choice = (await promptText("\n  Choice [1]: ")) || "1";
+
+	if (choice === "4") {
+		console.log("\n  Skipped. Fix Claude Code or run `jolli configure` later.\n");
+		return false;
+	}
+	if (choice === "2") {
+		try {
+			await browserLogin(getJolliUrl());
+		} catch (err) {
+			console.error(`\n  Login failed: ${err instanceof Error ? err.message : String(err)}\n`);
+			return false;
+		}
+		// Sign-in preserves an explicit local-agent choice (AuthConfig guard), so
+		// switching the engine to Jolli must be set explicitly here.
+		await saveConfigScoped({ aiProvider: "jolli" }, configDir);
+		console.log("\n  ✓ switched to Jolli");
+		return true;
+	}
+	if (choice === "3") {
+		return promptAndSaveAnthropicKey(configDir);
+	}
+	// choice 1 — retry the probe exactly once, then stop.
+	if (isClaudeCodeUsable({ overridePath: localAgentPath })) {
+		console.log("\n  ✓ Claude Code is working now.");
+		return true;
+	}
+	console.log("\n  Still no usable `claude`. Fix it and run `jolli` again, or `jolli configure`.\n");
+	return false;
+}
+
+/** Prompts for an Anthropic API key, saves it, and pins the provider to Anthropic. Returns whether a key was saved. */
+async function promptAndSaveAnthropicKey(configDir: string): Promise<boolean> {
+	const key = await promptText("\n  Anthropic API Key (press Enter to skip): ");
+	if (!key) {
+		console.log("  Skipped. Set a key in settings or run `jolli configure` later.\n");
+		return false;
+	}
+	await saveConfigScoped({ apiKey: key, aiProvider: "anthropic" }, configDir);
+	console.log("\n  ✓ Anthropic key saved");
+	return true;
+}
+
+/** Prompts for a Jolli API key, validates + saves it, and pins the provider to Jolli. Returns whether a key was saved. */
+async function promptAndSaveJolliKey(configDir: string): Promise<boolean> {
+	const key = await promptText("\n  Jolli API Key (press Enter to skip): ");
+	if (!key) {
+		console.log("  Skipped. Set a key in settings or run `jolli configure` later.\n");
+		return false;
+	}
+	try {
+		validateJolliApiKey(key);
+	} catch (err) {
+		console.error(`\n  Error: ${(err as Error).message}\n`);
+		return false;
+	}
+	await saveConfigScoped({ jolliApiKey: key, aiProvider: "jolli" }, configDir);
+	console.log("\n  ✓ Jolli key saved");
+	return true;
+}

--- a/cli/src/commands/GuidedFrontDoor.test.ts
+++ b/cli/src/commands/GuidedFrontDoor.test.ts
@@ -22,6 +22,8 @@ const h = vi.hoisted(() => ({
 	getGlobalConfigDir: vi.fn(),
 	loadUserProfile: vi.fn(),
 	saveUserProfile: vi.fn(),
+	isInsideGitWorkTree: vi.fn(),
+	isClaudeCodeUsable: vi.fn(),
 }));
 
 vi.mock("../auth/AuthConfig.js", () => ({ loadAuthToken: h.loadAuthToken, getJolliUrl: h.getJolliUrl }));
@@ -50,7 +52,16 @@ vi.mock("./SpaceSyncStep.js", () => ({ runSpaceSyncStep: h.runSpaceSyncStep }));
 vi.mock("./BackfillFrontDoorStep.js", () => ({ runBackfillFrontDoorStep: h.runBackfillFrontDoorStep }));
 vi.mock("./CliUtils.js", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("./CliUtils.js")>();
-	return { ...actual, promptText: h.promptText, resolveProjectDir: h.resolveProjectDir };
+	return {
+		...actual,
+		promptText: h.promptText,
+		resolveProjectDir: h.resolveProjectDir,
+		isInsideGitWorkTree: h.isInsideGitWorkTree,
+	};
+});
+vi.mock("../core/localagent/ClaudeExecutableResolver.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../core/localagent/ClaudeExecutableResolver.js")>();
+	return { ...actual, isClaudeCodeUsable: h.isClaudeCodeUsable };
 });
 
 import { getGuidedFrontDoorStatus, runGuidedFrontDoor } from "./GuidedFrontDoor.js";
@@ -102,6 +113,8 @@ describe("GuidedFrontDoor", () => {
 		h.promptSetup.mockResolvedValue(undefined);
 		h.loadUserProfile.mockResolvedValue({});
 		h.saveUserProfile.mockResolvedValue(undefined);
+		h.isInsideGitWorkTree.mockReturnValue(true);
+		h.isClaudeCodeUsable.mockReturnValue(true);
 	});
 
 	afterEach(() => {
@@ -195,7 +208,7 @@ describe("GuidedFrontDoor", () => {
 		expect(out()).not.toContain("signed in ·");
 		expect(out()).toContain("Jolli is listening");
 		expect(h.browserLogin).not.toHaveBeenCalled();
-		expect(h.promptText).not.toHaveBeenCalledWith(expect.stringContaining("Sign in now to sync"));
+		expect(h.promptText).not.toHaveBeenCalledWith(expect.stringContaining("Sign in to Jolli to sync"));
 	});
 
 	it("ANTHROPIC_API_KEY env counts as a credential (status line names Anthropic)", async () => {
@@ -232,7 +245,7 @@ describe("GuidedFrontDoor", () => {
 		h.loadConfig.mockResolvedValue({ apiKey: "sk-ant-x", jolliApiKey: "sk-jol-x", aiProvider: "anthropic" });
 		await runGuidedFrontDoor();
 		expect(out()).toContain("Anthropic API key set (not signed in to Jolli)");
-		expect(h.promptText).not.toHaveBeenCalledWith(expect.stringContaining("Sign in now to sync"));
+		expect(h.promptText).not.toHaveBeenCalledWith(expect.stringContaining("Sign in to Jolli to sync"));
 		expect(h.browserLogin).not.toHaveBeenCalled();
 		expect(out()).toContain("Jolli is listening");
 	});
@@ -252,6 +265,10 @@ describe("GuidedFrontDoor", () => {
 		expect(out()).toContain("5 memories");
 		expect(out()).toContain("signed in");
 		expect(out()).toContain("Restart your AI agent session");
+		// Concise install confirmation (repo basename of the mocked "/repo").
+		expect(out()).toContain("Git hooks added");
+		expect(out()).toContain("Agent hooks + MCP server added");
+		expect(out()).toContain("Jolli Memory enabled in repo");
 	});
 
 	it("front-door enable that FAILS does not clear the manual-disable opt-out", async () => {
@@ -350,7 +367,9 @@ describe("GuidedFrontDoor", () => {
 		await runGuidedFrontDoor();
 
 		expect(out()).toContain("Anthropic API key set (not signed in to Jolli)");
-		expect(h.promptText).toHaveBeenCalledWith(expect.stringContaining("Sign in now to sync memories to a Space"));
+		expect(h.promptText).toHaveBeenCalledWith(
+			expect.stringContaining("Sign in to Jolli to sync memories to a Space"),
+		);
 		expect(h.browserLogin).toHaveBeenCalledWith("https://acme.jolli.ai");
 		expect(out()).toContain("memories will sync to your Space");
 		expect(h.saveUserProfile).not.toHaveBeenCalled();
@@ -411,7 +430,7 @@ describe("GuidedFrontDoor", () => {
 		h.loadUserProfile.mockResolvedValue({ signInPromptDeclined: true });
 		await runGuidedFrontDoor();
 
-		expect(h.promptText).not.toHaveBeenCalledWith(expect.stringContaining("Sign in now to sync"));
+		expect(h.promptText).not.toHaveBeenCalledWith(expect.stringContaining("Sign in to Jolli to sync"));
 		expect(h.browserLogin).not.toHaveBeenCalled();
 		expect(h.saveUserProfile).not.toHaveBeenCalled();
 		expect(out()).toContain("Jolli is listening");
@@ -433,11 +452,16 @@ describe("GuidedFrontDoor", () => {
 
 	it("provider=anthropic + jolliApiKey, choose 'switch to Jolli' → saves aiProvider, listening reflects count", async () => {
 		h.loadAuthToken.mockResolvedValue("oauth-token");
-		h.loadConfig.mockResolvedValue({
-			jolliApiKey: "sk-jol-x",
-			aiProvider: "anthropic",
-			jolliUrl: "https://acme.jolli.ai",
-		});
+		// First read is the pre-switch config (anthropic, no anthropic key → can't
+		// generate → repair). The reload after the switch reflects the persisted
+		// aiProvider=jolli, so the recomputed canGenerate becomes true (jolli-proxy).
+		h.loadConfig
+			.mockResolvedValueOnce({
+				jolliApiKey: "sk-jol-x",
+				aiProvider: "anthropic",
+				jolliUrl: "https://acme.jolli.ai",
+			})
+			.mockResolvedValue({ jolliApiKey: "sk-jol-x", aiProvider: "jolli", jolliUrl: "https://acme.jolli.ai" });
 		h.getSummaryCount.mockResolvedValue(163);
 		h.promptText.mockResolvedValue("1");
 		await runGuidedFrontDoor();
@@ -556,6 +580,151 @@ describe("GuidedFrontDoor", () => {
 		await runGuidedFrontDoor();
 		expect(h.validateJolliApiKey).not.toHaveBeenCalled();
 		expect(h.saveConfigScoped).not.toHaveBeenCalled();
+	});
+
+	// ── Repo gate (not a git working tree) ──
+
+	it("not a git repo → dead end, exitCode 1, no storage / onboarding", async () => {
+		h.isInsideGitWorkTree.mockReturnValue(false);
+		await runGuidedFrontDoor();
+		expect(out()).toContain("not a git repository");
+		expect(out()).toContain("Change into a repo");
+		expect(process.exitCode).toBe(1);
+		expect(h.createStorage).not.toHaveBeenCalled();
+		expect(h.setActiveStorage).not.toHaveBeenCalled();
+		expect(h.promptSetup).not.toHaveBeenCalled();
+		// The dead-end keeps its own header but must NOT print the positive
+		// repo-confirmation line reserved for the happy path.
+		expect(out()).toContain("Jolli guided setup");
+		expect(out()).not.toContain("✓ Git repository");
+	});
+
+	it("inside a git repo → prints the guided-setup header + repo confirmation", async () => {
+		await runGuidedFrontDoor();
+		expect(out()).toContain("Jolli guided setup");
+		expect(out()).toContain("✓ Git repository /repo");
+	});
+
+	// ── M1: signed in + local agent → engine suffix on the status line ──
+
+	it("signed in with local-agent provider → status line names the engine", async () => {
+		h.loadAuthToken.mockResolvedValue("oauth-token");
+		h.loadConfig.mockResolvedValue({ jolliUrl: "https://acme.jolli.ai", aiProvider: "local-agent" });
+		h.getSummaryCount.mockResolvedValue(9);
+		await runGuidedFrontDoor();
+		expect(out()).toContain("signed in · acme.jolli.ai · summaries via Claude Code");
+		expect(out()).toContain("Jolli is listening");
+	});
+
+	// ── R3: local-agent configured but `claude` not usable ──
+
+	it("R3: local agent broken + skip → repair menu, no false listening", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig.mockResolvedValue({ aiProvider: "local-agent" });
+		h.isClaudeCodeUsable.mockReturnValue(false);
+		h.promptText.mockResolvedValue("4"); // skip
+		await runGuidedFrontDoor();
+		expect(out()).toContain("no usable `claude` was found");
+		expect(out()).toContain("Skipped");
+		expect(out()).not.toContain("Jolli is listening");
+		expect(h.runBackfillFrontDoorStep).not.toHaveBeenCalled();
+	});
+
+	it("R3: retry succeeds (claude now usable) → generation restored, listening", async () => {
+		h.loadAuthToken.mockResolvedValue("oauth-token");
+		h.loadConfig.mockResolvedValue({ jolliUrl: "https://acme.jolli.ai", aiProvider: "local-agent" });
+		h.getSummaryCount.mockResolvedValue(1);
+		h.isClaudeCodeUsable.mockReturnValueOnce(false).mockReturnValue(true);
+		h.promptText.mockResolvedValue("1"); // retry
+		await runGuidedFrontDoor();
+		expect(out()).toContain("Claude Code is working now");
+		expect(out()).toContain("Jolli is listening");
+	});
+
+	it("R3: retry still broken → stops, no listening", async () => {
+		h.loadAuthToken.mockResolvedValue("oauth-token");
+		h.loadConfig.mockResolvedValue({ aiProvider: "local-agent" });
+		h.isClaudeCodeUsable.mockReturnValue(false);
+		h.promptText.mockResolvedValue("1"); // retry, still broken
+		await runGuidedFrontDoor();
+		expect(out()).toContain("Still no usable `claude`");
+		expect(out()).not.toContain("Jolli is listening");
+	});
+
+	it("R3: switch to Jolli → browser login + provider set to jolli", async () => {
+		h.loadAuthToken.mockResolvedValueOnce(undefined).mockResolvedValue("new-token");
+		h.loadConfig
+			.mockResolvedValueOnce({ aiProvider: "local-agent" })
+			.mockResolvedValue({ aiProvider: "jolli", jolliApiKey: "sk-jol-new", jolliUrl: "https://acme.jolli.ai" });
+		h.isClaudeCodeUsable.mockReturnValue(false);
+		h.promptText.mockResolvedValue("2"); // switch to Jolli
+		await runGuidedFrontDoor();
+		expect(h.browserLogin).toHaveBeenCalledWith("https://acme.jolli.ai");
+		expect(h.saveConfigScoped).toHaveBeenCalledWith({ aiProvider: "jolli" }, "/global/config");
+		expect(out()).toContain("switched to Jolli");
+	});
+
+	it("R3: switch to Jolli but login fails → no provider change, no listening", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig.mockResolvedValue({ aiProvider: "local-agent" });
+		h.isClaudeCodeUsable.mockReturnValue(false);
+		h.promptText.mockResolvedValue("2");
+		h.browserLogin.mockRejectedValue(new Error("network down"));
+		await runGuidedFrontDoor();
+		expect(errors.join("\n")).toContain("network down");
+		expect(h.saveConfigScoped).not.toHaveBeenCalled();
+		expect(out()).not.toContain("Jolli is listening");
+	});
+
+	it("R3: enter an Anthropic key → saved with provider anthropic", async () => {
+		h.loadAuthToken.mockResolvedValue("oauth-token");
+		h.loadConfig.mockResolvedValue({ jolliUrl: "https://acme.jolli.ai", aiProvider: "local-agent" });
+		h.isClaudeCodeUsable.mockReturnValue(false);
+		h.promptText.mockResolvedValueOnce("3").mockResolvedValueOnce("sk-ant-new");
+		await runGuidedFrontDoor();
+		expect(h.saveConfigScoped).toHaveBeenCalledWith(
+			{ apiKey: "sk-ant-new", aiProvider: "anthropic" },
+			"/global/config",
+		);
+		expect(out()).toContain("Anthropic key saved");
+	});
+
+	it("R3: Enter at the repair menu defaults to Retry", async () => {
+		h.loadAuthToken.mockResolvedValue("oauth-token");
+		h.loadConfig.mockResolvedValue({ aiProvider: "local-agent" });
+		h.isClaudeCodeUsable.mockReturnValue(false); // broken; retry re-probes, still broken
+		h.promptText.mockResolvedValue(""); // Enter → default [1] = Retry
+		await runGuidedFrontDoor();
+		expect(out()).toContain("Still no usable `claude`");
+		expect(out()).not.toContain("Jolli is listening");
+	});
+
+	it("R3: switch to Jolli, login rejects with a non-Error value → still reported", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig.mockResolvedValue({ aiProvider: "local-agent" });
+		h.isClaudeCodeUsable.mockReturnValue(false);
+		h.promptText.mockResolvedValue("2"); // switch to Jolli
+		h.browserLogin.mockRejectedValue("odd failure"); // non-Error rejection
+		await runGuidedFrontDoor();
+		expect(errors.join("\n")).toContain("odd failure");
+		expect(out()).not.toContain("Jolli is listening");
+	});
+
+	// ── Next steps: only on a fresh first-run setup ──
+
+	it("fresh onboarding that becomes usable → prints Next steps", async () => {
+		h.loadAuthToken.mockResolvedValueOnce(undefined).mockResolvedValue("new-token");
+		h.loadConfig.mockResolvedValueOnce({}).mockResolvedValue({ jolliApiKey: "sk-jol-new" });
+		await runGuidedFrontDoor();
+		expect(h.promptSetup).toHaveBeenCalledTimes(1);
+		expect(out()).toContain("Next steps");
+		expect(out()).toContain("jolli recall");
+	});
+
+	it("returning user (already had a credential) → no Next steps", async () => {
+		h.getSummaryCount.mockResolvedValue(3);
+		await runGuidedFrontDoor();
+		expect(out()).not.toContain("Next steps");
 	});
 
 	describe("getGuidedFrontDoorStatus", () => {

--- a/cli/src/commands/GuidedFrontDoor.test.ts
+++ b/cli/src/commands/GuidedFrontDoor.test.ts
@@ -376,15 +376,28 @@ describe("GuidedFrontDoor", () => {
 		expect(out()).toContain("last memory saved");
 	});
 
-	it("local Anthropic key, answer 'n' → records the decline, no login, still listening", async () => {
+	it("local Anthropic key, answer 'n' (not now) → NO decline recorded, no login, offer returns next run", async () => {
 		h.loadAuthToken.mockResolvedValue(undefined);
 		h.loadConfig.mockResolvedValue({ apiKey: "sk-ant-x" });
 		h.promptText.mockResolvedValue("n");
 		await runGuidedFrontDoor();
 
 		expect(h.browserLogin).not.toHaveBeenCalled();
-		expect(h.saveUserProfile).toHaveBeenCalledWith({ signInPromptDeclined: true });
+		// "not now" is transient — nothing is persisted, so it reappears next run.
+		expect(h.saveUserProfile).not.toHaveBeenCalled();
 		expect(out()).toContain("You can sign in anytime");
+		expect(out()).toContain("Jolli is listening");
+	});
+
+	it("local Anthropic key, answer 'd' (don't ask again) → records the decline, no login", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig.mockResolvedValue({ apiKey: "sk-ant-x" });
+		h.promptText.mockResolvedValue("d");
+		await runGuidedFrontDoor();
+
+		expect(h.browserLogin).not.toHaveBeenCalled();
+		expect(h.saveUserProfile).toHaveBeenCalledWith({ signInPromptDeclined: true });
+		expect(out()).toContain("won't ask again");
 		expect(out()).toContain("Jolli is listening");
 	});
 
@@ -401,15 +414,15 @@ describe("GuidedFrontDoor", () => {
 		expect(out()).toContain("Jolli is listening");
 	});
 
-	it("local Anthropic key, decline but persisting the flag fails → swallowed, front door still finishes", async () => {
+	it("local Anthropic key, 'd' but persisting the flag fails → swallowed, front door still finishes", async () => {
 		h.loadAuthToken.mockResolvedValue(undefined);
 		h.loadConfig.mockResolvedValue({ apiKey: "sk-ant-x" });
-		h.promptText.mockResolvedValue("n");
+		h.promptText.mockResolvedValue("d");
 		h.saveUserProfile.mockRejectedValue(new Error("EACCES: read-only home"));
 		await runGuidedFrontDoor();
 
 		expect(h.saveUserProfile).toHaveBeenCalledWith({ signInPromptDeclined: true });
-		expect(out()).toContain("You can sign in anytime");
+		expect(out()).toContain("won't ask again");
 		expect(out()).toContain("Jolli is listening");
 	});
 
@@ -534,7 +547,7 @@ describe("GuidedFrontDoor", () => {
 			.mockResolvedValueOnce({ apiKey: "sk-ant-x", aiProvider: "jolli" })
 			.mockResolvedValueOnce({ apiKey: "sk-ant-x", aiProvider: "anthropic" });
 		h.getSummaryCount.mockResolvedValue(3);
-		h.promptText.mockResolvedValueOnce("1").mockResolvedValueOnce("n"); // switch, then decline login
+		h.promptText.mockResolvedValueOnce("1").mockResolvedValueOnce("d"); // switch, then "don't ask again"
 		await runGuidedFrontDoor();
 		expect(out()).toContain("no Jolli key is available");
 		expect(h.saveConfigScoped).toHaveBeenCalledWith({ aiProvider: "anthropic" }, "/global/config");
@@ -710,7 +723,9 @@ describe("GuidedFrontDoor", () => {
 		expect(out()).not.toContain("Jolli is listening");
 	});
 
-	// ── Next steps: only on a fresh first-run setup ──
+	// ── Next steps: shown on every path that reaches the end (new or returning
+	// user, generation configured or not); only the three early-return dead ends
+	// (not-a-repo / enable-declined / install-failure) omit it. ──
 
 	it("fresh onboarding that becomes usable → prints Next steps", async () => {
 		h.loadAuthToken.mockResolvedValueOnce(undefined).mockResolvedValue("new-token");
@@ -721,9 +736,32 @@ describe("GuidedFrontDoor", () => {
 		expect(out()).toContain("jolli recall");
 	});
 
-	it("returning user (already had a credential) → no Next steps", async () => {
+	it("returning user (already had a credential) → still prints Next steps", async () => {
 		h.getSummaryCount.mockResolvedValue(3);
 		await runGuidedFrontDoor();
+		expect(h.promptSetup).not.toHaveBeenCalled();
+		expect(out()).toContain("Next steps");
+	});
+
+	it("generation not configured (skipped setup) → still prints Next steps but no listening", async () => {
+		h.loadAuthToken.mockResolvedValue(undefined);
+		h.loadConfig.mockResolvedValue({});
+		await runGuidedFrontDoor();
+		expect(out()).toContain("Next steps");
+		expect(out()).not.toContain("Jolli is listening");
+	});
+
+	it("not a git repo → dead end omits Next steps", async () => {
+		h.isInsideGitWorkTree.mockReturnValue(false);
+		await runGuidedFrontDoor();
+		expect(out()).not.toContain("Next steps");
+	});
+
+	it("enable declined → dead end omits Next steps", async () => {
+		h.isGitHookInstalled.mockResolvedValue(false);
+		h.promptText.mockResolvedValue("n");
+		await runGuidedFrontDoor();
+		expect(out()).toContain("Not enabled");
 		expect(out()).not.toContain("Next steps");
 	});
 

--- a/cli/src/commands/GuidedFrontDoor.ts
+++ b/cli/src/commands/GuidedFrontDoor.ts
@@ -20,12 +20,9 @@
  */
 
 import { basename } from "node:path";
-import { getJolliUrl, loadAuthToken } from "../auth/AuthConfig.js";
-import { browserLogin } from "../auth/Login.js";
-import { validateJolliApiKey } from "../core/JolliApiUtils.js";
+import { loadAuthToken } from "../auth/AuthConfig.js";
 import { resolveLlmCredentialSource } from "../core/LlmClient.js";
-import { isClaudeCodeUsable } from "../core/localagent/ClaudeExecutableResolver.js";
-import { getGlobalConfigDir, loadConfig, saveConfigScoped } from "../core/SessionTracker.js";
+import { loadConfig } from "../core/SessionTracker.js";
 import { createStorage } from "../core/StorageFactory.js";
 import { getSummaryCount, setActiveStorage } from "../core/SummaryStore.js";
 import { track } from "../core/Telemetry.js";
@@ -33,10 +30,10 @@ import { triggerPendingPushRetry } from "../hooks/PushCompensation.js";
 import { isGitHookInstalled } from "../install/GitHookInstaller.js";
 import { install } from "../install/Installer.js";
 import { setLogDir } from "../Logger.js";
-import type { JolliMemoryConfig } from "../Types.js";
 import { runBackfillFrontDoorStep } from "./BackfillFrontDoorStep.js";
 import { isAffirmative, isInsideGitWorkTree, promptText, resolveProjectDir } from "./CliUtils.js";
 import { promptSetup } from "./EnableCommand.js";
+import { canGenerateNow, promptGenerationFix } from "./GenerationFix.js";
 import { offerOptionalJolliLogin } from "./OptionalLogin.js";
 import { runSpaceSyncStep } from "./SpaceSyncStep.js";
 
@@ -70,21 +67,6 @@ function siteHost(jolliUrl: string | undefined): string | undefined {
 	} catch {
 		return undefined;
 	}
-}
-
-/**
- * Whether summaries can be generated with the current config. Mirrors
- * `resolveLlmCredentialSource`, EXCEPT for the local agent: that resolver returns
- * "local-agent" unconditionally (it never probes the binary), so here we
- * additionally verify `claude` is actually runnable — this is what surfaces a
- * broken local agent (R3) on the interactive path instead of at commit time.
- */
-function canGenerateNow(config: JolliMemoryConfig): boolean {
-	// Probe the SAME binary the commit-time runtime would use — honor an explicit
-	// localAgentPath, else default PATH discovery — so this never disagrees with
-	// what actually generates summaries.
-	if (config.aiProvider === "local-agent") return isClaudeCodeUsable({ overridePath: config.localAgentPath });
-	return resolveLlmCredentialSource(config) !== null;
 }
 
 /**
@@ -234,7 +216,9 @@ export async function runGuidedFrontDoor(): Promise<void> {
 	await runSpaceSyncStep(cwd);
 	triggerPendingPushRetry(cwd, "cli-front-door");
 
-	// ── Closing: only promise "listening" when generation works. ──
+	// ── Closing: only promise "listening" when generation actually works. The
+	// back-fill offer and the listening line stay gated on canGenerate so we never
+	// claim to be capturing memories with no engine to build them. ──
 	if (canGenerate) {
 		// Cold-start back-fill offer (unchanged). Best-effort — never throws.
 		await runBackfillFrontDoorStep(cwd);
@@ -243,154 +227,25 @@ export async function runGuidedFrontDoor(): Promise<void> {
 			summaryCount === 0
 				? "Jolli is listening — your next commit is your first memory"
 				: "Jolli is listening — last memory saved.";
-		console.log(`\n  ${listening}\n`);
-
-		// Next steps only on a fresh setup (onboarding ran this run) — a returning
-		// user doesn't need the orientation again, and the not-a-repo / not-enabled
-		// dead ends never reach here.
-		if (ranOnboarding) printNextSteps();
+		console.log(`\n  ${listening}`);
 	}
+
+	// Next steps orientation — printed on EVERY path that reaches here, for new
+	// and returning users alike and whether or not generation is configured
+	// (unlike the listening line above, it makes no promise that could be false).
+	// The ONLY states that never show Next steps are the three early-return dead
+	// ends earlier in this function, none of which reach this line:
+	//   1. not a git repository        → returned early with exitCode 1
+	//   2. enable declined at the [Y/n] prompt → returned early (a valid choice)
+	//   3. install failure             → returned early with exitCode 1
+	printNextSteps();
 }
 
-/** Prints the one-time orientation shown after a successful first-run setup. */
+/** Prints the closing orientation shown on every non-dead-end front-door run. */
 function printNextSteps(): void {
-	console.log("  Next steps");
+	console.log("\n  Next steps");
 	console.log("    1. Keep working in your agent — every commit becomes a memory, automatically.");
 	console.log("    2. Reach back: jolli recall · jolli search · jolli compile · jolli graph · jolli mcp");
 	console.log("    3. In your editor: add the VS Code extension or IntelliJ plugin.");
 	console.log("    4. See all commands: jolli help\n");
-}
-
-/**
- * Reached only when generation is broken while a credential exists. Routes to the
- * local-agent repair (R3) when the provider is the local agent, else the
- * anthropic/jolli key-mismatch repair (R1/R2). Returns whether generation can now
- * proceed. The provider is only ever changed by an explicit choice here.
- */
-async function promptGenerationFix(config: JolliMemoryConfig): Promise<boolean> {
-	const configDir = getGlobalConfigDir();
-
-	// R3: the local agent is configured but `claude` isn't runnable.
-	if (config.aiProvider === "local-agent") {
-		return promptLocalAgentFix(configDir, config.localAgentPath);
-	}
-
-	const provider = config.aiProvider === "jolli" ? "jolli" : "anthropic";
-	const providerName = provider === "jolli" ? "Jolli" : "Anthropic";
-	const hasJolliKey = Boolean(config.jolliApiKey);
-	const hasAnthropicKey = Boolean(config.apiKey || process.env.ANTHROPIC_API_KEY);
-	// The *other* provider already has a key → switching to it fixes generation
-	// with no typing. Symmetric: covers both provider directions.
-	const otherHasKey = provider === "anthropic" ? hasJolliKey : hasAnthropicKey;
-	const otherProvider = provider === "anthropic" ? "jolli" : "anthropic";
-	const otherName = otherProvider === "jolli" ? "Jolli" : "Anthropic";
-	const enterKeyLabel = provider === "anthropic" ? "an Anthropic key" : "a Jolli key";
-	const enterMissingKey = (): Promise<boolean> =>
-		provider === "anthropic" ? promptAndSaveAnthropicKey(configDir) : promptAndSaveJolliKey(configDir);
-
-	console.log(
-		`\n  AI provider is set to ${providerName} but no ${providerName} key is available — memories won't be generated.\n`,
-	);
-
-	if (otherHasKey) {
-		const switchHint = otherProvider === "jolli" ? "use your sign-in" : "use existing key";
-		console.log(`    1. Switch to ${otherName} (${switchHint})`);
-		console.log(`    2. Enter ${enterKeyLabel}`);
-		console.log("    3. Skip for now");
-		const choice = (await promptText("\n  Choice [1]: ")) || "1";
-		if (choice === "3") {
-			console.log("\n  Skipped. Set a key in settings or run `jolli configure` later.\n");
-			return false;
-		}
-		if (choice === "1") {
-			await saveConfigScoped({ aiProvider: otherProvider }, configDir);
-			console.log(`\n  ✓ switched to ${otherName}`);
-			return true;
-		}
-		return enterMissingKey();
-	}
-
-	console.log(`    1. Enter ${enterKeyLabel}`);
-	console.log("    2. Skip for now");
-	const choice = (await promptText("\n  Choice [1]: ")) || "1";
-	if (choice === "2") {
-		console.log("\n  Skipped. Set a key in settings or run `jolli configure` later.\n");
-		return false;
-	}
-	return enterMissingKey();
-}
-
-/**
- * R3 repair: the provider is Local Agent but no usable `claude` was found.
- * Offers a retry (re-probe once), or a switch to Jolli / Anthropic, or skip.
- * Every branch terminates — no infinite retry loop. Returns whether generation
- * can now proceed.
- */
-async function promptLocalAgentFix(configDir: string, localAgentPath: string | undefined): Promise<boolean> {
-	console.log(
-		"\n  AI provider is set to Local Agent but no usable `claude` was found — memories won't be generated.\n",
-	);
-	console.log("    1. Retry (after install / upgrade, or `claude login`)");
-	console.log("    2. Switch to Jolli (sign in)");
-	console.log("    3. Enter an Anthropic key");
-	console.log("    4. Skip for now");
-	const choice = (await promptText("\n  Choice [1]: ")) || "1";
-
-	if (choice === "4") {
-		console.log("\n  Skipped. Fix Claude Code or run `jolli configure` later.\n");
-		return false;
-	}
-	if (choice === "2") {
-		try {
-			await browserLogin(getJolliUrl());
-		} catch (err) {
-			console.error(`\n  Login failed: ${err instanceof Error ? err.message : String(err)}\n`);
-			return false;
-		}
-		// Sign-in preserves an explicit local-agent choice (AuthConfig guard), so
-		// switching the engine to Jolli must be set explicitly here.
-		await saveConfigScoped({ aiProvider: "jolli" }, configDir);
-		console.log("\n  ✓ switched to Jolli");
-		return true;
-	}
-	if (choice === "3") {
-		return promptAndSaveAnthropicKey(configDir);
-	}
-	// choice 1 — retry the probe exactly once, then stop.
-	if (isClaudeCodeUsable({ overridePath: localAgentPath })) {
-		console.log("\n  ✓ Claude Code is working now.");
-		return true;
-	}
-	console.log("\n  Still no usable `claude`. Fix it and run `jolli` again, or `jolli configure`.\n");
-	return false;
-}
-
-/** Prompts for an Anthropic API key, saves it, and pins the provider to Anthropic. Returns whether a key was saved. */
-async function promptAndSaveAnthropicKey(configDir: string): Promise<boolean> {
-	const key = await promptText("\n  Anthropic API Key (press Enter to skip): ");
-	if (!key) {
-		console.log("  Skipped. Set a key in settings or run `jolli configure` later.\n");
-		return false;
-	}
-	await saveConfigScoped({ apiKey: key, aiProvider: "anthropic" }, configDir);
-	console.log("\n  ✓ Anthropic key saved");
-	return true;
-}
-
-/** Prompts for a Jolli API key, validates + saves it, and pins the provider to Jolli. Returns whether a key was saved. */
-async function promptAndSaveJolliKey(configDir: string): Promise<boolean> {
-	const key = await promptText("\n  Jolli API Key (press Enter to skip): ");
-	if (!key) {
-		console.log("  Skipped. Set a key in settings or run `jolli configure` later.\n");
-		return false;
-	}
-	try {
-		validateJolliApiKey(key);
-	} catch (err) {
-		console.error(`\n  Error: ${(err as Error).message}\n`);
-		return false;
-	}
-	await saveConfigScoped({ jolliApiKey: key, aiProvider: "jolli" }, configDir);
-	console.log("\n  ✓ Jolli key saved");
-	return true;
 }

--- a/cli/src/commands/GuidedFrontDoor.ts
+++ b/cli/src/commands/GuidedFrontDoor.ts
@@ -2,40 +2,43 @@
  * The guided front door — what bare `jolli` (no args, interactive TTY) runs.
  *
  * It reads two orthogonal capabilities and guides the next step:
- *   - can generate — is there a usable LLM key (`resolveLlmCredentialSource`)?
+ *   - can generate — is there a usable engine (`canGenerateNow`)? For the local
+ *     agent this actually probes that `claude` is runnable, so a broken CLI is
+ *     caught here rather than silently at commit time.
  *   - can sync     — is there any Jolli credential (OAuth token or jolliApiKey)
  *                    to push memories to a Space?
- * `signedIn` (an OAuth token) is display-only — it decides the status-line
- * wording, never the control flow.
  *
- * Flow: opening status line → capability ladder (fix generation if broken, then
- * offer sign-in if memories can't sync) → cloud side-effects with the settled
- * credentials → a closing "Jolli is listening" when generation works. It
- * replaces running `auth login`, `auth status`, `enable`, and `status` by hand
- * without removing those commands. Everything about the cloud side (pushing to a
- * Space, binding, sync prompts) is delegated to `runSpaceSyncStep`.
+ * Flow (order is fixed and identical across states — a run only shows the steps
+ * its state still needs):
+ *   git repo? → onboarding (fresh only) → repair broken provider → Sign in? →
+ *   Enable? → status line → cloud side-effects → backfill → listening / Next steps
+ *
+ * `Sign in?` deliberately precedes `Enable?`. The opening status line moved to
+ * AFTER `Enable?` so `✓ enabled` is always truthful. Non-git directories are a
+ * dead end (Jolli attaches memory to commits). The exit code is coarse: non-zero
+ * only on a hard blocker (not a repo, install failure); a valid decline is 0.
  */
 
+import { basename } from "node:path";
 import { getJolliUrl, loadAuthToken } from "../auth/AuthConfig.js";
 import { browserLogin } from "../auth/Login.js";
 import { validateJolliApiKey } from "../core/JolliApiUtils.js";
 import { resolveLlmCredentialSource } from "../core/LlmClient.js";
+import { isClaudeCodeUsable } from "../core/localagent/ClaudeExecutableResolver.js";
 import { getGlobalConfigDir, loadConfig, saveConfigScoped } from "../core/SessionTracker.js";
 import { createStorage } from "../core/StorageFactory.js";
 import { getSummaryCount, setActiveStorage } from "../core/SummaryStore.js";
 import { track } from "../core/Telemetry.js";
-import { loadUserProfile, saveUserProfile } from "../core/UserProfile.js";
 import { triggerPendingPushRetry } from "../hooks/PushCompensation.js";
 import { isGitHookInstalled } from "../install/GitHookInstaller.js";
 import { install } from "../install/Installer.js";
-import { createLogger, setLogDir } from "../Logger.js";
+import { setLogDir } from "../Logger.js";
 import type { JolliMemoryConfig } from "../Types.js";
 import { runBackfillFrontDoorStep } from "./BackfillFrontDoorStep.js";
-import { isAffirmative, promptText, resolveProjectDir } from "./CliUtils.js";
+import { isAffirmative, isInsideGitWorkTree, promptText, resolveProjectDir } from "./CliUtils.js";
 import { promptSetup } from "./EnableCommand.js";
+import { offerOptionalJolliLogin } from "./OptionalLogin.js";
 import { runSpaceSyncStep } from "./SpaceSyncStep.js";
-
-const log = createLogger("GuidedFrontDoor");
 
 /** Lightweight front-door status. Deliberately avoids the heavy `getStatus()`. */
 export interface GuidedFrontDoorStatus {
@@ -70,11 +73,47 @@ function siteHost(jolliUrl: string | undefined): string | undefined {
 }
 
 /**
+ * Whether summaries can be generated with the current config. Mirrors
+ * `resolveLlmCredentialSource`, EXCEPT for the local agent: that resolver returns
+ * "local-agent" unconditionally (it never probes the binary), so here we
+ * additionally verify `claude` is actually runnable — this is what surfaces a
+ * broken local agent (R3) on the interactive path instead of at commit time.
+ */
+function canGenerateNow(config: JolliMemoryConfig): boolean {
+	// Probe the SAME binary the commit-time runtime would use — honor an explicit
+	// localAgentPath, else default PATH discovery — so this never disagrees with
+	// what actually generates summaries.
+	if (config.aiProvider === "local-agent") return isClaudeCodeUsable({ overridePath: config.localAgentPath });
+	return resolveLlmCredentialSource(config) !== null;
+}
+
+/**
  * Runs the guided front door. Assumes the caller (Api.ts) has already confirmed
  * an interactive TTY on both stdin and stdout — this never guards for that.
  */
 export async function runGuidedFrontDoor(): Promise<void> {
 	const cwd = resolveProjectDir();
+
+	// ── Repo gate: Jolli attaches memory to commits, so it must run inside a git
+	// working tree. Checked BEFORE storage init so a non-repo doesn't resolve a
+	// bogus Memory Bank path off the cwd. Dead end by design (no git-init offer). ──
+	if (!isInsideGitWorkTree(cwd)) {
+		console.log("\n  Jolli guided setup");
+		console.log(`  Checking directory ${cwd} ..... not a git repository`);
+		console.log("  Jolli attaches memory to your commits, so it must run inside a git repository.");
+		console.log("  Change into a repo and run `jolli` again:");
+		console.log("    % cd ~/code/your-repo");
+		console.log("    % jolli\n");
+		process.exitCode = 1;
+		return;
+	}
+
+	// Repo confirmed: emit the same "Jolli guided setup" header the dead-end
+	// branch prints, plus a positive confirmation line, so the framing is
+	// identical whether the directory is a repo or not.
+	console.log("\n  Jolli guided setup");
+	console.log(`  ✓ Git repository ${cwd}`);
+
 	// Initialise storage the way every other memory-reading command does, so
 	// folder-mode users read from their Memory Bank rather than the orphan-branch
 	// fallback (which also logs a resolveStorage warning).
@@ -86,8 +125,7 @@ export async function runGuidedFrontDoor(): Promise<void> {
 	// Any of these counts as "has some credential" and skips the sign-in guide.
 	// `aiProvider: "local-agent"` is self-sufficient for generation — it drives the
 	// local agent tool's own login, holding no jollimemory credential — so it must
-	// short-circuit the sign-in guide too, matching resolveLlmCredentialSource
-	// (which always honors a "local-agent" choice without a presence check).
+	// short-circuit the onboarding guide too.
 	const hasCredential = (): boolean =>
 		Boolean(
 			token ||
@@ -97,19 +135,58 @@ export async function runGuidedFrontDoor(): Promise<void> {
 				config.aiProvider === "local-agent",
 		);
 
-	// ── Auth axis: no credential at all → run the existing sign-in / config guide ──
-	if (!hasCredential()) {
+	// Snapshot NOW whether onboarding runs this run — it gates Next steps at the
+	// very end, and `hasCredential()` flips to true after a sign-in mid-run, so it
+	// cannot be recomputed there.
+	const ranOnboarding = !hasCredential();
+
+	// ── Auth axis: no credential at all → run the onboarding guide (Claude
+	// auto-detect / provider menu). Shared with `jolli enable` via promptSetup. ──
+	if (ranOnboarding) {
 		await promptSetup();
 		token = await loadAuthToken();
 		config = await loadConfig();
 	}
 
-	// ── Enable axis: not enabled → offer to enable ──
+	// ── Two orthogonal capabilities, recomputed after each interactive step. ──
+	let canGenerate = canGenerateNow(config);
+	let canSync = Boolean(token || config.jolliApiKey);
+
+	// ── Rung 1 (blocking): a credential exists but the chosen provider can't use
+	// it → repair the provider mismatch. Covers R1/R2 (anthropic/jolli) and R3 (a
+	// configured local agent whose `claude` isn't runnable). `hasCredential()`
+	// excludes the fresh user who just skipped setup (nothing to repair). ──
+	if (!canGenerate && hasCredential()) {
+		await promptGenerationFix(config);
+		token = await loadAuthToken();
+		config = await loadConfig();
+		// Recompute from the freshly-saved config, not the fix's optimistic return:
+		// a switch to Jolli only actually restores generation if a jolliApiKey now
+		// exists, so trust canGenerateNow.
+		canGenerate = canGenerateNow(config);
+		canSync = Boolean(token || config.jolliApiKey);
+	}
+
+	// ── Sign in BEFORE enable: generation works but memories can't sync → offer
+	// sign-in once (default Yes; a prior global decline suppresses it). ──
+	if (canGenerate && !canSync) {
+		await offerOptionalJolliLogin();
+		token = await loadAuthToken();
+		config = await loadConfig();
+		// Signing in can flip an unset provider to "jolli"; if no jolliApiKey was
+		// minted, generation is no longer possible — recompute so the closing
+		// "listening" promise stays honest.
+		canGenerate = canGenerateNow(config);
+		canSync = Boolean(token || config.jolliApiKey);
+	}
+
+	// ── Enable axis: offer to enable AFTER identity/provider are settled. ──
 	if (!enabled) {
-		const answer = await promptText("\n  Enable Jolli in this repo? [Y/n] ");
+		const repoName = basename(cwd);
+		const answer = await promptText(`\n  Enable Jolli Memory in ${repoName}? [Y/n] `);
 		if (!isAffirmative(answer)) {
 			console.log("\n  Not enabled. Run `jolli` or `jolli enable` anytime.\n");
-			return;
+			return; // exitCode stays 0 — a valid choice, not an error.
 		}
 		setLogDir(cwd);
 		const result = await install(cwd, { source: "cli", clearManualDisableOnSuccess: true });
@@ -121,70 +198,45 @@ export async function runGuidedFrontDoor(): Promise<void> {
 		}
 		track("surface_enabled", { trigger: "cli" });
 		for (const warning of result.warnings) console.warn(`  Warning: ${warning}`);
+		// Concise install confirmation (the full per-path list stays in `jolli enable`).
+		console.log("\n  ✓ Git hooks added (post-commit, post-rewrite, prepare-commit-msg)");
+		console.log("  ✓ Agent hooks + MCP server added");
+		console.log(`  ✓ Jolli Memory enabled in ${repoName}.`);
 		// Git hooks record commits immediately, but the AI-agent session hooks
 		// (Claude, Gemini) only attach on a fresh session — say so once here.
-		console.log("\n  Restart your AI agent session so it records that session too.");
+		console.log("  Restart your AI agent session so it records that session too.");
 		enabled = true;
-		// enabled is now known true, so only the count can have changed — read it
-		// directly instead of re-running the whole lightweight status.
 		summaryCount = await getSummaryCount(cwd);
 	}
 
-	// ── Two orthogonal capabilities. `signedIn` (a token) is display-only. ──
-	const credSource = resolveLlmCredentialSource(config);
-	let canGenerate = credSource !== null;
-	let canSync = Boolean(token || config.jolliApiKey);
-
-	// ── Status line (opening snapshot; the token picks the wording only) ──
+	// ── Status line (AFTER enable, so `✓ enabled` is always truthful). ──
 	if (token) {
 		const site = siteHost(config.jolliUrl);
-		console.log(site ? `\n  ✓ signed in · ${site}` : "\n  ✓ signed in");
-	} else if (credSource === "local-agent") {
+		const engine = canGenerate && config.aiProvider === "local-agent" ? " · summaries via Claude Code" : "";
+		console.log(site ? `\n  ✓ signed in · ${site}${engine}` : `\n  ✓ signed in${engine}`);
+	} else if (canGenerate && config.aiProvider === "local-agent") {
 		console.log("\n  ✓ local agent set (not signed in to Jolli)");
-	} else if (credSource) {
-		const keyLabel = credSource === "jolli-proxy" ? "Jolli API key" : "Anthropic API key";
+	} else if (canGenerate) {
+		// Label the key that would ACTUALLY be used (credSource), not just whichever
+		// is present — a jolliApiKey alongside aiProvider="anthropic" still generates
+		// via Anthropic.
+		const keyLabel = resolveLlmCredentialSource(config) === "jolli-proxy" ? "Jolli API key" : "Anthropic API key";
 		console.log(`\n  ✓ ${keyLabel} set (not signed in to Jolli)`);
 	} else {
 		console.log("\n  ✗ not signed in — run `jolli auth login` to start generating memories");
 	}
 	console.log(`  ✓ enabled · ${summaryCount} ${summaryCount === 1 ? "memory" : "memories"}`);
 
-	// ── Rung 1 (blocking): a credential exists but the chosen provider can't use
-	// it → repair the provider/key mismatch. `hasCredential()` excludes the fresh
-	// user who just skipped setup (nothing to repair — don't re-ask). ──
-	if (!canGenerate && hasCredential()) {
-		canGenerate = await promptGenerationFix(config);
-		// A key entered / provider switched above may now allow sync too.
-		config = await loadConfig();
-		canSync = Boolean(token || config.jolliApiKey);
-	}
-
-	// ── Rung 2 (non-blocking): generation works, but memories can't leave the
-	// machine → offer sign-in once, defaulting to Yes. A prior decline (persisted
-	// in profile.json) suppresses it. Read the profile lazily — only here. ──
-	if (canGenerate && !canSync) {
-		const profile = await loadUserProfile();
-		if (!profile.signInPromptDeclined) {
-			await promptOptionalLogin();
-			token = await loadAuthToken();
-			config = await loadConfig();
-			canSync = Boolean(token || config.jolliApiKey);
-		}
-	}
-	// ── Cloud side-effects: only after credentials are settled, so a sign-in or
-	// key established above is picked up this run. We are always enabled by here
-	// (the enable axis above either enabled the repo or returned early). Bind the
-	// Space first (runSpaceSyncStep), then push the backlog to it —
-	// triggerPendingPushRetry is idempotent and no-ops when not signed in. ──
+	// ── Cloud side-effects: only after credentials are settled. Bind the Space
+	// first, then push the backlog — triggerPendingPushRetry no-ops when not
+	// signed in. We are always enabled by here (the enable axis returned early on
+	// decline). ──
 	await runSpaceSyncStep(cwd);
 	triggerPendingPushRetry(cwd, "cli-front-door");
 
-	// ── Closing confirmation: only promise "listening" when generation works. ──
+	// ── Closing: only promise "listening" when generation works. ──
 	if (canGenerate) {
-		// Cold-start back-fill offer. Runs after the capability ladder + cloud
-		// side-effects (so it benefits from any key/sign-in just established) and
-		// re-reads the count so the "listening" line reflects memories just built.
-		// Best-effort — the step never throws into the front door. See BackfillFrontDoorStep.
+		// Cold-start back-fill offer (unchanged). Best-effort — never throws.
 		await runBackfillFrontDoorStep(cwd);
 		summaryCount = await getSummaryCount(cwd);
 		const listening =
@@ -192,18 +244,37 @@ export async function runGuidedFrontDoor(): Promise<void> {
 				? "Jolli is listening — your next commit is your first memory"
 				: "Jolli is listening — last memory saved.";
 		console.log(`\n  ${listening}\n`);
+
+		// Next steps only on a fresh setup (onboarding ran this run) — a returning
+		// user doesn't need the orientation again, and the not-a-repo / not-enabled
+		// dead ends never reach here.
+		if (ranOnboarding) printNextSteps();
 	}
 }
 
+/** Prints the one-time orientation shown after a successful first-run setup. */
+function printNextSteps(): void {
+	console.log("  Next steps");
+	console.log("    1. Keep working in your agent — every commit becomes a memory, automatically.");
+	console.log("    2. Reach back: jolli recall · jolli search · jolli compile · jolli graph · jolli mcp");
+	console.log("    3. In your editor: add the VS Code extension or IntelliJ plugin.");
+	console.log("    4. See all commands: jolli help\n");
+}
+
 /**
- * Reached only when generation is broken while a credential exists: the chosen
- * `aiProvider` has no usable key. Offer the zero-typing fix first — switch to
- * whichever provider a key already exists for — then entering the missing key,
- * then skip. The provider is only ever changed by an explicit choice here.
- * Returns whether generation can now proceed (a key was set / provider switched).
+ * Reached only when generation is broken while a credential exists. Routes to the
+ * local-agent repair (R3) when the provider is the local agent, else the
+ * anthropic/jolli key-mismatch repair (R1/R2). Returns whether generation can now
+ * proceed. The provider is only ever changed by an explicit choice here.
  */
 async function promptGenerationFix(config: JolliMemoryConfig): Promise<boolean> {
 	const configDir = getGlobalConfigDir();
+
+	// R3: the local agent is configured but `claude` isn't runnable.
+	if (config.aiProvider === "local-agent") {
+		return promptLocalAgentFix(configDir, config.localAgentPath);
+	}
+
 	const provider = config.aiProvider === "jolli" ? "jolli" : "anthropic";
 	const providerName = provider === "jolli" ? "Jolli" : "Anthropic";
 	const hasJolliKey = Boolean(config.jolliApiKey);
@@ -249,6 +320,51 @@ async function promptGenerationFix(config: JolliMemoryConfig): Promise<boolean> 
 	return enterMissingKey();
 }
 
+/**
+ * R3 repair: the provider is Local Agent but no usable `claude` was found.
+ * Offers a retry (re-probe once), or a switch to Jolli / Anthropic, or skip.
+ * Every branch terminates — no infinite retry loop. Returns whether generation
+ * can now proceed.
+ */
+async function promptLocalAgentFix(configDir: string, localAgentPath: string | undefined): Promise<boolean> {
+	console.log(
+		"\n  AI provider is set to Local Agent but no usable `claude` was found — memories won't be generated.\n",
+	);
+	console.log("    1. Retry (after install / upgrade, or `claude login`)");
+	console.log("    2. Switch to Jolli (sign in)");
+	console.log("    3. Enter an Anthropic key");
+	console.log("    4. Skip for now");
+	const choice = (await promptText("\n  Choice [1]: ")) || "1";
+
+	if (choice === "4") {
+		console.log("\n  Skipped. Fix Claude Code or run `jolli configure` later.\n");
+		return false;
+	}
+	if (choice === "2") {
+		try {
+			await browserLogin(getJolliUrl());
+		} catch (err) {
+			console.error(`\n  Login failed: ${err instanceof Error ? err.message : String(err)}\n`);
+			return false;
+		}
+		// Sign-in preserves an explicit local-agent choice (AuthConfig guard), so
+		// switching the engine to Jolli must be set explicitly here.
+		await saveConfigScoped({ aiProvider: "jolli" }, configDir);
+		console.log("\n  ✓ switched to Jolli");
+		return true;
+	}
+	if (choice === "3") {
+		return promptAndSaveAnthropicKey(configDir);
+	}
+	// choice 1 — retry the probe exactly once, then stop.
+	if (isClaudeCodeUsable({ overridePath: localAgentPath })) {
+		console.log("\n  ✓ Claude Code is working now.");
+		return true;
+	}
+	console.log("\n  Still no usable `claude`. Fix it and run `jolli` again, or `jolli configure`.\n");
+	return false;
+}
+
 /** Prompts for an Anthropic API key, saves it, and pins the provider to Anthropic. Returns whether a key was saved. */
 async function promptAndSaveAnthropicKey(configDir: string): Promise<boolean> {
 	const key = await promptText("\n  Anthropic API Key (press Enter to skip): ");
@@ -277,33 +393,4 @@ async function promptAndSaveJolliKey(configDir: string): Promise<boolean> {
 	await saveConfigScoped({ jolliApiKey: key, aiProvider: "jolli" }, configDir);
 	console.log("\n  ✓ Jolli key saved");
 	return true;
-}
-
-/**
- * Generation works locally, but there's no Jolli credential to sync memories to
- * a Space. Offer to sign in — default Yes, asked once. On an explicit "no" we
- * persist the decline (profile.json) so this never reappears; a login failure is
- * NOT a decline, so it stays unrecorded and the next run can offer again.
- */
-async function promptOptionalLogin(): Promise<void> {
-	const answer = await promptText("\n  Not signed in to Jolli. Sign in now to sync memories to a Space? [Y/n] ");
-	if (!isAffirmative(answer)) {
-		// Persisting the decline is best-effort: a cosmetic "don't ask again" flag
-		// must never abort the front door if the profile dir isn't writable — we
-		// just offer again next run.
-		try {
-			await saveUserProfile({ signInPromptDeclined: true });
-		} catch {
-			log.debug("Could not persist the sign-in decline; will offer again next run");
-		}
-		console.log("  You can sign in anytime with `jolli auth login`.\n");
-		return;
-	}
-	try {
-		await browserLogin(getJolliUrl());
-		console.log("\n  ✓ signed in — memories will sync to your Space.\n");
-	} catch (err) {
-		console.error(`\n  Login failed: ${err instanceof Error ? err.message : String(err)}`);
-		console.log("  You can try again with `jolli auth login`.\n");
-	}
 }

--- a/cli/src/commands/OptionalLogin.ts
+++ b/cli/src/commands/OptionalLogin.ts
@@ -9,13 +9,19 @@
  * form an import cycle). This module only depends on `auth/*`, `UserProfile`,
  * and `CliUtils`, none of which import the command modules back.
  *
- * Semantics:
- *   - Skip entirely if the user previously declined (global, persisted in
- *     `UserProfile.signInPromptDeclined`). Sign-in is a machine-level act, so the
- *     decline is remembered machine-wide, matching where the credential lives.
- *   - Otherwise ask once, default Yes. On an explicit "no" persist the decline so
- *     it never reappears. A login FAILURE is NOT a decline — it stays unrecorded
- *     so the next run can offer again.
+ * Semantics (a three-way choice mirroring the cold-start back-fill prompt, so a
+ * single "no" never permanently silences the offer):
+ *   - Skip entirely if the user previously chose "don't ask again" (global,
+ *     persisted in `UserProfile.signInPromptDeclined`). Sign-in is a machine-level
+ *     act, so the decline is remembered machine-wide, matching where the
+ *     credential lives.
+ *   - Otherwise ask, default Yes:
+ *       [Y] yes             → open the browser sign-in.
+ *       [n] not now         → skip THIS run only; the offer returns next run
+ *                             (nothing persisted).
+ *       [d] don't ask again → persist the decline so it never reappears.
+ *     A login FAILURE is NOT a decline — it stays unrecorded so the next run can
+ *     offer again.
  *
  * The prompt wording is intentionally identical to every other place the choice
  * appears in the guided flow.
@@ -25,7 +31,7 @@ import { getJolliUrl } from "../auth/AuthConfig.js";
 import { browserLogin } from "../auth/Login.js";
 import { loadUserProfile, saveUserProfile } from "../core/UserProfile.js";
 import { createLogger } from "../Logger.js";
-import { isAffirmative, promptText } from "./CliUtils.js";
+import { promptText } from "./CliUtils.js";
 
 const log = createLogger("OptionalLogin");
 
@@ -38,8 +44,17 @@ export async function offerOptionalJolliLogin(): Promise<void> {
 	const profile = await loadUserProfile();
 	if (profile.signInPromptDeclined) return;
 
-	const answer = await promptText("\n  Sign in to Jolli to sync memories to a Space? [Y/n] ");
-	if (!isAffirmative(answer)) {
+	const choice = parseChoice(
+		await promptText(
+			"\n  Sign in to Jolli to sync memories to a Space?  [Y] yes  [n] not now  [d] don't ask again: ",
+		),
+	);
+	if (choice === "no") {
+		// Not now: skip this run only, persist nothing so the offer returns next run.
+		console.log("  You can sign in anytime with `jolli auth login`.\n");
+		return;
+	}
+	if (choice === "dismiss") {
 		// Persisting the decline is best-effort: a cosmetic "don't ask again" flag
 		// must never abort the caller if the profile dir isn't writable — we just
 		// offer again next run.
@@ -48,7 +63,7 @@ export async function offerOptionalJolliLogin(): Promise<void> {
 		} catch {
 			log.debug("Could not persist the sign-in decline; will offer again next run");
 		}
-		console.log("  You can sign in anytime with `jolli auth login`.\n");
+		console.log("  Got it — I won't ask again. Run `jolli auth login` anytime.\n");
 		return;
 	}
 	try {
@@ -58,4 +73,19 @@ export async function offerOptionalJolliLogin(): Promise<void> {
 		console.error(`\n  Login failed: ${err instanceof Error ? err.message : String(err)}`);
 		console.log("  You can try again with `jolli auth login`.\n");
 	}
+}
+
+type SignInChoice = "yes" | "no" | "dismiss";
+
+/**
+ * Maps a prompt answer to a choice. Enter / y / yes → sign in; d / don't / never
+ * → permanent dismiss; everything else (including n / no and any typo) → not now,
+ * the safe non-action that leaves the offer to reappear next run. Mirrors the
+ * cold-start back-fill prompt's parser.
+ */
+function parseChoice(answer: string): SignInChoice {
+	const a = answer.trim().toLowerCase();
+	if (a === "" || a === "y" || a === "yes") return "yes";
+	if (a === "d" || a === "dont" || a === "don't" || a === "never") return "dismiss";
+	return "no";
 }

--- a/cli/src/commands/OptionalLogin.ts
+++ b/cli/src/commands/OptionalLogin.ts
@@ -1,0 +1,61 @@
+/**
+ * The optional "sign in to Jolli to sync" nudge, shared by the guided front door
+ * (bare `jolli`) and `jolli enable`'s report step.
+ *
+ * Extracted to a neutral module so both callers use ONE implementation — same
+ * wording, same "ask once, remember a decline" semantics — and so neither
+ * command has to import the other (`GuidedFrontDoor` already imports
+ * `promptSetup` from `EnableCommand`; routing this helper through either would
+ * form an import cycle). This module only depends on `auth/*`, `UserProfile`,
+ * and `CliUtils`, none of which import the command modules back.
+ *
+ * Semantics:
+ *   - Skip entirely if the user previously declined (global, persisted in
+ *     `UserProfile.signInPromptDeclined`). Sign-in is a machine-level act, so the
+ *     decline is remembered machine-wide, matching where the credential lives.
+ *   - Otherwise ask once, default Yes. On an explicit "no" persist the decline so
+ *     it never reappears. A login FAILURE is NOT a decline — it stays unrecorded
+ *     so the next run can offer again.
+ *
+ * The prompt wording is intentionally identical to every other place the choice
+ * appears in the guided flow.
+ */
+
+import { getJolliUrl } from "../auth/AuthConfig.js";
+import { browserLogin } from "../auth/Login.js";
+import { loadUserProfile, saveUserProfile } from "../core/UserProfile.js";
+import { createLogger } from "../Logger.js";
+import { isAffirmative, promptText } from "./CliUtils.js";
+
+const log = createLogger("OptionalLogin");
+
+/**
+ * Offers the optional Jolli sign-in for cloud sync. No-op when the user has
+ * already declined once. Callers should re-read auth/config afterward to pick up
+ * a fresh sign-in — this returns nothing.
+ */
+export async function offerOptionalJolliLogin(): Promise<void> {
+	const profile = await loadUserProfile();
+	if (profile.signInPromptDeclined) return;
+
+	const answer = await promptText("\n  Sign in to Jolli to sync memories to a Space? [Y/n] ");
+	if (!isAffirmative(answer)) {
+		// Persisting the decline is best-effort: a cosmetic "don't ask again" flag
+		// must never abort the caller if the profile dir isn't writable — we just
+		// offer again next run.
+		try {
+			await saveUserProfile({ signInPromptDeclined: true });
+		} catch {
+			log.debug("Could not persist the sign-in decline; will offer again next run");
+		}
+		console.log("  You can sign in anytime with `jolli auth login`.\n");
+		return;
+	}
+	try {
+		await browserLogin(getJolliUrl());
+		console.log("\n  ✓ signed in — memories will sync to your Space.\n");
+	} catch (err) {
+		console.error(`\n  Login failed: ${err instanceof Error ? err.message : String(err)}`);
+		console.log("  You can try again with `jolli auth login`.\n");
+	}
+}

--- a/cli/src/core/RepoProfile.test.ts
+++ b/cli/src/core/RepoProfile.test.ts
@@ -56,7 +56,7 @@ describe("RepoProfile", () => {
 		expect(await readRepoProfile(cwd)).toEqual({});
 	});
 
-	it("migrates the legacy backfill-card-dismissed marker on read and persists it (read-once)", async () => {
+	it("migrates the legacy backfill-card-dismissed marker on read, persists it, and retires the marker", async () => {
 		// Legacy location: <git-common-dir>/jollimemory/backfill-card-dismissed.
 		const legacyMarker = join(cwd, ".git", "jollimemory", "backfill-card-dismissed");
 		mkdirSync(join(cwd, ".git", "jollimemory"), { recursive: true });
@@ -64,10 +64,11 @@ describe("RepoProfile", () => {
 
 		expect(await readRepoProfile(cwd)).toEqual({ backfillDismissed: true });
 		expect(existsSync(profilePath(cwd))).toBe(true);
+		// A successful migration retires the marker so a later profile.json reset
+		// (deleting the field) can't resurrect a stale dismiss.
+		expect(existsSync(legacyMarker)).toBe(false);
 
-		// Prove the value was PERSISTED, not merely re-derived: remove the legacy
-		// marker and read again — the dismiss must survive from profile.json alone.
-		rmSync(legacyMarker);
+		// The dismiss survives from profile.json alone (marker already gone).
 		expect(await readRepoProfile(cwd)).toEqual({ backfillDismissed: true });
 	});
 
@@ -86,6 +87,25 @@ describe("RepoProfile", () => {
 		expect(await readRepoProfile(cwd)).toEqual({ backfillDismissed: true });
 		// Persist failed → profile.json is still the directory (never became a file).
 		expect(statSync(profilePath(cwd)).isDirectory()).toBe(true);
+		// ...and the marker is preserved (unlink never runs when the persist throws),
+		// so the next read re-migrates.
+		expect(existsSync(join(legacyDir, "backfill-card-dismissed"))).toBe(true);
+	});
+
+	it("migrates and persists even when retiring the marker fails", async () => {
+		// Make the unlink fail deterministically: the marker is a non-empty DIRECTORY,
+		// so fileExists() still sees it but unlink() throws (EISDIR/EPERM). The persist
+		// succeeds, so the dismiss must still land in profile.json without crashing.
+		const legacyMarker = join(cwd, ".git", "jollimemory", "backfill-card-dismissed");
+		mkdirSync(legacyMarker, { recursive: true });
+		writeFileSync(join(legacyMarker, "child"), "keeps the dir non-empty");
+
+		expect(await readRepoProfile(cwd)).toEqual({ backfillDismissed: true });
+		expect(existsSync(profilePath(cwd))).toBe(true);
+		// The marker dir lingers (unlink failed) but is now inert: profile.json carries
+		// the field, so the next read never consults the marker again.
+		expect(existsSync(legacyMarker)).toBe(true);
+		expect(await readRepoProfile(cwd)).toEqual({ backfillDismissed: true });
 	});
 
 	it("does NOT let the legacy marker override an explicit profile value", async () => {

--- a/cli/src/core/RepoProfile.ts
+++ b/cli/src/core/RepoProfile.ts
@@ -143,14 +143,20 @@ export async function readRepoProfile(cwd: string): Promise<RepoProfile> {
 	const { profilePath, legacyMarkerPath } = await resolvePaths(cwd);
 	const profile = await readRaw(profilePath);
 	if (profile.backfillDismissed === undefined && legacyMarkerPath && (await fileExists(legacyMarkerPath))) {
+		const marker = legacyMarkerPath;
 		// Persist under the profile lock, re-reading inside so a concurrent write of
-		// the OTHER field (manuallyDisabled) isn't clobbered. Best-effort: a persist
-		// failure still returns the migrated value, and the next read re-migrates.
+		// the OTHER field (manuallyDisabled) isn't clobbered, then retire the legacy
+		// marker so a later profile.json reset can't resurrect a stale dismiss.
+		// Best-effort throughout: if the persist throws we never reach the unlink, so
+		// the marker survives and the next read re-migrates.
 		await withStrictProfileLock(cwd, async () => {
 			const current = await readRaw(profilePath);
 			if (current.backfillDismissed === undefined) {
 				await writeProfile(profilePath, { ...current, backfillDismissed: true });
 			}
+			// profile.json now durably carries the field, so the marker is obsolete —
+			// a failed unlink just leaves it inert (the field suppresses re-migration).
+			await unlink(marker).catch(() => {});
 		}).catch(() => {});
 		return { ...profile, backfillDismissed: true };
 	}

--- a/cli/src/core/localagent/ClaudeExecutableResolver.test.ts
+++ b/cli/src/core/localagent/ClaudeExecutableResolver.test.ts
@@ -3,7 +3,11 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { execFileSyncHidden } from "../../util/Subprocess.js";
-import { __resetResolverCacheForTest, resolveClaudeExecutable } from "./ClaudeExecutableResolver.js";
+import {
+	__resetResolverCacheForTest,
+	isClaudeCodeUsable,
+	resolveClaudeExecutable,
+} from "./ClaudeExecutableResolver.js";
 import { LocalAgentSetupError } from "./Types.js";
 
 vi.mock("../../util/Subprocess.js", () => ({ execFileSyncHidden: vi.fn() }));
@@ -305,5 +309,23 @@ describe("resolveClaudeExecutable", () => {
 			// Proves the win32 branch ran (`where`, not `which`) and filtered the .cmd out.
 			expect(mockedExecFileSync.mock.calls.some((c) => c[0] === "where")).toBe(true);
 		});
+	});
+});
+
+describe("isClaudeCodeUsable", () => {
+	it("true when a candidate resolves", () => {
+		__resetResolverCacheForTest();
+		expect(
+			isClaudeCodeUsable({
+				candidates: () => ["/a/claude"],
+				probe: () => ({ ok: true, version: "1.0.0" }),
+				now: () => 1000,
+			}),
+		).toBe(true);
+	});
+
+	it("false when nothing resolves (resolveClaudeExecutable throws)", () => {
+		__resetResolverCacheForTest();
+		expect(isClaudeCodeUsable({ candidates: () => [], probe: () => ({ ok: false }), now: () => 1000 })).toBe(false);
 	});
 });

--- a/cli/src/core/localagent/ClaudeExecutableResolver.ts
+++ b/cli/src/core/localagent/ClaudeExecutableResolver.ts
@@ -153,3 +153,25 @@ export function resolveClaudeExecutable(opts: ResolveOpts = {}): ResolvedExecuta
 	cached = { at: now(), key: cacheKey, result: best };
 	return best;
 }
+
+/**
+ * Non-throwing liveness check for the local Claude Code CLI: true when a
+ * compatible `claude` is resolvable (present on PATH / known locations AND it
+ * accepts the flags we pass), false otherwise. Thin wrapper over
+ * {@link resolveClaudeExecutable} so interactive callers (the guided front door,
+ * `promptSetup`) can branch on availability without a try/catch.
+ *
+ * Exported as its own function on purpose: it is the seam tests mock so they
+ * never shell out to a real `claude`. Cost is one `resolveClaudeExecutable`
+ * call — a successful resolution is cached for {@link RESOLUTION_CACHE_TTL_MS},
+ * but a failure is never cached, so a just-installed / just-fixed binary is
+ * picked up on the next call.
+ */
+export function isClaudeCodeUsable(opts: ResolveOpts = {}): boolean {
+	try {
+		resolveClaudeExecutable(opts);
+		return true;
+	} catch {
+		return false;
+	}
+}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (2)

1. Refactor enable flow: auto-detect Claude Code and add optional login nudge (`74bf8a0`) — [Memory](https://jolli.ai/very/o/default/articles/refactor-enable-flow-auto-detect-claude-code-and-add-optional-login-nudge-9092)
2. Extract repair ladder into GenerationFix and wire into EnableCommand (`eb14373`)

## Quick recap (2)

### Commit 1 of 2: Refactor enable flow: auto-detect Claude Code and add optional login nudge (`74bf8a0`)

Users with Claude Code installed now get Jolli configured automatically during setup — no menu, no API key, no account required to start generating memories. The automatic selection happens only when the local tool is verified as actually runnable with Jolli's requests; an installation that exists on disk but cannot be used is passed over and the standard provider menu appears instead.

The guided setup flow was substantially redesigned. The sign-in prompt for cloud sync is now offered before the repository is enabled; identity and generation provider are settled before hooks are installed. The "enabled" status indicator no longer appears until after the enable step actually completes. Directories outside a git repository now show a clear dead-end message and refuse to proceed. A recovery menu was added for users whose local Claude installation stops working after Jolli was already configured: they can retry after fixing the installation, switch to Jolli's cloud proxy, or enter an Anthropic key directly.

The sign-in prompt for cloud sync now appears in the direct enable command path as well, matching the guided flow. A long-standing bug was also fixed: resetting the settings file to clear preferences no longer causes a previously dismissed backfill prompt to reappear. The indicator file tracking that dismissal is now removed at the time the preference is first saved to the main settings file.

### Commit 2 of 2: Extract repair ladder into GenerationFix and wire into EnableCommand (`eb14373`)

The `jolli enable` command can now detect and interactively repair a broken generation setup before finishing. When a configured provider can't actually generate summaries — a broken local Claude installation or mismatched API keys — the same step-by-step repair flow available in the guided walkthrough now appears during enable as well. Users who already have a configured-but-broken provider see a single focused repair menu; the initial provider-selection menu is skipped for that case. A new shared module holds the repair logic used by both entry points, keeping their menus and behavior synchronized.

The sign-in prompt that appears after setup now offers three explicit choices: sign in now, skip this run, or never ask again. A transient skip leaves the offer to reappear on the next run, and only an explicit "don't ask again" answer permanently silences it. The "Next steps" orientation message now appears at the end of every successful run, for both new and returning users and regardless of whether generation is configured. The three situations where it still doesn't appear — not being in a git repository, declining to enable, or an installation failure — all exit before reaching the end of the flow.

## Topics (7)
<details>
<summary><strong>01 · [74bf8a0] Old &quot;don't show backfill offer&quot; setting survives settings file deletion</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user deleted their settings file to clear preferences, a previously dismissed backfill prompt kept reappearing. A separate indicator file that stored the same preference was being read and re-applied but was never removed after the preference was migrated to the main settings file.

**💡 Decisions Behind the Code**

Migrating the preference without removing the source file left two authoritative copies. If the settings file was later deleted, the old file would resurrect a decision the user had tried to clear. Running the deletion inside the same locked write operation keeps cleanup atomic with the save. Any failure to delete is silently ignored — the preference is already in the settings file and takes priority on future reads, so the stale file becomes inert rather than dangerous.

**✅ What Was Implemented**

Modified the migration logic in `RepoProfile.ts` so the legacy marker file is deleted immediately after a successful write to the main profile, inside the same exclusive lock as the write. Three new tests cover the success path (marker deleted after persist), a persist-failure path (marker preserved for re-migration on next read), and a marker-deletion-failure path (deletion fails but migration still completes cleanly).

**📁 FILES**
- `cli/src/core/RepoProfile.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [74bf8a0] Automatically use Claude Code subscription when it is installed, with no setup required</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The JOLLI-2025 feature request asked Jolli to detect a working Claude Code installation and automatically configure it as the memory generation engine, skipping the provider selection menu entirely for users who already have it installed.

**💡 Decisions Behind the Code**

- **Detection runs only on completely unconfigured setups**: The probe fires only when no generation method has been previously set — no stored key, no environment variable, no provider preference. This ensures an existing configuration or deliberate provider choice is never silently replaced when a user re-runs the command.
- **Binary-level verification rather than presence check**: The system runs the Claude Code binary with the flags Jolli actually passes, rather than just checking whether the executable exists on disk. A binary that is installed but not logged in, or that does not support Jolli's flags, would cause every commit to fail silently — the deeper check surfaces this before any repository is configured.
- **Probe exported as a standalone function**: The probe is its own exported symbol so test suites can replace it with a deterministic stub. Without this boundary every automated test of the setup flow would attempt to spawn a real process, producing results that vary by machine and break on CI environments where Claude Code is not installed.

**✅ What Was Implemented**

- Added `isClaudeCodeUsable()` to `ClaudeExecutableResolver.ts` as a non-throwing boolean probe. It invokes the binary with the exact flags Jolli passes at commit time, returning true only when generation would actually succeed. Exported as its own named symbol to serve as a stable test seam that test suites can replace with a deterministic stub.
- Modified `promptSetup` in `EnableCommand.ts` to run the probe on completely unconfigured setups. When a working binary is found, the local agent is selected automatically and the provider menu is skipped. The menu was also reduced from four items to three — Sign in, Anthropic key, Skip — with manual Jolli API key entry removed (still settable via `jolli configure`).

**📁 FILES**
- `cli/src/core/localagent/ClaudeExecutableResolver.ts`
- `cli/src/commands/EnableCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [74bf8a0] Guided setup flow checks for a git repo, reorders steps, and adds recovery for broken local agent</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Running Jolli with no arguments had several behavioral gaps: it could proceed in directories with no git repository and silently misconfigure, the "enabled" status line could appear before the user answered the enable question, the sign-in prompt came after enabling rather than before, and there was no recovery path when the local agent provider was configured but the underlying tool stopped working.

**💡 Decisions Behind the Code**

- **Non-git directories are a hard dead end with no initialization offer**: Jolli's entire value is attached to git commits; a non-git directory cannot produce anything useful. Offering to initialize a repository would add scope and could confuse a user who simply ran the command in the wrong folder.
- **Sign-in settled before enabling the repository**: Confirming identity and generation provider before activating the repository prevents a state where hooks are installed but the user then declines to set up any generation method, leaving the repository enabled with nothing to generate memories.
- **Status line placed after the enable step**: Displaying the "enabled" confirmation before the user answers the enable question risked showing inaccurate state on first runs. Moving it to after the step ensures the display always reflects reality.

**✅ What Was Implemented**

- Added a git working tree check at the very start of `GuidedFrontDoor.ts` before any storage is initialized. Non-git directories produce a clear dead-end message and exit with a non-zero code. The check reads subprocess output text rather than relying on exit code alone, correctly classifying bare repos and the internal `.git` directory as non-work-trees. Added `isInsideGitWorkTree()` to `CliUtils.ts` as the implementation.
- Reordered the guided flow: sign-in is now offered before the enable step, and the status line was moved to after enabling so the "enabled" indicator is always accurate. A header and repo path confirmation are printed on the happy path, and a "Next steps" section appears only after a successful first-run onboarding.
- Added a repair menu (`promptLocalAgentFix`) for when the local agent provider is configured but the binary is not runnable. Users can retry after fixing their installation, switch to Jolli's cloud proxy via browser login, enter an Anthropic key directly, or skip.

**📁 FILES**
- `cli/src/commands/GuidedFrontDoor.ts`
- `cli/src/commands/CliUtils.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [74bf8a0] Sign-in offer now appears consistently in both the guided flow and the enable command</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The optional prompt to sign in for cloud sync appeared only in the interactive guided flow started by running Jolli with no arguments. Users who triggered the enable command directly were never offered the chance to sign in during that same session, leaving them with generation working locally but no path to cloud sync without a separate manual step.

**💡 Decisions Behind the Code**

- **Shared implementation in a neutral module**: Both Jolli entry points need identical sign-in nudge behavior. Placing the logic inside either command would create a circular import dependency, since the guided flow already imports the enable command's shared setup function. A neutral module with no dependencies on the command layer avoids the cycle entirely.
- **Decline remembered machine-wide, not per repository**: Signing in stores a credential at the machine level, not scoped to a project. Remembering a decline at the same scope — across all repositories on that machine — is consistent with where the credential itself lives.

**✅ What Was Implemented**

- Created `OptionalLogin.ts` as a new shared module with a single exported function. It owns the "ask once, remember a decline" semantics — reads the machine-wide preference, prompts with consistent wording, persists a decline, and handles login failure — so both callers share one implementation.
- Updated `GuidedFrontDoor.ts` to call the shared function in place of its inline version. Added the same call to `reportEnableResult` in `EnableCommand.ts`, gated inside the interactive-mode check so automated and scripted runs never open a browser.

**📁 FILES**
- `cli/src/commands/OptionalLogin.ts`
- `cli/src/commands/EnableCommand.ts`
- `cli/src/commands/GuidedFrontDoor.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [eb14373] Repair broken generation setup interactively during jolli enable</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code review found that `jolli enable` could complete successfully while leaving generation silently broken. If a user had a configured provider that couldn't actually produce summaries — a broken local Claude installation, or mismatched keys — the command would finish without warning or offering a fix.

**💡 Decisions Behind the Code**

- **Full repair over a warning**: Two approaches were considered — add a warning telling users to run a separate command to fix the broken provider, or wire the full repair flow in-place. The full repair was chosen because it actually resolves the broken state at the point the user is already interacting with the tool, rather than shifting the burden to a follow-up step.
- **Neutral shared module to avoid circular imports**: The guided walkthrough already imports `promptSetup` from the enable command; having the enable command import back from the guided walkthrough would create a cycle. Extracting to a new neutral module — parallel to how `OptionalLogin` is structured — keeps the dependency graph clean and makes the shared logic independently testable.
- **Precise gate to avoid breaking the add-second-key path**: A blanket "skip setup if the user has any credential" gate would have silently removed the intentional behavior where a configured, working user can run `jolli enable` to add a second key (e.g., adding an Anthropic key to a Jolli account). The targeted gate — skip setup only when a credential exists AND generation is broken — hits the problematic case without disrupting the legitimate one.

**✅ What Was Implemented**

- Created `cli/src/commands/GenerationFix.ts`, a new shared module exporting `canGenerateNow` and `promptGenerationFix` (the R1/R2/R3 repair rungs previously private to the guided walkthrough). Extracted verbatim to guarantee the two entry points share a single implementation and can't drift.
- Updated `cli/src/commands/EnableCommand.ts` Step 2 to run the repair ladder when a credential exists but generation is broken, and to reload config and recompute generation capability after the repair before proceeding to the sync nudge. Added a precise gate that skips the initial setup menu for configured-but-broken users, preventing them from seeing two consecutive menus.
- Added three new tests in `Api.test.ts` with a partial mock of `GenerationFix.js` (real `canGenerateNow`, spied `promptGenerationFix`), mirroring how `OptionalLogin` is tested; fixed a test hygiene gap where a missing `ANTHROPIC_API_KEY` delete/restore could cause a false pass in a clean CI environment.

**📁 FILES**
- `cli/src/commands/GenerationFix.ts`
- `cli/src/commands/EnableCommand.ts`
- `cli/src/commands/GuidedFrontDoor.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · [eb14373] Sign-in prompt changed to three-way choice to avoid permanent silent dismissal</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The "Sign in to Jolli?" prompt used a simple yes/no answer, but answering "no" permanently recorded a decline and silenced the prompt on all future runs. A user who just wanted to skip once had no way to do so without accidentally opting out forever.

**💡 Decisions Behind the Code**

- **Align with the existing backfill prompt pattern**: The cold-start backfill prompt already used this exact three-option design and parser logic. Matching it makes both prompts consistent in wording and behavior, and the proven parser (`""` / `y` / `yes` → yes; `d` / `dont` / `don't` / `never` → dismiss; everything else → not now) is copied directly rather than reinvented.
- **Default non-action for unrecognized input**: Any input that isn't an explicit "yes" or "dismiss" — including typos, accidental Enter on a misread — resolves to "not now" rather than to a permanent dismiss. This means the worst accidental outcome is the offer reappearing next run, never a silent permanent opt-out.

**✅ What Was Implemented**

- Updated `cli/src/commands/OptionalLogin.ts` to display `[Y] yes  [n] not now  [d] don't ask again` with a local `parseChoice` function. Answering "n" now skips that run only and persists nothing; only an explicit "d" writes the permanent decline flag.
- Updated `cli/src/commands/GuidedFrontDoor.test.ts` to assert that "n" no longer calls `saveUserProfile`, added a new "d" test asserting the persistence and "won't ask again" wording, and repurposed the persist-failure test to use "d".

**📁 FILES**
- `cli/src/commands/OptionalLogin.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · [eb14373] Next steps orientation shown to all users, not just first-run</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The "Next steps" message listing available commands was only displayed to brand-new users who had just completed their first setup. Returning users and users who had skipped configuration never saw it, even though the guidance is useful regardless of setup state.

**💡 Decisions Behind the Code**

The "Jolli is listening" line promises active summary generation and must stay gated on whether generation actually works. The Next steps section makes no such promise — it lists commands that are available regardless of setup state — so there is no correctness reason to withhold it from users who skipped configuration or already had credentials. The three paths that remain excluded all exit early via explicit returns, making the annotation in comments accurate by construction rather than by fragile runtime logic.

**✅ What Was Implemented**

- Moved the `printNextSteps()` call in `cli/src/commands/GuidedFrontDoor.ts` out of the `canGenerate && ranOnboarding` guard to run unconditionally at the end of the function; the "Jolli is listening" line and backfill offer remain gated on `canGenerate`. Added inline comments identifying the three early-return dead ends (not-a-repo, declined enable, install failure) that naturally never reach this line.
- Updated `GuidedFrontDoor.test.ts`: changed the returning-user test to assert Next steps appear; added tests for the three dead-end paths asserting they don't; added a skipped-setup/no-generation test asserting Next steps appear without the listening line.

**📁 FILES**
- `cli/src/commands/GuidedFrontDoor.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 23, 2026 at 10:43 PM · via Local agent*
<!-- jollimemory-summary-end -->