### PR TITLE
Replace batch push with per-commit async push orchestration

### DIFF
--- a/cli/src/core/JolliMemoryPushClient.test.ts
+++ b/cli/src/core/JolliMemoryPushClient.test.ts
@@ -7,8 +7,6 @@ const loadConfigMock = vi.fn(async () => ({ jolliApiKey: "sk-jol-cfg" }) as { jo
 vi.mock("./SessionTracker.js", () => ({ loadConfig: () => loadConfigMock() }));
 
 import {
-	type BatchPushPayload,
-	BatchUnsupportedError,
 	BindingAlreadyExistsError,
 	BindingRequiredError,
 	ClientOutdatedError,
@@ -536,6 +534,22 @@ describe("push", () => {
 		).rejects.toMatchObject({
 			name: "PermissionDeniedError",
 			message: "Ask an administrator to add this repo to the Space.",
+		});
+	});
+	// Same 412 status as the allowlist refusal above, but a DIFFERENT class on
+	// purpose: this one is not a repo-wide refusal, so one unconfigured context
+	// kind must not abort the whole attachment loop. Covered here because the
+	// batch parser that used to exercise `doctype_not_allowed` is gone.
+	it("maps 412 doctype_not_allowed to DocTypeNotAllowedError carrying the docType", async () => {
+		const c = client(async () =>
+			jsonResponse(412, { error: "doctype_not_allowed", message: 'docType "skill" is not enabled' }),
+		);
+		await expect(
+			c.push({ title: "t", content: "c", commitHash: "abc1234", docType: "skill" }),
+		).rejects.toMatchObject({
+			name: "DocTypeNotAllowedError",
+			docType: "skill",
+			message: 'docType "skill" is not enabled',
 		});
 	});
 	it("maps 426 to ClientOutdatedError", async () => {
@@ -1136,230 +1150,5 @@ describe("invokePlatformTool", () => {
 		expect(capturedMethod).toBe("POST");
 		expect(capturedUrl).toBe("https://jolli.ai/api/mcp/tools/list_tickets");
 		expect(capturedBody).toBe(JSON.stringify({ status: "open" }));
-	});
-});
-
-describe("pushBatch", () => {
-	const payload: BatchPushPayload = {
-		repoUrl: "https://github.com/acme/repo",
-		items: [
-			{
-				commitHash: "a".repeat(40),
-				branch: "main",
-				summary: { title: "feat: one", content: "# body" },
-				attachments: [],
-			},
-		],
-	};
-
-	it("returns validated per-item results on 200", async () => {
-		const c = client(async () =>
-			jsonResponse(200, {
-				results: [
-					{
-						commitHash: "a".repeat(40),
-						ok: true,
-						summary: { docId: 9, url: "/articles/one-9", jrn: "jrn:9", created: true },
-						attachments: [{ clientKey: "plan-0", ok: true, docId: 10, url: "/articles/p-10" }],
-					},
-				],
-			}),
-		);
-		const r = await c.pushBatch(payload);
-		expect(r.results).toHaveLength(1);
-		expect(r.results[0]).toMatchObject({ commitHash: "a".repeat(40), ok: true });
-		expect(r.results[0].summary).toEqual({ docId: 9, url: "/articles/one-9", jrn: "jrn:9", created: true });
-		expect(r.results[0].attachments[0]).toMatchObject({ clientKey: "plan-0", ok: true, docId: 10 });
-		// Older servers echo no Space — the field is simply absent.
-		expect(r.jmSpace).toBeUndefined();
-	});
-
-	it("carries a failed attachment's machine-readable errorCode through the parser", async () => {
-		// Regression: the parser used to drop `errorCode`, which made the orchestrator's
-		// `doctype_not_allowed` branch dead code in production while unit tests that
-		// hand-built an already-parsed result still passed. This asserts from the RAW
-		// JSON on purpose — the parser is the thing under test.
-		const c = client(async () =>
-			jsonResponse(200, {
-				results: [
-					{
-						commitHash: "a".repeat(40),
-						ok: true,
-						summary: { docId: 9, url: "/articles/one-9", jrn: "jrn:9", created: true },
-						attachments: [
-							{
-								clientKey: "skill-0",
-								ok: false,
-								error: 'docType "skill" is not enabled',
-								errorCode: "doctype_not_allowed",
-							},
-						],
-					},
-				],
-			}),
-		);
-		const r = await c.pushBatch(payload);
-		expect(r.results[0].attachments[0]).toMatchObject({
-			clientKey: "skill-0",
-			ok: false,
-			errorCode: "doctype_not_allowed",
-		});
-	});
-
-	it("omits errorCode when the server sends none (older servers)", async () => {
-		const c = client(async () =>
-			jsonResponse(200, {
-				results: [
-					{
-						commitHash: "a".repeat(40),
-						ok: true,
-						summary: { docId: 9, url: "/articles/one-9", jrn: "jrn:9", created: true },
-						attachments: [{ clientKey: "plan-0", ok: false, error: "boom" }],
-					},
-				],
-			}),
-		);
-		const r = await c.pushBatch(payload);
-		expect(r.results[0].attachments[0].errorCode).toBeUndefined();
-		expect(r.results[0].attachments[0].error).toBe("boom");
-	});
-
-	it("passes the top-level jmSpace echo through on a 200", async () => {
-		const c = client(async () =>
-			jsonResponse(200, {
-				results: [
-					{
-						commitHash: "a".repeat(40),
-						ok: true,
-						summary: { docId: 9, url: "/articles/one-9", jrn: "jrn:9", created: true },
-						attachments: [],
-					},
-				],
-				jmSpace: { id: 7, name: "Acme Core" },
-			}),
-		);
-		const r = await c.pushBatch(payload);
-		expect(r.jmSpace).toEqual({ id: 7, name: "Acme Core" });
-	});
-
-	it("drops a malformed top-level jmSpace echo instead of poisoning the binding cache", async () => {
-		const c = client(async () =>
-			jsonResponse(200, {
-				results: [
-					{
-						commitHash: "a".repeat(40),
-						ok: true,
-						summary: { docId: 9, url: "/articles/one-9", jrn: "jrn:9", created: true },
-						attachments: [],
-					},
-				],
-				jmSpace: { id: "7", name: "" },
-			}),
-		);
-		const r = await c.pushBatch(payload);
-		expect(r.jmSpace).toBeUndefined();
-	});
-
-	it("downgrades an ok:true attachment without docId/url to a failure (contract drift guard)", async () => {
-		const c = client(async () =>
-			jsonResponse(200, {
-				results: [
-					{
-						commitHash: "a".repeat(40),
-						ok: true,
-						summary: { docId: 9, url: "/articles/one-9", jrn: "jrn:9", created: true },
-						attachments: [
-							{ clientKey: "plan-0", ok: true },
-							{ clientKey: "note-0", ok: true, docId: 12 },
-						],
-					},
-				],
-			}),
-		);
-		const r = await c.pushBatch(payload);
-		expect(r.results[0].attachments).toEqual([
-			{ clientKey: "plan-0", ok: false, error: "Batch attachment result was missing docId/url" },
-			{ clientKey: "note-0", ok: false, error: "Batch attachment result was missing docId/url" },
-		]);
-	});
-
-	it("maps 404 to BatchUnsupportedError (server predates the endpoint)", async () => {
-		const c = client(async () => jsonResponse(404, { error: "Not found" }));
-		await expect(c.pushBatch(payload)).rejects.toBeInstanceOf(BatchUnsupportedError);
-	});
-
-	it("maps 426 to ClientOutdatedError", async () => {
-		const c = client(async () => jsonResponse(426, { error: "client_outdated" }));
-		await expect(c.pushBatch(payload)).rejects.toBeInstanceOf(ClientOutdatedError);
-	});
-
-	it("maps 412 binding_required to BindingRequiredError carrying the repoUrl", async () => {
-		const c = client(async () =>
-			jsonResponse(412, { error: "binding_required", repoUrl: "https://github.com/acme/repo" }),
-		);
-		await expect(c.pushBatch(payload)).rejects.toBeInstanceOf(BindingRequiredError);
-	});
-
-	it("maps 412 repo_not_allowlisted to PermissionDeniedError (the allowlist refusal, NOT 403)", async () => {
-		const c = client(async () => jsonResponse(412, { error: "repo_not_allowlisted" }));
-		await expect(c.pushBatch(payload)).rejects.toBeInstanceOf(PermissionDeniedError);
-	});
-
-	it("maps 401 to NotAuthenticatedError", async () => {
-		const c = client(async () => jsonResponse(401, { error: "unauthorized" }));
-		await expect(c.pushBatch(payload)).rejects.toBeInstanceOf(NotAuthenticatedError);
-	});
-
-	it("maps 403 to PermissionDeniedError (signed in, but no space permission)", async () => {
-		const c = client(async () =>
-			jsonResponse(403, { error: "Insufficient space permissions", requiredPermission: "articles.edit" }),
-		);
-		await expect(c.pushBatch(payload)).rejects.toBeInstanceOf(PermissionDeniedError);
-	});
-
-	it("throws on a generic non-2xx with the server message", async () => {
-		const c = client(async () => jsonResponse(500, { error: "Batch push failed" }));
-		await expect(c.pushBatch(payload)).rejects.toThrow("Batch push failed");
-	});
-
-	it("rejects a 2xx whose body has no results array (gateway/HTML body)", async () => {
-		const c = client(async () => textResponse(200, "<html>gateway</html>"));
-		await expect(c.pushBatch(payload)).rejects.toThrow(/missing results/);
-	});
-
-	it("rejects a garbage result entry outright", async () => {
-		const c = client(async () => jsonResponse(200, { results: [42] }));
-		await expect(c.pushBatch(payload)).rejects.toThrow(/malformed/);
-	});
-
-	it("downgrades an ok item with unusable summary fields to a failure (never delete blind)", async () => {
-		const c = client(async () =>
-			jsonResponse(200, {
-				results: [{ commitHash: "a".repeat(40), ok: true, summary: { docId: "nope" }, attachments: [] }],
-			}),
-		);
-		const r = await c.pushBatch(payload);
-		expect(r.results[0].ok).toBe(false);
-		expect(r.results[0].errorCode).toBe("malformed_response");
-	});
-
-	it("keeps failed items with their error/errorCode and filters malformed attachments", async () => {
-		const c = client(async () =>
-			jsonResponse(200, {
-				results: [
-					{
-						commitHash: "a".repeat(40),
-						ok: false,
-						error: "boom",
-						errorCode: "push_failed",
-						attachments: [{ clientKey: "k", ok: false, error: "att boom" }, { bogus: true }],
-					},
-				],
-			}),
-		);
-		const r = await c.pushBatch(payload);
-		expect(r.results[0]).toMatchObject({ ok: false, error: "boom", errorCode: "push_failed" });
-		expect(r.results[0].attachments).toHaveLength(1);
-		expect(r.results[0].attachments[0]).toMatchObject({ clientKey: "k", ok: false, error: "att boom" });
 	});
 });

--- a/cli/src/core/JolliMemoryPushClient.ts
+++ b/cli/src/core/JolliMemoryPushClient.ts
@@ -16,13 +16,10 @@
  * VS Code `BindingInfo` type suggesting one.
  */
 
-import { createLogger } from "../Logger.js";
 import { JOLLI_CLIENT_HEADER } from "./ClientHeader.js";
 import { deriveJolliEnvKey, type JolliApiKeyMeta, parseBaseUrl, parseJolliApiKey } from "./JolliApiUtils.js";
 import { loadConfig } from "./SessionTracker.js";
 import { currentTraceHeader, newTraceHeader, TRACE_HEADER_NAME } from "./TraceContext.js";
-
-const log = createLogger("JolliMemoryPushClient");
 
 /** No `jolliApiKey` configured, or no Jolli URL could be resolved from it. */
 export class NotAuthenticatedError extends Error {
@@ -67,18 +64,6 @@ export class BindingRequiredError extends Error {
 		super(message ?? "binding_required");
 		this.name = "BindingRequiredError";
 		this.repoUrl = repoUrl;
-	}
-}
-
-/**
- * `POST /api/push/jollimemory/batch` returned 404 — the server predates the
- * batch endpoint. Callers leave their pending entries untouched (no retry
- * burn) so a later server deploy picks them up.
- */
-export class BatchUnsupportedError extends Error {
-	constructor(message?: string) {
-		super(message ?? "Jolli server does not support batch push yet");
-		this.name = "BatchUnsupportedError";
 	}
 }
 
@@ -362,7 +347,7 @@ interface PushResponseBody {
 }
 
 /**
- * Validates the optional Space echo of a push/pushBatch 2xx body field-by-field
+ * Validates the optional Space echo of a push 2xx body field-by-field
  * so a drifted shape degrades to "absent" rather than poisoning the caller's
  * binding cache.
  */
@@ -374,24 +359,18 @@ function parseJmSpaceEcho(
 		: undefined;
 }
 
-// ─── Batch push (POST /api/push/jollimemory/batch) ──────────────────────────
+// ─── Context attachment payload shape ───────────────────────────────────────
 
 /**
- * Max commits per batch request. MUST stay in lockstep with the server's
- * `BATCH_MAX_ITEMS` (`backend/src/router/PushRouter.ts`) — the server rejects
- * larger payloads with 400.
+ * One context attachment (plan/note/reference/skill/…) as assembled per commit.
+ *
+ * The batch endpoint that consumed these in bulk is gone (see the note in
+ * `PushExecutor`), so nothing here sends a `BatchPushAttachment` any more — the
+ * shape survives because `buildContextBatchAttachments` in `push/ContextPush.ts`
+ * still assembles one per registered kind, and its tests are what pin the
+ * per-kind title/body/docId-reuse rules the single-doc {@link push} path relies
+ * on. Keep it in sync with a kind definition's output, not with any request body.
  */
-export const BATCH_MAX_ITEMS = 30;
-
-/**
- * Remaining batch request limits. These MUST stay in lockstep with
- * `BatchPushRequestSchema` in the server's `PushRouter.ts`.
- */
-export const BATCH_MAX_ATTACHMENTS_PER_ITEM = 50;
-export const BATCH_MAX_CONTENT_CHARS = 2_000_000;
-export const BATCH_MAX_TOTAL_CONTENT_CHARS = 8_000_000;
-
-/** One attachment (plan/note/reference) inside a batch item. */
 export interface BatchPushAttachment {
 	readonly clientKey: string;
 	/** A context kind's `docType` — see the note on {@link PushPayload.docType} for why this is `string`. */
@@ -400,88 +379,6 @@ export interface BatchPushAttachment {
 	readonly content: string;
 	readonly relativePath?: string;
 	readonly docId?: number;
-}
-
-/** One commit's summary + owned attachments inside a batch payload. */
-export interface BatchPushItem {
-	readonly commitHash: string;
-	readonly branch?: string;
-	readonly summary: {
-		readonly title: string;
-		readonly content: string;
-		readonly relativePath?: string;
-		readonly docId?: number;
-		readonly summaryJson?: string;
-	};
-	readonly attachments: ReadonlyArray<BatchPushAttachment>;
-}
-
-/** Payload for `POST /api/push/jollimemory/batch`. */
-export interface BatchPushPayload {
-	readonly repoUrl?: string;
-	readonly items: ReadonlyArray<BatchPushItem>;
-}
-
-/** Per-attachment entry in a batch item result. */
-export interface BatchAttachmentResult {
-	readonly clientKey: string;
-	readonly ok: boolean;
-	readonly docId?: number;
-	readonly url?: string;
-	readonly jrn?: string;
-	readonly created?: boolean;
-	readonly error?: string;
-	/**
-	 * Machine-readable failure tag, mirroring the item-level `errorCode`.
-	 *
-	 * An attachment failure in a batch arrives as `ok: false` inside a 2xx body, so
-	 * there is no HTTP status to classify on — without a code the only signal is the
-	 * free-text `error`, which is too brittle to branch on. Absent on older servers,
-	 * in which case a failure degrades to "logged, skipped" exactly as before.
-	 */
-	readonly errorCode?: string;
-}
-
-/** Doc fields reported for a successfully pushed batch summary. */
-export interface BatchDocResult {
-	readonly docId: number;
-	readonly url: string;
-	readonly jrn: string;
-	readonly created: boolean;
-	readonly summaryJsonDocId?: number;
-}
-
-/** Per-item (= per-commit) entry of the batch response, in request order. */
-export interface BatchItemResult {
-	readonly commitHash: string;
-	readonly ok: boolean;
-	readonly summary?: BatchDocResult;
-	readonly attachments: ReadonlyArray<BatchAttachmentResult>;
-	readonly error?: string;
-	readonly errorCode?: string;
-}
-
-/** Validated response of `POST /api/push/jollimemory/batch`. */
-export interface BatchPushResult {
-	readonly results: ReadonlyArray<BatchItemResult>;
-	/**
-	 * The bound Space the batch landed in, echoed once at the top level by
-	 * newer servers on repoUrl-routed pushes (the server resolves the binding
-	 * and checks push rights before processing any item, so the echo holds even
-	 * when individual items fail). Callers persist it as the local binding
-	 * cache (`SpaceBindingCache`). Absent on older servers and on legacy
-	 * default-space pushes.
-	 */
-	readonly jmSpace?: { readonly id: number; readonly name: string };
-}
-
-/** Raw shape of `POST /api/push/jollimemory/batch` — validated entry-by-entry. */
-interface BatchPushResponseBody {
-	readonly results?: unknown;
-	readonly jmSpace?: { readonly id?: unknown; readonly name?: unknown };
-	readonly error?: string;
-	readonly message?: string;
-	readonly repoUrl?: string;
 }
 
 export class JolliMemoryPushClient {
@@ -687,68 +584,6 @@ export class JolliMemoryPushClient {
 	}
 
 	/**
-	 * Pushes up to {@link BATCH_MAX_ITEMS} commits (one summary + its owned
-	 * plans/notes/references each) in a single `POST /api/push/jollimemory/batch`
-	 * request. Whole-request error taxonomy mirrors {@link push}; 404 maps to
-	 * {@link BatchUnsupportedError} so the pre-push flow can leave its entries
-	 * pending instead of burning retries against a server that predates the
-	 * endpoint. Per-item success/failure is reported in `results` (request
-	 * order), HTTP 200 even on partial failure.
-	 */
-	async pushBatch(payload: BatchPushPayload): Promise<BatchPushResult> {
-		const { status, json } = await this.call<BatchPushResponseBody>("POST", "/api/push/jollimemory/batch", payload);
-		if (status === 404) {
-			throw new BatchUnsupportedError();
-		}
-		if (status === 426) {
-			throw new ClientOutdatedError(errorMessage(json) ?? "Client outdated — update the CLI/extension.");
-		}
-		if (status === 412 && json.error === "binding_required") {
-			throw new BindingRequiredError(json.repoUrl ?? payload.repoUrl ?? "", json.message);
-		}
-		// The allowlist refusal: the server emits `repo_not_allowlisted` as 412 (NOT
-		// 403 — that status is the bind path's `space_restricted`). Treat it like the
-		// other admin-action-required rejections so `classifyError` holds the retry
-		// budget instead of hammering the server with doomed pushes.
-		if (status === 412 && json.error === "repo_not_allowlisted") {
-			throw new PermissionDeniedError(errorMessage(json));
-		}
-		if (status === 401) {
-			throw new NotAuthenticatedError();
-		}
-		if (status === 403) {
-			throw new PermissionDeniedError(errorMessage(json));
-		}
-		if (status < 200 || status >= 300) {
-			throw new Error(errorMessage(json) ?? `HTTP ${status}`);
-		}
-		if (!Array.isArray(json.results)) {
-			// Same rationale as push(): a 2xx with a gateway/HTML body must not be
-			// mistaken for "everything pushed" — the caller would delete pending
-			// entries it never actually synced.
-			throw new Error(`Batch push returned HTTP ${status} but the response was missing results`);
-		}
-		const results: BatchItemResult[] = [];
-		for (const entry of json.results) {
-			const item = toBatchItemResult(entry);
-			if (!item) {
-				throw new Error(`Batch push returned HTTP ${status} but a result entry was malformed`);
-			}
-			results.push(item);
-		}
-		const okCount = results.filter((r) => r.ok).length;
-		log.debug(
-			"pushBatch: %d item(s) sent — ok=%d failed=%d",
-			payload.items.length,
-			okCount,
-			results.length - okCount,
-		);
-		// Optional top-level Space echo (newer servers, repoUrl-routed pushes only).
-		const jmSpace = parseJmSpaceEcho(json.jmSpace);
-		return { results, ...(jmSpace !== undefined ? { jmSpace } : {}) };
-	}
-
-	/**
 	 * Deletes an orphaned push doc (e.g. from a squashed/rebased commit).
 	 * Mirrors `deleteFromJolli` (`JolliPushService.ts:283-326`) — best-effort,
 	 * throws on any non-2xx so the caller can decide whether to retry.
@@ -929,129 +764,6 @@ export class JolliMemoryPushClient {
 			clearTimeout(timer);
 		}
 	}
-}
-
-/** Field-by-field validation of one batch summary doc result; undefined on shape mismatch. */
-function toBatchDocResult(value: unknown): BatchDocResult | undefined {
-	if (typeof value !== "object" || value === null) {
-		return undefined;
-	}
-	const raw = value as {
-		docId?: unknown;
-		url?: unknown;
-		jrn?: unknown;
-		created?: unknown;
-		summaryJsonDocId?: unknown;
-	};
-	if (typeof raw.docId !== "number" || typeof raw.url !== "string" || typeof raw.jrn !== "string") {
-		return undefined;
-	}
-	return {
-		docId: raw.docId,
-		url: raw.url,
-		jrn: raw.jrn,
-		created: raw.created === true,
-		...(typeof raw.summaryJsonDocId === "number" && { summaryJsonDocId: raw.summaryJsonDocId }),
-	};
-}
-
-/**
- * Field-by-field validation of one batch attachment result; undefined on shape
- * mismatch. An `ok: true` entry without a usable docId/url is DOWNGRADED to a
- * failure — same rationale as {@link toBatchItemResult}'s summary downgrade: a
- * malformed success would silently skip the write-back and re-CREATE the
- * attachment on the next push.
- */
-function toBatchAttachmentResult(value: unknown): BatchAttachmentResult | undefined {
-	if (typeof value !== "object" || value === null) {
-		return undefined;
-	}
-	const raw = value as {
-		clientKey?: unknown;
-		ok?: unknown;
-		docId?: unknown;
-		url?: unknown;
-		jrn?: unknown;
-		created?: unknown;
-		error?: unknown;
-		errorCode?: unknown;
-	};
-	if (typeof raw.clientKey !== "string" || typeof raw.ok !== "boolean") {
-		return undefined;
-	}
-	if (raw.ok && (typeof raw.docId !== "number" || typeof raw.url !== "string")) {
-		return {
-			clientKey: raw.clientKey,
-			ok: false,
-			error: "Batch attachment result was missing docId/url",
-		};
-	}
-	return {
-		clientKey: raw.clientKey,
-		ok: raw.ok,
-		...(typeof raw.docId === "number" && { docId: raw.docId }),
-		...(typeof raw.url === "string" && { url: raw.url }),
-		...(typeof raw.jrn === "string" && { jrn: raw.jrn }),
-		...(typeof raw.created === "boolean" && { created: raw.created }),
-		...(typeof raw.error === "string" && { error: raw.error }),
-		// Must be carried through: it is the ONLY machine-readable signal for an
-		// attachment failure (a batch failure arrives as `ok:false` inside a 2xx body,
-		// so there is no status to classify on). Dropping it here silently degrades a
-		// `doctype_not_allowed` config problem into an anonymous transient failure.
-		...(typeof raw.errorCode === "string" && { errorCode: raw.errorCode }),
-	};
-}
-
-/**
- * Field-by-field validation of one batch item result. An `ok: true` entry whose
- * summary fields are unusable is DOWNGRADED to a failure (not dropped): the
- * caller must keep that commit pending rather than delete it blind on a
- * malformed success. Returns undefined only when the entry itself is garbage.
- */
-function toBatchItemResult(value: unknown): BatchItemResult | undefined {
-	if (typeof value !== "object" || value === null) {
-		return undefined;
-	}
-	const raw = value as {
-		commitHash?: unknown;
-		ok?: unknown;
-		summary?: unknown;
-		attachments?: unknown;
-		error?: unknown;
-		errorCode?: unknown;
-	};
-	if (typeof raw.commitHash !== "string" || typeof raw.ok !== "boolean") {
-		return undefined;
-	}
-	const attachments: BatchAttachmentResult[] = [];
-	if (Array.isArray(raw.attachments)) {
-		for (const entry of raw.attachments) {
-			const attachment = toBatchAttachmentResult(entry);
-			if (attachment) {
-				attachments.push(attachment);
-			}
-		}
-	}
-	if (raw.ok) {
-		const summary = toBatchDocResult(raw.summary);
-		if (!summary) {
-			return {
-				commitHash: raw.commitHash,
-				ok: false,
-				attachments,
-				errorCode: "malformed_response",
-				error: "Batch item result was missing docId/url",
-			};
-		}
-		return { commitHash: raw.commitHash, ok: true, summary, attachments };
-	}
-	return {
-		commitHash: raw.commitHash,
-		ok: false,
-		attachments,
-		...(typeof raw.error === "string" && { error: raw.error }),
-		...(typeof raw.errorCode === "string" && { errorCode: raw.errorCode }),
-	};
 }
 
 function isErrorBody(value: unknown): value is ErrorResponseBody {

--- a/cli/src/core/JolliMemoryPushOrchestrator.test.ts
+++ b/cli/src/core/JolliMemoryPushOrchestrator.test.ts
@@ -60,9 +60,6 @@ vi.mock("./PushControl.js", async (orig) => ({
 import { getDefaultBranch } from "./GitOps.js";
 import { buildBranchRelativePath, getCanonicalRepoUrl } from "./GitRemoteUtils.js";
 import {
-	BATCH_MAX_ATTACHMENTS_PER_ITEM,
-	BATCH_MAX_CONTENT_CHARS,
-	type BatchItemResult,
 	BindingAlreadyExistsError,
 	BindingRequiredError,
 	ClientOutdatedError,
@@ -72,12 +69,10 @@ import {
 	type PushResult,
 } from "./JolliMemoryPushClient.js";
 import {
-	applyBatchResult,
 	applyNoteUrls,
 	applyPlanUrls,
 	applyReferenceUrls,
 	assignOwnedAttachments,
-	buildBatchItems,
 	buildPushMarkdown,
 	canReuseDocId,
 	docUrlPlaceholder,
@@ -92,7 +87,7 @@ import {
 import { loadBranchSummaries } from "./PrDescription.js";
 import { isOutboundPushAllowed } from "./PushControl.js";
 import { loadPushPending } from "./PushPendingStore.js";
-import { assignOwnedContext } from "./push/ContextPush.js";
+import { assignOwnedContext, buildContextBatchAttachments } from "./push/ContextPush.js";
 import { clearSpaceBindingCache, saveSpaceBindingCache } from "./SpaceBindingCache.js";
 import { buildPushTitle } from "./SummaryFormat.js";
 import {
@@ -1286,6 +1281,43 @@ describe("pushSummary", () => {
 		expect(summaryUrl).toBe(`${BASE}/articles?doc=42`);
 	});
 
+	// The article is already published when the local write fails, so this must be
+	// reported (with the minted id) rather than thrown: the drain records the id on
+	// its pending entry so the retry UPDATEs instead of CREATEing a duplicate.
+	it("reports writeBackFailed with the minted docId instead of failing the push", async () => {
+		const client = fakeClient();
+		vi.mocked(storeSummary).mockRejectedValueOnce(new Error("orphan branch lock busy"));
+
+		const result = await pushSummary(leaf(), baseCtx(client));
+
+		expect(result.writeBackFailed).toBe(true);
+		expect(result.docId).toBe(42);
+		expect(result.summaryUrl).toBe(`${BASE}/articles?doc=42`);
+	});
+
+	// The pre-push worker runs BEFORE git transfers objects, so deleting orphaned
+	// articles there could strip memories from history that is still on the remote.
+	it("defers orphan cleanup and reports cleanupPending when skipOrphanCleanup is set", async () => {
+		const client = fakeClient();
+		const summary = leaf({ orphanedDocIds: [1, 2] });
+
+		const result = await pushSummary(summary, baseCtx(client), undefined, { skipOrphanCleanup: true });
+
+		expect(result.cleanupPending).toBe(true);
+		expect(client.deleteDoc).not.toHaveBeenCalled();
+		// The write-back still happened — only the deletion was deferred.
+		expect(storeSummary).toHaveBeenCalledTimes(1);
+	});
+
+	it("reports no cleanupPending for a clean summary on the deferred path", async () => {
+		const client = fakeClient();
+
+		const result = await pushSummary(leaf(), baseCtx(client), undefined, { skipOrphanCleanup: true });
+
+		expect(result.cleanupPending).toBeUndefined();
+		expect(client.deleteDoc).not.toHaveBeenCalled();
+	});
+
 	it("does not fail the overall push when orphan cleanup throws a non-Error value", async () => {
 		const client = fakeClient();
 		vi.mocked(storeSummary)
@@ -1562,6 +1594,26 @@ describe("pushBranchToJolli", () => {
 		expect(client.push).toHaveBeenCalledTimes(2);
 	});
 
+	// pushSummary swallows a failed write-back and reports it as a flag, because the
+	// drains record the minted docId on their push-pending entry instead. This path
+	// keeps no such entry, so an ignored flag would report success while nothing
+	// points at the published article — and the next push would CREATE a second one.
+	it("reports an error (not a pushed count) when a published summary's local write-back failed", async () => {
+		const s1 = leaf({ commitHash: "aaa1111" });
+		const s2 = leaf({ commitHash: "bbb2222" });
+		vi.mocked(loadBranchSummaries).mockResolvedValue({ summaries: [s1, s2], missingCount: 0 });
+		vi.mocked(storeSummary).mockRejectedValueOnce(new Error("orphan branch lock busy"));
+		const client = fakeClient({ push: async () => fakePushResult({ docId: 42 }) });
+
+		const result = await pushBranchToJolli({ cwd: "/repo", client });
+
+		expect(result.type).toBe("error");
+		expect(result.type === "error" && result.message).toContain("aaa1111");
+		expect(result.type === "error" && result.message).toContain(`${BASE}/articles?doc=42`);
+		// The remaining summary is left unsent — it needs the same write that failed.
+		expect(client.push).toHaveBeenCalledTimes(1);
+	});
+
 	it("dedups a plan recurring across two commits to a single push (assignOwnedAttachments)", async () => {
 		const recurringPlan = plan({ slug: "refactor-a1b2c3d4", updatedAt: "2026-02-01T00:00:00.000Z" });
 		const s1 = leaf({
@@ -1800,7 +1852,7 @@ describe("pushBranchToJolli", () => {
 	});
 });
 
-// ─── Batch push helpers ──────────────────────────────────────────────────────
+// ─── Server placeholder contract ─────────────────────────────────────────────
 
 describe("docUrlPlaceholder", () => {
 	it("builds the lockstep placeholder shape", () => {
@@ -1808,432 +1860,35 @@ describe("docUrlPlaceholder", () => {
 	});
 });
 
-describe("buildBatchItems", () => {
-	beforeEach(() => {
-		vi.mocked(readPlanFromBranch).mockReset().mockResolvedValue(null);
-		vi.mocked(readNoteFromBranch).mockReset().mockResolvedValue(null);
-		vi.mocked(readReferenceFromBranch).mockReset().mockResolvedValue(null);
-	});
+describe("context attachment clientKey wire contract", () => {
+	// The clientKey is echoed by the server and is the payload of the
+	// `{{jolli:doc:<clientKey>}}` placeholder, whose format is a byte-for-byte
+	// lockstep contract with the server's substituter. Deriving it from `docType`
+	// once renamed this silently; `clientKeyPrefix` pins it and this asserts it.
+	// Asserted against `buildContextBatchAttachments` because the batch builder
+	// that used to be the caller is gone (see the note in `PushExecutor`).
+	it("emits `ref-N` for a reference, not `reference-N`", async () => {
+		const ref = reference();
+		const summary = leaf({ references: [ref] });
+		vi.mocked(readReferenceFromBranch).mockResolvedValue(null);
 
-	function owned(overrides: {
-		plans?: Map<string, ReadonlyArray<PlanReference>>;
-		notes?: Map<string, ReadonlyArray<NoteReference>>;
-		references?: Map<string, ReadonlyArray<ReferenceCommitRef>>;
-	}) {
-		return {
-			ownedPlans: overrides.plans ?? new Map(),
-			ownedNotes: overrides.notes ?? new Map(),
-			ownedReferences: overrides.references ?? new Map(),
-		};
-	}
-
-	it("builds one item per summary with placeholder-woven markdown and attachment keys", async () => {
-		const summary = leaf({ plans: [plan()] });
-		vi.mocked(readPlanFromBranch).mockResolvedValue("# Plan body");
-		const ctx = baseCtx(fakeClient());
-
-		const built = await buildBatchItems(
-			[summary],
-			owned({ plans: new Map([[summary.commitHash, [plan()]]]) }),
-			ctx,
-		);
-
-		expect(built).toHaveLength(1);
-		const item = built[0].item;
-		expect(item.commitHash).toBe(summary.commitHash);
-		expect(item.branch).toBe(summary.branch);
-		expect(item.attachments).toHaveLength(1);
-		expect(item.attachments[0]).toMatchObject({ clientKey: "plan-0", docType: "plan", content: "# Plan body" });
-		// The placeholder is woven into the summary markdown where the plan URL goes.
-		expect(item.summary.content).toContain(docUrlPlaceholder("plan-0"));
-		// Write-back bookkeeping maps the clientKey to the plan's slug.
-		expect(built[0].attachmentKeys.get("plan-0")).toEqual({ docType: "plan", key: "p1" });
-		expect(built[0].batchContentChars).toBe(
-			item.summary.content.length + (item.summary.summaryJson?.length ?? 0) + item.attachments[0].content.length,
-		);
-		expect(built[0].batchIneligibleReason).toBeUndefined();
-	});
-
-	it("marks an item with too many attachments for the per-commit fallback", async () => {
-		const plans = Array.from({ length: BATCH_MAX_ATTACHMENTS_PER_ITEM + 1 }, (_, index) =>
-			plan({ slug: `p-${index}` }),
-		);
-		const summary = leaf({ plans });
-		vi.mocked(readPlanFromBranch).mockResolvedValue("# Plan body");
-
-		const built = await buildBatchItems(
-			[summary],
-			owned({ plans: new Map([[summary.commitHash, plans]]) }),
+		const built = await buildContextBatchAttachments(
+			summary,
 			baseCtx(fakeClient()),
+			ENV_KEY,
+			new Map([["reference", [ref]]]),
+			docUrlPlaceholder,
 		);
 
-		expect(built[0].item.attachments).toHaveLength(BATCH_MAX_ATTACHMENTS_PER_ITEM + 1);
-		expect(built[0].batchIneligibleReason).toBe("attachment count exceeds the batch limit");
-	});
-
-	it("marks an item whose attachment body exceeds the per-doc limit for the per-commit fallback", async () => {
-		const summary = leaf({ plans: [plan()] });
-		vi.mocked(readPlanFromBranch).mockResolvedValue("x".repeat(BATCH_MAX_CONTENT_CHARS + 1));
-
-		const built = await buildBatchItems(
-			[summary],
-			owned({ plans: new Map([[summary.commitHash, [plan()]]]) }),
-			baseCtx(fakeClient()),
-		);
-
-		expect(built[0].batchIneligibleReason).toBe("attachment content exceeds the batch limit");
-	});
-
-	it("skips a plan whose content is unreadable (no attachment, no placeholder)", async () => {
-		const summary = leaf({ plans: [plan()] });
-		vi.mocked(readPlanFromBranch).mockResolvedValue(null);
-		const ctx = baseCtx(fakeClient());
-
-		const built = await buildBatchItems(
-			[summary],
-			owned({ plans: new Map([[summary.commitHash, [plan()]]]) }),
-			ctx,
-		);
-
-		expect(built[0].item.attachments).toHaveLength(0);
-		expect(built[0].item.summary.content).not.toContain("{{jolli:doc:");
-	});
-
-	it("carries a reusable docId when the stored doc URL matches the push env", async () => {
-		const summary = leaf({ plans: [plan()] });
-		vi.mocked(readPlanFromBranch).mockResolvedValue("# Plan body");
-		const reusable = plan({ jolliPlanDocId: 42, jolliPlanDocUrl: `${BASE}/articles/p-42` });
-		const ctx = baseCtx(fakeClient());
-
-		const built = await buildBatchItems(
-			[summary],
-			owned({ plans: new Map([[summary.commitHash, [reusable]]]) }),
-			ctx,
-		);
-
-		expect(built[0].item.attachments[0].docId).toBe(42);
-	});
-
-	it("drops a docId minted on a different backend (env mismatch)", async () => {
-		const summary = leaf({ plans: [plan()] });
-		vi.mocked(readPlanFromBranch).mockResolvedValue("# Plan body");
-		const foreign = plan({ jolliPlanDocId: 42, jolliPlanDocUrl: "https://other.jolli.dev/articles/p-42" });
-		const ctx = baseCtx(fakeClient());
-
-		const built = await buildBatchItems(
-			[summary],
-			owned({ plans: new Map([[summary.commitHash, [foreign]]]) }),
-			ctx,
-		);
-
-		expect(built[0].item.attachments[0].docId).toBeUndefined();
-	});
-
-	it("carries the summary's own reusable docId and summaryJson", async () => {
-		const summary = leaf({ jolliDocId: 7, jolliDocUrl: `${BASE}/articles/s-7` });
-		const ctx = baseCtx(fakeClient());
-
-		const built = await buildBatchItems([summary], owned({}), ctx);
-
-		expect(built[0].item.summary.docId).toBe(7);
-		expect(built[0].item.summary.summaryJson).toBeDefined();
-	});
-
-	it("uses a snippet note's inline content instead of reading from the branch", async () => {
-		const snippet = note({ format: "snippet", content: "inline note body" });
-		const summary = leaf({ notes: [snippet] });
-		const ctx = baseCtx(fakeClient());
-
-		const built = await buildBatchItems(
-			[summary],
-			owned({ notes: new Map([[summary.commitHash, [snippet]]]) }),
-			ctx,
-		);
-
-		expect(built[0].item.attachments[0]).toMatchObject({
-			clientKey: "note-0",
-			docType: "note",
-			content: "inline note body",
-		});
-		expect(readNoteFromBranch).not.toHaveBeenCalled();
-	});
-
-	/**
-	 * The other half of the format split, and the batch sibling of the individual
-	 * path's snippet case above: inline `content` is a SNIPPET-only field, so a
-	 * markdown note ignores whatever it carries and takes the orphan-branch copy.
-	 *
-	 * Pinned because the batch path used to read `note.content ?? branch` for BOTH
-	 * formats, and the test that covered it asserted only the inline half — so
-	 * narrowing the rule to snippets left the markdown half unpinned on this path.
-	 */
-	it("reads a markdown note's body from the branch even when it carries inline content", async () => {
-		const markdown = note({ format: "markdown", content: "stale inline copy" });
-		const summary = leaf({ notes: [markdown] });
-		vi.mocked(readNoteFromBranch).mockResolvedValue("# Branch body");
-		const ctx = baseCtx(fakeClient());
-
-		const built = await buildBatchItems(
-			[summary],
-			owned({ notes: new Map([[summary.commitHash, [markdown]]]) }),
-			ctx,
-		);
-
-		expect(built[0].item.attachments[0]).toMatchObject({ clientKey: "note-0", content: "# Branch body" });
-		expect(readNoteFromBranch).toHaveBeenCalledWith("n1", "/repo", undefined);
+		expect(built.attachments.map((a) => a.clientKey)).toEqual(["ref-0"]);
+		expect(built.attachmentKeys.get("ref-0")).toEqual({ docType: "reference", key: ref.archivedKey });
+		expect(built.placeholders.get("reference")).toEqual([
+			{ entryKey: ref.archivedKey, url: docUrlPlaceholder("ref-0") },
+		]);
 	});
 });
 
-describe("applyBatchResult", () => {
-	beforeEach(() => {
-		vi.mocked(storeSummary).mockReset().mockResolvedValue(undefined);
-		vi.mocked(getIndexEntryMap).mockReset().mockResolvedValue(new Map());
-		vi.mocked(getSummary).mockReset().mockResolvedValue(null);
-		vi.mocked(loadPushPending).mockReset().mockResolvedValue({ version: 1, entries: {} });
-		vi.mocked(readPlanFromBranch).mockReset().mockResolvedValue("# Plan body");
-		vi.mocked(readNoteFromBranch).mockReset().mockResolvedValue(null);
-		vi.mocked(readReferenceFromBranch).mockReset().mockResolvedValue(null);
-	});
-
-	async function buildOne(summary: CommitSummary, plans: ReadonlyArray<PlanReference> = []) {
-		const ctx = baseCtx(fakeClient());
-		const built = await buildBatchItems(
-			[summary],
-			{
-				ownedPlans: new Map(plans.length > 0 ? [[summary.commitHash, plans]] : []),
-				ownedNotes: new Map(),
-				ownedReferences: new Map(),
-			},
-			ctx,
-		);
-		return { ctx, built };
-	}
-
-	function okResult(summary: CommitSummary, attachments: BatchItemResult["attachments"] = []): BatchItemResult {
-		return {
-			commitHash: summary.commitHash,
-			ok: true,
-			summary: { docId: 9, url: "/articles/s-9", jrn: "jrn:9", created: true },
-			attachments,
-		};
-	}
-
-	it("writes back the summary docId/url and woven attachment URLs on success", async () => {
-		const summary = leaf({ plans: [plan()] });
-		const { ctx, built } = await buildOne(summary, [plan()]);
-
-		const outcome = await applyBatchResult(
-			built,
-			[okResult(summary, [{ clientKey: "plan-0", ok: true, docId: 11, url: "/articles/p-11" }])],
-			ctx,
-		);
-
-		expect(outcome).toEqual({ writtenBack: 1, childSkipped: 0 });
-		expect(storeSummary).toHaveBeenCalledTimes(1);
-		const stored = vi.mocked(storeSummary).mock.calls[0][0] as CommitSummary;
-		expect(stored.jolliDocId).toBe(9);
-		expect(stored.jolliDocUrl).toBe(`${BASE}/articles/s-9`);
-		expect(stored.plans?.[0]).toMatchObject({ jolliPlanDocId: 11, jolliPlanDocUrl: `${BASE}/articles/p-11` });
-	});
-
-	it("deletes the freshly-pushed article and skips write-back when the commit became a child mid-push", async () => {
-		const summary = leaf();
-		const { ctx, built } = await buildOne(summary);
-		vi.mocked(getIndexEntryMap).mockResolvedValue(
-			new Map([
-				[
-					summary.commitHash,
-					{
-						commitHash: summary.commitHash,
-						parentCommitHash: "def4567890",
-						commitMessage: "",
-						commitDate: "",
-						branch: summary.branch,
-						generatedAt: "",
-					},
-				],
-			]),
-		);
-
-		const outcome = await applyBatchResult(built, [okResult(summary)], ctx);
-
-		expect(outcome).toEqual({ writtenBack: 0, childSkipped: 1 });
-		expect(ctx.client.deleteDoc).toHaveBeenCalledWith(9);
-		expect(storeSummary).not.toHaveBeenCalled();
-	});
-
-	it("deletes only the CREATEd attachments alongside the article on the mid-push child guard", async () => {
-		const summary = leaf();
-		const { ctx, built } = await buildOne(summary);
-		vi.mocked(getIndexEntryMap).mockResolvedValue(
-			new Map([
-				[
-					summary.commitHash,
-					{
-						commitHash: summary.commitHash,
-						parentCommitHash: "def4567890",
-						commitMessage: "",
-						commitDate: "",
-						branch: summary.branch,
-						generatedAt: "",
-					},
-				],
-			]),
-		);
-
-		const outcome = await applyBatchResult(
-			built,
-			[
-				okResult(summary, [
-					{ clientKey: "plan-0", ok: true, docId: 11, url: "/articles/p-11", created: true },
-					{ clientKey: "note-0", ok: true, docId: 12, url: "/articles/n-12", created: false },
-					{ clientKey: "note-1", ok: true, created: true },
-					{ clientKey: "ref-0", ok: false, error: "boom" },
-				]),
-			],
-			ctx,
-		);
-
-		expect(outcome).toEqual({ writtenBack: 0, childSkipped: 1 });
-		expect(ctx.client.deleteDoc).toHaveBeenCalledWith(9);
-		expect(ctx.client.deleteDoc).toHaveBeenCalledWith(11);
-		expect(ctx.client.deleteDoc).toHaveBeenCalledTimes(2);
-		expect(storeSummary).not.toHaveBeenCalled();
-	});
-
-	it("tolerates a best-effort delete failure on the mid-push child guard", async () => {
-		const summary = leaf();
-		const ctx = baseCtx(fakeClient({ deleteDoc: async () => Promise.reject(new Error("network")) }));
-		const built = await buildBatchItems(
-			[summary],
-			{ ownedPlans: new Map(), ownedNotes: new Map(), ownedReferences: new Map() },
-			ctx,
-		);
-		vi.mocked(getIndexEntryMap).mockResolvedValue(
-			new Map([
-				[
-					summary.commitHash,
-					{
-						commitHash: summary.commitHash,
-						parentCommitHash: "def4567890",
-						commitMessage: "",
-						commitDate: "",
-						branch: summary.branch,
-						generatedAt: "",
-					},
-				],
-			]),
-		);
-
-		// The created attachment's delete fails too — both stay best-effort.
-		await expect(
-			applyBatchResult(
-				built,
-				[
-					okResult(summary, [
-						{ clientKey: "plan-0", ok: true, docId: 11, url: "/articles/p-11", created: true },
-					]),
-				],
-				ctx,
-			),
-		).resolves.toEqual({
-			writtenBack: 0,
-			childSkipped: 1,
-		});
-	});
-
-	it("skips failed items and items with no matching built entry", async () => {
-		const summary = leaf();
-		const { ctx, built } = await buildOne(summary);
-
-		const outcome = await applyBatchResult(
-			built,
-			[
-				{ commitHash: summary.commitHash, ok: false, attachments: [], error: "boom" },
-				{ ...okResult(summary), commitHash: "f".repeat(40) },
-			],
-			ctx,
-		);
-
-		expect(outcome).toEqual({ writtenBack: 0, childSkipped: 0 });
-		expect(storeSummary).not.toHaveBeenCalled();
-	});
-
-	it("reports a per-item write-back failure with the minted ids (article is already published)", async () => {
-		const summary = leaf();
-		const { ctx, built } = await buildOne(summary);
-		vi.mocked(storeSummary).mockRejectedValue(new Error("disk full"));
-
-		const outcome = await applyBatchResult(built, [okResult(summary)], ctx);
-
-		expect(outcome).toEqual({
-			writtenBack: 0,
-			childSkipped: 0,
-			writeBackFailures: [{ commitHash: summary.commitHash, docId: 9, url: `${BASE}/articles/s-9` }],
-		});
-	});
-
-	it("treats every commit as a root when the summary index cannot be read", async () => {
-		const summary = leaf();
-		const { ctx, built } = await buildOne(summary);
-		vi.mocked(getIndexEntryMap).mockRejectedValue(new Error("index unavailable"));
-
-		const outcome = await applyBatchResult(built, [okResult(summary)], ctx);
-
-		expect(outcome).toEqual({ writtenBack: 1, childSkipped: 0 });
-		expect(ctx.client.deleteDoc).not.toHaveBeenCalled();
-		expect(storeSummary).toHaveBeenCalledTimes(1);
-	});
-
-	it("deletes orphaned articles when cleanupOrphans is set (compensation path)", async () => {
-		const summary = leaf({ orphanedDocIds: [42] });
-		const { ctx, built } = await buildOne(summary);
-
-		const outcome = await applyBatchResult(built, [okResult(summary)], ctx, { cleanupOrphans: true });
-
-		expect(outcome).toEqual({ writtenBack: 1, childSkipped: 0 });
-		expect(ctx.client.deleteDoc).toHaveBeenCalledWith(42);
-		// Two persists: the docId/url write-back, then the cleaned orphan list.
-		expect(storeSummary).toHaveBeenCalledTimes(2);
-	});
-
-	it("skips orphan cleanup by default (budget-bound inline pre-push path)", async () => {
-		const summary = leaf({ orphanedDocIds: [42] });
-		const { ctx, built } = await buildOne(summary);
-
-		const outcome = await applyBatchResult(built, [okResult(summary)], ctx);
-
-		expect(ctx.client.deleteDoc).not.toHaveBeenCalled();
-		expect(outcome).toEqual({ writtenBack: 1, childSkipped: 0, cleanupPendingHashes: [summary.commitHash] });
-	});
-
-	it("keeps the write-back result when orphan cleanup itself fails", async () => {
-		const summary = leaf({ orphanedDocIds: [42] });
-		const ctx = baseCtx(fakeClient({ deleteDoc: async () => Promise.reject(new Error("network")) }));
-		const built = await buildBatchItems(
-			[summary],
-			{ ownedPlans: new Map(), ownedNotes: new Map(), ownedReferences: new Map() },
-			ctx,
-		);
-
-		const outcome = await applyBatchResult(built, [okResult(summary)], ctx, { cleanupOrphans: true });
-
-		expect(outcome).toEqual({ writtenBack: 1, childSkipped: 0, cleanupPendingHashes: [summary.commitHash] });
-	});
-
-	it("resolves orphan hashes before cleanup on the compensation batch path", async () => {
-		const summary = leaf({ unresolvedOrphanHashes: ["child1hash"] });
-		const { ctx, built } = await buildOne(summary);
-		vi.mocked(getSummary).mockResolvedValueOnce(leaf({ commitHash: "child1hash", jolliDocId: 201 }));
-
-		const outcome = await applyBatchResult(built, [okResult(summary)], ctx, { cleanupOrphans: true });
-
-		expect(ctx.client.deleteDoc).toHaveBeenCalledWith(201);
-		expect(outcome).toEqual({ writtenBack: 1, childSkipped: 0 });
-	});
-});
-
-// ─── Generic-forms + batch failure logging (table-driven push path) ─────────
+// ─── Generic call forms (table-driven push path) ─────────────────────────────
 
 describe("kind-agnostic call forms", () => {
 	beforeEach(() => {
@@ -2281,99 +1936,7 @@ describe("kind-agnostic call forms", () => {
 		expect(docTypes).toEqual(["plan", "summary"]);
 		expect(docTypes).not.toContain("skill");
 	});
-
-	it("buildBatchItems accepts the kind-agnostic OwnedContext form", async () => {
-		const summary = leaf({ plans: [plan()] });
-		const built = await buildBatchItems(
-			[summary],
-			new Map([["plan", { owned: new Map([[summary.commitHash, [plan()]]]), seeds: new Map() }]]),
-			baseCtx(fakeClient()),
-		);
-		expect(built[0].item.attachments.map((a) => a.clientKey)).toEqual(["plan-0"]);
-	});
 });
-
-describe("applyBatchResult attachment-failure logging", () => {
-	beforeEach(() => {
-		vi.mocked(storeSummary).mockReset().mockResolvedValue(undefined);
-		vi.mocked(getIndexEntryMap).mockReset().mockResolvedValue(new Map());
-		vi.mocked(getSummary).mockReset().mockResolvedValue(null);
-		vi.mocked(loadPushPending).mockReset().mockResolvedValue({ version: 1, entries: {} });
-		vi.mocked(readPlanFromBranch).mockReset().mockResolvedValue("# Plan body");
-		vi.mocked(readNoteFromBranch).mockReset().mockResolvedValue(null);
-		vi.mocked(readReferenceFromBranch).mockReset().mockResolvedValue(null);
-		mockLogWarn.mockReset();
-		mockLogError.mockReset();
-	});
-
-	it("write-back succeeds and failures are visible: doctype_not_allowed collapses to one line per kind, other errors log per item", async () => {
-		// Two failed plan attachments with errorCode doctype_not_allowed + one failed
-		// with plain error text + one successful. Batch attachment failures arrive as
-		// `ok: false` inside a 2xx body — they used to be dropped in SILENCE, which
-		// made a server-side rejection of a whole docType invisible on the default
-		// (batch-first) push path.
-		const p1 = plan({ slug: "p1-1234abcd", title: "P1" });
-		const p2 = plan({ slug: "p2-1234abcd", title: "P2" });
-		const p3 = plan({ slug: "p3-1234abcd", title: "P3" });
-		const p4 = plan({ slug: "p4-1234abcd", title: "P4" });
-		const summary = leaf({ plans: [p1, p2, p3, p4] });
-		const ctx = baseCtx(fakeClient());
-		const built = await buildBatchItems(
-			[summary],
-			{
-				ownedPlans: new Map([[summary.commitHash, [p1, p2, p3, p4]]]),
-				ownedNotes: new Map(),
-				ownedReferences: new Map(),
-			},
-			ctx,
-		);
-		const outcome = await applyBatchResult(
-			built,
-			[
-				{
-					commitHash: summary.commitHash,
-					ok: true,
-					summary: { docId: 9, url: "/articles/s-9", jrn: "jrn:9", created: true },
-					attachments: [
-						{ clientKey: "plan-0", ok: false, errorCode: "doctype_not_allowed", error: "not enabled" },
-						{ clientKey: "plan-1", ok: false, errorCode: "doctype_not_allowed", error: "not enabled" },
-						{ clientKey: "plan-2", ok: false, error: "boom" },
-						{
-							clientKey: "plan-3",
-							ok: true,
-							docId: 31,
-							url: "/articles/p-31",
-							jrn: "jrn:31",
-							created: true,
-						},
-					],
-				},
-			],
-			ctx,
-		);
-		expect(outcome.writtenBack).toBe(1);
-		// The successful attachment still gets woven back.
-		const stored = vi.mocked(storeSummary).mock.calls[0][0];
-		expect(stored.plans?.find((p) => p.slug === "p4-1234abcd")?.jolliPlanDocId).toBe(31);
-		expect(stored.plans?.find((p) => p.slug === "p1-1234abcd")?.jolliPlanDocId).toBeUndefined();
-
-		// The collapsing itself, asserted rather than described: TWO refused plan
-		// attachments produce exactly ONE warn naming the docType (a dozen skills on a
-		// server without that docType enabled must not emit a dozen identical lines),
-		// and it must name the kind, not the clientKey.
-		const docTypeWarnings = mockLogWarn.mock.calls.filter(([fmt]) => String(fmt).includes("docType"));
-		expect(docTypeWarnings).toHaveLength(1);
-		expect(docTypeWarnings[0]).toContain("plan");
-		// The plain failure keeps its own per-item line — it is not a kind-wide
-		// condition, so collapsing it would hide which attachment failed.
-		const itemErrors = mockLogError.mock.calls.filter(([fmt]) => String(fmt).includes("FAILED"));
-		expect(itemErrors).toHaveLength(1);
-		expect(itemErrors[0]).toContain("plan-2");
-		// And the successful attachment produced neither.
-		expect(mockLogError.mock.calls.some((call) => call.includes("plan-3"))).toBe(false);
-	});
-});
-
 describe("reference article body from the orphan snapshot", () => {
 	beforeEach(() => {
 		vi.mocked(storeSummary).mockReset().mockResolvedValue(undefined);
@@ -2573,41 +2136,5 @@ describe("skill attachments", () => {
 		const owned = assignOwnedContext([older, newer]).get("skill");
 		expect(owned?.owned.get("1111111111111")).toBeUndefined();
 		expect(owned?.owned.get("2222222222222")).toHaveLength(1);
-	});
-
-	it("adds a batch attachment but mints NO placeholder for it", async () => {
-		const summary = leaf({ skills: [skillRef] });
-		const built = await buildBatchItems(
-			[summary],
-			new Map([["skill", { owned: new Map([[summary.commitHash, [skillRef]]]), seeds: new Map() }]]),
-			baseCtx(fakeClient()),
-		);
-		expect(built[0].item.attachments.map((a) => a.docType)).toEqual(["skill"]);
-		expect(built[0].attachmentKeys.get("skill-0")).toEqual({ docType: "skill", key: skillRef.archivedKey });
-		// linksInMarkdown:false — the body has no per-skill link site, so sending a
-		// token the server has no substitution rule for would risk persisting it.
-		expect(built[0].item.summary.content).not.toContain(docUrlPlaceholder("skill-0"));
-	});
-});
-
-describe("batch clientKey wire contract", () => {
-	it("emits `ref-N` for a reference, not `reference-N`", async () => {
-		// The clientKey is echoed by the server and is the payload of the
-		// `{{jolli:doc:<clientKey>}}` placeholder, whose format is a byte-for-byte
-		// lockstep contract with the server's substituter. Deriving it from `docType`
-		// once renamed this silently; `clientKeyPrefix` pins it and this asserts it.
-		const ref = reference();
-		const summary = leaf({ references: [ref] });
-		vi.mocked(readReferenceFromBranch).mockResolvedValue(null);
-
-		const built = await buildBatchItems(
-			[summary],
-			new Map([["reference", { owned: new Map([[summary.commitHash, [ref]]]), seeds: new Map() }]]),
-			baseCtx(fakeClient()),
-		);
-
-		expect(built[0].item.attachments.map((a) => a.clientKey)).toEqual(["ref-0"]);
-		expect(built[0].attachmentKeys.get("ref-0")).toEqual({ docType: "reference", key: ref.archivedKey });
-		expect(built[0].item.summary.content).toContain(docUrlPlaceholder("ref-0"));
 	});
 });

--- a/cli/src/core/JolliMemoryPushOrchestrator.ts
+++ b/cli/src/core/JolliMemoryPushOrchestrator.ts
@@ -15,11 +15,6 @@ import { getDefaultBranch } from "./GitOps.js";
 import { buildBranchRelativePath, deriveRepoNameFromUrl, getCanonicalRepoUrl } from "./GitRemoteUtils.js";
 import { parseBaseUrl, resolveArticleUrl } from "./JolliApiUtils.js";
 import {
-	BATCH_MAX_ATTACHMENTS_PER_ITEM,
-	BATCH_MAX_CONTENT_CHARS,
-	BATCH_MAX_TOTAL_CONTENT_CHARS,
-	type BatchItemResult,
-	type BatchPushItem,
 	BindingAlreadyExistsError,
 	BindingRequiredError,
 	JolliMemoryPushClient,
@@ -34,9 +29,7 @@ import {
 	assertOutboundStillAllowed,
 	assignOwnedContext,
 	type BatchAttachmentKey,
-	buildContextBatchAttachments,
 	type ContextSelection,
-	legacyNamedOwnership,
 	legacyNamedSelection,
 	type OwnedContext,
 	type PushContext,
@@ -277,363 +270,6 @@ export function docUrlPlaceholder(clientKey: string): string {
 	return `{{jolli:doc:${clientKey}}}`;
 }
 
-/**
- * Legacy named-shape owner-assigned attachments.
- *
- * Accepted by {@link buildBatchItems} alongside the kind-agnostic
- * {@link OwnedContext} so existing callers and tests keep working. Deliberately
- * NOT extended for a new context kind — pass an {@link OwnedContext}.
- */
-export interface OwnedAttachmentMaps {
-	readonly ownedPlans: ReadonlyMap<string, ReadonlyArray<PlanReference>>;
-	readonly ownedNotes: ReadonlyMap<string, ReadonlyArray<NoteReference>>;
-	readonly ownedReferences: ReadonlyMap<string, ReadonlyArray<ReferenceCommitRef>>;
-}
-
-/**
- * Normalizes either ownership form into an {@link OwnedContext}.
- *
- * The named form is expanded by {@link legacyNamedOwnership}, which walks the
- * registry rather than emitting three fixed entries — see there for why the
- * hard-coded docType list lives in one place next to the registry.
- */
-function toOwnedContext(owned: OwnedContext | OwnedAttachmentMaps): OwnedContext {
-	if (!("ownedPlans" in owned)) return owned;
-	return legacyNamedOwnership(owned);
-}
-
-/** One built batch item plus the bookkeeping `applyBatchResult` needs. */
-export interface BuiltBatchItem {
-	readonly item: BatchPushItem;
-	readonly summary: CommitSummary;
-	readonly attachmentKeys: ReadonlyMap<string, BatchAttachmentKey>;
-	/** Character count used by the server's batch-wide content limit. */
-	readonly batchContentChars: number;
-	/** Set when this item must use the legacy per-commit push path. */
-	readonly batchIneligibleReason?: string;
-}
-
-/**
- * Builds one `BatchPushItem` per summary for `pushBatch`: reads attachment
- * bodies, assigns per-item clientKeys, weaves placeholder URLs into the
- * summary markdown (+ summaryJson), and carries existing docIds (env-gated by
- * {@link canReuseDocId}) so the server updates instead of creating.
- *
- * Attachment assembly is generic over the registered context kinds — see
- * `buildContextBatchAttachments`.
- *
- * Only URL fields carry placeholders — attachment docId fields inside the
- * summaryJson stay numeric/absent (a placeholder string there would break the
- * sidecar schema); the local write-back (`applyBatchResult`) records the real
- * ids for the next push.
- *
- * Unreadable/empty attachment bodies are skipped exactly as in the individual
- * path — their placeholder is never minted, so the woven copy keeps whatever URL
- * state the item already had.
- */
-export async function buildBatchItems(
-	summaries: ReadonlyArray<CommitSummary>,
-	owned: OwnedContext | OwnedAttachmentMaps,
-	ctx: PushContext,
-): Promise<Array<BuiltBatchItem>> {
-	const envKey = await ctx.client.resolveEnvKey();
-	const ownership = toOwnedContext(owned);
-	const built: Array<BuiltBatchItem> = [];
-	for (const summary of summaries) {
-		built.push(await buildOneBatchItem(summary, selectionForCommit(ownership, summary.commitHash), ctx, envKey));
-	}
-	const attachmentCount = built.reduce((sum, item) => sum + item.item.attachments.length, 0);
-	const fallbackCount = built.filter((item) => item.batchIneligibleReason !== undefined).length;
-	log.debug(
-		"buildBatchItems: built %d item(s) with %d attachment(s), individualFallback=%d",
-		built.length,
-		attachmentCount,
-		fallbackCount,
-	);
-	return built;
-}
-
-/** Mirrors the server's batch content accounting exactly. */
-function countBatchContentChars(item: BatchPushItem): number {
-	let total = item.summary.content.length + (item.summary.summaryJson?.length ?? 0);
-	for (const attachment of item.attachments) total += attachment.content.length;
-	return total;
-}
-
-/** Returns why an item cannot pass the server's batch schema, if any. */
-function getBatchIneligibleReason(item: BatchPushItem, contentChars: number): string | undefined {
-	if (item.summary.content.length > BATCH_MAX_CONTENT_CHARS) return "summary content exceeds the batch limit";
-	if ((item.summary.summaryJson?.length ?? 0) > BATCH_MAX_CONTENT_CHARS)
-		return "summary JSON exceeds the batch limit";
-	if (item.attachments.length > BATCH_MAX_ATTACHMENTS_PER_ITEM) return "attachment count exceeds the batch limit";
-	if (item.attachments.some((attachment) => attachment.content.length > BATCH_MAX_CONTENT_CHARS))
-		return "attachment content exceeds the batch limit";
-	if (contentChars > BATCH_MAX_TOTAL_CONTENT_CHARS) return "item content exceeds the batch total limit";
-	return undefined;
-}
-
-async function buildOneBatchItem(
-	summary: CommitSummary,
-	selection: ContextSelection,
-	ctx: PushContext,
-	envKey: string,
-): Promise<BuiltBatchItem> {
-	const { attachments, attachmentKeys, placeholders } = await buildContextBatchAttachments(
-		summary,
-		ctx,
-		envKey,
-		selection,
-		docUrlPlaceholder,
-	);
-
-	// Weave placeholder URLs into the enriched copy the markdown + summaryJson are
-	// built from — mirrors pushSummary's real-URL weave, minus docIds (`urlOnly`).
-	// `reduceOwnItems` first, because only the reduced set was uploaded and the
-	// rendered body must list the same set.
-	const summaryForMarkdown = applyPublishedUrls(reduceOwnItems(summary), placeholders, { urlOnly: true });
-	const markdown = buildPushMarkdown(summaryForMarkdown);
-	const summaryJson = serializeSummaryJson(summaryForMarkdown);
-
-	const item: BatchPushItem = {
-		commitHash: summary.commitHash,
-		branch: summary.branch,
-		summary: {
-			title: buildPushTitle(summary),
-			content: markdown,
-			relativePath: buildBranchRelativePath(summary.branch),
-			...(summary.jolliDocId !== undefined &&
-				canReuseDocId(summary.jolliDocUrl, envKey) && { docId: summary.jolliDocId }),
-			...(summaryJson && { summaryJson }),
-		},
-		attachments,
-	};
-	const batchContentChars = countBatchContentChars(item);
-	const batchIneligibleReason = getBatchIneligibleReason(item, batchContentChars);
-	return {
-		summary,
-		attachmentKeys,
-		item,
-		batchContentChars,
-		...(batchIneligibleReason !== undefined && { batchIneligibleReason }),
-	};
-}
-
-/**
- * A pushed item whose local docId/url write-back failed. Carries the minted
- * ids so the caller can persist them in the pending entry — the next drain
- * then retries as an UPDATE of the same article instead of a duplicate CREATE.
- */
-export interface BatchWriteBackFailure {
-	readonly commitHash: string;
-	readonly docId: number;
-	readonly url: string;
-}
-
-/** Outcome counts of {@link applyBatchResult}, for the caller's logging. */
-export interface ApplyBatchResultOutcome {
-	readonly writtenBack: number;
-	readonly childSkipped: number;
-	/** Successful items that still need confirmed post-push orphan cleanup. */
-	readonly cleanupPendingHashes?: ReadonlyArray<string>;
-	/** Successful items whose write-back failed — keep pending with the minted ids recorded. */
-	readonly writeBackFailures?: ReadonlyArray<BatchWriteBackFailure>;
-}
-
-/**
- * Post-batch write-back: for every `ok` item, resolves the final article URL,
- * weaves attachment URLs/docIds into the stored summary and persists it so the
- * next push updates instead of creating. Mirrors `pushSummary`'s write-back
- * including its mid-push child guard: a commit that became a child (squash)
- * while the request was on the network gets its freshly-minted article deleted
- * best-effort instead of a force-store that would resurrect a zombie root —
- * along with any attachments this same batch item CREATEd (attachments that
- * UPDATEd a pre-existing doc keep their article).
- * Best-effort per item — a failed write-back is logged and never fails the
- * caller (the article is already published). Each failed item is reported in
- * `writeBackFailures` with its minted docId/url so the caller can keep the
- * pending entry and retry as an UPDATE instead of a duplicate CREATE.
- *
- * `opts.cleanupOrphans` additionally resolves `unresolvedOrphanHashes` and
- * deletes the orphaned articles recorded on each written-back summary. The
- * compensation drain opts in; the budget-bound pre-push flow leaves it off and
- * receives `cleanupPendingHashes` so those pending entries are preserved.
- */
-export async function applyBatchResult(
-	built: ReadonlyArray<BuiltBatchItem>,
-	results: ReadonlyArray<BatchItemResult>,
-	ctx: PushContext,
-	opts?: { readonly cleanupOrphans?: boolean },
-): Promise<ApplyBatchResultOutcome> {
-	const displayBase = ctx.baseUrl.replace(/\/+$/, "");
-	const builtByHash = new Map(built.map((b) => [b.item.commitHash, b]));
-	const postPushIndex = await getIndexEntryMap(ctx.cwd, ctx.storage).catch((err: unknown) => {
-		// Degrading to "no commit is a child" keeps parity with pushSummary, but
-		// it also disarms the mid-push child guard below — say so in the log.
-		log.warn(
-			"Could not read the summary index for the mid-push child guard — treating every commit as a root: %s",
-			err instanceof Error ? err.message : String(err),
-		);
-		return new Map<string, unknown>();
-	});
-	let writtenBack = 0;
-	let childSkipped = 0;
-	const cleanupPendingHashes: string[] = [];
-	const writeBackFailures: BatchWriteBackFailure[] = [];
-	for (const result of results) {
-		const summaryDoc = result.ok ? result.summary : undefined;
-		if (!summaryDoc) continue;
-		const entry = builtByHash.get(result.commitHash);
-		if (!entry) continue;
-		const indexEntry = postPushIndex.get(result.commitHash) as
-			| { readonly parentCommitHash?: string | null }
-			| undefined;
-		if (indexEntry?.parentCommitHash != null) {
-			childSkipped++;
-			log.warn(
-				"Commit %s became a child mid-push (parent=%s); deleting freshly-pushed article %d and skipping write-back",
-				result.commitHash.substring(0, 8),
-				indexEntry.parentCommitHash.substring(0, 8),
-				summaryDoc.docId,
-			);
-			try {
-				await ctx.client.deleteDoc(summaryDoc.docId);
-			} catch (err) {
-				log.warn(
-					"Best-effort delete of newly-orphaned article %d failed: %s",
-					summaryDoc.docId,
-					err instanceof Error ? err.message : String(err),
-				);
-			}
-			// Attachments this same batch item CREATEd must go too, or they leak
-			// as stray docs of a commit that no longer exists as a root. Only the
-			// created ones: an attachment that UPDATEd a pre-existing doc keeps
-			// its article — that doc predates this push and is cleaned up by the
-			// squash consolidation's own orphan machinery.
-			for (const att of result.attachments) {
-				if (!att.ok || att.created !== true || att.docId === undefined) continue;
-				try {
-					await ctx.client.deleteDoc(att.docId);
-				} catch (err) {
-					log.warn(
-						"Best-effort delete of newly-orphaned attachment %d failed: %s",
-						att.docId,
-						err instanceof Error ? err.message : String(err),
-					);
-				}
-			}
-			continue;
-		}
-		try {
-			const updated = await writeBackBatchItem(entry, result, displayBase, ctx);
-			writtenBack++;
-			let finalUpdated = updated;
-			if (opts?.cleanupOrphans && finalUpdated && hasPendingOrphanCleanup(finalUpdated)) {
-				try {
-					finalUpdated = await resolveUnresolvedOrphanHashes(finalUpdated, ctx);
-					const cleaned = await cleanupOrphanedDocs(finalUpdated, finalUpdated, ctx);
-					if (cleaned) finalUpdated = cleaned;
-				} catch (err) {
-					log.warn(
-						"Orphan cleanup after batch push failed for %s: %s",
-						result.commitHash.substring(0, 8),
-						err instanceof Error ? err.message : String(err),
-					);
-				}
-			}
-			if (finalUpdated && hasPendingOrphanCleanup(finalUpdated)) {
-				cleanupPendingHashes.push(result.commitHash);
-			}
-		} catch (err) {
-			// The article exists server-side but its id never reached local
-			// storage — report the minted ids so the caller keeps the pending
-			// entry and the retry UPDATEs instead of CREATEing a duplicate.
-			writeBackFailures.push({
-				commitHash: result.commitHash,
-				docId: summaryDoc.docId,
-				url: resolveArticleUrl(displayBase, summaryDoc.url, summaryDoc.docId),
-			});
-			log.warn(
-				"Write-back after batch push failed for %s: %s",
-				result.commitHash.substring(0, 8),
-				err instanceof Error ? err.message : String(err),
-			);
-		}
-	}
-	log.debug(
-		"applyBatchResult: writtenBack=%d childSkipped=%d cleanupPending=%d writeBackFailed=%d cleanupOrphans=%s",
-		writtenBack,
-		childSkipped,
-		cleanupPendingHashes.length,
-		writeBackFailures.length,
-		opts?.cleanupOrphans === true,
-	);
-	return {
-		writtenBack,
-		childSkipped,
-		...(cleanupPendingHashes.length > 0 && { cleanupPendingHashes }),
-		...(writeBackFailures.length > 0 && { writeBackFailures }),
-	};
-}
-
-async function writeBackBatchItem(
-	entry: BuiltBatchItem,
-	result: BatchItemResult,
-	displayBase: string,
-	ctx: PushContext,
-): Promise<CommitSummary | undefined> {
-	const summaryDoc = result.summary;
-	/* v8 ignore next -- callers only pass ok results, which always carry summary */
-	if (!summaryDoc) return undefined;
-	const summaryUrl = resolveArticleUrl(displayBase, summaryDoc.url, summaryDoc.docId);
-	const published = new Map<string, Array<{ entryKey: string; url: string; docId: number }>>();
-	// A batch attachment failure arrives as `ok: false` inside a 2xx body, so nothing
-	// throws. These used to be dropped in silence, which made a server-side rejection
-	// of an entire docType invisible on the DEFAULT push path. `doctype_not_allowed`
-	// is collapsed to one line per docType — every attachment of that kind fails for
-	// the same reason, so one per item would be a dozen copies of one problem.
-	const unsupportedDocTypes = new Set<string>();
-	for (const att of result.attachments) {
-		const identity = entry.attachmentKeys.get(att.clientKey);
-		if (!att.ok || att.docId === undefined || att.url === undefined) {
-			if (!att.ok) {
-				if (att.errorCode === "doctype_not_allowed") {
-					unsupportedDocTypes.add(identity?.docType ?? "?");
-				} else {
-					log.error(
-						"Batch push: attachment %s (%s) of %s FAILED: %s",
-						att.clientKey,
-						identity?.docType ?? "?",
-						entry.summary.commitHash.substring(0, 8),
-						att.error ?? att.errorCode ?? "no reason reported",
-					);
-				}
-			}
-			continue;
-		}
-		if (!identity) continue;
-		const url = resolveArticleUrl(displayBase, att.url, att.docId);
-		const forKind = published.get(identity.docType);
-		const doc = { entryKey: identity.key, url, docId: att.docId };
-		if (forKind) forKind.push(doc);
-		else published.set(identity.docType, [doc]);
-	}
-	for (const docType of unsupportedDocTypes) {
-		log.warn(
-			"Batch push: the server does not have docType \"%s\" enabled, so none of %s's articles of that kind were created. Enable it in the server's supported-docType configuration.",
-			docType,
-			entry.summary.commitHash.substring(0, 8),
-		);
-	}
-	const summary = entry.summary;
-	const updatedSummary: CommitSummary = {
-		...applyPublishedUrls(summary, published),
-		jolliDocUrl: summaryUrl,
-		jolliDocId: summaryDoc.docId,
-	};
-	await storeSummary(updatedSummary, ctx.cwd, true, undefined, ctx.storage);
-	return updatedSummary;
-}
-
 // ── Push orchestration (network I/O) ─────────────────────────────────────────
 
 /**
@@ -678,12 +314,49 @@ function toContextSelection(
 export interface PushSummaryResult {
 	readonly summary: CommitSummary;
 	readonly summaryUrl: string;
+	/** Article id minted (or updated) by this push — pairs with {@link summaryUrl}. */
+	readonly docId: number;
 	/**
 	 * The server's Space echo from the summary push (newer servers,
 	 * repoUrl-routed pushes only) — callers persist it as the local binding
 	 * cache. Absent on older servers.
 	 */
 	readonly jmSpace?: { readonly id: number; readonly name: string };
+	/**
+	 * The article was published but its docId never reached local storage. The
+	 * push itself SUCCEEDED — the caller must keep the pending entry and record
+	 * {@link docId} / {@link summaryUrl} on it (`pushedDocId` / `pushedUrl`) so
+	 * the next drain UPDATEs that article instead of CREATEing a duplicate, and
+	 * must NOT burn a retry: nothing about the push needs retrying, only the
+	 * local bookkeeping.
+	 */
+	readonly writeBackFailed?: boolean;
+	/**
+	 * Orphaned articles are still awaiting deletion — either because
+	 * {@link PushSummaryOptions.skipOrphanCleanup} deferred it, or because a
+	 * cleanup pass could not delete every id. The caller must keep the pending
+	 * entry (patch, not delete) so a later confirmed drain finishes the job;
+	 * dropping it would strand those articles with nothing pointing at them.
+	 */
+	readonly cleanupPending?: boolean;
+}
+
+export interface PushSummaryOptions {
+	/**
+	 * Skips orphan resolution and deletion, reporting
+	 * {@link PushSummaryResult.cleanupPending} instead.
+	 *
+	 * The pre-push worker sets this. Orphan cleanup issues real `deleteDoc`
+	 * calls, and pre-push runs BEFORE git has transferred objects: if the push is
+	 * then rejected, the remote history still contains those commits while their
+	 * articles are gone, and the pending entry that could have restored them was
+	 * deleted on success. Unrecoverable.
+	 *
+	 * The compensation drains leave this off — they confirm the push against the
+	 * remote first, so deleting is safe there. Only the unconfirmed pre-push flow
+	 * sets it.
+	 */
+	readonly skipOrphanCleanup?: boolean;
 }
 
 /**
@@ -706,6 +379,7 @@ export async function pushSummary(
 	summary: CommitSummary,
 	ctx: PushContext,
 	attachments?: AttachmentSelection | ContextSelection,
+	opts?: PushSummaryOptions,
 ): Promise<PushSummaryResult> {
 	const displayBase = ctx.baseUrl.replace(/\/+$/, "");
 	// Env key of the tenant this push targets — every docId minted below is tagged
@@ -771,7 +445,12 @@ export async function pushSummary(
 				err instanceof Error ? err.message : String(err),
 			);
 		}
-		return { summary, summaryUrl, ...(result.jmSpace !== undefined ? { jmSpace: result.jmSpace } : {}) };
+		return {
+			summary,
+			summaryUrl,
+			docId: result.docId,
+			...(result.jmSpace !== undefined ? { jmSpace: result.jmSpace } : {}),
+		};
 	}
 
 	// Write-back weaves onto the summary's OWN items (not the reduced copy above), so
@@ -781,7 +460,42 @@ export async function pushSummary(
 		jolliDocUrl: summaryUrl,
 		jolliDocId: result.docId,
 	};
-	await storeSummary(updatedSummary, ctx.cwd, true, undefined, ctx.storage);
+	// The article exists server-side from here on, so a write-back failure must
+	// NOT surface as a failed push. Report it instead: the caller records the
+	// minted docId/url on the pending entry so the retry UPDATEs that article
+	// rather than CREATEing a second one. Without this the id is lost exactly
+	// like an aborted request loses it.
+	let writeBackFailed = false;
+	try {
+		await storeSummary(updatedSummary, ctx.cwd, true, undefined, ctx.storage);
+	} catch (err) {
+		writeBackFailed = true;
+		log.warn(
+			"Local write-back after a successful push failed for %s: %s",
+			summary.commitHash.substring(0, 8),
+			err instanceof Error ? err.message : String(err),
+		);
+	}
+
+	const common = {
+		summaryUrl,
+		docId: result.docId,
+		...(writeBackFailed ? { writeBackFailed: true } : {}),
+		...(result.jmSpace !== undefined ? { jmSpace: result.jmSpace } : {}),
+	};
+
+	// Orphan cleanup issues real deleteDoc calls, so it only runs where the push
+	// is already known to have reached the remote. See PushSummaryOptions.
+	if (opts?.skipOrphanCleanup) {
+		const cleanupPending = hasPendingOrphanCleanup(updatedSummary);
+		if (cleanupPending) {
+			log.info(
+				"Deferring orphan cleanup for %s — this push is not confirmed on the remote yet",
+				summary.commitHash.substring(0, 8),
+			);
+		}
+		return { ...common, summary: updatedSummary, ...(cleanupPending ? { cleanupPending: true } : {}) };
+	}
 
 	const summaryForCleanup = await resolveUnresolvedOrphanHashes(updatedSummary, ctx);
 
@@ -796,7 +510,14 @@ export async function pushSummary(
 		log.warn("Orphan cleanup failed after a successful push: %s", err instanceof Error ? err.message : String(err));
 	}
 
-	return { summary: finalSummary, summaryUrl, ...(result.jmSpace !== undefined ? { jmSpace: result.jmSpace } : {}) };
+	// Reported from the FINAL state rather than from "did we skip cleanup":
+	// cleanupOrphanedDocs leaves ids it could not delete in orphanedDocIds for the
+	// next push, and the caller has to keep the pending entry for those too.
+	return {
+		...common,
+		summary: finalSummary,
+		...(hasPendingOrphanCleanup(finalSummary) ? { cleanupPending: true } : {}),
+	};
 }
 
 function hasPendingOrphanCleanup(summary: CommitSummary): boolean {
@@ -931,6 +652,12 @@ export type PushBranchResult =
  * is attempted. Without `opts.space`, an unbound repo surfaces as
  * `{ type: "binding_required" }` with the space list so the caller can prompt
  * and retry with `opts.space` set.
+ *
+ * A published summary whose local write-back failed
+ * ({@link PushSummaryResult.writeBackFailed}) stops the loop with
+ * `{ type: "error" }`. This path has no per-commit retry state to carry the
+ * minted docId forward, so a "pushed" verdict there would hide a lost id behind
+ * a success and duplicate the article on the next push.
  */
 export async function pushBranchToJolli(opts: PushBranchOpts): Promise<PushBranchResult> {
 	const client = opts.client ?? new JolliMemoryPushClient();
@@ -995,9 +722,23 @@ export async function pushBranchToJolli(opts: PushBranchOpts): Promise<PushBranc
 		for (const s of summaries) {
 			const attachments = selectionForCommit(owned, s.commitHash);
 			// BindingRequiredError propagates — fatal for the whole batch.
-			const { summaryUrl, jmSpace } = await pushSummary(s, ctx, attachments);
+			const { summaryUrl, jmSpace, writeBackFailed } = await pushSummary(s, ctx, attachments);
 			if (jmSpace) {
 				confirmedSpace = jmSpace;
+			}
+			if (writeBackFailed) {
+				// The article IS published, but its docId never reached local storage.
+				// Unlike the drains (see PushExecutor's `writeBackFailed` branch) this
+				// path owns no push-pending entry to record the minted id on, so nothing
+				// points at that article any more: reporting "pushed" would send the user
+				// into a re-push that CREATEs a second article for this commit. Report the
+				// loud failure this was before `pushSummary` started swallowing the
+				// write-back error, and leave the remaining summaries unsent — they all
+				// need the very write that just failed.
+				return {
+					type: "error",
+					message: `Pushed ${s.commitHash.substring(0, 8)} to ${summaryUrl}, but recording its article id locally failed, so a re-push would create a second article for that commit. Remaining summaries were not pushed — see .jolli/jollimemory/debug.log.`,
+				};
 			}
 			urls.push(summaryUrl);
 		}

--- a/cli/src/core/PushExecutor.test.ts
+++ b/cli/src/core/PushExecutor.test.ts
@@ -3,22 +3,22 @@ import type { CommitSummary } from "../Types.js";
 import { execGit, getCurrentBranch, getDefaultBranch } from "./GitOps.js";
 import { getCanonicalRepoUrl } from "./GitRemoteUtils.js";
 import {
-	BATCH_MAX_ITEMS,
-	BATCH_MAX_TOTAL_CONTENT_CHARS,
-	type BatchPushPayload,
-	type BatchPushResult,
-	BatchUnsupportedError,
 	BindingRequiredError,
 	ClientOutdatedError,
 	NotAuthenticatedError,
 	PermissionDeniedError,
 } from "./JolliMemoryPushClient.js";
-import { applyBatchResult, type BuiltBatchItem, buildBatchItems, pushSummary } from "./JolliMemoryPushOrchestrator.js";
+import { pushSummary } from "./JolliMemoryPushOrchestrator.js";
 import { loadBranchSummaries } from "./PrDescription.js";
 import { isOutboundPushAllowed } from "./PushControl.js";
-import { classifyError, processPrePushInline, processPushPending, triggerPushForNewSummaries } from "./PushExecutor.js";
+import {
+	type CommitPushOutcome,
+	classifyError,
+	processPushPending,
+	triggerPushForNewSummaries,
+} from "./PushExecutor.js";
 import { claimForPush, loadPushPending, type PushPendingEntry, updateBatch } from "./PushPendingStore.js";
-import { assignOwnedContext, type OwnedContext } from "./push/ContextPush.js";
+import { assignOwnedContext, type ContextSelection } from "./push/ContextPush.js";
 import { loadConfig } from "./SessionTracker.js";
 import { clearSpaceBindingCache, saveSpaceBindingCache } from "./SpaceBindingCache.js";
 import { createStorage } from "./StorageFactory.js";
@@ -53,8 +53,6 @@ vi.mock("./JolliMemoryPushOrchestrator.js", async (importOriginal) => {
 	return {
 		...actual,
 		pushSummary: vi.fn(),
-		buildBatchItems: vi.fn(),
-		applyBatchResult: vi.fn(),
 	};
 });
 // Ownership is now computed by the generic context-kind engine, so that is what
@@ -72,6 +70,8 @@ vi.mock("./SpaceBindingCache.js", () => ({
 }));
 
 const CWD = "/repo";
+/** The stamp `claimForPush` returns — the heartbeat's compare-and-swap token. */
+const CLAIMED_AT = "2026-01-01T00:00:00.000Z";
 const HASH_A = "a".repeat(40);
 const HASH_B = "b".repeat(40);
 const FAKE_STORAGE = { id: "fake" } as never;
@@ -84,67 +84,31 @@ function summary(hash: string, branch = "feature/x"): CommitSummary {
 	} as CommitSummary;
 }
 
-/** pushBatch mock that succeeds for every item in the payload, per-item docIds 100+. */
-function okPushBatch(jmSpace?: { id: number; name: string }) {
-	return vi.fn(async (payload: { items: Array<{ commitHash: string }> }) => ({
-		results: payload.items.map((item, index) => ({
-			commitHash: item.commitHash,
-			ok: true,
-			summary: {
-				docId: 100 + index,
-				url: `/articles/doc-${100 + index}`,
-				jrn: `jrn:${index}`,
-				created: true,
-			},
-			attachments: [],
-		})),
-		...(jmSpace !== undefined ? { jmSpace } : {}),
-	}));
+/**
+ * Client stub for processPushPending tests. Uploads go through the mocked
+ * `pushSummary`, so the client only has to resolve a base URL.
+ */
+function fakeClient() {
+	return { resolveBaseUrl: vi.fn(async () => "https://acme.jolli.ai") } as never;
+}
+
+/** A successful `pushSummary` result for `hash`, optionally carrying extra flags. */
+function pushed(hash: string, extra: Record<string, unknown> = {}) {
+	return {
+		summary: summary(hash),
+		summaryUrl: `https://acme.jolli.ai/articles/doc-${hash.substring(0, 4)}`,
+		docId: 100,
+		...extra,
+	} as never;
 }
 
 /**
- * Client stub for processPushPending tests. The default pushBatch succeeds for
- * every item; pass an explicit mock to drive failures or capture payloads.
+ * Every entry update this run committed, merged across calls. Accounting is
+ * persisted per commit AS IT SETTLES, so no single `updateBatch` call holds the
+ * whole ledger — asserting on one of them only sees a fragment.
  */
-function fakeClient(pushBatch?: ReturnType<typeof vi.fn>) {
-	return {
-		resolveBaseUrl: vi.fn(async () => "https://acme.jolli.ai"),
-		pushBatch: pushBatch ?? okPushBatch(),
-	} as never;
-}
-
-/** Client stub for the inline batch path — `pushBatch` is injectable per test. */
-function fakeBatchClient(pushBatch: ReturnType<typeof vi.fn>) {
-	return {
-		resolveBaseUrl: vi.fn(async () => "https://acme.jolli.ai"),
-		pushBatch,
-	} as never;
-}
-
-/** Minimal BuiltBatchItem for one summary — mirrors what buildBatchItems produces. */
-function builtItem(hash: string, branch = "feature/x"): BuiltBatchItem {
-	return {
-		item: {
-			commitHash: hash,
-			branch,
-			summary: { title: `t-${hash.substring(0, 4)}`, content: "# body" },
-			attachments: [],
-		},
-		summary: summary(hash, branch),
-		attachmentKeys: new Map(),
-		batchContentChars: 6,
-	};
-}
-
-function okBatchResult(...hashes: string[]): BatchPushResult {
-	return {
-		results: hashes.map((hash, index) => ({
-			commitHash: hash,
-			ok: true,
-			summary: { docId: 100 + index, url: `/articles/doc-${100 + index}`, jrn: `jrn:${index}`, created: true },
-			attachments: [],
-		})),
-	};
+function flushedUpdates() {
+	return new Map(vi.mocked(updateBatch).mock.calls.flatMap((call) => [...call[1]]));
 }
 
 function entry(retryCount = 0, overrides: Partial<PushPendingEntry> = {}): PushPendingEntry {
@@ -168,10 +132,12 @@ beforeEach(() => {
 		missingCount: 0,
 	});
 	vi.mocked(assignOwnedContext).mockReturnValue(new Map());
-	vi.mocked(pushSummary).mockResolvedValue({ summary: summary(HASH_A), summaryUrl: "https://acme.jolli.ai/a" });
+	vi.mocked(pushSummary).mockResolvedValue({
+		summary: summary(HASH_A),
+		summaryUrl: "https://acme.jolli.ai/a",
+		docId: 1,
+	});
 	vi.mocked(updateBatch).mockResolvedValue(undefined);
-	vi.mocked(buildBatchItems).mockImplementation(async (summaries) => summaries.map((s) => builtItem(s.commitHash)));
-	vi.mocked(applyBatchResult).mockResolvedValue({ writtenBack: 0, childSkipped: 0 });
 	// Default: every candidate is claimed successfully, and the returned
 	// `entries` mirror whatever the current `loadPushPending` mock has been
 	// set up to return — so tests that seed a specific retryCount into
@@ -184,6 +150,7 @@ beforeEach(() => {
 		return {
 			claimed: new Set(candidates),
 			entries: Object.fromEntries(candidates.map((h) => [h, pendingEntries[h] ?? entry()])),
+			claimedAt: CLAIMED_AT,
 		};
 	});
 });
@@ -270,7 +237,7 @@ describe("processPushPending", () => {
 	// detached pass with no retry of its own — so a claim this run left behind makes
 	// `claimForPush` skip the entry (claims are honoured for CLAIM_STALE_MS = 5 min) and
 	// the backlog sits until some unrelated later trigger. The mirror site in
-	// `processPrePushInline` already released; this one silently did not.
+	// Releasing here is what makes the re-enable drain immediate.
 	it("releases the claim on every held entry so the re-enable drain can re-claim immediately", async () => {
 		vi.mocked(loadPushPending).mockResolvedValue({
 			version: 1,
@@ -280,18 +247,15 @@ describe("processPushPending", () => {
 
 		await processPushPending(CWD, { source: "activation", client: fakeClient() });
 
-		const flushed = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
-		expect(flushed?.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
-		expect(flushed?.get(HASH_B)).toEqual({ kind: "patch", patch: {} });
+		const flushed = flushedUpdates();
+		expect(flushed.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
+		expect(flushed.get(HASH_B)).toEqual({ kind: "patch", patch: {} });
 	});
 
-	it("releases the claim when the per-commit gate holds an individual-fallback push", async () => {
+	it("releases the claim when the per-commit gate holds a push", async () => {
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
 		// Batch-ineligible → the legacy per-commit fallback, whose own gate is the one
 		// under test here (the batch loop never runs: there are no eligible groups).
-		vi.mocked(buildBatchItems).mockImplementation(async (summaries) =>
-			summaries.map((s) => ({ ...builtItem(s.commitHash), batchIneligibleReason: "attachment too large" })),
-		);
 		vi.mocked(isOutboundPushAllowed).mockResolvedValueOnce(true).mockResolvedValue(false);
 
 		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
@@ -299,16 +263,13 @@ describe("processPushPending", () => {
 		expect(pushSummary).not.toHaveBeenCalled();
 		expect(r.pushed).toBe(0);
 		expect(r.failed).toBe(0);
-		const flushed = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
-		expect(flushed?.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
+		const flushed = flushedUpdates();
+		expect(flushed.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
 	});
 
 	it("releases the claim when the orchestrator's own live re-check rejects a fallback push", async () => {
 		const { PushDisabledError } = await import("./PushControl.js");
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		vi.mocked(buildBatchItems).mockImplementation(async (summaries) =>
-			summaries.map((s) => ({ ...builtItem(s.commitHash), batchIneligibleReason: "attachment too large" })),
-		);
 		// Both gates pass; the toggle lands between the attachment sends, so the refusal
 		// arrives as the orchestrator's typed error instead.
 		vi.mocked(pushSummary).mockRejectedValue(new PushDisabledError());
@@ -318,8 +279,8 @@ describe("processPushPending", () => {
 		// Held, not failed — and no retry burned, which is what the empty patch proves.
 		expect(r.pushed).toBe(0);
 		expect(r.failed).toBe(0);
-		const flushed = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
-		expect(flushed?.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
+		const flushed = flushedUpdates();
+		expect(flushed.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
 	});
 
 	it("skips entries that exhausted the retry budget", async () => {
@@ -334,15 +295,13 @@ describe("processPushPending", () => {
 			version: 1,
 			entries: { [HASH_A]: entry(), [HASH_B]: entry() },
 		});
-		const pushBatch = okPushBatch();
 		await processPushPending(CWD, {
 			source: "post-queue",
 			hashFilter: new Set([HASH_A]),
-			client: fakeClient(pushBatch),
+			client: fakeClient(),
 		});
-		expect(pushBatch).toHaveBeenCalledTimes(1);
-		const payload = pushBatch.mock.calls[0][0] as { items: Array<{ commitHash: string }> };
-		expect(payload.items.map((item) => item.commitHash)).toEqual([HASH_A]);
+		expect(pushSummary).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(pushSummary).mock.calls[0][0].commitHash).toBe(HASH_A);
 	});
 
 	it("skips candidates whose memory isn't generated yet and releases the claim so the post-queue trigger can re-claim", async () => {
@@ -354,7 +313,7 @@ describe("processPushPending", () => {
 		// Empty patch releases claimedAt so QueueWorker's post-drain trigger
 		// (triggerPushForNewSummaries) can re-claim once the summary lands.
 		expect(updateBatch).toHaveBeenCalledTimes(1);
-		const batch = vi.mocked(updateBatch).mock.calls[0][1];
+		const batch = flushedUpdates();
 		expect(batch.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
 	});
 
@@ -368,56 +327,26 @@ describe("processPushPending", () => {
 		// case above. Without it, the immediate post-queue push would be blocked
 		// by the still-fresh claimedAt for up to CLAIM_STALE_MS (5 min).
 		expect(updateBatch).toHaveBeenCalledTimes(1);
-		const batch = vi.mocked(updateBatch).mock.calls[0][1];
+		const batch = flushedUpdates();
 		expect(batch.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
 	});
 
-	it("pushes a candidate with memory in one batch request and deletes it on success", async () => {
+	it("pushes a candidate with memory and deletes its entry on success", async () => {
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const pushBatch = okPushBatch();
-		const r = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
-		expect(r.pushed).toBe(1);
-		expect(pushBatch).toHaveBeenCalledTimes(1);
-		expect(pushSummary).not.toHaveBeenCalled();
-		const batch = vi.mocked(updateBatch).mock.calls[0][1];
-		expect(batch.get(HASH_A)).toEqual({ kind: "delete" });
-		// Compensation opts into orphan cleanup during write-back.
-		expect(applyBatchResult).toHaveBeenCalledWith(expect.any(Array), expect.any(Array), expect.any(Object), {
-			cleanupOrphans: true,
-		});
-	});
-
-	it("keeps a pushed entry pending with the minted ids when its write-back fails", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		vi.mocked(applyBatchResult).mockResolvedValueOnce({
-			writtenBack: 0,
-			childSkipped: 0,
-			writeBackFailures: [{ commitHash: HASH_A, docId: 100, url: "https://acme.jolli.ai/articles/doc-100" }],
-		});
-
 		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
-
 		expect(r.pushed).toBe(1);
-		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
-		expect(batch?.get(HASH_A)).toEqual({
-			kind: "patch",
-			patch: {
-				lastAttemptAt: expect.any(String),
-				lastError: "pushed, but persisting the article id locally failed — will retry the write-back",
-				pushedDocId: 100,
-				pushedUrl: "https://acme.jolli.ai/articles/doc-100",
-			},
-		});
+		expect(pushSummary).toHaveBeenCalledTimes(1);
+		const batch = flushedUpdates();
+		expect(batch.get(HASH_A)).toEqual({ kind: "delete" });
+		// Compensation leaves orphan cleanup enabled; only pre-push defers it.
+		expect(vi.mocked(pushSummary).mock.calls[0][3]).toEqual({ skipOrphanCleanup: false });
 	});
 
-	it("grafts the recovered docId/url into the individual fallback push", async () => {
+	it("grafts the recovered docId/url into the push", async () => {
 		vi.mocked(loadPushPending).mockResolvedValue({
 			version: 1,
 			entries: { [HASH_A]: entry(0, { pushedDocId: 55, pushedUrl: "https://acme.jolli.ai/articles/doc-55" }) },
 		});
-		vi.mocked(buildBatchItems).mockImplementation(async (summaries) =>
-			summaries.map((s) => ({ ...builtItem(s.commitHash), batchIneligibleReason: "attachment too large" })),
-		);
 
 		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
 
@@ -429,108 +358,25 @@ describe("processPushPending", () => {
 		});
 	});
 
-	it("chunks more than BATCH_MAX_ITEMS commits into multiple batch requests", async () => {
-		const entries: Record<string, PushPendingEntry> = {};
-		for (let i = 0; i < BATCH_MAX_ITEMS + 1; i++) {
-			entries[`h-${String(i).padStart(3, "0")}`] = entry();
-		}
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries });
-		const pushBatch = okPushBatch();
-		const r = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
-		expect(pushBatch).toHaveBeenCalledTimes(2);
-		expect(r.pushed).toBe(BATCH_MAX_ITEMS + 1);
-	});
-
-	it("splits batch requests before their combined content exceeds the server limit", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({
-			version: 1,
-			entries: { [HASH_A]: entry(), [HASH_B]: entry() },
-		});
-		const charsPerItem = Math.floor(BATCH_MAX_TOTAL_CONTENT_CHARS / 2) + 1;
-		vi.mocked(buildBatchItems).mockResolvedValueOnce([
-			{ ...builtItem(HASH_A), batchContentChars: charsPerItem },
-			{ ...builtItem(HASH_B), batchContentChars: charsPerItem },
-		]);
-		const pushBatch = okPushBatch();
-
-		const result = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
-
-		expect(result.pushed).toBe(2);
-		expect(pushBatch).toHaveBeenCalledTimes(2);
-		expect(pushBatch.mock.calls[0][0].items).toHaveLength(1);
-		expect(pushBatch.mock.calls[1][0].items).toHaveLength(1);
-	});
-
-	it("uses the per-commit path for an item that cannot pass the batch schema", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		vi.mocked(buildBatchItems).mockResolvedValueOnce([
-			{ ...builtItem(HASH_A), batchIneligibleReason: "attachment count exceeds the batch limit" },
-		]);
-		const pushBatch = okPushBatch();
-
-		const result = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
-
-		expect(result.pushed).toBe(1);
-		expect(pushBatch).not.toHaveBeenCalled();
-		expect(pushSummary).toHaveBeenCalledTimes(1);
-	});
-
-	it("falls back to per-commit pushSummary when the server lacks batch support", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const pushBatch = vi.fn(async () => {
-			throw new BatchUnsupportedError();
-		});
-		const r = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
-		expect(pushSummary).toHaveBeenCalledTimes(1);
-		expect(r.pushed).toBe(1);
-		const batch = vi.mocked(updateBatch).mock.calls[0][1];
-		expect(batch.get(HASH_A)).toEqual({ kind: "delete" });
-	});
-
-	it("keeps a successful compensation entry pending while orphan cleanup remains", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		vi.mocked(applyBatchResult).mockResolvedValueOnce({
-			writtenBack: 1,
-			childSkipped: 0,
-			cleanupPendingHashes: [HASH_A],
-		});
-
-		const result = await processPushPending(CWD, { source: "activation", client: fakeClient() });
-
-		expect(result.pushed).toBe(1);
-		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
-		expect(batch?.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
-	});
-
-	it("keeps the raced-away guard on the per-commit fallback path", async () => {
+	it("keeps the raced-away guard on the per-commit path", async () => {
 		vi.mocked(loadBranchSummaries).mockResolvedValue({ summaries: [], missingCount: 0 });
 		vi.mocked(getSummary)
 			.mockResolvedValueOnce(summary(HASH_A)) // memory check
 			.mockResolvedValueOnce(null); // fallback pushOne re-read
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const pushBatch = vi.fn(async () => {
-			throw new BatchUnsupportedError();
-		});
-		const r = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
 		expect(r.failed).toBe(1);
 		expect(pushSummary).not.toHaveBeenCalled();
-		const batch = vi.mocked(updateBatch).mock.calls[0][1];
+		const batch = flushedUpdates();
 		expect(batch.get(HASH_A)).toEqual({ kind: "delete" });
 	});
 
 	it("persists the server's Space echo as the binding cache after a successful individual push", async () => {
 		// Only the per-commit fallback carries the echo — batch responses have none.
-		vi.mocked(pushSummary).mockResolvedValue({
-			summary: summary(HASH_A),
-			summaryUrl: "https://acme.jolli.ai/a",
-			jmSpace: { id: 7, name: "Acme Core" },
-		});
+		vi.mocked(pushSummary).mockResolvedValue(pushed(HASH_A, { jmSpace: { id: 7, name: "Acme Core" } }));
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const pushBatch = vi.fn(async () => {
-			throw new BatchUnsupportedError();
-		});
 
-		await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
+		await processPushPending(CWD, { source: "activation", client: fakeClient() });
 
 		expect(saveSpaceBindingCache).toHaveBeenCalledWith(CWD, {
 			repoUrl: "https://github.com/acme/repo",
@@ -543,11 +389,8 @@ describe("processPushPending", () => {
 
 	it("leaves the binding cache untouched when the server echoes no Space (older server)", async () => {
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const pushBatch = vi.fn(async () => {
-			throw new BatchUnsupportedError();
-		});
 
-		await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
+		await processPushPending(CWD, { source: "activation", client: fakeClient() });
 
 		expect(saveSpaceBindingCache).not.toHaveBeenCalled();
 		expect(clearSpaceBindingCache).not.toHaveBeenCalled();
@@ -566,10 +409,8 @@ describe("processPushPending", () => {
 	it("persists the batch top-level Space echo as the binding cache", async () => {
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
 
-		const r = await processPushPending(CWD, {
-			source: "activation",
-			client: fakeClient(okPushBatch({ id: 7, name: "Acme Core" })),
-		});
+		vi.mocked(pushSummary).mockResolvedValue(pushed(HASH_A, { jmSpace: { id: 7, name: "Acme Core" } }));
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
 
 		expect(r.pushed).toBe(1);
 		expect(saveSpaceBindingCache).toHaveBeenCalledWith(CWD, {
@@ -581,29 +422,25 @@ describe("processPushPending", () => {
 		});
 	});
 
-	it("clears the binding cache when a batch push is rejected with binding_required", async () => {
+	it("clears the binding cache when a push is rejected with binding_required", async () => {
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const pushBatch = vi.fn(async () => {
-			throw new BindingRequiredError("https://github.com/acme/repo");
-		});
+		vi.mocked(pushSummary).mockRejectedValue(new BindingRequiredError("https://github.com/acme/repo"));
 
-		const r = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
 
 		expect(r.failed).toBe(1);
 		expect(clearSpaceBindingCache).toHaveBeenCalledWith(CWD);
 		expect(saveSpaceBindingCache).not.toHaveBeenCalled();
 		// The 412 stays a held (non-counted) retry, exactly as before the cache.
-		const batch = vi.mocked(updateBatch).mock.calls[0][1];
+		const batch = flushedUpdates();
 		expect(batch.get(HASH_A)).toMatchObject({ kind: "patch", patch: { lastError: "binding-required" } });
 	});
 
-	it("clears the binding cache when a batch push is rejected with permission denied", async () => {
+	it("clears the binding cache when a push is rejected with permission denied", async () => {
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const pushBatch = vi.fn(async () => {
-			throw new PermissionDeniedError();
-		});
+		vi.mocked(pushSummary).mockRejectedValue(new PermissionDeniedError());
 
-		await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
+		await processPushPending(CWD, { source: "activation", client: fakeClient() });
 
 		expect(clearSpaceBindingCache).toHaveBeenCalledWith(CWD);
 	});
@@ -611,11 +448,8 @@ describe("processPushPending", () => {
 	it("clears the binding cache when an individual push is rejected as unauthenticated", async () => {
 		vi.mocked(pushSummary).mockRejectedValue(new NotAuthenticatedError());
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const pushBatch = vi.fn(async () => {
-			throw new BatchUnsupportedError();
-		});
 
-		await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
+		await processPushPending(CWD, { source: "activation", client: fakeClient() });
 
 		expect(clearSpaceBindingCache).toHaveBeenCalledWith(CWD);
 	});
@@ -623,11 +457,8 @@ describe("processPushPending", () => {
 	it("does not clear the binding cache on an operational (network) failure", async () => {
 		vi.mocked(pushSummary).mockRejectedValue(new Error("ECONNRESET"));
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const pushBatch = vi.fn(async () => {
-			throw new BatchUnsupportedError();
-		});
 
-		await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
+		await processPushPending(CWD, { source: "activation", client: fakeClient() });
 
 		expect(clearSpaceBindingCache).not.toHaveBeenCalled();
 	});
@@ -646,12 +477,11 @@ describe("processPushPending", () => {
 			},
 		});
 
-		const pushBatch = okPushBatch();
-		const result = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
+		const result = await processPushPending(CWD, { source: "activation", client: fakeClient() });
 
 		expect(result.pushed).toBe(1);
 		expect(execGit).toHaveBeenCalledWith(["ls-remote", "--refs", pushUrl, remoteRef], CWD);
-		expect(pushBatch).toHaveBeenCalledTimes(1);
+		expect(pushSummary).toHaveBeenCalledTimes(1);
 	});
 
 	it("keeps the entry when the remote ref does not contain the pushed SHA", async () => {
@@ -712,14 +542,16 @@ describe("processPushPending", () => {
 		expect(pushSummary).not.toHaveBeenCalled();
 	});
 
-	it("passes owned attachments into the batch build (cross-commit dedup)", async () => {
+	it("passes the owned selection into each commit's push (cross-commit dedup)", async () => {
 		vi.mocked(assignOwnedContext).mockReturnValue(
 			new Map([["plan", { owned: new Map([[HASH_A, [{ slug: "p-1234abcd" }]]]), seeds: new Map() }]]) as never,
 		);
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
 		await processPushPending(CWD, { source: "activation", client: fakeClient() });
-		const ownership = vi.mocked(buildBatchItems).mock.calls[0][1] as OwnedContext;
-		expect(ownership.get("plan")?.owned.get(HASH_A)).toHaveLength(1);
+		// A kind-agnostic ContextSelection, not the legacy `{plans, notes, references}`
+		// shape: naming only those three would mean "push zero skills".
+		const selection = vi.mocked(pushSummary).mock.calls[0][2] as ContextSelection;
+		expect(selection.get("plan")).toHaveLength(1);
 	});
 
 	it("builds attachment ownership from an off-current branch context", async () => {
@@ -752,18 +584,16 @@ describe("processPushPending", () => {
 		await processPushPending(CWD, { source: "activation", client: fakeClient() });
 
 		expect(assignOwnedContext).toHaveBeenCalledWith([offSummary]);
-		const ownership = vi.mocked(buildBatchItems).mock.calls[0][1] as OwnedContext;
-		expect(ownership.get("plan")?.owned.get(HASH_A)).toHaveLength(1);
+		const selection = vi.mocked(pushSummary).mock.calls[0][2] as ContextSelection;
+		expect(selection.get("plan")).toHaveLength(1);
 	});
 
-	it("increments retryCount when the batch request fails operationally", async () => {
-		const pushBatch = vi.fn(async () => {
-			throw new Error("network down");
-		});
+	it("increments retryCount when the push fails operationally", async () => {
+		vi.mocked(pushSummary).mockRejectedValue(new Error("network down"));
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(1) } });
-		const r = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
 		expect(r.failed).toBe(1);
-		const batch = vi.mocked(updateBatch).mock.calls[0][1];
+		const batch = flushedUpdates();
 		const update = batch.get(HASH_A);
 		expect(update).toMatchObject({ kind: "patch" });
 		if (update?.kind === "patch") {
@@ -773,31 +603,14 @@ describe("processPushPending", () => {
 	});
 
 	it("does NOT increment retryCount on NotAuthenticated mid-push", async () => {
-		const pushBatch = vi.fn(async () => {
-			throw new NotAuthenticatedError();
-		});
+		vi.mocked(pushSummary).mockRejectedValue(new NotAuthenticatedError());
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(1) } });
-		await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
-		const batch = vi.mocked(updateBatch).mock.calls[0][1];
+		await processPushPending(CWD, { source: "activation", client: fakeClient() });
+		const batch = flushedUpdates();
 		const update = batch.get(HASH_A);
 		if (update?.kind === "patch") {
 			expect(update.patch.retryCount).toBeUndefined();
 			expect(update.patch.lastError).toBe("not-authenticated");
-		}
-	});
-
-	it("records a per-item batch failure with a counted retry", async () => {
-		const pushBatch = vi.fn(async () => ({
-			results: [{ commitHash: HASH_A, ok: false, attachments: [], error: "boom", errorCode: "push_failed" }],
-		}));
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(1) } });
-		const r = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
-		expect(r.failed).toBe(1);
-		const batch = vi.mocked(updateBatch).mock.calls[0][1];
-		const update = batch.get(HASH_A);
-		if (update?.kind === "patch") {
-			expect(update.patch.retryCount).toBe(2);
-			expect(update.patch.lastError).toBe("boom");
 		}
 	});
 
@@ -837,7 +650,7 @@ describe("processPushPending", () => {
 		);
 		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
 		expect(pushSummary).not.toHaveBeenCalled();
-		const batch = vi.mocked(updateBatch).mock.calls[0][1];
+		const batch = flushedUpdates();
 		expect(batch.get(HASH_A)).toEqual({ kind: "delete" });
 		expect(r.note).toBe("all candidates were merged children");
 		expect(r.deletedChildren).toBe(1);
@@ -852,530 +665,184 @@ describe("processPushPending", () => {
 		vi.mocked(claimForPush).mockResolvedValue({
 			claimed: new Set([HASH_B]),
 			entries: { [HASH_B]: entry() },
+			claimedAt: CLAIMED_AT,
 		});
-		const pushBatch = okPushBatch();
-		await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
-		expect(pushBatch).toHaveBeenCalledTimes(1);
-		const payload = pushBatch.mock.calls[0][0] as { items: Array<{ commitHash: string }> };
-		expect(payload.items.map((item) => item.commitHash)).toEqual([HASH_B]);
+		await processPushPending(CWD, { source: "activation", client: fakeClient() });
+		expect(pushSummary).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(pushSummary).mock.calls[0][0].commitHash).toBe(HASH_B);
 	});
 
 	it("returns early when every candidate was already claimed by another process", async () => {
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		vi.mocked(claimForPush).mockResolvedValue({ claimed: new Set(), entries: {} });
-		const pushBatch = okPushBatch();
-		const r = await processPushPending(CWD, { source: "activation", client: fakeClient(pushBatch) });
+		vi.mocked(claimForPush).mockResolvedValue({ claimed: new Set(), entries: {}, claimedAt: CLAIMED_AT });
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
 		expect(r.note).toBe("all entries claimed by another process");
-		expect(pushBatch).not.toHaveBeenCalled();
+		expect(pushSummary).not.toHaveBeenCalled();
 	});
 });
+describe("processPushPending — pre-push options", () => {
+	const PUSH_TARGET = { remote: "origin", remoteRef: "refs/heads/feature/x", localSha: HASH_A };
 
-describe("processPrePushInline", () => {
-	const farDeadline = () => Date.now() + 60_000;
-
-	it("no-ops with no pending entries", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: {} });
-		const r = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(vi.fn()),
-		});
-		expect(r.note).toBe("no pending entries");
-		expect(claimForPush).not.toHaveBeenCalled();
-	});
-
-	it("keeps entries untouched when syncOnPush is disabled", async () => {
-		vi.mocked(loadConfig).mockResolvedValue({ jolliApiKey: "sk-jol-x", syncOnPush: false });
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const r = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(vi.fn()),
-		});
-		expect(r.note).toBe("syncOnPush disabled");
-		expect(updateBatch).not.toHaveBeenCalled();
-	});
-
-	it("keeps entries untouched when not signed in", async () => {
-		vi.mocked(loadConfig).mockResolvedValue({});
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const r = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(vi.fn()),
-		});
-		expect(r.note).toBe("not signed in");
-		expect(updateBatch).not.toHaveBeenCalled();
-	});
-
-	it("keeps entries untouched when push is disabled for the repo (Story 2)", async () => {
-		vi.mocked(isOutboundPushAllowed).mockResolvedValue(false);
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const r = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(vi.fn()),
-		});
-		expect(r.note).toBe("push disabled for this repo");
-		expect(updateBatch).not.toHaveBeenCalled();
-	});
-
-	it("marks retry-exhausted entries as failed in the result list", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(3) } });
-		const r = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(vi.fn()),
-		});
-		expect(r.skippedRetryExhausted).toBe(1);
-		expect(r.note).toBe("no eligible entries");
-		expect(r.commits).toEqual([{ hash: HASH_A, status: "failed", reason: "failed repeatedly — giving up" }]);
-	});
-
-	it("claims ONLY this push's commits — leftover entries stay for the compensation channels", async () => {
-		const leftover = "c".repeat(40);
+	it("skips the remote-ref confirmation gate when the pre-push worker asks for it", async () => {
+		// The worker runs while git still holds the hook open, so no ref has moved
+		// and ls-remote would refuse every entry. The control case below keeps the
+		// gate and drains nothing, which is what makes this meaningful.
 		vi.mocked(loadPushPending).mockResolvedValue({
 			version: 1,
-			entries: { [leftover]: entry(), [HASH_A]: entry() },
+			entries: { [HASH_A]: entry(0, { pushTargets: [PUSH_TARGET] }) },
 		});
-		const pushBatch = vi.fn(async () => okBatchResult(HASH_A));
-		const r = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(pushBatch),
+		const r = await processPushPending(CWD, {
+			source: "pre-push",
+			skipPushConfirmation: true,
+			client: fakeClient(),
 		});
-		expect(claimForPush).toHaveBeenCalledWith(CWD, [HASH_A]);
-		expect(r.commits.map((c) => c.hash)).toEqual([HASH_A]);
+		expect(r.pushed).toBe(1);
+		expect(execGit).not.toHaveBeenCalledWith(expect.arrayContaining(["ls-remote"]), CWD);
 	});
 
-	it("caps the candidate list at BATCH_MAX_ITEMS and defers the overflow", async () => {
-		const hashes = Array.from({ length: BATCH_MAX_ITEMS + 5 }, (_, i) => `hash-${String(i).padStart(3, "0")}`);
-		const entries: Record<string, PushPendingEntry> = {};
-		for (const hash of hashes) entries[hash] = entry();
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries });
-		const pushBatch = vi.fn(async () => ({ results: [] }));
-		const r = await processPrePushInline(CWD, {
-			priorityHashes: hashes,
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(pushBatch),
-		});
-		const candidates = vi.mocked(claimForPush).mock.calls[0][1];
-		expect(candidates).toHaveLength(BATCH_MAX_ITEMS);
-		expect(r.commits.filter((c) => c.status === "deferred")).toHaveLength(5);
-	});
-
-	it("returns early when every candidate was already claimed by another process", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		vi.mocked(claimForPush).mockResolvedValue({ claimed: new Set(), entries: {} });
-		const r = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(vi.fn()),
-		});
-		expect(r.note).toBe("all entries claimed by another process");
-	});
-
-	it("releases claims and reports notAttempted when the budget is already exhausted", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const pushBatch = vi.fn();
-		const r = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: Date.now() - 1,
-			client: fakeBatchClient(pushBatch),
-		});
-		expect(r.notAttempted).toBe(1);
-		expect(r.note).toBe("budget exhausted");
-		expect(pushBatch).not.toHaveBeenCalled();
-		expect(r.commits).toEqual([{ hash: HASH_A, status: "deferred", reason: "timed out — will sync later" }]);
-		const batch = vi.mocked(updateBatch).mock.calls[0][1];
-		expect(batch.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
-	});
-
-	it("releases no-memory candidates and deletes merged children before the batch", async () => {
-		const child = "e".repeat(40);
+	it("still enforces the confirmation gate for the compensation drains", async () => {
 		vi.mocked(loadPushPending).mockResolvedValue({
 			version: 1,
-			entries: { [HASH_A]: entry(), [child]: entry() },
+			entries: { [HASH_A]: entry(0, { pushTargets: [PUSH_TARGET] }) },
 		});
-		vi.mocked(getIndexEntryMap).mockResolvedValue(
-			new Map([
-				[
-					child,
-					{
-						commitHash: child,
-						parentCommitHash: HASH_B,
-						commitMessage: "",
-						commitDate: "",
-						branch: "feature/x",
-						generatedAt: "",
-					},
-				],
-			]),
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
+		expect(r.note).toBe("push not confirmed");
+		expect(pushSummary).not.toHaveBeenCalled();
+	});
+
+	it("passes the orphan-cleanup deferral through to pushSummary", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		await processPushPending(CWD, {
+			source: "pre-push",
+			skipPushConfirmation: true,
+			skipOrphanCleanup: true,
+			client: fakeClient(),
+		});
+		expect(vi.mocked(pushSummary).mock.calls[0][3]).toEqual({ skipOrphanCleanup: true });
+	});
+
+	it("keeps the entry pending when orphan cleanup is still outstanding", async () => {
+		// Dropping it would strand those articles with nothing left pointing at
+		// them — only a confirmed drain may delete them.
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
+		vi.mocked(pushSummary).mockResolvedValue(pushed(HASH_A, { cleanupPending: true }));
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
+		expect(r.pushed).toBe(1);
+		expect(flushedUpdates().get(HASH_A)).toEqual({ kind: "patch", patch: {} });
+	});
+
+	it("records the minted ids when the local write-back failed, without burning a retry", async () => {
+		// The article exists server-side; only the bookkeeping needs another go, so
+		// the next drain must UPDATE it rather than CREATE a duplicate.
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(1) } });
+		vi.mocked(pushSummary).mockResolvedValue(
+			pushed(HASH_A, { writeBackFailed: true, docId: 77, summaryUrl: "https://acme.jolli.ai/articles/doc-77" }),
 		);
-		vi.mocked(getSummary).mockResolvedValue(null);
-		const r = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A, child],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(vi.fn()),
-		});
-		expect(r.skippedNoMemory).toBe(1);
-		expect(r.deletedChildren).toBe(1);
-		expect(r.note).toBe("no candidates with memory");
-		expect(r.commits).toEqual([
-			{ hash: HASH_A, status: "generating", reason: "memory still generating — will sync later" },
-			{ hash: child, status: "merged", reason: "merged into another commit's memory" },
-		]);
-		const batch = vi.mocked(updateBatch).mock.calls[0][1];
-		expect(batch.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
-		expect(batch.get(child)).toEqual({ kind: "delete" });
-	});
-
-	it("pushes with-memory candidates in one batch, deletes successes, and writes back", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({
-			version: 1,
-			entries: { [HASH_A]: entry(), [HASH_B]: entry() },
-		});
-		const pushBatch = vi.fn(async (_payload: unknown) => okBatchResult(HASH_A, HASH_B));
-		const r = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A, HASH_B],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(pushBatch),
-		});
-		expect(r.pushed).toBe(2);
-		expect(r.failed).toBe(0);
-		expect(pushBatch).toHaveBeenCalledTimes(1);
-		const payload = pushBatch.mock.calls[0][0] as { repoUrl?: string; items: Array<{ commitHash: string }> };
-		expect(payload.repoUrl).toBe("https://github.com/acme/repo");
-		expect(payload.items.map((i) => i.commitHash).sort()).toEqual([HASH_A, HASH_B]);
-		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
-		expect(batch?.get(HASH_A)).toEqual({ kind: "delete" });
-		expect(batch?.get(HASH_B)).toEqual({ kind: "delete" });
-		expect(applyBatchResult).toHaveBeenCalledTimes(1);
-		// Per-commit outcomes carry the resolved absolute article URLs, in push order.
-		expect(r.commits).toEqual([
-			{ hash: HASH_A, status: "pushed", url: "https://acme.jolli.ai/articles/doc-100" },
-			{ hash: HASH_B, status: "pushed", url: "https://acme.jolli.ai/articles/doc-101" },
-		]);
-	});
-
-	it("persists the batch top-level Space echo as the binding cache", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const pushBatch = vi.fn(async () => ({ ...okBatchResult(HASH_A), jmSpace: { id: 7, name: "Acme Core" } }));
-
-		await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(pushBatch),
-		});
-
-		expect(saveSpaceBindingCache).toHaveBeenCalledWith(CWD, {
-			repoUrl: "https://github.com/acme/repo",
-			origin: "https://acme.jolli.ai",
-			jmSpaceId: 7,
-			spaceName: "Acme Core",
-			canPush: true,
-		});
-	});
-
-	it("leaves the binding cache untouched when the batch echoes no Space (older server)", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const pushBatch = vi.fn(async () => okBatchResult(HASH_A));
-
-		await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(pushBatch),
-		});
-
-		expect(saveSpaceBindingCache).not.toHaveBeenCalled();
-		expect(clearSpaceBindingCache).not.toHaveBeenCalled();
-	});
-
-	it("defers inline overflow beyond the server's total-content limit", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({
-			version: 1,
-			entries: { [HASH_A]: entry(), [HASH_B]: entry() },
-		});
-		vi.mocked(buildBatchItems).mockResolvedValueOnce([
-			{ ...builtItem(HASH_A), batchContentChars: BATCH_MAX_TOTAL_CONTENT_CHARS - 1 },
-			builtItem(HASH_B),
-		]);
-		const pushBatch = vi.fn(async (_payload: BatchPushPayload) => okBatchResult(HASH_A));
-
-		const result = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A, HASH_B],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(pushBatch),
-		});
-
-		expect(result.pushed).toBe(1);
-		expect(result.notAttempted).toBe(1);
-		expect(pushBatch).toHaveBeenCalledTimes(1);
-		expect(pushBatch.mock.calls[0][0].items.map((item: { commitHash: string }) => item.commitHash)).toEqual([
-			HASH_A,
-		]);
-		const updateCalls = vi.mocked(updateBatch).mock.calls;
-		expect(updateCalls.at(-1)?.[1].get(HASH_A)).toEqual({ kind: "delete" });
-		const releasedOverflow = updateCalls.find((call) => call[1].has(HASH_B))?.[1];
-		expect(releasedOverflow?.get(HASH_B)).toEqual({ kind: "patch", patch: {} });
-		expect(result.commits[1]).toEqual({
-			hash: HASH_B,
-			status: "deferred",
-			reason: "batch content limit reached — will sync later",
-		});
-	});
-
-	it("keeps an inline success pending when confirmed orphan cleanup is still required", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		vi.mocked(applyBatchResult).mockResolvedValueOnce({
-			writtenBack: 1,
-			childSkipped: 0,
-			cleanupPendingHashes: [HASH_A],
-		});
-
-		const result = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(vi.fn(async () => okBatchResult(HASH_A))),
-		});
-
-		expect(result.pushed).toBe(1);
-		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
-		expect(batch?.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
-	});
-
-	it("keeps an inline success pending with the minted ids when its write-back fails", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		vi.mocked(applyBatchResult).mockResolvedValueOnce({
-			writtenBack: 0,
-			childSkipped: 0,
-			writeBackFailures: [{ commitHash: HASH_A, docId: 100, url: "https://acme.jolli.ai/articles/doc-100" }],
-		});
-
-		const result = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(vi.fn(async () => okBatchResult(HASH_A))),
-		});
-
-		// The push itself succeeded — the commit still reports as pushed.
-		expect(result.pushed).toBe(1);
-		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
-		expect(batch?.get(HASH_A)).toEqual({
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
+		expect(r.pushed).toBe(1);
+		const update = flushedUpdates().get(HASH_A);
+		expect(update).toEqual({
 			kind: "patch",
 			patch: {
 				lastAttemptAt: expect.any(String),
-				lastError: "pushed, but persisting the article id locally failed — will retry the write-back",
-				pushedDocId: 100,
-				pushedUrl: "https://acme.jolli.ai/articles/doc-100",
+				lastError: expect.stringContaining("persisting the article id locally failed"),
+				pushedDocId: 77,
+				pushedUrl: "https://acme.jolli.ai/articles/doc-77",
 			},
 		});
+		// retryCount is deliberately absent: the push itself succeeded.
+		expect(update).not.toHaveProperty("patch.retryCount");
 	});
 
-	it("grafts the recovered docId/url from the pending entry into the batch build", async () => {
+	it("commits each entry's accounting as it settles, not in one batch at the end", async () => {
+		// A drain at commit granularity outlives the claim TTL, so buffering the
+		// whole ledger would let a crash replay commits that already published.
 		vi.mocked(loadPushPending).mockResolvedValue({
 			version: 1,
-			entries: { [HASH_A]: entry(0, { pushedDocId: 55, pushedUrl: "https://acme.jolli.ai/articles/doc-55" }) },
+			entries: { [HASH_A]: entry(), [HASH_B]: entry() },
 		});
-
-		await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(vi.fn(async () => okBatchResult(HASH_A))),
-		});
-
-		const builtSummaries = vi.mocked(buildBatchItems).mock.calls[0][0];
-		expect(builtSummaries[0]).toMatchObject({
-			jolliDocId: 55,
-			jolliDocUrl: "https://acme.jolli.ai/articles/doc-55",
-		});
+		await processPushPending(CWD, { source: "activation", client: fakeClient() });
+		const perCommitWrites = vi.mocked(updateBatch).mock.calls.filter((call) => call[1].size === 1);
+		expect(perCommitWrites).toHaveLength(2);
 	});
 
-	it("never overrides a summary's own docId with the recovered one", async () => {
-		vi.mocked(getSummary).mockImplementation(async (hash: string) => ({
-			...summary(hash),
-			jolliDocId: 7,
-			jolliDocUrl: "https://acme.jolli.ai/articles/doc-7",
-		}));
+	it("stops starting new pushes once the runtime ceiling passes", async () => {
 		vi.mocked(loadPushPending).mockResolvedValue({
 			version: 1,
-			entries: { [HASH_A]: entry(0, { pushedDocId: 55, pushedUrl: "https://acme.jolli.ai/articles/doc-55" }) },
+			entries: { [HASH_A]: entry(), [HASH_B]: entry() },
 		});
-
-		await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(vi.fn(async () => okBatchResult(HASH_A))),
+		const settled: CommitPushOutcome[] = [];
+		const r = await processPushPending(CWD, {
+			source: "pre-push",
+			skipPushConfirmation: true,
+			stopStartingAt: Date.now() - 1,
+			client: fakeClient(),
+			onCommitSettled: (o) => settled.push(o),
 		});
-
-		const builtSummaries = vi.mocked(buildBatchItems).mock.calls[0][0];
-		expect(builtSummaries[0]).toMatchObject({ jolliDocId: 7, jolliDocUrl: "https://acme.jolli.ai/articles/doc-7" });
+		// Nothing was sent, nothing failed, and no retry was burned — the entries
+		// look exactly like ones this drain never reached.
+		expect(pushSummary).not.toHaveBeenCalled();
+		expect(r.pushed).toBe(0);
+		expect(r.failed).toBe(0);
+		expect(settled.map((o) => o.status)).toEqual(["deferred", "deferred"]);
+		expect(flushedUpdates().get(HASH_B)).toEqual({ kind: "patch", patch: {} });
 	});
 
-	it("records a per-item failure with a counted retry while the rest succeed", async () => {
+	it("reports hashes another process already claimed instead of dropping them", async () => {
+		// The pre-push hook lists every commit of the push; an unreported one would
+		// render as "still running" long after this drain exits.
 		vi.mocked(loadPushPending).mockResolvedValue({
 			version: 1,
-			entries: { [HASH_A]: entry(1), [HASH_B]: entry() },
+			entries: { [HASH_A]: entry(), [HASH_B]: entry() },
 		});
-		const pushBatch = vi.fn(async () => ({
-			results: [
-				{ commitHash: HASH_A, ok: false, attachments: [], error: "boom", errorCode: "push_failed" },
-				...okBatchResult(HASH_B).results,
-			],
-		}));
-		const r = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A, HASH_B],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(pushBatch),
+		vi.mocked(claimForPush).mockResolvedValue({
+			claimed: new Set([HASH_B]),
+			entries: { [HASH_B]: entry() },
+			claimedAt: CLAIMED_AT,
 		});
-		expect(r.pushed).toBe(1);
-		expect(r.failed).toBe(1);
-		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
-		const update = batch?.get(HASH_A);
-		expect(update).toMatchObject({ kind: "patch" });
-		if (update?.kind === "patch") {
-			expect(update.patch.retryCount).toBe(2);
-			expect(update.patch.lastError).toBe("boom");
-		}
-		expect(batch?.get(HASH_B)).toEqual({ kind: "delete" });
-		expect(r.commits).toEqual([
-			{ hash: HASH_A, status: "failed", reason: "boom" },
-			{ hash: HASH_B, status: "pushed", url: "https://acme.jolli.ai/articles/doc-100" },
-		]);
+		const settled: CommitPushOutcome[] = [];
+		await processPushPending(CWD, {
+			source: "pre-push",
+			skipPushConfirmation: true,
+			client: fakeClient(),
+			onCommitSettled: (o) => settled.push(o),
+		});
+		expect(settled).toContainEqual({
+			hash: HASH_A,
+			status: "deferred",
+			reason: "another sync is already handling this commit",
+		});
 	});
 
-	it("marks a hash missing from the response as failed", async () => {
+	it("reports settled outcomes on early-exit paths too", async () => {
+		// The contract on `commits` has to hold on EVERY return, or the worker
+		// cannot promise its published result covers each requested hash.
+		vi.mocked(loadConfig).mockResolvedValue({});
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const pushBatch = vi.fn(async () => ({ results: [] }));
-		const r = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(pushBatch),
+		const r = await processPushPending(CWD, {
+			source: "pre-push",
+			client: fakeClient(),
+			onCommitSettled: () => {},
 		});
-		expect(r.failed).toBe(1);
-		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
-		const update = batch?.get(HASH_A);
-		if (update?.kind === "patch") {
-			expect(update.patch.lastError).toBe("missing batch result");
-		}
-		expect(r.commits).toEqual([{ hash: HASH_A, status: "failed", reason: "missing batch result" }]);
+		expect(r.note).toBe("not signed in");
+		expect(r.commits).toEqual([]);
 	});
 
-	it("counts the retry on a whole-request operational failure", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(1) } });
-		const pushBatch = vi.fn(async () => {
-			throw new Error("network down");
-		});
-		const r = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(pushBatch),
-		});
-		expect(r.failed).toBe(1);
-		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
-		const update = batch?.get(HASH_A);
-		if (update?.kind === "patch") {
-			expect(update.patch.retryCount).toBe(2);
-			expect(update.patch.lastError).toContain("network down");
-		}
-		expect(r.commits).toEqual([{ hash: HASH_A, status: "failed", reason: "network down" }]);
-	});
-
-	it("holds the retry count on a whole-request config failure (not signed in mid-flight)", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(1) } });
-		const pushBatch = vi.fn(async () => {
-			throw new NotAuthenticatedError();
-		});
-		const r = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(pushBatch),
-		});
-		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
-		const update = batch?.get(HASH_A);
-		if (update?.kind === "patch") {
-			expect(update.patch.retryCount).toBeUndefined();
-			expect(update.patch.lastError).toBe("not-authenticated");
-		}
-		// The result list shows the friendly wording, not the raw error code.
-		expect(r.commits).toEqual([{ hash: HASH_A, status: "failed", reason: "not signed in to Jolli" }]);
-		// The server just contradicted any cached binding — the inline drain drops it too.
-		expect(clearSpaceBindingCache).toHaveBeenCalledWith(CWD);
-	});
-
-	it("labels a space-permission failure distinctly in the result list (no retry burn)", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(1) } });
-		const pushBatch = vi.fn(async () => {
-			throw new PermissionDeniedError("Insufficient space permissions");
-		});
-		const r = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(pushBatch),
-		});
-		expect(r.commits).toEqual([
-			{ hash: HASH_A, status: "failed", reason: "no permission to write to the bound Jolli Space" },
-		]);
-		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
-		const update = batch?.get(HASH_A);
-		if (update?.kind === "patch") {
-			expect(update.patch.retryCount).toBeUndefined();
-			expect(update.patch.lastError).toBe("permission-denied");
-		}
-		// A 403 also invalidates the cached binding (canPush flipped server-side).
-		expect(clearSpaceBindingCache).toHaveBeenCalledWith(CWD);
-	});
-
-	it("releases claims without retry burn when the server lacks batch support", async () => {
+	it("omits the commits array entirely when no callback was supplied", async () => {
 		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const pushBatch = vi.fn(async () => {
-			throw new BatchUnsupportedError();
-		});
-		const r = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(pushBatch),
-		});
-		expect(r.notAttempted).toBe(1);
-		expect(r.note).toBe("server lacks batch support");
-		expect(r.commits).toEqual([
-			{ hash: HASH_A, status: "deferred", reason: "server does not support batch push yet" },
-		]);
-		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
-		expect(batch?.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
+		const r = await processPushPending(CWD, { source: "activation", client: fakeClient() });
+		expect(r.commits).toBeUndefined();
 	});
 
-	it("releases claims without retry burn when the request aborts at the deadline", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		const abortError = new Error("This operation was aborted");
-		abortError.name = "AbortError";
-		const pushBatch = vi.fn(async () => {
-			throw abortError;
+	it("reports retry-exhausted entries rather than skipping them silently", async () => {
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry(99) } });
+		const settled: CommitPushOutcome[] = [];
+		await processPushPending(CWD, {
+			source: "pre-push",
+			client: fakeClient(),
+			onCommitSettled: (o) => settled.push(o),
 		});
-		const r = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(pushBatch),
-		});
-		expect(r.notAttempted).toBe(1);
-		expect(r.note).toBe("deadline exceeded");
-		expect(r.commits).toEqual([{ hash: HASH_A, status: "deferred", reason: "timed out — will sync later" }]);
-		const batch = vi.mocked(updateBatch).mock.calls.at(-1)?.[1];
-		expect(batch?.get(HASH_A)).toEqual({ kind: "patch", patch: {} });
-	});
-
-	it("marks entries claimed by a concurrent process as deferred in the result list", async () => {
-		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_A]: entry() } });
-		vi.mocked(claimForPush).mockResolvedValue({ claimed: new Set(), entries: {} });
-		const r = await processPrePushInline(CWD, {
-			priorityHashes: [HASH_A],
-			deadlineAt: farDeadline(),
-			client: fakeBatchClient(vi.fn()),
-		});
-		expect(r.note).toBe("all entries claimed by another process");
-		expect(r.commits).toEqual([
-			{ hash: HASH_A, status: "deferred", reason: "another sync is already handling this commit" },
-		]);
+		expect(settled).toEqual([{ hash: HASH_A, status: "failed", reason: "failed repeatedly — giving up" }]);
 	});
 });
 

--- a/cli/src/core/PushExecutor.ts
+++ b/cli/src/core/PushExecutor.ts
@@ -1,26 +1,26 @@
 /**
  * PushExecutor — the shared "drain push-pending.json to Jolli Space" core.
  *
- * Two drain flavors share the triage/claim/accounting machinery:
- *   - `processPushPending`   — compensation drain, called by QueueWorker
- *     post-drain (source="post-queue", hashFilter set) and plugin/CLI
- *     activation (source="activation"). Publishes only after the remote ref
- *     confirms the git push landed. Batch-first (chunks of BATCH_MAX_ITEMS
- *     through `pushBatch`, orphan cleanup included); falls back to the legacy
- *     per-commit `pushSummary` loop when the server predates the endpoint.
- *   - `processPrePushInline` — called synchronously INSIDE the pre-push hook,
- *     before git transfers objects. Pushes every with-memory candidate in ONE
- *     `pushBatch` HTTP request under a hard wall-clock budget, deliberately
- *     WITHOUT push confirmation (waiting for the remote ref inside the hook
- *     would deadlock — git waits for the hook to exit before transferring).
+ * One function, `processPushPending`, serves all three callers; they differ only
+ * in the options they pass:
+ *   - post-queue  — QueueWorker's post-drain trigger (hashFilter set to the
+ *     summaries it just generated). Confirmation gate and orphan cleanup on.
+ *   - activation  — plugin / CLI activation and sign-in. No filter: drains the
+ *     whole backlog. Confirmation gate and orphan cleanup on.
+ *   - pre-push    — the detached worker the pre-push hook spawns. Scoped to one
+ *     push's commits, and the only caller that sets `skipPushConfirmation` +
+ *     `skipOrphanCleanup`: it runs BEFORE git transfers objects, so no ref has
+ *     moved yet (`ls-remote` would refuse everything) and deleting orphaned
+ *     articles could strip memories from history that is still on the remote.
  *
- * Both reuse the existing push_memory building blocks — `pushSummary` /
- * `buildBatchItems` + `applyBatchResult` for uploads and
- * `assignOwnedAttachments` for cross-commit plan/note dedup — so nothing about
- * the Jolli Space contract is re-implemented here (JOLLI-1900 requirement 3).
- * `pushBranchToJolli` is intentionally NOT used: it pushes the whole branch as
- * one unit with no per-commit retry state, which is what the pending-file
- * model provides.
+ * Uploads go through `pushSummary` at commit granularity, `PUSH_CONCURRENCY` in
+ * flight. The batch endpoint this file used to prefer was removed: its 8 MB
+ * payload cap sat above a typical gateway's body limit, and the resulting 413
+ * was indistinguishable from a transient failure — it burned every retry and
+ * then aged out silently. Cross-commit context dedup still runs through
+ * `assignOwnedContext`, so concurrent commits never touch the same remote
+ * document. `pushBranchToJolli` is intentionally NOT used: it pushes a whole
+ * branch as one unit with no per-commit retry state.
  *
  * Cross-commit dedup requires the full branch context. The current branch uses
  * `base..HEAD`; off-current branches are reconstructed from root summaries in
@@ -30,10 +30,9 @@
  * Binding-cache maintenance rides along: a successful push persists the
  * server's `jmSpace` echo via SpaceBindingCache (a push proves the binding and
  * push rights — and the server auto-binds single-Space tenants during the push
- * itself; `pushBatch` echoes once at the top level, `pushSummary` per commit),
- * while a 412/401/403 rejection clears the cache on every drain flavor. Older
- * servers echo nothing and the cache is left as-is. The push chain never adds
- * extra requests for this.
+ * itself), while a 412/401/403 rejection clears the cache. Older servers echo
+ * nothing and the cache is left as-is. The push chain never adds extra requests
+ * for this.
  */
 
 import { createLogger, errMsg } from "../Logger.js";
@@ -41,36 +40,27 @@ import type { CommitSummary } from "../Types.js";
 import { mapWithConcurrency } from "./Concurrency.js";
 import { execGit, getCurrentBranch, getDefaultBranch } from "./GitOps.js";
 import { getCanonicalRepoUrl } from "./GitRemoteUtils.js";
-import { parseBaseUrl, resolveArticleUrl } from "./JolliApiUtils.js";
+import { parseBaseUrl } from "./JolliApiUtils.js";
 import {
-	BATCH_MAX_ITEMS,
-	BATCH_MAX_TOTAL_CONTENT_CHARS,
-	type BatchPushResult,
-	BatchUnsupportedError,
 	BindingRequiredError,
 	ClientOutdatedError,
 	JolliMemoryPushClient,
 	NotAuthenticatedError,
 	PermissionDeniedError,
 } from "./JolliMemoryPushClient.js";
-import {
-	applyBatchResult,
-	type BatchWriteBackFailure,
-	type BuiltBatchItem,
-	buildBatchItems,
-	type PushContext,
-	pushSummary,
-} from "./JolliMemoryPushOrchestrator.js";
+import { type PushContext, pushSummary } from "./JolliMemoryPushOrchestrator.js";
 import { loadBranchSummaries } from "./PrDescription.js";
 import { isOutboundPushAllowed, PushDisabledError } from "./PushControl.js";
 import {
 	type BatchUpdate,
+	CLAIM_RENEW_INTERVAL_MS,
 	claimForPush,
 	loadPushPending,
 	MAX_RETRY_COUNT,
 	PUSH_CONCURRENCY,
 	type PushPendingEntry,
 	type PushTarget,
+	renewClaims,
 	updateBatch,
 } from "./PushPendingStore.js";
 import { assignOwnedContext, type OwnedContext, selectionForCommit } from "./push/ContextPush.js";
@@ -83,21 +73,63 @@ import { getActiveStorage, getIndexEntryMap, getSummary, setActiveStorage } from
 const log = createLogger("PushExecutor");
 
 /**
- * Minimum wall-clock budget worth spending on the inline batch HTTP request.
- * Below this, `processPrePushInline` releases its claims instead of firing a
- * request that would almost certainly be aborted mid-flight.
+ * Where a `processPushPending` call originated — used only for logging, but that
+ * logging matters: all three paths share one function and the pre-push one runs
+ * in a detached process with no stdout, so `debug.log` is the only way to tell
+ * which drain produced a line.
  */
-export const INLINE_MIN_HTTP_BUDGET_MS = 500;
-
-/** Where a `processPushPending` call originated — used only for logging. */
-export type PushSource = "post-queue" | "activation";
+export type PushSource = "pre-push" | "post-queue" | "activation";
 
 export interface ProcessPushPendingOptions {
 	readonly source: PushSource;
 	/** When set, only these hashes are considered (QueueWorker post-drain path). */
 	readonly hashFilter?: ReadonlySet<string>;
-	/** Test seam — defaults to a real client. */
+	/**
+	 * Overrides the push client. A test seam, and also how the pre-push worker
+	 * raises its HTTP timeout above the client default — an aborted request
+	 * discards a docId the server already minted, which is the failure this whole
+	 * per-commit path exists to avoid.
+	 */
 	readonly client?: JolliMemoryPushClient;
+	/**
+	 * Skips the remote-ref confirmation gate.
+	 *
+	 * Only the pre-push worker sets this. Git calls the hook BEFORE transferring
+	 * objects, so while the hook is still alive the remote ref points at the old
+	 * sha and `ls-remote` would refuse every entry. The compensation drains keep
+	 * the gate.
+	 */
+	readonly skipPushConfirmation?: boolean;
+	/**
+	 * Suppresses orphan-article deletion; entries with pending cleanup are kept
+	 * (patched, not deleted) for a later confirmed drain.
+	 *
+	 * Set together with `skipPushConfirmation` and for the same reason: deleting
+	 * remote articles before git confirms the push can leave the remote history
+	 * intact while its memories are gone, with nothing left to restore them.
+	 */
+	readonly skipOrphanCleanup?: boolean;
+	/**
+	 * Epoch-ms after which no NEW commit push is started. Commits already in
+	 * flight run to completion; the rest are reported as deferred and left
+	 * pending for the compensation channels.
+	 *
+	 * Deliberately a start-gate rather than a cancellation: aborting a request
+	 * mid-flight discards a docId the server may already have minted, and the
+	 * retry would then CREATE a duplicate article — the exact failure the
+	 * per-commit path exists to avoid. Bounding *starts* caps the run without
+	 * ever reintroducing it.
+	 *
+	 * Omit for an unbounded drain (the compensation channels, which are already
+	 * bounded by how much backlog exists).
+	 */
+	readonly stopStartingAt?: number;
+	/**
+	 * Invoked as each commit reaches a terminal state, so a detached worker can
+	 * publish partial results while the rest is still in flight. Called from
+	 * concurrent tasks — keep the implementation synchronous and cheap.
+	 */
+	readonly onCommitSettled?: (outcome: CommitPushOutcome) => void;
 }
 
 export interface ProcessPushPendingResult {
@@ -112,6 +144,11 @@ export interface ProcessPushPendingResult {
 	 * Reported separately from `pushed`/`failed` — no network was attempted.
 	 */
 	readonly deletedChildren: number;
+	/**
+	 * Per-commit outcomes, populated whenever `onCommitSettled` is supplied — on
+	 * EVERY return path, including the early ones.
+	 */
+	readonly commits?: ReadonlyArray<CommitPushOutcome>;
 	/** Set when the whole run short-circuited (no work / not signed in). */
 	readonly note?: string;
 }
@@ -260,69 +297,12 @@ async function buildAttachmentOwnership(
 	return merged;
 }
 
-/** Partitions batch-eligible items by both item count and total content size. */
-function partitionBatchItems(items: ReadonlyArray<BuiltBatchItem>): BuiltBatchItem[][] {
-	const batches: BuiltBatchItem[][] = [];
-	let current: BuiltBatchItem[] = [];
-	let currentChars = 0;
-	for (const item of items) {
-		if (
-			current.length > 0 &&
-			(current.length >= BATCH_MAX_ITEMS || currentChars + item.batchContentChars > BATCH_MAX_TOTAL_CONTENT_CHARS)
-		) {
-			batches.push(current);
-			current = [];
-			currentChars = 0;
-		}
-		current.push(item);
-		currentChars += item.batchContentChars;
-	}
-	if (current.length > 0) batches.push(current);
-	return batches;
-}
-
-/** Keeps successful entries queued when their orphan cleanup is not finished. */
-function preserveCleanupPending(
-	updates: Map<string, BatchUpdate>,
-	cleanupPendingHashes: ReadonlyArray<string> | undefined,
-): void {
-	for (const hash of cleanupPendingHashes ?? []) {
-		if (updates.get(hash)?.kind === "delete") updates.set(hash, { kind: "patch", patch: {} });
-	}
-}
-
-/**
- * Keeps entries whose article was pushed but whose local docId write-back
- * failed: the patch records the minted docId/url so the next drain retries as
- * an UPDATE of the same article (never a duplicate CREATE) and the write-back
- * gets another chance. `retryCount` is deliberately untouched — the push
- * itself succeeded, so the operational retry budget must not shrink.
- */
-function preserveWriteBackFailures(
-	updates: Map<string, BatchUpdate>,
-	failures: ReadonlyArray<BatchWriteBackFailure> | undefined,
-	attemptedAtIso: string,
-): void {
-	for (const failure of failures ?? []) {
-		if (updates.get(failure.commitHash)?.kind !== "delete") continue;
-		updates.set(failure.commitHash, {
-			kind: "patch",
-			patch: {
-				lastAttemptAt: attemptedAtIso,
-				lastError: "pushed, but persisting the article id locally failed — will retry the write-back",
-				pushedDocId: failure.docId,
-				pushedUrl: failure.url,
-			},
-		});
-	}
-}
-
 /**
  * Grafts the docId/url a previous push minted — but failed to persist locally
  * (see `PushPendingEntry.pushedDocId`) — onto a summary that lacks one, so the
  * retry UPDATEs the existing article instead of CREATEing a duplicate. The
- * tenant gate stays where it always was: `buildBatchItems`/`pushSummary` only
- * reuse the id when `canReuseDocId` accepts the grafted url.
+ * tenant gate stays where it always was: `pushSummary` only reuses the id when
+ * `canReuseDocId` accepts the grafted url.
  */
 function withRecoveredDocId(summary: CommitSummary, entry: PushPendingEntry | undefined): CommitSummary {
 	if (summary.jolliDocId !== undefined) return summary;
@@ -374,6 +354,20 @@ export async function processPushPending(
 		deletedChildren: 0,
 	};
 
+	// Mirror every settled outcome into the result as well, so callers can choose
+	// between a live stream (the pre-push worker) and a plain list.
+	const settled: CommitPushOutcome[] = [];
+	const onCommitSettled = options.onCommitSettled
+		? (outcome: CommitPushOutcome): void => {
+				settled.push(outcome);
+				options.onCommitSettled?.(outcome);
+			}
+		: undefined;
+	// Every `return` goes through this so an early exit still reports whatever was
+	// settled. Without it the contract on `commits` would only hold on the happy path.
+	const withCommits = (result: ProcessPushPendingResult): ProcessPushPendingResult =>
+		onCommitSettled ? { ...result, commits: [...settled] } : result;
+
 	// Unlocked pre-flight read: cheap scan for eligible candidates. The actual
 	// commitment to process specific hashes happens via `claimForPush` below,
 	// which atomically stamps `claimedAt` under the file lock so concurrent
@@ -382,7 +376,7 @@ export async function processPushPending(
 	const allHashes = Object.keys(pending.entries);
 	if (allHashes.length === 0) {
 		log.debug("processPushPending(%s): no pending entries", options.source);
-		return { ...empty, note: "no pending entries" };
+		return withCommits({ ...empty, note: "no pending entries" });
 	}
 	log.info(
 		"processPushPending(%s): %d pending entr(ies)%s",
@@ -399,7 +393,7 @@ export async function processPushPending(
 	// post-queue, pre-push), not just the pre-push hook.
 	if (config.syncOnPush === false) {
 		log.info("processPushPending(%s): syncOnPush disabled — skipping %d entries", options.source, allHashes.length);
-		return { ...empty, note: "syncOnPush disabled" };
+		return withCommits({ ...empty, note: "syncOnPush disabled" });
 	}
 
 	// Per-repo opt-out gate (Story 2): the user disabled OUTBOUND push for this
@@ -411,7 +405,7 @@ export async function processPushPending(
 			options.source,
 			allHashes.length,
 		);
-		return { ...empty, note: "push disabled for this repo" };
+		return withCommits({ ...empty, note: "push disabled for this repo" });
 	}
 
 	// Auth gate: without a jolliApiKey there is nothing to push to. Keep the
@@ -422,7 +416,7 @@ export async function processPushPending(
 			options.source,
 			allHashes.length,
 		);
-		return { ...empty, note: "not signed in" };
+		return withCommits({ ...empty, note: "not signed in" });
 	}
 
 	// Eligible = under the retry ceiling, and (when a filter is set) in the filter.
@@ -433,22 +427,29 @@ export async function processPushPending(
 		const entry = pending.entries[hash];
 		if (entry.retryCount >= MAX_RETRY_COUNT) {
 			skippedRetryExhausted++;
+			onCommitSettled?.({ hash, status: "failed", reason: "failed repeatedly — giving up" });
 			continue;
 		}
 		eligible.push(hash);
 	}
-	if (eligible.length === 0) return { ...empty, skippedRetryExhausted, note: "no eligible entries" };
+	if (eligible.length === 0) return withCommits({ ...empty, skippedRetryExhausted, note: "no eligible entries" });
 
 	// Do not publish until the remote ref proves that the push succeeded.
 	// Failed/rejected pushes remain pending for a retry.
-	const confirmed = await waitForConfirmedPushes(cwd, eligible, pending.entries);
+	//
+	// The pre-push worker is the one caller that must skip this: it runs while git
+	// is still waiting for the hook to exit, so no ref has moved yet and every
+	// candidate would be refused.
+	const confirmed = options.skipPushConfirmation
+		? eligible
+		: await waitForConfirmedPushes(cwd, eligible, pending.entries);
 	if (confirmed.length === 0) {
 		log.info(
 			"processPushPending(%s): no candidate confirmed on the remote yet — keeping %d entr(ies)",
 			options.source,
 			eligible.length,
 		);
-		return { ...empty, skippedRetryExhausted, note: "push not confirmed" };
+		return withCommits({ ...empty, skippedRetryExhausted, note: "push not confirmed" });
 	}
 	log.debug(
 		"processPushPending(%s): %d/%d candidate(s) confirmed on the remote",
@@ -460,12 +461,20 @@ export async function processPushPending(
 	// Atomic claim: stamp `claimedAt` on every confirmed hash under the file
 	// lock. A concurrent `processPushPending` that races us will see a fresh
 	// `claimedAt` and skip the entry, preventing duplicate Space articles.
-	const { claimed, entries: claimedEntries } = await claimForPush(cwd, confirmed);
+	const { claimed, entries: claimedEntries, claimedAt: claimToken } = await claimForPush(cwd, confirmed);
 	if (claimed.size === 0) {
 		log.info("processPushPending(%s): all candidates already claimed by another process", options.source);
-		return { ...empty, skippedRetryExhausted, note: "all entries claimed by another process" };
+		return withCommits({ ...empty, skippedRetryExhausted, note: "all entries claimed by another process" });
 	}
 	const claimedHashes = confirmed.filter((h) => claimed.has(h));
+	// A hash we did not win is NOT silently dropped: the pre-push hook lists every
+	// commit of the push, and an unreported one would be rendered as "still
+	// running" long after this drain has exited.
+	for (const hash of confirmed) {
+		if (!claimed.has(hash)) {
+			onCommitSettled?.({ hash, status: "deferred", reason: "another sync is already handling this commit" });
+		}
+	}
 	log.info(
 		"processPushPending(%s): claimed %d/%d candidate(s)",
 		options.source,
@@ -504,6 +513,7 @@ export async function processPushPending(
 		if (indexEntry && indexEntry.parentCommitHash != null) {
 			preFlightUpdates.set(hash, { kind: "delete" });
 			deletedChildren++;
+			onCommitSettled?.({ hash, status: "merged", reason: "merged into another commit's memory" });
 			log.info(
 				"Skipping child entry %s (parent=%s) — already merged",
 				hash.substring(0, 8),
@@ -523,6 +533,7 @@ export async function processPushPending(
 		} else {
 			preFlightUpdates.set(hash, { kind: "patch", patch: {} });
 			skippedNoMemory++;
+			onCommitSettled?.({ hash, status: "generating", reason: "memory still generating — will sync later" });
 		}
 	}
 	if (preFlightUpdates.size > 0) {
@@ -540,7 +551,7 @@ export async function processPushPending(
 			deletedChildren > 0 && skippedNoMemory === 0
 				? "all candidates were merged children"
 				: "no candidates with memory";
-		return { ...empty, skippedNoMemory, skippedRetryExhausted, deletedChildren, note };
+		return withCommits({ ...empty, skippedNoMemory, skippedRetryExhausted, deletedChildren, note });
 	}
 
 	const ownership = await buildAttachmentOwnership(cwd, storage, claimedEntries, withMemory, candidateSummaries);
@@ -552,246 +563,70 @@ export async function processPushPending(
 
 	log.info("processPushPending(%s): pushing %d commit(s)", options.source, withMemory.length);
 
-	const updates = new Map<string, BatchUpdate>();
 	const counters = { pushed: 0, failed: 0 };
-	// The server's Space echo from any accepted batch request this run
-	// (concurrent writers all observe the same binding, so last-write-wins is
-	// fine). The per-commit fallback persists its own echo inside
-	// pushCandidatesIndividually.
-	let confirmedSpace: { readonly id: number; readonly name: string } | undefined;
 
-	// Batch-first: candidate windows are capped by item count, then split again
-	// by the server's total-content limit. Items that cannot pass the batch schema
-	// use the legacy per-commit path so one oversized memory cannot reject every
-	// otherwise-valid item in its batch.
-	let index = 0;
-	batchLoop: while (index < withMemory.length) {
-		const chunkHashes = withMemory.slice(index, index + BATCH_MAX_ITEMS);
-		index += chunkHashes.length;
-		const chunkSummaries: CommitSummary[] = [];
-		for (const hash of chunkHashes) {
-			const summary = candidateSummaries.get(hash);
-			if (summary) chunkSummaries.push(summary);
-		}
-		const built = await buildBatchItems(chunkSummaries, ownership, ctx);
-		const individualFallbackHashes = built
-			.filter((item) => item.batchIneligibleReason !== undefined)
-			.map((item) => item.item.commitHash);
-		for (const item of built) {
-			if (item.batchIneligibleReason) {
-				log.info(
-					"Commit %s requires individual push: %s",
-					item.item.commitHash.substring(0, 8),
-					item.batchIneligibleReason,
-				);
-			}
-		}
-		const batchGroups = partitionBatchItems(built.filter((item) => item.batchIneligibleReason === undefined));
+	// Single push path: one request group per commit, concurrency-limited.
+	//
+	// The batch endpoint was removed on purpose. Its payload cap
+	// (8 MB of combined content) sits well above a typical gateway's
+	// client_max_body_size, and the resulting 413 was indistinguishable from an
+	// ordinary transient failure: it burned all three retries and then aged out
+	// silently, so the user just saw memories never arrive. A per-commit request
+	// keeps the body proportional to one commit, and lets a settled commit be
+	// reported the moment it lands instead of all-or-nothing per batch.
+	await pushCandidatesIndividually({
+		cwd,
+		storage,
+		hashes: withMemory,
+		ownership,
+		claimedEntries,
+		claimToken,
+		ctx,
+		counters,
+		skipOrphanCleanup: options.skipOrphanCleanup === true,
+		...(options.stopStartingAt !== undefined && { stopStartingAt: options.stopStartingAt }),
+		onCommitSettled,
+	});
 
-		/**
-		 * Every claimed candidate this drain has not attempted yet, counted from
-		 * `fromGroupIndex`: that group onwards, this chunk's individual-fallback items
-		 * (they run only after the group loop finishes), and the chunks never reached.
-		 * Disjoint from the hashes already in `updates`, which belong to groups the
-		 * loop has passed.
-		 */
-		const unattemptedFrom = (fromGroupIndex: number): string[] => [
-			...batchGroups.slice(fromGroupIndex).flatMap((group) => group.map((item) => item.item.commitHash)),
-			...individualFallbackHashes,
-			...withMemory.slice(index),
-		];
-
-		for (let groupIndex = 0; groupIndex < batchGroups.length; groupIndex++) {
-			const batchBuilt = batchGroups[groupIndex];
-			const batchHashes = batchBuilt.map((item) => item.item.commitHash);
-			// Story 2 / spec 306: re-read the opt-out before EVERY batch so a user who
-			// disables push mid-drain stops the remaining sends. Nothing is marked failed
-			// and no retry is burned — but every unattempted entry must also have its
-			// CLAIM released, or the re-enable drain (which runs immediately on toggle-on)
-			// finds them still claimed by this run and skips them: `claimForPush` honours
-			// a claim for CLAIM_STALE_MS (5 min), and the drain is a single detached pass
-			// with no retry of its own, so the backlog would sit until some unrelated
-			// trigger. Same fix as the mirror site in `processPrePushInline`, folded into
-			// the run's existing single `updateBatch` write instead of a second one.
-			if (!(await isOutboundPushAllowed(cwd))) {
-				const held = unattemptedFrom(groupIndex);
-				releaseClaimsInto(updates, held);
-				log.info(
-					"processPushPending(%s): push disabled mid-drain — stopping before batch %d of %d, releasing %d claim(s)",
-					options.source,
-					groupIndex + 1,
-					batchGroups.length,
-					held.length,
-				);
-				break batchLoop;
-			}
-			let batchResult: BatchPushResult;
-			try {
-				batchResult = await client.pushBatch({ repoUrl, items: batchBuilt.map((item) => item.item) });
-			} catch (err) {
-				if (err instanceof BatchUnsupportedError) {
-					log.info(
-						"processPushPending(%s): server lacks batch support — falling back to per-commit pushes",
-						options.source,
-					);
-					const fallbackHashes = [
-						...batchGroups.slice(groupIndex).flatMap((group) => group.map((item) => item.item.commitHash)),
-						...individualFallbackHashes,
-						...withMemory.slice(index),
-					];
-					await pushCandidatesIndividually({
-						cwd,
-						storage,
-						hashes: fallbackHashes,
-						ownership,
-						claimedEntries,
-						ctx,
-						updates,
-						counters,
-					});
-					break batchLoop;
-				}
-				const { increment, message } = classifyError(err);
-				if (
-					err instanceof BindingRequiredError ||
-					err instanceof NotAuthenticatedError ||
-					err instanceof PermissionDeniedError
-				) {
-					// The server just contradicted any cached binding (unbound
-					// elsewhere, or auth/permission revoked) — drop the cache so
-					// `jolli status` / bare `jolli` stop rendering a stale bound row.
-					await clearSpaceBindingCache(cwd);
-				}
-				const failedAtIso = new Date().toISOString();
-				// Config failures affect every unsent item identically, so release all
-				// remaining claims without wasting more network requests.
-				const affected = increment ? batchHashes : [...batchHashes, ...unattemptedFrom(groupIndex + 1)];
-				for (const hash of affected) {
-					updates.set(hash, {
-						kind: "patch",
-						patch: {
-							lastAttemptAt: failedAtIso,
-							lastError: message,
-							...(increment ? { retryCount: claimedEntries[hash].retryCount + 1 } : {}),
-						},
-					});
-				}
-				counters.failed += affected.length;
-				log.warn(
-					"processPushPending(%s): batch request failed for %d commit(s): %s (retry %s)",
-					options.source,
-					affected.length,
-					message,
-					increment ? "counted" : "held",
-				);
-				if (!increment) break batchLoop;
-				continue;
-			}
-
-			if (batchResult.jmSpace) {
-				confirmedSpace = batchResult.jmSpace;
-			}
-			const resultByHash = new Map(batchResult.results.map((result) => [result.commitHash, result]));
-			const nowIso = new Date().toISOString();
-			for (const hash of batchHashes) {
-				const result = resultByHash.get(hash);
-				if (result?.ok) {
-					updates.set(hash, { kind: "delete" });
-					counters.pushed++;
-					continue;
-				}
-				counters.failed++;
-				const message = result?.error ?? result?.errorCode ?? "missing batch result";
-				updates.set(hash, {
-					kind: "patch",
-					patch: {
-						lastAttemptAt: nowIso,
-						lastError: message,
-						retryCount: claimedEntries[hash].retryCount + 1,
-					},
-				});
-				log.warn("Batch push failed for %s: %s", hash.substring(0, 8), message);
-			}
-
-			// Compensation has no wall-clock budget, so it resolves delayed orphan
-			// hashes and deletes known orphaned articles after each successful batch.
-			try {
-				const writeBack = await applyBatchResult(batchBuilt, batchResult.results, ctx, {
-					cleanupOrphans: true,
-				});
-				preserveCleanupPending(updates, writeBack.cleanupPendingHashes);
-				preserveWriteBackFailures(updates, writeBack.writeBackFailures, nowIso);
-				log.info(
-					"processPushPending(%s): write-back — writtenBack=%d childSkipped=%d cleanupPending=%d writeBackFailed=%d",
-					options.source,
-					writeBack.writtenBack,
-					writeBack.childSkipped,
-					writeBack.cleanupPendingHashes?.length ?? 0,
-					writeBack.writeBackFailures?.length ?? 0,
-				);
-			} catch (err) {
-				log.warn("processPushPending(%s): write-back failed: %s", options.source, errMsg(err));
-			}
-		}
-
-		if (individualFallbackHashes.length > 0) {
-			await pushCandidatesIndividually({
-				cwd,
-				storage,
-				hashes: individualFallbackHashes,
-				ownership,
-				claimedEntries,
-				ctx,
-				updates,
-				counters,
-			});
-		}
-	}
-
-	await updateBatch(cwd, updates);
-	await persistConfirmedSpace(ctx, confirmedSpace);
 	log.info("processPushPending(%s): pushed=%d failed=%d", options.source, counters.pushed, counters.failed);
 
-	return {
+	return withCommits({
 		attempted: withMemory.length,
 		pushed: counters.pushed,
 		failed: counters.failed,
 		skippedNoMemory,
 		skippedRetryExhausted,
 		deletedChildren,
-	};
+	});
 }
 
 /**
- * Per-commit outcome of the fallback loop. `held` means the push was skipped by
+ * Per-commit outcome of the push loop. `held` means the push was skipped by
  * the per-repo outbound opt-out (spec 306) — no attempt is recorded, so it is
  * deliberately counted as neither a success nor a failure; only the claim is
- * released (see {@link releaseClaimsInto}).
+ * released.
  */
 type PushOutcome = "pushed" | "failed" | "held";
 
 /**
- * Stages a claim-release-only update for `hashes`: an empty patch clears
- * `claimedAt` and touches nothing else (see `updateBatch`), so the entry becomes
- * indistinguishable from one this drain never reached — no `lastError`, no retry
- * burned — while any later drain can re-claim it immediately instead of waiting
- * out the 5-minute claim TTL.
+ * The push loop: one request group per commit, `PUSH_CONCURRENCY` of them in
+ * flight at a time. Re-reads each summary right before the network call
+ * (stale-summary race guard), pushes via `pushSummary` (attachments first, then
+ * the summary itself), and commits each entry's accounting AS IT SETTLES rather
+ * than in one batch at the end.
  *
- * The in-place variant of {@link releaseClaims}, for callers that already have an
- * `updates` map being flushed in one `updateBatch` write.
- */
-function releaseClaimsInto(updates: Map<string, BatchUpdate>, hashes: Iterable<string>): void {
-	for (const hash of hashes) updates.set(hash, { kind: "patch", patch: {} });
-}
-
-/**
- * Legacy per-commit push loop — retained as the fallback for servers that
- * predate the batch endpoint. Identical semantics to the pre-batch drain:
- * re-reads each summary right before the network call (stale-summary race
- * guard), pushes via `pushSummary` (orphan cleanup included), and fills
- * `updates`/`counters` in place. Binding-cache maintenance matches the batch
- * path: the `jmSpace` echo of a successful `pushSummary` is persisted, a
- * 412/401/403 rejection clears the cache.
+ * Per-commit persistence is load-bearing, not a style choice. At commit
+ * granularity a drain routinely runs for minutes — longer than the claim TTL —
+ * so buffering the whole ledger in memory would mean a mid-run crash replays
+ * commits that already published, creating duplicate articles. The claim
+ * heartbeat covers the other half of that race: it keeps this drain's own claims
+ * alive so no other channel can take them over while a push is still in flight.
+ *
+ * Concurrency is safe at commit granularity because context ownership is decided
+ * up front by `assignOwnedContext`: an item of any registered kind shared by
+ * several commits is pushed by exactly one of them, so concurrent commits never
+ * touch the same remote document. Local write-back is serialised by
+ * `storeSummary`'s orphan-write lock.
  */
 async function pushCandidatesIndividually(args: {
 	readonly cwd: string;
@@ -799,57 +634,128 @@ async function pushCandidatesIndividually(args: {
 	readonly hashes: ReadonlyArray<string>;
 	readonly ownership: OwnedContext;
 	readonly claimedEntries: Readonly<Record<string, PushPendingEntry>>;
+	/** The `claimedAt` stamp this drain owns — the heartbeat's compare-and-swap token. */
+	readonly claimToken: string;
 	readonly ctx: PushContext;
-	readonly updates: Map<string, BatchUpdate>;
 	readonly counters: { pushed: number; failed: number };
+	/** Defer orphan deletion and keep the entry — see ProcessPushPendingOptions. */
+	readonly skipOrphanCleanup: boolean;
+	/** Start-gate for new pushes — see ProcessPushPendingOptions.stopStartingAt. */
+	readonly stopStartingAt?: number;
+	readonly onCommitSettled?: (outcome: CommitPushOutcome) => void;
 }): Promise<void> {
-	const { cwd, storage, hashes, ownership, claimedEntries, ctx, updates, counters } = args;
-	const nowIso = new Date().toISOString();
+	const { cwd, storage, hashes, ownership, claimedEntries, ctx, skipOrphanCleanup, onCommitSettled } = args;
+	const { stopStartingAt } = args;
 	// The server's Space echo from any successful push this run (concurrent
 	// writers all observe the same binding, so last-write-wins is fine).
 	let confirmedSpace: { readonly id: number; readonly name: string } | undefined;
-	const results = await mapWithConcurrency(hashes, PUSH_CONCURRENCY, async (hash): Promise<PushOutcome> => {
+
+	// Commit one entry's accounting immediately. Single-entry writes take the same
+	// file lock as a batch, so ordering across concurrent tasks stays safe.
+	const commitEntry = async (hash: string, update: BatchUpdate): Promise<void> => {
+		try {
+			await updateBatch(cwd, new Map([[hash, update]]));
+		} catch (err) {
+			// The push already happened; a bookkeeping failure must not fail it.
+			// The entry stays claimed and a later drain re-reads the stored docId,
+			// so the retry UPDATEs rather than duplicates. The one case that loses the
+			// id is a `writeBackFailed` patch failing here — that patch IS the backup
+			// copy of an id the local summary never received. Two consecutive local
+			// write failures, so a duplicate article there is the accepted floor.
+			log.warn("Could not persist push accounting for %s: %s", hash.substring(0, 8), errMsg(err));
+		}
+	};
+
+	const inFlight = new Set(hashes);
+	let claimToken = args.claimToken;
+	// Heartbeat: keep this drain's claims from going stale mid-flight. unref() so
+	// a stuck timer can never keep the worker process alive past its work.
+	const heartbeat = setInterval(() => {
+		if (inFlight.size === 0) return;
+		void renewClaims(cwd, [...inFlight], claimToken)
+			.then((renewed) => {
+				// undefined means nothing matched our token any more — every entry is
+				// either finished or now held by someone else. Keep the old token so a
+				// later beat cannot resurrect a claim we no longer own.
+				if (renewed) claimToken = renewed;
+			})
+			.catch((err: unknown) => {
+				log.debug("Claim renewal failed (will retry next beat): %s", errMsg(err));
+			});
+	}, CLAIM_RENEW_INTERVAL_MS);
+	heartbeat.unref();
+
+	const pushOne = async (hash: string): Promise<PushOutcome> => {
+		// Runtime ceiling. Checked before anything else so a commit that never
+		// started leaves no trace: the claim is released, no attempt is recorded,
+		// and no retry is burned — indistinguishable from one this drain never
+		// reached. Commits already in flight are untouched (see stopStartingAt).
+		if (stopStartingAt !== undefined && Date.now() >= stopStartingAt) {
+			await commitEntry(hash, { kind: "patch", patch: {} });
+			onCommitSettled?.({ hash, status: "deferred", reason: "run time limit reached — will sync later" });
+			return "held";
+		}
 		// Story 2 / spec 306: the drain's entry gate ran once, before this loop.
 		// Re-read the opt-out per commit so a user who disables push mid-drain stops
-		// the REMAINING sends — the VS Code client and the IntelliJ bridge both
-		// re-check per outbound call, and this is where the native CLI matches them.
-		// "held" is deliberately neither pushed nor failed: no attempt is recorded and
-		// no retry is burned. The claim IS released, because the re-enable drain runs
-		// immediately on toggle-on and `claimForPush` would otherwise skip a claim this
-		// young for CLAIM_STALE_MS (5 min) — leaving the backlog for an unrelated later
-		// trigger, the opposite of the catch-up this branch exists to enable.
+		// the REMAINING sends. "held" is deliberately neither pushed nor failed: no
+		// attempt is recorded and no retry is burned. The claim IS released, because
+		// the re-enable drain runs immediately on toggle-on and would otherwise skip
+		// a claim this young for the full TTL.
 		if (!(await isOutboundPushAllowed(cwd))) {
-			releaseClaimsInto(updates, [hash]);
+			await commitEntry(hash, { kind: "patch", patch: {} });
+			onCommitSettled?.({ hash, status: "deferred", reason: "outbound push disabled for this repo" });
 			return "held";
 		}
 		// Re-read immediately before the network call so a concurrent rewrite or
 		// cleanup cannot make us publish a stale summary captured earlier.
 		const freshSummary = await getSummary(hash, cwd, storage);
 		if (!freshSummary || freshSummary.commitHash !== hash) {
-			// Raced away (deleted between the memory check and here), or
-			// tree-hash fallback resolved to another commit's summary. Drop it.
-			updates.set(hash, { kind: "delete" });
+			// Raced away (deleted between the memory check and here), or tree-hash
+			// fallback resolved to another commit's summary. Drop it.
+			await commitEntry(hash, { kind: "delete" });
+			onCommitSettled?.({ hash, status: "failed", reason: "summary changed mid-push" });
 			return "failed";
 		}
 		const summary = withRecoveredDocId(freshSummary, claimedEntries[hash]);
 		// Kind-agnostic: whatever kinds are registered, this commit pushes exactly the
-		// items it owns for each of them.
+		// items it owns for each of them. Never hand-build the legacy
+		// `{plans, notes, references}` shape here — naming only those three means
+		// "push ZERO of every other kind", which would silently skip skill and every
+		// future kind on this path.
 		const attachments = selectionForCommit(ownership, hash);
 		try {
-			const { jmSpace } = await pushSummary(summary, ctx, attachments);
-			if (jmSpace) {
-				confirmedSpace = jmSpace;
+			const pushed = await pushSummary(summary, ctx, attachments, { skipOrphanCleanup });
+			if (pushed.jmSpace) confirmedSpace = pushed.jmSpace;
+			if (pushed.writeBackFailed) {
+				// The article exists server-side but its id never reached local
+				// storage. Record the minted ids so the next drain UPDATEs the same
+				// article instead of CREATEing a duplicate, and leave retryCount alone:
+				// the push itself succeeded, only the bookkeeping needs another go.
+				await commitEntry(hash, {
+					kind: "patch",
+					patch: {
+						lastAttemptAt: new Date().toISOString(),
+						lastError: "pushed, but persisting the article id locally failed — will retry the write-back",
+						pushedDocId: pushed.docId,
+						pushedUrl: pushed.summaryUrl,
+					},
+				});
+			} else {
+				// An entry whose orphan cleanup is still outstanding must SURVIVE as a
+				// patch: deleting it would strand those articles with nothing left
+				// pointing at them.
+				await commitEntry(hash, pushed.cleanupPending ? { kind: "patch", patch: {} } : { kind: "delete" });
 			}
-			updates.set(hash, { kind: "delete" });
+			onCommitSettled?.({ hash, status: "pushed", ...(pushed.summaryUrl ? { url: pushed.summaryUrl } : {}) });
 			return "pushed";
 		} catch (err) {
 			// The orchestrator's live re-check tripped between attachments (the
-			// per-commit check above passed). Record no attempt — no lastError, no retry —
-			// so the entry is indistinguishable from one this drain never reached, and
-			// report it as held rather than failed. Releasing the claim is what makes that
-			// true for the re-enable drain as well; see the per-commit gate above.
+			// per-commit check above passed). Record no attempt — no lastError, no
+			// retry — so the entry is indistinguishable from one this drain never
+			// reached, and report it as held rather than failed.
 			if (err instanceof PushDisabledError) {
-				releaseClaimsInto(updates, [hash]);
+				await commitEntry(hash, { kind: "patch", patch: {} });
+				onCommitSettled?.({ hash, status: "deferred", reason: "outbound push disabled for this repo" });
 				return "held";
 			}
 			const { increment, message } = classifyError(err);
@@ -858,16 +764,19 @@ async function pushCandidatesIndividually(args: {
 				err instanceof NotAuthenticatedError ||
 				err instanceof PermissionDeniedError
 			) {
-				// The server just contradicted any cached binding (unbound
-				// elsewhere, or auth/permission revoked) — drop the cache so
-				// `jolli status` / bare `jolli` stop rendering a stale bound row.
+				// The server just contradicted any cached binding (unbound elsewhere,
+				// or auth/permission revoked) — drop the cache so `jolli status` / bare
+				// `jolli` stop rendering a stale bound row.
 				await clearSpaceBindingCache(cwd);
 			}
 			const entry = claimedEntries[hash];
-			updates.set(hash, {
+			// Stamped per failure rather than once per drain: at commit granularity a
+			// drain runs for minutes, so a shared timestamp would misdate late
+			// failures by the whole run length.
+			await commitEntry(hash, {
 				kind: "patch",
 				patch: {
-					lastAttemptAt: nowIso,
+					lastAttemptAt: new Date().toISOString(),
 					lastError: message,
 					...(increment ? { retryCount: entry.retryCount + 1 } : {}),
 				},
@@ -878,79 +787,42 @@ async function pushCandidatesIndividually(args: {
 				message,
 				increment ? "counted" : "held",
 			);
+			onCommitSettled?.({ hash, status: "failed", reason: friendlyPushFailure(message) });
 			return "failed";
 		}
-	});
-	for (const result of results) {
-		if (result === "pushed") counters.pushed++;
-		else if (result === "failed") counters.failed++;
-		// "held" (opt-out) is counted as neither: nothing was sent and nothing failed,
-		// and the entry stays pending for the re-enable drain.
+	};
+
+	try {
+		const results = await mapWithConcurrency(hashes, PUSH_CONCURRENCY, async (hash): Promise<PushOutcome> => {
+			try {
+				return await pushOne(hash);
+			} finally {
+				inFlight.delete(hash);
+			}
+		});
+		for (const result of results) {
+			if (result === "pushed") args.counters.pushed++;
+			else if (result === "failed") args.counters.failed++;
+			// "held" (opt-out) is counted as neither: nothing was sent and nothing
+			// failed, and the entry stays pending for the re-enable drain.
+		}
+	} finally {
+		clearInterval(heartbeat);
 	}
 	await persistConfirmedSpace(ctx, confirmedSpace);
 }
 
-// ─── Inline pre-push drain (synchronous, budget-bound, single batch request) ─
+/** Display status of one commit in a push result list. */
+export type CommitPushStatus = "pushed" | "generating" | "failed" | "deferred" | "merged";
 
-export interface ProcessPrePushInlineOptions {
-	/** Commits of the current push — the ONLY entries this drain considers, in push order. */
-	readonly priorityHashes: ReadonlyArray<string>;
-	/** Absolute epoch-ms deadline for the WHOLE inline phase (local reads + HTTP). */
-	readonly deadlineAt: number;
-	/** Test seam — defaults to a real client whose timeout is the remaining budget. */
-	readonly client?: JolliMemoryPushClient;
-}
-
-/** Display status of one commit in the inline pre-push sync result list. */
-export type InlineCommitStatus = "pushed" | "generating" | "failed" | "deferred" | "merged";
-
-/** Per-commit outcome, in push order — feeds the hook's `git push` result list. */
-export interface InlineCommitOutcome {
+/** Per-commit outcome — feeds the pre-push hook's `git push` result list. */
+export interface CommitPushOutcome {
 	readonly hash: string;
-	readonly status: InlineCommitStatus;
+	readonly status: CommitPushStatus;
 	/** Absolute article URL — set only for "pushed". */
 	readonly url?: string;
 	/** Short human-readable reason — set for every non-"pushed" status. */
 	readonly reason?: string;
-}
-
-export interface ProcessPrePushInlineResult {
-	readonly attempted: number;
-	readonly pushed: number;
-	readonly failed: number;
-	readonly skippedNoMemory: number;
-	readonly skippedRetryExhausted: number;
-	readonly deletedChildren: number;
-	/** Claimed candidates released untouched — budget/limit deferral, deadline abort, or no batch support. */
-	readonly notAttempted: number;
-	/** Per-commit outcomes of THIS push's commits, in push order. */
-	readonly commits: ReadonlyArray<InlineCommitOutcome>;
-	/** Set when the run short-circuited or the batch request failed as a whole. */
-	readonly note?: string;
-}
-
-const EMPTY_INLINE_RESULT: ProcessPrePushInlineResult = {
-	attempted: 0,
-	pushed: 0,
-	failed: 0,
-	skippedNoMemory: 0,
-	skippedRetryExhausted: 0,
-	deletedChildren: 0,
-	notAttempted: 0,
-	commits: [],
-};
-
-/** Orders the collected outcomes by the push's own commit order. */
-function commitsInPushOrder(
-	priorityHashes: ReadonlyArray<string>,
-	outcomes: ReadonlyMap<string, InlineCommitOutcome>,
-): InlineCommitOutcome[] {
-	const commits: InlineCommitOutcome[] = [];
-	for (const hash of priorityHashes) {
-		const outcome = outcomes.get(hash);
-		if (outcome) commits.push(outcome);
-	}
-	return commits;
 }
 
 /** Short, user-facing reason for a failed push — printed verbatim in the hook's result list. */
@@ -961,471 +833,6 @@ function friendlyPushFailure(message: string): string {
 	if (message === "client-outdated") return "Jolli client is outdated — please update";
 	const compact = message.trim().replace(/\s+/g, " ");
 	return compact.length > 60 ? `${compact.substring(0, 59)}…` : compact;
-}
-
-/** True for a fetch aborted by the client's own deadline timer — not a server failure. */
-function isAbortError(err: unknown): boolean {
-	return err instanceof Error && err.name === "AbortError";
-}
-
-/**
- * Releases claims without recording an attempt: an empty patch clears
- * `claimedAt` only, so any later drain (post-queue, activation, next push)
- * can pick the entry up immediately instead of waiting out the claim TTL.
- */
-async function releaseClaims(cwd: string, hashes: ReadonlyArray<string>): Promise<void> {
-	if (hashes.length === 0) return;
-	const updates = new Map<string, BatchUpdate>();
-	for (const hash of hashes) updates.set(hash, { kind: "patch", patch: {} });
-	await updateBatch(cwd, updates);
-}
-
-/**
- * Synchronous pre-push drain, called INSIDE the git pre-push hook while git is
- * waiting for the hook to exit. Key differences from {@link processPushPending}:
- *
- * - **No push confirmation.** The hook runs before git transfers objects, so
- *   waiting for the remote ref would deadlock (git waits for the hook; the
- *   hook would wait for the push). Publishing is optimistic by design — a
- *   rejected push can briefly leave Space articles for commits that never
- *   reached the remote; the user's retry converges them via docId reuse.
- * - **At most one HTTP request.** Batch-eligible memories that fit the server's
- *   total-content limit go out in one `pushBatch` call. Oversized or overflow
- *   items stay pending for the compensation path.
- * - **Hard wall-clock budget.** Every phase checks `deadlineAt`; when the
- *   budget runs out, unprocessed candidates release their claims and stay
- *   pending. The HTTP call's own timeout is the remaining budget, so a hung
- *   connection cannot keep the hook process (and therefore `git push`) alive.
- * - **This push only.** Only the commits of the current push are considered;
- *   leftover entries from earlier pushes stay for the compensation channels
- *   (QueueWorker post-drain, activation retry) so the blocking window stays
- *   proportional to the push at hand. Every considered commit gets a per-hash
- *   entry in `commits` for the hook's result list.
- */
-export async function processPrePushInline(
-	cwd: string,
-	options: ProcessPrePushInlineOptions,
-): Promise<ProcessPrePushInlineResult> {
-	const remainingMs = (): number => options.deadlineAt - Date.now();
-
-	const pending = await loadPushPending(cwd);
-	const allHashes = Object.keys(pending.entries);
-	log.info(
-		"processPrePushInline: %d commit(s) in this push, %d pending entr(ies) on disk",
-		options.priorityHashes.length,
-		allHashes.length,
-	);
-	if (allHashes.length === 0) return { ...EMPTY_INLINE_RESULT, note: "no pending entries" };
-
-	// Same gates as processPushPending — the hook checks these before calling,
-	// but the gates stay here so any future caller inherits them.
-	const config = await loadConfig();
-	if (config.syncOnPush === false) {
-		log.info("processPrePushInline: syncOnPush disabled — skipping %d entries", allHashes.length);
-		return { ...EMPTY_INLINE_RESULT, note: "syncOnPush disabled" };
-	}
-	// Per-repo opt-out gate (Story 2). Entries are recorded write-first by the
-	// hook before this call, so returning here keeps them pending (a later
-	// re-enable drains them) while uploading nothing — the "record locally, skip
-	// outbound" behavior. The hook surfaces the note.
-	if (!(await isOutboundPushAllowed(cwd))) {
-		log.info("processPrePushInline: push disabled for this repo — skipping %d entries", allHashes.length);
-		return { ...EMPTY_INLINE_RESULT, note: "push disabled for this repo" };
-	}
-	if (!config.jolliApiKey) {
-		log.info("processPrePushInline: not signed in — keeping %d entries for later", allHashes.length);
-		return { ...EMPTY_INLINE_RESULT, note: "not signed in" };
-	}
-
-	// Scope: ONLY this push's commits, in push order, capped to the server's
-	// batch limit. Leftover entries from earlier pushes are deliberately left
-	// for the compensation channels.
-	const outcomes = new Map<string, InlineCommitOutcome>();
-	let skippedRetryExhausted = 0;
-	const candidates: string[] = [];
-	for (const hash of options.priorityHashes) {
-		const entry = pending.entries[hash];
-		if (!entry) continue; // not recorded (pruned/raced away) — nothing to report
-		if (entry.retryCount >= MAX_RETRY_COUNT) {
-			skippedRetryExhausted++;
-			outcomes.set(hash, { hash, status: "failed", reason: "failed repeatedly — giving up" });
-			continue;
-		}
-		if (candidates.length < BATCH_MAX_ITEMS) {
-			candidates.push(hash);
-		} else {
-			outcomes.set(hash, { hash, status: "deferred", reason: "over the batch limit — will sync later" });
-		}
-	}
-	if (candidates.length === 0) {
-		log.info("processPrePushInline: no eligible candidates (%d retry-exhausted)", skippedRetryExhausted);
-		return {
-			...EMPTY_INLINE_RESULT,
-			skippedRetryExhausted,
-			commits: commitsInPushOrder(options.priorityHashes, outcomes),
-			note: "no eligible entries",
-		};
-	}
-
-	// Atomic claim — identical race protection to processPushPending.
-	const { claimed, entries: claimedEntries } = await claimForPush(cwd, candidates);
-	const claimedHashes: string[] = [];
-	for (const hash of candidates) {
-		if (claimed.has(hash)) {
-			claimedHashes.push(hash);
-		} else {
-			outcomes.set(hash, { hash, status: "deferred", reason: "another sync is already handling this commit" });
-		}
-	}
-	log.info("processPrePushInline: claimed %d/%d candidate(s)", claimedHashes.length, candidates.length);
-	if (claimedHashes.length === 0) {
-		return {
-			...EMPTY_INLINE_RESULT,
-			skippedRetryExhausted,
-			commits: commitsInPushOrder(options.priorityHashes, outcomes),
-			note: "all entries claimed by another process",
-		};
-	}
-
-	const deferAll = (hashes: ReadonlyArray<string>, reason: string): void => {
-		for (const hash of hashes) outcomes.set(hash, { hash, status: "deferred", reason });
-	};
-
-	if (remainingMs() <= 0) {
-		log.warn("processPrePushInline: budget exhausted before triage — deferring %d commit(s)", claimedHashes.length);
-		await releaseClaims(cwd, claimedHashes);
-		deferAll(claimedHashes, "timed out — will sync later");
-		return {
-			...EMPTY_INLINE_RESULT,
-			skippedRetryExhausted,
-			notAttempted: claimedHashes.length,
-			commits: commitsInPushOrder(options.priorityHashes, outcomes),
-			note: "budget exhausted",
-		};
-	}
-
-	const storage = await ensureStorage(cwd);
-
-	// Triage — same rules as processPushPending: merged children drop out, and
-	// only commits whose own summary exists go into the batch.
-	const indexEntries = await getIndexEntryMap(cwd, storage);
-	const withMemory: string[] = [];
-	const candidateSummaries = new Map<string, CommitSummary>();
-	let skippedNoMemory = 0;
-	let deletedChildren = 0;
-	const preFlightUpdates = new Map<string, BatchUpdate>();
-	for (const hash of claimedHashes) {
-		const indexEntry = indexEntries.get(hash);
-		if (indexEntry && indexEntry.parentCommitHash != null) {
-			preFlightUpdates.set(hash, { kind: "delete" });
-			deletedChildren++;
-			outcomes.set(hash, { hash, status: "merged", reason: "merged into another commit's memory" });
-			log.info(
-				"Skipping child entry %s (parent=%s) — already merged",
-				hash.substring(0, 8),
-				indexEntry.parentCommitHash.substring(0, 8),
-			);
-			continue;
-		}
-		const summary = await getSummary(hash, cwd, storage);
-		if (summary && summary.commitHash === hash) {
-			withMemory.push(hash);
-			candidateSummaries.set(hash, withRecoveredDocId(summary, claimedEntries[hash]));
-		} else {
-			// The empty patch releases the claim so QueueWorker's post-drain
-			// trigger can push the commit the moment its summary lands.
-			preFlightUpdates.set(hash, { kind: "patch", patch: {} });
-			skippedNoMemory++;
-			outcomes.set(hash, { hash, status: "generating", reason: "memory still generating — will sync later" });
-		}
-	}
-	if (preFlightUpdates.size > 0) {
-		await updateBatch(cwd, preFlightUpdates);
-	}
-	log.info(
-		"processPrePushInline: triage — withMemory=%d generating=%d mergedChildren=%d",
-		withMemory.length,
-		skippedNoMemory,
-		deletedChildren,
-	);
-	const baseResult: ProcessPrePushInlineResult = {
-		...EMPTY_INLINE_RESULT,
-		skippedNoMemory,
-		skippedRetryExhausted,
-		deletedChildren,
-	};
-	if (withMemory.length === 0) {
-		const note =
-			deletedChildren > 0 && skippedNoMemory === 0
-				? "all candidates were merged children"
-				: "no candidates with memory";
-		return { ...baseResult, commits: commitsInPushOrder(options.priorityHashes, outcomes), note };
-	}
-
-	if (remainingMs() <= INLINE_MIN_HTTP_BUDGET_MS) {
-		log.warn(
-			"processPrePushInline: budget exhausted before the batch request — deferring %d commit(s)",
-			withMemory.length,
-		);
-		await releaseClaims(cwd, withMemory);
-		deferAll(withMemory, "timed out — will sync later");
-		return {
-			...baseResult,
-			notAttempted: withMemory.length,
-			commits: commitsInPushOrder(options.priorityHashes, outcomes),
-			note: "budget exhausted",
-		};
-	}
-
-	// Payload preparation needs auth/env helpers but performs no network request.
-	// A fresh deadline-bound client is created immediately before pushBatch below,
-	// after git reads and attachment loading have consumed their share of the budget.
-	const preparationClient = options.client ?? new JolliMemoryPushClient();
-	const repoUrl = await getCanonicalRepoUrl(cwd);
-	const baseUrl = await preparationClient.resolveBaseUrl();
-	const displayBase = baseUrl.replace(/\/+$/, "");
-	const preparationCtx: PushContext = { cwd, baseUrl, repoUrl, client: preparationClient, storage };
-
-	const summaries: CommitSummary[] = [];
-	for (const hash of withMemory) {
-		const summary = candidateSummaries.get(hash);
-		if (summary) summaries.push(summary);
-	}
-	const ownership = await buildAttachmentOwnership(cwd, storage, claimedEntries, withMemory, candidateSummaries);
-	const built = await buildBatchItems(summaries, ownership, preparationCtx);
-
-	if (remainingMs() <= INLINE_MIN_HTTP_BUDGET_MS) {
-		log.warn(
-			"processPrePushInline: budget exhausted after payload build — deferring %d commit(s)",
-			withMemory.length,
-		);
-		await releaseClaims(cwd, withMemory);
-		deferAll(withMemory, "timed out — will sync later");
-		return {
-			...baseResult,
-			notAttempted: withMemory.length,
-			commits: commitsInPushOrder(options.priorityHashes, outcomes),
-			note: "budget exhausted",
-		};
-	}
-
-	// Inline mode is intentionally one request. Fill it greedily within the
-	// server's total-content cap; invalid/overflow items release their claims and
-	// stay pending for the confirmed compensation path, which can split batches or
-	// fall back to individual pushes without blocking git.
-	const batchBuilt: BuiltBatchItem[] = [];
-	const deferredByBatchLimit: string[] = [];
-	let batchContentChars = 0;
-	for (const item of built) {
-		const hash = item.item.commitHash;
-		if (item.batchIneligibleReason) {
-			deferredByBatchLimit.push(hash);
-			outcomes.set(hash, {
-				hash,
-				status: "deferred",
-				reason: `${item.batchIneligibleReason} — will sync separately`,
-			});
-			continue;
-		}
-		if (batchContentChars + item.batchContentChars > BATCH_MAX_TOTAL_CONTENT_CHARS) {
-			deferredByBatchLimit.push(hash);
-			outcomes.set(hash, {
-				hash,
-				status: "deferred",
-				reason: "batch content limit reached — will sync later",
-			});
-			continue;
-		}
-		batchBuilt.push(item);
-		batchContentChars += item.batchContentChars;
-	}
-	if (deferredByBatchLimit.length > 0) {
-		await releaseClaims(cwd, deferredByBatchLimit);
-		log.info(
-			"processPrePushInline: deferred %d commit(s) that exceed inline batch limits",
-			deferredByBatchLimit.length,
-		);
-	}
-	if (batchBuilt.length === 0) {
-		return {
-			...baseResult,
-			notAttempted: deferredByBatchLimit.length,
-			commits: commitsInPushOrder(options.priorityHashes, outcomes),
-			note: "batch limits require compensation",
-		};
-	}
-
-	const batchHashes = batchBuilt.map((item) => item.item.commitHash);
-	if (remainingMs() <= INLINE_MIN_HTTP_BUDGET_MS) {
-		log.warn(
-			"processPrePushInline: budget exhausted before the batch request — deferring %d commit(s)",
-			batchHashes.length,
-		);
-		await releaseClaims(cwd, batchHashes);
-		deferAll(batchHashes, "timed out — will sync later");
-		return {
-			...baseResult,
-			notAttempted: deferredByBatchLimit.length + batchHashes.length,
-			commits: commitsInPushOrder(options.priorityHashes, outcomes),
-			note: "budget exhausted",
-		};
-	}
-
-	// Capture the latest remaining budget immediately before the network call.
-	const requestClient = options.client ?? new JolliMemoryPushClient({ timeoutMs: remainingMs() });
-	const requestCtx: PushContext = { ...preparationCtx, client: requestClient };
-	// Story 2 / spec 306: re-read the opt-out immediately before the send. The entry
-	// gate ran at the top of this function, but preparation (summary reads, batch
-	// building) sits in between — a toggle in that window must stop this batch.
-	// Mirrors the BatchUnsupportedError path: release the claims and defer, so the
-	// hook-recorded entries stay pending for the re-enable drain with no retry burned.
-	if (!(await isOutboundPushAllowed(cwd))) {
-		log.info("processPrePushInline: push disabled mid-run — holding %d commit(s)", batchHashes.length);
-		await releaseClaims(cwd, batchHashes);
-		deferAll(batchHashes, "outbound push disabled for this repo");
-		return {
-			...baseResult,
-			notAttempted: deferredByBatchLimit.length + batchHashes.length,
-			commits: commitsInPushOrder(options.priorityHashes, outcomes),
-			note: "push disabled for this repo",
-		};
-	}
-	log.info("processPrePushInline: pushing %d commit(s) in one batch request", batchBuilt.length);
-	let batchResult: BatchPushResult;
-	try {
-		batchResult = await requestClient.pushBatch({ repoUrl, items: batchBuilt.map((item) => item.item) });
-	} catch (err) {
-		if (err instanceof BatchUnsupportedError) {
-			// Server predates the endpoint — leave everything pending without
-			// burning retries; a later server deploy (or the pushSummary-based
-			// compensation paths) picks the entries up.
-			log.warn("processPrePushInline: %s", err.message);
-			await releaseClaims(cwd, batchHashes);
-			deferAll(batchHashes, "server does not support batch push yet");
-			return {
-				...baseResult,
-				notAttempted: deferredByBatchLimit.length + batchHashes.length,
-				commits: commitsInPushOrder(options.priorityHashes, outcomes),
-				note: "server lacks batch support",
-			};
-		}
-		if (isAbortError(err)) {
-			// Our own deadline abort — not a server failure, so no retry burn.
-			log.warn("processPrePushInline: batch request aborted at the deadline");
-			await releaseClaims(cwd, batchHashes);
-			deferAll(batchHashes, "timed out — will sync later");
-			return {
-				...baseResult,
-				notAttempted: deferredByBatchLimit.length + batchHashes.length,
-				commits: commitsInPushOrder(options.priorityHashes, outcomes),
-				note: "deadline exceeded",
-			};
-		}
-		const { increment, message } = classifyError(err);
-		if (
-			err instanceof BindingRequiredError ||
-			err instanceof NotAuthenticatedError ||
-			err instanceof PermissionDeniedError
-		) {
-			// The server just contradicted any cached binding (unbound
-			// elsewhere, or auth/permission revoked) — drop the cache so
-			// `jolli status` / bare `jolli` stop rendering a stale bound row.
-			await clearSpaceBindingCache(cwd);
-		}
-		const failureUpdates = new Map<string, BatchUpdate>();
-		const failedAtIso = new Date().toISOString();
-		const reason = friendlyPushFailure(message);
-		for (const hash of batchHashes) {
-			failureUpdates.set(hash, {
-				kind: "patch",
-				patch: {
-					lastAttemptAt: failedAtIso,
-					lastError: message,
-					...(increment ? { retryCount: claimedEntries[hash].retryCount + 1 } : {}),
-				},
-			});
-			outcomes.set(hash, { hash, status: "failed", reason });
-		}
-		await updateBatch(cwd, failureUpdates);
-		log.warn(
-			"processPrePushInline: batch request failed for %d commit(s): %s (retry %s)",
-			batchHashes.length,
-			message,
-			increment ? "counted" : "held",
-		);
-		return {
-			...baseResult,
-			attempted: batchHashes.length,
-			failed: batchHashes.length,
-			notAttempted: deferredByBatchLimit.length,
-			commits: commitsInPushOrder(options.priorityHashes, outcomes),
-			note: message,
-		};
-	}
-
-	// Per-item accounting: ok → entry gone; failed → error + retry counted.
-	const updates = new Map<string, BatchUpdate>();
-	const nowIso = new Date().toISOString();
-	const resultByHash = new Map(batchResult.results.map((r) => [r.commitHash, r]));
-	let pushed = 0;
-	let failed = 0;
-	for (const hash of batchHashes) {
-		const result = resultByHash.get(hash);
-		if (result?.ok) {
-			updates.set(hash, { kind: "delete" });
-			pushed++;
-			const url = result.summary
-				? resolveArticleUrl(displayBase, result.summary.url, result.summary.docId)
-				: undefined;
-			outcomes.set(hash, { hash, status: "pushed", ...(url !== undefined && { url }) });
-			continue;
-		}
-		failed++;
-		const message = result?.error ?? result?.errorCode ?? "missing batch result";
-		updates.set(hash, {
-			kind: "patch",
-			patch: {
-				lastAttemptAt: nowIso,
-				lastError: message,
-				retryCount: claimedEntries[hash].retryCount + 1,
-			},
-		});
-		outcomes.set(hash, { hash, status: "failed", reason: friendlyPushFailure(message) });
-		log.warn("Batch push failed for %s: %s", hash.substring(0, 8), message);
-	}
-
-	// Local write-back (docId/url → stored summary) so the next push updates
-	// instead of creating. Keep successful entries pending when confirmed orphan
-	// cleanup still remains; the inline hook cannot safely delete old articles
-	// before git confirms that the push itself succeeded.
-	try {
-		const writeBack = await applyBatchResult(batchBuilt, batchResult.results, requestCtx);
-		preserveCleanupPending(updates, writeBack.cleanupPendingHashes);
-		preserveWriteBackFailures(updates, writeBack.writeBackFailures, nowIso);
-		log.debug(
-			"processPrePushInline: write-back — writtenBack=%d childSkipped=%d cleanupPending=%d writeBackFailed=%d",
-			writeBack.writtenBack,
-			writeBack.childSkipped,
-			writeBack.cleanupPendingHashes?.length ?? 0,
-			writeBack.writeBackFailures?.length ?? 0,
-		);
-	} catch (err) {
-		log.warn("processPrePushInline: write-back failed: %s", errMsg(err));
-	}
-	await updateBatch(cwd, updates);
-	// The server accepted the batch request (binding + push rights verified),
-	// so the top-level Space echo is trustworthy even on per-item failures.
-	await persistConfirmedSpace(requestCtx, batchResult.jmSpace);
-
-	log.info("processPrePushInline: pushed=%d failed=%d", pushed, failed);
-	return {
-		...baseResult,
-		attempted: batchHashes.length,
-		pushed,
-		failed,
-		notAttempted: deferredByBatchLimit.length,
-		commits: commitsInPushOrder(options.priorityHashes, outcomes),
-	};
 }
 
 /**

--- a/cli/src/core/PushPendingStore.test.ts
+++ b/cli/src/core/PushPendingStore.test.ts
@@ -6,6 +6,7 @@ import { JOLLI_DIR, JOLLIMEMORY_DIR } from "../Logger.js";
 import { withPushPendingLock } from "./Locks.js";
 import {
 	__writeForTest,
+	CLAIM_RENEW_INTERVAL_MS,
 	claimForPush,
 	deleteEntry,
 	loadPushPending,
@@ -13,6 +14,7 @@ import {
 	PUSH_ERROR_MSG_MAX_LEN,
 	PUSH_PENDING_STALE_MS,
 	type PushPendingFile,
+	renewClaims,
 	truncateError,
 	updateBatch,
 	updateEntry,
@@ -363,6 +365,75 @@ describe("updateBatch / updateEntry / deleteEntry", () => {
 		const file = await loadPushPending(cwd);
 		// The two from beforeEach plus the six new = 8 distinct entries.
 		expect(Object.keys(file.entries).length).toBe(8);
+	});
+});
+
+describe("renewClaims", () => {
+	const seed = async (over: Record<string, unknown> = {}) => {
+		const now = new Date().toISOString();
+		await __writeForTest(cwd, {
+			version: 1,
+			entries: { [HASH_A]: { branch: "feature/x", enqueuedAt: now, retryCount: 0, ...over } },
+		});
+	};
+
+	it("refreshes a claim this drain still holds and returns the new token", async () => {
+		await seed();
+		const claim = await claimForPush(cwd, [HASH_A]);
+		const renewed = await renewClaims(cwd, [HASH_A], claim.claimedAt);
+		expect(renewed).toBeDefined();
+		// A same-millisecond renewal legitimately produces an identical stamp, so
+		// the contract is "never goes backwards", not "always differs".
+		expect(Date.parse(renewed as string)).toBeGreaterThanOrEqual(Date.parse(claim.claimedAt));
+		const file = await loadPushPending(cwd);
+		expect(file.entries[HASH_A].claimedAt).toBe(renewed);
+	});
+
+	it("leaves a claim someone else took over untouched", async () => {
+		// `claimedAt` carries no holder identity, so a stale-but-fresh check would
+		// happily renew THEIR claim and put both processes on the same commit.
+		await seed();
+		const claim = await claimForPush(cwd, [HASH_A]);
+		const theirs = new Date(Date.now() + 1000).toISOString();
+		await updateEntry(cwd, HASH_A, {});
+		await __writeForTest(cwd, {
+			version: 1,
+			entries: {
+				[HASH_A]: {
+					branch: "feature/x",
+					enqueuedAt: new Date().toISOString(),
+					retryCount: 0,
+					claimedAt: theirs,
+				},
+			},
+		});
+		const renewed = await renewClaims(cwd, [HASH_A], claim.claimedAt);
+		expect(renewed).toBeUndefined();
+		const file = await loadPushPending(cwd);
+		expect(file.entries[HASH_A].claimedAt).toBe(theirs);
+	});
+
+	it("ignores entries with no claim at all", async () => {
+		await seed();
+		const renewed = await renewClaims(cwd, [HASH_A], new Date().toISOString());
+		expect(renewed).toBeUndefined();
+		const file = await loadPushPending(cwd);
+		expect(file.entries[HASH_A].claimedAt).toBeUndefined();
+	});
+
+	it("ignores hashes that are no longer pending", async () => {
+		const renewed = await renewClaims(cwd, [HASH_A], new Date().toISOString());
+		expect(renewed).toBeUndefined();
+	});
+
+	it("no-ops on an empty hash list without touching the file", async () => {
+		await expect(renewClaims(cwd, [], new Date().toISOString())).resolves.toBeUndefined();
+	});
+
+	it("beats the claim TTL with room for a missed beat", async () => {
+		// The heartbeat only protects a long drain while it stays comfortably
+		// inside the TTL; a half-TTL interval would retry exactly on the boundary.
+		expect(CLAIM_RENEW_INTERVAL_MS * 2).toBeLessThan(5 * 60 * 1000);
 	});
 });
 

--- a/cli/src/core/PushPendingStore.ts
+++ b/cli/src/core/PushPendingStore.ts
@@ -140,8 +140,23 @@ export type BatchUpdate =
  * timeout (30 s default) plus headroom for push-confirmation polling (60 s).
  * A crashed process's claims expire after this, so entries are not stuck
  * forever.
+ *
+ * A drain that legitimately runs longer than this keeps its claims alive with
+ * {@link renewClaims} rather than by widening the window — a wider window would
+ * also delay recovery from a genuinely crashed holder.
  */
 const CLAIM_STALE_MS = 5 * 60 * 1000;
+
+/**
+ * How often a long-running drain should call {@link renewClaims}.
+ *
+ * Derived from {@link CLAIM_STALE_MS} and declared next to it on purpose: the
+ * invariant "a missed beat still leaves room for the next one" only holds while
+ * these two move together, and nothing else enforces it. At 1/3 of the TTL one
+ * missed beat still renews at 2/3 of the window; a half-TTL interval would put
+ * the retry exactly on the expiry boundary.
+ */
+export const CLAIM_RENEW_INTERVAL_MS = Math.floor(CLAIM_STALE_MS / 3);
 
 // ─── Path helpers ───────────────────────────────────────────────────────────
 
@@ -332,11 +347,8 @@ export async function mergeEntries(
  * `loadPushPending` read let two processes both see the same entries and both
  * push them, creating duplicate Space articles.
  */
-export async function claimForPush(
-	cwd: string,
-	candidates: ReadonlyArray<string>,
-): Promise<{ claimed: ReadonlySet<string>; entries: Readonly<Record<string, PushPendingEntry>> }> {
-	if (candidates.length === 0) return { claimed: new Set(), entries: {} };
+export async function claimForPush(cwd: string, candidates: ReadonlyArray<string>): Promise<ClaimResult> {
+	if (candidates.length === 0) return { claimed: new Set(), entries: {}, claimedAt: new Date().toISOString() };
 	const path = pendingPath(cwd);
 	const candidateSet = new Set(candidates);
 	return withPushPendingLock(cwd, async () => {
@@ -361,7 +373,67 @@ export async function claimForPush(
 			await writeOrUnlink(path, next);
 			logPrunedEntries(current.prunedCount);
 		}
-		return { claimed, entries: current.file.entries };
+		return { claimed, entries: current.file.entries, claimedAt: nowIso };
+	});
+}
+
+export interface ClaimResult {
+	readonly claimed: ReadonlySet<string>;
+	readonly entries: Readonly<Record<string, PushPendingEntry>>;
+	/**
+	 * The exact `claimedAt` stamped on every hash in `claimed`. `claimedAt` is a
+	 * bare timestamp with no holder identity, so this value doubles as the
+	 * ownership token {@link renewClaims} compares against.
+	 */
+	readonly claimedAt: string;
+}
+
+/**
+ * Refreshes `claimedAt` on hashes this drain still holds, so a run that outlives
+ * {@link CLAIM_STALE_MS} does not have its claims stolen mid-flight. Returns the
+ * new token to compare against on the next beat, or `undefined` when nothing was
+ * renewed (every hash is finished, gone, or now held by someone else).
+ *
+ * Without this, a long drain — commit-granularity pushes routinely run for
+ * minutes — lets another channel re-claim a hash that is still in flight here.
+ * Both processes would then read a summary with no docId and CREATE two articles
+ * for the same commit.
+ *
+ * The refresh is a compare-and-swap on the timestamp, NOT a "is it still fresh"
+ * check. `claimedAt` carries no holder identity, so a claim someone else took
+ * over looks exactly like our own: if this process stalls (machine sleep,
+ * SIGSTOP, a long blocking write) past the TTL and another channel reclaims the
+ * entry, a freshness check would happily renew THEIR claim and put both
+ * processes back on the same hash. Only an exact match proves the stamp is
+ * still the one we wrote.
+ */
+export async function renewClaims(
+	cwd: string,
+	hashes: ReadonlyArray<string>,
+	expectedClaimedAt: string,
+): Promise<string | undefined> {
+	if (hashes.length === 0) return undefined;
+	const path = pendingPath(cwd);
+	const wanted = new Set(hashes);
+	return withPushPendingLock(cwd, async () => {
+		const current = await readPushPendingSnapshot(cwd);
+		const next: Record<string, PushPendingEntry> = { ...current.file.entries };
+		const nowIso = new Date().toISOString();
+		let renewed = 0;
+		for (const hash of wanted) {
+			const entry = next[hash];
+			// Exact match only — see the compare-and-swap note above.
+			if (!entry || entry.claimedAt !== expectedClaimedAt) continue;
+			next[hash] = { ...entry, claimedAt: nowIso };
+			renewed++;
+		}
+		if (renewed > 0 || current.prunedCount > 0) {
+			await writeOrUnlink(path, next);
+			logPrunedEntries(current.prunedCount);
+		}
+		if (renewed === 0) return undefined;
+		log.debug("Renewed %d push claim(s)", renewed);
+		return nowIso;
 	});
 }
 

--- a/cli/src/hooks/CaptureProgress.test.ts
+++ b/cli/src/hooks/CaptureProgress.test.ts
@@ -205,6 +205,34 @@ describe("pruneStaleCaptureProgress", () => {
 		expect(() => readFileSync(join(dir, "recent.ndjson"), "utf-8")).not.toThrow();
 	});
 
+	it("sweeps the pre-push worker's json and tmp artifacts too", () => {
+		// Without these two suffixes every push leaves a request + result file
+		// behind forever, and a crashed `write + rename` leaks its scratch file.
+		const dir = captureProgressDir(tempDir);
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, "push-abc.request.json"), "{}", "utf-8");
+		writeFileSync(join(dir, "push-abc.result.json"), "{}", "utf-8");
+		writeFileSync(join(dir, "push-abc.result.json.tmp"), "{", "utf-8");
+		writeFileSync(join(dir, "push-abc.lock"), "1", "utf-8");
+		writeFileSync(join(dir, "keep.txt"), "z", "utf-8");
+		pruneStaleCaptureProgress(tempDir, 5_000, Date.now() + 10_000);
+		expect(existsSync(join(dir, "push-abc.request.json"))).toBe(false);
+		expect(existsSync(join(dir, "push-abc.result.json"))).toBe(false);
+		expect(existsSync(join(dir, "push-abc.result.json.tmp"))).toBe(false);
+		expect(existsSync(join(dir, "push-abc.lock"))).toBe(false);
+		expect(existsSync(join(dir, "keep.txt"))).toBe(true);
+	});
+
+	it("does not let the .json rule swallow the capture stream's .ndjson files", () => {
+		// `.ndjson` does not end with `.json`, so both entries are required — a
+		// single `.json` rule would silently stop sweeping progress streams.
+		const dir = captureProgressDir(tempDir);
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, "fresh.ndjson"), "x", "utf-8");
+		pruneStaleCaptureProgress(tempDir, 60_000, Date.now());
+		expect(existsSync(join(dir, "fresh.ndjson"))).toBe(true);
+	});
+
 	it("no-ops when the dir is missing", () => {
 		expect(() => pruneStaleCaptureProgress(tempDir, 1000)).not.toThrow();
 	});

--- a/cli/src/hooks/CaptureProgress.ts
+++ b/cli/src/hooks/CaptureProgress.ts
@@ -221,14 +221,25 @@ export function readCaptureEvents(path: string): CaptureProgressEvent[] {
 }
 
 /**
+ * Suffixes swept by {@link pruneStaleCaptureProgress} — every artifact kind that
+ * lands in this directory:
+ *   - `.ndjson` — the per-commit capture progress stream.
+ *   - `.lock`   — {@link acquireCaptureLock}'s per-hash lock, and the pre-push
+ *     worker's per-push lock. A force-killed worker leaves its lock behind and
+ *     that hash never re-runs, so it would otherwise linger forever.
+ *   - `.json`   — the pre-push worker's request/result hand-off files.
+ *   - `.tmp`    — a `write + rename` whose process died between the two steps.
+ *
+ * `.ndjson` does NOT match `.json` (the dot is part of the suffix), so both
+ * entries are required.
+ */
+const PRUNABLE_SUFFIXES = [".ndjson", ".lock", ".json", ".tmp"] as const;
+
+/**
  * Deletes stale files older than `maxAgeMs` from the capture-progress dir.
- * Best-effort. Covers both artifact kinds that live here:
- *   - `<hash>.ndjson` — the per-commit progress stream.
- *   - `<sha256>.lock`  — {@link acquireCaptureLock}'s per-hash lock file. A
- *     force-killed worker leaves its `.lock` behind and that hash never re-runs,
- *     so the lock would otherwise linger forever. The same mtime/age threshold
- *     is the safety margin: a live lock is refreshed well within `maxAgeMs`, so
- *     only genuinely abandoned locks age out.
+ * Best-effort. The mtime/age threshold is the safety margin: anything a live
+ * worker still touches is refreshed well within `maxAgeMs`, so only genuinely
+ * abandoned artifacts age out.
  */
 export function pruneStaleCaptureProgress(cwd: string | undefined, maxAgeMs: number, nowMs: number = Date.now()): void {
 	let names: string[];
@@ -238,7 +249,7 @@ export function pruneStaleCaptureProgress(cwd: string | undefined, maxAgeMs: num
 		return; // dir missing / unreadable — nothing to prune
 	}
 	for (const name of names) {
-		if (!name.endsWith(".ndjson") && !name.endsWith(".lock")) continue;
+		if (!PRUNABLE_SUFFIXES.some((suffix) => name.endsWith(suffix))) continue;
 		const full = join(captureProgressDir(cwd), name);
 		try {
 			if (nowMs - statSync(full).mtimeMs > maxAgeMs) unlinkSync(full);

--- a/cli/src/hooks/PrePushHook.test.ts
+++ b/cli/src/hooks/PrePushHook.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { type ProcessPrePushInlineResult, processPrePushInline } from "../core/PushExecutor.js";
+import type { CommitPushOutcome } from "../core/PushExecutor.js";
 import { mergeEntries } from "../core/PushPendingStore.js";
 import { loadConfig } from "../core/SessionTracker.js";
 import { createStorage } from "../core/StorageFactory.js";
 import { getIndexEntryMap, getSummary } from "../core/SummaryStore.js";
 import { execFileAsyncHidden } from "../util/Subprocess.js";
 import { PRE_PUSH_SYNC_BUDGET_MS, parsePushRefs, prePushEntry } from "./PrePushHook.js";
+import { triggerPendingPushRetry } from "./PushCompensation.js";
+import { type PushWorkerResult, watchPushResult, writePushRequest, writePushResult } from "./PushProgress.js";
 
 const mockReadManualDisableFlag = vi.hoisted(() => vi.fn().mockResolvedValue(false));
 const mockReadPushDisabledState = vi.hoisted(() => vi.fn().mockResolvedValue({ disabled: false }));
@@ -18,7 +20,14 @@ vi.mock("../core/PushControl.js", () => ({
 	readPushDisabledState: mockReadPushDisabledState,
 }));
 vi.mock("../core/PushPendingStore.js", () => ({ mergeEntries: vi.fn() }));
-vi.mock("../core/PushExecutor.js", () => ({ processPrePushInline: vi.fn() }));
+vi.mock("./PushCompensation.js", () => ({ triggerPendingPushRetry: vi.fn() }));
+// reasonFromNote stays real: it is a pure mapping the hook's output depends on.
+vi.mock("./PushProgress.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("./PushProgress.js")>()),
+	writePushRequest: vi.fn(),
+	writePushResult: vi.fn(),
+	watchPushResult: vi.fn(),
+}));
 vi.mock("../core/StorageFactory.js", () => ({ createStorage: vi.fn() }));
 vi.mock("../core/SummaryStore.js", () => ({ getIndexEntryMap: vi.fn(), getSummary: vi.fn() }));
 vi.mock("../util/Subprocess.js", () => ({ execFileAsyncHidden: vi.fn() }));
@@ -29,22 +38,28 @@ const LOCAL = "1".repeat(40);
 const REMOTE = "2".repeat(40);
 const REMOTE_NAME = "origin";
 
-const EMPTY_RESULT: ProcessPrePushInlineResult = {
-	attempted: 0,
-	pushed: 0,
-	failed: 0,
-	skippedNoMemory: 0,
-	skippedRetryExhausted: 0,
-	deletedChildren: 0,
-	notAttempted: 0,
-	commits: [],
-};
+const PUSH_ID = "trace-abc";
+
+/** A finished worker run that settled `commits` and nothing else. */
+function completed(commits: ReadonlyArray<CommitPushOutcome>, note?: string) {
+	const result: PushWorkerResult = { pushId: PUSH_ID, commits, complete: true, ...(note ? { note } : {}) };
+	return { ended: "complete" as const, result };
+}
+
+/** A watch that gave up while the worker kept running, having seen `commits`. */
+function timedOut(commits: ReadonlyArray<CommitPushOutcome>) {
+	if (commits.length === 0) return { ended: "timeout" as const };
+	const result: PushWorkerResult = { pushId: PUSH_ID, commits, complete: false };
+	return { ended: "timeout" as const, result };
+}
 
 beforeEach(() => {
 	vi.clearAllMocks();
 	vi.mocked(loadConfig).mockResolvedValue({ jolliApiKey: "sk-jol-x" });
 	vi.mocked(mergeEntries).mockResolvedValue(undefined);
-	vi.mocked(processPrePushInline).mockResolvedValue(EMPTY_RESULT);
+	vi.mocked(triggerPendingPushRetry).mockReturnValue(true);
+	vi.mocked(writePushRequest).mockReturnValue(undefined);
+	vi.mocked(watchPushResult).mockResolvedValue(completed([]));
 	vi.mocked(createStorage).mockResolvedValue({} as never);
 	vi.mocked(getIndexEntryMap).mockResolvedValue(new Map());
 	vi.mocked(getSummary).mockResolvedValue(null);
@@ -78,7 +93,7 @@ describe("prePushEntry", () => {
 		vi.mocked(loadConfig).mockResolvedValue({ jolliApiKey: "sk-jol-x", syncOnPush: false });
 		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
 		expect(mergeEntries).not.toHaveBeenCalled();
-		expect(processPrePushInline).not.toHaveBeenCalled();
+		expect(triggerPendingPushRetry).not.toHaveBeenCalled();
 	});
 
 	it("records commits but skips inline sync when outbound push is disabled for the repo (spec 306)", async () => {
@@ -87,7 +102,7 @@ describe("prePushEntry", () => {
 		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
 		// Entries are still recorded (a later re-enable catches up) but no sync runs.
 		expect(mergeEntries).toHaveBeenCalled();
-		expect(processPrePushInline).not.toHaveBeenCalled();
+		expect(triggerPendingPushRetry).not.toHaveBeenCalled();
 		// A genuine opt-out is the ONE case that may point at --enable.
 		expect(stderr.mock.calls.flat().join("")).toContain("jolli push-control --enable");
 	});
@@ -104,7 +119,7 @@ describe("prePushEntry", () => {
 		const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
 		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
 		expect(mergeEntries).toHaveBeenCalled();
-		expect(processPrePushInline).not.toHaveBeenCalled();
+		expect(triggerPendingPushRetry).not.toHaveBeenCalled();
 		const written = stderr.mock.calls.flat().join("");
 		expect(written).toContain("can't read your outbound-push setting");
 		expect(written).toContain("/g/push-control.json");
@@ -119,7 +134,7 @@ describe("prePushEntry", () => {
 			remoteRef: "refs/heads/x",
 			localSha: LOCAL,
 		});
-		expect(processPrePushInline).not.toHaveBeenCalled();
+		expect(triggerPendingPushRetry).not.toHaveBeenCalled();
 	});
 
 	it("lists at most three exact root memories when not signed in", async () => {
@@ -166,7 +181,7 @@ describe("prePushEntry", () => {
 		expect(output).not.toContain("Fourth memory");
 		expect(output).toContain("  ...");
 		expect(output).toContain("Run `jolli auth login` to sign in");
-		expect(processPrePushInline).not.toHaveBeenCalled();
+		expect(triggerPendingPushRetry).not.toHaveBeenCalled();
 	});
 
 	it("omits the signed-out notice when this push has no generated memories", async () => {
@@ -208,7 +223,7 @@ describe("prePushEntry", () => {
 			prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME),
 		).resolves.toBeUndefined();
 		expect(stderrSpy).not.toHaveBeenCalled();
-		expect(processPrePushInline).not.toHaveBeenCalled();
+		expect(triggerPendingPushRetry).not.toHaveBeenCalled();
 	});
 
 	it("stops the signed-out preview scan at the deadline instead of reading storage per commit", async () => {
@@ -226,7 +241,7 @@ describe("prePushEntry", () => {
 		expect(stderrSpy).not.toHaveBeenCalled();
 	});
 
-	it("records commits and runs the inline sync when signed in", async () => {
+	it("records commits and spawns the detached sync worker when signed in", async () => {
 		const startedAtMs = 1_000_000;
 		await prePushEntry(
 			CWD,
@@ -239,27 +254,31 @@ describe("prePushEntry", () => {
 			remoteRef: "refs/heads/feature/y",
 			localSha: LOCAL,
 		});
-		expect(processPrePushInline).toHaveBeenCalledWith(CWD, {
-			priorityHashes: ["c1", "c2"],
+		expect(writePushRequest).toHaveBeenCalledWith(CWD, { pushId: expect.any(String), hashes: ["c1", "c2"] });
+		const [, trigger, extraArgs] = vi.mocked(triggerPendingPushRetry).mock.calls[0];
+		expect(trigger).toBe("pre-push");
+		expect(extraArgs?.[0]).toBe("--push-id");
+		// The watch budget is anchored at process start, not at spawn time.
+		expect(vi.mocked(watchPushResult).mock.calls[0][2]).toMatchObject({
 			deadlineAt: startedAtMs + PRE_PUSH_SYNC_BUDGET_MS,
 		});
 	});
 
-	it("records entries BEFORE the inline sync runs (write-first crash safety)", async () => {
+	it("records entries BEFORE spawning the worker (write-first crash safety)", async () => {
 		const order: string[] = [];
 		vi.mocked(mergeEntries).mockImplementation(async () => {
 			order.push("merge");
 		});
-		vi.mocked(processPrePushInline).mockImplementation(async () => {
+		vi.mocked(triggerPendingPushRetry).mockImplementation(() => {
 			order.push("sync");
-			return EMPTY_RESULT;
+			return true;
 		});
 		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
 		expect(order).toEqual(["merge", "sync"]);
 	});
 
-	it("swallows inline sync failures so the push is never blocked", async () => {
-		vi.mocked(processPrePushInline).mockRejectedValue(new Error("network down"));
+	it("swallows result-watch failures so the push is never blocked", async () => {
+		vi.mocked(watchPushResult).mockRejectedValue(new Error("watch boom"));
 		await expect(
 			prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME),
 		).resolves.toBeUndefined();
@@ -272,16 +291,12 @@ describe("prePushEntry", () => {
 			}
 			return { stdout: "c1\nc2\n", stderr: "" };
 		});
-		vi.mocked(processPrePushInline).mockResolvedValue({
-			...EMPTY_RESULT,
-			attempted: 1,
-			pushed: 1,
-			skippedNoMemory: 1,
-			commits: [
+		vi.mocked(watchPushResult).mockResolvedValue(
+			completed([
 				{ hash: "c1", status: "pushed", url: "https://jolli.ai/articles/fix-login-bug-9" },
 				{ hash: "c2", status: "generating", reason: "memory still generating — will sync later" },
-			],
-		});
+			]),
+		);
 		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
 		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
 		const output = String(stderrSpy.mock.calls[0][0]);
@@ -294,12 +309,9 @@ describe("prePushEntry", () => {
 	});
 
 	it("prints a short failure reason for failed commits", async () => {
-		vi.mocked(processPrePushInline).mockResolvedValue({
-			...EMPTY_RESULT,
-			attempted: 1,
-			failed: 1,
-			commits: [{ hash: "c1", status: "failed", reason: "network timeout" }],
-		});
+		vi.mocked(watchPushResult).mockResolvedValue(
+			completed([{ hash: "c1", status: "failed", reason: "network timeout" }]),
+		);
 		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
 		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
 		const output = String(stderrSpy.mock.calls[0][0]);
@@ -313,12 +325,9 @@ describe("prePushEntry", () => {
 			if (args?.[0] === "show") return { stdout: `c1\t${longSubject}\n`, stderr: "" };
 			return { stdout: "c1\n", stderr: "" };
 		});
-		vi.mocked(processPrePushInline).mockResolvedValue({
-			...EMPTY_RESULT,
-			attempted: 1,
-			pushed: 1,
-			commits: [{ hash: "c1", status: "pushed", url: "https://jolli.ai/a" }],
-		});
+		vi.mocked(watchPushResult).mockResolvedValue(
+			completed([{ hash: "c1", status: "pushed", url: "https://jolli.ai/a" }]),
+		);
 		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
 		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
 		const output = String(stderrSpy.mock.calls[0][0]);
@@ -331,12 +340,9 @@ describe("prePushEntry", () => {
 			if (args?.[0] === "show") throw new Error("git boom");
 			return { stdout: "c1\n", stderr: "" };
 		});
-		vi.mocked(processPrePushInline).mockResolvedValue({
-			...EMPTY_RESULT,
-			attempted: 1,
-			pushed: 1,
-			commits: [{ hash: "c1", status: "pushed", url: "https://jolli.ai/a" }],
-		});
+		vi.mocked(watchPushResult).mockResolvedValue(
+			completed([{ hash: "c1", status: "pushed", url: "https://jolli.ai/a" }]),
+		);
 		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
 		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
 		const output = String(stderrSpy.mock.calls[0][0]);
@@ -344,16 +350,91 @@ describe("prePushEntry", () => {
 		expect(output).toContain("https://jolli.ai/a");
 	});
 
-	it("stays silent on stderr when there was nothing to sync", async () => {
+	it("labels commits the finished worker never reported from its note, not as background work", async () => {
+		// A `complete` result promises nothing more is coming, so an unreported hash
+		// must never be rendered as "still syncing" — the worker has already exited.
+		vi.mocked(watchPushResult).mockResolvedValue(completed([], "not signed in"));
 		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
 		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
-		expect(stderrSpy).not.toHaveBeenCalled();
+		const output = String(stderrSpy.mock.calls[0][0]);
+		expect(output).toContain("not signed in to Jolli");
+		expect(output).not.toContain("in the background");
+	});
+
+	it("prints settled commits and marks the rest as background work on timeout", async () => {
+		vi.mocked(watchPushResult).mockResolvedValue(
+			timedOut([{ hash: "c1", status: "pushed", url: "https://jolli.ai/a" }]),
+		);
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+		const output = String(stderrSpy.mock.calls[0][0]);
+		expect(output).toContain("✓ c1");
+		expect(output).toContain("https://jolli.ai/a");
+		// c2 never settled, and the worker is still alive — this wording is true.
+		expect(output).toContain("… c2");
+		expect(output).toContain("syncing in the background");
+	});
+
+	it("prints a single background notice when the watch times out with no results yet", async () => {
+		vi.mocked(watchPushResult).mockResolvedValue(timedOut([]));
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+		const output = String(stderrSpy.mock.calls[0][0]);
+		expect(output).toContain("syncing 2 commit(s) to Jolli Space in the background");
+	});
+
+	it("reports an interrupted sync when the worker died, never as background work", async () => {
+		vi.mocked(watchPushResult).mockResolvedValue({
+			ended: "worker-dead",
+			result: { pushId: PUSH_ID, commits: [{ hash: "c1", status: "pushed" }], complete: false },
+		});
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+		const output = stderrSpy.mock.calls.map((call) => String(call[0])).join("");
+		expect(output).toContain("✓ c1");
+		expect(output).toContain("interrupted — still pending");
+		expect(output).toContain("background sync was interrupted");
+		expect(output).not.toContain("syncing in the background");
+	});
+
+	it("degrades immediately when the work list cannot be written, without waiting out the budget", async () => {
+		vi.mocked(writePushRequest).mockImplementation(() => {
+			throw new Error("disk full");
+		});
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+		expect(triggerPendingPushRetry).not.toHaveBeenCalled();
+		expect(watchPushResult).not.toHaveBeenCalled();
+		expect(String(stderrSpy.mock.calls[0][0])).toContain("background sync could not start");
+	});
+
+	it("degrades immediately when the worker cannot be spawned", async () => {
+		vi.mocked(triggerPendingPushRetry).mockReturnValue(false);
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+		expect(watchPushResult).not.toHaveBeenCalled();
+		expect(String(stderrSpy.mock.calls[0][0])).toContain("background sync could not start");
+	});
+
+	it("publishes a terminal result when the spawn fails asynchronously", async () => {
+		// ENOENT/EACCES arrive on the child's error event, after spawn returned. The
+		// published result is what lets the poll loop exit on its next tick.
+		vi.mocked(triggerPendingPushRetry).mockImplementation((_cwd, _trigger, _args, onSpawnError) => {
+			onSpawnError?.(new Error("spawn ENOENT"));
+			return true;
+		});
+		vi.spyOn(process.stderr, "write").mockReturnValue(true);
+		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
+		expect(writePushResult).toHaveBeenCalledWith(
+			CWD,
+			expect.objectContaining({ complete: true, commits: [], note: expect.stringContaining("spawn ENOENT") }),
+		);
 	});
 
 	it("skips delete pushes (all-zero local sha)", async () => {
 		await prePushEntry(CWD, `(delete) ${ZERO} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
 		expect(mergeEntries).not.toHaveBeenCalled();
-		expect(processPrePushInline).not.toHaveBeenCalled();
+		expect(triggerPendingPushRetry).not.toHaveBeenCalled();
 	});
 
 	it("uses --not --remotes for a brand-new remote branch (zero remote sha)", async () => {
@@ -372,7 +453,7 @@ describe("prePushEntry", () => {
 		vi.mocked(execFileAsyncHidden).mockResolvedValue({ stdout: "\n", stderr: "" });
 		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
 		expect(mergeEntries).not.toHaveBeenCalled();
-		expect(processPrePushInline).not.toHaveBeenCalled();
+		expect(triggerPendingPushRetry).not.toHaveBeenCalled();
 	});
 
 	it("tolerates a git rev-list failure (logs, skips that ref)", async () => {

--- a/cli/src/hooks/PrePushHook.ts
+++ b/cli/src/hooks/PrePushHook.ts
@@ -3,19 +3,30 @@
  * PrePushHook — Git pre-push Event Handler.
  *
  * Invoked by git's pre-push hook before objects are transferred. Records the
- * commits being pushed into `push-pending.json`, then SYNCHRONOUSLY pushes the
- * batch-eligible memories that fit one request to Jolli Space
- * (`processPrePushInline`) — deliberately blocking the push, but never for
- * longer than {@link PRE_PUSH_SYNC_BUDGET_MS}. Commits without memory, items
- * beyond batch limits, and failed pushes stay in `push-pending.json` for the
- * compensation channels (QueueWorker post-drain, activation retry, the next
- * push).
+ * commits being pushed into `push-pending.json`, spawns a DETACHED worker to
+ * publish them to Jolli Space, and polls that worker's result for at most
+ * {@link PRE_PUSH_SYNC_BUDGET_MS} before letting git proceed.
  *
- * Publishing here is optimistic: it happens BEFORE git transfers objects, so a
- * subsequently rejected push can briefly leave Space articles for commits that
- * never reached the remote — accepted by design (the retry converges via docId
- * reuse). Waiting for push confirmation inside the hook would deadlock: git
- * waits for the hook to exit before transferring.
+ * The work is detached rather than inline because an aborted request is the
+ * worst outcome available: the server may already have minted a docId, the abort
+ * throws it away, and the next attempt CREATEs a duplicate article instead of
+ * UPDATEing (see `withRecoveredDocId`). The worker runs to completion with no
+ * wall-clock budget; only this hook's watch is bounded.
+ *
+ * The worker republishes after every settled commit, so a watch that times out
+ * still prints the commits that landed — one commit's push is a chain of
+ * requests (each plan, note and reference, then the summary), so a large push
+ * settles gradually rather than all at once.
+ *
+ * Publishing is optimistic: it happens BEFORE git transfers objects, so a
+ * rejected push can leave Space articles for commits that never reached the
+ * remote — accepted by design (the retry converges via docId reuse). What the
+ * worker must NOT do is the mirror image of that, and it does not: orphan
+ * deletion is deferred, so a rejected push can never strip articles from history
+ * that still exists on the remote. Waiting for push confirmation here would
+ * deadlock the watch — git waits for the hook to exit before transferring, so
+ * `ls-remote` cannot succeed while this process is alive. The worker's own tail
+ * pass and the compensation channels confirm, and they reconcile both directions.
  *
  * Failure policy: every error is caught, the exit code is always 0, and a
  * hard-exit timer (budget + grace) guarantees the hook can never hold
@@ -25,37 +36,44 @@
  *   <local-ref> <local-sha> <remote-ref> <remote-sha>
  */
 
+import { randomUUID } from "node:crypto";
 import { basename, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readPushDisabledState } from "../core/PushControl.js";
-import {
-	type InlineCommitStatus,
-	type ProcessPrePushInlineResult,
-	processPrePushInline,
-} from "../core/PushExecutor.js";
+import type { CommitPushOutcome, CommitPushStatus } from "../core/PushExecutor.js";
 import { mergeEntries, type PushTarget } from "../core/PushPendingStore.js";
 import { readManualDisableFlag } from "../core/RepoProfile.js";
 import { loadConfig } from "../core/SessionTracker.js";
 import { createStorage } from "../core/StorageFactory.js";
 import { getIndexEntryMap, getSummary } from "../core/SummaryStore.js";
-import { runWithTrace, traceIdFromEnv } from "../core/TraceContext.js";
+import { getCurrentTraceId, runWithTrace, traceIdFromEnv } from "../core/TraceContext.js";
 import { createLogger, errMsg } from "../Logger.js";
 import { execFileAsyncHidden } from "../util/Subprocess.js";
 import { readStdin } from "./HookUtils.js";
+import { triggerPendingPushRetry } from "./PushCompensation.js";
+import {
+	type PushWatchEnd,
+	type PushWorkerResult,
+	reasonFromNote,
+	watchPushResult,
+	writePushRequest,
+	writePushResult,
+} from "./PushProgress.js";
 
 const log = createLogger("PrePushHook");
 
 /**
- * Total wall-clock budget for the synchronous portion of the hook — local git
- * reads, the pending-file write, and the single batch HTTP request all share
- * it. Anchored at process start.
+ * Total wall-clock budget for the blocking portion of the hook — local git
+ * reads, the pending-file write, the worker spawn, and the result watch all
+ * share it. Anchored at process start, so the node startup this process already
+ * paid for is not charged to the watch. The worker itself is NOT bounded by it.
  */
 export const PRE_PUSH_SYNC_BUDGET_MS = 3_000;
 
 /**
  * Grace on top of the budget before the hard-exit timer force-terminates the
- * process. Last-resort guard: cooperative deadline checks and the HTTP abort
- * normally end the hook well before this fires.
+ * process. Last-resort guard: the result watch honours the deadline on its own,
+ * so this only fires if something wedges outside it.
  */
 export const PRE_PUSH_HARD_EXIT_GRACE_MS = 1_000;
 
@@ -145,7 +163,7 @@ async function loadCommitSubjects(cwd: string, hashes: ReadonlyArray<string>): P
 }
 
 /** One marker per status: pushed / still coming / merged away / failed. */
-const STATUS_MARKERS: Record<InlineCommitStatus, string> = {
+const STATUS_MARKERS: Record<CommitPushStatus, string> = {
 	pushed: "✓",
 	generating: "…",
 	deferred: "…",
@@ -155,23 +173,35 @@ const STATUS_MARKERS: Record<InlineCommitStatus, string> = {
 
 /**
  * Prints the per-commit sync results to stderr — git forwards hook stderr, so
- * the list shows up inline in the user's `git push` output. One line per
- * commit of this push: marker, short hash, truncated subject, then the article
- * URL (pushed) or a short reason (everything else).
+ * the list shows up inline in the user's `git push` output.
+ *
+ * Iterates `hashes` (push order), NOT the outcome list: the worker settles
+ * commits concurrently and reports them in completion order, so rendering that
+ * order directly would scramble the list relative to the push. A hash with no
+ * outcome yet is rendered with `pendingLabel`.
  */
-async function printSyncResults(cwd: string, result: ProcessPrePushInlineResult): Promise<void> {
-	if (result.commits.length === 0) return;
-	const subjects = await loadCommitSubjects(
-		cwd,
-		result.commits.map((commit) => commit.hash),
-	);
+async function printSyncResults(
+	cwd: string,
+	hashes: ReadonlyArray<string>,
+	outcomes: ReadonlyMap<string, CommitPushOutcome>,
+	pendingLabel: string,
+): Promise<void> {
+	if (hashes.length === 0) return;
+	const subjects = await loadCommitSubjects(cwd, hashes);
 	const lines = ["jollimemory: push to Jolli Space"];
-	for (const commit of result.commits) {
-		const marker = STATUS_MARKERS[commit.status];
-		const shortHash = commit.hash.substring(0, 8);
-		const subject = formatSubject(subjects.get(commit.hash) ?? "");
-		const tail = commit.status === "pushed" ? (commit.url ?? "") : (commit.reason ?? "");
-		lines.push(`  ${marker} ${shortHash} ${subject} ${tail}`);
+	for (const hash of hashes) {
+		const outcome = outcomes.get(hash);
+		const marker = outcome ? STATUS_MARKERS[outcome.status] : STATUS_MARKERS.deferred;
+		const subject = formatSubject(subjects.get(hash) ?? "");
+		let tail: string;
+		if (!outcome) {
+			tail = pendingLabel;
+		} else if (outcome.status === "pushed") {
+			tail = outcome.url ?? "";
+		} else {
+			tail = outcome.reason ?? "";
+		}
+		lines.push(`  ${marker} ${hash.substring(0, 8)} ${subject} ${tail}`);
 	}
 	process.stderr.write(`${lines.join("\n")}\n`);
 }
@@ -252,9 +282,11 @@ async function printSignedOutMemoryNotice(
 
 /**
  * Core pre-push logic. Records pushed commits into push-pending.json and (when
- * signed in) synchronously batch-pushes the ones that already have memory,
- * within the remaining wall-clock budget. `startedAtMs` anchors the budget at
- * process start; it defaults to "now" for callers that don't track it.
+ * signed in) hands them to a detached worker that owns every network round-trip,
+ * then watches the worker's result file for as long as the remaining wall-clock
+ * budget allows. Nothing is pushed on this process's own time: the worker runs to
+ * completion whether or not the watch is still there. `startedAtMs` anchors the
+ * budget at process start; it defaults to "now" for callers that don't track it.
  */
 export async function prePushEntry(cwd: string, stdin: string, remote?: string, startedAtMs?: number): Promise<void> {
 	const deadlineAt = (startedAtMs ?? Date.now()) + PRE_PUSH_SYNC_BUDGET_MS;
@@ -298,8 +330,8 @@ export async function prePushEntry(cwd: string, stdin: string, remote?: string, 
 
 	// Per-repo outbound-push opt-out (spec 306). Entries are already recorded
 	// above, so a later re-enable catches up; skip the sync and tell the user why
-	// rather than leaving them in silence (processPrePushInline would also gate,
-	// but its empty result prints nothing).
+	// rather than leaving them in silence (the worker gates on this too, but its
+	// empty result would print nothing).
 	//
 	// Read the STATE, not the boolean: the gate fails CLOSED, so an unreadable
 	// store reports "disabled" for every repo on the machine. Pointing that user at
@@ -329,26 +361,77 @@ export async function prePushEntry(cwd: string, stdin: string, remote?: string, 
 		return;
 	}
 
-	// Synchronous inline sync — scoped to THIS push's commits only (leftover
-	// entries belong to the compensation channels). Entries are already
-	// recorded above (write-first), so any failure here just leaves them for
-	// those channels — never block or fail the push on sync problems.
+	// Detached sync — the worker owns every network round-trip and runs to
+	// completion; this hook only watches it for as long as the budget allows.
+	// Entries are already recorded above (write-first), so a spawn failure or an
+	// abandoned watch just leaves them for the compensation channels.
+	const pushId = getCurrentTraceId() ?? randomUUID();
+	const hashes = [...allHashes];
 	try {
-		log.info("pre-push: starting inline sync — %dms of budget remaining", deadlineAt - Date.now());
-		const result = await processPrePushInline(cwd, { priorityHashes: [...allHashes], deadlineAt });
-		log.info(
-			"pre-push: inline sync done — pushed=%d failed=%d noMemory=%d notAttempted=%d children=%d%s",
-			result.pushed,
-			result.failed,
-			result.skippedNoMemory,
-			result.notAttempted,
-			result.deletedChildren,
-			result.note ? ` (${result.note})` : "",
-		);
-		await printSyncResults(cwd, result);
+		writePushRequest(cwd, { pushId, hashes });
 	} catch (error: unknown) {
-		log.error("Inline pre-push sync failed: %s", errMsg(error));
+		// Without a work list the worker has nothing to drain. Skip the spawn and
+		// the watch rather than making the user wait out the budget for nothing.
+		log.error("Could not write the pre-push work list: %s", errMsg(error));
+		process.stderr.write("jollimemory: recorded locally — background sync could not start.\n");
+		return;
 	}
+
+	// An async spawn failure (missing node, EACCES) arrives through this callback,
+	// not the return value. Publishing a terminal result lets the poll loop below
+	// exit on its next tick instead of waiting out the whole budget.
+	const spawned = triggerPendingPushRetry(cwd, "pre-push", ["--push-id", pushId], (error) => {
+		writePushResult(cwd, {
+			pushId,
+			commits: [],
+			complete: true,
+			note: `sync worker could not start: ${error.message}`,
+		});
+	});
+	if (!spawned) {
+		log.error("Pre-push sync worker could not be spawned — %d commit(s) left pending", total);
+		process.stderr.write("jollimemory: recorded locally — background sync could not start.\n");
+		return;
+	}
+
+	log.info("pre-push: worker spawned (pushId=%s) — watching for %dms", pushId, deadlineAt - Date.now());
+	// The worker is already running and owns the work from here on, so nothing
+	// this watch does may fail the push. A broken watch degrades to the same
+	// outcome as a timeout: git proceeds, the worker finishes on its own.
+	let ended: PushWatchEnd = "timeout";
+	let result: PushWorkerResult | undefined;
+	try {
+		({ ended, result } = await watchPushResult(cwd, pushId, { deadlineAt }));
+	} catch (error: unknown) {
+		log.error("pre-push: result watch failed: %s", errMsg(error));
+	}
+	const outcomes = new Map((result?.commits ?? []).map((commit) => [commit.hash, commit]));
+
+	if (ended === "complete") {
+		// The worker guarantees a complete result covers every hash, so anything
+		// still missing is a genuine anomaly — label it from the note rather than
+		// claiming it is still syncing, which would be false: the worker is gone.
+		log.info("pre-push: worker finished — %d outcome(s)%s", outcomes.size, result?.note ? ` (${result.note})` : "");
+		await printSyncResults(cwd, hashes, outcomes, reasonFromNote(result?.note));
+		return;
+	}
+
+	if (ended === "worker-dead") {
+		log.warn("pre-push: sync worker died with %d of %d commit(s) settled", outcomes.size, hashes.length);
+		await printSyncResults(cwd, hashes, outcomes, "interrupted — still pending");
+		process.stderr.write("jollimemory: background sync was interrupted (see .jolli/jollimemory/debug.log).\n");
+		return;
+	}
+
+	// Timed out with the worker still alive — "in the background" is accurate here.
+	log.info("pre-push: watch timed out — %d of %d settled", outcomes.size, hashes.length);
+	if (outcomes.size > 0) {
+		await printSyncResults(cwd, hashes, outcomes, "syncing in the background");
+		return;
+	}
+	process.stderr.write(
+		`jollimemory: syncing ${total} commit(s) to Jolli Space in the background — results land shortly.\n`,
+	);
 }
 
 // --- Script entry point (only when run directly, not when imported) ---

--- a/cli/src/hooks/PrePushWorker.test.ts
+++ b/cli/src/hooks/PrePushWorker.test.ts
@@ -1,10 +1,34 @@
-import { describe, expect, it, vi } from "vitest";
-import { type ProcessPushPendingResult, processPushPending } from "../core/PushExecutor.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	type CommitPushOutcome,
+	type ProcessPushPendingOptions,
+	type ProcessPushPendingResult,
+	processPushPending,
+} from "../core/PushExecutor.js";
+import { loadPushPending } from "../core/PushPendingStore.js";
 import { readManualDisableFlag } from "../core/RepoProfile.js";
-import { runPushWorker } from "./PrePushWorker.js";
+import { runPrePushSync, runPushWorker } from "./PrePushWorker.js";
+import { type PushWorkerResult, readPushRequest, releasePushLock, writePushResult } from "./PushProgress.js";
 
 vi.mock("../core/PushExecutor.js", () => ({ processPushPending: vi.fn() }));
 vi.mock("../core/RepoProfile.js", () => ({ readManualDisableFlag: vi.fn().mockResolvedValue(false) }));
+vi.mock("../core/PushPendingStore.js", () => ({ loadPushPending: vi.fn() }));
+vi.mock("./CaptureProgress.js", () => ({
+	CAPTURE_PROGRESS_MAX_AGE_MS: 3_600_000,
+	pruneStaleCaptureProgress: vi.fn(),
+}));
+vi.mock("./PushProgress.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("./PushProgress.js")>()),
+	acquirePushLock: vi.fn(),
+	releasePushLock: vi.fn(),
+	readPushRequest: vi.fn(),
+	writePushResult: vi.fn(),
+}));
+
+const CWD = "/repo";
+const PUSH_ID = "trace-1";
+const HASH_A = "a".repeat(40);
+const HASH_B = "b".repeat(40);
 
 const EMPTY_RESULT: ProcessPushPendingResult = {
 	attempted: 0,
@@ -15,16 +39,186 @@ const EMPTY_RESULT: ProcessPushPendingResult = {
 	deletedChildren: 0,
 };
 
+/** Every result the worker published, oldest first. */
+function published(): PushWorkerResult[] {
+	return vi.mocked(writePushResult).mock.calls.map((call) => call[1]);
+}
+
+/** The terminal publish — what the hook renders when it sees `complete`. */
+function terminal(): PushWorkerResult | undefined {
+	const complete = published().filter((result) => result.complete);
+	return complete[complete.length - 1];
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(readManualDisableFlag).mockResolvedValue(false);
+	vi.mocked(processPushPending).mockResolvedValue(EMPTY_RESULT);
+	vi.mocked(readPushRequest).mockReturnValue({ pushId: PUSH_ID, hashes: [HASH_A, HASH_B] });
+	vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: {} });
+});
+
 describe("runPushWorker", () => {
 	it("drains push-pending.json via the activation compensation path", async () => {
-		vi.mocked(processPushPending).mockResolvedValue(EMPTY_RESULT);
-		await runPushWorker("/repo", "cli-auth-login");
-		expect(processPushPending).toHaveBeenCalledWith("/repo", { source: "activation" });
+		await runPushWorker(CWD, "cli-auth-login");
+		expect(processPushPending).toHaveBeenCalledWith(CWD, { source: "activation" });
 	});
 
 	it("does nothing when the repository is manually disabled", async () => {
 		vi.mocked(readManualDisableFlag).mockResolvedValueOnce(true);
-		await runPushWorker("/repo");
+		await runPushWorker(CWD);
 		expect(processPushPending).not.toHaveBeenCalled();
+	});
+});
+
+describe("runPrePushSync", () => {
+	it("drains only this push's commits, unconfirmed and without deleting orphans", async () => {
+		await runPrePushSync(CWD, PUSH_ID);
+		const opts = vi.mocked(processPushPending).mock.calls[0][1] as ProcessPushPendingOptions;
+		expect(opts.source).toBe("pre-push");
+		expect([...(opts.hashFilter ?? [])]).toEqual([HASH_A, HASH_B]);
+		expect(opts.skipPushConfirmation).toBe(true);
+		expect(opts.skipOrphanCleanup).toBe(true);
+		expect(opts.stopStartingAt).toBeGreaterThan(Date.now());
+		expect(opts.client).toBeDefined();
+	});
+
+	it("republishes after every settled commit so a timed-out hook can still print", async () => {
+		vi.mocked(processPushPending).mockImplementation(async (_cwd, options) => {
+			options.onCommitSettled?.({ hash: HASH_A, status: "pushed", url: "https://jolli.ai/a" });
+			options.onCommitSettled?.({ hash: HASH_B, status: "failed", reason: "boom" });
+			return EMPTY_RESULT;
+		});
+		await runPrePushSync(CWD, PUSH_ID);
+		const partials = published().filter((result) => !result.complete);
+		expect(partials).toHaveLength(2);
+		expect(partials[0].commits).toHaveLength(1);
+		expect(partials[1].commits).toHaveLength(2);
+	});
+
+	it("publishes the terminal result before releasing the lock", async () => {
+		const order: string[] = [];
+		vi.mocked(writePushResult).mockImplementation((_cwd, result) => {
+			if (result.complete) order.push("publish");
+		});
+		vi.mocked(releasePushLock).mockImplementation(async () => {
+			order.push("release");
+		});
+		await runPrePushSync(CWD, PUSH_ID);
+		// A hook that sees the lock gone with no complete result would report an
+		// interruption for a run that actually finished.
+		expect(order).toEqual(["publish", "release"]);
+	});
+
+	it("backfills every hash the drain never reported on", async () => {
+		// `complete` promises nothing more is coming, so the hook needs an outcome
+		// for each requested hash or it would render one as "still syncing".
+		vi.mocked(processPushPending).mockImplementation(async (_cwd, options) => {
+			options.onCommitSettled?.({ hash: HASH_A, status: "pushed" });
+			return { ...EMPTY_RESULT, note: "not signed in" };
+		});
+		// HASH_B is still pending, so it takes the note-derived reason rather than
+		// the "someone else already drained it" branch.
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_B]: {} as never } });
+		await runPrePushSync(CWD, PUSH_ID);
+		expect(terminal()?.commits).toEqual([
+			{ hash: HASH_A, status: "pushed" },
+			{ hash: HASH_B, status: "deferred", reason: "not signed in to Jolli" },
+		]);
+	});
+
+	it("calls a hash that already left push-pending synced, not unreachable", async () => {
+		// Another channel drained it. Saying "see debug.log" would send the user
+		// after a problem that does not exist.
+		vi.mocked(processPushPending).mockResolvedValue({ ...EMPTY_RESULT, note: "no eligible entries" });
+		vi.mocked(loadPushPending).mockResolvedValue({ version: 1, entries: { [HASH_B]: {} as never } });
+		await runPrePushSync(CWD, PUSH_ID);
+		const commits = terminal()?.commits ?? [];
+		expect(commits).toContainEqual({ hash: HASH_A, status: "pushed" });
+		expect(commits).toContainEqual({ hash: HASH_B, status: "deferred", reason: "nothing left to sync" });
+	});
+
+	it("falls back to the note when push-pending cannot be re-read", async () => {
+		vi.mocked(processPushPending).mockResolvedValue({ ...EMPTY_RESULT, note: "not signed in" });
+		vi.mocked(loadPushPending).mockRejectedValue(new Error("unreadable"));
+		await runPrePushSync(CWD, PUSH_ID);
+		// Never a false "already synced" on a failed read.
+		expect(terminal()?.commits.every((c) => c.status === "deferred")).toBe(true);
+	});
+
+	it("still publishes a terminal result when the drain throws", async () => {
+		vi.mocked(processPushPending).mockRejectedValueOnce(new Error("drain exploded"));
+		await runPrePushSync(CWD, PUSH_ID);
+		expect(terminal()?.complete).toBe(true);
+		expect(terminal()?.note).toContain("drain exploded");
+		expect(releasePushLock).toHaveBeenCalled();
+	});
+
+	it("publishes instead of exiting silently when the repo is disabled", async () => {
+		// A silent exit leaves the hook polling to its deadline and then announcing
+		// background work that will never happen.
+		vi.mocked(readManualDisableFlag).mockResolvedValue(true);
+		await runPrePushSync(CWD, PUSH_ID);
+		expect(terminal()).toMatchObject({ complete: true, note: "repository disabled" });
+		expect(processPushPending).not.toHaveBeenCalled();
+	});
+
+	it("publishes instead of exiting silently when the work list is missing", async () => {
+		vi.mocked(readPushRequest).mockReturnValue(undefined);
+		await runPrePushSync(CWD, PUSH_ID);
+		expect(terminal()).toMatchObject({ complete: true, note: "work list missing" });
+		expect(processPushPending).not.toHaveBeenCalled();
+	});
+
+	it("finishes with a confirmed unfiltered tail pass", async () => {
+		// By now git has transferred, so ls-remote can confirm — this is what
+		// completes the deferred orphan cleanup instead of waiting for activation.
+		await runPrePushSync(CWD, PUSH_ID);
+		const tail = vi.mocked(processPushPending).mock.calls[1][1] as ProcessPushPendingOptions;
+		expect(tail.source).toBe("pre-push");
+		expect(tail.hashFilter).toBeUndefined();
+		expect(tail.skipPushConfirmation).toBeUndefined();
+		expect(tail.skipOrphanCleanup).toBeUndefined();
+		// Same HTTP budget as the scoped pass: this path publishes too.
+		expect(tail.client).toBeDefined();
+	});
+
+	it("skips the tail pass when the runtime ceiling is already spent", async () => {
+		vi.mocked(processPushPending).mockImplementation(async (_cwd, options) => {
+			// Simulate a scoped pass that ran right up to its ceiling.
+			if (options.stopStartingAt) vi.setSystemTime(new Date(options.stopStartingAt + 1));
+			return EMPTY_RESULT;
+		});
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+		try {
+			await runPrePushSync(CWD, PUSH_ID);
+		} finally {
+			vi.useRealTimers();
+		}
+		expect(processPushPending).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not fail the run when the tail pass throws", async () => {
+		vi.mocked(processPushPending).mockResolvedValueOnce(EMPTY_RESULT).mockRejectedValueOnce(new Error("tail boom"));
+		await expect(runPrePushSync(CWD, PUSH_ID)).resolves.toBeUndefined();
+		// The scoped pass is already published and must not be undone by the tail.
+		expect(terminal()?.complete).toBe(true);
+	});
+});
+
+/** Guards the outcome shape the hook's renderer depends on. */
+describe("published outcome shape", () => {
+	it("keeps commits in the order they settled", async () => {
+		const order: CommitPushOutcome[] = [
+			{ hash: HASH_B, status: "pushed" },
+			{ hash: HASH_A, status: "generating", reason: "memory still generating — will sync later" },
+		];
+		vi.mocked(processPushPending).mockImplementation(async (_cwd, options) => {
+			for (const outcome of order) options.onCommitSettled?.(outcome);
+			return EMPTY_RESULT;
+		});
+		await runPrePushSync(CWD, PUSH_ID);
+		// Completion order, not push order — the hook re-sorts when rendering.
+		expect(terminal()?.commits.map((c) => c.hash)).toEqual([HASH_B, HASH_A]);
 	});
 });

--- a/cli/src/hooks/PrePushWorker.ts
+++ b/cli/src/hooks/PrePushWorker.ts
@@ -1,28 +1,85 @@
 #!/usr/bin/env node
 /**
- * PrePushWorker — standalone drain of `push-pending.json` to Jolli Space.
+ * PrePushWorker — detached drain of `push-pending.json` to Jolli Space.
  *
- * The pre-push hook itself syncs inline (`processPrePushInline`, one
- * budget-bound batch request scoped to the current push). This entry point is
- * the cross-process compensation drain used by CLI and VS Code activation /
- * sign-in triggers, as well as the IntelliJ plugin's Kotlin integration.
- * External orchestrators can use it the same way:
+ * Two modes, selected by `--push-id`:
+ *   - pre-push (`--push-id <id>`): spawned by the pre-push hook. Drains THIS
+ *     push's commits, skips the remote-ref confirmation gate (git has not
+ *     transferred objects yet), defers orphan deletion for the same reason, and
+ *     republishes a result file after every settled commit so the hook can print
+ *     partial progress before its deadline. Finishes with a confirmed,
+ *     unfiltered tail pass — by then git is done, so the deferred cleanup and
+ *     any older backlog can be completed safely.
+ *   - compensation (no `--push-id`): the CLI / VS Code activation and sign-in
+ *     trigger. Drains whatever is pending, confirmation gate and orphan cleanup
+ *     both intact.
+ *
+ * External orchestrators can use the compensation mode the same way:
  * `node PrePushWorker.js --cwd <repo>`.
  *
- * Behavior matches the activation compensation path: eligible entries use the
- * batch endpoint first and fall back to per-commit `pushSummary` calls when an
- * item exceeds batch limits or the server predates batch support. Publishing
- * starts only after the remote ref confirms the git push actually landed.
+ * Both modes push at commit granularity — see the batch-removal note in
+ * PushExecutor for why the batch endpoint is no longer used.
  */
 
 import { basename, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { processPushPending } from "../core/PushExecutor.js";
+import { JolliMemoryPushClient } from "../core/JolliMemoryPushClient.js";
+import { type CommitPushOutcome, processPushPending } from "../core/PushExecutor.js";
+import { loadPushPending } from "../core/PushPendingStore.js";
 import { readManualDisableFlag } from "../core/RepoProfile.js";
 import { runWithTrace, traceIdFromEnv } from "../core/TraceContext.js";
-import { createLogger } from "../Logger.js";
+import { createLogger, errMsg } from "../Logger.js";
+import { CAPTURE_PROGRESS_MAX_AGE_MS, pruneStaleCaptureProgress } from "./CaptureProgress.js";
+import {
+	acquirePushLock,
+	type PushWorkerResult,
+	readPushRequest,
+	reasonFromNote,
+	releasePushLock,
+	writePushResult,
+} from "./PushProgress.js";
 
 const log = createLogger("PrePushWorker");
+
+/**
+ * HTTP timeout for the detached pre-push drain — double the client default.
+ * Nothing is waiting on this process, and an aborted request is the expensive
+ * failure here: the server may already have minted a docId that the abort
+ * discards, making the next attempt CREATE a duplicate article. A request still
+ * unanswered after this long is genuinely stuck and should fail normally.
+ *
+ * Kept at a third of {@link PRE_PUSH_WORKER_MAX_RUNTIME_MS} on purpose: a single
+ * stuck request must not swallow most of the run's budget.
+ */
+const PRE_PUSH_WORKER_TIMEOUT_MS = 60_000;
+
+/**
+ * Ceiling on how long this worker keeps STARTING new pushes.
+ *
+ * A normal push settles in seconds — even a few hundred commits over a healthy
+ * connection is well under a minute — so this only trips on a genuinely
+ * degraded run (a connection where every request times out) or an unusually
+ * large first push. Both are cases where continuing for tens of minutes buys
+ * nothing: the user has long since moved on, and the leftovers cost nothing to
+ * defer, because a deferred commit stays pending and the compensation channels
+ * pick it up. Bounding the run instead trades a little latency for never
+ * leaving an invisible process holding the network for hours.
+ *
+ * The ceiling covers the tail pass too — otherwise that could run just as long
+ * right after the scoped pass gave up.
+ */
+const PRE_PUSH_WORKER_MAX_RUNTIME_MS = 3 * 60 * 1000;
+
+/**
+ * Grace after the runtime ceiling before the process force-exits.
+ *
+ * Sized to let one in-flight request finish and write back: the ceiling stops
+ * new pushes but never cancels running ones, so the last batch can still be
+ * holding a request for up to {@link PRE_PUSH_WORKER_TIMEOUT_MS}. This timer is
+ * the last-resort guard for something wedging outside that path — under normal
+ * operation the drain returns well before it fires.
+ */
+const PRE_PUSH_WORKER_HARD_EXIT_GRACE_MS = 90_000;
 
 /** Drains push-pending.json to Jolli Space. Entry point for the standalone run. */
 export async function runPushWorker(cwd: string, trigger = "activation"): Promise<void> {
@@ -40,6 +97,186 @@ export async function runPushWorker(cwd: string, trigger = "activation"): Promis
 		result.failed,
 		result.note ? ` (${result.note})` : "",
 	);
+}
+
+/**
+ * Pre-push mode: drain THIS push's commits, republishing the result after every
+ * settled commit so the hook can print partial progress.
+ *
+ * Three things differ from the compensation drain, all deliberate:
+ *   - No remote-ref confirmation. Git has not transferred objects yet, so
+ *     `ls-remote` would refuse every entry.
+ *   - No orphan deletion. Same reason: if the push is then rejected, deleting
+ *     the old articles would leave the remote history intact with its memories
+ *     gone, and the pending entry that could restore them already removed.
+ *   - A longer HTTP timeout, and a ceiling on new pushes rather than on the run.
+ *     Nothing here is ever cancelled mid-flight: aborting throws away a docId the
+ *     server already minted, so {@link PRE_PUSH_WORKER_MAX_RUNTIME_MS} stops the
+ *     drain from STARTING more work instead, and the rest stays pending.
+ *
+ * The published result always covers EVERY requested hash. `processPushPending`
+ * has several short-circuit returns (not signed in, push disabled, nothing
+ * eligible) that report no per-commit outcome at all, and a thrown error skips
+ * the rest of the batch. Backfilling them here is what lets the hook print an
+ * honest list instead of claiming a commit is still syncing after this process
+ * has exited.
+ */
+export async function runPrePushSync(cwd: string, pushId: string): Promise<void> {
+	const stopStartingAt = Date.now() + PRE_PUSH_WORKER_MAX_RUNTIME_MS;
+	// Last-resort backstop for a wedge outside the drain (a hung write, a lock
+	// that never clears). unref() so it never keeps an otherwise-finished process
+	// alive, and exit 0 because a background sync must never look like a failure.
+	setTimeout(() => process.exit(0), PRE_PUSH_WORKER_MAX_RUNTIME_MS + PRE_PUSH_WORKER_HARD_EXIT_GRACE_MS).unref();
+	// Lock FIRST: everything below (the disable flag reads a git subprocess, the
+	// prune stats a directory) takes long enough that a crash in between would be
+	// invisible to the hook's liveness probe, costing it a full budget wait.
+	acquirePushLock(cwd, pushId);
+	const settled: CommitPushOutcome[] = [];
+	const publish = (complete: boolean, note?: string): void => {
+		writePushResult(cwd, {
+			pushId,
+			commits: [...settled],
+			complete,
+			...(note ? { note } : {}),
+		} satisfies PushWorkerResult);
+	};
+
+	try {
+		if (await readManualDisableFlag(cwd)) {
+			log.info("PrePushWorker(pre-push): skipped — repository manually disabled");
+			// Publish anyway: a silent exit would leave the hook polling until its
+			// deadline and then announcing background work that will never happen.
+			publish(true, "repository disabled");
+			return;
+		}
+		const request = readPushRequest(cwd, pushId);
+		if (!request || request.hashes.length === 0) {
+			log.warn("PrePushWorker(pre-push): no usable work list for %s", pushId);
+			publish(true, "work list missing");
+			return;
+		}
+
+		// Opportunistic age-based sweep, same policy as the capture stream: files
+		// are never deleted on completion (a killed worker leaves them behind
+		// anyway, and deleting right after a write races the hook's next poll).
+		pruneStaleCaptureProgress(cwd, CAPTURE_PROGRESS_MAX_AGE_MS);
+
+		let note: string | undefined;
+		try {
+			const result = await processPushPending(cwd, {
+				source: "pre-push",
+				hashFilter: new Set(request.hashes),
+				skipPushConfirmation: true,
+				skipOrphanCleanup: true,
+				stopStartingAt,
+				client: new JolliMemoryPushClient({ timeoutMs: PRE_PUSH_WORKER_TIMEOUT_MS }),
+				onCommitSettled: (outcome) => {
+					settled.push(outcome);
+					// Republish on every settled commit: the hook may give up at its
+					// deadline, and whatever landed by then is still worth printing.
+					publish(false);
+				},
+			});
+			note = result.note;
+			log.info(
+				"PrePushWorker(pre-push): drain done — pushed=%d failed=%d noMemory=%d%s",
+				result.pushed,
+				result.failed,
+				result.skippedNoMemory,
+				result.note ? ` (${result.note})` : "",
+			);
+		} catch (error: unknown) {
+			log.error("PrePushWorker(pre-push): drain failed: %s", errMsg(error));
+			note = errMsg(error);
+		}
+
+		await backfillUnreported(cwd, request.hashes, settled, note);
+		publish(true, note);
+	} finally {
+		// Release only after the terminal result exists: a hook that sees the lock
+		// gone while no complete result is published would report "interrupted"
+		// for a run that actually finished.
+		await releasePushLock(cwd, pushId);
+	}
+
+	await runConfirmedTailPass(cwd, stopStartingAt);
+}
+
+/**
+ * Gives every requested hash the drain did not report on an outcome, so a
+ * `complete` result is the whole story.
+ *
+ * A hash that has left push-pending entirely was drained by someone else (or by
+ * an earlier run) — that is a success, not an anomaly, and saying otherwise
+ * would send the user to debug.log over nothing. It gets `pushed` with no URL:
+ * the commit really is synced, this process just never held the article id.
+ */
+async function backfillUnreported(
+	cwd: string,
+	hashes: ReadonlyArray<string>,
+	settled: CommitPushOutcome[],
+	note: string | undefined,
+): Promise<void> {
+	const reported = new Set(settled.map((outcome) => outcome.hash));
+	if (hashes.every((hash) => reported.has(hash))) return;
+	// A failed read leaves `stillPending` undefined, which falls back to the
+	// note-derived reason — never to a false "already synced".
+	const stillPending = await loadPushPending(cwd)
+		.then((file) => new Set(Object.keys(file.entries)))
+		.catch((err: unknown) => {
+			log.debug("Could not re-read push-pending while backfilling outcomes: %s", errMsg(err));
+			return undefined;
+		});
+	const reason = reasonFromNote(note);
+	for (const hash of hashes) {
+		if (reported.has(hash)) continue;
+		if (stillPending && !stillPending.has(hash)) {
+			settled.push({ hash, status: "pushed" });
+			continue;
+		}
+		settled.push({ hash, status: "deferred", reason });
+	}
+}
+
+/**
+ * Confirmed, unfiltered drain run after the scoped pass has published its
+ * result. By now git has finished transferring, so `ls-remote` can confirm and
+ * two things that nothing else would reach get finished:
+ *   - the orphan cleanup our own pass deferred (those entries were kept as
+ *     patches, and only a confirmed drain may delete remote articles);
+ *   - any backlog left by earlier pushes.
+ *
+ * Without this, deferred cleanup would wait for an activation trigger — which a
+ * pure-CLI user may not hit for days, long enough for the 7-day prune to drop
+ * the entries and strand the articles.
+ *
+ * A rejected push simply fails confirmation and everything stays pending, which
+ * is exactly the behaviour that makes deferring safe in the first place. Failures
+ * are swallowed: the scoped pass is already published and must not be undone by
+ * a problem in this best-effort tail.
+ */
+async function runConfirmedTailPass(cwd: string, stopStartingAt: number): Promise<void> {
+	if (Date.now() >= stopStartingAt) {
+		log.info("PrePushWorker(pre-push): skipping the confirmed tail pass — run time limit already reached");
+		return;
+	}
+	try {
+		const result = await processPushPending(cwd, {
+			source: "pre-push",
+			stopStartingAt,
+			// Same budget as the scoped pass: this path publishes too, so an
+			// aborted request loses a docId here exactly as it would there.
+			client: new JolliMemoryPushClient({ timeoutMs: PRE_PUSH_WORKER_TIMEOUT_MS }),
+		});
+		log.info(
+			"PrePushWorker(pre-push): confirmed tail pass — pushed=%d failed=%d%s",
+			result.pushed,
+			result.failed,
+			result.note ? ` (${result.note})` : "",
+		);
+	} catch (error: unknown) {
+		log.warn("PrePushWorker(pre-push): confirmed tail pass failed: %s", errMsg(error));
+	}
 }
 
 // --- Script entry point (only when run directly, not when imported) ---
@@ -63,16 +300,23 @@ function isMainScript(): boolean {
 
 if (isMainScript()) {
 	const args = process.argv.slice(2);
-	const cwdIndex = args.indexOf("--cwd");
-	const cwd = cwdIndex >= 0 && args[cwdIndex + 1] ? args[cwdIndex + 1] : process.cwd();
-	const triggerIndex = args.indexOf("--trigger");
-	const trigger = triggerIndex >= 0 && args[triggerIndex + 1] ? args[triggerIndex + 1] : "activation";
+	const readArg = (name: string): string | undefined => {
+		const index = args.indexOf(name);
+		return index >= 0 && args[index + 1] ? args[index + 1] : undefined;
+	};
+	const cwd = readArg("--cwd") ?? process.cwd();
+	const trigger = readArg("--trigger") ?? "activation";
+	const pushId = readArg("--push-id");
 
-	runWithTrace(traceIdFromEnv(), () =>
-		runPushWorker(cwd, trigger).catch((error: unknown) => {
+	runWithTrace(traceIdFromEnv(), () => {
+		// `--push-id` selects the pre-push drain: scoped to one push's commits,
+		// unbudgeted, and it publishes a result file the hook may be polling for.
+		// Everything else is the compensation drain.
+		const run = pushId ? runPrePushSync(cwd, pushId) : runPushWorker(cwd, trigger);
+		return run.catch((error: unknown) => {
 			log.error("PrePushWorker fatal error: %s", error instanceof Error ? error.message : String(error));
 			process.exit(0); // never signal failure — this is a background sync
-		}),
-	);
+		});
+	});
 }
 /* v8 ignore stop */

--- a/cli/src/hooks/PushCompensation.test.ts
+++ b/cli/src/hooks/PushCompensation.test.ts
@@ -135,3 +135,47 @@ describe("triggerPendingPushRetry", () => {
 		);
 	});
 });
+
+describe("triggerPendingPushRetry — pre-push mode", () => {
+	it("forwards extra args and skips the backlog check", () => {
+		// The pre-push hook has just written those entries; a stat race must not
+		// silently drop the spawn.
+		h.existsSync.mockImplementation((path) => pathEndsWith(path, "/PrePushWorker.js"));
+
+		const started = triggerPendingPushRetry(CWD, "pre-push", ["--push-id", "trace-1"]);
+
+		expect(started).toBe(true);
+		const argv = h.spawnHidden.mock.calls[0][1] as string[];
+		expect(argv.slice(-4)).toEqual(["--trigger", "pre-push", "--push-id", "trace-1"]);
+	});
+
+	it("reports a synchronous failure through the return value", () => {
+		// No worker script on disk: the hook uses this to print a degraded notice
+		// immediately instead of waiting out its budget.
+		h.existsSync.mockReturnValue(false);
+
+		expect(triggerPendingPushRetry(CWD, "pre-push", ["--push-id", "trace-1"])).toBe(false);
+		expect(h.spawnHidden).not.toHaveBeenCalled();
+	});
+
+	it("routes an async spawn failure to onSpawnError", () => {
+		// ENOENT/EACCES arrive on the child's error event, after spawn returned —
+		// the return value cannot express them.
+		const onSpawnError = vi.fn();
+		let errorHandler: ((error: Error) => void) | undefined;
+		h.child.once.mockImplementation((event: string, handler: (error: Error) => void) => {
+			if (event === "error") errorHandler = handler;
+		});
+
+		const started = triggerPendingPushRetry(CWD, "pre-push", ["--push-id", "trace-1"], onSpawnError);
+		expect(started).toBe(true);
+
+		const failure = new Error("spawn ENOENT");
+		errorHandler?.(failure);
+		expect(onSpawnError).toHaveBeenCalledWith(failure);
+	});
+
+	it("still returns true for the compensation shape when a backlog exists", () => {
+		expect(triggerPendingPushRetry(CWD, "activation")).toBe(true);
+	});
+});

--- a/cli/src/hooks/PushCompensation.ts
+++ b/cli/src/hooks/PushCompensation.ts
@@ -44,29 +44,48 @@ function resolveWorkerInvocation(): WorkerInvocation | undefined {
 }
 
 /**
- * Starts an independent compensation drain when push-pending.json exists.
- * The detached child owns every network request and never inherits stdio.
- * Spawn failures are logged and left for the next trigger.
+ * Starts an independent drain as a detached child. The child owns every network
+ * request and never inherits stdio.
+ *
+ * Two callers, two shapes:
+ *   - compensation (default): drains whatever `push-pending.json` holds, and
+ *     skips entirely when there is no backlog file.
+ *   - pre-push (`extraArgs` carries `--push-id`): drains THIS push's commits and
+ *     publishes a result file. The backlog check is skipped — the hook has just
+ *     written those entries, and a stat race must not silently drop the spawn.
+ *
+ * The boolean return only reports SYNCHRONOUS failures (no worker script, or
+ * spawn throwing outright). The common ones — ENOENT on the node binary, EACCES
+ * — surface asynchronously on the child's `error` event, which is what
+ * `onSpawnError` is for: the pre-push hook uses it to publish a terminal result
+ * so its poll loop exits on the next tick instead of waiting out the budget.
  */
-export function triggerPendingPushRetry(cwd: string, trigger = "activation"): void {
+export function triggerPendingPushRetry(
+	cwd: string,
+	trigger = "activation",
+	extraArgs: ReadonlyArray<string> = [],
+	onSpawnError?: (error: Error) => void,
+): boolean {
 	try {
 		const projectDir = resolve(cwd);
-		const pendingPath = join(getJolliMemoryDir(projectDir), PUSH_PENDING_FILE);
-		if (!existsSync(pendingPath)) {
-			log.debug("Push compensation (%s): no push-pending backlog", trigger);
-			return;
+		if (extraArgs.length === 0) {
+			const pendingPath = join(getJolliMemoryDir(projectDir), PUSH_PENDING_FILE);
+			if (!existsSync(pendingPath)) {
+				log.debug("Push compensation (%s): no push-pending backlog", trigger);
+				return false;
+			}
 		}
 
 		const invocation = resolveWorkerInvocation();
 		if (!invocation) {
 			log.error("Push compensation (%s): PrePushWorker entry not found", trigger);
-			return;
+			return false;
 		}
 
 		const traceId = getCurrentTraceId();
 		const child = spawnHidden(
 			process.execPath,
-			[...invocation.nodeArgs, invocation.scriptPath, "--cwd", projectDir, "--trigger", trigger],
+			[...invocation.nodeArgs, invocation.scriptPath, "--cwd", projectDir, "--trigger", trigger, ...extraArgs],
 			{
 				detached: true,
 				stdio: "ignore",
@@ -76,9 +95,12 @@ export function triggerPendingPushRetry(cwd: string, trigger = "activation"): vo
 		);
 		child.once("error", (error) => {
 			log.debug("Push compensation (%s) worker failed to start: %s", trigger, errMsg(error));
+			onSpawnError?.(error);
 		});
 		child.unref();
+		return true;
 	} catch (error) {
 		log.debug("Push compensation (%s) trigger failed: %s", trigger, errMsg(error));
+		return false;
 	}
 }

--- a/cli/src/hooks/PushProgress.test.ts
+++ b/cli/src/hooks/PushProgress.test.ts
@@ -1,0 +1,292 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommitPushOutcome } from "../core/PushExecutor.js";
+import { captureProgressDir } from "./CaptureProgress.js";
+import {
+	acquirePushLock,
+	isPushWorkerDead,
+	type PushWorkerResult,
+	pushLockPath,
+	pushRequestPath,
+	pushResultPath,
+	readPushRequest,
+	readPushResult,
+	reasonFromNote,
+	releasePushLock,
+	watchPushResult,
+	writePushRequest,
+	writePushResult,
+} from "./PushProgress.js";
+
+const PUSH_ID = "trace-1";
+const HASH_A = "a".repeat(40);
+const HASH_B = "b".repeat(40);
+
+let cwd: string;
+
+beforeEach(async () => {
+	cwd = join(
+		tmpdir(),
+		`pushprog-${process.pid}-${Math.floor(Date.now() % 1e9)}-${Math.random().toString(36).slice(2)}`,
+	);
+	await mkdir(cwd, { recursive: true });
+});
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await rm(cwd, { recursive: true, force: true });
+});
+
+function outcome(hash: string, over: Partial<CommitPushOutcome> = {}): CommitPushOutcome {
+	return { hash, status: "pushed", ...over };
+}
+
+function result(over: Partial<PushWorkerResult> = {}): PushWorkerResult {
+	return { pushId: PUSH_ID, commits: [], complete: true, ...over };
+}
+
+describe("request hand-off", () => {
+	it("round-trips the work list", () => {
+		writePushRequest(cwd, { pushId: PUSH_ID, hashes: [HASH_A, HASH_B] });
+		expect(readPushRequest(cwd, PUSH_ID)).toEqual({ pushId: PUSH_ID, hashes: [HASH_A, HASH_B] });
+	});
+
+	it("returns undefined when the worker has no request file", () => {
+		expect(readPushRequest(cwd, PUSH_ID)).toBeUndefined();
+	});
+
+	it("rejects a request whose pushId does not match the one being read", () => {
+		// A stale file from an earlier push must not be mistaken for this push's
+		// work list — that would drain the wrong commits.
+		writePushRequest(cwd, { pushId: "other-push", hashes: [HASH_A] });
+		writeFileSync(pushRequestPath(cwd, PUSH_ID), JSON.stringify({ pushId: "other-push", hashes: [HASH_A] }));
+		expect(readPushRequest(cwd, PUSH_ID)).toBeUndefined();
+	});
+
+	it("rejects malformed hash lists rather than degrading to an empty drain", () => {
+		// Silently reading these as "no work" is indistinguishable from a
+		// legitimately empty push, so the worker could never report the difference.
+		const write = (body: unknown) => {
+			mkdirSync(captureProgressDir(cwd), { recursive: true });
+			writeFileSync(pushRequestPath(cwd, PUSH_ID), JSON.stringify(body));
+		};
+		write({ pushId: PUSH_ID, hashes: "not-an-array" });
+		expect(readPushRequest(cwd, PUSH_ID)).toBeUndefined();
+		write({ pushId: PUSH_ID, hashes: [HASH_A, 42] });
+		expect(readPushRequest(cwd, PUSH_ID)).toBeUndefined();
+		write({ pushId: PUSH_ID, hashes: [""] });
+		expect(readPushRequest(cwd, PUSH_ID)).toBeUndefined();
+	});
+
+	it("returns undefined for a torn or corrupt file", () => {
+		mkdirSync(captureProgressDir(cwd), { recursive: true });
+		writeFileSync(pushRequestPath(cwd, PUSH_ID), "{ not json");
+		expect(readPushRequest(cwd, PUSH_ID)).toBeUndefined();
+	});
+
+	it("clears the previous run's result and lock when the same pushId comes back", () => {
+		// A pushId is the ambient trace id whenever one is set, so uniqueness is not
+		// something this protocol enforces. Left in place, the old `complete: true`
+		// result would be read as THIS push's outcome (announcing commits it never
+		// sent) and the old dead-pid lock would report its worker as interrupted
+		// before it even started.
+		writePushResult(cwd, result({ commits: [outcome(HASH_A)] }));
+		writeFileSync(pushLockPath(cwd, PUSH_ID), "999999");
+
+		writePushRequest(cwd, { pushId: PUSH_ID, hashes: [HASH_B] });
+
+		expect(readPushResult(cwd, PUSH_ID)).toBeUndefined();
+		expect(existsSync(pushLockPath(cwd, PUSH_ID))).toBe(false);
+		expect(readPushRequest(cwd, PUSH_ID)).toEqual({ pushId: PUSH_ID, hashes: [HASH_B] });
+	});
+
+	it("throws when the work list cannot be written", () => {
+		// The hook relies on this throwing to skip the spawn entirely instead of
+		// waiting out its budget for a result that can never arrive. Rooting the
+		// path at a FILE makes the directory creation fail for real.
+		const blocked = join(cwd, "not-a-dir");
+		writeFileSync(blocked, "x");
+		expect(() => writePushRequest(blocked, { pushId: PUSH_ID, hashes: [HASH_A] })).toThrow();
+	});
+});
+
+describe("result hand-off", () => {
+	it("round-trips a published result", () => {
+		writePushResult(cwd, result({ commits: [outcome(HASH_A, { url: "https://jolli.ai/a" })] }));
+		const read = readPushResult(cwd, PUSH_ID);
+		expect(read?.complete).toBe(true);
+		expect(read?.commits).toEqual([{ hash: HASH_A, status: "pushed", url: "https://jolli.ai/a" }]);
+	});
+
+	it("returns undefined before the worker's first publish", () => {
+		expect(readPushResult(cwd, PUSH_ID)).toBeUndefined();
+	});
+
+	it("rejects a result belonging to a different push", () => {
+		writePushResult(cwd, result({ pushId: "other-push" }));
+		writeFileSync(
+			pushResultPath(cwd, PUSH_ID),
+			JSON.stringify({ pushId: "other-push", commits: [], complete: true }),
+		);
+		expect(readPushResult(cwd, PUSH_ID)).toBeUndefined();
+	});
+
+	it("publishes atomically so a reader never sees a partial file", () => {
+		writePushResult(cwd, result({ commits: [outcome(HASH_A)] }));
+		// temp + rename: the scratch file must not survive a successful write.
+		expect(existsSync(`${pushResultPath(cwd, PUSH_ID)}.tmp`)).toBe(false);
+		expect(JSON.parse(readFileSync(pushResultPath(cwd, PUSH_ID), "utf-8")).commits).toHaveLength(1);
+	});
+
+	it("swallows publish failures — a result nobody reads must not break the drain", () => {
+		// Same unwritable-root trick as above; here the failure must be absorbed,
+		// because the push it describes has already happened.
+		const blocked = join(cwd, "also-not-a-dir");
+		writeFileSync(blocked, "x");
+		expect(() => writePushResult(blocked, result())).not.toThrow();
+	});
+});
+
+describe("worker liveness", () => {
+	it("treats an absent lock as alive, not dead", async () => {
+		// The worker may simply not have started yet; reporting "dead" here would
+		// make the hook announce an interruption that never happened.
+		await expect(isPushWorkerDead(cwd, PUSH_ID)).resolves.toBe(false);
+	});
+
+	it("treats a lock owned by a running process as alive", async () => {
+		acquirePushLock(cwd, PUSH_ID);
+		expect(readFileSync(pushLockPath(cwd, PUSH_ID), "utf-8")).toBe(String(process.pid));
+		await expect(isPushWorkerDead(cwd, PUSH_ID)).resolves.toBe(false);
+	});
+
+	it("reports a lock whose owner is gone as dead", async () => {
+		mkdirSync(captureProgressDir(cwd), { recursive: true });
+		// A PID far outside any plausible live range stands in for a killed worker.
+		writeFileSync(pushLockPath(cwd, PUSH_ID), "999999");
+		await expect(isPushWorkerDead(cwd, PUSH_ID)).resolves.toBe(true);
+	});
+
+	it("releases only a lock this process owns", async () => {
+		mkdirSync(captureProgressDir(cwd), { recursive: true });
+		writeFileSync(pushLockPath(cwd, PUSH_ID), "999999");
+		await releasePushLock(cwd, PUSH_ID);
+		// A successor's lock must survive a stale release from a previous run.
+		expect(existsSync(pushLockPath(cwd, PUSH_ID))).toBe(true);
+
+		acquirePushLock(cwd, PUSH_ID);
+		await releasePushLock(cwd, PUSH_ID);
+		expect(existsSync(pushLockPath(cwd, PUSH_ID))).toBe(false);
+	});
+});
+
+describe("reasonFromNote", () => {
+	it("translates every short-circuit note into user-facing wording", () => {
+		expect(reasonFromNote("not signed in")).toBe("not signed in to Jolli");
+		expect(reasonFromNote("push disabled for this repo")).toBe("outbound push disabled for this repo");
+		expect(reasonFromNote("syncOnPush disabled")).toBe("push sync is turned off");
+		expect(reasonFromNote("all entries claimed by another process")).toBe(
+			"another sync is already handling this commit",
+		);
+		expect(reasonFromNote("push not confirmed")).toBe("push not confirmed on the remote");
+		expect(reasonFromNote("no pending entries")).toBe("nothing left to sync");
+		expect(reasonFromNote("no eligible entries")).toBe("nothing left to sync");
+	});
+
+	it("points at the log when there is no note at all", () => {
+		// Every known short-circuit sets a note, so an unreported hash without one
+		// is a genuine anomaly rather than an expected outcome.
+		expect(reasonFromNote(undefined)).toContain("debug.log");
+	});
+
+	it("passes an unrecognised note through verbatim", () => {
+		expect(reasonFromNote("ECONNRESET")).toBe("ECONNRESET");
+	});
+});
+
+describe("watchPushResult", () => {
+	const noSleep = async () => {};
+
+	it("returns as soon as the worker reports completion", async () => {
+		const watch = await watchPushResult(cwd, PUSH_ID, {
+			deadlineAt: Date.now() + 60_000,
+			sleep: noSleep,
+			readResult: () => result({ commits: [outcome(HASH_A)] }),
+		});
+		expect(watch.ended).toBe("complete");
+		expect(watch.result?.commits).toHaveLength(1);
+	});
+
+	it("keeps polling while the result is still incomplete", async () => {
+		let reads = 0;
+		const watch = await watchPushResult(cwd, PUSH_ID, {
+			deadlineAt: Date.now() + 60_000,
+			sleep: noSleep,
+			readResult: () => {
+				reads++;
+				return reads < 3 ? result({ complete: false, commits: [outcome(HASH_A)] }) : result({ complete: true });
+			},
+		});
+		expect(reads).toBe(3);
+		expect(watch.ended).toBe("complete");
+	});
+
+	it("returns the last partial result it saw when the deadline passes", async () => {
+		// The hook prints these: giving up must never discard commits that landed.
+		let now = 0;
+		const watch = await watchPushResult(cwd, PUSH_ID, {
+			deadlineAt: 100,
+			sleep: noSleep,
+			now: () => {
+				now += 60;
+				return now;
+			},
+			readResult: () => result({ complete: false, commits: [outcome(HASH_A)] }),
+		});
+		expect(watch.ended).toBe("timeout");
+		expect(watch.result?.commits).toEqual([{ hash: HASH_A, status: "pushed" }]);
+	});
+
+	it("reports a timeout with no result when the worker never published", async () => {
+		const watch = await watchPushResult(cwd, PUSH_ID, {
+			deadlineAt: Date.now() - 1,
+			sleep: noSleep,
+			readResult: () => undefined,
+		});
+		expect(watch.ended).toBe("timeout");
+		expect(watch.result).toBeUndefined();
+	});
+
+	it("stops early on a dead worker and still returns what it saw", async () => {
+		const watch = await watchPushResult(cwd, PUSH_ID, {
+			deadlineAt: Date.now() + 60_000,
+			sleep: noSleep,
+			readResult: () => result({ complete: false, commits: [outcome(HASH_A)] }),
+			workerDead: async () => true,
+		});
+		expect(watch.ended).toBe("worker-dead");
+		expect(watch.result?.commits).toHaveLength(1);
+	});
+
+	it("prefers a final result over a dead worker seen in the same tick", async () => {
+		// The worker publishes then exits; probing liveness first would report an
+		// interruption for a run that actually finished.
+		const watch = await watchPushResult(cwd, PUSH_ID, {
+			deadlineAt: Date.now() + 60_000,
+			sleep: noSleep,
+			readResult: () => result({ complete: true, commits: [outcome(HASH_A)] }),
+			workerDead: async () => true,
+		});
+		expect(watch.ended).toBe("complete");
+	});
+
+	it("reads through the real files when no seams are injected", async () => {
+		writePushResult(cwd, result({ commits: [outcome(HASH_B)] }));
+		const watch = await watchPushResult(cwd, PUSH_ID, { deadlineAt: Date.now() + 60_000, sleep: noSleep });
+		expect(watch.ended).toBe("complete");
+		expect(watch.result?.commits[0].hash).toBe(HASH_B);
+	});
+});

--- a/cli/src/hooks/PushProgress.ts
+++ b/cli/src/hooks/PushProgress.ts
@@ -1,0 +1,241 @@
+/**
+ * PushProgress — the hand-off files between the pre-push hook and the detached
+ * push worker.
+ *
+ * The hook records the commits, spawns the worker, and polls for a result file
+ * for at most its budget. The worker owns every network round-trip and runs to
+ * completion regardless of whether anyone is still watching — that is the whole
+ * point: an aborted request throws away a docId the server already minted, and
+ * the next attempt would then CREATE a duplicate article instead of UPDATEing
+ * the existing one (see `withRecoveredDocId`).
+ *
+ * The result is republished after EVERY settled commit, not once at the end, so
+ * a hook that gives up at its deadline can still print the commits that made it.
+ * That matters here: one commit's push is a chain of requests (each plan, note
+ * and reference, then the summary), so a large push settles gradually.
+ *
+ * A published result with `complete: true` is a promise that NOTHING more is
+ * coming, so the worker guarantees it covers every requested hash. The hook
+ * relies on that to avoid telling the user a commit is "still syncing" after the
+ * worker has exited.
+ *
+ * Files live in the same `capture-progress/` directory as the commit-capture
+ * stream: the repo is writable for anyone who can push, and worktrees get their
+ * own copy for free. `pruneStaleCaptureProgress` sweeps `.json` and `.tmp`
+ * alongside its own artifacts. Nothing is deleted on completion — a SIGKILLed
+ * worker never reaches its cleanup anyway, and deleting right after a write
+ * would race the hook's next poll and turn an early exit into a full-budget wait.
+ */
+
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { isPidAlive, readLockOwnerPid, releaseIfOwned } from "../core/LockPrimitives.js";
+import type { CommitPushOutcome } from "../core/PushExecutor.js";
+import { captureProgressDir } from "./CaptureProgress.js";
+
+/** Default poll interval for {@link watchPushResult}. */
+export const PUSH_RESULT_POLL_MS = 200;
+
+/** What the hook hands to the worker: the commits of THIS push, in push order. */
+export interface PushWorkerRequest {
+	readonly pushId: string;
+	readonly hashes: ReadonlyArray<string>;
+}
+
+/** What the worker publishes back — rewritten after every settled commit. */
+export interface PushWorkerResult {
+	readonly pushId: string;
+	/** Outcomes settled SO FAR. Order is completion order, NOT push order. */
+	readonly commits: ReadonlyArray<CommitPushOutcome>;
+	/**
+	 * False while the drain is still running. When true, `commits` covers every
+	 * requested hash — the hook prints it verbatim and never adds a "still
+	 * syncing" line, which would be false once the worker has exited.
+	 */
+	readonly complete: boolean;
+	/** Set when the run short-circuited (not signed in, push disabled, …). */
+	readonly note?: string;
+}
+
+export function pushRequestPath(cwd: string, pushId: string): string {
+	return join(captureProgressDir(cwd), `push-${pushId}.request.json`);
+}
+
+export function pushResultPath(cwd: string, pushId: string): string {
+	return join(captureProgressDir(cwd), `push-${pushId}.result.json`);
+}
+
+export function pushLockPath(cwd: string, pushId: string): string {
+	return join(captureProgressDir(cwd), `push-${pushId}.lock`);
+}
+
+/**
+ * Writes the worker's input. Throws on failure — the hook uses that to skip the
+ * spawn entirely rather than starting a worker that cannot find its work list
+ * and then making the user wait out a budget for a result that cannot come.
+ *
+ * Any artifact left by an earlier run of the SAME pushId is cleared first. A
+ * pushId is the ambient trace id when one is set, so uniqueness is a property of
+ * how the id was obtained, not something this protocol enforces — and nothing
+ * else here would catch the reuse: a leftover `complete` result reads as this
+ * push's own outcome (announcing commits this push never sent), and a leftover
+ * lock owned by a dead pid reports this push's worker as interrupted before it
+ * has even started. Both are removed before the work list is published, so a
+ * reused id starts from the same blank slate a fresh one does.
+ */
+export function writePushRequest(cwd: string, request: PushWorkerRequest): void {
+	mkdirSync(captureProgressDir(cwd), { recursive: true });
+	rmSync(pushResultPath(cwd, request.pushId), { force: true });
+	rmSync(pushLockPath(cwd, request.pushId), { force: true });
+	writeAtomic(pushRequestPath(cwd, request.pushId), JSON.stringify(request));
+}
+
+/**
+ * Reads the worker's input. Validates element types and the pushId round-trip:
+ * a malformed file would otherwise degrade into "no eligible entries", which is
+ * indistinguishable from a legitimately empty push.
+ */
+export function readPushRequest(cwd: string, pushId: string): PushWorkerRequest | undefined {
+	const parsed = readJson<PushWorkerRequest>(pushRequestPath(cwd, pushId));
+	if (!parsed || parsed.pushId !== pushId) return undefined;
+	if (!Array.isArray(parsed.hashes)) return undefined;
+	if (!parsed.hashes.every((hash) => typeof hash === "string" && hash.length > 0)) return undefined;
+	return parsed;
+}
+
+/**
+ * Publishes (or republishes) the worker's outcome. Best-effort: a result nobody
+ * reads changes nothing about the push that already happened, so a write failure
+ * must never break the worker's own accounting.
+ */
+export function writePushResult(cwd: string, result: PushWorkerResult): void {
+	try {
+		mkdirSync(captureProgressDir(cwd), { recursive: true });
+		writeAtomic(pushResultPath(cwd, result.pushId), JSON.stringify(result));
+	} catch {
+		// best-effort: the hook falls back to its timeout line
+	}
+}
+
+/** Reads a published result; undefined before the worker's first publish. */
+export function readPushResult(cwd: string, pushId: string): PushWorkerResult | undefined {
+	const parsed = readJson<PushWorkerResult>(pushResultPath(cwd, pushId));
+	if (!parsed || parsed.pushId !== pushId || !Array.isArray(parsed.commits)) return undefined;
+	return parsed;
+}
+
+/** Marks "this worker is alive" for the hook's liveness probe. Best-effort. */
+export function acquirePushLock(cwd: string, pushId: string): void {
+	try {
+		mkdirSync(captureProgressDir(cwd), { recursive: true });
+		writeFileSync(pushLockPath(cwd, pushId), String(process.pid), "utf-8");
+	} catch {
+		// best-effort: only the liveness probe degrades
+	}
+}
+
+/** Releases the lock, PID-guarded so a stale release cannot delete a live lock. */
+export async function releasePushLock(cwd: string, pushId: string): Promise<void> {
+	await releaseIfOwned(pushLockPath(cwd, pushId), "push worker lock");
+}
+
+/**
+ * True when the lock exists but its owner is gone — the worker was killed and
+ * will never publish again. An ABSENT lock is NOT dead: the worker may not have
+ * started yet, or may have finished and released. Same semantics as
+ * {@link isCaptureWorkerDead}.
+ */
+export async function isPushWorkerDead(cwd: string, pushId: string): Promise<boolean> {
+	const pid = await readLockOwnerPid(pushLockPath(cwd, pushId));
+	return pid !== null && !isPidAlive(pid);
+}
+
+/**
+ * Human-readable reason for a commit the drain never reported on, derived from
+ * its short-circuit note. Used by the worker to backfill outcomes (so a complete
+ * result really does cover every hash) and by the hook as its fallback wording.
+ *
+ * `undefined` deliberately does NOT mean "fine": every known short-circuit sets
+ * a note, so an unreported hash with no note is an anomaly worth pointing at the
+ * log for. The caller handles the one benign case — a hash that left
+ * push-pending entirely — before falling back here.
+ */
+export function reasonFromNote(note: string | undefined): string {
+	switch (note) {
+		case "not signed in":
+			return "not signed in to Jolli";
+		case "push disabled for this repo":
+			return "outbound push disabled for this repo";
+		case "syncOnPush disabled":
+			return "push sync is turned off";
+		case "all entries claimed by another process":
+			return "another sync is already handling this commit";
+		case "push not confirmed":
+			return "push not confirmed on the remote";
+		case "no pending entries":
+		case "no eligible entries":
+			return "nothing left to sync";
+		case undefined:
+			return "not reached — see .jolli/jollimemory/debug.log";
+		default:
+			return note;
+	}
+}
+
+/** How a {@link watchPushResult} loop ended. */
+export type PushWatchEnd = "complete" | "timeout" | "worker-dead";
+
+export interface WatchPushResultOptions {
+	readonly deadlineAt: number;
+	readonly pollMs?: number;
+	readonly sleep?: (ms: number) => Promise<void>;
+	readonly now?: () => number;
+	readonly readResult?: () => PushWorkerResult | undefined;
+	readonly workerDead?: () => Promise<boolean>;
+}
+
+/**
+ * Polls until the worker reports completion, is detected dead, or the deadline
+ * passes. Always returns the LAST result seen, even on timeout or death, so the
+ * caller can print whatever settled before giving up.
+ *
+ * The liveness probe runs AFTER the result read on every iteration: a worker
+ * that publishes its final result and exits in the same tick must be reported as
+ * "complete", never as "worker-dead".
+ */
+export async function watchPushResult(
+	cwd: string,
+	pushId: string,
+	opts: WatchPushResultOptions,
+): Promise<{ ended: PushWatchEnd; result?: PushWorkerResult }> {
+	const pollMs = opts.pollMs ?? PUSH_RESULT_POLL_MS;
+	const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+	const clock = opts.now ?? Date.now;
+	const read = opts.readResult ?? (() => readPushResult(cwd, pushId));
+	const dead = opts.workerDead ?? (() => isPushWorkerDead(cwd, pushId));
+
+	let latest: PushWorkerResult | undefined;
+	for (;;) {
+		const current = read();
+		if (current) latest = current;
+		if (latest?.complete) return { ended: "complete", result: latest };
+		if (clock() >= opts.deadlineAt) return { ended: "timeout", ...(latest && { result: latest }) };
+		if (await dead()) return { ended: "worker-dead", ...(latest && { result: latest }) };
+		await sleep(pollMs);
+	}
+}
+
+function writeAtomic(path: string, content: string): void {
+	const tmp = `${path}.tmp`;
+	writeFileSync(tmp, content, "utf-8");
+	renameSync(tmp, path);
+}
+
+function readJson<T>(path: string): T | undefined {
+	try {
+		return JSON.parse(readFileSync(path, "utf-8")) as T;
+	} catch {
+		// Missing (worker has not published yet) or torn mid-rename — same answer.
+		return undefined;
+	}
+}

--- a/vscode/esbuild.config.mjs
+++ b/vscode/esbuild.config.mjs
@@ -87,9 +87,8 @@ const cliOptions = {
 		{ in: `${jmSrc}/hooks/PostRewriteHook.ts`,         out: "PostRewriteHook" },
 		{ in: `${jmSrc}/hooks/PrepareMsgHook.ts`,          out: "PrepareMsgHook" },
 		{ in: `${jmSrc}/hooks/PrePushHook.ts`,             out: "PrePushHook" },
-		// NOT spawned by PrePushHook anymore (inline batch sync). Kept as the
-		// detached pending-push compensation drain used by the bundled CLI, the
-		// extension, and IntelliJ's CliIntegrations.retryPendingPushes.
+		// Spawned by PrePushHook (detached per-push sync) AND by the CLI / VS Code
+		// activation compensation drain. Must exist as its own file in dist/.
 		{ in: `${jmSrc}/hooks/PrePushWorker.ts`,           out: "PrePushWorker" },
 		{ in: `${jmSrc}/hooks/GeminiAfterAgentHook.ts`,   out: "GeminiAfterAgentHook" },
 		{ in: `${jmSrc}/hooks/SessionStartHook.ts`,       out: "SessionStartHook" },


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

When a developer pushes commits, each commit's memory-sync status now appears live, with a link to the published article and clear labels for commits still generating, failed, or merged into another commit's memory. Git push itself proceeds without waiting for the memory sync to finish.

The developer also replaced the single large batch upload with per-commit uploads running several in parallel. A single oversized commit can no longer drag down an entire batch, and each commit's status is recorded the moment it completes; a crash mid-drain cannot publish duplicate articles. Long-running syncs keep their place with a periodic heartbeat, and another session cannot take over an upload while it is still in flight.

---

## Topics (2)
<details>
<summary><strong>01 · Per-commit push orchestration replaces the batch upload endpoint</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Memory uploads were failing silently: the combined batch request could exceed a proxy's body-size limit, and the rejection looked like a temporary network failure, so every retry was exhausted and memories never arrived with no explanation.

**💡 Decisions Behind the Code**

- **Drop the batch endpoint instead of chunking around its limit**: the batch's combined payload cap sat above a typical proxy's body-size limit, and the size-limit rejection was indistinguishable from a transient failure, burning every retry and then aging out silently. Sending one request per commit keeps each payload proportional to a single commit and lets a settled commit be recorded immediately, so partial progress survives a failure.
- **Persist each commit's outcome the moment it settles**: a multi-commit drain can run for minutes, longer than the window after which another sync session may take over an in-flight upload, so holding the whole ledger in memory until the end would let a crash replay commits that already published and create duplicate articles. Single-entry writes take the same file lock, so ordering across concurrent uploads stays safe.
- **Heartbeat keeps long uploads from being overtaken**: without renewal, a drain running past the takeover window would lose its claims to another session, which would then re-upload the same commits. The renewal timer is unref'd so it can never keep the worker process alive by itself.

**✅ What Was Implemented**

- Removed the batch push path end-to-end: `pushBatch` plus its payload/result types and `BatchUnsupportedError` from `JolliMemoryPushClient.ts`, and `buildBatchItems` / `applyBatchResult` / `partitionBatchItems` / `processPrePushInline` from `JolliMemoryPushOrchestrator.ts` and `PushExecutor.ts`. `processPushPending` is now the single drain serving the post-queue, activation, and pre-push callers; it pushes one commit per request with `PUSH_CONCURRENCY` in flight and commits each entry's accounting (delete, or patch with `lastError` / `retryCount` / `pushedDocId` / `pushedUrl`) the moment that commit settles.
- `pushSummary` now returns the minted `docId` plus `writeBackFailed` / `cleanupPending` flags and accepts `PushSummaryOptions.skipOrphanCleanup`; the pre-push drain sets `skipPushConfirmation` and `skipOrphanCleanup`, while compensation drains pass `skipOrphanCleanup: false`. Per-commit outcomes stream to callers via `onCommitSettled`, and the result's `commits` array is populated on every return path, including early exits.
- `PushPendingStore.ts`: `claimForPush` now returns `claimedAt` as a compare-and-swap token, and a new `renewClaims` + `CLAIM_RENEW_INTERVAL_MS` heartbeat (an unref'd interval) keeps a long drain's claims alive; `PushCompensation.ts` and `CaptureProgress.ts` were adapted to the unified flow.

**📁 FILES**
- `cli/src/core/PushExecutor.ts`
- `cli/src/core/JolliMemoryPushClient.ts`
- `cli/src/core/JolliMemoryPushOrchestrator.ts`
- `cli/src/core/PushPendingStore.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Live per-commit sync progress during a git push</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Developers pushing commits got no feedback on which memories had synced, and the sync ran inline inside the push hook under a hard deadline, which could delay or block the push itself.

**💡 Decisions Behind the Code**

- **Run the pre-push sync as a background worker**: git waits for the hook to exit before transferring objects, so an inline sync would both delay the push and be unable to verify anything against the remote, since no ref has moved yet. A detached worker lets git proceed and report each commit's outcome as it settles; because the push is unconfirmed, deleting orphaned articles is deferred to a later confirmed run.
- **Report every commit of the push on every exit path**: the hook's result list covers all of the push's commits, so a commit the drain never reached would otherwise be displayed as still running long after the worker exited. Streaming an outcome on every return path, including early exits and commits claimed by another session, keeps that list accurate.

**✅ What Was Implemented**

- `PrePushHook.ts` no longer runs a synchronous inline drain; it spawns the detached `PrePushWorker`, which calls `processPushPending` with source "pre-push", `skipPushConfirmation` and `skipOrphanCleanup`, and a client whose HTTP timeout is raised above the default so a slow server cannot abort mid-request and discard a minted docId.
- New `PushProgress.ts` provides the progress channel between worker and hook, carrying per-commit statuses (pushed / generating / failed / deferred / merged) with article URLs, and is wired into `CaptureProgress.ts` for rendering; `esbuild.config.mjs` was updated to bundle the worker.

**📁 FILES**
- `cli/src/hooks/PrePushWorker.ts`
- `cli/src/hooks/PrePushHook.ts`
- `cli/src/hooks/PushProgress.ts`
- `cli/src/hooks/CaptureProgress.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 6, 2026 at 8:23 PM · via Local agent - Claude Code*
<!-- jollimemory-summary-end -->