### PR TITLE
Add local-agent-usable bridge action and force-register dist-paths in sandbox

### DIFF
--- a/cli/src/commands/IdeBridgeCommand.test.ts
+++ b/cli/src/commands/IdeBridgeCommand.test.ts
@@ -403,6 +403,14 @@ vi.mock("../core/TelemetryConsent.js", () => ({
 	shouldShowTelemetryNotice: vi.fn().mockReturnValue(false),
 }));
 
+vi.mock("../core/localagent/DetectAgents.js", () => ({
+	isLocalAgentUsable: vi.fn(),
+	// The override return value is opaque to the bridge — `isLocalAgentUsable`
+	// is the only thing that reads it, and this file mocks that too. A plain
+	// stub keeps the tests decoupled from the real config shape.
+	localAgentOverrideFrom: vi.fn().mockReturnValue(undefined),
+}));
+
 vi.mock("./CliUtils.js", async (importActual) => {
 	// Only readStdin needs to be stubbed (test scaffolding pipes raw JSON via
 	// runIdeBridgeAction, not via stdin). Every other export — including the
@@ -930,6 +938,76 @@ describe("runIdeBridgeAction — local-agent-tools", () => {
 			loginHint: meta.loginHint,
 		}));
 		expect(result.tools).toEqual(expected);
+	});
+});
+
+describe("runIdeBridgeAction — local-agent-usable", () => {
+	beforeEach(async () => {
+		const { isLocalAgentUsable } = await import("../core/localagent/DetectAgents.js");
+		vi.mocked(isLocalAgentUsable).mockReset();
+	});
+
+	it("throws loudly on an unknown tool id (allow-list contract)", async () => {
+		await expect(runIdeBridgeAction("local-agent-usable", "/r", { tool: "not-a-tool" })).rejects.toThrow(
+			/Unknown local agent tool "not-a-tool"/,
+		);
+	});
+
+	it("rejects prototype-chain keys — hasOwnProperty guards the allow-list", async () => {
+		// Prototype-chain keys ("toString", "__proto__", "constructor") are
+		// truthy under naive `LOCAL_AGENT_TOOLS[tool]` indexing but must fail
+		// the allow-list. Regression guard for the L6 finding.
+		await expect(runIdeBridgeAction("local-agent-usable", "/r", { tool: "toString" })).rejects.toThrow(
+			/Unknown local agent tool "toString"/,
+		);
+	});
+
+	it("passes through `isLocalAgentUsable` and returns { available: true }", async () => {
+		const { isLocalAgentUsable } = await import("../core/localagent/DetectAgents.js");
+		vi.mocked(isLocalAgentUsable).mockResolvedValue(true);
+		const result = await runIdeBridgeAction("local-agent-usable", "/r", {
+			tool: "claude-code",
+		});
+		expect(result).toEqual({ available: true });
+		expect(vi.mocked(isLocalAgentUsable)).toHaveBeenCalledWith("claude-code", {
+			override: undefined,
+		});
+	});
+
+	it("forwards a foreign-tool override verbatim — filtering is isLocalAgentUsable's job", async () => {
+		// The bridge must NOT drop a mismatched override on the caller's behalf:
+		// the tool/path pairing check lives inside `isLocalAgentUsable`
+		// (`opts.override?.tool === tool`), so what the bridge forwards must be
+		// the untouched value `localAgentOverrideFrom` returned. Without this
+		// test the default mock (`localAgentOverrideFrom → undefined`) used by
+		// every other case in this file would make a mistaken drop-in-the-bridge
+		// invisible.
+		const detect = await import("../core/localagent/DetectAgents.js");
+		const foreignOverride = { tool: "codex" as const, path: "/opt/codex" };
+		vi.mocked(detect.localAgentOverrideFrom).mockReturnValueOnce(foreignOverride);
+		vi.mocked(detect.isLocalAgentUsable).mockResolvedValue(false);
+		const result = await runIdeBridgeAction("local-agent-usable", "/r", {
+			tool: "claude-code",
+		});
+		// Bridge answers with whatever `isLocalAgentUsable` returned; the
+		// mismatched override doesn't change that.
+		expect(result).toEqual({ available: false });
+		// Critical assertion: the bridge forwarded the override verbatim.
+		expect(vi.mocked(detect.isLocalAgentUsable)).toHaveBeenCalledWith("claude-code", {
+			override: foreignOverride,
+		});
+	});
+
+	it("swallows a discovery throw and answers { available: false }", async () => {
+		// UI contract: "unknown ≡ not usable". A crashing detector must never
+		// leak to the caller as an unhandled promise rejection — the settings
+		// dialog would show a red banner instead of a clean "not found" line.
+		const { isLocalAgentUsable } = await import("../core/localagent/DetectAgents.js");
+		vi.mocked(isLocalAgentUsable).mockRejectedValue(new Error("detector crashed"));
+		const result = await runIdeBridgeAction("local-agent-usable", "/r", {
+			tool: "codex",
+		});
+		expect(result).toEqual({ available: false });
 	});
 });
 

--- a/cli/src/commands/IdeBridgeCommand.ts
+++ b/cli/src/commands/IdeBridgeCommand.ts
@@ -13,7 +13,7 @@ import { computeWatchTargets } from "../daemon/DaemonServer.js";
 import { DaemonWatcher } from "../daemon/DaemonWatcher.js";
 import { createLogger, setLogDir } from "../Logger.js";
 import type { ConflictUi, Tier3Pick } from "../sync/ConflictResolver.js";
-import type { FileWrite, JolliMemoryConfig, TranscriptSource } from "../Types.js";
+import type { FileWrite, JolliMemoryConfig, LocalAgentToolId, TranscriptSource } from "../Types.js";
 import { TRANSCRIPT_SOURCES as ALL_TRANSCRIPT_SOURCES } from "../Types.js";
 import { IDE_BRIDGE_STDIN_MAX_BYTES, readStdin } from "./CliUtils.js";
 
@@ -1060,6 +1060,47 @@ export async function runIdeBridgeAction(action: string, cwd: string, request: J
 					loginHint: meta.loginHint,
 				})),
 			};
+		}
+		case "local-agent-usable": {
+			// IntelliJ mirror of the VS Code webview's `probeLocalAgent`
+			// (see `handleProbeLocalAgent` in `SettingsWebviewPanel.ts`, which imports
+			// `isLocalAgentUsable` in-process because VS Code bundles the CLI). Kotlin
+			// cannot import the TS core, so it asks the same question over the bridge.
+			//
+			// `tool` is untrusted input and is allow-listed against LOCAL_AGENT_TOOLS
+			// before it reaches `isLocalAgentUsable`. An unknown id is a bug in the
+			// caller, not a user-visible outcome, so it fails loudly rather than
+			// silently reporting unavailable. Uses `getOwnPropertyDescriptor` — a
+			// plain index-truthy check would leak prototype keys (`toString`,
+			// `__proto__`, `constructor`) through the allow-list, and biome rejects
+			// `hasOwnProperty.call` while `Object.hasOwn` only lands in ES2022 (this
+			// project targets ES2020). Same pattern PluginLoader.ts uses.
+			//
+			// Every other failure mode (config unreadable, discovery throws) is caught
+			// and answered as `available: false`, matching the VS Code sibling — the
+			// UI contract is "unknown ≡ not usable" so the user is never blocked on an
+			// unanswered probe, and never told a tool works when we could not verify.
+			const rawTool = stringField(request, "tool");
+			const { LOCAL_AGENT_TOOLS } = await import("../core/localagent/ToolMeta.js");
+			if (Object.getOwnPropertyDescriptor(LOCAL_AGENT_TOOLS, rawTool) === undefined) {
+				throw new Error(`Unknown local agent tool "${rawTool}".`);
+			}
+			const tool = rawTool as LocalAgentToolId;
+			let available = false;
+			try {
+				// Tool-scoped override: `localAgentPath` belongs to the CONFIGURED tool,
+				// so probing the dropdown's current pick must NOT borrow it. See
+				// `localAgentOverrideFrom` for why the pairing is required.
+				const tracker = await import("../core/SessionTracker.js");
+				const config = await tracker.loadConfigFromDir(tracker.getGlobalConfigDir());
+				const { isLocalAgentUsable, localAgentOverrideFrom } = await import(
+					"../core/localagent/DetectAgents.js"
+				);
+				available = await isLocalAgentUsable(tool, { override: localAgentOverrideFrom(config) });
+			} catch (err) {
+				log.error("IdeBridge", `local-agent-usable probe failed for ${tool}: ${String(err)}`);
+			}
+			return { available };
 		}
 		case "folder-heal-visible-markdown": {
 			// Regenerates missing `<branch>/<slug>.md` files from their canonical

--- a/cli/src/core/skills/OpenCodeSkillDiscovery.test.ts
+++ b/cli/src/core/skills/OpenCodeSkillDiscovery.test.ts
@@ -14,6 +14,24 @@ vi.mock("../OpenCodeSessionDiscoverer.js", () => ({
 	getOpenCodeDbPath: () => dbPathRef.current,
 }));
 
+/**
+ * Isolate the developer's real `~/.jolli/jollimemory/config.json` from the run.
+ * `discoverOpenCodeSkills` short-circuits when `config.openCodeEnabled === false`,
+ * so a developer who disabled OpenCode locally (a valid preference) would
+ * silently see every test in this file return 0 without any tooling clue —
+ * the failure surface looks identical to a bug in the SQL / matcher paths.
+ * Preserve every other export via `importOriginal` because the test itself
+ * calls `loadPlansRegistry` and the discovery under test calls
+ * `upsertSkillEntry`, both real, on top of `SessionTracker`.
+ */
+vi.mock("../SessionTracker.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../SessionTracker.js")>();
+	return {
+		...actual,
+		loadConfig: vi.fn().mockResolvedValue({}),
+	};
+});
+
 const { discoverOpenCodeSkills } = await import("./OpenCodeSkillDiscovery.js");
 
 /** Builds a DB with OpenCode's real table shapes for `session`, `part` and `message`. */

