### PR TITLE
Anchor state dir to git worktree root via resolveStateRoot

### DIFF
--- a/cli/src/Cli.ts
+++ b/cli/src/Cli.ts
@@ -8,10 +8,11 @@
  */
 
 import { main } from "./Api.js";
+import { resolveProjectDir } from "./commands/CliUtils.js";
 import { shouldSkipExitFlush, trackCommandFailureIfPending } from "./core/TelemetryCommandHook.js";
 import { bootstrapTelemetry, flushTelemetryNow, maybeShowCliTelemetryNotice } from "./core/TelemetryStartup.js";
 import { runWithTrace, traceIdFromEnv } from "./core/TraceContext.js";
-import { setSilentConsole } from "./Logger.js";
+import { setLogDir, setSilentConsole } from "./Logger.js";
 
 // Auto-execute when run as a script (skip in test environment).
 /* v8 ignore start */
@@ -23,6 +24,11 @@ if (!process.env.VITEST) {
 	// callers of `main()` (e.g. embedders) don't pick up the global side
 	// effect by accident.
 	setSilentConsole(true);
+	// Anchor the Logger's global dir to the git worktree root before anything logs
+	// or buffers telemetry, so a CLI invocation from a subdirectory never writes
+	// debug.log / telemetry into a stray `.jolli/` there. `resolveProjectDir` is
+	// cached, so the per-command `--cwd` defaults reuse this same resolution.
+	setLogDir(resolveProjectDir());
 	// One trace per CLI invocation. Adopt JOLLI_TRACE_ID if a parent process set
 	// it, else mint a fresh id; all logs + outbound backend calls for this
 	// command share it.
@@ -36,7 +42,7 @@ if (!process.env.VITEST) {
 			// Then prime telemetry before command dispatch so the commander preAction
 			// auto-emit and any in-command track() calls have a live context. Never
 			// throws; the VITEST guard keeps it (and its installId mint) out of tests.
-			await bootstrapTelemetry({ cwd: process.cwd() });
+			await bootstrapTelemetry({ cwd: resolveProjectDir() });
 			let failed = false;
 			try {
 				await main();
@@ -56,7 +62,7 @@ if (!process.env.VITEST) {
 			// subcommand. Bounded timeout (not the flusher's 10s default) so a slow
 			// network can't stall the prompt; best-effort and never throws.
 			if (!shouldSkipExitFlush()) {
-				await flushTelemetryNow(process.cwd(), { timeoutMs: 2_000 });
+				await flushTelemetryNow(resolveProjectDir(), { timeoutMs: 2_000 });
 			}
 			if (failed) process.exit(1);
 		})(),

--- a/cli/src/commands/McpCommand.ts
+++ b/cli/src/commands/McpCommand.ts
@@ -8,6 +8,7 @@ import { SearchIndex } from "../core/SearchIndex.js";
 import { createStorage } from "../core/StorageFactory.js";
 import { setActiveStorage } from "../core/SummaryStore.js";
 import { startMcpServer } from "../mcp/McpServer.js";
+import { resolveProjectDir } from "./CliUtils.js";
 
 export function registerMcpCommand(program: Command): void {
 	program
@@ -15,7 +16,10 @@ export function registerMcpCommand(program: Command): void {
 		.description("Start the JolliMemory MCP server (stdio) for AI agents")
 		.option("--reindex", "Rebuild the local search index from source and exit")
 		.action(async (options: { reindex?: boolean }) => {
-			const cwd = process.cwd();
+			// Anchor to the git worktree root: an AI host may launch `jolli mcp` from
+			// a subdirectory, and this cwd drives storage / queue / telemetry for the
+			// whole (long-lived) server. See resolveStateRoot / resolveProjectDir.
+			const cwd = resolveProjectDir();
 			if (options.reindex) {
 				// Establish the configured backend before reading sources — mirrors
 				// startMcpServer. Without it, rebuild's reads fall through to the

--- a/cli/src/core/GitOps.stateRoot.realgit.test.ts
+++ b/cli/src/core/GitOps.stateRoot.realgit.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Real-git regression for `resolveStateRoot`.
+ *
+ * The unit tests in GitOps.test.ts mock `node:child_process`, so they prove the
+ * branching but not that the actual `git rev-parse --show-toplevel` invocation is
+ * correct. This file spawns REAL git against a throwaway repo to prove the
+ * end-to-end behavior the fix exists for: a subdirectory cwd resolves to the
+ * repo's worktree root, and a non-git directory falls back to the input verbatim.
+ *
+ * Deliberately NOT mocking child_process (own file, so the global mock in
+ * GitOps.test.ts does not apply). Git isolation (HOME / config) comes from the
+ * monorepo-wide test/gitEnv.ts wired into cli/vite.config.ts.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resetStateRootCache, resolveStateRoot } from "./GitOps.js";
+
+describe("resolveStateRoot (real git)", () => {
+	const created: string[] = [];
+
+	beforeEach(() => {
+		resetStateRootCache();
+	});
+
+	afterEach(() => {
+		for (const dir of created.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	function makeTempDir(): string {
+		const dir = mkdtempSync(join(tmpdir(), "jolli-stateroot-"));
+		created.push(dir);
+		return dir;
+	}
+
+	it("anchors a subdirectory to the git worktree root", () => {
+		const repo = makeTempDir();
+		execFileSync("git", ["init"], { cwd: repo, stdio: ["ignore", "ignore", "ignore"] });
+		const deep = join(repo, "sub", "deeper");
+		mkdirSync(deep, { recursive: true });
+
+		// Compare against git's own toplevel for the repo so path form (git emits
+		// forward slashes; on macOS the temp dir may be under a /private symlink)
+		// matches regardless of platform.
+		const expectedRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+			cwd: repo,
+			encoding: "utf-8",
+		}).trim();
+
+		expect(resolveStateRoot(deep)).toBe(expectedRoot);
+	});
+
+	it("falls back to the input path for a non-git directory", () => {
+		const plain = makeTempDir();
+		expect(resolveStateRoot(plain)).toBe(plain);
+	});
+});

--- a/cli/src/core/GitOps.test.ts
+++ b/cli/src/core/GitOps.test.ts
@@ -16,18 +16,22 @@ const NUL = "\x00";
  *   returns a fake ChildProcess with stdin/stdout/stderr EventEmitters.
  *   Results are queued with `mockSpawnSuccess` / `mockSpawnFailure`.
  */
-const { mockExecFileAsync, mockSpawn } = vi.hoisted(() => ({
+const { mockExecFileAsync, mockSpawn, mockExecFileSync } = vi.hoisted(() => ({
 	mockExecFileAsync: vi.fn(),
 	mockSpawn: vi.fn(),
+	mockExecFileSync: vi.fn(),
 }));
 
 vi.mock("node:util", () => ({
 	promisify: vi.fn(() => mockExecFileAsync),
 }));
 
+// `execFileSync` is required by `resolveStateRoot` (via execFileSyncHidden); the
+// other GitOps helpers use `execFile` (async) / `spawn`.
 vi.mock("node:child_process", () => ({
 	execFile: vi.fn(),
 	spawn: mockSpawn,
+	execFileSync: mockExecFileSync,
 }));
 
 // Suppress console output
@@ -62,7 +66,9 @@ import {
 	orphanBranchExists,
 	readFileFromBranch,
 	readOrigHead,
+	resetStateRootCache,
 	resolveGitHooksDir,
+	resolveStateRoot,
 	writeFileToBranch,
 	writeMultipleFilesToBranch,
 } from "./GitOps.js";
@@ -1724,6 +1730,62 @@ describe("GitOps", () => {
 			await expect(writeFileToBranch("branch", "summaries/abc.json", "{}", "Add")).rejects.toThrow(
 				"Unexpected ls-tree output",
 			);
+		});
+	});
+
+	describe("resolveStateRoot", () => {
+		beforeEach(() => {
+			mockExecFileSync.mockReset();
+			resetStateRootCache();
+		});
+
+		it("anchors a subdirectory to the git worktree root", () => {
+			mockExecFileSync.mockReturnValue("/repo/root\n");
+			expect(resolveStateRoot("/repo/root/sub/deeper")).toBe("/repo/root");
+		});
+
+		it("invokes `git rev-parse --show-toplevel` with the input as cwd", () => {
+			mockExecFileSync.mockReturnValue("/repo/root\n");
+			resolveStateRoot("/repo/root/sub");
+			expect(mockExecFileSync).toHaveBeenCalledWith(
+				"git",
+				["rev-parse", "--show-toplevel"],
+				expect.objectContaining({ cwd: "/repo/root/sub" }),
+			);
+		});
+
+		it("falls back to the input path when not a git repo (git throws)", () => {
+			mockExecFileSync.mockImplementation(() => {
+				throw new Error("fatal: not a git repository");
+			});
+			expect(resolveStateRoot("/tmp/plain-dir")).toBe("/tmp/plain-dir");
+		});
+
+		it("falls back to the input path when git prints nothing", () => {
+			mockExecFileSync.mockReturnValue("   \n");
+			expect(resolveStateRoot("/tmp/empty-out")).toBe("/tmp/empty-out");
+		});
+
+		it("memoizes per input — a repeated call spawns git only once", () => {
+			mockExecFileSync.mockReturnValue("/repo/root\n");
+			expect(resolveStateRoot("/repo/root/a")).toBe("/repo/root");
+			expect(resolveStateRoot("/repo/root/a")).toBe("/repo/root");
+			expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+		});
+
+		it("caches distinct inputs independently", () => {
+			mockExecFileSync.mockReturnValueOnce("/repo/one\n").mockReturnValueOnce("/repo/two\n");
+			expect(resolveStateRoot("/repo/one/x")).toBe("/repo/one");
+			expect(resolveStateRoot("/repo/two/y")).toBe("/repo/two");
+			expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+		});
+
+		it("resetStateRootCache forces re-resolution", () => {
+			mockExecFileSync.mockReturnValue("/repo/root\n");
+			resolveStateRoot("/repo/root/z");
+			resetStateRootCache();
+			resolveStateRoot("/repo/root/z");
+			expect(mockExecFileSync).toHaveBeenCalledTimes(2);
 		});
 	});
 });

--- a/cli/src/core/GitOps.ts
+++ b/cli/src/core/GitOps.ts
@@ -13,13 +13,64 @@ import { readFile, stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { createLogger } from "../Logger.js";
 import type { CommitInfo, DiffStats, FileWrite, GitCommandResult } from "../Types.js";
-import { execFileAsyncHidden, spawnHidden } from "../util/Subprocess.js";
+import { execFileAsyncHidden, execFileSyncHidden, spawnHidden } from "../util/Subprocess.js";
 
 const MAX_GIT_BUFFER_BYTES = 10 * 1024 * 1024; // 10MB
 /** NUL byte — used as entry separator in `git ls-tree -z` output. */
 const NUL = "\x00";
 
 const log = createLogger("GitOps");
+
+/** Memoized git-worktree-root cache, keyed by the candidate directory. */
+const _stateRootCache = new Map<string, string>();
+
+/** Test-only: clears the memo so cases don't leak resolved roots into each other. */
+export function resetStateRootCache(): void {
+	_stateRootCache.clear();
+}
+
+/**
+ * Anchors a project working directory to its git worktree root via
+ * `git rev-parse --show-toplevel`, memoized per input. Falls back to `cwd` on
+ * any failure (not a git repo, git missing).
+ *
+ * ONLY for project-cwd entry points whose cwd is implicit and may be a
+ * subdirectory — AI session hooks (payload cwd), CLI telemetry, the MCP server
+ * (`process.cwd()`). Without this, a session started from a subdirectory forks a
+ * second, independent `.jolli/` store there and its memory silently never joins
+ * the main one. NEVER call this on an explicit Memory Bank root (`kbRoot`): that
+ * path is already the exact target and must be used verbatim (see
+ * SearchIndex.resolveIndexDir / MultiRepoCompile), and rooting it would collapse
+ * multiple Memory Bank entries into an enclosing repo's `.jolli/`.
+ *
+ * `--show-toplevel` returns the *current worktree* root, so a `.claude/worktrees/*`
+ * checkout still resolves to its own root (no regression).
+ *
+ * Silent by design: successfully anchoring a subdir to its root is the correct
+ * path, and this runs (memoized) once per hook process, so a user-visible
+ * warning would repeat every process and pollute stderr (warn is never
+ * suppressed). Surfacing pre-existing stray stores to the user is a separate,
+ * marker-gated concern, not this function's job.
+ */
+export function resolveStateRoot(cwd: string): string {
+	const cached = _stateRootCache.get(cwd);
+	if (cached !== undefined) return cached;
+	let root = cwd;
+	try {
+		const out = execFileSyncHidden("git", ["rev-parse", "--show-toplevel"], {
+			cwd,
+			encoding: "utf-8",
+			// Capture git's stderr so a non-git cwd doesn't leak "fatal: not a git
+			// repository …" to the terminal; the throw is handled below.
+			stdio: ["ignore", "pipe", "pipe"],
+		}).trim();
+		if (out) root = out; // git prints the toplevel in forward-slash form on every platform
+	} catch {
+		// Not a git repo / git missing — keep the input path.
+	}
+	_stateRootCache.set(cwd, root);
+	return root;
+}
 
 /**
  * Executes a git command and returns the result.

--- a/cli/src/hooks/GeminiAfterAgentHook.test.ts
+++ b/cli/src/hooks/GeminiAfterAgentHook.test.ts
@@ -14,11 +14,21 @@ vi.mock("../core/TelemetryStartup.js", () => ({
 	flushTelemetryNow: vi.fn().mockResolvedValue(undefined),
 }));
 
+// Identity by default so the hook's git-root anchoring is deterministic and
+// spawns no git in-process (these tests use synthetic cwds); the real
+// resolveStateRoot is covered in GitOps.test.ts. A `vi.fn` so a test can override
+// it to assert the ROOT (not the raw subdir) is what feeds saveSession.
+vi.mock("../core/GitOps.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../core/GitOps.js")>()),
+	resolveStateRoot: vi.fn((cwd: string) => cwd),
+}));
+
 // Suppress console output
 vi.spyOn(console, "log").mockImplementation(() => {});
 vi.spyOn(console, "warn").mockImplementation(() => {});
 vi.spyOn(console, "error").mockImplementation(() => {});
 
+import { resolveStateRoot } from "../core/GitOps.js";
 import { saveSession } from "../core/SessionTracker.js";
 import { flushTelemetryNow } from "../core/TelemetryStartup.js";
 import { handleGeminiAfterAgentHook } from "./GeminiAfterAgentHook.js";
@@ -177,6 +187,27 @@ describe("GeminiAfterAgentHook", () => {
 			expect.objectContaining({ sessionId: "gemini-789" }),
 			"/claude/project",
 		);
+	});
+
+	it("anchors a subdirectory hookData.cwd to the git worktree root before saving", async () => {
+		// No env var → the payload cwd (a subdirectory) is anchored to the repo root.
+		vi.mocked(resolveStateRoot).mockReturnValueOnce("/repo/root");
+		mockStdin(JSON.stringify({ session_id: "g-sub", transcript_path: "/p", cwd: "/repo/root/backend" }));
+		captureStdout();
+		await handleGeminiAfterAgentHook();
+		expect(resolveStateRoot).toHaveBeenCalledWith("/repo/root/backend");
+		expect(saveSession).toHaveBeenCalledWith(expect.objectContaining({ sessionId: "g-sub" }), "/repo/root");
+	});
+
+	it("anchors a subdirectory GEMINI_PROJECT_DIR to the git worktree root", async () => {
+		// The env var itself can point at a subdirectory; it must be anchored too.
+		process.env.GEMINI_PROJECT_DIR = "/repo/root/backend";
+		vi.mocked(resolveStateRoot).mockReturnValueOnce("/repo/root");
+		mockStdin(JSON.stringify({ session_id: "g-env", transcript_path: "/p", cwd: "/ignored" }));
+		captureStdout();
+		await handleGeminiAfterAgentHook();
+		expect(resolveStateRoot).toHaveBeenCalledWith("/repo/root/backend");
+		expect(saveSession).toHaveBeenCalledWith(expect.objectContaining({ sessionId: "g-env" }), "/repo/root");
 	});
 
 	it("should write {} to stdout even on invalid JSON", async () => {

--- a/cli/src/hooks/GeminiAfterAgentHook.ts
+++ b/cli/src/hooks/GeminiAfterAgentHook.ts
@@ -20,6 +20,7 @@
 
 import { resolve as pathResolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveStateRoot } from "../core/GitOps.js";
 import { saveSession } from "../core/SessionTracker.js";
 import { flushTelemetryNow } from "../core/TelemetryStartup.js";
 import { createLogger, setLogDir } from "../Logger.js";
@@ -41,7 +42,11 @@ function writeStdout(): void {
  * Reads stdin, parses the hook payload, and saves session info with source="gemini".
  */
 export async function handleGeminiAfterAgentHook(): Promise<void> {
-	const envProjectDir = process.env.GEMINI_PROJECT_DIR ?? process.env.CLAUDE_PROJECT_DIR;
+	// Anchor to the git worktree root: the session cwd (env or, below, the hook
+	// payload) may be a subdirectory, which would otherwise fork a stray `.jolli/`
+	// store. See resolveStateRoot.
+	const envProjectDirRaw = process.env.GEMINI_PROJECT_DIR ?? process.env.CLAUDE_PROJECT_DIR;
+	const envProjectDir = envProjectDirRaw ? resolveStateRoot(envProjectDirRaw) : undefined;
 
 	// Set log directory early from env var (available before stdin parsing)
 	if (envProjectDir) {
@@ -73,8 +78,10 @@ export async function handleGeminiAfterAgentHook(): Promise<void> {
 		return;
 	}
 
-	// Use hookData.cwd as fallback when env var is not available
-	const projectDir = envProjectDir ?? hookData.cwd;
+	// Use hookData.cwd as fallback when env var is not available (also anchored).
+	// `?? process.cwd()` guards a payload that omits cwd (typed non-optional but
+	// JSON-sourced), matching SessionStartHook and the pre-fix behavior.
+	const projectDir = envProjectDir ?? resolveStateRoot(hookData.cwd ?? process.cwd());
 	if (!envProjectDir) {
 		setLogDir(projectDir);
 	}

--- a/cli/src/hooks/SessionStartHook.test.ts
+++ b/cli/src/hooks/SessionStartHook.test.ts
@@ -34,6 +34,11 @@ vi.mock("../core/SummaryStore.js", () => ({
 
 vi.mock("../core/GitOps.js", () => ({
 	readFileFromBranch: vi.fn(),
+	// Identity by default so the hook's git-root anchoring is deterministic and
+	// spawns no git in-process; the real resolveStateRoot is covered in
+	// GitOps.test.ts. A `vi.fn` so a test can override it to assert the ROOT (not
+	// the raw subdir) is what feeds setLogDir / the direct `.jolli/` joins.
+	resolveStateRoot: vi.fn((cwd: string) => cwd),
 }));
 
 vi.mock("../core/RepoProfile.js", () => ({
@@ -61,11 +66,13 @@ vi.mock("../Logger.js", () => ({
 
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { readFileFromBranch } from "../core/GitOps.js";
+import { readFileFromBranch, resolveStateRoot } from "../core/GitOps.js";
 import { readManualDisableFlag } from "../core/RepoProfile.js";
 import { loadConfig, saveConfig } from "../core/SessionTracker.js";
 import { getIndex } from "../core/SummaryStore.js";
 import { collectAllTopics } from "../core/SummaryTree.js";
+import { setLogDir } from "../Logger.js";
+import { readStdin } from "./HookUtils.js";
 
 const mockExecFileSync = vi.mocked(execFileSync);
 const mockGetIndex = vi.mocked(getIndex);
@@ -116,6 +123,18 @@ describe("SessionStartHook", () => {
 		mockReadFileFromBranch.mockResolvedValue(null);
 		mockExistsSync.mockReturnValue(false);
 		vi.mocked(readManualDisableFlag).mockResolvedValue(false);
+	});
+
+	it("anchors a subdirectory session cwd to the git worktree root", async () => {
+		// A session started from a subdirectory: resolveStateRoot maps it to the
+		// repo root. projectDir feeds setLogDir AND every direct `.jolli/` join in
+		// this hook (login marker, plans.json, briefing-cache), so anchoring it once
+		// keeps all of them out of a stray `<subdir>/.jolli/` store.
+		vi.mocked(readStdin).mockResolvedValueOnce(JSON.stringify({ cwd: "/repo/root/manager" }));
+		vi.mocked(resolveStateRoot).mockReturnValueOnce("/repo/root");
+		await main();
+		expect(resolveStateRoot).toHaveBeenCalledWith("/repo/root/manager");
+		expect(setLogDir).toHaveBeenCalledWith("/repo/root");
 	});
 
 	// ─── Skip conditions ────────────────────────────────────────────────────

--- a/cli/src/hooks/SessionStartHook.ts
+++ b/cli/src/hooks/SessionStartHook.ts
@@ -27,7 +27,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { dirname, join } from "node:path";
 import { isLocalAgentChild } from "../core/AgentReentry.js";
 import { resolveClientKind } from "../core/ClientHeader.js";
-import { readFileFromBranch } from "../core/GitOps.js";
+import { readFileFromBranch, resolveStateRoot } from "../core/GitOps.js";
 import { hasLlmCredentials } from "../core/LlmCredentials.js";
 import { readManualDisableFlag } from "../core/RepoProfile.js";
 import { loadConfig, normalizePlansRegistry, saveConfig } from "../core/SessionTracker.js";
@@ -246,7 +246,11 @@ export async function main(): Promise<void> {
 	try {
 		const input = await readStdin();
 		const { cwd } = JSON.parse(input) as { cwd?: string };
-		const projectDir = cwd ?? process.cwd();
+		// Anchor to the git worktree root: the session cwd may be a subdirectory,
+		// which would otherwise fork a stray `.jolli/` store (and this hook also
+		// writes briefing-cache / reads plans by joining `.jolli/` onto projectDir
+		// directly). See resolveStateRoot.
+		const projectDir = resolveStateRoot(cwd ?? process.cwd());
 		setLogDir(projectDir);
 
 		log.info("SessionStartHook invoked (cwd=%s)", projectDir);

--- a/cli/src/hooks/StopHook.test.ts
+++ b/cli/src/hooks/StopHook.test.ts
@@ -32,6 +32,15 @@ vi.mock("../core/TelemetryStartup.js", () => ({
 	flushTelemetryNow: vi.fn().mockResolvedValue(undefined),
 }));
 
+// Identity by default so the hook's git-root anchoring is deterministic and
+// spawns no git in-process (these tests use synthetic cwds like "/project"); the
+// real resolveStateRoot is covered in GitOps.test.ts. A `vi.fn` so a test can
+// override it to assert the ROOT (not the raw subdir) is what flows downstream.
+vi.mock("../core/GitOps.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../core/GitOps.js")>()),
+	resolveStateRoot: vi.fn((cwd: string) => cwd),
+}));
+
 // Mock Locks — these unit tests run with synthetic cwds (e.g. "/project"), so
 // the real per-worktree lock would create junk dirs off the drive root. Run the
 // plans.json RMW body inline; the lock contract is covered in Locks.test.ts.
@@ -85,6 +94,7 @@ vi.spyOn(console, "error").mockImplementation(() => {});
 import { createReadStream, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
+import { resolveStateRoot } from "../core/GitOps.js";
 import { readManualDisableFlag } from "../core/RepoProfile.js";
 import { extractReferencesFromTranscript } from "../core/references/ReferenceExtractor.js";
 import {
@@ -358,6 +368,45 @@ describe("StopHook", () => {
 				source: "claude",
 			}),
 			"/my/project",
+		);
+	});
+
+	it("anchors a subdirectory cwd to the git worktree root before saving the session", async () => {
+		// The session cwd is a subdirectory; resolveStateRoot maps it to the repo
+		// root. Without anchoring, the session would be written into a stray
+		// `<subdir>/.jolli/` store that never joins the main one.
+		vi.mocked(resolveStateRoot).mockReturnValueOnce("/repo/root");
+		mockStdin(
+			JSON.stringify({
+				session_id: "sub-dir-session",
+				transcript_path: "/home/user/.claude/projects/abc/session.jsonl",
+				cwd: "/repo/root/manager",
+			}),
+		);
+		await handleStopHook();
+		expect(resolveStateRoot).toHaveBeenCalledWith("/repo/root/manager");
+		expect(saveSession).toHaveBeenCalledWith(
+			expect.objectContaining({ sessionId: "sub-dir-session" }),
+			"/repo/root",
+		);
+	});
+
+	it("anchors a subdirectory CLAUDE_PROJECT_DIR to the git worktree root", async () => {
+		// The env var itself can point at a subdirectory; it must be anchored too.
+		process.env.CLAUDE_PROJECT_DIR = "/repo/root/manager";
+		vi.mocked(resolveStateRoot).mockReturnValueOnce("/repo/root");
+		mockStdin(
+			JSON.stringify({
+				session_id: "env-sub-session",
+				transcript_path: "/home/user/.claude/projects/abc/session.jsonl",
+				cwd: "/ignored",
+			}),
+		);
+		await handleStopHook();
+		expect(resolveStateRoot).toHaveBeenCalledWith("/repo/root/manager");
+		expect(saveSession).toHaveBeenCalledWith(
+			expect.objectContaining({ sessionId: "env-sub-session" }),
+			"/repo/root",
 		);
 	});
 

--- a/cli/src/hooks/StopHook.ts
+++ b/cli/src/hooks/StopHook.ts
@@ -29,6 +29,7 @@ import { existsSync } from "node:fs";
 import { join, resolve as pathResolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isLocalAgentChild } from "../core/AgentReentry.js";
+import { resolveStateRoot } from "../core/GitOps.js";
 import { scanPlansFrom } from "../core/plans/TranscriptPlanDiscovery.js";
 import { readManualDisableFlag } from "../core/RepoProfile.js";
 import { scanReferencesFrom } from "../core/references/TranscriptReferenceDiscovery.js";
@@ -60,7 +61,10 @@ export async function handleStopHook(): Promise<void> {
 		log.info("Stop hook skipped — running inside a jollimemory-spawned local agent");
 		return;
 	}
-	const envProjectDir = process.env.CLAUDE_PROJECT_DIR;
+	// Anchor to the git worktree root: the session cwd (env or, below, the hook
+	// payload) may be a subdirectory, which would otherwise fork a stray `.jolli/`
+	// store. See resolveStateRoot.
+	const envProjectDir = process.env.CLAUDE_PROJECT_DIR ? resolveStateRoot(process.env.CLAUDE_PROJECT_DIR) : undefined;
 
 	// Set log directory early from env var (available before stdin parsing)
 	if (envProjectDir) {
@@ -88,8 +92,10 @@ export async function handleStopHook(): Promise<void> {
 		return;
 	}
 
-	// Use hookData.cwd as fallback when env var is not available
-	const projectDir = envProjectDir ?? hookData.cwd;
+	// Use hookData.cwd as fallback when env var is not available (also anchored).
+	// `?? process.cwd()` guards a payload that omits cwd (typed non-optional but
+	// JSON-sourced), matching SessionStartHook and the pre-fix behavior.
+	const projectDir = envProjectDir ?? resolveStateRoot(hookData.cwd ?? process.cwd());
 	if (!envProjectDir) {
 		setLogDir(projectDir);
 	}

--- a/cli/src/mcp/McpServer.test.ts
+++ b/cli/src/mcp/McpServer.test.ts
@@ -88,6 +88,7 @@ import type { PlatformToolManifestEntry } from "../core/JolliMemoryPushClient.js
 import { createStorage } from "../core/StorageFactory.js";
 import { setActiveStorage } from "../core/SummaryStore.js";
 import { track } from "../core/Telemetry.js";
+import { getLogDir, resetLogDir } from "../Logger.js";
 import { dispatchTool, type PlatformToolClient, startMcpServer, TOOL_DEFINITIONS } from "./McpServer.js";
 import {
 	runBindSpace,
@@ -202,12 +203,18 @@ describe("startMcpServer", () => {
 		fetchManifestMock.mockReset();
 		invokePlatformToolMock.mockReset();
 		vi.mocked(track).mockClear();
+		// Clean baseline for the log-dir anchoring assertions below.
+		resetLogDir();
 	});
 
 	it("connects the stdio transport and registers two request handlers", async () => {
 		await startMcpServer("/repo");
 		expect(connectMock).toHaveBeenCalledTimes(1);
 		expect(capturedHandlers).toHaveLength(2);
+		// The server anchors the Logger's global dir to its (git-root) cwd so every
+		// tool-call log line lands in the repo's `.jolli/`, not a stray store under a
+		// subdirectory it was launched from.
+		expect(getLogDir()).toBe("/repo");
 	});
 
 	it("advertises the tools capability only when no menu is active", async () => {
@@ -376,6 +383,9 @@ describe("startMcpServer", () => {
 		expect(createStorage).not.toHaveBeenCalled();
 		expect(setActiveStorage).not.toHaveBeenCalled();
 		expect(connectMock).not.toHaveBeenCalled();
+		// Order invariant: setLogDir(cwd) must run AFTER this early return, so the
+		// throwaway temp cwd never becomes the global log dir.
+		expect(getLogDir()).toBeUndefined();
 	});
 });
 

--- a/cli/src/mcp/McpServer.ts
+++ b/cli/src/mcp/McpServer.ts
@@ -20,7 +20,7 @@ import { loadConfig } from "../core/SessionTracker.js";
 import { createStorage } from "../core/StorageFactory.js";
 import { setActiveStorage } from "../core/SummaryStore.js";
 import { track } from "../core/Telemetry.js";
-import { createLogger } from "../Logger.js";
+import { createLogger, setLogDir } from "../Logger.js";
 import type { JolliMemoryConfig } from "../Types.js";
 import {
 	buildJolliMenu,
@@ -237,6 +237,12 @@ export async function startMcpServer(cwd: string, deps: StartMcpServerDeps = {})
 		log.info("Local-agent child detected; skipping MCP server startup to avoid a spurious Memory Bank repo");
 		return;
 	}
+
+	// Anchor the Logger's global dir to this (already git-root-resolved) cwd so the
+	// long-lived server's debug.log — written on every tool call — lands in the
+	// repo's `.jolli/`, not a stray store under the subdirectory it was launched
+	// from. `cwd` is resolved by the `jolli mcp` command via resolveProjectDir.
+	setLogDir(cwd);
 
 	// Establish the configured storage backend up front. The tool handlers read
 	// through the store APIs without threading `storage`, so without this they'd

--- a/cli/vite.config.ts
+++ b/cli/vite.config.ts
@@ -109,6 +109,7 @@ const copyGraphAssets = {
 const SLOW_TEST_FILES = [
 	"src/backfill/CommitTargetIndex.test.ts",
 	"src/core/BranchCommitLister.test.ts",
+	"src/core/GitOps.stateRoot.realgit.test.ts",
 	"src/core/KBPathResolver.test.ts",
 	"src/core/Locks.test.ts",
 	"src/core/RepoProfile.test.ts",


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

When AI agent sessions or CLI commands ran from a subdirectory of a git repository, jollimemory would scatter its state — write locks, session data, telemetry queues, and memory indexes — across whichever directories each invocation happened to start in. Sessions from different directories maintained completely separate, incompatible stores, leaving them unable to coordinate write locks or share any memory history. Users who routinely ran commands from project subdirectories could accumulate many disconnected partial stores without any visible indication that their data was fragmented.

Five code paths that accept a working directory from the environment — the three AI session hooks, the CLI startup sequence, and the long-lived MCP server process — now resolve that directory to the enclosing git repository root before any state is written or read. A new internal helper handles this resolution for each of these paths and memoizes the result within each process invocation. Explicitly specified Memory Bank locations remain unaffected, preserving the distinct isolation that Memory Bank entries depend on.

---

## Topics (2)
<details>
<summary><strong>01 · Memory stores no longer scattered to whichever subdirectory a session started in</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When AI agent sessions or CLI commands ran from a subdirectory of a git repository, jollimemory created its state — write locks, memory indexes, telemetry queues, and session data — in that subdirectory rather than the repository root. Different invocations from different directories maintained separate, incompatible stores that could not coordinate with each other, silently breaking cross-session locking and making memory history inaccessible.

**💡 Decisions Behind the Code**

- **Why normalization happens at entry points rather than centrally**: The shared function that computes where state data is stored receives two fundamentally different kinds of directory paths — sometimes a "where did this session start" path that needs correcting, and sometimes a precise Memory Bank location that must be used exactly as given. Applying normalization inside that shared function would collapse Memory Bank entries from different locations into a single storage directory, breaking their isolation entirely. Limiting the fix to entry points that receive session-start directories leaves Memory Bank paths completely untouched.
- **Why the design reversed from a central fix to per-entry-point fixes**: The initial plan placed normalization inside the one central path-computation function, making it automatic for all callers. Multiple rounds of review with independent agents confirmed that the search index explicitly passes explicit Memory Bank root paths through the same function, making the "simpler" central approach a correctness bug rather than an improvement. The entry-point approach emerged as the only option that is both complete and safe after that reversal.
- **Why no per-process user-visible warning for subdirectory resolution**: Issuing a warning each time a subdirectory is normalized to the repo root would fire on every AI agent turn, as each turn spawns a fresh short-lived process. The result would be repeated terminal output throughout a session. Surfacing stray-store notifications to users is left to a separate, marker-file-based mechanism capable of genuinely firing only once across all processes.

**✅ What Was Implemented**

- Added `resolveStateRoot()` in `cli/src/core/GitOps.ts`: a memoized helper that runs `git rev-parse --show-toplevel` against any working directory to find the git worktree root, falling back silently to the input path if git is unavailable or the directory is not inside a repo. A companion `resetStateRootCache()` export is provided for test isolation.
- Applied anchoring at five entry points that receive untrusted "where did this run from" working directories: the three AI session hooks (`StopHook.ts`, `SessionStartHook.ts`, `GeminiAfterAgentHook.ts`) resolve both the environment-variable path and the hook payload cwd before any state is touched; the CLI bootstrap in `Cli.ts` anchors the global Logger directory and all telemetry paths; `McpCommand.ts` and `McpServer.ts` resolve the MCP server's cwd and anchor the Logger for the long-lived server process.
- Added behavioral anchoring tests proving subdirectory inputs are replaced by the repo root before session data or log directories are written, plus a real-git regression test (`GitOps.stateRoot.realgit.test.ts`) that initializes a throwaway repository and exercises actual `git rev-parse` end-to-end without mocking.

**📁 FILES**
- `cli/src/core/GitOps.ts`
- `cli/src/hooks/StopHook.ts`
- `cli/src/hooks/SessionStartHook.ts`
- `cli/src/hooks/GeminiAfterAgentHook.ts`
- `cli/src/Cli.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Phased plan drafted for retiring the legacy git-branch memory storage mechanism</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The tool has long written memory data to two places simultaneously: a hidden git branch and a local folder. The team needed a concrete plan to safely retire the git-branch copy entirely and operate from the folder alone, without losing anyone's existing memory history in the process.

**💡 Decisions Behind the Code**

- **Storage authority flip must be gated per repository on confirmed migration completion**: An earlier plan treated flipping which backend is authoritative as the first step and data migration as a later concern. Review confirmed that the write path constructs its storage provider unconditionally without checking folder completeness, so flipping before migration finishes would destroy the git branch as a rollback source on the very first write. The gate must strictly precede the flip, and must be enforced per repository individually.
- **Headless users require a migration trigger added to the post-commit background process**: Migration from the git branch to the folder is currently only triggered by IDE plugin startup or explicit sync commands. Users who work entirely through git commits and AI agent sessions never reach those triggers, leaving their history permanently un-migrated and making safe retirement unreachable for them. The post-commit background process — which runs for all users on every commit — is the only path guaranteed to cover this population.

**✅ What Was Implemented**

A planning document was written mapping all code paths that read from or write to the orphan branch (over 20 distinct write paths and 10+ read entry points across CLI commands, the IDE plugin, and the MCP server), plus 12 identified risk points. The plan was substantially revised after two independent review agents identified critical sequencing defects: flipping which backend is authoritative before verifying migration is complete would cause the very next write to overwrite the git branch — the intended rollback copy — with incomplete folder data. The final document restructures the work into four phases beginning with infrastructure prerequisites before any storage authority flip occurs.

**📋 Future Enhancements**

- Implement Phase 0 prerequisites: a per-repository storage mode switch that can be toggled at runtime (currently the mode cannot be changed via any user-facing command), and an automatic migration step in the post-commit background process for users who never open the IDE.
- Coordinate with the IntelliJ plugin team before stopping orphan-branch writes: the IntelliJ plugin falls back to reading the git branch when folder data is unavailable, and removing the branch without first coordinating that change would silently break IntelliJ users.

</blockquote>
</details>

---

*Generated by Jolli Memory · July 31, 2026 at 5:17 PM · via Local agent - Claude Code*
<!-- jollimemory-summary-end -->