### PR TITLE
Add Cline, Devin, and Antigravity MCP host registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ Hook installation uses dist-path indirection: hooks call `node "$($HOME/.jolli/j
 
 ### MCP server registration (multi-host)
 
-`jolli enable` wires the `jolli mcp` stdio server into every detected AI host. Registration is handled by per-host `McpHostRegistrar` implementations under [`cli/src/install/mcp/HostRegistrars.ts`](cli/src/install/mcp/HostRegistrars.ts). Each registrar carries a `scope`: **repo**-scoped hosts (config inside the worktree) are registered per-worktree via `registerRepoMcpHosts`; **global**-scoped hosts (one machine-wide file shared by every repo) are registered once via `registerGlobalMcpHosts`. Uninstall calls `removeRepoMcpHosts` — global entries are deliberately **not** removed, since a single-repo uninstall must not break MCP for other repos still using Jolli. Seven hosts are supported:
+`jolli enable` wires the `jolli mcp` stdio server into every detected AI host. Registration is handled by per-host `McpHostRegistrar` implementations under [`cli/src/install/mcp/HostRegistrars.ts`](cli/src/install/mcp/HostRegistrars.ts). Each registrar carries a `scope`: **repo**-scoped hosts (config inside the worktree) are registered per-worktree via `registerRepoMcpHosts`; **global**-scoped hosts (one machine-wide file shared by every repo) are registered once via `registerGlobalMcpHosts`. Uninstall calls `removeRepoMcpHosts` — global entries are deliberately **not** removed, since a single-repo uninstall must not break MCP for other repos still using Jolli. Ten hosts are supported:
 
 | Host | Scope | Config path | Writer |
 |------|-------|-------------|--------|
@@ -128,8 +128,11 @@ Hook installation uses dist-path indirection: hooks call `node "$($HOME/.jolli/j
 | OpenCode | global | `~/.config/opencode/opencode.json` | `JsonMcpWriter` (key `mcp`; entry needs `type:"local"` + combined command array) |
 | GitHub Copilot CLI | global | `~/.copilot/mcp-config.json` | `JsonMcpWriter` |
 | VS Code Copilot Chat | global | `<vscodeUserDataDir>/User/mcp.json` | `JsonMcpWriter` (key `servers`; entry `type:"stdio"`) |
+| Cline (VS Code ext) | global | `settings/cline_mcp_settings.json` under the ext's globalStorage, **per hosting flavor** | `JsonMcpWriter` (default key; Cline CLI has no MCP config) |
+| Devin CLI | global | `~/.config/devin/config.json` | `JsonMcpWriter` (default key; entry adds `transport:"stdio"`) |
+| Antigravity | global | `~/.gemini/config/mcp_config.json` | `JsonMcpWriter` (default key; stdio inferred from `command`, no type/transport) |
 
-Each non-Claude registrar is gated by its host's existing detector (`isCursorInstalled`, `isCodexInstalled`, …) so registration is skipped for hosts the user hasn't installed. **Claude is the exception**: its `detected` flag mirrors `config.claudeEnabled !== false` (not a filesystem detector) — but MCP registration still runs **regardless of `claudeEnabled`** (it happens before the `claudeEnabled` hook gate in the install loop), because the Claude hook and MCP registration are independent decisions. IntelliJ MCP registration is a follow-up; the IntelliJ plugin registers no MCP today.
+Each non-Claude registrar is gated by its host's existing detector (`isCursorInstalled`, `isCodexInstalled`, `isDevinInstalled`, `isAntigravityInstalled`, `isClineInstalled`/`isClineCliInstalled`, …) so registration is skipped for hosts the user hasn't installed. Each host's per-entry envelope differs (OpenCode `type:"local"`+array, Copilot Chat `type:"stdio"`, Devin `transport:"stdio"`, Antigravity none) — a shape correct for one host silently no-ops if written to another, so each was verified against the host's real on-disk config or app source. **Claude is the exception**: its `detected` flag mirrors `config.claudeEnabled !== false` (not a filesystem detector) — but MCP registration still runs **regardless of `claudeEnabled`** (it happens before the `claudeEnabled` hook gate in the install loop), because the Claude hook and MCP registration are independent decisions. IntelliJ MCP registration is a follow-up; the IntelliJ plugin registers no MCP today.
 
 ### MCP tool set and CLI↔MCP result parity
 

--- a/cli/src/core/AntigravityDetector.test.ts
+++ b/cli/src/core/AntigravityDetector.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { getAntigravityVariants, isAntigravityInstalled } from "./AntigravityDetector.js";
+import { getAntigravityVariants, isAntigravityInstalled, isAntigravityPresent } from "./AntigravityDetector.js";
 import { hasNodeSqliteSupport } from "./SqliteHelpers.js";
 
 function freshHome(): string {
@@ -39,5 +39,41 @@ describe("AntigravityDetector", () => {
 		// On the CLI's Node 22.5+ test runtime this is true; guard keeps the test
 		// meaningful if ever run on an older runtime.
 		expect(await isAntigravityInstalled(home)).toBe(hasNodeSqliteSupport());
+	});
+
+	it("isAntigravityPresent is true when a .db exists, regardless of the SQLite gate", async () => {
+		const home = freshHome();
+		const conv = join(home, ".gemini", "antigravity", "conversations");
+		mkdirSync(conv, { recursive: true });
+		writeFileSync(join(conv, "abc.db"), "");
+		// Presence is a pure filesystem check — used for MCP registration, which
+		// never reads the DB — so it is true even where isAntigravityInstalled
+		// (SQLite-gated) would be false on a Node-18 VS Code host.
+		expect(await isAntigravityPresent(home)).toBe(true);
+	});
+
+	it("isAntigravityPresent is false when no variant dir exists at all", async () => {
+		expect(await isAntigravityPresent(freshHome())).toBe(false);
+	});
+
+	// The MCP gate must fire for "installed but never chatted": Antigravity's dbs
+	// are per-conversation, and MCP registration only runs on an explicit
+	// `jolli enable` (SessionStart / plugin bootstrap short-circuits every detector
+	// via repoHooksOnly), so keying presence on a db meant the natural ordering
+	// install → enable → start chatting silently got no MCP server.
+	it("isAntigravityPresent is true for a bare variant dir with no conversation db", async () => {
+		const home = freshHome();
+		mkdirSync(join(home, ".gemini", "antigravity-ide"), { recursive: true });
+		expect(await isAntigravityPresent(home)).toBe(true);
+		// …while `installed` stays false — status tree and session discovery have
+		// nothing to show for a host with no readable conversations.
+		expect(await isAntigravityInstalled(home)).toBe(false);
+	});
+
+	it("isAntigravityPresent ignores unrelated ~/.gemini content (Gemini CLI's own dirs)", async () => {
+		const home = freshHome();
+		mkdirSync(join(home, ".gemini", "tmp"), { recursive: true });
+		mkdirSync(join(home, ".gemini", "commands"), { recursive: true });
+		expect(await isAntigravityPresent(home)).toBe(false);
 	});
 });

--- a/cli/src/core/AntigravityDetector.ts
+++ b/cli/src/core/AntigravityDetector.ts
@@ -16,7 +16,8 @@
  * "not installed" rather than "detected but 0 sessions".
  */
 
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync } from "node:fs";
+import { readdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { createLogger } from "../Logger.js";
@@ -52,6 +53,10 @@ export function getAntigravityVariants(home: string = homedir()): AntigravityVar
  * Checks whether Antigravity is installed AND the current runtime can read its
  * conversation dbs. Detection = any variant has at least one `*.db` under
  * `conversations/`.
+ *
+ * Deliberately keyed on the conversation dbs rather than the looser
+ * {@link isAntigravityPresent}: this drives session discovery and the status
+ * tree, where a host with no readable conversations has nothing to show.
  */
 export async function isAntigravityInstalled(home: string = homedir()): Promise<boolean> {
 	if (!hasNodeSqliteSupport()) {
@@ -61,12 +66,43 @@ export async function isAntigravityInstalled(home: string = homedir()): Promise<
 		);
 		return false;
 	}
+	return hasAntigravityConversationDb(home);
+}
+
+/** Does any variant have at least one conversation `*.db` on disk? */
+async function hasAntigravityConversationDb(home: string): Promise<boolean> {
 	for (const v of getAntigravityVariants(home)) {
 		try {
-			if (readdirSync(v.conversationsDir).some((f) => f.endsWith(".db"))) return true;
+			if ((await readdir(v.conversationsDir)).some((f) => f.endsWith(".db"))) return true;
 		} catch {
 			// Unreadable variant dir — skip and try the next variant.
 		}
 	}
 	return false;
+}
+
+/**
+ * Pure filesystem presence check for MCP registration: is Antigravity on this
+ * machine at all, regardless of whether THIS runtime can read its dbs? Unlike
+ * `isAntigravityInstalled`, this does NOT gate on `hasNodeSqliteSupport()` — MCP
+ * registration only writes a config file, so it must work on Node-18 VS Code
+ * hosts where the SQLite gate would otherwise suppress a host the user genuinely
+ * has installed.
+ *
+ * Accepts a bare `~/.gemini/<variant>/` directory, not just a conversation db,
+ * because MCP is registered only on an explicit `jolli enable` (the SessionStart
+ * / plugin bootstrap path runs with `repoHooksOnly`, which short-circuits every
+ * detector to false and therefore never self-heals). Antigravity's dbs are
+ * per-conversation, so keying on them meant "has the user chatted at least once"
+ * — and the most natural ordering (install Antigravity, `jolli enable`, then
+ * start using it) silently missed MCP until a second enable.
+ *
+ * Kept async even though both probes could be sync, so the whole
+ * `isXPresent` family (Cursor, Copilot, Devin, OpenCode) has one signature at
+ * the Installer call site. `getAntigravityVariants` stays sync — it is on the
+ * transcript-reader path and its callers are sync.
+ */
+export async function isAntigravityPresent(home: string = homedir()): Promise<boolean> {
+	if (await hasAntigravityConversationDb(home)) return true;
+	return ANTIGRAVITY_VARIANTS.some((variant) => existsSync(join(home, ".gemini", variant)));
 }

--- a/cli/src/core/ClineDetector.test.ts
+++ b/cli/src/core/ClineDetector.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { getClineStorageDirs, isClineInstalled } from "./ClineDetector.js";
+import { getClineStorageDirs, getInstalledClineStorageDirs, isClineInstalled } from "./ClineDetector.js";
 
 describe("ClineDetector", () => {
 	let home: string;
@@ -39,5 +39,22 @@ describe("ClineDetector", () => {
 		await mkdir(stateDir, { recursive: true });
 		await writeFile(join(stateDir, "taskHistory.json"), "[]", "utf8");
 		expect(await isClineInstalled(home)).toBe(true);
+	});
+
+	it("getInstalledClineStorageDirs() returns [] when no flavor has the extension", async () => {
+		expect(await getInstalledClineStorageDirs(home)).toEqual([]);
+	});
+
+	it("getInstalledClineStorageDirs() returns only the flavors that host Cline (no short-circuit)", async () => {
+		// Seed two different flavors (first and third dirs) with taskHistory.json;
+		// the helper must return BOTH, unlike isClineInstalled which stops at the first.
+		const dirs = getClineStorageDirs(home);
+		for (const idx of [0, 2]) {
+			const stateDir = join(dirs[idx], "state");
+			await mkdir(stateDir, { recursive: true });
+			await writeFile(join(stateDir, "taskHistory.json"), "[]", "utf8");
+		}
+		const installed = await getInstalledClineStorageDirs(home);
+		expect(installed).toEqual([dirs[0], dirs[2]]);
 	});
 });

