### PR TITLE
Fix six drift defects found reviewing #424; raise 51 CLI files to 100% coverage

### DIFF
--- a/cli/src/commands/PushControlCommand.test.ts
+++ b/cli/src/commands/PushControlCommand.test.ts
@@ -98,6 +98,57 @@ describe("jolli push-control", () => {
 		expect(JSON.parse(stdout)).toEqual({ type: "set", pushDisabled: true, cwd: "/current/repo" });
 	});
 
+	it("warns that a rebuild reset every other repo's opt-out, naming the kept file", async () => {
+		// --enable is the documented recovery from a corrupt store, and it rebuilds from
+		// an EMPTY set. A plain success line would let the user walk away believing the
+		// other repos are still opted out.
+		mockApply.mockResolvedValue({
+			disabled: false,
+			recoveredFromCorrupt: true,
+			preservedAt: "/g/push-control.json.corrupt-1",
+		});
+		const { stdout } = await run(["--enable"]);
+		expect(stdout).toContain("rebuilt from scratch");
+		expect(stdout).toContain("every other repository's opt-out was reset to ON");
+		expect(stdout).toContain("/g/push-control.json.corrupt-1");
+	});
+
+	it("still warns about the rebuild when the unreadable file could not be kept", async () => {
+		// Preserving the corrupt copy is best-effort; the reset happened either way, so
+		// the warning must not be conditional on having somewhere to point.
+		mockApply.mockResolvedValue({ disabled: false, recoveredFromCorrupt: true });
+		const { stdout } = await run(["--enable"]);
+		expect(stdout).toContain("rebuilt from scratch");
+		expect(stdout).not.toContain("kept at:");
+	});
+
+	it("reports the rebuild in the JSON set payload too", async () => {
+		mockApply.mockResolvedValue({
+			disabled: false,
+			recoveredFromCorrupt: true,
+			preservedAt: "/g/push-control.json.corrupt-1",
+		});
+		const { stdout } = await run(["--enable", "--format", "json"]);
+		expect(JSON.parse(stdout)).toEqual({
+			type: "set",
+			pushDisabled: false,
+			cwd: "/current/repo",
+			recoveredFromCorrupt: true,
+			preservedAt: "/g/push-control.json.corrupt-1",
+		});
+	});
+
+	it("omits preservedAt from the JSON payload when there is none", async () => {
+		mockApply.mockResolvedValue({ disabled: false, recoveredFromCorrupt: true });
+		const { stdout } = await run(["--enable", "--format", "json"]);
+		expect(JSON.parse(stdout)).toEqual({
+			type: "set",
+			pushDisabled: false,
+			cwd: "/current/repo",
+			recoveredFromCorrupt: true,
+		});
+	});
+
 	it("rejects --enable and --disable together", async () => {
 		const { stderr, exitCode } = await run(["--enable", "--disable"]);
 		expect(stderr).toContain("mutually exclusive");
@@ -116,6 +167,15 @@ describe("jolli push-control", () => {
 		mockApply.mockRejectedValue(new Error("nope"));
 		const { stdout, exitCode } = await run(["--disable", "--format", "json"]);
 		expect(JSON.parse(stdout)).toEqual({ type: "error", message: "nope" });
+		expect(exitCode).toBe(1);
+	});
+
+	it("stringifies a rejection that is not an Error", async () => {
+		// The core is free to reject with anything; reading `.message` off a non-Error
+		// would print `undefined` as the whole explanation.
+		mockState.mockRejectedValue("store vanished");
+		const { stderr, exitCode } = await run([]);
+		expect(stderr).toContain("store vanished");
 		expect(exitCode).toBe(1);
 	});
 });

--- a/cli/src/core/ActiveSessionAggregator.test.ts
+++ b/cli/src/core/ActiveSessionAggregator.test.ts
@@ -8,6 +8,17 @@ vi.mock("./CopilotSessionDiscoverer.js", () => ({ scanCopilotSessions: vi.fn() }
 vi.mock("./CopilotChatSessionDiscoverer.js", () => ({ scanCopilotChatSessions: vi.fn() }));
 vi.mock("./ClineSessionDiscoverer.js", () => ({ scanClineSessions: vi.fn() }));
 vi.mock("./ClineCliSessionDiscoverer.js", () => ({ scanClineCliSessions: vi.fn() }));
+vi.mock("./DevinSessionDiscoverer.js", () => ({ scanDevinSessions: vi.fn() }));
+vi.mock("./CursorCliSessionDiscoverer.js", () => ({ scanCursorCliSessions: vi.fn() }));
+vi.mock("./AntigravitySessionDiscoverer.js", () => ({ scanAntigravitySessions: vi.fn() }));
+// Partial mock: `saveOverlay` (used by the edited-badge test) and everything
+// else stay real; only `loadOverlay` becomes overridable so the defensive
+// catch in `safeHasOverlayChanges` can be reached — the real `loadOverlay`
+// swallows every failure internally and never rejects.
+vi.mock("./ConversationOverlayStore.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./ConversationOverlayStore.js")>();
+	return { ...actual, loadOverlay: vi.fn(actual.loadOverlay) };
+});
 vi.mock("./SessionTracker.js", () => ({ loadAllSessions: vi.fn().mockResolvedValue([]) }));
 vi.mock("./SessionTitleResolver.js", () => ({
 	resolveSessionTitle: vi.fn().mockImplementation(async (s) => s.title ?? `resolved:${s.sessionId}`),
@@ -21,13 +32,17 @@ vi.mock("./TranscriptMessageCounter.js", () => ({
 }));
 
 import { listActiveConversations } from "./ActiveSessionAggregator.js";
+import { scanAntigravitySessions } from "./AntigravitySessionDiscoverer.js";
 import { scanClineCliSessions } from "./ClineCliSessionDiscoverer.js";
 import { scanClineSessions } from "./ClineSessionDiscoverer.js";
 import { discoverCodexSessions } from "./CodexSessionDiscoverer.js";
 import { conversationKey, setExcluded } from "./CommitSelectionStore.js";
+import { loadOverlay } from "./ConversationOverlayStore.js";
 import { scanCopilotChatSessions } from "./CopilotChatSessionDiscoverer.js";
 import { scanCopilotSessions } from "./CopilotSessionDiscoverer.js";
+import { scanCursorCliSessions } from "./CursorCliSessionDiscoverer.js";
 import { scanCursorSessions } from "./CursorSessionDiscoverer.js";
+import { scanDevinSessions } from "./DevinSessionDiscoverer.js";
 import { scanOpenCodeSessions } from "./OpenCodeSessionDiscoverer.js";
 import { loadMergedTranscript, loadUnreadMergedTranscript } from "./TranscriptMessageCounter.js";
 
@@ -54,6 +69,9 @@ beforeEach(() => {
 	vi.mocked(scanCopilotChatSessions).mockReset().mockResolvedValue(scan([]));
 	vi.mocked(scanClineSessions).mockReset().mockResolvedValue(scan([]));
 	vi.mocked(scanClineCliSessions).mockReset().mockResolvedValue(scan([]));
+	vi.mocked(scanDevinSessions).mockReset().mockResolvedValue(scan([]));
+	vi.mocked(scanCursorCliSessions).mockReset().mockResolvedValue(scan([]));
+	vi.mocked(scanAntigravitySessions).mockReset().mockResolvedValue(scan([]));
 	vi.mocked(discoverCodexSessions).mockReset().mockResolvedValue([]);
 	vi.mocked(loadMergedTranscript)
 		.mockReset()
@@ -612,6 +630,60 @@ describe("listActiveConversations", () => {
 			vi.mocked(scanCopilotChatSessions).mockRejectedValueOnce(new Error("copilot-chat blew up"));
 			const items = await listActiveConversations({ cwd: "/proj", windowMs: 2 * DAY });
 			expect(items).toEqual([]);
+		});
+
+		it("loadDevin catches throws from the discoverer module", async () => {
+			vi.mocked(scanDevinSessions).mockRejectedValueOnce(new Error("devin blew up"));
+			const items = await listActiveConversations({ cwd: "/proj", windowMs: 2 * DAY });
+			expect(items).toEqual([]);
+		});
+
+		it("loadCursorCli catches throws from the discoverer module", async () => {
+			vi.mocked(scanCursorCliSessions).mockRejectedValueOnce(new Error("cursor-cli blew up"));
+			const items = await listActiveConversations({ cwd: "/proj", windowMs: 2 * DAY });
+			expect(items).toEqual([]);
+		});
+
+		it("loadAntigravity catches throws from the discoverer module", async () => {
+			vi.mocked(scanAntigravitySessions).mockRejectedValueOnce(new Error("antigravity blew up"));
+			const items = await listActiveConversations({ cwd: "/proj", windowMs: 2 * DAY });
+			expect(items).toEqual([]);
+		});
+
+		// The five non-SQLite / late-added sources report failures through the same
+		// `r.error` envelope as cursor/opencode above. Each must land in
+		// `failedSources` while still contributing whatever rows it did return, so
+		// the UI can show partial data with a hint instead of a silent short list.
+		it.each([
+			["cline", scanClineSessions],
+			["cline-cli", scanClineCliSessions],
+			["devin", scanDevinSessions],
+			["cursor-cli", scanCursorCliSessions],
+			["antigravity", scanAntigravitySessions],
+		] as const)(
+			"loader for %s reports r.error via failedSources and keeps its rows",
+			async (source, discoverer) => {
+				const { listActiveConversationsWithDiagnostics } = await import("./ActiveSessionAggregator.js");
+				vi.mocked(discoverer).mockResolvedValueOnce({
+					sessions: [{ sessionId: `${source}-partial`, transcriptPath: "/x", updatedAt: iso(-HOUR), source }],
+					error: { kind: "fs", message: "half-read" },
+				} as never);
+				const result = await listActiveConversationsWithDiagnostics({ cwd: "/proj", windowMs: 2 * DAY });
+				expect(result.items.map((i) => i.sessionId)).toEqual([`${source}-partial`]);
+				expect(result.failedSources).toEqual([source]);
+			},
+		);
+
+		// `loadOverlay` swallows its own IO failures, so this catch is defensive —
+		// but if a future refactor lets one escape, the row must still render with
+		// `isEdited: false` rather than taking down the whole listing.
+		it("safeHasOverlayChanges falls back to isEdited=false when the overlay load rejects", async () => {
+			vi.mocked(loadOverlay).mockRejectedValueOnce(new Error("overlay store exploded"));
+			vi.mocked(scanCursorSessions).mockResolvedValueOnce(
+				scan([{ sessionId: "ov", transcriptPath: "/x", updatedAt: iso(-HOUR), source: "cursor" }]),
+			);
+			const items = await listActiveConversations({ cwd: "/proj", windowMs: 2 * DAY });
+			expect(items).toEqual([expect.objectContaining({ sessionId: "ov", isEdited: false })]);
 		});
 
 		// `err instanceof Error ? err.message : String(err)` — exercise the

--- a/cli/src/core/AntigravityDetector.test.ts
+++ b/cli/src/core/AntigravityDetector.test.ts
@@ -1,7 +1,16 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+// Partial mock: everything in SqliteHelpers stays real, but `hasNodeSqliteSupport`
+// becomes overridable so the Node-<22.5 arm of `isAntigravityInstalled` can be
+// exercised on this (22.5+) test runtime.
+vi.mock("./SqliteHelpers.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./SqliteHelpers.js")>();
+	return { ...actual, hasNodeSqliteSupport: vi.fn(actual.hasNodeSqliteSupport) };
+});
+
 import { getAntigravityVariants, isAntigravityInstalled, isAntigravityPresent } from "./AntigravityDetector.js";
 import { hasNodeSqliteSupport } from "./SqliteHelpers.js";
 
@@ -68,6 +77,20 @@ describe("AntigravityDetector", () => {
 		// …while `installed` stays false — status tree and session discovery have
 		// nothing to show for a host with no readable conversations.
 		expect(await isAntigravityInstalled(home)).toBe(false);
+	});
+
+	// A Node-18 VS Code extension host cannot load node:sqlite, so it must report
+	// "not installed" (nothing readable to show in the status tree / discovery)
+	// even with conversation dbs sitting right there on disk.
+	it("isAntigravityInstalled is false on a runtime without node:sqlite, even with a db present", async () => {
+		const home = freshHome();
+		const conv = join(home, ".gemini", "antigravity", "conversations");
+		mkdirSync(conv, { recursive: true });
+		writeFileSync(join(conv, "abc.db"), "");
+		vi.mocked(hasNodeSqliteSupport).mockReturnValueOnce(false);
+		expect(await isAntigravityInstalled(home)).toBe(false);
+		// …while MCP registration (presence-only, never reads the db) still sees it.
+		expect(await isAntigravityPresent(home)).toBe(true);
 	});
 
 	it("isAntigravityPresent ignores unrelated ~/.gemini content (Gemini CLI's own dirs)", async () => {

--- a/cli/src/core/AntigravitySessionDiscoverer.test.ts
+++ b/cli/src/core/AntigravitySessionDiscoverer.test.ts
@@ -1,9 +1,42 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, realpathSync, utimesSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it, vi } from "vitest";
+
+// Two of the discoverer's guards protect against a TOCTOU race — the file or db
+// disappearing between the existsSync/statSync probe and the read. The
+// filesystem cannot be made to lose that race on demand, so the two holders
+// below inject the exact error the race would produce. Both default to
+// `undefined`, i.e. fully real behaviour.
+const race = vi.hoisted(() => ({
+	readStreamError: undefined as Error | undefined,
+	sqliteError: undefined as Error | undefined,
+}));
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return {
+		...actual,
+		createReadStream: (...args: Parameters<typeof actual.createReadStream>) => {
+			if (race.readStreamError) throw race.readStreamError;
+			return actual.createReadStream(...args);
+		},
+	};
+});
+vi.mock("./SqliteHelpers.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./SqliteHelpers.js")>();
+	return {
+		...actual,
+		withSqliteDb: (...args: Parameters<typeof actual.withSqliteDb>) => {
+			if (race.sqliteError) throw race.sqliteError;
+			return actual.withSqliteDb(...args);
+		},
+	};
+});
+
 import { buildMetadataBlob, createAntigravityConvo, REAL_TRANSCRIPT_FULL } from "../testUtils/antigravityFixture.js";
+import { symlinksSupported } from "../testUtils/symlinkSupport.js";
 import {
 	discoverAntigravitySessions,
 	extractWorkspacePath,
@@ -11,10 +44,22 @@ import {
 } from "./AntigravitySessionDiscoverer.js";
 import { hasNodeSqliteSupport } from "./SqliteHelpers.js";
 
+function enoent(message: string): Error {
+	return Object.assign(new Error(message), { code: "ENOENT" });
+}
+
 const sqliteOnly = hasNodeSqliteSupport() ? describe : describe.skip;
+// The non-ENOENT-stat case needs a self-referential symlink (ELOOP); symlink()
+// throws EPERM on a non-elevated Windows account, so skip it there.
+const itIfSymlinks = symlinksSupported ? it : it.skip;
 
 function freshDir(prefix: string): string {
 	return mkdtempSync(join(tmpdir(), prefix));
+}
+
+/** Overwrites a conversation's transcript_full.jsonl with raw (possibly malformed) text. */
+function overwriteTranscript(transcriptPath: string, text: string): void {
+	writeFileSync(transcriptPath, text);
 }
 
 describe("extractWorkspacePath", () => {
@@ -39,6 +84,34 @@ describe("extractWorkspacePath", () => {
 		// the extra slash must be dropped or the path never matches native "e:/jollimemory".
 		const blob = buildMetadataBlob("/e%3A/jollimemory");
 		expect(extractWorkspacePath(blob)).toBe("e:/jollimemory");
+	});
+
+	// A `file://` uri longer than 127 bytes needs a MULTI-byte protobuf length
+	// varint, so the backward walk over its continuation bytes (MSB set) has to
+	// run — a single-byte-only reader would misread the length and bail.
+	it("reads a length varint that spans multiple bytes (uri > 127 chars)", () => {
+		const deep = `/Users/x/${"nested-package-directory/".repeat(6)}repo`;
+		expect(`file://${deep}`.length).toBeGreaterThan(127);
+		expect(extractWorkspacePath(buildMetadataBlob(deep))).toBe(deep);
+	});
+
+	it("returns undefined when the length prefix is shorter than 'file://'", () => {
+		// tag 0x0a + length 0x03 — too short to be a uri, so the field is not one.
+		const blob = Buffer.concat([Buffer.from([0x0a, 0x03]), Buffer.from("file:///tmp/x")]);
+		expect(extractWorkspacePath(blob)).toBeUndefined();
+	});
+
+	it("returns undefined when the length prefix runs past the end of the blob", () => {
+		// tag 0x0a + length 0x7f (127) against a 12-byte payload — a truncated blob.
+		const blob = Buffer.concat([Buffer.from([0x0a, 0x7f]), Buffer.from("file://short")]);
+		expect(extractWorkspacePath(blob)).toBeUndefined();
+	});
+
+	it("keeps the raw slice when the uri carries a malformed %-escape", () => {
+		// `%zz` is not a valid escape — decodeURIComponent throws, and the extractor
+		// must fall back to the undecoded path rather than dropping the workspace.
+		const blob = buildMetadataBlob("/Users/x/repo%zz");
+		expect(extractWorkspacePath(blob)).toBe("/Users/x/repo%zz");
 	});
 });
 
@@ -182,5 +255,183 @@ sqliteOnly("AntigravitySessionDiscoverer", () => {
 		const sessions = await discoverAntigravitySessions(ws, home);
 		expect(sessions).toHaveLength(1);
 		expect(sessions[0].transcriptPath).toContain("antigravity-ide");
+	});
+
+	it("skips a conversation whose db was last touched more than 48h ago", async () => {
+		const home = freshDir("agy-home-");
+		const ws = freshDir("repo-");
+		const { dbPath } = createAntigravityConvo(home, {
+			convId: "stale",
+			workspacePath: ws,
+			transcriptLines: REAL_TRANSCRIPT_FULL,
+		});
+		const old = new Date(Date.now() - 49 * 3600_000);
+		utimesSync(dbPath, old, old);
+		expect(await discoverAntigravitySessions(ws, home)).toHaveLength(0);
+	});
+
+	it("skips a variant whose conversations path is not a directory", async () => {
+		// existsSync() is happy with a FILE at conversations/, so the variant is
+		// listed; readdirSync then fails with ENOTDIR and the variant is skipped
+		// rather than aborting the whole scan.
+		const home = freshDir("agy-home-");
+		const ws = freshDir("repo-");
+		mkdirSync(join(home, ".gemini", "antigravity-cli"), { recursive: true });
+		writeFileSync(join(home, ".gemini", "antigravity-cli", "conversations"), "not a dir");
+		createAntigravityConvo(home, {
+			convId: "healthy",
+			variant: "antigravity",
+			workspacePath: ws,
+			transcriptLines: REAL_TRANSCRIPT_FULL,
+		});
+		const { sessions, error } = await scanAntigravitySessions(ws, home);
+		expect(sessions.map((s) => s.sessionId)).toEqual(["healthy"]);
+		expect(error).toBeUndefined();
+	});
+
+	itIfSymlinks("skips a listed .db that cannot be stat'ed", async () => {
+		const home = freshDir("agy-home-");
+		const ws = freshDir("repo-");
+		const { dbPath } = createAntigravityConvo(home, {
+			convId: "healthy",
+			workspacePath: ws,
+			transcriptLines: REAL_TRANSCRIPT_FULL,
+		});
+		// Self-referential symlink — readdirSync lists it, statSync chases the link
+		// into itself and throws ELOOP. Models the real race where a conversation
+		// is deleted between the listing and the stat.
+		const loop = join(dbPath, "..", "loop.db");
+		symlinkSync(loop, loop, "file");
+		const { sessions } = await scanAntigravitySessions(ws, home);
+		expect(sessions.map((s) => s.sessionId)).toEqual(["healthy"]);
+	});
+
+	it("surfaces a scan error for an unreadable db while keeping the healthy ones", async () => {
+		const home = freshDir("agy-home-");
+		const ws = freshDir("repo-");
+		const { dbPath } = createAntigravityConvo(home, {
+			convId: "healthy",
+			workspacePath: ws,
+			transcriptLines: REAL_TRANSCRIPT_FULL,
+		});
+		// A .db that is not a SQLite file at all — node:sqlite throws on the query.
+		writeFileSync(join(dbPath, "..", "garbage.db"), "this is not a database");
+		const { sessions, error } = await scanAntigravitySessions(ws, home);
+		expect(sessions.map((s) => s.sessionId)).toEqual(["healthy"]);
+		expect(error).toBeDefined();
+	});
+
+	// The db passed statSync but was gone by the time SQLite opened it (the user
+	// deleted the conversation mid-scan). classifyScanError returns null for
+	// ENOENT, so this is benign: skip the conversation, surface NO error.
+	it("silently skips a conversation whose db vanished between the stat and the open", async () => {
+		const home = freshDir("agy-home-");
+		const ws = freshDir("repo-");
+		createAntigravityConvo(home, {
+			convId: "vanished",
+			workspacePath: ws,
+			transcriptLines: REAL_TRANSCRIPT_FULL,
+		});
+		race.sqliteError = enoent("no such file or directory, open db");
+		try {
+			const { sessions, error } = await scanAntigravitySessions(ws, home);
+			expect(sessions).toEqual([]);
+			expect(error).toBeUndefined();
+		} finally {
+			race.sqliteError = undefined;
+		}
+	});
+
+	it("skips a db whose trajectory_metadata_blob has no 'main' row", async () => {
+		const home = freshDir("agy-home-");
+		const ws = freshDir("repo-");
+		const convDir = join(home, ".gemini", "antigravity", "conversations");
+		mkdirSync(convDir, { recursive: true });
+		const db = new DatabaseSync(join(convDir, "no-main.db"));
+		db.exec("CREATE TABLE trajectory_metadata_blob (id TEXT PRIMARY KEY, data BLOB)");
+		db.close();
+		const { sessions, error } = await scanAntigravitySessions(ws, home);
+		expect(sessions).toEqual([]);
+		expect(error).toBeUndefined();
+	});
+});
+
+sqliteOnly("AntigravitySessionDiscoverer titles", () => {
+	/** Creates a matching conversation and rewrites its transcript with raw text. */
+	function convoWithRawTranscript(text: string): { ws: string; home: string; transcriptPath: string } {
+		const home = freshDir("agy-home-");
+		const ws = freshDir("repo-");
+		const { transcriptPath } = createAntigravityConvo(home, {
+			convId: "titled",
+			workspacePath: ws,
+			transcriptLines: [],
+		});
+		overwriteTranscript(transcriptPath, text);
+		return { ws, home, transcriptPath };
+	}
+
+	it("skips blank lines, malformed JSON and non-USER_INPUT rows when reading the title", async () => {
+		const { ws, home } = convoWithRawTranscript(
+			[
+				"",
+				"   ",
+				'{"type":"USER_INPUT","content":',
+				JSON.stringify({ type: "CHECKPOINT", content: "{{ CHECKPOINT 0 }}" }),
+				// USER_INPUT whose content is not a string — cannot be a title.
+				JSON.stringify({ type: "USER_INPUT", content: { text: "structured" } }),
+				// An empty envelope yields no text, so the scan keeps looking.
+				JSON.stringify({ type: "USER_INPUT", content: "<USER_REQUEST></USER_REQUEST>" }),
+				JSON.stringify({ type: "USER_INPUT", content: "<USER_REQUEST>\nthe real one\n</USER_REQUEST>" }),
+			].join("\n"),
+		);
+		const sessions = await discoverAntigravitySessions(ws, home);
+		expect(sessions[0].title).toBe("the real one");
+	});
+
+	it("truncates a long title at 120 chars with an ellipsis", async () => {
+		const long = "查".repeat(200);
+		const { ws, home } = convoWithRawTranscript(
+			JSON.stringify({ type: "USER_INPUT", content: `<USER_REQUEST>${long}</USER_REQUEST>` }),
+		);
+		const sessions = await discoverAntigravitySessions(ws, home);
+		expect(sessions[0].title).toBe(`${"查".repeat(120)}…`);
+	});
+
+	it("leaves the title undefined when the transcript holds no USER_INPUT", async () => {
+		const { ws, home } = convoWithRawTranscript(
+			JSON.stringify({ type: "PLANNER_RESPONSE", content: "no user turn here" }),
+		);
+		const sessions = await discoverAntigravitySessions(ws, home);
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0].title).toBeUndefined();
+	});
+
+	// The transcript passed existsSync but was gone by the time the stream opened.
+	// ENOENT is the expected shape of that race, so readTitle stays silent (no
+	// debug log) and the session still surfaces — just without a title.
+	it("leaves the title undefined, without logging, when the transcript vanished mid-scan", async () => {
+		const { ws, home } = convoWithRawTranscript(
+			JSON.stringify({ type: "USER_INPUT", content: "<USER_REQUEST>gone</USER_REQUEST>" }),
+		);
+		race.readStreamError = enoent("no such file or directory, open transcript_full.jsonl");
+		try {
+			const sessions = await discoverAntigravitySessions(ws, home);
+			expect(sessions).toHaveLength(1);
+			expect(sessions[0].title).toBeUndefined();
+		} finally {
+			race.readStreamError = undefined;
+		}
+	});
+
+	it("leaves the title undefined when the transcript path is unreadable", async () => {
+		// A DIRECTORY named transcript_full.jsonl: existsSync() passes the
+		// materialization gate, then the read stream fails with EISDIR — a
+		// non-ENOENT error, so readTitle logs and degrades to no title.
+		const { ws, home, transcriptPath } = convoWithRawTranscript("");
+		rmSync(transcriptPath);
+		mkdirSync(transcriptPath);
+		const sessions = await discoverAntigravitySessions(ws, home);
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0].title).toBeUndefined();
 	});
 });

