### PR TITLE
Make context-relevance ranking diff-informed and provider-uniform

### DIFF
--- a/cli/src/commands/DoctorCommand.ts
+++ b/cli/src/commands/DoctorCommand.ts
@@ -100,7 +100,7 @@ async function runDoctor(cwd: string, fix: boolean): Promise<void> {
 		message: branchExists ? "exists" : "not yet created (will be created on first commit)",
 	});
 
-	// 3. Worker lock (stuck = exists AND older than LOCK_TIMEOUT_MS; a normal worker
+	// 3. Worker lock (stuck = exists AND older than LOCK_HEARTBEAT_TIMEOUT_MS; a normal worker
 	// refreshes mtime every minute, so any age > 5 min implies a crashed worker).
 	// `orphan-write.lock` is held only for milliseconds and is not surfaced here —
 	// if a stale orphan-write lock ever appears, doctor's `--fix` would release it

--- a/cli/src/commands/PrDescriptionCommand.ts
+++ b/cli/src/commands/PrDescriptionCommand.ts
@@ -20,6 +20,8 @@
 
 import { type Command, Option } from "commander";
 import { buildPrDescription } from "../core/PrDescription.js";
+import { createStorage } from "../core/StorageFactory.js";
+import { setActiveStorage } from "../core/SummaryStore.js";
 import { setLogDir } from "../Logger.js";
 import { readStdin, resolveProjectDir, SAFE_ARGUMENT_PATTERN } from "./CliUtils.js";
 
