### PR TITLE
Enforce zero-write contract for manually disabled projects

### DIFF
--- a/cli/src/Logger.test.ts
+++ b/cli/src/Logger.test.ts
@@ -21,9 +21,11 @@ import {
 	createLogger,
 	formatLogMessage,
 	getJolliMemoryDir,
+	isManuallyDisabled,
 	resetLogDir,
 	setLogDir,
 	setLogLevel,
+	setManuallyDisabled,
 	setSilentConsole,
 } from "./Logger.js";
 
@@ -45,6 +47,7 @@ describe("Logger", () => {
 		fsMocks.unlink.mockReset();
 		resetLogDir();
 		setSilentConsole(true);
+		setManuallyDisabled(false);
 	});
 
 	describe("formatLogMessage", () => {
@@ -428,6 +431,50 @@ describe("Logger", () => {
 
 			expect(fsMocks.stat).not.toHaveBeenCalled();
 			expect(fsMocks.appendFile).not.toHaveBeenCalled();
+		});
+
+		it("should skip log file write when manuallyDisabled is true", async () => {
+			const envSpy = vi.spyOn(process, "env", "get");
+			fsMocks.stat.mockResolvedValue({});
+			fsMocks.appendFile.mockResolvedValue(undefined);
+			envSpy.mockReturnValue({ ...process.env, VITEST: "", JOLLI_DISABLE_LOG_FILE: "" });
+			setLogDir("/tmp/project");
+			setManuallyDisabled(true);
+
+			const logger = createLogger("TestMod");
+			logger.info("should not be written");
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(fsMocks.stat).not.toHaveBeenCalled();
+			expect(fsMocks.appendFile).not.toHaveBeenCalled();
+		});
+
+		it("should resume log file write after manuallyDisabled flips back to false", async () => {
+			const envSpy = vi.spyOn(process, "env", "get");
+			fsMocks.stat.mockResolvedValue({});
+			fsMocks.appendFile.mockResolvedValue(undefined);
+			envSpy.mockReturnValue({ ...process.env, VITEST: "", JOLLI_DISABLE_LOG_FILE: "" });
+			setLogDir("/tmp/project");
+			setManuallyDisabled(true);
+			setManuallyDisabled(false);
+
+			const logger = createLogger("TestMod");
+			logger.info("write resumed");
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(fsMocks.appendFile).toHaveBeenCalledOnce();
+		});
+	});
+
+	describe("setManuallyDisabled / isManuallyDisabled", () => {
+		it("reflects the latest value set", () => {
+			expect(isManuallyDisabled()).toBe(false);
+			setManuallyDisabled(true);
+			expect(isManuallyDisabled()).toBe(true);
+			setManuallyDisabled(false);
+			expect(isManuallyDisabled()).toBe(false);
 		});
 	});
 });

--- a/cli/src/Logger.ts
+++ b/cli/src/Logger.ts
@@ -76,6 +76,41 @@ export function resetLogDir(): void {
 	_logDirCwd = undefined;
 }
 
+/**
+ * In-memory mirror of the repo-wide manual-disable flag — RepoProfile's
+ * `manuallyDisabled` field in `<main-worktree>/.jolli/jollimemory/profile.json`.
+ * When true, `enqueueLogWrite` and the other write gates short-circuit.
+ *
+ * Why a mirror instead of reading the flag directly: the source of truth,
+ * `readManualDisableFlag` (RepoProfile), is async and resolves the main-worktree
+ * root via a `git rev-parse --git-common-dir` subprocess before reading and
+ * parsing profile.json. The gates here sit on synchronous hot paths —
+ * `enqueueLogWrite` runs on every log line, often inside a <5ms git/agent hook —
+ * where neither an `await` nor a per-call subprocess + file read is acceptable.
+ * So entry points read the flag once and cache it here: the VS Code extension's
+ * activate() seeds it synchronously via `readManualDisableFlagSync` before the
+ * first log call, and the enable/disable commands flip it in lockstep with the
+ * on-disk write. Each gate check is then a single boolean read.
+ *
+ * Process-local by design: CLI commands, hook scripts and the QueueWorker run
+ * in their own Node processes and never set it, so this in-memory gate is inert
+ * there. That is deliberate — disable uninstalls the git hooks, so no new
+ * hook/worker process starts while disabled; and those processes independently
+ * gate at their own entry on the async, disk-backed `readManualDisableFlag`
+ * (e.g. PostCommitHook, QueueWorker), which is the flag that counts there.
+ */
+let _manuallyDisabled = false;
+
+/** Sets the in-memory manually-disabled flag. */
+export function setManuallyDisabled(disabled: boolean): void {
+	_manuallyDisabled = disabled;
+}
+
+/** Reads the in-memory manually-disabled flag. */
+export function isManuallyDisabled(): boolean {
+	return _manuallyDisabled;
+}
+
 // ─── Log level filtering ─────────────────────────────────────────────────────
 
 const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
