### PR TITLE
Recompute a memory's conversation usage from its owned transcripts

### DIFF
--- a/cli/src/core/ConversationUsageRecompute.test.ts
+++ b/cli/src/core/ConversationUsageRecompute.test.ts
@@ -1,0 +1,339 @@
+import { describe, expect, it } from "vitest";
+import type { CommitSummary, ModelTokenUsage } from "../Types.js";
+import { CURRENT_SCHEMA_VERSION } from "../Types.js";
+import { type RecomputeSession, recomputeConversationUsage } from "./ConversationUsageRecompute.js";
+import { PRICES_AS_OF } from "./Pricing.js";
+
+const node = (over: Partial<CommitSummary> = {}): CommitSummary => ({
+	version: CURRENT_SCHEMA_VERSION,
+	commitHash: "a".repeat(40),
+	commitMessage: "test commit",
+	commitAuthor: "Tester",
+	commitDate: "2026-07-29T00:00:00.000Z",
+	branch: "feature/x",
+	generatedAt: "2026-07-29T00:00:01.000Z",
+	topics: [],
+	...over,
+});
+
+const opus = (input: number, output: number, cached: number): ModelTokenUsage => ({
+	model: "claude-opus-5",
+	provider: "anthropic",
+	input,
+	output,
+	cached,
+});
+
+const evidence = (
+	entries: Record<string, ReadonlyArray<RecomputeSession>>,
+): Map<string, ReadonlyArray<RecomputeSession>> => new Map(Object.entries(entries));
+
+const opusCost = (input: number, output: number, cached: number): number =>
+	(input * 5 + output * 25 + cached * 6.25) / 1_000_000;
+
+describe("recomputeConversationUsage", () => {
+	it("derives a node's figures from the sessions in the transcripts it owns", () => {
+		// The stored figures are inflated (pre-dedup history); the transcripts are the
+		// evidence, so the derived total replaces them outright rather than adjusting them.
+		const summary = node({
+			transcripts: ["t1"],
+			conversationTokens: 5000,
+			conversationTokenBreakdown: { input: 1000, output: 2000, cached: 2000 },
+			conversationModels: [opus(1000, 2000, 2000)],
+			estimatedCostUsd: 99,
+			pricesAsOf: "2026-01-01",
+		});
+
+		const result = recomputeConversationUsage(
+			summary,
+			evidence({
+				t1: [
+					{ usage: { input: 10, output: 20, cached: 30 }, usageByModel: [opus(10, 20, 30)] },
+					{ usage: { input: 1, output: 2, cached: 3 }, usageByModel: [opus(1, 2, 3)] },
+				],
+			}),
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.skipped).toEqual([]);
+		expect(result.summary.conversationTokens).toBe(66);
+		expect(result.summary.conversationTokenBreakdown).toEqual({ input: 11, output: 22, cached: 33 });
+		expect(result.summary.conversationModels).toEqual([opus(11, 22, 33)]);
+		expect(result.summary.estimatedCostUsd).toBeCloseTo(opusCost(11, 22, 33), 12);
+		expect(result.summary.pricesAsOf).toBe(PRICES_AS_OF);
+	});
+
+	it("is idempotent: a second pass over already-derived figures changes nothing", () => {
+		const stored = node({
+			transcripts: ["t1"],
+			conversationTokens: 66,
+			conversationTokenBreakdown: { input: 11, output: 22, cached: 33 },
+			conversationModels: [opus(11, 22, 33)],
+			estimatedCostUsd: opusCost(11, 22, 33),
+			pricesAsOf: PRICES_AS_OF,
+		});
+		const files = evidence({
+			t1: [{ usage: { input: 11, output: 22, cached: 33 }, usageByModel: [opus(11, 22, 33)] }],
+		});
+
+		const result = recomputeConversationUsage(stored, files);
+
+		expect(result.changed).toBe(false);
+		expect(result.summary).toBe(stored);
+	});
+
+	it("strips the whole usage group when the owned transcripts hold no sessions any more", () => {
+		// Detach removed the last session, so the file is gone — the honest figure is
+		// "this memory reports no usage", not a stored zero (see the display contract).
+		const summary = node({
+			transcripts: ["t1"],
+			conversationTokens: 300,
+			conversationTokenBreakdown: { input: 100, output: 100, cached: 100 },
+			conversationModels: [opus(100, 100, 100)],
+			estimatedCostUsd: opusCost(100, 100, 100),
+			pricesAsOf: PRICES_AS_OF,
+		});
+
+		const result = recomputeConversationUsage(summary, evidence({ t1: [] }));
+
+		expect(result.changed).toBe(true);
+		expect(result.summary.conversationTokens).toBeUndefined();
+		expect(result.summary.conversationTokenBreakdown).toBeUndefined();
+		expect(result.summary.conversationModels).toBeUndefined();
+		expect(result.summary.estimatedCostUsd).toBeUndefined();
+		expect(result.summary.pricesAsOf).toBeUndefined();
+	});
+
+	it("skips a node when a session in an owned transcript carries no usage", () => {
+		// Forward-only. A pre-v5 file (or a source that reports no usage) would sum to
+		// less than the memory legitimately has, so deriving there destroys real data.
+		const summary = node({
+			transcripts: ["t1"],
+			conversationTokens: 1000,
+			conversationTokenBreakdown: { input: 100, output: 200, cached: 700 },
+		});
+
+		const result = recomputeConversationUsage(
+			summary,
+			evidence({ t1: [{ usage: { input: 1, output: 2, cached: 3 } }, {}] }),
+		);
+
+		expect(result.changed).toBe(false);
+		expect(result.summary).toBe(summary);
+		expect(result.skipped).toEqual(["t1"]);
+	});
+
+	it("skips a node when one of its owned transcripts is missing from the evidence", () => {
+		// Partial evidence is the dangerous case: summing only the readable file would
+		// silently under-report, which reads exactly like a settled figure.
+		const summary = node({
+			transcripts: ["t1", "t2"],
+			conversationTokens: 1000,
+			conversationTokenBreakdown: { input: 100, output: 200, cached: 700 },
+		});
+
+		const result = recomputeConversationUsage(
+			summary,
+			evidence({ t1: [{ usage: { input: 1, output: 2, cached: 3 }, usageByModel: [opus(1, 2, 3)] }] }),
+		);
+
+		expect(result.changed).toBe(false);
+		expect(result.summary).toBe(summary);
+		expect(result.skipped).toEqual(["t2"]);
+	});
+
+	it("recomputes the child that owns the id and leaves the indexing root alone", () => {
+		const child = node({
+			commitHash: "c".repeat(40),
+			transcripts: ["t-child"],
+			conversationTokens: 900,
+			conversationTokenBreakdown: { input: 300, output: 300, cached: 300 },
+		});
+		const root = node({
+			transcripts: ["t-child", "t-root"],
+			children: [child],
+			conversationTokens: 60,
+			conversationTokenBreakdown: { input: 20, output: 20, cached: 20 },
+		});
+
+		const result = recomputeConversationUsage(
+			root,
+			evidence({
+				"t-child": [{ usage: { input: 1, output: 2, cached: 3 }, usageByModel: [opus(1, 2, 3)] }],
+				"t-root": [{ usage: { input: 20, output: 20, cached: 20 }, usageByModel: [opus(20, 20, 20)] }],
+			}),
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.summary.children?.[0].conversationTokens).toBe(6);
+		// The root's own delta figures already matched its own transcript, so they stay.
+		expect(result.summary.conversationTokens).toBe(60);
+	});
+
+	it("attributes a v5-migrated tree's ids to the child that counted them", () => {
+		// upgradeOneSummary indexes every descendant hash at the ROOT and leaves the
+		// child without a `transcripts` field. Deriving at the root would move the
+		// child's tokens up while the child kept its own — double-counted on every
+		// surface that aggregates the tree.
+		const childHash = "c".repeat(40);
+		const child = node({
+			commitHash: childHash,
+			conversationTokens: 900,
+			conversationTokenBreakdown: { input: 300, output: 300, cached: 300 },
+		});
+		const root = node({ transcripts: [childHash], children: [child] });
+
+		const result = recomputeConversationUsage(
+			root,
+			evidence({ [childHash]: [{ usage: { input: 1, output: 2, cached: 3 }, usageByModel: [opus(1, 2, 3)] }] }),
+		);
+
+		expect(result.summary.children?.[0].conversationTokens).toBe(6);
+		expect(result.summary.conversationTokens).toBeUndefined();
+	});
+
+	it("reports an id with ambiguous ownership and changes nothing", () => {
+		const left = node({ commitHash: "1".repeat(40), transcripts: ["t1"], conversationTokens: 10 });
+		const right = node({ commitHash: "2".repeat(40), transcripts: ["t1"], conversationTokens: 10 });
+		const root = node({ transcripts: ["t1"], children: [left, right] });
+
+		const result = recomputeConversationUsage(
+			root,
+			evidence({ t1: [{ usage: { input: 1, output: 1, cached: 1 }, usageByModel: [opus(1, 1, 1)] }] }),
+		);
+
+		expect(result.changed).toBe(false);
+		expect(result.summary).toBe(root);
+		expect(result.skipped).toEqual(["t1"]);
+	});
+
+	it("keeps a partial per-model split, matching what the write path stores", () => {
+		// Only one of the two sessions reported models. `conversationUsageFields` (the
+		// write path) stores that partial split and prices it; deriving must agree, or
+		// the first press of the recompute button would DELETE a cost the write path had
+		// legitimately stored. The under-statement is a property of the evidence, not of
+		// this function.
+		const summary = node({ transcripts: ["t1"] });
+
+		const result = recomputeConversationUsage(
+			summary,
+			evidence({
+				t1: [
+					{ usage: { input: 10, output: 10, cached: 10 }, usageByModel: [opus(10, 10, 10)] },
+					{ usage: { input: 5, output: 5, cached: 5 } },
+				],
+			}),
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.summary.conversationTokens).toBe(45);
+		expect(result.summary.conversationTokenBreakdown).toEqual({ input: 15, output: 15, cached: 15 });
+		expect(result.summary.conversationModels).toEqual([opus(10, 10, 10)]);
+		expect(result.summary.estimatedCostUsd).toBeCloseTo(opusCost(10, 10, 10), 12);
+	});
+
+	it("is idempotent on a node whose stored figures carry a partial per-model split", () => {
+		// The regression the case above protects: a healthy mixed-source memory must not
+		// be rewritten (and must not lose its cost) just because one session reported no
+		// model.
+		const stored = node({
+			transcripts: ["t1"],
+			conversationTokens: 45,
+			conversationTokenBreakdown: { input: 15, output: 15, cached: 15 },
+			conversationModels: [opus(10, 10, 10)],
+			estimatedCostUsd: opusCost(10, 10, 10),
+			pricesAsOf: PRICES_AS_OF,
+		});
+
+		const result = recomputeConversationUsage(
+			stored,
+			evidence({
+				t1: [
+					{ usage: { input: 10, output: 10, cached: 10 }, usageByModel: [opus(10, 10, 10)] },
+					{ usage: { input: 5, output: 5, cached: 5 } },
+				],
+			}),
+		);
+
+		expect(result.changed).toBe(false);
+		expect(result.summary).toBe(stored);
+	});
+
+	it("treats a stored breakdown with a different key order as unchanged", () => {
+		// A stored breakdown is JSON parsed off disk, so its key order is the writer's.
+		// Comparing the objects whole would rewrite the node on every pass — one
+		// orphan-branch write per button press, against an idempotence contract.
+		const reordered = { cached: 33, output: 22, input: 11 };
+		const stored = node({
+			transcripts: ["t1"],
+			conversationTokens: 66,
+			conversationTokenBreakdown: reordered,
+			conversationModels: [opus(11, 22, 33)],
+			estimatedCostUsd: opusCost(11, 22, 33),
+			pricesAsOf: PRICES_AS_OF,
+		});
+
+		const result = recomputeConversationUsage(
+			stored,
+			evidence({ t1: [{ usage: { input: 11, output: 22, cached: 33 }, usageByModel: [opus(11, 22, 33)] }] }),
+		);
+
+		expect(result.changed).toBe(false);
+		expect(result.summary).toBe(stored);
+	});
+
+	it("derives a child that only the child itself lists, with no entry in the root index", () => {
+		// The malformed-index shape the panel's evidence gathering must cover: the root's
+		// authoritative array is empty while a child still claims its transcript. The
+		// interest set walks every node, so the child is attributed and derived.
+		const child = node({
+			commitHash: "b".repeat(40),
+			transcripts: ["t1"],
+			conversationTokens: 5000,
+			conversationTokenBreakdown: { input: 2000, output: 2000, cached: 1000 },
+		});
+		const root = node({ transcripts: [], children: [child] });
+
+		const result = recomputeConversationUsage(
+			root,
+			evidence({ t1: [{ usage: { input: 1, output: 2, cached: 3 }, usageByModel: [opus(1, 2, 3)] }] }),
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.summary.conversationTokens).toBeUndefined();
+		expect(result.summary.children?.[0].conversationTokens).toBe(6);
+		expect(result.skipped).toEqual([]);
+	});
+
+	it("merges per-model usage across sessions and files owned by the same node", () => {
+		const sonnet: ModelTokenUsage = {
+			model: "claude-sonnet-5",
+			provider: "anthropic",
+			input: 4,
+			output: 8,
+			cached: 0,
+		};
+		const summary = node({ transcripts: ["t1", "t2"] });
+
+		const result = recomputeConversationUsage(
+			summary,
+			evidence({
+				t1: [{ usage: { input: 10, output: 20, cached: 30 }, usageByModel: [opus(10, 20, 30)] }],
+				t2: [{ usage: { input: 14, output: 28, cached: 30 }, usageByModel: [opus(10, 20, 30), sonnet] }],
+			}),
+		);
+
+		expect(result.summary.conversationModels).toEqual([opus(20, 40, 60), sonnet]);
+		expect(result.summary.conversationTokens).toBe(132);
+	});
+
+	it("leaves a node with no owned transcript untouched", () => {
+		const summary = node({ transcripts: [], conversationTokens: 42 });
+
+		const result = recomputeConversationUsage(summary, new Map());
+
+		expect(result.changed).toBe(false);
+		expect(result.summary).toBe(summary);
+		expect(result.skipped).toEqual([]);
+	});
+});

