### PR TITLE
Wire up IDE-bridge NDJSON daemon and JolliShare for slice-2 read path

### DIFF
--- a/cli/src/Api.ts
+++ b/cli/src/Api.ts
@@ -23,10 +23,12 @@ import { registerGraphCommand } from "./commands/GraphCommand.js";
 import { runGuidedFrontDoor } from "./commands/GuidedFrontDoor.js";
 import { registerHealFolderCommand } from "./commands/HealFolderCommand.js";
 import { getHelpGroup } from "./commands/HelpGroups.js";
+import { registerIdeBridgeCommand } from "./commands/IdeBridgeRegistration.js";
 import { registerBindCommand, registerPushCommand, registerSpacesCommand } from "./commands/JolliCloudCommands.js";
 import { registerLocalRunOfferCommand } from "./commands/LocalRunOfferCommand.js";
 import { registerMcpCommand } from "./commands/McpCommand.js";
 import { registerMigrateCommand } from "./commands/MigrateCommand.js";
+import { registerMigrateMemoryBankCommand } from "./commands/MigrateMemoryBankCommand.js";
 import { registerOpenUrlCommand } from "./commands/OpenUrlCommand.js";
 import { registerPrDescriptionCommand } from "./commands/PrDescriptionCommand.js";
 import { registerQueueStatusCommand } from "./commands/QueueStatusCommand.js";
@@ -371,6 +373,7 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 	registerCompileCommand(program);
 	registerGraphCommand(program);
 	registerMigrateCommand(program);
+	registerMigrateMemoryBankCommand(program);
 	registerHealFolderCommand(program);
 	registerExportPromptCommand(program);
 	registerExportCommand(program);