@@ -273,6 +308,7 @@ async function pathExists(p: string): Promise<boolean> {
  */
 function enqueueLogWrite(line: string): void {
 	if (process.env.VITEST || process.env.JOLLI_DISABLE_LOG_FILE) return;
+	if (_manuallyDisabled) return;
 
 	writeQueue = writeQueue.then(async () => {
 		try {

--- a/cli/src/core/CodexDiscovery.test.ts
+++ b/cli/src/core/CodexDiscovery.test.ts
@@ -17,6 +17,7 @@ vi.mock("./SessionTracker.js", () => ({
 	saveDiscoveryCursor: vi.fn(),
 }));
 
+import { setManuallyDisabled } from "../Logger.js";
 import { discoverCodexConversations } from "./CodexDiscovery.js";
 import { discoverCodexSessions, isCodexInstalled } from "./CodexSessionDiscoverer.js";
 import { scanPlansFrom } from "./plans/TranscriptPlanDiscovery.js";
@@ -43,6 +44,18 @@ beforeEach(() => {
 });
 
 describe("discoverCodexConversations", () => {
+	it("early-returns when the project is manually disabled (no config read, no scan, no cursor write)", async () => {
+		setManuallyDisabled(true);
+		try {
+			await discoverCodexConversations("/repo/disabled");
+			expect(loadConfig).not.toHaveBeenCalled();
+			expect(discoverCodexSessions).not.toHaveBeenCalled();
+			expect(saveDiscoveryCursor).not.toHaveBeenCalled();
+		} finally {
+			setManuallyDisabled(false);
+		}
+	});
+
 	it("early-returns when codexEnabled === false (no session scan)", async () => {
 		vi.mocked(loadConfig).mockResolvedValue({ codexEnabled: false } as never);
 		await discoverCodexConversations("/repo/a");

--- a/cli/src/core/CodexDiscovery.ts
+++ b/cli/src/core/CodexDiscovery.ts
@@ -23,7 +23,7 @@
  * and logged, so callers can `void`-call it without an unhandled rejection.
  */
 
-import { createLogger } from "../Logger.js";
+import { createLogger, isManuallyDisabled } from "../Logger.js";
 import { discoverCodexSessions, isCodexInstalled } from "./CodexSessionDiscoverer.js";
 import { scanPlansFrom } from "./plans/TranscriptPlanDiscovery.js";
 import { scanReferencesFrom } from "./references/TranscriptReferenceDiscovery.js";
@@ -67,6 +67,11 @@ async function runWithRerun(cwd: string, state: InFlight): Promise<void> {
 
 async function runOnce(cwd: string): Promise<void> {
 	try {
+		// A discovery pass persists cursors, plans and references into the
+		// project's .jolli/jollimemory/ — all disk writes a manually-disabled
+		// project must not receive (the sidebar's 60s tick keeps firing even
+		// while the disabled panel is shown).
+		if (isManuallyDisabled()) return;
 		const config = await loadConfig();
 		if (config.codexEnabled === false) return;
 		if (!(await isCodexInstalled())) return;

--- a/cli/src/core/DiscoveryCatchUp.test.ts
+++ b/cli/src/core/DiscoveryCatchUp.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	loadAllSessions: vi.fn(),
+	loadDiscoveryCursor: vi.fn(),
+	saveDiscoveryCursor: vi.fn(),
+	migrateDiscoveryCursors: vi.fn(),
+	scanPlansFrom: vi.fn(),
+	scanReferencesFrom: vi.fn(),
+	existsSync: vi.fn(),
+}));
+
+vi.mock("./SessionTracker.js", () => ({
+	loadAllSessions: mocks.loadAllSessions,
+	loadDiscoveryCursor: mocks.loadDiscoveryCursor,
+	saveDiscoveryCursor: mocks.saveDiscoveryCursor,
+	migrateDiscoveryCursors: mocks.migrateDiscoveryCursors,
+}));
+
+vi.mock("./plans/TranscriptPlanDiscovery.js", () => ({
+	scanPlansFrom: mocks.scanPlansFrom,
+}));
+
+vi.mock("./references/TranscriptReferenceDiscovery.js", () => ({
+	scanReferencesFrom: mocks.scanReferencesFrom,
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return { ...actual, existsSync: mocks.existsSync };
+});
+
+import { setManuallyDisabled } from "../Logger.js";
+import { catchUpTranscriptDiscovery } from "./DiscoveryCatchUp.js";
+
+describe("catchUpTranscriptDiscovery", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		setManuallyDisabled(false);
+		mocks.migrateDiscoveryCursors.mockResolvedValue(undefined);
+		mocks.loadDiscoveryCursor.mockResolvedValue({ transcriptPath: "/t.jsonl", lineNumber: 0 });
+		mocks.saveDiscoveryCursor.mockResolvedValue(undefined);
+		mocks.scanPlansFrom.mockResolvedValue(10);
+		mocks.scanReferencesFrom.mockResolvedValue(10);
+		mocks.existsSync.mockReturnValue(true);
+	});
+
+	afterEach(() => {
+		setManuallyDisabled(false);
+	});
+
+	it("no-ops without scanning when the project is manually disabled", async () => {
+		setManuallyDisabled(true);
+		mocks.loadAllSessions.mockResolvedValue([{ transcriptPath: "/a.jsonl" }]);
+
+		const result = await catchUpTranscriptDiscovery("/project");
+
+		expect(result).toEqual({ scanned: 0 });
+		expect(mocks.loadAllSessions).not.toHaveBeenCalled();
+		expect(mocks.scanPlansFrom).not.toHaveBeenCalled();
+	});
+
+	it("returns scanned:0 and swallows a loadAllSessions failure", async () => {
+		mocks.loadAllSessions.mockRejectedValue(new Error("read error"));
+
+		const result = await catchUpTranscriptDiscovery("/project");
+
+		expect(result).toEqual({ scanned: 0 });
+		expect(mocks.scanPlansFrom).not.toHaveBeenCalled();
+	});
+
+	it("scans a claude transcript and advances the cursor when lines were unscanned", async () => {
+		mocks.loadAllSessions.mockResolvedValue([{ transcriptPath: "/a.jsonl", source: "claude" }]);
+		mocks.loadDiscoveryCursor.mockResolvedValue({ transcriptPath: "/a.jsonl", lineNumber: 3 });
+		mocks.scanReferencesFrom.mockResolvedValue(12);
+
+		const result = await catchUpTranscriptDiscovery("/project");
+
+		expect(mocks.scanPlansFrom).toHaveBeenCalledWith("/a.jsonl", 3, "/project", "claude");
+		expect(mocks.scanReferencesFrom).toHaveBeenCalledWith("/a.jsonl", 3, "/project", "claude");
+		expect(mocks.saveDiscoveryCursor).toHaveBeenCalledWith(
+			expect.objectContaining({ transcriptPath: "/a.jsonl", lineNumber: 12 }),
+			"/project",
+		);
+		expect(result).toEqual({ scanned: 1 });
+	});
+
+	it("defaults the cursor to 0 when no cursor exists yet", async () => {
+		mocks.loadAllSessions.mockResolvedValue([{ transcriptPath: "/a.jsonl" }]);
+		mocks.loadDiscoveryCursor.mockResolvedValue(null);
+
+		await catchUpTranscriptDiscovery("/project");
+
+		expect(mocks.scanPlansFrom).toHaveBeenCalledWith("/a.jsonl", 0, "/project", "claude");
+	});
+
+	it("passes the gemini source through for gemini sessions", async () => {
+		mocks.loadAllSessions.mockResolvedValue([{ transcriptPath: "/g.jsonl", source: "gemini" }]);
+		mocks.scanReferencesFrom.mockResolvedValue(5);
+
+		await catchUpTranscriptDiscovery("/project");
+
+		expect(mocks.scanPlansFrom).toHaveBeenCalledWith("/g.jsonl", 0, "/project", "gemini");
+	});
+
+	it("skips codex sessions (they self-recover on the sidebar tick)", async () => {
+		mocks.loadAllSessions.mockResolvedValue([{ transcriptPath: "/c.jsonl", source: "codex" }]);
+
+		const result = await catchUpTranscriptDiscovery("/project");
+
+		expect(mocks.scanPlansFrom).not.toHaveBeenCalled();
+		expect(result).toEqual({ scanned: 0 });
+	});
+
+	it("skips sessions whose transcript file is missing", async () => {
+		mocks.loadAllSessions.mockResolvedValue([{ transcriptPath: "/gone.jsonl" }]);
+		mocks.existsSync.mockReturnValue(false);
+
+		const result = await catchUpTranscriptDiscovery("/project");
+
+		expect(mocks.scanPlansFrom).not.toHaveBeenCalled();
+		expect(result).toEqual({ scanned: 0 });
+	});
+
+	it("does NOT advance the cursor when the plan scan throws", async () => {
+		mocks.loadAllSessions.mockResolvedValue([{ transcriptPath: "/a.jsonl" }]);
+		mocks.scanPlansFrom.mockRejectedValue(new Error("plan boom"));
+		mocks.scanReferencesFrom.mockResolvedValue(20);
+
+		const result = await catchUpTranscriptDiscovery("/project");
+
+		expect(mocks.saveDiscoveryCursor).not.toHaveBeenCalled();
+		expect(result).toEqual({ scanned: 0 });
+	});
+
+	it("does NOT advance the cursor when the reference scan throws (line stays at fromLine)", async () => {
+		mocks.loadAllSessions.mockResolvedValue([{ transcriptPath: "/a.jsonl" }]);
+		mocks.loadDiscoveryCursor.mockResolvedValue({ transcriptPath: "/a.jsonl", lineNumber: 7 });
+		mocks.scanReferencesFrom.mockRejectedValue(new Error("ref boom"));
+
+		const result = await catchUpTranscriptDiscovery("/project");
+
+		expect(mocks.saveDiscoveryCursor).not.toHaveBeenCalled();
+		expect(result).toEqual({ scanned: 0 });
+	});
+
+	it("does NOT advance when there are no new lines (referenceLine === fromLine)", async () => {
+		mocks.loadAllSessions.mockResolvedValue([{ transcriptPath: "/a.jsonl" }]);
+		mocks.loadDiscoveryCursor.mockResolvedValue({ transcriptPath: "/a.jsonl", lineNumber: 9 });
+		mocks.scanReferencesFrom.mockResolvedValue(9);
+
+		const result = await catchUpTranscriptDiscovery("/project");
+
+		expect(mocks.saveDiscoveryCursor).not.toHaveBeenCalled();
+		expect(result).toEqual({ scanned: 0 });
+	});
+
+	it("swallows a per-session failure (loadDiscoveryCursor throws) and continues", async () => {
+		mocks.loadAllSessions.mockResolvedValue([{ transcriptPath: "/bad.jsonl" }, { transcriptPath: "/good.jsonl" }]);
+		mocks.loadDiscoveryCursor
+			.mockRejectedValueOnce(new Error("cursor read boom"))
+			.mockResolvedValueOnce({ transcriptPath: "/good.jsonl", lineNumber: 0 });
+		mocks.scanReferencesFrom.mockResolvedValue(4);
+
+		const result = await catchUpTranscriptDiscovery("/project");
+
+		// First session failed, second succeeded.
+		expect(result).toEqual({ scanned: 1 });
+		expect(mocks.saveDiscoveryCursor).toHaveBeenCalledWith(
+			expect.objectContaining({ transcriptPath: "/good.jsonl", lineNumber: 4 }),
+			"/project",
+		);
+	});
+});

--- a/cli/src/core/DiscoveryCatchUp.ts
+++ b/cli/src/core/DiscoveryCatchUp.ts
@@ -1,0 +1,112 @@
+/**
+ * DiscoveryCatchUp — re-runs incremental plan + reference discovery for the
+ * agent-hook-recorded sessions in `sessions.json`.
+ *
+ * Scope: this helper only enumerates sessions recorded in `sessions.json`.
+ * In current production paths, that registry is populated by the Claude hooks
+ * (StopHook and PluginBootstrapHook) and GeminiAfterAgentHook. Cursor, OpenCode,
+ * Devin, Copilot, Cline, Antigravity, and Codex sessions are discovered on
+ * demand and are not persisted there, so this helper does not enumerate them.
+ * Codex has a separate cursor-based recovery path in the sidebar discovery tick
+ * and is skipped defensively below.
+ *
+ * Why this exists: while a project is manually disabled, the agent hooks are
+ * uninstalled and the VS Code-side write gates are active, so neither the
+ * StopHook transcript scan nor the plans-dir watcher (`registerNewPlan`) can
+ * register plans/references produced during that window. The StopHook path is
+ * cursor-driven (`discovery-cursors.json`), and the cursor freezes while
+ * disabled — so a future turn in the same transcript would eventually re-scan
+ * the disabled window. But a session that sees no further turns after re-enable
+ * would never be re-scanned, silently dropping any plan/reference authored
+ * during the disabled window.
+ *
+ * The enable command calls this once after releasing the flag to determinist-
+ * ically drain that backlog: for each eligible file-backed session in
+ * `sessions.json` it scans from the frozen cursor forward and advances the
+ * shared cursor. Idempotent — already-scanned lines are never re-processed, so
+ * a no-backlog catch-up performs no writes.
+ *
+ * Codex sessions are intentionally skipped: they are driven by the sidebar's
+ * 60s Active Conversations tick (`CodexDiscovery`), whose cursor also froze
+ * while disabled, so they self-recover on the next tick after re-enable.
+ */
+
+import { existsSync } from "node:fs";
+import { createLogger, isManuallyDisabled } from "../Logger.js";
+import { scanPlansFrom } from "./plans/TranscriptPlanDiscovery.js";
+import { scanReferencesFrom } from "./references/TranscriptReferenceDiscovery.js";
+import {
+	loadAllSessions,
+	loadDiscoveryCursor,
+	migrateDiscoveryCursors,
+	saveDiscoveryCursor,
+} from "./SessionTracker.js";
+
+const log = createLogger("DiscoveryCatchUp");
+
+/**
+ * Re-runs the StopHook-style incremental discovery for all of the project's
+ * known session transcripts. Returns the number of transcripts whose cursor
+ * actually advanced (i.e. that had unscanned lines). Never rejects.
+ */
+export async function catchUpTranscriptDiscovery(cwd: string): Promise<{ scanned: number }> {
+	// Defensive: callers must release the flag before invoking this, but if it
+	// is somehow reached while disabled the scans below would write plans.json —
+	// honor the zero-write contract regardless.
+	if (isManuallyDisabled()) return { scanned: 0 };
+
+	let sessions: ReadonlyArray<{ transcriptPath: string; source?: string }>;
+	try {
+		sessions = await loadAllSessions(cwd);
+	} catch (err) {
+		log.warn("Failed to load sessions for catch-up: %s", (err as Error).message);
+		return { scanned: 0 };
+	}
+
+	await migrateDiscoveryCursors(cwd); // idempotent fold of legacy plan:/linear: cursors
+
+	let scanned = 0;
+	for (const session of sessions) {
+		const transcriptPath = session.transcriptPath;
+		// Codex rides the sidebar tick's own cursor-based recovery — skip here so
+		// we don't duplicate that work or mis-order its references-first scan.
+		if ((session.source ?? "claude") === "codex") continue;
+		if (!transcriptPath || !existsSync(transcriptPath)) continue;
+
+		try {
+			const fromLine = (await loadDiscoveryCursor(transcriptPath, cwd))?.lineNumber ?? 0;
+			const source = session.source === "gemini" ? "gemini" : "claude";
+
+			// Plan-first, then references — mirrors StopHook.discoverFromTranscript:
+			// both scan to EOF; the reference scan returns the authoritative cursor
+			// target, and the cursor advances only when the plan scan also completed
+			// so a throwing plan scan retries its window next time.
+			let planScanCompleted = false;
+			let referenceLine = fromLine;
+			try {
+				await scanPlansFrom(transcriptPath, fromLine, cwd, source);
+				planScanCompleted = true;
+			} catch (err) {
+				log.warn("Plan catch-up failed for %s: %s", session.transcriptPath, (err as Error).message);
+			}
+			try {
+				referenceLine = await scanReferencesFrom(transcriptPath, fromLine, cwd, source);
+			} catch (err) {
+				log.warn("Reference catch-up failed for %s: %s", session.transcriptPath, (err as Error).message);
+			}
+
+			if (planScanCompleted && referenceLine > fromLine) {
+				await saveDiscoveryCursor(
+					{ transcriptPath, lineNumber: referenceLine, updatedAt: new Date().toISOString() },
+					cwd,
+				);
+				scanned++;
+			}
+		} catch (err) {
+			log.warn("Discovery catch-up failed for %s: %s", session.transcriptPath, (err as Error).message);
+		}
+	}
+
+	if (scanned > 0) log.info("Discovery catch-up advanced %d transcript cursor(s)", scanned);
+	return { scanned };
+}

--- a/cli/src/core/DualWriteStorage.test.ts
+++ b/cli/src/core/DualWriteStorage.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setManuallyDisabled } from "../Logger.js";
 import { DualWriteStorage } from "./DualWriteStorage.js";
 import { FolderStorage } from "./FolderStorage.js";
 import { MetadataManager } from "./MetadataManager.js";
@@ -151,6 +152,39 @@ describe("DualWriteStorage", () => {
 
 		expect(await primary.readFile("test.txt")).toBe("hello");
 		expect(await shadow.readFile("test.txt")).toBe("hello");
+	});
+
+	it("isTopicWikiPresent falls back to false when the shadow lacks the probe", () => {
+		const dual = new DualWriteStorage(new InMemoryStorage(), new InMemoryStorage());
+		expect(dual.isTopicWikiPresent()).toBe(false);
+	});
+
+	it("skips both backends and clearDirty when manuallyDisabled is true", async () => {
+		const primary = new InMemoryStorage();
+		const shadowWriteFiles = vi.fn();
+		const shadowClearDirty = vi.fn();
+		const shadow = {
+			readFile: vi.fn(),
+			writeFiles: shadowWriteFiles,
+			clearDirty: shadowClearDirty,
+			listFiles: vi.fn(),
+			exists: vi.fn().mockResolvedValue(true),
+			ensure: vi.fn(),
+		} as unknown as StorageProvider;
+
+		const dual = new DualWriteStorage(primary, shadow);
+		setManuallyDisabled(true);
+		try {
+			await dual.writeFiles([{ path: "test.txt", content: "gated" }], "gated write");
+
+			expect(await primary.readFile("test.txt")).toBeNull();
+			expect(shadowWriteFiles).not.toHaveBeenCalled();
+			// clearDirty must not run either — it unlinks shadow-status.json and
+			// would mark a never-performed shadow write as clean.
+			expect(shadowClearDirty).not.toHaveBeenCalled();
+		} finally {
+			setManuallyDisabled(false);
+		}
 	});
 
 	it("primary succeeds even when shadow fails", async () => {

--- a/cli/src/core/DualWriteStorage.ts
+++ b/cli/src/core/DualWriteStorage.ts
@@ -6,7 +6,7 @@
  * are logged as warnings but never block the primary write path.
  */
 
-import { createLogger, errMsg } from "../Logger.js";
+import { createLogger, errMsg, isManuallyDisabled } from "../Logger.js";
 import type { FileWrite, SummaryIndexEntry } from "../Types.js";
 import type { HealOptions, HealResult, StorageProvider } from "./StorageProvider.js";
 import type { TopicPage } from "./TopicKBTypes.js";
@@ -43,6 +43,10 @@ export class DualWriteStorage implements StorageProvider {
 	// Shadow (folder KB) is best-effort — failures are swallowed so a flaky
 	// filesystem never blocks the critical git-based write path.
 	async writeFiles(files: FileWrite[], message: string): Promise<void> {
+		// Gated here as well as in both backends: the backend gates turn the
+		// writes into no-ops, but the `clearDirty()` below would still unlink
+		// shadow-status.json and mark a never-performed shadow write as clean.
+		if (isManuallyDisabled()) return;
 		await this.primary.writeFiles(files, message);
 		try {
 			await this.shadow.writeFiles(files, message);

--- a/cli/src/core/FolderStorage.test.ts
+++ b/cli/src/core/FolderStorage.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFile
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setManuallyDisabled } from "../Logger.js";
 import { FolderStorage } from "./FolderStorage.js";
 import type { ManifestEntry } from "./KBTypes.js";
 import { MetadataManager } from "./MetadataManager.js";
@@ -59,6 +60,7 @@ describe("FolderStorage", () => {
 
 	afterEach(() => {
 		rmrf(rootPath);
+		setManuallyDisabled(false);
 	});
 
 	describe("exists / ensure", () => {
@@ -2457,6 +2459,7 @@ describe("FolderStorage.renderTopicWiki", () => {
 	});
 
 	afterEach(() => {
+		setManuallyDisabled(false);
 		const { rmSync } = require("node:fs");
 		try {
 			rmSync(rootPath, { recursive: true, force: true });
@@ -2687,5 +2690,26 @@ describe("FolderStorage.renderTopicWiki", () => {
 		await expect(storage.renderTopicWiki([page])).rejects.toThrow();
 		// The bogus file is still in place (wipe's readdir catch logged + returned).
 		expect(existsSync(wikiAsFile)).toBe(true);
+	});
+
+	describe("manuallyDisabled gate", () => {
+		it("skips writeFiles entirely when manuallyDisabled is true", async () => {
+			setManuallyDisabled(true);
+
+			await storage.writeFiles([{ path: "summaries/abc12345deadbeef.json", content: makeSummaryJson() }], "test");
+
+			expect(existsSync(join(rootPath, ".jolli", "summaries", "abc12345deadbeef.json"))).toBe(false);
+			// Visible markdown layer must not be generated either.
+			expect(existsSync(join(rootPath, "main"))).toBe(false);
+		});
+
+		it("writes again after manuallyDisabled flips back to false", async () => {
+			setManuallyDisabled(true);
+			setManuallyDisabled(false);
+
+			await storage.writeFiles([{ path: "summaries/abc12345deadbeef.json", content: makeSummaryJson() }], "test");
+
+			expect(existsSync(join(rootPath, ".jolli", "summaries", "abc12345deadbeef.json"))).toBe(true);
+		});
 	});
 });

--- a/cli/src/core/FolderStorage.ts
+++ b/cli/src/core/FolderStorage.ts
@@ -15,7 +15,7 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync } from "node:fs";
 import { rmdir } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
-import { createLogger, errMsg } from "../Logger.js";
+import { createLogger, errMsg, isManuallyDisabled } from "../Logger.js";
 import { safeAtomicWriteSync } from "../sync/VaultSymlinkGuard.js";
 import type { CommitSummary, FileWrite, SummaryIndex, SummaryIndexEntry } from "../Types.js";
 import type { ManifestEntry } from "./KBTypes.js";
@@ -79,6 +79,7 @@ export class FolderStorage implements StorageProvider {
 	}
 
 	async writeFiles(files: FileWrite[], message: string): Promise<void> {
+		if (isManuallyDisabled()) return;
 		await this.ensure();
 		let written = 0;
 		let deleted = 0;

--- a/cli/src/core/KBPathResolver.test.ts
+++ b/cli/src/core/KBPathResolver.test.ts
@@ -3,6 +3,7 @@ import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "n
 import { homedir, tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setManuallyDisabled } from "../Logger.js";
 import * as Subprocess from "../util/Subprocess.js";
 import {
 	archiveKBFolder,
@@ -51,6 +52,7 @@ describe("KBPathResolver", () => {
 
 	afterEach(() => {
 		rmrf(tempDir);
+		setManuallyDisabled(false);
 	});
 
 	describe("extractRepoName", () => {
@@ -911,6 +913,19 @@ esac
 			} finally {
 				nowSpy.mockRestore();
 			}
+		});
+
+		it("resolveKBPath does not write identity when manuallyDisabled is true", () => {
+			setManuallyDisabled(true);
+			const kbRoot = resolveKBPath("gated-repo", null, tempDir);
+			expect(kbRoot).toBe(join(tempDir, "gated-repo"));
+			expect(existsSync(join(kbRoot, ".jolli"))).toBe(false);
+		});
+
+		it("initializeKBFolder does not touch the filesystem when manuallyDisabled is true", () => {
+			setManuallyDisabled(true);
+			initializeKBFolder(join(tempDir, "gated-repo"), "gated-repo", null);
+			expect(existsSync(join(tempDir, "gated-repo", ".jolli"))).toBe(false);
 		});
 
 		it("matches resolveKBPath's choice on a pristine system — Migrate parity", () => {

--- a/cli/src/core/KBPathResolver.ts
+++ b/cli/src/core/KBPathResolver.ts
@@ -19,7 +19,7 @@
 import { existsSync, mkdirSync, readFileSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join } from "node:path";
-import { createLogger } from "../Logger.js";
+import { createLogger, isManuallyDisabled } from "../Logger.js";
 import { execFileSyncHidden } from "../util/Subprocess.js";
 import type { KBConfig } from "./KBTypes.js";
 import { MetadataManager } from "./MetadataManager.js";
@@ -90,7 +90,9 @@ export function assertValidLocalFolder(customPath: string | undefined): void {
 /**
  * Resolves the KB root path for a repository AND claims it by writing identity
  * to `.jolli/config.json`. The returned path is guaranteed to have a
- * fully-populated config (`remoteUrl` + `repoName`) on return.
+ * fully-populated config (`remoteUrl` + `repoName`) on return — except when
+ * the project is manually disabled, in which case no identity is written and
+ * the returned path may be unclaimed (disabled mode must not touch disk).
  */
 export function resolveKBPath(repoName: string, remoteUrl: string | null, customPath?: string): string {
 	const parent = resolveKbParent(customPath);
@@ -517,6 +519,7 @@ function findAvailablePathAndClaim(parent: string, repoName: string, remoteUrl: 
  * with one that carries `remoteUrl` and `repoName`.
  */
 function writeKBIdentity(kbRoot: string, repoName: string, remoteUrl: string | null): void {
+	if (isManuallyDisabled()) return;
 	const manager = new MetadataManager(join(kbRoot, ".jolli"));
 	manager.ensure();
 	const config = manager.readConfig();

--- a/cli/src/core/KBTypes.ts
+++ b/cli/src/core/KBTypes.ts
@@ -55,9 +55,13 @@ export interface KBConfig {
 	readonly repoName?: string;
 }
 
-/** .jolli/migration.json — tracks orphan→folder migration progress */
+/**
+ * .jolli/migration.json — tracks orphan→folder migration progress.
+ * `"skipped"` is a transient return value used when the project is manually
+ * disabled; it is never persisted to disk.
+ */
 export interface MigrationState {
-	readonly status: "pending" | "in_progress" | "completed" | "partial" | "failed";
+	readonly status: "pending" | "in_progress" | "completed" | "partial" | "failed" | "skipped";
 	readonly totalEntries: number;
 	readonly migratedEntries: number;
 	readonly failedHashes?: readonly string[];

--- a/cli/src/core/MigrationEngine.test.ts
+++ b/cli/src/core/MigrationEngine.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setManuallyDisabled } from "../Logger.js";
 import type { FileWrite } from "../Types.js";
 import { FolderStorage } from "./FolderStorage.js";
 import { MetadataManager } from "./MetadataManager.js";
@@ -142,6 +143,7 @@ describe("MigrationEngine", () => {
 
 	afterEach(() => {
 		rmrf(kbRoot);
+		setManuallyDisabled(false);
 	});
 
 	function createEngine(): MigrationEngine {
@@ -1168,6 +1170,65 @@ describe("MigrationEngine", () => {
 			} finally {
 				spy.mockRestore();
 			}
+		});
+	});
+
+	describe("manuallyDisabled gate", () => {
+		it("runMigration returns skipped without reading the orphan branch or persisting state", async () => {
+			seedOrphan(orphan, [{ hash: "aaa11111aaa11111" }]);
+			const readSpy = vi.spyOn(orphan, "readFile");
+			setManuallyDisabled(true);
+
+			const state = await createEngine().runMigration();
+
+			expect(state.status).toBe("skipped");
+			expect(state.totalEntries).toBe(0);
+			expect(state.migratedEntries).toBe(0);
+			expect(readSpy).not.toHaveBeenCalled();
+			// The skipped result must NOT be persisted — migration.json untouched.
+			expect(metadataManager.readMigrationState()).toBeNull();
+		});
+
+		it("runStaleChildCleanup returns skipped with swept=0 and persists nothing", async () => {
+			setManuallyDisabled(true);
+
+			const state = await createEngine().runStaleChildCleanup();
+
+			expect(state.status).toBe("skipped");
+			expect(state.swept).toBe(0);
+			expect(metadataManager.readMigrationState()).toBeNull();
+		});
+
+		it("aborts a migration mid-run when the flag flips, without persisting a final state", async () => {
+			seedOrphan(orphan, [{ hash: "aaa11111aaa11111" }, { hash: "bbb22222bbb22222" }]);
+
+			// Flip the flag after the first entry completes — the loop's
+			// per-iteration check must abort before touching the second entry.
+			const state = await createEngine().runMigration((migrated) => {
+				if (migrated === 1) setManuallyDisabled(true);
+			});
+
+			expect(state.status).toBe("skipped");
+			expect(state.migratedEntries).toBe(1);
+			// The pre-flip "in_progress" snapshot is the last persisted state —
+			// NOT "completed" — so re-enabling re-runs the migration.
+			expect(metadataManager.readMigrationState()?.status).toBe("in_progress");
+			// The second entry was never migrated.
+			expect(await folderStorage.readFile("summaries/bbb22222bbb22222.json")).toBeNull();
+		});
+
+		it("does not persist the final completed state when the flag flips during the bulk passes", async () => {
+			seedOrphan(orphan, [{ hash: "aaa11111aaa11111" }]);
+
+			// Flip after the last per-entry progress callback: the loop finishes,
+			// and the pre-bulk check must abort before index copy + final save.
+			const state = await createEngine().runMigration((migrated, total) => {
+				if (migrated === total) setManuallyDisabled(true);
+			});
+
+			expect(state.status).toBe("skipped");
+			expect(metadataManager.readMigrationState()?.status).toBe("in_progress");
+			expect(await folderStorage.readFile("index.json")).toBeNull();
 		});
 	});
 });

--- a/cli/src/core/MigrationEngine.ts
+++ b/cli/src/core/MigrationEngine.ts
@@ -12,7 +12,7 @@
  * - Backfills missing titles on re-migration
  */
 
-import { createLogger, errMsg } from "../Logger.js";
+import { createLogger, errMsg, isManuallyDisabled } from "../Logger.js";
 import type { CommitSummary, SummaryIndex } from "../Types.js";
 import type { MigrationState } from "./KBTypes.js";
 import type { MetadataManager } from "./MetadataManager.js";
@@ -36,6 +36,10 @@ export class MigrationEngine {
 	 * @param onProgress callback with (migrated, total) counts
 	 */
 	async runMigration(onProgress?: (migrated: number, total: number) => void): Promise<MigrationState> {
+		if (isManuallyDisabled()) {
+			log.info("Skipping migration: project is manually disabled");
+			return { status: "skipped", totalEntries: 0, migratedEntries: 0 };
+		}
 		log.info("=== Migration started ===");
 
 		const indexJson = await this.orphanStorage.readFile("index.json");
@@ -63,6 +67,13 @@ export class MigrationEngine {
 		const failedHashes: string[] = [];
 
 		for (const entry of rootEntries) {
+			// The disable command can flip the flag while a long first-install
+			// migration is in flight. Abort instead of counting the storage
+			// gates' silently-dropped writes below as migrated entries.
+			if (isManuallyDisabled()) {
+				log.info("Migration aborted: project was manually disabled mid-run");
+				return { status: "skipped", totalEntries, migratedEntries: migrated };
+			}
 			const hash = entry.commitHash;
 
 			// Skip if already migrated — but backfill missing title
@@ -95,6 +106,13 @@ export class MigrationEngine {
 				failedHashes: failedHashes.length > 0 ? failedHashes : undefined,
 				lastMigratedHash: hash,
 			});
+		}
+
+		// Same mid-run check before the bulk passes: their writes are gated
+		// into no-ops, so proceeding would only record a false final state.
+		if (isManuallyDisabled()) {
+			log.info("Migration aborted: project was manually disabled mid-run");
+			return { status: "skipped", totalEntries, migratedEntries: migrated };
 		}
 
 		// Migrate all summaries (including children not covered by per-root migration)
@@ -212,6 +230,10 @@ export class MigrationEngine {
 	 * VS Code/IDE activate paths on every startup.
 	 */
 	async runStaleChildCleanup(): Promise<MigrationState & { readonly swept: number }> {
+		if (isManuallyDisabled()) {
+			log.info("Skipping stale-child cleanup: project is manually disabled");
+			return { status: "skipped", totalEntries: 0, migratedEntries: 0, swept: 0 };
+		}
 		const existing = this.metadataManager.readMigrationState();
 		const priorStamp = existing?.staleChildCleanup?.completedAt;
 
@@ -273,7 +295,9 @@ export class MigrationEngine {
 				regen.failed,
 			);
 		}
-		this.metadataManager.saveMigrationState(merged);
+		// Via the gated wrapper so a disable that flipped mid-run doesn't
+		// persist a stamp for work whose writes were silently dropped.
+		this.saveMigrationState(merged);
 		// `swept` is a transient signal for the caller (how many visible .md the
 		// run actually changed) — NOT persisted: `saveMigrationState` only writes
 		// the clean `merged` MigrationState above. It sums BOTH phases' real
@@ -466,6 +490,11 @@ export class MigrationEngine {
 	}
 
 	private saveMigrationState(state: MigrationState): MigrationState {
+		// A disable mid-run must not persist progress: the storage gates turn
+		// the actual file writes into silent no-ops, so persisting would
+		// record entries as migrated (worst case a false "completed") and
+		// block the re-enable catch-up from ever re-migrating them.
+		if (isManuallyDisabled()) return state;
 		this.metadataManager.saveMigrationState(state);
 		return state;
 	}

--- a/cli/src/core/OrphanBranchStorage.test.ts
+++ b/cli/src/core/OrphanBranchStorage.test.ts
@@ -10,7 +10,7 @@ vi.mock("./GitOps.js", () => ({
 	writeMultipleFilesToBranch: vi.fn(),
 }));
 
-import { ORPHAN_BRANCH } from "../Logger.js";
+import { ORPHAN_BRANCH, setManuallyDisabled } from "../Logger.js";
 import {
 	batchReadFilesFromBranch,
 	ensureOrphanBranch,
@@ -110,5 +110,19 @@ describe("OrphanBranchStorage", () => {
 		await storage.ensure();
 
 		expect(mockedEnsure).toHaveBeenCalledWith(ORPHAN_BRANCH, "/tmp/repo");
+	});
+
+	it("writeFiles is a no-op when manuallyDisabled is true", async () => {
+		setManuallyDisabled(true);
+		try {
+			const storage = new OrphanBranchStorage("/tmp/repo");
+
+			await storage.writeFiles([{ path: "summaries/abc.json", content: "{}" }], "test");
+
+			expect(mockedEnsure).not.toHaveBeenCalled();
+			expect(mockedWriteFiles).not.toHaveBeenCalled();
+		} finally {
+			setManuallyDisabled(false);
+		}
 	});
 });

--- a/cli/src/core/OrphanBranchStorage.ts
+++ b/cli/src/core/OrphanBranchStorage.ts
@@ -1,4 +1,4 @@
-import { ORPHAN_BRANCH } from "../Logger.js";
+import { isManuallyDisabled, ORPHAN_BRANCH } from "../Logger.js";
 import type { FileWrite } from "../Types.js";
 import {
 	batchReadFilesFromBranch,
@@ -22,6 +22,7 @@ export class OrphanBranchStorage implements StorageProvider {
 	}
 
 	async writeFiles(files: FileWrite[], message: string): Promise<void> {
+		if (isManuallyDisabled()) return;
 		await this.ensure();
 		await writeMultipleFilesToBranch(ORPHAN_BRANCH, files, message, this.cwd);
 	}

--- a/cli/src/core/RepoProfile.test.ts
+++ b/cli/src/core/RepoProfile.test.ts
@@ -3,7 +3,13 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } f
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { readManualDisableFlag, readRepoProfile, updateRepoProfile, writeManualDisableFlag } from "./RepoProfile.js";
+import {
+	readManualDisableFlag,
+	readManualDisableFlagSync,
+	readRepoProfile,
+	updateRepoProfile,
+	writeManualDisableFlag,
+} from "./RepoProfile.js";
 
 const GIT_ENV = {
 	...process.env,
@@ -245,6 +251,46 @@ describe("RepoProfile", () => {
 			// other. Pre-lock, last-writer-wins could silently drop manuallyDisabled.
 			await Promise.all([updateRepoProfile(cwd, { backfillDismissed: true }), writeManualDisableFlag(cwd, true)]);
 			expect(await readRepoProfile(cwd)).toEqual({ backfillDismissed: true, manuallyDisabled: true });
+		});
+
+		describe("readManualDisableFlagSync", () => {
+			it("returns false when nothing is set", () => {
+				expect(readManualDisableFlagSync(cwd)).toBe(false);
+			});
+
+			it("reads an explicit profile.json value (true then false)", async () => {
+				await writeManualDisableFlag(cwd, true);
+				expect(readManualDisableFlagSync(cwd)).toBe(true);
+				await writeManualDisableFlag(cwd, false);
+				expect(readManualDisableFlagSync(cwd)).toBe(false);
+			});
+
+			it("reads the main-worktree profile from a linked worktree", async () => {
+				execFileSync("git", ["commit", "--allow-empty", "-m", "init", "-q"], { cwd, env: GIT_ENV });
+				await writeManualDisableFlag(cwd, true);
+				const wt = mkdtempSync(join(tmpdir(), "jolli-repoprofile-wt-"));
+				try {
+					execFileSync("git", ["worktree", "add", "-q", wt, "HEAD"], { cwd });
+					expect(readManualDisableFlagSync(wt)).toBe(true);
+				} finally {
+					rmSync(wt, { recursive: true, force: true });
+				}
+			});
+
+			it("falls back to the legacy cwd marker when no profile value is set", () => {
+				mkdirSync(join(cwd, ".jolli", "jollimemory"), { recursive: true });
+				writeFileSync(legacyMarker(cwd), new Date(0).toISOString());
+				expect(readManualDisableFlagSync(cwd)).toBe(true);
+			});
+
+			it("returns false for a non-git dir with no profile or marker", () => {
+				const nonGit = mkdtempSync(join(tmpdir(), "jolli-repoprofile-nogit-"));
+				try {
+					expect(readManualDisableFlagSync(nonGit)).toBe(false);
+				} finally {
+					rmSync(nonGit, { recursive: true, force: true });
+				}
+			});
 		});
 	});
 });

--- a/cli/src/core/RepoProfile.ts
+++ b/cli/src/core/RepoProfile.ts
@@ -18,9 +18,11 @@
  * not re-prompted.
  */
 
+import { readFileSync, statSync } from "node:fs";
 import { mkdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join } from "node:path";
 import { getJolliMemoryDir } from "../Logger.js";
+import { execFileSyncHidden } from "../util/Subprocess.js";
 import { execGit, listWorktrees } from "./GitOps.js";
 import { withStrictProfileLock } from "./Locks.js";
 
@@ -234,4 +236,51 @@ export async function readManualDisableFlag(cwd: string): Promise<boolean> {
 /** Sets (`true`) or clears (`false`) the repo-wide manual-disable flag. */
 export async function writeManualDisableFlag(cwd: string, disabled: boolean): Promise<void> {
 	await updateRepoProfile(cwd, { manuallyDisabled: disabled });
+}
+
+/**
+ * Synchronous, read-only variant of {@link readManualDisableFlag}. The VS Code
+ * extension's `activate()` calls this to seed the in-memory zero-write flag
+ * before any async work runs — a stray log line during early activation must
+ * not touch disk in a manually disabled repo, and the async reader can't be
+ * awaited that early.
+ *
+ * Best-effort by design: unlike the async reader it never migrates the legacy
+ * marker or persists a decision (the async reader does that later); it only
+ * reports the current state. It still anchors to the main worktree root via a
+ * sync `git rev-parse --git-common-dir` so a linked worktree of a disabled repo
+ * reads the shared `profile.json` rather than re-enabling on reload. Any failure
+ * (not a git repo, missing/corrupt profile) falls through to the legacy marker
+ * in `cwd`, then to `false`.
+ */
+export function readManualDisableFlagSync(cwd: string): boolean {
+	let commonDir = "";
+	try {
+		const raw = execFileSyncHidden("git", ["rev-parse", "--git-common-dir"], { cwd, encoding: "utf-8" }).trim();
+		if (raw) {
+			commonDir = isAbsolute(raw) ? raw : join(cwd, raw);
+		}
+	} catch {
+		commonDir = "";
+	}
+	const mainRoot = commonDir ? dirname(commonDir) : cwd;
+	try {
+		const parsed = JSON.parse(readFileSync(join(getJolliMemoryDir(mainRoot), PROFILE_FILE), "utf-8"));
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			const flag = (parsed as RepoProfile).manuallyDisabled;
+			if (flag !== undefined) {
+				return flag === true;
+			}
+		}
+	} catch {
+		// Missing or corrupt profile — fall through to the legacy marker.
+	}
+	// Legacy per-worktree marker, this worktree only (the async reader
+	// enumerates every worktree and migrates; this fast path stays cheap).
+	try {
+		statSync(join(getJolliMemoryDir(cwd), LEGACY_DISABLE_FILE));
+		return true;
+	} catch {
+		return false;
+	}
 }

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -28,6 +28,7 @@ vi.spyOn(console, "error").mockImplementation(() => {});
 import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join as joinPath } from "node:path";
+import { setManuallyDisabled } from "../Logger.js";
 import type {
 	CatalogEntry,
 	CommitCatalog,
@@ -2476,6 +2477,18 @@ describe("SummaryStore", () => {
 			await expect(scanTreeHashAliases(["hash1"])).resolves.toBe(false);
 		});
 
+		it("should return false without reading the index or taking the lock when manually disabled", async () => {
+			setManuallyDisabled(true);
+			try {
+				await expect(scanTreeHashAliases(["hash1"])).resolves.toBe(false);
+				expect(readFileFromBranch).not.toHaveBeenCalled();
+				expect(acquireOrphanWriteLock).not.toHaveBeenCalled();
+				expect(writeMultipleFilesToBranch).not.toHaveBeenCalled();
+			} finally {
+				setManuallyDisabled(false);
+			}
+		});
+
 		it("should persist new aliases when tree hashes match shallow entries", async () => {
 			const index = v3Index(
 				[
@@ -4221,6 +4234,57 @@ describe("SummaryStore", () => {
 			// Write-wins on the shared row.
 			const shared = newCatalog.entries.find((e) => e.commitHash === "shared");
 			expect(shared?.recap).toBe("orphan recap");
+		});
+	});
+
+	describe("manuallyDisabled pre-lock gates", () => {
+		// The gate must fire BEFORE withRequiredOrphanWriteLock: acquiring
+		// orphan-write.lock is itself a disk write (mkdir + lock file), so the
+		// storage-level writeFiles gate alone would leave a lock artifact behind.
+		beforeEach(() => {
+			setManuallyDisabled(true);
+		});
+
+		afterEach(() => {
+			setManuallyDisabled(false);
+		});
+
+		it("storeSummary returns without taking the lock or writing", async () => {
+			await storeSummary(createMockSummary());
+
+			expect(acquireOrphanWriteLock).not.toHaveBeenCalled();
+			expect(writeMultipleFilesToBranch).not.toHaveBeenCalled();
+		});
+
+		it("saveTranscriptsBatch returns without taking the lock or writing", async () => {
+			await saveTranscriptsBatch([{ hash: "abc", data: { version: 1, messages: [] } as never }], [], undefined);
+
+			expect(acquireOrphanWriteLock).not.toHaveBeenCalled();
+			expect(writeMultipleFilesToBranch).not.toHaveBeenCalled();
+		});
+
+		it("storePlans returns without taking the lock or writing", async () => {
+			await storePlans([{ slug: "plan-1", content: "# Plan" }], "msg");
+
+			expect(acquireOrphanWriteLock).not.toHaveBeenCalled();
+			expect(writeMultipleFilesToBranch).not.toHaveBeenCalled();
+		});
+
+		it("storeNotes returns without taking the lock or writing", async () => {
+			await storeNotes([{ id: "note-1", content: "# Note" }], "msg");
+
+			expect(acquireOrphanWriteLock).not.toHaveBeenCalled();
+			expect(writeMultipleFilesToBranch).not.toHaveBeenCalled();
+		});
+
+		it("storeReferences returns without taking the lock or writing", async () => {
+			await storeReferences(
+				[{ archivedKey: "linear:ABC-1", source: "linear" as SourceId, content: "# Ref" }],
+				"msg",
+			);
+
+			expect(acquireOrphanWriteLock).not.toHaveBeenCalled();
+			expect(writeMultipleFilesToBranch).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -16,7 +16,7 @@
  *   - Cached aliases (`commitAliases`) so repeated lookups skip git calls
  */
 
-import { createLogger } from "../Logger.js";
+import { createLogger, isManuallyDisabled } from "../Logger.js";
 import type {
 	CatalogEntry,
 	CatalogTopic,
@@ -241,6 +241,10 @@ export async function storeSummary(
 	storage?: StorageProvider,
 	readStorage?: StorageProvider,
 ): Promise<void> {
+	// Checked BEFORE the lock: acquiring orphan-write.lock is itself a disk
+	// write (mkdir + lock file), so the storage-level writeFiles gate alone
+	// would still leave a lock artifact behind on a manually-disabled project.
+	if (isManuallyDisabled()) return;
 	await withRequiredOrphanWriteLock(cwd, "storeSummary", async () => {
 		const writeIndex = await loadIndex(cwd, storage);
 		const writeCatalog = await loadCatalog(cwd, storage);
@@ -1320,6 +1324,8 @@ export async function saveTranscriptsBatch(
 	}
 
 	if (files.length === 0) return;
+	// Pre-lock gate — see storeSummary for why this sits before the lock.
+	if (isManuallyDisabled()) return;
 
 	const summary = [
 		writes.length > 0 ? `${writes.length} written` : "",
@@ -1698,6 +1704,12 @@ export async function scanTreeHashAliases(
 	storage?: StorageProvider,
 	readStorage?: StorageProvider,
 ): Promise<boolean> {
+	// Manually-disabled projects must not write: the alias write below would
+	// be silently dropped by the storage gate anyway, but the orphan-write
+	// lock acquisition is itself a disk write — and because the dropped write
+	// never persists, every commits-panel refresh would re-detect the same
+	// candidates and re-create the lock file in a loop.
+	if (isManuallyDisabled()) return false;
 	const effectiveReadStorage = readStorage ?? storage;
 	// ── Phase 1: preflight (no lock) ────────────────────────────────────────
 	// Compute candidate aliases against the current index. Tree-hash lookup is
@@ -2329,6 +2341,8 @@ export async function storePlans(
 	storage?: StorageProvider,
 ): Promise<void> {
 	if (planFiles.length === 0) return;
+	// Pre-lock gate — see storeSummary for why this sits before the lock.
+	if (isManuallyDisabled()) return;
 
 	const files: FileWrite[] = planFiles.map((p) => ({
 		path: `plans/${p.slug}.md`,
@@ -2415,6 +2429,8 @@ export async function storeNotes(
 	storage?: StorageProvider,
 ): Promise<void> {
 	if (noteFiles.length === 0) return;
+	// Pre-lock gate — see storeSummary for why this sits before the lock.
+	if (isManuallyDisabled()) return;
 
 	const files: FileWrite[] = noteFiles.map((n) => ({
 		path: `notes/${n.id}.md`,
@@ -2518,6 +2534,8 @@ export async function storeReferences(
 	storage?: StorageProvider,
 ): Promise<void> {
 	if (referenceFiles.length === 0) return;
+	// Pre-lock gate — see storeSummary for why this sits before the lock.
+	if (isManuallyDisabled()) return;
 
 	const files: FileWrite[] = referenceFiles.map((e) => ({
 		path: orphanPathFor(e.source, e.archivedKey),

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -356,6 +356,17 @@ export function buildWorkerStartupBanner(info: {
  * or PostRewriteHook. It processes ALL queued entries (not just "its own"), ensuring that
  * operations queued during a previous Worker's LLM call are eventually processed.
  *
+ * Reads the repo-wide manual-disable flag once at entry (the disk-backed
+ * `readManualDisableFlag`, RepoProfile's `manuallyDisabled` in profile.json)
+ * and skips the drain when the repo is disabled. The in-memory `manuallyDisabled`
+ * mirror in Logger stays false in this separate process, so the disk flag is the
+ * one that counts here. Disabling a project uninstalls its git hooks, so normally
+ * no new worker is spawned while disabled; this entry check additionally covers
+ * the race where the user disables between postCommitEntry() spawning the worker
+ * and the worker starting. A worker that has already passed this check when the
+ * user clicks Disable keeps draining, so commits made while the project was still
+ * enabled still get their memories instead of being stranded in the queue.
+ *
  * @param cwd   - Working directory (git repo root)
  * @param force - When true, overwrites existing summaries (used by CLI `summarize` command)
  */

--- a/cli/src/install/SkillAutoRefresh.test.ts
+++ b/cli/src/install/SkillAutoRefresh.test.ts
@@ -107,6 +107,22 @@ describe("autoRefreshSkillsIfStale", () => {
 		expect(updateSkills).toHaveBeenCalledOnce();
 	});
 
+	it("is a no-op in a manually-disabled repo, even with a stale marker (zero-write contract)", async () => {
+		// disable() leaves the skill probe on disk, so the enabled-skills gate still
+		// matches; the manual-disable check is what must keep a version bump from
+		// rewriting skills (or stamping the marker) in a repo the user turned off.
+		const root = await makeEnabledRepo();
+		const updateSkills = vi.fn(async () => {});
+		await autoRefreshSkillsIfStale(root, {
+			version: "1.2.3",
+			loadConfig: async () => ({}),
+			updateSkills,
+			readManualDisable: () => true,
+		});
+		expect(updateSkills).not.toHaveBeenCalled();
+		expect(existsSync(markerPathFor(root))).toBe(false);
+	});
+
 	it("defaults to the build-stamped version when none is injected", async () => {
 		// Exercises the `deps.version ?? VERSION` default. Under the test runner VERSION
 		// is a real published version (not "dev"), so the refresh proceeds and the marker

--- a/cli/src/install/SkillAutoRefresh.ts
+++ b/cli/src/install/SkillAutoRefresh.ts
@@ -27,7 +27,13 @@
  *   - walking up from the invocation cwd finds a worktree root that already has an
  *     installed Jolli skill, so a plain `jolli` in an un-enabled repo never
  *     CREATES skills;
- *   - the marker's version differs from the running version.
+ *   - the marker's version differs from the running version;
+ *   - the repo is not manually disabled. `jolli disable` deliberately leaves the
+ *     skill files on disk (conservative cleanup), so the enabled-skills probe
+ *     still matches a disabled repo — this guard is what actually keeps a
+ *     version-bumped CLI from rewriting skills there, honoring the zero-write
+ *     contract. Checked only on the rare version-changed path so the common
+ *     already-current path stays a single marker read.
  *
  * The invoked command's own lifecycle guard (skip `enable` / `disable` /
  * `uninstall`, which own skills themselves) lives at the call site in `Api.ts`.
@@ -40,6 +46,7 @@ import { access, mkdir, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { VERSION } from "../commands/CliUtils.js";
 import { atomicWriteFile } from "../core/AtomicWrite.js";
+import { readManualDisableFlagSync } from "../core/RepoProfile.js";
 import { loadConfig } from "../core/SessionTracker.js";
 import { createLogger, getJolliMemoryDir } from "../Logger.js";
 import { updateSkillsIfNeeded } from "./SkillInstaller.js";
@@ -66,6 +73,8 @@ export interface AutoRefreshDeps {
 	readonly loadConfig?: () => Promise<{ claudeEnabled?: boolean }>;
 	/** Skill upsert. Defaults to {@link updateSkillsIfNeeded}. */
 	readonly updateSkills?: (root: string, config: { claudeEnabled?: boolean }) => Promise<void>;
+	/** Read-only manual-disable check. Defaults to {@link readManualDisableFlagSync}. */
+	readonly readManualDisable?: (cwd: string) => boolean;
 }
 
 async function pathExists(p: string): Promise<boolean> {
@@ -120,6 +129,14 @@ export async function autoRefreshSkillsIfStale(cwd: string, deps: AutoRefreshDep
 		const markerDir = getJolliMemoryDir(root);
 		const markerPath = join(markerDir, SKILLS_REFRESH_MARKER);
 		if ((await readMarkerVersion(markerPath)) === version) return; // already reconciled for this version
+
+		// Zero-write contract: a manually-disabled repo must not have its skills
+		// rewritten by a version bump. The probe above still matches because disable
+		// leaves the skill files in place, so this flag read is the real gate.
+		// Use the READ-ONLY sync reader: the async readManualDisableFlag migrates a
+		// legacy `disabled-by-user` marker into profile.json (a disk write), which
+		// would itself violate the zero-write contract on this path.
+		if ((deps.readManualDisable ?? readManualDisableFlagSync)(root)) return;
 
 		const config = await (deps.loadConfig ?? loadConfig)();
 		await (deps.updateSkills ?? updateSkillsIfNeeded)(root, { claudeEnabled: config.claudeEnabled });

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -24,6 +24,20 @@ const {
 	dispose: vi.fn(),
 }));
 
+// In-memory mirror of the cli Logger's manuallyDisabled flag. The mock keeps
+// real setter/getter semantics so activate's flag seeding drives the
+// initializeKB gate exactly like the production module-level state does.
+const { manuallyDisabledState, setManuallyDisabledMock, isManuallyDisabledMock } = vi.hoisted(() => {
+	const state = { value: false };
+	return {
+		manuallyDisabledState: state,
+		setManuallyDisabledMock: vi.fn((disabled: boolean) => {
+			state.value = disabled;
+		}),
+		isManuallyDisabledMock: vi.fn(() => state.value),
+	};
+});
+
 const { mockNotifyApiKeySaveError } = vi.hoisted(() => ({
 	mockNotifyApiKeySaveError: vi.fn(),
 }));
@@ -647,6 +661,14 @@ vi.mock("../../cli/src/core/PinStore.js", () => ({
 	listPins: vi.fn(async () => []),
 }));
 
+const { catchUpTranscriptDiscovery } = vi.hoisted(() => ({
+	catchUpTranscriptDiscovery: vi.fn(async () => ({ scanned: 0 })),
+}));
+
+vi.mock("../../cli/src/core/DiscoveryCatchUp.js", () => ({
+	catchUpTranscriptDiscovery,
+}));
+
 // Mock the KB folder-mode dependencies so the auto-migration path in `activate`
 // and the rebuildKnowledgeBase command run with predictable, side-effect-free
 // stand-ins. Each test that exercises those paths overrides the relevant helper
@@ -738,6 +760,8 @@ vi.mock("../../cli/src/Logger.js", () => ({
 	getJolliMemoryDir: vi.fn((cwd: string) => `${cwd}/.jolli/jollimemory`),
 	errMsg: vi.fn((err: unknown) => (err instanceof Error ? err.message : String(err))),
 	isEnoent: vi.fn((err: unknown) => (err as NodeJS.ErrnoException)?.code === "ENOENT"),
+	setManuallyDisabled: setManuallyDisabledMock,
+	isManuallyDisabled: isManuallyDisabledMock,
 }));
 
 vi.mock("../../cli/src/hooks/PushCompensation.js", () => ({
@@ -1052,13 +1076,15 @@ vi.mock("./sync/VsCodeSyncBootstrap.js", () => ({
 	activateSync: activateSyncMock,
 }));
 
-const { readManualDisableFlag, writeManualDisableFlag } = vi.hoisted(() => ({
+const { readManualDisableFlag, readManualDisableFlagSync, writeManualDisableFlag } = vi.hoisted(() => ({
 	readManualDisableFlag: vi.fn(async () => false),
+	readManualDisableFlagSync: vi.fn(() => false),
 	writeManualDisableFlag: vi.fn(async () => undefined),
 }));
 
 vi.mock("./services/ManualDisableFlag.js", () => ({
 	readManualDisableFlag,
+	readManualDisableFlagSync,
 	writeManualDisableFlag,
 }));
 
@@ -1185,6 +1211,15 @@ describe("Extension", () => {
 		// Default: workspace exists and CLI is found
 		getWorkspaceRoot.mockReturnValue("/test/workspace");
 		resolveCLIPath.mockReturnValue("/mock/extension/path/dist/Cli.js");
+
+		// Default: no manually-disabled marker; reset the in-memory mirror so a
+		// prior test's disabled state never leaks into the next activate. Both the
+		// sync and async reads are reset — the async one gates the worktree
+		// auto-install / auto-enable paths, and mockResolvedValue survives
+		// clearAllMocks, so a prior disabled-state test would otherwise leak.
+		manuallyDisabledState.value = false;
+		readManualDisableFlagSync.mockReturnValue(false);
+		readManualDisableFlag.mockResolvedValue(false);
 
 		// Default: no migrations needed
 		hasV1Branch.mockResolvedValue(false);
@@ -1747,6 +1782,67 @@ describe("Extension", () => {
 		});
 	});
 
+	// ── disabled startup: zero-write gating ──────────────────────────────────
+	//
+	// When the manually-disabled marker exists, activate must (a) seed the
+	// cli-side in-memory flag BEFORE the first log call, and (b) skip the
+	// entire initializeKB body — every step in it writes to disk.
+	describe("activate — manuallyDisabled zero-write gate", () => {
+		it("seeds the in-memory flag from the sync marker read before initLogger", () => {
+			readManualDisableFlagSync.mockReturnValue(true);
+			readManualDisableFlag.mockResolvedValue(true);
+
+			activate(makeContext());
+
+			expect(setManuallyDisabledMock).toHaveBeenCalledWith(true);
+			const setIdx = setManuallyDisabledMock.mock.invocationCallOrder[0];
+			const initLoggerIdx = initLogger.mock.invocationCallOrder[0];
+			expect(setIdx).toBeLessThan(initLoggerIdx);
+		});
+
+		it("seeds the flag with false when the marker is absent", () => {
+			readManualDisableFlagSync.mockReturnValue(false);
+
+			activate(makeContext());
+
+			expect(setManuallyDisabledMock).toHaveBeenCalledWith(false);
+		});
+
+		it("skips the entire initializeKB body when manuallyDisabled is true at activate", async () => {
+			// Let any prior test's fire-and-forget initializeKB settle so its
+			// calls don't land after the mockClear below.
+			await new Promise((resolve) => setTimeout(resolve, 0));
+			readManualDisableFlagSync.mockReturnValue(true);
+			readManualDisableFlag.mockResolvedValue(true);
+			const { resolveKBPath } = await import("../../cli/src/core/KBPathResolver.js");
+			const { readSchemaV5State } = await import("../../cli/src/core/SchemaV5Migration.js");
+			vi.mocked(resolveKBPath).mockClear();
+			vi.mocked(readSchemaV5State).mockClear();
+
+			activate(makeContext());
+			// initializeKB is fire-and-forget; give its (gated) body time to run.
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(readSchemaV5State).not.toHaveBeenCalled();
+			expect(resolveKBPath).not.toHaveBeenCalled();
+			expect(mockMigrationEngineInstance.runMigration).not.toHaveBeenCalled();
+			expect(mockMigrationEngineInstance.runStaleChildCleanup).not.toHaveBeenCalled();
+		});
+
+		it("skips refreshHookPathsIfStale when manuallyDisabled is true at activate", async () => {
+			readManualDisableFlagSync.mockReturnValue(true);
+			readManualDisableFlag.mockResolvedValue(true);
+			mockBridge.refreshHookPathsIfStale.mockClear();
+
+			activate(makeContext());
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			// Its stale-dist-path branch performs a full hook reinstall after
+			// every extension upgrade — running it would override the opt-out.
+			expect(mockBridge.refreshHookPathsIfStale).not.toHaveBeenCalled();
+		});
+	});
+
 	// ── KB folder auto-init / v3 stale-child cleanup on activate ─────────────
 	//
 	// Regression coverage for two related bugs:
@@ -2104,6 +2200,96 @@ describe("Extension", () => {
 					false,
 				);
 			});
+
+			it("releases the in-memory flag and re-runs initializeKB after a successful enable", async () => {
+				// Let activate's own fire-and-forget initializeKB settle so its
+				// resolveKBPath call doesn't pollute the ordering assertions below.
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				const { resolveKBPath } = await import("../../cli/src/core/KBPathResolver.js");
+				vi.mocked(resolveKBPath).mockClear();
+				mockBridge.enable.mockClear();
+				setManuallyDisabledMock.mockClear();
+
+				const handler = getRegisteredCommand("jollimemory.enableJolliMemory");
+				await handler();
+
+				expect(setManuallyDisabledMock).toHaveBeenCalledWith(false);
+				// initializeKB (observable via resolveKBPath) must run AFTER
+				// bridge.enable so the installer has already written the
+				// dist-paths/hook entries, and AFTER the flag release so the
+				// cli-side gates don't short-circuit it again.
+				expect(resolveKBPath).toHaveBeenCalled();
+				const enableIdx = mockBridge.enable.mock.invocationCallOrder[0];
+				const setIdx = setManuallyDisabledMock.mock.invocationCallOrder[0];
+				const kbIdx = vi.mocked(resolveKBPath).mock.invocationCallOrder[0];
+				expect(enableIdx).toBeLessThan(setIdx);
+				expect(setIdx).toBeLessThan(kbIdx);
+			});
+
+			it("tolerates a marker-unlink failure: flag released and initializeKB still runs", async () => {
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				const { resolveKBPath } = await import("../../cli/src/core/KBPathResolver.js");
+				vi.mocked(resolveKBPath).mockClear();
+				setManuallyDisabledMock.mockClear();
+				writeManualDisableFlag.mockRejectedValueOnce(new Error("EPERM: unlink"));
+
+				const handler = getRegisteredCommand("jollimemory.enableJolliMemory");
+				await handler();
+
+				// The in-memory flag is released BEFORE the marker write, so the
+				// session stays functional even when clearing the marker fails.
+				expect(setManuallyDisabledMock).toHaveBeenCalledWith(false);
+				expect(resolveKBPath).toHaveBeenCalled();
+			});
+
+			it("runs the transcript discovery catch-up after initializeKB on enable success", async () => {
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				const { resolveKBPath } = await import("../../cli/src/core/KBPathResolver.js");
+				vi.mocked(resolveKBPath).mockClear();
+				catchUpTranscriptDiscovery.mockClear();
+
+				const handler = getRegisteredCommand("jollimemory.enableJolliMemory");
+				await handler();
+
+				expect(catchUpTranscriptDiscovery).toHaveBeenCalledWith("/test/workspace");
+				// Must run AFTER initializeKB (observable via resolveKBPath) so the
+				// catch-up sees a fully-initialized KB folder.
+				const kbIdx = vi.mocked(resolveKBPath).mock.invocationCallOrder[0];
+				const catchUpIdx = catchUpTranscriptDiscovery.mock.invocationCallOrder[0];
+				expect(kbIdx).toBeLessThan(catchUpIdx);
+			});
+
+			it("does not run the discovery catch-up when enable fails", async () => {
+				catchUpTranscriptDiscovery.mockClear();
+				mockBridge.enable.mockResolvedValue({
+					success: false,
+					message: "git not found",
+				});
+
+				const handler = getRegisteredCommand("jollimemory.enableJolliMemory");
+				await handler();
+
+				expect(catchUpTranscriptDiscovery).not.toHaveBeenCalled();
+			});
+
+			it("keeps the flag and skips initializeKB catch-up when enable fails", async () => {
+				await new Promise((resolve) => setTimeout(resolve, 0));
+				const { resolveKBPath } = await import("../../cli/src/core/KBPathResolver.js");
+				vi.mocked(resolveKBPath).mockClear();
+				setManuallyDisabledMock.mockClear();
+				writeManualDisableFlag.mockClear();
+				mockBridge.enable.mockResolvedValue({
+					success: false,
+					message: "git not found",
+				});
+
+				const handler = getRegisteredCommand("jollimemory.enableJolliMemory");
+				await handler();
+
+				expect(writeManualDisableFlag).not.toHaveBeenCalled();
+				expect(setManuallyDisabledMock).not.toHaveBeenCalled();
+				expect(resolveKBPath).not.toHaveBeenCalled();
+			});
 		});
 
 		describe("disableJolliMemory", () => {
@@ -2169,6 +2355,23 @@ describe("Extension", () => {
 				expect(showErrorMessage).toHaveBeenCalledWith(
 					expect.stringContaining("could not save the disable setting"),
 				);
+			});
+
+			it("flips the in-memory flag to true after the marker write and before bridge.disable", async () => {
+				writeManualDisableFlag.mockClear();
+				setManuallyDisabledMock.mockClear();
+				mockBridge.disable.mockClear();
+				const handler = getRegisteredCommand("jollimemory.disableJolliMemory");
+				await handler();
+
+				expect(setManuallyDisabledMock).toHaveBeenCalledWith(true);
+				// Order: writeManualDisableFlag(true) → setManuallyDisabled(true)
+				// → bridge.disable, so every write after the flip is silenced.
+				const writeIdx = writeManualDisableFlag.mock.invocationCallOrder[0];
+				const setIdx = setManuallyDisabledMock.mock.invocationCallOrder[0];
+				const disableIdx = mockBridge.disable.mock.invocationCallOrder[0];
+				expect(writeIdx).toBeLessThan(setIdx);
+				expect(setIdx).toBeLessThan(disableIdx);
 			});
 		});
 
@@ -6812,6 +7015,54 @@ describe("Extension", () => {
 				expect(mockBridge.enable).not.toHaveBeenCalled();
 			});
 
+			it("first-install path: no marker — auto-enable fires and KB init runs ungated", async () => {
+				mockBridge.getStatus.mockResolvedValue({
+					enabled: false,
+					gitHookInstalled: false,
+					worktreeHooksInstalled: false,
+				});
+				mockBridge.enable.mockClear();
+				readManualDisableFlag.mockResolvedValue(false);
+				readManualDisableFlagSync.mockReturnValue(false);
+				const { resolveKBPath } = await import("../../cli/src/core/KBPathResolver.js");
+				vi.mocked(resolveKBPath).mockClear();
+
+				const ctx = makeContext();
+				activate(ctx);
+
+				await vi.waitFor(() => {
+					expect(mockBridge.enable).toHaveBeenCalled();
+				});
+				expect(setManuallyDisabledMock).toHaveBeenCalledWith(false);
+				// initializeKB ran without gating — the KB folder claim happened.
+				await vi.waitFor(() => {
+					expect(resolveKBPath).toHaveBeenCalled();
+				});
+			});
+
+			it("disabled-startup path: marker present — neither auto-enable nor KB init runs", async () => {
+				mockBridge.getStatus.mockResolvedValue({
+					enabled: false,
+					gitHookInstalled: false,
+					worktreeHooksInstalled: false,
+				});
+				mockBridge.enable.mockClear();
+				readManualDisableFlag.mockResolvedValue(true);
+				readManualDisableFlagSync.mockReturnValue(true);
+				const { resolveKBPath } = await import("../../cli/src/core/KBPathResolver.js");
+				vi.mocked(resolveKBPath).mockClear();
+
+				const ctx = makeContext();
+				activate(ctx);
+
+				await vi.waitFor(() => {
+					expect(mockStatusStore.refresh).toHaveBeenCalled();
+				});
+				expect(setManuallyDisabledMock).toHaveBeenCalledWith(true);
+				expect(mockBridge.enable).not.toHaveBeenCalled();
+				expect(resolveKBPath).not.toHaveBeenCalled();
+			});
+
 			it("does NOT call bridge.enable when status.enabled is already true", async () => {
 				mockBridge.getStatus.mockResolvedValue({
 					enabled: true,
@@ -8181,6 +8432,23 @@ describe("Extension", () => {
 			expect(mockArchiveKBFolder).toHaveBeenCalledWith("/test/kb-2", undefined);
 			expect(mockArchiveKBFolder).toHaveBeenCalledTimes(2);
 			expect(result.message).toContain("memories migrated to /test/kb");
+		});
+
+		it("refuses outright while the project is manually disabled", async () => {
+			activate(makeContext());
+			const handler = getRegisteredCommand("jollimemory.rebuildKnowledgeBase");
+
+			manuallyDisabledState.value = true;
+			try {
+				const result = (await handler()) as { ok: boolean; message: string };
+				expect(result.ok).toBe(false);
+				expect(result.message).toContain("disabled");
+			} finally {
+				manuallyDisabledState.value = false;
+			}
+			// Neither the migration nor the Repoint identity write may run.
+			expect(mockMigrationEngineInstance.runMigration).not.toHaveBeenCalled();
+			expect(mockMetadataManagerInstance.saveConfig).not.toHaveBeenCalled();
 		});
 
 		// Same successful-rebuild path, but with memoriesStore.hasFirstLoaded

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -15,6 +15,7 @@ import {
 	setExcluded,
 } from "../../cli/src/core/CommitSelectionStore.js";
 import { discoverCodexConversations } from "../../cli/src/core/CodexDiscovery.js";
+import { catchUpTranscriptDiscovery } from "../../cli/src/core/DiscoveryCatchUp.js";
 import type { FolderStorage, ForceRegenerateResult } from "../../cli/src/core/FolderStorage.js";
 import { getDefaultBranch } from "../../cli/src/core/GitOps.js";
 import {
@@ -56,7 +57,7 @@ import {
 	aggregateEstimatedCost,
 } from "../../cli/src/core/SummaryTree.js";
 import type { StorageProvider } from "../../cli/src/core/StorageProvider.js";
-import { ORPHAN_BRANCH } from "../../cli/src/Logger.js";
+import { isManuallyDisabled, ORPHAN_BRANCH, setManuallyDisabled } from "../../cli/src/Logger.js";
 import type { SourceId, StatusInfo } from "../../cli/src/Types.js";
 import { execFileSyncHidden } from "../../cli/src/util/Subprocess.js";
 import { runCopyBranchRecallPrompt, runRecallInClaudeCode } from "./commands/BranchRecallCommands.js";
@@ -101,6 +102,7 @@ import { readBackfillDismissFlag, writeBackfillDismissFlag } from "./services/Ba
 import { KbFoldersService } from "./services/KbFoldersService.js";
 import {
 	readManualDisableFlag,
+	readManualDisableFlagSync,
 	writeManualDisableFlag,
 } from "./services/ManualDisableFlag.js";
 import { MemoryFileDecorationProvider } from "./services/MemoryFileDecorationProvider.js";
@@ -444,6 +446,10 @@ export function activate(context: vscode.ExtensionContext): void {
 		return;
 	}
 
+	// MUST run before initLogger so the disabled-state path writes no debug.log.
+	// Sync read is deliberate: we cannot await here without making activate async.
+	setManuallyDisabled(readManualDisableFlagSync(workspaceRoot));
+
 	initLogger(workspaceRoot);
 	log.info("activate", "Activating JolliMemory extension", {
 		workspaceRoot,
@@ -703,11 +709,28 @@ export function activate(context: vscode.ExtensionContext): void {
 	const kbInitPromise = new Promise<void>((resolve) => {
 		resolveKbInit = resolve;
 	});
+	// Serialize every initializeKB() run. Its steps do unlocked
+	// read-modify-write on manifest.json / migration.json / index.json, so
+	// two concurrent runs (activate's fire-and-forget plus the enable
+	// command's catch-up, or a double-clicked enable) would race. All call
+	// sites go through this chain; errors are isolated per run so one
+	// failed run never wedges the chain for later callers. `initializeKB`
+	// is a function declaration further down — hoisted, so referencing it
+	// here is safe. The thunk handed to activateSync doubles as the
+	// orchestrator's per-round barrier: kbInitPromise alone cannot cover
+	// the enable command's catch-up run (it has already resolved by then).
+	let kbInitChain: Promise<void> = Promise.resolve();
+	function runInitializeKB(): Promise<void> {
+		const run = kbInitChain.then(() => initializeKB());
+		kbInitChain = run.catch(() => {});
+		return run;
+	}
 	const syncActivation = activateSync(
 		context,
 		statusBar,
 		kbInitPromise,
 		statusStore,
+		() => kbInitChain,
 	).catch((e) => {
 		log.warn("Memory Bank sync activation failed: %s", (e as Error).message);
 		return null;
@@ -1502,6 +1525,16 @@ export function activate(context: vscode.ExtensionContext): void {
 	// folder init + auto-migration) are serialized into one async function to
 	// prevent race conditions from concurrent orphan branch and config access.
 	async function initializeKB(): Promise<void> {
+		// Manually-disabled startup: skip everything — legacy migrations, the
+		// v5 schema migration, the KB-folder identity claim, full migration and
+		// the stale-child sweep. All of them write to disk, which a disabled
+		// project must never do. The enable command re-runs this function to
+		// catch up. The `.finally()` on the call site still fires, so the
+		// kbInit sync gate is released as usual.
+		if (isManuallyDisabled()) {
+			return;
+		}
+
 		// Dynamic imports are used throughout initializeKB because these cli/
 		// modules depend on Node-only APIs (fs, child_process). Static imports
 		// would cause esbuild to bundle them into the VS Code extension,
@@ -1730,7 +1763,8 @@ export function activate(context: vscode.ExtensionContext): void {
 		);
 		resolveKbInit();
 	}, 60_000);
-	initializeKB().finally(() => {
+
+	runInitializeKB().finally(() => {
 		clearTimeout(kbInitWatchdog);
 		resolveKbInit();
 		// Pre-push sync catch-up (JOLLI-1900): retry any commits left in
@@ -2031,6 +2065,16 @@ export function activate(context: vscode.ExtensionContext): void {
 		vscode.commands.registerCommand(
 			"jollimemory.rebuildKnowledgeBase",
 			async (): Promise<{ ok: boolean; message: string }> => {
+				// While manually disabled, the identity write below would be
+				// silently gated but `folder.ensure()` and the Repoint
+				// `saveConfig` would not — one click would de-identify the old
+				// folder while migrating nothing. Refuse outright.
+				if (isManuallyDisabled()) {
+					return {
+						ok: false,
+						message: "Jolli Memory is disabled for this project — enable it first.",
+					};
+				}
 				try {
 					const {
 						extractRepoName,
@@ -2223,6 +2267,12 @@ export function activate(context: vscode.ExtensionContext): void {
 					log.error("cmd", "enable failed", { message: result.message });
 					vscode.window.showErrorMessage(`Jolli Memory: ${result.message}`);
 				} else {
+					// Release the in-memory flag FIRST so this session is fully
+					// functional even if clearing the on-disk marker below fails
+					// (e.g. EPERM/EBUSY on the unlink under Windows). MUST happen
+					// before initializeKB() below, otherwise the gates inside it
+					// would short-circuit again.
+					setManuallyDisabled(false);
 					// Clear the opt-out so subsequent IDE restarts auto-enable as
 					// usual. Done only on success — a failed install means the
 					// previous (manuallyDisabled) state is still the user's intent.
@@ -2236,6 +2286,25 @@ export function activate(context: vscode.ExtensionContext): void {
 								err instanceof Error ? err.message : String(err)
 							}. Run "Jolli Memory: Enable" again to clear the opt-out.`,
 						);
+					}
+					// Catch up KB folder + migrations if they were skipped during a
+					// disabled-startup activate. Safe to re-run: every step inside
+					// is idempotent (config.json / migration.json state files), and
+					// runInitializeKB serializes against any still-running
+					// activate-time run.
+					await runInitializeKB();
+					// Drain the plan/reference discovery backlog from the disabled
+					// window. The plans-dir watcher's one-shot create events were
+					// dropped while disabled, and the StopHook cursor froze (hooks
+					// were uninstalled); this re-scans each known transcript from
+					// the frozen cursor forward so plans/references authored while
+					// disabled surface even for sessions that see no further turns.
+					// Awaited before the refresh below so the panels pick up the
+					// freshly-written plans.json. Idempotent; best-effort.
+					try {
+						await catchUpTranscriptDiscovery(workspaceRoot);
+					} catch (err) {
+						handleError("enable.catchUpDiscovery")(err);
 					}
 					// JOLLI-1904 (funnel): surface enabled. Mirrors IntelliJ
 					// surface_enabled { trigger }; surface=vscode auto-injected.
@@ -2312,6 +2381,9 @@ export function activate(context: vscode.ExtensionContext): void {
 					);
 					return;
 				}
+				// Silence the in-memory flag immediately so any log/write triggered
+				// by bridge.disable() or the refresh chain below does not hit disk.
+				setManuallyDisabled(true);
 				const result = await bridge.disable();
 				if (!result.success) {
 					log.error("cmd", "disable failed", { message: result.message });
@@ -3996,8 +4068,15 @@ export function activate(context: vscode.ExtensionContext): void {
 	// (e.g. jolli.jollimemory-vscode-0.1.0 → 0.2.0). If JolliMemory is enabled
 	// and the hook scripts point to the old directory, silently re-enable to
 	// update the paths — no manual disable → enable step required.
-	bridge
-		.refreshHookPathsIfStale(context.extensionPath)
+	//
+	// Manually-disabled projects skip the refresh: `refreshHookPathsIfStale`
+	// calls `enable()` (a full hook reinstall) whenever the dist-path entry is
+	// stale — which is true after every extension upgrade — so running it here
+	// would both write to disk and silently override the user's opt-out.
+	const hookPathRefresh = isManuallyDisabled()
+		? Promise.resolve(false)
+		: bridge.refreshHookPathsIfStale(context.extensionPath);
+	hookPathRefresh
 		.then(async (mismatch) => {
 			log.debug("activate", "Hook path refresh check complete");
 

--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -335,6 +335,7 @@ vi.mock("../../cli/src/Logger.js", () => ({
 		error: vi.fn(),
 	})),
 	setLogDir: vi.fn(),
+	isManuallyDisabled: () => false,
 }));
 
 vi.mock("./core/PlanService.js", () => ({

--- a/vscode/src/TelemetryActivation.test.ts
+++ b/vscode/src/TelemetryActivation.test.ts
@@ -24,6 +24,7 @@ vi.mock("../../cli/src/core/SessionTracker.js", () => ({
 	saveConfig: (...args: unknown[]) => saveConfig(...(args as [])),
 }));
 
+import { setManuallyDisabled } from "../../cli/src/Logger.js";
 import {
 	activateExtensionTelemetry,
 	flushExtensionTelemetry,
@@ -51,6 +52,9 @@ beforeEach(() => {
 	vi.clearAllMocks();
 	shouldShowTelemetryNotice.mockReturnValue(false);
 	loadConfig.mockResolvedValue({});
+	// Reset the shared in-memory zero-write flag so a prior test's disabled state
+	// never leaks into the next (setManuallyDisabled is real module state here).
+	setManuallyDisabled(false);
 });
 
 describe("activateExtensionTelemetry", () => {
@@ -112,6 +116,16 @@ describe("activateExtensionTelemetry", () => {
 		const { deps } = makeDeps();
 		await expect(activateExtensionTelemetry("/repo", deps)).resolves.toBeUndefined();
 	});
+
+	it("suppresses the automatic client_activated write in a manually-disabled repo", async () => {
+		setManuallyDisabled(true);
+		const { deps } = makeDeps();
+		await activateExtensionTelemetry("/repo", deps);
+		// bootstrap still runs (in-memory / machine-global consent, no repo write),
+		// but the per-repo activation event must not be buffered when disabled.
+		expect(bootstrapTelemetry).toHaveBeenCalled();
+		expect(track).not.toHaveBeenCalled();
+	});
 });
 
 describe("flushExtensionTelemetry", () => {
@@ -123,6 +137,12 @@ describe("flushExtensionTelemetry", () => {
 	it("passes platformDisabled=false when the host telemetry is enabled", () => {
 		flushExtensionTelemetry("/repo", false);
 		expect(flushTelemetryNow).toHaveBeenCalledWith("/repo", { platformDisabled: false });
+	});
+
+	it("skips the flush entirely in a manually-disabled repo (no per-repo buffer rewrite)", () => {
+		setManuallyDisabled(true);
+		flushExtensionTelemetry("/repo", false);
+		expect(flushTelemetryNow).not.toHaveBeenCalled();
 	});
 });
 

--- a/vscode/src/TelemetryActivation.ts
+++ b/vscode/src/TelemetryActivation.ts
@@ -13,6 +13,7 @@
  * URL) are injected so this module is unit-testable without a vscode mock; the
  * CLI core functions are imported from the bundled `cli/src/**`.
  */
+import { isManuallyDisabled } from "../../cli/src/Logger.js";
 import { loadConfig, saveConfig } from "../../cli/src/core/SessionTracker.js";
 import { shutdownTelemetry, track } from "../../cli/src/core/Telemetry.js";
 import { shouldShowTelemetryNotice } from "../../cli/src/core/TelemetryConsent.js";
@@ -41,7 +42,12 @@ export async function activateExtensionTelemetry(cwd: string, deps: TelemetryAct
 	// (a real session), carrying `surface_version` in the envelope; the metric dedups
 	// on first-seen (install_id, surface_version). No-op when telemetry is off — track
 	// re-gates consent. Unlike `app_installed` (once per machine), this catches upgrades.
-	track("client_activated");
+	// Suppressed in a manually-disabled repo: this is an automatic activation write
+	// into the repo's own `.jolli/jollimemory/` buffer, so the zero-write contract
+	// applies (unlike the user-gesture funnel events surface_enabled/disabled).
+	if (!isManuallyDisabled()) {
+		track("client_activated");
+	}
 	try {
 		const config = await loadConfig();
 		if (shouldShowTelemetryNotice({ config, platformDisabled: deps.platformDisabled })) {
@@ -68,6 +74,11 @@ export async function activateExtensionTelemetry(cwd: string, deps: TelemetryAct
  * turned VS Code telemetry off. Callers pass the live signal each tick.
  */
 export function flushExtensionTelemetry(cwd: string, platformDisabled: boolean): void {
+	// Every caller (the activate-time flush, the 60s interval, and the sidebar
+	// tick) is automatic, and a partial-send flush rewrites the per-repo buffer.
+	// A manually-disabled repo must stay zero-write, so skip the flush entirely
+	// there; it resumes automatically once the live flag flips back on enable.
+	if (isManuallyDisabled()) return;
 	void flushTelemetryNow(cwd, { platformDisabled });
 }
 

--- a/vscode/src/core/NoteService.test.ts
+++ b/vscode/src/core/NoteService.test.ts
@@ -83,6 +83,7 @@ vi.mock("../../../cli/src/core/SummaryStore.js", () => ({
 
 vi.mock("../../../cli/src/Logger.js", () => ({
 	getJolliMemoryDir: mockGetJolliMemoryDir,
+	isManuallyDisabled: () => false,
 }));
 
 vi.mock("../util/Logger.js", () => ({

--- a/vscode/src/core/NoteService.ts
+++ b/vscode/src/core/NoteService.ts
@@ -29,7 +29,7 @@ import {
 } from "../../../cli/src/core/SessionTracker.js";
 import type { StorageProvider } from "../../../cli/src/core/StorageProvider.js";
 import { storeNotes } from "../../../cli/src/core/SummaryStore.js";
-import { getJolliMemoryDir } from "../../../cli/src/Logger.js";
+import { getJolliMemoryDir, isManuallyDisabled } from "../../../cli/src/Logger.js";
 import type { NoteFormat, NoteReference } from "../../../cli/src/Types.js";
 import type { NoteEntry, NoteInfo } from "../Types.js";
 import { log } from "../util/Logger.js";
@@ -49,7 +49,10 @@ export async function detectNotes(cwd: string): Promise<Array<NoteInfo>> {
 	// persist the normalised registry once so plans.json is cleaned on first
 	// panel refresh after upgrade (deterministic-writeback migration).
 	const { registry, changed } = await loadPlansRegistryWithStatus(cwd);
-	if (changed) {
+	// Skipped while manually disabled — this is a read-side refresh and the
+	// write-back would touch plans.json + plans.lock; the next enabled
+	// refresh performs the same one-shot migration.
+	if (changed && !isManuallyDisabled()) {
 		// Migration writeback (rare). Take plans.lock and re-read fresh inside it
 		// so this cleanup can't clobber a concurrent write. The list below is built
 		// from the pre-lock snapshot, which is fine for a read-side refresh.

--- a/vscode/src/core/PlanService.test.ts
+++ b/vscode/src/core/PlanService.test.ts
@@ -126,6 +126,7 @@ vi.mock("node:child_process", () => ({
 
 // ─── Import under test (after mocks) ────────────────────────────────────────
 
+import { setManuallyDisabled } from "../../../cli/src/Logger.js";
 import {
 	addPlanToRegistry,
 	archivePlanForCommit,
@@ -847,6 +848,26 @@ describe("PlanService", () => {
 			expect(savePlansRegistry).not.toHaveBeenCalled();
 		});
 
+		it("skips the cleanup write-back while the project is manually disabled", async () => {
+			const entry = makeEntry();
+			loadPlansRegistry.mockResolvedValue({ version: 1, plans: { "test-plan": entry } });
+			loadPlansRegistryWithStatus.mockResolvedValueOnce({
+				registry: { version: 1, plans: { "test-plan": entry } },
+				changed: true,
+			});
+			mockExistsSync.mockReturnValue(true);
+			mockReadFileSync.mockReturnValue("# Test Plan");
+			mockStatSync.mockReturnValue({ mtime: new Date("2025-06-01T00:00:00.000Z") });
+
+			setManuallyDisabled(true);
+			try {
+				await detectPlans(CWD);
+				expect(savePlansRegistry).not.toHaveBeenCalled();
+			} finally {
+				setManuallyDisabled(false);
+			}
+		});
+
 		it("filters an uncommitted plan whose file vanishes between cleanup and render (L145 TOCTOU)", async () => {
 			// The cleanup pass sees the file present (survives), but toPlanInfo's
 			// re-check finds it gone → the L145 `commitHash===null && !existsSync`
@@ -1480,6 +1501,21 @@ describe("PlanService", () => {
 			await registerNewPlan("ghost-plan", CWD);
 
 			expect(savePlansRegistry).not.toHaveBeenCalled();
+		});
+
+		it("is a no-op while the project is manually disabled (the watcher keeps firing)", async () => {
+			loadPlansRegistry.mockResolvedValue(emptyRegistry());
+			mockExistsSync.mockReturnValue(true);
+			mockReadFileSync.mockReturnValue("# Gated Plan");
+
+			setManuallyDisabled(true);
+			try {
+				await registerNewPlan("gated-plan", CWD);
+				expect(loadPlansRegistry).not.toHaveBeenCalled();
+				expect(savePlansRegistry).not.toHaveBeenCalled();
+			} finally {
+				setManuallyDisabled(false);
+			}
 		});
 	});
 

--- a/vscode/src/core/PlanService.ts
+++ b/vscode/src/core/PlanService.ts
@@ -34,7 +34,7 @@ import {
 } from "../../../cli/src/core/SessionTracker.js";
 import type { StorageProvider } from "../../../cli/src/core/StorageProvider.js";
 import { storePlans } from "../../../cli/src/core/SummaryStore.js";
-import { getJolliMemoryDir } from "../../../cli/src/Logger.js";
+import { getJolliMemoryDir, isManuallyDisabled } from "../../../cli/src/Logger.js";
 import type { PlanReference } from "../../../cli/src/Types.js";
 import type { PlanEntry, PlanInfo } from "../Types.js";
 import { log } from "../util/Logger.js";
@@ -79,7 +79,12 @@ export async function detectPlans(cwd: string): Promise<Array<PlanInfo>> {
 			cleaned = true;
 		}
 	}
-	if (cleaned || changed) {
+	// The write-back is skipped while manually disabled: detectPlans runs on
+	// read-side refreshes (including the disabled-startup initialLoad before
+	// refreshStatusBar corrects the stores' enabled flags), and the cleanup
+	// would write plans.json + plans.lock. Purely a deferral — the next
+	// enabled refresh converges identically.
+	if ((cleaned || changed) && !isManuallyDisabled()) {
 		// Re-run the convergence cleanup on a fresh in-lock snapshot so it can't
 		// clobber a concurrent write (the Codex-discovery tick in this host, or a
 		// cross-process StopHook/QueueWorker). The display list uses the pre-lock
@@ -315,6 +320,12 @@ export async function registerNewPlan(
 	slug: string,
 	cwd: string,
 ): Promise<void> {
+	// The plans-dir watcher keeps firing while the project is manually
+	// disabled (Claude Code sessions can still save plan files); registering
+	// would write plans.json + plans.lock in the project dir. The plan is not
+	// lost — re-enabling and saving it again (or the StopHook once hooks are
+	// reinstalled) registers it.
+	if (isManuallyDisabled()) return;
 	const registry = await loadPlansRegistry(cwd);
 	if (slug in registry.plans) {
 		return;

--- a/vscode/src/core/ReferenceService.test.ts
+++ b/vscode/src/core/ReferenceService.test.ts
@@ -73,6 +73,7 @@ vi.mock("vscode", () => ({
 	},
 }));
 
+import { setManuallyDisabled } from "../../../cli/src/Logger.js";
 import type { ReferenceEntry } from "../../../cli/src/Types.js";
 import type { ReferenceInfo } from "../Types.js";
 import {
@@ -160,6 +161,20 @@ describe("detectReferences", () => {
 		await detectReferences("/repo");
 
 		expect(mockSavePlansRegistry).toHaveBeenCalledTimes(1);
+	});
+
+	it("skips the writeback when the project is manually disabled", async () => {
+		mockLoadPlansRegistryWithStatus.mockResolvedValueOnce({
+			registry: { version: 1, plans: {}, references: {} },
+			changed: true,
+		});
+		setManuallyDisabled(true);
+		try {
+			await detectReferences("/repo");
+			expect(mockSavePlansRegistry).not.toHaveBeenCalled();
+		} finally {
+			setManuallyDisabled(false);
+		}
 	});
 
 	it("skips the writeback when a concurrent process already normalised it (in-lock fresh.changed=false)", async () => {

--- a/vscode/src/core/ReferenceService.ts
+++ b/vscode/src/core/ReferenceService.ts
@@ -30,6 +30,7 @@ import {
 	savePlansRegistry,
 } from "../../../cli/src/core/SessionTracker.js";
 import { deleteReferenceMarkdown } from "../../../cli/src/core/references/ReferenceStore.js";
+import { isManuallyDisabled } from "../../../cli/src/Logger.js";
 import type {
 	PlansRegistry,
 	ReferenceEntry,
@@ -55,7 +56,10 @@ export async function detectReferences(
 	// persist the normalised registry once so plans.json is cleaned on first
 	// panel refresh after upgrade (deterministic-writeback migration).
 	const { registry, changed } = await loadPlansRegistryWithStatus(cwd);
-	if (changed) {
+	// Skipped while manually disabled — same contract as detectPlans /
+	// detectNotes: read-side refreshes must not write plans.json/plans.lock;
+	// the next enabled refresh performs the identical one-shot migration.
+	if (changed && !isManuallyDisabled()) {
 		// Migration writeback (rare — only after a legacy-purge on upgrade). Take
 		// plans.lock and re-read fresh inside it so this cleanup can't clobber a
 		// concurrent reference/plan/note write. The display list below is built

--- a/vscode/src/services/KbFoldersService.ts
+++ b/vscode/src/services/KbFoldersService.ts
@@ -58,6 +58,7 @@ import {
 } from "../../../cli/src/core/KBRepoDiscoverer.js";
 import type { Manifest, ManifestEntry } from "../../../cli/src/core/KBTypes.js";
 import { MetadataManager } from "../../../cli/src/core/MetadataManager.js";
+import { isManuallyDisabled } from "../../../cli/src/Logger.js";
 import type { FolderFileKind, FolderNode } from "../views/SidebarMessages.js";
 
 /**
@@ -239,7 +240,9 @@ export class KbFoldersService {
 			// manifest mutation the sidebar heal can do is `updateManifest`
 			// inside regenerate, which is keyed by fileId and is idempotent
 			// under concurrent re-runs.
-			if (!this.cleanRepos.has(repo.kbRoot)) {
+			// Reconcile + heal both write (manifest rewrite, regenerated .md) —
+			// skipped while manually disabled; the tree below still lists.
+			if (!this.cleanRepos.has(repo.kbRoot) && !isManuallyDisabled()) {
 				try {
 					const mm = new MetadataManager(join(repo.kbRoot, ".jolli"));
 					mm.reconcile(repo.kbRoot);

--- a/vscode/src/services/ManualDisableFlag.test.ts
+++ b/vscode/src/services/ManualDisableFlag.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { readManualDisableFlag, writeManualDisableFlag } from "./ManualDisableFlag.js";
+import { readManualDisableFlag, readManualDisableFlagSync, writeManualDisableFlag } from "./ManualDisableFlag.js";
 
 // The flag is CLI-owned (RepoProfile / profile.json) and repo-wide; this module
 // is a thin re-export. `git init` makes each temp dir a real repo so we exercise
@@ -44,5 +44,16 @@ describe("ManualDisableFlag (repo-wide, profile.json backed)", () => {
 		await mkdir(join(cwd, ".jolli", "jollimemory"), { recursive: true });
 		await writeFile(join(cwd, ".jolli", "jollimemory", "disabled-by-user"), new Date(0).toISOString());
 		expect(await readManualDisableFlag(cwd)).toBe(true);
+	});
+
+	describe("readManualDisableFlagSync", () => {
+		it("returns true when marker file exists", async () => {
+			await writeManualDisableFlag(cwd, true);
+			expect(readManualDisableFlagSync(cwd)).toBe(true);
+		});
+
+		it("returns false when marker file is absent", () => {
+			expect(readManualDisableFlagSync(cwd)).toBe(false);
+		});
 	});
 });

--- a/vscode/src/services/ManualDisableFlag.ts
+++ b/vscode/src/services/ManualDisableFlag.ts
@@ -13,4 +13,8 @@
  * site) so existing Extension.ts imports and their test mocks stay unchanged.
  */
 
-export { readManualDisableFlag, writeManualDisableFlag } from "../../../cli/src/core/RepoProfile.js";
+export {
+	readManualDisableFlag,
+	readManualDisableFlagSync,
+	writeManualDisableFlag,
+} from "../../../cli/src/core/RepoProfile.js";

--- a/vscode/src/sync/StatusOrchestrator.test.ts
+++ b/vscode/src/sync/StatusOrchestrator.test.ts
@@ -24,6 +24,7 @@ vi.mock("../../../cli/src/core/SessionTracker.js", () => ({
 	loadConfig,
 }));
 
+import { setManuallyDisabled } from "../../../cli/src/Logger.js";
 import type { SyncRoundResult } from "../../../cli/src/sync/SyncTypes.js";
 import {
 	buildDetail,
@@ -252,6 +253,105 @@ describe("StatusOrchestrator", () => {
 		expect(engine.runRound).toHaveBeenCalledWith(
 			expect.objectContaining({ reason: "manual" }),
 		);
+	});
+
+	it("skips the round (manual included) when the project is manually disabled", async () => {
+		const engine = makeStubEngine();
+		const statusBar = makeStubStatusBar();
+		const orch = new StatusOrchestrator({
+			engine,
+			statusBar,
+			workspaceFolder: FAKE_WORKSPACE_FOLDER,
+			timer: makeTimer(),
+		});
+		setManuallyDisabled(true);
+		try {
+			await orch.syncNow();
+		} finally {
+			setManuallyDisabled(false);
+		}
+		expect(engine.runRound).not.toHaveBeenCalled();
+		// The pre-tick state is restored — the status bar is not stuck on "syncing".
+		const lastCall = statusBar.setSyncState.mock.calls.at(-1);
+		expect(lastCall?.[0]).not.toBe("syncing");
+		orch.dispose();
+	});
+
+	it("waits for the kbInitBarrier before running the round", async () => {
+		let release!: () => void;
+		const barrier = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const engine = makeStubEngine();
+		const orch = new StatusOrchestrator({
+			engine,
+			statusBar: makeStubStatusBar(),
+			workspaceFolder: FAKE_WORKSPACE_FOLDER,
+			timer: makeTimer(),
+			kbInitBarrier: () => barrier,
+		});
+		const round = orch.syncNow();
+		for (let i = 0; i < 6; i++) await new Promise((r) => setImmediate(r));
+		expect(engine.runRound).not.toHaveBeenCalled();
+		release();
+		await round;
+		expect(engine.runRound).toHaveBeenCalledTimes(1);
+		orch.dispose();
+	});
+
+	it("cancels a queued poll tick when stop() runs while parked on the kbInitBarrier", async () => {
+		let release!: () => void;
+		const barrier = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const engine = makeStubEngine();
+		const timer = makeTimer();
+		const orch = new StatusOrchestrator({
+			engine,
+			statusBar: makeStubStatusBar(),
+			workspaceFolder: FAKE_WORKSPACE_FOLDER,
+			timer,
+			kbInitBarrier: () => barrier,
+		});
+		orch.start();
+		timer.fire();
+		for (let i = 0; i < 6; i++) await new Promise((r) => setImmediate(r));
+		expect(engine.runRound).not.toHaveBeenCalled();
+		// stop() bumps the poll generation while the tick waits on the
+		// barrier — the post-barrier re-check must bail before the round.
+		orch.stop();
+		release();
+		for (let i = 0; i < 6; i++) await new Promise((r) => setImmediate(r));
+		expect(engine.runRound).not.toHaveBeenCalled();
+		orch.dispose();
+	});
+
+	it("skips the round when the project is disabled while parked on the kbInitBarrier", async () => {
+		let release!: () => void;
+		const barrier = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const engine = makeStubEngine();
+		const orch = new StatusOrchestrator({
+			engine,
+			statusBar: makeStubStatusBar(),
+			workspaceFolder: FAKE_WORKSPACE_FOLDER,
+			timer: makeTimer(),
+			kbInitBarrier: () => barrier,
+		});
+		const round = orch.syncNow();
+		for (let i = 0; i < 6; i++) await new Promise((r) => setImmediate(r));
+		// Disable arrives while the round is parked on the barrier — the
+		// post-barrier re-check must silence the round.
+		setManuallyDisabled(true);
+		release();
+		try {
+			await round;
+		} finally {
+			setManuallyDisabled(false);
+		}
+		expect(engine.runRound).not.toHaveBeenCalled();
+		orch.dispose();
 	});
 
 	it("propagates conflict count to the status bar when the engine reports conflicts", async () => {

--- a/vscode/src/sync/StatusOrchestrator.ts
+++ b/vscode/src/sync/StatusOrchestrator.ts
@@ -28,7 +28,7 @@
 
 import type * as vscode from "vscode";
 import { loadConfig } from "../../../cli/src/core/SessionTracker.js";
-import { createLogger } from "../../../cli/src/Logger.js";
+import { createLogger, isManuallyDisabled } from "../../../cli/src/Logger.js";
 import type { SyncEngine } from "../../../cli/src/sync/SyncEngine.js";
 import { isTerminalSyncError } from "../../../cli/src/sync/SyncTypes.js";
 
@@ -116,6 +116,18 @@ export interface StatusOrchestratorOpts {
 	 */
 	readonly readyPromise?: Promise<void>;
 	/**
+	 * Per-round barrier for in-flight `initializeKB()` runs. `readyPromise`
+	 * is one-shot — on a manually-disabled startup it resolves immediately
+	 * (the gated initializeKB body is skipped), so it cannot protect the
+	 * enable command's later catch-up run, which migrates for minutes while
+	 * sync is already unblocked. The thunk re-reads the extension's
+	 * serialized initializeKB chain at round start so a round never overlaps
+	 * a catch-up migration's half-written output. Awaited with a 60s cap —
+	 * mirroring the extension-side kbInit watchdog — so a hung run degrades
+	 * to the pre-barrier behavior instead of blocking sync forever.
+	 */
+	readonly kbInitBarrier?: () => Promise<void>;
+	/**
 	 * Fires after every completed round, regardless of outcome. Used by
 	 * the VS Code wiring to invalidate the Memory Bank tree-view cache and
 	 * tell the sidebar webview to re-list folders — `git pull` produces
@@ -177,6 +189,7 @@ export class StatusOrchestrator implements vscode.Disposable {
 	private readonly pollMs: number;
 	private readonly timer: NonNullable<StatusOrchestratorOpts["timer"]>;
 	private readonly readyPromise: Promise<void>;
+	private readonly kbInitBarrier?: () => Promise<void>;
 	/**
 	 * Most-recent phase the engine emitted during the in-flight round.
 	 * Used to label a sticky error visual when the round ends in failure.
@@ -228,6 +241,7 @@ export class StatusOrchestrator implements vscode.Disposable {
 		this.statusStore = opts.statusStore;
 		this.cwd = opts.workspaceFolder.uri.fsPath;
 		this.readyPromise = opts.readyPromise ?? Promise.resolve();
+		this.kbInitBarrier = opts.kbInitBarrier;
 		this.onRoundFinished = opts.onRoundFinished;
 		this.notifyError = opts.notifyError;
 		this.lastSuccessAt = opts.lastSuccessAt;
@@ -481,6 +495,52 @@ export class StatusOrchestrator implements vscode.Disposable {
 					// Drop the sidebar indicator too — the round will not run.
 					this.statusStore?.setSyncPhase(null);
 					return;
+				}
+				// Manually-disabled projects must not touch the Memory Bank
+				// vault (zero-write contract): a round would `git add --all`,
+				// commit and push in the vault and spawn a QueueWorker after.
+				// Checked per round — not at start() — so a disable mid-session
+				// silences the next tick and a re-enable resumes without a
+				// rebuild.
+				if (isManuallyDisabled()) {
+					log.info("sync round skipped: project is manually disabled");
+					this.setState(preTickState);
+					this.statusStore?.setSyncPhase(null);
+					return;
+				}
+				// Per-round barrier: wait out any in-flight initializeKB run
+				// (most notably the enable command's catch-up migration, which
+				// the one-shot readyPromise cannot cover). 60s cap so a hung
+				// run degrades to the pre-barrier behavior instead of blocking
+				// sync forever — mirrors the extension-side kbInit watchdog.
+				if (this.kbInitBarrier) {
+					let barrierCap: ReturnType<typeof setTimeout> | undefined;
+					await Promise.race([
+						this.kbInitBarrier().catch(() => {}),
+						new Promise<void>((resolve) => {
+							barrierCap = setTimeout(resolve, 60_000);
+						}),
+					]);
+					if (barrierCap !== undefined) clearTimeout(barrierCap);
+					// The await above opens the same cancellation windows the
+					// readyPromise wait does — re-check both before running.
+					// A disable clicked while we were parked here must silence
+					// this round (zero-write), and a stop() must cancel a
+					// queued poll tick (P2#2 semantics).
+					if (
+						queuedAtGeneration !== undefined &&
+						queuedAtGeneration !== this.pollGeneration
+					) {
+						this.setState(preTickState);
+						this.statusStore?.setSyncPhase(null);
+						return;
+					}
+					if (isManuallyDisabled()) {
+						log.info("sync round skipped: project was manually disabled while waiting on KB init");
+						this.setState(preTickState);
+						this.statusStore?.setSyncPhase(null);
+						return;
+					}
 				}
 				// Read `syncTranscripts` from the CLI config (where the
 				// Settings webview writes it). Pre-fix this read used

--- a/vscode/src/sync/VsCodeSyncBootstrap.ts
+++ b/vscode/src/sync/VsCodeSyncBootstrap.ts
@@ -107,6 +107,11 @@ export class SyncRuntime {
 		 * Optional so older callers / tests don't need to inject one.
 		 */
 		private readonly statusStore?: StatusStore,
+		/**
+		 * Per-round barrier thunk for in-flight `initializeKB()` runs —
+		 * forwarded to the orchestrator. See `StatusOrchestratorOpts.kbInitBarrier`.
+		 */
+		private readonly kbInitBarrier?: () => Promise<void>,
 	) {}
 
 	/**
@@ -382,6 +387,7 @@ export class SyncRuntime {
 					workspaceFolder: folder,
 					pollIntervalSec: config.syncPollIntervalSec,
 					readyPromise: this.readyPromise,
+					kbInitBarrier: this.kbInitBarrier,
 					onRoundFinished: this.onRoundFinished,
 					lastSuccessAt: {
 						get: () => this.context.globalState.get<number>(lastSuccessKey),
@@ -527,8 +533,13 @@ export async function activateSync(
 	 * on the sidebar) keep working unchanged.
 	 */
 	statusStore?: StatusStore,
+	/**
+	 * Per-round barrier thunk for in-flight `initializeKB()` runs — see
+	 * `StatusOrchestratorOpts.kbInitBarrier`.
+	 */
+	kbInitBarrier?: () => Promise<void>,
 ): Promise<SyncActivationResult> {
-	const runtime = new SyncRuntime(context, statusBar, readyPromise, statusStore);
+	const runtime = new SyncRuntime(context, statusBar, readyPromise, statusStore, kbInitBarrier);
 
 	// Eager build for the common case where sync was already enabled when
 	// the window opened. Errors are swallowed — activation must never fail.

--- a/vscode/src/views/SettingsWebviewPanel.test.ts
+++ b/vscode/src/views/SettingsWebviewPanel.test.ts
@@ -185,6 +185,7 @@ vi.mock("../../../cli/src/core/KBPathResolver.js", async (importOriginal) => ({
 
 // ── Import under test ────────────────────────────────────────────────────────
 
+import { setManuallyDisabled } from "../../../cli/src/Logger.js";
 import { SettingsWebviewPanel } from "./SettingsWebviewPanel.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -1669,6 +1670,40 @@ describe("SettingsWebviewPanel", () => {
 			expect(mockInstallGeminiHook).toHaveBeenCalledWith("/workspace");
 			expect(mockRemoveClaudeHook).not.toHaveBeenCalled();
 			expect(mockRemoveGeminiHook).not.toHaveBeenCalled();
+		});
+
+		it("skips hook install/removal while the project is manually disabled but still saves global config", async () => {
+			const dispatch = await setupWithLoadedConfig();
+
+			setManuallyDisabled(true);
+			try {
+				dispatch({
+					command: "applySettings",
+					maskedApiKey: "",
+					maskedJolliApiKey: "",
+					settings: {
+						apiKey: "",
+						model: "sonnet",
+						maxTokens: null,
+						jolliApiKey: "",
+						claudeEnabled: true,
+						codexEnabled: true,
+						geminiEnabled: true,
+						excludePatterns: "",
+					},
+				});
+				await flushPromises();
+			} finally {
+				setManuallyDisabled(false);
+			}
+
+			// Reinstalling per-project hooks would silently override the opt-out.
+			expect(mockInstallClaudeHook).not.toHaveBeenCalled();
+			expect(mockInstallGeminiHook).not.toHaveBeenCalled();
+			expect(mockRemoveClaudeHook).not.toHaveBeenCalled();
+			expect(mockRemoveGeminiHook).not.toHaveBeenCalled();
+			// The global ~/.jolli config write is an explicit user action — allowed.
+			expect(mockSaveConfigScoped).toHaveBeenCalled();
 		});
 
 		it("syncs hooks across all worktrees returned by listWorktrees", async () => {

--- a/vscode/src/views/SettingsWebviewPanel.ts
+++ b/vscode/src/views/SettingsWebviewPanel.ts
@@ -36,6 +36,7 @@ import {
 	removeGeminiHook,
 	syncGlobalInstructions,
 } from "../../../cli/src/install/Installer.js";
+import { isManuallyDisabled } from "../../../cli/src/Logger.js";
 import type { JolliMemoryConfig } from "../../../cli/src/Types.js";
 import type { AuthService } from "../services/AuthService.js";
 import { log } from "../util/Logger.js";
@@ -687,6 +688,12 @@ export class SettingsWebviewPanel {
 		repoRoot: string,
 		settings: SettingsPayload,
 	): Promise<void> {
+		// The Settings panel stays reachable while the project is manually
+		// disabled (it's the sign-in / Memory Bank entry point). Applying
+		// global settings then must not reinstall per-project agent hooks —
+		// that would silently override the opt-out. Removals are equally
+		// unnecessary: disable already uninstalled the hooks.
+		if (isManuallyDisabled()) return;
 		let worktrees: ReadonlyArray<string>;
 		try {
 			worktrees = await listWorktrees(repoRoot);


### PR DESCRIPTION
<!-- jollimemory-summary-start -->


## Quick recap

Jolli Memory now enforces a complete zero-write contract for any project a user has explicitly disabled through the command palette. Previously, disabling a project would write the opt-out marker to disk but leave the extension free to continue writing debug logs, identity files, migration records, storage entries, and sync commits on every subsequent activation. Every write path — the logger, the knowledge-base path resolver, the migration engine, the folder and orphan-branch storage backends, the coordinating dual-write layer, the background discovery tick, the sync engine's periodic rounds, and several read-side panel refresh paths — now carries an early-exit guard that checks the disabled state before touching any file.

The disabled state is seeded correctly from the very first moment the extension loads. A synchronous marker-file check runs at the top of the activation sequence, before the logger opens any file handle, so a disabled workspace produces no disk activity at all during startup. When the user re-enables the project, the in-memory flag is released before the on-disk marker is cleared, meaning the current session becomes functional immediately even if the filesystem operation fails. The full initialization sequence then runs to catch up on anything that was skipped, and every step is idempotent so re-running is safe.

Long-running operations received additional protection beyond a simple entry-point gate. A migration already in progress when the user clicks Disable now checks the disabled flag on each loop iteration and aborts cleanly, returning a transient "skipped" status that is never written to disk. This ensures the migration record reflects the true prior state when the project is re-enabled, so the catch-up run processes all entries correctly. The sync engine now waits at the start of each round for any in-flight initialization migration to finish, with a 60-second cap, and re-checks both the disabled flag and the round's generation number after that wait completes. A sync round queued before a disable action or superseded by a newer generation exits cleanly without writing anything.

A new catch-up mechanism runs automatically when a project is re-enabled. While disabled, agent hooks are uninstalled and the discovery cursor freezes, meaning plans or references created during that window could be silently lost. On re-enable, the extension now scans every known session transcript from the frozen cursor position forward, recovers missing plans and references, and advances the cursor — all before the sidebar panels refresh, so recovered content appears immediately. Concurrent initialization runs triggered by activation and the Enable command are now serialized rather than allowed to race over shared index files. The Settings panel, which remains accessible while a project is disabled to allow sign-in and configuration changes, no longer reinstalls agent hooks when the user saves settings.

The zero-write contract — that a manually-disabled repository never receives automatic background writes — now extends to two paths that had been introduced after the original feature was written. Skill recipe files used by AI coding assistants were being rewritten on version upgrades even in repositories the user had explicitly opted out of. The disable flow deliberately leaves those files on disk, and the version-check process had no awareness of the disabled state, leaving upgraded CLI installations free to silently modify files in opted-out repos. The auto-refresh process now consults the disabled flag on the path where a version bump would trigger file changes; the common already-current path is unaffected.

Extension telemetry was similarly writing buffer files into a disabled repository's own state directory on activation and on two periodic timers, gated only by the user's separate telemetry consent preference. Both the activation event and the periodic buffer flush now skip the write in disabled repositories. The flush resumes automatically on re-enable with no additional configuration, and the user-gesture events emitted when someone explicitly clicks Enable or Disable continue to be recorded as before.

---

## Topics (16)
<details>
<summary><strong>01 · Backlog recovery for plans and references after re-enabling a disabled project</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a project was disabled, agent hooks were uninstalled and the discovery cursor froze. Any plans or references created during the disabled window would be silently lost for sessions that received no further activity after re-enabling.

**💡 Decisions Behind the Code**

- **Plans first, then references, cursor advances only on full success**: The scan order mirrors the existing stop-hook behavior. A throwing plan scan leaves the cursor frozen so the same window is retried on the next opportunity, preventing silent data loss at the cost of potentially re-scanning a window that partially succeeded.
- **Codex sessions intentionally excluded**: Codex discovery is driven by a separate periodic sidebar tick with its own cursor, which also froze while disabled and self-recovers on the next tick after re-enable. Including Codex sessions here would duplicate that work and risk mis-ordering the references-first scan that Codex uses.
- **Catch-up is best-effort and non-blocking**: The call is wrapped in a try/catch so a failure does not prevent the enable command from completing or the panels from refreshing. Per-session failures are isolated so one bad transcript does not abort recovery for the rest, trading completeness guarantees for resilience and simplicity.

**✅ What Was Implemented**

- Created `cli/src/core/DiscoveryCatchUp.ts` with a `catchUpTranscriptDiscovery` function that loads all known session transcripts, skips Codex sessions (which self-recover via their own sidebar tick), and for each remaining session re-runs incremental plan and reference scans from the frozen cursor position forward, advancing the cursor only when both scans complete successfully. The function is idempotent — already-scanned lines are never reprocessed.
- Wired `catchUpTranscriptDiscovery` into `vscode/src/Extension.ts` inside the enable command handler, called after `runInitializeKB` completes and awaited before the panel refresh so newly recovered content appears immediately. Errors are caught and logged without blocking the enable flow.
- Added tests in `DiscoveryCatchUp.test.ts` covering the disabled guard, missing transcript files, Codex skip, cursor advancement, and per-session failure isolation; added two tests in `Extension.test.ts` verifying that catch-up runs after KB init and is skipped when enable fails.

**📁 FILES**
- `cli/src/core/DiscoveryCatchUp.ts`
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Add pre-lock write guards to prevent any disk activity on disabled projects</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a project was manually disabled, the storage layer could still acquire a file lock and leave behind lock artifacts on disk, even though no actual data should have been written. The existing write gate fired only inside the lock, not before it.

**💡 Decisions Behind the Code**

- **Pre-lock placement over post-lock**: Acquiring a lock is itself a disk operation (creating a directory and lock file), so a gate placed only inside the lock would still leave a lock artifact behind on a disabled project. Placing the check before lock acquisition keeps the disabled state truly zero-write with no side effects at all.
- **Worker processes are exempt by design**: The queue worker process that drains commits made while the project was still enabled is deliberately not subject to the disabled flag. Disabling uninstalls the git hooks so no new worker is ever spawned, but a worker already running at the moment of disable is allowed to complete so that in-flight memories land rather than being stranded in the queue indefinitely.

**✅ What Was Implemented**

- Added `isManuallyDisabled()` checks at the top of five write functions in `cli/src/core/SummaryStore.ts` (`storeSummary`, `saveTranscriptsBatch`, `storePlans`, `storeNotes`, `storeReferences`), each placed before the lock-acquisition call, ensuring no lock file is created and no branch writes occur on a disabled project.
- Added five corresponding test cases in `SummaryStore.test.ts` verifying that each write function returns early without calling the lock-acquire or branch-write utilities when the project is disabled.
- Expanded the JSDoc on the manually-disabled flag in `Logger.ts` to clarify that the flag is process-local by design: CLI hook and worker processes never set it, and a worker already in flight when the user disables is intentionally allowed to finish its in-progress commits.

**📁 FILES**
- `cli/src/core/SummaryStore.ts`
- `cli/src/Logger.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Serialize concurrent knowledge-base initialization runs and fix enable-command ordering</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The extension's startup path and the Enable command could both trigger a knowledge-base initialization at the same time, sharing unlocked read-modify-write operations on shared index files and creating a race condition that could corrupt the knowledge base on first install.

**💡 Decisions Behind the Code**

- **Serialize rather than deduplicate**: A deduplication approach would silently drop the enable command's catch-up run if the activate run happened to still be in flight. Serialization ensures every requested run eventually executes in order, which is the correct behavior for a catch-up scenario where skipped initialization must be replayed.
- **Release the in-memory flag before clearing the on-disk marker**: The in-memory flag is what the runtime gates actually check, so it must be cleared first to make the session functional immediately. The on-disk marker is only needed for future restarts, so a failure to clear it is survivable — the user loses persistence across restarts but the current session works. Reversing the order would leave the session stuck in a disabled state after a filesystem error even though the user successfully clicked Enable.
- **Full KB init re-run on enable rather than selective replay**: Rather than tracking which initialization steps were skipped and replaying only those, the enable command calls the full initialization sequence again. Every step inside it is idempotent, so re-running is safe and keeps the recovery path simple and auditable.

**✅ What Was Implemented**

- Introduced a `runInitializeKB()` serialization chain in `vscode/src/Extension.ts` that queues every initialization run behind the previous one; errors in one run are isolated so they cannot wedge the chain for later callers. All call sites (activate, enable command) now go through this chain.
- Fixed the enable command's operation order: the in-memory disabled flag is now released before the on-disk marker is cleared, and the marker-clear is wrapped in a try/catch so a filesystem error does not prevent the session from becoming functional.
- Added an `isManuallyDisabled()` guard to the hook-path refresh logic so that an extension upgrade does not silently reinstall hooks and override the user's opt-out on a disabled project.
- Moved the serialization chain declarations earlier in `Extension.ts` so the barrier thunk can be passed into the sync runtime at construction time.

**📁 FILES**
- `vscode/src/Extension.ts`
- `vscode/src/sync/VsCodeSyncBootstrap.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Add per-round sync barrier to prevent races with in-flight initialization migrations</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a project was re-enabled after being manually disabled, a long-running initialization migration could run concurrently with the sync engine's first round, causing both to read and write the same files simultaneously and potentially corrupting output.

**💡 Decisions Behind the Code**

- **Per-round barrier thunk over a one-shot ready promise**: The existing ready promise resolves once at startup and cannot protect against the enable command's catch-up migration, which runs long after the promise has already resolved. A thunk that re-reads the live chain at each round start ensures every round independently waits out whatever migration is currently in flight.
- **60-second cap mirroring the existing watchdog**: Rather than waiting indefinitely, the barrier races against a timeout matching the extension-side initialization watchdog. A hung initialization degrades to the pre-barrier behavior (sync proceeds without waiting) rather than blocking the sync engine forever, preserving availability at the cost of a narrow race window in pathological cases.
- **Mirror the existing ready-promise guards after the barrier await**: The same generation and disabled checks already existed after the earlier ready-promise await. Duplicating them after the new barrier closes an identical cancellation window opened by any await point, keeping the two wait sites consistent rather than introducing a new abstraction that could diverge.
- **Zero-write semantics on abort**: When either post-barrier guard fires, the code restores the pre-tick state and clears the sync phase rather than leaving partial state in place, ensuring a disabled project produces no observable side effects from the aborted round.

**✅ What Was Implemented**

- Introduced a `kbInitBarrier` thunk on `StatusOrchestratorOpts` and wired it through `VsCodeSyncBootstrap.ts` and `Extension.ts`. At the start of each sync round, the orchestrator awaits the current in-flight initialization chain before proceeding, with a 60-second cap to prevent a hung run from blocking sync indefinitely.
- Added two guard checks in `StatusOrchestrator.ts` immediately after the barrier resolves: one compares the current poll generation against the generation captured when the tick was queued (exiting if stale), and one calls `isManuallyDisabled()` and aborts the round with state restoration if the project was disabled while parked at the barrier.

**📁 FILES**
- `vscode/src/sync/StatusOrchestrator.ts`
- `vscode/src/sync/VsCodeSyncBootstrap.ts`
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Close ungated write paths found by adversarial review of disabled-mode gating</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

An adversarial review found that the disabled state was enforced inconsistently: individual storage backends had guards, but coordinating layers above them still performed bookkeeping after calling those backends, leaving project state files in a corrupted condition even when no real content was written.

**💡 Decisions Behind the Code**

- **Gate at the coordinator, not just the backends**: The storage backends already had individual gates, but the coordinating layer performed bookkeeping (clearing dirty state, unlinking status files) after calling them. Gating only the backends left the coordinator free to corrupt the shadow state; adding a gate at the coordinator level was the only way to guarantee the bookkeeping never ran on a disabled project.
- **Per-call check rather than a startup latch**: The disabled flag is checked on every individual write call rather than once at startup. This means a user who disables mid-session silences the very next operation, and a re-enable resumes immediately without a restart or rebuild.

**✅ What Was Implemented**

- Added an early-return guard in `cli/src/core/CodexDiscovery.ts` so that the background discovery tick exits immediately without persisting cursors, plans, or references when the project is manually disabled.
- Added a gate at the top of `DualWriteStorage.writeFiles()` in `cli/src/core/DualWriteStorage.ts` so the coordinating layer exits before either backend is called; without this, shadow-status cleanup logic would still run and mark a never-performed write as clean even though the backend gates had silently dropped the actual file writes.
- Added `isManuallyDisabled()` checks in `vscode/src/core/NoteService.ts`, `vscode/src/core/PlanService.ts`, and `vscode/src/services/KbFoldersService.ts` to suppress write-back migrations and manifest reconciliation and heal operations that fire during read-side panel refreshes.

**📁 FILES**
- `cli/src/core/CodexDiscovery.ts`
- `cli/src/core/DualWriteStorage.ts`
- `vscode/src/core/NoteService.ts`
- `vscode/src/core/PlanService.ts`
- `vscode/src/services/KbFoldersService.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Abort in-flight migration when project is disabled mid-run and prevent false completion records</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A long first-install migration could be running when the user clicked Disable. The migration's per-entry loop would continue, but the storage gates would silently drop every file write — then the migration would record those entries as successfully migrated, permanently blocking a future re-enable from catching up.

**💡 Decisions Behind the Code**

- **Return "skipped" rather than "failed" on mid-run abort**: Treating a mid-run disable as a skip means the migration is cleanly re-attempted on re-enable. Marking it failed would require manual intervention or a separate recovery path, adding complexity with no user benefit.
- **Wrap the state-save call rather than inlining the check everywhere**: A private wrapper around the metadata save consolidates the disabled guard in one place. Every call site that previously called the metadata manager directly now goes through the wrapper, so future callers automatically inherit the protection without needing to add their own check.
- **Transient-only status value**: The "skipped" status was added to the shared type but explicitly documented as never persisted. This preserves the integrity of the on-disk migration record — a disabled project that later becomes re-enabled will still see its true prior state rather than a misleading "skipped" entry, keeping recovery paths clean.
- **Early return over conditional wrapping at entry points**: The gate was placed at the very top of each method rather than wrapping the body in a conditional block. This keeps the existing logic untouched and makes the disabled-project path trivially auditable — reviewers can confirm at a glance that no file I/O is reachable when the flag is set.

**✅ What Was Implemented**

- Added a per-entry disabled check inside the main migration loop in `cli/src/core/MigrationEngine.ts` so that a disable flip during a long run causes an immediate abort with a `"skipped"` status rather than continuing to count silently-dropped writes as progress.
- Added a second check before the bulk summary-migration phase for the same reason, and introduced a private `saveMigrationState()` wrapper that refuses to persist progress stamps when the project is disabled, preventing a false "completed" record from blocking the re-enable catch-up.
- Extended the `MigrationState` interface in `cli/src/core/KBTypes.ts` to include `"skipped"` as a valid status value, explicitly documented as never persisted to the migration state file on disk.
- Added early-return guards at the top of both `runMigration` and `runStaleChildCleanup` in `MigrationEngine.ts` so that when the project is already disabled at entry, both methods return a skipped result immediately without reading any files.

**📁 FILES**
- `cli/src/core/MigrationEngine.ts`
- `cli/src/core/KBTypes.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Close second-round review gaps: background scans, plan registration, and settings hook reinstall</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Several background processes were found to continue writing files to disk even after a user explicitly disabled a project. The most visible symptom was a feedback loop in the commits panel where a scan would detect the same candidates on every refresh, acquire a lock file each time, and repeat indefinitely.

**💡 Decisions Behind the Code**

- **Guard placement at the function entry point**: Each guard was placed at the top of the relevant write-initiating function rather than at the call sites, keeping the disabled-mode contract self-contained within each service so future callers automatically inherit the protection.
- **Read operations allowed, writes blocked**: The approach permits read-side refreshes to proceed normally while only suppressing the write step, preserving the ability to display current state in the UI without risking partial or looping writes to disk.
- **Deferred rather than discarded**: Work that is skipped (plan registration, migration writeback) is explicitly designed to be recoverable on re-enable rather than permanently lost, avoiding data loss while still honoring the opt-out.
- **Block hook writes but allow global settings changes**: Placing the guard inside the settings-apply path rather than disabling the Settings panel entirely preserves the panel's usefulness as a configuration surface while the project is disabled. Users can still adjust global preferences; hooks are simply not touched until the project is re-enabled.

**✅ What Was Implemented**

- Added an early-exit guard in `cli/src/core/SummaryStore.ts` (`scanTreeHashAliases`) that returns immediately when the project is manually disabled, preventing the lock acquisition itself from looping indefinitely on every commits-panel refresh.
- Added a similar early-exit in `vscode/src/core/PlanService.ts` (`registerNewPlan`) to skip writing the plans registry while disabled; the plan can be registered again after re-enabling.
- Added a write-suppression guard in `vscode/src/core/ReferenceService.ts` (`detectReferences`) so the one-shot migration writeback of the plans file is skipped while disabled, deferring it to the next enabled refresh.
- Added an early-exit guard at the top of the hook-sync function in `vscode/src/views/SettingsWebviewPanel.ts` so that saving settings while a project is disabled does not silently reinstall agent hooks and override the user's explicit opt-out.

**📁 FILES**
- `cli/src/core/SummaryStore.ts`
- `vscode/src/core/PlanService.ts`
- `vscode/src/core/ReferenceService.ts`
- `vscode/src/views/SettingsWebviewPanel.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Wire manually-disabled flag through activation, knowledge-base initialization, and enable/disable commands</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user had previously disabled the extension for a project, restarting VS Code would still run the full knowledge-base initialization sequence, writing files to disk on a workspace the user had explicitly opted out of.

**💡 Decisions Behind the Code**

- **Synchronous read at startup over async**: The extension entry point cannot be made async without violating the VS Code activation contract, so a synchronous file read was added specifically for this one call site. The trade-off is a tiny blocking read at startup, but it is the only way to guarantee the disabled flag is set before the logger opens its file handle — an async read would always lose the race. The async version remains the default everywhere else.
- **Flag seeded before logger initialization, not after**: Placing the flag-set call before logger initialization ensures the logger itself never creates a debug log file on a disabled workspace. Seeding it afterward would have protected most disk writes but left a window where the log file could be created, violating the zero-write contract.

**✅ What Was Implemented**

- `vscode/src/Extension.ts` now reads the manually-disabled marker synchronously at the top of `activate()`, before the logger is initialized, and seeds the in-memory disabled flag via `setManuallyDisabled()`. This ensures no debug log file is created on a disabled startup.
- The `initializeKB()` function gains an early-return guard that skips all disk-writing steps (schema migration, KB folder claim, full migration, stale-child sweep) when the flag is set.
- The enable command (`enableJolliMemory`) was updated to call `setManuallyDisabled(false)` after a successful install, then immediately invoke `initializeKB()` to catch up on any initialization skipped during the disabled startup.
- The disable command (`disableJolliMemory`) was updated to call `setManuallyDisabled(true)` after writing the marker file but before calling `bridge.disable()`, so any writes triggered by the uninstall path are silenced.
- Added `readManualDisableFlagSync` in `vscode/src/services/ManualDisableFlag.ts`, a synchronous counterpart to the existing async flag reader, using a blocking file-stat call and returning true if the marker file exists.

**📁 FILES**
- `vscode/src/Extension.ts`
- `vscode/src/services/ManualDisableFlag.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Gate knowledge-base identity writes, folder storage, and orphan branch storage behind disabled flag</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a project was manually disabled, the tool was still writing identity files, folder storage entries, and orphan branch data to disk during path resolution and folder initialization, leaving a filesystem footprint on workspaces the user had explicitly opted out of.

**💡 Decisions Behind the Code**

- **Guard at the lowest write point for identity writes**: The disable check was placed inside `writeKBIdentity` rather than at the call sites in `resolveKBPath` or `initializeKBFolder`. This keeps the guard in one place and ensures any future call path that reaches identity writing is automatically covered, reducing the risk of a missed call site introducing a regression.
- **First-line guard in storage backends**: Placing the check as the very first line of each storage backend's write method keeps the disable semantics total — no partial writes, no metadata updates, no directory creation side-effects can slip through. Any future code paths added inside these methods are automatically covered without needing individual guards.
- **Reuse the existing disabled flag rather than a new concept**: Rather than introducing a new parameter or configuration surface, all three changes reuse the flag already tracked by the logger module, keeping disabled-mode behavior consistent across the codebase.

**✅ What Was Implemented**

- `writeKBIdentity` in `cli/src/core/KBPathResolver.ts` now checks `isManuallyDisabled()` at the top of the function and returns immediately if the flag is set, skipping all filesystem writes. Two new tests cover both `resolveKBPath` and `initializeKBFolder`, each verifying that no `.jolli` directory is created on disk when the flag is active.
- `FolderStorage.writeFiles` in `cli/src/core/FolderStorage.ts` now checks `isManuallyDisabled()` at the top of the method and returns immediately, skipping all file I/O including atomic writes and downstream markdown generation.
- `OrphanBranchStorage.writeFiles` in `cli/src/core/OrphanBranchStorage.ts` now checks `isManuallyDisabled()` at the top of the method and returns early without performing any work, preventing both the branch-ensure step and the actual file write from executing.

**📁 FILES**
- `cli/src/core/KBPathResolver.ts`
- `cli/src/core/FolderStorage.ts`
- `cli/src/core/OrphanBranchStorage.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · Add in-memory flag to silence all log writes when project is manually disabled</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user had manually disabled the extension for a project, the extension was still writing to the debug log file on every activation, violating the intent of the disabled state.

**💡 Decisions Behind the Code**

- **In-memory flag rather than re-reading the disk marker on every write**: Reading the marker file on every log call would add filesystem I/O to a hot path and introduce async complexity into what is currently a synchronous gate. A module-level boolean means the gate is a single branch with zero I/O cost; the caller is responsible for keeping it in sync with the on-disk state at the two moments that matter: startup and enable/disable commands.
- **Placed after existing environment-variable guards, not before**: The existing checks already short-circuit in test and CI environments. Placing the new flag check immediately after preserves the existing fast-exit ordering and avoids any risk of the new flag accidentally suppressing test-environment log assertions that rely on those earlier guards being hit first.

**✅ What Was Implemented**

- Added `_manuallyDisabled` module-level boolean and two exported functions (`setManuallyDisabled`, `isManuallyDisabled`) to `cli/src/Logger.ts`. The flag acts as an in-memory mirror of the on-disk disabled marker so callers can set it once at startup and all subsequent write attempts are silently dropped.
- Added a one-line guard at the top of the private `enqueueLogWrite` function in `cli/src/Logger.ts` that returns immediately when the flag is true, placed after the existing environment-variable checks.
- Extended `cli/src/Logger.test.ts` with three new test cases: one verifying that file writes are never called while the flag is set, one verifying writes resume after the flag is cleared, and one exercising the getter/setter round-trip.

**📁 FILES**
- `cli/src/Logger.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · Guard background sync engine periodic tick against manually-disabled projects</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The background sync engine runs on a recurring timer that is not stopped when a project is manually disabled. Each tick would attempt to commit and push to the Memory Bank vault and spawn worker processes, violating the zero-write contract for disabled projects.

**💡 Decisions Behind the Code**

Checking on every tick rather than stopping the timer entirely keeps the implementation simple and avoids the need to restart the timer on re-enable. The cost of one skipped check per tick interval is negligible, and the behavior — disable silences the next tick, re-enable resumes the next tick — matches what users expect from a toggle.

**✅ What Was Implemented**

Added a per-tick `isManuallyDisabled()` check in `vscode/src/sync/StatusOrchestrator.ts` that exits the sync round early and restores the pre-tick state when the project is disabled. The check is placed inside the tick body rather than at startup so that a disable mid-session takes effect on the very next tick and a re-enable resumes without any rebuild.

**📁 FILES**
- `vscode/src/sync/StatusOrchestrator.ts`

</blockquote>
</details>
<details>
<summary><strong>12 · Regression tests pinning disabled-mode gates across all major subsystems</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The team needed confidence that every subsystem correctly halts its work when a project is manually disabled. Without regression tests, a future refactor could silently remove a gate and allow writes, syncs, or hook installs to run against an opted-out project.

**💡 Decisions Behind the Code**

- **Mid-run abort over pre-run check only**: The migration engine tests deliberately flip the flag partway through a run rather than only before it starts. This ensures the per-iteration gate is exercised independently of the entry-point gate, catching regressions where a future refactor moves the check outside the loop. The trade-off is slightly more complex test setup, but the coverage of the in-progress state machine is worth it.
- **Invocation-call-order assertions over mock call counts**: The ordering guarantees (flag before logger, KB init after flag release) are the safety-critical property, not merely whether functions were called. Using call-order indices makes the intent explicit and catches any future reordering that would break the zero-write contract.
- **Hook installs gated but global config write allowed in settings panel test**: The settings panel test distinguishes between per-project hook operations (blocked while disabled) and the global user-config write (permitted). Blocking the config write would prevent users from changing unrelated settings while a project is opted out, which would be a confusing and unnecessary restriction.
- **Microtask flush before clearing mocks**: Several tests that check "not called" assertions needed a microtask flush before clearing mocks, to let any async initialization from a prior test settle. This prevents false positives from async residue without requiring the tests to be restructured or serialized.

**✅ What Was Implemented**

- Added disabled-mode gate tests to `cli/src/core/CodexDiscovery.test.ts`, `cli/src/core/DualWriteStorage.test.ts`, `cli/src/core/SummaryStore.test.ts`, and `cli/src/core/MigrationEngine.test.ts`. Each test sets the manual-disable flag, invokes the relevant function, and asserts that no reads, writes, lock acquisitions, or cursor updates occur. The `MigrationEngine` tests cover two mid-run flip scenarios: one where the flag flips between loop iterations and one where it flips after the last progress callback, verifying the per-iteration abort gate independently of the entry-point gate.
- Added disabled-mode gate tests to `vscode/src/Extension.test.ts` covering hook-path refresh on activation, the rebuild-knowledge-base command refusing outright, and the enable-flow tolerating a marker-unlink failure while still releasing the in-memory flag and proceeding with initialization.
- Added disabled-mode gate tests to `vscode/src/core/PlanService.test.ts`, `vscode/src/core/ReferenceService.test.ts`, `vscode/src/views/SettingsWebviewPanel.test.ts`, and `vscode/src/sync/StatusOrchestrator.test.ts`. The `StatusOrchestrator` tests include a barrier-interaction case verifying that the disabled flag arriving while a sync round is parked at the KB init barrier still silences the round after the barrier resolves.
- Added ordering tests inside the enable/disable command describe blocks in `vscode/src/Extension.test.ts` using Vitest's `invocationCallOrder` to assert strict sequencing guarantees (flag before logger, KB init after flag release, disable silences writes before bridge call).

**📁 FILES**
- `cli/src/core/MigrationEngine.test.ts`
- `cli/src/core/DualWriteStorage.test.ts`
- `vscode/src/Extension.test.ts`
- `vscode/src/sync/StatusOrchestrator.test.ts`
- `vscode/src/core/PlanService.test.ts`

</blockquote>
</details>
<details>
<summary><strong>13 · Skill recipe files rewritten in disabled repositories after version upgrades</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A multi-agent audit of automatic write paths discovered that the CLI's skill auto-refresh process ran on every command without checking whether the target repository was manually disabled. Because the disable flow deliberately leaves skill files on disk (a conservative cleanup policy), a version upgrade would silently rewrite those files in opted-out repos.

**💡 Decisions Behind the Code**

- **Check placement after the staleness gate**: The common case — marker version matches running version — returns before reaching the new check. The flag read runs only on the path where a version bump would trigger skill rewrites, keeping the hot path as fast as before while concentrating the added I/O cost exactly where it prevents a write.
- **Injectable dep seam**: The disable reader is injected via the existing deps pattern (alongside `loadConfig` and `updateSkills`), so existing tests continue without constructing a disabled-repo fixture and the new behavior is isolated to a single, explicit test case.

**✅ What Was Implemented**

Added an injectable `readManualDisable` parameter to `autoRefreshSkillsIfStale` in `cli/src/install/SkillAutoRefresh.ts`, defaulting to `readManualDisableFlag`, that short-circuits the function before any file writes. The guard is placed after the marker-version staleness check so the common already-current path returns without any additional disk I/O; only the rare version-changed path incurs the flag read.

**📁 FILES**
- `cli/src/install/SkillAutoRefresh.ts`

</blockquote>
</details>
<details>
<summary><strong>14 · Telemetry buffer writes bypassed the disabled-repository zero-write contract</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The same audit found that extension activation and two automatic 60-second timers were writing telemetry queue files directly into a disabled repository's own state directory. These writes were gated only by the user's telemetry consent setting, not by whether the repository had been manually disabled.

**💡 Decisions Behind the Code**

- **Single choke-point in the shared functions rather than at each call site**: Placing the guard in the two shared functions (`activateExtensionTelemetry` and `flushExtensionTelemetry`) means future callers cannot accidentally bypass it, and the correct behavior is enforced regardless of how many new callers are added later.
- **User-gesture funnel events are not suppressed**: The explicit disable and enable confirmation events are emitted from user-initiated commands, not from background timers, so they are intentionally excluded from the guard. Suppressing them would silently drop funnel data for a user who deliberately interacts with the feature.
- **In-memory flag over an async disk read**: The flush function is synchronous and runs on timers, so an async read would require restructuring the call chain. The in-memory flag is kept current at activation and on every enable/disable command, making it the correct synchronous gate for this path.

**✅ What Was Implemented**

- Added an `isManuallyDisabled()` guard in `vscode/src/TelemetryActivation.ts` before `track("client_activated")` inside `activateExtensionTelemetry`, so the per-repo activation event is not queued when the extension is disabled. The machine-global bootstrap (consent notice) is unaffected.
- Added a guard at the top of `flushExtensionTelemetry` that makes all three callers — the activation-time flush, the 60-second interval, and the sidebar tick — skip the buffer rewrite when disabled. The flush resumes automatically when the in-memory flag flips back on re-enable, with no enable-side rewiring needed.

**📁 FILES**
- `vscode/src/TelemetryActivation.ts`

</blockquote>
</details>
<details>
<summary><strong>15 · Add test coverage for storage capability probes and orchestrator barrier cancellation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dual-write storage layer had two capability-detection paths that lacked automated tests, and the sync orchestrator's poll-cancellation path during a startup barrier had no coverage, leaving edge cases unverified.

**💡 Decisions Behind the Code**

- **Capability detection via duck-typing**: The tests confirm that optional storage capabilities are detected at call time rather than at construction time, meaning a backend that simply omits a method is treated as "not capable" rather than throwing. This keeps the dual-write layer safe to use with minimal backend implementations.
- **Manually controlled promise for barrier cancellation test**: The test captures the barrier's resolve function at construction time, allowing the barrier to be released at a precise moment after `stop()` has already incremented the cancellation generation. This makes the stop-then-release ordering deterministic and avoids real timers or async races.

**✅ What Was Implemented**

- Added two tests in `cli/src/core/DualWriteStorage.test.ts` covering the topic-wiki presence probe: one verifies the fallback returns false when the shadow storage lacks the probe method, and one verifies that file-stat requests return null when the primary storage has no stat capability. A third test verifies that when the primary storage does expose a stat capability, the dual-write layer correctly delegates the call and returns the result.
- Added a test in `vscode/src/sync/StatusOrchestrator.test.ts` that constructs an orchestrator with a never-resolving startup barrier, fires the poll timer, calls `stop()` before releasing the barrier, then asserts that no sync round was executed after the barrier resolves — verifying the generation-counter cancellation branch.

**📁 FILES**
- `cli/src/core/DualWriteStorage.test.ts`
- `vscode/src/sync/StatusOrchestrator.test.ts`

</blockquote>
</details>
<details>
<summary><strong>16 · Fix outdated and self-contradictory comments about the manual-disable flag</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The user noticed that the in-memory disable flag's comment still referenced a storage location ("disabled-by-user" marker) that no longer exists, and asked why the flag needs to live in memory at all rather than being read directly from its actual source. During the investigation, a second comment in the queue worker was found that flatly contradicted the code it was describing.

**💡 Decisions Behind the Code**

- **Mirror pattern documented rather than reconsidered**: The in-memory mirror was kept exactly as-is; the fix was to explain its purpose clearly. The synchronous, high-frequency call sites (every log line, inside sub-5ms git hooks) cannot await a Promise or fork a subprocess per call, so a cached boolean is the only viable approach. Documenting this trade-off explicitly guards against a future contributor "simplifying" the code by removing the mirror.
- **Code untouched; only the comment corrected for QueueWorker**: Line 372's behavior was already correct — read the disk flag once at worker entry and bail if disabled. The self-contradiction existed only in the comment, which had been written before that check was added to the code. The fix targets the comment alone and documents the specific race condition the check covers, so the rationale is no longer absent from the codebase.

**✅ What Was Implemented**

- In `Logger.ts`, the comment for `_manuallyDisabled` was rewritten to name the actual source of truth (the `manuallyDisabled` field in `profile.json` under the main worktree's `.jolli` directory) and to explain why an in-memory mirror is necessary: the authoritative read path is async and spawns a git subprocess to locate the main worktree root before reading the file, which is incompatible with the synchronous, per-log-line gates this flag protects. The comment also clarifies that CLI and hook processes gate independently on the disk-backed read rather than this mirror.
- In `QueueWorker.ts`, the `runWorker` doc comment was corrected: it previously stated the function "deliberately does NOT read" the disable flag, which directly contradicted line 372 where the code actually does read it. The replacement describes the entry-check behavior accurately, names the race condition it handles (the user disabling between the post-commit hook spawning the worker and the worker starting), and explains why workers that have already passed the check are intentionally allowed to finish draining.

**📁 FILES**
- `cli/src/Logger.ts`
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 27, 2026 at 3:41 PM · via mixed: Local agent, Anthropic*
<!-- jollimemory-summary-end -->