### PR TITLE
Add cwd sentinel channel to local-agent reentry guard & Show Memory Bank status in CLI and VS Code settings

### DIFF
--- a/cli/src/Api.test.ts
+++ b/cli/src/Api.test.ts
@@ -182,6 +182,10 @@ vi.mock("./install/Installer.js", () => ({
 		mostRecentSession: null,
 		summaryCount: 0,
 		orphanBranch: "jollimemory/summaries/v3",
+		// Required on StatusInfo — the real `getStatus` always resolves it, and the
+		// status renderer reads it unconditionally. Omitting it here made every
+		// test that relies on this default mock throw inside the Memory Bank row.
+		memoryBank: { kind: "orphan-only" },
 		sessionsBySource: {},
 	}),
 }));
@@ -1039,6 +1043,7 @@ describe("CLI", () => {
 
 		it("should display active session info", async () => {
 			vi.mocked(getStatus).mockResolvedValueOnce({
+				memoryBank: { kind: "orphan-only" },
 				enabled: true,
 				claudeHookInstalled: true,
 				gitHookInstalled: true,
@@ -1055,6 +1060,7 @@ describe("CLI", () => {
 
 		it("should print raw JSON when --json is passed", async () => {
 			const status = {
+				memoryBank: { kind: "orphan-only" } as const,
 				enabled: true,
 				claudeHookInstalled: true,
 				gitHookInstalled: true,
@@ -1073,6 +1079,7 @@ describe("CLI", () => {
 
 		it("should show hooks description with detected integrations", async () => {
 			vi.mocked(getStatus).mockResolvedValueOnce({
+				memoryBank: { kind: "orphan-only" },
 				enabled: true,
 				claudeHookInstalled: true,
 				gitHookInstalled: true,
@@ -1098,6 +1105,7 @@ describe("CLI", () => {
 
 		it("should show hooks as not installed when disabled", async () => {
 			vi.mocked(getStatus).mockResolvedValueOnce({
+				memoryBank: { kind: "orphan-only" },
 				enabled: false,
 				claudeHookInstalled: false,
 				gitHookInstalled: false,
@@ -1116,6 +1124,7 @@ describe("CLI", () => {
 
 		it("should show hook runtime in hooks line when hookSource is present", async () => {
 			vi.mocked(getStatus).mockResolvedValueOnce({
+				memoryBank: { kind: "orphan-only" },
 				enabled: true,
 				claudeHookInstalled: true,
 				gitHookInstalled: true,
@@ -1137,6 +1146,7 @@ describe("CLI", () => {
 		describe("integration rows", () => {
 			it("renders rows for all five integrations when detected, with session counts", async () => {
 				vi.mocked(getStatus).mockResolvedValueOnce({
+					memoryBank: { kind: "orphan-only" },
 					enabled: true,
 					claudeHookInstalled: true,
 					gitHookInstalled: true,
@@ -1179,6 +1189,7 @@ describe("CLI", () => {
 
 			it("renders 'detected but disabled' when an integration is turned off in config", async () => {
 				vi.mocked(getStatus).mockResolvedValueOnce({
+					memoryBank: { kind: "orphan-only" },
 					enabled: true,
 					claudeHookInstalled: false,
 					gitHookInstalled: true,
@@ -1208,6 +1219,7 @@ describe("CLI", () => {
 
 			it("renders 'hook not installed' for Gemini when detected+enabled but the AfterAgent hook is missing", async () => {
 				vi.mocked(getStatus).mockResolvedValueOnce({
+					memoryBank: { kind: "orphan-only" },
 					enabled: true,
 					claudeHookInstalled: false,
 					gitHookInstalled: true,
@@ -1228,6 +1240,7 @@ describe("CLI", () => {
 
 			it("renders 'unavailable — <kind>' for OpenCode when openCodeScanError is present", async () => {
 				vi.mocked(getStatus).mockResolvedValueOnce({
+					memoryBank: { kind: "orphan-only" },
 					enabled: true,
 					claudeHookInstalled: false,
 					gitHookInstalled: true,
@@ -1249,6 +1262,7 @@ describe("CLI", () => {
 
 			it("does NOT mark Cursor unavailable when only the IDE scan fails (healthy CLI must not be masked)", async () => {
 				vi.mocked(getStatus).mockResolvedValueOnce({
+					memoryBank: { kind: "orphan-only" },
 					enabled: true,
 					claudeHookInstalled: false,
 					gitHookInstalled: true,
@@ -1273,6 +1287,7 @@ describe("CLI", () => {
 
 			it("renders 'unavailable — <kind>' for Cursor only when BOTH IDE and CLI scans fail", async () => {
 				vi.mocked(getStatus).mockResolvedValueOnce({
+					memoryBank: { kind: "orphan-only" },
 					enabled: true,
 					claudeHookInstalled: false,
 					gitHookInstalled: true,
@@ -1296,6 +1311,7 @@ describe("CLI", () => {
 
 			it("does not print a row for an integration that was not detected", async () => {
 				vi.mocked(getStatus).mockResolvedValueOnce({
+					memoryBank: { kind: "orphan-only" },
 					enabled: true,
 					claudeHookInstalled: false,
 					gitHookInstalled: true,
@@ -4022,6 +4038,7 @@ describe("CLI", () => {
 
 		it("should display hook runtime without version when version is unknown", async () => {
 			vi.mocked(getStatus).mockResolvedValueOnce({
+				memoryBank: { kind: "orphan-only" },
 				enabled: true,
 				claudeHookInstalled: true,
 				gitHookInstalled: true,
@@ -4474,6 +4491,7 @@ describe("CLI", () => {
 			vi.mocked(inspectPlugins).mockReset();
 
 			vi.mocked(getStatus).mockResolvedValue({
+				memoryBank: { kind: "orphan-only" },
 				enabled: true,
 				claudeHookInstalled: overrides.claudeHookInstalled ?? true,
 				gitHookInstalled: overrides.gitHookInstalled ?? true,
@@ -6081,6 +6099,7 @@ describe("CLI", () => {
 			vi.mocked(traverseDistPaths).mockReset();
 
 			vi.mocked(getStatus).mockResolvedValue({
+				memoryBank: { kind: "orphan-only" },
 				enabled: true,
 				claudeHookInstalled: true,
 				gitHookInstalled: true,
@@ -6189,6 +6208,7 @@ describe("CLI", () => {
 	describe("status command — additional branches", () => {
 		it("should omit version suffix when hookVersion is 'unknown'", async () => {
 			vi.mocked(getStatus).mockResolvedValueOnce({
+				memoryBank: { kind: "orphan-only" },
 				enabled: true,
 				claudeHookInstalled: true,
 				gitHookInstalled: true,
@@ -6212,6 +6232,7 @@ describe("CLI", () => {
 
 		it("should show hook runtime without version when hookVersion is absent", async () => {
 			vi.mocked(getStatus).mockResolvedValueOnce({
+				memoryBank: { kind: "orphan-only" },
 				enabled: true,
 				claudeHookInstalled: true,
 				gitHookInstalled: true,

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -6,6 +6,7 @@
 
 import type { ClineScanError } from "./core/ClineTranscriptShared.js";
 import type { CopilotChatScanError } from "./core/CopilotChatTranscriptReader.js";
+import type { MemoryBankState } from "./core/KBTypes.js";
 import type { SqliteScanError } from "./core/SqliteHelpers.js";
 
 /**
@@ -1133,6 +1134,16 @@ export interface JolliMemoryConfig {
 	/** Absolute path to the user-chosen Memory Bank folder (mirrors orphan-branch
 	 *  artifacts to disk when storageMode is "folder" or "dual-write"). */
 	readonly localFolder?: string;
+	/**
+	 * Which `StorageProvider` the factories build (default: `"dual-write"`).
+	 * Any other value degrades to orphan-only — both `StorageFactory` and
+	 * `ReadStorageResolver` fall through to `OrphanBranchStorage` on an
+	 * unrecognized mode, so `resolveMemoryBankState` reports it as such.
+	 *
+	 * Declared here (rather than read as an untyped extra) because it is now
+	 * surfaced to users through the `Memory Bank:` status row.
+	 */
+	readonly storageMode?: "orphan" | "dual-write" | "folder";
 	/** OAuth auth token from browser login (stored by `jolli auth login`) */
 	readonly authToken?: string;
 	/**
@@ -1462,6 +1473,14 @@ export interface StatusInfo {
 	 * run on next opportunity (worker startup or explicit `jolli migrate`).
 	 */
 	readonly schemaV5?: "in-progress" | "completed" | "failed";
+	/**
+	 * Where folder-layer writes land — the `Memory Bank:` row in `jolli status`,
+	 * the MCP `status` tool, and the VS Code Settings → Memory Bank tab.
+	 *
+	 * Always present (unlike `schemaV5`): the whole point is that a degraded
+	 * folder layer used to be invisible, so "no field" must not be a state.
+	 */
+	readonly memoryBank: MemoryBankState;
 }
 
 /**

--- a/cli/src/commands/StatusCommand.test.ts
+++ b/cli/src/commands/StatusCommand.test.ts
@@ -93,6 +93,7 @@ const baseStatus: StatusInfo = {
 	activeSessions: 0,
 	mostRecentSession: null,
 	summaryCount: 0,
+	memoryBank: { kind: "orphan-only" },
 	orphanBranch: "jollimemory/summaries/v3",
 	sessionsBySource: {},
 };
@@ -499,6 +500,48 @@ describe("StatusCommand — Cursor integration row (merged IDE + CLI)", () => {
 		expect(out).toContain("unavailable");
 		expect(out).toContain("IDE scan failed (locked)");
 		expect(out).toContain("CLI scan failed (parse)");
+	});
+});
+
+describe("StatusCommand — Memory Bank row", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockLoadAuthToken.mockResolvedValue(null);
+		mockLoadConfigFromDir.mockResolvedValue({});
+		mockFrontDoor.mockResolvedValue({ status: "no_spaces" });
+		mockTenantOrigin.mockReturnValue(null);
+		mockLoadCache.mockResolvedValue(null);
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("prints the effective folder when the folder layer is live", async () => {
+		const out = await renderStatus({
+			...baseStatus,
+			memoryBank: { kind: "active", mode: "dual-write", folder: "/bank/widgets-2" },
+		});
+		// The RESOLVED folder, suffix and all — the configured parent would not
+		// answer "where did my memories actually go".
+		expect(out).toContain("Memory Bank:      /bank/widgets-2");
+	});
+
+	it("prints the blocker when the write-boundary gate degraded us to orphan-only", async () => {
+		// The regression this row exists for: before it, this state produced a
+		// `debug.log` line and nothing else, so a Memory Bank that stopped
+		// updating had no user-reachable cause.
+		const out = await renderStatus({
+			...baseStatus,
+			memoryBank: { kind: "degraded", blocker: "folder-inside-repo", parent: "/repo/bank" },
+		});
+		expect(out).toContain("Memory Bank:      Not writing");
+		expect(out).toContain("/repo/bank");
+	});
+
+	it("always prints the row, including in orphan-only mode", async () => {
+		const out = await renderStatus(baseStatus);
+		expect(out).toContain("Memory Bank:      Off");
 	});
 });
 

--- a/cli/src/commands/StatusCommand.ts
+++ b/cli/src/commands/StatusCommand.ts
@@ -19,6 +19,7 @@ import {
 } from "../core/JolliMemoryPushClient.js";
 import { resolveLlmCredentialSource } from "../core/LlmClient.js";
 import { localAgentToolLabel } from "../core/localagent/ToolMeta.js";
+import { describeMemoryBank } from "../core/MemoryBankStatusText.js";
 import { getGlobalConfigDir, loadConfigFromDir } from "../core/SessionTracker.js";
 import {
 	clearSpaceBindingCache,
@@ -618,6 +619,7 @@ export function registerStatusCommand(program: Command): void {
 			}
 
 			console.log(`  Stored memories:  ${status.summaryCount}`);
+			console.log(`  Memory Bank:      ${describeMemoryBank(status.memoryBank).text}`);
 			if (jolliSite) {
 				// `jolliSite` is the on-disk `jolliUrl`. Label it the live "Jolli
 				// Site" only when an on-disk credential actually backs it. We

--- a/cli/src/core/AgentReentry.test.ts
+++ b/cli/src/core/AgentReentry.test.ts
@@ -1,15 +1,111 @@
-import { describe, expect, it } from "vitest";
-import { isLocalAgentChild, LOCAL_AGENT_CHILD_ENV } from "./AgentReentry.js";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	createLocalAgentCwd,
+	isLocalAgentChild,
+	LOCAL_AGENT_CHILD_ENV,
+	LOCAL_AGENT_SENTINEL,
+	LOCAL_AGENT_TMP_PREFIX,
+} from "./AgentReentry.js";
+
+const created: string[] = [];
+
+afterEach(() => {
+	for (const dir of created.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+/** A plain temp dir with no sentinel — stands in for an arbitrary cwd. */
+function plainTempDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "jolli-reentry-test-"));
+	created.push(dir);
+	return dir;
+}
 
 describe("AgentReentry", () => {
-	it("is false when the sentinel is absent", () => {
-		expect(isLocalAgentChild({})).toBe(false);
+	describe("isLocalAgentChild — env channel", () => {
+		it("is false when neither channel signals", () => {
+			expect(isLocalAgentChild({}, plainTempDir())).toBe(false);
+		});
+
+		it("is true only for the exact '1' value the backend sets", () => {
+			const cwd = plainTempDir();
+			expect(isLocalAgentChild({ [LOCAL_AGENT_CHILD_ENV]: "1" }, cwd)).toBe(true);
+			// Guard against accidental truthiness of other values.
+			expect(isLocalAgentChild({ [LOCAL_AGENT_CHILD_ENV]: "0" }, cwd)).toBe(false);
+			expect(isLocalAgentChild({ [LOCAL_AGENT_CHILD_ENV]: "true" }, cwd)).toBe(false);
+		});
 	});
 
-	it("is true only for the exact '1' value the backend sets", () => {
-		expect(isLocalAgentChild({ [LOCAL_AGENT_CHILD_ENV]: "1" })).toBe(true);
-		// Guard against accidental truthiness of other values.
-		expect(isLocalAgentChild({ [LOCAL_AGENT_CHILD_ENV]: "0" })).toBe(false);
-		expect(isLocalAgentChild({ [LOCAL_AGENT_CHILD_ENV]: "true" })).toBe(false);
+	describe("isLocalAgentChild — cwd sentinel channel", () => {
+		// Codex spawns MCP servers with an 11-variable allowlist (HOME LANG LOGNAME
+		// PATH PWD SHELL SHLVL TMPDIR USER _ __CF_USER_TEXT_ENCODING), so the env
+		// marker never reaches `jolli mcp`. cwd DOES survive. These are the
+		// regression tests for the 136 spurious Memory Bank repos that produced.
+		it("detects a local-agent cwd from the sentinel alone, with the env marker stripped", () => {
+			const cwd = createLocalAgentCwd();
+			created.push(cwd);
+			expect(isLocalAgentChild({}, cwd)).toBe(true);
+		});
+
+		it("does not treat an arbitrary temp dir as a local-agent cwd", () => {
+			// The prefix alone must not be the signal — a stale dir left by an older
+			// build (or a user's own `jolli-localagent-*` folder) is not a live child.
+			const dir = mkdtempSync(join(tmpdir(), LOCAL_AGENT_TMP_PREFIX));
+			created.push(dir);
+			rmSync(join(dir, LOCAL_AGENT_SENTINEL), { force: true });
+			expect(isLocalAgentChild({}, dir)).toBe(false);
+		});
+
+		it("ignores the sentinel entirely when no cwd is passed", () => {
+			// Opt-in by design: hook / `jolli enable` call sites are spawned by the
+			// agent CLI itself (env is reliable there) and pass no cwd, so the guard
+			// cannot be flipped by a caller that stubs `existsSync` wholesale for
+			// unrelated reasons — which is exactly what the hook test suites do.
+			const cwd = createLocalAgentCwd();
+			created.push(cwd);
+			const spy = vi.spyOn(process, "cwd").mockReturnValue(cwd);
+			try {
+				expect(isLocalAgentChild({})).toBe(false);
+				expect(spy).not.toHaveBeenCalled();
+			} finally {
+				spy.mockRestore();
+			}
+		});
+
+		it("does not walk up to a parent's sentinel", () => {
+			// Scoped to the cwd itself: a sentinel higher up must not silently
+			// disable jollimemory for every repo nested beneath it.
+			const parent = createLocalAgentCwd();
+			created.push(parent);
+			const child = join(parent, "nested");
+			mkdtempSync(join(parent, "nested-"));
+			expect(isLocalAgentChild({}, parent)).toBe(true);
+			expect(isLocalAgentChild({}, `${child}-does-not-exist`)).toBe(false);
+		});
+	});
+
+	describe("createLocalAgentCwd", () => {
+		it("creates a fresh prefixed dir under tmpdir carrying the sentinel", () => {
+			const cwd = createLocalAgentCwd();
+			created.push(cwd);
+			expect(cwd.startsWith(tmpdir())).toBe(true);
+			expect(basename(cwd).startsWith(LOCAL_AGENT_TMP_PREFIX)).toBe(true);
+			expect(existsSync(join(cwd, LOCAL_AGENT_SENTINEL))).toBe(true);
+		});
+
+		it("returns a distinct dir per call", () => {
+			const a = createLocalAgentCwd();
+			const b = createLocalAgentCwd();
+			created.push(a, b);
+			expect(a).not.toBe(b);
+		});
+
+		it("keeps the sentinel a dotfile so it cannot be read as agent context", () => {
+			// `claude` folds a cwd CLAUDE.md into its system prompt; the temp cwd is
+			// deliberately empty for that reason. A dotfile is inert to every backend.
+			expect(LOCAL_AGENT_SENTINEL.startsWith(".")).toBe(true);
+		});
 	});
 });

--- a/cli/src/core/AgentReentry.ts
+++ b/cli/src/core/AgentReentry.ts
@@ -1,30 +1,97 @@
 /**
  * Re-entrancy guard for the local-agent provider.
  *
- * The local-agent backend drives a locally-installed `claude` CLI. But most
- * jollimemory users also have jollimemory's own Claude integration installed
- * (the `jolli` Claude Code plugin / hooks / MCP). Without a guard, the `claude`
- * that jollimemory spawns re-triggers jollimemory against the throwaway temp
- * cwd — the plugin's SessionStart hook runs `jolli enable`, a Stop hook records
- * a session, etc. — which historically claimed a spurious Memory Bank "repo"
- * named after the temp dir (one per summary call).
+ * The local-agent backend drives a locally-installed agent CLI (`claude`,
+ * `codex`, `cursor-agent`, `opencode`). But most jollimemory users also have
+ * jollimemory's own integration installed for those same hosts (hooks, the
+ * `jolli` plugin, the globally-registered `jolli mcp` server). Without a guard,
+ * the CLI that jollimemory spawns re-triggers jollimemory against the throwaway
+ * temp cwd — a SessionStart hook runs `jolli enable`, the host boots
+ * `jolli mcp`, etc. — which claims a spurious Memory Bank "repo" named after
+ * the temp dir, once per summary call.
  *
- * The backend sets {@link LOCAL_AGENT_CHILD_ENV} on the spawned child. Because
- * child processes inherit their parent's environment, every hook / CLI process
- * that the nested `claude` itself spawns also sees it. Each jollimemory entry
- * point that a nested `claude` could re-trigger checks {@link isLocalAgentChild}
- * and no-ops, cutting the recursion at the source — independent of whether the
- * temp cwd happens to be a git repo or which hook modes a future `claude`
- * fires.
+ * ## Two independent channels, because env alone is not enough
+ *
+ * {@link LOCAL_AGENT_CHILD_ENV} covers everything the agent CLI spawns *itself*
+ * (hooks inherit env). It does NOT survive an env-sanitizing host: Codex spawns
+ * MCP servers with an 11-variable allowlist — `HOME LANG LOGNAME PATH PWD SHELL
+ * SHLVL TMPDIR USER _ __CF_USER_TEXT_ENCODING` — so `jolli mcp` starts with the
+ * marker stripped. That is what produced 136 stray `jolli-localagent-…` folders
+ * under the user's Memory Bank after the env-only guard was already in place.
+ *
+ * {@link LOCAL_AGENT_SENTINEL} closes that hole: the temp cwd itself carries a
+ * marker file, and cwd is the one thing every host preserves (Codex is even
+ * handed it explicitly via `-C`). Any future host with its own env policy is
+ * covered without a new special case.
+ *
+ * Each jollimemory entry point a nested agent could re-trigger checks
+ * {@link isLocalAgentChild} and no-ops, cutting the recursion at the source.
+ * The write-boundary gate in `KBPathResolver.isClaimableProject` is the backstop
+ * for anything that still slips through — a guard is only as good as its
+ * coverage, and a temp cwd is not a git repo either way.
  */
+
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 /** Env var marking a process spawned (directly or transitively) by the local-agent backend. */
 export const LOCAL_AGENT_CHILD_ENV = "JOLLI_LOCAL_AGENT_CHILD";
 
 /**
- * True when the current process descends from a local-agent `claude` spawn and
- * must not re-enter jollimemory (skip hooks / enable / storage init).
+ * Marker file written into the local-agent temp cwd. A dotfile on purpose: the
+ * temp cwd is kept otherwise empty because `claude` folds a cwd `CLAUDE.md`
+ * into its system prompt, and a dotfile is inert to every backend.
  */
-export function isLocalAgentChild(env: NodeJS.ProcessEnv = process.env): boolean {
-	return env[LOCAL_AGENT_CHILD_ENV] === "1";
+export const LOCAL_AGENT_SENTINEL = ".jolli-local-agent-child";
+
+/**
+ * Prefix for the local-agent temp cwd. Shared with `LlmClient.callLocalAgent`,
+ * which recognizes (and safely removes) only directories created here.
+ */
+export const LOCAL_AGENT_TMP_PREFIX = "jolli-localagent-";
+
+/**
+ * Creates the throwaway cwd a local-agent spawn runs in, carrying the sentinel.
+ *
+ * Every backend goes through this one function so a future fifth backend cannot
+ * create a temp cwd that forgets the marker — the failure mode that leaks a
+ * permanent Memory Bank folder per call, silently and unrecoverably.
+ *
+ * A fresh empty cwd is required in the first place because agent CLIs
+ * auto-discover instruction files (`CLAUDE.md`, `AGENTS.md`) from cwd and fold
+ * them into the system prompt; running in the repo would pollute the summary
+ * and burn tokens. Removed again by `LlmClient.callLocalAgent`.
+ */
+export function createLocalAgentCwd(): string {
+	const cwd = mkdtempSync(join(tmpdir(), LOCAL_AGENT_TMP_PREFIX));
+	writeFileSync(join(cwd, LOCAL_AGENT_SENTINEL), "", "utf-8");
+	return cwd;
+}
+
+/**
+ * True when the current process descends from a local-agent spawn and must not
+ * re-enter jollimemory (skip hooks / enable / storage init).
+ *
+ * `cwd` is **opt-in**, and the split is deliberate:
+ *
+ *  - **Hooks / `jolli enable` / plugin bootstrap** are spawned by the agent CLI
+ *    itself, which is our own direct child with the env we set — env is reliable
+ *    there, so they call this with no `cwd` and stay env-only.
+ *  - **`jolli mcp` is spawned by the HOST**, not by our child, so the host's env
+ *    policy applies and the marker can vanish. That call site passes `cwd`
+ *    explicitly to consult the sentinel.
+ *
+ * Keeping the fs probe opt-in also means the guard cannot be flipped by a caller
+ * (or a test) that stubs `existsSync` wholesale for unrelated reasons.
+ *
+ * Checks `cwd` itself and deliberately does NOT walk up to a parent: a stray
+ * sentinel higher in the tree would otherwise silently disable jollimemory for
+ * every repo nested beneath it. The backends control cwd exactly, and hosts
+ * spawn their MCP servers in that same cwd (verified for Codex: actual process
+ * cwd equals the `-C` directory), so the narrower check is the sufficient one.
+ */
+export function isLocalAgentChild(env: NodeJS.ProcessEnv = process.env, cwd?: string): boolean {
+	if (env[LOCAL_AGENT_CHILD_ENV] === "1") return true;
+	return cwd !== undefined && existsSync(join(cwd, LOCAL_AGENT_SENTINEL));
 }

--- a/cli/src/core/IngestPipeline.ts
+++ b/cli/src/core/IngestPipeline.ts
@@ -169,9 +169,21 @@ export async function ingestPendingBatch(cwd: string, config: LlmConfig, opts?: 
 				log.error("Reconcile truncated for topic %s -- keeping old page, holding sources", slug);
 				return { kind: "failed", slug, refs: [...assignment.refs], code: INGEST_CODES.RECONCILE_TRUNCATED };
 			}
-			const parsed = parseReconciledPage(result.text ?? "", slug, title);
+			const text = result.text ?? "";
+			const parsed = parseReconciledPage(text, slug, title);
 			if (!parsed) {
-				log.error("Reconcile produced no topic block for %s -- keeping old page, holding sources", slug);
+				// Name the generator and quote what it actually said. An agentic
+				// local-agent CLI can "answer" a structured-output prompt by using its
+				// own tools (writing the page to a file) and replying with a one-line
+				// receipt — indistinguishable from a truncation or a model flub unless
+				// the reply itself is in the log.
+				log.error(
+					"Reconcile produced no topic block for %s (provider=%s tool=%s) -- keeping old page, holding sources; reply began: %s",
+					slug,
+					String(config.aiProvider),
+					String(config.localAgentTool),
+					JSON.stringify(text.slice(0, 200)),
+				);
 				return { kind: "failed", slug, refs: [...assignment.refs], code: INGEST_CODES.RECONCILE_PARSE_FAILED };
 			}
 

--- a/cli/src/core/KBPathResolver.test.ts
+++ b/cli/src/core/KBPathResolver.test.ts
@@ -5,6 +5,7 @@ import { basename, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setManuallyDisabled } from "../Logger.js";
 import * as Subprocess from "../util/Subprocess.js";
+import { createLocalAgentCwd } from "./AgentReentry.js";
 import {
 	archiveKBFolder,
 	assertValidLocalFolder,
@@ -15,6 +16,7 @@ import {
 	getRemoteUrl,
 	InvalidLocalFolderError,
 	initializeKBFolder,
+	isClaimableProject,
 	isValidLocalFolder,
 	peekKBPath,
 	resolveKBPath,
@@ -1014,6 +1016,94 @@ esac
 			expect(archiveKBFolder(kbRoot, tempDir)).toBeNull();
 			// The original folder is left untouched on failure.
 			expect(existsSync(kbRoot)).toBe(true);
+		});
+	});
+
+	// The write-boundary gate. `resolveKBPath` claims a folder for whatever
+	// repoName it is handed, so every caller that derives that name from a cwd
+	// (`extractRepoName`) is a potential pollution source: a nested agent's
+	// throwaway temp cwd, a probe script, `cd /tmp && jolli …`, or the Memory
+	// Bank folder itself. This predicate is the single gate those callers pass
+	// through, so coverage no longer depends on every entry point remembering
+	// its own re-entrancy check.
+	describe("isClaimableProject", () => {
+		// Kept separate from `tempDir` (which other blocks use as the Memory Bank
+		// parent) so a repo can live *outside* the parent in the accept cases.
+		let kbParent: string;
+
+		beforeEach(() => {
+			kbParent = makeTmpDir();
+		});
+
+		afterEach(() => {
+			rmrf(kbParent);
+		});
+
+		/** A git worktree at `dir` — the only shape that may claim a folder. */
+		function initRepo(dir: string): string {
+			mkdirSync(dir, { recursive: true });
+			git(dir, ["init"]);
+			return dir;
+		}
+
+		it("accepts a real git worktree", () => {
+			const repo = initRepo(join(tempDir, "real-repo"));
+			expect(isClaimableProject(repo, kbParent)).toBe(true);
+		});
+
+		it("accepts a subdirectory of a git worktree", () => {
+			// Monorepo package dirs and `git worktree` checkouts both land here.
+			const repo = initRepo(join(tempDir, "mono"));
+			const pkg = join(repo, "packages", "web");
+			mkdirSync(pkg, { recursive: true });
+			expect(isClaimableProject(pkg, kbParent)).toBe(true);
+		});
+
+		it("rejects a directory that is not inside any git worktree", () => {
+			// This is the gate that kills `jolli-localagent-*` and `jolli-probe-*`:
+			// the local-agent temp cwd is deliberately a bare empty dir, which is
+			// exactly why `codex exec` needs --skip-git-repo-check to run there.
+			const plain = join(tempDir, "not-a-repo");
+			mkdirSync(plain, { recursive: true });
+			expect(isClaimableProject(plain, kbParent)).toBe(false);
+		});
+
+		it("rejects a local-agent temp cwd", () => {
+			const cwd = createLocalAgentCwd();
+			try {
+				expect(isClaimableProject(cwd, kbParent)).toBe(false);
+			} finally {
+				rmrf(cwd);
+			}
+		});
+
+		it("rejects the filesystem root, whose basename is empty", () => {
+			// `extractRepoName` falls back to the literal "unknown" here, which is
+			// where the stray `unknown/` folder came from.
+			expect(isClaimableProject("/", kbParent)).toBe(false);
+		});
+
+		it("rejects the Memory Bank parent itself even though it is a git repo", () => {
+			// The Memory Bank folder is itself a git repo (for peer sync), so the
+			// git gate alone lets it through and it claims a folder named after
+			// itself — the stray `memorybank-prod/` inside `memorybank-prod/`.
+			initRepo(kbParent);
+			expect(isClaimableProject(kbParent, kbParent)).toBe(false);
+		});
+
+		it("rejects a repo nested inside the Memory Bank parent", () => {
+			const nested = initRepo(join(kbParent, "some-repo"));
+			expect(isClaimableProject(nested, kbParent)).toBe(false);
+		});
+
+		it("compares the Memory Bank parent path case-insensitively on darwin/win32", () => {
+			// Guards the `/Users/x/Documents/Bank` vs `/users/x/documents/bank`
+			// mismatch that would let a nested repo slip past the parent gate.
+			const nested = initRepo(join(kbParent, "cased-repo"));
+			// Case-insensitive platforms see through the upper-cased parent and reject;
+			// case-sensitive ones treat it as an unrelated path and allow the claim.
+			const caseInsensitive = process.platform === "darwin" || process.platform === "win32";
+			expect(isClaimableProject(nested, kbParent.toUpperCase())).toBe(!caseInsensitive);
 		});
 	});
 });

--- a/cli/src/core/KBPathResolver.test.ts
+++ b/cli/src/core/KBPathResolver.test.ts
@@ -9,6 +9,7 @@ import { createLocalAgentCwd } from "./AgentReentry.js";
 import {
 	archiveKBFolder,
 	assertValidLocalFolder,
+	checkClaimable,
 	extractRepoName,
 	findFreshKBPath,
 	findRepoFolders,
@@ -20,6 +21,7 @@ import {
 	isValidLocalFolder,
 	peekKBPath,
 	resolveKBPath,
+	resolveMemoryBankState,
 } from "./KBPathResolver.js";
 
 function git(cwd: string, args: string[]): void {
@@ -1091,19 +1093,130 @@ esac
 			expect(isClaimableProject(kbParent, kbParent)).toBe(false);
 		});
 
-		it("rejects a repo nested inside the Memory Bank parent", () => {
-			const nested = initRepo(join(kbParent, "some-repo"));
-			expect(isClaimableProject(nested, kbParent)).toBe(false);
+		it("rejects a cwd inside the Memory Bank's own git repo", () => {
+			// A per-repo `<bank>/<repo>/` folder is not its own repo — it belongs to
+			// the bank's worktree, so `mainWorktreeRoot` resolves to the bank and the
+			// same overlap check catches it. Without this, `extractRepoName` would
+			// name the folder after the BANK and claim `<bank>/<bankname>/`.
+			initRepo(kbParent);
+			const perRepoFolder = join(kbParent, "some-repo");
+			mkdirSync(perRepoFolder, { recursive: true });
+			expect(isClaimableProject(perRepoFolder, kbParent)).toBe(false);
 		});
 
-		it("compares the Memory Bank parent path case-insensitively on darwin/win32", () => {
+		it("accepts a repo that merely sits under the Memory Bank parent", () => {
+			// The regression this guards: `localFolder` pointed at a directory that
+			// also holds checkouts (~/Documents, a Dropbox root) used to reject every
+			// repo beneath it — silently degrading the whole folder layer to
+			// orphan-only. The repo has its own git identity and the bank is NOT
+			// inside it, so `resolveKBPath` can give it a sibling folder safely.
+			const nested = initRepo(join(kbParent, "some-repo"));
+			expect(isClaimableProject(nested, kbParent)).toBe(true);
+		});
+
+		it("rejects a Memory Bank folder configured INSIDE the repo", () => {
+			// Not caught by the old cwd-under-parent test, and the worse failure of
+			// the two: claiming would scatter generated Markdown through the working
+			// tree of the repo being summarized.
+			const repo = initRepo(join(tempDir, "self-hosting-repo"));
+			expect(isClaimableProject(repo, join(repo, "memory-bank"))).toBe(false);
+		});
+
+		it("compares the overlap case-insensitively on darwin/win32", () => {
 			// Guards the `/Users/x/Documents/Bank` vs `/users/x/documents/bank`
-			// mismatch that would let a nested repo slip past the parent gate.
-			const nested = initRepo(join(kbParent, "cased-repo"));
-			// Case-insensitive platforms see through the upper-cased parent and reject;
+			// mismatch that would let an in-repo bank slip past the overlap check.
+			const repo = initRepo(join(tempDir, "cased-repo"));
+			const insideBank = join(repo, "bank");
+			// Case-insensitive platforms see through the upper-cased path and reject;
 			// case-sensitive ones treat it as an unrelated path and allow the claim.
 			const caseInsensitive = process.platform === "darwin" || process.platform === "win32";
-			expect(isClaimableProject(nested, kbParent.toUpperCase())).toBe(!caseInsensitive);
+			expect(isClaimableProject(repo, insideBank.toUpperCase())).toBe(!caseInsensitive);
+		});
+
+		it("reports the blocker so callers can explain the degradation", () => {
+			const plain = join(tempDir, "verdict-not-a-repo");
+			mkdirSync(plain, { recursive: true });
+			expect(checkClaimable(plain, kbParent)).toEqual({
+				claimable: false,
+				blocker: "not-a-project",
+			});
+
+			const repo = initRepo(join(tempDir, "verdict-repo"));
+			expect(checkClaimable(repo, join(repo, "bank"))).toEqual({
+				claimable: false,
+				blocker: "folder-inside-repo",
+			});
+			expect(checkClaimable(repo, kbParent)).toEqual({ claimable: true });
+		});
+	});
+
+	describe("resolveMemoryBankState", () => {
+		let kbParent: string;
+
+		beforeEach(() => {
+			kbParent = makeTmpDir();
+		});
+
+		afterEach(() => {
+			rmrf(kbParent);
+		});
+
+		function initRepo(dir: string): string {
+			mkdirSync(dir, { recursive: true });
+			git(dir, ["init"]);
+			return dir;
+		}
+
+		it("reports orphan-only for storageMode=orphan without consulting git", () => {
+			// Cheap by design: the factories skip the gate entirely in orphan mode,
+			// so status must not pay for a git subprocess either. A non-repo path
+			// still reports orphan-only rather than the not-a-project blocker.
+			const plain = join(tempDir, "mbs-not-a-repo");
+			mkdirSync(plain, { recursive: true });
+			expect(resolveMemoryBankState(plain, { storageMode: "orphan", localFolder: kbParent })).toEqual({
+				kind: "orphan-only",
+			});
+		});
+
+		it("treats an unrecognized storageMode as orphan-only", () => {
+			// Mirrors both factories, whose switch default falls through to
+			// OrphanBranchStorage — status must not claim a folder is live.
+			const repo = initRepo(join(tempDir, "mbs-typo-mode"));
+			expect(resolveMemoryBankState(repo, { storageMode: "dual-wrote", localFolder: kbParent })).toEqual({
+				kind: "orphan-only",
+			});
+		});
+
+		it("reports the resolved folder for a claimable project", () => {
+			const repo = initRepo(join(tempDir, "mbs-live-repo"));
+			expect(resolveMemoryBankState(repo, { localFolder: kbParent })).toEqual({
+				kind: "active",
+				mode: "dual-write",
+				folder: join(kbParent, "mbs-live-repo"),
+			});
+		});
+
+		it("does NOT create the folder it reports (peek, not resolve)", () => {
+			// The whole point of routing through peekKBPath: asking where the Memory
+			// Bank is must not be what brings it into existence.
+			const repo = initRepo(join(tempDir, "mbs-peek-repo"));
+			const state = resolveMemoryBankState(repo, { storageMode: "folder", localFolder: kbParent });
+			expect(state).toEqual({
+				kind: "active",
+				mode: "folder",
+				folder: join(kbParent, "mbs-peek-repo"),
+			});
+			expect(existsSync(join(kbParent, "mbs-peek-repo"))).toBe(false);
+		});
+
+		it("reports the blocker and the parent when the gate refuses", () => {
+			const plain = join(tempDir, "mbs-degraded");
+			mkdirSync(plain, { recursive: true });
+			expect(resolveMemoryBankState(plain, { localFolder: kbParent })).toEqual({
+				kind: "degraded",
+				blocker: "not-a-project",
+				parent: kbParent,
+			});
 		});
 	});
 });

--- a/cli/src/core/KBPathResolver.ts
+++ b/cli/src/core/KBPathResolver.ts
@@ -23,6 +23,7 @@ import { createLogger, isManuallyDisabled } from "../Logger.js";
 import { execFileSyncHidden } from "../util/Subprocess.js";
 import type { KBConfig } from "./KBTypes.js";
 import { MetadataManager } from "./MetadataManager.js";
+import { normalizePathForCompare } from "./PathUtils.js";
 
 const log = createLogger("KBPathResolver");
 
@@ -93,6 +94,19 @@ export function assertValidLocalFolder(customPath: string | undefined): void {
  * fully-populated config (`remoteUrl` + `repoName`) on return — except when
  * the project is manually disabled, in which case no identity is written and
  * the returned path may be unclaimed (disabled mode must not touch disk).
+ *
+ * **Precondition: callers whose `repoName` is derived from an ambient cwd MUST
+ * first pass that cwd through {@link isClaimableProject}.** This function
+ * creates directories and writes files, so calling it from a non-project cwd
+ * permanently materializes `<localFolder>/<basename>/`. The precondition can't
+ * be enforced in here because the useful response to a non-claimable cwd is
+ * "use a different StorageProvider", which only the caller can pick. Current
+ * gated callers: `StorageFactory.createStorage`, `ReadStorageResolver`
+ * (via `createFolderStorage`), `MemoryBankScanner.tryResolveKBRoot`. Callers
+ * exempt because their path comes from the user rather than a cwd guess:
+ * `SyncCommand`, `MigrateMemoryBankCommand`, VS Code's repoint flow.
+ *
+ * Use {@link peekKBPath} when you only need the path and must not claim it.
  */
 export function resolveKBPath(repoName: string, remoteUrl: string | null, customPath?: string): string {
 	const parent = resolveKbParent(customPath);
@@ -308,6 +322,56 @@ export function extractRepoName(projectPath: string): string {
 	}
 
 	return basename(projectPath) || "unknown";
+}
+
+/**
+ * Whether `projectPath` may claim a Memory Bank folder at all.
+ *
+ * The write-boundary gate for `resolveKBPath`. That function is named like a
+ * pure resolver but *claims* the folder it returns (`writeKBIdentity` →
+ * `MetadataManager.ensure()`), and its `repoName` argument is derived by
+ * `extractRepoName` from whatever cwd the caller happened to have. So any
+ * jollimemory process running in a directory that is not a real project
+ * permanently materializes a junk `<localFolder>/<basename>/` folder — and the
+ * per-entry-point re-entrancy guards are a whack-a-mole defense that only holds
+ * while every entry point remembers to check (see AgentReentry: Codex strips the
+ * env marker, so `jolli mcp` claimed one folder per local-agent call).
+ *
+ * Two conditions, each mapping to a class of junk folders observed in the wild:
+ *
+ *  1. **Not inside a git worktree.** Covers every agent temp cwd
+ *     (`jolli-localagent-*`, `jolli-probe-*` — bare empty dirs, which is exactly
+ *     why `codex exec` needs `--skip-git-repo-check` to run there), plus
+ *     `cd /tmp && jolli …` (`tmp/`) and the empty-basename `"unknown"` fallback.
+ *  2. **At or inside the Memory Bank parent.** The Memory Bank folder is itself a
+ *     git repo (for peer sync), so condition 1 lets it through and it claims a
+ *     folder named after itself, nested one level down.
+ *
+ * Deliberately NOT gated on "under a temp root": every observed case is already
+ * covered by condition 1, while rejecting `tmpdir()` wholesale would break the
+ * legitimate case of a repo checked out under `/tmp` (and much of this repo's
+ * own real-git test suite).
+ *
+ * A `false` here means callers degrade to orphan-branch-only storage rather than
+ * touching the Memory Bank folder — no writes, no directories, nothing to clean
+ * up later.
+ */
+export function isClaimableProject(projectPath: string, customPath?: string): boolean {
+	if (!basename(projectPath)) return false;
+	if (!tryGitCommand(projectPath, ["rev-parse", "--git-dir"])) return false;
+
+	// `resolveKbParent` falls back to the default parent for a missing/unsafe
+	// customPath, matching what `resolveKBPath` would actually use.
+	let parent: string;
+	try {
+		parent = resolveKbParent(customPath);
+	} catch {
+		// An unusable parent can't be claimed into either way.
+		return false;
+	}
+	const project = normalizePathForCompare(projectPath);
+	const bank = normalizePathForCompare(parent);
+	return project !== bank && !project.startsWith(`${bank}/`);
 }
 
 // The plumbing commands this helper runs (`config --get`, `rev-parse`,

--- a/cli/src/core/KBPathResolver.ts
+++ b/cli/src/core/KBPathResolver.ts
@@ -21,9 +21,9 @@ import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join } from "node:path";
 import { createLogger, isManuallyDisabled } from "../Logger.js";
 import { execFileSyncHidden } from "../util/Subprocess.js";
-import type { KBConfig } from "./KBTypes.js";
+import type { ClaimVerdict, KBConfig, MemoryBankConfig, MemoryBankState } from "./KBTypes.js";
 import { MetadataManager } from "./MetadataManager.js";
-import { normalizePathForCompare } from "./PathUtils.js";
+import { isPathInside } from "./PathUtils.js";
 
 const log = createLogger("KBPathResolver");
 
@@ -309,23 +309,41 @@ export function extractRepoName(projectPath: string): string {
 		if (m?.[1]) return m[1];
 	}
 
-	const commonDir = tryGitCommand(projectPath, ["rev-parse", "--git-common-dir"]);
-	if (commonDir) {
-		const abs = isAbsolute(commonDir) ? commonDir : join(projectPath, commonDir);
-		const mainRepoDir = dirname(abs);
-		// `mainRepoDir` is the parent of `.git` — i.e. the main repo's
-		// working tree. Skip the filesystem-root / cwd-marker cases so a
-		// `basename` of `/` or `.` doesn't slip through.
-		if (mainRepoDir && mainRepoDir !== "/" && mainRepoDir !== ".") {
-			return basename(mainRepoDir);
-		}
-	}
+	const mainRepoDir = mainWorktreeRoot(projectPath);
+	if (mainRepoDir) return basename(mainRepoDir);
 
 	return basename(projectPath) || "unknown";
 }
 
 /**
- * Whether `projectPath` may claim a Memory Bank folder at all.
+ * The **main** worktree's root directory for `projectPath`, or `null` when
+ * `projectPath` isn't inside a git worktree at all.
+ *
+ * `git rev-parse --git-common-dir` deliberately, not `--git-dir`: from a linked
+ * `git worktree` checkout the former answers the *main* repo's `.git`, so every
+ * worktree of a repo resolves to one identity — the same anchor `RepoProfile`
+ * uses for repo-wide state.
+ *
+ * The answer is relative **to the cwd** from a subdirectory (`../../.git`) and a
+ * bare `.git` at the worktree root; `join` normalizes both, and the absolute
+ * answer a linked worktree gives passes through untouched.
+ *
+ * `null` for the degenerate `/` and `.` results so a `basename` of the
+ * filesystem root can't masquerade as a repo name.
+ *
+ * Shared by `extractRepoName` (repo identity) and `checkClaimable` (write
+ * boundary) so both agree on what "this project" is.
+ */
+function mainWorktreeRoot(projectPath: string): string | null {
+	const commonDir = tryGitCommand(projectPath, ["rev-parse", "--git-common-dir"]);
+	if (!commonDir) return null;
+	const abs = isAbsolute(commonDir) ? commonDir : join(projectPath, commonDir);
+	const root = dirname(abs);
+	return root && root !== "/" && root !== "." ? root : null;
+}
+
+/**
+ * Whether `projectPath` may claim a Memory Bank folder at all, and if not, why.
  *
  * The write-boundary gate for `resolveKBPath`. That function is named like a
  * pure resolver but *claims* the folder it returns (`writeKBIdentity` →
@@ -339,26 +357,48 @@ export function extractRepoName(projectPath: string): string {
  *
  * Two conditions, each mapping to a class of junk folders observed in the wild:
  *
- *  1. **Not inside a git worktree.** Covers every agent temp cwd
- *     (`jolli-localagent-*`, `jolli-probe-*` — bare empty dirs, which is exactly
- *     why `codex exec` needs `--skip-git-repo-check` to run there), plus
+ *  1. **Not inside a git worktree** (`"not-a-project"`). Covers every agent temp
+ *     cwd (`jolli-localagent-*`, `jolli-probe-*` — bare empty dirs, which is
+ *     exactly why `codex exec` needs `--skip-git-repo-check` to run there), plus
  *     `cd /tmp && jolli …` (`tmp/`) and the empty-basename `"unknown"` fallback.
- *  2. **At or inside the Memory Bank parent.** The Memory Bank folder is itself a
- *     git repo (for peer sync), so condition 1 lets it through and it claims a
- *     folder named after itself, nested one level down.
+ *  2. **The Memory Bank folder sits at or inside this project's own working
+ *     tree** (`"folder-inside-repo"`) — i.e. claiming would write Memory Bank
+ *     content into the repo we are summarizing. The observed instance is the
+ *     Memory Bank folder being itself a git repo (for peer sync): condition 1
+ *     lets it through, `mainWorktreeRoot` resolves to the bank, and it claims a
+ *     folder named after itself nested one level down (`memorybank-prod/
+ *     memorybank-prod/`). Any cwd *inside* that bank repo — including a
+ *     `<bank>/<repo>/` per-repo folder — resolves to the same worktree root and
+ *     is caught by the same check.
+ *
+ * Condition 2 is scoped to the **project's worktree**, not to the bank parent as
+ * a bare path prefix. An earlier `projectPath` at-or-under-`parent` test read as
+ * equivalent but silently disabled the folder layer for an entire legitimate
+ * class of setup: `localFolder` pointed at a directory that also *contains*
+ * checkouts (`~/Documents`, a Dropbox/iCloud root) rejected every repo beneath
+ * it, degrading to orphan-only with nothing but a `debug.log` line to explain
+ * why the Memory Bank had stopped updating. A repo under the bank parent is
+ * fine: `resolveKBPath` gives it its own sibling `<parent>/<repoName>/` folder,
+ * and the `-N` suffix ladder handles the case where that name is already taken
+ * by the checkout itself. What is NOT fine is the bank living inside the repo,
+ * which is exactly what this check now tests — and it newly catches
+ * `localFolder` pointed *into* a source tree, which the old prefix test missed.
  *
  * Deliberately NOT gated on "under a temp root": every observed case is already
  * covered by condition 1, while rejecting `tmpdir()` wholesale would break the
  * legitimate case of a repo checked out under `/tmp` (and much of this repo's
  * own real-git test suite).
  *
- * A `false` here means callers degrade to orphan-branch-only storage rather than
- * touching the Memory Bank folder — no writes, no directories, nothing to clean
- * up later.
+ * A non-claimable verdict means callers degrade to orphan-branch-only storage
+ * rather than touching the Memory Bank folder — no writes, no directories,
+ * nothing to clean up later. Because that degradation is invisible by design,
+ * the blocker is reported to users via {@link resolveMemoryBankState}.
  */
-export function isClaimableProject(projectPath: string, customPath?: string): boolean {
-	if (!basename(projectPath)) return false;
-	if (!tryGitCommand(projectPath, ["rev-parse", "--git-dir"])) return false;
+export function checkClaimable(projectPath: string, customPath?: string): ClaimVerdict {
+	if (!basename(projectPath)) return { claimable: false, blocker: "not-a-project" };
+
+	const worktreeRoot = mainWorktreeRoot(projectPath);
+	if (!worktreeRoot) return { claimable: false, blocker: "not-a-project" };
 
 	// `resolveKbParent` falls back to the default parent for a missing/unsafe
 	// customPath, matching what `resolveKBPath` would actually use.
@@ -366,12 +406,62 @@ export function isClaimableProject(projectPath: string, customPath?: string): bo
 	try {
 		parent = resolveKbParent(customPath);
 	} catch {
-		// An unusable parent can't be claimed into either way.
-		return false;
+		// Only reachable when `homedir()` itself throws (no passwd entry for the
+		// uid): an unusable parent can't be claimed into either way.
+		return { claimable: false, blocker: "unresolvable-folder" };
 	}
-	const project = normalizePathForCompare(projectPath);
-	const bank = normalizePathForCompare(parent);
-	return project !== bank && !project.startsWith(`${bank}/`);
+
+	if (isPathInside(parent, worktreeRoot)) {
+		return { claimable: false, blocker: "folder-inside-repo" };
+	}
+	return { claimable: true };
+}
+
+/** Boolean projection of {@link checkClaimable} for the gate's call sites. */
+export function isClaimableProject(projectPath: string, customPath?: string): boolean {
+	return checkClaimable(projectPath, customPath).claimable;
+}
+
+/**
+ * Where folder-layer writes for `projectPath` will actually land — the data
+ * behind the `Memory Bank:` row in `jolli status` and the Settings → Memory Bank
+ * tab.
+ *
+ * Read-only by construction: resolves through {@link peekKBPath}, never
+ * `resolveKBPath`, so *displaying* the state cannot create the folder it is
+ * describing.
+ *
+ * `"orphan-only"` covers both an explicit `storageMode: "orphan"` and any
+ * unrecognized value, mirroring what the factories actually do — both
+ * `StorageFactory.createStorage` and `createReadStorage` fall through their
+ * switch to `OrphanBranchStorage`.
+ */
+export function resolveMemoryBankState(projectPath: string, config: MemoryBankConfig): MemoryBankState {
+	const mode = config.storageMode ?? "dual-write";
+	if (mode !== "dual-write" && mode !== "folder") return { kind: "orphan-only" };
+
+	const verdict = checkClaimable(projectPath, config.localFolder);
+	if (!verdict.claimable) {
+		return { kind: "degraded", blocker: verdict.blocker, ...safeKbParent(config.localFolder) };
+	}
+	return {
+		kind: "active",
+		mode,
+		folder: peekKBPath(extractRepoName(projectPath), getRemoteUrl(projectPath), config.localFolder),
+	};
+}
+
+/**
+ * `{ parent }` for the degraded state, or `{}` when the parent is exactly what
+ * couldn't be resolved (the `"unresolvable-folder"` blocker) — so the display
+ * omits the row rather than printing a path it had to invent.
+ */
+function safeKbParent(customPath?: string): { parent?: string } {
+	try {
+		return { parent: resolveKbParent(customPath) };
+	} catch {
+		return {};
+	}
 }
 
 // The plumbing commands this helper runs (`config --get`, `rev-parse`,

--- a/cli/src/core/KBTypes.ts
+++ b/cli/src/core/KBTypes.ts
@@ -56,6 +56,50 @@ export interface KBConfig {
 }
 
 /**
+ * Why `KBPathResolver.checkClaimable` refused to let a cwd claim a Memory Bank
+ * folder. Each member is user-facing — it is rendered verbatim-ish by the
+ * `Memory Bank:` status row and the Settings → Memory Bank tab, so a new member
+ * needs a display string in both places.
+ */
+export type ClaimBlocker =
+	/** Not inside a git worktree: an agent temp cwd, a bare `/tmp`, or `/`. */
+	| "not-a-project"
+	/** The Memory Bank folder is at or inside this project's own working tree. */
+	| "folder-inside-repo"
+	/** The configured folder couldn't be resolved at all (unusable `$HOME`). */
+	| "unresolvable-folder";
+
+/** Result of the write-boundary gate. */
+export type ClaimVerdict = { readonly claimable: true } | { readonly claimable: false; readonly blocker: ClaimBlocker };
+
+/** The two config keys `resolveMemoryBankState` needs, so it stays config-loader-free. */
+export interface MemoryBankConfig {
+	readonly storageMode?: string;
+	readonly localFolder?: string;
+}
+
+/**
+ * Whether folder-layer writes will actually land, and where.
+ *
+ * Exists because the write-boundary gate degrades **silently**: `StorageFactory`
+ * and `ReadStorageResolver` both fall back to orphan-only with nothing but a
+ * `debug.log` line, and `storageMode` was never user-visible anywhere. A Memory
+ * Bank folder that stopped updating (or never appeared) was therefore
+ * unattributable from the outside — the only symptom was staleness. This is the
+ * type that makes the fallback reportable.
+ */
+export type MemoryBankState =
+	/** `storageMode` is `"orphan"` (or unrecognized) — no folder layer by choice. */
+	| { readonly kind: "orphan-only" }
+	/** Folder writes land in `folder`. */
+	| { readonly kind: "active"; readonly mode: "dual-write" | "folder"; readonly folder: string }
+	/**
+	 * Folder layer wanted but refused by the write-boundary gate. `parent` is the
+	 * resolved Memory Bank parent, absent only for `"unresolvable-folder"`.
+	 */
+	| { readonly kind: "degraded"; readonly blocker: ClaimBlocker; readonly parent?: string };
+
+/**
  * .jolli/migration.json — tracks orphan→folder migration progress.
  * `"skipped"` is a transient return value used when the project is manually
  * disabled; it is never persisted to disk.

--- a/cli/src/core/LlmClient.ts
+++ b/cli/src/core/LlmClient.ts
@@ -13,10 +13,11 @@ import { basename } from "node:path";
 import Anthropic from "@anthropic-ai/sdk";
 import { createLogger } from "../Logger.js";
 import type { LlmCredentialSource, LocalAgentToolId } from "../Types.js";
+import { LOCAL_AGENT_TMP_PREFIX } from "./AgentReentry.js";
 import { JOLLI_CLIENT_HEADER } from "./ClientHeader.js";
 import { parseBaseUrl, parseJolliApiKey } from "./JolliApiUtils.js";
 import { getBackend, registerBackend } from "./localagent/BackendRegistry.js";
-import { ClaudeCodeBackend, LOCAL_AGENT_TMP_PREFIX } from "./localagent/ClaudeCodeBackend.js";
+import { ClaudeCodeBackend } from "./localagent/ClaudeCodeBackend.js";
 import { CodexBackend } from "./localagent/CodexBackend.js";
 import { CursorAgentBackend } from "./localagent/CursorAgentBackend.js";
 import { describeCandidate } from "./localagent/ExecutableResolver.js";
@@ -534,11 +535,11 @@ async function callLocalAgent(options: LlmCallOptions, source: LlmCredentialSour
 		);
 		throw err;
 	} finally {
-		// Only remove a cwd WE created (buildInvocation's mkdtemp under tmpdir with
-		// our prefix); callLocalAgent is backend-generic and tests inject stubs
+		// Only remove a cwd WE created (createLocalAgentCwd's mkdtemp under tmpdir
+		// with our prefix); callLocalAgent is backend-generic and tests inject stubs
 		// with arbitrary cwds (e.g. a bare "/tmp"), so a blind rmSync here could
 		// delete an unrelated directory. LOCAL_AGENT_TMP_PREFIX is the single
-		// source of truth shared with ClaudeCodeBackend.buildInvocation.
+		// source of truth shared with createLocalAgentCwd in AgentReentry.
 		if (invocation.cwd.startsWith(tmpdir()) && basename(invocation.cwd).startsWith(LOCAL_AGENT_TMP_PREFIX)) {
 			try {
 				rmSync(invocation.cwd, { recursive: true, force: true });

--- a/cli/src/core/MemoryBankScanner.test.ts
+++ b/cli/src/core/MemoryBankScanner.test.ts
@@ -20,9 +20,13 @@ vi.mock("./KBPathResolver.js", () => ({
 	extractRepoName: vi.fn(),
 	getRemoteUrl: vi.fn(),
 	resolveKBPath: vi.fn(),
+	// Claimable by default: these fixtures stand in for a real repo cwd. The
+	// gate's own conditions are covered in KBPathResolver.test.ts against real
+	// git worktrees; here it is only wired so the scan is not short-circuited.
+	isClaimableProject: vi.fn().mockReturnValue(true),
 }));
 
-import { extractRepoName, getRemoteUrl, resolveKBPath } from "./KBPathResolver.js";
+import { extractRepoName, getRemoteUrl, isClaimableProject, resolveKBPath } from "./KBPathResolver.js";
 import { listAllUserKnowledge, listAllUserKnowledgeFromRoot, listUserKnowledge } from "./MemoryBankScanner.js";
 import { loadConfig } from "./SessionTracker.js";
 
@@ -328,6 +332,17 @@ describe("MemoryBankScanner.listUserKnowledge", () => {
 	it("listAllUserKnowledge returns [] when the Memory Bank root cannot be resolved", async () => {
 		mockLoadConfig.mockRejectedValue(new Error("config gone"));
 		expect(await listAllUserKnowledge(cwd)).toEqual([]);
+	});
+
+	it("listAllUserKnowledge skips a non-claimable cwd without resolving (and thus claiming) a folder", async () => {
+		// `resolveKBPath` CLAIMS the folder it returns, so scanning from a
+		// non-project cwd (an agent's throwaway temp dir, the Memory Bank folder
+		// itself) used to create one rather than merely find nothing.
+		vi.mocked(isClaimableProject).mockReturnValueOnce(false);
+		mockResolveKBPath.mockClear();
+
+		expect(await listAllUserKnowledge(cwd)).toEqual([]);
+		expect(mockResolveKBPath).not.toHaveBeenCalled();
 	});
 
 	it("returns global + repo + branch in one pass without duplication", async () => {

--- a/cli/src/core/MemoryBankScanner.ts
+++ b/cli/src/core/MemoryBankScanner.ts
@@ -22,7 +22,7 @@
 import { type Dirent, existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { createLogger } from "../Logger.js";
-import { extractRepoName, getRemoteUrl, resolveKBPath } from "./KBPathResolver.js";
+import { extractRepoName, getRemoteUrl, isClaimableProject, resolveKBPath } from "./KBPathResolver.js";
 import { MetadataManager } from "./MetadataManager.js";
 import { toForwardSlash } from "./PathUtils.js";
 import { loadConfig } from "./SessionTracker.js";
@@ -311,6 +311,13 @@ async function tryResolveKBRoot(cwd: string): Promise<string | null> {
 	try {
 		const config = (await loadConfig()) as { localFolder?: string };
 		const customKBPath = config.localFolder;
+		// Same write-boundary gate as StorageFactory: `resolveKBPath` below claims
+		// the folder it returns, so scanning from a non-project cwd would create
+		// one rather than merely failing to find one.
+		if (!isClaimableProject(cwd, customKBPath)) {
+			log.debug("Memory Bank kbRoot skipped for non-claimable cwd %s", cwd);
+			return null;
+		}
 		const repoName = extractRepoName(cwd);
 		const remoteUrl = getRemoteUrl(cwd);
 		return resolveKBPath(repoName, remoteUrl, customKBPath);

--- a/cli/src/core/MemoryBankStatusText.test.ts
+++ b/cli/src/core/MemoryBankStatusText.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { describeMemoryBank } from "./MemoryBankStatusText.js";
+
+describe("describeMemoryBank", () => {
+	it("shows the resolved folder when dual-write is live", () => {
+		// No mode qualifier for dual-write: it's the default, so naming it would
+		// add noise to the common case.
+		expect(describeMemoryBank({ kind: "active", mode: "dual-write", folder: "/bank/widgets" })).toEqual({
+			severity: "ok",
+			text: "/bank/widgets",
+		});
+	});
+
+	it("qualifies folder-only mode so the missing orphan branch isn't a surprise", () => {
+		expect(describeMemoryBank({ kind: "active", mode: "folder", folder: "/bank/widgets" })).toEqual({
+			severity: "ok",
+			text: "/bank/widgets (folder-only)",
+		});
+	});
+
+	it("treats orphan-only as informational, not a warning", () => {
+		// A deliberate configuration. Rendering it as a warning would train users
+		// to ignore the row that matters.
+		const display = describeMemoryBank({ kind: "orphan-only" });
+		expect(display.severity).toBe("off");
+		expect(display.text).toContain("orphan branch only");
+	});
+
+	it("names both the blocker and the remedy for an in-repo folder", () => {
+		// The user can see neither input (storageMode has no UI, the gate's verdict
+		// comes from a cwd they never typed), so the text has to carry both.
+		const display = describeMemoryBank({
+			kind: "degraded",
+			blocker: "folder-inside-repo",
+			parent: "/repo/memory-bank",
+		});
+		expect(display.severity).toBe("warn");
+		expect(display.text).toContain("/repo/memory-bank");
+		expect(display.text).toContain("outside the working tree");
+	});
+
+	it("warns when the cwd is not a git worktree", () => {
+		const display = describeMemoryBank({ kind: "degraded", blocker: "not-a-project" });
+		expect(display.severity).toBe("warn");
+		expect(display.text).toContain("not inside a git worktree");
+	});
+
+	it("warns without inventing a path when the folder is unresolvable", () => {
+		// `parent` is absent for this blocker precisely because resolving it is
+		// what failed — the text must not print `undefined`.
+		const display = describeMemoryBank({ kind: "degraded", blocker: "unresolvable-folder" });
+		expect(display.severity).toBe("warn");
+		expect(display.text).not.toContain("undefined");
+		expect(display.text).toContain("$HOME");
+	});
+});

--- a/cli/src/core/MemoryBankStatusText.ts
+++ b/cli/src/core/MemoryBankStatusText.ts
@@ -1,0 +1,59 @@
+/**
+ * User-facing wording for {@link MemoryBankState} — the ONE place the Memory
+ * Bank's effective state is turned into text.
+ *
+ * Shared rather than mirrored per surface: this text exists specifically because
+ * the folder layer degrades silently (`StorageFactory` and `ReadStorageResolver`
+ * fall back to orphan-only with nothing but a `debug.log` line), so the CLI's
+ * `Memory Bank:` status row and the VS Code Settings → Memory Bank tab must not
+ * be able to disagree about whether writes are landing. The neighbouring
+ * `describeSchemaV5Status` predates this rule and is duplicated by hand across
+ * surfaces — don't copy that pattern here.
+ *
+ * Every non-`ok` string names the blocker AND the remedy, because the user can
+ * see neither input: `storageMode` has no UI, and the write-boundary gate's
+ * verdict is computed from a cwd they never typed.
+ */
+
+import type { MemoryBankState } from "./KBTypes.js";
+
+/**
+ * `severity` drives presentation only (icon + colour token in the webview, no
+ * decoration in the CLI row). `"off"` is deliberately distinct from `"warn"`:
+ * orphan-only is a valid configuration, not a problem to fix.
+ */
+export interface MemoryBankDisplay {
+	readonly severity: "ok" | "warn" | "off";
+	readonly text: string;
+}
+
+/**
+ * The active arm reports the resolved **per-repo** folder rather than the
+ * configured parent: the `-N` suffix ladder means the two routinely differ, and
+ * the folder actually being written is the answer to "where did my memories go".
+ */
+export function describeMemoryBank(state: MemoryBankState): MemoryBankDisplay {
+	switch (state.kind) {
+		case "orphan-only":
+			return { severity: "off", text: "Off — memories are stored on the orphan branch only" };
+		case "active":
+			return {
+				severity: "ok",
+				text: state.mode === "folder" ? `${state.folder} (folder-only)` : state.folder,
+			};
+		default:
+			return { severity: "warn", text: describeBlocker(state) };
+	}
+}
+
+/** The degraded arms, split out to keep {@link describeMemoryBank} flat. */
+function describeBlocker(state: Extract<MemoryBankState, { kind: "degraded" }>): string {
+	switch (state.blocker) {
+		case "not-a-project":
+			return "Not writing — this directory is not inside a git worktree";
+		case "folder-inside-repo":
+			return `Not writing — the Memory Bank folder (${state.parent}) is inside this repository; point it somewhere outside the working tree`;
+		default:
+			return "Not writing — the Memory Bank folder could not be resolved (check $HOME)";
+	}
+}

--- a/cli/src/core/PathUtils.ts
+++ b/cli/src/core/PathUtils.ts
@@ -53,12 +53,16 @@ export function stripTrailingSlashes(p: string): string {
  * folding on Windows/macOS), then a directory-boundary check so that
  * `.jolli/jollimemoryX` is NOT treated as inside `.jolli/jollimemory`.
  *
- * Used to decide whether a registry entry's `sourcePath` lives inside the
- * per-project `.jolli/jollimemory/` directory: hard-delete the backing file
- * only for inside paths; external files (e.g. `~/.claude/plans/foo.md`) keep
- * their file and lose only the registry row. Like `normalizePathForCompare`
- * it does NOT call `path.resolve` (WSL POSIX-absolute rationale) — callers
- * pass absolute paths.
+ * Like `normalizePathForCompare` it does NOT call `path.resolve` (WSL
+ * POSIX-absolute rationale) — callers pass absolute paths.
+ *
+ * The single home for "is this path under that path" — used across the plan /
+ * note registries (is an entry's `sourcePath` inside `.jolli/jollimemory/`, so
+ * deleting the row should delete the file?), session→repo attribution
+ * (`SessionDirMatch`), webview path guards, and the Memory Bank write boundary
+ * (`KBPathResolver.checkClaimable`). Prefer it over an inline
+ * `c === p || c.startsWith(p + "/")`: the boundary check and the two
+ * `normalizePathForCompare` calls are exactly what open-coded copies forget.
  */
 export function isPathInside(child: string, parent: string): boolean {
 	const c = normalizePathForCompare(child);

--- a/cli/src/core/ReadStorageResolver.test.ts
+++ b/cli/src/core/ReadStorageResolver.test.ts
@@ -15,10 +15,18 @@ vi.mock("./StorageFactory.js", () => ({
 	createFolderStorage: vi.fn(),
 }));
 
+// Claimable by default — the gate's own conditions (git worktree, nested bank)
+// are covered in KBPathResolver.test.ts against real git worktrees. Mocked here
+// so these tests never shell out to git.
+vi.mock("./KBPathResolver.js", () => ({
+	isClaimableProject: vi.fn().mockReturnValue(true),
+}));
+
 // Suppress console output
 vi.spyOn(console, "log").mockImplementation(() => {});
 vi.spyOn(console, "warn").mockImplementation(() => {});
 
+import { isClaimableProject } from "./KBPathResolver.js";
 import { OrphanBranchStorage } from "./OrphanBranchStorage.js";
 import { createReadStorage } from "./ReadStorageResolver.js";
 import { loadConfig } from "./SessionTracker.js";
@@ -26,6 +34,7 @@ import { createFolderStorage } from "./StorageFactory.js";
 
 const mockLoadConfig = vi.mocked(loadConfig);
 const mockCreateFolderStorage = vi.mocked(createFolderStorage);
+const mockIsClaimableProject = vi.mocked(isClaimableProject);
 
 // Minimal FolderStorage stub: only the methods ReadStorageResolver touches.
 // biome-ignore lint/suspicious/noExplicitAny: minimal StorageProvider stub for read-resolver dispatch
@@ -40,6 +49,9 @@ function makeFolderStub(opts: { index?: unknown; isDirty?: boolean | undefined }
 describe("createReadStorage", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// `clearAllMocks` wipes recorded calls but keeps implementations, so a
+		// per-test `mockReturnValue(false)` would otherwise leak forward.
+		mockIsClaimableProject.mockReturnValue(true);
 	});
 
 	it('returns OrphanBranchStorage when storageMode is "orphan"', async () => {
@@ -143,5 +155,65 @@ describe("createReadStorage", () => {
 		expect((storage as unknown as Record<string, unknown>).type).toBe("orphan");
 		expect(warnSpy).toHaveBeenCalled();
 		expect(mockCreateFolderStorage).not.toHaveBeenCalled();
+	});
+
+	// The read side reaches `resolveKBPath` through `createFolderStorage`, which
+	// CLAIMS the folder it resolves. Without this gate a read launched from a
+	// non-project cwd (`cd /tmp && jolli generate …`, an agent's throwaway temp
+	// dir) leaves a junk `<localFolder>/<basename>/` behind — the same failure the
+	// write-side gate in StorageFactory prevents.
+	describe("non-claimable cwd degrades to orphan-only", () => {
+		it("dual-write: never constructs the FolderStorage", async () => {
+			mockLoadConfig.mockResolvedValue({ storageMode: "dual-write" } as unknown as Awaited<
+				ReturnType<typeof loadConfig>
+			>);
+			mockIsClaimableProject.mockReturnValue(false);
+
+			const storage = await createReadStorage("/var/folders/xx/jolli-localagent-abc123");
+
+			expect((storage as unknown as Record<string, unknown>).type).toBe("orphan");
+			// The assertion that pins the fix: no createFolderStorage call means no
+			// resolveKBPath call means nothing written to disk.
+			expect(mockCreateFolderStorage).not.toHaveBeenCalled();
+		});
+
+		it("folder: never constructs the FolderStorage", async () => {
+			mockLoadConfig.mockResolvedValue({ storageMode: "folder" } as unknown as Awaited<
+				ReturnType<typeof loadConfig>
+			>);
+			mockIsClaimableProject.mockReturnValue(false);
+
+			const storage = await createReadStorage("/var/folders/xx/jolli-localagent-abc123");
+
+			expect((storage as unknown as Record<string, unknown>).type).toBe("orphan");
+			expect(mockCreateFolderStorage).not.toHaveBeenCalled();
+		});
+
+		it("passes the configured localFolder to the gate so the nested-bank case is detectable", async () => {
+			mockLoadConfig.mockResolvedValue({
+				storageMode: "dual-write",
+				localFolder: "/Users/me/Documents/bank",
+			} as unknown as Awaited<ReturnType<typeof loadConfig>>);
+			mockCreateFolderStorage.mockReturnValue(makeFolderStub({ index: "{}", isDirty: false }));
+
+			await createReadStorage("/Users/me/Documents/bank/some-repo");
+
+			expect(mockIsClaimableProject).toHaveBeenCalledWith(
+				"/Users/me/Documents/bank/some-repo",
+				"/Users/me/Documents/bank",
+			);
+		});
+
+		it('does not consult the gate at all in "orphan" mode', async () => {
+			// Orphan mode never touches the Memory Bank folder, so the git
+			// subprocess the gate runs would be pure overhead on that path.
+			mockLoadConfig.mockResolvedValue({ storageMode: "orphan" } as unknown as Awaited<
+				ReturnType<typeof loadConfig>
+			>);
+
+			await createReadStorage("/project/path");
+
+			expect(mockIsClaimableProject).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/cli/src/core/ReadStorageResolver.ts
+++ b/cli/src/core/ReadStorageResolver.ts
@@ -23,6 +23,7 @@
  */
 
 import { createLogger } from "../Logger.js";
+import { isClaimableProject } from "./KBPathResolver.js";
 import { OrphanBranchStorage } from "./OrphanBranchStorage.js";
 import { loadConfig } from "./SessionTracker.js";
 import { createFolderStorage } from "./StorageFactory.js";
@@ -38,10 +39,31 @@ const log = createLogger("ReadStorageResolver");
  * probes every call. VSCode's `JolliMemoryBridge` memoizes the result and
  * invalidates on settings-save; CLI call sites (one-shot compile / recall)
  * typically don't need caching because they exit after a single read pass.
+ *
+ * READ side, but still gated by `isClaimableProject`: `createFolderStorage`
+ * resolves its kbRoot through `resolveKBPath`, which *claims* the folder it
+ * returns. So a read from a non-project cwd creates the very junk folder the
+ * write-side gate exists to prevent — the gate has to sit on every caller of
+ * `createFolderStorage`, not just `StorageFactory.createStorage`. Degrading to
+ * orphan costs nothing here: in dual-write the folder probe would have missed
+ * (`index.json` absent in a folder that only just came into existence) and
+ * fallen back to orphan anyway — just after leaving the folder behind.
  */
 export async function createReadStorage(cwd: string): Promise<StorageProvider> {
 	const config = (await loadConfig()) as Record<string, unknown>;
 	const mode = (config.storageMode as string | undefined) ?? "dual-write";
+
+	// Same shape as `StorageFactory.createStorage`: skipped entirely in orphan
+	// mode (no folder is touched there, so the gate's git subprocess would be
+	// pure overhead), consulted for every mode that can reach the folder layer.
+	if (mode !== "orphan" && !isClaimableProject(cwd, config.localFolder as string | undefined)) {
+		log.warn(
+			"createReadStorage: not a claimable project (no git worktree, or inside the Memory Bank folder): %s — reading from the orphan branch instead of %s",
+			cwd,
+			mode,
+		);
+		return new OrphanBranchStorage(cwd);
+	}
 
 	switch (mode) {
 		case "orphan":

--- a/cli/src/core/StorageFactory.test.ts
+++ b/cli/src/core/StorageFactory.test.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock dependencies before importing the module under test
 vi.mock("./SessionTracker.js", () => ({
@@ -11,6 +11,9 @@ vi.mock("./KBPathResolver.js", () => ({
 	getRemoteUrl: vi.fn().mockReturnValue("https://github.com/test/repo.git"),
 	resolveKBPath: vi.fn().mockReturnValue("/tmp/kb-test"),
 	initializeKBFolder: vi.fn(),
+	// Claimable by default; the gate's own conditions are covered in
+	// KBPathResolver.test.ts against real git worktrees.
+	isClaimableProject: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("./MetadataManager.js", () => {
@@ -118,6 +121,83 @@ describe("StorageFactory", () => {
 		expect((storage as unknown as Record<string, unknown>).type).toBe("dual-write");
 		// Verify that a warning was logged (our Logger writes to console.warn)
 		expect(warnSpy).toHaveBeenCalled();
+	});
+
+	// Write-boundary gate. Before it existed, a nested agent's throwaway temp cwd
+	// (or the Memory Bank folder itself) reached resolveKBPath and permanently
+	// claimed `<localFolder>/<tempDirBasename>/` — 136 such folders accumulated
+	// from local-agent summary calls alone.
+	describe("non-claimable project degrades to orphan-only", () => {
+		// `vi.clearAllMocks()` clears calls but keeps implementations, so a
+		// `mockReturnValue(false)` set here would leak into later tests.
+		afterEach(async () => {
+			const kbResolver = await import("./KBPathResolver.js");
+			(kbResolver.isClaimableProject as ReturnType<typeof vi.fn>).mockReturnValue(true);
+		});
+
+		async function withUnclaimable(): Promise<typeof import("./KBPathResolver.js")> {
+			const kbResolver = await import("./KBPathResolver.js");
+			(kbResolver.isClaimableProject as ReturnType<typeof vi.fn>).mockReturnValue(false);
+			return kbResolver;
+		}
+
+		it("returns OrphanBranchStorage instead of DualWriteStorage", async () => {
+			mockLoadConfig.mockResolvedValue({ storageMode: "dual-write" } as unknown as Awaited<
+				ReturnType<typeof loadConfig>
+			>);
+			const kbResolver = await withUnclaimable();
+
+			const storage = await createStorage("/var/folders/xx/jolli-localagent-abc123");
+
+			expect((storage as unknown as Record<string, unknown>).type).toBe("orphan");
+			expect(DualWriteStorage).not.toHaveBeenCalled();
+			// The claim never happens — nothing is written, so there is nothing to
+			// clean up afterwards. This is the assertion that pins the whole fix.
+			expect(kbResolver.resolveKBPath).not.toHaveBeenCalled();
+			expect(FolderStorage).not.toHaveBeenCalled();
+		});
+
+		it("returns OrphanBranchStorage instead of folder-only FolderStorage", async () => {
+			mockLoadConfig.mockResolvedValue({ storageMode: "folder" } as unknown as Awaited<
+				ReturnType<typeof loadConfig>
+			>);
+			const kbResolver = await withUnclaimable();
+
+			const storage = await createStorage("/var/folders/xx/jolli-localagent-abc123");
+
+			expect((storage as unknown as Record<string, unknown>).type).toBe("orphan");
+			expect(kbResolver.resolveKBPath).not.toHaveBeenCalled();
+		});
+
+		it('does not consult the gate at all in "orphan" mode', async () => {
+			// Orphan mode never touches the Memory Bank folder, so the git
+			// subprocess the gate runs would be pure overhead on that path.
+			mockLoadConfig.mockResolvedValue({ storageMode: "orphan" } as unknown as Awaited<
+				ReturnType<typeof loadConfig>
+			>);
+			const kbResolver = await import("./KBPathResolver.js");
+			(kbResolver.isClaimableProject as ReturnType<typeof vi.fn>).mockClear();
+
+			await createStorage("/project/path");
+
+			expect(kbResolver.isClaimableProject).not.toHaveBeenCalled();
+		});
+
+		it("passes the configured localFolder to the gate so the nested-bank case is detectable", async () => {
+			mockLoadConfig.mockResolvedValue({
+				storageMode: "dual-write",
+				localFolder: "/Users/me/Documents/bank",
+			} as unknown as Awaited<ReturnType<typeof loadConfig>>);
+			const kbResolver = await import("./KBPathResolver.js");
+			(kbResolver.isClaimableProject as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+			await createStorage("/Users/me/Documents/bank");
+
+			expect(kbResolver.isClaimableProject).toHaveBeenCalledWith(
+				"/Users/me/Documents/bank",
+				"/Users/me/Documents/bank",
+			);
+		});
 	});
 
 	it("createFolderStorageAtRoot builds a folder-only FolderStorage at the explicit kbRoot", async () => {

--- a/cli/src/core/StorageFactory.ts
+++ b/cli/src/core/StorageFactory.ts
@@ -11,7 +11,7 @@ import { join } from "node:path";
 import { createLogger } from "../Logger.js";
 import { DualWriteStorage } from "./DualWriteStorage.js";
 import { FolderStorage } from "./FolderStorage.js";
-import { extractRepoName, getRemoteUrl, resolveKBPath } from "./KBPathResolver.js";
+import { extractRepoName, getRemoteUrl, isClaimableProject, resolveKBPath } from "./KBPathResolver.js";
 import { MetadataManager } from "./MetadataManager.js";
 import { OrphanBranchStorage } from "./OrphanBranchStorage.js";
 import { loadConfig } from "./SessionTracker.js";
@@ -35,6 +35,19 @@ export async function createStorage(projectPath: string, cwd?: string): Promise<
 	const customKBPath = config.localFolder as string | undefined;
 
 	log.info("StorageFactory.create: storageMode=%s, projectPath=%s", mode, projectPath);
+
+	// Write-boundary gate: a non-project cwd (an agent's throwaway temp dir, the
+	// Memory Bank folder itself, a bare `/tmp`) must never claim a folder under
+	// `localFolder`. Degrade to orphan-only instead of materializing junk that
+	// only the user can clean up. See KBPathResolver.isClaimableProject.
+	if (mode !== "orphan" && !isClaimableProject(projectPath, customKBPath)) {
+		log.warn(
+			"Not a claimable project (no git worktree, or inside the Memory Bank folder): %s — using orphan-only storage instead of %s",
+			projectPath,
+			mode,
+		);
+		return new OrphanBranchStorage(cwd);
+	}
 
 	switch (mode) {
 		case "dual-write": {

--- a/cli/src/core/localagent/ClaudeCodeBackend.ts
+++ b/cli/src/core/localagent/ClaudeCodeBackend.ts
@@ -1,7 +1,4 @@
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { LOCAL_AGENT_CHILD_ENV } from "../AgentReentry.js";
+import { createLocalAgentCwd, LOCAL_AGENT_CHILD_ENV } from "../AgentReentry.js";
 import { resolveClaudeExecutable } from "./ClaudeExecutableResolver.js";
 import {
 	type Invocation,
@@ -46,13 +43,6 @@ const SCRUBBED_ENV_VARS = [
 	"CLAUDECODE",
 ] as const;
 
-/**
- * Prefix for the temp cwd created below. Exported so `LlmClient.callLocalAgent`
- * can recognize (and safely clean up) only directories THIS backend created,
- * without duplicating the literal string.
- */
-export const LOCAL_AGENT_TMP_PREFIX = "jolli-localagent-";
-
 export class ClaudeCodeBackend implements LocalAgentBackend {
 	readonly id = "claude-code";
 
@@ -68,12 +58,10 @@ export class ClaudeCodeBackend implements LocalAgentBackend {
 		// (SessionStart/Stop hooks, `jolli enable`, MCP storage init) no-ops
 		// instead of re-entering against this throwaway temp cwd. See AgentReentry.
 		env[LOCAL_AGENT_CHILD_ENV] = "1";
-		// Fresh empty cwd: `claude` auto-discovers a CLAUDE.md from cwd and folds
-		// it into the system prompt. Running in the repo would inject the repo's
-		// CLAUDE.md — polluting the summary and burning tokens. An empty temp dir
-		// is the clean isolation (mirrors claude-mem's cwd jail). Removed again by
-		// `LlmClient.callLocalAgent` once the run completes.
-		const cwd = mkdtempSync(join(tmpdir(), LOCAL_AGENT_TMP_PREFIX));
+		// Fresh temp cwd carrying the re-entrancy sentinel — see createLocalAgentCwd
+		// for why it must be empty of instruction files and why the env marker above
+		// is not sufficient on its own. Removed by `LlmClient.callLocalAgent`.
+		const cwd = createLocalAgentCwd();
 		return {
 			file: exe.file,
 			// `--tools <tools...>` is an ALLOW-list. Passing a single empty string

--- a/cli/src/core/localagent/ClaudeExecutableResolver.test.ts
+++ b/cli/src/core/localagent/ClaudeExecutableResolver.test.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { posix as pathPosix, win32 as pathWin32 } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { execFileSyncHidden } from "../../util/Subprocess.js";
 import {
@@ -226,7 +226,9 @@ describe("resolveClaudeExecutable", () => {
 		});
 
 		it("falls through to known install locations when `which` finds nothing", () => {
-			const knownPath = join(homedir(), ".local/bin/claude");
+			// `platform: "linux"` is pinned below, so the expectation must be built with
+			// `path.posix` — the host `join` yields backslashes on a Windows dev machine.
+			const knownPath = pathPosix.join(homedir(), ".local/bin/claude");
 			mockedExecFileSync.mockImplementation((file: unknown) => {
 				if (file === "which") throw new Error("not found");
 				return "2.1.210\n";
@@ -293,7 +295,7 @@ describe("resolveClaudeExecutable", () => {
 		});
 
 		it("falls back to a known .exe install location when `where` finds nothing", () => {
-			const knownExe = join(homedir(), ".local", "bin", "claude.exe");
+			const knownExe = pathWin32.join(homedir(), ".local", "bin", "claude.exe");
 			mockedExecFileSync.mockImplementation((file: unknown) => {
 				if (file === "where") throw new Error("INFO: Could not find files for the given pattern(s).");
 				return "2.1.210\n";

--- a/cli/src/core/localagent/ClaudeExecutableResolver.ts
+++ b/cli/src/core/localagent/ClaudeExecutableResolver.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { posix as pathPosix, win32 as pathWin32 } from "node:path";
 import {
 	type Candidate,
 	type ProbeFn,
@@ -14,8 +14,11 @@ const CLAUDE_SPEC = {
 	binName: "claude",
 	knownPaths: (home: string, platform: NodeJS.Platform) =>
 		platform === "win32"
-			? [join(home, ".local/bin/claude.exe"), join(home, ".claude/local/claude.exe")]
-			: [join(home, ".local/bin/claude"), join(home, ".claude/local/claude")],
+			? [
+					pathWin32.join(home, ".local", "bin", "claude.exe"),
+					pathWin32.join(home, ".claude", "local", "claude.exe"),
+				]
+			: [pathPosix.join(home, ".local/bin/claude"), pathPosix.join(home, ".claude/local/claude")],
 	// MUST stay in sync with ClaudeCodeBackend.buildInvocation flags.
 	probeArgs: ["--permission-mode", "dontAsk", "--version"] as const,
 } as const;

--- a/cli/src/core/localagent/CodexBackend.ts
+++ b/cli/src/core/localagent/CodexBackend.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, posix as pathPosix, win32 as pathWin32 } from "node:path";
 import { LOCAL_AGENT_CHILD_ENV } from "../AgentReentry.js";
 import { LOCAL_AGENT_TMP_PREFIX } from "./ClaudeCodeBackend.js";
 import { resolveExecutable } from "./ExecutableResolver.js";
@@ -36,7 +36,9 @@ interface CodexEvent {
 const CODEX_SPEC = {
 	binName: "codex",
 	knownPaths: (home: string, platform: NodeJS.Platform) =>
-		platform === "win32" ? [join(home, ".local/bin/codex.exe")] : [join(home, ".local/bin/codex")],
+		platform === "win32"
+			? [pathWin32.join(home, ".local", "bin", "codex.exe")]
+			: [pathPosix.join(home, ".local/bin/codex")],
 	probeArgs: ["--version"] as const,
 } as const;
 

--- a/cli/src/core/localagent/CodexBackend.ts
+++ b/cli/src/core/localagent/CodexBackend.ts
@@ -1,8 +1,5 @@
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join, posix as pathPosix, win32 as pathWin32 } from "node:path";
-import { LOCAL_AGENT_CHILD_ENV } from "../AgentReentry.js";
-import { LOCAL_AGENT_TMP_PREFIX } from "./ClaudeCodeBackend.js";
+import { posix as pathPosix, win32 as pathWin32 } from "node:path";
+import { createLocalAgentCwd, LOCAL_AGENT_CHILD_ENV } from "../AgentReentry.js";
 import { resolveExecutable } from "./ExecutableResolver.js";
 import {
 	type Invocation,
@@ -57,7 +54,7 @@ export class CodexBackend implements LocalAgentBackend {
 		// Fresh empty cwd, same rationale as ClaudeCodeBackend: isolate the run
 		// from the repo. Also passed via -C below, since codex exec resolves
 		// relative paths / repo context off its working directory.
-		const cwd = mkdtempSync(join(tmpdir(), LOCAL_AGENT_TMP_PREFIX));
+		const cwd = createLocalAgentCwd();
 		// codex exec has no separate system-prompt flag, so it is prepended to
 		// the user prompt (confirmed via --help).
 		const prompt = req.systemPrompt ? `${req.systemPrompt}\n\n${req.prompt}` : req.prompt;

--- a/cli/src/core/localagent/CursorAgentBackend.ts
+++ b/cli/src/core/localagent/CursorAgentBackend.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, win32 as pathWin32 } from "node:path";
+import { join, posix as pathPosix, win32 as pathWin32 } from "node:path";
 import { LOCAL_AGENT_CHILD_ENV } from "../AgentReentry.js";
 import { LOCAL_AGENT_TMP_PREFIX } from "./ClaudeCodeBackend.js";
 import { type Candidate, resolveExecutable, type ShimDeps } from "./ExecutableResolver.js";
@@ -84,7 +84,7 @@ function localAppData(home: string, env: NodeJS.ProcessEnv = process.env): strin
 
 /** Install locations to check directly, for when the tool is not on the search PATH. */
 export function cursorKnownPaths(home: string, platform: NodeJS.Platform, env?: NodeJS.ProcessEnv): string[] {
-	if (platform !== "win32") return [join(home, ".local/bin/cursor-agent")];
+	if (platform !== "win32") return [pathPosix.join(home, ".local/bin/cursor-agent")];
 	return [
 		// The installer's own location. `where` finds it only when it is on PATH,
 		// which a GUI-launched editor's minimal PATH often drops.

--- a/cli/src/core/localagent/CursorAgentBackend.ts
+++ b/cli/src/core/localagent/CursorAgentBackend.ts
@@ -1,8 +1,5 @@
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join, posix as pathPosix, win32 as pathWin32 } from "node:path";
-import { LOCAL_AGENT_CHILD_ENV } from "../AgentReentry.js";
-import { LOCAL_AGENT_TMP_PREFIX } from "./ClaudeCodeBackend.js";
+import { posix as pathPosix, win32 as pathWin32 } from "node:path";
+import { createLocalAgentCwd, LOCAL_AGENT_CHILD_ENV } from "../AgentReentry.js";
 import { type Candidate, resolveExecutable, type ShimDeps } from "./ExecutableResolver.js";
 import {
 	type Invocation,
@@ -114,7 +111,7 @@ export class CursorAgentBackend implements LocalAgentBackend {
 		// Fresh empty cwd, same rationale as ClaudeCodeBackend: isolate the run
 		// from the repo (and, for cursor-agent specifically, from its Workspace
 		// Trust prompt over an unfamiliar directory — see --trust below).
-		const cwd = mkdtempSync(join(tmpdir(), LOCAL_AGENT_TMP_PREFIX));
+		const cwd = createLocalAgentCwd();
 		// cursor-agent has no separate system-prompt flag in headless mode, so the
 		// system prompt is prepended to the user prompt (confirmed via --help).
 		const prompt = req.systemPrompt ? `${req.systemPrompt}\n\n${req.prompt}` : req.prompt;

--- a/cli/src/core/localagent/ExecutableResolver.ts
+++ b/cli/src/core/localagent/ExecutableResolver.ts
@@ -31,6 +31,12 @@ export interface ShimDeps {
 /** Generic shape of a local-agent CLI's discovery + capability-probe rules. */
 export interface ExecutableSpec {
 	readonly binName: string;
+	/**
+	 * Install locations to stat directly, for when the tool is not on the search
+	 * PATH. Build them with `path.win32` / `path.posix` matching the `platform`
+	 * argument — never the host `path` — so a `platform`-pinned unit test yields
+	 * the same string on a Windows dev machine as it does in POSIX CI.
+	 */
 	readonly knownPaths: (home: string, platform: NodeJS.Platform) => string[];
 	readonly probeArgs: readonly string[];
 	/**

--- a/cli/src/core/localagent/LocalAgentRunner.test.ts
+++ b/cli/src/core/localagent/LocalAgentRunner.test.ts
@@ -46,6 +46,34 @@ function fakeSpawn(opts: { stdout?: string; stderr?: string; code?: number | nul
 const inv = { file: "/x/claude", args: ["-p"], stdin: "PROMPT", env: {}, cwd: "/tmp" };
 
 describe("runInvocation", () => {
+	it("pins PWD to the invocation cwd and drops the inherited shell/npm cwd vars", async () => {
+		let seenEnv: NodeJS.ProcessEnv | undefined;
+		const spawnImpl = ((_file: string, _args: string[], opts: { env?: NodeJS.ProcessEnv }) => {
+			seenEnv = opts.env;
+			const child = makeFakeChild();
+			setImmediate(() => {
+				child.stdout.end();
+				child.stderr.end();
+				child.emit("close", 0);
+			});
+			return child;
+			// biome-ignore lint/suspicious/noExplicitAny: test double for spawn's signature
+		}) as any;
+		await runInvocation(
+			{
+				...inv,
+				cwd: "/tmp/jolli-localagent-abc",
+				env: { PWD: "/repo", OLDPWD: "/repo/sub", INIT_CWD: "/repo", PATH: "/usr/bin" },
+			},
+			{ spawnImpl },
+		);
+		expect(seenEnv?.PWD).toBe("/tmp/jolli-localagent-abc");
+		expect(seenEnv?.OLDPWD).toBeUndefined();
+		expect(seenEnv?.INIT_CWD).toBeUndefined();
+		// Unrelated vars are passed through untouched.
+		expect(seenEnv?.PATH).toBe("/usr/bin");
+	});
+
 	it("resolves stdout on a clean exit", async () => {
 		const out = await runInvocation(inv, { spawnImpl: fakeSpawn({ stdout: '{"ok":true}', code: 0 }) });
 		expect(out).toBe('{"ok":true}');

--- a/cli/src/core/localagent/LocalAgentRunner.ts
+++ b/cli/src/core/localagent/LocalAgentRunner.ts
@@ -47,10 +47,23 @@ export function runInvocation(inv: Invocation, opts: RunOpts = {}): Promise<stri
 	// (ClaudeCodeBackend sends the prompt via stdin below, a byte stream with no
 	// such restriction, so `inv.stdin` is deliberately left untouched.)
 	const args = inv.args.map((a) => a.replace(/\0/g, ""));
+	// `cwd` alone does NOT isolate the child: agent CLIs commonly resolve their
+	// working directory from `PWD` (the shell-maintained string, which preserves
+	// symlinked paths) instead of the kernel cwd, and every backend copies
+	// `process.env` wholesale — so a hook/worker parent whose PWD is the user's
+	// repo silently drags the agent BACK into that repo. Measured against
+	// opencode 1.18: spawned with cwd=<temp dir> but PWD=<repo>, it bound its
+	// session to the repo, read repo sources, and wrote a file there. Pin PWD to
+	// the cwd we actually chose and drop the two sibling vars that leak the
+	// parent's location (`OLDPWD` from shells, `INIT_CWD` from npm scripts).
+	// Same rationale as the NUL strip above: one spawn boundary, every backend.
+	const env: NodeJS.ProcessEnv = { ...inv.env, PWD: inv.cwd };
+	delete env.OLDPWD;
+	delete env.INIT_CWD;
 	return new Promise<string>((resolve, reject) => {
 		const child = spawnImpl(inv.file, args, {
 			cwd: inv.cwd,
-			env: inv.env,
+			env,
 			stdio: ["pipe", "pipe", "pipe"],
 		});
 		// Accumulate stdout as raw Buffers and decode once at the end: a single

--- a/cli/src/core/localagent/OpenCodeBackend.ts
+++ b/cli/src/core/localagent/OpenCodeBackend.ts
@@ -1,8 +1,5 @@
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join, posix as pathPosix, win32 as pathWin32 } from "node:path";
-import { LOCAL_AGENT_CHILD_ENV } from "../AgentReentry.js";
-import { LOCAL_AGENT_TMP_PREFIX } from "./ClaudeCodeBackend.js";
+import { posix as pathPosix, win32 as pathWin32 } from "node:path";
+import { createLocalAgentCwd, LOCAL_AGENT_CHILD_ENV } from "../AgentReentry.js";
 import { type Candidate, resolveExecutable, type ShimDeps } from "./ExecutableResolver.js";
 import {
 	type Invocation,
@@ -58,7 +55,7 @@ export class OpenCodeBackend implements LocalAgentBackend {
 		env[LOCAL_AGENT_CHILD_ENV] = "1";
 		// Fresh empty cwd, same rationale as ClaudeCodeBackend: isolate the run
 		// from the repo (opencode reads AGENTS.md from its cwd).
-		const cwd = mkdtempSync(join(tmpdir(), LOCAL_AGENT_TMP_PREFIX));
+		const cwd = createLocalAgentCwd();
 		// opencode run has no separate system-prompt flag, so it is prepended to
 		// the user prompt (confirmed via --help).
 		const prompt = req.systemPrompt ? `${req.systemPrompt}\n\n${req.prompt}` : req.prompt;

--- a/cli/src/core/localagent/OpenCodeBackend.ts
+++ b/cli/src/core/localagent/OpenCodeBackend.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, win32 as pathWin32 } from "node:path";
+import { join, posix as pathPosix, win32 as pathWin32 } from "node:path";
 import { LOCAL_AGENT_CHILD_ENV } from "../AgentReentry.js";
 import { LOCAL_AGENT_TMP_PREFIX } from "./ClaudeCodeBackend.js";
 import { type Candidate, resolveExecutable, type ShimDeps } from "./ExecutableResolver.js";
@@ -38,7 +38,7 @@ const OPENCODE_SPEC = {
 					pathWin32.join(home, ".opencode", "bin", "opencode.exe"),
 					pathWin32.join(home, ".local", "bin", "opencode.exe"),
 				]
-			: [join(home, ".local/bin/opencode")],
+			: [pathPosix.join(home, ".local/bin/opencode")],
 	probeArgs: ["--version"] as const,
 	expandShim: expandOpenCodeShim,
 } as const;

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -940,7 +940,18 @@ async function runIngestFromQueue(
 		return;
 	}
 	const result = await drainIngest(cwd, config, { triggeredBy: op.triggeredBy, writeGuard });
-	log.info("Ingest drained: %d batches, %d sources (%s)", result.batches, result.ingested, op.triggeredBy);
+	// Held topics are part of the outcome, not a footnote: their sources stay
+	// unprocessed and are retried on every later drain, so a drain that reports
+	// only "N sources" reads as clean while a topic silently stalls forever.
+	// `held=[]` on the happy path keeps this branch-free.
+	const held = result.topicFailures.map((f) => `${f.slug} (${f.code})`).join(", ");
+	log.info(
+		"Ingest drained: %d batches, %d sources, held=[%s] (%s)",
+		result.batches,
+		result.ingested,
+		held,
+		op.triggeredBy,
+	);
 	// Re-render when new sources landed, OR when the visible wiki is gone (the user
 	// deleted `_wiki/`): without the second clause a deleted wiki would never come
 	// back through the background path once all sources are already processed

--- a/cli/src/install/Installer.ts
+++ b/cli/src/install/Installer.ts
@@ -41,6 +41,7 @@ import { scanCursorSessions } from "../core/CursorSessionDiscoverer.js";
 import { isDevinInstalled, scanDevinSessions } from "../core/DevinSessionDiscoverer.js";
 import { isGeminiInstalled } from "../core/GeminiSessionDetector.js";
 import { getProjectRootDir, isInsideGitRepo, listWorktrees, orphanBranchExists } from "../core/GitOps.js";
+import { resolveMemoryBankState } from "../core/KBPathResolver.js";
 import { acquireRepoHooksLock, type StrictLockHandle, withRuntimeRegistryLock } from "../core/Locks.js";
 import {
 	isOpenCodeInstalled,
@@ -1160,6 +1161,11 @@ export async function getStatus(cwd?: string, storage?: StorageProvider): Promis
 		// the status display can prompt the user to check / re-run migrate.
 	}
 
+	// Effective Memory Bank state. Resolved through `peekKBPath`, so asking
+	// `jolli status` where the folder is can never create it — the same reason
+	// the Rebuild/Migrate flow peeks instead of resolving.
+	const memoryBank = resolveMemoryBankState(projectDir, config);
+
 	const status: StatusInfo = {
 		// The extension is "enabled" when the git hook is installed.
 		// Individual integration hooks (Claude, Codex, Gemini) have their own
@@ -1206,6 +1212,7 @@ export async function getStatus(cwd?: string, storage?: StorageProvider): Promis
 		antigravityScanError,
 		globalConfigDir,
 		worktreeStatePath,
+		memoryBank,
 		enabledWorktrees,
 		hookSource: activeSource?.source,
 		hookVersion: activeSource?.version,

--- a/cli/src/mcp/McpServer.ts
+++ b/cli/src/mcp/McpServer.ts
@@ -220,16 +220,20 @@ export interface StartMcpServerDeps {
 
 /** Start the stdio MCP server. Resolves when the transport closes. */
 export async function startMcpServer(cwd: string, deps: StartMcpServerDeps = {}): Promise<void> {
-	// Re-entrancy guard (JOLLI-2033): the local-agent backend spawns `claude` in a
-	// throwaway temp cwd marked JOLLI_LOCAL_AGENT_CHILD=1. When the jolli plugin is
-	// globally installed, that nested `claude` spawns `jolli mcp` here — inheriting
-	// the marker. Without this no-op, the storage init below roots a FolderStorage
-	// at <localFolder>/<tempDirName>/, claiming a spurious Memory Bank "repo" per
-	// summary call (the temp dir basename becomes the repoName). The child runs
-	// `--tools ""` (all tools denied) so it never invokes an MCP tool; no-op the
-	// whole server. Mirrors the SessionStartHook/StopHook/EnableCommand guards and
-	// honors the "MCP storage init no-ops" contract stated in AgentReentry.
-	if (isLocalAgentChild()) {
+	// Re-entrancy guard (JOLLI-2033): the local-agent backend spawns an agent CLI in
+	// a throwaway temp cwd marked JOLLI_LOCAL_AGENT_CHILD=1. That nested CLI boots
+	// the globally-registered `jolli mcp` here. Without this no-op, the storage init
+	// below roots a FolderStorage at <localFolder>/<tempDirName>/, claiming a
+	// spurious Memory Bank "repo" per summary call (the temp dir basename becomes
+	// the repoName).
+	//
+	// `cwd` is passed explicitly — unlike the hook guards, this process is spawned
+	// by the HOST rather than by our own child, so the env marker is subject to the
+	// host's env policy: Codex passes MCP servers an 11-variable allowlist that
+	// drops it, which is how 136 stray folders accumulated with the env-only guard
+	// already in place. The cwd sentinel is what actually survives that hop. See
+	// AgentReentry for the full two-channel rationale.
+	if (isLocalAgentChild(process.env, cwd)) {
 		log.info("Local-agent child detected; skipping MCP server startup to avoid a spurious Memory Bank repo");
 		return;
 	}

--- a/cli/src/mcp/McpTools.test.ts
+++ b/cli/src/mcp/McpTools.test.ts
@@ -392,6 +392,7 @@ function makeStatus(over: Partial<StatusInfo> = {}): StatusInfo {
 		mostRecentSession: null,
 		summaryCount: 0,
 		orphanBranch: "jollimemory/summaries/v3",
+		memoryBank: { kind: "orphan-only" },
 		...over,
 	};
 }

--- a/scripts/probe-local-agents.mjs
+++ b/scripts/probe-local-agents.mjs
@@ -30,10 +30,19 @@ const TOOLS = [
 for (const t of TOOLS) {
 	const dir = join(FIX, t.id);
 	mkdirSync(dir, { recursive: true });
+	// Mirror the real backends' re-entrancy marking, BOTH channels. Without it
+	// each probed CLI boots the globally-registered `jolli mcp` in this temp cwd,
+	// which claims a permanent `<localFolder>/jolli-probe-*/` Memory Bank folder
+	// (2 such folders were left behind by an earlier run of this script). The env
+	// var alone is not enough — Codex spawns MCP servers with an 11-variable
+	// allowlist that drops it; the cwd sentinel is what actually survives.
+	// See cli/src/core/AgentReentry.ts.
 	const cwd = mkdtempSync(join(tmpdir(), "jolli-probe-"));
-	const help = spawnSync(t.bin, t.help, { encoding: "utf8" });
+	writeFileSync(join(cwd, ".jolli-local-agent-child"), "");
+	const env = { ...process.env, JOLLI_LOCAL_AGENT_CHILD: "1" };
+	const help = spawnSync(t.bin, t.help, { encoding: "utf8", env });
 	writeFileSync(join(dir, "help.txt"), `${help.stdout ?? ""}\n---STDERR---\n${help.stderr ?? ""}`);
-	const run = spawnSync(t.bin, t.run, { cwd, encoding: "utf8", timeout: 120000 });
+	const run = spawnSync(t.bin, t.run, { cwd, encoding: "utf8", timeout: 120000, env });
 	writeFileSync(join(dir, "success.json"), run.stdout ?? "");
 	writeFileSync(
 		join(dir, "meta.json"),

--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -13,10 +13,16 @@ const { discoverRepos } = vi.hoisted(() => ({
 	discoverRepos: vi.fn().mockReturnValue([]),
 }));
 
-const { extractRepoName, getRemoteUrl, resolveKbParent } = vi.hoisted(() => ({
+const { extractRepoName, getRemoteUrl, resolveKbParent, isClaimableProject } = vi.hoisted(() => ({
 	extractRepoName: vi.fn().mockReturnValue("test-repo"),
 	getRemoteUrl: vi.fn().mockReturnValue(null),
 	resolveKbParent: vi.fn().mockReturnValue("/mock/home/Documents/jolli"),
+	// StorageFactory's write-boundary gate. `TEST_CWD` is a synthetic path, so the
+	// real predicate (which probes for a git worktree on disk) would reject it and
+	// silently degrade every folder-mode path in this file to orphan-only storage.
+	// The gate has its own coverage in cli/src/core/KBPathResolver.test.ts; here it
+	// is pinned open so these tests exercise the storage wiring they are about.
+	isClaimableProject: vi.fn().mockReturnValue(true),
 }));
 
 const {
@@ -241,6 +247,7 @@ vi.mock("../../cli/src/core/KBPathResolver.js", async (importOriginal) => {
 		extractRepoName,
 		getRemoteUrl,
 		resolveKbParent,
+		isClaimableProject,
 		// Stub: identity-claiming side-effects of `resolveKBPath` /
 		// `initializeKBFolder` reach into MetadataManager, which is mocked
 		// to a class with no-op methods (see `MockMetadataManager`). The
@@ -477,6 +484,7 @@ describe("JolliMemoryBridge", () => {
 		extractRepoName.mockReturnValue("test-repo");
 		getRemoteUrl.mockReturnValue(null);
 		resolveKbParent.mockReturnValue("/mock/home/Documents/jolli");
+		isClaimableProject.mockReturnValue(true);
 		savePluginSource.mockResolvedValue(undefined);
 		saveSquashPending.mockResolvedValue(undefined);
 		installerInstall.mockResolvedValue({

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -558,6 +558,11 @@ export class JolliMemoryBridge {
 				summaryCount: 0,
 				orphanBranch: ORPHAN_BRANCH,
 				codexDetected: false,
+				// `getStatus` threw before it could resolve anything, so the folder
+				// layer's real state is unknown. Report the same shape the rest of
+				// this fallback uses — "nothing is working" — rather than guessing
+				// at an active folder we never confirmed.
+				memoryBank: { kind: "orphan-only" },
 				geminiDetected: false,
 			};
 		}

--- a/vscode/src/views/SettingsCssBuilder.ts
+++ b/vscode/src/views/SettingsCssBuilder.ts
@@ -271,7 +271,8 @@ export function buildSettingsCss(): string {
 
   /* ── Status indicators ── */
   .status-ok,
-  .status-warn {
+  .status-warn,
+  .status-off {
     display: flex;
     align-items: flex-start;
     gap: 6px;
@@ -284,7 +285,12 @@ export function buildSettingsCss(): string {
      two webviews render identically when a theme omits the variable. */
   .status-ok { color: var(--vscode-testing-iconPassed, #89d185); }
   .status-warn { color: var(--vscode-testing-iconQueued, #cca700); }
+  /* Valid-but-inactive (storageMode=orphan): descriptive, not a problem to fix,
+     so it takes the muted foreground rather than a warning colour. */
+  .status-off { color: var(--vscode-descriptionForeground, #8b8b8b); }
   .status-icon { font-size: 14px; flex-shrink: 0; }
+  /* Long absolute paths must wrap instead of stretching the panel. */
+  #memoryBankState { word-break: break-all; }
 
   /* ── Advanced toggle (link-style button) ── */
   .link-btn {

--- a/vscode/src/views/SettingsHtmlBuilder.test.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.test.ts
@@ -179,6 +179,15 @@ describe("SettingsHtmlBuilder", () => {
 		expect(html).toContain("Browse");
 	});
 
+	it("Memory Bank tab contains the effective-state line, initially hidden", () => {
+		// Starts with the `.hidden` class (never the HTML `hidden` attribute, which
+		// `display: flex` silently overrides) so the row can't flash a verdict the
+		// host hasn't sent yet.
+		expect(html).toContain('id="memoryBankState"');
+		expect(html).toContain('id="memoryBankStateText"');
+		expect(html).toMatch(/class="status-off hidden" id="memoryBankState"/);
+	});
+
 	it("Memory Bank tab contains the Migrate to Memory Bank button", () => {
 		expect(html).toContain('id="rebuildKbBtn"');
 		expect(html).toContain("Migrate to Memory Bank");

--- a/vscode/src/views/SettingsHtmlBuilder.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.ts
@@ -193,6 +193,15 @@ export function buildSettingsHtml(nonce: string): string {
           <input type="text" id="localFolder" readonly placeholder="No folder selected" spellcheck="false" />
           <button type="button" class="browse-btn" id="browseLocalFolderBtn">Browse…</button>
         </div>
+        <!-- Effective state of the folder layer, not an echo of the input above.
+             The two differ routinely: the per-repo folder carries a -N suffix,
+             and the write-boundary gate can refuse this workspace outright, in
+             which case writes silently go to the orphan branch only. Populated
+             on settingsLoaded; starts hidden so it never flashes a stale verdict. -->
+        <div class="status-off hidden" id="memoryBankState">
+          <span class="status-icon" id="memoryBankStateIcon"></span>
+          <span id="memoryBankStateText"></span>
+        </div>
       </div>
 
       <div class="settings-row column">

--- a/vscode/src/views/SettingsScriptBuilder.test.ts
+++ b/vscode/src/views/SettingsScriptBuilder.test.ts
@@ -274,4 +274,95 @@ describe("SettingsScriptBuilder", () => {
 			/case 'settingsError':[\s\S]*pendingMigrateAfterApply = false/,
 		);
 	});
+
+	describe("Memory Bank state line", () => {
+		it("renders on BOTH entry paths (fresh load and post-save)", () => {
+			// A lazy display channel needs a trigger on every path that can change
+			// it: settingsLoaded seeds it, and settingsSaved is the only message the
+			// webview gets after Apply — where localFolder may just have changed.
+			expect(script).toMatch(/case 'settingsLoaded':[\s\S]*renderMemoryBankState\(msg\.settings\.memoryBank\)/);
+			expect(script).toMatch(/case 'settingsSaved':[\s\S]*renderMemoryBankState\(msg\.memoryBank\)/);
+		});
+
+		/**
+		 * Evaluates just `renderMemoryBankState` against fake elements. The three
+		 * elements it touches are closure variables in the real script, so they are
+		 * injected as parameters here — cheaper than standing up the whole webview,
+		 * and it exercises real behavior instead of asserting on source text.
+		 *
+		 * The `new Function` input is `buildSettingsScript()`'s own output — a
+		 * literal in this repo, with no runtime or user data reaching it. Same
+		 * technique the SidebarScriptBuilder tests use to parse built scripts.
+		 */
+		function loadRenderer() {
+			const src = script.match(/function renderMemoryBankState\(display\) \{[\s\S]*?\n {2}\}/)?.[0];
+			if (!src) throw new Error("renderMemoryBankState not found in built script");
+			const makeEl = () => {
+				const classes = new Set<string>(["status-off", "hidden"]);
+				return {
+					textContent: "",
+					classList: {
+						add: (...c: string[]): void => {
+							for (const name of c) classes.add(name);
+						},
+						remove: (...c: string[]): void => {
+							for (const name of c) classes.delete(name);
+						},
+						has: (c: string) => classes.has(c),
+					},
+				};
+			};
+			const root = makeEl();
+			const icon = makeEl();
+			const text = makeEl();
+			const fn = new Function(
+				"memoryBankState",
+				"memoryBankStateIcon",
+				"memoryBankStateText",
+				`${src}; return renderMemoryBankState;`,
+			)(root, icon, text) as (d: unknown) => void;
+			return { fn, root, icon, text };
+		}
+
+		it("shows the path with an ok icon when writes are landing", () => {
+			const { fn, root, icon, text } = loadRenderer();
+			fn({ severity: "ok", text: "/bank/widgets" });
+			expect(root.classList.has("hidden")).toBe(false);
+			expect(root.classList.has("status-ok")).toBe(true);
+			expect(root.classList.has("status-off")).toBe(false);
+			expect(icon.textContent).toBe("✓");
+			expect(text.textContent).toBe("/bank/widgets");
+		});
+
+		it("swaps the severity class rather than accumulating them", () => {
+			// Re-render after a settingsSaved that flipped the verdict: a stale
+			// status-ok left alongside status-warn would win or blend unpredictably.
+			const { fn, root } = loadRenderer();
+			fn({ severity: "ok", text: "/bank/widgets" });
+			fn({ severity: "warn", text: "Not writing — …" });
+			expect(root.classList.has("status-warn")).toBe(true);
+			expect(root.classList.has("status-ok")).toBe(false);
+		});
+
+		it("stays hidden when the host sent nothing", () => {
+			// An older host that doesn't send the field must not leave an empty
+			// coloured strip under the folder input.
+			const { fn, root } = loadRenderer();
+			fn(undefined);
+			expect(root.classList.has("hidden")).toBe(true);
+		});
+
+		it("falls back to the off severity for an unrecognized value", () => {
+			const { fn, root, icon } = loadRenderer();
+			fn({ severity: "explode", text: "x" });
+			expect(root.classList.has("status-off")).toBe(true);
+			expect(icon.textContent).toBe("○");
+		});
+
+		it("writes the path via textContent, never innerHTML", () => {
+			// The payload carries a filesystem path straight from config.
+			expect(script).toContain("memoryBankStateText.textContent = display.text");
+			expect(script).not.toContain("memoryBankStateText.innerHTML");
+		});
+	});
 });

--- a/vscode/src/views/SettingsScriptBuilder.ts
+++ b/vscode/src/views/SettingsScriptBuilder.ts
@@ -43,6 +43,9 @@ export function buildSettingsScript(): string {
   const antigravityEnabledInput = document.getElementById('antigravityEnabled');
   const globalInstructionsInput = document.getElementById('globalInstructions');
   const localFolderInput = document.getElementById('localFolder');
+  const memoryBankState = document.getElementById('memoryBankState');
+  const memoryBankStateIcon = document.getElementById('memoryBankStateIcon');
+  const memoryBankStateText = document.getElementById('memoryBankStateText');
   const browseLocalFolderBtn = document.getElementById('browseLocalFolderBtn');
   const rebuildKbBtn = document.getElementById('rebuildKbBtn');
   const rebuildKbStatus = document.getElementById('rebuildKbStatus');
@@ -141,6 +144,24 @@ export function buildSettingsScript(): string {
   function updateAnthropicWarning() {
     var hasKey = apiKeyInput.value.trim().length > 0;
     anthropicMissingWarn.classList.toggle('hidden', hasKey);
+  }
+
+  // Renders the host's Memory Bank verdict. The severity picks the class the
+  // panel already uses for status lines; the row stays hidden if the host sent
+  // nothing, so an older host can never leave an empty coloured strip behind.
+  // textContent (not innerHTML) because the payload carries a filesystem path.
+  function renderMemoryBankState(display) {
+    if (!memoryBankState) return;
+    if (!display || !display.text) {
+      memoryBankState.classList.add('hidden');
+      return;
+    }
+    var severity = display.severity === 'ok' || display.severity === 'warn' ? display.severity : 'off';
+    memoryBankState.classList.remove('status-ok', 'status-warn', 'status-off');
+    memoryBankState.classList.add('status-' + severity);
+    memoryBankStateIcon.textContent = severity === 'ok' ? '✓' : severity === 'warn' ? '⚠' : '○';
+    memoryBankStateText.textContent = display.text;
+    memoryBankState.classList.remove('hidden');
   }
 
   // ── Advanced (Jolli API Key) toggles ──
@@ -593,6 +614,7 @@ export function buildSettingsScript(): string {
         antigravityEnabledInput.checked = msg.settings.antigravityEnabled;
         globalInstructionsInput.checked = !!msg.settings.globalInstructions;
         localFolderInput.value = msg.settings.localFolder || '';
+        renderMemoryBankState(msg.settings.memoryBank);
         excludePatternsInput.value = msg.settings.excludePatterns;
         compileExcludeFoldersInput.value = msg.settings.compileExcludeFolders;
         dcoSignoffInput.checked = !!msg.settings.dcoSignoff;
@@ -679,6 +701,7 @@ export function buildSettingsScript(): string {
         saveFeedback.textContent = 'Settings saved';
         saveFeedback.classList.remove('error');
         saveFeedback.classList.add('visible');
+        renderMemoryBankState(msg.memoryBank);
         setTimeout(function() { saveFeedback.classList.remove('visible'); }, 2000);
         captureInitialState();
         if (pendingMigrateAfterApply) {

--- a/vscode/src/views/SettingsWebviewPanel.test.ts
+++ b/vscode/src/views/SettingsWebviewPanel.test.ts
@@ -1081,9 +1081,40 @@ describe("SettingsWebviewPanel", () => {
 			});
 			await flushPromises();
 
-			expect(postMessage).toHaveBeenCalledWith({ command: "settingsSaved" });
+			// `objectContaining`: the message also carries the refreshed Memory Bank
+			// verdict (asserted on its own below), which this case doesn't pin.
+			expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({ command: "settingsSaved" }));
 			expect(onSaved).toHaveBeenCalled();
 			expect(info).toHaveBeenCalledWith("SettingsPanel", "Settings saved");
+		});
+
+		it("re-sends the Memory Bank verdict with settingsSaved", async () => {
+			// `settingsSaved` is the only message the webview gets back after Apply,
+			// and changing `localFolder` can flip the write-boundary gate either way.
+			// Without the verdict riding along, the state line would keep asserting
+			// the pre-save answer until the panel was reopened.
+			const dispatch = await setupWithLoadedConfig();
+
+			dispatch({
+				command: "applySettings",
+				settings: {
+					apiKey: "",
+					model: "sonnet",
+					maxTokens: null,
+					jolliApiKey: "",
+					claudeEnabled: true,
+					codexEnabled: true,
+					geminiEnabled: true,
+					excludePatterns: "",
+				},
+			});
+			await flushPromises();
+
+			const saved = postMessage.mock.calls
+				.map(([msg]) => msg as { command: string; memoryBank?: { severity: string; text: string } })
+				.find((msg) => msg.command === "settingsSaved");
+			expect(saved?.memoryBank?.severity).toMatch(/^(ok|warn|off)$/);
+			expect(saved?.memoryBank?.text).toBeTruthy();
 		});
 
 		it("rejects a Jolli API key that cannot be decoded (wrong prefix), without saving", async () => {

--- a/vscode/src/views/SettingsWebviewPanel.ts
+++ b/vscode/src/views/SettingsWebviewPanel.ts
@@ -23,6 +23,11 @@ import {
 	parseJolliApiKey,
 	validateJolliApiKey,
 } from "../../../cli/src/core/JolliApiUtils.js";
+import { resolveMemoryBankState } from "../../../cli/src/core/KBPathResolver.js";
+import {
+	describeMemoryBank,
+	type MemoryBankDisplay,
+} from "../../../cli/src/core/MemoryBankStatusText.js";
 import { track } from "../../../cli/src/core/Telemetry.js";
 import {
 	getGlobalConfigDir,
@@ -62,6 +67,13 @@ interface SettingsPayload {
 	/** Tri-state config switch (undecided | "enabled" | "disabled") flattened to a checkbox; see handleApplySettings for the enable/disable/preserve-undecided persistence rules. */
 	readonly globalInstructions: boolean;
 	readonly localFolder: string;
+	/**
+	 * Read-only verdict on whether folder writes are actually landing, and where.
+	 * NOT derived from `localFolder` in the webview: the effective folder carries
+	 * the `-N` suffix the resolver picked, and the write-boundary gate can refuse
+	 * this workspace entirely — a state the configured path cannot express.
+	 */
+	readonly memoryBank: MemoryBankDisplay;
 	readonly excludePatterns: string;
 	/** Comma-separated folder names (exact or `*` glob) skipped by `jolli compile`. */
 	readonly compileExcludeFolders: string;
@@ -471,6 +483,11 @@ export class SettingsWebviewPanel {
 			antigravityEnabled: config.antigravityEnabled !== false,
 			globalInstructions: config.globalInstructions === "enabled",
 			localFolder: config.localFolder ?? "",
+			// `resolveMemoryBankState` peeks (never claims), so merely opening
+			// Settings cannot materialize the folder it is reporting on.
+			memoryBank: describeMemoryBank(
+				resolveMemoryBankState(this.workspaceRoot, config),
+			),
 			excludePatterns: config.excludePatterns
 				? config.excludePatterns.join(", ")
 				: "",
@@ -675,7 +692,21 @@ export class SettingsWebviewPanel {
 
 		log.info("SettingsPanel", "Settings saved");
 
-		this.panel.webview.postMessage({ command: "settingsSaved" });
+		// Re-send the Memory Bank verdict with the save: changing `localFolder` can
+		// flip the write-boundary gate in either direction, and `settingsSaved` is
+		// the only message the webview gets back — without this the state line
+		// would keep asserting the pre-save verdict until the panel is reopened.
+		// Computed from the values just persisted (`storageMode` isn't editable
+		// here, so it comes from the config we loaded).
+		this.panel.webview.postMessage({
+			command: "settingsSaved",
+			memoryBank: describeMemoryBank(
+				resolveMemoryBankState(this.workspaceRoot, {
+					storageMode: currentConfig.storageMode,
+					localFolder: update.localFolder,
+				}),
+			),
+		});
 		this.onSavedCallback?.();
 	}
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Quick recap (3)

### Commit 1 of 3: Use platform-specific path modules in local agent backends (`e497d0a`)

The developer fixed a cross-platform path bug in local agent detection that caused unit tests to fail on Windows development machines. Every local agent backend configuration now uses the correct path separator for whichever platform it is targeting, regardless of where tests are actually run. The documented interface contract makes sure future backends follow the same rule. Developers on any operating system can now run the full test suite without encountering path-separator mismatches.

### Commit 2 of 3: Add cwd sentinel channel to local-agent reentry guard (`bd10ea0`)

The developer hardened local assistant runs around temporary workspaces and Memory Bank storage. Background assistant jobs now stayed inside the scratch directory created for them, and the reentry guard recognized those runs even when a host application stripped inherited process markers. Memory Bank summaries and other folder-backed operations no longer created stray directories from those temporary locations. Read commands launched from unsafe locations also stayed on the orphan path, so routine reads no longer materialized new folders on disk.

The same batch made stalled knowledge generation much easier to inspect in routine logs. Failed runs now identified the generator involved, named the selected local tool, and showed the opening slice of malformed replies. Drain summaries also reported held topics and failure codes when work remained blocked, which left a visible record of incomplete background processing.

Cross-platform local assistant detection was tightened at the same time. Known install locations now used the path style of the platform being checked, and resolver expectations followed the same rule on every development machine. Developers running the test suite on Windows, macOS, or Linux now saw the same results for pinned platform cases.

### Commit 3 of 3: Show Memory Bank status in CLI and VS Code settings (`2385c33`)

The developer fixed a Memory Bank failure mode that had been turning off folder updates for valid repositories stored under broad parent folders such as Documents or synced drives. Those repositories now kept writing to their own Memory Bank folders. Projects that would place the Memory Bank inside the source tree remained blocked.

The command line status output now showed whether the Memory Bank was active, off, or not writing, and it displayed the exact folder or blocker text. The VS Code Settings panel gained the same state line directly under the folder picker. That line refreshed when settings were loaded and again after settings were saved, which kept the displayed state aligned with the user’s latest configuration.

## Topics (5)
<details>
<summary><strong>01 · [e497d0a] Local agent binary paths now use the correct separator for each target platform</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Unit tests for detecting locally installed AI coding tools failed on Windows development machines. They built file paths using the host operating system's path separator, which produced backslash paths even when testing the Linux or macOS detection logic.

**💡 Decisions Behind the Code**

- **Platform-decoupled path construction**: When detecting which AI coding tools are installed, the code accepts a target-platform parameter. The bug was that the host operating system's path-building function was used regardless, so a macOS-pinned test path produced backslashes on a Windows developer machine. The fix replaces every instance with the correct path builder for the target platform and synchronizes the test expectations to match.
- **Contract-level documentation**: Because no automated linter can catch this class of bug, the rule was captured in the documented interface that all local-agent detector specs must follow. This mirrors the codebase's existing convention-based enforcement for path-normalization rules.

**✅ What Was Implemented**

- The known-install-paths functions in CursorAgentBackend.ts, CodexBackend.ts, OpenCodeBackend.ts, and ClaudeExecutableResolver.ts were changed to use the path separator matching their platform argument rather than the host runtime.
- Two test assertions in ClaudeExecutableResolver.test.ts were similarly updated so expectations are consistent across all development machines regardless of the host OS.
- A documented contract was added to the `ExecutableSpec.knownPaths` interface requiring implementors to match the platform argument's path flavor.

**📁 FILES**
- `cli/src/core/localagent/CursorAgentBackend.ts`
- `cli/src/core/localagent/CodexBackend.ts`
- `cli/src/core/localagent/OpenCodeBackend.ts`
- `cli/src/core/localagent/ClaudeExecutableResolver.ts`
- `cli/src/core/localagent/ExecutableResolver.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [bd10ea0] Local agent runs now stay isolated from repositories and Memory Bank folders</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A user found 143 junk directories in the Memory Bank folder, all named after temporary workspaces created by locally run coding assistants. The original guard depended on one inherited process marker, and some host applications silently dropped it when they launched background assistant processes.

**💡 Decisions Behind the Code**

- **Two independent guard channels**: The developer kept the inherited process marker and added a file marker in the temporary workspace. That preserved the cheap direct-child check while covering hosts that strip environment variables from background launches. The final guard no longer depends on one fragile signal.
- **Shared runner fix over backend-by-backend patches**: The developer corrected the working-directory leak at the common spawn boundary used by every local assistant integration. That applied the protection across all current backends at once and reduced the chance that a future backend would reopen the same escape path.
- **Storage boundary over scattered checks**: The developer put the write-side safety decision at the layer that actually claims on-disk storage. That avoided relying on each caller to remember its own guard and made unsafe directories fail closed in one place.
- **Read-entry guard over low-level contract changes**: The developer added the read-side protection at the read resolver instead of changing the lower-level folder-claiming helper. That kept explicit folder-claiming flows intact while preventing ambient read commands from materializing new folders in temporary or non-project directories.
- **Safe orphan fallback over hard failure**: The developer treated unsafe directories as a supported read context and downgraded them to orphan storage. That kept the product usable from temporary or agent-created directories while stopping permanent junk folders from being created.

**✅ What Was Implemented**

- Added a second reentry signal by writing a sentinel file into every temporary local-agent working directory alongside the existing environment marker. `cli/src/mcp/McpServer.ts` now passes the working directory into the guard, and `cli/src/core/AgentReentry.ts` checks both channels so host-launched subprocesses are still recognized when inherited variables are stripped.
- Tightened local-agent workspace isolation at the shared runner boundary. `cli/src/core/localagent/LocalAgentRunner.ts` now pins child processes to the throwaway workspace created for the run and clears inherited directory variables that could pull a subprocess back into the user's real repository.
- Strengthened folder-claiming boundaries for both write and read flows. `cli/src/core/StorageFactory.ts` refuses to claim folder-backed storage when the current directory is outside a recognized git worktree or already inside the Memory Bank folder, and `cli/src/core/ReadStorageResolver.ts` now downgrades unsafe read modes to orphan storage before any folder-claiming side effects can create directories on disk.
- Clarified the path-resolution contract around guarded and intentionally exempt callers. `cli/src/core/KBPathResolver.ts` now documents the preconditions for ambient working-directory lookups and points pure path discovery toward the non-claiming path.

**📁 FILES**
- `cli/src/core/AgentReentry.ts`
- `cli/src/core/StorageFactory.ts`
- `cli/src/core/ReadStorageResolver.ts`
- `cli/src/core/KBPathResolver.ts`
- `cli/src/core/localagent/LocalAgentRunner.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [bd10ea0] Knowledge generation logs now expose blocked topics and malformed replies</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A background knowledge-generation run stalled, but routine logs did not show which generator failed or what content had blocked reconciliation. Held topics could remain queued while the drain summary still looked clean.

**💡 Decisions Behind the Code**

- **Observability over speculative recovery**: The developer chose to surface the generator identity, partial reply text, and blocked-topic list directly in logs. That made real failures diagnosable from routine output and kept the root failure visible instead of hiding it behind a fallback path.
- **Deferred broader hardening and UI work**: The developer left prompt-level restrictions for tool-using assistants and any user-facing blocked-topic surface for later follow-up. That kept this change focused on making current failures inspectable in production first.

**✅ What Was Implemented**

- Expanded reconciliation failure logs to include the active provider, the selected local tool, and the first 200 characters of the malformed reply. `cli/src/core/IngestPipeline.ts` now leaves enough evidence in ordinary logs to identify unusable structured-output responses without additional tracing.
- Updated drain summary logging to include held topics and their failure codes when work remains blocked. `cli/src/hooks/QueueWorker.ts` now reports pending retry state directly in the final summary instead of showing only that active draining ended.

**📋 Future Enhancements**

- Evaluate prompt hardening for tool-using local assistants after stable A/B testing with a reliable model.
- Add a user-facing surface for held knowledge topics, such as status output or IDE UI, using the recorded failure data.

**📁 FILES**
- `cli/src/core/IngestPipeline.ts`
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [bd10ea0] Platform-specific local agent install paths now resolve consistently everywhere</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Windows development machines failed local-agent detection tests that were pinned to another platform. The known install paths were being built with the host machine's path separator instead of the separator for the platform under test.

**💡 Decisions Behind the Code**

The developer kept the existing platform-argument design and corrected the path-building rule to match it everywhere. That fixed cross-platform determinism without introducing new abstractions, and the documented interface contract captured the convention for future backends.

**✅ What Was Implemented**

- Replaced host-path construction with platform-specific path construction in the known-install-path helpers for all local-agent backends. `cli/src/core/localagent/CursorAgentBackend.ts`, `cli/src/core/localagent/CodexBackend.ts`, and `cli/src/core/localagent/OpenCodeBackend.ts` now generate install locations that match the platform argument they receive.
- Updated the Claude-related resolver expectations and documented the path-flavor contract on the executable-spec interface. `cli/src/core/localagent/ClaudeExecutableResolver.ts` and `cli/src/core/localagent/ExecutableResolver.ts` now reflect the same cross-platform rule used by the backend helpers.

**📁 FILES**
- `cli/src/core/localagent/CursorAgentBackend.ts`
- `cli/src/core/localagent/CodexBackend.ts`
- `cli/src/core/localagent/OpenCodeBackend.ts`
- `cli/src/core/localagent/ClaudeExecutableResolver.ts`
- `cli/src/core/localagent/ExecutableResolver.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [2385c33] Fixed silent Memory Bank shutdowns and surfaced live folder status</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A valid repository could stop updating its Memory Bank when the chosen folder lived above the repo, and the only clue was a debug log line. The request was to stop that false shutdown and show the effective Memory Bank state in the command line and VS Code settings.

**💡 Decisions Behind the Code**

- **Scope the safety check to the repository itself**: The developer chose to block only cases where the Memory Bank folder would end up inside the repository being summarized. This preserved common setups where people keep repositories under a broad parent folder such as Documents or a synced drive. It also kept the real safety boundary intact for cases that would write generated markdown into source control.
- **Report the effective state, not just the saved path**: The developer showed the actual destination or blocker message instead of echoing the configured parent folder. This made the status output answer the practical question users have when memories stop appearing: where writes are landing, or why they are not landing at all. The same choice also covered suffix-adjusted folder names that differ from the raw setting.
- **Use a read-only status path shared across surfaces**: The developer resolved status through a non-creating path and centralized the user-facing wording. Checking status no longer risked materializing a folder just by opening the command or the settings panel. Reusing one text formatter also kept the command line and VS Code from drifting into contradictory explanations.

**✅ What Was Implemented**

- In `cli/src/core/KBPathResolver.ts`, the write-boundary gate was rewritten around `mainWorktreeRoot()` and the new `checkClaimable()` verdict type. The overlap test now rejects only cases where the Memory Bank would live inside the repository being summarized, instead of rejecting every repo that happens to sit under the configured parent folder. `resolveMemoryBankState()` was added alongside this to compute the effective folder-layer state without creating the folder on disk.
- In `cli/src/core/KBTypes.ts`, `cli/src/install/Installer.ts`, and `cli/src/commands/StatusCommand.ts`, Memory Bank state became a first-class part of `StatusInfo`. The CLI now resolves that state during `getStatus()` and prints a `Memory Bank:` row via the shared formatter in `cli/src/core/MemoryBankStatusText.ts`, covering active, degraded, and orphan-only modes with one wording source.
- In the VS Code settings flow, `vscode/src/views/SettingsWebviewPanel.ts` now sends the formatted Memory Bank verdict with both the initial settings payload and the post-save confirmation. `SettingsHtmlBuilder.ts`, `SettingsCssBuilder.ts`, and `SettingsScriptBuilder.ts` added a dedicated state line under the folder picker, severity styling for ok/warn/off states, and refresh logic that updates the line after Apply without leaving stale text on screen.

**📋 Future Enhancements**

- Consider adding the same write-boundary gate to the VS Code initialization path that still bypasses it in a narrow workspace-inside-bank case.
- Add equivalent write-boundary protection to the IntelliJ side, which was explicitly noted as lacking this safeguard.

**📁 FILES**
- `cli/src/core/KBPathResolver.ts`
- `cli/src/core/KBTypes.ts`
- `cli/src/core/MemoryBankStatusText.ts`
- `cli/src/install/Installer.ts`
- `cli/src/commands/StatusCommand.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 29, 2026 at 6:26 PM · via mixed: Local agent - OpenCode, Local agent - Codex*
<!-- jollimemory-summary-end -->