### PR TITLE
Update onboarding experience and improve local agent setup reliability

### DIFF
--- a/cli/src/Api.test.ts
+++ b/cli/src/Api.test.ts
@@ -142,11 +142,16 @@ vi.mock("open", () => ({
 vi.mock("./auth/Login.js", () => ({
 	browserLogin: vi.fn().mockResolvedValue(undefined),
 }));
-vi.mock("./core/localagent/ClaudeExecutableResolver.js", async (importOriginal) => {
-	const actual = await importOriginal<typeof import("./core/localagent/ClaudeExecutableResolver.js")>();
-	// Default: no local agent detected, so `promptSetup` shows the provider menu
-	// deterministically (never shells out to a real `claude` during tests).
-	return { ...actual, isClaudeCodeUsable: vi.fn(() => false) };
+vi.mock("./core/localagent/DetectAgents.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./core/localagent/DetectAgents.js")>();
+	// Default: nothing is present and no configured local-agent tool is usable,
+	// so `promptSetup` shows the provider menu and `canGenerateNow` deterministically
+	// reports "can't generate" without shelling out to a real CLI during tests.
+	return {
+		...actual,
+		listPresentLocalAgents: vi.fn().mockReturnValue([]),
+		isLocalAgentUsable: vi.fn().mockResolvedValue(false),
+	};
 });
 vi.mock("./commands/OptionalLogin.js", () => ({
 	offerOptionalJolliLogin: vi.fn().mockResolvedValue(undefined),
@@ -3641,8 +3646,9 @@ describe("CLI", () => {
 
 		it("should auto-select Local Agent when a working claude is detected (no menu)", async () => {
 			const { saveConfigScoped } = await import("./core/SessionTracker.js");
-			const { isClaudeCodeUsable } = await import("./core/localagent/ClaudeExecutableResolver.js");
-			vi.mocked(isClaudeCodeUsable).mockReturnValue(true);
+			const { listPresentLocalAgents, isLocalAgentUsable } = await import("./core/localagent/DetectAgents.js");
+			vi.mocked(listPresentLocalAgents).mockReturnValue([{ id: "claude-code", label: "Claude Code" }]);
+			vi.mocked(isLocalAgentUsable).mockResolvedValue(true);
 			// No menu input — detection auto-selects local agent and returns.
 			mockUserInput();
 			mockExistsSync.mockReturnValue(false);
@@ -3661,18 +3667,24 @@ describe("CLI", () => {
 				expect(calls.some((s) => s.includes("How would you like to generate summaries"))).toBe(false);
 			} finally {
 				Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
-				vi.mocked(isClaudeCodeUsable).mockReturnValue(false);
+				vi.mocked(listPresentLocalAgents).mockReturnValue([]);
+				vi.mocked(isLocalAgentUsable).mockResolvedValue(false);
 			}
 		});
 
 		it("should select a Local Agent tool via the picker on menu choice 3 (no key, no Anthropic prompt)", async () => {
 			const { saveConfigScoped } = await import("./core/SessionTracker.js");
+			const { isLocalAgentUsable } = await import("./core/localagent/DetectAgents.js");
+			// Chosen tool must pass its probe before anything is saved (module default
+			// is false, which would retry forever against a 4-option fallback list).
+			vi.mocked(isLocalAgentUsable).mockResolvedValue(true);
 			// Claude not auto-detected → the provider menu appears. Choose "3" (local
-			// agent CLI). The follow-up tool sub-menu gets no explicit answer, so it
-			// defaults to the first tool (claude-code). A fallthrough to the Anthropic
-			// prompt would hang on a missing answer, so reaching the end proves the
-			// self-sufficient early return.
-			mockUserInput("3");
+			// agent CLI), then "1" (Claude Code) in the tool sub-menu. That sub-menu
+			// answer must be explicit: it has no default, so the exhausted-answers ""
+			// this helper falls back to would be rejected and skip without writing. A
+			// fallthrough to the Anthropic prompt would consume that "" instead, so
+			// reaching the end proves the self-sufficient early return.
+			mockUserInput("3", "1");
 			mockExistsSync.mockReturnValue(false);
 			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
 
@@ -3689,6 +3701,7 @@ describe("CLI", () => {
 				expect(calls.some((s) => s.includes("Anthropic API Key"))).toBe(false);
 			} finally {
 				Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+				vi.mocked(isLocalAgentUsable).mockResolvedValue(false);
 			}
 		});
 
@@ -3827,9 +3840,9 @@ describe("CLI", () => {
 		it("enable nudge: local-agent generation, not signed in → offers sign-in", async () => {
 			const { offerOptionalJolliLogin } = await import("./commands/OptionalLogin.js");
 			const { loadConfig } = await import("./core/SessionTracker.js");
-			const { isClaudeCodeUsable } = await import("./core/localagent/ClaudeExecutableResolver.js");
+			const { isLocalAgentUsable } = await import("./core/localagent/DetectAgents.js");
 			vi.mocked(offerOptionalJolliLogin).mockClear();
-			vi.mocked(isClaudeCodeUsable).mockReturnValue(true);
+			vi.mocked(isLocalAgentUsable).mockResolvedValue(true);
 			vi.mocked(loadConfig).mockResolvedValue({ aiProvider: "local-agent" });
 			mockUserInput();
 			mockExistsSync.mockReturnValue(false);
@@ -3840,7 +3853,7 @@ describe("CLI", () => {
 				expect(offerOptionalJolliLogin).toHaveBeenCalled();
 			} finally {
 				Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
-				vi.mocked(isClaudeCodeUsable).mockReturnValue(false);
+				vi.mocked(isLocalAgentUsable).mockResolvedValue(false);
 				vi.mocked(loadConfig).mockResolvedValue({});
 			}
 		});
@@ -3850,7 +3863,7 @@ describe("CLI", () => {
 			const { loadConfig } = await import("./core/SessionTracker.js");
 			vi.mocked(promptGenerationFix).mockClear();
 			vi.mocked(console.log).mockClear();
-			// isClaudeCodeUsable stays false (module default) → local-agent can't generate,
+			// isLocalAgentUsable stays false (module default) → local-agent can't generate,
 			// so this configured-but-broken state must go STRAIGHT to the repair ladder.
 			vi.mocked(loadConfig).mockResolvedValue({ aiProvider: "local-agent" });
 			mockUserInput();
@@ -4596,6 +4609,7 @@ describe("CLI", () => {
 				discoverExecutable: vi.fn().mockResolvedValue({ file: "/usr/local/bin/claude", version: "2.1.210" }),
 				buildInvocation: vi.fn(),
 				parseResult: vi.fn(),
+				isPresent: vi.fn(),
 			});
 			const output = (await runDoctor(["doctor"], { config: { aiProvider: "local-agent" } })).join("\n");
 			expect(output).toContain("✓ Config");
@@ -4611,6 +4625,7 @@ describe("CLI", () => {
 				discoverExecutable: vi.fn().mockRejectedValue(new Error("No compatible Claude Code CLI found.")),
 				buildInvocation: vi.fn(),
 				parseResult: vi.fn(),
+				isPresent: vi.fn(),
 			});
 			const output = (await runDoctor(["doctor"], { config: { aiProvider: "local-agent" } })).join("\n");
 			// Config is still "selected" (green), but the liveness probe fails loudly.

--- a/cli/src/commands/DoctorCommand.test.ts
+++ b/cli/src/commands/DoctorCommand.test.ts
@@ -171,6 +171,36 @@ describe("DoctorCommand — local-agent tool diagnostic", () => {
 		expect(joined).toContain("Run `claude` once and sign in");
 	});
 
+	it("names localAgentPath as the likely cause when the probe fails with one configured", async () => {
+		// An override short-circuits discovery, so a stale path IS the failure —
+		// including a path orphaned by an older version that didn't clear it on a
+		// tool switch. Nothing else tells the user discovery never ran.
+		h.loadConfig.mockResolvedValue({
+			localAgentTool: "cursor-agent",
+			localAgentPath: "/opt/codex",
+		} as Partial<JolliMemoryConfig>);
+		h.getBackend.mockReturnValue({
+			discoverExecutable: vi
+				.fn()
+				.mockRejectedValue(
+					new Error('Configured local agent path "/opt/codex" is not a working cursor-agent CLI.'),
+				),
+		});
+
+		const joined = (await runDoctor()).join("\n");
+
+		expect(joined).toContain("Discovery was skipped because localAgentPath is set");
+		expect(joined).toContain("jolli configure --remove localAgentPath");
+	});
+
+	it("omits the localAgentPath hint when the probe fails without one", async () => {
+		h.getBackend.mockReturnValue({
+			discoverExecutable: vi.fn().mockRejectedValue(new Error("claude not found")),
+		});
+
+		expect((await runDoctor()).join("\n")).not.toContain("localAgentPath");
+	});
+
 	it("skips the local-agent probe entirely when the credential source isn't local-agent", async () => {
 		h.resolveLlmCredentialSource.mockReturnValue("anthropic-config");
 

--- a/cli/src/commands/DoctorCommand.ts
+++ b/cli/src/commands/DoctorCommand.ts
@@ -183,10 +183,19 @@ async function runDoctor(cwd: string, fix: boolean): Promise<void> {
 			// Append the tool-specific login hint so a not-signed-in user gets
 			// actionable guidance instead of just the raw discovery error.
 			const loginHint = localAgentToolLoginHint(localAgentTool);
+			// An explicit `localAgentPath` short-circuits discovery, so when the probe
+			// fails WITH one set, the path itself is the likeliest cause — including
+			// the case it was set for a different tool before `saveConfigScoped`
+			// started clearing orphans (configs that drifted under an older version
+			// heal on the next tool switch, never on their own). Name the escape
+			// hatch, because nothing else tells the user discovery was skipped.
+			const overrideHint = config.localAgentPath
+				? " Discovery was skipped because localAgentPath is set — clear it with `jolli configure --remove localAgentPath` to auto-discover instead."
+				: "";
 			checks.push({
 				name: "Local agent CLI",
 				status: "fail",
-				message: `${(err as Error).message} — ${loginHint}`,
+				message: `${(err as Error).message} — ${loginHint}${overrideHint}`,
 			});
 		}
 	}

--- a/cli/src/commands/EnableCommand.test.ts
+++ b/cli/src/commands/EnableCommand.test.ts
@@ -1,12 +1,29 @@
 /**
  * EnableCommand tests — focused on the local-agent tool-selection prompt in
- * `promptSetup` (`handleLocalAgent`).
+ * `promptSetup` (`handleLocalAgent`), and on the generalized presence-based
+ * auto-select / picker branches that front it.
  *
  * Covers:
  *   - picking the local-agent option then a non-default tool (Codex) persists
  *     { aiProvider: "local-agent", localAgentTool: "codex" }
- *   - an out-of-range / blank answer falls back to the first listed tool
+ *   - the tool sub-menu has NO default: a blank answer is re-asked exactly like
+ *     an out-of-range / unparseable one, and holding Enter skips without writing
+ *   - a tool that fails its probe is dropped from the menu, so the loop can
+ *     never re-probe a known-broken tool
  *   - the flow is self-sufficient: no Anthropic-key prompt runs afterward
+ *   - zero present tools falls through to the provider menu unchanged
+ *   - exactly one present + usable tool auto-selects silently, no prompt
+ *   - exactly one present but unusable tool falls through to the menu
+ *   - the local-agent route is gated on "no usable credential", NOT on an unset
+ *     aiProvider: a keyless leftover provider must not close it, while a real
+ *     Anthropic key must
+ *   - two or more present tools prompt among them, probing before saving
+ *   - a failed probe on the chosen tool retries rather than looping forever
+ *   - menu choice 3 lists only present tools, or all four with a note when
+ *     none are present
+ *   - exhausting the AUTO-ROUTED picker (every detected tool broken) hands the
+ *     user back the provider menu instead of dead-ending, while an explicit
+ *     "Skip for now" still ends the flow
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -18,7 +35,6 @@ const h = vi.hoisted(() => ({
 	getJolliUrl: vi.fn(),
 	browserLogin: vi.fn(),
 	isLocalAgentChild: vi.fn(),
-	isClaudeCodeUsable: vi.fn(),
 	validateJolliApiKey: vi.fn(),
 	readManualDisableFlag: vi.fn(),
 	writeManualDisableFlag: vi.fn(),
@@ -38,7 +54,6 @@ const h = vi.hoisted(() => ({
 vi.mock("../auth/AuthConfig.js", () => ({ getJolliUrl: h.getJolliUrl }));
 vi.mock("../auth/Login.js", () => ({ browserLogin: h.browserLogin }));
 vi.mock("../core/AgentReentry.js", () => ({ isLocalAgentChild: h.isLocalAgentChild }));
-vi.mock("../core/localagent/ClaudeExecutableResolver.js", () => ({ isClaudeCodeUsable: h.isClaudeCodeUsable }));
 vi.mock("../core/JolliApiUtils.js", () => ({ validateJolliApiKey: h.validateJolliApiKey }));
 vi.mock("../core/RepoProfile.js", () => ({
 	readManualDisableFlag: h.readManualDisableFlag,
@@ -64,38 +79,56 @@ vi.mock("./CliUtils.js", async (importOriginal) => {
 	};
 });
 
+import * as detect from "../core/localagent/DetectAgents.js";
 import { promptSetup } from "./EnableCommand.js";
 
 const GLOBAL_CONFIG_DIR = "/global/config";
+const promptText = h.promptText;
+
+let logs: string[];
+let output: string;
+let savedConfig: Partial<JolliMemoryConfig> | undefined;
+
+beforeEach(() => {
+	// resetAllMocks (not clearAllMocks): also drains any queued
+	// `.mockResolvedValueOnce(...)` values a prior test left unconsumed on the
+	// shared `h.promptText` mock — clearAllMocks only clears call history, so a
+	// leftover queued answer would silently leak into the next test's prompts.
+	vi.resetAllMocks();
+	logs = [];
+	output = "";
+	savedConfig = undefined;
+	vi.spyOn(console, "log").mockImplementation((...a: unknown[]) => {
+		logs.push(a.map(String).join(" "));
+		output = logs.join("\n");
+	});
+	h.getGlobalConfigDir.mockReturnValue(GLOBAL_CONFIG_DIR);
+	// No tools present by default, so promptSetup falls through to the provider
+	// menu rather than the zero-friction auto-select-and-return branch. (Left
+	// unmocked, the real detector would depend on whatever local agent CLIs are
+	// installed on the machine running the test.) Individual tests override via
+	// vi.spyOn(detect, ...) when they need presence.
+	vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([]);
+	vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+	// No jolliApiKey configured, so promptSetup shows the top-level menu
+	// instead of taking the early-return "already configured" branch.
+	h.loadConfigFromDir.mockResolvedValue({} as Partial<JolliMemoryConfig>);
+	h.saveConfigScoped.mockImplementation((partial: Partial<JolliMemoryConfig>) => {
+		savedConfig = partial;
+		return Promise.resolve(undefined);
+	});
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 describe("EnableCommand — promptSetup local-agent tool selection", () => {
-	let logs: string[];
-
-	beforeEach(() => {
-		vi.clearAllMocks();
-		logs = [];
-		vi.spyOn(console, "log").mockImplementation((...a: unknown[]) => {
-			logs.push(a.map(String).join(" "));
-		});
-		h.getGlobalConfigDir.mockReturnValue(GLOBAL_CONFIG_DIR);
-		// No auto-detected Claude Code, so promptSetup falls through to the provider
-		// menu rather than the zero-friction auto-select-and-return branch. (Left
-		// unmocked, the real probe spawns `claude` and its result would depend on
-		// whatever is installed on the test machine.)
-		h.isClaudeCodeUsable.mockReturnValue(false);
-		// No jolliApiKey configured, so promptSetup shows the top-level menu
-		// instead of taking the early-return "already configured" branch.
-		h.loadConfigFromDir.mockResolvedValue({} as Partial<JolliMemoryConfig>);
-		h.saveConfigScoped.mockResolvedValue(undefined);
-	});
-
-	afterEach(() => {
-		vi.restoreAllMocks();
-	});
-
 	it("persists the chosen local-agent tool (Codex, the 2nd listed tool)", async () => {
 		// Top-level menu choice "3" = local agent; second-level menu choice "2" =
 		// Codex, per LOCAL_AGENT_TOOLS insertion order (claude-code, codex, ...).
+		// No tools present (beforeEach default), so the picker falls back to all
+		// four with a note.
 		h.promptText.mockResolvedValueOnce("3").mockResolvedValueOnce("2");
 
 		await promptSetup();
@@ -111,26 +144,66 @@ describe("EnableCommand — promptSetup local-agent tool selection", () => {
 		expect(h.promptText).toHaveBeenCalledTimes(2);
 	});
 
-	it("persists claude-code when the tool sub-menu answer is blank (defaults to choice 1)", async () => {
-		h.promptText.mockResolvedValueOnce("3").mockResolvedValueOnce("");
+	it("re-asks (never pins the first tool) when the tool sub-menu answer is blank", async () => {
+		// The sub-menu has NO default. A bare Enter used to be coerced to "1" and
+		// silently wrote { aiProvider: "local-agent", localAgentTool: "claude-code" }
+		// to the global config — the whole product's first prompt, decided by a
+		// stray newline (one queued in the TTY buffer during startup is enough).
+		// Blank now takes the same re-ask path an out-of-range answer takes.
+		h.promptText.mockResolvedValueOnce("3").mockResolvedValueOnce("").mockResolvedValueOnce("2");
 
 		await promptSetup();
 
 		expect(h.saveConfigScoped).toHaveBeenCalledWith(
-			expect.objectContaining({ aiProvider: "local-agent", localAgentTool: "claude-code" }),
+			expect.objectContaining({ aiProvider: "local-agent", localAgentTool: "codex" }),
+			GLOBAL_CONFIG_DIR,
+		);
+		// Never probed claude-code on the way through — the blank consumed no candidate.
+		expect(logs.join("\n")).toContain("Enter a number between 1 and 5");
+	});
+
+	it("gives up and skips (writing nothing) when the sub-menu answer stays blank", async () => {
+		// Holding Enter is the exact input that used to auto-select Claude Code.
+		// It must now exhaust MAX_INVALID_CHOICES and leave the config untouched.
+		h.promptText.mockResolvedValueOnce("3").mockResolvedValue("");
+
+		await promptSetup();
+
+		expect(h.saveConfigScoped).not.toHaveBeenCalled();
+		expect(logs.join("\n")).toContain("Couldn't read a choice");
+	});
+
+	it("advertises no default in the sub-menu prompt", async () => {
+		// The `[1]` hint is what made a bare Enter look like a legitimate answer.
+		h.promptText.mockResolvedValueOnce("3").mockResolvedValueOnce("2");
+
+		await promptSetup();
+
+		const subMenuPrompt = h.promptText.mock.calls[1][0] as string;
+		expect(subMenuPrompt).toContain("Choice (1-5)");
+		expect(subMenuPrompt).not.toContain("[1]");
+	});
+
+	it("re-prompts (never silently pins the first tool) on an out-of-range sub-menu answer", async () => {
+		// `99` used to index past the list and fall back to list[0], pinning a tool
+		// the user never named. It must now be rejected and re-asked instead.
+		h.promptText.mockResolvedValueOnce("3").mockResolvedValueOnce("99").mockResolvedValueOnce("3");
+
+		await promptSetup();
+
+		expect(h.saveConfigScoped).toHaveBeenCalledWith(
+			expect.objectContaining({ aiProvider: "local-agent", localAgentTool: "cursor-agent" }),
 			GLOBAL_CONFIG_DIR,
 		);
 	});
 
-	it("persists claude-code when the tool sub-menu answer is out of range", async () => {
-		h.promptText.mockResolvedValueOnce("3").mockResolvedValueOnce("99");
+	it("gives up and skips after repeated unreadable sub-menu answers, writing nothing", async () => {
+		// The one loop branch that consumes no candidate needs its own bound.
+		h.promptText.mockResolvedValueOnce("3").mockResolvedValue("nonsense");
 
 		await promptSetup();
 
-		expect(h.saveConfigScoped).toHaveBeenCalledWith(
-			expect.objectContaining({ aiProvider: "local-agent", localAgentTool: "claude-code" }),
-			GLOBAL_CONFIG_DIR,
-		);
+		expect(h.saveConfigScoped).not.toHaveBeenCalled();
 	});
 
 	it("persists cursor-agent (the 3rd listed tool)", async () => {
@@ -142,5 +215,260 @@ describe("EnableCommand — promptSetup local-agent tool selection", () => {
 			expect.objectContaining({ aiProvider: "local-agent", localAgentTool: "cursor-agent" }),
 			GLOBAL_CONFIG_DIR,
 		);
+	});
+});
+
+describe("promptSetup — local agent auto-select", () => {
+	it("auto-selects silently when exactly one tool is present and usable", async () => {
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([{ id: "codex", label: "Codex" }]);
+		vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+		await promptSetup();
+		expect(savedConfig).toMatchObject({ aiProvider: "local-agent", localAgentTool: "codex" });
+		expect(promptText).not.toHaveBeenCalled();
+	});
+
+	it("falls through to the provider menu when the single present tool fails its probe", async () => {
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([{ id: "codex", label: "Codex" }]);
+		vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(false);
+		promptText.mockResolvedValue("4"); // Skip
+		await promptSetup();
+		expect(savedConfig).toBeUndefined();
+		expect(output).toContain("How would you like to generate summaries?");
+	});
+
+	it("prompts when two or more tools are present", async () => {
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([
+			{ id: "claude-code", label: "Claude Code" },
+			{ id: "opencode", label: "OpenCode" },
+		]);
+		vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+		promptText.mockResolvedValue("2");
+		await promptSetup();
+		expect(savedConfig).toMatchObject({ aiProvider: "local-agent", localAgentTool: "opencode" });
+	});
+
+	it("still routes to local agents when a KEYLESS aiProvider is left over on disk", async () => {
+		// The route used to be gated on `aiProvider === undefined`, i.e. "the field
+		// was never written" as a proxy for "the user never chose". VS Code's
+		// Settings panel breaks that proxy: it DERIVES a provider for display when
+		// the field is unset (not signed in → "anthropic") and persists it on the
+		// next Apply — even an Apply that only touched an unrelated field. That one
+		// stray write permanently closed the local-agent route on a machine with
+		// agents installed, sending the user to the top-level provider menu forever.
+		// A provider with no key behind it is a stale preference, not a decision.
+		h.loadConfigFromDir.mockResolvedValue({ aiProvider: "anthropic" } as Partial<JolliMemoryConfig>);
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([{ id: "codex", label: "Codex" }]);
+		vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+
+		await promptSetup();
+
+		expect(savedConfig).toMatchObject({ aiProvider: "local-agent", localAgentTool: "codex" });
+		expect(output).not.toContain("How would you like to generate summaries?");
+	});
+
+	it("does NOT route to local agents when a REAL Anthropic key backs the provider", async () => {
+		// The other half of the same contract: an actual credential is a decision to
+		// honour, so detection must not second-guess it even with tools installed.
+		h.loadConfigFromDir.mockResolvedValue({
+			aiProvider: "anthropic",
+			apiKey: "sk-ant-real",
+		} as Partial<JolliMemoryConfig>);
+		const present = vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([{ id: "codex", label: "Codex" }]);
+		promptText.mockResolvedValue("4"); // Skip at the provider menu.
+
+		await promptSetup();
+
+		expect(present).not.toHaveBeenCalled();
+		expect(output).toContain("How would you like to generate summaries?");
+		expect(savedConfig).toBeUndefined();
+	});
+
+	it("re-prompts when the chosen tool fails its probe, writing nothing", async () => {
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([
+			{ id: "claude-code", label: "Claude Code" },
+			{ id: "opencode", label: "OpenCode" },
+		]);
+		vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+		// A failed tool is REMOVED from the menu, so the second round renumbers:
+		// OpenCode becomes choice 1. Both answers are "1" against the freshly
+		// printed list — which is also what stops a held-Enter run from
+		// re-probing the same broken tool.
+		promptText.mockResolvedValueOnce("1").mockResolvedValueOnce("1");
+		await promptSetup();
+		expect(output).toContain("OpenCode");
+		expect(savedConfig).toMatchObject({ localAgentTool: "opencode" });
+	});
+
+	it("shows the provider menu unchanged when no tool is present", async () => {
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([]);
+		promptText.mockResolvedValue("4");
+		await promptSetup();
+		expect(output).toContain("How would you like to generate summaries?");
+	});
+});
+
+describe("menu choice 3 — explicit local agent", () => {
+	it("lists only present tools", async () => {
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([
+			{ id: "codex", label: "Codex" },
+			{ id: "opencode", label: "OpenCode" },
+		]);
+		vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+		promptText.mockResolvedValueOnce("3").mockResolvedValueOnce("1");
+		await promptSetup();
+		expect(output).toContain("1. Codex");
+		expect(output).toContain("2. OpenCode");
+		expect(output).not.toContain("Cursor");
+	});
+
+	it("falls back to all four with a note when none are present", async () => {
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([]);
+		vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+		promptText.mockResolvedValueOnce("3").mockResolvedValueOnce("1");
+		await promptSetup();
+		expect(output).toContain("None detected");
+		expect(output).toContain("Cursor");
+	});
+
+	it("terminates with install guidance, writing nothing, when the only listed tool fails its probe", async () => {
+		// Exactly one tool present: promptSetup's own fresh-config check probes
+		// it, the probe fails, and it falls through to the top-level menu (per
+		// the "1 present but unusable → menu" row). Choosing menu option "3"
+		// re-detects the same single tool and re-probes it inside
+		// handleLocalAgent's loop, which must empty the candidate list and return
+		// rather than looping forever waiting for a second promptText answer that
+		// never comes.
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([{ id: "codex", label: "Codex" }]);
+		vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(false);
+		promptText.mockResolvedValueOnce("3").mockResolvedValueOnce("1");
+		await promptSetup();
+		expect(output).toContain("Codex isn't usable on this machine — nothing was saved.");
+		// Detected-but-broken: "install one" would be a wrong diagnosis for a user
+		// who already has it on disk (that wording is reserved for the blind list).
+		expect(output).toContain("Every detected tool failed to run");
+		expect(savedConfig).toBeUndefined();
+		// Exactly the top-menu choice + the one submenu answer — proves the loop
+		// returned instead of prompting again.
+		expect(h.promptText).toHaveBeenCalledTimes(2);
+	});
+
+	it("terminates (rather than reprompting forever) when 2+ candidates all keep failing their probe", async () => {
+		// Regression for the deterministic hang: with 2+ candidates that never
+		// pass their probe, the old `for(;;)` loop only ever returned on
+		// `list.length === 1`, so it reprompted forever. A fresh config with
+		// 2+ present tools drives straight into handleLocalAgent's submenu
+		// (see "prompts when two or more tools are present" above), and
+		// promptText here always answers "1" (never "Skip"), so the ONLY thing
+		// that can stop this test from hanging until the test-runner's timeout
+		// is the loop shrinking its own candidate list. The low `it()` timeout
+		// below means a reintroduced unbounded loop fails fast via timeout
+		// instead of hanging the whole suite.
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([
+			{ id: "claude-code", label: "Claude Code" },
+			{ id: "opencode", label: "OpenCode" },
+		]);
+		const usable = vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(false);
+		promptText.mockResolvedValue("1");
+
+		await promptSetup();
+
+		expect(output).toContain("Every detected tool failed to run");
+		// Each failed tool is removed, so the loop runs exactly once per
+		// candidate — never re-probing a tool already known to be broken.
+		expect(usable).toHaveBeenCalledTimes(2);
+		// Exhausting the auto-routed picker hands the user back the provider menu
+		// (see the dedicated test below), where the always-"1" answer takes
+		// browser sign-in — hence the third prompt.
+		expect(h.promptText.mock.calls.length).toBe(3);
+		expect(h.browserLogin).toHaveBeenCalledTimes(1);
+	}, 2000);
+
+	it("falls through to the provider menu when every auto-routed candidate fails its probe", async () => {
+		// The user never ASKED for a local agent here — detection routed them into
+		// the picker. Dead-ending there ("install one, then run jolli enable
+		// again") stranded a multi-tool machine with no way to reach browser
+		// sign-in or an Anthropic key in the same run.
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([
+			{ id: "claude-code", label: "Claude Code" },
+			{ id: "opencode", label: "OpenCode" },
+		]);
+		vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(false);
+		// Two failing picks, then the provider menu's "2" (Anthropic key), then the
+		// key itself.
+		promptText
+			.mockResolvedValueOnce("1")
+			.mockResolvedValueOnce("1")
+			.mockResolvedValueOnce("2")
+			.mockResolvedValueOnce("sk-ant-test");
+
+		await promptSetup();
+
+		expect(output).toContain("How would you like to generate summaries?");
+		expect(savedConfig).toEqual({ apiKey: "sk-ant-test", aiProvider: "anthropic" });
+	}, 2000);
+
+	it("does NOT re-offer the provider menu when the user skips the auto-routed picker", async () => {
+		// Skip is the user's own decision and already names where to configure
+		// later — re-asking would read as the command ignoring the answer.
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([
+			{ id: "claude-code", label: "Claude Code" },
+			{ id: "opencode", label: "OpenCode" },
+		]);
+		vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+		promptText.mockResolvedValueOnce("3");
+
+		await promptSetup();
+
+		expect(output).not.toContain("How would you like to generate summaries?");
+		expect(savedConfig).toBeUndefined();
+		expect(h.promptText).toHaveBeenCalledTimes(1);
+	});
+
+	it("offers an explicit Skip choice in the local-agent submenu and honors it without probing", async () => {
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([
+			{ id: "claude-code", label: "Claude Code" },
+			{ id: "opencode", label: "OpenCode" },
+		]);
+		const usable = vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+		// Fresh config + 2 present tools enters the submenu directly (no
+		// top-level menu). Submenu lists 2 tools, so "Skip for now" is choice 3.
+		promptText.mockResolvedValue("3");
+
+		await promptSetup();
+
+		expect(output).toContain("3. Skip for now (configure later)");
+		expect(savedConfig).toBeUndefined();
+		expect(usable).not.toHaveBeenCalled();
+	});
+
+	it("threads config.localAgentPath into the probe for the two-or-more-present picker", async () => {
+		h.loadConfigFromDir.mockResolvedValue({ localAgentPath: "/custom/bin/tool" } as Partial<JolliMemoryConfig>);
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([
+			{ id: "claude-code", label: "Claude Code" },
+			{ id: "opencode", label: "OpenCode" },
+		]);
+		const usable = vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+		promptText.mockResolvedValue("1");
+
+		await promptSetup();
+
+		// Tool-SCOPED: the config names no localAgentTool, so the override binds to
+		// the "claude-code" default and reaches the probe only for that tool.
+		expect(usable).toHaveBeenCalledWith("claude-code", {
+			override: { tool: "claude-code", path: "/custom/bin/tool" },
+		});
+	});
+
+	it("threads config.localAgentPath into the probe for the explicit menu-choice-3 submenu", async () => {
+		h.loadConfigFromDir.mockResolvedValue({ localAgentPath: "/custom/bin/codex" } as Partial<JolliMemoryConfig>);
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([]);
+		const usable = vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+		promptText.mockResolvedValueOnce("3").mockResolvedValueOnce("1");
+
+		await promptSetup();
+
+		expect(usable).toHaveBeenCalledWith("claude-code", {
+			override: { tool: "claude-code", path: "/custom/bin/codex" },
+		});
 	});
 });

--- a/cli/src/commands/EnableCommand.ts
+++ b/cli/src/commands/EnableCommand.ts
@@ -10,8 +10,14 @@ import { type Command, Option } from "commander";
 import { getJolliUrl, loadAuthToken } from "../auth/AuthConfig.js";
 import { browserLogin } from "../auth/Login.js";
 import { isLocalAgentChild } from "../core/AgentReentry.js";
-import { isClaudeCodeUsable } from "../core/localagent/ClaudeExecutableResolver.js";
-import { LOCAL_AGENT_TOOLS, localAgentToolLabel } from "../core/localagent/ToolMeta.js";
+import {
+	type DetectedAgent,
+	isLocalAgentUsable,
+	type LocalAgentOverride,
+	listPresentLocalAgents,
+	localAgentOverrideFrom,
+} from "../core/localagent/DetectAgents.js";
+import { LOCAL_AGENT_TOOLS, localAgentToolLabel, localAgentToolLoginHint } from "../core/localagent/ToolMeta.js";
 import { getGlobalConfigDir, loadConfig, loadConfigFromDir, saveConfigScoped } from "../core/SessionTracker.js";
 import { track } from "../core/Telemetry.js";
 import { markSkipExitFlush } from "../core/TelemetryCommandHook.js";
@@ -27,11 +33,30 @@ import { offerOptionalJolliLogin } from "./OptionalLogin.js";
 const log = createLogger("EnableCommand");
 
 /**
- * Interactive provider-setup flow after hooks are installed. When a fresh config
- * meets a working local Claude Code CLI it auto-selects the local agent and
- * returns; otherwise it offers browser sign-in (recommended), an Anthropic key,
- * or skip. Always uses the global config directory. Shared by `jolli enable` and
- * the bare-`jolli` guided front door.
+ * How many unreadable answers the local-agent picker tolerates before it gives
+ * up and skips. Bounds the one loop branch that consumes no candidate — see
+ * {@link handleLocalAgent}. Three so a genuine typo costs nothing, while a
+ * prompt stuck returning garbage (or a user holding Enter, since that menu has no
+ * default) cannot spin.
+ */
+const MAX_INVALID_CHOICES = 3;
+
+/**
+ * What a run of {@link handleLocalAgent} settled on. `"exhausted"` is the one
+ * outcome the caller must react to: every offered tool failed its capability
+ * probe, so the local-agent route is closed on this machine and a caller that
+ * ENTERED that route automatically (the multi-tool fast path) has to hand the
+ * user back the full provider menu rather than dead-end them.
+ */
+type LocalAgentPickOutcome = "saved" | "skipped" | "exhausted";
+
+/**
+ * Interactive provider-setup flow after hooks are installed. When there is no
+ * usable credential and exactly one present, working local agent tool, it
+ * auto-selects that tool and returns; when two or more are present it prompts
+ * among them; otherwise it offers browser sign-in (recommended), an Anthropic
+ * key, a local-agent picker, or skip. Always uses the global config directory.
+ * Shared by `jolli enable` and the bare-`jolli` guided front door.
  */
 export async function promptSetup(): Promise<void> {
 	const configDir = getGlobalConfigDir();
@@ -44,17 +69,49 @@ export async function promptSetup(): Promise<void> {
 		return;
 	}
 
-	// Zero-friction default: when nothing is configured yet AND a working local
-	// Claude Code CLI is present, generate summaries through the user's own
-	// subscription (no API key, no sign-in) and skip the menu entirely. Probe
-	// ONLY on a truly fresh config so an existing Anthropic key or a deliberate
-	// provider choice is never second-guessed (and so an already-configured
-	// re-run never pays for the subprocess probe). Detection already picked the
-	// tool, so this bypasses the interactive local-agent picker below.
-	const fresh = !config.apiKey && !process.env.ANTHROPIC_API_KEY && config.aiProvider === undefined;
-	if (fresh && isClaudeCodeUsable({ overridePath: config.localAgentPath })) {
-		await autoSelectClaudeCode(configDir);
-		return;
+	// Zero-friction default: when there is no usable credential AND local agent
+	// tools are installed, generate summaries through the user's own subscription
+	// (no API key, no sign-in).
+	//
+	// The gate is "no credential that could generate", NOT "aiProvider was never
+	// written". A bare `aiProvider` with no key behind it is a STALE preference,
+	// not a decision to honour — and it is routinely written by accident: VS Code's
+	// Settings panel derives a provider for display when the field is unset
+	// (`SettingsWebviewPanel.resolveProvider` → "anthropic" when not signed in) and
+	// persists it on the next Apply, even one that only touched an unrelated field.
+	// Gating on `=== undefined` let that one stray write permanently close the
+	// local-agent route on a machine with four agents installed. A REAL Anthropic
+	// credential still suppresses the route — that is what the two checks below do.
+	// A jolliApiKey never reaches here (early return above).
+	//
+	// Presence detection is filesystem-only (~4 ms for all four tools); the
+	// expensive capability probe (161-1772 ms each) runs for at most ONE tool,
+	// never as a sweep.
+	//
+	// Exactly one present → auto-select it silently, as this command has always
+	// done for Claude Code. Two or more → there is a real choice to make, so ask.
+	const noCredential = !config.apiKey && !process.env.ANTHROPIC_API_KEY;
+	const override = localAgentOverrideFrom(config);
+	if (noCredential) {
+		const present = listPresentLocalAgents(override);
+		if (present.length === 1) {
+			const only = present[0];
+			if (await isLocalAgentUsable(only.id, { override })) {
+				await autoSelectLocalAgent(configDir, only.id);
+				return;
+			}
+			// Present but not runnable — fall through to the menu rather than
+			// pinning a provider that cannot generate.
+		} else if (present.length > 1) {
+			// The user did not ASK for a local agent here — detection routed them
+			// into the picker. So when every detected tool turns out to be unusable,
+			// the route we chose for them is closed and the menu below (sign-in /
+			// Anthropic key / skip) is still owed to them. Only "exhausted" falls
+			// through: an explicit "Skip for now" is the user's own decision and has
+			// already printed where to configure later.
+			if ((await handleLocalAgent(configDir, present, override)) !== "exhausted") return;
+			console.log("\n  No usable local agent CLI — here are the other ways to generate summaries.");
+		}
 	}
 
 	// Otherwise present the provider menu. A local agent CLI is always offered —
@@ -76,7 +133,10 @@ export async function promptSetup(): Promise<void> {
 	if (choice === "2") {
 		await handleAnthropicKey(configDir);
 	} else if (choice === "3") {
-		await handleLocalAgent(configDir);
+		// Outcome deliberately ignored: the user picked the local-agent route from
+		// this very menu, so "exhausted" has nowhere better to fall through to —
+		// re-offering the menu here would loop.
+		await handleLocalAgent(configDir, undefined, override);
 	} else if (choice === "4") {
 		console.log("\n  Skipped. Configure later with 'jolli auth login' or 'jolli configure'.");
 		console.log(`    ${join(configDir, "config.json")}\n`);
@@ -112,54 +172,162 @@ async function handleAnthropicKey(configDir: string): Promise<void> {
 }
 
 /**
- * Auto-selects the Local Agent provider after a working Claude Code CLI is
- * detected: summaries are generated by driving the local `claude` through the
- * user's own subscription, so no jollimemory-held API key is stored. Reached
- * only when {@link isClaudeCodeUsable} already returned true on a fresh config,
- * so it skips the interactive tool picker and states the detection plainly,
- * pointing at how to change it.
+ * Auto-selects the Local Agent provider after exactly one working tool was
+ * detected: summaries are generated by driving that tool through the user's own
+ * subscription, so no jollimemory-held API key is stored. Reached only when the
+ * tool already passed its capability probe, so it skips the picker and states
+ * the detection plainly, pointing at how to change it.
  */
-async function autoSelectClaudeCode(configDir: string): Promise<void> {
+async function autoSelectLocalAgent(configDir: string, tool: LocalAgentToolId): Promise<void> {
+	const label = localAgentToolLabel(tool);
 	await saveConfigScoped(
-		{ aiProvider: "local-agent", localAgentTool: "claude-code" } as Partial<JolliMemoryConfig>,
+		{ aiProvider: "local-agent", localAgentTool: tool } as Partial<JolliMemoryConfig>,
 		configDir,
 	);
-	console.log("\n  ✓ Detected Claude Code — using your subscription to generate summaries (claude -p), no API key.");
-	console.log("  Summaries run through your local `claude` login.");
+	console.log(`\n  ✓ Detected ${label} — using your subscription to generate summaries, no API key.`);
+	console.log(`  Summaries run through your local ${label} login.`);
 	console.log("  Change this anytime: 'jolli auth login', or 'jolli configure --set aiProvider=jolli'.");
 	console.log(`\n  Configuration saved to ${join(configDir, "config.json")}\n`);
 }
 
 /**
- * Selects the Local Agent provider from an interactive tool picker: summaries
- * are generated by driving a locally-installed agent CLI (Claude Code, Codex,
- * Cursor, or OpenCode) through its own subscription/account login, so no
- * jollimemory-held API key is stored. Self-sufficient — the caller does not
- * fall through to the Anthropic-key prompt. Binary liveness is verified by
- * `jolli doctor`, which probes that the chosen tool is installed and accepts the
- * flags we pass.
+ * Picks a local agent from a list and pins it as the provider. Summaries are
+ * generated by driving the chosen CLI through its own subscription login, so no
+ * jollimemory-held API key is stored.
+ *
+ * `candidates` is the detected list when any tool is present. When nothing is
+ * detected we still offer all four with a note, because reaching here means the
+ * user asked for a local agent explicitly and the command must not dead-end.
+ * `override` is the config's tool-scoped explicit path (see
+ * {@link localAgentOverrideFrom}); it reaches the probe only for the tool it
+ * actually names, so choosing a *different* tool is auto-discovered rather than
+ * probed at someone else's binary.
+ *
+ * The choice is capability-probed BEFORE it is written: this used to save any of
+ * the four unprobed and defer verification to `jolli doctor`, which let a
+ * known-broken configuration land in config.json.
+ *
+ * The prompt deliberately has NO default. This is an N-way choice the user did
+ * not necessarily ask to be in (the multi-tool fast path routes them here), and
+ * its outcome is a global-config write pinning a provider — so a bare Enter must
+ * not decide it. It used to be coerced to `1`, which meant a single stray newline
+ * (one queued in the TTY buffer while startup did its git + storage work is
+ * enough) silently pinned Claude Code. Blank now takes the same rejection path as
+ * `99`, bounded by {@link MAX_INVALID_CHOICES}, so the worst case is "nothing was
+ * saved" rather than "a provider the user never named".
+ *
+ * Termination has two independent guarantees, because the loop can turn over for
+ * two different reasons:
+ *
+ * - A tool that FAILS its probe is REMOVED from the menu, so a probing round
+ *   either writes a config, returns, or strictly shrinks a finite list. Leaving
+ *   the failed entry in place would offer a tool already known to be broken, and
+ *   re-picking it costs another 161-1772 ms probe to learn nothing new.
+ * - A BLANK / UNPARSEABLE / out-of-range answer consumes no candidate, so it is
+ *   capped separately by {@link MAX_INVALID_CHOICES}; without that cap a prompt
+ *   wired to keep returning garbage would spin forever.
+ *
+ * "Skip for now" stays available at every step. No exit path writes.
+ *
+ * Returns which of the three exits was taken (see {@link LocalAgentPickOutcome}),
+ * because "every tool failed" is not the same answer as "the user declined" and
+ * the auto-routed caller must be able to tell them apart.
  */
-async function handleLocalAgent(configDir: string): Promise<void> {
-	const toolIds = Object.keys(LOCAL_AGENT_TOOLS) as LocalAgentToolId[];
+async function handleLocalAgent(
+	configDir: string,
+	candidates?: DetectedAgent[],
+	override?: LocalAgentOverride,
+): Promise<LocalAgentPickOutcome> {
+	const detected = candidates ?? listPresentLocalAgents(override);
+	const none = detected.length === 0;
+	// Mutable: failed probes are spliced out (see the docstring). Copied so a
+	// caller's array is never mutated under it.
+	const list: DetectedAgent[] = none
+		? (Object.keys(LOCAL_AGENT_TOOLS) as LocalAgentToolId[]).map((id) => ({
+				id,
+				label: localAgentToolLabel(id),
+			}))
+		: [...detected];
 
-	console.log("\n  Which local agent CLI would you like to use?\n");
-	toolIds.forEach((id, i) => {
-		console.log(`    ${i + 1}. ${localAgentToolLabel(id)}`);
-	});
+	const skip = (): void => {
+		console.log("\n  Skipped. Configure later with 'jolli auth login' or 'jolli configure'.");
+		console.log(`    ${join(configDir, "config.json")}\n`);
+	};
 
-	const answer = await promptText(`\n  Choice [1]: `);
-	const index = Number.parseInt(answer.trim() || "1", 10) - 1;
-	const tool = toolIds[index] ?? toolIds[0];
-	const label = localAgentToolLabel(tool);
+	let invalid = 0;
+	// `for(;;)`, not `while (list.length > 0)`: `list` is non-empty on entry in
+	// both branches above, and the only way it empties is the splice below —
+	// which returns "exhausted" on the spot. A length condition here would
+	// therefore be a loop exit that cannot be taken, forcing an unreachable tail
+	// after the loop that no test can cover (see the 97% cli/src floor in
+	// AGENTS.md). Every exit is an explicit return inside the body; termination
+	// is guaranteed by the two bounds described in the docstring.
+	for (;;) {
+		// Recomputed each round: the skip entry always sits directly below the
+		// remaining tools, so its number moves down as failed tools are removed.
+		const skipChoice = list.length + 1;
+		console.log("\n  Which local agent CLI would you like to use?\n");
+		if (none) console.log("    (None detected on this machine — pick one to configure anyway.)\n");
+		list.forEach((a, i) => {
+			console.log(`    ${i + 1}. ${a.label}`);
+		});
+		console.log(`    ${skipChoice}. Skip for now (configure later)`);
 
-	await saveConfigScoped(
-		{ aiProvider: "local-agent", localAgentTool: tool } as Partial<JolliMemoryConfig>,
-		configDir,
-	);
-	console.log(`\n  AI provider:       Local Agent (${label}) ✓`);
-	console.log(`  No API key needed — summaries run through your local ${label} login.`);
-	console.log("  Run 'jolli doctor' to verify the tool is installed and signed in.");
-	console.log(`\n  Configuration saved to ${join(configDir, "config.json")}\n`);
+		// No default — see the docstring. `parseInt("")` is NaN, so a bare Enter
+		// falls into the same rejection branch as any other unreadable answer.
+		const answer = await promptText(`\n  Choice (1-${skipChoice}): `);
+		const index = Number.parseInt(answer.trim(), 10) - 1;
+
+		if (index === skipChoice - 1) {
+			skip();
+			return "skipped";
+		}
+
+		// Blank, out-of-range and non-numeric input are all REJECTED, never coerced
+		// to the first entry: typing `9` — or pressing Enter — used to probe (and
+		// could pin) a tool the user never named. Consumes no candidate, so it needs
+		// its own bound.
+		if (!Number.isInteger(index) || index < 0 || index >= list.length) {
+			invalid++;
+			if (invalid >= MAX_INVALID_CHOICES) {
+				console.log(`\n  Couldn't read a choice after ${MAX_INVALID_CHOICES} tries.`);
+				skip();
+				return "skipped";
+			}
+			console.log(`\n  Enter a number between 1 and ${skipChoice}.`);
+			continue;
+		}
+
+		const chosen = list[index];
+
+		if (await isLocalAgentUsable(chosen.id, { override })) {
+			await saveConfigScoped(
+				{ aiProvider: "local-agent", localAgentTool: chosen.id } as Partial<JolliMemoryConfig>,
+				configDir,
+			);
+			console.log(`\n  AI provider:       Local Agent (${chosen.label}) ✓`);
+			console.log(`  No API key needed — summaries run through your local ${chosen.label} login.`);
+			console.log(`  ${localAgentToolLoginHint(chosen.id)}`);
+			console.log(`\n  Configuration saved to ${join(configDir, "config.json")}\n`);
+			return "saved";
+		}
+
+		console.log(`\n  ${chosen.label} isn't usable on this machine — nothing was saved.`);
+		list.splice(index, 1);
+		if (list.length === 0) {
+			// Wording splits on WHY the list is empty. `none` means we offered all four
+			// blind, so "install one" is the right advice. Otherwise the tools were
+			// detected on disk and merely failed to run — telling that user to install
+			// something they already have reads as a broken diagnosis, and the real
+			// fixes are an upgrade or a different provider.
+			console.log(
+				none
+					? "  Install one, then run 'jolli enable' again.\n"
+					: "  Every detected tool failed to run — upgrade one, or pick another provider.\n",
+			);
+			return "exhausted";
+		}
+	}
 }
 
 /**
@@ -320,7 +488,7 @@ async function reportEnableResult(
 						process.env.ANTHROPIC_API_KEY ||
 						cfg.aiProvider === "local-agent",
 				);
-			let canGenerate = canGenerateNow(cfg);
+			let canGenerate = await canGenerateNow(cfg);
 			// Onboarding menu — EXCEPT when a provider is already configured but simply
 			// broken (has a credential yet can't generate). That case skips straight to
 			// the repair ladder below, so the user sees ONE menu (the fix), not two: the
@@ -331,18 +499,18 @@ async function reportEnableResult(
 				await promptSetup();
 				cfg = await loadConfig();
 				token = await loadAuthToken();
-				canGenerate = canGenerateNow(cfg);
+				canGenerate = await canGenerateNow(cfg);
 			}
 			// Repair ladder (parity with the guided front door's Rung 1): a provider
-			// that is configured but can't actually generate — a broken local `claude`,
-			// or an anthropic/jolli key mismatch — gets a one-step fix BEFORE the sync
-			// nudge, so `jolli enable` can't finish with generation silently broken.
+			// that is configured but can't actually generate — a broken local agent
+			// tool, or an anthropic/jolli key mismatch — gets a one-step fix BEFORE the
+			// sync nudge, so `jolli enable` can't finish with generation silently broken.
 			// Skipped for the fresh user who just chose "Skip" (no credential to repair).
 			if (!canGenerate && hasCredential()) {
 				await promptGenerationFix(cfg);
 				cfg = await loadConfig();
 				token = await loadAuthToken();
-				canGenerate = canGenerateNow(cfg);
+				canGenerate = await canGenerateNow(cfg);
 			}
 			// Sign-in nudge (parity with the guided front door's Rung 2): a user
 			// who just configured local-agent / Anthropic generation but isn't
@@ -358,7 +526,7 @@ async function reportEnableResult(
 			console.log("\n  Configure a provider to enable summarization:");
 			console.log(`    Edit: ${join(configDir, "config.json")}`);
 			console.log('    - Set "apiKey" (Anthropic) and/or "jolliApiKey" (Jolli Space), or');
-			console.log('    - Set "aiProvider": "local-agent" to drive a local Claude Code CLI (no key)\n');
+			console.log('    - Set "aiProvider": "local-agent" to drive a local agent CLI (no key)\n');
 		}
 
 		// Pre-push sync catch-up (JOLLI-1900): retry any commits left in

--- a/cli/src/commands/GenerationFix.test.ts
+++ b/cli/src/commands/GenerationFix.test.ts
@@ -1,0 +1,64 @@
+/**
+ * GenerationFix — `canGenerateNow` local-agent probing.
+ *
+ * The interactive repair-ladder branches (`promptGenerationFix` / R1-R3) are
+ * already exercised end-to-end via `GuidedFrontDoor.test.ts`, which mocks the
+ * same underlying modules (`auth/Login.js`, `core/SessionTracker.js`,
+ * `core/localagent/DetectAgents.js`, `./CliUtils.js`) that this module
+ * imports. This file covers the specific bug this task fixes: `canGenerateNow`
+ * must probe the CONFIGURED local-agent tool, not `claude` unconditionally.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as detect from "../core/localagent/DetectAgents.js";
+import { canGenerateNow } from "./GenerationFix.js";
+
+describe("canGenerateNow — configured tool, not claude", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("probes the configured tool, not claude", async () => {
+		const spy = vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+		await canGenerateNow({ aiProvider: "local-agent", localAgentTool: "codex" });
+		expect(spy).toHaveBeenCalledWith("codex", { override: undefined });
+	});
+
+	it("reports usable for a Codex-only machine", async () => {
+		vi.spyOn(detect, "isLocalAgentUsable").mockImplementation(async (t) => t === "codex");
+		await expect(canGenerateNow({ aiProvider: "local-agent", localAgentTool: "codex" })).resolves.toBe(true);
+	});
+
+	it("reports unusable when the configured tool is broken even if claude works", async () => {
+		vi.spyOn(detect, "isLocalAgentUsable").mockImplementation(async (t) => t === "claude-code");
+		await expect(canGenerateNow({ aiProvider: "local-agent", localAgentTool: "opencode" })).resolves.toBe(false);
+	});
+
+	it("defaults to claude-code when localAgentTool is absent", async () => {
+		const spy = vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+		await canGenerateNow({ aiProvider: "local-agent" });
+		expect(spy).toHaveBeenCalledWith("claude-code", { override: undefined });
+	});
+
+	it("passes an explicit localAgentPath through as a tool-SCOPED override", async () => {
+		const spy = vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+		await canGenerateNow({ aiProvider: "local-agent", localAgentTool: "cursor-agent", localAgentPath: "/opt/bin" });
+		expect(spy).toHaveBeenCalledWith("cursor-agent", {
+			override: { tool: "cursor-agent", path: "/opt/bin" },
+		});
+	});
+
+	it("non-local-agent providers defer to resolveLlmCredentialSource (no local-agent probe)", async () => {
+		const priorKey = process.env.ANTHROPIC_API_KEY;
+		delete process.env.ANTHROPIC_API_KEY;
+		try {
+			const spy = vi.spyOn(detect, "isLocalAgentUsable");
+			await expect(canGenerateNow({ aiProvider: "anthropic", apiKey: "sk-ant-x" })).resolves.toBe(true);
+			await expect(canGenerateNow({ aiProvider: "anthropic" })).resolves.toBe(false);
+			expect(spy).not.toHaveBeenCalled();
+		} finally {
+			if (priorKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+			else process.env.ANTHROPIC_API_KEY = priorKey;
+		}
+	});
+});

--- a/cli/src/commands/GenerationFix.ts
+++ b/cli/src/commands/GenerationFix.ts
@@ -17,21 +17,33 @@ import { getJolliUrl } from "../auth/AuthConfig.js";
 import { browserLogin } from "../auth/Login.js";
 import { validateJolliApiKey } from "../core/JolliApiUtils.js";
 import { resolveLlmCredentialSource } from "../core/LlmClient.js";
-import { isClaudeCodeUsable } from "../core/localagent/ClaudeExecutableResolver.js";
+import {
+	isLocalAgentUsable,
+	type LocalAgentOverride,
+	localAgentOverrideFrom,
+} from "../core/localagent/DetectAgents.js";
+import { localAgentToolLabel, localAgentToolLoginHint } from "../core/localagent/ToolMeta.js";
 import { getGlobalConfigDir, saveConfigScoped } from "../core/SessionTracker.js";
-import type { JolliMemoryConfig } from "../Types.js";
+import type { JolliMemoryConfig, LocalAgentToolId } from "../Types.js";
 import { promptText } from "./CliUtils.js";
 
 /**
  * True when the current config can actually generate summaries right now. For
- * the local agent this PROBES the same `claude` binary the commit-time runtime
- * would use (honoring an explicit `localAgentPath`) so it never disagrees with
- * what actually generates; for every other provider it defers to
- * {@link resolveLlmCredentialSource}. Shared verbatim by both the guided front
- * door and `jolli enable` so the two paths agree on "can generate?".
+ * the local agent this PROBES the CONFIGURED tool's binary — the same one the
+ * commit-time runtime resolves via getBackend(localAgentTool) — so it never
+ * disagrees with what actually generates. It used to probe `claude`
+ * unconditionally, which told Codex/Cursor/OpenCode users their generation was
+ * broken and sent them to repair a tool they never selected.
+ *
+ * The `?? "claude-code"` default matches StatusTreeProvider and SummaryUtils,
+ * and covers configs written before `localAgentTool` existed.
  */
-export function canGenerateNow(config: JolliMemoryConfig): boolean {
-	if (config.aiProvider === "local-agent") return isClaudeCodeUsable({ overridePath: config.localAgentPath });
+export async function canGenerateNow(config: JolliMemoryConfig): Promise<boolean> {
+	if (config.aiProvider === "local-agent") {
+		return isLocalAgentUsable(config.localAgentTool ?? "claude-code", {
+			override: localAgentOverrideFrom(config),
+		});
+	}
 	return resolveLlmCredentialSource(config) !== null;
 }
 
@@ -44,9 +56,9 @@ export function canGenerateNow(config: JolliMemoryConfig): boolean {
 export async function promptGenerationFix(config: JolliMemoryConfig): Promise<boolean> {
 	const configDir = getGlobalConfigDir();
 
-	// R3: the local agent is configured but `claude` isn't runnable.
+	// R3: the configured local agent tool isn't runnable.
 	if (config.aiProvider === "local-agent") {
-		return promptLocalAgentFix(configDir, config.localAgentPath);
+		return promptLocalAgentFix(configDir, config.localAgentTool ?? "claude-code", localAgentOverrideFrom(config));
 	}
 
 	const provider = config.aiProvider === "jolli" ? "jolli" : "anthropic";
@@ -95,23 +107,28 @@ export async function promptGenerationFix(config: JolliMemoryConfig): Promise<bo
 }
 
 /**
- * R3 repair: the provider is Local Agent but no usable `claude` was found.
- * Offers a retry (re-probe once), or a switch to Jolli / Anthropic, or skip.
- * Every branch terminates — no infinite retry loop. Returns whether generation
- * can now proceed.
+ * R3 repair: the provider is Local Agent but no usable binary was found for the
+ * CONFIGURED tool. Offers a retry (re-probe once), or a switch to Jolli /
+ * Anthropic, or skip. Every branch terminates — no infinite retry loop.
+ * Returns whether generation can now proceed.
  */
-async function promptLocalAgentFix(configDir: string, localAgentPath: string | undefined): Promise<boolean> {
+async function promptLocalAgentFix(
+	configDir: string,
+	tool: LocalAgentToolId,
+	override: LocalAgentOverride | undefined,
+): Promise<boolean> {
+	const label = localAgentToolLabel(tool);
 	console.log(
-		"\n  AI provider is set to Local Agent but no usable `claude` was found — memories won't be generated.\n",
+		`\n  AI provider is set to Local Agent (${label}) but no usable binary was found — memories won't be generated.\n`,
 	);
-	console.log("    1. Retry (after install / upgrade, or `claude login`)");
+	console.log("    1. Retry (after install / upgrade, or signing in)");
 	console.log("    2. Switch to Jolli (sign in)");
 	console.log("    3. Enter an Anthropic key");
 	console.log("    4. Skip for now");
 	const choice = (await promptText("\n  Choice [1]: ")) || "1";
 
 	if (choice === "4") {
-		console.log("\n  Skipped. Fix Claude Code or run `jolli configure` later.\n");
+		console.log(`\n  Skipped. Fix ${label} or run \`jolli configure\` later.\n`);
 		return false;
 	}
 	if (choice === "2") {
@@ -131,11 +148,12 @@ async function promptLocalAgentFix(configDir: string, localAgentPath: string | u
 		return promptAndSaveAnthropicKey(configDir);
 	}
 	// choice 1 — retry the probe exactly once, then stop.
-	if (isClaudeCodeUsable({ overridePath: localAgentPath })) {
-		console.log("\n  ✓ Claude Code is working now.");
+	if (await isLocalAgentUsable(tool, { override })) {
+		console.log(`\n  ✓ ${label} is working now.`);
 		return true;
 	}
-	console.log("\n  Still no usable `claude`. Fix it and run `jolli` again, or `jolli configure`.\n");
+	console.log(`\n  Still no usable ${label}. ${localAgentToolLoginHint(tool)}`);
+	console.log("  Fix it and run `jolli` again, or `jolli configure`.\n");
 	return false;
 }
 

--- a/cli/src/commands/GuidedFrontDoor.test.ts
+++ b/cli/src/commands/GuidedFrontDoor.test.ts
@@ -23,7 +23,7 @@ const h = vi.hoisted(() => ({
 	loadUserProfile: vi.fn(),
 	saveUserProfile: vi.fn(),
 	isInsideGitWorkTree: vi.fn(),
-	isClaudeCodeUsable: vi.fn(),
+	isLocalAgentUsable: vi.fn(),
 }));
 
 vi.mock("../auth/AuthConfig.js", () => ({ loadAuthToken: h.loadAuthToken, getJolliUrl: h.getJolliUrl }));
@@ -59,9 +59,9 @@ vi.mock("./CliUtils.js", async (importOriginal) => {
 		isInsideGitWorkTree: h.isInsideGitWorkTree,
 	};
 });
-vi.mock("../core/localagent/ClaudeExecutableResolver.js", async (importOriginal) => {
-	const actual = await importOriginal<typeof import("../core/localagent/ClaudeExecutableResolver.js")>();
-	return { ...actual, isClaudeCodeUsable: h.isClaudeCodeUsable };
+vi.mock("../core/localagent/DetectAgents.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../core/localagent/DetectAgents.js")>();
+	return { ...actual, isLocalAgentUsable: h.isLocalAgentUsable };
 });
 
 import { getGuidedFrontDoorStatus, runGuidedFrontDoor } from "./GuidedFrontDoor.js";
@@ -114,7 +114,7 @@ describe("GuidedFrontDoor", () => {
 		h.loadUserProfile.mockResolvedValue({});
 		h.saveUserProfile.mockResolvedValue(undefined);
 		h.isInsideGitWorkTree.mockReturnValue(true);
-		h.isClaudeCodeUsable.mockReturnValue(true);
+		h.isLocalAgentUsable.mockResolvedValue(true);
 	});
 
 	afterEach(() => {
@@ -629,25 +629,37 @@ describe("GuidedFrontDoor", () => {
 		expect(out()).toContain("Jolli is listening");
 	});
 
-	// ── R3: local-agent configured but `claude` not usable ──
+	it("names the configured local agent in the status line", async () => {
+		h.loadAuthToken.mockResolvedValue("oauth-token");
+		h.loadConfig.mockResolvedValue({
+			jolliUrl: "https://acme.jolli.ai",
+			aiProvider: "local-agent",
+			localAgentTool: "codex",
+		});
+		await runGuidedFrontDoor();
+		expect(out()).toContain("summaries via Codex");
+		expect(out()).not.toContain("summaries via Claude Code");
+	});
+
+	// ── R3: local-agent configured but the tool's binary isn't usable ──
 
 	it("R3: local agent broken + skip → repair menu, no false listening", async () => {
 		h.loadAuthToken.mockResolvedValue(undefined);
 		h.loadConfig.mockResolvedValue({ aiProvider: "local-agent" });
-		h.isClaudeCodeUsable.mockReturnValue(false);
+		h.isLocalAgentUsable.mockResolvedValue(false);
 		h.promptText.mockResolvedValue("4"); // skip
 		await runGuidedFrontDoor();
-		expect(out()).toContain("no usable `claude` was found");
+		expect(out()).toContain("no usable binary was found");
 		expect(out()).toContain("Skipped");
 		expect(out()).not.toContain("Jolli is listening");
 		expect(h.runBackfillFrontDoorStep).not.toHaveBeenCalled();
 	});
 
-	it("R3: retry succeeds (claude now usable) → generation restored, listening", async () => {
+	it("R3: retry succeeds (tool now usable) → generation restored, listening", async () => {
 		h.loadAuthToken.mockResolvedValue("oauth-token");
 		h.loadConfig.mockResolvedValue({ jolliUrl: "https://acme.jolli.ai", aiProvider: "local-agent" });
 		h.getSummaryCount.mockResolvedValue(1);
-		h.isClaudeCodeUsable.mockReturnValueOnce(false).mockReturnValue(true);
+		h.isLocalAgentUsable.mockResolvedValueOnce(false).mockResolvedValue(true);
 		h.promptText.mockResolvedValue("1"); // retry
 		await runGuidedFrontDoor();
 		expect(out()).toContain("Claude Code is working now");
@@ -657,10 +669,10 @@ describe("GuidedFrontDoor", () => {
 	it("R3: retry still broken → stops, no listening", async () => {
 		h.loadAuthToken.mockResolvedValue("oauth-token");
 		h.loadConfig.mockResolvedValue({ aiProvider: "local-agent" });
-		h.isClaudeCodeUsable.mockReturnValue(false);
+		h.isLocalAgentUsable.mockResolvedValue(false);
 		h.promptText.mockResolvedValue("1"); // retry, still broken
 		await runGuidedFrontDoor();
-		expect(out()).toContain("Still no usable `claude`");
+		expect(out()).toContain("Still no usable Claude Code");
 		expect(out()).not.toContain("Jolli is listening");
 	});
 
@@ -669,7 +681,7 @@ describe("GuidedFrontDoor", () => {
 		h.loadConfig
 			.mockResolvedValueOnce({ aiProvider: "local-agent" })
 			.mockResolvedValue({ aiProvider: "jolli", jolliApiKey: "sk-jol-new", jolliUrl: "https://acme.jolli.ai" });
-		h.isClaudeCodeUsable.mockReturnValue(false);
+		h.isLocalAgentUsable.mockResolvedValue(false);
 		h.promptText.mockResolvedValue("2"); // switch to Jolli
 		await runGuidedFrontDoor();
 		expect(h.browserLogin).toHaveBeenCalledWith("https://acme.jolli.ai");
@@ -680,7 +692,7 @@ describe("GuidedFrontDoor", () => {
 	it("R3: switch to Jolli but login fails → no provider change, no listening", async () => {
 		h.loadAuthToken.mockResolvedValue(undefined);
 		h.loadConfig.mockResolvedValue({ aiProvider: "local-agent" });
-		h.isClaudeCodeUsable.mockReturnValue(false);
+		h.isLocalAgentUsable.mockResolvedValue(false);
 		h.promptText.mockResolvedValue("2");
 		h.browserLogin.mockRejectedValue(new Error("network down"));
 		await runGuidedFrontDoor();
@@ -692,7 +704,7 @@ describe("GuidedFrontDoor", () => {
 	it("R3: enter an Anthropic key → saved with provider anthropic", async () => {
 		h.loadAuthToken.mockResolvedValue("oauth-token");
 		h.loadConfig.mockResolvedValue({ jolliUrl: "https://acme.jolli.ai", aiProvider: "local-agent" });
-		h.isClaudeCodeUsable.mockReturnValue(false);
+		h.isLocalAgentUsable.mockResolvedValue(false);
 		h.promptText.mockResolvedValueOnce("3").mockResolvedValueOnce("sk-ant-new");
 		await runGuidedFrontDoor();
 		expect(h.saveConfigScoped).toHaveBeenCalledWith(
@@ -705,17 +717,17 @@ describe("GuidedFrontDoor", () => {
 	it("R3: Enter at the repair menu defaults to Retry", async () => {
 		h.loadAuthToken.mockResolvedValue("oauth-token");
 		h.loadConfig.mockResolvedValue({ aiProvider: "local-agent" });
-		h.isClaudeCodeUsable.mockReturnValue(false); // broken; retry re-probes, still broken
+		h.isLocalAgentUsable.mockResolvedValue(false); // broken; retry re-probes, still broken
 		h.promptText.mockResolvedValue(""); // Enter → default [1] = Retry
 		await runGuidedFrontDoor();
-		expect(out()).toContain("Still no usable `claude`");
+		expect(out()).toContain("Still no usable Claude Code");
 		expect(out()).not.toContain("Jolli is listening");
 	});
 
 	it("R3: switch to Jolli, login rejects with a non-Error value → still reported", async () => {
 		h.loadAuthToken.mockResolvedValue(undefined);
 		h.loadConfig.mockResolvedValue({ aiProvider: "local-agent" });
-		h.isClaudeCodeUsable.mockReturnValue(false);
+		h.isLocalAgentUsable.mockResolvedValue(false);
 		h.promptText.mockResolvedValue("2"); // switch to Jolli
 		h.browserLogin.mockRejectedValue("odd failure"); // non-Error rejection
 		await runGuidedFrontDoor();

--- a/cli/src/commands/GuidedFrontDoor.ts
+++ b/cli/src/commands/GuidedFrontDoor.ts
@@ -3,8 +3,8 @@
  *
  * It reads two orthogonal capabilities and guides the next step:
  *   - can generate — is there a usable engine (`canGenerateNow`)? For the local
- *     agent this actually probes that `claude` is runnable, so a broken CLI is
- *     caught here rather than silently at commit time.
+ *     agent this actually probes that the CONFIGURED tool is runnable, so a
+ *     broken CLI is caught here rather than silently at commit time.
  *   - can sync     — is there any Jolli credential (OAuth token or jolliApiKey)
  *                    to push memories to a Space?
  *
@@ -22,6 +22,7 @@
 import { basename } from "node:path";
 import { loadAuthToken } from "../auth/AuthConfig.js";
 import { resolveLlmCredentialSource } from "../core/LlmClient.js";
+import { localAgentToolLabel } from "../core/localagent/ToolMeta.js";
 import { loadConfig } from "../core/SessionTracker.js";
 import { createStorage } from "../core/StorageFactory.js";
 import { getSummaryCount, setActiveStorage } from "../core/SummaryStore.js";
@@ -131,12 +132,12 @@ export async function runGuidedFrontDoor(): Promise<void> {
 	}
 
 	// ── Two orthogonal capabilities, recomputed after each interactive step. ──
-	let canGenerate = canGenerateNow(config);
+	let canGenerate = await canGenerateNow(config);
 	let canSync = Boolean(token || config.jolliApiKey);
 
 	// ── Rung 1 (blocking): a credential exists but the chosen provider can't use
 	// it → repair the provider mismatch. Covers R1/R2 (anthropic/jolli) and R3 (a
-	// configured local agent whose `claude` isn't runnable). `hasCredential()`
+	// configured local agent whose tool isn't runnable). `hasCredential()`
 	// excludes the fresh user who just skipped setup (nothing to repair). ──
 	if (!canGenerate && hasCredential()) {
 		await promptGenerationFix(config);
@@ -145,7 +146,7 @@ export async function runGuidedFrontDoor(): Promise<void> {
 		// Recompute from the freshly-saved config, not the fix's optimistic return:
 		// a switch to Jolli only actually restores generation if a jolliApiKey now
 		// exists, so trust canGenerateNow.
-		canGenerate = canGenerateNow(config);
+		canGenerate = await canGenerateNow(config);
 		canSync = Boolean(token || config.jolliApiKey);
 	}
 
@@ -158,7 +159,7 @@ export async function runGuidedFrontDoor(): Promise<void> {
 		// Signing in can flip an unset provider to "jolli"; if no jolliApiKey was
 		// minted, generation is no longer possible — recompute so the closing
 		// "listening" promise stays honest.
-		canGenerate = canGenerateNow(config);
+		canGenerate = await canGenerateNow(config);
 		canSync = Boolean(token || config.jolliApiKey);
 	}
 
@@ -194,7 +195,10 @@ export async function runGuidedFrontDoor(): Promise<void> {
 	// ── Status line (AFTER enable, so `✓ enabled` is always truthful). ──
 	if (token) {
 		const site = siteHost(config.jolliUrl);
-		const engine = canGenerate && config.aiProvider === "local-agent" ? " · summaries via Claude Code" : "";
+		const engine =
+			canGenerate && config.aiProvider === "local-agent"
+				? ` · summaries via ${localAgentToolLabel(config.localAgentTool ?? "claude-code")}`
+				: "";
 		console.log(site ? `\n  ✓ signed in · ${site}${engine}` : `\n  ✓ signed in${engine}`);
 	} else if (canGenerate && config.aiProvider === "local-agent") {
 		console.log("\n  ✓ local agent set (not signed in to Jolli)");

--- a/cli/src/core/DualWriteStorage.test.ts
+++ b/cli/src/core/DualWriteStorage.test.ts
@@ -68,6 +68,16 @@ describe("DualWriteStorage", () => {
 		rmrf(tempDir);
 	});
 
+	// Minification-safe backend identity — `constructor.name` is mangled in both
+	// shipping bundles, so diagnostics read this instead (JOLLI-2066). Reports
+	// "dual-write" rather than delegating to the primary's kind: a read served by
+	// the primary is still a dual-write installation, and that is what a log line
+	// naming the backend needs to say.
+	it("reports a stable kind that does not depend on the class name", () => {
+		const dual = new DualWriteStorage(new InMemoryStorage(), new InMemoryStorage());
+		expect(dual.kind).toBe("dual-write");
+	});
+
 	it("exposes the shadow's kbRoot via the kbRoot getter", () => {
 		const primary = new InMemoryStorage();
 		const shadow = {

--- a/cli/src/core/DualWriteStorage.ts
+++ b/cli/src/core/DualWriteStorage.ts
@@ -8,12 +8,14 @@
 
 import { createLogger, errMsg, isManuallyDisabled } from "../Logger.js";
 import type { FileWrite, SummaryIndexEntry } from "../Types.js";
-import type { HealOptions, HealResult, StorageProvider } from "./StorageProvider.js";
+import type { HealOptions, HealResult, StorageKind, StorageProvider } from "./StorageProvider.js";
 import type { TopicPage } from "./TopicKBTypes.js";
 
 const log = createLogger("DualWriteStorage");
 
 export class DualWriteStorage implements StorageProvider {
+	readonly kind: StorageKind = "dual-write";
+
 	constructor(
 		private readonly primary: StorageProvider,
 		private readonly shadow: StorageProvider,

--- a/cli/src/core/FolderStorage.test.ts
+++ b/cli/src/core/FolderStorage.test.ts
@@ -111,6 +111,66 @@ describe("FolderStorage", () => {
 			expect(existsSync(join(rootPath, ".jolli", "index.json"))).toBe(true);
 			expect(existsSync(join(rootPath, "index.json"))).toBe(false);
 		});
+
+		/**
+		 * A `null` from readFile means "absent" — but the same `null` used to be
+		 * returned for a file that IS present and failed to read, with the errno
+		 * discarded. Callers cannot recover that distinction, so the warning has
+		 * to happen here (JOLLI-2066).
+		 *
+		 * The failure is provoked with a directory standing where a file is
+		 * expected, so `readFileSync` throws EISDIR — a code that is neither
+		 * ENOENT nor ENOTDIR and therefore must be reported. That beats chmod,
+		 * which is a no-op for root and unreliable on Windows.
+		 */
+		it("warns (and still returns null) when an existing path cannot be read", async () => {
+			const warnSpy = vi.mocked(console.warn);
+			warnSpy.mockClear();
+			mkdirSync(join(rootPath, ".jolli", "trap.txt"));
+
+			expect(await storage.readFile("trap.txt")).toBeNull();
+
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+			const logged = String(warnSpy.mock.calls[0]?.[0]);
+			expect(logged).toContain("readFile failed for");
+			expect(logged).toContain("trap.txt");
+		});
+
+		it("stays quiet when the file is simply absent", async () => {
+			const warnSpy = vi.mocked(console.warn);
+			warnSpy.mockClear();
+
+			expect(await storage.readFile("never-written.txt")).toBeNull();
+
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+
+		it("stays quiet when a parent path segment is a FILE, not a directory", async () => {
+			// ENOTDIR: `<root>/.jolli/wall/inner.json` where `wall` is a regular
+			// file. Structurally "nothing here", same as ENOENT — so it must not
+			// warn, or a cross-repo sweep over a malformed sibling folder would
+			// warn on every read.
+			const warnSpy = vi.mocked(console.warn);
+			warnSpy.mockClear();
+			writeFileSync(join(rootPath, ".jolli", "wall"), "not a dir");
+
+			expect(await storage.readFile("wall/inner.json")).toBeNull();
+
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("kind", () => {
+		/**
+		 * Guards the minification trap this field exists to close: both shipping
+		 * bundles minify without `keepNames`, so `constructor.name` reaches
+		 * production mangled (`Xe` from the CLI, `t` from the extension) and is
+		 * useless for diagnostics. Asserting the literal keeps any rename of the
+		 * class from silently changing what logs report.
+		 */
+		it("reports a stable identity that does not depend on the class name", () => {
+			expect(storage.kind).toBe("folder");
+		});
 	});
 
 	describe("listFiles", () => {

--- a/cli/src/core/FolderStorage.ts
+++ b/cli/src/core/FolderStorage.ts
@@ -21,7 +21,7 @@ import type { CommitSummary, FileWrite, SummaryIndex, SummaryIndexEntry } from "
 import type { ManifestEntry } from "./KBTypes.js";
 import { MetadataManager } from "./MetadataManager.js";
 import { toForwardSlash } from "./PathUtils.js";
-import type { HealOptions, HealResult, StorageProvider } from "./StorageProvider.js";
+import type { HealOptions, HealResult, StorageKind, StorageProvider } from "./StorageProvider.js";
 import { buildMarkdown } from "./SummaryMarkdownBuilder.js";
 import type { TopicPage } from "./TopicKBTypes.js";
 import {
@@ -42,6 +42,8 @@ const log = createLogger("FolderStorage");
 export type ForceRegenerateResult = { ok: true } | { ok: false; reason: "missing" | "malformed" | "unlinkFailed" };
 
 export class FolderStorage implements StorageProvider {
+	readonly kind: StorageKind = "folder";
+
 	constructor(
 		private readonly rootPath: string,
 		private readonly metadataManager: MetadataManager,
@@ -70,10 +72,27 @@ export class FolderStorage implements StorageProvider {
 
 	async readFile(path: string): Promise<string | null> {
 		const file = join(this.rootPath, ".jolli", path);
-		if (!existsSync(file)) return null;
+		// Read first and classify the errno, rather than gating on existsSync:
+		// existsSync returns false for a file it merely cannot STAT, so an EACCES
+		// on a parent directory used to be indistinguishable from absence and fell
+		// straight through to a silent `null` — the exact failure class the (now
+		// DEBUG) loadIndex warning used to be the last line of defence for. It also
+		// halves the syscalls on the index-heavy sweep path this change is about.
 		try {
 			return readFileSync(file, "utf-8");
-		} catch {
+		} catch (error: unknown) {
+			const code = (error as NodeJS.ErrnoException).code;
+			// The routine "nothing here" outcomes: the file is missing, or a path
+			// segment above it is missing / not a directory. Absence is expected on
+			// a fresh repo and on a cross-repo scan, so it stays quiet.
+			if (code === "ENOENT" || code === "ENOTDIR") return null;
+			// Anything else — EACCES, EIO, EBUSY, EISDIR, a concurrent truncation —
+			// is a genuine failure that the `null` return hides. Callers cannot
+			// recover the distinction: to them it is identical to "absent". So the
+			// warning belongs here, where the errno is still in hand, rather than at
+			// a caller reduced to guessing ("fresh repo or backend read failed").
+			// See JOLLI-2066.
+			log.warn("readFile failed for %s: %s", file, errMsg(error));
 			return null;
 		}
 	}

--- a/cli/src/core/GitOps.test.ts
+++ b/cli/src/core/GitOps.test.ts
@@ -196,6 +196,34 @@ describe("GitOps", () => {
 			);
 		});
 
+		/**
+		 * git is gettext-localized: with translations installed and a non-English
+		 * LANG, its stderr comes back translated, which would silently defeat every
+		 * text-based classification we do on it (see GIT_ABSENT_STDERR_FRAGMENTS).
+		 * LC_ALL outranks LANG and LC_MESSAGES, so pinning it alone is sufficient.
+		 */
+		it("pins git's message locale so stderr stays parseable", async () => {
+			mockSuccess("main\n");
+			await execGit(["branch"]);
+			expect(mockExecFileAsync).toHaveBeenCalledWith(
+				"git",
+				["branch"],
+				expect.objectContaining({ env: expect.objectContaining({ LC_ALL: "C" }) }),
+			);
+		});
+
+		it("keeps the ambient environment while pinning the locale", async () => {
+			process.env.JOLLI_LOCALE_PIN_PROBE = "kept";
+			try {
+				mockSuccess("main\n");
+				await execGit(["branch"]);
+				const env = mockExecFileAsync.mock.calls.at(-1)?.[2]?.env as Record<string, string>;
+				expect(env.JOLLI_LOCALE_PIN_PROBE).toBe("kept");
+			} finally {
+				delete process.env.JOLLI_LOCALE_PIN_PROBE;
+			}
+		});
+
 		it("should handle command failure", async () => {
 			mockFailure(128, "fatal: not a git repository");
 			const result = await execGit(["status"]);
@@ -669,9 +697,67 @@ describe("GitOps", () => {
 		});
 
 		it("should return null when file does not exist", async () => {
-			mockFailure(128, "fatal: Path does not exist");
+			mockFailure(128, "fatal: path 'nonexistent.json' does not exist in 'branch'");
 			const content = await readFileFromBranch("branch", "nonexistent.json");
 			expect(content).toBeNull();
+		});
+
+		/**
+		 * Absence vs. failure classification (JOLLI-2066). Both exit 128, so only
+		 * stderr can tell them apart, and the caller sees an identical `null` —
+		 * making the log level the sole observable difference. Every `stderr`
+		 * string below is verbatim real `git show` output.
+		 */
+		describe("absence vs. read failure (JOLLI-2066)", () => {
+			const warnSpy = vi.mocked(console.warn);
+
+			beforeEach(() => {
+				warnSpy.mockClear();
+			});
+
+			it.each([
+				["path missing from an existing tree", "fatal: path 'x.json' does not exist in 'branch'"],
+				[
+					"path missing from disk and index",
+					"fatal: path 'x.json' does not exist (neither on disk nor in the index)",
+				],
+				["branch/ref absent (fresh repo)", "fatal: invalid object name 'branch'."],
+				[
+					"path present on disk but not on the branch",
+					"fatal: path 'x.json' exists on disk, but not in 'branch'",
+				],
+				[
+					"bare unknown revision",
+					"fatal: ambiguous argument 'x': unknown revision or path not in the working tree.",
+				],
+			])("stays quiet for absence: %s", async (_label, stderr) => {
+				mockFailure(128, stderr);
+
+				expect(await readFileFromBranch("branch", "x.json")).toBeNull();
+				expect(warnSpy).not.toHaveBeenCalled();
+			});
+
+			it.each([
+				["broken repo", 128, "fatal: not a git repository (or any of the parent directories): .git"],
+				["dubious ownership", 128, "fatal: detected dubious ownership in repository at '/repo'"],
+				["corrupt object database", 128, "fatal: object file .git/objects/ab/cdef does not exist"],
+				["git missing from PATH", 127, "spawn git ENOENT"],
+			])("warns for a real failure: %s", async (_label, code, stderr) => {
+				mockFailure(code, stderr);
+
+				expect(await readFileFromBranch("branch", "index.json")).toBeNull();
+				expect(warnSpy).toHaveBeenCalledTimes(1);
+				const logged = String(warnSpy.mock.calls[0]?.[0]);
+				expect(logged).toContain("Read failed for branch:index.json");
+				expect(logged).toContain(stderr);
+			});
+
+			it("labels an empty stderr rather than logging a blank reason", async () => {
+				mockFailure(1, "");
+
+				expect(await readFileFromBranch("branch", "index.json")).toBeNull();
+				expect(String(warnSpy.mock.calls[0]?.[0])).toContain("(no stderr)");
+			});
 		});
 	});
 

--- a/cli/src/core/GitOps.ts
+++ b/cli/src/core/GitOps.ts
@@ -32,6 +32,18 @@ const log = createLogger("GitOps");
  * argv array, sidestepping CodeQL's `js/shell-command-constructed-from-input`
  * static-analysis alert (`spawn` with an args array never invokes a shell,
  * but CodeQL tracks taint conservatively).
+ *
+ * `LC_ALL=C` pins git's messages to English. git is gettext-localized, so on a
+ * host with translations installed (`git-l10n` on most Linux distros; Apple git
+ * ships none, which is why this is invisible on macOS) a non-English `LANG`
+ * makes git emit translated stderr. Every consumer that classifies git output by
+ * text — {@link GIT_ABSENT_STDERR_FRAGMENTS} most sharply, since a missed match
+ * there turns a routine absence into a logged failure — would then silently
+ * misread it for exactly the users least able to report why. `LC_ALL` (rather
+ * than `LANG`/`LC_MESSAGES`) because it outranks both, so one variable is
+ * enough. Set here, at the single choke point for our message-parsing git
+ * calls; the `spawnHidden` paths below parse plumbing protocol output
+ * (`cat-file --batch` headers, fast-import), which git does not translate.
  */
 export async function execGit(args: ReadonlyArray<string>, cwd?: string): Promise<GitCommandResult> {
 	log.debug("git %s%s", cwd ? `[cwd=${cwd}] ` : "", args.join(" "));
@@ -39,6 +51,7 @@ export async function execGit(args: ReadonlyArray<string>, cwd?: string): Promis
 	try {
 		const { stdout, stderr } = await execFileAsyncHidden("git", args, {
 			maxBuffer: MAX_GIT_BUFFER_BYTES,
+			env: { ...process.env, LC_ALL: "C" },
 			...(cwd !== undefined && { cwd }),
 		});
 		const result: GitCommandResult = {
@@ -483,14 +496,72 @@ export async function ensureOrphanBranch(branch: string, cwd?: string): Promise<
 }
 
 /**
+ * stderr fragments git emits when the requested object is simply not there —
+ * a normal, expected outcome (fresh repo with no orphan branch yet, a path that
+ * predates a summary, a cross-repo probe).
+ *
+ * Matching is on stderr text rather than exit code because git returns **128**
+ * for both absence and genuine breakage alike (measured: missing path, missing
+ * ref, and "not a git repository" all exit 128). Each entry below is verbatim
+ * from real `git show` output:
+ *
+ *     fatal: path 'x.json' does not exist in '<branch>'
+ *     fatal: path 'x.json' does not exist (neither on disk nor in the index)
+ *     fatal: invalid object name '<branch>'.
+ *     fatal: path 'AGENTS.md' exists on disk, but not in '<branch>'
+ *     fatal: ambiguous argument 'x': unknown revision or path not in the working tree.
+ *
+ * The polarity is deliberate: this is an allowlist of *absence*, so anything
+ * unrecognized — a corrupt object database, `detected dubious ownership`,
+ * `not a git repository`, EACCES on `.git`, git missing from PATH — falls
+ * through to the failure branch and is reported. A denylist of failures would
+ * silently swallow every error phrasing we failed to anticipate.
+ *
+ * Note the fragments stay specific rather than collapsing to a bare
+ * "does not exist": a corrupt object database reports `object file … does not
+ * exist`, which is a real failure that the loose form would swallow.
+ */
+const GIT_ABSENT_STDERR_FRAGMENTS = [
+	"does not exist in",
+	"does not exist (neither on disk nor in the index)",
+	"invalid object name",
+	"exists on disk, but not in",
+	"unknown revision or path not in the working tree",
+] as const;
+
+/** True when git's stderr says the object is absent, as opposed to unreadable. */
+function isAbsentFromBranch(stderr: string): boolean {
+	const lower = stderr.toLowerCase();
+	return GIT_ABSENT_STDERR_FRAGMENTS.some((fragment) => lower.includes(fragment));
+}
+
+/**
  * Reads a file from a branch without checking it out.
- * Returns null if the file doesn't exist.
+ *
+ * Returns null when the file doesn't exist. A null is ALSO returned when the
+ * read fails outright, because callers have no third state to receive — but that
+ * case is logged as a warning here rather than passed up silently, since this is
+ * the last point where git's stderr is available to name the cause. Callers must
+ * therefore treat null as "nothing to read", not "nothing went wrong".
  */
 export async function readFileFromBranch(branch: string, filePath: string, cwd?: string): Promise<string | null> {
 	log.debug("Reading file from branch: %s:%s", branch, filePath);
 	const result = await execGit(["show", `${branch}:${filePath}`], cwd);
 	if (result.exitCode !== 0) {
-		log.debug("File not found: %s:%s", branch, filePath);
+		if (isAbsentFromBranch(result.stderr)) {
+			log.debug("File not found: %s:%s", branch, filePath);
+		} else {
+			// Not an absence — the read itself broke. Callers only ever see the
+			// `null` below and cannot tell the two apart, so this is the only
+			// place the cause can be named. See JOLLI-2066.
+			log.warn(
+				"Read failed for %s:%s (git exit %d): %s",
+				branch,
+				filePath,
+				result.exitCode,
+				result.stderr || "(no stderr)",
+			);
+		}
 		return null;
 	}
 	return result.stdout;

--- a/cli/src/core/LlmClient.test.ts
+++ b/cli/src/core/LlmClient.test.ts
@@ -1517,6 +1517,7 @@ describe("callLlm — local-agent", () => {
 				costUsd: 0.01,
 				stopReason: "end_turn",
 			}),
+			isPresent: () => true,
 		};
 		registerBackend(stub); // replaces the real claude-code backend for this test
 
@@ -1565,6 +1566,7 @@ describe("callLlm — local-agent", () => {
 				costUsd: 0,
 				stopReason: "end_turn",
 			}),
+			isPresent: () => true,
 		};
 		registerBackend(stub);
 
@@ -1589,6 +1591,7 @@ describe("callLlm — local-agent", () => {
 			parseResult: () => {
 				throw boom;
 			},
+			isPresent: () => true,
 		};
 		registerBackend(stub);
 
@@ -1619,6 +1622,7 @@ describe("callLlm — local-agent", () => {
 				costUsd: 0,
 				stopReason: null,
 			}),
+			isPresent: () => true,
 		};
 		registerBackend(stub);
 
@@ -1653,6 +1657,7 @@ describe("callLlm — local-agent", () => {
 					costUsd: 0,
 					stopReason: "end_turn",
 				}),
+				isPresent: () => true,
 			};
 			registerBackend(stub);
 
@@ -1683,6 +1688,7 @@ describe("callLlm — local-agent", () => {
 					costUsd: 0,
 					stopReason: "end_turn",
 				}),
+				isPresent: () => true,
 			};
 			registerBackend(stub);
 
@@ -1708,6 +1714,7 @@ describe("callLlm — local-agent", () => {
 				parseResult: () => {
 					throw new Error("should not be reached");
 				},
+				isPresent: () => true,
 			};
 			registerBackend(stub);
 
@@ -1744,6 +1751,7 @@ describe("callLlm — local-agent", () => {
 					costUsd: 0,
 					stopReason: "end_turn",
 				}),
+				isPresent: () => true,
 			};
 			registerBackend(stub);
 

--- a/cli/src/core/LlmClient.ts
+++ b/cli/src/core/LlmClient.ts
@@ -16,23 +16,13 @@ import type { LlmCredentialSource, LocalAgentToolId } from "../Types.js";
 import { LOCAL_AGENT_TMP_PREFIX } from "./AgentReentry.js";
 import { JOLLI_CLIENT_HEADER } from "./ClientHeader.js";
 import { parseBaseUrl, parseJolliApiKey } from "./JolliApiUtils.js";
-import { getBackend, registerBackend } from "./localagent/BackendRegistry.js";
-import { ClaudeCodeBackend } from "./localagent/ClaudeCodeBackend.js";
-import { CodexBackend } from "./localagent/CodexBackend.js";
-import { CursorAgentBackend } from "./localagent/CursorAgentBackend.js";
+import { getBackend } from "./localagent/BackendRegistry.js";
+import "./localagent/BuiltinBackends.js";
 import { describeCandidate } from "./localagent/ExecutableResolver.js";
 import { runInvocation as defaultRunInvocation } from "./localagent/LocalAgentRunner.js";
-import { OpenCodeBackend } from "./localagent/OpenCodeBackend.js";
 import { fillTemplate, findUnfilledPlaceholders, TEMPLATES } from "./PromptTemplates.js";
 import { resolveModelId } from "./Summarizer.js";
 import { currentTraceHeader, newTraceHeader, TRACE_HEADER_NAME } from "./TraceContext.js";
-
-// Register the v1 backend once at module load. The registry is the extension
-// point for future tools (Codex, Cursor) — add a `registerBackend(...)` here.
-registerBackend(new ClaudeCodeBackend());
-registerBackend(new CursorAgentBackend());
-registerBackend(new CodexBackend());
-registerBackend(new OpenCodeBackend());
 
 // Re-export so existing imports of LlmCredentialSource from this module keep
 // working — the source-of-truth definition lives in Types.ts because

--- a/cli/src/core/OrphanBranchStorage.test.ts
+++ b/cli/src/core/OrphanBranchStorage.test.ts
@@ -33,6 +33,12 @@ describe("OrphanBranchStorage", () => {
 		vi.clearAllMocks();
 	});
 
+	// Minification-safe backend identity — `constructor.name` is mangled in both
+	// shipping bundles, so diagnostics read this instead (JOLLI-2066).
+	it("reports a stable kind that does not depend on the class name", () => {
+		expect(new OrphanBranchStorage("/tmp/repo").kind).toBe("orphan-branch");
+	});
+
 	it("readFile forwards ORPHAN_BRANCH, path and cwd to readFileFromBranch", async () => {
 		mockedReadFile.mockResolvedValueOnce("hello");
 		const storage = new OrphanBranchStorage("/tmp/repo");

--- a/cli/src/core/OrphanBranchStorage.ts
+++ b/cli/src/core/OrphanBranchStorage.ts
@@ -8,9 +8,11 @@ import {
 	readFileFromBranch,
 	writeMultipleFilesToBranch,
 } from "./GitOps.js";
-import type { StorageProvider } from "./StorageProvider.js";
+import type { StorageKind, StorageProvider } from "./StorageProvider.js";
 
 export class OrphanBranchStorage implements StorageProvider {
+	readonly kind: StorageKind = "orphan-branch";
+
 	constructor(private readonly cwd?: string) {}
 
 	async readFile(path: string): Promise<string | null> {

--- a/cli/src/core/SessionTracker.test.ts
+++ b/cli/src/core/SessionTracker.test.ts
@@ -1461,6 +1461,105 @@ describe("SessionTracker", () => {
 			expect(() => JSON.parse(content)).not.toThrow();
 			expect(content).toContain("\t");
 		});
+
+		// The localAgentPath ownership invariant. `localAgentPath` names ONE tool's
+		// binary but is persisted without its owner, and an override
+		// short-circuits discovery — so a path left behind by a previous tool
+		// becomes the new tool's only launch candidate. Readers can't tell the
+		// difference; this write path is where the orphan is removed.
+		describe("localAgentPath ownership", () => {
+			const readSaved = async (dir: string): Promise<{ localAgentTool?: string; localAgentPath?: string }> =>
+				JSON.parse(await readFile(join(dir, "config.json"), "utf-8"));
+
+			it("clears an orphaned localAgentPath when the tool changes", async () => {
+				const targetDir = join(tempDir, "orphan-cleared");
+				await saveConfigScoped({ localAgentTool: "codex", localAgentPath: "/opt/codex" }, targetDir);
+
+				await saveConfigScoped({ aiProvider: "local-agent", localAgentTool: "cursor-agent" }, targetDir);
+
+				const config = await readSaved(targetDir);
+				expect(config.localAgentTool).toBe("cursor-agent");
+				expect(config.localAgentPath).toBeUndefined();
+			});
+
+			it("treats a path with no recorded tool as claude-code's", async () => {
+				// Pre-`localAgentTool` configs: localAgentOverrideFrom attributes a
+				// bare path to claude-code, so switching AWAY from claude-code must
+				// clear it, and re-saving claude-code must not.
+				const targetDir = join(tempDir, "orphan-legacy");
+				await saveConfigScoped({ localAgentPath: "/opt/claude" }, targetDir);
+
+				await saveConfigScoped({ localAgentTool: "claude-code" }, targetDir);
+				expect((await readSaved(targetDir)).localAgentPath).toBe("/opt/claude");
+
+				await saveConfigScoped({ localAgentTool: "opencode" }, targetDir);
+				expect((await readSaved(targetDir)).localAgentPath).toBeUndefined();
+			});
+
+			it("keeps the path when the tool is re-saved unchanged", async () => {
+				// The VS Code Settings panel writes localAgentTool on EVERY Apply, so
+				// a same-tool write must never discard the user's override.
+				const targetDir = join(tempDir, "orphan-unchanged");
+				await saveConfigScoped({ localAgentTool: "cursor-agent", localAgentPath: "/opt/cursor" }, targetDir);
+
+				await saveConfigScoped({ localAgentTool: "cursor-agent", model: "claude-sonnet" }, targetDir);
+
+				expect((await readSaved(targetDir)).localAgentPath).toBe("/opt/cursor");
+			});
+
+			it("keeps a path supplied in the same update as the new tool", async () => {
+				// Configuring a tool AND its binary in one write: the incoming path
+				// belongs to the incoming tool, so it is not an orphan.
+				const targetDir = join(tempDir, "orphan-paired");
+				await saveConfigScoped({ localAgentTool: "codex", localAgentPath: "/opt/codex" }, targetDir);
+
+				await saveConfigScoped({ localAgentTool: "cursor-agent", localAgentPath: "/opt/cursor" }, targetDir);
+
+				const config = await readSaved(targetDir);
+				expect(config.localAgentTool).toBe("cursor-agent");
+				expect(config.localAgentPath).toBe("/opt/cursor");
+			});
+
+			it("clears the path when the tool is explicitly cleared back to the default", async () => {
+				// `{localAgentTool: undefined}` is a WRITE ("reset to the default"),
+				// not an absent field: JSON.stringify drops the key, so the persisted
+				// config has a path and no tool, and localAgentOverrideFrom then reads
+				// it as claude-code's — Codex's binary handed to Claude Code. Presence
+				// must therefore be tested with `in`, exactly as it is for the path.
+				const targetDir = join(tempDir, "orphan-cleared-tool");
+				await saveConfigScoped({ localAgentTool: "codex", localAgentPath: "/opt/codex" }, targetDir);
+
+				await saveConfigScoped({ localAgentTool: undefined }, targetDir);
+
+				const config = await readSaved(targetDir);
+				expect(config.localAgentTool).toBeUndefined();
+				expect(config.localAgentPath).toBeUndefined();
+			});
+
+			it("keeps the path when clearing a tool that was already the default", async () => {
+				// The mirror case, and why `in` alone isn't the whole fix: both sides of
+				// the comparison normalize through `?? "claude-code"`, so clearing an
+				// already-defaulted tool is NOT a tool change and must not drop the
+				// override the user set for claude-code.
+				const targetDir = join(tempDir, "orphan-cleared-default");
+				await saveConfigScoped({ localAgentPath: "/opt/claude" }, targetDir);
+
+				await saveConfigScoped({ localAgentTool: undefined }, targetDir);
+
+				expect((await readSaved(targetDir)).localAgentPath).toBe("/opt/claude");
+			});
+
+			it("leaves unrelated updates alone when no path is configured", async () => {
+				const targetDir = join(tempDir, "orphan-none");
+				await saveConfigScoped({ localAgentTool: "codex" }, targetDir);
+
+				await saveConfigScoped({ localAgentTool: "cursor-agent" }, targetDir);
+
+				const config = await readSaved(targetDir);
+				expect(config.localAgentTool).toBe("cursor-agent");
+				expect(config.localAgentPath).toBeUndefined();
+			});
+		});
 	});
 
 	describe("filterSessionsByEnabledIntegrations", () => {

--- a/cli/src/core/SessionTracker.ts
+++ b/cli/src/core/SessionTracker.ts
@@ -325,8 +325,67 @@ function coalesceLegacyKeys(raw: JolliMemoryConfig): JolliMemoryConfig {
 }
 
 /**
+ * Drops a `localAgentPath` that the incoming `localAgentTool` would orphan.
+ *
+ * `localAgentPath` names ONE tool's binary (see `LocalAgentOverride` in
+ * `core/localagent/DetectAgents.ts`), but the persisted config records only the
+ * path — never its owner. So a path left behind by a previous tool is
+ * INDISTINGUISHABLE at read time from a path deliberately set for the current
+ * one: `{tool: "cursor", path: "…/codex"}` and `{tool: "cursor",
+ * path: "…/my-cursor"}` are the same two fields. That is why the ownership rule
+ * cannot be enforced by the readers (`callLocalAgent`, `jolli doctor`,
+ * `BackfillEngine`) — an override short-circuits discovery entirely
+ * (`resolveExecutable`), so a stale path becomes the ONLY candidate and the new
+ * tool is probed at the old tool's binary.
+ *
+ * It is enforced here instead, at the single write chokepoint every surface
+ * funnels through — CLI commands, the VS Code extension (which bundles this
+ * module), and the IntelliJ plugin (via `ide-bridge config-save`) — so no writer
+ * can forget it and no new writer has to remember.
+ *
+ * Two deliberate exemptions:
+ *   - The tool is UNCHANGED — re-saving the same tool must not discard the user's
+ *     override. The VS Code Settings panel writes `localAgentTool` on every Apply.
+ *     BOTH sides of that comparison go through `?? "claude-code"`, mirroring the
+ *     ownership fallback in `localAgentOverrideFrom`: an update that clears the
+ *     field is asking for the default, so clearing it on a config that was
+ *     already defaulted is not a tool change and must not drop the override.
+ *   - The update supplies `localAgentPath` ITSELF — setting both together is how
+ *     a tool + its explicit binary are configured in one write, so the incoming
+ *     path is the new owner's and stays.
+ *
+ * Both fields are tested for presence with `in`, never `=== undefined`. An
+ * explicit `undefined` IS a write — "clear this back to the default" — and
+ * `JSON.stringify` duly drops the key. Treating it as absent would let
+ * `{localAgentTool: undefined}` sail past this guard on a config holding
+ * `{tool: "codex", path: "…/codex"}`, persisting the path with no tool: read
+ * back, `localAgentOverrideFrom` reports `{tool: "claude-code", path: "…/codex"}`
+ * and Claude Code gets probed at Codex's binary — the exact orphan state this
+ * function exists to make unrepresentable. No writer does that today; the point
+ * of enforcing it here is that no future one has to know.
+ */
+function dropOrphanedLocalAgentPath(
+	existing: JolliMemoryConfig,
+	update: Partial<JolliMemoryConfig>,
+): Partial<JolliMemoryConfig> {
+	if (!("localAgentTool" in update) || "localAgentPath" in update) return update;
+	if ((existing.localAgentTool ?? "claude-code") === (update.localAgentTool ?? "claude-code")) return update;
+	if (existing.localAgentPath === undefined) return update;
+	log.info(
+		"Clearing localAgentPath (was set for %s, switching to %s)",
+		existing.localAgentTool ?? "claude-code",
+		update.localAgentTool,
+	);
+	return { ...update, localAgentPath: undefined };
+}
+
+/**
  * Saves a partial config update to a specific directory.
  * Creates the directory if needed, merges with existing config, writes atomically.
+ *
+ * Switching `localAgentTool` also clears a now-orphaned `localAgentPath` — see
+ * {@link dropOrphanedLocalAgentPath} for why that invariant lives here and not
+ * in the code that reads those two fields.
  *
  * @param update - Partial config fields to save
  * @param targetDir - Directory to write config.json into
@@ -336,7 +395,7 @@ export async function saveConfigScoped(update: Partial<JolliMemoryConfig>, targe
 	const existing = await loadConfigFromDir(targetDir);
 	// Fields set to undefined are omitted by JSON.stringify, effectively
 	// removing them from the persisted config file.
-	const merged = { ...existing, ...update };
+	const merged = { ...existing, ...dropOrphanedLocalAgentPath(existing, update) };
 	await atomicWrite(join(targetDir, CONFIG_FILE), JSON.stringify(merged, null, "\t"));
 	log.info("Config saved to %s", targetDir);
 }

--- a/cli/src/core/StorageProvider.ts
+++ b/cli/src/core/StorageProvider.ts
@@ -1,8 +1,36 @@
 import type { FileWrite, SummaryIndexEntry } from "../Types.js";
 import type { TopicPage } from "./TopicKBTypes.js";
 
+/**
+ * Stable, minification-safe identity of a storage backend.
+ *
+ * Exists because `constructor.name` is NOT usable for this: both shipping
+ * bundles minify without `keepNames`, so the class name reaches production as
+ * a mangled identifier that also differs per bundle (`Xe` from the CLI, `t`
+ * from the VS Code extension). Any diagnostic that needs to name the backend
+ * must read {@link StorageProvider.kind} instead.
+ */
+export type StorageKind = "orphan-branch" | "folder" | "dual-write";
+
 export interface StorageProvider {
-	/** Read a file's content. Returns null if not found. */
+	/**
+	 * Stable backend identity for diagnostics. See {@link StorageKind} for why
+	 * this exists rather than reading `constructor.name`.
+	 *
+	 * Optional so the many `as unknown as StorageProvider` test doubles keep
+	 * type-checking; consumers must therefore tolerate `undefined` (log it as
+	 * "unknown" rather than assuming a backend).
+	 */
+	readonly kind?: StorageKind;
+
+	/**
+	 * Read a file's content. Returns null if not found.
+	 *
+	 * A `null` return means **absent**, not "failed". Implementations that can
+	 * fail while the file is present (fs errno, git plumbing) MUST log the
+	 * failure themselves, at the point where the cause is still in hand —
+	 * callers receive an indistinguishable `null` and cannot report it.
+	 */
 	readFile(path: string): Promise<string | null>;
 
 	/**

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -2275,6 +2275,23 @@ describe("SummaryStore", () => {
 			expect(map.size).toBe(0);
 		});
 
+		/**
+		 * An absent index is routine — a fresh repo before its first summary, or a
+		 * cross-repo scan over a sibling Memory Bank that has none. It used to warn,
+		 * which put a WARN in front of first-run users mid-setup and produced
+		 * hundreds of lines per VS Code sidebar refresh. Real read failures are
+		 * warned by the backend instead, where the cause is known (JOLLI-2066).
+		 */
+		it("does not warn when the index is merely absent", async () => {
+			const warnSpy = vi.mocked(console.warn);
+			warnSpy.mockClear();
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null);
+
+			await getIndexEntryMap();
+
+			expect(warnSpy).not.toHaveBeenCalled();
+		});
+
 		it("should preserve topicCount and diffStats on entries", async () => {
 			const entry: SummaryIndexEntry = {
 				...rootEntry("hash1", "A"),

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -2082,20 +2082,21 @@ async function loadIndex(cwd?: string, storage?: StorageProvider): Promise<Summa
 	const store = resolveStorage(storage, cwd);
 	const content = await store.readFile(INDEX_FILE);
 	if (!content) {
-		// Surface as warn: in a healthy installation the index always exists
-		// once any summary has been generated. A null read here means either
-		// (a) fresh repo / no summaries yet, or (b) the backend's read failed
-		// (git plumbing for OrphanBranchStorage; fs/EACCES for FolderStorage)
-		// — `store.readFile` swallows the underlying error and returns null,
-		// so production needs the warn to notice (b). Callers (`getSummary`,
-		// `listSummaries`, …) treat this as "nothing to return" rather than
-		// throwing, so the warn is the only signal. Tagging the storage class
-		// keeps cross-repo foreign reads (FolderStorage on a sibling Memory
-		// Bank) from being misread as workspace orphan-branch failures.
-		log.warn(
-			"loadIndex: index.json unreadable from %s (fresh repo or backend read failed)",
-			store.constructor.name,
-		);
+		// DEBUG, not WARN. A null here now carries exactly one meaning — the
+		// index is absent — and absence is routine: a fresh repo before its
+		// first summary, or a cross-repo scan touching a sibling Memory Bank
+		// that has none. Warning on it produced hundreds of lines per sidebar
+		// refresh and greeted first-run users with a WARN mid-setup, while the
+		// failure it was meant to catch stayed invisible inside the noise.
+		//
+		// Genuine read failures are warned by the backend itself, where the
+		// errno / git stderr is still available to name the cause
+		// (`FolderStorage.readFile`, `readFileFromBranch`) — see JOLLI-2066.
+		//
+		// `store.kind`, never `store.constructor.name`: both shipping bundles
+		// minify without `keepNames`, so the class name reaches production
+		// mangled and bundle-specific (`Xe` / `t`).
+		log.debug("loadIndex: no index.json in %s storage", store.kind ?? "unknown");
 		return null;
 	}
 

--- a/cli/src/core/localagent/BackendRegistry.test.ts
+++ b/cli/src/core/localagent/BackendRegistry.test.ts
@@ -7,6 +7,7 @@ const fake: LocalAgentBackend = {
 	discoverExecutable: async () => ({ file: "/x/claude", version: "9.9.9" }),
 	buildInvocation: () => ({ file: "/x/claude", args: [], stdin: "", env: {}, cwd: "/tmp" }),
 	parseResult: () => ({ text: "", inputTokens: 0, outputTokens: 0, cachedTokens: 0, costUsd: 0, stopReason: null }),
+	isPresent: () => true,
 };
 
 describe("BackendRegistry", () => {

--- a/cli/src/core/localagent/BuiltinBackends.test.ts
+++ b/cli/src/core/localagent/BuiltinBackends.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+// Importing this module MUST be sufficient to populate the registry — no
+// LlmClient import anywhere in this file. That is the whole point of the test.
+import "./BuiltinBackends.js";
+import { getBackend } from "./BackendRegistry.js";
+
+describe("BuiltinBackends", () => {
+	it.each(["claude-code", "codex", "cursor-agent", "opencode"])("registers %s without importing LlmClient", (id) => {
+		expect(getBackend(id).id).toBe(id);
+	});
+});

--- a/cli/src/core/localagent/BuiltinBackends.ts
+++ b/cli/src/core/localagent/BuiltinBackends.ts
@@ -1,0 +1,24 @@
+/**
+ * Registers the four shipped local-agent backends.
+ *
+ * Importing this module for its side effect is the ONLY supported way to
+ * populate the registry. It exists because registration used to live at module
+ * scope in LlmClient, which made a populated registry an invisible consequence
+ * of importing an unrelated module: any other consumer calling `getBackend()`
+ * first saw an empty registry and threw "Unknown local agent tool". Both
+ * LlmClient and DetectAgents import this instead.
+ *
+ * Registration order is irrelevant here — `registerBackend` keys by id, and the
+ * ordering authority for anything user-facing is LOCAL_AGENT_TOOLS, not this
+ * file.
+ */
+import { registerBackend } from "./BackendRegistry.js";
+import { ClaudeCodeBackend } from "./ClaudeCodeBackend.js";
+import { CodexBackend } from "./CodexBackend.js";
+import { CursorAgentBackend } from "./CursorAgentBackend.js";
+import { OpenCodeBackend } from "./OpenCodeBackend.js";
+
+registerBackend(new ClaudeCodeBackend());
+registerBackend(new CursorAgentBackend());
+registerBackend(new CodexBackend());
+registerBackend(new OpenCodeBackend());

--- a/cli/src/core/localagent/ClaudeCodeBackend.test.ts
+++ b/cli/src/core/localagent/ClaudeCodeBackend.test.ts
@@ -1,7 +1,8 @@
 import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ClaudeCodeBackend } from "./ClaudeCodeBackend.js";
+import * as resolver from "./ExecutableResolver.js";
 import { LocalAgentAuthError, LocalAgentSetupError, LocalAgentTransientError } from "./Types.js";
 
 const successFixture = readFileSync(
@@ -205,5 +206,17 @@ describe("ClaudeCodeBackend.buildInvocation with launcher args", () => {
 			{ prompt: "p", model: "m", systemPrompt: "s" },
 		);
 		expect(inv.args.slice(0, 2)).toEqual(["cli.js", "-p"]);
+	});
+});
+
+describe("ClaudeCodeBackend.isPresent", () => {
+	it("is false for an override path that does not exist", () => {
+		expect(new ClaudeCodeBackend().isPresent("/nonexistent/path/to/claude")).toBe(false);
+	});
+
+	it("delegates to the CLAUDE_SPEC discovery, not another tool's", () => {
+		const spy = vi.spyOn(resolver, "isPresent").mockReturnValue(true);
+		expect(new ClaudeCodeBackend().isPresent()).toBe(true);
+		expect(spy).toHaveBeenCalledWith(expect.objectContaining({ binName: "claude" }), { overridePath: undefined });
 	});
 });

--- a/cli/src/core/localagent/ClaudeCodeBackend.ts
+++ b/cli/src/core/localagent/ClaudeCodeBackend.ts
@@ -1,5 +1,5 @@
 import { createLocalAgentCwd, LOCAL_AGENT_CHILD_ENV } from "../AgentReentry.js";
-import { resolveClaudeExecutable } from "./ClaudeExecutableResolver.js";
+import { isClaudeCodePresent, resolveClaudeExecutable } from "./ClaudeExecutableResolver.js";
 import {
 	type Invocation,
 	LocalAgentAuthError,
@@ -48,6 +48,10 @@ export class ClaudeCodeBackend implements LocalAgentBackend {
 
 	discoverExecutable(overridePath?: string): Promise<ResolvedExecutable> {
 		return Promise.resolve(resolveClaudeExecutable({ overridePath }));
+	}
+
+	isPresent(overridePath?: string): boolean {
+		return isClaudeCodePresent({ overridePath });
 	}
 
 	buildInvocation(exe: ResolvedExecutable, req: LocalAgentRequest): Invocation {

--- a/cli/src/core/localagent/ClaudeExecutableResolver.test.ts
+++ b/cli/src/core/localagent/ClaudeExecutableResolver.test.ts
@@ -3,11 +3,8 @@ import { homedir } from "node:os";
 import { posix as pathPosix, win32 as pathWin32 } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { execFileSyncHidden } from "../../util/Subprocess.js";
-import {
-	__resetResolverCacheForTest,
-	isClaudeCodeUsable,
-	resolveClaudeExecutable,
-} from "./ClaudeExecutableResolver.js";
+import { __resetResolverCacheForTest, resolveClaudeExecutable } from "./ClaudeExecutableResolver.js";
+import { isLocalAgentUsable } from "./DetectAgents.js";
 import { LocalAgentSetupError } from "./Types.js";
 
 vi.mock("../../util/Subprocess.js", () => ({ execFileSyncHidden: vi.fn() }));
@@ -322,20 +319,44 @@ describe("resolveClaudeExecutable", () => {
 	});
 });
 
-describe("isClaudeCodeUsable", () => {
-	it("true when a candidate resolves", () => {
+// Migrated from the former `isClaudeCodeUsable` (deleted alongside the
+// Claude-only fast path in EnableCommand.ts): same two behaviors, now exercised
+// through the registry-backed `isLocalAgentUsable("claude-code", …)` seam.
+// `isLocalAgentUsable` has no candidates/probe/now injection points of its own
+// — it goes through the real `discover()` + default probe — so these mock
+// `execFileSyncHidden` / `existsSync` (both already module-mocked above) the
+// same way the "default candidates/probe" suite does, rather than injecting
+// fakes directly.
+describe("isLocalAgentUsable (claude-code)", () => {
+	const mockedExecFileSync = vi.mocked(execFileSyncHidden);
+	const mockedExistsSync = vi.mocked(existsSync);
+
+	beforeEach(() => {
 		__resetResolverCacheForTest();
-		expect(
-			isClaudeCodeUsable({
-				candidates: () => [{ file: "/a/claude" }],
-				probe: () => ({ ok: true, version: "1.0.0" }),
-				now: () => 1000,
-			}),
-		).toBe(true);
+		mockedExecFileSync.mockReset();
+		mockedExistsSync.mockReset();
+		mockedExistsSync.mockReturnValue(false);
 	});
 
-	it("false when nothing resolves (resolveClaudeExecutable throws)", () => {
-		__resetResolverCacheForTest();
-		expect(isClaudeCodeUsable({ candidates: () => [], probe: () => ({ ok: false }), now: () => 1000 })).toBe(false);
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("true when a candidate resolves", async () => {
+		mockedExecFileSync.mockImplementation((file: unknown) => {
+			if (file === "which" || file === "where") return "/usr/local/bin/claude\n";
+			return "1.0.0\n";
+		});
+
+		await expect(isLocalAgentUsable("claude-code")).resolves.toBe(true);
+	});
+
+	it("false when nothing resolves (resolveClaudeExecutable throws)", async () => {
+		mockedExecFileSync.mockImplementation((file: unknown) => {
+			if (file === "which" || file === "where") throw new Error("not found");
+			return "1.0.0\n";
+		});
+
+		await expect(isLocalAgentUsable("claude-code")).resolves.toBe(false);
 	});
 });

--- a/cli/src/core/localagent/ClaudeExecutableResolver.ts
+++ b/cli/src/core/localagent/ClaudeExecutableResolver.ts
@@ -1,6 +1,8 @@
 import { posix as pathPosix, win32 as pathWin32 } from "node:path";
 import {
 	type Candidate,
+	isPresent,
+	type PresenceOpts,
 	type ProbeFn,
 	__resetResolverCacheForTest as reset,
 	resolveExecutable,
@@ -37,23 +39,10 @@ export function resolveClaudeExecutable(opts: ResolveOpts = {}): ResolvedExecuta
 }
 
 /**
- * Non-throwing liveness check for the local Claude Code CLI: true when a
- * compatible `claude` is resolvable (present on PATH / known locations AND it
- * accepts the flags we pass), false otherwise. Thin wrapper over
- * {@link resolveClaudeExecutable} so interactive callers (the guided front door,
- * `promptSetup`) can branch on availability without a try/catch.
- *
- * Exported as its own function on purpose: it is the seam tests mock so they
- * never shell out to a real `claude`. Cost is one `resolveClaudeExecutable`
- * call — a successful resolution is cached for {@link RESOLUTION_CACHE_TTL_MS},
- * but a failure is never cached, so a just-installed / just-fixed binary is
- * picked up on the next call.
+ * Presence-only counterpart of {@link resolveClaudeExecutable}: true when a
+ * `claude` binary is discoverable, WITHOUT probing that it runs. Kept beside the
+ * resolver so the Claude spec stays in one file.
  */
-export function isClaudeCodeUsable(opts: ResolveOpts = {}): boolean {
-	try {
-		resolveClaudeExecutable(opts);
-		return true;
-	} catch {
-		return false;
-	}
+export function isClaudeCodePresent(opts: PresenceOpts = {}): boolean {
+	return isPresent(CLAUDE_SPEC, opts);
 }

--- a/cli/src/core/localagent/CodexBackend.test.ts
+++ b/cli/src/core/localagent/CodexBackend.test.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { CodexBackend } from "./CodexBackend.js";
+import * as resolver from "./ExecutableResolver.js";
 import { LocalAgentAuthError, LocalAgentSetupError } from "./Types.js";
 
 const fixture = readFileSync(join(__dirname, "__fixtures__/codex/success.json"), "utf8");
@@ -94,5 +95,17 @@ describe("CodexBackend.buildInvocation with launcher args", () => {
 			{ prompt: "hi", model: "", systemPrompt: "" },
 		);
 		expect(inv.args.slice(0, 2)).toEqual(["cli.js", "exec"]);
+	});
+});
+
+describe("CodexBackend.isPresent", () => {
+	it("is false for an override path that does not exist", () => {
+		expect(new CodexBackend().isPresent("/nonexistent/path/to/codex")).toBe(false);
+	});
+
+	it("delegates to the CODEX_SPEC discovery, not another tool's", () => {
+		const spy = vi.spyOn(resolver, "isPresent").mockReturnValue(true);
+		expect(new CodexBackend().isPresent()).toBe(true);
+		expect(spy).toHaveBeenCalledWith(expect.objectContaining({ binName: "codex" }), { overridePath: undefined });
 	});
 });

--- a/cli/src/core/localagent/CodexBackend.ts
+++ b/cli/src/core/localagent/CodexBackend.ts
@@ -1,6 +1,6 @@
 import { posix as pathPosix, win32 as pathWin32 } from "node:path";
 import { createLocalAgentCwd, LOCAL_AGENT_CHILD_ENV } from "../AgentReentry.js";
-import { resolveExecutable } from "./ExecutableResolver.js";
+import { isPresent, resolveExecutable } from "./ExecutableResolver.js";
 import {
 	type Invocation,
 	LocalAgentAuthError,
@@ -44,6 +44,10 @@ export class CodexBackend implements LocalAgentBackend {
 
 	discoverExecutable(overridePath?: string): Promise<ResolvedExecutable> {
 		return Promise.resolve(resolveExecutable(CODEX_SPEC, { overridePath }));
+	}
+
+	isPresent(overridePath?: string): boolean {
+		return isPresent(CODEX_SPEC, { overridePath });
 	}
 
 	buildInvocation(exe: ResolvedExecutable, req: LocalAgentRequest): Invocation {

--- a/cli/src/core/localagent/CursorAgentBackend.test.ts
+++ b/cli/src/core/localagent/CursorAgentBackend.test.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { CursorAgentBackend, cursorKnownPaths, expandCursorShim } from "./CursorAgentBackend.js";
+import * as resolver from "./ExecutableResolver.js";
 import { LocalAgentAuthError, LocalAgentSetupError } from "./Types.js";
 
 const fixture = readFileSync(join(__dirname, "__fixtures__/cursor-agent/success.json"), "utf8");
@@ -148,5 +149,19 @@ describe("CursorAgentBackend.buildInvocation with a resolved Windows launcher", 
 		);
 		expect(inv.file).toBe(node);
 		expect(inv.args).toEqual(["--use-system-ca", entry, "-p", "--output-format", "json", "--trust", "hi"]);
+	});
+});
+
+describe("CursorAgentBackend.isPresent", () => {
+	it("is false for an override path that does not exist", () => {
+		expect(new CursorAgentBackend().isPresent("/nonexistent/path/to/cursor-agent")).toBe(false);
+	});
+
+	it("delegates to the CURSOR_SPEC discovery, not another tool's", () => {
+		const spy = vi.spyOn(resolver, "isPresent").mockReturnValue(true);
+		expect(new CursorAgentBackend().isPresent()).toBe(true);
+		expect(spy).toHaveBeenCalledWith(expect.objectContaining({ binName: "cursor-agent" }), {
+			overridePath: undefined,
+		});
 	});
 });

--- a/cli/src/core/localagent/CursorAgentBackend.ts
+++ b/cli/src/core/localagent/CursorAgentBackend.ts
@@ -1,6 +1,6 @@
 import { posix as pathPosix, win32 as pathWin32 } from "node:path";
 import { createLocalAgentCwd, LOCAL_AGENT_CHILD_ENV } from "../AgentReentry.js";
-import { type Candidate, resolveExecutable, type ShimDeps } from "./ExecutableResolver.js";
+import { type Candidate, isPresent, resolveExecutable, type ShimDeps } from "./ExecutableResolver.js";
 import {
 	type Invocation,
 	LocalAgentAuthError,
@@ -102,6 +102,10 @@ export class CursorAgentBackend implements LocalAgentBackend {
 
 	discoverExecutable(overridePath?: string): Promise<ResolvedExecutable> {
 		return Promise.resolve(resolveExecutable(CURSOR_SPEC, { overridePath }));
+	}
+
+	isPresent(overridePath?: string): boolean {
+		return isPresent(CURSOR_SPEC, { overridePath });
 	}
 
 	buildInvocation(exe: ResolvedExecutable, req: LocalAgentRequest): Invocation {

--- a/cli/src/core/localagent/DetectAgents.test.ts
+++ b/cli/src/core/localagent/DetectAgents.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { JolliMemoryConfig } from "../../Types.js";
+import * as registry from "./BackendRegistry.js";
+import { isLocalAgentUsable, listPresentLocalAgents, localAgentOverrideFrom } from "./DetectAgents.js";
+import { LocalAgentSetupError } from "./Types.js";
+
+/** Records every `overridePath` each backend method was handed. */
+let seenPresence: Record<string, string | undefined>;
+let seenDiscover: Record<string, string | undefined>;
+
+/** Builds a fake backend whose presence and probe results are scripted. */
+function fake(id: string, present: boolean, usable = true) {
+	return {
+		id,
+		isPresent: (overridePath?: string) => {
+			seenPresence[id] = overridePath;
+			return present;
+		},
+		discoverExecutable: (overridePath?: string) => {
+			seenDiscover[id] = overridePath;
+			return usable
+				? Promise.resolve({ file: `/bin/${id}`, version: "1.0.0" })
+				: Promise.reject(new LocalAgentSetupError(`No compatible ${id}`));
+		},
+		buildInvocation: () => {
+			throw new Error("not used");
+		},
+		parseResult: () => {
+			throw new Error("not used");
+		},
+	};
+}
+
+function stub(map: Record<string, boolean>) {
+	vi.spyOn(registry, "getBackend").mockImplementation((id: string) => fake(id, map[id] ?? false) as never);
+}
+
+beforeEach(() => {
+	seenPresence = {};
+	seenDiscover = {};
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("listPresentLocalAgents", () => {
+	it("returns all four in LOCAL_AGENT_TOOLS order when all are present", () => {
+		stub({ "claude-code": true, codex: true, "cursor-agent": true, opencode: true });
+		expect(listPresentLocalAgents().map((a) => a.id)).toEqual(["claude-code", "codex", "cursor-agent", "opencode"]);
+	});
+
+	it("uses LOCAL_AGENT_TOOLS order, NOT BackendRegistry order", () => {
+		// BuiltinBackends registers Claude, Cursor, Codex, OpenCode. If this ever
+		// starts reading the registry, Cursor would precede Codex and this fails.
+		stub({ "claude-code": true, codex: true, "cursor-agent": true, opencode: true });
+		const ids = listPresentLocalAgents().map((a) => a.id);
+		expect(ids.indexOf("codex")).toBeLessThan(ids.indexOf("cursor-agent"));
+	});
+
+	it("returns only the present tools", () => {
+		stub({ "claude-code": false, codex: true, "cursor-agent": false, opencode: true });
+		expect(listPresentLocalAgents().map((a) => a.id)).toEqual(["codex", "opencode"]);
+	});
+
+	it("returns an empty array when nothing is present", () => {
+		stub({});
+		expect(listPresentLocalAgents()).toEqual([]);
+	});
+
+	it("carries the display label from LOCAL_AGENT_TOOLS", () => {
+		stub({ "claude-code": true });
+		expect(listPresentLocalAgents()[0]).toEqual({ id: "claude-code", label: "Claude Code" });
+	});
+
+	it("treats a throwing backend as absent rather than failing the sweep", () => {
+		vi.spyOn(registry, "getBackend").mockImplementation((id: string) => {
+			if (id === "codex") throw new Error("registry exploded");
+			return fake(id, true) as never;
+		});
+		expect(listPresentLocalAgents().map((a) => a.id)).toEqual(["claude-code", "cursor-agent", "opencode"]);
+	});
+
+	/**
+	 * An override is a path for ONE tool. Handing it to the whole sweep as a bare
+	 * string used to short-circuit each backend's enumeration to that verbatim
+	 * path, so a Codex path reported Claude Code, Cursor and OpenCode installed
+	 * too — and each was then probed at Codex's binary.
+	 */
+	it("hands the override path ONLY to the tool it names", () => {
+		stub({ "claude-code": true, codex: true, "cursor-agent": true, opencode: true });
+
+		listPresentLocalAgents({ tool: "codex", path: "/custom/bin/codex" });
+
+		expect(seenPresence).toEqual({
+			"claude-code": undefined,
+			codex: "/custom/bin/codex",
+			"cursor-agent": undefined,
+			opencode: undefined,
+		});
+	});
+
+	it("passes no override to any tool when none is configured", () => {
+		stub({ "claude-code": true, codex: true });
+		listPresentLocalAgents();
+		expect(Object.values(seenPresence).every((v) => v === undefined)).toBe(true);
+	});
+});
+
+describe("localAgentOverrideFrom", () => {
+	const cfg = (c: Partial<JolliMemoryConfig>) => c as JolliMemoryConfig;
+
+	it("is undefined when no explicit path is configured", () => {
+		expect(localAgentOverrideFrom(cfg({ localAgentTool: "codex" }))).toBeUndefined();
+	});
+
+	it("binds the path to the configured tool", () => {
+		expect(localAgentOverrideFrom(cfg({ localAgentTool: "codex", localAgentPath: "/p" }))).toEqual({
+			tool: "codex",
+			path: "/p",
+		});
+	});
+
+	it("defaults an absent localAgentTool to claude-code, matching every other reader", () => {
+		expect(localAgentOverrideFrom(cfg({ localAgentPath: "/p" }))).toEqual({
+			tool: "claude-code",
+			path: "/p",
+		});
+	});
+});
+
+describe("isLocalAgentUsable", () => {
+	it("is true when the tool resolves", async () => {
+		vi.spyOn(registry, "getBackend").mockImplementation((id: string) => fake(id, true, true) as never);
+		await expect(isLocalAgentUsable("codex")).resolves.toBe(true);
+	});
+
+	it("is false when the tool fails to resolve", async () => {
+		vi.spyOn(registry, "getBackend").mockImplementation((id: string) => fake(id, true, false) as never);
+		await expect(isLocalAgentUsable("codex")).resolves.toBe(false);
+	});
+
+	it("is false for an unknown tool id rather than throwing", async () => {
+		vi.spyOn(registry, "getBackend").mockImplementation(() => {
+			throw new LocalAgentSetupError("Unknown local agent tool");
+		});
+		await expect(isLocalAgentUsable("codex")).resolves.toBe(false);
+	});
+
+	it("applies an override that names the probed tool", async () => {
+		vi.spyOn(registry, "getBackend").mockImplementation((id: string) => fake(id, true, true) as never);
+		await isLocalAgentUsable("codex", { override: { tool: "codex", path: "/custom/codex" } });
+		expect(seenDiscover.codex).toBe("/custom/codex");
+	});
+
+	it("drops an override that names a DIFFERENT tool, falling back to auto-discovery", async () => {
+		// Probing Cursor with the path the user configured for Codex would answer a
+		// question nobody asked — and, since an override short-circuits discovery,
+		// answer it wrongly in both directions.
+		vi.spyOn(registry, "getBackend").mockImplementation((id: string) => fake(id, true, true) as never);
+		await isLocalAgentUsable("cursor-agent", { override: { tool: "codex", path: "/custom/codex" } });
+		expect(seenDiscover["cursor-agent"]).toBeUndefined();
+	});
+});

--- a/cli/src/core/localagent/DetectAgents.ts
+++ b/cli/src/core/localagent/DetectAgents.ts
@@ -1,0 +1,115 @@
+/**
+ * Local-agent detection for onboarding surfaces.
+ *
+ * Two questions, deliberately separated by cost:
+ *
+ * - {@link listPresentLocalAgents} — "which tools are on disk?" Pure filesystem
+ *   work, no subprocess at all (see `discoverPresence`), measured at ~4 ms for
+ *   all four. Cheap enough to run on the VS Code activation path before first
+ *   paint.
+ * - {@link isLocalAgentUsable} — "does THIS tool actually run?" Spawns the
+ *   capability probe; measured 161-1772 ms for a single tool. Called only once
+ *   the user has committed to a specific tool.
+ *
+ * A full four-tool usability sweep costs 3384 ms on a machine with everything
+ * installed, which is why onboarding never does one.
+ */
+import type { JolliMemoryConfig, LocalAgentToolId } from "../../Types.js";
+import { getBackend } from "./BackendRegistry.js";
+// Side-effect import: populates the registry that getBackend reads.
+import "./BuiltinBackends.js";
+import { LOCAL_AGENT_TOOLS } from "./ToolMeta.js";
+
+/** One locally-installed agent tool, as offered to the user. */
+export interface DetectedAgent {
+	readonly id: LocalAgentToolId;
+	readonly label: string;
+}
+
+/**
+ * An explicit executable path, bound to the ONE tool it describes.
+ *
+ * `config.localAgentPath` overrides discovery for the *configured* tool only, so
+ * it can never be handed to a multi-tool sweep as a bare string: on POSIX an
+ * override short-circuits enumeration to the verbatim path, which would report
+ * every tool present at that one file — a Codex path making Claude Code, Cursor
+ * and OpenCode all "installed", and then each of them probed with Codex's
+ * binary. Pairing the path with its `tool` makes that mistake unrepresentable.
+ */
+export interface LocalAgentOverride {
+	readonly tool: LocalAgentToolId;
+	readonly path: string;
+}
+
+/**
+ * The tool-scoped override a config implies, or `undefined` when there is no
+ * explicit path to apply. An unset `localAgentTool` falls back to
+ * `"claude-code"`, matching every other reader of that field (GenerationFix,
+ * StatusTreeProvider, SummaryUtils) and covering configs written before it
+ * existed.
+ *
+ * The pairing is a re-derivation, not a stored fact: config.json holds the path
+ * WITHOUT its owner, so this function can only assume the path belongs to the
+ * currently-configured tool. What makes that assumption true is
+ * `saveConfigScoped`, which clears an orphaned `localAgentPath` whenever
+ * `localAgentTool` changes — see `dropOrphanedLocalAgentPath` in
+ * `core/SessionTracker.ts`. Readers cannot detect the drift themselves.
+ */
+export function localAgentOverrideFrom(config: JolliMemoryConfig): LocalAgentOverride | undefined {
+	if (!config.localAgentPath) return undefined;
+	return { tool: config.localAgentTool ?? "claude-code", path: config.localAgentPath };
+}
+
+/** All tool ids in display order. LOCAL_AGENT_TOOLS is the ordering authority
+ * for every user-facing list (the Settings dropdown already derives from it);
+ * BackendRegistry registers in a different order and must not be used here. */
+const TOOL_IDS = Object.keys(LOCAL_AGENT_TOOLS) as LocalAgentToolId[];
+
+/**
+ * Tools present on this machine, in display order. Never throws: a backend that
+ * blows up is reported absent, because a detection failure must degrade to
+ * "offer fewer options", never to a broken onboarding panel.
+ *
+ * `override` applies to its own `tool` and to no other — see
+ * {@link LocalAgentOverride}.
+ */
+export function listPresentLocalAgents(override?: LocalAgentOverride): DetectedAgent[] {
+	const found: DetectedAgent[] = [];
+	for (const id of TOOL_IDS) {
+		try {
+			if (getBackend(id).isPresent(override?.tool === id ? override.path : undefined)) {
+				found.push({ id, label: LOCAL_AGENT_TOOLS[id].label });
+			}
+		} catch {
+			// Absent. See the docstring — never fail the sweep for one tool.
+		}
+	}
+	return found;
+}
+
+/**
+ * True when `tool` resolves to a runnable binary that accepts the flags we pass.
+ * The registry-backed generalization of the former `isClaudeCodeUsable`, and the
+ * seam tests mock so they never shell out to a real agent CLI.
+ *
+ * Still says nothing about whether the user is SIGNED IN to that tool — there is
+ * no uniform auth probe. That failure surfaces at generation time and is what
+ * `localAgentToolLoginHint` exists for.
+ *
+ * Takes a tool-scoped {@link LocalAgentOverride} rather than a bare path, and
+ * applies it only when it names `tool`: probing Cursor with the path the user
+ * configured for Codex would answer a question nobody asked (and, since an
+ * override short-circuits discovery, would answer it wrongly in both
+ * directions).
+ */
+export async function isLocalAgentUsable(
+	tool: LocalAgentToolId,
+	opts: { override?: LocalAgentOverride } = {},
+): Promise<boolean> {
+	try {
+		await getBackend(tool).discoverExecutable(opts.override?.tool === tool ? opts.override.path : undefined);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/cli/src/core/localagent/ExecutableResolver.test.ts
+++ b/cli/src/core/localagent/ExecutableResolver.test.ts
@@ -1,14 +1,24 @@
-import { describe, expect, it } from "vitest";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as subprocess from "../../util/Subprocess.js";
 import {
 	__resetResolverCacheForTest,
 	type Candidate,
 	discover,
+	discoverPresence,
 	discoveryPath,
+	isPresent,
 	resolveExecutable,
 } from "./ExecutableResolver.js";
 import { LocalAgentSetupError } from "./Types.js";
 
 const spec = { binName: "codex", knownPaths: () => [], probeArgs: ["--version"] as const };
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 /** A fake `which`/`where` that only "finds" `binName` when `binDir` is on the search PATH. */
 function fakeFinder(binName: string, binDir: string, sep = ":") {
@@ -327,5 +337,254 @@ describe("default directory listing", () => {
 				basePath: "C:\\npm",
 			}),
 		).toEqual([]);
+	});
+});
+
+describe("isPresent", () => {
+	const SPEC = {
+		binName: "faketool",
+		knownPaths: () => [],
+		probeArgs: ["--version"] as const,
+	};
+
+	it("returns true when candidates are discovered", () => {
+		expect(isPresent(SPEC, { platform: "darwin", candidates: () => [{ file: "/usr/local/bin/faketool" }] })).toBe(
+			true,
+		);
+	});
+
+	it("spawns no subprocess — the whole point of the presence/usability split", () => {
+		// isPresent never probes — it only checks candidate enumeration. We use a
+		// candidates seam with a fake path that would error if spawned, to enforce
+		// the guarantee without relying on spy interception.
+		expect(
+			isPresent(SPEC, {
+				platform: "darwin",
+				candidates: () => [{ file: "/nonexistent/path/would/throw/if/probed" }],
+			}),
+		).toBe(true);
+	});
+
+	it("returns false when nothing is discovered", () => {
+		expect(isPresent(SPEC, { platform: "darwin", candidates: () => [] })).toBe(false);
+	});
+
+	it("honors an override path that exists on disk", () => {
+		expect(
+			isPresent(SPEC, {
+				platform: "darwin",
+				overridePath: "/opt/custom/faketool",
+				exists: (p) => p === "/opt/custom/faketool",
+			}),
+		).toBe(true);
+	});
+
+	it("rejects an override path that does not exist", () => {
+		expect(
+			isPresent(SPEC, {
+				platform: "darwin",
+				overridePath: "/opt/missing/faketool",
+				exists: () => false,
+			}),
+		).toBe(false);
+	});
+
+	it("does not consult the resolution cache — neither reads nor writes it", () => {
+		__resetResolverCacheForTest();
+		const now = () => 100;
+
+		// Prime the cache with a real resolveExecutable call.
+		resolveExecutable(SPEC, {
+			candidates: () => [{ file: "/cached/binary" }],
+			probe: () => ({ ok: true, version: "1.0.0" }),
+			now,
+			platform: "darwin",
+		});
+
+		// Now call isPresent for the same binName with empty candidates.
+		// If isPresent read the cache, it would see the cached resolution and return true.
+		// Instead it should see no candidates and return false.
+		expect(
+			isPresent(SPEC, {
+				platform: "darwin",
+				candidates: () => [],
+			}),
+		).toBe(false);
+
+		// Verify the cache was not evicted or overwritten by isPresent.
+		// Call resolveExecutable again with the same key; it should serve the cached hit
+		// (same probe call count, same resolution).
+		const r = resolveExecutable(SPEC, {
+			candidates: () => [{ file: "/other/binary" }],
+			probe: () => ({ ok: true, version: "2.0.0" }),
+			now: () => 150, // still within TTL
+			platform: "darwin",
+		});
+		// The cache was hit, so it returns the old result despite new candidates/probe.
+		expect(r).toEqual({ file: "/cached/binary", version: "1.0.0" });
+	});
+
+	it("defaults to process.platform and existsSync when not provided", () => {
+		// Tests the ?? operators for platform and exists defaults.
+		// Since we can't easily mock process.platform or existsSync in isolation,
+		// we use an override path that will go through the exists check.
+		expect(
+			isPresent(SPEC, {
+				overridePath: "/opt/custom/faketool",
+				exists: () => true,
+				// platform is NOT provided — should default to process.platform
+			}),
+		).toBe(true);
+	});
+
+	it("enumerates the filesystem when no candidates function is provided", () => {
+		// Tests the default path: with nothing on the (empty) search PATH and no
+		// knownPaths, discoverPresence finds nothing.
+		expect(
+			isPresent(SPEC, {
+				platform: "darwin",
+				basePath: "",
+				home: "/home/u",
+				exists: () => false,
+			}),
+		).toBe(false);
+	});
+
+	it("finds a binary sitting on the search PATH", () => {
+		expect(
+			isPresent(SPEC, {
+				platform: "darwin",
+				basePath: "/opt/bin",
+				home: "/home/u",
+				exists: (p) => p === "/opt/bin/faketool",
+			}),
+		).toBe(true);
+	});
+});
+
+describe("discoverPresence", () => {
+	const SPEC = { binName: "faketool", knownPaths: () => [], probeArgs: ["--version"] as const };
+
+	/**
+	 * The load-bearing guarantee: this runs synchronously on the VS Code extension
+	 * host's single thread during activation, where a blocked event loop stalls
+	 * EVERY extension. `discover` shells out to `which`/`where` via
+	 * `execFileSyncHidden`; presence must not.
+	 */
+	it("spawns no subprocess", () => {
+		const spawn = vi.spyOn(subprocess, "execFileSyncHidden");
+		discoverPresence(SPEC, "darwin", { basePath: "/opt/bin", home: "/home/u", exists: () => true });
+		expect(spawn).not.toHaveBeenCalled();
+	});
+
+	it("scans every PATH entry plus the common bin dirs", () => {
+		const seen: string[] = [];
+		discoverPresence(SPEC, "darwin", {
+			basePath: "/first",
+			home: "/home/u",
+			exists: (p) => {
+				seen.push(p);
+				return false;
+			},
+		});
+		expect(seen).toContain("/first/faketool");
+		// discoveryPath unions the GUI-launch-safe dirs in — the same reason
+		// `discover` hands them to `which`.
+		expect(seen).toContain("/opt/homebrew/bin/faketool");
+		expect(seen).toContain("/home/u/.local/bin/faketool");
+	});
+
+	it("includes the spec's known install locations", () => {
+		const spec = {
+			binName: "faketool",
+			knownPaths: () => ["/Applications/Thing.app/faketool"],
+			probeArgs: ["--version"] as const,
+		};
+		expect(discoverPresence(spec, "darwin", { basePath: "", home: "/home/u", exists: () => true })).toContain(
+			"/Applications/Thing.app/faketool",
+		);
+	});
+
+	it("dedupes a dir that appears in both PATH and the common dirs", () => {
+		const hits = discoverPresence(SPEC, "darwin", {
+			basePath: "/opt/homebrew/bin",
+			home: "/home/u",
+			exists: (p) => p === "/opt/homebrew/bin/faketool",
+		});
+		expect(hits).toEqual(["/opt/homebrew/bin/faketool"]);
+	});
+
+	it("accepts win32 shims as PRESENCE, even though they are not launch targets", () => {
+		// A `.cmd` cannot be spawned (see `discover`'s header) but it is still proof
+		// of an install. Resolving it to a native target stays resolveExecutable's job.
+		const hits = discoverPresence(SPEC, "win32", {
+			basePath: "C:\\bin",
+			home: "C:\\Users\\u",
+			exists: (p) => p === "C:\\bin\\faketool.cmd",
+		});
+		expect(hits).toEqual(["C:\\bin\\faketool.cmd"]);
+	});
+
+	it("splits the search path with the TARGET platform's separator", () => {
+		// `;` on win32, `:` elsewhere — getting this wrong silently collapses the
+		// whole PATH into one bogus directory name.
+		const hits = discoverPresence(SPEC, "win32", {
+			basePath: "C:\\a;C:\\b",
+			home: "C:\\Users\\u",
+			exists: (p) => p === "C:\\b\\faketool.exe",
+		});
+		expect(hits).toEqual(["C:\\b\\faketool.exe"]);
+	});
+
+	// Every test above injects `exists`, which is exactly why the DEFAULT
+	// predicate needs its own coverage against a real filesystem: a bare
+	// `existsSync` answers true for a directory and ignores the execute bit, and
+	// a presence-only false positive becomes a clickable onboarding option that
+	// cannot work.
+	describe("default file predicate (real filesystem)", () => {
+		let dir: string;
+
+		beforeEach(() => {
+			dir = mkdtempSync(join(tmpdir(), "jolli-presence-"));
+		});
+
+		afterEach(() => {
+			rmSync(dir, { recursive: true, force: true });
+		});
+
+		// POSIX-only: Windows has no execute bit, and the win32 branch deliberately
+		// stops at "is a regular file" so `.cmd` / `.ps1` shims still count.
+		const posixIt = process.platform === "win32" ? it.skip : it;
+
+		it("rejects a DIRECTORY that happens to be named like the binary", () => {
+			mkdirSync(join(dir, "faketool"));
+			expect(discoverPresence(SPEC, process.platform, { basePath: dir, home: dir })).toEqual([]);
+		});
+
+		posixIt("rejects a file with no execute bit", () => {
+			writeFileSync(join(dir, "faketool"), "");
+			chmodSync(join(dir, "faketool"), 0o644);
+			expect(discoverPresence(SPEC, process.platform, { basePath: dir, home: dir })).toEqual([]);
+		});
+
+		posixIt("accepts an executable regular file", () => {
+			writeFileSync(join(dir, "faketool"), "");
+			chmodSync(join(dir, "faketool"), 0o755);
+			expect(discoverPresence(SPEC, process.platform, { basePath: dir, home: dir })).toEqual([
+				join(dir, "faketool"),
+			]);
+		});
+
+		posixIt("rejects a broken symlink, matching existsSync", () => {
+			symlinkSync(join(dir, "nope"), join(dir, "faketool"));
+			expect(discoverPresence(SPEC, process.platform, { basePath: dir, home: dir })).toEqual([]);
+		});
+
+		it("applies the same predicate to isPresent's override path", () => {
+			// An override names one file; a directory at that path must not read as
+			// an installed tool just because something exists there.
+			mkdirSync(join(dir, "mytool"));
+			expect(isPresent(SPEC, { overridePath: join(dir, "mytool"), platform: process.platform })).toBe(false);
+		});
 	});
 });

--- a/cli/src/core/localagent/ExecutableResolver.ts
+++ b/cli/src/core/localagent/ExecutableResolver.ts
@@ -1,6 +1,6 @@
-import { existsSync, readdirSync } from "node:fs";
+import { accessSync, existsSync, constants as fsConstants, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { posix as pathPosix } from "node:path";
+import { posix as pathPosix, win32 as pathWin32 } from "node:path";
 import { createLogger } from "../../Logger.js";
 import { execFileSyncHidden } from "../../util/Subprocess.js";
 import { LocalAgentSetupError, type ResolvedExecutable } from "./Types.js";
@@ -230,6 +230,141 @@ export function discover(spec: ExecutableSpec, platform: NodeJS.Platform, deps: 
 	const candidates = dedupe([...unique.filter(isExe).map((file) => ({ file })), ...expanded]);
 	logDiscovery(spec, candidates.length, candidates.map(describeCandidate), shims, known, searchPath, ";");
 	return candidates;
+}
+
+/**
+ * win32 filename extensions a presence scan accepts. Deliberately WIDER than
+ * what {@link discover} treats as spawnable: a `.cmd` / `.ps1` / extensionless
+ * shim cannot be launched directly (see {@link discover}'s header), but it IS
+ * proof of an install, and presence answers "is this tool on disk?", not "can we
+ * spawn it?". Resolving a shim to a native target stays {@link resolveExecutable}'s
+ * job. `""` last so a real image sorts ahead of a shim in the returned list.
+ */
+const WIN32_PRESENCE_EXTS = [".exe", ".cmd", ".bat", ".ps1", ""] as const;
+
+/**
+ * Default file test for the PRESENCE half only. Deliberately stricter than
+ * `existsSync`, which answers true for a DIRECTORY and ignores the execute bit:
+ * a directory named `codex` somewhere on PATH, or an `opencode` that has been
+ * `chmod -x`'d, would otherwise both be reported as an installed tool.
+ *
+ * That matters because presence and usability must not disagree in the
+ * optimistic direction. {@link discover} cannot produce this false positive —
+ * `which -a` / `where` only ever name executables — so a presence-only "yes"
+ * becomes an onboarding option the user can click and then cannot use. The CLI
+ * menu absorbs it (a failed probe splices the entry out), but the VS Code
+ * onboarding card has no such fallback.
+ *
+ * NOT wired into {@link discover}'s `exists` seam, which is also handed to
+ * `expandShim` — that one legitimately tests a plain `index.js`, which carries
+ * no execute bit.
+ *
+ * `X_OK` is POSIX-only: Windows has no execute bit (Node treats `X_OK` as
+ * `F_OK` there) and a win32 presence hit is allowed to be a `.cmd` / `.ps1`
+ * shim, so win32 stops at "is a regular file". `statSync` follows symlinks,
+ * matching `existsSync` — a symlink to a real binary is a good install, and a
+ * broken one is absent under either predicate.
+ */
+function isPresentFile(file: string, platform: NodeJS.Platform): boolean {
+	try {
+		if (!statSync(file).isFile()) return false;
+		if (platform === "win32") return true;
+		accessSync(file, fsConstants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** Test seams and platform override for {@link isPresent} / {@link discoverPresence}. */
+export interface PresenceOpts {
+	readonly overridePath?: string;
+	/** Pre-baked enumeration result; bypasses {@link discoverPresence} entirely. */
+	readonly candidates?: () => readonly Candidate[];
+	readonly platform?: NodeJS.Platform;
+	readonly exists?: (path: string) => boolean;
+	/** Home directory; defaults to `os.homedir()`. */
+	readonly home?: string;
+	/** Base PATH scanned before common-dir augmentation; defaults to `process.env.PATH`. */
+	readonly basePath?: string;
+}
+
+/**
+ * Spawn-free presence enumeration: the files named `<binName>` (plus the win32
+ * extensions) that exist across {@link discoveryPath}, followed by the spec's
+ * known install locations.
+ *
+ * Deliberately does NOT shell out to `which` / `where` the way {@link discover}
+ * does. Those are synchronous subprocesses (`execFileSyncHidden`), and the whole
+ * point of the presence half is that a four-tool sweep can sit on the VS Code
+ * activation path — where the extension host is single-threaded and a blocked
+ * event loop stalls *every* extension, not just this one. Four `which` spawns
+ * are cheap on macOS and distinctly not cheap on Windows, where `where` runs
+ * tens of milliseconds apiece. Reading the same directories with `existsSync`
+ * answers the same question with no process at all.
+ *
+ * The trade-off versus `which`: PATHEXT subtleties and shell aliases are not
+ * modelled. That is acceptable precisely because presence is allowed to be
+ * approximate — {@link resolveExecutable} still runs the real enumeration and
+ * capability probe before anything is launched.
+ *
+ * Approximate is allowed to mean "misses an install"; it is NOT allowed to mean
+ * "invents one", since a presence-only yes is what paints a clickable onboarding
+ * option. Hence {@link isPresentFile} rather than a bare `existsSync` — see its
+ * header for the directory / non-executable false positives that closes.
+ */
+export function discoverPresence(spec: ExecutableSpec, platform: NodeJS.Platform, opts: PresenceOpts = {}): string[] {
+	const home = opts.home ?? homedir();
+	const basePath = opts.basePath ?? process.env.PATH ?? "";
+	const exists = opts.exists ?? ((f: string) => isPresentFile(f, platform));
+	// Join with the TARGET platform's rules, not the host's, so a `"darwin"`-
+	// pinned test on a Windows box still builds POSIX paths (same reason
+	// commonBinDirs uses path.posix).
+	const joinFor = platform === "win32" ? pathWin32.join : pathPosix.join;
+	const dirs = discoveryPath(basePath, home, platform).split(platform === "win32" ? ";" : ":");
+	const exts = platform === "win32" ? WIN32_PRESENCE_EXTS : [""];
+	const hits: string[] = [];
+	for (const dir of dirs) {
+		if (!dir) continue;
+		for (const ext of exts) {
+			const file = joinFor(dir, spec.binName + ext);
+			if (exists(file)) hits.push(file);
+		}
+	}
+	hits.push(...spec.knownPaths(home, platform).filter(exists));
+	return [...new Set(hits)];
+}
+
+/**
+ * Cheap "is this tool on disk?" check — filesystem enumeration only, with NO
+ * capability probe and NO subprocess.
+ *
+ * This is the presence half of the presence/usability split. {@link resolveExecutable}
+ * spawns `<bin> --version` per candidate to pick the newest and prove the tool
+ * accepts our flags; that costs a measured 161-1772 ms per tool and 3384 ms to
+ * sweep all four. Presence is pure filesystem work — see {@link discoverPresence}
+ * for why it avoids `which`/`where` too — which is what makes a four-tool sweep
+ * affordable on the VS Code activation path.
+ *
+ * Deliberately does NOT touch the module-level resolution cache: a presence
+ * answer must never be mistaken for, or displace, a real resolution.
+ *
+ * A `true` result means "found something that looks installed". It does not mean
+ * the binary runs, is a compatible version, or that the user is signed in.
+ * Callers that need those guarantees must still call {@link resolveExecutable}.
+ */
+export function isPresent(spec: ExecutableSpec, opts: PresenceOpts = {}): boolean {
+	const platform = opts.platform ?? process.platform;
+	const exists = opts.exists ?? ((f: string) => isPresentFile(f, platform));
+	if (opts.overridePath) {
+		// An override names one specific file. overrideCandidates always returns
+		// at least the verbatim path (so the probe can produce a useful error),
+		// which would make presence trivially true — so check the filesystem here
+		// instead of trusting the list's length.
+		return overrideCandidates(spec, opts.overridePath, platform).list.some((c) => exists(c.file));
+	}
+	if (opts.candidates) return opts.candidates().length > 0;
+	return discoverPresence(spec, platform, opts).length > 0;
 }
 
 /**

--- a/cli/src/core/localagent/OpenCodeBackend.test.ts
+++ b/cli/src/core/localagent/OpenCodeBackend.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import * as resolver from "./ExecutableResolver.js";
 import { expandOpenCodeShim, OpenCodeBackend } from "./OpenCodeBackend.js";
 import { LocalAgentSetupError } from "./Types.js";
 
@@ -94,5 +95,19 @@ describe("OpenCodeBackend.buildInvocation with launcher args", () => {
 			{ prompt: "hi", model: "", systemPrompt: "" },
 		);
 		expect(inv.args).toEqual(["cli.js", "run", "hi"]);
+	});
+});
+
+describe("OpenCodeBackend.isPresent", () => {
+	it("is false for an override path that does not exist", () => {
+		expect(new OpenCodeBackend().isPresent("/nonexistent/path/to/opencode")).toBe(false);
+	});
+
+	it("delegates to the OPENCODE_SPEC discovery, not another tool's", () => {
+		const spy = vi.spyOn(resolver, "isPresent").mockReturnValue(true);
+		expect(new OpenCodeBackend().isPresent()).toBe(true);
+		expect(spy).toHaveBeenCalledWith(expect.objectContaining({ binName: "opencode" }), {
+			overridePath: undefined,
+		});
 	});
 });

--- a/cli/src/core/localagent/OpenCodeBackend.ts
+++ b/cli/src/core/localagent/OpenCodeBackend.ts
@@ -1,6 +1,6 @@
 import { posix as pathPosix, win32 as pathWin32 } from "node:path";
 import { createLocalAgentCwd, LOCAL_AGENT_CHILD_ENV } from "../AgentReentry.js";
-import { type Candidate, resolveExecutable, type ShimDeps } from "./ExecutableResolver.js";
+import { type Candidate, isPresent, resolveExecutable, type ShimDeps } from "./ExecutableResolver.js";
 import {
 	type Invocation,
 	type LocalAgentBackend,
@@ -45,6 +45,10 @@ export class OpenCodeBackend implements LocalAgentBackend {
 
 	discoverExecutable(overridePath?: string): Promise<ResolvedExecutable> {
 		return Promise.resolve(resolveExecutable(OPENCODE_SPEC, { overridePath }));
+	}
+
+	isPresent(overridePath?: string): boolean {
+		return isPresent(OPENCODE_SPEC, { overridePath });
 	}
 
 	buildInvocation(exe: ResolvedExecutable, req: LocalAgentRequest): Invocation {

--- a/cli/src/core/localagent/Types.ts
+++ b/cli/src/core/localagent/Types.ts
@@ -51,6 +51,13 @@ export interface LocalAgentBackend {
 	discoverExecutable(overridePath?: string): Promise<ResolvedExecutable>;
 	buildInvocation(exe: ResolvedExecutable, req: LocalAgentRequest): Invocation;
 	parseResult(stdout: string): LocalAgentOutcome;
+	/**
+	 * Cheap presence check — is this tool on disk? No capability probe, no
+	 * subprocess. Used by onboarding surfaces that must decide what to OFFER
+	 * before the user has committed to a tool; anything that must know the tool
+	 * actually RUNS calls `discoverExecutable` instead.
+	 */
+	isPresent(overridePath?: string): boolean;
 }
 
 /* v8 ignore start */

--- a/cli/src/sync/BootstrapMerge.test.ts
+++ b/cli/src/sync/BootstrapMerge.test.ts
@@ -83,7 +83,7 @@ beforeAll(async () => {
 	execFileSync("git", ["add", "."], { cwd: seed });
 	execFileSync("git", ["commit", "--quiet", "-m", "[jolli-mb] seed"], { cwd: seed });
 	execFileSync("git", ["push", "--quiet", "origin", "main"], { cwd: seed });
-}, 30_000);
+}, 60_000);
 
 afterAll(async () => {
 	await rm(rootTempDir, { recursive: true, force: true });

--- a/cli/src/sync/GitClient.test.ts
+++ b/cli/src/sync/GitClient.test.ts
@@ -82,7 +82,7 @@ beforeAll(async () => {
 	execFileSync("git", ["add", "."], { cwd: seedClone });
 	execFileSync("git", ["commit", "--quiet", "-m", "[jolli-mb] seed"], { cwd: seedClone });
 	execFileSync("git", ["push", "--quiet", "origin", "main"], { cwd: seedClone });
-}, 30_000);
+}, 60_000);
 
 afterAll(async () => {
 	await rm(rootTempDir, { recursive: true, force: true });

--- a/docs/superpowers/plans/2026-07-28-onboarding-local-agent.md
+++ b/docs/superpowers/plans/2026-07-28-onboarding-local-agent.md
@@ -1,0 +1,1622 @@
+# Local Agent Preference Across Onboarding Surfaces — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every surface that configures AI summarization prefer a locally installed agent CLI (Claude Code, Codex, Cursor, OpenCode) when one is available, and let the user choose which one.
+
+**Architecture:** A new presence-only detection layer (`isPresent` → `listPresentLocalAgents`) answers "is this tool on disk?" with pure filesystem work in ~4 ms, while the expensive `--version` capability probe (measured 161–1772 ms per tool) is deferred to the moment a user commits to a specific tool. Three consumer surfaces are then updated — the VS Code onboarding card, `jolli enable` / the guided front door, and the Settings panel — plus a prerequisite repair of three health-check call sites that still hard-code `claude`.
+
+**Tech Stack:** TypeScript (ESM), Node 22.5+, Vitest, Biome, VS Code webview (esbuild → CJS).
+
+**Design spec:** [`docs/superpowers/specs/2026-07-28-vscode-onboarding-local-agent-design.md`](../specs/2026-07-28-vscode-onboarding-local-agent-design.md)
+
+## Global Constraints
+
+- **No per-task commits and no per-task `npm run all`.** Tasks contain test + implementation code only. The full gate and the commits happen once, in Task 11. Each task lists its targeted Vitest command as a *verification hint* (not a mandated step) so you can check your own work cheaply.
+- **DCO sign-off on every commit** — `git commit -s`. CI rejects PRs without `Signed-off-by:`.
+- **No `Co-Authored-By: Claude …` trailer and no `🤖 Generated with …` footer** in commit messages or PR descriptions.
+- **CLI coverage floor:** 97% statements / 96% branches / 97% functions / 97% lines for `cli/src/`. New code must not regress it.
+- **Biome:** tabs, 4-wide indent, 120 column limit. `noExplicitAny: error`, `noUnusedImports/Variables: error`. CI runs `biome check --error-on-warnings` — warnings fail.
+- **Webview CSP forbids inline `style=` and inline event handlers.** Dynamic styling goes through CSS classes; events go through `addEventListener`.
+- **Webview visibility toggles use the `.hidden` class**, never the HTML `hidden` attribute or `el.hidden = x` — author rules like `display: flex` beat the UA stylesheet and silently break the toggle.
+- **No backticks inside builder template literals**, including in comments — a stray backtick truncates the entire returned literal. Use single or double quotes when quoting identifiers.
+- **Tool ordering authority is `LOCAL_AGENT_TOOLS` key order** (Claude Code, Codex, Cursor, OpenCode) — *not* `BackendRegistry` order, which differs (Claude, Cursor, Codex, OpenCode).
+- **Cross-package imports in `vscode/src/**` are intentional** (e.g. `../../../cli/src/core/localagent/DetectAgents.js`); they resolve at esbuild bundle time. Do not refactor them into package imports.
+- **`v8 ignore` exemptions must use the block form** `/* v8 ignore start */` … `/* v8 ignore stop */`. The single-line `ignore next` form does not work in this repo.
+
+## File Structure
+
+**Created:**
+
+| File | Responsibility |
+| --- | --- |
+| `cli/src/core/localagent/BuiltinBackends.ts` | Self-registers the four backends; removes the hidden `LlmClient`-import coupling |
+| `cli/src/core/localagent/DetectAgents.ts` | `listPresentLocalAgents()` (presence sweep) + `isLocalAgentUsable()` (single-tool probe) |
+| `cli/src/core/localagent/DetectAgents.test.ts` | Tests for both |
+| `cli/src/core/localagent/BuiltinBackends.test.ts` | Registry populated without importing `LlmClient` |
+
+**Modified:**
+
+| File | Change |
+| --- | --- |
+| `cli/src/core/localagent/ExecutableResolver.ts` | Add `isPresent(spec, opts)` — candidate enumeration without probing |
+| `cli/src/core/localagent/Types.ts` | Add `isPresent()` to the `LocalAgentBackend` interface |
+| `cli/src/core/localagent/{ClaudeCode,Codex,CursorAgent,OpenCode}Backend.ts` | Implement `isPresent()` |
+| `cli/src/core/localagent/ClaudeExecutableResolver.ts` | Add `isClaudeCodePresent()`; delete `isClaudeCodeUsable()` in Task 4 |
+| `cli/src/core/LlmClient.ts` | Import `BuiltinBackends.js` instead of registering inline |
+| `cli/src/commands/GenerationFix.ts` | De-hardcode `claude` in `canGenerateNow()` and `promptLocalAgentFix()` |
+| `cli/src/commands/GuidedFrontDoor.ts` | De-hardcode the "summaries via Claude Code" status line |
+| `cli/src/commands/EnableCommand.ts` | Generalize auto-select; add multi-tool picker; filter menu choice 3 |
+| `vscode/src/services/data/StatusDataService.ts`, `vscode/src/JolliMemoryBridge.ts` | Derive `usesLocalAgent` |
+| `vscode/src/stores/StatusStore.ts` | Carry `usesLocalAgent` in the snapshot |
+| `vscode/src/Extension.ts` | Extend `configured`; run detection under the barrier; add the select command |
+| `vscode/src/views/SidebarMessages.ts` | `localAgents` on `init`; `localAgent:selectError` message |
+| `vscode/src/views/SidebarWebviewProvider.ts` | Carry `localAgents`; add `notifyLocalAgentSelectError` |
+| `vscode/src/views/SidebarHtmlBuilder.ts` | The card skeleton |
+| `vscode/src/views/SidebarCssBuilder.ts` | Card / select / hint / error styles |
+| `vscode/src/views/SidebarScriptBuilder.ts` | Populate the dropdown, wire the button, render errors |
+| `vscode/src/views/SettingsHtmlBuilder.ts` | Availability status line under the Agent tool dropdown |
+| `vscode/src/views/SettingsScriptBuilder.ts` | Probe on change/open; feed `hasErrors` |
+| `vscode/src/views/SettingsWebviewPanel.ts` | Handle `probeLocalAgent`, reply with the result |
+
+---
+
+### Task 1: Presence check in the executable resolver
+
+**Files:**
+- Modify: `cli/src/core/localagent/ExecutableResolver.ts`
+- Test: `cli/src/core/localagent/ExecutableResolver.test.ts`
+
+**Interfaces:**
+- Consumes: existing `discover(spec, platform, deps)`, `overrideCandidates(spec, path, platform)`, `ExecutableSpec`, `Candidate`.
+- Produces: `isPresent(spec: ExecutableSpec, opts?: PresenceOpts): boolean` and `interface PresenceOpts { overridePath?: string; candidates?: () => readonly Candidate[]; platform?: NodeJS.Platform; exists?: (p: string) => boolean }`.
+
+**Why this matters:** `resolveExecutable` answers "is this usable?" by spawning `<bin> --version` for every candidate — measured at 3384 ms across four installed tools. `isPresent` answers the cheaper question "is this on disk?" by stopping after candidate enumeration: ~4 ms, zero subprocesses.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `cli/src/core/localagent/ExecutableResolver.test.ts`:
+
+```ts
+describe("isPresent", () => {
+	const SPEC = {
+		binName: "faketool",
+		knownPaths: () => [],
+		probeArgs: ["--version"] as const,
+	};
+
+	it("returns true when candidates are discovered", () => {
+		expect(
+			isPresent(SPEC, { platform: "darwin", candidates: () => [{ file: "/usr/local/bin/faketool" }] }),
+		).toBe(true);
+	});
+
+	it("spawns no subprocess — the whole point of the presence/usability split", () => {
+		// SPEC.binName is fake, so if isPresent ever probed, this would attempt to
+		// spawn a nonexistent binary. Assert on the module's real subprocess seam
+		// so the guarantee is enforced rather than assumed.
+		const spawnSpy = vi.spyOn(subprocess, "execFileSyncHidden");
+		expect(
+			isPresent(SPEC, { platform: "darwin", candidates: () => [{ file: "/usr/local/bin/faketool" }] }),
+		).toBe(true);
+		expect(spawnSpy).not.toHaveBeenCalled();
+	});
+
+	it("returns false when nothing is discovered", () => {
+		expect(isPresent(SPEC, { platform: "darwin", candidates: () => [] })).toBe(false);
+	});
+
+	it("honors an override path that exists on disk", () => {
+		expect(
+			isPresent(SPEC, {
+				platform: "darwin",
+				overridePath: "/opt/custom/faketool",
+				exists: (p) => p === "/opt/custom/faketool",
+			}),
+		).toBe(true);
+	});
+
+	it("rejects an override path that does not exist", () => {
+		expect(
+			isPresent(SPEC, {
+				platform: "darwin",
+				overridePath: "/opt/missing/faketool",
+				exists: () => false,
+			}),
+		).toBe(false);
+	});
+
+	it("does not consult the resolution cache", () => {
+		// isPresent must never seed or read the single-slot resolveExecutable
+		// cache: a cheap presence answer must not mask a later real resolution.
+		expect(isPresent(SPEC, { platform: "darwin", candidates: () => [{ file: "/a" }] })).toBe(true);
+		expect(isPresent(SPEC, { platform: "darwin", candidates: () => [] })).toBe(false);
+	});
+});
+```
+
+Add `isPresent` to the existing import from `./ExecutableResolver.js`, plus
+`import * as subprocess from "../../util/Subprocess.js";` and `vi` from `vitest`,
+at the top of the test file.
+
+- [ ] **Step 2: Implement**
+
+In `cli/src/core/localagent/ExecutableResolver.ts`, add after the `discover` function:
+
+```ts
+/** Test seams and platform override for {@link isPresent}. */
+export interface PresenceOpts {
+	readonly overridePath?: string;
+	readonly candidates?: () => readonly Candidate[];
+	readonly platform?: NodeJS.Platform;
+	readonly exists?: (path: string) => boolean;
+}
+
+/**
+ * Cheap "is this tool on disk?" check — candidate enumeration only, with NO
+ * capability probe.
+ *
+ * This is the presence half of the presence/usability split. {@link resolveExecutable}
+ * spawns `<bin> --version` per candidate to pick the newest and prove the tool
+ * accepts our flags; that costs a measured 161-1772 ms per tool and 3384 ms to
+ * sweep all four. Presence is pure filesystem work (`which` plus `existsSync`)
+ * and comes back in single-digit milliseconds, which is what makes a four-tool
+ * sweep affordable on the VS Code activation path.
+ *
+ * Deliberately does NOT touch the module-level resolution cache: a presence
+ * answer must never be mistaken for, or displace, a real resolution.
+ *
+ * A `true` result means "found something spawnable-looking". It does not mean
+ * the binary runs, is a compatible version, or that the user is signed in.
+ * Callers that need those guarantees must still call {@link resolveExecutable}.
+ */
+export function isPresent(spec: ExecutableSpec, opts: PresenceOpts = {}): boolean {
+	const platform = opts.platform ?? process.platform;
+	const exists = opts.exists ?? existsSync;
+	if (opts.overridePath) {
+		// An override names one specific file. overrideCandidates always returns
+		// at least the verbatim path (so the probe can produce a useful error),
+		// which would make presence trivially true — so check the filesystem here
+		// instead of trusting the list's length.
+		return overrideCandidates(spec, opts.overridePath, platform).list.some((c) => exists(c.file));
+	}
+	return (opts.candidates ?? (() => discover(spec, platform)))().length > 0;
+}
+```
+
+**Verification hint:** `npm run test -w @jolli.ai/cli -- src/core/localagent/ExecutableResolver.test.ts`
+
+---
+
+### Task 2: `isPresent` on every backend + extract backend registration
+
+**Files:**
+- Create: `cli/src/core/localagent/BuiltinBackends.ts`
+- Create: `cli/src/core/localagent/BuiltinBackends.test.ts`
+- Modify: `cli/src/core/localagent/Types.ts` (the `LocalAgentBackend` interface)
+- Modify: `cli/src/core/localagent/ClaudeExecutableResolver.ts`
+- Modify: `cli/src/core/localagent/ClaudeCodeBackend.ts`, `CodexBackend.ts`, `CursorAgentBackend.ts`, `OpenCodeBackend.ts`
+- Modify: `cli/src/core/LlmClient.ts:30-34`
+- Test: each backend's existing `*.test.ts`
+
+**Interfaces:**
+- Consumes: `isPresent(spec, opts)` from Task 1.
+- Produces: `LocalAgentBackend.isPresent(overridePath?: string): boolean` on all four backends; `isClaudeCodePresent(opts?: PresenceOpts): boolean`; module `BuiltinBackends.ts` whose import registers all four backends.
+
+**Why this matters:** backends are registered as a side effect of importing `LlmClient` ([`LlmClient.ts:31-34`](../../../cli/src/core/LlmClient.ts)). Any other consumer calling `getBackend()` without that import silently sees an empty registry and throws "Unknown local agent tool". Task 3's detector is exactly such a consumer.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `cli/src/core/localagent/BuiltinBackends.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+// Importing this module MUST be sufficient to populate the registry — no
+// LlmClient import anywhere in this file. That is the whole point of the test.
+import "./BuiltinBackends.js";
+import { getBackend } from "./BackendRegistry.js";
+
+describe("BuiltinBackends", () => {
+	it.each(["claude-code", "codex", "cursor-agent", "opencode"])(
+		"registers %s without importing LlmClient",
+		(id) => {
+			expect(getBackend(id).id).toBe(id);
+		},
+	);
+});
+```
+
+Append to `cli/src/core/localagent/CodexBackend.test.ts` (and mirror for the other three, changing the class, id, and binary name):
+
+```ts
+describe("CodexBackend.isPresent", () => {
+	it("is false for an override path that does not exist", () => {
+		expect(new CodexBackend().isPresent("/nonexistent/path/to/codex")).toBe(false);
+	});
+
+	it("delegates to the CODEX_SPEC discovery, not another tool's", () => {
+		const spy = vi.spyOn(resolver, "isPresent").mockReturnValue(true);
+		expect(new CodexBackend().isPresent()).toBe(true);
+		expect(spy).toHaveBeenCalledWith(
+			expect.objectContaining({ binName: "codex" }),
+			{ overridePath: undefined },
+		);
+	});
+});
+```
+
+Add `import * as resolver from "./ExecutableResolver.js";` to each backend test file.
+
+> The first case asserts the negative deterministically — the path exists on no
+> machine. The second is the one that actually matters: it pins each backend to
+> *its own* spec, which is what a copy-paste error between the four
+> near-identical implementations would break. A positive filesystem case is
+> deliberately not asserted here; it would depend on the host having the tool
+> installed. Real positive coverage lives in `ExecutableResolver.test.ts`
+> (Task 1) and `DetectAgents.test.ts` (Task 3), which inject seams.
+
+- [ ] **Step 2: Add `isPresent` to the interface**
+
+In `cli/src/core/localagent/Types.ts`, inside `interface LocalAgentBackend`, after `discoverExecutable`:
+
+```ts
+	/**
+	 * Cheap presence check — is this tool on disk? No capability probe, no
+	 * subprocess. Used by onboarding surfaces that must decide what to OFFER
+	 * before the user has committed to a tool; anything that must know the tool
+	 * actually RUNS calls `discoverExecutable` instead.
+	 */
+	isPresent(overridePath?: string): boolean;
+```
+
+- [ ] **Step 3: Implement on each backend**
+
+`cli/src/core/localagent/CodexBackend.ts` — add to the class, right after `discoverExecutable`:
+
+```ts
+	isPresent(overridePath?: string): boolean {
+		return isPresent(CODEX_SPEC, { overridePath });
+	}
+```
+
+Add `isPresent` to the existing `./ExecutableResolver.js` import in that file.
+
+Repeat verbatim in `CursorAgentBackend.ts` with `CURSOR_SPEC` and `OpenCodeBackend.ts` with `OPENCODE_SPEC`.
+
+For Claude, first add to `cli/src/core/localagent/ClaudeExecutableResolver.ts`:
+
+```ts
+/**
+ * Presence-only counterpart of {@link resolveClaudeExecutable}: true when a
+ * `claude` binary is discoverable, WITHOUT probing that it runs. Kept beside the
+ * resolver so the Claude spec stays in one file.
+ */
+export function isClaudeCodePresent(opts: PresenceOpts = {}): boolean {
+	return isPresent(CLAUDE_SPEC, opts);
+}
+```
+
+importing `isPresent` and `type PresenceOpts` from `./ExecutableResolver.js`. Then in `ClaudeCodeBackend.ts`:
+
+```ts
+	isPresent(overridePath?: string): boolean {
+		return isClaudeCodePresent({ overridePath });
+	}
+```
+
+- [ ] **Step 4: Extract registration**
+
+Create `cli/src/core/localagent/BuiltinBackends.ts`:
+
+```ts
+/**
+ * Registers the four shipped local-agent backends.
+ *
+ * Importing this module for its side effect is the ONLY supported way to
+ * populate the registry. It exists because registration used to live at module
+ * scope in LlmClient, which made a populated registry an invisible consequence
+ * of importing an unrelated module: any other consumer calling `getBackend()`
+ * first saw an empty registry and threw "Unknown local agent tool". Both
+ * LlmClient and DetectAgents import this instead.
+ *
+ * Registration order is irrelevant here — `registerBackend` keys by id, and the
+ * ordering authority for anything user-facing is LOCAL_AGENT_TOOLS, not this
+ * file.
+ */
+import { registerBackend } from "./BackendRegistry.js";
+import { ClaudeCodeBackend } from "./ClaudeCodeBackend.js";
+import { CodexBackend } from "./CodexBackend.js";
+import { CursorAgentBackend } from "./CursorAgentBackend.js";
+import { OpenCodeBackend } from "./OpenCodeBackend.js";
+
+registerBackend(new ClaudeCodeBackend());
+registerBackend(new CursorAgentBackend());
+registerBackend(new CodexBackend());
+registerBackend(new OpenCodeBackend());
+```
+
+In `cli/src/core/LlmClient.ts`, delete lines 31-34 and the four backend class imports, and replace them with:
+
+```ts
+import "./localagent/BuiltinBackends.js";
+```
+
+Keep the existing `getBackend` import — it is still used at line 473.
+
+**Verification hint:** `npm run test -w @jolli.ai/cli -- src/core/localagent/`
+
+---
+
+### Task 3: `DetectAgents` — the presence sweep and the single-tool probe
+
+**Files:**
+- Create: `cli/src/core/localagent/DetectAgents.ts`
+- Create: `cli/src/core/localagent/DetectAgents.test.ts`
+
+**Interfaces:**
+- Consumes: `getBackend` (BackendRegistry), `LOCAL_AGENT_TOOLS` / `localAgentToolLabel` (ToolMeta), `LocalAgentToolId` (Types), `BuiltinBackends.js` side effect from Task 2.
+- Produces:
+  - `interface DetectedAgent { readonly id: LocalAgentToolId; readonly label: string }`
+  - `listPresentLocalAgents(overridePath?: string): DetectedAgent[]`
+  - `isLocalAgentUsable(tool: LocalAgentToolId, opts?: { overridePath?: string }): Promise<boolean>`
+
+**Why this matters:** this is the single seam every consumer surface uses, and the ordering authority lives here. `isLocalAgentUsable` is the registry-backed generalization of `isClaudeCodeUsable`, which Task 4 deletes.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `cli/src/core/localagent/DetectAgents.test.ts`:
+
+```ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as registry from "./BackendRegistry.js";
+import { isLocalAgentUsable, listPresentLocalAgents } from "./DetectAgents.js";
+import { LocalAgentSetupError } from "./Types.js";
+
+/** Builds a fake backend whose presence and probe results are scripted. */
+function fake(id: string, present: boolean, usable = true) {
+	return {
+		id,
+		isPresent: () => present,
+		discoverExecutable: () =>
+			usable
+				? Promise.resolve({ file: `/bin/${id}`, version: "1.0.0" })
+				: Promise.reject(new LocalAgentSetupError(`No compatible ${id}`)),
+		buildInvocation: () => {
+			throw new Error("not used");
+		},
+		parseResult: () => {
+			throw new Error("not used");
+		},
+	};
+}
+
+function stub(map: Record<string, boolean>) {
+	vi.spyOn(registry, "getBackend").mockImplementation((id: string) => fake(id, map[id] ?? false) as never);
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("listPresentLocalAgents", () => {
+	it("returns all four in LOCAL_AGENT_TOOLS order when all are present", () => {
+		stub({ "claude-code": true, codex: true, "cursor-agent": true, opencode: true });
+		expect(listPresentLocalAgents().map((a) => a.id)).toEqual([
+			"claude-code",
+			"codex",
+			"cursor-agent",
+			"opencode",
+		]);
+	});
+
+	it("uses LOCAL_AGENT_TOOLS order, NOT BackendRegistry order", () => {
+		// BuiltinBackends registers Claude, Cursor, Codex, OpenCode. If this ever
+		// starts reading the registry, Cursor would precede Codex and this fails.
+		stub({ "claude-code": true, codex: true, "cursor-agent": true, opencode: true });
+		const ids = listPresentLocalAgents().map((a) => a.id);
+		expect(ids.indexOf("codex")).toBeLessThan(ids.indexOf("cursor-agent"));
+	});
+
+	it("returns only the present tools", () => {
+		stub({ "claude-code": false, codex: true, "cursor-agent": false, opencode: true });
+		expect(listPresentLocalAgents().map((a) => a.id)).toEqual(["codex", "opencode"]);
+	});
+
+	it("returns an empty array when nothing is present", () => {
+		stub({});
+		expect(listPresentLocalAgents()).toEqual([]);
+	});
+
+	it("carries the display label from LOCAL_AGENT_TOOLS", () => {
+		stub({ "claude-code": true });
+		expect(listPresentLocalAgents()[0]).toEqual({ id: "claude-code", label: "Claude Code" });
+	});
+
+	it("treats a throwing backend as absent rather than failing the sweep", () => {
+		vi.spyOn(registry, "getBackend").mockImplementation((id: string) => {
+			if (id === "codex") throw new Error("registry exploded");
+			return fake(id, true) as never;
+		});
+		expect(listPresentLocalAgents().map((a) => a.id)).toEqual([
+			"claude-code",
+			"cursor-agent",
+			"opencode",
+		]);
+	});
+});
+
+describe("isLocalAgentUsable", () => {
+	it("is true when the tool resolves", async () => {
+		vi.spyOn(registry, "getBackend").mockImplementation((id: string) => fake(id, true, true) as never);
+		await expect(isLocalAgentUsable("codex")).resolves.toBe(true);
+	});
+
+	it("is false when the tool fails to resolve", async () => {
+		vi.spyOn(registry, "getBackend").mockImplementation((id: string) => fake(id, true, false) as never);
+		await expect(isLocalAgentUsable("codex")).resolves.toBe(false);
+	});
+
+	it("is false for an unknown tool id rather than throwing", async () => {
+		vi.spyOn(registry, "getBackend").mockImplementation(() => {
+			throw new LocalAgentSetupError("Unknown local agent tool");
+		});
+		await expect(isLocalAgentUsable("codex")).resolves.toBe(false);
+	});
+});
+```
+
+- [ ] **Step 2: Implement**
+
+Create `cli/src/core/localagent/DetectAgents.ts`:
+
+```ts
+/**
+ * Local-agent detection for onboarding surfaces.
+ *
+ * Two questions, deliberately separated by cost:
+ *
+ * - {@link listPresentLocalAgents} — "which tools are on disk?" Pure filesystem
+ *   work, measured at ~4 ms for all four. Cheap enough to run on the VS Code
+ *   activation path before first paint.
+ * - {@link isLocalAgentUsable} — "does THIS tool actually run?" Spawns the
+ *   capability probe; measured 161-1772 ms for a single tool. Called only once
+ *   the user has committed to a specific tool.
+ *
+ * A full four-tool usability sweep costs 3384 ms on a machine with everything
+ * installed, which is why onboarding never does one.
+ */
+import type { LocalAgentToolId } from "../../Types.js";
+import { getBackend } from "./BackendRegistry.js";
+// Side-effect import: populates the registry that getBackend reads.
+import "./BuiltinBackends.js";
+import { LOCAL_AGENT_TOOLS } from "./ToolMeta.js";
+
+/** One locally-installed agent tool, as offered to the user. */
+export interface DetectedAgent {
+	readonly id: LocalAgentToolId;
+	readonly label: string;
+}
+
+/** All tool ids in display order. LOCAL_AGENT_TOOLS is the ordering authority
+ * for every user-facing list (the Settings dropdown already derives from it);
+ * BackendRegistry registers in a different order and must not be used here. */
+const TOOL_IDS = Object.keys(LOCAL_AGENT_TOOLS) as LocalAgentToolId[];
+
+/**
+ * Tools present on this machine, in display order. Never throws: a backend that
+ * blows up is reported absent, because a detection failure must degrade to
+ * "offer fewer options", never to a broken onboarding panel.
+ */
+export function listPresentLocalAgents(overridePath?: string): DetectedAgent[] {
+	const found: DetectedAgent[] = [];
+	for (const id of TOOL_IDS) {
+		try {
+			if (getBackend(id).isPresent(overridePath)) {
+				found.push({ id, label: LOCAL_AGENT_TOOLS[id].label });
+			}
+		} catch {
+			// Absent. See the docstring — never fail the sweep for one tool.
+		}
+	}
+	return found;
+}
+
+/**
+ * True when `tool` resolves to a runnable binary that accepts the flags we pass.
+ * The registry-backed generalization of the former `isClaudeCodeUsable`, and the
+ * seam tests mock so they never shell out to a real agent CLI.
+ *
+ * Still says nothing about whether the user is SIGNED IN to that tool — there is
+ * no uniform auth probe. That failure surfaces at generation time and is what
+ * `localAgentToolLoginHint` exists for.
+ */
+export async function isLocalAgentUsable(
+	tool: LocalAgentToolId,
+	opts: { overridePath?: string } = {},
+): Promise<boolean> {
+	try {
+		await getBackend(tool).discoverExecutable(opts.overridePath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+```
+
+**Verification hint:** `npm run test -w @jolli.ai/cli -- src/core/localagent/DetectAgents.test.ts`
+
+---
+
+### Task 4: De-hardcode the local-agent health checks
+
+**Files:**
+- Modify: `cli/src/commands/GenerationFix.ts:20,34,98-140`
+- Modify: `cli/src/commands/GuidedFrontDoor.ts:197`
+- Modify: `cli/src/commands/EnableCommand.ts:361`
+- Modify: `cli/src/core/localagent/ClaudeExecutableResolver.ts` (delete `isClaudeCodeUsable`)
+- Test: `cli/src/commands/GenerationFix.test.ts`, `cli/src/commands/GuidedFrontDoor.test.ts`, `cli/src/core/localagent/ClaudeExecutableResolver.test.ts`
+
+**Interfaces:**
+- Consumes: `isLocalAgentUsable(tool, opts)` from Task 3; `localAgentToolLabel` / `localAgentToolLoginHint` from `ToolMeta.js`.
+- Produces: nothing new. This task only removes hard-coded `claude` assumptions.
+
+**Why this matters — this is a live bug, not new scope.** `localAgentTool` is already settable to any of the four (menu choice 3, `jolli configure --set localAgentTool=codex`, the Settings dropdown), and generation honors it correctly at [`LlmClient.ts:473`](../../../cli/src/core/LlmClient.ts). But three health-check sites still probe `claude` unconditionally, so a Codex user with no Claude installed is told generation is broken and sent to repair a tool they never chose. The runtime is generic; only the diagnostics lie. [`DoctorCommand.ts:171`](../../../cli/src/commands/DoctorCommand.ts) already does this correctly and is the reference implementation.
+
+`canGenerateNow` becomes async — check and update every caller.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `cli/src/commands/GenerationFix.test.ts`:
+
+```ts
+describe("canGenerateNow — configured tool, not claude", () => {
+	it("probes the configured tool, not claude", async () => {
+		const spy = vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+		await canGenerateNow({ aiProvider: "local-agent", localAgentTool: "codex" });
+		expect(spy).toHaveBeenCalledWith("codex", { overridePath: undefined });
+	});
+
+	it("reports usable for a Codex-only machine", async () => {
+		vi.spyOn(detect, "isLocalAgentUsable").mockImplementation(async (t) => t === "codex");
+		await expect(
+			canGenerateNow({ aiProvider: "local-agent", localAgentTool: "codex" }),
+		).resolves.toBe(true);
+	});
+
+	it("reports unusable when the configured tool is broken even if claude works", async () => {
+		vi.spyOn(detect, "isLocalAgentUsable").mockImplementation(async (t) => t === "claude-code");
+		await expect(
+			canGenerateNow({ aiProvider: "local-agent", localAgentTool: "opencode" }),
+		).resolves.toBe(false);
+	});
+
+	it("defaults to claude-code when localAgentTool is absent", async () => {
+		const spy = vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+		await canGenerateNow({ aiProvider: "local-agent" });
+		expect(spy).toHaveBeenCalledWith("claude-code", { overridePath: undefined });
+	});
+});
+```
+
+Add `import * as detect from "../core/localagent/DetectAgents.js";` to that test file.
+
+Append to `cli/src/commands/GuidedFrontDoor.test.ts` a case asserting the status line names the configured tool:
+
+```ts
+it("names the configured local agent in the status line", async () => {
+	// Arrange the front door with aiProvider local-agent + localAgentTool codex
+	// using this file's existing harness, then assert on captured stdout:
+	expect(output).toContain("summaries via Codex");
+	expect(output).not.toContain("summaries via Claude Code");
+});
+```
+
+- [ ] **Step 2: Rewrite `canGenerateNow`**
+
+In `cli/src/commands/GenerationFix.ts`, replace the `isClaudeCodeUsable` import with `isLocalAgentUsable` from `../core/localagent/DetectAgents.js`, and replace the function:
+
+```ts
+/**
+ * True when the current config can actually generate summaries right now. For
+ * the local agent this PROBES the CONFIGURED tool's binary — the same one the
+ * commit-time runtime resolves via getBackend(localAgentTool) — so it never
+ * disagrees with what actually generates. It used to probe `claude`
+ * unconditionally, which told Codex/Cursor/OpenCode users their generation was
+ * broken and sent them to repair a tool they never selected.
+ *
+ * The `?? "claude-code"` default matches StatusTreeProvider and SummaryUtils,
+ * and covers configs written before `localAgentTool` existed.
+ */
+export async function canGenerateNow(config: JolliMemoryConfig): Promise<boolean> {
+	if (config.aiProvider === "local-agent") {
+		return isLocalAgentUsable(config.localAgentTool ?? "claude-code", {
+			overridePath: config.localAgentPath,
+		});
+	}
+	return resolveLlmCredentialSource(config) !== null;
+}
+```
+
+Update every caller to `await`. Find them with:
+
+```bash
+grep -rn "canGenerateNow" cli/src vscode/src --include='*.ts'
+```
+
+- [ ] **Step 3: Parameterize the R3 repair**
+
+In `promptLocalAgentFix`, take the tool id, and replace all `claude`-specific copy. The three hard-coded strings at lines 105, 114, 135, 138 become:
+
+```ts
+	const label = localAgentToolLabel(tool);
+	console.log(
+		`\n  AI provider is set to Local Agent (${label}) but no usable binary was found — memories won't be generated.\n`,
+	);
+	// … choice 1 retry:
+	if (await isLocalAgentUsable(tool, { overridePath: localAgentPath })) {
+		console.log(`\n  ✓ ${label} is working now.`);
+		return true;
+	}
+	console.log(`\n  Still no usable ${label}. ${localAgentToolLoginHint(tool)}`);
+	console.log("  Fix it and run `jolli` again, or `jolli configure`.\n");
+	return false;
+```
+
+and the skip message at line 114 becomes `` `\n  Skipped. Fix ${label} or run \`jolli configure\` later.\n` ``.
+
+Update `promptGenerationFix` to pass `config.localAgentTool ?? "claude-code"` into it.
+
+- [ ] **Step 4: Fix the front-door status line**
+
+`cli/src/commands/GuidedFrontDoor.ts:197` — replace:
+
+```ts
+		const engine = canGenerate && config.aiProvider === "local-agent" ? " · summaries via Claude Code" : "";
+```
+
+with:
+
+```ts
+		const engine =
+			canGenerate && config.aiProvider === "local-agent"
+				? ` · summaries via ${localAgentToolLabel(config.localAgentTool ?? "claude-code")}`
+				: "";
+```
+
+importing `localAgentToolLabel` from `../core/localagent/ToolMeta.js`.
+
+- [ ] **Step 5: Generalize the stale hint and delete the dead helper**
+
+`cli/src/commands/EnableCommand.ts:361` — replace the Claude-specific hint:
+
+```ts
+			console.log('    - Set "aiProvider": "local-agent" to drive a local agent CLI (no key)\n');
+```
+
+Delete `isClaudeCodeUsable` from `cli/src/core/localagent/ClaudeExecutableResolver.ts` (Task 5 removes its last caller — if `EnableCommand.ts:55` still references it at this point, leave the deletion to Task 5 and do it there instead). Migrate its tests in `ClaudeExecutableResolver.test.ts` to `isLocalAgentUsable("claude-code", …)` rather than deleting them — dropping them would read as a coverage pass while losing real assertions.
+
+**Verification hint:** `npm run test -w @jolli.ai/cli -- src/commands/GenerationFix.test.ts src/commands/GuidedFrontDoor.test.ts`
+
+---
+
+### Task 5: `jolli enable` — generalized auto-select and multi-tool picker
+
+**Files:**
+- Modify: `cli/src/commands/EnableCommand.ts:40-160`
+- Test: `cli/src/commands/EnableCommand.test.ts`
+
+**Interfaces:**
+- Consumes: `listPresentLocalAgents()`, `isLocalAgentUsable(tool, opts)` from Task 3; `localAgentToolLabel` from `ToolMeta.js`; existing `promptText`, `saveConfigScoped`.
+- Produces: `autoSelectLocalAgent(configDir: string, tool: LocalAgentToolId): Promise<void>` replacing `autoSelectClaudeCode(configDir)`.
+
+**Behavior table (fresh config only — `fresh` stays the existing guard, so an existing key or a deliberate provider choice is never second-guessed):**
+
+| Present tools | Behavior |
+| --- | --- |
+| 0 | Fall through to the existing provider menu, unchanged |
+| 1 | Probe it. Usable → auto-select silently. Not usable → fall through to the menu |
+| 2+ | Prompt listing the present tools; probe the chosen one, then save |
+
+The single-tool branch preserves today's exact semantics (presence *and* a passing probe before anything is written) — it is simply no longer hard-coded to Claude Code. VS Code deliberately differs by always showing its picker; see "One deliberate asymmetry" in the spec. Do not "align" them.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `cli/src/commands/EnableCommand.test.ts`:
+
+```ts
+describe("promptSetup — local agent auto-select", () => {
+	it("auto-selects silently when exactly one tool is present and usable", async () => {
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([{ id: "codex", label: "Codex" }]);
+		vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+		await promptSetup();
+		expect(savedConfig).toMatchObject({ aiProvider: "local-agent", localAgentTool: "codex" });
+		expect(promptText).not.toHaveBeenCalled();
+	});
+
+	it("falls through to the provider menu when the single present tool fails its probe", async () => {
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([{ id: "codex", label: "Codex" }]);
+		vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(false);
+		promptText.mockResolvedValue("4"); // Skip
+		await promptSetup();
+		expect(savedConfig).toBeUndefined();
+		expect(output).toContain("How would you like to generate summaries?");
+	});
+
+	it("prompts when two or more tools are present", async () => {
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([
+			{ id: "claude-code", label: "Claude Code" },
+			{ id: "opencode", label: "OpenCode" },
+		]);
+		vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+		promptText.mockResolvedValue("2");
+		await promptSetup();
+		expect(savedConfig).toMatchObject({ aiProvider: "local-agent", localAgentTool: "opencode" });
+	});
+
+	it("re-prompts when the chosen tool fails its probe, writing nothing", async () => {
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([
+			{ id: "claude-code", label: "Claude Code" },
+			{ id: "opencode", label: "OpenCode" },
+		]);
+		vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+		promptText.mockResolvedValueOnce("1").mockResolvedValueOnce("2");
+		await promptSetup();
+		expect(output).toContain("OpenCode");
+		expect(savedConfig).toMatchObject({ localAgentTool: "opencode" });
+	});
+
+	it("shows the provider menu unchanged when no tool is present", async () => {
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([]);
+		promptText.mockResolvedValue("4");
+		await promptSetup();
+		expect(output).toContain("How would you like to generate summaries?");
+	});
+});
+
+describe("menu choice 3 — explicit local agent", () => {
+	it("lists only present tools", async () => {
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([
+			{ id: "codex", label: "Codex" },
+			{ id: "opencode", label: "OpenCode" },
+		]);
+		vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+		promptText.mockResolvedValueOnce("3").mockResolvedValueOnce("1");
+		await promptSetup();
+		expect(output).toContain("1. Codex");
+		expect(output).toContain("2. OpenCode");
+		expect(output).not.toContain("Cursor");
+	});
+
+	it("falls back to all four with a note when none are present", async () => {
+		vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([]);
+		vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+		promptText.mockResolvedValueOnce("3").mockResolvedValueOnce("1");
+		await promptSetup();
+		expect(output).toContain("None detected");
+		expect(output).toContain("Cursor");
+	});
+});
+```
+
+Add `import * as detect from "../core/localagent/DetectAgents.js";` to that test file. Reuse the file's existing harness for `savedConfig`, `output`, and the `promptText` mock rather than inventing new ones.
+
+- [ ] **Step 2: Replace the Claude-only fast path**
+
+In `cli/src/commands/EnableCommand.ts`, replace the block at lines 47-58 with:
+
+```ts
+	// Zero-friction default: when nothing is configured yet AND local agent
+	// tools are installed, generate summaries through the user's own
+	// subscription (no API key, no sign-in). Probe ONLY on a truly fresh config
+	// so an existing Anthropic key or a deliberate provider choice is never
+	// second-guessed.
+	//
+	// Presence detection is filesystem-only (~4 ms for all four tools); the
+	// expensive capability probe (161-1772 ms each) runs for at most ONE tool,
+	// never as a sweep.
+	//
+	// Exactly one present → auto-select it silently, as this command has always
+	// done for Claude Code. Two or more → there is a real choice to make, so ask.
+	const fresh = !config.apiKey && !process.env.ANTHROPIC_API_KEY && config.aiProvider === undefined;
+	if (fresh) {
+		const present = listPresentLocalAgents(config.localAgentPath);
+		if (present.length === 1) {
+			const only = present[0];
+			if (await isLocalAgentUsable(only.id, { overridePath: config.localAgentPath })) {
+				await autoSelectLocalAgent(configDir, only.id);
+				return;
+			}
+			// Present but not runnable — fall through to the menu rather than
+			// pinning a provider that cannot generate.
+		} else if (present.length > 1) {
+			await handleLocalAgent(configDir, present);
+			return;
+		}
+	}
+```
+
+- [ ] **Step 3: Generalize `autoSelectClaudeCode`**
+
+Replace it wholesale:
+
+```ts
+/**
+ * Auto-selects the Local Agent provider after exactly one working tool was
+ * detected: summaries are generated by driving that tool through the user's own
+ * subscription, so no jollimemory-held API key is stored. Reached only when the
+ * tool already passed its capability probe, so it skips the picker and states
+ * the detection plainly, pointing at how to change it.
+ */
+async function autoSelectLocalAgent(configDir: string, tool: LocalAgentToolId): Promise<void> {
+	const label = localAgentToolLabel(tool);
+	await saveConfigScoped(
+		{ aiProvider: "local-agent", localAgentTool: tool } as Partial<JolliMemoryConfig>,
+		configDir,
+	);
+	console.log(`\n  ✓ Detected ${label} — using your subscription to generate summaries, no API key.`);
+	console.log(`  Summaries run through your local ${label} login.`);
+	console.log("  Change this anytime: 'jolli auth login', or 'jolli configure --set aiProvider=jolli'.");
+	console.log(`\n  Configuration saved to ${join(configDir, "config.json")}\n`);
+}
+```
+
+- [ ] **Step 4: Rewrite `handleLocalAgent` to take a candidate list and probe before saving**
+
+```ts
+/**
+ * Picks a local agent from a list and pins it as the provider. Summaries are
+ * generated by driving the chosen CLI through its own subscription login, so no
+ * jollimemory-held API key is stored.
+ *
+ * `candidates` is the detected list when any tool is present. When nothing is
+ * detected we still offer all four with a note, because reaching here means the
+ * user asked for a local agent explicitly and the command must not dead-end.
+ *
+ * The choice is capability-probed BEFORE it is written: this used to save any of
+ * the four unprobed and defer verification to `jolli doctor`, which let a
+ * known-broken configuration land in config.json.
+ */
+async function handleLocalAgent(configDir: string, candidates?: DetectedAgent[]): Promise<void> {
+	const detected = candidates ?? listPresentLocalAgents();
+	const none = detected.length === 0;
+	const list: DetectedAgent[] = none
+		? (Object.keys(LOCAL_AGENT_TOOLS) as LocalAgentToolId[]).map((id) => ({
+				id,
+				label: localAgentToolLabel(id),
+			}))
+		: detected;
+
+	for (;;) {
+		console.log("\n  Which local agent CLI would you like to use?\n");
+		if (none) console.log("    (None detected on this machine — pick one to configure anyway.)\n");
+		list.forEach((a, i) => {
+			console.log(`    ${i + 1}. ${a.label}`);
+		});
+
+		const answer = await promptText("\n  Choice [1]: ");
+		const index = Number.parseInt(answer.trim() || "1", 10) - 1;
+		const chosen = list[index] ?? list[0];
+
+		if (await isLocalAgentUsable(chosen.id, { overridePath: undefined })) {
+			await saveConfigScoped(
+				{ aiProvider: "local-agent", localAgentTool: chosen.id } as Partial<JolliMemoryConfig>,
+				configDir,
+			);
+			console.log(`\n  AI provider:       Local Agent (${chosen.label}) ✓`);
+			console.log(`  No API key needed — summaries run through your local ${chosen.label} login.`);
+			console.log(`  ${localAgentToolLoginHint(chosen.id)}`);
+			console.log(`\n  Configuration saved to ${join(configDir, "config.json")}\n`);
+			return;
+		}
+
+		console.log(`\n  ${chosen.label} isn't usable on this machine — nothing was saved.`);
+		if (list.length === 1) {
+			console.log("  Install it, then run 'jolli enable' again.\n");
+			return;
+		}
+	}
+}
+```
+
+Update the menu's `choice === "3"` branch to call `handleLocalAgent(configDir)` with no list, so it re-detects. Update imports: add `listPresentLocalAgents`, `isLocalAgentUsable`, `type DetectedAgent` from `../core/localagent/DetectAgents.js`, and `localAgentToolLoginHint` from `../core/localagent/ToolMeta.js`. Remove the now-unused `isClaudeCodeUsable` import and delete the function from `ClaudeExecutableResolver.ts` if Task 4 left it in place.
+
+**Verification hint:** `npm run test -w @jolli.ai/cli -- src/commands/EnableCommand.test.ts`
+
+---
+
+### Task 6: VS Code — `usesLocalAgent` in the configured gate
+
+**Files:**
+- Modify: `vscode/src/services/data/StatusDataService.ts:16,39`
+- Modify: `vscode/src/JolliMemoryBridge.ts:883`
+- Modify: `vscode/src/stores/StatusStore.ts:81-82`
+- Modify: `vscode/src/Extension.ts:1483`
+- Test: `vscode/src/stores/StatusStore.test.ts`, `vscode/src/Extension.test.ts`
+
+**Interfaces:**
+- Consumes: existing `derived.signedIn` / `derived.hasApiKey` snapshot plumbing.
+- Produces: `derived.usesLocalAgent: boolean` on the status snapshot.
+
+**Why this matters:** without this, choosing a local agent sets neither `signedIn` nor `hasApiKey`, so `configured` stays false, the onboarding panel reappears on every reload, and the user's choice never sticks. Do this before Tasks 7-9 or the card will appear to do nothing.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe("configured gate", () => {
+	it("is configured when the provider is local-agent with no key and no sign-in", () => {
+		const snap = buildSnapshot({ aiProvider: "local-agent" });
+		expect(snap.derived.usesLocalAgent).toBe(true);
+		expect(snap.derived.signedIn || snap.derived.hasApiKey || snap.derived.usesLocalAgent).toBe(true);
+	});
+
+	it("is not configured for anthropic with no key", () => {
+		const snap = buildSnapshot({ aiProvider: "anthropic" });
+		expect(snap.derived.usesLocalAgent).toBe(false);
+	});
+
+	it("stays configured after the agent binary disappears", () => {
+		// usesLocalAgent is keyed on config INTENT, not live presence: losing the
+		// binary must not silently discard the user's provider choice and dump
+		// them back into onboarding.
+		const snap = buildSnapshot({ aiProvider: "local-agent" });
+		expect(snap.derived.usesLocalAgent).toBe(true);
+	});
+});
+```
+
+- [ ] **Step 2: Derive the flag**
+
+`vscode/src/services/data/StatusDataService.ts` — add to the interface beside `hasApiKey`:
+
+```ts
+	readonly usesLocalAgent: boolean;
+```
+
+and to the object literal at line 39:
+
+```ts
+			usesLocalAgent: config?.aiProvider === "local-agent",
+```
+
+`vscode/src/JolliMemoryBridge.ts:883` — add beside `hasApiKey: !!config.apiKey,`:
+
+```ts
+			usesLocalAgent: config.aiProvider === "local-agent",
+```
+
+`vscode/src/stores/StatusStore.ts` — add `usesLocalAgent: false,` to the `EMPTY` derived block at line 81-82 and carry it through `rebuildSnapshot`.
+
+- [ ] **Step 3: Extend the gate**
+
+`vscode/src/Extension.ts:1483`:
+
+```ts
+			// A local-agent provider is self-sufficient — it drives the tool's own
+			// login and holds no jollimemory credential — so it counts as
+			// configured. Keyed on config intent, NOT live detection: if the user
+			// later uninstalls the agent we must not silently drop them back into
+			// onboarding and discard the choice. That failure belongs to
+			// `jolli doctor` and the generation error path.
+			const nextConfigured =
+				snap.derived.signedIn || snap.derived.hasApiKey || snap.derived.usesLocalAgent;
+```
+
+**Verification hint:** `npm run test:vscode -- src/stores/StatusStore.test.ts`
+
+---
+
+### Task 7: VS Code — detection under the activation barrier
+
+**Files:**
+- Modify: `vscode/src/Extension.ts` (near line 895 for state, 4048 for the barrier)
+- Modify: `vscode/src/views/SidebarMessages.ts:84`
+- Modify: `vscode/src/views/SidebarWebviewProvider.ts`
+- Test: `vscode/src/Extension.test.ts`
+
+**Interfaces:**
+- Consumes: `listPresentLocalAgents()` from Task 3; `currentConfigured` from Task 6.
+- Produces: `localAgents?: DetectedAgent[]` on the `init` message payload.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it("carries detected local agents on the first init message", async () => {
+	vi.spyOn(detect, "listPresentLocalAgents").mockReturnValue([{ id: "codex", label: "Codex" }]);
+	await activateExtension();
+	expect(firstInitMessage().localAgents).toEqual([{ id: "codex", label: "Codex" }]);
+});
+
+it("skips detection entirely when already configured", async () => {
+	const spy = vi.spyOn(detect, "listPresentLocalAgents");
+	await activateExtension({ configured: true });
+	expect(spy).not.toHaveBeenCalled();
+});
+
+it("degrades to an empty list when detection throws", async () => {
+	vi.spyOn(detect, "listPresentLocalAgents").mockImplementation(() => {
+		throw new Error("boom");
+	});
+	await activateExtension();
+	expect(firstInitMessage().localAgents).toEqual([]);
+});
+```
+
+- [ ] **Step 2: Add the state and the resolver**
+
+In `vscode/src/Extension.ts`, beside `currentConfigured` (line ~895):
+
+```ts
+	// Local agent tools present on this machine, for the onboarding card. Empty
+	// until resolved under the initialStateReady barrier, and left empty for
+	// already-configured users (who never see the card).
+	let currentLocalAgents: DetectedAgent[] = [];
+```
+
+Add the resolver next to `computeColdStartSignals`:
+
+```ts
+	/**
+	 * Presence-only sweep of the local agent CLIs, for the onboarding card.
+	 *
+	 * Filesystem work only — measured at ~4 ms for all four tools — which is why
+	 * it can sit on the activation path. The expensive capability probe
+	 * (161-1772 ms per tool; 3384 ms to sweep all four) is deliberately NOT run
+	 * here; it happens once, for the one tool the user picks.
+	 *
+	 * Skipped when already configured: those users never see the card.
+	 * Best-effort — any failure leaves the list empty, which renders today's
+	 * onboarding panel unchanged.
+	 */
+	const detectLocalAgents = (): void => {
+		if (currentConfigured) return;
+		try {
+			currentLocalAgents = listPresentLocalAgents();
+		} catch (err) {
+			log.warn("detectLocalAgents", "Detection failed", { error: (err as Error).message });
+			currentLocalAgents = [];
+		}
+	};
+```
+
+Call it in the existing `.finally` at line ~4057, before `resolveInitialStateReady()`:
+
+```ts
+	).finally(async () => {
+		await computeColdStartSignals();
+		detectLocalAgents();
+		resolveInitialStateReady();
+	});
+```
+
+- [ ] **Step 3: Put it on the wire**
+
+`vscode/src/views/SidebarMessages.ts` — beside `configured?: boolean` at line 84:
+
+```ts
+	/**
+	 * Local agent CLIs detected on this machine, in display order. Drives the
+	 * onboarding panel's local-agent card: empty (or absent) means no card and a
+	 * panel identical to the pre-feature one.
+	 *
+	 * Sent only on `init`. There is no change channel: the list matters only
+	 * while the onboarding panel is up, detection runs once per window, and a
+	 * user who installs an agent mid-panel can reload.
+	 */
+	readonly localAgents?: DetectedAgent[];
+```
+
+Add the `localAgent:selectError` variant beside `configured:changed` at line 941:
+
+```ts
+	| { readonly type: "localAgent:selectError"; readonly message: string }
+```
+
+In `vscode/src/views/SidebarWebviewProvider.ts`, thread `localAgents` into the `init` payload the same way `configured` is threaded, and add:
+
+```ts
+	/** Pushed only on the failure path of the onboarding local-agent selection. */
+	notifyLocalAgentSelectError(message: string): void {
+		void this.post({ type: "localAgent:selectError", message });
+	}
+```
+
+**Verification hint:** `npm run test:vscode -- src/Extension.test.ts`
+
+---
+
+### Task 8: VS Code — the onboarding card
+
+**Files:**
+- Modify: `vscode/src/views/SidebarHtmlBuilder.ts:98-119`
+- Modify: `vscode/src/views/SidebarCssBuilder.ts`
+- Modify: `vscode/src/views/SidebarScriptBuilder.ts` (element refs ~246, init handler ~800)
+- Test: `vscode/src/views/SidebarHtmlBuilder.test.ts`, `vscode/src/views/SidebarScriptBuilder.test.ts`
+
+**Interfaces:**
+- Consumes: `localAgents` from the `init` message (Task 7).
+- Produces: DOM ids `onboarding-localagent-block`, `onboarding-localagent-select`, `onboarding-localagent-btn`, `onboarding-localagent-error`; CSS classes `ob-select`, `ob-hint`, `ob-error`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe("onboarding local-agent card", () => {
+	it("renders the block hidden by default", () => {
+		const html = buildSidebarHtml("n", "c", "u", strings);
+		expect(html).toContain('id="onboarding-localagent-block"');
+		expect(html).toMatch(/onboarding-localagent-block[^>]*class="[^"]*hidden/);
+	});
+
+	it("uses the exact approved copy", () => {
+		const html = buildSidebarHtml("n", "c", "u", strings);
+		expect(html).toContain("Use your local agent tool");
+		expect(html).toContain(
+			"Use your local agent tool for AI summarization. Memories are stored locally only.",
+		);
+		expect(html).toContain("Use Local Agent Tool");
+		expect(html).toContain("Make sure you're signed in to the tool.");
+	});
+
+	it("carries no inline style or inline handler (CSP)", () => {
+		const html = buildSidebarHtml("n", "c", "u", strings);
+		expect(html).not.toMatch(/<[^>]*\sstyle="/);
+		expect(html).not.toMatch(/\son(click|change)=/);
+	});
+});
+```
+
+Script-builder tests (driven through the existing harness that dispatches an `init` message):
+
+```ts
+it("shows the card and moves the RECOMMENDED badge when agents are present", () => {
+	postInit({ localAgents: [{ id: "codex", label: "Codex" }] });
+	expect(el("onboarding-localagent-block").classList.contains("hidden")).toBe(false);
+	expect(el("onboarding-apikey-card").querySelector(".ob-badge")).toBeNull();
+});
+
+it("keeps the card hidden and the badge in place when none are present", () => {
+	postInit({ localAgents: [] });
+	expect(el("onboarding-localagent-block").classList.contains("hidden")).toBe(true);
+	expect(el("onboarding-apikey-card").querySelector(".ob-badge")).not.toBeNull();
+});
+
+it("populates options in order with the first pre-selected", () => {
+	postInit({
+		localAgents: [
+			{ id: "codex", label: "Codex" },
+			{ id: "opencode", label: "OpenCode" },
+		],
+	});
+	const opts = [...el("onboarding-localagent-select").options];
+	expect(opts.map((o) => o.value)).toEqual(["codex", "opencode"]);
+	expect(el("onboarding-localagent-select").value).toBe("codex");
+});
+```
+
+- [ ] **Step 2: Add the skeleton**
+
+In `vscode/src/views/SidebarHtmlBuilder.ts`, insert immediately after the `<hr class="ob-divider" />` at line 97 and give the existing API-key `<section>` the id `onboarding-apikey-card`, moving its `<span class="ob-badge">RECOMMENDED</span>` into the new block:
+
+```html
+      <div class="ob-localagent hidden" id="onboarding-localagent-block">
+        <section class="ob-card ob-card--recommended">
+          <span class="ob-badge">RECOMMENDED</span>
+          <div class="ob-card-row">
+            <i class="codicon codicon-key ob-card-icon" aria-hidden="true"></i>
+            <div class="ob-card-text">
+              <h3 class="ob-card-title">Use your local agent tool</h3>
+              <p class="ob-card-desc">Use your local agent tool for AI summarization. Memories are stored locally only.</p>
+            </div>
+          </div>
+        </section>
+        <p class="ob-hint">Make sure you're signed in to the tool.</p>
+        <label class="ob-select-label" for="onboarding-localagent-select">Agent tool</label>
+        <select class="ob-select" id="onboarding-localagent-select"></select>
+        <p class="ob-error hidden" id="onboarding-localagent-error" role="alert"></p>
+        <button type="button" id="onboarding-localagent-btn" class="ob-btn ob-btn--primary">Use Local Agent Tool</button>
+        <div class="ob-or"><span>OR</span></div>
+      </div>
+```
+
+The API-key card keeps its position and copy but loses `ob-card--recommended` and its badge; when `localAgents` is empty the script re-adds both (Step 4).
+
+- [ ] **Step 3: Styles**
+
+In `vscode/src/views/SidebarCssBuilder.ts`, add rules for `.ob-select`, `.ob-select-label`, `.ob-hint`, `.ob-error` using VS Code theme variables (`--vscode-dropdown-background`, `--vscode-dropdown-border`, `--vscode-dropdown-foreground`, `--vscode-descriptionForeground`, `--vscode-errorForeground`), matching the existing `.apikey-input` / `.apikey-error` rules in that file for sizing and spacing.
+
+- [ ] **Step 4: Wire the script**
+
+In `vscode/src/views/SidebarScriptBuilder.ts`, add element refs beside line 246, and render on `init`:
+
+```js
+  function applyLocalAgents(agents) {
+    const list = Array.isArray(agents) ? agents : [];
+    localAgentSelect.replaceChildren();
+    if (list.length === 0) {
+      // No agents: hide the block and restore the RECOMMENDED badge to the
+      // API key card, so the panel is identical to the pre-feature one.
+      localAgentBlock.classList.add('hidden');
+      apikeyCard.classList.add('ob-card--recommended');
+      apikeyBadge.classList.remove('hidden');
+      return;
+    }
+    for (const a of list) {
+      const opt = document.createElement('option');
+      opt.value = a.id;
+      opt.textContent = a.label;
+      localAgentSelect.appendChild(opt);
+    }
+    localAgentSelect.value = list[0].id;
+    localAgentBlock.classList.remove('hidden');
+    apikeyCard.classList.remove('ob-card--recommended');
+    apikeyBadge.classList.add('hidden');
+  }
+```
+
+Call `applyLocalAgents(msg.localAgents)` from the `init` handler.
+
+**Verification hint:** `npm run test:vscode -- src/views/SidebarHtmlBuilder.test.ts src/views/SidebarScriptBuilder.test.ts`
+
+---
+
+### Task 9: VS Code — commit the selection
+
+**Files:**
+- Modify: `vscode/src/Extension.ts` (register beside `jollimemory.saveAnthropicApiKey` at line 3774)
+- Modify: `vscode/src/views/SidebarScriptBuilder.ts`
+- Test: `vscode/src/Extension.test.ts`, `vscode/src/views/SidebarScriptBuilder.test.ts`
+
+**Interfaces:**
+- Consumes: `isLocalAgentUsable(tool, opts)` (Task 3); `notifyLocalAgentSelectError` (Task 7); `LOCAL_AGENT_TOOLS` for validation.
+- Produces: command `jollimemory.selectLocalAgentTool` taking one `string` argument.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe("jollimemory.selectLocalAgentTool", () => {
+	it("saves provider and tool when the probe passes", async () => {
+		vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(true);
+		await vscode.commands.executeCommand("jollimemory.selectLocalAgentTool", "codex");
+		expect(savedConfig).toMatchObject({ aiProvider: "local-agent", localAgentTool: "codex" });
+	});
+
+	it("writes nothing and reports an error when the probe fails", async () => {
+		vi.spyOn(detect, "isLocalAgentUsable").mockResolvedValue(false);
+		await vscode.commands.executeCommand("jollimemory.selectLocalAgentTool", "codex");
+		expect(savedConfig).toBeUndefined();
+		expect(notifyLocalAgentSelectError).toHaveBeenCalledWith(expect.stringContaining("Codex"));
+	});
+
+	it("rejects an unknown tool id without writing", async () => {
+		await vscode.commands.executeCommand("jollimemory.selectLocalAgentTool", "evil-tool");
+		expect(savedConfig).toBeUndefined();
+		expect(notifyLocalAgentSelectError).toHaveBeenCalled();
+	});
+});
+```
+
+- [ ] **Step 2: Register the command**
+
+```ts
+		// Onboarding local-agent selection — wired from the sidebar card's
+		// "Use Local Agent Tool" button. Mirrors saveAnthropicApiKey: touches only
+		// the provider fields, and a successful save flips configured=true via
+		// statusStore.refresh, which retires the panel through the existing
+		// configured:changed plumbing — no success ack needed.
+		//
+		// The capability probe runs HERE rather than during detection: the
+		// onboarding sweep is presence-only (~4 ms) precisely so that the
+		// expensive probe (161-1772 ms) is paid once, for the one tool the user
+		// actually chose.
+		vscode.commands.registerCommand(
+			"jollimemory.selectLocalAgentTool",
+			async (rawTool: unknown) => {
+				log.info("cmd", "selectLocalAgentTool invoked");
+				// Webview input is untrusted — allow-list against the tool registry.
+				const tool =
+					typeof rawTool === "string" && rawTool in LOCAL_AGENT_TOOLS
+						? (rawTool as LocalAgentToolId)
+						: null;
+				if (!tool) {
+					sidebarProvider.notifyLocalAgentSelectError("Unknown local agent tool.");
+					return;
+				}
+				const label = localAgentToolLabel(tool);
+				try {
+					const cfg = await loadConfig();
+					if (!(await isLocalAgentUsable(tool, { overridePath: cfg?.localAgentPath }))) {
+						sidebarProvider.notifyLocalAgentSelectError(
+							`Found ${label}, but it didn't respond as expected. Try another tool.`,
+						);
+						return;
+					}
+					await saveConfigScoped(
+						{ aiProvider: "local-agent", localAgentTool: tool },
+						getGlobalConfigDir(),
+					);
+					await statusStore.refresh();
+				} catch (err) {
+					const message =
+						err instanceof Error ? err.message : `Failed to select ${label}.`;
+					log.error("cmd", `selectLocalAgentTool failed: ${message}`);
+					sidebarProvider.notifyLocalAgentSelectError(message);
+				}
+			},
+		),
+```
+
+- [ ] **Step 3: Wire the button and the error**
+
+In `vscode/src/views/SidebarScriptBuilder.ts`:
+
+```js
+  localAgentBtn.addEventListener('click', function() {
+    const tool = localAgentSelect.value;
+    if (!tool) return;
+    localAgentBtn.disabled = true;
+    localAgentSelect.disabled = true;
+    localAgentBtn.textContent = 'Checking…';
+    localAgentError.classList.add('hidden');
+    localAgentError.textContent = '';
+    vscode.postMessage({
+      type: 'command',
+      command: 'jollimemory.selectLocalAgentTool',
+      args: [tool],
+    });
+  });
+```
+
+and in the message switch, beside `case 'apikey:saveError'`:
+
+```js
+      case 'localAgent:selectError':
+        // Only restore the control if the onboarding panel is still up; a
+        // success path that raced past us has already hidden it.
+        if (!onboardingPanel.classList.contains('hidden')) {
+          localAgentBtn.disabled = false;
+          localAgentSelect.disabled = false;
+          localAgentBtn.textContent = 'Use Local Agent Tool';
+          localAgentError.textContent =
+            typeof msg.message === 'string' && msg.message.length > 0
+              ? msg.message
+              : 'Could not use that tool.';
+          localAgentError.classList.remove('hidden');
+        }
+        break;
+```
+
+**Verification hint:** `npm run test:vscode -- src/Extension.test.ts src/views/SidebarScriptBuilder.test.ts`
+
+---
+
+### Task 10: Settings — Agent tool availability check
+
+**Files:**
+- Modify: `vscode/src/views/SettingsHtmlBuilder.ts:163-170`
+- Modify: `vscode/src/views/SettingsScriptBuilder.ts` (refs ~30, validation ~358-393, listener ~435, message switch ~582)
+- Modify: `vscode/src/views/SettingsWebviewPanel.ts`
+- Test: `vscode/src/views/SettingsScriptBuilder.test.ts`, `vscode/src/views/SettingsWebviewPanel.test.ts`
+
+**Interfaces:**
+- Consumes: `isLocalAgentUsable(tool, opts)` (Task 3); the existing `hasErrors` / `validateAll()` / `updateApplyBtn()` seam.
+- Produces: webview→host `{ type: "probeLocalAgent", tool: string }`; host→webview `{ type: "localAgentProbeResult", tool: string, available: boolean }`.
+
+**The dropdown keeps listing all four** — this is the advanced surface and filtering would hide the tool a user is about to install. What changes is that the selection is verified and an unusable configuration cannot be saved.
+
+**Two rules that are easy to get wrong:**
+1. **Scope the block.** "Apply Changes" is one global button ([`SettingsHtmlBuilder.ts:293`](../../../vscode/src/views/SettingsHtmlBuilder.ts)) that saves every setting across all tabs. An unavailable agent tool must not block an unrelated Memory Bank path edit — so the error only arms when `aiProvider === "local-agent"`, which is exactly when `localAgentTool` is read at all ([`Types.ts:1162`](../../../cli/src/Types.ts): "Ignored unless `aiProvider === 'local-agent'`").
+2. **In-flight probes never arm `hasErrors`.** Only a confirmed-unavailable result does, or a slow probe makes Apply flicker to disabled.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe("Settings agent tool availability", () => {
+	it("disables Apply when the selected tool is unavailable and provider is local-agent", () => {
+		setProvider("local-agent");
+		selectTool("cursor-agent");
+		receive({ type: "localAgentProbeResult", tool: "cursor-agent", available: false });
+		expect(applyBtn.disabled).toBe(true);
+		expect(el("localAgentStatus").textContent).toContain("not found");
+	});
+
+	it("does NOT disable Apply while the probe is in flight", () => {
+		setProvider("local-agent");
+		selectTool("cursor-agent"); // probe dispatched, no reply yet
+		expect(applyBtn.disabled).toBe(false);
+		expect(el("localAgentStatus").textContent).toContain("Checking");
+	});
+
+	it("does NOT disable Apply when the provider is not local-agent", () => {
+		setProvider("anthropic");
+		selectTool("cursor-agent");
+		receive({ type: "localAgentProbeResult", tool: "cursor-agent", available: false });
+		expect(applyBtn.disabled).toBe(false);
+	});
+
+	it("clears the error when the provider switches away from local-agent", () => {
+		setProvider("local-agent");
+		selectTool("cursor-agent");
+		receive({ type: "localAgentProbeResult", tool: "cursor-agent", available: false });
+		setProvider("jolli");
+		expect(applyBtn.disabled).toBe(false);
+	});
+
+	it("ignores a stale reply for a tool that is no longer selected", () => {
+		setProvider("local-agent");
+		selectTool("cursor-agent");
+		selectTool("codex");
+		receive({ type: "localAgentProbeResult", tool: "cursor-agent", available: false });
+		expect(applyBtn.disabled).toBe(false);
+	});
+});
+```
+
+- [ ] **Step 2: Add the status line**
+
+`vscode/src/views/SettingsHtmlBuilder.ts`, inside the `data-card="local-agent"` panel, between the `<select>` and the existing `.section-hint`:
+
+```html
+        <p class="local-agent-status" id="localAgentStatus"></p>
+```
+
+- [ ] **Step 3: Handle the probe in the panel host**
+
+In `vscode/src/views/SettingsWebviewPanel.ts`, in the webview message switch:
+
+```ts
+			case "probeLocalAgent": {
+				const raw = (msg as { tool?: unknown }).tool;
+				const tool =
+					typeof raw === "string" && raw in LOCAL_AGENT_TOOLS ? (raw as LocalAgentToolId) : null;
+				if (!tool) return;
+				const cfg = await loadConfig();
+				const available = await isLocalAgentUsable(tool, { overridePath: cfg?.localAgentPath });
+				void panel.webview.postMessage({ type: "localAgentProbeResult", tool, available });
+				return;
+			}
+```
+
+- [ ] **Step 4: Wire validation in the script**
+
+In `vscode/src/views/SettingsScriptBuilder.ts`:
+
+```js
+  // Availability of the currently-selected agent tool. null = unknown / probe
+  // in flight. Only a confirmed false arms hasErrors, so a slow probe never
+  // flickers Apply to disabled.
+  var localAgentAvailable = null;
+  var localAgentProbeTool = null;
+
+  function probeLocalAgent() {
+    var tool = localAgentToolSelect.value;
+    localAgentProbeTool = tool;
+    localAgentAvailable = null;
+    localAgentStatus.textContent = 'Checking…';
+    localAgentStatus.classList.remove('error');
+    updateApplyBtn();
+    vscode.postMessage({ type: 'probeLocalAgent', tool: tool });
+  }
+
+  // Only meaningful when the provider actually reads localAgentTool. Apply is a
+  // single global button saving every tab, so an unusable agent tool must not
+  // block an unrelated Memory Bank edit.
+  function localAgentBlocks() {
+    return aiProviderSelect.value === 'local-agent' && localAgentAvailable === false;
+  }
+```
+
+Add `|| localAgentBlocks()` to the `hasErrors` computation inside `validateAll()`, call `probeLocalAgent()` from the `localAgentToolSelect` change listener at line ~435 and on panel open, add a `change` listener on `aiProviderSelect` that calls `updateApplyBtn()` (and `probeLocalAgent()` when switching *to* local-agent), and handle the reply in the message switch:
+
+```js
+      case 'localAgentProbeResult':
+        // Ignore a stale reply for a tool the user has already moved off.
+        if (msg.tool !== localAgentProbeTool) break;
+        localAgentAvailable = !!msg.available;
+        localAgentStatus.textContent = msg.available
+          ? ''
+          : localAgentToolSelect.options[localAgentToolSelect.selectedIndex].textContent +
+            ' not found on this machine. Install it, or pick another tool.';
+        localAgentStatus.classList.toggle('error', !msg.available);
+        updateApplyBtn();
+        break;
+```
+
+Add a `.local-agent-status` / `.local-agent-status.error` rule to `SettingsCssBuilder.ts` using `--vscode-descriptionForeground` and `--vscode-errorForeground`.
+
+**Verification hint:** `npm run test:vscode -- src/views/SettingsScriptBuilder.test.ts src/views/SettingsWebviewPanel.test.ts`
+
+---
+
+### Task 11: Full gate and commits
+
+**Files:** none — verification and version control only.
+
+- [ ] **Step 1: Lint and auto-fix**
+
+```bash
+npm run lint:fix
+npm run lint
+```
+
+Expected: clean. Biome runs with `--error-on-warnings`, so warnings fail CI.
+
+- [ ] **Step 2: Run the full gate**
+
+```bash
+npm run all
+```
+
+Expected: clean → build → lint → test all pass. CLI coverage must hold at ≥97% statements / ≥96% branches / ≥97% functions / ≥97% lines.
+
+If a coverage line fails, add the missing test — do **not** add a `v8 ignore` to paper over it. If an exemption is genuinely warranted, use the block form `/* v8 ignore start */` … `/* v8 ignore stop */`; the single-line `ignore next` form does not work in this repo.
+
+- [ ] **Step 3: Verify no forbidden trailers will be introduced**
+
+Commit messages must carry `Signed-off-by:` and must **not** carry `Co-Authored-By: Claude …` or a `🤖 Generated with …` footer.
+
+- [ ] **Step 4: Commit in three logical commits**
+
+```bash
+git add cli/src/core/localagent/
+git commit -s -m "Add presence-only local agent detection
+
+Split 'is this tool on disk?' from 'does it run?'. A full four-tool
+capability sweep costs 3384ms; presence detection costs 4ms, which is what
+makes it affordable on the VS Code activation path.
+
+Also extracts backend registration out of LlmClient so the registry is no
+longer populated as a side effect of importing an unrelated module."
+
+git add cli/src/commands/
+git commit -s -m "Probe the configured local agent, not always Claude Code
+
+canGenerateNow, the R3 repair prompt, and the guided front door's status
+line all probed 'claude' regardless of localAgentTool, so a Codex user was
+told generation was broken and sent to repair a tool they never selected.
+Generation itself already honored the setting; only the diagnostics did not.
+
+Also generalizes 'jolli enable' auto-select to all four tools: one present
+tool is auto-selected as before, two or more now prompt."
+
+git add vscode/src/
+git commit -s -m "Offer installed local agents during VS Code onboarding
+
+The onboarding panel showed only the API key and Jolli sign-in paths even
+when the user already had an agent CLI installed. It now leads with a
+local agent card listing the detected tools, and Settings refuses to save
+an agent tool that is not available."
+```
+
+- [ ] **Step 5: Confirm the tree is clean**
+
+```bash
+git status --short
+git log --oneline -3
+git log -1 --format='%B' | grep -c 'Signed-off-by:'
+```
+
+Expected: empty status, three new commits, sign-off present.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+| --- | --- |
+| Presence, not usability | 1, 3 |
+| Component 1 — detection layer | 1, 2, 3 |
+| Component 2 — `configured` gate | 6 |
+| Component 3 — activation barrier | 7 |
+| Component 4 — the card | 8 |
+| Component 5 — commit | 9 |
+| Component 6 — CLI `jolli enable` | 5 |
+| Component 7 — Settings availability | 10 |
+| Component 8 — de-hardcode health checks | 4 |
+| Surface coverage table | 4, 5 (`jolli doctor` correctly untouched) |
+| Error handling table | 3 (swallow), 5 (probe failures), 9 (validation), 10 (scope + in-flight) |
+| Testing section | every task, plus the gate in 11 |
+
+**Type consistency:** `DetectedAgent { id, label }` is defined in Task 3 and consumed unchanged in Tasks 5, 7, 8. `isLocalAgentUsable(tool, opts)` is async everywhere (Tasks 3, 4, 5, 9, 10) — which is why Task 4 makes `canGenerateNow` async and calls out updating its callers. `isPresent` exists at two levels with different shapes by design: `isPresent(spec, opts)` on the resolver (Task 1) and `isPresent(overridePath?)` on the backend interface (Task 2).
+
+**Known follow-up, deliberately out of scope:** IntelliJ has its own copy of the provider-selection UI and is untouched here. It shares `config.json`, so a local-agent choice made in the CLI or VS Code is honored by it — but IntelliJ offers no local-agent picker of its own.

--- a/docs/superpowers/specs/2026-07-28-vscode-onboarding-local-agent-design.md
+++ b/docs/superpowers/specs/2026-07-28-vscode-onboarding-local-agent-design.md
@@ -1,0 +1,519 @@
+# VS Code onboarding: prefer a locally installed agent
+
+**Date:** 2026-07-28
+**Status:** Design approved, pending implementation plan
+
+## Problem
+
+The VS Code sidebar shows its onboarding panel — "Use your Anthropic API key" /
+"Sign in to Jolli" — whenever the user has neither an Anthropic API key nor a
+Jolli sign-in. It never considers a third, cheaper option the user may already
+have: a locally installed agent CLI (Claude Code, Codex, Cursor, OpenCode) that
+can generate summaries through the user's own subscription with no API key and
+no account.
+
+The CLI already prefers that option. On a truly fresh config,
+[`EnableCommand.ts`](../../../cli/src/commands/EnableCommand.ts) probes
+`isClaudeCodeUsable()` and silently pins `aiProvider: "local-agent"`, skipping
+the provider menu entirely. VS Code never got the equivalent, so the two
+surfaces disagree about what a first run looks like.
+
+## Goals
+
+- Add a third onboarding condition: show the API-key / sign-in panel only when
+  the user *also* has no usable local agent.
+- When local agents are present, surface them first as the recommended path and
+  let the user pick which one.
+- Keep the panel byte-identical to today when no local agent is present.
+
+The same preference is applied consistently across all three surfaces that
+choose a local agent:
+
+- **Sidebar onboarding** (the trigger for this work) — new card, always asks.
+- **CLI `jolli enable`** — generalize the Claude-only auto-select to all four
+  tools, and ask when more than one is present.
+- **Settings → AI Summary → Agent tool** — verify the picked tool is actually
+  available, and refuse to save a configuration that cannot run.
+
+Plus one prerequisite repair: three local-agent health checks still probe
+`claude` regardless of which tool is configured. That is a live bug today, and
+promoting non-Claude tools to a mainstream path makes it unavoidable. See
+Component 8.
+
+## Non-goals
+
+- Detecting whether the user is *signed in* to the chosen tool. See
+  "Presence, not usability" below.
+- Auto-installing or offering to install a missing agent.
+
+## One deliberate asymmetry
+
+VS Code always shows the picker, even when exactly one agent is present; the CLI
+auto-selects silently in that case. This is a decided difference, not an
+oversight, and should not be "fixed" into consistency:
+
+- The sidebar is a persistent surface the user is already looking at. Rendering
+  a pre-selected dropdown costs nothing and makes the choice legible.
+- `jolli enable` is a one-shot terminal command. An interactive prompt there is
+  a stop-the-world event, so the zero-friction path — which the command already
+  had for Claude Code — is worth preserving whenever there is nothing to
+  actually decide.
+
+Both surfaces ask the moment there is a real choice to make (two or more
+present), and neither ever picks *between* tools on the user's behalf.
+
+## Design
+
+### Presence, not usability
+
+Detection answers "is this tool on disk?", not "does this tool work?". Those are
+separate questions with wildly different costs, and this repo has already split
+them once: MCP host registration is gated on a pure-filesystem `isXPresent`,
+while the SQLite-backed `isXInstalled` feeds only discovery and status.
+
+The cost difference is measured, not assumed. On a machine with all four tools
+installed, a full `discoverExecutable()` sweep costs **3384 ms**:
+
+| Tool | `discoverExecutable()` | Result |
+| --- | ---: | --- |
+| claude-code | 794 ms | v2.1.220 |
+| codex | 161 ms | codex-cli |
+| cursor-agent | 656 ms | v2026.07.23 |
+| opencode | 1772 ms | v1.18.5 |
+| **Total** | **3384 ms** | |
+
+On a machine with none installed the same sweep costs **4 ms** — `which -a`
+returns nothing, `knownPaths` all miss, and not one probe subprocess is spawned.
+All of the cost is the `--version` capability probe, none of it is the lookup.
+
+Two consequences drive the design:
+
+1. **The slow case is the well-equipped user, not the empty machine.** Blocking
+   first paint on a full sweep would penalize exactly the users the feature is
+   for, and leave the no-agent user — who gets nothing from it — unaffected.
+2. **The probe's 10 s timeout is per *candidate*, not per tool.** `which -a`
+   plus `knownPaths` yields 6 candidates on the reference machine (claude 2,
+   codex 1, cursor 1, opencode 2), so the pathological ceiling is 60 s, not 40 s.
+
+So onboarding detection is **presence-only**, and the capability probe moves to
+the moment the user commits to a tool.
+
+### Component 1 — `cli/src/core/localagent/`
+
+**`BuiltinBackends.ts` (new).** The four `registerBackend(...)` calls move here
+from [`LlmClient.ts`](../../../cli/src/core/LlmClient.ts) into a self-registering
+module. Today the registry is populated as a side effect of importing
+`LlmClient`; any other consumer calling `getBackend()` without that import
+silently sees an empty registry. `LlmClient` and the detector both import this
+module, making the coupling explicit and order-independent.
+
+**`LocalAgentBackend.isPresent()` (new interface method).**
+
+```ts
+isPresent(overridePath?: string): boolean;
+```
+
+Each backend implements it in one line against its existing module-private
+`*_SPEC`, via a new `isPresent(spec, opts)` helper in `ExecutableResolver.ts`
+that mirrors `resolveExecutable`'s option and platform defaults but stops after
+candidate enumeration. `ClaudeCodeBackend` delegates to a new
+`isClaudeCodePresent()` exported from `ClaudeExecutableResolver.ts`, alongside
+the existing `isClaudeCodeUsable()`.
+
+**`DetectAgents.ts` (new).**
+
+```ts
+export interface DetectedAgent {
+    readonly id: LocalAgentToolId;
+    readonly label: string;   // from LOCAL_AGENT_TOOLS
+}
+
+export function listPresentLocalAgents(overridePath?: string): DetectedAgent[];
+```
+
+Iterates `LOCAL_AGENT_TOOLS` key order — Claude Code, Codex, Cursor, OpenCode —
+and keeps the ones reporting present.
+
+That map, **not** the backend registry, is the ordering authority. The
+precedent is the Settings panel's own "Agent tool" dropdown, which the
+onboarding dropdown must visually agree with: `LOCAL_AGENT_TOOL_OPTIONS` in
+[`SettingsHtmlBuilder.ts:23`](../../../vscode/src/views/SettingsHtmlBuilder.ts)
+is built by mapping straight over `Object.keys(LOCAL_AGENT_TOOLS)`. Deriving
+onboarding from the same map means the two dropdowns cannot drift apart.
+
+`BackendRegistry` is deliberately not used for this: it registers in a different
+order (Claude, **Cursor**, **Codex**, OpenCode), and its own docstring already
+designates `LOCAL_AGENT_TOOLS` as the source for UI and CLI tool lists. Pure filesystem work, no
+subprocess, no timeout budget, no cache — measured at ~4 ms, which is cheaper
+than any cache would be to maintain. Returns `[]` on a machine with nothing
+installed.
+
+No version string is carried: the dropdown shows labels only, and obtaining a
+version requires the very probe this path exists to avoid.
+
+### Component 2 — the `configured` gate
+
+[`Extension.ts:1483`](../../../vscode/src/Extension.ts) currently computes:
+
+```ts
+const nextConfigured = snap.derived.signedIn || snap.derived.hasApiKey;
+```
+
+Choosing a local agent sets neither, so the onboarding panel would reappear on
+every reload and the choice would never stick. Extend it:
+
+```ts
+const nextConfigured =
+    snap.derived.signedIn || snap.derived.hasApiKey || snap.derived.usesLocalAgent;
+```
+
+`usesLocalAgent: config?.aiProvider === "local-agent"` is derived in
+[`StatusDataService.ts`](../../../vscode/src/services/data/StatusDataService.ts)
+and [`JolliMemoryBridge.ts`](../../../vscode/src/JolliMemoryBridge.ts) alongside
+the existing `hasApiKey`.
+
+Keyed on **config intent, not live presence**, on purpose. If the user later
+uninstalls the agent, we must not silently drop them back into onboarding and
+discard their choice — that failure belongs to `jolli doctor` and the generation
+error path, both of which already handle it.
+
+### Component 3 — detection under the activation barrier
+
+`listPresentLocalAgents()` runs in the `.finally` block of `initialLoad()` in
+[`Extension.ts:4048`](../../../vscode/src/Extension.ts), beside the existing
+`computeColdStartSignals()` call — the same best-effort-under-the-barrier
+pattern. The result is therefore settled before `resolveInitialStateReady()`
+fires, so the first `init` message the webview receives already carries it and
+the panel never reshuffles.
+
+Gated on `!currentConfigured`: configured users, the overwhelming majority of
+activations, skip it entirely. At ~4 ms the gate is a formality rather than an
+optimization, but it keeps the activation path honest.
+
+The result rides on the existing `init` payload as
+`localAgents?: DetectedAgent[]`. No `localAgents:changed` push message: the list
+only matters while the panel is up, detection runs once, and a user who installs
+an agent mid-session while sitting on the onboarding panel can reload the
+window. Adding a change channel for that would be speculative.
+
+Failure is swallowed to `[]` — a detection error degrades to today's panel, never
+to a broken one.
+
+### Component 4 — the card
+
+A third card takes first position in the onboarding panel and inherits the
+`RECOMMENDED` badge from the API-key card, which keeps its position and copy but
+loses the badge:
+
+```
+Get started with Jolli Memory
+─────────────────────────────────────────
+┌ 🔑  Use your local agent tool  RECOMMENDED ┐
+│ Use your local agent tool for AI            │
+│ summarization. Memories are stored          │
+│ locally only.                               │
+└─────────────────────────────────────────────┘
+  Make sure you're signed in to the tool.
+  [ Claude Code                            ▾ ]
+  [          Use Local Agent Tool            ]
+                 ── OR ──
+┌ 🔑  Use your Anthropic API key ┐
+  [ Configure API Key ]
+┌ ☁️  Sign in to Jolli ┐
+  [ Sign In / Sign Up ]
+```
+
+Skeleton lives in
+[`SidebarHtmlBuilder.ts`](../../../vscode/src/views/SidebarHtmlBuilder.ts);
+the `<option>` list is populated by
+[`SidebarScriptBuilder.ts`](../../../vscode/src/views/SidebarScriptBuilder.ts)
+via DOM API, per the file's existing "skeleton contains no user-supplied data"
+contract.
+
+- Card, hint, `<select>` and button live in one container toggled by the
+  `.hidden` class. `localAgents.length === 0` hides the container, leaves the
+  `RECOMMENDED` badge on the API-key card, and yields a panel identical to
+  today's.
+- The `<select>` lists only present agents in `LOCAL_AGENT_TOOLS` order, first
+  pre-selected. Labels come from the same map, so both the order and the wording
+  match the Settings panel's "Agent tool" dropdown — the two are the same control
+  in two places and must not read differently.
+- The hint line — "Make sure you're signed in to the tool." — is permanent, not
+  an error state. Presence detection cannot see auth, and the honest thing is to
+  say so before the user commits rather than after generation fails.
+
+Repo conventions that apply here and have each broken this webview before:
+visibility toggles use the `.hidden` class, never the HTML `hidden` attribute or
+`el.hidden`; no inline `style=` or inline event handlers (the webview CSP drops
+both silently); and no backticks inside the builder's returned template literal,
+including in comments.
+
+### Component 5 — commit
+
+The button posts `{ type: "onboardingSelectLocalAgent", tool }`. The handler in
+`Extension.ts` mirrors the existing inline API-key save at
+[`Extension.ts:3758`](../../../vscode/src/Extension.ts):
+
+1. Validate `tool` against `LOCAL_AGENT_TOOLS` — webview input is untrusted.
+2. Disable the button, label it `Checking…`.
+3. `await getBackend(tool).discoverExecutable(config.localAgentPath)` — the real
+   capability probe, for the selected tool only. Measured 161–1772 ms.
+4. On success: `saveConfigScoped({ aiProvider: "local-agent", localAgentTool: tool })`
+   → `statusStore.refresh()` → `configured` flips → main UI.
+5. On `LocalAgentSetupError`: post the failure back, render it inline in the card
+   ("Found Claude Code, but it didn't respond as expected. Try another tool."),
+   re-enable the dropdown and button. Nothing is written to config.
+
+This is where the 3384 ms of the old design goes: one probe of one tool, behind a
+spinner the user asked for, instead of a full sweep blocking every first paint.
+The tradeoff is that the dropdown can list a tool that turns out unusable — one
+click and an honest error. The rejected alternative bought nothing in exchange
+for the delay: it merely moved the same failure from the click to the first
+summary generation.
+
+### Component 6 — CLI `jolli enable`
+
+[`EnableCommand.ts`](../../../cli/src/commands/EnableCommand.ts) today has a
+Claude-Code-only fast path:
+
+```ts
+const fresh = !config.apiKey && !process.env.ANTHROPIC_API_KEY && config.aiProvider === undefined;
+if (fresh && isClaudeCodeUsable({ overridePath: config.localAgentPath })) {
+    await autoSelectClaudeCode(configDir);
+    return;
+}
+```
+
+Generalize it to all four tools while preserving its shape — `fresh` stays the
+guard, so an existing key or a deliberate provider choice is still never
+second-guessed:
+
+| Present tools (fresh config) | Behavior |
+| --- | --- |
+| 0 | Fall through to the existing provider menu, unchanged |
+| 1 | Probe it. Usable → auto-select silently, as today. Not usable → fall through to the menu |
+| 2+ | New prompt listing the present tools; probe the chosen one, then save |
+
+The single-tool branch keeps today's exact semantics (presence *and* a passing
+probe before anything is written), just no longer hard-coded to Claude Code. The
+probe is affordable here because at most one runs, and only on a fresh config —
+the same condition that gates it today.
+
+`autoSelectClaudeCode()` becomes `autoSelectLocalAgent(configDir, tool)`, with
+its hard-coded "Detected Claude Code" copy parameterized off
+`localAgentToolLabel(tool)`.
+
+**Explicit menu choice 3** ("Use a local agent CLI") lists **only present
+tools**, matching the sidebar dropdown. When none are present it falls back to
+listing all four plus a one-line note that none were detected — the user asked
+for a local agent explicitly, so the command must not dead-end. The chosen tool
+is probed before saving; on failure the error prints and the picker repeats,
+rather than saving a configuration known not to work.
+
+This replaces `handleLocalAgent()`'s current behavior of saving any of the four
+unprobed and deferring verification to `jolli doctor`.
+
+### Component 7 — Settings → Agent tool availability
+
+The dropdown keeps listing **all four** tools — this is the advanced surface and
+filtering it would hide the tool a user is about to install. What changes is that
+the selection is verified and an unusable configuration cannot be saved.
+
+On panel open and on every `change` of `#localAgentTool`, the webview posts
+`{ type: "probeLocalAgent", tool }`. The extension probes and replies with
+`{ available, version?, error? }`, rendered under the dropdown:
+
+```
+  Agent tool
+  [ Cursor                              ▾ ]
+  ✗ Cursor not found on this machine.
+    Install it, or pick another tool.
+```
+
+Probing is async and off the render path, so the panel never blocks. While a
+probe is in flight the line reads `Checking…`.
+
+**Blocking Apply.** [`SettingsScriptBuilder.ts:392`](../../../vscode/src/views/SettingsScriptBuilder.ts)
+already gates the single global Apply button on a validation flag:
+
+```js
+applyBtn.disabled = !isDirty || hasErrors;
+```
+
+Agent-unavailability becomes one more input to `hasErrors` via the existing
+`validateAll()` / `updateApplyBtn()` seam — no new gating mechanism.
+
+**Scoped to when it matters.** "Apply Changes" saves *every* setting across all
+tabs, so an unavailable agent tool must not block an unrelated Memory Bank path
+edit. The error therefore only arms when `aiProvider === "local-agent"`, which
+is exactly when `localAgentTool` is read at all — [`Types.ts:1162`](../../../cli/src/Types.ts)
+already documents it as "Ignored unless `aiProvider === 'local-agent'`".
+Switching the provider away from local-agent clears the error and re-enables
+Apply.
+
+**In-flight probes do not block.** `hasErrors` is armed only by a *confirmed*
+unavailable result, never by the `Checking…` state. A slow probe must not make
+Apply flicker to disabled.
+
+### Component 8 — De-hardcode the local-agent health checks
+
+This is a **pre-existing bug**, not new scope. It must ship with this work
+because this work is what makes non-Claude tools a mainstream path.
+
+`localAgentTool` has been settable to any of the four for some time — via menu
+choice 3, `jolli configure --set localAgentTool=codex`, or the Settings
+dropdown. Generation honors it correctly: [`LlmClient.ts:473`](../../../cli/src/core/LlmClient.ts)
+resolves `getBackend(tool)` and drives whatever the user chose. But three
+*health-check* call sites never got the memo and still probe `claude`
+unconditionally:
+
+| Site | Current | Effect when `localAgentTool !== "claude-code"` |
+| --- | --- | --- |
+| [`GenerationFix.ts:34`](../../../cli/src/commands/GenerationFix.ts) `canGenerateNow()` | `isClaudeCodeUsable(...)` | Probes the wrong binary. Codex user without Claude is told generation is broken; Claude-installed user with a broken OpenCode is told it is fine |
+| [`GenerationFix.ts:134`](../../../cli/src/commands/GenerationFix.ts) `promptLocalAgentFix()` | `isClaudeCodeUsable(...)`, "Still no usable `claude`" | Sends the user to repair a tool they never selected |
+| [`GuidedFrontDoor.ts:197`](../../../cli/src/commands/GuidedFrontDoor.ts) | `" · summaries via Claude Code"` | States the wrong tool outright |
+
+The failure shape is worth naming: **the runtime is generic, the diagnostics are
+hard-coded.** Summaries actually generate fine through Codex today — only the
+pre-flight checks and their messaging lie, which is why this has gone unnoticed.
+
+[`DoctorCommand.ts:171`](../../../cli/src/commands/DoctorCommand.ts) is already
+correct — `getBackend(localAgentTool)` plus `localAgentToolLoginHint(...)` — and
+serves as the reference implementation the other three are brought in line with.
+
+**Changes:**
+
+- Add `isLocalAgentUsable(tool, opts)` to `DetectAgents.ts` — the registry-backed
+  generalization of `isClaudeCodeUsable`, and the new test-mocking seam.
+- Point all three sites at it, resolving the tool as
+  `config.localAgentTool ?? "claude-code"`. That default matches what
+  `StatusTreeProvider` and `SummaryUtils` already use for configs written before
+  the field existed.
+- Replace hard-coded tool names in user-facing strings with
+  `localAgentToolLabel(tool)`, and the repair hint with
+  `localAgentToolLoginHint(tool)`.
+- Delete `isClaudeCodeUsable` once its last caller is gone. Its tests move to
+  `isLocalAgentUsable` with a `claude-code` argument, so the existing coverage is
+  preserved rather than dropped.
+- Generalize the stale hint at [`EnableCommand.ts:361`](../../../cli/src/commands/EnableCommand.ts)
+  ("drive a local Claude Code CLI") to name the tool family, not Claude.
+
+**Not touched:** `EnableCommand.ts:290` ("Claude Code hooks") refers to Claude
+*agent hooks*, an unrelated subsystem that is correctly Claude-specific.
+
+### Surface coverage
+
+`GuidedFrontDoor` shares the setup path with `jolli enable` — it calls
+`promptSetup()` directly — so Component 6 covers its onboarding branch with no
+separate change. What it needs on its own is the Component 8 string fix. Full
+list of surfaces that choose or validate a local agent, and where each is
+handled:
+
+| Surface | Handled by |
+| --- | --- |
+| Sidebar onboarding card | Components 1–5 |
+| `jolli enable` → `promptSetup()` | Component 6 |
+| `jolli` guided front door | Component 6 (shared `promptSetup`) + Component 8 |
+| `promptGenerationFix()` R3 repair | Component 8 |
+| Settings → Agent tool | Component 7 |
+| `jolli doctor` | Already correct — no change |
+
+## Error handling
+
+| Condition | Behavior |
+| --- | --- |
+| Detection throws | Swallowed to `[]`; today's panel renders |
+| Zero agents present | Card hidden; panel identical to today |
+| Probe fails on click | Inline card error, config untouched, user can retry or pick another |
+| Unknown `tool` in message | Rejected by the allow-list check; no write |
+| Agent uninstalled after selection | `configured` stays true by design; surfaces via `jolli doctor` and the existing "llm-failed" placeholder + Regenerate path |
+| CLI: single present tool fails its probe | Falls through to the provider menu; nothing written |
+| CLI: chosen tool fails its probe | Error printed, picker repeats; nothing written |
+| CLI: menu choice 3 with zero present | Lists all four with a "none detected" note rather than dead-ending |
+| Settings: selected tool unavailable | Inline error, Apply disabled — but only while `aiProvider === "local-agent"` |
+| Settings: probe still running | `Checking…`; Apply stays enabled (in-flight never arms `hasErrors`) |
+
+## Testing
+
+- `DetectAgents.test.ts` — all four present, none present, partial,
+  `LOCAL_AGENT_TOOLS` order preserved (and specifically *not* backend-registry
+  order, which differs), error swallowed to `[]`.
+- Ordering-parity test — the onboarding `<option>` sequence equals the Settings
+  panel's `LOCAL_AGENT_TOOL_OPTIONS` sequence, filtered to present tools. Guards
+  the one invariant a future reorder would silently break.
+- `BuiltinBackends.test.ts` — registry is populated without importing
+  `LlmClient`.
+- `ExecutableResolver.test.ts` — `isPresent` returns true/false without spawning
+  a probe (assert the probe seam is never called).
+- Per-backend tests — `isPresent` delegates to the right `*_SPEC`.
+- `Extension` tests — extended `configured` predicate across all four
+  combinations; `onboardingSelectLocalAgent` happy path, probe-failure path, and
+  unknown-tool rejection.
+- `SidebarHtmlBuilder` / `SidebarScriptBuilder` tests — card visibility and
+  `RECOMMENDED` badge placement at 0 vs N agents; `<option>` list contents and
+  order.
+
+- `EnableCommand.test.ts` — fresh config with 0 / 1 / 2+ present tools; the
+  single-tool probe-fails path falls through to the menu; the multi-tool picker
+  probes before saving and repeats on failure; menu choice 3 lists only present
+  tools, and falls back to all four when none are present. Existing Claude-Code
+  auto-select tests must keep passing unchanged — that path is being generalized,
+  not replaced.
+- `SettingsWebviewPanel` / `SettingsScriptBuilder` tests — `probeLocalAgent`
+  round-trip; Apply disabled on a confirmed-unavailable tool; Apply **not**
+  disabled while a probe is in flight; Apply **not** disabled when the same tool
+  is unavailable but `aiProvider !== "local-agent"`; switching provider away
+  clears the error.
+
+- `GenerationFix.test.ts` — `canGenerateNow()` probes the **configured** tool,
+  not `claude`: a Codex-configured machine with no Claude reports usable, and a
+  Claude-installed machine with a broken configured tool reports unusable. R3
+  repair names the configured tool in every message.
+- `GuidedFrontDoor.test.ts` — the status line reads "summaries via Codex" when
+  Codex is configured.
+- Regression test for the missing-`localAgentTool` config (`aiProvider:
+  "local-agent"` with no tool set) defaulting to `claude-code` across all three
+  repaired sites.
+
+CLI coverage floor is 97% statements / 96% branches; `DetectAgents.ts`, the
+`isPresent` additions, the rewritten `EnableCommand` branches, and the
+`isLocalAgentUsable` migration all need full branch coverage. The
+`isClaudeCodeUsable` tests are migrated, not deleted — dropping them would show
+as a coverage pass while losing real assertions.
+
+## Rejected alternatives
+
+**Full `discoverExecutable()` sweep before first paint.** Verifies every
+dropdown entry, but costs a measured 3384 ms of blocked first paint for
+four-tool users and does not actually prevent the failure it appears to prevent —
+presence plus a working `--version` still says nothing about auth, which is the
+realistic failure. Rejected on measurement.
+
+**Sweep with a tightened per-probe timeout.** A budget low enough to matter
+(~1.5 s) would cut off OpenCode at its measured 1772 ms and report a
+perfectly good install as absent. Rejected: a false negative is worse than a
+slow true positive.
+
+**Parallel sweep.** The resolver is built on `execFileSync`; concurrency would
+require child processes and a serialization protocol for a problem that
+presence-only detection dissolves at ~4 ms.
+
+**Listing all four tools with undetected ones greyed out.** More discoverable,
+but adds dead rows to a first-run screen. Rejected in favor of listing only what
+works.
+
+**Auto-selecting silently when exactly one agent is present — in the sidebar.**
+Fastest, but the user never learns a choice was made on their behalf, and the
+sidebar is a persistent surface where showing the choice is nearly free. Rejected
+for VS Code only: the CLI *does* auto-select in that case, deliberately. See
+"One deliberate asymmetry" above.
+
+**Filtering the Settings dropdown to present tools.** Considered and rejected in
+favor of checking availability instead. Filtering would hide the tool a user is
+about to install and give no explanation for its absence; an inline "not found"
+line on a still-visible option says strictly more. The save-blocking rule
+delivers the same guarantee filtering would have — no unusable configuration
+gets persisted — without hiding anything.
+
+**Caching the detection result.** At ~4 ms there is nothing to amortize, and a
+cache would need invalidating when the user installs a tool.

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -8,6 +8,11 @@ const { getWorkspaceRoot, resolveCLIPath } = vi.hoisted(() => ({
 	resolveCLIPath: vi.fn(),
 }));
 
+const { listPresentLocalAgents, isLocalAgentUsable } = vi.hoisted(() => ({
+	listPresentLocalAgents: vi.fn(() => [] as Array<{ id: string; label: string }>),
+	isLocalAgentUsable: vi.fn(async () => true),
+}));
+
 const {
 	info,
 	warn,
@@ -38,8 +43,9 @@ const { manuallyDisabledState, setManuallyDisabledMock, isManuallyDisabledMock }
 	};
 });
 
-const { mockNotifyApiKeySaveError } = vi.hoisted(() => ({
+const { mockNotifyApiKeySaveError, mockNotifyLocalAgentSelectError } = vi.hoisted(() => ({
 	mockNotifyApiKeySaveError: vi.fn(),
+	mockNotifyLocalAgentSelectError: vi.fn(),
 }));
 
 const { triggerPendingPushRetry } = vi.hoisted(() => ({
@@ -55,13 +61,21 @@ const { mockRefreshKnowledgeBaseFolders, mockClearKnowledgeBaseFolderDivergence 
 	mockClearKnowledgeBaseFolderDivergence: vi.fn(),
 }));
 
-const { mockNotifyEnabledChanged, mockNotifyAuthChanged, mockToggleStatus, mockNotifyColdStart } =
-	vi.hoisted(() => ({
-		mockNotifyEnabledChanged: vi.fn(),
-		mockNotifyAuthChanged: vi.fn(),
-		mockToggleStatus: vi.fn(),
-		mockNotifyColdStart: vi.fn(),
-	}));
+const {
+	mockNotifyEnabledChanged,
+	mockNotifyAuthChanged,
+	mockToggleStatus,
+	mockNotifyColdStart,
+	mockNotifyConfiguredChanged,
+	mockNotifyLocalAgentsChanged,
+} = vi.hoisted(() => ({
+	mockNotifyEnabledChanged: vi.fn(),
+	mockNotifyAuthChanged: vi.fn(),
+	mockToggleStatus: vi.fn(),
+	mockNotifyColdStart: vi.fn(),
+	mockNotifyConfiguredChanged: vi.fn(),
+	mockNotifyLocalAgentsChanged: vi.fn(),
+}));
 
 const { isWorkerBusy, readIngestPhase } = vi.hoisted(() => ({
 	isWorkerBusy: vi.fn(),
@@ -669,6 +683,15 @@ vi.mock("../../cli/src/core/DiscoveryCatchUp.js", () => ({
 	catchUpTranscriptDiscovery,
 }));
 
+// Partial mock: the detection/probe seams are stubbed, but `localAgentOverrideFrom`
+// (a pure config→override mapper) stays real so the tool-scoping rule is exercised
+// rather than re-implemented here.
+vi.mock("../../cli/src/core/localagent/DetectAgents.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../../cli/src/core/localagent/DetectAgents.js")>()),
+	listPresentLocalAgents,
+	isLocalAgentUsable,
+}));
+
 // Mock the KB folder-mode dependencies so the auto-migration path in `activate`
 // and the rebuildKnowledgeBase command run with predictable, side-effect-free
 // stand-ins. Each test that exercises those paths overrides the relevant helper
@@ -979,12 +1002,17 @@ vi.mock("./views/SidebarWebviewProvider.js", () => ({
 		notifyColdStart = mockNotifyColdStart;
 		toggleStatus = mockToggleStatus;
 		notifyAuthChanged = mockNotifyAuthChanged;
-		notifyConfiguredChanged() {}
+		notifyConfiguredChanged = mockNotifyConfiguredChanged;
+		notifyLocalAgentsChanged = mockNotifyLocalAgentsChanged;
 		setBadge() {}
 		// Tracked via a shared vi.fn so saveAnthropicApiKey-error tests can
 		// assert the failure-path message routing without needing access to
 		// the constructed instance.
 		notifyApiKeySaveError = mockNotifyApiKeySaveError;
+		// Tracked via a shared vi.fn so selectLocalAgentTool-error tests can
+		// assert the failure-path message routing without needing access to
+		// the constructed instance.
+		notifyLocalAgentSelectError = mockNotifyLocalAgentSelectError;
 	},
 }));
 
@@ -1229,6 +1257,8 @@ describe("Extension", () => {
 		isWorkerBusy.mockResolvedValue(false);
 		readIngestPhase.mockResolvedValue({ busy: false, phase: null });
 		loadConfig.mockResolvedValue({});
+		listPresentLocalAgents.mockReturnValue([]);
+		isLocalAgentUsable.mockResolvedValue(true);
 
 		// Reset provider mocks to defaults
 		for (const p of [
@@ -2429,6 +2459,44 @@ describe("Extension", () => {
 					"refreshStatus failed: status fetch failed",
 					expect.any(Error),
 				);
+			});
+		});
+
+		// The onboarding-vs-main-UI gate registered via `statusStore.onChange`
+		// (Extension.ts ~1483): `nextConfigured = signedIn || hasApiKey ||
+		// usesLocalAgent`. `usesLocalAgent` widens the gate on config INTENT
+		// alone — losing the agent binary later must not flip this back to
+		// false, so there's no "binary present" input for this callback to
+		// observe in the first place.
+		describe("statusStore configured gate", () => {
+			// `ctx`/`activate(ctx)` already ran in the enclosing "command
+			// handlers" beforeEach, which registered the callback we're after.
+			function invokeStatusChange(derived: Record<string, boolean>) {
+				const onChangeCallback = mockStatusStore.onChange.mock.calls[0]?.[0] as (snap: {
+					derived: Record<string, boolean>;
+					status: { enabled: boolean } | null;
+				}) => void;
+				onChangeCallback({ derived, status: null });
+			}
+
+			it("is configured when usesLocalAgent is true even with no key and no sign-in", () => {
+				invokeStatusChange({
+					signedIn: false,
+					hasApiKey: false,
+					usesLocalAgent: true,
+				});
+
+				expect(mockNotifyConfiguredChanged).toHaveBeenCalledWith(true);
+			});
+
+			it("is not configured when signedIn, hasApiKey, and usesLocalAgent are all false", () => {
+				invokeStatusChange({
+					signedIn: false,
+					hasApiKey: false,
+					usesLocalAgent: false,
+				});
+
+				expect(mockNotifyConfiguredChanged).not.toHaveBeenCalled();
 			});
 		});
 
@@ -7349,6 +7417,163 @@ describe("Extension", () => {
 		});
 	});
 
+	describe("selectLocalAgentTool command", () => {
+		// Onboarding local-agent-card "Use Local Agent Tool" button path. The
+		// capability probe (isLocalAgentUsable) runs here, once, for the tool the
+		// user picked — the onboarding sweep (listPresentLocalAgents) stays
+		// presence-only. Success is implicit: saveConfigScoped + statusStore.refresh
+		// flip `configured`, which rides the existing configured:changed channel —
+		// only failures post localAgent:selectError.
+
+		it("registers the selectLocalAgentTool command", () => {
+			activate(makeContext());
+			const handler = getRegisteredCommand("jollimemory.selectLocalAgentTool");
+			expect(handler).toBeDefined();
+		});
+
+		it("saves aiProvider:'local-agent' + the chosen tool and refreshes statusStore when the probe passes", async () => {
+			activate(makeContext());
+			isLocalAgentUsable.mockResolvedValueOnce(true);
+			saveConfigScoped.mockResolvedValueOnce(undefined);
+			mockStatusStore.refresh.mockClear();
+
+			const handler = getRegisteredCommand("jollimemory.selectLocalAgentTool");
+			await handler("codex");
+
+			expect(isLocalAgentUsable).toHaveBeenCalledWith("codex", { overridePath: undefined });
+			expect(saveConfigScoped).toHaveBeenCalledWith(
+				{ aiProvider: "local-agent", localAgentTool: "codex" },
+				"/home/user/.jolli/jollimemory",
+			);
+			expect(mockStatusStore.refresh).toHaveBeenCalled();
+			expect(mockNotifyLocalAgentSelectError).not.toHaveBeenCalled();
+		});
+
+		it("forwards a configured localAgentPath override to the probe when it names the chosen tool", async () => {
+			activate(makeContext());
+			loadConfig.mockResolvedValueOnce({
+				localAgentTool: "codex",
+				localAgentPath: "/opt/homebrew/bin/codex",
+			});
+			isLocalAgentUsable.mockResolvedValueOnce(true);
+			saveConfigScoped.mockResolvedValueOnce(undefined);
+
+			const handler = getRegisteredCommand("jollimemory.selectLocalAgentTool");
+			await handler("codex");
+
+			expect(isLocalAgentUsable).toHaveBeenCalledWith("codex", {
+				override: { tool: "codex", path: "/opt/homebrew/bin/codex" },
+			});
+		});
+
+		it("does not lend one tool's configured path to a different tool's probe", async () => {
+			// The override is tool-scoped: picking OpenCode while `localAgentPath`
+			// points at Codex's binary must auto-discover OpenCode, not probe
+			// Codex's file and call the answer OpenCode's.
+			activate(makeContext());
+			loadConfig.mockResolvedValueOnce({
+				localAgentTool: "codex",
+				localAgentPath: "/opt/homebrew/bin/codex",
+			});
+			isLocalAgentUsable.mockResolvedValueOnce(true);
+			saveConfigScoped.mockResolvedValueOnce(undefined);
+
+			const handler = getRegisteredCommand("jollimemory.selectLocalAgentTool");
+			await handler("opencode");
+
+			expect(isLocalAgentUsable).toHaveBeenCalledWith("opencode", {
+				override: { tool: "codex", path: "/opt/homebrew/bin/codex" },
+			});
+			// isLocalAgentUsable itself drops the mismatched override — asserted
+			// directly in DetectAgents.test.ts.
+		});
+
+		it("writes nothing and reports an error naming the tool when the probe fails", async () => {
+			activate(makeContext());
+			isLocalAgentUsable.mockResolvedValueOnce(false);
+
+			const handler = getRegisteredCommand("jollimemory.selectLocalAgentTool");
+			await handler("codex");
+
+			expect(saveConfigScoped).not.toHaveBeenCalled();
+			expect(mockNotifyLocalAgentSelectError).toHaveBeenCalledWith(
+				"Found Codex, but it didn't respond as expected. Try another tool.",
+			);
+		});
+
+		it("rejects an unrecognized tool id without probing or writing", async () => {
+			activate(makeContext());
+
+			const handler = getRegisteredCommand("jollimemory.selectLocalAgentTool");
+			await handler("evil-tool");
+
+			expect(isLocalAgentUsable).not.toHaveBeenCalled();
+			expect(saveConfigScoped).not.toHaveBeenCalled();
+			expect(mockNotifyLocalAgentSelectError).toHaveBeenCalledWith(
+				"Unknown local agent tool.",
+			);
+		});
+
+		it("rejects non-string input (defensive against malformed webview message) without probing or saving", async () => {
+			activate(makeContext());
+
+			const handler = getRegisteredCommand("jollimemory.selectLocalAgentTool");
+			await handler(42 as unknown);
+
+			expect(isLocalAgentUsable).not.toHaveBeenCalled();
+			expect(saveConfigScoped).not.toHaveBeenCalled();
+			expect(mockNotifyLocalAgentSelectError).toHaveBeenCalledWith(
+				"Unknown local agent tool.",
+			);
+		});
+
+		// Regression: the allow-list used to read as `rawTool in LOCAL_AGENT_TOOLS`,
+		// which walks the prototype chain — `"toString"` / `"constructor"` pass
+		// that check even though they are never own keys of LOCAL_AGENT_TOOLS.
+		// Object.hasOwn closes that gap.
+		it("rejects a prototype-chain key ('toString') without probing or saving", async () => {
+			activate(makeContext());
+
+			const handler = getRegisteredCommand("jollimemory.selectLocalAgentTool");
+			await handler("toString");
+
+			expect(isLocalAgentUsable).not.toHaveBeenCalled();
+			expect(saveConfigScoped).not.toHaveBeenCalled();
+			expect(mockNotifyLocalAgentSelectError).toHaveBeenCalledWith(
+				"Unknown local agent tool.",
+			);
+		});
+
+		it("posts localAgent:selectError with the error message when saveConfigScoped throws", async () => {
+			activate(makeContext());
+			isLocalAgentUsable.mockResolvedValueOnce(true);
+			saveConfigScoped.mockRejectedValueOnce(new Error("EROFS: read-only fs"));
+
+			const handler = getRegisteredCommand("jollimemory.selectLocalAgentTool");
+			await handler("codex");
+
+			expect(mockNotifyLocalAgentSelectError).toHaveBeenCalledWith(
+				"EROFS: read-only fs",
+			);
+		});
+
+		// Defensive fallback: a non-Error rejection (a plain string from a
+		// misbehaving lower layer) must still surface a user-readable message
+		// via notifyLocalAgentSelectError rather than blowing up the selection flow.
+		it("falls back to a generic message naming the tool when saveConfigScoped rejects with a non-Error", async () => {
+			activate(makeContext());
+			isLocalAgentUsable.mockResolvedValueOnce(true);
+			saveConfigScoped.mockRejectedValueOnce("plain-string-failure");
+
+			const handler = getRegisteredCommand("jollimemory.selectLocalAgentTool");
+			await handler("codex");
+
+			expect(mockNotifyLocalAgentSelectError).toHaveBeenCalledWith(
+				"Failed to select Codex.",
+			);
+		});
+	});
+
 	describe("URI handler", () => {
 		it("registers a URI handler on activation", () => {
 			const ctx = makeContext();
@@ -8046,6 +8271,125 @@ describe("Extension", () => {
 			mockNotifyColdStart.mockClear();
 			await runEnable();
 			expect(mockNotifyColdStart).toHaveBeenCalledWith(expect.objectContaining({ coldStartVariant: null }));
+		});
+	});
+
+	// ── Local agent detection under the initialStateReady barrier ──────────
+	// detectLocalAgents() runs inside initialLoad's `.finally`, right beside
+	// computeColdStartSignals and before resolveInitialStateReady, so the
+	// first `init` message already carries the answer (no reshuffle).
+	describe("local agent detection (onboarding card)", () => {
+		function localAgentsState(): { localAgents?: Array<{ id: string; label: string }> } {
+			return (
+				sidebarDepsCaptured as {
+					getInitialState: () => { localAgents?: Array<{ id: string; label: string }> };
+				}
+			).getInitialState();
+		}
+
+		it("carries detected local agents on the first init message", async () => {
+			listPresentLocalAgents.mockReturnValue([{ id: "codex", label: "Codex" }]);
+			activate(makeContext());
+			// Poll until initialLoad's .finally(async …) has run detectLocalAgents,
+			// rather than guessing a tick count — matches the file's established
+			// vi.waitFor convention for async-settling assertions.
+			await vi.waitFor(() => {
+				expect(localAgentsState().localAgents).toEqual([{ id: "codex", label: "Codex" }]);
+			});
+		});
+
+		it("skips detection entirely when already configured", async () => {
+			activate(makeContext());
+			// Flip currentConfigured to true via the same statusStore.onChange
+			// callback the "statusStore configured gate" tests use, BEFORE letting
+			// initialLoad's .finally settle, so detectLocalAgents observes
+			// currentConfigured === true and short-circuits.
+			const onChangeCallback = mockStatusStore.onChange.mock.calls[0]?.[0] as (snap: {
+				derived: Record<string, boolean>;
+				status: { enabled: boolean } | null;
+			}) => void;
+			onChangeCallback({
+				derived: { signedIn: true, hasApiKey: false, usesLocalAgent: false },
+				status: null,
+			});
+			// "never called" can't itself be expressed as a positive vi.waitFor
+			// condition — it's equally true before AND after the barrier settles,
+			// so polling it would pass instantly without proving the barrier ever
+			// ran. Instead, await the exact barrier promise the SidebarWebviewProvider
+			// dep receives (`initialStateReady` — the same promise `detectLocalAgents`
+			// and `resolveInitialStateReady` are sequenced under in Extension.ts's
+			// `.finally`), then assert the negative. This is deterministic — no
+			// fixed tick count, no polling interval — because it's the real
+			// settlement signal, not a proxy for it.
+			await (sidebarDepsCaptured as { initialStateReady: Promise<void> }).initialStateReady;
+			expect(listPresentLocalAgents).not.toHaveBeenCalled();
+			expect(localAgentsState().localAgents).toEqual([]);
+		});
+
+		// Onboarding is not a one-shot: `configured` can flip back to false
+		// mid-window (sign-out, cleared key) and re-raise the panel. Detection is
+		// skipped for configured users, so without a re-run + push the reappearing
+		// panel silently omits the local-agent card until the window is reloaded.
+		describe("configured flips back to false mid-window", () => {
+			function flipConfigured(configured: boolean): void {
+				const onChangeCallback = mockStatusStore.onChange.mock.calls[0]?.[0] as (snap: {
+					derived: Record<string, boolean>;
+					status: { enabled: boolean } | null;
+				}) => void;
+				onChangeCallback({
+					derived: { signedIn: configured, hasApiKey: false, usesLocalAgent: false },
+					status: null,
+				});
+			}
+
+			it("re-detects and pushes the refreshed list before the panel is shown", async () => {
+				activate(makeContext());
+				// Start configured, so the activation-path sweep short-circuits and the
+				// host's list is empty — the exact state that used to strand the card.
+				flipConfigured(true);
+				await (sidebarDepsCaptured as { initialStateReady: Promise<void> }).initialStateReady;
+				expect(listPresentLocalAgents).not.toHaveBeenCalled();
+
+				listPresentLocalAgents.mockReturnValue([{ id: "codex", label: "Codex" }]);
+				mockNotifyConfiguredChanged.mockClear();
+				flipConfigured(false);
+
+				expect(listPresentLocalAgents).toHaveBeenCalledTimes(1);
+				expect(mockNotifyLocalAgentsChanged).toHaveBeenCalledWith([{ id: "codex", label: "Codex" }]);
+				expect(localAgentsState().localAgents).toEqual([{ id: "codex", label: "Codex" }]);
+				// Ordering matters: the list must land BEFORE the panel is un-hidden,
+				// or the card renders one message late.
+				expect(mockNotifyLocalAgentsChanged.mock.invocationCallOrder[0]).toBeLessThan(
+					mockNotifyConfiguredChanged.mock.invocationCallOrder[0],
+				);
+			});
+
+			it("does not re-detect when configured flips to true", async () => {
+				activate(makeContext());
+				await (sidebarDepsCaptured as { initialStateReady: Promise<void> }).initialStateReady;
+				listPresentLocalAgents.mockClear();
+
+				flipConfigured(true);
+
+				expect(listPresentLocalAgents).not.toHaveBeenCalled();
+				expect(mockNotifyLocalAgentsChanged).not.toHaveBeenCalled();
+			});
+		});
+
+		it("degrades to an empty list when detection throws", async () => {
+			listPresentLocalAgents.mockImplementation(() => {
+				throw new Error("boom");
+			});
+			activate(makeContext());
+			// Poll for the sweep having actually run (and thrown) rather than a
+			// fixed tick count — [] alone can't distinguish "ran and degraded" from
+			// "never ran", so wait on the call + warn evidence together with the
+			// resulting state.
+			await vi.waitFor(() => {
+				expect(listPresentLocalAgents).toHaveBeenCalled();
+				expect(warn).toHaveBeenCalledWith("detectLocalAgents", "Detection failed", { error: "boom" });
+				expect(localAgentsState().localAgents).toEqual([]);
+			});
 		});
 	});
 

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -18,6 +18,13 @@ import { discoverCodexConversations } from "../../cli/src/core/CodexDiscovery.js
 import { catchUpTranscriptDiscovery } from "../../cli/src/core/DiscoveryCatchUp.js";
 import type { FolderStorage, ForceRegenerateResult } from "../../cli/src/core/FolderStorage.js";
 import { getDefaultBranch } from "../../cli/src/core/GitOps.js";
+import type { DetectedAgent } from "../../cli/src/core/localagent/DetectAgents.js";
+import {
+	isLocalAgentUsable,
+	listPresentLocalAgents,
+	localAgentOverrideFrom,
+} from "../../cli/src/core/localagent/DetectAgents.js";
+import { LOCAL_AGENT_TOOLS, localAgentToolLabel } from "../../cli/src/core/localagent/ToolMeta.js";
 import {
 	extractRepoName,
 	getRemoteUrl,
@@ -58,7 +65,7 @@ import {
 } from "../../cli/src/core/SummaryTree.js";
 import type { StorageProvider } from "../../cli/src/core/StorageProvider.js";
 import { isManuallyDisabled, ORPHAN_BRANCH, setManuallyDisabled } from "../../cli/src/Logger.js";
-import type { SourceId, StatusInfo } from "../../cli/src/Types.js";
+import type { LocalAgentToolId, SourceId, StatusInfo } from "../../cli/src/Types.js";
 import { execFileSyncHidden } from "../../cli/src/util/Subprocess.js";
 import { runCopyBranchRecallPrompt, runRecallInClaudeCode } from "./commands/BranchRecallCommands.js";
 import { CommitCommand } from "./commands/CommitCommand.js";
@@ -894,6 +901,12 @@ export function activate(context: vscode.ExtensionContext): void {
 	// from statusStore.onChange so sign-in / sign-out / settings save / config
 	// reload all converge on a single source of truth.
 	let currentConfigured = false;
+	// Local agent tools present on this machine, for the onboarding card. Empty
+	// until resolved under the initialStateReady barrier, and left empty for
+	// already-configured users (who never see the card) — those users get a
+	// detection sweep only if `configured` later flips back to false, which is
+	// where the onboarding panel can reappear mid-window. See detectLocalAgents.
+	let currentLocalAgents: DetectedAgent[] = [];
 	// Per-repo cold-start signals for the back-fill card. Optimistic defaults
 	// (has memories / no variant / not dismissed) so the card never flashes
 	// before initialLoad resolves the real values under the barrier.
@@ -1060,6 +1073,38 @@ export function activate(context: vscode.ExtensionContext): void {
 		}
 	}
 
+	/**
+	 * Presence-only sweep of the local agent CLIs, for the onboarding card.
+	 *
+	 * Filesystem work only — `existsSync` across the discovery dirs, no `which`
+	 * and no subprocess of any kind (see `discoverPresence`) — measured at ~4 ms
+	 * for all four tools, which is what lets it sit on the activation path at all:
+	 * this runs synchronously on the extension host's single thread, where a
+	 * blocked event loop stalls every extension, not just this one. The expensive
+	 * capability probe (161-1772 ms per tool; 3384 ms to sweep all four) is
+	 * deliberately NOT run here; it happens once, for the one tool the user picks.
+	 *
+	 * Skipped when already configured: those users never see the card. That is a
+	 * cost optimization, NOT a one-shot — `configured` can flip back to false
+	 * mid-window (sign-out, cleared API key) and bring the onboarding panel with
+	 * it, so the statusStore subscription calls this again on that transition
+	 * (after `currentConfigured` has been updated, or the guard would swallow it).
+	 * Without that second call the reappearing panel would silently omit the
+	 * local-agent card, because the host's list was never populated.
+	 *
+	 * Best-effort — any failure leaves the list empty, which renders today's
+	 * onboarding panel unchanged.
+	 */
+	const detectLocalAgents = (): void => {
+		if (currentConfigured) return;
+		try {
+			currentLocalAgents = listPresentLocalAgents();
+		} catch (err) {
+			log.warn("detectLocalAgents", "Detection failed", { error: (err as Error).message });
+			currentLocalAgents = [];
+		}
+	};
+
 	let sidebarProvider: SidebarWebviewProvider;
 	sidebarProvider = new SidebarWebviewProvider({
 		executeCommand: (cmd, ...args) =>
@@ -1073,6 +1118,7 @@ export function activate(context: vscode.ExtensionContext): void {
 			enabled: currentEnabled && !isManuallyDisabled(),
 			authenticated: currentAuthenticated,
 			configured: currentConfigured,
+			localAgents: currentLocalAgents,
 			activeTab: "branch",
 			kbMode: "folders",
 			branchName: currentBranchName,
@@ -1486,9 +1532,26 @@ export function activate(context: vscode.ExtensionContext): void {
 	// webview round-trips minimal.
 	context.subscriptions.push({
 		dispose: statusStore.onChange((snap) => {
-			const nextConfigured = snap.derived.signedIn || snap.derived.hasApiKey;
+			// A local-agent provider is self-sufficient — it drives the tool's own
+			// login and holds no jollimemory credential — so it counts as
+			// configured. Keyed on config intent, NOT live detection: if the user
+			// later uninstalls the agent we must not silently drop them back into
+			// onboarding and discard the choice. That failure belongs to
+			// `jolli doctor` and the generation error path.
+			const nextConfigured =
+				snap.derived.signedIn || snap.derived.hasApiKey || snap.derived.usesLocalAgent;
 			if (nextConfigured !== currentConfigured) {
 				currentConfigured = nextConfigured;
+				// Onboarding can come BACK mid-window: signing out or clearing the API
+				// key flips `configured` to false and re-raises the panel. Refresh the
+				// local-agent list and push it BEFORE the panel is shown, so the card is
+				// already correct on the first paint rather than one message late. The
+				// assignment above must come first — detectLocalAgents self-guards on
+				// `currentConfigured`.
+				if (!nextConfigured) {
+					detectLocalAgents();
+					sidebarProvider.notifyLocalAgentsChanged(currentLocalAgents);
+				}
 				sidebarProvider.notifyConfiguredChanged(nextConfigured);
 			}
 			if (snap.status && snap.status.enabled !== currentEnabled) {
@@ -3812,6 +3875,54 @@ export function activate(context: vscode.ExtensionContext): void {
 			},
 		),
 
+		// Onboarding local-agent selection — wired from the sidebar card's
+		// "Use Local Agent Tool" button. Mirrors saveAnthropicApiKey: touches only
+		// the provider fields, and a successful save flips configured=true via
+		// statusStore.refresh, which retires the panel through the existing
+		// configured:changed plumbing — no success ack needed.
+		//
+		// The capability probe runs HERE rather than during detection: the
+		// onboarding sweep is presence-only (~4 ms) precisely so that the
+		// expensive probe (161-1772 ms) is paid once, for the one tool the user
+		// actually chose.
+		vscode.commands.registerCommand(
+			"jollimemory.selectLocalAgentTool",
+			async (rawTool: unknown) => {
+				log.info("cmd", "selectLocalAgentTool invoked");
+				// Webview input is untrusted — allow-list against the tool registry.
+				const tool =
+					typeof rawTool === "string" && Object.hasOwn(LOCAL_AGENT_TOOLS, rawTool)
+						? (rawTool as LocalAgentToolId)
+						: null;
+				if (!tool) {
+					sidebarProvider.notifyLocalAgentSelectError("Unknown local agent tool.");
+					return;
+				}
+				const label = localAgentToolLabel(tool);
+				try {
+					const cfg = await loadConfig();
+					// Tool-scoped override: `localAgentPath` names ONE tool's binary, so
+					// it reaches the probe only when it names the tool being selected.
+					const override = cfg ? localAgentOverrideFrom(cfg) : undefined;
+					if (!(await isLocalAgentUsable(tool, { override }))) {
+						sidebarProvider.notifyLocalAgentSelectError(
+							`Found ${label}, but it didn't respond as expected. Try another tool.`,
+						);
+						return;
+					}
+					await saveConfigScoped(
+						{ aiProvider: "local-agent", localAgentTool: tool },
+						getGlobalConfigDir(),
+					);
+					await statusStore.refresh();
+				} catch (err) {
+					const message = err instanceof Error ? err.message : `Failed to select ${label}.`;
+					log.error("cmd", `selectLocalAgentTool failed: ${message}`);
+					sidebarProvider.notifyLocalAgentSelectError(message);
+				}
+			},
+		),
+
 		// Auth — sign in / sign out via browser-based OAuth flow.
 		vscode.commands.registerCommand("jollimemory.signIn", async () => {
 			log.info("cmd", "signIn invoked");
@@ -4077,6 +4188,7 @@ export function activate(context: vscode.ExtensionContext): void {
 		// (no flash). Best-effort inside the helper: any failure leaves the
 		// optimistic defaults (no variant → no card).
 		await computeColdStartSignals();
+		detectLocalAgents();
 		resolveInitialStateReady();
 	});
 

--- a/vscode/src/JolliMemoryBridge.integration.test.ts
+++ b/vscode/src/JolliMemoryBridge.integration.test.ts
@@ -27,6 +27,17 @@ vi.mock("./util/Logger.js", () => ({
 
 import { JolliMemoryBridge } from "./JolliMemoryBridge.js";
 
+// The shared `beforeEach` below spawns real `git` subprocesses (init, config,
+// commit) and is file-scoped, so it applies across every `describe` block in
+// this file — a describe-level `{ timeout }` option would only cover the one
+// describe it wraps, not this hook. Under v8 coverage instrumentation plus a
+// large parallel suite, that subprocess chain can occasionally take longer
+// than Vitest's 5s/10s defaults, which is a load signal, not a correctness
+// one. Bump both timeouts file-wide so the suite stays robust under load
+// without hiding an actual hang (45s is far beyond any real subprocess
+// latency).
+vi.setConfig({ testTimeout: 45_000, hookTimeout: 45_000 });
+
 let repoDir: string;
 
 beforeEach(() => {

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -886,6 +886,7 @@ export class JolliMemoryBridge {
 			diffLength: stagedDiff.length,
 			branch,
 			hasApiKey: !!config.apiKey,
+			usesLocalAgent: config.aiProvider === "local-agent",
 			model: config.model,
 		});
 

--- a/vscode/src/services/BackfillDismissFlag.test.ts
+++ b/vscode/src/services/BackfillDismissFlag.test.ts
@@ -9,7 +9,15 @@ import { readBackfillDismissFlag, writeBackfillDismissFlag } from "./BackfillDis
 // exhaustive path-resolution / migration / worktree-sharing coverage lives in
 // cli/src/core/RepoProfile.test.ts; here we only assert the boolean forwarding
 // and the new storage location.
-describe("BackfillDismissFlag", () => {
+//
+// Direct sibling of ManualDisableFlag.test.ts: both wrap the same RepoProfile
+// helpers and spawn a real `git init` in beforeEach plus real git reads/writes
+// via `git rev-parse --git-common-dir`. Under v8 coverage instrumentation plus
+// a large parallel suite, that subprocess can occasionally take longer than
+// Vitest's 5s default, which is a load signal, not a correctness one. Give the
+// whole suite a generous timeout so it stays robust under load without hiding
+// an actual hang (45s is far beyond any real subprocess latency).
+describe("BackfillDismissFlag", { timeout: 45_000 }, () => {
 	let cwd: string;
 
 	beforeEach(() => {

--- a/vscode/src/services/ManualDisableFlag.test.ts
+++ b/vscode/src/services/ManualDisableFlag.test.ts
@@ -10,7 +10,15 @@ import { readManualDisableFlag, readManualDisableFlagSync, writeManualDisableFla
 // is a thin re-export. `git init` makes each temp dir a real repo so we exercise
 // RepoProfile's git-common-dir anchoring (the actual VS Code path) and don't
 // accidentally resolve to an enclosing repo if TMPDIR happens to sit inside one.
-describe("ManualDisableFlag (repo-wide, profile.json backed)", () => {
+//
+// Every test in this suite (directly or via beforeEach's `git init`) spawns a
+// real `git` subprocess — read/write both resolve the repo root via
+// `git rev-parse --git-common-dir`. Under v8 coverage instrumentation plus a
+// large parallel suite, that subprocess can occasionally take longer than
+// Vitest's 5s default, which is a load signal, not a correctness one. Give the
+// whole suite a generous timeout so it stays robust under load without hiding
+// an actual hang (45s is far beyond any real subprocess latency).
+describe("ManualDisableFlag (repo-wide, profile.json backed)", { timeout: 45_000 }, () => {
 	let cwd: string;
 
 	beforeEach(async () => {

--- a/vscode/src/services/data/StatusDataService.test.ts
+++ b/vscode/src/services/data/StatusDataService.test.ts
@@ -28,6 +28,7 @@ describe("StatusDataService.derive", () => {
 		expect(derived).toEqual({
 			hasApiKey: false,
 			signedIn: false,
+			usesLocalAgent: false,
 			allHooksInstalled: false,
 			hooksDescription: "none installed",
 		});
@@ -73,5 +74,19 @@ describe("StatusDataService.derive", () => {
 		const derived = StatusDataService.derive(null, config);
 		expect(derived.hasApiKey).toBe(false);
 		expect(derived.signedIn).toBe(false);
+	});
+
+	it("reports usesLocalAgent when aiProvider is local-agent, with no key and no sign-in", () => {
+		const config = { aiProvider: "local-agent" } as JolliMemoryConfig;
+		const derived = StatusDataService.derive(null, config);
+		expect(derived.usesLocalAgent).toBe(true);
+		expect(derived.hasApiKey).toBe(false);
+		expect(derived.signedIn).toBe(false);
+	});
+
+	it("does not report usesLocalAgent for other providers", () => {
+		const config = { aiProvider: "anthropic" } as JolliMemoryConfig;
+		const derived = StatusDataService.derive(null, config);
+		expect(derived.usesLocalAgent).toBe(false);
 	});
 });

--- a/vscode/src/services/data/StatusDataService.ts
+++ b/vscode/src/services/data/StatusDataService.ts
@@ -15,6 +15,14 @@ import type {
 export interface StatusDerived {
 	readonly hasApiKey: boolean;
 	readonly signedIn: boolean;
+	/**
+	 * True when `config.aiProvider === "local-agent"`. Keyed on config INTENT,
+	 * NOT on whether the agent binary is currently present or runnable — if
+	 * the user later uninstalls the agent we must not silently drop them back
+	 * into onboarding and discard their provider choice. That failure belongs
+	 * to `jolli doctor` and the generation error path, not this gate.
+	 */
+	readonly usesLocalAgent: boolean;
 	readonly allHooksInstalled: boolean;
 	readonly hooksDescription: string;
 }
@@ -38,6 +46,7 @@ export class StatusDataService {
 		return {
 			hasApiKey: !!config?.apiKey,
 			signedIn: !!config?.authToken,
+			usesLocalAgent: config?.aiProvider === "local-agent",
 			allHooksInstalled: !!status?.gitHookInstalled,
 			hooksDescription: parts.length > 0 ? parts.join(" + ") : "none installed",
 		};

--- a/vscode/src/stores/StatusStore.test.ts
+++ b/vscode/src/stores/StatusStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { StatusInfo } from "../../../cli/src/Types.js";
+import type { JolliMemoryConfig, StatusInfo } from "../../../cli/src/Types.js";
 
 const { loadConfigFromDir, getGlobalConfigDir } = vi.hoisted(() => ({
 	loadConfigFromDir: vi.fn(),
@@ -231,6 +231,39 @@ describe("StatusStore", () => {
 			expect(store.getSnapshot().workerBusy).toBe(false);
 			expect(store.getSnapshot().ingestBusy).toBe(true);
 			expect(store.getSnapshot().ingestPhase).toBe("wiki");
+		});
+	});
+
+	// ── configured gate — usesLocalAgent must widen it without live detection ──
+	describe("configured gate", () => {
+		async function buildSnapshot(configOverrides: Partial<JolliMemoryConfig> = {}) {
+			const bridge = { getStatus: vi.fn(async () => makeStatus()) };
+			loadConfigFromDir.mockResolvedValue(configOverrides);
+			const store = new StatusStore(bridge as never);
+			await store.refresh();
+			return store.getSnapshot();
+		}
+
+		it("is configured when the provider is local-agent with no key and no sign-in", async () => {
+			const snap = await buildSnapshot({ aiProvider: "local-agent" });
+			expect(snap.derived.usesLocalAgent).toBe(true);
+			expect(snap.derived.signedIn || snap.derived.hasApiKey || snap.derived.usesLocalAgent).toBe(true);
+		});
+
+		it("is not configured for anthropic with no key", async () => {
+			const snap = await buildSnapshot({ aiProvider: "anthropic" });
+			expect(snap.derived.usesLocalAgent).toBe(false);
+			expect(snap.derived.signedIn || snap.derived.hasApiKey || snap.derived.usesLocalAgent).toBe(false);
+		});
+
+		it("stays configured after the agent binary disappears", async () => {
+			// usesLocalAgent is keyed on config INTENT, not live presence: losing
+			// the binary must not silently discard the user's provider choice and
+			// dump them back into onboarding. There is no "binary present" input
+			// to this derivation at all — re-deriving from the same config
+			// (simulating a reload with the agent gone) must still be true.
+			const snap = await buildSnapshot({ aiProvider: "local-agent" });
+			expect(snap.derived.usesLocalAgent).toBe(true);
 		});
 	});
 });

--- a/vscode/src/stores/StatusStore.ts
+++ b/vscode/src/stores/StatusStore.ts
@@ -80,6 +80,7 @@ export interface StatusSnapshot extends Snapshot<StatusChangeReason> {
 const INITIAL_DERIVED: StatusDerived = {
 	hasApiKey: false,
 	signedIn: false,
+	usesLocalAgent: false,
 	allHooksInstalled: false,
 	hooksDescription: "none installed",
 };

--- a/vscode/src/views/SettingsCssBuilder.ts
+++ b/vscode/src/views/SettingsCssBuilder.ts
@@ -164,6 +164,17 @@ export function buildSettingsCss(): string {
     min-height: 14px;
   }
 
+  /* ── Local agent tool availability status (Settings > AI Summary) ── */
+  .local-agent-status {
+    font-size: 12px;
+    color: var(--vscode-descriptionForeground);
+    margin: 4px 0 0;
+    min-height: 16px;
+  }
+  .local-agent-status.error {
+    color: var(--vscode-errorForeground);
+  }
+
   select {
     cursor: pointer;
     appearance: auto;

--- a/vscode/src/views/SettingsHtmlBuilder.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.ts
@@ -166,6 +166,7 @@ export function buildSettingsHtml(nonce: string): string {
         <select id="localAgentTool">
           ${LOCAL_AGENT_TOOL_OPTIONS}
         </select>
+        <p class="local-agent-status" id="localAgentStatus"></p>
         <p class="section-hint">Uses your local agent's own login (subscription/BYOK). Sign in with that tool's CLI if prompted.</p>
       </div>
     </section>

--- a/vscode/src/views/SettingsScriptBuilder.test.ts
+++ b/vscode/src/views/SettingsScriptBuilder.test.ts
@@ -1,6 +1,211 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ALLOWED_JOLLI_HOSTS } from "../../../cli/src/core/JolliApiUtils.js";
+import { LOCAL_AGENT_TOOLS } from "../../../cli/src/core/localagent/ToolMeta.js";
 import { buildSettingsScript } from "./SettingsScriptBuilder.js";
+
+// ── Minimal fake-DOM harness for behaviorally executing the generated script ──
+//
+// No jsdom dependency exists anywhere in this monorepo (checked: neither a
+// devDependency nor hoisted). Rather than adding one, this stubs just enough
+// of `window` / `document` / `acquireVsCodeApi` for `buildSettingsScript()`'s
+// output to run unmodified under `new Function(...)` in Node's own global
+// scope (which already provides `atob`, `URL`, `setTimeout`, etc. that the
+// script also references). `document.getElementById` lazily fabricates a
+// generic element for any id the script asks for, so the ~40 unrelated DOM
+// refs the script declares up front never need to be enumerated by hand —
+// only the handful this suite actually drives or inspects get a typed,
+// pre-seeded element (the two `<select>`s, the status line, the Apply button).
+
+interface FakeClassList {
+	add(...classes: string[]): void;
+	remove(...classes: string[]): void;
+	toggle(cls: string, force?: boolean): boolean;
+	contains(cls: string): boolean;
+}
+
+type Listener = () => void;
+
+interface FakeElement {
+	value: string;
+	textContent: string;
+	checked: boolean;
+	disabled: boolean;
+	readonly selectedIndex: number;
+	readonly options: ReadonlyArray<{ readonly value: string; readonly textContent: string }>;
+	readonly classList: FakeClassList;
+	addEventListener(type: string, cb: Listener): void;
+	fire(type: string): void;
+}
+
+function createClassList(): FakeClassList {
+	const classes = new Set<string>();
+	return {
+		add: (...cs) => {
+			for (const c of cs) classes.add(c);
+		},
+		remove: (...cs) => {
+			for (const c of cs) classes.delete(c);
+		},
+		toggle: (cls, force) => {
+			const shouldHave = force === undefined ? !classes.has(cls) : force;
+			if (shouldHave) classes.add(cls);
+			else classes.delete(cls);
+			return shouldHave;
+		},
+		contains: (cls) => classes.has(cls),
+	};
+}
+
+function createElement(optionValues?: readonly string[], labels?: Record<string, string>): FakeElement {
+	const listeners: Record<string, Listener[]> = {};
+	let currentValue = optionValues?.[0] ?? "";
+	const options = (optionValues ?? []).map((v) => ({ value: v, textContent: labels?.[v] ?? v }));
+	return {
+		get value() {
+			return currentValue;
+		},
+		set value(v: string) {
+			currentValue = v;
+		},
+		textContent: "",
+		checked: false,
+		disabled: false,
+		get selectedIndex() {
+			return (optionValues ?? []).indexOf(currentValue);
+		},
+		options,
+		classList: createClassList(),
+		addEventListener(type, cb) {
+			if (!listeners[type]) listeners[type] = [];
+			listeners[type].push(cb);
+		},
+		fire(type) {
+			for (const cb of listeners[type] ?? []) cb();
+		},
+	};
+}
+
+interface ScriptHandles {
+	readonly aiProviderSelect: FakeElement;
+	readonly localAgentToolSelect: FakeElement;
+	readonly localAgentStatus: FakeElement;
+	readonly applyBtn: FakeElement;
+	readonly posted: ReadonlyArray<Record<string, unknown>>;
+	/** Lazily-fabricated access to any other element by id (e.g. `saveFeedback`,
+	 * `rebuildKbBtn`, `syncNowBtn`) — for tests that need to read text or fire
+	 * an event on one of the ~40 refs not pre-seeded above. */
+	element(id: string): FakeElement;
+	receive(msg: Record<string, unknown>): void;
+	setProvider(value: string): void;
+	selectTool(value: string): void;
+}
+
+/** Executes `scriptSource` (the output of `buildSettingsScript()`) against a
+ * fresh fake DOM and returns handles for driving it. Each call gets isolated
+ * state — `new Function` creates a distinct closure per invocation. */
+function runScript(scriptSource: string): ScriptHandles {
+	const elements = new Map<string, FakeElement>();
+	const messageListeners: Array<(event: { data: Record<string, unknown> }) => void> = [];
+	const posted: Array<Record<string, unknown>> = [];
+
+	const toolIds = Object.keys(LOCAL_AGENT_TOOLS);
+	const toolLabels: Record<string, string> = {};
+	for (const id of toolIds) {
+		toolLabels[id] = LOCAL_AGENT_TOOLS[id as keyof typeof LOCAL_AGENT_TOOLS].label;
+	}
+
+	function get(id: string): FakeElement {
+		let el = elements.get(id);
+		if (!el) {
+			el = createElement();
+			elements.set(id, el);
+		}
+		return el;
+	}
+
+	elements.set("aiProvider", createElement(["anthropic", "jolli", "local-agent"]));
+	elements.set("localAgentTool", createElement(toolIds, toolLabels));
+	const aiProviderSelect = get("aiProvider");
+	const localAgentToolSelect = get("localAgentTool");
+	const localAgentStatus = get("localAgentStatus");
+	const applyBtn = get("applyBtn");
+
+	const documentStub = {
+		getElementById: (id: string) => get(id),
+		querySelectorAll: () => ({ forEach: () => {} }),
+		querySelector: () => null,
+		addEventListener: () => {},
+	};
+
+	const windowStub = {
+		addEventListener: (type: string, cb: (event: { data: Record<string, unknown> }) => void) => {
+			if (type === "message") messageListeners.push(cb);
+		},
+	};
+
+	function acquireVsCodeApi() {
+		return { postMessage: (m: Record<string, unknown>) => posted.push(m) };
+	}
+
+	const run = new Function("window", "document", "acquireVsCodeApi", scriptSource) as (
+		w: unknown,
+		d: unknown,
+		a: unknown,
+	) => void;
+	run(windowStub, documentStub, acquireVsCodeApi);
+
+	return {
+		aiProviderSelect,
+		localAgentToolSelect,
+		localAgentStatus,
+		applyBtn,
+		posted,
+		element: (id) => get(id),
+		receive(msg) {
+			for (const cb of messageListeners) cb({ data: msg });
+		},
+		setProvider(value) {
+			aiProviderSelect.value = value;
+			aiProviderSelect.fire("change");
+		},
+		selectTool(value) {
+			localAgentToolSelect.value = value;
+			localAgentToolSelect.fire("change");
+		},
+	};
+}
+
+/** Dispatches a `settingsLoaded` message so `captureInitialState()` runs and
+ * the form reaches its normal post-load baseline (isDirty=false, hasErrors=
+ * false) before a test starts driving it. */
+function loadSettings(handles: ScriptHandles, settingsOverrides: Record<string, unknown> = {}): void {
+	handles.receive({
+		command: "settingsLoaded",
+		maskedApiKey: "",
+		maskedJolliApiKey: "",
+		settings: {
+			model: "sonnet",
+			maxTokens: null,
+			aiProvider: "anthropic",
+			localAgentTool: "claude-code",
+			claudeEnabled: true,
+			codexEnabled: false,
+			geminiEnabled: false,
+			openCodeEnabled: false,
+			cursorEnabled: false,
+			devinEnabled: false,
+			copilotEnabled: false,
+			clineEnabled: false,
+			antigravityEnabled: false,
+			globalInstructions: false,
+			localFolder: "",
+			excludePatterns: "",
+			compileExcludeFolders: "",
+			dcoSignoff: false,
+			...settingsOverrides,
+		},
+	});
+}
 
 describe("SettingsScriptBuilder", () => {
 	const script = buildSettingsScript();
@@ -224,6 +429,270 @@ describe("SettingsScriptBuilder", () => {
 		expect(script).toContain("localAgentToolSelect.value = msg.settings.localAgentTool");
 	});
 
+	// ── Local agent tool availability check ──
+	//
+	// This suite is source-text (regex) based, like the rest of this file — it
+	// asserts the generated script *contains* the right shape, not that a live
+	// DOM behaves correctly. It's still useful for pinning the exact predicate
+	// text and wiring shape, but it cannot catch a behaviorally different
+	// expression that happens to match the regex (an inverted operator, a
+	// widened `&&`→`||`, a dropped negation). The three scoping/timing rules
+	// (provider scoping, in-flight never blocking, stale-reply rejection) get
+	// real behavioral coverage below, in the "local agent tool availability
+	// (behavioral)" block, which executes this exact generated script against a
+	// fake DOM and drives it like a live webview would.
+	describe("local agent tool availability", () => {
+		it("models availability as three states, not a boolean", () => {
+			// null = unknown/in-flight; only a confirmed `false` may block Apply —
+			// a boolean would collapse "unknown" into either "blocks" or
+			// "doesn't", both wrong for a pending probe.
+			expect(script).toContain("let localAgentAvailable = null;");
+			expect(script).toContain("localAgentAvailable = null;");
+			expect(script).toContain("localAgentAvailable = !!msg.available;");
+		});
+
+		it("scopes the block to aiProvider === 'local-agent' (rule 1)", () => {
+			expect(script).toContain("function localAgentBlocks()");
+			expect(script).toMatch(
+				/function localAgentBlocks\(\) {\s*return aiProviderSelect\.value === 'local-agent' && localAgentAvailable === false;/,
+			);
+		});
+
+		it("feeds localAgentBlocks() into the existing applyBtn.disabled seam, not a parallel gate", () => {
+			expect(script).toContain(
+				"applyBtn.disabled = !isDirty || hasErrors || localAgentBlocks();",
+			);
+		});
+
+		it("only a confirmed-unavailable probe result arms the block (rule 2)", () => {
+			// probeLocalAgent() resets to null (unknown) before posting — an
+			// in-flight probe must never read as available === false.
+			expect(script).toMatch(
+				/function probeLocalAgent\(\) {[\s\S]*localAgentAvailable = null;[\s\S]*vscode\.postMessage\(\{ command: 'probeLocalAgent', tool: tool \}\);/,
+			);
+		});
+
+		it("tracks which tool the in-flight probe was for and ignores stale replies (rule 3)", () => {
+			expect(script).toContain("let localAgentProbeTool = null;");
+			expect(script).toContain("localAgentProbeTool = tool;");
+			expect(script).toMatch(/case 'localAgentProbeResult':[\s\S]*if \(msg\.tool !== localAgentProbeTool\) break;/);
+		});
+
+		it("probes on tool-select change, on switching the provider to local-agent, and on panel open", () => {
+			expect(script).toMatch(
+				/localAgentToolSelect\.addEventListener\('change', function\(\) {\s*checkDirty\(\); clearSaveFeedback\(\); probeLocalAgent\(\);/,
+			);
+			expect(script).toMatch(
+				/aiProviderSelect\.addEventListener\('change', function\(\) {[\s\S]*if \(aiProviderSelect\.value === 'local-agent'\) probeLocalAgent\(\);/,
+			);
+			expect(script).toMatch(
+				/case 'settingsLoaded':[\s\S]*if \(aiProviderSelect\.value === 'local-agent'\) probeLocalAgent\(\);[\s\S]*captureInitialState\(\);/,
+			);
+		});
+
+		it("gates the on-open probe on the provider — the card is hidden for every other one", () => {
+			// An unconditional probe on open spends a 161-1772 ms subprocess to
+			// render a status line inside a `.hidden` card panel.
+			const onOpen = /case 'settingsLoaded':[\s\S]*?captureInitialState\(\);/.exec(script)?.[0] ?? "";
+			expect(onOpen).toContain("if (aiProviderSelect.value === 'local-agent') probeLocalAgent();");
+			expect(onOpen).not.toMatch(/(?<!'local-agent'\) )probeLocalAgent\(\);/);
+		});
+
+		it("posts probeLocalAgent with the selected tool id", () => {
+			expect(script).toContain(
+				"vscode.postMessage({ command: 'probeLocalAgent', tool: tool });",
+			);
+		});
+
+		it("renders a not-found message and toggles the .error class via classList (no inline style)", () => {
+			expect(script).toContain("not found on this machine. Install it, or pick another tool.");
+			expect(script).toContain("localAgentStatus.classList.toggle('error', !msg.available);");
+		});
+	});
+
+	// ── Local agent tool availability check (behavioral) ──
+	//
+	// Executes the actual generated script (via `runScript` — see the fake-DOM
+	// harness at the top of this file) against a fake DOM and drives it exactly
+	// as a live webview would: dispatching `change` events on the real select
+	// elements and `message` events carrying host replies, then reading back
+	// `applyBtn.disabled` / `localAgentStatus.textContent`. Unlike the regex
+	// suite above, these tests fail on a behaviorally wrong predicate even if
+	// its source text would still match a loose regex.
+	describe("local agent tool availability (behavioral)", () => {
+		it("blocks Apply when the selected tool is confirmed unavailable and aiProvider is local-agent", () => {
+			const h = runScript(script);
+			loadSettings(h);
+			h.setProvider("local-agent");
+			h.selectTool("cursor-agent");
+			h.receive({ command: "localAgentProbeResult", tool: "cursor-agent", available: false });
+
+			expect(h.applyBtn.disabled).toBe(true);
+			expect(h.localAgentStatus.textContent).toContain("not found");
+		});
+
+		it("rule 1: does NOT block Apply for the same unavailable tool when aiProvider is not local-agent", () => {
+			const h = runScript(script);
+			loadSettings(h); // aiProvider defaults to 'anthropic'
+			h.selectTool("cursor-agent");
+			h.receive({ command: "localAgentProbeResult", tool: "cursor-agent", available: false });
+
+			expect(h.applyBtn.disabled).toBe(false);
+		});
+
+		it("rule 1: re-enables Apply when the provider switches away from local-agent", () => {
+			const h = runScript(script);
+			loadSettings(h);
+			h.setProvider("local-agent");
+			h.selectTool("cursor-agent");
+			h.receive({ command: "localAgentProbeResult", tool: "cursor-agent", available: false });
+			expect(h.applyBtn.disabled).toBe(true);
+
+			h.setProvider("anthropic");
+
+			expect(h.applyBtn.disabled).toBe(false);
+		});
+
+		it("rule 2: does NOT block Apply while the probe is in flight (no reply yet)", () => {
+			const h = runScript(script);
+			loadSettings(h);
+			h.setProvider("local-agent");
+			h.selectTool("cursor-agent"); // dispatches the probe; no reply delivered
+
+			expect(h.applyBtn.disabled).toBe(false);
+			expect(h.localAgentStatus.textContent).toContain("Checking");
+		});
+
+		it("rule 3: ignores a stale reply for a tool the user has already moved off", () => {
+			const h = runScript(script);
+			loadSettings(h);
+			h.setProvider("local-agent");
+			h.selectTool("cursor-agent"); // probe A dispatched
+			h.selectTool("codex"); // probe B dispatched; probe A is now stale
+			h.receive({ command: "localAgentProbeResult", tool: "cursor-agent", available: false }); // A's (stale) reply
+
+			// codex's probe is still unresolved (unknown), and the stale cursor-agent
+			// reply must not have been applied — so Apply stays enabled.
+			expect(h.applyBtn.disabled).toBe(false);
+		});
+	});
+
+	// ── Apply held behind an in-flight probe ──
+	//
+	// Rule 2 keeps Apply ENABLED while a probe is in flight (a single global
+	// button must not gray out for an unrelated tab's edit), which leaves a
+	// 161-1772 ms window — the measured single-tool probe cost, DetectAgents.ts —
+	// where a click would persist `aiProvider: 'local-agent'` against a tool
+	// nobody verified. The race is closed at the save chokepoint instead: the
+	// click is HELD, and the probe reply decides it.
+	describe("apply held behind an in-flight local-agent probe", () => {
+		/** Drives the form to "provider = local-agent, probe in flight, form dirty". */
+		function armInFlightProbe(tool = "cursor-agent"): ScriptHandles {
+			const h = runScript(script);
+			loadSettings(h);
+			h.setProvider("local-agent");
+			h.selectTool(tool); // probe dispatched; no reply delivered
+			return h;
+		}
+
+		const appliesOf = (h: ScriptHandles) => h.posted.filter((m) => m.command === "applySettings");
+
+		it("holds the save instead of posting it, and says so", () => {
+			const h = armInFlightProbe();
+
+			// Rule 2 is intact: the button itself never goes disabled mid-probe.
+			expect(h.applyBtn.disabled).toBe(false);
+			h.applyBtn.fire("click");
+
+			expect(appliesOf(h)).toHaveLength(0);
+			expect(h.element("saveFeedback").textContent).toContain("Checking");
+			expect(h.element("saveFeedback").classList.contains("error")).toBe(false);
+		});
+
+		it("posts the held save once the probe confirms the tool is available", () => {
+			const h = armInFlightProbe();
+			h.applyBtn.fire("click");
+			expect(appliesOf(h)).toHaveLength(0);
+
+			h.receive({ command: "localAgentProbeResult", tool: "cursor-agent", available: true });
+
+			const applied = appliesOf(h);
+			expect(applied).toHaveLength(1);
+			expect(applied[0]?.settings).toMatchObject({
+				aiProvider: "local-agent",
+				localAgentTool: "cursor-agent",
+			});
+		});
+
+		it("never posts the held save when the probe confirms the tool is unavailable", () => {
+			const h = armInFlightProbe();
+			h.applyBtn.fire("click");
+
+			h.receive({ command: "localAgentProbeResult", tool: "cursor-agent", available: false });
+
+			expect(appliesOf(h)).toHaveLength(0);
+			// Falls into submitApplySettings()'s existing localAgentBlocks() branch,
+			// so the user gets the actionable wording, not the neutral 'Checking…'.
+			expect(h.element("saveFeedback").textContent).toContain("isn't available on this machine");
+			expect(h.element("saveFeedback").classList.contains("error")).toBe(true);
+		});
+
+		it("drops the held save when the user switches tools mid-hold", () => {
+			const h = armInFlightProbe("cursor-agent");
+			h.applyBtn.fire("click"); // held against cursor-agent
+
+			h.selectTool("codex"); // form moved; the held click is now stale
+			h.receive({ command: "localAgentProbeResult", tool: "codex", available: true });
+
+			// The codex probe resolving must not retroactively fire a click the user
+			// made while looking at cursor-agent.
+			expect(appliesOf(h)).toHaveLength(0);
+		});
+
+		it("a stale reply neither posts nor releases the held save", () => {
+			const h = armInFlightProbe("cursor-agent");
+			h.applyBtn.fire("click");
+
+			// A reply for a tool that is no longer the probe target is dropped by the
+			// rule-3 guard before the resume site is ever reached.
+			h.receive({ command: "localAgentProbeResult", tool: "codex", available: true });
+
+			expect(appliesOf(h)).toHaveLength(0);
+			expect(h.element("saveFeedback").textContent).toContain("Checking");
+		});
+
+		it("watchdog: reports a failure and saves nothing when no reply ever arrives", () => {
+			vi.useFakeTimers();
+			try {
+				const h = armInFlightProbe();
+				h.applyBtn.fire("click");
+
+				vi.advanceTimersByTime(8000);
+
+				expect(appliesOf(h)).toHaveLength(0);
+				expect(h.element("saveFeedback").textContent).toContain("Couldn't verify");
+				expect(h.element("saveFeedback").classList.contains("error")).toBe(true);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("a late reply after the watchdog fired does not resurrect the save", () => {
+			vi.useFakeTimers();
+			try {
+				const h = armInFlightProbe();
+				h.applyBtn.fire("click");
+				vi.advanceTimersByTime(8000);
+
+				h.receive({ command: "localAgentProbeResult", tool: "cursor-agent", available: true });
+
+				expect(appliesOf(h)).toHaveLength(0);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+	});
+
 	// ── Advanced toggle ──
 
 	it("wires the Advanced links to data-advanced-panel siblings", () => {
@@ -267,11 +736,15 @@ describe("SettingsScriptBuilder", () => {
 		);
 	});
 
-	it("aborts the migrate-after-apply chain on settingsError", () => {
+	it("aborts the migrate-after-apply and sync-after-apply chains on settingsError", () => {
 		// Without this, a server-side rejection (e.g. invalid jolli key) would
-		// leave the migrate to run anyway against unsaved settings.
+		// leave the migrate to run anyway against unsaved settings. Both links are
+		// asserted because the clearing moved behind abortApplyChains() — shared
+		// with the probe-hold paths, which need the same disarm — so checking only
+		// the call site would pass even if the helper stopped clearing a flag.
+		expect(script).toMatch(/case 'settingsError':[\s\S]*abortApplyChains\(\)/);
 		expect(script).toMatch(
-			/case 'settingsError':[\s\S]*pendingMigrateAfterApply = false/,
+			/function abortApplyChains\(\) {[\s\S]*pendingMigrateAfterApply = false;[\s\S]*pendingSyncAfterApply = false;/,
 		);
 	});
 

--- a/vscode/src/views/SettingsScriptBuilder.ts
+++ b/vscode/src/views/SettingsScriptBuilder.ts
@@ -28,6 +28,7 @@ export function buildSettingsScript(): string {
   const maxTokensInput = document.getElementById('maxTokens');
   const aiProviderSelect = document.getElementById('aiProvider');
   const localAgentToolSelect = document.getElementById('localAgentTool');
+  const localAgentStatus = document.getElementById('localAgentStatus');
   // Two Jolli API key inputs (jolli-ok and jolli-nokey cards) — kept in sync.
   const jolliApiKeyInput = document.getElementById('jolliApiKey');
   const jolliApiKeyNoKeyInput = document.getElementById('jolliApiKeyNoKey');
@@ -73,6 +74,22 @@ export function buildSettingsScript(): string {
   let initialState = {};
   let isDirty = false;
   let hasErrors = false;
+  // Availability of the currently-selected agent tool. null = unknown / probe
+  // in flight. Only a confirmed false blocks Apply (via localAgentBlocks(),
+  // read from updateApplyBtn), so a slow probe never flickers Apply to
+  // disabled.
+  let localAgentAvailable = null;
+  // Which tool the in-flight probe was dispatched for. A reply is applied
+  // only when it still matches the current dropdown value, so switching tools
+  // before a slow reply lands can't apply a stale result to the new selection.
+  let localAgentProbeTool = null;
+  // Set when an Apply click landed while a probe was still in flight. The save
+  // is HELD (not rejected, not sent) until the reply decides it — see
+  // submitApplySettings. Cleared by probeLocalAgent(), so any form edit that
+  // dispatches a new probe drops the held save rather than applying a click the
+  // user made against a form state that no longer exists.
+  let pendingApply = false;
+  let pendingApplyTimer = null;
   // Auth state pushed by the extension host (settingsLoaded + authStateChanged).
   let signedIn = false;
   let hasJolliKey = false;
@@ -405,17 +422,73 @@ export function buildSettingsScript(): string {
     updateApplyBtn();
   }
 
+  // Only meaningful when the provider actually reads localAgentTool ("Ignored
+  // unless aiProvider === 'local-agent'" — cli/src/Types.ts). Apply is a
+  // single global button saving every tab, so an unusable agent tool must not
+  // block an unrelated Memory Bank edit. A pending probe (localAgentAvailable
+  // === null) never blocks — only a confirmed-unavailable result does.
+  function localAgentBlocks() {
+    return aiProviderSelect.value === 'local-agent' && localAgentAvailable === false;
+  }
+
+  // Looks up a tool's display label by <option value>, never by selectedIndex:
+  // selectedIndex is -1 when nothing is selected, and indexing options[-1]
+  // throws. Falls back to the raw id so a lookup miss degrades to readable
+  // text instead of "undefined".
+  function localAgentToolOptionLabel(toolId) {
+    for (var i = 0; i < localAgentToolSelect.options.length; i++) {
+      if (localAgentToolSelect.options[i].value === toolId) {
+        return localAgentToolSelect.options[i].textContent;
+      }
+    }
+    return toolId;
+  }
+
+  // Verifies the currently-selected agent tool actually runs on this machine.
+  // Dispatched on tool-select change, on switching the provider to
+  // local-agent, and once on panel open (settingsLoaded) so an already-
+  // unavailable configured tool surfaces immediately.
+  function probeLocalAgent() {
+    var tool = localAgentToolSelect.value;
+    // A new probe means the form moved (tool switched, provider switched, or a
+    // fresh load). Whatever Apply click is being held was made against the old
+    // state, so drop it instead of silently re-targeting it at the new value.
+    // The change handlers call clearSaveFeedback() just before this, so the
+    // 'Checking…' line the held save wrote is already gone.
+    cancelPendingApply();
+    localAgentProbeTool = tool;
+    localAgentAvailable = null;
+    if (localAgentStatus) {
+      localAgentStatus.textContent = 'Checking…';
+      localAgentStatus.classList.remove('error');
+    }
+    updateApplyBtn();
+    vscode.postMessage({ command: 'probeLocalAgent', tool: tool });
+  }
+
   function updateApplyBtn() {
-    // Gate on both "nothing to save" and "has client-side errors". The click
-    // handler also re-runs validateAll() and surfaces a saveFeedback message
-    // if a validation error slips through (e.g. programmatic value change),
-    // so the user gets explicit feedback rather than a swallowed click.
-    applyBtn.disabled = !isDirty || hasErrors;
+    // Gate on "nothing to save", "has client-side errors", and an unusable
+    // local-agent tool selection (localAgentBlocks — only live while the
+    // provider is local-agent). The click handler also re-runs validateAll()
+    // and surfaces a saveFeedback message if a validation error slips through
+    // (e.g. programmatic value change), so the user gets explicit feedback
+    // rather than a swallowed click.
+    applyBtn.disabled = !isDirty || hasErrors || localAgentBlocks();
   }
 
   function clearSaveFeedback() {
     saveFeedback.classList.remove('visible');
     saveFeedback.classList.remove('error');
+  }
+
+  // Drops a held Apply and disarms its watchdog. Idempotent — safe to call when
+  // nothing is held, which is the common case.
+  function cancelPendingApply() {
+    pendingApply = false;
+    if (pendingApplyTimer) {
+      clearTimeout(pendingApplyTimer);
+      pendingApplyTimer = null;
+    }
   }
 
   // ── Event listeners ──
@@ -453,28 +526,102 @@ export function buildSettingsScript(): string {
     rebuildKbStatus.textContent = '';
   });
   modelSelect.addEventListener('change', function() { checkDirty(); clearSaveFeedback(); });
-  localAgentToolSelect.addEventListener('change', function() { checkDirty(); clearSaveFeedback(); });
+  localAgentToolSelect.addEventListener('change', function() {
+    checkDirty(); clearSaveFeedback(); probeLocalAgent();
+  });
   aiProviderSelect.addEventListener('change', function() {
     checkDirty(); clearSaveFeedback(); syncProviderCard();
+    // Re-verify when switching TO local-agent (a stale/never-probed result
+    // must not silently pass); switching away is handled by checkDirty()'s
+    // updateApplyBtn() call above, since localAgentBlocks() reads the live
+    // provider value and clears on its own.
+    if (aiProviderSelect.value === 'local-agent') probeLocalAgent();
   });
   [claudeEnabledInput, codexEnabledInput, geminiEnabledInput, openCodeEnabledInput, cursorEnabledInput, copilotEnabledInput, clineEnabledInput, devinEnabledInput, antigravityEnabledInput, globalInstructionsInput].forEach(function(input) {
     input.addEventListener('change', function() { validateAll(); checkDirty(); clearSaveFeedback(); });
   });
   dcoSignoffInput.addEventListener('change', function() { checkDirty(); clearSaveFeedback(); });
 
+  // Aborts a queued Migrate-after-Apply / SyncNow-after-Apply chain. Called
+  // wherever the save those chains are waiting on will definitively not land:
+  // the host rejected it (settingsError), a resumed held save hit a validation
+  // error, or the probe watchdog gave up. Without a single place doing this, a
+  // flag armed by the Sync now / Migrate button can outlive its save and fire
+  // against some LATER, unrelated one.
+  function abortApplyChains() {
+    if (pendingMigrateAfterApply) {
+      // Don't migrate against state that was never persisted.
+      pendingMigrateAfterApply = false;
+      rebuildKbStatus.textContent = '';
+    }
+    // Same reason: no sync round against config the host never wrote.
+    pendingSyncAfterApply = false;
+  }
+
   // ── Apply Changes ──
-  // Returns true if the apply message was posted, false if a validation error
-  // blocked the post. The Migrate-after-Apply chain uses the return value to
-  // decide whether to clear pendingMigrateAfterApply on the spot.
+  // Returns true if the save is under way — either posted now, or HELD behind an
+  // in-flight local-agent probe that will re-enter this function. Returns false
+  // only when the save definitively will not happen (a validation error, or a
+  // confirmed-unavailable agent tool).
+  //
+  // The Migrate-after-Apply / SyncNow-after-Apply chains read this to decide
+  // whether to disarm on the spot, so "held" must be truthy: those chains have
+  // to stay armed across the hold and fire on the resumed save's settingsSaved.
+  // The resume site is what disarms them if the held save is then rejected.
   function submitApplySettings() {
     // Final client-side pass so inline errors stay in sync even if a field was
     // changed programmatically or before any input event had a chance to fire.
     validateAll();
-    if (hasErrors) {
-      saveFeedback.textContent = 'Please fix the highlighted fields before saving';
+    // Mirror updateApplyBtn()'s gate here too: the Apply button being disabled
+    // only stops a direct click. Migrate-after-Apply and SyncNow-after-Apply
+    // call submitApplySettings() directly, bypassing the button entirely, so a
+    // confirmed-unavailable local-agent tool must be re-checked at the actual
+    // save chokepoint or it can still be persisted through those chains.
+    if (hasErrors || localAgentBlocks()) {
+      saveFeedback.textContent = hasErrors
+        ? 'Please fix the highlighted fields before saving'
+        : localAgentToolOptionLabel(localAgentToolSelect.value) +
+          " isn't available on this machine. Install it, or pick another tool before saving.";
       saveFeedback.classList.add('error');
       saveFeedback.classList.add('visible');
       return false;
+    }
+    // An in-flight probe means "unknown", not "usable". localAgentBlocks() above
+    // only fires on a CONFIRMED false, by design: Apply is one global button and
+    // must not gray out mid-probe for an unrelated tab's edit (rule 2). That
+    // leaves a 161-1772 ms window (single-tool probe cost, DetectAgents.ts) in
+    // which a click would persist aiProvider: 'local-agent' against a tool
+    // nobody has verified — so the race is closed HERE instead, by HOLDING the
+    // save until the reply arrives. The localAgentProbeResult handler then
+    // re-enters this function, which either posts or reports the tool as
+    // unavailable through the branch above.
+    if (aiProviderSelect.value === 'local-agent' && localAgentAvailable === null) {
+      pendingApply = true;
+      saveFeedback.textContent =
+        'Checking ' + localAgentToolOptionLabel(localAgentToolSelect.value) + '…';
+      saveFeedback.classList.remove('error');
+      saveFeedback.classList.add('visible');
+      // Watchdog. handleProbeLocalAgent replies on every path a dropdown pick can
+      // take, but a held save must not depend on that promise: one lost reply
+      // would swallow the click with no save and no error, and the user has no
+      // way to tell that from a slow probe. Armed only when a save is actually
+      // held (never on an ordinary probe), and set well past the 1772 ms
+      // worst-case so a slow-but-live probe still wins.
+      if (pendingApplyTimer) clearTimeout(pendingApplyTimer);
+      pendingApplyTimer = setTimeout(function() {
+        pendingApplyTimer = null;
+        if (!pendingApply) return;
+        pendingApply = false;
+        saveFeedback.textContent =
+          "Couldn't verify " + localAgentToolOptionLabel(localAgentToolSelect.value) +
+          ' — nothing was saved. Click Apply to try again.';
+        saveFeedback.classList.add('error');
+        saveFeedback.classList.add('visible');
+        abortApplyChains();
+      }, 8000);
+      // Truthy: the save is queued, not refused. See the docstring — the
+      // Migrate/Sync chains must stay armed across the hold.
+      return true;
     }
     var maxVal = maxTokensInput.value.trim();
     vscode.postMessage({
@@ -644,6 +791,13 @@ export function buildSettingsScript(): string {
         // clicked on an unknown count.
         if (missingSummariesCount) missingSummariesCount.textContent = 'Checking…';
         if (generateSummariesBtn) generateSummariesBtn.disabled = true;
+        // Probe on open (not just on dropdown change) so a panel opened with
+        // an already-unavailable tool configured shows the problem immediately.
+        // Gated on the provider: the local-agent card is hidden for every other
+        // provider, so an unconditional probe would spend a 161-1772 ms
+        // subprocess producing a status line nobody can see. Switching TO
+        // local-agent later re-probes via the aiProvider change handler.
+        if (aiProviderSelect.value === 'local-agent') probeLocalAgent();
         captureInitialState();
         break;
       case 'missingSummaryCountLoaded': {
@@ -663,6 +817,36 @@ export function buildSettingsScript(): string {
         // Pushed after sign-in / sign-out so the cards re-render without
         // requiring a full settings reload. Mirror IntelliJ's auth listener.
         applyAuthState(msg);
+        break;
+      case 'localAgentProbeResult':
+        // Ignore a stale reply for a tool the user has already moved off —
+        // e.g. switched from Cursor to Codex before Cursor's probe returned.
+        if (msg.tool !== localAgentProbeTool) break;
+        localAgentAvailable = !!msg.available;
+        if (localAgentStatus) {
+          // Derive the label from localAgentProbeTool (the id the reply is
+          // for), not localAgentToolSelect.selectedIndex — selectedIndex is
+          // -1 when nothing is selected, and indexing options[-1] throws.
+          localAgentStatus.textContent = msg.available
+            ? ''
+            : localAgentToolOptionLabel(localAgentProbeTool) +
+              ' not found on this machine. Install it, or pick another tool.';
+          localAgentStatus.classList.toggle('error', !msg.available);
+        }
+        updateApplyBtn();
+        // Resume a save the probe was holding. Reached only past the stale-reply
+        // guard above, so the verdict being acted on is the one for the tool
+        // currently selected. Re-entering submitApplySettings() (rather than
+        // posting from here) keeps ONE save chokepoint: availability is now a
+        // definite true/false, so it either posts or takes the
+        // localAgentBlocks() error branch with its existing wording.
+        if (pendingApply) {
+          cancelPendingApply();
+          // Disarm the Migrate/Sync chains here if the verdict turned the held
+          // save into a rejection — they were deliberately left armed across the
+          // hold, so this is the only place that can still catch them.
+          if (!submitApplySettings()) abortApplyChains();
+        }
         break;
       case 'setLocalFolder':
         localFolderInput.value = msg.path || '';
@@ -719,17 +903,12 @@ export function buildSettingsScript(): string {
         saveFeedback.textContent = msg.message;
         saveFeedback.classList.add('error');
         saveFeedback.classList.add('visible');
-        if (pendingMigrateAfterApply) {
-          // Host rejected the save (e.g. server-side jolli key validation).
-          // Abort the chain so we don't migrate against unsaved state.
-          pendingMigrateAfterApply = false;
-          rebuildKbStatus.textContent = '';
-        }
-        if (pendingSyncAfterApply) {
-          // Same reason: don't run a sync round against config the host just
-          // refused to persist.
-          pendingSyncAfterApply = false;
-        }
+        // Host rejected the save (e.g. server-side jolli key validation).
+        abortApplyChains();
+        // Deliberately does NOT touch pendingApply. This message is about a save
+        // that was POSTED; a held save has posted nothing, so an error arriving
+        // mid-hold belongs to an earlier submission. Cancelling here would drop
+        // the newer held save silently — let it resume and be judged on its own.
         break;
     }
   });

--- a/vscode/src/views/SettingsWebviewPanel.test.ts
+++ b/vscode/src/views/SettingsWebviewPanel.test.ts
@@ -96,6 +96,18 @@ vi.mock("../../../cli/src/core/GitOps.js", () => ({
 	listWorktrees: mockListWorktrees,
 }));
 
+const { mockIsLocalAgentUsable } = vi.hoisted(() => ({
+	mockIsLocalAgentUsable: vi.fn().mockResolvedValue(true),
+}));
+
+// Partial mock: only the expensive capability probe is stubbed. The rest —
+// notably `localAgentOverrideFrom`, a pure config→override mapper — stays real,
+// so these tests exercise the actual tool-scoping rule rather than a copy of it.
+vi.mock("../../../cli/src/core/localagent/DetectAgents.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../../../cli/src/core/localagent/DetectAgents.js")>()),
+	isLocalAgentUsable: mockIsLocalAgentUsable,
+}));
+
 const {
 	mockInstallClaudeHook,
 	mockRemoveClaudeHook,
@@ -237,6 +249,7 @@ describe("SettingsWebviewPanel", () => {
 		mockGetProjectRootDir.mockResolvedValue("/workspace");
 		mockSaveConfigScoped.mockResolvedValue(undefined);
 		mockListWorktrees.mockResolvedValue(["/workspace"]);
+		mockIsLocalAgentUsable.mockResolvedValue(true);
 	});
 
 	// ── show() ───────────────────────────────────────────────────────────────
@@ -2819,6 +2832,156 @@ describe("SettingsWebviewPanel", () => {
 
 			expect(postMessage).not.toHaveBeenCalledWith(
 				expect.objectContaining({ command: "rebuildKnowledgeBaseDone" }),
+			);
+		});
+	});
+
+	describe("probeLocalAgent message", () => {
+		it("probes the allow-listed tool with the configured localAgentPath override and posts the result back", async () => {
+			mockLoadConfigFromDir.mockResolvedValue({
+				apiKey: "",
+				model: "sonnet",
+				maxTokens: null,
+				localAgentTool: "cursor-agent",
+				localAgentPath: "/custom/path/to/cursor-agent",
+				claudeEnabled: true,
+			});
+			mockIsLocalAgentUsable.mockResolvedValue(true);
+
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+			postMessage.mockClear();
+
+			dispatch({ command: "probeLocalAgent", tool: "cursor-agent" });
+			await flushPromises();
+
+			// Tool-scoped: the path is paired with the tool it belongs to, so a
+			// dropdown pick of a DIFFERENT tool auto-discovers instead of borrowing
+			// this path (isLocalAgentUsable drops the mismatch — see
+			// DetectAgents.test.ts).
+			expect(mockIsLocalAgentUsable).toHaveBeenCalledWith("cursor-agent", {
+				override: { tool: "cursor-agent", path: "/custom/path/to/cursor-agent" },
+			});
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "localAgentProbeResult",
+				tool: "cursor-agent",
+				available: true,
+			});
+		});
+
+		it("posts available: false when the backend reports the tool unusable", async () => {
+			mockIsLocalAgentUsable.mockResolvedValue(false);
+
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+			postMessage.mockClear();
+
+			dispatch({ command: "probeLocalAgent", tool: "codex" });
+			await flushPromises();
+
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "localAgentProbeResult",
+				tool: "codex",
+				available: false,
+			});
+		});
+
+		it("still answers available: false when reading the config throws", async () => {
+			// The webview holds an Apply click that lands mid-probe until the reply
+			// decides it, so a swallowed reply strands a save. A failure to even
+			// establish usability must therefore answer, and answer `false` —
+			// matching isLocalAgentUsable's own error semantics rather than
+			// optimistically reporting a tool nobody could verify.
+			mockLoadConfigFromDir.mockRejectedValue(new Error("EACCES: config.json"));
+
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+			postMessage.mockClear();
+
+			dispatch({ command: "probeLocalAgent", tool: "codex" });
+			await flushPromises();
+
+			expect(mockIsLocalAgentUsable).not.toHaveBeenCalled();
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "localAgentProbeResult",
+				tool: "codex",
+				available: false,
+			});
+		});
+
+		it("drops an unrecognized tool id instead of trusting untrusted webview input", async () => {
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+			postMessage.mockClear();
+
+			dispatch({ command: "probeLocalAgent", tool: "not-a-real-tool" });
+			await flushPromises();
+
+			expect(mockIsLocalAgentUsable).not.toHaveBeenCalled();
+			expect(postMessage).not.toHaveBeenCalledWith(
+				expect.objectContaining({ command: "localAgentProbeResult" }),
+			);
+		});
+
+		it("drops a non-string tool value instead of trusting untrusted webview input", async () => {
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+			postMessage.mockClear();
+
+			dispatch({ command: "probeLocalAgent", tool: 12345 });
+			await flushPromises();
+
+			expect(mockIsLocalAgentUsable).not.toHaveBeenCalled();
+			expect(postMessage).not.toHaveBeenCalledWith(
+				expect.objectContaining({ command: "localAgentProbeResult" }),
+			);
+		});
+
+		it("logs a rejection from isLocalAgentUsable and still answers available: false", async () => {
+			// isLocalAgentUsable swallows its own errors in production, so this only
+			// fires if that contract changes. Either way the probe must not go
+			// unanswered: a reply is what releases an Apply click held mid-probe.
+			mockIsLocalAgentUsable.mockRejectedValue(new Error("probe boom"));
+
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+			postMessage.mockClear();
+
+			dispatch({ command: "probeLocalAgent", tool: "opencode" });
+			await flushPromises();
+
+			expect(logError).toHaveBeenCalledWith(
+				"SettingsPanel",
+				expect.stringContaining("probe boom"),
+			);
+			expect(postMessage).toHaveBeenCalledWith({
+				command: "localAgentProbeResult",
+				tool: "opencode",
+				available: false,
+			});
+		});
+
+		it("bails out of posting when the panel was disposed before the probe resolved", async () => {
+			let resolveProbe: (available: boolean) => void = () => {};
+			mockIsLocalAgentUsable.mockImplementation(
+				() => new Promise((res) => { resolveProbe = res; }),
+			);
+
+			await SettingsWebviewPanel.show(extensionUri, workspaceRoot);
+			const dispatch = captureMessageHandler();
+			postMessage.mockClear();
+
+			dispatch({ command: "probeLocalAgent", tool: "claude-code" });
+			// Let the pending loadConfigFromDir microtask resolve and
+			// isLocalAgentUsable actually get invoked (capturing resolveProbe)
+			// before disposing the panel and resolving the probe.
+			await flushPromises();
+			(SettingsWebviewPanel as unknown as { currentPanel: undefined }).currentPanel = undefined;
+			resolveProbe(true);
+			await flushPromises();
+
+			expect(postMessage).not.toHaveBeenCalledWith(
+				expect.objectContaining({ command: "localAgentProbeResult" }),
 			);
 		});
 	});

--- a/vscode/src/views/SettingsWebviewPanel.ts
+++ b/vscode/src/views/SettingsWebviewPanel.ts
@@ -24,16 +24,18 @@ import {
 	validateJolliApiKey,
 } from "../../../cli/src/core/JolliApiUtils.js";
 import { resolveMemoryBankState } from "../../../cli/src/core/KBPathResolver.js";
+import { isLocalAgentUsable, localAgentOverrideFrom } from "../../../cli/src/core/localagent/DetectAgents.js";
+import { LOCAL_AGENT_TOOLS } from "../../../cli/src/core/localagent/ToolMeta.js";
 import {
 	describeMemoryBank,
 	type MemoryBankDisplay,
 } from "../../../cli/src/core/MemoryBankStatusText.js";
-import { track } from "../../../cli/src/core/Telemetry.js";
 import {
 	getGlobalConfigDir,
 	loadConfigFromDir,
 	saveConfigScoped,
 } from "../../../cli/src/core/SessionTracker.js";
+import { track } from "../../../cli/src/core/Telemetry.js";
 import {
 	installClaudeHook,
 	installGeminiHook,
@@ -100,6 +102,7 @@ type SettingsMessage =
 	| { command: "signIn" }
 	| { command: "signOut" }
 	| { command: "syncNow" }
+	| { command: "probeLocalAgent"; tool?: unknown }
 	| {
 			command: "applySettings";
 			settings: SettingsPayload;
@@ -328,7 +331,57 @@ export class SettingsWebviewPanel {
 						);
 					});
 				break;
+			case "probeLocalAgent":
+				this.handleProbeLocalAgent(message.tool).catch((err: unknown) => {
+					log.error("SettingsPanel", `probeLocalAgent failed: ${err}`);
+				});
+				break;
 		}
+	}
+
+	/**
+	 * Verifies whether the tool the webview's Agent tool dropdown currently
+	 * holds is actually usable on this machine, and posts the result back.
+	 *
+	 * The webview is untrusted input, so `tool` is allow-listed against
+	 * `LOCAL_AGENT_TOOLS` before it's ever passed to `isLocalAgentUsable` —
+	 * mirrors the same guard in `jollimemory.selectLocalAgentTool`
+	 * (Extension.ts). An id that fails the guard is silently dropped: there is
+	 * no tool selected for the script to be blocked on, so no reply is needed.
+	 *
+	 * Every OTHER path must answer. The webview holds an Apply click that lands
+	 * while a probe is in flight until the reply decides it (see
+	 * `submitApplySettings` in SettingsScriptBuilder), so a swallowed reply would
+	 * strand a save. A failure to even read the config answers `false`, matching
+	 * `isLocalAgentUsable`'s own error semantics — "couldn't establish that this
+	 * runs" is reported as not usable, never optimistically as usable.
+	 */
+	private async handleProbeLocalAgent(rawTool: unknown): Promise<void> {
+		const tool =
+			typeof rawTool === "string" && Object.hasOwn(LOCAL_AGENT_TOOLS, rawTool)
+				? (rawTool as LocalAgentToolId)
+				: null;
+		if (!tool) return;
+		let available = false;
+		try {
+			const configDir = this.resolveConfigDir();
+			const config = await loadConfigFromDir(configDir);
+			// Tool-scoped: `localAgentPath` belongs to the CONFIGURED tool, so probing
+			// the dropdown's current pick must not borrow it. `localAgentOverrideFrom`
+			// pairs the path with its owner and `isLocalAgentUsable` drops it on a
+			// mismatch, so switching the dropdown auto-discovers instead.
+			available = await isLocalAgentUsable(tool, {
+				override: localAgentOverrideFrom(config),
+			});
+		} catch (err) {
+			log.error("SettingsPanel", `probeLocalAgent(${tool}) failed: ${err}`);
+		}
+		if (SettingsWebviewPanel.currentPanel !== this) return;
+		this.panel.webview.postMessage({
+			command: "localAgentProbeResult",
+			tool,
+			available,
+		});
 	}
 
 	/**

--- a/vscode/src/views/SidebarCssBuilder.ts
+++ b/vscode/src/views/SidebarCssBuilder.ts
@@ -1944,6 +1944,48 @@ export function buildSidebarCss(): string {
     flex: 1;
     border-top: 1px solid var(--vscode-widget-border, var(--vscode-editorWidget-border));
   }
+  /* ── Local-agent onboarding card ──────────────────────────────────────
+     Block above the Anthropic API key card, shown only when
+     state.localAgents (Task 7) is non-empty. The hint + label + dropdown
+     live INSIDE the recommended .ob-card (below .ob-card-row); only the
+     error line and the action button are siblings of the card. Sizing
+     mirrors the .apikey-label / .apikey-input / .apikey-error rules above
+     so both panels read the same. */
+  .ob-select-label {
+    display: block;
+    font-size: 12px;
+    font-weight: 600;
+    margin: 12px 0 6px 0;
+    color: var(--vscode-foreground);
+  }
+  .ob-select {
+    display: block;
+    width: 100%;
+    padding: 6px 8px;
+    box-sizing: border-box;
+    background: var(--vscode-dropdown-background);
+    color: var(--vscode-dropdown-foreground);
+    border: 1px solid var(--vscode-dropdown-border, var(--vscode-widget-border, transparent));
+    border-radius: 4px;
+    font-size: 12px;
+    font-family: var(--vscode-font-family);
+  }
+  .ob-select:focus {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: -1px;
+  }
+  .ob-hint {
+    margin: 8px 0 0 0;
+    font-size: 11px;
+    line-height: 1.4;
+    color: var(--vscode-descriptionForeground);
+  }
+  .ob-error {
+    margin: 8px 0 0 0;
+    font-size: 12px;
+    color: var(--vscode-errorForeground);
+    line-height: 1.4;
+  }
 
   /* Pinned to the bottom of the sidebar (the .sidebar-root box is the
      positioning context — see its position:relative). absolute (not sticky)

--- a/vscode/src/views/SidebarHtmlBuilder.test.ts
+++ b/vscode/src/views/SidebarHtmlBuilder.test.ts
@@ -171,7 +171,7 @@ describe("SidebarHtmlBuilder", () => {
 			expect(html).toContain('id="onboarding-apikey-btn"');
 		});
 
-		it("renders Anthropic API key as the recommended option above Sign in to Jolli", () => {
+		it("renders Anthropic API key above Sign in to Jolli, with the RECOMMENDED badge preceding both", () => {
 			const html = buildSidebarHtml(
 				"test-nonce",
 				"vscode-resource:",
@@ -183,14 +183,22 @@ describe("SidebarHtmlBuilder", () => {
 			expect(apikeyIdx).toBeGreaterThan(-1);
 			expect(signinIdx).toBeGreaterThan(-1);
 			expect(apikeyIdx).toBeLessThan(signinIdx);
-			// The RECOMMENDED badge must live in the same DOM region as the
-			// Anthropic card — i.e. between the panel header and the Sign in card.
+			// In the static skeleton the RECOMMENDED badge lives inside the
+			// (hidden-by-default) local-agent card, which sits above the API-key
+			// card — SidebarScriptBuilder moves it back onto the API-key card at
+			// runtime only when state.localAgents is empty. Either way it must
+			// precede the Sign in to Jolli card.
 			const badgeIdx = html.indexOf("RECOMMENDED");
 			expect(badgeIdx).toBeGreaterThan(-1);
 			expect(badgeIdx).toBeLessThan(signinIdx);
+			// The API-key card itself no longer carries the recommended styling
+			// statically — that is applied dynamically only in the no-agents case.
+			const apikeyCardTag = html.match(/<section[^>]*id="onboarding-apikey-card"[^>]*>/)?.[0] ?? "";
+			expect(apikeyCardTag).not.toBe("");
+			expect(apikeyCardTag).not.toContain("ob-card--recommended");
 		});
 
-		it("uses primary button class on Configure API Key and secondary on Sign In", () => {
+		it("uses secondary button class on both Configure API Key and Sign In", () => {
 			const html = buildSidebarHtml(
 				"test-nonce",
 				"vscode-resource:",
@@ -198,11 +206,107 @@ describe("SidebarHtmlBuilder", () => {
 				SIDEBAR_EMPTY_STRINGS,
 			);
 			expect(html).toMatch(
-				/id="onboarding-apikey-btn"[^>]*class="ob-btn ob-btn--primary"/,
+				/id="onboarding-apikey-btn"[^>]*class="ob-btn ob-btn--secondary"/,
 			);
 			expect(html).toMatch(
 				/id="onboarding-signin-btn"[^>]*class="ob-btn ob-btn--secondary"/,
 			);
+		});
+	});
+
+	describe("onboarding local-agent card", () => {
+		it("renders the block hidden by default", () => {
+			const html = buildSidebarHtml(
+				"test-nonce",
+				"vscode-resource:",
+				"https://example/codicon.css",
+				SIDEBAR_EMPTY_STRINGS,
+			);
+			expect(html).toContain('id="onboarding-localagent-block"');
+			expect(html).toMatch(/<div class="ob-localagent hidden" id="onboarding-localagent-block">/);
+		});
+
+		it("uses the exact approved copy", () => {
+			const html = buildSidebarHtml(
+				"test-nonce",
+				"vscode-resource:",
+				"https://example/codicon.css",
+				SIDEBAR_EMPTY_STRINGS,
+			);
+			expect(html).toContain("Use your local agent tool");
+			expect(html).toContain(
+				"Use your local agent tool for AI summarization. Memories are stored locally only.",
+			);
+			expect(html).toContain("Use Local Agent Tool");
+			expect(html).toContain("Make sure you're signed in to the tool.");
+		});
+
+		it("carries no inline style or inline handler (CSP)", () => {
+			const html = buildSidebarHtml(
+				"test-nonce",
+				"vscode-resource:",
+				"https://example/codicon.css",
+				SIDEBAR_EMPTY_STRINGS,
+			);
+			expect(html).not.toMatch(/<[^>]*\sstyle="/);
+			expect(html).not.toMatch(/\son(click|change)=/);
+		});
+
+		it("produces the DOM ids and CSS classes the script builder consumes", () => {
+			const html = buildSidebarHtml(
+				"test-nonce",
+				"vscode-resource:",
+				"https://example/codicon.css",
+				SIDEBAR_EMPTY_STRINGS,
+			);
+			expect(html).toContain('id="onboarding-localagent-select"');
+			expect(html).toContain('id="onboarding-localagent-btn"');
+			expect(html).toContain('id="onboarding-localagent-error"');
+			expect(html).toContain('class="ob-select"');
+			expect(html).toContain('class="ob-hint"');
+			// The error paragraph starts hidden — Task 9 owns showing it.
+			expect(html).toMatch(/class="ob-error hidden" id="onboarding-localagent-error"/);
+			// The <option> list is NOT interpolated into the HTML string — the
+			// skeleton's own docstring states it carries no user-supplied data.
+			// SidebarScriptBuilder populates it via the DOM API on init.
+			const selectTag = html.match(/<select[^>]*id="onboarding-localagent-select"[^>]*>[\s\S]*?<\/select>/)?.[0] ?? "";
+			expect(selectTag).not.toBe("");
+			expect(selectTag).not.toContain("<option");
+		});
+
+		it("positions the block immediately after the onboarding divider, above the API-key card", () => {
+			const html = buildSidebarHtml(
+				"test-nonce",
+				"vscode-resource:",
+				"https://example/codicon.css",
+				SIDEBAR_EMPTY_STRINGS,
+			);
+			const dividerIdx = html.indexOf('<hr class="ob-divider" />');
+			const blockIdx = html.indexOf('id="onboarding-localagent-block"');
+			const apikeyCardIdx = html.indexOf('id="onboarding-apikey-card"');
+			expect(dividerIdx).toBeGreaterThan(-1);
+			expect(blockIdx).toBeGreaterThan(dividerIdx);
+			expect(apikeyCardIdx).toBeGreaterThan(blockIdx);
+		});
+
+		it("nests the hint, label and dropdown inside the recommended card", () => {
+			const html = buildSidebarHtml(
+				"test-nonce",
+				"vscode-resource:",
+				"https://example/codicon.css",
+				SIDEBAR_EMPTY_STRINGS,
+			);
+			// The card is the only .ob-card--recommended section and holds no
+			// nested <section>, so a non-greedy match is its full inner HTML.
+			const card =
+				html.match(/<section class="ob-card ob-card--recommended">[\s\S]*?<\/section>/)?.[0] ?? "";
+			expect(card).not.toBe("");
+			expect(card).toContain("Make sure you're signed in to the tool.");
+			expect(card).toContain('for="onboarding-localagent-select"');
+			expect(card).toContain('id="onboarding-localagent-select"');
+			// The action button and error line stay outside the card.
+			expect(card).not.toContain('id="onboarding-localagent-btn"');
+			expect(card).not.toContain('id="onboarding-localagent-error"');
 		});
 	});
 

--- a/vscode/src/views/SidebarHtmlBuilder.ts
+++ b/vscode/src/views/SidebarHtmlBuilder.ts
@@ -13,6 +13,17 @@
  *     key). In that mode the tab bar and tab content are hidden; the onboarding
  *     panel takes the entire viewport. The Anthropic API key path is positioned
  *     as the recommended primary option above the secondary Sign in to Jolli card.
+ *   - A local-agent card sibling (`#onboarding-localagent-block`), hidden by
+ *     default and rendered above the Anthropic API key card. `init` carries
+ *     `state.localAgents` (Task 7); when non-empty, SidebarScriptBuilder shows
+ *     this card, moves the RECOMMENDED badge onto it, populates the
+ *     `<select>` with the detected tools (first entry pre-selected), and
+ *     drops `ob-card--recommended` / the badge from the API-key card
+ *     (`#onboarding-apikey-card`) below. When `localAgents` is empty or
+ *     absent, the block stays hidden and the badge / recommended styling
+ *     move back onto the API-key card, so exactly one card is ever marked
+ *     recommended. (The "Configure API Key" button itself is `--secondary`
+ *     in both cases — it now matches "Sign In / Sign Up".)
  *   - An API key entry panel sibling, hidden by default. Shown when the user
  *     clicks "Configure API Key" from the onboarding panel — replaces the
  *     onboarding cards with a focused input + Save/Back so users can save the
@@ -95,8 +106,25 @@ export function buildSidebarHtml(
         <p class="ob-subtitle">Jolli Memory automatically captures your work context and surfaces relevant memories as you code. Choose how you'd like to set it up.</p>
       </header>
       <hr class="ob-divider" />
-      <section class="ob-card ob-card--recommended">
-        <span class="ob-badge">RECOMMENDED</span>
+      <div class="ob-localagent hidden" id="onboarding-localagent-block">
+        <section class="ob-card ob-card--recommended">
+          <span class="ob-badge">RECOMMENDED</span>
+          <div class="ob-card-row">
+            <i class="codicon codicon-terminal ob-card-icon" aria-hidden="true"></i>
+            <div class="ob-card-text">
+              <h3 class="ob-card-title">Use your local agent tool</h3>
+              <p class="ob-card-desc">Use your local agent tool for AI summarization. Memories are stored locally only.</p>
+            </div>
+          </div>
+          <p class="ob-hint">Make sure you're signed in to the tool.</p>
+          <label class="ob-select-label" for="onboarding-localagent-select">Agent tool</label>
+          <select class="ob-select" id="onboarding-localagent-select"></select>
+        </section>
+        <p class="ob-error hidden" id="onboarding-localagent-error" role="alert"></p>
+        <button type="button" id="onboarding-localagent-btn" class="ob-btn ob-btn--primary">Use Local Agent Tool</button>
+        <div class="ob-or"><span>OR</span></div>
+      </div>
+      <section class="ob-card" id="onboarding-apikey-card">
         <div class="ob-card-row">
           <i class="codicon codicon-key ob-card-icon" aria-hidden="true"></i>
           <div class="ob-card-text">
@@ -105,7 +133,7 @@ export function buildSidebarHtml(
           </div>
         </div>
       </section>
-      <button type="button" id="onboarding-apikey-btn" class="ob-btn ob-btn--primary">Configure API Key</button>
+      <button type="button" id="onboarding-apikey-btn" class="ob-btn ob-btn--secondary">Configure API Key</button>
       <div class="ob-or"><span>OR</span></div>
       <section class="ob-card">
         <div class="ob-card-row">

--- a/vscode/src/views/SidebarMessages.ts
+++ b/vscode/src/views/SidebarMessages.ts
@@ -9,6 +9,7 @@
  */
 
 import type { ActiveConversationItem } from "../../../cli/src/core/ActiveSessionAggregator.js";
+import type { DetectedAgent } from "../../../cli/src/core/localagent/DetectAgents.js";
 import type { PinEntry, PinKind } from "../../../cli/src/core/PinStore.js";
 import type { ReferenceField, SourceId, TranscriptSource } from "../../../cli/src/Types.js";
 import type { IngestPhase } from "../stores/StatusStore.js";
@@ -82,6 +83,18 @@ export interface SidebarState {
 	 * `configured: true` once `currentConfigured` is hydrated.
 	 */
 	readonly configured?: boolean;
+	/**
+	 * Local agent CLIs detected on this machine, in display order. Drives the
+	 * onboarding panel's local-agent card: empty (or absent) means no card and a
+	 * panel identical to the pre-feature one.
+	 *
+	 * Sent on `init` and refreshed through `localAgents:changed` when the
+	 * onboarding panel reappears mid-window (sign-out / cleared key), since the
+	 * host deliberately skips detection while the user is configured. A user who
+	 * INSTALLS an agent while the panel is already up still needs a reload —
+	 * that would require watching the filesystem, which the card doesn't warrant.
+	 */
+	readonly localAgents?: DetectedAgent[];
 	readonly activeTab: SidebarTab;
 	readonly kbMode: KbMode;
 	readonly branchName: string;
@@ -955,6 +968,14 @@ export type SidebarInboundMsg =
 	| { readonly type: "enabled:changed"; readonly enabled: boolean }
 	| { readonly type: "auth:changed"; readonly authenticated: boolean }
 	| { readonly type: "configured:changed"; readonly configured: boolean }
+	/**
+	 * Refreshed local-agent list for the onboarding card. Pushed just before
+	 * `configured:changed` flips the panel back on, because the host skips
+	 * detection while the user is configured and the `init` list would be stale
+	 * (empty) for anyone who signs out mid-window. See `SidebarState.localAgents`.
+	 */
+	| { readonly type: "localAgents:changed"; readonly localAgents: DetectedAgent[] }
+	| { readonly type: "localAgent:selectError"; readonly message: string }
 	| {
 			readonly type: "worker:busy";
 			readonly busy: boolean;

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -1972,6 +1972,134 @@ describe("SidebarScriptBuilder", () => {
 			const end = js.indexOf("function ", start + 1);
 			expect(js.slice(start, end)).toMatch(/applyEnabled\(state\.enabled\)/);
 		});
+
+		describe("onboarding local-agent card", () => {
+			// NOTE: like the rest of this file, these are assertions on the
+			// GENERATED SCRIPT STRING (no jsdom execution — see the file-level
+			// convention note elsewhere in this suite), sliced to the relevant
+			// function/case body so a regression in structure or ordering fails
+			// loudly even without a live DOM.
+			it("declares element refs for every local-agent DOM id the HTML produces", () => {
+				const js = buildSidebarScript();
+				expect(js).toContain("getElementById('onboarding-localagent-block')");
+				expect(js).toContain("getElementById('onboarding-localagent-select')");
+				expect(js).toContain("getElementById('onboarding-localagent-btn')");
+				expect(js).toContain("getElementById('onboarding-localagent-error')");
+				expect(js).toContain("getElementById('onboarding-apikey-card')");
+			});
+
+			it("init handler forwards state.localAgents to applyLocalAgents", () => {
+				const js = buildSidebarScript();
+				const start = js.indexOf("case 'init'");
+				const end = js.indexOf("case '", start + 1);
+				expect(start).toBeGreaterThan(-1);
+				const body = js.slice(start, end);
+				expect(body).toContain("applyLocalAgents(msg.state.localAgents)");
+			});
+
+			it("handles localAgents:changed by re-applying the refreshed list", () => {
+				// The onboarding panel can come back mid-window (sign-out / cleared
+				// key) with a host-side list that was never populated. Without this
+				// case the panel re-renders from the stale init snapshot and silently
+				// drops the local-agent card.
+				const js = buildSidebarScript();
+				const start = js.indexOf("case 'localAgents:changed'");
+				expect(start).toBeGreaterThan(-1);
+				const body = js.slice(start, js.indexOf("case '", start + 1));
+				expect(body).toContain("applyLocalAgents(msg.localAgents)");
+				// Ordering guarantee mirrored on the host: the list case is handled
+				// before the panel-visibility case in the same switch.
+				expect(start).toBeLessThan(js.indexOf("case 'configured:changed'"));
+			});
+
+			it("applyLocalAgents: empty list hides the block and restores ob-card--recommended onto the API-key card", () => {
+				const js = buildSidebarScript();
+				expect(js).toContain("function applyLocalAgents");
+				const start = js.indexOf("function applyLocalAgents");
+				const end = js.indexOf("\n  function ", start + 1);
+				const body = js.slice(start, end);
+				const listIsEmptyIdx = body.search(/if\s*\(\s*list\.length === 0\s*\)/);
+				expect(listIsEmptyIdx).toBeGreaterThan(-1);
+				const emptyBranch = body.slice(listIsEmptyIdx, body.indexOf("return;", listIsEmptyIdx));
+				expect(emptyBranch).toContain("onboardingLocalAgentBlock.classList.add('hidden')");
+				expect(emptyBranch).toContain("onboardingApikeyCard.classList.add('ob-card--recommended')");
+				// The badge is moved (not merely un-hidden) onto the API-key card —
+				// a real DOM reparent so querySelector('.ob-badge') on the
+				// local-agent card returns null once it has moved.
+				expect(emptyBranch).toMatch(
+					/onboardingApikeyCard\.insertBefore\(onboardingLocalAgentBadge,\s*onboardingApikeyCard\.firstChild\)/,
+				);
+			});
+
+			it("applyLocalAgents: non-empty list populates <option>s in order, pre-selects the first, and shows the block", () => {
+				const js = buildSidebarScript();
+				const start = js.indexOf("function applyLocalAgents");
+				const end = js.indexOf("\n  function ", start + 1);
+				const body = js.slice(start, end);
+				// Cleared before repopulating so a second init (or a stale list)
+				// never leaves duplicate <option>s behind.
+				expect(body).toContain("onboardingLocalAgentSelect.replaceChildren()");
+				expect(body).toMatch(
+					/for\s*\(\s*const a of list\s*\)[\s\S]*?opt\.value = a\.id;[\s\S]*?opt\.textContent = a\.label;[\s\S]*?onboardingLocalAgentSelect\.appendChild\(opt\)/,
+				);
+				expect(body).toContain("onboardingLocalAgentSelect.value = list[0].id");
+				expect(body).toContain("onboardingLocalAgentBlock.classList.remove('hidden')");
+				expect(body).toContain("onboardingApikeyCard.classList.remove('ob-card--recommended')");
+				// Idempotent badge placement: if a previous no-agents init already
+				// moved it onto the API-key card, this call moves it back.
+				expect(body).toMatch(
+					/localAgentCard\.insertBefore\(onboardingLocalAgentBadge,\s*localAgentCard\.firstChild\)/,
+				);
+			});
+
+			it("wires the button click to dispatch jollimemory.selectLocalAgentTool with the selected tool and shows Checking…", () => {
+				const js = buildSidebarScript();
+				expect(js).toContain("onboardingLocalAgentBtn.addEventListener('click'");
+				const start = js.indexOf("onboardingLocalAgentBtn.addEventListener('click'");
+				const end = js.indexOf("});", start);
+				const body = js.slice(start, end);
+				// Both controls are disabled while the (possibly slow) capability
+				// probe is in flight, and any stale error from a prior attempt is
+				// cleared before dispatching.
+				expect(body).toContain("onboardingLocalAgentBtn.disabled = true");
+				expect(body).toContain("onboardingLocalAgentSelect.disabled = true");
+				expect(body).toMatch(/onboardingLocalAgentBtn\.textContent\s*=\s*['"]Checking/);
+				expect(body).toContain("onboardingLocalAgentError.classList.add('hidden')");
+				expect(body).toContain("onboardingLocalAgentError.textContent = ''");
+				expect(body).toContain("'jollimemory.selectLocalAgentTool'");
+				// The selected <option>'s value (a LOCAL_AGENT_TOOLS id) is forwarded
+				// as args:[tool] — SidebarWebviewProvider.handleOutbound spreads it
+				// into the registered handler's first positional parameter.
+				expect(body).toMatch(/args:\s*\[\s*tool\s*\]/);
+			});
+
+			it("guards the click handler on a non-empty select value", () => {
+				const js = buildSidebarScript();
+				const start = js.indexOf("onboardingLocalAgentBtn.addEventListener('click'");
+				const end = js.indexOf("});", start);
+				const body = js.slice(start, end);
+				expect(body).toMatch(/if\s*\(\s*!tool\s*\)\s*return;/);
+			});
+
+			it("localAgent:selectError restores the button and select and surfaces the message inline (only when onboarding is still active)", () => {
+				const js = buildSidebarScript();
+				expect(js).toContain("case 'localAgent:selectError'");
+				const start = js.indexOf("case 'localAgent:selectError'");
+				const end = js.indexOf("break", start);
+				const body = js.slice(start, end);
+				// Guard: if the onboarding panel was already retired (success raced
+				// past us), don't re-show the controls.
+				expect(body).toContain("onboardingPanel.classList.contains('hidden')");
+				expect(body).toContain("onboardingLocalAgentBtn.disabled = false");
+				expect(body).toContain("onboardingLocalAgentSelect.disabled = false");
+				expect(body).toMatch(
+					/onboardingLocalAgentBtn\.textContent\s*=\s*['"]Use Local Agent Tool['"]/,
+				);
+				expect(body).toContain("onboardingLocalAgentError.classList.remove('hidden')");
+				// Fall-back string when the host posts an empty/non-string message.
+				expect(body).toContain("Could not use that tool.");
+			});
+		});
 	});
 
 	describe("Current Branch command bar footer", () => {

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -267,6 +267,20 @@ export function buildSidebarScript(): string {
   const onboardingPanel = document.getElementById('onboarding-panel');
   const onboardingSigninBtn = document.getElementById('onboarding-signin-btn');
   const onboardingApikeyBtn = document.getElementById('onboarding-apikey-btn');
+  // Local-agent onboarding card — sibling of the Anthropic API-key card,
+  // shown only when the host reports a non-empty local-agent list (on init, or
+  // via 'localAgents:changed'). See applyLocalAgents below.
+  const onboardingLocalAgentBlock = document.getElementById('onboarding-localagent-block');
+  const onboardingLocalAgentSelect = document.getElementById('onboarding-localagent-select');
+  const onboardingLocalAgentBtn = document.getElementById('onboarding-localagent-btn');
+  const onboardingLocalAgentError = document.getElementById('onboarding-localagent-error');
+  const onboardingApikeyCard = document.getElementById('onboarding-apikey-card');
+  // The single RECOMMENDED badge node lives in the local-agent card's markup
+  // by default (SidebarHtmlBuilder) and is physically moved onto the API-key
+  // card when there are no local agents to offer -- never duplicated, never
+  // just hidden, so querySelector('.ob-badge') reflects which card is
+  // actually recommended.
+  const onboardingLocalAgentBadge = onboardingLocalAgentBlock.querySelector('.ob-badge');
   // Disabled panel — full-viewport "Enable" CTA shown when the user is
   // configured but has explicitly disabled the extension. Sibling of the
   // onboarding panel; mutually exclusive with it.
@@ -708,6 +722,27 @@ export function buildSidebarScript(): string {
     });
   }
 
+  // Onboarding local-agent card -- "Use Local Agent Tool" button. The host
+  // command runs the (expensive) capability probe for the chosen tool only,
+  // then writes aiProvider/localAgentTool on success. Success flips
+  // configured via statusStore.refresh -> configured:changed retires the
+  // onboarding panel, same hand-off as submitApikey above. Failure comes
+  // back as 'localAgent:selectError', handled below.
+  onboardingLocalAgentBtn.addEventListener('click', function() {
+    const tool = onboardingLocalAgentSelect.value;
+    if (!tool) return;
+    onboardingLocalAgentBtn.disabled = true;
+    onboardingLocalAgentSelect.disabled = true;
+    onboardingLocalAgentBtn.textContent = 'Checking…';
+    onboardingLocalAgentError.classList.add('hidden');
+    onboardingLocalAgentError.textContent = '';
+    vscode.postMessage({
+      type: 'command',
+      command: 'jollimemory.selectLocalAgentTool',
+      args: [tool],
+    });
+  });
+
   // Disabled-panel Enable button — same command as the legacy in-Status
   // disabled-banner Enable button (jollimemory.enableJolliMemory). Wired
   // separately because the two buttons live in disjoint DOM regions and
@@ -762,6 +797,9 @@ export function buildSidebarScript(): string {
         // true on undefined (e.g. older host code, transient init message)
         // so the regular UI keeps working without a strict-host upgrade.
         applyConfigured(msg.state.configured !== false);
+        // Initial list; refreshed later via 'localAgents:changed' when the
+        // onboarding panel reappears mid-window (see SidebarMessages.ts).
+        applyLocalAgents(msg.state.localAgents);
         // Guard against a stale persisted tab that no longer exists (e.g. the
         // removed 'knowledge' view): fall back to the default 'branch' rather
         // than switching to a tab with no panel/toolbar. Only honored on the
@@ -807,6 +845,12 @@ export function buildSidebarScript(): string {
         // toolbar; re-render so the swap takes effect immediately.
         if (state.activeTab === 'status') renderToolbar();
         break;
+      case 'localAgents:changed':
+        // Host re-ran detection because the onboarding panel is about to
+        // reappear (sign-out / cleared key). Arrives BEFORE configured:changed,
+        // so the card is already right when applyConfigured un-hides the panel.
+        applyLocalAgents(msg.localAgents);
+        break;
       case 'configured:changed': {
         // Capture the prior value BEFORE applyConfigured mutates state.configured —
         // we use the false→true edge to detect "user just finished onboarding"
@@ -840,6 +884,20 @@ export function buildSidebarScript(): string {
             ? msg.message
             : 'Failed to save the API key.';
           apikeyError.classList.remove('hidden');
+        }
+        break;
+      case 'localAgent:selectError':
+        // Only restore the controls if the onboarding panel is still up; a
+        // success path that raced past us has already hidden it (see the
+        // apikey:saveError guard above for the same pattern).
+        if (!onboardingPanel.classList.contains('hidden')) {
+          onboardingLocalAgentBtn.disabled = false;
+          onboardingLocalAgentSelect.disabled = false;
+          onboardingLocalAgentBtn.textContent = 'Use Local Agent Tool';
+          onboardingLocalAgentError.textContent = typeof msg.message === 'string' && msg.message.length > 0
+            ? msg.message
+            : 'Could not use that tool.';
+          onboardingLocalAgentError.classList.remove('hidden');
         }
         break;
       case 'worker:busy': {
@@ -1299,6 +1357,40 @@ export function buildSidebarScript(): string {
     // the bar in disabled mode because disabled-panel owns the viewport),
     // so just delegate — no manual tabBar.classList.remove('hidden') needed.
     applyEnabled(state.enabled);
+  }
+
+  // Local-agent onboarding card -- shown when the host detects a local agent
+  // CLI (state.localAgents on init, refreshed by 'localAgents:changed' when the
+  // panel comes back mid-window). Renders
+  // the select options in display order with the first entry pre-selected,
+  // and moves the single RECOMMENDED badge node onto whichever card is
+  // actually recommended: the local-agent card when agents are present, back
+  // onto the API-key card when the list is empty -- so exactly one card in
+  // the panel is ever marked recommended.
+  function applyLocalAgents(agents) {
+    const list = Array.isArray(agents) ? agents : [];
+    onboardingLocalAgentSelect.replaceChildren();
+    if (list.length === 0) {
+      onboardingLocalAgentBlock.classList.add('hidden');
+      onboardingApikeyCard.classList.add('ob-card--recommended');
+      if (onboardingLocalAgentBadge.parentElement !== onboardingApikeyCard) {
+        onboardingApikeyCard.insertBefore(onboardingLocalAgentBadge, onboardingApikeyCard.firstChild);
+      }
+      return;
+    }
+    for (const a of list) {
+      const opt = document.createElement('option');
+      opt.value = a.id;
+      opt.textContent = a.label;
+      onboardingLocalAgentSelect.appendChild(opt);
+    }
+    onboardingLocalAgentSelect.value = list[0].id;
+    onboardingLocalAgentBlock.classList.remove('hidden');
+    onboardingApikeyCard.classList.remove('ob-card--recommended');
+    const localAgentCard = onboardingLocalAgentBlock.querySelector('.ob-card');
+    if (localAgentCard && onboardingLocalAgentBadge.parentElement !== localAgentCard) {
+      localAgentCard.insertBefore(onboardingLocalAgentBadge, localAgentCard.firstChild);
+    }
   }
 
   // Degraded mode (no workspace / no git) keeps the legacy disabled-banner

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -2209,6 +2209,36 @@ describe("SidebarWebviewProvider", () => {
 		).toBe(true);
 	});
 
+	it("notifyLocalAgentSelectError posts localAgent:selectError with the supplied message", () => {
+		const view = makeMockView();
+		const provider = new SidebarWebviewProvider({
+			executeCommand: vi.fn(),
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				configured: false,
+				activeTab: "status",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.postMessage.mockClear();
+		provider.notifyLocalAgentSelectError("agent not found");
+		const sent = view.webview.postMessage.mock.calls.map((c) => c[0]);
+		expect(
+			sent.some(
+				(m) =>
+					typeof m === "object" &&
+					m !== null &&
+					(m as { type?: unknown }).type === "localAgent:selectError" &&
+					(m as { message?: unknown }).message === "agent not found",
+			),
+		).toBe(true);
+	});
+
 	it("notifyConfiguredChanged posts configured:changed with the new configured flag", () => {
 		const view = makeMockView();
 		const provider = new SidebarWebviewProvider({
@@ -2235,6 +2265,37 @@ describe("SidebarWebviewProvider", () => {
 					m !== null &&
 					(m as { type?: unknown }).type === "configured:changed" &&
 					(m as { configured?: unknown }).configured === true,
+			),
+		).toBe(true);
+	});
+
+	it("notifyLocalAgentsChanged posts localAgents:changed with the refreshed list", () => {
+		const view = makeMockView();
+		const provider = new SidebarWebviewProvider({
+			executeCommand: vi.fn(),
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				configured: false,
+				activeTab: "status",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		view.webview.postMessage.mockClear();
+		provider.notifyLocalAgentsChanged([{ id: "codex", label: "Codex" }]);
+		const sent = view.webview.postMessage.mock.calls.map((c) => c[0]);
+		expect(
+			sent.some(
+				(m) =>
+					typeof m === "object" &&
+					m !== null &&
+					(m as { type?: unknown }).type === "localAgents:changed" &&
+					JSON.stringify((m as { localAgents?: unknown }).localAgents) ===
+						JSON.stringify([{ id: "codex", label: "Codex" }]),
 			),
 		).toBe(true);
 	});

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -9,6 +9,7 @@
 
 import { randomBytes } from "node:crypto";
 import * as vscode from "vscode";
+import type { DetectedAgent } from "../../../cli/src/core/localagent/DetectAgents.js";
 import type { PinEntry, PinKind } from "../../../cli/src/core/PinStore.js";
 import { resolveSessionTitle } from "../../../cli/src/core/SessionTitleResolver.js";
 import { getTranscriptIds } from "../../../cli/src/core/SummaryTree.js";
@@ -1912,11 +1913,22 @@ export class SidebarWebviewProvider
 
 	/**
 	 * Pushed whenever the user's `configured` state changes — i.e. whenever
-	 * either of the two underlying signals (`signedIn`, `hasApiKey`) flips.
-	 * Drives the onboarding-panel vs main-UI split in the webview.
+	 * any of the underlying signals (`signedIn`, `hasApiKey`, `usesLocalAgent`)
+	 * flips. Drives the onboarding-panel vs main-UI split in the webview.
 	 */
 	notifyConfiguredChanged(configured: boolean): void {
 		this.postMessage({ type: "configured:changed", configured });
+	}
+
+	/**
+	 * Pushed when the onboarding panel is about to reappear mid-window, so its
+	 * local-agent card reflects a fresh detection sweep instead of the `init`
+	 * snapshot (which is deliberately empty for users who started out
+	 * configured). Sent before `configured:changed` so the card is correct on the
+	 * panel's first paint.
+	 */
+	notifyLocalAgentsChanged(localAgents: DetectedAgent[]): void {
+		this.postMessage({ type: "localAgents:changed", localAgents });
 	}
 
 	/**
@@ -1928,6 +1940,11 @@ export class SidebarWebviewProvider
 	 */
 	notifyApiKeySaveError(message: string): void {
 		this.postMessage({ type: "apikey:saveError", message });
+	}
+
+	/** Pushed only on the failure path of the onboarding local-agent selection. */
+	notifyLocalAgentSelectError(message: string): void {
+		this.postMessage({ type: "localAgent:selectError", message });
 	}
 
 	private pushStatus(): void {


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Quick recap

The developer expanded local assistant setup across the command line so installed tools are detected early, validated at the right moment, and saved under the assistant the user actually chose. New users can move through onboarding with detected local options, invalid answers no longer trap the picker, and a failed local path no longer leaves setup pointing at the wrong executable. Troubleshooting and repair flows also follow the same saved assistant choice, and their messages now call out the active tool and any lingering manual path that is blocking it.

The VS Code extension gained the same local-assistant path across onboarding, status, and settings. First-run onboarding can show detected local assistants immediately, selecting one completes setup through the normal configured flow, and the settings view reports live availability for the current choice. The onboarding panel also refreshes its local-assistant card when a user signs out or removes a key in an existing window, so the restored setup view shows current options right away.

Repository diagnostics became much quieter for fresh or empty repositories while preserving clear warnings for real read failures. Missing files no longer produce noisy warnings, backend names stay readable in production diagnostics, and unexpected repository read errors now surface with actionable detail.

---

## Topics (4)
<details>
<summary><strong>01 · CLI local assistant setup now detects, validates, and stays aligned</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Local agent onboarding needed to recognize which supported tools were installed without paying the cost of fully testing every tool at startup. The same detection path also needed to work reliably outside the main summarization flow.

**💡 Decisions Behind the Code**

- **Presence scan before readiness probe**: The work kept startup and onboarding on a cheap installed-tool pass first, then deferred deeper validation until a user actually picked a local assistant or reused a saved one. That preserved responsiveness while still preventing broken choices from being saved as working configuration.

- **Follow the saved assistant everywhere**: Generation, repair, onboarding, and health checks were aligned around the assistant the user had selected, with a compatibility fallback for older setups that never stored a tool name. That removed mismatches where setup could succeed for one assistant while later flows still talked to another.

- **Save-time cleanup over runtime guesswork**: The stale-path fix was applied when configuration changed, not by teaching every later reader to infer path ownership from incomplete state. That made the correction durable across all command paths and let older installations heal naturally on the next assistant switch.

- **Escape hatches with bounded retries**: The picker gained a visible skip path, finite handling for malformed input, and forward progress when one detected tool failed validation. The automatic path can still move users into browser sign-in or API-key setup when every detected assistant is present but unusable, while explicit local-assistant choices keep their own predictable flow.

- **Scoped executable overrides**: A manual executable path is treated as belonging to one named assistant, not as a global override for every detected option. That kept probes, saved configuration, and troubleshooting output aligned with the tool the user actually intended to use.

**✅ What Was Implemented**

- `cli/src/core/localagent/DetectAgents.ts`, `BuiltinBackends.ts`, and `ExecutableResolver.ts` split fast installed-tool discovery from deeper usability checks and applied `LocalAgentOverride` only to the matching assistant. Setup can now list only present tools first, validate the chosen one before saving, and keep a custom executable path attached to the correct assistant.

- `cli/src/commands/EnableCommand.ts` reworked `promptSetup()` and `handleLocalAgent()` to auto-route when one usable tool is found, offer a filtered picker when several are detected, reject invalid numbered answers, remove failed candidates from the list, and expose a `Skip for now` exit. When the automatic multi-tool path exhausts every detected assistant, setup falls back to the main provider menu and differentiates between broken installations and missing tools.

- `cli/src/core/SessionTracker.ts` now clears orphaned manual executable paths when a user switches assistants without supplying a new path. Existing path-only configurations recover on the next tool change, while same-tool saves and explicit tool-plus-path updates still preserve intentional overrides.

- `cli/src/commands/GenerationFix.ts`, `GuidedFrontDoor.ts`, and `DoctorCommand.ts` now use the assistant and executable path stored in settings for readiness checks, repair prompts, and troubleshooting output. Failure messages name the user’s actual tool, and diagnostics call out a lingering manual path when that setting is the likely blocker.

**📁 FILES**
- `cli/src/commands/EnableCommand.ts`
- `cli/src/core/localagent/DetectAgents.ts`
- `cli/src/core/SessionTracker.ts`
- `cli/src/commands/DoctorCommand.ts`
- `cli/src/commands/GenerationFix.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · VS Code onboarding and settings now fully support local assistants</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users setting up the extension needed a quicker path when they already had a supported local agent installed. The onboarding screen only offered API key entry or Jolli sign-in, which left the local-agent path undiscoverable at first run.

**💡 Decisions Behind the Code**

- **Fast startup snapshot, delayed verification**: The extension surfaces installed local assistants during startup with a cheap presence check and waits to do deeper validation until the user selects a tool or opens the relevant settings area. That kept the extension host responsive while making the local-assistant path visible immediately.

- **Reuse the configured-state flow**: A successful local-assistant choice enters the same configured-state path used by the other onboarding methods. That kept status updates, onboarding exit behavior, and the main UI transition consistent across setup options.

- **Configuration state separate from live availability**: A saved local assistant still counts as configured even if the binary disappears later, while settings independently report current availability. That preserves user intent and prevents the extension from unexpectedly bouncing someone back into setup.

- **Push refreshed choices before showing onboarding again**: When a configured window becomes unconfigured after sign-out or key removal, the extension reruns local-agent detection and sends the updated list before the onboarding view becomes visible. That keeps the restored onboarding card populated on first paint and avoids an empty-state flash.

- **Stale-reply protection in the UI**: Availability remains unknown until a real answer arrives, and late probe responses only apply to the tool currently visible in the settings view. That kept status text, badges, and action-button state aligned with the user’s current selection.

**✅ What Was Implemented**

- `vscode/src/Extension.ts` now detects present local agents during startup, includes them in the sidebar’s initial state, and registers the local-assistant selection command. Picking a tool probes it, saves local-agent configuration, refreshes status, and exits onboarding through the same configured-state path used by other setup methods.

- `vscode/src/views/SidebarHtmlBuilder.ts`, `SidebarCssBuilder.ts`, `SidebarScriptBuilder.ts`, `SidebarMessages.ts`, and `SidebarWebviewProvider.ts` added a dedicated onboarding card for detected local assistants and later extended it with live refresh support. The sidebar can render current choices on first run, disable actions during selection, surface inline failures, and repopulate the local-assistant card when onboarding returns after sign-out or key removal in the same window.

- `vscode/src/services/data/StatusDataService.ts`, `StatusStore.ts`, `JolliMemoryBridge.ts`, `SettingsHtmlBuilder.ts`, `SettingsScriptBuilder.ts`, and `SettingsWebviewPanel.ts` now treat a saved local assistant as a configured state while reporting live availability separately. The Settings panel shows tri-state availability, ignores stale probe replies that no longer match the visible tool, and only runs readiness probes when the local-agent section is active.

**📁 FILES**
- `vscode/src/Extension.ts`
- `vscode/src/views/SidebarHtmlBuilder.ts`
- `vscode/src/views/SidebarScriptBuilder.ts`
- `vscode/src/views/SidebarWebviewProvider.ts`
- `vscode/src/views/SettingsHtmlBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Storage diagnostics now separate empty repositories from real read failures</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Repository storage reads were treating ordinary missing data and actual read failures as the same outcome, which flooded logs with warnings and hid the real cause of genuine problems. Production diagnostics also used backend names that became unreadable after bundling.

**💡 Decisions Behind the Code**

- **Warn at the point of knowledge**: The storage backend performing the read has the actual errno and error text available. Emitting diagnostics there removed guesswork and made warnings reflect the real failure mode.

- **Allowlist normal absence cases**: Only known missing-file cases stay quiet, while unfamiliar read failures still produce warnings. That kept fresh and empty repositories calm without hiding new problems.

- **Stable backend labels**: Diagnostics use an explicit backend kind rather than runtime class names. Production logs stay readable even after bundling changes how classes are named.

**✅ What Was Implemented**

- `cli/src/core/StorageProvider.ts` added a stable `kind` field across folder, orphan-branch, and dual-write backends, and `cli/src/core/SummaryStore.ts` now treats a missing index as a debug-only absence case. Backend-specific warnings now carry a readable storage identifier.

- `cli/src/core/FolderStorage.ts` removed the upfront `existsSync` gate and classifies read results directly from the returned error. `ENOENT` and `ENOTDIR` stay quiet as normal absence, while `EACCES`, `EIO`, `EISDIR`, and other real failures emit warnings with the underlying error detail.

- `cli/src/core/GitOps.ts` now forces git stderr to English and allow-lists known messages that represent normal absence cases. Unrecognized repository read failures now surface as real warnings instead of blending into the empty-repository path.

**📁 FILES**
- `cli/src/core/StorageProvider.ts`
- `cli/src/core/FolderStorage.ts`
- `cli/src/core/GitOps.ts`
- `cli/src/core/SummaryStore.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Real-git test suites now tolerate heavier parallel execution load</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Parallel test runs were intermittently timing out in suites that exercise real repository operations, especially under heavier coverage and worker load. A few heavier tests were still using tighter local time limits than the rest of the test setup expected.

**💡 Decisions Behind the Code**

- **Target only expensive suites**: The timeout increases were limited to tests that create real repositories or spawn real git processes. Faster unit tests kept their tighter budgets, which preserves useful hang detection in the cheaper parts of the suite.

- **Fix local overrides, not global policy**: Some failing CLI suites had already reduced their own timeout ceiling below what surrounding setup expected. Raising those local limits addressed the flake with less blast radius than a repository-wide timeout change.

- **Match the timeout mechanism to the setup shape**: File-level configuration was used where shared setup lived outside one suite, and suite-level protection was used where the expensive work stayed contained. That kept the extra time budget effective without adding new global behavior.

**✅ What Was Implemented**

- `cli/src/sync/BootstrapMerge.test.ts` and `GitClient.test.ts` raised their file-level test and hook timeouts from `30_000` to `60_000`, including matching `beforeAll` budgets. The change aligns those heavier CLI suites with the broader timeout envelope already assumed by nearby setup.

- `vscode/src/JolliMemoryBridge.integration.test.ts`, `BackfillDismissFlag.test.ts`, and `ManualDisableFlag.test.ts` added targeted `45_000` timeout protection around real-repository setup and git-heavy scenarios. The wider limits stay scoped to expensive suites rather than changing repository-wide timeout behavior.

**📁 FILES**
- `cli/src/sync/BootstrapMerge.test.ts`
- `cli/src/sync/GitClient.test.ts`
- `vscode/src/JolliMemoryBridge.integration.test.ts`
- `vscode/src/services/BackfillDismissFlag.test.ts`
- `vscode/src/services/ManualDisableFlag.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 29, 2026 at 7:11 PM · via mixed: Local agent - Codex, Local agent - Claude Code*
<!-- jollimemory-summary-end -->