### PR TITLE
Collapse duplicate KB folders on sidebar Refresh (jolliai + jolliai-2 symptom)

### DIFF
--- a/cli/src/core/FolderConsolidation.test.ts
+++ b/cli/src/core/FolderConsolidation.test.ts
@@ -1,0 +1,419 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FileWrite, SummaryIndex } from "../Types.js";
+import {
+	__setSotResolverForTests,
+	type ConsolidationPlan,
+	classifyDuplicateFolders,
+	executeConsolidation,
+} from "./FolderConsolidation.js";
+import { __setSshRunnerForTests } from "./SshAliasResolver.js";
+import type { StorageProvider } from "./StorageProvider.js";
+
+// Keep visible-markdown generation trivial so the orphan-superset rebuild does
+// not depend on the full CommitSummary rendering surface.
+vi.mock("./SummaryMarkdownBuilder.js", () => ({
+	buildMarkdown: vi.fn().mockReturnValue("# Mock Markdown\n\nBody"),
+}));
+
+vi.spyOn(console, "log").mockImplementation(() => {});
+vi.spyOn(console, "warn").mockImplementation(() => {});
+vi.spyOn(console, "error").mockImplementation(() => {});
+
+/** In-memory StorageProvider standing in for the orphan branch. */
+class InMemoryStorage implements StorageProvider {
+	private files = new Map<string, string>();
+	private present: boolean;
+	constructor(present = true) {
+		this.present = present;
+	}
+	async readFile(path: string): Promise<string | null> {
+		return this.files.get(path) ?? null;
+	}
+	async writeFiles(files: FileWrite[], _msg: string): Promise<void> {
+		for (const f of files) {
+			if (f.delete) this.files.delete(f.path);
+			else this.files.set(f.path, f.content);
+		}
+	}
+	async listFiles(prefix: string): Promise<string[]> {
+		return [...this.files.keys()].filter((k) => k.startsWith(prefix)).sort();
+	}
+	async exists(): Promise<boolean> {
+		return this.present;
+	}
+	async ensure(): Promise<void> {}
+}
+
+function makeTmpParent(): string {
+	const dir = join(tmpdir(), `kb-consol-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+function summaryJson(hash: string): string {
+	return JSON.stringify({
+		version: 3,
+		commitHash: hash,
+		commitMessage: "Test commit",
+		commitAuthor: "Alice",
+		commitDate: "2026-01-15T10:00:00Z",
+		branch: "main",
+		generatedAt: "2026-01-15T10:00:00Z",
+		topics: [{ title: "T", trigger: "t", response: "r", decisions: "d" }],
+		stats: { filesChanged: 1, insertions: 1, deletions: 0 },
+	});
+}
+
+function indexJson(hashes: string[]): string {
+	const index: SummaryIndex = {
+		version: 3,
+		entries: hashes.map((h) => ({
+			commitHash: h,
+			parentCommitHash: null,
+			commitMessage: "Test",
+			commitDate: "2026-01-15T10:00:00Z",
+			branch: "main",
+			generatedAt: "2026-01-15T10:00:00Z",
+		})),
+	};
+	return JSON.stringify(index);
+}
+
+/** Creates `<parent>/<name>/.jolli/{config,index,summaries}` for a repo. */
+function makeKbFolder(
+	parent: string,
+	name: string,
+	opts: { remoteUrl: string; repoName: string; hashes: string[] },
+): string {
+	const root = join(parent, name);
+	const jolli = join(root, ".jolli");
+	mkdirSync(join(jolli, "summaries"), { recursive: true });
+	writeFileSync(
+		join(jolli, "config.json"),
+		JSON.stringify({ version: 1, sortOrder: "date", remoteUrl: opts.remoteUrl, repoName: opts.repoName }),
+	);
+	for (const h of opts.hashes) writeFileSync(join(jolli, "summaries", `${h}.json`), summaryJson(h));
+	writeFileSync(join(jolli, "index.json"), indexJson(opts.hashes));
+	return root;
+}
+
+function summaryHashesOnDisk(root: string): string[] {
+	try {
+		return readdirSync(join(root, ".jolli", "summaries"))
+			.filter((n) => n.endsWith(".json"))
+			.map((n) => n.slice(0, -5))
+			.sort();
+	} catch {
+		return [];
+	}
+}
+
+const REMOTE = "git@github.com:acme/app.git";
+
+function assertPlan(plan: ConsolidationPlan | null): asserts plan is ConsolidationPlan {
+	expect(plan).not.toBeNull();
+	if (!plan) throw new Error("expected a consolidation plan");
+}
+
+describe("FolderConsolidation", () => {
+	let parent: string;
+
+	beforeEach(() => {
+		parent = makeTmpParent();
+		// Default: orphan branch empty (present but no summaries) → union-largest path.
+		__setSotResolverForTests(async () => new InMemoryStorage(true));
+	});
+
+	afterEach(() => {
+		__setSotResolverForTests(null);
+		__setSshRunnerForTests(null);
+		try {
+			rmSync(parent, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	describe("classifyDuplicateFolders", () => {
+		it("returns null when fewer than two folders exist for the repo", async () => {
+			makeKbFolder(parent, "app", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2"] });
+			expect(await classifyDuplicateFolders("/cwd", "app", REMOTE, parent)).toBeNull();
+		});
+
+		it("classifies identical folders and keeps the shortest name as survivor", async () => {
+			makeKbFolder(parent, "app", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2"] });
+			makeKbFolder(parent, "app-2", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2"] });
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			expect(plan?.kind).toBe("identical");
+			expect(plan?.survivor).toBe(join(parent, "app"));
+			expect(plan?.archived).toEqual([join(parent, "app-2")]);
+			expect(plan?.counts.added).toBe(0);
+		});
+
+		it("classifies union-largest when a folder holds summaries beyond the orphan branch", async () => {
+			makeKbFolder(parent, "app", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2", "a3"] });
+			makeKbFolder(parent, "app-2", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "z9"] });
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			expect(plan?.kind).toBe("union-largest");
+			expect(plan?.survivor).toBe(join(parent, "app")); // 3 > 2
+			expect(plan?.counts.union).toBe(4);
+			expect(plan?.counts.survivor).toBe(3);
+			expect(plan?.counts.added).toBe(1);
+		});
+
+		it("classifies orphan-superset when the orphan branch already covers every folder", async () => {
+			makeKbFolder(parent, "app", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2"] });
+			makeKbFolder(parent, "app-2", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a3"] });
+			const sot = new InMemoryStorage(true);
+			await sot.writeFiles(
+				[
+					{ path: "index.json", content: indexJson(["a1", "a2", "a3"]) },
+					{ path: "summaries/a1.json", content: summaryJson("a1") },
+					{ path: "summaries/a2.json", content: summaryJson("a2") },
+					{ path: "summaries/a3.json", content: summaryJson("a3") },
+				],
+				"seed",
+			);
+			__setSotResolverForTests(async () => sot);
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			expect(plan?.kind).toBe("orphan-superset");
+			expect(plan?.survivor).toBe(join(parent, "app")); // canonical base slot
+			expect(plan?.archived).toEqual([join(parent, "app"), join(parent, "app-2")]);
+		});
+
+		it("groups folders split only by an ssh host alias", async () => {
+			makeKbFolder(parent, "app", {
+				remoteUrl: "git@github-alias:acme/app.git",
+				repoName: "app",
+				hashes: ["a1", "a2", "a3"],
+			});
+			makeKbFolder(parent, "app-2", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1"] });
+			__setSshRunnerForTests((host) =>
+				host === "github-alias" ? "hostname github.com\n" : `hostname ${host}\n`,
+			);
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			expect(plan).not.toBeNull();
+			expect(plan?.folders).toEqual([join(parent, "app"), join(parent, "app-2")]);
+			expect(plan?.kind).toBe("union-largest");
+		});
+	});
+
+	describe("executeConsolidation", () => {
+		it("identical: archives the loser, survivor unchanged", async () => {
+			makeKbFolder(parent, "app", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2"] });
+			makeKbFolder(parent, "app-2", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2"] });
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			assertPlan(plan);
+			const result = await executeConsolidation(plan, "/cwd", REMOTE, parent);
+			expect(result.kind).toBe("identical");
+			expect(summaryHashesOnDisk(join(parent, "app"))).toEqual(["a1", "a2"]);
+			expect(existsSync(join(parent, "app-2"))).toBe(false);
+			expect(existsSync(join(parent, ".jolli", "archive"))).toBe(true);
+		});
+
+		it("union-largest: folds the smaller folder into the largest and archives it", async () => {
+			makeKbFolder(parent, "app", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2", "a3"] });
+			makeKbFolder(parent, "app-2", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "z9"] });
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			assertPlan(plan);
+			const result = await executeConsolidation(plan, "/cwd", REMOTE, parent);
+
+			expect(result.kind).toBe("union-largest");
+			expect(result.survivor).toBe(join(parent, "app"));
+			expect(result.summariesAfter).toBe(4);
+			// Survivor gained z9 from app-2.
+			expect(summaryHashesOnDisk(join(parent, "app"))).toEqual(["a1", "a2", "a3", "z9"]);
+			// Merged index.json contains the union.
+			const idx = JSON.parse(readFileSync(join(parent, "app", ".jolli", "index.json"), "utf-8")) as SummaryIndex;
+			expect(idx.entries.map((e) => e.commitHash).sort()).toEqual(["a1", "a2", "a3", "z9"]);
+			// Loser archived.
+			expect(existsSync(join(parent, "app-2"))).toBe(false);
+			const archived = readdirSync(join(parent, ".jolli", "archive"));
+			expect(archived.some((n) => n.startsWith("app-2-"))).toBe(true);
+		});
+
+		it("union-largest: does not overwrite a summary the survivor already has", async () => {
+			makeKbFolder(parent, "app", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2"] });
+			makeKbFolder(parent, "app-2", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1"] });
+			// Give the survivor's a1 a distinctive content; app-2's a1 must not clobber it.
+			writeFileSync(join(parent, "app", ".jolli", "summaries", "a1.json"), '{"marker":"survivor"}');
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			assertPlan(plan);
+			await executeConsolidation(plan, "/cwd", REMOTE, parent);
+			expect(readFileSync(join(parent, "app", ".jolli", "summaries", "a1.json"), "utf-8")).toBe(
+				'{"marker":"survivor"}',
+			);
+		});
+
+		it("orphan-superset: rebuilds the base folder from the orphan branch and archives the pile", async () => {
+			makeKbFolder(parent, "app", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2"] });
+			makeKbFolder(parent, "app-2", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a3"] });
+			const sot = new InMemoryStorage(true);
+			await sot.writeFiles(
+				[
+					{ path: "index.json", content: indexJson(["a1", "a2", "a3"]) },
+					{ path: "summaries/a1.json", content: summaryJson("a1") },
+					{ path: "summaries/a2.json", content: summaryJson("a2") },
+					{ path: "summaries/a3.json", content: summaryJson("a3") },
+				],
+				"seed",
+			);
+			__setSotResolverForTests(async () => sot);
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			assertPlan(plan);
+			const result = await executeConsolidation(plan, "/cwd", REMOTE, parent);
+
+			expect(result.kind).toBe("orphan-superset");
+			expect(result.survivor).toBe(join(parent, "app"));
+			expect(summaryHashesOnDisk(join(parent, "app"))).toEqual(["a1", "a2", "a3"]);
+			// Both original folders were archived (base then recreated by the rebuild).
+			const archived = readdirSync(join(parent, ".jolli", "archive"));
+			expect(archived.some((n) => n.startsWith("app-2-"))).toBe(true);
+			expect(archived.some((n) => /^app-\d/.test(n))).toBe(true);
+		});
+
+		it("orphan-superset falls back to a folder merge if the source of truth is gone at execute time", async () => {
+			makeKbFolder(parent, "app", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2"] });
+			makeKbFolder(parent, "app-2", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a3"] });
+			const sot = new InMemoryStorage(true);
+			await sot.writeFiles(
+				[
+					{ path: "index.json", content: indexJson(["a1", "a2", "a3"]) },
+					{ path: "summaries/a1.json", content: summaryJson("a1") },
+					{ path: "summaries/a2.json", content: summaryJson("a2") },
+					{ path: "summaries/a3.json", content: summaryJson("a3") },
+				],
+				"seed",
+			);
+			__setSotResolverForTests(async () => sot);
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			assertPlan(plan);
+			expect(plan.kind).toBe("orphan-superset");
+			// Source of truth vanishes before execution → must not archive everything
+			// and rebuild nothing; falls back to a lossless folder union instead.
+			__setSotResolverForTests(async () => new InMemoryStorage(false));
+			const result = await executeConsolidation(plan, "/cwd", REMOTE, parent);
+			expect(result.kind).toBe("union-largest");
+			expect(summaryHashesOnDisk(join(parent, "app"))).toEqual(["a1", "a2", "a3"]);
+			expect(existsSync(join(parent, "app-2"))).toBe(false);
+		});
+
+		it("copies a survivor-absent visible file too, not just hidden .jolli data", async () => {
+			makeKbFolder(parent, "app", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2"] });
+			makeKbFolder(parent, "app-2", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1"] });
+			// A visible branch-folder markdown only app-2 has.
+			mkdirSync(join(parent, "app-2", "main"), { recursive: true });
+			writeFileSync(join(parent, "app-2", "main", "note-abc.md"), "# hi");
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			assertPlan(plan);
+			await executeConsolidation(plan, "/cwd", REMOTE, parent);
+			expect(existsSync(join(parent, "app", "main", "note-abc.md"))).toBe(true);
+		});
+	});
+
+	describe("classification edge cases", () => {
+		it("treats an unreadable source of truth as empty → union-largest", async () => {
+			makeKbFolder(parent, "app", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2"] });
+			makeKbFolder(parent, "app-2", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a3"] });
+			__setSotResolverForTests(async () => {
+				throw new Error("boom");
+			});
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			expect(plan?.kind).toBe("union-largest");
+		});
+
+		it("breaks a size tie toward the shortest folder name", async () => {
+			makeKbFolder(parent, "app", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2"] });
+			makeKbFolder(parent, "app-2", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a3"] });
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			expect(plan?.kind).toBe("union-largest");
+			expect(plan?.survivor).toBe(join(parent, "app")); // 2 == 2 → shortest name wins
+		});
+
+		it("unions manifest and branches across folders, deduping by id/branch", async () => {
+			makeKbFolder(parent, "app", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2", "a3"] });
+			makeKbFolder(parent, "app-2", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "z9"] });
+			// Survivor (app) and loser (app-2) each carry manifest + branches, with one
+			// overlapping fileId ("a1") and one overlapping branch ("main").
+			writeFileSync(
+				join(parent, "app", ".jolli", "manifest.json"),
+				JSON.stringify({
+					version: 1,
+					files: [{ path: "main/a1.md", fileId: "a1", type: "commit", fingerprint: "x", source: {} }],
+				}),
+			);
+			writeFileSync(
+				join(parent, "app-2", ".jolli", "manifest.json"),
+				JSON.stringify({
+					version: 1,
+					files: [
+						{ path: "main/a1.md", fileId: "a1", type: "commit", fingerprint: "y", source: {} },
+						{ path: "main/z9.md", fileId: "z9", type: "commit", fingerprint: "z", source: {} },
+					],
+				}),
+			);
+			writeFileSync(
+				join(parent, "app", ".jolli", "branches.json"),
+				JSON.stringify({ version: 1, mappings: [{ folder: "main", branch: "main", createdAt: "t" }] }),
+			);
+			writeFileSync(
+				join(parent, "app-2", ".jolli", "branches.json"),
+				JSON.stringify({
+					version: 1,
+					mappings: [
+						{ folder: "main", branch: "main", createdAt: "t2" },
+						{ folder: "feat", branch: "feat", createdAt: "t3" },
+					],
+				}),
+			);
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			assertPlan(plan);
+			await executeConsolidation(plan, "/cwd", REMOTE, parent);
+
+			const manifest = JSON.parse(readFileSync(join(parent, "app", ".jolli", "manifest.json"), "utf-8"));
+			// Union by fileId: a1 (survivor's, kept) + z9 (from loser).
+			expect(manifest.files.map((f: { fileId: string }) => f.fileId).sort()).toEqual(["a1", "z9"]);
+			expect(manifest.files.find((f: { fileId: string }) => f.fileId === "a1").fingerprint).toBe("x");
+			const branches = JSON.parse(readFileSync(join(parent, "app", ".jolli", "branches.json"), "utf-8"));
+			expect(branches.mappings.map((m: { branch: string }) => m.branch).sort()).toEqual(["feat", "main"]);
+		});
+
+		it("tolerates a duplicate folder with no summaries directory", async () => {
+			makeKbFolder(parent, "app", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2"] });
+			// A same-repo folder that has config/index but no summaries/ dir at all.
+			mkdirSync(join(parent, "app-2", ".jolli"), { recursive: true });
+			writeFileSync(
+				join(parent, "app-2", ".jolli", "config.json"),
+				JSON.stringify({ version: 1, sortOrder: "date", remoteUrl: REMOTE, repoName: "app" }),
+			);
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			expect(plan?.kind).toBe("union-largest");
+			expect(plan?.counts.perFolder[join(parent, "app-2")]).toBe(0);
+			expect(plan?.survivor).toBe(join(parent, "app"));
+		});
+
+		it("merges commitAliases across folders", async () => {
+			makeKbFolder(parent, "app", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2", "a3"] });
+			makeKbFolder(parent, "app-2", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "z9"] });
+			writeFileSync(
+				join(parent, "app-2", ".jolli", "index.json"),
+				JSON.stringify({
+					version: 3,
+					entries: [
+						{ commitHash: "a1", parentCommitHash: null },
+						{ commitHash: "z9", parentCommitHash: null },
+					],
+					commitAliases: { unknownhash: "z9" },
+				}),
+			);
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			assertPlan(plan);
+			await executeConsolidation(plan, "/cwd", REMOTE, parent);
+			const idx = JSON.parse(readFileSync(join(parent, "app", ".jolli", "index.json"), "utf-8")) as SummaryIndex;
+			expect(idx.commitAliases).toMatchObject({ unknownhash: "z9" });
+		});
+	});
+});

--- a/cli/src/core/FolderConsolidation.ts
+++ b/cli/src/core/FolderConsolidation.ts
@@ -165,6 +165,14 @@ export async function classifyDuplicateFolders(
 /**
  * Executes a plan produced by {@link classifyDuplicateFolders}. Returns a
  * summary of what happened.
+ *
+ * MUST be called while holding `vault-write.lock` for the vault
+ * (`resolveKbParent(customPath)`): the copy-if-absent, metadata union and
+ * `archiveKBFolder` all mutate the vault working tree, so an unlocked run can
+ * race QueueWorker / SyncEngine / compile (a torn `git status`, or a sync
+ * `git add` on a path this just moved). The only caller today,
+ * `KbFoldersService.runConsolidation`, wraps it in `withVaultWriteLock`; any
+ * new caller must do the same.
  */
 export async function executeConsolidation(
 	plan: ConsolidationPlan,

--- a/cli/src/core/FolderConsolidation.ts
+++ b/cli/src/core/FolderConsolidation.ts
@@ -1,0 +1,421 @@
+/**
+ * FolderConsolidation — merges duplicate Memory Bank folders for ONE repo into a
+ * single survivor, chosen by comparing folder contents against each other and
+ * against the orphan branch (the system of record).
+ *
+ * Why this exists: a repo could split across `<repo>` and `<repo>-2` folders —
+ * most often because a `~/.ssh/config` host alias made the same remote fold to
+ * two different keys (fixed at the identity layer in `KBPathResolver`, but that
+ * fix cannot retract the folders already on disk). PR #443's Refresh sweep only
+ * archives *empty* folders; a populated duplicate needs a real merge.
+ *
+ * The three cases (the classifier picks one; the executor acts on it):
+ *
+ *  - **identical** — every folder holds the same set of summaries. Keep the
+ *    shortest-named folder, archive the rest. Nothing is moved (they match).
+ *  - **orphan-superset** — folders differ, but the orphan branch already
+ *    contains every folder's summaries. Rebuild one clean folder from the
+ *    orphan branch (the existing Migrate-to-Memory-Bank flow) and archive the
+ *    pile — lossless because the source of truth has everything.
+ *  - **union-largest** — some folder holds summaries the orphan branch does
+ *    NOT (typically written by another clone whose orphan branch lives
+ *    elsewhere). Rebuilding from the orphan branch would DROP those, so instead
+ *    fold every folder into the largest one (copy-if-absent across every layer),
+ *    merge the metadata indexes, then archive the drained duplicates.
+ *
+ * Scoped to a single repo — the caller passes the currently-open repo's
+ * identity. Archiving is `KBPathResolver.archiveKBFolder` (a recoverable move
+ * into `<parent>/.jolli/archive/`), never a hard delete.
+ *
+ * Product rule, so it lives in `cli/src/core` (VS Code imports it; IntelliJ can
+ * reach it over the ide-bridge later).
+ */
+
+import { copyFileSync, type Dirent, existsSync, mkdirSync, readdirSync, renameSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, relative } from "node:path";
+import { createLogger } from "../Logger.js";
+import type { SummaryIndex } from "../Types.js";
+import { FolderStorage } from "./FolderStorage.js";
+import { archiveKBFolder, findRepoFolders, initializeKBFolder, resolveKbParent } from "./KBPathResolver.js";
+import type { BranchesJson, Manifest } from "./KBTypes.js";
+import { MetadataManager } from "./MetadataManager.js";
+import { MigrationEngine } from "./MigrationEngine.js";
+import { toForwardSlash } from "./PathUtils.js";
+import { resolveSotStorage } from "./SotStorageResolver.js";
+import type { StorageProvider } from "./StorageProvider.js";
+
+const log = createLogger("FolderConsolidation");
+
+// Indirection so tests can supply a fake source of truth (a FolderStorage over a
+// temp dir) instead of standing up a real orphan branch. Production always uses
+// `resolveSotStorage`.
+let sotResolver: (cwd: string) => Promise<StorageProvider> = resolveSotStorage;
+
+/** Test seam: override the source-of-truth resolver. Pass `null` to restore. */
+export function __setSotResolverForTests(fn: ((cwd: string) => Promise<StorageProvider>) | null): void {
+	sotResolver = fn ?? resolveSotStorage;
+}
+
+export type ConsolidationKind = "identical" | "orphan-superset" | "union-largest";
+
+export interface ConsolidationPlan {
+	readonly kind: ConsolidationKind;
+	readonly repoName: string;
+	/** Absolute paths of every folder that currently holds this repo (≥ 2). */
+	readonly folders: readonly string[];
+	/**
+	 * The folder that will remain live. For `orphan-superset` this is the
+	 * canonical `<parent>/<repo>` base slot the rebuild lands on (which may
+	 * itself be archived-then-recreated); for the other kinds it is an existing
+	 * folder in {@link folders}.
+	 */
+	readonly survivor: string;
+	/** Folders that will be archived. For `orphan-superset` this is ALL folders. */
+	readonly archived: readonly string[];
+	readonly counts: {
+		/** folder path → summary count. */
+		readonly perFolder: Readonly<Record<string, number>>;
+		readonly orphan: number;
+		readonly union: number;
+		readonly survivor: number;
+		/** Summaries the survivor gains from the others (`union − survivor`). */
+		readonly added: number;
+	};
+}
+
+export interface ConsolidationResult {
+	readonly kind: ConsolidationKind;
+	readonly survivor: string;
+	readonly archived: readonly string[];
+	readonly summariesAfter: number;
+}
+
+/** `.jolli/` top-level files that are merged (index) or survivor-owned — never raw-copied. */
+const MERGED_OR_OWNED_META: ReadonlySet<string> = new Set([
+	".jolli/index.json",
+	".jolli/manifest.json",
+	".jolli/branches.json",
+	".jolli/config.json",
+	".jolli/migration.json",
+	".jolli/shadow-status.json",
+]);
+
+/**
+ * Classifies the duplicate folders for the given repo, or returns `null` when
+ * there is nothing to consolidate (fewer than two folders).
+ */
+export async function classifyDuplicateFolders(
+	cwd: string,
+	repoName: string,
+	remoteUrl: string | null,
+	customPath?: string,
+): Promise<ConsolidationPlan | null> {
+	const folders = findRepoFolders(repoName, remoteUrl, customPath);
+	if (folders.length < 2) return null;
+
+	const perFolder: Record<string, number> = {};
+	const hashSets = new Map<string, Set<string>>();
+	const union = new Set<string>();
+	for (const folder of folders) {
+		const hashes = readSummaryHashes(folder);
+		hashSets.set(folder, hashes);
+		perFolder[folder] = hashes.size;
+		for (const h of hashes) union.add(h);
+	}
+
+	const orphan = await readOrphanSummaryHashes(cwd);
+	const first = hashSets.get(folders[0]) ?? new Set<string>();
+	const allEqual = folders.every((f) => setsEqual(hashSets.get(f) ?? new Set(), first));
+
+	let kind: ConsolidationKind;
+	let survivor: string;
+	let archived: readonly string[];
+	if (allEqual) {
+		kind = "identical";
+		survivor = shortestNamed(folders);
+		archived = folders.filter((f) => f !== survivor);
+	} else if (isSubset(union, orphan)) {
+		kind = "orphan-superset";
+		// The rebuild lands on the canonical base slot; the whole pile is archived
+		// first (the base included), mirroring rebuildKnowledgeBase.
+		survivor = join(resolveKbParent(customPath), repoName);
+		archived = folders;
+	} else {
+		kind = "union-largest";
+		survivor = largestNamed(folders, perFolder);
+		archived = folders.filter((f) => f !== survivor);
+	}
+
+	return {
+		kind,
+		repoName,
+		folders,
+		survivor,
+		archived,
+		counts: {
+			perFolder,
+			orphan: orphan.size,
+			union: union.size,
+			survivor: perFolder[survivor] ?? 0,
+			added: union.size - (perFolder[survivor] ?? 0),
+		},
+	};
+}
+
+/**
+ * Executes a plan produced by {@link classifyDuplicateFolders}. Returns a
+ * summary of what happened.
+ */
+export async function executeConsolidation(
+	plan: ConsolidationPlan,
+	cwd: string,
+	remoteUrl: string | null,
+	customPath?: string,
+): Promise<ConsolidationResult> {
+	if (plan.kind === "orphan-superset") {
+		return rebuildFromOrphan(plan, cwd, remoteUrl, customPath);
+	}
+	return mergeIntoSurvivor(plan, customPath);
+}
+
+// ── Executors ──────────────────────────────────────────────────────────────
+
+async function mergeIntoSurvivor(plan: ConsolidationPlan, customPath?: string): Promise<ConsolidationResult> {
+	const survivor = plan.survivor;
+	mkdirSync(join(survivor, ".jolli"), { recursive: true });
+
+	// 1. Copy every layer (hidden + visible) from each other folder into the
+	//    survivor when absent. A plain copy-if-absent cannot lose data: the
+	//    survivor keeps its own version of any path they share, and gains the
+	//    rest. The merged/owned metadata files are handled in step 2 instead.
+	for (const other of plan.archived) {
+		copyTreeIfAbsent(other, survivor);
+	}
+
+	// 2. Union the three metadata indexes (survivor entries win on conflict).
+	mergeIndexes(survivor, plan.archived);
+
+	// 3. Regenerate any missing visible summary markdown (safety net — copied
+	//    raw above, this fixes gaps left by an interrupted earlier write).
+	const mm = new MetadataManager(join(survivor, ".jolli"));
+	const folder = new FolderStorage(survivor, mm);
+	await folder.healMissingVisibleMarkdown();
+
+	// 4. Archive the drained duplicates (recoverable move).
+	for (const other of plan.archived) {
+		archiveKBFolder(other, customPath);
+	}
+
+	return {
+		kind: plan.kind,
+		survivor,
+		archived: plan.archived,
+		summariesAfter: readSummaryHashes(survivor).size,
+	};
+}
+
+async function rebuildFromOrphan(
+	plan: ConsolidationPlan,
+	cwd: string,
+	remoteUrl: string | null,
+	customPath?: string,
+): Promise<ConsolidationResult> {
+	const sot = await sotResolver(cwd);
+	// Defensive: `orphan-superset` implies a non-empty orphan branch, but if the
+	// source of truth is somehow gone, fall back to a lossless folder merge
+	// rather than archiving everything and rebuilding nothing.
+	if (!(await sot.exists())) {
+		log.warn("rebuildFromOrphan: no source of truth — falling back to folder merge");
+		const survivor = largestNamed(plan.folders, plan.counts.perFolder);
+		return mergeIntoSurvivor(
+			{ ...plan, kind: "union-largest", survivor, archived: plan.folders.filter((f) => f !== survivor) },
+			customPath,
+		);
+	}
+
+	// Archive the whole pile first (base included) so the rebuild lands back on
+	// the canonical base slot — the same sequence as rebuildKnowledgeBase.
+	for (const folder of plan.folders) {
+		archiveKBFolder(folder, customPath);
+	}
+
+	const base = plan.survivor;
+	initializeKBFolder(base, plan.repoName, remoteUrl);
+	const mm = new MetadataManager(join(base, ".jolli"));
+	const folder = new FolderStorage(base, mm);
+	await folder.ensure();
+	await new MigrationEngine(sot, folder, mm).runMigration();
+
+	return {
+		kind: plan.kind,
+		survivor: base,
+		archived: plan.folders,
+		summariesAfter: readSummaryHashes(base).size,
+	};
+}
+
+// ── Metadata merge ───────────────────────────────────────────────────────────
+
+function mergeIndexes(survivor: string, others: readonly string[]): void {
+	mergeIndexJson(survivor, others);
+	mergeManifestJson(survivor, others);
+	mergeBranchesJson(survivor, others);
+}
+
+function mergeIndexJson(survivor: string, others: readonly string[]): void {
+	const survivorMm = new MetadataManager(join(survivor, ".jolli"));
+	const base = survivorMm.readIndex();
+	const byHash = new Map<string, SummaryIndex["entries"][number]>();
+	const aliases: Record<string, string> = {};
+	let version: SummaryIndex["version"] = base?.version ?? 3;
+
+	// Survivor first so its entries win on conflict.
+	const sources = [survivor, ...others];
+	for (const root of sources) {
+		const idx = new MetadataManager(join(root, ".jolli")).readIndex();
+		if (!idx) continue;
+		if (root === survivor) version = idx.version;
+		for (const [k, v] of Object.entries(idx.commitAliases ?? {})) {
+			if (!(k in aliases)) aliases[k] = v;
+		}
+		for (const entry of idx.entries ?? []) {
+			if (entry?.commitHash && !byHash.has(entry.commitHash)) byHash.set(entry.commitHash, entry);
+		}
+	}
+
+	const merged: SummaryIndex = {
+		version,
+		entries: [...byHash.values()],
+		...(Object.keys(aliases).length > 0 ? { commitAliases: aliases } : {}),
+	};
+	atomicWriteJson(join(survivor, ".jolli", "index.json"), merged);
+}
+
+function mergeManifestJson(survivor: string, others: readonly string[]): void {
+	const byId = new Map<string, Manifest["files"][number]>();
+	let version = 1;
+	for (const root of [survivor, ...others]) {
+		const manifest = new MetadataManager(join(root, ".jolli")).readManifest();
+		if (root === survivor) version = manifest.version;
+		for (const file of manifest.files) {
+			if (file?.fileId && !byId.has(file.fileId)) byId.set(file.fileId, file);
+		}
+	}
+	atomicWriteJson(join(survivor, ".jolli", "manifest.json"), { version, files: [...byId.values()] });
+}
+
+function mergeBranchesJson(survivor: string, others: readonly string[]): void {
+	const byBranch = new Map<string, BranchesJson["mappings"][number]>();
+	let version = 1;
+	for (const root of [survivor, ...others]) {
+		const branches = new MetadataManager(join(root, ".jolli")).readBranches();
+		if (root === survivor) version = branches.version;
+		for (const mapping of branches.mappings) {
+			if (mapping?.branch && !byBranch.has(mapping.branch)) byBranch.set(mapping.branch, mapping);
+		}
+	}
+	atomicWriteJson(join(survivor, ".jolli", "branches.json"), { version, mappings: [...byBranch.values()] });
+}
+
+// ── Filesystem helpers ───────────────────────────────────────────────────────
+
+/** Recursively copies files from `src` into `dst`, skipping any that already exist. */
+function copyTreeIfAbsent(src: string, dst: string): void {
+	walkFiles(src, (absPath) => {
+		const rel = toForwardSlash(relative(src, absPath));
+		if (MERGED_OR_OWNED_META.has(rel)) return;
+		// Never descend into a nested archive or a git dir (per-repo folders have
+		// neither, but the Memory Bank root can — belt and braces).
+		if (rel.startsWith(".jolli/archive/") || rel === ".git" || rel.startsWith(".git/")) return;
+		const target = join(dst, rel);
+		if (existsSync(target)) return;
+		mkdirSync(dirname(target), { recursive: true });
+		copyFileSync(absPath, target);
+	});
+}
+
+function walkFiles(dir: string, onFile: (absPath: string) => void): void {
+	let entries: Dirent[];
+	try {
+		entries = readdirSync(dir, { withFileTypes: true });
+	} catch {
+		/* v8 ignore next -- defensive: an unreadable subdir mid-walk (permission/race); skip it rather than abort the merge */
+		return;
+	}
+	for (const entry of entries) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (entry.name === "archive" || entry.name === ".git") continue;
+			walkFiles(full, onFile);
+		} else if (entry.isFile()) {
+			onFile(full);
+		}
+	}
+}
+
+function readSummaryHashes(folderRoot: string): Set<string> {
+	const out = new Set<string>();
+	let names: string[];
+	try {
+		names = readdirSync(join(folderRoot, ".jolli", "summaries"));
+	} catch {
+		return out;
+	}
+	for (const name of names) {
+		if (name.endsWith(".json")) out.add(name.slice(0, -".json".length));
+	}
+	return out;
+}
+
+async function readOrphanSummaryHashes(cwd: string): Promise<Set<string>> {
+	const out = new Set<string>();
+	try {
+		const sot = await sotResolver(cwd);
+		if (!(await sot.exists())) return out;
+		for (const path of await sot.listFiles("summaries")) {
+			const name = basename(path);
+			if (name.endsWith(".json")) out.add(name.slice(0, -".json".length));
+		}
+	} catch (err) {
+		// Treat an unreadable source of truth as empty → the safe `union-largest`
+		// branch (fold folders together) rather than a rebuild that could drop data.
+		log.warn("readOrphanSummaryHashes failed: %s", err instanceof Error ? err.message : String(err));
+	}
+	return out;
+}
+
+function atomicWriteJson(path: string, obj: unknown): void {
+	mkdirSync(dirname(path), { recursive: true });
+	const tmp = `${path}.tmp`;
+	writeFileSync(tmp, JSON.stringify(obj, null, "\t"), "utf-8");
+	renameSync(tmp, path);
+}
+
+// ── Set / selection helpers ──────────────────────────────────────────────────
+
+function setsEqual(a: Set<string>, b: Set<string>): boolean {
+	if (a.size !== b.size) return false;
+	for (const v of a) if (!b.has(v)) return false;
+	return true;
+}
+
+function isSubset(subset: Set<string>, superset: Set<string>): boolean {
+	for (const v of subset) if (!superset.has(v)) return false;
+	return true;
+}
+
+/** Folder with the shortest basename; ties broken lexicographically for determinism. */
+function shortestNamed(folders: readonly string[]): string {
+	return [...folders].sort((a, b) => {
+		const la = basename(a).length;
+		const lb = basename(b).length;
+		return la !== lb ? la - lb : basename(a).localeCompare(basename(b));
+	})[0];
+}
+
+/** Folder with the most summaries; ties broken by {@link shortestNamed}. */
+function largestNamed(folders: readonly string[], perFolder: Readonly<Record<string, number>>): string {
+	const max = Math.max(...folders.map((f) => perFolder[f] ?? 0));
+	const tied = folders.filter((f) => (perFolder[f] ?? 0) === max);
+	return shortestNamed(tied);
+}

--- a/cli/src/core/KBPathResolver.test.ts
+++ b/cli/src/core/KBPathResolver.test.ts
@@ -23,6 +23,7 @@ import {
 	resolveKBPath,
 	resolveMemoryBankState,
 } from "./KBPathResolver.js";
+import { __setSshRunnerForTests } from "./SshAliasResolver.js";
 
 function git(cwd: string, args: string[]): void {
 	execFileSync("git", args, { cwd, stdio: "ignore" });
@@ -387,6 +388,36 @@ esac
 			expect(foldGitTransportToHttps("C:/repos/foo")).toBe("C:/repos/foo");
 			expect(foldGitTransportToHttps("my-notes")).toBe("my-notes");
 			expect(foldGitTransportToHttps("mygit.local:repos/foo")).toBe("mygit.local:repos/foo");
+		});
+
+		describe("ssh host alias resolution (~/.ssh/config)", () => {
+			afterEach(() => {
+				__setSshRunnerForTests(null);
+			});
+
+			it("folds an ssh alias to its real HostName so aliased and direct clones match", () => {
+				__setSshRunnerForTests((host) =>
+					host === "github-jolli" ? "user git\nhostname github.com\nport 22\n" : `hostname ${host}\n`,
+				);
+				expect(foldGitTransportToHttps("git@github-jolli:jolliai/jolliai.git")).toBe(
+					"https://github.com/jolliai/jolliai.git",
+				);
+				expect(foldGitTransportToHttps("ssh://git@github-jolli/jolliai/jolliai")).toBe(
+					"https://github.com/jolliai/jolliai",
+				);
+			});
+
+			it("leaves the host unchanged when ssh -G fails or reports no alias", () => {
+				__setSshRunnerForTests(() => null);
+				expect(foldGitTransportToHttps("git@github.com:user/repo.git")).toBe(
+					"https://github.com/user/repo.git",
+				);
+			});
+
+			it("does not resolve bare host:path (no user@) — passthrough stays literal even with an alias runner", () => {
+				__setSshRunnerForTests(() => "hostname github.com\n");
+				expect(foldGitTransportToHttps("mygit.local:repos/foo")).toBe("mygit.local:repos/foo");
+			});
 		});
 	});
 

--- a/cli/src/core/KBPathResolver.ts
+++ b/cli/src/core/KBPathResolver.ts
@@ -551,13 +551,15 @@ function isSameRepo(config: KBConfig, remoteUrl: string | null, repoName: string
  * Canonical form of a git remote URL for identity comparison: SSH/git
  * transports folded to https, trailing slashes and `.git` stripped, lowercased.
  *
- * Exported (rather than kept private to `isSameRepo`) so consumers that need to
- * answer "are these two KB folders the same repo?" — VS Code's
- * `KbFoldersService.dedupeFolders` — reuse this exact comparer instead of
- * growing a fourth copy. The copies diverging is precisely what produced
- * duplicate `<repo>` / `<repo>-2` folders before.
+ * Deliberately module-private: "are these two folders the same repo?" is a
+ * question only the folder-claiming path should answer, and it must answer it
+ * through `isSameRepo`. A previous iteration exported this so the VS Code
+ * sidebar's Refresh could collapse duplicate folders on its own; that feature
+ * was withdrawn because Refresh must never move a folder holding memories —
+ * consolidating duplicates is Migrate's job (it can rebuild the survivor from
+ * the orphan branch, which a plain archive-the-loser move cannot).
  */
-export function normalizeRemoteUrl(url: string): string {
+function normalizeRemoteUrl(url: string): string {
 	return foldGitTransportToHttps(url)
 		.replace(/\/+$/, "")
 		.replace(/\.git$/, "")

--- a/cli/src/core/KBPathResolver.ts
+++ b/cli/src/core/KBPathResolver.ts
@@ -547,7 +547,17 @@ function isSameRepo(config: KBConfig, remoteUrl: string | null, repoName: string
 	return false;
 }
 
-function normalizeRemoteUrl(url: string): string {
+/**
+ * Canonical form of a git remote URL for identity comparison: SSH/git
+ * transports folded to https, trailing slashes and `.git` stripped, lowercased.
+ *
+ * Exported (rather than kept private to `isSameRepo`) so consumers that need to
+ * answer "are these two KB folders the same repo?" — VS Code's
+ * `KbFoldersService.dedupeFolders` — reuse this exact comparer instead of
+ * growing a fourth copy. The copies diverging is precisely what produced
+ * duplicate `<repo>` / `<repo>-2` folders before.
+ */
+export function normalizeRemoteUrl(url: string): string {
 	return foldGitTransportToHttps(url)
 		.replace(/\/+$/, "")
 		.replace(/\.git$/, "")

--- a/cli/src/core/KBPathResolver.ts
+++ b/cli/src/core/KBPathResolver.ts
@@ -24,6 +24,7 @@ import { execFileSyncHidden } from "../util/Subprocess.js";
 import type { ClaimVerdict, KBConfig, MemoryBankConfig, MemoryBankState } from "./KBTypes.js";
 import { MetadataManager } from "./MetadataManager.js";
 import { isPathInside } from "./PathUtils.js";
+import { resolveHostAlias } from "./SshAliasResolver.js";
 
 const log = createLogger("KBPathResolver");
 
@@ -588,6 +589,14 @@ function normalizeRemoteUrl(url: string): string {
  *     distinction of the SCP path is preserved (`host:/srv/repo` →
  *     `…host//srv/repo` vs `host:srv/repo` → `…host/srv/repo`).
  *
+ * The host token of every SSH/git transport is passed through
+ * {@link resolveHostAlias}, which resolves a `~/.ssh/config` `Host` alias to
+ * its real `HostName` (`git@github-jolli:owner/repo` → `https://github.com/
+ * owner/repo` when `github-jolli` aliases `github.com`). Without this, a repo
+ * cloned via an ssh alias and the same repo via `git@github.com:` folded to
+ * different keys and split into `<repo>` / `<repo>-2` folders. The bare
+ * `host:path` passthrough is unaffected — it never reaches the fold.
+ *
  * Anything else (https, file paths, bare names) passes through unchanged.
  *
  * Shared by the local folder-reuse predicate (`isSameRepo` above) and the
@@ -596,10 +605,11 @@ function normalizeRemoteUrl(url: string): string {
  * repo cloned via SSH on one device and https on another produced duplicate
  * `repos.json` rows plus a split local folder (`<repo>` / `<repo>-2`).
  *
- * The IntelliJ plugin carries a Kotlin port (`KBPathResolver.kt
- * foldGitTransportToHttps`) that must stay in lockstep — both IDEs resolve
- * folders in the same Memory Bank, and divergent folding sends them to
- * different folders for the same repo.
+ * The IntelliJ plugin resolves folder identity by calling this function over
+ * the `kb` ide-bridge action (see `KBPathResolver.kt`, a thin adapter), so
+ * this fix reaches IntelliJ with no Kotlin change. The *separate* server
+ * binding-key normalizer in `cli/src/core/GitRemoteUtils.ts` and its Kotlin
+ * twin `GitRemoteUtils.kt` are NOT alias-aware yet — a follow-up.
  */
 /**
  * Hosts whose owner/repo path is case-insensitive on the wire — clones typed
@@ -617,11 +627,11 @@ export const CASE_INSENSITIVE_PATH_HOSTS: ReadonlySet<string> = new Set(["github
 
 export function foldGitTransportToHttps(url: string): string {
 	const ssh = url.match(/^(?:git\+)?ssh:\/\/(?:[^@/]+@)?([^/:]+)(?::(\d+))?\/(.+)$/i);
-	if (ssh) return `https://${ssh[1]}${nonDefaultPortSegment(ssh[2], "22")}/${ssh[3]}`;
+	if (ssh) return `https://${resolveHostAlias(ssh[1])}${nonDefaultPortSegment(ssh[2], "22")}/${ssh[3]}`;
 	const git = url.match(/^git:\/\/([^/:]+)(?::(\d+))?\/(.+)$/i);
-	if (git) return `https://${git[1]}${nonDefaultPortSegment(git[2], "9418")}/${git[3]}`;
+	if (git) return `https://${resolveHostAlias(git[1])}${nonDefaultPortSegment(git[2], "9418")}/${git[3]}`;
 	const scp = url.match(/^[^@/:]+@([^/:]+):(.+)$/);
-	if (scp) return `https://${scp[1]}/${scp[2]}`;
+	if (scp) return `https://${resolveHostAlias(scp[1])}/${scp[2]}`;
 	return url;
 }
 

--- a/cli/src/core/SshAliasResolver.test.ts
+++ b/cli/src/core/SshAliasResolver.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { __resetSshAliasCacheForTests, __setSshRunnerForTests, resolveHostAlias } from "./SshAliasResolver.js";
+
+describe("SshAliasResolver", () => {
+	afterEach(() => {
+		// Restore the default (VITEST-guarded, no-op) runner and clear the cache.
+		__setSshRunnerForTests(null);
+	});
+
+	it("resolves an alias to its configured HostName from `ssh -G` output", () => {
+		__setSshRunnerForTests((host) =>
+			host === "github-jolli" ? "user git\nhostname github.com\nport 22\nidentityfile ~/.ssh/id_ed25519\n" : null,
+		);
+		expect(resolveHostAlias("github-jolli")).toBe("github.com");
+	});
+
+	it("returns the host unchanged when the runner reports failure (ssh missing / timeout)", () => {
+		__setSshRunnerForTests(() => null);
+		expect(resolveHostAlias("github.com")).toBe("github.com");
+	});
+
+	it("returns the host unchanged when output has no hostname line", () => {
+		__setSshRunnerForTests(() => "user git\nport 22\n");
+		expect(resolveHostAlias("weird-host")).toBe("weird-host");
+	});
+
+	it("is case-insensitive on the `hostname` key and tolerates CRLF", () => {
+		__setSshRunnerForTests(() => "User git\r\nHostName internal.example\r\nPort 2222\r\n");
+		expect(resolveHostAlias("alias")).toBe("internal.example");
+	});
+
+	it("memoizes: the runner is invoked at most once per host", () => {
+		const runner = vi.fn((host: string) => `hostname ${host === "a" ? "resolved-a" : host}\n`);
+		__setSshRunnerForTests(runner as unknown as (host: string) => string | null);
+		expect(resolveHostAlias("a")).toBe("resolved-a");
+		expect(resolveHostAlias("a")).toBe("resolved-a");
+		expect(runner).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns an empty host unchanged without invoking the runner", () => {
+		const runner = vi.fn(() => "hostname x\n");
+		__setSshRunnerForTests(runner as unknown as (host: string) => string | null);
+		expect(resolveHostAlias("")).toBe("");
+		expect(runner).not.toHaveBeenCalled();
+	});
+
+	it("re-queries after the cache is cleared", () => {
+		const runner = vi.fn(() => "hostname github.com\n");
+		__setSshRunnerForTests(runner as unknown as (host: string) => string | null);
+		expect(resolveHostAlias("gh")).toBe("github.com");
+		__resetSshAliasCacheForTests();
+		expect(resolveHostAlias("gh")).toBe("github.com");
+		expect(runner).toHaveBeenCalledTimes(2);
+	});
+
+	it("default runner is a no-op under VITEST (hermetic): unset runner returns host unchanged", () => {
+		// No runner injected → defaultSshRunner, which short-circuits under VITEST.
+		__setSshRunnerForTests(null);
+		expect(resolveHostAlias("github-jolli")).toBe("github-jolli");
+	});
+});

--- a/cli/src/core/SshAliasResolver.ts
+++ b/cli/src/core/SshAliasResolver.ts
@@ -1,0 +1,105 @@
+/**
+ * SshAliasResolver — resolves an SSH host token to its real `HostName`.
+ *
+ * A user's `~/.ssh/config` can define host aliases, e.g.
+ *
+ *     Host github-jolli
+ *         HostName github.com
+ *
+ * so `git@github-jolli:owner/repo.git` and `git@github.com:owner/repo.git`
+ * point at the SAME GitHub repo. Every git-remote canonicalizer that compares
+ * the *literal* host token would treat those as two different repos — which is
+ * exactly what split one repo into `<repo>` and `<repo>-2` Memory Bank folders.
+ *
+ * `resolveHostAlias` runs `ssh -G <host>` (offline — it only parses the ssh
+ * config, no network) and returns the resolved `hostname`. It is:
+ *
+ *  - **Memoized** per host (the ssh config is static for a process lifetime),
+ *    so at most one subprocess per distinct host token.
+ *  - **Fail-safe**: any error — `ssh` missing from PATH, a timeout, an
+ *    unparseable output — returns the original host unchanged, never throws.
+ *    A host with no matching `Host` block resolves to itself anyway (ssh
+ *    echoes the token back as `hostname`), so a bare `github.com` is a no-op.
+ *
+ * Hermetic in tests: the default runner short-circuits under `VITEST`, so the
+ * many `foldGitTransportToHttps` folding assertions stay pure and never spawn a
+ * subprocess. Tests that exercise resolution inject a fake runner via
+ * {@link __setSshRunnerForTests}.
+ */
+
+import { createLogger } from "../Logger.js";
+import { execFileSyncHidden } from "../util/Subprocess.js";
+
+const log = createLogger("SshAliasResolver");
+
+// `ssh -G` is a local config parse, near-instant; the timeout only bounds a
+// genuinely wedged ssh (e.g. one blocked on a ProxyCommand). A miss just falls
+// back to the literal host, so a tight cap costs nothing.
+const SSH_G_TIMEOUT_MS = 5_000;
+
+/** Runs `ssh -G <host>` and returns raw stdout, or `null` on any failure. */
+type SshRunner = (host: string) => string | null;
+
+const cache = new Map<string, string>();
+let sshRunner: SshRunner = defaultSshRunner;
+
+/* v8 ignore start -- spawns a real subprocess; unit tests inject a fake runner */
+function defaultSshRunner(host: string): string | null {
+	// Never spawn during tests — keeps the folding-assertion suites hermetic.
+	// Resolution is covered via an injected runner in SshAliasResolver.test.ts.
+	if (process.env.VITEST) return null;
+	try {
+		return execFileSyncHidden("ssh", ["-G", host], {
+			encoding: "utf-8",
+			timeout: SSH_G_TIMEOUT_MS,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+	} catch (err) {
+		log.debug("ssh -G %s failed: %s", host, err instanceof Error ? err.message : String(err));
+		return null;
+	}
+}
+/* v8 ignore stop */
+
+/** Extracts the `hostname <value>` line from `ssh -G` output. */
+function parseHostname(sshGOutput: string): string | null {
+	for (const line of sshGOutput.split(/\r?\n/)) {
+		const m = line.match(/^hostname\s+(\S+)/i);
+		if (m?.[1]) return m[1];
+	}
+	return null;
+}
+
+/**
+ * Resolves an SSH host token to its configured `HostName`, or returns it
+ * unchanged when there is no alias (or resolution fails). Memoized per host.
+ */
+export function resolveHostAlias(host: string): string {
+	if (!host) return host;
+	const cached = cache.get(host);
+	if (cached !== undefined) return cached;
+
+	let resolved = host;
+	const raw = sshRunner(host);
+	if (raw) {
+		const hostname = parseHostname(raw);
+		if (hostname) resolved = hostname;
+	}
+	cache.set(host, resolved);
+	return resolved;
+}
+
+/**
+ * Test seam: inject a fake `ssh -G` runner (returning raw stdout, or `null`
+ * for a failure) and clear the cache. Pass `null` to restore the default
+ * runner. Not for production use.
+ */
+export function __setSshRunnerForTests(runner: SshRunner | null): void {
+	sshRunner = runner ?? defaultSshRunner;
+	cache.clear();
+}
+
+/** Test seam: clear the memoization cache without changing the runner. */
+export function __resetSshAliasCacheForTests(): void {
+	cache.clear();
+}

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -920,6 +920,7 @@ export function activate(context: vscode.ExtensionContext): void {
 			kbParent: sidebarKbParent,
 			currentRepoName: sidebarRepoName,
 			currentRemoteUrl: sidebarRemoteUrl,
+			currentProjectRoot: workspaceRoot || null,
 		}),
 		(info) => {
 			// Heal recovered files during this listChildren — the call itself

--- a/vscode/src/services/KbFoldersService.test.ts
+++ b/vscode/src/services/KbFoldersService.test.ts
@@ -1792,187 +1792,302 @@ describe("parseMdTitle", () => {
 	});
 });
 
-// ─── dedupeFolders: collapse KB folders that share one repo identity ───────────
-// Archive target is `<parent>/.jolli/archive/` (hidden, recoverable) — same path
-// the Migrate-to-Memory-Bank flow uses. seedRepo writes a `.jolli/config.json`,
-// so the archive of that folder is deterministically under the parent's
-// `.jolli/archive` dir.
+// ─── archiveUnusedFolders: archive folders that were never a useful repo ───────
+// Same archive target as dedupeFolders (`<parent>/.jolli/archive/`, hidden and
+// recoverable). `seedRepo` writes only `.jolli/config.json`, which IS the empty
+// shape this sweep targets — so each "keeps" test has to add the specific piece
+// of content that must protect the folder.
 
-describe("KbFoldersService.dedupeFolders", () => {
+describe("KbFoldersService.archiveUnusedFolders", () => {
 	let tmpParent: string;
-	let svc: KbFoldersService;
 
 	beforeEach(() => {
-		tmpParent = mkdtempSync(join(tmpdir(), "kbfolders-dedupe-"));
-		svc = new KbFoldersService(() => ({
-			kbParent: tmpParent,
-			currentRepoName: null,
-			currentRemoteUrl: null,
-		}));
+		tmpParent = mkdtempSync(join(tmpdir(), "kbfolders-unused-"));
 	});
 	afterEach(() => {
 		rmSync(tmpParent, { recursive: true, force: true });
 	});
 
-	function archivedDir(): string {
-		return join(tmpParent, ".jolli", "archive");
+	/** Service whose "current project" is `repoName`/`remoteUrl` (both optional). */
+	function makeSvc(
+		currentRepoName: string | null = null,
+		currentRemoteUrl: string | null = null,
+	): KbFoldersService {
+		return new KbFoldersService(() => ({
+			kbParent: tmpParent,
+			currentRepoName,
+			currentRemoteUrl,
+		}));
 	}
-	/** Give `<parent>/<dirName>` an `index.json` carrying `count` summaries. */
-	function seedIndex(parent: string, dirName: string, count: number): void {
+	function writeJolli(dirName: string, file: string, body: unknown): void {
 		writeFileSync(
-			join(parent, dirName, ".jolli", "index.json"),
-			JSON.stringify({
-				version: 3,
-				entries: Array.from({ length: count }, (_, i) => ({
-					commitHash: `${dirName}${i}`.padEnd(40, "0"),
-					parentCommitHash: null,
-				})),
-			}),
+			join(tmpParent, dirName, ".jolli", file),
+			typeof body === "string" ? body : JSON.stringify(body),
 			"utf-8",
 		);
 	}
 	function isArchived(dirName: string): boolean {
-		const a = archivedDir();
+		const a = join(tmpParent, ".jolli", "archive");
 		if (!existsSync(a)) return false;
 		return readdirSync(a).some((n) => n.startsWith(`${dirName}-`));
 	}
 
-	it("collapses the base + -2 duplicate where the shadow has a null remote", async () => {
-		// The classic symptom: `jolliai` carries the real URL, the auto-
-		// spawned `jolliai-2` got remoteUrl:null (e.g. a git timeout). Both
-		// share repoName `jolliai`. The null-remote shadow must be archived,
-		// the base kept.
-		seedRepo(tmpParent, "jolliai", {
-			repoName: "jolliai",
-			remoteUrl: "https://github.com/o/jolliai.git",
-		});
-		seedRepo(tmpParent, "jolliai-2", {
-			repoName: "jolliai",
-			remoteUrl: null,
-		});
-		const archived = await svc.dedupeFolders();
-		expect(archived).toHaveLength(1);
-		expect(archived[0]).toBe(join(tmpParent, "jolliai-2"));
-		expect(existsSync(join(tmpParent, "jolliai"))).toBe(true);
-		expect(isArchived("jolliai-2")).toBe(true);
+	it("archives an empty folder claimed from a cwd that was never a project", async () => {
+		// The `system32` / `unknown` / `tmp.XXXXXX` shape: `resolveKBPath` claimed
+		// a folder named after whatever cwd the process had, and nothing was ever
+		// written into it.
+		seedRepo(tmpParent, "system32", { repoName: "system32", remoteUrl: null });
+		const archived = await makeSvc().archiveUnusedFolders();
+		expect(archived).toEqual([join(tmpParent, "system32")]);
+		expect(existsSync(join(tmpParent, "system32"))).toBe(false);
+		// Moved, not deleted — a mis-classification stays recoverable.
+		expect(isArchived("system32")).toBe(true);
 	});
 
-	it("collapses two folders that share an identical non-null remote", async () => {
-		// Same URL byte-for-byte in both configs — the simplest dupe shape.
-		seedRepo(tmpParent, "repo", {
-			repoName: "repo",
-			remoteUrl: "https://github.com/o/repo.git",
+	it("archives an empty folder that carries a real remote (checkout opened once, never committed to)", async () => {
+		// Identifying a real repo is not the same as being useful: the row is
+		// pure noise until a memory lands, and the folder returns the moment
+		// `resolveKBPath` re-claims it.
+		seedRepo(tmpParent, "nextra", {
+			repoName: "nextra",
+			remoteUrl: "https://github.com/shuding/nextra.git",
 		});
-		seedRepo(tmpParent, "repo-2", {
-			repoName: "repo",
-			remoteUrl: "https://github.com/o/repo.git",
-		});
-		const archived = await svc.dedupeFolders();
-		expect(archived).toEqual([join(tmpParent, "repo-2")]);
-		expect(existsSync(join(tmpParent, "repo"))).toBe(true);
+		const archived = await makeSvc().archiveUnusedFolders();
+		expect(archived).toEqual([join(tmpParent, "nextra")]);
 	});
 
-	it("collapses an SSH clone against its HTTPS twin (remotes canonicalized)", async () => {
-		// The legacy SSH-vs-HTTPS pile: two configs holding the SAME repo in
-		// two transports. Compared raw they look like distinct remotes and the
-		// group is skipped as "forks"; they only collapse because the remote
-		// comparison folds transports via `normalizeRemoteUrl`, the same
-		// comparer `isSameRepo` uses.
-		seedRepo(tmpParent, "repo", {
-			repoName: "repo",
-			remoteUrl: "git@github.com:o/repo.git",
-		});
-		seedRepo(tmpParent, "repo-2", {
-			repoName: "repo",
-			remoteUrl: "https://github.com/o/repo",
-		});
-		const archived = await svc.dedupeFolders();
-		expect(archived).toEqual([join(tmpParent, "repo-2")]);
-		expect(existsSync(join(tmpParent, "repo"))).toBe(true);
+	it("archives several unused folders in one pass and reports each path", async () => {
+		seedRepo(tmpParent, "tmp.abc123", { remoteUrl: null });
+		seedRepo(tmpParent, "unknown", { remoteUrl: null });
+		seedRepo(tmpParent, "keeper", { remoteUrl: null });
+		seedIndexEntries("keeper", 3);
+		const archived = await makeSvc().archiveUnusedFolders();
+		expect(archived.sort()).toEqual(
+			[join(tmpParent, "tmp.abc123"), join(tmpParent, "unknown")].sort(),
+		);
+		expect(existsSync(join(tmpParent, "keeper"))).toBe(true);
 	});
 
-	it("keeps the folder holding the real remote even when it is the suffixed one", async () => {
-		// Reversed shadow: the BASE was claimed while `git` returned no remote
-		// and `<repo>-2` carries the real URL — so `resolveKBPath` resolves
-		// writes to `-2` (the base fails `isSameRepo` against a real remote).
-		// Archiving `-2` here would bury the live folder, `resolveKBPath` would
-		// re-claim an empty `-2`, and the next Refresh would archive that one
-		// too — one archived directory per refresh, forever.
-		seedRepo(tmpParent, "shadow", { repoName: "shadow", remoteUrl: null });
-		seedRepo(tmpParent, "shadow-2", {
-			repoName: "shadow",
-			remoteUrl: "https://github.com/o/shadow.git",
-		});
-		const archived = await svc.dedupeFolders();
-		expect(archived).toEqual([join(tmpParent, "shadow")]);
-		expect(existsSync(join(tmpParent, "shadow-2"))).toBe(true);
-		expect(isArchived("shadow")).toBe(true);
+	it("keeps a folder holding summaries", async () => {
+		seedRepo(tmpParent, "real", { remoteUrl: "https://github.com/o/real.git" });
+		seedIndexEntries("real", 12);
+		expect(await makeSvc().archiveUnusedFolders()).toEqual([]);
+		expect(existsSync(join(tmpParent, "real"))).toBe(true);
 	});
 
-	it("keeps the folder with the most memories over the lower suffix", async () => {
-		// Archiving is a plain move — nothing re-migrates the loser into the
-		// winner — so the populated folder must always survive, even when the
-		// empty one owns the base slot and the real remote.
-		seedRepo(tmpParent, "rich", {
-			repoName: "rich",
-			remoteUrl: "https://github.com/o/rich.git",
+	it("keeps a folder whose manifest has rows even when the index is empty", async () => {
+		// Plans / notes land in the manifest without necessarily producing an
+		// index entry, so the manifest is checked independently.
+		seedRepo(tmpParent, "notesonly", { remoteUrl: null });
+		writeJolli("notesonly", "manifest.json", {
+			files: [{ path: "main/note.md", fileId: "n1", type: "note" }],
 		});
-		seedIndex(tmpParent, "rich", 0);
-		seedRepo(tmpParent, "rich-2", {
-			repoName: "rich",
-			remoteUrl: "https://github.com/o/rich.git",
-		});
-		seedIndex(tmpParent, "rich-2", 12);
-		const archived = await svc.dedupeFolders();
-		expect(archived).toEqual([join(tmpParent, "rich")]);
-		expect(existsSync(join(tmpParent, "rich-2"))).toBe(true);
+		expect(await makeSvc().archiveUnusedFolders()).toEqual([]);
+		expect(existsSync(join(tmpParent, "notesonly"))).toBe(true);
 	});
 
-	it("keeps the base folder when both have null remotes (local-only shadow)", async () => {
-		// Two local-only folders sharing a basename: keep the canonical base,
-		// archive the suffixed shadow. A lone local-only folder alone is NOT
-		// touched (covered below).
-		seedRepo(tmpParent, "local", { repoName: "local", remoteUrl: null });
-		seedRepo(tmpParent, "local-2", { repoName: "local", remoteUrl: null });
-		const archived = await svc.dedupeFolders();
-		expect(archived).toEqual([join(tmpParent, "local-2")]);
-		expect(existsSync(join(tmpParent, "local"))).toBe(true);
+	it("keeps a folder holding a user-dropped visible file", async () => {
+		// The user put something here by hand. It isn't a memory, which is
+		// exactly why an emptiness test — not a manifest test — guards it.
+		seedRepo(tmpParent, "example1", { remoteUrl: null });
+		writeFileSync(join(tmpParent, "example1", "test.md"), "# mine", "utf-8");
+		expect(await makeSvc().archiveUnusedFolders()).toEqual([]);
+		expect(existsSync(join(tmpParent, "example1"))).toBe(true);
 	});
 
-	it("never merges two repos that share a basename but have distinct remotes", async () => {
-		// Forks named the same — different repos, must both survive. The
-		// user's "no remote URL" heuristic would wrongly delete one of these
-		// if applied naively; this rule protects them.
-		seedRepo(tmpParent, "shared", {
-			repoName: "shared",
-			remoteUrl: "https://github.com/a/shared.git",
-		});
-		seedRepo(tmpParent, "shared-2", {
-			repoName: "shared",
-			remoteUrl: "https://github.com/b/shared.git",
-		});
-		const archived = await svc.dedupeFolders();
-		expect(archived).toEqual([]);
-		expect(existsSync(join(tmpParent, "shared"))).toBe(true);
-		expect(existsSync(join(tmpParent, "shared-2"))).toBe(true);
+	it("keeps a folder holding a visible branch directory", async () => {
+		seedRepo(tmpParent, "branchy", { remoteUrl: null });
+		mkdirSync(join(tmpParent, "branchy", "main"), { recursive: true });
+		expect(await makeSvc().archiveUnusedFolders()).toEqual([]);
 	});
 
-	it("leaves a single folder (no duplicate) untouched", async () => {
-		seedRepo(tmpParent, "solo", {
-			repoName: "solo",
-			remoteUrl: "https://github.com/o/solo.git",
+	it("keeps a folder with an unrecognized entry under .jolli (a summaries dir)", async () => {
+		// Allowlist, not denylist: anything this code doesn't recognize counts as
+		// content. An empty `summaries/` also covers the corrupt-index case —
+		// a populated folder can never look empty on the strength of its index
+		// alone.
+		seedRepo(tmpParent, "hassummaries", { remoteUrl: null });
+		mkdirSync(join(tmpParent, "hassummaries", ".jolli", "summaries"), {
+			recursive: true,
 		});
-		const archived = await svc.dedupeFolders();
-		expect(archived).toEqual([]);
-		expect(existsSync(join(tmpParent, "solo"))).toBe(true);
+		expect(await makeSvc().archiveUnusedFolders()).toEqual([]);
 	});
 
-	it("preserves a lone local-only folder (no remote) — not all null-remote folders are dupes", async () => {
-		// Directly contradicts the naive "delete folders without a remote
-		// URL" rule: a single local-only repo is legitimate and must remain.
-		seedRepo(tmpParent, "lonely", { repoName: "lonely", remoteUrl: null });
-		const archived = await svc.dedupeFolders();
-		expect(archived).toEqual([]);
-		expect(existsSync(join(tmpParent, "lonely"))).toBe(true);
+	it("keeps a folder carrying the dual-write dirty marker", async () => {
+		// `shadow-status.json` means a folder write was attempted and hasn't
+		// landed. Empty-looking, but mid-write — not disposable.
+		seedRepo(tmpParent, "midwrite", { remoteUrl: null });
+		writeJolli("midwrite", "shadow-status.json", { dirty: true });
+		expect(await makeSvc().archiveUnusedFolders()).toEqual([]);
 	});
+
+	it("keeps a folder whose manifest is unparseable", async () => {
+		// Corrupt state is never assumed empty.
+		seedRepo(tmpParent, "corrupt", { remoteUrl: null });
+		writeJolli("corrupt", "manifest.json", "{not json");
+		expect(await makeSvc().archiveUnusedFolders()).toEqual([]);
+	});
+
+	it("keeps a folder whose manifest parses to a non-array `files`", async () => {
+		seedRepo(tmpParent, "weird", { remoteUrl: null });
+		writeJolli("weird", "manifest.json", { files: "nope" });
+		expect(await makeSvc().archiveUnusedFolders()).toEqual([]);
+	});
+
+	it("never archives the current project's own folder even when empty", async () => {
+		// A fresh install's folder is legitimately empty until the first commit;
+		// archiving it on the Refresh the user clicked to look at it would spawn
+		// one archive dir per click.
+		seedRepo(tmpParent, "mine", {
+			repoName: "mine",
+			remoteUrl: "https://github.com/o/mine.git",
+		});
+		const svc = makeSvc("mine", "git@github.com:o/mine.git");
+		expect(await svc.archiveUnusedFolders()).toEqual([]);
+		expect(existsSync(join(tmpParent, "mine"))).toBe(true);
+	});
+
+	it("never archives an empty folder sharing the current repoName under a different remote", async () => {
+		// The host-alias shape (`git@github-jolli:o/repo.git` vs
+		// `github.com`): `isCurrentRepo` compares remotes and says "foreign", yet
+		// this is a folder the current session may be about to write into. The
+		// name guard is what keeps it.
+		seedRepo(tmpParent, "mine-2", {
+			repoName: "mine",
+			remoteUrl: "https://github.com/o/mine.git",
+		});
+		const svc = makeSvc("mine", "git@github-alias:o/mine.git");
+		expect(await svc.archiveUnusedFolders()).toEqual([]);
+		expect(existsSync(join(tmpParent, "mine-2"))).toBe(true);
+	});
+
+	it("ignores OS noise files when deciding emptiness", async () => {
+		// One Explorer/Finder visit must not pin a junk folder in the tree.
+		seedRepo(tmpParent, "visited", { remoteUrl: null });
+		writeFileSync(join(tmpParent, "visited", ".DS_Store"), "\0", "utf-8");
+		writeFileSync(join(tmpParent, "visited", "Thumbs.db"), "\0", "utf-8");
+		expect(await makeSvc().archiveUnusedFolders()).toEqual([
+			join(tmpParent, "visited"),
+		]);
+	});
+
+	it("keeps a folder holding an unrecognized dotfile (e.g. a git repo the user init'd)", async () => {
+		seedRepo(tmpParent, "gitinit", { remoteUrl: null });
+		mkdirSync(join(tmpParent, "gitinit", ".git"), { recursive: true });
+		expect(await makeSvc().archiveUnusedFolders()).toEqual([]);
+	});
+
+	it("leaves duplicate folders that hold memories alone — dedupe is Migrate's job", async () => {
+		// Refresh's contract: it never moves a folder holding memories. Two
+		// folders sharing one repo identity is the more visible annoyance, but
+		// collapsing them means burying one populated folder, and only Migrate can
+		// rebuild a merged survivor from the orphan branch. This test is the guard
+		// against a duplicate-collapsing pass being re-added to this sweep.
+		seedRepo(tmpParent, "dupe", {
+			repoName: "dupe",
+			remoteUrl: "https://github.com/o/dupe.git",
+		});
+		seedIndexEntries("dupe", 35);
+		seedRepo(tmpParent, "dupe-2", {
+			repoName: "dupe",
+			remoteUrl: "https://github.com/o/dupe.git",
+		});
+		seedIndexEntries("dupe-2", 751);
+		expect(await makeSvc().archiveUnusedFolders()).toEqual([]);
+		expect(existsSync(join(tmpParent, "dupe"))).toBe(true);
+		expect(existsSync(join(tmpParent, "dupe-2"))).toBe(true);
+	});
+
+	it("archives an EMPTY duplicate sibling — emptiness is the test, not uniqueness", async () => {
+		// The flip side: a duplicate that never held anything is still just an
+		// empty folder, so it goes. No memory is buried, which is exactly the line
+		// this sweep draws.
+		seedRepo(tmpParent, "half", {
+			repoName: "half",
+			remoteUrl: "https://github.com/o/half.git",
+		});
+		seedIndexEntries("half", 12);
+		seedRepo(tmpParent, "half-2", {
+			repoName: "half",
+			remoteUrl: "https://github.com/o/half.git",
+		});
+		expect(await makeSvc().archiveUnusedFolders()).toEqual([
+			join(tmpParent, "half-2"),
+		]);
+		expect(existsSync(join(tmpParent, "half"))).toBe(true);
+	});
+
+	it("never touches user-dropped top-level folders (no .jolli/config.json)", async () => {
+		// `discoverRepos` can't see them, so they're out of scope by construction
+		// — this pins that the sweep never grew its own directory scan.
+		mkdirSync(join(tmpParent, "notes"), { recursive: true });
+		expect(await makeSvc().archiveUnusedFolders()).toEqual([]);
+		expect(existsSync(join(tmpParent, "notes"))).toBe(true);
+	});
+
+	// `chmod 0o111` is execute-without-read: traversal still resolves
+	// `.jolli/config.json` (so `discoverRepos` yields the folder as a candidate)
+	// while the directory listing itself fails. That is the only way to reach the
+	// two readdir catch paths without a filesystem race — and it's the real shape
+	// of a permission-restricted folder, which must be KEPT: emptiness has to be
+	// proven, never assumed. Windows ignores chmod for unprivileged access, same
+	// reason the deriveMdTitle chmod tests skip there.
+	skipIfWin32(
+		"keeps a folder whose contents cannot be listed (permissions)",
+		async () => {
+			const dir = seedRepo(tmpParent, "locked", { remoteUrl: null });
+			chmodSync(dir, 0o111);
+			try {
+				expect(await makeSvc().archiveUnusedFolders()).toEqual([]);
+			} finally {
+				// Restore before afterEach's rmSync, which can't remove an
+				// unreadable directory.
+				chmodSync(dir, 0o755);
+			}
+			expect(existsSync(dir)).toBe(true);
+		},
+	);
+
+	skipIfWin32(
+		"keeps a folder whose .jolli directory cannot be listed (permissions)",
+		async () => {
+			const dir = seedRepo(tmpParent, "lockedmeta", { remoteUrl: null });
+			const meta = join(dir, ".jolli");
+			chmodSync(meta, 0o111);
+			try {
+				expect(await makeSvc().archiveUnusedFolders()).toEqual([]);
+			} finally {
+				chmodSync(meta, 0o755);
+			}
+			expect(existsSync(dir)).toBe(true);
+		},
+	);
+
+	it("creates no archive directory when nothing qualifies", async () => {
+		seedRepo(tmpParent, "solo", { remoteUrl: null });
+		seedIndexEntries("solo", 1);
+		expect(await makeSvc().archiveUnusedFolders()).toEqual([]);
+		expect(existsSync(join(tmpParent, ".jolli", "archive"))).toBe(false);
+	});
+
+	it("returns an empty list when the Memory Bank parent does not exist", async () => {
+		const gone = join(tmpParent, "nope");
+		const svc = new KbFoldersService(() => ({
+			kbParent: gone,
+			currentRepoName: null,
+			currentRemoteUrl: null,
+		}));
+		expect(await svc.archiveUnusedFolders()).toEqual([]);
+	});
+
+	/** Give `<parent>/<dirName>` an `index.json` carrying `count` summaries. */
+	function seedIndexEntries(dirName: string, count: number): void {
+		writeJolli(dirName, "index.json", {
+			version: 3,
+			entries: Array.from({ length: count }, (_, i) => ({
+				commitHash: `${dirName}${i}`.padEnd(40, "0"),
+				parentCommitHash: null,
+			})),
+		});
+	}
 });

--- a/vscode/src/services/KbFoldersService.test.ts
+++ b/vscode/src/services/KbFoldersService.test.ts
@@ -15,7 +15,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __setSotResolverForTests } from "../../../cli/src/core/FolderConsolidation";
 import { MetadataManager } from "../../../cli/src/core/MetadataManager";
 import type { StorageProvider } from "../../../cli/src/core/StorageProvider";
+import { VaultWriteBusyError, withVaultWriteLock } from "../../../cli/src/sync/VaultWriteLock";
 import { KbFoldersService, parseMdTitle } from "./KbFoldersService";
+
+// The service now takes vault-write.lock around every vault mutation. Mock it to
+// a pass-through (no real lock file) so the archive / consolidation tests stay
+// hermetic; individual tests override it to simulate a busy vault.
+vi.mock("../../../cli/src/sync/VaultWriteLock.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../../cli/src/sync/VaultWriteLock.js")>();
+	return {
+		...actual,
+		withVaultWriteLock: vi.fn(async (_root: string, _mode: unknown, body: () => Promise<unknown>) => ({
+			ran: true,
+			value: await body(),
+		})),
+	};
+});
 
 // Windows ignores chmod for unprivileged file accesses, so a `chmod 0o000`
 // based "unreadable file" test ends up reading the file just fine and the
@@ -2195,5 +2210,32 @@ describe("KbFoldersService — duplicate consolidation", () => {
 		expect(result.summariesAfter).toBe(4);
 		expect(existsSync(join(tmpParent, "app-2"))).toBe(false);
 		expect(existsSync(join(tmpParent, "app", ".jolli", "summaries", "z9.json"))).toBe(true);
+	});
+
+	it("runConsolidation throws VaultWriteBusyError when the vault lock is busy", async () => {
+		makeRepo("app", ["a1", "a2", "a3"]);
+		makeRepo("app-2", ["a1", "z9"]);
+		const service = svc("app", "/cwd");
+		const plan = await service.planDuplicateConsolidation();
+		if (!plan) throw new Error("expected a consolidation plan");
+		vi.mocked(withVaultWriteLock).mockResolvedValueOnce({ ran: false });
+
+		await expect(service.runConsolidation(plan)).rejects.toBeInstanceOf(VaultWriteBusyError);
+		// Nothing was moved — the loser folder survives for the next attempt.
+		expect(existsSync(join(tmpParent, "app-2"))).toBe(true);
+	});
+
+	it("archiveUnusedFolders returns [] and archives nothing when the vault lock is busy", async () => {
+		makeRepo("app", ["a1"]); // current repo, never swept
+		// An empty foreign folder that WOULD be swept if the lock were free.
+		mkdirSync(join(tmpParent, "junk", ".jolli"), { recursive: true });
+		writeFileSync(
+			join(tmpParent, "junk", ".jolli", "config.json"),
+			JSON.stringify({ version: 1, sortOrder: "date", remoteUrl: "https://github.com/x/junk.git", repoName: "junk" }),
+		);
+		vi.mocked(withVaultWriteLock).mockResolvedValueOnce({ ran: false });
+
+		expect(await svc("app", "/cwd").archiveUnusedFolders()).toEqual([]);
+		expect(existsSync(join(tmpParent, "junk"))).toBe(true);
 	});
 });

--- a/vscode/src/services/KbFoldersService.test.ts
+++ b/vscode/src/services/KbFoldersService.test.ts
@@ -12,7 +12,9 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __setSotResolverForTests } from "../../../cli/src/core/FolderConsolidation";
 import { MetadataManager } from "../../../cli/src/core/MetadataManager";
+import type { StorageProvider } from "../../../cli/src/core/StorageProvider";
 import { KbFoldersService, parseMdTitle } from "./KbFoldersService";
 
 // Windows ignores chmod for unprivileged file accesses, so a `chmod 0o000`
@@ -2117,4 +2119,81 @@ describe("KbFoldersService.archiveUnusedFolders", () => {
 			})),
 		});
 	}
+});
+
+describe("KbFoldersService — duplicate consolidation", () => {
+	let tmpParent: string;
+
+	// Empty source of truth → classify takes the safe `union-largest` branch
+	// without touching a real git repo.
+	const emptySot: StorageProvider = {
+		readFile: async () => null,
+		writeFiles: async () => {},
+		listFiles: async () => [],
+		exists: async () => false,
+		ensure: async () => {},
+	};
+
+	beforeEach(() => {
+		tmpParent = mkdtempSync(join(tmpdir(), "kbconsol-"));
+		__setSotResolverForTests(async () => emptySot);
+	});
+	afterEach(() => {
+		__setSotResolverForTests(null);
+		rmSync(tmpParent, { recursive: true, force: true });
+	});
+
+	function makeRepo(dirName: string, hashes: string[]): string {
+		const root = join(tmpParent, dirName);
+		mkdirSync(join(root, ".jolli", "summaries"), { recursive: true });
+		writeFileSync(
+			join(root, ".jolli", "config.json"),
+			JSON.stringify({ version: 1, sortOrder: "date", repoName: "app" }),
+		);
+		for (const h of hashes) {
+			writeFileSync(join(root, ".jolli", "summaries", `${h}.json`), JSON.stringify({ commitHash: h }));
+		}
+		writeFileSync(
+			join(root, ".jolli", "index.json"),
+			JSON.stringify({ version: 3, entries: hashes.map((h) => ({ commitHash: h, parentCommitHash: null })) }),
+		);
+		return root;
+	}
+
+	function svc(currentRepoName: string | null, currentProjectRoot: string | null): KbFoldersService {
+		return new KbFoldersService(() => ({
+			kbParent: tmpParent,
+			currentRepoName,
+			currentRemoteUrl: null,
+			currentProjectRoot,
+		}));
+	}
+
+	it("returns null when the host has no current git project", async () => {
+		makeRepo("app", ["a1"]);
+		makeRepo("app-2", ["a2"]);
+		expect(await svc(null, "/cwd").planDuplicateConsolidation()).toBeNull();
+		expect(await svc("app", null).planDuplicateConsolidation()).toBeNull();
+	});
+
+	it("returns null when the repo has only one folder", async () => {
+		makeRepo("app", ["a1"]);
+		expect(await svc("app", "/cwd").planDuplicateConsolidation()).toBeNull();
+	});
+
+	it("plans a union-largest merge and executes it", async () => {
+		makeRepo("app", ["a1", "a2", "a3"]);
+		makeRepo("app-2", ["a1", "z9"]);
+		const service = svc("app", "/cwd");
+
+		const plan = await service.planDuplicateConsolidation();
+		expect(plan?.kind).toBe("union-largest");
+		expect(plan?.survivor).toBe(join(tmpParent, "app"));
+		if (!plan) throw new Error("expected a consolidation plan");
+
+		const result = await service.runConsolidation(plan);
+		expect(result.summariesAfter).toBe(4);
+		expect(existsSync(join(tmpParent, "app-2"))).toBe(false);
+		expect(existsSync(join(tmpParent, "app", ".jolli", "summaries", "z9.json"))).toBe(true);
+	});
 });

--- a/vscode/src/services/KbFoldersService.test.ts
+++ b/vscode/src/services/KbFoldersService.test.ts
@@ -4,6 +4,7 @@ import {
 	mkdirSync,
 	mkdtempSync,
 	readFileSync,
+	readdirSync,
 	renameSync,
 	rmSync,
 	writeFileSync,
@@ -1788,5 +1789,190 @@ describe("parseMdTitle", () => {
 		expect(parseMdTitle('---\ntitle: ""\n---\n# Fallback Heading\n')).toBe(
 			"Fallback Heading",
 		);
+	});
+});
+
+// ─── dedupeFolders: collapse KB folders that share one repo identity ───────────
+// Archive target is `<parent>/.jolli/archive/` (hidden, recoverable) — same path
+// the Migrate-to-Memory-Bank flow uses. seedRepo writes a `.jolli/config.json`,
+// so the archive of that folder is deterministically under the parent's
+// `.jolli/archive` dir.
+
+describe("KbFoldersService.dedupeFolders", () => {
+	let tmpParent: string;
+	let svc: KbFoldersService;
+
+	beforeEach(() => {
+		tmpParent = mkdtempSync(join(tmpdir(), "kbfolders-dedupe-"));
+		svc = new KbFoldersService(() => ({
+			kbParent: tmpParent,
+			currentRepoName: null,
+			currentRemoteUrl: null,
+		}));
+	});
+	afterEach(() => {
+		rmSync(tmpParent, { recursive: true, force: true });
+	});
+
+	function archivedDir(): string {
+		return join(tmpParent, ".jolli", "archive");
+	}
+	/** Give `<parent>/<dirName>` an `index.json` carrying `count` summaries. */
+	function seedIndex(parent: string, dirName: string, count: number): void {
+		writeFileSync(
+			join(parent, dirName, ".jolli", "index.json"),
+			JSON.stringify({
+				version: 3,
+				entries: Array.from({ length: count }, (_, i) => ({
+					commitHash: `${dirName}${i}`.padEnd(40, "0"),
+					parentCommitHash: null,
+				})),
+			}),
+			"utf-8",
+		);
+	}
+	function isArchived(dirName: string): boolean {
+		const a = archivedDir();
+		if (!existsSync(a)) return false;
+		return readdirSync(a).some((n) => n.startsWith(`${dirName}-`));
+	}
+
+	it("collapses the base + -2 duplicate where the shadow has a null remote", async () => {
+		// The classic symptom: `jolliai` carries the real URL, the auto-
+		// spawned `jolliai-2` got remoteUrl:null (e.g. a git timeout). Both
+		// share repoName `jolliai`. The null-remote shadow must be archived,
+		// the base kept.
+		seedRepo(tmpParent, "jolliai", {
+			repoName: "jolliai",
+			remoteUrl: "https://github.com/o/jolliai.git",
+		});
+		seedRepo(tmpParent, "jolliai-2", {
+			repoName: "jolliai",
+			remoteUrl: null,
+		});
+		const archived = await svc.dedupeFolders();
+		expect(archived).toHaveLength(1);
+		expect(archived[0]).toBe(join(tmpParent, "jolliai-2"));
+		expect(existsSync(join(tmpParent, "jolliai"))).toBe(true);
+		expect(isArchived("jolliai-2")).toBe(true);
+	});
+
+	it("collapses two folders that share an identical non-null remote", async () => {
+		// Same URL byte-for-byte in both configs — the simplest dupe shape.
+		seedRepo(tmpParent, "repo", {
+			repoName: "repo",
+			remoteUrl: "https://github.com/o/repo.git",
+		});
+		seedRepo(tmpParent, "repo-2", {
+			repoName: "repo",
+			remoteUrl: "https://github.com/o/repo.git",
+		});
+		const archived = await svc.dedupeFolders();
+		expect(archived).toEqual([join(tmpParent, "repo-2")]);
+		expect(existsSync(join(tmpParent, "repo"))).toBe(true);
+	});
+
+	it("collapses an SSH clone against its HTTPS twin (remotes canonicalized)", async () => {
+		// The legacy SSH-vs-HTTPS pile: two configs holding the SAME repo in
+		// two transports. Compared raw they look like distinct remotes and the
+		// group is skipped as "forks"; they only collapse because the remote
+		// comparison folds transports via `normalizeRemoteUrl`, the same
+		// comparer `isSameRepo` uses.
+		seedRepo(tmpParent, "repo", {
+			repoName: "repo",
+			remoteUrl: "git@github.com:o/repo.git",
+		});
+		seedRepo(tmpParent, "repo-2", {
+			repoName: "repo",
+			remoteUrl: "https://github.com/o/repo",
+		});
+		const archived = await svc.dedupeFolders();
+		expect(archived).toEqual([join(tmpParent, "repo-2")]);
+		expect(existsSync(join(tmpParent, "repo"))).toBe(true);
+	});
+
+	it("keeps the folder holding the real remote even when it is the suffixed one", async () => {
+		// Reversed shadow: the BASE was claimed while `git` returned no remote
+		// and `<repo>-2` carries the real URL — so `resolveKBPath` resolves
+		// writes to `-2` (the base fails `isSameRepo` against a real remote).
+		// Archiving `-2` here would bury the live folder, `resolveKBPath` would
+		// re-claim an empty `-2`, and the next Refresh would archive that one
+		// too — one archived directory per refresh, forever.
+		seedRepo(tmpParent, "shadow", { repoName: "shadow", remoteUrl: null });
+		seedRepo(tmpParent, "shadow-2", {
+			repoName: "shadow",
+			remoteUrl: "https://github.com/o/shadow.git",
+		});
+		const archived = await svc.dedupeFolders();
+		expect(archived).toEqual([join(tmpParent, "shadow")]);
+		expect(existsSync(join(tmpParent, "shadow-2"))).toBe(true);
+		expect(isArchived("shadow")).toBe(true);
+	});
+
+	it("keeps the folder with the most memories over the lower suffix", async () => {
+		// Archiving is a plain move — nothing re-migrates the loser into the
+		// winner — so the populated folder must always survive, even when the
+		// empty one owns the base slot and the real remote.
+		seedRepo(tmpParent, "rich", {
+			repoName: "rich",
+			remoteUrl: "https://github.com/o/rich.git",
+		});
+		seedIndex(tmpParent, "rich", 0);
+		seedRepo(tmpParent, "rich-2", {
+			repoName: "rich",
+			remoteUrl: "https://github.com/o/rich.git",
+		});
+		seedIndex(tmpParent, "rich-2", 12);
+		const archived = await svc.dedupeFolders();
+		expect(archived).toEqual([join(tmpParent, "rich")]);
+		expect(existsSync(join(tmpParent, "rich-2"))).toBe(true);
+	});
+
+	it("keeps the base folder when both have null remotes (local-only shadow)", async () => {
+		// Two local-only folders sharing a basename: keep the canonical base,
+		// archive the suffixed shadow. A lone local-only folder alone is NOT
+		// touched (covered below).
+		seedRepo(tmpParent, "local", { repoName: "local", remoteUrl: null });
+		seedRepo(tmpParent, "local-2", { repoName: "local", remoteUrl: null });
+		const archived = await svc.dedupeFolders();
+		expect(archived).toEqual([join(tmpParent, "local-2")]);
+		expect(existsSync(join(tmpParent, "local"))).toBe(true);
+	});
+
+	it("never merges two repos that share a basename but have distinct remotes", async () => {
+		// Forks named the same — different repos, must both survive. The
+		// user's "no remote URL" heuristic would wrongly delete one of these
+		// if applied naively; this rule protects them.
+		seedRepo(tmpParent, "shared", {
+			repoName: "shared",
+			remoteUrl: "https://github.com/a/shared.git",
+		});
+		seedRepo(tmpParent, "shared-2", {
+			repoName: "shared",
+			remoteUrl: "https://github.com/b/shared.git",
+		});
+		const archived = await svc.dedupeFolders();
+		expect(archived).toEqual([]);
+		expect(existsSync(join(tmpParent, "shared"))).toBe(true);
+		expect(existsSync(join(tmpParent, "shared-2"))).toBe(true);
+	});
+
+	it("leaves a single folder (no duplicate) untouched", async () => {
+		seedRepo(tmpParent, "solo", {
+			repoName: "solo",
+			remoteUrl: "https://github.com/o/solo.git",
+		});
+		const archived = await svc.dedupeFolders();
+		expect(archived).toEqual([]);
+		expect(existsSync(join(tmpParent, "solo"))).toBe(true);
+	});
+
+	it("preserves a lone local-only folder (no remote) — not all null-remote folders are dupes", async () => {
+		// Directly contradicts the naive "delete folders without a remote
+		// URL" rule: a single local-only repo is legitimate and must remain.
+		seedRepo(tmpParent, "lonely", { repoName: "lonely", remoteUrl: null });
+		const archived = await svc.dedupeFolders();
+		expect(archived).toEqual([]);
+		expect(existsSync(join(tmpParent, "lonely"))).toBe(true);
 	});
 });

--- a/vscode/src/services/KbFoldersService.test.ts
+++ b/vscode/src/services/KbFoldersService.test.ts
@@ -1793,7 +1793,7 @@ describe("parseMdTitle", () => {
 });
 
 // ─── archiveUnusedFolders: archive folders that were never a useful repo ───────
-// Same archive target as dedupeFolders (`<parent>/.jolli/archive/`, hidden and
+// Same archive target as archiveUnusedFolders (`<parent>/.jolli/archive/`, hidden and
 // recoverable). `seedRepo` writes only `.jolli/config.json`, which IS the empty
 // shape this sweep targets — so each "keeps" test has to add the specific piece
 // of content that must protect the folder.
@@ -1914,10 +1914,11 @@ describe("KbFoldersService.archiveUnusedFolders", () => {
 	});
 
 	it("keeps a folder carrying the dual-write dirty marker", async () => {
-		// `shadow-status.json` means a folder write was attempted and hasn't
-		// landed. Empty-looking, but mid-write — not disposable.
-		seedRepo(tmpParent, "midwrite", { remoteUrl: null });
-		writeJolli("midwrite", "shadow-status.json", { dirty: true });
+		// `shadow-status.json` records that a shadow write to this folder FAILED
+		// (`DualWriteStorage` writes it only from a write's `catch`). Empty-looking,
+		// but a write meant to land here didn't — not disposable.
+		seedRepo(tmpParent, "failedwrite", { remoteUrl: null });
+		writeJolli("failedwrite", "shadow-status.json", { dirty: true });
 		expect(await makeSvc().archiveUnusedFolders()).toEqual([]);
 	});
 
@@ -1969,6 +1970,32 @@ describe("KbFoldersService.archiveUnusedFolders", () => {
 		expect(await makeSvc().archiveUnusedFolders()).toEqual([
 			join(tmpParent, "visited"),
 		]);
+	});
+
+	it("ignores OS noise nested under .jolli/ too (a .DS_Store a Finder visit dropped)", async () => {
+		// Same skip as the top-level loop. Without it a single Finder visit that
+		// wrote `.jolli/.DS_Store` would pin the junk folder permanently, because
+		// the strict `.jolli` allowlist rejects every unrecognized name.
+		seedRepo(tmpParent, "visited-jolli", { remoteUrl: null });
+		writeJolli("visited-jolli", ".DS_Store", "\0");
+		expect(await makeSvc().archiveUnusedFolders()).toEqual([
+			join(tmpParent, "visited-jolli"),
+		]);
+	});
+
+	it("treats OS noise names case-insensitively (lowercase thumbs.db, uppercase .DS_STORE)", async () => {
+		// Windows commonly writes `thumbs.db` lowercase; a case-sensitive match
+		// would let it pin the folder. Checked at both levels.
+		seedRepo(tmpParent, "winvisited", { remoteUrl: null });
+		writeFileSync(join(tmpParent, "winvisited", "thumbs.db"), "\0", "utf-8");
+		writeJolli("winvisited", ".DS_STORE", "\0");
+		expect(await makeSvc().archiveUnusedFolders()).toEqual([
+			join(tmpParent, "winvisited"),
+		]);
+	});
+
+	it("archiveDir() points at the hidden recoverable archive under the parent", async () => {
+		expect(makeSvc().archiveDir()).toBe(join(tmpParent, ".jolli", "archive"));
 	});
 
 	it("keeps a folder holding an unrecognized dotfile (e.g. a git repo the user init'd)", async () => {

--- a/vscode/src/services/KbFoldersService.ts
+++ b/vscode/src/services/KbFoldersService.ts
@@ -51,6 +51,12 @@ import type { Dirent } from "node:fs";
 import { existsSync, promises as fs, readdirSync, readFileSync } from "node:fs";
 import { isAbsolute, join, normalize } from "node:path";
 import type { SummaryIndex } from "../../../cli/src/Types.js";
+import {
+	classifyDuplicateFolders,
+	type ConsolidationPlan,
+	type ConsolidationResult,
+	executeConsolidation,
+} from "../../../cli/src/core/FolderConsolidation.js";
 import { FolderStorage } from "../../../cli/src/core/FolderStorage.js";
 import { archiveKBFolder } from "../../../cli/src/core/KBPathResolver.js";
 import {
@@ -78,6 +84,14 @@ export interface KbFoldersContext {
 	 */
 	readonly currentRepoName: string | null;
 	readonly currentRemoteUrl: string | null;
+	/**
+	 * Working-tree root of the currently opened project. Needed to read this
+	 * repo's orphan branch (the system of record) when deciding how to
+	 * consolidate duplicate folders. Null/absent for a non-git / no-workspace
+	 * host (duplicate consolidation is then skipped). Optional so callers that
+	 * don't use consolidation need not supply it.
+	 */
+	readonly currentProjectRoot?: string | null;
 }
 
 /**
@@ -225,6 +239,44 @@ export class KbFoldersService {
 	 */
 	archiveDir(): string {
 		return join(this.getContext().kbParent, ".jolli", "archive");
+	}
+
+	/**
+	 * Detects duplicate Memory Bank folders for the CURRENTLY OPEN repo and, if
+	 * there are two or more, returns a plan describing how they would be merged
+	 * (see {@link classifyDuplicateFolders}). Returns `null` when there is
+	 * nothing to consolidate, or when the host has no current git project (a
+	 * duplicate set only makes sense relative to a specific repo identity).
+	 *
+	 * Split from {@link runConsolidation} so the caller can show a case-specific
+	 * confirmation between detection and the (folder-moving) execution.
+	 */
+	async planDuplicateConsolidation(): Promise<ConsolidationPlan | null> {
+		const ctx = this.getContext();
+		if (!ctx.currentRepoName || !ctx.currentProjectRoot) return null;
+		return classifyDuplicateFolders(
+			ctx.currentProjectRoot,
+			ctx.currentRepoName,
+			ctx.currentRemoteUrl,
+			ctx.kbParent,
+		);
+	}
+
+	/**
+	 * Executes a plan from {@link planDuplicateConsolidation} — the folder merge
+	 * / rebuild + archive. Drops the "clean repo" memo afterwards so the next
+	 * listing re-reads the survivor. Returns what happened.
+	 */
+	async runConsolidation(plan: ConsolidationPlan): Promise<ConsolidationResult> {
+		const ctx = this.getContext();
+		const result = await executeConsolidation(
+			plan,
+			ctx.currentProjectRoot ?? ctx.kbParent,
+			ctx.currentRemoteUrl,
+			ctx.kbParent,
+		);
+		this.cleanRepos.clear();
+		return result;
 	}
 
 	/**

--- a/vscode/src/services/KbFoldersService.ts
+++ b/vscode/src/services/KbFoldersService.ts
@@ -169,8 +169,9 @@ export class KbFoldersService {
 	 *     row is pure noise; the folder returns the moment it earns content.
 	 *
 	 * Anything unrecognized under `.jolli/` — including the `shadow-status.json`
-	 * dirty marker, which means a write was attempted and hasn't landed — counts
-	 * as content and keeps the folder. Unknown state is never assumed disposable.
+	 * dirty marker, which records that a shadow write to this folder FAILED
+	 * (`DualWriteStorage` writes it only from a write's `catch`) — counts as
+	 * content and keeps the folder. Unknown state is never assumed disposable.
 	 *
 	 * NEVER touched: the current project's folder, or any folder carrying the
 	 * current project's `repoName`. A fresh install's own folder is legitimately
@@ -213,6 +214,17 @@ export class KbFoldersService {
 		}
 		if (archived.length > 0) this.cleanRepos.clear();
 		return archived;
+	}
+
+	/**
+	 * Absolute path of the hidden archive directory
+	 * (`<kbParent>/.jolli/archive/`) that {@link archiveUnusedFolders} moves
+	 * swept folders into — the same recoverable location the Migrate flow uses
+	 * (`archiveKBFolder`). Exposed so the sidebar's post-sweep toast can offer a
+	 * "Reveal Archive" action: the folders are recoverable, and this is where.
+	 */
+	archiveDir(): string {
+		return join(this.getContext().kbParent, ".jolli", "archive");
 	}
 
 	/**
@@ -709,9 +721,10 @@ function repoDisplayName(repo: DiscoveredRepo): string {
  * requires them to hold zero entries.
  *
  * `shadow-status.json` is deliberately ABSENT: that is the dual-write dirty
- * marker (`DualWriteStorage.markDirty`), so its presence means a folder write
- * was attempted and hasn't completed. A folder mid-write is not disposable
- * even while it still looks empty.
+ * marker, and `DualWriteStorage` writes it ONLY from a write's `catch`, so its
+ * presence means the last shadow write to this folder FAILED — not that one is
+ * currently in flight. Either way a write meant to land here didn't, so the
+ * folder is not the inert-empty shape this sweep targets and is kept.
  */
 const INERT_JOLLI_ENTRIES: ReadonlySet<string> = new Set([
 	"config.json",
@@ -725,9 +738,15 @@ const INERT_JOLLI_ENTRIES: ReadonlySet<string> = new Set([
  * OS-generated files that appear inside any browsed directory and say nothing
  * about whether the user keeps memories there. Ignored when deciding emptiness
  * so a single Finder/Explorer visit can't pin a junk folder in the tree
- * forever.
+ * forever. Names are stored lowercase and matched case-insensitively via
+ * {@link isOsNoise}: `Thumbs.db` is often written lowercase (`thumbs.db`) on
+ * Windows, and macOS filesystems are case-insensitive by default.
  */
-const OS_NOISE_FILES: ReadonlySet<string> = new Set([".DS_Store", "Thumbs.db"]);
+const OS_NOISE_FILES: ReadonlySet<string> = new Set([".ds_store", "thumbs.db"]);
+
+function isOsNoise(name: string): boolean {
+	return OS_NOISE_FILES.has(name.toLowerCase());
+}
 
 /**
  * True when `kbRoot` is a claimed-but-empty Memory Bank folder: nothing the
@@ -752,7 +771,7 @@ function isEmptyKbFolder(kbRoot: string): boolean {
 	}
 	for (const e of top) {
 		if (e.name === ".jolli") continue;
-		if (OS_NOISE_FILES.has(e.name)) continue;
+		if (isOsNoise(e.name)) continue;
 		// A visible branch dir / `.md`, or a dotfile we don't recognize (a `.git`
 		// the user init'd here, an editor workspace file) — real content.
 		return false;
@@ -769,6 +788,10 @@ function isEmptyKbFolder(kbRoot: string): boolean {
 		return false;
 	}
 	for (const e of jolli) {
+		// Same OS-noise skip as the top-level loop: a `.jolli/.DS_Store` a
+		// Finder visit dropped is not content, and without this it would pin the
+		// junk folder permanently (the strict allowlist below rejects it).
+		if (isOsNoise(e.name)) continue;
 		if (!INERT_JOLLI_ENTRIES.has(e.name)) return false;
 	}
 

--- a/vscode/src/services/KbFoldersService.ts
+++ b/vscode/src/services/KbFoldersService.ts
@@ -48,14 +48,11 @@
  */
 
 import type { Dirent } from "node:fs";
-import { existsSync, promises as fs, readFileSync } from "node:fs";
+import { existsSync, promises as fs, readdirSync, readFileSync } from "node:fs";
 import { isAbsolute, join, normalize } from "node:path";
 import type { SummaryIndex } from "../../../cli/src/Types.js";
 import { FolderStorage } from "../../../cli/src/core/FolderStorage.js";
-import {
-	archiveKBFolder,
-	normalizeRemoteUrl,
-} from "../../../cli/src/core/KBPathResolver.js";
+import { archiveKBFolder } from "../../../cli/src/core/KBPathResolver.js";
 import {
 	type DiscoveredRepo,
 	discoverRepos,
@@ -126,96 +123,93 @@ export class KbFoldersService {
 	}
 
 	/**
-	 * Collapses duplicate KB folders that share one repo identity so the Folders
-	 * tab stops showing the same repo twice (the `jolliai` + `jolliai-2` symptom).
+	 * Archives Memory Bank folders that were claimed for something that never
+	 * turned out to be a useful repo, so the Folders tab stops listing rows the
+	 * user has no reason to browse. This is the ONLY mutation the sidebar's
+	 * Refresh performs.
 	 *
-	 * WHY dupes exist: `resolveKBPath` claims a folder per `(repoName, remoteUrl)`
-	 * at activation time. When the current project's `remoteUrl` reads back as
-	 * `null` (local-only repo, or a transient `git` timeout degrading
-	 * `extractRepoName` to a basename), it can spawn a `-2` sibling whose
-	 * `config.json` carries `remoteUrl: null` while the base folder holds the
-	 * real URL. Two folders, same on-disk repo, two Folders-tab rows. The other
-	 * classic cause is a LEGACY SSH-vs-HTTPS clone mismatch: `isSameRepo` folds
-	 * transports today, but folders claimed before that fold shipped still hold
-	 * `git@host:o/r.git` in one `config.json` and `https://host/o/r` in the
-	 * other, so their piles survive. Both configs are read verbatim here, which
-	 * is why the remote comparison below has to canonicalize.
+	 * REFRESH'S CONTRACT — Refresh clears folders that a past bug created and
+	 * that never held anything; it NEVER moves a folder holding memories. That is
+	 * the whole reason this sweep is keyed on emptiness and nothing else, and why
+	 * DUPLICATE folders are deliberately out of scope here even though they are
+	 * the more visible annoyance: collapsing duplicates means picking one of
+	 * several populated folders and burying the rest, since an archive is a plain
+	 * move that cannot merge them. The only correct survivor is one rebuilt from
+	 * the orphan branch (the system of record), which is Migrate's job — so
+	 * duplicates belong to Migrate, and a Refresh stays a safe, lossless action
+	 * the user can click without thinking. An earlier revision did wire a
+	 * duplicate-collapsing pass into Refresh; it was withdrawn for exactly this
+	 * reason. Do not re-add one here.
 	 *
-	 * GROUPING RULE — group by `repoName`, then COLLAPSE only when every member
-	 * of the group is "the same repo":
-	 *   - two members with equal non-null remotes  → dupes (collapse).
-	 *   - a member with a real remote + a member with `null` remote → the null
-	 *     one is the auto-spawned shadow (collapse it, keep the one with a
-	 *     remote). This is the exact `jolliai`/`jolliai-2` case the user sees.
-	 *   - two members with DISTINCT non-null remotes → DIFFERENT repos that
-	 *     merely share a basename (forks) → NEVER collapse; that would merge two
-	 *     unrelated knowledge bases. The user's "no remote URL" heuristic is a
-	 *     SUBSET of this rule: a lone local-only folder legitimately has
-	 *     `remoteUrl: null` and must be preserved.
+	 * WHY these folders exist: `resolveKBPath` CLAIMS the folder it returns
+	 * (writes `.jolli/config.json`) and takes its `repoName` from whatever cwd the
+	 * calling process happened to have. Every jollimemory process that ran outside
+	 * a real project therefore materialized a folder named after that cwd —
+	 * `system32`, `unknown`, `tmp.XXXXXX`, an agent's temp dir, a doc title a
+	 * local-agent run used as its working directory. `checkClaimable` is the gate
+	 * that stops NEW ones (see its docstring for the full taxonomy), but it can't
+	 * retract the pile already on disk from before it shipped, and users have to
+	 * clear those by hand today. The same shape also comes from browsing: opening
+	 * an unrelated checkout once claims its folder, and if no commit ever lands
+	 * there the folder stays forever empty.
 	 *
-	 * KEEP PICK: see {@link pickCanonical} — most content first, then a non-null
-	 * remote, then the lowest `-N` suffix. Content leads because nothing here
-	 * merges the loser into the winner; archiving is a plain move, so the
-	 * populated folder has to be the survivor.
+	 * RULE — archive only a folder that holds NOTHING (see {@link isEmptyKbFolder}):
+	 * no summaries in `index.json`, no rows in `manifest.json`, no visible files
+	 * or branch dirs, and nothing under `.jolli/` beyond the inert metadata stubs
+	 * `MetadataManager.ensure()` seeds. Emptiness is the whole test on purpose:
+	 *   - It cannot lose memories. Archiving is a move, and an empty folder has
+	 *     nothing to move; if the repo becomes active again `resolveKBPath`
+	 *     re-claims the same path on the next write.
+	 *   - It needs no name heuristics. Guessing junk from a *name* (`system32`,
+	 *     `tmp.*`, "looks like a doc title") would eventually archive someone's
+	 *     legitimately-named repo, and a populated `system32` folder means the
+	 *     user really does keep memories for a project by that name.
+	 *   - It covers the empty-but-real-remote rows too (a checkout opened once,
+	 *     never committed to). Those identify a real repo but hold nothing, so the
+	 *     row is pure noise; the folder returns the moment it earns content.
 	 *
-	 * ACTION: extra folders are MOVED into the hidden archive dir via
-	 * `archiveKBFolder` — the same recoverable path the Migrate-to-Memory-Bank
-	 * flow uses — rather than hard-deleted, so a mis-classification is undoable.
-	 * The orphan branch remains the system of record regardless.
+	 * Anything unrecognized under `.jolli/` — including the `shadow-status.json`
+	 * dirty marker, which means a write was attempted and hasn't landed — counts
+	 * as content and keeps the folder. Unknown state is never assumed disposable.
 	 *
-	 * DISTINCT-REMOTE groups are left completely untouched (no archive, no
-	 * notification) so legitimate forks are never disturbed.
+	 * NEVER touched: the current project's folder, or any folder carrying the
+	 * current project's `repoName`. A fresh install's own folder is legitimately
+	 * empty until the first commit lands, and archiving it on the Refresh the user
+	 * clicked to look at it would spawn one archive dir per click.
+	 *
+	 * Folders without `.jolli/config.json` are invisible to `discoverRepos` and so
+	 * never candidates — user-dropped notes and files under `<kbParent>` are out
+	 * of scope by construction.
+	 *
+	 * ACTION: a MOVE into the hidden `<kbParent>/.jolli/archive/` dir — the same
+	 * recoverable path the Migrate-to-Memory-Bank flow uses — never a delete, so
+	 * a mis-classification is undoable. The orphan branch remains the system of
+	 * record regardless.
 	 *
 	 * @returns the list of folder paths that were archived (empty if none).
 	 */
-	async dedupeFolders(): Promise<string[]> {
+	async archiveUnusedFolders(): Promise<string[]> {
 		const ctx = this.getContext();
 		const repos = discoverRepos(
 			ctx.currentRepoName,
 			ctx.currentRemoteUrl,
 			ctx.kbParent,
 		);
-		// Group by config repoName. Two DiscoveryRepos with the same dirName
-		// can't happen (discoverRepos scans distinct dirs), but two different
-		// dirNames (base + -N, or two forks) can share a repoName.
-		const byName = new Map<string, DiscoveredRepo[]>();
-		for (const r of repos) {
-			const key = r.repoName;
-			const group = byName.get(key);
-			if (group) group.push(r);
-			else byName.set(key, [r]);
-		}
-
 		const archived: string[] = [];
-		for (const group of byName.values()) {
-			if (group.length < 2) continue;
-			// Remotes must be compared CANONICALIZED, not raw: the SSH-vs-HTTPS
-			// clone mismatch this method exists to collapse stores
-			// `git@github.com:o/r.git` in one config and
-			// `https://github.com/o/r` in the other. Raw string equality calls
-			// those two "distinct remotes" and skips the group — i.e. the second
-			// of the two documented causes would never have been collapsed.
-			// `normalizeRemoteUrl` is the same comparer `KBPathResolver.isSameRepo`
-			// uses to decide folder reuse, imported rather than re-derived so the
-			// two can't drift (a divergent copy is what split `<repo>`/`<repo>-2`
-			// in the first place).
-			const distinctRemotes = new Set(
-				group
-					.map((r) => r.remoteUrl)
-					.filter((u): u is string => u != null)
-					.map(normalizeRemoteUrl),
-			);
-			if (distinctRemotes.size > 1) {
-				// Different repos sharing a basename — forks, not dupes.
+		for (const repo of repos) {
+			// Two-part current-repo guard. `isCurrentRepo` is remote-first, so it
+			// misses a same-repo folder whose config holds a different transport
+			// or host alias for the current project's remote — exactly the shape
+			// that spawns an extra empty folder in the first place. Matching the
+			// name as well keeps every folder that could be the one this session
+			// is about to write into.
+			if (repo.isCurrentRepo) continue;
+			if (ctx.currentRepoName != null && repo.repoName === ctx.currentRepoName) {
 				continue;
 			}
-			// Collapsible group: pick the canonical survivor.
-			const keep = pickCanonical(group);
-			for (const r of group) {
-				if (r.kbRoot === keep.kbRoot) continue;
-				const dest = archiveKBFolder(r.kbRoot, ctx.kbParent);
-				if (dest) archived.push(r.kbRoot);
-			}
+			if (!isEmptyKbFolder(repo.kbRoot)) continue;
+			const dest = archiveKBFolder(repo.kbRoot, ctx.kbParent);
+			if (dest) archived.push(repo.kbRoot);
 		}
 		if (archived.length > 0) this.cleanRepos.clear();
 		return archived;
@@ -703,63 +697,113 @@ function repoDisplayName(repo: DiscoveredRepo): string {
 }
 
 /**
- * Picks the canonical survivor from a dedup group, in priority order:
+ * Entries under `<kbRoot>/.jolli/` that carry no memories on their own — the
+ * schema stubs `MetadataManager.ensure()` seeds when a folder is claimed, plus
+ * the two bookkeeping files a claim can leave behind. Every other name (
+ * `summaries/`, `transcripts/`, `plans/`, `notes/`, `references/`, `catalog.json`,
+ * `topics/`, `graph/`, anything a future writer adds) counts as content and
+ * keeps the folder.
  *
- *   1. **Most content** (`.jolli/index.json` entry count). Nothing here
- *      re-migrates the loser's contents into the winner — archiving is a pure
- *      move — so the folder holding the memories must always be the one that
- *      stays. Everything below is only a tiebreak between folders that hold
- *      the same amount.
- *   2. **A non-null `remoteUrl`**, so the folder carrying a real identity
- *      survives over the degraded shadow.
- *   3. **Lowest collision suffix** (base `<repo>` before `<repo>-2`).
- *      `dirName` is always `<repoName>` or `<repoName>-N`, so the numeric
- *      suffix parse is well-defined.
+ * `index.json` / `manifest.json` are inert only in the sense that their
+ * PRESENCE proves nothing — {@link isEmptyKbFolder} still reads both and
+ * requires them to hold zero entries.
  *
- * Suffix used to be the FIRST key, which inverted rules 1 and 2 and produced a
- * self-perpetuating loop: with a null-remote base and the real remote in
- * `<repo>-2`, `resolveKBPath` resolves writes to `<repo>-2` (the base fails
- * `isSameRepo` against a real remote), so suffix-first archived the *live*
- * folder, the next write re-claimed an empty `<repo>-2`, and the following
- * Refresh archived that one too — one archived directory per refresh, forever,
- * with the populated folder buried each time.
+ * `shadow-status.json` is deliberately ABSENT: that is the dual-write dirty
+ * marker (`DualWriteStorage.markDirty`), so its presence means a folder write
+ * was attempted and hasn't completed. A folder mid-write is not disposable
+ * even while it still looks empty.
  */
-function pickCanonical(group: DiscoveredRepo[]): DiscoveredRepo {
-	let best = group[0];
-	let bestKey = canonicalKey(best);
-	for (let i = 1; i < group.length; i++) {
-		const key = canonicalKey(group[i]);
-		if (
-			key.entries > bestKey.entries ||
-			(key.entries === bestKey.entries &&
-				(key.hasRemote > bestKey.hasRemote ||
-					(key.hasRemote === bestKey.hasRemote && key.rank < bestKey.rank)))
-		) {
-			best = group[i];
-			bestKey = key;
-		}
+const INERT_JOLLI_ENTRIES: ReadonlySet<string> = new Set([
+	"config.json",
+	"branches.json",
+	"manifest.json",
+	"index.json",
+	"migration.json",
+]);
+
+/**
+ * OS-generated files that appear inside any browsed directory and say nothing
+ * about whether the user keeps memories there. Ignored when deciding emptiness
+ * so a single Finder/Explorer visit can't pin a junk folder in the tree
+ * forever.
+ */
+const OS_NOISE_FILES: ReadonlySet<string> = new Set([".DS_Store", "Thumbs.db"]);
+
+/**
+ * True when `kbRoot` is a claimed-but-empty Memory Bank folder: nothing the
+ * user could browse and nothing the system recorded. The emptiness test behind
+ * {@link KbFoldersService.archiveUnusedFolders} — see that method for why
+ * emptiness (rather than the folder's name or its missing remote) is the whole
+ * criterion.
+ *
+ * Every check is "keep unless proven empty", so an unreadable directory, an
+ * unparseable manifest, or any name this code doesn't recognize resolves to
+ * `false` (keep). A folder is only archived on positive evidence that it holds
+ * nothing.
+ */
+function isEmptyKbFolder(kbRoot: string): boolean {
+	let top: Dirent<string>[];
+	try {
+		top = readdirSync(kbRoot, { withFileTypes: true }) as Dirent<string>[];
+	} catch {
+		// Unreadable (permissions, vanished mid-scan) — not provably empty, and
+		// `archiveKBFolder` would fail on it anyway.
+		return false;
 	}
-	return best;
+	for (const e of top) {
+		if (e.name === ".jolli") continue;
+		if (OS_NOISE_FILES.has(e.name)) continue;
+		// A visible branch dir / `.md`, or a dotfile we don't recognize (a `.git`
+		// the user init'd here, an editor workspace file) — real content.
+		return false;
+	}
+
+	let jolli: Dirent<string>[];
+	try {
+		jolli = readdirSync(join(kbRoot, ".jolli"), {
+			withFileTypes: true,
+		}) as Dirent<string>[];
+	} catch {
+		// `discoverRepos` only yields folders whose `.jolli/config.json` parsed,
+		// so this is a vanished-mid-scan race, not a normal state.
+		return false;
+	}
+	for (const e of jolli) {
+		if (!INERT_JOLLI_ENTRIES.has(e.name)) return false;
+	}
+
+	// `countIndexEntries` reads a missing OR unparseable index as 0. That is safe
+	// here only because a folder holding real summaries also holds
+	// `.jolli/summaries/`, which the allowlist above already rejected — a corrupt
+	// index alone can never make a populated folder look empty.
+	if (countIndexEntries(kbRoot) > 0) return false;
+	return countManifestFiles(kbRoot) === 0;
 }
 
-/** Sort key for {@link pickCanonical}: higher `entries`/`hasRemote` and lower `rank` win. */
-function canonicalKey(repo: DiscoveredRepo): {
-	entries: number;
-	hasRemote: number;
-	rank: number;
-} {
-	return {
-		entries: countIndexEntries(repo.kbRoot),
-		hasRemote: repo.remoteUrl != null ? 1 : 0,
-		rank: suffixRank(repo.dirName),
-	};
+/**
+ * Number of rows in `<kbRoot>/.jolli/manifest.json`, or `-1` when the file
+ * exists but can't be read or parsed. The sentinel keeps
+ * {@link isEmptyKbFolder}'s `=== 0` test from treating a corrupt manifest as
+ * proof of emptiness; a missing manifest is a genuine `0` (nothing was ever
+ * written).
+ */
+function countManifestFiles(kbRoot: string): number {
+	const path = join(kbRoot, ".jolli", "manifest.json");
+	if (!existsSync(path)) return 0;
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf-8")) as Manifest;
+		return Array.isArray(parsed.files) ? parsed.files.length : -1;
+	} catch {
+		return -1;
+	}
 }
 
 /**
  * Number of summaries recorded in `<kbRoot>/.jolli/index.json`, or `0` when the
- * file is missing or unparseable. A missing index reads as "empty", which is
- * the safe direction: an unreadable folder never outranks a readable populated
- * one for survival.
+ * file is missing or unparseable. Reading a missing index as "empty" is what
+ * {@link isEmptyKbFolder} needs (a folder that never got an index never got a
+ * summary); the unparseable case is safe there because a folder holding real
+ * summaries also holds `.jolli/summaries/`, which that check rejects first.
  */
 function countIndexEntries(kbRoot: string): number {
 	try {
@@ -770,15 +814,6 @@ function countIndexEntries(kbRoot: string): number {
 	} catch {
 		return 0;
 	}
-}
-
-/**
- * Collision-suffix rank for a KB dir name: `0` for the base `<repo>`, `N` for
- * `<repo>-N`. Extraction mirrors `KBPathResolver`'s `<repo>-N` ladder.
- */
-function suffixRank(dirName: string): number {
-	const m = dirName.match(/-(\d+)$/);
-	return m ? Number(m[1]) : 0;
 }
 
 /**

--- a/vscode/src/services/KbFoldersService.ts
+++ b/vscode/src/services/KbFoldersService.ts
@@ -66,6 +66,11 @@ import {
 import type { Manifest, ManifestEntry } from "../../../cli/src/core/KBTypes.js";
 import { MetadataManager } from "../../../cli/src/core/MetadataManager.js";
 import { isManuallyDisabled } from "../../../cli/src/Logger.js";
+import {
+	DEFAULT_PULL_LOCK_WAIT_MS,
+	VaultWriteBusyError,
+	withVaultWriteLock,
+} from "../../../cli/src/sync/VaultWriteLock.js";
 import type { FolderFileKind, FolderNode } from "../views/SidebarMessages.js";
 
 /**
@@ -201,33 +206,53 @@ export class KbFoldersService {
 	 * a mis-classification is undoable. The orphan branch remains the system of
 	 * record regardless.
 	 *
-	 * @returns the list of folder paths that were archived (empty if none).
+	 * SYNCED VAULTS: `<kbParent>` is also the vault git working tree, so the
+	 * `renameSync` is simultaneously an unlocked working-tree mutation and an
+	 * implicit `git rm` of the folder's four git-tracked `.jolli/*.json` stubs.
+	 * Two consequences, both handled here rather than left implicit:
+	 *   1. It must not race a concurrent vault writer (QueueWorker mid-drain, a
+	 *      sync round that already snapshotted `git status`, a compile). So the
+	 *      whole sweep runs under `vault-write.lock` — the SAME lock keyed on the
+	 *      SAME canonical `<kbParent>` those writers take. Best-effort: if the
+	 *      vault is busy we skip and let the next Refresh retry, rather than
+	 *      block the click.
+	 *   2. The staged `git rm` propagates the empty folder's removal to peers.
+	 *      That is correct, not data loss: a synced vault has git-identical
+	 *      content on every peer, so a folder empty here is empty there too, and
+	 *      `resolveKBPath` re-claims (re-writing `config.json`) on the next write
+	 *      on whichever device the repo becomes active — the same self-heal that
+	 *      makes the local move safe. The only unpushed-peer-write edge is bounded
+	 *      by the lock plus `ConflictResolver`'s base-aware merge.
+	 *
+	 * @returns the list of folder paths that were archived (empty if none, or if
+	 * the vault was busy).
 	 */
 	async archiveUnusedFolders(): Promise<string[]> {
 		const ctx = this.getContext();
-		const repos = discoverRepos(
-			ctx.currentRepoName,
-			ctx.currentRemoteUrl,
-			ctx.kbParent,
-		);
-		const archived: string[] = [];
-		for (const repo of repos) {
-			// Two-part current-repo guard. `isCurrentRepo` is remote-first, so it
-			// misses a same-repo folder whose config holds a different transport
-			// or host alias for the current project's remote — exactly the shape
-			// that spawns an extra empty folder in the first place. Matching the
-			// name as well keeps every folder that could be the one this session
-			// is about to write into.
-			if (repo.isCurrentRepo) continue;
-			if (ctx.currentRepoName != null && repo.repoName === ctx.currentRepoName) {
-				continue;
+		const result = await withVaultWriteLock(ctx.kbParent, { wait: DEFAULT_PULL_LOCK_WAIT_MS }, async () => {
+			const repos = discoverRepos(ctx.currentRepoName, ctx.currentRemoteUrl, ctx.kbParent);
+			const archived: string[] = [];
+			for (const repo of repos) {
+				// Two-part current-repo guard. `isCurrentRepo` is remote-first, so it
+				// misses a same-repo folder whose config holds a different transport
+				// or host alias for the current project's remote — exactly the shape
+				// that spawns an extra empty folder in the first place. Matching the
+				// name as well keeps every folder that could be the one this session
+				// is about to write into.
+				if (repo.isCurrentRepo) continue;
+				if (ctx.currentRepoName != null && repo.repoName === ctx.currentRepoName) {
+					continue;
+				}
+				if (!isEmptyKbFolder(repo.kbRoot)) continue;
+				const dest = archiveKBFolder(repo.kbRoot, ctx.kbParent);
+				if (dest) archived.push(repo.kbRoot);
 			}
-			if (!isEmptyKbFolder(repo.kbRoot)) continue;
-			const dest = archiveKBFolder(repo.kbRoot, ctx.kbParent);
-			if (dest) archived.push(repo.kbRoot);
-		}
-		if (archived.length > 0) this.cleanRepos.clear();
-		return archived;
+			if (archived.length > 0) this.cleanRepos.clear();
+			return archived;
+		});
+		// Vault busy (a worker/sync/compile held the lock through the budget): skip
+		// this sweep silently — it is best-effort and the next Refresh retries.
+		return result.ran ? result.value : [];
 	}
 
 	/**
@@ -266,17 +291,29 @@ export class KbFoldersService {
 	 * Executes a plan from {@link planDuplicateConsolidation} — the folder merge
 	 * / rebuild + archive. Drops the "clean repo" memo afterwards so the next
 	 * listing re-reads the survivor. Returns what happened.
+	 *
+	 * Held under `vault-write.lock` for the same reason as the empty sweep: the
+	 * copy-if-absent + metadata union + `archiveKBFolder` all mutate the vault
+	 * working tree, and must serialise against QueueWorker / SyncEngine / compile
+	 * instead of racing their `git status` / staging windows. Throws
+	 * {@link VaultWriteBusyError} when the vault is busy so the caller can tell
+	 * the user "try again shortly" — unlike the best-effort sweep, a user asked
+	 * for this merge, so a silent skip would look like it did nothing.
 	 */
 	async runConsolidation(plan: ConsolidationPlan): Promise<ConsolidationResult> {
 		const ctx = this.getContext();
-		const result = await executeConsolidation(
-			plan,
-			ctx.currentProjectRoot ?? ctx.kbParent,
-			ctx.currentRemoteUrl,
-			ctx.kbParent,
-		);
-		this.cleanRepos.clear();
-		return result;
+		const result = await withVaultWriteLock(ctx.kbParent, { wait: DEFAULT_PULL_LOCK_WAIT_MS }, async () => {
+			const r = await executeConsolidation(
+				plan,
+				ctx.currentProjectRoot ?? ctx.kbParent,
+				ctx.currentRemoteUrl,
+				ctx.kbParent,
+			);
+			this.cleanRepos.clear();
+			return r;
+		});
+		if (!result.ran) throw new VaultWriteBusyError();
+		return result.value;
 	}
 
 	/**

--- a/vscode/src/services/KbFoldersService.ts
+++ b/vscode/src/services/KbFoldersService.ts
@@ -53,6 +53,10 @@ import { isAbsolute, join, normalize } from "node:path";
 import type { SummaryIndex } from "../../../cli/src/Types.js";
 import { FolderStorage } from "../../../cli/src/core/FolderStorage.js";
 import {
+	archiveKBFolder,
+	normalizeRemoteUrl,
+} from "../../../cli/src/core/KBPathResolver.js";
+import {
 	type DiscoveredRepo,
 	discoverRepos,
 } from "../../../cli/src/core/KBRepoDiscoverer.js";
@@ -119,6 +123,102 @@ export class KbFoldersService {
 	notifyDirty(kbRoot?: string): void {
 		if (kbRoot) this.cleanRepos.delete(kbRoot);
 		else this.cleanRepos.clear();
+	}
+
+	/**
+	 * Collapses duplicate KB folders that share one repo identity so the Folders
+	 * tab stops showing the same repo twice (the `jolliai` + `jolliai-2` symptom).
+	 *
+	 * WHY dupes exist: `resolveKBPath` claims a folder per `(repoName, remoteUrl)`
+	 * at activation time. When the current project's `remoteUrl` reads back as
+	 * `null` (local-only repo, or a transient `git` timeout degrading
+	 * `extractRepoName` to a basename), it can spawn a `-2` sibling whose
+	 * `config.json` carries `remoteUrl: null` while the base folder holds the
+	 * real URL. Two folders, same on-disk repo, two Folders-tab rows. The other
+	 * classic cause is a LEGACY SSH-vs-HTTPS clone mismatch: `isSameRepo` folds
+	 * transports today, but folders claimed before that fold shipped still hold
+	 * `git@host:o/r.git` in one `config.json` and `https://host/o/r` in the
+	 * other, so their piles survive. Both configs are read verbatim here, which
+	 * is why the remote comparison below has to canonicalize.
+	 *
+	 * GROUPING RULE — group by `repoName`, then COLLAPSE only when every member
+	 * of the group is "the same repo":
+	 *   - two members with equal non-null remotes  → dupes (collapse).
+	 *   - a member with a real remote + a member with `null` remote → the null
+	 *     one is the auto-spawned shadow (collapse it, keep the one with a
+	 *     remote). This is the exact `jolliai`/`jolliai-2` case the user sees.
+	 *   - two members with DISTINCT non-null remotes → DIFFERENT repos that
+	 *     merely share a basename (forks) → NEVER collapse; that would merge two
+	 *     unrelated knowledge bases. The user's "no remote URL" heuristic is a
+	 *     SUBSET of this rule: a lone local-only folder legitimately has
+	 *     `remoteUrl: null` and must be preserved.
+	 *
+	 * KEEP PICK: see {@link pickCanonical} — most content first, then a non-null
+	 * remote, then the lowest `-N` suffix. Content leads because nothing here
+	 * merges the loser into the winner; archiving is a plain move, so the
+	 * populated folder has to be the survivor.
+	 *
+	 * ACTION: extra folders are MOVED into the hidden archive dir via
+	 * `archiveKBFolder` — the same recoverable path the Migrate-to-Memory-Bank
+	 * flow uses — rather than hard-deleted, so a mis-classification is undoable.
+	 * The orphan branch remains the system of record regardless.
+	 *
+	 * DISTINCT-REMOTE groups are left completely untouched (no archive, no
+	 * notification) so legitimate forks are never disturbed.
+	 *
+	 * @returns the list of folder paths that were archived (empty if none).
+	 */
+	async dedupeFolders(): Promise<string[]> {
+		const ctx = this.getContext();
+		const repos = discoverRepos(
+			ctx.currentRepoName,
+			ctx.currentRemoteUrl,
+			ctx.kbParent,
+		);
+		// Group by config repoName. Two DiscoveryRepos with the same dirName
+		// can't happen (discoverRepos scans distinct dirs), but two different
+		// dirNames (base + -N, or two forks) can share a repoName.
+		const byName = new Map<string, DiscoveredRepo[]>();
+		for (const r of repos) {
+			const key = r.repoName;
+			const group = byName.get(key);
+			if (group) group.push(r);
+			else byName.set(key, [r]);
+		}
+
+		const archived: string[] = [];
+		for (const group of byName.values()) {
+			if (group.length < 2) continue;
+			// Remotes must be compared CANONICALIZED, not raw: the SSH-vs-HTTPS
+			// clone mismatch this method exists to collapse stores
+			// `git@github.com:o/r.git` in one config and
+			// `https://github.com/o/r` in the other. Raw string equality calls
+			// those two "distinct remotes" and skips the group — i.e. the second
+			// of the two documented causes would never have been collapsed.
+			// `normalizeRemoteUrl` is the same comparer `KBPathResolver.isSameRepo`
+			// uses to decide folder reuse, imported rather than re-derived so the
+			// two can't drift (a divergent copy is what split `<repo>`/`<repo>-2`
+			// in the first place).
+			const distinctRemotes = new Set(
+				group
+					.map((r) => r.remoteUrl)
+					.filter((u): u is string => u != null)
+					.map(normalizeRemoteUrl),
+			);
+			if (distinctRemotes.size > 1) {
+				// Different repos sharing a basename — forks, not dupes.
+				continue;
+			}
+			// Collapsible group: pick the canonical survivor.
+			const keep = pickCanonical(group);
+			for (const r of group) {
+				if (r.kbRoot === keep.kbRoot) continue;
+				const dest = archiveKBFolder(r.kbRoot, ctx.kbParent);
+				if (dest) archived.push(r.kbRoot);
+			}
+		}
+		if (archived.length > 0) this.cleanRepos.clear();
+		return archived;
 	}
 
 	/**
@@ -600,6 +700,85 @@ function repoDisplayName(repo: DiscoveredRepo): string {
 	return repo.repoName === repo.dirName
 		? repo.repoName
 		: `${repo.repoName} (${repo.dirName})`;
+}
+
+/**
+ * Picks the canonical survivor from a dedup group, in priority order:
+ *
+ *   1. **Most content** (`.jolli/index.json` entry count). Nothing here
+ *      re-migrates the loser's contents into the winner — archiving is a pure
+ *      move — so the folder holding the memories must always be the one that
+ *      stays. Everything below is only a tiebreak between folders that hold
+ *      the same amount.
+ *   2. **A non-null `remoteUrl`**, so the folder carrying a real identity
+ *      survives over the degraded shadow.
+ *   3. **Lowest collision suffix** (base `<repo>` before `<repo>-2`).
+ *      `dirName` is always `<repoName>` or `<repoName>-N`, so the numeric
+ *      suffix parse is well-defined.
+ *
+ * Suffix used to be the FIRST key, which inverted rules 1 and 2 and produced a
+ * self-perpetuating loop: with a null-remote base and the real remote in
+ * `<repo>-2`, `resolveKBPath` resolves writes to `<repo>-2` (the base fails
+ * `isSameRepo` against a real remote), so suffix-first archived the *live*
+ * folder, the next write re-claimed an empty `<repo>-2`, and the following
+ * Refresh archived that one too — one archived directory per refresh, forever,
+ * with the populated folder buried each time.
+ */
+function pickCanonical(group: DiscoveredRepo[]): DiscoveredRepo {
+	let best = group[0];
+	let bestKey = canonicalKey(best);
+	for (let i = 1; i < group.length; i++) {
+		const key = canonicalKey(group[i]);
+		if (
+			key.entries > bestKey.entries ||
+			(key.entries === bestKey.entries &&
+				(key.hasRemote > bestKey.hasRemote ||
+					(key.hasRemote === bestKey.hasRemote && key.rank < bestKey.rank)))
+		) {
+			best = group[i];
+			bestKey = key;
+		}
+	}
+	return best;
+}
+
+/** Sort key for {@link pickCanonical}: higher `entries`/`hasRemote` and lower `rank` win. */
+function canonicalKey(repo: DiscoveredRepo): {
+	entries: number;
+	hasRemote: number;
+	rank: number;
+} {
+	return {
+		entries: countIndexEntries(repo.kbRoot),
+		hasRemote: repo.remoteUrl != null ? 1 : 0,
+		rank: suffixRank(repo.dirName),
+	};
+}
+
+/**
+ * Number of summaries recorded in `<kbRoot>/.jolli/index.json`, or `0` when the
+ * file is missing or unparseable. A missing index reads as "empty", which is
+ * the safe direction: an unreadable folder never outranks a readable populated
+ * one for survival.
+ */
+function countIndexEntries(kbRoot: string): number {
+	try {
+		const parsed = JSON.parse(
+			readFileSync(join(kbRoot, ".jolli", "index.json"), "utf-8"),
+		) as SummaryIndex;
+		return Array.isArray(parsed.entries) ? parsed.entries.length : 0;
+	} catch {
+		return 0;
+	}
+}
+
+/**
+ * Collision-suffix rank for a KB dir name: `0` for the base `<repo>`, `N` for
+ * `<repo>-N`. Extraction mirrors `KBPathResolver`'s `<repo>-N` ladder.
+ */
+function suffixRank(dirName: string): number {
+	const m = dirName.match(/-(\d+)$/);
+	return m ? Number(m[1]) : 0;
 }
 
 /**

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -9,6 +9,7 @@ import type {
 } from "./SidebarMessages";
 import { setManuallyDisabled } from "../../../cli/src/Logger.js";
 import type { ConsolidationPlan } from "../../../cli/src/core/FolderConsolidation.js";
+import { VaultWriteBusyError } from "../../../cli/src/sync/VaultWriteLock";
 import { describeConsolidationPlan, SidebarWebviewProvider } from "./SidebarWebviewProvider";
 
 interface MockWebview {
@@ -2157,6 +2158,47 @@ describe("SidebarWebviewProvider", () => {
 				"rebuilt from it",
 			);
 			expect(describeConsolidationPlan(makePlan({ kind: "union-largest" }))).toContain("will absorb 1 more");
+		});
+
+		it("shows a 'busy — try again' toast when the vault lock is contended", async () => {
+			const { view, runConsolidation } = makeConsolidationProvider(makePlan());
+			runConsolidation.mockRejectedValueOnce(new VaultWriteBusyError());
+			showWarningMessage.mockResolvedValueOnce("Merge");
+			view.webview.triggerMessage({ type: "refresh", scope: "kb" });
+			await new Promise((r) => setTimeout(r, 0));
+			await new Promise((r) => setTimeout(r, 0));
+			expect(runConsolidation).toHaveBeenCalledTimes(1);
+			expect(showInformationMessage).toHaveBeenCalledTimes(1);
+			expect(showInformationMessage.mock.calls[0][0]).toContain("busy writing a summary");
+		});
+
+		it("re-pushes the breadcrumb repo list after a kb refresh (archived repos leave the dropdown)", async () => {
+			const view = makeMockView();
+			const provider = new SidebarWebviewProvider({
+				executeCommand: vi.fn().mockResolvedValue(undefined),
+				getInitialState: () => ({
+					enabled: true,
+					authenticated: false,
+					activeTab: "kb",
+					kbMode: "folders",
+					branchName: "main",
+					detached: false,
+				}),
+				extensionUri: mockExtensionUri as unknown as never,
+				kbFolders: { listChildren: vi.fn().mockResolvedValue([]) },
+				selection: {
+					listRepos: vi.fn(() => [{ repoName: "app", remoteUrl: null, isCurrent: true }]),
+					listBranches: vi.fn(() => ["main"]),
+				},
+			});
+			provider.resolveWebviewView(view as unknown as never);
+			view.webview.postMessage.mockClear();
+			view.webview.triggerMessage({ type: "refresh", scope: "kb" });
+			await new Promise((r) => setTimeout(r, 0));
+			await new Promise((r) => setTimeout(r, 0));
+			const posted = view.webview.postMessage.mock.calls.map((c) => (c[0] as { type: string }).type);
+			expect(posted).toContain("selection:repos");
+			expect(posted).toContain("selection:branches");
 		});
 	});
 

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -8,7 +8,8 @@ import type {
 	SidebarState,
 } from "./SidebarMessages";
 import { setManuallyDisabled } from "../../../cli/src/Logger.js";
-import { SidebarWebviewProvider } from "./SidebarWebviewProvider";
+import type { ConsolidationPlan } from "../../../cli/src/core/FolderConsolidation.js";
+import { describeConsolidationPlan, SidebarWebviewProvider } from "./SidebarWebviewProvider";
 
 interface MockWebview {
 	html: string;
@@ -50,8 +51,11 @@ const { clipboardWriteText } = vi.hoisted(() => ({
 }));
 // Backs the toast the KB refresh raises after `kbFolders.archiveUnusedFolders()`
 // archives folders that hold no memories at all.
-const { showInformationMessage } = vi.hoisted(() => ({
+const { showInformationMessage, showWarningMessage } = vi.hoisted(() => ({
 	showInformationMessage: vi.fn().mockResolvedValue(undefined),
+	// Backs the modal confirmation the KB refresh raises before merging duplicate
+	// folders. Default: user cancels (resolves undefined).
+	showWarningMessage: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock("vscode", () => ({
 	Uri: {
@@ -69,6 +73,7 @@ vi.mock("vscode", () => ({
 			dispose: vi.fn(),
 		})),
 		showInformationMessage,
+		showWarningMessage,
 	},
 	workspace: {
 		get workspaceFolders() {
@@ -2061,6 +2066,98 @@ describe("SidebarWebviewProvider", () => {
 		await new Promise((r) => setTimeout(r, 0));
 		expect(showInformationMessage).not.toHaveBeenCalled();
 		expect(kbFolders.listChildren).toHaveBeenCalledWith("");
+	});
+
+	describe("duplicate-folder consolidation on refresh", () => {
+		function makePlan(over: Partial<ConsolidationPlan> = {}): ConsolidationPlan {
+			return {
+				kind: "union-largest",
+				repoName: "app",
+				folders: ["/kb/app", "/kb/app-2"],
+				survivor: "/kb/app",
+				archived: ["/kb/app-2"],
+				counts: { perFolder: { "/kb/app": 3, "/kb/app-2": 2 }, orphan: 0, union: 4, survivor: 3, added: 1 },
+				...over,
+			};
+		}
+
+		function makeConsolidationProvider(plan: ConsolidationPlan | null) {
+			const view = makeMockView();
+			const executeCommand = vi.fn().mockResolvedValue(undefined);
+			const runConsolidation = vi.fn().mockResolvedValue({
+				kind: plan?.kind ?? "union-largest",
+				survivor: plan?.survivor ?? "/kb/app",
+				archived: plan?.archived ?? ["/kb/app-2"],
+				summariesAfter: 4,
+			});
+			const kbFolders = {
+				listChildren: vi.fn().mockResolvedValue([]),
+				notifyDirty: vi.fn(),
+				archiveDir: vi.fn(() => "/kb/.jolli/archive"),
+				planDuplicateConsolidation: vi.fn().mockResolvedValue(plan),
+				runConsolidation,
+			};
+			const provider = new SidebarWebviewProvider({
+				executeCommand,
+				getInitialState: () => ({
+					enabled: true,
+					authenticated: false,
+					activeTab: "kb",
+					kbMode: "folders",
+					branchName: "main",
+					detached: false,
+				}),
+				extensionUri: mockExtensionUri as unknown as never,
+				kbFolders,
+			});
+			provider.resolveWebviewView(view as unknown as never);
+			showInformationMessage.mockClear();
+			showWarningMessage.mockClear();
+			return { view, kbFolders, executeCommand, runConsolidation };
+		}
+
+		it("prompts, merges on confirm, and toasts the survivor", async () => {
+			const { view, runConsolidation, kbFolders } = makeConsolidationProvider(makePlan());
+			showWarningMessage.mockResolvedValueOnce("Merge");
+			view.webview.triggerMessage({ type: "refresh", scope: "kb" });
+			await new Promise((r) => setTimeout(r, 0));
+			await new Promise((r) => setTimeout(r, 0));
+			expect(showWarningMessage).toHaveBeenCalledTimes(1);
+			expect(showWarningMessage.mock.calls[0][1]).toEqual({ modal: true });
+			expect(runConsolidation).toHaveBeenCalledTimes(1);
+			expect(kbFolders.notifyDirty).toHaveBeenCalled();
+			expect(showInformationMessage).toHaveBeenCalledTimes(1);
+			expect(showInformationMessage.mock.calls[0][0]).toContain('merged duplicate Memory Bank folders into "app"');
+		});
+
+		it("does nothing when the user cancels the prompt", async () => {
+			const { view, runConsolidation } = makeConsolidationProvider(makePlan());
+			showWarningMessage.mockResolvedValueOnce(undefined); // dismissed
+			view.webview.triggerMessage({ type: "refresh", scope: "kb" });
+			await new Promise((r) => setTimeout(r, 0));
+			await new Promise((r) => setTimeout(r, 0));
+			expect(showWarningMessage).toHaveBeenCalledTimes(1);
+			expect(runConsolidation).not.toHaveBeenCalled();
+			expect(showInformationMessage).not.toHaveBeenCalled();
+		});
+
+		it("stays silent when there are no duplicates to consolidate", async () => {
+			const { view, runConsolidation } = makeConsolidationProvider(null);
+			view.webview.triggerMessage({ type: "refresh", scope: "kb" });
+			await new Promise((r) => setTimeout(r, 0));
+			expect(showWarningMessage).not.toHaveBeenCalled();
+			expect(runConsolidation).not.toHaveBeenCalled();
+		});
+
+		it("phrases the prompt per case", () => {
+			expect(describeConsolidationPlan(makePlan({ kind: "identical", counts: makePlan().counts }))).toContain(
+				"identical contents",
+			);
+			expect(describeConsolidationPlan(makePlan({ kind: "orphan-superset" }))).toContain(
+				"rebuilt from it",
+			);
+			expect(describeConsolidationPlan(makePlan({ kind: "union-largest" }))).toContain("will absorb 1 more");
+		});
 	});
 
 	it("handles refresh scope='branch' by invoking the three branch refresh commands", () => {

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -48,6 +48,11 @@ const mockWorkspaceFolders: Array<{ uri: { fsPath: string } }> = [];
 const { clipboardWriteText } = vi.hoisted(() => ({
 	clipboardWriteText: vi.fn().mockResolvedValue(undefined),
 }));
+// Backs the "collapsed N duplicate folders" toast the KB refresh raises after
+// `kbFolders.dedupeFolders()` archives something.
+const { showInformationMessage } = vi.hoisted(() => ({
+	showInformationMessage: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock("vscode", () => ({
 	Uri: {
 		joinPath: vi.fn((_base: unknown, ...segments: string[]) => ({
@@ -63,6 +68,7 @@ vi.mock("vscode", () => ({
 			show: vi.fn(),
 			dispose: vi.fn(),
 		})),
+		showInformationMessage,
 	},
 	workspace: {
 		get workspaceFolders() {
@@ -1919,6 +1925,64 @@ describe("SidebarWebviewProvider", () => {
 		await new Promise((r) => setTimeout(r, 0));
 		expect(kbFolders.listChildren).toHaveBeenCalledWith("");
 		expect(exec).toHaveBeenCalledWith("jollimemory.refreshMemories");
+	});
+
+	/** Builds a kb-tab provider whose `kbFolders` carries a stubbed dedupe. */
+	function makeKbDedupeProvider(dedupeFolders: () => Promise<string[]>) {
+		const view = makeMockView();
+		const kbFolders = {
+			listChildren: vi.fn().mockResolvedValue([]),
+			dedupeFolders: vi.fn(dedupeFolders),
+		};
+		const provider = new SidebarWebviewProvider({
+			executeCommand: vi.fn().mockResolvedValue(undefined),
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				activeTab: "kb",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+			kbFolders,
+		});
+		provider.resolveWebviewView(view as unknown as never);
+		showInformationMessage.mockClear();
+		return { view, kbFolders };
+	}
+
+	it("toasts once per refresh when dedupeFolders archived duplicate folders", async () => {
+		const { view, kbFolders } = makeKbDedupeProvider(async () => [
+			"/kb/jolliai-2",
+		]);
+		view.webview.triggerMessage({ type: "refresh", scope: "kb" });
+		await new Promise((r) => setTimeout(r, 0));
+		expect(kbFolders.dedupeFolders).toHaveBeenCalledTimes(1);
+		expect(showInformationMessage).toHaveBeenCalledTimes(1);
+		// Singular noun for one folder; the count is what the user acts on.
+		expect(showInformationMessage.mock.calls[0][0]).toContain("1 duplicate folder");
+		expect(kbFolders.listChildren).toHaveBeenCalledWith("");
+	});
+
+	it("stays silent when dedupeFolders found nothing to archive", async () => {
+		const { view, kbFolders } = makeKbDedupeProvider(async () => []);
+		view.webview.triggerMessage({ type: "refresh", scope: "kb" });
+		await new Promise((r) => setTimeout(r, 0));
+		expect(showInformationMessage).not.toHaveBeenCalled();
+		expect(kbFolders.listChildren).toHaveBeenCalledWith("");
+	});
+
+	it("still re-lists the tree when dedupeFolders throws", async () => {
+		// Dedupe is best-effort: a failed archive (locked directory, permissions)
+		// must not cost the user the refresh they actually asked for.
+		const { view, kbFolders } = makeKbDedupeProvider(async () => {
+			throw new Error("EPERM");
+		});
+		view.webview.triggerMessage({ type: "refresh", scope: "kb" });
+		await new Promise((r) => setTimeout(r, 0));
+		expect(showInformationMessage).not.toHaveBeenCalled();
+		expect(kbFolders.listChildren).toHaveBeenCalledWith("");
 	});
 
 	it("handles refresh scope='branch' by invoking the three branch refresh commands", () => {

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -1933,16 +1933,21 @@ describe("SidebarWebviewProvider", () => {
 	 * (not stubbed to `[]`) — the shape every pre-existing test uses, and the
 	 * reason the dep declares it optional.
 	 */
-	function makeKbSweepProvider(archiveUnusedFolders?: () => Promise<string[]>) {
+	function makeKbSweepProvider(
+		archiveUnusedFolders?: () => Promise<string[]>,
+		archiveDir?: string,
+	) {
 		const view = makeMockView();
+		const executeCommand = vi.fn().mockResolvedValue(undefined);
 		const kbFolders = {
 			listChildren: vi.fn().mockResolvedValue([]),
 			...(archiveUnusedFolders
 				? { archiveUnusedFolders: vi.fn(archiveUnusedFolders) }
 				: {}),
+			...(archiveDir ? { archiveDir: vi.fn(() => archiveDir) } : {}),
 		};
 		const provider = new SidebarWebviewProvider({
-			executeCommand: vi.fn().mockResolvedValue(undefined),
+			executeCommand,
 			getInitialState: () => ({
 				enabled: true,
 				authenticated: false,
@@ -1956,7 +1961,7 @@ describe("SidebarWebviewProvider", () => {
 		});
 		provider.resolveWebviewView(view as unknown as never);
 		showInformationMessage.mockClear();
-		return { view, kbFolders };
+		return { view, kbFolders, executeCommand };
 	}
 
 	it("sweeps unused folders then re-lists, toasting the singular form for one", async () => {
@@ -2009,6 +2014,43 @@ describe("SidebarWebviewProvider", () => {
 		view.webview.triggerMessage({ type: "refresh", scope: "all" });
 		await new Promise((r) => setTimeout(r, 0));
 		expect(showInformationMessage).toHaveBeenCalledTimes(1);
+	});
+
+	it("offers a Reveal Archive action and reveals the archive dir in the OS on click", async () => {
+		// "(recoverable)" should be an action, not just a claim about a hidden
+		// dir the user would never find on their own.
+		const { view, executeCommand } = makeKbSweepProvider(
+			async () => ["/kb/system32"],
+			"/kb/.jolli/archive",
+		);
+		showInformationMessage.mockResolvedValueOnce("Reveal Archive");
+		view.webview.triggerMessage({ type: "refresh", scope: "kb" });
+		await new Promise((r) => setTimeout(r, 0));
+		await new Promise((r) => setTimeout(r, 0));
+		// The button was offered as the toast's action.
+		expect(showInformationMessage.mock.calls[0][1]).toBe("Reveal Archive");
+		// Clicking it revealed the hidden archive dir in the OS file manager.
+		const reveal = executeCommand.mock.calls.find(
+			(c) => c[0] === "revealFileInOS",
+		);
+		expect(reveal).toBeDefined();
+		expect((reveal?.[1] as { toString(): string }).toString()).toBe(
+			"file:///kb/.jolli/archive",
+		);
+	});
+
+	it("offers no Reveal Archive action when the host didn't wire archiveDir", async () => {
+		// Backward-compat: a host that wires only the sweep still toasts, just
+		// without the reveal button.
+		const { view, executeCommand } = makeKbSweepProvider(async () => [
+			"/kb/system32",
+		]);
+		view.webview.triggerMessage({ type: "refresh", scope: "kb" });
+		await new Promise((r) => setTimeout(r, 0));
+		expect(showInformationMessage.mock.calls[0][1]).toBeUndefined();
+		expect(
+			executeCommand.mock.calls.some((c) => c[0] === "revealFileInOS"),
+		).toBe(false);
 	});
 
 	it("skips the sweep when the host didn't wire it", async () => {

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -48,8 +48,8 @@ const mockWorkspaceFolders: Array<{ uri: { fsPath: string } }> = [];
 const { clipboardWriteText } = vi.hoisted(() => ({
 	clipboardWriteText: vi.fn().mockResolvedValue(undefined),
 }));
-// Backs the "collapsed N duplicate folders" toast the KB refresh raises after
-// `kbFolders.dedupeFolders()` archives something.
+// Backs the toast the KB refresh raises after `kbFolders.archiveUnusedFolders()`
+// archives folders that hold no memories at all.
 const { showInformationMessage } = vi.hoisted(() => ({
 	showInformationMessage: vi.fn().mockResolvedValue(undefined),
 }));
@@ -1927,12 +1927,19 @@ describe("SidebarWebviewProvider", () => {
 		expect(exec).toHaveBeenCalledWith("jollimemory.refreshMemories");
 	});
 
-	/** Builds a kb-tab provider whose `kbFolders` carries a stubbed dedupe. */
-	function makeKbDedupeProvider(dedupeFolders: () => Promise<string[]>) {
+	/**
+	 * Builds a kb-tab provider whose `kbFolders` carries a stubbed unused-folder
+	 * sweep. Omitting `archiveUnusedFolders` leaves it ABSENT on the injected dep
+	 * (not stubbed to `[]`) — the shape every pre-existing test uses, and the
+	 * reason the dep declares it optional.
+	 */
+	function makeKbSweepProvider(archiveUnusedFolders?: () => Promise<string[]>) {
 		const view = makeMockView();
 		const kbFolders = {
 			listChildren: vi.fn().mockResolvedValue([]),
-			dedupeFolders: vi.fn(dedupeFolders),
+			...(archiveUnusedFolders
+				? { archiveUnusedFolders: vi.fn(archiveUnusedFolders) }
+				: {}),
 		};
 		const provider = new SidebarWebviewProvider({
 			executeCommand: vi.fn().mockResolvedValue(undefined),
@@ -1952,33 +1959,62 @@ describe("SidebarWebviewProvider", () => {
 		return { view, kbFolders };
 	}
 
-	it("toasts once per refresh when dedupeFolders archived duplicate folders", async () => {
-		const { view, kbFolders } = makeKbDedupeProvider(async () => [
-			"/kb/jolliai-2",
-		]);
+	it("sweeps unused folders then re-lists, toasting the singular form for one", async () => {
+		const { view, kbFolders } = makeKbSweepProvider(async () => ["/kb/system32"]);
 		view.webview.triggerMessage({ type: "refresh", scope: "kb" });
 		await new Promise((r) => setTimeout(r, 0));
-		expect(kbFolders.dedupeFolders).toHaveBeenCalledTimes(1);
+		expect(kbFolders.archiveUnusedFolders).toHaveBeenCalledTimes(1);
 		expect(showInformationMessage).toHaveBeenCalledTimes(1);
-		// Singular noun for one folder; the count is what the user acts on.
-		expect(showInformationMessage.mock.calls[0][0]).toContain("1 duplicate folder");
+		expect(showInformationMessage.mock.calls[0][0]).toContain(
+			"archived 1 unused Memory Bank folder with no memories in it",
+		);
 		expect(kbFolders.listChildren).toHaveBeenCalledWith("");
 	});
 
-	it("stays silent when dedupeFolders found nothing to archive", async () => {
-		const { view, kbFolders } = makeKbDedupeProvider(async () => []);
+	it("toasts the plural form when the sweep archived several folders", async () => {
+		const { view } = makeKbSweepProvider(async () => [
+			"/kb/system32",
+			"/kb/unknown",
+		]);
+		view.webview.triggerMessage({ type: "refresh", scope: "kb" });
+		await new Promise((r) => setTimeout(r, 0));
+		expect(showInformationMessage.mock.calls[0][0]).toContain(
+			"archived 2 unused Memory Bank folders with no memories in them",
+		);
+	});
+
+	it("stays silent when the sweep found nothing to archive", async () => {
+		const { view } = makeKbSweepProvider(async () => []);
+		view.webview.triggerMessage({ type: "refresh", scope: "kb" });
+		await new Promise((r) => setTimeout(r, 0));
+		expect(showInformationMessage).not.toHaveBeenCalled();
+	});
+
+	it("still re-lists the tree when the sweep throws", async () => {
+		// The sweep is best-effort: a failed archive (locked directory,
+		// permissions) must not cost the user the refresh they asked for.
+		const { view, kbFolders } = makeKbSweepProvider(async () => {
+			throw new Error("EPERM");
+		});
 		view.webview.triggerMessage({ type: "refresh", scope: "kb" });
 		await new Promise((r) => setTimeout(r, 0));
 		expect(showInformationMessage).not.toHaveBeenCalled();
 		expect(kbFolders.listChildren).toHaveBeenCalledWith("");
 	});
 
-	it("still re-lists the tree when dedupeFolders throws", async () => {
-		// Dedupe is best-effort: a failed archive (locked directory, permissions)
-		// must not cost the user the refresh they actually asked for.
-		const { view, kbFolders } = makeKbDedupeProvider(async () => {
-			throw new Error("EPERM");
-		});
+	it("runs the sweep on a scope='all' refresh too", async () => {
+		// The toolbar's whole-sidebar Refresh shares the kb branch; the user
+		// shouldn't have to pick the Folders-only scope to get the sweep.
+		const { view } = makeKbSweepProvider(async () => ["/kb/tmp.abc"]);
+		view.webview.triggerMessage({ type: "refresh", scope: "all" });
+		await new Promise((r) => setTimeout(r, 0));
+		expect(showInformationMessage).toHaveBeenCalledTimes(1);
+	});
+
+	it("skips the sweep when the host didn't wire it", async () => {
+		// Absent dep must be a silent no-op, not a crash — the sweep is additive
+		// to a refresh that has to keep working without it.
+		const { view, kbFolders } = makeKbSweepProvider();
 		view.webview.triggerMessage({ type: "refresh", scope: "kb" });
 		await new Promise((r) => setTimeout(r, 0));
 		expect(showInformationMessage).not.toHaveBeenCalled();

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -177,6 +177,14 @@ export interface SidebarWebviewDeps {
 		 * (which inject only `listChildren`) keep working.
 		 */
 		notifyDirty?: (kbRoot?: string) => void;
+		/**
+		 * Collapses duplicate KB folders that share one repo identity so the
+		 * Folders tab stops showing the same repo twice (the `jolliai` +
+		 * `jolliai-2` symptom). Optional so existing tests keep compiling.
+		 * Resolves to the list of folder paths that were archived; an empty
+		 * array means no duplicates were found.
+		 */
+		dedupeFolders?: () => Promise<string[]>;
 	};
 	/**
 	 * Source for the breadcrumb repo/branch dropdowns. `listRepos` enumerates
@@ -1166,7 +1174,10 @@ export class SidebarWebviewProvider
 				void this.deps.applyDismissAiExclude?.(msg.kind, msg.key);
 				return;
 			case "refresh":
-				this.handleRefresh(msg.scope);
+				// Now async (the KB scope awaits `dedupeFolders` before
+				// re-listing). It swallows its own failures, so the caller
+				// stays fire-and-forget like every other message handler.
+				void this.handleRefresh(msg.scope);
 				return;
 			case "selection:request":
 				this.handleSelectionRequest(msg.repoName, msg.branchName, msg.silent);
@@ -1816,7 +1827,7 @@ export class SidebarWebviewProvider
 	 * have no command equivalent (no upstream cache; we read fs each time), so
 	 * we call `handleExpandFolder("")` directly to push a fresh root listing.
 	 */
-	private handleRefresh(
+	private async handleRefresh(
 		scope:
 			| "kb"
 			| "branch"
@@ -1824,8 +1835,35 @@ export class SidebarWebviewProvider
 			| "branch-commits"
 			| "status"
 			| "all",
-	): void {
+	): Promise<void> {
 		if (scope === "kb" || scope === "all") {
+			// Dedupe first so a Refresh both re-lists AND collapses the
+			// `jolliai` + `jolliai-2` duplicate folders that share one repo
+			// identity. Dedupe is best-effort and recoverable (folders are
+			// moved into the hidden archive dir, not deleted), so a failure
+			// here must not block the following re-list — we report it and
+			// continue. The follow-up handleExpandFolder("") re-reads the
+			// trimmed directory so the dupes vanish from the tree on the
+			// same refresh.
+			if (this.deps.kbFolders?.dedupeFolders) {
+				try {
+					const archived = await this.deps.kbFolders.dedupeFolders();
+					if (archived.length > 0) {
+						const noun = archived.length === 1 ? "folder" : "folders";
+						const msg =
+							`Jolli Memory: collapsed ${archived.length} duplicate ` +
+							`${noun} sharing a repo identity. Moved to the archive folder (recoverable).`;
+						void vscode.window.showInformationMessage(msg);
+					}
+				} catch (err) {
+					log.warn(
+						"SidebarWebviewProvider",
+						`dedupeFolders failed: ${
+							err instanceof Error ? err.message : String(err)
+						}`,
+					);
+				}
+			}
 			void this.handleExpandFolder("");
 			void this.deps.executeCommand("jollimemory.refreshMemories");
 		}

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -178,13 +178,17 @@ export interface SidebarWebviewDeps {
 		 */
 		notifyDirty?: (kbRoot?: string) => void;
 		/**
-		 * Collapses duplicate KB folders that share one repo identity so the
-		 * Folders tab stops showing the same repo twice (the `jolliai` +
-		 * `jolliai-2` symptom). Optional so existing tests keep compiling.
-		 * Resolves to the list of folder paths that were archived; an empty
-		 * array means no duplicates were found.
+		 * Archives Memory Bank folders that hold nothing at all — the folders a
+		 * past bug claimed from a cwd that was never a useful repo (`system32`,
+		 * `tmp.XXXXXX`, an agent temp dir) plus checkouts opened once and never
+		 * committed to. Optional so existing tests keep compiling. Resolves to
+		 * the list of folder paths that were archived.
+		 *
+		 * Duplicate folders are NOT in scope — see the service method's contract:
+		 * a Refresh never moves a folder holding memories, so consolidating
+		 * duplicates is Migrate's job.
 		 */
-		dedupeFolders?: () => Promise<string[]>;
+		archiveUnusedFolders?: () => Promise<string[]>;
 	};
 	/**
 	 * Source for the breadcrumb repo/branch dropdowns. `listRepos` enumerates
@@ -1837,34 +1841,13 @@ export class SidebarWebviewProvider
 			| "all",
 	): Promise<void> {
 		if (scope === "kb" || scope === "all") {
-			// Dedupe first so a Refresh both re-lists AND collapses the
-			// `jolliai` + `jolliai-2` duplicate folders that share one repo
-			// identity. Dedupe is best-effort and recoverable (folders are
-			// moved into the hidden archive dir, not deleted), so a failure
-			// here must not block the following re-list — we report it and
-			// continue. The follow-up handleExpandFolder("") re-reads the
-			// trimmed directory so the dupes vanish from the tree on the
-			// same refresh.
-			if (this.deps.kbFolders?.dedupeFolders) {
-				try {
-					const archived = await this.deps.kbFolders.dedupeFolders();
-					if (archived.length > 0) {
-						const noun = archived.length === 1 ? "folder" : "folders";
-						const msg =
-							`Jolli Memory: collapsed ${archived.length} duplicate ` +
-							`${noun} sharing a repo identity. Moved to the archive folder (recoverable).`;
-						void vscode.window.showInformationMessage(msg);
-					}
-				} catch (err) {
-					log.warn(
-						"SidebarWebviewProvider",
-						`dedupeFolders failed: ${
-							err instanceof Error ? err.message : String(err)
-						}`,
-					);
-				}
-			}
-			void this.handleExpandFolder("");
+			// `void`, not `await`: the sweep is async and everything below this
+			// block must still run in the SAME tick as the user's click. Awaiting
+			// here pushed the branch/status refreshes past a microtask, which is a
+			// behaviour change for every other scope (the Codex discovery kick a
+			// scope="all" refresh owes `pushConversations` stopped being observable
+			// synchronously). The kb work keeps its own ordering inside the chain.
+			void this.tidyAndRelistKbFolders();
 			void this.deps.executeCommand("jollimemory.refreshMemories");
 		}
 		// Current Memory block: conversations + context (plans/notes) + files.
@@ -1897,6 +1880,56 @@ export class SidebarWebviewProvider
 		if (scope === "status" || scope === "all") {
 			void this.deps.executeCommand("jollimemory.refreshStatus");
 		}
+	}
+
+	/**
+	 * The Folders-tab half of a Refresh: sweep the Memory Bank, then re-list it.
+	 *
+	 * Sweep first so one Refresh both re-lists AND clears the rows the user can't
+	 * act on: folders a past bug claimed for something that never became a useful
+	 * repo and that never held anything (empty `system32` / `tmp.XXXXXX` /
+	 * agent-temp-dir claims, plus checkouts opened once and never committed to).
+	 * The trailing `handleExpandFolder("")` re-reads the trimmed directory, which
+	 * is what makes them vanish on the same click.
+	 *
+	 * Deliberately NOT a duplicate-collapsing pass. Refresh's contract is that it
+	 * never moves a folder holding memories — see
+	 * `KbFoldersService.archiveUnusedFolders` for why collapsing duplicates
+	 * requires rebuilding the survivor from the orphan branch and therefore
+	 * belongs to Migrate.
+	 *
+	 * Errors are logged and swallowed: the sweep is best-effort and recoverable
+	 * (folders are MOVED into the hidden archive dir, never deleted), so a locked
+	 * directory or a permission denial must not cost the user the re-list they
+	 * actually asked for. Nothing archived → no toast; a Refresh that found
+	 * nothing must not nag.
+	 */
+	private async tidyAndRelistKbFolders(): Promise<void> {
+		// Called as a method on the live `KbFoldersService` instance — it reads
+		// `this.getContext()` and clears `this.cleanRepos`, so the receiver has to
+		// survive the call.
+		const kb = this.deps.kbFolders;
+		if (kb?.archiveUnusedFolders) {
+			try {
+				const archived = await kb.archiveUnusedFolders();
+				if (archived.length > 0) {
+					const noun = archived.length === 1 ? "folder" : "folders";
+					void vscode.window.showInformationMessage(
+						`Jolli Memory: archived ${archived.length} unused Memory Bank ${noun} ` +
+							`with no memories in ${archived.length === 1 ? "it" : "them"}. ` +
+							`Moved to the archive folder (recoverable).`,
+					);
+				}
+			} catch (err) {
+				log.warn(
+					"SidebarWebviewProvider",
+					`archiveUnusedFolders failed: ${
+						err instanceof Error ? err.message : String(err)
+					}`,
+				);
+			}
+		}
+		await this.handleExpandFolder("");
 	}
 
 	/**

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -189,6 +189,13 @@ export interface SidebarWebviewDeps {
 		 * duplicates is Migrate's job.
 		 */
 		archiveUnusedFolders?: () => Promise<string[]>;
+		/**
+		 * Absolute path of the hidden `<kbParent>/.jolli/archive/` dir that
+		 * `archiveUnusedFolders` moves swept folders into. Used to offer a
+		 * "Reveal Archive" action on the post-sweep toast. Optional so existing
+		 * tests (which inject only `listChildren`) keep working.
+		 */
+		archiveDir?: () => string;
 	};
 	/**
 	 * Source for the breadcrumb repo/branch dropdowns. `listRepos` enumerates
@@ -1178,10 +1185,11 @@ export class SidebarWebviewProvider
 				void this.deps.applyDismissAiExclude?.(msg.kind, msg.key);
 				return;
 			case "refresh":
-				// Now async (the KB scope awaits `dedupeFolders` before
-				// re-listing). It swallows its own failures, so the caller
-				// stays fire-and-forget like every other message handler.
-				void this.handleRefresh(msg.scope);
+				// Fire-and-forget like every other message handler. The KB
+				// scope's folder sweep is async but `handleRefresh` void-calls
+				// it rather than awaiting (so the other scopes stay same-tick),
+				// so nothing here needs to wait on it.
+				this.handleRefresh(msg.scope);
 				return;
 			case "selection:request":
 				this.handleSelectionRequest(msg.repoName, msg.branchName, msg.silent);
@@ -1829,9 +1837,14 @@ export class SidebarWebviewProvider
 	 * data via the same `jollimemory.refresh*` commands that the section-level
 	 * refresh buttons use — keeps the refresh contract in one place. KB folders
 	 * have no command equivalent (no upstream cache; we read fs each time), so
-	 * we call `handleExpandFolder("")` directly to push a fresh root listing.
+	 * the KB scope runs `tidyAndRelistKbFolders()` (sweep unused folders, then
+	 * re-list the root) directly.
+	 *
+	 * Returns `void`, not a promise: every call in the body is `void`-ed on
+	 * purpose (see the kb-scope note below), so the method never awaits and its
+	 * completion carries no meaning worth handing back to the caller.
 	 */
-	private async handleRefresh(
+	private handleRefresh(
 		scope:
 			| "kb"
 			| "branch"
@@ -1839,7 +1852,7 @@ export class SidebarWebviewProvider
 			| "branch-commits"
 			| "status"
 			| "all",
-	): Promise<void> {
+	): void {
 		if (scope === "kb" || scope === "all") {
 			// `void`, not `await`: the sweep is async and everything below this
 			// block must still run in the SAME tick as the user's click. Awaiting
@@ -1914,11 +1927,28 @@ export class SidebarWebviewProvider
 				const archived = await kb.archiveUnusedFolders();
 				if (archived.length > 0) {
 					const noun = archived.length === 1 ? "folder" : "folders";
-					void vscode.window.showInformationMessage(
-						`Jolli Memory: archived ${archived.length} unused Memory Bank ${noun} ` +
-							`with no memories in ${archived.length === 1 ? "it" : "them"}. ` +
-							`Moved to the archive folder (recoverable).`,
-					);
+					// Offer a way to the archive so "(recoverable)" is an action,
+					// not just a claim about a hidden dir the user would never
+					// find on their own. Only when the service can tell us where
+					// the archive is; the dir exists here — the sweep just moved
+					// a folder into it.
+					const archiveDir = kb.archiveDir?.();
+					const REVEAL = "Reveal Archive";
+					void vscode.window
+						.showInformationMessage(
+							`Jolli Memory: archived ${archived.length} unused Memory Bank ${noun} ` +
+								`with no memories in ${archived.length === 1 ? "it" : "them"}. ` +
+								`Moved to the archive folder (recoverable).`,
+							...(archiveDir ? [REVEAL] : []),
+						)
+						.then((choice) => {
+							if (choice === REVEAL && archiveDir) {
+								void this.deps.executeCommand(
+									"revealFileInOS",
+									vscode.Uri.file(archiveDir),
+								);
+							}
+						});
 				}
 			} catch (err) {
 				log.warn(

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -8,7 +8,13 @@
  */
 
 import { randomBytes } from "node:crypto";
+import { basename } from "node:path";
 import * as vscode from "vscode";
+import type {
+	ConsolidationKind,
+	ConsolidationPlan,
+	ConsolidationResult,
+} from "../../../cli/src/core/FolderConsolidation.js";
 import type { DetectedAgent } from "../../../cli/src/core/localagent/DetectAgents.js";
 import type { PinEntry, PinKind } from "../../../cli/src/core/PinStore.js";
 import { resolveSessionTitle } from "../../../cli/src/core/SessionTitleResolver.js";
@@ -130,6 +136,32 @@ function isAllowedWebviewCommandArgs(command: string, args: ReadonlyArray<unknow
 	}
 }
 
+/**
+ * Builds the case-specific confirmation shown before a duplicate-folder merge.
+ * Each `ConsolidationKind` states exactly what will happen and the counts, so
+ * the user is agreeing to a concrete action, not a vague "merge".
+ */
+export function describeConsolidationPlan(plan: ConsolidationPlan): string {
+	const n = plan.folders.length;
+	const survivor = basename(plan.survivor);
+	const messages: Record<ConsolidationKind, string> = {
+		identical:
+			`Jolli found ${n} Memory Bank folders for "${plan.repoName}" with identical contents ` +
+			`(${plan.counts.survivor} memories). Keep "${survivor}" and archive the ${n - 1} duplicate ` +
+			`${n - 1 === 1 ? "folder" : "folders"}?`,
+		"orphan-superset":
+			`Jolli found ${n} Memory Bank folders for "${plan.repoName}". The orphan branch already ` +
+			`contains all ${plan.counts.orphan} memories, so a single clean "${survivor}" folder will be ` +
+			`rebuilt from it and the ${n} duplicates archived. Proceed?`,
+		"union-largest":
+			`Jolli found ${n} Memory Bank folders for "${plan.repoName}" with different contents. ` +
+			`"${survivor}" (${plan.counts.survivor} memories) will absorb ${plan.counts.added} more from the ` +
+			`others (total ${plan.counts.union}), then the ${n - 1} duplicate ` +
+			`${n - 1 === 1 ? "folder" : "folders"} will be archived. Proceed?`,
+	};
+	return messages[plan.kind];
+}
+
 export interface SidebarWebviewDeps {
 	executeCommand: (
 		command: string,
@@ -196,6 +228,15 @@ export interface SidebarWebviewDeps {
 		 * tests (which inject only `listChildren`) keep working.
 		 */
 		archiveDir?: () => string;
+		/**
+		 * Detects duplicate Memory Bank folders for the current repo and returns a
+		 * merge plan, or `null` when there is nothing to consolidate. Split from
+		 * `runConsolidation` so Refresh can show a case-specific confirmation
+		 * before moving any folder. Optional so trimmed-down test hosts compile.
+		 */
+		planDuplicateConsolidation?: () => Promise<ConsolidationPlan | null>;
+		/** Executes a plan from `planDuplicateConsolidation` (merge/rebuild + archive). */
+		runConsolidation?: (plan: ConsolidationPlan) => Promise<ConsolidationResult>;
 	};
 	/**
 	 * Source for the breadcrumb repo/branch dropdowns. `listRepos` enumerates
@@ -1905,11 +1946,15 @@ export class SidebarWebviewProvider
 	 * The trailing `handleExpandFolder("")` re-reads the trimmed directory, which
 	 * is what makes them vanish on the same click.
 	 *
-	 * Deliberately NOT a duplicate-collapsing pass. Refresh's contract is that it
-	 * never moves a folder holding memories — see
-	 * `KbFoldersService.archiveUnusedFolders` for why collapsing duplicates
-	 * requires rebuilding the survivor from the orphan branch and therefore
-	 * belongs to Migrate.
+	 * After the empty-folder sweep, Refresh ALSO offers to consolidate DUPLICATE
+	 * folders for the current repo (`<repo>` + `<repo>-2`, typically split by an
+	 * ssh host alias). Unlike the empty sweep this can move folders holding
+	 * memories, so it is gated behind a modal confirmation whose text depends on
+	 * how the merge will be done (identical → keep shortest; orphan-superset →
+	 * rebuild one folder from the orphan branch; union-largest → fold into the
+	 * largest, preserving summaries the orphan branch lacks). This supersedes the
+	 * older "duplicates belong to Migrate, not Refresh" stance: the merge is real
+	 * (not a lossy archive-the-loser move) and the user confirms it explicitly.
 	 *
 	 * Errors are logged and swallowed: the sweep is best-effort and recoverable
 	 * (folders are MOVED into the hidden archive dir, never deleted), so a locked
@@ -1959,7 +2004,59 @@ export class SidebarWebviewProvider
 				);
 			}
 		}
+		await this.consolidateDuplicateKbFolders();
 		await this.handleExpandFolder("");
+	}
+
+	/**
+	 * The duplicate-folder half of a Refresh: detect two-or-more folders for the
+	 * current repo, ask the user (with a case-specific prompt) whether to merge
+	 * them, and execute on confirm. No-op when nothing is duplicated or the host
+	 * did not wire the consolidation callbacks. Best-effort: any failure is
+	 * logged and swallowed so the re-list the user asked for still happens.
+	 */
+	private async consolidateDuplicateKbFolders(): Promise<void> {
+		const kb = this.deps.kbFolders;
+		if (!kb?.planDuplicateConsolidation || !kb.runConsolidation) return;
+		try {
+			const plan = await kb.planDuplicateConsolidation();
+			if (!plan) return;
+
+			const MERGE = "Merge";
+			const choice = await vscode.window.showWarningMessage(
+				describeConsolidationPlan(plan),
+				{ modal: true },
+				MERGE,
+			);
+			if (choice !== MERGE) return;
+
+			const result = await kb.runConsolidation(plan);
+
+			// The merged/rebuilt survivor's contents changed even when its path did
+			// not, so drop the "clean repo" memo before the re-list picks it up.
+			kb.notifyDirty?.();
+
+			const archiveDir = kb.archiveDir?.();
+			const REVEAL = "Reveal Archive";
+			const noun = result.archived.length === 1 ? "folder" : "folders";
+			void vscode.window
+				.showInformationMessage(
+					`Jolli Memory: merged duplicate Memory Bank folders into ` +
+						`"${basename(result.survivor)}" (${result.summariesAfter} memories). ` +
+						`Archived ${result.archived.length} duplicate ${noun} (recoverable).`,
+					...(archiveDir ? [REVEAL] : []),
+				)
+				.then((c) => {
+					if (c === REVEAL && archiveDir) {
+						void this.deps.executeCommand("revealFileInOS", vscode.Uri.file(archiveDir));
+					}
+				});
+		} catch (err) {
+			log.warn(
+				"SidebarWebviewProvider",
+				`consolidateDuplicateKbFolders failed: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
 	}
 
 	/**

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -16,6 +16,7 @@ import type {
 	ConsolidationResult,
 } from "../../../cli/src/core/FolderConsolidation.js";
 import type { DetectedAgent } from "../../../cli/src/core/localagent/DetectAgents.js";
+import { VaultWriteBusyError } from "../../../cli/src/sync/VaultWriteLock.js";
 import type { PinEntry, PinKind } from "../../../cli/src/core/PinStore.js";
 import { resolveSessionTitle } from "../../../cli/src/core/SessionTitleResolver.js";
 import { getTranscriptIds } from "../../../cli/src/core/SummaryTree.js";
@@ -2006,6 +2007,28 @@ export class SidebarWebviewProvider
 		}
 		await this.consolidateDuplicateKbFolders();
 		await this.handleExpandFolder("");
+		// The sweep / consolidation may have archived repos, so refresh the
+		// breadcrumb's repo + branch dropdowns too — otherwise they keep offering
+		// an archived repo, and picking it hits `if (!target) return` and silently
+		// does nothing until a window reload. Same re-push refreshKnowledgeBaseFolders
+		// uses for external writes.
+		this.pushBreadcrumbSelection();
+	}
+
+	/**
+	 * Re-pushes the breadcrumb's `selection:repos` and the active repo's
+	 * `selection:branches`. These messages are otherwise only sent at init /
+	 * repo-switch time, so any path that changes the set of repos or branches on
+	 * disk (external write, sync, a folder sweep / consolidation) must call this
+	 * or the dropdowns go stale until a window reload. `listRepos` / `listBranches`
+	 * read fresh from disk on every call.
+	 */
+	private pushBreadcrumbSelection(): void {
+		if (!this.deps.selection) return;
+		this.pushRepos();
+		const repos = this.deps.selection.listRepos();
+		const current = repos.find((r) => r.isCurrent) ?? repos[0];
+		if (current) this.pushBranches(current.repoName);
 	}
 
 	/**
@@ -2052,6 +2075,15 @@ export class SidebarWebviewProvider
 					}
 				});
 		} catch (err) {
+			// The vault was busy (a summary was being written / synced) for the whole
+			// lock budget. The user asked for this merge, so say so and let them retry
+			// — a silent swallow would look like Refresh did nothing.
+			if (err instanceof VaultWriteBusyError) {
+				void vscode.window.showInformationMessage(
+					"Jolli Memory is busy writing a summary right now — click Refresh again shortly to merge the duplicate folders.",
+				);
+				return;
+			}
 			log.warn(
 				"SidebarWebviewProvider",
 				`consolidateDuplicateKbFolders failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -2080,21 +2112,12 @@ export class SidebarWebviewProvider
 		this.deps.kbFolders?.notifyDirty?.();
 		this.postMessage({ type: "kb:foldersReset" });
 		void this.handleExpandFolder("");
-		// Also re-push the breadcrumb's repo list AND the active repo's
-		// branches: those use the `selection:*` messages which are
-		// otherwise only sent at init / repo-switch time. Pre-fix, a sync
-		// round (or any external write that added a new branch directory)
-		// would leave the breadcrumb's branch dropdown frozen on the
-		// pre-sync set until the user manually switched repos. `listRepos`
-		// and `listBranches` both read fresh from disk on every call, so
-		// this re-push immediately reflects whatever the latest
-		// `branches.json` says.
-		if (this.deps.selection) {
-			this.pushRepos();
-			const repos = this.deps.selection.listRepos();
-			const current = repos.find((r) => r.isCurrent) ?? repos[0];
-			if (current) this.pushBranches(current.repoName);
-		}
+		// Re-push the breadcrumb dropdowns: the `selection:*` messages are
+		// otherwise only sent at init / repo-switch time, so a sync round (or any
+		// external write that added a branch directory) would leave the branch
+		// dropdown frozen on the pre-sync set until the user manually switched
+		// repos.
+		this.pushBreadcrumbSelection();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Refresh now runs a single sweep — `KbFoldersService.archiveUnusedFolders()` — that archives Memory Bank folders holding **nothing**: no `index.json` summaries, no `manifest.json` rows, no visible files or branch dirs, and nothing under `.jolli/` beyond the inert stubs `MetadataManager.ensure()` seeds. One click both re-lists the Folders tab and clears the rows the user can't act on. A toast reports how many were archived and offers a **Reveal Archive** action.

## Why

`resolveKBPath` **claims** the folder it returns (writes `.jolli/config.json`) using whatever cwd the calling process had. Every jollimemory process that ran outside a real project therefore materialized a folder named after that cwd — `system32`, `unknown`, `tmp.XXXXXX`, an agent's temp dir, a doc title a local-agent run used as its working directory — plus checkouts opened once and never committed to. `checkClaimable` now gates new ones, but it can't retract the pile already on disk, and users have had to clear it by hand. Measured on a real Memory Bank: **25 of 57 rows**, every one with zero memories.

## Emptiness is the whole criterion (deliberately not a dedupe pass)

An earlier revision (`808c5c22`) wired a duplicate-collapsing pass into Refresh; `b60ac2c9` **withdrew it entirely**. Archiving is a plain `renameSync`, and a move cannot merge — collapsing two populated folders means burying one. The only correct survivor is one rebuilt from the orphan branch (the system of record), which is **Migrate's** capability, not Refresh's. So Refresh stays a lossless action with one stated invariant: it never moves a folder holding memories.

Keying on emptiness alone is what makes that safe:

- **It cannot lose memories.** An empty folder has nothing to move, and `resolveKBPath` re-claims the path on the next write.
- **It needs no name heuristics.** Guessing junk from a name would eventually archive a legitimately-named repo; a populated `system32` folder means the user really does keep memories for a project by that name.
- **"Keep unless proven empty" at every exit** — unreadable dir, unparseable manifest, unrecognized `.jolli/` entry (including the `shadow-status.json` dirty marker) all resolve to *keep*.

Never touched: the current project's folder, or any folder carrying its `repoName` (a fresh install's own folder is legitimately empty until the first commit). Folders without `.jolli/config.json` are invisible to `discoverRepos` and out of scope by construction. Extras are **moved** to the hidden, recoverable `<kbParent>/.jolli/archive/` (same path as Migrate), never hard-deleted.

## Follow-up (review fixes, `c5cdcf60`)

Addresses the review on `b60ac2c9`: corrected the stale `dedupeFolders` comments and the misleading `async` signature on `handleRefresh`; extended the OS-noise skip into the `.jolli/` loop and made it case-insensitive (lowercase Windows `thumbs.db`); fixed the `shadow-status.json` docstring (it records a *failed* shadow write, written from `DualWriteStorage`'s `catch`, not one in flight); and added the **Reveal Archive** toast action.

## Scope note

This sweep is VS Code-only. The IntelliJ Memory Bank sidebar gets no equivalent yet, so the junk rows persist there — a deliberate follow-up, not part of this PR.

## Verification

- `node scripts/run-vitest.mjs` on the two changed test files → **2 files / 340 tests passed**.
- Full `npm run test:vscode` (with coverage) → **112 files / 4620 passed / 16 skipped**, coverage above the 97/97/97/97 floor.
- `npm run lint:vscode` (biome `--error-on-warnings`) → clean, 229 files.
- `npm run typecheck:vscode` → exit 0.
