### PR TITLE
Collapse Space stubs to single top-level `space` command

### DIFF
--- a/cli/src/Api.test.ts
+++ b/cli/src/Api.test.ts
@@ -685,11 +685,11 @@ describe("CLI", () => {
 			const siteHeader = helpOutput.indexOf("Jolli Site — Generate");
 			const spaceHeader = helpOutput.indexOf("Jolli Space — Sync docs");
 			const otherHeader = helpOutput.indexOf("Other commands:");
-			const syncIdx = helpOutput.indexOf("sync ");
+			const spaceCmdIdx = helpOutput.indexOf("space [args");
 
 			expect(spaceHeader).toBeGreaterThan(siteHeader);
-			// A representative Space command appears inside the Space section.
-			expect(syncIdx).toBeGreaterThan(spaceHeader);
+			// The single top-level `space` command appears inside the Space section.
+			expect(spaceCmdIdx).toBeGreaterThan(spaceHeader);
 			if (otherHeader >= 0) expect(spaceHeader).toBeLessThan(otherHeader);
 			exitSpy.mockRestore();
 		});
@@ -702,7 +702,7 @@ describe("CLI", () => {
 				throw new Error("process.exit");
 			}) as never);
 			try {
-				await main(["sync", "up"]);
+				await main(["space", "sync", "up"]);
 			} catch {
 				// stub action calls process.exit(1)
 			}
