### PR TITLE
Resolve the plugin README marketplace source at publish time

### DIFF
--- a/claude-plugin/DEVELOPMENT.md
+++ b/claude-plugin/DEVELOPMENT.md
@@ -217,8 +217,15 @@ Shared knobs:
   for `publish-local.sh`; `publish-zip.sh` takes the output path as its argument).
 
 **`publish-dev.sh` and `publish-prod.sh` are the same flow** (`publish_git_repo` in
-`_publish-lib.sh`) and differ *only* in the default target repo, so a prod release can never
-behave differently from the dev dry-run that rehearsed it. Both **refuse a same-version
+`_publish-lib.sh`) and differ *only* in the default target repo plus the marketplace slug they
+pass for the README, so a prod release can never behave differently from the dev dry-run that
+rehearsed it. That slug is why [`README.md`](README.md) keeps a neutral `<marketplace-source>`
+placeholder wherever it names the marketplace to add: `publish_readme_source` resolves it on the
+**mirrored copy** (prod repo, dev repo, or the local directory), because a hardcoded slug in the
+source README made the dev mirror tell dry-run readers to install the public release. Publishing
+fails loudly if the placeholder is missing — shipping the literal token is an install command
+that cannot work. `publish-zip.sh` needs no resolution: it packs `plugins/jolli/` and ships no
+README. Both **refuse a same-version
 republish**: Claude Code's `/plugin update` compares `plugin.json` `version`, so re-publishing
 changed bytes under an unchanged version would leave installed users stuck on "up to date" and
 they'd never pull the fix. Bump `version` in

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -17,9 +17,11 @@ hooks are what generate the memory that the plugin surfaces let you consume.
 - **Commands** — `/jolli:init`, `/jolli:status`, `/jolli:timeline`,
   `/jolli:login`, `/jolli:logout`.
 - **Skills** — `/jolli:recall`, `/jolli:search`, `/jolli:push`.
