### PR TITLE
Remove branch field from PlanEntry, NoteEntry, and ReferenceEntry types

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -682,13 +682,6 @@ export interface PlanEntry {
 	readonly commitHash: string | null;
 	/** SHA-256 hash of the plan file content when associated with a commit. Used as a guard to detect if the file was overwritten with new content. */
 	readonly contentHashAtCommit?: string;
-	/**
-	 * Branch the plan was created/last touched on. Optional: legacy rows and rows
-	 * written before branch-scoping omit it (treated as visible on every branch).
-	 * The CLI does not filter on it, but persists it so the IntelliJ plugin — which
-	 * shares this plans.json — can branch-scope its CONTEXT view.
-	 */
-	readonly branch?: string;
 }
 
 /**
@@ -725,12 +718,6 @@ export interface NoteEntry {
 	readonly contentHashAtCommit?: string;
 	/** File path in .jolli/jollimemory/notes/<id>.md (all notes are file-backed) */
 	readonly sourcePath?: string;
-	/**
-	 * Branch the note was created on. Optional for the same reason as
-	 * {@link PlanEntry.branch}: persisted by the CLI (not filtered on) so the
-	 * IntelliJ plugin can branch-scope its shared CONTEXT view.
-	 */
-	readonly branch?: string;
 }
 
 // ─── Plan progress types ────────────────────────────────────────────────────