--- a/cli/src/install/DistPathWriter.test.ts
+++ b/cli/src/install/DistPathWriter.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { installDistPath } from "./DistPathWriter.js";
 
@@ -127,5 +128,82 @@ describe("installDistPath — source-tag write-boundary guard", () => {
 		// complete dist — otherwise a single-source install would resolve to nothing.
 		expect(await installDistPath("claude-plugin", incomplete, "9.0.0", globalDir)).toBe(true);
 		expect(await readFile(join(globalDir, "dist-paths", "claude-plugin"), "utf-8")).toBe(`2.0.0\n${complete}`);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// REQUIRED_RUNTIME_FILES lockstep — three hand-maintained copies exist:
+//
+//   1. cli/src/install/DistPathWriter.ts — production source of truth,
+//      used by `isCompleteRuntimeDist` to gate every dist-paths write.
+//   2. intellij/scripts/run-sandbox.mjs — dev-only sandbox launcher's copy,
+//      used to assert the local build is complete before it stomps
+//      `dist-paths/{cli,intellij}`. Outside biome coverage AND outside
+//      `npm run all`, so drift is silent without a test.
+//   3. claude-plugin/plugins/jolli/scripts/build.mjs — plugin build's
+//      canonical entry set, checked at build time. Superset of the other
+//      two (adds `PluginBootstrapHook`, no `.js` extension), self-checked
+//      by its own build.mjs — so this test asserts the SUPERSET relation
+//      rather than exact equality.
+//
+// A single lockstep test here would have caught the exact class of drift
+// every other lockstep contract in this repo has a pin for
+// (LocalAgentToolsTest, skill fingerprints, …). Keeping the assertion at
+// the DistPathWriter site — the source of truth — because that's where
+// authors editing the array will look next.
+// ---------------------------------------------------------------------------
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+
+function extractStringArray(source: string, name: string): string[] {
+	// Match `const <name> = [ ... ]` up to the closing bracket. Trailing
+	// commas, mixed whitespace, and per-line comments are all fine — we
+	// only pluck the string literals out of the captured region.
+	const declaration = new RegExp(`const\\s+${name}\\s*=\\s*\\[([\\s\\S]*?)\\]`);
+	const match = source.match(declaration);
+	if (!match) throw new Error(`Could not find \`const ${name}\` array in source`);
+	const items: string[] = [];
+	// Non-greedy match on either quote style; matches only in-array string literals.
+	const literal = /"([^"]+)"|'([^']+)'/g;
+	let m: RegExpExecArray | null;
+	// biome-ignore lint/suspicious/noAssignInExpressions: standard exec-loop shape
+	while ((m = literal.exec(match[1] ?? "")) !== null) {
+		items.push(m[1] ?? m[2] ?? "");
+	}
+	return items;
+}
+
+describe("REQUIRED_RUNTIME_FILES — lockstep with sibling copies", () => {
+	it("matches run-sandbox.mjs's copy in name AND order", async () => {
+		const [writerSrc, sandboxSrc] = await Promise.all([
+			readFile(join(repoRoot, "cli", "src", "install", "DistPathWriter.ts"), "utf-8"),
+			readFile(join(repoRoot, "intellij", "scripts", "run-sandbox.mjs"), "utf-8"),
+		]);
+		const writerList = extractStringArray(writerSrc, "REQUIRED_RUNTIME_FILES");
+		const sandboxList = extractStringArray(sandboxSrc, "REQUIRED_RUNTIME_FILES");
+		// The completeness check in run-sandbox.mjs runs the same
+		// every-file-must-exist loop — a name/order drift silently allows
+		// through a dist that `installDistPath()` would later reject.
+		expect(sandboxList).toEqual(writerList);
+		// Sanity guard on our own local copy at the top of this file. If the
+		// production list ever grows/shrinks, the test-file copy powers the
+		// `completeDist(...)` fixtures below — its own regression would show
+		// up as unrelated tests failing, but this assertion pins it directly.
+		expect([...requiredRuntimeFiles]).toEqual(writerList);
+	});
+
+	it("is a subset of claude-plugin's entry set (plugin adds PluginBootstrapHook)", async () => {
+		const [writerSrc, buildSrc] = await Promise.all([
+			readFile(join(repoRoot, "cli", "src", "install", "DistPathWriter.ts"), "utf-8"),
+			readFile(join(repoRoot, "claude-plugin", "plugins", "jolli", "scripts", "build.mjs"), "utf-8"),
+		]);
+		const writerList = extractStringArray(writerSrc, "REQUIRED_RUNTIME_FILES");
+		const pluginList = extractStringArray(buildSrc, "EXPECTED_ENTRY_OUTS");
+		// build.mjs strips `.js` from each entry (`Cli.js` → `Cli`) and adds
+		// `PluginBootstrapHook` for the manifest-launched hook. Reconstruct
+		// the plugin's expected shape and assert the relation both ways so a
+		// removal on either side fails loudly.
+		const pluginExpected = new Set([...writerList.map((f) => f.replace(/\.js$/, "")), "PluginBootstrapHook"]);
+		expect(new Set(pluginList)).toEqual(pluginExpected);
 	});
 });

--- a/intellij/scripts/run-sandbox.mjs
+++ b/intellij/scripts/run-sandbox.mjs
@@ -2,7 +2,7 @@
  * Cross-platform launcher for the IntelliJ sandbox.
  *
  * Pipeline (each step logged with an `[intellij:sandbox]` prefix):
- *   1. Ensure npm deps — checks `node_modules/` at repo root; runs `npm install` only if missing
+ *   1. Ensure npm deps — checks `node_modules/` at repo root; runs `npm install` only if missing.
  *   2. Build — always runs `npm run build`. Gradle's `prepareSandbox` copies
  *      `vscode/dist/*.js` into the sandbox plugin's `cli-dist/`, so any change to
  *      `cli/src/**` or `vscode/src/**` must land in `vscode/dist/Cli.js` before launch
@@ -12,10 +12,22 @@
  *      `intellij/build/idea-sandbox/<ide>/` so every launch starts from a fresh sandbox
  *      IDE. Note this discards manually-installed plugins in the sandbox, keybindings,
  *      window layout, and the project index — first-launch indexing runs each time.