--- a/cli/src/core/ClineDetector.test.ts
+++ b/cli/src/core/ClineDetector.test.ts
@@ -2,7 +2,20 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { getClineStorageDirs, getInstalledClineStorageDirs, isClineInstalled } from "./ClineDetector.js";
+import {
+	clineMcpSettingsPath,
+	getClineStorageDirs,
+	getInstalledClineStorageDirs,
+	isClineInstalled,
+	isClinePresent,
+} from "./ClineDetector.js";
+
+/** Mimic Cline's McpHub seeding its settings file on first activation. */
+async function seedMcpSettings(storageDir: string): Promise<void> {
+	const path = clineMcpSettingsPath(storageDir);
+	await mkdir(join(storageDir, "settings"), { recursive: true });
+	await writeFile(path, JSON.stringify({ mcpServers: {} }, null, 2), "utf8");
+}
 
 describe("ClineDetector", () => {
 	let home: string;
@@ -46,15 +59,46 @@ describe("ClineDetector", () => {
 	});
 
 	it("getInstalledClineStorageDirs() returns only the flavors that host Cline (no short-circuit)", async () => {
-		// Seed two different flavors (first and third dirs) with taskHistory.json;
-		// the helper must return BOTH, unlike isClineInstalled which stops at the first.
+		// Seed two different flavors (first and third dirs) with the MCP settings
+		// file; the helper must return BOTH, unlike isClineInstalled which stops at
+		// the first.
 		const dirs = getClineStorageDirs(home);
 		for (const idx of [0, 2]) {
-			const stateDir = join(dirs[idx], "state");
-			await mkdir(stateDir, { recursive: true });
-			await writeFile(join(stateDir, "taskHistory.json"), "[]", "utf8");
+			await seedMcpSettings(dirs[idx]);
 		}
 		const installed = await getInstalledClineStorageDirs(home);
 		expect(installed).toEqual([dirs[0], dirs[2]]);
+	});
+
+	// Regression: Cline's McpHub creates settings/cline_mcp_settings.json on first
+	// activation, while state/taskHistory.json only appears once the user has run a
+	// task. Gating MCP registration on taskHistory silently skipped a freshly
+	// installed, never-used Cline.
+	it("getInstalledClineStorageDirs() counts a freshly installed Cline with no task history", async () => {
+		const dirs = getClineStorageDirs(home);
+		await seedMcpSettings(dirs[0]);
+		expect(await getInstalledClineStorageDirs(home)).toEqual([dirs[0]]);
+		// …and that same install is invisible to the usage-based signal.
+		expect(await isClineInstalled(home)).toBe(false);
+	});
+
+	it("getInstalledClineStorageDirs() ignores a flavor that only has task history", async () => {
+		// Inverse guard: taskHistory alone must not be mistaken for the extension —
+		// otherwise we would create a spurious settings file under that flavor.
+		const stateDir = join(getClineStorageDirs(home)[0], "state");
+		await mkdir(stateDir, { recursive: true });
+		await writeFile(join(stateDir, "taskHistory.json"), "[]", "utf8");
+		expect(await getInstalledClineStorageDirs(home)).toEqual([]);
+	});
+
+	it("isClinePresent() is false with no extension and true once any flavor has it", async () => {
+		expect(await isClinePresent(home)).toBe(false);
+		await seedMcpSettings(getClineStorageDirs(home)[1]);
+		expect(await isClinePresent(home)).toBe(true);
+	});
+
+	it("clineMcpSettingsPath() points at the file the MCP registrar writes", () => {
+		const dir = getClineStorageDirs(home)[0];
+		expect(clineMcpSettingsPath(dir)).toBe(join(dir, "settings", "cline_mcp_settings.json"));
 	});
 });

--- a/cli/src/core/ClineDetector.ts
+++ b/cli/src/core/ClineDetector.ts
@@ -15,6 +15,15 @@ export function getClineStorageDirs(home: string = homedir()): string[] {
 	return ALL_VSCODE_FLAVORS.map((f) => flavorStorageDir(f, home));
 }
 
+/**
+ * Cline's MCP settings file inside one flavor's globalStorage dir. Single source
+ * of truth for the path: it is both the presence signal below and the file the
+ * MCP registrar writes, so the two must never drift apart.
+ */
+export function clineMcpSettingsPath(storageDir: string): string {
+	return join(storageDir, "settings", "cline_mcp_settings.json");
+}
+
 export async function isClineInstalled(home: string = homedir()): Promise<boolean> {
 	for (const dir of getClineStorageDirs(home)) {
 		try {
@@ -28,23 +37,46 @@ export async function isClineInstalled(home: string = homedir()): Promise<boolea
 }
 
 /**
- * The Cline-extension globalStorage dirs where the extension is actually
- * installed (its `state/taskHistory.json` exists), one per VS Code flavor that
- * has it. Used by MCP registration to write `settings/cline_mcp_settings.json`
- * only into the flavors that host Cline — never creating a spurious settings
- * file under a flavor that doesn't. Unlike `isClineInstalled`, this does not
- * short-circuit: a user may run Cline in more than one flavor (e.g. Code and
- * Cursor), and each has its own independent MCP settings file.
+ * The Cline-extension globalStorage dirs where the extension is PRESENT, one per
+ * VS Code flavor that has it. Used by MCP registration to write
+ * `settings/cline_mcp_settings.json` only into the flavors that host Cline —
+ * never creating a spurious settings file under a flavor that doesn't. Unlike
+ * `isClineInstalled`, this does not short-circuit: a user may run Cline in more
+ * than one flavor (e.g. Code and Cursor), and each has its own independent MCP
+ * settings file.
+ *
+ * The presence signal is `settings/cline_mcp_settings.json`, NOT
+ * `state/taskHistory.json`. Cline's McpHub creates the settings file (seeded as
+ * `{"mcpServers": {}}`) when the extension first activates, before any task
+ * exists; `taskHistory.json` is written lazily on the first history save, and
+ * Cline itself treats its absence as an empty history. So taskHistory proves the
+ * user has USED Cline, not that they installed it — gating on it silently skipped
+ * MCP registration for a freshly installed, not-yet-used Cline. Verified on a
+ * real install: `settings/cline_mcp_settings.json` predates the first `tasks/`
+ * entry, while `taskHistory.json` appears only later.
  */
 export async function getInstalledClineStorageDirs(home: string = homedir()): Promise<string[]> {
 	const out: string[] = [];
 	for (const dir of getClineStorageDirs(home)) {
 		try {
-			await access(join(dir, "state", "taskHistory.json"));
+			await access(clineMcpSettingsPath(dir));
 			out.push(dir);
 		} catch {
 			// extension not present under this flavor — skip it
 		}
 	}
 	return out;
+}
+
+/**
+ * Is the Cline VS Code EXTENSION present in any flavor? The MCP-registration
+ * gate, deliberately distinct from `isClineInstalled`, which is the broader
+ * "has the user used Cline" signal that session discovery / auto-enable / the
+ * status tree want. It is also narrower than the installer's `clineDetectedOnce`
+ * (`isClineInstalled() || isClineCliInstalled()`): the Cline CLI ships no MCP
+ * config file, so it is not an MCP host, and a CLI-only user must not make the
+ * MCP `detected.cline` flag true.
+ */
+export async function isClinePresent(home: string = homedir()): Promise<boolean> {
+	return (await getInstalledClineStorageDirs(home)).length > 0;
 }

--- a/cli/src/core/ClineDetector.ts
+++ b/cli/src/core/ClineDetector.ts
@@ -26,3 +26,25 @@ export async function isClineInstalled(home: string = homedir()): Promise<boolea
 	}
 	return false;
 }
+
+/**
+ * The Cline-extension globalStorage dirs where the extension is actually
+ * installed (its `state/taskHistory.json` exists), one per VS Code flavor that
+ * has it. Used by MCP registration to write `settings/cline_mcp_settings.json`
+ * only into the flavors that host Cline — never creating a spurious settings
+ * file under a flavor that doesn't. Unlike `isClineInstalled`, this does not
+ * short-circuit: a user may run Cline in more than one flavor (e.g. Code and
+ * Cursor), and each has its own independent MCP settings file.
+ */
+export async function getInstalledClineStorageDirs(home: string = homedir()): Promise<string[]> {
+	const out: string[] = [];
+	for (const dir of getClineStorageDirs(home)) {
+		try {
+			await access(join(dir, "state", "taskHistory.json"));
+			out.push(dir);
+		} catch {
+			// extension not present under this flavor — skip it
+		}
+	}
+	return out;
+}

--- a/cli/src/core/CopilotDetector.test.ts
+++ b/cli/src/core/CopilotDetector.test.ts
@@ -70,4 +70,20 @@ describe("CopilotDetector", () => {
 		const { isCopilotInstalled } = await import("./CopilotDetector.js");
 		await expect(isCopilotInstalled()).resolves.toBe(false);
 	});
+
+	it("isCopilotPresent returns true when the DB exists even on a runtime without node:sqlite", async () => {
+		// Presence is decoupled from the SQLite gate so MCP registration (which only
+		// writes a config file) still runs on Node-18 VS Code hosts.
+		vi.spyOn(process.versions, "node", "get").mockReturnValue("18.0.0");
+		vi.mocked(stat).mockResolvedValue({ isFile: () => true } as Awaited<ReturnType<typeof stat>>);
+		const { isCopilotInstalled, isCopilotPresent } = await import("./CopilotDetector.js");
+		await expect(isCopilotPresent()).resolves.toBe(true);
+		await expect(isCopilotInstalled()).resolves.toBe(false);
+	});
+
+	it("isCopilotPresent returns false when the DB is missing", async () => {
+		vi.mocked(stat).mockRejectedValue(Object.assign(new Error("no file"), { code: "ENOENT" }));
+		const { isCopilotPresent } = await import("./CopilotDetector.js");
+		await expect(isCopilotPresent()).resolves.toBe(false);
+	});
 });

--- a/cli/src/core/CopilotDetector.ts
+++ b/cli/src/core/CopilotDetector.ts
@@ -32,6 +32,18 @@ export async function isCopilotInstalled(): Promise<boolean> {
 		);
 		return false;
 	}