@@ -882,8 +869,6 @@ export interface ReferenceEntry {
 	readonly updatedAt: string;
 	/** MCP tool name that originally surfaced this reference. */
 	readonly sourceToolName: string;
-	/** Branch the reference was last captured on; see {@link PlanEntry.branch}. */
-	readonly branch?: string;
 }
 
 /**

--- a/cli/src/core/SessionTracker.test.ts
+++ b/cli/src/core/SessionTracker.test.ts
@@ -2162,7 +2162,7 @@ describe("SessionTracker", () => {
 		}
 
 		it("returns uncommitted entries on the current branch", async () => {
-			await upsertReferenceEntry(ref(), tempDir, "main");
+			await upsertReferenceEntry(ref(), tempDir);
 			const ids = await detectUncommittedReferenceIds(tempDir, "main");
 			expect(ids.map((i) => i.mapKey)).toEqual(["linear:PROJ-1528"]);
 			expect((await getReferenceEntriesForBranch(tempDir, "main")).map((e) => e.nativeId)).toEqual(["PROJ-1528"]);
@@ -2220,32 +2220,19 @@ describe("SessionTracker", () => {
 		});
 
 		it("creates a fresh entry when none exists", async () => {
-			await upsertReferenceEntry(ref(), tempDir, "main");
+			await upsertReferenceEntry(ref(), tempDir);
 			const reg = await loadPlansRegistry(tempDir);
 			const e = linearIssuesOfReg(reg)?.["PROJ-1528"];
 			expect(e).toBeDefined();
 			expect(e?.sourcePath).toContain("PROJ-1528.md");
 			expect(e?.sourceToolName).toBe("mcp__linear__get_issue");
 			expect(e?.title).toBe("Treat referenced Linear issues");
-			// Branch is stamped so IntelliJ can branch-scope the shared plans.json.
-			expect(e?.branch).toBe("main");
-		});
-
-		it("stamps the current branch on insert and re-stamps it on update", async () => {
-			await upsertReferenceEntry(ref(), tempDir, "feature/x");
-			expect(linearIssuesOfReg(await loadPlansRegistry(tempDir))?.["PROJ-1528"]?.branch).toBe("feature/x");
-			// Re-surfaced on another branch → follows the new branch.
-			await upsertReferenceEntry(ref({ title: "v2" }), tempDir, "feature/y");
-			expect(linearIssuesOfReg(await loadPlansRegistry(tempDir))?.["PROJ-1528"]?.branch).toBe("feature/y");
-		});
-
-		it("omits branch on an unknown git lookup (stays visible on every branch)", async () => {
-			await upsertReferenceEntry(ref(), tempDir, "unknown");
-			expect(linearIssuesOfReg(await loadPlansRegistry(tempDir))?.["PROJ-1528"]?.branch).toBeUndefined();
+			// Working-area references are worktree-scoped: no `branch` is persisted.
+			expect((e as Record<string, unknown> | undefined)?.branch).toBeUndefined();
 		});
 
 		it("refreshes title/url/sourceToolName on an existing entry, preserving addedAt", async () => {
-			await upsertReferenceEntry(ref(), tempDir, "main");
+			await upsertReferenceEntry(ref(), tempDir);
 			const before = await loadPlansRegistry(tempDir);
 			const addedAt = linearIssuesOfReg(before)?.["PROJ-1528"]?.addedAt;
 
@@ -2256,7 +2243,6 @@ describe("SessionTracker", () => {
 					toolName: "mcp__linear__list_issues",
 				}),
 				tempDir,
-				"main",
 			);
 			const after = await loadPlansRegistry(tempDir);
 			const e = linearIssuesOfReg(after)?.["PROJ-1528"];
@@ -2406,7 +2392,7 @@ describe("SessionTracker", () => {
 		}
 
 		it("upserts a new entity and surfaces it from getReferenceEntriesForBranch", async () => {
-			await upsertReferenceEntry(entityRef(), tempDir, "main");
+			await upsertReferenceEntry(entityRef(), tempDir);
 			const entries = await getReferenceEntriesForBranch(tempDir, "main");
 			expect(entries).toHaveLength(1);
 			expect(entries[0]?.source).toBe("jira");
@@ -2414,18 +2400,17 @@ describe("SessionTracker", () => {
 		});
 
 		it("routes entries by source — does not mix Jira and Linear", async () => {
-			await upsertReferenceEntry(entityRef(), tempDir, "main");
+			await upsertReferenceEntry(entityRef(), tempDir);
 			await upsertReferenceEntry(
 				entityRef({ mapKey: "linear:PROJ-1", source: "linear", nativeId: "PROJ-1", title: "Linear" }),
 				tempDir,
-				"main",
 			);
 			const entries = await getReferenceEntriesForBranch(tempDir, "main");
 			expect(entries.map((e) => e.source).sort()).toEqual(["jira", "linear"]);
 		});
 
 		it("detectUncommittedReferenceIds returns {mapKey, source, sourcePath} triples", async () => {
-			await upsertReferenceEntry(entityRef(), tempDir, "main");
+			await upsertReferenceEntry(entityRef(), tempDir);
 			const ids = await detectUncommittedReferenceIds(tempDir, "main");
 			expect(ids).toHaveLength(1);
 			expect(ids[0]).toMatchObject({ mapKey: "jira:KAN-5", source: "jira" });
@@ -2436,8 +2421,8 @@ describe("SessionTracker", () => {
 			// Pins the `existing === undefined ? "new" : "updated"` ternary's
 			// "updated" arm in upsertReferenceEntry's log line, plus the
 			// canRefreshUncommitted branch above it.
-			await upsertReferenceEntry(entityRef(), tempDir, "main");
-			await upsertReferenceEntry(entityRef({ title: "renamed" }), tempDir, "main");
+			await upsertReferenceEntry(entityRef(), tempDir);
+			await upsertReferenceEntry(entityRef({ title: "renamed" }), tempDir);
 			const entries = await getReferenceEntriesForBranch(tempDir, "main");
 			expect(entries).toHaveLength(1);
 			expect(entries[0]?.title).toBe("renamed");
@@ -2544,7 +2529,6 @@ describe("SessionTracker", () => {
 					toolName: "mcp__atlassian__getJiraIssue",
 				},
 				tempDir,
-				"main",
 			);
 			const after = await loadPlansRegistry(tempDir);
 			if (after.version !== 1) return;
@@ -2567,7 +2551,6 @@ describe("SessionTracker", () => {
 					referencedAt: "x",
 				},
 				tempDir,
-				"main",
 			);
 			const after = await loadPlansRegistry(tempDir);
 			if (after.version !== 1) return;
@@ -2598,7 +2581,7 @@ describe("normalizePlansRegistry", () => {
 		...over,
 	});
 
-	it("plans: drops ignored rows, strips ignored/editCount, keeps guard and branch", () => {
+	it("plans: drops ignored rows, strips ignored/editCount/branch, keeps guard", () => {
 		const raw = {
 			version: 1,
 			plans: {
@@ -2618,15 +2601,14 @@ describe("normalizePlansRegistry", () => {
 
 		expect(changed).toBe(true);
 		expect(Object.keys(registry.plans).sort()).toEqual(["active", "guard"]);
-		expect(JSON.stringify(registry.plans)).not.toMatch(/editCount|"ignored"/);
-		// `branch` is preserved (IntelliJ branch-scopes off it via the shared plans.json).
-		expect(registry.plans.active?.branch).toBe("main");
-		expect(registry.plans.guard?.branch).toBe("main");
+		// `branch` is stripped alongside editCount/ignored — working-area entries are
+		// worktree-scoped, not branch-scoped.
+		expect(JSON.stringify(registry.plans)).not.toMatch(/editCount|"ignored"|"branch"/);
 		expect(registry.plans.guard?.commitHash).toBe("abc");
 		expect(registry.plans.guard?.contentHashAtCommit).toBe("h");
 	});
 
-	it("notes: drops ignored rows, strips ignored, keeps guard and branch", () => {
+	it("notes: drops ignored rows, strips ignored/branch, keeps guard", () => {
 		const raw = {
 			version: 1,
 			plans: {},
@@ -2656,9 +2638,8 @@ describe("normalizePlansRegistry", () => {
 
 		expect(changed).toBe(true);
 		expect(Object.keys(registry.notes ?? {})).toEqual(["keep"]);
-		expect(JSON.stringify(registry.notes)).not.toMatch(/"ignored"/);
-		// `branch` is preserved for the IntelliJ shared-plans.json branch filter.
-		expect(registry.notes?.keep?.branch).toBe("main");
+		// `branch` is stripped alongside `ignored` — notes are worktree-scoped.
+		expect(JSON.stringify(registry.notes)).not.toMatch(/"ignored"|"branch"/);
 	});
 
 	it("notes: strips a lingering `ignored: false` field (changed=true) but leaves a clean note untouched", () => {
@@ -2714,9 +2695,8 @@ describe("normalizePlansRegistry", () => {
 
 		expect(changed).toBe(true);
 		expect(Object.keys(registry.references ?? {}).sort()).toEqual(["linear:ACTIVE-1", "linear:ENG-12345678"]);
-		expect(JSON.stringify(registry.references)).not.toMatch(/"ignored"|"commitHash"|contentHashAtCommit/);
-		// `branch` is preserved on the surviving active rows.
-		expect(registry.references?.["linear:ACTIVE-1"]?.branch).toBe("main");
+		// `branch` is stripped alongside the dead fields — references are worktree-scoped.
+		expect(JSON.stringify(registry.references)).not.toMatch(/"ignored"|"commitHash"|contentHashAtCommit|"branch"/);
 	});
 
 	it("is idempotent: an already-clean registry returns changed=false and equal data", () => {

--- a/cli/src/core/SessionTracker.ts
+++ b/cli/src/core/SessionTracker.ts
@@ -958,14 +958,16 @@ async function pruneOrphanedCursors(dir: string, stalePaths: ReadonlyArray<strin
 
 /**
  * Legacy fields removed from PlanEntry (`editCount` is plan-only) and NoteEntry.
- * `branch` is intentionally NOT stripped: the CLI does not filter on it, but the
- * IntelliJ plugin shares this plans.json and branch-scopes its CONTEXT view, so
- * stripping it here would erase IntelliJ's value on every CLI write.
+ * `branch` is stripped: working-area context (plans/notes/references) is
+ * worktree-scoped, not branch-scoped — it follows the worktree across branch
+ * switches and is associated to a branch only at commit (recorded on
+ * `CommitSummary.branch`), exactly like Conversations and uncommitted code. So a
+ * `branch` on a working-area entry never persists past a load->save.
  */
