### PR TITLE
dashboard: emit web-local UI telemetry from the local web view

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -92,6 +92,9 @@ disk **before** they are sent.
 | `memory_shared` | User invoked Share for a branch's memories (read-only share link). Props: none. |
 | `key_rejected` | The server rejected the API key (401/403). Props: retried, where. |
 | `reauth_completed` | Re-authentication after a rejected key finished. Props: outcome. |
+| `dashboard_opened` | The local web dashboard was opened in a browser (surface web-local). Props: first_run (bool — first open on this install). |
+| `range_changed` | The dashboard time-range control was changed. Props: range (discriminator: 7d/30d/90d/custom). |
+| `chart_split_changed` | A dashboard card's split-by control was changed. Props: card (discriminator: tokens/spend/mcp), split (discriminator). |
 
 ---
 *Generated from `cli/src/core/TelemetryEvents.ts`. The IntelliJ plugin is an

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -92,10 +92,10 @@ disk **before** they are sent.
 | `memory_shared` | User invoked Share for a branch's memories (read-only share link). Props: none. |
 | `key_rejected` | The server rejected the API key (401/403). Props: retried, where. |
 | `reauth_completed` | Re-authentication after a rejected key finished. Props: outcome. |
-| `dashboard_opened` | The local web dashboard was opened in a browser (surface web-local). Props: first_run (bool — first open on this install). |
+| `dashboard_opened` | The local web dashboard was opened in a browser (surface web-local). Props: first_run (bool — first open in this browser profile; per-origin localStorage, so it re-reports across ports, browsers, or a storage clear). |
 | `dashboard_view_switched` | The local web dashboard's left-nav view was switched. Props: view (discriminator: stats/standup/repositories/memories). Distinct from view_switched, which is the IDE tool-window event with its own view vocabulary. |
 | `range_changed` | The dashboard time-range control was changed. Props: range (discriminator: 7d/30d/90d/custom). |
-| `chart_split_changed` | A dashboard card's split-by control was changed. Props: card (discriminator: tokens/spend/mcp), split (discriminator). |
+| `chart_split_changed` | A dashboard card's split-by control was changed. Props: card (discriminator: tokens/mcp), split (discriminator). |
 
 ---
 *Generated from `cli/src/core/TelemetryEvents.ts`. The IntelliJ plugin is an

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -93,6 +93,7 @@ disk **before** they are sent.
 | `key_rejected` | The server rejected the API key (401/403). Props: retried, where. |
 | `reauth_completed` | Re-authentication after a rejected key finished. Props: outcome. |
 | `dashboard_opened` | The local web dashboard was opened in a browser (surface web-local). Props: first_run (bool — first open on this install). |
+| `dashboard_view_switched` | The local web dashboard's left-nav view was switched. Props: view (discriminator: stats/standup/repositories/memories). Distinct from view_switched, which is the IDE tool-window event with its own view vocabulary. |
 | `range_changed` | The dashboard time-range control was changed. Props: range (discriminator: 7d/30d/90d/custom). |
 | `chart_split_changed` | A dashboard card's split-by control was changed. Props: card (discriminator: tokens/spend/mcp), split (discriminator). |
 

--- a/cli/src/commands/DashboardCommand.test.ts
+++ b/cli/src/commands/DashboardCommand.test.ts
@@ -47,6 +47,7 @@ import {
 	importDashboardHistory,
 	registerDashboardCommand,
 	releaseSpawnLock,
+	resolveServerCwd,
 } from "./DashboardCommand.js";
 
 let configDir: string;