+	return isCopilotPresent();
+}
+
+/**
+ * Pure filesystem presence check: is Copilot CLI's session DB on disk,
+ * regardless of whether THIS runtime can read it? Unlike `isCopilotInstalled`,
+ * this does NOT gate on `hasNodeSqliteSupport()`. Used for MCP registration,
+ * which only writes a config file and never reads the DB — so it must work on
+ * Node-18 VS Code hosts where the SQLite gate would otherwise suppress a host
+ * that is genuinely installed.
+ */
+export async function isCopilotPresent(): Promise<boolean> {
 	const dbPath = getCopilotDbPath();
 	try {
 		const fileStat = await stat(dbPath);

--- a/cli/src/core/CursorDetector.test.ts
+++ b/cli/src/core/CursorDetector.test.ts
@@ -21,7 +21,12 @@ vi.mock("./SqliteHelpers.js", async () => ({
 	hasNodeSqliteSupport: mockSqliteSupport,
 }));
 
-import { getCursorGlobalDbPath, getCursorWorkspaceStorageDir, isCursorInstalled } from "./CursorDetector.js";
+import {
+	getCursorGlobalDbPath,
+	getCursorWorkspaceStorageDir,
+	isCursorInstalled,
+	isCursorPresent,
+} from "./CursorDetector.js";
 
 describe("isCursorInstalled (darwin)", () => {
 	let tmpHome: string;
@@ -81,6 +86,37 @@ describe("isCursorInstalled (linux)", () => {
 		await mkdir(globalDir, { recursive: true });
 		await writeFile(join(globalDir, "state.vscdb"), "stub");
 		expect(await isCursorInstalled()).toBe(true);
+	});
+});
+
+describe("isCursorPresent (decoupled from the SQLite gate)", () => {
+	let tmpHome: string;
+
+	beforeEach(async () => {
+		tmpHome = await mkdtemp(join(tmpdir(), "cursor-present-"));
+		mockHomedir.mockReturnValue(tmpHome);
+		mockPlatform.mockReturnValue("darwin");
+	});
+
+	afterEach(async () => {
+		await rm(tmpHome, { recursive: true, force: true });
+	});
+
+	it("returns false when the DB does not exist", async () => {
+		mockSqliteSupport.mockReturnValue(false);
+		expect(await isCursorPresent()).toBe(false);
+	});
+
+	it("returns true when the DB exists EVEN ON a runtime without node:sqlite (Node 18 VS Code host)", async () => {
+		const globalDir = join(tmpHome, "Library/Application Support/Cursor/User/globalStorage");
+		await mkdir(globalDir, { recursive: true });
+		await writeFile(join(globalDir, "state.vscdb"), "stub");
+		// This is the crux of the MCP-registration fix: presence is independent of
+		// the transcript-readability gate. On the same runtime, isCursorInstalled
+		// (gated) reports false while isCursorPresent reports true.
+		mockSqliteSupport.mockReturnValue(false);
+		expect(await isCursorPresent()).toBe(true);
+		expect(await isCursorInstalled()).toBe(false);
 	});
 });
 

--- a/cli/src/core/CursorDetector.ts
+++ b/cli/src/core/CursorDetector.ts
@@ -41,6 +41,18 @@ export async function isCursorInstalled(): Promise<boolean> {
 		);
 		return false;
 	}
+	return isCursorPresent();
+}
+
+/**
+ * Pure filesystem presence check: is Cursor's DB on disk, regardless of whether
+ * THIS runtime can read it? Unlike `isCursorInstalled`, this does NOT gate on
+ * `hasNodeSqliteSupport()`. Used for MCP registration, which only writes a
+ * config file and never reads the SQLite DB — so it must work on Node-18 VS Code
+ * hosts where the transcript-readability gate (correct for session discovery)
+ * would otherwise suppress a host that is genuinely installed.
+ */
+export async function isCursorPresent(): Promise<boolean> {
 	const dbPath = getCursorGlobalDbPath();
 	try {
 		const fileStat = await stat(dbPath);

--- a/cli/src/core/DevinSessionDiscoverer.test.ts
+++ b/cli/src/core/DevinSessionDiscoverer.test.ts
@@ -22,6 +22,7 @@ import {
 	discoverDevinSessions,
 	getDevinSessionsDbPath,
 	isDevinInstalled,
+	isDevinPresent,
 	scanDevinSessions,
 	scanDevinSessionsAt,
 } from "./DevinSessionDiscoverer.js";
@@ -124,6 +125,49 @@ describe("DevinSessionDiscoverer", () => {
 			const originalDescriptor = Object.getOwnPropertyDescriptor(process.versions, "node");
 			Object.defineProperty(process.versions, "node", { value: "20.15.0", configurable: true });
 			try {
+				expect(await isDevinInstalled()).toBe(false);
+			} finally {
+				/* v8 ignore next -- Object.getOwnPropertyDescriptor on a standard process field always returns a descriptor on supported runtimes */
+				if (originalDescriptor) Object.defineProperty(process.versions, "node", originalDescriptor);
+			}
+		});
+	});
+
+	describe("isDevinPresent", () => {
+		it("returns true when sessions.db exists", async () => {
+			const dbDir = join(fakeDataHome, "devin", "cli");
+			await mkdir(dbDir, { recursive: true });
+			await writeFile(join(dbDir, "sessions.db"), "");
+			expect(await isDevinPresent()).toBe(true);
+		});
+
+		it("returns false when Devin's data dir does not exist", async () => {
+			expect(await isDevinPresent()).toBe(false);
+		});
+
+		// The MCP gate must fire for "installed but never used": MCP registration
+		// runs only on an explicit `jolli enable` (SessionStart / plugin bootstrap
+		// short-circuits every detector via repoHooksOnly), so keying presence on
+		// sessions.db meant the natural ordering install → enable → start using
+		// silently got no MCP server.
+		it("returns true for the CLI data dir alone, before any session is stored", async () => {
+			await mkdir(join(fakeDataHome, "devin", "cli"), { recursive: true });
+			expect(await isDevinPresent()).toBe(true);
+			// …while `installed` stays false — discovery and the status tree have
+			// nothing to show without a readable DB.
+			expect(await isDevinInstalled()).toBe(false);
+		});
+
+		it("stays true on a runtime below the node:sqlite threshold (unlike isDevinInstalled)", async () => {
+			// Presence is a pure filesystem check for MCP registration, which never
+			// reads the DB — so it is independent of the transcript-readability gate.
+			const dbDir = join(fakeDataHome, "devin", "cli");
+			await mkdir(dbDir, { recursive: true });
+			await writeFile(join(dbDir, "sessions.db"), "");
+			const originalDescriptor = Object.getOwnPropertyDescriptor(process.versions, "node");
+			Object.defineProperty(process.versions, "node", { value: "20.15.0", configurable: true });
+			try {
+				expect(await isDevinPresent()).toBe(true);
 				expect(await isDevinInstalled()).toBe(false);
 			} finally {
 				/* v8 ignore next -- Object.getOwnPropertyDescriptor on a standard process field always returns a descriptor on supported runtimes */

--- a/cli/src/core/DevinSessionDiscoverer.ts
+++ b/cli/src/core/DevinSessionDiscoverer.ts
@@ -105,6 +105,10 @@ export function getDevinSessionsDbPath(home?: string): string {
  * Devin is "installed" when its session DB exists AND the runtime can read
  * SQLite. Gated on hasNodeSqliteSupport() so Node 18 VS Code hosts report
  * "not installed" rather than "detected but 0 sessions".
+ *
+ * Deliberately keyed on the DB rather than the looser {@link isDevinPresent}:
+ * this drives session discovery and the status tree, where a host with no
+ * readable conversations has nothing to show.
  */
 export async function isDevinInstalled(): Promise<boolean> {
 	if (!hasNodeSqliteSupport()) {
@@ -114,8 +118,38 @@ export async function isDevinInstalled(): Promise<boolean> {
 		);
 		return false;
 	}
+	return hasDevinSessionDb();
+}
+
+/** Does Devin CLI's global session DB exist on disk? */
+async function hasDevinSessionDb(): Promise<boolean> {
 	try {
 		return (await stat(getDevinSessionsDbPath())).isFile();
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Pure filesystem presence check for MCP registration: is Devin on this machine
+ * at all, regardless of whether THIS runtime can read its DB? Unlike
+ * `isDevinInstalled`, this does NOT gate on `hasNodeSqliteSupport()` — MCP
+ * registration only writes a config file, so it must work on Node-18 VS Code
+ * hosts where the SQLite gate would otherwise suppress a host the user
+ * genuinely has installed.
+ *
+ * Accepts the CLI's data DIRECTORY, not just `sessions.db`, because MCP is
+ * registered only on an explicit `jolli enable` (the SessionStart / plugin
+ * bootstrap path runs with `repoHooksOnly`, which short-circuits every detector
+ * to false and therefore never self-heals). Keying on the DB alone made the most
+ * natural ordering — install Devin, `jolli enable`, then start using it — miss
+ * MCP until the user happened to enable a second time. The directory exists from
+ * Devin's first run, before any conversation is stored.
+ */
+export async function isDevinPresent(): Promise<boolean> {
+	if (await hasDevinSessionDb()) return true;
+	try {
+		return (await stat(getDevinCliDir())).isDirectory();
 	} catch {
 		return false;
 	}

--- a/cli/src/core/OpenCodeSessionDiscoverer.test.ts
+++ b/cli/src/core/OpenCodeSessionDiscoverer.test.ts
@@ -30,6 +30,7 @@ import {
 	discoverOpenCodeSessions,
 	getOpenCodeDbPath,
 	isOpenCodeInstalled,
+	isOpenCodePresent,
 	scanOpenCodeSessions,
 } from "./OpenCodeSessionDiscoverer.js";
 
@@ -192,6 +193,34 @@ describe("OpenCodeSessionDiscoverer", () => {
 			const originalDescriptor = Object.getOwnPropertyDescriptor(process.versions, "node");
 			Object.defineProperty(process.versions, "node", { value: "20.15.0", configurable: true });
 			try {
+				expect(await isOpenCodeInstalled()).toBe(false);
+			} finally {
+				/* v8 ignore next -- Object.getOwnPropertyDescriptor on a standard process field always returns a descriptor on supported runtimes */
+				if (originalDescriptor) Object.defineProperty(process.versions, "node", originalDescriptor);
+			}
+		});
+	});
+
+	describe("isOpenCodePresent", () => {
+		it("returns true when opencode.db exists", async () => {
+			const dbDir = join(fakeHome, ".local", "share", "opencode");
+			await createOpenCodeDb(dbDir, []);
+			expect(await isOpenCodePresent()).toBe(true);
+		});
+
+		it("returns false when opencode.db does not exist", async () => {
+			expect(await isOpenCodePresent()).toBe(false);
+		});
+
+		it("stays true on a runtime below the node:sqlite threshold (unlike isOpenCodeInstalled)", async () => {
+			// Presence is a pure filesystem check for MCP registration, which never
+			// reads the DB — so it is independent of the transcript-readability gate.
+			const dbDir = join(fakeHome, ".local", "share", "opencode");
+			await createOpenCodeDb(dbDir, []);
+			const originalDescriptor = Object.getOwnPropertyDescriptor(process.versions, "node");
+			Object.defineProperty(process.versions, "node", { value: "20.15.0", configurable: true });
+			try {
+				expect(await isOpenCodePresent()).toBe(true);
 				expect(await isOpenCodeInstalled()).toBe(false);
 			} finally {
 				/* v8 ignore next -- Object.getOwnPropertyDescriptor on a standard process field always returns a descriptor on supported runtimes */

--- a/cli/src/core/OpenCodeSessionDiscoverer.ts
+++ b/cli/src/core/OpenCodeSessionDiscoverer.ts
@@ -94,6 +94,18 @@ export async function isOpenCodeInstalled(): Promise<boolean> {
 		);
 		return false;
 	}
+	return isOpenCodePresent();
+}
+
+/**
+ * Pure filesystem presence check: is OpenCode's DB on disk, regardless of
+ * whether THIS runtime can read it? Unlike `isOpenCodeInstalled`, this does NOT
+ * gate on `hasNodeSqliteSupport()`. Used for MCP registration, which only writes
+ * a config file and never reads the DB — so it must work on Node-18 VS Code
+ * hosts where the SQLite gate would otherwise suppress a host that is genuinely
+ * installed.
+ */
+export async function isOpenCodePresent(): Promise<boolean> {
 	const dbPath = getOpenCodeDbPath();
 	try {
 		const fileStat = await stat(dbPath);

--- a/cli/src/install/Installer.test.ts
+++ b/cli/src/install/Installer.test.ts
@@ -70,13 +70,18 @@ vi.mock("./mcp/HostRegistrars.js", async (importOriginal) => {
 // Mock OpenCodeSessionDiscoverer for status/install checks
 vi.mock("../core/OpenCodeSessionDiscoverer.js", () => ({
 	isOpenCodeInstalled: vi.fn().mockResolvedValue(false),
+	isOpenCodePresent: vi.fn().mockResolvedValue(false),
 	discoverOpenCodeSessions: vi.fn().mockResolvedValue([]),
 	scanOpenCodeSessions: vi.fn().mockResolvedValue({ sessions: [] }),
 }));
 
-// Mock CursorDetector for status/install checks
+// Mock CursorDetector for status/install checks. isCursorInstalled (SQLite-gated)
+// drives session discovery / auto-enable; isCursorPresent (pure filesystem) drives
+// MCP registration — kept as separate mocks so a test can exercise the Node-18
+// case where a host is present but unreadable.
 vi.mock("../core/CursorDetector.js", () => ({
 	isCursorInstalled: vi.fn().mockResolvedValue(false),
+	isCursorPresent: vi.fn().mockResolvedValue(false),
 }));
 
 // Mock CursorSessionDiscoverer for status/install checks
@@ -87,6 +92,7 @@ vi.mock("../core/CursorSessionDiscoverer.js", () => ({
 // Mock CopilotDetector for status/install checks
 vi.mock("../core/CopilotDetector.js", () => ({
 	isCopilotInstalled: vi.fn().mockResolvedValue(false),
+	isCopilotPresent: vi.fn().mockResolvedValue(false),
 	getCopilotDbPath: vi.fn().mockReturnValue("/fake/.copilot/session-store.db"),
 }));
 
@@ -108,9 +114,21 @@ vi.mock("../core/CopilotChatSessionDiscoverer.js", () => ({
 	discoverCopilotChatSessions: vi.fn().mockResolvedValue([]),
 }));
 
-// Mock ClineDetector for status/install checks
+// Mock ClineDetector for status/install checks. isClineInstalled ("has the user
+// used Cline") drives status + auto-enable; isClinePresent ("is the VS Code
+// extension there") is the narrower MCP-registration gate — they are mocked
+// independently so a test can exercise one without implying the other.
+// `clineControl.storageDirs` lets a test point the per-flavor globalStorage dirs
+// at a temp dir so the real MCP settings write is observable.
+const { clineControl } = vi.hoisted(() => ({
+	clineControl: { storageDirs: [] as string[] },
+}));
 vi.mock("../core/ClineDetector.js", () => ({
 	isClineInstalled: vi.fn().mockResolvedValue(false),
+	isClinePresent: vi.fn().mockResolvedValue(false),
+	getInstalledClineStorageDirs: vi.fn(async () => clineControl.storageDirs),
+	getClineStorageDirs: vi.fn(() => clineControl.storageDirs),
+	clineMcpSettingsPath: (dir: string) => join(dir, "settings", "cline_mcp_settings.json"),
 }));
 
 // Mock ClineCliDetector for status/install checks
@@ -260,6 +278,8 @@ describe("Installer", () => {
 		originalCwd = process.cwd();
 		// Create .git/hooks directory to simulate a git repo
 		await mkdir(join(tempDir, ".git", "hooks"), { recursive: true });
+		// No Cline flavors by default; the MCP tests below point this at a temp dir.
+		clineControl.storageDirs = [];
 		// Reset integration detector mocks to defaults so state doesn't leak between tests
 		const { isCodexInstalled, discoverCodexSessions } = await import("../core/CodexSessionDiscoverer.js");
 		vi.mocked(isCodexInstalled).mockResolvedValue(false);
@@ -1283,12 +1303,14 @@ describe("Installer", () => {
 
 	describe("multi-host MCP registration", () => {
 		it("registers MCP across detected hosts during enable", async () => {
-			// claude=true (default), cursor=true, gemini=false, codex=false.
+			// claude=true (default), cursor present=true, gemini=false, codex=false.
 			// cursor writes to <wt>/.cursor/mcp.json (tmpdir-safe).
 			// claude writes to <wt>/.mcp.json (tmpdir-safe).
 			// gemini/codex stay false so no real ~/.gemini or ~/.codex is touched.
-			const { isCursorInstalled } = await import("../core/CursorDetector.js");
-			vi.mocked(isCursorInstalled).mockResolvedValue(true);
+			// MCP registration keys off host PRESENCE (isCursorPresent), not the
+			// SQLite-gated isCursorInstalled.
+			const { isCursorPresent } = await import("../core/CursorDetector.js");
+			vi.mocked(isCursorPresent).mockResolvedValue(true);
 
 			const result = await install(tempDir);
 			expect(result.success).toBe(true);
@@ -1309,8 +1331,8 @@ describe("Installer", () => {
 		it("registers non-Claude MCP hosts even when claudeEnabled is false", async () => {
 			// Save config with claudeEnabled=false, then install.
 			await writeFile(join(emptyGlobalDir, "config.json"), JSON.stringify({ claudeEnabled: false }), "utf-8");
-			const { isCursorInstalled } = await import("../core/CursorDetector.js");
-			vi.mocked(isCursorInstalled).mockResolvedValue(true);
+			const { isCursorPresent } = await import("../core/CursorDetector.js");
+			vi.mocked(isCursorPresent).mockResolvedValue(true);
 
 			const result = await install(tempDir);
 			expect(result.success).toBe(true);
@@ -1323,6 +1345,70 @@ describe("Installer", () => {
 			const cursorMcpPath = join(tempDir, ".cursor", "mcp.json");
 			const cursorMcp = JSON.parse(await readFile(cursorMcpPath, "utf-8"));
 			expect(cursorMcp.mcpServers.jollimemory).toBeDefined();
+		});
+
+		it("registers MCP for a host present on disk but unreadable on this runtime (Node-18 VS Code host)", async () => {
+			// Regression guard for the SQLite-gating bug: a VS Code extension host
+			// runs a Node without built-in node:sqlite, so isCursorInstalled (gated)
+			// is false there. MCP registration must still run — it only writes a
+			// config file and never reads the DB — so it keys off isCursorPresent.
+			const { isCursorInstalled, isCursorPresent } = await import("../core/CursorDetector.js");
+			vi.mocked(isCursorInstalled).mockResolvedValue(false); // Node 18: gated → "not installed"
+			vi.mocked(isCursorPresent).mockResolvedValue(true); // …but Cursor IS on disk
+
+			const result = await install(tempDir);
+			expect(result.success).toBe(true);
+
+			// Cursor MCP config IS written despite isCursorInstalled === false.
+			const cursorMcpPath = join(tempDir, ".cursor", "mcp.json");
+			const cursorMcp = JSON.parse(await readFile(cursorMcpPath, "utf-8"));
+			expect(cursorMcp.mcpServers.jollimemory).toBeDefined();
+
+			// …but session discovery is NOT auto-enabled: that path stays gated on
+			// isCursorInstalled, so a runtime that cannot read the DB does not flip
+			// cursorEnabled on. This proves the two concerns are decoupled.
+			// The evidence is that NO global config was persisted at all: the
+			// auto-enable write is the only thing in this flow that would create
+			// config.json, so its absence is a strictly stronger guard than reading
+			// the file behind a catch-all and asserting a missing key (which passes
+			// vacuously whether or not the file exists — verified: it does not).
+			await expect(readFile(join(emptyGlobalDir, "config.json"), "utf-8")).rejects.toThrow(/ENOENT/);
+		});
+
+		it("registers Cline MCP when the VS Code extension is present", async () => {
+			const { isClinePresent } = await import("../core/ClineDetector.js");
+			const flavor = join(fakeHomeDir, "Code", "globalStorage", "saoudrizwan.claude-dev");
+			clineControl.storageDirs = [flavor];
+			vi.mocked(isClinePresent).mockResolvedValue(true);
+
+			expect((await install(tempDir)).success).toBe(true);
+
+			const settings = JSON.parse(await readFile(join(flavor, "settings", "cline_mcp_settings.json"), "utf-8"));
+			expect(settings.mcpServers.jollimemory).toBeDefined();
+		});
+
+		it("does not register Cline MCP for a CLI-only user, even though clineEnabled is auto-enabled", async () => {
+			// The Cline CLI ships no MCP config file, so it is not an MCP host. The
+			// installer's clineDetectedOnce is `extension OR CLI` and drives
+			// auto-enable; MCP must key off the narrower extension-only presence
+			// flag, or detected.cline would mean "some Cline" rather than "this MCP
+			// host is here". Both halves are asserted together so the two flags
+			// cannot be collapsed back into one without failing here.
+			const { isClineInstalled, isClinePresent } = await import("../core/ClineDetector.js");
+			const { isClineCliInstalled } = await import("../core/ClineCliDetector.js");
+			const flavor = join(fakeHomeDir, "Code", "globalStorage", "saoudrizwan.claude-dev");
+			clineControl.storageDirs = [flavor];
+			vi.mocked(isClineInstalled).mockResolvedValue(false); // extension absent
+			vi.mocked(isClinePresent).mockResolvedValue(false); // …so not an MCP host
+			vi.mocked(isClineCliInstalled).mockResolvedValue(true); // but the CLI is there
+
+			expect((await install(tempDir)).success).toBe(true);
+
+			await expect(readFile(join(flavor, "settings", "cline_mcp_settings.json"), "utf-8")).rejects.toThrow(
+				/ENOENT/,
+			);
+			const globalConfig = JSON.parse(await readFile(join(emptyGlobalDir, "config.json"), "utf-8"));
+			expect(globalConfig.clineEnabled).toBe(true);
 		});
 	});
 

--- a/cli/src/install/Installer.ts
+++ b/cli/src/install/Installer.ts
@@ -349,6 +349,8 @@ export async function install(
 		const copilotDetectedOnce = repoHooksOnly ? false : await isCopilotInstalled();
 		const copilotChatDetectedOnce = repoHooksOnly ? false : await isCopilotChatInstalled();
 		const clineDetectedOnce = repoHooksOnly ? false : (await isClineInstalled()) || (await isClineCliInstalled());
+		const devinDetectedOnce = repoHooksOnly ? false : await isDevinInstalled();
+		const antigravityDetectedOnce = repoHooksOnly ? false : await isAntigravityInstalled();
 
 		// Install .jolli/jollimemory/ state dir (always) and Claude Code hook (if enabled)
 		let claudeResult: HookOpResult = {};
@@ -426,6 +428,9 @@ export async function install(
 				opencode: opencodeDetectedOnce,
 				copilot: copilotDetectedOnce,
 				copilotChat: copilotChatDetectedOnce,
+				cline: clineDetectedOnce,
+				devin: devinDetectedOnce,
+				antigravity: antigravityDetectedOnce,
 			};
 			// Keep the user's `git status` clean by adding Jolli-managed paths to
 			// `.git/info/exclude`. Worktree-aware: linked worktrees may have their
@@ -463,9 +468,10 @@ export async function install(
 		}
 
 		// Register the MCP server in the detected GLOBAL hosts (Codex, Gemini,
-		// OpenCode, Copilot, Copilot Chat). Their config files are machine-wide and
-		// shared across every repo, so we write them ONCE here rather than rewriting
-		// the same file on each worktree iteration above. Detection-gated only.
+		// OpenCode, Copilot, Copilot Chat, Cline, Devin, Antigravity). Their config
+		// files are machine-wide and shared across every repo, so we write them ONCE
+		// here rather than rewriting the same file on each worktree iteration above.
+		// Detection-gated only.
 		await registerGlobalMcpHosts({
 			claude: false,
 			cursor: false,
@@ -474,6 +480,9 @@ export async function install(
 			opencode: opencodeDetectedOnce,
 			copilot: copilotDetectedOnce,
 			copilotChat: copilotChatDetectedOnce,
+			cline: clineDetectedOnce,
+			devin: devinDetectedOnce,
+			antigravity: antigravityDetectedOnce,
 		});
 
 		// Prefer Jolli's skills by default: write a standing rule into each

--- a/cli/src/install/Installer.ts
+++ b/cli/src/install/Installer.ts
@@ -17,34 +17,35 @@
 import { stat, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { isAntigravityInstalled } from "../core/AntigravityDetector.js";
+import { isAntigravityInstalled, isAntigravityPresent } from "../core/AntigravityDetector.js";
 import { scanAntigravitySessions } from "../core/AntigravitySessionDiscoverer.js";
 import { isClaudeInstalled } from "../core/ClaudeDetector.js";
 import { isClineCliInstalled } from "../core/ClineCliDetector.js";
 import { scanClineCliSessions } from "../core/ClineCliSessionDiscoverer.js";
-import { isClineInstalled } from "../core/ClineDetector.js";
+import { isClineInstalled, isClinePresent } from "../core/ClineDetector.js";
 import { scanClineSessions } from "../core/ClineSessionDiscoverer.js";
 import type { ClineScanError } from "../core/ClineTranscriptShared.js";
 import { discoverCodexSessions, isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
 import { isCopilotChatInstalled } from "../core/CopilotChatDetector.js";
 import { scanCopilotChatSessions } from "../core/CopilotChatSessionDiscoverer.js";
 import type { CopilotChatScanError } from "../core/CopilotChatTranscriptReader.js";
-import { isCopilotInstalled } from "../core/CopilotDetector.js";
+import { isCopilotInstalled, isCopilotPresent } from "../core/CopilotDetector.js";
 import { scanCopilotSessions } from "../core/CopilotSessionDiscoverer.js";
 import {
 	type CursorCliScanError,
 	isCursorCliInstalled,
 	scanCursorCliSessions,
 } from "../core/CursorCliSessionDiscoverer.js";
-import { isCursorInstalled } from "../core/CursorDetector.js";
+import { isCursorInstalled, isCursorPresent } from "../core/CursorDetector.js";
 import { scanCursorSessions } from "../core/CursorSessionDiscoverer.js";
-import { isDevinInstalled, scanDevinSessions } from "../core/DevinSessionDiscoverer.js";
+import { isDevinInstalled, isDevinPresent, scanDevinSessions } from "../core/DevinSessionDiscoverer.js";
 import { isGeminiInstalled } from "../core/GeminiSessionDetector.js";
 import { getProjectRootDir, isInsideGitRepo, listWorktrees, orphanBranchExists } from "../core/GitOps.js";
 import { resolveMemoryBankState } from "../core/KBPathResolver.js";
 import { acquireRepoHooksLock, type StrictLockHandle, withRuntimeRegistryLock } from "../core/Locks.js";
 import {
 	isOpenCodeInstalled,
+	isOpenCodePresent,
 	type OpenCodeScanError,
 	scanOpenCodeSessions,
 } from "../core/OpenCodeSessionDiscoverer.js";
@@ -349,8 +350,35 @@ export async function install(
 		const copilotDetectedOnce = repoHooksOnly ? false : await isCopilotInstalled();
 		const copilotChatDetectedOnce = repoHooksOnly ? false : await isCopilotChatInstalled();
 		const clineDetectedOnce = repoHooksOnly ? false : (await isClineInstalled()) || (await isClineCliInstalled());
-		const devinDetectedOnce = repoHooksOnly ? false : await isDevinInstalled();
-		const antigravityDetectedOnce = repoHooksOnly ? false : await isAntigravityInstalled();
+		// NOTE: Devin and Antigravity have no SQLite-gated auto-enable step inside
+		// install() (unlike OpenCode/Cursor/Copilot below), so their only consumer
+		// here is MCP registration — which keys off the PRESENCE flags below, not a
+		// *DetectedOnce flag. isDevinInstalled/isAntigravityInstalled are still used
+		// by getStatus() for the status tree.
+
+		// MCP-registration presence flags. Distinct from the *DetectedOnce flags
+		// above for the five SQLite-gated hosts (Cursor, OpenCode, Copilot, Devin,
+		// Antigravity): *DetectedOnce answers "is the host installed AND can THIS
+		// runtime read its transcripts" — the right gate for session discovery and
+		// the auto-enable writes below. But MCP registration only writes a config
+		// file; it never reads the DB, so it must key off raw on-disk PRESENCE
+		// instead. Otherwise a Node-18 VS Code host (no built-in node:sqlite) would
+		// silently skip MCP for a host the user genuinely has installed. Hosts that
+		// are not SQLite-gated (Codex, Gemini, Copilot Chat) already work on Node 18,
+		// so they reuse their *DetectedOnce flag directly.
+		//
+		// Cline needs its own present flag for a DIFFERENT reason: it is not
+		// SQLite-gated, but `clineDetectedOnce` above is `extension OR CLI` — and the
+		// Cline CLI ships no MCP config file, so it is not an MCP host. Feeding the
+		// broad flag to MCP would build+run clineRegistrar for a CLI-only user and
+		// write nothing, making `detected.cline` mean "some Cline" while every other
+		// field means "this MCP host is here". isClinePresent() is extension-only.
+		const cursorPresentOnce = repoHooksOnly ? false : await isCursorPresent();
+		const opencodePresentOnce = repoHooksOnly ? false : await isOpenCodePresent();
+		const copilotPresentOnce = repoHooksOnly ? false : await isCopilotPresent();
+		const clinePresentOnce = repoHooksOnly ? false : await isClinePresent();
+		const devinPresentOnce = repoHooksOnly ? false : await isDevinPresent();
+		const antigravityPresentOnce = repoHooksOnly ? false : await isAntigravityPresent();
 
 		// Install .jolli/jollimemory/ state dir (always) and Claude Code hook (if enabled)
 		let claudeResult: HookOpResult = {};
@@ -423,14 +451,14 @@ export async function install(
 			const detected: DetectedHosts = {
 				claude: config.claudeEnabled !== false,
 				codex: codexDetectedOnce,
-				cursor: cursorDetectedOnce,
+				cursor: cursorPresentOnce,
 				gemini: geminiDetectedOnce,
-				opencode: opencodeDetectedOnce,
-				copilot: copilotDetectedOnce,
+				opencode: opencodePresentOnce,
+				copilot: copilotPresentOnce,
 				copilotChat: copilotChatDetectedOnce,
-				cline: clineDetectedOnce,
-				devin: devinDetectedOnce,
-				antigravity: antigravityDetectedOnce,
+				cline: clinePresentOnce,
+				devin: devinPresentOnce,
+				antigravity: antigravityPresentOnce,
 			};
 			// Keep the user's `git status` clean by adding Jolli-managed paths to
 			// `.git/info/exclude`. Worktree-aware: linked worktrees may have their
@@ -477,12 +505,12 @@ export async function install(
 			cursor: false,
 			codex: codexDetectedOnce,
 			gemini: geminiDetectedOnce,
-			opencode: opencodeDetectedOnce,
-			copilot: copilotDetectedOnce,
+			opencode: opencodePresentOnce,
+			copilot: copilotPresentOnce,
 			copilotChat: copilotChatDetectedOnce,
-			cline: clineDetectedOnce,
-			devin: devinDetectedOnce,
-			antigravity: antigravityDetectedOnce,
+			cline: clinePresentOnce,
+			devin: devinPresentOnce,
+			antigravity: antigravityPresentOnce,
 		});
 
 		// Prefer Jolli's skills by default: write a standing rule into each

--- a/cli/src/install/mcp/HostRegistrars.test.ts
+++ b/cli/src/install/mcp/HostRegistrars.test.ts
@@ -14,6 +14,9 @@ const NONE = {
 	opencode: false,
 	copilot: false,
 	copilotChat: false,
+	cline: false,
+	devin: false,
+	antigravity: false,
 } as const;
 
 let dir: string;
@@ -343,6 +346,135 @@ describe("new registrars — register targets & entry shape (mocked writer)", ()
 	});
 });
 
+describe("cline/devin/antigravity registrars — structure", () => {
+	it("cline appears when detected.cline is true, with empty gitExcludePaths", () => {
+		const [r] = buildRegistrars({ ...NONE, cline: true });
+		expect(r.host).toBe("cline");
+		expect(r.gitExcludePaths()).toEqual([]);
+	});
+	it("devin appears when detected.devin is true, with empty gitExcludePaths", () => {
+		const [r] = buildRegistrars({ ...NONE, devin: true });
+		expect(r.host).toBe("devin");
+		expect(r.gitExcludePaths()).toEqual([]);
+	});
+	it("antigravity appears when detected.antigravity is true, with empty gitExcludePaths", () => {
+		const [r] = buildRegistrars({ ...NONE, antigravity: true });
+		expect(r.host).toBe("antigravity");
+		expect(r.gitExcludePaths()).toEqual([]);
+	});
+	it("all three are global-scoped — registerRepoMcpHosts writes no worktree file for them", async () => {
+		// Global hosts must be skipped by the repo pass; if they leaked through, cline
+		// would even write to a real machine-global settings file — so this also guards
+		// against that. registerRepoMcpHosts filters to scope === "repo".
+		await registerRepoMcpHosts(dir, { ...NONE, cline: true, devin: true, antigravity: true });
+		await expect(readFile(join(dir, ".mcp.json"), "utf-8")).rejects.toThrow();
+	});
+});
+
+describe("devin & antigravity registrars — register/remove targets (mocked writer)", () => {
+	const upsertMock = vi.fn().mockResolvedValue(undefined);
+	const removeMock = vi.fn().mockResolvedValue(undefined);
+	beforeEach(() => {
+		vi.resetModules();
+		vi.doMock("./JsonMcpWriter.js", () => ({ upsertJsonMcpServer: upsertMock, removeJsonMcpServer: removeMock }));
+		upsertMock.mockClear();
+		removeMock.mockClear();
+	});
+	afterEach(() => {
+		vi.doUnmock("./JsonMcpWriter.js");
+		vi.resetModules();
+	});
+
+	it("devin register() → ~/.config/devin/config.json, default key, {command,args,transport:'stdio'}", async () => {
+		const { buildRegistrars: build } = await import("./HostRegistrars.js");
+		const [r] = build({ ...NONE, devin: true });
+		await r.register("/some/wt");
+		const [path, entry, key] = upsertMock.mock.calls[0];
+		expect(path).toBe(join(homedir(), ".config", "devin", "config.json"));
+		expect(key).toBeUndefined(); // default mcpServers
+		expect(entry.transport).toBe("stdio"); // Devin's stdio envelope
+		expect(entry.args).toContain("mcp");
+	});
+
+	it("devin remove() → ~/.config/devin/config.json, default key", async () => {
+		const { buildRegistrars: build } = await import("./HostRegistrars.js");
+		await build({ ...NONE, devin: true })[0].remove("/some/wt");
+		const [path, key] = removeMock.mock.calls[0];
+		expect(path).toBe(join(homedir(), ".config", "devin", "config.json"));
+		expect(key).toBeUndefined();
+	});
+
+	it("antigravity register() → ~/.gemini/config/mcp_config.json, default key, {command,args} (no transport/type)", async () => {
+		const { buildRegistrars: build } = await import("./HostRegistrars.js");
+		const [r] = build({ ...NONE, antigravity: true });
+		await r.register("/some/wt");
+		const [path, entry, key] = upsertMock.mock.calls[0];
+		expect(path).toBe(join(homedir(), ".gemini", "config", "mcp_config.json"));
+		expect(key).toBeUndefined(); // default mcpServers
+		expect(entry.args).toContain("mcp");
+		// Antigravity infers stdio from the presence of `command`; the shipped
+		// mcp_servers.md schema uses no transport/type field for local servers.
+		expect(entry.transport).toBeUndefined();
+		expect(entry.type).toBeUndefined();
+	});
+
+	it("antigravity remove() → ~/.gemini/config/mcp_config.json, default key", async () => {
+		const { buildRegistrars: build } = await import("./HostRegistrars.js");
+		await build({ ...NONE, antigravity: true })[0].remove("/some/wt");
+		const [path, key] = removeMock.mock.calls[0];
+		expect(path).toBe(join(homedir(), ".gemini", "config", "mcp_config.json"));
+		expect(key).toBeUndefined();
+	});
+});
+
+describe("cline registrar — per-flavor settings files (mocked writer + detector)", () => {
+	const upsertMock = vi.fn().mockResolvedValue(undefined);
+	const removeMock = vi.fn().mockResolvedValue(undefined);
+	const fakeInstalled = [join("/fake", "Code", "globalStorage", "saoudrizwan.claude-dev")];
+	const fakeAll = [
+		join("/fake", "Code", "globalStorage", "saoudrizwan.claude-dev"),
+		join("/fake", "Cursor", "globalStorage", "saoudrizwan.claude-dev"),
+	];
+	beforeEach(() => {
+		vi.resetModules();
+		vi.doMock("./JsonMcpWriter.js", () => ({ upsertJsonMcpServer: upsertMock, removeJsonMcpServer: removeMock }));
+		// getInstalledClineStorageDirs / getClineStorageDirs read real disk; mock them
+		// so the test is deterministic regardless of what's installed on the machine.
+		vi.doMock("../../core/ClineDetector.js", () => ({
+			getInstalledClineStorageDirs: async () => fakeInstalled,
+			getClineStorageDirs: () => fakeAll,
+		}));
+		upsertMock.mockClear();
+		removeMock.mockClear();
+	});
+	afterEach(() => {
+		vi.doUnmock("./JsonMcpWriter.js");
+		vi.doUnmock("../../core/ClineDetector.js");
+		vi.resetModules();
+	});
+
+	it("register() writes settings/cline_mcp_settings.json for each INSTALLED flavor, default key, {command,args}", async () => {
+		const { buildRegistrars: build } = await import("./HostRegistrars.js");
+		const [r] = build({ ...NONE, cline: true });
+		await r.register("/some/wt");
+		expect(upsertMock).toHaveBeenCalledTimes(fakeInstalled.length);
+		const [path, entry, key] = upsertMock.mock.calls[0];
+		expect(path).toBe(join(fakeInstalled[0], "settings", "cline_mcp_settings.json"));
+		expect(key).toBeUndefined(); // default mcpServers
+		expect(entry.args).toContain("mcp");
+	});
+
+	it("remove() clears settings/cline_mcp_settings.json for EVERY flavor (not just installed)", async () => {
+		const { buildRegistrars: build } = await import("./HostRegistrars.js");
+		const [r] = build({ ...NONE, cline: true });
+		await r.remove("/some/wt");
+		expect(removeMock).toHaveBeenCalledTimes(fakeAll.length);
+		expect(removeMock.mock.calls.map((c) => c[0])).toEqual(
+			fakeAll.map((d) => join(d, "settings", "cline_mcp_settings.json")),
+		);
+	});
+});
+
 describe("scope filtering — global vs repo", () => {
 	const upsertMock = vi.fn().mockResolvedValue(undefined);
 	const removeMock = vi.fn().mockResolvedValue(undefined);
@@ -363,6 +495,14 @@ describe("scope filtering — global vs repo", () => {
 		const paths = upsertMock.mock.calls.map((c) => c[0] as string);
 		expect(paths).toContain(join(homedir(), ".copilot", "mcp-config.json"));
 		expect(paths.every((p) => !p.includes(".cursor"))).toBe(true);
+	});
+
+	it("registerGlobalMcpHosts writes the new global hosts (devin, antigravity)", async () => {
+		const { registerGlobalMcpHosts: regGlobal } = await import("./HostRegistrars.js");
+		await regGlobal({ ...NONE, devin: true, antigravity: true });
+		const paths = upsertMock.mock.calls.map((c) => c[0] as string);
+		expect(paths).toContain(join(homedir(), ".config", "devin", "config.json"));
+		expect(paths).toContain(join(homedir(), ".gemini", "config", "mcp_config.json"));
 	});
 
 	it("registerGlobalMcpHosts is a no-op when no global hosts detected", async () => {

--- a/cli/src/install/mcp/HostRegistrars.test.ts
+++ b/cli/src/install/mcp/HostRegistrars.test.ts
@@ -443,6 +443,7 @@ describe("cline registrar — per-flavor settings files (mocked writer + detecto
 		vi.doMock("../../core/ClineDetector.js", () => ({
 			getInstalledClineStorageDirs: async () => fakeInstalled,
 			getClineStorageDirs: () => fakeAll,
+			clineMcpSettingsPath: (dir: string) => join(dir, "settings", "cline_mcp_settings.json"),
 		}));
 		upsertMock.mockClear();
 		removeMock.mockClear();

--- a/cli/src/install/mcp/HostRegistrars.ts
+++ b/cli/src/install/mcp/HostRegistrars.ts
@@ -12,6 +12,7 @@
 
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { getClineStorageDirs, getInstalledClineStorageDirs } from "../../core/ClineDetector.js";
 import { getGlobalConfigDir } from "../../core/SessionTracker.js";
 import { getVscodeUserDataDir } from "../../core/VscodeWorkspaceLocator.js";
 import { createLogger } from "../../Logger.js";
@@ -35,6 +36,9 @@ export interface DetectedHosts {
 	opencode: boolean;
 	copilot: boolean;
 	copilotChat: boolean;
+	cline: boolean;
+	devin: boolean;
+	antigravity: boolean;
 }
 
 export interface McpHostRegistrar {
@@ -183,6 +187,76 @@ const copilotChatRegistrar: McpHostRegistrar = {
 };
 
 /**
+ * Cline (VS Code extension `saoudrizwan.claude-dev`): global, per-flavor
+ * `<vscodeUserDataDir(flavor)>/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`.
+ * Format live-verified on a real install: top-level key `mcpServers`, entry
+ * `{ command, args }` (the settings file already ships as `{"mcpServers": {}}`).
+ * The Cline CLI (`~/.cline`) has NO MCP config file, so only the VS Code
+ * extension is an MCP host. globalStorage is machine-wide (shared by every
+ * workspace), so this is global-scoped. A user may run Cline in more than one
+ * flavor (Code, Cursor, …), each with its own settings file — so register()
+ * writes every INSTALLED flavor's file, and remove() clears every flavor's.
+ * Global config — never committed, so gitExcludePaths returns [].
+ */
+const clineRegistrar: McpHostRegistrar = {
+	host: "cline",
+	scope: "global",
+	register: async () => {
+		for (const dir of await getInstalledClineStorageDirs()) {
+			await upsertJsonMcpServer(join(dir, "settings", "cline_mcp_settings.json"), { ...jolliEntry() });
+		}
+	},
+	remove: async () => {
+		for (const dir of getClineStorageDirs()) {
+			await removeJsonMcpServer(join(dir, "settings", "cline_mcp_settings.json"));
+		}
+	},
+	gitExcludePaths: () => [],
+};
+
+/**
+ * Devin CLI: global `~/.config/devin/config.json` (the `user` scope of
+ * `devin mcp add`; `local`/`project` scopes are per-repo `.devin/config*.json`).
+ * Format live-verified via `devin mcp add <name> --scope user -- <cmd> <args>`,
+ * which writes:
+ *   { "mcpServers": { "<name>": { "command", "args": [...], "transport": "stdio" } } }
+ * Top-level key `mcpServers`; the stdio entry carries a `transport: "stdio"`
+ * field (Devin's own envelope — distinct from Antigravity's `type` and OpenCode's
+ * `type`). Global config — never committed, so gitExcludePaths returns [].
+ */
+const devinRegistrar: McpHostRegistrar = {
+	host: "devin",
+	scope: "global",
+	register: () =>
+		upsertJsonMcpServer(join(homedir(), ".config", "devin", "config.json"), {
+			...jolliEntry(),
+			transport: "stdio",
+		}),
+	remove: () => removeJsonMcpServer(join(homedir(), ".config", "devin", "config.json")),
+	gitExcludePaths: () => [],
+};
+
+/**
+ * Antigravity (Google's Gemini-powered agentic IDE/CLI): global single file
+ * `~/.gemini/config/mcp_config.json`.
+ * Format verified from Antigravity's own bundled app source (jetskiAgent /
+ * workbench.desktop.main.js: reads `{mcpServers:{}}`, upserts `mcpServers[name]`)
+ * AND its shipped docs (`agy-customizations/docs/mcp_servers.md`: "Global
+ * Configuration: ~/.gemini/config/mcp_config.json", key `mcpServers`, stdio entry
+ * `{ command, args, env? }`). Stdio needs NO `type` field — Antigravity infers
+ * it from the presence of `command`. This is the canonical file; the per-variant
+ * `~/.gemini/<variant>/mcp_config.json` are symlinks/scaffolds pointing here.
+ * Global config — never committed, so gitExcludePaths returns [].
+ */
+const antigravityRegistrar: McpHostRegistrar = {
+	host: "antigravity",
+	scope: "global",
+	register: () => upsertJsonMcpServer(join(homedir(), ".gemini", "config", "mcp_config.json"), { ...jolliEntry() }),
+	remove: () => removeJsonMcpServer(join(homedir(), ".gemini", "config", "mcp_config.json")),
+	gitExcludePaths: () => [],
+};
+
+/**
  * Return the ordered list of registrars for the detected set of hosts.
  */
 export function buildRegistrars(detected: DetectedHosts): McpHostRegistrar[] {
@@ -194,6 +268,9 @@ export function buildRegistrars(detected: DetectedHosts): McpHostRegistrar[] {
 	if (detected.opencode) out.push(opencodeRegistrar);
 	if (detected.copilot) out.push(copilotCliRegistrar);
 	if (detected.copilotChat) out.push(copilotChatRegistrar);
+	if (detected.cline) out.push(clineRegistrar);
+	if (detected.devin) out.push(devinRegistrar);
+	if (detected.antigravity) out.push(antigravityRegistrar);
 	return out;
 }
 
@@ -207,6 +284,9 @@ const ALL_DETECTED: DetectedHosts = {
 	opencode: true,
 	copilot: true,
 	copilotChat: true,
+	cline: true,
+	devin: true,
+	antigravity: true,
 };
 
 /** Run `fn` over `regs` with per-host error isolation — one failure is logged
@@ -238,9 +318,9 @@ export async function registerRepoMcpHosts(wt: string, detected: DetectedHosts):
 
 /**
  * Register the MCP server in the detected **global** hosts (Codex, Gemini,
- * OpenCode, Copilot, Copilot Chat). Their config files are machine-wide and
- * shared by every repo, so this is called ONCE per install — not per worktree —
- * to avoid rewriting the same file N times.
+ * OpenCode, Copilot, Copilot Chat, Cline, Devin, Antigravity). Their config
+ * files are machine-wide and shared by every repo, so this is called ONCE per
+ * install — not per worktree — to avoid rewriting the same file N times.
  */
 export async function registerGlobalMcpHosts(detected: DetectedHosts): Promise<void> {
 	const regs = buildRegistrars(detected).filter((r) => r.scope === "global");

--- a/cli/src/install/mcp/HostRegistrars.ts
+++ b/cli/src/install/mcp/HostRegistrars.ts
@@ -12,7 +12,7 @@
 
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { getClineStorageDirs, getInstalledClineStorageDirs } from "../../core/ClineDetector.js";
+import { clineMcpSettingsPath, getClineStorageDirs, getInstalledClineStorageDirs } from "../../core/ClineDetector.js";
 import { getGlobalConfigDir } from "../../core/SessionTracker.js";
 import { getVscodeUserDataDir } from "../../core/VscodeWorkspaceLocator.js";
 import { createLogger } from "../../Logger.js";
@@ -192,10 +192,13 @@ const copilotChatRegistrar: McpHostRegistrar = {
  * Format live-verified on a real install: top-level key `mcpServers`, entry
  * `{ command, args }` (the settings file already ships as `{"mcpServers": {}}`).
  * The Cline CLI (`~/.cline`) has NO MCP config file, so only the VS Code
- * extension is an MCP host. globalStorage is machine-wide (shared by every
- * workspace), so this is global-scoped. A user may run Cline in more than one
- * flavor (Code, Cursor, …), each with its own settings file — so register()
- * writes every INSTALLED flavor's file, and remove() clears every flavor's.
+ * extension is an MCP host — which is why `detected.cline` is fed by
+ * `isClinePresent()` (extension only) and not by the installer's broader
+ * `clineDetectedOnce` (extension OR CLI). globalStorage is machine-wide (shared
+ * by every workspace), so this is global-scoped. A user may run Cline in more
+ * than one flavor (Code, Cursor, …), each with its own settings file — so
+ * register() writes every PRESENT flavor's file, and remove() clears every
+ * flavor's.
  * Global config — never committed, so gitExcludePaths returns [].
  */
 const clineRegistrar: McpHostRegistrar = {
@@ -203,12 +206,12 @@ const clineRegistrar: McpHostRegistrar = {
 	scope: "global",
 	register: async () => {
 		for (const dir of await getInstalledClineStorageDirs()) {
-			await upsertJsonMcpServer(join(dir, "settings", "cline_mcp_settings.json"), { ...jolliEntry() });
+			await upsertJsonMcpServer(clineMcpSettingsPath(dir), { ...jolliEntry() });
 		}
 	},
 	remove: async () => {
 		for (const dir of getClineStorageDirs()) {
-			await removeJsonMcpServer(join(dir, "settings", "cline_mcp_settings.json"));
+			await removeJsonMcpServer(clineMcpSettingsPath(dir));
 		}
 	},
 	gitExcludePaths: () => [],
@@ -223,6 +226,17 @@ const clineRegistrar: McpHostRegistrar = {
  * Top-level key `mcpServers`; the stdio entry carries a `transport: "stdio"`
  * field (Devin's own envelope — distinct from Antigravity's `type` and OpenCode's
  * `type`). Global config — never committed, so gitExcludePaths returns [].
+ *
+ * ⚠️ Path verified on macOS/Linux only. `~/.config` is hardcoded here, while this
+ * repo's own `getDevinCliDir()` (DevinSessionDiscoverer) resolves Devin's DATA dir
+ * to `%APPDATA%\devin\cli` on win32 — so Windows Devin IS supported elsewhere and
+ * `isDevinPresent()` can return true there. Whether its CONFIG dir also moves to
+ * `%APPDATA%` is unverified (data dir ≠ config dir, and plenty of cross-platform
+ * CLIs keep `~/.config` everywhere), so we don't guess: on Windows this either
+ * lands correctly or leaves one unread file. Confirm against a real Windows
+ * install before adding a branch — the failure mode of guessing wrong is the same
+ * unread file, plus a wrong path baked into the shared helper the OpenCode /
+ * Copilot registrars would then inherit.
  */
 const devinRegistrar: McpHostRegistrar = {
 	host: "devin",
@@ -246,6 +260,9 @@ const devinRegistrar: McpHostRegistrar = {
  * `{ command, args, env? }`). Stdio needs NO `type` field — Antigravity infers
  * it from the presence of `command`. This is the canonical file; the per-variant
  * `~/.gemini/<variant>/mcp_config.json` are symlinks/scaffolds pointing here.
+ * ⚠️ Derived from Antigravity's bundled source + shipped docs; not yet confirmed
+ * by a live smoke test (same confidence tier as copilotChat above — unlike Devin,
+ * verified with a revertible real write, and Cline, verified on a real install).
  * Global config — never committed, so gitExcludePaths returns [].
  */
 const antigravityRegistrar: McpHostRegistrar = {

--- a/docs/superpowers/plans/2026-06-21-mcp-registration-opencode-copilot.md
+++ b/docs/superpowers/plans/2026-06-21-mcp-registration-opencode-copilot.md
@@ -366,7 +366,9 @@ Expected: PASS.
 
 **Interfaces:**
 - Consumes: `isOpenCodeInstalled()` (`../core/OpenCodeSessionDiscoverer.js`, already imported ~line 32), `isCopilotInstalled()` (`../core/CopilotDetector.js`, imported ~line 25), `isCopilotChatInstalled()` (`../core/CopilotChatDetector.js`, imported ~line 22). All three imports already exist in this file.
-- Produces: `detected` now carries all seven hosts.
+- Produces: `detected` now carries all seven hosts. (Historical: seven was the
+  count as of this plan; later work added Cline, Devin, and Antigravity, so
+  `buildRegistrars` dispatches ten today.)
 
 - [ ] **Step 1: Add the detector calls** next to the existing once-before-loop block (after line 188):
 

--- a/specs/149-mcp-client-registration.md
+++ b/specs/149-mcp-client-registration.md
@@ -32,7 +32,7 @@ During hook install or removal, the product writes (or removes) its own well-kno
 
 ### Supported hosts and their registries
 
-Seven hosts are supported. Each carries a scope that determines where its config lives and when it is written:
+Ten hosts are supported. Each carries a scope that determines where its config lives and when it is written:
 
 | Host | Scope | Registry file | Top-level key | Entry shape |
 |---|---|---|---|---|
@@ -43,6 +43,11 @@ Seven hosts are supported. Each carries a scope that determines where its config
 | OpenCode | global | user-global OpenCode config | `mcp` | `{ type: "local", command: [command, …args], enabled: true }` (single combined command array) |
 | GitHub Copilot CLI | global | user-global Copilot config | `mcpServers` | `{ command, args }` |
 | VS Code Copilot Chat | global | a file under the VS Code user-data directory | `servers` | `{ type: "stdio", command, args }` |
+| Cline (VS Code extension) | global | `settings/cline_mcp_settings.json` under the extension's globalStorage, written once per VS Code flavor that hosts the extension | `mcpServers` | `{ command, args }` |
+| Devin CLI | global | user-global Devin config (`~/.config/devin/config.json`, the `user` scope of `devin mcp add`) | `mcpServers` | `{ command, args, transport: "stdio" }` |
+| Antigravity | global | user-global Antigravity MCP config (`~/.gemini/config/mcp_config.json`) | `mcpServers` | `{ command, args }` (stdio is inferred from the presence of `command`; no transport/type field) |
+
+The Cline CLI (`~/.cline`) is deliberately **not** an MCP host — it ships no MCP config file; only the Cline VS Code extension does. Cline's registry lives per VS Code flavor (Code, Cursor, VSCodium, …), and the extension may be installed under more than one, so registration writes every flavor's settings file that hosts the extension (and removal clears every flavor's).
 
 The well-known server name / key is `jollimemory` in every registry. Other entries under the host's server map, and all other top-level properties of the document, are opaque to this topic and must round-trip untouched.
 
@@ -136,7 +141,7 @@ Transitions:
 
 ## Notable Behavior
 
-- **Registration is multi-host, split by scope.** Repo-scoped hosts (Claude, Cursor) are written per worktree; global-scoped hosts (Gemini, Codex, OpenCode, Copilot CLI, Copilot Chat) are written once per install. The split exists because a global config is shared by every repo on the machine. (Notable.)
+- **Registration is multi-host, split by scope.** Repo-scoped hosts (Claude, Cursor) are written per worktree; global-scoped hosts (Gemini, Codex, OpenCode, Copilot CLI, Copilot Chat, Cline, Devin, Antigravity) are written once per install. The split exists because a global config is shared by every repo on the machine. (Notable.)
 - **Global-scoped hosts are never removed on a single-repo uninstall.** Their `jollimemory` entry is machine-wide, so removing it would break MCP for every other repo still using Jolli. A stale global entry is harmless (idempotently refreshed on the next install) and far preferable to cross-repo breakage. Only repo-scoped hosts are cleaned up. This same removal path is the one invoked by the machine-wide uninstall command's current-repo item — see the CLI machine-wide uninstall spec — so a full machine-wide uninstall still never removes a global host's entry. (Surprising; intentional.)
 - **Each host is gated on its own detection** (Claude's detection mirrors the Claude-enabled flag), so registration is skipped for hosts the user has not installed. Repo-scoped registration runs before the Claude-enabled hook gate, so a Cursor user with Claude disabled still gets MCP registered. (Notable.)
 - **Malformed registry is never overwritten.** A parse failure on an existing file is treated fundamentally differently from a missing file: writing a fresh empty document would silently drop every other MCP server the user configured by hand, so the behavior is to log and leave the file untouched, deferring recovery to the user fixing it. (Notable.)
@@ -144,7 +149,7 @@ Transitions:
 - **Re-registration replaces, never duplicates.** Because the entry lives under a single fixed key, repeated install runs always produce a single entry whose contents are refreshed in place. (Notable.)
 - **The repo-scoped registry files must not be committed.** They contain machine-local absolute paths, so the install pipeline contributes their filenames to the worktree's git-exclude list. Uninstall leaves those exclude entries behind, intentionally — they are inert when the file is absent. (Notable.)
 - **Per-host error isolation is non-fatal at the orchestration boundary.** A read-only or unwritable registry for one host yields a logged warning but never blocks the other hosts or the surrounding install/uninstall — in particular it cannot prevent removal of the shared repository-level git hooks. (Notable.)
-- **OpenCode and Codex have distinct entry shapes.** OpenCode requires a `type: "local"` wrapper and a single combined command array (split command/args is rejected by its loader); Codex uses an underscore table key in TOML; Copilot Chat adds a `type: "stdio"` field. The well-known `jollimemory` key and the underlying command/args are the same; only the per-host envelope differs. (Notable.)
+- **Hosts differ in their per-entry envelope.** OpenCode requires a `type: "local"` wrapper and a single combined command array (split command/args is rejected by its loader); Codex uses an underscore table key in TOML; Copilot Chat adds a `type: "stdio"` field; Devin adds a `transport: "stdio"` field; Antigravity needs neither (it infers stdio from the presence of `command`). The well-known `jollimemory` key and the underlying command/args are the same across all hosts; only the per-host envelope differs, so a shape correct for one host is a silent no-op if written to another. (Notable.)
 - **Windows fallback writes a knowingly-broken descriptor.** When no active distribution is yet registered on a Windows host, the POSIX-shaped descriptor written cannot spawn; it exists purely to defer correctness to the next install/enable run. (Surprising; intentional.)
 - **Writes are full-file overwrites, not appends or patches.** No backup file and no temp-file-then-rename atomicity is used. A crash mid-write can leave a truncated registry file, which the next install treats as malformed and leaves alone — the user must repair it by hand. (Notable.)
 - **The JVM IDE plugin is a consumer of this mechanism, not a reimplementation of it.** The plugin runs its own native git hooks and generates memory without Node, so it installs **no** Node hooks — but MCP and the skills are inherently Node programs, so the plugin drives the bundled command-line tool's "enable integrations-only" as a subprocess (dispatch scripts + dist-paths + MCP registration + skills, **no** hooks) rather than writing any registry file itself. It runs that subprocess in the project directory, so the repo-scoped hosts land in the project root exactly as for a CLI-driven install; the global-scoped hosts land in their machine-wide files. Consequently, any future change to registration behavior applies to the plugin with **no plugin-side change**. This corrects the earlier assumption that the JVM plugin registers no MCP. (Notable.)


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (2)

1. Add Cline, Devin, and Antigravity MCP host registration (`95508df`)
2. Decouple MCP registration from the node:sqlite readability gate (`c2819f5`)

## Quick recap (2)

### Commit 1 of 2: Add Cline, Devin, and Antigravity MCP host registration (`95508df`)

The developer added Jolli MCP registration for Cline, Devin, and Antigravity. Users who run Jolli enable on a machine with those agents installed will now get Jolli's live tools registered in each product's native settings, including the per-flavor Cline extension settings, Devin's user config, and Antigravity's Gemini-family MCP config.

This commit also tightened the integration contract around those agents. Cline registration now targets only the VS Code flavors that actually host the extension, Devin uses the entry shape its own CLI saves on disk, and Antigravity follows the path and schema published by its shipped application files. The install docs and registration spec now list all ten supported MCP hosts, keeping future work aligned with the verified behavior.

### Commit 2 of 2: Decouple MCP registration from the node:sqlite readability gate (`c2819f5`)

The developer fixed Jolli's MCP registration flow for editor and extension runtimes that still ship older Node versions. Enabling Jolli from VS Code now writes integration settings for installed tools such as Cursor, Copilot, OpenCode, Devin, and Antigravity.

Session discovery and auto-enable behavior remained unchanged on runtimes that still cannot read those tools' local databases. The commit also added regression coverage for the exact case where a tool is present on disk but unreadable from the current runtime, which makes future MCP registration work much safer to extend.

## Topics (2)
<details>
<summary><strong>01 · [95508df] Registered Jolli tools in Cline, Devin, and Antigravity</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The user needed Jolli's live tools to appear inside three newer AI agents that already had transcript support. This work needed real verification of each product's settings location and format, because a guessed integration would silently do nothing.

**💡 Decisions Behind the Code**

- **Verified each host from real evidence**: The implementation was driven by live app behavior and shipped source or documentation, not by naming conventions or family resemblance. Devin was confirmed by writing a reversible probe entry and observing the exact saved format, and Antigravity was confirmed from its bundled app source and shipped MCP guide after its own assistant gave conflicting advice.
- **Treated the three agents as global integrations**: These registrations were added as machine-wide settings written once during install, matching how their products store configuration. That keeps behavior consistent across repositories and avoids creating repo-local files for hosts that do not use them.
- **Separated Cline extension support from the Cline CLI**: The work registered only the VS Code extension, since that is the surface with a real MCP settings file. The CLI was intentionally excluded after direct inspection showed no MCP config location to write.

**✅ What Was Implemented**

- Added three new global MCP host registrations in `cli/src/install/mcp/HostRegistrars.ts` for Cline, Devin, and Antigravity. The new registrars write each host's verified config file, use the correct top-level server map, and preserve the host-specific entry envelope, including Devin's extra `transport: "stdio"` field.
- Wired the new detections into the install flow in `cli/src/install/Installer.ts` and added `getInstalledClineStorageDirs()` in `cli/src/core/ClineDetector.ts`. This lets the installer register Devin and Antigravity once per machine-wide install pass, and lets Cline write only the VS Code flavors that actually host the extension.
- Extended coverage and source-of-truth docs for the expanded host list. `cli/src/install/mcp/HostRegistrars.test.ts` and `cli/src/core/ClineDetector.test.ts` now cover the new paths and shapes, while `specs/149-mcp-client-registration.md` and `AGENTS.md` were updated from seven to ten supported MCP hosts.

**📁 FILES**
- `cli/src/install/mcp/HostRegistrars.ts`
- `cli/src/install/Installer.ts`
- `cli/src/core/ClineDetector.ts`
- `specs/149-mcp-client-registration.md`
- `AGENTS.md`

</blockquote>
</details>
<details>
<summary><strong>02 · [c2819f5] Fix MCP registration on Node 18 and VS Code hosts</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Enabling Jolli from VS Code was skipping MCP registration for some installed tools, even though their config files could have been written successfully. The registration path was tied to a runtime-readability check that intentionally fails on older Node hosts, which blocked one of Jolli's main enable flows.

**💡 Decisions Behind the Code**

- **Separate presence from readability**: The fix treated "is the tool on disk?" and "can this runtime read its local database?" as different questions. That kept MCP registration aligned with what it actually needs to do, while preserving the stricter gate for transcript-backed features.
- **Keep discovery behavior unchanged**: The implementation did not relax the existing session-discovery and auto-enable rules on older runtimes. This avoided reintroducing misleading "detected but no sessions" behavior on hosts that still cannot read the underlying databases.
- **Apply the fix to the whole affected host family**: The change was broadened from the newly added tools to every host using the same SQLite-gated pattern. That removed a systemic inconsistency and prevented the same failure mode from surviving under older integrations.

**✅ What Was Implemented**

- Split host detection into two concepts across the SQLite-gated integrations: "present on disk" versus "installed and readable on this runtime." `CursorDetector.ts`, `OpenCodeSessionDiscoverer.ts`, `CopilotDetector.ts`, `DevinSessionDiscoverer.ts`, and `AntigravityDetector.ts` now expose `is*Present` helpers, while `is*Installed` keeps the existing `hasNodeSqliteSupport()` gate for transcript/session reading.
- Rewired `cli/src/install/Installer.ts` so MCP registration uses the new presence checks for Cursor, OpenCode, Copilot, Devin, and Antigravity. The existing auto-enable and session-discovery logic still uses the SQLite-gated installed checks, preserving current behavior for status trees and unreadable runtimes.
- Added regression coverage for the new split in the detector tests and in `Installer.test.ts`. The new installer test explicitly covers the Node-18-style case where a host is on disk but unreadable, and verifies that MCP config is still written without auto-enabling session discovery.

**📁 FILES**
- `cli/src/install/Installer.ts`
- `cli/src/core/CursorDetector.ts`
- `cli/src/core/OpenCodeSessionDiscoverer.ts`
- `cli/src/core/CopilotDetector.ts`
- `cli/src/core/DevinSessionDiscoverer.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 28, 2026 at 3:32 PM · via Local agent*
<!-- jollimemory-summary-end -->