-const LEGACY_PLAN_FIELDS = ["ignored", "editCount"] as const;
-const LEGACY_NOTE_FIELDS = ["ignored"] as const;
+const LEGACY_PLAN_FIELDS = ["ignored", "branch", "editCount"] as const;
+const LEGACY_NOTE_FIELDS = ["ignored", "branch"] as const;
 /** Reference committed/guard rows became dead fields (a live row is uncommitted). */
-const LEGACY_REFERENCE_FIELDS = ["ignored", "commitHash", "contentHashAtCommit"] as const;
+const LEGACY_REFERENCE_FIELDS = ["ignored", "branch", "commitHash", "contentHashAtCommit"] as const;
 
 /** Deletes `fields` from a shallow copy of `entry`; returns the copy + whether anything was dropped. */
 function stripLegacyFields<T>(entry: T, fields: ReadonlyArray<string>): { value: T; changed: boolean } {
@@ -986,15 +988,14 @@ function stripLegacyFields<T>(entry: T, fields: ReadonlyArray<string>): { value:
  *
  * Pure + idempotent — clean input returns `changed: false`. Per type:
  *   - plans / notes: drop rows with `ignored === true`; strip dead fields
- *     (`ignored` / `editCount`); keep the `commitHash` + `contentHashAtCommit`
- *     guard. `branch` is preserved (see LEGACY_PLAN_FIELDS) so IntelliJ's
- *     branch-scoping survives CLI writes to the shared plans.json.
+ *     (`ignored` / `branch` / `editCount`); keep the `commitHash` +
+ *     `contentHashAtCommit` guard. `branch` is stripped — working-area entries
+ *     are worktree-scoped, not branch-scoped (branch lives on CommitSummary).
  *   - references: also drop committed / guard rows — detected ONLY by the
  *     `commitHash` / `contentHashAtCommit` fields, deliberately NOT by a
  *     `-<8hex>` key shape (an active ticket id can legitimately end in 8 digits;
  *     see the predicate below) — a reference row is now always
- *     active/uncommitted — and strip the now-dead fields from survivors (but
- *     keep `branch`).
+ *     active/uncommitted — and strip the now-dead fields from survivors.
  *
  * `JSON.parse` keeps unknown keys and `savePlansRegistry` re-serialises the
  * whole object, so legacy fields/rows do NOT disappear on their own; this is
@@ -1258,14 +1259,10 @@ export async function detectUncommittedReferenceIds(
  * happens there). The near-write reread only overwrites our own mapKey, so a
  * concurrent writer touching other mapKeys is preserved.
  */
-export async function upsertReferenceEntry(ref: Reference, cwd: string, branch: string): Promise<void> {
+export async function upsertReferenceEntry(ref: Reference, cwd: string): Promise<void> {
 	const { sourcePath } = await writeReferenceMarkdown(ref, cwd);
 	const mapKey = `${ref.source}:${ref.nativeId}`;
 	const now = new Date().toISOString();
-	// Persist a real branch only — a failed git lookup ("unknown") is left off so
-	// the row stays branch-less (visible on every branch) rather than scoped to a
-	// non-existent "unknown" branch. The CLI never reads this; IntelliJ does.
-	const branchField = branch && branch !== "unknown" ? { branch } : {};
 
 	// Whole load→save under plans.lock so a concurrent StopHook / QueueWorker /
 	// Codex-discovery write to plans.json can't clobber this reference (and vice
@@ -1285,9 +1282,6 @@ export async function upsertReferenceEntry(ref: Reference, cwd: string, branch: 
 						sourcePath,
 						sourceToolName: ref.toolName,
 						updatedAt: now,
-						// Re-stamp to the current branch (a re-surfaced ref follows it);
-						// an "unknown" lookup keeps the existing branch via the spread.
-						...branchField,
 					}
 				: {
 						source: ref.source,
@@ -1298,7 +1292,6 @@ export async function upsertReferenceEntry(ref: Reference, cwd: string, branch: 
 						addedAt: now,
 						updatedAt: now,
 						sourceToolName: ref.toolName,
-						...branchField,
 					};
 
 		// Near-write reread — only overwrites our own mapKey, so a concurrent writer

--- a/cli/src/core/plans/TranscriptPlanDiscovery.ts
+++ b/cli/src/core/plans/TranscriptPlanDiscovery.ts
@@ -15,7 +15,6 @@ import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { createLogger } from "../../Logger.js";
 import type { PlanEntry, TranscriptSource } from "../../Types.js";
-import { getCurrentBranchSafe } from "../GitBranch.js";
 import { withPlansLock } from "../Locks.js";
 import { normalizePathForCompare } from "../PathUtils.js";
 import { loadPlansRegistry, savePlansRegistry } from "../SessionTracker.js";
@@ -211,12 +210,6 @@ export async function scanPlansFrom(
 	const registry = await loadPlansRegistry(cwd);
 	const plans = { ...registry.plans };
 	const now = new Date().toISOString();
-	// Stamp the branch on newly-created rows so the IntelliJ plugin (which shares
-	// this plans.json) can branch-scope its CONTEXT view. Omit on an "unknown" git
-	// lookup so the row stays branch-less (visible everywhere) rather than scoped
-	// to a non-existent branch. The CLI itself does not filter on it.
-	const discoveredBranch = getCurrentBranchSafe(cwd);
-	const branchField = discoveredBranch && discoveredBranch !== "unknown" ? { branch: discoveredBranch } : {};
 	let changed = false;
 	// Tracks slugs we actually modified in this run. Used at writeback time to
 	// merge our changes onto the freshest registry snapshot per-slug rather
@@ -238,7 +231,6 @@ export async function scanPlansFrom(
 					addedAt: now,
 					updatedAt: now,
 					commitHash: null,
-					...branchField,
 				};
 				changed = true;
 				touchedSlugs.add(slug);
@@ -258,7 +250,6 @@ export async function scanPlansFrom(
 				addedAt: now,
 				updatedAt: now,
 				commitHash: null,
-				...branchField,
 			};
 			changed = true;
 			touchedSlugs.add(slug);

--- a/cli/src/core/references/TranscriptReferenceDiscovery.ts
+++ b/cli/src/core/references/TranscriptReferenceDiscovery.ts
@@ -11,7 +11,6 @@
 
 import { createLogger } from "../../Logger.js";
 import type { TranscriptSource } from "../../Types.js";
-import { getCurrentBranchSafe } from "../GitBranch.js";
 import { upsertReferenceEntry } from "../SessionTracker.js";
 import { extractReferencesFromTranscript } from "./ReferenceExtractor.js";
 
@@ -38,7 +37,6 @@ export async function scanReferencesFrom(
 		return lastLineNumberScanned;
 	}
 
-	const branch = getCurrentBranchSafe(cwd);
 	const upserted: string[] = [];
 	const failed: string[] = [];
 	for (const ref of references) {
@@ -48,7 +46,7 @@ export async function scanReferencesFrom(
 		// cursor save in the caller is skipped, so the next pass re-processes the
 		// same refs and hits the same failure in a loop.
 		try {
-			await upsertReferenceEntry(ref, cwd, branch);
+			await upsertReferenceEntry(ref, cwd);
 			upserted.push(ref.mapKey);
 		} catch (err) {
 			log.warn(

--- a/cli/src/hooks/StopHook.test.ts
+++ b/cli/src/hooks/StopHook.test.ts
@@ -1972,7 +1972,7 @@ describe("StopHook — entity discovery (multi-source)", () => {
 		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
 		await handleStopHook();
 
-		expect(upsertReferenceEntry).toHaveBeenCalledWith(REF, PROJECT_DIR, expect.any(String));
+		expect(upsertReferenceEntry).toHaveBeenCalledWith(REF, PROJECT_DIR);
 		expect(saveDiscoveryCursor).toHaveBeenCalledWith(
 			expect.objectContaining({
 				transcriptPath: `${TRANSCRIPT_PATH}`,

--- a/vscode/src/core/NoteService.test.ts
+++ b/vscode/src/core/NoteService.test.ts
@@ -46,10 +46,6 @@ const { mockGetCurrentBranch } = vi.hoisted(() => ({
 	mockGetCurrentBranch: vi.fn(() => "feature/test"),
 }));
 
-const { mockGetCurrentBranchSafe } = vi.hoisted(() => ({
-	mockGetCurrentBranchSafe: vi.fn(() => "unknown"),
-}));
-
 const { mockCreateHash, mockRandomBytes } = vi.hoisted(() => ({
 	mockCreateHash: vi.fn(() => ({
 		update: vi.fn().mockReturnThis(),
@@ -102,10 +98,6 @@ vi.mock("node:fs", () => ({
 
 vi.mock("./PlanService.js", () => ({
 	getCurrentBranch: mockGetCurrentBranch,
-}));
-
-vi.mock("../../../cli/src/core/GitBranch.js", () => ({
-	getCurrentBranchSafe: mockGetCurrentBranchSafe,
 }));
 
 vi.mock("node:crypto", () => ({
@@ -196,8 +188,6 @@ describe("NoteService", () => {
 		mockRandomBytes.mockReturnValue({ toString: () => "a1b2" });
 		mockGetCurrentBranch.mockReset();
 		mockGetCurrentBranch.mockReturnValue("main");
-		mockGetCurrentBranchSafe.mockReset();
-		mockGetCurrentBranchSafe.mockReturnValue("unknown");
 		mockUnlinkSync.mockReset();
 	});
 
@@ -960,10 +950,9 @@ describe("NoteService", () => {
 			// (id is provided, so generateNoteSlug is not called)
 		});
 
-		it("stamps the current branch on the saved entry when git resolves a real branch (L139 truthy arm)", async () => {
-			// cond-expr L139: `noteBranch && noteBranch !== "unknown" ? { branch } : {}`
-			// — the consequent arm runs only when git returns a real branch name.
-			mockGetCurrentBranchSafe.mockReturnValue("feature/branchy");
+		it("does not persist a branch field on the saved note (worktree-scoped)", async () => {
+			// Working-area notes are worktree-scoped, not branch-scoped: no `branch`
+			// is written; branch association is recorded on CommitSummary at commit.
 			mockLoadPlansRegistry.mockResolvedValue(emptyRegistry());
 			mockExistsSync.mockReturnValue(true);
 			mockReadFileSync.mockReturnValue("content");
@@ -971,7 +960,7 @@ describe("NoteService", () => {
 			await saveNote(undefined, "Branchy Note", "content", "snippet", CWD);
 
 			const saved = mockSavePlansRegistry.mock.calls[0][0];
-			expect(saved.notes["branchy-note-a1b2"].branch).toBe("feature/branchy");
+			expect((saved.notes["branchy-note-a1b2"] as Record<string, unknown>).branch).toBeUndefined();
 		});
 	});
 

--- a/vscode/src/core/NoteService.ts
+++ b/vscode/src/core/NoteService.ts
@@ -20,7 +20,6 @@ import {
 import { basename, join } from "node:path";
 import { withPlansLock } from "../../../cli/src/core/Locks.js";
 import { isPathInside } from "../../../cli/src/core/PathUtils.js";
-import { getCurrentBranchSafe } from "../../../cli/src/core/GitBranch.js";
 import {
 	loadPlansRegistry,
 	loadPlansRegistryWithStatus,
@@ -126,10 +125,6 @@ export async function saveNote(
 		resolvedTitle = title || extractTitle(sourcePath);
 	}
 
-	// Stamp the current branch so the IntelliJ plugin (sharing this plans.json)
-	// can branch-scope its CONTEXT view; an "unknown" git lookup keeps any branch
-	// already on the existing row via the leading spread.
-	const noteBranch = getCurrentBranchSafe(cwd);
 	const entry: NoteEntry = {
 		...(existingNotes[noteId] ?? {}),
 		id: noteId,
@@ -139,7 +134,6 @@ export async function saveNote(
 		addedAt: existingNotes[noteId]?.addedAt ?? now,
 		updatedAt: now,
 		commitHash: existingNotes[noteId]?.commitHash ?? null,
-		...(noteBranch && noteBranch !== "unknown" ? { branch: noteBranch } : {}),
 	};
 
 	// plans.lock + fresh re-read so this single-note upsert can't clobber a

--- a/vscode/src/core/PlanService.test.ts
+++ b/vscode/src/core/PlanService.test.ts
@@ -486,12 +486,9 @@ describe("PlanService", () => {
 			expect(savePlansRegistry).not.toHaveBeenCalled();
 		});
 
-		it("omits the branch field when the git branch lookup is unknown (L279 ternary else)", async () => {
-			// getCurrentBranchSafe returns "unknown" when git fails → the branchField
-			// ternary takes its empty-object alternate and no `branch` is stamped.
-			mockExecFileSync.mockImplementation(() => {
-				throw new Error("not a git repo");
-			});
+		it("does not persist a branch field on a fresh plan entry (worktree-scoped)", async () => {
+			// Working-area plans are worktree-scoped, not branch-scoped: no `branch`
+			// is written; branch association is recorded on CommitSummary at commit.
 			loadPlansRegistry.mockResolvedValue(emptyRegistry());
 			mockExistsSync.mockReturnValue(true);
 			mockReadFileSync.mockReturnValue("# Fresh Plan");
@@ -499,7 +496,7 @@ describe("PlanService", () => {
 			await addPlanToRegistry("fresh-plan", CWD);
 
 			const saved = savePlansRegistry.mock.calls[0][0];
-			expect(saved.plans["fresh-plan"].branch).toBeUndefined();
+			expect((saved.plans["fresh-plan"] as Record<string, unknown>).branch).toBeUndefined();
 		});
 
 		it("resets existing commitHash when re-adding an ignored plan", async () => {
@@ -633,12 +630,9 @@ describe("PlanService", () => {
 			expect(result?.slug).toBe("new-plan-aaaa1111");
 		});
 
-		it("omits the branch field on a freshly-created entry when git branch is unknown (L431 ternary else)", async () => {
-			// slug not in registry → a fresh entry is built; getCurrentBranchSafe
-			// returning "unknown" (git failure) takes the ternary's empty-object arm.
-			mockExecFileSync.mockImplementation(() => {
-				throw new Error("no git");
-			});
+		it("creates a fresh entry (no branch field) when slug not in registry", async () => {
+			// slug not in registry → a fresh, worktree-scoped entry is built with no
+			// `branch` field (branch association is recorded on CommitSummary at commit).
 			loadPlansRegistry.mockResolvedValue(emptyRegistry());
 			mockExistsSync.mockReturnValue(true);
 			mockReadFileSync.mockReturnValue("# New Plan\nContent");
@@ -651,6 +645,10 @@ describe("PlanService", () => {
 
 			expect(result).not.toBeNull();
 			expect(result?.slug).toBe("new-plan-aaaa1111");
+			// The fresh guard entry (keyed by the base slug) carries no `branch`:
+			// working-area plans are worktree-scoped; branch lives on CommitSummary.
+			const saved = savePlansRegistry.mock.calls[0][0];
+			expect((saved.plans["new-plan"] as Record<string, unknown>).branch).toBeUndefined();
 		});
 
 		it("returns null when plan file does not exist and slug not in registry", async () => {

--- a/vscode/src/core/PlanService.ts
+++ b/vscode/src/core/PlanService.ts
@@ -24,7 +24,6 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { withPlansLock } from "../../../cli/src/core/Locks.js";
 import { isPathInside } from "../../../cli/src/core/PathUtils.js";
-import { getCurrentBranchSafe } from "../../../cli/src/core/GitBranch.js";
 import {
 	loadAllSessions,
 	loadPlansRegistry,
@@ -278,11 +277,6 @@ export async function addPlanToRegistry(
 	const existing = registry.plans[slug];
 	const now = new Date().toISOString();
 
-	// Stamp the current branch so the IntelliJ plugin (sharing this plans.json)
-	// can branch-scope its CONTEXT view; omit on an "unknown" git lookup.
-	const planBranch = getCurrentBranchSafe(cwd);
-	const branchField = planBranch && planBranch !== "unknown" ? { branch: planBranch } : {};
-
 	// Always reset to a fresh uncommitted entry — clears contentHashAtCommit
 	// and commitHash so the plan becomes visible and editable again.
 	const entry: PlanEntry = {
@@ -292,7 +286,6 @@ export async function addPlanToRegistry(
 		addedAt: existing?.addedAt ?? now,
 		updatedAt: now,
 		commitHash: null,
-		...branchField,
 	};
 
 	// plans.lock + fresh re-read so this single-plan upsert merges onto the latest
@@ -431,7 +424,6 @@ export async function archivePlanForCommit(
 		if (!existsSync(planFile)) {
 			return null;
 		}
-		const planBranch = getCurrentBranchSafe(cwd);
 		entry = {
 			slug,
 			title: extractTitle(planFile),
@@ -439,7 +431,6 @@ export async function archivePlanForCommit(
 			addedAt: new Date().toISOString(),
 			updatedAt: new Date().toISOString(),
 			commitHash: null,
-			...(planBranch && planBranch !== "unknown" ? { branch: planBranch } : {}),
 		};
 	}
 


### PR DESCRIPTION
The root principle: working-area state — the uncommitted code diff, Conversations, plans, and notes — belongs to the worktree, not to a branch. It only binds to a branch at the moment of commit. This is exactly how git itself behaves: your uncommitted changes follow you across git checkout and belong to no branch until you commit them. Plans and the Context set should follow the same rule as Conversations — while uncommitted they are tied to the current worktree, and association to a branch happens only at commit time.

I made this explicit back in #179 (jollimemory plans.json simplification): branch was deliberately dropped from plans.json, precisely so that switching branches keeps all discovered plan/note/context files (same logic as Conversations), with association deferred to commit.

That principle was then reverted in #255 (IntelliJ memory panel UX), which re-introduced and started stamping a branch field on plan/note/reference entries so IntelliJ could branch-scope its CONTEXT view.

I will do this first step: restore the #179 principle — plans/notes/context are branch-independent working-area state; branch does not live in plans.json; binding happens only at commit. We fix this layer first, before touching the deeper relevance / lifecycle questions.