### PR TITLE
Fix sidebar and commitAI to respect manual-disable flag

### DIFF
--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -2746,6 +2746,17 @@ describe("Extension", () => {
 
 				expect(mockCommitCommand.execute).toHaveBeenCalled();
 			});
+
+			it("skips execute and notifies when the repo is manually disabled", () => {
+				manuallyDisabledState.value = true;
+				const handler = getRegisteredCommand("jollimemory.commitAI");
+				handler();
+
+				expect(mockCommitCommand.execute).not.toHaveBeenCalled();
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					"Jolli Memory is disabled for this project — enable it first.",
+				);
+			});
 		});
 
 		describe("squash", () => {
@@ -7947,6 +7958,18 @@ describe("Extension", () => {
 			// session would re-show the dismissed card (getInitialState reads this).
 			const state = (sidebarDepsCaptured as { getInitialState: () => { backfillDismissed?: boolean } }).getInitialState();
 			expect(state.backfillDismissed).toBe(true);
+		});
+
+		it("getInitialState reports enabled=false when the repo is manually disabled (initial paint)", () => {
+			// The opt-out is folded into the sidebar's effective enabled so the first
+			// paint collapses to the Enable panel even if the git hook is still
+			// installed (status.enabled true). activate() re-reads the flag via
+			// readManualDisableFlagSync (Extension.ts sync boot), so drive it there
+			// rather than poking manuallyDisabledState directly.
+			readManualDisableFlagSync.mockReturnValue(true);
+			activate(makeContext());
+			const state = (sidebarDepsCaptured as { getInitialState: () => { enabled?: boolean } }).getInitialState();
+			expect(state.enabled).toBe(false);
 		});
 
 		it("the Settings full-scope command runs back-fill but does NOT clear the sticky dismiss flag", async () => {

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1064,7 +1064,12 @@ export function activate(context: vscode.ExtensionContext): void {
 		executeCommand: (cmd, ...args) =>
 			vscode.commands.executeCommand(cmd, ...args),
 		getInitialState: () => ({
-			enabled: currentEnabled,
+			// Fold in the manual-disable opt-out so the initial paint matches the
+			// update path (SidebarWebviewProvider.notifyEnabledChanged). `currentEnabled`
+			// tracks status.enabled (git hook installed), which can be true while the
+			// repo is manually disabled (a shared core.hooksPath hook across worktrees,
+			// or a hook reinstalled out-of-band).
+			enabled: currentEnabled && !isManuallyDisabled(),
 			authenticated: currentAuthenticated,
 			configured: currentConfigured,
 			activeTab: "branch",
@@ -2468,6 +2473,17 @@ export function activate(context: vscode.ExtensionContext): void {
 
 		vscode.commands.registerCommand("jollimemory.commitAI", () => {
 			log.info("cmd", "commitAI invoked");
+			// Defence-in-depth: the sidebar collapses to the Enable panel when the
+			// repo is manually disabled, so the button isn't visible — but the command
+			// is still reachable via the palette. A disabled repo must never write, so
+			// refuse the manual commit here too.
+			if (isManuallyDisabled()) {
+				log.info("cmd", "commitAI skipped — repository manually disabled");
+				void vscode.window.showInformationMessage(
+					"Jolli Memory is disabled for this project — enable it first.",
+				);
+				return;
+			}
 			// JOLLI-1904: memory_committed engagement event (mirrors IntelliJ). Gather
 			// the counts off the click path so telemetry never delays the commit.
 			void trackMemoryCommitted({

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -7,6 +7,7 @@ import type {
 	SidebarOutboundMsg,
 	SidebarState,
 } from "./SidebarMessages";
+import { setManuallyDisabled } from "../../../cli/src/Logger.js";
 import { SidebarWebviewProvider } from "./SidebarWebviewProvider";
 
 interface MockWebview {
@@ -2014,6 +2015,61 @@ describe("SidebarWebviewProvider", () => {
 					(m as { enabled?: unknown }).enabled === false,
 			),
 		).toBe(true);
+	});
+
+	const postedEnabled = (view: ReturnType<typeof makeMockView>): boolean | undefined => {
+		const msg = view.webview.postMessage.mock.calls
+			.map((c) => c[0])
+			.find(
+				(m): m is { type: string; enabled: boolean } =>
+					typeof m === "object" && m !== null && (m as { type?: unknown }).type === "enabled:changed",
+			);
+		return msg?.enabled;
+	};
+
+	it("notifyEnabledChanged posts enabled:true when enabled and not manually disabled", () => {
+		const view = makeMockView();
+		const provider = new SidebarWebviewProvider({
+			executeCommand: vi.fn(),
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				activeTab: "status",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.postMessage.mockClear();
+		provider.notifyEnabledChanged(true);
+		expect(postedEnabled(view)).toBe(true);
+	});
+
+	it("notifyEnabledChanged folds in the manual-disable opt-out (posts false even when enabled=true)", () => {
+		setManuallyDisabled(true);
+		try {
+			const view = makeMockView();
+			const provider = new SidebarWebviewProvider({
+				executeCommand: vi.fn(),
+				getInitialState: () => ({
+					enabled: true,
+					authenticated: false,
+					activeTab: "status",
+					kbMode: "folders",
+					branchName: "main",
+					detached: false,
+				}),
+				extensionUri: mockExtensionUri as unknown as never,
+			});
+			provider.resolveWebviewView(view as unknown as never);
+			view.webview.postMessage.mockClear();
+			provider.notifyEnabledChanged(true);
+			expect(postedEnabled(view)).toBe(false);
+		} finally {
+			setManuallyDisabled(false);
+		}
 	});
 
 	it("toggleStatus posts status:toggle", () => {

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -24,6 +24,7 @@ import type { ActiveConversationItem } from "../../../cli/src/core/ActiveSession
 import type { ActiveSessionsProvider } from "../services/ActiveSessionsProvider.js";
 import type { CommitFileInfo } from "../Types.js";
 import { track } from "../../../cli/src/core/Telemetry.js";
+import { isManuallyDisabled } from "../../../cli/src/Logger.js";
 import { flushExtensionTelemetry } from "../TelemetryActivation.js";
 import type { IngestPhase } from "../stores/StatusStore.js";
 import { log } from "../util/Logger.js";
@@ -1831,9 +1832,19 @@ export class SidebarWebviewProvider
 	}
 
 	/** Pushed from refreshStatusBar after enable/disable so the sidebar can show
-	 * or hide the disabled banner without an extension reload. */
+	 * or hide the disabled banner without an extension reload.
+	 *
+	 * The webview's effective "enabled" folds in the CLI-owned manual-disable
+	 * opt-out: `status.enabled` alone is the install-state signal (git hook
+	 * present), which can legitimately be true while the repo is manually
+	 * disabled (a shared `core.hooksPath` hook across git worktrees, or a hook
+	 * reinstalled out-of-band). Without this AND, a disabled repo whose hook is
+	 * still installed would render the full operable sidebar instead of the
+	 * Enable panel. All runtime-update call sites funnel through here, so this is
+	 * the single chokepoint for the update path (the initial paint mirrors it in
+	 * the sidebar shell's getInitialState). */
 	notifyEnabledChanged(enabled: boolean): void {
-		this.postMessage({ type: "enabled:changed", enabled });
+		this.postMessage({ type: "enabled:changed", enabled: enabled && !isManuallyDisabled() });
 	}
 
 	/**


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The sidebar no longer shows the full working interface for projects the user has deliberately disabled. Previously, if the underlying git hook remained installed after a manual disable, the sidebar would render as fully operational — users could see and interact with features that should have been locked out. Now the sidebar correctly collapses to the Enable panel in that state, both on the first load and whenever the enabled status changes at runtime.

The commit action gained an additional safety check as well. Even with the sidebar showing the Enable panel, VS Code's command palette still exposes every registered command. A user who found and ran the commit command directly would previously have been able to write to a disabled project. The command now detects the disabled state, shows a short explanatory message, and returns without doing anything.

---

## Topic (1)
<details>
<summary><strong>01 · Sidebar and commit command now respect manual project disable setting</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a project was manually disabled by the user, the sidebar was still showing the full working interface instead of the "Enable" panel, as long as the underlying git hook remained installed. The commit action was also still executable, which could allow unintended writes to a deliberately disabled project.

**💡 Decisions Behind the Code**

- **Single chokepoint for sidebar state**: The manual-disable check was placed exclusively inside `notifyEnabledChanged` for runtime updates, mirrored once in `getInitialState` for the initial paint, rather than scattered across every call site that reads enabled state. This keeps the logic in two predictable places and avoids future callers accidentally bypassing the check. The trade-off is that the initial paint and the update path must be kept in sync manually — the comments in the code note this pairing explicitly.
- **Defence-in-depth for the commit command**: The sidebar hides the commit button when a project is disabled, but VS Code commands remain reachable through the command palette regardless of UI state. Adding a guard directly in the command handler ensures a manually disabled project can never write, even if a user discovers and invokes the command outside the normal UI flow. The small cost is a slightly more defensive code path on every commit invocation.

**✅ What Was Implemented**

- In `vscode/src/views/SidebarWebviewProvider.ts`, the `notifyEnabledChanged` method now combines the git-hook install state with the manual-disable flag before posting the enabled/disabled state to the webview. This is the single chokepoint for all runtime sidebar state updates.
- In `vscode/src/Extension.ts`, the `getInitialState` function (which drives the first paint of the sidebar shell) now applies the same combined check, so the initial render and subsequent updates are consistent.
- Also in `vscode/src/Extension.ts`, the `jollimemory.commitAI` command handler now checks the manual-disable flag at invocation time and refuses to proceed, showing an information message ("Jolli Memory is disabled for this project — enable it first.") instead of executing the commit.

**📁 FILES**
- `vscode/src/Extension.ts`
- `vscode/src/views/SidebarWebviewProvider.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 27, 2026 at 11:36 PM · via Local agent*
<!-- jollimemory-summary-end -->