### PR TITLE
Fix transcript token stats and detach pricing calculations

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -95,6 +95,28 @@ export interface ConversationTokenBreakdown {
 	readonly cached: number;
 }
 
+/**
+ * One transcript line's usage, plus an optional identity for de-duplicating the
+ * SAME model response reported on more than one line.
+ *
+ * Claude Code writes one JSONL line per content block of an assistant response
+ * (a `thinking` block, a `text` block, and one line per parallel `tool_use`),
+ * and EVERY one of those lines carries a verbatim copy of that response's single
+ * `message.usage` object — not a per-block share of it. Summing per line
+ * therefore counts one API call's tokens once per block: measured against real
+ * transcripts the inflation runs 2.2×–10×, the high end being agentic turns that
+ * fire six or seven tool calls from one response.
+ *
+ * `dedupKey` is that response's identity (`message.id` for Claude). The reader
+ * keeps a per-read set of keys it has already counted and skips repeats, so a
+ * response contributes exactly once no matter how many lines carry it. Omitted
+ * when a source cannot identify the response, in which case every line counts
+ * (the pre-existing behaviour, correct for sources that report usage once).
+ */
+export interface ParsedTurnUsage extends ConversationTokenBreakdown {
+	readonly dedupKey?: string;
+}
+
 /** Billing provider for a conversation model — selects the pricing formula. */
 export type TokenProvider = "anthropic" | "openai" | "unknown";
 
@@ -143,6 +165,23 @@ export interface StoredSession {
 	/** Original JSONL file path, preserved for re-summarize (future) */
 	readonly transcriptPath?: string;
 	readonly entries: ReadonlyArray<TranscriptEntry>;
+	/**
+	 * This session's own share of the commit's conversation tokens — the
+	 * per-session attribution the queue worker already computes in memory while
+	 * reading slices, now persisted so it survives the write.
+	 *
+	 * Without it, detaching one conversation from a committed memory cannot
+	 * update that memory's token total: the summary stores only the post-merge
+	 * aggregate, so there is no way to know how much of it belonged to the
+	 * session being removed. Forward-only — absent on memories written before
+	 * this field existed, and on sources whose transcript carries no usage; a
+	 * detach that finds no `usage` leaves the token total untouched rather than
+	 * guessing at a subtrahend.
+	 */
+	readonly usage?: ConversationTokenBreakdown;
+	/** Per-model split of {@link usage}, so a detach can also correct the cost
+	 *  estimate (which is priced per model, not from the aggregate). */
+	readonly usageByModel?: ReadonlyArray<ModelTokenUsage>;
 }
 
 /** Structured transcript data for a commit, stored as `transcripts/{commitHash}.json` in the orphan branch */

--- a/cli/src/core/DetachedUsageSubtraction.test.ts
+++ b/cli/src/core/DetachedUsageSubtraction.test.ts
@@ -1,0 +1,459 @@
+import { describe, expect, it } from "vitest";
+import type { CommitSummary, ModelTokenUsage } from "../Types.js";
+import { CURRENT_SCHEMA_VERSION } from "../Types.js";
+import { type DetachedSessionUsage, subtractDetachedUsage } from "./DetachedUsageSubtraction.js";
+import { PRICES_AS_OF } from "./Pricing.js";
+
+const node = (over: Partial<CommitSummary> = {}): CommitSummary => ({
+	version: CURRENT_SCHEMA_VERSION,
+	commitHash: "a".repeat(40),
+	commitMessage: "test commit",
+	commitAuthor: "Tester",
+	commitDate: "2026-07-29T00:00:00.000Z",
+	branch: "feature/x",
+	generatedAt: "2026-07-29T00:00:01.000Z",
+	topics: [],
+	...over,
+});
+
+const opus = (input: number, output: number, cached: number): ModelTokenUsage => ({
+	model: "claude-opus-5",
+	provider: "anthropic",
+	input,
+	output,
+	cached,
+});
+
+const removed = (
+	transcriptId: string,
+	sessions: ReadonlyArray<DetachedSessionUsage>,
+): Map<string, ReadonlyArray<DetachedSessionUsage>> => new Map([[transcriptId, sessions]]);
+
+describe("subtractDetachedUsage", () => {
+	it("is a no-op with an empty removal map", () => {
+		const summary = node({ transcripts: ["t1"], conversationTokens: 100 });
+		const result = subtractDetachedUsage(summary, new Map());
+		expect(result.summary).toBe(summary);
+		expect(result.changed).toBe(false);
+		expect(result.unattributed).toEqual([]);
+	});
+
+	it("subtracts the detached session's share and re-derives cost from the remaining models", () => {
+		const summary = node({
+			transcripts: ["t1"],
+			conversationTokens: 1000,
+			conversationTokenBreakdown: { input: 100, output: 200, cached: 700 },
+			conversationModels: [opus(100, 200, 700)],
+			estimatedCostUsd: 9.875,
+			pricesAsOf: PRICES_AS_OF,
+		});
+		const result = subtractDetachedUsage(
+			summary,
+			removed("t1", [{ usage: { input: 40, output: 50, cached: 200 }, usageByModel: [opus(40, 50, 200)] }]),
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.unattributed).toEqual([]);
+		expect(result.summary.conversationTokens).toBe(710);
+		expect(result.summary.conversationTokenBreakdown).toEqual({ input: 60, output: 150, cached: 500 });
+		expect(result.summary.conversationModels).toEqual([opus(60, 150, 500)]);
+		// Re-priced from what's left at the Opus 5 rates (5 / 25 / 6.25 per MTok):
+		// 60·5e-6 + 150·25e-6 + 500·6.25e-6 = 0.0000003 + 0.00000375 + ...
+		const expected = (60 * 5 + 150 * 25 + 500 * 6.25) / 1_000_000;
+		expect(result.summary.estimatedCostUsd).toBeCloseTo(expected, 12);
+		expect(result.summary.pricesAsOf).toBe(PRICES_AS_OF);
+	});
+
+	it("strips the whole usage group rather than storing zeros when nothing is left", () => {
+		const summary = node({
+			transcripts: ["t1"],
+			conversationTokens: 300,
+			conversationTokenBreakdown: { input: 100, output: 100, cached: 100 },
+			conversationModels: [opus(100, 100, 100)],
+			estimatedCostUsd: 0.003,
+			pricesAsOf: PRICES_AS_OF,
+		});
+		const result = subtractDetachedUsage(
+			summary,
+			removed("t1", [{ usage: { input: 100, output: 100, cached: 100 }, usageByModel: [opus(100, 100, 100)] }]),
+		);
+
+		expect(result.changed).toBe(true);
+		// Absent, not zero: the display contract reads "absent" as "reports no usage",
+		// while a stored 0 renders as a real measurement of nothing.
+		expect(result.summary).not.toHaveProperty("conversationTokens");
+		expect(result.summary).not.toHaveProperty("conversationTokenBreakdown");
+		expect(result.summary).not.toHaveProperty("conversationModels");
+		expect(result.summary).not.toHaveProperty("estimatedCostUsd");
+		expect(result.summary).not.toHaveProperty("pricesAsOf");
+		// Everything else survives.
+		expect(result.summary.commitMessage).toBe("test commit");
+	});
+
+	it("floors at zero when the subtrahend exceeds a pre-dedup-fix inflated total", () => {
+		// A memory written before the per-line de-duplication fix carries an inflated
+		// aggregate, while the detached session's recorded usage is not inflated in the
+		// same proportion — so the subtraction can overshoot. It must not go negative.
+		const summary = node({
+			transcripts: ["t1"],
+			conversationTokens: 50,
+			conversationTokenBreakdown: { input: 10, output: 10, cached: 30 },
+			conversationModels: [opus(10, 10, 30)],
+		});
+		const result = subtractDetachedUsage(
+			summary,
+			removed("t1", [{ usage: { input: 999, output: 999, cached: 999 } }]),
+		);
+		expect(result.changed).toBe(true);
+		expect(result.summary.conversationTokens).toBeUndefined();
+	});
+
+	it("subtracts from the child that owns the transcript, not the amend root", () => {
+		// Root and child carry their own token fields and SummaryTree aggregates both, so
+		// a detach must land on the node that actually counted the tokens. Disjoint id
+		// lists here; the next test covers the real amend shape, where the root re-lists
+		// the child's id.
+		const child = node({
+			commitHash: "b".repeat(40),
+			transcripts: ["t-child"],
+			conversationTokens: 500,
+			conversationTokenBreakdown: { input: 50, output: 50, cached: 400 },
+			conversationModels: [opus(50, 50, 400)],
+		});
+		const summary = node({
+			transcripts: ["t-root"],
+			conversationTokens: 100,
+			conversationTokenBreakdown: { input: 10, output: 10, cached: 80 },
+			conversationModels: [opus(10, 10, 80)],
+			children: [child],
+		});
+
+		const result = subtractDetachedUsage(
+			summary,
+			removed("t-child", [{ usage: { input: 20, output: 20, cached: 100 }, usageByModel: [opus(20, 20, 100)] }]),
+		);
+
+		expect(result.changed).toBe(true);
+		// Root untouched.
+		expect(result.summary.conversationTokens).toBe(100);
+		expect(result.summary.conversationTokenBreakdown).toEqual({ input: 10, output: 10, cached: 80 });
+		// Child corrected.
+		expect(result.summary.children?.[0].conversationTokens).toBe(360);
+		expect(result.summary.children?.[0].conversationTokenBreakdown).toEqual({
+			input: 30,
+			output: 30,
+			cached: 300,
+		});
+	});
+
+	it("subtracts ONCE on a real amend root, which re-lists its child's transcript id", () => {
+		// The shape production actually writes (QueueWorker `amendTranscripts` =
+		// `[...inheritedAmendIds, deltaId]`, buildHoistedAmendRoot `children:
+		// [oldSummary]`): the root's `transcripts` array is the tree-wide authoritative
+		// INDEX — every id `getTranscriptIds` must find — while its token fields cover
+		// the DELTA only. The child keeps both its own id and its own tokens.
+		//
+		// Matching an id against every node that lists it therefore hits root AND child
+		// for one detach: the child's correction is right, the root's is a subtraction of
+		// tokens it never carried. Floored at 0, that wiped the root's whole delta and the
+		// tree total (root + child, per SummaryTree.aggregateConversationTokens) came out
+		// short by it.
+		const child = node({
+			commitHash: "b".repeat(40),
+			transcripts: ["t-child"],
+			conversationTokens: 500,
+			conversationTokenBreakdown: { input: 50, output: 50, cached: 400 },
+			conversationModels: [opus(50, 50, 400)],
+		});
+		const summary = node({
+			transcripts: ["t-child", "t-root-delta"],
+			conversationTokens: 100,
+			conversationTokenBreakdown: { input: 10, output: 10, cached: 80 },
+			conversationModels: [opus(10, 10, 80)],
+			children: [child],
+		});
+
+		const result = subtractDetachedUsage(
+			summary,
+			removed("t-child", [{ usage: { input: 20, output: 20, cached: 100 }, usageByModel: [opus(20, 20, 100)] }]),
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.unattributed).toEqual([]);
+		// Root's delta figures survive intact — it re-lists the id but does not own it.
+		expect(result.summary.conversationTokens).toBe(100);
+		expect(result.summary.conversationTokenBreakdown).toEqual({ input: 10, output: 10, cached: 80 });
+		expect(result.summary.conversationModels).toEqual([opus(10, 10, 80)]);
+		// Child corrected exactly once.
+		expect(result.summary.children?.[0].conversationTokens).toBe(360);
+		expect(result.summary.children?.[0].conversationTokenBreakdown).toEqual({
+			input: 30,
+			output: 30,
+			cached: 300,
+		});
+	});
+
+	it("subtracts at the DEEPEST owner down an amend chain that re-lists the id twice", () => {
+		// Amend-of-an-amend: each root inherits the ids below it, so the grandchild's id
+		// appears on all three nodes. Only the grandchild's token fields cover it.
+		const grandchild = node({
+			commitHash: "c".repeat(40),
+			transcripts: ["t-g"],
+			conversationTokens: 300,
+			conversationTokenBreakdown: { input: 100, output: 100, cached: 100 },
+		});
+		const child = node({
+			commitHash: "b".repeat(40),
+			transcripts: ["t-g", "t-child-delta"],
+			conversationTokens: 200,
+			conversationTokenBreakdown: { input: 100, output: 50, cached: 50 },
+			children: [grandchild],
+		});
+		const summary = node({
+			transcripts: ["t-g", "t-child-delta", "t-root-delta"],
+			conversationTokens: 100,
+			conversationTokenBreakdown: { input: 50, output: 25, cached: 25 },
+			children: [child],
+		});
+
+		const result = subtractDetachedUsage(summary, removed("t-g", [{ usage: { input: 40, output: 0, cached: 0 } }]));
+
+		expect(result.summary.conversationTokens).toBe(100);
+		expect(result.summary.children?.[0].conversationTokens).toBe(200);
+		expect(result.summary.children?.[0].children?.[0].conversationTokens).toBe(260);
+	});
+
+	it("reports an id two siblings both claim rather than subtracting it from both", () => {
+		// Ambiguous ownership: `mergeManyToOne` dedups ids at the squash root but cannot
+		// stop two source commits from carrying the same id (its own comment allows for
+		// legacy migrated-from-v3 hashes colliding). Neither sibling is a descendant of
+		// the other, so there is no deepest owner — and subtracting from both is the very
+		// double-count this module must not produce. Same treatment as an id no node
+		// claims: correct nothing, report it.
+		const a = node({ commitHash: "b".repeat(40), transcripts: ["t-dup"], conversationTokens: 100 });
+		const b = node({ commitHash: "c".repeat(40), transcripts: ["t-dup"], conversationTokens: 100 });
+		const summary = node({ transcripts: ["t-dup"], children: [a, b] });
+
+		const result = subtractDetachedUsage(
+			summary,
+			removed("t-dup", [{ usage: { input: 10, output: 0, cached: 0 } }]),
+		);
+
+		expect(result.changed).toBe(false);
+		expect(result.summary).toBe(summary);
+		expect(result.unattributed).toEqual(["t-dup"]);
+	});
+
+	it("keeps untouched subtrees by reference so callers can compare identity", () => {
+		const untouched = node({ commitHash: "c".repeat(40), transcripts: ["t-other"], conversationTokens: 7 });
+		const target = node({
+			commitHash: "d".repeat(40),
+			transcripts: ["t-target"],
+			conversationTokens: 100,
+			conversationTokenBreakdown: { input: 100, output: 0, cached: 0 },
+		});
+		const summary = node({ transcripts: ["t-root"], children: [untouched, target] });
+
+		const result = subtractDetachedUsage(
+			summary,
+			removed("t-target", [{ usage: { input: 40, output: 0, cached: 0 } }]),
+		);
+		expect(result.summary.children?.[0]).toBe(untouched);
+		expect(result.summary.children?.[1]).not.toBe(target);
+		expect(result.summary.children?.[1].conversationTokens).toBe(60);
+	});
+
+	it("reports a session with no recorded usage as unattributed and changes nothing", () => {
+		// Forward-only: memories written before StoredSession.usage existed have no
+		// subtrahend, so their totals must be left alone rather than guessed at.
+		const summary = node({
+			transcripts: ["t1"],
+			conversationTokens: 1000,
+			conversationTokenBreakdown: { input: 100, output: 200, cached: 700 },
+		});
+		const result = subtractDetachedUsage(summary, removed("t1", [{}]));
+
+		expect(result.changed).toBe(false);
+		expect(result.summary).toBe(summary);
+		expect(result.unattributed).toEqual(["t1"]);
+	});
+
+	it("reports a PARTIALLY attributable transcript even though it also corrects the total", () => {
+		// Two sessions removed from one transcript, only one with recorded usage. The
+		// subtraction can account for 100 of the 1000 but not the other session's share,
+		// so the remaining figure is short. Reporting only the all-missing case would
+		// leave this silently wrong — the caller logs nothing and the bar looks settled.
+		const summary = node({
+			transcripts: ["t1"],
+			conversationTokens: 1000,
+			conversationTokenBreakdown: { input: 100, output: 200, cached: 700 },
+		});
+		const result = subtractDetachedUsage(
+			summary,
+			removed("t1", [{ usage: { input: 100, output: 0, cached: 0 } }, {}]),
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.summary.conversationTokens).toBe(900);
+		expect(result.unattributed).toEqual(["t1"]);
+	});
+
+	it("reports a transcript id no node claims as unattributed", () => {
+		const summary = node({ transcripts: ["t1"], conversationTokens: 100 });
+		const result = subtractDetachedUsage(
+			summary,
+			removed("t-unknown", [{ usage: { input: 5, output: 0, cached: 0 } }]),
+		);
+
+		expect(result.changed).toBe(false);
+		expect(result.unattributed).toEqual(["t-unknown"]);
+	});
+
+	it("leaves a pre-v5 node (no transcripts array) untouched and reports it", () => {
+		const summary = node({
+			conversationTokens: 1000,
+			conversationTokenBreakdown: { input: 1000, output: 0, cached: 0 },
+		});
+		const result = subtractDetachedUsage(summary, removed("t1", [{ usage: { input: 400, output: 0, cached: 0 } }]));
+
+		expect(result.changed).toBe(false);
+		expect(result.summary.conversationTokens).toBe(1000);
+		expect(result.unattributed).toEqual(["t1"]);
+	});
+
+	it("sums several detached sessions removed from the same transcript", () => {
+		const summary = node({
+			transcripts: ["t1"],
+			conversationTokens: 1000,
+			conversationTokenBreakdown: { input: 300, output: 300, cached: 400 },
+			conversationModels: [opus(300, 300, 400)],
+		});
+		const result = subtractDetachedUsage(
+			summary,
+			removed("t1", [
+				{ usage: { input: 100, output: 100, cached: 100 }, usageByModel: [opus(100, 100, 100)] },
+				{ usage: { input: 50, output: 50, cached: 50 }, usageByModel: [opus(50, 50, 50)] },
+			]),
+		);
+		expect(result.summary.conversationTokens).toBe(550);
+		expect(result.summary.conversationTokenBreakdown).toEqual({ input: 150, output: 150, cached: 250 });
+	});
+
+	it("drops a model whose tokens are fully detached while keeping the others", () => {
+		const haiku: ModelTokenUsage = {
+			model: "claude-haiku-4-5",
+			provider: "anthropic",
+			input: 100,
+			output: 100,
+			cached: 0,
+		};
+		const summary = node({
+			transcripts: ["t1"],
+			conversationTokens: 600,
+			conversationTokenBreakdown: { input: 200, output: 200, cached: 200 },
+			conversationModels: [opus(100, 100, 200), haiku],
+		});
+		const result = subtractDetachedUsage(
+			summary,
+			removed("t1", [{ usage: { input: 100, output: 100, cached: 0 }, usageByModel: [haiku] }]),
+		);
+		expect(result.summary.conversationModels).toEqual([opus(100, 100, 200)]);
+	});
+
+	it("subtracts from the scalar on a node that has tokens but no breakdown", () => {
+		// Older memories recorded `conversationTokens` without the per-segment split.
+		// Treating the missing breakdown as zeros would compute 0 remaining and wipe
+		// usage the memory still legitimately has — here 1000 - 290 must leave 710,
+		// rendered as the meter's total-only single segment.
+		const summary = node({ transcripts: ["t1"], conversationTokens: 1000 });
+		const result = subtractDetachedUsage(
+			summary,
+			removed("t1", [{ usage: { input: 40, output: 50, cached: 200 } }]),
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.summary.conversationTokens).toBe(710);
+		expect(result.summary.conversationTokenBreakdown).toBeUndefined();
+	});
+
+	it("keeps a scalar-only node's per-model split and re-derives its cost", () => {
+		// `conversationModels` / `estimatedCostUsd` are independent of the breakdown, so a
+		// node can carry a cost without one. The strip-then-restore had only restored them
+		// on the breakdown path, silently deleting a cost the surviving models still earn.
+		const summary = node({
+			transcripts: ["t1"],
+			conversationTokens: 1000,
+			conversationModels: [opus(400, 300, 300)],
+			estimatedCostUsd: 12.5,
+			pricesAsOf: "2026-01-01",
+		});
+		const result = subtractDetachedUsage(
+			summary,
+			removed("t1", [{ usage: { input: 100, output: 0, cached: 0 }, usageByModel: [opus(100, 0, 0)] }]),
+		);
+
+		expect(result.summary.conversationTokens).toBe(900);
+		expect(result.summary.conversationTokenBreakdown).toBeUndefined();
+		expect(result.summary.conversationModels).toEqual([opus(300, 300, 300)]);
+		// Re-derived from the remaining models, not carried over: opus-5 at $5/$25/$6.25
+		// per MTok → 300 * (5 + 25 + 6.25) / 1e6.
+		expect(result.summary.estimatedCostUsd).toBeCloseTo(0.010875, 9);
+		expect(result.summary.pricesAsOf).toBe(PRICES_AS_OF);
+	});
+
+	it("strips a scalar-only node's usage when the detached share covers all of it", () => {
+		const summary = node({ transcripts: ["t1"], conversationTokens: 100 });
+		const result = subtractDetachedUsage(
+			summary,
+			removed("t1", [{ usage: { input: 100, output: 50, cached: 0 } }]),
+		);
+		expect(result.summary).not.toHaveProperty("conversationTokens");
+	});
+
+	it("treats an explicitly empty children array like a leaf", () => {
+		const summary = node({
+			transcripts: ["t1"],
+			conversationTokens: 100,
+			conversationTokenBreakdown: { input: 100, output: 0, cached: 0 },
+			children: [],
+		});
+		const result = subtractDetachedUsage(summary, removed("t1", [{ usage: { input: 30, output: 0, cached: 0 } }]));
+		expect(result.summary.conversationTokens).toBe(70);
+		expect(result.summary.children).toEqual([]);
+	});
+
+	it("leaves a node that carries no token fields alone", () => {
+		// Squash containers hold children but no usage of their own.
+		const summary = node({ transcripts: ["t1"] });
+		const result = subtractDetachedUsage(
+			summary,
+			removed("t1", [{ usage: { input: 10, output: 10, cached: 10 } }]),
+		);
+		expect(result.changed).toBe(false);
+		expect(result.summary).toBe(summary);
+	});
+
+	it("omits cost when every remaining model is unpriced", () => {
+		const unpriced: ModelTokenUsage = {
+			model: "some-future-model",
+			provider: "unknown",
+			input: 100,
+			output: 0,
+			cached: 0,
+		};
+		const summary = node({
+			transcripts: ["t1"],
+			conversationTokens: 200,
+			conversationTokenBreakdown: { input: 200, output: 0, cached: 0 },
+			conversationModels: [unpriced],
+			estimatedCostUsd: 1,
+			pricesAsOf: PRICES_AS_OF,
+		});
+		const result = subtractDetachedUsage(summary, removed("t1", [{ usage: { input: 50, output: 0, cached: 0 } }]));
+		expect(result.summary.conversationTokens).toBe(150);
+		// Unpriced usage keeps its models but carries no cost, so the reader shows
+		// "unknown" instead of a misleading $0.00.
+		expect(result.summary.estimatedCostUsd).toBeUndefined();
+		expect(result.summary.pricesAsOf).toBeUndefined();
+	});
+});