-- **Umbrella** — a bare `/jolli` action menu that lists the above and routes to
-  your pick (written into `.claude/skills/jolli/` on first session; a plugin
-  can't expose a bare command itself, so this is a project-level skill).
+- **Umbrella** — a bare `/jolli` front door: it reads how Jolli is set up in this
+  repo, leads with setup when something is missing, and otherwise shows a status
+  snapshot and routes to your pick (written into `.claude/skills/jolli/` on first
+  session; a plugin can't expose a bare command itself, so this is a
+  project-level skill).
 - **Hooks** — one `SessionStart` bootstrap that installs the git hooks and the
   canonical agent hooks, which then build memory
   from your commits, and — until you sign in — remind you to run `/jolli:login`.
@@ -29,11 +31,11 @@ hooks are what generate the memory that the plugin surfaces let you consume.
 Install from Jolli's Claude Code marketplace:
 
 ```
-/plugin marketplace add jolliai/jolli-claude-plugin
+/plugin marketplace add <marketplace-source>
 /plugin install jolli@jolli-marketplace
 ```
 
-`jolliai/jolli-claude-plugin` is the marketplace repo (its `marketplace.json`
+`<marketplace-source>` is the marketplace repo (its `marketplace.json`
 names the marketplace `jolli-marketplace`, which is why the install target is
 `jolli@jolli-marketplace`).
 
@@ -42,6 +44,13 @@ source, then enable **Jolli Memory** under **Manage plugins**.
 
 After install the MCP tools, `/jolli:*` skills and commands, and the hooks are
 all live.
+
+Start with **`/jolli`**. It reads how Jolli is set up in this repository, leads
+with setup when something is missing, and otherwise shows a status snapshot and
+routes you to recall, search, a PR description, or a Space. In a brand-new repo
+the bare `/jolli` may not appear until the plugin has written it during its first
+session — **`/jolli:init`** always works directly, and is also what you run to
+re-run setup or change the bound Space.
 
 ## Memory generation works out of the box
 
@@ -69,8 +78,9 @@ other devices can recall them. It is not required to generate them.
 This opens your browser and, on success, saves a Jolli API Key. Run
 `/jolli:logout` to sign out.
 
-**`/jolli:init`** is the one-shot path: it signs you in if needed, enables the
-repo, and binds it to a Space.
+**`/jolli:init`** does all of it in one pass: it signs you in if needed, enables
+the repo, and binds it to a Space. `/jolli` routes there on its own whenever setup
+is incomplete.
 
 > **Prefer your own Anthropic key?** Setting `ANTHROPIC_API_KEY` on its own is not
 > enough once the plugin has seeded `local-agent`, because the provider choice is

--- a/claude-plugin/scripts/_publish-lib.sh
+++ b/claude-plugin/scripts/_publish-lib.sh
@@ -48,6 +48,13 @@ PUBLISH_REQUIRED_CONFIG=(
 	plugins/jolli/.claude-plugin/plugin.json
 )
 
+# The neutral token the SOURCE README carries wherever it names the marketplace to
+# add. Each publish target resolves it to something different — the public release
+# repo, the dev dry-run repo, a local directory — so the monorepo copy cannot name
+# any one of them. (The dev mirror used to ship the PROD slug, telling dry-run
+# readers to install the public release.) Mirrors codex-plugin's mechanism.
+README_SOURCE_PLACEHOLDER='<marketplace-source>'
+
 # publish_assert_dist_built — every required dist file exists and is non-empty on
 # disk. Run right after the build so an incomplete bundle fails the publish here
 # instead of shipping a commit-breaking plugin to colleagues.
@@ -161,6 +168,45 @@ publish_sync() {
 		"$SRC"/ "$dest"/
 }
 
+# publish_readme_source <dest-dir> <marketplace-source> — resolve the README's
+# marketplace name on the MIRRORED copy, so each target names the marketplace its
+# readers can actually add.
+#
+# Run after publish_sync (which would overwrite it) and before the commit, so the
+# resolved text is what lands in the target repo. The source README keeps the
+# neutral placeholder; publish-zip.sh needs no call because it packs only
+# plugins/jolli/ and ships no README at all.
+#
+# The placeholder MUST be present. Shipping the literal `<marketplace-source>`
+# gives users a command that cannot work, and README.md is not even in
+# PUBLISH_REQUIRED_CONFIG — so nothing else here would notice a README edit that
+# drops, renames or duplicates the token.
+publish_readme_source() {
+	local dest="$1" source_ref="$2" readme="$1/README.md"
+	[ -n "$source_ref" ] || { echo "error: publish_readme_source needs a marketplace source" >&2; return 1; }
+	[ -s "$readme" ] || { echo "error: mirrored README is missing or empty: '$readme'" >&2; return 1; }
+	if ! grep -Fq "$README_SOURCE_PLACEHOLDER" "$readme"; then
+		echo "error: '$readme' has no ${README_SOURCE_PLACEHOLDER} placeholder to resolve." >&2
+		echo "       claude-plugin/README.md must keep it wherever it names the marketplace," >&2
+		echo "       so each publish target can name its own." >&2
+		return 1
+	fi
+	# Literal index-based replacement, not sed: the value is a slug or an absolute
+	# path, and both `/` (delimiter) and `&` (backreference) would need escaping in a
+	# sed replacement. awk's substr arithmetic treats it as plain text.
+	awk -v ph="$README_SOURCE_PLACEHOLDER" -v val="$source_ref" '
+		{ i = index($0, ph); if (i > 0) $0 = substr($0, 1, i - 1) val substr($0, i + length(ph)); print }
+	' "$readme" > "$readme.tmp" && mv "$readme.tmp" "$readme"
+	# One replacement per line above, so a second occurrence on the SAME line would
+	# survive silently. Assert the token is gone rather than trust the loop-free form.
+	if grep -Fq "$README_SOURCE_PLACEHOLDER" "$readme"; then
+		echo "error: '$readme' still contains ${README_SOURCE_PLACEHOLDER} after rewriting." >&2
+		echo "       Keep the placeholder to a single occurrence per line." >&2
+		return 1
+	fi
+	echo "==> README marketplace source -> ${source_ref}"
+}
+
 publish_version() {
 	# Pass the path on argv rather than interpolating it into the JS source, so a
 	# repo path containing a quote or backslash can't corrupt the expression.
@@ -177,8 +223,14 @@ publish_version() {
 # never hand-edited. Honors:
 #   NO_PUSH=1               commit but don't push
 #   JOLLI_PUBLISH_FORCE=1   allow a same-version republish (skips the version guard)
+#
+# <marketplace-source> is the `owner/repo` slug readers of THIS target's README will
+# type into `/plugin marketplace add`. Passed in rather than derived from the
+# checkout's `origin`: the README is written before the push, so a mistyped
+# destination path should not silently produce a README documenting whichever repo
+# the wrong checkout happens to point at.
 publish_git_repo() {
-	local dest="$1"
+	local dest="$1" marketplace_source="$2"
 	if [ ! -d "$dest/.git" ]; then
 		echo "error: '$dest' is not a git checkout." >&2
 		echo "       Clone the marketplace repo first:" >&2
@@ -189,6 +241,7 @@ publish_git_repo() {
 
 	publish_build
 	publish_sync "$dest"
+	publish_readme_source "$dest" "$marketplace_source"
 
 	cd "$dest"
 	# Publish exactly what rsync placed on disk. Neutralize the user's MACHINE-GLOBAL

--- a/claude-plugin/scripts/publish-dev.sh
+++ b/claude-plugin/scripts/publish-dev.sh
@@ -20,4 +20,4 @@ set -euo pipefail
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_publish-lib.sh"
 
 DEST="${MARKETPLACE_REPO:-${1:-$MONOREPO/../claude-plugin-marketplace}}"
-publish_git_repo "$DEST"
+publish_git_repo "$DEST" "jolli-plugin-dev/claude-plugin-marketplace"

--- a/claude-plugin/scripts/publish-local.sh
+++ b/claude-plugin/scripts/publish-local.sh
@@ -19,6 +19,9 @@ DEST="$(cd "$DEST" && pwd)"
 
 publish_build
 publish_sync "$DEST"
+# A local marketplace is added by path, so that path IS this copy's install source —
+# the mirrored README then matches the command printed below verbatim.
+publish_readme_source "$DEST" "$DEST"
 
 echo ""
 echo "Local marketplace ready at: $DEST"

--- a/claude-plugin/scripts/publish-prod.sh
+++ b/claude-plugin/scripts/publish-prod.sh
@@ -32,4 +32,4 @@ set -euo pipefail
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_publish-lib.sh"
 
 DEST="${MARKETPLACE_REPO:-${1:-$MONOREPO/../jolli-claude-plugin}}"
-publish_git_repo "$DEST"
+publish_git_repo "$DEST" "jolliai/jolli-claude-plugin"

--- a/cli/src/hooks/ClaudePluginPublishDocs.test.ts
+++ b/cli/src/hooks/ClaudePluginPublishDocs.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Shape tests for the Claude plugin's published README.
+ *
+ * The marketplace repo's README is the front page end users see, and it is a
+ * GENERATED mirror — so the two halves that must agree live in different files and
+ * nothing type-checks either. Same technique and rationale as the Codex pair in
+ * CodexPluginManifest.test.ts.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const readme = () => readFileSync(join(repoRoot, "claude-plugin", "README.md"), "utf-8");
+const script = (name: string) => readFileSync(join(repoRoot, "claude-plugin", "scripts", name), "utf-8");
+
+describe("Claude publish resolves the README marketplace source", () => {
+	// The README used to hardcode the PROD slug, so the dev mirror told dry-run
+	// readers to install the public release instead of the rehearsal copy. The
+	// placeholder is what lets one source README serve both targets.
+	it("names no concrete marketplace slug in the source README", () => {
+		const text = readme();
+		const placeholder = script("_publish-lib.sh").match(/^README_SOURCE_PLACEHOLDER='([^']+)'$/mu)?.[1] ?? "";
+
+		expect(placeholder).toBe("<marketplace-source>");
+		expect(text).toContain(`/plugin marketplace add ${placeholder}`);
+		expect(text).not.toContain("marketplace add jolliai/");
+		expect(text).not.toContain("marketplace add jolli-plugin-dev/");
+	});
+
+	// publish_readme_source replaces at most one occurrence per LINE, then asserts the
+	// token is gone — so several placeholders are fine, two on one line are not.
+	it("keeps every placeholder on its own line", () => {
+		for (const line of readme().split("\n")) {
+			expect(line.split("<marketplace-source>").length).toBeLessThanOrEqual(2);
+		}
+	});
+
+	it("passes each target's own marketplace slug", () => {
+		expect(script("publish-dev.sh")).toContain(
+			'publish_git_repo "$DEST" "jolli-plugin-dev/claude-plugin-marketplace"',
+		);
+		expect(script("publish-prod.sh")).toContain('publish_git_repo "$DEST" "jolliai/jolli-claude-plugin"');
+		// publish-local.sh resolves to the local directory it just wrote; publish-zip.sh
+		// needs no call at all because it packs plugins/jolli/ and ships no README.
+		expect(script("publish-local.sh")).toContain('publish_readme_source "$DEST" "$DEST"');
+		expect(script("publish-zip.sh")).not.toContain("publish_readme_source");
+	});
+});
+
+describe("Claude plugin README entry point", () => {
+	// `/jolli` is the front door: its "not fully set up" branch invokes jolli:init
+	// itself. The README pointed at /jolli:init as "the one-shot path", which teaches
+	// a sub-skill and skips the state-aware routing.
+	it("leads with the bare /jolli front door", () => {
+		const text = readme();
+		expect(text).toContain("Start with **`/jolli`**");
+		expect(text).not.toContain("is the one-shot path");
+		// The first-session caveat is load-bearing on Claude (unlike Codex, whose
+		// umbrella ships in the bundle): the bare menu is a project skill this plugin
+		// writes, so a brand-new repo may not show it until the next session.
+		expect(text).toMatch(/brand-new repo[\s\S]{0,200}`\/jolli:init`/u);
+	});
+});

--- a/cli/src/hooks/CodexPluginManifest.test.ts
+++ b/cli/src/hooks/CodexPluginManifest.test.ts
@@ -176,6 +176,35 @@ describe("Codex publish inventory tracks the shipped skills", () => {
 	});
 });
 
+// The README's `marketplace add` argument differs per publish target, so the source
+// copy carries a placeholder that each publish script resolves on the mirror. Two
+// halves that can drift apart: the README could lose the token (the publish script
+// fails loudly, but only at release time), or a script could pass the WRONG slug —
+// and dev/prod are the same repository name in two orgs, so a swapped slug documents
+// a marketplace the reader has no access to while every other check passes.
+describe("Codex publish resolves the README install source", () => {
+	const readReadme = () => readFileSync(join(repoRoot, "codex-plugin", "README.md"), "utf-8");
+	const readScript = (name: string) => readFileSync(join(repoRoot, "codex-plugin", "scripts", name), "utf-8");
+
+	it("keeps a single resolvable placeholder in the marketplace add command", () => {
+		const readme = readReadme();
+		const libText = readScript("_publish-lib.sh");
+		const placeholder = libText.match(/^README_SOURCE_PLACEHOLDER='([^']+)'$/mu)?.[1] ?? "";
+
+		expect(placeholder).toBe("<marketplace-source>");
+		// One occurrence: publish_readme_source rewrites at most once per line.
+		expect(readme.split(placeholder)).toHaveLength(2);
+		expect(readme).toContain(`codex plugin marketplace add ${placeholder}`);
+	});
+
+	it("passes each target's own marketplace slug", () => {
+		expect(readScript("publish-dev.sh")).toContain(
+			'publish_git_repo "$DEST" "jolli-plugin-dev/jolli-chatgpt-plugin"',
+		);
+		expect(readScript("publish-prod.sh")).toContain('publish_git_repo "$DEST" "jolliai/jolli-chatgpt-plugin"');
+	});
+});
+
 describe("Codex plugin marketplace", () => {
 	it("is discoverable at .agents/plugins/marketplace.json", () => {
 		const marketplace = readJson(repoRoot, "codex-plugin", ".agents", "plugins", "marketplace.json");

--- a/codex-plugin/DEVELOPMENT.md
+++ b/codex-plugin/DEVELOPMENT.md
@@ -330,6 +330,15 @@ implements. Both stages use the SAME repository name in different orgs, which is
 why the dev checkout carries a `-dev` suffix locally; nothing but the local
 directory name differs.
 
+Because both stages share a repository name, the install command a reader should
+type differs per target while the source tree has only one README. `README.md`
+therefore keeps a neutral `<marketplace-source>` placeholder in its
+`codex plugin marketplace add` line, and every publish script resolves it on the
+**mirrored copy** (`publish_readme_source` in `_publish-lib.sh`) — the dev org slug,
+the prod org slug, the local directory, or a generic absolute path for the zip. The
+placeholder must survive in the source README: publishing fails loudly if it is
+missing, because the alternative is shipping users a command that cannot work.
+
 Clone them once before the first git-backed publish:
 
 ```bash

--- a/codex-plugin/README.md
+++ b/codex-plugin/README.md
@@ -45,13 +45,19 @@ bootstrap of the session that is already running.
 
 ## First-time setup
 
-Invoke `$jolli:init`. It:
+Invoke `$jolli`. It reads how Jolli is set up in this repository and, on a fresh
+repo, leads with setup — routing into `$jolli:init`, which:
 
 1. checks the current repository state;
 2. enables memory capture, records Codex as the local summarization agent, and
    registers the Jolli Memory MCP server (its tools load in your next session);
 3. optionally signs in to Jolli in the browser;
 4. binds the repository to a Jolli Space for team sharing.
+
+`$jolli` remains the entry point afterwards: once setup is complete it shows a
+status snapshot and routes to recall, search, PR descriptions and the rest.
+Invoke `$jolli:init` directly when you want to re-run setup or change the bound
+Space.
 
 Memory generation uses the local Codex/ChatGPT login by default and does not
 require a Jolli account or API key. Jolli sign-in is required only for Space
@@ -73,25 +79,19 @@ codex login
 - `$jolli:push` — publish memories to a Space.
 - `$jolli:local-run` / `$jolli:remote-run` — run Jolli workflows.
 
-## Development
-
-See [DEVELOPMENT.md](DEVELOPMENT.md) for architecture, build prerequisites,
-local acceptance testing, publishing, versioning, and the release checklist.
-
-From the monorepo root:
-
-```bash
-npm run build:codex-plugin
-bash codex-plugin/scripts/publish-local.sh
-```
-
-Reinstall the local plugin after publishing because Codex caches plugin
-versions under `~/.codex/plugins/cache/`.
-
 ## Requirements
 
 - Node.js must be available on `PATH`, or recorded by a supported Jolli IDE
   integration.
 - Codex must be installed and signed in for the default local-agent provider.
+
+## Support and source
+
+- Product: [jolli.ai](https://jolli.ai)
+- Source, issues, and security policy: [github.com/jolliai/jolliai](https://github.com/jolliai/jolliai)
+
+This repository is a generated release artifact — the plugin is built from the
+Jolli monorepo, so file changes here are overwritten by the next release. Report
+problems and send patches to the monorepo instead.
 
 Apache-2.0.

--- a/codex-plugin/scripts/_publish-lib.sh
+++ b/codex-plugin/scripts/_publish-lib.sh
@@ -57,6 +57,11 @@ PUBLISH_REQUIRED_CONFIG=(
 	README.md
 )
 
+# The neutral token the SOURCE README carries in its install command. Every publish
+# target resolves it to something different — a dev org slug, the public org slug, a
+# local directory — so the monorepo copy cannot name any one of them.
+README_SOURCE_PLACEHOLDER='<marketplace-source>'
+
 # publish_build — build dist/, then assert it is complete on disk.
 publish_build() {
 	echo "==> Building dist/ (bundles current cli/src) ..."
@@ -157,6 +162,45 @@ publish_sync() {
 		"$SRC"/ "$dest"/
 }
 
+# publish_readme_source <dest-dir> <marketplace-source> — resolve the README's install
+# command on the MIRRORED copy, so each target names the marketplace its readers can
+# actually add.
+#
+# Run after publish_sync (which would overwrite it) and before the commit, so the
+# resolved text is what lands in the target repo. The source README keeps the neutral
+# placeholder: dev and prod are the same repository NAME in two different orgs, so a
+# hardcoded slug in the monorepo copy would send half of all readers to the wrong one.
+#
+# The placeholder MUST be present. Shipping the literal `<marketplace-source>` gives
+# users a command that cannot work, and it fails no other check here — so a README edit
+# that drops, renames or duplicates the token has to fail loudly at publish time rather
+# than reach the marketplace.
+publish_readme_source() {
+	local dest="$1" source_ref="$2" readme="$1/README.md"
+	[ -n "$source_ref" ] || { echo "error: publish_readme_source needs a marketplace source" >&2; return 1; }
+	[ -s "$readme" ] || { echo "error: mirrored README is missing or empty: '$readme'" >&2; return 1; }
+	if ! grep -Fq "$README_SOURCE_PLACEHOLDER" "$readme"; then
+		echo "error: '$readme' has no ${README_SOURCE_PLACEHOLDER} placeholder to resolve." >&2
+		echo "       codex-plugin/README.md must keep it in the 'marketplace add' command so" >&2
+		echo "       each publish target can name its own marketplace." >&2
+		return 1
+	fi
+	# Literal index-based replacement, not sed: the value is a slug or an absolute path,
+	# and both `/` (delimiter) and `&` (backreference) would need escaping in a sed
+	# replacement. awk's substr arithmetic treats it as plain text.
+	awk -v ph="$README_SOURCE_PLACEHOLDER" -v val="$source_ref" '
+		{ i = index($0, ph); if (i > 0) $0 = substr($0, 1, i - 1) val substr($0, i + length(ph)); print }
+	' "$readme" > "$readme.tmp" && mv "$readme.tmp" "$readme"
+	# One replacement per line above, so a second occurrence on the same line would
+	# survive silently. Assert the token is gone rather than trust the loop-free form.
+	if grep -Fq "$README_SOURCE_PLACEHOLDER" "$readme"; then
+		echo "error: '$readme' still contains ${README_SOURCE_PLACEHOLDER} after rewriting." >&2
+		echo "       Keep the placeholder to a single occurrence per line." >&2
+		return 1
+	fi
+	echo "==> README install source -> ${source_ref}"
+}
+
 publish_version() {
 	# Pass the path on argv rather than interpolating it into the JS source, so a
 	# repo path containing a quote or backslash cannot corrupt the expression.
@@ -215,8 +259,14 @@ publish_push() {
 }
 
 # Build, mirror, commit with DCO sign-off, and optionally push a marketplace repo.
+#
+# <marketplace-source> is the `owner/repo` slug readers of THIS target's README will
+# type into `codex plugin marketplace add`. It is passed in rather than derived from
+# the checkout's `origin` on purpose: the README is written before the push, and a
+# mistyped destination path should not silently produce a README that documents
+# whichever repo the wrong checkout happens to point at.
 publish_git_repo() {
-	local dest="$1"
+	local dest="$1" marketplace_source="$2"
 	if [ ! -d "$dest/.git" ]; then
 		echo "error: '$dest' is not a git checkout." >&2
 		echo "       Clone the target marketplace repository first." >&2
@@ -227,6 +277,7 @@ publish_git_repo() {
 	publish_build
 	publish_assert_skills
 	publish_sync "$dest"
+	publish_readme_source "$dest" "$marketplace_source"
 
 	# Subshell: this `cd` must not leak into the caller's shell. It does not today —
 	# publish_git_repo is the last statement in publish-dev.sh and publish-prod.sh — but

--- a/codex-plugin/scripts/publish-dev.sh
+++ b/codex-plugin/scripts/publish-dev.sh
@@ -16,4 +16,4 @@ set -euo pipefail
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_publish-lib.sh"
 
 DEST="${MARKETPLACE_REPO:-${1:-$MONOREPO/../jolli-chatgpt-plugin-dev}}"
-publish_git_repo "$DEST"
+publish_git_repo "$DEST" "jolli-plugin-dev/jolli-chatgpt-plugin"

--- a/codex-plugin/scripts/publish-local.sh
+++ b/codex-plugin/scripts/publish-local.sh
@@ -25,6 +25,9 @@ DEST="$(cd "$DEST" && pwd)"
 publish_build
 publish_assert_skills
 publish_sync "$DEST"
+# A local marketplace is added by path, so that path IS this copy's install source —
+# the mirrored README then matches the command printed below verbatim.
+publish_readme_source "$DEST" "$DEST"
 
 VERSION="$(publish_version)"
 

--- a/codex-plugin/scripts/publish-prod.sh
+++ b/codex-plugin/scripts/publish-prod.sh
@@ -12,4 +12,4 @@ set -euo pipefail
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_publish-lib.sh"
 
 DEST="${MARKETPLACE_REPO:-${1:-$MONOREPO/../jolli-chatgpt-plugin}}"
-publish_git_repo "$DEST"
+publish_git_repo "$DEST" "jolliai/jolli-chatgpt-plugin"

--- a/codex-plugin/scripts/publish-zip.sh
+++ b/codex-plugin/scripts/publish-zip.sh
@@ -25,6 +25,10 @@ publish_assert_skills
 STAGE="$(mktemp -d)"
 trap 'rm -rf "$STAGE"' EXIT
 publish_sync "$STAGE"
+# The recipient chooses where they unzip, so no concrete source exists — but the
+# staging path must not leak into the README either (it is a temp dir that will not
+# exist on their machine). Name the shape of the command instead.
+publish_readme_source "$STAGE" "/absolute/path/to/unzipped-marketplace"
 
 rm -f "$OUT"
 (


### PR DESCRIPTION
## Problem

Both plugin READMEs are published to more than one marketplace, but each carried a single hardcoded install target. Dev and prod use the **same repository name in two different orgs**, so the dev mirror told dry-run readers to add the *public release* repo instead of the rehearsal copy.

## Change

The source READMEs now keep a neutral `<marketplace-source>` placeholder wherever they name the marketplace to add, and a new `publish_readme_source` helper resolves it on the **mirrored copy**:

| Target | Resolves to |
|---|---|
| `publish-prod.sh` | the public org slug |
| `publish-dev.sh` | the dev org slug |
| `publish-local.sh` | the local directory it just wrote |
| `publish-zip.sh` | a generic absolute path (recipient picks where they unzip) |

Resolution runs after `publish_sync` (which would overwrite it) and before the commit. The slug is **passed in** by each publish script rather than derived from the checkout's `origin`: the README is written before the push, so a mistyped destination should not silently produce a README documenting whichever repo that checkout happens to point at.

Publishing **fails loudly** when the placeholder is missing. `README.md` is not covered by the dist or config inventories, so nothing else would notice a README edit that drops or renames the token — and shipping the literal token is an install command that cannot work. Replacement uses `awk` substr arithmetic rather than `sed`, because slugs and absolute paths contain both `/` (delimiter) and `&` (backreference); since that rewrites at most once per line, the helper then asserts the token is gone.

## Front door

Both READMEs now point at the bare `/jolli` (`$jolli` on Codex) front door instead of `jolli:init`. The umbrella reads how the repo is set up and routes into init itself when setup is incomplete, so naming the sub-skill first skipped the state-aware entry point.

- The Claude README keeps the first-session caveat — its umbrella is a project skill the plugin *writes*, not a bundled one, so a brand-new repo may not show it until the next session.
- The Codex README drops its Development section: the published repo is a generated release artifact, and its readers should be sent to the monorepo for source, issues, and patches.

## Tests

Shape tests pin both halves, which live in different files and are not type-checked — the placeholder's presence and its one-per-line form, and each script's own slug. New `ClaudePluginPublishDocs.test.ts` mirrors the technique already used for Codex in `CodexPluginManifest.test.ts`.

`npm run all` passes: all four build targets, both typechecks and lints, CLI 372 files / 10136 tests, 5 acceptance files, vscode 109 files / 4536 tests.