### PR TITLE
Limit graph-edges LLM fan-out to 1 under local-agent provider

### DIFF
--- a/cli/src/graph/GraphDistiller.test.ts
+++ b/cli/src/graph/GraphDistiller.test.ts
@@ -413,6 +413,95 @@ describe("distillGraph", () => {
 	});
 });
 
+// The edge phase fans out one graph-edges call per category. Under the
+// local-agent provider each call spawns a real CLI agent process, so it must
+// serialize to 1 like every other LLM fan-out; under a network provider it may
+// run categories in parallel. A tracker on the graph-edges mock records the peak
+// number of concurrently in-flight calls.
+describe("edge distillation fan-out", () => {
+	function fourCategoryInput(): DistillInput {
+		return {
+			topics: [1, 2, 3, 4].map((n) => ({
+				slug: `t${n}`,
+				title: `Topic${n}`,
+				summary: `s${n}`,
+				content: `b${n}`,
+			})),
+		};
+	}
+
+	// Each topic sits in its own category and carries two units, so every category
+	// batch has >=2 units and triggers a real graph-edges call — a genuine
+	// four-wide fan-out to observe (distillEdges skips the LLM below two units).
+	function setupFourCategories(onEdges: () => Promise<void>): void {
+		const twoUnits = (p: string) =>
+			JSON.stringify({
+				units: [
+					{ id: `${p}a`, kind: "decision", shortTitle: "A", summary: "s" },
+					{ id: `${p}b`, kind: "mechanism", shortTitle: "B", summary: "s" },
+				],
+			});
+		callLlm.mockImplementation(async (opts: { action: string; params: Record<string, string> }) => {
+			if (opts.action === "graph-categories")
+				return {
+					text: JSON.stringify({
+						categories: [1, 2, 3, 4].map((n) => ({ id: `cat${n}`, shortTitle: `C${n}`, summary: "c" })),
+						topics: [1, 2, 3, 4].map((n) => ({
+							slug: `t${n}`,
+							title: `Topic${n}`,
+							shortTitle: `T${n}`,
+							summary: "s",
+							categoryId: `cat${n}`,
+						})),
+					}),
+				};
+			if (opts.action === "graph-units") {
+				const units: Record<string, string> = {
+					Topic1: twoUnits("u1"),
+					Topic2: twoUnits("u2"),
+					Topic3: twoUnits("u3"),
+					Topic4: twoUnits("u4"),
+				};
+				return { text: units[opts.params.topicTitle] ?? '{"units":[]}' };
+			}
+			if (opts.action === "graph-edges") {
+				await onEdges();
+				return { text: '{"edges":[]}', stopReason: null };
+			}
+			throw new Error(`unexpected action ${opts.action}`);
+		});
+	}
+
+	function peakTracker(): { peak: () => number; onEdges: () => Promise<void> } {
+		let inFlight = 0;
+		let max = 0;
+		return {
+			peak: () => max,
+			onEdges: async () => {
+				inFlight++;
+				max = Math.max(max, inFlight);
+				// Yield so any sibling calls that were allowed to start can overlap.
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				inFlight--;
+			},
+		};
+	}
+
+	it("serializes edge distillation to one call under the local-agent provider", async () => {
+		const t = peakTracker();
+		setupFourCategories(t.onEdges);
+		await distillGraph(fourCategoryInput(), { ...CONFIG, aiProvider: "local-agent" });
+		expect(t.peak()).toBe(1);
+	});
+
+	it("fans edge distillation out across categories under a network provider", async () => {
+		const t = peakTracker();
+		setupFourCategories(t.onEdges);
+		await distillGraph(fourCategoryInput(), { ...CONFIG, aiProvider: "anthropic" });
+		expect(t.peak()).toBeGreaterThan(1);
+	});
+});
+
 describe("distillGraphIncremental", () => {
 	function baseline(): DistilledGraph {
 		return {

--- a/cli/src/graph/GraphDistiller.ts
+++ b/cli/src/graph/GraphDistiller.ts
@@ -443,7 +443,7 @@ async function distillEdgesForCategories(
 	const targets = opts?.onlyCategories ?? [...groups.keys()];
 	const perCategory = await mapWithConcurrency(
 		targets,
-		EDGES_CONCURRENCY,
+		llmFanoutLimit(EDGES_CONCURRENCY, config),
 		(catId) => distillEdges(groups.get(catId) ?? [], config, { strict: opts?.strict }),
 		opts?.strict
 			? undefined // strict: a throw must fail the round (keep prior graph) — never swallow


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Knowledge graphs built in local-agent mode now include the full set of relationship edges between knowledge units. Connection finding now respects the same single-process limit applied to every other knowledge-building phase, and a regression test locks in that constraint going forward. The test measures peak parallelism directly during a run and fails immediately if more than one AI call fires at a time for this step under local-agent mode, making any future regression visible rather than silent.

---

## Topic (1)
<details>
<summary><strong>01 · Fix knowledge graph connections missing silently in local-agent mode</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When building a knowledge graph in local-agent mode with four or more topic categories, the step that finds relationships between knowledge units was ignoring the limit that restricts AI activity to one call at a time. Failures from the resulting parallel calls were silently discarded, leaving users with an incomplete graph and no visible error message.

**💡 Decisions Behind the Code**

- **Minimal fix over helper refactor**: Applying the existing provider-aware limit helper at the single missing call site was chosen over redesigning the helper's interface to make omissions structurally impossible. Changing the helper's signature would have required touching every call site across the codebase and amounted to a separate architectural change. The issue explicitly flagged this distinction and the developer agreed to defer it to a follow-up.
- **Regression test as the primary safety net**: A direct concurrency measurement test was added rather than relying on integration tests or manual verification, because the bug had no visible symptom in the normal (non-strict) build path — failures were swallowed and the graph appeared intact. A test that fails loudly on any future reintroduction was the lowest-cost, highest-confidence guard available, and the absence of any such test is what allowed the bug to ship undetected.

**✅ What Was Implemented**

- In `GraphDistiller.ts`, the `distillEdgesForCategories` function now passes the concurrency value through `llmFanoutLimit` before handing it to `mapWithConcurrency`, matching the pattern already used for both the full-build and incremental units distillation steps. The change is a single line and requires no new imports or parameter threading since `config` and `llmFanoutLimit` were already in scope.
- In `GraphDistiller.test.ts`, a new "edge distillation fan-out" describe block was added. It constructs a four-category input where each category holds two units (the minimum to trigger a real LLM call per category), attaches a peak-concurrency tracker to the graph-edges mock, and asserts that peak concurrency equals 1 under local-agent and is greater than 1 under a network provider. The tracker increments synchronously before any async yield, making the measurement deterministic and free of timing flakiness.

**📋 Future Enhancements**

Consider a structural guard on the concurrency helper (e.g. accept only pre-resolved limits, or assert at call boundaries) to prevent the same class of omission from appearing at a new call site. Explicitly deferred from this PR as a separate architectural change.

**📁 FILES**
- `cli/src/graph/GraphDistiller.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 27, 2026 at 10:03 AM · via Local agent*
<!-- jollimemory-summary-end -->