### PR TITLE
Consume working-area Context on the squash paths

### DIFF
--- a/cli/src/core/JolliMemoryPushOrchestrator.ts
+++ b/cli/src/core/JolliMemoryPushOrchestrator.ts
@@ -31,6 +31,7 @@ import { loadBranchSummaries } from "./PrDescription.js";
 import { isOutboundPushAllowed, PushDisabledError } from "./PushControl.js";
 import { loadPushPending } from "./PushPendingStore.js";
 import { isRepoWideRefusal } from "./PushRefusal.js";
+import { REF_HASH_SUFFIX } from "./RefMerge.js";
 import { readReferenceMarkdownFromString } from "./references/ReferenceStore.js";
 import { clearSpaceBindingCache, saveSpaceBindingCache } from "./SpaceBindingCache.js";
 import type { StorageProvider } from "./StorageProvider.js";
@@ -169,9 +170,13 @@ export function applyReferenceUrls(
  * Strips a trailing archived commit-hash suffix (`-<8 hex>`) to get the base
  * name. Committed snapshots (`refactor-auth-a1b2c3d4`) and an uncommitted base
  * (`refactor-auth`) collapse to the same key.
+ *
+ * Shares `REF_HASH_SUFFIX` with RefMerge's `baseKeyOf.plan` rather than re-spelling
+ * the pattern: this is the same base key the amend hoist dedupes by, and a drift
+ * between the two would have the push path group snapshots the summary kept apart.
  */
 export function planBaseKey(slug: string): string {
-	return slug.replace(/-[0-9a-f]{8}$/, "");
+	return slug.replace(REF_HASH_SUFFIX, "");
 }
 
 /**

--- a/cli/src/core/RefMerge.test.ts
+++ b/cli/src/core/RefMerge.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type { NoteReference, PlanReference, ReferenceCommitRef } from "../Types.js";
+import { baseKeyOf, mergeRefsNewWins, snapshotKeyOf } from "./RefMerge.js";
+
+// Moved here from QueueWorker.test.ts when mergeRefsNewWins was hoisted out of
+// QueueWorker: both hoisted roots (amend's buildHoistedAmendRoot and squash's
+// mergeManyToOne) union their newly-associated refs through it — but with
+// DIFFERENT dedupe keys. The key-family tests below are the contract that keeps
+// those two apart; using one path's family on the other strands orphan-branch
+// files (a snapshot with no summary pointing at it).
+describe("mergeRefsNewWins", () => {
+	const bySlug = (r: { slug: string }) => r.slug;
+
+	it("returns [] for empty / undefined inputs", () => {
+		expect(mergeRefsNewWins(undefined, undefined, bySlug)).toEqual([]);
+		expect(mergeRefsNewWins([], [], bySlug)).toEqual([]);
+	});
+
+	it("keeps old refs when there are no new refs", () => {
+		const old = [{ slug: "a" }, { slug: "b" }];
+		expect(mergeRefsNewWins(old, undefined, bySlug)).toEqual(old);
+	});
+
+	it("unions non-colliding new refs after the old ones", () => {
+		const merged = mergeRefsNewWins([{ slug: "a" }], [{ slug: "b" }], bySlug);
+		expect(merged.map(bySlug)).toEqual(["a", "b"]);
+	});
+
+	it("new ref wins on key collision (drops the stale old snapshot)", () => {
+		const merged = mergeRefsNewWins([{ slug: "a", tag: "old" }], [{ slug: "a", tag: "new" }], bySlug);
+		expect(merged).toEqual([{ slug: "a", tag: "new" }]);
+	});
+
+	it("keeps the OLD ref's position when a new ref replaces it", () => {
+		// Map.set on an existing key updates in place, so a replaced ref does not
+		// jump to the end — display order stays stable across an amend.
+		const merged = mergeRefsNewWins(
+			[{ slug: "a", tag: "old" }, { slug: "b" }],
+			[{ slug: "a", tag: "new" }],
+			bySlug,
+		);
+		expect(merged.map(bySlug)).toEqual(["a", "b"]);
+	});
+});
+
+const AT = "2026-04-01T00:00:00.000Z";
+const plan = (slug: string): PlanReference => ({ slug, title: "T", addedAt: AT, updatedAt: AT });
+const note = (id: string): NoteReference => ({ id, title: "T", format: "markdown", addedAt: AT, updatedAt: AT });
+const reference = (hash: string): ReferenceCommitRef => ({
+	source: "linear",
+	nativeId: "PROJ-9",
+	archivedKey: `linear:PROJ-9-${hash}`,
+	title: "Proj nine",
+	url: "https://linear.app/x/PROJ-9",
+	referencedAt: AT,
+	sourceToolName: "mcp__linear__get_issue",
+});
+
+describe("baseKeyOf (amend keys)", () => {
+	it("strips the -<8 hex> archive stamp from plan slugs and note ids", () => {
+		expect(baseKeyOf.plan(plan("my-plan-a1b2c3d4"))).toBe("my-plan");
+		expect(baseKeyOf.note(note("note-1-a1b2c3d4"))).toBe("note-1");
+	});
+
+	it("leaves an unstamped slug / id untouched", () => {
+		expect(baseKeyOf.plan(plan("my-plan"))).toBe("my-plan");
+		expect(baseKeyOf.note(note("note-1"))).toBe("note-1");
+	});
+
+	it("keys a reference by source:nativeId, ignoring which commit archived it", () => {
+		expect(baseKeyOf.reference(reference("aaaaaaaa"))).toBe("linear:PROJ-9");
+		expect(baseKeyOf.reference(reference("bbbbbbbb"))).toBe("linear:PROJ-9");
+	});
+
+	it("collapses two snapshots of the same item into one ref (the amend contract)", () => {
+		// A revived guard re-archives the same plan under the amend's new hash; the
+		// old snapshot must NOT be listed alongside it.
+		const merged = mergeRefsNewWins([plan("my-plan-aaaaaaaa")], [plan("my-plan-bbbbbbbb")], baseKeyOf.plan);
+		expect(merged.map((p) => p.slug)).toEqual(["my-plan-bbbbbbbb"]);
+	});
+});
+
+describe("snapshotKeyOf (squash keys)", () => {
+	it("keys by the hash-stamped identity of the archived file", () => {
+		expect(snapshotKeyOf.plan(plan("my-plan-a1b2c3d4"))).toBe("my-plan-a1b2c3d4");
+		expect(snapshotKeyOf.note(note("note-1-a1b2c3d4"))).toBe("note-1-a1b2c3d4");
+		expect(snapshotKeyOf.reference(reference("aaaaaaaa"))).toBe("linear:PROJ-9-aaaaaaaa");
+	});
+
+	// The bug these keys exist to prevent: a squash root hoists refs from N
+	// children, and two children can hold the same logical item at different
+	// commits (consult PROJ-9 on commit 1, consult it again on commit 3). Both
+	// orphan-branch files outlive the squash — reassociateMetadata only re-anchors
+	// plans.json rows, nothing renames or deletes a child's snapshot — so both need
+	// a pointer. Base keys would keep whichever child was visited last.
+	it("keeps BOTH children's snapshots of the same item, where base keys would keep one", () => {
+		const twoChildren = [reference("aaaaaaaa"), reference("bbbbbbbb")];
+
+		const withSnapshotKeys = mergeRefsNewWins(twoChildren, undefined, snapshotKeyOf.reference);
+		expect(withSnapshotKeys.map((r) => r.archivedKey)).toEqual([
+			"linear:PROJ-9-aaaaaaaa",
+			"linear:PROJ-9-bbbbbbbb",
+		]);
+
+		// Guard the divergence itself: if these two families ever agree, one of the
+		// paths is using the wrong one and the assertion above stopped proving anything.
+		expect(mergeRefsNewWins(twoChildren, undefined, baseKeyOf.reference)).toHaveLength(1);
+	});
+
+	it("keeps both children's plans / notes for the same reason", () => {
+		const plans = mergeRefsNewWins(
+			[plan("my-plan-aaaaaaaa"), plan("my-plan-bbbbbbbb")],
+			undefined,
+			snapshotKeyOf.plan,
+		);
+		expect(plans.map((p) => p.slug)).toEqual(["my-plan-aaaaaaaa", "my-plan-bbbbbbbb"]);
+
+		const notes = mergeRefsNewWins(
+			[note("note-1-aaaaaaaa"), note("note-1-bbbbbbbb")],
+			undefined,
+			snapshotKeyOf.note,
+		);
+		expect(notes.map((n) => n.id)).toEqual(["note-1-aaaaaaaa", "note-1-bbbbbbbb"]);
+	});
+
+	it("still lets a newly consumed ref replace the identical snapshot key", () => {
+		const merged = mergeRefsNewWins(
+			[{ ...reference("aaaaaaaa"), title: "stale" }],
+			[{ ...reference("aaaaaaaa"), title: "fresh" }],
+			snapshotKeyOf.reference,
+		);
+		expect(merged).toHaveLength(1);
+		expect(merged[0].title).toBe("fresh");
+	});
+});

--- a/cli/src/core/RefMerge.ts
+++ b/cli/src/core/RefMerge.ts
@@ -1,0 +1,91 @@
+/**
+ * Union of archived working-area refs (plans / notes / references) into a
+ * hoisted summary root.
+ *
+ * One merge function, TWO key families — and picking the wrong family silently
+ * strands orphan-branch files (a snapshot on the branch with no summary pointing
+ * at it), which is the failure class this module exists to prevent:
+ *
+ * - `baseKeyOf` — amend. Collapses the per-commit `-<shortHash>` stamp, so a
+ *   revived guard re-archived under a new hash lists once.
+ * - `snapshotKeyOf` — squash. Keeps the stamp, so N children each holding the
+ *   same logical item at a different commit keep N pointers.
+ *
+ * Its own module rather than a SummaryStore export because the consumers span
+ * both files — `SummaryStore.mergeManyToOne` (squash) and
+ * `QueueWorker.buildHoistedAmendRoot` (amend) — and QueueWorker's tests mock
+ * SummaryStore wholesale. A pure helper living in a mocked module would force
+ * every such suite to re-export it from its mock factory.
+ */
+
+import type { NoteReference, PlanReference, ReferenceCommitRef } from "../Types.js";
+
+/**
+ * Trailing `-<8 hex>` short-hash suffix that association appends to plan slugs / note ids.
+ *
+ * The single spelling of this pattern. Besides `baseKeyOf` below, the display and
+ * push paths that group snapshots by logical item import it: `planBaseKey`
+ * (JolliMemoryPushOrchestrator and the panel's PlanGrouping) and the relevance
+ * lookups in SummaryMarkdownBuilder / SummaryHtmlBuilder. Any drift between them
+ * would have one layer group snapshots another layer kept apart. No `g` flag, so
+ * the shared object carries no `lastIndex` state between callers.
+ */
+export const REF_HASH_SUFFIX = /-[0-9a-f]{8}$/;
+
+/**
+ * Unions old (hoisted) refs with newly-associated refs, deduped by the caller's
+ * key, with **new refs winning** on collision. New-wins is a data-integrity
+ * requirement: the new ref is the one whose markdown was just written to the
+ * orphan branch, so dropping it in favour of the old ref would leave an
+ * orphan-branch file with no summary pointer.
+ *
+ * The dedupe key decides which snapshots survive — pass `baseKeyOf.*` on amend
+ * and `snapshotKeyOf.*` on squash. See this module's header.
+ */
+export function mergeRefsNewWins<T>(
+	oldRefs: ReadonlyArray<T> | undefined,
+	newRefs: ReadonlyArray<T> | undefined,
+	dedupeKey: (ref: T) => string,
+): T[] {
+	const byKey = new Map<string, T>();
+	for (const ref of oldRefs ?? []) byKey.set(dedupeKey(ref), ref);
+	for (const ref of newRefs ?? []) byKey.set(dedupeKey(ref), ref);
+	return [...byKey.values()];
+}
+
+/**
+ * AMEND keys — identity of the logical ITEM, with the per-commit hash stamp
+ * stripped. `foo-<oldHash>` and `foo-<newHash>` collide, so a revived guard that
+ * re-archived the same plan under the amend's new hash lists once (as the new
+ * ref) instead of twice.
+ *
+ * Sound only because an amend root has exactly ONE old summary, so there is at
+ * most one old ref per base key. Never use these on a many-children merge.
+ */
+export const baseKeyOf = {
+	plan: (p: PlanReference): string => p.slug.replace(REF_HASH_SUFFIX, ""),
+	note: (n: NoteReference): string => n.id.replace(REF_HASH_SUFFIX, ""),
+	reference: (r: ReferenceCommitRef): string => `${r.source}:${r.nativeId}`,
+} as const;
+
+/**
+ * SQUASH keys — identity of the archived FILE, hash stamp included.
+ *
+ * A squash root hoists refs from N children, and two children can legitimately
+ * hold the same logical item at different commits: consult ticket PROJ-9 on
+ * commit 1, consult it again on commit 3, and the branch carries BOTH
+ * `linear:PROJ-9-<hash1>` and `linear:PROJ-9-<hash3>` as separate orphan-branch
+ * files. Nothing on the squash path renames or deletes a child's snapshot
+ * (`reassociateMetadata` only re-anchors `plans.json` registry rows), so both
+ * files outlive the squash and both need a pointer. Base keys here would keep
+ * whichever child was visited last and strand the other.
+ *
+ * These are the same keys `collectChildPlans` / `collectChildNotes` /
+ * `collectChildReferences` already dedupe by, so feeding their output through
+ * `mergeRefsNewWins` with these is order-preserving and idempotent.
+ */
+export const snapshotKeyOf = {
+	plan: (p: PlanReference): string => p.slug,
+	note: (n: NoteReference): string => n.id,
+	reference: (r: ReferenceCommitRef): string => r.archivedKey,
+} as const;

--- a/cli/src/core/SummaryMarkdownBuilder.ts
+++ b/cli/src/core/SummaryMarkdownBuilder.ts
@@ -8,6 +8,7 @@
 
 import type { CommitSummary, E2eTestScenario, ReferenceCommitRef, SourceId } from "../Types.js";
 import { escMdLinkText, escMdStrikeText, escMdUrl } from "./MarkdownEscape.js";
+import { REF_HASH_SUFFIX } from "./RefMerge.js";
 import { referenceDisplayTitle } from "./references/ReferenceDisplay.js";
 import { getRegistry } from "./references/SourceDefinitionRegistry.js";
 import { buildSkillsSummaryLabel } from "./SkillsAggregateMarkdown.js";
@@ -154,19 +155,17 @@ export function referencesBySourceOrder(
 	return out;
 }
 
-/** Archive suffix on committed plan slugs / note ids (`slug-<hash8>`). Relevance
- *  keys are working-area identities (pre-archive), so lookups try the exact key
- *  first and then this stripped form. Mirrors QueueWorker's REF_HASH_SUFFIX. */
-const ARCHIVE_HASH_SUFFIX = /-[0-9a-f]{8}$/;
-
 /** Relevance lookup for one archived ref: exact key first (covers unarchived or
- *  naturally-hex-ending working keys), then the archive-suffix-stripped base. */
+ *  naturally-hex-ending working keys), then the archive-suffix-stripped base.
+ *  `REF_HASH_SUFFIX` (from RefMerge) is the archive suffix on committed plan slugs
+ *  / note ids (`slug-<hash8>`); relevance keys are working-area identities, i.e.
+ *  pre-archive, which is why the stripped form has to be tried at all. */
 function lookupRelevance(
 	map: ReadonlyMap<string, { tier: "high" | "mid" | "low"; reason: string }>,
 	kind: "plan" | "note" | "reference",
 	key: string,
 ): { tier: "high" | "mid" | "low"; reason: string } | undefined {
-	return map.get(`${kind}:${key}`) ?? map.get(`${kind}:${key.replace(ARCHIVE_HASH_SUFFIX, "")}`);
+	return map.get(`${kind}:${key}`) ?? map.get(`${kind}:${key.replace(REF_HASH_SUFFIX, "")}`);
 }
 
 const TIER_LABEL = { high: "High", mid: "Med", low: "Low" } as const;

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -36,6 +36,7 @@ import type {
 	CommitSummary,
 	FileWrite,
 	PlanProgressArtifact,
+	ReferenceCommitRef,
 	SourceId,
 	SummaryIndex,
 	SummaryIndexEntry,
@@ -1402,11 +1403,12 @@ describe("SummaryStore", () => {
 				[createMockSummary("old1"), createMockSummary("old2")],
 				createMockCommitInfo("newhash"),
 				undefined,
-				undefined,
 				{
-					topics: [{ title: "Consolidated topic", trigger: "t", response: "r", decisions: "d" }],
-					recap: "Consolidated paragraph.",
-					ticketId: "PROJ-1",
+					consolidated: {
+						topics: [{ title: "Consolidated topic", trigger: "t", response: "r", decisions: "d" }],
+						recap: "Consolidated paragraph.",
+						ticketId: "PROJ-1",
+					},
 				},
 			);
 
@@ -1649,6 +1651,49 @@ describe("SummaryStore", () => {
 			]);
 		});
 