--- a/cli/src/core/ConversationUsageRecompute.ts
+++ b/cli/src/core/ConversationUsageRecompute.ts
@@ -1,0 +1,299 @@
+/**
+ * ConversationUsageRecompute
+ *
+ * DERIVES a committed memory's conversation token / cost figures from the sessions
+ * still stored in the transcripts each node owns, rather than adjusting them by a
+ * delta. Rewrites `conversationTokens`, `conversationTokenBreakdown`,
+ * `conversationModels`, `estimatedCostUsd` and `pricesAsOf` per node.
+ *
+ * Why a derivation exists alongside {@link subtractDetachedUsage}'s subtraction:
+ *
+ *  - **Detach's failure window is otherwise unrecoverable.** Detach writes the
+ *    transcript files first and the summary second (the reverse ordering is worse —
+ *    see `handleConversationDetach`). If the summary write fails, the sessions are
+ *    already gone from the files and the subtrahend was only readable while they
+ *    were still in them: a retry finds nothing to remove, so the figures stay
+ *    permanently high by the detached conversation's share. A derivation needs no
+ *    subtrahend — it reads whatever is left — so it can run after the fact.
+ *  - **A stored aggregate can disagree with the stored per-session split.**
+ *    Subtraction can only nudge the aggregate by a delta; a derivation replaces it
+ *    with the sum of what the transcripts actually record, so any drift between the
+ *    two is resolved in favour of the per-session evidence.
+ *
+ * What it deliberately does NOT repair: the pre-dedup inflated history (memories
+ * whose aggregate counted one response once per transcript line, median 2.13× across
+ * the corpus). `StoredSession.usage` and the per-`message.id` de-duplication landed in
+ * the SAME change, so a transcript that carries per-session usage was written by a
+ * de-duplicating reader by construction, and every inflated memory predates the field
+ * entirely — its sessions carry no `usage`, so the forward-only gate below skips the
+ * node and the inflated figure is preserved rather than corrected. Repairing that
+ * corpus needs per-session `usage` backfilled onto those legacy transcripts first;
+ * this module then derives from it like any other evidence.
+ *
+ * Being a derivation, it is IDEMPOTENT: running it on already-correct figures
+ * returns the same tree by reference. That is what lets one routine serve both the
+ * post-failure self-heal and a one-off backfill.
+ *
+ * Attribution is per NODE and resolved structurally by
+ * {@link resolveTranscriptOwnership} — a consolidated root's `transcripts` array is
+ * a tree-wide index, not an ownership record, and the tree aggregation in
+ * `SummaryTree.ts` walks root AND children, so summing a child's sessions into the
+ * root would double-count them on every surface.
+ *
+ * **Forward-only, and conservative about evidence.** A node is left EXACTLY as-is
+ * whenever the evidence for it is anything less than complete:
+ *   - a session in an owned transcript carries no `usage` (a pre-v5 file, or a
+ *     source that reports none) — the sum would be short, so deriving would destroy
+ *     usage the memory legitimately has;
+ *   - an owned id is missing from the supplied evidence (unreadable file, caller
+ *     didn't read it) — summing the rest silently under-reports;
+ *   - the id has no single owner (nothing claims it, or sibling claimants do).
+ * Those ids are reported in `skipped` so callers can surface them. A stale figure
+ * with a trace beats an invented one that reads as settled truth.
+ *
+ * CALLER CONTRACT: `sessionsByTranscriptId` must be COMPLETE for the tree — one
+ * entry per transcript id the caller resolved, with an EMPTY array for an id whose
+ * file is known to be absent (e.g. detach deleted a transcript that became empty).
+ * Never map an id you failed to read to `[]`: that is indistinguishable from "the
+ * file is gone" and would strip usage the memory still has. Leave it out instead
+ * and its owner is skipped.
+ *
+ * "Complete for the tree" means the ids from {@link resolveTranscriptIdsForUsage},
+ * NOT `getTranscriptIds`: attribution is per node, so a caller that only reads the
+ * root's index leaves every child-listed id unread, and this module then skips
+ * exactly the child that needed repairing.
+ *
+ * Skill figures (`SkillCommitRef.usageBySession`) are deliberately NOT touched
+ * here. Their per-session split is an explicit map, so correcting one is a key
+ * deletion that `subtractDetachedUsage` already applies idempotently at every node;
+ * re-deriving it would mean pruning keys not seen in the transcript files, which is
+ * only safe when the evidence covers the WHOLE tree — an amend hoists a child's
+ * skills onto the root, so a key legitimately absent from the root's own files
+ * would look detached.
+ */
+
+import type { CommitSummary, ConversationTokenBreakdown, ModelTokenUsage } from "../Types.js";
+import { estimateCostUsd, PRICES_AS_OF } from "./Pricing.js";
+import { collectListedTranscriptIds } from "./SummaryTree.js";
+import { resolveTranscriptOwnership } from "./TranscriptOwnership.js";
+
+/** One stored session's recorded usage, as read back off a stored transcript. */
+export interface RecomputeSession {
+	readonly usage?: ConversationTokenBreakdown;
+	readonly usageByModel?: ReadonlyArray<ModelTokenUsage>;
+}
+
+/** A session that passed the forward-only gate, so its `usage` is known present. */
+interface AttributedSession extends RecomputeSession {
+	readonly usage: ConversationTokenBreakdown;
+}
+
+export interface ConversationUsageRecomputeResult {
+	/** The summary with derived figures. Same reference when nothing changed. */
+	readonly summary: CommitSummary;
+	/** True when at least one node's figures were rewritten. */
+	readonly changed: boolean;
+	/**
+	 * Transcript ids whose owning node could not be derived — unattributable, or
+	 * backed by evidence that was incomplete (see the module header). The figures
+	 * for those nodes are untouched; callers should surface this rather than let a
+	 * stale bar read as a settled measurement.
+	 */
+	readonly skipped: ReadonlyArray<string>;
+}
+
+/** The five usage fields this module owns, as a spreadable group. */
+type UsageFields = Partial<
+	Pick<
+		CommitSummary,
+		"conversationTokens" | "conversationTokenBreakdown" | "conversationModels" | "estimatedCostUsd" | "pricesAsOf"
+	>
+>;
+
+/**
+ * Sums one node's owned sessions into the usage fields it should carry.
+ *
+ * The per-model split is emitted whenever ANY session reported models, which is
+ * exactly what `conversationUsageFields` does at write time (QueueWorker): both
+ * sum the buckets that exist and price those. Matching it is what makes this
+ * function idempotent on a healthy memory — gating the split on EVERY session
+ * having reported models would delete a legitimately partial `conversationModels` /
+ * `estimatedCostUsd` the write path had stored, on the first press of the recompute
+ * button. A partial split does mean the cost covers only the sessions that reported
+ * a model; that under-statement is a property of the stored evidence, identical on
+ * both paths, and the meter labels the figure as an estimate.
+ *
+ * Cost is always re-derived from the models (never scaled from the previous figure),
+ * so an unpriced model yields tokens with no cost.
+ */
+function deriveUsageFields(sessions: ReadonlyArray<AttributedSession>): UsageFields {
+	let input = 0;
+	let output = 0;
+	let cached = 0;
+	const byModel = new Map<string, ModelTokenUsage>();
+	for (const session of sessions) {
+		input += session.usage.input;
+		output += session.usage.output;
+		cached += session.usage.cached;
+		for (const m of session.usageByModel ?? []) {
+			const prev = byModel.get(m.model);
+			byModel.set(
+				m.model,
+				prev
+					? {
+							...prev,
+							input: prev.input + m.input,
+							output: prev.output + m.output,
+							cached: prev.cached + m.cached,
+						}
+					: { ...m },
+			);
+		}
+	}
+
+	const total = input + output + cached;
+	// Strip the whole group rather than store zeros: the display contract is
+	// "absent means this memory reports no usage", and a stored 0 renders as a real
+	// measurement of nothing (see conversationUsageFields in QueueWorker).
+	if (total === 0) return {};
+
+	const models = [...byModel.values()];
+	const { totalUsd } = models.length > 0 ? estimateCostUsd(models) : { totalUsd: 0 };
+	return {
+		conversationTokens: total,
+		conversationTokenBreakdown: { input, output, cached },
+		...(models.length > 0 && { conversationModels: models }),
+		...(totalUsd > 0 && { estimatedCostUsd: totalUsd, pricesAsOf: PRICES_AS_OF }),
+	};
+}
+
+/**
+ * The forward-only gate: true when EVERY session carries a recorded `usage`. A type
+ * guard so the summing pass below is statically bound to gated input — one missing
+ * `usage` makes the whole node unusable, never a partial sum.
+ */
+function hasCompleteUsage(sessions: ReadonlyArray<RecomputeSession>): sessions is ReadonlyArray<AttributedSession> {
+	return sessions.every((s) => s.usage !== undefined);
+}
+
+/**
+ * Canonical form of the five usage fields, so "did this change" is decided on the
+ * VALUES rather than on object identity or per-model ordering (which follows the
+ * order sessions were read in, not anything meaningful).
+ */
+function usageFingerprint(fields: UsageFields): string {
+	const models = [...(fields.conversationModels ?? [])]
+		// Byte-order sort: `localeCompare` would reorder under a non-English locale
+		// and turn an unchanged node into a rewrite (see the generated-artifact rule).
+		.sort((a, b) => (a.model < b.model ? -1 : a.model > b.model ? 1 : 0))
+		.map((m) => [m.model, m.provider, m.input, m.output, m.cached]);
+	// Every object is projected to a positional tuple before serializing — never
+	// stringified whole. A stored breakdown is JSON parsed off disk, so its KEY ORDER
+	// is whatever the writer used; `JSON.stringify(breakdown)` would then differ from
+	// the derived `{input, output, cached}` on values that are equal, and the node
+	// would be rewritten on every pass (an orphan-branch write per button press,
+	// against a module whose contract is idempotence).
+	const breakdown = fields.conversationTokenBreakdown;
+	return JSON.stringify([
+		fields.conversationTokens ?? null,
+		breakdown ? [breakdown.input, breakdown.output, breakdown.cached] : null,
+		models,
+		fields.estimatedCostUsd ?? null,
+		fields.pricesAsOf ?? null,
+	]);
+}
+
+/** Replaces a node's usage group with `fields`, or returns it unchanged. */
+function applyUsageFields(node: CommitSummary, fields: UsageFields): CommitSummary {
+	const current: UsageFields = {
+		...(node.conversationTokens !== undefined && { conversationTokens: node.conversationTokens }),
+		...(node.conversationTokenBreakdown !== undefined && {
+			conversationTokenBreakdown: node.conversationTokenBreakdown,
+		}),
+		...(node.conversationModels !== undefined && { conversationModels: node.conversationModels }),
+		...(node.estimatedCostUsd !== undefined && { estimatedCostUsd: node.estimatedCostUsd }),
+		...(node.pricesAsOf !== undefined && { pricesAsOf: node.pricesAsOf }),
+	};
+	if (usageFingerprint(current) === usageFingerprint(fields)) return node;
+
+	// Strip first, then re-add: a node that keeps e.g. `estimatedCostUsd` while the
+	// derived figures carry none would otherwise hold a cost belonging to sessions
+	// that are no longer there.
+	const {
+		conversationTokens: _t,
+		conversationTokenBreakdown: _b,
+		conversationModels: _m,
+		estimatedCostUsd: _c,
+		pricesAsOf: _p,
+		...withoutUsage
+	} = node;
+	return { ...withoutUsage, ...fields };
+}
+
+/**
+ * Derives every node's conversation usage from the transcripts it owns.
+ *
+ * @param summary - The memory tree to correct (never mutated).
+ * @param sessionsByTranscriptId - The evidence: transcript id → the sessions that
+ *   file currently holds, with `[]` for an id whose file is known to be absent.
+ *   Must be complete for the tree — see the CALLER CONTRACT in the module header.
+ */
+export function recomputeConversationUsage(
+	summary: CommitSummary,
+	sessionsByTranscriptId: ReadonlyMap<string, ReadonlyArray<RecomputeSession>>,
+): ConversationUsageRecomputeResult {
+	// Interest spans the ids the tree LISTS as well as the ids the caller read: a
+	// listed id missing from the evidence must still resolve to an owner, because
+	// that owner is exactly the node whose figures cannot be derived.
+	const interest = new Set<string>(sessionsByTranscriptId.keys());
+	for (const id of collectListedTranscriptIds(summary)) interest.add(id);
+	if (interest.size === 0) return { summary, changed: false, skipped: [] };
+
+	const { ownerById, unresolved } = resolveTranscriptOwnership(summary, interest);
+	const skipped = new Set<string>(unresolved);
+
+	// Group the owned ids per node, keyed by node identity — `walk` below sees the
+	// very objects the resolver recorded, since it reads children off the input tree.
+	const idsByOwner = new Map<CommitSummary, string[]>();
+	for (const [id, owner] of ownerById) {
+		const bucket = idsByOwner.get(owner);
+		if (bucket) bucket.push(id);
+		else idsByOwner.set(owner, [id]);
+	}
+
+	// Decide per node before rewriting anything, so a node with one unusable id is
+	// skipped whole rather than derived from its readable ids alone.
+	const fieldsByOwner = new Map<CommitSummary, UsageFields>();
+	for (const [owner, ids] of idsByOwner) {
+		const sessions: AttributedSession[] = [];
+		let usable = true;
+		for (const id of ids) {
+			const stored = sessionsByTranscriptId.get(id);
+			if (stored === undefined || !hasCompleteUsage(stored)) {
+				usable = false;
+				skipped.add(id);
+				continue;
+			}
+			sessions.push(...stored);
+		}
+		if (!usable) continue;
+		fieldsByOwner.set(owner, deriveUsageFields(sessions));
+	}
+
+	let changed = false;
+	const walk = (node: CommitSummary): CommitSummary => {
+		const fields = fieldsByOwner.get(node);
+		const withOwn = fields !== undefined ? applyUsageFields(node, fields) : node;
+		if (withOwn !== node) changed = true;
+
+		const children = node.children;
+		if (!children || children.length === 0) return withOwn;
+		const nextChildren = children.map(walk);
+		// Rebuild the children array only when a descendant actually changed, so an
+		// untouched subtree keeps its identity and callers can compare by reference.
+		return nextChildren.some((c, i) => c !== children[i]) ? { ...withOwn, children: nextChildren } : withOwn;
+	};
+
+	const next = fieldsByOwner.size > 0 ? walk(summary) : summary;
+	return { summary: next, changed, skipped: [...skipped] };
+}

--- a/cli/src/core/DetachedUsageSubtraction.test.ts
+++ b/cli/src/core/DetachedUsageSubtraction.test.ts
@@ -223,6 +223,31 @@ describe("subtractDetachedUsage", () => {
 		expect(result.summary.children?.[0].children?.[0].conversationTokens).toBe(260);
 	});
 