--- a/cli/src/core/DetachedUsageSubtraction.ts
+++ b/cli/src/core/DetachedUsageSubtraction.ts
@@ -1,0 +1,297 @@
+/**
+ * DetachedUsageSubtraction
+ *
+ * Corrects a committed memory's conversation token/cost figures after the user
+ * detaches a conversation from it.
+ *
+ * Detach rewrites the stored transcript files (dropping one `source:sessionId`)
+ * but the summary carries only the POST-merge aggregate — `conversationTokens`,
+ * `conversationTokenBreakdown`, `conversationModels`, `estimatedCostUsd`. Those
+ * are sums over every session that fed the commit, with no record of which
+ * session contributed what, so there is nothing to subtract from them unless the
+ * per-session split was persisted at write time. It now is, on
+ * `StoredSession.usage` / `.usageByModel`, and this module applies it.
+ *
+ * Attribution is per NODE, not per tree: an amend/squash root and its children
+ * each carry their own token fields, so a session detached from a child must be
+ * subtracted from that child — subtracting at the root would corrupt a node that
+ * never carried those tokens while leaving the one that did untouched (and the
+ * tree aggregation in `SummaryTree.ts` walks both).
+ *
+ * `summary.transcripts` is NOT that per-node ownership record, which is why
+ * ownership is resolved by {@link resolveOwners} rather than read off the field.
+ * The array means two different things depending on where it sits:
+ *   - on a leaf — the ids whose sessions this node's token fields cover;
+ *   - on a consolidated root — the tree-wide authoritative INDEX. Amend
+ *     (`QueueWorker`'s `amendTranscripts` = inherited ∪ delta), rebase-pick
+ *     (`migrateOneToOne`) and squash (`mergeManyToOne`, union over children) all
+ *     re-list every descendant id at the root so `getTranscriptIds` finds every
+ *     file — while the root's token fields cover its DELTA only (amend/pick), or
+ *     nothing at all (squash).
+ * A node therefore OWNS an id only when no descendant claims it, and each id must
+ * be subtracted exactly once, at that owner.
+ *
+ * Deliberately forward-only. A node with no `transcripts` array (pre-v5), a
+ * removed session with no stored `usage` (written before the field existed, or a
+ * source that reports no usage), and an id with no single owner are all reported
+ * as unattributable and left EXACTLY as-is. Guessing a subtrahend — splitting the
+ * aggregate evenly, zeroing the node, or subtracting from every node that lists
+ * the id — would replace a known-stale number with an invented one.
+ *
+ * One case ownership resolution deliberately does NOT special-case: a v5-MIGRATED
+ * legacy tree, where `upgradeOneSummary` puts every descendant commit hash on the
+ * root's `transcripts` and leaves the children without the field at all — so the
+ * root is the sole claimant of an id whose sessions a child counted. Nothing is
+ * mis-subtracted in practice because those transcript files predate
+ * `StoredSession.usage` (migration rewrites the schema, not transcript content), so
+ * every session there is unattributable and the subtrahend is zero. If a path ever
+ * backfills `usage` onto legacy transcripts, attribute by `commitHash` here first.
+ */
+
+import type { CommitSummary, ConversationTokenBreakdown, ModelTokenUsage } from "../Types.js";
+import { estimateCostUsd, PRICES_AS_OF } from "./Pricing.js";
+
+/** One detached session's persisted attribution, as read back off the stored transcript. */
+export interface DetachedSessionUsage {
+	readonly usage?: ConversationTokenBreakdown;
+	readonly usageByModel?: ReadonlyArray<ModelTokenUsage>;
+}
+
+export interface DetachedUsageSubtractionResult {
+	/** The summary with corrected figures. Same reference when nothing changed. */
+	readonly summary: CommitSummary;
+	/** True when at least one node's figures were rewritten. */
+	readonly changed: boolean;
+	/**
+	 * Transcript ids whose detached sessions could not be FULLY attributed — any of:
+	 * no node in the tree claims the id, none of its removed sessions carried a
+	 * stored `usage`, or only some of them did (a partial subtraction still leaves
+	 * the figure wrong, so it is reported too). Callers should surface/log this: the
+	 * memory's token bar stays stale or short, and that is a known limitation rather
+	 * than a silent miscount. An id can appear here while `changed` is true — the
+	 * partial case corrects part of the total and reports the rest.
+	 */
+	readonly unattributed: ReadonlyArray<string>;
+}
+
+/**
+ * Finds, for each id of interest, the node(s) that OWN it — list it and have no
+ * descendant that lists it. See the header on why the field alone can't say this.
+ *
+ * Post-order so a node only becomes an owner once its whole subtree has had the
+ * chance to claim the id. The returned set is what the caller's subtree claimed,
+ * restricted to `interest` so an unrelated tree-wide index costs nothing to walk.
+ *
+ * Sibling claimants both land in the list (neither is the other's descendant, so
+ * there is no deepest one); the caller treats that ambiguity as unattributable
+ * rather than subtracting twice.
+ */
+function resolveOwners(
+	node: CommitSummary,
+	interest: ReadonlySet<string>,
+	owners: Map<string, CommitSummary[]>,
+): Set<string> {
+	const claimedBelow = new Set<string>();
+	for (const child of node.children ?? []) {
+		for (const id of resolveOwners(child, interest, owners)) claimedBelow.add(id);
+	}
+	const claimed = new Set(claimedBelow);
+	for (const id of node.transcripts ?? []) {
+		if (!interest.has(id)) continue;
+		claimed.add(id);
+		if (claimedBelow.has(id)) continue;
+		const existing = owners.get(id);
+		if (existing) existing.push(node);
+		else owners.set(id, [node]);
+	}
+	return claimed;
+}
+
+/**
+ * Sums the segments of every detached session recorded against one transcript id.
+ *
+ * `fullyAttributable` is false as soon as ONE removed session carries no stored
+ * `usage`, not only when they all do. A partial sum is a silent under-subtraction:
+ * the caller would subtract the sessions it can account for, leave the rest in the
+ * total, and report nothing — the exact "stale bar with no trace" this module's
+ * header rules out. Reporting the id makes the shortfall visible instead.
+ */
+function sumRemoved(removed: ReadonlyArray<DetachedSessionUsage>): {
+	breakdown: ConversationTokenBreakdown;
+	byModel: Map<string, ModelTokenUsage>;
+	fullyAttributable: boolean;
+} {
+	let input = 0;
+	let output = 0;
+	let cached = 0;
+	let missing = 0;
+	const byModel = new Map<string, ModelTokenUsage>();
+	for (const r of removed) {
+		if (!r.usage) {
+			missing++;
+			continue;
+		}
+		input += r.usage.input;
+		output += r.usage.output;
+		cached += r.usage.cached;
+		for (const m of r.usageByModel ?? []) {
+			const prev = byModel.get(m.model);
+			byModel.set(
+				m.model,
+				prev
+					? {
+							...prev,
+							input: prev.input + m.input,
+							output: prev.output + m.output,
+							cached: prev.cached + m.cached,
+						}
+					: { ...m },
+			);
+		}
+	}
+	return { breakdown: { input, output, cached }, byModel, fullyAttributable: missing === 0 };
+}
+
+/**
+ * Subtracts one node's share and re-derives its cost. Returns the same reference
+ * when the node carries no usage to correct.
+ *
+ * Every segment is floored at 0. A subtrahend can legitimately exceed the stored
+ * value: the node may have been written before the per-line de-duplication fix,
+ * so its aggregate is inflated while the detached session's `usage` is not. A
+ * floor keeps that from producing a negative bar; it does not make the remaining
+ * figure exact, which is why over-subtraction collapses the node to "no usage"
+ * rather than to a fabricated remainder.
+ */
+function subtractFromNode(node: CommitSummary, removed: ReadonlyArray<DetachedSessionUsage>): CommitSummary {
+	const { breakdown: sub, byModel: subByModel } = sumRemoved(removed);
+	if (sub.input + sub.output + sub.cached === 0) return node;
+	if (!node.conversationTokens) return node;
+
+	// Strip the whole group rather than store zeros: the display contract is
+	// "absent means this memory reports no usage", and a stored 0 would render as
+	// a real measurement of nothing (see conversationUsageFields in QueueWorker).
+	const {
+		conversationTokens: _t,
+		conversationTokenBreakdown: _b,
+		conversationModels: _m,
+		estimatedCostUsd: _c,
+		pricesAsOf: _p,
+		...withoutUsage
+	} = node;
+
+	// Remaining per-model split and the cost re-derived from it. Computed for BOTH
+	// node shapes below, not just the breakdown one: `conversationModels` /
+	// `estimatedCostUsd` are independent of `conversationTokenBreakdown`, so a node
+	// that carries a cost but no breakdown would otherwise have that cost silently
+	// deleted by the strip above and never restored.
+	//
+	// Cost is re-derived from the remaining models, never scaled from the old
+	// figure: the detached session may have run a different (or unpriced) model than
+	// the ones left behind, so a proportional adjustment would be wrong.
+	const models: ModelTokenUsage[] = [];
+	for (const m of node.conversationModels ?? []) {
+		const s = subByModel.get(m.model);
+		const remaining: ModelTokenUsage = s
+			? {
+					...m,
+					input: Math.max(0, m.input - s.input),
+					output: Math.max(0, m.output - s.output),
+					cached: Math.max(0, m.cached - s.cached),
+				}
+			: m;
+		if (remaining.input + remaining.output + remaining.cached > 0) models.push(remaining);
+	}
+	const { totalUsd } = estimateCostUsd(models);
+	const costFields = {
+		...(models.length > 0 && { conversationModels: models }),
+		...(totalUsd > 0 && { estimatedCostUsd: totalUsd, pricesAsOf: PRICES_AS_OF }),
+	};
+
+	// Scalar-only node (an older memory that recorded `conversationTokens` but no
+	// per-segment split): subtract from the scalar and leave the breakdown absent,
+	// which is the "total-only degrade" the meter already renders as a single
+	// full-width segment. Treating the missing breakdown as zeros would compute a
+	// remaining total of 0 and wipe usage the memory legitimately still has.
+	const subTotal = sub.input + sub.output + sub.cached;
+	if (!node.conversationTokenBreakdown) {
+		const remaining = Math.max(0, node.conversationTokens - subTotal);
+		if (remaining === 0) return withoutUsage;
+		return { ...withoutUsage, conversationTokens: remaining, ...costFields };
+	}
+
+	const own = node.conversationTokenBreakdown;
+	const input = Math.max(0, own.input - sub.input);
+	const output = Math.max(0, own.output - sub.output);
+	const cached = Math.max(0, own.cached - sub.cached);
+	const total = input + output + cached;
+	if (total === 0) return withoutUsage;
+
+	return {
+		...withoutUsage,
+		conversationTokens: total,
+		conversationTokenBreakdown: { input, output, cached },
+		...costFields,
+	};
+}
+
+/**
+ * Applies `removedByTranscriptId` across the summary tree, subtracting each id's
+ * share exactly once — at the single node that OWNS it (see {@link resolveOwners}
+ * and the module header on why a node listing an id doesn't mean it owns it).
+ *
+ * @param removedByTranscriptId - Detached sessions keyed by the id of the stored
+ *   transcript they were removed from (the same id space as
+ *   `CommitSummary.transcripts`).
+ */
+export function subtractDetachedUsage(
+	summary: CommitSummary,
+	removedByTranscriptId: ReadonlyMap<string, ReadonlyArray<DetachedSessionUsage>>,
+): DetachedUsageSubtractionResult {
+	if (removedByTranscriptId.size === 0) {
+		return { summary, changed: false, unattributed: [] };
+	}
+	const unattributed = new Set<string>();
+	let changed = false;
+
+	// Resolve ownership over the WHOLE tree before touching anything, then apply.
+	// Two passes rather than one because a node cannot tell whether it owns an id
+	// until its descendants have been inspected, and a consolidated root is visited
+	// first.
+	const owners = new Map<string, CommitSummary[]>();
+	resolveOwners(summary, new Set(removedByTranscriptId.keys()), owners);
+
+	// Keyed by node identity — `walk` below receives the very objects `resolveOwners`
+	// recorded, since it reads children off the untouched input tree.
+	const byOwner = new Map<CommitSummary, DetachedSessionUsage[]>();
+	for (const [id, sessions] of removedByTranscriptId) {
+		const claimants = owners.get(id) ?? [];
+		// Zero claimants: the summary and the transcript files disagree about what
+		// belongs to this memory. More than one: ambiguous ownership (see
+		// `resolveOwners`). Neither is guessable, so report and correct nothing.
+		if (claimants.length !== 1) {
+			unattributed.add(id);
+			continue;
+		}
+		if (!sumRemoved(sessions).fullyAttributable) unattributed.add(id);
+		const bucket = byOwner.get(claimants[0]);
+		if (bucket) bucket.push(...sessions);
+		else byOwner.set(claimants[0], [...sessions]);
+	}
+
+	const walk = (node: CommitSummary): CommitSummary => {
+		const removed = byOwner.get(node);
+		const withOwn = removed !== undefined ? subtractFromNode(node, removed) : node;
+		if (withOwn !== node) changed = true;
+
+		const children = node.children;
+		if (!children || children.length === 0) return withOwn;
+		const nextChildren = children.map(walk);
+		// Rebuild the children array only when a descendant actually changed, so an
+		// untouched subtree keeps its identity and callers can compare by reference.
+		return nextChildren.some((c, i) => c !== children[i]) ? { ...withOwn, children: nextChildren } : withOwn;
+	};
+
+	const next = byOwner.size > 0 ? walk(summary) : summary;
+	return { summary: next, changed, unattributed: [...unattributed] };
+}

--- a/cli/src/core/Pricing.test.ts
+++ b/cli/src/core/Pricing.test.ts
@@ -82,6 +82,113 @@ describe("estimateCostUsd", () => {
 	});
 });
 