@@ -588,5 +589,44 @@ describe("createDeferredWriter", () => {
 		const quiet = createDeferredWriter();
 		quiet.write("  never shown");
 		expect(log2).not.toHaveBeenCalled();
+	});
+});
+
+describe("resolveServerCwd", () => {
+	let tmp: string;
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), "jolli-servercwd-"));
+	});
+	afterEach(() => {
+		rmSync(tmp, { recursive: true, force: true });
+	});
+
+	it("resolves to the git top level when the cwd is inside a repo", async () => {
+		const root = mkdtempSync(join(tmpdir(), "jolli-root-"));
+		try {
+			const resolved = await resolveServerCwd(tmp, async () => root);
+			expect(resolved).toBe(root);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("falls back to process.cwd() when --cwd does not exist", async () => {
+		const missing = join(tmp, "does-not-exist");
+		// base becomes process.cwd(); the injected getRoot echoes it back.
+		const resolved = await resolveServerCwd(missing, async (c) => c);
+		expect(resolved).toBe(process.cwd());
+	});
+
+	it("keeps the validated dir when it is not inside a git repo", async () => {
+		const resolved = await resolveServerCwd(tmp, async () => {
+			throw new Error("not a git repository");
+		});
+		expect(resolved).toBe(tmp);
+	});
+
+	it("ignores a git root that no longer exists", async () => {
+		const resolved = await resolveServerCwd(tmp, async () => join(tmp, "gone"));
+		expect(resolved).toBe(tmp);
 	});
 });

--- a/cli/src/commands/DashboardCommand.test.ts
+++ b/cli/src/commands/DashboardCommand.test.ts
@@ -150,6 +150,19 @@ describe("ensureServerRunning", () => {
 		expect(d.spawned).toEqual([]);
 	});
 
+	it("passes the resolved cwd through to the spawned server", async () => {
+		let spawnedCwd: string | undefined;
+		const d = deps({
+			cwd: "/repo/root",
+			spawnServer: (port, cwd) => {
+				spawnedCwd = cwd;
+				void writeDashboardState(state({ port: port ?? 1818 }), configDir);
+			},
+		});
+		await ensureServerRunning(undefined, d);
+		expect(spawnedCwd).toBe("/repo/root");
+	});
+
 	it("reuses a healthy server when --port names the port it is already on", async () => {
 		await writeDashboardState(state({ port: 1818 }), configDir);
 		const d = deps();

--- a/cli/src/commands/DashboardCommand.ts
+++ b/cli/src/commands/DashboardCommand.ts
@@ -50,12 +50,20 @@ export interface DashboardOptions {
 export interface DashboardDeps {
 	readonly configDir?: string;
 	readonly dbPath?: string;
-	readonly spawnServer?: (port: number | undefined) => void;
+	/**
+	 * Spawns the detached server. `cwd` is the launcher's resolved repo directory
+	 * (`--cwd` or the process cwd): the child runs there so its telemetry buffer
+	 * lands under that repo's `.jolli` rather than wherever the launcher happened
+	 * to be invoked from.
+	 */
+	readonly spawnServer?: (port: number | undefined, cwd: string) => void;
 	readonly openBrowser?: (url: string) => Promise<void>;
 	readonly fetchHealth?: (port: number) => Promise<{ ok: boolean; pid?: number }>;
 	readonly killPid?: (pid: number) => boolean;
 	readonly now?: () => number;
 	readonly sleep?: (ms: number) => Promise<void>;
+	/** Launcher's resolved repo directory, threaded to {@link spawnServer}. Defaults to `process.cwd()`. */
+	readonly cwd?: string;
 }
 
 /* v8 ignore start -- default seams do real process/network/browser work; tests inject fakes */
@@ -73,7 +81,7 @@ async function defaultFetchHealth(port: number): Promise<{ ok: boolean; pid?: nu
 	}
 }
 
-function defaultSpawnServer(port: number | undefined): void {
+function defaultSpawnServer(port: number | undefined, cwd: string): void {
 	// Resolve the entry by directory + filename, not import.meta.url alone —
 	// same rationale as QueueWorker.launchWorker: this function gets inlined
 	// into whichever bundle imports it, and the sibling file is the contract.
@@ -87,6 +95,10 @@ function defaultSpawnServer(port: number | undefined): void {
 	const child = spawnHidden(process.execPath, [scriptPath], {
 		detached: true,
 		stdio: "ignore",
+		// Run the server in the launcher's resolved repo dir so its telemetry
+		// buffer (ServerTelemetry uses process.cwd()) lands under that repo's
+		// `.jolli`, not wherever `jolli dashboard` was invoked from.
+		cwd,
 		env: {
 			...process.env,
 			...(port !== undefined ? { JOLLI_DASHBOARD_PORT: String(port) } : {}),
@@ -133,7 +145,7 @@ function resolveSeams(deps: DashboardDeps): ResolvedSeams {
 /** {@link DashboardDeps} with every optional seam filled in. */
 interface ResolvedSeams {
 	readonly configDir: string;
-	readonly spawnServer: (port: number | undefined) => void;
+	readonly spawnServer: (port: number | undefined, cwd: string) => void;
 	readonly openBrowser: (url: string) => Promise<void>;
 	readonly fetchHealth: (port: number) => Promise<{ ok: boolean; pid?: number }>;
 	readonly killPid: (pid: number) => boolean;
@@ -265,7 +277,7 @@ export async function ensureServerRunning(
 		throw new Error("Another process is starting the dashboard but it never became healthy.");
 	}
 	try {
-		seams.spawnServer(requestedPort);
+		seams.spawnServer(requestedPort, deps.cwd ?? process.cwd());
 		for (let waited = 0; waited < STARTUP_TIMEOUT_MS; waited += 250) {
 			await sleep(250);
 			const state = await readDashboardState(configDir);
@@ -637,7 +649,7 @@ export async function executeDashboard(
 
 	let state: DashboardServerState;
 	try {
-		state = await ensureServerRunning(port, { ...deps, configDir: seams.configDir });
+		state = await ensureServerRunning(port, { ...deps, configDir: seams.configDir, cwd });
 	} catch (err) {
 		console.error(`\n  Error: ${errMsg(err)}\n`);
 		return false;

--- a/cli/src/commands/DashboardCommand.ts
+++ b/cli/src/commands/DashboardCommand.ts
@@ -21,10 +21,11 @@
  * open v11 is pure ESM and the VS Code bundle is CJS.
  */
 
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Command } from "commander";
+import { getProjectRootDir } from "../core/GitOps.js";
 import { getGlobalConfigDir } from "../core/SessionTracker.js";
 import { type BackfillProgress, backfillRepos } from "../dashboard/Backfill.js";
 import { opportunisticSnapshot } from "../dashboard/Backup.js";
@@ -104,6 +105,11 @@ function defaultSpawnServer(port: number | undefined, cwd: string): void {
 			...(port !== undefined ? { JOLLI_DASHBOARD_PORT: String(port) } : {}),
 		},
 	});
+	// A detached spawn emits `error` asynchronously (e.g. a cwd that vanished
+	// between the resolve and the spawn); with no listener Node re-throws it as an
+	// uncaught exception and kills the launcher. Swallow it — a failed spawn means
+	// no dashboard, and the /health probe already reports that to the user.
+	child.on("error", (err) => log.warn("dashboard server failed to spawn: %s", errMsg(err)));
 	child.unref();
 }
 
@@ -238,6 +244,45 @@ export function releaseSpawnLock(configDir: string): void {
 async function isRecordedServerLive(state: DashboardServerState, seams: ResolvedSeams): Promise<boolean> {
 	const health = await seams.fetchHealth(state.port);
 	return health.ok && health.pid === state.pid;
+}
+
+/**
+ * Resolves the working directory the detached server should run in, from the
+ * launcher's raw `--cwd`/process cwd.
+ *
+ * Two review-driven guarantees, both about the fact that the server inherits its
+ * cwd and that the telemetry buffer's identity IS the literal cwd (JOLLI-1957):
+ *
+ *  - **Always a real directory.** A bad `--cwd` (nonexistent, or a file) would
+ *    make the detached `spawn` emit an `error` (ENOENT) and — before the
+ *    `child.on("error")` guard — crash the whole launcher. An invalid path falls
+ *    back to `process.cwd()`, which is always valid.
+ *  - **The repo ROOT, not a subdir.** Launched from `repo/sub`, the raw cwd is
+ *    `repo/sub`, whose buffer no other surface (hooks, QueueWorker, `jolli
+ *    compile`, VS Code) drains — the server's own 60 s flush would be the only
+ *    thing shipping it. Resolving to the git top level lets the server share the
+ *    one repo-root buffer everything else uses.
+ *
+ * `getRoot` is injected for tests; production uses the real `getProjectRootDir`.
+ * Non-repo directories (and any git failure) keep the validated base dir.
+ */
+export async function resolveServerCwd(
+	rawCwd: string,
+	getRoot: (cwd: string) => Promise<string> = getProjectRootDir,
+): Promise<string> {
+	let base = process.cwd();
+	try {
+		if (statSync(rawCwd).isDirectory()) base = rawCwd;
+	} catch {
+		// nonexistent path or a file — keep the always-valid process.cwd()
+	}
+	try {
+		const root = await getRoot(base);
+		if (statSync(root).isDirectory()) return root;
+	} catch {
+		// `base` is not inside a git repo (or git is unavailable) — use it as-is
+	}
+	return base;
 }
 
 /**
@@ -647,9 +692,12 @@ export async function executeDashboard(
 		return false;
 	}
 
+	// The server runs at the repo root and only at a real directory — see
+	// resolveServerCwd. `registerRepo` above keeps using the raw `cwd`.
+	const serverCwd = await resolveServerCwd(cwd);
 	let state: DashboardServerState;
 	try {
-		state = await ensureServerRunning(port, { ...deps, configDir: seams.configDir, cwd });
+		state = await ensureServerRunning(port, { ...deps, configDir: seams.configDir, cwd: serverCwd });
 	} catch (err) {
 		console.error(`\n  Error: ${errMsg(err)}\n`);
 		return false;

--- a/cli/src/core/Telemetry.test.ts
+++ b/cli/src/core/Telemetry.test.ts
@@ -12,6 +12,7 @@ import {
 	scrubProperties,
 	shutdownTelemetry,
 	track,
+	trackAs,
 	trackError,
 } from "./Telemetry.js";
 import { readTelemetryEvents } from "./TelemetryBuffer.js";
@@ -274,5 +275,51 @@ describe("trackError (JOLLI-1961)", () => {
 		trackError("sync", "conflict", { retryable: false });
 		const [e] = await readTelemetryEvents(cwd);
 		expect(e.properties).toEqual({ where: "sync", code: "conflict", retryable: false });
+	});
+});
+
+describe("trackAs", () => {
+	const init = () => initTelemetry({ cwd, installId: "install-1", origin: "https://acme.jolli.ai", config: {} });
+
+	it("stamps the overridden surface while keeping every other envelope field", async () => {
+		init();
+		trackAs("web-local", "range_changed", { range: "30d" });
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e).toMatchObject({
+			eventName: "range_changed",
+			surface: "web-local", // overridden — the process itself is `cli`
+			installId: "install-1",
+			env: "prod",
+			accountId: null,
+			properties: { range: "30d" },
+		});
+	});
+
+	it("does not disturb the process's own surface — a following track() is still cli", async () => {
+		init();
+		trackAs("web-local", "dashboard_opened", { first_run: true });
+		track("search_performed");
+		const [webEvent, cliEvent] = await readTelemetryEvents(cwd);
+		expect(webEvent.surface).toBe("web-local");
+		expect(cliEvent.surface).toBe("cli");
+	});
+
+	it("is a no-op before initialization", async () => {
+		trackAs("web-local", "dashboard_opened");
+		expect(await readTelemetryEvents(cwd)).toEqual([]);
+	});
+
+	it("does not emit when consent is off", async () => {
+		initTelemetry({ cwd, installId: "install-1", origin: "https://acme.jolli.ai", config: { telemetry: "off" } });
+		trackAs("web-local", "dashboard_opened");
+		expect(await readTelemetryEvents(cwd)).toEqual([]);
+	});
+
+	it("scrubs properties like track() does", async () => {
+		init();
+		trackAs("web-local", "chart_split_changed", { card: "tokens", split: "model", token: "sk-secret" });
+		const [e] = await readTelemetryEvents(cwd);
+		// The always-drop `token` key is gone; the safe discriminators survive.
+		expect(e.properties).toEqual({ card: "tokens", split: "model" });
 	});
 });

--- a/cli/src/core/Telemetry.ts
+++ b/cli/src/core/Telemetry.ts
@@ -104,6 +104,38 @@ export function getTelemetryContext(): Readonly<TelemetryContext> | null {
  * guard additionally drops any name that slips through an `as`-cast.
  */
 export function track(eventName: TelemetryEventName, properties: Readonly<Record<string, unknown>> = {}): void {
+	emit(eventName, properties, undefined);
+}
+
+/**
+ * Like {@link track}, but stamps an explicit `surface` instead of the process's
+ * own. The one caller is the local dashboard server's `/api/telemetry` beacon
+ * (see `DashboardServer.ts`): that process self-identifies as the `cli` surface,
+ * but the events it forwards describe user interactions in the local web view,
+ * which are the `web-local` surface. Every OTHER envelope field (installId,
+ * env, surfaceVersion, sessionId) still comes from the initialized context —
+ * only the surface dimension is overridden — so a browser click is attributed
+ * to `web-local` while the same process's own `command_invoked` stays `cli`.
+ *
+ * `surface` is not constrained to the client's own `parseSurface` output: it is
+ * whatever the caller knows the originating surface to be. The backend gates it
+ * against its own closed `SURFACES` allowlist, so an unknown value is dropped
+ * there rather than here.
+ */
+export function trackAs(
+	surface: string,
+	eventName: TelemetryEventName,
+	properties: Readonly<Record<string, unknown>> = {},
+): void {
+	emit(eventName, properties, surface);
+}
+
+/** Shared body of {@link track} / {@link trackAs}. No-op when uninitialized or opted out; never throws. */
+function emit(
+	eventName: TelemetryEventName,
+	properties: Readonly<Record<string, unknown>>,
+	surfaceOverride: string | undefined,
+): void {
 	const ctx = context;
 	if (!ctx || !ctx.enabled) return;
 	if (!isTelemetryEventName(eventName)) return;
@@ -115,7 +147,7 @@ export function track(eventName: TelemetryEventName, properties: Readonly<Record
 			// backend dedups on (event_id, ts) — see TelemetryEnvelope (JOLLI-1966).
 			eventId: randomUUID(),
 			eventName,
-			surface: ctx.surface,
+			surface: surfaceOverride ?? ctx.surface,
 			surfaceVersion: ctx.surfaceVersion,
 			installId: ctx.installId,
 			...(ctx.sessionId ? { sessionId: ctx.sessionId } : {}),

--- a/cli/src/core/TelemetryEvents.ts
+++ b/cli/src/core/TelemetryEvents.ts
@@ -80,12 +80,12 @@ export const TELEMETRY_EVENTS = {
 	reauth_completed: "Re-authentication after a rejected key finished. Props: outcome.",
 	// ── local web dashboard UI (web-local surface) ──
 	dashboard_opened:
-		"The local web dashboard was opened in a browser (surface web-local). Props: first_run (bool — first open on this install).",
+		"The local web dashboard was opened in a browser (surface web-local). Props: first_run (bool — first open in this browser profile; per-origin localStorage, so it re-reports across ports, browsers, or a storage clear).",
 	dashboard_view_switched:
 		"The local web dashboard's left-nav view was switched. Props: view (discriminator: stats/standup/repositories/memories). Distinct from view_switched, which is the IDE tool-window event with its own view vocabulary.",
 	range_changed: "The dashboard time-range control was changed. Props: range (discriminator: 7d/30d/90d/custom).",
 	chart_split_changed:
-		"A dashboard card's split-by control was changed. Props: card (discriminator: tokens/spend/mcp), split (discriminator).",
+		"A dashboard card's split-by control was changed. Props: card (discriminator: tokens/mcp), split (discriminator).",
 } as const;
 
 /** Union of every registered event name. */

--- a/cli/src/core/TelemetryEvents.ts
+++ b/cli/src/core/TelemetryEvents.ts
@@ -81,6 +81,8 @@ export const TELEMETRY_EVENTS = {
 	// ── local web dashboard UI (web-local surface) ──
 	dashboard_opened:
 		"The local web dashboard was opened in a browser (surface web-local). Props: first_run (bool — first open on this install).",
+	dashboard_view_switched:
+		"The local web dashboard's left-nav view was switched. Props: view (discriminator: stats/standup/repositories/memories). Distinct from view_switched, which is the IDE tool-window event with its own view vocabulary.",
 	range_changed: "The dashboard time-range control was changed. Props: range (discriminator: 7d/30d/90d/custom).",
 	chart_split_changed:
 		"A dashboard card's split-by control was changed. Props: card (discriminator: tokens/spend/mcp), split (discriminator).",

--- a/cli/src/core/TelemetryEvents.ts
+++ b/cli/src/core/TelemetryEvents.ts
@@ -78,6 +78,12 @@ export const TELEMETRY_EVENTS = {
 	memory_shared: "User invoked Share for a branch's memories (read-only share link). Props: none.",
 	key_rejected: "The server rejected the API key (401/403). Props: retried, where.",
 	reauth_completed: "Re-authentication after a rejected key finished. Props: outcome.",
+	// ── local web dashboard UI (web-local surface) ──
+	dashboard_opened:
+		"The local web dashboard was opened in a browser (surface web-local). Props: first_run (bool — first open on this install).",
+	range_changed: "The dashboard time-range control was changed. Props: range (discriminator: 7d/30d/90d/custom).",
+	chart_split_changed:
+		"A dashboard card's split-by control was changed. Props: card (discriminator: tokens/spend/mcp), split (discriminator).",
 } as const;
 
 /** Union of every registered event name. */

--- a/cli/src/dashboard/DashboardServer.test.ts
+++ b/cli/src/dashboard/DashboardServer.test.ts
@@ -49,6 +49,8 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 
 import { unlink } from "node:fs/promises";
 import * as gitOps from "../core/GitOps.js";
+import { initTelemetry, shutdownTelemetry } from "../core/Telemetry.js";
+import { readTelemetryEvents } from "../core/TelemetryBuffer.js";
 import * as installer from "../install/Installer.js";
 import { withDashboardDb } from "./DashboardDb.js";
 import type { DashboardModel, DashboardScope, DashboardView } from "./DashboardModel.js";
@@ -1281,5 +1283,67 @@ describe("Decisions card gist (Stats view only)", () => {
 
 		expect(res.status).toBe(200);
 		expect(mockGetDecisionGist).not.toHaveBeenCalled();
+	});
+});
+
+describe("telemetry beacon", () => {
+	// The endpoint sits BEFORE the mutation-token gate on purpose (the token is
+	// inlined only into the write-surface pages), so it must accept a tokenless
+	// POST — the exact opposite of every /api/repos/* route above.
+	async function post(port: number, body: unknown, headers: Record<string, string> = {}): Promise<Response> {
+		return fetch(`http://127.0.0.1:${port}/api/telemetry`, {
+			method: "POST",
+			headers: { "content-type": "application/json", ...headers },
+			body: typeof body === "string" ? body : JSON.stringify(body),
+		});
+	}
+
+	afterEach(() => {
+		// The telemetry context is a module singleton — never leak it between tests.
+		shutdownTelemetry();
+	});
+
+	it("accepts a tokenless beacon (204) and forwards it stamped web-local", async () => {
+		initTelemetry({ cwd: dir, installId: "install-1", origin: "https://acme.jolli.ai", config: {}, env: {} });
+		const port = await listen(testServer());
+		const res = await post(port, { event: "dashboard_opened", properties: { first_run: true } });
+		expect(res.status).toBe(204);
+		const events = await readTelemetryEvents(dir);
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({
+			eventName: "dashboard_opened",
+			surface: "web-local",
+			properties: { first_run: true },
+		});
+	});
+
+	it("drops an unregistered event name but still answers 204", async () => {
+		initTelemetry({ cwd: dir, installId: "install-1", origin: "https://acme.jolli.ai", config: {}, env: {} });
+		const port = await listen(testServer());
+		const res = await post(port, { event: "totally_made_up_event", properties: {} });
+		expect(res.status).toBe(204);
+		expect(await readTelemetryEvents(dir)).toEqual([]);
+	});
+
+	it("answers 204 on a malformed body — a beacon is never taught to retry", async () => {
+		initTelemetry({ cwd: dir, installId: "install-1", origin: "https://acme.jolli.ai", config: {}, env: {} });
+		const port = await listen(testServer());
+		const res = await post(port, "}{ not json");
+		expect(res.status).toBe(204);
+		expect(await readTelemetryEvents(dir)).toEqual([]);
+	});
+
+	it("answers 204 for a valid event even when telemetry is opted out, buffering nothing", async () => {
+		initTelemetry({
+			cwd: dir,
+			installId: "install-1",
+			origin: "https://acme.jolli.ai",
+			config: { telemetry: "off" },
+			env: {},
+		});
+		const port = await listen(testServer());
+		const res = await post(port, { event: "range_changed", properties: { range: "7d" } });
+		expect(res.status).toBe(204);
+		expect(await readTelemetryEvents(dir)).toEqual([]);
 	});
 });

--- a/cli/src/dashboard/DashboardServer.test.ts
+++ b/cli/src/dashboard/DashboardServer.test.ts
@@ -1325,6 +1325,16 @@ describe("telemetry beacon", () => {
 		expect(await readTelemetryEvents(dir)).toEqual([]);
 	});
 
+	it("drops a registered event that is NOT a dashboard event (no forging via web-local)", async () => {
+		initTelemetry({ cwd: dir, installId: "install-1", origin: "https://acme.jolli.ai", config: {}, env: {} });
+		const port = await listen(testServer());
+		// `search_performed` is a real registered event, but not one the local web
+		// view emits — the beacon must refuse to stamp it web-local.
+		const res = await post(port, { event: "search_performed", properties: { hit: true } });
+		expect(res.status).toBe(204);
+		expect(await readTelemetryEvents(dir)).toEqual([]);
+	});
+
 	it("answers 204 on a malformed body — a beacon is never taught to retry", async () => {
 		initTelemetry({ cwd: dir, installId: "install-1", origin: "https://acme.jolli.ai", config: {}, env: {} });
 		const port = await listen(testServer());

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -69,6 +69,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath, URL } from "node:url";
 import { getProjectRootDir, listReachableCommits } from "../core/GitOps.js";
 import { getGlobalConfigDir, loadConfigFromDir } from "../core/SessionTracker.js";
+import { trackAs } from "../core/Telemetry.js";
+import { isTelemetryEventName } from "../core/TelemetryEvents.js";
 import { install, uninstall } from "../install/Installer.js";
 import { createLogger, errMsg, isEnoent } from "../Logger.js";
 import { projectRepoRegistryState } from "./Backfill.js";
@@ -433,6 +435,14 @@ function sendText(res: ServerResponse, status: number, text: string): void {
 const TOKEN_HEADER = "x-jolli-dashboard-token";
 
 /**
+ * Surface stamped on telemetry forwarded from the local web view. Distinct from
+ * the hosting process's own `cli` surface (see `trackAs`) and from the future
+ * hosted `web` frontend. Must be in the backend's `SURFACES` allowlist or the
+ * event is dropped at ingest.
+ */
+const WEB_LOCAL_SURFACE = "web-local";
+
+/**
  * Constant-time token check. A length mismatch is checked first (bailing out
  * before `timingSafeEqual`, which throws on unequal-length buffers) — that
  * branch leaks only the token's length, which is fixed and public (every
@@ -467,6 +477,35 @@ async function readJsonBody(req: IncomingMessage): Promise<unknown> {
 	}
 	const raw = Buffer.concat(chunks).toString("utf-8");
 	return raw ? JSON.parse(raw) : {};
+}
+
+/**
+ * The `/api/telemetry` beacon. Forwards ONE content-free, already-bucketed event
+ * from the local web view into the shared telemetry buffer, stamped `web-local`.
+ *
+ * Fire-and-forget by contract: any bad input — an unreadable/oversized body, a
+ * non-object payload, or an unregistered event name — is dropped and answered
+ * 204, so a browser beacon is never taught to retry. Property scrubbing and the
+ * opt-out/uninitialized no-op both live in `trackAs`, so this handler only has
+ * to validate the event NAME (the one thing the registry gates on).
+ */
+async function handleTelemetry(req: IncomingMessage, res: ServerResponse): Promise<void> {
+	try {
+		const body = await readJsonBody(req);
+		if (typeof body === "object" && body !== null) {
+			const b = body as Record<string, unknown>;
+			const event = typeof b.event === "string" ? b.event : "";
+			const properties =
+				typeof b.properties === "object" && b.properties !== null
+					? (b.properties as Record<string, unknown>)
+					: {};
+			if (isTelemetryEventName(event)) trackAs(WEB_LOCAL_SURFACE, event, properties);
+		}
+	} catch {
+		// Unreadable / oversized body, or a socket error — drop silently. The
+		// payload is content-free and a beacon must never learn to retry.
+	}
+	res.writeHead(204).end();
 }
 
 function parseScope(url: URL): DashboardScope {
@@ -621,6 +660,17 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 		res.setHeader("X-Frame-Options", "DENY");
 		res.setHeader("Content-Security-Policy", "frame-ancestors 'none'");
 
+		// The telemetry beacon is deliberately handled BEFORE `handlePost`'s
+		// mutation-token gate. The token is inlined only into the write-surface
+		// pages (Repositories/Settings), so a token-gated beacon would silently
+		// drop every event fired from the stats/memories pages. It is safe to
+		// leave ungated: the host-allowlist + Origin + `frame-ancestors` checks
+		// above already reject cross-site callers, and the payload is content-free
+		// and non-mutating. `handleTelemetry` never rejects a beacon (always 204).
+		if (req.method === "POST" && url.pathname === "/api/telemetry") {
+			await handleTelemetry(req, res);
+			return;
+		}
 		if (req.method === "POST") {
 			await handlePost(req, res, url);
 			return;

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -70,7 +70,7 @@ import { fileURLToPath, URL } from "node:url";
 import { getProjectRootDir, listReachableCommits } from "../core/GitOps.js";
 import { getGlobalConfigDir, loadConfigFromDir } from "../core/SessionTracker.js";
 import { trackAs } from "../core/Telemetry.js";
-import { isTelemetryEventName } from "../core/TelemetryEvents.js";
+import { isTelemetryEventName, type TelemetryEventName } from "../core/TelemetryEvents.js";
 import { install, uninstall } from "../install/Installer.js";
 import { createLogger, errMsg, isEnoent } from "../Logger.js";
 import { projectRepoRegistryState } from "./Backfill.js";
@@ -443,6 +443,21 @@ const TOKEN_HEADER = "x-jolli-dashboard-token";
 const WEB_LOCAL_SURFACE = "web-local";
 
 /**
+ * The only events the beacon may stamp `web-local`. The endpoint is reachable by
+ * any same-origin script — and, lacking an Origin header, by any local process —
+ * so gating on {@link isTelemetryEventName} alone would let a caller forge an
+ * unrelated registered event (e.g. `search_performed`) under this surface.
+ * Restricting to the four dashboard-UI events matches the documented contract:
+ * this endpoint forwards local-web-view interactions, nothing else.
+ */
+const WEB_LOCAL_EVENTS: ReadonlySet<TelemetryEventName> = new Set([
+	"dashboard_opened",
+	"dashboard_view_switched",
+	"range_changed",
+	"chart_split_changed",
+]);
+
+/**
  * Constant-time token check. A length mismatch is checked first (bailing out
  * before `timingSafeEqual`, which throws on unequal-length buffers) — that
  * branch leaks only the token's length, which is fixed and public (every
@@ -499,7 +514,8 @@ async function handleTelemetry(req: IncomingMessage, res: ServerResponse): Promi
 				typeof b.properties === "object" && b.properties !== null
 					? (b.properties as Record<string, unknown>)
 					: {};
-			if (isTelemetryEventName(event)) trackAs(WEB_LOCAL_SURFACE, event, properties);
+			if (isTelemetryEventName(event) && WEB_LOCAL_EVENTS.has(event))
+				trackAs(WEB_LOCAL_SURFACE, event, properties);
 		}
 	} catch {
 		// Unreadable / oversized body, or a socket error — drop silently. The

--- a/cli/src/dashboard/ServerEntry.test.ts
+++ b/cli/src/dashboard/ServerEntry.test.ts
@@ -11,6 +11,14 @@ vi.mock("./DashboardDb.js", async (importOriginal) => {
 	const original = await importOriginal<typeof import("./DashboardDb.js")>();
 	return { ...original, canUseDashboardDb: vi.fn(() => true) };
 });
+// Keep the real telemetry lifecycle (fs reads, timers) out of these tests; its
+// own behaviour is covered by ServerTelemetry.test.ts. Here we only assert the
+// wiring: it is started at boot and stopped on shutdown.
+const { telemetryStop, startServerTelemetrySpy } = vi.hoisted(() => {
+	const stop = vi.fn(async () => {});
+	return { telemetryStop: stop, startServerTelemetrySpy: vi.fn(async () => ({ stop })) };
+});
+vi.mock("./ServerTelemetry.js", () => ({ startServerTelemetry: startServerTelemetrySpy }));
 
 import { canUseDashboardDb } from "./DashboardDb.js";
 import { clearDashboardState, startDashboardServer } from "./DashboardServer.js";
@@ -26,6 +34,8 @@ beforeEach(() => {
 		server: { closeAllConnections: vi.fn(), close: vi.fn() } as never,
 		port: 1818,
 	});
+	// clearMocks wipes implementations too — re-arm the telemetry handle.
+	startServerTelemetrySpy.mockResolvedValue({ stop: telemetryStop });
 });
 
 afterEach(() => {
@@ -76,6 +86,17 @@ describe("runServerEntry", () => {
 		options.onIdleShutdown?.();
 		await new Promise((resolve) => setImmediate(resolve));
 		expect(clearDashboardState).toHaveBeenCalled();
+		expect(exit).toHaveBeenCalledWith(0);
+	});
+
+	it("primes telemetry at boot and stops it on shutdown (before exit)", async () => {
+		const exit = vi.fn();
+		const { shutdown } = await runServerEntry({}, exit);
+		expect(startServerTelemetrySpy).toHaveBeenCalledTimes(1);
+		expect(telemetryStop).not.toHaveBeenCalled();
+		shutdown();
+		await new Promise((resolve) => setImmediate(resolve));
+		expect(telemetryStop).toHaveBeenCalledTimes(1);
 		expect(exit).toHaveBeenCalledWith(0);
 	});
 });

--- a/cli/src/dashboard/ServerEntry.ts
+++ b/cli/src/dashboard/ServerEntry.ts
@@ -15,6 +15,7 @@
 import { createLogger, errMsg } from "../Logger.js";
 import { canUseDashboardDb, DashboardRuntimeError } from "./DashboardDb.js";
 import { clearDashboardState, startDashboardServer } from "./DashboardServer.js";
+import { startServerTelemetry } from "./ServerTelemetry.js";
 
 const log = createLogger("DashboardServerEntry");
 
@@ -41,20 +42,30 @@ export async function runServerEntry(
 	}
 	const portRaw = env[DASHBOARD_PORT_ENV];
 	const port = portRaw !== undefined ? Number.parseInt(portRaw, 10) : undefined;
+	// Prime telemetry for this long-lived process and start its periodic flush,
+	// so the `/api/telemetry` beacon's `web-local` events are actually recorded
+	// and shipped (see ServerTelemetry). Best-effort; never blocks serving.
+	const telemetry = await startServerTelemetry();
 	// Both teardown paths clear the state file guarded by our own pid: if the
 	// record has moved on to another server, it is that server's now and deleting
-	// it would leave a live dashboard no launcher can find.
+	// it would leave a live dashboard no launcher can find. The final telemetry
+	// flush runs first so a clean shutdown ships what the last interval did not.
+	const finish = async (): Promise<void> => {
+		await telemetry.stop();
+		await clearOwnState();
+		exit(0);
+	};
 	const clearOwnState = () => clearDashboardState(undefined, process.pid);
 	const { server } = await startDashboardServer({
 		...(port !== undefined && Number.isFinite(port) ? { port } : {}),
 		onIdleShutdown: () => {
-			void clearOwnState().finally(() => exit(0));
+			void finish();
 		},
 	});
 	const shutdown = () => {
 		server.closeAllConnections();
 		server.close();
-		void clearOwnState().finally(() => exit(0));
+		void finish();
 	};
 	process.on("SIGINT", shutdown);
 	process.on("SIGTERM", shutdown);

--- a/cli/src/dashboard/ServerTelemetry.test.ts
+++ b/cli/src/dashboard/ServerTelemetry.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_SERVER_FLUSH_MS, startServerTelemetry } from "./ServerTelemetry.js";
+
+describe("startServerTelemetry", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("bootstraps telemetry once with the given cwd", async () => {
+		const bootstrap = vi.fn(async () => {});
+		const flush = vi.fn(async () => {});
+		await startServerTelemetry({ cwd: "/work", bootstrap, flush });
+		expect(bootstrap).toHaveBeenCalledTimes(1);
+		expect(bootstrap).toHaveBeenCalledWith("/work");
+	});
+
+	it("flushes on the configured interval", async () => {
+		const bootstrap = vi.fn(async () => {});
+		const flush = vi.fn(async () => {});
+		await startServerTelemetry({ cwd: "/work", bootstrap, flush, flushIntervalMs: 1000 });
+		expect(flush).not.toHaveBeenCalled();
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(flush).toHaveBeenCalledWith("/work");
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(flush).toHaveBeenCalledTimes(2);
+	});
+
+	it("stop() clears the timer and does one final flush, and is idempotent", async () => {
+		const bootstrap = vi.fn(async () => {});
+		const flush = vi.fn(async () => {});
+		const { stop } = await startServerTelemetry({ cwd: "/work", bootstrap, flush, flushIntervalMs: 1000 });
+		await stop();
+		expect(flush).toHaveBeenCalledTimes(1); // the final flush
+		// Timer was cleared — no further periodic flushes.
+		await vi.advanceTimersByTimeAsync(5000);
+		expect(flush).toHaveBeenCalledTimes(1);
+		// Idempotent: a second stop() does nothing.
+		await stop();
+		expect(flush).toHaveBeenCalledTimes(1);
+	});
+
+	it("swallows a bootstrap failure and still arms the flush loop", async () => {
+		const bootstrap = vi.fn(async () => {
+			throw new Error("boom");
+		});
+		const flush = vi.fn(async () => {});
+		const handle = await startServerTelemetry({ cwd: "/work", bootstrap, flush, flushIntervalMs: 1000 });
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(flush).toHaveBeenCalledWith("/work");
+		await handle.stop();
+	});
+
+	it("swallows a periodic flush rejection without unhandled rejection", async () => {
+		const bootstrap = vi.fn(async () => {});
+		const flush = vi.fn(async () => {
+			throw new Error("network down");
+		});
+		const { stop } = await startServerTelemetry({ cwd: "/work", bootstrap, flush, flushIntervalMs: 1000 });
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(flush).toHaveBeenCalled();
+		// stop()'s final flush also rejects — must not throw.
+		await expect(stop()).resolves.toBeUndefined();
+	});
+
+	it("exposes a sane default flush cadence", () => {
+		expect(DEFAULT_SERVER_FLUSH_MS).toBeGreaterThanOrEqual(10_000);
+	});
+});

--- a/cli/src/dashboard/ServerTelemetry.ts
+++ b/cli/src/dashboard/ServerTelemetry.ts
@@ -1,0 +1,82 @@
+/**
+ * ServerTelemetry — telemetry lifecycle for the detached dashboard server.
+ *
+ * A one-shot CLI command primes telemetry at startup and flushes the buffer on
+ * exit. The dashboard server is neither: it is long-lived, and it is the process
+ * the `/api/telemetry` beacon runs inside. So it needs two things a command does
+ * not:
+ *
+ *   1. Its telemetry context primed once at boot. Without it, `trackAs` in
+ *      `DashboardServer.handleTelemetry` is a no-op and every `web-local` event
+ *      is silently dropped.
+ *   2. A PERIODIC flush. Nothing else drains this process's buffer while it runs
+ *      — a CLI command flushes on its own exit, but this server can stay up for
+ *      hours, so its events would sit on disk (and eventually age out of the
+ *      ring buffer) until it happens to be stopped.
+ *
+ * Consent is honored entirely by the shared helpers this wraps: an opted-out
+ * install primes a disabled context (so `trackAs` no-ops) and `flushTelemetryNow`
+ * clears the buffer instead of sending it. Everything here is best-effort and
+ * never throws — telemetry must not keep the server from serving.
+ */
+
+import { bootstrapTelemetry, flushTelemetryNow } from "../core/TelemetryStartup.js";
+import { createLogger, errMsg } from "../Logger.js";
+
+const log = createLogger("ServerTelemetry");
+
+/** Default periodic flush cadence for the long-lived server. */
+export const DEFAULT_SERVER_FLUSH_MS = 60_000;
+
+export interface ServerTelemetryDeps {
+	/** Prime the telemetry context. Defaults to the real `bootstrapTelemetry`. */
+	readonly bootstrap?: (cwd: string) => Promise<void>;
+	/** Flush the buffer once. Defaults to the real `flushTelemetryNow`. */
+	readonly flush?: (cwd: string) => Promise<void>;
+	/** Periodic flush cadence. Defaults to {@link DEFAULT_SERVER_FLUSH_MS}. */
+	readonly flushIntervalMs?: number;
+	/** Buffer/init working dir. Defaults to `process.cwd()` — init and flush MUST agree on it. */
+	readonly cwd?: string;
+}
+
+export interface ServerTelemetryHandle {
+	/** Clears the flush timer and does one final best-effort flush. Idempotent. */
+	readonly stop: () => Promise<void>;
+}
+
+/**
+ * Primes telemetry for the server process and starts a periodic flush. Never
+ * throws. The returned `stop` clears the timer and flushes once more, so a
+ * clean shutdown ships what the last interval did not.
+ */
+export async function startServerTelemetry(deps: ServerTelemetryDeps = {}): Promise<ServerTelemetryHandle> {
+	const cwd = deps.cwd ?? process.cwd();
+	const bootstrap = deps.bootstrap ?? ((c: string) => bootstrapTelemetry({ cwd: c }));
+	const flush = deps.flush ?? flushTelemetryNow;
+	const intervalMs = deps.flushIntervalMs ?? DEFAULT_SERVER_FLUSH_MS;
+
+	try {
+		await bootstrap(cwd);
+	} catch (err) {
+		log.warn("telemetry bootstrap failed: %s", errMsg(err));
+	}
+
+	const timer = setInterval(() => {
+		void flush(cwd).catch(() => {});
+	}, intervalMs);
+	// Never let the flush timer keep the event loop (or a test runner) alive.
+	timer.unref?.();
+
+	let stopped = false;
+	const stop = async (): Promise<void> => {
+		if (stopped) return;
+		stopped = true;
+		clearInterval(timer);
+		try {
+			await flush(cwd);
+		} catch {
+			// best-effort final flush — the process is going away regardless
+		}
+	};
+	return { stop };
+}

--- a/cli/src/dashboard/ServerTelemetry.ts
+++ b/cli/src/dashboard/ServerTelemetry.ts
@@ -28,6 +28,14 @@ const log = createLogger("ServerTelemetry");
 /** Default periodic flush cadence for the long-lived server. */
 export const DEFAULT_SERVER_FLUSH_MS = 60_000;
 
+/**
+ * Per-flush network cap. Well under the flusher's 10 s default: the final flush
+ * runs on the shutdown path (idle timeout / SIGTERM) before `exit(0)`, and a
+ * slow network must not hold the process — and `dashboard.json` — open for ten
+ * seconds. A dropped batch is best-effort and recovered on the next run.
+ */
+export const SERVER_FLUSH_TIMEOUT_MS = 2_000;
+
 export interface ServerTelemetryDeps {
 	/** Prime the telemetry context. Defaults to the real `bootstrapTelemetry`. */
 	readonly bootstrap?: (cwd: string) => Promise<void>;
@@ -52,7 +60,7 @@ export interface ServerTelemetryHandle {
 export async function startServerTelemetry(deps: ServerTelemetryDeps = {}): Promise<ServerTelemetryHandle> {
 	const cwd = deps.cwd ?? process.cwd();
 	const bootstrap = deps.bootstrap ?? ((c: string) => bootstrapTelemetry({ cwd: c }));
-	const flush = deps.flush ?? flushTelemetryNow;
+	const flush = deps.flush ?? ((c: string) => flushTelemetryNow(c, { timeoutMs: SERVER_FLUSH_TIMEOUT_MS }));
 	const intervalMs = deps.flushIntervalMs ?? DEFAULT_SERVER_FLUSH_MS;
 
 	try {

--- a/cli/src/dashboard/assets/js/main.js
+++ b/cli/src/dashboard/assets/js/main.js
@@ -20,5 +20,18 @@
 	if (model) {
 		render(model);
 		window.JD.startRefresh(render);
+		/* Fire once per browser SESSION — nav is a full page reload, so a naive
+		   call would re-fire on every page. `first_run` is the first-ever open in
+		   this browser profile: a content-free proxy for a fresh install. */
+		try {
+			if (window.JD.track && !sessionStorage.getItem("jdOpened")) {
+				sessionStorage.setItem("jdOpened", "1");
+				var everOpened = !!localStorage.getItem("jdEverOpened");
+				localStorage.setItem("jdEverOpened", "1");
+				window.JD.track("dashboard_opened", { first_run: !everOpened });
+			}
+		} catch (e) {
+			/* storage blocked (private mode) — skip; telemetry never breaks boot */
+		}
 	}
 })();

--- a/cli/src/dashboard/assets/js/shell.js
+++ b/cli/src/dashboard/assets/js/shell.js
@@ -184,6 +184,8 @@ window.JD = window.JD || {};
 			(item.child ? " child" : "") +
 			'" data-nav-path="' +
 			item.path +
+			'" data-nav-view="' +
+			(item.view || "") +
 			'"' +
 			(active ? ' aria-current="page"' : "") +
 			(disabled ? ' aria-disabled="true" title="Available once a repository is enabled"' : "") +
@@ -310,6 +312,7 @@ window.JD = window.JD || {};
 				return;
 			}
 			button.onclick = () => {
+				JD.track("range_changed", { range: value });
 				window.location.href = JD.viewPath(model.view) + JD.query(model, { range: value });
 			};
 		});
@@ -318,6 +321,7 @@ window.JD = window.JD || {};
 			custom.onsubmit = (event) => {
 				event.preventDefault();
 				if (!selectedFrom || !selectedTo) return;
+				JD.track("range_changed", { range: "custom" });
 				window.location.href =
 					JD.viewPath(model.view) +
 					JD.query(model, { range: "custom", from: selectedFrom, to: selectedTo });
@@ -353,7 +357,9 @@ window.JD = window.JD || {};
 		Array.prototype.forEach.call(document.querySelectorAll("#sbNav .sb-item, #sbBottom .sb-item"), (button) => {
 			if (button.getAttribute("aria-disabled") === "true") return;
 			var path = button.getAttribute("data-nav-path");
+			var navView = button.getAttribute("data-nav-view");
 			button.onclick = () => {
+				if (navView && navView !== model.view) JD.track("view_switched", { view: navView });
 				window.location.href = path + JD.query(model, { range: undefined, repo: undefined });
 			};
 		});
@@ -522,6 +528,33 @@ window.JD = window.JD || {};
 	 * page that needs it — see `DashboardServer.ts`'s module header for why the
 	 * header carries it and a query string never does.
 	 */
+	/**
+	 * Fire-and-forget UI telemetry beacon → POST /api/telemetry (the server
+	 * stamps it with the `web-local` surface). Content-free: pass only bucketed
+	 * values and fixed discriminators, never raw counts or user text. Prefers
+	 * `navigator.sendBeacon` so the event survives the full-page navigation a
+	 * nav/range click triggers, falling back to keepalive fetch. Never throws,
+	 * and needs no token — the endpoint sits ahead of the mutation-token gate
+	 * (see DashboardServer.handleTelemetry).
+	 */
+	JD.track = (event, properties) => {
+		try {
+			var body = JSON.stringify({ event: event, properties: properties || {} });
+			if (navigator.sendBeacon) {
+				navigator.sendBeacon("/api/telemetry", new Blob([body], { type: "application/json" }));
+				return;
+			}
+			fetch("/api/telemetry", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: body,
+				keepalive: true,
+			}).catch(function () {});
+		} catch (e) {
+			/* telemetry must never break the UI */
+		}
+	};
+
 	JD.post = (path, body) =>
 		fetch(path, {
 			method: "POST",

--- a/cli/src/dashboard/assets/js/shell.js
+++ b/cli/src/dashboard/assets/js/shell.js
@@ -312,11 +312,14 @@ window.JD = window.JD || {};
 				return;
 			}
 			button.onclick = () => {
-				/* Emit the user-facing label token (7d/30d/90d), not the internal
-				   DashboardRange token (week/month/3m), so the telemetry discriminator
-				   matches the registry doc and the button labels. `custom` is handled
-				   by its own branch above and reported as "custom" on Apply. */
-				JD.track("range_changed", { range: { week: "7d", month: "30d", "3m": "90d" }[value] || value });
+				/* Only a real change is a change: clicking the already-active range
+				   must not emit range_changed. Emit the user-facing label token
+				   (7d/30d/90d), not the internal DashboardRange token (week/month/3m),
+				   so the discriminator matches the registry doc and the button labels.
+				   `custom` is handled by its own branch above and reported on Apply. */
+				if (value !== activeRange) {
+					JD.track("range_changed", { range: { week: "7d", month: "30d", "3m": "90d" }[value] || value });
+				}
 				window.location.href = JD.viewPath(model.view) + JD.query(model, { range: value });
 			};
 		});

--- a/cli/src/dashboard/assets/js/shell.js
+++ b/cli/src/dashboard/assets/js/shell.js
@@ -312,7 +312,11 @@ window.JD = window.JD || {};
 				return;
 			}
 			button.onclick = () => {
-				JD.track("range_changed", { range: value });
+				/* Emit the user-facing label token (7d/30d/90d), not the internal
+				   DashboardRange token (week/month/3m), so the telemetry discriminator
+				   matches the registry doc and the button labels. `custom` is handled
+				   by its own branch above and reported as "custom" on Apply. */
+				JD.track("range_changed", { range: { week: "7d", month: "30d", "3m": "90d" }[value] || value });
 				window.location.href = JD.viewPath(model.view) + JD.query(model, { range: value });
 			};
 		});
@@ -359,7 +363,7 @@ window.JD = window.JD || {};
 			var path = button.getAttribute("data-nav-path");
 			var navView = button.getAttribute("data-nav-view");
 			button.onclick = () => {
-				if (navView && navView !== model.view) JD.track("view_switched", { view: navView });
+				if (navView && navView !== model.view) JD.track("dashboard_view_switched", { view: navView });
 				window.location.href = path + JD.query(model, { range: undefined, repo: undefined });
 			};
 		});

--- a/cli/src/dashboard/assets/js/stats.js
+++ b/cli/src/dashboard/assets/js/stats.js
@@ -979,7 +979,6 @@ window.JD = window.JD || {};
 		document.querySelectorAll(".chips .chip[data-dim]").forEach((chip) => {
 			chip.onclick = () => {
 				JD.dimension = chip.getAttribute("data-dim");
-				JD.track("chart_split_changed", { card: "spend", split: JD.dimension });
 				JD.refreshNow(JD.renderPage);
 			};
 		});
@@ -1007,8 +1006,8 @@ window.JD = window.JD || {};
 		document.querySelectorAll("[data-toksplit]").forEach((button) => {
 			button.onclick = () => {
 				var view = button.getAttribute("data-toksplit");
+				if (view !== (JD.tokSplitView || "type")) JD.track("chart_split_changed", { card: "tokens", split: view });
 				JD.tokSplitView = view;
-				JD.track("chart_split_changed", { card: "tokens", split: view });
 				var wantDim = view === "model" ? "model" : view === "repo" ? "project" : null;
 				if (wantDim && JD.dimension !== wantDim) {
 					JD.dimension = wantDim;
@@ -1025,8 +1024,9 @@ window.JD = window.JD || {};
 		   instead of rolled up — so this is pure view state, never a re-fetch. */
 		document.querySelectorAll("[data-mcpsplit]").forEach((button) => {
 			button.onclick = () => {
-				JD.mcpSplitView = button.getAttribute("data-mcpsplit");
-				JD.track("chart_split_changed", { card: "mcp", split: JD.mcpSplitView });
+				var value = button.getAttribute("data-mcpsplit");
+				if (value !== (JD.mcpSplitView || "server")) JD.track("chart_split_changed", { card: "mcp", split: value });
+				JD.mcpSplitView = value;
 				JD.renderPage(model);
 			};
 		});

--- a/cli/src/dashboard/assets/js/stats.js
+++ b/cli/src/dashboard/assets/js/stats.js
@@ -979,6 +979,7 @@ window.JD = window.JD || {};
 		document.querySelectorAll(".chips .chip[data-dim]").forEach((chip) => {
 			chip.onclick = () => {
 				JD.dimension = chip.getAttribute("data-dim");
+				JD.track("chart_split_changed", { card: "spend", split: JD.dimension });
 				JD.refreshNow(JD.renderPage);
 			};
 		});
@@ -1007,6 +1008,7 @@ window.JD = window.JD || {};
 			button.onclick = () => {
 				var view = button.getAttribute("data-toksplit");
 				JD.tokSplitView = view;
+				JD.track("chart_split_changed", { card: "tokens", split: view });
 				var wantDim = view === "model" ? "model" : view === "repo" ? "project" : null;
 				if (wantDim && JD.dimension !== wantDim) {
 					JD.dimension = wantDim;
@@ -1024,6 +1026,7 @@ window.JD = window.JD || {};
 		document.querySelectorAll("[data-mcpsplit]").forEach((button) => {
 			button.onclick = () => {
 				JD.mcpSplitView = button.getAttribute("data-mcpsplit");
+				JD.track("chart_split_changed", { card: "mcp", split: JD.mcpSplitView });
 				JD.renderPage(model);
 			};
 		});

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
@@ -76,7 +76,8 @@ object TelemetryEvents {
             // ── local web dashboard UI (web-local surface) ──
             "dashboard_opened" to
                 "The local web dashboard was opened in a browser (surface web-local). " +
-                "Props: first_run (bool — first open on this install).",
+                "Props: first_run (bool — first open in this browser profile; per-origin localStorage, " +
+                "so it re-reports across ports, browsers, or a storage clear).",
             "dashboard_view_switched" to
                 "The local web dashboard's left-nav view was switched. " +
                 "Props: view (discriminator: stats/standup/repositories/memories). " +
@@ -85,7 +86,7 @@ object TelemetryEvents {
                 "The dashboard time-range control was changed. Props: range (discriminator: 7d/30d/90d/custom).",
             "chart_split_changed" to
                 "A dashboard card's split-by control was changed. " +
-                "Props: card (discriminator: tokens/spend/mcp), split (discriminator).",
+                "Props: card (discriminator: tokens/mcp), split (discriminator).",
         )
 
     /** `object_action`: lowercase snake_case with at least two words. */

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
@@ -77,6 +77,10 @@ object TelemetryEvents {
             "dashboard_opened" to
                 "The local web dashboard was opened in a browser (surface web-local). " +
                 "Props: first_run (bool — first open on this install).",
+            "dashboard_view_switched" to
+                "The local web dashboard's left-nav view was switched. " +
+                "Props: view (discriminator: stats/standup/repositories/memories). " +
+                "Distinct from view_switched, which is the IDE tool-window event with its own view vocabulary.",
             "range_changed" to
                 "The dashboard time-range control was changed. Props: range (discriminator: 7d/30d/90d/custom).",
             "chart_split_changed" to

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
@@ -73,6 +73,15 @@ object TelemetryEvents {
             "memory_shared" to "User invoked Share for a branch's memories (read-only share link). Props: none.",
             "key_rejected" to "The server rejected the API key (401/403). Props: retried, where.",
             "reauth_completed" to "Re-authentication after a rejected key finished. Props: outcome.",
+            // ── local web dashboard UI (web-local surface) ──
+            "dashboard_opened" to
+                "The local web dashboard was opened in a browser (surface web-local). " +
+                "Props: first_run (bool — first open on this install).",
+            "range_changed" to
+                "The dashboard time-range control was changed. Props: range (discriminator: 7d/30d/90d/custom).",
+            "chart_split_changed" to
+                "A dashboard card's split-by control was changed. " +
+                "Props: card (discriminator: tokens/spend/mcp), split (discriminator).",
         )
 
     /** `object_action`: lowercase snake_case with at least two words. */


### PR DESCRIPTION
## What

Wires the local dashboard web view as its own `web-local` telemetry surface, sharing one event catalog with the future hosted `web` frontend.

## Why

The local dashboard was a telemetry blind spot: launching it emits `command_invoked`, but nothing recorded what a user did once the web view was open (which pages, which time range, which chart splits).

## Changes

- **Events**: register `dashboard_opened`, `range_changed`, `chart_split_changed` (reuse `view_switched`); mirror into the Kotlin registry; regenerate `TELEMETRY.md`.
- **Surface**: `trackAs(surface, …)` overrides only the surface dimension, so browser-forwarded events are `web-local` while the hosting process's own events stay `cli`.
- **Endpoint**: `POST /api/telemetry`, placed **before** the mutation-token gate (the token is inlined only into write-surface pages, so a gated beacon would drop events from the stats/memories pages). Cross-site is already blocked by the host/Origin/`frame-ancestors` layers. Bad input always answers 204 — a beacon is never taught to retry.
- **Server lifecycle**: `ServerTelemetry` primes telemetry and runs a periodic flush for the long-lived server process — otherwise `trackAs` is a no-op and the buffer is never drained.
- **Browser**: `JD.track` beacon (`sendBeacon`, survives navigation) wired to `dashboard_opened` (once per session), `view_switched`, `range_changed`, `chart_split_changed`. All content-free — bucketed values and fixed discriminators only.

## Verification

`tsc` + biome clean; 134 telemetry tests green (incl. `trackAs`, `/api/telemetry`, `ServerTelemetry`, `ServerEntry`, and the `TELEMETRY.md` up-to-date check).

## Dependency

`web-local` events are **dropped at ingest** until jolliai/jolli#1247 (surface allowlist) merges. Land that first.