### PR TITLE
Add clickable JM reference IDs to memory titles and panels

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -79,6 +79,7 @@ disk **before** they are sent.
 | `memory_item_opened` | An item inside a memory was opened. Props: item_type (discriminator: conversation/file/plan/note/reference/shipped); render (conversation only: live/stored — whether the source transcript was reopened or the stored copy was shown); source (conversation only: the transcript source, e.g. claude/codex); status (file only: the git status code, e.g. A/M/D). |
 | `session_resumed` | A conversation session was resumed in a terminal. Props: source (discriminator). |
 | `recall_prompt_copied` | A recall prompt was copied to the clipboard. Props: none. |
+| `memory_ref_id_copied` | A memory reference id (JM-<docId>) was copied to the clipboard. Props: surface_area (discriminator: list/detail — which UI the chip was clicked in). |
 | `memory_pinned` | An item was pinned. Props: kind (discriminator). |
 | `memory_unpinned` | An item was unpinned. Props: kind (discriminator). |
 | `repo_switched` | User switched the active repo in the tool window's breadcrumb. Props: is_foreign (bool). |

--- a/cli/src/core/MemoryRefId.test.ts
+++ b/cli/src/core/MemoryRefId.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { formatMemoryRefId, formatMemoryRefIdWithHashFallback, MEMORY_REF_PREFIX } from "./MemoryRefId.js";
+
+describe("formatMemoryRefId", () => {
+	it("formats a positive integer doc id as JM-<n>", () => {
+		expect(formatMemoryRefId(142)).toBe("JM-142");
+		expect(formatMemoryRefId(1)).toBe("JM-1");
+	});
+
+	it("uses the shared MEMORY_REF_PREFIX", () => {
+		expect(formatMemoryRefId(9)).toBe(`${MEMORY_REF_PREFIX}9`);
+	});
+
+	it("returns undefined when the doc id is missing", () => {
+		expect(formatMemoryRefId(undefined)).toBeUndefined();
+	});
+
+	it("returns undefined for non-positive or non-integer doc ids", () => {
+		expect(formatMemoryRefId(0)).toBeUndefined();
+		expect(formatMemoryRefId(-5)).toBeUndefined();
+		expect(formatMemoryRefId(1.5)).toBeUndefined();
+		expect(formatMemoryRefId(Number.NaN)).toBeUndefined();
+		expect(formatMemoryRefId(Number.POSITIVE_INFINITY)).toBeUndefined();
+	});
+});
+
+describe("formatMemoryRefIdWithHashFallback", () => {
+	const hash = "f159924cabc0000000000000000000000000dead";
+
+	it("uses the doc id when present", () => {
+		expect(formatMemoryRefIdWithHashFallback(142, hash)).toBe("JM-142");
+	});
+
+	it("falls back to JM-<first 8 hash chars> when there is no doc id", () => {
+		expect(formatMemoryRefIdWithHashFallback(undefined, hash)).toBe("JM-f159924c");
+	});
+
+	it("uses the hash fallback for non-positive / non-integer doc ids too", () => {
+		expect(formatMemoryRefIdWithHashFallback(0, hash)).toBe("JM-f159924c");
+		expect(formatMemoryRefIdWithHashFallback(1.5, hash)).toBe("JM-f159924c");
+	});
+
+	it("uses the whole hash when it is shorter than 8 chars", () => {
+		expect(formatMemoryRefIdWithHashFallback(undefined, "abc123")).toBe("JM-abc123");
+	});
+});

--- a/cli/src/core/MemoryRefId.ts
+++ b/cli/src/core/MemoryRefId.ts
@@ -1,0 +1,39 @@
+/**
+ * MemoryRefId — formats a memory's human-facing reference id (`JM-<n>`) from the
+ * Jolli Space doc id the web backend mints on a successful push
+ * (`CommitSummary.jolliDocId`). Deliberately a dependency-free leaf module: it is
+ * consumed at display boundaries in both the CLI-bundled VS Code webview
+ * (SummaryHtmlBuilder, HistoryTreeProvider) so it must not drag any heavier graph
+ * along. The `JM-` prefix is defined here once for the whole TS side; the IntelliJ
+ * (Kotlin) port mirrors it in `SummaryUtils.kt`.
+ */
+
+/** Display prefix for a memory reference id. Single source of truth on the TS side. */
+export const MEMORY_REF_PREFIX = "JM-";
+
+/**
+ * Formats the reference id for a memory, or `undefined` when it has none.
+ *
+ * A memory only has a reference id once it has been pushed to a Jolli Space and
+ * the backend has returned a positive integer doc id (persisted as
+ * `jolliDocId`). Anything else — missing, non-integer, or non-positive — yields
+ * `undefined` so callers render no prefix for unsynced memories.
+ */
+export function formatMemoryRefId(jolliDocId?: number): string | undefined {
+	if (typeof jolliDocId !== "number" || !Number.isInteger(jolliDocId) || jolliDocId <= 0) {
+		return undefined;
+	}
+	return `${MEMORY_REF_PREFIX}${jolliDocId}`;
+}
+
+/**
+ * Like {@link formatMemoryRefId} but always returns a value: when the memory has
+ * no backend doc id yet (not synced to a Space), it falls back to the first 8
+ * chars of the commit hash — e.g. `JM-f159924c`. Used where the surface wants to
+ * always show a reference (the detail panel title), rather than hide it for
+ * unsynced memories. The two forms are distinguishable (numeric vs hex), and the
+ * value becomes the stable `JM-<docId>` once the memory syncs.
+ */
+export function formatMemoryRefIdWithHashFallback(jolliDocId: number | undefined, commitHash: string): string {
+	return formatMemoryRefId(jolliDocId) ?? `${MEMORY_REF_PREFIX}${commitHash.slice(0, 8)}`;
+}