@@ -77,6 +79,15 @@ export function registerPrDescriptionCommand(program: Command): void {
 			try {
 				const projectDir = options.cwd;
 				setLogDir(projectDir);
+				// Establish the configured storage backend before any read — same as
+				// the MCP `get_pr_description` tool (McpServer.startMcpServer) and the
+				// recall/search commands. buildPrDescription → loadBranchSummaries reads
+				// through getSummary without threading `storage`, so without this it
+				// falls through resolveStorage to the orphan branch and logs the
+				// "resolveStorage fallback to OrphanBranchStorage" WARN. Reads still
+				// resolve from the orphan branch, but folder-mode users otherwise see
+				// the spurious warning on every CLI pr-description run.
+				setActiveStorage(await createStorage(projectDir, projectDir));
 
 				// --arg-stdin and --base name the same value via two channels; mixing
 				// them would silently favor one and undermine the here-doc contract

--- a/cli/src/core/ContextRelevance.test.ts
+++ b/cli/src/core/ContextRelevance.test.ts
@@ -16,13 +16,18 @@ import {
 	buildChangeSignal,
 	buildDecisionFromAiRelevance,
 	buildItemsBlock,
+	type ChangeSignal,
 	type ContextItem,
+	capDiffForRelevance,
 	computeChangeFingerprint,
 	extractCandidateRepr,
 	extractSymbols,
 	keptContextRelevanceRefs,
 	parseRankContextResponse,
+	RELEVANCE_DIFF_BUDGET,
 	rankContextRelevance,
+	rankTimeoutForProvider,
+	sortByChangeAffinity,
 	stripFrontmatter,
 } from "./ContextRelevance.js";
 import { execGit, getDiffContent } from "./GitOps.js";
@@ -138,13 +143,30 @@ describe("buildItemsBlock", () => {
 
 describe("buildChangeBlock", () => {
 	it("renders message, files, and symbols", () => {
-		const block = buildChangeBlock({ commitMessage: "Fix X", changedFiles: ["a/b.ts"], symbols: ["doThing"] });
+		const block = buildChangeBlock({
+			commitMessage: "Fix X",
+			changedFiles: ["a/b.ts"],
+			symbols: ["doThing"],
+			diff: "",
+		});
 		expect(block).toContain("Commit message: Fix X");
 		expect(block).toContain("a/b.ts");
 		expect(block).toContain("doThing");
 	});
 	it("handles empty message/files/symbols", () => {
-		expect(buildChangeBlock({ commitMessage: "", changedFiles: [], symbols: [] })).toBe("Commit message: (none)");
+		expect(buildChangeBlock({ commitMessage: "", changedFiles: [], symbols: [], diff: "" })).toBe(
+			"Commit message: (none)",
+		);
+	});
+	it("renders the diff body when present", () => {
+		const block = buildChangeBlock({
+			commitMessage: "m",
+			changedFiles: [],
+			symbols: [],
+			diff: "+const answer = 42;",
+		});
+		expect(block).toContain("Diff (may be truncated):");
+		expect(block).toContain("+const answer = 42;");
 	});
 });
 
@@ -190,7 +212,7 @@ describe("parseRankContextResponse", () => {
 describe("rankContextRelevance", () => {
 	it("returns [] for no items", async () => {
 		expect(
-			await rankContextRelevance({ commitMessage: "m", changedFiles: [], symbols: [] }, [], { config }),
+			await rankContextRelevance({ commitMessage: "m", changedFiles: [], symbols: [], diff: "" }, [], { config }),
 		).toEqual([]);
 	});
 
@@ -210,7 +232,7 @@ describe("rankContextRelevance", () => {
 			),
 		);
 		const items = [item("plan", "p1", "Low", "aa"), item("note", "n1", "High", "bb")];
-		const res = await rankContextRelevance({ commitMessage: "m", changedFiles: [], symbols: [] }, items, {
+		const res = await rankContextRelevance({ commitMessage: "m", changedFiles: [], symbols: [], diff: "" }, items, {
 			config,
 		});
 		expect(res[0]).toMatchObject({ id: "n1", rank: 1, tier: "high", relevant: true });
@@ -220,7 +242,7 @@ describe("rankContextRelevance", () => {
 	it("conservatively keeps items the LLM omitted", async () => {
 		mockCallLlm.mockResolvedValue(llmText(["===ITEM===", "index: 1", "tier: high", "reason: x"].join("\n")));
 		const items = [item("plan", "p1", "Has", "aa"), item("note", "n1", "Omitted", "bb")];
-		const res = await rankContextRelevance({ commitMessage: "m", changedFiles: [], symbols: [] }, items, {
+		const res = await rankContextRelevance({ commitMessage: "m", changedFiles: [], symbols: [], diff: "" }, items, {
 			config,
 		});
 		const omitted = res.find((r) => r.id === "n1");
@@ -231,7 +253,7 @@ describe("rankContextRelevance", () => {
 	it("fails open (keeps all) when the LLM call throws", async () => {
 		mockCallLlm.mockRejectedValue(new Error("boom"));
 		const items = [item("plan", "p1", "A", "aa"), item("note", "n1", "B", "bb")];
-		const res = await rankContextRelevance({ commitMessage: "m", changedFiles: [], symbols: [] }, items, {
+		const res = await rankContextRelevance({ commitMessage: "m", changedFiles: [], symbols: [], diff: "" }, items, {
 			config,
 		});
 		expect(res).toHaveLength(2);
@@ -242,18 +264,65 @@ describe("rankContextRelevance", () => {
 		expect(res.map((r) => r.id)).toEqual(["p1", "n1"]);
 	});
 
-	it("skips the LLM entirely under local-agent (keeps all, no spawn)", async () => {
-		mockCallLlm.mockRejectedValue(new Error("should not be called"));
+	it("ranks under local-agent too, using the longer local-agent wall-clock", async () => {
+		mockCallLlm.mockResolvedValue(llmText(["===ITEM===", "index: 1", "tier: low", "reason: unrelated"].join("\n")));
 		const localAgentConfig = { aiProvider: "local-agent" } as LlmConfig;
 		const items = [item("plan", "p1", "A", "aa"), item("note", "n1", "B", "bb")];
-		const res = await rankContextRelevance({ commitMessage: "m", changedFiles: [], symbols: [] }, items, {
+		const res = await rankContextRelevance({ commitMessage: "m", changedFiles: [], symbols: [], diff: "" }, items, {
 			config: localAgentConfig,
 		});
-		// A cold multi-minute CLI agent can't finish inside RANK_TIMEOUT_MS; skip
-		// straight to the conservative keep-all without cold-spawning `claude`.
-		expect(mockCallLlm).not.toHaveBeenCalled();
-		expect(res).toHaveLength(2);
-		expect(res.every((r) => r.relevant && r.tier === "mid" && !r.autoExclude)).toBe(true);
+		// local-agent is no longer short-circuited — it ranks like every provider,
+		// only with a longer wall-clock (rankTimeoutForProvider) to absorb the
+		// cold-spawn without SIGKILLing a call that would have succeeded.
+		expect(mockCallLlm).toHaveBeenCalledTimes(1);
+		expect(mockCallLlm.mock.calls[0][0].timeoutMs).toBe(180_000);
+		// The verdict is honored (item 1 low → excluded), not a blanket keep-all.
+		expect(res.find((r) => r.id === "p1")?.autoExclude).toBe(true);
+	});
+
+	it("uses the 120s API wall-clock for anthropic/jolli providers", async () => {
+		mockCallLlm.mockResolvedValue(llmText(["===ITEM===", "index: 1", "tier: high", "reason: r"].join("\n")));
+		const items = [item("plan", "p1", "A", "aa")];
+		await rankContextRelevance({ commitMessage: "m", changedFiles: [], symbols: [], diff: "" }, items, {
+			config: { aiProvider: "anthropic" } as LlmConfig,
+		});
+		expect(mockCallLlm.mock.calls[0][0].timeoutMs).toBe(120_000);
+	});
+
+	it("passes the change diff into the LLM prompt (end-to-end integration)", async () => {
+		mockCallLlm.mockResolvedValue(llmText(["===ITEM===", "index: 1", "tier: high", "reason: r"].join("\n")));
+		await rankContextRelevance(
+			{ commitMessage: "m", changedFiles: [], symbols: [], diff: "+const sentinel = 42;" },
+			[item("plan", "p1", "A", "aa")],
+			{ config },
+		);
+		// The diff must actually reach callLlm's prompt, not just be renderable in isolation.
+		expect(mockCallLlm.mock.calls[0][0].params.changeSignal).toContain("+const sentinel = 42;");
+		// And the raised output budget is wired through.
+		expect(mockCallLlm.mock.calls[0][0].maxTokens).toBe(8192);
+	});
+
+	it("judges the low-affinity item and keeps the dropped high-affinity item as mid (ascending + merge-back)", async () => {
+		// Ascending sort sends the LOW-affinity (likely-unrelated) item to the LLM so it
+		// can be excluded; the HIGH-affinity item overflows totalBudget:1 and is dropped →
+		// kept "mid". The dropped item is at original index 0, so a buggy `?? i+1` fallback
+		// would graft the judged item's block-index-1 verdict onto it — this guards both the
+		// ascending direction AND the affinity-reorder merge-back fix.
+		mockCallLlm.mockResolvedValue(llmText(["===ITEM===", "index: 1", "tier: low", "reason: unrelated"].join("\n")));
+		const items = [
+			item("plan", "highAff", "Auth service", "touches AuthService in cli/src/core"), // original index 0
+			item("plan", "lowAff", "Marketing", "nothing to do with the change"), // original index 1
+		];
+		const res = await rankContextRelevance(
+			{ commitMessage: "m", changedFiles: ["cli/src/core/AuthService.ts"], symbols: ["AuthService"], diff: "" },
+			items,
+			{ config, totalBudget: 1 },
+		);
+		// The low-affinity item was SENT to the LLM → judged low → excluded.
+		expect(res.find((r) => r.id === "lowAff")?.autoExclude).toBe(true);
+		// The high-affinity item overflowed → dropped → kept "mid", NOT grafted the low verdict.
+		expect(res.find((r) => r.id === "highAff")?.tier).toBe("mid");
+		expect(res.find((r) => r.id === "highAff")?.autoExclude).toBe(false);
 	});
 });
 
@@ -265,6 +334,8 @@ describe("buildChangeSignal", () => {
 		expect(sig.changedFiles).toEqual(["cli/src/a.ts", "cli/src/b.ts"]);
 		expect(sig.symbols).toContain("newFn");
 		expect(sig.commitMessage).toBe("Fix a");
+		// The diff body is now retained (not just mined for symbols then discarded).
+		expect(sig.diff).toContain("newFn");
 	});
 	it("leaves fields empty when git fails", async () => {
 		mockExecGit.mockResolvedValue({ stdout: "", stderr: "bad", exitCode: 1 });
@@ -272,6 +343,89 @@ describe("buildChangeSignal", () => {
 		const sig = await buildChangeSignal("m", "a", "b", "/repo");
 		expect(sig.changedFiles).toEqual([]);
 		expect(sig.symbols).toEqual([]);
+		expect(sig.diff).toBe("");
+	});
+	it("caps an oversized diff to the relevance budget with a truncation marker", async () => {
+		mockExecGit.mockResolvedValue({ stdout: "cli/src/a.ts", stderr: "", exitCode: 0 });
+		mockGetDiff.mockResolvedValue("+".repeat(RELEVANCE_DIFF_BUDGET + 5_000));
+		const sig = await buildChangeSignal("m", "a", "b", "/repo");
+		expect(sig.diff.length).toBeLessThan(RELEVANCE_DIFF_BUDGET + 200);
+		expect(sig.diff).toContain("diff truncated");
+	});
+});
+
+describe("capDiffForRelevance", () => {
+	it("returns a small diff unchanged", () => {
+		expect(capDiffForRelevance("small diff")).toBe("small diff");
+	});
+	it("truncates to the head + a marker when over budget", () => {
+		const out = capDiffForRelevance("x".repeat(RELEVANCE_DIFF_BUDGET + 100));
+		expect(out.startsWith("x".repeat(RELEVANCE_DIFF_BUDGET))).toBe(true);
+		expect(out).toContain("diff truncated");
+	});
+});
+
+describe("rankTimeoutForProvider", () => {
+	it("uses 180s for local-agent and 120s otherwise", () => {
+		expect(rankTimeoutForProvider("local-agent")).toBe(180_000);
+		expect(rankTimeoutForProvider("anthropic")).toBe(120_000);
+		expect(rankTimeoutForProvider("jolli")).toBe(120_000);
+		expect(rankTimeoutForProvider(undefined)).toBe(120_000);
+	});
+});
+
+describe("sortByChangeAffinity", () => {
+	const change = (files: string[], symbols: string[] = []): ChangeSignal => ({
+		commitMessage: "",
+		changedFiles: files,
+		symbols,
+		diff: "",
+	});
+	it("orders least-affinity (likely-unrelated) FIRST so the budget judges the excludable ones", () => {
+		// Ascending: the low-affinity item survives the budget and gets judged (can be
+		// excluded); the high-affinity item is the drop-on-overflow tail (kept unranked,
+		// which is correct — it is the likely-relevant set).
+		const items = [
+			item("plan", "unrelated", "Marketing plan", "nothing to do with the change"),
+			item("plan", "related", "Auth refactor", "touches AuthService in cli/src/core"),
+		];
+		const sorted = sortByChangeAffinity(items, change(["cli/src/core/AuthService.ts"], ["AuthService"]));
+		expect(sorted.map((s) => s.id)).toEqual(["unrelated", "related"]);
+	});
+	it("is stable (keeps original order) when nothing matches", () => {
+		const items = [item("plan", "a", "A", "x"), item("plan", "b", "B", "y")];
+		const sorted = sortByChangeAffinity(items, change(["zzz/nope.ts"]));
+		expect(sorted.map((s) => s.id)).toEqual(["a", "b"]);
+	});
+	it("returns a copy without mutating the input", () => {
+		const items = [item("plan", "a", "A", "x")];
+		const sorted = sortByChangeAffinity(items, change([]));
+		expect(sorted).not.toBe(items);
+		expect(sorted.map((s) => s.id)).toEqual(["a"]);
+	});
+	it("short-circuits a single-item list even when the change has needles", () => {
+		const items = [item("plan", "a", "A", "x")];
+		const sorted = sortByChangeAffinity(items, change(["cli/src/core/Thing.ts"], ["Thing"]));
+		expect(sorted.map((s) => s.id)).toEqual(["a"]);
+		expect(sorted).not.toBe(items);
+	});
+	it("uses the basename (not generic dir segments) as the needle", () => {
+		// If dir segments were needles, "dirs" (mentions core/src) would outscore "file"
+		// and sort last. With only the basename "Makefile" as a needle, "file" scores 1
+		// and "dirs" scores 0 → ascending puts "dirs" first. Also covers the `dot > 0`
+		// false branch (Makefile has no extension → no without-ext needle).
+		const items = [
+			item("plan", "dirs", "X", "all about core and src layout"),
+			item("plan", "file", "Y", "edits the Makefile"),
+		];
+		const sorted = sortByChangeAffinity(items, change(["core/src/Makefile"]));
+		expect(sorted.map((s) => s.id)).toEqual(["dirs", "file"]);
+	});
+	it("adds the basename without extension but drops a <3-char stem", () => {
+		// "src/ab.ts": basename "ab.ts" is a needle; its stem "ab" is <3 chars → dropped.
+		const items = [item("plan", "stem", "F", "mentions ab"), item("plan", "full", "G", "mentions ab.ts")];
+		const sorted = sortByChangeAffinity(items, change(["src/ab.ts"]));
+		expect(sorted.map((s) => s.id)).toEqual(["stem", "full"]);
 	});
 });
 
@@ -300,7 +454,7 @@ describe("review-fix regressions", () => {
 			item("note", "n1", "B", "y"),
 			item("reference", "linear:R", "C", "z"),
 		];
-		const res = await rankContextRelevance({ commitMessage: "m", changedFiles: [], symbols: [] }, items, {
+		const res = await rankContextRelevance({ commitMessage: "m", changedFiles: [], symbols: [], diff: "" }, items, {
 			config,
 		});
 		// Ordered by tier (high → mid → low), not input order.
@@ -339,7 +493,7 @@ describe("review-fix regressions", () => {
 			item("note", "n1", "B", "y"),
 			item("reference", "linear:R", "C", "z"),
 		];
-		const res = await rankContextRelevance({ commitMessage: "m", changedFiles: [], symbols: [] }, items, {
+		const res = await rankContextRelevance({ commitMessage: "m", changedFiles: [], symbols: [], diff: "" }, items, {
 			config,
 		});
 		expect(res.map((r) => r.tier)).toEqual(["low", "low", "low"]);
@@ -405,7 +559,7 @@ describe("assessContextRelevance", () => {
 		mockCallLlm.mockResolvedValue(rankTwo());
 		const decision = await assessContextRelevance(
 			twoPlans(),
-			{ commitMessage: "m", changedFiles: ["a.ts"], symbols: [] },
+			{ commitMessage: "m", changedFiles: ["a.ts"], symbols: [], diff: "" },
 			config,
 		);
 		expect(decision.plans.map((p) => p.slug)).toEqual(["p1"]);
@@ -419,7 +573,7 @@ describe("assessContextRelevance", () => {
 		mockCallLlm.mockResolvedValue(llmText(["===ITEM===", "index: 1", "tier: high", "reason: x"].join("\n")));
 		const decision = await assessContextRelevance(
 			{ plans: [planEntry("p1", "P1")], notes: [], references: [] },
-			{ commitMessage: "m", changedFiles: ["a.ts"], symbols: [] },
+			{ commitMessage: "m", changedFiles: ["a.ts"], symbols: [], diff: "" },
 			config,
 		);
 		expect(decision.plans).toHaveLength(1);
@@ -428,7 +582,7 @@ describe("assessContextRelevance", () => {
 	it("returns raw entries and empty results when there are no items", async () => {
 		const decision = await assessContextRelevance(
 			{ plans: [], notes: [], references: [] },
-			{ commitMessage: "m", changedFiles: [], symbols: [] },
+			{ commitMessage: "m", changedFiles: [], symbols: [], diff: "" },
 			config,
 		);
 		expect(decision.results).toEqual([]);
@@ -462,7 +616,7 @@ describe("assessContextRelevance", () => {
 		const ref = { source: "linear", nativeId: "X-1", title: "Ref", sourcePath: "/x/r.md" } as never;
 		const decision = await assessContextRelevance(
 			{ plans: [], notes: [note], references: [ref] },
-			{ commitMessage: "m", changedFiles: ["a.ts"], symbols: [] },
+			{ commitMessage: "m", changedFiles: ["a.ts"], symbols: [], diff: "" },
 			config,
 		);
 		expect(decision.notes).toEqual([note]);
@@ -483,7 +637,7 @@ describe("assessContextRelevance", () => {
 		} as never;
 		const decision = await assessContextRelevance(
 			{ plans: [planEntry("p1", "P1")], notes: [note], references: [] },
-			{ commitMessage: "m", changedFiles: ["a.ts"], symbols: [] },
+			{ commitMessage: "m", changedFiles: ["a.ts"], symbols: [], diff: "" },
 			config,
 		);
 		expect(decision.notes).toEqual([]);
@@ -497,7 +651,7 @@ describe("assessContextRelevance", () => {
 		const ref = { source: "linear", nativeId: "X-1", title: "Ref", sourcePath: "/x/r.md" } as never;
 		const decision = await assessContextRelevance(
 			{ plans: [planEntry("p1", "P1")], notes: [], references: [ref] },
-			{ commitMessage: "m", changedFiles: ["a.ts"], symbols: [] },
+			{ commitMessage: "m", changedFiles: ["a.ts"], symbols: [], diff: "" },
 			config,
 		);
 		expect(decision.references).toEqual([]);
@@ -510,19 +664,19 @@ describe("assessContextRelevance", () => {
 
 describe("computeChangeFingerprint", () => {
 	it("is stable regardless of changed-file order", () => {
-		expect(computeChangeFingerprint({ commitMessage: "m", changedFiles: ["a.ts", "b.ts"], symbols: [] })).toBe(
-			computeChangeFingerprint({ commitMessage: "m", changedFiles: ["b.ts", "a.ts"], symbols: [] }),
-		);
+		expect(
+			computeChangeFingerprint({ commitMessage: "m", changedFiles: ["a.ts", "b.ts"], symbols: [], diff: "" }),
+		).toBe(computeChangeFingerprint({ commitMessage: "m", changedFiles: ["b.ts", "a.ts"], symbols: [], diff: "" }));
 	});
 	it("ignores the commit message (panel has none pre-commit) and keys only on files", () => {
 		// Same files, different message → same fingerprint (so panel↔worker match).
-		expect(computeChangeFingerprint({ commitMessage: "m1", changedFiles: ["a.ts"], symbols: [] })).toBe(
-			computeChangeFingerprint({ commitMessage: "m2", changedFiles: ["a.ts"], symbols: [] }),
+		expect(computeChangeFingerprint({ commitMessage: "m1", changedFiles: ["a.ts"], symbols: [], diff: "" })).toBe(
+			computeChangeFingerprint({ commitMessage: "m2", changedFiles: ["a.ts"], symbols: [], diff: "" }),
 		);
 		// Different files → different fingerprint.
-		expect(computeChangeFingerprint({ commitMessage: "m", changedFiles: ["a.ts"], symbols: [] })).not.toBe(
-			computeChangeFingerprint({ commitMessage: "m", changedFiles: ["b.ts"], symbols: [] }),
-		);
+		expect(
+			computeChangeFingerprint({ commitMessage: "m", changedFiles: ["a.ts"], symbols: [], diff: "" }),
+		).not.toBe(computeChangeFingerprint({ commitMessage: "m", changedFiles: ["b.ts"], symbols: [], diff: "" }));
 	});
 });
 

--- a/cli/src/core/ContextRelevance.ts
+++ b/cli/src/core/ContextRelevance.ts
@@ -48,10 +48,30 @@ const log = createLogger("ContextRelevance");
  *  prompts rather than overflow. */
 export const CHARS_PER_TOKEN = 3;
 
-/** Total character budget for the rendered <context-items> block. ~40K tokens
- *  at CHARS_PER_TOKEN. Items beyond the budget (after skeletonization) are
- *  dropped from the tail of the initial order and logged. */
-export const TOTAL_ITEMS_CHAR_BUDGET = 120_000;
+/** Total character budget for the rendered <context-items> block. ~53K tokens
+ *  at CHARS_PER_TOKEN. Items beyond the budget (after skeletonization) are dropped
+ *  from the tail and logged — and a dropped item is conservatively KEPT unranked
+ *  (see rankContextRelevance), so an overflow leaves items unjudged. Candidates are
+ *  pre-sorted by change-affinity ASCENDING before the budget is applied (see
+ *  sortByChangeAffinity), so the dropped tail is the HIGH-affinity (likely-relevant,
+ *  kept-anyway) set and the budget is spent judging the low-affinity candidates that
+ *  might warrant exclusion.
+ *
+ *  Note: for the arg-based local-agent backends (codex / cursor-agent / opencode)
+ *  the whole prompt is passed as a single argv string, which on Linux is capped at
+ *  ~128 KiB (MAX_ARG_STRLEN); items (up to this budget) + diff can exceed that and
+ *  the spawn fails with E2BIG → caught → keepAll (a safe fallback, identical to the
+ *  pre-ranking local-agent behavior). The robust fix (feed the prompt via stdin like
+ *  ClaudeCodeBackend, or a local-agent-specific smaller budget) is deferred. */
+export const TOTAL_ITEMS_CHAR_BUDGET = 160_000;
+
+/** Character budget for the diff body embedded in the <change> block. The diff
+ *  is the strongest relevance signal ("what did this change actually do"), but it
+ *  competes with TOTAL_ITEMS_CHAR_BUDGET for the model window and the wall-clock
+ *  budget, so it is capped to the head of the diff. Sized between the commit-
+ *  message diff budget (12K) and the summary's own diff cap (150K): enough to
+ *  characterize the change without dominating the prompt. */
+export const RELEVANCE_DIFF_BUDGET = 20_000;
 
 /** A reference whose (frontmatter-stripped) body is at/under this is sent
  *  whole; aligned with the summarize-stage per-reference cap so we never send
@@ -64,12 +84,33 @@ export const PLANNOTE_WHOLE_CHAR_CAP = 6_000;
 /** Hard cap on a single item's skeleton (~1.5K tokens). */
 export const SKELETON_CHAR_CAP = 4_500;
 
-/** Short per-call wall-clock so a wedged ranking call fails open fast without
- *  holding the post-commit queue lock. */
-export const RANK_TIMEOUT_MS = 45_000;
+/** Per-call wall-clock for API providers (anthropic / jolli). Bounds how long a
+ *  ranking call can hold the post-commit queue lock before it fails open. Raised
+ *  from the original 45s because the <change> block now carries a diff body
+ *  (bigger input → longer), and the ranker runs in the detached post-commit
+ *  worker (git has already returned), so it can afford the same order of budget
+ *  as the summary call that follows it. Still well under the worker-lock heartbeat
+ *  window (see LOCK_HEARTBEAT_TIMEOUT_MS), and the summary call's own cap. */
+export const RANK_TIMEOUT_MS = 120_000;
 
-/** Max output tokens for the ranking call — one short block per item. */
-const RANK_MAX_TOKENS = 4_096;
+/** Per-call wall-clock for the local-agent provider. A local CLI agent cold-spawns
+ *  a real `claude`/`codex` process, so a ranking (small prompt, single turn) is
+ *  expected to be tens of seconds — this ceiling only exists to absorb cold-spawn
+ *  variance without SIGKILLing a call that is about to succeed. It does NOT imply
+ *  ranking is minutes-long (that is the summary worst case). The worker heartbeats
+ *  the lock every 60s regardless, so a longer run never trips the stale-reclaim. */
+export const RANK_TIMEOUT_LOCAL_AGENT_MS = 180_000;
+
+/** Resolves the ranking wall-clock for the active provider. */
+export function rankTimeoutForProvider(aiProvider: LlmConfig["aiProvider"]): number {
+	return aiProvider === "local-agent" ? RANK_TIMEOUT_LOCAL_AGENT_MS : RANK_TIMEOUT_MS;
+}
+
+/** Max output tokens for the ranking call — one short block per item. Raised to
+ *  keep the response from truncating when many items are ranked in one call: a
+ *  truncated tail is omitted from the parse and then conservatively KEPT (mid),
+ *  which is the same silent-leak failure mode as an items-budget overflow. */
+const RANK_MAX_TOKENS = 8_192;
 
 // -- Types --------------------------------------------------------------------
 
@@ -91,6 +132,10 @@ export interface ChangeSignal {
 	readonly commitMessage: string;
 	readonly changedFiles: readonly string[];
 	readonly symbols: readonly string[];
+	/** Head of the change's diff (capped to RELEVANCE_DIFF_BUDGET). The strongest
+	 *  relevance signal — what the change actually did — beyond file names and
+	 *  declared symbols. May be empty when the diff is unavailable. */
+	readonly diff: string;
 }
 
 export type RelevanceTier = "high" | "mid" | "low";
@@ -243,6 +288,68 @@ export function extractCandidateRepr(item: ContextItem): string {
 
 // -- Prompt assembly ----------------------------------------------------------
 
+/** How many chars of an item's body to scan when scoring change-affinity. Bounds
+ *  the sort's cost for large items; the head of a doc carries its topic. */
+const AFFINITY_SCAN_CAP = 8_000;
+
+/** Lowercased, deduped tokens that characterize the change: each changed file's
+ *  basename (with and without extension) plus declared symbols. Intermediate path
+ *  directories are DELIBERATELY excluded — in a monorepo, generic segments like
+ *  `cli` / `src` / `core` / `hooks` match almost any document and would dominate
+ *  the affinity score with noise (affinityScore is substring-based). Tokens shorter
+ *  than 3 chars are dropped (too generic to signal). */
+function changeNeedles(change: ChangeSignal): string[] {
+	const out = new Set<string>();
+	const add = (raw: string): void => {
+		const t = raw.trim().toLowerCase();
+		if (t.length >= 3) out.add(t);
+	};
+	for (const file of change.changedFiles) {
+		const segments = file.split("/").filter((s) => s.length > 0);
+		const base = segments[segments.length - 1];
+		if (base) {
+			add(base); // basename with extension
+			const dot = base.lastIndexOf(".");
+			if (dot > 0) add(base.slice(0, dot)); // basename without extension
+		}
+	}
+	for (const sym of change.symbols) add(sym);
+	return [...out];
+}
+
+/** Count of distinct change-needles that appear in an item's (title + bounded
+ *  body) text. Cheap, deterministic, best-effort — never throws. */
+function affinityScore(item: ContextItem, needles: readonly string[]): number {
+	const hay = `${item.title}\n${item.content.slice(0, AFFINITY_SCAN_CAP)}`.toLowerCase();
+	let score = 0;
+	for (const n of needles) if (hay.includes(n)) score += 1;
+	return score;
+}
+
+/**
+ * Orders candidates by change-affinity ASCENDING (least-affinity first) before the
+ * items-budget is applied. This is deliberately the *opposite* of "most important
+ * first", because the ranker is fail-open-KEEP: a candidate dropped by the budget
+ * is conservatively KEPT unranked, so ONLY the candidates that actually reach the
+ * LLM can be excluded. The scarce prompt budget must therefore be spent on the
+ * candidates most likely to warrant exclusion — the LOW-affinity ones (little
+ * overlap with the change ⇒ likely unrelated). High-affinity candidates that
+ * overflow the budget are dropped and kept unranked, which is correct: they are the
+ * likely-relevant set and would have been kept anyway (the only cost is losing their
+ * displayed tier/reason). Sorting the other way would drop the likely-unrelated tail
+ * and keep it unjudged — the exact silent leak this filter exists to prevent.
+ *
+ * Stable: ties keep original order (so no signal ⇒ order unchanged); returns a copy
+ * (never mutates the input).
+ */
+export function sortByChangeAffinity(items: readonly ContextItem[], change: ChangeSignal): ContextItem[] {
+	const needles = changeNeedles(change);
+	if (needles.length === 0 || items.length < 2) return [...items];
+	const scored = items.map((item, i) => ({ item, i, score: affinityScore(item, needles) }));
+	scored.sort((a, b) => a.score - b.score || a.i - b.i);
+	return scored.map((s) => s.item);
+}
+
 /** Renders the <context-items> block and the index→id map. Enforces a total
  *  char budget by dropping items from the tail of the initial order (logged),
  *  so an oversized candidate set never overflows the prompt. */
@@ -278,6 +385,15 @@ export function buildItemsBlock(
 }
 
 /** Renders the <change> block from a ChangeSignal. */
+/** Caps a raw diff to the head of RELEVANCE_DIFF_BUDGET chars (+ a truncation
+ *  marker). Shared by `buildChangeSignal` (post-commit worker) and the pre-commit
+ *  preview panel so both feed the ranker an identically-shaped diff signal. */
+export function capDiffForRelevance(diff: string): string {
+	return diff.length > RELEVANCE_DIFF_BUDGET
+		? `${diff.slice(0, RELEVANCE_DIFF_BUDGET)}\n--- diff truncated (${diff.length} chars total) ---`
+		: diff;
+}
+
 export function buildChangeBlock(change: ChangeSignal): string {
 	const lines: string[] = [`Commit message: ${change.commitMessage || "(none)"}`];
 	if (change.changedFiles.length > 0) {
@@ -285,6 +401,9 @@ export function buildChangeBlock(change: ChangeSignal): string {
 	}
 	if (change.symbols.length > 0) {
 		lines.push(`Key symbols: ${change.symbols.join(", ")}`);
+	}
+	if (change.diff.length > 0) {
+		lines.push(`Diff (may be truncated):\n${change.diff}`);
 	}
 	return lines.join("\n");
 }
@@ -397,25 +516,26 @@ export async function rankContextRelevance(
 ): Promise<ContextRelevanceResult[]> {
 	if (items.length === 0) return [];
 
-	// The ranker is a latency-sensitive, fail-open optimization: its short
-	// RANK_TIMEOUT_MS exists so a wedged call never holds the post-commit queue
-	// lock. A local CLI agent runs a full multi-minute agentic turn, so under the
-	// local-agent provider this call could never finish inside that budget — it
-	// would cold-spawn `claude` only to be SIGKILLed on every commit. Skip
-	// straight to the conservative keep-all result (identical to the fail-open
-	// branch below) without spawning anything.
-	if (opts.config.aiProvider === "local-agent") {
-		log.info("Skipping context-relevance ranking under local-agent provider — keeping all items");
-		return keepAll(items);
-	}
-
+	// Relevance ranking runs for EVERY provider. It is the engine behind the
+	// pre-commit preview panel and the summary's excluded set, so it must not be
+	// provider-gated (a local-agent user opens the same panel and needs the same
+	// filtering). The RANK_TIMEOUT_MS ceiling exists so a wedged call cannot pin
+	// the post-commit queue lock indefinitely; the local-agent ceiling is longer
+	// (rankTimeoutForProvider) to absorb its cold-spawn without SIGKILLing a call
+	// that is about to succeed. On any failure this falls open to keepAll below.
 	try {
-		const { block, indexToId } = buildItemsBlock(items, opts.totalBudget ?? TOTAL_ITEMS_CHAR_BUDGET);
+		// Pre-sort by change-affinity ASCENDING so a budget/token overflow drops the
+		// HIGH-affinity (likely-relevant, kept-anyway) tail and spends the budget
+		// judging the low-affinity candidates that might warrant exclusion. Dropped
+		// items are conservatively kept unranked (fail-open), so only judged ones can
+		// be excluded — see sortByChangeAffinity for why this direction is correct.
+		const ordered = sortByChangeAffinity(items, change);
+		const { block, indexToId } = buildItemsBlock(ordered, opts.totalBudget ?? TOTAL_ITEMS_CHAR_BUDGET);
 		const llmResult = await callLlm({
 			action: "rank-context",
 			params: { changeSignal: buildChangeBlock(change), items: block },
 			maxTokens: RANK_MAX_TOKENS,
-			timeoutMs: opts.timeoutMs ?? RANK_TIMEOUT_MS,
+			timeoutMs: opts.timeoutMs ?? rankTimeoutForProvider(opts.config.aiProvider),
 			model: resolveModelId(opts.config.model),
 			...llmCredentials(opts.config),
 		});
@@ -426,12 +546,18 @@ export async function rankContextRelevance(
 		const byIndex = new Map<number, ParsedItem>();
 		for (const p of parsed) byIndex.set(p.index, p);
 
-		const merged = items.map((item, i) => {
-			// index in the block is 1-based and matches insertion order up to any
-			// dropped tail; find this item's block index via indexToId.
-			const blockIndex = findIndexForId(indexToId, item.id) ?? i + 1;
-			const p = byIndex.get(blockIndex);
-			// Omitted item → conservative "mid" keep (never a false high, never excluded).
+		const merged = items.map((item) => {
+			// Look up this item's verdict by its block index. Candidates are affinity-
+			// sorted before buildItemsBlock, so block order != original order, and a
+			// budget overflow drops the block's TAIL. An item absent from indexToId was
+			// therefore DROPPED — it must be conservatively kept as "mid". Never fall
+			// back to a guessed block index from the original position: after the
+			// reorder that would graft a DIFFERENT item's verdict onto the dropped one,
+			// silently excluding context the model never judged.
+			const blockIndex = findIndexForId(indexToId, item.id);
+			const p = blockIndex !== undefined ? byIndex.get(blockIndex) : undefined;
+			// Dropped or LLM-omitted item → conservative "mid" keep (never a false
+			// high, never excluded).
 			const tier = p?.tier ?? "mid";
 			const reason = p?.reason ?? "";
 			return { item, tier, reason };
@@ -514,20 +640,41 @@ export async function buildChangeSignal(
 			.filter((l) => l.length > 0);
 	}
 	let symbols: readonly string[] = [];
+	let diff = "";
 	try {
-		const diff = await getDiffContent(fromRef, toRef, cwd, 60_000);
-		symbols = extractSymbols(diff);
+		// One diff read serves both signals: the full (capped) body feeds symbol
+		// extraction, and its head (RELEVANCE_DIFF_BUDGET) becomes the change's diff
+		// signal. Previously the body was extracted-from then discarded.
+		const fullDiff = await getDiffContent(fromRef, toRef, cwd, 60_000);
+		symbols = extractSymbols(fullDiff);
+		diff = capDiffForRelevance(fullDiff);
 	} catch {
-		// symbols are best-effort; leave empty on failure
+		// diff + symbols are best-effort; leave empty on failure
 	}
-	return { commitMessage, changedFiles, symbols };
+	return { commitMessage, changedFiles, symbols, diff };
 }
 
 /** Fingerprint of a change for panel↔worker reuse coordination. Keyed ONLY on the
  *  sorted changed-file set — deliberately NOT the commit message — so the pre-commit
  *  panel (which has no message yet) and the post-commit worker (which does) produce
  *  the SAME fingerprint for the same file set, letting the worker reuse the panel's
- *  ranking instead of re-running the LLM. Order-independent (sorted). */
+ *  ranking instead of re-running the LLM. Order-independent (sorted).
+ *
+ *  ACCEPTED LIMITATION (diff deliberately NOT in the key — rare, left unhandled):
+ *  the ranker now also consumes the change diff, but this fingerprint stays
+ *  file-set-only. So a stale-diff reuse is possible: the panel ranks file set F with
+ *  working-tree diff D1, then the user edits the SAME files (F unchanged) to add
+ *  content on a new topic and commits diff D2 WITHOUT the panel re-ranking, so the
+ *  worker reuses the D1-based decision against the D2 commit. The trigger is narrow —
+ *  it needs the interactive preview panel open, a prior rank, an in-place edit that
+ *  keeps the file set identical but changes the topic, and a commit before any
+ *  re-rank. It cannot happen on the CLI/MCP `pr-description`/`push` path (no panel →
+ *  the worker always ranks fresh against the real commit diff). We deliberately do NOT
+ *  handle it: folding the diff into the key would defeat reuse across the board,
+ *  because the panel diff (`git diff HEAD`) and the worker diff
+ *  (`git diff <commit>~1..<commit>`) are not guaranteed byte-identical for the same
+ *  content, so the keys would perpetually miss and every commit would pay a redundant
+ *  re-rank — too high a price for so rare a case. */
 export function computeChangeFingerprint(change: ChangeSignal): string {
 	const h = createHash("sha1");
 	h.update([...change.changedFiles].sort().join("\n"));

--- a/cli/src/core/LockPrimitives.ts
+++ b/cli/src/core/LockPrimitives.ts
@@ -7,7 +7,7 @@
  *
  *   - PID written into the file as ASCII
  *   - mtime is the freshness signal
- *   - locks older than `LOCK_TIMEOUT_MS` are reclaimable by the next acquirer
+ *   - locks older than `LOCK_HEARTBEAT_TIMEOUT_MS` are reclaimable by the next acquirer
  *   - releases are PID-checked to prevent the stale-reclaim race where
  *     process A's finally block deletes process B's freshly-acquired lock
  *
@@ -29,14 +29,24 @@ import { createLogger } from "../Logger.js";
 const log = createLogger("LockPrimitives");
 
 /**
- * Stale-reclaim threshold for all jollimemory file locks.
+ * Heartbeat-lapse threshold for all jollimemory file locks: a lock whose mtime
+ * (its heartbeat) has not been bumped within this window is treated as owned by a
+ * dead process and is reclaimable by the next acquirer.
+ *
+ * This is NOT a cap on how long a lock may be held. A live holder bumps its mtime
+ * on an independent timer (the worker: every 60 s, via a setInterval that fires
+ * during the awaited LLM call), so a legitimately long operation — a multi-minute
+ * summary or relevance turn — keeps the lock indefinitely without ever tripping
+ * this threshold. It fires only on an actual death (crash, kill, machine sleep),
+ * where recovery latency is bounded by this value. Hence the name: it is a
+ * heartbeat timeout, not a lock-duration timeout.
  *
  * Invariant: must be greater than 2 × the longest heartbeat interval of any
  * caller. Today the worker bumps mtime every 60 s while running, so 5 min
  * leaves ample margin for a missed GC tick or slow scheduler. Sync rounds
  * are shorter (no LLM by default), but follow the same convention.
  */
-export const LOCK_TIMEOUT_MS = 5 * 60 * 1000;
+export const LOCK_HEARTBEAT_TIMEOUT_MS = 5 * 60 * 1000;
 
 /** Optional knobs for `acquireWithPoll`. */
 export interface PollOpts {
@@ -87,7 +97,7 @@ export function isPidAlive(pidStr: string): boolean {
  * filesystem error blocked us.
  *
  * Stale locks are removed automatically — "stale" means either:
- *   1. `mtime` older than `LOCK_TIMEOUT_MS` (heartbeat lapsed → process
+ *   1. `mtime` older than `LOCK_HEARTBEAT_TIMEOUT_MS` (heartbeat lapsed → process
  *      probably hung), OR
  *   2. the written PID is no longer alive (`isPidAlive` returns false →
  *      owner crashed without running the release path; mtime check would
@@ -103,7 +113,7 @@ export async function tryAcquireOnce(lockPath: string): Promise<boolean> {
 		const age = Date.now() - lockStat.mtimeMs;
 		const ownerPid = await readLockOwnerPid(lockPath);
 		const ownerDead = ownerPid !== null && !isPidAlive(ownerPid);
-		if (!ownerDead && age < LOCK_TIMEOUT_MS) {
+		if (!ownerDead && age < LOCK_HEARTBEAT_TIMEOUT_MS) {
 			return false;
 		}
 		if (ownerDead) {
@@ -212,14 +222,14 @@ export async function refreshLockMtime(lockPath: string): Promise<void> {
 }
 
 /**
- * Returns true when `lockPath` exists and is younger than `LOCK_TIMEOUT_MS`.
+ * Returns true when `lockPath` exists and is younger than `LOCK_HEARTBEAT_TIMEOUT_MS`.
  * Used by callers that need to detect "is anyone currently running?" without
  * trying to acquire.
  */
 export async function isLockHeld(lockPath: string): Promise<boolean> {
 	try {
 		const lockStat = await stat(lockPath);
-		return Date.now() - lockStat.mtimeMs < LOCK_TIMEOUT_MS;
+		return Date.now() - lockStat.mtimeMs < LOCK_HEARTBEAT_TIMEOUT_MS;
 		/* v8 ignore next 3 -- ENOENT: lock doesn't exist, return false */
 	} catch {
 		return false;
@@ -227,14 +237,14 @@ export async function isLockHeld(lockPath: string): Promise<boolean> {
 }
 
 /**
- * Returns true when `lockPath` exists but is older than `LOCK_TIMEOUT_MS` —
+ * Returns true when `lockPath` exists but is older than `LOCK_HEARTBEAT_TIMEOUT_MS` —
  * a crashed holder left it behind and the next acquirer will reclaim it. Used
  * by `doctor` and similar diagnostics, not the acquire path.
  */
 export async function isLockStale(lockPath: string): Promise<boolean> {
 	try {
 		const lockStat = await stat(lockPath);
-		return Date.now() - lockStat.mtimeMs >= LOCK_TIMEOUT_MS;
+		return Date.now() - lockStat.mtimeMs >= LOCK_HEARTBEAT_TIMEOUT_MS;
 		/* v8 ignore next 3 -- ENOENT: lock doesn't exist, return false */
 	} catch {
 		return false;

--- a/cli/src/core/Locks.test.ts
+++ b/cli/src/core/Locks.test.ts
@@ -35,7 +35,7 @@ import {
 	INGEST_LOCK_FILE,
 	isWorkerLockHeld,
 	isWorkerLockStale,
-	LOCK_TIMEOUT_MS,
+	LOCK_HEARTBEAT_TIMEOUT_MS,
 	ORPHAN_WRITE_LOCK_FILE,
 	PLANS_LOCK_FILE,
 	PROFILE_LOCK_FILE,
@@ -144,9 +144,9 @@ describe("Locks", () => {
 			await releaseWorkerLock(tempDir);
 		});
 
-		it("reclaims a stale lock (older than LOCK_TIMEOUT_MS) and acquires", async () => {
+		it("reclaims a stale lock (older than LOCK_HEARTBEAT_TIMEOUT_MS) and acquires", async () => {
 			expect(await acquireWorkerLock(tempDir)).toBe(true);
-			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
+			const past = new Date(Date.now() - LOCK_HEARTBEAT_TIMEOUT_MS - 60_000);
 			await utimes(workerLockPath(tempDir), past, past);
 			expect(await acquireWorkerLock(tempDir)).toBe(true);
 			await releaseWorkerLock(tempDir);
@@ -156,7 +156,7 @@ describe("Locks", () => {
 			// Simulate a crashed-without-release: write a PID that definitely
 			// doesn't exist (huge number, virtually never reused) without
 			// advancing mtime. Previously the next acquirer had to wait the
-			// full LOCK_TIMEOUT_MS; with the PID liveness check it reclaims
+			// full LOCK_HEARTBEAT_TIMEOUT_MS; with the PID liveness check it reclaims
 			// immediately.
 			const fsPromises = await import("node:fs/promises");
 			await fsPromises.writeFile(workerLockPath(tempDir), "9999999", "utf-8");
@@ -226,9 +226,9 @@ describe("Locks", () => {
 			await releaseWorkerLock(tempDir);
 		});
 
-		it("isWorkerLockStale returns true when lock is older than LOCK_TIMEOUT_MS", async () => {
+		it("isWorkerLockStale returns true when lock is older than LOCK_HEARTBEAT_TIMEOUT_MS", async () => {
 			await acquireWorkerLock(tempDir);
-			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
+			const past = new Date(Date.now() - LOCK_HEARTBEAT_TIMEOUT_MS - 60_000);
 			await utimes(workerLockPath(tempDir), past, past);
 			expect(await isWorkerLockStale(tempDir)).toBe(true);
 			await releaseWorkerLock(tempDir);
@@ -238,7 +238,7 @@ describe("Locks", () => {
 	describe("refreshWorkerLockMtime", () => {
 		it("bumps the lock's mtime so a long-lived worker is not reaped", async () => {
 			await acquireWorkerLock(tempDir);
-			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
+			const past = new Date(Date.now() - LOCK_HEARTBEAT_TIMEOUT_MS - 60_000);
 			await utimes(workerLockPath(tempDir), past, past);
 			expect(await isWorkerLockStale(tempDir)).toBe(true);
 
@@ -263,7 +263,7 @@ describe("Locks", () => {
 			const fsPromises = await import("node:fs/promises");
 			await fsPromises.mkdir(join(tempDir, ".jolli", "jollimemory"), { recursive: true });
 			await writeFile(lockPath, "999999", "utf-8");
-			const backdated = new Date(Date.now() - 2 * LOCK_TIMEOUT_MS);
+			const backdated = new Date(Date.now() - 2 * LOCK_HEARTBEAT_TIMEOUT_MS);
 			await utimes(lockPath, backdated, backdated);
 
 			await refreshWorkerLockMtime(tempDir);
@@ -326,7 +326,7 @@ describe("Locks", () => {
 
 		it("reclaims a stale orphan-write lock", async () => {
 			expect(await acquireOrphanWriteLock(tempDir)).toBe(true);
-			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
+			const past = new Date(Date.now() - LOCK_HEARTBEAT_TIMEOUT_MS - 60_000);
 			await utimes(orphanWriteLockPath(tempDir), past, past);
 			expect(await acquireOrphanWriteLock(tempDir, { timeoutMs: 100 })).toBe(true);
 			await releaseOrphanWriteLock(tempDir);
@@ -366,7 +366,7 @@ describe("Locks", () => {
 			await fsPromises.mkdir(join(tempDir, ".jolli", "jollimemory"), { recursive: true });
 			const stalePath = workerLockPath(tempDir);
 			await writeFile(stalePath, "12345", "utf-8");
-			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
+			const past = new Date(Date.now() - LOCK_HEARTBEAT_TIMEOUT_MS - 60_000);
 			await utimes(stalePath, past, past);
 
 			expect(await acquireOrphanWriteLock(tempDir)).toBe(true);
@@ -379,7 +379,7 @@ describe("Locks", () => {
 	//
 	// Stale-reclaim race the PID check guards against:
 	//   1. Process A acquires lock (mtime t0)
-	//   2. A blocks long enough that age ≥ LOCK_TIMEOUT_MS
+	//   2. A blocks long enough that age ≥ LOCK_HEARTBEAT_TIMEOUT_MS
 	//   3. Process B's tryAcquireOnce removes A's lock and writes its own PID
 	//   4. A wakes up and runs its `finally { releaseLock }` block
 	//   5. Without the PID check: A would `rm` B's lock → C arrives → no lock
@@ -808,7 +808,7 @@ describe("Locks", () => {
 			const dir = await jmDir(tempDir);
 			const lockPath = join(dir, "worker.lock");
 			await writeFile(lockPath, String(process.pid));
-			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
+			const past = new Date(Date.now() - LOCK_HEARTBEAT_TIMEOUT_MS - 60_000);
 			await utimes(lockPath, past, past);
 			expect(await getWorkerBusyState(tempDir)).toEqual({ held: false, blocking: false });
 		});
@@ -842,7 +842,7 @@ describe("Locks", () => {
 			const lockPath = ingestLockPath(tempDir);
 			await mkdir(join(tempDir, ".jolli", "jollimemory"), { recursive: true });
 			await writeFile(lockPath, "999999");
-			const past = new Date(Date.now() - LOCK_TIMEOUT_MS - 60_000);
+			const past = new Date(Date.now() - LOCK_HEARTBEAT_TIMEOUT_MS - 60_000);
 			await utimes(lockPath, past, past);
 			expect(await acquireIngestLock(tempDir)).toBe(true);
 			expect((await readFile(lockPath, "utf-8")).trim()).toBe(String(process.pid));
@@ -868,7 +868,7 @@ describe("Locks", () => {
 			await utimes(lockPath, past, past);
 			await refreshIngestLockMtime(tempDir);
 			const fresh = await stat(lockPath);
-			expect(Date.now() - fresh.mtimeMs).toBeLessThan(LOCK_TIMEOUT_MS);
+			expect(Date.now() - fresh.mtimeMs).toBeLessThan(LOCK_HEARTBEAT_TIMEOUT_MS);
 		});
 	});
 });

--- a/cli/src/core/Locks.ts
+++ b/cli/src/core/Locks.ts
@@ -33,7 +33,7 @@
  * compare its PID against `process.pid` before removing. Without the check, a
  * stale-reclaim race could let process A delete process B's freshly-acquired
  * lock and re-open the concurrent-write window:
- *   1. A holds lock, lock becomes stale (≥ `LOCK_TIMEOUT_MS`)
+ *   1. A holds lock, lock becomes stale (≥ `LOCK_HEARTBEAT_TIMEOUT_MS`)
  *   2. B's `tryAcquireOnce` removes A's lock and writes its own PID
  *   3. A's finally block runs `releaseLock` — without the PID check, A would rm B's lock
  *   4. C now sees no lock and acquires concurrently with B → corrupt writes
@@ -51,7 +51,7 @@
  * boundary tick inside a 60 s refresh cycle — vanishingly unlikely.
  *
  * **Why PID, not a UUID token.** PID-reuse collision inside one lock lifetime
- * would require: OS restart within `LOCK_TIMEOUT_MS` AND the lock file
+ * would require: OS restart within `LOCK_HEARTBEAT_TIMEOUT_MS` AND the lock file
  * surviving the restart AND the new PID matching the dead holder's exact
  * value AND that recycled-PID process happening to acquire the same lock. We
  * accept this as an intentional simplification — a token file would close it
@@ -67,7 +67,7 @@ import * as Subprocess from "../util/Subprocess.js";
 import {
 	acquireWithPoll,
 	isLockStale,
-	LOCK_TIMEOUT_MS,
+	LOCK_HEARTBEAT_TIMEOUT_MS,
 	refreshLockMtime,
 	releaseIfOwned,
 	tryAcquireOnce,
@@ -75,7 +75,7 @@ import {
 
 // Re-export so existing callers (Locks.test.ts, QueueWorker.ts, etc.) that
 // imported it from this module keep compiling.
-export { LOCK_TIMEOUT_MS };
+export { LOCK_HEARTBEAT_TIMEOUT_MS };
 
 const log = createLogger("Locks");
 
@@ -97,7 +97,7 @@ export const WORKER_LOCK_FILE = "worker.lock";
  * generation: summary drain keeps `worker.lock`, ingest runs concurrently
  * under `ingest.lock`. Lives next to `worker.lock` at
  * `<cwd>/.jolli/jollimemory/ingest.lock`. Heartbeated the same way (an ingest
- * can outlast `LOCK_TIMEOUT_MS`, so its mtime must be bumped to avoid a
+ * can outlast `LOCK_HEARTBEAT_TIMEOUT_MS`, so its mtime must be bumped to avoid a
  * stale-reclaim by the next worker).
  */
 export const INGEST_LOCK_FILE = "ingest.lock";
@@ -269,7 +269,7 @@ export async function releaseWorkerLock(cwd?: string): Promise<void> {
 }
 
 /**
- * Returns true when `worker.lock` exists and is younger than `LOCK_TIMEOUT_MS`.
+ * Returns true when `worker.lock` exists and is younger than `LOCK_HEARTBEAT_TIMEOUT_MS`.
  * Used by PostRewriteHook and PostCommitHook to decide whether a worker is
  * already running. The check intentionally ignores `orphan-write.lock` so a
  * brief background writer (scanTreeHashAliases, getCatalogWithLazyBuild) does
@@ -280,14 +280,14 @@ export async function isWorkerLockHeld(cwd?: string): Promise<boolean> {
 	const lockPath = join(dir, WORKER_LOCK_FILE);
 	try {
 		const lockStat = await stat(lockPath);
-		return Date.now() - lockStat.mtimeMs < LOCK_TIMEOUT_MS;
+		return Date.now() - lockStat.mtimeMs < LOCK_HEARTBEAT_TIMEOUT_MS;
 	} catch {
 		return false;
 	}
 }
 
 /**
- * Returns true when `worker.lock` exists but is older than `LOCK_TIMEOUT_MS`.
+ * Returns true when `worker.lock` exists but is older than `LOCK_HEARTBEAT_TIMEOUT_MS`.
  * Used by `doctor` to detect a crashed worker that left its lock behind.
  */
 export async function isWorkerLockStale(cwd?: string): Promise<boolean> {
@@ -310,7 +310,7 @@ export async function getWorkerBusyState(cwd?: string): Promise<{ held: boolean;
 
 /**
  * Bumps the mtime on `worker.lock` so a long-running worker (e.g. an LLM call
- * that exceeds `LOCK_TIMEOUT_MS`) cannot be stolen by the stale-lock reclaimer.
+ * that exceeds `LOCK_HEARTBEAT_TIMEOUT_MS`) cannot be stolen by the stale-lock reclaimer.
  * The worker calls this on a periodic timer for the duration of its run.
  *
  * Skips the bump when the lock is owned by a different PID — refreshing

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -78,7 +78,12 @@ vi.mock("../core/ContextRelevance.js", async (importOriginal) => {
 		// throws, the relevance try-block skips assessContextRelevance entirely. Stub it
 		// so assess actually runs. computeChangeFingerprint / buildDecisionFromAiExcluded
 		// keep their real implementations.
-		buildChangeSignal: vi.fn(async () => ({ commitMessage: "", changedFiles: ["src/file.ts"], symbols: [] })),
+		buildChangeSignal: vi.fn(async () => ({
+			commitMessage: "",
+			changedFiles: ["src/file.ts"],
+			symbols: [],
+			diff: "",
+		})),
 		assessContextRelevance: vi.fn(async (raw: Parameters<typeof actual.assessContextRelevance>[0]) => ({
 			plans: raw.plans,
 			notes: raw.notes,
@@ -3527,7 +3532,7 @@ describe("QueueWorker", () => {
 				.mockResolvedValueOnce([])
 				.mockResolvedValueOnce([]);
 			setupPipelineMocks();
-			const signal = { commitMessage: "", changedFiles: ["src/file.ts"], symbols: [] as string[] };
+			const signal = { commitMessage: "", changedFiles: ["src/file.ts"], symbols: [] as string[], diff: "" };
 			vi.mocked(buildChangeSignal).mockResolvedValueOnce(signal);
 			// Persisted fingerprint matches this change → executePipeline takes the
 			// buildDecisionFromAiExcluded reuse arm and skips assessContextRelevance.
@@ -4872,7 +4877,7 @@ describe("QueueWorker", () => {
 				.mockResolvedValueOnce([])
 				.mockResolvedValueOnce([]);
 			setupPipelineMocks();
-			const signal = { commitMessage: "", changedFiles: ["src/file.ts"], symbols: [] as string[] };
+			const signal = { commitMessage: "", changedFiles: ["src/file.ts"], symbols: [] as string[], diff: "" };
 			vi.mocked(buildChangeSignal).mockResolvedValueOnce(signal);
 			// Matching fingerprint → the reuse arm runs (no LLM). This suite's
 			// default mocks detect no plans/notes/refs, so the meaningful assertion
@@ -4912,7 +4917,7 @@ describe("QueueWorker", () => {
 					commitHash: null,
 				} as never,
 			]);
-			const signal = { commitMessage: "", changedFiles: ["src/file.ts"], symbols: [] as string[] };
+			const signal = { commitMessage: "", changedFiles: ["src/file.ts"], symbols: [] as string[], diff: "" };
 			vi.mocked(buildChangeSignal).mockResolvedValueOnce(signal);
 			vi.mocked(readAiSelection).mockResolvedValueOnce({
 				aiRelevance: [

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -194,7 +194,7 @@ const RETRY_DELAY_MS = 2000;
 
 /**
  * How often to bump the worker.lock's mtime while the worker is running.
- * Comfortably below `LOCK_TIMEOUT_MS` (5 min) so even a missed tick keeps
+ * Comfortably below `LOCK_HEARTBEAT_TIMEOUT_MS` (5 min) so even a missed tick keeps
  * the lock alive against the stale-lock reclaimer.
  */
 const WORKER_LOCK_REFRESH_INTERVAL_MS = 60_000;
@@ -462,7 +462,7 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 
 	// Periodically bump vault-write.lock's mtime so a long-running LLM call
 	// (rare, but possible when an upstream is slow) cannot be reaped by the
-	// stale-lock reclaimer at LOCK_TIMEOUT_MS. Same refresh cadence as
+	// stale-lock reclaimer at LOCK_HEARTBEAT_TIMEOUT_MS. Same refresh cadence as
 	// worker.lock's timer further below.
 	/* v8 ignore start -- setInterval's lambda only fires on a real timer tick; unit tests finish in milliseconds and never observe the callback. */
 	const vaultRefreshTimer = setInterval(() => {

--- a/cli/src/sync/SyncEngine.test.ts
+++ b/cli/src/sync/SyncEngine.test.ts
@@ -775,7 +775,7 @@ describe("SyncEngine.runRound — onRoundComplete (P2 #1 chain-spawn hook)", () 
 describe("SyncEngine.runRound — vault-write.lock refresh during long pullRebase", () => {
 	it("refreshes `vault-write.lock` mtime while `withPullLock` holds it across a long resolver", async () => {
 		// Regression guard: a Tier-2-heavy or Tier-3-prompt conflict round
-		// can exceed `LOCK_TIMEOUT_MS` (5 min). Without an in-flight refresh
+		// can exceed `LOCK_HEARTBEAT_TIMEOUT_MS` (5 min). Without an in-flight refresh
 		// the lock's mtime falls behind and a peer `acquireWithPoll` would
 		// reclaim it — reopening R9. The refresher inside `withPullLock`
 		// must drive `lock.refresh()` on the configured interval so the

--- a/cli/src/sync/SyncEngine.ts
+++ b/cli/src/sync/SyncEngine.ts
@@ -714,7 +714,7 @@ export class SyncEngine {
 		// Refresh `vault-write.lock`'s mtime while `fn` runs. The lock can be
 		// held across `ConflictResolver.resolveAll`, which may invoke N Tier 2
 		// AI merges (~30 s each) and/or open-ended Tier 3 user prompts. If the
-		// total exceeds `LOCK_TIMEOUT_MS` (5 min), a peer `acquireWithPoll`
+		// total exceeds `LOCK_HEARTBEAT_TIMEOUT_MS` (5 min), a peer `acquireWithPoll`
 		// would mtime-reclaim the lock and a concurrent QueueWorker write could
 		// land in the paused-rebase window — exactly the R9 race this lock was
 		// added to close. The 60 s interval matches the `sync.lock` refresher

--- a/cli/src/sync/SyncLock.test.ts
+++ b/cli/src/sync/SyncLock.test.ts
@@ -229,7 +229,7 @@ describe("SyncLock", () => {
 			const lockPath = getSyncLockPath();
 			await mkdir(join(tempDir, ".jolli", "jollimemory"), { recursive: true });
 			await writeFile(lockPath, String(process.pid));
-			// Backdate beyond LOCK_TIMEOUT_MS (5 min). Use 6 min to be safe.
+			// Backdate beyond LOCK_HEARTBEAT_TIMEOUT_MS (5 min). Use 6 min to be safe.
 			const sixMinAgo = new Date(Date.now() - 6 * 60 * 1000);
 			await utimes(lockPath, sixMinAgo, sixMinAgo);
 

--- a/cli/src/sync/SyncLock.ts
+++ b/cli/src/sync/SyncLock.ts
@@ -96,7 +96,7 @@ export async function refreshSyncLockMtime(): Promise<void> {
 }
 
 /**
- * Returns true when `sync.lock` exists and is younger than `LOCK_TIMEOUT_MS`.
+ * Returns true when `sync.lock` exists and is younger than `LOCK_HEARTBEAT_TIMEOUT_MS`.
  * Used by the VS Code status orchestrator to detect "another round is in
  * flight" without trying to acquire (avoids creating contention for a quick
  * status probe).

--- a/cli/src/sync/VaultWriteLock.test.ts
+++ b/cli/src/sync/VaultWriteLock.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { LOCK_TIMEOUT_MS } from "../core/LockPrimitives.js";
+import { LOCK_HEARTBEAT_TIMEOUT_MS } from "../core/LockPrimitives.js";
 import { consumePendingWorkers, recordPendingWorker } from "./PendingWorkers.js";
 import { getVaultWriteLockPath } from "./VaultLockPath.js";
 import { acquireVaultWriteLock, isVaultWriteLockHeld, withVaultWriteLock } from "./VaultWriteLock.js";
@@ -289,12 +289,12 @@ describe("acquireVaultWriteLock", () => {
 			}
 		});
 
-		it("LOCK_TIMEOUT_MS (5 min) is what the mtime-refresh story assumes", () => {
+		it("LOCK_HEARTBEAT_TIMEOUT_MS (5 min) is what the mtime-refresh story assumes", () => {
 			// Not a behavioural test — just pins the constant so a future
 			// refactor of LockPrimitives that changes the threshold doesn't
 			// silently invalidate the refresh-interval choice in SyncEngine
 			// and QueueWorker (both bump every ~60s).
-			expect(LOCK_TIMEOUT_MS).toBe(5 * 60 * 1000);
+			expect(LOCK_HEARTBEAT_TIMEOUT_MS).toBe(5 * 60 * 1000);
 		});
 	});
 });

--- a/cli/src/sync/VaultWriteLock.ts
+++ b/cli/src/sync/VaultWriteLock.ts
@@ -162,7 +162,7 @@ export type VaultWriteLockMode = "fail-fast" | { readonly wait: number };
  * Returns a handle with `release()` / `refresh()` methods on success, or
  * `null` on miss (fail-fast) / timeout (wait-mode). The handle MUST be
  * released on every exit path — caller's `try/finally` is the load-bearing
- * cleanup hook. Failure to release leaks the lock for up to `LOCK_TIMEOUT_MS`
+ * cleanup hook. Failure to release leaks the lock for up to `LOCK_HEARTBEAT_TIMEOUT_MS`
  * (5 min) before the next acquirer reclaims it.
  *
  * The handle interface mirrors a Disposable / Resource pattern so callers
@@ -288,7 +288,7 @@ export async function withVaultWriteLock<T>(
 
 /**
  * Returns true when `vault-write.lock` exists and is younger than
- * `LOCK_TIMEOUT_MS`. Diagnostic-only — callers that want to act on the
+ * `LOCK_HEARTBEAT_TIMEOUT_MS`. Diagnostic-only — callers that want to act on the
  * outcome should `acquireVaultWriteLock` instead, since this read is
  * inherently racy (lock can be released between the check and any
  * follow-up action).

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -943,8 +943,13 @@ export class JolliMemoryBridge {
 	 * them, so the title preview must see their content. `git ls-files --others`
 	 * finds the untracked subset of the selection; each is diffed against
 	 * `/dev/null`. Entirely read-only — the index is never touched.
+	 *
+	 * Public because the Next Memory preview panel also feeds this working-tree
+	 * diff into the context-relevance ranker (the strongest relevance signal), so
+	 * the panel's cached ranking — which the post-commit worker reuses on a
+	 * fingerprint hit — is judged against the same diff the worker would use.
 	 */
-	private async diffForSelection(paths: Array<string>): Promise<string> {
+	async diffForSelection(paths: ReadonlyArray<string>): Promise<string> {
 		const [tracked, untrackedRaw] = await Promise.all([
 			tryExecGit(["-c", "core.quotepath=false", "diff", "HEAD", "--", ...paths], this.cwd),
 			tryExecGit(["-c", "core.quotepath=false", "ls-files", "--others", "--exclude-standard", "--", ...paths], this.cwd),

--- a/vscode/src/util/LockUtils.ts
+++ b/vscode/src/util/LockUtils.ts
@@ -24,13 +24,13 @@ import { readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 
 /**
- * Lock timeout matches `LOCK_TIMEOUT_MS` in cli/src/core/Locks.ts (5 minutes).
+ * Lock timeout matches `LOCK_HEARTBEAT_TIMEOUT_MS` in cli/src/core/Locks.ts (5 minutes).
  * Doubles as the freshness window for the cosmetic `ingest-phase` file: the
  * worker heartbeats both `ingest.lock` and the `ingest-phase` file every 60 s
  * (WORKER_LOCK_REFRESH_INTERVAL_MS in QueueWorker), so the same 5× margin
  * applies to all three files.
  */
-const LOCK_TIMEOUT_MS = 5 * 60 * 1000;
+const LOCK_HEARTBEAT_TIMEOUT_MS = 5 * 60 * 1000;
 
 function jolliMemoryFile(cwd: string, name: string): string {
 	return join(cwd, ".jolli", "jollimemory", name);
@@ -39,7 +39,7 @@ function jolliMemoryFile(cwd: string, name: string): string {
 async function isFileFresh(path: string): Promise<boolean> {
 	try {
 		const st = await stat(path);
-		return Date.now() - st.mtimeMs < LOCK_TIMEOUT_MS;
+		return Date.now() - st.mtimeMs < LOCK_HEARTBEAT_TIMEOUT_MS;
 	} catch {
 		return false;
 	}

--- a/vscode/src/views/NextMemoryPreviewPanel.test.ts
+++ b/vscode/src/views/NextMemoryPreviewPanel.test.ts
@@ -41,6 +41,10 @@ const { assessMock, detectPlansMock, writeAiMock } = vi.hoisted(() => ({
 vi.mock("../../../cli/src/core/ContextRelevance.js", () => ({
 	assessContextRelevance: assessMock,
 	computeChangeFingerprint: () => "fp",
+	// Identity so a folded diff passes through unchanged in tests. Without this the
+	// panel's `import { capDiffForRelevance }` resolves to undefined and the whole
+	// diff-fold block silently runs in its catch (vacuous test).
+	capDiffForRelevance: (d: string) => d,
 }));
 vi.mock("../../../cli/src/core/SessionTracker.js", () => ({
 	loadConfig: vi.fn().mockResolvedValue({}),
@@ -77,6 +81,9 @@ function makeBridge(overrides: Record<string, unknown> = {}) {
 	return {
 		generateCommitMessageForFiles: vi.fn().mockResolvedValue("feat: example"),
 		getCurrentBranch: vi.fn().mockResolvedValue("feature/demo"),
+		// Working-tree diff fed to the relevance ranker. Empty by default (so existing
+		// tests are unaffected); the diff-fold test overrides it with real content.
+		diffForSelection: vi.fn().mockResolvedValue(""),
 		...overrides,
 	};
 }
@@ -463,6 +470,26 @@ describe("NextMemoryPreviewPanel — context relevance overlay", () => {
 		expect(sidebar.pushContextRelevanceToSidebar).toHaveBeenCalledWith([
 			expect.objectContaining({ id: "p1", autoExclude: true }),
 		]);
+	});
+
+	it("folds the working-tree diff into the ranker signal on a cache miss", async () => {
+		postMessage.mockClear();
+		assessMock.mockClear(); // this suite has no per-test mock reset — clear so calls[0] is ours
+		detectPlansMock.mockResolvedValue([{ slug: "diffFoldPlan", title: "P" }]);
+		assessMock.mockResolvedValue({ plans: [], notes: [], references: [], excludedContext: [], results: [] });
+		const bridge = makeBridge({ diffForSelection: vi.fn().mockResolvedValue("+const sentinel = 1;") });
+		const sidebar = makeSidebarProvider({
+			getFilesSnapshot: vi.fn().mockReturnValue([{ id: "f1", description: "src/a.ts", isSelected: true }]),
+		});
+		await openAndReady(bridge, sidebar);
+		// Wait on the specific call we're testing (not the shared assessMock, which can
+		// be stale from a prior test).
+		await vi.waitFor(() => expect(bridge.diffForSelection).toHaveBeenCalled());
+		// The working-tree diff was fetched for exactly the selected paths...
+		expect(bridge.diffForSelection).toHaveBeenCalledWith(["src/a.ts"]);
+		// ...and folded into the changeSignal (2nd arg) handed to the ranker — without
+		// this the whole diff-informed ranking is dead in the panel path.
+		expect(assessMock.mock.calls[0][1]).toMatchObject({ diff: "+const sentinel = 1;" });
 	});
 
 	it("does not persist fabricated empty-reason verdicts (fail-open keepAll)", async () => {

--- a/vscode/src/views/NextMemoryPreviewPanel.ts
+++ b/vscode/src/views/NextMemoryPreviewPanel.ts
@@ -2,7 +2,7 @@ import { randomBytes } from "node:crypto";
 import * as vscode from "vscode";
 import type { ActiveConversationItem } from "../../../cli/src/core/ActiveSessionAggregator.js";
 import { sumConversationTokens } from "../../../cli/src/core/ConversationTokenTotals.js";
-import { assessContextRelevance, computeChangeFingerprint } from "../../../cli/src/core/ContextRelevance.js";
+import { assessContextRelevance, capDiffForRelevance, computeChangeFingerprint } from "../../../cli/src/core/ContextRelevance.js";
 import { type AiRelevanceEntry, readExclusions, writeAiSelection } from "../../../cli/src/core/CommitSelectionStore.js";
 import { getWorkingTreeDiffStats } from "../../../cli/src/core/GitOps.js";
 import {
@@ -18,6 +18,9 @@ import type { SerializedTreeItem } from "./SidebarMessages.js";
 interface Bridge {
 	generateCommitMessageForFiles(relativePaths: ReadonlyArray<string>): Promise<string>;
 	getCurrentBranch(): Promise<string>;
+	/** Working-tree diff (staged + unstaged + untracked) for the selected paths —
+	 *  fed to the relevance ranker so the panel's cached decision is diff-informed. */
+	diffForSelection(relativePaths: ReadonlyArray<string>): Promise<string>;
 }
 
 interface SidebarBroadcastHost {
@@ -431,7 +434,10 @@ export class NextMemoryPreviewPanel {
 				notes: notes.filter((n) => !exclusions.notes.has(n.id)),
 				references: refs.filter((e) => !exclusions.references.has(`${e.source}:${e.nativeId}`)),
 			};
-			const changeSignal = { commitMessage: "", changedFiles, symbols: [] };
+			// The fingerprint is keyed only on changedFiles (see computeChangeFingerprint),
+			// so the diff is left empty here — it is fetched below, only on a cache MISS,
+			// and folded into the signal passed to the ranker.
+			const changeSignal = { commitMessage: "", changedFiles, symbols: [], diff: "" };
 			const fingerprint = computeChangeFingerprint(changeSignal);
 			// Cache key = file fingerprint + candidate item set. Reopening the panel or
 			// switching editor tabs re-invokes this; when both are unchanged, reuse the
@@ -459,10 +465,22 @@ export class NextMemoryPreviewPanel {
 			// A newer refresh started while we read the registry — let it own the
 			// ranking; don't fire a redundant LLM call or post a stale overlay.
 			if (isStale()) return;
+			// Fetch the working-tree diff ONLY now (cache missed), so cache hits above
+			// never pay for it. Best-effort: a diff failure just yields a diff-less
+			// signal (the ranker still has files + symbols). Re-check staleness after
+			// this extra async hop before firing the LLM call.
+			let diffForRanker = "";
+			try {
+				diffForRanker = capDiffForRelevance(await bridge.diffForSelection(changedFiles));
+			} catch {
+				// diff is best-effort; fall through with an empty diff.
+			}
+			if (isStale()) return;
 			void webview.postMessage({ type: "context:analyzing", analyzing: true });
-			const decision = await assessContextRelevance(raw, changeSignal, config);
-			// Superseded during the (up-to-45s) LLM call → discard, so this stale file
-			// set's ranking can't clobber the newer result's cache/overlay/fingerprint.
+			const decision = await assessContextRelevance(raw, { ...changeSignal, diff: diffForRanker }, config);
+			// Superseded during the (multi-second, provider-dependent) LLM call → discard,
+			// so this stale file set's ranking can't clobber the newer result's
+			// cache/overlay/fingerprint.
 			if (isStale()) return;
 			// Persist EVERY item's full verdict (tier + reason + the AI's exclude
 			// decision) as ONE list: the post-commit worker's fingerprint-reuse path


### PR DESCRIPTION
<!-- jollimemory-summary-start -->


## Quick recap

The context relevance filter — which decides which knowledge-base articles attach to a commit's memory and appear in PR descriptions — was substantially strengthened. Previously the filter judged relevance using only the commit message, changed file names, and a list of newly declared symbol names. The actual content of the change was never considered, leaving the model with almost no basis to reject articles about unrelated topics. The commit now feeds the head of the change's diff directly into the ranking prompt, giving the model concrete evidence of what the change did. Articles about unrelated systems are now far more likely to be correctly identified and excluded.

A correctness bug introduced alongside the new pre-sorting step was caught during review and fixed before landing. When the candidate list was too large to rank in a single call, items dropped from the prompt could silently inherit the verdict of a different item that happened to occupy the same numbered slot in the original ordering. The fix ensures dropped items are always kept with a neutral verdict rather than being incorrectly excluded based on another item's judgment.

The local-agent provider, used by subscribers running a local coding assistant, previously received no relevance filtering at all — every article was unconditionally attached to every commit. This was traced to a misunderstanding about how long a ranking call takes for that provider: the concern was based on worst-case summary generation times, not the much smaller ranking prompt. The skip was removed and the local-agent provider now goes through the same ranking path as all others, with a slightly longer timeout to accommodate process startup time.

---

## Topics (5)
<details>
<summary><strong>01 · Add diff body to context relevance ranking signal</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The relevance filter that decides which knowledge-base articles attach to a commit was making decisions with almost no information about what the commit actually changed. File names and declared symbol names were the only signals, so the filter frequently kept unrelated articles because it had no basis to reject them.

**💡 Decisions Behind the Code**

- **Diff over symbols alone**: The diff body was already being read to extract symbol names and then thrown away. Retaining it and capping it to a modest budget (20K characters, well below the model window) was the highest-leverage change available: it gives the model direct evidence of what the commit did rather than just a list of declared names. The threshold was chosen to sit between the commit-message diff budget (12K) and the full summary diff cap (150K), large enough to characterize the change without dominating the prompt.
- **Keep the threshold unchanged (only exclude "low")**: The existing policy of keeping anything the model does not explicitly mark as unrelated was deliberately preserved. The goal was to give the model better evidence so it correctly judges borderline articles as unrelated, not to lower the bar for exclusion and risk dropping genuinely relevant context. A more aggressive threshold would trade false negatives for false positives in the wrong direction.
- **Overflow drops least-affinity tail**: A new pre-sort by change-affinity (how many changed file names and symbol names appear in an article) was added before the budget is applied. This ensures that when the candidate list is too large to fit, the items most likely to be irrelevant are the ones dropped rather than an arbitrary registry-order tail. Dropped items are still conservatively kept unranked rather than excluded.

**✅ What Was Implemented**

- `ContextRelevance.ts` was extended so `ChangeSignal` now carries a `diff` field. `buildChangeSignal` already read the full diff to extract symbol names and then discarded it; it now retains the head of that diff (capped at 20,000 characters via the new `capDiffForRelevance` helper) and includes it in the signal sent to the ranking call. `buildChangeBlock` renders the diff body into the prompt under a "Diff (may be truncated)" heading.
- The pre-commit preview panel in `NextMemoryPreviewPanel.ts` was updated to fetch the working-tree diff via `bridge.diffForSelection` on a cache miss and fold it into the ranking signal, keeping the panel's cached decision consistent with what the post-commit worker would compute. `JolliMemoryBridge.diffForSelection` was made public to support this.
- Supporting budget constants were raised: the context-items character budget went from 120K to 160K characters, and the ranking output token limit went from 4,096 to 8,192 tokens, reducing the chance that items are silently kept unranked due to overflow.

**📋 Future Enhancements**

- The change fingerprint used for panel-to-worker reuse is keyed only on the changed file set, not the diff content. If a user edits the same files to cover a new topic and commits without reopening the panel, the worker may reuse a stale diff-based decision. The robust fix (incorporating a diff hash into the fingerprint, or having the worker re-verify the diff) was deferred because the panel diff and the worker diff are not guaranteed to be byte-identical for the same content, which could defeat reuse entirely.
- The "zombie plan" cleanup (skipping registry entries whose backing file no longer exists) was deferred. These entries are fed to the ranker on every commit but can never be archived. The fix was scoped out because injecting a filesystem check into the pure registry-query functions would require significant test changes disproportionate to the low harm of the issue.

**📁 FILES**
- `cli/src/core/ContextRelevance.ts`
- `vscode/src/views/NextMemoryPreviewPanel.ts`
- `vscode/src/JolliMemoryBridge.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Make context relevance ranking uniform across all provider types</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users running the local subscription version of the coding assistant received no relevance filtering at all — every knowledge-base article was unconditionally attached to every commit. The filtering was skipped entirely for this provider type, meaning those users always got the worst-case behavior the feature was designed to prevent.

**💡 Decisions Behind the Code**

- **Remove the provider-specific skip entirely**: The original skip was motivated by the concern that a local agent process takes minutes per call and would hold the post-commit queue lock too long. Investigation showed this reasoning was based on the worst-case summary generation time, not the much smaller relevance ranking prompt. The correct fix was to give the local-agent provider its own, longer timeout rather than bypass ranking altogether. The queue lock is heartbeated independently on a timer, so a longer ranking call does not risk the lock being reclaimed.
- **Separate timeouts rather than a single shared value**: API providers benefit from a tighter ceiling (faster failure, shorter queue delays) while the local-agent provider needs headroom for process startup. Encoding this as a per-provider lookup keeps the logic explicit and avoids the previous situation where a single conservative value was used as justification for skipping the call entirely.

**✅ What Was Implemented**

- The blanket early-return that skipped ranking for the local-agent provider was removed from `ContextRelevance.ts`. All three provider types now go through the same control flow: fingerprint hit reuses the panel result, fingerprint miss computes a fresh ranking.
- A new `rankTimeoutForProvider` function was added to give each provider an appropriate wall-clock ceiling: 120 seconds for API-based providers (up from 45 seconds, reflecting the larger input now that a diff is included) and 180 seconds for the local-agent provider (to absorb cold-start variance without killing a call that is about to succeed).

**📁 FILES**
- `cli/src/core/ContextRelevance.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Fix incorrect verdict assignment when candidate list overflows ranking budget</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A review of the newly implemented affinity-based pre-sorting revealed a correctness bug: when the candidate list was too large to fit in the ranking prompt, items that were dropped from the prompt could inherit the verdict of a different item that happened to share the same position number in the original list order.

**💡 Decisions Behind the Code**

The conservative keep-as-neutral approach for dropped items was chosen over alternatives such as excluding them or re-ranking in a second pass. Dropped items were never evaluated by the model, so assigning any definitive verdict would be fabricating a judgment. Keeping them neutral preserves the existing fail-safe behavior (unranked items are never excluded) while the affinity pre-sort ensures the dropped tail is the least likely to be relevant.

**✅ What Was Implemented**

The merge-back logic in `rankContextRelevance` was corrected so that any item absent from the ranked block is unconditionally kept with a neutral "mid" verdict rather than falling back to a position-based index lookup. The old fallback used the item's original list position as a block index, which was safe before affinity sorting was introduced but became incorrect once the sort could place a different item at that position. A regression test was added that forces a budget overflow with a known affinity ordering and asserts that the dropped item receives a neutral verdict rather than inheriting the ranked item's result.

**📁 FILES**
- `cli/src/core/ContextRelevance.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Rename worker lock constant to reflect its actual meaning</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The constant controlling when a stale worker lock can be reclaimed was named in a way that implied it was a cap on how long the lock could be held. This caused confusion: developers reading the code assumed long-running operations would trip the timeout, when in fact a live worker heartbeats the lock continuously and can hold it indefinitely.

**💡 Decisions Behind the Code**

The rename was chosen over leaving the name unchanged because the misleading name was actively cited as justification for the local-agent ranking skip (the reasoning "a long call would exceed the lock timeout" was incorrect precisely because of this naming confusion). Correcting the name removes a recurring source of incorrect reasoning about lock safety without changing any behavior.

**✅ What Was Implemented**

`LOCK_TIMEOUT_MS` was renamed to `LOCK_HEARTBEAT_TIMEOUT_MS` across `LockPrimitives.ts`, `Locks.ts`, `LockUtils.ts` (VS Code), and all test files that referenced it. The constant's documentation was expanded to explain that it is a heartbeat-lapse threshold — a lock is only reclaimable when its last heartbeat is older than this value, which only happens when the owning process has died. The rename was applied with a word-boundary constraint to avoid touching sibling constants that share a suffix.

**📁 FILES**
- `cli/src/core/LockPrimitives.ts`
- `cli/src/core/Locks.ts`
- `vscode/src/util/LockUtils.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Fix spurious storage warning when generating PR descriptions from the command line</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Running the PR description generator from the command line produced a warning on every run indicating that the storage backend had not been configured. The warning was harmless for most users but caused confusion and, for users with folder-mode storage, meant writes were not going to the correct location.

**💡 Decisions Behind the Code**

The fix was kept intentionally narrow — only the CLI command path was missing this initialization step; the MCP server path already called it correctly. The warning was confirmed to be a logging and write-consistency issue rather than a cause of the unrelated-articles bug, so it was addressed as a standalone cleanup rather than part of the main relevance fix.

**✅ What Was Implemented**

`PrDescriptionCommand.ts` was updated to initialize the active storage backend before invoking the PR description builder, mirroring the pattern already used by the recall and search commands. This eliminates the fallback warning and ensures folder-mode users see consistent write behavior.

**📁 FILES**
- `cli/src/commands/PrDescriptionCommand.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · July 30, 2026 at 5:05 PM · via Anthropic*
<!-- jollimemory-summary-end -->