- *   4. Sync hooks — OPT-IN via `--sync-hooks`: copy `vscode/dist/*.js` (except Extension.js)
- *      to `~/.jolli/jollimemory/dist-intellij/` for local hook execution. Off by default
- *      because this writes to a machine-global path shared with the developer's other repos.
- *   5. Launch — `./gradlew runIde` (or `gradlew.bat runIde` on Windows)
+ *   4. Sync hooks — always copies `vscode/dist/*.js` (except Extension.js) to
+ *      `~/.jolli/jollimemory/dist-intellij/`. Used to be opt-in via `--sync-hooks`, but the
+ *      sandbox workflow is "rebuild → relaunch and see the change", and the plugin's
+ *      `integrationsUpToDate()` gate is keyed on `.version == pluginVersion`, so on
+ *      same-version relaunches the plugin skips `extractCliDist()` and the sandbox keeps
+ *      running last launch's Cli.js. Refreshing here decouples that from the version stamp.
+ *   5. Force-register dist-paths — always rewrites both
+ *      `~/.jolli/jollimemory/dist-paths/cli` and `~/.jolli/jollimemory/dist-paths/intellij`
+ *      to point at this repo's fresh build (version from `cli/package.json`). Reason: the
+ *      per-source dist-paths registry is what `run-hook`/`run-cli` and MCP resolve at
+ *      dispatch time; without an explicit rewrite, a stale `dist-paths/cli` on the machine
+ *      (from a global `@jolli.ai/cli` install, or an older sandbox run) can outrank this
+ *      repo's build at equal version — cli wins tie-break in `SOURCE_PREFERENCE_ORDER`.
+ *      Writing both entries every launch means "code changed → relaunch sandbox → sandbox
+ *      runs new code" holds without touching versions or stamps.
+ *   6. Launch — `./gradlew runIde` (or `gradlew.bat runIde` on Windows).
  *
  * Gradle dependency downloads (IntelliJ Platform SDK, Kotlin, etc.) are cached by Gradle
  * itself under `~/.gradle/caches/` — first `runIde` downloads, subsequent runs are instant.
@@ -25,7 +37,16 @@
  */
 
 import { spawn } from "node:child_process";
-import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -39,17 +60,17 @@ if (args.has("--help") || args.has("-h")) {
 	console.log(`
 Usage: node intellij/scripts/run-sandbox.mjs [flags]
 
-  --sync-hooks    After building, also copy hook scripts into
-                  ~/.jolli/jollimemory/dist-intellij/ (machine-global path).
   --help, -h      Show this message.
 
 The script always runs \`npm install\` (if node_modules/ is missing), then
 \`npm run build\`, wipes the sandbox IDE's config/system/log so every launch
-starts fresh, then \`gradlew runIde\`.
+starts fresh, unconditionally syncs hook scripts into
+\`~/.jolli/jollimemory/dist-intellij/\`, force-refreshes the
+\`~/.jolli/jollimemory/dist-paths/{cli,intellij}\` entries to point at this
+repo's build, then runs \`gradlew runIde\`.
 `);
 	process.exit(0);
 }
