### PR TITLE
Preview Context snapshots as rendered markdown, not untitled buffers

### DIFF
--- a/cli/src/core/SkillsAggregateMarkdown.ts
+++ b/cli/src/core/SkillsAggregateMarkdown.ts
@@ -144,9 +144,9 @@ export function buildSkillsAggregateMarkdown(summary: CommitSummary, skills: Rea
  * VS Code sidebar's single aggregate Context row opens.
  *
  * No frontmatter and no commit hash, because neither exists yet: this is a view
- * of the working registry, not a stored artifact, and it is opened as an untitled
- * document rather than written to disk. Once the work is committed the same rows
- * reappear as `skills--<hash8>.md` with the commit's identity attached.
+ * of the working registry, not a stored artifact, and it is rendered into a
+ * virtual document rather than written to disk. Once the work is committed the
+ * same rows reappear as `skills--<hash8>.md` with the commit's identity attached.
  */
 export function buildLiveSkillsMarkdown(skills: ReadonlyArray<SkillTableRow>): string {
 	const lines: string[] = [

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -293,6 +293,10 @@ const {
 			sourceRemoteUrl: null,
 		}),
 		listPlans: vi.fn().mockResolvedValue([]),
+		// Working skill registry behind openSkillsAggregate. Empty by default:
+		// the command short-circuits with an information message, which is what
+		// most tests touching it want.
+		listSkills: vi.fn().mockResolvedValue([]),
 		removePlan: vi.fn().mockResolvedValue(undefined),
 		listNotes: vi.fn().mockResolvedValue([]),
 		removeNote: vi.fn().mockResolvedValue(undefined),
@@ -1146,6 +1150,7 @@ vi.mock("node:timers", () => ({
 
 import * as vscode from "vscode";
 import { runCopyBranchRecallPrompt, runRecallInClaudeCode } from "./commands/BranchRecallCommands.js";
+import { encodePreviewRef } from "./core/PreviewUri.js";
 import { activate, deactivate } from "./Extension.js";
 import { activateExtensionTelemetry, reinitExtensionTelemetry } from "./TelemetryActivation.js";
 import { loadBranchSummaries } from "./views/BranchSummaryLoader.js";
@@ -2668,10 +2673,11 @@ describe("Extension", () => {
 				expect(mockBridge.previewReferenceMarkdown).not.toHaveBeenCalled();
 			});
 
-			it("previewCommittedReference: reads the archived snapshot off the orphan branch and opens an untitled doc", async () => {
+			it("previewCommittedReference: reads the archived snapshot off the orphan branch and renders it", async () => {
 				readReferenceFromBranch.mockResolvedValueOnce("# PROJ-1\nArchived snapshot body");
 				openTextDocument.mockClear();
 				showTextDocument.mockClear();
+				executeCommand.mockClear();
 
 				const handler = getRegisteredCommand(
 					"jollimemory.previewCommittedReference",
@@ -2686,10 +2692,81 @@ describe("Extension", () => {
 					expect.anything(),
 					undefined,
 				);
+				// A named virtual document, then the rendered preview — never a raw
+				// text editor over an unnamed, dirty-on-birth untitled buffer.
 				expect(openTextDocument).toHaveBeenCalledWith(
-					expect.objectContaining({ language: "markdown", content: "# PROJ-1\nArchived snapshot body" }),
+					expect.objectContaining({
+						scheme: "jollimemory-archived",
+						path: "/linear-PROJ-1-ab12cd34.md",
+					}),
 				);
-				expect(showTextDocument).toHaveBeenCalled();
+				expect(executeCommand).toHaveBeenCalledWith(
+					"markdown.showPreview",
+					expect.objectContaining({ scheme: "jollimemory-archived" }),
+				);
+				expect(showTextDocument).not.toHaveBeenCalled();
+			});
+
+			// Both skills commands render an in-memory table. They previously opened it
+			// as an untitled document, which VS Code names `Untitled-1`, marks dirty on
+			// creation (so closing prompts to save), and shows as raw markdown source
+			// rather than the rendered table the clicked row promises.
+			it("openSkillsAggregate: previews the live table under its own name", async () => {
+				mockBridge.listSkills.mockResolvedValueOnce([
+					{ skill: "brainstorming", invocationCount: 2 },
+				]);
+				openTextDocument.mockClear();
+				showTextDocument.mockClear();
+				executeCommand.mockClear();
+
+				const handler = getRegisteredCommand("jollimemory.openSkillsAggregate");
+				await handler();
+
+				expect(openTextDocument).toHaveBeenCalledWith(
+					expect.objectContaining({
+						scheme: "jollimemory-archived",
+						path: "/Skills used — uncommitted.md",
+					}),
+				);
+				expect(executeCommand).toHaveBeenCalledWith(
+					"markdown.showPreview",
+					expect.objectContaining({ scheme: "jollimemory-archived" }),
+				);
+				expect(showTextDocument).not.toHaveBeenCalled();
+			});
+
+			it("previewCommittedSkills: previews the archived table titled by short hash", async () => {
+				mockBridge.getSummaryAnyRepoWithSource.mockResolvedValueOnce({
+					summary: {
+						commitHash: "ab12cd34ef567890",
+						branch: "feature/x",
+						generatedAt: "2026-08-05T00:00:00.000Z",
+						commitMessage: "Add the thing",
+						skills: [{ skill: "brainstorming", invocationCount: 1 }],
+					},
+					sourceRepoName: null,
+					sourceRemoteUrl: null,
+				} as never);
+				openTextDocument.mockClear();
+				showTextDocument.mockClear();
+				executeCommand.mockClear();
+
+				const handler = getRegisteredCommand(
+					"jollimemory.previewCommittedSkills",
+				);
+				await handler("ab12cd34ef567890");
+
+				expect(openTextDocument).toHaveBeenCalledWith(
+					expect.objectContaining({
+						scheme: "jollimemory-archived",
+						path: "/Skills used — ab12cd34.md",
+					}),
+				);
+				expect(executeCommand).toHaveBeenCalledWith(
+					"markdown.showPreview",
+					expect.objectContaining({ scheme: "jollimemory-archived" }),
+				);
+				expect(showTextDocument).not.toHaveBeenCalled();
 			});
 
 			it("previewCommittedReference: threads foreign FolderStorage when foreignRepoName is set", async () => {
@@ -2728,6 +2805,190 @@ describe("Extension", () => {
 					expect.stringContaining("linear:GONE-1"),
 				);
 				expect(openTextDocument).not.toHaveBeenCalled();
+			});
+
+			it("previewCommittedReference: names the tab after the title the sidebar passes", async () => {
+				// The sidebar's evidence row used to pass no title, so its tab was named
+				// after the storage key while the SAME snapshot opened from the memory
+				// detail panel got the real title — one snapshot, two differently-named
+				// tabs.
+				readReferenceFromBranch.mockResolvedValueOnce("# body");
+				openTextDocument.mockClear();
+
+				const handler = getRegisteredCommand(
+					"jollimemory.previewCommittedReference",
+				);
+				await handler(
+					"linear:PROJ-1-ab12cd34",
+					"linear",
+					null,
+					null,
+					"Fix the login redirect",
+				);
+
+				expect(openTextDocument).toHaveBeenCalledWith(
+					expect.objectContaining({ path: "/Fix the login redirect.md" }),
+				);
+			});
+
+			// The archived scheme's content provider — third registration, after plan
+			// and note. These cover the RE-READ path: VS Code restores a preview tab
+			// after a window reload and asks for a body the extension host no longer
+			// caches, so everything here must come back from source.
+			describe("archived snapshot re-read", () => {
+				function archivedProvider(): {
+					provideTextDocumentContent: (uri: {
+						query: string;
+					}) => Promise<string>;
+				} {
+					const call = registerTextDocumentContentProvider.mock.calls[2] as
+						| [
+								string,
+								{
+									provideTextDocumentContent: (uri: {
+										query: string;
+									}) => Promise<string>;
+								},
+						  ]
+						| undefined;
+					if (!call) throw new Error("archived provider was never registered");
+					return call[1];
+				}
+
+				it("re-renders the live skills table", async () => {
+					mockBridge.listSkills.mockResolvedValueOnce([
+						{ skill: "brainstorming", invocationCount: 2 },
+					]);
+
+					const body = await archivedProvider().provideTextDocumentContent({
+						query: encodePreviewRef({ ns: "skills-live" }),
+					});
+
+					expect(body).toContain("brainstorming");
+				});
+
+				it("reports the live table as unavailable once the registry is empty", async () => {
+					mockBridge.listSkills.mockResolvedValueOnce([]);
+
+					const body = await archivedProvider().provideTextDocumentContent({
+						query: encodePreviewRef({ ns: "skills-live" }),
+					});
+
+					expect(body).toContain("no longer available");
+				});
+
+				it("re-renders a committed skills table from the summary", async () => {
+					mockBridge.getSummaryAnyRepoWithSource.mockResolvedValueOnce({
+						summary: {
+							commitHash: "ab12cd34ef567890",
+							branch: "feature/x",
+							generatedAt: "2026-08-05T00:00:00.000Z",
+							commitMessage: "Add the thing",
+							skills: [{ skill: "writing-plans", invocationCount: 1 }],
+						},
+						sourceRepoName: null,
+						sourceRemoteUrl: null,
+					} as never);
+
+					const body = await archivedProvider().provideTextDocumentContent({
+						query: encodePreviewRef({
+							ns: "skills",
+							commitHash: "ab12cd34ef567890",
+						}),
+					});
+
+					expect(body).toContain("writing-plans");
+				});
+
+				it("reports a squashed-away commit as unavailable", async () => {
+					mockBridge.getSummaryAnyRepoWithSource.mockResolvedValueOnce({
+						summary: null,
+						sourceRepoName: null,
+						sourceRemoteUrl: null,
+					} as never);
+
+					const body = await archivedProvider().provideTextDocumentContent({
+						query: encodePreviewRef({ ns: "skills", commitHash: "deadbeef" }),
+					});
+
+					expect(body).toContain("no longer available");
+				});
+
+				it("re-reads a reference off the orphan branch and promotes its frontmatter", async () => {
+					readReferenceFromBranch.mockResolvedValueOnce(
+						[
+							"---",
+							'source: "linear"',
+							'nativeId: "PROJ-1"',
+							'title: "Fix the login redirect"',
+							'url: "https://linear.app/acme/issue/PROJ-1"',
+							'referencedAt: "2026-08-05T09:30:00.000Z"',
+							'sourceToolName: "get_issue"',
+							"---",
+							"",
+							"Body.",
+						].join("\n"),
+					);
+
+					const body = await archivedProvider().provideTextDocumentContent({
+						query: encodePreviewRef({
+							ns: "reference",
+							source: "linear",
+							archivedKey: "linear:PROJ-1-ab12cd34",
+						}),
+					});
+
+					// The rewrite has to happen on the re-read too — otherwise a restored
+					// tab silently loses the link line the first render had.
+					expect(body).toContain(
+						"[https://linear.app/acme/issue/PROJ-1](https://linear.app/acme/issue/PROJ-1)",
+					);
+					expect(body).toContain("Body.");
+				});
+
+				it("rebuilds a foreign repo's storage from the provenance in the ref", async () => {
+					// Nothing but the URI survives the reload, so the storage cannot be
+					// carried over — it has to be reconstructed from name + url.
+					mockBridge.createStorageForRepo.mockResolvedValueOnce({
+						storage: { tag: "foreign-storage" },
+					} as never);
+					readReferenceFromBranch.mockResolvedValueOnce("# body");
+
+					await archivedProvider().provideTextDocumentContent({
+						query: encodePreviewRef({
+							ns: "reference",
+							source: "linear",
+							archivedKey: "linear:PROJ-9-ffe1",
+							repoName: "other-repo",
+							remoteUrl: "https://github.com/org/other-repo",
+						}),
+					});
+
+					expect(mockBridge.createStorageForRepo).toHaveBeenCalledWith(
+						"other-repo",
+						"https://github.com/org/other-repo",
+					);
+					expect(readReferenceFromBranch).toHaveBeenCalledWith(
+						"linear",
+						"linear:PROJ-9-ffe1",
+						expect.anything(),
+						{ tag: "foreign-storage" },
+					);
+				});
+
+				it("reports an unarchived reference as unavailable", async () => {
+					readReferenceFromBranch.mockResolvedValueOnce(null);
+
+					const body = await archivedProvider().provideTextDocumentContent({
+						query: encodePreviewRef({
+							ns: "reference",
+							source: "linear",
+							archivedKey: "linear:GONE-1",
+						}),
+					});
+
+					expect(body).toContain("no longer available");
+				});
 			});
 
 			it("ignoreReference: marks the entity ignored and refreshes plans", async () => {
@@ -3332,10 +3593,14 @@ describe("Extension", () => {
 					| undefined;
 				expect(provider).toBeDefined();
 				expect(
-					provider?.provideTextDocumentContent({ query: "id=note-1" }),
+					provider?.provideTextDocumentContent({
+						query: encodePreviewRef({ id: "note-1" }),
+					}),
 				).toBe("# Note content");
 				expect(
-					provider?.provideTextDocumentContent({ query: "id=missing" }),
+					provider?.provideTextDocumentContent({
+						query: encodePreviewRef({ id: "missing" }),
+					}),
 				).toBe("# Note not found");
 				expect(provider?.provideTextDocumentContent({ query: "" })).toBe(
 					"# Note not found",
@@ -3459,10 +3724,14 @@ describe("Extension", () => {
 					| undefined;
 				expect(provider).toBeDefined();
 				expect(
-					provider?.provideTextDocumentContent({ query: "slug=my-plan" }),
+					provider?.provideTextDocumentContent({
+						query: encodePreviewRef({ slug: "my-plan" }),
+					}),
 				).toBe("# Plan content");
 				expect(
-					provider?.provideTextDocumentContent({ query: "slug=missing" }),
+					provider?.provideTextDocumentContent({
+						query: encodePreviewRef({ slug: "missing" }),
+					}),
 				).toBe("# Plan not found");
 				expect(provider?.provideTextDocumentContent({ query: "" })).toBe(
 					"# Plan not found",
@@ -4068,10 +4337,14 @@ describe("Extension", () => {
 					| undefined;
 				expect(provider).toBeDefined();
 				expect(
-					provider?.provideTextDocumentContent({ query: "id=note-abc" }),
+					provider?.provideTextDocumentContent({
+						query: encodePreviewRef({ id: "note-abc" }),
+					}),
 				).toBe("# Note content");
 				expect(
-					provider?.provideTextDocumentContent({ query: "id=missing" }),
+					provider?.provideTextDocumentContent({
+						query: encodePreviewRef({ id: "missing" }),
+					}),
 				).toBe("# Note not found");
 				expect(provider?.provideTextDocumentContent({ query: "" })).toBe(
 					"# Note not found",

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -82,6 +82,12 @@ import {
 	selectAllPlansAndNotesCommand,
 } from "./commands/SelectAllSelection.js";
 import { SquashCommand } from "./commands/SquashCommand.js";
+import {
+	registerArchivedMarkdownPreview,
+	showArchivedMarkdownPreview,
+} from "./core/ArchivedMarkdownPreview.js";
+import { decodePreviewRef, encodePreviewRef, sanitizeTitleForUriPath } from "./core/PreviewUri.js";
+import { renderReferenceForPreview } from "./core/ReferencePreviewMarkdown.js";
 import { getNotesDir } from "./core/NoteService.js";
 import {
 	addPlanToRegistry,
@@ -554,7 +560,7 @@ export function activate(context: vscode.ExtensionContext): void {
 			this._onDidChange.fire(uri);
 		}
 		provideTextDocumentContent(uri: vscode.Uri): string {
-			const slug = new URLSearchParams(uri.query).get("slug") ?? "";
+			const slug = decodePreviewRef(uri.query)?.slug ?? "";
 			log.info(
 				"cmd",
 				`provideTextDocumentContent: slug="${slug}", found=${this.contents.has(slug)}`,
@@ -589,19 +595,15 @@ export function activate(context: vscode.ExtensionContext): void {
 			);
 			return;
 		}
-		const safeTitle = title.replace(/[/\\:*?"<>|#%&{}]/g, "-").substring(0, 80);
 		// Uri.from() correctly separates query from path (Uri.parse treats ?key=val as path for opaque URIs).
 		const uri = vscode.Uri.from({
 			scheme: PLAN_SCHEME,
-			path: `/${safeTitle}.md`,
-			query: `slug=${encodeURIComponent(slug)}`,
+			path: `/${sanitizeTitleForUriPath(title)}.md`,
+			query: encodePreviewRef({ slug }),
 		});
 		// Set content and fire onDidChange to invalidate any cached virtual document.
 		planContentProvider.setContent(slug, content, uri);
-		// Load virtual document (triggers provideTextDocumentContent) without showing a raw text tab.
-		await vscode.workspace.openTextDocument(uri);
-		// Open only the rendered markdown preview.
-		await vscode.commands.executeCommand("markdown.showPreview", uri);
+		await openRenderedPreview(uri);
 	}
 
 	// ── Note readonly preview ───────────────────────────────────────────────
@@ -618,7 +620,7 @@ export function activate(context: vscode.ExtensionContext): void {
 			this._onDidChange.fire(uri);
 		}
 		provideTextDocumentContent(uri: vscode.Uri): string {
-			const id = new URLSearchParams(uri.query).get("id") ?? "";
+			const id = decodePreviewRef(uri.query)?.id ?? "";
 			log.info(
 				"cmd",
 				`provideTextDocumentContent (note): id="${id}", found=${this.contents.has(id)}`,
@@ -649,15 +651,88 @@ export function activate(context: vscode.ExtensionContext): void {
 			);
 			return;
 		}
-		const safeTitle = title.replace(/[/\\:*?"<>|#%&{}]/g, "-").substring(0, 80);
 		const uri = vscode.Uri.from({
 			scheme: NOTE_SCHEME,
-			path: `/${safeTitle}.md`,
-			query: `id=${encodeURIComponent(id)}`,
+			path: `/${sanitizeTitleForUriPath(title)}.md`,
+			query: encodePreviewRef({ id }),
 		});
 		noteContentProvider.setContent(id, content, uri);
-		await vscode.workspace.openTextDocument(uri);
-		await vscode.commands.executeCommand("markdown.showPreview", uri);
+		await openRenderedPreview(uri);
+	}
+
+	// ── In-memory snapshot previews (skills aggregate, archived references) ──
+	// Third registration, after plan and note — Extension.test.ts reaches for those
+	// two providers by registration index.
+	//
+	// The resolver is what lets a preview tab survive a window reload: VS Code
+	// restores the tab and re-asks the provider for a body the extension host no
+	// longer has cached. Every snapshot this scheme serves is recomputable, so the
+	// miss is re-read here rather than shown as a dead page.
+	context.subscriptions.push(
+		registerArchivedMarkdownPreview(async (ref) => {
+			if (ref.ns === "skills-live") {
+				const skills = await bridge.listSkills();
+				return skills.length > 0 ? buildLiveSkillsMarkdown(skills) : undefined;
+			}
+			if (ref.ns === "skills") {
+				const { summary } = await bridge.getSummaryAnyRepoWithSource(
+					ref.commitHash,
+				);
+				if (!summary || (summary.skills?.length ?? 0) === 0) return undefined;
+				return buildSkillsAggregateMarkdown(summary, summary.skills ?? []);
+			}
+			return await readReferenceForPreview(
+				ref.source as SourceId,
+				ref.archivedKey,
+				ref.repoName ?? null,
+				ref.remoteUrl ?? null,
+			);
+		}),
+	);
+
+	/**
+	 * Reads an archived reference snapshot and prepares it for RENDERED display.
+	 *
+	 * Single entry point on purpose: the frontmatter-to-header rewrite has to happen
+	 * on the first open and on every re-read after a reload, and doing it at only one
+	 * of the two would make a restored tab lose its link line.
+	 */
+	async function readReferenceForPreview(
+		source: SourceId,
+		archivedKey: string,
+		foreignRepoName: string | null,
+		foreignRepoUrl: string | null,
+	): Promise<string | undefined> {
+		const readStorageResult = foreignRepoName
+			? await bridge.createStorageForRepo(foreignRepoName, foreignRepoUrl)
+			: null;
+		const content = await readReferenceFromBranch(
+			source,
+			archivedKey,
+			workspaceRoot,
+			readStorageResult?.storage,
+		);
+		return content ? renderReferenceForPreview(content) : undefined;
+	}
+
+	/**
+	 * Loads a virtual document (so its provider is asked for content) and opens only
+	 * the rendered markdown preview — never a raw text tab.
+	 *
+	 * `markdown.showPreview` comes from the built-in markdown-language-features
+	 * extension. A user who disabled it would otherwise see a bare
+	 * "command 'markdown.showPreview' not found".
+	 */
+	async function openRenderedPreview(uri: vscode.Uri): Promise<void> {
+		try {
+			await vscode.workspace.openTextDocument(uri);
+			await vscode.commands.executeCommand("markdown.showPreview", uri);
+		} catch (e) {
+			log.warn("cmd", `openRenderedPreview failed — ${String(e)}`);
+			void vscode.window.showErrorMessage(
+				"Could not open the Markdown preview. The built-in Markdown extension may be disabled.",
+			);
+		}
 	}
 
 	// ── Add note helpers ─────────────────────────────────────────────────────
@@ -3170,7 +3245,7 @@ export function activate(context: vscode.ExtensionContext): void {
 		// Opens the aggregate view of every skill captured but not yet committed —
 		// what the single Context "Skills" row and its hover card both point at.
 		//
-		// Rendered into an UNTITLED document rather than opened from disk. There is no
+		// Rendered into a virtual document rather than opened from disk. There is no
 		// file to open: on disk each skill is its own `skills/<source>/<stem>.md`, and
 		// the aggregate only becomes a real file (`skills--<hash8>.md`) once the work
 		// is committed and the summary's visible layer is written. Rendering through
@@ -3188,11 +3263,11 @@ export function activate(context: vscode.ExtensionContext): void {
 				);
 				return;
 			}
-			const doc = await vscode.workspace.openTextDocument({
-				content: buildLiveSkillsMarkdown(skills),
-				language: "markdown",
-			});
-			await vscode.window.showTextDocument(doc, { preview: true });
+			await showArchivedMarkdownPreview(
+				{ ns: "skills-live" },
+				"Skills used — uncommitted",
+				buildLiveSkillsMarkdown(skills),
+			);
 		}),
 
 		// The COMMITTED counterpart of openSkillsAggregate: the aggregate Context row
@@ -3203,11 +3278,11 @@ export function activate(context: vscode.ExtensionContext): void {
 		// are archived onto the commit, so the live path would open an unrelated (or
 		// empty) table. The archived snapshot on the summary is the only correct source.
 		//
-		// Untitled document rather than the `skills--<hash8>.md` file on disk: that file
-		// exists only in the Memory Bank's visible layer, which is absent in
-		// orphan-branch-only storage mode and for a foreign repo whose folder this
-		// machine may never have seen. Rendering from the summary works in every mode,
-		// and `buildSkillsAggregateMarkdown` is the same renderer that wrote the file.
+		// Rendered from the summary rather than opened from the `skills--<hash8>.md`
+		// file on disk: that file exists only in the Memory Bank's visible layer, which
+		// is absent in orphan-branch-only storage mode and for a foreign repo whose
+		// folder this machine may never have seen. Rendering works in every mode, and
+		// `buildSkillsAggregateMarkdown` is the same renderer that wrote the file.
 		vscode.commands.registerCommand(
 			"jollimemory.previewCommittedSkills",
 			async (
@@ -3229,11 +3304,11 @@ export function activate(context: vscode.ExtensionContext): void {
 					);
 					return;
 				}
-				const doc = await vscode.workspace.openTextDocument({
-					content: buildSkillsAggregateMarkdown(summary, skills),
-					language: "markdown",
-				});
-				await vscode.window.showTextDocument(doc, { preview: true });
+				await showArchivedMarkdownPreview(
+					{ ns: "skills", commitHash },
+					`Skills used — ${commitHash.substring(0, 8)}`,
+					buildSkillsAggregateMarkdown(summary, skills),
+				);
 			},
 		),
 
@@ -3268,32 +3343,41 @@ export function activate(context: vscode.ExtensionContext): void {
 				source: SourceId,
 				foreignRepoName?: string | null,
 				foreignRepoUrl?: string | null,
+				// The reference's human title. Optional so an older caller still works,
+				// but the sidebar passes it — without it the tab is named after the
+				// storage key (`linear-PROJ-1-ab12cd34.md`) while the SAME snapshot
+				// opened from the memory detail panel gets the real title, i.e. one
+				// snapshot showing up as two differently-named tabs.
+				title?: string,
 			) => {
 				log.info("cmd", `previewCommittedReference: ${source}:${archivedKey}`);
 				if (!archivedKey) return;
-				const readStorageResult = foreignRepoName
-					? await bridge.createStorageForRepo(foreignRepoName, foreignRepoUrl ?? null)
-					: null;
-				const content = await readReferenceFromBranch(
+				// Virtual doc — same rationale as plan/note preview elsewhere: never
+				// re-materialize an archived snapshot on the user's disk; the orphan
+				// branch is the source of truth.
+				const body = await readReferenceForPreview(
 					source,
 					archivedKey,
-					workspaceRoot,
-					readStorageResult?.storage,
+					foreignRepoName ?? null,
+					foreignRepoUrl ?? null,
 				);
-				if (!content) {
+				if (!body) {
 					vscode.window.showErrorMessage(
 						`Reference snapshot "${archivedKey}" not found on the orphan branch.`,
 					);
 					return;
 				}
-				// Untitled markdown doc — same rationale as plan/note/reference
-				// preview elsewhere: never re-materialize an archived snapshot on
-				// the user's disk; the orphan branch is the source of truth.
-				const doc = await vscode.workspace.openTextDocument({
-					language: "markdown",
-					content,
-				});
-				await vscode.window.showTextDocument(doc);
+				await showArchivedMarkdownPreview(
+					{
+						ns: "reference",
+						source,
+						archivedKey,
+						...(foreignRepoName ? { repoName: foreignRepoName } : {}),
+						...(foreignRepoUrl ? { remoteUrl: foreignRepoUrl } : {}),
+					},
+					title || archivedKey,
+					body,
+				);
 			},
 		),
 

--- a/vscode/src/core/ArchivedMarkdownPreview.test.ts
+++ b/vscode/src/core/ArchivedMarkdownPreview.test.ts
@@ -1,0 +1,511 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+	mockRegisterTextDocumentContentProvider,
+	mockOpenTextDocument,
+	mockExecuteCommand,
+	mockShowErrorMessage,
+	mockFire,
+	mockRegistrationDispose,
+	mockEmitterDispose,
+} = vi.hoisted(() => ({
+	mockRegisterTextDocumentContentProvider: vi.fn(),
+	mockOpenTextDocument: vi.fn(),
+	mockExecuteCommand: vi.fn(),
+	mockShowErrorMessage: vi.fn(),
+	mockFire: vi.fn(),
+	mockRegistrationDispose: vi.fn(),
+	mockEmitterDispose: vi.fn(),
+}));
+
+vi.mock("vscode", () => ({
+	Uri: {
+		// Mirrors what Uri.from gives the production code: the scheme/path/query
+		// triple, plus a stringification the provider never parses back.
+		from: vi.fn((parts: { scheme: string; path: string; query: string }) => ({
+			...parts,
+			toString: () => `${parts.scheme}:${parts.path}?${parts.query}`,
+		})),
+	},
+	EventEmitter: class {
+		event = vi.fn();
+		fire = mockFire;
+		dispose = mockEmitterDispose;
+	},
+	workspace: {
+		registerTextDocumentContentProvider: mockRegisterTextDocumentContentProvider,
+		openTextDocument: mockOpenTextDocument,
+	},
+	commands: { executeCommand: mockExecuteCommand },
+	window: {
+		showErrorMessage: mockShowErrorMessage,
+		createOutputChannel: vi.fn(() => ({
+			appendLine: vi.fn(),
+			append: vi.fn(),
+			show: vi.fn(),
+			dispose: vi.fn(),
+		})),
+	},
+}));
+
+import { encodePreviewRef } from "./PreviewUri.js";
+
+import {
+	ARCHIVED_MARKDOWN_SCHEME,
+	archivedRefToQuery,
+	type ArchivedSnapshotRef,
+	MAX_CACHED_SNAPSHOT_BODIES,
+	registerArchivedMarkdownPreview,
+	showArchivedMarkdownPreview,
+} from "./ArchivedMarkdownPreview.js";
+
+type Provider = {
+	provideTextDocumentContent: (uri: { query: string }) => Promise<string>;
+};
+
+/** Every disposable handed out in a test, torn down in afterEach. */
+const opened: Array<{ dispose: () => void }> = [];
+
+/**
+ * Registers the provider with `resolver` and returns what VS Code was handed.
+ *
+ * Registration is idempotent, so calling this twice in one test is safe and
+ * yields the same provider — which is exactly what the idempotence test asserts.
+ */
+function register(
+	resolver: (ref: ArchivedSnapshotRef) => Promise<string | undefined> = async () =>
+		undefined,
+): Provider {
+	opened.push(registerArchivedMarkdownPreview(resolver));
+	const call = mockRegisterTextDocumentContentProvider.mock.calls.at(-1) as
+		| [string, Provider]
+		| undefined;
+	if (!call) throw new Error("provider was never registered");
+	return call[1];
+}
+
+/** The Uri.from argument of the most recent preview. */
+function lastUriParts(): { scheme: string; path: string; query: string } {
+	const call = mockOpenTextDocument.mock.calls.at(-1) as
+		| [{ scheme: string; path: string; query: string }]
+		| undefined;
+	if (!call) throw new Error("no document was opened");
+	return call[0];
+}
+
+const REF_SKILLS_LIVE: ArchivedSnapshotRef = { ns: "skills-live" };
+const REF_LINEAR: ArchivedSnapshotRef = {
+	ns: "reference",
+	source: "linear",
+	archivedKey: "linear:PROJ-1-aaaaaaaa",
+};
+const referenceRef = (n: number): ArchivedSnapshotRef => ({
+	ns: "reference",
+	source: "linear",
+	archivedKey: `linear:PROJ-${n}-aaaaaaaa`,
+});
+
+describe("ArchivedMarkdownPreview", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockRegisterTextDocumentContentProvider.mockReturnValue({
+			dispose: mockRegistrationDispose,
+		});
+	});
+
+	// Every test starts from a clean module — no ordering dependency, so the file
+	// is safe under --sequence.shuffle and under someone moving a case.
+	afterEach(() => {
+		for (const d of opened.splice(0)) d.dispose();
+	});
+
+	describe("registerArchivedMarkdownPreview", () => {
+		it("registers the provider under the archived scheme", () => {
+			register();
+
+			expect(mockRegisterTextDocumentContentProvider).toHaveBeenCalledWith(
+				ARCHIVED_MARKDOWN_SCHEME,
+				expect.objectContaining({
+					provideTextDocumentContent: expect.any(Function),
+				}),
+			);
+		});
+
+		it("replaces the live registration instead of stacking a second one", () => {
+			const first = registerArchivedMarkdownPreview(async () => undefined);
+			opened.push(registerArchivedMarkdownPreview(async () => undefined));
+
+			// Two registrations on one scheme would simply coexist — VS Code does not
+			// swap providers for you. Registering twice used to overwrite the
+			// module-level emitter while leaving the first registration alive, so
+			// disposing the FIRST handle nulled the emitter out from under the second:
+			// `fire` short-circuited and every open preview froze on its first body.
+			expect(mockRegistrationDispose).toHaveBeenCalledTimes(1);
+			expect(mockRegisterTextDocumentContentProvider).toHaveBeenCalledTimes(2);
+
+			// The superseded handle is inert — disposing it must not take the live
+			// registration down with it.
+			first.dispose();
+			expect(mockRegistrationDispose).toHaveBeenCalledTimes(1);
+		});
+
+		it("serves through the resolver handed to the newest registration", async () => {
+			register();
+			const provider = register(async () => "# from the second resolver");
+
+			await expect(
+				provider.provideTextDocumentContent({
+					query: archivedRefToQuery(REF_SKILLS_LIVE),
+				}),
+			).resolves.toBe("# from the second resolver");
+		});
+	});
+
+	describe("showArchivedMarkdownPreview", () => {
+		it("opens the rendered markdown preview, never a raw text editor", async () => {
+			register();
+
+			await showArchivedMarkdownPreview(REF_SKILLS_LIVE, "Skills used", "# table");
+
+			// The document is loaded only so the provider is asked for content; the
+			// visible surface must be markdown.showPreview, not showTextDocument.
+			expect(lastUriParts().scheme).toBe(ARCHIVED_MARKDOWN_SCHEME);
+			expect(mockExecuteCommand).toHaveBeenCalledWith(
+				"markdown.showPreview",
+				expect.objectContaining({ scheme: ARCHIVED_MARKDOWN_SCHEME }),
+			);
+		});
+
+		it("names the tab after the title so it is never an Untitled-N buffer", async () => {
+			register();
+
+			await showArchivedMarkdownPreview(
+				REF_SKILLS_LIVE,
+				"Skills used — uncommitted",
+				"# table",
+			);
+
+			expect(lastUriParts().path).toBe("/Skills used — uncommitted.md");
+		});
+
+		it("carries the self-describing ref in the query", async () => {
+			register();
+
+			await showArchivedMarkdownPreview(REF_LINEAR, "PROJ-1", "# body");
+
+			expect(lastUriParts().query).toBe(
+				encodePreviewRef({
+					ns: "reference",
+					source: "linear",
+					archivedKey: "linear:PROJ-1-aaaaaaaa",
+				}),
+			);
+		});
+
+		it("sanitizes the title into the path segment", async () => {
+			register();
+
+			await showArchivedMarkdownPreview(
+				REF_LINEAR,
+				'feat/thing: #12 "quoted" <b>|{x}',
+				"# body",
+			);
+
+			expect(lastUriParts().path).toBe("/feat-thing- -12 -quoted- -b---x-.md");
+		});
+
+		it("serves the stored body back without consulting the resolver", async () => {
+			const resolver = vi.fn(async () => "# re-read");
+			const provider = register(resolver);
+
+			await showArchivedMarkdownPreview(REF_SKILLS_LIVE, "Skills", "# rows");
+
+			await expect(
+				provider.provideTextDocumentContent({ query: lastUriParts().query }),
+			).resolves.toBe("# rows");
+			expect(resolver).not.toHaveBeenCalled();
+		});
+
+		it("refreshes an already-open preview when the same ref is re-rendered", async () => {
+			const provider = register();
+			await showArchivedMarkdownPreview(REF_SKILLS_LIVE, "Skills", "# one row");
+			const { query } = lastUriParts();
+			mockFire.mockClear();
+
+			await showArchivedMarkdownPreview(REF_SKILLS_LIVE, "Skills", "# two rows");
+
+			// onDidChange is what makes VS Code re-ask; without it the open preview
+			// keeps serving the body it was first opened with.
+			expect(mockFire).toHaveBeenCalledTimes(1);
+			await expect(provider.provideTextDocumentContent({ query })).resolves.toBe(
+				"# two rows",
+			);
+		});
+
+		it("keeps the callers' namespaces apart", async () => {
+			const provider = register();
+
+			await showArchivedMarkdownPreview(REF_SKILLS_LIVE, "Skills", "# skills");
+			const skillsQuery = lastUriParts().query;
+			await showArchivedMarkdownPreview(REF_LINEAR, "PROJ-1", "# linear");
+			const linearQuery = lastUriParts().query;
+
+			expect(skillsQuery).not.toBe(linearQuery);
+			await expect(
+				provider.provideTextDocumentContent({ query: skillsQuery }),
+			).resolves.toBe("# skills");
+			await expect(
+				provider.provideTextDocumentContent({ query: linearQuery }),
+			).resolves.toBe("# linear");
+		});
+
+		it("still opens when nothing is registered yet", async () => {
+			// The emitter only exists once `activate` has run. Firing through an
+			// absent emitter must be a no-op, not a crash.
+			await showArchivedMarkdownPreview(REF_LINEAR, "PROJ-1", "# body");
+
+			expect(mockFire).not.toHaveBeenCalled();
+			expect(mockExecuteCommand).toHaveBeenCalledWith(
+				"markdown.showPreview",
+				expect.anything(),
+			);
+		});
+
+		it("reports a failure to open the preview instead of throwing", async () => {
+			// markdown.showPreview belongs to the built-in markdown-language-features
+			// extension. A user who disabled it gets a real error here, and the raw
+			// "command 'markdown.showPreview' not found" is not actionable.
+			register();
+			mockExecuteCommand.mockRejectedValueOnce(new Error("command not found"));
+
+			await showArchivedMarkdownPreview(REF_LINEAR, "PROJ-1", "# body");
+
+			expect(mockShowErrorMessage).toHaveBeenCalledWith(
+				expect.stringContaining("Markdown preview"),
+			);
+		});
+	});
+
+	describe("provideTextDocumentContent", () => {
+		it("re-reads the snapshot through the resolver on a cache miss", async () => {
+			// The load-bearing case: VS Code restores preview tabs across a window
+			// reload, and the in-memory body cache does not survive the extension
+			// host. Every body this module serves is recomputable, so a miss is a
+			// re-read rather than a dead page.
+			const resolver = vi.fn(async () => "# read back from the orphan branch");
+			const provider = register(resolver);
+
+			const body = await provider.provideTextDocumentContent({
+				query: archivedRefToQuery(REF_LINEAR),
+			});
+
+			expect(body).toBe("# read back from the orphan branch");
+			expect(resolver).toHaveBeenCalledWith(REF_LINEAR);
+		});
+
+		it("caches what the resolver returned so a redraw does not re-read", async () => {
+			const resolver = vi.fn(async () => "# body");
+			const provider = register(resolver);
+			const query = archivedRefToQuery(REF_SKILLS_LIVE);
+
+			await provider.provideTextDocumentContent({ query });
+			await provider.provideTextDocumentContent({ query });
+
+			expect(resolver).toHaveBeenCalledTimes(1);
+		});
+
+		it("threads a foreign repo's provenance back to the resolver", async () => {
+			// A foreign-repo memory's snapshot lives in the OWNING repo's storage.
+			// Provenance has to ride in the ref, because nothing else survives the
+			// reload that caused the miss.
+			const ref: ArchivedSnapshotRef = {
+				ns: "reference",
+				source: "jira",
+				archivedKey: "jira:KAN-9-bbbbbbbb",
+				repoName: "other-repo",
+				remoteUrl: "https://example.test/other-repo.git",
+			};
+			const resolver = vi.fn(async () => "# foreign body");
+			const provider = register(resolver);
+
+			await provider.provideTextDocumentContent({
+				query: archivedRefToQuery(ref),
+			});
+
+			expect(resolver).toHaveBeenCalledWith(ref);
+		});
+
+		it("carries the commit hash for a committed skills table", async () => {
+			const ref: ArchivedSnapshotRef = { ns: "skills", commitHash: "abc12345" };
+			const resolver = vi.fn(async () => "# skills");
+			const provider = register(resolver);
+
+			await provider.provideTextDocumentContent({
+				query: archivedRefToQuery(ref),
+			});
+
+			expect(resolver).toHaveBeenCalledWith(ref);
+		});
+
+		it("explains what to do when the snapshot cannot be re-read", async () => {
+			const provider = register(async () => undefined);
+
+			const body = await provider.provideTextDocumentContent({
+				query: archivedRefToQuery(REF_SKILLS_LIVE),
+			});
+
+			expect(body).toContain("no longer available");
+			expect(body).toContain("Jolli Memory sidebar");
+		});
+
+		it("explains itself for a query carrying no ref at all", async () => {
+			const provider = register();
+
+			await expect(
+				provider.provideTextDocumentContent({ query: "" }),
+			).resolves.toContain("no longer available");
+		});
+
+		it("explains itself for a ref with an unrecognized namespace", async () => {
+			const resolver = vi.fn(async () => "# body");
+			const provider = register(resolver);
+
+			const body = await provider.provideTextDocumentContent({
+				query: encodePreviewRef({ ns: "not-a-namespace" }),
+			});
+
+			expect(body).toContain("no longer available");
+			expect(resolver).not.toHaveBeenCalled();
+		});
+
+		it("explains itself for a reference ref missing its archivedKey", async () => {
+			const resolver = vi.fn(async () => "# body");
+			const provider = register(resolver);
+
+			const body = await provider.provideTextDocumentContent({
+				query: encodePreviewRef({ ns: "reference", source: "linear" }),
+			});
+
+			expect(body).toContain("no longer available");
+			expect(resolver).not.toHaveBeenCalled();
+		});
+
+		it("explains itself for a committed skills ref missing its hash", async () => {
+			const resolver = vi.fn(async () => "# body");
+			const provider = register(resolver);
+
+			const body = await provider.provideTextDocumentContent({
+				query: encodePreviewRef({ ns: "skills" }),
+			});
+
+			expect(body).toContain("no longer available");
+			expect(resolver).not.toHaveBeenCalled();
+		});
+
+		it("explains itself when the resolver throws", async () => {
+			// A foreign-repo storage that no longer resolves, a git failure — the
+			// provider must degrade to the message, not reject the document load.
+			const provider = register(async () => {
+				throw new Error("git show failed");
+			});
+
+			await expect(
+				provider.provideTextDocumentContent({
+					query: archivedRefToQuery(REF_SKILLS_LIVE),
+				}),
+			).resolves.toContain("no longer available");
+		});
+	});
+
+	describe("body cache eviction", () => {
+		it("evicts the least recently used body past the cap", async () => {
+			// Reference snapshots are one per commit per source and a Confluence or
+			// Notion body can be large; browsing the Timeline would otherwise pin
+			// every visited snapshot in the extension host for the whole session.
+			const resolver = vi.fn(async () => "# re-read");
+			const provider = register(resolver);
+
+			for (let n = 0; n <= MAX_CACHED_SNAPSHOT_BODIES; n++) {
+				await showArchivedMarkdownPreview(
+					referenceRef(n),
+					`PROJ-${n}`,
+					`# body ${n}`,
+				);
+			}
+
+			// The oldest fell out and comes back through the resolver...
+			await expect(
+				provider.provideTextDocumentContent({
+					query: archivedRefToQuery(referenceRef(0)),
+				}),
+			).resolves.toBe("# re-read");
+			expect(resolver).toHaveBeenCalledTimes(1);
+			// ...while the newest is still served from memory.
+			await expect(
+				provider.provideTextDocumentContent({
+					query: archivedRefToQuery(referenceRef(MAX_CACHED_SNAPSHOT_BODIES)),
+				}),
+			).resolves.toBe(`# body ${MAX_CACHED_SNAPSHOT_BODIES}`);
+			expect(resolver).toHaveBeenCalledTimes(1);
+		});
+
+		it("counts a read as a use, so an open preview is not evicted behind the user", async () => {
+			// Without this, the tab the user is actually looking at is the one most
+			// likely to be evicted — it was rendered longest ago.
+			const provider = register(async () => "# re-read");
+			const firstQuery = archivedRefToQuery(referenceRef(0));
+
+			await showArchivedMarkdownPreview(referenceRef(0), "PROJ-0", "# body 0");
+			for (let n = 1; n < MAX_CACHED_SNAPSHOT_BODIES; n++) {
+				await showArchivedMarkdownPreview(
+					referenceRef(n),
+					`PROJ-${n}`,
+					`# body ${n}`,
+				);
+				await provider.provideTextDocumentContent({ query: firstQuery });
+			}
+			await showArchivedMarkdownPreview(
+				referenceRef(MAX_CACHED_SNAPSHOT_BODIES),
+				"PROJ-last",
+				"# body last",
+			);
+
+			await expect(
+				provider.provideTextDocumentContent({ query: firstQuery }),
+			).resolves.toBe("# body 0");
+		});
+	});
+
+	describe("dispose", () => {
+		it("tears the registration down and drops every cached body", async () => {
+			const provider = register(async () => undefined);
+			await showArchivedMarkdownPreview(REF_SKILLS_LIVE, "Skills", "# rows");
+			const { query } = lastUriParts();
+
+			for (const d of opened.splice(0)) d.dispose();
+
+			expect(mockRegistrationDispose).toHaveBeenCalledTimes(1);
+			expect(mockEmitterDispose).toHaveBeenCalledTimes(1);
+			await expect(
+				provider.provideTextDocumentContent({ query }),
+			).resolves.toContain("no longer available");
+		});
+
+		it("is safe to call twice", () => {
+			const handle = registerArchivedMarkdownPreview(async () => undefined);
+
+			handle.dispose();
+			handle.dispose();
+
+			expect(mockRegistrationDispose).toHaveBeenCalledTimes(1);
+		});
+
+		it("allows a fresh registration afterwards", () => {
+			registerArchivedMarkdownPreview(async () => undefined).dispose();
+
+			register();
+
+			expect(mockRegisterTextDocumentContentProvider).toHaveBeenCalledTimes(2);
+		});
+	});
+});

--- a/vscode/src/core/ArchivedMarkdownPreview.ts
+++ b/vscode/src/core/ArchivedMarkdownPreview.ts
@@ -1,0 +1,272 @@
+/**
+ * ArchivedMarkdownPreview
+ *
+ * One virtual-document scheme backing every read-only markdown preview whose body is
+ * *rendered in memory* rather than read from a file on disk: the skills aggregate and
+ * archived reference snapshots.
+ *
+ * Why not an untitled document (what these surfaces used to open): an untitled buffer
+ * has no name and no backing file, so VS Code titles it `Untitled-1` and treats it as
+ * dirty from birth — closing it prompts to save content the user never authored. And
+ * `showTextDocument` on it lands on raw markdown source, not the rendered table the
+ * clicked row promises.
+ *
+ * Why not a real file: these snapshots must never be re-materialized on the user's
+ * disk. The orphan branch is the system of record; the Memory Bank's visible layer is
+ * absent in orphan-branch-only storage mode and for a foreign repo whose folder this
+ * machine may never have seen.
+ *
+ * A `TextDocumentContentProvider` is the only option that gets all three: a named tab,
+ * a document VS Code knows is provider-backed (never dirty, no save prompt), and a URI
+ * that `markdown.showPreview` accepts.
+ *
+ * **The URI is the whole state.** An untitled buffer's content is backed up and
+ * restored by VS Code's hot exit; a provider-backed one's is not — VS Code restores
+ * the preview *tab* after a window reload and asks this provider for the body again,
+ * long after the extension host that cached it died. So the URI query carries a
+ * self-describing {@link ArchivedSnapshotRef} rather than an opaque cache key, and a
+ * miss is re-read through the resolver registered by `activate`. Every body served
+ * here is recomputable (the working skill registry, a summary, the orphan branch),
+ * which is also what makes the LRU cap below safe.
+ *
+ * Mirrors the plan / note preview providers in `Extension.ts`, which read their bodies
+ * from the orphan branch and so keep their own scheme per entity.
+ */
+
+import * as vscode from "vscode";
+import { log } from "../util/Logger.js";
+import {
+	decodePreviewRef,
+	encodePreviewRef,
+	type PreviewRef,
+	sanitizeTitleForUriPath,
+} from "./PreviewUri.js";
+
+export const ARCHIVED_MARKDOWN_SCHEME = "jollimemory-archived";
+
+/**
+ * Everything needed to re-render a snapshot from scratch, carried in the URI.
+ *
+ * Deliberately no `repoName` on `skills`: `previewCommittedSkills` resolves a
+ * commit through `getSummaryAnyRepoWithSource`, which already searches every known
+ * repo by hash. Only the reference namespace needs provenance to find its storage.
+ */
+export type ArchivedSnapshotRef =
+	/** The working skill registry — not yet committed, so keyed by nothing. */
+	| { readonly ns: "skills-live" }
+	/** The skills table archived onto one commit. */
+	| { readonly ns: "skills"; readonly commitHash: string }
+	/** One archived reference snapshot on the orphan branch. */
+	| {
+			readonly ns: "reference";
+			readonly source: string;
+			readonly archivedKey: string;
+			readonly repoName?: string;
+			readonly remoteUrl?: string;
+	  };
+
+/**
+ * Re-renders a snapshot whose body is no longer cached. Registered once by
+ * `activate`, which owns the bridge and workspace root this needs.
+ *
+ * Returns `undefined` when the snapshot genuinely no longer exists (squashed
+ * commit, unarchived reference); the provider then serves the explanatory body.
+ */
+export type ArchivedSnapshotResolver = (
+	ref: ArchivedSnapshotRef,
+) => Promise<string | undefined>;
+
+/**
+ * How many snapshot bodies stay in memory.
+ *
+ * Bounded because reference snapshots are one per commit per source and a
+ * Confluence or Notion body can be large — browsing the Timeline would otherwise
+ * pin every visited snapshot in the extension host for the whole session. Safe to
+ * evict precisely because a miss re-reads: the cost of being wrong is one
+ * `git show`, not a dead tab.
+ */
+export const MAX_CACHED_SNAPSHOT_BODIES = 24;
+
+/** Served when the body is neither cached nor recoverable. */
+const UNAVAILABLE_BODY = [
+	"# Snapshot no longer available",
+	"",
+	"This preview's content could not be re-read. That is expected after the",
+	"memory it belongs to was squashed, amended, or removed.",
+	"",
+	"Open the row again from the Jolli Memory sidebar to render a fresh preview.",
+	"",
+].join("\n");
+
+/**
+ * Bodies keyed by the URI query, in least-recently-used order (a `Map` iterates in
+ * insertion order, and every use re-inserts). Module-level rather than per-panel:
+ * `SummaryWebviewPanel` is disposed and recreated freely, and a preview tab outlives
+ * the panel that opened it — VS Code will re-ask the provider for content long after.
+ */
+const contents = new Map<string, string>();
+
+/**
+ * The live registration, or `undefined` before `activate` and after dispose.
+ *
+ * Held as one object rather than loose module variables so a repeat registration
+ * cannot half-replace it. The previous shape overwrote the emitter while leaving the
+ * first registration alive, and disposing the first handle then nulled the emitter out
+ * from under the second — `fire` silently short-circuited and every open preview froze
+ * on the body it was first opened with.
+ */
+let state:
+	| {
+			readonly handle: vscode.Disposable;
+			readonly emitter: vscode.EventEmitter<vscode.Uri>;
+			resolver: ArchivedSnapshotResolver;
+	  }
+	| undefined;
+
+/** The URI query for `ref` — also its cache key, so the two can never disagree. */
+export function archivedRefToQuery(ref: ArchivedSnapshotRef): string {
+	return encodePreviewRef(ref as PreviewRef);
+}
+
+/**
+ * Rebuilds an {@link ArchivedSnapshotRef} from a URI query, or `undefined` if the
+ * query is absent, truncated, or names a namespace this module does not serve.
+ */
+function queryToArchivedRef(query: string): ArchivedSnapshotRef | undefined {
+	const raw = decodePreviewRef(query);
+	if (!raw) return undefined;
+	if (raw.ns === "skills-live") return { ns: "skills-live" };
+	if (raw.ns === "skills") {
+		return raw.commitHash ? { ns: "skills", commitHash: raw.commitHash } : undefined;
+	}
+	if (raw.ns === "reference") {
+		if (!raw.source || !raw.archivedKey) return undefined;
+		return {
+			ns: "reference",
+			source: raw.source,
+			archivedKey: raw.archivedKey,
+			...(raw.repoName ? { repoName: raw.repoName } : {}),
+			...(raw.remoteUrl ? { remoteUrl: raw.remoteUrl } : {}),
+		};
+	}
+	return undefined;
+}
+
+/** Stores `body` under `query` as the most recently used entry, evicting past the cap. */
+function cacheBody(query: string, body: string): void {
+	contents.delete(query);
+	contents.set(query, body);
+	while (contents.size > MAX_CACHED_SNAPSHOT_BODIES) {
+		// `keys().next()` is the least recently used: every read and write re-inserts.
+		const oldest = contents.keys().next();
+		/* v8 ignore start -- unreachable: the loop condition already proves size > 0, so the iterator always yields. */
+		if (oldest.done) break;
+		/* v8 ignore stop */
+		contents.delete(oldest.value);
+	}
+}
+
+async function provideTextDocumentContent(uri: { query: string }): Promise<string> {
+	const cached = contents.get(uri.query);
+	if (cached !== undefined) {
+		// Reading counts as a use: without this the tab the user is actually looking
+		// at is the one most likely to be evicted, having been rendered longest ago.
+		cacheBody(uri.query, cached);
+		return cached;
+	}
+	const ref = queryToArchivedRef(uri.query);
+	if (!ref || !state) {
+		log.info("cmd", `provideTextDocumentContent (archived): unrecoverable query`);
+		return UNAVAILABLE_BODY;
+	}
+	log.info("cmd", `provideTextDocumentContent (archived): re-reading ${ref.ns}`);
+	try {
+		const body = await state.resolver(ref);
+		if (body === undefined) return UNAVAILABLE_BODY;
+		cacheBody(uri.query, body);
+		return body;
+	} catch (e) {
+		log.warn(
+			"cmd",
+			`provideTextDocumentContent (archived): re-read failed — ${String(e)}`,
+		);
+		return UNAVAILABLE_BODY;
+	}
+}
+
+/**
+ * Registers the scheme. Call once from `activate`; push the result onto subscriptions.
+ *
+ * A repeat call REPLACES the live registration rather than stacking a second one:
+ * VS Code does not swap providers for you, so two registrations on one scheme would
+ * simply coexist with VS Code picking a winner. The previous shape overwrote the
+ * module-level emitter while leaving the first registration alive, which meant
+ * disposing the first handle nulled the emitter out from under the second — `fire`
+ * silently short-circuited and every open preview froze on its first body.
+ *
+ * Handles are self-checking, so disposing a superseded one (or the same one twice)
+ * is a no-op rather than tearing down the live registration.
+ */
+export function registerArchivedMarkdownPreview(
+	resolver: ArchivedSnapshotResolver,
+): vscode.Disposable {
+	state?.handle.dispose();
+	const emitter = new vscode.EventEmitter<vscode.Uri>();
+	const registration = vscode.workspace.registerTextDocumentContentProvider(
+		ARCHIVED_MARKDOWN_SCHEME,
+		{ onDidChange: emitter.event, provideTextDocumentContent },
+	);
+	const handle: vscode.Disposable = {
+		dispose(): void {
+			// Guard the double-dispose: `context.subscriptions` and a test teardown can
+			// both hold this handle.
+			if (state?.handle !== handle) return;
+			state = undefined;
+			registration.dispose();
+			emitter.dispose();
+			contents.clear();
+		},
+	};
+	state = { handle, emitter, resolver };
+	return handle;
+}
+
+/**
+ * Opens `content` as a rendered, read-only markdown preview titled `title`.
+ *
+ * `ref` identifies the snapshot and is what the provider re-reads from after a
+ * reload. Re-opening the same ref rewrites its cache entry and fires `onDidChange`,
+ * so an already-open preview refreshes in place rather than serving the body it was
+ * first opened with — load-bearing for the uncommitted skills table, whose rows keep
+ * growing during a session.
+ */
+export async function showArchivedMarkdownPreview(
+	ref: ArchivedSnapshotRef,
+	title: string,
+	content: string,
+): Promise<void> {
+	const query = archivedRefToQuery(ref);
+	// Uri.from() correctly separates query from path (Uri.parse treats ?key=val as path
+	// for opaque URIs).
+	const uri = vscode.Uri.from({
+		scheme: ARCHIVED_MARKDOWN_SCHEME,
+		path: `/${sanitizeTitleForUriPath(title)}.md`,
+		query,
+	});
+	cacheBody(query, content);
+	state?.emitter.fire(uri);
+	try {
+		// Load the virtual document (triggers provideTextDocumentContent) without
+		// showing a raw text tab, then open only the rendered preview.
+		await vscode.workspace.openTextDocument(uri);
+		await vscode.commands.executeCommand("markdown.showPreview", uri);
+	} catch (e) {
+		// `markdown.showPreview` belongs to the built-in markdown-language-features
+		// extension. A user who disabled it would otherwise get a bare
+		// "command 'markdown.showPreview' not found".
+		log.warn("cmd", `showArchivedMarkdownPreview failed — ${String(e)}`);
+		void vscode.window.showErrorMessage(
+			"Could not open the Markdown preview. The built-in Markdown extension may be disabled.",
+		);
+	}
+}

--- a/vscode/src/core/PreviewUri.test.ts
+++ b/vscode/src/core/PreviewUri.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	decodePreviewRef,
+	encodePreviewRef,
+	sanitizeTitleForUriPath,
+} from "./PreviewUri.js";
+
+describe("sanitizeTitleForUriPath", () => {
+	it("replaces path- and fragment-significant characters", () => {
+		// `#` would be parsed as a URI fragment and truncate the name; `/` and `:`
+		// would fabricate path segments.
+		expect(sanitizeTitleForUriPath('feat/thing: #12 "quoted" <b>|{x}')).toBe(
+			"feat-thing- -12 -quoted- -b---x-",
+		);
+	});
+
+	it("truncates to 80 characters", () => {
+		expect(sanitizeTitleForUriPath("x".repeat(200))).toBe("x".repeat(80));
+	});
+
+	it("leaves an ordinary title untouched", () => {
+		expect(sanitizeTitleForUriPath("Skills used — uncommitted")).toBe(
+			"Skills used — uncommitted",
+		);
+	});
+});
+
+describe("encodePreviewRef / decodePreviewRef", () => {
+	it("round-trips a multi-field ref", () => {
+		const query = encodePreviewRef({
+			ns: "reference",
+			source: "linear",
+			id: "linear:PROJ-1-aaaaaaaa",
+		});
+
+		expect(decodePreviewRef(query)).toEqual({
+			ns: "reference",
+			source: "linear",
+			id: "linear:PROJ-1-aaaaaaaa",
+		});
+	});
+
+	it("survives the percent-decode Uri.parse performs when restoring a tab", () => {
+		// This is the whole reason the payload is base64url rather than
+		// percent-encoded params: VS Code decodes the query once when it
+		// reconstructs a Uri from its string form (window reload, preview tab
+		// restore). A percent-encoded `&` inside a value would decode back into a
+		// real separator there and split one param into two.
+		const query = encodePreviewRef({ ns: "reference", id: "a&b=c d" });
+
+		expect(decodePreviewRef(decodeURIComponent(query))).toEqual({
+			ns: "reference",
+			id: "a&b=c d",
+		});
+	});
+
+	it("emits a query whose payload needs no percent-encoding at all", () => {
+		// base64url's alphabet (A-Za-z0-9-_) plus the `ref=` key — nothing here is
+		// touched by either percent-encoding or form-urlencoded space handling.
+		expect(encodePreviewRef({ ns: "reference", id: "a&b=c d" })).toMatch(
+			/^ref=[A-Za-z0-9\-_]+$/,
+		);
+	});
+
+	it("orders keys so the same ref always yields the same cache key", () => {
+		// The query string doubles as the body-cache key, so two spellings of the
+		// same ref must not produce two cache entries (and two provider misses).
+		expect(encodePreviewRef({ source: "linear", ns: "reference" })).toBe(
+			encodePreviewRef({ ns: "reference", source: "linear" }),
+		);
+	});
+
+	it("omits undefined values rather than encoding the string 'undefined'", () => {
+		expect(decodePreviewRef(encodePreviewRef({ ns: "skills", repo: undefined }))).toEqual({
+			ns: "skills",
+		});
+	});
+
+	it("returns undefined for a query with no ref param", () => {
+		expect(decodePreviewRef("")).toBeUndefined();
+	});
+
+	it("returns undefined for a ref that is not valid base64url JSON", () => {
+		// Reachable via a hand-typed or truncated URI; must not throw inside the
+		// content provider.
+		expect(decodePreviewRef("ref=not-base64-json")).toBeUndefined();
+	});
+
+	it("returns undefined for a payload that decodes to a non-object", () => {
+		const query = `ref=${Buffer.from('"a string"').toString("base64url")}`;
+
+		expect(decodePreviewRef(query)).toBeUndefined();
+	});
+});

--- a/vscode/src/core/PreviewUri.ts
+++ b/vscode/src/core/PreviewUri.ts
@@ -1,0 +1,76 @@
+/**
+ * PreviewUri
+ *
+ * Shared URI plumbing for the three read-only markdown preview schemes
+ * (`jollimemory-plan`, `jollimemory-note`, `jollimemory-archived`). Every one of
+ * them builds the same shape — a sanitized title as the path segment, an
+ * identifying payload in the query — and each used to hand-roll both halves.
+ *
+ * Pure string functions on purpose: no `vscode` import, so the callers own
+ * `Uri.from` and this module stays trivially testable.
+ */
+
+/**
+ * Makes `title` safe to use as a URI path segment (and therefore as the preview
+ * tab's name).
+ *
+ * `#` in particular would be parsed as a URI fragment and silently truncate the
+ * name; `/` and `:` would fabricate path segments. The 80-character cap keeps a
+ * long Jira/Notion title from becoming an unreadable tab.
+ */
+export function sanitizeTitleForUriPath(title: string): string {
+	return title.replace(/[/\\:*?"<>|#%&{}]/g, "-").substring(0, 80);
+}
+
+/** The identifying payload carried in a preview URI's query. */
+export type PreviewRef = Readonly<Record<string, string | undefined>>;
+
+/**
+ * Encodes `ref` into a preview URI query string (`ref=<base64url of JSON>`).
+ *
+ * Base64url rather than percent-encoded params, because the query has to survive
+ * a decode it does not control: VS Code percent-decodes the query when it
+ * reconstructs a `Uri` from its string form — which is exactly what happens when
+ * a preview tab is restored after a window reload. A value containing `&` or `=`
+ * (an archived reference key is built from a source-supplied native id) would
+ * decode back into real separators there and split one param into two. The
+ * base64url alphabet is `A-Za-z0-9-_`, which neither percent-encoding nor
+ * form-urlencoded space handling touches, so the round trip is lossless.
+ *
+ * Keys are sorted so the same ref always produces the same string — the query
+ * doubles as the body-cache key, and two spellings would mean two cache entries.
+ * `undefined` values are dropped rather than serialized.
+ */
+export function encodePreviewRef(ref: PreviewRef): string {
+	const entries = Object.entries(ref)
+		.filter((e): e is [string, string] => e[1] !== undefined)
+		// No equality arm: object keys are unique, so two entries can never tie.
+		// Not `localeCompare` — that reads the ambient locale, and the query it
+		// orders doubles as a cache key that must not vary by machine.
+		.sort((a, b) => (a[0] < b[0] ? -1 : 1));
+	const payload = JSON.stringify(Object.fromEntries(entries));
+	return `ref=${Buffer.from(payload, "utf8").toString("base64url")}`;
+}
+
+/**
+ * Decodes a query string produced by {@link encodePreviewRef}.
+ *
+ * Returns `undefined` — never throws — for a missing, truncated or hand-typed
+ * `ref`, because the only caller is a `TextDocumentContentProvider` and a throw
+ * there surfaces as a broken tab rather than a message.
+ */
+export function decodePreviewRef(query: string): Record<string, string> | undefined {
+	const raw = new URLSearchParams(query).get("ref");
+	if (!raw) return undefined;
+	try {
+		const parsed: unknown = JSON.parse(
+			Buffer.from(raw, "base64url").toString("utf8"),
+		);
+		if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+			return undefined;
+		}
+		return parsed as Record<string, string>;
+	} catch {
+		return undefined;
+	}
+}

--- a/vscode/src/core/ReferencePreviewMarkdown.test.ts
+++ b/vscode/src/core/ReferencePreviewMarkdown.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import { readReferenceMarkdownFromString } from "../../../cli/src/core/references/ReferenceStore.js";
+import { renderReferenceForPreview } from "./ReferencePreviewMarkdown.js";
+
+/**
+ * Shaped exactly like `ReferenceStore.renderMarkdown` writes it — the frontmatter
+ * key order and the JSON-stringified values are that writer's contract, and the
+ * assertion below proves this fixture still parses as a real reference.
+ */
+const LINEAR_SNAPSHOT = [
+	"---",
+	'source: "linear"',
+	'nativeId: "PROJ-1"',
+	'title: "Fix the login redirect"',
+	'url: "https://linear.app/acme/issue/PROJ-1"',
+	"fields:",
+	'  - {"label":"Status","value":"In Progress"}',
+	'referencedAt: "2026-08-05T09:30:00.000Z"',
+	'sourceToolName: "get_issue"',
+	"---",
+	"",
+	"The redirect drops the `next` param when the session is stale.",
+	"",
+].join("\n");
+
+/** A bookmark-shaped snapshot: no permalink, and the body points at a link. */
+const SLACK_SNAPSHOT = [
+	"---",
+	'source: "slack"',
+	'nativeId: "C123-1699999999.000100"',
+	'title: "#eng-standup thread"',
+	'referencedAt: "2026-08-05T09:30:00.000Z"',
+	'sourceToolName: "slack_read_thread"',
+	"---",
+	"",
+	"<!-- jolli-reference-note -->",
+	"",
+	"---",
+	"",
+	"> ℹ️ **This is a bookmark, not a full copy.** Only the query is recorded here.",
+	"",
+].join("\n");
+
+describe("renderReferenceForPreview", () => {
+	it("the fixtures are real references as far as the CLI parser is concerned", () => {
+		// Guards against this file drifting from ReferenceStore.renderMarkdown and
+		// quietly testing a shape that never reaches disk.
+		expect(readReferenceMarkdownFromString(LINEAR_SNAPSHOT)?.url).toBe(
+			"https://linear.app/acme/issue/PROJ-1",
+		);
+		expect(readReferenceMarkdownFromString(SLACK_SNAPSHOT)?.url).toBeUndefined();
+	});
+
+	it("promotes the title out of the invisible frontmatter into a heading", () => {
+		// VS Code's markdown preview mounts markdown-it-front-matter with an empty
+		// renderer, so every frontmatter field is invisible in a rendered preview.
+		expect(renderReferenceForPreview(LINEAR_SNAPSHOT)).toContain(
+			"# Fix the login redirect",
+		);
+	});
+
+	it("makes the url visible as a link", () => {
+		expect(renderReferenceForPreview(LINEAR_SNAPSHOT)).toContain(
+			"[https://linear.app/acme/issue/PROJ-1](https://linear.app/acme/issue/PROJ-1)",
+		);
+	});
+
+	it("shows the source and the capture time", () => {
+		const out = renderReferenceForPreview(LINEAR_SNAPSHOT);
+
+		expect(out).toContain("linear");
+		expect(out).toContain("2026-08-05T09:30:00.000Z");
+	});
+
+	it("keeps the body verbatim", () => {
+		expect(renderReferenceForPreview(LINEAR_SNAPSHOT)).toContain(
+			"The redirect drops the `next` param when the session is stale.",
+		);
+	});
+
+	it("keeps the bookmark note, which the parser would have stripped", () => {
+		// `parseMarkdown` runs `stripReferenceNote` before handing back a Reference,
+		// so rebuilding the body from the parsed object would delete exactly the
+		// paragraph that explains why there is no full copy.
+		expect(renderReferenceForPreview(SLACK_SNAPSHOT)).toContain(
+			"This is a bookmark, not a full copy.",
+		);
+	});
+
+	it("omits the link line for a reference that has no url", () => {
+		// Slack threads without a permalink, and jollimemory's own lookups, have no
+		// url at all — an empty `[]()` would be worse than nothing.
+		const out = renderReferenceForPreview(SLACK_SNAPSHOT);
+
+		expect(out).toContain("# #eng-standup thread");
+		expect(out).not.toContain("]()");
+	});
+
+	it("emits no frontmatter of its own", () => {
+		// A leading `---` would be swallowed by the same front-matter renderer this
+		// function exists to route around.
+		expect(renderReferenceForPreview(LINEAR_SNAPSHOT).startsWith("---")).toBe(
+			false,
+		);
+	});
+
+	it("returns markdown that carries no frontmatter unchanged", () => {
+		const plain = "# Already plain\n\nBody.";
+
+		expect(renderReferenceForPreview(plain)).toBe(plain);
+	});
+
+	it("returns an unterminated frontmatter block unchanged", () => {
+		const broken = "---\nsource: not-json\n";
+
+		expect(renderReferenceForPreview(broken)).toBe(broken);
+	});
+
+	it("returns a closed but unparseable frontmatter block unchanged", () => {
+		// Missing the required `nativeId` / `title` / `referencedAt` keys, so the CLI
+		// parser rejects it. Showing the body with a hidden header beats dropping it.
+		const broken = '---\nsource: "linear"\n---\n\nBody worth keeping.\n';
+
+		expect(renderReferenceForPreview(broken)).toBe(broken);
+	});
+});

--- a/vscode/src/core/ReferencePreviewMarkdown.ts
+++ b/vscode/src/core/ReferencePreviewMarkdown.ts
@@ -1,0 +1,62 @@
+/**
+ * ReferencePreviewMarkdown
+ *
+ * Makes an archived reference snapshot readable as a *rendered* markdown preview.
+ *
+ * The snapshots on the orphan branch put their identity in YAML frontmatter —
+ * `source`, `nativeId`, `title`, `url`, `fields`, `referencedAt`, `sourceToolName`
+ * (see `ReferenceStore.renderMarkdown`). That was fine while these opened as raw
+ * text. It is not fine in a rendered preview: VS Code's built-in markdown preview
+ * mounts `markdown-it-front-matter` with an empty renderer, so every one of those
+ * fields is invisible.
+ *
+ * The sharpest case is a bookmark-shaped reference — a Slack thread with no
+ * permalink, a context7 lookup that records only the query. Its body says "only the
+ * query and the link are recorded here" while the link itself sits in the
+ * frontmatter, so the rendered page talks about a link the reader cannot see.
+ *
+ * So: replace the frontmatter block with a small visible header, and leave the body
+ * byte-for-byte alone.
+ *
+ * **Why not rebuild the body from the parsed `Reference`.** `parseMarkdown` runs
+ * `stripReferenceNote` before returning, which deletes precisely the "this is a
+ * bookmark, not a full copy" paragraph that explains the missing content. The parser
+ * is used here for its field extraction only; the body is sliced off the original
+ * text.
+ */
+
+import { readReferenceMarkdownFromString } from "../../../cli/src/core/references/ReferenceStore.js";
+
+/** Index just past the closing `---` of a frontmatter block, or -1 if there is none. */
+function bodyStart(markdown: string): number {
+	if (!markdown.startsWith("---\n")) return -1;
+	const close = markdown.indexOf("\n---\n", 3);
+	return close === -1 ? -1 : close + "\n---\n".length;
+}
+
+/**
+ * Rewrites an archived reference snapshot for rendered display.
+ *
+ * Returns `markdown` unchanged when it carries no frontmatter, or when the
+ * frontmatter does not parse as a reference — losing the body would be a far worse
+ * outcome than showing it with its header still hidden.
+ */
+export function renderReferenceForPreview(markdown: string): string {
+	const start = bodyStart(markdown);
+	if (start === -1) return markdown;
+	const ref = readReferenceMarkdownFromString(markdown);
+	if (!ref) return markdown;
+
+	const header = [`# ${ref.title}`, ""];
+	// Rendered as an explicit `[url](url)` rather than a bare autolink so it stays a
+	// visible, clickable line even for sources whose url is long and unlovely.
+	if (ref.url !== undefined && ref.url.length > 0) {
+		header.push(`[${ref.url}](${ref.url})`, "");
+	}
+	// `referencedAt` verbatim, not `toLocaleString()`: the ISO timestamp is
+	// unambiguous and, unlike a locale-formatted one, does not change shape with the
+	// machine's language settings.
+	header.push(`\`${ref.source}\` · captured ${ref.referencedAt}`, "");
+
+	return header.join("\n") + markdown.slice(start).replace(/^\n+/, "");
+}

--- a/vscode/src/views/SidebarMessages.ts
+++ b/vscode/src/views/SidebarMessages.ts
@@ -928,6 +928,13 @@ export type SidebarOutboundMsg =
 			readonly type: "kb:openEvidenceReference";
 			readonly archivedKey: string;
 			readonly source: string;
+			/**
+			 * The reference's human title, so the preview tab is named after it and
+			 * not after the storage key. The memory detail panel's route to the same
+			 * snapshot already passes one; without this the two entry points name the
+			 * same snapshot differently.
+			 */
+			readonly title: string;
 			readonly sourceRepoName: string | null;
 			readonly sourceRemoteUrl: string | null;
 	  }

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -2790,6 +2790,7 @@ export function buildSidebarScript(): string {
             type: 'kb:openEvidenceReference',
             archivedKey: item.id,
             source: item.source || '',
+            title: item.title || item.id || '',
             sourceRepoName: srcRepoName,
             sourceRemoteUrl: srcRemoteUrl,
           });

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -4967,15 +4967,19 @@ describe("SidebarWebviewProvider", () => {
 				type: "kb:openEvidenceReference",
 				archivedKey: "linear:PROJ-1-ab12cd34",
 				source: "linear",
+				title: "Fix the login redirect",
 				sourceRepoName: null,
 				sourceRemoteUrl: null,
 			});
+			// The title rides along so the preview tab is named after the reference
+			// rather than after its storage key.
 			expect(executeCommand).toHaveBeenCalledWith(
 				"jollimemory.previewCommittedReference",
 				"linear:PROJ-1-ab12cd34",
 				"linear",
 				null,
 				null,
+				"Fix the login redirect",
 			);
 		});
 
@@ -4988,6 +4992,7 @@ describe("SidebarWebviewProvider", () => {
 				type: "kb:openEvidenceReference",
 				archivedKey: "slack:C0-123.456-ab12cd34",
 				source: "slack",
+				title: "#eng-standup thread",
 				sourceRepoName: null,
 				sourceRemoteUrl: null,
 			});
@@ -4997,6 +5002,7 @@ describe("SidebarWebviewProvider", () => {
 				"slack",
 				null,
 				null,
+				"#eng-standup thread",
 			);
 		});
 

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -915,6 +915,7 @@ export class SidebarWebviewProvider
 					msg.source,
 					msg.sourceRepoName,
 					msg.sourceRemoteUrl,
+					msg.title,
 				);
 				return;
 			}

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -155,6 +155,19 @@ vi.mock("../util/WorkspaceUtils.js", () => ({
 	loadGlobalConfig: mockLoadConfig,
 }));
 
+// The archived-snapshot preview registers a TextDocumentContentProvider and holds a
+// module-level EventEmitter, neither of which the lightweight `vscode` mock above
+// provides. Stub it: the panel's contract is "read from the orphan branch, hand the
+// body to the preview" — the rendering itself is covered in
+// core/ArchivedMarkdownPreview.test.ts.
+const { mockShowArchivedMarkdownPreview } = vi.hoisted(() => ({
+	mockShowArchivedMarkdownPreview: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../core/ArchivedMarkdownPreview.js", () => ({
+	showArchivedMarkdownPreview: mockShowArchivedMarkdownPreview,
+}));
+
 const { mockGenerateE2eTest, mockGenerateRecap, mockTranslateToEnglish } =
 	vi.hoisted(() => ({
 		mockGenerateE2eTest: vi.fn().mockResolvedValue([]),
@@ -8778,9 +8791,20 @@ describe("SummaryWebviewPanel", () => {
 
 			it("Linear: reads the snapshot from the orphan branch", async () => {
 				mockReadReferenceFromBranch.mockResolvedValueOnce(
-					'---\nticketId: "PROJ-1"\n---\nbody from orphan branch',
+					[
+						"---",
+						'source: "linear"',
+						'nativeId: "PROJ-1"',
+						'title: "T"',
+						'url: "https://linear.app/acme/issue/PROJ-1"',
+						'referencedAt: "2026-08-05T09:30:00.000Z"',
+						'sourceToolName: "get_issue"',
+						"---",
+						"",
+						"body from orphan branch",
+					].join("\n"),
 				);
-				openTextDocument.mockClear();
+				mockShowArchivedMarkdownPreview.mockClear();
 				const dispatch = await setupPanel();
 
 				dispatch({
@@ -8798,20 +8822,36 @@ describe("SummaryWebviewPanel", () => {
 					workspaceRoot,
 					undefined,
 				);
-				// Opens an untitled markdown doc with the orphan-branch content
-				// — does NOT re-materialize the local file. Orphan branch is
-				// the source of truth for archived snapshots.
-				expect(openTextDocument).toHaveBeenCalledWith({
-					language: "markdown",
-					content: '---\nticketId: "PROJ-1"\n---\nbody from orphan branch',
-				});
+				// Previews the orphan-branch content from an in-memory virtual
+				// document — does NOT re-materialize the local file. Orphan branch
+				// is the source of truth for archived snapshots.
+				//
+				// The ref is self-describing so the provider can re-read the snapshot
+				// after a window reload drops the in-memory body.
+				expect(mockShowArchivedMarkdownPreview).toHaveBeenCalledWith(
+					{
+						ns: "reference",
+						source: "linear",
+						archivedKey: "linear:PROJ-1-aaaaaaaa",
+					},
+					"T",
+					// Frontmatter is promoted into the body: VS Code's markdown preview
+					// hides it, and the url lives there.
+					expect.stringContaining(
+						"[https://linear.app/acme/issue/PROJ-1](https://linear.app/acme/issue/PROJ-1)",
+					),
+				);
+				const [, , renderedBody] = mockShowArchivedMarkdownPreview.mock
+					.calls[0] as [unknown, string, string];
+				expect(renderedBody).toContain("body from orphan branch");
+				expect(renderedBody.startsWith("---")).toBe(false);
 			});
 
 			it("Jira: reads the snapshot from the orphan branch", async () => {
 				mockReadReferenceFromBranch.mockResolvedValueOnce(
 					"# KAN-5\n\nJira ticket body",
 				);
-				openTextDocument.mockClear();
+				mockShowArchivedMarkdownPreview.mockClear();
 				const dispatch = await setupPanel();
 
 				dispatch({
@@ -8829,10 +8869,16 @@ describe("SummaryWebviewPanel", () => {
 					workspaceRoot,
 					undefined,
 				);
-				expect(openTextDocument).toHaveBeenCalledWith({
-					language: "markdown",
-					content: "# KAN-5\n\nJira ticket body",
-				});
+				// No frontmatter to promote — the body passes through untouched.
+				expect(mockShowArchivedMarkdownPreview).toHaveBeenCalledWith(
+					{
+						ns: "reference",
+						source: "jira",
+						archivedKey: "jira:KAN-5-aaaa1111",
+					},
+					"Jira ticket",
+					"# KAN-5\n\nJira ticket body",
+				);
 			});
 
 			it("shows an error when the orphan-branch lookup misses", async () => {

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -67,6 +67,8 @@ import type {
 	TranscriptSource,
 } from "../../../cli/src/Types.js";
 import { CURRENT_SCHEMA_VERSION } from "../../../cli/src/Types.js";
+import { showArchivedMarkdownPreview } from "../core/ArchivedMarkdownPreview.js";
+import { renderReferenceForPreview } from "../core/ReferencePreviewMarkdown.js";
 import { removeNote, saveNote } from "../core/NoteService.js";
 import {
 	listAvailablePlans,
@@ -3429,8 +3431,8 @@ export class SummaryWebviewPanel {
 	}
 
 	/**
-	 * Opens the captured-at-commit markdown snapshot for a reference in a
-	 * read-only editor.
+	 * Opens the captured-at-commit markdown snapshot for a reference as a
+	 * read-only rendered preview.
 	 *
 	 * Source: orphan branch `references/<source>/<sanitized>.md`. Once a
 	 * reference is associated with a commit, the local `.jolli/jollimemory/`
@@ -3441,7 +3443,7 @@ export class SummaryWebviewPanel {
 		archivedKey: string,
 		source: SourceId,
 		_nativeId: string,
-		_title: string,
+		title: string,
 	): Promise<void> {
 		if (!archivedKey) return;
 		const content = await readReferenceFromBranch(
@@ -3456,14 +3458,27 @@ export class SummaryWebviewPanel {
 			);
 			return;
 		}
-		// Untitled doc — same rationale as plan / note preview: never re-
+		// Virtual doc — same rationale as plan / note preview: never re-
 		// materialize on the user's disk. The orphan branch is the source of
 		// truth for archived snapshots.
-		const doc = await vscode.workspace.openTextDocument({
-			language: "markdown",
-			content,
-		});
-		await vscode.window.showTextDocument(doc);
+		//
+		// The ref carries this panel's provenance rather than its already-built
+		// `foreignStorage`, because the ref is all that survives a window reload —
+		// the provider rebuilds the storage from the name/url when VS Code restores
+		// the tab and re-asks for the body.
+		await showArchivedMarkdownPreview(
+			{
+				ns: "reference",
+				source,
+				archivedKey,
+				...(this.foreignRepoName ? { repoName: this.foreignRepoName } : {}),
+				...(this.foreignRepoName && this.foreignRepoUrl
+					? { remoteUrl: this.foreignRepoUrl }
+					: {}),
+			},
+			title || archivedKey,
+			renderReferenceForPreview(content),
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Skills-aggregate and archived-reference previews (`openSkillsAggregate`, `previewCommittedSkills`, `previewCommittedReference`, and the webview's reference preview) opened as VS Code untitled documents, which VS Code names `Untitled-1`, marks dirty on creation (prompting a save on close for content the user never authored), and shows as raw markdown source rather than the rendered table/body the clicked row promises.
- Adds `ArchivedMarkdownPreview.ts`: one `TextDocumentContentProvider` scheme (`jollimemory-archived`) backing every in-memory-rendered read-only preview. Content is kept in a module-level map keyed by caller identity (`skills:<hash>`, `reference:<source>:<archivedKey>`), so re-opening the same key refreshes an already-open tab in place instead of serving stale content — needed for the uncommitted skills table, whose rows grow during a session.
- Switches the four call sites above from `openTextDocument({content}) + showTextDocument` to `showArchivedMarkdownPreview(key, title, content)` + `markdown.showPreview`.

## Test plan
- [x] `vscode/src/core/ArchivedMarkdownPreview.test.ts` (new): registration, title sanitization/truncation, query encoding, refresh-in-place, namespace isolation, dispose/teardown.
- [x] `vscode/src/Extension.test.ts`: updated `previewCommittedReference` assertions to expect the virtual-doc scheme instead of an untitled doc; added coverage for `openSkillsAggregate` and `previewCommittedSkills`.
- [x] `vscode/src/views/SummaryWebviewPanel.test.ts`: updated reference-preview tests to assert against the new `showArchivedMarkdownPreview` call.