+describe("MODEL_PRICES coverage", () => {
+	// claude-opus-5 was missing from the table while it was already the model
+	// recorded in real transcripts, so every memory it produced was `unpriced` →
+	// no `estimatedCostUsd` was stored → the UI silently fell back to Sonnet rates
+	// and under-reported the cost of Opus work.
+	it("prices claude-opus-5, the model real transcripts record today", () => {
+		const price = MODEL_PRICES["claude-opus-5"];
+		expect(price).toBeDefined();
+		expect(price.inputPerMTok).toBe(5);
+		expect(price.outputPerMTok).toBe(25);
+		// 5-minute cache WRITE rate — 1.25x input, per the table's segment contract.
+		expect(price.cachedPerMTok).toBe(6.25);
+	});
+
+	// Mythos 5 sits at the same rates as Fable 5 on the published pricing page
+	// (limited availability). Pinned as a deliberate equality rather than left as two
+	// coincidentally-identical rows: identical adjacent numbers are exactly what an
+	// unverified copy looks like, and this table's `-pro` policy forbids guessing.
+	it("prices claude-mythos-5 at the Fable 5 rates the pricing page lists for it", () => {
+		expect(MODEL_PRICES["claude-mythos-5"]).toEqual({
+			provider: "anthropic",
+			inputPerMTok: 10,
+			outputPerMTok: 50,
+			cachedPerMTok: 12.5,
+		});
+		expect(MODEL_PRICES["claude-mythos-5"]).toEqual(MODEL_PRICES["claude-fable-5"]);
+	});
+
+	// Verified against developers.openai.com/api/docs/pricing on 2026-07-29. The
+	// prior values for these three were placeholders copied off the GPT-5 tier and
+	// were wrong (gpt-5.5 by 4x on input), so every Codex conversation on them was
+	// costed too low. Pinned here so a future edit can't quietly re-guess them.
+	it.each([
+		["gpt-5.6-sol", 5, 30, 0.5],
+		["gpt-5.6-terra", 2.5, 15, 0.25],
+		["gpt-5.6-luna", 1, 6, 0.1],
+		["gpt-5.5", 5, 30, 0.5],
+		["gpt-5.4", 2.5, 15, 0.25],
+		["gpt-5.4-mini", 0.75, 4.5, 0.075],
+		["gpt-5.4-nano", 0.2, 1.25, 0.02],
+		["gpt-5.3-codex", 1.75, 14, 0.175],
+		["gpt-5.2-codex", 1.75, 14, 0.175],
+		["gpt-5-mini", 0.25, 2, 0.025],
+		["gpt-5-nano", 0.05, 0.4, 0.005],
+	])("prices %s at the published list rate", (model, input, output, cached) => {
+		expect(MODEL_PRICES[model]).toEqual({
+			provider: "openai",
+			inputPerMTok: input,
+			outputPerMTok: output,
+			cachedPerMTok: cached,
+		});
+	});
+
+	it("prices the OpenAI cached segment BELOW input (a cache read, not a write)", () => {
+		// Inverted from Anthropic, whose cached segment is a cache write at 1.25x input.
+		// Getting this backwards would overstate Codex cost and understate Claude cost.
+		// `-pro` is exempt: the page publishes no cached-input rate for those, so they
+		// are billed at the full input rate (never below) — see the next test.
+		for (const [model, price] of Object.entries(MODEL_PRICES)) {
+			if (price.provider !== "openai" || model.endsWith("-pro")) continue;
+			expect(price.cachedPerMTok, `${model} cached rate should be below input`).toBeLessThan(price.inputPerMTok);
+		}
+		for (const [model, price] of Object.entries(MODEL_PRICES)) {
+			if (price.provider !== "anthropic") continue;
+			expect(price.cachedPerMTok, `${model} cached rate should exceed input`).toBeGreaterThan(price.inputPerMTok);
+		}
+	});
+
+	// Verified against developers.openai.com/api/docs/pricing on 2026-07-30: input and
+	// output are published, the cached-input column shows "-". These rows were absent
+	// while that dash was read as "unpriceable", which sent their WHOLE usage to the
+	// flat Sonnet fallback — $3/$15 for a model billed $30/$180. Pinned so the rows
+	// can't quietly disappear again.
+	it.each([
+		["gpt-5.5-pro", 30, 180],
+		["gpt-5.4-pro", 30, 180],
+		["gpt-5.2-pro", 21, 168],
+		["gpt-5-pro", 15, 120],
+	])("prices %s with its cached segment at the full input rate", (model, input, output) => {
+		expect(MODEL_PRICES[model]).toEqual({
+			provider: "openai",
+			inputPerMTok: input,
+			outputPerMTok: output,
+			// No published discount: either the model doesn't cache (segment is always 0)
+			// or it caches at list price. Equal to input is the only non-invented value.
+			cachedPerMTok: input,
+		});
+	});
+
+	it("costs a -pro conversation far above the Sonnet fallback it used to receive", () => {
+		// The regression this row set fixes, stated in dollars: 1M in + 1M out on
+		// gpt-5.5-pro is $210, where the unpriced path handed the display layer $0 and it
+		// fell back to Sonnet's $3 + $15.
+		const estimate = estimateCostUsd([
+			{ model: "gpt-5.5-pro", provider: "openai", input: 1_000_000, output: 1_000_000, cached: 0 },
+		]);
+		expect(estimate.totalUsd).toBeCloseTo(210, 6);
+		expect(estimate.unpricedModels).toEqual([]);
+	});
+
+	it("leaves no priced model without a cached rate", () => {
+		for (const [model, price] of Object.entries(MODEL_PRICES)) {
+			expect(price.cachedPerMTok, `${model} has no cached rate`).toBeGreaterThan(0);
+		}
+	});
+});
+
 describe("PRICES_AS_OF", () => {
 	it("is an ISO date string", () => {
 		expect(PRICES_AS_OF).toMatch(/^\d{4}-\d{2}-\d{2}$/);

--- a/cli/src/core/Pricing.ts
+++ b/cli/src/core/Pricing.ts
@@ -30,6 +30,17 @@
  * so this table is hand-maintained. {@link PRICES_AS_OF} stamps it. Estimates
  * assume standard list pricing — no promotional/intro, batch, or volume
  * discounts (e.g. Sonnet's intro rate). Surface that caveat next to any figure.
+ *
+ * Official pricing pages — re-verify against these when editing a rate, and bump
+ * {@link PRICES_AS_OF}. Copying a neighbouring row's numbers is how every OpenAI
+ * rate in this table came to be wrong by up to 4x before 2026-07-29:
+ *   - Anthropic: https://platform.claude.com/docs/en/about-claude/pricing
+ *   - OpenAI:    https://developers.openai.com/api/docs/pricing
+ *
+ * One deliberate divergence from the Anthropic page: Sonnet 5 is priced here at
+ * its standard $3/$15 rate, not the $2/$10 introductory rate in effect through
+ * 2026-08-31 — consistent with the no-promotional-pricing rule above, and it
+ * makes the estimate an upper bound for Sonnet 5 work until that date.
  */
 
 import type { ModelTokenUsage, TokenProvider } from "../Types.js";
@@ -47,6 +58,9 @@ export interface ModelPrice {
 	 * provider: an Anthropic cache *write* (~1.25× input, so higher) vs an
 	 * OpenAI cache *read* (~0.1× input, so lower). Keeping it a literal keeps the
 	 * table transparent and the formula uniform.
+	 *
+	 * A third case: OpenAI's `-pro` models publish no cached-input rate, so theirs
+	 * is set EQUAL to input — see the note above those rows.
 	 */
 	readonly cachedPerMTok: number;
 }
@@ -56,19 +70,25 @@ export interface ModelPrice {
  * every summary that carries a cost estimate so a reader can tell how stale the
  * figure is. Bump it whenever a price below changes.
  */
-export const PRICES_AS_OF = "2026-07-04";
+export const PRICES_AS_OF = "2026-07-30";
 
 /**
  * List prices, keyed by the exact model identifier that appears in the
  * transcript (`message.model` for Claude, `turn_context.payload.model` for
  * Codex). Anthropic figures are from the published pricing table; the cached
- * rate is the 5-minute cache-*write* rate (1.25× input). OpenAI GPT-5-family
- * figures are best-known list prices and MUST be re-verified before shipping
- * user-facing cost — treat them as provisional (see the note on each).
+ * rate is the 5-minute cache-*write* rate (1.25× input). OpenAI figures are the
+ * published list prices, verified on the date in {@link PRICES_AS_OF}.
  */
 export const MODEL_PRICES: Readonly<Record<string, ModelPrice>> = {
 	// ── Anthropic (input / output verified; cached = 1.25× input cache-write) ──
 	"claude-fable-5": { provider: "anthropic", inputPerMTok: 10, outputPerMTok: 50, cachedPerMTok: 12.5 },
+	// Mythos 5 is listed on the pricing page as limited-availability at the SAME
+	// rates as Fable 5 ($10 / $12.50 5m-write / $50) — verified there, not inferred
+	// from the neighbouring row. Stated explicitly because identical numbers next to
+	// each other are exactly what an unverified copy looks like, and the `-pro`
+	// policy at the bottom of this table forbids guessing a rate.
+	"claude-mythos-5": { provider: "anthropic", inputPerMTok: 10, outputPerMTok: 50, cachedPerMTok: 12.5 },
+	"claude-opus-5": { provider: "anthropic", inputPerMTok: 5, outputPerMTok: 25, cachedPerMTok: 6.25 },
 	"claude-opus-4-8": { provider: "anthropic", inputPerMTok: 5, outputPerMTok: 25, cachedPerMTok: 6.25 },
 	"claude-opus-4-7": { provider: "anthropic", inputPerMTok: 5, outputPerMTok: 25, cachedPerMTok: 6.25 },
 	"claude-opus-4-6": { provider: "anthropic", inputPerMTok: 5, outputPerMTok: 25, cachedPerMTok: 6.25 },
@@ -77,13 +97,56 @@ export const MODEL_PRICES: Readonly<Record<string, ModelPrice>> = {
 	"claude-sonnet-4-6": { provider: "anthropic", inputPerMTok: 3, outputPerMTok: 15, cachedPerMTok: 3.75 },
 	"claude-sonnet-4-5": { provider: "anthropic", inputPerMTok: 3, outputPerMTok: 15, cachedPerMTok: 3.75 },
 	"claude-haiku-4-5": { provider: "anthropic", inputPerMTok: 1, outputPerMTok: 5, cachedPerMTok: 1.25 },
-	// ── OpenAI / Codex (PROVISIONAL — re-verify before shipping) ──────────────
-	// cached = cache-read rate (~0.1× input). gpt-5.4 / gpt-5.5 are post-cutoff;
-	// numbers mirror the GPT-5 list tier and must be confirmed against OpenAI's
-	// current pricing page. Unknown models simply fall through to "unpriced".
-	"gpt-5.5": { provider: "openai", inputPerMTok: 1.25, outputPerMTok: 10, cachedPerMTok: 0.125 },
-	"gpt-5.4": { provider: "openai", inputPerMTok: 1.25, outputPerMTok: 10, cachedPerMTok: 0.125 },
-	"gpt-5.2-codex": { provider: "openai", inputPerMTok: 1.25, outputPerMTok: 10, cachedPerMTok: 0.125 },
+	// ── OpenAI / Codex ────────────────────────────────────────────────────────
+	// Verified against developers.openai.com/api/docs/pricing on 2026-07-29.
+	// `cached` is OpenAI's cached-input rate — a cache READ (0.1× input), the
+	// opposite direction from Anthropic's cache-write rate above; the parser
+	// subtracts the cached portion out of `input` before it reaches here, so the
+	// two segments stay disjoint (see the module header).
+	//
+	// The previous values for the three pre-existing rows were placeholders that
+	// mirrored the GPT-5 list tier and were all wrong — gpt-5.5 by 4× on input
+	// and 3× on output — which silently under-reported the cost of every Codex
+	// conversation on those models. Re-verify against the page above when adding
+	// a row rather than copying a neighbour's numbers.
+	"gpt-5.6-sol": { provider: "openai", inputPerMTok: 5, outputPerMTok: 30, cachedPerMTok: 0.5 },
+	"gpt-5.6-terra": { provider: "openai", inputPerMTok: 2.5, outputPerMTok: 15, cachedPerMTok: 0.25 },
+	"gpt-5.6-luna": { provider: "openai", inputPerMTok: 1, outputPerMTok: 6, cachedPerMTok: 0.1 },
+	"gpt-5.5": { provider: "openai", inputPerMTok: 5, outputPerMTok: 30, cachedPerMTok: 0.5 },
+	"gpt-5.4": { provider: "openai", inputPerMTok: 2.5, outputPerMTok: 15, cachedPerMTok: 0.25 },
+	"gpt-5.4-mini": { provider: "openai", inputPerMTok: 0.75, outputPerMTok: 4.5, cachedPerMTok: 0.075 },
+	"gpt-5.4-nano": { provider: "openai", inputPerMTok: 0.2, outputPerMTok: 1.25, cachedPerMTok: 0.02 },
+	"gpt-5.3-codex": { provider: "openai", inputPerMTok: 1.75, outputPerMTok: 14, cachedPerMTok: 0.175 },
+	"gpt-5.2": { provider: "openai", inputPerMTok: 1.75, outputPerMTok: 14, cachedPerMTok: 0.175 },
+	"gpt-5.2-codex": { provider: "openai", inputPerMTok: 1.75, outputPerMTok: 14, cachedPerMTok: 0.175 },
+	"gpt-5.1": { provider: "openai", inputPerMTok: 1.25, outputPerMTok: 10, cachedPerMTok: 0.125 },
+	"gpt-5.1-codex-max": { provider: "openai", inputPerMTok: 1.25, outputPerMTok: 10, cachedPerMTok: 0.125 },
+	"gpt-5.1-codex": { provider: "openai", inputPerMTok: 1.25, outputPerMTok: 10, cachedPerMTok: 0.125 },
+	"gpt-5": { provider: "openai", inputPerMTok: 1.25, outputPerMTok: 10, cachedPerMTok: 0.125 },
+	"gpt-5-codex": { provider: "openai", inputPerMTok: 1.25, outputPerMTok: 10, cachedPerMTok: 0.125 },
+	"gpt-5-mini": { provider: "openai", inputPerMTok: 0.25, outputPerMTok: 2, cachedPerMTok: 0.025 },
+	"gpt-5-nano": { provider: "openai", inputPerMTok: 0.05, outputPerMTok: 0.4, cachedPerMTok: 0.005 },
+	// ── OpenAI `-pro`: cached segment at the FULL input rate ──────────────────
+	// The pricing page states input and output for these but shows "-" in the
+	// cached-input column, with no note explaining the dash. They were absent from
+	// this table for that reason — but absence is the worse error of the two:
+	// an unpriced model contributes $0 here, so the display layer prices its ENTIRE
+	// usage at the flat Sonnet fallback (see `estimateCost` in SummaryHtmlBuilder and
+	// `estimateConversationCostUsd`) — $3/$15 against gpt-5.5-pro's real $30/$180, a
+	// ~10x understatement across every segment. Pricing the two published segments
+	// correctly and the undocumented one at the full input rate keeps the error inside
+	// the cached segment alone.
+	//
+	// The input rate is also the only non-invented value available for that segment:
+	// the dash means either the model does not support prompt caching (then `cached`
+	// is always 0 and the rate never applies) or it caches with no discount (then the
+	// input rate is exactly right). Both readings are consistent with billing at the
+	// input rate; neither supports a discount, which is what a made-up number would
+	// imply. Same spirit as the no-promotional-pricing rule: prefer the upper bound.
+	"gpt-5.5-pro": { provider: "openai", inputPerMTok: 30, outputPerMTok: 180, cachedPerMTok: 30 },
+	"gpt-5.4-pro": { provider: "openai", inputPerMTok: 30, outputPerMTok: 180, cachedPerMTok: 30 },
+	"gpt-5.2-pro": { provider: "openai", inputPerMTok: 21, outputPerMTok: 168, cachedPerMTok: 21 },
+	"gpt-5-pro": { provider: "openai", inputPerMTok: 15, outputPerMTok: 120, cachedPerMTok: 15 },
 };
 
 /** Result of estimating cost across a set of per-model usage buckets. */

--- a/cli/src/core/RegenerateContext.test.ts
+++ b/cli/src/core/RegenerateContext.test.ts
@@ -103,6 +103,26 @@ describe("loadRegenerateContext", () => {
 		expect(ctx.sources).toEqual(["Claude"]);
 	});
 
+	it("excludes a usage-only carrier from sessionCount but keeps an entries-less legacy session", async () => {
+		// A carrier is a zero-entry session that carries `usage` — stored only so a
+		// later detach has a token subtrahend, and hidden from every Conversations
+		// surface. Counting it would make the confirm dialog promise a conversation the
+		// user cannot see, and it contributes nothing to the regenerate prompt anyway.
+		// A session that merely omits/empties `entries` WITHOUT `usage` is legacy data
+		// and must keep counting.
+		vi.mocked(SummaryStore.readTranscriptsForCommits).mockResolvedValue(
+			singleHashMap(baseSummary.commitHash, {
+				sessions: [
+					{ sessionId: "carrier", source: "claude", entries: [], usage: { input: 6, output: 3, cached: 0 } },
+					{ sessionId: "legacy", source: "claude", entries: [] },
+				],
+			}),
+		);
+
+		const ctx = await loadRegenerateContext(baseSummary, "/repo");
+		expect(ctx.sessionCount).toBe(1);
+	});
+
 	it("defaults missing session.source to 'claude' for sessionId dedup keys", async () => {
 		// Legacy / partial stored sessions may not carry .source. The
 		// dedup key uses `session.source ?? "claude"` so two sessions

--- a/cli/src/core/RegenerateContext.ts
+++ b/cli/src/core/RegenerateContext.ts
@@ -68,6 +68,14 @@ export async function loadRegenerateContext(
 			for (const entry of session.entries) {
 				if (entry.role === "human") humanTurns++;
 			}
+			// Skip a usage-only carrier: the queue worker stores a zero-entry session
+			// carrying `usage` purely so `detach` has a token subtrahend, and the
+			// Conversations surfaces hide it. Counting it here would make the confirm
+			// dialog promise a conversation the user cannot see (and which contributes
+			// nothing to the regenerate prompt — buildMultiSessionContext emits no block
+			// for an entry-less session). A session that merely omits `entries` is legacy
+			// data, not a carrier, and still counts — hence the `usage` half.
+			if (session.entries.length === 0 && session.usage !== undefined) continue;
 			const sourceKey = session.source ?? "claude";
 			seenSessions.add(`${sourceKey}:${session.sessionId}`);
 			sourceSet.add(transcriptSourceLabel(session.source));

--- a/cli/src/core/TranscriptParser.test.ts
+++ b/cli/src/core/TranscriptParser.test.ts
@@ -208,6 +208,34 @@ describe("ClaudeTranscriptParser", () => {
 	});
 
 	describe("parseUsageTokens", () => {
+		it("emits message.id as the dedupKey so repeated block lines collapse to one response", () => {
+			const line = JSON.stringify({
+				type: "assistant",
+				message: {
+					id: "msg_01EWeKJMpUeBRTNGECP3PiaQ",
+					role: "assistant",
+					content: [{ type: "thinking", thinking: "…" }],
+					usage: { input_tokens: 15654, cache_creation_input_tokens: 23100, output_tokens: 1402 },
+				},
+			});
+			expect(parser.parseUsageTokens(line, 1)).toEqual({
+				input: 15654,
+				output: 1402,
+				cached: 23100,
+				dedupKey: "msg_01EWeKJMpUeBRTNGECP3PiaQ",
+			});
+		});
+
+		it("omits dedupKey when the line carries no message.id, so the line still counts", () => {
+			const line = JSON.stringify({
+				type: "assistant",
+				message: { role: "assistant", content: [], usage: { input_tokens: 7, output_tokens: 1 } },
+			});
+			const parsed = parser.parseUsageTokens(line, 1);
+			expect(parsed).toEqual({ input: 7, output: 1, cached: 0 });
+			expect(parsed.dedupKey).toBeUndefined();
+		});
+
 		it("sums input + cache_creation + output, EXCLUDING the cumulative cache_read prefix", () => {
 			const line = JSON.stringify({
 				type: "assistant",
@@ -322,6 +350,62 @@ describe("ClaudeTranscriptParser", () => {
 				type: "assistant",
 				message: { role: "assistant", content: [{ type: "text", text: "x" }], model, usage },
 			});
+
+		// Real-shape regression: Claude Code writes one line per content block of a
+		// single assistant response and repeats that response's whole `usage` object
+		// verbatim on each. The `message.id` + usage values below are copied from a
+		// real transcript (~/.claude/projects/-Users-flyer-jolli-code-jollimemory/
+		// 9cc7113b-….jsonl, captured 2026-07-29) where msg_01EWeKJMpUeBRTNGECP3PiaQ
+		// spans 5 lines: thinking, text, and three parallel tool_use blocks — all
+		// carrying in=15654 out=1402 cc=23100. Summing per line bills that one API
+		// call 5×. Across that file, 186 of 262 responses repeat this way, inflating
+		// the total 2.54×; the worst measured file inflated 10.13×.
+		it("counts one response once even when its blocks span five lines (real transcript shape)", () => {
+			const usage = {
+				input_tokens: 15654,
+				cache_creation_input_tokens: 23100,
+				cache_read_input_tokens: 18831,
+				output_tokens: 1402,
+			};
+			const blockLine = (content: unknown): string =>
+				JSON.stringify({
+					type: "assistant",
+					message: {
+						id: "msg_01EWeKJMpUeBRTNGECP3PiaQ",
+						role: "assistant",
+						model: "claude-opus-5",
+						stop_reason: "tool_use",
+						content: [content],
+						usage,
+					},
+				});
+			const lines = [
+				blockLine({ type: "thinking", thinking: "…" }),
+				blockLine({ type: "text", text: "Let me check three files." }),
+				blockLine({ type: "tool_use", id: "toolu_1", name: "Read", input: {} }),
+				blockLine({ type: "tool_use", id: "toolu_2", name: "Read", input: {} }),
+				blockLine({ type: "tool_use", id: "toolu_3", name: "Read", input: {} }),
+			];
+			expect(parser.parseUsageByModel(lines)).toEqual([
+				{ model: "claude-opus-5", provider: "anthropic", input: 15654, output: 1402, cached: 23100 },
+			]);
+		});
+
+		it("still sums distinct responses that share a model", () => {
+			const withId = (id: string, usage: Record<string, number>): string =>
+				JSON.stringify({
+					type: "assistant",
+					message: { id, role: "assistant", model: "claude-opus-5", content: [], usage },
+				});
+			const lines = [
+				withId("msg_a", { input_tokens: 10, output_tokens: 1, cache_creation_input_tokens: 2 }),
+				withId("msg_a", { input_tokens: 10, output_tokens: 1, cache_creation_input_tokens: 2 }), // repeat block
+				withId("msg_b", { input_tokens: 30, output_tokens: 3, cache_creation_input_tokens: 4 }),
+			];
+			expect(parser.parseUsageByModel(lines)).toEqual([
+				{ model: "claude-opus-5", provider: "anthropic", input: 40, output: 4, cached: 6 },
+			]);
+		});
 
 		it("buckets by model with the same segment semantics as parseUsageTokens", () => {
 			const line = turn("claude-opus-4-8", {

--- a/cli/src/core/TranscriptParser.ts
+++ b/cli/src/core/TranscriptParser.ts
@@ -11,7 +11,7 @@
  */
 
 import { createLogger } from "../Logger.js";
-import type { ConversationTokenBreakdown, ModelTokenUsage, TranscriptEntry } from "../Types.js";
+import type { ModelTokenUsage, ParsedTurnUsage, TranscriptEntry } from "../Types.js";
 import { parseTranscriptLine } from "./TranscriptReader.js";
 
 const log = createLogger("TranscriptParser");
@@ -23,9 +23,11 @@ const log = createLogger("TranscriptParser");
 export interface TranscriptParser {
 	parseLine(line: string, lineNum: number): TranscriptEntry | null;
 	/** Per-turn token usage split into input / output / cached segments. The
-	 *  reader sums these into the scalar `usageTokens` total. Absent method =
-	 *  source exposes no usage (all downstream sums default to 0). */
-	parseUsageTokens?(line: string, lineNum: number): ConversationTokenBreakdown;
+	 *  reader sums these into the scalar `usageTokens` total, skipping any line
+	 *  whose `dedupKey` it has already counted — see {@link ParsedTurnUsage} for
+	 *  why one response can arrive on several lines. Absent method = source
+	 *  exposes no usage (all downstream sums default to 0). */
+	parseUsageTokens?(line: string, lineNum: number): ParsedTurnUsage;
 	/** Per-model token usage over a whole consumed slice, one bucket per model
 	 *  the transcript attributed tokens to. Whole-slice (not per-line) because a
 	 *  source may record the model on a *different* line than the usage (e.g.
@@ -51,10 +53,19 @@ export class ClaudeTranscriptParser implements TranscriptParser {
 		return parseTranscriptLine(line, lineNum);
 	}
 
-	parseUsageTokens(line: string, _lineNum?: number): ConversationTokenBreakdown {
+	parseUsageTokens(line: string, _lineNum?: number): ParsedTurnUsage {
 		const usage = extractClaudeUsage(line);
 		if (!usage) return { input: 0, output: 0, cached: 0 };
-		return { input: usage.input, output: usage.output, cached: usage.cached };
+		return {
+			input: usage.input,
+			output: usage.output,
+			cached: usage.cached,
+			// `message.id` identifies the API response, not the line. Several lines
+			// (one per content block) repeat the same id and the same usage object;
+			// the reader counts only the first. Omitted when the id is absent so the
+			// line still counts rather than being silently dropped.
+			...(usage.id && { dedupKey: usage.id }),
+		};
 	}
 
 	/**
@@ -63,12 +74,22 @@ export class ClaudeTranscriptParser implements TranscriptParser {
 	 * drift from {@link parseUsageTokens}. Lines with usage but no model string
 	 * are bucketed under an empty model id (provider "anthropic") — they still
 	 * count toward tokens; pricing will treat an unknown id as unpriced.
+	 *
+	 * De-duplicates by `message.id` for the same reason the reader does (see
+	 * {@link ParsedTurnUsage}) — and it must dedupe on the SAME identity, or the
+	 * per-model buckets would drift from the breakdown and the cost estimate
+	 * would be priced off a larger token count than the bar displays.
 	 */
 	parseUsageByModel(lines: ReadonlyArray<string>): ModelTokenUsage[] {
 		const byModel = new Map<string, ModelTokenUsage>();
+		const seen = new Set<string>();
 		for (const line of lines) {
 			const usage = extractClaudeUsage(line);
 			if (!usage) continue;
+			if (usage.id) {
+				if (seen.has(usage.id)) continue;
+				seen.add(usage.id);
+			}
 			const existing = byModel.get(usage.model);
 			if (existing) {
 				byModel.set(usage.model, {
@@ -197,11 +218,17 @@ function parseCodexAgentMessage(
  * `model` is `message.model` (falling back to a top-level `model`), or an empty
  * string when absent; the turn still counts toward tokens and pricing treats an
  * empty/unknown id as unpriced.
+ *
+ * `id` is `message.id` — the API response's identity, used to collapse the
+ * several lines one response is written across (see `ParsedTurnUsage`). Empty
+ * when absent, which makes the caller count the line unconditionally.
  */
-function extractClaudeUsage(line: string): { model: string; input: number; output: number; cached: number } | null {
+function extractClaudeUsage(
+	line: string,
+): { id: string; model: string; input: number; output: number; cached: number } | null {
 	try {
 		const o = JSON.parse(line) as {
-			message?: { usage?: Record<string, unknown>; model?: unknown };
+			message?: { usage?: Record<string, unknown>; model?: unknown; id?: unknown };
 			usage?: Record<string, unknown>;
 			model?: unknown;
 		};
@@ -210,7 +237,9 @@ function extractClaudeUsage(line: string): { model: string; input: number; outpu
 		const n = (k: string) => (typeof u[k] === "number" ? (u[k] as number) : 0);
 		const rawModel = o.message?.model ?? o.model;
 		const model = typeof rawModel === "string" ? rawModel : "";
+		const rawId = o.message?.id;
 		return {
+			id: typeof rawId === "string" ? rawId : "",
 			model,
 			input: n("input_tokens"),
 			output: n("output_tokens"),

--- a/cli/src/core/TranscriptReader.test.ts
+++ b/cli/src/core/TranscriptReader.test.ts
@@ -973,6 +973,82 @@ describe("TranscriptReader", () => {
 			expect(result.usageBreakdown).toEqual({ input: 100, output: 5, cached: 20 });
 		});
 
+		// The bug this pins: the token bar read 13M for one commit whose real usage was
+		// ~5M. Claude Code writes one JSONL line per content block of an assistant
+		// response — thinking, text, and one per parallel tool_use — and every line
+		// repeats that response's whole `usage` object verbatim, so accumulating per
+		// line billed one API call once per block. Measured inflation across six real
+		// transcripts: 2.17×–10.13×, the high end being turns that fire six or seven
+		// tool calls from a single response. Shape and values below are copied from a
+		// real transcript (9cc7113b-….jsonl, captured 2026-07-29).
+		it("counts a multi-block response once, not once per block line", async () => {
+			const filePath = join(tempDir, "claude-usage-multiblock.jsonl");
+			const usage = {
+				input_tokens: 15654,
+				cache_creation_input_tokens: 23100,
+				cache_read_input_tokens: 18831,
+				output_tokens: 1402,
+			};
+			const block = (content: unknown): string =>
+				JSON.stringify({
+					type: "assistant",
+					message: {
+						id: "msg_01EWeKJMpUeBRTNGECP3PiaQ",
+						role: "assistant",
+						model: "claude-opus-5",
+						stop_reason: "tool_use",
+						content: [content],
+						usage,
+					},
+					timestamp: "2026-07-29T02:11:00Z",
+				});
+			await writeFile(
+				filePath,
+				[
+					block({ type: "thinking", thinking: "…" }),
+					block({ type: "text", text: "Checking three files." }),
+					block({ type: "tool_use", id: "toolu_1", name: "Read", input: {} }),
+					block({ type: "tool_use", id: "toolu_2", name: "Read", input: {} }),
+					block({ type: "tool_use", id: "toolu_3", name: "Read", input: {} }),
+				].join("\n"),
+				"utf-8",
+			);
+
+			const result = await readTranscript(filePath);
+			// One response → counted once: 15654 + 1402 + 23100 = 40156.
+			// Pre-fix this returned 5 × 40156 = 200780.
+			expect(result.usageTokens).toBe(40156);
+			expect(result.usageBreakdown).toEqual({ input: 15654, output: 1402, cached: 23100 });
+			// The per-model split must dedupe on the SAME identity, or the cost estimate
+			// would be priced off more tokens than the bar displays.
+			expect(result.usageByModel).toEqual([
+				{ model: "claude-opus-5", provider: "anthropic", input: 15654, output: 1402, cached: 23100 },
+			]);
+		});
+
+		it("keeps counting separate responses that repeat identical usage values", async () => {
+			const filePath = join(tempDir, "claude-usage-distinct-ids.jsonl");
+			// Two genuinely distinct API calls that happen to report the same numbers —
+			// deduping on the values rather than on message.id would wrongly drop one.
+			const turn = (id: string): string =>
+				JSON.stringify({
+					type: "assistant",
+					message: {
+						id,
+						role: "assistant",
+						model: "claude-opus-5",
+						content: [{ type: "text", text: "x" }],
+						usage: { input_tokens: 10, cache_creation_input_tokens: 2, output_tokens: 1 },
+					},
+					timestamp: "2026-07-29T02:11:00Z",
+				});
+			await writeFile(filePath, [turn("msg_a"), turn("msg_b")].join("\n"), "utf-8");
+
+			const result = await readTranscript(filePath);
+			expect(result.usageTokens).toBe(26);
+			expect(result.usageBreakdown).toEqual({ input: 20, output: 2, cached: 4 });
+		});
+
 		it("produces per-model usage buckets from the consumed slice", async () => {
 			const filePath = join(tempDir, "claude-usage-by-model.jsonl");
 			const lines = [

--- a/cli/src/core/TranscriptReader.ts
+++ b/cli/src/core/TranscriptReader.ts
@@ -21,7 +21,14 @@
 
 import { readFile } from "node:fs/promises";
 import { createLogger } from "../Logger.js";
-import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult, TranscriptSource } from "../Types.js";
+import type {
+	ConversationTokenBreakdown,
+	ModelTokenUsage,
+	TranscriptCursor,
+	TranscriptEntry,
+	TranscriptReadResult,
+	TranscriptSource,
+} from "../Types.js";
 import type { TranscriptParser } from "./TranscriptParser.js";
 import { ClaudeTranscriptParser } from "./TranscriptParser.js";
 
@@ -109,6 +116,18 @@ export async function readTranscript(
 	let usageInput = 0;
 	let usageOutput = 0;
 	let usageCached = 0;
+	// Response ids already counted in this read. One API response is written
+	// across several lines (one per content block) and every line repeats that
+	// response's whole `usage` object, so counting per line multiplied real usage
+	// by the block count — 2.2×–10× on measured transcripts. See ParsedTurnUsage.
+	//
+	// Scoped to this read, which closes the inflation within a slice but not the
+	// rarer cross-slice case: if `beforeTimestamp` cuts between two blocks of one
+	// response, this commit counts it and the next commit counts it again (each
+	// read starts with an empty set). Bounded to one duplicated response per
+	// commit boundary — closing it fully means persisting the last counted id in
+	// the cursor, which is not worth the schema change at that magnitude.
+	const countedUsageKeys = new Set<string>();
 
 	for (let i = 0; i < newLines.length; i++) {
 		const lineNum = startLine + i;
@@ -130,9 +149,12 @@ export async function readTranscript(
 		if (entry) {
 			rawEntries.push(entry);
 		}
-		// Accumulate per-line token usage (per segment) from the parser
+		// Accumulate per-response token usage (per segment) from the parser. A line
+		// whose response was already counted contributes nothing; a line with no
+		// `dedupKey` always counts (sources that report usage once per line).
 		const usage = activeParser.parseUsageTokens?.(newLines[i], lineNum);
-		if (usage) {
+		if (usage && !(usage.dedupKey && countedUsageKeys.has(usage.dedupKey))) {
+			if (usage.dedupKey) countedUsageKeys.add(usage.dedupKey);
 			usageInput += usage.input;
 			usageOutput += usage.output;
 			usageCached += usage.cached;
@@ -328,6 +350,13 @@ export interface SessionTranscript {
 	 */
 	readonly source?: TranscriptSource;
 	readonly entries: ReadonlyArray<TranscriptEntry>;
+	/** This session's own share of the commit's conversation tokens, attached by
+	 *  the queue worker after overlay reconciliation so `buildStoredTranscript`
+	 *  can persist it (see {@link StoredSession.usage} for why it must survive
+	 *  the write). Absent for sources whose transcript carries no usage. */
+	readonly usage?: ConversationTokenBreakdown;
+	/** Per-model split of {@link usage}. */
+	readonly usageByModel?: ReadonlyArray<ModelTokenUsage>;
 }
 
 /**

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -2407,6 +2407,257 @@ describe("QueueWorker", () => {
 			expect(stored.sessions[0].source).toBeUndefined();
 			expect(stored.sessions[0].transcriptPath).toBe("/claude/legacy.jsonl");
 		});
+
+		it("persists each session's own token attribution so a later detach can subtract it", async () => {
+			// The worker computes this split in memory while reading slices; before it was
+			// persisted, only the merged total reached disk and detaching one conversation
+			// from a committed memory had no subtrahend to correct the token bar with.
+			const stored = __test__.buildStoredTranscript([
+				{
+					sessionId: "s1",
+					transcriptPath: "/claude/s1.jsonl",
+					source: "claude",
+					entries: [],
+					usage: { input: 100, output: 200, cached: 700 },
+					usageByModel: [
+						{ model: "claude-opus-5", provider: "anthropic", input: 100, output: 200, cached: 700 },
+					],
+				},
+			]);
+
+			expect(stored.sessions[0].usage).toEqual({ input: 100, output: 200, cached: 700 });
+			expect(stored.sessions[0].usageByModel).toEqual([
+				{ model: "claude-opus-5", provider: "anthropic", input: 100, output: 200, cached: 700 },
+			]);
+		});
+
+		it("omits an all-zero usage record so absent stays distinguishable from zero", async () => {
+			// A stored zero would read as "this session used nothing", which detach would
+			// treat as a valid no-op subtraction; absent means "cannot attribute" and
+			// leaves the memory's totals alone. Sources with no usage must land on absent.
+			const stored = __test__.buildStoredTranscript([
+				{
+					sessionId: "s1",
+					transcriptPath: "/gemini/s1.json",
+					source: "gemini",
+					entries: [],
+					usage: { input: 0, output: 0, cached: 0 },
+					usageByModel: [],
+				},
+			]);
+
+			expect(stored.sessions[0]).not.toHaveProperty("usage");
+			expect(stored.sessions[0]).not.toHaveProperty("usageByModel");
+		});
+	});
+
+	describe("attachPerSessionUsage", () => {
+		const bucket = (input: number, output: number, cached: number) => ({
+			tokens: input + output + cached,
+			breakdown: { input, output, cached },
+			byModel: new Map([
+				["claude-opus-5", { model: "claude-opus-5", provider: "anthropic" as const, input, output, cached }],
+			]),
+		});
+
+		it("attaches the bucket to exactly one slice when a conversation yields several", () => {
+			// readAllTranscripts merges repeated slices of one conversation into a SINGLE
+			// bucket but pushes one SessionTranscript per slice. Copying the bucket onto
+			// every slice would persist the usage twice, and detach sums ALL stored
+			// sessions matching the key — so it would subtract 2x what the summary counted
+			// and Math.max(0, …) would floor the meter to "not reported".
+			const slices = [
+				{ sessionId: "s1", transcriptPath: "/a/s1.jsonl", source: "cline" as const, entries: [] },
+				{ sessionId: "s1", transcriptPath: "/b/s1.jsonl", source: "cline" as const, entries: [] },
+			];
+			const out = __test__.attachPerSessionUsage(
+				slices,
+				new Map([["cline:s1", bucket(100, 200, 700)]]),
+				new Map(),
+				new Map(),
+			);
+
+			const carriers = out.filter((s) => s.usage !== undefined);
+			expect(carriers).toHaveLength(1);
+			expect(carriers[0].usage).toEqual({ input: 100, output: 200, cached: 700 });
+			// The sum across all persisted slices must equal the bucket exactly once —
+			// this is the number detach subtracts.
+			const persistedTotal = out.reduce(
+				(acc, s) => acc + (s.usage ? s.usage.input + s.usage.output + s.usage.cached : 0),
+				0,
+			);
+			expect(persistedTotal).toBe(1000);
+		});
+
+		it("keeps distinct conversations independent", () => {
+			const out = __test__.attachPerSessionUsage(
+				[
+					{ sessionId: "s1", transcriptPath: "/a.jsonl", source: "claude" as const, entries: [] },
+					{ sessionId: "s2", transcriptPath: "/b.jsonl", source: "claude" as const, entries: [] },
+				],
+				new Map([
+					["claude:s1", bucket(1, 2, 3)],
+					["claude:s2", bucket(10, 20, 30)],
+				]),
+				new Map(),
+				new Map(),
+			);
+
+			expect(out[0].usage).toEqual({ input: 1, output: 2, cached: 3 });
+			expect(out[1].usage).toEqual({ input: 10, output: 20, cached: 30 });
+		});
+
+		it("attaches nothing for a session an overlay pruned", () => {
+			// Pruned sessions are excluded from the summary totals, so persisting their
+			// raw pre-overlay usage would over-subtract on a later detach.
+			const out = __test__.attachPerSessionUsage(
+				[{ sessionId: "s1", transcriptPath: "/a.jsonl", source: "claude" as const, entries: [] }],
+				new Map([["claude:s1", bucket(100, 200, 700)]]),
+				new Map([["claude:s1", 5]]),
+				new Map([["claude:s1", 2]]),
+			);
+
+			expect(out[0]).not.toHaveProperty("usage");
+		});
+
+		it("leaves a slice untouched when no bucket recorded its conversation", () => {
+			const out = __test__.attachPerSessionUsage(
+				[{ sessionId: "s1", transcriptPath: "/a.jsonl", source: "claude" as const, entries: [] }],
+				new Map(),
+				new Map(),
+				new Map(),
+			);
+
+			expect(out[0]).not.toHaveProperty("usage");
+			expect(out[0]).not.toHaveProperty("usageByModel");
+		});
+
+		it("omits usageByModel when the bucket recorded no model", () => {
+			const out = __test__.attachPerSessionUsage(
+				[{ sessionId: "s1", transcriptPath: "/a.jsonl", source: "claude" as const, entries: [] }],
+				new Map([
+					["claude:s1", { tokens: 3, breakdown: { input: 1, output: 2, cached: 0 }, byModel: new Map() }],
+				]),
+				new Map(),
+				new Map(),
+			);
+
+			expect(out[0].usage).toEqual({ input: 1, output: 2, cached: 0 });
+			expect(out[0]).not.toHaveProperty("usageByModel");
+		});
+	});
+
+	// ─── usage-only carrier: the persistence path for tokens with no entries ─────
+	// `attachPerSessionUsage` can only attach a bucket to a SessionTranscript that
+	// EXISTS. A conversation whose every slice yielded zero merged entries never got
+	// one, so its tokens reached the summary while no `StoredSession.usage` reached
+	// disk — leaving detach with nothing to subtract. These pin the carrier policy.
+	describe("appendUsageOnlyCarriers", () => {
+		const bucket = (input: number, output: number, cached: number) => ({
+			tokens: input + output + cached,
+			breakdown: { input, output, cached },
+			byModel: new Map<string, never>(),
+		});
+		const identity = (sessionId: string, source: "claude" | "cline" = "claude") => ({
+			sessionId,
+			transcriptPath: `/tmp/${sessionId}.jsonl`,
+			source,
+		});
+
+		it("appends one zero-entry carrier for a conversation with tokens but no entries", () => {
+			const sessionTranscripts: Parameters<typeof __test__.appendUsageOnlyCarriers>[0] = [];
+
+			__test__.appendUsageOnlyCarriers(
+				sessionTranscripts,
+				new Map([["claude:s1", bucket(600, 300, 0)]]),
+				new Map([["claude:s1", identity("s1")]]),
+			);
+
+			expect(sessionTranscripts).toHaveLength(1);
+			expect(sessionTranscripts[0].sessionId).toBe("s1");
+			expect(sessionTranscripts[0].source).toBe("claude");
+			expect(sessionTranscripts[0].transcriptPath).toBe("/tmp/s1.jsonl");
+			expect(sessionTranscripts[0].entries).toHaveLength(0);
+			// The carrier is bare — attachPerSessionUsage (which runs later, in
+			// loadSessionTranscripts) is the single place that stamps `usage`.
+			expect(sessionTranscripts[0]).not.toHaveProperty("usage");
+		});
+
+		it("appends nothing when the conversation already has an entry-bearing slice", () => {
+			// Its bucket rides that real slice; a second, entry-less object for the same
+			// key would be persisted entry-less AND usage-less (attachPerSessionUsage is
+			// first-wins per key) — pure noise in the stored transcript.
+			const sessionTranscripts = [
+				{
+					sessionId: "s1",
+					transcriptPath: "/tmp/s1.jsonl",
+					source: "claude" as const,
+					entries: [{ role: "human" as const, content: "hi" }],
+				},
+			];
+
+			__test__.appendUsageOnlyCarriers(
+				sessionTranscripts,
+				new Map([["claude:s1", bucket(600, 300, 0)]]),
+				new Map([["claude:s1", identity("s1")]]),
+			);
+
+			expect(sessionTranscripts).toHaveLength(1);
+			expect(sessionTranscripts[0].entries).toHaveLength(1);
+		});
+
+		it("appends nothing for a conversation that recorded zero tokens", () => {
+			// No entries AND no tokens: buildStoredTranscript would emit a session with
+			// neither content nor a `usage` record, which detach reads as "cannot
+			// attribute" anyway. Persisting it only invents an empty conversation.
+			const sessionTranscripts: Parameters<typeof __test__.appendUsageOnlyCarriers>[0] = [];
+
+			__test__.appendUsageOnlyCarriers(
+				sessionTranscripts,
+				new Map([["claude:s1", bucket(0, 0, 0)]]),
+				new Map([["claude:s1", identity("s1")]]),
+			);
+
+			expect(sessionTranscripts).toHaveLength(0);
+		});
+
+		it("appends exactly ONE carrier when a conversation had several usage-only slices", () => {
+			// readAllTranscripts merges repeated slices into a SINGLE bucket, so N
+			// carriers would mean N-1 entry-less, usage-less sessions on disk.
+			const sessionTranscripts: Parameters<typeof __test__.appendUsageOnlyCarriers>[0] = [];
+
+			__test__.appendUsageOnlyCarriers(
+				sessionTranscripts,
+				new Map([["claude:s1", bucket(600, 300, 0)]]),
+				// One identity per conversationKey by construction (first slice wins), so
+				// the merged bucket can only ever produce one carrier.
+				new Map([["claude:s1", identity("s1")]]),
+			);
+
+			expect(sessionTranscripts.filter((s) => s.sessionId === "s1")).toHaveLength(1);
+		});
+
+		it("carries independent conversations separately", () => {
+			const sessionTranscripts: Parameters<typeof __test__.appendUsageOnlyCarriers>[0] = [];
+
+			__test__.appendUsageOnlyCarriers(
+				sessionTranscripts,
+				new Map([
+					["claude:s1", bucket(10, 5, 0)],
+					["cline:s2", bucket(20, 5, 0)],
+				]),
+				new Map([
+					["claude:s1", identity("s1")],
+					["cline:s2", identity("s2", "cline")],
+				]),
+			);
+
+			expect(sessionTranscripts).toHaveLength(2);
+			expect(sessionTranscripts.map((s) => `${s.source}:${s.sessionId}`).sort()).toEqual([
+				"claude:s1",
+				"cline:s2",
+			]);
+		});
 	});
 
 	describe("OpenCode integration — empty sessions", () => {
@@ -3998,13 +4249,90 @@ describe("QueueWorker", () => {
 					},
 					totalLinesRead: 3,
 					usageTokens: 777,
+					// Mirrors readTranscript's single return shape, where usageTokens IS
+					// input+output+cached and usageBreakdown is always present
+					// (TranscriptReader.ts). Omitting it here would encode a state the
+					// reader cannot produce, and appendUsageOnlyCarriers gates the carrier
+					// on the breakdown sum — the same predicate buildStoredTranscript uses
+					// to decide whether `usage` reaches disk.
+					usageBreakdown: { input: 500, output: 277, cached: 0 },
 				});
 
 				const result = await __test__.loadSessionTranscripts(cwd, {});
 
 				expect(result.totalEntries).toBe(0);
-				expect(result.sessionTranscripts).toHaveLength(0);
 				expect(result.conversationTokens).toBe(777);
+				// A usage-only conversation now gets a zero-entry CARRIER so its bucket
+				// can reach disk (previously this asserted length 0 — the tokens were
+				// counted but nothing persisted them; see the "usage-only carrier"
+				// tests). Still zero *entries*, so totalEntries stays 0.
+				expect(result.sessionTranscripts).toHaveLength(1);
+				expect(result.sessionTranscripts[0].entries).toHaveLength(0);
+			} finally {
+				rmSync(cwd, { recursive: true, force: true });
+			}
+		});
+
+		// End-to-end contract for the fix: token accumulation is deliberately
+		// decoupled from the `entries.length > 0` gate, but the only carrier a
+		// per-session split has to reach disk is a SessionTranscript — and that object
+		// used to be pushed ONLY inside the same gate. A usage-only conversation
+		// therefore landed in `conversationTokens` (persisted on the summary) while
+		// `buildStoredTranscript` had nothing to serialize: no StoredSession, no
+		// `usage` record, and no transcript id allocated by the leaf/amend writers.
+		// Consequences, both reachable:
+		//   1. the memory reported nonzero tokens/cost with an EMPTY Conversations list;
+		//   2. detach could never subtract those tokens (no `StoredSession.usage` to
+		//      sum), so detaching every *visible* conversation left a residue the token
+		//      bar kept showing with zero conversations to explain it.
+		it("persists a usage-only conversation's per-session record so detach has a subtrahend", async () => {
+			const cwd = mkdtempSync(join(tmpdir(), "jolli-c5b-"));
+			try {
+				vi.mocked(loadAllSessions).mockResolvedValue([
+					{
+						sessionId: "claude-usage-only",
+						transcriptPath: "/tmp/claude-usage-only.jsonl",
+						updatedAt: "2026-04-01T12:00:00.000Z",
+						source: "claude" as const,
+					},
+				]);
+				vi.mocked(loadCursorForTranscript).mockResolvedValue(null);
+				vi.mocked(saveCursor).mockResolvedValue(undefined);
+				vi.mocked(readTranscript).mockResolvedValue({
+					entries: [],
+					newCursor: {
+						transcriptPath: "/tmp/claude-usage-only.jsonl",
+						lineNumber: 4,
+						updatedAt: "2026-04-01T12:00:00.000Z",
+					},
+					totalLinesRead: 4,
+					usageTokens: 900,
+					usageBreakdown: { input: 600, output: 300, cached: 0 },
+					usageByModel: [
+						{ model: "claude-opus-5", provider: "anthropic" as const, input: 600, output: 300, cached: 0 },
+					],
+				});
+
+				const result = await __test__.loadSessionTranscripts(cwd, {});
+
+				// The summary carries these tokens…
+				expect(result.conversationTokens).toBe(900);
+				expect(result.conversationTokenBreakdown).toEqual({ input: 600, output: 300, cached: 0 });
+				expect(result.conversationModels).toHaveLength(1);
+
+				// …and the stored transcript now carries the matching per-session record,
+				// so `subtractDetachedUsage` has an exact subtrahend and the leaf/amend
+				// writers allocate a transcript id for it.
+				const stored = __test__.buildStoredTranscript(result.sessionTranscripts);
+				expect(stored.sessions).toHaveLength(1);
+				expect(stored.sessions[0].sessionId).toBe("claude-usage-only");
+				expect(stored.sessions[0].entries).toHaveLength(0);
+				expect(stored.sessions[0].usage).toEqual({ input: 600, output: 300, cached: 0 });
+				expect(stored.sessions[0].usageByModel).toHaveLength(1);
+				// The persisted record sums to exactly what the summary counted — an
+				// over- or under-sized subtrahend would floor or strand the token bar.
+				const persisted = stored.sessions[0].usage as { input: number; output: number; cached: number };
+				expect(persisted.input + persisted.output + persisted.cached).toBe(result.conversationTokens);
 			} finally {
 				rmSync(cwd, { recursive: true, force: true });
 			}

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -3551,9 +3551,11 @@ async function loadSessionTranscripts(
 	};
 	const conversationModels: ModelTokenUsage[] = [...modelMerge.values()];
 
+	const withUsage = attachPerSessionUsage(sessionTranscripts, raw.perSessionTokens, preBySession, postBySession);
+
 	return {
 		allSessions,
-		sessionTranscripts,
+		sessionTranscripts: withUsage,
 		totalEntries,
 		humanEntries,
 		conversationTokens,
@@ -3567,10 +3569,62 @@ async function loadSessionTranscripts(
  * the scalar total, the 3-segment breakdown, and the per-model split (keyed by
  * model id) used to estimate cost. `byModel` segments sum to `breakdown`.
  */
-interface SessionTokenBucket {
+/**
+ * Exported only so `attachPerSessionUsage`'s signature is nameable: `__test__` is
+ * re-exported through `PostCommitHook._testHelpers`, and TS4023 rejects a public
+ * declaration whose parameter type is module-private.
+ */
+export interface SessionTokenBucket {
 	tokens: number;
 	breakdown: { input: number; output: number; cached: number };
 	byModel: Map<string, ModelTokenUsage>;
+}
+
+/**
+ * Attaches each surviving conversation's own token attribution to its
+ * `SessionTranscript` so `buildStoredTranscript` can persist it alongside the
+ * entries. Without this the per-session split dies with the local
+ * `perSessionTokens` map and only the merged total reaches disk — which is exactly
+ * what leaves a later detach with no subtrahend to correct the token bar (see
+ * `StoredSession.usage`).
+ *
+ * Exactly ONE carrier per conversation key. A single run can produce several
+ * `SessionTranscript` objects for the same key: `readAllTranscripts` merges
+ * repeated slices into ONE bucket but pushes one object per slice, and nothing
+ * upstream de-duplicates `allSessions` (the hook-tracked registry is keyed by
+ * sessionId, but each hookless discoverer concatenates several scan roots). Copying
+ * the bucket onto every object would persist the same usage N times, and detach —
+ * which sums ALL stored sessions matching the key — would subtract N× what the
+ * summary ever counted, flooring the meter to "not reported". First in traversal
+ * order wins: the bucket is already the whole conversation's merged total, so which
+ * slice carries it is arbitrary, and splitting it per slice would mean inventing a
+ * share no usage line supports.
+ *
+ * @param preBySession - entry counts BEFORE conversation-edit overlays were applied
+ * @param postBySession - entry counts AFTER; a lower count means the overlay pruned
+ *   entries, so that session's tokens were excluded from the summary totals and its
+ *   raw pre-overlay usage must NOT be persisted (it would over-subtract on detach).
+ */
+function attachPerSessionUsage(
+	sessionTranscripts: ReadonlyArray<SessionTranscript>,
+	perSessionTokens: ReadonlyMap<string, SessionTokenBucket>,
+	preBySession: ReadonlyMap<string, number>,
+	postBySession: ReadonlyMap<string, number>,
+): SessionTranscript[] {
+	const attached = new Set<string>();
+	return sessionTranscripts.map((st) => {
+		const key = conversationKey(st.source ?? "claude", st.sessionId);
+		if ((postBySession.get(key) ?? 0) < (preBySession.get(key) ?? 0)) return st;
+		if (attached.has(key)) return st;
+		const bucket = perSessionTokens.get(key);
+		if (!bucket) return st;
+		attached.add(key);
+		return {
+			...st,
+			usage: { ...bucket.breakdown },
+			...(bucket.byModel.size > 0 && { usageByModel: [...bucket.byModel.values()] }),
+		};
+	});
 }
 
 /**
@@ -3611,6 +3665,13 @@ async function readAllTranscripts(
 	// populated even when a slice yields zero merged entries (a usage-only slice),
 	// so the subtraction stays exact.
 	const perSessionTokens = new Map<string, SessionTokenBucket>();
+	// Session identity per conversationKey, so a conversation that produced tokens
+	// but no merged entries can still be given a persistence carrier after the loop
+	// (see the usage-only reconciliation below). `perSessionTokens` is keyed by
+	// conversationKey alone and carries no `transcriptPath`/`source`, which a
+	// `SessionTranscript` needs. First slice wins: these three fields are identical
+	// across a conversation's slices.
+	const sessionIdentity = new Map<string, { sessionId: string; transcriptPath: string; source: TranscriptSource }>();
 
 	for (const session of sessions) {
 		const cursor = await loadCursorForTranscript(session.transcriptPath, cwd);
@@ -3738,6 +3799,13 @@ async function readAllTranscripts(
 		// (source, sessionId) identity used everywhere else; a repeated session merges
 		// into its bucket rather than overwriting.
 		const convKey = conversationKey(source, session.sessionId);
+		if (!sessionIdentity.has(convKey)) {
+			sessionIdentity.set(convKey, {
+				sessionId: session.sessionId,
+				transcriptPath: session.transcriptPath,
+				source,
+			});
+		}
 		const bucket = perSessionTokens.get(convKey) ?? {
 			tokens: 0,
 			breakdown: { input: 0, output: 0, cached: 0 },
@@ -3790,7 +3858,69 @@ async function readAllTranscripts(
 		await saveCursor(result.newCursor, cwd);
 	}
 
+	// Give every conversation that spent tokens a persistence carrier, including the
+	// ones the entries gate above skipped. Runs AFTER the loop because slice order is
+	// arbitrary: whether a conversation has any entry-bearing slice is only knowable
+	// once every slice has been read.
+	appendUsageOnlyCarriers(sessionTranscripts, perSessionTokens, sessionIdentity);
+
 	return { sessionTranscripts, totalEntries, humanEntries, conversationTokens, perSessionTokens };
+}
+
+/**
+ * Appends a zero-entry `SessionTranscript` for each conversation that accumulated
+ * tokens but never produced a merged entry, so its `perSessionTokens` bucket has
+ * something to ride to disk on.
+ *
+ * Why this exists: token accounting is deliberately decoupled from the
+ * `entries.length > 0` gate in {@link readAllTranscripts} (a tool-only or
+ * noise-filtered slice still spent real tokens, so its usage belongs in
+ * `conversationTokens`). But the ONLY carrier a per-session split has to reach
+ * disk is a `SessionTranscript`: `attachPerSessionUsage` maps over that array, and
+ * `buildStoredTranscript` serializes it. A conversation absent from the array had
+ * its bucket die in memory — the summary kept the tokens while the stored
+ * transcript kept no record of who spent them, which left `detach` with no
+ * subtrahend (`StoredSession.usage`) and, when the conversation was the commit's
+ * only one, meant no transcript id was ever allocated for it at all.
+ *
+ * Mutates `sessionTranscripts` in place (append-only) — the caller's array is
+ * already the loop's accumulator.
+ *
+ * @param sessionIdentity - conversationKey → the session's identity fields, needed
+ *   because `perSessionTokens` is keyed by conversationKey alone.
+ */
+function appendUsageOnlyCarriers(
+	sessionTranscripts: SessionTranscript[],
+	perSessionTokens: ReadonlyMap<string, SessionTokenBucket>,
+	sessionIdentity: ReadonlyMap<string, { sessionId: string; transcriptPath: string; source: TranscriptSource }>,
+): void {
+	// Keys already represented by a real slice. Derived with the SAME expression
+	// attachPerSessionUsage uses to look buckets up, so "already carried" here means
+	// exactly "that pass will find this slice" — a divergent key would append a
+	// duplicate carrier that then never receives its usage.
+	const carried = new Set(sessionTranscripts.map((st) => conversationKey(st.source ?? "claude", st.sessionId)));
+
+	for (const [key, bucket] of perSessionTokens) {
+		if (carried.has(key)) continue;
+		// Gate on the breakdown, not `bucket.tokens`: the breakdown sum is the exact
+		// predicate buildStoredTranscript uses to decide whether `usage` reaches disk.
+		// A source that reports usageTokens but no usageBreakdown would otherwise get a
+		// carrier whose usage is stripped on serialize, leaving an entry-less AND
+		// usage-less session — the noise this function exists to avoid.
+		if (bucket.breakdown.input + bucket.breakdown.output + bucket.breakdown.cached <= 0) continue;
+		const identity = sessionIdentity.get(key);
+		// Unreachable by construction (both maps are populated from the same slice, in
+		// the same iteration), but a carrier without identity fields is unserializable.
+		/* v8 ignore start */
+		if (!identity) continue;
+		/* v8 ignore stop */
+		sessionTranscripts.push({
+			sessionId: identity.sessionId,
+			transcriptPath: identity.transcriptPath,
+			source: identity.source,
+			entries: [],
+		});
+	}
 }
 
 /**
@@ -3810,6 +3940,12 @@ function buildStoredTranscript(sessionTranscripts: ReadonlyArray<SessionTranscri
 			source: st.source,
 			transcriptPath: st.transcriptPath,
 			entries: [...st.entries],
+			// Per-session usage is persisted only when non-zero: a stored `usage` of
+			// all zeros is indistinguishable from "this source reports no usage", and
+			// detach treats a present-but-zero record as a legitimate no-op subtraction
+			// while an absent one means "cannot attribute" (see StoredSession.usage).
+			...(st.usage && st.usage.input + st.usage.output + st.usage.cached > 0 && { usage: st.usage }),
+			...(st.usageByModel && st.usageByModel.length > 0 && { usageByModel: st.usageByModel }),
 		})),
 	};
 }
@@ -3829,6 +3965,8 @@ export const __test__ = {
 	handleAmendPipeline,
 	handleSquashFromQueue,
 	loadSessionTranscripts,
+	attachPerSessionUsage,
+	appendUsageOnlyCarriers,
 	buildStoredTranscript,
 	processQueueEntry,
 	runIngestEntry,

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/ModelPricing.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/ModelPricing.kt
@@ -21,8 +21,14 @@ package ai.jolli.jollimemory.core
  *
  * Prices are hand-maintained (no official machine-readable pricing API exists) and
  * stamped by [PRICES_AS_OF]. Estimates assume standard list pricing — no
- * promotional/intro, batch, or volume discounts. Keep this table in lockstep with
+ * promotional/intro, batch, or volume discounts (so Sonnet 5 is priced at its
+ * standard $3/$15, not the introductory rate). Keep this table in lockstep with
  * the CLI's `MODEL_PRICES`.
+ *
+ * Official pricing pages — re-verify against these when editing a rate, and bump
+ * [PRICES_AS_OF]:
+ *   - Anthropic: https://platform.claude.com/docs/en/about-claude/pricing
+ *   - OpenAI:    https://developers.openai.com/api/docs/pricing
  */
 object ModelPricing {
 
@@ -44,18 +50,26 @@ object ModelPricing {
 	 * whenever a rate below changes; stored/surfaced so a reader can judge
 	 * staleness.
 	 */
-	const val PRICES_AS_OF: String = "2026-07-04"
+	const val PRICES_AS_OF: String = "2026-07-30"
 
 	/**
 	 * List prices keyed by the exact model id that appears in the transcript
 	 * (`message.model` for Claude). Anthropic figures are from the published
-	 * pricing table (cacheWrite = 1.25x input). OpenAI GPT-5-family figures are
-	 * best-known list prices and MUST be re-verified before shipping user-facing
-	 * cost — treat them as provisional.
+	 * pricing table (cacheWrite = 1.25x input). OpenAI figures are from
+	 * developers.openai.com/api/docs/pricing, verified on [PRICES_AS_OF]; for
+	 * those models the third segment is a cache *read* (0.1x input), not a write —
+	 * the field name reflects the Anthropic case, and the values match the CLI's
+	 * `cachedPerMTok` so the two surfaces cost a conversation identically.
 	 */
 	val MODEL_PRICES: Map<String, ModelPrice> = mapOf(
 		// Anthropic (input / output verified; cacheWrite = 1.25x input)
 		"claude-fable-5" to ModelPrice("anthropic", 10.0, 50.0, 12.5),
+		// Mythos 5 is listed on the pricing page as limited-availability at the SAME
+		// rates as Fable 5 — verified there, not copied from the row above. Stated
+		// explicitly because identical adjacent numbers are what an unverified copy
+		// looks like, and this table forbids guessing a rate (see the `-pro` note).
+		"claude-mythos-5" to ModelPrice("anthropic", 10.0, 50.0, 12.5),
+		"claude-opus-5" to ModelPrice("anthropic", 5.0, 25.0, 6.25),
 		"claude-opus-4-8" to ModelPrice("anthropic", 5.0, 25.0, 6.25),
 		"claude-opus-4-7" to ModelPrice("anthropic", 5.0, 25.0, 6.25),
 		"claude-opus-4-6" to ModelPrice("anthropic", 5.0, 25.0, 6.25),
@@ -64,10 +78,39 @@ object ModelPricing {
 		"claude-sonnet-4-6" to ModelPrice("anthropic", 3.0, 15.0, 3.75),
 		"claude-sonnet-4-5" to ModelPrice("anthropic", 3.0, 15.0, 3.75),
 		"claude-haiku-4-5" to ModelPrice("anthropic", 1.0, 5.0, 1.25),
-		// OpenAI / Codex (PROVISIONAL — re-verify before shipping)
-		"gpt-5.5" to ModelPrice("openai", 1.25, 10.0, 0.0),
-		"gpt-5.4" to ModelPrice("openai", 1.25, 10.0, 0.0),
-		"gpt-5.2-codex" to ModelPrice("openai", 1.25, 10.0, 0.0),
+		// OpenAI / Codex — verified list prices; third segment is the cached-input
+		// (cache read) rate. The previous values here were placeholders mirroring the
+		// GPT-5 tier with the cached rate zeroed, so Codex cost was understated twice
+		// over; these mirror the CLI table entry-for-entry.
+		"gpt-5.6-sol" to ModelPrice("openai", 5.0, 30.0, 0.5),
+		"gpt-5.6-terra" to ModelPrice("openai", 2.5, 15.0, 0.25),
+		"gpt-5.6-luna" to ModelPrice("openai", 1.0, 6.0, 0.1),
+		"gpt-5.5" to ModelPrice("openai", 5.0, 30.0, 0.5),
+		"gpt-5.4" to ModelPrice("openai", 2.5, 15.0, 0.25),
+		"gpt-5.4-mini" to ModelPrice("openai", 0.75, 4.5, 0.075),
+		"gpt-5.4-nano" to ModelPrice("openai", 0.2, 1.25, 0.02),
+		"gpt-5.3-codex" to ModelPrice("openai", 1.75, 14.0, 0.175),
+		"gpt-5.2" to ModelPrice("openai", 1.75, 14.0, 0.175),
+		"gpt-5.2-codex" to ModelPrice("openai", 1.75, 14.0, 0.175),
+		"gpt-5.1" to ModelPrice("openai", 1.25, 10.0, 0.125),
+		"gpt-5.1-codex-max" to ModelPrice("openai", 1.25, 10.0, 0.125),
+		"gpt-5.1-codex" to ModelPrice("openai", 1.25, 10.0, 0.125),
+		"gpt-5" to ModelPrice("openai", 1.25, 10.0, 0.125),
+		"gpt-5-codex" to ModelPrice("openai", 1.25, 10.0, 0.125),
+		"gpt-5-mini" to ModelPrice("openai", 0.25, 2.0, 0.025),
+		"gpt-5-nano" to ModelPrice("openai", 0.05, 0.4, 0.005),
+		// OpenAI `-pro`: input and output are published, the cached-input column shows
+		// "-". These were absent while that dash was read as "unpriceable", but absence
+		// is the worse error — an unpriced model contributes nothing, so the whole
+		// conversation falls to [estimateSonnetCostUsd] ($3/$15) instead of gpt-5.5-pro's
+		// real $30/$180. Pricing the two published segments and billing the undocumented
+		// one at the full input rate confines the error to the cached segment: the dash
+		// means either no prompt caching (segment always 0) or caching at list price, and
+		// neither reading supports a discount. Lockstep with the CLI table.
+		"gpt-5.5-pro" to ModelPrice("openai", 30.0, 180.0, 30.0),
+		"gpt-5.4-pro" to ModelPrice("openai", 30.0, 180.0, 30.0),
+		"gpt-5.2-pro" to ModelPrice("openai", 21.0, 168.0, 21.0),
+		"gpt-5-pro" to ModelPrice("openai", 15.0, 120.0, 15.0),
 	)
 
 	/** Provider for a model id, or "unknown" when it's absent from the table. */

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/ModelPricingTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/ModelPricingTest.kt
@@ -1,5 +1,6 @@
 package ai.jolli.jollimemory.core
 
+import io.kotest.assertions.withClue
 import io.kotest.matchers.doubles.shouldBeGreaterThan
 import io.kotest.matchers.doubles.shouldBeLessThan
 import io.kotest.matchers.nulls.shouldBeNull
@@ -33,11 +34,67 @@ class ModelPricingTest {
         p.cacheWritePerMTok shouldBeGreaterThan p.inputPerMTok
     }
 
+    // Replaces an earlier assertion that OpenAI input was cheaper than Opus input.
+    // That stopped being true once the table was verified against published pricing:
+    // gpt-5.5 and gpt-5.6-sol are both $5/MTok input, the same as Opus. The invariant
+    // that does hold is the segment direction — OpenAI's third segment is a cache
+    // READ (0.1x input), the opposite of Anthropic's cache WRITE (1.25x input).
     @Test
-    fun `openai input rate is below the anthropic opus input rate`() {
-        val gpt = ModelPricing.MODEL_PRICES.getValue("gpt-5.5")
-        val opus = ModelPricing.MODEL_PRICES.getValue("claude-opus-4-8")
-        gpt.inputPerMTok shouldBeLessThan opus.inputPerMTok
+    fun `openai cached rate is below input while anthropic cacheWrite is above`() {
+        for ((model, p) in ModelPricing.MODEL_PRICES) {
+            withClue(model) {
+                when {
+                    // `-pro` publishes no cached-input rate, so it is billed at the full
+                    // input rate — never below. See `pro models`, below.
+                    model.endsWith("-pro") -> p.cacheWritePerMTok shouldBe p.inputPerMTok
+                    p.provider == "openai" -> p.cacheWritePerMTok shouldBeLessThan p.inputPerMTok
+                    else -> p.cacheWritePerMTok shouldBeGreaterThan p.inputPerMTok
+                }
+            }
+        }
+    }
+
+    // Lockstep with the CLI table (cli/src/core/Pricing.ts). Absent here, a gpt-5.5-pro
+    // conversation would fall to the Sonnet fallback — $3/$15 against a real $30/$180.
+    @Test
+    fun `prices the pro models with their cached segment at the input rate`() {
+        ModelPricing.MODEL_PRICES.getValue("gpt-5.5-pro") shouldBe
+            ModelPricing.ModelPrice("openai", 30.0, 180.0, 30.0)
+        ModelPricing.MODEL_PRICES.getValue("gpt-5.4-pro") shouldBe
+            ModelPricing.ModelPrice("openai", 30.0, 180.0, 30.0)
+        ModelPricing.MODEL_PRICES.getValue("gpt-5.2-pro") shouldBe
+            ModelPricing.ModelPrice("openai", 21.0, 168.0, 21.0)
+        ModelPricing.MODEL_PRICES.getValue("gpt-5-pro") shouldBe
+            ModelPricing.ModelPrice("openai", 15.0, 120.0, 15.0)
+        // 1M in + 1M out = $210, where the unpriced path yielded $0 and the caller then
+        // estimated $18 at Sonnet rates.
+        ModelPricing.estimateModelCostUsd(usage("gpt-5.5-pro", input = 1_000_000, output = 1_000_000))!! shouldBe 210.0
+    }
+
+    // Kept in lockstep with the CLI's MODEL_PRICES (cli/src/core/Pricing.ts). A model
+    // missing here but present there means IntelliJ silently falls back to the Sonnet
+    // estimate for work VS Code prices correctly — the two tools then disagree on the
+    // cost of the same memory.
+    @Test
+    fun `prices the models real transcripts record today`() {
+        ModelPricing.MODEL_PRICES.getValue("claude-opus-5") shouldBe
+            ModelPricing.ModelPrice("anthropic", 5.0, 25.0, 6.25)
+        // Mythos 5 is listed at the Fable 5 rates (limited availability). Pinned as a
+        // deliberate equality, not left as two coincidentally-matching rows.
+        ModelPricing.MODEL_PRICES.getValue("claude-mythos-5") shouldBe
+            ModelPricing.MODEL_PRICES.getValue("claude-fable-5")
+        ModelPricing.MODEL_PRICES.getValue("claude-mythos-5") shouldBe
+            ModelPricing.ModelPrice("anthropic", 10.0, 50.0, 12.5)
+        ModelPricing.MODEL_PRICES.getValue("gpt-5.4") shouldBe
+            ModelPricing.ModelPrice("openai", 2.5, 15.0, 0.25)
+        ModelPricing.MODEL_PRICES.getValue("gpt-5.4-mini") shouldBe
+            ModelPricing.ModelPrice("openai", 0.75, 4.5, 0.075)
+        ModelPricing.MODEL_PRICES.getValue("gpt-5.6-sol") shouldBe
+            ModelPricing.ModelPrice("openai", 5.0, 30.0, 0.5)
+        ModelPricing.MODEL_PRICES.getValue("gpt-5.6-terra") shouldBe
+            ModelPricing.ModelPrice("openai", 2.5, 15.0, 0.25)
+        ModelPricing.MODEL_PRICES.getValue("gpt-5.6-luna") shouldBe
+            ModelPricing.ModelPrice("openai", 1.0, 6.0, 0.1)
     }
 
     @Test

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -4081,6 +4081,68 @@ describe("SidebarWebviewProvider", () => {
 	});
 
 	describe("kb:expandMemory → kb:memoryEvidence", () => {
+		it("omits a usage-only carrier from the conversations evidence, keeps entries-less legacy sessions", async () => {
+			// A carrier (empty `entries` + a recorded `usage`) is stored only so `detach`
+			// has a token subtrahend; an evidence row for it would read as an empty
+			// conversation. A session that merely OMITS `entries` is legacy data, not a
+			// carrier, and must still surface with a turn count of 0 — hence the `usage`
+			// half of the predicate.
+			const view = makeMockView();
+			const fakeSummary = {
+				version: 5,
+				commitHash: "abc1234",
+				commitMessage: "feat: add widget",
+				commitAuthor: "Dev",
+				commitDate: "2024-01-01T00:00:00Z",
+				branch: "main",
+				generatedAt: "2024-01-01T00:01:00Z",
+				transcripts: ["tid-1"],
+			};
+			const fakeTranscript = {
+				sessions: [
+					{
+						sessionId: "sess-real",
+						source: "claude" as const,
+						transcriptPath: "/tmp/claude.jsonl",
+						entries: [{ role: "human" as const, content: "hi" }],
+					},
+					{
+						sessionId: "sess-carrier",
+						source: "claude" as const,
+						transcriptPath: "/tmp/carrier.jsonl",
+						entries: [],
+						usage: { input: 600, output: 300, cached: 0 },
+					},
+					{ sessionId: "sess-legacy", source: "claude" as const, transcriptPath: "/tmp/legacy.jsonl" },
+				],
+			};
+			const provider = new SidebarWebviewProvider({
+				executeCommand: vi.fn(),
+				getInitialState: () => ({
+					enabled: true,
+					authenticated: false,
+					activeTab: "kb",
+					kbMode: "memories",
+					branchName: "main",
+					detached: false,
+					currentRepoName: "myrepo",
+				}),
+				extensionUri: mockExtensionUri as unknown as never,
+				getSummaryByHash: vi.fn().mockResolvedValue(fakeSummary),
+				readTranscriptById: vi.fn().mockResolvedValue(fakeTranscript),
+			});
+			provider.resolveWebviewView(view as unknown as never);
+			view.webview.postMessage.mockClear();
+			view.webview.triggerMessage({ type: "kb:expandMemory", commitHash: "abc1234" });
+			const sent = await flushUntilMessage(view, "kb:memoryEvidence");
+			const evidenceMsg = sent.find((m) => m.type === "kb:memoryEvidence");
+
+			expect(evidenceMsg.evidence.conversations.map((c: { id: string }) => c.id)).toEqual([
+				"sess-real",
+				"sess-legacy",
+			]);
+		});
+
 		it("posts kb:memoryEvidence with projected conversations/context/files from the summary", async () => {
 			const view = makeMockView();
 			const fakeSummary = {

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -1477,20 +1477,32 @@ export class SidebarWebviewProvider
 		// by their first known timestamp reconstructs the true conversation order.
 		// The sort is stable, so slices with no parseable timestamp (legacy data)
 		// keep their first-seen order rather than jumping to the front.
-		return order.map((key) => {
-			// Non-null: every key in `order` was set in `grouped` above.
-			const { base, parts } = grouped.get(key) as {
-				base: StoredSession;
-				parts: ReadonlyArray<TranscriptEntry>[];
-			};
-			const sorted = [...parts].sort((a, b) => {
-				const ta = sliceStartTime(a);
-				const tb = sliceStartTime(b);
-				if (ta === undefined || tb === undefined) return 0;
-				return ta - tb;
-			});
-			return { ...base, entries: sorted.flat() };
-		});
+		return (
+			order
+				.map((key) => {
+					// Non-null: every key in `order` was set in `grouped` above.
+					const { base, parts } = grouped.get(key) as {
+						base: StoredSession;
+						parts: ReadonlyArray<TranscriptEntry>[];
+					};
+					const sorted = [...parts].sort((a, b) => {
+						const ta = sliceStartTime(a);
+						const tb = sliceStartTime(b);
+						if (ta === undefined || tb === undefined) return 0;
+						return ta - tb;
+					});
+					return { ...base, entries: sorted.flat() };
+				})
+				// Drop usage-only carriers: stored so `detach` has a per-session
+				// subtrahend, but with no readable turn to show — an evidence/branch row
+				// for one would render as an empty conversation. Applied to the MERGED
+				// entries so a conversation that is a carrier in one transcript and real in
+				// another still surfaces. A session that merely OMITS `entries` (legacy /
+				// malformed stored data) is not a carrier and is deliberately kept: those
+				// are real conversations, rendered with a turn count of 0 — hence the
+				// `usage` half of the predicate.
+				.filter((session) => session.entries.length > 0 || session.usage === undefined)
+		);
 	}
 
 	/**

--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
 	aggregateConversationTokenBreakdown,
 	aggregateConversationTokens,
+	aggregateEstimatedCost,
 	aggregateStats,
 	aggregateTurns,
 	formatDurationLabel,
@@ -15,6 +16,7 @@ const {
 	interface TokNode {
 		conversationTokens?: number;
 		conversationTokenBreakdown?: { input: number; output: number; cached: number };
+		estimatedCostUsd?: number;
 		children?: ReadonlyArray<TokNode>;
 	}
 	// Mirror the real SummaryTree aggregators: the token meter now sums the whole
@@ -32,9 +34,14 @@ const {
 			{ input: raw?.input ?? 0, output: raw?.output ?? 0, cached: raw?.cached ?? 0 },
 		);
 	};
+	// Same recursion for the stored per-model cost: a consolidated memory carries
+	// it on the folded children, so the meter must sum the tree to prefer it.
+	const sumCost = (node: TokNode): number =>
+		(node.children ?? []).reduce((a, c) => a + sumCost(c), node.estimatedCostUsd ?? 0);
 	return {
 		aggregateConversationTokens: vi.fn(sumTokens),
 		aggregateConversationTokenBreakdown: vi.fn(sumBreakdown),
+		aggregateEstimatedCost: vi.fn(sumCost),
 		aggregateStats: vi.fn(() => ({
 			insertions: 10,
 			deletions: 5,
@@ -137,6 +144,7 @@ const {
 vi.mock("../../../cli/src/core/SummaryTree.js", () => ({
 	aggregateConversationTokenBreakdown,
 	aggregateConversationTokens,
+	aggregateEstimatedCost,
 	aggregateStats,
 	aggregateTurns,
 	formatDurationLabel,
@@ -1841,6 +1849,122 @@ describe("SummaryHtmlBuilder", () => {
 			expect(html).not.toContain("seg-cache");
 			expect(html).not.toContain("tmeter-legend");
 			expect(html).not.toContain("tmeter na");
+		});
+
+		it("prefers the stored per-model cost over the flat Sonnet estimate", () => {
+			// This surface used to price every memory at Sonnet rates unconditionally
+			// while the sidebar preferred the stored per-model figure, so the same memory
+			// showed two different dollar amounts — and Opus work was understated here.
+			const html = buildTokenMeter(
+				makeSummary({
+					conversationTokens: 1_000_000,
+					conversationTokenBreakdown: { input: 200_000, output: 300_000, cached: 500_000 },
+					estimatedCostUsd: 42.5,
+				}),
+			);
+			expect(html).toContain("≈$42.50");
+			// Sonnet-rate arithmetic on the same breakdown would land near $6.47.
+			expect(html).not.toContain("≈$6.4");
+			expect(html).toContain("priced per model at list rates");
+		});
+
+		it("falls back to the Sonnet estimate, and says so, when no stored cost exists", () => {
+			const html = buildTokenMeter(
+				makeSummary({
+					conversationTokens: 1_000_000,
+					conversationTokenBreakdown: { input: 200_000, output: 300_000, cached: 500_000 },
+					estimatedCostUsd: undefined,
+				}),
+			);
+			// 200k·$3 + 300k·$15 + 500k·$3.75 per MTok = $6.975, which toFixed(2) renders
+			// as 6.97 (6.975 has no exact binary form and lands just below the midpoint).
+			expect(html).toContain("≈$6.97");
+			expect(html).toContain("assumes Sonnet pricing");
+		});
+
+		it("aggregates the stored cost across the consolidation tree, not just the root", () => {
+			const html = buildTokenMeter(
+				makeSummary({
+					conversationTokens: undefined,
+					estimatedCostUsd: undefined,
+					children: [
+						makeSummary({ conversationTokens: 500_000, estimatedCostUsd: 10 }),
+						makeSummary({ conversationTokens: 500_000, estimatedCostUsd: 5.25 }),
+					],
+				}),
+			);
+			expect(html).toContain("≈$15.25");
+		});
+
+		it("fills in the Sonnet fallback per node when only part of the tree has a stored cost", () => {
+			// The token headline aggregates EVERY node, so an all-or-nothing "any stored
+			// cost wins" test priced only the root of a mixed consolidation and showed that
+			// figure next to the whole tree's tokens — a dollar amount covering half the
+			// tokens beside it, and lower than the flat estimate it replaced.
+			const html = buildTokenMeter(
+				makeSummary({
+					conversationTokens: 500_000,
+					conversationTokenBreakdown: { input: 500_000, output: 0, cached: 0 },
+					estimatedCostUsd: 10,
+					children: [
+						makeSummary({
+							conversationTokens: 500_000,
+							conversationTokenBreakdown: { input: 200_000, output: 300_000, cached: 0 },
+							estimatedCostUsd: undefined,
+						}),
+					],
+				}),
+			);
+			// $10 stored for the root + Sonnet rates for the child (200k·$3 + 300k·$15
+			// per MTok = $5.10) = $15.10. The old behaviour showed the root's $10 alone.
+			expect(html).toContain("≈$15.10");
+			expect(html).not.toContain("≈$10.00");
+			// And the tooltip must not claim everything was priced per model.
+			expect(html).toContain("where that model has a known price");
+			expect(html).not.toContain("assumes Sonnet pricing");
+		});
+
+		it("tops up the stored cost with the flat rate for a node's unpriced models", () => {
+			// A stored `estimatedCostUsd` is a LOWER bound, not full coverage: write time
+			// prices only the models in the host table and excludes the rest. Gemini is the
+			// live example — a supported transcript source with no rows in Pricing.ts, so
+			// its buckets arrive `provider: "unknown"` and unpriced. Reading
+			// `estimatedCostUsd > 0` as "fully priced" charged $0 for those tokens while
+			// still counting them in the headline beside the figure.
+			const html = buildTokenMeter(
+				makeSummary({
+					conversationTokens: 1_000_000,
+					conversationTokenBreakdown: { input: 700_000, output: 300_000, cached: 0 },
+					conversationModels: [
+						{ model: "claude-opus-5", provider: "anthropic", input: 200_000, output: 300_000, cached: 0 },
+						{ model: "gemini-3-flash", provider: "unknown", input: 500_000, output: 0, cached: 0 },
+					],
+					// Opus alone: 200k·$5 + 300k·$25 per MTok = $8.50.
+					estimatedCostUsd: 8.5,
+				}),
+			);
+			// $8.50 stored + the unpriced gemini-3-flash bucket at Sonnet input rates
+			// (500k·$3 per MTok = $1.50) = $10.00.
+			expect(html).toContain("≈$10.00");
+			expect(html).not.toContain("≈$8.50");
+			// Mixed, not "stored": the tooltip must stop claiming a fully model-priced figure.
+			expect(html).toContain("where that model has a known price");
+		});
+
+		it("keeps the stored cost as-is when every recorded model is priced", () => {
+			const html = buildTokenMeter(
+				makeSummary({
+					conversationTokens: 500_000,
+					conversationTokenBreakdown: { input: 200_000, output: 300_000, cached: 0 },
+					conversationModels: [
+						{ model: "claude-opus-5", provider: "anthropic", input: 200_000, output: 300_000, cached: 0 },
+					],
+					estimatedCostUsd: 8.5,
+				}),
+			);
+			expect(html).toContain("≈$8.50");
+			expect(html).toContain("priced per model at list rates");
+			expect(html).not.toContain("where that model has a known price");
 		});
 
 		it("token meter treats conversationTokens of 0 as unreported", () => {

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -11,6 +11,7 @@
 
 import { labelLeadsWithNativeId, referenceDisplayTitle } from "../../../cli/src/core/references/ReferenceDisplay.js";
 import { getRegistry } from "../../../cli/src/core/references/SourceDefinitionRegistry.js";
+import { estimateModelCostUsd } from "../../../cli/src/core/Pricing.js";
 import { isSummaryError } from "../../../cli/src/core/SummaryErrorMarker.js";
 import {
 	aggregateConversationTokenBreakdown,
@@ -23,6 +24,7 @@ import type {
 	ConversationTokenBreakdown,
 	E2eTestScenario,
 	ExcludedContextItem,
+	ModelTokenUsage,
 	NoteReference,
 	PlanReference,
 	ReferenceCommitRef,
@@ -553,14 +555,97 @@ export function buildPropTable(
 // \u2500\u2500\u2500 Token meter \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
 
 /**
- * Rough cache-aware $ estimate at Sonnet pricing. `cached` (= cache_creation) is
- * priced at the cache-write rate; input/output at their standard rates. See spec \u00a74.2.
- * Uses the same per-token constants and "\u2248$"/"<$0.01" formatting the sidebar's
- * token bar uses (`SummaryUtils.ts`), so the two surfaces never disagree on
- * the same underlying token counts.
+ * Sums the token segments of a node's per-model buckets whose model has no entry
+ * in the host price table, or null when every bucket is priced (or the node
+ * records no buckets to inspect).
+ *
+ * These are exactly the tokens `estimatedCostUsd` deliberately left out of its
+ * total rather than guessing a rate for, so they are what a stored cost still
+ * owes. Membership is probed through `estimateModelCostUsd`'s null return — the
+ * same predicate the write-time estimate uses — rather than by reading
+ * `MODEL_PRICES` here, so the two can never disagree about what "unpriced" means.
+ *
+ * A node carrying a cost but no `conversationModels` (hand-edited or otherwise
+ * off-contract data — write time only stores a cost alongside buckets) returns
+ * null: there is nothing to inspect, so the stored figure is taken at face value.
  */
-function estimateCost(b: ConversationTokenBreakdown | undefined, total: number): string {
-	return formatSonnetCostEstimate(estimateConversationCostUsd(b, total));
+function unpricedSegments(models: ReadonlyArray<ModelTokenUsage> | undefined): ConversationTokenBreakdown | null {
+	let input = 0;
+	let output = 0;
+	let cached = 0;
+	for (const m of models ?? []) {
+		if (estimateModelCostUsd(m) !== null) continue;
+		input += m.input;
+		output += m.output;
+		cached += m.cached;
+	}
+	return input + output + cached > 0 ? { input, output, cached } : null;
+}
+
+/**
+ * Cache-aware $ estimate, preferring the cost computed at WRITE time from the
+ * conversation's actual model(s) via the host price table. Falls back to the flat
+ * Sonnet-rate estimate for whatever the stored cost does not cover \u2014 legacy
+ * memories, or a conversation whose model is absent from the price table.
+ *
+ * The sidebar's token bar already prefers the stored value; this surface used to
+ * price everything at Sonnet unconditionally, so the same memory could show two
+ * different dollar figures depending on where you looked at it \u2014 and Opus work
+ * was understated in the detail view. Keep the two preferring the same source.
+ *
+ * The preference is resolved PER NODE, not once for the whole tree. A tree-wide
+ * "any stored cost wins" test silently under-reports a mixed consolidation: the
+ * token headline beside this figure aggregates EVERY node, so a squash whose root
+ * carries a stored cost while a folded legacy child does not would price only the
+ * root and show that total next to the full tree's tokens. Summing per node keeps
+ * the two figures over the same set. (The Sonnet formula is linear per segment, so
+ * summing per-node fallbacks equals estimating from their aggregate \u2014 no drift
+ * against the previous behaviour for an all-fallback tree.)
+ *
+ * A stored cost is a LOWER bound, not proof of full coverage, so the per-node
+ * preference is resolved per MODEL bucket rather than per node — see
+ * `unpricedSegments`.
+ *
+ * Returns the formatted figure plus which sources fed it, so the caller's tooltip
+ * can describe the number it is actually showing rather than overclaiming.
+ */
+function estimateCost(summary: CommitSummary): { label: string; mode: "stored" | "sonnet" | "mixed" } {
+	let usd = 0;
+	let storedNodes = 0;
+	let fallbackNodes = 0;
+	const walk = (node: CommitSummary): void => {
+		const own = node.estimatedCostUsd ?? 0;
+		const tokens = node.conversationTokens ?? 0;
+		if (own > 0) {
+			usd += own;
+			storedNodes++;
+			// A positive stored cost does NOT mean the node is fully priced. Write time
+			// records `estimatedCostUsd` as a lower bound: `estimateCostUsd` prices only
+			// the buckets present in the host price table and EXCLUDES the rest rather
+			// than guessing (see Pricing.ts's `-pro` note, Types.ts on
+			// `estimatedCostUsd`, and conversationUsageFields in QueueWorker). Treating
+			// `own > 0` as full coverage therefore under-reports every node that mixed a
+			// priced model with an unpriced one — the unpriced bucket's tokens sit in the
+			// headline total beside this figure while contributing $0 to it. Price
+			// exactly those buckets at the flat rate, the same treatment a wholly
+			// unpriced node gets below, and let them tip the mode to "mixed" so the
+			// tooltip stops claiming the figure is fully model-priced.
+			const unpriced = unpricedSegments(node.conversationModels);
+			if (unpriced) {
+				usd += estimateConversationCostUsd(unpriced, unpriced.input + unpriced.output + unpriced.cached);
+				fallbackNodes++;
+			}
+		} else if (tokens > 0) {
+			// No stored cost but real tokens \u2014 this node needs the flat-rate fallback.
+			// Nodes with neither contribute nothing and must NOT tip the mode either way.
+			usd += estimateConversationCostUsd(node.conversationTokenBreakdown, tokens);
+			fallbackNodes++;
+		}
+		for (const child of node.children ?? []) walk(child);
+	};
+	walk(summary);
+	const mode = storedNodes > 0 ? (fallbackNodes > 0 ? "mixed" : "stored") : "sonnet";
+	return { label: formatSonnetCostEstimate(usd), mode };
 }
 
 /**
@@ -628,11 +713,18 @@ export function buildTokenMeter(summary: CommitSummary): string {
 	} else {
 		bar = `<div class="tmeter-bar"><span class="seg-in" data-pct="100"></span></div>`;
 	}
+	const cost = estimateCost(summary);
+	const costNote =
+		cost.mode === "stored"
+			? "The \u2248$ cost is a cache-aware estimate priced per model at list rates (no promotional/volume discounts), so actual spend may differ."
+			: cost.mode === "mixed"
+				? "The \u2248$ cost is a cache-aware estimate: priced per model at list rates where that model has a known price, and at Sonnet rates for the rest, so actual spend may differ."
+				: "The \u2248$ cost is a cache-aware estimate; it assumes Sonnet pricing, so actual cost varies by model.";
 	return `
 <div class="tmeter">
-  <div class="tmeter-head"><span class="tmeter-total">${formatTokensCompact(total)}</span> tokens &middot; <span class="tmeter-cost">${estimateCost(b, total)}</span> &middot; this task
+  <div class="tmeter-head"><span class="tmeter-total">${formatTokensCompact(total)}</span> tokens &middot; <span class="tmeter-cost">${cost.label}</span> &middot; this task
     <span class="tok-help-wrap"><button class="tok-help" type="button" data-foreign-safe>?</button>
-      <span class="tok-pop">Counts input + output + cache-creation across sessions (cache reads are excluded \u2014 they double-count). The \u2248$ cost is a cache-aware estimate at Sonnet pricing; actual cost varies by model.</span></span>
+      <span class="tok-pop">Counts input + output + cache-creation across sessions (cache reads are excluded \u2014 they double-count). ${costNote}</span></span>
   </div>
   ${bar}
 </div>`;

--- a/vscode/src/views/SummaryScriptBuilder.test.ts
+++ b/vscode/src/views/SummaryScriptBuilder.test.ts
@@ -563,6 +563,19 @@ describe("SummaryScriptBuilder", () => {
 			expect(script).toContain(".row[data-session=");
 		});
 
+		it("swaps the token meter in place on the ack instead of rebuilding the panel", () => {
+			// The detached conversation's tokens no longer belong to this memory, so the
+			// meter must not keep showing the pre-detach total until the panel reopens.
+			expect(script).toContain("msg.tokenMeterHtml");
+			expect(script).toContain("document.querySelector('.tmeter')");
+			// Widths and the '?' listener are bound per element, so the replaced node
+			// needs re-initialisation or it renders as an empty bar with a dead button.
+			// Scoped to the new meter, NOT document-wide: a second pass over the whole
+			// page would bind a duplicate click listener to every other pinnable popover,
+			// and two listeners toggle the pin twice per click (net no-op).
+			expect(script).toContain("initTokenMeter(document.querySelector('.tmeter'))");
+		});
+
 		it("matches the acked row by the source:sessionId composite key, not sessionId alone", () => {
 			expect(script).toContain("function conversationRowSelector(sessionId, source)");
 			expect(script).toContain('[data-source="');

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -76,24 +76,33 @@ export function buildScript(options: SummaryScriptOptions = {}): string {
   // unsafe-inline for styles. buildTokenMeter emits each segment with a
   // data-pct attribute instead; a JS property write (el.style.width) is
   // allowed even though an inline style attribute is not, so we set it here.
-  document.querySelectorAll('.tmeter-bar [data-pct]').forEach(function(el) {
-    el.style.width = el.dataset.pct + '%';
-  });
-  // The '?' help button toggles a pinned popover (click-to-pin rather than
-  // hover-only, so it stays reachable on touch/keyboard). Clicking elsewhere
-  // on the page closes any open popover.
-  document.querySelectorAll('.tok-help').forEach(function(btn) {
-    btn.addEventListener('click', function(e) {
-      e.stopPropagation();
-      var wrap = btn.closest('.tok-help-wrap');
-      if (!wrap) { return; }
-      var wasPinned = wrap.classList.contains('pinned');
-      document.querySelectorAll('.tok-help-wrap.pinned').forEach(function(w) {
-        w.classList.remove('pinned');
-      });
-      if (!wasPinned) { wrap.classList.add('pinned'); }
+  // Wrapped in a function (rather than run once inline) because the meter is
+  // replaced in place when a conversation is detached — the 'conversationDetached'
+  // handler re-runs this against the new node. Both the widths and the '?'
+  // listener are bound per element, so a replaced meter renders as an empty bar
+  // with a dead help button unless this re-runs.
+  function initTokenMeter(root) {
+    var scope = root || document;
+    scope.querySelectorAll('.tmeter-bar [data-pct]').forEach(function(el) {
+      el.style.width = el.dataset.pct + '%';
     });
-  });
+    // The '?' help button toggles a pinned popover (click-to-pin rather than
+    // hover-only, so it stays reachable on touch/keyboard). Clicking elsewhere
+    // on the page closes any open popover.
+    scope.querySelectorAll('.tok-help').forEach(function(btn) {
+      btn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        var wrap = btn.closest('.tok-help-wrap');
+        if (!wrap) { return; }
+        var wasPinned = wrap.classList.contains('pinned');
+        document.querySelectorAll('.tok-help-wrap.pinned').forEach(function(w) {
+          w.classList.remove('pinned');
+        });
+        if (!wasPinned) { wrap.classList.add('pinned'); }
+      });
+    });
+  }
+  initTokenMeter(document);
   document.addEventListener('click', function() {
     document.querySelectorAll('.tok-help-wrap.pinned').forEach(function(w) {
       w.classList.remove('pinned');
@@ -2412,6 +2421,29 @@ ${buildSourceLabelScript()}
         if (cntEl) cntEl.textContent = String(remaining);
         if (remaining === 0) {
           conversationsBody.innerHTML = '<p class="conv-empty">No conversations linked to this memory.</p>';
+        }
+      }
+      // The detached conversation's tokens no longer belong to this memory, so
+      // the meter is rebuilt host-side and swapped in with the row removal
+      // rather than left showing the pre-detach total until the panel reopens.
+      // Absent when the host could not attribute the removed usage (memories
+      // written before per-session usage was recorded) — the meter then stays
+      // as-is, which is the honest reading of "we don't know".
+      if (typeof msg.tokenMeterHtml === 'string' && msg.tokenMeterHtml !== '') {
+        var meterEl = document.querySelector('.tmeter');
+        if (meterEl) {
+          // outerHTML is safe here specifically: tokenMeterHtml is composed
+          // host-side by buildTokenMeter from numeric aggregates and literal
+          // strings only — no summary text, path, or other repo content reaches
+          // it. Do not extend this to markup carrying commit/user strings.
+          meterEl.outerHTML = msg.tokenMeterHtml;
+          // Re-init scoped to the REPLACED meter, not the whole document: the help
+          // button gets its click listener bound per element, so re-scanning
+          // document-wide would hand a second listener to every other pinnable
+          // popover on the page and each click would toggle it twice (net no-op).
+          // Only .tmeter carries .tok-help today, but the scope keeps that from
+          // becoming a trap the next time one is added elsewhere.
+          initTokenMeter(document.querySelector('.tmeter'));
         }
       }
     }

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -496,6 +496,7 @@ const {
 	mockRenderE2eScenario,
 	mockBuildPlansAndNotesSection,
 	mockBuildJolliRow,
+	mockBuildTokenMeter,
 } = vi.hoisted(() => ({
 	mockBuildHtml: vi.fn().mockReturnValue("<html>mock</html>"),
 	mockBuildE2eTestSection: vi.fn().mockReturnValue("<div>e2e</div>"),
@@ -507,6 +508,7 @@ const {
 		.fn()
 		.mockReturnValue("<div>plansAndNotes</div>"),
 	mockBuildJolliRow: vi.fn().mockReturnValue("<div>jolliRow</div>"),
+	mockBuildTokenMeter: vi.fn().mockReturnValue('<div class="tmeter">meter</div>'),
 }));
 
 vi.mock("./SummaryHtmlBuilder.js", async (importActual) => {
@@ -524,6 +526,11 @@ vi.mock("./SummaryHtmlBuilder.js", async (importActual) => {
 		buildPlansAndNotesSection: mockBuildPlansAndNotesSection,
 		buildJolliRow: mockBuildJolliRow,
 		contextChipCount: actual.contextChipCount,
+		// Stubbed rather than real: the real one reaches into SummaryUtils (fully
+		// mocked here), and the markup itself is covered by SummaryHtmlBuilder's own
+		// tests. What matters at this layer is WHICH summary the panel rebuilds the
+		// meter from, which the stub captures.
+		buildTokenMeter: mockBuildTokenMeter,
 	};
 });
 
@@ -4509,6 +4516,74 @@ describe("SummaryWebviewPanel", () => {
 		// ── loadTranscriptStats ──────────────────────────────────────────────
 
 		describe("loadTranscriptStats", () => {
+			it("excludes a usage-only carrier from sessionCounts but still counts a split conversation", async () => {
+				// The count must agree with the Conversations list, which hides carriers —
+				// "1 conversation" against an empty list reads as a bug. Skipping a carrier
+				// slice must NOT consume the key though: the same conversation's real turns
+				// may live in another transcript, and that one counts.
+				// Hashes must intersect the summary's own transcript ids (v3 ⇒ its commit
+				// hash), or loadTranscriptStats early-returns without posting at all.
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123", "def456"]));
+				const transcriptMap = new Map([
+					[
+						"abc123",
+						{
+							sessions: [
+								{
+									sessionId: "carrier-only",
+									source: "claude" as const,
+									entries: [],
+									usage: { input: 600, output: 300, cached: 0 },
+								},
+								// Carrier slice of a conversation that is real elsewhere.
+								{
+									sessionId: "split",
+									source: "codex" as const,
+									entries: [],
+									usage: { input: 1, output: 1, cached: 0 },
+								},
+							],
+						},
+					],
+					[
+						"def456",
+						{
+							sessions: [
+								{
+									sessionId: "split",
+									source: "codex" as const,
+									entries: [{ role: "human" as const, content: "hi" }],
+								},
+							],
+						},
+					],
+				]);
+				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap as never);
+
+				await SummaryWebviewPanel.show(
+					makeSummary(),
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "loadTranscriptStats" });
+				await flushPromises();
+
+				const call = postMessage.mock.calls.find(
+					(c) => (c[0] as { command?: string })?.command === "transcriptStatsLoaded",
+				);
+				const msg = call?.[0] as {
+					totalEntries: number;
+					sessionCounts: Record<string, number>;
+				};
+				// `carrier-only` contributes to neither count; `split` counts once, via c2.
+				expect(msg.sessionCounts).toEqual({ codex: 1 });
+				expect(msg.totalEntries).toBe(1);
+			});
+
 			it("deduplicates sessions and counts codex sessions separately", async () => {
 				mockGetTranscriptHashes.mockResolvedValue(
 					new Set(["abc123", "def456"]),
@@ -5454,6 +5529,289 @@ describe("SummaryWebviewPanel", () => {
 				});
 			});
 
+			it("subtracts the detached session's tokens from the summary and refreshes the meter in place", async () => {
+				// The reported bug: detaching a conversation rewrote the transcript files but
+				// left `conversationTokens` / breakdown / cost at their pre-detach values, so
+				// the memory kept reporting usage from a conversation no longer attached.
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				mockReadTranscriptsForCommits.mockResolvedValue(
+					new Map([
+						[
+							"abc123",
+							{
+								sessions: [
+									{
+										sessionId: "s1",
+										source: "claude" as const,
+										entries: [{ role: "human" as const, content: "A" }],
+										usage: { input: 40, output: 50, cached: 200 },
+										usageByModel: [
+											{
+												model: "claude-opus-5",
+												provider: "anthropic" as const,
+												input: 40,
+												output: 50,
+												cached: 200,
+											},
+										],
+									},
+									{
+										sessionId: "keep",
+										source: "claude" as const,
+										entries: [{ role: "human" as const, content: "K" }],
+										usage: { input: 60, output: 150, cached: 500 },
+									},
+								],
+							},
+						],
+					]),
+				);
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: ["abc123"],
+					conversationTokens: 1000,
+					conversationTokenBreakdown: { input: 100, output: 200, cached: 700 },
+					conversationModels: [
+						{ model: "claude-opus-5", provider: "anthropic" as const, input: 100, output: 200, cached: 700 },
+					],
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
+				mockStoreSummary.mockClear();
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "conversationDetach", hash: "abc123", sessionId: "s1", source: "claude" });
+				await flushPromises();
+
+				// No transcript became empty, so `persistTranscriptIdRemoval` does not run and
+				// the corrected totals need their own write.
+				const written = mockStoreSummary.mock.calls.at(-1)?.[0] as CommitSummary;
+				expect(written.conversationTokens).toBe(710);
+				expect(written.conversationTokenBreakdown).toEqual({ input: 60, output: 150, cached: 500 });
+
+				// In-place meter swap rather than a full panel rebuild, which would collapse
+				// scroll position and expanded sections for a single-row change.
+				const ack = postMessage.mock.calls
+					.map((c) => c[0])
+					.find((m: { command?: string }) => m?.command === "conversationDetached");
+				expect(ack.tokenMeterHtml).toBe('<div class="tmeter">meter</div>');
+				// Rebuilt from the CORRECTED summary — rebuilding from the pre-detach one
+				// would swap in a meter showing the very total the fix removes.
+				const meterArg = mockBuildTokenMeter.mock.calls.at(-1)?.[0] as CommitSummary;
+				expect(meterArg.conversationTokens).toBe(710);
+			});
+
+			it("warns the user when a lost summary write leaves the token figures permanently stale", async () => {
+				// Files first, summary second — so a summary-write failure leaves the sessions
+				// gone from disk while the memory still counts their tokens. That is not
+				// recoverable: a retry finds nothing to remove (plain ack), the subtrahend was
+				// only readable while the sessions were still in the files, and Regenerate
+				// carries `conversationTokens` over verbatim. Logging it and posting a clean ack
+				// reported the operation as fully successful; the user must be told.
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				mockReadTranscriptsForCommits.mockResolvedValue(
+					new Map([
+						[
+							"abc123",
+							{
+								sessions: [
+									{
+										sessionId: "s1",
+										source: "claude" as const,
+										entries: [{ role: "human" as const, content: "A" }],
+										usage: { input: 40, output: 50, cached: 200 },
+									},
+									{
+										sessionId: "keep",
+										source: "claude" as const,
+										entries: [{ role: "human" as const, content: "K" }],
+										usage: { input: 60, output: 150, cached: 500 },
+									},
+								],
+							},
+						],
+					]),
+				);
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: ["abc123"],
+					conversationTokens: 1000,
+					conversationTokenBreakdown: { input: 100, output: 200, cached: 700 },
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
+				// Nothing is emptied, so the correction takes the rescue `storeSummary` path.
+				mockStoreSummary.mockRejectedValueOnce(new Error("orphan-write lock timeout"));
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "conversationDetach", hash: "abc123", sessionId: "s1", source: "claude" });
+				await flushPromises();
+
+				expect(showWarningMessage).toHaveBeenCalledWith(
+					expect.stringContaining("token and cost figures could not be updated"),
+				);
+				// The files really did change, so the row is still acked — but with no meter,
+				// since the figures on disk are the old ones.
+				const ack = postMessage.mock.calls
+					.map((c) => c[0])
+					.find((m: { command?: string }) => m?.command === "conversationDetached");
+				expect(ack).toBeDefined();
+				expect(ack).not.toHaveProperty("tokenMeterHtml");
+			});
+
+			it("leaves token totals untouched when the detached session has no recorded usage", async () => {
+				// Forward-only: memories written before per-session usage was persisted have
+				// no subtrahend, so the honest behaviour is to leave the figure alone and post
+				// no meter update rather than invent a remainder.
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				mockReadTranscriptsForCommits.mockResolvedValue(
+					new Map([
+						[
+							"abc123",
+							{
+								sessions: [
+									{ sessionId: "s1", source: "claude" as const, entries: [{ role: "human" as const, content: "A" }] },
+									{ sessionId: "keep", source: "claude" as const, entries: [{ role: "human" as const, content: "K" }] },
+								],
+							},
+						],
+					]),
+				);
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: ["abc123"],
+					conversationTokens: 1000,
+					conversationTokenBreakdown: { input: 100, output: 200, cached: 700 },
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
+				mockStoreSummary.mockClear();
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "conversationDetach", hash: "abc123", sessionId: "s1", source: "claude" });
+				await flushPromises();
+
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+				const ack = postMessage.mock.calls
+					.map((c) => c[0])
+					.find((m: { command?: string }) => m?.command === "conversationDetached");
+				expect(ack).not.toHaveProperty("tokenMeterHtml");
+			});
+
+			it("does not subtract twice when a retry follows a failed transcript write", async () => {
+				// The corrected totals are persisted only AFTER the files are durably
+				// rewritten, and `currentSummary` is not reassigned before that write lands.
+				// Otherwise the failed attempt would leave the panel holding an
+				// already-subtracted summary, the row would still be there (no ack is posted
+				// on the error path), and the user's retry would subtract a second time —
+				// flooring the meter to "not reported" via Math.max(0, …).
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				mockReadTranscriptsForCommits.mockResolvedValue(
+					new Map([
+						[
+							"abc123",
+							{
+								sessions: [
+									{
+										sessionId: "s1",
+										source: "claude" as const,
+										entries: [{ role: "human" as const, content: "A" }],
+										usage: { input: 40, output: 50, cached: 200 },
+									},
+									{
+										sessionId: "keep",
+										source: "claude" as const,
+										entries: [{ role: "human" as const, content: "K" }],
+										usage: { input: 60, output: 150, cached: 500 },
+									},
+								],
+							},
+						],
+					]),
+				);
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: ["abc123"],
+					conversationTokens: 1000,
+					conversationTokenBreakdown: { input: 100, output: 200, cached: 700 },
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
+				mockStoreSummary.mockClear();
+				const dispatch = captureMessageHandler();
+
+				// Attempt 1: the file batch fails, so nothing about the totals is persisted.
+				mockSaveTranscriptsBatch.mockRejectedValueOnce(new Error("disk full"));
+				dispatch({ command: "conversationDetach", hash: "abc123", sessionId: "s1", source: "claude" });
+				await flushPromises();
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+
+				// Attempt 2: the batch succeeds. The subtraction must run against the
+				// ORIGINAL 1000, landing on 710 — not 420 (a second 290 taken off 710).
+				dispatch({ command: "conversationDetach", hash: "abc123", sessionId: "s1", source: "claude" });
+				await flushPromises();
+
+				const written = mockStoreSummary.mock.calls.at(-1)?.[0] as CommitSummary;
+				expect(written.conversationTokens).toBe(710);
+				expect(written.conversationTokenBreakdown).toEqual({ input: 60, output: 150, cached: 500 });
+			});
+
+			it("still corrects the totals on retry when the failed attempt emptied the whole transcript", async () => {
+				// The `deletes.length > 0` sibling of the retry case above, and the reason the
+				// transcript-id removal moved AFTER the file batch. Stripping the id first is a
+				// durable write: when the batch then fails, the sessions are still in the files
+				// but no node claims their transcript id any more, so the retry's
+				// `subtractDetachedUsage` finds nothing to attribute the removed usage to (its
+				// `claimed` check) and gives up — the detach "succeeds" the second time with
+				// conversationTokens/cost permanently stale.
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				mockReadTranscriptsForCommits.mockResolvedValue(
+					new Map([
+						[
+							"abc123",
+							{
+								sessions: [
+									{
+										sessionId: "s1",
+										source: "claude" as const,
+										entries: [{ role: "human" as const, content: "A" }],
+										usage: { input: 40, output: 50, cached: 200 },
+									},
+								],
+							},
+						],
+					]),
+				);
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: ["abc123"],
+					conversationTokens: 1000,
+					conversationTokenBreakdown: { input: 100, output: 200, cached: 700 },
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
+				mockStoreSummary.mockClear();
+				const dispatch = captureMessageHandler();
+
+				// Attempt 1: the batch fails, so neither the id list nor the totals are written.
+				mockSaveTranscriptsBatch.mockRejectedValueOnce(new Error("disk full"));
+				dispatch({ command: "conversationDetach", hash: "abc123", sessionId: "s1", source: "claude" });
+				await flushPromises();
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+
+				// Attempt 2: the summary still claims "abc123", so the removed usage is
+				// attributable and the correction lands — 1000 − 290 = 710 — in the SAME write
+				// that drops the emptied transcript's id.
+				dispatch({ command: "conversationDetach", hash: "abc123", sessionId: "s1", source: "claude" });
+				await flushPromises();
+
+				const written = mockStoreSummary.mock.calls.at(-1)?.[0] as CommitSummary;
+				expect(written.conversationTokens).toBe(710);
+				expect(written.conversationTokenBreakdown).toEqual({ input: 60, output: 150, cached: 500 });
+				expect(written.transcripts).toEqual([]);
+				expect(mockStoreSummary).toHaveBeenCalledTimes(1);
+			});
+
 			it("openConversation opens the archived transcript in a read-only ConversationDetailsPanel", async () => {
 				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
 				mockReadTranscriptsForCommits.mockResolvedValue(
@@ -5740,7 +6098,14 @@ describe("SummaryWebviewPanel", () => {
 				);
 			});
 
-			it("reports an error and leaves the summary untouched when persisting the transcript-ID removal fails", async () => {
+			it("completes the detach when persisting the transcript-ID removal fails — the dangling id self-heals", async () => {
+				// The files are rewritten FIRST, so a summary-write failure lands on the
+				// tolerated side: `summary.transcripts` still lists an id whose file is gone,
+				// which `refreshTranscriptHashes` heals by intersecting tree ids with the files
+				// on disk. The detach itself succeeded, so it must not report a failure or
+				// leave the row stuck — the opposite ordering would abort with the sessions
+				// still in the files but their id already stripped, which is unrecoverable
+				// (see the retry test below).
 				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
 				mockReadTranscriptsForCommits.mockResolvedValue(
 					new Map([
@@ -5774,16 +6139,18 @@ describe("SummaryWebviewPanel", () => {
 				mockSaveTranscriptsBatch.mockClear();
 				const dispatch = captureMessageHandler();
 
-				// The only session in the only transcript → kept.length === 0 →
-				// deletes.length > 0 → persistTranscriptIdRemoval runs (and fails)
-				// before the (never-reached) file batch write.
+				// The only session in the only transcript → kept.length === 0 → the transcript
+				// is deleted and `persistTranscriptIdRemoval` runs (and fails) afterwards.
 				dispatch({ command: "conversationDetach", hash: "abc123", sessionId: "s1", source: "claude" });
 				await flushPromises();
 
-				expect(showErrorMessage).toHaveBeenCalledWith(
+				expect(mockSaveTranscriptsBatch).toHaveBeenCalledWith([], ["abc123"], workspaceRoot);
+				expect(showErrorMessage).not.toHaveBeenCalledWith(
 					expect.stringContaining("Detach conversation failed"),
 				);
-				expect(mockSaveTranscriptsBatch).not.toHaveBeenCalled();
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({ command: "conversationDetached" }),
+				);
 			});
 
 			it("is denied on a foreign-repo panel", async () => {
@@ -11907,6 +12274,82 @@ describe("SummaryWebviewPanel", () => {
 				});
 			});
 
+			it("hides a usage-only carrier but keeps a real conversation that shares the transcript", async () => {
+				// The queue worker persists a zero-entry session carrying `usage` when a
+				// conversation spent tokens without producing a readable turn — it exists
+				// only so `detach` has a subtrahend. Listing it would render an empty
+				// conversation row, so the reader drops it. The sibling with real turns,
+				// and an entries-less LEGACY session (no `usage`), both still list.
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["c1"]));
+				const map = new Map<
+					string,
+					{
+						sessions: Array<{
+							sessionId: string;
+							source?: string;
+							entries?: unknown[];
+							usage?: { input: number; output: number; cached: number };
+						}>;
+					}
+				>([
+					[
+						"c1",
+						{
+							sessions: [
+								{ sessionId: "real", entries: [{ role: "human", content: "hi" }] },
+								{ sessionId: "carrier", entries: [], usage: { input: 600, output: 300, cached: 0 } },
+								// Legacy/malformed: omits `entries`, carries no `usage` → NOT a
+								// carrier, still listed with a turn count of 0.
+								{ sessionId: "legacy" },
+							],
+						},
+					],
+				]);
+				mockReadTranscriptsForCommits.mockResolvedValue(map as never);
+				const dispatch = await openPanel();
+
+				dispatch({ command: "loadConversations" });
+				await flushPromises();
+
+				const call = postMessage.mock.calls.find(
+					(c) => (c[0] as { command?: string })?.command === "conversationsData",
+				);
+				const items = call?.[0].items as Array<{ sessionId: string; messageCount: number }>;
+				expect(items.map((i) => i.sessionId)).toEqual(["real", "legacy"]);
+			});
+
+			it("keeps a conversation whose carrier slice is joined by real turns in another transcript", async () => {
+				// Merged-view semantics: the same conversation can be a carrier in one
+				// commit's transcript and carry real turns in another. Filtering per slice
+				// would hide a conversation the user can actually read.
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["c1", "c2"]));
+				const map = new Map<
+					string,
+					{
+						sessions: Array<{
+							sessionId: string;
+							entries?: unknown[];
+							usage?: { input: number; output: number; cached: number };
+						}>;
+					}
+				>([
+					["c1", { sessions: [{ sessionId: "split", entries: [], usage: { input: 1, output: 1, cached: 0 } }] }],
+					["c2", { sessions: [{ sessionId: "split", entries: [{ role: "human", content: "hi" }] }] }],
+				]);
+				mockReadTranscriptsForCommits.mockResolvedValue(map as never);
+				const dispatch = await openPanel();
+
+				dispatch({ command: "loadConversations" });
+				await flushPromises();
+
+				const call = postMessage.mock.calls.find(
+					(c) => (c[0] as { command?: string })?.command === "conversationsData",
+				);
+				const items = call?.[0].items as Array<{ sessionId: string; messageCount: number }>;
+				expect(items).toHaveLength(1);
+				expect(items[0]).toMatchObject({ sessionId: "split", messageCount: 1 });
+			});
+
 			it("logs a warning when the transcript read rejects (Error and non-Error)", async () => {
 				const dispatch = await openPanel();
 				warn.mockClear();
@@ -12141,7 +12584,7 @@ describe("SummaryWebviewPanel", () => {
 				expect(result).toBe(summary);
 			});
 
-			it("reports an error when persisting the transcript-ID removal rejects with a non-Error", async () => {
+			it("tolerates a non-Error rejection when persisting the transcript-ID removal", async () => {
 				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
 				mockReadTranscriptsForCommits.mockResolvedValue(
 					new Map([
@@ -12182,8 +12625,14 @@ describe("SummaryWebviewPanel", () => {
 				});
 				await flushPromises();
 
-				expect(showErrorMessage).toHaveBeenCalledWith(
+				// Covers the `String(err)` side of the post-write catch's log formatting. The
+				// files are already rewritten at that point, so the failure is logged and the
+				// detach still completes rather than reporting a failure it didn't have.
+				expect(showErrorMessage).not.toHaveBeenCalledWith(
 					expect.stringContaining("Detach conversation failed"),
+				);
+				expect(postMessage).toHaveBeenCalledWith(
+					expect.objectContaining({ command: "conversationDetached" }),
 				);
 			});
 

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -21,6 +21,10 @@
 import { randomBytes } from "node:crypto";
 import * as vscode from "vscode";
 import { execFileSyncHidden } from "../../../cli/src/util/Subprocess.js";
+import {
+	type DetachedSessionUsage,
+	subtractDetachedUsage,
+} from "../../../cli/src/core/DetachedUsageSubtraction.js";
 import { isAncestor } from "../../../cli/src/core/GitOps.js";
 import { withPlansLock } from "../../../cli/src/core/Locks.js";
 import { toForwardSlash } from "../../../cli/src/core/PathUtils.js";
@@ -112,6 +116,7 @@ import {
 	buildJolliRow,
 	buildPlansAndNotesSection,
 	buildRecapSection,
+	buildTokenMeter,
 	buildTopicsSection,
 	contextChipCount,
 	type FileRow,
@@ -3823,6 +3828,17 @@ export class SummaryWebviewPanel {
 				if (seen.has(key)) {
 					continue;
 				}
+				// Skip a usage-only carrier slice WITHOUT marking the key seen: such a
+				// conversation must not be counted (its row is hidden, so a count of 1
+				// against an empty list reads as a bug), but a conversation whose slice in
+				// THIS transcript happens to be a carrier still gets counted when a later
+				// transcript carries its real turns. Same merged-view semantics as
+				// readGroupedArchivedSessions, reached without a second grouping pass, and
+				// the same narrow predicate — a session that merely omits `entries` is
+				// legacy data, not a carrier, and still counts.
+				if ((session.entries ?? []).length === 0 && session.usage !== undefined) {
+					continue;
+				}
 				seen.add(key);
 				sessionCounts[source] = (sessionCounts[source] ?? 0) + 1;
 			}
@@ -3907,9 +3923,29 @@ export class SummaryWebviewPanel {
 				if (ta === undefined || tb === undefined) return 0;
 				return ta - tb;
 			});
-			grouped.set(key, { session: g.session, hash: g.hash, entries: sorted.flat() });
+			const entries = sorted.flat();
+			// Hide a usage-only conversation: it exists on disk only so `detach` has a
+			// per-session subtrahend (the queue worker persists a zero-entry carrier for
+			// a conversation that spent tokens without producing a readable turn), so a
+			// row for it would render as an empty conversation.
+			//
+			// The `usage` half of the predicate is load-bearing. "No entries at all" is a
+			// DIFFERENT case: a legacy/malformed stored session can omit `entries`
+			// entirely, and those are real conversations this panel deliberately still
+			// lists (turn count 0). Only a carrier is identifiable by empty-entries AND a
+			// recorded `usage`.
+			//
+			// Filtered on the MERGED entries, not per slice: a conversation split across
+			// commits can legitimately be entry-less in one transcript and real in
+			// another, and that one must still show. Detach reads `transcript.sessions`
+			// directly and is deliberately NOT filtered — the record stays subtractable.
+			if (entries.length === 0 && g.session.usage !== undefined) continue;
+			grouped.set(key, { session: g.session, hash: g.hash, entries });
 		}
-		return { order, grouped };
+		// Keep `order` in sync with `grouped` so callers can zip the two without
+		// hitting a key that was just filtered out (handleLoadConversations maps over
+		// `order` and non-null-asserts the lookup).
+		return { order: order.filter((key) => grouped.has(key)), grouped };
 	}
 
 	private async handleLoadConversations(): Promise<void> {
@@ -4146,6 +4182,11 @@ export class SummaryWebviewPanel {
 
 		const writes: Array<{ hash: string; data: StoredTranscript }> = [];
 		const deletes: Array<string> = [];
+		// The detached sessions' own token attribution, keyed by the transcript id
+		// they came out of, so the summary's token/cost figures can be corrected by
+		// the same amount the files lost. Collected here (before the files are
+		// rewritten) because that is the last point the removed sessions are readable.
+		const removedUsage = new Map<string, Array<DetachedSessionUsage>>();
 		let removedAny = false;
 
 		for (const [commitHash, transcript] of transcriptMap) {
@@ -4157,6 +4198,13 @@ export class SummaryWebviewPanel {
 				continue;
 			}
 			removedAny = true;
+			const dropped = transcript.sessions.filter(
+				(s) => s.sessionId === sessionId && (s.source ?? "claude") === source,
+			);
+			removedUsage.set(
+				commitHash,
+				dropped.map((s) => ({ usage: s.usage, usageByModel: s.usageByModel })),
+			);
 			if (kept.length === 0) {
 				deletes.push(commitHash);
 			} else {
@@ -4176,39 +4224,124 @@ export class SummaryWebviewPanel {
 			return;
 		}
 
-		// Summary-first ordering (same rationale as persistTranscriptIdRemoval's
-		// other callers): if any transcript files become empty, drop their IDs from
-		// `summary.transcripts` BEFORE touching files, so a file-batch failure
-		// leaves at worst "no files touched yet" rather than a dangling reference.
-		// Both steps re-throw on failure (rather than swallowing the error) so
-		// the dispatcher's `catchAndShow` wrapper surfaces a visible error toast
-		// instead of leaving `summary.transcripts` and the on-disk transcript
-		// files silently inconsistent with each other. Unlike the old modal's
-		// Save/Delete buttons, this row has no "in progress" UI state to unstick,
-		// so there's no need for a dedicated webview-side failure message.
-		if (deletes.length > 0 && this.currentSummary) {
-			try {
-				this.currentSummary = await this.persistTranscriptIdRemoval(
-					this.currentSummary,
-					new Set(deletes),
+		// Compute the memory's corrected conversation token/cost figures — the detached
+		// session's own recorded share subtracted — but hold the result in a LOCAL and
+		// publish nothing yet.
+		//
+		// `this.currentSummary` must NOT be reassigned here. Every write below can
+		// throw, and an already-subtracted in-memory summary would survive the failure:
+		// the row stays in the webview (no `conversationDetached` is posted on the error
+		// path), so the user retries, the sessions are still in the transcript files, and
+		// the subtraction runs a SECOND time against a figure that already had it
+		// applied. `Math.max(0, …)` then floors the meter to nothing, which renders
+		// exactly like a legacy memory that never reported usage. Publish only what is
+		// durable.
+		let correctedSummary: CommitSummary | undefined;
+		if (this.currentSummary) {
+			const subtraction = subtractDetachedUsage(this.currentSummary, removedUsage);
+			if (subtraction.unattributed.length > 0) {
+				// Forward-only by design: memories written before per-session usage was
+				// persisted have nothing to subtract, so their totals stay as-is. A
+				// partially-attributable transcript lands here too (some removed sessions
+				// carried `usage`, some did not) — the total is corrected by what could be
+				// accounted for and the shortfall is reported. Logged rather than silently
+				// skipped: a stale or short bar with no trace reads as a bug.
+				log.info(
+					"Detach: token totals incomplete — no recorded per-session usage for transcript(s): %s",
+					subtraction.unattributed.join(", "),
 				);
-			} catch (err) {
-				log.warn(
-					"Detach aborted — could not persist summary.transcripts: %s",
-					err instanceof Error ? err.message : String(err),
-				);
-				throw new Error("Could not update summary. Transcript files were NOT modified.");
 			}
+			if (subtraction.changed) correctedSummary = subtraction.summary;
 		}
 
+		// FILES FIRST, then ONE summary write carrying both the transcript-id removal
+		// and the token correction.
+		//
+		// The reverse (ids first, as persistTranscriptIdRemoval's other callers do) is
+		// unrecoverable here, because the id strip is a DURABLE write
+		// (`storeSummary(force=true)`) while the batch below may still fail. The
+		// sessions then remain in the files, but neither the summary on disk nor
+		// `this.currentSummary` claims those ids any more — so the user's retry recomputes
+		// `subtractDetachedUsage` against a summary in which no node claims the detached
+		// id, which that module reports as unattributable and refuses to guess at (see its
+		// `claimed` check). The detach then "succeeds" on the second attempt with
+		// conversationTokens/cost permanently stale, and the orphaned files are no longer
+		// referenced by anything.
+		//
+		// Writing files first turns both failure modes into tolerated ones:
+		//   - batch fails         → nothing has been written at all, so a retry is a clean
+		//                           redo: the sessions are still readable and the summary
+		//                           still claims their ids.
+		//   - summary write fails → a dangling `summary.transcripts` id (file gone, id
+		//                           still listed) plus a stale meter. The id self-heals —
+		//                           `refreshTranscriptHashes` intersects tree ids with the
+		//                           files that actually exist on disk — and a stale meter is
+		//                           the already-logged "could not attribute" outcome, not a
+		//                           corrupted figure.
+		// The batch re-throws so the dispatcher's `catchAndShow` wrapper surfaces a visible
+		// error toast rather than leaving the files and `summary.transcripts` silently
+		// inconsistent. Unlike the old modal's Save/Delete buttons, this row has no "in
+		// progress" UI state to unstick, so there's no need for a dedicated webview-side
+		// failure message.
 		try {
 			await this.bridge.saveTranscriptsBatch(writes, deletes);
 		} catch (err) {
 			log.warn(
-				"Summary updated but transcript file batch failed during detach: %s",
+				"Detach aborted — transcript file batch failed, summary left untouched: %s",
 				err instanceof Error ? err.message : String(err),
 			);
 			throw new Error("Some transcript files failed to write. See logs.");
+		}
+
+		// The files have lost the sessions, so the corrected totals are now the truth —
+		// persist them together with the id removal. `correctedSummary` was derived from
+		// the PRE-removal summary (subtraction needs the nodes to still claim the detached
+		// transcript ids), so it carries the unfiltered id list; routing it back through
+		// `persistTranscriptIdRemoval` re-applies the same filter and writes in one step.
+		// When nothing was attributable there is no correction to fold in, but any emptied
+		// transcript's id must still be dropped — hence the `this.currentSummary` fallback.
+		let usageChanged = false;
+		const summaryToPersist = correctedSummary ?? this.currentSummary;
+		if (summaryToPersist && (correctedSummary || deletes.length > 0)) {
+			try {
+				const persisted =
+					deletes.length > 0
+						? await this.persistTranscriptIdRemoval(summaryToPersist, new Set(deletes))
+						: summaryToPersist;
+				// A same-reference return means the id filter was a no-op and
+				// `persistTranscriptIdRemoval` wrote NOTHING — which happens when the root's
+				// `transcripts` list is empty because a CHILD node claims the detached id (the
+				// helper only inspects the root). The correction then still owes its own write;
+				// without this the panel would publish a correction that never reached disk.
+				// Only the correction needs that rescue write: a no-op id filter with no
+				// correction to carry has nothing to persist.
+				if (correctedSummary && persisted === correctedSummary) {
+					await this.bridge.storeSummary(correctedSummary, true);
+				}
+				this.currentSummary = persisted;
+				usageChanged = correctedSummary !== undefined;
+			} catch (err) {
+				log.warn(
+					"Detach succeeded but the summary could not be updated — transcript ids may dangle and the meter stays stale: %s",
+					err instanceof Error ? err.message : String(err),
+				);
+				// Surface it. The write is not retried and the outcome is NOT recoverable:
+				// the sessions are already gone from the transcript files, so a second attempt
+				// finds nothing to remove (`removedAny` false → plain ack) and the subtrahend
+				// this run held in memory is unrecoverable — `subtractDetachedUsage` is fed
+				// from the removed sessions' own stored `usage`, which is only readable while
+				// they are still in the files. Regenerate does not help either: it carries
+				// `conversationTokens` over verbatim (see Regenerator) rather than recomputing
+				// from transcripts. So the figures stay permanently high by the detached
+				// conversation's share, and a log line the user never opens is not an honest
+				// way to report that. The row is still acked below — the files really did
+				// change, and leaving the row on screen would only invite that no-op retry.
+				if (correctedSummary) {
+					vscode.window.showWarningMessage(
+						"Conversation detached, but this memory's token and cost figures could not be updated — they still include the detached conversation. See the Jolli Memory log for details.",
+					);
+				}
+			}
 		}
 
 		if (this.currentSummary) {
@@ -4220,6 +4353,11 @@ export class SummaryWebviewPanel {
 			hash,
 			sessionId,
 			source,
+			// Rebuilt only when the totals actually changed, so the webview swaps the
+			// meter in place instead of rebuilding the whole panel (which would collapse
+			// scroll position and expanded sections for a single-row change). Omitted
+			// when nothing was attributable — the meter then keeps its current value.
+			...(usageChanged && this.currentSummary && { tokenMeterHtml: buildTokenMeter(this.currentSummary) }),
 		});
 	}
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer corrected how detaching a conversation changes saved memory totals. Removing a conversation now subtracts tokens and estimated cost only from the history entry that actually owned that conversation, and token-bearing conversations with no readable messages still keep a hidden accounting record for later cleanup. The summary view refreshes to the corrected meter after a successful save. When the files are updated but the corrected totals cannot be stored, the user now sees a warning and the screen no longer implies that the numbers were refreshed.

The developer also fixed transcript accounting that had been inflating usage when one assistant response appeared multiple times across transcript lines or slices. Total tokens and per-model breakdowns now stay aligned under the same deduplication rule, and each conversation keeps only one persisted usage carrier for later pricing and detach work. Existing memories that were already inflated remain unchanged until a later repair pass.

Pricing coverage was expanded across the command line, VS Code, and IntelliJ experiences. New Claude, GPT-5, and OpenAI pro model rates are now valued from published tables, and mixed-model memories combine stored per-model pricing with fallback pricing only for any still-unpriced remainder. The memory detail tooltip now explains when a dollar total reflects direct model pricing plus fallback estimation, which makes the displayed cost easier to interpret.

---

## Topics (3)
<details>
<summary><strong>01 · Detached conversations now update only their owning usage totals</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Removing a conversation from a saved memory did not change its token bar or cost figure. Usage from detached or message-free conversations could stay behind even after the visible conversation was gone.

**💡 Decisions Behind the Code**

- **Persist measured usage per conversation**: The developer kept each conversation's recorded share at write time instead of reconstructing it later from merged totals. That choice made detach cleanup exact for newly written data and avoided guesswork after a conversation had already been removed.

- **Resolve one owner before subtracting**: Repeated transcript ids can appear across amended or squashed history chains. The cleanup now assigns each id to a single deepest owner, which keeps parent history entries from losing usage they never actually carried.

- **Correct only provable usage**: Missing attribution and conflicting sibling claims are left visible rather than force-corrected. That favors accounting honesty and prevents fabricated token or cost changes in older or ambiguous histories.

- **Keep detach acknowledged, but surface stale totals immediately**: The file removal still completes when transcript edits land, even if the corrected memory record fails to save afterward. The warning and missing meter refresh make the stale-state risk visible at the moment it happens.

- **Hide accounting-only records from the UI, not from storage**: Token-only activity still needs a stored per-conversation carrier for later subtraction and pricing repair. Visible surfaces now hide only the new empty-with-usage shape, which keeps lists readable while preserving repair data.

**✅ What Was Implemented**

- Extended persisted transcript data in `cli/src/Types.ts` and `cli/src/hooks/QueueWorker.ts` so each conversation can retain stable identity, per-conversation usage attribution, and per-model splits when that evidence exists. The write path now preserves the difference between unknown attribution and a measured zero, which gives later cleanup work concrete data to subtract.

- Added and expanded `cli/src/core/DetachedUsageSubtraction.ts`, then reworked the detach flow in `vscode/src/views/SummaryWebviewPanel.ts` to resolve ownership before mutating totals. Shared transcript ids are now subtracted exactly once from the deepest owning summary entry, while missing or conflicting claims remain unattributed and untouched.

- `cli/src/hooks/QueueWorker.ts` now writes one hidden usage-only carrier for token-bearing conversations that produced no readable entries. `vscode/src/views/SummaryWebviewPanel.ts`, `vscode/src/views/SidebarWebviewProvider.ts`, and `cli/src/core/RegenerateContext.ts` filter that accounting-only shape out of visible conversation lists, evidence rows, and regenerate counts while keeping real split conversations visible.

- The detach flow now rewrites transcript files before dropping emptied references, saves id removal and corrected totals together, refreshes the open token meter after a successful save, and treats a late summary-save failure as a degraded success. When the file change succeeds but the corrected totals cannot be stored, `vscode/src/views/SummaryWebviewPanel.ts` shows a warning and withholds refreshed meter HTML from the acknowledgement.

**📋 Future Enhancements**

- Older memories written before per-conversation attribution and hidden usage-carrier persistence still cannot always be corrected during detach.
- Add a self-healing recomputation path that rebuilds totals from the transcripts a memory still owns, including recovery after a failed detach write and cleanup of older inflated histories (`JOLLI-2090`).
- No stale-data marker was added for historical memories whose detached usage cannot be fully attributed.

**📁 FILES**
- ``vscode/src/views/SummaryWebviewPanel.ts``
- ``cli/src/core/DetachedUsageSubtraction.ts``
- ``cli/src/hooks/QueueWorker.ts``
- ``cli/src/Types.ts``
- ``vscode/src/views/SidebarWebviewProvider.ts``

</blockquote>
</details>
<details>
<summary><strong>02 · Pricing estimates now cover mixed-model and pro-model usage accurately</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Dollar estimates did not match the models actually used, and newer model families were missing from pricing. Different views could also show different prices for the same memory.

**💡 Decisions Behind the Code**

- **Published rates only**: The pricing tables were limited to models whose public pricing exposed the rate segments needed by the current formula. That keeps estimates tied to verifiable list prices and avoids filling gaps with guessed numbers.

- **Stable list pricing over temporary promotions**: The stored rates stayed on standard published pricing. That makes estimates easier to compare across memories and dates, with less churn from short-lived vendor discounts.

- **Price known pro-model segments now**: Pro-tier OpenAI usage was moved off the cheap generic fallback and onto dedicated rows. That captures the large visible difference in those conversations and keeps the estimate closer to the actual model mix.

- **Treat cached usage conservatively**: The published pro tables did not provide a discounted cached rate. Using the full input price avoids inventing a lower number and keeps the estimate on the safe side.

- **Treat stored cost as partial coverage and fill only real gaps**: A stored price is no longer treated as proof that every token in a memory has already been priced. Known-price usage keeps its recorded estimate, and only uncovered usage receives fallback pricing, which keeps surfaces aligned on the same total.

**✅ What Was Implemented**

- Updated pricing tables in `cli/src/core/Pricing.ts` and `intellij/src/main/kotlin/ai/jolli/jollimemory/core/ModelPricing.kt` with newer Claude, GPT-5, and OpenAI pro-family entries. The tables now carry published pro-model rates, use the input rate for cached segments where no discounted cached rate was published, and advance `PRICES_AS_OF` to `2026-07-30`.

- Reworked `vscode/src/views/SummaryHtmlBuilder.ts` so memory detail totals walk each summary node and combine stored `estimatedCostUsd` values with fallback pricing only for uncovered or unpriced usage. Mixed-model memories now keep their known priced portion, price pro-model usage under its own rows, and use the generic fallback only for truly unpriced remainder.

- Added and refreshed regressions in `cli/src/core/Pricing.test.ts`, `intellij/src/test/kotlin/ai/jolli/jollimemory/core/ModelPricingTest.kt`, and `vscode/src/views/SummaryHtmlBuilder.test.ts`. The checks pin the new rows, verify cached-segment behavior, and keep the UI fallback test focused on a genuinely unpriced model.

**📁 FILES**
- ``cli/src/core/Pricing.ts``
- ``intellij/src/main/kotlin/ai/jolli/jollimemory/core/ModelPricing.kt``
- ``vscode/src/views/SummaryHtmlBuilder.ts``

</blockquote>
</details>
<details>
<summary><strong>03 · Transcript usage now deduplicates repeated assistant responses and slices</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Some commit-level token counts looked implausibly large. Investigation showed that the same model response could be counted several times.

**💡 Decisions Behind the Code**

- **Deduplicate by identity, not by matching numbers**: The fix keys off response or conversation identity instead of collapsing records that merely happen to report the same token values. Separate real calls stay separate, and only duplicated bookkeeping noise is removed.

- **Keep totals and model breakdowns in lockstep**: The same deduplication identity is applied to both the headline token count and the per-model accounting. That prevents the product from showing one amount of usage at the top and pricing a different amount underneath.

- **Store one usage carrier per conversation**: Repeated transcript slices now place the measured usage on exactly one stored slice for that conversation. Later detach and pricing paths can read one consistent recorded share without multiplying a single observed session.

**✅ What Was Implemented**

- Changed `cli/src/core/TranscriptParser.ts` to return a `dedupKey` with parsed usage, using Claude `message.id` when available, and updated `parseUsageByModel()` to apply the same identity. Headline totals and per-model buckets now follow the same deduplication rule.

- Updated `cli/src/core/TranscriptReader.ts` to keep a per-read set of counted response ids and skip repeated usage records for the same response. Claude multi-line assistant responses that repeat one usage payload across thinking, text, or tool-use lines no longer inflate totals during a read.

- In `cli/src/hooks/QueueWorker.ts`, `attachPerSessionUsage()` now stores one merged usage bucket on exactly one `SessionTranscript` per `conversationKey`. Repeated transcript slices for the same conversation no longer persist the same recorded share multiple times, while overlay-pruned sessions and empty attribution cases still remain unattached.

**📋 Future Enhancements**

- Older inflated summaries were not backfilled, and no stale-data flag was added for them.
- A response split across a commit boundary can still be counted once on each side.

**📁 FILES**
- ``cli/src/core/TranscriptParser.ts``
- ``cli/src/core/TranscriptReader.ts``
- ``cli/src/hooks/QueueWorker.ts``
- ``cli/src/Types.ts``

</blockquote>
</details>

---

*Generated by Jolli Memory · July 30, 2026 at 4:38 PM · via Local agent - Codex*
<!-- jollimemory-summary-end -->