--- a/cli/src/core/TelemetryEvents.ts
+++ b/cli/src/core/TelemetryEvents.ts
@@ -63,6 +63,8 @@ export const TELEMETRY_EVENTS = {
 		"An item inside a memory was opened. Props: item_type (discriminator: conversation/file/plan/note/reference/shipped); render (conversation only: live/stored — whether the source transcript was reopened or the stored copy was shown); source (conversation only: the transcript source, e.g. claude/codex); status (file only: the git status code, e.g. A/M/D).",
 	session_resumed: "A conversation session was resumed in a terminal. Props: source (discriminator).",
 	recall_prompt_copied: "A recall prompt was copied to the clipboard. Props: none.",
+	memory_ref_id_copied:
+		"A memory reference id (JM-<docId>) was copied to the clipboard. Props: surface_area (discriminator: list/detail — which UI the chip was clicked in).",
 	memory_pinned: "An item was pinned. Props: kind (discriminator).",
 	memory_unpinned: "An item was unpinned. Props: kind (discriminator).",
 	repo_switched: "User switched the active repo in the tool window's breadcrumb. Props: is_foreign (bool).",

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt
@@ -45,21 +45,10 @@ class SummaryReader(private val worktreeDir: String, private val git: GitOps) {
     fun listSummaries(): List<CommitSummaryBrief> {
         val files = git.listBranchFiles(ORPHAN_BRANCH, "summaries/")
         return files.mapNotNull { path ->
-            try {
-                val json = git.readBranchFile(ORPHAN_BRANCH, path) ?: return@mapNotNull null
-                val obj = JsonParser.parseString(json).asJsonObject
-                CommitSummaryBrief(
-                    hash = obj.get("commitHash")?.asString ?: "",
-                    shortHash = (obj.get("commitHash")?.asString ?: "").take(8),
-                    message = obj.get("commitMessage")?.asString ?: "",
-                    author = obj.get("commitAuthor")?.asString ?: "",
-                    date = obj.get("commitDate")?.asString ?: "",
-                    topicCount = obj.getAsJsonArray("topics")?.size() ?: 0,
-                    hasSummary = true,
-                )
-            } catch (e: Exception) {
-                log.debug("Failed to parse summary %s: %s", path, e.message)
-                null
+            val json = git.readBranchFile(ORPHAN_BRANCH, path) ?: return@mapNotNull null
+            parseSummaryBrief(json).also {
+                // Unreadable file vs unparseable content: only the latter is worth a line.
+                if (it == null) log.debug("Failed to parse summary %s", path)
             }
         }.sortedByDescending { it.date }
     }
@@ -131,21 +120,54 @@ class SummaryReader(private val worktreeDir: String, private val git: GitOps) {
     companion object {
         const val ORPHAN_BRANCH = JmLogger.ORPHAN_BRANCH
 
+        /**
+         * Parses one stored `summaries/<hash>.json` body into a list row. Pure and
+         * tolerant — returns null for null/blank/malformed input rather than throwing,
+         * so one bad file never breaks the list.
+         *
+         * Every optional member goes through [notNull], which is load-bearing rather
+         * than defensive: Gson hands back JsonNull — a non-null JsonElement — for an
+         * explicit `"field": null`, so `obj.get(f)?.asInt` does NOT short-circuit and
+         * the `asInt` throws. Caught here, that would drop the WHOLE summary, turning
+         * one stray null field into a silently missing memory in the UI.
+         */
+        fun parseSummaryBrief(json: String?): CommitSummaryBrief? {
+            if (json.isNullOrBlank()) return null
+            return try {
+                val obj = JsonParser.parseString(json).asJsonObject
+                val commitHash = obj.notNull("commitHash")?.asString ?: ""
+                CommitSummaryBrief(
+                    hash = commitHash,
+                    shortHash = commitHash.take(8),
+                    message = obj.notNull("commitMessage")?.asString ?: "",
+                    author = obj.notNull("commitAuthor")?.asString ?: "",
+                    date = obj.notNull("commitDate")?.asString ?: "",
+                    topicCount = obj.arrayOrNull("topics")?.size() ?: 0,
+                    hasSummary = true,
+                    // Keep parity with getBranchCommits so a future UI caller of
+                    // listSummaries() still gets the clickable JM- chip.
+                    jolliDocId = obj.notNull("jolliDocId")?.asInt,
+                )
+            } catch (_: Exception) {
+                null
+            }
+        }
+
         /** Renders the matching session's entries from a stored transcript JSON as markdown. */
         private fun sessionToMarkdown(json: String?, sessionId: String): String? {
             if (json.isNullOrBlank()) return null
             return try {
                 val obj = JsonParser.parseString(json).asJsonObject
-                val sessions = obj.getAsJsonArray("sessions") ?: return null
+                val sessions = obj.arrayOrNull("sessions") ?: return null
                 val session = sessions.map { it.asJsonObject }.firstOrNull {
-                    (it.get("sessionId")?.takeIf { e -> !e.isJsonNull }?.asString ?: "") == sessionId
+                    (it.notNull("sessionId")?.asString ?: "") == sessionId
                 } ?: sessions.firstOrNull()?.asJsonObject ?: return null
-                val entries = session.getAsJsonArray("entries") ?: return null
+                val entries = session.arrayOrNull("entries") ?: return null
                 val sb = StringBuilder()
                 for (el in entries) {
                     val e = el.asJsonObject
-                    val role = e.get("role")?.takeIf { !it.isJsonNull }?.asString ?: "?"
-                    val content = e.get("content")?.takeIf { !it.isJsonNull }?.asString ?: ""
+                    val role = e.notNull("role")?.asString ?: "?"
+                    val content = e.notNull("content")?.asString ?: ""
                     val who = when (role.lowercase()) {
                         "human", "user" -> "User"
                         "assistant" -> "Assistant"
@@ -173,18 +195,18 @@ class SummaryReader(private val worktreeDir: String, private val git: GitOps) {
             if (json.isNullOrBlank()) return emptyList()
             return try {
                 val obj = JsonParser.parseString(json).asJsonObject
-                val sessions = obj.getAsJsonArray("sessions") ?: return emptyList()
+                val sessions = obj.arrayOrNull("sessions") ?: return emptyList()
                 sessions.mapNotNull { el ->
                     val session = el.asJsonObject
-                    val source = session.get("source")?.takeIf { !it.isJsonNull }?.asString ?: "ai"
-                    val entries = session.getAsJsonArray("entries")
+                    val source = session.notNull("source")?.asString ?: "ai"
+                    val entries = session.arrayOrNull("entries")
                     val messageCount = entries?.size() ?: 0
                     ConversationBrief(
                         source = source,
                         title = deriveTitle(entries, source),
                         messageCount = messageCount,
-                        sessionId = session.get("sessionId")?.takeIf { !it.isJsonNull }?.asString ?: "",
-                        transcriptPath = session.get("transcriptPath")?.takeIf { !it.isJsonNull }?.asString,
+                        sessionId = session.notNull("sessionId")?.asString ?: "",
+                        transcriptPath = session.notNull("transcriptPath")?.asString,
                     )
                 }
             } catch (_: Exception) {
@@ -193,16 +215,47 @@ class SummaryReader(private val worktreeDir: String, private val git: GitOps) {
         }
 
         private fun deriveTitle(entries: com.google.gson.JsonArray?, source: String): String {
-            val firstHuman = entries?.firstOrNull { el ->
-                val role = el.asJsonObject.get("role")?.asString
-                role == "human" || role == "user"
-            }?.asJsonObject?.get("content")?.asString
-            val firstLine = firstHuman?.lineSequence()?.firstOrNull { it.isNotBlank() }?.trim()
+            // Fall through human turns whose role or content is JSON null / blank — a single
+            // null-content turn must not shadow the first turn that actually carries text.
+            val firstLine = entries
+                ?.asSequence()
+                ?.map { it.asJsonObject }
+                ?.filter {
+                    val role = it.notNull("role")?.asString
+                    role == "human" || role == "user"
+                }
+                ?.mapNotNull { it.notNull("content")?.asString }
+                ?.mapNotNull { content -> content.lineSequence().firstOrNull { it.isNotBlank() }?.trim() }
+                ?.firstOrNull { it.isNotEmpty() }
             if (firstLine.isNullOrEmpty()) return "${source.replaceFirstChar { it.uppercase() }} session"
             return if (firstLine.length > 60) firstLine.take(57) + "…" else firstLine
         }
     }
 }
+
+/**
+ * Reads a member and returns null for BOTH "absent" and "present but JSON null".
+ *
+ * `JsonObject.get()` returns [com.google.gson.JsonNull] — a non-null JsonElement — for an
+ * explicit `"field": null`, so `obj.get("f")?.asInt` does not short-circuit and the
+ * `asInt` throws `UnsupportedOperationException`. Every accessor in this file sits inside
+ * a catch-all that degrades to null / emptyList, so one stray JSON null would silently
+ * drop an entire summary or conversation list rather than one field. Funnel optional
+ * member reads through here.
+ */
+private fun com.google.gson.JsonObject.notNull(member: String): com.google.gson.JsonElement? =
+    get(member)?.takeIf { !it.isJsonNull }
+
+/**
+ * Array counterpart of [notNull] — null for absent, JSON null, AND wrong type.
+ *
+ * Gson's own `getAsJsonArray(member)` is a bare cast (`(JsonArray) members.get(member)`), so
+ * `"topics": null` throws ClassCastException rather than returning null. Caught by the
+ * surrounding degrade-to-null handler, that would drop the whole record — the same failure
+ * mode [notNull] exists to prevent, one type over.
+ */
+private fun com.google.gson.JsonObject.arrayOrNull(member: String): com.google.gson.JsonArray? =
+    notNull(member)?.takeIf { it.isJsonArray }?.asJsonArray
 
 /** Lightweight commit info for list display — matches VS Code BranchCommit. */
 data class CommitSummaryBrief(
@@ -236,6 +289,12 @@ data class CommitSummaryBrief(
     val conversationTurns: Int? = null,
     /** Count of linked context items (plans + notes + references). */
     val contextCount: Int = 0,
+    /**
+     * Backend memory doc id used to render the `JM-<id>` reference prefix in the
+     * Committed Memories panel. Null until the memory is synced to a Jolli Space;
+     * the panel then falls back to `JM-<short hash>` so a reference is always shown.
+     */
+    val jolliDocId: Int? = null,
 ) {
     val hasE2eGuide: Boolean get() = e2eScenarioCount > 0
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
@@ -54,6 +54,9 @@ object TelemetryEvents {
             "memory_item_opened" to "An item inside a memory was opened. Props: item_type (discriminator: conversation/file/plan/note/reference/shipped); render (conversation only: live/stored); source (conversation only: transcript source); status (file only: git status code).",
             "session_resumed" to "A conversation session was resumed in a terminal. Props: source (discriminator).",
             "recall_prompt_copied" to "A recall prompt was copied to the clipboard. Props: none.",
+            "memory_ref_id_copied" to
+                "A memory reference id (JM-<docId>) was copied to the clipboard. " +
+                "Props: surface_area (discriminator: list/detail — which UI the chip was clicked in).",
             "memory_pinned" to "An item was pinned. Props: kind (discriminator).",
             "memory_unpinned" to "An item was unpinned. Props: kind (discriminator).",
             "repo_switched" to "User switched the active repo in the tool window's breadcrumb. Props: is_foreign (bool).",

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt
@@ -1035,6 +1035,7 @@ class JolliMemoryService(private val project: Project) : Disposable {
             var e2eScenarioCount = 0
             var isSyncedToJolli = false
             var jolliDocUrl: String? = null
+            var jolliDocId: Int? = null
             var conversationTurns: Int? = null
             var contextCount = 0
             if (hash in summaryHashSet) {
@@ -1068,6 +1069,7 @@ class JolliMemoryService(private val project: Project) : Disposable {
                     e2eScenarioCount = summary.e2eTestGuide?.size ?: 0
                     isSyncedToJolli = summary.jolliDocId != null || summary.jolliDocUrl != null
                     jolliDocUrl = summary.jolliDocUrl
+                    jolliDocId = summary.jolliDocId
                     conversationTurns = summary.conversationTurns
                     contextCount = (summary.plans?.size ?: 0) +
                         (summary.notes?.size ?: 0) +
@@ -1102,6 +1104,7 @@ class JolliMemoryService(private val project: Project) : Disposable {
                 e2eScenarioCount = e2eScenarioCount,
                 isSyncedToJolli = isSyncedToJolli,
                 jolliDocUrl = jolliDocUrl,
+                jolliDocId = jolliDocId,
                 conversationTurns = conversationTurns,
                 contextCount = contextCount,
             )

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
@@ -12,6 +12,7 @@ import com.google.gson.Gson
 import ai.jolli.jollimemory.services.CommitFileInfo
 import ai.jolli.jollimemory.services.JolliMemoryService
 import ai.jolli.jollimemory.services.PrService
+import ai.jolli.jollimemory.toolwindow.views.SummaryUtils
 import com.intellij.diff.DiffContentFactory
 import com.intellij.diff.DiffManager
 import com.intellij.diff.requests.SimpleDiffRequest
@@ -773,6 +774,10 @@ class CommitsPanel(
         val displayMessage = commit.message.ifBlank { commit.shortHash }
         val pushedBadge = if (commit.isPushed) " \u2601" else ""
         val typeBadge = if (commit.commitType != null) " [${commit.commitType}]" else ""
+        // Memory rows carry a `JM-<docId>` reference prefix ONLY once the memory is synced
+        // to a Jolli Space (no short-hash fallback) \u2014 matching the VS Code sidebar/history
+        // tree, which sets memoryRefId = formatMemoryRefId(jolliDocId). Unsynced memories and
+        // code-only commits get no prefix. (The detail panel still shows the hash fallback.)
         val titleLabel = JTextArea("$displayMessage$pushedBadge$typeBadge").apply {
             // Wrapping title so long commit messages wrap and grow the row instead of
             // clipping. Styled like a label at the mockup's 12px (base − 1).
@@ -786,6 +791,39 @@ class CommitsPanel(
             font = JBUI.Fonts.label().let { it.deriveFont(it.size2D - 1f) }
             alignmentX = Component.LEFT_ALIGNMENT
             cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+        }
+
+        // Memory reference id (JM-<docId>) chip — synced-only, mirroring VS Code's `.mem-ref`:
+        // a muted monospace, clickable "JM-142:" prefix that copies the id (and does NOT open
+        // the row). Only memory rows synced to a Jolli Space carry a docId; unsynced and
+        // code-only commits get no chip. Placed at the top-left of the wrapping title so
+        // continuation lines hang-indent under the first title char, like VS Code's flex row.
+        val refId = if (commit.hasSummary) SummaryUtils.formatMemoryRefId(commit.jolliDocId) else null
+        val refChip: JLabel? = refId?.let { id ->
+            JLabel("$id:").apply {
+                font = java.awt.Font(java.awt.Font.MONOSPACED, java.awt.Font.PLAIN, (JBUI.Fonts.label().size2D - 1f).toInt())
+                val dim = UIManager.getColor("Component.infoForeground") ?: Color.GRAY
+                foreground = dim
+                verticalAlignment = SwingConstants.TOP
+                toolTipText = "Memory ID — click to copy"
+                cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+                border = JBUI.Borders.emptyRight(4)
+                addMouseListener(object : MouseAdapter() {
+                    override fun mouseClicked(e: MouseEvent) {
+                        // The chip is never registered with `rowClickListener` (see below), so a
+                        // click here can't open the row anyway — just copy the id.
+                        if (SwingUtilities.isLeftMouseButton(e)) {
+                            copyMemoryId(id, this@apply)
+                        }
+                    }
+                    override fun mouseEntered(e: MouseEvent) {
+                        foreground = UIManager.getColor("Component.foreground") ?: dim
+                    }
+                    override fun mouseExited(e: MouseEvent) {
+                        foreground = dim
+                    }
+                })
+            }
         }
 
         // Sub-line: "<relative time> \u00b7 <shortHash> \u00b7 <token spend>".
@@ -826,11 +864,25 @@ class CommitsPanel(
             }
         }
 
+        // Ref chip (when present) sits WEST, top-aligned, with the wrapping title in CENTER so
+        // continuation lines hang-indent under the first title char. Without a chip the title
+        // spans the full width directly.
+        val titleRow: JComponent = if (refChip != null) {
+            JPanel(BorderLayout(0, 0)).apply {
+                isOpaque = false
+                alignmentX = Component.LEFT_ALIGNMENT
+                add(refChip, BorderLayout.WEST)
+                add(titleLabel, BorderLayout.CENTER)
+            }
+        } else {
+            titleLabel
+        }
+
         val centerPanel = JPanel().apply {
             layout = BoxLayout(this, BoxLayout.Y_AXIS)
             isOpaque = false
             alignmentX = Component.LEFT_ALIGNMENT
-            add(titleLabel)
+            add(titleRow)
             add(subLabel)
         }
 
@@ -862,7 +914,10 @@ class CommitsPanel(
                 val ins = insets
                 val cW = (w - ins.left - ins.right - leftPanel.preferredSize.width - rightPanel.preferredSize.width - 2 * 2)
                     .coerceAtLeast(JBUI.scale(20))
-                titleLabel.setSize(cW, Short.MAX_VALUE.toInt())
+                // The ref chip (if any) occupies WEST of the title row, so the wrapping title
+                // measures against the remaining width — otherwise the last line would clip.
+                val refW = refChip?.preferredSize?.width ?: 0
+                titleLabel.setSize((cW - refW).coerceAtLeast(JBUI.scale(20)), Short.MAX_VALUE.toInt())
                 val centerH = titleLabel.preferredSize.height + subLabel.preferredSize.height
                 val h = maxOf(centerH, leftPanel.preferredSize.height, rightPanel.preferredSize.height)
                 return Dimension(base.width, h + ins.top + ins.bottom)
@@ -969,7 +1024,7 @@ class CommitsPanel(
                 scheduleHoverDismiss()
             }
         }
-        for (child in listOf(arrowLabel, titleLabel, subLabel, leftPanel, rightPanel, topLine, row)) {
+        for (child in listOfNotNull(arrowLabel, titleLabel, subLabel, leftPanel, rightPanel, topLine, row, refChip)) {
             child.addMouseListener(hoverListener)
         }
         rowActions.forEach { it.addMouseListener(hoverListener) }
@@ -1988,6 +2043,31 @@ class CommitsPanel(
     }
 
     // ─── Copy recall prompt ──────────────────────────────────────────────────
+
+    /**
+     * Copies a memory reference id (e.g. "JM-142") to the system clipboard and flashes a
+     * short confirmation balloon under the clicked chip. Mirrors the VS Code sidebar's
+     * click-to-copy affordance on the JM- prefix.
+     */
+    private fun copyMemoryId(refId: String, anchor: JComponent) {
+        Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(refId), null)
+        ai.jolli.jollimemory.core.telemetry.Telemetry.track(
+            "memory_ref_id_copied",
+            mapOf("surface_area" to "list"),
+        )
+        com.intellij.openapi.ui.popup.JBPopupFactory.getInstance()
+            .createHtmlTextBalloonBuilder(
+                "Copied <b>${com.intellij.openapi.util.text.StringUtil.escapeXmlEntities(refId)}</b>",
+                com.intellij.openapi.ui.MessageType.INFO,
+                null,
+            )
+            .setFadeoutTime(1500)
+            .createBalloon()
+            .show(
+                com.intellij.ui.awt.RelativePoint.getSouthOf(anchor),
+                com.intellij.openapi.ui.popup.Balloon.Position.below,
+            )
+    }
 
     /**
      * Copies the recall prompt to clipboard for a commit hash.

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
@@ -852,6 +852,13 @@ class SummaryPanel(
         try {
             when (command) {
                 "editState" -> webviewDirty = json.get("editing")?.asBoolean == true
+                // Telemetry only — the webview already wrote the id to the clipboard
+                // itself and showed its own toast; there is nothing else to do here.
+                "trackMemoryRefIdCopied" ->
+                    ai.jolli.jollimemory.core.telemetry.Telemetry.track(
+                        "memory_ref_id_copied",
+                        mapOf("surface_area" to "detail"),
+                    )
                 "copyMarkdown" -> handleCopyMarkdown()
                 "downloadMarkdown" -> handleDownloadMarkdown()
                 "pushToJolli" -> handlePushToJolli()

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryCssBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryCssBuilder.kt
@@ -97,8 +97,72 @@ $rootVars
     color: var(--text-primary);
     letter-spacing: -0.01em;
   }
+  /* Memory reference id (JM-<docId>) prefixing the title — monospace + muted so
+     it reads as an identifier badge without competing with the commit message.
+     Clickable: click copies the id, the tooltip hints at it. */
+  .page-title-ref {
+    font-family: monospace;
+    font-weight: 500;
+    color: var(--text-secondary);
+    cursor: pointer;
+  }
+  .page-title-ref:hover {
+    color: var(--text-primary);
+    text-decoration: underline;
+  }
+  .page-title-ref:focus-visible {
+    outline: 1px solid var(--focus-border);
+    outline-offset: 2px;
+    border-radius: 3px;
+  }
+  /* Transient "copied" toast (memory-id copy), pinned bottom-center. Fades in on
+     .show (added by showMemoryCopyToast) and out ~1.5s later. Floats over arbitrary
+     page content, so it uses the OPAQUE --overlay-* tokens, not --panel-inner (see
+     the token block for why translucent surfaces don't work for floating elements). */
+  .copy-toast {
+    position: fixed;
+    left: 50%;
+    bottom: 16px;
+    transform: translateX(-50%) translateY(8px);
+    background: var(--overlay-bg);
+    color: var(--overlay-fg);
+    border: 1px solid var(--overlay-border);
+    border-radius: 6px;
+    padding: 6px 12px;
+    font-size: 12px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease, transform 0.15s ease;
+    z-index: 1000;
+  }
+  .copy-toast.show {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+  /* In-document tooltip: JCEF does not surface native HTML `title` tooltips, so
+     hover hints (e.g. the JM- reference id) are rendered here instead. Shown by the
+     delegated hover handler in SummaryScriptBuilder. */
+  .jm-tooltip {
+    position: fixed;
+    z-index: 2000;
+    max-width: 320px;
+    padding: 4px 8px;
+    border: 1px solid var(--tooltip-border);
+    border-radius: 4px;
+    background: var(--tooltip-bg);
+    color: var(--tooltip-fg);
+    font-size: 11px;
+    line-height: 1.4;
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.45);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.1s ease;
+  }
+  .jm-tooltip.show { opacity: 1; }
   /* ── Export dropdown (Copy / Save as Markdown) ── */
   .export-menu-group { position: relative; display: inline-block; }
+  /* Also a floating overlay (absolute, over page content) → opaque --overlay-* tokens. */
   .split-menu {
     display: none;
     position: absolute;
@@ -107,9 +171,9 @@ $rootVars
     z-index: 30;
     min-width: 180px;
     padding: 4px;
-    border: 1px solid var(--border-light);
+    border: 1px solid var(--overlay-border);
     border-radius: 8px;
-    background: var(--panel-inner);
+    background: var(--overlay-bg);
     box-shadow: 0 6px 20px rgba(0, 0, 0, 0.28);
   }
   .split-menu.open { display: block; }
@@ -774,7 +838,7 @@ $rootVars
     top: 12px;
     bottom: 12px;
     width: 2px;
-    background: var(--border-light);
+    background: var(--timeline-line);
     border-radius: 1px;
   }
   .timeline-group {
@@ -800,7 +864,7 @@ $rootVars
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    background: var(--text-tertiary);
+    background: var(--timeline-dot-bg);
     border: 2px solid var(--bg);
     z-index: 1;
   }
@@ -1667,6 +1731,11 @@ ${ShareWebview.css()}
     /* ── Surface / borders ── */
     --surface-hover: rgba(255, 255, 255, 0.035);
     --border-light: rgba(255, 255, 255, 0.06);
+    /* Opaque sibling of --border-light for the timeline spine (position: absolute) — a
+       translucent background on a floating element trips the opaque-overlay guard. */
+    --timeline-line: #3a3d41;
+    /* Opaque equivalent of --text-tertiary for the absolute-positioned timeline dot. */
+    --timeline-dot-bg: #6e6e6e;
     --text-secondary: rgba(255, 255, 255, 0.45);
     --text-tertiary: rgba(255, 255, 255, 0.30);
     --prop-label: rgba(255, 255, 255, 0.40);
@@ -1699,7 +1768,23 @@ ${ShareWebview.css()}
     --panel-bg: rgba(255, 255, 255, 0.018);
     --panel-inner: rgba(255, 255, 255, 0.045);
     --ship-ok: #4ece8d;
-    --ship-warn: #e0ac2b;"""
+    --ship-warn: #e0ac2b;
+    /* ── Floating-overlay tokens (must be OPAQUE) ──
+       The surface tokens above (--panel-bg / --panel-inner / --surface-hover) are 1.5–4.5%
+       alpha. That works for elements STACKED on a known background (a card inside a panel),
+       and fails for elements FLOATING over arbitrary content (position: fixed/absolute) —
+       the page shows straight through and the overlay's own text collides with whatever
+       scrolled underneath it. Anything floating uses these instead; the criterion is
+       "does this element sit on a known background, or on unknown content?".
+       --overlay-*: theme-matched opaque surface (toast, dropdown menu) — mirrors VS Code's
+       --vscode-notifications-background. --tooltip-*: deliberately INVERTED high-contrast
+       bubble, a different job from a surface. */
+    --overlay-bg: #3c3f41;
+    --overlay-fg: #e6e6e6;
+    --overlay-border: rgba(255, 255, 255, 0.14);
+    --tooltip-bg: #3c3f41;
+    --tooltip-fg: #e6e6e6;
+    --tooltip-border: rgba(255, 255, 255, 0.14);"""
 
     /** Light theme variable block (matches `body.vscode-light` values). */
     private fun buildLightVars(pageBgHex: String): String = """
@@ -1744,6 +1829,9 @@ ${ShareWebview.css()}
     /* ── Surface / borders ── */
     --surface-hover: rgba(0, 0, 0, 0.028);
     --border-light: rgba(0, 0, 0, 0.06);
+    /* Opaque sibling of --border-light for the timeline spine — see the dark block. */
+    --timeline-line: #d0d0d0;
+    --timeline-dot-bg: #adadad;
     --text-secondary: rgba(0, 0, 0, 0.45);
     --text-tertiary: rgba(0, 0, 0, 0.32);
     --prop-label: rgba(0, 0, 0, 0.42);
@@ -1776,5 +1864,14 @@ ${ShareWebview.css()}
     --panel-bg: rgba(0, 0, 0, 0.015);
     --panel-inner: rgba(0, 0, 0, 0.035);
     --ship-ok: #1b8a4f;
-    --ship-warn: #96680e;"""
+    --ship-warn: #96680e;
+    /* Floating-overlay tokens — see the dark block for the full rationale. --overlay-* is a
+       theme-matched opaque surface (white on a light page); --tooltip-* stays an inverted
+       dark bubble, which is high-contrast and readable over light content. */
+    --overlay-bg: #ffffff;
+    --overlay-fg: #1e1e1e;
+    --overlay-border: rgba(0, 0, 0, 0.18);
+    --tooltip-bg: #2b2d30;
+    --tooltip-fg: #f5f5f5;
+    --tooltip-border: rgba(0, 0, 0, 0.25);"""
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryHtmlBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryHtmlBuilder.kt
@@ -17,6 +17,7 @@ import ai.jolli.jollimemory.toolwindow.views.SummaryUtils.escAttr
 import ai.jolli.jollimemory.toolwindow.views.SummaryUtils.escHtml
 import ai.jolli.jollimemory.toolwindow.views.SummaryUtils.formatDate
 import ai.jolli.jollimemory.toolwindow.views.SummaryUtils.formatFullDate
+import ai.jolli.jollimemory.toolwindow.views.SummaryUtils.formatMemoryRefIdWithHashFallback
 import ai.jolli.jollimemory.toolwindow.views.SummaryUtils.padIndex
 import ai.jolli.jollimemory.toolwindow.views.SummaryUtils.renderCalloutText
 import ai.jolli.jollimemory.toolwindow.views.SummaryUtils.timeAgo
@@ -331,12 +332,21 @@ ${buildTranscriptModal()}"""
             """$totalFiles file$filesPlural changed, <span class="stat-add">$totalInsertions insertion$insPlural(+)</span>, <span class="stat-del">$totalDeletions deletion$delPlural(-)</span>"""
         val totalTurns = SummaryTree.aggregateTurns(summary)
         val shortHash = escHtml(summary.commitHash.take(8))
+        // Reference id (JM-<docId>) prefix — the backend doc id once synced, else a
+        // JM-<short hash> fallback so every memory shows a reference. Mirrors the VS
+        // Code detail panel.
+        // role/tabindex + the Enter-Space handler in SummaryScriptBuilder make the chip
+        // keyboard-reachable; a bare click-only <span> would strand keyboard users.
+        val refId = formatMemoryRefIdWithHashFallback(summary.jolliDocId, summary.commitHash)
+        val refPrefix =
+            """<span class="page-title-ref" role="button" tabindex="0" aria-label="Copy memory ID ${escAttr(refId)}" """ +
+                """title="Memory ID — click to copy" data-copy-memory-id="${escAttr(refId)}">${escHtml(refId)}:</span> """
 
         // Meta strip mirrors the VS Code detail view: hash · branch · date, then the
         // Details toggle and the Share link + Export actions on the same line (author,
         // line-change counts, and conversation turns live in the collapsed Details table).
         return """
-<h1 class="page-title">${escHtml(summary.commitMessage)}</h1>
+<h1 class="page-title">$refPrefix${escHtml(summary.commitMessage)}</h1>
 <div class="meta-strip">
   <span class="meta-hash">$shortHash</span>
   <span class="meta-sep">&middot;</span>

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilder.kt
@@ -77,6 +77,99 @@ object SummaryScriptBuilder {
     });
   });
 
+  // Memory reference-id prefix (JM-<docId>): click copies the id and flashes a
+  // bottom-center toast. clipboard is reachable in this webview (see hash-copy).
+  document.querySelectorAll('.page-title-ref').forEach(function(ref) {
+    function copyRefId() {
+      var id = ref.dataset.copyMemoryId || '';
+      if (!id) { return; }
+      // Optimistic toast, byte-for-byte the VS Code semantics: show it immediately
+      // rather than awaiting the clipboard promise. Waiting (the old
+      // .then(done, done)) delayed the confirmation whenever the clipboard was slow
+      // and still fired on failure, so it bought nothing for the latency it cost.
+      navigator.clipboard.writeText(id).catch(function() {});
+      showMemoryCopyToast(id + ' copied');
+      // Telemetry-only ping — the clipboard write already happened here in the
+      // webview; the host just counts it (memory_ref_id_copied).
+      jmSend({ command: 'trackMemoryRefIdCopied' });
+    }
+    ref.addEventListener('click', copyRefId);
+    // The chip is role=button/tabindex=0, so it must also answer the keyboard.
+    ref.addEventListener('keydown', function(e) {
+      if (e.key !== 'Enter' && e.key !== ' ') { return; }
+      e.preventDefault();
+      copyRefId();
+    });
+  });
+  function showMemoryCopyToast(text) {
+    var t = document.getElementById('jm-copy-toast');
+    if (!t) {
+      t = document.createElement('div');
+      t.id = 'jm-copy-toast';
+      t.className = 'copy-toast';
+      document.body.appendChild(t);
+    }
+    t.textContent = text;
+    t.classList.add('show');
+    if (t._hideTimer) { clearTimeout(t._hideTimer); }
+    t._hideTimer = setTimeout(function() { t.classList.remove('show'); }, 1500);
+  }
+
+  // In-document tooltips: JCEF does not render native HTML `title` tooltips (VS Code,
+  // on Electron, does), so hovering the JM- reference id — and every other titled
+  // control in this panel — showed nothing. Re-create them in the document: lazily
+  // move each element's `title` into data-jm-tip (so no stray native tooltip competes)
+  // and show a positioned bubble after a short hover delay. Delegated so it also covers
+  // content inserted by in-place section updates.
+  (function() {
+    var tip = null, timer = null, curEl = null;
+    function bubble() {
+      if (!tip) { tip = document.createElement('div'); tip.className = 'jm-tooltip'; document.body.appendChild(tip); }
+      return tip;
+    }
+    function hide() {
+      if (timer) { clearTimeout(timer); timer = null; }
+      if (tip) { tip.classList.remove('show'); }
+      curEl = null;
+    }
+    function titled(node) {
+      var el = node && node.closest ? node.closest('[title],[data-jm-tip]') : null;
+      if (!el) return null;
+      // A live `title` always wins: cache it into data-jm-tip (refreshing any
+      // stale cache from a previous hover) and strip `title` so the native OS
+      // tooltip doesn't double up. Code that mutates `.title` at runtime (regen
+      // button, delete/restore toggle, plan links) relies on this refresh —
+      // reading data-jm-tip first would pin the first-hover text forever.
+      // Invariant: nothing else in this panel READS `.title` at runtime — once
+      // hovered, an element's hint lives in data-jm-tip, not `.title`. If a future
+      // reader needs it, read data-jm-tip (falling back to `.title`) instead.
+      var live = el.getAttribute('title');
+      if (live) { el.setAttribute('data-jm-tip', live); el.removeAttribute('title'); return el; }
+      var text = el.getAttribute('data-jm-tip');
+      return text ? el : null;
+    }
+    document.addEventListener('mouseover', function(e) {
+      var el = titled(e.target);
+      if (el === curEl) return;
+      hide();
+      if (!el) return;
+      curEl = el;
+      var text = el.getAttribute('data-jm-tip');
+      timer = setTimeout(function() {
+        var t = bubble();
+        t.textContent = text;
+        t.classList.add('show');
+        var r = el.getBoundingClientRect();
+        var left = Math.min(r.left, window.innerWidth - t.offsetWidth - 6);
+        t.style.left = Math.max(6, left) + 'px';
+        t.style.top = (r.bottom + 6) + 'px';
+      }, 350);
+    });
+    document.addEventListener('mouseout', function(e) {
+      if (!e.relatedTarget) hide();
+    });
+  })();
+
   // ── Redesign v2: Details disclosure + panel/card/drawer collapse ──
   var detailsToggle = document.getElementById('detailsToggle');
   if (detailsToggle) {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryUtils.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryUtils.kt
@@ -114,6 +114,26 @@ object SummaryUtils {
 
     // ── Title builders ─────────────────────────────────────────────────────
 
+    /** Display prefix for a memory reference id. Mirrors cli/src/core/MemoryRefId.ts. */
+    const val MEMORY_REF_PREFIX = "JM-"
+
+    /**
+     * Formats a memory's human-facing reference id (`JM-<docId>`) from the Jolli
+     * Space doc id the web backend mints on a successful push (`jolliDocId`), or
+     * null when the memory has none — unsynced, or a non-positive id. TS port:
+     * cli/src/core/MemoryRefId.ts (keep the two in lockstep).
+     */
+    fun formatMemoryRefId(jolliDocId: Int?): String? =
+        if (jolliDocId != null && jolliDocId > 0) "$MEMORY_REF_PREFIX$jolliDocId" else null
+
+    /**
+     * Like [formatMemoryRefId] but always returns a value: when the memory has no
+     * backend doc id yet (unsynced), falls back to the first 8 chars of the commit
+     * hash — e.g. `JM-f159924c`. TS port: cli/src/core/MemoryRefId.ts.
+     */
+    fun formatMemoryRefIdWithHashFallback(jolliDocId: Int?, commitHash: String): String =
+        formatMemoryRefId(jolliDocId) ?: "$MEMORY_REF_PREFIX${commitHash.take(8)}"
+
     /** Regex fallback: extracts ticket from commit message or branch. */
     private fun extractTicketFallback(commitMessage: String, branch: String): String? {
         val pattern = Regex("[A-Z][A-Z0-9]+-\\d+")

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/SummaryReaderConversationsTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/SummaryReaderConversationsTest.kt
@@ -1,6 +1,7 @@
 package ai.jolli.jollimemory.bridge
 
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -72,6 +73,108 @@ class SummaryReaderConversationsTest {
             rows.map { it.source } shouldBe listOf("claude", "cursor")
             rows[1].messageCount shouldBe 0
             rows[1].title shouldBe "Cursor session"
+        }
+
+        /**
+         * Gson returns JsonNull — not Kotlin null — for `"role": null`, so `?.asString`
+         * does not short-circuit and throws. Unguarded, that exception is caught by
+         * parseConversations and blanks the WHOLE list.
+         */
+        @Test
+        fun `an explicit null role or content does not blank the conversation list`() {
+            val json = """
+                {"sessions":[
+                  {"sessionId":"s1","source":"claude","entries":[
+                    {"role":null,"content":"x"},
+                    {"role":"human","content":null},
+                    {"role":"human","content":"real turn"}
+                  ]}
+                ]}
+            """.trimIndent()
+            val rows = SummaryReader.parseConversations(json)
+            rows.size shouldBe 1
+            rows[0].messageCount shouldBe 3
+            // Falls through the two null-bearing turns to the first usable human line.
+            rows[0].title shouldBe "real turn"
+        }
+
+        @Test
+        fun `an explicit null source or sessionId falls back instead of dropping the row`() {
+            val json = """{"sessions":[{"sessionId":null,"source":null,"entries":[]}]}"""
+            val rows = SummaryReader.parseConversations(json)
+            rows.size shouldBe 1
+            rows[0].source shouldBe "ai"
+            rows[0].sessionId shouldBe ""
+            rows[0].transcriptPath shouldBe null
+        }
+    }
+
+    @Nested
+    inner class ParseSummaryBrief {
+        private val full = """
+            {"commitHash":"abc12345def","commitMessage":"Fix login","commitAuthor":"Ada",
+             "commitDate":"2026-07-01","topics":[{"t":1},{"t":2}],"jolliDocId":142}
+        """.trimIndent()
+
+        @Test
+        fun `parses every field and derives the short hash`() {
+            val brief = SummaryReader.parseSummaryBrief(full)!!
+            brief.hash shouldBe "abc12345def"
+            brief.shortHash shouldBe "abc12345"
+            brief.message shouldBe "Fix login"
+            brief.author shouldBe "Ada"
+            brief.date shouldBe "2026-07-01"
+            brief.topicCount shouldBe 2
+            brief.hasSummary shouldBe true
+            brief.jolliDocId shouldBe 142
+        }
+
+        @Test
+        fun `null blank or malformed input yields null rather than throwing`() {
+            SummaryReader.parseSummaryBrief(null) shouldBe null
+            SummaryReader.parseSummaryBrief("") shouldBe null
+            SummaryReader.parseSummaryBrief("   ") shouldBe null
+            SummaryReader.parseSummaryBrief("{not json") shouldBe null
+        }
+
+        /**
+         * The regression this guards: Gson returns JsonNull for `"jolliDocId": null`, so
+         * `obj.get("jolliDocId")?.asInt` does not short-circuit and throws
+         * UnsupportedOperationException. Caught by the parse, that dropped the ENTIRE
+         * summary — one stray null field silently removed a memory from the list.
+         */
+        @Test
+        fun `an explicit null jolliDocId yields a row with no doc id, not a dropped summary`() {
+            val json = """{"commitHash":"abc12345def","commitMessage":"Fix login","jolliDocId":null}"""
+            val brief = SummaryReader.parseSummaryBrief(json)
+            brief shouldNotBe null
+            brief!!.hash shouldBe "abc12345def"
+            brief.jolliDocId shouldBe null
+        }
+
+        @Test
+        fun `an explicit null on any string field falls back to empty, not a dropped summary`() {
+            val json = """
+                {"commitHash":null,"commitMessage":null,"commitAuthor":null,
+                 "commitDate":null,"topics":null,"jolliDocId":null}
+            """.trimIndent()
+            val brief = SummaryReader.parseSummaryBrief(json)
+            brief shouldNotBe null
+            brief!!.hash shouldBe ""
+            brief.shortHash shouldBe ""
+            brief.message shouldBe ""
+            brief.author shouldBe ""
+            brief.date shouldBe ""
+            brief.topicCount shouldBe 0
+            brief.jolliDocId shouldBe null
+        }
+
+        @Test
+        fun `absent optional fields behave the same as explicit nulls`() {
+            val brief = SummaryReader.parseSummaryBrief("""{"commitHash":"abc12345def"}""")!!
+            brief.message shouldBe ""
+            brief.topicCount shouldBe 0
+            brief.jolliDocId shouldBe null
         }
     }
 }

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEventsTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEventsTest.kt
@@ -2,8 +2,11 @@ package ai.jolli.jollimemory.core.telemetry
 
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.string.shouldNotBeBlank
+import java.io.File
 import org.junit.jupiter.api.Test
 
 class TelemetryEventsTest {
@@ -38,5 +41,52 @@ class TelemetryEventsTest {
         TelemetryEvents.isTelemetryEventName("signin_completed").shouldBeTrue()
         TelemetryEvents.isTelemetryEventName("not_a_real_event").shouldBeFalse()
         TelemetryEvents.isTelemetryEventName("").shouldBeFalse()
+    }
+
+    /**
+     * Every `Telemetry.track("…")` literal in production code must name a REGISTERED event,
+     * because `track` silently drops anything else — an unregistered name is a call site that
+     * looks like instrumentation and reports nothing, which is worse than no call at all
+     * (`memory_ref_id_copied` shipped that way and produced zero data).
+     *
+     * The CLI/VS Code side gets this from the compiler: its `track` takes the
+     * `TelemetryEventName` union, so an unregistered name fails typecheck. Kotlin's takes a
+     * plain `String`, so nothing catches it there — hence this test.
+     */
+    @Test
+    fun `every tracked event name in production code is registered`() {
+        val unregistered = trackedEventNames()
+            .filterNot { (_, name) -> TelemetryEvents.isTelemetryEventName(name) }
+            .map { (file, name) -> "$name (in $file)" }
+        unregistered.shouldBeEmpty()
+    }
+
+    @Test
+    fun `the tracked-name sweep can actually see the call sites it is guarding`() {
+        // Guards the guard: a sweep that finds nothing would pass vacuously forever —
+        // which is the failure mode that let an unregistered name ship in the first place.
+        val found = trackedEventNames().map { (_, name) -> name }.toSet()
+        found.size shouldBeGreaterThanOrEqual 5
+        found shouldContain "memory_ref_id_copied"
+    }
+
+    private companion object {
+        private val TRACK_CALL = Regex("""Telemetry\.track\(\s*"([^"]+)"""")
+
+        /**
+         * (file name, event name) for every `Telemetry.track("…")` literal in production
+         * Kotlin. Tolerates being run from either the `intellij/` project dir (Gradle's
+         * default test working dir) or the repo root (some IDE run configurations).
+         */
+        fun trackedEventNames(): List<Pair<String, String>> {
+            val root = listOf("src/main/kotlin", "intellij/src/main/kotlin")
+                .map { File(it) }
+                .firstOrNull { it.isDirectory }
+                ?: return emptyList()
+            return root.walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .flatMap { file -> TRACK_CALL.findAll(file.readText()).map { file.name to it.groupValues[1] } }
+                .toList()
+        }
     }
 }

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryCssBuilderTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryCssBuilderTest.kt
@@ -1,0 +1,145 @@
+package ai.jolli.jollimemory.toolwindow.views
+
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Test
+
+/**
+ * Guards the *floating overlay must be opaque* invariant in the summary webview's CSS.
+ *
+ * The surface tokens in this stylesheet (`--panel-bg`, `--panel-inner`, `--surface-hover`, …)
+ * are 1.5–4.5% alpha. That is correct for an element STACKED on a known background — a card
+ * inside a panel composites against the panel and reads as a subtle lift. It is wrong for an
+ * element FLOATING over arbitrary content (`position: fixed` / `absolute`): the page shows
+ * straight through and the overlay's own text collides with whatever happens to be scrolled
+ * underneath. A copy-confirmation toast pinned to `bottom: 16px` over a list of topic cards
+ * was invisible for exactly this reason.
+ *
+ * [floatingOverlaysUseOpaqueBackgrounds] is the real guard: it walks EVERY declaration block
+ * in the generated stylesheet rather than the handful we happened to think of, so the next
+ * floating element that reaches for a translucent surface token fails here instead of in a
+ * screenshot. The per-element tests below pin the specific elements this was found on.
+ */
+class SummaryCssBuilderTest {
+
+    /** `--token: value;` definitions, i.e. the `:root` custom-property block. */
+    private val tokenPattern = Regex("""--([a-z0-9-]+)\s*:\s*([^;]+);""")
+
+    /**
+     * Innermost declaration blocks — a `selector { … }` whose body contains no further `{`.
+     * Restricting to innermost blocks is what makes this safe against the `@media` /
+     * `@keyframes` wrappers in this stylesheet: their bodies contain braces, so they are
+     * skipped as containers and their inner rules are matched individually.
+     */
+    private val declBlockPattern = Regex("""([^{}]+)\{([^{}]*)\}""")
+
+    private val backgroundPattern = Regex("""\bbackground(?:-color)?\s*:\s*([^;]+)""")
+    private val varRefPattern = Regex("""var\(\s*(--[a-z0-9-]+)""")
+
+    /**
+     * Partial alpha only — `0 < a < 1`. Fully `transparent` is deliberately NOT flagged:
+     * that's a click-catcher scrim, which paints nothing and carries no text, so being
+     * see-through is the entire point. The bug this guards is the opposite intent — "I
+     * wanted a visible surface" plus a token that is almost invisible.
+     */
+    private fun isTranslucent(value: String): Boolean {
+        val alpha = Regex("""(?:rgba|hsla)\([^)]*,\s*([0-9.]+)\s*\)""").find(value.trim())
+            ?.groupValues?.get(1)?.toDoubleOrNull()
+        return alpha != null && alpha > 0.0 && alpha < 1.0
+    }
+
+    private fun tokensIn(css: String): Map<String, String> =
+        tokenPattern.findAll(css).associate { it.groupValues[1] to it.groupValues[2].trim() }
+
+    /**
+     * Selectors of blocks that float and paint a translucent *surface token*. Resolves one
+     * level of `var()` indirection against the stylesheet's own token block, so the check is
+     * on the effective colour rather than on the token's name.
+     *
+     * Only backgrounds that reach for a `var(--…)` token are considered — the bug this guards
+     * is "I wanted a visible surface" plus a token that is almost invisible (see class doc).
+     * A deliberate inline literal, e.g. the modal backdrop's `rgba(0, 0, 0, 0.5)` dimming
+     * scrim, is not a mis-grabbed surface token; it is excluded for the same reason a fully
+     * `transparent` click-catcher is — being see-through is the entire point.
+     */
+    private fun translucentFloatingSelectors(input: String): List<String> {
+        // Strip comments so a preceding /* … */ can't end up in the reported selector.
+        val css = input.replace(Regex("""/\*[\s\S]*?\*/"""), "")
+        val tokens = tokensIn(css)
+        return declBlockPattern.findAll(css).mapNotNull { block ->
+            val selector = block.groupValues[1].trim()
+            val body = block.groupValues[2]
+            if (!body.contains("position:")) return@mapNotNull null
+            val floats = Regex("""position\s*:\s*(fixed|absolute)""").containsMatchIn(body)
+            if (!floats) return@mapNotNull null
+            val background = backgroundPattern.find(body)?.groupValues?.get(1) ?: return@mapNotNull null
+            val tokenName = varRefPattern.find(background)?.groupValues?.get(1)?.removePrefix("--")
+                ?: return@mapNotNull null
+            val resolved = tokens[tokenName] ?: return@mapNotNull null
+            if (isTranslucent(resolved)) selector else null
+        }.toList()
+    }
+
+    @Test
+    fun `floating overlays use opaque backgrounds in both themes`() {
+        for (isDark in listOf(true, false)) {
+            translucentFloatingSelectors(SummaryCssBuilder.buildCss(isDark = isDark))
+                .shouldBeEmpty()
+        }
+    }
+
+    @Test
+    fun `the alpha detector recognizes the token shapes this stylesheet actually uses`() {
+        // Guards the guard: if isTranslucent stopped matching these, the sweep above would
+        // pass vacuously and the original bug could walk right back in.
+        isTranslucent("rgba(255, 255, 255, 0.045)") shouldBe true
+        isTranslucent("rgba(0, 0, 0, 0.035)") shouldBe true
+        isTranslucent("rgba(60, 63, 65, 1)") shouldBe false
+        isTranslucent("#3c3f41") shouldBe false
+        isTranslucent("#ffffff") shouldBe false
+        // A click-catcher scrim means to be invisible — not the bug being guarded.
+        isTranslucent("transparent") shouldBe false
+        isTranslucent("rgba(0, 0, 0, 0)") shouldBe false
+    }
+
+    @Test
+    fun `the sweep flags a floating element that reaches for a translucent token`() {
+        // Proves the sweep has teeth by feeding it the exact bug it exists to catch.
+        val regressed = """
+          :root { --panel-inner: rgba(255, 255, 255, 0.045); }
+          .copy-toast { position: fixed; bottom: 16px; background: var(--panel-inner); }
+        """
+        translucentFloatingSelectors(regressed) shouldContain ".copy-toast"
+    }
+
+    @Test
+    fun `the copy toast and export dropdown paint the opaque overlay surface`() {
+        for (isDark in listOf(true, false)) {
+            val css = SummaryCssBuilder.buildCss(isDark = isDark)
+            css shouldContain "background: var(--overlay-bg)"
+            css shouldContain "--overlay-bg:"
+            css shouldContain "--overlay-fg:"
+            css shouldContain "--overlay-border:"
+        }
+    }
+
+    @Test
+    fun `the in-document tooltip stays opaque and inverted`() {
+        // JCEF renders no native `title` tooltips, so this bubble IS the tooltip — it floats
+        // over arbitrary content and must never be see-through.
+        for (isDark in listOf(true, false)) {
+            val tokens = tokensIn(SummaryCssBuilder.buildCss(isDark = isDark))
+            isTranslucent(tokens.getValue("tooltip-bg")) shouldBe false
+            isTranslucent(tokens.getValue("overlay-bg")) shouldBe false
+        }
+    }
+
+    @Test
+    fun `the reference-id chip has a visible focus ring for keyboard users`() {
+        for (isDark in listOf(true, false)) {
+            SummaryCssBuilder.buildCss(isDark = isDark) shouldContain ".page-title-ref:focus-visible"
+        }
+    }
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryHtmlBuilderTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryHtmlBuilderTest.kt
@@ -59,6 +59,35 @@ class SummaryHtmlBuilderTest {
         }
 
         @Test
+        fun `prefixes title with JM-docId reference id when the memory is synced`() {
+            val html = SummaryHtmlBuilder.buildHtml(makeSummary().copy(jolliDocId = 142))
+            html shouldContain "page-title-ref"
+            // Carries the copy affordance: the raw id (no colon) to copy.
+            html shouldContain "data-copy-memory-id=\"JM-142\""
+            html shouldContain "JM-142:"
+        }
+
+        @Test
+        fun `falls back to JM-short-hash in the title when there is no jolliDocId`() {
+            // makeSummary's commitHash starts with "abc12345".
+            val html = SummaryHtmlBuilder.buildHtml(makeSummary())
+            html shouldContain "data-copy-memory-id=\"JM-abc12345\""
+            html shouldContain "JM-abc12345:"
+        }
+
+        /**
+         * The chip is a click-to-copy control built on a <span>, so the button semantics
+         * have to be declared explicitly or keyboard users cannot reach it.
+         */
+        @Test
+        fun `makes the reference-id chip keyboard-reachable and screen-reader labelled`() {
+            val html = SummaryHtmlBuilder.buildHtml(makeSummary().copy(jolliDocId = 142))
+            html shouldContain "role=\"button\""
+            html shouldContain "tabindex=\"0\""
+            html shouldContain "aria-label=\"Copy memory ID JM-142\""
+        }
+
+        @Test
         fun `includes CSS and script`() {
             val html = SummaryHtmlBuilder.buildHtml(makeSummary())
             html shouldContain "<style>"

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -776,6 +776,7 @@ export function activate(context: vscode.ExtensionContext): void {
 		const tokens = aggregateConversationTokens(s);
 		return {
 			jolliDocUrl: s.jolliDocUrl,
+			jolliDocId: s.jolliDocId,
 			e2eCount: s.e2eTestGuide?.length,
 			...(tokens > 0 && { conversationTokens: tokens }),
 		};

--- a/vscode/src/providers/HistoryTreeProvider.test.ts
+++ b/vscode/src/providers/HistoryTreeProvider.test.ts
@@ -982,6 +982,34 @@ describe("HistoryTreeProvider.serialize", () => {
 		expect((items[0] as { jolliDocUrl?: string }).jolliDocUrl).toBe("https://team.jolli.app/d/42");
 	});
 
+	it("serialize sets memoryRefId (JM-<docId>) from lookupSummary when the memory is synced", async () => {
+		const commit = { ...makeCommit("abcd1234efgh5678"), hasSummary: true };
+		const bridge = makeBridge(() => makeResult([commit]));
+		const store = new CommitsStore(bridge as never);
+		const provider = new HistoryTreeProvider(store, async (hash) =>
+			hash === "abcd1234efgh5678" ? { jolliDocId: 142 } : null,
+		);
+
+		await store.refresh();
+		const items = await provider.serialize();
+
+		expect((items[0] as { memoryRefId?: string }).memoryRefId).toBe("JM-142");
+	});
+
+	it("serialize omits memoryRefId when the memory has no jolliDocId", async () => {
+		const commit = { ...makeCommit("abcd1234efgh5678"), hasSummary: true };
+		const bridge = makeBridge(() => makeResult([commit]));
+		const store = new CommitsStore(bridge as never);
+		const provider = new HistoryTreeProvider(store, async (_hash) => ({
+			jolliDocUrl: "https://team.jolli.app/d/7",
+		}));
+
+		await store.refresh();
+		const items = await provider.serialize();
+
+		expect((items[0] as { memoryRefId?: string }).memoryRefId).toBeUndefined();
+	});
+
 	it("serialize omits jolliDocUrl when commit has no memory", async () => {
 		const commit = { ...makeCommit("h1"), hasSummary: false };
 		const bridge = makeBridge(() => makeResult([commit]));

--- a/vscode/src/providers/HistoryTreeProvider.ts
+++ b/vscode/src/providers/HistoryTreeProvider.ts
@@ -17,6 +17,7 @@
 
 import { basename } from "node:path";
 import * as vscode from "vscode";
+import { formatMemoryRefId } from "../../../cli/src/core/MemoryRefId.js";
 import type { CommitsStore } from "../stores/CommitsStore.js";
 import type { BranchCommit, CommitFileInfo } from "../Types.js";
 import { formatShortRelativeDate } from "../util/FormatUtils.js";
@@ -166,13 +167,17 @@ export class HistoryTreeProvider
 	 */
 	private readonly lookupSummary?: (
 		hash: string,
-	) => Promise<{ jolliDocUrl?: string; e2eCount?: number; conversationTokens?: number } | null | undefined>;
+	) => Promise<
+		{ jolliDocUrl?: string; e2eCount?: number; conversationTokens?: number; jolliDocId?: number } | null | undefined
+	>;
 
 	constructor(
 		private readonly store: CommitsStore,
 		lookupSummary?: (
 			hash: string,
-		) => Promise<{ jolliDocUrl?: string; e2eCount?: number; conversationTokens?: number } | null | undefined>,
+		) => Promise<
+			{ jolliDocUrl?: string; e2eCount?: number; conversationTokens?: number; jolliDocId?: number } | null | undefined
+		>,
 	) {
 		this.lookupSummary = lookupSummary;
 		this.unsubscribe = store.onChange((snap) => {
@@ -274,14 +279,18 @@ export class HistoryTreeProvider
 			let jolliDocUrl: string | undefined;
 			let e2eCount: number | undefined;
 			let conversationTokens: number | undefined;
+			let memoryRefId: string | undefined;
 			if (item.commit.hasSummary && this.lookupSummary) {
 				try {
 					const s = await this.lookupSummaryMemoized(item.commit.hash, memo);
 					jolliDocUrl = s?.jolliDocUrl;
 					e2eCount = s?.e2eCount;
 					conversationTokens = s?.conversationTokens;
+					// Preformatted here (host-side) because the sidebar webview is a
+					// bundled string and cannot import formatMemoryRefId itself.
+					memoryRefId = formatMemoryRefId(s?.jolliDocId);
 				} catch {
-					// Graceful fallback — leave all three fields undefined so the row
+					// Graceful fallback — leave all four fields undefined so the row
 					// renders in a degraded-but-safe state. Matches the per-commit
 					// getChildren degradation pattern (line ~291).
 				}
@@ -294,6 +303,7 @@ export class HistoryTreeProvider
 				...(jolliDocUrl !== undefined && { jolliDocUrl }),
 				...(e2eCount !== undefined && { e2eCount }),
 				...(conversationTokens !== undefined && { conversationTokens }),
+				...(memoryRefId !== undefined && { memoryRefId }),
 			};
 		} else {
 			// CommitFileItem: surface the four fields needed to dispatch

--- a/vscode/src/views/SidebarCssBuilder.ts
+++ b/vscode/src/views/SidebarCssBuilder.ts
@@ -1336,6 +1336,51 @@ export function buildSidebarCss(): string {
     font-size: 10px;
     opacity: 0.85;
   }
+  /* Memory reference id (JM-<docId>) prefix, shown before the commit title on
+     synced memory rows. Plain monospace + muted (no background) — a Linear-style
+     id prefix, not a filled badge. Clickable: click copies the id, the tooltip
+     hints at it. */
+  /* Deliberately NOT user-select: none — click-to-copy is one affordance, and
+     manually selecting the text to copy it is the fallback when that one fails
+     (or when the user just wants part of the id). Don't take the fallback away. */
+  .mem-ref {
+    flex: 0 0 auto;
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+    margin-right: 4px;
+    cursor: pointer;
+  }
+  .mem-ref:hover { color: var(--vscode-foreground); text-decoration: underline; }
+  .mem-ref:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: 1px;
+    border-radius: 2px;
+  }
+
+  /* Transient "copied" toast, pinned bottom-center of the sidebar. Fades in on
+     .show (added by showCopyToast) and out ~1.5s later. */
+  .copy-toast {
+    position: fixed;
+    left: 50%;
+    bottom: 16px;
+    transform: translateX(-50%) translateY(8px);
+    background: var(--vscode-notifications-background, var(--vscode-editorWidget-background));
+    color: var(--vscode-notifications-foreground, var(--vscode-foreground));
+    border: 1px solid var(--vscode-notifications-border, var(--vscode-editorWidget-border));
+    border-radius: 6px;
+    padding: 6px 12px;
+    font-size: 12px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease, transform 0.15s ease;
+    z-index: 1000;
+  }
+  .copy-toast.show {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
   /* Middle-dot separators match the muted subline tone. */
   .mem-sub-sep {
     color: var(--vscode-descriptionForeground);

--- a/vscode/src/views/SidebarMessages.ts
+++ b/vscode/src/views/SidebarMessages.ts
@@ -159,6 +159,14 @@ export interface SerializedTreeItem {
 	readonly id: string;
 	readonly label: string;
 	readonly description?: string;
+	/**
+	 * Preformatted memory reference id (e.g. `"JM-142"`), derived host-side from
+	 * the summary's `jolliDocId`. Present only for committed-memory rows that have
+	 * been synced to a Jolli Space. The webview renders it verbatim as a prefix
+	 * badge before the commit title (it cannot format it itself — the sidebar
+	 * script is a bundled string with no module imports).
+	 */
+	readonly memoryRefId?: string;
 	readonly iconKey?: string;
 	readonly iconColor?: string;
 	readonly tooltip?: string;
@@ -713,6 +721,14 @@ export type SidebarOutboundMsg =
 			readonly type: "command";
 			readonly command: string;
 			readonly args?: ReadonlyArray<unknown>;
+	  }
+	| {
+			// Copy an arbitrary short string to the OS clipboard. Used by the
+			// memory reference-id (JM-<docId>) badge — the webview can't reliably
+			// reach the clipboard itself, so the host writes it. The webview shows
+			// its own inline toast; no host response is needed.
+			readonly type: "copyText";
+			readonly text: string;
 	  }
 	| {
 			readonly type: "refresh";

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -99,6 +99,33 @@ describe("SidebarScriptBuilder", () => {
 		expect(js).toContain("Build Knowledge Wiki");
 	});
 
+	// Reference-id chip (JM-<docId>) on synced memory rows. It's a <span> with a
+	// click handler, so the button semantics and the keyboard path have to be
+	// declared explicitly — otherwise the affordance is mouse-only.
+	describe("memory reference-id chip", () => {
+		it("renders the chip with button semantics and a keyboard-reachable tabIndex", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("className: 'mem-ref'");
+			expect(js).toContain("role: 'button'");
+			expect(js).toContain("tabIndex: 0");
+			expect(js).toContain("'aria-label': 'Copy memory ID ' + item.memoryRefId");
+		});
+
+		it("copies on Enter/Space as well as click, without toggling the parent row", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("refEl.addEventListener('keydown'");
+			expect(js).toContain("e.key !== 'Enter' && e.key !== ' '");
+			// stopPropagation on both paths keeps the surrounding commit row from
+			// also opening/toggling when the chip is activated.
+			expect(js).toContain("copyMemoryId(item.memoryRefId)");
+		});
+
+		it("routes the clipboard write through the host via copyText", () => {
+			const js = buildSidebarScript();
+			expect(js).toContain("vscode.postMessage({ type: 'copyText', text: id })");
+		});
+	});
+
 	// Regression guards for the Current Branch / Knowledge review findings.
 	// These are substring assertions; the `new Function(...)` parse smoke test
 	// above is what guarantees the surrounding edits stay syntactically valid.

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -95,6 +95,28 @@ export function buildSidebarScript(): string {
   }
   function clear(container) { container.replaceChildren(); }
 
+  // Copy a memory reference id (JM-<docId>) to the clipboard via the host, then
+  // flash an inline toast. The host owns the actual clipboard write (webviews
+  // can't reliably reach it); the toast is optimistic — the write effectively
+  // never fails for a short plain string.
+  function copyMemoryId(id) {
+    if (!id) return;
+    vscode.postMessage({ type: 'copyText', text: id });
+    showCopyToast(id + ' copied');
+  }
+  // Transient bottom-center toast, reused across clicks (one node, re-shown).
+  function showCopyToast(text) {
+    let t = document.getElementById('jm-copy-toast');
+    if (!t) {
+      t = el('div', { id: 'jm-copy-toast', className: 'copy-toast' });
+      document.body.appendChild(t);
+    }
+    t.textContent = text;
+    t.classList.add('show');
+    if (t._hideTimer) clearTimeout(t._hideTimer);
+    t._hideTimer = setTimeout(function() { t.classList.remove('show'); }, 1500);
+  }
+
   // Shared back-fill row-label helpers (formatBackfillMeta / formatBackfillResult) —
   // single source of truth with the Settings panel; see BackfillListRenderer.ts.
   ${backfillListRendererSource()}
@@ -5035,8 +5057,37 @@ export function buildSidebarScript(): string {
       twirl,
       leading,
       memIcon,
-      el('span', { className: 'label', text: item.label }),
     ];
+    // Reference-id badge (JM-<docId>) — preformatted host-side and carried on the
+    // serialized item. Present only for memory rows already synced to a Jolli
+    // Space. Clickable chip: hovering shows a copy hint, clicking copies the id
+    // (via the host) and shows an inline "copied" toast. stopPropagation keeps
+    // the click from also toggling / opening the surrounding commit row.
+    // role/tabIndex/Enter-Space make it reachable without a mouse — it's an
+    // interactive control, so a bare <span> + click would strand keyboard users.
+    if (item.memoryRefId) {
+      const refEl = el('span', {
+        className: 'mem-ref',
+        text: item.memoryRefId + ':',
+        title: 'Memory ID — click to copy',
+        role: 'button',
+        tabIndex: 0,
+        'aria-label': 'Copy memory ID ' + item.memoryRefId,
+      });
+      refEl.addEventListener('click', function(e) {
+        e.stopPropagation();
+        e.preventDefault();
+        copyMemoryId(item.memoryRefId);
+      });
+      refEl.addEventListener('keydown', function(e) {
+        if (e.key !== 'Enter' && e.key !== ' ') { return; }
+        e.stopPropagation();
+        e.preventDefault();
+        copyMemoryId(item.memoryRefId);
+      });
+      kids.push(refEl);
+    }
+    kids.push(el('span', { className: 'label', text: item.label }));
     // Plain commit rows show the short date (item.description) inline — it's
     // their only time cue. Committed-memory rows omit it: the relative date
     // already lives in the .mem-subline below the title, so the MM-DD here is

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -44,6 +44,10 @@ const mockExtensionUri = {
 // `projectDir` passed to ConversationDetailsPanel.show). The mock value is an
 // array so tests can mutate the first slot per-case without re-mocking.
 const mockWorkspaceFolders: Array<{ uri: { fsPath: string } }> = [];
+// `env.clipboard.writeText` backs the `copyText` message (JM- reference-id copy).
+const { clipboardWriteText } = vi.hoisted(() => ({
+	clipboardWriteText: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock("vscode", () => ({
 	Uri: {
 		joinPath: vi.fn((_base: unknown, ...segments: string[]) => ({
@@ -65,6 +69,7 @@ vi.mock("vscode", () => ({
 			return mockWorkspaceFolders.length > 0 ? mockWorkspaceFolders : undefined;
 		},
 	},
+	env: { clipboard: { writeText: clipboardWriteText } },
 }));
 
 // Spy on track() (funnel telemetry, JOLLI-1904) but keep every other real
@@ -147,6 +152,7 @@ describe("SidebarWebviewProvider", () => {
 
 	beforeEach(() => {
 		track.mockClear();
+		clipboardWriteText.mockClear();
 		executeCommand = vi.fn().mockResolvedValue(undefined);
 		provider = new SidebarWebviewProvider({
 			executeCommand: executeCommand as never,
@@ -202,6 +208,50 @@ describe("SidebarWebviewProvider", () => {
 			command: "jollimemory.openSettings",
 		});
 		expect(executeCommand).toHaveBeenCalledWith("jollimemory.openSettings");
+	});
+
+	// ── copyText (JM- reference-id copy from a memory row) ──
+	// Deliberately NOT routed through the command allowlist — it writes a plain
+	// string to the clipboard, it doesn't dispatch a command — so the guard on the
+	// payload is the whole security surface and each of its branches gets a test.
+
+	it("writes a `copyText` payload to the clipboard and counts it", () => {
+		const view = makeMockView();
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({ type: "copyText", text: "JM-142" });
+		expect(clipboardWriteText).toHaveBeenCalledWith("JM-142");
+		expect(track).toHaveBeenCalledWith("memory_ref_id_copied", { surface_area: "list" });
+	});
+
+	it("never dispatches a command for `copyText` (it is not a command message)", () => {
+		const view = makeMockView();
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({ type: "copyText", text: "jollimemory.enable" });
+		expect(clipboardWriteText).toHaveBeenCalledWith("jollimemory.enable");
+		expect(executeCommand).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		["an empty string", ""],
+		["a non-string payload", 42 as unknown as string],
+		["a missing payload", undefined as unknown as string],
+		// Blast-radius bound: a webview-side bug that hands over a whole summary
+		// body must not silently replace the user's clipboard with it.
+		["a payload over the 256-char cap", "J".repeat(257)],
+	])("ignores `copyText` with %s", (_label, text) => {
+		const view = makeMockView();
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.triggerMessage({ type: "copyText", text } as never);
+		expect(clipboardWriteText).not.toHaveBeenCalled();
+		expect(track).not.toHaveBeenCalledWith("memory_ref_id_copied", expect.anything());
+	});
+
+	it("accepts a `copyText` payload exactly at the 256-char cap", () => {
+		const view = makeMockView();
+		provider.resolveWebviewView(view as unknown as never);
+		const atCap = "J".repeat(256);
+		view.webview.triggerMessage({ type: "copyText", text: atCap });
+		expect(clipboardWriteText).toHaveBeenCalledWith(atCap);
 	});
 
 	// ── JOLLI-1904 funnel telemetry (mirrors IntelliJ event names + props) ──

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -89,6 +89,14 @@ const PIN_KIND_TELEMETRY: Readonly<Record<PinKind, string>> = {
  */
 const ALLOWED_BUILTIN_WEBVIEW_COMMANDS = new Set<string>(["vscode.open", "vscode.openFolder"]);
 
+/**
+ * Upper bound on a `copyText` payload. The only caller copies a memory reference id
+ * (`JM-<docId>` / `JM-<hash8>`), so this is generous by two orders of magnitude — it
+ * exists to bound the damage of a webview-side bug that hands over the wrong string,
+ * not to validate the format.
+ */
+const MAX_COPY_TEXT_LENGTH = 256;
+
 /** True when the webview may ask the host to run `command` (see the set above). */
 function isAllowedWebviewCommand(command: string): boolean {
 	return command.startsWith("jollimemory.") || ALLOWED_BUILTIN_WEBVIEW_COMMANDS.has(command);
@@ -799,6 +807,20 @@ export class SidebarWebviewProvider
 					void this.deps.executeCommand(msg.command, ...msg.args);
 				} else {
 					void this.deps.executeCommand(msg.command);
+				}
+				return;
+			case "copyText":
+				// Webview-supplied text (e.g. a "JM-142" reference id) → OS
+				// clipboard. Plain string, no command dispatch, so it needs no
+				// allowlist gate. The webview owns the "copied" toast.
+				//
+				// The length cap is a blast-radius bound, not a validation rule: the
+				// only intended payload is a short reference id, so anything longer is
+				// a webview-side bug, and without the cap such a bug would silently
+				// replace the user's clipboard with (say) an entire summary body.
+				if (typeof msg.text === "string" && msg.text.length > 0 && msg.text.length <= MAX_COPY_TEXT_LENGTH) {
+					void vscode.env.clipboard.writeText(msg.text);
+					track("memory_ref_id_copied", { surface_area: "list" });
 				}
 				return;
 			case "kb:expandFolder":

--- a/vscode/src/views/SummaryCssBuilder.test.ts
+++ b/vscode/src/views/SummaryCssBuilder.test.ts
@@ -177,6 +177,82 @@ describe("SummaryCssBuilder", () => {
 		expect(css).toContain("--callout-detail-label");
 	});
 
+	// ─── Floating overlays must be opaque ─────────────────────────────────
+	// The local surface tokens here (--surface-hover, --callout-*-bg, …) are
+	// 3–10% alpha. Correct for an element STACKED on a known background — a
+	// callout inside a panel composites against the panel. Wrong for an element
+	// FLOATING over arbitrary content (position: fixed/absolute): the page shows
+	// straight through and the overlay's text collides with whatever is scrolled
+	// underneath. Sweep every declaration block rather than the ones we thought
+	// of, so the next floating element that grabs a translucent token fails here
+	// instead of in a screenshot. Mirrors SummaryCssBuilderTest.kt.
+	describe("floating overlays", () => {
+		/**
+		 * Partial alpha only — `0 < a < 1`. Fully `transparent` is deliberately NOT
+		 * flagged: that's a click-catcher scrim (`.share-overlay` is `inset: 0;
+		 * background: transparent`), which paints nothing and carries no text, so
+		 * being see-through is the entire point. The bug this guards is the opposite
+		 * intent — "I wanted a visible surface" plus a token that is almost invisible.
+		 */
+		function isTranslucent(value: string): boolean {
+			const alpha = /(?:rgba|hsla)\([^)]*,\s*([0-9.]+)\s*\)/.exec(value.trim())?.[1];
+			return alpha !== undefined && Number(alpha) > 0 && Number(alpha) < 1;
+		}
+
+		/**
+		 * Innermost declaration blocks only — a body containing `{` is a container
+		 * (`@media`, `body.vscode-dark`), so its inner rules get matched on their own
+		 * and the wrapper is skipped.
+		 */
+		function floatingBlocksWithTranslucentBackground(input: string): string[] {
+			// Strip comments so a preceding /* … */ can't end up in the reported selector.
+			const sheet = input.replace(/\/\*[\s\S]*?\*\//g, "");
+			// Every `--token: value;` in the sheet, for one level of var() resolution.
+			const tokens = new Map<string, string>();
+			for (const m of sheet.matchAll(/--([a-z0-9-]+)\s*:\s*([^;]+);/g)) {
+				tokens.set(m[1], m[2].trim());
+			}
+			const offenders: string[] = [];
+			for (const m of sheet.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+				const selector = m[1].trim();
+				const body = m[2];
+				if (!/position\s*:\s*(fixed|absolute)/.test(body)) continue;
+				const background = /\bbackground(?:-color)?\s*:\s*([^;]+)/.exec(body)?.[1];
+				if (background === undefined) continue;
+				// Only backgrounds that reach for a var(--…) surface token are the bug this
+				// guards. A deliberate inline literal — e.g. a modal backdrop's rgba(0,0,0,0.5)
+				// dimming scrim — is excluded for the same reason a fully `transparent`
+				// click-catcher is: being see-through is the entire point.
+				const ref = /var\(\s*(--[a-z0-9-]+)/.exec(background)?.[1]?.slice(2);
+				if (ref === undefined) continue;
+				const resolved = tokens.get(ref);
+				if (resolved !== undefined && isTranslucent(resolved)) offenders.push(selector);
+			}
+			return offenders;
+		}
+
+		it("no position:fixed/absolute rule paints a translucent background", () => {
+			expect(floatingBlocksWithTranslucentBackground(css)).toEqual([]);
+		});
+
+		it("the sweep flags a floating element that reaches for a translucent token", () => {
+			// Guards the guard — a vacuous sweep would let the original bug back in.
+			const regressed = `
+				:root { --panel-inner: rgba(255, 255, 255, 0.045); }
+				.copy-toast { position: fixed; bottom: 16px; background: var(--panel-inner); }
+			`;
+			expect(floatingBlocksWithTranslucentBackground(regressed)).toContain(".copy-toast");
+		});
+
+		it("the copy toast paints the opaque notifications surface", () => {
+			expect(css).toContain("--vscode-notifications-background");
+		});
+
+		it("gives the reference-id chip a visible focus ring", () => {
+			expect(css).toContain(".page-title-ref:focus-visible");
+		});
+	});
+
 	// ─── Foreign-repo read-only mode ──────────────────────────────────────
 	// SummaryHtmlBuilder marks .page with `foreign-readonly` when the loaded
 	// summary belongs to a non-current repo. The CSS below hides every

--- a/vscode/src/views/SummaryCssBuilder.ts
+++ b/vscode/src/views/SummaryCssBuilder.ts
@@ -97,6 +97,47 @@ export function buildCss(): string {
     color: var(--vscode-foreground);
     letter-spacing: -0.01em;
   }
+  /* Memory reference id (JM-<docId>) prefixing the title — monospace + muted so
+     it reads as an identifier prefix without competing with the commit message.
+     Clickable: click copies the id, the tooltip hints at it. */
+  .page-title-ref {
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-weight: 500;
+    color: var(--vscode-descriptionForeground);
+    cursor: pointer;
+  }
+  .page-title-ref:hover {
+    color: var(--vscode-foreground);
+    text-decoration: underline;
+  }
+  .page-title-ref:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: 2px;
+    border-radius: 3px;
+  }
+  /* Transient "copied" toast (memory-id copy), pinned bottom-center. Fades in on
+     .show (added by showMemoryCopyToast) and out ~1.5s later. */
+  .copy-toast {
+    position: fixed;
+    left: 50%;
+    bottom: 16px;
+    transform: translateX(-50%) translateY(8px);
+    background: var(--vscode-notifications-background, var(--vscode-editorWidget-background));
+    color: var(--vscode-notifications-foreground, var(--vscode-foreground));
+    border: 1px solid var(--vscode-notifications-border, var(--vscode-editorWidget-border));
+    border-radius: 6px;
+    padding: 6px 12px;
+    font-size: 12px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease, transform 0.15s ease;
+    z-index: 1000;
+  }
+  .copy-toast.show {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
   .action-btn {
     font-family: var(--vscode-font-family);
     font-size: 0.8em;

--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -499,6 +499,35 @@ describe("SummaryHtmlBuilder", () => {
 			}
 		});
 
+		// Reference id (JM-<docId>) — the Jolli Space doc id the backend mints on
+		// push, surfaced as a Linear-style prefix on the memory title.
+		it("prefixes the page title with the JM-<id> reference id when the memory is synced", () => {
+			const html = buildPageTitleAndMetaStrip(makeSummary({ jolliDocId: 142 }));
+			expect(html).toContain('class="page-title-ref"');
+			// Carries the copy affordance: tooltip + the raw id (no colon) to copy.
+			expect(html).toContain('data-copy-memory-id="JM-142"');
+			expect(html).toContain("JM-142:");
+			// The prefix precedes the commit message inside the <h1>.
+			expect(html.indexOf("JM-142")).toBeLessThan(html.indexOf("feat: add new feature"));
+		});
+
+		it("falls back to JM-<short hash> in the title when the memory has no jolliDocId", () => {
+			// makeSummary's commitHash starts with "abcdef12".
+			const html = buildPageTitleAndMetaStrip(makeSummary({ jolliDocId: undefined }));
+			expect(html).toContain("page-title-ref");
+			expect(html).toContain('data-copy-memory-id="JM-abcdef12"');
+			expect(html).toContain("JM-abcdef12:");
+		});
+
+		// The chip is a click-to-copy control built on a <span>, so the button
+		// semantics have to be declared explicitly or keyboard users can't reach it.
+		it("makes the reference-id chip keyboard-reachable and screen-reader labelled", () => {
+			const html = buildPageTitleAndMetaStrip(makeSummary({ jolliDocId: 142 }));
+			expect(html).toContain('role="button"');
+			expect(html).toContain('tabindex="0"');
+			expect(html).toContain('aria-label="Copy memory ID JM-142"');
+		});
+
 		// ─── Foreign-repo read-only mode ──────────────────────────────────────
 		// When the panel renders a summary that came from a non-current repo
 		// (Memory Bank cross-repo lookup), every destructive control must be

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -29,6 +29,7 @@ import type {
 	SourceId,
 	TopicCategory,
 } from "../../../cli/src/Types.js";
+import { formatMemoryRefIdWithHashFallback } from "../../../cli/src/core/MemoryRefId.js";
 import { annotatePlans } from "../util/PlanGrouping.js";
 import { getSourceMeta, sourceClassToken } from "./SourceLabels.js";
 import { buildCss } from "./SummaryCssBuilder.js";
@@ -467,8 +468,14 @@ function buildBackfillBadge(summary: CommitSummary): string {
  */
 export function buildPageTitleAndMetaStrip(summary: CommitSummary): string {
 	const shortHash = escHtml(summary.commitHash.substring(0, 8));
+	// Always shown: the backend doc id (JM-142) once synced, else a JM-<short
+	// hash> fallback (JM-f159924c) so every memory has a visible reference.
+	const refId = formatMemoryRefIdWithHashFallback(summary.jolliDocId, summary.commitHash);
+	// role/tabindex + the Enter-Space handler in SummaryScriptBuilder make the chip
+	// keyboard-reachable; a bare click-only <span> would strand keyboard users.
+	const refPrefix = `<span class="page-title-ref" role="button" tabindex="0" aria-label="Copy memory ID ${escAttr(refId)}" title="Memory ID — click to copy" data-copy-memory-id="${escAttr(refId)}">${escHtml(refId)}:</span> `;
 	return `
-<h1 class="page-title">${escHtml(summary.commitMessage)}</h1>
+<h1 class="page-title">${refPrefix}${escHtml(summary.commitMessage)}</h1>
 <div class="meta-strip">
   <span class="meta-hash">${shortHash}</span>
   <span class="meta-sep">&middot;</span>

--- a/vscode/src/views/SummaryScriptBuilder.test.ts
+++ b/vscode/src/views/SummaryScriptBuilder.test.ts
@@ -133,6 +133,29 @@ describe("SummaryScriptBuilder", () => {
 		expect(script).toContain("navigator.clipboard.writeText");
 	});
 
+	// Reference-id chip (JM-<docId>) click-to-copy. The chip is a <span> carrying
+	// role=button/tabindex=0, so it must answer Enter/Space as well as click — and
+	// the toast is deliberately optimistic (not awaiting the clipboard promise), the
+	// same semantics as the sidebar path.
+	it("wires the reference-id chip to copy on click and on Enter/Space", () => {
+		expect(script).toContain("querySelectorAll('.page-title-ref')");
+		expect(script).toContain("addEventListener('click', copyRefId)");
+		expect(script).toContain("addEventListener('keydown'");
+		expect(script).toContain("e.key !== 'Enter' && e.key !== ' '");
+	});
+
+	it("shows the copy toast optimistically rather than awaiting the clipboard", () => {
+		// `.catch(…)` swallows the rejection; the toast call must NOT be chained off a
+		// .then(), which would delay confirmation whenever the clipboard is slow.
+		expect(script).toContain("navigator.clipboard.writeText(id).catch(function() {});");
+		expect(script).toContain("showMemoryCopyToast(id + ' copied')");
+		expect(script).not.toMatch(/writeText\(id\)\s*\.then\(/);
+	});
+
+	it("pings the host so the copy is counted (memory_ref_id_copied)", () => {
+		expect(script).toContain("vscode.postMessage({ command: 'trackMemoryRefIdCopied' })");
+	});
+
 	it("contains Copy Markdown button handler", () => {
 		expect(script).toContain("copyMdBtn");
 		expect(script).toContain("copyMarkdown");

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -116,6 +116,44 @@ export function buildScript(options: SummaryScriptOptions = {}): string {
     });
   });
 
+  // Memory reference-id prefix (JM-<docId>): click copies the id and flashes a
+  // bottom-center toast. clipboard is reachable in this webview (see hash-copy).
+  document.querySelectorAll('.page-title-ref').forEach(function(ref) {
+    function copyRefId() {
+      var id = ref.dataset.copyMemoryId || '';
+      if (!id) { return; }
+      // Optimistic toast — the write effectively never fails for a short plain
+      // string, matching the sidebar copy path (SidebarScriptBuilder). Swallow
+      // any rejection so we never surface an unhandled promise, and don't gate
+      // the toast on it (the old .then(done, done) also fired on failure).
+      navigator.clipboard.writeText(id).catch(function() {});
+      showMemoryCopyToast(id + ' copied');
+      // Telemetry-only ping — the clipboard write already happened here in the
+      // webview; the host just counts it (memory_ref_id_copied).
+      vscode.postMessage({ command: 'trackMemoryRefIdCopied' });
+    }
+    ref.addEventListener('click', copyRefId);
+    // The chip is role=button/tabindex=0, so it must also answer the keyboard.
+    ref.addEventListener('keydown', function(e) {
+      if (e.key !== 'Enter' && e.key !== ' ') { return; }
+      e.preventDefault();
+      copyRefId();
+    });
+  });
+  function showMemoryCopyToast(text) {
+    var t = document.getElementById('jm-copy-toast');
+    if (!t) {
+      t = document.createElement('div');
+      t.id = 'jm-copy-toast';
+      t.className = 'copy-toast';
+      document.body.appendChild(t);
+    }
+    t.textContent = text;
+    t.classList.add('show');
+    if (t._hideTimer) { clearTimeout(t._hideTimer); }
+    t._hideTimer = setTimeout(function() { t.classList.remove('show'); }, 1500);
+  }
+
   // Copy Markdown button with brief visual feedback
   var copyBtn = document.getElementById('copyMdBtn');
   if (copyBtn) {

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -35,6 +35,7 @@ import {
 } from "../../../cli/src/core/Summarizer.js";
 import { getRepoContributors, type RepoContributor } from "../../../cli/src/core/GitOps.js";
 import { resolveSessionTitle } from "../../../cli/src/core/SessionTitleResolver.js";
+import { track } from "../../../cli/src/core/Telemetry.js";
 import { runWithTrace } from "../../../cli/src/core/TraceContext.js";
 import {
 	getTranscriptHashes as coreGetTranscriptHashes,
@@ -301,6 +302,8 @@ type WebviewMessage =
 	| { command: "shareRemoveRecipient"; email: string; shareKind?: ShareKind }
 	| { command: "openRewrittenCommit"; hash: string }
 	| { command: "loadFiles" }
+	/** Telemetry only — the webview already did the clipboard write itself. */
+	| { command: "trackMemoryRefIdCopied" }
 	| {
 			command: "openFileDiff";
 			path: string;
@@ -369,6 +372,10 @@ const FOREIGN_SAFE_COMMANDS: ReadonlySet<WebviewMessage["command"]> = new Set([
 	// foreign or unreachable commit.
 	"loadFiles",
 	"openFileDiff",
+	// Telemetry-only ping for the JM- chip copy. Touches neither git nor storage,
+	// and the reference id belongs to the summary already on screen — safe to
+	// count regardless of which repo the summary came from.
+	"trackMemoryRefIdCopied",
 ]);
 
 function isForeignSafeCommand(command: WebviewMessage["command"]): boolean {
@@ -424,6 +431,9 @@ const REGENERATE_SAFE_COMMANDS: ReadonlySet<WebviewMessage["command"]> = new Set
 	// removePlan / translatePlan.
 	"previewReference",
 	"openReferenceExternal",
+	// Telemetry-only ping for the JM- chip copy — no summary write, so it cannot
+	// race the in-flight regenerate's storeSummary.
+	"trackMemoryRefIdCopied",
 	// regenerateSummary itself is denied while one is in flight; the
 	// handler's own `regenerateInProgress` guard short-circuits a re-entry.
 ]);
@@ -1086,6 +1096,9 @@ export class SummaryWebviewPanel {
 					this.openRewrittenCommit(message.hash),
 					"Open rewritten commit failed",
 				);
+				break;
+			case "trackMemoryRefIdCopied":
+				track("memory_ref_id_copied", { surface_area: "detail" });
 				break;
 			case "loadFiles":
 				this.handleLoadFiles().catch((err: unknown) => {


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

Every memory in Jolli Memory now carries a short reference identifier — formatted as "JM-" followed by a number for synced memories, or "JM-" followed by a short hash for memories not yet synced to a space. The identifier appears in two places: as a muted prefix on the memory detail panel title and as a small chip before the commit title in the history sidebar. Every memory is citable and copyable from the moment it is created, and the identifier upgrades automatically to the stable numeric form once the memory syncs.

All reference identifiers are now fully interactive across both the VS Code extension and the IntelliJ plugin. Hovering over one shows a tooltip reading "Memory ID — click to copy", and clicking copies the identifier to the clipboard and briefly displays a confirmation toast at the bottom of the panel. The confirmation fades out automatically after about a second and a half, and rapid successive clicks reset the timer cleanly. The VS Code detail panel, the VS Code sidebar, the IntelliJ detail panel, and the IntelliJ Committed Memories panel all behave consistently.

The IntelliJ Committed Memories panel also gained a clickable reference chip next to each synced commit. The chip uses a muted monospace style and brightens on hover, matching the visual treatment of the equivalent element in the VS Code sidebar. Clicking it copies the reference identifier and shows a brief confirmation balloon anchored to the chip itself.

Hovering over the reference chip — and over any other labeled control in the IntelliJ panel — now shows a visible tooltip. Previous hover hints were silently swallowed by the embedded browser component; the fix renders tooltips as a positioned overlay inside the panel's own document using fully opaque background colors, making them readable over any content.

---

## E2E Test (5)
<details>
<summary><strong>1. Memory reference ID always visible in detail panel (synced and unsynced)</strong></summary>
<br>
<blockquote>

**Preconditions:** Have at least one memory that has been synced to a Jolli Space (showing a numeric JM number) and at least one that has not yet synced.

**Steps:**
1. Open the Jolli Memory detail panel for a memory that has already synced to a Jolli Space.
2. Check the title area at the top of the panel and verify a reference label like "JM-142:" appears before the commit message.
3. Now open the detail panel for a memory that has NOT yet synced to a Jolli Space.
4. Check the title area again and verify a reference label still appears, but this time it shows a short mix of letters and numbers after "JM-" (for example "JM-f159924c:") rather than a plain number.

**Expected Results:**
- Synced memories show a numeric reference like "JM-142:" in the panel title.
- Unsynced memories show a short hex-style reference like "JM-f159924c:" in the panel title — never a blank where the label would be.

</blockquote>
</details>
<details>
<summary><strong>2. Clicking the memory reference ID in the detail panel copies it to clipboard</strong></summary>
<br>
<blockquote>

**Preconditions:** Have at least one memory open in the detail panel (either VS Code or IntelliJ).

**Steps:**
1. Open the Jolli Memory detail panel for any memory.
2. Hover your mouse over the "JM-..." reference label in the title area.
3. Check that the cursor changes to a hand/pointer and the label shows a visual hint (underline or tooltip) indicating it is clickable.
4. Click the "JM-..." label.
5. Open any text editor or document and paste (Ctrl+V / Cmd+V).

**Expected Results:**
- Hovering the label shows a pointer cursor and a tooltip saying something like "Memory ID — click to copy".
- After clicking, a small toast or confirmation message briefly appears on screen confirming the copy.
- Pasting into a text editor produces the raw reference ID (for example "JM-142" with no trailing colon).

</blockquote>
</details>
<details>
<summary><strong>3. Memory reference chip in IntelliJ Committed Memories panel is clickable and copies ID</strong></summary>
<br>
<blockquote>

**Preconditions:** Have at least one memory that has been synced to a Jolli Space visible in the IntelliJ Committed Memories panel.

**Steps:**
1. Open the Committed Memories panel in IntelliJ.
2. Find a commit row that shows a "JM-..." chip/badge to the left of the commit title.
3. Hover over the chip and check that it visually brightens or highlights.
4. Click the chip.
5. Open any text editor and paste (Ctrl+V / Cmd+V).
6. Also verify that clicking the chip does NOT open or expand the memory row — only the chip action fires.

**Expected Results:**
- The chip brightens on hover, signalling it is interactive.
- After clicking, a small balloon or confirmation message appears briefly near the chip confirming the copy.
- Pasting into a text editor produces the reference ID (for example "JM-142").
- The memory row does not open or toggle when the chip is clicked.

</blockquote>
</details>
<details>
<summary><strong>4. Memory reference ID in VS Code sidebar is clickable and copies ID with toast feedback</strong></summary>
<br>
<blockquote>

**Preconditions:** Have at least one synced memory visible in the VS Code Jolli Memory sidebar history list.

**Steps:**
1. Open the Jolli Memory sidebar panel in VS Code.
2. Locate a memory row that shows a "JM-..." label before the commit title.
3. Hover over the "JM-..." label and check that the cursor changes to a pointer.
4. Click the "JM-..." label.
5. Open any text editor and paste (Ctrl+V / Cmd+V).

**Expected Results:**
- The label shows a pointer cursor on hover.
- After clicking, a small toast notification briefly appears at the bottom of the panel confirming the copy.
- Pasting produces the raw reference ID (for example "JM-142") without a trailing colon.
- The surrounding memory row does not toggle or expand when the label is clicked.

</blockquote>
</details>
<details>
<summary><strong>5. Hover tooltips appear over reference IDs and controls in the IntelliJ detail panel</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a memory open in the IntelliJ detail panel.

**Steps:**
1. Open the Jolli Memory detail panel for any memory in IntelliJ.
2. Hover your mouse over the "JM-..." reference label in the title and hold for about one second.
3. Check whether a tooltip bubble appears below the label.
4. Move the mouse away and verify the tooltip disappears.

**Expected Results:**
- After hovering for roughly one second, a small tooltip bubble appears below the reference label with descriptive text (such as "Memory ID — click to copy").
- Moving the mouse away causes the tooltip to hide promptly.
- The tooltip is clearly readable — not invisible or transparent.

</blockquote>
</details>

---

## Topics (7)
<details>
<summary><strong>01 · Memory reference ID always visible with hash fallback for unsynced memories</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The detail panel only showed a reference identifier for memories that had already synced to a backend space, leaving users with nothing to cite or copy for memories that hadn't yet synced.

**💡 Decisions Behind the Code**

- **Always show a reference rather than hiding it for unsynced memories**: Omitting the identifier for unsynced memories left users with no stable label to cite or copy from the moment a memory was created. Showing a hash-based fallback gives every memory a copyable reference immediately, and the value upgrades automatically to the numeric ID once the memory syncs with no user action required.
- **Same `JM-` prefix for both synced and unsynced forms**: Using a single prefix keeps the UI consistent and the copy behavior identical across both states. The numeric vs. hex distinction is sufficient to signal sync state without introducing a second label style or a conditional layout branch.

**✅ What Was Implemented**

- Added `formatMemoryRefIdWithHashFallback` to `cli/src/core/MemoryRefId.ts` and a matching Kotlin function in `SummaryUtils.kt`: when no backend doc ID exists, the function returns `JM-<first 8 chars of commit hash>` as a fallback, so every memory has a copyable reference from the moment it is created. The numeric suffix signals a synced memory; the hex suffix signals an unsynced one.
- Updated `SummaryHtmlBuilder.ts` and `SummaryHtmlBuilder.kt` to call the fallback function unconditionally, so the reference span is always rendered with a `data-copy-memory-id` attribute and tooltip regardless of sync state. The identifier upgrades automatically to the stable numeric form once the memory syncs.
- Tests in `MemoryRefId.test.ts`, `SummaryHtmlBuilder.test.ts`, and `SummaryHtmlBuilderTest.kt` were updated to assert the hash-fallback form appears for unsynced memories, replacing the old "should not contain" assertions.

**📁 FILES**
- `cli/src/core/MemoryRefId.ts`
- `vscode/src/views/SummaryHtmlBuilder.ts`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryUtils.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryHtmlBuilder.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Memory reference chip in IntelliJ commit list made clickable with copy and tooltip</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The memory reference identifier shown next to each commit in the Committed Memories panel was not interactive — it could not be clicked to copy, had no hover tooltip, and did not visually match the equivalent element in the VS Code sidebar.

**💡 Decisions Behind the Code**

- **Synced-only display in the panel, no hash fallback**: The panel chip follows the VS Code sidebar rule — only commits already synced to a Jolli Space show a reference prefix; unsynced commits show nothing. An earlier iteration used a short-hash fallback so every memory row always had a reference, but strict VS Code parity was the explicit requirement, and the detail panel (which always shows a reference via the hash fallback) already covers the unsynced case.
- **Swing chip component over plain text prefix**: A standalone label component was used rather than prepending the id string to the title text. This allows independent styling (monospace, muted color, hover brightening), a separate click handler that consumes the event without triggering row-open, and correct width accounting for the wrapping title — none of which are achievable with a plain text prefix in a text area.
- **Balloon anchored to chip, not row**: The copy-confirmation balloon is shown relative to the chip component rather than the row or a fixed screen position. This keeps the feedback spatially close to the element the user clicked, matching the affordance pattern already used elsewhere in the panel for hash-copy and recall-prompt actions.

**✅ What Was Implemented**

- `CommitSummaryBrief` in `SummaryReader.kt` gained a `jolliDocId` field, and `JolliMemoryService.kt` was updated to populate it from the full summary during the branch-commits enrichment pass. Previously the panel row model carried only a sync flag and a doc URL, giving the panel nothing to render a reference identifier from.
- `CommitsPanel.kt` was restructured to build a styled `JLabel` chip ("JM-142:") when a synced doc id is present. The chip uses a monospace muted font, sits in the `WEST` slot of a `BorderLayout` row with the title in `CENTER`, brightens on hover, copies the id to the clipboard on click (consuming the event so the row does not also open), and shows a confirmation balloon anchored below the chip. The title's wrap-width calculation was adjusted to subtract the chip's width, and the chip was added to the hover-listener list so row-highlight state stays consistent.
- A `copyMemoryId` helper was added to `CommitsPanel.kt` mirroring the existing `copyRecallPrompt` pattern: it writes to the system clipboard, fires a telemetry event, and shows a short-lived `JBPopupFactory` balloon anchored below the chip.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliMemoryService.kt`

</blockquote>
</details>
<details>
<summary><strong>03 · In-document tooltip system added to fix invisible hover hints in the IntelliJ plugin panel</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Hovering over the memory reference identifier and other controls in the IntelliJ plugin panel showed no tooltip, even though the same controls display tooltips in VS Code. The embedded browser component silently swallowed hover hints even when the underlying markup was correct.

**💡 Decisions Behind the Code**

- **In-document rendering over native JCEF handler**: Tooltips are rendered as a positioned div inside the Chromium document rather than wiring a native callback on the Java side. The native callback approach would require changes to the browser pool, introduce Swing/JCEF layering complexity, and only cover title attributes — the in-document approach works for any labeled element and is self-contained in the HTML/CSS/JS layer already owned by the panel.
- **Opaque tooltip background tokens over reused surface tokens**: Dedicated tooltip color variables were introduced rather than reusing existing surface tokens. The existing surface tokens are intentionally semi-transparent (3–5% opacity) to layer over the panel background; a tooltip bubble needs to be fully opaque to be readable over arbitrary content, so reusing those tokens always produced an invisible bubble regardless of other styling.

**✅ What Was Implemented**

- `SummaryScriptBuilder.kt` received a self-contained delegated hover handler that intercepts `mouseover` events on any element carrying a `title` attribute, lazily migrates the value to a `data-jm-tip` attribute (preventing the browser's own invisible native tooltip from competing), and after a 350 ms delay positions a `.jm-tooltip` div below the hovered element. A `mouseout` handler hides and cancels the timer. The delegation pattern means tooltips work on content inserted by in-place section refreshes without re-registration.
- `SummaryCssBuilder.kt` gained a `.jm-tooltip` rule using new `--tooltip-bg`, `--tooltip-fg`, and `--tooltip-border` CSS variables, plus fully opaque solid-color values for those variables in both the dark and light theme blocks. An initial implementation that reused a near-transparent surface token produced an invisible bubble and was replaced with dedicated opaque values.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilder.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryCssBuilder.kt`

</blockquote>
</details>
<details>
<summary><strong>04 · Memory reference ID clickable to copy with toast feedback in VS Code sidebar</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Memory reference identifiers like "JM-142" appeared as static labels in the VS Code sidebar panel with no way to copy them and no tooltip indicating they were interactive.

**💡 Decisions Behind the Code**

- **Host writes clipboard, webview shows toast optimistically**: The sidebar webview cannot reliably access the OS clipboard directly in all VS Code webview contexts, so the clipboard write is delegated to the extension host via a new message type. The toast is shown immediately in the webview without waiting for host acknowledgment — a short plain-string write effectively never fails, and waiting for a round-trip would make the feedback feel sluggish.
- **Single reused toast node**: Rather than creating a new DOM element on every click, the implementation checks for an existing node by ID and reuses it, resetting its timer on rapid successive clicks. This avoids accumulating stale elements in the DOM and keeps the animation consistent when the user clicks multiple identifiers quickly.
- **New message type bypasses the command allowlist**: The `copyText` message is a direct clipboard write, not a VS Code command, so routing it through the command-dispatch allowlist would add indirection without any safety benefit. It carries its own validation — a non-empty string check — which is sufficient for this operation.

**✅ What Was Implemented**

- In `SidebarScriptBuilder.ts`, the memory reference element was upgraded from a static label to an interactive element with a tooltip ("Memory ID — click to copy"), a click handler that calls a `copyMemoryId` helper, and `stopPropagation` to prevent the surrounding row from toggling. A `showCopyToast` helper creates and reuses a single toast node, resetting its timer on rapid successive clicks.
- In `SidebarWebviewProvider.ts`, a new `copyText` message case was added to the outbound message handler. It validates that the payload is a non-empty string and writes it to the OS clipboard via the VS Code clipboard API. No host-side toast is shown; the webview owns that feedback.
- In `SidebarCssBuilder.ts`, the `.mem-ref` rule was updated to include `cursor: pointer`, a hover underline, and a new `.copy-toast` class for a fixed bottom-center notification with fade-in/out transition.

**📁 FILES**
- `vscode/src/views/SidebarScriptBuilder.ts`
- `vscode/src/views/SidebarWebviewProvider.ts`
- `vscode/src/views/SidebarCssBuilder.ts`
- `vscode/src/views/SidebarMessages.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Memory reference ID clickable to copy with toast feedback in VS Code detail panel</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The memory detail panel showed a reference identifier in the page title but it was a static label with no copy interaction, inconsistent with the click-to-copy behavior being added to the sidebar.

**💡 Decisions Behind the Code**

- **`navigator.clipboard` directly in the detail panel**: The detail panel already demonstrated that `navigator.clipboard.writeText` works — the existing "Copy Markdown" button uses it. Routing through the extension host via a message would add unnecessary complexity for no gain. The same optimistic toast pattern is used: the callback fires on both resolve and reject, so the user always sees feedback.
- **Data attribute carries the raw ID, display text carries the colon**: Separating the copyable value from the display text keeps the copy behavior clean — users copy "JM-142" not "JM-142:". This also avoids any string manipulation in the click handler.

**✅ What Was Implemented**

- In `SummaryHtmlBuilder.ts`, the reference identifier span was extended with a `title` attribute ("Memory ID — click to copy") and a `data-copy-memory-id` attribute carrying the raw identifier without the trailing colon. Tests in `SummaryHtmlBuilder.test.ts` were updated to assert on these attributes.
- In `SummaryScriptBuilder.ts`, a `querySelectorAll` listener was added for `.page-title-ref` elements. On click it reads the `data-copy-memory-id` attribute and writes it to the clipboard via `navigator.clipboard.writeText`, then calls `showMemoryCopyToast` regardless of success or failure.
- In `SummaryCssBuilder.ts`, the `.page-title-ref` rule gained `cursor: pointer` and a hover underline, and the same `.copy-toast` keyframe pattern used in the sidebar was added for the detail panel's toast node.

**📁 FILES**
- `vscode/src/views/SummaryHtmlBuilder.ts`
- `vscode/src/views/SummaryScriptBuilder.ts`
- `vscode/src/views/SummaryCssBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Memory reference ID clickable to copy with toast feedback in IntelliJ detail panel</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The IntelliJ plugin's memory detail panel displayed the reference identifier with a "click to copy" tooltip, but clicking it did nothing. The copy behavior existed only in VS Code, so the two editors advertised the same affordance but only one delivered it.

**💡 Decisions Behind the Code**

- **Mirroring VS Code exactly rather than inventing a new pattern**: The VS Code implementation was already tested and shipped. Reusing the same attribute name, the same lazy-toast creation pattern, and the same 1.5-second hide delay meant the two platforms would behave identically and the Kotlin changes could be validated by direct comparison rather than independent design review.
- **Lazy toast element creation in script rather than a static HTML element**: Injecting the toast div from JavaScript on first use keeps the HTML template clean and avoids the risk of the element being duplicated if the webview is reloaded. The timer handle is stored directly on the element so rapid repeated clicks correctly reset the hide delay without a separate tracking variable.

**✅ What Was Implemented**

- `SummaryHtmlBuilder.kt` was updated to add a `data-copy-memory-id` attribute carrying the raw identifier (no colon) to the clickable span, mirroring the attribute VS Code already used as the hook for its copy handler.
- `SummaryScriptBuilder.kt` gained a click handler that reads the attribute, writes the value to the clipboard, and calls a new `showMemoryCopyToast` function. The toast element is created lazily, appended to the document body, shown with a CSS class, and auto-hidden after 1.5 seconds — matching the VS Code interaction model.
- `SummaryCssBuilder.kt` received the supporting styles: `cursor: pointer` and a hover underline on the identifier span, plus `.copy-toast` / `.copy-toast.show` rules using the existing theme variables for background, border, and text color.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryHtmlBuilder.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilder.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryCssBuilder.kt`

</blockquote>
</details>
<details>
<summary><strong>07 · JM-number reference badge added to synced memory titles and sidebar rows</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Every memory pushed to a Jolli Space needed a human-readable reference identifier — similar to a Linear ticket number — so users could quickly cite or locate a specific memory. The identifier had to appear both on the memory detail panel title and in the history sidebar list.

**💡 Decisions Behind the Code**

- **Reference number source from existing backend doc id**: The web backend already mints and returns a numeric doc id when a memory is pushed, and that value was already persisted on the memory record. Constructing `JM-<id>` from that existing number on the client required no backend changes, no new storage fields, and no coordination with the server team — the entire feature is a display-only addition.
- **Host-side formatting for the VS Code sidebar**: The VS Code sidebar runs as an isolated webview with no module system, so it cannot call a shared formatting function at runtime. Formatting the badge string on the host side and passing the finished value through the serialized data contract kept the webview script simple and avoided duplicating the `JM-` prefix string in two places.
- **Single prefix constant, two language ports**: Defining `MEMORY_REF_PREFIX = "JM-"` once in the TypeScript module and once in the Kotlin utility object (with a comment linking them) was chosen over a shared config file or code-generation approach. The prefix is stable and the two runtimes are completely separate, so the small duplication risk was judged lower-cost than adding a cross-language build step.

**✅ What Was Implemented**

- Created `cli/src/core/MemoryRefId.ts` as the single source of truth for the `JM-` prefix and the formatting logic. The function returns `undefined` for memories that have not yet been synced (missing, zero, or non-integer doc id), so unsynced rows render no badge at that stage. A Kotlin mirror (`SummaryUtils.formatMemoryRefId`) was added for the IntelliJ plugin with identical semantics.
- Updated the VS Code detail panel (`vscode/src/views/SummaryHtmlBuilder.ts`) and the IntelliJ detail panel (`intellij/src/main/kotlin/.../SummaryHtmlBuilder.kt`) to prepend a muted monospace `JM-<id>:` span before the commit message inside the page title heading. CSS rules (`.page-title-ref`) were added to both style builders to render the badge in a secondary color without competing with the commit message.
- Threaded `memoryRefId` through the VS Code sidebar pipeline: `HistoryTreeProvider` formats the string on the host side and passes it via the serialized tree item type to the sidebar webview script, which renders a `.mem-ref` span before the commit label. Formatting is done on the host side rather than inside the webview script because the webview is a self-contained bundled string that cannot import modules.

**📁 FILES**
- `cli/src/core/MemoryRefId.ts`
- `vscode/src/providers/HistoryTreeProvider.ts`
- `vscode/src/views/SidebarMessages.ts`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryUtils.kt`

</blockquote>
</details>




---

*Generated by Jolli Memory · July 28, 2026 at 9:11 AM · via Anthropic*
<!-- jollimemory-summary-end -->