--- a/cli/src/core/AntigravitySessionDiscoverer.ts
+++ b/cli/src/core/AntigravitySessionDiscoverer.ts
@@ -68,7 +68,12 @@ export function extractWorkspacePath(blob: Uint8Array): string | undefined {
 	if (len < FILE_URI_PREFIX.length || idx + len > buf.length) return undefined;
 
 	const value = buf.toString("utf8", idx, idx + len);
+	/* v8 ignore start -- unreachable: `idx` is a latin1 (byte-for-byte) match on the
+	   ASCII prefix and the guard above proves the slice is at least that long, so the
+	   utf8 re-decode always starts with it. Kept as a belt-and-braces guard in case
+	   the offset search above is ever changed to something lossier. */
 	if (!value.startsWith(FILE_URI_PREFIX)) return undefined;
+	/* v8 ignore stop */
 	// Antigravity is VS Code-based; the recorded URI is percent-encoded
 	// (`Uri.toString()`), so spaces / non-ASCII segments arrive as %XX and must
 	// be decoded before the on-disk path comparison. Fall back to the raw slice

--- a/cli/src/core/AntigravityTranscriptReader.test.ts
+++ b/cli/src/core/AntigravityTranscriptReader.test.ts
@@ -3,13 +3,17 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { REAL_TRANSCRIPT_FULL } from "../testUtils/antigravityFixture.js";
-import { readAntigravityTranscript } from "./AntigravityTranscriptReader.js";
+import { readAntigravityTranscript, unwrapUserRequest } from "./AntigravityTranscriptReader.js";
 
-function writeTranscript(lines: ReadonlyArray<Record<string, unknown>>): string {
+function writeRaw(text: string): string {
 	const dir = mkdtempSync(join(tmpdir(), "agy-tr-"));
 	const path = join(dir, "transcript_full.jsonl");
-	writeFileSync(path, `${lines.map((l) => JSON.stringify(l)).join("\n")}\n`);
+	writeFileSync(path, text);
 	return path;
+}
+
+function writeTranscript(lines: ReadonlyArray<Record<string, unknown>>): string {
+	return writeRaw(`${lines.map((l) => JSON.stringify(l)).join("\n")}\n`);
 }
 
 describe("readAntigravityTranscript", () => {
@@ -52,5 +56,81 @@ describe("readAntigravityTranscript", () => {
 		const result = await readAntigravityTranscript("/no/such/transcript_full.jsonl");
 		expect(result.entries).toHaveLength(0);
 		expect(result.totalLinesRead).toBe(0);
+	});
+
+	it("preserves the caller's cursor on a missing file instead of rewinding to 0", async () => {
+		const cursor = { transcriptPath: "/no/such/t.jsonl", lineNumber: 7, updatedAt: "2026-07-19T09:00:00Z" };
+		const result = await readAntigravityTranscript("/no/such/t.jsonl", cursor);
+		expect(result.newCursor).toEqual(cursor);
+	});
+
+	// A torn write (Antigravity appends while we read) leaves a half-flushed line.
+	// It must be skipped, not abort the whole read — the lines after it are valid.
+	it("skips a malformed JSONL line and keeps reading", async () => {
+		const path = writeRaw(
+			[
+				JSON.stringify({ type: "USER_INPUT", created_at: "2026-07-19T09:46:50Z", content: "first" }),
+				'{"type":"USER_INPUT","content":',
+				JSON.stringify({ type: "USER_INPUT", created_at: "2026-07-19T09:46:51Z", content: "third" }),
+			].join("\n"),
+		);
+		const result = await readAntigravityTranscript(path);
+		expect(result.entries.map((e) => e.content)).toEqual(["first\n\nthird"]);
+		expect(result.totalLinesRead).toBe(3);
+	});
+
+	// `created_at` is present on every row of a real transcript, but the reader
+	// must not stamp a non-string value onto the entry (nor let it drive lastTs).
+	it("leaves the timestamp undefined when created_at is not a string", async () => {
+		const path = writeTranscript([{ type: "USER_INPUT", created_at: 1_784_631_456, content: "no iso stamp" }]);
+		const result = await readAntigravityTranscript(path);
+		expect(result.entries).toEqual([{ role: "human", content: "no iso stamp", timestamp: undefined }]);
+	});
+
+	it("drops rows whose payload carries nothing to show", async () => {
+		const path = writeTranscript([
+			// USER_INPUT with an empty envelope → no human text.
+			{ type: "USER_INPUT", created_at: "2026-07-19T09:00:00Z", content: "<USER_REQUEST></USER_REQUEST>" },
+			// PLANNER_RESPONSE with neither content nor tool_calls.
+			{ type: "PLANNER_RESPONSE", created_at: "2026-07-19T09:00:01Z" },
+			// PLANNER_RESPONSE whose tool_calls is not an array.
+			{ type: "PLANNER_RESPONSE", created_at: "2026-07-19T09:00:02Z", tool_calls: "run_command" },
+			// RUN_COMMAND that produced no output.
+			{ type: "RUN_COMMAND", created_at: "2026-07-19T09:00:03Z", content: "" },
+			// A row type the reader deliberately ignores.
+			{ type: "LIST_DIRECTORY", created_at: "2026-07-19T09:00:04Z", content: "src/" },
+		]);
+		const result = await readAntigravityTranscript(path);
+		expect(result.entries).toEqual([]);
+		expect(result.totalLinesRead).toBe(5);
+	});
+
+	// toolCallSummary's three detail sources: CommandLine (covered by the real
+	// fixture), toolSummary, and neither — plus a tool call missing `name`/`args`
+	// entirely, which must degrade to the bare "↪ tool" marker.
+	it("summarizes tool_calls that lack CommandLine, name, or args", async () => {
+		const path = writeTranscript([
+			{
+				type: "PLANNER_RESPONSE",
+				created_at: "2026-07-19T09:00:00Z",
+				tool_calls: [
+					{ name: "view_file", args: { toolSummary: "Read src/app.ts" } },
+					{ name: "grep_search", args: { AbsolutePath: "/repo" } },
+					{},
+				],
+			},
+		]);
+		const result = await readAntigravityTranscript(path);
+		expect(result.entries[0].content).toBe("↪ view_file: Read src/app.ts\n↪ grep_search\n↪ tool");
+	});
+});
+
+describe("unwrapUserRequest", () => {
+	it("returns the trimmed inner text when the envelope is present", () => {
+		expect(unwrapUserRequest("<USER_REQUEST>\n  查看当前分支\n</USER_REQUEST>\ntrailing")).toBe("查看当前分支");
+	});
+
+	it("returns the trimmed whole string when the envelope is absent", () => {
+		expect(unwrapUserRequest("  plain user text  ")).toBe("plain user text");
 	});
 });

--- a/cli/src/core/ClineCliSessionDiscoverer.test.ts
+++ b/cli/src/core/ClineCliSessionDiscoverer.test.ts
@@ -1,7 +1,15 @@
 import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// `discoverClineCliSessions` (the QueueWorker wrapper) takes no sessions-dir
+// override, so the only way to point it at a fixture is through the detector it
+// resolves the path from. Defaults to a path that does not exist, which keeps
+// the wrapper inert (ENOENT → empty, no error) for tests that don't opt in.
+const detector = vi.hoisted(() => ({ sessionsDir: "/no-such-cline-cli-sessions-dir" }));
+vi.mock("./ClineCliDetector.js", () => ({ getClineCliSessionsDir: () => detector.sessionsDir }));
+
 import { discoverClineCliSessions, scanClineCliSessions } from "./ClineCliSessionDiscoverer.js";
 
 async function writeSession(sessionsDir: string, id: string, sidecar: object): Promise<void> {
@@ -16,6 +24,7 @@ describe("scanClineCliSessions", () => {
 	const project = "/tmp/proj-a";
 	beforeEach(async () => {
 		sessionsDir = await mkdtemp(join(tmpdir(), "cline-cli-disc-"));
+		detector.sessionsDir = "/no-such-cline-cli-sessions-dir";
 	});
 	afterEach(async () => {
 		await rm(sessionsDir, { recursive: true, force: true });
@@ -101,12 +110,12 @@ describe("scanClineCliSessions", () => {
 	});
 
 	it("discoverClineCliSessions returns empty array on fs error (logs warn)", async () => {
-		// Pass a file path instead of directory to trigger fs error
+		// A FILE where the sessions dir should be → readdir fails with ENOTDIR,
+		// which is a genuine fs error (not ENOENT), so the scan populates the
+		// error channel that the wrapper must warn about and then drop.
 		const filePath = join(sessionsDir, "not-a-dir");
 		await writeFile(filePath, "test", "utf8");
-		const sessions = await discoverClineCliSessions(project);
-		// Should return array (not error) despite fs error
-		expect(Array.isArray(sessions)).toBe(true);
-		expect(sessions).toHaveLength(0);
+		detector.sessionsDir = filePath;
+		expect(await discoverClineCliSessions(project)).toEqual([]);
 	});
 });

--- a/cli/src/core/ClineSessionDiscoverer.test.ts
+++ b/cli/src/core/ClineSessionDiscoverer.test.ts
@@ -1,7 +1,15 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// `discoverClineSessions` (the QueueWorker wrapper) takes no storage-dir
+// override, so the only way to point it at a fixture is through the detector it
+// resolves the flavor dirs from. Defaults to an empty list, which keeps the
+// wrapper inert for every test that doesn't opt in.
+const detector = vi.hoisted(() => ({ dirs: [] as string[] }));
+vi.mock("./ClineDetector.js", () => ({ getClineStorageDirs: () => detector.dirs }));
+
 import { discoverClineSessions, scanClineSessions } from "./ClineSessionDiscoverer.js";
 
 async function writeHistory(storageDir: string, entries: object[]): Promise<void> {
@@ -15,6 +23,7 @@ describe("scanClineSessions", () => {
 	const project = "/tmp/proj-a";
 	beforeEach(async () => {
 		sd = await mkdtemp(join(tmpdir(), "cline-ext-disc-"));
+		detector.dirs = [];
 	});
 	afterEach(async () => {
 		await rm(sd, { recursive: true, force: true });
@@ -62,6 +71,34 @@ describe("scanClineSessions", () => {
 		]);
 		const r = await scanClineSessions(project, [sd]);
 		expect(r.sessions.map((s) => s.sessionId)).toEqual(["t2"]);
+	});
+
+	// Valid JSON that is not an array — Cline rewrites taskHistory.json wholesale,
+	// so a half-migrated or hand-edited file can legitimately hold an object.
+	// Treat it as "no history" rather than letting `for…of` throw.
+	it("treats a non-array taskHistory.json as empty (no error)", async () => {
+		await mkdir(join(sd, "state"), { recursive: true });
+		await writeFile(join(sd, "state", "taskHistory.json"), JSON.stringify({ tasks: [] }), "utf8");
+		expect(await scanClineSessions(project, [sd])).toEqual({ sessions: [] });
+	});
+
+	it("skips entries lacking a string id or cwdOnTaskInitialization", async () => {
+		await writeHistory(sd, [
+			{ ts: Date.now(), task: "no id", cwdOnTaskInitialization: project },
+			{ id: 42, ts: Date.now(), task: "numeric id", cwdOnTaskInitialization: project },
+			{ id: "no-cwd", ts: Date.now(), task: "no cwd" },
+			{ id: "ok", ts: Date.now(), task: "keeper", cwdOnTaskInitialization: project },
+		]);
+		const r = await scanClineSessions(project, [sd]);
+		expect(r.sessions.map((s) => s.sessionId)).toEqual(["ok"]);
+	});
+
+	it("discoverClineSessions logs and swallows a scan error from the detector's dirs", async () => {
+		// EISDIR on taskHistory.json — a genuine fs failure, so scanClineSessions
+		// populates the error channel that the wrapper must warn about and drop.
+		await mkdir(join(sd, "state", "taskHistory.json"), { recursive: true });
+		detector.dirs = [sd];
+		expect(await discoverClineSessions(project)).toEqual([]);
 	});
 
 	it("reports a fs-kind error (not parse) when the history path is unreadable", async () => {

--- a/cli/src/core/ClineTranscriptReader.test.ts
+++ b/cli/src/core/ClineTranscriptReader.test.ts
@@ -138,4 +138,38 @@ describe("readClineTranscript", () => {
 		const r = await readClineTranscript(join(dir, "nope.json"));
 		expect(r.entries).toEqual([]);
 	});
+
+	// Cline's own extension always writes block arrays, but the Anthropic
+	// message shape it mirrors permits a bare string `content`. Treat it as a
+	// single text block so a provider (or a future Cline version) emitting the
+	// short form still yields the human's words instead of an empty turn.
+	it("treats a bare string content as a single text block", async () => {
+		const stringContent = [
+			{ role: "user", content: "<task>\nsummarize the diff\n</task>", ts: 1000 },
+			{ role: "assistant", content: "Here is the summary.", ts: 2000 },
+		];
+		await writeFile(path, JSON.stringify(stringContent), "utf8");
+		const r = await readClineTranscript(path);
+		expect(r.entries).toEqual([
+			{ role: "human", content: "summarize the diff", timestamp: new Date(1000).toISOString() },
+			{ role: "assistant", content: "Here is the summary.", timestamp: new Date(2000).toISOString() },
+		]);
+	});
+
+	// A message with no `content` key at all (observed on aborted turns) must
+	// not throw — `textBlocks` iterates an empty list and the turn drops out.
+	it("tolerates a message with no content field", async () => {
+		await writeFile(path, JSON.stringify([{ role: "user", ts: 1000 }, { role: "assistant" }]), "utf8");
+		const r = await readClineTranscript(path);
+		expect(r.entries).toEqual([]);
+	});
+
+	// Valid JSON that is not an array (e.g. a `{ "error": … }` written by a
+	// crashed export) must degrade to "no messages", not throw.
+	it("returns empty for valid JSON that is not an array", async () => {
+		await writeFile(path, JSON.stringify({ messages: [] }), "utf8");
+		const r = await readClineTranscript(path);
+		expect(r.entries).toEqual([]);
+		expect(r.newCursor.lineNumber).toBe(0);
+	});
 });

--- a/cli/src/core/CursorCliSessionDiscoverer.test.ts
+++ b/cli/src/core/CursorCliSessionDiscoverer.test.ts
@@ -3,6 +3,18 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CURSOR_CLI_META_JSON, CURSOR_CLI_TRANSCRIPT_JSONL } from "../testUtils/cursorCliFixture.js";
+
+// `discoverCursorCliSessions` (the QueueWorker wrapper) takes no dir-override
+// params — it resolves ~/.cursor from `homedir()`. Redirect just that one export
+// (everything else in node:os, `tmpdir()` included, stays real) so the wrapper
+// can be aimed at a fixture home. `undefined` = delegate to the real homedir,
+// which is the state every test starts in.
+const os = vi.hoisted(() => ({ home: undefined as string | undefined }));
+vi.mock("node:os", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:os")>();
+	return { ...actual, homedir: () => os.home ?? actual.homedir() };
+});
+
 import {
 	discoverCursorCliSessions,
 	isCursorCliInstalled,
@@ -33,6 +45,7 @@ describe("scanCursorCliSessions", () => {
 		projectsDir = join(base, "projects");
 		await mkdir(chatsDir, { recursive: true });
 		await mkdir(projectsDir, { recursive: true });
+		os.home = undefined;
 	});
 	afterEach(async () => {
 		await rm(join(chatsDir, ".."), { recursive: true, force: true });
@@ -140,12 +153,26 @@ describe("scanCursorCliSessions", () => {
 		const scanned = await scanCursorCliSessions(project, filePath, projectsDir);
 		expect(scanned.error?.kind).toBe("fs");
 
-		// discoverCursorCliSessions (the QueueWorker wrapper) takes no dir-override params, so
-		// it can't be pointed at `filePath` — it always resolves against the real machine's
-		// ~/.cursor/chats. What we CAN assert deterministically is its documented contract: for
-		// a project with no matching sessions it resolves to the plain (error-stripped) array.
+		// discoverCursorCliSessions (the QueueWorker wrapper) takes no dir-override params —
+		// it resolves ~/.cursor/chats from homedir(). Its documented contract: for a project
+		// with no matching sessions it resolves to the plain (error-stripped) array.
 		const sessions = await discoverCursorCliSessions("/nope-does-not-exist");
 		expect(sessions).toEqual([]);
+	});
+
+	it("discoverCursorCliSessions logs and swallows a scan error", async () => {
+		// A FILE where ~/.cursor/chats should be → readdir fails with ENOTDIR, so the
+		// scan populates the error channel that the wrapper must warn about and drop.
+		const home = await mkdtemp(join(tmpdir(), "cursor-cli-home-"));
+		try {
+			await mkdir(join(home, ".cursor"), { recursive: true });
+			await writeFile(join(home, ".cursor", "chats"), "not a dir", "utf8");
+			os.home = home;
+			expect(await scanCursorCliSessions(project).then((r) => r.error?.kind)).toBe("fs");
+			expect(await discoverCursorCliSessions(project)).toEqual([]);
+		} finally {
+			await rm(home, { recursive: true, force: true });
+		}
 	});
 
 	it("isCursorCliInstalled is false when chats dir missing", async () => {

--- a/cli/src/core/CursorCliTranscriptReader.test.ts
+++ b/cli/src/core/CursorCliTranscriptReader.test.ts
@@ -1,9 +1,17 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CURSOR_CLI_TRANSCRIPT_JSONL } from "../testUtils/cursorCliFixture.js";
 import { readCursorCliTranscript } from "./CursorCliTranscriptReader.js";
+
+// Partial mock: the fixture helpers below stay real; only `readFile` is made
+// steerable, so a failure with no `errno` code can be injected. Every real fs error
+// carries one, and the reader's code-copying guard has to survive one that does not.
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs/promises")>();
+	return { ...actual, readFile: vi.fn(actual.readFile) };
+});
 
 // Real line shapes verified on a live cursor-agent install (JOLLI-2023):
 //   {role, message:{content:[{type:"text"|"tool_use", …}]}}  and  {type, status}
@@ -104,6 +112,59 @@ describe("readCursorCliTranscript", () => {
 
 	it("throws (with preserved code) when the file is missing", async () => {
 		await expect(readCursorCliTranscript(join(dir, "nope.jsonl"))).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
+	it("still throws its own wrapper when the underlying error carries no code", async () => {
+		// Callers branch on `code` (ENOENT is routine, anything else is worth a warning),
+		// so the wrapper must not invent one — an absent code has to stay absent.
+		vi.mocked(readFile).mockRejectedValueOnce(new Error("something else went wrong"));
+		const err = await readCursorCliTranscript(join(dir, "t.jsonl")).catch((e: unknown) => e);
+		expect(err).toBeInstanceOf(Error);
+		expect((err as Error).message).toContain("Cannot read Cursor CLI transcript");
+		expect(err).not.toHaveProperty("code");
+	});
+
+	it("keeps a user turn that carries a stamp but no <user_query> wrapper", async () => {
+		// The wrapper marks a typed prompt; a resumed or injected turn arrives as bare
+		// text after the stamp, and dropping the stamp is all that is needed there.
+		const p = join(dir, "bare.jsonl");
+		await writeFile(
+			p,
+			`${JSON.stringify({
+				role: "user",
+				message: {
+					content: [
+						{
+							type: "text",
+							text: "<timestamp>Tuesday, Jul 21, 2026, 6:56 PM (UTC+8)</timestamp>\nbare prompt",
+						},
+					],
+				},
+			})}\n`,
+			"utf8",
+		);
+		const r = await readCursorCliTranscript(p);
+		expect(r.entries).toEqual([{ role: "human", content: "bare prompt" }]);
+	});
+
+	it("tolerates a user turn with no message body and a text part with no text", async () => {
+		// Both shapes are read twice per line under a cutoff — once to look for a
+		// timestamp and once to extract content — so neither may throw on either pass.
+		const p = join(dir, "sparse.jsonl");
+		await writeFile(
+			p,
+			[
+				JSON.stringify({ role: "user" }),
+				JSON.stringify({ role: "user", message: { content: [{ type: "text" }] } }),
+				asst("still here"),
+				"",
+			].join("\n"),
+			"utf8",
+		);
+		const r = await readCursorCliTranscript(p, null, new Date("2026-07-21T10:57:00Z").toISOString());
+		expect(r.entries).toEqual([{ role: "assistant", content: "still here" }]);
+		// Contentless turns are consumed, not deferred — nothing about them is pending.
+		expect(r.newCursor.lineNumber).toBe(3);
 	});
 
 	const userAt = (clock: string, q: string) =>

--- a/cli/src/core/DetachedUsageSubtraction.test.ts
+++ b/cli/src/core/DetachedUsageSubtraction.test.ts
@@ -364,6 +364,45 @@ describe("subtractDetachedUsage", () => {
 		expect(result.summary.conversationTokenBreakdown).toEqual({ input: 150, output: 150, cached: 250 });
 	});
 
+	it("pools two transcripts owned by the same node into one subtraction", () => {
+		// A leaf routinely lists several transcript ids (one per conversation that fed
+		// the commit). Detaching from two of them must sum into a single correction of
+		// that node, not overwrite the first bucket with the second.
+		const summary = node({
+			transcripts: ["t1", "t2"],
+			conversationTokens: 3330,
+			conversationTokenBreakdown: { input: 30, output: 3000, cached: 300 },
+		});
+		const result = subtractDetachedUsage(
+			summary,
+			new Map([
+				["t1", [{ usage: { input: 10, output: 1000, cached: 100 } }]],
+				["t2", [{ usage: { input: 5, output: 500, cached: 50 } }]],
+			]),
+		);
+		expect(result.summary.conversationTokenBreakdown).toEqual({ input: 15, output: 1500, cached: 150 });
+		expect(result.summary.conversationTokens).toBe(1665);
+		expect(result.unattributed).toEqual([]);
+	});
+
+	it("keeps the children array itself when only the root changed", () => {
+		// The mirror of the case above: a rebuilt array on an unchanged subtree would
+		// defeat the reference comparison callers use to skip a rewrite.
+		const child = node({ commitHash: "b".repeat(40), transcripts: ["t2"], conversationTokens: 50 });
+		const summary = node({
+			transcripts: ["t1"],
+			conversationTokens: 3330,
+			conversationTokenBreakdown: { input: 30, output: 3000, cached: 300 },
+			children: [child],
+		});
+		const result = subtractDetachedUsage(
+			summary,
+			removed("t1", [{ usage: { input: 10, output: 1000, cached: 100 } }]),
+		);
+		expect(result.summary.conversationTokens).toBe(2220);
+		expect(result.summary.children).toBe(summary.children);
+	});
+
 	it("drops a model whose tokens are fully detached while keeping the others", () => {
 		const haiku: ModelTokenUsage = {
 			model: "claude-haiku-4-5",
@@ -625,6 +664,34 @@ describe("subtractDetachedUsage — skill figures", () => {
 			removed("t1", detached("claude:sessA", { input: 10, output: 1000, cached: 100 })),
 		);
 		expect(result.summary.skills?.[0].usage?.confidence).toBe("attributed");
+	});
+
+	it("keeps the estimate label when an estimated session is what survives", () => {
+		// The mirror of the case above. A total is only as trustworthy as its weakest
+		// contributor, so dropping the attributed session must not promote the remainder
+		// from "estimated" to "attributed".
+		const summary = node({
+			transcripts: ["t1"],
+			skills: [
+				skill({
+					usage: { input: 30, cached: 300, output: 3000, confidence: "estimated" },
+					usageBySession: {
+						"claude:sessA": { input: 10, cached: 100, output: 1000, confidence: "attributed" },
+						"claude:sessB": { input: 20, cached: 200, output: 2000, confidence: "estimated" },
+					},
+				}),
+			],
+		});
+		const result = subtractDetachedUsage(
+			summary,
+			removed("t1", detached("claude:sessA", { input: 10, output: 1000, cached: 100 })),
+		);
+		expect(result.summary.skills?.[0].usage).toEqual({
+			input: 20,
+			cached: 200,
+			output: 2000,
+			confidence: "estimated",
+		});
 	});
 
 	it("reports changed when only skill figures moved", () => {

--- a/cli/src/core/DevinSessionDiscoverer.test.ts
+++ b/cli/src/core/DevinSessionDiscoverer.test.ts
@@ -425,6 +425,24 @@ describe("DevinSessionDiscoverer", () => {
 			expect((await discoverDevinSessions(projectDir)).map((s) => s.sessionId)).toEqual(["wd-match"]);
 		});
 
+		// Same malformed payloads, but with a working_directory that does NOT
+		// match — so `parseWorkspaceDirs` is the only thing deciding, and its
+		// tolerance has to yield "no extra dirs" rather than throwing.
+		it.each([
+			["malformed JSON", "{not valid json"],
+			["a non-array payload", '{"dirs":[]}'],
+			["non-string entries", "[42, null, {}]"],
+			["an empty string", ""],
+		])("yields no extra dirs for %s when working_directory also misses", async (_label, raw) => {
+			const dbDir = join(fakeDataHome, "devin", "cli");
+			const nowSec = Math.floor(Date.now() / 1000);
+			await createDevinDb(dbDir, [
+				{ id: "wd-miss", workingDirectory: "/tmp/elsewhere", workspaceDirs: raw, lastActivityAt: nowSec - 100 },
+			]);
+
+			expect(await discoverDevinSessions(projectDir)).toEqual([]);
+		});
+
 		it("returns a silent empty result (no error) when the runtime lacks node:sqlite", async () => {
 			const dbDir = join(fakeDataHome, "devin", "cli");
 			const nowSec = Math.floor(Date.now() / 1000);

--- a/cli/src/core/DevinTranscriptReader.test.ts
+++ b/cli/src/core/DevinTranscriptReader.test.ts
@@ -441,6 +441,73 @@ describe("readDevinTranscript", () => {
 		await rm(dir, { recursive: true, force: true });
 	});
 
+	// pickFallbackTip ranks leaves by `metadata.created_at`. A node that carries no
+	// metadata at all scores NaN → treated as -Infinity, so any timestamped leaf
+	// outranks it and the untimed one only wins on the node_id tie-break.
+	it("ranks a leaf with no created_at below every timestamped leaf when inferring the tip", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "devin-untimed-leaf-"));
+		const p = join(dir, "s.db");
+		const db = new DatabaseSync(p);
+		db.exec(
+			"CREATE TABLE sessions(id TEXT, main_chain_id INTEGER); CREATE TABLE message_nodes(session_id TEXT, node_id INTEGER, parent_node_id INTEGER, chat_message TEXT);",
+		);
+		db.prepare("INSERT INTO sessions VALUES('s', NULL)").run();
+		// Highest node_id, but NO metadata → NaN → must lose to the timestamped leaf.
+		db.prepare("INSERT INTO message_nodes VALUES('s',9,NULL,?)").run(
+			JSON.stringify({ role: "assistant", content: "untimed-loser" }),
+		);
+		db.prepare("INSERT INTO message_nodes VALUES('s',1,NULL,?)").run(
+			JSON.stringify({
+				role: "assistant",
+				content: "timestamped-winner",
+				metadata: { created_at: "2026-07-18T00:00:00Z" },
+			}),
+		);
+		db.close();
+
+		const { entries } = await readDevinTranscript(`${p}#s`);
+		expect(entries.map((e) => e.content)).toEqual(["timestamped-winner"]);
+
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	// A fully-cyclic graph (every node is someone's parent) has no leaves at all.
+	// Rather than crash on an empty candidate list, the tip is inferred from every
+	// node — and buildMainChain's `visited` set stops the walk from looping.
+	it("still infers a tip when the node graph is fully cyclic (no leaves)", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "devin-cyclic-"));
+		const p = join(dir, "s.db");
+		const db = new DatabaseSync(p);
+		db.exec(
+			"CREATE TABLE sessions(id TEXT, main_chain_id INTEGER); CREATE TABLE message_nodes(session_id TEXT, node_id INTEGER, parent_node_id INTEGER, chat_message TEXT);",
+		);
+		db.prepare("INSERT INTO sessions VALUES('s', NULL)").run();
+		const mk = (content: string, createdAt: string) =>
+			JSON.stringify({ role: "assistant", content, metadata: { created_at: createdAt } });
+		// 1 → 2 → 1: each node parents the other, so `parentIds` covers both.
+		db.prepare("INSERT INTO message_nodes VALUES('s',1,2,?)").run(mk("older", "2026-07-18T00:00:00Z"));
+		db.prepare("INSERT INTO message_nodes VALUES('s',2,1,?)").run(mk("newer-tip", "2026-07-18T01:00:00Z"));
+		db.close();
+
+		const { entries } = await readDevinTranscript(`${p}#s`);
+		// Tip is the newest node; the walk terminates after visiting both once.
+		expect(entries.map((e) => e.content)).toEqual(["older\n\nnewer-tip"]);
+
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	// Cursors are read back from JSON on disk, so a record written before
+	// `lineNumber` existed arrives without it. Resume from the start rather than
+	// producing `NaN` indices.
+	it("treats a cursor with no lineNumber at all as a read from the start", async () => {
+		const legacy = { transcriptPath, updatedAt: "2026-07-18T00:00:00Z" } as unknown as Parameters<
+			typeof readDevinTranscript
+		>[1];
+		const fromScratch = await readDevinTranscript(transcriptPath);
+		const resumed = await readDevinTranscript(transcriptPath, legacy);
+		expect(resumed.entries).toEqual(fromScratch.entries);
+	});
+
 	it("falls back to the positional lineNumber for a legacy cursor without an anchorId", async () => {
 		// A cursor persisted before anchors existed carries only lineNumber. The reader
 		// must still resume positionally (and clamp an over-long lineNumber to the chain).

--- a/cli/src/core/LlmClient.test.ts
+++ b/cli/src/core/LlmClient.test.ts
@@ -19,6 +19,7 @@ import {
 	STREAM_MAX_WALL_CLOCK_MS,
 } from "./LlmClient.js";
 import { registerBackend } from "./localagent/BackendRegistry.js";
+import { runInvocation } from "./localagent/LocalAgentRunner.js";
 import type { LocalAgentBackend } from "./localagent/Types.js";
 import { COMMIT_MSG_DIFF_BUDGET } from "./Summarizer.js";
 import { runWithTrace } from "./TraceContext.js";
@@ -72,6 +73,14 @@ vi.mock("../Logger.js", () => ({
 }));
 
 // Mock JolliApiUtils
+// The default spawner. Mocked (rather than always overridden via the
+// `__localAgentRun` seam) so the production default path can be exercised
+// without launching a real CLI.
+vi.mock("./localagent/LocalAgentRunner.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./localagent/LocalAgentRunner.js")>();
+	return { ...actual, runInvocation: vi.fn(async () => "stdout-from-default-runner") };
+});
+
 vi.mock("./JolliApiUtils.js", () => ({
 	parseBaseUrl: vi.fn().mockReturnValue({ origin: "https://jolli.app", tenantSlug: undefined }),
 	parseJolliApiKey: vi.fn().mockReturnValue({ t: "tenant1", u: "https://jolli.app", o: "eng" }),
@@ -515,6 +524,22 @@ describe("LlmClient", () => {
 
 		it("recognizes a premature close by message text (no code) and recovers", async () => {
 			mockStream.mockReturnValueOnce(rejectingStream(new Error("terminated: Premature close"), streamedMessage));
+			const result = await callLlm({
+				action: "translate",
+				params: { content: "x" },
+				apiKey: "sk-ant-test",
+				maxTokens: 8192,
+			});
+			expect(result.text).toBe("recovered response");
+		});
+
+		// undici surfaces the transport reason on `cause` and sometimes rejects with
+		// a bare object carrying no top-level `message`. Reading it must not stringify
+		// `undefined` into the haystack (which would make "undefined" matchable).
+		it("recognizes a premature close on `cause` when the outer error has no message", async () => {
+			mockStream.mockReturnValueOnce(
+				rejectingStream({ cause: { message: "terminated: Premature close" } }, streamedMessage),
+			);
 			const result = await callLlm({
 				action: "translate",
 				params: { content: "x" },
@@ -1535,6 +1560,89 @@ describe("callLlm — local-agent", () => {
 		expect(result.inputTokens).toBe(5);
 		expect(result.outputTokens).toBe(9);
 		expect(result.cachedTokens).toBe(4738);
+	});
+
+	// Three defaults that only apply when the caller leaves them off: the tool
+	// (claude-code), the spawner (the real runInvocation, not the test seam), and
+	// a fully-parameterised template (no unfilled-placeholder warning).
+	it("defaults to claude-code, the real runner, and warns about nothing when params are complete", async () => {
+		let seenPrompt: string | undefined;
+		let seenStdout: string | undefined;
+		const stub: LocalAgentBackend = {
+			id: "claude-code",
+			discoverExecutable: async () => ({ file: "/x/claude", version: "2.1.210" }),
+			buildInvocation: (_exe, req) => {
+				seenPrompt = req.prompt;
+				return { file: "/x/claude", args: [], stdin: req.prompt, env: {}, cwd: "/tmp" };
+			},
+			parseResult: (stdout) => {
+				seenStdout = stdout;
+				return {
+					text: "SUMMARY",
+					inputTokens: 1,
+					outputTokens: 1,
+					cachedTokens: 0,
+					costUsd: 0,
+					stopReason: "end_turn",
+				};
+			},
+			isPresent: () => true,
+		};
+		registerBackend(stub);
+
+		const result = await callLlm({
+			action: "recap",
+			// The recap template's real placeholders — nothing left unfilled.
+			params: { commitMessage: "fix: thing", topicsSummary: "one topic" },
+			aiProvider: "local-agent",
+			// localAgentTool and __localAgentRun both intentionally omitted.
+		});
+
+		expect(result.text).toBe("SUMMARY");
+		expect(seenPrompt).not.toContain("{{");
+		// The default spawner ran, and its stdout reached the backend's parser.
+		expect(runInvocation).toHaveBeenCalledTimes(1);
+		expect(seenStdout).toBe("stdout-from-default-runner");
+		expect(mockLogWarn).not.toHaveBeenCalledWith(
+			expect.stringContaining("unfilled placeholders"),
+			expect.anything(),
+			expect.anything(),
+		);
+	});
+
+	// Only claude-code gets a resolved model id — its model selection is
+	// action-driven. Every other tool runs whatever model it is configured with,
+	// so passing an empty model tells the backend to emit no model flag at all.
+	it("passes an empty model to any tool other than claude-code", async () => {
+		let seenModel: string | undefined;
+		const stub: LocalAgentBackend = {
+			id: "codex",
+			discoverExecutable: async () => ({ file: "/x/codex", version: "0.1.0" }),
+			buildInvocation: (_exe, req) => {
+				seenModel = req.model;
+				return { file: "/x/codex", args: [], stdin: req.prompt, env: {}, cwd: "/tmp" };
+			},
+			parseResult: () => ({
+				text: "OK",
+				inputTokens: 0,
+				outputTokens: 0,
+				cachedTokens: 0,
+				costUsd: 0,
+				stopReason: "end_turn",
+			}),
+			isPresent: () => true,
+		};
+		registerBackend(stub);
+
+		await callLlm({
+			action: "recap",
+			params: { commitMessage: "m", topicsSummary: "t" },
+			aiProvider: "local-agent",
+			localAgentTool: "codex",
+			__localAgentRun: async () => "ignored-by-stub",
+		});
+
+		expect(seenModel).toBe("");
 	});
 
 	it("throws when the action has no known template", async () => {

--- a/cli/src/core/OnboardingFunnel.test.ts
+++ b/cli/src/core/OnboardingFunnel.test.ts
@@ -15,12 +15,19 @@ vi.mock("./Telemetry.js", async (importOriginal) => {
 	// Keep the real `bucket`; only track + the consent gate are controllable.
 	return { ...actual, track: vi.fn(), getTelemetryContext: vi.fn() };
 });
+// The durable disable reader spawns a real `git rev-parse` — stubbed so this stays
+// in the fast tier; the two gate tests below drive it explicitly.
+vi.mock("./RepoProfile.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./RepoProfile.js")>();
+	return { ...actual, readManualDisableFlagSync: vi.fn() };
+});
 
 import { getStatus } from "../install/Installer.js";
-import { getJolliMemoryDir } from "../Logger.js";
+import { getJolliMemoryDir, setManuallyDisabled } from "../Logger.js";
 import { isInsideGitRepo } from "./GitOps.js";
 import { resolveLlmCredentialSource } from "./LlmClient.js";
 import { captureMethodOf, maybeEmitOnboardingProgress, resolveOnboardingFunnel } from "./OnboardingFunnel.js";
+import { readManualDisableFlagSync } from "./RepoProfile.js";
 import { getTelemetryContext, track } from "./Telemetry.js";
 
 const isGit = isInsideGitRepo as Mock;
@@ -29,6 +36,7 @@ const getStatusMock = getStatus as Mock;
 const jolliDir = getJolliMemoryDir as Mock;
 const trackMock = track as Mock;
 const ctxMock = getTelemetryContext as Mock;
+const durableDisabled = readManualDisableFlagSync as Mock;
 
 const LEDGER = "onboarding-progress.json";
 let tmp: string;
@@ -40,9 +48,12 @@ beforeEach(async () => {
 	ctxMock.mockReturnValue({ enabled: true });
 	isGit.mockResolvedValue(true);
 	resolveSrc.mockReturnValue(null);
+	durableDisabled.mockReturnValue(false);
 });
 
 afterEach(async () => {
+	// Module-level flag: leaking `true` would silently no-op every later test here.
+	setManuallyDisabled(false);
 	await rm(tmp, { recursive: true, force: true });
 });
 
@@ -136,6 +147,49 @@ describe("maybeEmitOnboardingProgress", () => {
 		expect(trackMock).not.toHaveBeenCalled();
 		expect(isGit).not.toHaveBeenCalled();
 		await expect(readFile(ledgerPath(), "utf-8")).rejects.toThrow();
+	});
+
+	it("does nothing (no git work, no ledger) when the repo is manually disabled", async () => {
+		// Spec 304: the in-memory suppression flag is the gate every write site in the
+		// editor host consults. This emitter used to skip it entirely, so the Disable
+		// command's own status refresh created `onboarding-progress.json` inside the
+		// repo it had just disabled — a second, undocumented write class.
+		setManuallyDisabled(true);
+		await maybeEmitOnboardingProgress({ cwd: tmp, config: {}, status: { enabled: true, summaryCount: 1 } });
+		expect(trackMock).not.toHaveBeenCalled();
+		expect(isGit).not.toHaveBeenCalled();
+		await expect(readFile(ledgerPath(), "utf-8")).rejects.toThrow();
+	});
+
+	it("does nothing (no git work, no ledger) when only the durable flag says disabled", async () => {
+		// The CLI half of spec 304. `setManuallyDisabled` is process-local and no CLI
+		// entry point ever calls it, so after `jolli disable` the in-memory mirror is
+		// still false in a fresh `jolli status` / bare `jolli` / QueueWorker process.
+		// Without the durable reader those recreated `onboarding-progress.json` in the
+		// repo the user had just disabled.
+		setManuallyDisabled(false);
+		durableDisabled.mockReturnValue(true);
+		await maybeEmitOnboardingProgress({ cwd: tmp, config: {}, status: { enabled: true, summaryCount: 1 } });
+		expect(durableDisabled).toHaveBeenCalledWith(tmp);
+		expect(trackMock).not.toHaveBeenCalled();
+		expect(isGit).not.toHaveBeenCalled();
+		await expect(readFile(ledgerPath(), "utf-8")).rejects.toThrow();
+	});
+
+	it("skips the durable read entirely when the in-memory mirror already says disabled", async () => {
+		// Short-circuit order matters: the editor host seeds the free mirror at
+		// activate() and fires this from ≥5 uncoordinated refresh triggers, so a
+		// disabled workspace must not pay a sync `git rev-parse` per refresh.
+		setManuallyDisabled(true);
+		await maybeEmitOnboardingProgress({ cwd: tmp, config: {}, status: { enabled: true, summaryCount: 1 } });
+		expect(durableDisabled).not.toHaveBeenCalled();
+	});
+
+	it("skips the durable read entirely when telemetry is inactive", async () => {
+		// The consent short-circuit stays first: an opted-out user pays no disk/git cost.
+		ctxMock.mockReturnValue(null);
+		await maybeEmitOnboardingProgress({ cwd: tmp, config: {}, status: { enabled: true, summaryCount: 1 } });
+		expect(durableDisabled).not.toHaveBeenCalled();
 	});
 
 	it("emits the content-free snapshot and writes the dedup ledger on first run", async () => {

--- a/cli/src/core/OnboardingFunnel.ts
+++ b/cli/src/core/OnboardingFunnel.ts
@@ -46,11 +46,12 @@
 
 import { mkdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { getJolliMemoryDir } from "../Logger.js";
+import { getJolliMemoryDir, isManuallyDisabled } from "../Logger.js";
 import type { JolliMemoryConfig, StatusInfo } from "../Types.js";
 import { atomicWriteFile } from "./AtomicWrite.js";
 import { isInsideGitRepo } from "./GitOps.js";
 import { resolveLlmCredentialSource } from "./LlmClient.js";
+import { readManualDisableFlagSync } from "./RepoProfile.js";
 import { type BucketLabel, bucket, getTelemetryContext, track } from "./Telemetry.js";
 
 /** Which route (if any) the user has configured to capture memory. */
@@ -210,6 +211,46 @@ export async function maybeEmitOnboardingProgress(opts: ResolveFunnelOptions): P
 		// Short-circuit before any git/status work — and before taking the lock —
 		// when telemetry is off, so an opted-out user pays nothing.
 		if (!getTelemetryContext()?.enabled) return;
+		// Same, for a repo the user durably opted out of (spec 304). The ledger is a
+		// NEW repo-local file, not an append to the buffer the telemetry primitive
+		// already owns, so the "telemetry recording is ungated" carve-out does not
+		// cover it — without this gate the Disable command's own status refresh
+		// writes into the repo it just disabled.
+		//
+		// BOTH readers are consulted because neither alone covers every trigger:
+		//   - `isManuallyDisabled()` is the free in-memory mirror the editor host
+		//     seeds at activate() and flips in lockstep with enable/disable. It is
+		//     the only reader available on VS Code's synchronous write paths, but
+		//     it is process-local — CLI processes never set it (see Logger.ts), so
+		//     on its own it left `jolli status` / bare `jolli` / `jolli enable` /
+		//     the QueueWorker's IngestRunStore recreating the ledger in a repo the
+		//     user had already disabled.
+		//   - `readManualDisableFlagSync` is the durable, disk-backed truth those
+		//     CLI processes need. It must be the SYNC variant: the async
+		//     `readManualDisableFlag` persists a legacy-marker migration decision,
+		//     i.e. a write, which is exactly what this gate exists to prevent.
+		//     Steady-state cost is one `readFileSync`: the `git rev-parse` it needs
+		//     to anchor on the main worktree runs once per `cwd` and is then served
+		//     from `_mainRootCache` (see `RepoProfile.ts`), because this gate is NOT
+		//     a once-per-process seed — VS Code reaches it from every
+		//     `StatusStore.refresh()`, including two file watchers that fire
+		//     repeatedly while an AI session is live, so an unmemoized subprocess
+		//     spawn per refresh would block the extension host's event loop. What
+		//     is left is charged only after the telemetry-consent short-circuit,
+		//     and is small next to the `isInsideGitRepo` / `getStatus` work
+		//     `resolveOnboardingFunnel` runs immediately after it.
+		//
+		// KNOWN TRADE-OFF, deliberate: this sits ahead of `track()`, not merely ahead
+		// of the ledger write, so disabling a repo silences the funnel INCLUDING the
+		// `repo_enabled: false` snapshot that would have recorded the disable itself.
+		// The last snapshot on record for that repo says "enabled" and nothing ever
+		// supersedes it — so the drop-off this funnel exists to observe is the one
+		// event it cannot see. Gating only the persist is NOT the fix: the dedup
+		// ledger would go unread, turning every status refresh into a fresh emit, and
+		// the zero-write contract (spec 304) is the stronger of the two promises.
+		// Recovering the signal needs a one-shot emit at the disable GESTURE itself,
+		// which is a separate design — not a relaxation of this gate.
+		if (isManuallyDisabled() || readManualDisableFlagSync(opts.cwd)) return;
 		ledgerPath = join(getJolliMemoryDir(opts.cwd), LEDGER_FILE);
 		const path = ledgerPath;
 		run = (ledgerLocks.get(path) ?? Promise.resolve()).then(() => emitOnce(opts, path));

--- a/cli/src/core/PrDescription.test.ts
+++ b/cli/src/core/PrDescription.test.ts
@@ -102,6 +102,13 @@ describe("replaceMarkerRegion", () => {
 			`Before\n\n${MARKER_START}\n${payload}\n${MARKER_END}\n\nAfter`,
 		);
 	});
+
+	// An unwritten PR body is "" — appending with the usual blank-line separator
+	// would leave the body starting with two stray newlines.
+	it("emits the block alone when the current body is empty", () => {
+		const wrapped = wrapWithMarkers("Generated");
+		expect(replaceMarkerRegion("", wrapped)).toBe(wrapped);
+	});
 });
 
 describe("loadBranchSummaries", () => {

--- a/cli/src/core/PushControl.test.ts
+++ b/cli/src/core/PushControl.test.ts
@@ -12,6 +12,13 @@ vi.mock("./SessionTracker.js", async (orig) => {
 	return { ...actual, getGlobalConfigDir: () => globalDirRef.path };
 });
 
+// Real behaviour by default; wrapped so the identity memo can be observed (call
+// counting) and so a resolution failure can be injected.
+vi.mock("./GitRemoteUtils.js", async (orig) => {
+	const actual = await orig<typeof import("./GitRemoteUtils.js")>();
+	return { ...actual, getCanonicalRepoUrl: vi.fn(actual.getCanonicalRepoUrl) };
+});
+
 import { getCanonicalRepoUrl } from "./GitRemoteUtils.js";
 import {
 	__resetGateInputCache,
@@ -22,7 +29,7 @@ import {
 	readPushDisabledState,
 	setRepoPushDisabledByIdentity,
 } from "./PushControl.js";
-import { setRepoPushDisabled } from "./PushControlStore.js";
+import { getPushControlPath, setRepoPushDisabled } from "./PushControlStore.js";
 import { writeManualDisableFlag } from "./RepoProfile.js";
 
 describe("PushControl", () => {
@@ -106,6 +113,62 @@ describe("PushControl", () => {
 		expect(await readPushDisabledState(repo)).toEqual({ disabled: true });
 	});
 
+	it("readPushDisabledState fails closed and stringifies a non-Error throw", async () => {
+		// A thrown non-Error (a bare string from an over-eager `throw`) must still
+		// produce a readable `error` alongside the fail-closed `disabled: true`.
+		vi.mocked(getCanonicalRepoUrl).mockRejectedValueOnce("git exploded");
+		expect(await readPushDisabledState(repo)).toEqual({ disabled: true, error: "git exploded" });
+	});
+
+	// The memo is per-cwd and never shrinks on its own, so a long-lived host that
+	// walks many roots would grow it without bound. Past the cap, a miss also
+	// drops whatever has expired.
+	it("sweeps expired identities once the memo reaches its cap", async () => {
+		// Mirrors PushControl's IDENTITY_CACHE_SWEEP_AT / GATE_IDENTITY_TTL_MS.
+		const SWEEP_AT = 64;
+		const TTL_MS = 5_000;
+		// Distinct cwds inside ONE git repo: each is its own memo key, but only one
+		// `git init` is paid. The clock is pinned so nothing expires mid-fill.
+		const t0 = Date.now();
+		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(t0);
+		const resolver = vi.mocked(getCanonicalRepoUrl);
+		const realResolver = resolver.getMockImplementation();
+		// Stub the resolution itself: filling the memo needs 65 distinct cwds, and
+		// paying a `git config` spawn for each would add ~15s to the suite for no
+		// extra coverage — the memo's behaviour is what's under test.
+		resolver.mockImplementation(async (cwd: string) => `file://${cwd}`);
+		try {
+			for (let i = 0; i <= SWEEP_AT; i++) {
+				const sub = join(repo, `sub-${i}`);
+				mkdirSync(sub, { recursive: true });
+				await readPushDisabledState(sub);
+			}
+			// The last iteration crossed the cap and swept — but nothing had expired,
+			// so every entry survived and a repeat read is still served from the memo.
+			const before = vi.mocked(getCanonicalRepoUrl).mock.calls.length;
+			await readPushDisabledState(join(repo, "sub-0"));
+			expect(vi.mocked(getCanonicalRepoUrl)).toHaveBeenCalledTimes(before);
+
+			// Past the TTL the next miss evicts them, and sub-0 has to be resolved again.
+			nowSpy.mockReturnValue(t0 + TTL_MS + 1);
+			const sweeper = join(repo, "sweeper");
+			mkdirSync(sweeper, { recursive: true });
+			await readPushDisabledState(sweeper);
+			await readPushDisabledState(join(repo, "sub-0"));
+			expect(vi.mocked(getCanonicalRepoUrl).mock.calls.length).toBeGreaterThan(before);
+		} finally {
+			nowSpy.mockRestore();
+			if (realResolver) resolver.mockImplementation(realResolver);
+		}
+	});
+
+	it("setRepoPushDisabledByIdentity reports a rebuild from an unreadable store", async () => {
+		await setRepoPushDisabledByIdentity("https://github.com/acme/other", true, "cli");
+		writeFileSync(getPushControlPath(globalDir), "{ not json");
+		const result = await setRepoPushDisabledByIdentity("https://github.com/acme/x", false, "vscode");
+		expect(result.recoveredFromCorrupt).toBe(true);
+	});
+
 	describe("listPushControlRepos", () => {
 		let localFolder: string;
 
@@ -168,6 +231,51 @@ describe("PushControl", () => {
 			expect(rows[0].isCurrentRepo).toBe(true);
 			expect(rows[0].repoIdentity).toBe("https://github.com/acme/other");
 			expect(rows[1].isCurrentRepo).toBe(false);
+		});
+
+		// Two non-current rows exercise the name tiebreak; the current repo (added
+		// last, so it starts out AFTER them) exercises the other side of the
+		// isCurrentRepo comparison.
+		it("sorts the current repo first, then the rest by name", async () => {
+			for (const name of ["alpha", "zulu"]) {
+				const kbRoot = join(localFolder, name);
+				mkdirSync(join(kbRoot, ".jolli"), { recursive: true });
+				writeFileSync(
+					join(kbRoot, ".jolli", "config.json"),
+					JSON.stringify({ repoName: name, remoteUrl: `https://github.com/acme/${name}.git` }),
+				);
+			}
+			execFileSync("git", ["remote", "add", "origin", "https://github.com/acme/mine.git"], { cwd: repo });
+
+			const rows = await listPushControlRepos({ localFolder, currentCwd: repo });
+			expect(rows.map((r) => r.repoName)).toEqual(["mine", "alpha", "widgets", "zulu"]);
+			expect(rows.map((r) => r.isCurrentRepo)).toEqual([true, false, false, false]);
+		});
+
+		// Same ordering rule from the other side: when the current repo COLLAPSES
+		// onto an existing Memory Bank row it keeps that row's position in the
+		// pre-sort list, so the comparator sees it as the second operand.
+		it("keeps a collapsed current-repo row first even when it started ahead of the others", async () => {
+			const kbRoot = join(localFolder, "alpha");
+			mkdirSync(join(kbRoot, ".jolli"), { recursive: true });
+			writeFileSync(
+				join(kbRoot, ".jolli", "config.json"),
+				JSON.stringify({ repoName: "alpha", remoteUrl: "https://github.com/acme/alpha.git" }),
+			);
+			execFileSync("git", ["remote", "add", "origin", "https://github.com/acme/alpha.git"], { cwd: repo });
+
+			const rows = await listPushControlRepos({ localFolder, currentCwd: repo });
+			expect(rows.map((r) => r.repoName)).toEqual(["alpha", "widgets"]);
+			expect(rows.map((r) => r.isCurrentRepo)).toEqual([true, false]);
+		});
+
+		it("still lists Memory Bank rows when the current repo's identity cannot be resolved", async () => {
+			// A cwd that is not a repo (or a git failure) must not sink the whole
+			// list — the current-repo row is simply omitted.
+			vi.mocked(getCanonicalRepoUrl).mockRejectedValueOnce(new Error("not a git repository"));
+			const rows = await listPushControlRepos({ localFolder, currentCwd: repo });
+			expect(rows.map((r) => r.repoName)).toEqual(["widgets"]);
+			expect(rows[0].isCurrentRepo).toBe(false);
 		});
 
 		it("still lists the current repo when it has no remote (file:// identity)", async () => {

--- a/cli/src/core/PushControlStore.test.ts
+++ b/cli/src/core/PushControlStore.test.ts
@@ -1,8 +1,38 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Two seams for the recovery path, both defaulting to real behaviour:
+//  - `rename` so the "could not preserve the unreadable store" arm is reachable
+//    without making the whole directory unwritable (the rebuild must still run);
+//  - the file lock so the "never silently drop a toggle" fallback can be
+//    exercised without waiting out a real lock timeout.
+const seam = vi.hoisted(() => ({ renameError: undefined as unknown, lockUnavailable: false }));
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs/promises")>();
+	return {
+		...actual,
+		// Scoped to the corrupt-store BACKUP rename only: `atomicWriteFile` renames
+		// too, and failing that would break the rebuild this test needs to observe.
+		rename: async (...args: Parameters<typeof actual.rename>) => {
+			if (seam.renameError !== undefined && String(args[1]).includes(".corrupt-")) throw seam.renameError;
+			return actual.rename(...args);
+		},
+	};
+});
+vi.mock("./Locks.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./Locks.js")>();
+	return {
+		...actual,
+		withPushControlLock: async <T>(
+			fn: () => Promise<T>,
+			opts?: Parameters<typeof actual.withPushControlLock>[1],
+		) => (seam.lockUnavailable ? { acquired: false as const } : actual.withPushControlLock(fn, opts)),
+	};
+});
+
 import {
 	CORRUPT_SUFFIX,
 	getPushControlPath,
@@ -17,6 +47,8 @@ describe("PushControlStore", () => {
 
 	beforeEach(() => {
 		dir = mkdtempSync(join(tmpdir(), "jolli-pcstore-"));
+		seam.renameError = undefined;
+		seam.lockUnavailable = false;
 	});
 	afterEach(() => {
 		rmSync(dir, { recursive: true, force: true });
@@ -123,6 +155,41 @@ describe("PushControlStore", () => {
 		// ...and the rebuilt store is valid but empty — the other repo's opt-out is
 		// gone, which is exactly why the flag above has to be surfaced.
 		expect((await loadDisabledRepos(dir)).size).toBe(0);
+	});
+
+	it("propagates a read fault that is not a missing file, naming the path", async () => {
+		// A DIRECTORY where the store should be → EISDIR. Unlike ENOENT ("nothing
+		// disabled yet") this is a real fault, so the gate must fail closed.
+		mkdirSync(getPushControlPath(dir), { recursive: true });
+		await expect(loadDisabledRepos(dir)).rejects.toThrow(getPushControlPath(dir));
+	});
+
+	it("treats a JSON `null` store as empty rather than dereferencing it", async () => {
+		writeFileSync(getPushControlPath(dir), "null");
+		expect((await loadDisabledRepos(dir)).size).toBe(0);
+	});
+
+	it("still rebuilds when the unreadable store cannot be moved aside", async () => {
+		// Preserving the bad bytes is best-effort. If the rename fails the user
+		// still asked to enable, so the rebuild must proceed — just without a
+		// `preservedAt` to report.
+		await setRepoPushDisabled("https://github.com/acme/other", true, { globalDir: dir });
+		writeFileSync(getPushControlPath(dir), "{ not json");
+		seam.renameError = Object.assign(new Error("EXDEV: cross-device link not permitted"), { code: "EXDEV" });
+
+		const result = await setRepoPushDisabled("https://github.com/acme/x", false, { globalDir: dir });
+		expect(result).toMatchObject({ disabled: false, recoveredFromCorrupt: true });
+		expect(result.preservedAt).toBeUndefined();
+		expect((await loadDisabledRepos(dir)).size).toBe(0);
+	});
+
+	it("writes the toggle anyway when the store lock cannot be acquired", async () => {
+		// Losing the lock must never silently drop a user's toggle — the write is
+		// re-run unlocked rather than skipped.
+		seam.lockUnavailable = true;
+		const result = await setRepoPushDisabled("https://github.com/acme/x", true, { globalDir: dir });
+		expect(result.disabled).toBe(true);
+		expect(await isRepoPushDisabled("https://github.com/acme/x", dir)).toBe(true);
 	});
 
 	it("refuses a NEWER-schema store both ways, and never rebuilds it", async () => {

--- a/cli/src/core/PushControlStore.ts
+++ b/cli/src/core/PushControlStore.ts
@@ -19,7 +19,7 @@
  */
 import { readFile, rename } from "node:fs/promises";
 import { join } from "node:path";
-import { createLogger } from "../Logger.js";
+import { createLogger, errMsg } from "../Logger.js";
 import { atomicWriteFile } from "./AtomicWrite.js";
 import { deriveRepoNameFromUrl } from "./GitRemoteUtils.js";
 import { withPushControlLock } from "./Locks.js";
@@ -241,12 +241,12 @@ export async function setRepoPushDisabled(
 				log.warn(
 					"setRepoPushDisabled: could not preserve the unreadable store at %s: %s",
 					path,
-					renameError instanceof Error ? renameError.message : String(renameError),
+					errMsg(renameError),
 				);
 			}
 			log.warn(
 				"setRepoPushDisabled: push-control store was unreadable (%s) — rebuilding from empty on the enable path; every other repo's opt-out is dropped%s",
-				error instanceof Error ? error.message : String(error),
+				errMsg(error),
 				preservedAt ? ` (previous file kept at ${preservedAt})` : "",
 			);
 			recoveredFromCorrupt = true;
@@ -267,9 +267,17 @@ export async function setRepoPushDisabled(
 		// `listPushControlRepos` pins "en" for the same reason). Identities are also
 		// case-sensitive keys — a collator with `sensitivity: "base"` would call two
 		// distinct identities equal and leave their relative order unstable.
-		const disabledList = [...current.values()].sort((a, b) =>
-			a.identity < b.identity ? -1 : a.identity > b.identity ? 1 : 0,
-		);
+		const disabledList = [...current.values()].sort((a, b) => {
+			/* v8 ignore start -- unreachable today: `current` is a Map keyed by identity, so
+			   two entries can never carry the same one. Kept anyway, because dropping it
+			   makes the comparator INCONSISTENT for a duplicate key (both argument orders
+			   would return the same sign), and V8's TimSort answers an inconsistent
+			   comparator with an arbitrary order — so a future change that admits duplicates
+			   would silently reshuffle this on-disk file with no test failing. */
+			if (a.identity === b.identity) return 0;
+			/* v8 ignore stop */
+			return a.identity < b.identity ? -1 : 1;
+		});
 		const file: PushControlFile = { version: PUSH_CONTROL_VERSION, disabled: disabledList };
 		await atomicWriteFile(getPushControlPath(dir), `${JSON.stringify(file, null, "\t")}\n`);
 	};

--- a/cli/src/core/PushPendingStore.test.ts
+++ b/cli/src/core/PushPendingStore.test.ts
@@ -56,6 +56,82 @@ describe("loadPushPending", () => {
 		expect(Object.keys(file.entries)).toHaveLength(0);
 	});
 
+	// The shape guard has to reject each way the file can be valid JSON yet not a
+	// pending file — a bad state file must never block the pre-push flow.
+	it.each([
+		["a bare JSON scalar", JSON.stringify("just a string")],
+		["JSON null", "null"],
+		["a non-object `entries`", JSON.stringify({ version: 1, entries: 5 })],
+		["a null `entries`", JSON.stringify({ version: 1, entries: null })],
+	])("returns empty for %s", async (_label, contents) => {
+		await writeFile(filePath(), contents, "utf8");
+		expect(Object.keys((await loadPushPending(cwd)).entries)).toHaveLength(0);
+	});
+
+	it("returns empty when the pending path is unreadable (not merely absent)", async () => {
+		// A DIRECTORY where the file should be → EISDIR, which is a real failure
+		// rather than the routine "nothing enqueued yet" ENOENT.
+		await rm(filePath(), { force: true });
+		await mkdir(filePath(), { recursive: true });
+		expect(Object.keys((await loadPushPending(cwd)).entries)).toHaveLength(0);
+	});
+
+	it("tolerates an unlink failure when the file becomes empty", async () => {
+		// Non-empty DIRECTORY at the pending path → the `rm` inside writeOrUnlink
+		// fails. Writing an empty entry set must still resolve, not reject.
+		await rm(filePath(), { force: true });
+		await mkdir(join(filePath(), "occupied"), { recursive: true });
+		await expect(__writeForTest(cwd, { version: 1, entries: {} })).resolves.toBeUndefined();
+	});
+
+	// The locked re-read exists because another process can refresh the entries
+	// between the optimistic read and the lock. When it has, there is nothing
+	// left to prune and the load must NOT rewrite the file it just re-read.
+	it("skips the prune write when a concurrent writer already refreshed the entries", async () => {
+		const old = new Date(Date.now() - PUSH_PENDING_STALE_MS - 1000).toISOString();
+		const fresh = new Date().toISOString();
+		await __writeForTest(cwd, {
+			version: 1,
+			entries: { [HASH_A]: { branch: "b", enqueuedAt: old, retryCount: 0 } },
+		});
+
+		let releaseHolder: () => void = () => {};
+		let markEntered: () => void = () => {};
+		const entered = new Promise<void>((resolve) => {
+			markEntered = resolve;
+		});
+		const holder = withPushPendingLock(cwd, async () => {
+			markEntered();
+			await new Promise<void>((resolve) => {
+				releaseHolder = resolve;
+			});
+			// Stand in for the concurrent enqueue: replace the stale entry with a
+			// fresh one AFTER the loader's optimistic read has already seen the
+			// stale file and queued behind this lock.
+			await writeFile(
+				filePath(),
+				JSON.stringify({
+					version: 1,
+					entries: { [HASH_B]: { branch: "b", enqueuedAt: fresh, retryCount: 0 } },
+				}),
+				"utf8",
+			);
+		});
+		await entered;
+
+		// Optimistic read happens here and sees the stale entry, so the loader
+		// takes the lock instead of returning early.
+		const loading = loadPushPending(cwd);
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		releaseHolder();
+		await holder;
+
+		expect(Object.keys((await loading).entries)).toEqual([HASH_B]);
+		// The refreshed file is left exactly as the concurrent writer wrote it.
+		const onDisk = JSON.parse(await readFile(filePath(), "utf8")) as PushPendingFile;
+		expect(Object.keys(onDisk.entries)).toEqual([HASH_B]);
+	});
+
 	it("reads back a valid file", async () => {
 		const now = new Date().toISOString();
 		await __writeForTest(cwd, {

--- a/cli/src/core/PushRefusal.test.ts
+++ b/cli/src/core/PushRefusal.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { isRepoWideRefusal, REPO_WIDE_REFUSAL_NAMES } from "./PushRefusal.js";
+
+/** Builds an error carrying only a `name` — the cross-surface contract this module matches on. */
+function named(name: string, message = "boom"): Error {
+	const err = new Error(message);
+	err.name = name;
+	return err;
+}
+
+describe("isRepoWideRefusal", () => {
+	it("classifies every listed name as repo-wide", () => {
+		for (const name of REPO_WIDE_REFUSAL_NAMES) {
+			expect(isRepoWideRefusal(named(name))).toBe(true);
+		}
+	});
+
+	it("carries both spellings of each cross-surface condition", () => {
+		// The CLI and the two IDE clients name the same server response differently,
+		// and errors cross the IDE bridge BY NAME — so listing one spelling would
+		// silently demote the other to a per-item failure on the surface that raises it.
+		expect(REPO_WIDE_REFUSAL_NAMES.has("ClientOutdatedError")).toBe(true); // CLI, 426
+		expect(REPO_WIDE_REFUSAL_NAMES.has("PluginOutdatedError")).toBe(true); // VS Code + IntelliJ, 426
+		expect(REPO_WIDE_REFUSAL_NAMES.has("NotAuthenticatedError")).toBe(true); // CLI, 401
+		expect(REPO_WIDE_REFUSAL_NAMES.has("UnauthorizedError")).toBe(true); // IntelliJ, 401
+	});
+
+	it("treats a rejected credential as repo-wide, not as one failed attachment", () => {
+		// A 401 is a property of the repo + credential: every remaining document in
+		// the loop gets the identical rejection. Collecting it reported one sign-in
+		// problem as N `plan "X" failed` lines and fired N doomed requests. IntelliJ's
+		// `repoWideStopReason` already classified it this way; this is the entry that
+		// brings the other three classifiers into line with it.
+		expect(isRepoWideRefusal(named("NotAuthenticatedError"))).toBe(true);
+		expect(isRepoWideRefusal(named("UnauthorizedError"))).toBe(true);
+	});
+
+	it("leaves BindingRequiredError out — it is recoverable, not a refusal", () => {
+		// Each loop that cannot run the binding chooser adds it explicitly; folding it
+		// in here would make it fatal for the callers that CAN recover from it.
+		expect(isRepoWideRefusal(named("BindingRequiredError"))).toBe(false);
+	});
+
+	it("leaves ordinary failures on the collect path", () => {
+		expect(isRepoWideRefusal(named("Error", "HTTP 500"))).toBe(false);
+		expect(isRepoWideRefusal(named("TypeError"))).toBe(false);
+	});
+
+	it("returns false for non-Error values", () => {
+		expect(isRepoWideRefusal("PermissionDeniedError")).toBe(false);
+		expect(isRepoWideRefusal({ name: "PermissionDeniedError" })).toBe(false);
+		expect(isRepoWideRefusal(undefined)).toBe(false);
+		expect(isRepoWideRefusal(null)).toBe(false);
+	});
+});

--- a/cli/src/core/PushRefusal.ts
+++ b/cli/src/core/PushRefusal.ts
@@ -42,11 +42,39 @@
  * Error `name`s that mean "this repo cannot push right now", for any credential
  * and for every document in it.
  *
- * Both spellings of the outdated-client condition are listed on purpose: the CLI
- * raises `ClientOutdatedError` while the VS Code and IntelliJ clients raise
- * `PluginOutdatedError` for the identical server response (HTTP 426). Since this
- * set is shared and errors also cross the IDE bridge by name, matching only one
- * spelling would silently classify the other as a per-item failure.
+ * Two conditions are listed under BOTH of their spellings on purpose, because the
+ * surfaces name the same server response differently and errors cross the IDE
+ * bridge by name — matching one spelling would silently classify the other as a
+ * per-item failure. HTTP 426: `ClientOutdatedError` (CLI) / `PluginOutdatedError`
+ * (VS Code + IntelliJ). HTTP 401: `NotAuthenticatedError` (CLI) /
+ * `UnauthorizedError` (IntelliJ).
+ *
+ * Note that 403 maps to whichever of the two auth names the endpoint can justify,
+ * and both are listed here because both are repo-wide: the read-shaped endpoints
+ * (`frontDoor`, `deleteDoc`) cannot tell a rejected credential from a forbidden
+ * repo and fold 403 into `NotAuthenticatedError`, while the push/bind endpoints
+ * distinguish it and raise `PermissionDeniedError`. Don't go looking for a single
+ * 403 branch — there isn't one (see `JolliMemoryPushClient`).
+ *
+ * A rejected credential is repo-wide for the same reason the others are: it is a
+ * property of the repo + credential, so every remaining document in a loop gets
+ * the identical rejection. It was the last classifier disagreement — IntelliJ's
+ * `CreatePrPanel.repoWideStopReason` already stopped the whole loop on it and
+ * reported "sign-in rejected", while `JolliPushOrchestrator.isFatalPushError` and
+ * the CLI's three attachment loops collected it as N separate `plan "X" failed`
+ * lines and fired N doomed requests on the way.
+ *
+ * **That 401 promotion reaches the CLI and IntelliJ, NOT VS Code** — membership
+ * here is necessary but not sufficient, because a surface also has to PRODUCE one
+ * of these names. `vscode/src/services/JolliPushService.ts` branches on 426, 412,
+ * 409 and 403 only, so a 401 falls through to its generic non-2xx arm and rejects
+ * with a plain `Error`, whose `name` is `"Error"` — a string this set cannot
+ * match. Its attachment loops therefore still collect a rejected credential as N
+ * per-item failures, exactly the shape the promotion removes elsewhere. A
+ * `status === 401` branch in that client, raising `UnauthorizedError`, is all it
+ * takes for VS Code to inherit the behaviour; until it exists, read "shared
+ * classifier" as shared membership, not as identical behaviour on this one
+ * condition.
  *
  * `BindingRequiredError` is deliberately ABSENT: it is recoverable — the caller
  * runs the binding chooser and retries — so it is fatal only to the loop that
@@ -56,6 +84,8 @@
 export const REPO_WIDE_REFUSAL_NAMES: ReadonlySet<string> = new Set([
 	"ClientOutdatedError",
 	"PluginOutdatedError",
+	"NotAuthenticatedError",
+	"UnauthorizedError",
 	"PushDisabledError",
 	"PermissionDeniedError",
 ]);

--- a/cli/src/core/RepoProfile.test.ts
+++ b/cli/src/core/RepoProfile.test.ts
@@ -7,6 +7,7 @@ import {
 	readManualDisableFlag,
 	readManualDisableFlagSync,
 	readRepoProfile,
+	resetRepoProfileRootCache,
 	updateRepoProfile,
 	writeManualDisableFlag,
 } from "./RepoProfile.js";
@@ -25,6 +26,9 @@ describe("RepoProfile", () => {
 	beforeEach(() => {
 		cwd = mkdtempSync(join(tmpdir(), "jolli-repoprofile-"));
 		execFileSync("git", ["init", "-q"], { cwd });
+		// The sync reader memoizes its main-root resolution per cwd; clear it so a
+		// recycled temp path can't inherit a previous case's answer.
+		resetRepoProfileRootCache();
 	});
 	afterEach(() => {
 		rmSync(cwd, { recursive: true, force: true });
@@ -281,6 +285,25 @@ describe("RepoProfile", () => {
 				mkdirSync(join(cwd, ".jolli", "jollimemory"), { recursive: true });
 				writeFileSync(legacyMarker(cwd), new Date(0).toISOString());
 				expect(readManualDisableFlagSync(cwd)).toBe(true);
+			});
+
+			it("memoizes the main-root resolution so repeat calls spawn no further git", async () => {
+				// The funnel telemetry gate calls this on every VS Code status refresh, so
+				// the `git rev-parse` must be paid once per cwd. Proven behaviorally: read
+				// from a SUBDIR (where the resolution is what maps it back to the repo
+				// root), then remove `.git`. A memoized reader keeps answering from the
+				// main root; an unmemoized one would re-resolve, fail, and fall back to the
+				// subdir — where there is no profile.
+				const sub = join(cwd, "nested");
+				mkdirSync(sub, { recursive: true });
+				await writeManualDisableFlag(cwd, true);
+				expect(readManualDisableFlagSync(sub)).toBe(true);
+
+				rmSync(join(cwd, ".git"), { recursive: true, force: true });
+				expect(readManualDisableFlagSync(sub)).toBe(true);
+
+				resetRepoProfileRootCache();
+				expect(readManualDisableFlagSync(sub)).toBe(false);
 			});
 
 			it("returns false for a non-git dir with no profile or marker", () => {

--- a/cli/src/core/RepoProfile.ts
+++ b/cli/src/core/RepoProfile.ts
@@ -239,11 +239,64 @@ export async function writeManualDisableFlag(cwd: string, disabled: boolean): Pr
 }
 
 /**
- * Synchronous, read-only variant of {@link readManualDisableFlag}. The VS Code
- * extension's `activate()` calls this to seed the in-memory zero-write flag
- * before any async work runs — a stray log line during early activation must
+ * Memo for the sync reader's main-worktree-root resolution, keyed by input `cwd`.
+ *
+ * Mirrors `GitOps._stateRootCache` and exists for the same reason: this is no
+ * longer a once-per-process seed. The onboarding-funnel gate calls
+ * {@link readManualDisableFlagSync} from `maybeEmitOnboardingProgress`, which VS
+ * Code runs on every `StatusStore.refresh()` — including two file watchers that
+ * fire repeatedly while an AI session is live — so an unmemoized
+ * `git rev-parse --git-common-dir` would spawn a subprocess per refresh on the
+ * extension host's event loop.
+ *
+ * Memoizing this cannot stale the flag: a repo's common dir is fixed for the life
+ * of a process, and the `profile.json` read that carries the actual answer stays
+ * uncached, so every enable/disable is still observed on the next call. The
+ * not-a-git-repo answer is memoized too — equally stable, and the case that pays
+ * the full subprocess cost.
+ */
+const _mainRootCache = new Map<string, string>();
+
+/** Test-only: clears the memo so cases don't leak resolved roots into each other. */
+export function resetRepoProfileRootCache(): void {
+	_mainRootCache.clear();
+}
+
+/** Resolves (and memoizes) the main worktree root for the sync reader. */
+function resolveMainRootSync(cwd: string): string {
+	const cached = _mainRootCache.get(cwd);
+	if (cached !== undefined) return cached;
+	let commonDir = "";
+	try {
+		const raw = execFileSyncHidden("git", ["rev-parse", "--git-common-dir"], {
+			cwd,
+			encoding: "utf-8",
+			// Capture git's stderr so a non-git cwd doesn't leak "fatal: not a git
+			// repository …" to the user's terminal; the throw is handled below. Load
+			// bearing since the onboarding-funnel gate calls this from the guided
+			// front door's non-git dead end, where the leak would print directly
+			// under jolli's own "not a git repository" message.
+			stdio: ["ignore", "pipe", "pipe"],
+		}).trim();
+		if (raw) {
+			commonDir = isAbsolute(raw) ? raw : join(cwd, raw);
+		}
+	} catch {
+		commonDir = "";
+	}
+	const mainRoot = commonDir ? dirname(commonDir) : cwd;
+	_mainRootCache.set(cwd, mainRoot);
+	return mainRoot;
+}
+
+/**
+ * Synchronous, read-only variant of {@link readManualDisableFlag}. Two callers:
+ * the VS Code extension's `activate()` seeds the in-memory zero-write flag with
+ * it before any async work runs (a stray log line during early activation must
  * not touch disk in a manually disabled repo, and the async reader can't be
- * awaited that early.
+ * awaited that early), and the onboarding-funnel telemetry gate uses it as the
+ * disk-backed truth that CLI processes — which never set the in-memory mirror —
+ * need. The funnel gate calls it repeatedly, hence the `_mainRootCache` memo.
  *
  * Best-effort by design: unlike the async reader it never migrates the legacy
  * marker or persists a decision (the async reader does that later); it only
@@ -254,16 +307,7 @@ export async function writeManualDisableFlag(cwd: string, disabled: boolean): Pr
  * in `cwd`, then to `false`.
  */
 export function readManualDisableFlagSync(cwd: string): boolean {
-	let commonDir = "";
-	try {
-		const raw = execFileSyncHidden("git", ["rev-parse", "--git-common-dir"], { cwd, encoding: "utf-8" }).trim();
-		if (raw) {
-			commonDir = isAbsolute(raw) ? raw : join(cwd, raw);
-		}
-	} catch {
-		commonDir = "";
-	}
-	const mainRoot = commonDir ? dirname(commonDir) : cwd;
+	const mainRoot = resolveMainRootSync(cwd);
 	try {
 		const parsed = JSON.parse(readFileSync(join(getJolliMemoryDir(mainRoot), PROFILE_FILE), "utf-8"));
 		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {

--- a/cli/src/core/SessionTitleResolver.test.ts
+++ b/cli/src/core/SessionTitleResolver.test.ts
@@ -150,6 +150,33 @@ describe("resolveSessionTitle", () => {
 	});
 });
 
+// Every source has an entry in PARSE_LINE, but the ones whose discoverer always
+// supplies a native title are deliberate no-op stubs — they exist so the record
+// stays exhaustive over TranscriptSource, not because a line format was ever
+// reverse-engineered for them. Pin that: the resolver must still hand the
+// fallback a parser, and that parser must decline every line rather than invent
+// a title from a transcript shape nobody verified.
+describe("PARSE_LINE stubs for discoverer-titled sources", () => {
+	it.each(["opencode", "cursor", "copilot", "cline", "cline-cli", "devin", "cursor-cli", "antigravity"] as const)(
+		"passes a parser for %s that declines every line",
+		async (source) => {
+			vi.mocked(readFirstUserMessageTitle).mockResolvedValueOnce("(untitled session)");
+			await resolveSessionTitle({
+				sessionId: "s1",
+				transcriptPath: "/tmp/x.jsonl",
+				updatedAt: "2026-05-15T00:00:00Z",
+				source,
+			});
+
+			const { parseLine } = vi.mocked(readFirstUserMessageTitle).mock.calls.at(-1)?.[0] ?? {};
+			expect(parseLine).toBeTypeOf("function");
+			for (const line of ['{"type":"user","content":"hello"}', "not json", ""]) {
+				expect(parseLine?.(line)).toBeUndefined();
+			}
+		},
+	);
+});
+
 // `firstUserMessageTitleFromEntries` is a pure helper exposed for the
 // sidebar aggregator's "load once, derive both count and title" shortcut.
 // Tested directly so the mergedEntries→title contract stays pinned even if

--- a/cli/src/core/SessionTracker.test.ts
+++ b/cli/src/core/SessionTracker.test.ts
@@ -432,6 +432,42 @@ describe("SessionTracker", () => {
 			await expect(migrateDiscoveryCursors(tempDir)).resolves.toBeUndefined();
 			expect(await loadDiscoveryCursor("/path/none.jsonl", tempDir)).toBeNull();
 		});
+
+		// The shared `lineNumber` must track the SLOWEST extractor. When a record
+		// already carries per-extractor marks but none for a legacy-covered
+		// extractor, that extractor's floor is whatever the record's own
+		// `lineNumber` claimed — advancing past it would make an older dist (which
+		// reads only `lineNumber`) skip lines nobody scanned.
+		it("floors the shared lineNumber at the record's own value for an unmarked legacy extractor", async () => {
+			const path = "/path/partial.jsonl";
+			await saveDiscoveryCursor(
+				{
+					transcriptPath: path,
+					lineNumber: 20,
+					updatedAt: "t",
+					// `skills` has run; neither legacy-covered extractor has a mark.
+					extractors: { skills: 400 },
+				},
+				tempDir,
+			);
+
+			await saveExtractorCursor(path, "skills", 500, tempDir);
+
+			const cursor = await loadDiscoveryCursor(path, tempDir);
+			expect(cursor?.lineNumber).toBe(20);
+			expect(await loadExtractorCursorLine(path, "skills", tempDir)).toBe(500);
+		});
+
+		// Devin's resume anchor lives on the cursor, not in `lineNumber`. Advancing
+		// an extractor must not drop it, or the next read re-scans the whole forest.
+		it("preserves an existing anchorId when advancing an extractor", async () => {
+			const path = "/devin/sessions.db#s1";
+			await saveDiscoveryCursor({ transcriptPath: path, lineNumber: 3, updatedAt: "t", anchorId: "42" }, tempDir);
+
+			await saveExtractorCursor(path, "references", 9, tempDir);
+
+			expect((await loadDiscoveryCursor(path, tempDir))?.anchorId).toBe("42");
+		});
 	});
 
 	describe("loadMostRecentSession", () => {
@@ -1598,6 +1634,20 @@ describe("SessionTracker", () => {
 
 				await saveConfigScoped({ localAgentTool: "opencode" }, targetDir);
 				expect((await readSaved(targetDir)).localAgentPath).toBeUndefined();
+			});
+
+			it("clears a legacy bare path on the FIRST switch away from the default", async () => {
+				// Same legacy shape as above, but switching straight to another tool
+				// without first re-saving claude-code — so the stored config still has
+				// no `localAgentTool` at the moment the orphan is detected.
+				const targetDir = join(tempDir, "orphan-legacy-direct");
+				await saveConfigScoped({ localAgentPath: "/opt/claude" }, targetDir);
+
+				await saveConfigScoped({ localAgentTool: "codex" }, targetDir);
+
+				const config = await readSaved(targetDir);
+				expect(config.localAgentTool).toBe("codex");
+				expect(config.localAgentPath).toBeUndefined();
 			});
 
 			it("keeps the path when the tool is re-saved unchanged", async () => {
@@ -3074,6 +3124,20 @@ describe("skills registry", () => {
 			expect(row?.contentHashAtCommit).toBe("archivehash");
 		});
 
+		it("ignores a key that is not an archived key at all", async () => {
+			// Hoisting feeds this every ref on a squashed commit, including plan and
+			// note refs whose keys carry no `-<shortHash>` suffix. Those must be
+			// skipped silently rather than treated as a missing skill guard.
+			const before = {
+				version: 1 as const,
+				plans: {},
+				skills: { "claude:superpowers:brainstorming": skillRow({ commitHash: "424f5413aaaaaaaa" }) },
+			};
+			await savePlansRegistry(before, tempDir);
+			await associateSkillWithCommit("not-an-archived-key", "11de7b16cccccccc", tempDir);
+			await expect(loadPlansRegistry(tempDir)).resolves.toEqual(before);
+		});
+
 		it("leaves the registry alone when no guard matches the old short hash", async () => {
 			const before = {
 				version: 1 as const,
@@ -3106,6 +3170,46 @@ describe("skills registry", () => {
 			expect(Object.keys(registry.skills ?? {})).toEqual(["claude:superpowers:brainstorming"]);
 			expect(registry.skills?.["claude:superpowers:brainstorming"]?.invocationCount).toBe(2);
 			expect(registry.skills?.["claude:superpowers:brainstorming"]?.lastUsedAt).toBe("2026-07-30T07:00:00.000Z");
+		});
+
+		// The plugin is discovered from the transcript envelope, which not every
+		// pass carries. A later pass without one must not erase the row's plugin.
+		it("keeps the row's plugin when a later pass reports none", async () => {
+			await upsertSkillEntry(skillUse(), tempDir);
+			await upsertSkillEntry(skillUse({ plugin: undefined }), tempDir);
+			expect((await loadPlansRegistry(tempDir)).skills?.["claude:superpowers:brainstorming"]?.plugin).toBe(
+				"superpowers",
+			);
+		});
+
+		// A row guarded by a build that predates `archivedTotals` has no baseline,
+		// so `uncommittedDelta`'s legacy rule reads it as fully committed forever.
+		// The next fold seeds the baseline from the pre-fold counters, which is
+		// exactly what that archive froze.
+		it("seeds archivedTotals from the pre-fold counters for a legacy-guarded row", async () => {
+			await savePlansRegistry(
+				{
+					version: 1,
+					plans: {},
+					skills: {
+						"claude:superpowers:brainstorming": skillRow({
+							commitHash: "424f5413aaaaaaaa",
+							contentHashAtCommit: "archivehash",
+							invocationCount: 1,
+							// no archivedTotals — the legacy shape
+						}),
+					},
+				},
+				tempDir,
+			);
+
+			await upsertSkillEntry(skillUse({ invocations: [{ at: "2026-07-30T07:00:00.000Z", ok: true }] }), tempDir);
+
+			const row = (await loadPlansRegistry(tempDir)).skills?.["claude:superpowers:brainstorming"];
+			// Seeded from the guarded row's counters — that is what the archive froze.
+			expect(row?.archivedTotals).toEqual({ invocationCount: 1 });
+			// The guard itself is never resurrected by a fold.
+			expect(row?.commitHash).toBe("424f5413aaaaaaaa");
 		});
 
 		it("keeps the same skill from two sources as two rows", async () => {

--- a/cli/src/core/SessionTracker.ts
+++ b/cli/src/core/SessionTracker.ts
@@ -348,7 +348,10 @@ export async function saveExtractorCursor(
 		const existing = registry.cursors[transcriptPath] ?? null;
 
 		const marks = effectiveExtractorMarks(existing);
-		marks[extractor] = Math.max(marks[extractor] ?? 0, lineNumber);
+		// Kept in a local as well as on `marks`: reading it back out of the partial
+		// record below would need a `??` fallback that can never fire.
+		const advancedMark = Math.max(marks[extractor] ?? 0, lineNumber);
+		marks[extractor] = advancedMark;
 
 		// The shared field must not overtake an extractor that has no mark yet. Its floor
 		// is whatever the record already claimed (legacy seeding covers a bare
@@ -357,10 +360,7 @@ export async function saveExtractorCursor(
 		// makes a dist reading only this field skip lines nobody processed. That is
 		// exactly the straddling-fetch protection the Codex discovery path relies on.
 		const legacyFloor = existing?.lineNumber ?? 0;
-		const values = [
-			...LEGACY_COVERED_EXTRACTORS.map((e) => marks[e] ?? legacyFloor),
-			marks[extractor] ?? lineNumber,
-		];
+		const values = [...LEGACY_COVERED_EXTRACTORS.map((e) => marks[e] ?? legacyFloor), advancedMark];
 		const next: TranscriptCursor = {
 			transcriptPath,
 			lineNumber: Math.min(...values),

--- a/cli/src/core/SkillsAggregateMarkdown.test.ts
+++ b/cli/src/core/SkillsAggregateMarkdown.test.ts
@@ -98,6 +98,28 @@ describe("buildSkillsTable", () => {
 		]);
 	});
 
+	it("still orders by name when NO row has a total to sort by", () => {
+		// Every unattributed row totals 0, so the name tie-break carries the whole
+		// ordering — the common shape for a host that attributes nothing at all.
+		const none = { usage: undefined };
+		const lines = buildSkillsTable([
+			row({ skill: "zebra", ...none }),
+			row({ skill: "alpha", ...none }),
+			row({ skill: "mango", ...none }),
+		]);
+		expect(lines.slice(2).map((l) => l.split(" | ")[0])).toEqual(["| alpha", "| mango", "| zebra"]);
+	});
+
+	it("keeps two rows that share a skill id instead of collapsing them", () => {
+		// The renderer takes an array, not a map: an equal-name tie must stay a tie so
+		// both rows reach the table and their counts stay distinguishable.
+		const lines = buildSkillsTable([
+			row({ skill: "same", invocationCount: 1, usage: undefined }),
+			row({ skill: "same", invocationCount: 7, usage: undefined }),
+		]);
+		expect(lines.slice(2)).toEqual(["| same | 1 | — | — | — | — |", "| same | 7 | — | — | — | — |"]);
+	});
+
 	it("daggers an inferred row and spells the footnote out once", () => {
 		const lines = buildSkillsTable([row({ detection: "heuristic", usage: undefined }), row()]);
 		expect(lines).toContain("| superpowers:brainstorming † | 2 | — | — | — | — |");

--- a/cli/src/core/SummaryFormat.test.ts
+++ b/cli/src/core/SummaryFormat.test.ts
@@ -10,6 +10,7 @@ import {
 	collectAllNotesWithHosts,
 	collectAllPlans,
 	collectAllPlansWithHosts,
+	collectLlmSources,
 	collectSortedTopics,
 	formatDate,
 	formatFullDate,
@@ -577,6 +578,40 @@ describe("collectAllNotesWithHosts", () => {
 
 	it("returns empty array when no notes exist", () => {
 		expect(collectAllNotesWithHosts(leaf())).toHaveLength(0);
+	});
+});
+
+// ─── collectLlmSources ──────────────────────────────────────────────────────
+
+// Consumed by the VS Code extension through `views/SummaryUtils` (the CLI is
+// bundled into it), so the contract is pinned here too rather than only in the
+// vscode suite.
+describe("collectLlmSources", () => {
+	it("returns an empty list when no node carries a source", () => {
+		expect(collectLlmSources({ children: [] } as never)).toEqual([]);
+	});
+
+	it("collects the root's own source", () => {
+		expect(collectLlmSources({ llm: { source: "anthropic-env" }, children: [] } as never)).toEqual([
+			"anthropic-env",
+		]);
+	});
+
+	// A plain (non-squash) commit summary has no `children` key at all.
+	it("handles a leaf with no children key", () => {
+		expect(collectLlmSources({ llm: { source: "local-agent" } } as never)).toEqual(["local-agent"]);
+	});
+
+	// A squash container has no `llm` of its own — the providers that actually
+	// produced the content live on its children, so the walk must recurse.
+	it("recurses into children and de-duplicates, in first-seen order", () => {
+		const squash = {
+			children: [
+				{ llm: { source: "jolli-proxy" }, children: [] },
+				{ llm: { source: "anthropic-config" }, children: [{ llm: { source: "jolli-proxy" }, children: [] }] },
+			],
+		};
+		expect(collectLlmSources(squash as never)).toEqual(["jolli-proxy", "anthropic-config"]);
 	});
 });
 

--- a/cli/src/core/SummaryFormat.ts
+++ b/cli/src/core/SummaryFormat.ts
@@ -159,11 +159,14 @@ export function collectLlmSources(summary: CommitSummary): ReadonlyArray<LlmCred
  * Every other source renders through the static `PROVIDER_LABELS` map,
  * unchanged from before.
  */
-function nodeLabel(llm: NonNullable<CommitSummary["llm"]>): string {
-	if (llm.source === "local-agent") {
+// `source` is passed separately, already narrowed by the caller's truthiness
+// guard. Re-reading `llm.source` here would force a `?? "anthropic-config"`
+// fallback that no caller can ever reach.
+function nodeLabel(llm: NonNullable<CommitSummary["llm"]>, source: LlmCredentialSource): string {
+	if (source === "local-agent") {
 		return llm.localAgentTool ? `Local agent - ${localAgentToolLabel(llm.localAgentTool)}` : "Local agent";
 	}
-	return PROVIDER_LABELS[llm.source ?? "anthropic-config"];
+	return PROVIDER_LABELS[source];
 }
 
 /**
@@ -183,7 +186,8 @@ function nodeLabel(llm: NonNullable<CommitSummary["llm"]>): string {
 export function formatProviderLabel(summary: CommitSummary): string | undefined {
 	const labels = new Set<string>();
 	const visit = (node: CommitSummary): void => {
-		if (node.llm?.source) labels.add(nodeLabel(node.llm));
+		const llm = node.llm;
+		if (llm?.source) labels.add(nodeLabel(llm, llm.source));
 		for (const child of node.children ?? []) visit(child);
 	};
 	visit(summary);

--- a/cli/src/core/TraceContext.test.ts
+++ b/cli/src/core/TraceContext.test.ts
@@ -5,7 +5,26 @@
  * *propagation semantics* (scope nesting, env adoption), never a specific id.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+// The all-zero id is the sentinel the backend rejects, so `randomNonZeroHex`
+// loops until it draws something else. That draw is astronomically unlikely
+// (2^-128), so the retry arm is only reachable by forcing the first draw.
+const crypto = vi.hoisted(() => ({ forceZeroOnce: false }));
+vi.mock("node:crypto", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:crypto")>();
+	return {
+		...actual,
+		randomBytes: (size: number) => {
+			if (crypto.forceZeroOnce) {
+				crypto.forceZeroOnce = false;
+				return Buffer.alloc(size);
+			}
+			return actual.randomBytes(size);
+		},
+	};
+});
+
 import {
 	buildTraceHeader,
 	currentTraceHeader,
@@ -150,5 +169,21 @@ describe("traceIdFromEnv", () => {
 
 	it("ignores the all-zero sentinel env value", () => {
 		expect(traceIdFromEnv({ [TRACE_ID_ENV]: ALL_ZERO_TRACE_ID })).toBeUndefined();
+	});
+});
+
+describe("all-zero rejection at generation time", () => {
+	it("redraws a trace id when the first random draw is all-zero", () => {
+		crypto.forceZeroOnce = true;
+		const id = generateTraceId();
+		expect(id).toMatch(TRACE_ID_RE);
+		expect(id).not.toBe(ALL_ZERO_TRACE_ID);
+	});
+
+	it("redraws a span id when the first random draw is all-zero", () => {
+		crypto.forceZeroOnce = true;
+		const id = generateSpanId();
+		expect(id).toMatch(SPAN_ID_RE);
+		expect(id).not.toBe("0".repeat(16));
 	});
 });

--- a/cli/src/core/TranscriptLoader.test.ts
+++ b/cli/src/core/TranscriptLoader.test.ts
@@ -23,13 +23,41 @@ vi.mock("./ClineTranscriptReader.js", () => ({
 vi.mock("./ClineCliTranscriptReader.js", () => ({
 	readClineCliTranscript: vi.fn(),
 }));
+vi.mock("./DevinTranscriptReader.js", () => ({
+	readDevinTranscript: vi.fn(),
+}));
+vi.mock("./CursorCliTranscriptReader.js", () => ({
+	readCursorCliTranscript: vi.fn(),
+}));
+// Partial: the antigravity happy path below reads a REAL jsonl file, so the
+// reader stays real and is only overridden for the throw cases.
+vi.mock("./AntigravityTranscriptReader.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./AntigravityTranscriptReader.js")>();
+	return { ...actual, readAntigravityTranscript: vi.fn(actual.readAntigravityTranscript) };
+});
 
+import { readAntigravityTranscript } from "./AntigravityTranscriptReader.js";
 import { readClineCliTranscript } from "./ClineCliTranscriptReader.js";
 import { readClineTranscript } from "./ClineTranscriptReader.js";
 import { readCopilotTranscript } from "./CopilotTranscriptReader.js";
+import { readCursorCliTranscript } from "./CursorCliTranscriptReader.js";
 import { readCursorTranscript } from "./CursorTranscriptReader.js";
+import { readDevinTranscript } from "./DevinTranscriptReader.js";
 import { readOpenCodeTranscript } from "./OpenCodeTranscriptReader.js";
 import { loadTranscript } from "./TranscriptLoader.js";
+
+/** An ENOENT-coded error — the shape every reader-level "file is gone" surfaces as. */
+function enoent(): Error {
+	return Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" });
+}
+
+function readResult(entries: Array<{ role: "human" | "assistant"; content: string }>, path: string) {
+	return {
+		entries,
+		newCursor: { transcriptPath: path, lineNumber: entries.length, updatedAt: "2026-07-19T00:00:00Z" },
+		totalLinesRead: entries.length,
+	};
+}
 
 describe("loadTranscript", () => {
 	let dir: string;
@@ -251,6 +279,41 @@ describe("loadTranscript", () => {
 	it("returns [] for a missing antigravity transcript", async () => {
 		const result = await loadTranscript({ source: "antigravity", transcriptPath: join(dir, "nope.jsonl") });
 		expect(result).toEqual([]);
+	});
+
+	it("dispatches devin source to readDevinTranscript with the synthetic db#session path", async () => {
+		const path = "/devin/sessions.db#sess-1";
+		vi.mocked(readDevinTranscript).mockResolvedValueOnce(
+			readResult([{ role: "human", content: "devin ask" }], path),
+		);
+		const result = await loadTranscript({ source: "devin", transcriptPath: path });
+		expect(readDevinTranscript).toHaveBeenCalledWith(path);
+		expect(result).toEqual([{ role: "human", content: "devin ask" }]);
+	});
+
+	it("dispatches cursor-cli source to readCursorCliTranscript", async () => {
+		const path = "/cursor/agent-transcripts/u1/u1.jsonl";
+		vi.mocked(readCursorCliTranscript).mockResolvedValueOnce(
+			readResult([{ role: "assistant", content: "cursor-cli reply" }], path),
+		);
+		const result = await loadTranscript({ source: "cursor-cli", transcriptPath: path });
+		expect(readCursorCliTranscript).toHaveBeenCalledWith(path);
+		expect(result).toEqual([{ role: "assistant", content: "cursor-cli reply" }]);
+	});
+
+	// Two arms per reader: a vanished file (ENOENT) is routine and must stay
+	// silent, while anything else is worth a warning. Both degrade to [] so a
+	// single unreadable session never takes down the panel.
+	it.each([
+		["devin", readDevinTranscript, "/devin/sessions.db#sess-1"],
+		["cursor-cli", readCursorCliTranscript, "/cursor/u1.jsonl"],
+		["antigravity", readAntigravityTranscript, "/agy/transcript_full.jsonl"],
+	] as const)("returns [] when the %s reader throws, ENOENT or otherwise", async (source, reader, path) => {
+		vi.mocked(reader).mockRejectedValueOnce(enoent(path));
+		expect(await loadTranscript({ source, transcriptPath: path })).toEqual([]);
+
+		vi.mocked(reader).mockRejectedValueOnce(new Error("schema drift"));
+		expect(await loadTranscript({ source, transcriptPath: path })).toEqual([]);
 	});
 
 	// Each sqlite-backed reader's catch branch — proves loader errors degrade

--- a/cli/src/core/TranscriptMessageCounter.test.ts
+++ b/cli/src/core/TranscriptMessageCounter.test.ts
@@ -396,6 +396,60 @@ describe("countTranscriptMessages", () => {
 			expect(entries).toHaveLength(2);
 		});
 
+		// Every source has to be routed to its own reader. These three were added
+		// after the switch and had no arm-level cover: a missing arm silently falls
+		// through to the Claude parser, which reads a Devin sqlite path or an
+		// Antigravity JSONL as Claude JSONL and reports zero messages forever.
+		it.each([
+			["devin", "sessions.db#sess-1"],
+			["cursor-cli", "chat.jsonl"],
+			["antigravity", "transcript_full.jsonl"],
+		] as const)("routes %s to its own reader and degrades to [] when unreadable", async (source, name) => {
+			// A projectDir is required or the loader short-circuits to the full-
+			// transcript path and never reaches the per-source switch. The temp dir
+			// has no cursors.json, so the reader is also handed a null cursor.
+			const projectDir = mkdtempSync(join(tmpdir(), "msg-counter-src-"));
+			try {
+				const entries = await loadUnreadTranscript(source, join(dir, "does-not-exist", name), projectDir);
+				expect(entries).toEqual([]);
+			} finally {
+				rmSync(projectDir, { recursive: true, force: true });
+			}
+		});
+
+		// The Antigravity reader takes `TranscriptCursor | undefined` (not `| null`),
+		// so the loader has to translate a "no cursor stored" null. Both sides of
+		// that translation need to hold.
+		it("passes a stored cursor through to the Antigravity reader", async () => {
+			const projectDir = mkdtempSync(join(tmpdir(), "msg-counter-agy-"));
+			try {
+				const file = join(dir, "agy-unread.jsonl");
+				writeFileSync(
+					file,
+					[
+						JSON.stringify({ type: "USER_INPUT", created_at: "2026-07-19T09:00:00Z", content: "used" }),
+						JSON.stringify({ type: "USER_INPUT", created_at: "2026-07-19T09:00:01Z", content: "fresh" }),
+						"",
+					].join("\n"),
+				);
+				const jmDir = join(projectDir, ".jolli", "jollimemory");
+				mkdirSync(jmDir, { recursive: true });
+				writeFileSync(
+					join(jmDir, "cursors.json"),
+					JSON.stringify({
+						version: 1,
+						cursors: {
+							[file]: { transcriptPath: file, lineNumber: 1, updatedAt: "2026-07-19T09:00:00Z" },
+						},
+					}),
+				);
+				const entries = await loadUnreadTranscript("antigravity", file, projectDir);
+				expect(entries.map((e) => e.content)).toEqual(["fresh"]);
+			} finally {
+				rmSync(projectDir, { recursive: true, force: true });
+			}
+		});
+
 		it("returns an empty array on read failure", async () => {
 			const projectDir = mkdtempSync(join(tmpdir(), "msg-counter-raw-err-"));
 			try {

--- a/cli/src/core/localagent/CodexBackend.test.ts
+++ b/cli/src/core/localagent/CodexBackend.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { CodexBackend } from "./CodexBackend.js";
+import { CODEX_SPEC, CodexBackend } from "./CodexBackend.js";
 import * as resolver from "./ExecutableResolver.js";
 import { LocalAgentAuthError, LocalAgentSetupError } from "./Types.js";
 
@@ -31,6 +31,24 @@ describe("CodexBackend", () => {
 		].join("\n");
 		const out = b.parseResult(stream);
 		expect(out.text).toBe("hello 42");
+	});
+
+	it("tolerates a typeless event, an empty agent_message, and a usage-less turn", () => {
+		const stream = [
+			// No `type` at all (a bare handshake line) — must not be treated as an
+			// error just because the haystack is empty.
+			JSON.stringify({ thread_id: "abc" }),
+			JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "the answer" } }),
+			// A later empty agent_message must not blank the text already captured.
+			JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "" } }),
+			// turn.completed with a usage object that reports nothing.
+			JSON.stringify({ type: "turn.completed", usage: {} }),
+		].join("\n");
+		const out = b.parseResult(stream);
+		expect(out.text).toBe("the answer");
+		expect(out.inputTokens).toBe(0);
+		expect(out.outputTokens).toBe(0);
+		expect(out.cachedTokens).toBe(0);
 	});
 
 	it("scrubs OPENAI_API_KEY and OPENAI_BASE_URL, sets child-reentry env", () => {
@@ -107,5 +125,26 @@ describe("CodexBackend.isPresent", () => {
 		const spy = vi.spyOn(resolver, "isPresent").mockReturnValue(true);
 		expect(new CodexBackend().isPresent()).toBe(true);
 		expect(spy).toHaveBeenCalledWith(expect.objectContaining({ binName: "codex" }), { overridePath: undefined });
+	});
+});
+
+describe("CodexBackend.discoverExecutable", () => {
+	it("resolves through the shared resolver, forwarding the override path", async () => {
+		const spy = vi.spyOn(resolver, "resolveExecutable").mockReturnValue({ file: "/opt/codex", version: "0.9.0" });
+		await expect(b.discoverExecutable("/opt/codex")).resolves.toEqual({ file: "/opt/codex", version: "0.9.0" });
+		expect(spy).toHaveBeenCalledWith(expect.objectContaining({ binName: "codex" }), {
+			overridePath: "/opt/codex",
+		});
+		spy.mockRestore();
+	});
+});
+
+describe("CODEX_SPEC.knownPaths", () => {
+	// Built with path.win32 / path.posix rather than the host `path`, so the
+	// expectations hold on a Windows dev machine and in POSIX CI alike.
+	it("points at the standalone installer's location on each platform", () => {
+		expect(CODEX_SPEC.knownPaths("C:\\Users\\u", "win32")).toEqual(["C:\\Users\\u\\.local\\bin\\codex.exe"]);
+		expect(CODEX_SPEC.knownPaths("/home/u", "darwin")).toEqual(["/home/u/.local/bin/codex"]);
+		expect(CODEX_SPEC.knownPaths("/home/u", "linux")).toEqual(["/home/u/.local/bin/codex"]);
 	});
 });

--- a/cli/src/core/localagent/CodexBackend.ts
+++ b/cli/src/core/localagent/CodexBackend.ts
@@ -30,7 +30,8 @@ interface CodexEvent {
 	message?: string;
 }
 
-const CODEX_SPEC = {
+/** Exported so the install-location rules can be asserted per platform in tests. */
+export const CODEX_SPEC = {
 	binName: "codex",
 	knownPaths: (home: string, platform: NodeJS.Platform) =>
 		platform === "win32"

--- a/cli/src/core/localagent/CursorAgentBackend.test.ts
+++ b/cli/src/core/localagent/CursorAgentBackend.test.ts
@@ -59,6 +59,42 @@ describe("CursorAgentBackend", () => {
 	it("throws LocalAgentSetupError on non-JSON stdout", () => {
 		expect(() => b.parseResult("not json")).toThrow(LocalAgentSetupError);
 	});
+
+	// The error envelope's detail is best-effort: `result`, else `subtype`, else a
+	// placeholder. A message reading `Cursor returned an error: undefined` would
+	// tell the user nothing at all.
+	it("falls back through result → subtype → 'unknown' for the error detail", () => {
+		expect(() => b.parseResult(JSON.stringify({ is_error: true, subtype: "rate_limited" }))).toThrow(
+			"Cursor returned an error: rate_limited",
+		);
+		expect(() => b.parseResult(JSON.stringify({ is_error: true }))).toThrow("Cursor returned an error: unknown");
+	});
+
+	it("classifies an auth failure signalled only by the subtype", () => {
+		// `result` carries no auth wording; the subtype is the only signal.
+		expect(() =>
+			b.parseResult(JSON.stringify({ is_error: true, subtype: "auth_expired", result: "nope" })),
+		).toThrow(LocalAgentAuthError);
+	});
+
+	// A success envelope from an older/leaner CLI build carries neither `usage`
+	// nor `result`. Every numeric field must still come back as a number.
+	it("defaults every field when the success envelope is bare", () => {
+		const out = b.parseResult(JSON.stringify({ type: "result" }));
+		expect(out).toEqual({
+			text: "",
+			inputTokens: 0,
+			outputTokens: 0,
+			cachedTokens: 0,
+			costUsd: 0,
+			stopReason: null,
+		});
+	});
+
+	it("sums the two cache counters when only one is reported", () => {
+		const out = b.parseResult(JSON.stringify({ result: "hi", usage: { cacheReadTokens: 7 } }));
+		expect(out.cachedTokens).toBe(7);
+	});
 });
 
 /**
@@ -155,6 +191,20 @@ describe("CursorAgentBackend.buildInvocation with a resolved Windows launcher", 
 describe("CursorAgentBackend.isPresent", () => {
 	it("is false for an override path that does not exist", () => {
 		expect(new CursorAgentBackend().isPresent("/nonexistent/path/to/cursor-agent")).toBe(false);
+	});
+
+	it("resolves through the shared resolver, forwarding the override path", async () => {
+		const spy = vi
+			.spyOn(resolver, "resolveExecutable")
+			.mockReturnValue({ file: "/opt/cursor-agent", version: "1.0.0" });
+		await expect(new CursorAgentBackend().discoverExecutable("/opt/cursor-agent")).resolves.toEqual({
+			file: "/opt/cursor-agent",
+			version: "1.0.0",
+		});
+		expect(spy).toHaveBeenCalledWith(expect.objectContaining({ binName: "cursor-agent" }), {
+			overridePath: "/opt/cursor-agent",
+		});
+		spy.mockRestore();
 	});
 
 	it("delegates to the CURSOR_SPEC discovery, not another tool's", () => {

--- a/cli/src/core/localagent/ExecutableResolver.test.ts
+++ b/cli/src/core/localagent/ExecutableResolver.test.ts
@@ -586,5 +586,59 @@ describe("discoverPresence", () => {
 			mkdirSync(join(dir, "mytool"));
 			expect(isPresent(SPEC, { overridePath: join(dir, "mytool"), platform: process.platform })).toBe(false);
 		});
+
+		// Windows has no execute bit and a presence hit is allowed to be a `.cmd` /
+		// `.ps1` shim, so the win32 predicate stops at "is a regular file". Pinned
+		// with an explicit platform so it holds on POSIX CI too.
+		it("accepts a non-executable regular file under win32 rules", () => {
+			const file = join(dir, "mytool");
+			writeFileSync(file, "");
+			chmodSync(file, 0o644);
+			expect(isPresent(SPEC, { overridePath: file, platform: "win32" })).toBe(true);
+			// The same file is rejected on POSIX, where the execute bit is the signal.
+			if (process.platform !== "win32") {
+				expect(isPresent(SPEC, { overridePath: file, platform: "linux" })).toBe(false);
+			}
+		});
+	});
+
+	// The three ambient defaults `discoverPresence` falls back to when the caller
+	// supplies no seams. Exercised through an empty PATH so the scan is bounded to
+	// the common-dir augmentation and cannot hit a real install.
+	describe("ambient defaults", () => {
+		it("falls back to the real home and an absent PATH without throwing", () => {
+			vi.stubEnv("PATH", undefined as unknown as string);
+			try {
+				expect(discoverPresence(SPEC, "darwin", { exists: () => false })).toEqual([]);
+			} finally {
+				vi.unstubAllEnvs();
+			}
+		});
+
+		// win32 only: `discoveryPath` already drops empty POSIX segments, but it
+		// returns the Windows PATH verbatim, so a doubled / trailing `;` survives
+		// to the scan and would otherwise join to a bare relative "faketool.exe".
+		it("skips empty PATH segments on win32 instead of probing a relative path", () => {
+			const probed: string[] = [];
+			discoverPresence(SPEC, "win32", {
+				basePath: "C:\\a;;C:\\b;",
+				home: "C:\\Users\\u",
+				exists: (f) => {
+					probed.push(f);
+					return false;
+				},
+			});
+			expect(probed.length).toBeGreaterThan(0);
+			expect(probed.every((p) => p.includes("\\"))).toBe(true);
+		});
+
+		it("falls back to an absent PATH inside discover() too", () => {
+			vi.stubEnv("PATH", undefined as unknown as string);
+			try {
+				expect(discover(SPEC, "darwin", { runFinder: () => "", exists: () => false })).toEqual([]);
+			} finally {
+				vi.unstubAllEnvs();
+			}
+		});
 	});
 });

--- a/cli/src/core/localagent/LocalAgentRunner.test.ts
+++ b/cli/src/core/localagent/LocalAgentRunner.test.ts
@@ -249,4 +249,54 @@ describe("runInvocation", () => {
 			vi.useRealTimers();
 		}
 	});
+
+	// Mirror of the case above: the child wins the race, so the timeout must be
+	// cancelled — otherwise a finished run would still be SIGTERM'd (and a
+	// long-lived host would leak a kill timer per call).
+	it("cancels its timeout once the child has finished", async () => {
+		vi.useFakeTimers();
+		try {
+			const child = makeFakeChild();
+			const promise = runInvocation(inv, { timeoutMs: 50, spawnImpl: spawnReturning(child) });
+			child.stdout.write("done");
+			child.stdout.end();
+			child.stderr.end();
+			child.emit("close", 0);
+			await expect(promise).resolves.toBe("done");
+
+			// The late timer must not kill anything or reject a settled promise.
+			await vi.advanceTimersByTimeAsync(60);
+			expect(child.kill).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	// A stream configured with an encoding emits strings, not Buffers. Both
+	// pipes have to cope, or the output is `[object Object]`-ish garbage.
+	it("accepts string chunks on stdout and stderr, not just Buffers", async () => {
+		const child = makeFakeChild();
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		const promise = runInvocation(inv, { spawnImpl: spawnReturning(child) });
+		child.stdout.write("chunked ");
+		child.stdout.write("output");
+		child.stderr.write("a warning");
+		child.stdout.end();
+		child.stderr.end();
+		child.emit("close", 0);
+		await expect(promise).resolves.toBe("chunked output");
+	});
+
+	// No `spawnImpl` override: the production default really launches a process.
+	it("spawns for real when no spawnImpl is injected", async () => {
+		const out = await runInvocation({
+			file: process.execPath,
+			args: ["-e", "process.stdout.write('from a real child')"],
+			stdin: "",
+			env: {},
+			cwd: process.cwd(),
+		});
+		expect(out).toBe("from a real child");
+	});
 });

--- a/cli/src/core/localagent/LocalAgentRunner.ts
+++ b/cli/src/core/localagent/LocalAgentRunner.ts
@@ -81,7 +81,12 @@ export function runInvocation(inv: Invocation, opts: RunOpts = {}): Promise<stri
 		// created, so by construction it can never be un-set again before that
 		// timer fires — no need to track/clear it from the close/error handlers.
 		const timer = setTimeout(() => {
+			/* v8 ignore start -- unreachable: the close and error handlers each set `settled`
+			   and clearTimeout THIS timer within one synchronous turn, so there is no point
+			   at which a settled run still has a live timer to fire. Kept as a belt-and-braces
+			   guard against a future handler that sets `settled` but forgets to clear. */
 			if (settled) return;
+			/* v8 ignore stop */
 			settled = true;
 			child.kill("SIGTERM");
 			setTimeout(() => child.kill("SIGKILL"), KILL_GRACE_MS).unref?.();

--- a/cli/src/core/localagent/OpenCodeBackend.test.ts
+++ b/cli/src/core/localagent/OpenCodeBackend.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import * as resolver from "./ExecutableResolver.js";
-import { expandOpenCodeShim, OpenCodeBackend } from "./OpenCodeBackend.js";
+import { expandOpenCodeShim, OPENCODE_SPEC, OpenCodeBackend } from "./OpenCodeBackend.js";
 import { LocalAgentSetupError } from "./Types.js";
 
 const fixture = readFileSync(join(__dirname, "__fixtures__/opencode/success.json"), "utf8");
@@ -109,5 +109,34 @@ describe("OpenCodeBackend.isPresent", () => {
 		expect(spy).toHaveBeenCalledWith(expect.objectContaining({ binName: "opencode" }), {
 			overridePath: undefined,
 		});
+	});
+});
+
+describe("OpenCodeBackend.discoverExecutable", () => {
+	it("resolves through the shared resolver, forwarding the override path", async () => {
+		const spy = vi
+			.spyOn(resolver, "resolveExecutable")
+			.mockReturnValue({ file: "/opt/opencode", version: "1.2.3" });
+		await expect(b.discoverExecutable("/opt/opencode")).resolves.toEqual({
+			file: "/opt/opencode",
+			version: "1.2.3",
+		});
+		expect(spy).toHaveBeenCalledWith(expect.objectContaining({ binName: "opencode" }), {
+			overridePath: "/opt/opencode",
+		});
+		spy.mockRestore();
+	});
+});
+
+describe("OPENCODE_SPEC.knownPaths", () => {
+	// Built with path.win32 / path.posix rather than the host `path`, so the
+	// expectations hold on a Windows dev machine and in POSIX CI alike. Windows
+	// lists the standalone installer's native binary first, then the npm layout.
+	it("lists the install locations for each platform", () => {
+		expect(OPENCODE_SPEC.knownPaths("C:\\Users\\u", "win32")).toEqual([
+			"C:\\Users\\u\\.opencode\\bin\\opencode.exe",
+			"C:\\Users\\u\\.local\\bin\\opencode.exe",
+		]);
+		expect(OPENCODE_SPEC.knownPaths("/home/u", "darwin")).toEqual(["/home/u/.local/bin/opencode"]);
 	});
 });

--- a/cli/src/core/localagent/OpenCodeBackend.ts
+++ b/cli/src/core/localagent/OpenCodeBackend.ts
@@ -26,7 +26,8 @@ export function expandOpenCodeShim(shimPath: string, deps: ShimDeps): Candidate[
 	return deps.exists(exe) ? [{ file: exe }] : [];
 }
 
-const OPENCODE_SPEC = {
+/** Exported so the install-location rules can be asserted per platform in tests. */
+export const OPENCODE_SPEC = {
 	binName: "opencode",
 	knownPaths: (home: string, platform: NodeJS.Platform) =>
 		platform === "win32"

--- a/cli/src/core/plans/ClaudePlanScanner.test.ts
+++ b/cli/src/core/plans/ClaudePlanScanner.test.ts
@@ -1,0 +1,100 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { claudePlanScanner } from "./ClaudePlanScanner.js";
+
+/**
+ * A Claude transcript line carrying one Write/Edit `tool_use`.
+ *
+ * `filePathLiteral` is spliced in RAW rather than passed through `JSON.stringify`:
+ * the escape sequences inside that literal are exactly what the scanner has to
+ * decode, and re-encoding would hand it a different string than the one on disk.
+ */
+const writeTool = (filePathLiteral: string, name: "Write" | "Edit" = "Write"): string =>
+	`{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"${name}","input":{"file_path":"${filePathLiteral}","content":"x"}}]}}`;
+
+let dir: string;
+let transcript: string;
+const cwd = "/work/repo";
+
+const write = (...lines: string[]): void => writeFileSync(transcript, `${lines.join("\n")}\n`, "utf-8");
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "claude-plan-scan-"));
+	transcript = join(dir, "session.jsonl");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("ClaudePlanScanner", () => {
+	it("keys a ~/.claude/plans/ write by slug rather than by path", async () => {
+		write(writeTool("/Users/dev/.claude/plans/refactor-storage.md"));
+		const res = await claudePlanScanner.scan(transcript, 0, cwd);
+		expect([...res.slugs]).toEqual(["refactor-storage"]);
+		expect(res.externalPlans.size).toBe(0);
+	});
+
+	it("collects any other .md write as an external plan path", async () => {
+		write(writeTool("/work/repo/docs/design.md", "Edit"));
+		const res = await claudePlanScanner.scan(transcript, 0, cwd);
+		expect([...res.externalPlans]).toEqual(["/work/repo/docs/design.md"]);
+		expect(res.slugs.size).toBe(0);
+	});
+
+	it("decodes every JSON escape in the captured path, unicode included", async () => {
+		// The capture is a substring of a JSON string literal, so any escape the format
+		// allows can appear. A plain backslash-unescape would leave `\u8bbe` verbatim.
+		write(writeTool(String.raw`C:\\work\\\u8bbe\u8ba1.md`));
+		const res = await claudePlanScanner.scan(transcript, 0, cwd);
+		expect([...res.externalPlans]).toEqual([String.raw`C:\work\设计.md`]);
+	});
+
+	it("drops a path whose escape sequence cannot be decoded", async () => {
+		// `\x` is not a JSON escape, so the re-parse throws. Recording the raw, still
+		// escaped substring instead would put a path that exists nowhere on disk into
+		// the plan set, so skipping the target is the only honest option.
+		write(writeTool(String.raw`/work/repo/bad\xescape.md`));
+		const res = await claudePlanScanner.scan(transcript, 0, cwd);
+		expect(res.externalPlans.size).toBe(0);
+		expect(res.totalLines).toBe(1);
+	});
+
+	it("reads a plan-mode slug field on its own", async () => {
+		write('{"type":"user","toolUseResult":{"plan":"...","slug":"pipeline-redesign"}}');
+		const res = await claudePlanScanner.scan(transcript, 0, cwd);
+		expect([...res.slugs]).toEqual(["pipeline-redesign"]);
+	});
+
+	it("ignores an empty slug field", async () => {
+		// The cheap `includes` pre-filter admits it; the capture requires at least one
+		// character, and a blank slug would key a plan file that cannot be resolved.
+		write('{"type":"user","toolUseResult":{"slug":""}}');
+		const res = await claudePlanScanner.scan(transcript, 0, cwd);
+		expect(res.slugs.size).toBe(0);
+	});
+
+	it("honours the fromLine / toLine window and still reports the full line count", async () => {
+		// `totalLines` is the caller's cursor, so it counts every line the stream
+		// yielded — not just the ones the window admitted.
+		write(writeTool("/a/one.md"), writeTool("/a/two.md"), writeTool("/a/three.md"), writeTool("/a/four.md"));
+		const res = await claudePlanScanner.scan(transcript, 1, cwd, 3);
+		expect([...res.externalPlans].sort()).toEqual(["/a/three.md", "/a/two.md"]);
+		expect(res.totalLines).toBe(4);
+	});
+
+	it("ignores a Write to a non-markdown target", async () => {
+		write(writeTool("/work/repo/src/index.ts"));
+		const res = await claudePlanScanner.scan(transcript, 0, cwd);
+		expect(res.externalPlans.size).toBe(0);
+		expect(res.slugs.size).toBe(0);
+	});
+
+	it("ignores a .md file_path belonging to a tool other than Write/Edit", async () => {
+		// Reading a plan is not writing one; only the two mutating tools count.
+		write(
+			'{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Read","input":{"file_path":"/work/repo/docs/design.md"}}]}}',
+		);
+		const res = await claudePlanScanner.scan(transcript, 0, cwd);
+		expect(res.externalPlans.size).toBe(0);
+	});
+});

--- a/cli/src/core/references/ClaudeEnvelopeParser.test.ts
+++ b/cli/src/core/references/ClaudeEnvelopeParser.test.ts
@@ -536,3 +536,78 @@ describe("ClaudeEnvelopeParser jollimemory (self-referential, arguments-derived)
 		expect(results[0].payload).toEqual({ tool: "recall", title: "Recall", query: "(current branch)" });
 	});
 });
+
+describe("ClaudeEnvelopeParser confluence", () => {
+	// Confluence is a context-normalized source not because it needs out-of-payload
+	// context, but because the DSL cannot flatten its `{content:{nodes:[…]}}`
+	// wrapper (nor an ADF-object body) into the canonical page shape.
+	const PAGE_URL = "https://acme.atlassian.net/wiki/spaces/ENG/pages/557292/Per-Provider";
+
+	function confluenceLines(body: unknown): string[] {
+		return [
+			JSON.stringify({
+				message: {
+					role: "assistant",
+					content: [
+						{
+							type: "tool_use",
+							id: "c1",
+							name: "mcp__claude_ai_Atlassian__getConfluencePage",
+							input: { pageId: "557292" },
+						},
+					],
+				},
+			}),
+			JSON.stringify({
+				message: {
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "c1",
+							content: JSON.stringify({
+								content: {
+									totalCount: 1,
+									nodes: [
+										{
+											id: "557292",
+											type: "page",
+											title: "Per-Provider pools",
+											space: { key: "ENG", name: "Engineering" },
+											author: { displayName: "Flyer Li" },
+											webUrl: PAGE_URL,
+											body,
+										},
+									],
+								},
+							}),
+						},
+					],
+				},
+			}),
+		];
+	}
+
+	it("flattens the nodes wrapper into the canonical page shape", () => {
+		const { results } = claudeEnvelopeParser.parse(confluenceLines("## TL;DR\n\nUse one pool."), {});
+		expect(results).toHaveLength(1);
+		expect(results[0].def.id).toBe("confluence");
+		expect(results[0].payload).toMatchObject({
+			pageId: "557292",
+			title: "Per-Provider pools",
+			url: PAGE_URL,
+			body: "## TL;DR\n\nUse one pool.",
+			space: "Engineering",
+			author: "Flyer Li",
+		});
+	});
+
+	it("renders an ADF-object body to text on the way through", () => {
+		const adf = {
+			type: "doc",
+			content: [{ type: "paragraph", content: [{ type: "text", text: "One pool per provider." }] }],
+		};
+		const { results } = claudeEnvelopeParser.parse(confluenceLines(adf), {});
+		expect((results[0].payload as { body?: string }).body).toBe("One pool per provider.");
+	});
+});

--- a/cli/src/core/references/CodexEnvelopeParser.test.ts
+++ b/cli/src/core/references/CodexEnvelopeParser.test.ts
@@ -1490,3 +1490,151 @@ describe("jollimemory local MCP (fallback path, three bare tool names)", () => {
 		expect(codexEnvelopeParser.parse([line], {}).results).toHaveLength(0);
 	});
 });
+
+// ─── envelope-level defensive paths ──────────────────────────────────────────
+//
+// Rollout files are appended live by another process, so the parser has to
+// survive blank lines, torn writes and rows whose optional keys are simply
+// absent — without dropping the well-formed rows around them.
+describe("CodexEnvelopeParser — malformed and partial rows", () => {
+	/** Minimal monday board payload — enough for the itemIds gate to pass. */
+	const MONDAY_ITEMS = {
+		board: { id: "18421599187", name: "Tasks" },
+		items: [
+			{
+				id: "12511130115",
+				name: "Add monday MCP integration",
+				url: "https://jolli-squad.monday.com/boards/18421599187/pulses/12511130115",
+			},
+		],
+	};
+
+	it("skips blank lines and JSON that is not an object, keeping the surrounding rows", () => {
+		const lines = [
+			"",
+			// Valid JSON that is a bare string. It carries the pre-filter needle, so
+			// it reaches JSON.parse and must be rejected on shape, not crash.
+			JSON.stringify("mcp_tool_call_end"),
+			fnCall("mcp__codex_apps__linear", "_get_issue", "c1"),
+			fnOutput("c1", LINEAR, { wrap: "array", prefix: true }),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results.map((r) => r.def.id)).toEqual(["linear"]);
+	});
+
+	it("defaults referencedAt to the empty string when a row carries no timestamp", () => {
+		const call = JSON.stringify({
+			type: "response_item",
+			payload: { type: "function_call", name: "_get_issue", namespace: "mcp__codex_apps__linear", call_id: "c1" },
+		});
+		const out = JSON.stringify({
+			type: "response_item",
+			payload: {
+				type: "function_call_output",
+				call_id: "c1",
+				output: JSON.stringify([{ type: "text", text: JSON.stringify(LINEAR) }]),
+			},
+		});
+		const { results } = codexEnvelopeParser.parse([call, out], {});
+		expect(results).toHaveLength(1);
+		expect(results[0].referencedAt).toBe("");
+	});
+
+	it("ignores a result row that carries no call_id to correlate on", () => {
+		const orphanOutput = JSON.stringify({
+			type: "response_item",
+			timestamp: TS,
+			payload: { type: "function_call_output", output: JSON.stringify(LINEAR) },
+		});
+		const orphanEnd = JSON.stringify({
+			type: "event_msg",
+			timestamp: TS,
+			payload: {
+				type: "mcp_tool_call_end",
+				invocation: { server: "codex_apps", tool: "linear.get_issue" },
+				result: { Ok: { content: [{ type: "text", text: JSON.stringify(LINEAR) }] } },
+			},
+		});
+		// The event still yields its reference (correlation is only needed to reach
+		// back for the paired request's arguments); the bare output row does not.
+		expect(codexEnvelopeParser.parse([orphanOutput], {}).results).toHaveLength(0);
+		expect(codexEnvelopeParser.parse([orphanEnd], {}).results).toHaveLength(1);
+	});
+
+	it("drops an mcp_tool_call_end whose result content is not a text block", () => {
+		for (const content of [[42], ["text"], [null]]) {
+			const line = JSON.stringify({
+				type: "event_msg",
+				timestamp: TS,
+				payload: {
+					type: "mcp_tool_call_end",
+					call_id: "c1",
+					invocation: { server: "codex_apps", tool: "linear.get_issue" },
+					result: { Ok: { content } },
+				},
+			});
+			expect(codexEnvelopeParser.parse([line], {}).results).toHaveLength(0);
+		}
+	});
+
+	it("parses a JSON-string invocation.arguments the same as a pre-parsed object", () => {
+		// codex_apps events carry `arguments` pre-parsed; the sibling function_call
+		// serializes it. Both shapes must reach the gating normalizer identically.
+		const asString = toolCallEnd(
+			"monday_com.get_board_items_page",
+			"c1",
+			MONDAY_ITEMS,
+			JSON.stringify({ itemIds: [12511130115] }),
+		);
+		const asObject = toolCallEnd("monday_com.get_board_items_page", "c2", MONDAY_ITEMS, {
+			itemIds: [12511130115],
+		});
+		expect(codexEnvelopeParser.parse([asString], {}).results).toHaveLength(1);
+		expect(codexEnvelopeParser.parse([asObject], {}).results).toHaveLength(1);
+	});
+
+	it("treats unparsable function_call arguments as absent rather than throwing", () => {
+		// A torn `arguments` string on the request row must not sink the paired
+		// event; the gating normalizer just fails closed for lack of input.
+		const call = fnCall("mcp__codex_apps__monday_com", "_get_board_items_page", "c1", '{"itemIds":[1');
+		const end = toolCallEnd("monday_com.get_board_items_page", "c1", MONDAY_ITEMS);
+		expect(codexEnvelopeParser.parse([call, end], {}).results).toHaveLength(0);
+	});
+
+	it("drops an mcp_tool_call_end whose timestamp is past the cutoff", () => {
+		const line = toolCallEnd("linear.get_issue", "c1", LINEAR);
+		// Same line, read with a cutoff BEFORE its timestamp: the event is dropped,
+		// but its call is still marked answered so the cursor is not pinned on it.
+		expect(codexEnvelopeParser.parse([line], {}).results).toHaveLength(1);
+		const cut = codexEnvelopeParser.parse([line], { beforeTimestamp: "2026-01-01T00:00:00.000Z" });
+		expect(cut.results).toHaveLength(0);
+		expect(cut.lastLineNumberScanned).toBe(1);
+	});
+
+	it("keeps the event payload as-is when the recovery hook cannot salvage anything", () => {
+		// Jira's `recover` stitches a `webUrl` out of the raw output. When the raw
+		// output holds no webUrl at all it returns null, and the event's own
+		// (url-less) payload must be used unchanged rather than blanked.
+		const lines = [
+			toolCallEnd("atlassian_rovo.getJiraIssue", "c_jira", JIRA_BARE_NO_URL),
+			fnOutputRaw("c_jira", "Wall time: 0.4s\nOutput:\n<not json, and no webUrl anywhere>"),
+		];
+		const { results } = codexEnvelopeParser.parse(lines, {});
+		expect(results.map((r) => r.def.id)).toEqual(["jira"]);
+		// No tenant browse URL was salvaged, so the payload keeps the REST `self`
+		// the normalizer derives — not a stitched-in one.
+		expect((results[0].payload as { webUrl?: string }).webUrl).toBe(JIRA_BARE_NO_URL.self);
+	});
+
+	// The cursor must not advance past ANY in-flight request, so with several
+	// unanswered calls it holds at the earliest of them.
+	it("holds the cursor at the EARLIEST unanswered request, not the latest", () => {
+		const lines = [
+			fnCall("mcp__codex_apps__linear", "_get_issue", "first"),
+			fnCall("mcp__codex_apps__linear", "_get_issue", "second"),
+			fnCall("mcp__codex_apps__linear", "_get_issue", "third"),
+		];
+		const { lastLineNumberScanned } = codexEnvelopeParser.parse(lines, {});
+		expect(lastLineNumberScanned).toBe(0);
+	});
+});

--- a/cli/src/core/references/CodexEnvelopeParser.ts
+++ b/cli/src/core/references/CodexEnvelopeParser.ts
@@ -513,7 +513,10 @@ function readInvocationTool(invocation: unknown): string | undefined {
  * thing separating its `search` from every other local server's `search`.
  */
 function readInvocationServer(invocation: unknown): string | undefined {
+	/* v8 ignore start -- unreachable: the sole call site runs only after
+	   readInvocationTool returned a tool name, which already proved this is an object. */
 	if (!isObject(invocation)) return undefined;
+	/* v8 ignore stop */
 	return readString(invocation.server);
 }
 
@@ -525,7 +528,10 @@ function readInvocationServer(invocation: unknown): string | undefined {
  * yield the same object downstream. Returns undefined when absent/unparsable.
  */
 function readInvocationArguments(invocation: unknown): unknown {
+	/* v8 ignore start -- unreachable: same call site as readInvocationServer, reached
+	   only once readInvocationTool has proved this is an object. */
 	if (!isObject(invocation)) return undefined;
+	/* v8 ignore stop */
 	const args = invocation.arguments;
 	return typeof args === "string" ? parseArguments(args) : args;
 }

--- a/cli/src/core/references/ReferenceExtractor.test.ts
+++ b/cli/src/core/references/ReferenceExtractor.test.ts
@@ -41,6 +41,14 @@ const { ACCUMULATING_DEF } = vi.hoisted(() => ({
 	} as unknown as import("./SourceDefinition.js").SourceDefinition,
 }));
 
+// Partial mock so the Slack workspace-url config read can be made to throw. The
+// real `loadConfig` swallows a missing file, so the extractor's tolerate-a-throw
+// guard is only reachable by forcing one.
+vi.mock("../SessionTracker.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../SessionTracker.js")>();
+	return { ...actual, loadConfig: vi.fn(actual.loadConfig) };
+});
+
 vi.mock("./SourceDefinitionRegistry.js", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("./SourceDefinitionRegistry.js")>();
 	let patched: SourceDefinitionRegistry | undefined;
@@ -54,6 +62,7 @@ vi.mock("./SourceDefinitionRegistry.js", async (importOriginal) => {
 });
 
 import type { Reference } from "../../Types.js";
+import { loadConfig } from "../SessionTracker.js";
 import { extractReferencesFromTranscript } from "./ReferenceExtractor.js";
 import { formatAccumulatedEntry } from "./ReferenceStore.js";
 import type { SourceDefinitionRegistry } from "./SourceDefinitionRegistry.js";
@@ -170,6 +179,28 @@ describe("extractReferencesFromTranscript", () => {
 		expect(fieldVal(references[0], "labels")).toBe("JolliMemory, Feature");
 		expect(references[0].description).toContain("Linear issues are high-density");
 		expect(lastLineNumberScanned).toBe(2);
+	});
+
+	// The config read only supplies Slack's fallback workspace URL. A failure
+	// there must never abort extraction of every other source in the transcript.
+	it("still extracts references when the config read throws", async () => {
+		const jsonl = makeJsonl(
+			toolUseLine({
+				toolUseId: "toolu_cfg",
+				toolName: "mcp__linear__get_issue",
+				timestamp: "2026-05-14T06:06:00.228Z",
+			}),
+			toolResultLine({
+				toolUseId: "toolu_cfg",
+				timestamp: "2026-05-14T06:06:01.123Z",
+				payload: SAMPLE_ISSUE_PAYLOAD,
+			}),
+		);
+		mockReadFile.mockResolvedValue(jsonl);
+		vi.mocked(loadConfig).mockRejectedValueOnce(new Error("config store unavailable"));
+
+		const { references } = await extractReferencesFromTranscript("/fake.jsonl");
+		expect(references.map((r) => r.nativeId)).toEqual(["PROJ-1528"]);
 	});
 
 	it("captures zero references from a list_issues enumeration result", async () => {

--- a/cli/src/core/references/ReferenceStore.test.ts
+++ b/cli/src/core/references/ReferenceStore.test.ts
@@ -9,6 +9,36 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // a real source's id would make an unrelated edit to that definition fail them.
 // Extending is safe: no other test in this file references this id, and every shipped
 // definition is left exactly as loaded.
+// Every SHIPPED source that sets either flag sets both, so the two single-flag
+// note variants are only reachable through synthetic definitions. They exist so
+// the note stays correct if a future source ever picks just one.
+const { ARGS_ONLY_DEF, TRACK_ONLY_DEF } = vi.hoisted(() => {
+	const base = (id: string, label: string) => ({
+		id,
+		label,
+		icon: "history",
+		match: { claude: { prefixes: [`mcp__${id}__`] } },
+		wrapperKeys: [],
+		reference: {
+			nativeId: { pipe: [{ op: "path", path: "tool" }] },
+			title: { pipe: [{ op: "path", path: "tool" }] },
+			description: { pipe: [{ op: "path", path: "query" }], optional: true },
+		},
+		fields: [],
+		storage: { nativeIdPathSafe: true },
+	});
+	return {
+		ARGS_ONLY_DEF: {
+			...base("argsonly", "Args Only"),
+			argumentsDerived: true,
+		} as unknown as import("./SourceDefinition.js").SourceDefinition,
+		TRACK_ONLY_DEF: {
+			...base("trackonly", "Track Only"),
+			trackOnly: true,
+		} as unknown as import("./SourceDefinition.js").SourceDefinition,
+	};
+});
+
 const { ACCUMULATING_DEF } = vi.hoisted(() => ({
 	ACCUMULATING_DEF: {
 		id: "acctest",
@@ -42,7 +72,12 @@ vi.mock("./SourceDefinitionRegistry.js", async (importOriginal) => {
 	return {
 		...actual,
 		getRegistry: (): SourceDefinitionRegistry => {
-			patched ??= new actual.SourceDefinitionRegistry([...actual.getRegistry().all(), ACCUMULATING_DEF]);
+			patched ??= new actual.SourceDefinitionRegistry([
+				...actual.getRegistry().all(),
+				ACCUMULATING_DEF,
+				ARGS_ONLY_DEF,
+				TRACK_ONLY_DEF,
+			]);
 			return patched;
 		},
 	};
@@ -485,6 +520,33 @@ describe("ReferenceStore", () => {
 			expect(ref?.fields).toBeUndefined();
 		});
 
+		it("skips a fields list item that parses to a scalar or null", async () => {
+			// Valid JSON, wrong shape: one corrupt row must not drop the reference.
+			const file = join(tempDir, "scalar-list.md");
+			await writeFile(
+				file,
+				[
+					"---",
+					'source: "linear"',
+					'nativeId: "PROJ-3"',
+					'title: "t"',
+					'url: "u"',
+					"fields:",
+					"  - 42",
+					"  - null",
+					'  - "a string"',
+					'  - {"key":"status","label":"Status","value":"open"}',
+					'referencedAt: ""',
+					'sourceToolName: "x"',
+					"---",
+					"",
+				].join("\n"),
+				"utf-8",
+			);
+			const ref = await readReferenceMarkdown(file);
+			expect(ref?.fields).toEqual([{ key: "status", label: "Status", value: "open" }]);
+		});
+
 		it("skips a fields list item whose key has unsafe characters, keeps valid items", async () => {
 			// `key` is interpolated raw into the prompt's <issue …> attribute name,
 			// which can't be quote-escaped — so a poisoned orphan-branch key like
@@ -725,6 +787,33 @@ describe("ReferenceStore", () => {
 			expect(content).toContain("bookmark, not a full copy");
 			expect(content).toContain("Track-only");
 		});
+
+		// The note is assembled from independent paragraphs, one per flag. Every
+		// shipped source sets both, so these pin the halves in isolation.
+		it("emits only the bookmark paragraph for an arguments-derived source", async () => {
+			const ref = linearRef({ mapKey: "argsonly:q", source: "argsonly", nativeId: "q", url: undefined });
+			const { sourcePath } = await writeReferenceMarkdown(ref, tempDir);
+			const content = await readFile(sourcePath, "utf-8");
+			expect(content).toContain("bookmark, not a full copy");
+			expect(content).not.toContain("Track-only");
+		});
+
+		it("emits only the track-only paragraph for a track-only source", async () => {
+			const ref = linearRef({ mapKey: "trackonly:q", source: "trackonly", nativeId: "q", url: undefined });
+			const { sourcePath } = await writeReferenceMarkdown(ref, tempDir);
+			const content = await readFile(sourcePath, "utf-8");
+			expect(content).toContain("Track-only");
+			expect(content).not.toContain("bookmark, not a full copy");
+		});
+	});
+
+	it("omits the body entirely when the description is only edge newlines", async () => {
+		// `stripBodyEdges` eats the newlines and leaves nothing — the render must
+		// then emit no body at all rather than a blank line, since the guard hash
+		// is taken over the exact bytes.
+		const { sourcePath } = await writeReferenceMarkdown(linearRef({ description: "\n\n\n" }), tempDir);
+		expect((await readFile(sourcePath, "utf-8")).trimEnd().endsWith("---")).toBe(true);
+		expect((await readReferenceMarkdown(sourcePath))?.description).toBeUndefined();
 	});
 
 	describe("mergeAccumulatedBody", () => {

--- a/cli/src/core/references/bindings/claude/index.test.ts
+++ b/cli/src/core/references/bindings/claude/index.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { CLAUDE_SHELL_TOOL_NAMES, CLAUDE_TOOL_PREFIXES } from "./index.js";
+
+afterEach(() => {
+	vi.doUnmock("../../SourceDefinitionRegistry.js");
+	vi.resetModules();
+});
 
 describe("Claude producer binding", () => {
 	describe("CLAUDE_TOOL_PREFIXES", () => {
@@ -25,6 +30,25 @@ describe("Claude producer binding", () => {
 				"mcp__context7__",
 				"mcp__jollimemory__",
 			]);
+		});
+
+		// Every shipped definition happens to declare a Claude match today, but the
+		// registry is open: a Codex-only source (or one whose Claude match carries
+		// no prefixes) must contribute nothing here rather than injecting a hole
+		// into the pre-filter's needle list.
+		it("contributes no needle for a definition without Claude prefixes", async () => {
+			vi.resetModules();
+			vi.doMock("../../SourceDefinitionRegistry.js", () => ({
+				getRegistry: () => ({
+					all: () => [
+						{ match: { codex: { namespaces: ["mcp__codex_apps__acme"] } } },
+						{ match: { claude: {} } },
+						{ match: { claude: { prefixes: ["mcp__only_one__"] } } },
+					],
+				}),
+			}));
+			const { CLAUDE_TOOL_PREFIXES: prefixes } = await import("./index.js");
+			expect(prefixes).toEqual(["mcp__only_one__"]);
 		});
 	});
 

--- a/cli/src/core/references/bindings/codex/CodexJiraBinding.test.ts
+++ b/cli/src/core/references/bindings/codex/CodexJiraBinding.test.ts
@@ -55,6 +55,17 @@ describe("jiraCodexBinding.normalize (derive fields.summary from versionedRepres
 		expect(out.fields.summary).toBe("new");
 	});
 
+	// Jira's versionedRepresentations keys are version NUMBERS. A non-numeric key
+	// (schema drift, or a `$schema`-style annotation) must be skipped rather than
+	// coerced to NaN and silently allowed to win the comparison.
+	it("ignores non-numeric representation keys", () => {
+		const out = normalize({
+			key: "KAN-4",
+			versionedRepresentations: { summary: { latest: "bogus", "1": "real" } },
+		}) as { fields: { summary: string } };
+		expect(out.fields.summary).toBe("real");
+	});
+
 	it("leaves an already adapter-shaped node (with fields.summary) untouched", () => {
 		const shaped = {
 			key: "KAN-4",

--- a/cli/src/core/references/bindings/codex/CodexJolliMemoryBinding.test.ts
+++ b/cli/src/core/references/bindings/codex/CodexJolliMemoryBinding.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { CLAUDE_TOOL_PREFIX } from "../../sources/JolliMemoryNormalize.js";
+import type { CodexNormalizeEnv } from "./CodexBinding.js";
+import { jolliMemoryCodexBinding } from "./CodexJolliMemoryBinding.js";
+
+const binding = jolliMemoryCodexBinding;
+const canonical = (raw: string) => (binding.canonicalToolName as (r: string) => string)(raw);
+
+/** The scan-wide fields are always supplied by the parser; only `toolName` varies per call. */
+const env = (toolName: string): CodexNormalizeEnv => ({ permalinks: new Map(), toolName });
+
+describe("jolliMemoryCodexBinding", () => {
+	it("is registered under the jollimemory source id", () => {
+		expect(binding.id).toBe("jollimemory");
+	});
+
+	// Codex reports the BARE tool name; persisting it verbatim would make
+	// `sourceToolName` differ from the same lookup captured under Claude.
+	it("maps each bare Codex tool name back onto its Claude spelling", () => {
+		expect(canonical("recall")).toBe(`${CLAUDE_TOOL_PREFIX}recall`);
+		expect(canonical("search")).toBe(`${CLAUDE_TOOL_PREFIX}search`);
+		expect(canonical("get_decision_timeline")).toBe(`${CLAUDE_TOOL_PREFIX}get_decision_timeline`);
+	});
+
+	it("distinguishes the three tools by env.toolName, ignoring the business payload", () => {
+		const business = { irrelevant: true };
+		expect(binding.normalize(business, {}, env("recall"))).toMatchObject({ tool: "recall" });
+		expect(binding.normalize(business, { query: "orphan branch" }, env("search"))).toMatchObject({
+			tool: "search",
+			query: "orphan branch",
+		});
+		expect(binding.normalize(business, { slug: "storage-mode" }, env("get_decision_timeline"))).toMatchObject({
+			tool: "get_decision_timeline",
+			query: "storage-mode",
+		});
+	});
+
+	it("accepts the Claude-prefixed spelling of the tool name too", () => {
+		expect(binding.normalize({}, {}, env(`${CLAUDE_TOOL_PREFIX}recall`))).toMatchObject({
+			tool: "recall",
+		});
+	});
+
+	// Only the `mcp_tool_call_end` fallback carries an `invocation`, so a caller
+	// that never resolved one passes no env at all. With no tool name there is
+	// nothing to identify, so the reference must be voided rather than guessed.
+	it("voids the reference when no env (or no toolName) is supplied", () => {
+		expect(binding.normalize({})).toBeNull();
+		expect(binding.normalize({}, {})).toBeNull();
+		expect(binding.normalize({}, {}, { permalinks: new Map() } as CodexNormalizeEnv)).toBeNull();
+	});
+
+	it("voids a tool this source does not own", () => {
+		expect(binding.normalize({}, {}, env("list_branches"))).toBeNull();
+	});
+});

--- a/cli/src/core/references/sources/AdfToText.test.ts
+++ b/cli/src/core/references/sources/AdfToText.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { adfToText } from "./AdfToText.js";
+
+describe("adfToText", () => {
+	it("renders a whole document: headings, paragraphs, lists and quotes", () => {
+		const doc = {
+			type: "doc",
+			content: [
+				{ type: "heading", attrs: { level: 2 }, content: [{ type: "text", text: "Design" }] },
+				{
+					type: "paragraph",
+					content: [
+						{ type: "text", text: "We chose " },
+						{ type: "text", text: "A" },
+					],
+				},
+				{
+					type: "bulletList",
+					content: [
+						{
+							type: "listItem",
+							content: [{ type: "paragraph", content: [{ type: "text", text: "one" }] }],
+						},
+						{
+							type: "listItem",
+							content: [{ type: "paragraph", content: [{ type: "text", text: "two" }] }],
+						},
+					],
+				},
+				{
+					type: "orderedList",
+					content: [
+						{
+							type: "listItem",
+							content: [{ type: "paragraph", content: [{ type: "text", text: "first" }] }],
+						},
+						{
+							type: "listItem",
+							content: [{ type: "paragraph", content: [{ type: "text", text: "second" }] }],
+						},
+					],
+				},
+				{ type: "blockquote", content: [{ type: "paragraph", content: [{ type: "text", text: "cited" }] }] },
+				{ type: "codeBlock", content: [{ type: "text", text: "npm run all" }] },
+			],
+		};
+		expect(adfToText(doc)).toBe(
+			["## Design", "We chose A", "- one\n- two", "1. first\n2. second", "> cited", "npm run all"].join("\n\n"),
+		);
+	});
+
+	it("clamps the heading level into the 1-6 markdown range", () => {
+		const heading = (level: unknown) => ({
+			type: "heading",
+			attrs: { level },
+			content: [{ type: "text", text: "H" }],
+		});
+		expect(adfToText(heading(0))).toBe("# H");
+		expect(adfToText(heading(9))).toBe("###### H");
+		// A missing / non-numeric level falls back to h1 rather than producing "undefined".
+		expect(adfToText(heading("2"))).toBe("# H");
+		expect(adfToText({ type: "heading", content: [{ type: "text", text: "H" }] })).toBe("# H");
+	});
+
+	it("concatenates the children of an unknown node type", () => {
+		const node = {
+			type: "panel",
+			content: [{ type: "text", text: "a" }, { type: "emoji" }, { type: "text", text: "b" }],
+		};
+		expect(adfToText(node)).toBe("ab");
+	});
+
+	it("returns an empty string for anything that is not an ADF node", () => {
+		for (const input of [null, undefined, "plain", 42, []]) {
+			expect(adfToText(input)).toBe("");
+		}
+	});
+
+	it("returns an empty string for a text node whose `text` is missing or not a string", () => {
+		expect(adfToText({ type: "text" })).toBe("");
+		expect(adfToText({ type: "text", text: 42 })).toBe("");
+	});
+
+	it("treats a node whose `content` is absent or not an array as having no children", () => {
+		expect(adfToText({ type: "paragraph" })).toBe("");
+		expect(adfToText({ type: "paragraph", content: "not an array" })).toBe("");
+		expect(adfToText({ type: "doc", content: {} })).toBe("");
+	});
+});

--- a/cli/src/core/references/sources/GitHubNormalize.test.ts
+++ b/cli/src/core/references/sources/GitHubNormalize.test.ts
@@ -72,6 +72,13 @@ describe("reshapeGitHubIssue", () => {
 		expect(out.assignees).toBeUndefined();
 	});
 
+	// GitHub search hits can arrive with a non-string (or absent) title; the
+	// reshaper must omit the key rather than carry `undefined`/a number through.
+	it("omits `title` when it is absent or not a string", () => {
+		expect("title" in reshape({ number: 1 })).toBe(false);
+		expect("title" in reshape({ number: 1, title: 42 })).toBe(false);
+	});
+
 	it("returns non-object input unchanged", () => {
 		expect(reshapeGitHubIssue(123)).toBe(123);
 		expect(reshapeGitHubIssue(null)).toBe(null);

--- a/cli/src/core/references/sources/MondayNormalize.test.ts
+++ b/cli/src/core/references/sources/MondayNormalize.test.ts
@@ -153,4 +153,35 @@ describe("normalizeMonday", () => {
 		const p = { items: [ITEM_B_NO_DESC] };
 		expect(normalizeMonday(p, { itemIds: [1] })?.items[0].board).toBeUndefined();
 	});
+
+	it("treats a payload whose `items` is not an array as having none", () => {
+		expect(normalizeMonday({ board: { name: "B" }, items: { nope: 1 } }, { itemIds: [1] })).toEqual({ items: [] });
+		expect(normalizeMonday({ board: { name: "B" } }, { itemIds: [1] })).toEqual({ items: [] });
+	});
+
+	it("skips non-object entries in `items`", () => {
+		const p = { items: [null, 42, "x", ITEM_B_NO_DESC] };
+		expect(normalizeMonday(p, { itemIds: [1] })?.items).toHaveLength(1);
+	});
+
+	// The description flattener has to survive every shape monday's block list can
+	// take. None of these may throw, and none may surface as a partial body.
+	it.each([
+		["a non-object item_description", { item_description: "plain string" }],
+		["a non-array `blocks`", { item_description: { blocks: { nope: 1 } } }],
+		["a block that is not an object", { item_description: { blocks: [null, 7] } }],
+		["a block whose content is not a string", { item_description: { blocks: [{ content: 42 }] } }],
+		["a block whose content is blank", { item_description: { blocks: [{ content: "   " }] } }],
+		[
+			"a deltaFormat whose segments carry no insert string",
+			{ item_description: { blocks: [{ content: '{"deltaFormat":[{"x":1},"str",null]}' }] } },
+		],
+	])("yields no description for %s", (_label, descriptionShape) => {
+		const p = {
+			items: [
+				{ id: "1", name: "n", url: "https://monday.com/i/1", ...(descriptionShape as Record<string, unknown>) },
+			],
+		};
+		expect(normalizeMonday(p, { itemIds: [1] })?.items[0].description).toBeUndefined();
+	});
 });

--- a/cli/src/core/skills/ClaudeSkillScanner.test.ts
+++ b/cli/src/core/skills/ClaudeSkillScanner.test.ts
@@ -128,7 +128,28 @@ describe("scanClaudeSkillLines — Skill tool entry path", () => {
 		expect(uses[0].invocations[0].args).toBe("plan build");
 	});
 
-	it("takes the plugin from attributionPlugin when a later turn reports it", () => {
+	it("prefers the host's attributionPlugin over a guess from the id prefix", () => {
+		// `j:specs-pr-review` lives in the `jolli` plugin — the namespace is an alias, so
+		// the prefix guess reports `j`. The host's own answer only reaches this scanner on
+		// a line that also clears the pre-filter, and a NESTED Skill call is exactly that:
+		// it enters an inner skill while still attributed to the outer one.
+		const outerCall = TOOL_CALL.replace('"skill":"superpowers:brainstorming"', '"skill":"j:specs-pr-review"');
+		const outerResult = TOOL_RESULT.replace(
+			'"commandName":"superpowers:brainstorming"',
+			'"commandName":"j:specs-pr-review"',
+		);
+		const nestedCall = TOOL_CALL.replace('"toolu_019BtdUXtkPLcwtXEUiUv1Dc"', '"toolu_NESTED"').replace(
+			'"isSidechain":false',
+			'"isSidechain":false,"attributionSkill":"j:specs-pr-review","attributionPlugin":"jolli"',
+		);
+		const { uses } = scanClaudeSkillLines([outerCall, outerResult, nestedCall], 0);
+		expect(uses.find((u) => u.skill === "j:specs-pr-review")?.plugin).toBe("jolli");
+	});
+
+	it("still resolves a plugin when the attributed turn is filtered out before parsing", () => {
+		// ATTRIBUTED_TURN matches none of the pre-filter needles, so its attribution
+		// never reaches the map — the prefix guess is what answers here. Pinned so the
+		// prefix fallback is not mistaken for the attribution path working.
 		const { uses } = scanClaudeSkillLines([TOOL_CALL, TOOL_RESULT, TOOL_BODY, ATTRIBUTED_TURN], 0);
 		expect(uses[0].plugin).toBe("superpowers");
 	});
@@ -217,6 +238,21 @@ describe("scanClaudeSkillLines — slash-command entry path", () => {
 		expect(uses[0].invocations[0].args).toBeUndefined();
 	});
 
+	it("ignores a command block whose name tag is empty", () => {
+		// An empty name would bucket every such block under one blank skill id.
+		const empty = COMMAND_TAGS.replace(
+			"<command-name>/j:specs-pr-review</command-name>",
+			"<command-name></command-name>",
+		);
+		expect(scanClaudeSkillLines([empty, COMMAND_BODY], 0).uses).toEqual([]);
+	});
+
+	it("dates a command entry with no timestamp as empty rather than dropping it", () => {
+		const noTimestamp = COMMAND_TAGS.replace('"timestamp":"2026-07-30T03:42:11.043Z",', "");
+		const { uses } = scanClaudeSkillLines([noTimestamp, COMMAND_BODY], 0);
+		expect(uses[0].invocations[0].at).toBe("");
+	});
+
 	it("strips the leading slash from the command name", () => {
 		const { uses } = scanClaudeSkillLines([COMMAND_TAGS, COMMAND_BODY], 0);
 		expect(uses[0].skill).not.toContain("/");
@@ -295,6 +331,102 @@ describe("scanClaudeSkillLines — resumption and robustness", () => {
 		expect(uses).toHaveLength(1);
 	});
 
+	it("ignores a line that clears the pre-filter and then fails to parse", () => {
+		// The pre-filter is a substring test, so a truncated final line — the normal
+		// shape while a session is live — reaches `JSON.parse` and must be dropped there.
+		const truncated = '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Skill"';
+		const { uses } = scanClaudeSkillLines([truncated, TOOL_CALL, TOOL_RESULT], 0);
+		expect(uses).toHaveLength(1);
+	});
+
+	it("ignores a pre-filtered line whose JSON is not an object", () => {
+		const arrayLine = '[{"name":"Skill"}]';
+		const { uses } = scanClaudeSkillLines([arrayLine, TOOL_CALL, TOOL_RESULT], 0);
+		expect(uses).toHaveLength(1);
+	});
+
+	it("ignores a Skill tool_use missing the fields that identify it", () => {
+		// A block with no id cannot be joined to its result, and one with no
+		// `input.skill` names nothing — either way there is no invocation to report.
+		const noId =
+			'{"type":"assistant","timestamp":"2026-07-12T11:08:24.954Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Skill","input":{"skill":"superpowers:brainstorming"}}]}}';
+		const noInput =
+			'{"type":"assistant","timestamp":"2026-07-12T11:08:24.954Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_X","name":"Skill"}]}}';
+		expect(scanClaudeSkillLines([noId, noInput], 0).uses).toEqual([]);
+	});
+
+	it("dates a Skill tool_use with no timestamp as empty rather than dropping it", () => {
+		// The store identifies invocations by `at`, so an empty one folds them together —
+		// but the entry itself is real and reporting nothing would lose it outright.
+		const noTimestamp = TOOL_CALL.replace('"timestamp":"2026-07-12T11:08:24.954Z",', "");
+		const { uses } = scanClaudeSkillLines([noTimestamp], 0);
+		expect(uses[0].invocations[0].at).toBe("");
+	});
+
+	it("reads a tool_result whose toolUseResult is a bare string", () => {
+		// Not every tool writes an object there; the field is free-form. With no
+		// `success` flag and no `is_error` block the invocation stands as succeeded, and
+		// the resolved name simply is not available.
+		const stringResult = TOOL_RESULT.replace(
+			'"toolUseResult":{"success":true,"commandName":"superpowers:brainstorming"}',
+			'"toolUseResult":"Launching skill: superpowers:brainstorming"',
+		);
+		const { uses } = scanClaudeSkillLines([TOOL_CALL, stringResult], 0);
+		expect(uses[0].skill).toBe("superpowers:brainstorming");
+		expect(uses[0].invocations[0].ok).toBe(true);
+	});
+
+	it("ignores a toolUseResult record that carries no tool_result block", () => {
+		const noBlock =
+			'{"type":"user","timestamp":"2026-07-12T11:08:24.966Z","toolUseResult":{"success":true},"message":{"role":"user","content":[{"type":"text","text":"not a result"}]}}';
+		const { uses } = scanClaudeSkillLines([TOOL_CALL, noBlock], 0);
+		// The tool_use still stands on its own; it simply never got resolved.
+		expect(uses[0].invocations[0].ok).toBe(true);
+	});
+
+	it("ignores a body record whose content is neither a string nor a list", () => {
+		const objectBody = TOOL_BODY.replace(/"content":\[[\s\S]*?\]/, '"content":{"type":"text"}');
+		const noMessage = '{"type":"user","isMeta":true,"timestamp":"2026-07-12T11:08:24.965Z"}';
+		const { uses } = scanClaudeSkillLines([TOOL_CALL, TOOL_RESULT, objectBody, noMessage], 0);
+		expect(uses[0].invocations[0].bodyChars).toBeUndefined();
+	});
+
+	it("ignores a body record whose first block is not text", () => {
+		const imageBody = TOOL_BODY.replace(/"content":\[[\s\S]*?\]/, '"content":[{"type":"image","source":{}}]');
+		const { uses } = scanClaudeSkillLines([TOOL_CALL, TOOL_RESULT, imageBody], 0);
+		expect(uses[0].invocations[0].bodyChars).toBeUndefined();
+	});
+
+	it("does not measure a list-form local-command caveat as a skill body", () => {
+		// The caveat is isMeta too, and it appears in both content shapes. Measuring it
+		// would promote every client-side command into a skill with a plausible size.
+		const listCaveat = TOOL_BODY.replace(
+			/"content":\[[\s\S]*?\]/,
+			'"content":[{"type":"text","text":"<local-command-caveat>Caveat: …</local-command-caveat>"}]',
+		);
+		const { uses } = scanClaudeSkillLines([TOOL_CALL, TOOL_RESULT, listCaveat], 0);
+		expect(uses[0].invocations[0].bodyChars).toBeUndefined();
+	});
+
+	it("drops a body record that belongs to neither entry path", () => {
+		// No `sourceToolUseID` and no open command: the tag record that would have
+		// claimed it sits behind the resume point. There is nothing to attach it to.
+		const orphanBody = TOOL_BODY.replace('"sourceToolUseID":"toolu_019BtdUXtkPLcwtXEUiUv1Dc",', "");
+		expect(scanClaudeSkillLines([orphanBody], 0).uses).toEqual([]);
+	});
+
+	it("keeps both entries when one response calls the same skill twice", () => {
+		// Both tool_use blocks share the record's timestamp, so the newest-first sort
+		// sees a tie. Collapsing it here would drop one before the store ever folds them.
+		const twice = TOOL_CALL.replace(
+			'"content":[{"type":"tool_use","id":"toolu_019BtdUXtkPLcwtXEUiUv1Dc","name":"Skill","input":{"skill":"superpowers:brainstorming"}}]',
+			'"content":[{"type":"tool_use","id":"toolu_A","name":"Skill","input":{"skill":"superpowers:brainstorming"}},{"type":"tool_use","id":"toolu_B","name":"Skill","input":{"skill":"superpowers:brainstorming"}}]',
+		);
+		const { uses } = scanClaudeSkillLines([twice], 0);
+		expect(uses).toHaveLength(1);
+		expect(uses[0].invocations).toHaveLength(2);
+	});
+
 	it("ignores record types it has never seen", () => {
 		// `attachment` and `queue-operation` records appear in real transcripts and
 		// are not in any documented union — unknown types must be skipped, not
@@ -321,12 +453,22 @@ describe("scanClaudeSkillLines — resumption and robustness", () => {
 	});
 
 	it("orders invocations newest-first across the whole scan", () => {
-		const later = TOOL_CALL.replace(
-			'"timestamp":"2026-07-12T11:08:24.954Z"',
-			'"timestamp":"2026-07-12T23:00:00.000Z"',
-		).replace('"toolu_019BtdUXtkPLcwtXEUiUv1Dc"', '"toolu_LATER"');
-		const { uses } = scanClaudeSkillLines([TOOL_CALL, later], 0);
-		expect(uses[0].invocations[0].at).toBe("2026-07-12T23:00:00.000Z");
+		// Shuffled on purpose: line order in a transcript is write order, and a
+		// catch-up pass can surface an older invocation after a newer one.
+		const at = (stamp: string, id: string) =>
+			TOOL_CALL.replace('"timestamp":"2026-07-12T11:08:24.954Z"', `"timestamp":"${stamp}"`).replace(
+				'"toolu_019BtdUXtkPLcwtXEUiUv1Dc"',
+				`"toolu_${id}"`,
+			);
+		const { uses } = scanClaudeSkillLines(
+			[at("2026-07-12T23:00:00.000Z", "LATER"), TOOL_CALL, at("2026-07-11T09:00:00.000Z", "OLDEST")],
+			0,
+		);
+		expect(uses[0].invocations.map((i) => i.at)).toEqual([
+			"2026-07-12T23:00:00.000Z",
+			"2026-07-12T11:08:24.954Z",
+			"2026-07-11T09:00:00.000Z",
+		]);
 	});
 });
 

--- a/cli/src/core/skills/ClaudeSkillScanner.ts
+++ b/cli/src/core/skills/ClaudeSkillScanner.ts
@@ -87,7 +87,17 @@ interface PendingCommandEntry {
 	readonly skill: string;
 	readonly at: string;
 	readonly args?: string;
-	bodyChars?: number;
+}
+
+/**
+ * A command-path entry validated by its body record.
+ *
+ * `bodyChars` is required, not optional: the body IS the promotion, so an entry that
+ * reaches this type has been measured. Carrying it as optional here would leave an
+ * absent-body case downstream that no input can produce.
+ */
+interface CompletedCommandEntry extends PendingCommandEntry {
+	readonly bodyChars: number;
 }
 
 /**
@@ -105,7 +115,7 @@ interface PendingCommandEntry {
  */
 export function scanClaudeSkillLines(lines: ReadonlyArray<string>, fromLine: number): SkillScanResult {
 	const pendingTools = new Map<string, PendingToolEntry>();
-	const commandEntries: PendingCommandEntry[] = [];
+	const commandEntries: CompletedCommandEntry[] = [];
 	/** Command-path entries still waiting to be validated by a following body record. */
 	let openCommand: PendingCommandEntry | undefined;
 	const toolEntries: PendingToolEntry[] = [];
@@ -146,8 +156,7 @@ export function scanClaudeSkillLines(lines: ReadonlyArray<string>, fromLine: num
 				if (pending !== undefined) pending.bodyChars = bodyChars;
 			} else if (openCommand !== undefined) {
 				// Command path: a body with no owning tool_use validates the open command.
-				openCommand.bodyChars = bodyChars;
-				commandEntries.push(openCommand);
+				commandEntries.push({ ...openCommand, bodyChars });
 				openCommand = undefined;
 			}
 			continue;
@@ -305,7 +314,7 @@ function tagValue(text: string, tag: string): string | undefined {
 /** Group entries by skill id into one {@link SkillUse} each, invocations newest-first. */
 function assemble(
 	toolEntries: ReadonlyArray<PendingToolEntry>,
-	commandEntries: ReadonlyArray<PendingCommandEntry>,
+	commandEntries: ReadonlyArray<CompletedCommandEntry>,
 	pluginBySkill: ReadonlyMap<string, string>,
 ): ReadonlyArray<SkillUse> {
 	const bySkill = new Map<string, { paths: Set<SkillEntryPath>; invocations: SkillInvocation[] }>();
@@ -336,7 +345,7 @@ function assemble(
 		bucket(entry.skill, "command").invocations.push({
 			at: entry.at,
 			...(entry.args !== undefined ? { args: entry.args } : {}),
-			...(entry.bodyChars !== undefined ? { bodyChars: entry.bodyChars } : {}),
+			bodyChars: entry.bodyChars,
 			ok: true,
 		});
 	}

--- a/cli/src/core/skills/CodexSkillScanner.test.ts
+++ b/cli/src/core/skills/CodexSkillScanner.test.ts
@@ -204,4 +204,14 @@ describe("scanCodexSkillLines", () => {
 		const stray = CODEX_CAT_SKILL.split("/skills/comprehensive-review-full-review/").join("/docs/");
 		expect(scanCodexSkillLines([codexRecord(stray, T1)], 0).uses).toEqual([]);
 	});
+
+	// A torn write (Codex appends while the scan runs) leaves a half-flushed line
+	// that still carries the needle. Skip it and keep scanning — the lines after
+	// it are intact, and the cursor must still advance past the bad one.
+	it("skips an unparsable line that carries the needle and keeps scanning", () => {
+		const truncated = `{"payload":{"type":"function_call","arguments":"cat /x/skills/foo/SKILL.md`;
+		const { uses, lastLine } = scanCodexSkillLines([truncated, codexRecord(CODEX_CAT_SKILL, T1)], 0);
+		expect(uses.map((u) => u.skill)).toEqual(["comprehensive-review-full-review"]);
+		expect(lastLine).toBe(2);
+	});
 });

--- a/cli/src/core/skills/OpenCodeSkillDiscovery.test.ts
+++ b/cli/src/core/skills/OpenCodeSkillDiscovery.test.ts
@@ -2,8 +2,13 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { loadPlansRegistry } from "../SessionTracker.js";
-import { OC_ASSISTANT_MESSAGE, OC_NON_SKILL_TOOL, OC_SKILL_NO_TOP_METADATA } from "./__fixtures__/openCodeParts.js";
+import { setManuallyDisabled } from "../../Logger.js";
+import {
+	OC_ASSISTANT_MESSAGE,
+	OC_NON_SKILL_TOOL,
+	OC_SKILL_NO_TOP_METADATA,
+	OC_SKILL_WITH_TOP_METADATA,
+} from "./__fixtures__/openCodeParts.js";
 
 /**
  * The DB path is resolved by the OpenCode session discoverer; point it at a temp
@@ -16,10 +21,15 @@ vi.mock("../OpenCodeSessionDiscoverer.js", () => ({
 
 /**
  * Isolate the developer's real `~/.jolli/jollimemory/config.json` from the run.
+ * `loadConfig` reads the MACHINE-GLOBAL config, so the `openCodeEnabled` toggle
+ * cannot be exercised (or neutralised) through the temp project dir at all:
  * `discoverOpenCodeSkills` short-circuits when `config.openCodeEnabled === false`,
  * so a developer who disabled OpenCode locally (a valid preference) would
  * silently see every test in this file return 0 without any tooling clue —
  * the failure surface looks identical to a bug in the SQL / matcher paths.
+ * The empty default is a `mockResolvedValue`, not a `mockResolvedValueOnce`, so
+ * the toggle test below can still queue its own value on top for one call
+ * (`clearMocks` clears calls, not implementations).
  * Preserve every other export via `importOriginal` because the test itself
  * calls `loadPlansRegistry` and the discovery under test calls
  * `upsertSkillEntry`, both real, on top of `SessionTracker`.
@@ -31,6 +41,8 @@ vi.mock("../SessionTracker.js", async (importOriginal) => {
 		loadConfig: vi.fn().mockResolvedValue({}),
 	};
 });
+
+import { loadConfig, loadPlansRegistry } from "../SessionTracker.js";
 
 const { discoverOpenCodeSkills } = await import("./OpenCodeSkillDiscovery.js");
 
@@ -72,6 +84,7 @@ describe("discoverOpenCodeSkills", () => {
 	});
 
 	afterEach(async () => {
+		setManuallyDisabled(false);
 		await rm(cwd, { recursive: true, force: true });
 		await rm(dbDir, { recursive: true, force: true });
 	});
@@ -188,5 +201,62 @@ describe("discoverOpenCodeSkills", () => {
 		await discoverOpenCodeSkills(cwd);
 		await discoverOpenCodeSkills(cwd);
 		expect((await loadPlansRegistry(cwd)).skills?.["opencode:jolli"]?.invocationCount).toBe(1);
+	});
+
+	it("writes nothing while the project is manually disabled", async () => {
+		// The 60s tick keeps firing behind a disabled panel; a pass must not put
+		// files back into a project the user switched off.
+		await buildDb(dbPathRef.current, {
+			sessions: [{ id: "ses_1", directory: cwd }],
+			parts: [{ id: "prt_1", sessionId: "ses_1", timeCreated: Date.now(), data: OC_SKILL_NO_TOP_METADATA }],
+		});
+		setManuallyDisabled(true);
+		expect(await discoverOpenCodeSkills(cwd)).toBe(0);
+		expect((await loadPlansRegistry(cwd)).skills).toBeUndefined();
+	});
+
+	it("writes nothing when OpenCode discovery is switched off in config", async () => {
+		await buildDb(dbPathRef.current, {
+			sessions: [{ id: "ses_1", directory: cwd }],
+			parts: [{ id: "prt_1", sessionId: "ses_1", timeCreated: Date.now(), data: OC_SKILL_NO_TOP_METADATA }],
+		});
+		vi.mocked(loadConfig).mockResolvedValueOnce({ openCodeEnabled: false });
+		expect(await discoverOpenCodeSkills(cwd)).toBe(0);
+	});
+
+	it("de-duplicates a concurrent tick instead of running the scan twice", async () => {
+		// Two overlapping ticks must share ONE pass; a second scan would fold the
+		// same invocation in again before the first pass has written its cursor.
+		await buildDb(dbPathRef.current, {
+			sessions: [{ id: "ses_1", directory: cwd }],
+			parts: [{ id: "prt_1", sessionId: "ses_1", timeCreated: Date.now(), data: OC_SKILL_NO_TOP_METADATA }],
+		});
+		const [a, b] = await Promise.all([discoverOpenCodeSkills(cwd), discoverOpenCodeSkills(cwd)]);
+		expect([a, b]).toEqual([1, 1]);
+		expect((await loadPlansRegistry(cwd)).skills?.["opencode:jolli"]?.invocationCount).toBe(1);
+	});
+
+	it("collects several parts of one session into a single group", async () => {
+		// The grouper creates a session bucket on first sight and reuses it for every
+		// later part — a per-part bucket would split one conversation's timeline in
+		// two and mis-attribute the interval spend.
+		const t = Date.now();
+		await buildDb(dbPathRef.current, {
+			sessions: [{ id: "ses_a", directory: cwd }],
+			parts: [
+				{ id: "prt_1", sessionId: "ses_a", timeCreated: t, data: OC_SKILL_NO_TOP_METADATA },
+				{ id: "prt_2", sessionId: "ses_a", timeCreated: t + 50, data: OC_SKILL_WITH_TOP_METADATA },
+			],
+			messages: [{ id: "msg_1", sessionId: "ses_a", timeCreated: t + 100, data: OC_ASSISTANT_MESSAGE }],
+		});
+		expect(await discoverOpenCodeSkills(cwd)).toBe(2);
+		// Both parts land in ONE group, so both skills are scanned against the same
+		// session timeline (and both carry that session's key), rather than being
+		// split into two disjoint single-part groups.
+		const skills = (await loadPlansRegistry(cwd)).skills ?? {};
+		expect(Object.keys(skills).sort()).toEqual(["opencode:comprehensive-review-full-review", "opencode:jolli"]);
+		expect(Object.keys(skills["opencode:comprehensive-review-full-review"]?.usageBySession ?? {})).toEqual([
+			"opencode:ses_a",
+		]);
 	});
 });

--- a/cli/src/core/skills/OpenCodeSkillDiscovery.ts
+++ b/cli/src/core/skills/OpenCodeSkillDiscovery.ts
@@ -14,7 +14,7 @@
  */
 
 import { stat } from "node:fs/promises";
-import { createLogger, isManuallyDisabled } from "../../Logger.js";
+import { createLogger, errMsg, isManuallyDisabled } from "../../Logger.js";
 import { getOpenCodeDbPath } from "../OpenCodeSessionDiscoverer.js";
 import { sessionDirBelongsToRepo } from "../SessionDirMatch.js";
 import { loadConfig, upsertSkillEntry } from "../SessionTracker.js";
@@ -132,7 +132,7 @@ async function runOnce(cwd: string): Promise<number> {
 		if (persisted > 0) log.info("Persisted %d OpenCode skill(s)", persisted);
 		return persisted;
 	} catch (err) {
-		log.debug("OpenCode skill discovery skipped: %s", err instanceof Error ? err.message : String(err));
+		log.debug("OpenCode skill discovery skipped: %s", errMsg(err));
 		return 0;
 	}
 }

--- a/cli/src/core/skills/OpenCodeSkillScanner.test.ts
+++ b/cli/src/core/skills/OpenCodeSkillScanner.test.ts
@@ -97,6 +97,65 @@ describe("scanOpenCodeSkillRows", () => {
 		expect(uses).toHaveLength(1);
 	});
 
+	it("skips a skill row that carries no state block", () => {
+		// Without `state` there is no status, and a row that has not reported completion
+		// is indistinguishable from one still loading.
+		const noState = '{"type":"tool","tool":"skill","callID":"call_x"}';
+		expect(scanOpenCodeSkillRows([part(noState)], []).uses).toEqual([]);
+	});
+
+	it("skips a completed row that names no skill", () => {
+		// Neither the resolved name nor the requested one survived. There is nothing to
+		// key a registry row on, so the invocation is dropped rather than filed under an
+		// empty id where it would merge with every other unnamed row.
+		const unnamed =
+			'{"type":"tool","tool":"skill","state":{"status":"completed","output":"x","time":{"start":1785216878468}}}';
+		expect(scanOpenCodeSkillRows([part(unnamed)], []).uses).toEqual([]);
+	});
+
+	it("falls back to the requested name when the resolved one is blank", () => {
+		// `state.metadata.name` is what the host resolved and is authoritative; on a row
+		// where it is empty, `state.input.name` is the only name there is.
+		const blank = OC_SKILL_NO_TOP_METADATA.replace('"metadata":{"name":"jolli"', '"metadata":{"name":""');
+		expect(scanOpenCodeSkillRows([part(blank)], []).uses[0].skill).toBe("jolli");
+	});
+
+	it("falls back to the row's storage clock when the state carries no times", () => {
+		// `state.time.start` is the event moment and is preferred, but a sparse row still
+		// describes a real invocation — dating it by `time_created` is better than
+		// dropping it, and an absent output means no body size rather than a zero one.
+		const sparse = '{"type":"tool","tool":"skill","state":{"status":"completed","metadata":{"name":"jolli"}}}';
+		const { uses } = scanOpenCodeSkillRows([part(sparse, 1785216878468)], []);
+		expect(uses[0].invocations[0]).toEqual({ at: new Date(1785216878468).toISOString(), ok: true });
+	});
+
+	it("orders invocations newest-first however the rows arrive", () => {
+		const older = OC_SKILL_NO_TOP_METADATA.replace('"start":1785216878468', '"start":1785216000000');
+		const { uses } = scanOpenCodeSkillRows(
+			[part(OC_SKILL_NO_TOP_METADATA, 1785216878468, "prt_a"), part(older, 1785216000000, "prt_b")],
+			[],
+		);
+		expect(uses[0].invocations.map((i) => i.at)).toEqual([
+			new Date(1785216878468).toISOString(),
+			new Date(1785216000000).toISOString(),
+		]);
+	});
+
+	it("keeps both rows when two invocations share a start timestamp", () => {
+		// Nothing dedupes at this layer — the store does, on `at`. Collapsing a tie in
+		// the comparator would drop one before it ever reached that fold.
+		const twin = OC_SKILL_NO_TOP_METADATA.replace('"call_a0d984da877148ac902f33bd"', '"call_twin"');
+		const { uses } = scanOpenCodeSkillRows(
+			[part(OC_SKILL_NO_TOP_METADATA, 1785216878468, "prt_a"), part(twin, 1785216878469, "prt_b")],
+			[],
+		);
+		expect(uses[0].invocations).toHaveLength(2);
+	});
+
+	it("reports no cursor when there were no rows to consume", () => {
+		expect(scanOpenCodeSkillRows([], [])).toEqual({ uses: [] });
+	});
+
 	it("reports the newest row id so the caller can resume", () => {
 		const { lastRowId } = scanOpenCodeSkillRows(
 			[part(OC_SKILL_NO_TOP_METADATA, 1, "prt_a"), part(OC_NON_SKILL_TOOL, 2, "prt_b")],
@@ -143,6 +202,13 @@ describe("openCodeTurnSpend", () => {
 		expect(openCodeTurnSpend(JSON.parse(OC_USER_MESSAGE))).toBeUndefined();
 	});
 
+	it("returns undefined for a message row that is not an object at all", () => {
+		// The column is free-form JSON; an array or a bare scalar reads every field as
+		// undefined and would otherwise report a turn that spent nothing.
+		expect(openCodeTurnSpend([{ tokens: { output: 5 } }])).toBeUndefined();
+		expect(openCodeTurnSpend(null)).toBeUndefined();
+	});
+
 	it("treats missing counters as zero rather than failing", () => {
 		expect(openCodeTurnSpend({ role: "assistant", tokens: { output: 5 } })).toEqual({
 			input: 0,
@@ -153,6 +219,21 @@ describe("openCodeTurnSpend", () => {
 });
 
 describe("scanOpenCodeSkillRows — interval attribution", () => {
+	it("steps over unreadable and token-less message rows inside an interval", () => {
+		// Both loops over the interval re-parse the same rows, so a corrupt row has to
+		// be survivable twice. A row with no token block is the normal case, not an
+		// error — user turns and tool acks carry none.
+		const { uses } = scanOpenCodeSkillRows(
+			[part(OC_SKILL_NO_TOP_METADATA, 1000, "prt_a")],
+			[
+				message("{not json", 1100, "msg_bad"),
+				message('{"role":"assistant"}', 1200, "msg_no_tokens"),
+				message(OC_ASSISTANT_MESSAGE, 1300, "msg_ok"),
+			],
+		);
+		expect(uses[0].usage).toEqual({ input: 89, output: 151, cached: 0, confidence: "estimated" });
+	});
+
 	it("estimates a skill's spend from the turns that follow it", () => {
 		// OpenCode carries NO per-skill attribution anywhere in its schema, so an
 		// interval is the only option — and it is therefore always "estimated", never

--- a/cli/src/core/skills/OpenCodeSkillScanner.ts
+++ b/cli/src/core/skills/OpenCodeSkillScanner.ts
@@ -155,7 +155,11 @@ export function scanOpenCodeSkillRows(
 		});
 	}
 
-	if (entries.length === 0) return lastRowId !== undefined ? { uses: [], lastRowId } : { uses: [] };
+	// Resolved once: `lastRowId` is unset only when there were no part rows at all, so
+	// re-testing it at the second return would be a branch that arm can never take.
+	const cursor = lastRowId !== undefined ? { lastRowId } : {};
+
+	if (entries.length === 0) return { uses: [], ...cursor };
 
 	const spendBySkill = attributeByInterval(entries, messageRows);
 
@@ -181,7 +185,7 @@ export function scanOpenCodeSkillRows(
 	}
 
 	log.debug("Scanned %d OpenCode skill(s) from %d part row(s)", uses.length, partRows.length);
-	return lastRowId !== undefined ? { uses, lastRowId } : { uses };
+	return { uses, ...cursor };
 }
 
 /**

--- a/cli/src/core/skills/SkillArchive.test.ts
+++ b/cli/src/core/skills/SkillArchive.test.ts
@@ -79,6 +79,26 @@ describe("associateSkillsWithCommit", () => {
 		});
 	});
 
+	// A heuristically-detected skill must keep reading as inferred once archived.
+	// Dropping `detection` here would silently promote a guess to an observation
+	// the moment the commit landed.
+	it("carries the heuristic detection marker onto the commit ref", async () => {
+		await upsertSkillEntry(
+			{
+				source: "codex",
+				skill: "inferred-skill",
+				entryPaths: ["tool"],
+				invocations: [{ at: "2026-07-30T06:01:57.000Z", ok: true, bodyChars: 100 }],
+				detection: "heuristic",
+				sessionKey: "codex:sess-h",
+			},
+			tempDir,
+		);
+		const { refs } = await associateSkillsWithCommit(COMMIT, tempDir, "main");
+		expect(refs).toHaveLength(1);
+		expect(refs[0].detection).toBe("heuristic");
+	});
+
 	it("hands the caller the raw working-file bytes to store, not a re-render", async () => {
 		// Archival is a COPY. Rendering markdown again at archive time would put the
 		// display format in a second place and let the two drift.

--- a/cli/src/core/skills/SkillAttribution.test.ts
+++ b/cli/src/core/skills/SkillAttribution.test.ts
@@ -94,6 +94,21 @@ describe("attributeSkillUsage — attributed path", () => {
 		expect(usage.get("superpowers:brainstorming")?.output).toBe(797);
 	});
 
+	it("drops a usage-bearing line that is not parseable JSON", () => {
+		// The pre-filter is a substring test, so a truncated write — the shape a
+		// transcript takes while the host is mid-flush — reaches the parser. It has to
+		// fall out of the scan rather than take the whole pass down with it.
+		const truncated = '{"type":"assistant","message":{"id":"m","usage":{"output_tokens":5';
+		expect(attributeSkillUsage([truncated, USAGE_SPLIT_LINE_1]).get("superpowers:brainstorming")?.output).toBe(797);
+	});
+
+	it("drops a usage-bearing line whose JSON is not an object", () => {
+		// JSONL is one record per line by convention, not by enforcement; an array
+		// would satisfy `JSON.parse` and then read every field as undefined.
+		const arrayLine = '[{"usage":{"output_tokens":5}}]';
+		expect(attributeSkillUsage([arrayLine, USAGE_SPLIT_LINE_1]).get("superpowers:brainstorming")?.output).toBe(797);
+	});
+
 	it("tolerates a usage object missing the optional counters", () => {
 		const sparse =
 			'{"type":"assistant","timestamp":"2026-07-12T11:00:00.000Z","attributionSkill":"a:b","message":{"id":"m","usage":{"output_tokens":5}}}';
@@ -259,6 +274,60 @@ describe("attributeSkillUsage — interval fallback", () => {
 	it("still dedupes repeated lines on the fallback path", () => {
 		const repeated = turn("m1", "2026-07-12T11:09:00.000Z", 500);
 		const usage = attributeSkillUsage([TOOL_CALL, repeated, repeated, repeated]);
+		expect(usage.get("superpowers:brainstorming")?.output).toBe(500);
+	});
+
+	it("steps over unreadable lines without closing the open interval", () => {
+		// Both shapes clear the substring pre-filter and then fail: a truncated write,
+		// and a line that parses to an array. Neither is a user turn, so neither may
+		// end the interval — dropping the line is the whole of the correct response.
+		const truncated = '{"type":"assistant","message":{"id":"mX","usage":{"output_tokens":5';
+		const arrayLine = '[{"role":"user"}]';
+		// A blank line and a record the pre-filter rejects outright, for the same reason.
+		const uninteresting = '{"type":"summary","summary":"Skill coverage work"}';
+		const usage = attributeSkillUsage([
+			TOOL_CALL,
+			"",
+			uninteresting,
+			truncated,
+			arrayLine,
+			turn("m1", "2026-07-12T11:09:00.000Z", 500),
+		]);
+		expect(usage.get("superpowers:brainstorming")?.output).toBe(500);
+	});
+
+	it("counts every unidentified line in the interval, since none can be deduped", () => {
+		// A line with no `message.id` carries no response identity. Collapsing two of
+		// them onto each other would silently discard real spend, so the dedupe set is
+		// bypassed and both count — the same rule the attributed path follows.
+		const anon = (at: string, out: number) =>
+			`{"type":"assistant","timestamp":"${at}","message":{"role":"assistant","usage":{"input_tokens":1,"output_tokens":${out}},"content":[{"type":"text","text":"x"}]}}`;
+		const usage = attributeSkillUsage([
+			TOOL_CALL,
+			anon("2026-07-12T11:09:00.000Z", 500),
+			anon("2026-07-12T11:10:00.000Z", 300),
+		]);
+		expect(usage.get("superpowers:brainstorming")?.output).toBe(800);
+	});
+
+	it("ends the interval at a user record that carries no message body", () => {
+		const bare = '{"type":"user","timestamp":"2026-07-12T11:09:30.000Z"}';
+		const usage = attributeSkillUsage([
+			TOOL_CALL,
+			turn("m1", "2026-07-12T11:09:00.000Z", 500),
+			bare,
+			turn("m2", "2026-07-12T11:10:00.000Z", 9999),
+		]);
+		expect(usage.get("superpowers:brainstorming")?.output).toBe(500);
+	});
+
+	it("does not treat a Skill block that names no skill as an entry", () => {
+		// A `Skill` tool_use whose input never made it to disk resolves to no id. It
+		// must leave the open interval alone: closing it would strand the following
+		// turns under no skill at all, which is worse than billing them to the caller.
+		const noInput =
+			'{"type":"assistant","timestamp":"2026-07-12T11:08:30.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_TRUNC","name":"Skill"}]}}';
+		const usage = attributeSkillUsage([TOOL_CALL, noInput, turn("m1", "2026-07-12T11:09:00.000Z", 500)]);
 		expect(usage.get("superpowers:brainstorming")?.output).toBe(500);
 	});
 

--- a/cli/src/core/skills/SkillDelta.ts
+++ b/cli/src/core/skills/SkillDelta.ts
@@ -99,11 +99,18 @@ function mergeUsageSplits(
 	contributors: ReadonlyArray<SkillCommitRef>,
 ): Readonly<Record<string, SkillUsage>> | undefined {
 	if (contributors.length === 0) return undefined;
-	if (contributors.some((ref) => ref.usageBySession === undefined)) return undefined;
+	// Collect while checking, rather than `some(...)` then re-reading the field in
+	// the merge loop: the second read would need a `?? {}` fallback that can never
+	// fire, since the check above already rejected every undefined split.
+	const splits: Array<Readonly<Record<string, SkillUsage>>> = [];
+	for (const ref of contributors) {
+		if (ref.usageBySession === undefined) return undefined;
+		splits.push(ref.usageBySession);
+	}
 
 	const merged: Record<string, SkillUsage> = {};
-	for (const ref of contributors) {
-		for (const [key, usage] of Object.entries(ref.usageBySession ?? {})) {
+	for (const split of splits) {
+		for (const [key, usage] of Object.entries(split)) {
 			const prior = merged[key];
 			merged[key] =
 				prior === undefined

--- a/cli/src/core/skills/SkillStore.test.ts
+++ b/cli/src/core/skills/SkillStore.test.ts
@@ -303,9 +303,71 @@ describe("foldSkillUse", () => {
 		);
 		expect(fresh.usage).toEqual({ input: 20, output: 30, cached: 40, confidence: "attributed" });
 	});
+	it("keeps a heuristic detection mark once a pass has set it", () => {
+		// Sticky like `trimmed`: a later pass that happens not to say "inferred" is not
+		// evidence the capture became observed, so downgrading would overstate it.
+		const first = foldSkillUse(use({ detection: "heuristic" }), undefined);
+		expect(first.detection).toBe("heuristic");
+
+		const second = foldSkillUse(use({ invocations: [inv("2026-07-30T07:00:00.000Z")] }), first);
+		expect(second.detection).toBe("heuristic");
+	});
+
+	it("keeps the prior plugin when a later pass reports none", () => {
+		const first = foldSkillUse(use(), undefined);
+		const second = foldSkillUse(use({ plugin: undefined, invocations: [inv("2026-07-30T07:00:00.000Z")] }), first);
+		expect(second.plugin).toBe("superpowers");
+	});
+
+	it("walks firstUsedAt backwards when a catch-up pass finds older invocations", () => {
+		// The prior file's bound is a candidate, not a floor: a rewound cursor can
+		// surface rows older than anything the file has ever seen.
+		const first = foldSkillUse(use({ invocations: [inv("2026-07-30T06:00:00.000Z")] }), undefined);
+		const second = foldSkillUse(
+			use({ invocations: [inv("2026-07-29T05:00:00.000Z"), inv("2026-07-31T08:00:00.000Z")] }),
+			first,
+		);
+		expect(second.firstUsedAt).toBe("2026-07-29T05:00:00.000Z");
+		expect(second.lastUsedAt).toBe("2026-07-31T08:00:00.000Z");
+	});
+
+	it("yields empty bounds for a fold with nothing to date it by", () => {
+		// No scanner emits this today. The folder is exported, so it must degrade to
+		// empty strings rather than writing `undefined` into the frontmatter.
+		const folded = foldSkillUse(use({ invocations: [] }), undefined);
+		expect(folded.firstUsedAt).toBe("");
+		expect(folded.lastUsedAt).toBe("");
+		expect(folded.invocationCount).toBe(0);
+	});
 });
 
 describe("renderSkillMarkdown / parseSkillMarkdownFromString", () => {
+	it("round-trips the heuristic detection mark", () => {
+		// The mark is what tells the UI a capture was inferred rather than observed;
+		// losing it on the round-trip would silently promote every reloaded skill.
+		const content = foldSkillUse(use({ detection: "heuristic" }), undefined);
+		expect(renderSkillMarkdown(content)).toContain('detection: "heuristic"');
+		expect(parseSkillMarkdownFromString(renderSkillMarkdown(content))?.detection).toBe("heuristic");
+	});
+
+	it("ignores a frontmatter line that carries no key/value separator", () => {
+		// A stray blank or continuation line inside the frontmatter block. `indexOf`
+		// also returns 0 for a line that opens with the separator, which is not a key.
+		const parsed = parseSkillMarkdownFromString(
+			["---", "", ": orphan", 'source: "claude"', 'skill: "a:b"', "---", ""].join("\n"),
+		);
+		expect(parsed?.skill).toBe("a:b");
+	});
+
+	it("drops an unparseable body count but keeps the invocation", () => {
+		// A half-written row still identifies a real invocation by its timestamp; only
+		// the field that cannot be read is discarded.
+		const parsed = parseSkillMarkdownFromString(
+			["---", 'source: "claude"', 'skill: "a:b"', "---", "", "- 2026-07-30T06:35:21.000Z · body: n/a"].join("\n"),
+		);
+		expect(parsed?.invocations).toEqual([{ at: "2026-07-30T06:35:21.000Z", ok: true }]);
+	});
+
 	it("round-trips a fully populated skill file", () => {
 		const content = foldSkillUse(
 			use({
@@ -449,6 +511,23 @@ describe("writeSkillMarkdown", () => {
 		const onDisk = await readSkillMarkdown(result.sourcePath);
 		expect(onDisk?.skill).toBe("superpowers:brainstorming");
 		expect(onDisk?.invocationCount).toBe(1);
+	});
+
+	it("reports both the usage total and its per-session split back to the caller", async () => {
+		// Same reason as the detection mark: the registry row is assembled from this
+		// return value, and the split is what a later detach subtracts from.
+		const usage = { input: 79, output: 33944, cached: 59796, confidence: "attributed" } as const;
+		const result = await writeSkillMarkdown(use({ usage }), tempDir);
+		expect(result.usage).toEqual(usage);
+		expect(result.usageBySession).toEqual({ "claude:sess-a": usage });
+	});
+
+	it("reports the detection mark back to the caller, not just to disk", async () => {
+		// The registry row is built from this return value, so a mark that only reached
+		// the markdown would leave the sidebar claiming the capture was observed.
+		const result = await writeSkillMarkdown(use({ detection: "heuristic" }), tempDir);
+		expect(result.detection).toBe("heuristic");
+		expect((await readSkillMarkdown(result.sourcePath))?.detection).toBe("heuristic");
 	});
 
 	it("folds a second pass into the file already on disk", async () => {

--- a/cli/src/core/skills/SkillStore.ts
+++ b/cli/src/core/skills/SkillStore.ts
@@ -295,7 +295,17 @@ export function foldSkillUse(use: SkillUse, prior: SkillFileContent | undefined)
 		byAt.set(incoming.at, moreCompleteInvocation(existing, incoming));
 	}
 
-	const merged = [...byAt.values()].sort((a, b) => (a.at === b.at ? 0 : a.at < b.at ? 1 : -1));
+	const merged = [...byAt.values()].sort((a, b) => {
+		/* v8 ignore start -- unreachable today: `byAt` is keyed on `at`, so two surviving
+		   invocations can never carry the same one. Kept anyway, because dropping it makes
+		   the comparator INCONSISTENT for a duplicate key (both argument orders would
+		   return the same sign), and V8's TimSort answers an inconsistent comparator with
+		   an arbitrary order — so a future change that admits duplicates would silently
+		   reorder this invocation list with no test failing. */
+		if (a.at === b.at) return 0;
+		/* v8 ignore stop */
+		return a.at < b.at ? 1 : -1;
+	});
 	const kept = merged.slice(0, SKILL_INVOCATION_CAP);
 	const trimmed = (prior?.trimmed ?? false) || merged.length > kept.length;
 	if (merged.length > kept.length) {
@@ -481,8 +491,13 @@ function parseInvocationLine(line: string): SkillInvocation | null {
 	const argsMatch = /args: ("(?:[^"\\]|\\.)*")/.exec(tail);
 	if (argsMatch !== null) {
 		try {
-			const parsed: unknown = JSON.parse(argsMatch[1]);
-			if (typeof parsed === "string") args = parsed;
+			// The cast is sound ONLY because of the capture group above: `"(?:[^"\\]|\\.)*"`
+			// can match nothing but a well-formed JSON string literal (the `[^"\\]` class
+			// stops the greedy run at the first unescaped quote), so a parse that returns
+			// at all returns a string, and a `typeof` re-check would be a branch no input
+			// can take. Relaxing that regex invalidates this — restore the check if it
+			// ever admits a bare number, object, or array.
+			args = JSON.parse(argsMatch[1]) as string;
 		} catch {
 			// Unrecoverable args text is dropped; the invocation itself still counts.
 		}

--- a/cli/src/core/skills/TranscriptSkillDiscovery.test.ts
+++ b/cli/src/core/skills/TranscriptSkillDiscovery.test.ts
@@ -1,8 +1,8 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { loadExtractorCursorLine, loadPlansRegistry } from "../SessionTracker.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadExtractorCursorLine, loadPlansRegistry, upsertSkillEntry } from "../SessionTracker.js";
 import {
 	ATTRIBUTED_TURN,
 	COMMAND_BODY,
@@ -16,6 +16,14 @@ import {
 	USAGE_SUBAGENT_TURN,
 } from "./__fixtures__/claudeTranscript.js";
 import { scanSkillsFrom, scanSkillsWithCursor } from "./TranscriptSkillDiscovery.js";
+
+// Partial mock: every other export stays real (the tests below read the registry and
+// the cursors back through them), only the persist call is made steerable so a
+// mid-scan failure can be injected.
+vi.mock("../SessionTracker.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../SessionTracker.js")>();
+	return { ...actual, upsertSkillEntry: vi.fn(actual.upsertSkillEntry) };
+});
 
 describe("scanSkillsFrom", () => {
 	let tempDir: string;
@@ -133,6 +141,26 @@ describe("scanSkillsFrom", () => {
 		await writeFile(join(dir, "agent-x.meta.json"), '{"agentType":"Explore"}', "utf-8");
 		await expect(scanSkillsFrom(path, 0, tempDir, "claude")).resolves.toBe(0);
 		expect((await loadPlansRegistry(tempDir)).skills).toBeUndefined();
+	});
+
+	it("skips an unreadable subagent file and still scans the rest", async () => {
+		// readdir lists the name, readFile then fails on it — the real case is a file
+		// removed between the listing and the read, reproduced deterministically here
+		// with a directory wearing the transcript name. One bad entry must not cost the
+		// session its own skills, nor the sibling subagent's.
+		const inSubagent = TOOL_CALL.replace(
+			'"skill":"superpowers:brainstorming"',
+			'"skill":"superpowers:test-driven-development"',
+		).replace('"toolu_019BtdUXtkPLcwtXEUiUv1Dc"', '"toolu_SUB"');
+		const path = await writeTranscript([TOOL_CALL, TOOL_RESULT, TOOL_BODY]);
+		await writeSubagent("zzz", [inSubagent]);
+		await mkdir(join(projectsDir, SESSION_ID, "subagents", "agent-broken.jsonl"), { recursive: true });
+
+		await expect(scanSkillsFrom(path, 0, tempDir, "claude")).resolves.toBe(3);
+		expect(Object.keys((await loadPlansRegistry(tempDir)).skills ?? {}).sort()).toEqual([
+			"claude:superpowers:brainstorming",
+			"claude:superpowers:test-driven-development",
+		]);
 	});
 
 	it("is a no-op for a transcript with no subagents directory", async () => {
@@ -276,6 +304,17 @@ describe("scanSkillsFrom", () => {
 			const missing = join(projectsDir, "does-not-exist.jsonl");
 			await expect(scanSkillsWithCursor(missing, tempDir, "claude")).resolves.toBeUndefined();
 			expect(await loadExtractorCursorLine(missing, "skills", tempDir)).toBe(0);
+		});
+
+		it("swallows a mid-scan failure and holds the mark", async () => {
+			// The scan itself can throw — a plans.lock timeout is the live example. The
+			// helper must neither propagate it into the hook nor advance the mark over
+			// lines it never finished persisting.
+			const path = await writeTranscript([TOOL_CALL, TOOL_RESULT, TOOL_BODY]);
+			vi.mocked(upsertSkillEntry).mockRejectedValueOnce(new Error("plans.lock timeout"));
+
+			await expect(scanSkillsWithCursor(path, tempDir, "claude")).resolves.toBeUndefined();
+			expect(await loadExtractorCursorLine(path, "skills", tempDir)).toBe(0);
 		});
 
 		it("is a no-op for a source with no skill scanner", async () => {

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -527,6 +527,17 @@ describe("PostCommitHook", () => {
 		expect(spawn).not.toHaveBeenCalled();
 	});
 
+	it("delegates to the synchronous entry once the disable gate passes", async () => {
+		// The gate is the ONLY thing runPostCommitHook adds; past it, the result is
+		// whatever postCommitEntry decides. Drive it with GIT_REFLOG_ACTION=rebase —
+		// the one branch that resolves without reading git state or spawning — so the
+		// delegation is observable without pinning the whole enqueue pipeline here.
+		vi.mocked(readManualDisableFlag).mockResolvedValue(false);
+		vi.stubEnv("GIT_REFLOG_ACTION", "rebase");
+		await expect(runPostCommitHook("/test/project")).resolves.toBeNull();
+		expect(spawn).not.toHaveBeenCalled();
+	});
+
 	it("debounce-enqueues a post-commit ingest after processing a commit", async () => {
 		setupFullPipeline();
 

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -5437,6 +5437,50 @@ describe("QueueWorker", () => {
 			expect(saved.references?.[0].archivedKey).toBe("linear:PROJ-1-abc12345");
 		});
 
+		it("amend fresh-leaf attaches archived skills to the summary (skills spread)", async () => {
+			// Regression: the fresh leaf spread plans/notes/references but NOT skills,
+			// while both other amend paths (short-circuit, full consolidation) did. The
+			// association had already guarded the registry row and emitted the orphan
+			// bytes by then, so the skills were archived and then referenced by nothing
+			// — gone from the working area AND absent from the summary.
+			const op = makeCommitOp({
+				type: "amend",
+				commitHash: "abc12345def67890",
+				branch: "feature/x",
+				sourceHashes: ["0123456789abcdef0123456789abcdef01234567"],
+			});
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op, filePath: "/tmp/queue/entry.json" }])
+				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]);
+			setupPipelineMocks("abc12345def67890");
+			vi.mocked(getCurrentBranch).mockResolvedValue("feature/x");
+			// Non-trivial delta + no old summary → fresh-leaf path.
+			vi.mocked(getDiffStats).mockResolvedValue({ filesChanged: 1, insertions: 60, deletions: 1 });
+			const { associateSkillsWithCommit } = await import("../core/skills/SkillArchive.js");
+			vi.mocked(associateSkillsWithCommit).mockResolvedValue({
+				refs: [
+					{
+						archivedKey: "claude:superpowers:brainstorming-abc12345",
+						source: "claude",
+						skill: "superpowers:brainstorming",
+						plugin: "superpowers",
+						entryPaths: ["tool"],
+						invocationCount: 2,
+						firstUsedAt: "2026-05-14T06:00:00.000Z",
+						lastUsedAt: "2026-05-14T06:30:00.000Z",
+					},
+				],
+				filesToStore: [{ path: "skills/claude/superpowers-brainstorming-abc12345.md", content: "# skill" }],
+			});
+
+			await runWorker("/test/cwd");
+
+			expect(storeSummary).toHaveBeenCalledTimes(1);
+			const saved = vi.mocked(storeSummary).mock.calls[0][0];
+			expect(saved.skills?.[0].archivedKey).toBe("claude:superpowers:brainstorming-abc12345");
+		});
+
 		it("clears the AI selection layer once, up front, on an amend", async () => {
 			// A `git commit --amend` moves HEAD → the panel's cached fingerprint is
 			// stale, so every amend path invalidates it (mirrors the normal pipeline's

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -3570,6 +3570,11 @@ async function handleAmendPipeline(
 	const freshLeafPlanRefs = consumed.planAssociation.refs;
 	const freshLeafNoteRefs = consumed.noteRefs;
 	const freshLeafReferenceRefs = consumed.referenceRefs;
+	// Skills must be spread below alongside the other three. `consumeWorkspaceContext`
+	// has already guarded the registry rows and written the orphan bytes, so a leaf
+	// that omits the refs does not merely under-report — it strands the archive:
+	// the rows are consumed (off the panel) and nothing addresses the stored files.
+	const freshLeafSkillRefs = consumed.skillRefs;
 
 	const freshLeaf: CommitSummary = {
 		version: CURRENT_SCHEMA_VERSION,
@@ -3589,6 +3594,7 @@ async function handleAmendPipeline(
 		...(freshLeafPlanRefs.length > 0 ? { plans: freshLeafPlanRefs } : {}),
 		...(freshLeafNoteRefs.length > 0 ? { notes: freshLeafNoteRefs } : {}),
 		...(freshLeafReferenceRefs.length > 0 ? { references: freshLeafReferenceRefs } : {}),
+		...(freshLeafSkillRefs.length > 0 ? { skills: freshLeafSkillRefs } : {}),
 		// AI soft-exclude audit, mirroring the normal commit pipeline: this path
 		// generated a new summary, so record what the relevance layer set aside.
 		...(amendExcludedContext.length > 0 ? { excludedContext: amendExcludedContext } : {}),

--- a/cli/src/mcp/McpTools.test.ts
+++ b/cli/src/mcp/McpTools.test.ts
@@ -455,6 +455,40 @@ describe("buildStatusSummary", () => {
 		expect(r.space).toBeNull();
 	});
 
+	it("omits the push-disabled pair when outbound push is allowed", () => {
+		// Spec 310's gate treats an absent flag as allowed, so absent is the honest
+		// encoding of "this repo pushes" — the same rule `jolli status` follows by
+		// printing the `Outbound push:` row only when push is off.
+		const r = buildStatusSummary(makeStatus({ pushDisabled: false }), {
+			version: "1",
+			isClaudePlugin: false,
+			account,
+		});
+		expect(r).not.toHaveProperty("pushDisabled");
+		expect(r).not.toHaveProperty("pushDisabledError");
+	});
+
+	it("projects pushDisabled so an AI host can learn why push_memory was refused", () => {
+		const r = buildStatusSummary(makeStatus({ pushDisabled: true }), {
+			version: "1",
+			isClaudePlugin: false,
+			account,
+		});
+		expect(r.pushDisabled).toBe(true);
+		expect(r).not.toHaveProperty("pushDisabledError");
+	});
+
+	it("carries pushDisabledError so a fail-closed read is not misattributed to the user", () => {
+		// An unreadable store reports OFF for EVERY repo. Reporting the boolean alone
+		// would tell the host "you turned this repo off" when the user chose nothing.
+		const r = buildStatusSummary(
+			makeStatus({ pushDisabled: true, pushDisabledError: "Push-control store at /x could not be read: EACCES" }),
+			{ version: "1", isClaudePlugin: false, account },
+		);
+		expect(r.pushDisabled).toBe(true);
+		expect(r.pushDisabledError).toBe("Push-control store at /x could not be read: EACCES");
+	});
+
 	it("surfaces anthropicKeyConfigured only for the anthropic provider (signed out)", () => {
 		const r = buildStatusSummary(makeStatus(), {
 			version: "1",

--- a/cli/src/mcp/McpTools.ts
+++ b/cli/src/mcp/McpTools.ts
@@ -247,6 +247,20 @@ export interface StatusResult {
 	 * pre-push hook, so this drives the `syncing · Space "<name>"` snapshot line.
 	 */
 	readonly space: { readonly name: string } | null;
+	/**
+	 * Present (and `true`) ONLY when this repo's outbound push to a Jolli Space is
+	 * off — spec 310's gate treats an absent flag as allowed, so absent is the
+	 * honest encoding of "this repo pushes". Without it an AI host whose
+	 * `push_memory` was refused has no channel for learning why.
+	 */
+	readonly pushDisabled?: boolean;
+	/**
+	 * Why {@link pushDisabled} is true when it is NOT the user's recorded choice:
+	 * the push-control store could not be read, which fails closed and reports OFF
+	 * for *every* repo machine-wide. Reporting the boolean alone would misattribute
+	 * a machine-wide read failure to a per-repo decision the user never made.
+	 */
+	readonly pushDisabledError?: string;
 }
 
 /**
@@ -345,6 +359,11 @@ export function buildStatusSummary(
 		storedMemories: status.summaryCount,
 		orphanBranch: status.orphanBranch,
 		space: ctx.space ?? null,
+		// Both halves or neither — the error explains which OFF this is, and a
+		// boolean without it reads as "you turned this repo off" even when the
+		// store was simply unreadable.
+		...(status.pushDisabled ? { pushDisabled: true } : {}),
+		...(status.pushDisabled && status.pushDisabledError ? { pushDisabledError: status.pushDisabledError } : {}),
 	};
 }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliPushOrchestrator.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliPushOrchestrator.kt
@@ -46,8 +46,15 @@ object JolliPushOrchestrator {
      * ("contact an admin") / quiet ("re-enable to push") handling they have for
      * exactly these two.
      *
-     * Mirrors vscode's `FATAL_PUSH_ERROR_NAMES`; shared by BOTH attachment loops so
-     * the fatal set cannot drift between them.
+     * Mirrors `REPO_WIDE_REFUSAL_NAMES` in `cli/src/core/PushRefusal.ts` — the shared
+     * source of truth the CLI and VS Code loops both read (it superseded vscode's old
+     * `FATAL_PUSH_ERROR_NAMES`, which no longer exists). Shared by BOTH attachment
+     * loops here so the fatal set cannot drift between them either.
+     *
+     * Sharing the set is not the same as sharing the behaviour: VS Code reads it but
+     * `JolliPushService` has no 401 branch, so a rejected credential still reaches its
+     * loops as a plain `Error` and is collected per attachment. The 401 stop described
+     * below is live on this surface and the CLI only.
      *
      * Membership must stay in step with `CreatePrPanel.repoWideStopReason`, the other
      * place this project decides "repo-wide or per-item". The two differ in exactly
@@ -55,7 +62,9 @@ object JolliPushOrchestrator {
      * cannot run a chooser) but RECOVERABLE there (the panel resolves the binding and
      * retries). Every other repo-wide type belongs in both — a type added to only one
      * is the bug shape that let a repo-wide refusal be counted as a single per-item
-     * failure. When adding one, update both.
+     * failure. When adding one, update both. `UnauthorizedError` was exactly that
+     * shape for a while: present only in `repoWideStopReason`, so a 401 mid-loop here
+     * became N per-attachment failures instead of one "sign-in rejected" stop.
      *
      * `internal` so the set is unit-testable: both loops reach it only through a
      * static [JolliApiClient.pushToJolli] call, which cannot be faked without the
@@ -64,6 +73,7 @@ object JolliPushOrchestrator {
     internal fun isFatalPushError(e: Throwable): Boolean =
         e is JolliApiClient.BindingRequiredError ||
             e is JolliApiClient.PluginOutdatedError ||
+            e is JolliApiClient.UnauthorizedError ||
             e is JolliApiClient.PermissionDeniedError ||
             e is JolliShareService.PushDisabledError ||
             // Not reachable from inside the attachment loops today (the gate that raises

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt
@@ -5,6 +5,8 @@ import ai.jolli.jollimemory.core.ActiveSessionAggregator
 import ai.jolli.jollimemory.core.CommitSelectionStore
 import ai.jolli.jollimemory.core.PinStore
 import ai.jolli.jollimemory.core.SessionTracker
+import ai.jolli.jollimemory.core.references.SourceDisplay
+import ai.jolli.jollimemory.core.references.SourceIds
 import ai.jolli.jollimemory.services.JolliMemoryService
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.Disposable
@@ -133,7 +135,7 @@ class PinnedPanel(
 		val badge: JComponent = if (sourceLogo != null) {
 			JLabel(sourceLogo).apply { toolTipText = entry.badge }
 		} else {
-			BadgePill(entry.badge, badgeColor(entry))
+			BadgePill(badgeText(entry), badgeColor(entry))
 		}
 		val west = JPanel(GridBagLayout()).apply {
 			isOpaque = false
@@ -284,11 +286,6 @@ class PinnedPanel(
 		}
 	}
 
-	private fun badgeColor(entry: PinStore.PinnedEntry): Color = when (entry.kind) {
-		"conversations" -> SOURCE_COLORS[entry.badge.lowercase()] ?: JBColor.GRAY
-		else -> TAG_COLORS[entry.badge] ?: JBColor.GRAY
-	}
-
 	// ── Open content on click ───────────────────────────────────────────────
 
 	private fun openPinned(entry: PinStore.PinnedEntry) {
@@ -373,7 +370,7 @@ class PinnedPanel(
 		}
 	}
 
-	private companion object {
+	internal companion object {
 
 		// Mirrors ConversationRowComponent.SourceBadge colors.
 		val SOURCE_COLORS = mapOf(
@@ -383,15 +380,67 @@ class PinnedPanel(
 			"opencode" to JBColor(Color(37, 99, 235), Color(37, 99, 235)),
 			"cursor" to JBColor(Color(220, 38, 38), Color(220, 38, 38)),
 		)
-		// Mirrors PlansPanel tag colors (P/N/S/L/GH/J/No).
+
+		/**
+		 * Colors for the two badge letters this panel owns outright: plan "P", and
+		 * note "N" / snippet "S". Reference letters are deliberately ABSENT — see
+		 * [badgeColor]. Keep this in step with PlansPanel's plan/note tag colors.
+		 */
 		val TAG_COLORS = mapOf(
 			"P" to JBColor(0x4C82F7, 0x4C82F7),
 			"N" to JBColor(0x3FA45B, 0x3FA45B),
 			"S" to JBColor(0xC9851E, 0xD18616),
-			"L" to JBColor(0x7A6FF0, 0x8A7FF5),
-			"GH" to JBColor(0x6E7681, 0x8B949E),
-			"J" to JBColor(0x2A78C8, 0x3B82D6),
-			"No" to JBColor(0x6B6B6B, 0x9B9B9B),
 		)
+
+		/**
+		 * Accent color for a pinned row's badge pill.
+		 *
+		 * A reference's color is resolved from its SOURCE, never from the letter
+		 * tag, because the tag is not a unique key: Jira and Jolli Memory both
+		 * stamp "J", Zoom Doc and Zoom Meeting both stamp "Z". A letter-keyed map
+		 * cannot be right for both members of such a pair, and it also silently
+		 * collides with the note/snippet letters this panel does own ("N" is both
+		 * Notion and note, "S" is both Slack and snippet) — so a Notion pin used to
+		 * paint note-green and a Slack pin snippet-amber, while the six letters
+		 * added since the map was written ("G", "C", "A", "M", "Z", "7") fell
+		 * through to gray.
+		 *
+		 * The pin's `key` IS the registry mapKey (`<wire>:<nativeId>`), so the
+		 * source is recoverable with no change to the stored shape, and
+		 * [SourceDisplay] stays the single place reference colors live — a new
+		 * source can never desync this panel again. An unparseable wire name lands
+		 * on [SourceDisplay.unknown]'s neutral gray, the same fallback the
+		 * reference rows themselves use.
+		 */
+		internal fun badgeColor(entry: PinStore.PinnedEntry): Color = when (entry.kind) {
+			"conversations" -> SOURCE_COLORS[entry.badge.lowercase()] ?: JBColor.GRAY
+			"references" -> SourceDisplay.of(SourceIds.parse(entry.key.substringBefore(":"))).color
+			else -> TAG_COLORS[entry.badge] ?: JBColor.GRAY
+		}
+
+		/**
+		 * Letter tag for a pinned row's badge pill.
+		 *
+		 * References re-derive it from the `key`'s wire name for the same reason
+		 * [badgeColor] does, and re-deriving BOTH is what actually closes the drift:
+		 * the stored letter is whatever the plugin version that created the pin
+		 * stamped, and that alphabet has since changed — pins written before the
+		 * single-letter scheme carry "GH" (GitHub) and "No" (Notion), and a pin
+		 * written before `badge` existed at all falls back to the raw source name
+		 * (see `PinStore.load`). Color-only derivation would render those forever
+		 * with the new, correct hue behind a stale letter. An unparseable wire name
+		 * takes [SourceDisplay.unknown]'s "R" together with its neutral gray, which
+		 * is exactly how the reference rows themselves render it.
+		 *
+		 * Every other kind keeps the stored badge: plan "P" / note "N" / snippet "S"
+		 * and the conversation source name are the row's own label, not a derived
+		 * view of the reference registry.
+		 */
+		internal fun badgeText(entry: PinStore.PinnedEntry): String =
+			if (entry.kind == "references") {
+				SourceDisplay.of(SourceIds.parse(entry.key.substringBefore(":"))).tag
+			} else {
+				entry.badge
+			}
 	}
 }

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliPushOrchestratorTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/services/JolliPushOrchestratorTest.kt
@@ -69,15 +69,15 @@ class JolliPushOrchestratorTest {
         }
 
         @Test
-        fun `KNOWN GAP - unauthorized is repo-wide but still takes the collect path`() {
-            // Pins current behavior, NOT an endorsement. A 401 is repo-wide (every
-            // remaining attachment gets the same rejection) and `CreatePrPanel`'s
-            // `repoWideStopReason` already classifies it as a whole-loop stop — so this
-            // is the one type the two classifiers disagree on beyond the deliberate
-            // `BindingRequiredError` exception. Promoting it here means promoting
-            // `NotAuthenticatedError` in vscode's `FATAL_PUSH_ERROR_NAMES` in the same
-            // change; until then this test is the record that the gap is known.
-            JolliPushOrchestrator.isFatalPushError(JolliApiClient.UnauthorizedError("no token")) shouldBe false
+        fun `unauthorized aborts the push instead of becoming N attachment failures`() {
+            // Repo-wide: a rejected credential rejects every remaining attachment
+            // identically. This used to be the one type the two classifiers disagreed
+            // on beyond the deliberate `BindingRequiredError` exception —
+            // `CreatePrPanel.repoWideStopReason` stopped the loop and said "sign-in
+            // rejected" while this one collected N `plan "X" failed` lines. Promoted
+            // alongside `NotAuthenticatedError` / `UnauthorizedError` in
+            // `cli/src/core/PushRefusal.ts`, which the CLI and VS Code loops share.
+            JolliPushOrchestrator.isFatalPushError(JolliApiClient.UnauthorizedError("no token")) shouldBe true
         }
     }
 }

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanelBadgeColorTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanelBadgeColorTest.kt
@@ -1,0 +1,124 @@
+package ai.jolli.jollimemory.toolwindow
+
+import ai.jolli.jollimemory.core.PinStore
+import ai.jolli.jollimemory.core.references.SourceDisplay
+import ai.jolli.jollimemory.core.references.SourceId
+import com.intellij.ui.JBColor
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.Test
+
+/**
+ * Pinned rows mirror their source row's badge. For a reference BOTH halves are
+ * derived from the pin's `key`, never from the stored letter: the letter tag is not
+ * a unique key (Jira/Jolli both "J", Zoom Doc/Meeting both "Z") and it collides with
+ * the note/snippet letters this panel owns ("N", "S"), so it cannot drive the color;
+ * and the stored letter is itself whatever alphabet the writing plugin version used,
+ * so it cannot be trusted as the label either.
+ *
+ * Identity comparisons throughout: JBColor resolves its RGB against the active
+ * theme, which is not stood up in these unit tests, so the assertion is "the same
+ * Style object the reference row would have used" rather than a value compare.
+ */
+class PinnedPanelBadgeColorTest {
+
+    private fun pin(kind: String, key: String, badge: String) =
+        PinStore.PinnedEntry(kind = kind, key = key, title = "t", badge = badge, pinnedAt = 0)
+
+    @Test
+    fun `reference color comes from the source, not the letter tag`() {
+        val notion = PinnedPanel.badgeColor(pin("references", "notion:abc123", "N"))
+        notion shouldBe SourceDisplay.of(SourceId.notion).color
+        // The regression: "N" also keys note-green in this panel's own tag map.
+        notion shouldNotBe PinnedPanel.TAG_COLORS["N"]
+    }
+
+    @Test
+    fun `slack does not inherit the snippet amber that shares its letter`() {
+        val slack = PinnedPanel.badgeColor(pin("references", "slack:C123-1700000000", "S"))
+        slack shouldBe SourceDisplay.of(SourceId.slack).color
+        slack shouldNotBe PinnedPanel.TAG_COLORS["S"]
+    }
+
+    @Test
+    fun `the two sources sharing the letter J resolve to different colors`() {
+        val jira = PinnedPanel.badgeColor(pin("references", "jira:KAN-5", "J"))
+        val jolli = PinnedPanel.badgeColor(pin("references", "jollimemory:recall", "J"))
+        jira shouldBe SourceDisplay.of(SourceId.jira).color
+        jolli shouldBe SourceDisplay.of(SourceId.jollimemory).color
+        jira shouldNotBe jolli
+    }
+
+    @Test
+    fun `hyphenated wire names resolve rather than falling through to unknown`() {
+        // `zoom-doc` is the wire name, not the enum name — a naive valueOf would miss it.
+        val zoomDoc = PinnedPanel.badgeColor(pin("references", "zoom-doc:xyz", "Z"))
+        zoomDoc shouldBe SourceDisplay.of(SourceId.zoom_doc).color
+    }
+
+    @Test
+    fun `sources added since the old letter map still get their brand color`() {
+        // "G", "C", "A", "M", "7" had no entry in the letter map and fell through to gray.
+        for ((key, id) in listOf(
+            "github:o/r#1" to SourceId.github,
+            "confluence:1234" to SourceId.confluence,
+            "asana:1" to SourceId.asana,
+            "monday:1" to SourceId.monday,
+            "context7:/vercel/next.js" to SourceId.context7,
+        )) {
+            PinnedPanel.badgeColor(pin("references", key, "?")) shouldBe SourceDisplay.of(id).color
+        }
+    }
+
+    @Test
+    fun `an unknown wire name lands on the reference placeholder, not the conversation fallback`() {
+        // The placeholder is itself a neutral gray (#6E7681) — what this pins is that it
+        // is the SAME neutral the reference rows use, not the `JBColor.GRAY` that the
+        // conversation branch falls back to.
+        val unknown = PinnedPanel.badgeColor(pin("references", "notatool:1", "R"))
+        unknown shouldBe SourceDisplay.unknown().color
+        unknown shouldNotBe JBColor.GRAY
+    }
+
+    @Test
+    fun `plan and note letters still resolve from the panel's own tag map`() {
+        PinnedPanel.badgeColor(pin("plans", "my-plan", "P")) shouldBe PinnedPanel.TAG_COLORS["P"]
+        PinnedPanel.badgeColor(pin("notes", "n1", "N")) shouldBe PinnedPanel.TAG_COLORS["N"]
+        PinnedPanel.badgeColor(pin("notes", "n2", "S")) shouldBe PinnedPanel.TAG_COLORS["S"]
+    }
+
+    @Test
+    fun `conversation rows keep resolving by source name`() {
+        PinnedPanel.badgeColor(pin("conversations", "claude:sess", "Claude")) shouldBe
+            PinnedPanel.SOURCE_COLORS["claude"]
+        PinnedPanel.badgeColor(pin("conversations", "x:sess", "Nope")) shouldBe JBColor.GRAY
+    }
+
+    @Test
+    fun `a reference letter stamped by an older plugin is re-derived, not rendered as stored`() {
+        // Pre-single-letter alphabet: GitHub was "GH", Notion "No". Deriving only the
+        // color would leave those letters next to the new, correct hue forever.
+        PinnedPanel.badgeText(pin("references", "github:o/r#1", "GH")) shouldBe SourceDisplay.of(SourceId.github).tag
+        PinnedPanel.badgeText(pin("references", "notion:abc123", "No")) shouldBe SourceDisplay.of(SourceId.notion).tag
+    }
+
+    @Test
+    fun `a reference pin with no stored badge still gets its letter`() {
+        // `PinStore.load` falls back to the raw source name when `badge` is absent.
+        PinnedPanel.badgeText(pin("references", "slack:C123-1700000000", "slack")) shouldBe
+            SourceDisplay.of(SourceId.slack).tag
+    }
+
+    @Test
+    fun `an unknown reference wire name takes the placeholder letter`() {
+        PinnedPanel.badgeText(pin("references", "notatool:1", "X")) shouldBe SourceDisplay.unknown().tag
+    }
+
+    @Test
+    fun `plan, note and conversation letters are kept as stored, not derived`() {
+        PinnedPanel.badgeText(pin("plans", "my-plan", "P")) shouldBe "P"
+        PinnedPanel.badgeText(pin("notes", "n1", "N")) shouldBe "N"
+        PinnedPanel.badgeText(pin("notes", "n2", "S")) shouldBe "S"
+        PinnedPanel.badgeText(pin("conversations", "claude:sess", "Claude")) shouldBe "Claude"
+    }
+}

--- a/vscode/src/views/SidebarScriptBuilder.test.ts
+++ b/vscode/src/views/SidebarScriptBuilder.test.ts
@@ -2770,25 +2770,29 @@ describe("SidebarScriptBuilder", () => {
 			expect(body).toContain("'jollimemory.openNoteForPreview'");
 		});
 
-		it("mouseover dispatches by data-context to plan / note / entity renderers", () => {
+		it("mouseover dispatches to every hover renderer with no data-context allowlist", () => {
 			const js = buildSidebarScript();
-			// Single selector + branch on ctx — three separate listeners would
-			// invite race conditions on the show / hide timers.
+			// Single selector + branch on the lookup result — separate listeners
+			// would invite race conditions on the show / hide timers.
 			expect(js).toContain("'.tree-node[data-id]'");
-			expect(js).toMatch(
-				/ctx\s*!==\s*'plan'\s*&&\s*ctx\s*!==\s*'note'\s*&&\s*ctx\s*!==\s*'reference'/,
-			);
 			expect(js).toContain("renderPlanHoverCard(rowId");
 			expect(js).toContain("renderNoteHoverCard(rowId");
 			expect(js).toContain("renderReferenceHoverCard(rowId");
+			expect(js).toContain("renderSkillsHoverCard(rowId");
+			// A ctx allowlist here would be a SECOND list of hover kinds beside the
+			// dispatch above, and it is the one that goes stale — it did, silently
+			// stranding the skills row. lookupBranchHoverById returning null is the
+			// only gate, so there is exactly one list to keep current.
+			expect(js).not.toMatch(/ctx\s*!==\s*'plan'/);
 		});
 
-		it("unified lookup reads planHover / noteHover / referenceHover off the matching serialized item", () => {
+		it("unified lookup reads every *Hover field off the matching serialized item", () => {
 			const js = buildSidebarScript();
 			expect(js).toContain("function lookupBranchHoverById");
 			expect(js).toContain("items[i].planHover");
 			expect(js).toContain("items[i].noteHover");
 			expect(js).toContain("items[i].referenceHover");
+			expect(js).toContain("items[i].skillsHover");
 		});
 
 		it("trash button (data-inline='remove') routes by row contextValue to the right command", () => {

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -3509,8 +3509,16 @@ export function buildSidebarScript(): string {
   tabContents.branch.addEventListener('mouseover', function(e) {
     const row = e.target.closest('.tree-node[data-id]');
     if (!row) return;
-    const ctx = row.getAttribute('data-context');
-    if (ctx !== 'plan' && ctx !== 'note' && ctx !== 'reference') return;
+    // No data-context allowlist here on purpose. One used to sit at this line
+    // naming plan/note/reference, which made it a SECOND list of hover kinds
+    // beside the dispatch below — and it was the one that went stale: the
+    // skills row (data-context 'skills') returned here before ever reaching
+    // its renderer, so renderSkillsHoverCard was unreachable and the tooltip
+    // was no fallback (the extension contributes only a webview view, never a
+    // createTreeView, so SerializedTreeItem.tooltip is inert for every kind).
+    // lookupBranchHoverById already answers "does this row have hover data",
+    // so it is the only list that needs maintaining.
+    //
     // Inline action buttons own their own visual feedback; dismiss the row
     // hover card to avoid stacking a popover on top of a button tooltip.
     if (e.target.closest('.inline-actions')) {
@@ -3535,8 +3543,10 @@ export function buildSidebarScript(): string {
   tabContents.branch.addEventListener('mouseout', function(e) {
     const row = e.target.closest('.tree-node[data-id]');
     if (!row) return;
-    const ctx = row.getAttribute('data-context');
-    if (ctx !== 'plan' && ctx !== 'note' && ctx !== 'reference') return;
+    // No ctx allowlist here either — it has to stay symmetric with the mouseover
+    // above or a kind that can OPEN a card cannot close it. Leaving a row that
+    // never had a card is a harmless no-op: the hide path is already a no-op on
+    // an element that is hidden.
     const to = e.relatedTarget;
     // Stay open if mouse moved onto the card itself or stayed on the row
     // (transitioning between child spans — label / desc / icon).


### PR DESCRIPTION
## Summary

Fixes the six defects found while reviewing #424 — each one a place where two lists that had to agree drifted apart — and raises 51 CLI files to 100% statement/branch/function/line coverage.

## Motivation

The six defects share a shape: a second, redundant copy of a decision that nobody updated when the first one changed. A stale `data-context` allowlist made the skills hover card unreachable; a letter-keyed color map collided once two sources stamped the same letter; three push-error classifiers disagreed about HTTP 401. None of them fail loudly — they degrade silently, which is why they survived until a review.

The coverage work is the other half of the same problem. Every gap closed here was a branch no test had ever taken, which is exactly where this class of drift hides.

## Changes

**Defect fixes**

- **Onboarding ledger writes into a disabled repo** ([`OnboardingFunnel.ts`](cli/src/core/OnboardingFunnel.ts)) — the ledger is a new repo-local file, not an append to the buffer the telemetry primitive owns, so the "telemetry recording is ungated" carve-out never covered it. The Disable command's own status refresh was writing into the repo it had just disabled. Gated on the in-memory `isManuallyDisabled()` mirror rather than the durable reader, which can itself persist a migration decision — a write, inside a zero-write gate.
- **Amend stranded its skill archive** ([`QueueWorker.ts`](cli/src/hooks/QueueWorker.ts)) — `consumeWorkspaceContext` had already guarded the registry rows and written the orphan bytes, but the fresh leaf spread only plans/notes/references. The rows came off the panel and nothing addressed the stored files.
- **Skills hover card was unreachable** ([`SidebarScriptBuilder.ts`](vscode/src/views/SidebarScriptBuilder.ts)) — a `data-context` allowlist on the mouseover handler was a second list of hover kinds beside the dispatch below it, and it was the one that went stale. Removed rather than extended: `lookupBranchHoverById` already answers "does this row have hover data". The tooltip was no fallback — the extension contributes only a webview view, so `SerializedTreeItem.tooltip` is inert for every kind.
- **Pinned reference badges painted the wrong color** ([`PinnedPanel.kt`](intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PinnedPanel.kt)) — colors were keyed on the letter tag, which is not a unique key: Jira and Jolli Memory both stamp "J", Zoom Doc and Zoom Meeting both stamp "Z", and "N"/"S" collide with the note/snippet letters the panel does own. Notion pins painted note-green, Slack pins snippet-amber, and the six letters added since the map was written fell through to gray. References now resolve through `SourceDisplay`, so a new source cannot desync this panel again.
- **MCP `status` could not explain a refused push** ([`McpTools.ts`](cli/src/mcp/McpTools.ts)) — added `pushDisabled` / `pushDisabledError`. Both halves or neither: a bare boolean reads as "you turned this repo off" even when the store was simply unreadable, which fails closed machine-wide.
- **401 classified three different ways** ([`PushRefusal.ts`](cli/src/core/PushRefusal.ts), [`JolliPushOrchestrator.kt`](intellij/src/main/kotlin/ai/jolli/jollimemory/services/JolliPushOrchestrator.kt)) — `NotAuthenticatedError` (CLI) / `UnauthorizedError` (IntelliJ) are the same server response. `CreatePrPanel.repoWideStopReason` already stopped the whole loop and reported "sign-in rejected", while the three attachment loops collected N separate `plan "X" failed` lines and fired N doomed requests on the way.

**Coverage — 51 files to 100%**

Session discovery and transcript readers (Antigravity, Cline, Cline CLI, Cursor CLI, Devin), the references DSL (envelope parsers, bindings, normalizers), the skills capture pipeline (scanners, attribution, store, archive), local-agent backends, and push-control. Mostly untaken defensive branches: malformed JSONL, absent optional fields, degraded host shapes.

A handful of gaps turned out to be unreachable rather than untested, and were removed rather than papered over — each with a comment recording the invariant the type system cannot express:

- `sort` comparators with an equal-case arm over a `Map` keyed on the sort field (`SkillStore`, `PushControlStore`).
- A `typeof === "string"` re-check on `JSON.parse` of a regex-captured JSON string literal (`SkillStore`).
- A second `lastRowId !== undefined` test at a return the first one already proved (`OpenCodeSkillScanner`).
- `bodyChars?: number` on a command entry that only exists because its body was measured — now a `CompletedCommandEntry` with the field required (`ClaudeSkillScanner`).

Four genuinely defensive guards were kept and marked `/* v8 ignore */` with the reason.

One test defect fixed along the way: `ClaudeSkillScanner.test.ts`'s "takes the plugin from attributionPlugin" asserted a value that actually came from the id-prefix fallback — `ATTRIBUTED_TURN` matches none of the scanner's pre-filter needles, so it never reaches `captureAttribution`. Split into two tests: one using a nested Skill call (which carries both the attribution fields and a `"name":"Skill"` needle) to exercise the real path, one pinning the prefix fallback.

## Testing

- [x] Added/updated unit tests — 51 files to 100%, verified against a full-suite coverage run, not per-file runs
- [x] CLI suite: 360 files / 9786 tests, **99.21% statements / 97.49% branches / 99.21% functions / 99.41% lines** (floor is 97/96/97/97)
- [x] VS Code suite: 109 files / 4511 tests
- [x] `npm run typecheck` and `npm run lint` clean
- [ ] `npm run all` green end-to-end in a single run — see below

Two runs of `npm run all` each hit a different real-`git` test timing out under full fan-out with coverage (`JolliMemoryBridge.integration.test.ts`, then `GitClient.test.ts` at 341s for the file). Both pass in isolation — 7/7 and 135/135, the latter in 48s — which is the load signal [`AGENTS.md`](AGENTS.md) describes rather than a regression, and neither file is touched by this PR. Worth a look at CI's result before merging.

`intellij/` is unchanged in its build; the two Kotlin edits are covered by `JolliPushOrchestratorTest` and a new `PinnedPanelBadgeColorTest`.

## Checklist

- [x] Code follows the existing style
- [ ] Documentation updated (README / CHANGELOG) if user-facing — the six fixes are all repairs to documented behavior, so no changelog entry
- [x] No new warnings from Plugin Verifier
