### PR TITLE
Add skills-* bridge operations for IntelliJ skill surface

### DIFF
--- a/cli/src/commands/IdeBridgeCommand.test.ts
+++ b/cli/src/commands/IdeBridgeCommand.test.ts
@@ -2711,7 +2711,12 @@ describe("runIdeBridgeAction — shared-store", () => {
 		expect(addPin).toHaveBeenCalledWith("/repo-fallback", "repo-fallback", "main", expect.anything());
 	});
 
-	it("reads selection exclusions as arrays", async () => {
+	// `skills` is absent from the mocked value on purpose: it postdates the persisted
+	// shape, so `readExclusions` omits it for a selection file written before skills
+	// were selectable. The response must still carry the key as an empty array — a
+	// caller that saw it vanish could not tell "nothing excluded" from "this CLI is
+	// too old to know about skills".
+	it("reads selection exclusions as arrays, defaulting an absent skills set to empty", async () => {
 		const { readExclusions } = await import("../core/CommitSelectionStore.js");
 		vi.mocked(readExclusions).mockResolvedValue({
 			conversations: new Set(["c"]),
@@ -2720,7 +2725,20 @@ describe("runIdeBridgeAction — shared-store", () => {
 			references: new Set(),
 		} as never);
 		const result = await runIdeBridgeAction("shared-store", "/r", { operation: "selection-read" });
-		expect(result).toEqual({ conversations: ["c"], plans: [], notes: [], references: [] });
+		expect(result).toEqual({ conversations: ["c"], plans: [], notes: [], references: [], skills: [] });
+	});
+
+	it("reads an excluded skill key back out of the selection set", async () => {
+		const { readExclusions } = await import("../core/CommitSelectionStore.js");
+		vi.mocked(readExclusions).mockResolvedValue({
+			conversations: new Set(),
+			plans: new Set(),
+			notes: new Set(),
+			references: new Set(),
+			skills: new Set(["claude:brainstorming"]),
+		} as never);
+		const result = await runIdeBridgeAction("shared-store", "/r", { operation: "selection-read" });
+		expect(result).toMatchObject({ skills: ["claude:brainstorming"] });
 	});
 
 	it("computes a selection key", async () => {
@@ -2765,6 +2783,133 @@ describe("runIdeBridgeAction — shared-store", () => {
 			excluded: true,
 		});
 		expect(setAllExcluded).toHaveBeenCalledWith("/r", "plans", ["a", "b"], true);
+	});
+
+	// ---------- skills-* ----------
+	//
+	// These four operations are IntelliJ's ONLY skill surface — it renders no skill
+	// table of its own by design — so a break here is invisible to the VS Code
+	// suite. `SkillsAggregateMarkdown` is deliberately left unmocked: the point of
+	// routing IntelliJ through the bridge is that it gets the same renderer the
+	// Memory Bank file uses, and a mocked renderer would not prove that.
+
+	const skillRow = (over: Record<string, unknown> = {}) => ({
+		source: "claude",
+		skill: "brainstorming",
+		entryPaths: ["tool"],
+		invocations: [],
+		invocationCount: 2,
+		firstUsedAt: "2026-07-30T06:00:00.000Z",
+		lastUsedAt: "2026-07-30T07:00:00.000Z",
+		usage: { input: 100, cached: 900, output: 0, confidence: "attributed" },
+		sourcePath: "/tmp/x.md",
+		commitHash: null,
+		...over,
+	});
+
+	it("projects the active skills and the summary label that goes with them", async () => {
+		const { loadPlansRegistry } = await import("../core/SessionTracker.js");
+		vi.mocked(loadPlansRegistry).mockResolvedValue({
+			skills: { "claude:brainstorming": skillRow() },
+		} as never);
+
+		const result = (await runIdeBridgeAction("shared-store", "/r", { operation: "skills-active" })) as {
+			skills: Array<{ mapKey: string; invocationCount: number }>;
+			summaryLabel: string;
+		};
+		expect(result.skills).toHaveLength(1);
+		expect(result.skills[0]).toMatchObject({ mapKey: "claude:brainstorming", invocationCount: 2 });
+		// The label rides along so the caller needs one round trip, not two.
+		expect(result.summaryLabel).toBe("1 skill · 1.0k tokens");
+	});
+
+	it("renders the live aggregate table for uncommitted skills", async () => {
+		const { loadPlansRegistry } = await import("../core/SessionTracker.js");
+		vi.mocked(loadPlansRegistry).mockResolvedValue({
+			skills: { "claude:brainstorming": skillRow() },
+		} as never);
+
+		const { markdown } = (await runIdeBridgeAction("shared-store", "/r", {
+			operation: "skills-live-markdown",
+		})) as { markdown: string };
+		expect(markdown).toContain("# Skills used — uncommitted");
+		expect(markdown).toContain("| brainstorming | 2 | 1.0k |");
+	});
+
+	// null rather than an empty table: committing archives every skill, so an empty
+	// registry is the normal post-commit state and the caller says so in words.
+	it("returns a null live markdown when nothing is captured", async () => {
+		const { loadPlansRegistry } = await import("../core/SessionTracker.js");
+		vi.mocked(loadPlansRegistry).mockResolvedValue({ skills: {} } as never);
+
+		expect(await runIdeBridgeAction("shared-store", "/r", { operation: "skills-live-markdown" })).toEqual({
+			markdown: null,
+		});
+	});
+
+	// Takes the rows off the request rather than reading the registry: the caller is
+	// summarising an ARCHIVED set off a CommitSummary, which the registry no longer holds.
+	it("labels an archived skill set passed in by the caller", async () => {
+		const result = await runIdeBridgeAction("shared-store", "/r", {
+			operation: "skills-label",
+			skills: [
+				{ skill: "a", invocationCount: 1, usage: { input: 1, cached: 2, output: 3, confidence: "estimated" } },
+				{ skill: "b", invocationCount: 2 },
+			],
+		});
+		expect(result).toEqual({ label: "2 skills · ~6 tokens" });
+	});
+
+	it("rejects a skills field that is not an array of objects", async () => {
+		await expect(
+			runIdeBridgeAction("shared-store", "/r", { operation: "skills-label", skills: ["a"] }),
+		).rejects.toThrow('Request field "skills" must be an array of objects.');
+		await expect(
+			runIdeBridgeAction("shared-store", "/r", { operation: "skills-label", skills: "nope" }),
+		).rejects.toThrow('Request field "skills" must be an array of objects.');
+		await expect(
+			runIdeBridgeAction("shared-store", "/r", { operation: "skills-label", skills: [null] }),
+		).rejects.toThrow('Request field "skills" must be an array of objects.');
+	});
+
+	it("renders a committed memory's skills table from the summary it is given", async () => {
+		const { markdown } = (await runIdeBridgeAction("shared-store", "/r", {
+			operation: "skills-committed-markdown",
+			summary: {
+				commitHash: "abcdef1234567890",
+				branch: "main",
+				generatedAt: "2026-07-30T08:00:00.000Z",
+				commitMessage: "do the thing",
+				skills: [{ skill: "a", invocationCount: 1 }],
+			},
+		})) as { markdown: string };
+		expect(markdown).toContain("# Skills used — abcdef12");
+		expect(markdown).toContain("commitHash: abcdef1234567890");
+		// Unattributed rows dash all four cells rather than showing a zero.
+		expect(markdown).toContain("| a | 1 | — | — | — | — |");
+	});
+
+	it("returns a null committed markdown when the summary archived no skills", async () => {
+		expect(
+			await runIdeBridgeAction("shared-store", "/r", {
+				operation: "skills-committed-markdown",
+				summary: { commitHash: "abcdef12", skills: [] },
+			}),
+		).toEqual({ markdown: null });
+		expect(await runIdeBridgeAction("shared-store", "/r", { operation: "skills-committed-markdown" })).toEqual({
+			markdown: null,
+		});
+	});
+
+	// The `skills-` prefix must not swallow an unknown operation into a silent
+	// success, and must not pay for a registry read before rejecting it.
+	it("rejects an unrecognised skills operation without reading the registry", async () => {
+		const { loadPlansRegistry } = await import("../core/SessionTracker.js");
+		vi.mocked(loadPlansRegistry).mockClear();
+		await expect(runIdeBridgeAction("shared-store", "/r", { operation: "skills-bogus" })).rejects.toThrow(
+			'Unknown shared-store operation "skills-bogus".',
+		);
+		expect(loadPlansRegistry).not.toHaveBeenCalled();
 	});
 
 	it("puts a branch share", async () => {

--- a/cli/src/commands/IdeBridgeCommand.ts
+++ b/cli/src/commands/IdeBridgeCommand.ts
@@ -10,6 +10,7 @@
 import { existsSync } from "node:fs";
 import { isAbsolute } from "node:path";
 import type { LiveSharePatch, LiveSharePayload } from "../core/JolliShareClient.js";
+import type { SkillTableRow } from "../core/SkillsAggregateMarkdown.js";
 import { runWithTrace } from "../core/TraceContext.js";
 import { computeWatchTargets } from "../daemon/DaemonServer.js";
 import { DaemonWatcher } from "../daemon/DaemonWatcher.js";
@@ -96,6 +97,23 @@ function booleanField(request: JsonObject, key: string): boolean {
 	const value = request[key];
 	if (typeof value !== "boolean") throw new Error(`Request field "${key}" must be a boolean.`);
 	return value;
+}
+
+/**
+ * The `skills` field as aggregate-table rows.
+ *
+ * Validated only as far as {@link buildSkillsSummaryLabel} actually reads it — the
+ * caller may send either side of the commit boundary (live `ActiveSkill` rows or
+ * archived `SkillCommitRef`s), and both are deliberately wider than the row type.
+ * Rejecting anything beyond "array of objects" would couple this to whichever of
+ * the two shapes was passed.
+ */
+function skillTableRows(request: JsonObject): SkillTableRow[] {
+	const value = request.skills;
+	if (!Array.isArray(value) || value.some((item) => typeof item !== "object" || item === null)) {
+		throw new Error('Request field "skills" must be an array of objects.');
+	}
+	return value as SkillTableRow[];
 }
 
 function numberField(request: JsonObject, key: string): number {
@@ -735,6 +753,10 @@ async function runSharedStoreAction(cwd: string, request: JsonObject): Promise<u
 				plans: [...value.plans],
 				notes: [...value.notes],
 				references: [...value.references],
+				// Optional on the persisted shape (it postdates the file), so an absent
+				// set reads as "nothing excluded" rather than being omitted from the
+				// response — a caller that saw the key vanish could not tell the two apart.
+				skills: [...(value.skills ?? [])],
 			};
 		}
 		if (operation === "selection-key") {
@@ -780,6 +802,42 @@ async function runSharedStoreAction(cwd: string, request: JsonObject): Promise<u
 			const key = (await loadConfig()).jolliApiKey;
 			const backendKey = deriveJolliBackendKey(key ? parseJolliApiKey(key)?.u : undefined);
 			return { record: (await shares.getShare(cwd, branch, backendKey, commitHash)) ?? null };
+		}
+	}
+	if (operation.startsWith("skills-")) {
+		// Every skill surface an IDE renders is served from here, so the aggregate table
+		// and the row that summarises it cannot disagree. IntelliJ has no Kotlin skill
+		// renderer by design — see the module header of SkillProjection.
+		const aggregate = await import("../core/SkillsAggregateMarkdown.js");
+		if (operation === "skills-label") {
+			// Takes the rows rather than reading them: the caller may be summarising an
+			// ARCHIVED set off a CommitSummary, which the working registry no longer holds.
+			return { label: aggregate.buildSkillsSummaryLabel(skillTableRows(request)) };
+		}
+		if (operation === "skills-committed-markdown") {
+			// Rendered from the summary rather than read from `skills--<hash8>.md`: that
+			// file only exists in the Memory Bank's visible layer, which is absent in
+			// orphan-branch-only mode and for a foreign repo this machine never synced.
+			const { buildSkillsAggregateMarkdown } = aggregate;
+			const summary = request.summary as Parameters<typeof buildSkillsAggregateMarkdown>[0];
+			const skills = summary?.skills ?? [];
+			if (skills.length === 0) return { markdown: null };
+			return { markdown: buildSkillsAggregateMarkdown(summary, skills) };
+		}
+		// Gated on the two operations that read the working registry rather than run
+		// for the whole `skills-` family: an unrecognised operation must fall through
+		// to the unknown-operation error without paying for a registry read first.
+		if (operation === "skills-active" || operation === "skills-live-markdown") {
+			const { projectActiveSkills } = await import("../core/skills/SkillProjection.js");
+			const active = await projectActiveSkills(cwd);
+			if (operation === "skills-active") {
+				// The label rides along because every caller of this needs both and it is
+				// derived from the rows already in hand — a second round trip would buy nothing.
+				return { skills: active, summaryLabel: aggregate.buildSkillsSummaryLabel(active) };
+			}
+			// null, not an empty table: committing archives every skill, so an empty list
+			// here is the normal post-commit state and the caller should say so in words.
+			return { markdown: active.length > 0 ? aggregate.buildLiveSkillsMarkdown(active) : null };
 		}
 	}
 	if (operation === "push-pending-hashes") {

--- a/cli/src/core/skills/SkillProjection.test.ts
+++ b/cli/src/core/skills/SkillProjection.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for SkillProjection — the shared IDE read path.
+ *
+ * It moved out of the VS Code extension so BOTH hosts consume one copy of the
+ * uncommitted-delta rule, which means the CLI suite is now the only place that
+ * covers it: the VS Code tests reach it through `detectSkills`, and IntelliJ
+ * reaches it over the `skills-active` ide-bridge operation with no Kotlin
+ * counterpart at all.
+ *
+ * The registry is REAL against a temp directory rather than a mocked
+ * `loadPlansRegistry`, so these exercise the actual `plans.json` shape — a
+ * projection that agreed with a mock but not with what `savePlansRegistry` writes
+ * would pass while shipping empty panels.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { PlansRegistry, SkillEntry, SkillUsage } from "../../Types.js";
+import { savePlansRegistry } from "../SessionTracker.js";
+import { projectActiveSkills } from "./SkillProjection.js";
+
+const usage = (input: number, cached: number, output: number, confidence: SkillUsage["confidence"]): SkillUsage => ({
+	input,
+	cached,
+	output,
+	confidence,
+});
+
+const entry = (over: Partial<SkillEntry> = {}): SkillEntry => ({
+	source: "claude",
+	skill: "superpowers:brainstorming",
+	entryPaths: ["tool"],
+	invocations: [],
+	invocationCount: 2,
+	firstUsedAt: "2026-07-30T06:00:00.000Z",
+	lastUsedAt: "2026-07-30T07:00:00.000Z",
+	sourcePath: "/tmp/brainstorming.md",
+	commitHash: null,
+	...over,
+});
+
+describe("projectActiveSkills", () => {
+	let cwd: string;
+
+	beforeEach(async () => {
+		cwd = await mkdtemp(join(tmpdir(), "skill-projection-test-"));
+	});
+
+	afterEach(async () => {
+		await rm(cwd, { recursive: true, force: true });
+	});
+
+	const save = async (skills: Record<string, SkillEntry>): Promise<void> => {
+		await savePlansRegistry({ plans: {}, skills } as unknown as PlansRegistry, cwd);
+	};
+
+	it("returns nothing when the registry has no skills map at all", async () => {
+		await savePlansRegistry({ plans: {} } as unknown as PlansRegistry, cwd);
+		expect(await projectActiveSkills(cwd)).toEqual([]);
+	});
+
+	it("projects a never-archived row in full, carrying the map key and timestamps", async () => {
+		await save({ "claude:superpowers:brainstorming": entry({ usage: usage(5, 10, 2, "attributed") }) });
+
+		expect(await projectActiveSkills(cwd)).toEqual([
+			{
+				kind: "skill",
+				mapKey: "claude:superpowers:brainstorming",
+				source: "claude",
+				skill: "superpowers:brainstorming",
+				entryPaths: ["tool"],
+				invocationCount: 2,
+				firstUsedAt: "2026-07-30T06:00:00.000Z",
+				lastUsedAt: "2026-07-30T07:00:00.000Z",
+				usage: usage(5, 10, 2, "attributed"),
+				sourcePath: "/tmp/brainstorming.md",
+				lastModified: "2026-07-30T07:00:00.000Z",
+			},
+		]);
+	});
+
+	// The filter that makes this different from `detectReferences`: a skill row is
+	// GUARDED on archive rather than deleted, so returning the raw map would put
+	// every skill ever used back on the panel as fresh working state.
+	it("hides a row whose counters have not moved past the archived baseline", async () => {
+		await save({
+			"claude:done": entry({
+				skill: "done",
+				commitHash: "abc1234",
+				archivedTotals: { invocationCount: 2 },
+			}),
+		});
+		expect(await projectActiveSkills(cwd)).toEqual([]);
+	});
+
+	it("hides a legacy row archived before archivedTotals existed", async () => {
+		await save({ "claude:legacy": entry({ skill: "legacy", commitHash: "abc1234" }) });
+		expect(await projectActiveSkills(cwd)).toEqual([]);
+	});
+
+	// The reason the delta is PROJECTED and not just used as a visibility test: the
+	// row accumulates for the skill's whole life, and `storeSkills` archives the
+	// delta's figures — so reporting the running total would overstate the pending
+	// commit by everything already frozen onto earlier ones.
+	it("reports the delta's counters, not the row's running total, for a re-entered skill", async () => {
+		await save({
+			"claude:reused": entry({
+				skill: "reused",
+				invocationCount: 5,
+				usage: usage(100, 200, 50, "attributed"),
+				commitHash: "abc1234",
+				archivedTotals: { invocationCount: 3, usage: usage(60, 150, 20, "attributed") },
+			}),
+		});
+
+		const [row] = await projectActiveSkills(cwd);
+		expect(row?.invocationCount).toBe(2);
+		expect(row?.usage).toEqual(usage(40, 50, 30, "attributed"));
+		// Timestamps still come from the ROW — `SkillArchivedTotals` carries none, and
+		// `storeSkills` stamps its ref from the row too, so this is parity, not a leak.
+		expect(row?.firstUsedAt).toBe("2026-07-30T06:00:00.000Z");
+		expect(row?.lastModified).toBe("2026-07-30T07:00:00.000Z");
+	});
+
+	it("leaves usage absent rather than rendering a zero when the source attributed nothing", async () => {
+		await save({ "codex:heuristic": entry({ source: "codex", skill: "heuristic", detection: "heuristic" }) });
+
+		const [row] = await projectActiveSkills(cwd);
+		expect(row).not.toHaveProperty("usage");
+		expect(row?.detection).toBe("heuristic");
+	});
+
+	it("omits plugin and detection when the row does not carry them", async () => {
+		await save({ "claude:bare": entry({ skill: "bare" }) });
+
+		const [row] = await projectActiveSkills(cwd);
+		expect(row).not.toHaveProperty("plugin");
+		expect(row).not.toHaveProperty("detection");
+	});
+
+	it("carries the plugin through when present", async () => {
+		await save({ "claude:p": entry({ skill: "p:x", plugin: "p" }) });
+		expect((await projectActiveSkills(cwd))[0]?.plugin).toBe("p");
+	});
+
+	it("sorts newest-first by lastModified so skills interleave with the other kinds", async () => {
+		await save({
+			"claude:old": entry({ skill: "old", lastUsedAt: "2026-07-30T01:00:00.000Z" }),
+			"claude:new": entry({ skill: "new", lastUsedAt: "2026-07-30T09:00:00.000Z" }),
+			"claude:mid": entry({ skill: "mid", lastUsedAt: "2026-07-30T05:00:00.000Z" }),
+		});
+
+		expect((await projectActiveSkills(cwd)).map((s) => s.skill)).toEqual(["new", "mid", "old"]);
+	});
+});

--- a/cli/src/core/skills/SkillProjection.ts
+++ b/cli/src/core/skills/SkillProjection.ts
@@ -1,0 +1,119 @@
+/**
+ * SkillProjection — the read path that turns `plans.json.skills` into the rows an
+ * IDE Context surface shows.
+ *
+ * It lives here rather than inside one editor's extension because BOTH IDE
+ * surfaces consume it: the VS Code extension imports it directly (it bundles
+ * `cli/src/**`), and the IntelliJ plugin reaches it over the `skills-active`
+ * ide-bridge operation. Neither host reimplements the rule below — that is the
+ * whole point of the module, and the reason it is not a private helper of
+ * {@link SkillArchive}.
+ *
+ * **Unlike references, this MUST filter.** A reference row is deleted when its
+ * commit lands, so every row in that registry is by definition uncommitted and
+ * `detectReferences` can return all of them. A skill row is GUARDED instead —
+ * archival leaves the row in place so a later re-entry can be detected. Returning
+ * every row would put every skill ever used back on the panel as if it were fresh
+ * working state.
+ *
+ * The predicate is {@link uncommittedDelta}, imported rather than restated. It is
+ * NOT the plan/note guard check: a plan is archived once and finished, while a
+ * skill can be entered again afterwards and its row keeps accumulating, so
+ * "uncommitted" is the counters moving past the archived baseline. A hand-copied
+ * version of that rule drifted out of sync once already and hid every re-used
+ * skill from the panel.
+ *
+ * The delta is also what gets PROJECTED, not just what decides visibility. These
+ * rows preview what the next commit will carry, and `storeSkills` archives
+ * `uncommittedDelta`'s figures — so reporting the row's running total would
+ * overstate a re-used skill by everything already frozen onto earlier commits.
+ */
+
+import { createLogger } from "../../Logger.js";
+import type { SkillArchivedTotals, SkillEntry, SkillEntryPath, SkillSource, SkillUsage } from "../../Types.js";
+import { loadPlansRegistry } from "../SessionTracker.js";
+import { uncommittedDelta } from "./SkillDelta.js";
+
+const log = createLogger("SkillProjection");
+
+/**
+ * One captured skill, projected for display.
+ *
+ * Structurally assignable to {@link SkillTableRow}, so the same aggregate table
+ * renders live and archived rows — see that interface for why it is deliberately
+ * narrower than either concrete type.
+ *
+ * `lastModified` mirrors `lastUsedAt` so a skill sorts against plans / notes /
+ * references in one list, the same way a reference row mirrors `updatedAt`.
+ */
+export interface ActiveSkill {
+	readonly kind: "skill";
+	/** plans.json.skills map key — `<source>:<skill>`. */
+	readonly mapKey: string;
+	readonly source: SkillSource;
+	/** Fully-qualified skill id, e.g. `superpowers:brainstorming`. */
+	readonly skill: string;
+	readonly plugin?: string;
+	readonly entryPaths: ReadonlyArray<SkillEntryPath>;
+	readonly invocationCount: number;
+	readonly firstUsedAt: string;
+	readonly lastUsedAt: string;
+	/** Absent when the source could not attribute tokens — never rendered as a zero. */
+	readonly usage?: SkillUsage;
+	readonly sourcePath: string;
+	/** Present when the invocation was inferred rather than observed (Codex). */
+	readonly detection?: "heuristic";
+	/** ISO 8601 — same as lastUsedAt, for sort consistency with the other kinds. */
+	readonly lastModified: string;
+}
+
+/** Active (usage no commit has claimed) skills, newest first. */
+export async function projectActiveSkills(cwd: string): Promise<ReadonlyArray<ActiveSkill>> {
+	const registry = await loadPlansRegistry(cwd);
+	const skills = registry.skills ?? {};
+
+	const result: ActiveSkill[] = [];
+	for (const [mapKey, entry] of Object.entries(skills)) {
+		const delta = uncommittedDelta(entry);
+		if (delta === undefined) continue;
+		result.push(toActiveSkill(mapKey, entry, delta));
+	}
+
+	result.sort((a, b) => new Date(b.lastModified).getTime() - new Date(a.lastModified).getTime());
+	log.info("projectActiveSkills: %d active (%d in registry)", result.length, Object.keys(skills).length);
+	return result;
+}
+
+/**
+ * Project one row, with the COUNTERS taken from `delta` rather than the row.
+ *
+ * The row accumulates for the skill's whole life; `delta` is the part no commit has
+ * claimed. Those agree only until a skill is entered a second time, after which the
+ * row reports work that is already committed — so the figures here would disagree
+ * with the ones `storeSkills` is about to archive, and the memory preview would
+ * overstate the pending commit.
+ *
+ * The timestamps deliberately still come from the row. `SkillArchivedTotals` carries
+ * no time fields, and `storeSkills` likewise stamps its ref from `entry.firstUsedAt`
+ * / `entry.lastUsedAt` — so reading them from the row is what keeps this in parity
+ * with the committed record, not a leak of the same kind.
+ */
+function toActiveSkill(mapKey: string, entry: SkillEntry, delta: SkillArchivedTotals): ActiveSkill {
+	return {
+		kind: "skill",
+		mapKey,
+		source: entry.source,
+		skill: entry.skill,
+		...(entry.plugin !== undefined ? { plugin: entry.plugin } : {}),
+		entryPaths: entry.entryPaths,
+		invocationCount: delta.invocationCount,
+		firstUsedAt: entry.firstUsedAt,
+		lastUsedAt: entry.lastUsedAt,
+		// Absent stays absent: a source that cannot attribute tokens must not be
+		// rendered as having spent zero.
+		...(delta.usage !== undefined ? { usage: delta.usage } : {}),
+		...(entry.detection !== undefined ? { detection: entry.detection } : {}),
+		sourcePath: entry.sourcePath,
+		lastModified: entry.lastUsedAt,
+	};
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/CommitSelectionStore.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/CommitSelectionStore.kt
@@ -1,129 +1,123 @@
 package ai.jolli.jollimemory.core
 
-import ai.jolli.jollimemory.core.JmLogger.JOLLIMEMORY_DIR
-import ai.jolli.jollimemory.core.JmLogger.JOLLI_DIR
+import ai.jolli.jollimemory.bridge.CliIntegrations
 import com.google.gson.Gson
+import com.google.gson.JsonArray
 import com.google.gson.JsonObject
-import java.io.File
 
 /**
- * CommitSelectionStore — persists the set of sidebar items the user wants
- * EXCLUDED from the next summary pipeline run.
+ * CommitSelectionStore — thin bridge adapter for CLI `CommitSelectionStore.ts`,
+ * holding the set of sidebar items the user wants EXCLUDED from the next summary
+ * pipeline run.
  *
- * Four kinds (conversations / plans / notes / references) live in a single
- * JSON file under `<projectDir>/.jolli/jollimemory/commit-selection.json`.
+ * Sticky semantics: an entry stays excluded until the user explicitly re-checks the
+ * row. No git operation or pipeline outcome modifies it — the PostCommitHook only
+ * ever READS.
  *
- * Sticky semantics: an entry stays in this file until the user explicitly
- * un-excludes the item (re-checks the row). No git operation or pipeline
- * outcome modifies the file — the PostCommitHook only ever READS it.
+ * **This used to read and write `commit-selection.json` itself, and the write half
+ * was silently destructive.** The file carries more than the exclusion kinds: an
+ * `aiRelevance` array (the relevance ranker's verdicts) and its `changeFingerprint`
+ * (what makes those verdicts still valid) live alongside them, and `skills` was
+ * added as a fifth kind after this port was written. The Kotlin writer rebuilt the
+ * payload field by field from the four kinds it knew about, so EVERY exclusion
+ * toggle — a conversation, a plan, a note, a reference — rewrote the file without
+ * the fields it had never heard of. A skill the user excluded in VS Code came back
+ * and was archived onto the next commit anyway, and the ranker's work was discarded.
+ * The CLI's own serializer carries those fields explicitly and says why; this had no
+ * counterpart to that guard.
+ *
+ * Delegating fixes it by construction rather than by remembering: there is one
+ * writer, in one language, and a field added to the persisted shape can no longer be
+ * dropped by a host that does not know it exists. Same reason [PinStore] is a bridge
+ * adapter — hand-porting the file format back here would be a regression, not an
+ * optimisation.
  */
 object CommitSelectionStore {
 
-	private val log = JmLogger.create("CommitSelection")
-	private const val SELECTION_FILE = "commit-selection.json"
-	private const val SELECTION_VERSION = 2
-	private val gson = Gson()
+    private val log = JmLogger.create("CommitSelection")
+    private val gson = Gson()
 
-	data class CommitExclusions(
-		val conversations: Set<String> = emptySet(),
-		val plans: Set<String> = emptySet(),
-		val notes: Set<String> = emptySet(),
-		val references: Set<String> = emptySet(),
-	)
+    data class CommitExclusions(
+        val conversations: Set<String> = emptySet(),
+        val plans: Set<String> = emptySet(),
+        val notes: Set<String> = emptySet(),
+        val references: Set<String> = emptySet(),
+        /** Skill key `<source>:<skill>` — one entry per captured skill, not per aggregate row. */
+        val skills: Set<String> = emptySet(),
+    )
 
-	private fun selectionFile(projectDir: String): File {
-		return File(projectDir, "$JOLLI_DIR/$JOLLIMEMORY_DIR/$SELECTION_FILE")
-	}
+    /**
+     * Reads every exclusion kind. Degrades to "nothing excluded" on a bridge failure,
+     * which keeps a panel rendering rather than blanking it.
+     *
+     * The write paths below deliberately do NOT swallow — but be aware that today
+     * nothing DOWNSTREAM surfaces what they throw either: every caller runs them on a
+     * pooled thread with no handler (or, in `WorkingMemoryPanel`, logs and returns),
+     * so a failed write reaches idea.log and nowhere else. The row is left showing the
+     * state the user clicked while the store still holds the old one, until the next
+     * refresh corrects it. That was near-unreachable while this wrote a local file;
+     * routing it through the bridge makes ordinary causes (daemon down, CLI missing)
+     * reach it. Not letting these throw would only make it quieter — the missing half
+     * is feedback at the call sites, not a catch here.
+     */
+    fun readExclusions(projectDir: String): CommitExclusions {
+        return try {
+            val json = run(projectDir, request("selection-read")).asJsonObject
+            CommitExclusions(
+                conversations = asStringSet(json, "conversations"),
+                plans = asStringSet(json, "plans"),
+                notes = asStringSet(json, "notes"),
+                references = asStringSet(json, "references"),
+                skills = asStringSet(json, "skills"),
+            )
+        } catch (ex: Exception) {
+            log.warn("readExclusions failed: %s", ex.message)
+            CommitExclusions()
+        }
+    }
 
-	fun readExclusions(projectDir: String): CommitExclusions {
-		val file = selectionFile(projectDir)
-		if (!file.exists()) return CommitExclusions()
+    fun setExcluded(projectDir: String, kind: String, key: String, excluded: Boolean) {
+        run(
+            projectDir,
+            request("selection-set").apply {
+                addProperty("kind", kind)
+                addProperty("key", key)
+                addProperty("excluded", excluded)
+            },
+        )
+    }
 
-		return try {
-			val json = gson.fromJson(file.readText(), JsonObject::class.java) ?: return CommitExclusions()
-			val version = json.get("version")?.asInt
-			if (version != SELECTION_VERSION && version != 1) {
-				log.warn("readExclusions version mismatch (got %s) — ignoring file", version)
-				return CommitExclusions()
-			}
-			CommitExclusions(
-				conversations = asStringSet(json, "conversations"),
-				plans = asStringSet(json, "plans"),
-				notes = asStringSet(json, "notes"),
-				references = asStringSet(json, "references"),
-			)
-		} catch (ex: Exception) {
-			log.warn("readExclusions failed: %s", ex.message)
-			CommitExclusions()
-		}
-	}
+    fun setAllExcluded(projectDir: String, kind: String, keys: List<String>, excluded: Boolean) {
+        run(
+            projectDir,
+            request("selection-set-all").apply {
+                addProperty("kind", kind)
+                add("keys", JsonArray().apply { keys.forEach { add(it) } })
+                addProperty("excluded", excluded)
+            },
+        )
+    }
 
-	fun setExcluded(projectDir: String, kind: String, key: String, excluded: Boolean) {
-		val current = readExclusions(projectDir)
-		val next = mutableMapOf(
-			"conversations" to current.conversations.toMutableSet(),
-			"plans" to current.plans.toMutableSet(),
-			"notes" to current.notes.toMutableSet(),
-			"references" to current.references.toMutableSet(),
-		)
-		val set = next[kind] ?: return
-		if (excluded) set.add(key) else set.remove(key)
+    /**
+     * Kept local rather than routed through the bridge's `selection-key` operation:
+     * it is a two-part string join that every rendered conversation row needs, so a
+     * round trip per row would cost more than the format is worth. The colon is
+     * reserved across jollimemory and [TranscriptSource] names never contain one, so
+     * this matches the CLI's `conversationKey` exactly.
+     */
+    fun conversationKey(source: TranscriptSource, sessionId: String): String {
+        return "${source.name}:$sessionId"
+    }
 
-		writeExclusions(projectDir, next)
-	}
+    private fun request(operation: String): JsonObject = JsonObject().apply { addProperty("operation", operation) }
 
-	fun setAllExcluded(projectDir: String, kind: String, keys: List<String>, excluded: Boolean) {
-		val current = readExclusions(projectDir)
-		val next = mutableMapOf(
-			"conversations" to current.conversations.toMutableSet(),
-			"plans" to current.plans.toMutableSet(),
-			"notes" to current.notes.toMutableSet(),
-			"references" to current.references.toMutableSet(),
-		)
-		val set = next[kind] ?: return
-		if (excluded) {
-			for (k in keys) set.add(k)
-		} else {
-			for (k in keys) set.remove(k)
-		}
+    private fun run(cwd: String, request: JsonObject) =
+        CliIntegrations.runIdeBridge(cwd, "shared-store", gson.toJson(request))
 
-		writeExclusions(projectDir, next)
-	}
-
-	fun conversationKey(source: TranscriptSource, sessionId: String): String {
-		return "${source.name}:$sessionId"
-	}
-
-	private fun writeExclusions(projectDir: String, data: Map<String, Set<String>>) {
-		val file = selectionFile(projectDir)
-		file.parentFile?.mkdirs()
-
-		val payload = mapOf(
-			"version" to SELECTION_VERSION,
-			"conversations" to (data["conversations"] ?: emptySet()).toList(),
-			"plans" to (data["plans"] ?: emptySet()).toList(),
-			"notes" to (data["notes"] ?: emptySet()).toList(),
-			"references" to (data["references"] ?: emptySet()).toList(),
-		)
-
-		val tmp = File(file.parentFile, "${file.name}.tmp-${ProcessHandle.current().pid()}-${System.currentTimeMillis()}")
-		try {
-			tmp.writeText(gson.toJson(payload))
-			if (!tmp.renameTo(file)) {
-				// renameTo can fail on Windows; fall back to overwrite
-				file.writeText(tmp.readText())
-				tmp.delete()
-			}
-		} catch (ex: Exception) {
-			tmp.delete()
-			throw ex
-		}
-	}
-
-	private fun asStringSet(json: JsonObject, key: String): Set<String> {
-		val arr = json.getAsJsonArray(key) ?: return emptySet()
-		return arr.mapNotNull { el ->
-			try { el.asString } catch (_: Exception) { null }
-		}.toSet()
-	}
+    private fun asStringSet(json: JsonObject, key: String): Set<String> {
+        val arr = json.getAsJsonArray(key) ?: return emptySet()
+        return arr.mapNotNull { el ->
+            try { el.asString } catch (_: Exception) { null }
+        }.toSet()
+    }
 }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SkillsProjection.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/SkillsProjection.kt
@@ -1,0 +1,153 @@
+package ai.jolli.jollimemory.core
+
+import ai.jolli.jollimemory.bridge.CliIntegrations
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+
+/**
+ * SkillsProjection — bridge adapter for the CLI's skill read and render surface
+ * (`cli/src/core/skills/SkillProjection.ts` + `cli/src/core/SkillsAggregateMarkdown.ts`).
+ *
+ * Everything here is one `shared-store` call. Nothing about skills is computed in
+ * Kotlin, and that is deliberate rather than lazy:
+ *
+ *  - **Which rows are still uncommitted** is not readable off a registry row. A
+ *    skill row keeps accumulating across sessions and is GUARDED rather than deleted
+ *    on archive, so "uncommitted" means the counters moved past the archived
+ *    baseline — and the reported figures must be that delta, not the running total,
+ *    or a re-used skill overstates the pending commit by everything already frozen
+ *    onto earlier ones. VS Code hand-copied that rule once and every re-used skill
+ *    vanished from its panel.
+ *  - **The table and its one-line summary must agree** with the `skills--<hash8>.md`
+ *    file the CLI writes into the Memory Bank, and with what VS Code shows. A second
+ *    renderer is a second set of rounding, ordering and em-dash-vs-zero decisions.
+ *
+ * Every call is remote, so callers must stay OFF the EDT — the daemon is 5-20ms warm
+ * but 500ms-2s on its first spawn, which is well past IntelliJ's slow-EDT threshold.
+ * The existing callers fetch inside an off-EDT bundle and render from the result.
+ */
+object SkillsProjection {
+
+    private val log = JmLogger.create("SkillsProjection")
+    private val gson = Gson()
+
+    /**
+     * One captured skill as the CLI projects it.
+     *
+     * Field names must match `ActiveSkill` in `SkillProjection.ts` exactly — Gson
+     * silently leaves a renamed field at its default instead of failing to compile.
+     * Defaults are supplied throughout for the same reason: a field the CLI stops
+     * sending degrades to empty rather than to a null-dereference.
+     */
+    data class ActiveSkill(
+        /** plans.json.skills map key `<source>:<skill>` — the exclusion key, not a display value. */
+        val mapKey: String = "",
+        val source: String = "",
+        val skill: String = "",
+        val plugin: String? = null,
+        val invocationCount: Int = 0,
+        val firstUsedAt: String? = null,
+        val lastUsedAt: String? = null,
+        /** Absent when the source could not attribute tokens — must never render as a zero. */
+        val usage: SkillUsage? = null,
+        /** "heuristic" when the invocation was inferred from a file read rather than observed. */
+        val detection: String? = null,
+        val lastModified: String = "",
+    )
+
+    /**
+     * The active rows plus the label that goes on the single aggregate row.
+     *
+     * One row for however many skills were captured: a session routinely enters a
+     * dozen, and no Context surface can absorb a dozen affordance-free rows. The
+     * per-skill figures live one click away in [liveMarkdown].
+     */
+    data class ActiveSkills(
+        val skills: List<ActiveSkill> = emptyList(),
+        val summaryLabel: String = "",
+    ) {
+        val isEmpty: Boolean get() = skills.isEmpty()
+
+        /**
+         * Exclusion keys for every captured skill — what the aggregate checkbox writes.
+         * Named for its purpose rather than `mapKeys`, which reads as Kotlin's
+         * `Map.mapKeys` transform at the call site.
+         */
+        val exclusionKeys: List<String> get() = skills.map { it.mapKey }
+
+        /** True when any row was inferred rather than observed, so the label can say so. */
+        val anyInferred: Boolean get() = skills.any { it.detection == "heuristic" }
+    }
+
+    /** Skills captured but not yet archived onto a commit. Empty on any bridge failure. */
+    fun readActive(projectDir: String): ActiveSkills {
+        return try {
+            gson.fromJson(run(projectDir, request("skills-active")), ActiveSkills::class.java) ?: ActiveSkills()
+        } catch (ex: Exception) {
+            log.warn("readActive failed: %s", ex.message)
+            ActiveSkills()
+        }
+    }
+
+    /**
+     * The uncommitted aggregate table, or null when nothing is captured.
+     *
+     * Null is the normal state right after a commit (archival empties the working
+     * registry), so the caller should say that in words rather than show an empty table.
+     *
+     * Throws when the bridge cannot answer — see [markdownOf] for why this one does
+     * not degrade the way the read paths above do.
+     */
+    fun liveMarkdown(projectDir: String): String? = markdownOf(projectDir, request("skills-live-markdown"))
+
+    /**
+     * The summary label for an ARCHIVED set, read off a [CommitSummary] rather than the
+     * working registry — which no longer holds these rows once they are committed.
+     */
+    fun committedLabel(projectDir: String, skills: List<SkillCommitRef>): String? {
+        return try {
+            val response = run(
+                projectDir,
+                request("skills-label").apply { add("skills", gson.toJsonTree(skills)) },
+            ).asJsonObject
+            response.get("label")?.takeIf { !it.isJsonNull }?.asString
+        } catch (ex: Exception) {
+            log.warn("committedLabel failed: %s", ex.message)
+            null
+        }
+    }
+
+    /**
+     * One commit's archived skills table, rendered from the summary.
+     *
+     * Rendered rather than read from `skills--<hash8>.md`: that file exists only in the
+     * Memory Bank's visible layer, which is absent in orphan-branch-only storage mode
+     * and for a foreign repo whose folder this machine has never seen.
+     *
+     * Throws when the bridge cannot answer — see [markdownOf]. Null here means the
+     * summary really carried no skills, which for this caller is close to unreachable:
+     * its row is only drawn when `summary.skills` is non-empty.
+     */
+    fun committedMarkdown(projectDir: String, summary: CommitSummary): String? =
+        markdownOf(projectDir, request("skills-committed-markdown").apply { add("summary", gson.toJsonTree(summary)) })
+
+    /**
+     * Renders one of the two tables, THROWING on a bridge failure rather than
+     * degrading to null.
+     *
+     * The read paths above degrade because their null means "draw nothing", which is
+     * an honest thing to do with no data. Here null means the opposite: both callers
+     * turn it into a sentence asserting something about the memory ("no archived
+     * skill usage"). Swallowing made a daemon that was merely unreachable say that —
+     * and in the committed case the row the user just clicked was drawn from the
+     * summary on disk, so the panel would be contradicting data it had already read.
+     * Callers separate the two and say which happened.
+     */
+    private fun markdownOf(projectDir: String, request: JsonObject): String? =
+        run(projectDir, request).asJsonObject.get("markdown")?.takeIf { !it.isJsonNull }?.asString
+
+    private fun request(operation: String): JsonObject = JsonObject().apply { addProperty("operation", operation) }
+
+    private fun run(cwd: String, request: JsonObject) =
+        CliIntegrations.runIdeBridge(cwd, "shared-store", gson.toJson(request))
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/Types.kt
@@ -331,11 +331,12 @@ data class CommitSummary(
     val notes: List<NoteReference>? = null,
     val references: List<ReferenceCommitRef>? = null,
     /**
-     * Archived skill usage. Declared here for a WRITE reason, not a read one: this
-     * plugin does not render skills, but `SummaryTree.updateTopicInTree` round-trips a
-     * whole summary through Gson and `SummaryPanel` stores the result — and Gson drops
-     * every JSON member the data class does not declare. Without this field, editing
-     * one topic in the IntelliJ panel would silently erase the commit's skill record.
+     * Archived skill usage. Read by [SkillsProjection] for the committed CONTEXT row,
+     * but the reason it must stay declared is still a WRITE one:
+     * `SummaryTree.updateTopicInTree` round-trips a whole summary through Gson and
+     * `SummaryPanel` stores the result — and Gson drops every JSON member the data
+     * class does not declare. Without this field, editing one topic in the IntelliJ
+     * panel would silently erase the commit's skill record.
      */
     val skills: List<SkillCommitRef>? = null,
     val summaryError: String? = null,
@@ -485,10 +486,12 @@ data class SkillArchivedTotals(
 /**
  * Snapshot of one skill's usage on a commit — Kotlin port of `SkillCommitRef`.
  *
- * Read-through only: nothing in this plugin renders these today. It exists so a
- * summary can survive a Gson round-trip intact (see [CommitSummary.skills]), which
- * means field names must match the TS interface exactly — a rename here does not
- * fail to compile, it silently drops that member on the next topic edit.
+ * Rendered only indirectly: [SkillsProjection] ships these BACK to the CLI, which
+ * owns both the summary label and the aggregate table, so no field here is read for
+ * display in Kotlin. That makes matching the TS interface exactly load-bearing twice
+ * over — a rename does not fail to compile, it silently drops that member both from
+ * the summary on the next topic edit (see [CommitSummary.skills]) and from the table
+ * the CLI renders back.
  *
  * Every field except `archivedKey` is a value snapshot holding THIS commit's
  * increment, not the registry row's running total.

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt
@@ -6,6 +6,7 @@ import ai.jolli.jollimemory.bridge.ConversationBrief
 import ai.jolli.jollimemory.core.ActiveConversationItem
 import ai.jolli.jollimemory.core.CommitSummary
 import ai.jolli.jollimemory.core.NoteFormat
+import ai.jolli.jollimemory.core.SkillsProjection
 import ai.jolli.jollimemory.core.TranscriptSource
 import ai.jolli.jollimemory.core.KBDataCache
 import com.google.gson.Gson
@@ -500,6 +501,29 @@ class CommitsPanel(
                 // Collapse the list back to the first page on a new branch / new
                 // commit; a content-identical refresh leaves the count untouched.
                 visibleCommits = CappedRows.CAP
+            }
+
+            // Evict any detail bundled while its summary did not exist yet.
+            //
+            // The sequence check above cannot cover this: committing puts the hash in
+            // the list IMMEDIATELY, while the QueueWorker writes the summary seconds
+            // later after its LLM call. Expanding the new row in that window — the
+            // obvious thing to do right after committing — bundles `summary = null`,
+            // and because that future resolves WITHOUT error it is never evicted (the
+            // whenComplete handler only removes on `error != null`). Every later
+            // refresh then compares an unchanged hash list and keeps it, so the row
+            // served an empty CONTEXT for the life of the panel — no skills, no plans,
+            // no notes — until a branch switch or a new commit.
+            //
+            // `hasSummary` is re-derived from storage on every refresh, so its flip is
+            // exactly the moment the bundle went stale. Evicting only the affected
+            // hashes keeps this off the block above, whose other effects (clearing the
+            // selection, collapsing back to page one) must NOT fire when a summary
+            // merely lands.
+            val previousHasSummary = commits.associate { it.hash to it.hasSummary }
+            for (fresh in newCommits) {
+                val before = previousHasSummary[fresh.hash] ?: continue
+                if (before != fresh.hasSummary) detailCache.remove(fresh.hash)
             }
 
             // Detect merged state: branch HEAD is reachable from main
@@ -1374,10 +1398,15 @@ class CommitsPanel(
             CompletableFuture.supplyAsync(
                 {
                     val summary = service.getSummary(hash)
+                    val archivedSkills = summary?.skills ?: emptyList()
                     ExpansionDetail(
                         summary = summary,
                         conversations = gatherConversations(hash, summary),
                         files = service.listCommitFiles(hash),
+                        skillsLabel = archivedSkills.takeIf { it.isNotEmpty() }?.let { refs ->
+                            val cwd = service.mainRepoRoot ?: project.basePath
+                            cwd?.let { SkillsProjection.committedLabel(it, refs) }
+                        },
                     )
                 },
                 { cmd -> ApplicationManager.getApplication().executeOnPooledThread(cmd) },
@@ -1551,6 +1580,25 @@ class CommitsPanel(
                 }
             })
         }
+        // ONE row for however many skills this memory archived, matching the live
+        // CONTEXT list and VS Code — a commit routinely carries a dozen, and no
+        // Context surface can absorb a dozen rows whose only action is the same click.
+        // The per-skill figures are in the table that click opens.
+        val archivedSkills = summary?.skills ?: emptyList()
+        if (summary != null && archivedSkills.isNotEmpty()) {
+            contextRows.add(
+                contextRow(
+                    "S",
+                    detail.skillsLabel ?: "Skills used",
+                    isLink = false,
+                    tagColor = TagLabel.SKILL,
+                ) {
+                    trackItemOpened("skill")
+                    openCommittedSkills(summary)
+                },
+            )
+        }
+
         val contextCount = contextRows.size
         if (contextRows.isEmpty()) contextRows.add(plainDetailRow("No linked context"))
         addGroup(container, "CONTEXT", contextCount, contextRows)
@@ -1930,6 +1978,52 @@ class CommitsPanel(
         val safeName = if (name.endsWith(".md")) name else "$name.md"
         val vf = com.intellij.testFramework.LightVirtualFile(safeName, content).apply { isWritable = false }
         MarkdownPreview.open(project, vf)
+    }
+
+    /**
+     * Opens one committed memory's archived skills table.
+     *
+     * Rendered from the summary rather than opened from the `skills--<hash8>.md` file
+     * on disk: that file exists only in the Memory Bank's visible layer, which is
+     * absent in orphan-branch-only storage mode and for a foreign repo whose folder
+     * this machine has never synced. Rendering works in every mode, and it is the same
+     * renderer that wrote the file.
+     */
+    private fun openCommittedSkills(summary: CommitSummary) {
+        val cwd = service.mainRepoRoot ?: project.basePath ?: return
+        ApplicationManager.getApplication().executeOnPooledThread {
+            // The two failure shapes are kept apart deliberately. This row is drawn from
+            // `summary.skills` — data already read off disk — so reporting an
+            // unreachable CLI as "this memory has no archived skill usage" would have the
+            // panel contradict what it just rendered, and send the user looking for a
+            // missing memory instead of a stopped daemon.
+            val markdown = try {
+                SkillsProjection.committedMarkdown(cwd, summary)
+            } catch (ex: Exception) {
+                SwingUtilities.invokeLater { showSkillsMessage("Could not render this memory's skills: ${ex.message}") }
+                return@executeOnPooledThread
+            }
+            SwingUtilities.invokeLater {
+                if (markdown == null) {
+                    // Reachable when the memory was squashed or amended away between
+                    // render and click — the row is drawn from a snapshot.
+                    showSkillsMessage("This memory has no archived skill usage.")
+                    return@invokeLater
+                }
+                // Same tab name VS Code gives this document, and the same H1 the table
+                // itself opens with. Every other preview here is named after what the
+                // user clicked (a plan / note / reference title); `skills-<hash8>` was
+                // the one that leaked a file-slug instead. VS Code's tab reads
+                // "Preview Skills used — 709d49fa.md" — the "Preview" prefix is added by
+                // its `markdown.showPreview` command and has no IntelliJ counterpart, so
+                // the part we control is the name.
+                openMarkdownContent(markdown, "Skills used — ${summary.commitHash.take(8)}")
+            }
+        }
+    }
+
+    private fun showSkillsMessage(message: String) {
+        JOptionPane.showMessageDialog(this, message, "Skills", JOptionPane.INFORMATION_MESSAGE)
     }
 
     /**
@@ -2558,6 +2652,15 @@ class CommitsPanel(
         val summary: CommitSummary?,
         val conversations: List<ConversationBrief>,
         val files: List<CommitFileInfo>,
+        /**
+         * Label for the aggregate skills row, e.g. `3 skills · 93.8k tokens`.
+         *
+         * Resolved with the rest of this bundle rather than at render time, because
+         * that is a bridge round trip and [renderExpandedGroups] runs on the EDT — a
+         * cold daemon spawn there would freeze the UI for up to two seconds. Null when
+         * the commit archived no skills, or when the bridge could not answer.
+         */
+        val skillsLabel: String?,
     )
 
     private fun statusColor(code: String): Color {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PlansPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PlansPanel.kt
@@ -7,6 +7,7 @@ import ai.jolli.jollimemory.core.PlanEntry
 import ai.jolli.jollimemory.core.CommitSelectionStore
 import ai.jolli.jollimemory.core.PinStore
 import ai.jolli.jollimemory.core.SessionTracker
+import ai.jolli.jollimemory.core.SkillsProjection
 import ai.jolli.jollimemory.core.references.ReferenceEntry
 import ai.jolli.jollimemory.core.references.ReferenceStore
 import ai.jolli.jollimemory.core.references.SourceDisplay
@@ -38,6 +39,7 @@ import java.awt.event.MouseEvent
 import java.awt.font.TextAttribute
 import java.io.File
 import java.net.URI
+import java.util.Locale
 import javax.swing.Box
 import javax.swing.BoxLayout
 import javax.swing.JComponent
@@ -86,6 +88,22 @@ class PlansPanel(
             ref.title,
             ref.updatedAt,
         )
+
+        /**
+         * The aggregate row standing for EVERY skill captured this session — one row,
+         * not one per skill, because a session routinely enters a dozen and this list
+         * caps at six before collapsing. The per-skill figures are one click away in
+         * the table the CLI renders.
+         *
+         * It carries no artifact id, which is what makes it different from the three
+         * above: there is nothing to pin, edit or remove, and its checkbox writes
+         * every captured skill's key at once. Sorted by the newest skill's timestamp
+         * so it interleaves with the other kinds rather than pinning to an end.
+         */
+        class SkillsItem(val skills: SkillsProjection.ActiveSkills) : ListItem(
+            "Skills used",
+            skills.skills.maxOfOrNull { it.lastModified } ?: "",
+        )
     }
 
     // ─── Sticky hover popup (JWindow, same pattern as CommitsPanel) ──────
@@ -98,17 +116,27 @@ class PlansPanel(
         const val HOVER_SHOW_DELAY_MS = 1000
         const val HOVER_HIDE_GRACE_MS = 200
 
+        /**
+         * Skills named in the aggregate row's hover card before it collapses to "+N more".
+         * Matches VS Code's `SKILLS_HOVER_ROW_CAP` so the same session does not show a
+         * different number of rows in the two IDEs.
+         */
+        const val SKILLS_POPUP_CAP = 8
+
         // Context type-tag accent colors for the three kinds authored *here*
         // (plans, notes, snippets); reference colors come from SourceDisplay so
         // there is one table for all sources.
         val TAG_PLAN = JBColor(0x4C82F7, 0x4C82F7)
         val TAG_NOTE = JBColor(0x3FA45B, 0x3FA45B)
         val TAG_SNIPPET = JBColor(0xC9851E, 0xD18616)
+        // Skill accent is NOT declared here: CommitsPanel paints the same badge for a
+        // committed memory, so it lives in TagLabel.SKILL where both can reach it.
     }
     private val emptyLabel = JBLabel("No plans or notes yet.", SwingConstants.CENTER)
     private var excludedReferences: Set<String> = emptySet()
     private var excludedPlans: Set<String> = emptySet()
     private var excludedNotes: Set<String> = emptySet()
+    private var excludedSkills: Set<String> = emptySet()
 
     /** Full item list + expand state for the 6-row cap ("Show N more"). */
     private var allContextItems: List<ListItem> = emptyList()
@@ -142,6 +170,9 @@ class PlansPanel(
             is ListItem.PlanItem -> "plan" to (selected.plan.title.ifBlank { selected.plan.slug })
             is ListItem.NoteItem -> "note" to selected.note.title
             is ListItem.ReferenceItem -> "reference" to selected.ref.title
+            // Skills are a record of what ran, not a document the user curates — there
+            // is nothing to delete. Excluding them from the next memory is the checkbox.
+            is ListItem.SkillsItem -> return
         }
 
         val result = Messages.showYesNoDialog(
@@ -158,6 +189,8 @@ class PlansPanel(
                 is ListItem.PlanItem -> doRemovePlan(selected.plan.slug, cwd)
                 is ListItem.NoteItem -> doRemoveNote(selected.note, cwd)
                 is ListItem.ReferenceItem -> doRemoveReference(selected.mapKey, selected.ref.sourcePath, cwd)
+                // Unreachable: the guard above returns before the confirm dialog.
+                is ListItem.SkillsItem -> Unit
             }
             service.refreshStatus()
         }
@@ -308,41 +341,78 @@ class PlansPanel(
         return sb.toString()
     }
 
-    /** (kind, key) used by CommitSelectionStore / PinStore for a given list item. */
-    private fun kindKeyOf(item: ListItem): Pair<String, String> = when (item) {
+    /**
+     * (kind, key) used by CommitSelectionStore / PinStore for a given list item, or
+     * null for a row that addresses no single artifact.
+     *
+     * Only the aggregate skills row returns null, and it has to: its checkbox stands
+     * for every captured skill, so there is no one key to carry.
+     */
+    private fun kindKeyOf(item: ListItem): Pair<String, String>? = when (item) {
         is ListItem.PlanItem -> "plans" to item.plan.slug
         is ListItem.NoteItem -> "notes" to item.note.id
         is ListItem.ReferenceItem -> "references" to item.mapKey
+        is ListItem.SkillsItem -> null
     }
 
-    private fun isExcluded(item: ListItem): Boolean {
-        val (kind, key) = kindKeyOf(item)
-        return when (kind) {
-            "plans" -> key in excludedPlans
-            "notes" -> key in excludedNotes
-            else -> key in excludedReferences
-        }
+    /**
+     * Exhaustive over the item type rather than over the kind STRING.
+     *
+     * The string form ended in `else -> key in excludedReferences`, so a kind added
+     * later was silently treated as a reference: the row rendered from the wrong
+     * exclude set, and its toggle wrote into it. VS Code shipped exactly that bug
+     * twice — once defaulting to `plan`, once to `reference` — which is why its
+     * per-kind decisions now live in one table instead of a ternary chain. Here the
+     * compiler enforces it: a new [ListItem] subclass fails to build until this
+     * `when` accounts for it.
+     */
+    private fun isExcluded(item: ListItem): Boolean = when (item) {
+        is ListItem.PlanItem -> item.plan.slug in excludedPlans
+        is ListItem.NoteItem -> item.note.id in excludedNotes
+        is ListItem.ReferenceItem -> item.mapKey in excludedReferences
+        // One checkbox for all captured skills, so it reads as excluded only when every
+        // one of them is. A partially-excluded set therefore shows as included, and the
+        // next click excludes the remainder instead of re-including what was already out.
+        is ListItem.SkillsItem ->
+            item.skills.exclusionKeys.isNotEmpty() && item.skills.exclusionKeys.all { it in excludedSkills }
     }
 
     /** Toggles include/exclude for any item kind (select toggle click). */
     private fun toggleExclusion(item: ListItem) {
-        val (kind, key) = kindKeyOf(item)
         val nowExcluded = !isExcluded(item)
         val cwd = service.mainRepoRoot ?: project.basePath ?: return
         ApplicationManager.getApplication().executeOnPooledThread {
-            CommitSelectionStore.setExcluded(cwd, kind, key, nowExcluded)
+            when (item) {
+                // Every captured skill in one write: the aggregate row has no per-skill
+                // affordance, so leaving any key untouched would strand it in a state the
+                // user has no way to see or change.
+                is ListItem.SkillsItem ->
+                    CommitSelectionStore.setAllExcluded(cwd, "skills", item.skills.exclusionKeys, nowExcluded)
+                else -> {
+                    val (kind, key) = kindKeyOf(item) ?: return@executeOnPooledThread
+                    CommitSelectionStore.setExcluded(cwd, kind, key, nowExcluded)
+                }
+            }
             service.notifySelectionChanged()
             val ex = CommitSelectionStore.readExclusions(cwd)
             excludedReferences = ex.references
             excludedPlans = ex.plans
             excludedNotes = ex.notes
+            excludedSkills = ex.skills
             SwingUtilities.invokeLater { renderList() }
         }
     }
 
-    /** Pins an item so it appears in the Pinned section (pin hover action). */
+    /**
+     * Pins an item so it appears in the Pinned section (pin hover action).
+     *
+     * Unreachable for the aggregate skills row — [contextRow] gives it no pin icon,
+     * because Pinned addresses one artifact by key and this row has none. Its `when`
+     * branches below are still required: narrowing on the null key does not narrow the
+     * item type, so the compiler wants every subclass accounted for.
+     */
     private fun pinItem(item: ListItem) {
-        val (kind, key) = kindKeyOf(item)
+        val (kind, key) = kindKeyOf(item) ?: return
         val title = when (item) {
             is ListItem.PlanItem -> item.plan.title.ifBlank { item.plan.slug }
             is ListItem.NoteItem -> item.note.title
@@ -350,6 +420,7 @@ class PlansPanel(
             is ListItem.ReferenceItem -> SourceDisplay.displayTitle(
                 item.ref.source, item.ref.nativeId, item.ref.title,
             )
+            is ListItem.SkillsItem -> return
         }
         // Same letter tag the Context row shows, so the Pinned row mirrors the icon.
         // Reference letter comes from the shared SourceDisplay table so PlansPanel
@@ -358,6 +429,7 @@ class PlansPanel(
             is ListItem.PlanItem -> "P"
             is ListItem.NoteItem -> if (item.note.format == NoteFormat.snippet) "S" else "N"
             is ListItem.ReferenceItem -> SourceDisplay.of(item.ref.source).tag
+            is ListItem.SkillsItem -> return
         }
         val cwd = service.mainRepoRoot ?: project.basePath ?: return
         ai.jolli.jollimemory.core.telemetry.Telemetry.track("memory_pinned", mapOf("kind" to kind))
@@ -373,7 +445,56 @@ class PlansPanel(
             is ListItem.PlanItem -> openPlan(item.plan)
             is ListItem.NoteItem -> openNote(item.note)
             is ListItem.ReferenceItem -> openReference(item.ref)
+            is ListItem.SkillsItem -> openSkillsAggregate()
         }
+    }
+
+    /**
+     * Opens the table of every skill captured but not yet committed.
+     *
+     * There is no file to open: on disk each skill is its own
+     * `skills/<source>/<stem>.md`, and the aggregate only becomes a real file
+     * (`skills--<hash8>.md`) once the work is committed. So this renders the same
+     * table through the CLI and shows it read-only, which is also what keeps the
+     * before-commit and after-commit views identical.
+     */
+    private fun openSkillsAggregate() {
+        val cwd = service.mainRepoRoot ?: project.basePath ?: return
+        ApplicationManager.getApplication().executeOnPooledThread {
+            // Separated from the empty case below: a bridge that cannot answer is not
+            // evidence about what was captured, and saying so would point the user at
+            // the wrong problem.
+            val markdown = try {
+                SkillsProjection.liveMarkdown(cwd)
+            } catch (ex: Exception) {
+                SwingUtilities.invokeLater { showSkillsMessage("Could not render the skills table: ${ex.message}") }
+                return@executeOnPooledThread
+            }
+            SwingUtilities.invokeLater {
+                if (markdown == null) {
+                    // Normal right after a commit: archival empties the working registry.
+                    // Worded as where they WENT, not as their absence — the row was on
+                    // screen a moment ago, so "none captured" would read as a loss.
+                    showSkillsMessage(
+                        "These skills are now archived on your latest memory — " +
+                            "nothing new has been captured for the current working session.",
+                    )
+                    return@invokeLater
+                }
+                MarkdownPreview.open(
+                    project,
+                    // Matches VS Code's tab for the same document, and the table's own
+                    // H1 — the committed counterpart in CommitsPanel is named the same
+                    // way, so the before-commit and after-commit tabs read as one pair.
+                    com.intellij.testFramework.LightVirtualFile("Skills used — uncommitted.md", markdown)
+                        .apply { isWritable = false },
+                )
+            }
+        }
+    }
+
+    private fun showSkillsMessage(message: String) {
+        JOptionPane.showMessageDialog(this, message, "Skills", JOptionPane.INFORMATION_MESSAGE)
     }
 
     private fun openReferenceInBrowser(url: String) {
@@ -415,6 +536,7 @@ class PlansPanel(
             excludedReferences = ex.references
             excludedPlans = ex.plans
             excludedNotes = ex.notes
+            excludedSkills = ex.skills
 
             val planItems = filterPlans(registry.plans, gitOps, currentBranch)
                 .map { ListItem.PlanItem(it) }
@@ -424,9 +546,18 @@ class PlansPanel(
             // (a commit deletes the row; there is no committed/guard state to filter).
             val refItems = (registry.references ?: emptyMap())
                 .map { (mapKey, entry) -> ListItem.ReferenceItem(entry, mapKey) }
+            // Not read off `registry.skills` like the three above: a skill row survives
+            // archival (it is guarded, not deleted, so a later re-entry is detectable),
+            // so the raw map would list every skill ever used as if it were fresh working
+            // state. The CLI decides which rows are still uncommitted, and reports the
+            // delta rather than each row's lifetime total.
+            val skillItems = SkillsProjection.readActive(cwd)
+                .takeIf { !it.isEmpty }
+                ?.let { listOf(ListItem.SkillsItem(it)) }
+                ?: emptyList()
 
             // Merge and sort by lastModified descending (newest first), matching VS Code
-            (planItems + noteItems + refItems).sortedByDescending { it.lastModified }
+            (planItems + noteItems + refItems + skillItems).sortedByDescending { it.lastModified }
         } catch (_: Exception) {
             emptyList()
         }
@@ -607,7 +738,10 @@ class PlansPanel(
             if (excluded) AllIcons.General.Add else AllIcons.Actions.Close,
             if (excluded) "Include in next memory" else "Exclude from next memory",
         ) { toggleExclusion(item) }
-        val icons = listOf(pin, edit, toggle)
+        // The aggregate skills row gets the checkbox and nothing else — matching VS
+        // Code, where its kind declares no inline actions. There is no single document
+        // to pin or edit, and Pin addresses one artifact by key, which this row lacks.
+        val icons = if (item is ListItem.SkillsItem) listOf(toggle) else listOf(pin, edit, toggle)
         val iconsRow = JPanel(FlowLayout(FlowLayout.RIGHT, 0, 0)).apply {
             isOpaque = false
             icons.forEach { add(it) }
@@ -716,6 +850,16 @@ class PlansPanel(
 
     private fun showRowContextMenu(item: ListItem, e: MouseEvent) {
         val popup = JPopupMenu()
+        // The aggregate skills row offers Preview only: it is a record of what ran, so
+        // there is nothing to remove, and a Remove item that silently did nothing would
+        // be worse than its absence.
+        if (item is ListItem.SkillsItem) {
+            popup.add(JMenuItem("Preview", JolliMemoryIcons.Eye).apply {
+                addActionListener { openSkillsAggregate() }
+            })
+            popup.show(e.component, e.x, e.y)
+            return
+        }
         if (item is ListItem.ReferenceItem) {
             popup.add(JMenuItem("Preview", JolliMemoryIcons.Eye).apply { addActionListener { openReference(item.ref) } })
             val refUrl = item.ref.url
@@ -739,6 +883,7 @@ class PlansPanel(
         // table; a source the enum hasn't caught up with yet gets the neutral
         // Reference placeholder instead of crashing the row renderer.
         is ListItem.ReferenceItem -> SourceDisplay.of(item.ref.source).let { it.tag to it.color }
+        is ListItem.SkillsItem -> "S" to TagLabel.SKILL
     }
 
     private fun titleFor(item: ListItem): String = when (item) {
@@ -758,6 +903,14 @@ class PlansPanel(
         is ListItem.ReferenceItem -> SourceDisplay.displayTitle(
             item.ref.source, item.ref.nativeId, item.ref.title,
         )
+        // The CLI's own label ("3 skills · 93.8k tokens"), not a Kotlin restatement of
+        // it: this row must read the same here, in VS Code, and in the committed
+        // `skills--<hash8>.md`. The "some inferred" suffix is appended per-surface
+        // because the table spells the same caveat as a `†` footnote instead.
+        is ListItem.SkillsItem -> {
+            val label = item.skills.summaryLabel.ifBlank { "Skills used" }
+            if (item.skills.anyInferred) "$label · some inferred" else label
+        }
     }
 
     private fun showMoreRow(remaining: Int): JPanel {
@@ -795,9 +948,10 @@ class PlansPanel(
 
         val cwd = service.mainRepoRoot ?: project.basePath ?: return
         ApplicationManager.getApplication().executeOnPooledThread {
-            for (item in refItems) {
-                CommitSelectionStore.setExcluded(cwd, "references", item.mapKey, !select)
-            }
+            // One bulk write, not one per row. Same net effect — every reference gets
+            // the same `!select` — but the store is reached over the ide-bridge now, so
+            // a per-row loop paid one daemon round trip per reference.
+            CommitSelectionStore.setAllExcluded(cwd, "references", refItems.map { it.mapKey }, !select)
             service.notifySelectionChanged()
             excludedReferences = CommitSelectionStore.readExclusions(cwd).references
             SwingUtilities.invokeLater { renderList() }
@@ -839,6 +993,7 @@ class PlansPanel(
             is ListItem.PlanItem -> buildPlanPopupContent(content, item.plan, fg, dimFg)
             is ListItem.NoteItem -> buildNotePopupContent(content, item.note, fg, dimFg)
             is ListItem.ReferenceItem -> buildReferencePopupContent(content, item.ref, fg, dimFg)
+            is ListItem.SkillsItem -> buildSkillsPopupContent(content, item.skills, fg, dimFg)
         }
 
         popup.contentPane = JPanel(BorderLayout()).apply {
@@ -882,6 +1037,80 @@ class PlansPanel(
         content.add(JBLabel("${plan.editCount} edit${if (plan.editCount != 1) "s" else ""}").apply {
             foreground = dimFg; alignmentX = Component.LEFT_ALIGNMENT
         })
+    }
+
+    /**
+     * Names the skills behind the aggregate row, heaviest first.
+     *
+     * The row itself can only show a count and a token total, so without this the user
+     * has to open the table to learn WHICH skills ran. Capped at [SKILLS_POPUP_CAP]
+     * with an overflow line — a session can enter a dozen, and a popup taller than the
+     * panel is worse than a truncated one. Ordering matches the table's (by tokens,
+     * then name) so the two do not disagree about what dominated the work.
+     */
+    private fun buildSkillsPopupContent(
+        content: JPanel,
+        skills: SkillsProjection.ActiveSkills,
+        fg: Color,
+        dimFg: Color,
+    ) {
+        content.add(JBLabel(skills.summaryLabel.ifBlank { "Skills used" }).apply {
+            foreground = fg; font = font.deriveFont(Font.BOLD); alignmentX = Component.LEFT_ALIGNMENT
+        })
+        content.add(Box.createVerticalStrut(JBUI.scale(4)))
+
+        // Heaviest first, then by name — the aggregate table's own ordering, so the card
+        // and the table agree about what dominated the work. Deliberately not a
+        // locale-aware compare: the ambient locale would reorder rows for a colleague.
+        val ordered = skills.skills.sortedWith(
+            compareByDescending<SkillsProjection.ActiveSkill> { totalTokensOf(it) }.thenBy { it.skill },
+        )
+        for (skill in ordered.take(SKILLS_POPUP_CAP)) {
+            // Count AND tokens, the table's two columns. An unattributed skill shows an
+            // em dash for tokens, never a zero — Codex and Cursor heuristics measure
+            // nothing, and a rendered 0 reads as a measurement rather than its absence.
+            val tokens = skill.usage
+                ?.let { u -> formatTokens(totalTokensOf(skill), u.confidence != "attributed") }
+                ?: "—"
+            val inferred = if (skill.detection == "heuristic") " †" else ""
+            content.add(JBLabel("${skill.skill}$inferred — ${skill.invocationCount}× · $tokens").apply {
+                foreground = dimFg; alignmentX = Component.LEFT_ALIGNMENT
+            })
+        }
+        val hidden = ordered.size - SKILLS_POPUP_CAP
+        if (hidden > 0) {
+            content.add(JBLabel("+$hidden more — click to open the table").apply {
+                foreground = dimFg; alignmentX = Component.LEFT_ALIGNMENT
+            })
+        }
+        if (skills.anyInferred) {
+            content.add(Box.createVerticalStrut(JBUI.scale(2)))
+            content.add(JBLabel("† inferred from a file read, not an observed call").apply {
+                foreground = dimFg; alignmentX = Component.LEFT_ALIGNMENT
+            })
+        }
+    }
+
+    private fun totalTokensOf(skill: SkillsProjection.ActiveSkill): Int =
+        skill.usage?.let { it.input + it.cached + it.output } ?: 0
+
+    /**
+     * `93.8k` / `~12.3k` — the CLI table's compact form.
+     *
+     * Restated in Kotlin only because this is a PER-SKILL figure and the bridge exposes
+     * the aggregate label, not per-row text. VS Code's own hover card does the same for
+     * the same reason. Keep the formula identical to `formatCompact` in
+     * `SkillsAggregateMarkdown.ts` — the card sits one click from that table, and two
+     * roundings of the same number is a bug report.
+     */
+    private fun formatTokens(total: Int, estimated: Boolean): String {
+        val marker = if (estimated) "~" else ""
+        // Locale.ROOT, not the bare `String.format` extension: that one takes the
+        // ambient locale, so a comma-decimal IDE would render `93,8k` here while the
+        // table one click away — rendered by the CLI's `toFixed(1)`, which has no
+        // locale — still says `93.8k`. Same reason the sort above avoids a
+        // locale-aware compare.
+        return if (total < 1000) "$marker$total" else marker + String.format(Locale.ROOT, "%.1fk", total / 1000.0)
     }
 
     private fun buildNotePopupContent(content: JPanel, note: NoteEntry, fg: Color, dimFg: Color) {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/TagLabel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/TagLabel.kt
@@ -24,6 +24,21 @@ import javax.swing.SwingConstants
  * (mirroring VSCode's `SOURCE_META`) — do not hard-code hex values at call sites.
  */
 class TagLabel : JLabel("", SwingConstants.CENTER) {
+
+	companion object {
+		/**
+		 * Skill accent, matching VS Code's `.kb-tag.t-skill`.
+		 *
+		 * It lives here rather than in either panel's companion because BOTH paint this
+		 * badge — the live CONTEXT list and a committed memory's CONTEXT sub-group — and
+		 * this class is where the module header says badge look has its single home. The
+		 * LETTER is "S" on both surfaces, matching VS Code, which collides with the
+		 * snippet-note tag; the two are told apart by colour, and relabelling a skill in
+		 * one IDE only would be the worse trade.
+		 */
+		val SKILL: Color = JBColor(0xB180D7, 0xB180D7)
+	}
+
 	private var badgeColor: Color = JBColor.GRAY
 
 	init {

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/WorkingMemoryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/WorkingMemoryPanel.kt
@@ -4,6 +4,7 @@ import ai.jolli.jollimemory.core.ActiveConversationItem
 import ai.jolli.jollimemory.core.ActiveSessionAggregator
 import ai.jolli.jollimemory.core.CommitSelectionStore
 import ai.jolli.jollimemory.core.SessionTracker
+import ai.jolli.jollimemory.core.SkillsProjection
 import ai.jolli.jollimemory.core.StoredSession
 import ai.jolli.jollimemory.core.ConversationUsage
 import ai.jolli.jollimemory.core.TranscriptMessageCounter
@@ -80,7 +81,17 @@ class WorkingMemoryPanel(private val project: Project) : JPanel(BorderLayout()) 
                             val key = json.get("key")?.asString
                             val excluded = json.get("excluded")?.asBoolean ?: false
                             if (kind != null && key != null) {
-                                SwingUtilities.invokeLater { handleToggleExclude(kind, key, excluded) }
+                                // Pooled, NOT the EDT: the store this writes is now reached
+                                // over the ide-bridge, so a click costs a daemon round trip
+                                // (and a cold spawn's couple of seconds when none is warm).
+                                // `handleToggleExclude` touches no Swing directly — every
+                                // refresh it triggers re-pools and hops back via
+                                // invokeLater itself. Same reasoning as the first load in
+                                // createContent(); `commitMemory` stays on the EDT because
+                                // it opens dialogs.
+                                ApplicationManager.getApplication().executeOnPooledThread {
+                                    handleToggleExclude(kind, key, excluded)
+                                }
                             }
                         }
                     }
@@ -111,7 +122,16 @@ class WorkingMemoryPanel(private val project: Project) : JPanel(BorderLayout()) 
             b.component.isOpaque = true
             b.component.background = wmBg
             b.setPageBackgroundColor(wmBg.toCssHex())
-            b.loadHTML(buildHtml())
+            // First load goes through the same pooled thread as reload(): createContent()
+            // runs from init on the EDT, and buildHtml → gatherView makes several
+            // ide-bridge round trips (active conversations, exclusions, active skills).
+            // Doing them inline froze the EDT for as long as the daemon took to answer —
+            // up to a cold spawn's couple of seconds. The themed background above is what
+            // makes the brief pre-content moment invisible rather than a white flash.
+            ApplicationManager.getApplication().executeOnPooledThread {
+                val html = buildHtml()
+                SwingUtilities.invokeLater { b.loadHTML(html) }
+            }
             b.component
         } catch (e: Exception) {
             LOG.info("JCEF unavailable for Working Memory: ${e.message}")
@@ -260,10 +280,37 @@ class WorkingMemoryPanel(private val project: Project) : JPanel(BorderLayout()) 
         )
     }
 
-    /** Flips a working-memory item's commit-selection exclusion, then refreshes. */
+    /**
+     * Flips a working-memory item's commit-selection exclusion, then refreshes.
+     *
+     * Must be called OFF the EDT — every branch below makes at least one ide-bridge
+     * round trip. It touches no Swing itself, so that is safe: `reload()` and both
+     * panel `refresh()`es re-pool and hop back through `invokeLater` on their own.
+     */
     private fun handleToggleExclude(kind: String, key: String, excluded: Boolean) {
         try {
-            CommitSelectionStore.setExcluded(cwd, kind, key, excluded)
+            if (kind == "skills") {
+                // The aggregate row carries no key, so the keys come from the registry.
+                // All of them in one write: the row has no per-skill affordance, so
+                // leaving any behind would strand it in a state the user cannot see.
+                val keys = SkillsProjection.readActive(cwd).exclusionKeys
+                // Empty is never a legitimate "nothing to do" here — this row is only
+                // drawn when skills were captured. It means either the read failed
+                // (`readActive` degrades to empty instead of throwing, so the catch
+                // below cannot see it) or a commit in another window archived them
+                // between render and click. Either way `setAllExcluded` would rewrite
+                // the file unchanged and report ok, so the click would disappear with
+                // nothing in the log to explain it. Skip the pointless write but still
+                // fall through to the refresh, which resyncs the checkbox or drops the
+                // stale row.
+                if (keys.isEmpty()) {
+                    LOG.warn("toggleExclude skills: no active skills resolved; leaving selection unchanged")
+                } else {
+                    CommitSelectionStore.setAllExcluded(cwd, kind, keys, excluded)
+                }
+            } else {
+                CommitSelectionStore.setExcluded(cwd, kind, key, excluded)
+            }
         } catch (e: Exception) {
             LOG.warn("toggleExclude failed: ${e.message}")
             return
@@ -282,7 +329,8 @@ class WorkingMemoryPanel(private val project: Project) : JPanel(BorderLayout()) 
         svc.panelRegistry?.let { reg ->
             when (kind) {
                 "conversations" -> reg.activeConversationsPanel?.refresh()
-                else -> reg.plansPanel?.refresh() // plans / notes / references live in the CONTEXT (Plans) panel
+                // plans / notes / references / skills all live in the CONTEXT (Plans) panel
+                else -> reg.plansPanel?.refresh()
             }
         }
     }
@@ -363,6 +411,20 @@ class WorkingMemoryPanel(private val project: Project) : JPanel(BorderLayout()) 
             }
             registry.references?.forEach { (mapKey, r) ->
                 out.add(WmContext(referenceTag(r.source), r.title, "references", mapKey, mapKey in exclusions.references))
+            }
+            // ONE aggregate row for every captured skill, matching the sidebar CONTEXT
+            // list and VS Code. Not read off `registry.skills`: a skill row survives
+            // archival (guarded, not deleted, so a re-entry is still detectable), so the
+            // raw map would list every skill ever used as if it were pending. The CLI
+            // decides which are still uncommitted and reports the delta.
+            //
+            // The key is empty — see [WmContext]. It reads as excluded only when EVERY
+            // captured skill is, so a partial set shows as included and the next click
+            // excludes the remainder.
+            val skills = SkillsProjection.readActive(cwd)
+            if (!skills.isEmpty) {
+                val allExcluded = skills.exclusionKeys.all { it in exclusions.skills }
+                out.add(WmContext("S", skills.summaryLabel, "skills", "", allExcluded))
             }
         } catch (_: Exception) {
             // best-effort

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/WorkingMemoryHtmlBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/WorkingMemoryHtmlBuilder.kt
@@ -43,9 +43,13 @@ object WorkingMemoryHtmlBuilder {
     )
 
     /**
-     * A linked context item (plan / note / reference). `tag` is the kb glyph;
-     * [kind] is the commit-selection kind (`plans` / `notes` / `references`) and
-     * [key] its selection key (slug / id / mapKey).
+     * A linked context item (plan / note / reference / the aggregate skills row).
+     * `tag` is the kb glyph; [kind] is the commit-selection kind (`plans` / `notes` /
+     * `references` / `skills`) and [key] its selection key (slug / id / mapKey).
+     *
+     * [key] is EMPTY for `skills`, and the toggle handler must recognise that: one row
+     * stands for every captured skill, so there is no single key to carry and the
+     * handler expands the write to all of them.
      */
     data class WmContext(
         val tag: String,
@@ -258,7 +262,7 @@ object WorkingMemoryHtmlBuilder {
 
     private fun contextPanel(v: WorkingMemoryView): String {
         val rows = if (v.context.isEmpty()) {
-            emptyRow("No linked plans, notes, or references.")
+            emptyRow("No linked plans, notes, references, or skills.")
         } else {
             v.context.joinToString("") { c ->
                 """

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/SkillsProjectionTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/SkillsProjectionTest.kt
@@ -1,0 +1,169 @@
+package ai.jolli.jollimemory.core
+
+import com.google.gson.Gson
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the Gson wire mapping of the `skills-active` response.
+ *
+ * [SkillsProjection] is the ONLY skill surface IntelliJ has, and nothing else in this
+ * repo can see a break in it: the CLI suite tests `SkillProjection.ts` against its own
+ * TypeScript types, and the VS Code suite imports those types directly. The Kotlin
+ * mirror is hand-written, and Gson resolves fields by name at runtime — a rename on
+ * either side compiles clean and silently leaves the field at its default, which for
+ * this DTO means a skill row that renders as an unnamed zero-invocation entry, or an
+ * aggregate checkbox that writes an empty key list.
+ *
+ * Follows the precedent of `TypesTest.GsonRoundTrip`, which pins the same hazard for
+ * `CommitSummary.skills` / `PlansRegistry.skills`. The payloads below are shaped like
+ * the real bridge response — including the three members the CLI sends and this DTO
+ * deliberately does not declare (`kind`, `entryPaths`, `sourcePath`).
+ */
+class SkillsProjectionTest {
+
+    private val gson = Gson()
+
+    /** One full row as `toActiveSkill` in `SkillProjection.ts` emits it. */
+    private val fullResponse = """
+        {"skills":[
+          {"kind":"skill","mapKey":"claude:superpowers:brainstorming","source":"claude",
+           "skill":"superpowers:brainstorming","plugin":"superpowers","entryPaths":["tool"],
+           "invocationCount":3,"firstUsedAt":"2026-07-31T09:00:00Z","lastUsedAt":"2026-07-31T09:30:00Z",
+           "usage":{"input":79,"output":33944,"cached":59796,"confidence":"attributed"},
+           "sourcePath":"/p/.jolli/jollimemory/skills/claude/s.md","detection":"heuristic",
+           "lastModified":"2026-07-31T09:30:00Z"}
+        ],"summaryLabel":"1 skill · 1.0k tokens"}
+    """.trimIndent()
+
+    @Nested
+    inner class ActiveSkillsMapping {
+
+        @Test
+        fun `every declared field of a full skills-active row lands`() {
+            val parsed = gson.fromJson(fullResponse, SkillsProjection.ActiveSkills::class.java)
+
+            parsed.summaryLabel shouldBe "1 skill · 1.0k tokens"
+            parsed.isEmpty shouldBe false
+
+            val skill = parsed.skills.single()
+            skill.mapKey shouldBe "claude:superpowers:brainstorming"
+            skill.source shouldBe "claude"
+            skill.skill shouldBe "superpowers:brainstorming"
+            skill.plugin shouldBe "superpowers"
+            skill.invocationCount shouldBe 3
+            skill.firstUsedAt shouldBe "2026-07-31T09:00:00Z"
+            skill.lastUsedAt shouldBe "2026-07-31T09:30:00Z"
+            skill.usage?.input shouldBe 79
+            skill.usage?.output shouldBe 33944
+            skill.usage?.cached shouldBe 59796
+            skill.usage?.confidence shouldBe "attributed"
+            skill.detection shouldBe "heuristic"
+            skill.lastModified shouldBe "2026-07-31T09:30:00Z"
+        }
+
+        /**
+         * The aggregate checkbox writes exactly this list. A `mapKey` rename would leave
+         * it a list of empty strings rather than fail, and `setAllExcluded` would happily
+         * persist those — so the values matter, not just the count.
+         */
+        @Test
+        fun `exclusionKeys are the mapKeys in response order`() {
+            val json = """
+                {"skills":[{"mapKey":"claude:a","lastModified":"2026-07-31T09:30:00Z"},
+                           {"mapKey":"codex:b","lastModified":"2026-07-31T09:00:00Z"}],
+                 "summaryLabel":"2 skills"}
+            """.trimIndent()
+
+            gson.fromJson(json, SkillsProjection.ActiveSkills::class.java)
+                .exclusionKeys shouldBe listOf("claude:a", "codex:b")
+        }
+
+        /**
+         * `usage` absent must stay absent. The CLI omits the member when the source
+         * could not attribute tokens, and the table renders an em-dash for it — a
+         * zero-valued `SkillUsage` here would report that the skill spent nothing.
+         */
+        @Test
+        fun `an omitted usage stays null rather than becoming a zero`() {
+            val json = """
+                {"skills":[{"mapKey":"codex:x","source":"codex","skill":"x",
+                 "invocationCount":1,"lastModified":"2026-07-31T09:00:00Z"}],"summaryLabel":"1 skill"}
+            """.trimIndent()
+
+            gson.fromJson(json, SkillsProjection.ActiveSkills::class.java).skills.single().usage.shouldBeNull()
+        }
+
+        @Test
+        fun `anyInferred tracks the heuristic detection marker`() {
+            fun responseWith(detection: String) = """
+                {"skills":[{"mapKey":"codex:x","detection":$detection,
+                 "lastModified":"2026-07-31T09:00:00Z"}],"summaryLabel":"1 skill"}
+            """.trimIndent()
+
+            gson.fromJson(responseWith("\"heuristic\""), SkillsProjection.ActiveSkills::class.java)
+                .anyInferred shouldBe true
+            // Omitted entirely — an observed invocation. The label must not claim inference.
+            val observed = """
+                {"skills":[{"mapKey":"codex:x","lastModified":"2026-07-31T09:00:00Z"}],"summaryLabel":"1 skill"}
+            """.trimIndent()
+            gson.fromJson(observed, SkillsProjection.ActiveSkills::class.java).anyInferred shouldBe false
+        }
+    }
+
+    /**
+     * The declared defaults only apply because EVERY constructor parameter of these
+     * three data classes has one, which is what makes Kotlin emit a synthetic no-arg
+     * constructor for Gson to call. Add one parameter without a default and Gson falls
+     * back to `Unsafe` allocation instead: every default silently stops applying, and
+     * the non-null `String` fields come back as `null` to blow up at first use. These
+     * cases fail the moment that happens.
+     */
+    @Nested
+    inner class DefaultsSurviveDeserialisation {
+
+        @Test
+        fun `a sparse row falls back to declared defaults`() {
+            val json = """{"skills":[{"mapKey":"claude:a"}],"summaryLabel":"1 skill"}"""
+
+            val skill = gson.fromJson(json, SkillsProjection.ActiveSkills::class.java).skills.single()
+            skill.mapKey shouldBe "claude:a"
+            skill.source shouldBe ""
+            skill.skill shouldBe ""
+            skill.lastModified shouldBe ""
+            skill.invocationCount shouldBe 0
+            skill.plugin.shouldBeNull()
+            skill.firstUsedAt.shouldBeNull()
+            skill.lastUsedAt.shouldBeNull()
+        }
+
+        @Test
+        fun `a sparse usage falls back to zeroed counters`() {
+            val json = """{"skills":[{"mapKey":"claude:a","usage":{}}],"summaryLabel":"1 skill"}"""
+
+            val usage = gson.fromJson(json, SkillsProjection.ActiveSkills::class.java).skills.single().usage
+            usage?.input shouldBe 0
+            usage?.output shouldBe 0
+            usage?.cached shouldBe 0
+            usage?.confidence.shouldBeNull()
+        }
+
+        /**
+         * `readActive` returns this shape on a response that carries neither member, and
+         * the aggregate checkbox calls `exclusionKeys` on it — so `skills` must be an
+         * empty list, never null.
+         */
+        @Test
+        fun `an empty response object yields empty skills rather than null`() {
+            val parsed = gson.fromJson("{}", SkillsProjection.ActiveSkills::class.java)
+
+            parsed.skills shouldBe emptyList()
+            parsed.summaryLabel shouldBe ""
+            parsed.isEmpty shouldBe true
+            parsed.exclusionKeys shouldBe emptyList()
+            parsed.anyInferred shouldBe false
+        }
+    }
+}

--- a/vscode/src/Types.ts
+++ b/vscode/src/Types.ts
@@ -141,15 +141,10 @@ export type {
 	SourceId,
 } from "../../cli/src/Types.js";
 
-// Import for use in NoteInfo / ReferenceInfo / SkillInfo
-import type {
-	NoteFormat,
-	ReferenceField,
-	SkillEntryPath,
-	SkillSource,
-	SkillUsage,
-	SourceId,
-} from "../../cli/src/Types.js";
+// Import for use in NoteInfo / ReferenceInfo
+import type { NoteFormat, ReferenceField, SourceId } from "../../cli/src/Types.js";
+// The skill row's shape lives with the projection that builds it — see SkillInfo below.
+import type { ActiveSkill } from "../../cli/src/core/skills/SkillProjection.js";
 
 /** Display-level note metadata for the VSCode tree view */
 export interface NoteInfo {
@@ -179,29 +174,12 @@ export interface NoteInfo {
 /**
  * Panel-display projection of a captured skill usage row.
  *
- * `lastModified` mirrors `lastUsedAt` so a skill sorts against plans / notes /
- * references in one list, the same way ReferenceInfo mirrors `updatedAt`.
+ * An ALIAS, not a declaration: the same rows are served to IntelliJ over the
+ * `skills-active` ide-bridge operation, so the shape belongs next to the projection
+ * that builds it. Re-declaring it here would let the two drift silently — a field
+ * this panel reads could disappear from the projection and still typecheck.
  */
-export interface SkillInfo {
-	readonly kind: "skill";
-	/** plans.json.skills map key — `<source>:<skill>`. */
-	readonly mapKey: string;
-	readonly source: SkillSource;
-	/** Fully-qualified skill id, e.g. `superpowers:brainstorming`. */
-	readonly skill: string;
-	readonly plugin?: string;
-	readonly entryPaths: ReadonlyArray<SkillEntryPath>;
-	readonly invocationCount: number;
-	readonly firstUsedAt: string;
-	readonly lastUsedAt: string;
-	/** Absent when the source could not attribute tokens — never rendered as a zero. */
-	readonly usage?: SkillUsage;
-	readonly sourcePath: string;
-	/** Present when the invocation was inferred rather than observed (Codex). */
-	readonly detection?: "heuristic";
-	/** ISO 8601 — same as lastUsedAt, for sort consistency with the other kinds. */
-	readonly lastModified: string;
-}
+export type SkillInfo = ActiveSkill;
 
 export interface ReferenceInfo {
 	readonly kind: "reference";

--- a/vscode/src/core/SkillService.ts
+++ b/vscode/src/core/SkillService.ts
@@ -1,82 +1,22 @@
 /**
  * SkillService — panel read path for captured skill usage.
  *
- * Reads `plans.json.skills` and projects the active rows into {@link SkillInfo}
- * for the Context list.
+ * A thin delegate: the projection itself lives in the CLI, as
+ * {@link projectActiveSkills}. It moved there because the IntelliJ plugin needs the
+ * same rows and reaches them over the `skills-active` ide-bridge operation, and a
+ * second copy of the uncommitted-delta rule is exactly what drifted out of sync
+ * once already and hid every re-used skill from this panel. Read that module's
+ * header for why the rows are filtered and why the counters come from the delta
+ * rather than the registry row.
  *
- * **Unlike references, this MUST filter.** A reference row is deleted when its
- * commit lands, so every row in the registry is by definition uncommitted and
- * `detectReferences` can return all of them. A skill row is GUARDED instead —
- * archival leaves the row in place so a later re-entry can be detected. Returning
- * every row would put every skill ever used back on the panel as if it were fresh
- * working state.
- *
- * The predicate is {@link uncommittedDelta}, imported from the CLI rather than
- * restated here. It is NOT the plan/note guard check: a plan is archived once and
- * finished, while a skill can be entered again afterwards and its row keeps
- * accumulating, so "uncommitted" is the counters moving past the archived baseline.
- * A local copy of that rule drifted out of sync once already and hid every re-used
- * skill from this panel.
- *
- * The delta is also what gets PROJECTED, not just what decides visibility. This panel
- * previews what the next commit will carry, and `storeSkills` archives
- * `uncommittedDelta`'s figures — so showing the row's running total would overstate a
- * re-used skill by everything already frozen onto earlier commits.
+ * The file survives so the panel keeps importing `detectSkills` under the name the
+ * rest of the extension already uses.
  */
 
-import { loadPlansRegistry } from "../../../cli/src/core/SessionTracker.js";
-import { uncommittedDelta } from "../../../cli/src/core/skills/SkillDelta.js";
-import type { SkillArchivedTotals, SkillEntry } from "../../../cli/src/Types.js";
+import { projectActiveSkills } from "../../../cli/src/core/skills/SkillProjection.js";
 import type { SkillInfo } from "../Types.js";
-import { log } from "../util/Logger.js";
 
 /** Active (usage no commit has claimed) skills, newest first. */
-export async function detectSkills(cwd: string): Promise<ReadonlyArray<SkillInfo>> {
-	const registry = await loadPlansRegistry(cwd);
-	const skills = registry.skills ?? {};
-
-	const result: SkillInfo[] = [];
-	for (const [mapKey, entry] of Object.entries(skills)) {
-		const delta = uncommittedDelta(entry);
-		if (delta === undefined) continue;
-		result.push(toSkillInfo(mapKey, entry, delta));
-	}
-
-	result.sort((a, b) => new Date(b.lastModified).getTime() - new Date(a.lastModified).getTime());
-	log.info("skills", `detectSkills found ${result.length} active (${Object.keys(skills).length} in registry)`);
-	return result;
-}
-
-/**
- * Project one row, with the COUNTERS taken from `delta` rather than the row.
- *
- * The row accumulates for the skill's whole life; `delta` is the part no commit has
- * claimed. Those agree only until a skill is entered a second time, after which the
- * row reports work that is already committed — so the figures here would disagree
- * with the ones `storeSkills` is about to archive, and the memory preview would
- * overstate the pending commit.
- *
- * The timestamps deliberately still come from the row. `SkillArchivedTotals` carries
- * no time fields, and `storeSkills` likewise stamps its ref from `entry.firstUsedAt`
- * / `entry.lastUsedAt` — so reading them from the row is what keeps this in parity
- * with the committed record, not a leak of the same kind.
- */
-function toSkillInfo(mapKey: string, entry: SkillEntry, delta: SkillArchivedTotals): SkillInfo {
-	return {
-		kind: "skill",
-		mapKey,
-		source: entry.source,
-		skill: entry.skill,
-		...(entry.plugin !== undefined ? { plugin: entry.plugin } : {}),
-		entryPaths: entry.entryPaths,
-		invocationCount: delta.invocationCount,
-		firstUsedAt: entry.firstUsedAt,
-		lastUsedAt: entry.lastUsedAt,
-		// Absent stays absent: a source that cannot attribute tokens must not be
-		// rendered as having spent zero.
-		...(delta.usage !== undefined ? { usage: delta.usage } : {}),
-		...(entry.detection !== undefined ? { detection: entry.detection } : {}),
-		sourcePath: entry.sourcePath,
-		lastModified: entry.lastUsedAt,
-	};
+export function detectSkills(cwd: string): Promise<ReadonlyArray<SkillInfo>> {
+	return projectActiveSkills(cwd);
 }


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Quick recap

The IntelliJ plugin now displays captured skills in its memory panels: the working-memory view, the context list, and committed memory details each show an aggregate skills row, with the per-skill breakdown one click away. IntelliJ and VS Code both read skill data from one shared module in the command-line tool, and the two editors present identical tables, labels, and exclusion behavior. The plugin's selection store now delegates its file writes to the command-line tool, keeping the persisted selection data complete across all editors.

Two review passes over the pending work fixed ten issues. A checkbox click in the working-memory panel could freeze the interface for up to two seconds while the background daemon answered; those clicks now run off the UI thread, and the panel's first load does the same. New tests brought the shared skill logic from zero coverage to fully covered, and the suite now pins the selection file's backward-compatible response shape. The second pass verified everything with a real build — 789 plugin tests and the full cross-project gate all pass — and separated two failure modes that had been conflated: a stopped daemon now shows an explicit error message, and the context panel's empty state says where the skills went. Users clicking a skills row see accurate information whether the background service is running or not.

---

## Topics (3)
<details>
<summary><strong>01 · Second review pass: build-verified fixes for skills error handling</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The user asked for a second review to confirm the previous round's fixes had landed and to look for any new problems before shipping.

**💡 Decisions Behind the Code**

- **Error honesty over silent degradation**: For the rendered tables, a bridge failure used to be indistinguishable from "no skills recorded" — both came back as empty, and both callers turned empty into a sentence asserting a fact about the memory. The panels now surface the failure explicitly, because a wrong-but-confident answer was worse than an honest error, especially since the committed-memory row is drawn from data the panel had already read off disk and would have contradicted.
- **Documenting reality instead of inventing error UX**: The store's documentation was corrected to admit that failed writes currently reach only the log file, rather than claiming they surface errors or bolting on a half-built mechanism. Choosing a real feedback path — a toast, reverting the checkbox, or a retry — is a product decision, not a cleanup, so it was explicitly left open.

**✅ What Was Implemented**

- Verified the entire change set with a real build for the first time: a JDK was found on the machine, the IntelliJ plugin now compiles cleanly and its 789 tests pass, and the full CLI/VS Code gate exits 0 — the previous round's fixes, which had only been checked by inspection, are now confirmed by actual compilation and test runs.
- Separated two failure modes that had been conflated in skills table rendering (SkillsProjection.kt, CommitsPanel.kt, PlansPanel.kt): a bridge that cannot answer now throws and the panels show an explicit "could not render" message, while a genuinely empty result still shows "no archived skill usage" — a stopped daemon no longer reads as a memory with no skills.
- Reworded the context panel's empty-state message to say where the skills went (archived on the latest memory) instead of claiming none were captured, and corrected the selection store's documentation to state plainly that failed writes are currently silent.

**📋 Future Enhancements**

- A product decision is still open on how failed selection writes should surface to the user (toast, checkbox revert, or retry) — writes currently fail silently in the logs.
- The bridge request parser does not validate the selection kind; a malformed request could corrupt exclusion state. Unreachable from shipped hosts, but the sibling validator in the same file is the precedent for tightening it.
- Two select-all handlers in the context panels are dead code with no callers; pre-existing, and the skills change did not make them reachable.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/SkillsProjection.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/CommitsPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PlansPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/CommitSelectionStore.kt`

</blockquote>
</details>
<details>
<summary><strong>02 · First review pass: freeze, gate, and test coverage fixes</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The user asked for a full code review of the pending skills work, fixing anything that would not change existing behavior.

**💡 Decisions Behind the Code**

- **Keep bridge round trips off the UI thread**: Every checkbox click that touches the selection store now costs a daemon round trip, and a cold start can take up to two seconds. Pooling the work keeps the interface responsive, and it is safe because the handlers touch no UI state directly — every refresh re-pools and hops back through the UI thread itself.
- **Test the shared surface where it is the only surface**: IntelliJ renders no skill table of its own, so these bridge operations are its entire skill surface and a break there is invisible to the VS Code suite — making CLI tests the only safety net. The tests run against a real registry on disk rather than a mock, so a projection that disagrees with what the serializer actually writes fails instead of shipping an empty panel.
- **One formatting source of truth**: Token totals are formatted with a fixed locale so the hover card agrees with the table one click away; the ambient locale would render "93,8k" next to "93.8k" on comma-decimal systems.

**✅ What Was Implemented**

- Fixed the red gate: the selection-read bridge response now always carries the skills key as an empty array for selection files written before skills existed, and new tests pin that backward-compatible contract (IdeBridgeCommand.test.ts).
- Fixed an interface freeze: exclusion checkbox clicks in the working-memory panel ran on the UI thread and blocked it for up to a cold daemon spawn's couple of seconds on every round trip; the handler and the panel's first load now run on a pooled thread (WorkingMemoryPanel.kt).
- Closed the test gap: added SkillProjection.test.ts (9 cases against a real temp registry) plus 8 cases for the skills-* bridge operations, taking SkillProjection.ts from 0% to 100% coverage and IdeBridgeCommand.ts to 98%+; also switched token formatting to a fixed locale so the hover card matches the table one click away, gated unknown skills-* operations before any registry read, and collapsed per-row exclusion writes into one bulk write.

**📁 FILES**
- `cli/src/commands/IdeBridgeCommand.ts`
- `cli/src/core/skills/SkillProjection.ts`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/WorkingMemoryPanel.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PlansPanel.kt`

</blockquote>
</details>
<details>
<summary><strong>03 · IntelliJ skills surface over a shared command-line bridge</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The IntelliJ plugin rendered no skill surface at all — skills were captured and archived by the command-line tool and shown only in VS Code — so the plugin needed a way to read and render the same data, and VS Code's own skill view had drifted out of sync with the archive logic once before.

**💡 Decisions Behind the Code**

- **One shared projection instead of two hand-written views**: The uncommitted-skill rule had been hand-copied into VS Code before and drifted, hiding every re-used skill from the panel. Moving it into the CLI gives both editors one copy, so a correction lands in both at once — the rule that decides which rows are still uncommitted and the delta figures reported for them live in exactly one place.
- **Delegation over porting the file format**: The Kotlin selection store rewrote the shared selection file from the fields it knew about, silently destroying the relevance ranker's verdicts and any skill exclusions set from VS Code. Routing writes through the CLI's own serializer fixes that class of bug by construction — a field added to the format can no longer be dropped by a host that never heard of it.
- **Degrade to empty, never to null**: The Kotlin models give every field a default value so a field the CLI stops sending reads as empty rather than crashing, and the computed helper properties have no backing fields for Gson to touch — verified against the compiled classes, where the synthetic no-arg constructors confirm Kotlin defaults apply.

**✅ What Was Implemented**

- Moved the skill projection out of the VS Code extension into a shared CLI module (cli/src/core/skills/SkillProjection.ts) and added four skills-* bridge operations (skills-active, skills-live-markdown, skills-label, skills-committed-markdown) so IntelliJ consumes the exact same rows, labels, and tables as VS Code.
- Rewrote the IntelliJ selection store as a thin bridge adapter: the old Kotlin writer rebuilt the selection file from the four kinds it knew about, silently dropping the relevance ranker's data and skill exclusions it had never heard of; delegation gives the CLI sole ownership of the file format (CommitSelectionStore.kt, SkillsProjection.kt).
- Added the IntelliJ UI surface: an aggregate skills row — one row per session with the per-skill breakdown one click away — in the working-memory view, the context list, and committed memory details, plus the shared badge color, and changed the VS Code skill service into a thin delegate to the shared projection.

**📁 FILES**
- `cli/src/core/skills/SkillProjection.ts`
- `cli/src/commands/IdeBridgeCommand.ts`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/CommitSelectionStore.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/SkillsProjection.kt`
- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/PlansPanel.kt`

</blockquote>
</details>

---

*Generated by JolliMemory · August 6, 2026 at 7:55 PM · via local-agent*
<!-- jollimemory-summary-end -->