### PR TITLE
Track the specs review high-water mark in git

### DIFF
--- a/specs/.state.json
+++ b/specs/.state.json
@@ -1,0 +1,11 @@
+{
+  "branches": {
+    "main": {
+      "revision": "b09ac5189533e2497621a5c3dd7690df10fe9c1f",
+      "subject": "fix(claude-plugin): drop JOLLI_DIST_PREFER_SOURCE so cli wins same-version ties",
+      "reviewedAt": "2026-07-25T17:34:32Z",
+      "actor": "douglas.schroeder",
+      "skill": "specs-update"
+    }
+  }
+}


### PR DESCRIPTION
## What

Commits `specs/.state.json`, recording the revision the `specs/` corpus was last reviewed against.

## Why

`specs/` is committed, but until now the record of *which* revision it was reviewed up to lived only in `.claude/specs-revision-state.json` — and `.claude/` is gitignored. Anyone else cloning the repo had no way to tell how current the specs are short of re-deriving it from history. This puts the high-water mark next to the specs it describes.

## Scope

One file, `specs/.state.json` (11 lines of JSON). No code, no build, lint, test, or coverage impact — the path matches none of the `detect-relevant-paths` globs in the CI workflows, so `build-vscode` and `build-intellij` skip their build steps and report success.