@@ -710,7 +710,7 @@ describe("CLI", () => {
 				.mocked(console.error)
 				.mock.calls.map((c) => String(c[0]))
 				.join("\n");
-			expect(stderr).toContain("Space command `sync` requires the @jolli.ai/space-cli plugin.");
+			expect(stderr).toContain("Space command `space` requires the @jolli.ai/space-cli plugin.");
 			expect(stderr).toContain("npm install -g @jolli.ai/space-cli");
 			expect(exitSpy).toHaveBeenCalledWith(1);
 			exitSpy.mockRestore();
@@ -838,12 +838,15 @@ describe("CLI", () => {
 			exitSpy.mockRestore();
 		});
 
-		it("keeps the rest of the Space stubs when one stub name is already taken", async () => {
-			// P3 regression: a single duplicate-name throw must not abort the stub
-			// batch. Pre-occupy `init` (the first Space stub) via a mocked plugin;
-			// the Jolli Space section and a later stub (`agent`) must still render.
+		it("skips the space stub gracefully when a plugin already owns `space`", async () => {
+			// Collision tolerance at the integration level: if another command
+			// already owns the top-level `space` name, `registerMissingStubs` must
+			// skip the stub rather than throw out of help rendering. The stub is the
+			// only Space-grouped command, so skipping it drops the "Jolli Space"
+			// section entirely — the colliding command still renders (untagged, so
+			// under "Other commands:"), and help must not throw.
 			vi.mocked(loadPlugins).mockImplementationOnce(async (program) => {
-				program.command("init").description("unrelated plugin init");
+				program.command("space").description("unrelated plugin space");
 				return { loaded: new Set<string>(), diagnostics: [] };
 			});
 			const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
@@ -857,13 +860,10 @@ describe("CLI", () => {
 			const writes = vi.mocked(process.stdout.write).mock.calls.map((c) => String(c[0]));
 			const helpOutput = writes.join("");
 
-			const spaceHeader = helpOutput.indexOf("Jolli Space — Sync docs");
-			// Match the stub's command term ("agent [args...]") rather than the
-			// bare word, which also occurs in the Memory section's "AI-agent" prose.
-			const agentIdx = helpOutput.indexOf("agent [args");
-			expect(spaceHeader).toBeGreaterThanOrEqual(0);
-			// A stub registered after the collided `init` still appears.
-			expect(agentIdx).toBeGreaterThan(spaceHeader);
+			// The pre-existing `space` renders (proves no throw, help still built)…
+			expect(helpOutput).toContain("unrelated plugin space");
+			// …and the stub was skipped, so no dedicated Space section is emitted.
+			expect(helpOutput.indexOf("Jolli Space — Sync docs")).toBe(-1);
 			exitSpy.mockRestore();
 		});
 	});

--- a/cli/src/KnownPlugins.ts
+++ b/cli/src/KnownPlugins.ts
@@ -45,9 +45,10 @@ export interface KnownPlugin {
 export const KNOWN_PLUGINS: ReadonlyArray<KnownPlugin> = [
 	{
 		// @jolli.ai/space-cli — Jolli proprietary plugin (separate repository).
-		// When missing, stubs keep the Space commands (init / space / source /
-		// impact / sync / agent) visible in `--help` and emit a one-line install
-		// hint on invocation — identical UX to site-cli below.
+		// When missing, the stub keeps the top-level `space` command (whose
+		// subcommands init / status / switch / ls / source / impact / sync / agent
+		// the plugin owns) visible in `--help` and emits a one-line install hint
+		// on invocation — identical UX to site-cli below.
 		id: "c56530c4-3f2f-467f-a4a4-db4d44c79c1c",
 		packageName: "@jolli.ai/space-cli",
 		installHint: "npm install -g @jolli.ai/space-cli",

--- a/cli/src/commands/SpaceCommandStubs.test.ts
+++ b/cli/src/commands/SpaceCommandStubs.test.ts
@@ -3,14 +3,14 @@
  * `@jolli.ai/space-cli` plugin is not installed.
  *
  * Covers:
- *   - registration adds all Space stub commands (including `docs`) to a bare program
- *   - each stub is tagged with the "space" help group
- *   - invoking a stub (`docs`) prints the install hint and exits non-zero
- *   - `jolli docs pull --branch x` / `jolli docs publish --foo` forward the
+ *   - registration adds the single top-level `space` stub to a bare program
+ *   - the stub is tagged with the "space" help group
+ *   - invoking the stub (`space`) prints the install hint and exits non-zero
+ *   - `jolli space sync up` / `jolli space status --foo` forward the
  *     subcommand + unknown flags to the action (no parser error) via
  *     allowUnknownOption + [args...]
- *   - the collision-tolerant guard: a stub whose name is already occupied
- *     (by command name or by alias) is skipped rather than throwing
+ *   - the collision-tolerant guard: the `space` stub is skipped (not thrown)
+ *     when its name is already occupied by a command name or by an alias
  */
 
 import { Command } from "commander";
@@ -21,7 +21,7 @@ import { registerSpaceCommandStubs } from "./SpaceCommandStubs.js";
 // ─── Constants mirrored from the source under test ───────────────────────────
 
 /** The Space command names the stubs register, in declaration order. */
-const SPACE_NAMES = ["init", "space", "source", "impact", "sync", "docs", "agent"];
+const SPACE_NAMES = ["space"];
 
 const INSTALL_COMMAND = "npm install -g @jolli.ai/space-cli";
 
@@ -69,7 +69,7 @@ afterEach(() => {
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe("registerSpaceCommandStubs", () => {
-	it("registers all Space stub commands (including docs) on a bare program", () => {
+	it("registers the single top-level `space` stub on a bare program", () => {
 		const program = new Command();
 		registerSpaceCommandStubs(program);
 		expect(program.commands.map((c) => c.name())).toEqual(SPACE_NAMES);
@@ -91,58 +91,60 @@ describe("registerSpaceCommandStubs", () => {
 		}
 	});
 
-	it("prints the install hint and exits non-zero when the docs stub is invoked", async () => {
+	it("prints the install hint and exits non-zero when the space stub is invoked", async () => {
 		const program = new Command();
 		registerSpaceCommandStubs(program);
 
-		const { output, exitCode } = await runStub(program, "docs");
+		const { output, exitCode } = await runStub(program, "space");
 		expect(exitCode).toBe(1);
-		expect(output).toContain("Space command `docs` requires the @jolli.ai/space-cli plugin.");
+		expect(output).toContain("Space command `space` requires the @jolli.ai/space-cli plugin.");
 		expect(output).toContain(INSTALL_COMMAND);
-		expect(output).toContain("Then re-run: jolli docs ...");
+		expect(output).toContain("Then re-run: jolli space ...");
 	});
 
-	it("forwards `docs pull --branch x` to the action without a parser error", async () => {
+	it("forwards `space sync up` to the action without a parser error", async () => {
 		const program = new Command();
 		registerSpaceCommandStubs(program);
 
-		// The subcommand token + the unknown --branch flag must reach the action
+		// The subcommand tokens must reach the action (install-hint exit), NOT
+		// raise Commander's "unknown command" error.
+		const { exitCode } = await runStub(program, "space", ["sync", "up"]);
+		expect(exitCode).toBe(1);
+	});
+
+	it("forwards `space status --foo` to the action without a parser error", async () => {
+		const program = new Command();
+		registerSpaceCommandStubs(program);
+
+		// The subcommand token + the unknown --foo flag must reach the action
 		// (install-hint exit), NOT raise Commander's "unknown option" error.
-		const { exitCode } = await runStub(program, "docs", ["pull", "--branch", "jolli/run-123"]);
+		const { exitCode } = await runStub(program, "space", ["status", "--foo"]);
 		expect(exitCode).toBe(1);
 	});
 
-	it("forwards `docs publish --foo` to the action without a parser error", async () => {
+	it("skips the stub whose name is already occupied by an existing command", () => {
 		const program = new Command();
+		// Pre-register a command named "space" that the stub must not clobber.
+		program.command("space").description("pre-existing space command");
 		registerSpaceCommandStubs(program);
 
-		const { exitCode } = await runStub(program, "docs", ["publish", "--foo"]);
-		expect(exitCode).toBe(1);
+		const spaceCommands = program.commands.filter((c) => c.name() === "space");
+		expect(spaceCommands).toHaveLength(1);
+		expect(spaceCommands[0].description()).toBe("pre-existing space command");
+		expect(getHelpGroup(spaceCommands[0])).toBeUndefined();
+		// Only the pre-existing `space` remains; the stub is skipped, not duplicated.
+		expect(program.commands.map((c) => c.name())).toEqual(["space"]);
 	});
 
-	it("skips a stub whose name is already occupied by an existing command", () => {
+	it("skips the stub whose name collides with an existing command's alias", () => {
 		const program = new Command();
-		// Pre-register a command named "docs" that the stub must not clobber.
-		program.command("docs").description("pre-existing docs command");
+		// An existing command aliased "space" must block the space stub.
+		program.command("spaces").alias("space").description("pre-existing spaces command");
 		registerSpaceCommandStubs(program);
 
-		const docsCommands = program.commands.filter((c) => c.name() === "docs");
-		expect(docsCommands).toHaveLength(1);
-		expect(docsCommands[0].description()).toBe("pre-existing docs command");
-		expect(getHelpGroup(docsCommands[0])).toBeUndefined();
-		// The pre-existing `docs` plus the other six stubs (docs skipped).
-		expect(program.commands.map((c) => c.name())).toEqual(["docs", ...SPACE_NAMES.filter((n) => n !== "docs")]);
-	});
-
-	it("skips a stub whose name collides with an existing command's alias", () => {
-		const program = new Command();
-		// An existing command aliased "docs" must block the docs stub.
-		program.command("documents").alias("docs").description("pre-existing documents command");
-		registerSpaceCommandStubs(program);
-
-		// No second command literally named "docs" should be added.
-		expect(program.commands.filter((c) => c.name() === "docs")).toHaveLength(0);
+		// No second command literally named "space" should be added.
+		expect(program.commands.filter((c) => c.name() === "space")).toHaveLength(0);
 		const stubNames = program.commands.map((c) => c.name()).filter((n) => SPACE_NAMES.includes(n));
-		expect(stubNames).toEqual(SPACE_NAMES.filter((n) => n !== "docs"));
+		expect(stubNames).toEqual([]);
 	});
 });

--- a/cli/src/commands/SpaceCommandStubs.ts
+++ b/cli/src/commands/SpaceCommandStubs.ts
@@ -5,18 +5,18 @@
  * Why this exists
  * ----------------
  *
- * The space / sync / source / impact / docs / agent commands live in the
- * `@jolli.ai/space-cli` plugin package. The host CLI discovers it through
- * `PluginLoader` (allow-listed by `jolliPluginId`, not by name). When the
- * plugin is installed alongside the host CLI, its `register()` adds the real
- * `init` / `space` / `source` / `impact` / `sync` / `docs` / `agent` commands.
- * When it isn't installed, `PluginLoader` falls back to registering the stubs
- * in this file so:
+ * The `space` command — and all of its subcommands (`init` / `status` /
+ * `switch` / `ls` / `clones` / `source` / `impact` / `sync` / `agent`) — lives
+ * in the `@jolli.ai/space-cli` plugin package. The host CLI discovers it
+ * through `PluginLoader` (allow-listed by `jolliPluginId`, not by name). When
+ * the plugin is installed alongside the host CLI, its `register()` adds the
+ * real top-level `space` command with all its subcommands. When it isn't
+ * installed, `PluginLoader` falls back to registering the stub in this file so:
  *
- *   - `jolli --help` still shows the Space commands under the "Jolli Space"
+ *   - `jolli --help` still shows the `space` command under the "Jolli Space"
  *     section, so users discover the feature exists.
- *   - Running a Space command prints a clear install hint instead of an
- *     "unknown command" error.
+ *   - Running a Space command (e.g. `jolli space sync up`) prints a clear
+ *     install hint instead of an "unknown command" error.
  *
  * This mirrors `SiteCommandStubs` for `@jolli.ai/site-cli` — the two plugins
  * present identically in `--help` whether or not they are installed.
@@ -36,43 +36,39 @@ interface StubSpec {
 }
 
 /**
- * Mirrors the real space-cli command descriptions so `jolli --help` shows the
+ * Mirrors the real space-cli command description so `jolli --help` shows the
  * same text whether or not space-cli is installed. Only the top-level command
- * surface is mirrored — the real plugin owns the subcommands (e.g. `sync up`,
- * `space status`); `.argument("[args...]")` + `.allowUnknownOption()` forward
- * any subcommand/flag to the stub action so it still prints the install hint.
- * The `(requires @jolli.ai/space-cli)` suffix is appended so the user
- * understands why invoking the command might prompt for installation.
+ * surface is mirrored — since the 0.99.x namespace overhaul that surface is a
+ * single `space` command, and the real plugin owns every subcommand (e.g.
+ * `space status`, `space sync up`). `.argument("[args...]")` +
+ * `.allowUnknownOption()` forward any subcommand/flag to the stub action so it
+ * still prints the install hint. The `(requires @jolli.ai/space-cli)` suffix is
+ * appended so the user understands why invoking the command might prompt for
+ * installation.
  */
 const SPACE_COMMAND_STUBS: ReadonlyArray<StubSpec> = [
-	{ name: "init", description: "Initialize this directory: login (if needed) and select a space" },
-	{ name: "space", description: "Inspect Jolli auth state and select a space for sync" },
-	{ name: "source", description: "Manage source repositories for impact analysis" },
-	{ name: "impact", description: "Documentation impact analysis tools" },
-	{ name: "sync", description: "Sync markdown files with the server" },
-	{ name: "docs", description: "Pull and publish documents for a git-backed space" },
-	{ name: "agent", description: "Interactive LLM agent with local tool execution" },
+	{ name: "space", description: "Manage Jolli spaces, synchronization, sources, impact analysis, and agents" },
 ];
 
 const INSTALL_COMMAND = "npm install -g @jolli.ai/space-cli";
 
 /**
- * Registers stub commanders for every Space command. Each stub prints a
- * one-line install hint and exits non-zero so scripts that depended on the
- * real command fail loudly rather than silently no-op.
+ * Registers the `space` stub commander. It prints a one-line install hint and
+ * exits non-zero so scripts that depended on the real command fail loudly
+ * rather than silently no-op.
  *
  * `.allowUnknownOption()` + `.argument("[args...]")` keep the user's
  * original argv from triggering Commander's "unknown option" rejection,
- * so a user typing `jolli sync up --some-flag` sees the install hint
+ * so a user typing `jolli space sync up --some-flag` sees the install hint
  * instead of a parser error.
  *
  * Registration is collision-tolerant: Commander's `program.command(name)`
- * throws on a duplicate name, and a single throw would abort the whole loop —
- * one already-occupied name (e.g. a builtin or another plugin owning `sync` or
- * `init`) would otherwise drop every remaining stub and the entire Space
- * section. We snapshot the occupied namespace (names + aliases) up front and
- * skip any stub whose name is already taken, so the rest of the batch still
- * registers.
+ * throws on a duplicate name, and an unguarded throw here would abort help
+ * rendering entirely. We snapshot the occupied namespace (names + aliases) up
+ * front and skip the `space` stub if that name is already taken (by a builtin
+ * or another plugin), so a collision degrades gracefully to "no Space section"
+ * rather than throwing. Kept as a loop so re-expanding the top-level surface
+ * later is a one-line array change.
  */
 export function registerSpaceCommandStubs(program: Command): void {
 	const occupied = new Set<string>();


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Quick recap

The CLI's fallback help display — shown when the space plugin is not installed — now accurately reflects the plugin's current shape. Previously it listed seven separate top-level commands matching an older plugin structure; it now shows a single top-level `space` command, matching what users see after installing the plugin. The install hint triggered by commands like `jolli space sync up` continues to work as before, and the displayed description is identical whether or not the plugin is present.

---

## Topic (1)
<details>
<summary><strong>01 · Update space plugin help stubs to match new single-command namespace</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The space plugin had reorganized its commands from seven separate top-level entries into a single top-level command with subcommands, but the CLI host's fallback help display (shown when the plugin isn't installed) still advertised the old flat structure. Users without the plugin installed saw outdated command names.

**💡 Decisions Behind the Code**

- **Mirror only the top-level surface, not subcommands**: The stub intentionally omits subcommand entries even though listing them would give users a preview when the plugin is absent. Embedding the plugin's internal command table in the host would create a maintenance coupling — every time the plugin adds, renames, or removes subcommands, the host would need a matching update and would silently drift if not updated. The existing workflow and site plugin stubs follow the same convention, so consistency across all three plugin families was also a factor.
- **Single-entry array kept as a loop**: The registration logic was kept as an iterated loop over an array rather than inlined as a direct single call. This preserves the collision-guard pattern and makes it a one-line change to expand the top-level surface again if the plugin namespace ever re-flattens, at no additional complexity cost.
- **Deprecated `docs` alias left untouched**: The `SkillInstaller` local-run recipe still calls the old `docs pull` and `docs publish` commands, which the plugin retains as deprecated aliases for `space sync down/up`. Migrating those calls would have required coordinating with a different team member responsible for the workflow feature area, so the change was explicitly scoped to help display only.

**✅ What Was Implemented**

- Updated `cli/src/commands/SpaceCommandStubs.ts` to replace the seven-entry stub array (`init`, `space`, `source`, `impact`, `sync`, `docs`, `agent`) with a single `space` entry whose description matches the real plugin's top-level description exactly. The existing forwarding mechanism (`[args...]` + `allowUnknownOption`) was preserved so invocations like `jolli space sync up` still produce an install hint rather than a parser error.
- Updated `cli/src/KnownPlugins.ts` comment to enumerate the new subcommand names (`init/status/switch/ls/clones/source/impact/sync/agent`) and remove references to the old flat surface.
- Updated `cli/src/commands/SpaceCommandStubs.test.ts` and `cli/src/Api.test.ts` to reflect the single-command surface: `SPACE_NAMES` collapsed to `["space"]`, install-hint tests now invoke `space sync up`, and the integration collision test was rewritten to assert that a `space`-name conflict causes the entire Space section to be gracefully omitted rather than leaving partial stubs.

**📋 Future Enhancements**

Migrate `SkillInstaller` local-run recipe steps from the deprecated `docs pull`/`docs publish` aliases to their canonical `space sync down`/`space sync up` equivalents once the workflow feature owner is ready to coordinate that change.

**📁 FILES**
- `cli/src/commands/SpaceCommandStubs.ts`
- `cli/src/KnownPlugins.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 27, 2026 at 3:54 PM · via Local agent*
<!-- jollimemory-summary-end -->