### PR TITLE
Set up jteam plugin configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,26 @@ Thumbs.db
 .env.*
 
 # Jolli / Claude
-.jolli/
+#
+# `.jolli/` holds two very different things, so it is excluded entry-by-entry rather
+# than as a directory. Everything in it is per-developer state — `jollimemory/` carries
+# sessions, cursors and queues, written per worktree with absolute local paths — and
+# none of that is a team artifact.
+#
+# The one exception is `agents.json`: a decision somebody made about *this* repository
+# (its verify gate, base branch, directory layout), which a teammate cannot regenerate
+# and therefore must be committed. The ORDER matters and so does the trailing `*`: a
+# bare `.jolli/` would stop git descending into the directory at all, and a negation
+# cannot re-include a file whose parent was never entered.
+#
+# Note the anchoring, which is the subtle half. The old `.jolli/` had no internal slash,
+# so it matched a `.jolli` directory at ANY depth — including `cli/.jolli/`, which is
+# also per-developer state. Adding `/*` anchors the rule to the root and would have
+# quietly exposed the nested ones, so they are re-excluded explicitly below.
+/.jolli/*
+!/.jolli/agents.json
+*/.jolli/
+*/**/.jolli/
 .claude/
 .kiro/
 .gemini/

--- a/.jolli/agents.json
+++ b/.jolli/agents.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jolliai/jolli-team-plugins/main/schema/agents.schema.json",
+  "version": 1,
+  "tracker": {
+    "kind": "none"
+  },
+  "verify": {
+    "gate": ["npm run all"],
+    "scope": "repo-root",
+    "coveragePolicy": "never-lower",
+    "configFilesOffLimits": ["cli/vite.config.ts", "vscode/vite.config.ts"]
+  },
+  "vcs": {
+    "forbiddenTrailers": ["Co-Authored-By", "Generated with"]
+  }
+}


### PR DESCRIPTION
## What

Adds `.jolli/agents.json` and reworks the `.jolli/` ignore rule so that one file can be committed while the rest of the directory stays ignored.

## Why

The jteam plugin skills need repository-specific facts they cannot infer: that `npm run all` is the verify gate, that coverage must never drop, that `cli/vite.config.ts` and `vscode/vite.config.ts` are off limits to edit, and that commit messages must not carry AI co-author or generated-by trailers. Unconfigured, every session has to be told these again — and any session that isn't gets them wrong.

`agents.json` is a decision about *this* repository, so it belongs in git. Everything else under `.jolli/` is per-developer state (sessions, cursors, queues — written per worktree with absolute local paths) and must stay ignored.

## The ignore rule

`.gitignore` moves from a bare `.jolli/` directory exclusion to entry-by-entry:

- `/.jolli/*` — git still descends into the root directory (a bare `.jolli/` would not, and a negation cannot re-include a file whose parent was never entered).
- `!/.jolli/agents.json` — the one committed file.
- `*/.jolli/` and `*/**/.jolli/` — the nested per-workspace directories. The old unanchored `.jolli/` matched at *any* depth; anchoring the root rule with `/*` stops that, so these are re-excluded explicitly.

Order matters here, as does the trailing `*`.

## Verification

`git check-ignore -v` confirms the intended outcome:

- `.jolli/agents.json` — not ignored
- `.jolli/jollimemory/sessions.json` — ignored by `/.jolli/*`
- `cli/.jolli/foo`, `vscode/.jolli/jollimemory/x` — ignored by `*/**/.jolli/`

No source, build, or test files are touched.