+		it("keeps every child's snapshot of the same reference alongside the squash's own", async () => {
+			// Regression pin. The hoisted union used to be keyed by BASE key
+			// (`source:nativeId`), so a branch where the same ticket was consulted on
+			// two commits kept only the child visited last: the other child's
+			// orphan-branch file survived the squash with no summary pointing at it —
+			// the exact stranding that consuming Context on this path exists to prevent.
+			// `snapshotKeyOf` keys by archivedKey, i.e. one pointer per archived file.
+			const ref = (hash: string): ReferenceCommitRef => ({
+				source: "linear",
+				nativeId: "PROJ-9",
+				archivedKey: `linear:PROJ-9-${hash}`,
+				title: "Proj nine",
+				url: "https://linear.app/x/PROJ-9",
+				referencedAt: "2026-02-18T00:00:00Z",
+				sourceToolName: "mcp__linear__get_issue",
+			});
+			const old1: CommitSummary = {
+				...createMockSummary("old1", "Old 1"),
+				commitDate: "2026-02-20T00:00:00Z",
+				references: [ref("aaaaaaaa")],
+			};
+			const old2: CommitSummary = {
+				...createMockSummary("old2", "Old 2"),
+				commitDate: "2026-02-19T00:00:00Z",
+				references: [ref("bbbbbbbb")],
+			};
+			vi.mocked(readFileFromBranch).mockResolvedValueOnce(JSON.stringify(v3Index([])));
+
+			// `cccccccc` stands in for the ref runSquashPipeline just archived for the
+			// squash commit itself — same ticket, third snapshot.
+			await mergeManyToOne([old1, old2], createMockCommitInfo("newhash"), undefined, {
+				extraRefs: { references: [ref("cccccccc")] },
+			});
+
+			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
+			const merged = JSON.parse(files[0].content) as CommitSummary;
+			expect(merged.references?.map((r) => r.archivedKey)).toEqual([
+				"linear:PROJ-9-aaaaaaaa",
+				"linear:PROJ-9-bbbbbbbb",
+				"linear:PROJ-9-cccccccc",
+			]);
+		});
+
 		it("should hoist merge metadata and e2e guides onto the new container summary", async () => {
 			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null);
 
@@ -1668,7 +1713,7 @@ describe("SummaryStore", () => {
 				],
 				createMockCommitInfo("newhash"),
 				undefined,
-				{ commitType: "squash", commitSource: "plugin" },
+				{ metadata: { commitType: "squash", commitSource: "plugin" } },
 			);
 
 			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;
@@ -2139,10 +2184,11 @@ describe("SummaryStore", () => {
 				[createMockSummary("old1"), createMockSummary("old2")],
 				createMockCommitInfo(newHash),
 				undefined,
-				undefined,
 				{
-					topics: [{ title: "Merged", trigger: "t", response: "r", decisions: "d" }],
-					summaryError: "llm-failed",
+					consolidated: {
+						topics: [{ title: "Merged", trigger: "t", response: "r", decisions: "d" }],
+						summaryError: "llm-failed",
+					},
 				},
 			);
 
@@ -2156,8 +2202,8 @@ describe("SummaryStore", () => {
 			vi.mocked(readFileFromBranch).mockResolvedValueOnce(null);
 			const newHash = "newhash0000000000000098";
 
-			await mergeManyToOne([createMockSummary("old1")], createMockCommitInfo(newHash), undefined, undefined, {
-				topics: [{ title: "Merged", trigger: "t", response: "r", decisions: "d" }],
+			await mergeManyToOne([createMockSummary("old1")], createMockCommitInfo(newHash), undefined, {
+				consolidated: { topics: [{ title: "Merged", trigger: "t", response: "r", decisions: "d" }] },
 			});
 
 			const files = vi.mocked(writeMultipleFilesToBranch).mock.calls[0][1] as ReadonlyArray<FileWrite>;

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -43,6 +43,7 @@ import { CURRENT_SCHEMA_VERSION } from "../Types.js";
 import { getDiffStats, getTreeHash } from "./GitOps.js";
 import { acquireOrphanWriteLock, releaseOrphanWriteLock } from "./Locks.js";
 import { OrphanBranchStorage } from "./OrphanBranchStorage.js";
+import { mergeRefsNewWins, snapshotKeyOf } from "./RefMerge.js";
 import { isRegisteredSourceId, sanitizeNativeIdForPath } from "./references/ReferenceStore.js";
 import type { StorageProvider } from "./StorageProvider.js";
 import type { SquashConsolidationSource } from "./Summarizer.js";
@@ -664,6 +665,17 @@ export function collectChildSkills(nodes: ReadonlyArray<CommitSummary>): Readonl
 	return mergeSkillRefs(all);
 }
 
+/**
+ * Working-area Context refs a caller just associated with the new commit, to be
+ * merged into a hoisted root alongside the refs inherited from its children.
+ * Mirrors the `newRefs` parameter of `buildHoistedAmendRoot`.
+ */
+export interface NewlyAssociatedRefs {
+	readonly plans?: ReadonlyArray<PlanReference>;
+	readonly notes?: ReadonlyArray<NoteReference>;
+	readonly references?: ReadonlyArray<ReferenceCommitRef>;
+}
+
 /** Returns a deep copy of the summary tree with Jolli metadata stripped from all nodes. */
 function stripJolliMetadata(node: CommitSummary): CommitSummary {
 	const { jolliDocId: _d, jolliDocUrl: _u, orphanedDocIds: _o, unresolvedOrphanHashes: _h, ...rest } = node;
@@ -1063,23 +1075,38 @@ export interface ConsolidatedTopics {
  * E2E test guides, plans, notes, jolliDoc metadata are still hoisted from
  * children via the existing collect* helpers; that part of the contract is
  * unchanged. The new piece is topics/recap going in via `consolidated`.
+ *
+ * `options.extraRefs` are the plans/notes/references the CALLER just associated
+ * with the squash commit itself (via consumeWorkspaceContext) — refs that exist
+ * in no child, so the collect* helpers cannot see them. They are unioned over
+ * the hoisted set by SNAPSHOT key (`snapshotKeyOf`), not base key: see RefMerge's
+ * header for why squash and amend need different keys here.
+ *
+ * The optional tail is one object rather than four positional parameters so a
+ * caller that wants only the last one doesn't have to pass `undefined`
+ * placeholders (and so adding a fifth doesn't shift anyone's argument list).
  */
-export async function mergeManyToOne(
-	oldSummaries: ReadonlyArray<CommitSummary>,
-	newCommitInfo: CommitInfo,
-	cwd?: string,
-	metadata?: { readonly commitType?: CommitType; readonly commitSource?: CommitSource },
-	consolidated?: ConsolidatedTopics,
-	storage?: StorageProvider,
+export interface MergeManyToOneOptions {
+	readonly metadata?: { readonly commitType?: CommitType; readonly commitSource?: CommitSource };
+	readonly consolidated?: ConsolidatedTopics;
+	readonly storage?: StorageProvider;
+	readonly extraRefs?: NewlyAssociatedRefs;
 	/**
 	 * Skill refs archived for THIS squash, on top of whatever the children carry.
 	 * A squash lands new work, so uncommitted skill rows belong on the root exactly
 	 * as they would on a plain commit; the children's own refs cannot supply them.
 	 */
-	extraSkills?: ReadonlyArray<SkillCommitRef>,
+	readonly extraSkills?: ReadonlyArray<SkillCommitRef>;
+}
+
+export async function mergeManyToOne(
+	oldSummaries: ReadonlyArray<CommitSummary>,
+	newCommitInfo: CommitInfo,
+	cwd?: string,
+	options?: MergeManyToOneOptions,
 ): Promise<{ orphanedDocIds: number[] }> {
 	return withRequiredOrphanWriteLock(cwd, "mergeManyToOne", () =>
-		mergeManyToOneLocked(oldSummaries, newCommitInfo, cwd, metadata, consolidated, storage, extraSkills),
+		mergeManyToOneLocked(oldSummaries, newCommitInfo, cwd, options),
 	);
 }
 
@@ -1087,11 +1114,9 @@ async function mergeManyToOneLocked(
 	oldSummaries: ReadonlyArray<CommitSummary>,
 	newCommitInfo: CommitInfo,
 	cwd?: string,
-	metadata?: { readonly commitType?: CommitType; readonly commitSource?: CommitSource },
-	consolidated?: ConsolidatedTopics,
-	storage?: StorageProvider,
-	extraSkills?: ReadonlyArray<SkillCommitRef>,
+	options?: MergeManyToOneOptions,
 ): Promise<{ orphanedDocIds: number[] }> {
+	const { metadata, consolidated, storage, extraRefs, extraSkills } = options ?? {};
 	log.info("Merging %d summaries into %s", oldSummaries.length, newCommitInfo.hash.substring(0, 8));
 
 	// Sort children by activity date descending (newest first) via getDisplayDate.
@@ -1107,12 +1132,22 @@ async function mergeManyToOneLocked(
 	// - orphanedDocIds: accumulated memory article IDs pending cleanup on next push
 	// - topics/recap: from `consolidated` (LLM or mechanical); see ConsolidatedTopics.
 	const hoistedE2e = collectChildE2eScenarios(children);
-	const hoistedPlans = collectChildPlans(children);
-	const hoistedNotes = collectChildNotes(children);
-	const hoistedReferences = collectChildReferences(children);
+	// Children's refs ∪ the refs this squash just associated. Without the union
+	// the newly archived orphan-branch snapshots would have no pointer from any
+	// summary. Keyed by SNAPSHOT key (hash stamp included) — the amend paths' base
+	// keys would collapse two children that archived the same logical item at
+	// different commits and strand one of their orphan-branch files. See RefMerge.
+	const hoistedPlans = mergeRefsNewWins(collectChildPlans(children), extraRefs?.plans, snapshotKeyOf.plan);
+	const hoistedNotes = mergeRefsNewWins(collectChildNotes(children), extraRefs?.notes, snapshotKeyOf.note);
+	const hoistedReferences = mergeRefsNewWins(
+		collectChildReferences(children),
+		extraRefs?.references,
+		snapshotKeyOf.reference,
+	);
 	// Newly-archived rows (squash lands new work) merge with the children's own refs
 	// through the same fold, so a skill entered both before and during the squash is
-	// one row carrying the sum.
+	// one row carrying the sum. Skills need no snapshot-key union: mergeSkillRefs
+	// ACCUMULATES per skill instead of deduping, so nothing can be stranded.
 	const hoistedSkills = mergeSkillRefs([...collectChildSkills(children), ...(extraSkills ?? [])]);
 	const jolliMeta = collectChildJolliMeta(children);
 	const inheritedOrphanIds = children.flatMap((c) => c.orphanedDocIds ?? []);

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -1414,13 +1414,13 @@ describe("queue-driven Worker", () => {
 				]),
 				expect.objectContaining({ hash: "newHash" }),
 				"/test/project",
-				expect.objectContaining({ commitType: "squash" }),
-				// runSquashPipeline passes a 5th `consolidated` arg to mergeManyToOne.
-				expect.objectContaining({ topics: expect.any(Array) }),
-				// 6th `storage` is left undefined; 7th carries the skill refs archived for
-				// THIS squash (see runSquashPipeline).
-				undefined,
-				expect.any(Array),
+				expect.objectContaining({
+					metadata: expect.objectContaining({ commitType: "squash" }),
+					consolidated: expect.objectContaining({ topics: expect.any(Array) }),
+					extraRefs: expect.objectContaining({ plans: expect.any(Array) }),
+					// Skill refs archived for THIS squash (see runSquashPipeline).
+					extraSkills: expect.any(Array),
+				}),
 			);
 			expect(generateSummary).not.toHaveBeenCalled();
 		});
@@ -1450,8 +1450,8 @@ describe("queue-driven Worker", () => {
 
 			await runWorker("/test/project");
 
-			// Should merge with only the 2 available summaries; the 5th arg is the
-			// consolidated topics/recap built by runSquashPipeline.
+			// Should merge with only the 2 available summaries; `options.consolidated`
+			// is the topics/recap built by runSquashPipeline.
 			expect(mergeManyToOne).toHaveBeenCalledWith(
 				expect.arrayContaining([
 					expect.objectContaining({ commitHash: "hash1" }),
@@ -1459,12 +1459,12 @@ describe("queue-driven Worker", () => {
 				]),
 				expect.objectContaining({ hash: "newHash" }),
 				"/test/project",
-				expect.anything(),
-				expect.objectContaining({ topics: expect.any(Array) }),
-				// 6th `storage` is left undefined; 7th carries the skill refs archived for
-				// THIS squash (see runSquashPipeline).
-				undefined,
-				expect.any(Array),
+				expect.objectContaining({
+					consolidated: expect.objectContaining({ topics: expect.any(Array) }),
+					extraRefs: expect.objectContaining({ plans: expect.any(Array) }),
+					// Skill refs archived for THIS squash (see runSquashPipeline).
+					extraSkills: expect.any(Array),
+				}),
 			);
 			// Verify exactly 2 summaries were passed (not 3)
 			const summariesArg = vi.mocked(mergeManyToOne).mock.calls[0][0];
@@ -2329,7 +2329,7 @@ describe("queue-driven Worker", () => {
 
 			await runWorker("/test/project");
 
-			// Should merge available summaries (2 of 3); 5th arg is consolidated topics/recap.
+			// Should merge available summaries (2 of 3); options.consolidated carries topics/recap.
 			expect(mergeManyToOne).toHaveBeenCalledWith(
 				expect.arrayContaining([
 					expect.objectContaining({ commitHash: "hash1" }),
@@ -2337,12 +2337,12 @@ describe("queue-driven Worker", () => {
 				]),
 				expect.anything(),
 				"/test/project",
-				expect.anything(),
-				expect.objectContaining({ topics: expect.any(Array) }),
-				// 6th `storage` is left undefined; 7th carries the skill refs archived for
-				// THIS squash (see runSquashPipeline).
-				undefined,
-				expect.any(Array),
+				expect.objectContaining({
+					consolidated: expect.objectContaining({ topics: expect.any(Array) }),
+					extraRefs: expect.objectContaining({ plans: expect.any(Array) }),
+					// Skill refs archived for THIS squash (see runSquashPipeline).
+					extraSkills: expect.any(Array),
+				}),
 			);
 		});
 	});

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -3062,7 +3062,13 @@ describe("QueueWorker", () => {
 				firstUsedAt: "2026-04-01T09:00:00.000Z",
 				lastUsedAt: "2026-04-01T09:30:00.000Z",
 			};
-			vi.mocked(associateSkillsWithCommit).mockResolvedValue({
+			// `…Once`, not `mockResolvedValue`: this path calls associateSkillsWithCommit
+			// TWICE (here, then again inside consumeWorkspaceContext), and the real second
+			// call finds nothing — uncommittedDelta returns undefined once the first call
+			// has advanced `archivedTotals` to the row's total. The beforeEach default
+			// ({ refs: [], filesToStore: [] }) models that. A blanket mockResolvedValue
+			// would instead hand the SAME delta back twice, which is the race below.
+			vi.mocked(associateSkillsWithCommit).mockResolvedValueOnce({
 				refs: [skillRef],
 				filesToStore: [{ path: "skills/claude/superpowers-brainstorming-newhash1.md", content: "# x" }],
 			});
@@ -3081,9 +3087,70 @@ describe("QueueWorker", () => {
 				"feature/test",
 				new Set(),
 			);
-			expect(storeSkills).toHaveBeenCalled();
-			// And handed to mergeManyToOne so the root it writes carries them.
-			expect(vi.mocked(mergeManyToOne).mock.calls[0]?.[6]).toEqual([skillRef]);
+			// Exactly once: the no-op second association must not emit a second batch of
+			// orphan-branch bytes. Loosening this to toHaveBeenCalled() is what let the
+			// double archival below go unnoticed.
+			expect(storeSkills).toHaveBeenCalledTimes(1);
+			// And handed to mergeManyToOne so the root it writes carries them. Asserted by
+			// NAME, not argument position — the optional tail is one options object.
+			expect(vi.mocked(mergeManyToOne).mock.calls[0]?.[3]?.extraSkills).toEqual([skillRef]);
+		});
+
+		it("carries a skill archived by the SECOND association too (no stranded orphan bytes)", async () => {
+			// The race the merged `extraSkills` exists for. consumeWorkspaceContext archives
+			// skills as well, so this path calls associateSkillsWithCommit twice, and a skill
+			// entered for the FIRST time between the two calls (the Stop hook writes
+			// plans.json asynchronously) yields a real delta on the second one. Being a
+			// different skill, it gets its own archivedKey and its own orphan-branch path —
+			// so dropping its ref, as this call site used to, left those bytes with no
+			// summary pointer AND the row guarded, i.e. never re-archived. Permanent.
+			//
+			// Note the same-skill case is NOT this bug: both calls share the commit hash, so
+			// archivedKey and the orphan path are identical, the second write overwrites the
+			// first and the existing ref still points at it. mergeSkillRefs deliberately
+			// dedupes such a repeat rather than summing it (see its header — a squash tree
+			// meets each hoisted ref twice), so that window costs an undercount, not bytes.
+			const { associateSkillsWithCommit } = await import("../core/skills/SkillArchive.js");
+			const { getSummary, mergeManyToOne, storeSkills } = await import("../core/SummaryStore.js");
+			vi.mocked(getSummary).mockResolvedValue({
+				version: 5,
+				commitHash: "oldhash",
+				commitMessage: "Old",
+				commitAuthor: "Jane",
+				commitDate: "2026-04-01T10:00:00.000Z",
+				branch: "feature/test",
+				generatedAt: "2026-04-01T10:00:00.000Z",
+				topics: [{ title: "Old topic", trigger: "t", response: "r", decisions: "d" }],
+			} as Awaited<ReturnType<typeof getSummary>>);
+			const base = {
+				source: "claude" as const,
+				entryPaths: ["tool" as const],
+				invocationCount: 1,
+				firstUsedAt: "2026-04-01T09:00:00.000Z",
+				lastUsedAt: "2026-04-01T09:30:00.000Z",
+			};
+			vi.mocked(associateSkillsWithCommit)
+				.mockResolvedValueOnce({
+					refs: [{ ...base, archivedKey: "claude:brainstorming-newhash2", skill: "brainstorming" }],
+					filesToStore: [{ path: "skills/claude/brainstorming-newhash2.md", content: "# a" }],
+				})
+				// Landed during the window — a skill the first call could not have seen.
+				.mockResolvedValueOnce({
+					refs: [{ ...base, archivedKey: "claude:writing-plans-newhash2", skill: "writing-plans" }],
+					filesToStore: [{ path: "skills/claude/writing-plans-newhash2.md", content: "# b" }],
+				});
+			setupPipelineMocks("newhash2");
+
+			await __test__.handleSquashFromQueue(
+				makeCommitOp({ commitHash: "newhash2", sourceHashes: ["oldhash"] }),
+				"/test/cwd",
+			);
+
+			// Both associations wrote their own bytes to the orphan branch…
+			expect(storeSkills).toHaveBeenCalledTimes(2);
+			// …and the summary points at both, so neither file is stranded.
+			const extraSkills = vi.mocked(mergeManyToOne).mock.calls[0]?.[3]?.extraSkills;
+			expect(extraSkills?.map((s) => s.skill)).toEqual(["brainstorming", "writing-plans"]);
 		});
 
 		it("passes user skill exclusions INTO the squash association, not as a post-filter", async () => {
@@ -3185,18 +3252,19 @@ describe("QueueWorker", () => {
 				"/test/cwd",
 			);
 
-			// runSquashPipeline calls mergeManyToOne with a 5th `consolidated`
-			// argument (LLM result or mechanicalConsolidate fallback).
+			// runSquashPipeline passes `options.consolidated` (LLM result or
+			// mechanicalConsolidate fallback) plus the refs it just consumed.
 			expect(mergeManyToOne).toHaveBeenCalledWith(
 				expect.any(Array),
 				expect.objectContaining({ hash: "newhash123" }),
 				"/test/cwd",
-				expect.objectContaining({ commitSource: "cli", commitType: "squash" }),
-				expect.objectContaining({ topics: expect.any(Array) }),
-				// 6th `storage` is left undefined; 7th carries the skill refs archived for
-				// THIS squash (see runSquashPipeline).
-				undefined,
-				expect.any(Array),
+				expect.objectContaining({
+					metadata: expect.objectContaining({ commitSource: "cli", commitType: "squash" }),
+					consolidated: expect.objectContaining({ topics: expect.any(Array) }),
+					extraRefs: expect.objectContaining({ plans: expect.any(Array) }),
+					// Skill refs archived for THIS squash (see runSquashPipeline).
+					extraSkills: expect.any(Array),
+				}),
 			);
 		});
 
@@ -3222,7 +3290,7 @@ describe("QueueWorker", () => {
 			);
 
 			expect(mergeManyToOne).toHaveBeenCalledTimes(1);
-			const consolidatedArg = vi.mocked(mergeManyToOne).mock.calls[0][4];
+			const consolidatedArg = vi.mocked(mergeManyToOne).mock.calls[0][3]?.consolidated;
 			expect(consolidatedArg?.summaryError).toBe("llm-failed");
 			expect((consolidatedArg?.topics ?? []).length).toBeGreaterThan(0); // mechanical preserved content
 		});
@@ -3249,7 +3317,7 @@ describe("QueueWorker", () => {
 			);
 
 			expect(mergeManyToOne).toHaveBeenCalledTimes(1);
-			const consolidatedArg = vi.mocked(mergeManyToOne).mock.calls[0][4];
+			const consolidatedArg = vi.mocked(mergeManyToOne).mock.calls[0][3]?.consolidated;
 			expect(consolidatedArg?.summaryError).toBeUndefined();
 		});
 
@@ -3297,7 +3365,7 @@ describe("QueueWorker", () => {
 			);
 
 			expect(mergeManyToOne).toHaveBeenCalledTimes(1);
-			const consolidatedArg = vi.mocked(mergeManyToOne).mock.calls[0][4];
+			const consolidatedArg = vi.mocked(mergeManyToOne).mock.calls[0][3]?.consolidated;
 			expect(consolidatedArg?.summaryError).toBe("llm-failed");
 		});
 
@@ -3340,7 +3408,7 @@ describe("QueueWorker", () => {
 			);
 
 			expect(mergeManyToOne).toHaveBeenCalledTimes(1);
-			const consolidatedArg = vi.mocked(mergeManyToOne).mock.calls[0][4];
+			const consolidatedArg = vi.mocked(mergeManyToOne).mock.calls[0][3]?.consolidated;
 			expect(consolidatedArg?.summaryError).toBeUndefined();
 		});
 
@@ -3370,8 +3438,331 @@ describe("QueueWorker", () => {
 			);
 
 			expect(mergeManyToOne).toHaveBeenCalledTimes(1);
-			const consolidatedArg = vi.mocked(mergeManyToOne).mock.calls[0][4];
+			const consolidatedArg = vi.mocked(mergeManyToOne).mock.calls[0][3]?.consolidated;
 			expect(consolidatedArg?.summaryError).toBe("llm-failed");
+		});
+
+		// ── Working-area Context consumption on the squash paths ────────────
+		// runSquashPipeline used to call only reassociateMetadata (migrate the
+		// OLD summaries' refs onto the new hash) and never consumeWorkspaceContext
+		// (archive the refs the user activated for THIS commit). A reference
+		// captured during the session that ended in a squash was therefore left
+		// active on the panel with no pointer from the squash memory.
+		it("squash archives an active reference onto the squash commit", async () => {
+			const { getSummary, mergeManyToOne, storeReferences } = await import("../core/SummaryStore.js");
+			vi.mocked(getSummary).mockResolvedValue({
+				version: 5,
+				commitHash: "sqsrc1",
+				commitMessage: "Src",
+				commitAuthor: "Jane",
+				commitDate: "2026-04-01T10:00:00.000Z",
+				branch: "feature/test",
+				generatedAt: "2026-04-01T10:00:00.000Z",
+				topics: [{ title: "Src topic", trigger: "t", response: "r", decisions: "d" }],
+			} as Awaited<ReturnType<typeof getSummary>>);
+			setupPipelineMocks("sqref123def45678");
+			vi.mocked(detectUncommittedReferenceIds).mockResolvedValue([
+				{ mapKey: "linear:PROJ-9", source: "linear", sourcePath: "/ref.md" },
+			]);
+			vi.mocked(loadPlansRegistry).mockResolvedValue({
+				version: 1,
+				plans: {},
+				references: {
+					"linear:PROJ-9": {
+						source: "linear",
+						nativeId: "PROJ-9",
+						title: "Proj nine",
+						url: "https://linear.app/x/PROJ-9",
+						sourcePath: "/ref.md",
+						addedAt: "2026-04-01T00:00:00Z",
+						updatedAt: "2026-04-01T00:00:00Z",
+						sourceToolName: "mcp__linear__get_issue",
+					},
+				},
+			});
+			const { readReferenceMarkdown } = await import("../core/references/ReferenceStore.js");
+			vi.mocked(readReferenceMarkdown).mockResolvedValue({
+				mapKey: "linear:PROJ-9",
+				source: "linear",
+				nativeId: "PROJ-9",
+				title: "Proj nine",
+				url: "https://linear.app/x/PROJ-9",
+				toolName: "mcp__linear__get_issue",
+				referencedAt: "2026-05-14T06:06:01.123Z",
+			});
+			const { readFile } = await import("node:fs/promises");
+			(readFile as unknown as { mockResolvedValue: (v: string) => void }).mockResolvedValue("ref content");
+
+			await __test__.handleSquashFromQueue(
+				makeCommitOp({ commitHash: "sqref123def45678", sourceHashes: ["sqsrc1"] }),
+				"/test/cwd",
+			);
+
+			// Orphan-branch snapshot written for the squash hash…
+			expect(storeReferences).toHaveBeenCalledTimes(1);
+			// …and the new ref is handed to mergeManyToOne so the merged root points at it.
+			const extraRefs = vi.mocked(mergeManyToOne).mock.calls[0][3]?.extraRefs;
+			expect(extraRefs?.references?.map((r) => r.archivedKey)).toEqual(["linear:PROJ-9-sqref123"]);
+		});
+
+		it("squash archives an active plan onto the squash commit", async () => {
+			const { getSummary, mergeManyToOne, storePlans } = await import("../core/SummaryStore.js");
+			vi.mocked(getSummary).mockResolvedValue({
+				version: 5,
+				commitHash: "sqsrc2",
+				commitMessage: "Src",
+				commitAuthor: "Jane",
+				commitDate: "2026-04-01T10:00:00.000Z",
+				branch: "feature/test",
+				generatedAt: "2026-04-01T10:00:00.000Z",
+				topics: [{ title: "Src topic", trigger: "t", response: "r", decisions: "d" }],
+			} as Awaited<ReturnType<typeof getSummary>>);
+			setupPipelineMocks("sqplan12def34567");
+			vi.mocked(loadPlansRegistry).mockResolvedValue({
+				version: 1,
+				plans: {
+					"my-plan": {
+						slug: "my-plan",
+						title: "My plan",
+						sourcePath: "/x/my-plan.md",
+						addedAt: "2026-04-01T00:00:00Z",
+						updatedAt: "2026-04-01T00:00:00Z",
+						commitHash: null,
+					},
+				},
+			} as Awaited<ReturnType<typeof loadPlansRegistry>>);
+			vi.mocked(existsSync).mockReturnValue(true);
+			vi.mocked(readFileSync).mockReturnValue("# My plan");
+
+			await __test__.handleSquashFromQueue(
+				makeCommitOp({ commitHash: "sqplan12def34567", sourceHashes: ["sqsrc2"] }),
+				"/test/cwd",
+			);
+
+			expect(storePlans).toHaveBeenCalledTimes(1);
+			const extraRefs = vi.mocked(mergeManyToOne).mock.calls[0][3]?.extraRefs;
+			expect(extraRefs?.plans?.map((p) => p.slug)).toEqual(["my-plan-sqplan12"]);
+		});
+
+		it("squash archives an active note onto the squash commit", async () => {
+			// The third artifact type consumeWorkspaceContext returns. Covered
+			// explicitly because plans/notes/references each have their own detect →
+			// associate → store triplet, so a plan passing proves nothing about notes.
+			const { getSummary, mergeManyToOne, storeNotes } = await import("../core/SummaryStore.js");
+			vi.mocked(getSummary).mockResolvedValue({
+				version: 5,
+				commitHash: "sqsrc4",
+				commitMessage: "Src",
+				commitAuthor: "Jane",
+				commitDate: "2026-04-01T10:00:00.000Z",
+				branch: "feature/test",
+				generatedAt: "2026-04-01T10:00:00.000Z",
+				topics: [{ title: "Src topic", trigger: "t", response: "r", decisions: "d" }],
+			} as Awaited<ReturnType<typeof getSummary>>);
+			setupPipelineMocks("sqnote12def34567");
+			vi.mocked(loadPlansRegistry).mockResolvedValue({
+				version: 1,
+				plans: {},
+				notes: {
+					"my-note": {
+						id: "my-note",
+						title: "My note",
+						format: "markdown" as const,
+						sourcePath: "/x/my-note.md",
+						addedAt: "2026-04-01T00:00:00Z",
+						updatedAt: "2026-04-01T00:00:00Z",
+						commitHash: null,
+					},
+				},
+			} as Awaited<ReturnType<typeof loadPlansRegistry>>);
+			vi.mocked(existsSync).mockReturnValue(true);
+			vi.mocked(readFileSync).mockReturnValue("# My note");
+
+			await __test__.handleSquashFromQueue(
+				makeCommitOp({ commitHash: "sqnote12def34567", sourceHashes: ["sqsrc4"] }),
+				"/test/cwd",
+			);
+
+			expect(storeNotes).toHaveBeenCalledTimes(1);
+			const extraRefs = vi.mocked(mergeManyToOne).mock.calls[0][3]?.extraRefs;
+			expect(extraRefs?.notes?.map((n) => n.id)).toEqual(["my-note-sqnote12"]);
+		});
+
+		it("falls back to the source summaries' branch when the live read fails", async () => {
+			// The queue entry carries no branch (both enqueue hooks omit the field when
+			// their own read failed) and the live read throws. Archival must NOT be
+			// skipped: skill archival on this path takes its branch from the source
+			// summaries and would proceed regardless, so bailing here produced a squash
+			// that recorded skills but not plans/notes/references. The source summaries'
+			// branch is already in hand and cannot throw, so it backstops the live read.
+			const { getSummary, storeReferences } = await import("../core/SummaryStore.js");
+			vi.mocked(getSummary).mockResolvedValue({
+				version: 5,
+				commitHash: "sqsrc5",
+				commitMessage: "Src",
+				commitAuthor: "Jane",
+				commitDate: "2026-04-01T10:00:00.000Z",
+				branch: "feature/from-summary",
+				generatedAt: "2026-04-01T10:00:00.000Z",
+				topics: [{ title: "Src topic", trigger: "t", response: "r", decisions: "d" }],
+			} as Awaited<ReturnType<typeof getSummary>>);
+			setupPipelineMocks("sqnobr12def34567");
+			// makeCommitOp carries no `branch`, so the pipeline falls through to the
+			// live read — which fails here.
+			vi.mocked(getCurrentBranch).mockRejectedValue(new Error("fatal: not a git repository"));
+			vi.mocked(detectUncommittedReferenceIds).mockResolvedValue([
+				{ mapKey: "linear:PROJ-7", source: "linear", sourcePath: "/ref.md" },
+			]);
+			vi.mocked(loadPlansRegistry).mockResolvedValue({
+				version: 1,
+				plans: {},
+				references: {
+					"linear:PROJ-7": {
+						source: "linear",
+						nativeId: "PROJ-7",
+						title: "Proj seven",
+						url: "https://linear.app/x/PROJ-7",
+						sourcePath: "/ref.md",
+						addedAt: "2026-04-01T00:00:00Z",
+						updatedAt: "2026-04-01T00:00:00Z",
+						sourceToolName: "mcp__linear__get_issue",
+					},
+				},
+			});
+			const { readReferenceMarkdown } = await import("../core/references/ReferenceStore.js");
+			vi.mocked(readReferenceMarkdown).mockResolvedValue({
+				mapKey: "linear:PROJ-7",
+				source: "linear",
+				nativeId: "PROJ-7",
+				title: "Proj seven",
+				url: "https://linear.app/x/PROJ-7",
+				toolName: "mcp__linear__get_issue",
+				referencedAt: "2026-05-14T06:06:01.123Z",
+			});
+			const { readFile } = await import("node:fs/promises");
+			(readFile as unknown as { mockResolvedValue: (v: string) => void }).mockResolvedValue("ref content");
+
+			await __test__.handleSquashFromQueue(
+				makeCommitOp({ commitHash: "sqnobr12def34567", sourceHashes: ["sqsrc5"] }),
+				"/test/cwd",
+			);
+
+			// Archival happened, filed under the fallback branch rather than skipped.
+			expect(detectUncommittedReferenceIds).toHaveBeenCalledWith("/test/cwd", "feature/from-summary");
+			expect(storeReferences).toHaveBeenCalledTimes(1);
+			expect(vi.mocked(storeReferences).mock.calls[0][3]).toBe("feature/from-summary");
+		});
+
+		it("prefers the enqueue-time branch hint over a live read", async () => {
+			// The worker drains asynchronously, so HEAD may have moved since the commit.
+			// `op.branch` is the branch as of enqueue and must win outright — a live read
+			// on this path is not merely redundant, it can file the archive under whatever
+			// branch a sibling worktree or a later checkout left at HEAD.
+			const { getSummary } = await import("../core/SummaryStore.js");
+			vi.mocked(getSummary).mockResolvedValue({
+				version: 5,
+				commitHash: "sqsrc6",
+				commitMessage: "Src",
+				commitAuthor: "Jane",
+				commitDate: "2026-04-01T10:00:00.000Z",
+				branch: "feature/stale-summary-branch",
+				generatedAt: "2026-04-01T10:00:00.000Z",
+				topics: [{ title: "Src topic", trigger: "t", response: "r", decisions: "d" }],
+			} as Awaited<ReturnType<typeof getSummary>>);
+			setupPipelineMocks("sqhint12def34567");
+			vi.mocked(getCurrentBranch).mockClear();
+
+			await __test__.handleSquashFromQueue(
+				makeCommitOp({
+					commitHash: "sqhint12def34567",
+					sourceHashes: ["sqsrc6"],
+					branch: "feature/hinted",
+				}),
+				"/test/cwd",
+			);
+
+			expect(detectUncommittedReferenceIds).toHaveBeenCalledWith("/test/cwd", "feature/hinted");
+			// Not consulted at all — the hint short-circuits it.
+			expect(getCurrentBranch).not.toHaveBeenCalled();
+		});
+
+		it("squash invalidates the panel's cached AI ranking", async () => {
+			// A squash always moves HEAD, so the stored change fingerprint is stale —
+			// a later commit must not reuse its exclude decisions. Mirrors the amend
+			// paths, which clear up front for the same reason.
+			const { getSummary } = await import("../core/SummaryStore.js");
+			vi.mocked(getSummary).mockResolvedValue({
+				version: 5,
+				commitHash: "sqsrc3",
+				commitMessage: "Src",
+				commitAuthor: "Jane",
+				commitDate: "2026-04-01T10:00:00.000Z",
+				branch: "feature/test",
+				generatedAt: "2026-04-01T10:00:00.000Z",
+				topics: [{ title: "Src topic", trigger: "t", response: "r", decisions: "d" }],
+			} as Awaited<ReturnType<typeof getSummary>>);
+			setupPipelineMocks("sqclear1def23456");
+			vi.mocked(clearAiSelection).mockClear();
+
+			await __test__.handleSquashFromQueue(
+				makeCommitOp({ commitHash: "sqclear1def23456", sourceHashes: ["sqsrc3"] }),
+				"/test/cwd",
+			);
+
+			expect(clearAiSelection).toHaveBeenCalledWith("/test/cwd");
+		});
+
+		it("rebase-squash also archives an active reference (same pipeline)", async () => {
+			const { getSummary, storeReferences } = await import("../core/SummaryStore.js");
+			vi.mocked(getSummary).mockResolvedValue({
+				version: 5,
+				commitHash: "rbsrc1",
+				commitMessage: "Src",
+				commitAuthor: "Jane",
+				commitDate: "2026-04-01T10:00:00.000Z",
+				branch: "feature/test",
+				generatedAt: "2026-04-01T10:00:00.000Z",
+				topics: [{ title: "Src topic", trigger: "t", response: "r", decisions: "d" }],
+			} as Awaited<ReturnType<typeof getSummary>>);
+			setupPipelineMocks("rbsq1234def56789");
+			vi.mocked(detectUncommittedReferenceIds).mockResolvedValue([
+				{ mapKey: "linear:PROJ-8", source: "linear", sourcePath: "/ref.md" },
+			]);
+			vi.mocked(loadPlansRegistry).mockResolvedValue({
+				version: 1,
+				plans: {},
+				references: {
+					"linear:PROJ-8": {
+						source: "linear",
+						nativeId: "PROJ-8",
+						title: "Proj eight",
+						url: "https://linear.app/x/PROJ-8",
+						sourcePath: "/ref.md",
+						addedAt: "2026-04-01T00:00:00Z",
+						updatedAt: "2026-04-01T00:00:00Z",
+						sourceToolName: "mcp__linear__get_issue",
+					},
+				},
+			});
+			const { readReferenceMarkdown } = await import("../core/references/ReferenceStore.js");
+			vi.mocked(readReferenceMarkdown).mockResolvedValue({
+				mapKey: "linear:PROJ-8",
+				source: "linear",
+				nativeId: "PROJ-8",
+				title: "Proj eight",
+				url: "https://linear.app/x/PROJ-8",
+				toolName: "mcp__linear__get_issue",
+				referencedAt: "2026-05-14T06:06:01.123Z",
+			});
+			const { readFile } = await import("node:fs/promises");
+			(readFile as unknown as { mockResolvedValue: (v: string) => void }).mockResolvedValue("ref content");
+
+			await __test__.handleRebaseSquashFromQueue(
+				makeCommitOp({ type: "rebase-squash", commitHash: "rbsq1234def56789", sourceHashes: ["rbsrc1"] }),
+				"/test/cwd",
+			);
+
+			expect(storeReferences).toHaveBeenCalledTimes(1);
 		});
 	});
 
@@ -4662,33 +5053,9 @@ describe("QueueWorker", () => {
 
 	// ─── amend Context consumption: new-wins ref union, audit filter, plan soft-exclude, fresh-leaf refs ───
 	describe("amend workspace-Context consumption", () => {
-		const bySlug = (r: { slug: string }) => r.slug;
-
-		describe("mergeRefsNewWins", () => {
-			it("returns [] for empty / undefined inputs", () => {
-				expect(__test__.mergeRefsNewWins(undefined, undefined, bySlug)).toEqual([]);
-				expect(__test__.mergeRefsNewWins([], [], bySlug)).toEqual([]);
-			});
-
-			it("keeps old refs when there are no new refs", () => {
-				const old = [{ slug: "a" }, { slug: "b" }];
-				expect(__test__.mergeRefsNewWins(old, undefined, bySlug)).toEqual(old);
-			});
-
-			it("unions non-colliding new refs after the old ones", () => {
-				const merged = __test__.mergeRefsNewWins([{ slug: "a" }], [{ slug: "b" }], bySlug);
-				expect(merged.map(bySlug)).toEqual(["a", "b"]);
-			});
-
-			it("new ref wins on base-key collision (drops the stale old snapshot)", () => {
-				const merged = __test__.mergeRefsNewWins(
-					[{ slug: "a", tag: "old" }],
-					[{ slug: "a", tag: "new" }],
-					bySlug,
-				);
-				expect(merged).toEqual([{ slug: "a", tag: "new" }]);
-			});
-		});
+		// mergeRefsNewWins itself now lives in core/RefMerge (both hoisted roots need
+		// it — amend and squash, with different dedupe keys); its unit tests, and the
+		// coverage of which key family each path must use, live in RefMerge.test.ts.
 
 		describe("buildHoistedAmendRoot ref merge + audit", () => {
 			const newInfo: CommitInfo = {

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -31,7 +31,13 @@ import { isClineInstalled } from "../core/ClineDetector.js";
 import { discoverClineSessions } from "../core/ClineSessionDiscoverer.js";
 import { readClineTranscript } from "../core/ClineTranscriptReader.js";
 import { discoverCodexSessions, isCodexInstalled } from "../core/CodexSessionDiscoverer.js";
-import { clearAiSelection, conversationKey, readAiSelection, readExclusions } from "../core/CommitSelectionStore.js";
+import {
+	type CommitExclusions,
+	clearAiSelection,
+	conversationKey,
+	readAiSelection,
+	readExclusions,
+} from "../core/CommitSelectionStore.js";
 import {
 	assessContextRelevance,
 	buildChangeSignal,
@@ -74,6 +80,7 @@ import { evaluatePlanProgress } from "../core/PlanProgressEvaluator.js";
 import { formatPlansBlock } from "../core/PlanPromptFormatter.js";
 import { estimateCostUsd, PRICES_AS_OF } from "../core/Pricing.js";
 import { triggerPushForNewSummaries } from "../core/PushExecutor.js";
+import { baseKeyOf, mergeRefsNewWins } from "../core/RefMerge.js";
 import { readManualDisableFlag } from "../core/RepoProfile.js";
 import {
 	accumulatedQueryOf,
@@ -131,6 +138,7 @@ import {
 } from "../core/SummaryStore.js";
 import { resolveTranscriptIdsFiltered } from "../core/SummaryTree.js";
 import { associateSkillsWithCommit } from "../core/skills/SkillArchive.js";
+import { mergeSkillRefs } from "../core/skills/SkillDelta.js";
 import { getTelemetryContext, track } from "../core/Telemetry.js";
 import { bootstrapTelemetry, flushTelemetryNow } from "../core/TelemetryStartup.js";
 import { getCurrentTraceId, runWithTrace, TRACE_ID_ENV, traceIdFromEnv } from "../core/TraceContext.js";
@@ -1655,7 +1663,7 @@ async function consumeWorkspaceContext(args: {
 		readonly skills?: ReadonlySet<string>;
 	};
 	readonly excludedContext: ReadonlyArray<ExcludedContextItem>;
-	readonly archiveLabel?: "commit" | "amend";
+	readonly archiveLabel?: "commit" | "amend" | "squash";
 }): Promise<ConsumedWorkspaceContext> {
 	const { cwd, branch, commitHash, exclusions, excludedContext, archiveLabel = "commit" } = args;
 
@@ -2199,6 +2207,60 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 }
 
 /**
+ * Resolves the branch and consumes the working-area Context for a squash commit.
+ *
+ * Branch resolution cannot fail the caller, by construction — three sources, the
+ * last of which performs no I/O:
+ *   1. `branchHint`, captured at enqueue time. Preferred because the worker drains
+ *      asynchronously and HEAD may have moved since the commit.
+ *   2. A live read. Reachable by design: both enqueue hooks deliberately tolerate
+ *      their own branch read failing and omit the field, and pre-0.99.x queue
+ *      entries predate it entirely.
+ *   3. `fallbackBranch` — the source summaries' own branch. Already in hand and
+ *      cannot throw, so a failed live read costs nothing.
+ *
+ * Step 3 exists because skipping archival on a failed live read produced a partial
+ * memory rather than a smaller one: skill archival on this path resolves its branch
+ * from the same source summaries and would have proceeded anyway, so the squash
+ * would record skills but not plans/notes/references. `fallbackBranch` may be stale
+ * relative to HEAD (that is exactly why it is last), but a stale branch label costs
+ * at most a mis-filed archive, where skipping cost the pointer altogether.
+ *
+ * `exclusions` is passed in rather than read here so this path reads the panel's
+ * selection exactly once — a second read straddles an orphan write and can disagree
+ * with the set the caller's own skill archival already honoured.
+ */
+async function consumeSquashContext(args: {
+	readonly cwd: string;
+	readonly branchHint: string | undefined;
+	readonly fallbackBranch: string;
+	readonly commitHash: string;
+	readonly exclusions: CommitExclusions;
+}): Promise<ConsumedWorkspaceContext> {
+	const { cwd, branchHint, fallbackBranch, commitHash, exclusions } = args;
+	let branch = branchHint;
+	if (!branch) {
+		try {
+			branch = await getCurrentBranch(cwd);
+		} catch (err) {
+			log.warn(
+				"Squash: live branch read failed (%s) — falling back to the source summaries' branch",
+				errMsg(err),
+			);
+			branch = fallbackBranch;
+		}
+	}
+	return consumeWorkspaceContext({
+		cwd,
+		branch,
+		commitHash,
+		exclusions,
+		excludedContext: [],
+		archiveLabel: "squash",
+	});
+}
+
+/**
  * Shared squash consolidation pipeline. Used by BOTH:
  *   - handleSquashFromQueue (op.type = "squash"): VSCode plugin Squash button
  *     (writes squash-pending.json + git reset --soft + git commit), or `git
@@ -2227,7 +2289,15 @@ async function runSquashPipeline(
 	commitInfo: CommitInfo,
 	cwd: string,
 	metadata: { readonly commitType: CommitType; readonly commitSource: CommitSource },
+	branchHint: string | undefined,
 ): Promise<number> {
+	// Invalidate the panel's cached AI ranking up front, for the same reason the
+	// amend paths do: a squash always moves HEAD, so the stored change fingerprint
+	// is stale and a LATER commit must not reuse its exclude decisions. Clearing
+	// before the LLM window keeps a concurrent panel re-rank from being clobbered.
+	// Best-effort — a clear failure must never break consolidation.
+	await clearAiSelection(cwd).catch((err) => log.warn("clearAiSelection failed: %s", (err as Error).message));
+
 	// Expand each source via expandSourcesForConsolidation: preserves per-commit
 	// grouping for nested squash roots (so the LLM can apply rule 4 evidence).
 	const sources: ReadonlyArray<SquashConsolidationSource> = oldSummaries.flatMap(expandSourcesForConsolidation);
@@ -2311,9 +2381,6 @@ async function runSquashPipeline(
 	);
 	/* v8 ignore stop */
 
-	// mergeManyToOne writes the v4 root with these consolidated topics + recap +
-	// stripped children. Hoist invariant always completes (consolidated is never
-	// undefined here, even on LLM failure thanks to mechanicalConsolidate).
 	// A squash lands new work, so uncommitted skill rows belong on the squash commit
 	// exactly as they would on a plain commit. Done BEFORE mergeManyToOne so the refs
 	// can be hoisted onto the root it writes — there is no second write to patch them
@@ -2324,6 +2391,14 @@ async function runSquashPipeline(
 	// MUST go into the association rather than filter its result: it guards the row
 	// and emits orphan-branch bytes, so a post-filter would leave an excluded skill
 	// archived on the branch while merely hiding it from the summary.
+	//
+	// Ordered BEFORE consumeSquashContext, not after: storeSkills is another orphan
+	// write that can throw, and everything between the consume and the summary write
+	// is a window where a throw strands a snapshot with no pointer (see below). Skills
+	// carry no such window — their registry rows are only migrated, never torn down.
+	// One read of the panel selection for the whole path — shared with
+	// consumeSquashContext below. Two reads would straddle the storeSkills orphan
+	// write and could disagree, leaving the two halves honouring different sets.
 	const branch = oldSummaries[0].branch;
 	const squashExclusions = await readExclusions(cwd);
 	const { refs: newSkillRefs, filesToStore: newSkillFiles } = await associateSkillsWithCommit(
@@ -2341,9 +2416,71 @@ async function runSquashPipeline(
 		);
 	}
 
-	await mergeManyToOne(oldSummaries, commitInfo, cwd, metadata, consolidated, undefined, newSkillRefs);
+	// Consume the working-area Context for the squash commit itself. Squash used to
+	// run only reassociateMetadata, which MIGRATES the sources' already-archived
+	// refs — it can never archive a plan/note/reference the user activated during
+	// the session that ended in this squash. Those stayed on the panel with the
+	// squash memory holding no pointer to them.
+	//
+	// Placed HERE, immediately before mergeManyToOne, rather than at the top of the
+	// pipeline: consumeWorkspaceContext is write-ahead (it commits the orphan-branch
+	// snapshot, THEN tears down the local registry rows), so every await between it
+	// and the summary write is a window where a throw — an orphan write-lock timeout
+	// is the realistic one — strands a snapshot with no pointer and no panel row.
+	// Consuming after the consolidation LLM keeps that window at one call, matching
+	// the amend full path (which also consumes only once its LLM has returned).
+	//
+	// `excludedContext: []`: squash runs no relevance LLM (it consolidates existing
+	// topic structures rather than re-deriving from diff + transcript), so there is
+	// no AI soft-exclude set — the user's panel selection is associated in full,
+	// minus their hard excludes. Same argument as applyAmendShortCircuit.
+	const consumed = await consumeSquashContext({
+		cwd,
+		branchHint,
+		fallbackBranch: branch,
+		commitHash: commitInfo.hash,
+		exclusions: squashExclusions,
+	});
 
-	// Re-associate plans, notes and skill guards with the new squash commit hash.
+	// mergeManyToOne writes the v4 root with these consolidated topics + recap +
+	// stripped children. Hoist invariant always completes (consolidated is never
+	// undefined here, even on LLM failure thanks to mechanicalConsolidate). The
+	// just-consumed refs ride along as `extraRefs` so the merged root points at
+	// the orphan-branch snapshots consumeWorkspaceContext just wrote; the skill refs
+	// ride along as `extraSkills` for the same reason.
+	//
+	// `newSkillRefs` ∪ `consumed.skillRefs`: consumeWorkspaceContext archives skills
+	// too, so this path calls associateSkillsWithCommit twice. The second call is
+	// normally a no-op — uncommittedDelta returns undefined once the first call has
+	// advanced `archivedTotals` to the row's total — but "normally" is not "always":
+	// a skill entered for the first time between the two calls (the Stop hook writes
+	// plans.json asynchronously) yields a real delta on the second one. Being a
+	// different skill it gets its own archivedKey and its own orphan-branch path, so
+	// dropping its ref here stranded those bytes with no summary pointer AND left the
+	// row guarded, i.e. unable to ever re-archive — the exact permanent, silent
+	// stranding this consumption exists to prevent.
+	//
+	// A repeat of the SAME skill is not that bug and needs no handling: both calls
+	// share the commit hash, so archivedKey and the orphan path are identical, the
+	// second write overwrites the first and the first call's ref still points at it.
+	// mergeSkillRefs dedupes such a repeat rather than summing it — deliberately, see
+	// its header — so that window costs an undercount of the in-window increment, not
+	// bytes on the branch.
+	await mergeManyToOne(oldSummaries, commitInfo, cwd, {
+		metadata,
+		consolidated,
+		extraSkills: mergeSkillRefs([...newSkillRefs, ...consumed.skillRefs]),
+		extraRefs: {
+			plans: consumed.planAssociation.refs,
+			notes: consumed.noteRefs,
+			references: consumed.referenceRefs,
+		},
+	});
+
+	// Re-associate plans, notes and skill guards with the new squash commit hash. Runs
+	// AFTER the associations above so a revived guard's commitHash has already moved to
+	// the new hash — reassociate's old-short-hash guard is then a no-op for it, avoiding
+	// a double migration (same ordering rationale as applyAmendShortCircuit).
 	await reassociateMetadata(oldSummaries, commitInfo.hash, cwd);
 
 	// Consolidated topic count for the caller's `stored` progress event — mirrors
@@ -2410,10 +2547,16 @@ async function handleSquashFromQueue(op: CommitGitOperation, cwd: string): Promi
 
 	const commitInfo = await getCommitInfo(op.commitHash, cwd);
 	/* v8 ignore start -- commitSource is always set by the enqueue path; fallback is defensive */
-	const topics = await runSquashPipeline(oldSummaries, commitInfo, cwd, {
-		commitType: "squash",
-		commitSource: op.commitSource ?? "cli",
-	});
+	const topics = await runSquashPipeline(
+		oldSummaries,
+		commitInfo,
+		cwd,
+		{
+			commitType: "squash",
+			commitSource: op.commitSource ?? "cli",
+		},
+		op.branch,
+	);
 	/* v8 ignore stop */
 	emitCaptureProgress(cwd, op.commitHash, "stored", { data: { topics } });
 }
@@ -2479,10 +2622,16 @@ async function handleRebaseSquashFromQueue(op: CommitGitOperation, cwd: string):
 	}
 
 	const newCommitInfo = await getCommitInfo(op.commitHash, cwd);
-	const topics = await runSquashPipeline(oldSummaries, newCommitInfo, cwd, {
-		commitType: "squash",
-		commitSource: (op.commitSource ?? "cli") as CommitSource,
-	});
+	const topics = await runSquashPipeline(
+		oldSummaries,
+		newCommitInfo,
+		cwd,
+		{
+			commitType: "squash",
+			commitSource: (op.commitSource ?? "cli") as CommitSource,
+		},
+		op.branch,
+	);
 	emitCaptureProgress(cwd, op.commitHash, "stored", { data: { topics } });
 }
 
@@ -2583,30 +2732,6 @@ function conversationUsageFields(
 	};
 }
 
-/** Trailing `-<8 hex>` short-hash suffix that association appends to plan slugs / note ids. */
-const REF_HASH_SUFFIX = /-[0-9a-f]{8}$/;
-
-/**
- * Unions old (hoisted) refs with newly-associated refs, deduped by BASE key,
- * with **new refs winning** on collision. Base key strips the per-commit
- * `-<shortHash>` suffix (plans/notes) or uses `<source>:<nativeId>` (references),
- * so a revived guard that re-archives `foo-<oldHash>` as `foo-<newHash>` lists
- * once — as the NEW ref. New-wins is a data-integrity requirement: the new ref
- * is the one whose markdown was just written to the orphan branch, so dropping
- * it in favour of the old ref would leave an orphan-branch file with no summary
- * pointer (the exact bug this consumption fix exists to prevent).
- */
-function mergeRefsNewWins<T>(
-	oldRefs: ReadonlyArray<T> | undefined,
-	newRefs: ReadonlyArray<T> | undefined,
-	baseKey: (ref: T) => string,
-): T[] {
-	const byKey = new Map<string, T>();
-	for (const ref of oldRefs ?? []) byKey.set(baseKey(ref), ref);
-	for (const ref of newRefs ?? []) byKey.set(baseKey(ref), ref);
-	return [...byKey.values()];
-}
-
 /**
  * Builds the v4 amend root with all 8 Hoist fields populated and the old
  * summary attached as a stripped child. Used by all three amend paths
@@ -2621,8 +2746,8 @@ function mergeRefsNewWins<T>(
  *
  * `newRefs` are the plans/notes/references this amend just associated (via
  * consumeWorkspaceContext). They are merged into the hoisted old refs with
- * NEW winning per base key (see mergeRefsNewWins) — without this, the newly
- * archived orphan-branch snapshots would have no pointer in the summary root.
+ * NEW winning per base key (`baseKeyOf`) — without this, the newly archived
+ * orphan-branch snapshots would have no pointer in the summary root.
  * `excludedContext` is the AI soft-exclude audit, written only on the paths
  * that generate a new summary (full path / fresh leaf), mirroring the normal
  * commit pipeline; the short-circuit paths pass `[]`.
@@ -2656,24 +2781,21 @@ function buildHoistedAmendRoot(
 	excludedContext?: ReadonlyArray<ExcludedContextItem>,
 	contextRelevance?: ReadonlyArray<ContextRelevanceRef>,
 ): CommitSummary {
-	// Old (hoisted) refs ∪ new refs, deduped by base key with new winning.
+	// Old (hoisted) refs ∪ new refs, deduped by BASE key with new winning — sound
+	// here because an amend root has exactly one old summary (see RefMerge). The
+	// squash path deliberately keys the same union differently.
 	const hoistedMeta = hoistMetadataFromOldSummary(oldSummary);
-	const mergedPlans = mergeRefsNewWins(hoistedMeta.plans, newRefs?.plans, (p) => p.slug.replace(REF_HASH_SUFFIX, ""));
-	const mergedNotes = mergeRefsNewWins(hoistedMeta.notes, newRefs?.notes, (n) => n.id.replace(REF_HASH_SUFFIX, ""));
-	const mergedReferences = mergeRefsNewWins(
-		hoistedMeta.references,
-		newRefs?.references,
-		(r) => `${r.source}:${r.nativeId}`,
-	);
-	// Skills merge on the registry mapKey `<source>:<skill>` verbatim — NOT via
-	// REF_HASH_SUFFIX like plans and notes above. Those two carry the archive short
-	// hash inside the identifier they are keyed on (`<slug>-<hash8>`), so it has to be
-	// stripped to recover a base key; a skill ref keeps its hash in `archivedKey` and
-	// leaves `skill` as the raw id, so there is nothing to strip. Stripping anyway
-	// silently truncated any id that happens to end in 8 hex characters, folding two
-	// distinct skills into one row here while `attachedBaseKeys.skill` below and
-	// `mergeSkillRefs` both kept them apart — three derivations of one key that have
-	// to agree.
+	const mergedPlans = mergeRefsNewWins(hoistedMeta.plans, newRefs?.plans, baseKeyOf.plan);
+	const mergedNotes = mergeRefsNewWins(hoistedMeta.notes, newRefs?.notes, baseKeyOf.note);
+	const mergedReferences = mergeRefsNewWins(hoistedMeta.references, newRefs?.references, baseKeyOf.reference);
+	// Skills merge on the registry mapKey `<source>:<skill>` verbatim, so they get no
+	// `baseKeyOf` entry — there is no hash stamp to strip. Plans and notes carry the
+	// archive short hash inside the identifier they are keyed on (`<slug>-<hash8>`),
+	// which is what `baseKeyOf.plan` / `.note` strip; a skill ref keeps its hash in
+	// `archivedKey` and leaves `skill` as the raw id. Stripping anyway silently
+	// truncated any id that happens to end in 8 hex characters, folding two distinct
+	// skills into one row here while `attachedBaseKeys.skill` below and `mergeSkillRefs`
+	// both kept them apart — three derivations of one key that have to agree.
 	const mergedSkills = mergeRefsNewWins(hoistedMeta.skills, newRefs?.skills, (s) => `${s.source}:${s.skill}`);
 	// Drop from the AI-exclude audit any item that is nonetheless ATTACHED to this
 	// summary via a hoisted (inherited) ref — otherwise the same item would appear
@@ -2683,9 +2805,9 @@ function buildHoistedAmendRoot(
 	// old snapshot is still hoisted. plans/notes skip committed guards upstream
 	// (detectActive*ForBranch), but we filter all three kinds for symmetry.
 	const attachedBaseKeys: Record<ExcludedContextItem["kind"], ReadonlySet<string>> = {
-		plan: new Set(mergedPlans.map((p) => p.slug.replace(REF_HASH_SUFFIX, ""))),
-		note: new Set(mergedNotes.map((n) => n.id.replace(REF_HASH_SUFFIX, ""))),
-		reference: new Set(mergedReferences.map((r) => `${r.source}:${r.nativeId}`)),
+		plan: new Set(mergedPlans.map((p) => baseKeyOf.plan(p))),
+		note: new Set(mergedNotes.map((n) => baseKeyOf.note(n))),
+		reference: new Set(mergedReferences.map((r) => baseKeyOf.reference(r))),
 		skill: new Set(mergedSkills.map((s) => `${s.source}:${s.skill}`)),
 	};
 	const auditedExclusions = (excludedContext ?? []).filter((e) => !attachedBaseKeys[e.kind].has(e.key));
@@ -4063,7 +4185,6 @@ export const __test__ = {
 	detectPlanSlugsFromRegistry,
 	detectUncommittedNoteIds,
 	hoistMetadataFromOldSummary,
-	mergeRefsNewWins,
 	buildHoistedAmendRoot,
 	consumeWorkspaceContext,
 	associatePlansWithCommit,
@@ -4072,6 +4193,7 @@ export const __test__ = {
 	executePipeline,
 	handleAmendPipeline,
 	handleSquashFromQueue,
+	handleRebaseSquashFromQueue,
 	loadSessionTranscripts,
 	attachPerSessionUsage,
 	appendUsageOnlyCarriers,

--- a/vscode/src/util/PlanGrouping.ts
+++ b/vscode/src/util/PlanGrouping.ts
@@ -11,6 +11,7 @@
  * push-to-Jolli path (latestPlanPerName) so the two never drift.
  */
 
+import { REF_HASH_SUFFIX } from "../../../cli/src/core/RefMerge.js";
 import type { PlanReference } from "../../../cli/src/Types.js";
 
 /** A plan plus its standing among its same-named siblings. */
@@ -26,9 +27,13 @@ export interface AnnotatedPlan {
  * Strips a trailing archived commit-hash suffix (`-<8 hex>`) to get the base
  * name. Committed snapshots (`refactor-auth-a1b2c3d4`) and an uncommitted base
  * (`refactor-auth`) collapse to the same key.
+ *
+ * Shares `REF_HASH_SUFFIX` with cli's `baseKeyOf.plan` / `planBaseKey` rather than
+ * re-spelling the pattern: this is the same base key the amend hoist dedupes by, and
+ * a drift would have the panel group snapshots the summary kept apart.
  */
 export function planBaseKey(slug: string): string {
-	return slug.replace(/-[0-9a-f]{8}$/, "");
+	return slug.replace(REF_HASH_SUFFIX, "");
 }
 
 /**

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -12,6 +12,7 @@
 import { labelLeadsWithNativeId, referenceDisplayTitle } from "../../../cli/src/core/references/ReferenceDisplay.js";
 import { getRegistry } from "../../../cli/src/core/references/SourceDefinitionRegistry.js";
 import { estimateModelCostUsd } from "../../../cli/src/core/Pricing.js";
+import { REF_HASH_SUFFIX } from "../../../cli/src/core/RefMerge.js";
 import { isSummaryError } from "../../../cli/src/core/SummaryErrorMarker.js";
 import {
 	aggregateConversationTokenBreakdown,
@@ -864,11 +865,6 @@ export interface ContextRelevanceDisplay {
 	readonly excluded?: ReadonlyArray<ExcludedContextItem>;
 }
 
-/** Archive suffix on committed plan slugs / note ids (`slug-<hash8>`). Relevance
- *  keys are working-area identities (pre-archive), so lookups try the exact key
- *  first, then this stripped form. Mirrors QueueWorker's REF_HASH_SUFFIX. */
-const ARCHIVE_HASH_SUFFIX = /-[0-9a-f]{8}$/;
-
 const TIER_LABEL = { high: "High", mid: "Med", low: "Low" } as const;
 const TIER_TIP = {
 	high: "High relevance to this change",
@@ -882,12 +878,17 @@ function buildRelevanceLookup(refs: ReadonlyArray<ContextRelevanceRef> | undefin
 	return map;
 }
 
+/** Relevance lookup for one archived ref: exact key first (covers unarchived or
+ *  naturally-hex-ending working keys), then the archive-suffix-stripped base.
+ *  `REF_HASH_SUFFIX` (from cli's RefMerge) is the archive suffix on committed plan
+ *  slugs / note ids (`slug-<hash8>`); relevance keys are working-area identities,
+ *  i.e. pre-archive, which is why the stripped form has to be tried at all. */
 function lookupRelevance(
 	map: ReadonlyMap<string, ContextRelevanceRef>,
 	kind: "plan" | "note" | "reference",
 	key: string,
 ): ContextRelevanceRef | undefined {
-	return map.get(`${kind}:${key}`) ?? map.get(`${kind}:${key.replace(ARCHIVE_HASH_SUFFIX, "")}`);
+	return map.get(`${kind}:${key}`) ?? map.get(`${kind}:${key.replace(REF_HASH_SUFFIX, "")}`);
 }
 
 /** Second meta line under a kept row's title: tier chip + the AI's one-line


### PR DESCRIPTION
## Problem

`runSquashPipeline` called only `reassociateMetadata`, which migrates the source summaries' *already-archived* refs onto the new hash. It never called `consumeWorkspaceContext`, so a plan, note or reference the user activated during the session that ended in a squash was never archived at all: the registry row stayed in the working area and the squash memory held no pointer to it.

Both squash routes share the pipeline, so both were affected — `git merge --squash` / the VS Code Squash button, and `rebase -i` squash/fixup.

## Change

- **Consume the working-area Context on the squash paths**, immediately before `mergeManyToOne`, and pass the just-associated refs through as `options.extraRefs`. The `collectChild*` helpers can only see refs carried by children, so without this the orphan-branch snapshots would have no summary pointer.
- **Placement is load-bearing.** `consumeWorkspaceContext` is write-ahead: it commits the orphan-branch snapshot, *then* tears down the local registry rows. Every `await` between it and the summary write is a window where a throw — an orphan write-lock timeout being the realistic one — strands a snapshot with neither a summary pointer nor a panel row. Consuming after the consolidation LLM keeps that window at one call, matching the amend full path. The same argument puts the consume *after* the squash path's existing skill archival rather than before it: `storeSkills` is another orphan write that can throw, and skills carry no equivalent window of their own — their registry rows are only migrated, never torn down.
- **Two dedupe keys, now named.** `mergeRefsNewWins` moves out of `QueueWorker` into `core/RefMerge`, alongside `baseKeyOf` (amend) and `snapshotKeyOf` (squash). Amend collapses the per-commit hash stamp so a revived guard re-archived under the new hash lists once — sound only because an amend root has exactly one old summary. A squash root hoists from N children, and two children can legitimately hold the same logical item at different commits (consult a ticket on commit 1, consult it again on commit 3); nothing on the squash path renames or deletes a child's snapshot, so both orphan-branch files outlive the squash and both need a pointer. Squash therefore keys by archived identity — the same key `collectChildPlans` / `collectChildNotes` / `collectChildReferences` already dedupe by.
- **Branch resolution degrades instead of throwing.** Consolidation itself needs no branch, and both enqueue hooks deliberately omit the field when their own read fails, so a failed live read now costs at most this commit's ref archival (the rows survive with a null `commitHash` and re-archive next commit) rather than the whole consolidated memory.
- `mergeManyToOne`'s four optional tail parameters become one options object, so callers no longer pass `undefined` placeholders and the tests no longer assert by argument position.
- Squash's orphan-branch archive commits are now labelled `squash` rather than `commit`.

## Intentionally unchanged

- **References keep no migration guard row.** They are deleted on commit and travel through `collectChildReferences`, so that half of the lifecycle was already correct.
- **`rebase-pick` still skips consumption.** It migrates hashes 1:1 for an existing commit rather than producing a new one, so there is no new commit to associate a working-area row with.
- **The amend paths' dedupe semantics.** They keep base keys; only the key extractor's *name* changed, not its behaviour.
- **`mergeRefsNewWins`' new-wins rule and in-place ordering.** A replaced ref keeps the old ref's position, so display order stays stable.
- **Skills' hoist union stays outside both key families.** The fourth artifact type landed on `main` ahead of this branch, and it deliberately needs neither key: `mergeSkillRefs` dedupes by `archivedKey` and then **accumulates** per skill, so the N-children case that forces `snapshotKeyOf` for plans/notes/references cannot strand anything here — two children holding the same skill sum into one row instead of competing for one slot. On the amend side the union keys the registry mapKey `<source>:<skill>` verbatim, which is why it is an inline key at the call site rather than a `baseKeyOf` member: a skill keeps its hash in `archivedKey`, not in the id, so there is no stamp to strip and stripping one anyway would fold two distinct skills into one row whenever an id ends in 8 hex characters. The only skill-touching edits here are mechanical: `extraSkills` moves from a tail parameter into the options object, and the amend-side union now passes that inline key to `mergeRefsNewWins` in its new `RefMerge` home.

## Testing

`npm run all` — `GATE_EXIT=0`:

| Tier | Result | Coverage (floor 97/96/97/97) |
|---|---|---|
| CLI unit | 344 files / 9205 tests | 98.74 / 96.49 / 98.79 / 99.02 |
| CLI acceptance | 5 files / 9 tests | — |
| vscode | 107 files / 4455 tests | 99.09 / 97.80 / 98.74 / 99.31 |

New coverage:

- A regression pin at the `mergeManyToOne` level: a squash whose two children each archived the same ticket, plus the squash's own snapshot, keeps all three `archivedKey` pointers in the summary written to the orphan branch. Base keys kept one.
- A guard on the key-family divergence itself — if `baseKeyOf` and `snapshotKeyOf` ever agree on the two-children input, the test above has stopped proving anything.
- Note archival on the squash path (plans and references were covered; notes were not).
- Branch-resolution failure: consolidation completes, no `extraRefs` are claimed, and nothing is archived.