-const shouldSyncHooks = args.has("--sync-hooks");
 
 function log(msg) {
 	console.log(`[intellij:sandbox] ${msg}`);
@@ -110,7 +131,31 @@ function cleanSandboxCache() {
 	log(`Cleared ${removed} sandbox cache director${removed === 1 ? "y" : "ies"}.`);
 }
 
-function syncHooks() {
+// Mirrors REQUIRED_RUNTIME_FILES in cli/src/install/DistPathWriter.ts. Kept in
+// sync manually: if that list grows, this one must too, or the completeness
+// check below will allow-through a dist that `installDistPath()` would later
+// consider incomplete.
+const REQUIRED_RUNTIME_FILES = [
+	"Cli.js",
+	"StopHook.js",
+	"SessionStartHook.js",
+	"PostCommitHook.js",
+	"PostRewriteHook.js",
+	"PrepareMsgHook.js",
+	"PostMergeHook.js",
+	"PrePushHook.js",
+	"QueueWorker.js",
+	"PrePushWorker.js",
+];
+
+function assertCompleteDist(distDir, label) {
+	const missing = REQUIRED_RUNTIME_FILES.filter((f) => !existsSync(join(distDir, f)));
+	if (missing.length > 0) {
+		throw new Error(`${label} at ${distDir} is missing required runtime files: ${missing.join(", ")}`);
+	}
+}
+
+function syncIntellijDist() {
 	const source = join(repoRoot, "vscode", "dist");
 	const dest = join(homedir(), ".jolli", "jollimemory", "dist-intellij");
 	mkdirSync(dest, { recursive: true });
@@ -121,10 +166,137 @@ function syncHooks() {
 		copyFileSync(join(source, entry), join(dest, entry));
 		copied++;
 	}
-	if (!existsSync(join(dest, "PrePushWorker.js"))) {
-		throw new Error(`PrePushWorker.js missing after sync — build output looks incomplete.`);
-	}
+	assertCompleteDist(dest, "dist-intellij");
 	log(`Synced ${copied} hook script${copied === 1 ? "" : "s"} → ${dest}`);
+}
+
+function readCliVersion() {
+	const pkgPath = join(repoRoot, "cli", "package.json");
+	const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+	if (!pkg.version || typeof pkg.version !== "string") {
+		throw new Error(`Could not read version from ${pkgPath}`);
+	}
+	return pkg.version;
+}
+
+// Writes `~/.jolli/jollimemory/dist-paths/<sourceTag>` with the CLI's 2-line
+// format (version, then absolute dist path). Uses tmp+rename so a concurrent
+// reader — the run-hook shell script and the plugin can both parse it at any
+// moment — never sees a torn file. The tmp name is dot-prefixed so a crash
+// between write and rename leaves a hidden file that `resolve-dist-path`'s
+// `for f in "$DIR/dist-paths"/*` glob skips (POSIX sh globs exclude dotfiles
+// by default). This intentionally bypasses the CLI's `installDistPath()` and
+// its "keep existing complete dist" gate: the sandbox contract here is "the
+// current repo build is the source of truth for this launch, always overwrite".
+//
+// Deliberately NOT wrapped in `withRuntimeRegistryLock` — the machine-global
+// lock every `installDistPath()` caller holds — for two reasons:
+//
+//   1. Development-only entry point. This launcher runs interactively from a
+//      developer's terminal (`npm run intellij:sandbox`) and never fires from
+//      hooks, CI, postinstall, or any autonomous flow. In practice a developer
+//      is not running `jolli enable` or an `npm i` postinstall concurrently
+//      with a sandbox launch on the same box; the "concurrent writers to
+//      dist-paths/<sourceTag>" scenario the lock exists to defend against is
+//      not a real workload here.
+//   2. Pure overwrite, not read-modify-write. `installDistPath()` reads the
+//      existing entry to decide keep-or-overwrite by dist completeness, so it
+//      needs the lock to close a check-then-act race. This function makes no
+//      decision — it stomps unconditionally — so the only surviving race is
+//      "concurrent writers racing which value lands last", which for two
+//      developer-initiated writes is either indistinguishable (same content)
+//      or resolved by "last write wins" — both acceptable in a dev script.
+//
+// The tmp+rename write itself is still atomic, so a reader mid-launch always
+// sees either the old file or the new one — never a torn one. If a future
+// caller starts invoking this from a non-interactive path, the analysis above
+// no longer holds and the lock must be added.
+function writeDistPath(sourceTag, distDir, version) {
+	const distPathsDir = join(homedir(), ".jolli", "jollimemory", "dist-paths");
+	mkdirSync(distPathsDir, { recursive: true });
+	const target = join(distPathsDir, sourceTag);
+	const tmp = join(distPathsDir, `.${sourceTag}.tmp.${process.pid}`);
+	const payload = `${version}\n${distDir}`;
+	writeFileSync(tmp, payload);
+	try {
+		renameSync(tmp, target);
+	} catch (err) {
+		// Windows: rename can fail with EPERM/EACCES when the target is held open
+		// by antivirus, file watchers, etc. Same fallback pattern as the CLI's
+		// `atomicWriteFile` (cli/src/core/AtomicWrite.ts): overwrite the target
+		// directly and drop the tmp. Not fully atomic, but this is a dev-only
+		// launcher — an unlikely torn read still lands on the same 2-line format
+		// that the shell dispatchers already parse defensively.
+		if (err && (err.code === "EPERM" || err.code === "EACCES")) {
+			writeFileSync(target, payload);
+			rmSync(tmp, { force: true });
+		} else {
+			throw err;
+		}
+	}
+	log(`Wrote dist-paths/${sourceTag} → ${distDir} (version=${version})`);
+}
+
+// Sandbox contract: rewrites BOTH `dist-paths/cli` and `dist-paths/intellij`
+// on every launch. The `cli` overwrite is intentional and permanent — this
+// script deliberately does NOT snapshot-and-restore the previous entry:
+//
+//   1. Machine-global by design. `~/.jolli/jollimemory/dist-paths/` is one
+//      shared registry; every git hook, `run-cli`, `run-hook`, and MCP
+//      dispatch on this machine resolves through it. After this line, every
+//      repo on the machine will run through this worktree's `cli/dist/` — a
+//      global `@jolli.ai/cli` install's registration is destroyed in place.
+//      That is the intent: the sandbox has to outrank `cli` because the
+//      tie-break order in `SOURCE_PREFERENCE_ORDER` is `["cli","vscode","cursor"]`
+//      and any global `cli` install at the same version would otherwise win.
+//   2. No `process.on('exit')` restore. The plugin under test is expected to
+//      call the current-worktree `Cli.js` between sandbox runs (e.g. from
+//      the developer's real IDE while iterating), so "revert on exit" would
+//      defeat the purpose. Rolling back to a global `cli` install after the
+//      sandbox quits is done manually by re-running `npm install -g .` in
+//      that install's checkout, or by any other `installDistPath()` caller
+//      writing a higher version.
+//   3. Not lock-serialized. Skips `withRuntimeRegistryLock` (used by
+//      `installDistPath()` for read-modify-write) because this is a pure
+//      overwrite — no keep/overwrite decision is read. Concurrent
+//      `jolli enable` / `postinstall` running at the exact same moment could
+//      lose an update against this write; accepted because sandbox launches
+//      are developer-triggered and not colocated with those flows.
+//
+// This is by design — do not restore, do not lock, do not scope to `intellij`
+// only. If you are reviewing this and reaching for a "why is it clobbering
+// the global cli slot?" comment, the answer is above.
+function forceRegisterDistPaths() {
+	const version = readCliVersion();
+	const cliDist = join(repoRoot, "cli", "dist");
+	const intellijDist = join(homedir(), ".jolli", "jollimemory", "dist-intellij");
+	assertCompleteDist(cliDist, "cli/dist");
+	// dist-intellij is populated by the preceding syncIntellijDist() call; the
+	// assertion there already ran, but re-check to keep this function's contract
+	// self-contained (would surface a regression if the two steps ever drift).
+	assertCompleteDist(intellijDist, "dist-intellij");
+	// Surface what the machine-global `dist-paths/cli` entry pointed at before
+	// this write, so a developer whose non-sandbox `jolli` invocations later
+	// resolve to this worktree isn't left grepping logs to explain the drift.
+	// The write itself is intentional (see the block comment above
+	// `writeDistPath`); the log is defensive telemetry, not a change of
+	// contract — no revert, no lock, no scope narrowing.
+	logPreviousCliRegistration();
+	writeDistPath("cli", cliDist, version);
+	writeDistPath("intellij", intellijDist, version);
+}
+
+function logPreviousCliRegistration() {
+	const cliEntry = join(homedir(), ".jolli", "jollimemory", "dist-paths", "cli");
+	try {
+		const [prevVer, prevDir] = readFileSync(cliEntry, "utf-8").split("\n");
+		if (prevDir) log(`Overwriting machine-global dist-paths/cli (was ${prevVer} @ ${prevDir}).`);
+	} catch {
+		// Missing (ENOENT) / unreadable / torn — nothing to warn about. Skipping
+		// the existsSync pre-check on purpose: the try/catch already covers the
+		// missing case AND closes the TOCTOU window where a concurrent writer
+		// could delete the file between the check and the read.
+	}
 }
 
 async function runGradleSandbox() {
@@ -137,11 +309,8 @@ try {
 	await ensureNpmInstalled();
 	await runBuild();
 	cleanSandboxCache();
-	if (shouldSyncHooks) {
-		syncHooks();
-	} else {
-		log("Skipping hook sync (pass --sync-hooks to copy hooks into ~/.jolli/jollimemory/dist-intellij).");
-	}
+	syncIntellijDist();
+	forceRegisterDistPaths();
 	await runGradleSandbox();
 } catch (err) {
 	console.error(`[intellij:sandbox] FAILED: ${err.message}`);

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt
@@ -26,6 +26,7 @@ import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.openapi.util.Disposer
+import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBPasswordField
@@ -87,6 +88,63 @@ class SettingsDialog(
      * not the human label (`Codex`).
      */
     private var localAgentTools: List<LocalAgentToolOption> = LocalAgentTools.DEFAULT_TOOLS
+
+    /**
+     * Status line rendered under [localAgentToolCombo]. Mirrors the same line
+     * VS Code shows in its settings webview: empty while the selected tool
+     * probes clean, "Checking…" while a probe is in flight, and a red
+     * "<Tool> not found on this machine. Install it, or pick another tool."
+     * when the CLI's `local-agent-usable` bridge action reports the pick
+     * cannot run. Kept a JBLabel (not an inline error) so the layout height
+     * stays stable across states — a single space keeps a line's worth of
+     * vertical room reserved on first render.
+     */
+    private val localAgentStatusLabel = JBLabel(" ").apply {
+        alignmentX = JComponent.LEFT_ALIGNMENT
+    }
+
+    /**
+     * ID of the tool the most recent probe was fired for. The probe reply is
+     * discarded when this no longer matches — e.g. the user switched from
+     * Codex to Cursor before Codex's probe returned; without this guard the
+     * stale Codex verdict would overwrite the fresh Cursor "Checking…" line.
+     */
+    private var localAgentProbeTool: String? = null
+
+    /**
+     * Tri-state verdict: null = no evidence either way (initial state, probe in
+     * flight, OR probe landed on a permissively-unknown outcome — see the
+     * unknown-action / unknown-tool branches in [probeLocalAgentUsableAsync]);
+     * false = the last probe confirmed unavailable; true = confirmed usable.
+     *
+     * Both [doValidate] and [doOKAction] gate strictly on `== false`, so `null`
+     * is deliberately permissive at both chokepoints. This is the "we couldn't
+     * verify, don't block the user" contract — matches VS Code's `updateApplyBtn`
+     * where `localAgentBlocks()` is false while the probe result is null.
+     *
+     * "In flight" vs "landed as null" is distinguished by [localAgentProbeInFlight]
+     * — [awaitLocalAgentProbe] short-circuits when the latter is false so an
+     * unknown verdict can't leave the user stuck in an 8 s modal.
+     *
+     * @Volatile because [awaitLocalAgentProbe]'s modal-progress task polls this
+     * from a pooled thread while the probe's `invokeLater` writes it on the EDT.
+     * Volatile gives us cross-thread visibility without wrapping in an atomic.
+     */
+    @Volatile
+    private var localAgentAvailable: Boolean? = null
+
+    /**
+     * True from the moment [probeLocalAgentUsableAsync] hands work to the pool
+     * thread until its `invokeLater` reply lands (regardless of outcome). Lets
+     * [awaitLocalAgentProbe] tell "probe is genuinely running, worth waiting
+     * up to 8 s" apart from "no probe fired (early return) or already resolved"
+     * — both of the latter leave [localAgentAvailable] null, so waiting on
+     * that alone can't distinguish them.
+     *
+     * @Volatile for the same reason as [localAgentAvailable].
+     */
+    @Volatile
+    private var localAgentProbeInFlight: Boolean = false
     private val modelCombo = ComboBox(DefaultComboBoxModel(arrayOf(
         "haiku — fastest, cheapest",
         "sonnet — balanced (default)",
@@ -377,6 +435,10 @@ class SettingsDialog(
         // LOCAL_AGENT_TOOLS map via `refreshLocalAgentToolCombo`, so new backends
         // added to that map appear here automatically). Uses the tool's own
         // subscription sign-in, so no API key is collected here — mirrors the VS Code card.
+        //
+        // [localAgentStatusLabel] sits directly under the combo and carries the
+        // same "not found on this machine" line the VS Code webview shows when
+        // the selected tool cannot run.
         val localAgentContent = JPanel().apply {
             layout = BoxLayout(this, BoxLayout.Y_AXIS)
             alignmentX = JComponent.LEFT_ALIGNMENT
@@ -385,6 +447,8 @@ class SettingsDialog(
                 .addLabeledComponent(JBLabel("Agent tool:"), localAgentToolCombo, 1, false)
                 .addTooltip("Uses your local agent's own login (subscription). Sign in with the corresponding CLI if prompted.")
                 .panel))
+            add(Box.createVerticalStrut(4))
+            add(localAgentStatusLabel)
         }
 
         anthropicCardPanel.add(anthropicContent, CARD_ANTHROPIC)
@@ -399,7 +463,27 @@ class SettingsDialog(
         panel.add(advancedLink)
         panel.add(advancedPanel)
 
-        providerCombo.addItemListener { syncProviderCard() }
+        providerCombo.addItemListener {
+            syncProviderCard()
+            // Switching TO local-agent must re-verify the current pick (a stale
+            // "unavailable" verdict from a previous provider selection must not
+            // silently keep OK disabled, and a never-probed pick must not
+            // silently pass). Matches VS Code's aiProviderSelect change handler.
+            if (it.stateChange == java.awt.event.ItemEvent.SELECTED &&
+                providerCombo.selectedItem == PROVIDER_LOCAL_AGENT
+            ) {
+                probeLocalAgentUsableAsync()
+            }
+        }
+        // Tool-combo edits trigger a fresh probe so the status line follows the
+        // dropdown. Guarded on SELECTED so we don't fire twice per user click.
+        localAgentToolCombo.addItemListener {
+            if (it.stateChange == java.awt.event.ItemEvent.SELECTED &&
+                providerCombo.selectedItem == PROVIDER_LOCAL_AGENT
+            ) {
+                probeLocalAgentUsableAsync()
+            }
+        }
 
         return wrapTabContent(panel)
     }
@@ -762,6 +846,19 @@ class SettingsDialog(
             }
         } else if (provider == "Jolli" && !JolliAuthService.isSignedIn()) {
             return ValidationInfo("Sign in to Jolli first to use it as AI provider", providerCombo)
+        } else if (provider == PROVIDER_LOCAL_AGENT && localAgentAvailable == false) {
+            // Only a confirmed-unavailable verdict blocks Apply — the null state
+            // (probe still in flight, or never fired) is deliberately permissive
+            // so the user can commit their pick without waiting on the daemon.
+            // Matches VS Code's `updateApplyBtn`, whose `localAgentBlocks()` is
+            // false while the probe result is null.
+            val toolLabel = currentSelectedLocalAgentToolId()
+                ?.let { toolId -> localAgentTools.firstOrNull { it.id == toolId }?.label ?: toolId }
+                ?: "The selected tool"
+            return ValidationInfo(
+                "$toolLabel not found on this machine. Install it, or pick another tool.",
+                localAgentToolCombo,
+            )
         }
 
         val maxTokensText = maxTokensField.text.trim()
@@ -783,6 +880,33 @@ class SettingsDialog(
     }
 
     override fun doOKAction() {
+        // Hold OK when a local-agent probe is still in flight. Mirrors VS Code's
+        // `pendingApply` mechanism (SettingsScriptBuilder.ts:672–698) — without
+        // it, a click landing in the ~500 ms – 2 s daemon cold-spawn window
+        // would save `aiProvider=local-agent` against a tool that nobody has
+        // verified. [doValidate] blocks a CONFIRMED unavailable pick but
+        // deliberately lets `null` (checking…) through so OK doesn't gray out
+        // mid-probe; this is the second gate at the actual save chokepoint.
+        if (providerCombo.selectedItem == PROVIDER_LOCAL_AGENT && localAgentAvailable == null) {
+            if (!awaitLocalAgentProbe()) {
+                // Watchdog fired or user canceled the modal — do NOT persist.
+                // Show the same wording VS Code shows on `pendingApplyTimer`
+                // (SettingsScriptBuilder.ts:689) so the two UIs read the same.
+                val toolLabel = currentSelectedLocalAgentToolId()
+                    ?.let { id -> localAgentTools.firstOrNull { it.id == id }?.label ?: id }
+                    ?: "the selected tool"
+                localAgentStatusLabel.text =
+                    "Couldn't verify $toolLabel — nothing was saved. Click Apply to try again."
+                localAgentStatusLabel.foreground = JBColor.RED
+                return
+            }
+            // Verdict landed during the wait. `false` will surface as a red
+            // ValidationInfo through the alarm the probe's `invokeLater`
+            // scheduled — return without calling super so the dialog stays
+            // open. `true` falls through to the regular save below.
+            if (localAgentAvailable == false) return
+        }
+
         val provider = when (providerCombo.selectedItem as String) {
             "Anthropic" -> "anthropic"
             PROVIDER_LOCAL_AGENT -> "local-agent"
@@ -1223,6 +1347,15 @@ class SettingsDialog(
                 localAgentTools = tools
                 localAgentToolCombo.model = DefaultComboBoxModel(tools.map { it.label }.toTypedArray())
                 applyLocalAgentSelection(tools, currentId)
+                // Fire a probe once the combo lands on its persisted selection.
+                // The [localAgentToolCombo] itemListener already probes on user
+                // clicks, but assigning the same index it currently holds is a
+                // no-op for the listener, so an already-selected tool would
+                // never verify itself. Only when local-agent is the active
+                // provider — no point probing a card the user cannot see.
+                if (providerCombo.selectedItem == PROVIDER_LOCAL_AGENT) {
+                    probeLocalAgentUsableAsync()
+                }
             }
         }
     }
@@ -1230,6 +1363,226 @@ class SettingsDialog(
     /** Selects the combo row whose tool id matches [currentId], else the first. */
     private fun applyLocalAgentSelection(tools: List<LocalAgentToolOption>, currentId: String) {
         localAgentToolCombo.selectedIndex = tools.indexOfFirst { it.id == currentId }.takeIf { it >= 0 } ?: 0
+    }
+
+    /**
+     * Verifies the currently-selected agent tool actually runs on this machine
+     * by asking the CLI over the `local-agent-usable` ide-bridge action.
+     * Mirrors VS Code's `probeLocalAgent` (`SettingsScriptBuilder.ts`) — the
+     * same UX shows the same wording, and [doValidate] blocks Apply while an
+     * unavailable pick is selected.
+     *
+     * Off-EDT because the daemon fast path is ~5-20 ms but the one-shot spawn
+     * fallback can hit hundreds of milliseconds; the dialog is already visible
+     * and IntelliJ's slow-EDT floor is 300 ms, so the wait must not block.
+     *
+     * Stale-reply guard: [localAgentProbeTool] pins the id the current probe
+     * was fired for. When the invokeLater lands it drops the verdict if the
+     * user has since switched off this tool, so a slow Codex answer cannot
+     * overwrite a fresh Cursor "Checking…" line.
+     */
+    private fun probeLocalAgentUsableAsync() {
+        val tool = currentSelectedLocalAgentToolId() ?: return
+        // Coalesce redundant probes for the SAME tool. On dialog open, three
+        // triggers can fire in ~ms succession for a saved local-agent config:
+        // the providerCombo item listener (populateFields sets it → SELECTED),
+        // the localAgentToolCombo item listener (applyLocalAgentSelection sets
+        // it → SELECTED, when savedId ≠ ctor-default claude-code), and
+        // refreshLocalAgentToolCombo's trailing explicit call. Without this
+        // guard the same tool gets probed 2-3 times per open, and on a machine
+        // with a cold daemon each probe is one node cold-start.
+        //
+        // Skip when the same tool is either still in flight OR already carries
+        // a verdict — the FIRST caller does the work and later callers reuse
+        // its result. `probeTool != tool` (user picked a different tool)
+        // always falls through and re-probes. Overrides don't change during
+        // the dialog's lifetime (`localAgentPath` is edited only at save), so
+        // a settled verdict for `tool` remains accurate until the pick moves.
+        if (localAgentProbeTool == tool && (localAgentProbeInFlight || localAgentAvailable != null)) {
+            return
+        }
+        // Resolve the repo root BEFORE mutating any UI — otherwise a null
+        // `mainRepoRoot` (no worktree open) would leave the status label
+        // stuck on "Checking…" forever.
+        val projectDir = service.mainRepoRoot ?: project.basePath ?: return
+        localAgentProbeTool = tool
+        localAgentAvailable = null
+        localAgentProbeInFlight = true
+        localAgentStatusLabel.text = "Checking…"
+        localAgentStatusLabel.foreground = JBColor.foreground()
+        // Refresh the OK button through DialogWrapper's validation pass so the
+        // "Checking…" state doesn't inherit a stale ValidationInfo from before.
+        initValidation()
+        ApplicationManager.getApplication().executeOnPooledThread {
+            // `Boolean?` return: null means "we couldn't verify — do not claim
+            // either verdict, be permissive downstream". See the catch below.
+            val available: Boolean? = try {
+                val body = JsonObject().apply { addProperty("tool", tool) }
+                val res = CliIntegrations.runIdeBridge(projectDir, "local-agent-usable", body.toString())
+                val obj = res.takeIf { it.isJsonObject }?.asJsonObject
+                obj?.get("available")
+                    ?.takeIf { it.isJsonPrimitive && it.asJsonPrimitive.isBoolean }
+                    ?.asBoolean
+                    // Malformed reply: treat as unavailable — the "unknown ≡ not
+                    // usable" contract matches the CLI-side catch below and
+                    // VS Code's `handleProbeLocalAgent`. See the bridge action.
+                    ?: run {
+                        LOG.warn("local-agent-usable returned a malformed reply ($res)")
+                        false
+                    }
+            } catch (e: com.intellij.openapi.progress.ProcessCanceledException) {
+                // IntelliJ contract: PCE must never be swallowed by a generic
+                // Exception catch. Propagate so the pool-thread task unwinds
+                // cleanly on cancel.
+                throw e
+            } catch (e: Exception) {
+                val msg = e.message.orEmpty()
+                when {
+                    // Old CLI without this PR — the `local-agent-usable` action
+                    // was added in the same change as this Kotlin caller.
+                    // Users on a stale global `@jolli.ai/cli` install (that
+                    // outranks the plugin's own bundle via `cli` tie-break in
+                    // SOURCE_PREFERENCE_ORDER) hit this path. Reporting the
+                    // tool as "not found on this machine" would misdirect the
+                    // user: the tool may be perfectly installed — the CLI
+                    // just doesn't yet know how to answer. Return null and
+                    // let the caller be permissive.
+                    "Unknown IDE bridge action" in msg -> {
+                        LOG.info(
+                            "local-agent-usable: resolved CLI predates this action; " +
+                                "treating $tool as unknown/permissive"
+                        )
+                        null
+                    }
+                    // Kotlin's LocalAgentTools.DEFAULT_TOOLS mirror is ahead of
+                    // the resolved CLI's LOCAL_AGENT_TOOLS map. The CLI raises
+                    // this loudly by design — it's a caller bug worth ERROR
+                    // level for us — but the user cannot act on it and it is
+                    // NOT a fact about their environment, so still permissive.
+                    "Unknown local agent tool" in msg -> {
+                        LOG.error(
+                            "local-agent-usable: CLI does not recognize tool id \"$tool\" " +
+                                "(Kotlin DEFAULT_TOOLS / CLI LOCAL_AGENT_TOOLS drift?)",
+                            e,
+                        )
+                        null
+                    }
+                    // Everything else (config unreadable, discovery threw, IO
+                    // error) keeps the "unknown ≡ not usable" contract — same
+                    // as the CLI's own catch and the VS Code sibling.
+                    else -> {
+                        LOG.warn("local-agent-usable probe failed for $tool", e)
+                        false
+                    }
+                }
+            }
+            SwingUtilities.invokeLater {
+                // Drop when the dialog was closed (Cancel / window close) while
+                // the probe was in flight. `initValidation()` on a disposed
+                // DialogWrapper is a documented no-op, but skipping the whole
+                // body keeps us from touching the label at all.
+                if (isDisposed) return@invokeLater
+                // Drop the stale reply if the user has since switched off this tool.
+                if (localAgentProbeTool != tool) return@invokeLater
+                // Write order is load-bearing: `available` MUST be set before
+                // `probeInFlight` flips to false. [awaitProbeSettlement] polls
+                // `probeInFlight` first and returns as soon as it reads false;
+                // [doOKAction] then reads `available`. Both fields are @Volatile,
+                // so the volatile happens-before guarantees that a reader
+                // observing `probeInFlight = false` also sees the fresh write to
+                // `available`. Reversing these two lines opens a window where
+                // the reader sees a settled probe but stale `available`.
+                localAgentAvailable = available
+                localAgentProbeInFlight = false
+                when (available) {
+                    // Confirmed usable OR permissive-unknown: keep the status
+                    // line empty. Rendering red text for `null` would be a
+                    // factual lie ("not found on this machine") when we in
+                    // fact have no evidence of any such condition.
+                    true, null -> {
+                        localAgentStatusLabel.text = " "
+                        localAgentStatusLabel.foreground = JBColor.foreground()
+                    }
+                    false -> {
+                        val label = localAgentTools.firstOrNull { it.id == tool }?.label ?: tool
+                        localAgentStatusLabel.text =
+                            "$label not found on this machine. Install it, or pick another tool."
+                        localAgentStatusLabel.foreground = JBColor.RED
+                    }
+                }
+                initValidation()
+            }
+        }
+    }
+
+    /**
+     * Blocks OK with a cancelable modal progress until the in-flight probe
+     * returns or the 8 s watchdog trips — the same 8 s VS Code's
+     * `pendingApplyTimer` arms (SettingsScriptBuilder.ts:685). Returns true
+     * when a verdict landed inside the window OR when no probe is in flight
+     * to wait for; false on cancel or timeout.
+     *
+     * The no-in-flight fast path exists because `localAgentAvailable == null`
+     * (the state that got us here from [doOKAction]) has three sources:
+     *   1. Probe genuinely running — wait for it.
+     *   2. Probe never fired — [probeLocalAgentUsableAsync] can early-return
+     *      when there is no project root, or [refreshLocalAgentToolCombo]'s
+     *      up-stack guard swallowed the trigger.
+     *   3. Probe already landed on a permissive-unknown outcome — the
+     *      unknown-action / unknown-tool branches in
+     *      [probeLocalAgentUsableAsync] write `available = null`.
+     * (2) and (3) both leave [localAgentProbeInFlight] false, so waiting
+     * 8 s can only ever time out — the user then sees "Couldn't verify …"
+     * with no way to self-heal short of jiggling the combo. Short-circuit
+     * them to true here so the save proceeds — matches the "null is
+     * permissive" contract already used by [doValidate].
+     *
+     * Does NOT relaunch a probe. The pool-thread task from
+     * [probeLocalAgentUsableAsync] runs on independently; its
+     * `SwingUtilities.invokeLater` reply pumps while the modal is up, so
+     * [localAgentProbeInFlight] flips on the EDT. The polling task here
+     * runs on a separate pooled thread, so both @Volatile fields it reads
+     * ([localAgentProbeInFlight] and [localAgentAvailable]) must be
+     * @Volatile to make the EDT writes visible across threads.
+     */
+    private fun awaitLocalAgentProbe(): Boolean {
+        val toolId = currentSelectedLocalAgentToolId() ?: return true
+        if (!localAgentProbeInFlight) return true
+        val toolLabel = localAgentTools.firstOrNull { it.id == toolId }?.label ?: toolId
+        val landed = java.util.concurrent.atomic.AtomicBoolean(false)
+        try {
+            ProgressManager.getInstance().runProcessWithProgressSynchronously({
+                val indicator = ProgressManager.getInstance().progressIndicator
+                // Poll body lives in [awaitProbeSettlement], a top-level pure function
+                // so it can be unit-tested without spinning up IntelliJ's progress
+                // subsystem. See LocalAgentProbePollTest.
+                landed.set(
+                    awaitProbeSettlement(
+                        now = { System.currentTimeMillis() },
+                        sleepMillis = { ms -> Thread.sleep(ms) },
+                        inFlight = { localAgentProbeInFlight },
+                        isCanceled = { indicator?.isCanceled == true },
+                        deadlineMillis = 8000L,
+                    ),
+                )
+            }, "Checking $toolLabel…", true, project)
+        } catch (e: com.intellij.openapi.progress.ProcessCanceledException) {
+            // User canceled the modal — leave `landed` false so doOKAction
+            // reports "nothing was saved" and the dialog stays open.
+        }
+        return landed.get()
+    }
+
+    /**
+     * The id (e.g. `codex`) of the tool the combo currently displays. Returns
+     * null when the combo has no valid selection (should not happen once
+     * [refreshLocalAgentToolCombo] has landed, but the probe guards on this so
+     * an intermediate state never fires a bogus `local-agent-usable` request).
+     */
+    private fun currentSelectedLocalAgentToolId(): String? {
+        val idx = localAgentToolCombo.selectedIndex
+        if (idx < 0 || idx >= localAgentTools.size) return null
+        return localAgentTools[idx].id
     }
 
     private fun populateFields(config: JolliMemoryConfig) {
@@ -1428,4 +1781,38 @@ class SettingsDialog(
         private const val CARD_SYNC_NOKEY = "card.sync.nokey"
         private const val CARD_SYNC_SIGNEDIN = "card.sync.in"
     }
+}
+
+/**
+ * Pure poll loop that awaits an async probe reply. Extracted from
+ * [SettingsDialog.awaitLocalAgentProbe] so its "wait until settled OR deadline
+ * OR cancel" semantics can be unit-tested without the IntelliJ progress
+ * subsystem — every side-effecting dependency (clock, sleep, in-flight flag,
+ * cancel signal) is injected as a lambda, and the function itself has no
+ * global state.
+ *
+ * Returns `true` when [inFlight] is observed as false inside the window;
+ * `false` on deadline or when [isCanceled] reads true. The function body itself
+ * never throws — but it does not catch exceptions from the injected lambdas.
+ * In production `sleepMillis = { Thread.sleep(it) }`, which throws
+ * `InterruptedException` if the thread is interrupted; IntelliJ's cancellation
+ * goes through the polled [isCanceled] rather than an interrupt, so this is
+ * theoretical, but callers must not assume settlement on any exceptional exit.
+ *
+ * The [pollIntervalMillis] default matches what the production caller uses.
+ */
+internal fun awaitProbeSettlement(
+    now: () -> Long,
+    sleepMillis: (Long) -> Unit,
+    inFlight: () -> Boolean,
+    isCanceled: () -> Boolean,
+    deadlineMillis: Long,
+    pollIntervalMillis: Long = 50L,
+): Boolean {
+    val deadline = now() + deadlineMillis
+    while (now() < deadline && !isCanceled()) {
+        if (!inFlight()) return true
+        sleepMillis(pollIntervalMillis)
+    }
+    return false
 }

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/LocalAgentProbePollTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/LocalAgentProbePollTest.kt
@@ -1,0 +1,121 @@
+package ai.jolli.jollimemory.toolwindow
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [awaitProbeSettlement], the pure poll loop extracted from
+ * [SettingsDialog.awaitLocalAgentProbe]. Every side-effecting dependency
+ * is injected, so the tests drive time and the in-flight flag directly —
+ * no Swing, no IntelliJ progress subsystem, no real sleep.
+ *
+ * Guards the production contract:
+ *   - Returns true as soon as inFlight() flips to false.
+ *   - Returns false at deadline.
+ *   - Returns false when isCanceled() reads true (short-circuits the wait).
+ *   - Never sleeps past the deadline.
+ */
+class LocalAgentProbePollTest {
+
+	@Test
+	fun `returns true when inFlight flips to false before deadline`() {
+		val clock = FakeClock(start = 1_000L)
+		var callsBeforeSettled = 3
+		val sleeps = mutableListOf<Long>()
+		val landed = awaitProbeSettlement(
+			now = clock::now,
+			sleepMillis = { ms -> sleeps.add(ms); clock.advance(ms) },
+			inFlight = { --callsBeforeSettled > 0 },
+			isCanceled = { false },
+			deadlineMillis = 8_000L,
+		)
+		landed shouldBe true
+		// 2 sleeps expected: initial check returns true (in-flight), sleep,
+		// second check returns true (in-flight), sleep, third check returns
+		// false → landed. Contract: never sleeps once the settlement is
+		// observed.
+		sleeps shouldBe listOf(50L, 50L)
+	}
+
+	@Test
+	fun `returns false when deadline elapses`() {
+		val clock = FakeClock(start = 0L)
+		val sleeps = mutableListOf<Long>()
+		val landed = awaitProbeSettlement(
+			now = clock::now,
+			sleepMillis = { ms -> sleeps.add(ms); clock.advance(ms) },
+			inFlight = { true },
+			isCanceled = { false },
+			deadlineMillis = 200L,
+			pollIntervalMillis = 50L,
+		)
+		landed shouldBe false
+		// 200 / 50 = 4 sleeps before the loop's `now() < deadline` check fails.
+		sleeps shouldBe listOf(50L, 50L, 50L, 50L)
+	}
+
+	@Test
+	fun `short-circuits on cancel without sleeping again`() {
+		val clock = FakeClock(start = 0L)
+		var polls = 0
+		val sleeps = mutableListOf<Long>()
+		val landed = awaitProbeSettlement(
+			now = clock::now,
+			sleepMillis = { ms -> sleeps.add(ms); clock.advance(ms) },
+			inFlight = { true },
+			isCanceled = { polls++ >= 2 },
+			deadlineMillis = 10_000L,
+		)
+		landed shouldBe false
+		// Cancel checked at top of each iteration: polls=0 → not cancelled,
+		// sleep; polls=1 → not cancelled, sleep; polls=2 → cancelled, exit.
+		// Two sleeps expected — never sleeps after the cancel is observed.
+		sleeps shouldBe listOf(50L, 50L)
+	}
+
+	@Test
+	fun `honors a caller-supplied poll interval`() {
+		val clock = FakeClock(start = 0L)
+		val sleeps = mutableListOf<Long>()
+		awaitProbeSettlement(
+			now = clock::now,
+			sleepMillis = { ms -> sleeps.add(ms); clock.advance(ms) },
+			inFlight = { true },
+			isCanceled = { false },
+			deadlineMillis = 100L,
+			pollIntervalMillis = 25L,
+		)
+		// 100 / 25 = 4 sleeps at the caller's chosen interval.
+		sleeps shouldBe listOf(25L, 25L, 25L, 25L)
+	}
+
+	@Test
+	fun `returns true immediately when inFlight is false on entry`() {
+		val clock = FakeClock(start = 5_000L)
+		val sleeps = mutableListOf<Long>()
+		val landed = awaitProbeSettlement(
+			now = clock::now,
+			sleepMillis = { ms -> sleeps.add(ms); clock.advance(ms) },
+			inFlight = { false },
+			isCanceled = { false },
+			deadlineMillis = 8_000L,
+		)
+		landed shouldBe true
+		// Fast path: the very first inFlight() check returns false, so the
+		// loop exits before any sleep. Guards against a regression where the
+		// deadline check gets reordered ahead of the settlement check and
+		// forces a wasted sleep even when the reply landed synchronously.
+		sleeps shouldBe emptyList()
+	}
+}
+
+/**
+ * Deterministic clock. Volatile field so a reader on the test thread sees
+ * writes from a lambda called on the same thread (unlike a plain var, which
+ * the JIT could hoist across the sleep-that-isn't-really-a-sleep).
+ */
+private class FakeClock(start: Long) {
+	@Volatile private var t = start
+	fun now(): Long = t
+	fun advance(ms: Long) { t += ms }
+}

--- a/specs/STACK.md
+++ b/specs/STACK.md
@@ -2,7 +2,8 @@
 
 Operational reference for an agent about to change this repo: what the deliverables are, how to
 iterate on each, and the exact gate a change must pass. Every value here was read out of a manifest
-in this tree — not inferred. Recorded at `93933725`.
+in this tree — not inferred. Recorded at `93933725`; sandbox launcher pipeline (§4.5) refreshed at
+`be2f67ab`.
 
 This is **not** a behavioral spec. Command names, file paths, and version numbers are the point.
 
@@ -182,26 +183,25 @@ inlines `cli/src/**` at bundle time, so a stale `cli/` means a stale extension.
 
 ```bash
 npm run intellij:sandbox                            # from repo root
-npm run intellij:sandbox -- --sync-hooks
 ```
 
 This is the **one root script that reaches into `intellij/`** — §1's "no root script touches it" governs
 the build/lint/test stages, not this launcher. It is a thin cross-platform wrapper
 (`intellij/scripts/run-sandbox.mjs`); every step logs with an `[intellij:sandbox]` prefix and any
-failure exits 1.
+failure exits 1. The launcher takes no flags other than `--help` / `-h` — every step below runs
+unconditionally.
 
-Five steps, and **`--sync-hooks` is the only flag** — there is no `--clean`:
+| Step | What it does |
+|---|---|
+| npm deps | `npm install`, but **only if** root `node_modules/` is missing |
+| build | root `npm run build` (CLI + Claude plugin + VS Code extension); fails if `vscode/dist/Cli.js` is absent afterwards. Unconditional because Gradle's `prepareSandbox` copies `vscode/dist/*.js` into the sandbox plugin's `cli-dist/`, so any `cli/src/**` or `vscode/src/**` change must reach `vscode/dist/` before launch or the sandbox runs stale code. Incremental esbuild/vite is ~2 s, so it always rebuilds rather than staleness-detecting |
+| sandbox cache clean | removes `config/`, `system/`, `log/` under `intellij/build/idea-sandbox/<ide>/` so every launch starts from a fresh sandbox IDE. The script's own header flags the cost: this discards manually-installed sandbox plugins, keybindings, window layout, and the project index, so first-launch indexing runs every time |
+| hook sync | copies `vscode/dist/*.js` (**except `Extension.js`**) into `~/.jolli/jollimemory/dist-intellij/`, failing if any required runtime file is absent afterwards. Unconditional because the plugin's `integrationsUpToDate()` gate is keyed on `.version == pluginVersion`, so on same-version relaunches it would skip `extractCliDist()` and keep running last launch's `Cli.js` — refreshing here decouples that from the version stamp |
+| force-register dist-paths | rewrites `~/.jolli/jollimemory/dist-paths/{cli,intellij}` to point at this repo's fresh build. Unconditional because a stale `dist-paths/cli` on the machine (from a global `@jolli.ai/cli` install, or an older sandbox run) can otherwise outrank this repo's build at equal version — `cli` wins the tie-break in `SOURCE_PREFERENCE_ORDER` |
+| launch | `./gradlew runIde` (`gradlew.bat runIde` on Windows) from `intellij/` |
 
-| Step | Default | What it does |
-|---|---|---|
-| 1. npm deps | always | `npm install`, but **only if** root `node_modules/` is missing |
-| 2. build | **always** | root `npm run build`, then asserts `vscode/dist/Cli.js` exists afterwards. Unconditional because Gradle's `prepareSandbox` copies `vscode/dist/*.js` into the sandbox plugin's `cli-dist/`, so any `cli/src/**` or `vscode/src/**` change must reach `vscode/dist/` before launch or the sandbox runs stale code. Incremental esbuild/vite is ~2 s, so it always rebuilds rather than staleness-detecting |
-| 3. sandbox cache clean | **always** | removes `config/`, `system/`, `log/` under `intellij/build/idea-sandbox/<ide>/` so every launch starts fresh. The script's own header flags the cost: this discards manually-installed sandbox plugins, keybindings, window layout, and the project index, so first-launch indexing runs every time |
-| 4. hook sync | **off** — `--sync-hooks` | copies `vscode/dist/*.js` (**except `Extension.js`**) into `~/.jolli/jollimemory/dist-intellij/`, failing if `PrePushWorker.js` is absent afterwards. Copy only — the build already happened in step 2. Off by default because that destination is a machine-global path shared with your other repos |
-| 5. launch | always | `./gradlew runIde` (`gradlew.bat runIde` on Windows) from `intellij/` |
-
-`--help` / `-h` prints the flag list. Gradle's own `~/.gradle/caches/` handles the SDK and Kotlin
-downloads, so the first launch is slow and later ones are not.
+Gradle's own `~/.gradle/caches/` handles the SDK and Kotlin downloads, so the first launch is slow and
+later ones are not.
 
 The underlying Gradle commands, if you would rather drive them directly:
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Quick recap

The IntelliJ settings panel now tells users immediately whether their chosen agent tool is actually installed and runnable on their machine. When the tool isn't found, a red status message appears below the selector, and the Apply button is disabled until the user picks a working tool or installs the missing one. The availability check runs in the background, keeping the settings panel responsive at all times. IntelliJ and VS Code now offer matching availability feedback in their respective settings panels.

The sandbox development workflow also changed: every sandbox launch now unconditionally refreshes the compiled hook scripts and registers the current repo's build as the authoritative version on the local machine. Developers can rebuild and relaunch the sandbox with confidence that the freshly compiled code is what the plugin runs, regardless of any other CLI installations present on the machine.

---

## Topics (2)
<details>
<summary><strong>01 · IntelliJ settings shows real-time availability of selected local agent tool</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The IntelliJ settings panel had no way to tell users whether their chosen agent tool was actually installed and runnable on their machine. VS Code already had this check built into its settings panel, leaving IntelliJ users to discover missing tools only when they tried to use them.

**💡 Decisions Behind the Code**

- **Kotlin calls the bridge rather than running checks in-process**: VS Code hosts its availability check inside the same process as the extension and can call the detection function directly. IntelliJ has no way to run the same TypeScript logic in-process, so the only path is to ask the CLI over the existing inter-process bridge. This keeps the detection logic in one canonical place in the CLI rather than duplicating it in Kotlin.
- **Unknown tool ID throws; all other failures return unavailable**: An unrecognized tool ID can only arrive from a bug in the calling code, not from user action, so a loud error is appropriate. Every other failure mode — config unreadable, discovery throws, malformed response — is silently treated as unavailable. The UI contract is that an unknown result is safer to report as "can't use" than as "works fine," which would mislead the user.
- **Null verdict does not block Apply**: While a probe is in flight or before any probe has run, the user is not blocked from saving their settings. This avoids a situation where a slow daemon startup prevents the user from applying any settings at all, and matches the existing VS Code behavior exactly.

**✅ What Was Implemented**

- Added a new `local-agent-usable` action to `cli/src/commands/IdeBridgeCommand.ts`. It validates the requested tool ID against a whitelist (unknown IDs throw as caller bugs), reads the per-tool config override via `localAgentOverrideFrom`, calls `isLocalAgentUsable`, and returns `{ available: bool }`. All other failures return `available: false`, matching the VS Code sibling's "unknown ≡ not usable" contract.
- Added a status label and async probe logic to `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt`. The label cycles through empty (tool fine), "Checking…" (probe in flight), and a red "not found on this machine" message. Probes fire on provider switch, tool-combo change, and on initial combo population. A `localAgentProbeTool` guard discards verdicts that arrive after the user has switched to a different tool.
- `doValidate` blocks Apply only on a confirmed-false verdict; a null result (probe still in flight or never fired) is deliberately permissive, matching VS Code's `updateApplyBtn` / `localAgentBlocks()` behavior.

**📁 FILES**
- `cli/src/commands/IdeBridgeCommand.ts`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SettingsDialog.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · Sandbox launch unconditionally syncs hooks and force-registers the local build as authoritative</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

During IntelliJ sandbox development, relaunching after a code change without bumping the version number would leave the old compiled files in place, and a globally-installed CLI on the machine could outrank the local repo's freshly-built version. Developers couldn't reliably see their changes just by rebuilding and relaunching.

**💡 Decisions Behind the Code**

- **Made unconditional rather than opt-in**: The plugin's version-based freshness gate skips the file extraction step entirely on same-version relaunches. An unconditional sync on launch decouples "did the code change?" from the version stamp, giving developers a reliable rebuild-then-relaunch cycle without touching version numbers.
- **Force-writes registry entries rather than relying on the CLI's install logic**: The CLI's normal dist-path installer preserves an existing entry when it already points at a complete dist, and at equal version it prefers a globally-installed CLI over the local build. Bypassing that logic on every sandbox launch ensures the local repo's build always wins during development.

**✅ What Was Implemented**

- `syncIntellijDist()` (formerly opt-in `syncHooks()`) now runs unconditionally on every launch; the `--sync-hooks` flag and its guard were removed. `assertCompleteDist()` verifies all required runtime files are present against a mirrored `REQUIRED_RUNTIME_FILES` list after the copy.
- `forceRegisterDistPaths()` was added to write both `cli` and `intellij` entries in the dist-path registry on every launch, pointing at this repo's fresh build. Writes use tmp+rename for atomic access. This bypasses the CLI's normal "keep existing complete dist" gate, asserting the current repo as the source of truth for the sandbox session.

**📁 FILES**
- `intellij/scripts/run-sandbox.mjs`

</blockquote>
</details>

---

*Generated by JolliMemory · August 1, 2026 at 7:49 PM · via local-agent*
<!-- jollimemory-summary-end -->