@@ -380,6 +383,7 @@ export async function main(args?: ReadonlyArray<string>): Promise<void> {
 	registerTelemetryCommand(program);
 	registerGenerateCommand(program);
 	registerDaemonCommand(program);
+	registerIdeBridgeCommand(program);
 
 	// Auto-emit `command_invoked` for every command (built-in, plugin, future).
 	// No-op until telemetry is bootstrapped (Cli.ts), so harmless in tests.

--- a/cli/src/commands/DaemonCommand.test.ts
+++ b/cli/src/commands/DaemonCommand.test.ts
@@ -1,0 +1,92 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runDaemonServerMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const setLogDirMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../daemon/DaemonServer.js", () => ({
+	runDaemonServer: runDaemonServerMock,
+}));
+
+vi.mock("../Logger.js", () => ({
+	setLogDir: setLogDirMock,
+	createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+	getJolliMemoryDir: (cwd: string) => `${cwd}/.jolli/jollimemory`,
+}));
+
+// resolveProjectDir shells out to git in production; stub the underlying
+// child_process call so the module-load cache defaults to a stable value.
+vi.mock("../util/Subprocess.js", () => ({
+	execFileSyncHidden: () => "/mock/repo",
+}));
+
+import { registerDaemonCommand } from "./DaemonCommand.js";
+
+function makeProgram(): Command {
+	const program = new Command();
+	program.exitOverride();
+	registerDaemonCommand(program);
+	return program;
+}
+
+beforeEach(() => {
+	runDaemonServerMock.mockClear();
+	setLogDirMock.mockClear();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("registerDaemonCommand", () => {
+	it("registers a hidden 'daemon' command with --cwd and --debounce options", () => {
+		const program = makeProgram();
+		const cmd = program.commands.find((c) => c.name() === "daemon");
+		expect(cmd).toBeDefined();
+		// commander marks hidden commands via a private flag; assert its
+		// visible-help description is stable so the shape is regression-checked.
+		expect(cmd?.description()).toMatch(/long-running stdio daemon/i);
+	});
+
+	it("forwards --cwd to setLogDir and to runDaemonServer without a debounce override", async () => {
+		await makeProgram().parseAsync(["daemon", "--cwd", "/my/repo"], { from: "user" });
+		expect(setLogDirMock).toHaveBeenCalledWith("/my/repo");
+		expect(runDaemonServerMock).toHaveBeenCalledWith({ cwd: "/my/repo", debounceMs: undefined });
+	});
+
+	it("parses --debounce as a non-negative integer and forwards it", async () => {
+		await makeProgram().parseAsync(["daemon", "--cwd", "/r", "--debounce", "150"], { from: "user" });
+		expect(runDaemonServerMock).toHaveBeenCalledWith({ cwd: "/r", debounceMs: 150 });
+	});
+
+	it("accepts 0 as a valid debounce value (no coalescing)", async () => {
+		await makeProgram().parseAsync(["daemon", "--cwd", "/r", "--debounce", "0"], { from: "user" });
+		expect(runDaemonServerMock).toHaveBeenCalledWith({ cwd: "/r", debounceMs: 0 });
+	});
+
+	it("rejects a non-integer --debounce value with a clear error", async () => {
+		await expect(
+			makeProgram().parseAsync(["daemon", "--cwd", "/r", "--debounce", "1.5"], { from: "user" }),
+		).rejects.toThrow(/Invalid --debounce value: 1\.5/);
+	});
+
+	it("rejects a negative --debounce value", async () => {
+		await expect(
+			makeProgram().parseAsync(["daemon", "--cwd", "/r", "--debounce", "-3"], { from: "user" }),
+		).rejects.toThrow(/Invalid --debounce value: -3/);
+	});
+
+	it("rejects a trailing-junk --debounce value that parseInt would silently accept", async () => {
+		await expect(
+			makeProgram().parseAsync(["daemon", "--cwd", "/r", "--debounce", "300abc"], { from: "user" }),
+		).rejects.toThrow(/Invalid --debounce value: 300abc/);
+	});
+
+	it("defaults --cwd to the resolved project directory when the flag is omitted", async () => {
+		await makeProgram().parseAsync(["daemon"], { from: "user" });
+		expect(setLogDirMock).toHaveBeenCalledOnce();
+		const arg = setLogDirMock.mock.calls[0][0];
+		expect(typeof arg).toBe("string");
+		expect(arg.length).toBeGreaterThan(0);
+	});
+});

--- a/cli/src/commands/IdeBridgeCommand.test.ts
+++ b/cli/src/commands/IdeBridgeCommand.test.ts
@@ -1,0 +1,2690 @@
+/**
+ * Full-coverage test suite for IdeBridgeCommand.ts.
+ *
+ * Structure:
+ *   1. Small exported helpers (IdeBridgeConflictUi, IDE_BRIDGE_PROTOCOL,
+ *      writeServeLine, computeServeResponse) — no I/O.
+ *   2. runIdeBridgeAction — the giant dispatcher. One describe() per action
+ *      (and one per sub-operation for the multi-op actions). Modules that hit
+ *      disk / network are mocked at file scope.
+ *   3. executeIdeBridgeCommand — one-shot stdin/stdout envelope mode.
+ *   4. runIdeBridgeServe — long-lived NDJSON server, plus the private
+ *      startRefreshWatchers retry loop reached through it.
+ */
+
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------- module mocks (hoisted by vitest to top-of-file) ----------
+
+const daemonWatcherInstances: Array<{
+	opts: { path: string; onTrigger: () => void; debounceMs: number; ensureDir?: boolean };
+	start: ReturnType<typeof vi.fn>;
+	stop: ReturnType<typeof vi.fn>;
+}> = [];
+
+vi.mock("../daemon/DaemonServer.js", () => ({
+	computeWatchTargets: vi.fn((cwd: string) => [
+		{ kind: "queue", path: `${cwd}/queue`, ensureDir: true },
+		{ kind: "orphan-ref", path: `${cwd}/refs`, ensureDir: false },
+	]),
+}));
+
+vi.mock("../daemon/DaemonWatcher.js", () => ({
+	DaemonWatcher: vi.fn().mockImplementation(function DaemonWatcherMock(
+		this: unknown,
+		opts: {
+			path: string;
+			onTrigger: () => void;
+			debounceMs: number;
+			ensureDir?: boolean;
+		},
+	) {
+		const start = vi.fn().mockReturnValue(true);
+		const stop = vi.fn();
+		const instance = { opts, start, stop };
+		daemonWatcherInstances.push(instance);
+		Object.assign(this as object, instance);
+	}),
+}));
+
+vi.mock("../Logger.js", () => ({
+	setLogDir: vi.fn(),
+	createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+	getJolliMemoryDir: (cwd: string) => `${cwd}/.jolli/jollimemory`,
+}));
+
+vi.mock("../core/StorageFactory.js", () => ({
+	createStorage: vi.fn(),
+}));
+
+vi.mock("../core/HiddenConversationsStore.js", () => ({
+	hideConversation: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../core/ConversationOverlayStore.js", () => ({
+	loadOverlay: vi.fn(),
+	saveOverlay: vi.fn(),
+	applyOverlay: vi.fn(),
+	applyDeletes: vi.fn(),
+	mergeOverlay: vi.fn(),
+}));
+
+vi.mock("../core/SessionTracker.js", () => ({
+	getGlobalConfigDir: vi.fn().mockReturnValue("/global/config"),
+	loadConfigFromDir: vi.fn(),
+	loadConfig: vi.fn().mockResolvedValue({}),
+	saveConfigScoped: vi.fn().mockResolvedValue(undefined),
+	loadPlansRegistry: vi.fn().mockResolvedValue({}),
+	savePlansRegistry: vi.fn().mockResolvedValue(undefined),
+	savePluginSource: vi.fn().mockResolvedValue(undefined),
+	saveSquashPending: vi.fn().mockResolvedValue(undefined),
+	getOrCreateInstallId: vi.fn().mockResolvedValue({ installId: "install-1", created: false }),
+}));
+
+vi.mock("../core/Locks.js", () => ({
+	getWorkerBusyState: vi.fn().mockResolvedValue({ held: false, blocking: false }),
+}));
+
+vi.mock("../auth/AuthConfig.js", () => ({
+	getJolliUrl: vi.fn().mockReturnValue("https://jolli.ai"),
+	loadAuthToken: vi.fn().mockResolvedValue(undefined),
+	saveAuthCredentials: vi.fn().mockResolvedValue(undefined),
+	clearAuthCredentials: vi.fn().mockResolvedValue(undefined),
+	shouldRequestFreshApiKey: vi.fn().mockReturnValue(false),
+	resolveSignInJolliUrl: vi.fn((_apiKey: string | undefined, url: string) => url),
+}));
+
+vi.mock("../auth/CliExchange.js", () => ({
+	exchangeCliCode: vi.fn(),
+}));
+
+vi.mock("../core/JolliApiUtils.js", () => ({
+	parseJolliApiKey: vi.fn().mockReturnValue({ u: "https://jolli.ai" }),
+	validateJolliApiKey: vi.fn(),
+	assertJolliOriginAllowed: vi.fn(),
+	deriveJolliBackendKey: vi.fn().mockReturnValue("prod"),
+}));
+
+vi.mock("../core/JolliMemoryPushClient.js", () => {
+	const push = vi.fn().mockResolvedValue({ ok: true });
+	const deleteDoc = vi.fn().mockResolvedValue(undefined);
+	const listSpaces = vi.fn().mockResolvedValue({ spaces: [], defaultSpaceId: null });
+	const createBinding = vi.fn().mockResolvedValue({ ok: true });
+	// vi.fn() constructs the mock as callable+constructable; the impl MUST be a
+	// non-arrow function so `new fn()` finds [[Construct]] and its object
+	// return supplants the fresh `this`. Arrow functions have no [[Construct]]
+	// and throw "is not a constructor".
+	const JolliMemoryPushClient = vi.fn().mockImplementation(function JolliMemoryPushClientMock() {
+		return { push, deleteDoc, listSpaces, createBinding };
+	});
+	return { JolliMemoryPushClient };
+});
+
+vi.mock("../core/JolliShareClient.js", () => {
+	const create = vi.fn().mockResolvedValue({ shareId: "s1" });
+	const update = vi.fn().mockResolvedValue({ ok: true });
+	const revoke = vi.fn().mockResolvedValue(undefined);
+	const invite = vi.fn().mockResolvedValue({ invited: 1 });
+	const listOrgMembers = vi.fn().mockResolvedValue([{ id: 1 }]);
+	const JolliShareClient = vi.fn().mockImplementation(function JolliShareClientMock() {
+		return { create, update, revoke, invite, listOrgMembers };
+	});
+	return { JolliShareClient };
+});
+
+vi.mock("../core/JolliMemoryPushOrchestrator.js", () => ({
+	serializeSummaryJson: vi.fn().mockReturnValue('{"summary":true}'),
+	planBaseKey: vi.fn((slug: string) => `plan:${slug}`),
+	latestPlanPerName: vi.fn((plans: unknown[]) => plans),
+}));
+
+vi.mock("../core/GitRemoteUtils.js", () => ({
+	getCanonicalRepoUrl: vi.fn().mockResolvedValue("git@github.com:acme/repo.git"),
+	deriveRepoNameFromUrl: vi.fn().mockReturnValue("repo"),
+	normalizeRemoteUrl: vi.fn().mockReturnValue("git@github.com:acme/repo.git"),
+	sanitizeBranchSlug: vi.fn().mockReturnValue("main-slug"),
+}));
+
+vi.mock("../core/GitOps.js", () => ({
+	execGit: vi.fn().mockResolvedValue({ stdout: "", stderr: "", exitCode: 0 }),
+	getProjectRootDir: vi.fn().mockResolvedValue("/repo/root"),
+	getCurrentBranch: vi.fn().mockResolvedValue("main"),
+}));
+
+vi.mock("../core/PinStore.js", () => ({
+	listPins: vi.fn().mockResolvedValue([]),
+	addPin: vi.fn().mockResolvedValue(undefined),
+	removePin: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../core/CommitSelectionStore.js", () => ({
+	readExclusions: vi.fn().mockResolvedValue({
+		conversations: [],
+		plans: [],
+		notes: [],
+		references: [],
+	}),
+	conversationKey: vi.fn().mockReturnValue("k"),
+	setExcluded: vi.fn().mockResolvedValue(undefined),
+	setAllExcluded: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../core/BranchShareStore.js", () => ({
+	putBranchShare: vi.fn().mockResolvedValue(undefined),
+	removeShare: vi.fn().mockResolvedValue(undefined),
+	getShare: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../core/PushPendingStore.js", () => ({
+	loadPushPending: vi.fn().mockResolvedValue({ entries: { hashA: 1, hashB: 2 } }),
+}));
+
+vi.mock("../core/RepoProfile.js", () => ({
+	readRepoProfile: vi.fn().mockResolvedValue({ backfillDismissed: false, manuallyDisabled: false }),
+	updateRepoProfile: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../core/SummaryMarkdownBuilder.js", () => ({
+	buildMarkdown: vi.fn().mockReturnValue("# md"),
+	buildReferencePushMarkdown: vi.fn().mockReturnValue("# ref"),
+}));
+
+vi.mock("../core/SummaryPrMarkdownBuilder.js", () => ({
+	buildPrMarkdown: vi.fn().mockReturnValue("# pr md"),
+}));
+
+vi.mock("../core/PrDescription.js", () => ({
+	wrapWithMarkers: vi.fn((md: string) => `<!--start-->${md}<!--end-->`),
+	replaceSummaryInBody: vi.fn((body: string) => `${body}[patched]`),
+	buildPrDescription: vi.fn().mockResolvedValue({ title: "T", body: "B" }),
+}));
+
+vi.mock("../core/SummaryFormat.js", () => ({
+	buildReferencePushTitle: vi.fn().mockReturnValue("Ref Title"),
+}));
+
+vi.mock("../core/references/ReferenceStore.js", () => ({
+	readReferenceMarkdown: vi.fn().mockResolvedValue({ source: "src", archivedKey: "k", content: "c" }),
+	readReferenceMarkdownFromString: vi.fn().mockReturnValue({ description: "desc" }),
+}));
+
+vi.mock("../core/SummaryStore.js", () => ({
+	getIndex: vi.fn(),
+	getSummary: vi.fn().mockResolvedValue({ commitHash: "abc" }),
+	listSummaries: vi.fn().mockResolvedValue([]),
+	getSummaryCount: vi.fn().mockResolvedValue(0),
+	scanTreeHashAliases: vi.fn().mockResolvedValue(false),
+	storeSummary: vi.fn().mockResolvedValue(undefined),
+	readPlanProgress: vi.fn().mockResolvedValue([]),
+	readPlanFromBranch: vi.fn().mockResolvedValue("plan-content"),
+	storePlans: vi.fn().mockResolvedValue(undefined),
+	readReferenceFromBranch: vi.fn().mockResolvedValue("ref-content"),
+	storeReferences: vi.fn().mockResolvedValue(undefined),
+	getTranscriptHashes: vi.fn().mockResolvedValue(new Set<string>(["h1", "h2"])),
+	readTranscript: vi.fn().mockResolvedValue({ entries: [] }),
+	saveTranscriptsBatch: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../core/SummaryTree.js", () => ({
+	isUnifiedHoistFormat: vi.fn().mockReturnValue(true),
+	collectAllTopics: vi.fn().mockReturnValue([]),
+	collectDisplayTopics: vi.fn().mockReturnValue([]),
+	aggregateStats: vi.fn().mockReturnValue({ files: 0, insertions: 0, deletions: 0 }),
+	aggregateTurns: vi.fn().mockReturnValue(1),
+	aggregateConversationTokens: vi.fn().mockReturnValue(2),
+	aggregateConversationTokenBreakdown: vi.fn().mockReturnValue({ input: 1, output: 1 }),
+	aggregateEstimatedCost: vi.fn().mockReturnValue(0.01),
+	countTopics: vi.fn().mockReturnValue(3),
+	collectSourceNodes: vi.fn().mockReturnValue([]),
+	isLeafNode: vi.fn().mockReturnValue(true),
+	computeDurationDays: vi.fn().mockReturnValue(1),
+	formatDurationLabel: vi.fn().mockReturnValue("1d"),
+	updateTopicInTree: vi.fn().mockReturnValue({ updated: true }),
+	deleteTopicInTree: vi.fn().mockReturnValue({ deleted: true }),
+}));
+
+vi.mock("../core/KBPathResolver.js", () => ({
+	resolveKBPath: vi.fn().mockReturnValue("/kb"),
+	initializeKBFolder: vi.fn(),
+	findRepoFolders: vi.fn().mockReturnValue([]),
+	findFreshKBPath: vi.fn().mockReturnValue("/kb-fresh"),
+	archiveKBFolder: vi.fn().mockReturnValue("/kb-archive"),
+	extractRepoName: vi.fn().mockReturnValue("repo"),
+	getRemoteUrl: vi.fn().mockReturnValue("git@github.com:acme/repo.git"),
+}));
+
+vi.mock("../core/KBRepoDiscoverer.js", () => ({
+	discoverRepos: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock("../core/MetadataManager.js", () => {
+	const ensure = vi.fn();
+	const readManifest = vi.fn().mockReturnValue({ files: [] });
+	const readIndex = vi.fn().mockReturnValue({ version: 1, entries: [] });
+	const readConfig = vi.fn().mockReturnValue({});
+	const findByPath = vi.fn().mockReturnValue({ fileId: "id" });
+	const updatePath = vi.fn().mockReturnValue(true);
+	const renameBranchFolder = vi.fn().mockReturnValue(3);
+	const removeBranchFolder = vi.fn().mockReturnValue(2);
+	const removeFromManifest = vi.fn().mockReturnValue(true);
+	const reconcile = vi.fn().mockReturnValue(1);
+	const saveMigrationState = vi.fn();
+	const MetadataManager = vi.fn().mockImplementation(function MetadataManagerMock() {
+		return {
+			ensure,
+			readManifest,
+			readIndex,
+			readConfig,
+			findByPath,
+			updatePath,
+			renameBranchFolder,
+			removeBranchFolder,
+			removeFromManifest,
+			reconcile,
+			saveMigrationState,
+		};
+	});
+	return { MetadataManager };
+});
+
+vi.mock("../core/ActiveSessionAggregator.js", () => ({
+	listActiveConversationsWithDiagnostics: vi.fn().mockResolvedValue({ conversations: [], diagnostics: {} }),
+}));
+
+vi.mock("../core/TranscriptMessageCounter.js", () => ({
+	loadUnreadTranscript: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../core/TranscriptLoader.js", () => ({
+	loadTranscript: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../core/MultiRepoCompile.js", () => ({
+	compileAllRepos: vi.fn().mockResolvedValue({ repos: [] }),
+}));
+
+vi.mock("../install/Installer.js", () => ({
+	getStatus: vi.fn().mockResolvedValue({ installed: true }),
+}));
+
+vi.mock("./SyncCommand.js", () => ({
+	ensureKBInitAndMigrated: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../sync/SyncBootstrap.js", () => ({
+	buildSyncEngine: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../core/TokenCost.js", () => ({
+	estimateConversationCostUsd: vi.fn().mockReturnValue(0.5),
+}));
+
+vi.mock("../core/Pricing.js", () => ({
+	MODEL_PRICES: { "gpt-4": { provider: "openai" } },
+	estimateModelCostUsd: vi.fn().mockReturnValue(0.25),
+	estimateCostUsd: vi.fn().mockReturnValue({ totalUsd: 1.5 }),
+}));
+
+vi.mock("../core/TelemetryStartup.js", () => ({
+	bootstrapTelemetry: vi.fn().mockResolvedValue(undefined),
+	flushTelemetryNow: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../core/Telemetry.js", () => ({
+	track: vi.fn(),
+	bucket: vi.fn((n: number) => `bucket-${n}`),
+}));
+
+vi.mock("../core/TelemetryConsent.js", () => ({
+	shouldShowTelemetryNotice: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("./CliUtils.js", () => ({
+	readStdin: vi.fn(),
+}));
+
+// ---------- module under test (import AFTER vi.mock declarations) ----------
+
+import {
+	computeServeResponse,
+	executeIdeBridgeCommand,
+	IDE_BRIDGE_PROTOCOL,
+	IdeBridgeConflictUi,
+	runIdeBridgeAction,
+	runIdeBridgeServe,
+	writeServeLine,
+} from "./IdeBridgeCommand.js";
+
+// ---------- shared helpers ----------
+
+/**
+ * Spies on stdout / stderr / console.log so their output can be inspected but
+ * never leaks to the terminal during a real test run.
+ */
+function captureConsole(): { stdout: string[]; stderr: string[]; consoleLog: string[] } {
+	const stdout: string[] = [];
+	const stderr: string[] = [];
+	const consoleLog: string[] = [];
+	vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+		stdout.push(typeof chunk === "string" ? chunk : String(chunk));
+		return true;
+	});
+	vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+		stderr.push(typeof chunk === "string" ? chunk : String(chunk));
+		return true;
+	});
+	vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+		consoleLog.push(args.map((a) => (typeof a === "string" ? a : String(a))).join(" "));
+	});
+	vi.spyOn(console, "error").mockImplementation(() => {});
+	return { stdout, stderr, consoleLog };
+}
+
+beforeEach(() => {
+	daemonWatcherInstances.length = 0;
+	process.exitCode = undefined;
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	process.exitCode = undefined;
+});
+
+// ---------- 1. small exported helpers ----------
+
+describe("IdeBridgeConflictUi", () => {
+	it("records unresolved conflict content and skips the first bridge round", async () => {
+		const ui = new IdeBridgeConflictUi({});
+		await expect(ui.promptBinaryPick("repo/file.md", "mine", "remote")).resolves.toBe("skip");
+		expect(ui.details).toEqual([{ path: "repo/file.md", ours: "mine", theirs: "remote" }]);
+	});
+
+	it("replays an IDE 'mine' choice without recording another prompt", async () => {
+		const ui = new IdeBridgeConflictUi({ "repo/file.md": "mine" });
+		await expect(ui.promptBinaryPick("repo/file.md", "mine", "remote")).resolves.toBe("mine");
+		expect(ui.details).toEqual([]);
+	});
+
+	it("replays an IDE 'theirs' choice without recording another prompt", async () => {
+		const ui = new IdeBridgeConflictUi({ "repo/file.md": "theirs" });
+		await expect(ui.promptBinaryPick("repo/file.md", "mine", "remote")).resolves.toBe("theirs");
+		expect(ui.details).toEqual([]);
+	});
+
+	it("deduplicates the same path across multiple unresolved prompts in one round", async () => {
+		const ui = new IdeBridgeConflictUi({});
+		await ui.promptBinaryPick("dup.md", "x", "y");
+		await ui.promptBinaryPick("dup.md", "x", "y");
+		expect(ui.details).toEqual([{ path: "dup.md", ours: "x", theirs: "y" }]);
+	});
+});
+
+describe("IDE_BRIDGE_PROTOCOL", () => {
+	it("advertises the pinned wire protocol name — matches the Kotlin CliDaemonClient constant", () => {
+		expect(IDE_BRIDGE_PROTOCOL).toBe("jolli-ide-bridge-jsonrpc-v1");
+	});
+});
+
+describe("writeServeLine — stringify fallback", () => {
+	function capture(fn: () => void): string {
+		const chunks: string[] = [];
+		vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown): boolean => {
+			chunks.push(typeof chunk === "string" ? chunk : String(chunk));
+			return true;
+		});
+		fn();
+		return chunks.join("");
+	}
+
+	it("emits a serialisable object verbatim", () => {
+		const payload = { jsonrpc: "2.0", id: 1, result: { ok: true } };
+		expect(capture(() => writeServeLine(payload))).toBe(`${JSON.stringify(payload)}\n`);
+	});
+
+	it("emits a minimal JSON-RPC error envelope when the response contains a bigint", () => {
+		const out = capture(() => writeServeLine({ jsonrpc: "2.0", id: 42, result: { big: 9007199254740993n } }));
+		const parsed = JSON.parse(out.trimEnd());
+		expect(parsed).toMatchObject({
+			jsonrpc: "2.0",
+			id: 42,
+			error: {
+				code: -32603,
+				message: expect.stringContaining("response not serialisable"),
+				data: { errorName: "SerializationError" },
+			},
+		});
+	});
+
+	it("emits a minimal error envelope when the response contains a circular reference", () => {
+		const obj: Record<string, unknown> = { jsonrpc: "2.0", id: "call-7" };
+		const self: Record<string, unknown> = {};
+		self.self = self;
+		obj.result = self;
+		const out = capture(() => writeServeLine(obj));
+		const parsed = JSON.parse(out.trimEnd());
+		expect(parsed).toMatchObject({
+			jsonrpc: "2.0",
+			id: "call-7",
+			error: { code: -32603, data: { errorName: "SerializationError" } },
+		});
+	});
+
+	it("passes through a null id when the failing response had no usable id", () => {
+		const out = capture(() => writeServeLine({ jsonrpc: "2.0", method: "ready", params: { pid: 12345n } }));
+		const parsed = JSON.parse(out.trimEnd());
+		expect(parsed.id).toBeNull();
+		expect(parsed).toMatchObject({ jsonrpc: "2.0", error: { code: -32603 } });
+	});
+
+	it("falls back to id=null when the failing response carries a boolean id", () => {
+		const out = capture(() => writeServeLine({ jsonrpc: "2.0", id: true, params: { pid: 1n } }));
+		const parsed = JSON.parse(out.trimEnd());
+		expect(parsed.id).toBeNull();
+	});
+
+	it("stringifies the error itself with String() when it is not an Error instance", () => {
+		// throw a non-Error primitive from JSON.stringify by using a getter
+		const bad = {
+			jsonrpc: "2.0",
+			id: 5,
+			get result() {
+				// eslint-disable-next-line @typescript-eslint/no-throw-literal
+				throw "raw-string-error";
+			},
+		};
+		const out = capture(() => writeServeLine(bad));
+		const parsed = JSON.parse(out.trimEnd());
+		expect(parsed.error.message).toContain("raw-string-error");
+	});
+});
+
+describe("computeServeResponse", () => {
+	// plan-grouping is a pure handler with no external I/O — the mock stubs
+	// planBaseKey directly so the envelope is deterministic.
+	const validLine = JSON.stringify({
+		jsonrpc: "2.0",
+		id: 42,
+		method: "plan-grouping",
+		params: { cwd: "/repo", request: { operation: "base-key", slug: "s" } },
+	});
+
+	it("wraps the handler result in a JSON-RPC 2.0 envelope", async () => {
+		const envelope = await computeServeResponse(validLine, "/fallback");
+		expect(envelope).toMatchObject({ jsonrpc: "2.0", id: 42, result: { key: "plan:s" } });
+	});
+
+	it("uses params.cwd over the default", async () => {
+		const envelope = await computeServeResponse(validLine, "/never-used");
+		expect(envelope).toMatchObject({ jsonrpc: "2.0", id: 42 });
+	});
+
+	it("falls back to the default cwd when params.cwd is missing", async () => {
+		const line = JSON.stringify({
+			jsonrpc: "2.0",
+			id: 1,
+			method: "plan-grouping",
+			params: { request: { operation: "base-key", slug: "s" } },
+		});
+		const envelope = await computeServeResponse(line, "/default");
+		expect(envelope).toMatchObject({ id: 1, result: { key: "plan:s" } });
+	});
+
+	it("falls back to the default cwd when params.cwd is an empty string", async () => {
+		const line = JSON.stringify({
+			jsonrpc: "2.0",
+			id: 1,
+			method: "plan-grouping",
+			params: { cwd: "", request: { operation: "base-key", slug: "s" } },
+		});
+		const envelope = await computeServeResponse(line, "/default");
+		expect(envelope).toMatchObject({ id: 1, result: { key: "plan:s" } });
+	});
+
+	it("returns a paired error envelope for an unknown method", async () => {
+		const envelope = await computeServeResponse(
+			JSON.stringify({ jsonrpc: "2.0", id: 7, method: "no-such-action", params: {} }),
+			"/x",
+		);
+		expect(envelope).toMatchObject({
+			jsonrpc: "2.0",
+			id: 7,
+			error: { code: -32000, message: expect.stringContaining("Unknown IDE bridge action") },
+		});
+	});
+
+	it("returns id:null with an error for a malformed JSON line", async () => {
+		const envelope = await computeServeResponse("this is not json {", "/x");
+		expect(envelope.id).toBeNull();
+		expect(envelope).toMatchObject({
+			jsonrpc: "2.0",
+			error: { code: -32000, message: expect.any(String) },
+		});
+	});
+
+	it("rejects a non-object top-level value with an id-less error", async () => {
+		const envelope = await computeServeResponse("[1,2,3]", "/x");
+		expect(envelope).toMatchObject({
+			jsonrpc: "2.0",
+			id: null,
+			error: { code: -32000, message: expect.stringContaining("Request must be a JSON object.") },
+		});
+	});
+
+	it("rejects a request without a method field but preserves the id", async () => {
+		const envelope = await computeServeResponse(JSON.stringify({ jsonrpc: "2.0", id: 3 }), "/x");
+		expect(envelope).toMatchObject({
+			jsonrpc: "2.0",
+			id: 3,
+			error: { code: -32000, message: expect.stringContaining('"method"') },
+		});
+	});
+
+	it("rejects a request whose method field is an empty string", async () => {
+		const envelope = await computeServeResponse(JSON.stringify({ jsonrpc: "2.0", id: 3, method: "" }), "/x");
+		expect(envelope).toMatchObject({ error: { message: expect.stringContaining('"method"') } });
+	});
+
+	it("rejects a request whose params is not a JSON object", async () => {
+		const envelope = await computeServeResponse(
+			JSON.stringify({ jsonrpc: "2.0", id: 3, method: "x", params: [1, 2, 3] }),
+			"/x",
+		);
+		expect(envelope).toMatchObject({ error: { message: expect.stringContaining('"params"') } });
+	});
+
+	it("rejects a request whose params.cwd is not a string", async () => {
+		const envelope = await computeServeResponse(
+			JSON.stringify({ jsonrpc: "2.0", id: 3, method: "x", params: { cwd: 123 } }),
+			"/x",
+		);
+		expect(envelope).toMatchObject({ error: { message: expect.stringContaining('"params.cwd"') } });
+	});
+
+	it("rejects a request whose params.request is not a JSON object", async () => {
+		const envelope = await computeServeResponse(
+			JSON.stringify({ jsonrpc: "2.0", id: 3, method: "x", params: { request: [1] } }),
+			"/x",
+		);
+		expect(envelope).toMatchObject({ error: { message: expect.stringContaining('"params.request"') } });
+	});
+
+	it("accepts a missing params body — handler decides what to do", async () => {
+		const envelope = await computeServeResponse(
+			JSON.stringify({ jsonrpc: "2.0", id: 99, method: "plan-grouping" }),
+			"/x",
+		);
+		expect(envelope.id).toBe(99);
+		// plan-grouping needs an operation; the handler throws its own error.
+		expect(envelope).toMatchObject({ error: { code: -32000 } });
+	});
+
+	it("passes a string id back verbatim", async () => {
+		const line = JSON.stringify({
+			jsonrpc: "2.0",
+			id: "call-a1",
+			method: "plan-grouping",
+			params: { cwd: "/x", request: { operation: "base-key", slug: "x" } },
+		});
+		const envelope = await computeServeResponse(line, "/x");
+		expect(envelope).toMatchObject({ jsonrpc: "2.0", id: "call-a1" });
+	});
+
+	it("preserves errorName in error.data for named errors", async () => {
+		const envelope = await computeServeResponse(
+			JSON.stringify({ jsonrpc: "2.0", id: 11, method: "no-such-action" }),
+			"/x",
+		);
+		expect(envelope).toMatchObject({
+			jsonrpc: "2.0",
+			id: 11,
+			error: { code: -32000, data: { errorName: "Error" } },
+		});
+	});
+});
+
+// ---------- 2. runIdeBridgeAction — per-action coverage ----------
+
+describe("runIdeBridgeAction — active-conversations", () => {
+	it("delegates to listActiveConversationsWithDiagnostics with a default 48h window", async () => {
+		const { listActiveConversationsWithDiagnostics } = await import("../core/ActiveSessionAggregator.js");
+		vi.mocked(listActiveConversationsWithDiagnostics).mockResolvedValue({
+			conversations: [{ id: "a" }],
+			diagnostics: { c: 1 },
+		} as never);
+		const result = await runIdeBridgeAction("active-conversations", "/repo", {});
+		expect(listActiveConversationsWithDiagnostics).toHaveBeenCalledWith({
+			cwd: "/repo",
+			windowMs: 2 * 24 * 60 * 60 * 1000,
+		});
+		expect(result).toMatchObject({ conversations: [{ id: "a" }] });
+	});
+
+	it("honours a numeric windowMs override", async () => {
+		const { listActiveConversationsWithDiagnostics } = await import("../core/ActiveSessionAggregator.js");
+		await runIdeBridgeAction("active-conversations", "/repo", { windowMs: 1234 });
+		expect(listActiveConversationsWithDiagnostics).toHaveBeenCalledWith({ cwd: "/repo", windowMs: 1234 });
+	});
+});
+
+describe("runIdeBridgeAction — unread-transcript", () => {
+	it("dispatches to loadUnreadTranscript for a known source", async () => {
+		const { loadUnreadTranscript } = await import("../core/TranscriptMessageCounter.js");
+		vi.mocked(loadUnreadTranscript).mockResolvedValue([{ text: "hi" }] as never);
+		const result = await runIdeBridgeAction("unread-transcript", "/r", {
+			source: "claude",
+			transcriptPath: "/tmp/t.jsonl",
+		});
+		expect(loadUnreadTranscript).toHaveBeenCalledWith("claude", "/tmp/t.jsonl", "/r");
+		expect(result).toEqual({ entries: [{ text: "hi" }] });
+	});
+
+	it("rejects an unknown transcript source", async () => {
+		await expect(
+			runIdeBridgeAction("unread-transcript", "/r", { source: "nope", transcriptPath: "/t" }),
+		).rejects.toThrow(/Unknown transcript source/);
+	});
+});
+
+describe("runIdeBridgeAction — transcript", () => {
+	it("dispatches to loadTranscript for a known source", async () => {
+		const { loadTranscript } = await import("../core/TranscriptLoader.js");
+		vi.mocked(loadTranscript).mockResolvedValue([{ text: "row" }] as never);
+		const result = await runIdeBridgeAction("transcript", "/r", { source: "codex", transcriptPath: "/t" });
+		expect(loadTranscript).toHaveBeenCalledWith({ source: "codex", transcriptPath: "/t" });
+		expect(result).toEqual({ entries: [{ text: "row" }] });
+	});
+
+	it("rejects an unknown transcript source", async () => {
+		await expect(runIdeBridgeAction("transcript", "/r", { source: "nope", transcriptPath: "/t" })).rejects.toThrow(
+			/Unknown transcript source/,
+		);
+	});
+});
+
+describe("runIdeBridgeAction — compile", () => {
+	it("compiles using the config-provided localFolder when the request omits it", async () => {
+		const { compileAllRepos } = await import("../core/MultiRepoCompile.js");
+		vi.mocked(compileAllRepos).mockResolvedValue({ repos: ["r1"] } as never);
+		const config = { localFolder: "/bank" };
+		const result = await runIdeBridgeAction("compile", "/r", { config });
+		expect(compileAllRepos).toHaveBeenCalledWith("/bank", config);
+		expect(result).toEqual({ repos: ["r1"] });
+	});
+
+	it("prefers the request-provided localFolder over config.localFolder", async () => {
+		const { compileAllRepos } = await import("../core/MultiRepoCompile.js");
+		await runIdeBridgeAction("compile", "/r", { config: { localFolder: "/config" }, localFolder: "/override" });
+		expect(compileAllRepos).toHaveBeenCalledWith("/override", expect.anything());
+	});
+
+	it("rejects when the request has no config object", async () => {
+		await expect(runIdeBridgeAction("compile", "/r", {})).rejects.toThrow(/"config"/);
+	});
+
+	it("rejects when there is no folder configured anywhere", async () => {
+		await expect(runIdeBridgeAction("compile", "/r", { config: {} })).rejects.toThrow(/No Memory Bank folder/);
+	});
+});
+
+describe("runIdeBridgeAction — pr-description", () => {
+	it("passes through baseBranch and includeMarkers to buildPrDescription", async () => {
+		const { buildPrDescription } = await import("../core/PrDescription.js");
+		vi.mocked(buildPrDescription).mockResolvedValue({ title: "T", body: "B" } as never);
+		const result = await runIdeBridgeAction("pr-description", "/r", {
+			baseBranch: "main",
+			includeMarkers: false,
+		});
+		expect(buildPrDescription).toHaveBeenCalledWith("/r", { baseBranch: "main", includeMarkers: false });
+		expect(result).toEqual({ title: "T", body: "B" });
+	});
+
+	it("defaults includeMarkers to true when not explicitly set to false", async () => {
+		const { buildPrDescription } = await import("../core/PrDescription.js");
+		await runIdeBridgeAction("pr-description", "/r", {});
+		expect(buildPrDescription).toHaveBeenCalledWith("/r", { baseBranch: undefined, includeMarkers: true });
+	});
+});
+
+describe("runIdeBridgeAction — status", () => {
+	it("delegates to Installer.getStatus with the created storage", async () => {
+		const { getStatus } = await import("../install/Installer.js");
+		const { createStorage } = await import("../core/StorageFactory.js");
+		vi.mocked(createStorage).mockResolvedValue({ tag: "storage" } as never);
+		vi.mocked(getStatus).mockResolvedValue({ installed: false } as never);
+		const result = await runIdeBridgeAction("status", "/r", {});
+		expect(getStatus).toHaveBeenCalledWith("/r", { tag: "storage" });
+		expect(result).toEqual({ installed: false });
+	});
+});
+
+describe("runIdeBridgeAction — sync", () => {
+	it("throws when config has no jolliApiKey", async () => {
+		const { loadConfig } = await import("../core/SessionTracker.js");
+		vi.mocked(loadConfig).mockResolvedValue({} as never);
+		await expect(runIdeBridgeAction("sync", "/r", {})).rejects.toThrow(/Sync requires a Jolli sign-in\./);
+	});
+
+	it("throws when buildSyncEngine returns null", async () => {
+		const { loadConfig } = await import("../core/SessionTracker.js");
+		vi.mocked(loadConfig).mockResolvedValue({ jolliApiKey: "sk" } as never);
+		const { buildSyncEngine } = await import("../sync/SyncBootstrap.js");
+		vi.mocked(buildSyncEngine).mockResolvedValue(null);
+		await expect(runIdeBridgeAction("sync", "/r", {})).rejects.toThrow(/Sync requires a Jolli sign-in\./);
+	});
+
+	it("throws for an unknown sync reason", async () => {
+		const { loadConfig } = await import("../core/SessionTracker.js");
+		vi.mocked(loadConfig).mockResolvedValue({ jolliApiKey: "sk" } as never);
+		const { buildSyncEngine } = await import("../sync/SyncBootstrap.js");
+		vi.mocked(buildSyncEngine).mockResolvedValue({ runRound: vi.fn() } as never);
+		await expect(runIdeBridgeAction("sync", "/r", { reason: "bogus" })).rejects.toThrow(/Unknown sync reason/);
+	});
+
+	it("runs a full sync round with the resolved reason and merges conflictDetails", async () => {
+		const { loadConfig } = await import("../core/SessionTracker.js");
+		vi.mocked(loadConfig).mockResolvedValue({
+			jolliApiKey: "sk",
+			localFolder: "/bank",
+			syncTranscripts: false,
+		} as never);
+		const { buildSyncEngine } = await import("../sync/SyncBootstrap.js");
+		const runRound = vi.fn().mockResolvedValue({ pushed: 1 });
+		vi.mocked(buildSyncEngine).mockResolvedValue({ runRound } as never);
+		const result = await runIdeBridgeAction("sync", "/r", {
+			reason: "post-commit",
+			transcripts: true,
+			conflictChoices: { "a/b.md": "mine" },
+		});
+		expect(runRound).toHaveBeenCalledWith({ cwd: "/r", reason: "post-commit", transcripts: true });
+		expect(result).toMatchObject({ pushed: 1, conflictDetails: [] });
+	});
+
+	it("defaults sync reason to 'manual' when omitted and honours config.syncTranscripts", async () => {
+		const { loadConfig } = await import("../core/SessionTracker.js");
+		vi.mocked(loadConfig).mockResolvedValue({
+			jolliApiKey: "sk",
+			syncTranscripts: true,
+		} as never);
+		const { buildSyncEngine } = await import("../sync/SyncBootstrap.js");
+		const runRound = vi.fn().mockResolvedValue({ pushed: 0 });
+		vi.mocked(buildSyncEngine).mockResolvedValue({ runRound } as never);
+		await runIdeBridgeAction("sync", "/r", {});
+		expect(runRound).toHaveBeenCalledWith({ cwd: "/r", reason: "manual", transcripts: true });
+	});
+
+	it("rejects an invalid conflictChoices value with a specific error", async () => {
+		const { loadConfig } = await import("../core/SessionTracker.js");
+		vi.mocked(loadConfig).mockResolvedValue({ jolliApiKey: "sk" } as never);
+		await expect(runIdeBridgeAction("sync", "/r", { conflictChoices: { "a.md": "sideways" } })).rejects.toThrow(
+			/Conflict choice for "a\.md" must be/,
+		);
+	});
+
+	it("rejects a non-object conflictChoices value", async () => {
+		const { loadConfig } = await import("../core/SessionTracker.js");
+		vi.mocked(loadConfig).mockResolvedValue({ jolliApiKey: "sk" } as never);
+		await expect(runIdeBridgeAction("sync", "/r", { conflictChoices: [1, 2] })).rejects.toThrow(
+			/"conflictChoices"/,
+		);
+	});
+});
+
+describe("runIdeBridgeAction — conversation-overlay", () => {
+	it("hides a conversation on the 'hide' operation", async () => {
+		const { hideConversation } = await import("../core/HiddenConversationsStore.js");
+		const result = await runIdeBridgeAction("conversation-overlay", "/r", {
+			operation: "hide",
+			source: "claude",
+			sessionId: "sess-1",
+		});
+		expect(hideConversation).toHaveBeenCalledWith("/r", "claude", "sess-1");
+		expect(result).toEqual({ ok: true });
+	});
+
+	it("returns overlay + displayed + rawWithDeletesOnly on 'view'", async () => {
+		const overlayStore = await import("../core/ConversationOverlayStore.js");
+		vi.mocked(overlayStore.loadOverlay).mockResolvedValue({ deletes: [], edits: [] } as never);
+		vi.mocked(overlayStore.applyOverlay).mockReturnValue(["disp"] as never);
+		vi.mocked(overlayStore.applyDeletes).mockReturnValue(["raw"] as never);
+		const result = await runIdeBridgeAction("conversation-overlay", "/r", {
+			operation: "view",
+			source: "claude",
+			sessionId: "s",
+			entries: [{ id: "e1" }],
+		});
+		expect(result).toMatchObject({ displayed: ["disp"], rawWithDeletesOnly: ["raw"] });
+	});
+
+	it("rejects 'view' when entries is not an array", async () => {
+		await expect(
+			runIdeBridgeAction("conversation-overlay", "/r", {
+				operation: "view",
+				source: "claude",
+				sessionId: "s",
+			}),
+		).rejects.toThrow(/"entries"/);
+	});
+
+	it("merges and saves on 'merge-save'", async () => {
+		const overlayStore = await import("../core/ConversationOverlayStore.js");
+		vi.mocked(overlayStore.loadOverlay).mockResolvedValue({ deletes: [], edits: [] } as never);
+		vi.mocked(overlayStore.mergeOverlay).mockReturnValue({ deletes: ["d"], edits: [] } as never);
+		vi.mocked(overlayStore.saveOverlay).mockResolvedValue({ deletes: ["d"], edits: [] } as never);
+		const result = await runIdeBridgeAction("conversation-overlay", "/r", {
+			operation: "merge-save",
+			source: "claude",
+			sessionId: "s",
+			deletes: [{ id: "d" }],
+			edits: [],
+		});
+		expect(overlayStore.saveOverlay).toHaveBeenCalled();
+		expect(result).toMatchObject({ deletes: ["d"] });
+	});
+
+	it("rejects 'merge-save' when deletes/edits are not arrays", async () => {
+		await expect(
+			runIdeBridgeAction("conversation-overlay", "/r", {
+				operation: "merge-save",
+				source: "claude",
+				sessionId: "s",
+				deletes: "no",
+				edits: [],
+			}),
+		).rejects.toThrow(/"deletes" and "edits"/);
+	});
+
+	it("rejects an unknown conversation-overlay operation", async () => {
+		await expect(
+			runIdeBridgeAction("conversation-overlay", "/r", {
+				operation: "shred",
+				source: "claude",
+				sessionId: "s",
+			}),
+		).rejects.toThrow(/Unknown conversation-overlay operation/);
+	});
+
+	it("rejects an unknown transcript source at the conversation-overlay entry", async () => {
+		await expect(
+			runIdeBridgeAction("conversation-overlay", "/r", {
+				operation: "view",
+				source: "nope",
+				sessionId: "s",
+				entries: [],
+			}),
+		).rejects.toThrow(/Unknown transcript source/);
+	});
+});
+
+describe("runIdeBridgeAction — session-state", () => {
+	it("returns the global-config-dir", async () => {
+		const result = await runIdeBridgeAction("session-state", "/r", { operation: "global-config-dir" });
+		expect(result).toEqual({ path: "/global/config" });
+	});
+
+	it("builds a notes-dir under the jolli memory dir", async () => {
+		const result = await runIdeBridgeAction("session-state", "/r", { operation: "notes-dir" });
+		expect(result).toEqual({ path: "/r/.jolli/jollimemory/notes" });
+	});
+
+	it("loads config from a specific dir when dir is provided", async () => {
+		const { loadConfigFromDir } = await import("../core/SessionTracker.js");
+		vi.mocked(loadConfigFromDir).mockResolvedValue({ jolliUrl: "x" } as never);
+		const result = await runIdeBridgeAction("session-state", "/r", { operation: "config-load", dir: "/scoped" });
+		expect(loadConfigFromDir).toHaveBeenCalledWith("/scoped");
+		expect(result).toMatchObject({ jolliUrl: "x" });
+	});
+
+	it("loads the global config when no dir is given", async () => {
+		const { loadConfig } = await import("../core/SessionTracker.js");
+		vi.mocked(loadConfig).mockResolvedValue({ jolliUrl: "y" } as never);
+		const result = await runIdeBridgeAction("session-state", "/r", { operation: "config-load" });
+		expect(loadConfig).toHaveBeenCalled();
+		expect(result).toMatchObject({ jolliUrl: "y" });
+	});
+
+	it("saves config to a specific dir when dir is provided", async () => {
+		const { saveConfigScoped } = await import("../core/SessionTracker.js");
+		await runIdeBridgeAction("session-state", "/r", {
+			operation: "config-save",
+			config: { jolliUrl: "z" },
+			dir: "/scoped",
+		});
+		expect(saveConfigScoped).toHaveBeenCalledWith({ jolliUrl: "z" }, "/scoped");
+	});
+
+	it("saves config to the global dir when dir is omitted", async () => {
+		const { saveConfigScoped, getGlobalConfigDir } = await import("../core/SessionTracker.js");
+		vi.mocked(getGlobalConfigDir).mockReturnValue("/global/config");
+		await runIdeBridgeAction("session-state", "/r", { operation: "config-save", config: { x: 1 } });
+		expect(saveConfigScoped).toHaveBeenCalledWith({ x: 1 }, "/global/config");
+	});
+
+	it("rejects config-save with a non-object config", async () => {
+		await expect(
+			runIdeBridgeAction("session-state", "/r", { operation: "config-save", config: "no" }),
+		).rejects.toThrow(/"config"/);
+	});
+
+	it("loads plans registry on plans-load", async () => {
+		const { loadPlansRegistry } = await import("../core/SessionTracker.js");
+		vi.mocked(loadPlansRegistry).mockResolvedValue({ plans: [] } as never);
+		const result = await runIdeBridgeAction("session-state", "/r", { operation: "plans-load" });
+		expect(result).toEqual({ plans: [] });
+	});
+
+	it("saves plans registry on plans-save", async () => {
+		const { savePlansRegistry } = await import("../core/SessionTracker.js");
+		const registry = { plans: [{ slug: "a" }] };
+		await runIdeBridgeAction("session-state", "/r", { operation: "plans-save", registry });
+		expect(savePlansRegistry).toHaveBeenCalledWith(registry, "/r");
+	});
+
+	it("returns worker-busy state", async () => {
+		const { getWorkerBusyState } = await import("../core/Locks.js");
+		vi.mocked(getWorkerBusyState).mockResolvedValue({ held: true, blocking: false } as never);
+		const result = await runIdeBridgeAction("session-state", "/r", { operation: "worker-busy" });
+		expect(result).toEqual({ held: true, blocking: false });
+	});
+
+	it("records save-plugin-source", async () => {
+		const { savePluginSource } = await import("../core/SessionTracker.js");
+		await runIdeBridgeAction("session-state", "/r", { operation: "save-plugin-source" });
+		expect(savePluginSource).toHaveBeenCalledWith("/r");
+	});
+
+	it("records save-squash-pending with hashes and parent", async () => {
+		const { saveSquashPending } = await import("../core/SessionTracker.js");
+		await runIdeBridgeAction("session-state", "/r", {
+			operation: "save-squash-pending",
+			sourceHashes: ["a", "b"],
+			expectedParentHash: "p",
+		});
+		expect(saveSquashPending).toHaveBeenCalledWith(["a", "b"], "p", "/r");
+	});
+
+	it("rejects an unknown session-state operation", async () => {
+		await expect(runIdeBridgeAction("session-state", "/r", { operation: "wat" })).rejects.toThrow(
+			/Unknown session-state operation/,
+		);
+	});
+});
+
+describe("runIdeBridgeAction — auth", () => {
+	it("returns the site url", async () => {
+		expect(await runIdeBridgeAction("auth", "/r", { operation: "site-url" })).toEqual({ url: "https://jolli.ai" });
+	});
+
+	it("reports signed-in true when an auth token is present", async () => {
+		const auth = await import("../auth/AuthConfig.js");
+		vi.mocked(auth.loadAuthToken).mockResolvedValue("tok");
+		expect(await runIdeBridgeAction("auth", "/r", { operation: "is-signed-in" })).toEqual({ signedIn: true });
+	});
+
+	it("reports signed-in false when no auth token is present", async () => {
+		const auth = await import("../auth/AuthConfig.js");
+		vi.mocked(auth.loadAuthToken).mockResolvedValue(undefined);
+		expect(await runIdeBridgeAction("auth", "/r", { operation: "is-signed-in" })).toEqual({ signedIn: false });
+	});
+
+	it("parses an API key and returns meta", async () => {
+		const { parseJolliApiKey } = await import("../core/JolliApiUtils.js");
+		vi.mocked(parseJolliApiKey).mockReturnValue({ u: "u" } as never);
+		const result = await runIdeBridgeAction("auth", "/r", { operation: "parse-api-key", apiKey: "sk-jol-x" });
+		expect(result).toEqual({ meta: { u: "u" } });
+	});
+
+	it("validates an API key", async () => {
+		expect(await runIdeBridgeAction("auth", "/r", { operation: "validate-api-key", apiKey: "sk" })).toEqual({
+			ok: true,
+		});
+	});
+
+	it("asserts an origin is allowed", async () => {
+		expect(
+			await runIdeBridgeAction("auth", "/r", { operation: "assert-origin", origin: "https://jolli.ai" }),
+		).toEqual({ ok: true });
+	});
+
+	it("reports should-request-fresh based on config", async () => {
+		const auth = await import("../auth/AuthConfig.js");
+		vi.mocked(auth.shouldRequestFreshApiKey).mockReturnValue(true);
+		const result = await runIdeBridgeAction("auth", "/r", {
+			operation: "should-request-fresh",
+			existingKey: undefined,
+			jolliUrl: "https://jolli.ai",
+		});
+		expect(result).toEqual({ fresh: true });
+	});
+
+	it("builds a login url with all optional fields", async () => {
+		const result = await runIdeBridgeAction("auth", "/r", {
+			operation: "build-login-url",
+			jolliUrl: "https://jolli.ai",
+			callbackUrl: "http://localhost:1/cb",
+			clientVersion: "1.0.0",
+			generateApiKey: true,
+			installId: "abc",
+		});
+		expect(typeof (result as { url: string }).url).toBe("string");
+		const url = new URL((result as { url: string }).url);
+		expect(url.pathname).toBe("/login");
+		expect(url.searchParams.get("client")).toBe("intellij");
+		expect(url.searchParams.get("generate_api_key")).toBe("true");
+		expect(url.searchParams.get("install_id")).toBe("abc");
+	});
+
+	it("omits generate_api_key when not truthy and skips install_id when absent", async () => {
+		const result = await runIdeBridgeAction("auth", "/r", {
+			operation: "build-login-url",
+			jolliUrl: "https://jolli.ai",
+			callbackUrl: "http://localhost:1/cb",
+			clientVersion: "1.0.0",
+		});
+		const url = new URL((result as { url: string }).url);
+		expect(url.searchParams.has("generate_api_key")).toBe(false);
+		expect(url.searchParams.has("install_id")).toBe(false);
+	});
+
+	it("exchanges and saves credentials, forwarding the api key when returned", async () => {
+		const { exchangeCliCode } = await import("../auth/CliExchange.js");
+		const auth = await import("../auth/AuthConfig.js");
+		vi.mocked(exchangeCliCode).mockResolvedValue({ token: "tok", jolliApiKey: "sk-jol-x" } as never);
+		vi.mocked(auth.resolveSignInJolliUrl).mockReturnValue("https://jolli.ai");
+		const result = await runIdeBridgeAction("auth", "/r", {
+			operation: "exchange-and-save",
+			jolliUrl: "https://jolli.ai",
+			code: "code",
+		});
+		expect(auth.saveAuthCredentials).toHaveBeenCalledWith({
+			token: "tok",
+			jolliUrl: "https://jolli.ai",
+			jolliApiKey: "sk-jol-x",
+		});
+		expect(result).toEqual({ token: "tok", jolliApiKey: "sk-jol-x" });
+	});
+
+	it("exchanges without an api key when the server does not return one", async () => {
+		const { exchangeCliCode } = await import("../auth/CliExchange.js");
+		const auth = await import("../auth/AuthConfig.js");
+		vi.mocked(exchangeCliCode).mockResolvedValue({ token: "tok" } as never);
+		vi.mocked(auth.resolveSignInJolliUrl).mockReturnValue("https://jolli.ai");
+		await runIdeBridgeAction("auth", "/r", {
+			operation: "exchange-and-save",
+			jolliUrl: "https://jolli.ai",
+			code: "c",
+		});
+		expect(auth.saveAuthCredentials).toHaveBeenCalledWith({ token: "tok", jolliUrl: "https://jolli.ai" });
+	});
+
+	it("saves legacy credentials with an api key", async () => {
+		const auth = await import("../auth/AuthConfig.js");
+		vi.mocked(auth.resolveSignInJolliUrl).mockReturnValue("https://jolli.ai");
+		await runIdeBridgeAction("auth", "/r", {
+			operation: "save-legacy-credentials",
+			token: "tok",
+			jolliUrl: "https://jolli.ai",
+			jolliApiKey: "sk-jol-x",
+		});
+		expect(auth.saveAuthCredentials).toHaveBeenCalledWith({
+			token: "tok",
+			jolliUrl: "https://jolli.ai",
+			jolliApiKey: "sk-jol-x",
+		});
+	});
+
+	it("saves legacy credentials without an api key when absent", async () => {
+		const auth = await import("../auth/AuthConfig.js");
+		vi.mocked(auth.resolveSignInJolliUrl).mockReturnValue("https://jolli.ai");
+		await runIdeBridgeAction("auth", "/r", {
+			operation: "save-legacy-credentials",
+			token: "tok",
+			jolliUrl: "https://jolli.ai",
+		});
+		expect(auth.saveAuthCredentials).toHaveBeenCalledWith({ token: "tok", jolliUrl: "https://jolli.ai" });
+	});
+
+	it("signs out", async () => {
+		const auth = await import("../auth/AuthConfig.js");
+		await runIdeBridgeAction("auth", "/r", { operation: "sign-out" });
+		expect(auth.clearAuthCredentials).toHaveBeenCalled();
+	});
+
+	it("rejects an unknown auth operation", async () => {
+		await expect(runIdeBridgeAction("auth", "/r", { operation: "bogus" })).rejects.toThrow(
+			/Unknown auth operation/,
+		);
+	});
+});
+
+describe("runIdeBridgeAction — jolli-api", () => {
+	it("serializes a summary to JSON", async () => {
+		const { serializeSummaryJson } = await import("../core/JolliMemoryPushOrchestrator.js");
+		vi.mocked(serializeSummaryJson).mockReturnValue('{"s":1}');
+		const result = await runIdeBridgeAction("jolli-api", "/r", { operation: "serialize-summary", summary: {} });
+		expect(result).toEqual({ json: '{"s":1}' });
+	});
+
+	it("returns json:null when serializer returns undefined", async () => {
+		const { serializeSummaryJson } = await import("../core/JolliMemoryPushOrchestrator.js");
+		vi.mocked(serializeSummaryJson).mockReturnValue(undefined);
+		const result = await runIdeBridgeAction("jolli-api", "/r", { operation: "serialize-summary", summary: {} });
+		expect(result).toEqual({ json: null });
+	});
+
+	it("pushes a payload via JolliMemoryPushClient", async () => {
+		const result = await runIdeBridgeAction("jolli-api", "/r", {
+			operation: "push",
+			apiKey: "sk",
+			baseUrl: "https://api",
+			payload: { a: 1 },
+		});
+		expect(result).toEqual({ ok: true });
+	});
+
+	it("deletes a doc via JolliMemoryPushClient", async () => {
+		expect(await runIdeBridgeAction("jolli-api", "/r", { operation: "delete", apiKey: "sk", docId: 7 })).toEqual({
+			ok: true,
+		});
+	});
+
+	it("lists spaces", async () => {
+		expect(await runIdeBridgeAction("jolli-api", "/r", { operation: "list-spaces", apiKey: "sk" })).toEqual({
+			spaces: [],
+			defaultSpaceId: null,
+		});
+	});
+
+	it("creates a binding", async () => {
+		expect(
+			await runIdeBridgeAction("jolli-api", "/r", {
+				operation: "create-binding",
+				apiKey: "sk",
+				repoUrl: "u",
+				repoName: "n",
+				jmSpaceId: 3,
+			}),
+		).toEqual({ ok: true });
+	});
+
+	it("creates a live share", async () => {
+		expect(
+			await runIdeBridgeAction("jolli-api", "/r", { operation: "create-share", apiKey: "sk", payload: {} }),
+		).toEqual({ shareId: "s1" });
+	});
+
+	it("updates a live share", async () => {
+		expect(
+			await runIdeBridgeAction("jolli-api", "/r", {
+				operation: "update-share",
+				apiKey: "sk",
+				shareId: "s1",
+				patch: {},
+			}),
+		).toEqual({ ok: true });
+	});
+
+	it("revokes a live share", async () => {
+		expect(
+			await runIdeBridgeAction("jolli-api", "/r", { operation: "revoke-share", apiKey: "sk", shareId: "s1" }),
+		).toEqual({ ok: true });
+	});
+
+	it("invites to a live share with a message", async () => {
+		expect(
+			await runIdeBridgeAction("jolli-api", "/r", {
+				operation: "invite-share",
+				apiKey: "sk",
+				shareId: "s1",
+				recipients: ["a@x", "b@x"],
+				message: "hi",
+			}),
+		).toEqual({ invited: 1 });
+	});
+
+	it("invites to a live share without a message", async () => {
+		expect(
+			await runIdeBridgeAction("jolli-api", "/r", {
+				operation: "invite-share",
+				apiKey: "sk",
+				shareId: "s1",
+				recipients: [],
+			}),
+		).toEqual({ invited: 1 });
+	});
+
+	it("lists org members", async () => {
+		expect(await runIdeBridgeAction("jolli-api", "/r", { operation: "list-org-members", apiKey: "sk" })).toEqual({
+			members: [{ id: 1 }],
+		});
+	});
+
+	it("rejects an unknown jolli-api operation", async () => {
+		await expect(runIdeBridgeAction("jolli-api", "/r", { operation: "wat", apiKey: "sk" })).rejects.toThrow(
+			/Unknown Jolli API operation/,
+		);
+	});
+});
+
+describe("runIdeBridgeAction — pricing", () => {
+	it("computes a sonnet cost estimate", async () => {
+		const { estimateConversationCostUsd } = await import("../core/TokenCost.js");
+		vi.mocked(estimateConversationCostUsd).mockReturnValue(0.75);
+		const result = await runIdeBridgeAction("pricing", "/r", {
+			operation: "sonnet-cost",
+			breakdown: {},
+			totalTokens: 1000,
+		});
+		expect(result).toEqual({ costUsd: 0.75 });
+	});
+
+	it("reports the provider for a known model", async () => {
+		expect(await runIdeBridgeAction("pricing", "/r", { operation: "provider", model: "gpt-4" })).toEqual({
+			provider: "openai",
+		});
+	});
+
+	it("falls back to 'unknown' for an unknown model", async () => {
+		expect(await runIdeBridgeAction("pricing", "/r", { operation: "provider", model: "not-a-model" })).toEqual({
+			provider: "unknown",
+		});
+	});
+
+	it("computes a model cost estimate", async () => {
+		expect(
+			await runIdeBridgeAction("pricing", "/r", { operation: "model-cost", usage: { model: "gpt-4" } }),
+		).toEqual({ costUsd: 0.25 });
+	});
+
+	it("computes a total cost across usages", async () => {
+		expect(await runIdeBridgeAction("pricing", "/r", { operation: "total-cost", usages: [] })).toEqual({
+			totalUsd: 1.5,
+		});
+	});
+
+	it("rejects an unknown pricing operation", async () => {
+		await expect(runIdeBridgeAction("pricing", "/r", { operation: "guess" })).rejects.toThrow(
+			/Unknown pricing operation/,
+		);
+	});
+});
+
+describe("runIdeBridgeAction — shared-store", () => {
+	// pins-*, selection-*, branch-share-*, push-pending-hashes, repo-profile-*,
+	// summary-markdown, summary-pr-markdown, pr-wrap-markdown, pr-replace-markdown,
+	// reference-push-presentation.
+
+	it("reads pins", async () => {
+		const { listPins } = await import("../core/PinStore.js");
+		vi.mocked(listPins).mockResolvedValue([{ id: "p" }] as never);
+		expect(await runIdeBridgeAction("shared-store", "/r", { operation: "pins-read" })).toEqual({
+			pins: [{ id: "p" }],
+		});
+	});
+
+	it("adds a conversation pin, mapping the plural kind + carrying badge as source", async () => {
+		const { addPin } = await import("../core/PinStore.js");
+		await runIdeBridgeAction("shared-store", "/r", {
+			operation: "pins-add",
+			kind: "conversations",
+			key: "id-1",
+			title: "T",
+			badge: "codex",
+		});
+		expect(addPin).toHaveBeenCalledWith(
+			"/r",
+			"repo",
+			"main",
+			expect.objectContaining({ kind: "conversation", id: "id-1", title: "T", badge: "codex", source: "codex" }),
+		);
+	});
+
+	it("adds a plan pin without a source field when badge is absent", async () => {
+		const { addPin } = await import("../core/PinStore.js");
+		await runIdeBridgeAction("shared-store", "/r", {
+			operation: "pins-add",
+			kind: "plans",
+			key: "p",
+			title: "Plan",
+		});
+		const arg = vi.mocked(addPin).mock.calls[0][3];
+		expect(arg.source).toBeUndefined();
+	});
+
+	it("removes a pin", async () => {
+		const { removePin } = await import("../core/PinStore.js");
+		await runIdeBridgeAction("shared-store", "/r", {
+			operation: "pins-remove",
+			kind: "notes",
+			key: "n",
+		});
+		expect(removePin).toHaveBeenCalledWith("/r", "repo", "main", "note", "n");
+	});
+
+	it("accepts every valid singular pin kind", async () => {
+		const { addPin } = await import("../core/PinStore.js");
+		for (const kind of ["conversation", "plan", "note", "memory", "reference"] as const) {
+			await runIdeBridgeAction("shared-store", "/r", {
+				operation: "pins-add",
+				kind,
+				key: `k-${kind}`,
+				title: "T",
+			});
+		}
+		expect(addPin).toHaveBeenCalledTimes(5);
+	});
+
+	it("rejects an unknown pin kind", async () => {
+		await expect(
+			runIdeBridgeAction("shared-store", "/r", { operation: "pins-add", kind: "wat", key: "k", title: "t" }),
+		).rejects.toThrow(/Unknown pin kind/);
+	});
+
+	it("falls back to the project root basename when there is no remote URL", async () => {
+		const { addPin } = await import("../core/PinStore.js");
+		const { getCanonicalRepoUrl, getProjectRootDir } = await Promise.all([
+			import("../core/GitRemoteUtils.js"),
+			import("../core/GitOps.js"),
+		]).then(([r, o]) => ({
+			getCanonicalRepoUrl: r.getCanonicalRepoUrl,
+			getProjectRootDir: o.getProjectRootDir,
+		}));
+		vi.mocked(getCanonicalRepoUrl).mockResolvedValue("");
+		vi.mocked(getProjectRootDir).mockResolvedValue("/my/project");
+		await runIdeBridgeAction("shared-store", "/r", { operation: "pins-add", kind: "plan", key: "k", title: "t" });
+		expect(addPin).toHaveBeenCalledWith(
+			"/r",
+			"project", // basename of /my/project
+			"main",
+			expect.anything(),
+		);
+	});
+
+	it("falls back to cwd basename when getProjectRootDir throws", async () => {
+		const { addPin } = await import("../core/PinStore.js");
+		const { getCanonicalRepoUrl } = await import("../core/GitRemoteUtils.js");
+		const { getProjectRootDir } = await import("../core/GitOps.js");
+		vi.mocked(getCanonicalRepoUrl).mockResolvedValue("");
+		vi.mocked(getProjectRootDir).mockRejectedValue(new Error("no git"));
+		await runIdeBridgeAction("shared-store", "/repo-fallback", {
+			operation: "pins-add",
+			kind: "plan",
+			key: "k",
+			title: "t",
+		});
+		expect(addPin).toHaveBeenCalledWith("/repo-fallback", "repo-fallback", "main", expect.anything());
+	});
+
+	it("reads selection exclusions as arrays", async () => {
+		const { readExclusions } = await import("../core/CommitSelectionStore.js");
+		vi.mocked(readExclusions).mockResolvedValue({
+			conversations: new Set(["c"]),
+			plans: new Set(),
+			notes: new Set(),
+			references: new Set(),
+		} as never);
+		const result = await runIdeBridgeAction("shared-store", "/r", { operation: "selection-read" });
+		expect(result).toEqual({ conversations: ["c"], plans: [], notes: [], references: [] });
+	});
+
+	it("computes a selection key", async () => {
+		const { conversationKey } = await import("../core/CommitSelectionStore.js");
+		vi.mocked(conversationKey).mockReturnValue("claude#s");
+		const result = await runIdeBridgeAction("shared-store", "/r", {
+			operation: "selection-key",
+			source: "claude",
+			sessionId: "s",
+		});
+		expect(result).toEqual({ key: "claude#s" });
+	});
+
+	it("sets a single selection", async () => {
+		const { setExcluded } = await import("../core/CommitSelectionStore.js");
+		await runIdeBridgeAction("shared-store", "/r", {
+			operation: "selection-set",
+			kind: "conversations",
+			key: "k",
+			excluded: true,
+		});
+		expect(setExcluded).toHaveBeenCalledWith("/r", "conversations", "k", true);
+	});
+
+	it("defaults selection-set excluded flag to false when the field is not exactly true", async () => {
+		const { setExcluded } = await import("../core/CommitSelectionStore.js");
+		await runIdeBridgeAction("shared-store", "/r", {
+			operation: "selection-set",
+			kind: "conversations",
+			key: "k",
+			excluded: "yes",
+		});
+		expect(setExcluded).toHaveBeenCalledWith("/r", "conversations", "k", false);
+	});
+
+	it("sets all selections", async () => {
+		const { setAllExcluded } = await import("../core/CommitSelectionStore.js");
+		await runIdeBridgeAction("shared-store", "/r", {
+			operation: "selection-set-all",
+			kind: "plans",
+			keys: ["a", "b"],
+			excluded: true,
+		});
+		expect(setAllExcluded).toHaveBeenCalledWith("/r", "plans", ["a", "b"], true);
+	});
+
+	it("puts a branch share", async () => {
+		const { putBranchShare } = await import("../core/BranchShareStore.js");
+		await runIdeBridgeAction("shared-store", "/r", {
+			operation: "branch-share-put",
+			branch: "main",
+			commitHash: "abc",
+			record: { id: 1 },
+		});
+		expect(putBranchShare).toHaveBeenCalledWith("/r", "main", { id: 1 }, "abc");
+	});
+
+	it("removes a branch share", async () => {
+		const { removeShare } = await import("../core/BranchShareStore.js");
+		await runIdeBridgeAction("shared-store", "/r", {
+			operation: "branch-share-remove",
+			branch: "main",
+			commitHash: "abc",
+		});
+		expect(removeShare).toHaveBeenCalledWith("/r", "main", "abc");
+	});
+
+	it("gets a branch share (record found)", async () => {
+		const { getShare } = await import("../core/BranchShareStore.js");
+		vi.mocked(getShare).mockResolvedValue({ id: 42 } as never);
+		const { loadConfig } = await import("../core/SessionTracker.js");
+		vi.mocked(loadConfig).mockResolvedValue({ jolliApiKey: "sk-jol-x" } as never);
+		const result = await runIdeBridgeAction("shared-store", "/r", {
+			operation: "branch-share-get",
+			branch: "main",
+			commitHash: "abc",
+		});
+		expect(result).toEqual({ record: { id: 42 } });
+	});
+
+	it("gets a branch share (record null; api key absent)", async () => {
+		const { loadConfig } = await import("../core/SessionTracker.js");
+		vi.mocked(loadConfig).mockResolvedValue({} as never);
+		const { getShare } = await import("../core/BranchShareStore.js");
+		vi.mocked(getShare).mockResolvedValue(undefined);
+		const result = await runIdeBridgeAction("shared-store", "/r", {
+			operation: "branch-share-get",
+			branch: "main",
+		});
+		expect(result).toEqual({ record: null });
+	});
+
+	it("returns push-pending hashes", async () => {
+		expect(await runIdeBridgeAction("shared-store", "/r", { operation: "push-pending-hashes" })).toEqual({
+			hashes: ["hashA", "hashB"],
+		});
+	});
+
+	it("reads the repo profile", async () => {
+		const result = await runIdeBridgeAction("shared-store", "/r", { operation: "repo-profile-read" });
+		expect(result).toMatchObject({ profile: { backfillDismissed: false } });
+	});
+
+	it("sets backfill-dismissed on the repo profile", async () => {
+		const { updateRepoProfile } = await import("../core/RepoProfile.js");
+		await runIdeBridgeAction("shared-store", "/r", {
+			operation: "repo-profile-set-backfill-dismissed",
+			dismissed: true,
+		});
+		expect(updateRepoProfile).toHaveBeenCalledWith("/r", { backfillDismissed: true });
+	});
+
+	it("rejects a non-boolean 'dismissed' field on repo-profile-set-backfill-dismissed", async () => {
+		await expect(
+			runIdeBridgeAction("shared-store", "/r", {
+				operation: "repo-profile-set-backfill-dismissed",
+				dismissed: 1,
+			}),
+		).rejects.toThrow(/"dismissed"/);
+	});
+
+	it("returns a summary-markdown string", async () => {
+		expect(await runIdeBridgeAction("shared-store", "/r", { operation: "summary-markdown", summary: {} })).toEqual({
+			markdown: "# md",
+		});
+	});
+
+	it("returns a summary-pr-markdown string", async () => {
+		expect(
+			await runIdeBridgeAction("shared-store", "/r", { operation: "summary-pr-markdown", summary: {} }),
+		).toEqual({ markdown: "# pr md" });
+	});
+
+	it("wraps a markdown with PR markers", async () => {
+		const result = await runIdeBridgeAction("shared-store", "/r", {
+			operation: "pr-wrap-markdown",
+			markdown: "hello",
+		});
+		expect(result).toMatchObject({ markdown: expect.stringContaining("hello") });
+	});
+
+	it("replaces a summary block in a PR body", async () => {
+		const result = await runIdeBridgeAction("shared-store", "/r", {
+			operation: "pr-replace-markdown",
+			currentBody: "body",
+			markdown: "md",
+		});
+		expect(result).toEqual({ body: "body[patched]" });
+	});
+
+	it("builds reference push presentation (with a stored markdown carrying a description)", async () => {
+		const references = await import("../core/references/ReferenceStore.js");
+		// `-Once` so the override doesn't leak into the reference-store 'parse'
+		// test that follows (clearMocks: true only wipes call history, not
+		// return-value overrides).
+		vi.mocked(references.readReferenceMarkdownFromString).mockReturnValueOnce({ description: "d" } as never);
+		const result = await runIdeBridgeAction("shared-store", "/r", {
+			operation: "reference-push-presentation",
+			reference: { source: "s", key: "k" },
+			storedMarkdown: "# ref",
+		});
+		expect(result).toMatchObject({ title: "Ref Title", markdown: "# ref" });
+	});
+
+	it("builds reference push presentation (no storedMarkdown)", async () => {
+		const result = await runIdeBridgeAction("shared-store", "/r", {
+			operation: "reference-push-presentation",
+			reference: { source: "s", key: "k" },
+		});
+		expect(result).toMatchObject({ title: "Ref Title" });
+	});
+
+	it("builds reference push presentation when the stored markdown parses to null", async () => {
+		const references = await import("../core/references/ReferenceStore.js");
+		// `-Once` — see the earlier reference-push-presentation test for why.
+		vi.mocked(references.readReferenceMarkdownFromString).mockReturnValueOnce(null);
+		const result = await runIdeBridgeAction("shared-store", "/r", {
+			operation: "reference-push-presentation",
+			reference: { source: "s", key: "k" },
+			storedMarkdown: "raw",
+		});
+		expect(result).toMatchObject({ title: "Ref Title" });
+	});
+
+	it("rejects reference-push-presentation with a non-object reference", async () => {
+		await expect(
+			runIdeBridgeAction("shared-store", "/r", { operation: "reference-push-presentation", reference: "x" }),
+		).rejects.toThrow(/"reference"/);
+	});
+
+	it("rejects an unknown shared-store operation", async () => {
+		await expect(runIdeBridgeAction("shared-store", "/r", { operation: "nothing" })).rejects.toThrow(
+			/Unknown shared-store operation/,
+		);
+	});
+});
+
+describe("runIdeBridgeAction — summary-store", () => {
+	it("returns the index", async () => {
+		const { getIndex } = await import("../core/SummaryStore.js");
+		vi.mocked(getIndex).mockResolvedValue({ entries: [] } as never);
+		expect(await runIdeBridgeAction("summary-store", "/r", { operation: "index" })).toEqual({ entries: [] });
+	});
+
+	it("returns a single summary", async () => {
+		expect(await runIdeBridgeAction("summary-store", "/r", { operation: "get", commitHash: "abc" })).toMatchObject({
+			commitHash: "abc",
+		});
+	});
+
+	it("lists summaries with the default count of 10 when count is not given", async () => {
+		const { listSummaries } = await import("../core/SummaryStore.js");
+		await runIdeBridgeAction("summary-store", "/r", { operation: "list" });
+		expect(listSummaries).toHaveBeenCalledWith(10, "/r", expect.anything());
+	});
+
+	it("lists summaries with an explicit count", async () => {
+		const { listSummaries } = await import("../core/SummaryStore.js");
+		await runIdeBridgeAction("summary-store", "/r", { operation: "list", count: 3 });
+		expect(listSummaries).toHaveBeenCalledWith(3, "/r", expect.anything());
+	});
+
+	it("returns a count", async () => {
+		const { getSummaryCount } = await import("../core/SummaryStore.js");
+		vi.mocked(getSummaryCount).mockResolvedValue(7);
+		expect(await runIdeBridgeAction("summary-store", "/r", { operation: "count" })).toEqual({ count: 7 });
+	});
+
+	it("find-root returns null when there is no index", async () => {
+		const { getIndex } = await import("../core/SummaryStore.js");
+		vi.mocked(getIndex).mockResolvedValue(null);
+		expect(await runIdeBridgeAction("summary-store", "/r", { operation: "find-root", commitHash: "x" })).toEqual({
+			hash: null,
+		});
+	});
+
+	it("find-root returns null when the hash is not in the index", async () => {
+		const { getIndex } = await import("../core/SummaryStore.js");
+		vi.mocked(getIndex).mockResolvedValue({
+			entries: [{ commitHash: "root", parentCommitHash: null }],
+			commitAliases: {},
+		} as never);
+		expect(
+			await runIdeBridgeAction("summary-store", "/r", { operation: "find-root", commitHash: "missing" }),
+		).toEqual({ hash: null });
+	});
+
+	it("find-root walks parent pointers to the root", async () => {
+		const { getIndex } = await import("../core/SummaryStore.js");
+		vi.mocked(getIndex).mockResolvedValue({
+			entries: [
+				{ commitHash: "root", parentCommitHash: null },
+				{ commitHash: "child", parentCommitHash: "root" },
+				{ commitHash: "leaf", parentCommitHash: "child" },
+			],
+			commitAliases: { alias: "leaf" },
+		} as never);
+		expect(
+			await runIdeBridgeAction("summary-store", "/r", { operation: "find-root", commitHash: "alias" }),
+		).toEqual({ hash: "root" });
+	});
+
+	it("find-root stops when a parent is missing from the index", async () => {
+		const { getIndex } = await import("../core/SummaryStore.js");
+		vi.mocked(getIndex).mockResolvedValue({
+			entries: [{ commitHash: "leaf", parentCommitHash: "gone" }],
+			commitAliases: {},
+		} as never);
+		expect(await runIdeBridgeAction("summary-store", "/r", { operation: "find-root", commitHash: "leaf" })).toEqual(
+			{
+				hash: "leaf",
+			},
+		);
+	});
+
+	it("filter-hashes returns only hashes present in the index or in aliases", async () => {
+		const { getIndex } = await import("../core/SummaryStore.js");
+		vi.mocked(getIndex).mockResolvedValue({
+			entries: [{ commitHash: "known" }],
+			commitAliases: { alt: "known" },
+		} as never);
+		expect(
+			await runIdeBridgeAction("summary-store", "/r", {
+				operation: "filter-hashes",
+				hashes: ["known", "alt", "missing"],
+			}),
+		).toEqual({ hashes: ["known", "alt"] });
+	});
+
+	it("filter-hashes handles a null index", async () => {
+		const { getIndex } = await import("../core/SummaryStore.js");
+		vi.mocked(getIndex).mockResolvedValue(null);
+		expect(
+			await runIdeBridgeAction("summary-store", "/r", {
+				operation: "filter-hashes",
+				hashes: ["a"],
+			}),
+		).toEqual({ hashes: [] });
+	});
+
+	it("scan-aliases returns the changed flag from the store", async () => {
+		const { scanTreeHashAliases } = await import("../core/SummaryStore.js");
+		vi.mocked(scanTreeHashAliases).mockResolvedValue(true);
+		expect(await runIdeBridgeAction("summary-store", "/r", { operation: "scan-aliases", hashes: ["x"] })).toEqual({
+			changed: true,
+		});
+	});
+
+	it("resolve-alias returns the alias target when present", async () => {
+		const { getIndex } = await import("../core/SummaryStore.js");
+		vi.mocked(getIndex).mockResolvedValue({ entries: [], commitAliases: { a: "b" } } as never);
+		expect(
+			await runIdeBridgeAction("summary-store", "/r", { operation: "resolve-alias", commitHash: "a" }),
+		).toEqual({ hash: "b" });
+	});
+
+	it("resolve-alias returns the original hash when no alias exists", async () => {
+		const { getIndex } = await import("../core/SummaryStore.js");
+		vi.mocked(getIndex).mockResolvedValue({ entries: [], commitAliases: {} } as never);
+		expect(
+			await runIdeBridgeAction("summary-store", "/r", { operation: "resolve-alias", commitHash: "z" }),
+		).toEqual({ hash: "z" });
+	});
+
+	it("store-summary rejects a non-object summary", async () => {
+		await expect(
+			runIdeBridgeAction("summary-store", "/r", { operation: "store-summary", summary: null }),
+		).rejects.toThrow(/"summary"/);
+	});
+
+	it("store-summary passes optional transcript / planProgress / referenceFiles", async () => {
+		const { storeSummary } = await import("../core/SummaryStore.js");
+		await runIdeBridgeAction("summary-store", "/r", {
+			operation: "store-summary",
+			summary: { commitHash: "h" },
+			force: true,
+			transcript: { entries: [] },
+			planProgress: [{ slug: "x" }],
+			referenceFiles: [{ path: "p", content: "c" }],
+		});
+		expect(storeSummary).toHaveBeenCalledWith(
+			{ commitHash: "h" },
+			"/r",
+			true,
+			expect.objectContaining({ transcript: expect.any(Object), planProgress: expect.any(Array) }),
+			expect.anything(),
+		);
+	});
+
+	it("store-summary works without any optional extras", async () => {
+		const { storeSummary } = await import("../core/SummaryStore.js");
+		await runIdeBridgeAction("summary-store", "/r", {
+			operation: "store-summary",
+			summary: { commitHash: "h" },
+		});
+		expect(storeSummary).toHaveBeenCalledWith(
+			{ commitHash: "h" },
+			"/r",
+			false,
+			expect.any(Object),
+			expect.anything(),
+		);
+	});
+
+	it("reads plan progress", async () => {
+		const { readPlanProgress } = await import("../core/SummaryStore.js");
+		vi.mocked(readPlanProgress).mockResolvedValue([{ step: 1 }] as never);
+		expect(await runIdeBridgeAction("summary-store", "/r", { operation: "read-plan-progress", slug: "s" })).toEqual(
+			[{ step: 1 }],
+		);
+	});
+
+	it("store-files rejects when files is not an array", async () => {
+		await expect(
+			runIdeBridgeAction("summary-store", "/r", { operation: "store-files", files: "no", message: "m" }),
+		).rejects.toThrow(/"files"/);
+	});
+
+	it("store-files writes to storage", async () => {
+		const write = vi.fn().mockResolvedValue(undefined);
+		const { createStorage } = await import("../core/StorageFactory.js");
+		vi.mocked(createStorage).mockResolvedValue({ writeFiles: write } as never);
+		await runIdeBridgeAction("summary-store", "/r", {
+			operation: "store-files",
+			files: [{ path: "p", content: "c" }],
+			message: "msg",
+		});
+		expect(write).toHaveBeenCalledWith([{ path: "p", content: "c" }], "msg");
+	});
+
+	it("reads a plan from the branch", async () => {
+		expect(await runIdeBridgeAction("summary-store", "/r", { operation: "read-plan", slug: "s" })).toEqual({
+			content: "plan-content",
+		});
+	});
+
+	it("writes a plan", async () => {
+		const { storePlans } = await import("../core/SummaryStore.js");
+		await runIdeBridgeAction("summary-store", "/r", {
+			operation: "write-plan",
+			slug: "s",
+			content: "c",
+			message: "m",
+		});
+		expect(storePlans).toHaveBeenCalled();
+	});
+
+	it("reads a reference from the branch", async () => {
+		expect(
+			await runIdeBridgeAction("summary-store", "/r", {
+				operation: "read-reference",
+				source: "claude",
+				archivedKey: "k",
+			}),
+		).toEqual({ content: "ref-content" });
+	});
+
+	it("writes a reference", async () => {
+		const { storeReferences } = await import("../core/SummaryStore.js");
+		await runIdeBridgeAction("summary-store", "/r", {
+			operation: "write-reference",
+			source: "claude",
+			archivedKey: "k",
+			content: "c",
+			message: "m",
+		});
+		expect(storeReferences).toHaveBeenCalled();
+	});
+
+	it("returns transcript hashes as an array", async () => {
+		expect(await runIdeBridgeAction("summary-store", "/r", { operation: "transcript-hashes" })).toEqual({
+			hashes: ["h1", "h2"],
+		});
+	});
+
+	it("reads a transcript", async () => {
+		expect(
+			await runIdeBridgeAction("summary-store", "/r", {
+				operation: "read-transcript",
+				commitHash: "h",
+			}),
+		).toEqual({ entries: [] });
+	});
+
+	it("write-transcript-batch rejects when writes is not a plain object", async () => {
+		await expect(
+			runIdeBridgeAction("summary-store", "/r", {
+				operation: "write-transcript-batch",
+				writes: [1],
+				deletes: [],
+			}),
+		).rejects.toThrow(/"writes"/);
+	});
+
+	it("write-transcript-batch calls saveTranscriptsBatch", async () => {
+		const { saveTranscriptsBatch } = await import("../core/SummaryStore.js");
+		await runIdeBridgeAction("summary-store", "/r", {
+			operation: "write-transcript-batch",
+			writes: { h1: { entries: [] } },
+			deletes: ["d1"],
+		});
+		expect(saveTranscriptsBatch).toHaveBeenCalledWith(
+			[{ hash: "h1", data: { entries: [] } }],
+			["d1"],
+			"/r",
+			expect.anything(),
+		);
+	});
+
+	it("rejects an unknown summary-store operation", async () => {
+		await expect(runIdeBridgeAction("summary-store", "/r", { operation: "wat" })).rejects.toThrow(
+			/Unknown summary-store operation/,
+		);
+	});
+});
+
+describe("runIdeBridgeAction — summary-tree", () => {
+	it("analyzes a summary", async () => {
+		const result = await runIdeBridgeAction("summary-tree", "/r", { operation: "analyze", summary: {} });
+		expect(result).toMatchObject({ unified: true, topicCount: 3, durationLabel: "1d" });
+	});
+
+	it("updates a topic in the tree", async () => {
+		const result = await runIdeBridgeAction("summary-tree", "/r", {
+			operation: "update-topic",
+			summary: {},
+			globalIndex: 0,
+			updates: { title: "T" },
+		});
+		expect(result).toEqual({ updated: true });
+	});
+
+	it("update-topic defaults updates to {} when absent", async () => {
+		const { updateTopicInTree } = await import("../core/SummaryTree.js");
+		await runIdeBridgeAction("summary-tree", "/r", {
+			operation: "update-topic",
+			summary: {},
+			globalIndex: 1,
+		});
+		expect(updateTopicInTree).toHaveBeenCalledWith({}, 1, {});
+	});
+
+	it("deletes a topic from the tree", async () => {
+		expect(
+			await runIdeBridgeAction("summary-tree", "/r", {
+				operation: "delete-topic",
+				summary: {},
+				globalIndex: 2,
+			}),
+		).toEqual({ deleted: true });
+	});
+
+	it("rejects a summary that is not an object", async () => {
+		await expect(runIdeBridgeAction("summary-tree", "/r", { operation: "analyze", summary: null })).rejects.toThrow(
+			/"summary"/,
+		);
+	});
+
+	it("rejects an unknown summary-tree operation", async () => {
+		await expect(runIdeBridgeAction("summary-tree", "/r", { operation: "nope", summary: {} })).rejects.toThrow(
+			/Unknown summary-tree operation/,
+		);
+	});
+});
+
+describe("runIdeBridgeAction — plan-grouping", () => {
+	it("returns a single base key", async () => {
+		expect(await runIdeBridgeAction("plan-grouping", "/r", { operation: "base-key", slug: "s" })).toEqual({
+			key: "plan:s",
+		});
+	});
+
+	it("returns a map of base keys per slug", async () => {
+		expect(
+			await runIdeBridgeAction("plan-grouping", "/r", {
+				operation: "base-keys",
+				slugs: ["a", "b"],
+			}),
+		).toEqual({ a: "plan:a", b: "plan:b" });
+	});
+
+	it("returns the latest plan per name", async () => {
+		const { latestPlanPerName } = await import("../core/JolliMemoryPushOrchestrator.js");
+		vi.mocked(latestPlanPerName).mockReturnValue([{ slug: "s" }] as never);
+		expect(
+			await runIdeBridgeAction("plan-grouping", "/r", { operation: "latest", plans: [{ slug: "s" }] }),
+		).toEqual([{ slug: "s" }]);
+	});
+
+	it("rejects 'latest' with a non-array plans field", async () => {
+		await expect(runIdeBridgeAction("plan-grouping", "/r", { operation: "latest", plans: "no" })).rejects.toThrow(
+			/"plans"/,
+		);
+	});
+
+	it("rejects an unknown plan-grouping operation", async () => {
+		await expect(runIdeBridgeAction("plan-grouping", "/r", { operation: "wat" })).rejects.toThrow(
+			/Unknown plan-grouping operation/,
+		);
+	});
+});
+
+describe("runIdeBridgeAction — reference-store", () => {
+	it("reads a reference markdown from disk", async () => {
+		expect(await runIdeBridgeAction("reference-store", "/r", { operation: "read", sourcePath: "/x.md" })).toEqual({
+			source: "src",
+			archivedKey: "k",
+			content: "c",
+		});
+	});
+
+	it("parses a reference markdown string", async () => {
+		expect(await runIdeBridgeAction("reference-store", "/r", { operation: "parse", content: "# ref" })).toEqual({
+			description: "desc",
+		});
+	});
+
+	it("rejects an unknown reference-store operation", async () => {
+		await expect(runIdeBridgeAction("reference-store", "/r", { operation: "wat" })).rejects.toThrow(
+			/Unknown reference-store operation/,
+		);
+	});
+});
+
+describe("runIdeBridgeAction — kb (path helpers)", () => {
+	it("resolves a KB path with a custom parent", async () => {
+		expect(
+			await runIdeBridgeAction("kb", "/r", {
+				operation: "resolve",
+				repoName: "n",
+				remoteUrl: "u",
+				customPath: "/c",
+			}),
+		).toEqual({ path: "/kb" });
+	});
+
+	it("passes a null remoteUrl when the field is missing", async () => {
+		const { resolveKBPath } = await import("../core/KBPathResolver.js");
+		await runIdeBridgeAction("kb", "/r", { operation: "resolve", repoName: "n" });
+		expect(resolveKBPath).toHaveBeenCalledWith("n", null, undefined);
+	});
+
+	it("initializes a KB folder", async () => {
+		const { initializeKBFolder } = await import("../core/KBPathResolver.js");
+		await runIdeBridgeAction("kb", "/r", {
+			operation: "initialize",
+			kbRoot: "/kb",
+			repoName: "n",
+			remoteUrl: "u",
+		});
+		expect(initializeKBFolder).toHaveBeenCalledWith("/kb", "n", "u");
+	});
+
+	it("finds repo folders", async () => {
+		expect(await runIdeBridgeAction("kb", "/r", { operation: "find-repo-folders", repoName: "n" })).toEqual({
+			paths: [],
+		});
+	});
+
+	it("finds fresh kb path", async () => {
+		expect(await runIdeBridgeAction("kb", "/r", { operation: "find-fresh", repoName: "n" })).toEqual({
+			path: "/kb-fresh",
+		});
+	});
+
+	it("archives a kb folder", async () => {
+		expect(await runIdeBridgeAction("kb", "/r", { operation: "archive", kbRoot: "/kb" })).toEqual({
+			path: "/kb-archive",
+		});
+	});
+
+	it("extracts a repo name", async () => {
+		expect(await runIdeBridgeAction("kb", "/r", { operation: "extract-repo-name", projectPath: "/p" })).toEqual({
+			value: "repo",
+		});
+	});
+
+	it("gets a remote url", async () => {
+		expect(await runIdeBridgeAction("kb", "/r", { operation: "get-remote-url", projectPath: "/p" })).toEqual({
+			value: "git@github.com:acme/repo.git",
+		});
+	});
+
+	it("discovers repos", async () => {
+		expect(await runIdeBridgeAction("kb", "/r", { operation: "discover" })).toEqual({ repos: [] });
+	});
+});
+
+describe("runIdeBridgeAction — kb (metadata operations)", () => {
+	it("ensures metadata", async () => {
+		expect(await runIdeBridgeAction("kb", "/r", { operation: "metadata-ensure", jolliDir: "/j" })).toEqual({
+			ok: true,
+		});
+	});
+
+	it("reads the manifest", async () => {
+		expect(await runIdeBridgeAction("kb", "/r", { operation: "metadata-read-manifest", jolliDir: "/j" })).toEqual({
+			files: [],
+		});
+	});
+
+	it("reads the index", async () => {
+		expect(await runIdeBridgeAction("kb", "/r", { operation: "metadata-read-index", jolliDir: "/j" })).toEqual({
+			version: 1,
+			entries: [],
+		});
+	});
+
+	it("reads the config", async () => {
+		expect(await runIdeBridgeAction("kb", "/r", { operation: "metadata-read-config", jolliDir: "/j" })).toEqual({});
+	});
+
+	it("finds by path", async () => {
+		expect(
+			await runIdeBridgeAction("kb", "/r", { operation: "metadata-find-by-path", jolliDir: "/j", path: "p" }),
+		).toEqual({ entry: { fileId: "id" } });
+	});
+
+	it("updates a path", async () => {
+		expect(
+			await runIdeBridgeAction("kb", "/r", {
+				operation: "metadata-update-path",
+				jolliDir: "/j",
+				fileId: "id",
+				newPath: "p2",
+			}),
+		).toEqual({ changed: true });
+	});
+
+	it("renames a branch folder", async () => {
+		expect(
+			await runIdeBridgeAction("kb", "/r", {
+				operation: "metadata-rename-branch-folder",
+				jolliDir: "/j",
+				oldFolder: "o",
+				newFolder: "n",
+			}),
+		).toEqual({ count: 3 });
+	});
+
+	it("removes a branch folder", async () => {
+		expect(
+			await runIdeBridgeAction("kb", "/r", {
+				operation: "metadata-remove-branch-folder",
+				jolliDir: "/j",
+				folder: "f",
+			}),
+		).toEqual({ count: 2 });
+	});
+
+	it("removes from the manifest", async () => {
+		expect(
+			await runIdeBridgeAction("kb", "/r", {
+				operation: "metadata-remove-manifest",
+				jolliDir: "/j",
+				fileId: "id",
+			}),
+		).toEqual({ changed: true });
+	});
+
+	it("reconciles metadata", async () => {
+		expect(
+			await runIdeBridgeAction("kb", "/r", {
+				operation: "metadata-reconcile",
+				jolliDir: "/j",
+				kbRoot: "/kb",
+			}),
+		).toEqual({ count: 1 });
+	});
+
+	it("saves the migration state", async () => {
+		expect(
+			await runIdeBridgeAction("kb", "/r", {
+				operation: "metadata-save-migration",
+				jolliDir: "/j",
+				state: { status: "completed", totalEntries: 0, migratedEntries: 0 },
+			}),
+		).toEqual({ ok: true });
+	});
+
+	it("rejects an unknown kb operation", async () => {
+		await expect(runIdeBridgeAction("kb", "/r", { operation: "wat", jolliDir: "/j" })).rejects.toThrow(
+			/Unknown KB operation/,
+		);
+	});
+});
+
+describe("runIdeBridgeAction — storage", () => {
+	it("reads a file", async () => {
+		const readFile = vi.fn().mockResolvedValue("content");
+		const { createStorage } = await import("../core/StorageFactory.js");
+		vi.mocked(createStorage).mockResolvedValue({ readFile } as never);
+		expect(await runIdeBridgeAction("storage", "/r", { operation: "read", path: "p" })).toEqual({
+			content: "content",
+		});
+	});
+
+	it("lists files", async () => {
+		const listFiles = vi.fn().mockResolvedValue(["a", "b"]);
+		const { createStorage } = await import("../core/StorageFactory.js");
+		vi.mocked(createStorage).mockResolvedValue({ listFiles } as never);
+		expect(await runIdeBridgeAction("storage", "/r", { operation: "list", prefix: "p/" })).toEqual({
+			paths: ["a", "b"],
+		});
+	});
+
+	it("checks existence", async () => {
+		const exists = vi.fn().mockResolvedValue(true);
+		const { createStorage } = await import("../core/StorageFactory.js");
+		vi.mocked(createStorage).mockResolvedValue({ exists } as never);
+		expect(await runIdeBridgeAction("storage", "/r", { operation: "exists" })).toEqual({ exists: true });
+	});
+
+	it("ensures the storage exists", async () => {
+		const ensure = vi.fn().mockResolvedValue(undefined);
+		const { createStorage } = await import("../core/StorageFactory.js");
+		vi.mocked(createStorage).mockResolvedValue({ ensure } as never);
+		expect(await runIdeBridgeAction("storage", "/r", { operation: "ensure" })).toEqual({ ok: true });
+	});
+
+	it("writes files", async () => {
+		const writeFiles = vi.fn().mockResolvedValue(undefined);
+		const { createStorage } = await import("../core/StorageFactory.js");
+		vi.mocked(createStorage).mockResolvedValue({ writeFiles } as never);
+		expect(
+			await runIdeBridgeAction("storage", "/r", {
+				operation: "write",
+				files: [{ path: "p", content: "c" }],
+				message: "m",
+			}),
+		).toEqual({ ok: true });
+	});
+
+	it("rejects a write with non-array files", async () => {
+		const writeFiles = vi.fn();
+		const { createStorage } = await import("../core/StorageFactory.js");
+		vi.mocked(createStorage).mockResolvedValue({ writeFiles } as never);
+		await expect(
+			runIdeBridgeAction("storage", "/r", { operation: "write", files: "nope", message: "m" }),
+		).rejects.toThrow(/"files"/);
+	});
+
+	it("rejects an unknown storage operation", async () => {
+		const { createStorage } = await import("../core/StorageFactory.js");
+		vi.mocked(createStorage).mockResolvedValue({} as never);
+		await expect(runIdeBridgeAction("storage", "/r", { operation: "wat" })).rejects.toThrow(
+			/Unknown storage operation/,
+		);
+	});
+});
+
+describe("runIdeBridgeAction — git-exec / git-main-worktree-root / git-remote", () => {
+	it("executes a git command", async () => {
+		const { execGit } = await import("../core/GitOps.js");
+		vi.mocked(execGit).mockResolvedValue({ stdout: "ok", stderr: "", exitCode: 0 } as never);
+		expect(await runIdeBridgeAction("git-exec", "/r", { args: ["status"] })).toEqual({
+			stdout: "ok",
+			stderr: "",
+			exitCode: 0,
+		});
+	});
+
+	it("returns the main worktree root", async () => {
+		const { getProjectRootDir } = await import("../core/GitOps.js");
+		vi.mocked(getProjectRootDir).mockResolvedValue("/main");
+		expect(await runIdeBridgeAction("git-main-worktree-root", "/r", {})).toEqual({ path: "/main" });
+	});
+
+	it("gets the canonical repo url", async () => {
+		const { getCanonicalRepoUrl } = await import("../core/GitRemoteUtils.js");
+		vi.mocked(getCanonicalRepoUrl).mockResolvedValue("git@github.com:acme/repo.git");
+		expect(await runIdeBridgeAction("git-remote", "/r", { operation: "canonical-url" })).toEqual({
+			value: "git@github.com:acme/repo.git",
+		});
+	});
+
+	it("normalizes a remote url", async () => {
+		expect(
+			await runIdeBridgeAction("git-remote", "/r", { operation: "normalize-url", remote: "git@github.com:x/y" }),
+		).toEqual({ value: "git@github.com:acme/repo.git" });
+	});
+
+	it("derives a repo name from a url", async () => {
+		expect(
+			await runIdeBridgeAction("git-remote", "/r", {
+				operation: "derive-name",
+				repoUrl: "git@github.com:acme/repo.git",
+			}),
+		).toEqual({ value: "repo" });
+	});
+
+	it("sanitizes a branch slug", async () => {
+		expect(
+			await runIdeBridgeAction("git-remote", "/r", { operation: "sanitize-branch", branch: "feat/x" }),
+		).toEqual({ value: "main-slug" });
+	});
+
+	it("rejects an unknown git-remote operation", async () => {
+		await expect(runIdeBridgeAction("git-remote", "/r", { operation: "wat" })).rejects.toThrow(
+			/Unknown git-remote operation/,
+		);
+	});
+});
+
+describe("runIdeBridgeAction — telemetry", () => {
+	it("tracks an event with properties and bucketCounts", async () => {
+		const { track, bucket } = await import("../core/Telemetry.js");
+		expect(
+			await runIdeBridgeAction("telemetry-track", "/r", {
+				eventName: "ide.sync",
+				properties: { a: 1 },
+				bucketCounts: { n: 12 },
+				platformDisabled: false,
+			}),
+		).toEqual({ ok: true });
+		expect(bucket).toHaveBeenCalledWith(12);
+		expect(track).toHaveBeenCalledWith("ide.sync", expect.objectContaining({ a: 1, n: "bucket-12" }));
+	});
+
+	it("tracks an event without bucketCounts", async () => {
+		await runIdeBridgeAction("telemetry-track", "/r", { eventName: "ide.sync" });
+		const { track } = await import("../core/Telemetry.js");
+		expect(track).toHaveBeenCalled();
+	});
+
+	it("rejects a non-object bucketCounts", async () => {
+		await expect(
+			runIdeBridgeAction("telemetry-track", "/r", { eventName: "e", bucketCounts: [1, 2] }),
+		).rejects.toThrow(/"bucketCounts"/);
+	});
+
+	it("rejects a bucket count that is not a number", async () => {
+		await expect(
+			runIdeBridgeAction("telemetry-track", "/r", { eventName: "e", bucketCounts: { k: "no" } }),
+		).rejects.toThrow(/Bucket count "k"/);
+	});
+
+	it("bootstraps telemetry and returns the notice flag", async () => {
+		const { shouldShowTelemetryNotice } = await import("../core/TelemetryConsent.js");
+		vi.mocked(shouldShowTelemetryNotice).mockReturnValue(true);
+		expect(await runIdeBridgeAction("telemetry-bootstrap", "/r", { platformDisabled: true })).toEqual({
+			shouldShowNotice: true,
+		});
+	});
+
+	it("returns a telemetry install id", async () => {
+		expect(await runIdeBridgeAction("telemetry-install-id", "/r", {})).toEqual({
+			installId: "install-1",
+			created: false,
+		});
+	});
+
+	it("flushes telemetry", async () => {
+		expect(await runIdeBridgeAction("telemetry-flush", "/r", { platformDisabled: true })).toEqual({
+			ok: true,
+		});
+	});
+});
+
+describe("runIdeBridgeAction — unknown action", () => {
+	it("throws for a completely unknown action", async () => {
+		await expect(runIdeBridgeAction("nope", "/r", {})).rejects.toThrow(/Unknown IDE bridge action/);
+	});
+});
+
+// ---------- 3. field validators (through the entry actions) ----------
+
+describe("runIdeBridgeAction — field validators", () => {
+	it("stringField rejects a non-string value", async () => {
+		await expect(runIdeBridgeAction("summary-store", "/r", { operation: 42 })).rejects.toThrow(/"operation"/);
+	});
+
+	it("optionalString accepts undefined and null (both mean 'not set')", async () => {
+		// session-state 'config-load' with dir undefined + dir null both pass validation
+		await runIdeBridgeAction("session-state", "/r", { operation: "config-load", dir: null });
+		await runIdeBridgeAction("session-state", "/r", { operation: "config-load" });
+	});
+
+	it("optionalString rejects a non-string value", async () => {
+		await expect(runIdeBridgeAction("session-state", "/r", { operation: "config-load", dir: 5 })).rejects.toThrow(
+			/"dir"/,
+		);
+	});
+
+	it("stringArrayField rejects a non-array value", async () => {
+		await expect(
+			runIdeBridgeAction("summary-store", "/r", { operation: "scan-aliases", hashes: "no" }),
+		).rejects.toThrow(/"hashes"/);
+	});
+
+	it("stringArrayField rejects an array with non-string values", async () => {
+		await expect(
+			runIdeBridgeAction("summary-store", "/r", { operation: "scan-aliases", hashes: [1, 2] }),
+		).rejects.toThrow(/"hashes"/);
+	});
+});
+
+// ---------- 4. executeIdeBridgeCommand ----------
+
+describe("executeIdeBridgeCommand", () => {
+	it("prints a JSON-RPC result envelope for a successful action", async () => {
+		const cli = await import("./CliUtils.js");
+		vi.mocked(cli.readStdin).mockResolvedValue(JSON.stringify({ operation: "base-key", slug: "s" }));
+		const cap = captureConsole();
+		await executeIdeBridgeCommand("plan-grouping", "/r");
+		expect(cap.consoleLog[0]).toContain('"result"');
+		expect(cap.consoleLog[0]).toContain('"key":"plan:s"');
+		expect(process.exitCode).not.toBe(1);
+	});
+
+	it("prints a JSON-RPC error envelope and sets exit code 1 on failure", async () => {
+		const cli = await import("./CliUtils.js");
+		vi.mocked(cli.readStdin).mockResolvedValue("{}");
+		const cap = captureConsole();
+		await executeIdeBridgeCommand("no-such-action", "/r");
+		expect(cap.consoleLog[0]).toContain('"error"');
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("treats an empty stdin body as an empty request object", async () => {
+		const cli = await import("./CliUtils.js");
+		vi.mocked(cli.readStdin).mockResolvedValue("");
+		const cap = captureConsole();
+		await executeIdeBridgeCommand("plan-grouping", "/r");
+		// plan-grouping's own error surfaces (operation required)
+		expect(cap.consoleLog[0]).toContain('"error"');
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("rejects a non-object JSON body", async () => {
+		const cli = await import("./CliUtils.js");
+		vi.mocked(cli.readStdin).mockResolvedValue("[1,2,3]");
+		const cap = captureConsole();
+		await executeIdeBridgeCommand("plan-grouping", "/r");
+		expect(cap.consoleLog[0]).toContain("Bridge request must be a JSON object");
+	});
+
+	it("stringifies a non-Error thrown value using String()", async () => {
+		const cli = await import("./CliUtils.js");
+		vi.mocked(cli.readStdin).mockRejectedValue("stdin-fail" as never);
+		const cap = captureConsole();
+		await executeIdeBridgeCommand("plan-grouping", "/r");
+		expect(cap.consoleLog[0]).toContain("stdin-fail");
+	});
+
+	it("copies primitive extras from a thrown Error into error.data", async () => {
+		// AmbiguousHashError-like: name + primitive extras copied over.
+		class MyErr extends Error {
+			readonly code = "E_TEST";
+			readonly retry = 3;
+			readonly ok = false;
+			readonly nested = { x: 1 };
+			constructor() {
+				super("boom");
+				this.name = "MyErr";
+			}
+		}
+		const cli = await import("./CliUtils.js");
+		vi.mocked(cli.readStdin).mockResolvedValue("{}");
+		const { getStatus } = await import("../install/Installer.js");
+		vi.mocked(getStatus).mockRejectedValue(new MyErr());
+		const cap = captureConsole();
+		await executeIdeBridgeCommand("status", "/r");
+		const envelope = JSON.parse(cap.consoleLog[0]);
+		expect(envelope.error.data.errorName).toBe("MyErr");
+		expect(envelope.error.data.code).toBe("E_TEST");
+		expect(envelope.error.data.retry).toBe(3);
+		expect(envelope.error.data.ok).toBe(false);
+		// non-primitive fields are skipped
+		expect(envelope.error.data.nested).toBeUndefined();
+	});
+
+	it("redacts fields whose name or value looks like a credential", async () => {
+		class LeakyErr extends Error {
+			readonly apiKey = "sk-jol-should-not-leak";
+			readonly jolliApiKey = "sk-jol-also-should-not-leak";
+			readonly authToken = "abc";
+			readonly bearerToken = "xyz";
+			readonly password = "hunter2";
+			readonly secret = "shh";
+			readonly credential = "c";
+			readonly api_key = "under-score-variant";
+			// Innocent-looking field that happens to hold a Jolli API key.
+			readonly note = "sk-jol-still-a-key";
+			// A JWT-shape string stashed under a neutral name.
+			readonly detail = "eyJhbGciOiJI.eyJzdWIi.signaturepart";
+			readonly safeCode = "OK_TO_SHOW";
+			constructor() {
+				super("boom");
+				this.name = "LeakyErr";
+			}
+		}
+		const cli = await import("./CliUtils.js");
+		vi.mocked(cli.readStdin).mockResolvedValue("{}");
+		const { getStatus } = await import("../install/Installer.js");
+		vi.mocked(getStatus).mockRejectedValue(new LeakyErr());
+		const cap = captureConsole();
+		await executeIdeBridgeCommand("status", "/r");
+		const raw = cap.consoleLog[0];
+		expect(raw).not.toContain("sk-jol-");
+		expect(raw).not.toContain("hunter2");
+		const envelope = JSON.parse(raw);
+		expect(envelope.error.data.errorName).toBe("LeakyErr");
+		expect(envelope.error.data.safeCode).toBe("OK_TO_SHOW");
+		// Every sensitive field is dropped, not stringified as [REDACTED].
+		expect(envelope.error.data.apiKey).toBeUndefined();
+		expect(envelope.error.data.jolliApiKey).toBeUndefined();
+		expect(envelope.error.data.authToken).toBeUndefined();
+		expect(envelope.error.data.bearerToken).toBeUndefined();
+		expect(envelope.error.data.password).toBeUndefined();
+		expect(envelope.error.data.secret).toBeUndefined();
+		expect(envelope.error.data.credential).toBeUndefined();
+		expect(envelope.error.data.api_key).toBeUndefined();
+		// Neutral name, sensitive-looking value → still dropped.
+		expect(envelope.error.data.note).toBeUndefined();
+		expect(envelope.error.data.detail).toBeUndefined();
+	});
+});
+
+// ---------- 5. runIdeBridgeServe (long-lived server) ----------
+
+/** Fake stdin that behaves like `process.stdin` enough to satisfy readline. */
+function makeFakeStdin(): NodeJS.ReadableStream {
+	const stream = new PassThrough();
+	return stream;
+}
+
+describe("runIdeBridgeServe", () => {
+	it("writes a handshake, dispatches one request line, and exits on stdin EOF", async () => {
+		const stdin = makeFakeStdin();
+		const originalStdin = process.stdin;
+		Object.defineProperty(process, "stdin", { value: stdin, configurable: true });
+		const cap = captureConsole();
+
+		const done = runIdeBridgeServe("/repo");
+		// Give readline a tick to arm.
+		await new Promise((r) => setTimeout(r, 5));
+
+		// One valid request line, then EOF.
+		(stdin as PassThrough).write(
+			`${JSON.stringify({
+				jsonrpc: "2.0",
+				id: 1,
+				method: "plan-grouping",
+				params: { cwd: "/repo", request: { operation: "base-key", slug: "s" } },
+			})}\n`,
+		);
+		(stdin as PassThrough).end();
+
+		await done;
+
+		// Restore before assertions to avoid leaking a fake stdin into other tests.
+		Object.defineProperty(process, "stdin", { value: originalStdin, configurable: true });
+
+		const lines = cap.stdout
+			.join("")
+			.split("\n")
+			.filter((l) => l.length > 0);
+		// First line is the handshake (method:"ready"), then a response.
+		expect(JSON.parse(lines[0]).method).toBe("ready");
+		expect(JSON.parse(lines[1])).toMatchObject({ id: 1, result: { key: "plan:s" } });
+	});
+
+	it("ignores blank input lines", async () => {
+		const stdin = makeFakeStdin();
+		const originalStdin = process.stdin;
+		Object.defineProperty(process, "stdin", { value: stdin, configurable: true });
+		captureConsole();
+
+		const done = runIdeBridgeServe("/repo");
+		await new Promise((r) => setTimeout(r, 5));
+
+		(stdin as PassThrough).write("\n   \n\n");
+		(stdin as PassThrough).end();
+
+		await done;
+		Object.defineProperty(process, "stdin", { value: originalStdin, configurable: true });
+	});
+
+	it("emits an error envelope for a malformed request line and keeps running", async () => {
+		const stdin = makeFakeStdin();
+		const originalStdin = process.stdin;
+		Object.defineProperty(process, "stdin", { value: stdin, configurable: true });
+		const cap = captureConsole();
+
+		const done = runIdeBridgeServe("/repo");
+		await new Promise((r) => setTimeout(r, 5));
+
+		(stdin as PassThrough).write("not-json\n");
+		(stdin as PassThrough).end();
+
+		await done;
+		Object.defineProperty(process, "stdin", { value: originalStdin, configurable: true });
+
+		const lines = cap.stdout
+			.join("")
+			.split("\n")
+			.filter((l) => l.length > 0);
+		// Handshake + one error envelope.
+		expect(lines.length).toBeGreaterThanOrEqual(2);
+		const err = JSON.parse(lines[1]);
+		expect(err.error).toBeDefined();
+	});
+
+	it("arms watchers via computeWatchTargets and emits refresh notifications when they fire", async () => {
+		const stdin = makeFakeStdin();
+		const originalStdin = process.stdin;
+		Object.defineProperty(process, "stdin", { value: stdin, configurable: true });
+		const cap = captureConsole();
+
+		const done = runIdeBridgeServe("/repo");
+		await new Promise((r) => setTimeout(r, 5));
+
+		// Fire the onTrigger on the queue watcher.
+		const queue = daemonWatcherInstances.find((w) => w.opts.path === "/repo/queue");
+		queue?.opts.onTrigger();
+
+		(stdin as PassThrough).end();
+		await done;
+		Object.defineProperty(process, "stdin", { value: originalStdin, configurable: true });
+
+		const refresh = cap.stdout
+			.join("")
+			.split("\n")
+			.filter((l) => l.length > 0)
+			.map((l) => JSON.parse(l))
+			.find((obj) => obj.method === "refresh");
+		expect(refresh).toBeDefined();
+		expect(refresh.params.kind).toBe("queue");
+	});
+
+	it("arms a setInterval retry when a watcher's initial start() fails, and the retry callback clears itself on success", async () => {
+		// Real timers are kept — fake timers would break readline's internal
+		// tick machinery and hang the for-await loop below. Instead the retry
+		// callback is grabbed off the setInterval spy and invoked directly so
+		// its two branches (start=false → keep polling; start=true → clear +
+		// splice) are both exercised.
+		const setIntervalSpy = vi.spyOn(global, "setInterval");
+		const clearIntervalSpy = vi.spyOn(global, "clearInterval");
+
+		const { DaemonWatcher } = await import("../daemon/DaemonWatcher.js");
+		// First construction: start() returns false first, then true (used when
+		// the retry callback re-invokes it). Second construction (orphan-ref)
+		// uses the default mock which returns true, so only ONE retry is armed.
+		const startResults = [false, false, true];
+		vi.mocked(DaemonWatcher).mockImplementationOnce(function DaemonWatcherRetryMock(this: unknown, opts) {
+			const start = vi.fn().mockImplementation(() => startResults.shift() ?? true);
+			const stop = vi.fn();
+			const instance = { opts, start, stop };
+			daemonWatcherInstances.push(instance);
+			Object.assign(this as object, instance);
+		});
+
+		const stdin = makeFakeStdin();
+		const originalStdin = process.stdin;
+		Object.defineProperty(process, "stdin", { value: stdin, configurable: true });
+		captureConsole();
+
+		const done = runIdeBridgeServe("/repo");
+		await new Promise((r) => setTimeout(r, 5));
+
+		// The 5000ms retry interval is armed exactly once.
+		const retryArm = setIntervalSpy.mock.calls.find(([, delay]) => delay === 5000);
+		expect(retryArm).toBeDefined();
+
+		// Invoke the retry callback twice: first with start=false (branch that
+		// keeps polling), then with start=true (branch that clears the retry).
+		const callback = retryArm?.[0] as () => void;
+		callback(); // start() returns false here — no clearInterval
+		callback(); // start() returns true — clearInterval fires
+		expect(clearIntervalSpy).toHaveBeenCalled();
+
+		(stdin as PassThrough).end();
+		await done;
+
+		Object.defineProperty(process, "stdin", { value: originalStdin, configurable: true });
+	});
+});
+
+// ---------- 6. process-level guards (uncaughtException / unhandledRejection) ----------
+
+describe("runIdeBridgeServe — process-level guards", () => {
+	it("registers uncaughtException and unhandledRejection handlers", async () => {
+		// spyOn without mockReturnValue would still register the real listener
+		// and leak it across tests. Turn it into a no-op so only the spy sees
+		// the call.
+		const spy = vi.spyOn(process, "on").mockReturnValue(process);
+		const stdin = makeFakeStdin();
+		const originalStdin = process.stdin;
+		Object.defineProperty(process, "stdin", { value: stdin, configurable: true });
+		captureConsole();
+
+		const done = runIdeBridgeServe("/repo");
+		await new Promise((r) => setTimeout(r, 5));
+		(stdin as PassThrough).end();
+		await done;
+		Object.defineProperty(process, "stdin", { value: originalStdin, configurable: true });
+
+		const events = spy.mock.calls.map((c) => c[0]);
+		expect(events).toContain("uncaughtException");
+		expect(events).toContain("unhandledRejection");
+	});
+});

--- a/cli/src/commands/IdeBridgeCommand.ts
+++ b/cli/src/commands/IdeBridgeCommand.ts
@@ -1,0 +1,1359 @@
+/**
+ * Hidden JSON bridge used by IDE hosts that cannot import the TypeScript core.
+ *
+ * VS Code imports `cli/src/**` in-process. IntelliJ runs on the JVM, so it sends
+ * one JSON request to `jolli ide-bridge <action>` and reads one JSON response.
+ * Keeping every action here makes the CLI implementation the single source of
+ * truth while the IntelliJ side remains a process/DTO adapter.
+ */
+
+import type { LiveSharePatch, LiveSharePayload } from "../core/JolliShareClient.js";
+import { computeWatchTargets } from "../daemon/DaemonServer.js";
+import { DaemonWatcher } from "../daemon/DaemonWatcher.js";
+import { setLogDir } from "../Logger.js";
+import type { ConflictUi, Tier3Pick } from "../sync/ConflictResolver.js";
+import type { FileWrite, JolliMemoryConfig, TranscriptSource } from "../Types.js";
+import { readStdin } from "./CliUtils.js";
+
+type JsonObject = Record<string, unknown>;
+
+const TRANSCRIPT_SOURCES = new Set<TranscriptSource>([
+	"claude",
+	"codex",
+	"gemini",
+	"opencode",
+	"cursor",
+	"copilot",
+	"copilot-chat",
+]);
+
+function parseRequest(raw: string): JsonObject {
+	if (raw.trim().length === 0) return {};
+	const parsed: unknown = JSON.parse(raw);
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		throw new Error("Bridge request must be a JSON object.");
+	}
+	return parsed as JsonObject;
+}
+
+// Custom errors carry structured detail (AmbiguousHashError.prefix,
+// SyncBackendError.status, ...) that IDE hosts render as part of the failure
+// message. The one-shot and long-lived error envelopes both forward primitive
+// extras so the two shapes stay identical, but the copier MUST NOT leak a
+// credential a caller has stashed on the Error — nothing on the CLI side stops
+// a future author from writing `err.jolliApiKey = cfg.jolliApiKey` for context.
+// Two barriers below, either drops the field:
+//   1. key name matches a common secret naming pattern
+//      (api-key / token / secret / password / credential / authorization),
+//   2. string value looks like a Jolli API key or a JWT.
+// Non-string primitives are safe from #2 but still pass #1.
+const SENSITIVE_ERROR_KEY_PATTERN = /api[-_]?key|token|secret|password|passwd|credential|authorization|bearer/i;
+const SENSITIVE_ERROR_VALUE_PATTERN = /^(?:sk-jol-|eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+$)/;
+
+function copyPrimitiveErrorFields(error: unknown, data: Record<string, unknown>): void {
+	if (typeof error !== "object" || error === null) return;
+	for (const [key, value] of Object.entries(error)) {
+		if (key === "name" || key === "message" || key === "stack") continue;
+		if (SENSITIVE_ERROR_KEY_PATTERN.test(key)) continue;
+		if (typeof value === "string") {
+			if (SENSITIVE_ERROR_VALUE_PATTERN.test(value)) continue;
+			data[key] = value;
+		} else if (typeof value === "number" || typeof value === "boolean") {
+			data[key] = value;
+		}
+	}
+}
+
+function stringField(request: JsonObject, key: string): string {
+	const value = request[key];
+	if (typeof value !== "string") throw new Error(`Request field "${key}" must be a string.`);
+	return value;
+}
+
+function optionalString(request: JsonObject, key: string): string | undefined {
+	const value = request[key];
+	if (value === undefined || value === null) return undefined;
+	if (typeof value !== "string") throw new Error(`Request field "${key}" must be a string.`);
+	return value;
+}
+
+function stringArrayField(request: JsonObject, key: string): string[] {
+	const value = request[key];
+	if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+		throw new Error(`Request field "${key}" must be an array of strings.`);
+	}
+	return value;
+}
+
+function numberField(request: JsonObject, key: string): number {
+	const value = request[key];
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		throw new Error(`Request field "${key}" must be a finite number.`);
+	}
+	return value;
+}
+
+function optionalNumberField(request: JsonObject, key: string, fallback: number): number {
+	const value = request[key];
+	if (value === undefined || value === null) return fallback;
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		throw new Error(`Request field "${key}" must be a finite number.`);
+	}
+	return value;
+}
+
+export interface IdeBridgeConflictDetail {
+	readonly path: string;
+	readonly ours: string | null;
+	readonly theirs: string | null;
+}
+
+/** Conflict UI that records prompt data for the IDE and replays IDE-selected choices on the next bridge call. */
+export class IdeBridgeConflictUi implements ConflictUi {
+	readonly details: IdeBridgeConflictDetail[] = [];
+	private readonly seen = new Set<string>();
+
+	constructor(private readonly choices: Readonly<Record<string, "mine" | "theirs">>) {}
+
+	async promptBinaryPick(path: string, ours: string | null, theirs: string | null): Promise<Tier3Pick> {
+		const choice = this.choices[path];
+		if (choice === "mine" || choice === "theirs") return choice;
+		if (!this.seen.has(path)) {
+			this.seen.add(path);
+			this.details.push({ path, ours, theirs });
+		}
+		return "skip";
+	}
+}
+
+function conflictChoices(request: JsonObject): Record<string, "mine" | "theirs"> {
+	const raw = request.conflictChoices;
+	if (raw === undefined || raw === null) return {};
+	if (typeof raw !== "object" || Array.isArray(raw)) {
+		throw new Error('Request field "conflictChoices" must be an object.');
+	}
+	const choices: Record<string, "mine" | "theirs"> = {};
+	for (const [path, value] of Object.entries(raw)) {
+		if (value !== "mine" && value !== "theirs") {
+			throw new Error(`Conflict choice for "${path}" must be "mine" or "theirs".`);
+		}
+		choices[path] = value;
+	}
+	return choices;
+}
+
+async function runStorageAction(cwd: string, request: JsonObject): Promise<unknown> {
+	const { createStorage } = await import("../core/StorageFactory.js");
+	const storage = await createStorage(cwd, cwd);
+	const operation = stringField(request, "operation");
+	switch (operation) {
+		case "read":
+			return { content: await storage.readFile(stringField(request, "path")) };
+		case "list":
+			return { paths: await storage.listFiles(stringField(request, "prefix")) };
+		case "exists":
+			return { exists: await storage.exists() };
+		case "ensure":
+			await storage.ensure();
+			return { ok: true };
+		case "write": {
+			const files = request.files;
+			if (!Array.isArray(files)) throw new Error('Request field "files" must be an array.');
+			await storage.writeFiles(files as FileWrite[], stringField(request, "message"));
+			return { ok: true };
+		}
+		default:
+			throw new Error(`Unknown storage operation "${operation}".`);
+	}
+}
+
+async function runConversationOverlayAction(cwd: string, request: JsonObject): Promise<unknown> {
+	const source = stringField(request, "source") as TranscriptSource;
+	if (!TRANSCRIPT_SOURCES.has(source)) throw new Error(`Unknown transcript source "${source}".`);
+	const sessionId = stringField(request, "sessionId");
+	const operation = stringField(request, "operation");
+	if (operation === "hide") {
+		const { hideConversation } = await import("../core/HiddenConversationsStore.js");
+		await hideConversation(cwd, source, sessionId);
+		return { ok: true };
+	}
+	const overlayStore = await import("../core/ConversationOverlayStore.js");
+	const key = { projectDir: cwd, source, sessionId };
+	if (operation === "view") {
+		if (!Array.isArray(request.entries)) throw new Error('Request field "entries" must be an array.');
+		const entries = request.entries as Parameters<typeof overlayStore.applyOverlay>[0];
+		const overlay = await overlayStore.loadOverlay(key);
+		return {
+			overlay,
+			displayed: overlayStore.applyOverlay(entries, overlay),
+			rawWithDeletesOnly: overlayStore.applyDeletes(entries, overlay),
+		};
+	}
+	if (operation === "merge-save") {
+		if (!Array.isArray(request.deletes) || !Array.isArray(request.edits)) {
+			throw new Error('Request fields "deletes" and "edits" must be arrays.');
+		}
+		const existing = await overlayStore.loadOverlay(key);
+		const merged = overlayStore.mergeOverlay(existing, {
+			deletes: request.deletes as Parameters<typeof overlayStore.mergeOverlay>[1]["deletes"],
+			edits: request.edits as Parameters<typeof overlayStore.mergeOverlay>[1]["edits"],
+		});
+		return overlayStore.saveOverlay(key, merged);
+	}
+	throw new Error(`Unknown conversation-overlay operation "${operation}".`);
+}
+
+async function runSessionStateAction(cwd: string, request: JsonObject): Promise<unknown> {
+	const operation = stringField(request, "operation");
+	const tracker = await import("../core/SessionTracker.js");
+	switch (operation) {
+		case "global-config-dir":
+			return { path: tracker.getGlobalConfigDir() };
+		case "notes-dir": {
+			const { join } = await import("node:path");
+			const { getJolliMemoryDir } = await import("../Logger.js");
+			return { path: join(getJolliMemoryDir(cwd), "notes") };
+		}
+		case "config-load": {
+			const dir = optionalString(request, "dir");
+			return dir ? tracker.loadConfigFromDir(dir) : tracker.loadConfig();
+		}
+		case "config-save": {
+			const config = request.config as Partial<JolliMemoryConfig> | undefined;
+			if (!config || typeof config !== "object") throw new Error('Request field "config" must be an object.');
+			const dir = optionalString(request, "dir") ?? tracker.getGlobalConfigDir();
+			await tracker.saveConfigScoped(config, dir);
+			return { ok: true };
+		}
+		case "plans-load":
+			return tracker.loadPlansRegistry(cwd);
+		case "plans-save":
+			await tracker.savePlansRegistry(request.registry as Parameters<typeof tracker.savePlansRegistry>[0], cwd);
+			return { ok: true };
+		case "worker-busy": {
+			const { getWorkerBusyState } = await import("../core/Locks.js");
+			return getWorkerBusyState(cwd);
+		}
+		case "save-plugin-source":
+			await tracker.savePluginSource(cwd);
+			return { ok: true };
+		case "save-squash-pending":
+			await tracker.saveSquashPending(
+				stringArrayField(request, "sourceHashes"),
+				stringField(request, "expectedParentHash"),
+				cwd,
+			);
+			return { ok: true };
+		default:
+			throw new Error(`Unknown session-state operation "${operation}".`);
+	}
+}
+
+async function runAuthAction(request: JsonObject): Promise<unknown> {
+	const operation = stringField(request, "operation");
+	const auth = await import("../auth/AuthConfig.js");
+	switch (operation) {
+		case "site-url":
+			return { url: auth.getJolliUrl() };
+		case "is-signed-in":
+			return { signedIn: Boolean(await auth.loadAuthToken()) };
+		case "parse-api-key": {
+			const { parseJolliApiKey } = await import("../core/JolliApiUtils.js");
+			return { meta: parseJolliApiKey(stringField(request, "apiKey")) };
+		}
+		case "validate-api-key": {
+			const { validateJolliApiKey } = await import("../core/JolliApiUtils.js");
+			validateJolliApiKey(stringField(request, "apiKey"));
+			return { ok: true };
+		}
+		case "assert-origin": {
+			const { assertJolliOriginAllowed } = await import("../core/JolliApiUtils.js");
+			assertJolliOriginAllowed(stringField(request, "origin"));
+			return { ok: true };
+		}
+		case "should-request-fresh":
+			return {
+				fresh: auth.shouldRequestFreshApiKey(
+					optionalString(request, "existingKey"),
+					stringField(request, "jolliUrl"),
+				),
+			};
+		case "build-login-url": {
+			const url = new URL("/login", stringField(request, "jolliUrl"));
+			url.searchParams.set("cli_callback", stringField(request, "callbackUrl"));
+			url.searchParams.set("client", "intellij");
+			url.searchParams.set("client_version", stringField(request, "clientVersion"));
+			if (request.generateApiKey === true) url.searchParams.set("generate_api_key", "true");
+			const installId = optionalString(request, "installId");
+			if (installId) url.searchParams.set("install_id", installId);
+			return { url: url.toString() };
+		}
+		case "exchange-and-save": {
+			const jolliUrl = stringField(request, "jolliUrl");
+			const { exchangeCliCode } = await import("../auth/CliExchange.js");
+			const exchanged = await exchangeCliCode(jolliUrl, stringField(request, "code"));
+			await auth.saveAuthCredentials({
+				token: exchanged.token,
+				jolliUrl: auth.resolveSignInJolliUrl(exchanged.jolliApiKey, jolliUrl),
+				...(exchanged.jolliApiKey ? { jolliApiKey: exchanged.jolliApiKey } : {}),
+			});
+			return exchanged;
+		}
+		case "save-legacy-credentials": {
+			const jolliUrl = stringField(request, "jolliUrl");
+			const apiKey = optionalString(request, "jolliApiKey");
+			await auth.saveAuthCredentials({
+				token: stringField(request, "token"),
+				jolliUrl: auth.resolveSignInJolliUrl(apiKey, jolliUrl),
+				...(apiKey ? { jolliApiKey: apiKey } : {}),
+			});
+			return { ok: true };
+		}
+		case "sign-out":
+			await auth.clearAuthCredentials();
+			return { ok: true };
+		default:
+			throw new Error(`Unknown auth operation "${operation}".`);
+	}
+}
+
+async function runJolliApiAction(_cwd: string, request: JsonObject): Promise<unknown> {
+	const operation = stringField(request, "operation");
+	if (operation === "serialize-summary") {
+		const { serializeSummaryJson } = await import("../core/JolliMemoryPushOrchestrator.js");
+		return { json: serializeSummaryJson(request.summary as Parameters<typeof serializeSummaryJson>[0]) ?? null };
+	}
+	const apiKey = stringField(request, "apiKey");
+	const baseUrl = optionalString(request, "baseUrl");
+	const { JolliMemoryPushClient } = await import("../core/JolliMemoryPushClient.js");
+	const client = new JolliMemoryPushClient({ baseUrlOverride: baseUrl, apiKeyProvider: async () => apiKey });
+	switch (operation) {
+		case "push":
+			return client.push(request.payload as Parameters<typeof client.push>[0]);
+		case "delete":
+			await client.deleteDoc(numberField(request, "docId"));
+			return { ok: true };
+		case "list-spaces":
+			return client.listSpaces();
+		case "create-binding":
+			return client.createBinding({
+				repoUrl: stringField(request, "repoUrl"),
+				repoName: stringField(request, "repoName"),
+				jmSpaceId: numberField(request, "jmSpaceId"),
+			});
+		case "create-share": {
+			const { JolliShareClient } = await import("../core/JolliShareClient.js");
+			return new JolliShareClient(apiKey, baseUrl).create(request.payload as LiveSharePayload);
+		}
+		case "update-share": {
+			const { JolliShareClient } = await import("../core/JolliShareClient.js");
+			return new JolliShareClient(apiKey, baseUrl).update(
+				stringField(request, "shareId"),
+				request.patch as LiveSharePatch,
+			);
+		}
+		case "revoke-share": {
+			const { JolliShareClient } = await import("../core/JolliShareClient.js");
+			await new JolliShareClient(apiKey, baseUrl).revoke(stringField(request, "shareId"));
+			return { ok: true };
+		}
+		case "invite-share": {
+			const { JolliShareClient } = await import("../core/JolliShareClient.js");
+			return new JolliShareClient(apiKey, baseUrl).invite(
+				stringField(request, "shareId"),
+				stringArrayField(request, "recipients"),
+				optionalString(request, "message"),
+			);
+		}
+		case "list-org-members": {
+			const { JolliShareClient } = await import("../core/JolliShareClient.js");
+			return { members: await new JolliShareClient(apiKey, baseUrl).listOrgMembers() };
+		}
+		default:
+			throw new Error(`Unknown Jolli API operation "${operation}".`);
+	}
+}
+
+async function currentPinGroup(cwd: string): Promise<{ repoName: string; branch: string }> {
+	const [{ getCanonicalRepoUrl, deriveRepoNameFromUrl }, { getCurrentBranch, getProjectRootDir }, path] =
+		await Promise.all([import("../core/GitRemoteUtils.js"), import("../core/GitOps.js"), import("node:path")]);
+	const repoUrl = await getCanonicalRepoUrl(cwd);
+	const root = await getProjectRootDir(cwd).catch(() => cwd);
+	return {
+		repoName: repoUrl ? deriveRepoNameFromUrl(repoUrl) : path.basename(root),
+		branch: await getCurrentBranch(cwd),
+	};
+}
+
+function pinKind(kind: string): "conversation" | "plan" | "note" | "memory" | "reference" {
+	const normalized =
+		(
+			{
+				conversations: "conversation",
+				plans: "plan",
+				notes: "note",
+				memories: "memory",
+				references: "reference",
+			} as const
+		)[kind as "conversations" | "plans" | "notes" | "memories" | "references"] ?? kind;
+	if (["conversation", "plan", "note", "memory", "reference"].includes(normalized)) {
+		return normalized as "conversation" | "plan" | "note" | "memory" | "reference";
+	}
+	throw new Error(`Unknown pin kind "${kind}".`);
+}
+
+async function runSharedStoreAction(cwd: string, request: JsonObject): Promise<unknown> {
+	const operation = stringField(request, "operation");
+	if (operation.startsWith("pins-")) {
+		const pins = await import("../core/PinStore.js");
+		const group = await currentPinGroup(cwd);
+		if (operation === "pins-read") return { pins: await pins.listPins(cwd, group.repoName, group.branch) };
+		const kind = pinKind(stringField(request, "kind"));
+		const id = stringField(request, "key");
+		if (operation === "pins-add") {
+			const badge = optionalString(request, "badge");
+			// Prefer an explicit "source" from the caller; fall back to the badge for
+			// conversation pins so IntelliJ hosts that only pass a source-derived
+			// badge keep populating PinEntry.source without extra plumbing.
+			const source = optionalString(request, "source") ?? (kind === "conversation" ? badge : undefined);
+			const transcriptPath = optionalString(request, "transcriptPath");
+			await pins.addPin(cwd, group.repoName, group.branch, {
+				kind,
+				id,
+				title: stringField(request, "title"),
+				pinnedAt: Date.now(),
+				...(badge !== undefined ? { badge } : {}),
+				...(source !== undefined ? { source } : {}),
+				...(transcriptPath !== undefined ? { transcriptPath } : {}),
+			});
+			return { ok: true };
+		}
+		if (operation === "pins-remove") {
+			await pins.removePin(cwd, group.repoName, group.branch, kind, id);
+			return { ok: true };
+		}
+	}
+	if (operation.startsWith("selection-")) {
+		const selection = await import("../core/CommitSelectionStore.js");
+		if (operation === "selection-read") {
+			const value = await selection.readExclusions(cwd);
+			return {
+				conversations: [...value.conversations],
+				plans: [...value.plans],
+				notes: [...value.notes],
+				references: [...value.references],
+			};
+		}
+		if (operation === "selection-key") {
+			return {
+				key: selection.conversationKey(
+					stringField(request, "source") as TranscriptSource,
+					stringField(request, "sessionId"),
+				),
+			};
+		}
+		const kind = stringField(request, "kind") as Parameters<typeof selection.setExcluded>[1];
+		if (operation === "selection-set") {
+			await selection.setExcluded(cwd, kind, stringField(request, "key"), request.excluded === true);
+			return { ok: true };
+		}
+		if (operation === "selection-set-all") {
+			await selection.setAllExcluded(cwd, kind, stringArrayField(request, "keys"), request.excluded === true);
+			return { ok: true };
+		}
+	}
+	if (operation.startsWith("branch-share-")) {
+		const shares = await import("../core/BranchShareStore.js");
+		const branch = stringField(request, "branch");
+		const commitHash = optionalString(request, "commitHash");
+		if (operation === "branch-share-put") {
+			await shares.putBranchShare(
+				cwd,
+				branch,
+				request.record as Parameters<typeof shares.putBranchShare>[2],
+				commitHash,
+			);
+			return { ok: true };
+		}
+		if (operation === "branch-share-remove") {
+			await shares.removeShare(cwd, branch, commitHash);
+			return { ok: true };
+		}
+		if (operation === "branch-share-get") {
+			const [{ loadConfig }, { deriveJolliBackendKey, parseJolliApiKey }] = await Promise.all([
+				import("../core/SessionTracker.js"),
+				import("../core/JolliApiUtils.js"),
+			]);
+			const key = (await loadConfig()).jolliApiKey;
+			const backendKey = deriveJolliBackendKey(key ? parseJolliApiKey(key)?.u : undefined);
+			return { record: (await shares.getShare(cwd, branch, backendKey, commitHash)) ?? null };
+		}
+	}
+	if (operation === "push-pending-hashes") {
+		const { loadPushPending } = await import("../core/PushPendingStore.js");
+		return { hashes: Object.keys((await loadPushPending(cwd)).entries) };
+	}
+	if (operation === "repo-profile-read") {
+		const { readRepoProfile } = await import("../core/RepoProfile.js");
+		return { profile: await readRepoProfile(cwd) };
+	}
+	if (operation === "repo-profile-set-backfill-dismissed") {
+		if (typeof request.dismissed !== "boolean") {
+			throw new Error('Request field "dismissed" must be a boolean.');
+		}
+		const { updateRepoProfile } = await import("../core/RepoProfile.js");
+		await updateRepoProfile(cwd, { backfillDismissed: request.dismissed });
+		return { ok: true };
+	}
+	if (operation === "summary-markdown") {
+		const { buildMarkdown } = await import("../core/SummaryMarkdownBuilder.js");
+		return { markdown: buildMarkdown(request.summary as Parameters<typeof buildMarkdown>[0]) };
+	}
+	if (operation === "summary-pr-markdown") {
+		const { buildPrMarkdown } = await import("../core/SummaryPrMarkdownBuilder.js");
+		return { markdown: buildPrMarkdown(request.summary as Parameters<typeof buildPrMarkdown>[0]) };
+	}
+	if (operation === "pr-wrap-markdown") {
+		const { wrapWithMarkers } = await import("../core/PrDescription.js");
+		return { markdown: wrapWithMarkers(stringField(request, "markdown")) };
+	}
+	if (operation === "pr-replace-markdown") {
+		const { replaceSummaryInBody } = await import("../core/PrDescription.js");
+		return {
+			body: replaceSummaryInBody(stringField(request, "currentBody"), stringField(request, "markdown")),
+		};
+	}
+	if (operation === "reference-push-presentation") {
+		if (typeof request.reference !== "object" || request.reference === null || Array.isArray(request.reference)) {
+			throw new Error('Request field "reference" must be an object.');
+		}
+		const [{ buildReferencePushTitle }, { buildReferencePushMarkdown }, references] = await Promise.all([
+			import("../core/SummaryFormat.js"),
+			import("../core/SummaryMarkdownBuilder.js"),
+			import("../core/references/ReferenceStore.js"),
+		]);
+		const reference = request.reference as Parameters<typeof buildReferencePushMarkdown>[0];
+		const storedMarkdown = optionalString(request, "storedMarkdown");
+		const description = storedMarkdown
+			? (references.readReferenceMarkdownFromString(storedMarkdown)?.description ?? undefined)
+			: undefined;
+		return {
+			title: buildReferencePushTitle(reference),
+			markdown: buildReferencePushMarkdown(reference, description),
+		};
+	}
+	throw new Error(`Unknown shared-store operation "${operation}".`);
+}
+
+async function runSummaryStoreAction(cwd: string, request: JsonObject): Promise<unknown> {
+	const operation = stringField(request, "operation");
+	const [summaries, { createStorage }] = await Promise.all([
+		import("../core/SummaryStore.js"),
+		import("../core/StorageFactory.js"),
+	]);
+	const storage = await createStorage(cwd, cwd);
+	switch (operation) {
+		case "index":
+			return summaries.getIndex(cwd, storage);
+		case "get":
+			return summaries.getSummary(stringField(request, "commitHash"), cwd, storage);
+		case "list":
+			return summaries.listSummaries(optionalNumberField(request, "count", 10), cwd, storage);
+		case "count":
+			return { count: await summaries.getSummaryCount(cwd, storage) };
+		case "find-root": {
+			const index = await summaries.getIndex(cwd, storage);
+			if (!index) return { hash: null };
+			const requested = stringField(request, "commitHash");
+			const resolved = index.commitAliases?.[requested] ?? requested;
+			const entries = new Map(index.entries.map((entry) => [entry.commitHash, entry]));
+			let current = entries.get(resolved);
+			if (!current) return { hash: null };
+			while (current.parentCommitHash !== null && current.parentCommitHash !== undefined) {
+				const parent = entries.get(current.parentCommitHash);
+				if (!parent) break;
+				current = parent;
+			}
+			return { hash: current.commitHash };
+		}
+		case "filter-hashes": {
+			const index = await summaries.getIndex(cwd, storage);
+			const available = new Set(index?.entries.map((entry) => entry.commitHash) ?? []);
+			for (const alias of Object.keys(index?.commitAliases ?? {})) available.add(alias);
+			return { hashes: stringArrayField(request, "hashes").filter((hash) => available.has(hash)) };
+		}
+		case "scan-aliases":
+			return {
+				changed: await summaries.scanTreeHashAliases(
+					stringArrayField(request, "hashes"),
+					cwd,
+					storage,
+					storage,
+				),
+			};
+		case "resolve-alias": {
+			const hash = stringField(request, "commitHash");
+			const index = await summaries.getIndex(cwd, storage);
+			return { hash: index?.commitAliases?.[hash] ?? hash };
+		}
+		case "store-summary": {
+			const summary = request.summary as Parameters<typeof summaries.storeSummary>[0];
+			if (!summary || typeof summary !== "object") throw new Error('Request field "summary" must be an object.');
+			const transcript = request.transcript;
+			const planProgress = request.planProgress;
+			const referenceFiles = request.referenceFiles;
+			await summaries.storeSummary(
+				summary,
+				cwd,
+				request.force === true,
+				{
+					...(transcript && typeof transcript === "object"
+						? {
+								transcript: {
+									id: summary.commitHash,
+									data: transcript as Parameters<
+										typeof summaries.saveTranscriptsBatch
+									>[0][number]["data"],
+								},
+							}
+						: {}),
+					...(Array.isArray(planProgress)
+						? {
+								planProgress: planProgress as NonNullable<
+									Parameters<typeof summaries.storeSummary>[3]
+								>["planProgress"],
+							}
+						: {}),
+					...(Array.isArray(referenceFiles) ? { referenceFiles: referenceFiles as FileWrite[] } : {}),
+				},
+				storage,
+			);
+			return { ok: true };
+		}
+		case "read-plan-progress":
+			return summaries.readPlanProgress(stringField(request, "slug"), cwd, storage);
+		case "store-files": {
+			const files = request.files;
+			if (!Array.isArray(files)) throw new Error('Request field "files" must be an array.');
+			await storage.writeFiles(files as FileWrite[], stringField(request, "message"));
+			return { ok: true };
+		}
+		case "read-plan":
+			return { content: await summaries.readPlanFromBranch(stringField(request, "slug"), cwd, storage) };
+		case "write-plan":
+			await summaries.storePlans(
+				[{ slug: stringField(request, "slug"), content: stringField(request, "content") }],
+				stringField(request, "message"),
+				cwd,
+				undefined,
+				storage,
+			);
+			return { ok: true };
+		case "read-reference":
+			return {
+				content: await summaries.readReferenceFromBranch(
+					stringField(request, "source"),
+					stringField(request, "archivedKey"),
+					cwd,
+					storage,
+				),
+			};
+		case "write-reference":
+			await summaries.storeReferences(
+				[
+					{
+						source: stringField(request, "source"),
+						archivedKey: stringField(request, "archivedKey"),
+						content: stringField(request, "content"),
+					},
+				],
+				stringField(request, "message"),
+				cwd,
+				undefined,
+				storage,
+			);
+			return { ok: true };
+		case "transcript-hashes":
+			return { hashes: [...(await summaries.getTranscriptHashes(cwd, storage))] };
+		case "read-transcript":
+			return summaries.readTranscript(stringField(request, "commitHash"), cwd, storage);
+		case "write-transcript-batch": {
+			const rawWrites = request.writes;
+			if (typeof rawWrites !== "object" || rawWrites === null || Array.isArray(rawWrites)) {
+				throw new Error('Request field "writes" must be an object.');
+			}
+			const writes = Object.entries(rawWrites).map(([hash, data]) => ({
+				hash,
+				data: data as Parameters<typeof summaries.saveTranscriptsBatch>[0][number]["data"],
+			}));
+			await summaries.saveTranscriptsBatch(writes, stringArrayField(request, "deletes"), cwd, storage);
+			return { ok: true };
+		}
+		default:
+			throw new Error(`Unknown summary-store operation "${operation}".`);
+	}
+}
+
+async function runSummaryTreeAction(request: JsonObject): Promise<unknown> {
+	const operation = stringField(request, "operation");
+	const summary = request.summary;
+	if (!summary || typeof summary !== "object") throw new Error('Request field "summary" must be an object.');
+	const tree = await import("../core/SummaryTree.js");
+	type Summary = Parameters<typeof tree.aggregateStats>[0];
+	const value = summary as Summary;
+	const nestedTopics = (topics: ReturnType<typeof tree.collectAllTopics>) =>
+		topics.map(({ commitDate, generatedAt: _generatedAt, treeIndex, ...topic }) => ({
+			topic,
+			commitDate,
+			treeIndex,
+		}));
+	switch (operation) {
+		case "analyze":
+			return {
+				unified: tree.isUnifiedHoistFormat(value),
+				allTopics: nestedTopics(tree.collectAllTopics(value)),
+				displayTopics: nestedTopics(tree.collectDisplayTopics(value)),
+				stats: tree.aggregateStats(value),
+				turns: tree.aggregateTurns(value),
+				tokens: tree.aggregateConversationTokens(value),
+				breakdown: tree.aggregateConversationTokenBreakdown(value),
+				estimatedCost: tree.aggregateEstimatedCost(value),
+				topicCount: tree.countTopics(value),
+				sourceNodes: tree.collectSourceNodes(value),
+				leaf: tree.isLeafNode(value),
+				durationDays: tree.computeDurationDays(value),
+				durationLabel: tree.formatDurationLabel(value),
+			};
+		case "update-topic":
+			return tree.updateTopicInTree(
+				value,
+				numberField(request, "globalIndex"),
+				(request.updates ?? {}) as Parameters<typeof tree.updateTopicInTree>[2],
+			);
+		case "delete-topic":
+			return tree.deleteTopicInTree(value, numberField(request, "globalIndex"));
+		default:
+			throw new Error(`Unknown summary-tree operation "${operation}".`);
+	}
+}
+
+async function runPlanGroupingAction(request: JsonObject): Promise<unknown> {
+	const plans = await import("../core/JolliMemoryPushOrchestrator.js");
+	switch (stringField(request, "operation")) {
+		case "base-key":
+			return { key: plans.planBaseKey(stringField(request, "slug")) };
+		case "base-keys":
+			return Object.fromEntries(
+				stringArrayField(request, "slugs").map((slug) => [slug, plans.planBaseKey(slug)]),
+			);
+		case "latest": {
+			if (!Array.isArray(request.plans)) throw new Error('Request field "plans" must be an array.');
+			return plans.latestPlanPerName(request.plans as Parameters<typeof plans.latestPlanPerName>[0]);
+		}
+		default:
+			throw new Error("Unknown plan-grouping operation.");
+	}
+}
+
+async function runReferenceStoreAction(request: JsonObject): Promise<unknown> {
+	const references = await import("../core/references/ReferenceStore.js");
+	switch (stringField(request, "operation")) {
+		case "read":
+			return references.readReferenceMarkdown(stringField(request, "sourcePath"));
+		case "parse":
+			return references.readReferenceMarkdownFromString(stringField(request, "content"));
+		default:
+			throw new Error("Unknown reference-store operation.");
+	}
+}
+
+async function runKbAction(request: JsonObject): Promise<unknown> {
+	const operation = stringField(request, "operation");
+	const paths = await import("../core/KBPathResolver.js");
+	switch (operation) {
+		case "resolve":
+			return {
+				path: paths.resolveKBPath(
+					stringField(request, "repoName"),
+					optionalString(request, "remoteUrl") ?? null,
+					optionalString(request, "customPath"),
+				),
+			};
+		case "initialize":
+			paths.initializeKBFolder(
+				stringField(request, "kbRoot"),
+				stringField(request, "repoName"),
+				optionalString(request, "remoteUrl") ?? null,
+			);
+			return { ok: true };
+		case "find-repo-folders":
+			return {
+				paths: paths.findRepoFolders(
+					stringField(request, "repoName"),
+					optionalString(request, "remoteUrl") ?? null,
+					optionalString(request, "customPath"),
+				),
+			};
+		case "find-fresh":
+			return {
+				path: paths.findFreshKBPath(stringField(request, "repoName"), optionalString(request, "customPath")),
+			};
+		case "archive":
+			return {
+				path: paths.archiveKBFolder(stringField(request, "kbRoot"), optionalString(request, "customPath")),
+			};
+		case "extract-repo-name":
+			return { value: paths.extractRepoName(stringField(request, "projectPath")) };
+		case "get-remote-url":
+			return { value: paths.getRemoteUrl(stringField(request, "projectPath")) };
+		case "discover": {
+			const { discoverRepos } = await import("../core/KBRepoDiscoverer.js");
+			return {
+				repos: discoverRepos(
+					optionalString(request, "currentRepoName") ?? null,
+					optionalString(request, "currentRemoteUrl") ?? null,
+					optionalString(request, "customParent"),
+				),
+			};
+		}
+	}
+	const { MetadataManager } = await import("../core/MetadataManager.js");
+	const manager = new MetadataManager(stringField(request, "jolliDir"));
+	switch (operation) {
+		case "metadata-ensure":
+			manager.ensure();
+			return { ok: true };
+		case "metadata-read-manifest":
+			return manager.readManifest();
+		case "metadata-read-index":
+			return manager.readIndex();
+		case "metadata-read-config":
+			return manager.readConfig();
+		case "metadata-find-by-path":
+			return { entry: manager.findByPath(stringField(request, "path")) ?? null };
+		case "metadata-update-path":
+			return { changed: manager.updatePath(stringField(request, "fileId"), stringField(request, "newPath")) };
+		case "metadata-rename-branch-folder":
+			return {
+				count: manager.renameBranchFolder(stringField(request, "oldFolder"), stringField(request, "newFolder")),
+			};
+		case "metadata-remove-branch-folder":
+			return { count: manager.removeBranchFolder(stringField(request, "folder")) };
+		case "metadata-remove-manifest":
+			return { changed: manager.removeFromManifest(stringField(request, "fileId")) };
+		case "metadata-reconcile":
+			return { count: manager.reconcile(stringField(request, "kbRoot")) };
+		case "metadata-save-migration":
+			manager.saveMigrationState(request.state as Parameters<typeof manager.saveMigrationState>[0]);
+			return { ok: true };
+		default:
+			throw new Error(`Unknown KB operation "${operation}".`);
+	}
+}
+
+export async function runIdeBridgeAction(action: string, cwd: string, request: JsonObject): Promise<unknown> {
+	switch (action) {
+		case "active-conversations": {
+			const { listActiveConversationsWithDiagnostics } = await import("../core/ActiveSessionAggregator.js");
+			const windowMs = typeof request.windowMs === "number" ? request.windowMs : 2 * 24 * 60 * 60 * 1000;
+			return listActiveConversationsWithDiagnostics({ cwd, windowMs });
+		}
+		case "unread-transcript": {
+			const source = stringField(request, "source") as TranscriptSource;
+			if (!TRANSCRIPT_SOURCES.has(source)) throw new Error(`Unknown transcript source "${source}".`);
+			const { loadUnreadTranscript } = await import("../core/TranscriptMessageCounter.js");
+			return { entries: await loadUnreadTranscript(source, stringField(request, "transcriptPath"), cwd) };
+		}
+		case "transcript": {
+			const source = stringField(request, "source") as TranscriptSource;
+			if (!TRANSCRIPT_SOURCES.has(source)) throw new Error(`Unknown transcript source "${source}".`);
+			const { loadTranscript } = await import("../core/TranscriptLoader.js");
+			return {
+				entries: await loadTranscript({ source, transcriptPath: stringField(request, "transcriptPath") }),
+			};
+		}
+		case "compile": {
+			const config = request.config as JolliMemoryConfig | undefined;
+			if (!config || typeof config !== "object") throw new Error('Request field "config" must be an object.');
+			const localFolder = optionalString(request, "localFolder") ?? config.localFolder;
+			if (!localFolder) throw new Error("No Memory Bank folder configured.");
+			const { compileAllRepos } = await import("../core/MultiRepoCompile.js");
+			return compileAllRepos(localFolder, config);
+		}
+		case "pr-description": {
+			const { buildPrDescription } = await import("../core/PrDescription.js");
+			return buildPrDescription(cwd, {
+				baseBranch: optionalString(request, "baseBranch"),
+				includeMarkers: request.includeMarkers !== false,
+			});
+		}
+		case "status": {
+			const { createStorage } = await import("../core/StorageFactory.js");
+			const { getStatus } = await import("../install/Installer.js");
+			return getStatus(cwd, await createStorage(cwd, cwd));
+		}
+		case "sync": {
+			const { loadConfig } = await import("../core/SessionTracker.js");
+			const config = await loadConfig();
+			if (!config.jolliApiKey) throw new Error("Sync requires a Jolli sign-in.");
+			const { ensureKBInitAndMigrated } = await import("./SyncCommand.js");
+			await ensureKBInitAndMigrated(cwd, config.localFolder);
+			const { buildSyncEngine } = await import("../sync/SyncBootstrap.js");
+			const ui = new IdeBridgeConflictUi(conflictChoices(request));
+			const engine = await buildSyncEngine({ cwd, ui });
+			if (engine === null) throw new Error("Sync requires a Jolli sign-in.");
+			const rawReason = optionalString(request, "reason") ?? "manual";
+			const reason = (["post-commit", "poll", "manual", "first-bind"] as const).find(
+				(candidate) => candidate === rawReason,
+			);
+			if (reason === undefined) throw new Error(`Unknown sync reason "${rawReason}".`);
+			const result = await engine.runRound({
+				cwd,
+				reason,
+				transcripts: request.transcripts === true || config.syncTranscripts === true,
+			});
+			return { ...result, conflictDetails: ui.details };
+		}
+		case "conversation-overlay":
+			return runConversationOverlayAction(cwd, request);
+		case "session-state":
+			return runSessionStateAction(cwd, request);
+		case "auth":
+			return runAuthAction(request);
+		case "jolli-api":
+			return runJolliApiAction(cwd, request);
+		case "pricing": {
+			const operation = stringField(request, "operation");
+			if (operation === "sonnet-cost") {
+				const { estimateConversationCostUsd } = await import("../core/TokenCost.js");
+				return {
+					costUsd: estimateConversationCostUsd(
+						request.breakdown as Parameters<typeof estimateConversationCostUsd>[0],
+						numberField(request, "totalTokens"),
+					),
+				};
+			}
+			const pricing = await import("../core/Pricing.js");
+			if (operation === "provider") {
+				return { provider: pricing.MODEL_PRICES[stringField(request, "model")]?.provider ?? "unknown" };
+			}
+			if (operation === "model-cost") {
+				return {
+					costUsd: pricing.estimateModelCostUsd(
+						request.usage as Parameters<typeof pricing.estimateModelCostUsd>[0],
+					),
+				};
+			}
+			if (operation === "total-cost") {
+				return pricing.estimateCostUsd(request.usages as Parameters<typeof pricing.estimateCostUsd>[0]);
+			}
+			throw new Error(`Unknown pricing operation "${operation}".`);
+		}
+		case "shared-store":
+			return runSharedStoreAction(cwd, request);
+		case "summary-store":
+			return runSummaryStoreAction(cwd, request);
+		case "summary-tree":
+			return runSummaryTreeAction(request);
+		case "plan-grouping":
+			return runPlanGroupingAction(request);
+		case "reference-store":
+			return runReferenceStoreAction(request);
+		case "kb":
+			return runKbAction(request);
+		case "storage":
+			return runStorageAction(cwd, request);
+		case "git-exec": {
+			const { execGit } = await import("../core/GitOps.js");
+			return execGit(stringArrayField(request, "args"), cwd);
+		}
+		case "git-main-worktree-root": {
+			const { getProjectRootDir } = await import("../core/GitOps.js");
+			return { path: await getProjectRootDir(cwd) };
+		}
+		case "git-remote": {
+			const remote = await import("../core/GitRemoteUtils.js");
+			switch (stringField(request, "operation")) {
+				case "canonical-url":
+					return { value: await remote.getCanonicalRepoUrl(cwd) };
+				case "normalize-url":
+					return { value: remote.normalizeRemoteUrl(stringField(request, "remote"), cwd) };
+				case "derive-name":
+					return { value: remote.deriveRepoNameFromUrl(stringField(request, "repoUrl")) };
+				case "sanitize-branch":
+					return { value: remote.sanitizeBranchSlug(optionalString(request, "branch")) };
+				default:
+					throw new Error("Unknown git-remote operation.");
+			}
+		}
+		case "telemetry-track": {
+			const { bootstrapTelemetry } = await import("../core/TelemetryStartup.js");
+			const { bucket, track } = await import("../core/Telemetry.js");
+			await bootstrapTelemetry({ cwd, platformDisabled: request.platformDisabled === true });
+			const properties = {
+				...((request.properties as Readonly<Record<string, unknown>> | undefined) ?? {}),
+			};
+			const bucketCounts = request.bucketCounts;
+			if (bucketCounts !== undefined) {
+				if (typeof bucketCounts !== "object" || bucketCounts === null || Array.isArray(bucketCounts)) {
+					throw new Error('Request field "bucketCounts" must be an object.');
+				}
+				for (const [key, value] of Object.entries(bucketCounts)) {
+					if (typeof value !== "number") throw new Error(`Bucket count "${key}" must be a number.`);
+					properties[key] = bucket(value);
+				}
+			}
+			track(stringField(request, "eventName") as Parameters<typeof track>[0], properties);
+			return { ok: true };
+		}
+		case "telemetry-bootstrap": {
+			const { bootstrapTelemetry } = await import("../core/TelemetryStartup.js");
+			const { loadConfig } = await import("../core/SessionTracker.js");
+			const { shouldShowTelemetryNotice } = await import("../core/TelemetryConsent.js");
+			const platformDisabled = request.platformDisabled === true;
+			await bootstrapTelemetry({ cwd, platformDisabled });
+			return { shouldShowNotice: shouldShowTelemetryNotice({ config: await loadConfig(), platformDisabled }) };
+		}
+		case "telemetry-install-id": {
+			const { getOrCreateInstallId } = await import("../core/SessionTracker.js");
+			return getOrCreateInstallId();
+		}
+		case "telemetry-flush": {
+			const { flushTelemetryNow } = await import("../core/TelemetryStartup.js");
+			await flushTelemetryNow(cwd, { platformDisabled: request.platformDisabled === true });
+			return { ok: true };
+		}
+		default:
+			throw new Error(`Unknown IDE bridge action "${action}".`);
+	}
+}
+
+/**
+ * One-shot mode. Reads one request body from stdin (already just the `request`
+ * payload — `method` and `cwd` come from the CLI args), invokes the handler,
+ * and writes one JSON-RPC 2.0 response envelope on stdout. Success and error
+ * shapes match the long-lived server so the host has a single parser.
+ * Note there is no `id` in the one-shot response: the process itself is the
+ * correlation — one spawn = one call.
+ */
+export async function executeIdeBridgeCommand(action: string, cwd: string): Promise<void> {
+	try {
+		setLogDir(cwd);
+		const result = await runIdeBridgeAction(action, cwd, parseRequest(await readStdin()));
+		console.log(JSON.stringify({ jsonrpc: "2.0", result }));
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		const data: Record<string, unknown> = {};
+		if (error instanceof Error && error.name.length > 0) {
+			data.errorName = error.name;
+		}
+		copyPrimitiveErrorFields(error, data);
+		console.log(JSON.stringify({ jsonrpc: "2.0", error: { code: -32000, message, data } }));
+		process.exitCode = 1;
+	}
+}
+
+/**
+ * Wire protocol name for the long-lived JSON-RPC 2.0 ide-bridge server. The
+ * host side refuses a handshake with any other value so a mismatched Node
+ * binary (older plugin dist, newer client) fails loudly instead of silently
+ * misbehaving.
+ */
+export const IDE_BRIDGE_PROTOCOL = "jolli-ide-bridge-jsonrpc-v1";
+
+/** Handshake — a JSON-RPC 2.0 notification (no `id`) with method "ready". */
+interface HandshakeLine {
+	readonly jsonrpc: "2.0";
+	readonly method: "ready";
+	readonly params: {
+		readonly protocol: typeof IDE_BRIDGE_PROTOCOL;
+		readonly pluginVersion: string;
+		readonly pid: number;
+	};
+}
+
+/** One request received from the IDE. Fields extra to this shape are ignored. */
+interface ServeRequest {
+	readonly id: number | string | null;
+	readonly action: string;
+	readonly cwd?: string;
+	readonly request?: JsonObject;
+}
+
+/**
+ * Extracts the id from a decoded request line without throwing — used on the
+ * error path so a malformed line still gets a paired error response when the
+ * `id` field alone is intelligible.
+ */
+function extractRequestId(parsed: unknown): number | string | null {
+	if (typeof parsed !== "object" || parsed === null) return null;
+	const id = (parsed as { id?: unknown }).id;
+	if (typeof id === "number" || typeof id === "string") return id;
+	return null;
+}
+
+/**
+ * Validates and normalises one raw JSON-RPC 2.0 request line into a
+ * [ServeRequest]. Throws with a specific message on any missing / wrong-typed
+ * field — the caller pairs the resulting error with whatever id could be
+ * extracted separately.
+ *
+ * Wire shape: `{"jsonrpc":"2.0","id":<n|s>,"method":"<action>","params":{"cwd":"...","request":{...}}}`.
+ * `jsonrpc` is required by the spec but we accept its absence for transitional
+ * clients — the presence of `method`/`id` is what actually drives dispatch.
+ */
+function normaliseServeRequest(parsed: unknown): ServeRequest {
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		throw new Error("Request must be a JSON object.");
+	}
+	const raw = parsed as Record<string, unknown>;
+	const method = raw.method;
+	if (typeof method !== "string" || method.length === 0) {
+		throw new Error('Request field "method" must be a non-empty string.');
+	}
+	const rawParams = raw.params;
+	if (rawParams !== undefined && (typeof rawParams !== "object" || rawParams === null || Array.isArray(rawParams))) {
+		throw new Error('Request field "params" must be a JSON object.');
+	}
+	const params = (rawParams as Record<string, unknown> | undefined) ?? {};
+	const cwd = params.cwd;
+	if (cwd !== undefined && typeof cwd !== "string") {
+		throw new Error('Request field "params.cwd" must be a string.');
+	}
+	const request = params.request;
+	if (request !== undefined && (typeof request !== "object" || request === null || Array.isArray(request))) {
+		throw new Error('Request field "params.request" must be a JSON object.');
+	}
+	const id = extractRequestId(parsed);
+	return {
+		id,
+		action: method,
+		...(typeof cwd === "string" ? { cwd } : {}),
+		...(request ? { request: request as JsonObject } : {}),
+	};
+}
+
+/**
+ * Emits one JSON line to stdout as the wire format for the daemon. Kept as a
+ * single choke point so any future framing change (e.g. Content-Length) is a
+ * one-line edit.
+ *
+ * Stringify guard: a handler that returns a value carrying a bigint or a
+ * circular reference makes `JSON.stringify` throw AFTER the request already
+ * committed an id. Without this fallback the host's per-id future is orphaned
+ * and only unblocks when the caller's own timeout fires (300 s in the default
+ * bridge budget). Fall back to a minimal, guaranteed-serialisable error
+ * envelope carrying the same id so the caller fails fast with a real message.
+ *
+ * Exported so vitest can assert the fallback envelope shape without spawning
+ * a real daemon.
+ */
+export function writeServeLine(obj: object): void {
+	let line: string;
+	try {
+		line = JSON.stringify(obj);
+	} catch (err: unknown) {
+		const rawId = (obj as { id?: unknown }).id;
+		const id = typeof rawId === "number" || typeof rawId === "string" ? rawId : null;
+		const message = err instanceof Error ? err.message : String(err);
+		// JSON-RPC 2.0 error object. -32603 = internal error (spec).
+		line = JSON.stringify({
+			jsonrpc: "2.0",
+			id,
+			error: {
+				code: -32603,
+				message: `response not serialisable: ${message}`,
+				data: { errorName: "SerializationError" },
+			},
+		});
+	}
+	process.stdout.write(`${line}\n`);
+}
+
+/**
+ * Long-lived NDJSON server mode for `ide-bridge`. Reads one JSON request per
+ * line from stdin and writes one JSON response per line to stdout; every
+ * request is dispatched concurrently by [runIdeBridgeAction] so a slow request
+ * (e.g. `sync`, `compile`) cannot block a fast one (`session-state`, `status`).
+ *
+ * Contract highlights (see also IDE_BRIDGE_PROTOCOL):
+ *   - Handshake — one `{"type":"ready", …}` line is emitted before any request
+ *     is read, so the host can wait for it before sending traffic.
+ *   - Requests — `{"id":<int|string>, "action":"<a>", "cwd":"<abs>", "request":{…}}`.
+ *   - Responses — success `{"id":<n>, "type":"<action>", "result":<any>}`;
+ *     failure `{"id":<n>, "type":"error", "message":"…", "errorName":"…",
+ *     "details":{…}}` — same shape as the one-shot mode so the host can reuse
+ *     one parser.
+ *   - Malformed lines produce an error response whose id is whatever could be
+ *     extracted, or `null` when even that fails; the loop keeps running.
+ *   - Handler exceptions are caught per-request; the daemon process never
+ *     exits from a business-logic error.
+ *   - stdin EOF (`readline` `close` event) drains outstanding responses and
+ *     exits cleanly with code 0.
+ *   - stdout is protocol-only. All logging goes through [setLogDir] to the
+ *     per-project log file, and any accidental stray writer would violate the
+ *     protocol; the two `console.log`s in this file are the only stdout
+ *     writers, both emitting well-formed JSON envelopes.
+ */
+export async function runIdeBridgeServe(cwdDefault: string): Promise<void> {
+	setLogDir(cwdDefault);
+
+	// Last-resort guards — any un-caught throw would otherwise crash the daemon
+	// and orphan every in-flight future in the Kotlin client. Route to stderr
+	// (Node's default for console.error / .warn) so stdout stays clean.
+	process.on("uncaughtException", (err) => {
+		console.error(
+			`[ide-bridge-serve] uncaughtException: ${err instanceof Error ? (err.stack ?? err.message) : err}`,
+		);
+	});
+	process.on("unhandledRejection", (reason) => {
+		console.error(
+			`[ide-bridge-serve] unhandledRejection: ${reason instanceof Error ? (reason.stack ?? reason.message) : reason}`,
+		);
+	});
+
+	const handshake: HandshakeLine = {
+		jsonrpc: "2.0",
+		method: "ready",
+		params: {
+			protocol: IDE_BRIDGE_PROTOCOL,
+			pluginVersion: typeof __CLI_PKG_VERSION__ !== "undefined" ? __CLI_PKG_VERSION__ : "dev",
+			pid: process.pid,
+		},
+	};
+	writeServeLine(handshake);
+
+	// Same stdout is used for two message families:
+	//   - request/response pairs (this loop below)
+	//   - server→client refresh notifications from fs.watch on the write outputs
+	// Merging both into one process (scheme A') means the Kotlin host only
+	// spawns and manages a single Node child; notifications carry no `id`, so
+	// the host can route them by envelope `type` alone.
+	const watchers = startRefreshWatchers(cwdDefault);
+
+	const readline = await import("node:readline");
+	const rl = readline.createInterface({ input: process.stdin, crlfDelay: Number.POSITIVE_INFINITY });
+
+	const pending = new Set<Promise<void>>();
+	for await (const rawLine of rl) {
+		if (rawLine.trim().length === 0) continue;
+		const task = handleServeLine(rawLine, cwdDefault).catch((err) => {
+			// handleServeLine already writes a JSON error line for any expected
+			// failure; this catch only fires if the writer itself threw (e.g.
+			// EPIPE after the client went away). Log and continue — the read
+			// loop will naturally exit next.
+			console.error(
+				`[ide-bridge-serve] response write failed: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		});
+		pending.add(task);
+		task.finally(() => pending.delete(task));
+	}
+
+	// stdin closed → stop watchers and let outstanding work finish before
+	// exiting so the host receives every pending response instead of a
+	// truncated stream.
+	stopRefreshWatchers(watchers);
+	await Promise.all(pending);
+}
+
+/**
+ * Debounced fs.watch on the two write outputs of the CLI-native git hooks:
+ *   - `.jolli/jollimemory/git-op-queue/` (queue writes)
+ *   - `<gitCommonDir>/refs/heads/jollimemory/summaries/` (orphan ref moves)
+ *
+ * Bursts collapse into one refresh line per kind after the watcher's quiet
+ * window. Notification envelope carries no `id` — the host distinguishes it
+ * from a response by the absence of that field and routes by `type` alone.
+ * When the target directory does not yet exist (typical for orphan-ref on a
+ * fresh clone), start a retry timer that polls until the first summary lands
+ * and arm the watcher then.
+ */
+function startRefreshWatchers(cwd: string): {
+	watchers: DaemonWatcher[];
+	armRetries: NodeJS.Timeout[];
+} {
+	const DEBOUNCE_MS = 300;
+	const ARM_RETRY_MS = 5000;
+	const watchers: DaemonWatcher[] = [];
+	const armRetries: NodeJS.Timeout[] = [];
+	for (const target of computeWatchTargets(cwd)) {
+		const watcher = new DaemonWatcher({
+			path: target.path,
+			debounceMs: DEBOUNCE_MS,
+			ensureDir: target.ensureDir,
+			onTrigger: () => {
+				// JSON-RPC 2.0 server→client notification (no `id`).
+				writeServeLine({
+					jsonrpc: "2.0",
+					method: "refresh",
+					params: { kind: target.kind, cwd },
+				});
+			},
+		});
+		if (!watcher.start()) {
+			const retry = setInterval(() => {
+				if (watcher.start()) {
+					clearInterval(retry);
+					const idx = armRetries.indexOf(retry);
+					if (idx >= 0) armRetries.splice(idx, 1);
+				}
+			}, ARM_RETRY_MS);
+			retry.unref?.();
+			armRetries.push(retry);
+		}
+		watchers.push(watcher);
+	}
+	return { watchers, armRetries };
+}
+
+function stopRefreshWatchers({
+	watchers,
+	armRetries,
+}: {
+	watchers: DaemonWatcher[];
+	armRetries: NodeJS.Timeout[];
+}): void {
+	for (const w of watchers) w.stop();
+	for (const t of armRetries) clearInterval(t);
+}
+
+/** Dispatches one line; always writes exactly one response line (success or error). */
+async function handleServeLine(line: string, cwdDefault: string): Promise<void> {
+	writeServeLine(await computeServeResponse(line, cwdDefault));
+}
+
+/**
+ * Turns one request line into its response envelope — the object that the
+ * daemon would otherwise pass straight to [writeServeLine]. Split out from
+ * [handleServeLine] so vitest can exercise it without touching stdin/stdout
+ * or spawning readline. Never throws — every failure (malformed JSON,
+ * validator, handler exception) produces an `error`-typed envelope.
+ */
+export async function computeServeResponse(line: string, cwdDefault: string): Promise<Record<string, unknown>> {
+	let id: number | string | null = null;
+	try {
+		const parsed: unknown = JSON.parse(line);
+		id = extractRequestId(parsed);
+		const req = normaliseServeRequest(parsed);
+		id = req.id;
+		const cwd = req.cwd && req.cwd.length > 0 ? req.cwd : cwdDefault;
+		const result = await runIdeBridgeAction(req.action, cwd, req.request ?? {});
+		return { jsonrpc: "2.0", id, result };
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		// -32000 is the server-defined error range per JSON-RPC 2.0. Business
+		// errors from handlers all funnel here; parse/dispatch failures share
+		// the same envelope so the host has one code path.
+		const data: Record<string, unknown> = {};
+		if (error instanceof Error && error.name.length > 0) {
+			data.errorName = error.name;
+		}
+		copyPrimitiveErrorFields(error, data);
+		return {
+			jsonrpc: "2.0",
+			id,
+			error: { code: -32000, message, data },
+		};
+	}
+}

--- a/cli/src/commands/IdeBridgeRegistration.test.ts
+++ b/cli/src/commands/IdeBridgeRegistration.test.ts
@@ -1,0 +1,80 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const executeIdeBridgeCommandMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const runIdeBridgeServeMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+// The registration file dynamically imports IdeBridgeCommand.ts inside each
+// action so the large dispatcher is only loaded on demand. Mock both so the
+// tests exercise the registration + dispatch wiring without pulling in the
+// real handler (which touches storage / auth / git).
+vi.mock("./IdeBridgeCommand.js", () => ({
+	executeIdeBridgeCommand: executeIdeBridgeCommandMock,
+	runIdeBridgeServe: runIdeBridgeServeMock,
+}));
+
+vi.mock("../util/Subprocess.js", () => ({
+	execFileSyncHidden: () => "/mock/repo",
+}));
+
+import { registerIdeBridgeCommand } from "./IdeBridgeRegistration.js";
+
+function makeProgram(): Command {
+	const program = new Command();
+	program.exitOverride();
+	registerIdeBridgeCommand(program);
+	return program;
+}
+
+beforeEach(() => {
+	executeIdeBridgeCommandMock.mockClear();
+	runIdeBridgeServeMock.mockClear();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("registerIdeBridgeCommand", () => {
+	it("registers both 'ide-bridge' and 'ide-bridge-serve'", () => {
+		const program = makeProgram();
+		const names = program.commands.map((c) => c.name());
+		expect(names).toContain("ide-bridge");
+		expect(names).toContain("ide-bridge-serve");
+	});
+
+	it("routes 'ide-bridge <action> --cwd <dir>' to executeIdeBridgeCommand with the parsed args", async () => {
+		await makeProgram().parseAsync(["ide-bridge", "status", "--cwd", "/some/repo"], { from: "user" });
+		expect(executeIdeBridgeCommandMock).toHaveBeenCalledWith("status", "/some/repo");
+		expect(runIdeBridgeServeMock).not.toHaveBeenCalled();
+	});
+
+	it("defaults ide-bridge --cwd to the resolved project directory", async () => {
+		await makeProgram().parseAsync(["ide-bridge", "status"], { from: "user" });
+		expect(executeIdeBridgeCommandMock).toHaveBeenCalledOnce();
+		const [action, cwd] = executeIdeBridgeCommandMock.mock.calls[0];
+		expect(action).toBe("status");
+		expect(typeof cwd).toBe("string");
+		expect(cwd.length).toBeGreaterThan(0);
+	});
+
+	it("routes 'ide-bridge-serve --cwd <dir>' to runIdeBridgeServe", async () => {
+		await makeProgram().parseAsync(["ide-bridge-serve", "--cwd", "/serve/repo"], { from: "user" });
+		expect(runIdeBridgeServeMock).toHaveBeenCalledWith("/serve/repo");
+		expect(executeIdeBridgeCommandMock).not.toHaveBeenCalled();
+	});
+
+	it("defaults ide-bridge-serve --cwd to the resolved project directory", async () => {
+		await makeProgram().parseAsync(["ide-bridge-serve"], { from: "user" });
+		expect(runIdeBridgeServeMock).toHaveBeenCalledOnce();
+		const [cwd] = runIdeBridgeServeMock.mock.calls[0];
+		expect(typeof cwd).toBe("string");
+		expect(cwd.length).toBeGreaterThan(0);
+	});
+
+	it("gives ide-bridge-serve a stable, user-readable description", () => {
+		const program = makeProgram();
+		const cmd = program.commands.find((c) => c.name() === "ide-bridge-serve");
+		expect(cmd?.description()).toMatch(/long-lived ndjson ide-bridge server/i);
+	});
+});

--- a/cli/src/commands/IdeBridgeRegistration.ts
+++ b/cli/src/commands/IdeBridgeRegistration.ts
@@ -1,0 +1,35 @@
+import type { Command } from "commander";
+import { resolveProjectDir } from "./CliUtils.js";
+
+/**
+ * Registers the hidden IDE IPC commands without loading the large dispatcher on
+ * every CLI invocation.
+ *
+ * Two subcommands:
+ *   - `ide-bridge <action>` — one-shot: reads one JSON request from stdin,
+ *     writes one JSON response, exits. Used by hooks and by IDE hosts that
+ *     have not yet started the long-lived daemon.
+ *   - `ide-bridge-serve` — long-lived NDJSON server. Reads one JSON request
+ *     per stdin line, writes one JSON response per stdout line, keeps running
+ *     until stdin EOF. Amortises Node startup (~500 ms – 2 s) across every
+ *     IntelliJ ide-bridge call so subsequent requests are ~5–20 ms.
+ */
+export function registerIdeBridgeCommand(program: Command): void {
+	program
+		.command("ide-bridge", { hidden: true })
+		.argument("<action>")
+		.option("--cwd <dir>", "Project directory", resolveProjectDir())
+		.action(async (action: string, options: { cwd: string }) => {
+			const { executeIdeBridgeCommand } = await import("./IdeBridgeCommand.js");
+			await executeIdeBridgeCommand(action, options.cwd);
+		});
+
+	program
+		.command("ide-bridge-serve", { hidden: true })
+		.description("Long-lived NDJSON ide-bridge server for IDE plugins")
+		.option("--cwd <dir>", "Project directory", resolveProjectDir())
+		.action(async (options: { cwd: string }) => {
+			const { runIdeBridgeServe } = await import("./IdeBridgeCommand.js");
+			await runIdeBridgeServe(options.cwd);
+		});
+}

--- a/cli/src/commands/MigrateMemoryBankCommand.test.ts
+++ b/cli/src/commands/MigrateMemoryBankCommand.test.ts
@@ -1,0 +1,138 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FolderStorage } from "../core/FolderStorage.js";
+import * as KBPathResolver from "../core/KBPathResolver.js";
+import type { MigrationState } from "../core/KBTypes.js";
+import { MetadataManager } from "../core/MetadataManager.js";
+import { MigrationEngine } from "../core/MigrationEngine.js";
+import { OrphanBranchStorage } from "../core/OrphanBranchStorage.js";
+import * as SessionTracker from "../core/SessionTracker.js";
+import { registerMigrateMemoryBankCommand, runMemoryBankMigration } from "./MigrateMemoryBankCommand.js";
+
+/** Stubs path resolution + config so no real repo/config is touched. */
+function stubResolution(localFolder?: string): void {
+	vi.spyOn(SessionTracker, "loadConfig").mockResolvedValue({ localFolder });
+	vi.spyOn(KBPathResolver, "extractRepoName").mockReturnValue("myrepo");
+	vi.spyOn(KBPathResolver, "getRemoteUrl").mockReturnValue("git@github.com:acme/myrepo.git");
+	vi.spyOn(KBPathResolver, "resolveKBPath").mockReturnValue("/kb/myrepo");
+}
+
+beforeEach(() => {
+	process.exitCode = 0;
+	// FolderStorage.ensure() is a filesystem side effect the unit test must not run.
+	vi.spyOn(FolderStorage.prototype, "ensure").mockResolvedValue(undefined);
+});
+afterEach(() => {
+	vi.restoreAllMocks();
+	process.exitCode = 0;
+});
+
+describe("runMemoryBankMigration", () => {
+	it("reports an empty completed run when there is no orphan branch", async () => {
+		stubResolution();
+		vi.spyOn(OrphanBranchStorage.prototype, "exists").mockResolvedValue(false);
+		const runMigration = vi.spyOn(MigrationEngine.prototype, "runMigration");
+
+		const result = await runMemoryBankMigration("/repo");
+
+		expect(result).toEqual({ status: "completed", totalEntries: 0, migratedEntries: 0 });
+		expect(runMigration).not.toHaveBeenCalled();
+	});
+
+	it("runs a full migration when migration state is absent", async () => {
+		stubResolution("/custom/bank");
+		vi.spyOn(OrphanBranchStorage.prototype, "exists").mockResolvedValue(true);
+		vi.spyOn(MetadataManager.prototype, "readMigrationState").mockReturnValue(null);
+		const runMigration = vi
+			.spyOn(MigrationEngine.prototype, "runMigration")
+			.mockResolvedValue({ status: "completed", totalEntries: 4, migratedEntries: 4 } as MigrationState);
+		const reconcile = vi.spyOn(MigrationEngine.prototype, "runStaleChildCleanup");
+
+		const result = await runMemoryBankMigration("/repo");
+
+		expect(result).toEqual({ status: "completed", totalEntries: 4, migratedEntries: 4 });
+		expect(runMigration).toHaveBeenCalledOnce();
+		expect(reconcile).not.toHaveBeenCalled();
+	});
+
+	it("runs a full migration when a prior run did not complete", async () => {
+		stubResolution();
+		vi.spyOn(OrphanBranchStorage.prototype, "exists").mockResolvedValue(true);
+		vi.spyOn(MetadataManager.prototype, "readMigrationState").mockReturnValue({
+			status: "in_progress",
+			totalEntries: 10,
+			migratedEntries: 2,
+		} as MigrationState);
+		const runMigration = vi
+			.spyOn(MigrationEngine.prototype, "runMigration")
+			.mockResolvedValue({ status: "partial", totalEntries: 10, migratedEntries: 9 } as MigrationState);
+
+		const result = await runMemoryBankMigration("/repo");
+
+		expect(result).toEqual({ status: "partial", totalEntries: 10, migratedEntries: 9 });
+		expect(runMigration).toHaveBeenCalledOnce();
+	});
+
+	it("runs the idempotent stale-child reconcile when already completed", async () => {
+		stubResolution();
+		vi.spyOn(OrphanBranchStorage.prototype, "exists").mockResolvedValue(true);
+		vi.spyOn(MetadataManager.prototype, "readMigrationState").mockReturnValue({
+			status: "completed",
+			totalEntries: 7,
+			migratedEntries: 7,
+		} as MigrationState);
+		const runMigration = vi.spyOn(MigrationEngine.prototype, "runMigration");
+		const reconcile = vi
+			.spyOn(MigrationEngine.prototype, "runStaleChildCleanup")
+			.mockResolvedValue({ status: "completed", totalEntries: 7, migratedEntries: 7, swept: 0 });
+
+		const result = await runMemoryBankMigration("/repo");
+
+		expect(result).toEqual({ status: "completed", totalEntries: 7, migratedEntries: 7 });
+		expect(runMigration).not.toHaveBeenCalled();
+		expect(reconcile).toHaveBeenCalledOnce();
+	});
+});
+
+/** Runs `jolli migrate-memory-bank` capturing stdout. */
+async function run(): Promise<string> {
+	const logs: string[] = [];
+	vi.spyOn(console, "log").mockImplementation((m?: unknown) => void logs.push(String(m)));
+	const program = new Command();
+	registerMigrateMemoryBankCommand(program);
+	await program.parseAsync(["node", "jolli", "migrate-memory-bank", "--cwd", "/repo"]);
+	return logs.join("\n");
+}
+
+describe("migrate-memory-bank command", () => {
+	it("prints the migration result as a single JSON line", async () => {
+		stubResolution();
+		vi.spyOn(OrphanBranchStorage.prototype, "exists").mockResolvedValue(false);
+
+		const out = await run();
+
+		expect(JSON.parse(out)).toEqual({
+			type: "migrate-memory-bank",
+			status: "completed",
+			totalEntries: 0,
+			migratedEntries: 0,
+		});
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("prints a JSON error and sets exit code 1 when migration throws", async () => {
+		stubResolution();
+		vi.spyOn(OrphanBranchStorage.prototype, "exists").mockResolvedValue(true);
+		vi.spyOn(MetadataManager.prototype, "readMigrationState").mockReturnValue(null);
+		vi.spyOn(MigrationEngine.prototype, "runMigration").mockRejectedValue(new TypeError("index.json corrupt"));
+
+		const out = await run();
+
+		expect(JSON.parse(out)).toEqual({
+			type: "error",
+			message: "index.json corrupt",
+			errorName: "TypeError",
+		});
+		expect(process.exitCode).toBe(1);
+	});
+});

--- a/cli/src/commands/MigrateMemoryBankCommand.ts
+++ b/cli/src/commands/MigrateMemoryBankCommand.ts
@@ -1,0 +1,118 @@
+/**
+ * MigrateMemoryBankCommand — hidden machine-facing bridge for the
+ * orphan-branch → Memory Bank folder migration.
+ *
+ * `jolli migrate-memory-bank` exposes the `MigrationEngine` folder migration to
+ * callers that cannot import it in-process. The VS Code extension bundles
+ * `cli/src/**` and runs `MigrationEngine.runMigration()` directly from its
+ * `activate()` path; the IntelliJ plugin is a JVM process, so it spawns
+ * `node Cli.js migrate-memory-bank --cwd <dir>` and reads a single-line JSON
+ * response from stdout.
+ *
+ * Behaviour mirrors `ensureKBInitAndMigrated` in SyncCommand.ts (the canonical
+ * shared step, itself a mirror of the VS Code `initializeKB()` block):
+ *   - no orphan branch yet → nothing to migrate, report an empty completed run
+ *   - migration not completed → full `runMigration()` (copies summaries /
+ *     transcripts / plans / notes onto disk)
+ *   - already completed → idempotent `runStaleChildCleanup()` reconcile, so the
+ *     "visible folder shows only heads" invariant self-heals on every startup
+ *     exactly as it does for VS Code
+ *
+ * Unlike `jolli sync-memory-bank`, this does NOT require a Jolli sign-in: the
+ * local folder migration is on by default and must run even for users who never
+ * connect a Personal Space.
+ *
+ * Output contract (single line on stdout):
+ *   - success — `{ "type": "migrate-memory-bank", "status": "…",
+ *                  "totalEntries": <n>, "migratedEntries": <n> }`
+ *   - failure — `{ "type": "error", "message": "…", "errorName": "…" }` with a
+ *                non-zero exit code, matching the `generate` bridge so the
+ *                IntelliJ plugin can reuse one JSON-response parser.
+ *
+ * The command is hidden from `jolli --help`: it is IDE plumbing.
+ */
+
+import { join } from "node:path";
+import type { Command } from "commander";
+import { FolderStorage } from "../core/FolderStorage.js";
+import { extractRepoName, getRemoteUrl, resolveKBPath } from "../core/KBPathResolver.js";
+import { MetadataManager } from "../core/MetadataManager.js";
+import { MigrationEngine } from "../core/MigrationEngine.js";
+import { OrphanBranchStorage } from "../core/OrphanBranchStorage.js";
+import { loadConfig } from "../core/SessionTracker.js";
+import { setLogDir } from "../Logger.js";
+import { resolveProjectDir } from "./CliUtils.js";
+
+interface MigrateMemoryBankOptions {
+	cwd: string;
+}
+
+/** The subset of MigrationState the IDE caller needs for its status line. */
+interface MigrateResult {
+	readonly status: string;
+	readonly totalEntries: number;
+	readonly migratedEntries: number;
+}
+
+/**
+ * Runs the orphan → folder migration for [cwd], resolving the Memory Bank root
+ * from the shared config exactly as `ensureKBInitAndMigrated` does. Exported for
+ * unit tests. Never touches the orphan branch as anything but a read source.
+ */
+export async function runMemoryBankMigration(cwd: string): Promise<MigrateResult> {
+	const config = await loadConfig();
+	const repoName = extractRepoName(cwd);
+	const remoteUrl = getRemoteUrl(cwd);
+	const kbRoot = resolveKBPath(repoName, remoteUrl, config.localFolder);
+
+	const orphan = new OrphanBranchStorage(cwd);
+	if (!(await orphan.exists())) {
+		return { status: "completed", totalEntries: 0, migratedEntries: 0 };
+	}
+
+	const mm = new MetadataManager(join(kbRoot, ".jolli"));
+	const folder = new FolderStorage(kbRoot, mm);
+	await folder.ensure();
+	const engine = new MigrationEngine(orphan, folder, mm);
+
+	const state = mm.readMigrationState();
+	if (!state || state.status !== "completed") {
+		const result = await engine.runMigration();
+		return {
+			status: result.status,
+			totalEntries: result.totalEntries,
+			migratedEntries: result.migratedEntries,
+		};
+	}
+
+	// Already migrated: run the idempotent stale-child reconcile every startup,
+	// matching the VS Code activate path (see MigrationEngine.runStaleChildCleanup).
+	const reconciled = await engine.runStaleChildCleanup();
+	return {
+		status: reconciled.status,
+		totalEntries: reconciled.totalEntries,
+		migratedEntries: reconciled.migratedEntries,
+	};
+}
+
+/**
+ * Registers the hidden `migrate-memory-bank` command on the given program.
+ */
+export function registerMigrateMemoryBankCommand(program: Command): void {
+	program
+		.command("migrate-memory-bank", { hidden: true })
+		.description("Orphan-branch → Memory Bank folder migration bridge for IDE plugins (JSON on stdout)")
+		.option("--cwd <dir>", "Project directory (default: git repo root)", resolveProjectDir())
+		.action(async (options: MigrateMemoryBankOptions) => {
+			try {
+				setLogDir(options.cwd);
+				const result = await runMemoryBankMigration(options.cwd);
+				console.log(JSON.stringify({ type: "migrate-memory-bank", ...result }));
+			} catch (error: unknown) {
+				const message = error instanceof Error ? error.message : String(error);
+				const errorName = error instanceof Error ? error.name : "Error";
+				console.log(JSON.stringify({ type: "error", message, errorName }));
+				process.exitCode = 1;
+			}
+		});
+}

--- a/cli/src/core/CursorCliSessionDiscoverer.test.ts
+++ b/cli/src/core/CursorCliSessionDiscoverer.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CURSOR_CLI_META_JSON, CURSOR_CLI_TRANSCRIPT_JSONL } from "../testUtils/cursorCliFixture.js";
 import {
 	discoverCursorCliSessions,
@@ -55,22 +55,34 @@ describe("scanCursorCliSessions", () => {
 	});
 
 	it("parses a real pinned cursor-agent meta.json + JSONL fixture end to end", async () => {
-		const uuid = "6f2a9c3e-6b3c-4e7a-9b8a-1a2b3c4d5e6f";
-		const fixtureProject = "/Users/example/proj"; // must match CURSOR_CLI_META_JSON.cwd verbatim
-		const dir = join(chatsDir, "real-hash", uuid);
-		await mkdir(dir, { recursive: true });
-		await writeFile(join(dir, "meta.json"), CURSOR_CLI_META_JSON, "utf8");
-		await writeTranscript(projectsDir, "example-proj", uuid, CURSOR_CLI_TRANSCRIPT_JSONL);
+		// The fixture's updatedAtMs is a real historical timestamp; discoverer
+		// enforces a 48h staleness gate against Date.now(), so real-time clock
+		// drift would eventually flip this test from green to red without any
+		// code change. Pin "now" to just after the fixture time to keep the
+		// gate deterministic. Scoped to this single it() so the other cases
+		// that use the top-level `now = Date.now()` are unaffected.
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(1784631456880 + 1000));
+		try {
+			const uuid = "6f2a9c3e-6b3c-4e7a-9b8a-1a2b3c4d5e6f";
+			const fixtureProject = "/Users/example/proj"; // must match CURSOR_CLI_META_JSON.cwd verbatim
+			const dir = join(chatsDir, "real-hash", uuid);
+			await mkdir(dir, { recursive: true });
+			await writeFile(join(dir, "meta.json"), CURSOR_CLI_META_JSON, "utf8");
+			await writeTranscript(projectsDir, "example-proj", uuid, CURSOR_CLI_TRANSCRIPT_JSONL);
 
-		const r = await scanCursorCliSessions(fixtureProject, chatsDir, projectsDir);
+			const r = await scanCursorCliSessions(fixtureProject, chatsDir, projectsDir);
 
-		expect(r.sessions).toHaveLength(1);
-		expect(r.sessions[0]).toMatchObject({
-			sessionId: uuid,
-			title: "Hello There",
-			updatedAt: new Date(1784631456880).toISOString(),
-			source: "cursor-cli",
-		});
+			expect(r.sessions).toHaveLength(1);
+			expect(r.sessions[0]).toMatchObject({
+				sessionId: uuid,
+				title: "Hello There",
+				updatedAt: new Date(1784631456880).toISOString(),
+				source: "cursor-cli",
+			});
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("does NOT attribute a session run from a repo subdirectory (exact-equality contract, like Devin)", async () => {

--- a/cli/src/core/JolliShareClient.test.ts
+++ b/cli/src/core/JolliShareClient.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+import { JolliShareClient, type LiveSharePayload, ShareRevokedError } from "./JolliShareClient.js";
+
+const payload: LiveSharePayload = {
+	repoUrl: "https://github.com/acme/repo",
+	repoName: "repo",
+	branch: "feature/x",
+	kind: "branch",
+	visibility: "private",
+	decisionCount: 2,
+	headCommitHash: "abc",
+	commitHashes: ["abc"],
+	ref: { kind: "branchCollection" },
+};
+
+function jsonResponse(status: number, value: unknown): Response {
+	return new Response(JSON.stringify(value), { status, headers: { "content-type": "application/json" } });
+}
+
+function client(response: Response | (() => Promise<Response>)) {
+	const fetchImpl = vi.fn(
+		typeof response === "function" ? response : async () => response,
+	) as unknown as typeof fetch;
+	return {
+		client: new JolliShareClient("sk-jol-test", "https://jolli.dev/acme", fetchImpl),
+		fetchImpl,
+	};
+}
+
+describe("JolliShareClient", () => {
+	it("creates a share with canonical headers and response defaults", async () => {
+		const { client: api, fetchImpl } = client(
+			jsonResponse(201, {
+				shareId: "share-1",
+				shareUrl: "https://jolli.dev/s/share-1",
+				token: "token",
+				recipients: ["a@example.com"],
+			}),
+		);
+
+		await expect(api.create(payload)).resolves.toEqual({
+			shareId: "share-1",
+			shareUrl: "https://jolli.dev/s/share-1",
+			expiresAt: "",
+			visibility: "private",
+			token: "token",
+			recipients: ["a@example.com"],
+		});
+		const [url, init] = vi.mocked(fetchImpl).mock.calls[0];
+		expect(String(url)).toBe("https://jolli.dev/api/share/branch");
+		expect(init?.method).toBe("POST");
+		expect(init?.headers).toMatchObject({
+			authorization: "Bearer sk-jol-test",
+			"content-type": "application/json",
+			"x-tenant-slug": "acme",
+		});
+		expect(JSON.parse(String(init?.body))).toEqual(payload);
+	});
+
+	it("normalizes a numeric share id to a string", async () => {
+		await expect(
+			client(jsonResponse(201, { shareId: 7, shareUrl: "https://jolli.dev/s/7" })).client.create(payload),
+		).resolves.toMatchObject({ shareId: "7", shareUrl: "https://jolli.dev/s/7" });
+	});
+
+	it("rejects malformed success and maps ordinary server errors", async () => {
+		await expect(client(jsonResponse(200, { shareId: "only-id" })).client.create(payload)).rejects.toThrow(
+			"missing shareId/shareUrl",
+		);
+		await expect(client(new Response("gateway down", { status: 502 })).client.create(payload)).rejects.toThrow(
+			"request failed (HTTP 502): gateway down",
+		);
+	});
+
+	it("updates fields and maps revoked/outdated responses", async () => {
+		await expect(
+			client(
+				jsonResponse(200, { shareId: "s", visibility: "public", recipients: ["a@example.com"] }),
+			).client.update("s/1", { visibility: "public" }),
+		).resolves.toEqual({ shareId: "s", visibility: "public", recipients: ["a@example.com"] });
+		await expect(client(jsonResponse(410, {})).client.update("s", {})).rejects.toBeInstanceOf(ShareRevokedError);
+		await expect(client(jsonResponse(400, { revoked: true })).client.update("s", {})).rejects.toBeInstanceOf(
+			ShareRevokedError,
+		);
+		await expect(client(jsonResponse(426, { message: "upgrade" })).client.update("s", {})).rejects.toMatchObject({
+			name: "ClientOutdatedError",
+			message: "upgrade",
+		});
+	});
+
+	it("treats revoke 404 as idempotent and encodes the share id", async () => {
+		const { client: api, fetchImpl } = client(jsonResponse(404, {}));
+		await expect(api.revoke("s/1")).resolves.toBeUndefined();
+		expect(String(vi.mocked(fetchImpl).mock.calls[0][0])).toContain("s%2F1");
+		await expect(client(jsonResponse(500, { error: "boom", message: "retry" })).client.revoke("s")).rejects.toThrow(
+			"boom — retry (HTTP 500)",
+		);
+	});
+
+	it("invites recipients and tolerates omitted response arrays", async () => {
+		const { client: api, fetchImpl } = client(jsonResponse(200, { sent: ["a@example.com"], failed: [] }));
+		await expect(api.invite("share", ["a@example.com"], "hello")).resolves.toEqual({
+			sent: ["a@example.com"],
+			failed: [],
+		});
+		expect(JSON.parse(String(vi.mocked(fetchImpl).mock.calls[0][1]?.body))).toEqual({
+			recipients: ["a@example.com"],
+			message: "hello",
+		});
+		await expect(client(new Response(null, { status: 204 })).client.invite("share", [])).resolves.toEqual({
+			sent: [],
+			failed: [],
+		});
+	});
+
+	it("filters malformed organization members and degrades failures to empty", async () => {
+		await expect(
+			client(
+				jsonResponse(200, {
+					members: [
+						{ name: "Alice", email: " alice@example.com " },
+						{ name: 42, email: "bob@example.com" },
+						{ name: "Missing email" },
+						null,
+					],
+				}),
+			).client.listOrgMembers(),
+		).resolves.toEqual([
+			{ name: "Alice", email: "alice@example.com" },
+			{ name: "", email: "bob@example.com" },
+		]);
+		await expect(client(jsonResponse(500, {})).client.listOrgMembers()).resolves.toEqual([]);
+		await expect(client(async () => Promise.reject(new Error("offline"))).client.listOrgMembers()).resolves.toEqual(
+			[],
+		);
+	});
+
+	it("requires either an override or a URL-bearing API key", async () => {
+		const api = new JolliShareClient("old-key", undefined, vi.fn() as unknown as typeof fetch);
+		await expect(api.create(payload)).rejects.toThrow("Jolli site URL could not be determined");
+	});
+});

--- a/cli/src/core/JolliShareClient.ts
+++ b/cli/src/core/JolliShareClient.ts
@@ -1,0 +1,219 @@
+import { JOLLI_CLIENT_HEADER } from "./ClientHeader.js";
+import { parseBaseUrl, parseJolliApiKey } from "./JolliApiUtils.js";
+import { currentTraceHeader, newTraceHeader, TRACE_HEADER_NAME } from "./TraceContext.js";
+
+export interface LiveSharePayload {
+	readonly repoUrl: string;
+	readonly repoName: string;
+	readonly branch: string;
+	readonly kind: string;
+	readonly visibility: string;
+	readonly decisionCount: number;
+	readonly headCommitHash: string;
+	readonly commitHashes: readonly string[];
+	readonly branchSlug?: string;
+	readonly ref: unknown;
+	readonly recipients?: readonly string[];
+}
+
+export interface LiveShareResult {
+	readonly shareId: string;
+	readonly shareUrl: string;
+	readonly expiresAt: string;
+	readonly visibility: string;
+	readonly token?: string;
+	readonly recipients?: readonly string[];
+}
+
+export interface LiveSharePatch {
+	readonly visibility?: string;
+	readonly expiresAt?: string;
+	readonly ref?: unknown;
+	readonly recipients?: readonly string[];
+}
+
+export interface LiveShareUpdateResult {
+	readonly shareId?: string;
+	readonly shareUrl?: string;
+	readonly expiresAt?: string;
+	readonly visibility?: string;
+	readonly token?: string;
+	readonly recipients?: readonly string[];
+}
+
+export class ShareRevokedError extends Error {
+	constructor(message = "This share has been stopped.") {
+		super(message);
+		this.name = "ShareRevokedError";
+	}
+}
+
+type JsonObject = Record<string, unknown>;
+
+function stringValue(json: JsonObject, key: string): string | undefined {
+	return typeof json[key] === "string" ? json[key] : undefined;
+}
+
+function identifierValue(json: JsonObject, key: string): string | undefined {
+	const value = json[key];
+	if (typeof value === "string") return value;
+	return typeof value === "number" && Number.isFinite(value) ? String(value) : undefined;
+}
+
+function stringList(json: JsonObject, key: string): string[] | undefined {
+	const value = json[key];
+	return Array.isArray(value) && value.every((item) => typeof item === "string") ? value : undefined;
+}
+
+function errorMessage(status: number, json: JsonObject | undefined, raw: string): string {
+	const detail = [json && stringValue(json, "error"), json && stringValue(json, "message")]
+		.filter((value): value is string => Boolean(value))
+		.join(" — ");
+	return `${detail || "request failed"} (HTTP ${status})${json ? "" : `: ${raw.slice(0, 200)}`}`;
+}
+
+export class JolliShareClient {
+	constructor(
+		private readonly apiKey: string,
+		private readonly baseUrlOverride?: string,
+		private readonly fetchImpl: typeof fetch = fetch,
+	) {}
+
+	async create(payload: LiveSharePayload): Promise<LiveShareResult> {
+		const { status, json, raw } = await this.request("POST", "/api/share/branch", payload);
+		if (status >= 200 && status < 300) {
+			const shareId = json && identifierValue(json, "shareId");
+			const shareUrl = json && stringValue(json, "shareUrl");
+			if (!shareId || !shareUrl) {
+				throw new Error(
+					`Share endpoint returned an unexpected response (missing shareId/shareUrl). HTTP ${status}: ${raw.slice(0, 300)}`,
+				);
+			}
+			return {
+				shareId,
+				shareUrl,
+				expiresAt: stringValue(json, "expiresAt") ?? "",
+				visibility: stringValue(json, "visibility") ?? payload.visibility,
+				...(stringValue(json, "token") ? { token: stringValue(json, "token") } : {}),
+				...(stringList(json, "recipients") ? { recipients: stringList(json, "recipients") } : {}),
+			};
+		}
+		throw this.toError(status, json, raw);
+	}
+
+	async update(shareId: string, patch: LiveSharePatch): Promise<LiveShareUpdateResult> {
+		const { status, json, raw } = await this.request(
+			"PATCH",
+			`/api/share/branch/${encodeURIComponent(shareId)}`,
+			patch,
+		);
+		if (status >= 200 && status < 300 && json) {
+			const responseShareId = identifierValue(json, "shareId");
+			return {
+				...(responseShareId ? { shareId: responseShareId } : {}),
+				...(stringValue(json, "shareUrl") ? { shareUrl: stringValue(json, "shareUrl") } : {}),
+				...(stringValue(json, "expiresAt") ? { expiresAt: stringValue(json, "expiresAt") } : {}),
+				...(stringValue(json, "visibility") ? { visibility: stringValue(json, "visibility") } : {}),
+				...(stringValue(json, "token") ? { token: stringValue(json, "token") } : {}),
+				...(stringList(json, "recipients") ? { recipients: stringList(json, "recipients") } : {}),
+			};
+		}
+		throw this.toError(status, json, raw);
+	}
+
+	async revoke(shareId: string): Promise<void> {
+		const { status, json, raw } = await this.request("DELETE", `/api/share/branch/${encodeURIComponent(shareId)}`);
+		if (status === 200 || status === 204 || status === 404) return;
+		throw this.toError(status, json, raw);
+	}
+
+	async invite(
+		shareId: string,
+		recipients: readonly string[],
+		message?: string,
+	): Promise<{ sent: string[]; failed: string[] }> {
+		const { status, json, raw } = await this.request(
+			"POST",
+			`/api/share/branch/${encodeURIComponent(shareId)}/invite`,
+			{
+				recipients,
+				...(message ? { message } : {}),
+			},
+		);
+		if (status >= 200 && status < 300) {
+			return {
+				sent: (json && stringList(json, "sent")) ?? [],
+				failed: (json && stringList(json, "failed")) ?? [],
+			};
+		}
+		throw this.toError(status, json, raw);
+	}
+
+	async listOrgMembers(): Promise<Array<{ name: string; email: string }>> {
+		try {
+			const { status, json } = await this.request("GET", "/api/jolli-memory/org-members");
+			if (status < 200 || status >= 300 || !json || !Array.isArray(json.members)) return [];
+			return json.members.flatMap((row) => {
+				if (typeof row !== "object" || row === null || Array.isArray(row)) return [];
+				const member = row as JsonObject;
+				const email = stringValue(member, "email")?.trim();
+				return email ? [{ name: stringValue(member, "name") ?? "", email }] : [];
+			});
+		} catch {
+			return [];
+		}
+	}
+
+	private resolveBaseUrl(): string {
+		const baseUrl = this.baseUrlOverride ?? parseJolliApiKey(this.apiKey)?.u;
+		if (!baseUrl)
+			throw new Error(
+				"Jolli site URL could not be determined. Please regenerate your Jolli API Key and set it again.",
+			);
+		return baseUrl;
+	}
+
+	private async request(
+		method: string,
+		path: string,
+		body?: unknown,
+	): Promise<{ status: number; json?: JsonObject; raw: string }> {
+		const baseUrl = this.resolveBaseUrl();
+		const parsed = parseBaseUrl(baseUrl);
+		const keyMeta = parseJolliApiKey(this.apiKey);
+		const headers: Record<string, string> = {
+			authorization: `Bearer ${this.apiKey}`,
+			"x-jolli-client": JOLLI_CLIENT_HEADER,
+			[TRACE_HEADER_NAME]: currentTraceHeader() ?? newTraceHeader(),
+		};
+		if (body !== undefined) headers["content-type"] = "application/json";
+		if (parsed.tenantSlug) headers["x-tenant-slug"] = parsed.tenantSlug;
+		if (keyMeta?.o) headers["x-org-slug"] = keyMeta.o;
+		const response = await this.fetchImpl(new URL(path, parsed.origin), {
+			method,
+			headers,
+			...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+			signal: AbortSignal.timeout(method === "DELETE" || method === "GET" ? 30_000 : 60_000),
+		});
+		const raw = await response.text();
+		let json: JsonObject | undefined;
+		try {
+			const parsedBody: unknown = raw ? JSON.parse(raw) : undefined;
+			if (typeof parsedBody === "object" && parsedBody !== null && !Array.isArray(parsedBody))
+				json = parsedBody as JsonObject;
+		} catch {
+			// The status mapper includes a bounded raw response when JSON is malformed.
+		}
+		return { status: response.status, json, raw };
+	}
+
+	private toError(status: number, json: JsonObject | undefined, raw: string): Error {
+		if (status === 410 || json?.revoked === true) return new ShareRevokedError();
+		if (status === 426) {
+			const error = new Error(stringValue(json ?? {}, "message") ?? "Client outdated — update Jolli Memory.");
+			error.name = "ClientOutdatedError";
+			return error;
+		}
+		return new Error(errorMessage(status, json, raw));
+	}
+}

--- a/cli/src/core/MetadataManager.ts
+++ b/cli/src/core/MetadataManager.ts
@@ -12,6 +12,7 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { createLogger } from "../Logger.js";
+import type { SummaryIndex } from "../Types.js";
 import { tryMarkHiddenOnWindows } from "../util/WindowsHidden.js";
 import type { BranchesJson, BranchMapping, KBConfig, Manifest, ManifestEntry, MigrationState } from "./KBTypes.js";
 import { toForwardSlash } from "./PathUtils.js";
@@ -272,6 +273,11 @@ export class MetadataManager {
 				(e.parentCommitHash === null || typeof e.parentCommitHash === "string") &&
 				e.parentCommitHash === null,
 		);
+	}
+
+	/** Full index DTO for IDE display adapters. */
+	readIndex(): SummaryIndex | null {
+		return this.readJson<SummaryIndex>(this.indexPath);
 	}
 
 	// ── Config ─────────────────────────────────────────────────────────────

--- a/cli/src/core/PinStore.ts
+++ b/cli/src/core/PinStore.ts
@@ -24,6 +24,8 @@ export interface PinEntry {
 	readonly id: string;
 	readonly title: string;
 	readonly pinnedAt: number;
+	/** Optional compact badge supplied by UI hosts (IntelliJ uses source-specific badges). */
+	readonly badge?: string;
 	/** Only populated for kind === 'conversation'. Identifies the transcript provider. */
 	readonly source?: string;
 	/** Only populated for kind === 'conversation'. Absolute path to the transcript file. */
@@ -65,7 +67,10 @@ function asPinEntryArray(v: unknown): PinEntry[] {
 			PIN_KINDS.has(p.kind) &&
 			typeof p.id === "string" &&
 			typeof p.title === "string" &&
-			typeof p.pinnedAt === "number"
+			typeof p.pinnedAt === "number" &&
+			(p.badge === undefined || typeof p.badge === "string") &&
+			(p.source === undefined || typeof p.source === "string") &&
+			(p.transcriptPath === undefined || typeof p.transcriptPath === "string")
 		);
 	});
 }

--- a/cli/src/core/PrDescription.test.ts
+++ b/cli/src/core/PrDescription.test.ts
@@ -13,6 +13,8 @@ import {
 	MARKER_END,
 	MARKER_START,
 	pickPrTitle,
+	replaceMarkerRegion,
+	replaceSummaryInBody,
 	wrapWithMarkers,
 } from "./PrDescription.js";
 import { getSummary } from "./SummaryStore.js";
@@ -60,6 +62,45 @@ describe("buildPrBodyMarkdown", () => {
 describe("wrapWithMarkers", () => {
 	it("wraps with start/end markers", () => {
 		expect(wrapWithMarkers("X")).toBe("<!-- jollimemory-summary-start -->\nX\n<!-- jollimemory-summary-end -->");
+	});
+});
+
+describe("replaceSummaryInBody", () => {
+	it("replaces the managed region while preserving surrounding text", () => {
+		expect(
+			replaceSummaryInBody(
+				"Before\n\n<!-- jollimemory-summary-start -->\nOld\n<!-- jollimemory-summary-end -->\n\nAfter",
+				"New",
+			),
+		).toBe("Before\n\n<!-- jollimemory-summary-start -->\nNew\n<!-- jollimemory-summary-end -->\n\nAfter");
+	});
+
+	it("appends a managed region when none exists", () => {
+		expect(replaceSummaryInBody("Manual", "Generated")).toBe(
+			"Manual\n\n<!-- jollimemory-summary-start -->\nGenerated\n<!-- jollimemory-summary-end -->",
+		);
+	});
+});
+
+describe("replaceMarkerRegion", () => {
+	it("accepts a block that is already wrapped", () => {
+		expect(replaceMarkerRegion("Manual", wrapWithMarkers("Generated"))).toBe(
+			"Manual\n\n<!-- jollimemory-summary-start -->\nGenerated\n<!-- jollimemory-summary-end -->",
+		);
+	});
+
+	// Regression: String.prototype.replace's SECOND arg is a substitution pattern
+	// when it's a string ($&/$$/$`/$'/$n are all parsed). LLM summaries commonly
+	// contain `$` (money like `$$100`, sed snippets like `s/x/$&/g`, backtick
+	// hints). Passing the block as a string would silently corrupt the PR body;
+	// the fix uses a function replacer so every `$` sequence stays literal.
+	it("treats $ sequences in the wrapped block as literals (not substitution patterns)", () => {
+		const current = `Before\n\n${MARKER_START}\nOLD\n${MARKER_END}\n\nAfter`;
+		const payload = "Costs $$100. Use sed s/x/$&/g. Also $` and $' and $1.";
+		const wrapped = wrapWithMarkers(payload);
+		expect(replaceMarkerRegion(current, wrapped)).toBe(
+			`Before\n\n${MARKER_START}\n${payload}\n${MARKER_END}\n\nAfter`,
+		);
 	});
 });
 

--- a/cli/src/core/PrDescription.ts
+++ b/cli/src/core/PrDescription.ts
@@ -17,10 +17,33 @@ import { getSummary } from "./SummaryStore.js";
 
 export const MARKER_START = "<!-- jollimemory-summary-start -->";
 export const MARKER_END = "<!-- jollimemory-summary-end -->";
+const MARKER_PATTERN = new RegExp(
+	`${MARKER_START.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[\\s\\S]*?${MARKER_END.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
+);
 
 /** Wraps markdown content with start/end markers (idempotent PR updates). */
 export function wrapWithMarkers(markdown: string): string {
 	return `${MARKER_START}\n${markdown}\n${MARKER_END}`;
+}
+
+/**
+ * Replaces the managed marker region with an already-wrapped block.
+ *
+ * Uses a function replacer, not a string, so `$` sequences inside the wrapped
+ * summary markdown (`$&`, `$$`, `` $` ``, `$'`, `$n`) are treated as literals
+ * rather than `String.prototype.replace` substitution patterns — otherwise a
+ * summary containing e.g. `$$100`, a sed snippet `s/x/$&/g`, or a backtick
+ * pattern would silently corrupt the PR body (fold in the old marker region,
+ * swallow a `$`, etc.). Mirrors the Kotlin lambda form in PrService.kt.
+ */
+export function replaceMarkerRegion(currentBody: string, wrappedBlock: string): string {
+	if (MARKER_PATTERN.test(currentBody)) return currentBody.replace(MARKER_PATTERN, () => wrappedBlock);
+	return currentBody ? `${currentBody}\n\n${wrappedBlock}` : wrappedBlock;
+}
+
+/** Replaces the managed marker region, or appends one while preserving user-authored text. */
+export function replaceSummaryInBody(currentBody: string, newMarkdown: string): string {
+	return replaceMarkerRegion(currentBody, wrapWithMarkers(newMarkdown));
 }
 
 /**

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/CliDaemonClient.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/CliDaemonClient.kt
@@ -1,0 +1,473 @@
+package ai.jolli.jollimemory.bridge
+
+import ai.jolli.jollimemory.core.JmLogger
+import com.google.gson.JsonElement
+import com.google.gson.JsonNull
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import java.io.BufferedReader
+import java.io.File
+import java.io.IOException
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Long-lived NDJSON connection to `jolli ide-bridge-serve`. Amortises Node's
+ * cold-start (~500ms - 2s) across every IntelliJ ide-bridge call by keeping
+ * one process alive per project. Idle calls drop to ~5-20ms wall clock, so a
+ * button click that previously stalled the EDT past IntelliJ's 300ms slow-EDT
+ * threshold now returns fast enough to feel instant.
+ *
+ * Ownership + lifecycle:
+ *   - One instance per Project (@Service(Level.PROJECT)); registered in
+ *     META-INF/plugin.xml. Disposable — dispose() destroys the daemon.
+ *   - Lazy start: the Node process is spawned on the first successful call().
+ *     A subsequent call whose daemon process is dead, or whose bundled CLI
+ *     dist has been re-extracted at a new version, respawns transparently.
+ *   - Reader thread and stderr-drain thread are daemon threads so they never
+ *     block JVM shutdown; every in-flight future is failed on process death
+ *     or on dispose so callers unblock instead of hanging on their own
+ *     timeout.
+ *
+ * Wire protocol: see [PROTOCOL] and cli/src/commands/IdeBridgeCommand.ts.
+ */
+@Service(Service.Level.PROJECT)
+class CliDaemonClient(private val project: Project) : Disposable {
+
+	private val log = JmLogger.create("CliDaemonClient")
+
+	private val nextId = AtomicLong(0)
+	private val processRef = AtomicReference<DaemonProcess?>()
+	private val disposed = AtomicBoolean(false)
+	private val startLock = Any()
+
+	/**
+	 * A snapshot of one live daemon and its associated request state. `inFlight`
+	 * is deliberately per-daemon (not global on the enclosing service) so that
+	 * a dying daemon's [onProcessDeath] only fails ITS OWN in-flight futures.
+	 * Without this scoping, a late-firing death of a replaced daemon (dist
+	 * version bumped, or handshake-timeout destroyForcibly) would trample the
+	 * fresh futures owned by the newly-spawned successor and make the caller
+	 * retry a non-idempotent request (squash, force-push, …).
+	 */
+	private data class DaemonProcess(
+		val process: Process,
+		val writer: OutputStreamWriter,
+		val readerThread: Thread,
+		val stderrThread: Thread,
+		val distVersion: String,
+		val readyFuture: CompletableFuture<JsonObject>,
+		val inFlight: ConcurrentHashMap<Long, CompletableFuture<JsonElement>>,
+	)
+
+	/**
+	 * Runs one action against the daemon and returns the `result` element the
+	 * caller would receive from a one-shot [CliIntegrations.runIdeBridge]
+	 * spawn — same shape, so the rewire in [CliIntegrations] can prefer this
+	 * transparently.
+	 *
+	 * Throws [CliIntegrations.CliBridgeException] when the daemon returns an
+	 * `error` envelope. Throws [RuntimeException] on any local failure
+	 * (daemon unavailable, timeout, process died mid-request, writer broke).
+	 * Never returns null.
+	 */
+	fun call(action: String, cwd: String, requestJson: String?, timeoutSeconds: Long): JsonElement {
+		if (disposed.get()) throw IllegalStateException("CliDaemonClient is disposed")
+		// Resolve the daemon FIRST so we can register the future in that
+		// daemon's own inFlight map — this is what scopes onProcessDeath.
+		val daemon = ensureDaemonStarted()
+		val id = nextId.incrementAndGet()
+		val future = CompletableFuture<JsonElement>()
+		daemon.inFlight[id] = future
+		try {
+			val payload = buildRequestLine(id, action, cwd, requestJson)
+			try {
+				synchronized(daemon.writer) {
+					daemon.writer.write(payload)
+					daemon.writer.write("\n")
+					daemon.writer.flush()
+				}
+			} catch (e: IOException) {
+				// Writer broke (usually: daemon died between calls). Force a
+				// full reset so the next call spawns a fresh process instead
+				// of trying to reuse a dead one, then rethrow. The reset only
+				// touches THIS daemon's inFlight, so a concurrent call that
+				// already registered against a NEW daemon is unaffected.
+				onProcessDeath(daemon.process, daemon.inFlight, "writer broke: ${e.message}")
+				throw RuntimeException("Failed to write to CLI daemon: ${e.message}", e)
+			}
+			val envelope = try {
+				future.get(timeoutSeconds, TimeUnit.SECONDS).asJsonObject
+			} catch (e: TimeoutException) {
+				// Distinct type so [CliIntegrations.runIdeBridge] can propagate
+				// instead of retrying via one-shot spawn — the daemon is still
+				// running the action, and a retry would double-execute any
+				// side-effectful operation (sync push, store-summary write, …).
+				throw CliDaemonTimeoutException(
+					"CLI daemon action '$action' timed out after ${timeoutSeconds}s",
+				)
+			} catch (e: ExecutionException) {
+				throw e.cause ?: e
+			}
+			return unwrapResponseEnvelope(envelope)
+		} finally {
+			daemon.inFlight.remove(id)
+		}
+	}
+
+	private fun buildRequestLine(id: Long, action: String, cwd: String, requestJson: String?): String =
+		serializeRequestLine(id, action, cwd, requestJson)
+
+	private fun ensureDaemonStarted(): DaemonProcess {
+		val cur = processRef.get()
+		if (cur != null && cur.process.isAlive && cur.distVersion == currentDistVersion()) return cur
+		synchronized(startLock) {
+			// Re-check disposed under the lock so we cannot race with dispose():
+			// a caller that passed the top-level `disposed.get()` gate can still
+			// arrive here after dispose() ran, and without this re-check we would
+			// spawn a Node process into a disposed service that nothing destroys.
+			if (disposed.get()) throw IllegalStateException("CliDaemonClient is disposed")
+			val cur2 = processRef.get()
+			if (cur2 != null && cur2.process.isAlive && cur2.distVersion == currentDistVersion()) return cur2
+			// Kill any stale/mismatched process so we don't leak, then start fresh.
+			cur2?.let { destroy(it) }
+			processRef.set(null)
+			val started = startDaemon()
+			// Second disposal check — dispose() could have flipped between our
+			// startLock acquisition and the handshake completing. If so, destroy
+			// the just-spawned daemon rather than orphaning it.
+			if (disposed.get()) {
+				destroy(started)
+				throw IllegalStateException("CliDaemonClient disposed during startup")
+			}
+			processRef.set(started)
+			return started
+		}
+	}
+
+	private fun startDaemon(): DaemonProcess {
+		val node = CliIntegrations.resolveNode()
+			?: throw RuntimeException(
+				"Node.js not found — required for Jolli Memory. Install Node.js and reopen the project.",
+			)
+		val cliJs = CliIntegrations.resolveCliJs()
+			?: throw RuntimeException("The bundled CLI was not found. Try reinstalling Jolli Memory.")
+		val distVersion = currentDistVersion()
+		val basePath = project.basePath?.let { File(it).absolutePath } ?: File(".").absolutePath
+		val pb = ProcessBuilder(node, cliJs.absolutePath, "ide-bridge-serve", "--cwd", basePath)
+			.directory(File(basePath))
+			.redirectErrorStream(false)
+		// Marker for diagnostics — `ps -ef | grep JOLLI_IDE_BRIDGE_SERVE`
+		// pinpoints our daemon vs any other node process.
+		pb.environment()["JOLLI_IDE_BRIDGE_SERVE"] = "1"
+		val proc = pb.start()
+		val readyFuture = CompletableFuture<JsonObject>()
+		// Per-daemon inFlight — created here and captured by the reader thread's
+		// closure. The successor daemon's map is a distinct instance, so a
+		// late-dying predecessor can only ever fail its own futures.
+		val inFlight = ConcurrentHashMap<Long, CompletableFuture<JsonElement>>()
+		val writer = OutputStreamWriter(proc.outputStream, StandardCharsets.UTF_8)
+		val reader = BufferedReader(InputStreamReader(proc.inputStream, StandardCharsets.UTF_8))
+		val readerThread = Thread({ readLoop(reader, proc, inFlight, readyFuture) }, "JolliCliDaemon-reader").apply {
+			isDaemon = true
+			start()
+		}
+		val stderrThread = Thread({ drainStderr(proc) }, "JolliCliDaemon-stderr").apply {
+			isDaemon = true
+			start()
+		}
+		// Bound handshake wait so a broken daemon fails fast — better than every
+		// downstream call paying its own timeout waiting for a process that
+		// never speaks. 5 s is generous vs a ~500 ms cold start on Node 22.
+		val handshake = try {
+			readyFuture.get(5, TimeUnit.SECONDS)
+		} catch (e: TimeoutException) {
+			proc.destroyForcibly()
+			throw RuntimeException("CLI daemon did not send a handshake within 5s — check ~/.jolli/logs")
+		} catch (e: ExecutionException) {
+			proc.destroyForcibly()
+			throw RuntimeException("CLI daemon handshake failed: ${e.cause?.message ?: e.message}", e.cause)
+		}
+		// JSON-RPC 2.0 notification: fields live inside `params`, not top-level.
+		val handshakeParams = handshake.get("params")?.takeIf { it.isJsonObject }?.asJsonObject
+			?: JsonObject()
+		val protocol = handshakeParams.get("protocol")?.asString
+		if (protocol != PROTOCOL) {
+			proc.destroyForcibly()
+			throw RuntimeException(
+				"CLI daemon speaks protocol '$protocol' but this plugin expects '$PROTOCOL'. " +
+					"Try reinstalling Jolli Memory.",
+			)
+		}
+		val pid = handshakeParams.get("pid")?.asInt ?: -1
+		val ver = handshakeParams.get("pluginVersion")?.asString ?: "?"
+		log.info("CLI daemon started: pid=%d pluginVersion=%s distVersion=%s", pid, ver, distVersion)
+		return DaemonProcess(proc, writer, readerThread, stderrThread, distVersion, readyFuture, inFlight)
+	}
+
+	private fun readLoop(
+		reader: BufferedReader,
+		proc: Process,
+		inFlight: ConcurrentHashMap<Long, CompletableFuture<JsonElement>>,
+		readyFuture: CompletableFuture<JsonObject>,
+	) {
+		try {
+			reader.use {
+				var line = it.readLine()
+				while (line != null) {
+					dispatchLine(line, inFlight, readyFuture)
+					line = it.readLine()
+				}
+			}
+		} catch (e: IOException) {
+			log.warn("Daemon reader IO error: %s", e.message)
+		}
+		onProcessDeath(proc, inFlight, "stdout EOF")
+	}
+
+	private fun dispatchLine(
+		line: String,
+		inFlight: ConcurrentHashMap<Long, CompletableFuture<JsonElement>>,
+		readyFuture: CompletableFuture<JsonObject>,
+	) {
+		if (line.isBlank()) return
+		val obj = try {
+			JsonParser.parseString(line).asJsonObject
+		} catch (_: Exception) {
+			log.warn("Skipping unparseable daemon line: %s", line.take(200))
+			return
+		}
+		val idElem = obj.get("id")
+		if (idElem == null || idElem.isJsonNull) {
+			// JSON-RPC 2.0 server→client notification (no `id`). The
+			// ide-bridge-serve process reuses the same stdout for
+			// request/response pairs and for refresh notifications from its
+			// internal fs.watch, so we route by the notification's `method`.
+			val method = obj.get("method")?.asString
+			when (method) {
+				"ready" -> if (!readyFuture.isDone) readyFuture.complete(obj)
+				"refresh" -> dispatchRefresh(obj)
+				else -> log.warn("Received unaddressed line from daemon (method=%s)", method)
+			}
+			return
+		}
+		val id = try {
+			idElem.asLong
+		} catch (_: Exception) {
+			log.warn("Received line with non-numeric id: %s", idElem)
+			return
+		}
+		val fut = inFlight.remove(id)
+		if (fut == null) {
+			// Caller already timed out. Not a bug, just late.
+			log.info("Daemon response for id=%d has no waiter (already returned to caller)", id)
+			return
+		}
+		fut.complete(obj)
+	}
+
+	/**
+	 * Turns one JSON-RPC 2.0 `refresh` notification from ide-bridge-serve into
+	 * a fan-out to every plugin listener via [DaemonNotificationClient].
+	 * Keeping the fan-out in that service (instead of a per-client listener
+	 * list here) means every UI consumer registered before the JSON-RPC
+	 * upgrade stays wired without a single import change.
+	 *
+	 * The fan-out runs on a pooled thread so a heavy listener never blocks
+	 * THIS reader thread — which also carries every request/response line for
+	 * concurrent bridge calls. Without the pool hop a listener that reads a
+	 * file synchronously would stall every in-flight future.
+	 *
+	 * Wire shape: `{"jsonrpc":"2.0","method":"refresh","params":{"kind":<k>,"cwd":<p>}}`.
+	 */
+	private fun dispatchRefresh(obj: JsonObject) {
+		val params = obj.get("params")?.takeIf { it.isJsonObject }?.asJsonObject ?: return
+		val kind = params.get("kind")?.asString ?: return
+		val cwd = params.get("cwd")?.asString ?: ""
+		ApplicationManager.getApplication().executeOnPooledThread {
+			try {
+				project.getService(DaemonNotificationClient::class.java)
+					?.injectRefresh(RefreshEvent(kind, cwd))
+			} catch (e: Exception) {
+				log.warn("Failed to inject refresh: %s", e.message)
+			}
+		}
+	}
+
+	private fun drainStderr(proc: Process) {
+		try {
+			proc.errorStream.bufferedReader(StandardCharsets.UTF_8).use { r ->
+				var line = r.readLine()
+				while (line != null) {
+					// Truncate loud stack traces so a runaway daemon does not
+					// flood the plugin log; keep enough head to diagnose.
+					log.info("[daemon-stderr] %s", line.take(500))
+					line = r.readLine()
+				}
+			}
+		} catch (_: IOException) {
+			// Stream closed on process exit — expected.
+		}
+	}
+
+	private fun onProcessDeath(
+		proc: Process,
+		inFlight: ConcurrentHashMap<Long, CompletableFuture<JsonElement>>,
+		why: String,
+	) {
+		val exitCode = runCatching { proc.exitValue() }.getOrNull()
+		log.warn("CLI daemon process died (why=%s exit=%s)", why, exitCode?.toString() ?: "still running")
+		// Fail ONLY this daemon's own in-flight futures — the new successor
+		// daemon's futures live in a separate map, so a late-firing death of
+		// the predecessor cannot trample them. Snapshot + clear keeps a
+		// simultaneous caller's `future.get()` from returning stale.
+		val snapshot = HashMap(inFlight)
+		inFlight.clear()
+		val ex = RuntimeException("CLI daemon process exited (why=$why, exit=$exitCode)")
+		for ((_, fut) in snapshot) fut.completeExceptionally(ex)
+		// Clear processRef only if this dying daemon is still the current one;
+		// on a version-bump respawn processRef already points to the successor
+		// and we leave it alone.
+		val cur = processRef.get()
+		if (cur != null && cur.process === proc) processRef.compareAndSet(cur, null)
+	}
+
+	private fun currentDistVersion(): String {
+		val stamp = File(CliIntegrations.distIntellijDir(), ".version")
+		return runCatching { stamp.readText().trim() }.getOrDefault("")
+	}
+
+	override fun dispose() {
+		if (!disposed.compareAndSet(false, true)) return
+		// Serialize disposal against [ensureDaemonStarted] under the same lock
+		// so a caller that raced past the `disposed.get()` gate cannot leak a
+		// freshly-spawned Node process into a torn-down service. The inner
+		// re-checks in [ensureDaemonStarted] will trip once we return.
+		synchronized(startLock) {
+			val cur = processRef.getAndSet(null)
+			cur?.let { d ->
+				val snapshot = HashMap(d.inFlight)
+				d.inFlight.clear()
+				val ex = RuntimeException("CliDaemonClient disposed")
+				for ((_, fut) in snapshot) fut.completeExceptionally(ex)
+				destroy(d)
+			}
+		}
+	}
+
+	private fun destroy(daemon: DaemonProcess) {
+		// Closing stdin lets the daemon exit cleanly through its readline
+		// `close` event — the CLI side then drains outstanding responses in
+		// `Promise.all(pending)` before returning from `runIdeBridgeServe`.
+		// We deliberately do NOT call `daemon.process.destroy()` as an
+		// intermediate step: on Windows the JDK maps that to `TerminateProcess`,
+		// an immediate hard kill that would race the stdin-EOF drain and cut
+		// off in-flight write handlers (store-summary, sync push) mid-operation.
+		// stdin close alone is the graceful signal on all three platforms; the
+		// 2 s wait then `destroyForcibly()` covers a stuck daemon.
+		runCatching { daemon.writer.close() }
+		if (!daemon.process.waitFor(2, TimeUnit.SECONDS)) {
+			runCatching { daemon.process.destroyForcibly() }
+		}
+	}
+
+	/**
+	 * A daemon call exceeded its per-call [timeoutSeconds] budget. Distinct
+	 * from a plain [RuntimeException] because the daemon is STILL processing
+	 * the action — the caller must not retry via the one-shot spawn fallback,
+	 * which would double-execute side-effectful operations (sync push,
+	 * store-summary write, force-push, …). [CliIntegrations.runIdeBridge]
+	 * catches this specifically and rethrows instead of falling through.
+	 */
+	class CliDaemonTimeoutException(message: String) : RuntimeException(message)
+
+	companion object {
+		/**
+		 * Wire protocol expected from the CLI. Must match IDE_BRIDGE_PROTOCOL
+		 * in cli/src/commands/IdeBridgeCommand.ts. Bump both together when the
+		 * envelope shape changes so an old dist paired with a new plugin
+		 * (or vice versa) fails loudly at handshake instead of silently
+		 * misbehaving.
+		 */
+		const val PROTOCOL: String = "jolli-ide-bridge-jsonrpc-v1"
+
+		fun getInstance(project: Project): CliDaemonClient =
+			project.getService(CliDaemonClient::class.java)
+
+		/**
+		 * Formats one request as a JSON-RPC 2.0 request line — one JSON object
+		 * with `jsonrpc:"2.0"` / `id` / `method` / `params:{cwd, request}` and
+		 * no trailing newline. Exposed so unit tests can assert the wire shape
+		 * without spawning a daemon. `requestJson` may be null or blank; both
+		 * mean an empty request body.
+		 */
+		internal fun serializeRequestLine(
+			id: Long,
+			action: String,
+			cwd: String,
+			requestJson: String?,
+		): String {
+			// The server contract is "request is a JSON object" — a top-level
+			// array or primitive would silently ship as `"request": [1,2,3]`
+			// and only fail on the daemon side, robbing the caller of a
+			// stack-local error. Reject at serialisation time instead.
+			val body: JsonElement = if (requestJson.isNullOrBlank()) {
+				JsonObject()
+			} else {
+				val parsed = JsonParser.parseString(requestJson)
+				require(parsed.isJsonObject) {
+					"Request body must be a JSON object (got: ${parsed.javaClass.simpleName})"
+				}
+				parsed
+			}
+			val params = JsonObject().apply {
+				addProperty("cwd", cwd)
+				add("request", body)
+			}
+			val req = JsonObject().apply {
+				addProperty("jsonrpc", "2.0")
+				addProperty("id", id)
+				addProperty("method", action)
+				add("params", params)
+			}
+			// Gson's default toString serialises without newlines — protocol-safe.
+			return req.toString()
+		}
+
+		/**
+		 * Reads one JSON-RPC 2.0 response envelope (as produced by
+		 * IdeBridgeCommand.ts `computeServeResponse`) and returns the `result`
+		 * element the caller would receive from a one-shot
+		 * [CliIntegrations.runIdeBridge]. A response with a top-level `error`
+		 * object is rethrown as [CliIntegrations.CliBridgeException] with the
+		 * same fields the one-shot path already surfaces, so callers up the
+		 * stack cannot tell which path served them. Exposed so unit tests can
+		 * assert the error-mapping without any live process.
+		 */
+		internal fun unwrapResponseEnvelope(envelope: JsonObject): JsonElement {
+			val errorObj = envelope.get("error")?.takeIf { it.isJsonObject }?.asJsonObject
+			if (errorObj != null) {
+				val data = errorObj.get("data")?.takeIf { it.isJsonObject }?.asJsonObject ?: JsonObject()
+				throw CliIntegrations.CliBridgeException(
+					data.get("errorName")?.takeUnless { it.isJsonNull }?.asString,
+					errorObj.get("message")?.asString ?: "unknown CLI bridge error",
+					data,
+				)
+			}
+			return envelope.get("result") ?: JsonNull.INSTANCE
+		}
+	}
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/CliIntegrations.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/CliIntegrations.kt
@@ -15,6 +15,8 @@ object CliIntegrations {
 
     private val log = JmLogger.create("CliIntegrations")
 
+    private const val IDE_BRIDGE_TIMEOUT_SECONDS = 300L
+
     sealed class Result {
         /** Integrations set up successfully. */
         object Ok : Result()
@@ -156,10 +158,11 @@ object CliIntegrations {
      * Records a successful enable by stamping the current plugin version.
      *
      * The write is atomic (temp sibling + [java.nio.file.Files.move] with
-     * ATOMIC_MOVE) so a concurrent reader can never observe a half-truncated
-     * stamp. Without this, a reader that landed inside `writeText`'s truncate
-     * window would compare against `""` and mistakenly conclude the dist is
-     * stale.
+     * ATOMIC_MOVE) so a concurrent reader — [CliDaemonClient.currentDistVersion]
+     * runs on every daemon call() — can never observe a half-truncated stamp.
+     * Without this, a reader that landed inside `writeText`'s truncate window
+     * would compare the daemon's cached distVersion against `""`, decide the
+     * daemon was stale, tear it down, and pull every in-flight future with it.
      */
     internal fun markIntegrationsEnabled(distDir: File) {
         try {
@@ -457,6 +460,184 @@ object CliIntegrations {
     }
 
     /**
+     * Runs one hidden `jolli ide-bridge <action>` JSON request. Domain behavior
+     * stays in `cli/src`; Kotlin callers only serialize DTOs and consume the
+     * returned `result` element.
+     */
+    fun runIdeBridge(
+        projectDir: String,
+        action: String,
+        requestJson: String? = null,
+        timeoutSeconds: Long = IDE_BRIDGE_TIMEOUT_SECONDS,
+    ): com.google.gson.JsonElement {
+        // Prefer the long-lived daemon when the caller's project has one bound.
+        // A daemon call is ~5-20ms vs a one-shot spawn's ~500ms-2s cold start,
+        // so this shift is what pulls hot-path bridge reads (config-load,
+        // status, session-state, etc.) below IntelliJ's 300ms slow-EDT floor.
+        // A real business-logic error propagates as [CliBridgeException] —
+        // same shape as before so callers up the stack don't care which path
+        // ran. Any local failure (daemon crashed, protocol mismatch, socket
+        // broke) is logged and falls through to the legacy one-shot spawn so
+        // the request still completes.
+        findDaemonForCwd(projectDir)?.let { client ->
+            try {
+                return client.call(action, projectDir, requestJson, timeoutSeconds)
+            } catch (e: CliBridgeException) {
+                throw e
+            } catch (e: CliDaemonClient.CliDaemonTimeoutException) {
+                // Timeout means the daemon is STILL running the action. A
+                // one-shot fallback would spawn a second Node process that
+                // starts the same action fresh, so a side-effectful op
+                // (sync push, store-summary, force-push) would run twice.
+                // Surface the timeout instead — the daemon's own guarantee
+                // is the same as the legacy one-shot path once the wait
+                // budget is exhausted.
+                throw e
+            } catch (e: Exception) {
+                log.warn("CLI daemon call failed, falling back to one-shot spawn: %s", e.message)
+            }
+        }
+        val node = resolveNode()
+            ?: throw RuntimeException("Node.js not found — it is required for Jolli Memory. Install Node.js and reopen the project.")
+        val cliJs = resolveCliJs()
+            ?: throw RuntimeException("The bundled CLI was not found in the plugin. Try reinstalling Jolli Memory.")
+        val outFile = File.createTempFile("jolli-ide-bridge-", ".json")
+        try {
+            val proc = ProcessBuilder(node, cliJs.absolutePath, "ide-bridge", action, "--cwd", projectDir)
+                .directory(File(projectDir))
+                .redirectOutput(outFile)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
+                .start()
+            proc.outputStream.use { stdin ->
+                if (requestJson != null) stdin.write(requestJson.toByteArray(Charsets.UTF_8))
+            }
+            if (!proc.waitFor(timeoutSeconds, TimeUnit.SECONDS)) {
+                proc.destroyForcibly()
+                throw RuntimeException("CLI bridge action '$action' timed out after ${timeoutSeconds}s")
+            }
+            val line = outFile.readText(Charsets.UTF_8).lineSequence().lastOrNull { it.isNotBlank() }
+                ?: throw RuntimeException("CLI bridge action '$action' produced no output (exit ${proc.exitValue()})")
+            val obj = try {
+                JsonParser.parseString(line).asJsonObject
+            } catch (_: Exception) {
+                throw RuntimeException("CLI bridge action '$action' returned unreadable output: ${line.take(200)}")
+            }
+            // JSON-RPC 2.0 wire: success has `result`, failure has `error: {code, message, data}`.
+            val errorObj = obj.get("error")?.takeIf { it.isJsonObject }?.asJsonObject
+            if (errorObj != null) {
+                val data = errorObj.get("data")?.takeIf { it.isJsonObject }?.asJsonObject
+                    ?: com.google.gson.JsonObject()
+                throw CliBridgeException(
+                    data.get("errorName")?.takeUnless { it.isJsonNull }?.asString,
+                    errorObj.get("message")?.asString ?: "unknown CLI bridge error",
+                    data,
+                )
+            }
+            if (proc.exitValue() != 0) {
+                throw RuntimeException("CLI bridge action '$action' failed (exit ${proc.exitValue()})")
+            }
+            return obj.get("result") ?: com.google.gson.JsonNull.INSTANCE
+        } finally {
+            outFile.delete()
+        }
+    }
+
+    /**
+     * Locates a working `Cli.js` by the same 4-step chain the one-shot bridge
+     * has always used: installed plugin dist → workspace dev checkout → the
+     * previously-extracted intellij dist → freshly re-extract from the plugin
+     * jar. Consolidated here so [runIdeBridge] and [CliDaemonClient] use one
+     * lookup and can never drift.
+     */
+    internal fun resolveCliJs(): File? =
+        resolveBundledCliJs()
+            ?: resolveDevelopmentCliJs()
+            ?: File(distIntellijDir(), "Cli.js").takeIf { it.exists() }
+            ?: extractCliDist()?.let { File(it, "Cli.js") }
+
+    /**
+     * Unit tests and local Gradle runs execute classes outside an installed plugin,
+     * so there is no `<plugin>/cli-dist`. Reuse the freshly built workspace CLI in
+     * that environment. Installed plugins always resolve [resolveBundledCliJs]
+     * first and never enter this development-only lookup.
+     */
+    private fun resolveDevelopmentCliJs(): File? {
+        val workingDir = File(System.getProperty("user.dir"))
+        return sequenceOf(
+            File(workingDir, "cli/dist/Cli.js"),
+            File(workingDir, "../cli/dist/Cli.js"),
+        ).firstOrNull { it.isFile }
+    }
+
+    /**
+     * Locates the [CliDaemonClient] whose project owns [projectDir], or null
+     * when no matching open Project has a daemon service attached.
+     *
+     * A project has TWO valid "cwds": `project.basePath` (where IntelliJ was
+     * pointed) and the main git worktree root the plugin resolved during
+     * startup (`JolliMemoryService.mainRepoRoot`). These two can be
+     * completely disjoint filesystem paths when the IDE opened a *linked*
+     * worktree — the mainRepoRoot is `.../repo` while basePath is
+     * `.../repo-feature`, and neither is a prefix of the other. Every
+     * hot-path caller in the audit passes `service.mainRepoRoot ?: basePath`,
+     * so we must be able to match either form; otherwise the daemon quietly
+     * falls through to one-shot spawns for the majority of clicks.
+     *
+     * Matching per candidate: direct canonical equality, then either-way
+     * prefix containment (covers a caller cwd that is a subdirectory of the
+     * project root, and the rarer reverse). We use `getServiceIfCreated` to
+     * read `mainRepoRoot` — creating JolliMemoryService here would trigger
+     * its heavy `initialize()` from an ide-bridge call, which is not the
+     * responsibility of this cheap lookup.
+     *
+     * A no-match returns null so [runIdeBridge] falls through to the
+     * one-shot spawn path without incident.
+     */
+    private fun findDaemonForCwd(projectDir: String): CliDaemonClient? {
+        if (projectDir.isBlank()) return null
+        val cwdCanon = runCatching { File(projectDir).canonicalPath }.getOrNull() ?: return null
+        val projects = try {
+            com.intellij.openapi.project.ProjectManager.getInstance().openProjects
+        } catch (_: Throwable) {
+            // ProjectManager not ready (very early startup) — one-shot spawn works.
+            return null
+        }
+        for (project in projects) {
+            if (project.isDisposed) continue
+            val candidates = buildList {
+                project.basePath?.let { add(it) }
+                mainRepoRootOf(project)?.let { add(it) }
+            }
+            for (raw in candidates) {
+                val candidate = runCatching { File(raw).canonicalPath }.getOrNull() ?: continue
+                val matches = candidate == cwdCanon ||
+                    cwdCanon.startsWith(candidate + File.separator) ||
+                    candidate.startsWith(cwdCanon + File.separator)
+                if (!matches) continue
+                return runCatching { project.getService(CliDaemonClient::class.java) }.getOrNull()
+            }
+        }
+        return null
+    }
+
+    /**
+     * Reads the JolliMemoryService's mainRepoRoot without forcing service
+     * creation. If the service has not been instantiated yet (very early
+     * startup) we return null and let the caller consider only basePath.
+     */
+    private fun mainRepoRootOf(project: com.intellij.openapi.project.Project): String? {
+        return try {
+            val cls = ai.jolli.jollimemory.services.JolliMemoryService::class.java
+            // `getServiceIfCreated` returns null when the service isn't already
+            // bound — safer than `getService`, which would trigger its heavy
+            // initialize() from an ide-bridge call.
+            project.getServiceIfCreated(cls)?.mainRepoRoot
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    /**
      * User-facing text for a classified CLI generation failure. The CLI tags its
      * error JSON with `errorName` (see cli/src/commands/GenerateCommand.ts); the
      * local-agent auth failure gets sign-in guidance because its raw message
@@ -469,6 +650,96 @@ object CliIntegrations {
             "Claude Code is installed but not signed in. Open a terminal, run `claude`, " +
                 "and sign in with /login — or switch the AI provider in Jolli Memory settings."
         else -> message
+    }
+
+    /** Result of one `jolli migrate-memory-bank` run — the subset the UI status lines need. */
+    data class MigrationBridgeResult(
+        val status: String,
+        val migratedEntries: Int,
+        val totalEntries: Int,
+    )
+
+    /**
+     * Wall-clock budget for one Memory Bank migration. Generous because a first
+     * migration on a large repo copies every summary / transcript / plan / note
+     * from the orphan branch onto disk; the steady-state stale-child reconcile
+     * finishes in well under a second.
+     */
+    private const val MIGRATE_TIMEOUT_SECONDS = 300L
+
+    /**
+     * Runs the orphan-branch → Memory Bank folder migration via the bundled CLI's
+     * hidden `migrate-memory-bank` command (see
+     * cli/src/commands/MigrateMemoryBankCommand.ts). This replaces the plugin's own
+     * Kotlin `MigrationEngine`: the CLI resolves the Memory Bank root from the shared
+     * config, runs the full migration when it has not completed yet, and otherwise
+     * runs the idempotent stale-child reconcile — matching the VS Code activate path.
+     *
+     * The command needs no stdin and prints a single JSON line on stdout —
+     * `{"type":"migrate-memory-bank","status":…,"migratedEntries":…,"totalEntries":…}`
+     * on success, `{"type":"error", …}` on failure. stdout is redirected to a temp
+     * file so a chatty migration log can never fill the pipe and deadlock [waitFor].
+     *
+     * Throws [RuntimeException] with a user-facing message on ANY failure (Node
+     * missing, bundle missing, timeout, CLI error) — callers surface `ex.message`.
+     */
+    fun migrateMemoryBank(projectDir: String): MigrationBridgeResult {
+        val node = resolveNode()
+            ?: throw RuntimeException(
+                "Node.js not found — it is required for Memory Bank migration. Install Node.js and reopen the project.",
+            )
+        val distDir = distIntellijDir().takeIf { File(it, "Cli.js").exists() }
+            ?: extractCliDist()
+            ?: throw RuntimeException("The bundled CLI was not found in the plugin. Try reinstalling the Jolli Memory plugin.")
+        val cliJs = File(distDir, "Cli.js")
+
+        val outFile = File.createTempFile("jolli-migrate-", ".json")
+        try {
+            val proc = ProcessBuilder(node, cliJs.absolutePath, "migrate-memory-bank", "--cwd", projectDir)
+                .directory(File(projectDir))
+                .redirectOutput(outFile)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
+                .start()
+            if (!proc.waitFor(MIGRATE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                proc.destroyForcibly()
+                throw RuntimeException("Memory Bank migration timed out after ${MIGRATE_TIMEOUT_SECONDS}s")
+            }
+            return parseMigrateResponse(outFile.readText(Charsets.UTF_8), proc.exitValue())
+        } finally {
+            outFile.delete()
+        }
+    }
+
+    /**
+     * Parses the `migrate-memory-bank` stdout contract. Split out for direct
+     * testing — the response is the LAST non-blank line so stray Node runtime
+     * output (e.g. experimental-feature warnings) cannot break it.
+     */
+    internal fun parseMigrateResponse(stdout: String, exitValue: Int): MigrationBridgeResult {
+        val line = stdout.lineSequence().lastOrNull { it.isNotBlank() }
+            ?: throw RuntimeException("Memory Bank migration produced no output (exit $exitValue)")
+        val obj = try {
+            JsonParser.parseString(line).asJsonObject
+        } catch (_: Exception) {
+            throw RuntimeException("Memory Bank migration returned unreadable output (exit $exitValue): ${line.take(200)}")
+        }
+        if (obj.get("type")?.asString == "error") {
+            // Preserve the CLI's classified errorName so downstream dialogs can
+            // route on the same key runIdeBridge already surfaces (e.g. auth
+            // failures) instead of degrading to a generic RuntimeException.
+            throw CliBridgeException(
+                obj.get("errorName")?.takeUnless { it.isJsonNull }?.asString,
+                obj.get("message")?.asString ?: "unknown error",
+            )
+        }
+        if (exitValue != 0) {
+            throw RuntimeException("Memory Bank migration failed (exit $exitValue)")
+        }
+        val status = obj.get("status")?.asString ?: "unknown"
+        val migrated = obj.get("migratedEntries")?.asInt ?: 0
+        val total = obj.get("totalEntries")?.asInt ?: 0
+        log.info("migrate-memory-bank succeeded: %s (%d/%d)", status, migrated, total)
+        return MigrationBridgeResult(status, migrated, total)
     }
 
     /**
@@ -553,5 +824,11 @@ object CliIntegrations {
             log.warn("Failed to run bundled CLI %s (non-fatal): %s", label, e.message)
             Result.Failed(e.message ?: "unknown")
         }
-	}
+    }
+
+    class CliBridgeException(
+        val errorName: String?,
+        message: String,
+        val details: com.google.gson.JsonObject = com.google.gson.JsonObject(),
+    ) : RuntimeException(message)
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/DaemonNotificationClient.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/DaemonNotificationClient.kt
@@ -142,11 +142,29 @@ class DaemonNotificationClient(private val project: Project) : Disposable {
         return Disposable { listeners.remove(listener) }
     }
 
-    /** Idempotent start — spawns the daemon subprocess if not already running. */
+    /**
+     * Idempotent start.
+     *
+     * In slice 2 (scheme A') a single `jolli ide-bridge-serve` process carries
+     * both request/response traffic and `refresh` notifications, and that
+     * process is owned by [CliDaemonClient]. This class no longer spawns its
+     * own daemon; it stays alive purely as the plugin-wide refresh-listener
+     * registry. [CliDaemonClient] calls [injectRefresh] whenever its stdout
+     * carries a refresh line, and every previously registered
+     * [addRefreshListener] callback keeps working unchanged.
+     */
     fun start() {
         if (stopped.get()) return
-        if (!started.compareAndSet(false, true)) return
-        spawnDaemon()
+        started.compareAndSet(false, true)
+    }
+
+    /**
+     * Fires the given event to every registered listener. Invoked by
+     * [CliDaemonClient] when its long-lived ide-bridge-serve stdout emits a
+     * `refresh` notification.
+     */
+    fun injectRefresh(event: RefreshEvent) {
+        onRefresh(event)
     }
 
     private fun spawnDaemon() {

--- a/intellij/src/main/resources/META-INF/plugin.xml
+++ b/intellij/src/main/resources/META-INF/plugin.xml
@@ -35,10 +35,20 @@
         <projectService
             serviceImplementation="ai.jolli.jollimemory.services.JolliMemoryService"/>
 
-        <!-- Slice-1 daemon channel: spawns `jolli daemon` and dispatches refresh
-             notifications to JolliMemoryService.refreshStatus. -->
+        <!-- Refresh-listener registry. In scheme A' this no longer spawns its own
+             daemon subprocess; CliDaemonClient owns the single ide-bridge-serve
+             process and injects `refresh` events into this service, so every
+             previously wired addRefreshListener callback keeps working unchanged. -->
         <projectService
             serviceImplementation="ai.jolli.jollimemory.bridge.DaemonNotificationClient"/>
+
+        <!-- Long-lived NDJSON connection to `jolli ide-bridge-serve`. Amortises Node
+             cold-start across every ide-bridge call so panel refreshes and action
+             clicks return in ~5-20 ms instead of ~500 ms - 2 s. The same stdio
+             stream also delivers server-pushed `refresh` notifications, which this
+             client injects into DaemonNotificationClient. -->
+        <projectService
+            serviceImplementation="ai.jolli.jollimemory.bridge.CliDaemonClient"/>
 
         <!-- Tool window: sidebar with collapsible STATUS, MEMORIES, PLANS & NOTES, CHANGES panels -->
         <toolWindow

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/CliDaemonClientTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/CliDaemonClientTest.kt
@@ -1,0 +1,241 @@
+package ai.jolli.jollimemory.bridge
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonNull
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [CliDaemonClient]'s wire helpers. Spawning a real daemon
+ * requires a built Cli.js and a Node runtime, so those paths are integration
+ * territory; the pieces asserted here are the ones that would silently rot
+ * without being noticed — the JSON-RPC 2.0 envelope on the way in and the way
+ * out.
+ */
+class CliDaemonClientTest {
+
+	// ── PROTOCOL — lockstep with cli/src/commands/IdeBridgeCommand.ts ──────
+	// If this value ever drifts, every ide-bridge call the plugin makes
+	// falls back to one-shot spawns (the handshake check in [startDaemon]
+	// rejects a mismatched daemon), so the daemon speedup silently
+	// disappears. Bump both together.
+
+	@Test
+	fun `PROTOCOL is the stable named version`() {
+		CliDaemonClient.PROTOCOL shouldBe "jolli-ide-bridge-jsonrpc-v1"
+	}
+
+	// ── serializeRequestLine — wire shape of every request ────────────────
+
+	@Test
+	fun `serializeRequestLine emits a single-line JSON-RPC 2_0 request`() {
+		val line = CliDaemonClient.serializeRequestLine(
+			id = 7L,
+			action = "session-state",
+			cwd = "/tmp/repo",
+			requestJson = """{"operation":"config-load"}""",
+		)
+		// Protocol invariant: exactly one JSON object per line.
+		line shouldNotContain "\n"
+		val obj = JsonParser.parseString(line).asJsonObject
+		obj.get("jsonrpc").asString shouldBe "2.0"
+		obj.get("id").asLong shouldBe 7L
+		obj.get("method").asString shouldBe "session-state"
+		val params = obj.getAsJsonObject("params")
+		params.get("cwd").asString shouldBe "/tmp/repo"
+		params.getAsJsonObject("request").get("operation").asString shouldBe "config-load"
+	}
+
+	@Test
+	fun `serializeRequestLine treats a null request body as an empty object (not a missing field)`() {
+		// A missing `request` field would make the server-side normaliseServeRequest
+		// happy too, but the invariant we want is "always present so downstream
+		// code can just index into it." Assert it.
+		val line = CliDaemonClient.serializeRequestLine(1L, "status", "/tmp/x", null)
+		val obj = JsonParser.parseString(line).asJsonObject
+		val params = obj.getAsJsonObject("params")
+		params.has("request") shouldBe true
+		params.getAsJsonObject("request").size() shouldBe 0
+	}
+
+	@Test
+	fun `serializeRequestLine treats a blank request body identically to null`() {
+		val a = CliDaemonClient.serializeRequestLine(1L, "status", "/tmp/x", null)
+		val b = CliDaemonClient.serializeRequestLine(1L, "status", "/tmp/x", "")
+		val c = CliDaemonClient.serializeRequestLine(1L, "status", "/tmp/x", "   \t\n ")
+		a shouldBe b
+		b shouldBe c
+	}
+
+	@Test
+	fun `serializeRequestLine round-trips an already-serialized JSON body`() {
+		// The Kotlin caller side (SummaryStore.run, PinStore.run, etc.) hands
+		// us a preserialized JSON string. It must round-trip losslessly.
+		val body = """{"operation":"filter-hashes","hashes":["aaaa1111","bbbb2222"]}"""
+		val line = CliDaemonClient.serializeRequestLine(3L, "summary-store", "/tmp/x", body)
+		val obj = JsonParser.parseString(line).asJsonObject
+		val request = obj.getAsJsonObject("params").getAsJsonObject("request")
+		request.get("operation").asString shouldBe "filter-hashes"
+		val arr = request.get("hashes") as JsonArray
+		arr.size() shouldBe 2
+		arr[0].asString shouldBe "aaaa1111"
+		arr[1].asString shouldBe "bbbb2222"
+	}
+
+	@Test
+	fun `serializeRequestLine rejects a body that is not a JSON object (top-level array)`() {
+		// A JSON array top level would be ambiguous — the server contract is
+		// "a JSON object" — so we surface parse-time failure loudly rather
+		// than shipping a wrong payload the daemon would then reject.
+		val ex = assertThrows(IllegalArgumentException::class.java) {
+			CliDaemonClient.serializeRequestLine(1L, "x", "/tmp/x", "[1,2,3]")
+		}
+		ex.message!! shouldContain "JSON object"
+	}
+
+	@Test
+	fun `serializeRequestLine rejects a top-level primitive`() {
+		// String / number / boolean bodies are the same wire-shape violation
+		// as an array — reject them at serialise time for the same reason.
+		assertThrows(IllegalArgumentException::class.java) {
+			CliDaemonClient.serializeRequestLine(1L, "x", "/tmp/x", "\"just a string\"")
+		}
+		assertThrows(IllegalArgumentException::class.java) {
+			CliDaemonClient.serializeRequestLine(1L, "x", "/tmp/x", "42")
+		}
+	}
+
+	// ── unwrapResponseEnvelope — error / success mapping ──────────────────
+
+	@Test
+	fun `unwrapResponseEnvelope returns the result element on success`() {
+		val env = JsonObject().apply {
+			addProperty("jsonrpc", "2.0")
+			addProperty("id", 5L)
+			add("result", JsonObject().apply { addProperty("enabled", true) })
+		}
+		val res = CliDaemonClient.unwrapResponseEnvelope(env).asJsonObject
+		res.get("enabled").asBoolean shouldBe true
+	}
+
+	@Test
+	fun `unwrapResponseEnvelope returns JsonNull when success has no result field`() {
+		// The CLI passes `undefined` through as an absent field; the wrapper
+		// normalises that to JsonNull.INSTANCE so callers can assume the
+		// element is never null-in-Kotlin.
+		val env = JsonObject().apply {
+			addProperty("jsonrpc", "2.0")
+			addProperty("id", 5L)
+		}
+		CliDaemonClient.unwrapResponseEnvelope(env) shouldBe JsonNull.INSTANCE
+	}
+
+	@Test
+	fun `unwrapResponseEnvelope rethrows an error envelope as CliBridgeException`() {
+		val env = JsonObject().apply {
+			addProperty("jsonrpc", "2.0")
+			addProperty("id", 5L)
+			add(
+				"error",
+				JsonObject().apply {
+					addProperty("code", -32000)
+					addProperty("message", "No LLM provider available.")
+					add("data", JsonObject().apply { addProperty("errorName", "SomeError") })
+				},
+			)
+		}
+		val ex = assertThrows(CliIntegrations.CliBridgeException::class.java) {
+			CliDaemonClient.unwrapResponseEnvelope(env)
+		}
+		ex.message shouldBe "No LLM provider available."
+		ex.errorName shouldBe "SomeError"
+	}
+
+	@Test
+	fun `unwrapResponseEnvelope surfaces optional data as an empty JsonObject when absent`() {
+		val env = JsonObject().apply {
+			addProperty("jsonrpc", "2.0")
+			addProperty("id", 5L)
+			add(
+				"error",
+				JsonObject().apply {
+					addProperty("code", -32000)
+					addProperty("message", "boom")
+				},
+			)
+		}
+		val ex = assertThrows(CliIntegrations.CliBridgeException::class.java) {
+			CliDaemonClient.unwrapResponseEnvelope(env)
+		}
+		ex.details.size() shouldBe 0
+	}
+
+	@Test
+	fun `unwrapResponseEnvelope surfaces error data when the CLI returned it`() {
+		val data = JsonObject().apply {
+			addProperty("errorName", "AuthFailure")
+			addProperty("kind", "auth")
+			addProperty("retryable", false)
+		}
+		val env = JsonObject().apply {
+			addProperty("jsonrpc", "2.0")
+			addProperty("id", 5L)
+			add(
+				"error",
+				JsonObject().apply {
+					addProperty("code", -32000)
+					addProperty("message", "auth failed")
+					add("data", data)
+				},
+			)
+		}
+		val ex = assertThrows(CliIntegrations.CliBridgeException::class.java) {
+			CliDaemonClient.unwrapResponseEnvelope(env)
+		}
+		ex.details.get("kind").asString shouldBe "auth"
+		ex.details.get("retryable").asBoolean shouldBe false
+	}
+
+	@Test
+	fun `unwrapResponseEnvelope tolerates a JsonNull errorName inside data`() {
+		// The CLI writes errorName as undefined when the thrown value is not
+		// an Error subclass. Gson serialises that as JSON `null`. The wrapper
+		// must not turn "explicit null" into the literal string "null".
+		val env = JsonObject().apply {
+			addProperty("jsonrpc", "2.0")
+			add(
+				"error",
+				JsonObject().apply {
+					addProperty("code", -32000)
+					addProperty("message", "plain failure")
+					add("data", JsonObject().apply { add("errorName", JsonNull.INSTANCE) })
+				},
+			)
+		}
+		val ex = assertThrows(CliIntegrations.CliBridgeException::class.java) {
+			CliDaemonClient.unwrapResponseEnvelope(env)
+		}
+		ex.errorName shouldBe null
+	}
+
+	// ── PROTOCOL parity with the CLI ──────────────────────────────────────
+	// A soft double-check that the Kotlin side of the handshake matches the
+	// TypeScript constant. Reading the CLI source is a fragile test in isolation,
+	// but the value is short and stable, so we cross-check by string here — a
+	// grep-visible early warning if someone bumps only one side.
+
+	@Test
+	fun `PROTOCOL matches the value literal declared in IdeBridgeCommand ts`() {
+		// This is deliberately duplicated from the previous test as a
+		// grep target: search for the literal string to find every location
+		// that must be bumped together.
+		CliDaemonClient.PROTOCOL shouldBe "jolli-ide-bridge-jsonrpc-v1"
+		CliDaemonClient.PROTOCOL shouldNotBe ""
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -551,29 +551,6 @@
 				"node": ">=14.21.3"
 			}
 		},
-		"node_modules/@emnapi/core": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.1",
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@emnapi/runtime": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
 		"node_modules/@emnapi/wasi-threads": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -3816,6 +3793,7 @@
 			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
 			"integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=16.9.0"
 			}
@@ -6510,6 +6488,7 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -7177,6 +7156,7 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
 			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/vscode/src/services/PrCommentService.ts
+++ b/vscode/src/services/PrCommentService.ts
@@ -39,10 +39,17 @@ const MARKER_PATTERN = new RegExp(
  * existing marker region in place, or appends when the body has no markers
  * yet. Everything outside the marker region (manual description, checklist,
  * reviewer notes, …) is preserved verbatim.
+ *
+ * Uses a function replacer, not a string, so `$` sequences inside the wrapped
+ * summary markdown (`$&`, `$$`, `` $` ``, `$'`, `$n`) are treated as literals
+ * rather than `String.prototype.replace` substitution patterns — otherwise a
+ * summary containing e.g. `$$100`, a sed snippet `s/x/$&/g`, or a backtick
+ * pattern would silently corrupt the PR body (fold in the old marker region,
+ * swallow a `$`, etc.). Kept lockstep with the CLI + Kotlin implementations.
  */
 function replaceMarkerRegion(currentBody: string, wrappedBlock: string): string {
 	if (MARKER_PATTERN.test(currentBody)) {
-		return currentBody.replace(MARKER_PATTERN, wrappedBlock);
+		return currentBody.replace(MARKER_PATTERN, () => wrappedBlock);
 	}
 	return currentBody ? `${currentBody}\n\n${wrappedBlock}` : wrappedBlock;
 }


### PR DESCRIPTION
## Summary

Slice-2 read-path work: a long-lived NDJSON bridge between IntelliJ and the CLI, plus the supporting store, migration, and share surface, all covered by unit tests.

- **CLI** — Add hidden `jolli ide-bridge` (one-shot) and `jolli ide-bridge-serve` (long-lived NDJSON server) that expose the TS core to non-Node IDE hosts, plus `jolli migrate-memory-bank` (explicit re-migrate into a fresh `-N`-suffixed folder) and a `JolliShareClient` HTTP client for the live-share endpoints. Small tweaks in `MetadataManager`, `PinStore`, and `PrDescription` for the new callers.
- **IntelliJ** — Introduce `CliDaemonClient` (owns the single `ide-bridge-serve` Node process, demuxes responses from server-pushed `refresh` notifications) and route every prior CLI spawn through it via `CliIntegrations`, `DaemonNotificationClient`, and `plugin.xml`. Panel refreshes and action clicks now return in ~5–20 ms instead of ~500 ms – 2 s.
- **Tests** — `DaemonCommand.ts`, `IdeBridgeRegistration.ts`, and `IdeBridgeCommand.ts` reach 100% statements / branches / functions / lines. Every dispatcher action (`auth`, `jolli-api`, `pricing`, `shared-store`, `summary-store`, `summary-tree`, `plan-grouping`, `reference-store`, `kb`, `storage`, `git-*`, `telemetry-*`), the one-shot envelope path, and the long-lived server (including its refresh-watcher retry loop and process-level guards) are all exercised.

## Test plan

- [ ] `npm run all` at the repo root passes (clean → build → lint → test with the CLI's 97/96/97/97 coverage floor)
- [ ] `npx vitest run --no-coverage src/commands/DaemonCommand.test.ts src/commands/IdeBridgeRegistration.test.ts src/commands/IdeBridgeCommand.test.ts` from `cli/` — the three targeted files
- [ ] `cd intellij && ./gradlew test` — Kotlin `CliDaemonClientTest` and friends
- [ ] Manual smoke: install the IntelliJ plugin locally, open a Jolli-enabled project, and confirm the sidebar panel populates without the ~1 s spawn latency on every click