+	it("subtracts at the child a v5-migrated root merely indexes", () => {
+		// `SchemaV5Migration.upgradeOneSummary` lists every descendant commit hash on the
+		// ROOT and leaves the children without a `transcripts` field, so the root is the
+		// sole claimant of an id whose sessions a child's token fields cover. Attributing
+		// by claim alone would apply the subtraction to a root that carries no usage —
+		// silently dropping the correction while reporting nothing.
+		const childHash = "c".repeat(40);
+		const child = node({
+			commitHash: childHash,
+			conversationTokens: 1000,
+			conversationTokenBreakdown: { input: 400, output: 300, cached: 300 },
+		});
+		const summary = node({ transcripts: [childHash], children: [child] });
+
+		const result = subtractDetachedUsage(
+			summary,
+			removed(childHash, [{ usage: { input: 400, output: 0, cached: 0 } }]),
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.unattributed).toEqual([]);
+		expect(result.summary.children?.[0].conversationTokens).toBe(600);
+		expect(result.summary.conversationTokens).toBeUndefined();
+	});
+
 	it("reports an id two siblings both claim rather than subtracting it from both", () => {
 		// Ambiguous ownership: `mergeManyToOne` dedups ids at the squash root but cannot
 		// stop two source commits from carrying the same id (its own comment allows for

--- a/cli/src/core/DetachedUsageSubtraction.ts
+++ b/cli/src/core/DetachedUsageSubtraction.ts
@@ -16,36 +16,24 @@
  * each carry their own token fields, so a session detached from a child must be
  * subtracted from that child — subtracting at the root would corrupt a node that
  * never carried those tokens while leaving the one that did untouched (and the
- * tree aggregation in `SummaryTree.ts` walks both).
+ * tree aggregation in `SummaryTree.ts` walks both). Which node owns an id is NOT
+ * readable off `summary.transcripts` (on a consolidated root that array is a
+ * tree-wide index, not an ownership record); it is resolved structurally by
+ * {@link resolveTranscriptOwnership}, whose header carries the full rationale and
+ * the v5-migration case. Each id is subtracted exactly once, at its owner.
  *
- * `summary.transcripts` is NOT that per-node ownership record, which is why
- * ownership is resolved by {@link resolveOwners} rather than read off the field.
- * The array means two different things depending on where it sits:
- *   - on a leaf — the ids whose sessions this node's token fields cover;
- *   - on a consolidated root — the tree-wide authoritative INDEX. Amend
- *     (`QueueWorker`'s `amendTranscripts` = inherited ∪ delta), rebase-pick
- *     (`migrateOneToOne`) and squash (`mergeManyToOne`, union over children) all
- *     re-list every descendant id at the root so `getTranscriptIds` finds every
- *     file — while the root's token fields cover its DELTA only (amend/pick), or
- *     nothing at all (squash).
- * A node therefore OWNS an id only when no descendant claims it, and each id must
- * be subtracted exactly once, at that owner.
+ * Deliberately forward-only. A removed session with no stored `usage` (written
+ * before the field existed, or a source that reports no usage) and an id with no
+ * single owner are both reported as unattributable and left EXACTLY as-is.
+ * Guessing a subtrahend — splitting the aggregate evenly, zeroing the node, or
+ * subtracting from every node that lists the id — would replace a known-stale
+ * number with an invented one.
  *
- * Deliberately forward-only. A node with no `transcripts` array (pre-v5), a
- * removed session with no stored `usage` (written before the field existed, or a
- * source that reports no usage), and an id with no single owner are all reported
- * as unattributable and left EXACTLY as-is. Guessing a subtrahend — splitting the
- * aggregate evenly, zeroing the node, or subtracting from every node that lists
- * the id — would replace a known-stale number with an invented one.
- *
- * One case ownership resolution deliberately does NOT special-case: a v5-MIGRATED
- * legacy tree, where `upgradeOneSummary` puts every descendant commit hash on the
- * root's `transcripts` and leaves the children without the field at all — so the
- * root is the sole claimant of an id whose sessions a child counted. Nothing is
- * mis-subtracted in practice because those transcript files predate
- * `StoredSession.usage` (migration rewrites the schema, not transcript content), so
- * every session there is unattributable and the subtrahend is zero. If a path ever
- * backfills `usage` onto legacy transcripts, attribute by `commitHash` here first.
+ * A subtraction is a one-shot correction: it can only run while the detached
+ * sessions are still readable, and it cannot repair an aggregate that was already
+ * wrong (pre-dedup inflation). {@link recomputeConversationUsage} derives the same
+ * figures from the surviving transcripts instead, and is what heals a memory whose
+ * detach write failed after the files had already changed.
  */
 
 import type {
@@ -56,6 +44,7 @@ import type {
 	SkillUsage,
 } from "../Types.js";
 import { estimateCostUsd, PRICES_AS_OF } from "./Pricing.js";
+import { resolveTranscriptOwnership } from "./TranscriptOwnership.js";
 
 /** One detached session's persisted attribution, as read back off the stored transcript. */
 export interface DetachedSessionUsage {
@@ -88,39 +77,6 @@ export interface DetachedUsageSubtractionResult {
 	 * partial case corrects part of the total and reports the rest.
 	 */
 	readonly unattributed: ReadonlyArray<string>;
-}
-
-/**
- * Finds, for each id of interest, the node(s) that OWN it — list it and have no
- * descendant that lists it. See the header on why the field alone can't say this.
- *
- * Post-order so a node only becomes an owner once its whole subtree has had the
- * chance to claim the id. The returned set is what the caller's subtree claimed,
- * restricted to `interest` so an unrelated tree-wide index costs nothing to walk.
- *
- * Sibling claimants both land in the list (neither is the other's descendant, so
- * there is no deepest one); the caller treats that ambiguity as unattributable
- * rather than subtracting twice.
- */
-function resolveOwners(
-	node: CommitSummary,
-	interest: ReadonlySet<string>,
-	owners: Map<string, CommitSummary[]>,
-): Set<string> {
-	const claimedBelow = new Set<string>();
-	for (const child of node.children ?? []) {
-		for (const id of resolveOwners(child, interest, owners)) claimedBelow.add(id);
-	}
-	const claimed = new Set(claimedBelow);
-	for (const id of node.transcripts ?? []) {
-		if (!interest.has(id)) continue;
-		claimed.add(id);
-		if (claimedBelow.has(id)) continue;
-		const existing = owners.get(id);
-		if (existing) existing.push(node);
-		else owners.set(id, [node]);
-	}
-	return claimed;
 }
 
 /**
@@ -258,7 +214,7 @@ function subtractFromNode(node: CommitSummary, removed: ReadonlyArray<DetachedSe
  * how the aggregate figures are handled, and for a structural reason rather than
  * convenience. `conversationTokens` is a scalar sum with no record of who
  * contributed what, so subtracting it at two nodes would remove the same tokens
- * twice; that is what {@link resolveOwners} exists to prevent. A skill's
+ * twice; that is what {@link resolveTranscriptOwnership} exists to prevent. A skill's
  * `usageBySession` is an explicit map, so correcting it is a key DELETION —
  * idempotent, and impossible to over-apply.
  *
@@ -321,8 +277,9 @@ function subtractSkillUsage(node: CommitSummary, detachedKeys: ReadonlySet<strin
 
 /**
  * Applies `removedByTranscriptId` across the summary tree, subtracting each id's
- * share exactly once — at the single node that OWNS it (see {@link resolveOwners}
- * and the module header on why a node listing an id doesn't mean it owns it).
+ * share exactly once — at the single node that OWNS it (see
+ * {@link resolveTranscriptOwnership} and the module header on why a node listing an
+ * id doesn't mean it owns it).
  *
  * @param removedByTranscriptId - Detached sessions keyed by the id of the stored
  *   transcript they were removed from (the same id space as
@@ -342,8 +299,10 @@ export function subtractDetachedUsage(
 	// Two passes rather than one because a node cannot tell whether it owns an id
 	// until its descendants have been inspected, and a consolidated root is visited
 	// first.
-	const owners = new Map<string, CommitSummary[]>();
-	resolveOwners(summary, new Set(removedByTranscriptId.keys()), owners);
+	const { ownerById, unresolved: unownedIds } = resolveTranscriptOwnership(
+		summary,
+		new Set(removedByTranscriptId.keys()),
+	);
 
 	// Skill correction is keyed on session identity, not on transcript ownership, so
 	// it is collected across the whole removal map at once. See subtractSkillUsage
@@ -355,22 +314,20 @@ export function subtractDetachedUsage(
 		}
 	}
 
-	// Keyed by node identity — `walk` below receives the very objects `resolveOwners`
-	// recorded, since it reads children off the untouched input tree.
+	// Keyed by node identity — `walk` below receives the very objects the ownership
+	// resolver recorded, since it reads children off the untouched input tree.
 	const byOwner = new Map<CommitSummary, DetachedSessionUsage[]>();
+	// No owner: either the summary and the transcript files disagree about what
+	// belongs to this memory, or ownership is ambiguous (sibling claimants). Neither
+	// is guessable, so report and correct nothing — see `resolveTranscriptOwnership`.
+	for (const id of unownedIds) unattributed.add(id);
 	for (const [id, sessions] of removedByTranscriptId) {
-		const claimants = owners.get(id) ?? [];
-		// Zero claimants: the summary and the transcript files disagree about what
-		// belongs to this memory. More than one: ambiguous ownership (see
-		// `resolveOwners`). Neither is guessable, so report and correct nothing.
-		if (claimants.length !== 1) {
-			unattributed.add(id);
-			continue;
-		}
+		const owner = ownerById.get(id);
+		if (owner === undefined) continue;
 		if (!sumRemoved(sessions).fullyAttributable) unattributed.add(id);
-		const bucket = byOwner.get(claimants[0]);
+		const bucket = byOwner.get(owner);
 		if (bucket) bucket.push(...sessions);
-		else byOwner.set(claimants[0], [...sessions]);
+		else byOwner.set(owner, [...sessions]);
 	}
 
 	const walk = (node: CommitSummary): CommitSummary => {

--- a/cli/src/core/Regenerator.test.ts
+++ b/cli/src/core/Regenerator.test.ts
@@ -125,6 +125,63 @@ describe("regenerateSummary", () => {
 		);
 	});
 
+	it("re-derives conversation usage from the stored transcripts rather than carrying the stored figures", async () => {
+		// Pre-dedup memories are inflated (one response counted once per transcript
+		// line). Regenerate already rebuilds every other field from the archive, so
+		// carrying the aggregate over verbatim left the token bar permanently wrong
+		// with no way for the user to fix it.
+		const inflated: CommitSummary = {
+			...baseSummary,
+			conversationTokens: 5000,
+			conversationTokenBreakdown: { input: 1000, output: 2000, cached: 2000 },
+		};
+		vi.mocked(SummaryStore.readTranscriptsForCommits).mockResolvedValue(
+			new Map([
+				[
+					baseSummary.commitHash,
+					{
+						sessions: [
+							{
+								...storedTranscript.sessions[0],
+								usage: { input: 10, output: 20, cached: 30 },
+								usageByModel: [
+									{
+										model: "claude-opus-5",
+										provider: "anthropic" as const,
+										input: 10,
+										output: 20,
+										cached: 30,
+									},
+								],
+							},
+						],
+					},
+				],
+			]),
+		);
+
+		const { updated } = await regenerateSummary(inflated, "/repo", config);
+
+		expect(updated.conversationTokens).toBe(60);
+		expect(updated.conversationTokenBreakdown).toEqual({ input: 10, output: 20, cached: 30 });
+		expect(updated.estimatedCostUsd).toBeGreaterThan(0);
+	});
+
+	it("keeps the stored figures when a stored session reports no usage", async () => {
+		// Forward-only: a transcript written before per-session usage existed cannot be
+		// summed, and deriving from it would zero out usage the memory legitimately has.
+		const legacy: CommitSummary = {
+			...baseSummary,
+			conversationTokens: 5000,
+			conversationTokenBreakdown: { input: 1000, output: 2000, cached: 2000 },
+		};
+
+		const { updated } = await regenerateSummary(legacy, "/repo", config);
+
+		expect(updated.conversationTokens).toBe(5000);
+		expect(updated.conversationTokenBreakdown).toEqual({ input: 1000, output: 2000, cached: 2000 });
+	});
+
 	it("clears summaryError marker on successful regenerate", async () => {
 		const stale: CommitSummary = {
 			...baseSummary,

--- a/cli/src/core/Regenerator.ts
+++ b/cli/src/core/Regenerator.ts
@@ -1,5 +1,6 @@
 import { createLogger } from "../Logger.js";
 import type { CommitSummary, LlmConfig, Reference, ReferenceCommitRef } from "../Types.js";
+import { type RecomputeSession, recomputeConversationUsage } from "./ConversationUsageRecompute.js";
 import { getDiffContent } from "./GitOps.js";
 import { escapeForAttr, escapeForText } from "./PromptXmlEscape.js";
 import { truncate } from "./references/ReferenceExtractor.js";
@@ -15,7 +16,7 @@ import {
 	readReferenceFromBranch,
 	readTranscriptsForCommits,
 } from "./SummaryStore.js";
-import { getTranscriptIds } from "./SummaryTree.js";
+import { resolveTranscriptIdsForUsage } from "./SummaryTree.js";
 import { buildMultiSessionContext, type SessionTranscript } from "./TranscriptReader.js";
 
 const log = createLogger("Regenerator");
@@ -36,7 +37,13 @@ export interface RegenerateResult {
  * that callers pass to `storeSummary(_, _, true)` (force=true).
  *
  * Fields replaced:        topics, recap, diffStats, transcriptEntries,
- *                         conversationTurns, llm, generatedAt
+ *                         conversationTurns, llm, generatedAt, and — where the
+ *                         stored transcripts carry enough evidence to derive them —
+ *                         the conversation usage group (conversationTokens,
+ *                         conversationTokenBreakdown, conversationModels,
+ *                         estimatedCostUsd, pricesAsOf). See
+ *                         `recomputeConversationUsage`; without complete evidence
+ *                         the stored figures are preserved.
  * Fields preserved:       ticketId, e2eTestGuide, plans, notes, references,
  *                         commitType, commitSource, jolliDocUrl, jolliDocId,
  *                         orphanedDocIds, unresolvedOrphanHashes, everything
@@ -89,10 +96,17 @@ export async function regenerateSummary(
 	// fallback in resolveStorage — without it the LLM would see an empty
 	// conversation on every regenerate in folder-only mode.
 	//
-	// v5 schema: `getTranscriptIds` returns `summary.transcripts` (the v5
-	// authoritative ID array) when present, else falls back to walking
-	// children for v3/v4 data — both forms read correctly.
-	const transcriptIds = getTranscriptIds(normalized);
+	// v5 schema: the union of every node's `transcripts` array, falling back to
+	// walking children for v3/v4 data — both forms read correctly.
+	//
+	// The union (`resolveTranscriptIdsForUsage`) rather than the root's index alone
+	// (`getTranscriptIds`) because this read is now also the EVIDENCE for the usage
+	// derivation below, which attributes per node: a child-listed id the root index
+	// omits would leave that child skipped, i.e. unrepairable on the one path that
+	// rebuilds everything else. It is a superset on every well-formed v5 tree and
+	// equal to the old value on all the others, so the conversation fed to the LLM
+	// can only gain the sessions a malformed index was hiding.
+	const transcriptIds = resolveTranscriptIdsForUsage(normalized);
 	const transcriptMap = await readTranscriptsForCommits(transcriptIds, cwd, storage);
 	const sessions: SessionTranscript[] = [];
 	for (const stored of transcriptMap.values()) {
@@ -160,7 +174,27 @@ export async function regenerateSummary(
 		summaryError: undefined,
 	};
 
-	return { updated, result };
+	// Re-derive the conversation token/cost figures from the transcripts just read,
+	// rather than carrying the stored aggregate over with the spread above. Regenerate
+	// rebuilds every other field from the archive, and the stored aggregate can be
+	// wrong in two ways nothing else repairs: inflated by the pre-dedup counting bug,
+	// or left stale by a detach whose summary write failed after the files had already
+	// changed. `recomputeConversationUsage` is forward-only — a node with any
+	// usage-less session, or a transcript this read did not return, keeps its stored
+	// figures untouched (see that module's header), so legacy memories are unaffected.
+	//
+	// The evidence deliberately does NOT map a listed-but-unread id to `[]`: on this
+	// path a missing entry means "readTranscriptsForCommits didn't return it", which is
+	// indistinguishable from an unreadable file, and treating it as "the file is gone"
+	// would strip usage the memory still has.
+	const sessionsByTranscriptId = new Map<string, ReadonlyArray<RecomputeSession>>();
+	for (const [id, stored] of transcriptMap) sessionsByTranscriptId.set(id, stored.sessions);
+	const recomputed = recomputeConversationUsage(updated, sessionsByTranscriptId);
+	if (recomputed.skipped.length > 0) {
+		log.debug("Regenerate: kept stored usage figures for transcript(s) %s", recomputed.skipped.join(", "));
+	}
+
+	return { updated: recomputed.summary, result };
 }
 
 // ─── Prompt-block reconstruction from orphan-branch archives ────────────────

--- a/cli/src/core/SummaryTree.test.ts
+++ b/cli/src/core/SummaryTree.test.ts
@@ -10,6 +10,7 @@ import {
 	collectAllTopics,
 	collectAllTranscriptHashes,
 	collectDisplayTopics,
+	collectListedTranscriptIds,
 	collectSourceNodes,
 	computeDurationDays,
 	countTopics,
@@ -20,6 +21,7 @@ import {
 	isUnifiedHoistFormat,
 	resolveDiffStats,
 	resolveTranscriptIdsFiltered,
+	resolveTranscriptIdsForUsage,
 	updateTopicInTree,
 } from "./SummaryTree.js";
 
@@ -408,6 +410,50 @@ describe("SummaryTree", () => {
 		it("falls back to collectAllTranscriptHashes when transcripts is undefined (v3/v4 schema)", () => {
 			// transcripts field absent → v3/v4 schema → derive from the tree.
 			expect(getTranscriptIds(A)).toEqual(["aaa"]);
+		});
+	});
+
+	describe("collectListedTranscriptIds", () => {
+		it("unions every node's own transcripts array, root included", () => {
+			const child = { ...A, version: 5, transcripts: ["uuid-child"] } as CommitSummary;
+			const root = { ...C, version: 5, transcripts: ["uuid-root"], children: [child] } as CommitSummary;
+			expect(collectListedTranscriptIds(root)).toEqual(["uuid-root", "uuid-child"]);
+		});
+
+		it("de-duplicates an id a consolidated root re-lists from its child", () => {
+			const child = { ...A, version: 5, transcripts: ["uuid-1"] } as CommitSummary;
+			const root = { ...C, version: 5, transcripts: ["uuid-1", "uuid-2"], children: [child] } as CommitSummary;
+			expect(collectListedTranscriptIds(root)).toEqual(["uuid-1", "uuid-2"]);
+		});
+
+		it("finds a child-listed id the root index omits", () => {
+			// The malformed shape the usage derivation must still cover — the root index is
+			// empty, so `getTranscriptIds` sees nothing while the child still claims a file.
+			const child = { ...A, version: 5, transcripts: ["uuid-child"] } as CommitSummary;
+			const root = { ...C, version: 5, transcripts: [], children: [child] } as CommitSummary;
+			expect(getTranscriptIds(root)).toEqual([]);
+			expect(collectListedTranscriptIds(root)).toEqual(["uuid-child"]);
+		});
+
+		it("returns [] for a pre-v5 tree, where no node carries the field", () => {
+			expect(collectListedTranscriptIds(D)).toEqual([]);
+		});
+	});
+
+	describe("resolveTranscriptIdsForUsage", () => {
+		it("prefers the tree-wide union over the root index", () => {
+			const child = { ...A, version: 5, transcripts: ["uuid-child"] } as CommitSummary;
+			const root = { ...C, version: 5, transcripts: [], children: [child] } as CommitSummary;
+			expect(resolveTranscriptIdsForUsage(root)).toEqual(["uuid-child"]);
+		});
+
+		it("falls back to the legacy commit-hash walk when the tree lists nothing", () => {
+			expect(resolveTranscriptIdsForUsage(D)).toEqual(["ddd", "bbb", "ccc", "aaa"]);
+		});
+
+		it("returns [] for a v5 tree that genuinely references no transcript", () => {
+			const v5Empty = { ...A, version: 5, transcripts: [] } as CommitSummary;
+			expect(resolveTranscriptIdsForUsage(v5Empty)).toEqual([]);
 		});
 	});
 

--- a/cli/src/core/SummaryTree.ts
+++ b/cli/src/core/SummaryTree.ts
@@ -303,6 +303,47 @@ export function getTranscriptIds(summary: CommitSummary): ReadonlyArray<string> 
 }
 
 /**
+ * Every transcript id LISTED anywhere in the tree — the union over each node's
+ * own `transcripts` array, root included. Empty for a pre-v5 tree, where no node
+ * carries the field.
+ *
+ * Distinct from {@link getTranscriptIds} on purpose. That one answers "which ids
+ * does this summary advertise", and on a v5 root it stops at the root's index —
+ * which is the right answer for display, and for any caller that trusts the
+ * "a consolidated root re-lists every descendant id" invariant.
+ *
+ * This one answers "which ids does any node in this tree claim", which is what a
+ * caller must ask when it is about to REWRITE per-node figures: attribution is
+ * resolved per node (see `TranscriptOwnership`), so evidence gathered from the
+ * root index alone would silently miss a child-listed id and leave that child
+ * unrepairable — the exact failure shape the id lists can be in after a lost
+ * write, i.e. when the repair is needed most.
+ */
+export function collectListedTranscriptIds(summary: CommitSummary): ReadonlyArray<string> {
+	const ids = new Set<string>();
+	const walk = (node: CommitSummary): void => {
+		for (const id of node.transcripts ?? []) ids.add(id);
+		for (const child of node.children ?? []) walk(child);
+	};
+	walk(summary);
+	return [...ids];
+}
+
+/**
+ * The ids a usage-correcting caller must READ: every id any node lists, falling
+ * back to {@link getTranscriptIds} when the tree lists none (a pre-v5 tree, whose
+ * ids are commit hashes, and a v5 root whose index is legitimately empty).
+ *
+ * A superset of `getTranscriptIds` on every well-formed v5 tree, and equal to it
+ * on all the others — see {@link collectListedTranscriptIds} for why the root
+ * index alone is not enough on the write side.
+ */
+export function resolveTranscriptIdsForUsage(summary: CommitSummary): ReadonlyArray<string> {
+	const listed = collectListedTranscriptIds(summary);
+	return listed.length > 0 ? listed : getTranscriptIds(summary);
+}
+
+/**
  * Like `getTranscriptIds`, but for the WRITE side: when materializing an
  * authoritative v5 `transcripts` array from a (possibly legacy) summary, the
  * legacy tree-walk must be filtered to IDs that actually have a backing

--- a/cli/src/core/TranscriptOwnership.test.ts
+++ b/cli/src/core/TranscriptOwnership.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import type { CommitSummary } from "../Types.js";
+import { CURRENT_SCHEMA_VERSION } from "../Types.js";
+import { resolveTranscriptOwnership } from "./TranscriptOwnership.js";
+
+const node = (over: Partial<CommitSummary> = {}): CommitSummary => ({
+	version: CURRENT_SCHEMA_VERSION,
+	commitHash: "a".repeat(40),
+	commitMessage: "test commit",
+	commitAuthor: "Tester",
+	commitDate: "2026-07-29T00:00:00.000Z",
+	branch: "feature/x",
+	generatedAt: "2026-07-29T00:00:01.000Z",
+	topics: [],
+	...over,
+});
+
+describe("resolveTranscriptOwnership", () => {
+	it("attributes an id to the deepest node that lists it, not the root index", () => {
+		const child = node({ commitHash: "c".repeat(40), transcripts: ["t1"] });
+		const root = node({ transcripts: ["t1", "t2"], children: [child] });
+
+		const { ownerById, unresolved } = resolveTranscriptOwnership(root, new Set(["t1"]));
+
+		expect(ownerById.get("t1")).toBe(child);
+		expect(unresolved).toEqual([]);
+	});
+
+	it("attributes an id only the root lists to the root", () => {
+		const child = node({ commitHash: "c".repeat(40), transcripts: ["t1"] });
+		const root = node({ transcripts: ["t1", "t2"], children: [child] });
+
+		const { ownerById } = resolveTranscriptOwnership(root, new Set(["t2"]));
+
+		expect(ownerById.get("t2")).toBe(root);
+	});
+
+	it("ignores ids outside the requested set", () => {
+		const root = node({ transcripts: ["t1", "t2"] });
+
+		const { ownerById, unresolved } = resolveTranscriptOwnership(root, new Set(["t1"]));
+
+		expect([...ownerById.keys()]).toEqual(["t1"]);
+		expect(unresolved).toEqual([]);
+	});
+
+	it("resolves nothing, and walks nothing, for an empty id set", () => {
+		const root = node({ transcripts: ["t1"], children: [node({ commitHash: "c".repeat(40) })] });
+
+		const { ownerById, unresolved } = resolveTranscriptOwnership(root, new Set());
+
+		expect(ownerById.size).toBe(0);
+		expect(unresolved).toEqual([]);
+	});
+
+	it("reports an id nothing claims and no commit hash matches as unresolved", () => {
+		const root = node({ transcripts: ["t1"] });
+
+		const { ownerById, unresolved } = resolveTranscriptOwnership(root, new Set(["gone"]));
+
+		expect(ownerById.has("gone")).toBe(false);
+		expect(unresolved).toEqual(["gone"]);
+	});
+
+	it("reports sibling claimants as unresolved rather than picking one", () => {
+		const left = node({ commitHash: "1".repeat(40), transcripts: ["t1"] });
+		const right = node({ commitHash: "2".repeat(40), transcripts: ["t1"] });
+		const root = node({ transcripts: ["t1"], children: [left, right] });
+
+		const { ownerById, unresolved } = resolveTranscriptOwnership(root, new Set(["t1"]));
+
+		expect(ownerById.has("t1")).toBe(false);
+		expect(unresolved).toEqual(["t1"]);
+	});
+
+	it("attributes a v5-migrated id to the descendant whose commitHash matches it", () => {
+		// SchemaV5Migration.upgradeOneSummary lists every descendant commit hash on the
+		// ROOT and leaves the children without a `transcripts` field, so the root is the
+		// sole claimant of ids whose sessions a child's own token fields cover.
+		const childHash = "c".repeat(40);
+		const child = node({ commitHash: childHash });
+		const root = node({ transcripts: [childHash], children: [child] });
+
+		const { ownerById, unresolved } = resolveTranscriptOwnership(root, new Set([childHash]));
+
+		expect(ownerById.get(childHash)).toBe(child);
+		expect(unresolved).toEqual([]);
+	});
+
+	it("prefers the claiming node itself when it is also the commitHash match", () => {
+		const rootHash = "a".repeat(40);
+		const child = node({ commitHash: "c".repeat(40) });
+		const root = node({ commitHash: rootHash, transcripts: [rootHash], children: [child] });
+
+		const { ownerById } = resolveTranscriptOwnership(root, new Set([rootHash]));
+
+		expect(ownerById.get(rootHash)).toBe(root);
+	});
+
+	it("keeps the claiming node when the commitHash match sits outside its subtree", () => {
+		// The claim is the stronger evidence: a stale id that happens to equal an
+		// unrelated node's commit hash must not hand that node someone else's sessions.
+		const otherHash = "b".repeat(40);
+		const other = node({ commitHash: otherHash });
+		const claimant = node({ commitHash: "c".repeat(40), transcripts: [otherHash] });
+		const root = node({ transcripts: [otherHash], children: [other, claimant] });
+
+		const { ownerById } = resolveTranscriptOwnership(root, new Set([otherHash]));
+
+		expect(ownerById.get(otherHash)).toBe(claimant);
+	});
+
+	it("falls back to a unique commitHash match on a pre-v5 tree that lists nothing", () => {
+		// Legacy v3/v4 data has no `transcripts` field anywhere; transcript files are
+		// named after each commit's own hash, so the hash IS the ownership record.
+		const childHash = "c".repeat(40);
+		const child = node({ commitHash: childHash });
+		const root = node({ children: [child] });
+
+		const { ownerById, unresolved } = resolveTranscriptOwnership(root, new Set([childHash]));
+
+		expect(ownerById.get(childHash)).toBe(child);
+		expect(unresolved).toEqual([]);
+	});
+});

--- a/cli/src/core/TranscriptOwnership.ts
+++ b/cli/src/core/TranscriptOwnership.ts
@@ -1,0 +1,142 @@
+/**
+ * TranscriptOwnership
+ *
+ * Answers one question for the whole summary tree: **which single node's token /
+ * cost figures cover the sessions in `transcripts/<id>.json`?**
+ *
+ * Every consumer that corrects a committed memory's conversation usage needs
+ * that answer, and none of them can read it off a field. `summary.transcripts`
+ * means two different things depending on where it sits:
+ *   - on a leaf — the ids whose sessions this node's token fields cover;
+ *   - on a consolidated root — the tree-wide authoritative INDEX. Amend
+ *     (`QueueWorker`'s `amendTranscripts` = inherited ∪ delta), rebase-pick
+ *     (`migrateOneToOne`) and squash (`mergeManyToOne`, union over children) all
+ *     re-list every descendant id at the root so `getTranscriptIds` finds every
+ *     file — while the root's token fields cover its DELTA only (amend/pick), or
+ *     nothing at all (squash).
+ *
+ * Attribution is therefore per NODE, resolved structurally, and each id resolves
+ * to at most ONE owner: an amend/squash root and its children each carry their own
+ * token fields, and the tree aggregation in `SummaryTree.ts` walks both, so an id
+ * counted at two nodes is counted twice on every surface.
+ *
+ * Two independent kinds of evidence exist, and they are consulted in this order:
+ *
+ *  1. **A claim** — the deepest node that lists the id. Post-order resolution, so
+ *     a node only becomes a claimant once its whole subtree has had the chance to
+ *     claim it; that is what stops a consolidated root's index from outranking the
+ *     leaf whose figures actually cover the id.
+ *  2. **The filename** — `transcripts/<id>.json` is written under the commit hash
+ *     of the commit whose sessions it holds, so a node with `commitHash === id` is
+ *     the node those sessions were counted at. This is what rescues a **v5-migrated
+ *     legacy tree**: `SchemaV5Migration.upgradeOneSummary` puts every descendant
+ *     commit hash on the ROOT's `transcripts` and leaves the children without the
+ *     field at all, so the root is the sole claimant of ids a child counted.
+ *
+ * The hash is only allowed to move ownership DOWN, inside the claimant's own
+ * subtree (and it is consulted alone when nothing claims the id at all, which is
+ * every pre-v5 tree). A hash match outside the claimant's subtree is ignored on
+ * purpose: a stale id that happens to equal an unrelated node's commit hash would
+ * otherwise hand that node someone else's sessions, and the claim is the stronger
+ * evidence there.
+ *
+ * Anything that cannot be pinned to exactly one node — no claimant and no unique
+ * hash match, or sibling claimants (neither is the other's descendant, so there is
+ * no deepest one) — is reported as unresolved rather than guessed at. Callers
+ * surface that and leave the figures EXACTLY as they are: replacing a known-stale
+ * number with an invented one is strictly worse, and a silently wrong figure reads
+ * as settled truth.
+ */
+
+import type { CommitSummary } from "../Types.js";
+
+export interface TranscriptOwnershipResult {
+	/** Transcript id → the single node whose usage figures cover it. */
+	readonly ownerById: ReadonlyMap<string, CommitSummary>;
+	/**
+	 * Ids of interest that could not be pinned to exactly one node. Callers must
+	 * treat these as "unknown" — see the module header on why guessing is worse.
+	 */
+	readonly unresolved: ReadonlyArray<string>;
+}
+
+/**
+ * Post-order walk recording a claimant for an id the moment a node lists it and
+ * no descendant did. Returns what this subtree claimed, so the parent can tell
+ * whether its own listing is a claim or just an index entry.
+ *
+ * `interest` restricts everything, so walking a consolidated root's tree-wide
+ * index costs nothing when only one id is being corrected.
+ */
+function collectClaimants(
+	node: CommitSummary,
+	interest: ReadonlySet<string>,
+	claimants: Map<string, CommitSummary[]>,
+): Set<string> {
+	const claimedBelow = new Set<string>();
+	for (const child of node.children ?? []) {
+		for (const id of collectClaimants(child, interest, claimants)) claimedBelow.add(id);
+	}
+	const claimed = new Set(claimedBelow);
+	for (const id of node.transcripts ?? []) {
+		if (!interest.has(id)) continue;
+		claimed.add(id);
+		if (claimedBelow.has(id)) continue;
+		const existing = claimants.get(id);
+		if (existing) existing.push(node);
+		else claimants.set(id, [node]);
+	}
+	return claimed;
+}
+
+/** Collects, per id of interest, every node in the tree whose commitHash matches. */
+function collectHashNodes(node: CommitSummary, interest: ReadonlySet<string>, out: Map<string, CommitSummary[]>): void {
+	if (interest.has(node.commitHash)) {
+		const existing = out.get(node.commitHash);
+		if (existing) existing.push(node);
+		else out.set(node.commitHash, [node]);
+	}
+	for (const child of node.children ?? []) collectHashNodes(child, interest, out);
+}
+
+/**
+ * Resolves the owning node of each id in `ids`. See the module header for the
+ * evidence order (claim, then filename-within-subtree) and for why unresolvable
+ * ids are reported instead of assigned.
+ */
+export function resolveTranscriptOwnership(root: CommitSummary, ids: ReadonlySet<string>): TranscriptOwnershipResult {
+	const ownerById = new Map<string, CommitSummary>();
+	const unresolved: string[] = [];
+	if (ids.size === 0) return { ownerById, unresolved };
+
+	const claimants = new Map<string, CommitSummary[]>();
+	collectClaimants(root, ids, claimants);
+
+	// Hash matches are re-collected per claimant subtree below; the tree-wide map
+	// is what the no-claimant fallback needs (every pre-v5 tree lands there).
+	const treeHashNodes = new Map<string, CommitSummary[]>();
+	collectHashNodes(root, ids, treeHashNodes);
+
+	for (const id of ids) {
+		const claiming = claimants.get(id) ?? [];
+		if (claiming.length > 1) {
+			// Ambiguous claim — see the module header.
+			unresolved.push(id);
+			continue;
+		}
+		if (claiming.length === 0) {
+			const hashMatches = treeHashNodes.get(id) ?? [];
+			if (hashMatches.length === 1) ownerById.set(id, hashMatches[0]);
+			else unresolved.push(id);
+			continue;
+		}
+		const claimant = claiming[0];
+		// The hash may only move ownership DOWN, into the claimant's own subtree.
+		const withinClaimant = new Map<string, CommitSummary[]>();
+		collectHashNodes(claimant, ids, withinClaimant);
+		const candidates = withinClaimant.get(id) ?? [];
+		ownerById.set(id, candidates.length === 1 ? candidates[0] : claimant);
+	}
+
+	return { ownerById, unresolved };
+}

--- a/vscode/src/JolliMemoryBridge.integration.test.ts
+++ b/vscode/src/JolliMemoryBridge.integration.test.ts
@@ -27,16 +27,17 @@ vi.mock("./util/Logger.js", () => ({
 
 import { JolliMemoryBridge } from "./JolliMemoryBridge.js";
 
+// NO per-file `vi.setConfig({ testTimeout, hookTimeout })` here, deliberately.
+//
 // The shared `beforeEach` below spawns real `git` subprocesses (init, config,
-// commit) and is file-scoped, so it applies across every `describe` block in
-// this file — a describe-level `{ timeout }` option would only cover the one
-// describe it wraps, not this hook. Under v8 coverage instrumentation plus a
-// large parallel suite, that subprocess chain can occasionally take longer
-// than Vitest's 5s/10s defaults, which is a load signal, not a correctness
-// one. Bump both timeouts file-wide so the suite stays robust under load
-// without hiding an actual hang (45s is far beyond any real subprocess
-// latency).
-vi.setConfig({ testTimeout: 45_000, hookTimeout: 45_000 });
+// commit), and under v8 coverage instrumentation plus the full parallel suite
+// that chain gets CPU-starved — a load signal, not a correctness one. The
+// timeouts that cover it live in `vitest.config.ts` (60s for both), and
+// `vi.setConfig` REPLACES those rather than widening them: the 45s this file
+// used to set was a CLAMP, so it timed out at 45s inside a suite the config had
+// already given 60s, and only in a full run — green in isolation, which reads
+// exactly like a flake. Tune the config file if this ever needs more; a value
+// here can only ever take time away.
 
 let repoDir: string;
 

--- a/vscode/src/views/SummaryCssBuilder.ts
+++ b/vscode/src/views/SummaryCssBuilder.ts
@@ -1282,6 +1282,14 @@ export function buildCss(): string {
     white-space: normal;
   }
   .tok-help-wrap.pinned .tok-pop { display: block; }
+  /* Re-derive figures from the archived conversations. Sits after the '?' wrap,
+     which owns the 'margin-left: auto' that pushes both to the right edge. */
+  .tmeter-recalc {
+    background: none; border: 1px solid var(--border-light); border-radius: 50%;
+    width: 15px; height: 15px; line-height: 1; padding: 0; font-size: 0.8em;
+    color: var(--text-tertiary); cursor: pointer;
+  }
+  .tmeter-recalc:hover { color: var(--vscode-foreground); border-color: var(--text-secondary); }
 
   /* ── Ship bar (hero) ── */
   .ship-bar {

--- a/vscode/src/views/SummaryHtmlBuilder.test.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.test.ts
@@ -1852,6 +1852,29 @@ describe("SummaryHtmlBuilder", () => {
 			expect(html).not.toContain("tmeter na");
 		});
 
+		it("offers the recompute action in both the reported and the not-reported state", () => {
+			// The escape hatch has to be reachable from BOTH states: a memory whose figures
+			// were wrongly stripped renders as "not reported", and that is exactly the memory
+			// a user needs to re-derive.
+			const reported = buildTokenMeter(
+				makeSummary({ conversationTokens: 5000, conversationTokenBreakdown: { input: 1, output: 2, cached: 4997 } }),
+				{ showRecompute: true },
+			);
+			const notReported = buildTokenMeter(makeSummary({ conversationTokens: undefined }), { showRecompute: true });
+
+			expect(reported).toContain('id="recomputeUsageBtn"');
+			expect(notReported).toContain('id="recomputeUsageBtn"');
+		});
+
+		it("omits the recompute action by default so read-only panels ship no write affordance", () => {
+			// Foreign (cross-repo) and stale-rewritten panels must not offer a button whose
+			// handler writes to this workspace's orphan branch — the dispatch guard denies it
+			// anyway, so shipping it would only promise something that cannot happen.
+			const html = buildTokenMeter(makeSummary({ conversationTokens: 5000 }));
+
+			expect(html).not.toContain("recomputeUsageBtn");
+		});
+
 		it("prefers the stored per-model cost over the flat Sonnet estimate", () => {
 			// This surface used to price every memory at Sonnet rates unconditionally
 			// while the sidebar preferred the stored per-model figure, so the same memory

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -209,7 +209,7 @@ ${codiconLinkTag}
 ${buildSummaryErrorBanner(summary, { readOnly })}
 ${staleBannerHtml}
 ${buildPageTitleAndMetaStrip(summary)}
-${buildTokenMeter(summary)}
+${buildTokenMeter(summary, { showRecompute: !readOnly })}
 ${buildPropTable(summary, totalFiles, transcriptHashSet)}
 ${buildShipBar(summary)}
 ${buildMemoryPanel(summary, { readOnly }, !!opts.foreignRepoName)}
@@ -666,8 +666,14 @@ function estimateCost(summary: CommitSummary): { label: string; mode: "stored" |
  * `style="width"` \u2014 the webview's CSP has no `unsafe-inline` for styles, so
  * SummaryScriptBuilder sets `el.style.width` from `data-pct` after load (a
  * JS property write, not an inline attribute, so CSP allows it).
+ *
+ * `showRecompute` adds the re-derive action (see {@link buildRecomputeAction}). It
+ * defaults to OFF so a read-only panel ships no affordance for a handler that
+ * writes to this workspace's orphan branch; the caller that knows the panel is
+ * writable opts in.
  */
-export function buildTokenMeter(summary: CommitSummary): string {
+export function buildTokenMeter(summary: CommitSummary, opts: { readonly showRecompute?: boolean } = {}): string {
+	const recompute = opts.showRecompute ? buildRecomputeAction() : "";
 	// Aggregate across the WHOLE consolidation tree — NOT the root's own scalar.
 	// A squash/amend/rebase memory carries its conversation tokens on the folded
 	// child commits, so reading only `summary.conversationTokens` (the root's own
@@ -681,7 +687,7 @@ export function buildTokenMeter(summary: CommitSummary): string {
 <div class="tmeter na">
   <div class="tmeter-head"><span class="tmeter-total">Task usage not reported</span>
     <span class="tok-help-wrap"><button class="tok-help" type="button" data-foreign-safe>?</button>
-      <span class="tok-pop">No session on this memory reports token usage, so there's nothing to total.</span></span>
+      <span class="tok-pop">No session on this memory reports token usage, so there's nothing to total.</span></span>${recompute}
   </div>
 </div>`;
 	}
@@ -727,10 +733,28 @@ export function buildTokenMeter(summary: CommitSummary): string {
 <div class="tmeter">
   <div class="tmeter-head"><span class="tmeter-total">${formatTokensCompact(total)}</span> tokens &middot; <span class="tmeter-cost">${cost.label}</span> &middot; this task
     <span class="tok-help-wrap"><button class="tok-help" type="button" data-foreign-safe>?</button>
-      <span class="tok-pop">Counts input + output + cache-creation across sessions (cache reads are excluded \u2014 they double-count). ${costNote}</span></span>
+      <span class="tok-pop">Counts input + output + cache-creation across sessions (cache reads are excluded \u2014 they double-count). ${costNote}</span></span>${recompute}
   </div>
   ${bar}
 </div>`;
+}
+
+/**
+ * The meter's re-derive action: recomputes this memory's token / cost figures from
+ * its archived transcripts (`recomputeUsage` \u2192 `handleRecomputeUsage`).
+ *
+ * Deliberately reachable from BOTH meter states. A memory whose figures were
+ * stripped \u2014 or never corrected after a lost detach write \u2014 renders as
+ * "Task usage not reported", and that is precisely the memory a user wants to
+ * re-derive; an action attached only to the populated state would be missing
+ * exactly when it is needed.
+ *
+ * NOT `data-foreign-safe`: the handler writes to the orphan branch. Read-only
+ * panels never render it in the first place (`showRecompute` defaults to false).
+ */
+function buildRecomputeAction(): string {
+	return `
+    <button class="tmeter-recalc" id="recomputeUsageBtn" type="button" title="Recompute this memory's token and cost figures from its archived conversations">&#x21BB;</button>`;
 }
 
 // \u2500\u2500\u2500 Ship bar + content panels (presentation wrappers) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500

--- a/vscode/src/views/SummaryScriptBuilder.test.ts
+++ b/vscode/src/views/SummaryScriptBuilder.test.ts
@@ -507,6 +507,27 @@ describe("SummaryScriptBuilder", () => {
 			expect(script).toContain("el.style.width = el.dataset.pct + '%'");
 		});
 
+		it("wires the recompute button to post recomputeUsage", () => {
+			expect(script).toContain("recomputeUsageBtn");
+			expect(script).toContain("command: 'recomputeUsage'");
+		});
+
+		it("re-binds the recompute button inside initTokenMeter so a swapped meter keeps it live", () => {
+			// The button sits inside .tmeter-head, so an outerHTML swap replaces the node and
+			// drops its listener. initTokenMeter is the re-init hook both swap paths already
+			// call — binding anywhere else leaves a dead button after the first recompute.
+			const initBody = script.slice(
+				script.indexOf("function initTokenMeter("),
+				script.indexOf("initTokenMeter(document);"),
+			);
+			expect(initBody).toContain("recomputeUsageBtn");
+		});
+
+		it("swaps the meter on usageRecomputed through the same helper as the detach ack", () => {
+			expect(script).toContain("msg.command === 'usageRecomputed'");
+			expect(script).toContain("function swapTokenMeter(");
+		});
+
 		it("wires the .tok-help button to toggle .pinned on its .tok-help-wrap", () => {
 			expect(script).toContain(".tok-help");
 			expect(script).toContain("closest('.tok-help-wrap')");

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -101,6 +101,36 @@ export function buildScript(options: SummaryScriptOptions = {}): string {
         if (!wasPinned) { wrap.classList.add('pinned'); }
       });
     });
+    // Re-derive figures from the archived conversations. Bound here rather than once
+    // at load because the button lives inside .tmeter-head: an outerHTML swap of the
+    // meter replaces the node and drops any listener bound to the old one, so the
+    // second press of the button would do nothing.
+    var recalc = scope.querySelector('#recomputeUsageBtn');
+    if (recalc) {
+      recalc.addEventListener('click', function() {
+        vscode.postMessage({ command: 'recomputeUsage' });
+      });
+    }
+  }
+  // Replaces the meter in place and re-inits the new node. Shared by every path that
+  // corrects the figures (detach ack, recompute reply) so they cannot drift on the
+  // re-init step, which is what keeps a swapped meter from rendering as an empty bar
+  // with dead buttons.
+  //
+  // outerHTML is safe here specifically: the html is composed host-side by
+  // buildTokenMeter from numeric aggregates and literal strings only — no summary
+  // text, path, or other repo content reaches it. Do not extend this to markup
+  // carrying commit/user strings.
+  function swapTokenMeter(html) {
+    if (typeof html !== 'string' || html === '') { return; }
+    var meterEl = document.querySelector('.tmeter');
+    if (!meterEl) { return; }
+    meterEl.outerHTML = html;
+    // Re-init scoped to the REPLACED meter, not the whole document: the help button
+    // gets its click listener bound per element, so re-scanning document-wide would
+    // hand a second listener to every other pinnable popover on the page and each
+    // click would toggle it twice (net no-op).
+    initTokenMeter(document.querySelector('.tmeter'));
   }
   initTokenMeter(document);
   document.addEventListener('click', function() {
@@ -2435,26 +2465,17 @@ ${buildSourceLabelScript()}
       // The detached conversation's tokens no longer belong to this memory, so
       // the meter is rebuilt host-side and swapped in with the row removal
       // rather than left showing the pre-detach total until the panel reopens.
-      // Absent when the host could not attribute the removed usage (memories
-      // written before per-session usage was recorded) — the meter then stays
-      // as-is, which is the honest reading of "we don't know".
-      if (typeof msg.tokenMeterHtml === 'string' && msg.tokenMeterHtml !== '') {
-        var meterEl = document.querySelector('.tmeter');
-        if (meterEl) {
-          // outerHTML is safe here specifically: tokenMeterHtml is composed
-          // host-side by buildTokenMeter from numeric aggregates and literal
-          // strings only — no summary text, path, or other repo content reaches
-          // it. Do not extend this to markup carrying commit/user strings.
-          meterEl.outerHTML = msg.tokenMeterHtml;
-          // Re-init scoped to the REPLACED meter, not the whole document: the help
-          // button gets its click listener bound per element, so re-scanning
-          // document-wide would hand a second listener to every other pinnable
-          // popover on the page and each click would toggle it twice (net no-op).
-          // Only .tmeter carries .tok-help today, but the scope keeps that from
-          // becoming a trap the next time one is added elsewhere.
-          initTokenMeter(document.querySelector('.tmeter'));
-        }
-      }
+      // Absent when the host could neither attribute the removed usage nor
+      // re-derive the figures (memories with a session that records no usage) —
+      // the meter then stays as-is, which is the honest reading of "we don't know".
+      swapTokenMeter(msg.tokenMeterHtml);
+    }
+    if (msg.command === 'usageRecomputed') {
+      // Manual re-derive finished and changed something. Only the meter moved, so
+      // the panel is not rebuilt (that would collapse scroll position and every
+      // expanded section). No message arrives when nothing changed — the host says
+      // so with a notification instead.
+      swapTokenMeter(msg.tokenMeterHtml);
     }
     if (msg.command === 'transcriptStatsLoaded') {
       if (conversationsStats) {

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -5619,13 +5619,12 @@ describe("SummaryWebviewPanel", () => {
 				expect(meterArg.conversationTokens).toBe(710);
 			});
 
-			it("warns the user when a lost summary write leaves the token figures permanently stale", async () => {
+			it("warns the user when both the summary write and the self-heal that follows it fail", async () => {
 				// Files first, summary second — so a summary-write failure leaves the sessions
-				// gone from disk while the memory still counts their tokens. That is not
-				// recoverable: a retry finds nothing to remove (plain ack), the subtrahend was
-				// only readable while the sessions were still in the files, and Regenerate
-				// carries `conversationTokens` over verbatim. Logging it and posting a clean ack
-				// reported the operation as fully successful; the user must be told.
+				// gone from disk while the memory still counts their tokens. The panel then
+				// re-derives the figures from the surviving transcripts (see the self-heal test
+				// below); this is the case where that write fails too, and the user must be told
+				// rather than shown a clean ack for a memory whose figures stayed stale.
 				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
 				mockReadTranscriptsForCommits.mockResolvedValue(
 					new Map([
@@ -5659,7 +5658,14 @@ describe("SummaryWebviewPanel", () => {
 				} as ReturnType<typeof makeSummary>;
 				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
 				// Nothing is emptied, so the correction takes the rescue `storeSummary` path.
-				mockStoreSummary.mockRejectedValueOnce(new Error("orphan-write lock timeout"));
+				// Both writes fail — the correction's and the self-heal's that follows it — as
+				// they would while something else holds the orphan write lock. Two `…Once`s
+				// rather than a blanket `mockRejectedValue`: the latter survives
+				// `vi.clearAllMocks()` (which resets calls, not implementations) and would
+				// fail every later test in the file.
+				mockStoreSummary
+					.mockRejectedValueOnce(new Error("orphan-write lock timeout"))
+					.mockRejectedValueOnce(new Error("orphan-write lock timeout"));
 				const dispatch = captureMessageHandler();
 
 				dispatch({ command: "conversationDetach", hash: "abc123", sessionId: "s1", source: "claude" });
@@ -5828,6 +5834,590 @@ describe("SummaryWebviewPanel", () => {
 				expect(written.conversationTokenBreakdown).toEqual({ input: 60, output: 150, cached: 500 });
 				expect(written.transcripts).toEqual([]);
 				expect(mockStoreSummary).toHaveBeenCalledTimes(1);
+			});
+
+			it("self-heals the figures from the surviving transcripts when the summary write fails", async () => {
+				// The unrecoverable window: the files have already lost the session, so the
+				// subtrahend is gone and a retry finds nothing to remove. Deriving from what is
+				// LEFT needs no subtrahend, so the correction is recoverable after all — the
+				// same 710 the subtraction would have produced, reached from the other side.
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				const detached = {
+					sessionId: "s1",
+					source: "claude" as const,
+					entries: [{ role: "human" as const, content: "A" }],
+					usage: { input: 40, output: 50, cached: 200 },
+				};
+				const kept = {
+					sessionId: "keep",
+					source: "claude" as const,
+					entries: [{ role: "human" as const, content: "K" }],
+					usage: { input: 60, output: 150, cached: 500 },
+					usageByModel: [
+						{ model: "claude-opus-5", provider: "anthropic" as const, input: 60, output: 150, cached: 500 },
+					],
+				};
+				mockReadTranscriptsForCommits
+					// The detach's own read still sees both sessions…
+					.mockResolvedValueOnce(new Map([["abc123", { sessions: [detached, kept] }]]))
+					// …and the self-heal's read sees the file the batch already rewrote.
+					.mockResolvedValue(new Map([["abc123", { sessions: [kept] }]]));
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: ["abc123"],
+					conversationTokens: 1000,
+					conversationTokenBreakdown: { input: 100, output: 200, cached: 700 },
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
+				mockStoreSummary.mockClear();
+				// The correction's own write is lost; the self-heal's write lands.
+				mockStoreSummary.mockRejectedValueOnce(new Error("orphan-write lock timeout"));
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "conversationDetach", hash: "abc123", sessionId: "s1", source: "claude" });
+				await flushPromises();
+
+				const written = mockStoreSummary.mock.calls.at(-1)?.[0] as CommitSummary;
+				expect(written.conversationTokens).toBe(710);
+				expect(written.conversationTokenBreakdown).toEqual({ input: 60, output: 150, cached: 500 });
+				// Healed, so the user gets the meter rather than a warning about stale figures.
+				expect(showWarningMessage).not.toHaveBeenCalled();
+				const ack = postMessage.mock.calls
+					.map((c) => c[0])
+					.find((m: { command?: string }) => m?.command === "conversationDetached");
+				expect(ack.tokenMeterHtml).toBe('<div class="tmeter">meter</div>');
+			});
+
+			it("recomputeUsage derives the figures from the stored transcripts and swaps the meter", async () => {
+				// The manual escape hatch for a figure that is already stale — a detach whose
+				// summary write was lost, or a memory written before the per-response dedup fix
+				// (median 2.13× inflation). Nothing else in the product could repair either.
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				mockReadTranscriptsForCommits.mockResolvedValue(
+					new Map([
+						[
+							"abc123",
+							{
+								sessions: [
+									{
+										sessionId: "keep",
+										source: "claude" as const,
+										entries: [{ role: "human" as const, content: "K" }],
+										usage: { input: 60, output: 150, cached: 500 },
+										usageByModel: [
+											{ model: "claude-opus-5", provider: "anthropic" as const, input: 60, output: 150, cached: 500 },
+										],
+									},
+								],
+							},
+						],
+					]),
+				);
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: ["abc123"],
+					conversationTokens: 2130,
+					conversationTokenBreakdown: { input: 128, output: 320, cached: 1682 },
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
+				mockStoreSummary.mockClear();
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "recomputeUsage" });
+				await flushPromises();
+
+				const written = mockStoreSummary.mock.calls.at(-1)?.[0] as CommitSummary;
+				expect(written.conversationTokens).toBe(710);
+				expect(written.conversationTokenBreakdown).toEqual({ input: 60, output: 150, cached: 500 });
+				const ack = postMessage.mock.calls
+					.map((c) => c[0])
+					.find((m: { command?: string }) => m?.command === "usageRecomputed");
+				expect(ack.tokenMeterHtml).toBe('<div class="tmeter">meter</div>');
+			});
+
+			it("recomputeUsage strips the figures and the dangling id when the transcript file is gone", async () => {
+				// The other half of a lost detach write: the file that became empty was
+				// deleted, but the id it was listed under — and the tokens it contributed —
+				// are still on the summary. Both are corrected in one write.
+				mockGetTranscriptHashes.mockResolvedValue(new Set());
+				mockReadTranscriptsForCommits.mockResolvedValue(new Map());
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: ["abc123"],
+					conversationTokens: 710,
+					conversationTokenBreakdown: { input: 60, output: 150, cached: 500 },
+					estimatedCostUsd: 3.5,
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
+				mockStoreSummary.mockClear();
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "recomputeUsage" });
+				await flushPromises();
+
+				const written = mockStoreSummary.mock.calls.at(-1)?.[0] as CommitSummary;
+				// Absent, not zero: "this memory reports no usage" is the display contract, and
+				// a stored 0 renders as a real measurement of nothing.
+				expect(written.conversationTokens).toBeUndefined();
+				expect(written.estimatedCostUsd).toBeUndefined();
+				expect(written.transcripts).toEqual([]);
+				expect(mockStoreSummary).toHaveBeenCalledTimes(1);
+			});
+
+			it("recomputeUsage leaves a legacy summary's figures alone when a commit has no transcript file", async () => {
+				// A pre-v5 summary has no id list — `getTranscriptIds` walks commit hashes, and
+				// most commits never had an AI session. Reading those absences as "the file was
+				// deleted" would zero out every legacy memory's usage on one button press.
+				mockGetTranscriptHashes.mockResolvedValue(new Set());
+				mockReadTranscriptsForCommits.mockResolvedValue(new Map());
+				const summary = {
+					...makeSummary(),
+					version: 4,
+					transcripts: undefined,
+					conversationTokens: 710,
+					conversationTokenBreakdown: { input: 60, output: 150, cached: 500 },
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
+				mockStoreSummary.mockClear();
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "recomputeUsage" });
+				await flushPromises();
+
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+				// And says nothing was read, rather than "already match" — which would claim
+				// the figures were verified against evidence that was never there.
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					expect.stringContaining("no archived conversations"),
+				);
+			});
+
+			it("recomputeUsage writes nothing and says so when the figures already match", async () => {
+				// Idempotence is what lets this be a button a user can press twice. A no-op that
+				// silently did nothing would read as a broken button, so it reports instead.
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				mockReadTranscriptsForCommits.mockResolvedValue(
+					new Map([
+						[
+							"abc123",
+							{
+								sessions: [
+									{
+										sessionId: "keep",
+										source: "claude" as const,
+										entries: [{ role: "human" as const, content: "K" }],
+										usage: { input: 60, output: 150, cached: 500 },
+									},
+								],
+							},
+						],
+					]),
+				);
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: ["abc123"],
+					conversationTokens: 710,
+					conversationTokenBreakdown: { input: 60, output: 150, cached: 500 },
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
+				mockStoreSummary.mockClear();
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "recomputeUsage" });
+				await flushPromises();
+
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					expect.stringContaining("already match"),
+				);
+			});
+
+			it("recomputeUsage reports the conversations it could not derive from", async () => {
+				// Forward-only: one session with no recorded usage makes the whole node
+				// unusable, and the user is told which conversations blocked it rather than
+				// being shown a figure derived from partial evidence.
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				mockReadTranscriptsForCommits.mockResolvedValue(
+					new Map([
+						[
+							"abc123",
+							{
+								sessions: [
+									{ sessionId: "legacy", source: "claude" as const, entries: [{ role: "human" as const, content: "L" }] },
+								],
+							},
+						],
+					]),
+				);
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: ["abc123"],
+					conversationTokens: 2130,
+					conversationTokenBreakdown: { input: 128, output: 320, cached: 1682 },
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
+				mockStoreSummary.mockClear();
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "recomputeUsage" });
+				await flushPromises();
+
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					expect.stringContaining("no recorded per-conversation usage"),
+				);
+			});
+
+			it("recomputeUsage derives a child-listed transcript the root index omits", async () => {
+				// Evidence is gathered from every node's id list, not the root's index alone:
+				// attribution is per node, so a child-listed id that went unread would leave
+				// that child skipped — the shape the detach path already rescues around.
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["child-t1"]));
+				mockReadTranscriptsForCommits.mockResolvedValue(
+					new Map([
+						[
+							"child-t1",
+							{
+								sessions: [
+									{
+										sessionId: "keep",
+										source: "claude" as const,
+										entries: [{ role: "human" as const, content: "K" }],
+										usage: { input: 1, output: 2, cached: 3 },
+									},
+								],
+							},
+						],
+					]),
+				);
+				const child = {
+					...makeSummary(),
+					commitHash: "child1",
+					version: 5,
+					transcripts: ["child-t1"],
+					conversationTokens: 2130,
+					conversationTokenBreakdown: { input: 128, output: 320, cached: 1682 },
+				} as ReturnType<typeof makeSummary>;
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: [],
+					children: [child],
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
+				mockStoreSummary.mockClear();
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "recomputeUsage" });
+				await flushPromises();
+
+				const written = mockStoreSummary.mock.calls.at(-1)?.[0] as CommitSummary;
+				expect(written.children?.[0].conversationTokens).toBe(6);
+				expect(written.children?.[0].conversationTokenBreakdown).toEqual({ input: 1, output: 2, cached: 3 });
+			});
+
+			it("recomputeUsage reports a dangling-id cleanup that changed no figure", async () => {
+				// The write happened even though the figures already matched, so "already
+				// match" alone would hide that the memory was modified and make the
+				// Conversations card losing a row look like a bug.
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				mockReadTranscriptsForCommits.mockResolvedValue(
+					new Map([
+						[
+							"abc123",
+							{
+								sessions: [
+									{
+										sessionId: "keep",
+										source: "claude" as const,
+										entries: [{ role: "human" as const, content: "K" }],
+										usage: { input: 60, output: 150, cached: 500 },
+									},
+								],
+							},
+						],
+					]),
+				);
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: ["abc123", "gone-t2"],
+					conversationTokens: 710,
+					conversationTokenBreakdown: { input: 60, output: 150, cached: 500 },
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
+				mockStoreSummary.mockClear();
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "recomputeUsage" });
+				await flushPromises();
+
+				const written = mockStoreSummary.mock.calls.at(-1)?.[0] as CommitSummary;
+				expect(written.transcripts).toEqual(["abc123"]);
+				expect(written.conversationTokens).toBe(710);
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					expect.stringContaining("Dropped 1 stale conversation reference"),
+				);
+			});
+
+			it("recomputeUsage says a transcript could not be READ rather than that it records no usage", async () => {
+				// Two different facts about the memory: an unreadable archive may be fixable on
+				// this machine, while a readable one with no recorded usage never will be.
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				mockReadTranscriptsForCommits.mockResolvedValue(new Map());
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: ["abc123"],
+					conversationTokens: 710,
+					conversationTokenBreakdown: { input: 60, output: 150, cached: 500 },
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
+				mockStoreSummary.mockClear();
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "recomputeUsage" });
+				await flushPromises();
+
+				expect(mockStoreSummary).not.toHaveBeenCalled();
+				expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("could not be read"));
+			});
+
+			it("recomputeUsage drops a dangling id that only a CHILD lists", async () => {
+				// The malformed shape a lost detach write leaves: the root's index is empty
+				// while a child still claims an id whose file is gone. Filtering the root alone
+				// stripped the child's figures and left the dead id on disk, so the next press
+				// found the figures already correct and reported "already match" forever.
+				mockGetTranscriptHashes.mockResolvedValue(new Set<string>());
+				mockReadTranscriptsForCommits.mockResolvedValue(new Map());
+				const child = {
+					...makeSummary(),
+					commitHash: "child1",
+					version: 5,
+					transcripts: ["gone-t1"],
+					conversationTokens: 2130,
+					conversationTokenBreakdown: { input: 128, output: 320, cached: 1682 },
+				} as ReturnType<typeof makeSummary>;
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: [],
+					children: [child],
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
+				mockStoreSummary.mockClear();
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "recomputeUsage" });
+				await flushPromises();
+
+				const written = mockStoreSummary.mock.calls.at(-1)?.[0] as CommitSummary;
+				expect(written.children?.[0].transcripts).toEqual([]);
+				expect(written.children?.[0].conversationTokens).toBeUndefined();
+				// One write, not a recompute write followed by a rescue write.
+				expect(mockStoreSummary).toHaveBeenCalledTimes(1);
+			});
+
+			it("recomputeUsage leaves a child's version alone when filtering its transcript ids", async () => {
+				// Only the array is rewritten: a descendant's `version` records the schema it
+				// was written under, and the v5 migration never stamps descendants. Bumping it
+				// here would claim a migration that didn't run.
+				mockGetTranscriptHashes.mockResolvedValue(new Set<string>());
+				mockReadTranscriptsForCommits.mockResolvedValue(new Map());
+				const child = {
+					...makeSummary(),
+					commitHash: "child1",
+					version: 4,
+					transcripts: ["gone-t1"],
+					conversationTokens: 2130,
+					conversationTokenBreakdown: { input: 128, output: 320, cached: 1682 },
+				} as ReturnType<typeof makeSummary>;
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: [],
+					children: [child],
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
+				mockStoreSummary.mockClear();
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "recomputeUsage" });
+				await flushPromises();
+
+				const written = mockStoreSummary.mock.calls.at(-1)?.[0] as CommitSummary;
+				expect(written.children?.[0].version).toBe(4);
+				expect(written.version).toBe(5);
+			});
+
+			it("recomputeUsage says figures were PARTLY updated when one node derived and another skipped", async () => {
+				// `skipped` and `changed` co-occur on a tree with two owner nodes. Reporting
+				// only "left as they are" contradicts the meter the user watches change
+				// underneath the toast.
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["root-t1", "child-t1"]));
+				mockReadTranscriptsForCommits.mockResolvedValue(
+					new Map([
+						[
+							"root-t1",
+							{
+								sessions: [
+									{
+										sessionId: "keep",
+										source: "claude" as const,
+										entries: [{ role: "human" as const, content: "K" }],
+										usage: { input: 1, output: 2, cached: 3 },
+									},
+								],
+							},
+						],
+						[
+							"child-t1",
+							{
+								sessions: [
+									{
+										sessionId: "legacy",
+										source: "claude" as const,
+										entries: [{ role: "human" as const, content: "L" }],
+									},
+								],
+							},
+						],
+					]),
+				);
+				const child = {
+					...makeSummary(),
+					commitHash: "child1",
+					version: 5,
+					transcripts: ["child-t1"],
+					conversationTokens: 2130,
+					conversationTokenBreakdown: { input: 128, output: 320, cached: 1682 },
+				} as ReturnType<typeof makeSummary>;
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: ["root-t1", "child-t1"],
+					conversationTokens: 999,
+					conversationTokenBreakdown: { input: 100, output: 200, cached: 699 },
+					children: [child],
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
+				mockStoreSummary.mockClear();
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "recomputeUsage" });
+				await flushPromises();
+
+				const written = mockStoreSummary.mock.calls.at(-1)?.[0] as CommitSummary;
+				expect(written.conversationTokens).toBe(6);
+				// The child kept its stored figures — that is the share the toast must not
+				// claim was updated.
+				expect(written.children?.[0].conversationTokens).toBe(2130);
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					expect.stringContaining("partly updated"),
+				);
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					expect.stringContaining("the share covering it was left as it is"),
+				);
+			});
+
+			it("recomputeUsage reports a dangling drop alongside a skipped conversation", async () => {
+				// The two facts are independent, so the skipped-branch toast has to carry the
+				// dropped-reference note too — otherwise a press that modified the memory
+				// reports only "left as they are".
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				mockReadTranscriptsForCommits.mockResolvedValue(
+					new Map([
+						[
+							"abc123",
+							{
+								sessions: [
+									{
+										sessionId: "legacy",
+										source: "claude" as const,
+										entries: [{ role: "human" as const, content: "L" }],
+									},
+								],
+							},
+						],
+					]),
+				);
+				const child = {
+					...makeSummary(),
+					commitHash: "child1",
+					version: 5,
+					transcripts: ["gone-t1"],
+					conversationTokens: 2130,
+					conversationTokenBreakdown: { input: 128, output: 320, cached: 1682 },
+				} as ReturnType<typeof makeSummary>;
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: ["abc123"],
+					conversationTokens: 2130,
+					conversationTokenBreakdown: { input: 128, output: 320, cached: 1682 },
+					children: [child],
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
+				mockStoreSummary.mockClear();
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "recomputeUsage" });
+				await flushPromises();
+
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					expect.stringContaining("no recorded per-conversation usage"),
+				);
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					expect.stringContaining("Dropped 1 stale conversation reference"),
+				);
+			});
+
+			it("detach drops a child-listed transcript id when the root index omits it", async () => {
+				// Detach shares the same helper, so the child-only shape must clear there too:
+				// otherwise the summary keeps referencing a transcript file the batch deleted.
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				mockReadTranscriptsForCommits.mockResolvedValue(
+					new Map([
+						[
+							"abc123",
+							{
+								sessions: [
+									{
+										sessionId: "s1",
+										source: "claude" as const,
+										entries: [{ role: "human" as const, content: "A" }],
+									},
+								],
+							},
+						],
+					]),
+				);
+				const child = {
+					...makeSummary(),
+					commitHash: "child1",
+					version: 5,
+					transcripts: ["abc123"],
+				} as ReturnType<typeof makeSummary>;
+				const summary = {
+					...makeSummary(),
+					version: 5,
+					transcripts: [],
+					children: [child],
+				} as ReturnType<typeof makeSummary>;
+				await SummaryWebviewPanel.show(summary, extensionUri, workspaceRoot, stubBridge, mainBranch);
+				mockStoreSummary.mockClear();
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "conversationDetach", hash: "abc123", sessionId: "s1", source: "claude" });
+				await flushPromises();
+
+				const written = mockStoreSummary.mock.calls.at(-1)?.[0] as CommitSummary;
+				expect(written.children?.[0].transcripts).toEqual([]);
 			});
 
 			it("openConversation opens the archived transcript in a read-only ConversationDetailsPanel", async () => {
@@ -11552,6 +12142,34 @@ describe("SummaryWebviewPanel", () => {
 				expect(mockStoreSummary).not.toHaveBeenCalled();
 			});
 
+			it("filters a GRANDCHILD's transcript ids and leaves unrelated nodes by reference", async () => {
+				// The removal walks the whole tree because the shape it is called on is the one
+				// where the root index is NOT the tree-wide list it is supposed to be. Nodes
+				// that list nothing to remove keep their identity, so the write carries no
+				// gratuitous churn and the caller's reference check stays meaningful.
+				await openPanel();
+				const panel = firstCommitPanel<{
+					persistTranscriptIdRemoval(
+						summary: CommitSummary,
+						idsToRemove: ReadonlySet<string>,
+					): Promise<CommitSummary>;
+				}>();
+				const grandchild = makeSummary({ commitHash: "gc", version: 5, transcripts: ["dead", "live"] });
+				const sibling = makeSummary({ commitHash: "sib", version: 5, transcripts: ["live"], children: [] });
+				const parent = makeSummary({ commitHash: "p", version: 5, transcripts: ["live"], children: [grandchild] });
+				const summary = makeSummary({ version: 5, transcripts: ["live"], children: [parent, sibling] });
+				mockStoreSummary.mockClear();
+
+				const result = await panel.persistTranscriptIdRemoval(summary, new Set(["dead"]));
+
+				expect(result.children?.[0].children?.[0].transcripts).toEqual(["live"]);
+				// The parent itself listed nothing to drop — only its `children` field is new.
+				expect(result.children?.[0].transcripts).toEqual(["live"]);
+				expect(result.children?.[1]).toBe(sibling);
+				expect(result.transcripts).toEqual(["live"]);
+				expect(mockStoreSummary).toHaveBeenCalledTimes(1);
+			});
+
 			describe("no-summary early returns", () => {
 				it("editRecap returns early when currentSummary is null", async () => {
 					const dispatch = await openPanelThenClearSummary();
@@ -12579,6 +13197,35 @@ describe("SummaryWebviewPanel", () => {
 				// own foreign guard is exercised.
 				await instance.handleConversationDetach("abc123", "s1", "claude");
 
+				expect(showInformationMessage).toHaveBeenCalledWith(
+					expect.stringContaining("disabled"),
+				);
+			});
+
+			it("handleRecomputeUsage denies a foreign-repo panel at the handler level", async () => {
+				await SummaryWebviewPanel.show(
+					makeSummary(),
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+					"memory",
+					"other-repo",
+					"https://github.com/x/foreign.git",
+				);
+				const instance = (
+					SummaryWebviewPanel as unknown as {
+						currentMemoryPanel: { handleRecomputeUsage: () => Promise<void> };
+					}
+				).currentMemoryPanel;
+				mockStoreSummary.mockClear();
+
+				// Direct call bypasses the dispatch-level foreign gate so the handler's own
+				// guard is exercised: the recompute writes to the orphan branch, which for a
+				// foreign-origin memory would be the WRONG repo's branch.
+				await instance.handleRecomputeUsage();
+
+				expect(mockStoreSummary).not.toHaveBeenCalled();
 				expect(showInformationMessage).toHaveBeenCalledWith(
 					expect.stringContaining("disabled"),
 				);

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -22,6 +22,10 @@ import { randomBytes } from "node:crypto";
 import * as vscode from "vscode";
 import { execFileSyncHidden } from "../../../cli/src/util/Subprocess.js";
 import {
+	type RecomputeSession,
+	recomputeConversationUsage,
+} from "../../../cli/src/core/ConversationUsageRecompute.js";
+import {
 	type DetachedSessionUsage,
 	subtractDetachedUsage,
 } from "../../../cli/src/core/DetachedUsageSubtraction.js";
@@ -129,7 +133,7 @@ import { ConversationDetailsPanel } from "./ConversationDetailsPanel.js";
 import { buildPanelTitle, collectSortedTopics, formatActiveProviderLabel } from "./SummaryUtils.js";
 import type { RegenerateContext } from "../../../cli/src/core/RegenerateContext.js";
 import { isSummaryError } from "../../../cli/src/core/SummaryErrorMarker.js";
-import { getTranscriptIds } from "../../../cli/src/core/SummaryTree.js";
+import { getTranscriptIds, resolveTranscriptIdsForUsage } from "../../../cli/src/core/SummaryTree.js";
 import type { LlmConfig } from "../../../cli/src/Types.js";
 
 const SHARE_KINDS = new Set<ShareKind>(["branch", "commit"]);
@@ -293,6 +297,13 @@ type WebviewMessage =
 			sessionId: string;
 			source: TranscriptSource;
 	  }
+	/**
+	 * Re-derives this memory's token / cost figures from its archived transcripts.
+	 * The user-reachable escape hatch for a figure that has gone stale — a detach
+	 * whose summary write was lost, or any other drift from the per-session usage the
+	 * transcripts record. Idempotent, so pressing it twice is harmless.
+	 */
+	| { command: "recomputeUsage" }
 	| { command: "translatePlan"; slug: string }
 	| { command: "editRecap"; recap: string }
 	| { command: "generateRecap" }
@@ -1106,6 +1117,9 @@ export class SummaryWebviewPanel {
 					this.handleConversationDetach(message.hash, message.sessionId, message.source),
 					"Detach conversation failed",
 				);
+				break;
+			case "recomputeUsage":
+				this.catchAndShow(this.handleRecomputeUsage(), "Recompute token figures failed");
 				break;
 			case "openConversation":
 				this.handleOpenConversation(message.sessionId, message.source).catch((err: unknown) => {
@@ -4350,9 +4364,9 @@ export class SummaryWebviewPanel {
 						? await this.persistTranscriptIdRemoval(summaryToPersist, new Set(deletes))
 						: summaryToPersist;
 				// A same-reference return means the id filter was a no-op and
-				// `persistTranscriptIdRemoval` wrote NOTHING — which happens when the root's
-				// `transcripts` list is empty because a CHILD node claims the detached id (the
-				// helper only inspects the root). The correction then still owes its own write;
+				// `persistTranscriptIdRemoval` wrote NOTHING — which happens when no node in the
+				// tree lists the detached id at all (a legacy summary whose file-backed set is
+				// empty, or a v5 tree whose arrays never named it). The correction still owes a write;
 				// without this the panel would publish a correction that never reached disk.
 				// Only the correction needs that rescue write: a no-op id filter with no
 				// correction to carry has nothing to persist.
@@ -4363,21 +4377,27 @@ export class SummaryWebviewPanel {
 				usageChanged = correctedSummary !== undefined;
 			} catch (err) {
 				log.warn(
-					"Detach succeeded but the summary could not be updated — transcript ids may dangle and the meter stays stale: %s",
+					"Detach succeeded but the summary could not be updated — transcript ids may dangle and the meter is stale; re-deriving from the surviving transcripts: %s",
 					err instanceof Error ? err.message : String(err),
 				);
-				// Surface it. The write is not retried and the outcome is NOT recoverable:
-				// the sessions are already gone from the transcript files, so a second attempt
-				// finds nothing to remove (`removedAny` false → plain ack) and the subtrahend
-				// this run held in memory is unrecoverable — `subtractDetachedUsage` is fed
+				// The subtraction this run held in memory is now unrecoverable: it was fed
 				// from the removed sessions' own stored `usage`, which is only readable while
-				// they are still in the files. Regenerate does not help either: it carries
-				// `conversationTokens` over verbatim (see Regenerator) rather than recomputing
-				// from transcripts. So the figures stay permanently high by the detached
-				// conversation's share, and a log line the user never opens is not an honest
-				// way to report that. The row is still acked below — the files really did
-				// change, and leaving the row on screen would only invite that no-op retry.
-				if (correctedSummary) {
+				// they are still in the files, and a retry finds nothing to remove
+				// (`removedAny` false → plain ack). Deriving the figures from the sessions
+				// that are LEFT needs no subtrahend, so it recovers the same correction from
+				// the other side — and it doubles as the fix for the dangling ids, since the
+				// heal writes the filtered id list too.
+				const healed = await this.selfHealUsageAfterFailedDetach();
+				if (healed) {
+					usageChanged = true;
+				} else if (correctedSummary) {
+					// Nothing else can repair it now: the heal is forward-only, so a memory
+					// with a usage-less archived session (pre-v5 file, or a source that
+					// reports none) legitimately has no derivable figure. The figures stay
+					// high by the detached conversation's share, and a log line the user
+					// never opens is not an honest way to report that. The row is still
+					// acked below — the files really did change, and leaving the row on
+					// screen would only invite that no-op retry.
 					vscode.window.showWarningMessage(
 						"Conversation detached, but this memory's token and cost figures could not be updated — they still include the detached conversation. See the Jolli Memory log for details.",
 					);
@@ -4398,13 +4418,276 @@ export class SummaryWebviewPanel {
 			// meter in place instead of rebuilding the whole panel (which would collapse
 			// scroll position and expanded sections for a single-row change). Omitted
 			// when nothing was attributable — the meter then keeps its current value.
-			...(usageChanged && this.currentSummary && { tokenMeterHtml: buildTokenMeter(this.currentSummary) }),
+			// `showRecompute` matches what the initial render emitted: this handler only
+			// runs on a writable panel (foreign is denied above), so the replacement
+			// markup must carry the action too or the swap would silently drop the button.
+			...(usageChanged &&
+				this.currentSummary && { tokenMeterHtml: buildTokenMeter(this.currentSummary, { showRecompute: true }) }),
 		});
 	}
 
 	/**
-	 * Removes the given transcript IDs from `summary.transcripts` and persists
-	 * the updated summary via `storeSummary(force=true)`. Returns the new
+	 * Re-derives this memory's conversation token / cost figures from the transcript
+	 * files that are on the orphan branch right now, and persists the result.
+	 *
+	 * A derivation rather than an adjustment, which is what makes it usable as both a
+	 * self-heal and a user-pressable button: it needs no record of what changed, and
+	 * running it on already-correct figures writes nothing (see
+	 * `recomputeConversationUsage`, which is idempotent and forward-only — a node
+	 * whose evidence is incomplete keeps its stored figures).
+	 *
+	 * Dangling ids (listed by a v5 summary, no file on disk) are dropped in the SAME
+	 * write. They are the other half of a lost detach write, so healing the figures
+	 * without them would leave the memory referencing transcripts that no longer exist.
+	 */
+	private async recomputeAndPersistUsage(): Promise<{
+		changed: boolean;
+		skipped: ReadonlyArray<string>;
+		/**
+		 * The subset of `skipped` that was skipped for lack of a readable transcript
+		 * rather than for lack of recorded usage in one. Two different facts about the
+		 * memory, so the caller reports them differently.
+		 */
+		unread: ReadonlyArray<string>;
+		/** Stale transcript ids dropped from the summary by this run. */
+		danglingRemoved: number;
+		/**
+		 * How many transcripts the derivation had to read. Zero means there was nothing
+		 * to derive FROM — distinct from "derived and unchanged", which is why the caller
+		 * can tell the user which of the two happened.
+		 */
+		evidenceCount: number;
+	}> {
+		const summary = this.currentSummary;
+		if (!summary) {
+			return { changed: false, skipped: [], unread: [], danglingRemoved: 0, evidenceCount: 0 };
+		}
+		const { evidence, danglingIds, unreadIds } = await this.readUsageEvidence(summary);
+		const recomputed = recomputeConversationUsage(summary, evidence);
+		const unread = recomputed.skipped.filter((id) => unreadIds.has(id));
+		if (!recomputed.changed && danglingIds.size === 0) {
+			return {
+				changed: false,
+				skipped: recomputed.skipped,
+				unread,
+				danglingRemoved: 0,
+				evidenceCount: evidence.size,
+			};
+		}
+
+		const persisted =
+			danglingIds.size > 0
+				? await this.persistTranscriptIdRemoval(recomputed.summary, danglingIds)
+				: recomputed.summary;
+		// Same rescue write the detach path needs, and here it is the ONLY write path for
+		// the common case: with no dangling ids there is no removal to fold the correction
+		// into, so `persisted` is the un-persisted recompute. It also covers a removal that
+		// turned out to be a no-op (no node listed any dangling id).
+		if (recomputed.changed && persisted === recomputed.summary) {
+			await this.bridge.storeSummary(recomputed.summary, true);
+		}
+		this.currentSummary = persisted;
+		await this.refreshTranscriptHashes(persisted);
+		return {
+			changed: recomputed.changed,
+			skipped: recomputed.skipped,
+			unread,
+			// Counted off the WRITE, not off `danglingIds`: a same-reference return means no
+			// node listed any of them, so reporting a removal would tell the user about a
+			// write that never happened. Now that the filter walks the whole tree, every id
+			// the read side saw listed does get dropped, so the count is exact rather than an
+			// upper bound on what the root happened to carry.
+			danglingRemoved: persisted !== recomputed.summary ? danglingIds.size : 0,
+			evidenceCount: evidence.size,
+		};
+	}
+
+	/**
+	 * Reads the transcript files this memory references and shapes them into
+	 * `recomputeConversationUsage` evidence: transcript id → the sessions that file
+	 * holds right now.
+	 *
+	 * Read failures are deliberately NOT swallowed here. `refreshTranscriptHashes`
+	 * falls back to an empty set because an incomplete list only under-renders the
+	 * panel; here the same fallback would look exactly like "every transcript file is
+	 * gone" and the recompute would strip usage the memory still has. The caller
+	 * aborts on a throw instead.
+	 *
+	 * The ids come from `resolveTranscriptIdsForUsage` — the union over every node's
+	 * `transcripts` array, not the root's index alone. The derivation attributes per
+	 * node, so an id only a CHILD lists would otherwise go unread and that child would
+	 * be skipped; the detach path already treats "root index empty, child claims the
+	 * id" as a shape that occurs (see its rescue write), which is precisely when a
+	 * repair is being asked for.
+	 *
+	 * A **v5** id with no file on disk maps to `[]`: that id list is authoritative and
+	 * file-backed by construction, so an absent file means the transcript really was
+	 * deleted (a detach that emptied it) — the case the self-heal exists for. That
+	 * inference assumes detach is the only writer that can leave the pair
+	 * inconsistent, which holds because every other path writes the files BEFORE the
+	 * id list; a future path that writes the id list first would make an absent file
+	 * mean "never written", and mapping it to `[]` would then strip usage the memory
+	 * legitimately has. On a legacy summary the same absence means nothing at all,
+	 * since the ids are commit hashes there and most commits never had an AI session;
+	 * those ids are left OUT of the evidence, so their owner keeps its stored figures
+	 * instead of being zeroed.
+	 *
+	 * @returns `unreadIds` — ids that were listed but produced no evidence (no file on
+	 *   a legacy summary, or a file that could not be parsed). Their owners keep their
+	 *   stored figures, and the caller words its report on "could not read" rather than
+	 *   on "records no usage", which is a different fact about the memory.
+	 */
+	private async readUsageEvidence(summary: CommitSummary): Promise<{
+		evidence: Map<string, ReadonlyArray<RecomputeSession>>;
+		danglingIds: Set<string>;
+		unreadIds: Set<string>;
+	}> {
+		const ids = resolveTranscriptIdsForUsage(summary);
+		const fileIds = await this.bridge.getTranscriptHashes();
+		const present = ids.filter((id) => fileIds.has(id));
+		const danglingIds = new Set(summary.transcripts !== undefined ? ids.filter((id) => !fileIds.has(id)) : []);
+		const transcripts = await this.bridge.readTranscriptsForCommits(present);
+
+		const evidence = new Map<string, ReadonlyArray<RecomputeSession>>();
+		for (const id of danglingIds) evidence.set(id, []);
+		for (const id of present) {
+			const stored = transcripts.get(id);
+			// An unreadable or unparsable file is "unknown", never "empty" — omitting it
+			// makes its owner skip, storing `[]` would wipe that owner's figures.
+			if (stored) evidence.set(id, stored.sessions);
+		}
+		const unreadIds = new Set(ids.filter((id) => !evidence.has(id)));
+		return { evidence, danglingIds, unreadIds };
+	}
+
+	/**
+	 * Last-resort recovery for the detach failure that used to be permanent (the
+	 * transcript files already changed, the summary write was lost). Never throws: it
+	 * runs inside the detach's own failure handler, whose next step is to warn the
+	 * user, so a second failure must not replace that warning with an error toast.
+	 *
+	 * @returns true when the figures were re-derived and persisted.
+	 */
+	private async selfHealUsageAfterFailedDetach(): Promise<boolean> {
+		try {
+			const outcome = await this.recomputeAndPersistUsage();
+			if (outcome.changed) {
+				log.info("SummaryPanel", "Detach: token figures re-derived from the surviving transcripts");
+			} else if (outcome.skipped.length > 0) {
+				log.info(
+					"SummaryPanel",
+					`Detach: cannot re-derive token figures — ${
+						outcome.unread.length > 0 ? "unreadable transcript(s)" : "no recorded per-session usage"
+					} for: ${outcome.skipped.join(", ")}`,
+				);
+			}
+			return outcome.changed;
+		} catch (err) {
+			log.warn(
+				"SummaryPanel",
+				`Detach: re-deriving the token figures failed too, figures stay stale: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			);
+			return false;
+		}
+	}
+
+	/**
+	 * The manual entry point behind the token meter's recompute button: re-derives the
+	 * figures on demand for a memory whose numbers are already stale — a detach whose
+	 * summary write was lost before the self-heal existed, or any other drift between
+	 * the stored aggregate and the per-session usage the transcripts record. No other
+	 * path repairs those without also re-running the LLM (regenerate).
+	 *
+	 * It does NOT repair the pre-dedup inflated history: those memories predate
+	 * `StoredSession.usage` entirely, so there is nothing to derive from and the button
+	 * reports exactly that (see `ConversationUsageRecompute`'s header).
+	 *
+	 * Always reports an outcome. A silent no-op reads as a broken button, and a partial
+	 * derivation the user isn't told about reads as a settled figure.
+	 */
+	private async handleRecomputeUsage(): Promise<void> {
+		if (this.foreignRepoName) {
+			this.notifyForeignDenied("recomputeUsage");
+			return;
+		}
+		// Same stale-commit guard the transcript write handlers use: after an
+		// amend/rebase this panel's hashes point at the orphaned tree, and writing
+		// would correct the wrong commit's figures.
+		if (!(await this.ensureCommitNotRewritten("recompute token figures"))) {
+			return;
+		}
+
+		const outcome = await this.recomputeAndPersistUsage();
+		// Appended to whichever branch reports, not owned by one: a dangling-id drop is a
+		// write the user must hear about even when the headline is "some conversations were
+		// skipped". Unreachable in the `evidenceCount === 0` branch, since dangling ids are
+		// themselves evidence entries (mapped to `[]`).
+		const droppedNote =
+			outcome.danglingRemoved > 0
+				? ` Dropped ${outcome.danglingRemoved} stale conversation reference${
+						outcome.danglingRemoved === 1 ? "" : "s"
+					}.`
+				: "";
+		if (outcome.skipped.length > 0) {
+			log.info("SummaryPanel", `Recompute: figures left as-is for transcript(s): ${outcome.skipped.join(", ")}`);
+			const count = outcome.skipped.length;
+			const plural = count === 1 ? "" : "s";
+			// Two distinct reasons, reported as such: an unreadable archive is a
+			// this-machine problem the user may be able to fix, while a readable archive
+			// with no recorded usage is a permanent property of when the memory was
+			// written. Collapsing both into "carries no recorded usage" told the user the
+			// wrong thing about half of them.
+			const subject =
+				outcome.unread.length > 0
+					? `${count} archived conversation${plural} on this memory could not be read`
+					: `${count} archived conversation${plural} on this memory ${
+							count === 1 ? "carries" : "carry"
+						} no recorded per-conversation usage`;
+			// A tree can skip one owner node and still re-derive another, so `skipped` and
+			// `changed` co-occur. Reporting only "left as they are" then contradicts the meter
+			// the user watches change underneath the toast — the figures WERE updated, just
+			// not the share these conversations account for.
+			void vscode.window.showInformationMessage(
+				`${
+					outcome.changed
+						? `Token and cost figures were partly updated: ${subject}, so the share covering ${
+								count === 1 ? "it" : "them"
+							} was left as it is.`
+						: `${subject}, so its token and cost figures were left as they are.`
+				}${droppedNote}${outcome.unread.length > 0 ? " See the Jolli Memory log for details." : ""}`,
+			);
+		} else if (outcome.evidenceCount === 0) {
+			// Nothing to derive FROM. The common case is a pre-v5 memory, whose transcript
+			// ids are commit hashes with no files behind them — reporting "already match"
+			// there would claim the figures were verified when nothing was read.
+			void vscode.window.showInformationMessage(
+				"This memory has no archived conversations to derive token and cost figures from.",
+			);
+		} else if (!outcome.changed) {
+			// A dangling-id cleanup with no figure change still WROTE. Saying only "already
+			// match" would hide that the memory was modified, and the Conversations card
+			// silently losing a row then looks like a bug.
+			void vscode.window.showInformationMessage(
+				`Token and cost figures already match the stored conversations.${droppedNote}`,
+			);
+		}
+		if (outcome.changed && this.currentSummary) {
+			this.panel.webview.postMessage({
+				command: "usageRecomputed",
+				// Swapped in place rather than rebuilt whole, for the same reason the detach
+				// ack carries the meter: a full rebuild collapses scroll position and every
+				// expanded section for what is a one-element change.
+				// Keeps the action in the replacement markup — see the detach ack above.
+				tokenMeterHtml: buildTokenMeter(this.currentSummary, { showRecompute: true }),
+			});
+		}
+	}
+
+	/**
+	 * Removes the given transcript IDs from **every** node's `transcripts` array and
+	 * persists the updated summary via `storeSummary(force=true)`. Returns the new
 	 * summary on success; **throws** on `storeSummary` failure so callers can
 	 * surface the abort decision (e.g. skip the file delete that would otherwise
 	 * leave a half-migration state).
@@ -4424,9 +4707,19 @@ export class SummaryWebviewPanel {
 	 *     just-deleted IDs via the legacy fallback and stamp them onto the new
 	 *     v5 root.
 	 *
-	 * No-op (returns same reference) when nothing references any of the
-	 * removal IDs — both for empty v5 arrays and for legacy summaries whose
-	 * file-backed set is empty.
+	 * **Descendants are filtered too, and that is not defensive breadth.** The root
+	 * index is *supposed* to re-list every descendant id, but the shape this helper
+	 * is called on is precisely the one where it doesn't — a lost detach write leaves
+	 * the root's array empty (or short) while a CHILD still claims the id. Filtering
+	 * the root alone then reports success, drops the child's usage, and leaves the
+	 * dead id on disk: the next press finds the figures already corrected, writes
+	 * nothing, and tells the user everything matches while the stale reference
+	 * survives forever. Mirrors the read side, which resolves ids tree-wide via
+	 * `resolveTranscriptIdsForUsage` for the same reason.
+	 *
+	 * No-op (returns same reference) when no node references any of the removal IDs —
+	 * both for empty v5 arrays and for legacy summaries whose file-backed set is
+	 * empty.
 	 */
 	private async persistTranscriptIdRemoval(
 		summary: CommitSummary,
@@ -4438,16 +4731,14 @@ export class SummaryWebviewPanel {
 		// the file-backed set the migration would produce — using it avoids
 		// re-baking dangling IDs. v5: the array is authoritative.
 		const current = isLegacy ? [...this.transcriptHashSet] : (summary.transcripts ?? []);
-		if (current.length === 0) {
-			return summary;
-		}
 		const filtered = current.filter((id) => !idsToRemove.has(id));
-		// Fast-path: nothing removed AND already v5-shaped → return as-is.
-		// Legacy summaries still need a write even when `filtered.length ===
-		// current.length` would normally short-circuit, because the legacy
-		// summary itself doesn't have a `transcripts` field / `version: 5` —
-		// writing it is the lazy-upgrade.
-		if (!isLegacy && filtered.length === current.length) {
+		// Legacy summaries need a write even when the filter removed nothing, because
+		// the legacy summary itself doesn't have a `transcripts` field / `version: 5`
+		// — writing it IS the lazy upgrade. The one exception is an empty file-backed
+		// set: there is no id list to upgrade and nothing to remove.
+		const rootChanged = isLegacy ? current.length > 0 : filtered.length !== current.length;
+		const children = removeTranscriptIdsFromChildren(summary.children, idsToRemove);
+		if (!rootChanged && children === summary.children) {
 			return summary;
 		}
 		// Write back as a real v5 record: stamp `version: 5` AND the
@@ -4456,13 +4747,56 @@ export class SummaryWebviewPanel {
 		// the version keeps the on-disk record from being a "version<5 but has
 		// transcripts" hybrid that a future version-routing read path would
 		// misclassify.
-		const updated: CommitSummary = { ...summary, version: CURRENT_SCHEMA_VERSION, transcripts: filtered };
+		const updated: CommitSummary = {
+			...summary,
+			version: CURRENT_SCHEMA_VERSION,
+			transcripts: filtered,
+			...(children !== summary.children && { children }),
+		};
 		await this.bridge.storeSummary(updated, true);
 		return updated;
 	}
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Filters `idsToRemove` out of every descendant's own `transcripts` array,
+ * returning the SAME array reference when no descendant listed any of them — the
+ * caller uses reference identity to decide whether a write is owed at all.
+ *
+ * Only the array is rewritten: a child's `version` is deliberately left alone. The
+ * v5 migration hoists ids to the root and never stamps descendants, so a child's
+ * version records the schema it was written under and nothing routes reads off it.
+ * Bumping it here would claim a migration that didn't happen. A child with no
+ * `transcripts` field is likewise left untouched rather than given an empty array —
+ * the field's absence is what marks it as pre-v5-nested.
+ */
+function removeTranscriptIdsFromChildren(
+	children: ReadonlyArray<CommitSummary> | undefined,
+	idsToRemove: ReadonlySet<string>,
+): ReadonlyArray<CommitSummary> | undefined {
+	if (!children || children.length === 0) {
+		return children;
+	}
+	let changed = false;
+	const next = children.map((child) => {
+		const own = child.transcripts;
+		const filteredOwn = own?.filter((id) => !idsToRemove.has(id));
+		const ownChanged = own !== undefined && filteredOwn !== undefined && filteredOwn.length !== own.length;
+		const grandchildren = removeTranscriptIdsFromChildren(child.children, idsToRemove);
+		if (!ownChanged && grandchildren === child.children) {
+			return child;
+		}
+		changed = true;
+		return {
+			...child,
+			...(ownChanged && { transcripts: filteredOwn }),
+			...(grandchildren !== child.children && { children: grandchildren }),
+		};
+	});
+	return changed ? next : children;
+}
 
 /**
  * Deep-equal comparison for two CommitSummary objects via JSON serialization.


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The developer added a recompute action to the editor's memory panel that derives a memory's conversation token and cost figures fresh from the transcripts it owns. A circular button on the token meter triggers the recalculation for any writable memory, works from both the reported and "not reported" states, and reports its outcome — figures changed, already matching, or nothing to derive from. When a conversation-detach save fails, the panel now heals itself by re-reading the surviving transcripts and rebuilding the figures, and dangling conversation references are cleaned up in the same write.

The derivation sums the sessions in the transcripts each memory owns and is idempotent: running it twice never changes the result, a property that also makes it a safe way to backfill figures inflated by an older counting bug. Partial per-model pricing is preserved, and the recalculation stays conservative — memories with incomplete evidence keep their stored numbers untouched. On migrated legacy trees, ownership is resolved structurally and corrections land on the node that actually counted the tokens.

Regenerate now also re-derives the usage figures from the archived conversations on every run. The panel reports archives that could not be read and conversations that carry no usage with distinct messages, pointing the user to the right next step.

---

## Topics (3)
<details>
<summary><strong>01 · Recompute token and cost figures by deriving them from owned transcripts, idempotently</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a conversation was detached from a memory, a failed save could leave the memory's token and cost figures permanently stale, and memories written before an earlier de-duplication fix carried inflated counts. Both problems needed a way to re-derive the figures from the sessions a memory actually owns.

**💡 Decisions Behind the Code**

- **Derive instead of subtract**: the previous approach corrected figures by subtracting a detached session's stored usage once, which was unrecoverable after a failed write and could not fix pre-dedup inflation. Summing what survives needs no record of what changed, is idempotent, and therefore serves both the post-failure self-heal and a one-off backfill of stale history.
- **Ownership is structural, not a field**: the consolidated root's transcript list is a tree-wide index rather than a per-node ownership record, and tree aggregation walks root and children, so summing a child's sessions into the root would double-count. Ownership is resolved by tree structure, and on v5-migrated legacy trees the commit-hash match is consulted first so the child that actually counted the tokens keeps the correction.
- **Forward-only and conservative**: a node with any session lacking usage, or an owned id missing from the evidence, is skipped whole rather than partially derived — protecting legacy memories from being zeroed. Some genuinely stale figures stay untouched, and callers surface that explicitly instead of inventing a number that reads as settled truth.
- **Match the write path's rule exactly**: the earlier gate dropped the per-model split and cost unless every session reported a model, so a first button press would have deleted a legitimately stored cost on a healthy mixed-source memory. Deriving under the same rule the writer uses is what makes the feature genuinely idempotent; the under-statement of a partial split is a property of the evidence, identical on both paths. Change detection fingerprints projected values rather than whole stored objects, so a different key order on disk never flags an unchanged node as changed.
- **Gather evidence across the whole tree, not the root index**: ownership is resolved per node, so reading only the root's id list leaves child-listed ids unread and the recompute skips exactly the child a lost write left broken. The union is a superset of the old read on well-formed trees and equal to it elsewhere, so the conversations fed to regeneration can only gain the sessions a malformed index was hiding.

**✅ What Was Implemented**

- New `TranscriptOwnership.ts` resolves which single tree node owns a transcript id, consulting two evidence sources in order: the deepest node that lists the id (a claim), then a node whose commit hash matches the id (the filename), which rescues v5-migrated legacy trees where the root indexes every descendant hash. Ids that cannot be pinned to exactly one node are reported unresolved, never guessed.
- New `ConversationUsageRecompute.ts` sums the sessions in the transcripts each node owns to derive `conversationTokens`, `conversationTokenBreakdown`, `conversationModels`, `estimatedCostUsd` and `pricesAsOf`. It is idempotent and forward-only: a node with any usage-less session, a missing evidence entry, or ambiguous ownership is left exactly as-is with blocking ids returned in `skipped`; a node owning no surviving sessions gets its whole usage group stripped (absent, not zero).
- Dropped the gate that discarded `conversationModels` and `estimatedCostUsd` unless every owned session reported a model: `deriveUsageFields` now stores and prices whatever partial split exists, matching the write path in `cli/src/hooks/QueueWorker`. Cost is still always re-derived from the models, never scaled from the stored figure.
- `SummaryTree.ts` gained `collectListedTranscriptIds` (union of every node's `transcripts` array) and `resolveTranscriptIdsForUsage` (union with fallback to the legacy commit-hash walk). The recompute module's interest set, `Regenerator.ts`, and `SummaryWebviewPanel.ts` now gather evidence through these helpers, so a child-listed id the root index omits is attributed and repaired instead of skipped.
- Projected `conversationTokenBreakdown` to a positional tuple in `usageFingerprint` so stored key order no longer flags an unchanged node as changed; the module header now documents that pre-dedup inflated history is deliberately not repaired (those memories predate `StoredSession.usage` and the forward-only gate skips them).

**📁 FILES**
- `cli/src/core/TranscriptOwnership.ts`
- `cli/src/core/ConversationUsageRecompute.ts`
- `cli/src/core/SummaryTree.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Add detach self-heal and a manual recompute button for stale token figures in the editor panel</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The token meter in the editor panel could stay permanently stale when a conversation-detach save failed, and users had no way to repair figures inflated by the old counting bug.

**💡 Decisions Behind the Code**

- **Heal from surviving evidence instead of retrying**: a retry of the subtraction finds nothing to remove once the sessions are gone from the files, so the panel re-derives from what is left — recovering the same correction from the other side and cleaning up dangling ids in one write. The manual entry point was deliberately limited to a panel action, with no CLI subcommand.
- **One button for two problems**: the manual recompute covers both the lost-detach-write case and pre-dedup inflation, since both reduce to the same derivation over the transcripts. Being idempotent makes pressing it twice harmless, and it always reports an outcome so a no-op does not read as a broken button.
- **Reachable from the "not reported" state**: a memory whose figures were wrongly stripped is exactly the one a user needs to re-derive, so the action renders in both meter states. Read-only and foreign-repo panels never show it, since the handler writes to the orphan branch and would target the wrong repo's branch for a foreign memory.
- **Distinguish unreadable from usage-less**: an unreadable archive is a this-machine problem the user may be able to fix, while a readable archive with no recorded usage is a permanent property of when the memory was written; collapsing both into one message told the user the wrong thing about half of them. Separate wording keeps the user's next action accurate — fix locally versus accept the figure.
- **Count dropped references off the write, not the dangling set**: when nothing else changed, the panel persists the summary by reference, so counting the stale-id set would announce a cleanup write that never happened and make a preserved tree look modified.

**✅ What Was Implemented**

- `SummaryWebviewPanel.ts` now self-heals after a failed detach summary write: it re-reads the surviving transcripts, re-derives the usage figures, drops dangling transcript ids in the same write, and only shows the previous warning when the self-heal also fails. It gathers its evidence tree-wide through the shared resolve helpers.
- A new `recomputeUsage` message and `handleRecomputeUsage` handler back a circular recompute button added to the token meter, present in both the reported and "not reported" states but only rendered on writable panels; foreign-repo panels deny it at the handler level. Outcomes are reported distinctly: figures changed (meter swapped in place), already match, or no archived conversations to derive from.
- `readUsageEvidence` now returns `unreadIds` alongside evidence and `danglingIds`; `recomputeAndPersistUsage` threads these through as `unread` and `danglingRemoved`, the latter counted off the actual write (`persisted !== recomputed.summary`) rather than off `danglingIds`. The handler and self-heal log now report "could not be read" for unread transcripts, and the "already match" message appends "Dropped N stale conversation reference(s)" when a cleanup actually wrote.
- The panel script gained a shared `swapTokenMeter` helper used by both the detach ack and the recompute reply so a swapped-in meter keeps its buttons live, with the recompute button re-bound inside the meter re-init; `SummaryHtmlBuilder` gained `buildRecomputeAction` and `SummaryCssBuilder` the button styles.
- Removed the per-file `vi.setConfig({ hookTimeout: 45_000 })` clamp in `vscode/src/JolliMemoryBridge.integration.test.ts`: `vi.setConfig` replaces the vitest.config.ts 60s value rather than widening it, so the clamp timed out only under full-suite CPU load — green in isolation, indistinguishable from a flake. The file now relies on the global config.

**📁 FILES**
- `vscode/src/views/SummaryWebviewPanel.ts`
- `vscode/src/views/SummaryHtmlBuilder.ts`
- `vscode/src/views/SummaryScriptBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Fix silent detach-correction loss on migrated trees and re-derive usage on regenerate</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The correction applied when a conversation was detached could silently disappear on migrated legacy trees, and a full regenerate simply carried the stored token totals forward, leaving no path to repair inflated or stale figures.

**💡 Decisions Behind the Code**

- **Extract ownership into one shared module**: the subtraction module's header had documented the v5-tree hazard as a known latent limitation; routing it through the shared resolver fixed the silent-loss bug as a side effect. Keeping one resolver for all consumers avoids the cost and drift of per-module copies.
- **Regenerate is a natural healing path**: it already rebuilds every other field from the archive, so re-deriving usage there removes the need to remember a separate repair step. It stays forward-only, so legacy memories without per-session usage are untouched.

**✅ What Was Implemented**

- `DetachedUsageSubtraction.ts` now resolves ownership through the shared `TranscriptOwnership` resolver; on a v5-migrated tree the subtraction lands on the child node that actually counted the tokens, fixing a silent bug where the correction vanished with `changed:false` and an empty `unattributed` list.
- `Regenerator.ts` no longer carries `conversationTokens` over verbatim: it feeds the transcripts it just read into `recomputeConversationUsage` so regenerate also re-derives the usage group, preserving the stored figures (with a debug log) when the evidence is incomplete — for example a pre-v5 file with no per-session usage.

**📁 FILES**
- `cli/src/core/DetachedUsageSubtraction.ts`
- `cli/src/core/Regenerator.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 4, 2026 at 1:08 PM · via Local agent - OpenCode*
<!-- jollimemory-summary-end -->
